### PR TITLE
feat: support user recipients in scion message CLI

### DIFF
--- a/cmd/message.go
+++ b/cmd/message.go
@@ -43,25 +43,43 @@ var msgNotify bool
 
 // messageCmd represents the message command
 var messageCmd = &cobra.Command{
-	Use:     "message [agent] <message>",
+	Use:     "message [recipient] <message>",
 	Aliases: []string{"msg"},
-	Short:   "Send a message to an agent's harness",
-	Long: `Sends a message to a running agent's harness by enqueuing it into the tmux session.
-If --broadcast is used, the agent name can be omitted and the message will be sent to all running agents.`,
+	Short:   "Send a message to an agent or user",
+	Long: `Sends a message to a running agent's harness or to a user's inbox.
+
+Recipients:
+  <agent-name>       Send to an agent (default, same as agent:<name>)
+  agent:<name>       Send to an agent explicitly
+  user:<name>        Send to a user's inbox (Hub mode only)
+
+If --broadcast is used, the recipient can be omitted and the message will be sent to all running agents.
+
+Examples:
+  scion message my-agent "Please review the PR"
+  scion message user:alice "I need clarification on the auth module"`,
 	Args:              cobra.MinimumNArgs(1),
 	ValidArgsFunction: getAgentNames,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var agentName string
+		var userRecipient string
 		var message string
 
 		if msgBroadcast || msgAll {
 			message = strings.Join(args, " ")
 		} else {
 			if len(args) < 2 {
-				return fmt.Errorf("agent name and message are required unless --broadcast is used")
+				return fmt.Errorf("recipient and message are required unless --broadcast is used")
 			}
-			agentName = api.Slugify(args[0])
+			recipient := args[0]
 			message = strings.Join(args[1:], " ")
+
+			if strings.HasPrefix(recipient, "user:") {
+				userRecipient = recipient
+			} else {
+				// Strip optional "agent:" prefix for backwards compatibility
+				agentName = api.Slugify(strings.TrimPrefix(recipient, "agent:"))
+			}
 		}
 
 		// Validate scheduling flags
@@ -93,6 +111,19 @@ If --broadcast is used, the agent name can be omitted and the message will be se
 			return fmt.Errorf("--notify cannot be combined with --broadcast or --all")
 		}
 
