### PR TITLE
add copyable secret manager URI tooltip on version badge

### DIFF
--- a/web/src/components/shared/resource-styles.ts
+++ b/web/src/components/shared/resource-styles.ts
@@ -201,6 +201,14 @@ export const resourceStyles = css`
     font-family: var(--scion-font-mono, monospace);
   }
 
+  .version-badge-copyable {
+    cursor: pointer;
+  }
+
+  .version-badge-copyable:hover {
+    background: var(--scion-bg-hover, #e2e8f0);
+  }
+
   /* ── Empty / Loading / Error states ─────────────────────────────────── */
 
   .empty-state {

--- a/web/src/components/shared/secret-list.ts
+++ b/web/src/components/shared/secret-list.ts
@@ -58,6 +58,9 @@ export class ScionSecretList extends LitElement {
   // Delete
   @state() private deletingKey: string | null = null;
 
+  // Copy-to-clipboard feedback
+  @state() private copiedSecretKey: string | null = null;
+
   static override styles = [resourceStyles];
 
   override connectedCallback(): void {
@@ -225,6 +228,19 @@ export class ScionSecretList extends LitElement {
     }
   }
 
+  private async copySecretRef(secret: Secret): Promise<void> {
+    if (!secret.secretRef) return;
+    try {
+      await navigator.clipboard.writeText(secret.secretRef);
+      this.copiedSecretKey = secret.key;
+      setTimeout(() => {
+        this.copiedSecretKey = null;
+      }, 1500);
+    } catch {
+      // Silently fail if clipboard is unavailable
+    }
+  }
+
   // ── Rendering ────────────────────────────────────────────────────────
 
   override render() {
@@ -355,7 +371,15 @@ export class ScionSecretList extends LitElement {
           : nothing}
         <td class="description-cell hide-mobile">${secret.description || '\u2014'}</td>
         <td>
-          <span class="version-badge">v${secret.version}</span>
+          ${secret.secretRef
+            ? html`<sl-tooltip content=${this.copiedSecretKey === secret.key ? 'Copied!' : secret.secretRef} hoist>
+                <span
+                  class="version-badge version-badge-copyable"
+                  @click=${() => this.copySecretRef(secret)}
+                  title=""
+                >v${secret.version}</span>
+              </sl-tooltip>`
+            : html`<span class="version-badge">v${secret.version}</span>`}
         </td>
         <td class="hide-mobile">
           <span class="meta-text">${this.formatRelativeTime(secret.updated)}</span>

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -500,6 +500,7 @@ export interface Secret {
   injectionMode: InjectionMode;
   allowProgeny?: boolean;
   version: number;
+  secretRef?: string;
   created: string;
   updated: string;
   createdBy?: string;


### PR DESCRIPTION
When a secret is backed by secret manager (has a secretRef), the version badge (e.g. "v2") now shows the full resource URI on hover and copies it to clipboard on click, making it easy to cross-reference with debug logs.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
