### PR TITLE
fix: close handshake response body on websocket dial failure

### DIFF
--- a/pkg/runtimebroker/controlchannel.go
+++ b/pkg/runtimebroker/controlchannel.go
@@ -219,10 +219,16 @@ func (c *ControlChannelClient) doConnect() error {
 		return fmt.Errorf("failed to build auth headers: %w", err)
 	}
 
-	// Connect
+	// Connect. gorilla/websocket's Dialer returns a non-nil *http.Response on
+	// handshake failure (e.g. 401/403), and the application is responsible
+	// for closing resp.Body in that case — otherwise the transport holds the
+	// connection open and leaks the file descriptor. Drain-and-close before
+	// returning the error.
 	conn, resp, err := wsprotocol.Dial(c.ctx, wsURL, headers)
 	if err != nil {
 		if resp != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
 			return fmt.Errorf("websocket dial failed (status %d): %w", resp.StatusCode, err)
 		}
 		return fmt.Errorf("websocket dial failed: %w", err)

--- a/pkg/wsprotocol/connection.go
+++ b/pkg/wsprotocol/connection.go
@@ -309,11 +309,19 @@ func ParseMessage[T any](data []byte) (*T, error) {
 }
 
 // Dial creates a WebSocket connection to the given URL.
+//
+// When err is non-nil and resp is also non-nil (e.g. the server rejected the
+// handshake with an HTTP status), the caller is responsible for closing
+// resp.Body — otherwise the underlying connection leaks. This matches
+// gorilla/websocket's Dialer.DialContext contract.
 func Dial(ctx context.Context, url string, headers http.Header) (*Connection, *http.Response, error) {
 	return DialWithConfig(ctx, url, headers, DefaultConnectionConfig())
 }
 
 // DialWithConfig creates a WebSocket connection with custom configuration.
+//
+// When err is non-nil and resp is also non-nil, the caller is responsible
+// for closing resp.Body (see Dial).
 func DialWithConfig(ctx context.Context, url string, headers http.Header, config ConnectionConfig) (*Connection, *http.Response, error) {
 	dialer := websocket.Dialer{
 		ReadBufferSize:  config.ReadBufferSize,


### PR DESCRIPTION
## Summary
- **Bug**: gorilla/websocket's \`Dialer.DialContext\` returns a non-nil \`*http.Response\` on handshake failure (e.g. a 401 or 403), and per its documented contract the caller MUST close \`resp.Body\`. The runtime broker's control-channel dial path (\`pkg/runtimebroker/controlchannel.go:225-228\`) reads \`resp.StatusCode\` into the error message but never calls \`resp.Body.Close()\`. The transport keeps the underlying connection alive and the file descriptor leaks. On an auth-rejection reconnect loop — which exists in this code — this is measurable.
- **Fix**: drain and close \`resp.Body\` on the error path in the caller. Also document the caller's obligation on \`wsprotocol.Dial\` / \`DialWithConfig\` so future callers don't repeat the mistake.

## Test plan
- [x] \`go build ./pkg/wsprotocol/... ./pkg/runtimebroker/...\`
- [x] \`go test ./...\` — no new failures vs baseline
