### PR TITLE
Support in-cluster Kubernetes auth

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -61,10 +61,43 @@ func NewClient(kubeconfigPath string) (*Client, error) {
 // NewClientWithContext creates a Kubernetes client targeting a specific context.
 // If contextName is empty, the current context from the kubeconfig is used.
 func NewClientWithContext(kubeconfigPath, contextName string) (*Client, error) {
-	var config *rest.Config
-	var err error
-	var currentContext string
+	return newClientWithContext(
+		kubeconfigPath,
+		contextName,
+		loadClientConfig,
+		rest.InClusterConfig,
+		func(config *rest.Config) (dynamic.Interface, error) {
+			return dynamic.NewForConfig(config)
+		},
+		func(config *rest.Config) (kubernetes.Interface, error) {
+			return kubernetes.NewForConfig(config)
+		},
+	)
+}
 
+func newClientWithContext(
+	kubeconfigPath,
+	contextName string,
+	loadConfig func(string, string) (*rest.Config, string, error),
+	inClusterConfig func() (*rest.Config, error),
+	newDynamicClient func(*rest.Config) (dynamic.Interface, error),
+	newClientset func(*rest.Config) (kubernetes.Interface, error),
+) (*Client, error) {
+	config, currentContext, err := loadConfig(kubeconfigPath, contextName)
+	if err != nil {
+		if kubeconfigPath == "" && contextName == "" {
+			config, err = inClusterConfig()
+			if err == nil {
+				return newClientFromConfig(config, "in-cluster", newDynamicClient, newClientset)
+			}
+		}
+		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+
+	return newClientFromConfig(config, currentContext, newDynamicClient, newClientset)
+}
+
+func loadClientConfig(kubeconfigPath, contextName string) (*rest.Config, string, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if kubeconfigPath != "" {
 		loadingRules.ExplicitPath = kubeconfigPath
@@ -80,11 +113,12 @@ func NewClientWithContext(kubeconfigPath, contextName string) (*Client, error) {
 		overrides,
 	)
 
-	config, err = configLoader.ClientConfig()
+	config, err := configLoader.ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
+		return nil, "", err
 	}
 
+	currentContext := ""
 	rawConfig, err := configLoader.RawConfig()
 	if err == nil {
 		if contextName != "" {
@@ -94,12 +128,21 @@ func NewClientWithContext(kubeconfigPath, contextName string) (*Client, error) {
 		}
 	}
 
-	dynClient, err := dynamic.NewForConfig(config)
+	return config, currentContext, nil
+}
+
+func newClientFromConfig(
+	config *rest.Config,
+	currentContext string,
+	newDynamicClient func(*rest.Config) (dynamic.Interface, error),
+	newClientset func(*rest.Config) (kubernetes.Interface, error),
+) (*Client, error) {
+	dynClient, err := newDynamicClient(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
 	}
 
-	clientset, err := kubernetes.NewForConfig(config)
+	clientset, err := newClientset(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kubernetes clientset: %w", err)
 	}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -16,6 +16,7 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -91,10 +92,11 @@ func newClientWithContext(
 			if err == nil {
 				return newClientFromConfig(config, "in-cluster", newDynamicClient, newClientset)
 			}
-			return nil, fmt.Errorf(
-				"failed to load kubeconfig and in-cluster config: kubeconfig=%s: in-cluster=%w",
-				kubeconfigErr.Error(),
-				err,
+			return nil, fmt.Errorf("failed to load kubeconfig and in-cluster config: %w",
+				errors.Join(
+					fmt.Errorf("kubeconfig: %w", kubeconfigErr),
+					fmt.Errorf("in-cluster: %w", err),
+				),
 			)
 		}
 		return nil, fmt.Errorf("failed to load kubeconfig: %w", kubeconfigErr)

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -85,13 +85,19 @@ func newClientWithContext(
 ) (*Client, error) {
 	config, currentContext, err := loadConfig(kubeconfigPath, contextName)
 	if err != nil {
+		kubeconfigErr := err
 		if kubeconfigPath == "" && contextName == "" {
 			config, err = inClusterConfig()
 			if err == nil {
 				return newClientFromConfig(config, "in-cluster", newDynamicClient, newClientset)
 			}
+			return nil, fmt.Errorf(
+				"failed to load kubeconfig and in-cluster config: kubeconfig=%s: in-cluster=%w",
+				kubeconfigErr.Error(),
+				err,
+			)
 		}
-		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
+		return nil, fmt.Errorf("failed to load kubeconfig: %w", kubeconfigErr)
 	}
 
 	return newClientFromConfig(config, currentContext, newDynamicClient, newClientset)

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -16,6 +16,7 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -280,6 +281,8 @@ func testKubeconfigLoadError() error {
 	return fmt.Errorf("no kubeconfig found: %w", os.ErrNotExist)
 }
 
+var errMissingServiceAccountToken = errors.New("service account token missing")
+
 func TestNewClientWithContext_FallsBackToInClusterConfig(t *testing.T) {
 	client, err := newClientWithContext(
 		"",
@@ -340,5 +343,37 @@ func TestNewClientWithContext_DoesNotFallBackWhenContextExplicit(t *testing.T) {
 
 	if inClusterCalled {
 		t.Fatal("expected in-cluster fallback to be skipped when context is explicit")
+	}
+}
+
+func TestNewClientWithContext_ReportsBothKubeconfigAndInClusterErrors(t *testing.T) {
+	loadErr := testKubeconfigLoadError()
+
+	_, err := newClientWithContext(
+		"",
+		"",
+		func(kubeconfigPath, contextName string) (*rest.Config, string, error) {
+			return nil, "", loadErr
+		},
+		func() (*rest.Config, error) {
+			return nil, errMissingServiceAccountToken
+		},
+		func(config *rest.Config) (dynamic.Interface, error) {
+			return dynamic.NewForConfig(config)
+		},
+		func(config *rest.Config) (kubernetes.Interface, error) {
+			return kubernetes.NewForConfig(config)
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error when kubeconfig and in-cluster config both fail")
+	}
+
+	if !strings.Contains(err.Error(), loadErr.Error()) {
+		t.Fatalf("expected kubeconfig error context, got: %v", err)
+	}
+
+	if !errors.Is(err, errMissingServiceAccountToken) {
+		t.Fatalf("expected wrapped in-cluster error, got: %v", err)
 	}
 }

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -27,9 +27,11 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 )
 
 func TestClient_ListSandboxClaims(t *testing.T) {
@@ -271,5 +273,72 @@ users:
 
 	if client.CurrentContext != "test-context" {
 		t.Errorf("expected CurrentContext 'test-context', got %q", client.CurrentContext)
+	}
+}
+
+func testKubeconfigLoadError() error {
+	return fmt.Errorf("no kubeconfig found: %w", os.ErrNotExist)
+}
+
+func TestNewClientWithContext_FallsBackToInClusterConfig(t *testing.T) {
+	client, err := newClientWithContext(
+		"",
+		"",
+		func(kubeconfigPath, contextName string) (*rest.Config, string, error) {
+			return nil, "", testKubeconfigLoadError()
+		},
+		func() (*rest.Config, error) {
+			return &rest.Config{Host: "https://10.43.0.1:443"}, nil
+		},
+		func(config *rest.Config) (dynamic.Interface, error) {
+			return dynamic.NewForConfig(config)
+		},
+		func(config *rest.Config) (kubernetes.Interface, error) {
+			return kubernetes.NewForConfig(config)
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewClientWithContext should fall back to in-cluster config: %v", err)
+	}
+
+	if client.CurrentContext != "in-cluster" {
+		t.Errorf("expected CurrentContext 'in-cluster', got %q", client.CurrentContext)
+	}
+
+	if client.Config.Host != "https://10.43.0.1:443" {
+		t.Errorf("expected in-cluster host to be used, got %q", client.Config.Host)
+	}
+}
+
+func TestNewClientWithContext_DoesNotFallBackWhenContextExplicit(t *testing.T) {
+	inClusterCalled := false
+	loadErr := testKubeconfigLoadError()
+	_, err := newClientWithContext(
+		"",
+		"explicit-context",
+		func(kubeconfigPath, contextName string) (*rest.Config, string, error) {
+			return nil, "", loadErr
+		},
+		func() (*rest.Config, error) {
+			inClusterCalled = true
+			return &rest.Config{Host: "https://10.43.0.1:443"}, nil
+		},
+		func(config *rest.Config) (dynamic.Interface, error) {
+			return dynamic.NewForConfig(config)
+		},
+		func(config *rest.Config) (kubernetes.Interface, error) {
+			return kubernetes.NewForConfig(config)
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error when explicit context kubeconfig resolution fails")
+	}
+
+	if !strings.Contains(err.Error(), loadErr.Error()) {
+		t.Fatalf("expected original kubeconfig load error, got: %v", err)
+	}
+
+	if inClusterCalled {
+		t.Fatal("expected in-cluster fallback to be skipped when context is explicit")
 	}
 }

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -277,9 +277,7 @@ users:
 	}
 }
 
-func testKubeconfigLoadError() error {
-	return fmt.Errorf("no kubeconfig found: %w", os.ErrNotExist)
-}
+var errKubeconfigLoad = fmt.Errorf("no kubeconfig found: %w", os.ErrNotExist)
 
 var errMissingServiceAccountToken = errors.New("service account token missing")
 
@@ -288,7 +286,7 @@ func TestNewClientWithContext_FallsBackToInClusterConfig(t *testing.T) {
 		"",
 		"",
 		func(kubeconfigPath, contextName string) (*rest.Config, string, error) {
-			return nil, "", testKubeconfigLoadError()
+			return nil, "", errKubeconfigLoad
 		},
 		func() (*rest.Config, error) {
 			return &rest.Config{Host: "https://10.43.0.1:443"}, nil
@@ -315,29 +313,24 @@ func TestNewClientWithContext_FallsBackToInClusterConfig(t *testing.T) {
 
 func TestNewClientWithContext_DoesNotFallBackWhenContextExplicit(t *testing.T) {
 	inClusterCalled := false
-	loadErr := testKubeconfigLoadError()
 	_, err := newClientWithContext(
 		"",
 		"explicit-context",
 		func(kubeconfigPath, contextName string) (*rest.Config, string, error) {
-			return nil, "", loadErr
+			return nil, "", errKubeconfigLoad
 		},
 		func() (*rest.Config, error) {
 			inClusterCalled = true
 			return &rest.Config{Host: "https://10.43.0.1:443"}, nil
 		},
-		func(config *rest.Config) (dynamic.Interface, error) {
-			return dynamic.NewForConfig(config)
-		},
-		func(config *rest.Config) (kubernetes.Interface, error) {
-			return kubernetes.NewForConfig(config)
-		},
+		nil, // unreachable: loadConfig fails and no fallback is attempted
+		nil,
 	)
 	if err == nil {
 		t.Fatal("expected error when explicit context kubeconfig resolution fails")
 	}
 
-	if !strings.Contains(err.Error(), loadErr.Error()) {
+	if !errors.Is(err, errKubeconfigLoad) {
 		t.Fatalf("expected original kubeconfig load error, got: %v", err)
 	}
 
@@ -347,33 +340,27 @@ func TestNewClientWithContext_DoesNotFallBackWhenContextExplicit(t *testing.T) {
 }
 
 func TestNewClientWithContext_ReportsBothKubeconfigAndInClusterErrors(t *testing.T) {
-	loadErr := testKubeconfigLoadError()
-
 	_, err := newClientWithContext(
 		"",
 		"",
 		func(kubeconfigPath, contextName string) (*rest.Config, string, error) {
-			return nil, "", loadErr
+			return nil, "", errKubeconfigLoad
 		},
 		func() (*rest.Config, error) {
 			return nil, errMissingServiceAccountToken
 		},
-		func(config *rest.Config) (dynamic.Interface, error) {
-			return dynamic.NewForConfig(config)
-		},
-		func(config *rest.Config) (kubernetes.Interface, error) {
-			return kubernetes.NewForConfig(config)
-		},
+		nil, // unreachable: both config paths fail
+		nil,
 	)
 	if err == nil {
 		t.Fatal("expected error when kubeconfig and in-cluster config both fail")
 	}
 
-	if !strings.Contains(err.Error(), loadErr.Error()) {
-		t.Fatalf("expected kubeconfig error context, got: %v", err)
+	if !errors.Is(err, errKubeconfigLoad) {
+		t.Fatalf("expected kubeconfig error in chain, got: %v", err)
 	}
 
 	if !errors.Is(err, errMissingServiceAccountToken) {
-		t.Fatalf("expected wrapped in-cluster error, got: %v", err)
+		t.Fatalf("expected in-cluster error in chain, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- fall back to `rest.InClusterConfig()` when no explicit kubeconfig path or context is provided
- preserve existing behavior when a kubeconfig path or context is explicitly set
- add focused tests for the fallback and non-fallback paths

## Why
Scion's Kubernetes runtime currently assumes kubeconfig loading even when the broker is running inside Kubernetes. In-cluster deployments should use the mounted service account credentials by default instead of requiring a separate kubeconfig artifact.

## Validation
- `go test ./pkg/k8s`
- `golangci-lint run --config .golangci.yml --new-from-rev=main ./pkg/k8s`
- `make build`
- in-cluster validation against a real Scion deployment confirmed the new code path uses in-cluster config successfully once Kubernetes API egress is allowed by policy
