### PR TITLE
fix(sciontool): use scion home dir for git credential config when running as root

### DIFF
--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -1126,9 +1126,15 @@ func gitCloneWorkspace(uid, gid int) error {
 	// matching the pattern used by shared-workspace groves. When GitHub App
 	// token refresh is enabled, use sciontool's credential-helper command
 	// which handles on-demand token refresh from the Hub.
-	agentHomeDir := os.Getenv("HOME")
-	if agentHomeDir == "" {
-		agentHomeDir = "/home/scion"
+	// When sciontool runs as root (HOME=/root) but git executes as the target
+	// UID (e.g. 502), writing to /root/.gitconfig fails with permission denied.
+	// Use the scion user's actual home directory instead.
+	agentHomeDir := "/home/scion"
+	if uid == 0 {
+		// Running as root — use root's HOME directly.
+		if h := os.Getenv("HOME"); h != "" {
+			agentHomeDir = h
+		}
 	}
 	gitconfigPath := filepath.Join(agentHomeDir, ".gitconfig")
 


### PR DESCRIPTION
## Summary

When `sciontool` runs as PID 1 (root), `os.Getenv("HOME")` returns `/root`. The git credential helper is then configured in `/root/.gitconfig`, but `git config` executes as the target UID (e.g. `502` on macOS hosts) which lacks write permission to `/root/` — causing `exit status 255` and the error:

```
Git clone failed: failed to configure git credential helper: exit status 255
```

This can be reproduced on any macOS host where the host UID does not match the container's scion user UID (1000). The `SCION_HOST_UID` remapping in sciontool correctly adjusts the scion user, but the credential helper config then fails because it still targets the root home.

## Fix

Default `agentHomeDir` to `/home/scion` (the scion user's actual home), and only fall back to the process `HOME` env var when `uid == 0` (i.e. the target user is actually root).

## Test plan

- [ ] Start an agent on a macOS host where host UID ≠ 1000
- [ ] Confirm git clone completes without `failed to configure git credential helper` error
- [ ] Confirm `.gitconfig` with credential helper is written to `/home/scion/.gitconfig` in the container