### PR TITLE
Add provider selection for hub auth login

### DIFF
--- a/cmd/hub_auth.go
+++ b/cmd/hub_auth.go
@@ -34,23 +34,16 @@ var (
 	hubAuthNoBrowser bool
 )
 
-const (
-	hubAuthProviderGoogle = "google"
-	hubAuthProviderGitHub = "github"
-	hubAuthClientTypeCLI  = "cli"
-	hubAuthClientTypeDev  = "device"
-)
-
 type invalidHubAuthProviderError struct {
 	provider string
 }
 
 func (e invalidHubAuthProviderError) Error() string {
-	return fmt.Sprintf("invalid provider %q: must be google or github", e.provider)
+	return fmt.Sprintf("invalid provider %q: must be one of %s", e.provider, strings.Join(hubclient.OAuthProviderOrder(), ", "))
 }
 
 type noHubAuthProvidersConfiguredError struct {
-	clientType string
+	clientType hubclient.OAuthClientType
 }
 
 func (e noHubAuthProvidersConfiguredError) Error() string {
@@ -58,7 +51,7 @@ func (e noHubAuthProvidersConfiguredError) Error() string {
 }
 
 type multipleHubAuthProvidersConfiguredError struct {
-	clientType string
+	clientType hubclient.OAuthClientType
 	providers  []string
 }
 
@@ -143,7 +136,7 @@ func runHubAuthLogin(cmd *cobra.Command, args []string) error {
 	}
 
 	if hubAuthNoBrowser || util.IsHeadlessEnvironment() {
-		provider, err := resolveHubAuthProvider(cmd.Context(), client.Auth(), hubAuthClientTypeDev, provider)
+		provider, err := resolveHubAuthProvider(cmd.Context(), client.Auth(), hubclient.OAuthClientTypeDevice, provider)
 		if err != nil {
 			return err
 		}
@@ -166,7 +159,7 @@ func runHubAuthLogin(cmd *cobra.Command, args []string) error {
 
 // runBrowserAuthFlow performs the browser-based OAuth flow.
 func runBrowserAuthFlow(cmd *cobra.Command, client hubclient.Client, requestedProvider string) (*hubclient.CLITokenResponse, error) {
-	provider, err := resolveHubAuthProvider(cmd.Context(), client.Auth(), hubAuthClientTypeCLI, requestedProvider)
+	provider, err := resolveHubAuthProvider(cmd.Context(), client.Auth(), hubclient.OAuthClientTypeCLI, requestedProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -277,16 +270,16 @@ func getDefaultHubURL() string {
 	return settings.GetHubEndpoint()
 }
 
-func resolveHubAuthProvider(ctx context.Context, authSvc hubclient.AuthService, clientType, requestedProvider string) (string, error) {
+func resolveHubAuthProvider(ctx context.Context, authSvc hubclient.AuthService, clientType hubclient.OAuthClientType, requestedProvider string) (string, error) {
 	if requestedProvider != "" {
 		provider := strings.ToLower(strings.TrimSpace(requestedProvider))
-		if provider != hubAuthProviderGoogle && provider != hubAuthProviderGitHub {
+		if !hubclient.IsKnownOAuthProvider(provider) {
 			return "", invalidHubAuthProviderError{provider: requestedProvider}
 		}
 		return provider, nil
 	}
 
-	resp, err := authSvc.GetAuthProviders(ctx, clientType)
+	resp, err := authSvc.GetAuthProviders(ctx, string(clientType))
 	if err != nil {
 		return "", fmt.Errorf("failed to discover OAuth providers: %w", err)
 	}

--- a/cmd/hub_auth.go
+++ b/cmd/hub_auth.go
@@ -15,8 +15,10 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
@@ -31,6 +33,38 @@ var (
 	hubAuthHubURL    string
 	hubAuthNoBrowser bool
 )
+
+const (
+	hubAuthProviderGoogle = "google"
+	hubAuthProviderGitHub = "github"
+	hubAuthClientTypeCLI  = "cli"
+	hubAuthClientTypeDev  = "device"
+)
+
+type invalidHubAuthProviderError struct {
+	provider string
+}
+
+func (e invalidHubAuthProviderError) Error() string {
+	return fmt.Sprintf("invalid provider %q: must be google or github", e.provider)
+}
+
+type noHubAuthProvidersConfiguredError struct {
+	clientType string
+}
+
+func (e noHubAuthProvidersConfiguredError) Error() string {
+	return fmt.Sprintf("no OAuth providers configured for %s flow", e.clientType)
+}
+
+type multipleHubAuthProvidersConfiguredError struct {
+	clientType string
+	providers  []string
+}
+
+func (e multipleHubAuthProvidersConfiguredError) Error() string {
+	return fmt.Sprintf("multiple OAuth providers configured for %s flow (%s); specify one with --provider", e.clientType, strings.Join(e.providers, ", "))
+}
 
 // hubAuthCmd represents the auth subcommand under hub
 var hubAuthCmd = &cobra.Command{
@@ -60,7 +94,8 @@ that you can enter on any device with a browser.
 Example:
   scion hub auth login
   scion hub auth login --hub-url https://hub.example.com
-  scion hub auth login --no-browser`,
+  scion hub auth login --no-browser
+  scion hub auth login --provider github`,
 	RunE: runHubAuthLogin,
 }
 
@@ -80,6 +115,7 @@ func init() {
 	// Flags for login command
 	hubAuthLoginCmd.Flags().StringVar(&hubAuthHubURL, "hub-url", "", "Hub server URL (defaults to configured endpoint)")
 	hubAuthLoginCmd.Flags().BoolVar(&hubAuthNoBrowser, "no-browser", false, "Use device flow instead of opening a browser")
+	hubAuthLoginCmd.Flags().String("provider", "", "OAuth provider to use (google or github)")
 }
 
 func runHubAuthLogin(cmd *cobra.Command, args []string) error {
@@ -101,17 +137,25 @@ func runHubAuthLogin(cmd *cobra.Command, args []string) error {
 	}
 
 	var tokenResp *hubclient.CLITokenResponse
+	provider, err := cmd.Flags().GetString("provider")
+	if err != nil {
+		return fmt.Errorf("failed to read provider flag: %w", err)
+	}
 
 	if hubAuthNoBrowser || util.IsHeadlessEnvironment() {
+		provider, err := resolveHubAuthProvider(cmd.Context(), client.Auth(), hubAuthClientTypeDev, provider)
+		if err != nil {
+			return err
+		}
 		// Device authorization flow for headless environments
-		deviceAuth := auth.NewDeviceFlowAuth(client.Auth())
+		deviceAuth := auth.NewDeviceFlowAuth(client.Auth(), provider)
 		tokenResp, err = deviceAuth.Authenticate(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("device flow authentication failed: %w", err)
 		}
 	} else {
 		// Browser-based OAuth flow
-		tokenResp, err = runBrowserAuthFlow(cmd, client)
+		tokenResp, err = runBrowserAuthFlow(cmd, client, provider)
 		if err != nil {
 			return err
 		}
@@ -121,7 +165,12 @@ func runHubAuthLogin(cmd *cobra.Command, args []string) error {
 }
 
 // runBrowserAuthFlow performs the browser-based OAuth flow.
-func runBrowserAuthFlow(cmd *cobra.Command, client hubclient.Client) (*hubclient.CLITokenResponse, error) {
+func runBrowserAuthFlow(cmd *cobra.Command, client hubclient.Client, requestedProvider string) (*hubclient.CLITokenResponse, error) {
+	provider, err := resolveHubAuthProvider(cmd.Context(), client.Auth(), hubAuthClientTypeCLI, requestedProvider)
+	if err != nil {
+		return nil, err
+	}
+
 	// Start localhost callback server
 	authServer := auth.NewLocalhostAuthServer()
 	callbackURL, state, err := authServer.Start(cmd.Context())
@@ -131,7 +180,7 @@ func runBrowserAuthFlow(cmd *cobra.Command, client hubclient.Client) (*hubclient
 	defer authServer.Shutdown()
 
 	// Get OAuth URL from Hub
-	authResp, err := client.Auth().GetAuthURL(cmd.Context(), callbackURL, state)
+	authResp, err := client.Auth().GetAuthURL(cmd.Context(), callbackURL, state, provider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get auth URL: %w", err)
 	}
@@ -151,7 +200,7 @@ func runBrowserAuthFlow(cmd *cobra.Command, client hubclient.Client) (*hubclient
 	}
 
 	// Exchange code for token
-	tokenResp, err := client.Auth().ExchangeCode(cmd.Context(), code, callbackURL)
+	tokenResp, err := client.Auth().ExchangeCode(cmd.Context(), code, callbackURL, provider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get token: %w", err)
 	}
@@ -226,4 +275,28 @@ func getDefaultHubURL() string {
 	}
 
 	return settings.GetHubEndpoint()
+}
+
+func resolveHubAuthProvider(ctx context.Context, authSvc hubclient.AuthService, clientType, requestedProvider string) (string, error) {
+	if requestedProvider != "" {
+		provider := strings.ToLower(strings.TrimSpace(requestedProvider))
+		if provider != hubAuthProviderGoogle && provider != hubAuthProviderGitHub {
+			return "", invalidHubAuthProviderError{provider: requestedProvider}
+		}
+		return provider, nil
+	}
+
+	resp, err := authSvc.GetAuthProviders(ctx, clientType)
+	if err != nil {
+		return "", fmt.Errorf("failed to discover OAuth providers: %w", err)
+	}
+
+	switch len(resp.Providers) {
+	case 0:
+		return "", noHubAuthProvidersConfiguredError{clientType: clientType}
+	case 1:
+		return resp.Providers[0], nil
+	default:
+		return "", multipleHubAuthProvidersConfiguredError{clientType: clientType, providers: resp.Providers}
+	}
 }

--- a/cmd/hub_auth_test.go
+++ b/cmd/hub_auth_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
+)
+
+type mockHubAuthService struct {
+	providersResp *hubclient.AuthProvidersResponse
+	providersErr  error
+}
+
+type mockHubAuthNotImplementedError struct{}
+
+func (mockHubAuthNotImplementedError) Error() string {
+	return "not implemented"
+}
+
+func (m *mockHubAuthService) Login(ctx context.Context, req *hubclient.LoginRequest) (*hubclient.LoginResponse, error) {
+	return nil, mockHubAuthNotImplementedError{}
+}
+func (m *mockHubAuthService) Logout(ctx context.Context) error {
+	return mockHubAuthNotImplementedError{}
+}
+func (m *mockHubAuthService) Refresh(ctx context.Context, refreshToken string) (*hubclient.TokenResponse, error) {
+	return nil, mockHubAuthNotImplementedError{}
+}
+func (m *mockHubAuthService) Me(ctx context.Context) (*hubclient.User, error) {
+	return nil, mockHubAuthNotImplementedError{}
+}
+func (m *mockHubAuthService) GetWSTicket(ctx context.Context) (*hubclient.WSTicketResponse, error) {
+	return nil, mockHubAuthNotImplementedError{}
+}
+func (m *mockHubAuthService) GetAuthProviders(ctx context.Context, clientType string) (*hubclient.AuthProvidersResponse, error) {
+	return m.providersResp, m.providersErr
+}
+func (m *mockHubAuthService) GetAuthURL(ctx context.Context, callbackURL, state, provider string) (*hubclient.AuthURLResponse, error) {
+	return nil, mockHubAuthNotImplementedError{}
+}
+func (m *mockHubAuthService) ExchangeCode(ctx context.Context, code, callbackURL, provider string) (*hubclient.CLITokenResponse, error) {
+	return nil, mockHubAuthNotImplementedError{}
+}
+func (m *mockHubAuthService) RequestDeviceCode(ctx context.Context, provider string) (*hubclient.DeviceCodeResponse, error) {
+	return nil, mockHubAuthNotImplementedError{}
+}
+func (m *mockHubAuthService) PollDeviceToken(ctx context.Context, deviceCode, provider string) (*hubclient.DeviceTokenPollResponse, error) {
+	return nil, mockHubAuthNotImplementedError{}
+}
+
+func TestResolveHubAuthProvider_ExplicitProvider(t *testing.T) {
+	t.Parallel()
+
+	authSvc := &mockHubAuthService{}
+	got, err := resolveHubAuthProvider(context.Background(), authSvc, "device", "GitHub")
+	if err != nil {
+		t.Fatalf("resolveHubAuthProvider returned error: %v", err)
+	}
+	if got != "github" {
+		t.Fatalf("resolveHubAuthProvider = %q, want github", got)
+	}
+}
+
+func TestResolveHubAuthProvider_InvalidExplicitProvider(t *testing.T) {
+	t.Parallel()
+
+	authSvc := &mockHubAuthService{}
+	_, err := resolveHubAuthProvider(context.Background(), authSvc, "cli", "gitlab")
+	if err == nil {
+		t.Fatal("expected error for invalid provider")
+	}
+	if !strings.Contains(err.Error(), "must be google or github") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveHubAuthProvider_AutoSelectSingleProvider(t *testing.T) {
+	t.Parallel()
+
+	authSvc := &mockHubAuthService{
+		providersResp: &hubclient.AuthProvidersResponse{
+			ClientType: "device",
+			Providers:  []string{"github"},
+		},
+	}
+
+	got, err := resolveHubAuthProvider(context.Background(), authSvc, "device", "")
+	if err != nil {
+		t.Fatalf("resolveHubAuthProvider returned error: %v", err)
+	}
+	if got != "github" {
+		t.Fatalf("resolveHubAuthProvider = %q, want github", got)
+	}
+}
+
+func TestResolveHubAuthProvider_MultipleProviders(t *testing.T) {
+	t.Parallel()
+
+	authSvc := &mockHubAuthService{
+		providersResp: &hubclient.AuthProvidersResponse{
+			ClientType: "cli",
+			Providers:  []string{"google", "github"},
+		},
+	}
+
+	_, err := resolveHubAuthProvider(context.Background(), authSvc, "cli", "")
+	if err == nil {
+		t.Fatal("expected error for multiple providers")
+	}
+	if !strings.Contains(err.Error(), "--provider") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveHubAuthProvider_NoProviders(t *testing.T) {
+	t.Parallel()
+
+	authSvc := &mockHubAuthService{
+		providersResp: &hubclient.AuthProvidersResponse{
+			ClientType: "device",
+			Providers:  []string{},
+		},
+	}
+
+	_, err := resolveHubAuthProvider(context.Background(), authSvc, "device", "")
+	if err == nil {
+		t.Fatal("expected error when no providers are configured")
+	}
+	if !strings.Contains(err.Error(), "no OAuth providers configured") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/hub_auth_test.go
+++ b/cmd/hub_auth_test.go
@@ -68,7 +68,7 @@ func TestResolveHubAuthProvider_ExplicitProvider(t *testing.T) {
 	t.Parallel()
 
 	authSvc := &mockHubAuthService{}
-	got, err := resolveHubAuthProvider(context.Background(), authSvc, "device", "GitHub")
+	got, err := resolveHubAuthProvider(context.Background(), authSvc, hubclient.OAuthClientTypeDevice, "GitHub")
 	if err != nil {
 		t.Fatalf("resolveHubAuthProvider returned error: %v", err)
 	}
@@ -81,11 +81,11 @@ func TestResolveHubAuthProvider_InvalidExplicitProvider(t *testing.T) {
 	t.Parallel()
 
 	authSvc := &mockHubAuthService{}
-	_, err := resolveHubAuthProvider(context.Background(), authSvc, "cli", "gitlab")
+	_, err := resolveHubAuthProvider(context.Background(), authSvc, hubclient.OAuthClientTypeCLI, "gitlab")
 	if err == nil {
 		t.Fatal("expected error for invalid provider")
 	}
-	if !strings.Contains(err.Error(), "must be google or github") {
+	if !strings.Contains(err.Error(), "must be one of google, github") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -95,12 +95,12 @@ func TestResolveHubAuthProvider_AutoSelectSingleProvider(t *testing.T) {
 
 	authSvc := &mockHubAuthService{
 		providersResp: &hubclient.AuthProvidersResponse{
-			ClientType: "device",
+			ClientType: string(hubclient.OAuthClientTypeDevice),
 			Providers:  []string{"github"},
 		},
 	}
 
-	got, err := resolveHubAuthProvider(context.Background(), authSvc, "device", "")
+	got, err := resolveHubAuthProvider(context.Background(), authSvc, hubclient.OAuthClientTypeDevice, "")
 	if err != nil {
 		t.Fatalf("resolveHubAuthProvider returned error: %v", err)
 	}
@@ -114,12 +114,12 @@ func TestResolveHubAuthProvider_MultipleProviders(t *testing.T) {
 
 	authSvc := &mockHubAuthService{
 		providersResp: &hubclient.AuthProvidersResponse{
-			ClientType: "cli",
-			Providers:  []string{"google", "github"},
+			ClientType: string(hubclient.OAuthClientTypeCLI),
+			Providers:  hubclient.OAuthProviderOrder(),
 		},
 	}
 
-	_, err := resolveHubAuthProvider(context.Background(), authSvc, "cli", "")
+	_, err := resolveHubAuthProvider(context.Background(), authSvc, hubclient.OAuthClientTypeCLI, "")
 	if err == nil {
 		t.Fatal("expected error for multiple providers")
 	}
@@ -133,12 +133,12 @@ func TestResolveHubAuthProvider_NoProviders(t *testing.T) {
 
 	authSvc := &mockHubAuthService{
 		providersResp: &hubclient.AuthProvidersResponse{
-			ClientType: "device",
+			ClientType: string(hubclient.OAuthClientTypeDevice),
 			Providers:  []string{},
 		},
 	}
 
-	_, err := resolveHubAuthProvider(context.Background(), authSvc, "device", "")
+	_, err := resolveHubAuthProvider(context.Background(), authSvc, hubclient.OAuthClientTypeDevice, "")
 	if err == nil {
 		t.Fatal("expected error when no providers are configured")
 	}

--- a/pkg/hub/auth.go
+++ b/pkg/hub/auth.go
@@ -307,6 +307,8 @@ func isUnauthenticatedEndpoint(path string) bool {
 		return true
 	case "/api/v1/auth/logout": // Logout
 		return true
+	case "/api/v1/auth/providers": // OAuth provider discovery for CLI login
+		return true
 	case "/api/v1/auth/cli/authorize": // CLI OAuth authorization URL
 		return true
 	case "/api/v1/auth/cli/token": // CLI OAuth token exchange

--- a/pkg/hub/auth/device_flow.go
+++ b/pkg/hub/auth/device_flow.go
@@ -16,13 +16,17 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 )
+
+var errDeviceFlowProviderRequired = errors.New("device flow provider is required")
 
 // DeviceFlowAuth handles the OAuth 2.0 Device Authorization Grant flow
 // for headless environments where a browser cannot be opened directly.
@@ -34,10 +38,6 @@ type DeviceFlowAuth struct {
 
 // NewDeviceFlowAuth creates a new DeviceFlowAuth.
 func NewDeviceFlowAuth(client hubclient.AuthService, provider string) *DeviceFlowAuth {
-	if provider == "" {
-		provider = "google"
-	}
-
 	return &DeviceFlowAuth{
 		client:   client,
 		output:   os.Stdout,
@@ -51,6 +51,10 @@ func NewDeviceFlowAuth(client hubclient.AuthService, provider string) *DeviceFlo
 // 3. Polls for authorization completion
 // 4. Returns the token response on success
 func (d *DeviceFlowAuth) Authenticate(ctx context.Context) (*hubclient.CLITokenResponse, error) {
+	if strings.TrimSpace(d.provider) == "" {
+		return nil, errDeviceFlowProviderRequired
+	}
+
 	// Request device code
 	codeResp, err := d.client.RequestDeviceCode(ctx, d.provider)
 	if err != nil {

--- a/pkg/hub/auth/device_flow.go
+++ b/pkg/hub/auth/device_flow.go
@@ -27,15 +27,21 @@ import (
 // DeviceFlowAuth handles the OAuth 2.0 Device Authorization Grant flow
 // for headless environments where a browser cannot be opened directly.
 type DeviceFlowAuth struct {
-	client hubclient.AuthService
-	output io.Writer
+	client   hubclient.AuthService
+	output   io.Writer
+	provider string
 }
 
 // NewDeviceFlowAuth creates a new DeviceFlowAuth.
-func NewDeviceFlowAuth(client hubclient.AuthService) *DeviceFlowAuth {
+func NewDeviceFlowAuth(client hubclient.AuthService, provider string) *DeviceFlowAuth {
+	if provider == "" {
+		provider = "google"
+	}
+
 	return &DeviceFlowAuth{
-		client: client,
-		output: os.Stdout,
+		client:   client,
+		output:   os.Stdout,
+		provider: provider,
 	}
 }
 
@@ -46,7 +52,7 @@ func NewDeviceFlowAuth(client hubclient.AuthService) *DeviceFlowAuth {
 // 4. Returns the token response on success
 func (d *DeviceFlowAuth) Authenticate(ctx context.Context) (*hubclient.CLITokenResponse, error) {
 	// Request device code
-	codeResp, err := d.client.RequestDeviceCode(ctx, "google")
+	codeResp, err := d.client.RequestDeviceCode(ctx, d.provider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to request device code: %w", err)
 	}
@@ -78,7 +84,7 @@ func (d *DeviceFlowAuth) Authenticate(ctx context.Context) (*hubclient.CLITokenR
 			return nil, fmt.Errorf("device authorization expired")
 		}
 
-		pollResp, err := d.client.PollDeviceToken(ctx, codeResp.DeviceCode, "google")
+		pollResp, err := d.client.PollDeviceToken(ctx, codeResp.DeviceCode, d.provider)
 		if err != nil {
 			return nil, fmt.Errorf("failed to poll device token: %w", err)
 		}

--- a/pkg/hub/auth/device_flow_test.go
+++ b/pkg/hub/auth/device_flow_test.go
@@ -26,11 +26,19 @@ import (
 
 // mockAuthService implements hubclient.AuthService for testing.
 type mockAuthService struct {
-	deviceCodeResp *hubclient.DeviceCodeResponse
-	deviceCodeErr  error
-	pollResponses  []*hubclient.DeviceTokenPollResponse
-	pollErrors     []error
-	pollIndex      int
+	deviceCodeResp     *hubclient.DeviceCodeResponse
+	deviceCodeErr      error
+	pollResponses      []*hubclient.DeviceTokenPollResponse
+	pollErrors         []error
+	pollIndex          int
+	requestedProviders []string
+	polledProviders    []string
+}
+
+type mockDeviceFlowNotImplementedError struct{}
+
+func (mockDeviceFlowNotImplementedError) Error() string {
+	return "not implemented"
 }
 
 func (m *mockAuthService) Login(ctx context.Context, req *hubclient.LoginRequest) (*hubclient.LoginResponse, error) {
@@ -48,18 +56,23 @@ func (m *mockAuthService) Me(ctx context.Context) (*hubclient.User, error) {
 func (m *mockAuthService) GetWSTicket(ctx context.Context) (*hubclient.WSTicketResponse, error) {
 	return nil, fmt.Errorf("not implemented")
 }
-func (m *mockAuthService) GetAuthURL(ctx context.Context, callbackURL, state string) (*hubclient.AuthURLResponse, error) {
-	return nil, fmt.Errorf("not implemented")
+func (m *mockAuthService) GetAuthProviders(ctx context.Context, clientType string) (*hubclient.AuthProvidersResponse, error) {
+	return nil, mockDeviceFlowNotImplementedError{}
 }
-func (m *mockAuthService) ExchangeCode(ctx context.Context, code, callbackURL string) (*hubclient.CLITokenResponse, error) {
-	return nil, fmt.Errorf("not implemented")
+func (m *mockAuthService) GetAuthURL(ctx context.Context, callbackURL, state, provider string) (*hubclient.AuthURLResponse, error) {
+	return nil, mockDeviceFlowNotImplementedError{}
+}
+func (m *mockAuthService) ExchangeCode(ctx context.Context, code, callbackURL, provider string) (*hubclient.CLITokenResponse, error) {
+	return nil, mockDeviceFlowNotImplementedError{}
 }
 
 func (m *mockAuthService) RequestDeviceCode(ctx context.Context, provider string) (*hubclient.DeviceCodeResponse, error) {
+	m.requestedProviders = append(m.requestedProviders, provider)
 	return m.deviceCodeResp, m.deviceCodeErr
 }
 
 func (m *mockAuthService) PollDeviceToken(ctx context.Context, deviceCode, provider string) (*hubclient.DeviceTokenPollResponse, error) {
+	m.polledProviders = append(m.polledProviders, provider)
 	if m.pollIndex >= len(m.pollResponses) {
 		return nil, fmt.Errorf("no more poll responses")
 	}
@@ -96,7 +109,7 @@ func TestDeviceFlowAuth_Success(t *testing.T) {
 		},
 	}
 
-	d := NewDeviceFlowAuth(mock)
+	d := NewDeviceFlowAuth(mock, "github")
 	var buf bytes.Buffer
 	d.output = &buf
 
@@ -116,6 +129,14 @@ func TestDeviceFlowAuth_Success(t *testing.T) {
 	}
 	if resp.User == nil || resp.User.Email != "test@example.com" {
 		t.Error("expected user email 'test@example.com'")
+	}
+	if len(mock.requestedProviders) != 1 || mock.requestedProviders[0] != "github" {
+		t.Fatalf("expected RequestDeviceCode to use provider github, got %v", mock.requestedProviders)
+	}
+	for _, provider := range mock.polledProviders {
+		if provider != "github" {
+			t.Fatalf("expected PollDeviceToken provider github, got %v", mock.polledProviders)
+		}
 	}
 
 	// Check output contains the user code
@@ -143,7 +164,7 @@ func TestDeviceFlowAuth_SlowDown(t *testing.T) {
 		},
 	}
 
-	d := NewDeviceFlowAuth(mock)
+	d := NewDeviceFlowAuth(mock, "google")
 	d.output = &bytes.Buffer{}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -173,7 +194,7 @@ func TestDeviceFlowAuth_ExpiredToken(t *testing.T) {
 		},
 	}
 
-	d := NewDeviceFlowAuth(mock)
+	d := NewDeviceFlowAuth(mock, "google")
 	d.output = &bytes.Buffer{}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -201,7 +222,7 @@ func TestDeviceFlowAuth_ContextCancellation(t *testing.T) {
 		pollResponses: []*hubclient.DeviceTokenPollResponse{},
 	}
 
-	d := NewDeviceFlowAuth(mock)
+	d := NewDeviceFlowAuth(mock, "google")
 	d.output = &bytes.Buffer{}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -222,7 +243,7 @@ func TestDeviceFlowAuth_DeviceCodeError(t *testing.T) {
 		deviceCodeErr: fmt.Errorf("network error"),
 	}
 
-	d := NewDeviceFlowAuth(mock)
+	d := NewDeviceFlowAuth(mock, "google")
 	d.output = &bytes.Buffer{}
 
 	_, err := d.Authenticate(context.Background())

--- a/pkg/hub/auth/device_flow_test.go
+++ b/pkg/hub/auth/device_flow_test.go
@@ -209,6 +209,24 @@ func TestDeviceFlowAuth_ExpiredToken(t *testing.T) {
 	}
 }
 
+func TestDeviceFlowAuth_RequiresProvider(t *testing.T) {
+	mock := &mockAuthService{}
+
+	d := NewDeviceFlowAuth(mock, "")
+	d.output = &bytes.Buffer{}
+
+	_, err := d.Authenticate(context.Background())
+	if err == nil {
+		t.Fatal("expected error when provider is empty")
+	}
+	if err.Error() != "device flow provider is required" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.requestedProviders) != 0 {
+		t.Fatalf("expected no device code request, got providers %v", mock.requestedProviders)
+	}
+}
+
 func TestDeviceFlowAuth_ContextCancellation(t *testing.T) {
 	mock := &mockAuthService{
 		deviceCodeResp: &hubclient.DeviceCodeResponse{

--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -116,6 +116,12 @@ type CLIAuthAuthorizeRequest struct {
 	Provider    string `json:"provider,omitempty"` // "google" (default) or "github"
 }
 
+// CLIAuthProvidersResponse is the response for GET /api/v1/auth/providers.
+type CLIAuthProvidersResponse struct {
+	ClientType string   `json:"clientType"`
+	Providers  []string `json:"providers"`
+}
+
 // CLIAuthAuthorizeResponse is the response for /api/v1/auth/cli/authorize.
 type CLIAuthAuthorizeResponse struct {
 	URL string `json:"url"`
@@ -782,6 +788,48 @@ func (s *Server) handleCLIAuthAuthorize(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, CLIAuthAuthorizeResponse{
 		URL: authURL,
 	})
+}
+
+// handleCLIAuthProviders handles GET /api/v1/auth/providers.
+// This endpoint returns configured OAuth providers for a given client type.
+func (s *Server) handleCLIAuthProviders(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	clientTypeParam := strings.TrimSpace(r.URL.Query().Get("clientType"))
+	if clientTypeParam == "" {
+		ValidationError(w, "missing required query parameter: clientType", map[string]interface{}{
+			"required": []string{"clientType"},
+		})
+		return
+	}
+
+	var clientType OAuthClientType
+	switch clientTypeParam {
+	case string(OAuthClientTypeWeb):
+		clientType = OAuthClientTypeWeb
+	case string(OAuthClientTypeCLI):
+		clientType = OAuthClientTypeCLI
+	case string(OAuthClientTypeDevice):
+		clientType = OAuthClientTypeDevice
+	default:
+		ValidationError(w, "invalid clientType", map[string]interface{}{
+			"allowed": []string{string(OAuthClientTypeWeb), string(OAuthClientTypeCLI), string(OAuthClientTypeDevice)},
+		})
+		return
+	}
+
+	resp := CLIAuthProvidersResponse{
+		ClientType: clientTypeParam,
+		Providers:  []string{},
+	}
+	if s.oauthService != nil {
+		resp.Providers = s.oauthService.ConfiguredProvidersForClient(clientType)
+	}
+
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // handleCLIAuthToken handles POST /api/v1/auth/cli/token.

--- a/pkg/hub/handlers_auth_test.go
+++ b/pkg/hub/handlers_auth_test.go
@@ -406,6 +406,56 @@ func TestCLIDeviceAuthorize_MethodNotAllowed(t *testing.T) {
 	}
 }
 
+func TestCLIAuthProviders_ReturnsConfiguredProviders(t *testing.T) {
+	srv, _ := testServer(t)
+	srv.oauthService = NewOAuthService(OAuthConfig{
+		CLI: OAuthClientConfig{
+			GitHub: OAuthProviderConfig{
+				ClientID:     "cli-gh-id",
+				ClientSecret: "cli-gh-secret",
+			},
+		},
+		Device: OAuthClientConfig{
+			GitHub: OAuthProviderConfig{
+				ClientID:     "device-gh-id",
+				ClientSecret: "device-gh-secret",
+			},
+		},
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/auth/providers?clientType=device", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp CLIAuthProvidersResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.ClientType != "device" {
+		t.Fatalf("expected clientType device, got %q", resp.ClientType)
+	}
+	if len(resp.Providers) != 1 || resp.Providers[0] != "github" {
+		t.Fatalf("expected providers [github], got %v", resp.Providers)
+	}
+}
+
+func TestCLIAuthProviders_InvalidClientType(t *testing.T) {
+	srv, _ := testServer(t)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/auth/providers?clientType=desktop", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestCLIDeviceToken_MissingDeviceCode(t *testing.T) {
 	srv, _ := testServer(t)
 

--- a/pkg/hub/oauth.go
+++ b/pkg/hub/oauth.go
@@ -23,6 +23,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 )
 
 // OAuthProviderConfig holds OAuth credentials for a single provider.
@@ -45,9 +47,9 @@ func (c *OAuthClientConfig) IsConfigured() bool {
 // IsProviderConfigured returns true if the specified provider is configured.
 func (c *OAuthClientConfig) IsProviderConfigured(provider string) bool {
 	switch provider {
-	case googleOAuthProvider:
+	case hubclient.OAuthProviderGoogle:
 		return c.Google.ClientID != "" && c.Google.ClientSecret != ""
-	case githubOAuthProvider:
+	case hubclient.OAuthProviderGitHub:
 		return c.GitHub.ClientID != "" && c.GitHub.ClientSecret != ""
 	default:
 		return false
@@ -57,9 +59,9 @@ func (c *OAuthClientConfig) IsProviderConfigured(provider string) bool {
 // GetProvider returns the provider config for the specified provider.
 func (c *OAuthClientConfig) GetProvider(provider string) OAuthProviderConfig {
 	switch provider {
-	case googleOAuthProvider:
+	case hubclient.OAuthProviderGoogle:
 		return c.Google
-	case githubOAuthProvider:
+	case hubclient.OAuthProviderGitHub:
 		return c.GitHub
 	default:
 		return OAuthProviderConfig{}
@@ -88,26 +90,20 @@ func (c *OAuthConfig) IsProviderConfigured(provider string) bool {
 	return c.Web.IsProviderConfigured(provider) || c.CLI.IsProviderConfigured(provider) || c.Device.IsProviderConfigured(provider)
 }
 
-// ClientType represents the type of client (web or CLI).
-type OAuthClientType string
+// OAuthClientType represents the type of client (web or CLI).
+type OAuthClientType = hubclient.OAuthClientType
 
 const (
-	googleOAuthProvider = "google"
-	githubOAuthProvider = "github"
-
 	// OAuthClientTypeWeb is for web browser-based OAuth flows.
-	OAuthClientTypeWeb OAuthClientType = "web"
+	OAuthClientTypeWeb = hubclient.OAuthClientTypeWeb
 	// OAuthClientTypeCLI is for CLI localhost callback OAuth flows.
-	OAuthClientTypeCLI OAuthClientType = "cli"
+	OAuthClientTypeCLI = hubclient.OAuthClientTypeCLI
 	// OAuthClientTypeDevice is for device authorization grant (headless) flows.
-	OAuthClientTypeDevice OAuthClientType = "device"
+	OAuthClientTypeDevice = hubclient.OAuthClientTypeDevice
 )
 
 func oauthProviderOrder() []string {
-	return []string{
-		googleOAuthProvider,
-		githubOAuthProvider,
-	}
+	return hubclient.OAuthProviderOrder()
 }
 
 // OAuthService handles OAuth operations for authentication.
@@ -203,9 +199,9 @@ func (s *OAuthService) GetAuthorizationURLForClient(clientType OAuthClientType, 
 	cfg := s.getClientConfig(clientType)
 
 	switch provider {
-	case googleOAuthProvider:
+	case hubclient.OAuthProviderGoogle:
 		return s.getGoogleAuthURLWithConfig(cfg.Google, callbackURL, state)
-	case githubOAuthProvider:
+	case hubclient.OAuthProviderGitHub:
 		return s.getGitHubAuthURLWithConfig(cfg.GitHub, callbackURL, state)
 	default:
 		return "", fmt.Errorf("unsupported OAuth provider: %s", provider)

--- a/pkg/hub/oauth.go
+++ b/pkg/hub/oauth.go
@@ -137,6 +137,19 @@ func (s *OAuthService) IsProviderConfiguredForClient(clientType OAuthClientType,
 	return cfg.IsProviderConfigured(provider)
 }
 
+// ConfiguredProvidersForClient returns the configured OAuth providers for the
+// given client type in stable display order.
+func (s *OAuthService) ConfiguredProvidersForClient(clientType OAuthClientType) []string {
+	providers := make([]string, 0, 2)
+	for _, provider := range []string{"google", "github"} {
+		if s.IsProviderConfiguredForClient(clientType, provider) {
+			providers = append(providers, provider)
+		}
+	}
+
+	return providers
+}
+
 // OAuthUserInfo contains user information retrieved from an OAuth provider.
 type OAuthUserInfo struct {
 	ID          string

--- a/pkg/hub/oauth.go
+++ b/pkg/hub/oauth.go
@@ -45,9 +45,9 @@ func (c *OAuthClientConfig) IsConfigured() bool {
 // IsProviderConfigured returns true if the specified provider is configured.
 func (c *OAuthClientConfig) IsProviderConfigured(provider string) bool {
 	switch provider {
-	case "google":
+	case googleOAuthProvider:
 		return c.Google.ClientID != "" && c.Google.ClientSecret != ""
-	case "github":
+	case githubOAuthProvider:
 		return c.GitHub.ClientID != "" && c.GitHub.ClientSecret != ""
 	default:
 		return false
@@ -57,9 +57,9 @@ func (c *OAuthClientConfig) IsProviderConfigured(provider string) bool {
 // GetProvider returns the provider config for the specified provider.
 func (c *OAuthClientConfig) GetProvider(provider string) OAuthProviderConfig {
 	switch provider {
-	case "google":
+	case googleOAuthProvider:
 		return c.Google
-	case "github":
+	case githubOAuthProvider:
 		return c.GitHub
 	default:
 		return OAuthProviderConfig{}
@@ -92,6 +92,9 @@ func (c *OAuthConfig) IsProviderConfigured(provider string) bool {
 type OAuthClientType string
 
 const (
+	googleOAuthProvider = "google"
+	githubOAuthProvider = "github"
+
 	// OAuthClientTypeWeb is for web browser-based OAuth flows.
 	OAuthClientTypeWeb OAuthClientType = "web"
 	// OAuthClientTypeCLI is for CLI localhost callback OAuth flows.
@@ -99,6 +102,13 @@ const (
 	// OAuthClientTypeDevice is for device authorization grant (headless) flows.
 	OAuthClientTypeDevice OAuthClientType = "device"
 )
+
+func oauthProviderOrder() []string {
+	return []string{
+		googleOAuthProvider,
+		githubOAuthProvider,
+	}
+}
 
 // OAuthService handles OAuth operations for authentication.
 type OAuthService struct {
@@ -141,7 +151,7 @@ func (s *OAuthService) IsProviderConfiguredForClient(clientType OAuthClientType,
 // given client type in stable display order.
 func (s *OAuthService) ConfiguredProvidersForClient(clientType OAuthClientType) []string {
 	providers := make([]string, 0, 2)
-	for _, provider := range []string{"google", "github"} {
+	for _, provider := range oauthProviderOrder() {
 		if s.IsProviderConfiguredForClient(clientType, provider) {
 			providers = append(providers, provider)
 		}
@@ -192,9 +202,9 @@ func (s *OAuthService) GetAuthorizationURLForClient(clientType OAuthClientType, 
 	cfg := s.getClientConfig(clientType)
 
 	switch provider {
-	case "google":
+	case googleOAuthProvider:
 		return s.getGoogleAuthURLWithConfig(cfg.Google, callbackURL, state)
-	case "github":
+	case githubOAuthProvider:
 		return s.getGitHubAuthURLWithConfig(cfg.GitHub, callbackURL, state)
 	default:
 		return "", fmt.Errorf("unsupported OAuth provider: %s", provider)

--- a/pkg/hub/oauth.go
+++ b/pkg/hub/oauth.go
@@ -150,8 +150,9 @@ func (s *OAuthService) IsProviderConfiguredForClient(clientType OAuthClientType,
 // ConfiguredProvidersForClient returns the configured OAuth providers for the
 // given client type in stable display order.
 func (s *OAuthService) ConfiguredProvidersForClient(clientType OAuthClientType) []string {
-	providers := make([]string, 0, 2)
-	for _, provider := range oauthProviderOrder() {
+	order := oauthProviderOrder()
+	providers := make([]string, 0, len(order))
+	for _, provider := range order {
 		if s.IsProviderConfiguredForClient(clientType, provider) {
 			providers = append(providers, provider)
 		}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1953,6 +1953,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/auth/me", s.handleAuthMe)
 	s.mux.HandleFunc("/api/v1/auth/tokens", s.handleTokens)
 	s.mux.HandleFunc("/api/v1/auth/tokens/", s.handleTokenByID)
+	s.mux.HandleFunc("/api/v1/auth/providers", s.handleCLIAuthProviders)
 
 	// CLI OAuth endpoints (unauthenticated - used for login)
 	s.mux.HandleFunc("/api/v1/auth/cli/authorize", s.handleCLIAuthAuthorize)

--- a/pkg/hubclient/auth.go
+++ b/pkg/hubclient/auth.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
 )
@@ -39,11 +40,14 @@ type AuthService interface {
 	// GetWSTicket gets a short-lived WebSocket authentication ticket.
 	GetWSTicket(ctx context.Context) (*WSTicketResponse, error)
 
+	// GetAuthProviders returns configured OAuth providers for a client type.
+	GetAuthProviders(ctx context.Context, clientType string) (*AuthProvidersResponse, error)
+
 	// GetAuthURL returns the OAuth authorization URL for CLI login.
-	GetAuthURL(ctx context.Context, callbackURL, state string) (*AuthURLResponse, error)
+	GetAuthURL(ctx context.Context, callbackURL, state, provider string) (*AuthURLResponse, error)
 
 	// ExchangeCode exchanges an authorization code for tokens.
-	ExchangeCode(ctx context.Context, code, callbackURL string) (*CLITokenResponse, error)
+	ExchangeCode(ctx context.Context, code, callbackURL, provider string) (*CLITokenResponse, error)
 
 	// RequestDeviceCode initiates the device authorization flow.
 	RequestDeviceCode(ctx context.Context, provider string) (*DeviceCodeResponse, error)
@@ -87,6 +91,13 @@ type WSTicketResponse struct {
 // AuthURLResponse is the response containing the OAuth authorization URL.
 type AuthURLResponse struct {
 	URL string `json:"url"`
+}
+
+// AuthProvidersResponse is the response containing configured OAuth providers
+// for a given client type.
+type AuthProvidersResponse struct {
+	ClientType string   `json:"clientType"`
+	Providers  []string `json:"providers"`
 }
 
 // CLITokenResponse is the response from CLI token exchange.
@@ -147,14 +158,41 @@ func (s *authService) GetWSTicket(ctx context.Context) (*WSTicketResponse, error
 	return apiclient.DecodeResponse[WSTicketResponse](resp)
 }
 
+// GetAuthProviders returns configured OAuth providers for a client type.
+func (s *authService) GetAuthProviders(ctx context.Context, clientType string) (*AuthProvidersResponse, error) {
+	query := url.Values{}
+	query.Set("clientType", clientType)
+
+	resp, err := s.c.transport.GetWithQuery(ctx, "/api/v1/auth/providers", query, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode >= 400 {
+		return nil, apiclient.ParseErrorResponse(resp)
+	}
+
+	var result AuthProvidersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode auth providers response: %w", err)
+	}
+
+	return &result, nil
+}
+
 // GetAuthURL returns the OAuth authorization URL for CLI login.
-func (s *authService) GetAuthURL(ctx context.Context, callbackURL, state string) (*AuthURLResponse, error) {
+func (s *authService) GetAuthURL(ctx context.Context, callbackURL, state, provider string) (*AuthURLResponse, error) {
 	body := struct {
 		CallbackURL string `json:"callbackUrl"`
 		State       string `json:"state"`
+		Provider    string `json:"provider,omitempty"`
 	}{
 		CallbackURL: callbackURL,
 		State:       state,
+		Provider:    provider,
 	}
 	resp, err := s.c.transport.Post(ctx, "/api/v1/auth/cli/authorize", body, nil)
 	if err != nil {
@@ -164,13 +202,15 @@ func (s *authService) GetAuthURL(ctx context.Context, callbackURL, state string)
 }
 
 // ExchangeCode exchanges an authorization code for tokens.
-func (s *authService) ExchangeCode(ctx context.Context, code, callbackURL string) (*CLITokenResponse, error) {
+func (s *authService) ExchangeCode(ctx context.Context, code, callbackURL, provider string) (*CLITokenResponse, error) {
 	body := struct {
 		Code        string `json:"code"`
 		CallbackURL string `json:"callbackUrl"`
+		Provider    string `json:"provider,omitempty"`
 	}{
 		Code:        code,
 		CallbackURL: callbackURL,
+		Provider:    provider,
 	}
 	resp, err := s.c.transport.Post(ctx, "/api/v1/auth/cli/token", body, nil)
 	if err != nil {

--- a/pkg/hubclient/auth.go
+++ b/pkg/hubclient/auth.go
@@ -23,6 +23,33 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
 )
 
+type OAuthClientType string
+
+const (
+	OAuthProviderGoogle = "google"
+	OAuthProviderGitHub = "github"
+
+	OAuthClientTypeWeb    OAuthClientType = "web"
+	OAuthClientTypeCLI    OAuthClientType = "cli"
+	OAuthClientTypeDevice OAuthClientType = "device"
+)
+
+func OAuthProviderOrder() []string {
+	return []string{
+		OAuthProviderGoogle,
+		OAuthProviderGitHub,
+	}
+}
+
+func IsKnownOAuthProvider(provider string) bool {
+	for _, candidate := range OAuthProviderOrder() {
+		if provider == candidate {
+			return true
+		}
+	}
+	return false
+}
+
 // AuthService handles authentication operations.
 type AuthService interface {
 	// Login performs user login.


### PR DESCRIPTION
## Summary
- add `--provider` to `scion hub auth login`
- add a hub auth providers endpoint so the CLI can discover configured providers for browser and device flows
- auto-select the provider only when exactly one is configured, and require an explicit choice when multiple providers are available

## Problem
CLI auth currently does not have a clean way to target a specific OAuth provider. That causes two user-facing issues:
- a hub configured for GitHub-only auth can fail headless login when the CLI assumes a different provider
- a hub configured with multiple providers has no explicit selection path for CLI login

## Approach
This keeps provider selection explicit and predictable instead of relying on client-side fallback behavior:
- `scion hub auth login --provider <provider>` lets users choose directly
- when `--provider` is omitted, the CLI asks the hub which providers are configured for the relevant client flow
- if exactly one provider is configured, the CLI uses it automatically
- if multiple providers are configured, the CLI returns an error asking the user to pass `--provider`

## Testing
- `go test ./cmd ./pkg/hub/auth ./pkg/hubclient`
- `go test ./pkg/hub -run 'TestCLIAuthProviders|TestCLIAuthProviders_InvalidClientType|TestCLIDeviceAuthorize|TestCLIDeviceToken|TestProviderInferenceFromGitHubRedirectURI'`