### PR TITLE
fix(image-build): use apt-get for google-cloud-sdk installation

### DIFF
--- a/image-build/core-base/Dockerfile
+++ b/image-build/core-base/Dockerfile
@@ -134,11 +134,9 @@ COPY --from=builder /usr/local/libexec/git-core /usr/local/libexec/git-core
 COPY --from=builder /usr/local/share/git-core /usr/local/share/git-core
 
 # Install gcloud CLI
-RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz && \
-    mkdir -p /usr/local/gcloud && \
-    tar -C /usr/local/gcloud -xf /tmp/google-cloud-sdk.tar.gz && \
-    /usr/local/gcloud/google-cloud-sdk/install.sh --quiet && \
-    rm /tmp/google-cloud-sdk.tar.gz
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    apt-get update && apt-get install -y google-cloud-cli && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Setup npm global directory
 RUN mkdir -p /usr/local/share/npm-global


### PR DESCRIPTION
This changes the installation method for the gcloud CLI in the `core-base` image from downloading a tarball directly to using the official cloud-sdk apt-get repository. 
        
This resolves transient network timeouts hitting `dl.google.com` during image builds, preventing `403 Forbidden` and connection resets, and is a generally more robust method for dependency management in Debian-based containers.