### PR TITLE
fix: propagate publisher context to subscriber handlers in InProcessBroker

### DIFF
--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -158,6 +158,42 @@ func TestInProcessBroker_BroadcastTopic(t *testing.T) {
 	wg.Wait()
 }
 
+// TestInProcessBroker_PropagatesPublisherContext verifies that the context
+// passed to Publish is delivered to the subscriber handler. Regression for a
+// bug where the dispatcher replaced the real ctx with context.Background(),
+// preventing handlers from honoring cancellation or carrying publisher values.
+func TestInProcessBroker_PropagatesPublisherContext(t *testing.T) {
+	b := newTestBroker()
+	defer b.Close()
+
+	type ctxKey string
+	const key ctxKey = "trace"
+
+	got := make(chan string, 1)
+	_, err := b.Subscribe("scion.grove.g1.broadcast", func(ctx context.Context, topic string, msg *messages.StructuredMessage) {
+		v, _ := ctx.Value(key).(string)
+		got <- v
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.WithValue(context.Background(), key, "abc123")
+	msg := messages.NewInstruction("u:a", "grove:g1", "hi")
+	if err := b.Publish(ctx, "scion.grove.g1.broadcast", msg); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case v := <-got:
+		if v != "abc123" {
+			t.Fatalf("handler got ctx value %q, want %q — publisher ctx was not propagated", v, "abc123")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for handler")
+	}
+}
+
 func TestInProcessBroker_Unsubscribe(t *testing.T) {
 	b := newTestBroker()
 	defer b.Close()

--- a/pkg/broker/inprocess.go
+++ b/pkg/broker/inprocess.go
@@ -37,7 +37,10 @@ type subscriber struct {
 }
 
 // publishedMessage pairs a topic with its message for channel delivery.
+// The publisher's context travels with the message so that subscriber
+// handlers can honor cancellation and deadlines from the publish side.
 type publishedMessage struct {
+	ctx   context.Context
 	topic string
 	msg   *messages.StructuredMessage
 }
@@ -80,7 +83,7 @@ func (b *InProcessBroker) Publish(ctx context.Context, topic string, msg *messag
 		return ErrBrokerClosed
 	}
 
-	pm := publishedMessage{topic: topic, msg: msg}
+	pm := publishedMessage{ctx: ctx, topic: topic, msg: msg}
 
 	for _, sub := range b.subscribers {
 		if subjectMatchesPattern(sub.pattern, topic) {
@@ -113,11 +116,16 @@ func (b *InProcessBroker) Subscribe(pattern string, handler MessageHandler) (Sub
 		done:    make(chan struct{}),
 	}
 
-	// Start a dispatch goroutine for this subscriber
+	// Start a dispatch goroutine for this subscriber. The publisher's context
+	// rides along in pm.ctx so handlers can honor cancellation/deadlines.
 	go func() {
 		defer close(sub.done)
 		for pm := range sub.ch {
-			sub.handler(context.Background(), pm.topic, pm.msg)
+			ctx := pm.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			sub.handler(ctx, pm.topic, pm.msg)
 		}
 	}()
 


### PR DESCRIPTION
## Summary
- **Bug**: the per-subscriber dispatch goroutine in \`pkg/broker/inprocess.go\` calls \`sub.handler(context.Background(), pm.topic, pm.msg)\`, discarding the context passed to \`Publish(ctx, ...)\`. That defeats \`MessageHandler\`'s \`ctx context.Context\` parameter: handlers cannot honor publisher-side cancellation, deadlines, or values (e.g. tracing).
- **Fix**: \`publishedMessage\` now carries the publisher ctx; the dispatcher passes it through to the handler. Falls back to \`context.Background()\` only for zero-value messages that have no ctx set.

## Test plan
- [x] \`go test ./pkg/broker/...\` — new \`TestInProcessBroker_PropagatesPublisherContext\` passes
- [x] \`go test ./...\` — no new failures vs baseline (44 pre-existing failures in \`cmd\`, \`pkg/agent\`, \`pkg/hub\`, \`pkg/util\` are unrelated)
