### PR TITLE
feat(templates): replace bootstrap container sync with direct server-…

### DIFF
--- a/.design/template-import-refactor.md
+++ b/.design/template-import-refactor.md
@@ -1,0 +1,89 @@
+# Template Import Refactor: Direct Server-Side Import
+
+## Problem
+
+The web UI's "Load Templates" feature on the Grove Settings page works by spawning a
+bootstrap container agent that runs `scion templates sync --all` inside a Docker
+container. This approach has several drawbacks:
+
+- **Slow**: Requires container provisioning before any work begins.
+- **Inflexible path**: `scion templates sync --all` only looks for templates in
+  `.scion/templates/` at the workspace root — it cannot target a templates directory
+  at an arbitrary subdirectory depth.
+- **Heavyweight**: A full agent lifecycle (create → dispatch → provision → run → stop)
+  just to import a handful of template files.
+
+## Solution
+
+Replace the bootstrap container agent with a direct server-side import that mirrors
+the `scion templates import` CLI workflow:
+
+1. The Hub server fetches the remote source URL (GitHub deep path, archive, or rclone)
+   directly using the existing `pkg/config.FetchRemoteTemplate()` infrastructure.
+2. The Hub parses the fetched directory using `pkg/config/templateimport` to find scion
+   templates.
+3. The Hub registers each template in the database and storage using the same
+   `bootstrapSingleTemplate` / `syncExistingTemplate` functions already used at startup.
+4. The HTTP response is synchronous — the frontend gets a result immediately.
+
+## New API Endpoint
+
+```
+POST /api/v1/groves/{groveId}/import-templates
+```
+
+**Request body:**
+```json
+{
+  "sourceUrl": "https://github.com/org/repo/tree/main/path/to/templates"
+}
+```
+
+**Response:**
+```json
+{
+  "templates": ["poker-dealer", "poker-player", "poker-auditor"],
+  "count": 3
+}
+```
+
+`sourceUrl` supports any format understood by `config.FetchRemoteTemplate`:
+- GitHub URLs including deep subdirectory paths (via svn export or sparse git checkout)
+- Archive URLs (`.zip`, `.tar.gz`, `.tgz`)
+- rclone paths (`:gcs:bucket/path`)
+
+## Template Scoping
+
+Templates imported through this endpoint are **grove-scoped** — they appear only within
+the grove they were imported into. This matches the intent of the Grove Settings page
+being the entry point.
+
+Global templates (available across all groves) continue to be managed via the
+`BootstrapTemplatesFromDir` path at Hub startup.
+
+## Removed: Bootstrap Container Sync
+
+The previous `POST /api/v1/groves/{groveId}/sync-templates` endpoint and its bootstrap
+container agent are removed. The web UI now uses `import-templates` exclusively.
+
+The `scion templates sync` CLI command continues to work for direct CLI-to-Hub syncing
+from a local workspace.
+
+## Web UI Changes
+
+The Templates tab in Grove Settings is updated:
+
+- URL input is shown for **all** groves (previously hidden for git-anchored groves).
+- For git-anchored groves the URL input is pre-populated with the grove's git remote URL.
+- Users can override or extend the URL with a deep path
+  (e.g., append `/tree/main/.scion/templates`).
+- The button calls `import-templates` and awaits a synchronous result — no agent
+  polling loop.
+
+## Key Files Changed
+
+| File | Change |
+|------|--------|
+| `pkg/hub/template_bootstrap.go` | `bootstrapSingleTemplate` gains `scope`/`groveID` params; new `importTemplatesFromRemote` |
+| `pkg/hub/handlers.go` | New `handleGroveImportTemplates`; removed `handleGroveSyncTemplates`, `cleanTemplateRepoURL` |
+| `web/src/components/pages/grove-settings.ts` | Replaced agent-polling sync flow with direct import call |

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -3638,9 +3638,9 @@ func (s *Server) handleGroveRoutes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check for nested /sync-templates path
-	if subPath == "sync-templates" {
-		s.handleGroveSyncTemplates(w, r, groveID)
+	// Check for nested /import-templates path
+	if subPath == "import-templates" {
+		s.handleGroveImportTemplates(w, r, groveID)
 		return
 	}
 
@@ -8020,22 +8020,23 @@ func (s *Server) handlePublicSettings(w http.ResponseWriter, r *http.Request) {
 }
 
 // ============================================================================
-// Grove Template Sync
+// Grove Template Import
 // ============================================================================
 
-// SyncTemplatesRequest is the optional request body for template sync.
-type SyncTemplatesRequest struct {
-	RepoURL string `json:"repoUrl,omitempty"`
+// ImportTemplatesRequest is the request body for direct template import.
+type ImportTemplatesRequest struct {
+	SourceURL string `json:"sourceUrl"`
 }
 
-// SyncTemplatesResponse is returned when a template sync agent is dispatched.
-type SyncTemplatesResponse struct {
-	AgentID string `json:"agentId"`
-	Status  string `json:"status"`
+// ImportTemplatesResponse is returned after a direct template import completes.
+type ImportTemplatesResponse struct {
+	Templates []string `json:"templates"`
+	Count     int      `json:"count"`
 }
 
-// handleGroveSyncTemplates dispatches an agent to synchronize templates for a grove.
-func (s *Server) handleGroveSyncTemplates(w http.ResponseWriter, r *http.Request, groveID string) {
+// handleGroveImportTemplates imports templates directly from a remote URL into
+// the grove's template store without spawning a bootstrap container agent.
+func (s *Server) handleGroveImportTemplates(w http.ResponseWriter, r *http.Request, groveID string) {
 	if r.Method != http.MethodPost {
 		MethodNotAllowed(w)
 		return
@@ -8044,17 +8045,15 @@ func (s *Server) handleGroveSyncTemplates(w http.ResponseWriter, r *http.Request
 	ctx := r.Context()
 
 	// Authorize the caller
-	var createdBy string
 	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
 		if !agentIdent.HasScope(ScopeAgentCreate) {
 			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Missing required scope: grove:agent:create", nil)
 			return
 		}
 		if groveID != agentIdent.GroveID() {
-			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agents can only sync templates within their own grove", nil)
+			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agents can only import templates within their own grove", nil)
 			return
 		}
-		createdBy = agentIdent.ID()
 	} else if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
 		decision := s.authzService.CheckAccess(ctx, userIdent, Resource{
 			Type:       "agent",
@@ -8063,25 +8062,22 @@ func (s *Server) handleGroveSyncTemplates(w http.ResponseWriter, r *http.Request
 		}, ActionCreate)
 		if !decision.Allowed {
 			writeError(w, http.StatusForbidden, ErrCodeForbidden,
-				"You don't have permission to sync templates in this grove", nil)
+				"You don't have permission to import templates in this grove", nil)
 			return
 		}
-		createdBy = userIdent.ID()
 	} else {
 		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required", nil)
 		return
 	}
 
-	// Parse optional request body for repoUrl.
-	var req SyncTemplatesRequest
-	if r.Body != nil {
-		// Ignore decode errors for empty bodies (the field is optional).
-		_ = readJSON(r, &req)
+	var req ImportTemplatesRequest
+	if err := readJSON(r, &req); err != nil || req.SourceURL == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "sourceUrl is required", nil)
+		return
 	}
 
 	// Verify grove exists
-	grove, err := s.store.GetGrove(ctx, groveID)
-	if err != nil {
+	if _, err := s.store.GetGrove(ctx, groveID); err != nil {
 		if err == store.ErrNotFound {
 			NotFound(w, "Grove")
 			return
@@ -8090,138 +8086,19 @@ func (s *Server) handleGroveSyncTemplates(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Resolve a runtime broker (use grove default)
-	runtimeBrokerID, err := s.resolveRuntimeBroker(ctx, w, "", grove)
+	if s.GetStorage() == nil {
+		writeError(w, http.StatusServiceUnavailable, "storage_unavailable", "Template storage is not configured", nil)
+		return
+	}
+
+	imported, err := s.importTemplatesFromRemote(ctx, groveID, req.SourceURL)
 	if err != nil {
-		// Error response already written by resolveRuntimeBroker
+		writeError(w, http.StatusBadRequest, "import_failed", err.Error(), nil)
 		return
 	}
 
-	// Check broker dispatch access
-	if runtimeBrokerID != "" {
-		if !s.checkBrokerDispatchAccess(ctx, w, runtimeBrokerID) {
-			return
-		}
-	}
-
-	// Build agent name with timestamp
-	agentName := fmt.Sprintf("template-sync-%d", time.Now().Unix())
-	slug, err := api.ValidateAgentName(agentName)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_name", err.Error(), nil)
-		return
-	}
-
-	agent := &store.Agent{
-		ID:              api.NewUUID(),
-		Slug:            slug,
-		Name:            slug,
-		GroveID:         groveID,
-		RuntimeBrokerID: runtimeBrokerID,
-		Phase:           string(state.PhaseCreated),
-		Labels: map[string]string{
-			"scion.dev/purpose": "template-sync",
-		},
-		Visibility: store.VisibilityPrivate,
-		CreatedBy:  createdBy,
-		OwnerID:    createdBy,
-		Detached:   true,
-		AppliedConfig: &store.AgentAppliedConfig{
-			HarnessConfig: "generic",
-			Task:          "scion templates sync --all",
-		},
-	}
-
-	// Populate GitClone config for git-anchored groves so the broker
-	// clones the repo before running the sync command. Without this,
-	// the container starts with an empty workspace and the sync exits
-	// immediately because there are no templates to find.
-	s.populateAgentConfig(agent, grove, nil)
-
-	// For non-git groves, allow loading templates from an external repo URL.
-	if req.RepoURL != "" && grove.GitRemote == "" {
-		cleanedURL := cleanTemplateRepoURL(req.RepoURL)
-		// Accept bare host/org/repo inputs by prepending https://.
-		if !strings.Contains(cleanedURL, "://") && !strings.HasPrefix(cleanedURL, "git@") {
-			cleanedURL = "https://" + cleanedURL
-		}
-		if !util.IsGitURL(cleanedURL) {
-			writeError(w, http.StatusBadRequest, "invalid_repo_url", "The provided URL is not a valid git repository URL", nil)
-			return
-		}
-		cloneURL := util.ToHTTPSCloneURL(cleanedURL)
-		agent.AppliedConfig.GitClone = &api.GitCloneConfig{
-			URL:    cloneURL,
-			Branch: "main",
-			Depth:  1,
-		}
-
-		// Look up a GitHub App installation that covers this repo directly,
-		// then find a grove owned by the same user that references it so the
-		// dispatcher can mint a token for cloning.
-		normalizedRemote := util.NormalizeGitRemote(cleanedURL)
-		if parts := strings.SplitN(normalizedRemote, "/", 2); len(parts) == 2 {
-			if inst, err := s.store.GetInstallationForRepository(ctx, parts[1]); err == nil {
-				matchingGroves, _ := s.store.GetGrovesByGitRemote(ctx, normalizedRemote)
-				for _, g := range matchingGroves {
-					if g.GitHubInstallationID != nil && *g.GitHubInstallationID == inst.InstallationID && g.OwnerID == grove.OwnerID {
-						agent.Labels["scion.dev/github-token-source-grove"] = g.ID
-						break
-					}
-				}
-			}
-		}
-	}
-
-	if err := s.store.CreateAgent(ctx, agent); err != nil {
-		writeErrorFromErr(w, err, "")
-		return
-	}
-
-	// Dispatch to runtime broker.
-	// Set the phase to provisioning BEFORE dispatching so that a fast
-	// container failure (e.g. git clone error) that reports phase=error
-	// via the status API doesn't get clobbered by a post-dispatch update.
-	if dispatcher := s.GetDispatcher(); dispatcher != nil {
-		agent.Phase = string(state.PhaseProvisioning)
-		if err := s.store.UpdateAgent(ctx, agent); err != nil {
-			s.agentLifecycleLog.Warn("Failed to update template-sync agent phase", "error", err)
-		}
-
-		if err := dispatcher.DispatchAgentCreate(ctx, agent); err != nil {
-			// Clean up on dispatch failure
-			s.agentLifecycleLog.Warn("Failed to dispatch template-sync agent", "agent_id", agent.ID, "error", err)
-			_ = dispatcher.DispatchAgentDelete(ctx, agent, true, true, false, time.Time{})
-			_ = s.store.DeleteAgent(ctx, agent.ID)
-			RuntimeError(w, "Failed to dispatch template sync agent: "+err.Error())
-			return
-		}
-	}
-
-	s.events.PublishAgentCreated(ctx, agent)
-
-	s.agentLifecycleLog.Info("Template sync agent dispatched",
-		"agent_id", agent.ID, "grove_id", groveID, "broker", runtimeBrokerID)
-
-	writeJSON(w, http.StatusOK, SyncTemplatesResponse{
-		AgentID: agent.ID,
-		Status:  "syncing",
+	writeJSON(w, http.StatusOK, ImportTemplatesResponse{
+		Templates: imported,
+		Count:     len(imported),
 	})
-}
-
-// cleanTemplateRepoURL strips .scion/templates suffixes and common
-// repository browse paths (e.g. /tree/main) from a URL so that it can
-// be normalized to a plain clone URL.
-func cleanTemplateRepoURL(rawURL string) string {
-	// Strip .scion/templates suffix (with optional trailing slash).
-	if idx := strings.Index(rawURL, "/.scion/templates"); idx >= 0 {
-		rawURL = rawURL[:idx]
-	}
-	// Strip GitHub/GitLab browse path segments (longer patterns first).
-	for _, seg := range []string{"/-/tree/", "/-/blob/", "/tree/", "/blob/"} {
-		if idx := strings.Index(rawURL, seg); idx >= 0 {
-			rawURL = rawURL[:idx]
-		}
-	}
-	return strings.TrimRight(rawURL, "/")
 }

--- a/pkg/hub/template_bootstrap.go
+++ b/pkg/hub/template_bootstrap.go
@@ -16,12 +16,14 @@ package hub
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/config/templateimport"
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/GoogleCloudPlatform/scion/pkg/transfer"
@@ -72,7 +74,7 @@ func (s *Server) BootstrapTemplatesFromDir(ctx context.Context, templatesDir str
 
 		if existing == nil {
 			// New template — import it
-			if err := s.bootstrapSingleTemplate(ctx, name, templatePath); err != nil {
+			if err := s.bootstrapSingleTemplate(ctx, name, templatePath, store.TemplateScopeGlobal, ""); err != nil {
 				s.templateLog.Warn("template bootstrap: failed to import template, skipping",
 					"template", name, "error", err)
 				continue
@@ -178,8 +180,9 @@ func (s *Server) syncExistingTemplate(ctx context.Context, existing *store.Templ
 }
 
 // bootstrapSingleTemplate imports one local template directory into the
-// Hub's database and storage backend.
-func (s *Server) bootstrapSingleTemplate(ctx context.Context, name, templatePath string) error {
+// Hub's database and storage backend under the given scope and groveID.
+// For global templates pass store.TemplateScopeGlobal and "".
+func (s *Server) bootstrapSingleTemplate(ctx context.Context, name, templatePath, scope, groveID string) error {
 	stor := s.GetStorage()
 
 	// Collect files from the template directory
@@ -192,20 +195,21 @@ func (s *Server) bootstrapSingleTemplate(ctx context.Context, name, templatePath
 	harness := detectHarnessFromConfig(templatePath, name)
 
 	slug := api.Slugify(name)
-	scope := store.TemplateScopeGlobal
 
 	// Create a pending template record
-	storagePath := storage.TemplateStoragePath(scope, "", slug)
+	storagePath := storage.TemplateStoragePath(scope, groveID, slug)
 	tmpl := &store.Template{
 		ID:            api.NewUUID(),
 		Name:          name,
 		Slug:          slug,
 		Harness:       harness,
 		Scope:         scope,
+		ScopeID:       groveID,
+		GroveID:       groveID, // deprecated alias kept for compatibility
 		Status:        store.TemplateStatusPending,
 		StoragePath:   storagePath,
 		StorageBucket: stor.Bucket(),
-		StorageURI:    storage.TemplateStorageURI(stor.Bucket(), scope, "", slug),
+		StorageURI:    storage.TemplateStorageURI(stor.Bucket(), scope, groveID, slug),
 		Visibility:    store.VisibilityPrivate,
 	}
 
@@ -294,4 +298,78 @@ func inferHarnessFromName(name string) string {
 	default:
 		return ""
 	}
+}
+
+// importTemplatesFromRemote fetches a remote source URL, discovers scion
+// templates within it, and registers each one into the Hub store scoped
+// to the given grove. Returns the names of all templates imported or updated.
+func (s *Server) importTemplatesFromRemote(ctx context.Context, groveID, sourceURL string) ([]string, error) {
+	if !config.IsRemoteURI(sourceURL) {
+		return nil, fmt.Errorf("source must be a remote URI (http://, https://, or rclone)")
+	}
+
+	stor := s.GetStorage()
+	if stor == nil {
+		return nil, fmt.Errorf("template storage is not configured")
+	}
+
+	// Fetch to a temporary directory
+	cachePath, err := config.FetchRemoteTemplate(ctx, sourceURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch remote templates: %w", err)
+	}
+	defer os.RemoveAll(cachePath)
+
+	// Collect template directories to import
+	type templateDir struct{ name, path string }
+	var dirs []templateDir
+
+	if templateimport.IsScionTemplate(cachePath) {
+		// URL pointed directly at a single template directory
+		dirs = append(dirs, templateDir{filepath.Base(cachePath), cachePath})
+	} else {
+		entries, err := os.ReadDir(cachePath)
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			dir := filepath.Join(cachePath, entry.Name())
+			if templateimport.IsScionTemplate(dir) {
+				dirs = append(dirs, templateDir{entry.Name(), dir})
+			}
+		}
+	}
+
+	if len(dirs) == 0 {
+		return nil, fmt.Errorf("no scion templates found at %s", sourceURL)
+	}
+
+	var imported []string
+	for _, td := range dirs {
+		slug := api.Slugify(td.name)
+		existing, err := s.store.GetTemplateBySlug(ctx, slug, store.TemplateScopeGrove, groveID)
+		if err != nil && err != store.ErrNotFound {
+			s.templateLog.Warn("template import: failed to look up template, skipping",
+				"name", td.name, "error", err)
+			continue
+		}
+		if existing == nil {
+			if err := s.bootstrapSingleTemplate(ctx, td.name, td.path, store.TemplateScopeGrove, groveID); err != nil {
+				s.templateLog.Warn("template import: failed to import template, skipping",
+					"name", td.name, "error", err)
+				continue
+			}
+		} else {
+			if _, err := s.syncExistingTemplate(ctx, existing, td.path); err != nil {
+				s.templateLog.Warn("template import: failed to sync template, skipping",
+					"name", td.name, "error", err)
+				continue
+			}
+		}
+		imported = append(imported, td.name)
+	}
+	return imported, nil
 }

--- a/web/src/components/pages/grove-settings.ts
+++ b/web/src/components/pages/grove-settings.ts
@@ -35,11 +35,6 @@ import '../shared/scheduled-event-list.js';
 import '../shared/subscription-manager.js';
 import '../shared/schedule-list.js';
 
-interface Agent {
-  id: string;
-  phase: string;
-  activity?: string;
-}
 
 interface GroveResourceSpec {
   requests?: { cpu?: string | undefined; memory?: string | undefined };
@@ -217,8 +212,6 @@ export class ScionPageGroveSettings extends LitElement {
 
   private brokerRelativeTimeInterval: ReturnType<typeof setInterval> | null = null;
 
-  private syncAgentId: string | null = null;
-  private syncPollTimer: ReturnType<typeof setInterval> | null = null;
 
   static override styles = css`
     :host {
@@ -753,7 +746,6 @@ export class ScionPageGroveSettings extends LitElement {
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.stopSyncPolling();
     if (this.brokerRelativeTimeInterval) {
       clearInterval(this.brokerRelativeTimeInterval);
       this.brokerRelativeTimeInterval = null;
@@ -772,6 +764,10 @@ export class ScionPageGroveSettings extends LitElement {
       }
 
       this.grove = (await response.json()) as Grove;
+      // Pre-populate template import URL with the grove's git remote when set
+      if (this.grove.gitRemote && !this.syncRepoUrl) {
+        this.syncRepoUrl = this.grove.gitRemote;
+      }
       // Populate GitHub App fields from grove data
       this.githubAppInstallationId = this.grove.githubInstallationId ?? null;
       this.githubAppStatus = this.grove.githubAppStatus ?? null;
@@ -994,80 +990,24 @@ export class ScionPageGroveSettings extends LitElement {
     this.syncSuccess = null;
 
     try {
-      const fetchOpts: RequestInit = { method: 'POST' };
-      if (this.syncRepoUrl) {
-        fetchOpts.headers = { 'Content-Type': 'application/json' };
-        fetchOpts.body = JSON.stringify({ repoUrl: this.syncRepoUrl });
-      }
-      const response = await apiFetch(`/api/v1/groves/${this.groveId}/sync-templates`, fetchOpts);
+      const response = await apiFetch(`/api/v1/groves/${this.groveId}/import-templates`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sourceUrl: this.syncRepoUrl }),
+      });
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `Failed to start template sync: HTTP ${response.status}`));
+        throw new Error(await extractApiError(response, `Failed to import templates: HTTP ${response.status}`));
       }
 
-      const data = (await response.json()) as { agentId: string; status: string };
-      this.syncAgentId = data.agentId;
-      this.startSyncPolling();
+      const data = (await response.json()) as { templates: string[]; count: number };
+      await Promise.all([this.loadTemplates(), this.loadDropdownTemplates()]);
+      this.syncSuccess = `${data.count} template${data.count !== 1 ? 's' : ''} imported successfully.`;
     } catch (err) {
-      console.error('Failed to sync templates:', err);
-      this.syncError = err instanceof Error ? err.message : 'Failed to sync templates';
+      console.error('Failed to import templates:', err);
+      this.syncError = err instanceof Error ? err.message : 'Failed to import templates';
+    } finally {
       this.syncLoading = false;
-    }
-  }
-
-  private startSyncPolling(): void {
-    this.stopSyncPolling();
-    this.syncPollTimer = setInterval(() => void this.pollSyncAgent(), 3000);
-  }
-
-  private stopSyncPolling(): void {
-    if (this.syncPollTimer) {
-      clearInterval(this.syncPollTimer);
-      this.syncPollTimer = null;
-    }
-  }
-
-  private async pollSyncAgent(): Promise<void> {
-    if (!this.syncAgentId) return;
-
-    try {
-      const response = await apiFetch(`/api/v1/agents/${this.syncAgentId}`);
-      if (!response.ok) {
-        this.stopSyncPolling();
-        this.syncError = 'Lost track of sync agent';
-        this.syncLoading = false;
-        return;
-      }
-
-      const agent = (await response.json()) as Agent;
-
-      if (agent.phase === 'stopped' || agent.phase === 'completed') {
-        this.stopSyncPolling();
-        void this.cleanupSyncAgent();
-        await Promise.all([this.loadTemplates(), this.loadDropdownTemplates()]);
-        this.syncLoading = false;
-        this.syncSuccess = 'Templates synced successfully.';
-      } else if (agent.phase === 'error') {
-        this.stopSyncPolling();
-        this.syncLoading = false;
-        this.syncError = 'Template sync agent encountered an error.';
-        void this.cleanupSyncAgent();
-      }
-    } catch {
-      this.stopSyncPolling();
-      this.syncError = 'Failed to check sync status';
-      this.syncLoading = false;
-    }
-  }
-
-  private async cleanupSyncAgent(): Promise<void> {
-    if (!this.syncAgentId) return;
-    const agentId = this.syncAgentId;
-    this.syncAgentId = null;
-    try {
-      await apiFetch(`/api/v1/agents/${agentId}`, { method: 'DELETE' });
-    } catch {
-      // Best-effort cleanup
     }
   }
 
@@ -1787,12 +1727,11 @@ export class ScionPageGroveSettings extends LitElement {
   }
 
   private renderTemplatesContent() {
-    const isGitGrove = !!this.grove?.gitRemote;
     const canSync = canAny(this.grove!._capabilities, 'update', 'manage');
     return html`
       <div class="section-header" style="margin-bottom: 1rem;">
         <div class="section-header-text">
-          <p style="margin: 0;">Grove-scoped agent templates synced to the Hub.</p>
+          <p style="margin: 0;">Grove-scoped agent templates imported into the Hub.</p>
         </div>
         ${canSync
           ? html`
@@ -1800,21 +1739,21 @@ export class ScionPageGroveSettings extends LitElement {
                 size="small"
                 variant="default"
                 ?loading=${this.syncLoading}
-                ?disabled=${this.syncLoading || (!isGitGrove && !this.syncRepoUrl)}
+                ?disabled=${this.syncLoading || !this.syncRepoUrl}
                 @click=${() => this.handleSyncTemplates()}
               >
-                <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
-                Load Templates
+                <sl-icon slot="prefix" name="download"></sl-icon>
+                Import Templates
               </sl-button>
             `
           : ''}
       </div>
-      ${canSync && !isGitGrove
+      ${canSync
         ? html`
             <div style="margin-bottom: 1rem;">
               <sl-input
-                label="Load from repo"
-                placeholder="https://github.com/org/repo"
+                label="Import from URL"
+                placeholder="https://github.com/org/repo/tree/main/.scion/templates"
                 size="small"
                 clearable
                 .value=${this.syncRepoUrl}
@@ -1829,7 +1768,7 @@ export class ScionPageGroveSettings extends LitElement {
                 <sl-icon slot="prefix" name="github"></sl-icon>
               </sl-input>
               <div style="margin-top: 0.25rem; font-size: 0.75rem; color: var(--sl-color-neutral-500);">
-                Git repository URL containing templates in <code>.scion/templates</code>
+                GitHub URL to a template or templates directory — supports arbitrary deep paths
               </div>
             </div>
           `
@@ -1839,9 +1778,7 @@ export class ScionPageGroveSettings extends LitElement {
         ? html`
             <div class="sync-status syncing">
               <sl-spinner style="font-size: 0.875rem;"></sl-spinner>
-              ${isGitGrove || !this.syncRepoUrl
-                ? 'Syncing templates from grove...'
-                : `Syncing templates from ${this.syncRepoUrl}...`}
+              ${`Importing templates from ${this.syncRepoUrl}...`}
             </div>
           `
         : ''}
@@ -1885,13 +1822,9 @@ export class ScionPageGroveSettings extends LitElement {
           : html`
               <div class="empty-templates">
                 <sl-icon name="file-earmark"></sl-icon>
-                <p>No grove templates synced yet.</p>
+                <p>No grove templates imported yet.</p>
                 ${canSync
-                  ? html`<p>
-                      ${isGitGrove
-                        ? 'Use "Load Templates" to sync templates from the grove\'s repository.'
-                        : 'Enter a repository URL above and click "Load Templates" to import templates.'}
-                    </p>`
+                  ? html`<p>Enter a URL above and click "Import Templates" to import.</p>`
                   : ''}
               </div>
             `}


### PR DESCRIPTION
…side import

Web-based template import no longer spawns a detached bootstrap container agent running 'scion templates sync --all'. Instead, the Hub server fetches the remote source URL directly (using the existing FetchRemoteTemplate infrastructure), discovers scion templates, and registers them in the store — all within the HTTP request handler.

Key changes:
- New POST /api/v1/groves/{id}/import-templates endpoint accepts a sourceUrl supporting GitHub deep paths (e.g. /tree/main/path/to/templates), archives, and rclone URIs. Imported templates are grove-scoped.
- bootstrapSingleTemplate now accepts scope/groveID params; BootstrapTemplatesFromDir continues to create global-scoped templates as before.
- New importTemplatesFromRemote server method combines FetchRemoteTemplate, templateimport detection, and bootstrap/sync registration.
- Removed handleGroveSyncTemplates, SyncTemplatesRequest/Response, and cleanTemplateRepoURL from handlers.go.
- Web UI: replaced agent-polling sync flow with direct synchronous import call; URL input now shown for all groves (git groves pre-populated with gitRemote); placeholder shows deep-path example.
- Added .design/template-import-refactor.md design doc.

https://claude.ai/code/session_012ewUnDzD2Zhn4BEZYtCzEA

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
