### PR TITLE
fix: drop close of pending request channels in BrokerConnection.Close

### DIFF
--- a/pkg/hub/controlchannel.go
+++ b/pkg/hub/controlchannel.go
@@ -659,11 +659,13 @@ func (hc *BrokerConnection) Close() {
 	hc.streams = make(map[string]*StreamProxy)
 	hc.streamsMu.Unlock()
 
-	// Cancel all pending requests
+	// Drop all pending requests. We deliberately do NOT close the response
+	// channels here: doing so races with handleResponse trying to send on
+	// them (send-on-closed panic), and would also cause TunnelRequest's
+	// `case resp := <-respCh` to unblock with a nil response and return it
+	// as a success. TunnelRequest already observes hc.ctx.Done() (cancelled
+	// by hc.cancel() above), which is the correct unblock path.
 	hc.pendingMu.Lock()
-	for _, ch := range hc.pendingRequests {
-		close(ch)
-	}
 	hc.pendingRequests = make(map[string]chan *wsprotocol.ResponseEnvelope)
 	hc.pendingMu.Unlock()
 


### PR DESCRIPTION
## Summary
- **Bug**: race condition in \`pkg/hub/controlchannel.go\` \`BrokerConnection.Close\`. Close iterated \`hc.pendingRequests\` under \`pendingMu\` and called \`close(ch)\` on every response channel. Meanwhile \`ControlChannelManager.handleResponse\` looks the channel up under \`RLock\`, releases the lock, and then sends to it. Interleaved, the sender panics with \"send on closed channel\" and takes the hub process down.
- **Second bug same line**: closing the channels is also semantically wrong. \`TunnelRequest\`'s select treats a closed channel as a successful receive and returns the nil zero-value \`*wsprotocol.ResponseEnvelope\` to the caller as if it were a real response.
- **Fix**: don't close the channels. \`TunnelRequest\` already observes \`hc.ctx.Done()\` (cancelled by \`hc.cancel()\` at the top of \`Close\`), which is the correct unblock path for in-flight waiters. \`Close\` now just drops the map.

## Why no regression test
\`handleResponse\` is unexported and needs a live \`*wsprotocol.Connection\`; \`Close\` calls \`hc.conn.Close()\` which nil-derefs on a bare struct. Building the scaffolding for a race-detector repro is more plumbing than the fix itself. The \`-race\` suite will catch anyone re-adding \`close(ch)\` if we ever write a higher-level integration test for this path.

## Test plan
- [x] \`go build ./pkg/hub/...\`
- [x] \`go test ./...\` — no new failures vs baseline (44 pre-existing failures in \`cmd\`, \`pkg/agent\`, \`pkg/hub\`, \`pkg/util\` are unrelated: notifications, groves, GitHub, worktree env)
- [ ] Manual: confirm hub no longer crashes on \`broker disconnect during active request\`