+		// Validate user-recipient restrictions
+		if userRecipient != "" {
+			if msgBroadcast || msgAll {
+				return fmt.Errorf("user recipients cannot be combined with --broadcast or --all")
+			}
+			if msgRaw {
+				return fmt.Errorf("--raw cannot be used with user recipients")
+			}
+			if msgIn != "" || msgAt != "" {
+				return fmt.Errorf("--in/--at cannot be used with user recipients")
+			}
+		}
+
 		// Validate attachments
 		if len(msgAttach) > messages.MaxAttachments {
 			return fmt.Errorf("too many attachments: %d (max %d)", len(msgAttach), messages.MaxAttachments)
@@ -101,7 +132,10 @@ If --broadcast is used, the agent name can be omitted and the message will be se
 		// Check if Hub should be used
 		var hubCtx *HubContext
 		var err error
-		if msgAll {
+		if userRecipient != "" {
+			// User recipient: skip sync (no agent involved)
+			hubCtx, err = CheckHubAvailabilityWithOptions(grovePath, true)
+		} else if msgAll {
 			// Cross-grove operation: skip sync
 			hubCtx, err = CheckHubAvailabilityWithOptions(grovePath, true)
 		} else if msgBroadcast {
@@ -115,6 +149,11 @@ If --broadcast is used, the agent name can be omitted and the message will be se
 			return err
 		}
 
+		// User recipients require Hub mode
+		if userRecipient != "" && hubCtx == nil {
+			return fmt.Errorf("sending messages to users requires Hub mode (use 'scion hub enable' first)")
+		}
+
 		// Handle scheduled messages
 		if msgIn != "" || msgAt != "" {
 			if hubCtx == nil {
@@ -126,6 +165,11 @@ If --broadcast is used, the agent name can be omitted and the message will be se
 		// --notify requires Hub mode
 		if msgNotify && hubCtx == nil {
 			return fmt.Errorf("--notify requires Hub mode (use 'scion hub enable' first)")
+		}
+
+		// User-targeted messages: route to outbound-message endpoint
+		if userRecipient != "" {
+			return sendOutboundMessageViaHub(hubCtx, userRecipient, message, msgInterrupt)
 		}
 
 		if hubCtx != nil {
@@ -383,6 +427,44 @@ func sendMessageViaHub(hubCtx *HubContext, agentName string, message string, int
 		if notify {
 			fmt.Printf("Subscribed to notifications for agent '%s'.\n", agentName)
 		}
+	}
+	return nil
+}
+
+func sendOutboundMessageViaHub(hubCtx *HubContext, userRecipient string, message string, urgent bool) error {
+	if !isJSONOutput() {
+		PrintUsingHub(hubCtx.Endpoint)
+	}
+
+	// Determine the sending agent's name. This command is intended for use
+	// by agents running inside containers, where SCION_AGENT_NAME is set.
+	senderAgent := os.Getenv("SCION_AGENT_NAME")
+	if senderAgent == "" {
+		return fmt.Errorf("sending messages to users is only supported from within an agent container (SCION_AGENT_NAME not set)")
+	}
+
+	groveID, err := GetGroveID(hubCtx)
+	if err != nil {
+		return wrapHubError(err)
+	}
+	agentSvc := hubCtx.Client.GroveAgents(groveID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	outMsg := &hubclient.OutboundMessageRequest{
+		Recipient: userRecipient,
+		Msg:       message,
+		Type:      "instruction",
+		Urgent:    urgent,
+	}
+
+	if err := agentSvc.SendOutboundMessage(ctx, senderAgent, outMsg); err != nil {
+		return wrapHubError(fmt.Errorf("failed to send message to %s: %w", userRecipient, err))
+	}
+
+	if !isJSONOutput() {
+		fmt.Printf("Message sent to %s via Hub.\n", userRecipient)
 	}
 	return nil
 }

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -555,6 +555,117 @@ func TestSendMessageViaHub_NotifyFlag(t *testing.T) {
 	mu.Unlock()
 }
 
+func TestSendOutboundMessageViaHub(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	groveID := "grove-msg-outbound"
+
+	var receivedMsg *hubclient.OutboundMessageRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
+			json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/groves/"+groveID+"/agents/my-agent/outbound-message":
+			var msg hubclient.OutboundMessageRequest
+			json.NewDecoder(r.Body).Decode(&msg)
+			receivedMsg = &msg
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:   client,
+		Endpoint: server.URL,
+		GroveID:  groveID,
+	}
+
+	t.Setenv("SCION_AGENT_NAME", "my-agent")
+
+	err = sendOutboundMessageViaHub(hubCtx, "user:alice", "I need help", false)
+	require.NoError(t, err)
+
+	require.NotNil(t, receivedMsg)
+	assert.Equal(t, "user:alice", receivedMsg.Recipient)
+	assert.Equal(t, "I need help", receivedMsg.Msg)
+	assert.Equal(t, "instruction", receivedMsg.Type)
+	assert.False(t, receivedMsg.Urgent)
+}
+
+func TestSendOutboundMessageViaHub_RequiresAgentContext(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+	}))
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:   client,
+		Endpoint: server.URL,
+		GroveID:  "grove-test",
+	}
+
+	t.Setenv("SCION_AGENT_NAME", "")
+
+	err = sendOutboundMessageViaHub(hubCtx, "user:alice", "hello", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SCION_AGENT_NAME not set")
+}
+
+func TestUserRecipientFlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		raw     bool
+		in      string
+		wantErr string
+	}{
+		{
+			name:    "raw with user recipient not allowed",
+			args:    []string{"user:alice", "hello"},
+			raw:     true,
+			wantErr: "--raw cannot be used with user recipients",
+		},
+		{
+			name:    "scheduled with user recipient not allowed",
+			args:    []string{"user:alice", "hello"},
+			in:      "30m",
+			wantErr: "--in/--at cannot be used with user recipients",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			origRaw := msgRaw
+			origIn := msgIn
+			defer func() {
+				msgRaw = origRaw
+				msgIn = origIn
+			}()
+
+			msgRaw = tc.raw
+			msgIn = tc.in
+
+			err := messageCmd.RunE(messageCmd, tc.args)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
 func TestNotifyFlagValidation(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -4206,6 +4206,8 @@ func (s *Server) handleGroveAgentAction(w http.ResponseWriter, r *http.Request, 
 		s.submitAgentEnv(w, r, groveID, agentID)
 	case "restore":
 		s.restoreAgent(w, r, agent.ID)
+	case "outbound-message":
+		s.handleAgentOutboundMessage(w, r, agent.ID)
 	default:
 		NotFound(w, "Action")
 	}

--- a/pkg/hubclient/agents.go
+++ b/pkg/hubclient/agents.go
@@ -83,6 +83,10 @@ type AgentService interface {
 	// GetLogs retrieves agent logs.
 	GetLogs(ctx context.Context, agentID string, opts *GetLogsOptions) (string, error)
 
+	// SendOutboundMessage sends a message from an agent to a human inbox.
+	// Used when agents need to communicate with users (e.g., asking questions).
+	SendOutboundMessage(ctx context.Context, agentID string, msg *OutboundMessageRequest) error
+
 	// GetCloudLogs retrieves structured log entries from Cloud Logging.
 	GetCloudLogs(ctx context.Context, agentID string, opts *GetCloudLogsOptions) (*CloudLogsResponse, error)
 
@@ -436,6 +440,24 @@ func (s *agentService) SendStructuredMessage(ctx context.Context, agentID string
 		Notify:            notify,
 	}
 	resp, err := s.c.transport.Post(ctx, s.agentPath(agentID)+"/message", body, nil)
+	if err != nil {
+		return err
+	}
+	return apiclient.CheckResponse(resp)
+}
+
+// OutboundMessageRequest is the request body for sending an agent-to-human outbound message.
+type OutboundMessageRequest struct {
+	Recipient   string `json:"recipient,omitempty"`
+	RecipientID string `json:"recipient_id,omitempty"`
+	Msg         string `json:"msg"`
+	Type        string `json:"type,omitempty"`
+	Urgent      bool   `json:"urgent,omitempty"`
+}
+
+// SendOutboundMessage sends a message from an agent to a human inbox.
+func (s *agentService) SendOutboundMessage(ctx context.Context, agentID string, msg *OutboundMessageRequest) error {
+	resp, err := s.c.transport.Post(ctx, s.agentPath(agentID)+"/outbound-message", msg, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Enable agents to send messages to human inboxes via `scion message user:<name> "msg"`. Routes user-targeted messages to the outbound-message Hub endpoint, adds SendOutboundMessage to hubclient.AgentService, and wires the grove-scoped handler path.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
