### PR TITLE
fix: surface daemon exit errors from StartComponent's reaper

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -89,9 +90,19 @@ func StartComponent(component, executable string, args []string, globalDir strin
 		return fmt.Errorf("failed to write PID file: %w", err)
 	}
 
+	// Background reaper. This goroutine is intentionally untracked: a daemon
+	// starter by definition fire-and-forgets the child, and the goroutine's
+	// lifetime is bounded by the child process lifetime. We surface any Wait
+	// error (which may carry OS-level exit status) so operators can tell a
+	// clean exit from an unexpected one.
 	go func() {
-		_ = cmd.Wait()
-		logFile.Close()
+		defer logFile.Close()
+		if err := cmd.Wait(); err != nil {
+			slog.Warn("Daemon component exited with error",
+				"component", component,
+				"pid", cmd.Process.Pid,
+				"error", err)
+		}
 	}()
 
 	return nil


### PR DESCRIPTION
## Summary
Minor. The background goroutine that reaps the daemon child in \`StartComponent\` was silently swallowing \`cmd.Wait\`'s error (\`_ = cmd.Wait()\`). Operators had no way to tell whether a daemon exited cleanly or crashed without tailing the log file the child wrote to.

## Fix
- Log the Wait error (if any) via \`slog.Warn\` with \`component\`, \`pid\`, and \`error\` so unclean exits are visible in the parent's logs.
- Move \`logFile.Close\` into a proper \`defer\` in the goroutine.
- Add a comment calling out that the goroutine is **intentionally** untracked — a daemon starter fire-and-forgets by design, and its lifetime is bounded by the child's — so nobody "fixes" it in the wrong direction.

## Note
This was the weakest of the six bugs I flagged and I called it "arguably by design" in the original report. Including it because you asked for all six. If you'd rather close this one WONTFIX, that's a defensible call.

## Test plan
- [x] \`go build ./pkg/daemon/...\`
- [x] \`go test -race ./pkg/daemon/...\`
- [x] \`go test ./...\` — no new failures vs baseline
