### PR TITLE
fix: handle empty PLATFORM_ARGS array under bash set -u

### DIFF
--- a/image-build/scripts/build-images.sh
+++ b/image-build/scripts/build-images.sh
@@ -121,7 +121,7 @@ ensure_builder() {
 build_core_base() {
   echo "==> Building core-base..."
   docker buildx build \
-    "${PLATFORM_ARGS[@]}" \
+    ${PLATFORM_ARGS[@]+"${PLATFORM_ARGS[@]}"} \
     -t "${REGISTRY}/core-base:${TAG}" \
     -f "${IMAGE_BUILD_DIR}/core-base/Dockerfile" \
     ${PUSH} ${LOAD_ARG} \
@@ -133,7 +133,7 @@ build_scion_base() {
   local base_tag="${1:-latest}"
   echo "==> Building scion-base..."
   docker buildx build \
-    "${PLATFORM_ARGS[@]}" \
+    ${PLATFORM_ARGS[@]+"${PLATFORM_ARGS[@]}"} \
     --build-arg "BASE_IMAGE=${REGISTRY}/core-base:${base_tag}" \
     --build-arg "GIT_COMMIT=$(git -C "${REPO_ROOT}" rev-parse HEAD 2>/dev/null || echo unknown)" \
     -t "${REGISTRY}/scion-base:${TAG}" \
@@ -148,7 +148,7 @@ build_harness() {
   local base_tag="${2:-latest}"
   echo "==> Building scion-${name}..."
   docker buildx build \
-    "${PLATFORM_ARGS[@]}" \
+    ${PLATFORM_ARGS[@]+"${PLATFORM_ARGS[@]}"} \
     --build-arg "BASE_IMAGE=${REGISTRY}/scion-base:${base_tag}" \
     -t "${REGISTRY}/scion-${name}:${TAG}" \
     -f "${IMAGE_BUILD_DIR}/${name}/Dockerfile" \


### PR DESCRIPTION
## Summary

- `build-images.sh` uses `set -euo pipefail`, which causes `${PLATFORM_ARGS[@]}` to fail with "unbound variable" when no `--platform` flag is passed and the array is empty
- Fixes all three `docker buildx build` call sites using the `${array[@]+"${array[@]}"}` idiom, which expands only when the array is non-empty

## Test plan

- [x] Verified `build-images.sh --registry local/test --target core-base` now runs without error (previously failed immediately with unbound variable)
- [x] `--platform` flag still works correctly when provided