### PR TITLE
feat: normalize template source URLs in grove settings import

### DIFF
--- a/pkg/config/remote_templates.go
+++ b/pkg/config/remote_templates.go
@@ -65,6 +65,44 @@ func remoteCacheDir() (string, error) {
 	return filepath.Join(globalDir, "cache", "remote-templates"), nil
 }
 
+// NormalizeTemplateSourceURL normalizes a user-provided template source URL.
+// It handles two cases of user convenience:
+//  1. Missing scheme: if the URL doesn't start with a scheme or rclone prefix,
+//     "https://" is prepended automatically (e.g. "github.com/org/repo").
+//  2. Bare GitHub org/repo: if the result is a GitHub URL with only owner/repo
+//     in the path (no deeper path), "/.scion/templates/" is appended so that
+//     the standard template directory is used automatically.
+func NormalizeTemplateSourceURL(raw string) string {
+	s := strings.TrimSpace(raw)
+
+	// Add https:// scheme if missing (not rclone and not already http/https)
+	if !strings.HasPrefix(s, ":") && !strings.HasPrefix(s, "http://") && !strings.HasPrefix(s, "https://") {
+		s = "https://" + s
+	}
+
+	// For GitHub URLs with just owner/repo, append /.scion/templates/
+	u, err := url.Parse(s)
+	if err != nil {
+		return s
+	}
+	if strings.EqualFold(u.Host, "github.com") {
+		// Split path and filter empty segments
+		var parts []string
+		for _, p := range strings.Split(strings.TrimPrefix(u.Path, "/"), "/") {
+			if p != "" {
+				parts = append(parts, p)
+			}
+		}
+		if len(parts) == 2 {
+			// Just owner/repo — point to the standard templates directory
+			u.Path = "/" + parts[0] + "/" + parts[1] + "/.scion/templates/"
+			return u.String()
+		}
+	}
+
+	return s
+}
+
 // IsRemoteURI checks if the given string looks like a remote template URI.
 // Returns true for:
 // - URLs starting with http:// or https://

--- a/pkg/config/remote_templates_test.go
+++ b/pkg/config/remote_templates_test.go
@@ -149,6 +149,67 @@ func TestParseGitHubURL(t *testing.T) {
 	}
 }
 
+func TestNormalizeTemplateSourceURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "full https URL unchanged",
+			input:    "https://github.com/org/repo/tree/main/.scion/templates",
+			expected: "https://github.com/org/repo/tree/main/.scion/templates",
+		},
+		{
+			name:     "scheme-less github domain gets https prefix",
+			input:    "github.com/org/repo/tree/main/.scion/templates",
+			expected: "https://github.com/org/repo/tree/main/.scion/templates",
+		},
+		{
+			name:     "bare org/repo appends scion templates path",
+			input:    "https://github.com/org/repo",
+			expected: "https://github.com/org/repo/.scion/templates/",
+		},
+		{
+			name:     "scheme-less bare org/repo gets scheme and scion templates path",
+			input:    "github.com/org/repo",
+			expected: "https://github.com/org/repo/.scion/templates/",
+		},
+		{
+			name:     "GitHub.com capitalized is normalized",
+			input:    "GitHub.com/org/repo",
+			expected: "https://GitHub.com/org/repo/.scion/templates/",
+		},
+		{
+			name:     "rclone prefix left unchanged",
+			input:    ":gcs:bucket/path",
+			expected: ":gcs:bucket/path",
+		},
+		{
+			name:     "http URL unchanged",
+			input:    "http://example.com/template.tgz",
+			expected: "http://example.com/template.tgz",
+		},
+		{
+			name:     "whitespace trimmed",
+			input:    "  github.com/org/repo  ",
+			expected: "https://github.com/org/repo/.scion/templates/",
+		},
+		{
+			name:     "deeper path not modified",
+			input:    "github.com/org/repo/.scion/templates/mytmpl",
+			expected: "https://github.com/org/repo/.scion/templates/mytmpl",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalizeTemplateSourceURL(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestConvertToSvnURL(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -8164,6 +8164,8 @@ func (s *Server) handleGroveImportTemplates(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	req.SourceURL = config.NormalizeTemplateSourceURL(req.SourceURL)
+
 	// Verify grove exists
 	if _, err := s.store.GetGrove(ctx, groveID); err != nil {
 		if err == store.ErrNotFound {


### PR DESCRIPTION
Accept scheme-less GitHub URLs (e.g. github.com/org/repo) by prepending https:// automatically. When the URL points at just an org/repo with no deeper path, append /.scion/templates/ so the standard template directory is used without requiring the user to spell out the full path.


Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
