### PR TITLE
feat: add OAuth token auth support for Claude harness

### DIFF
--- a/.omc/project-memory.json
+++ b/.omc/project-memory.json
@@ -1,0 +1,218 @@
+{
+  "version": "1.0.0",
+  "lastScanned": 1775793250506,
+  "projectRoot": "/Users/donovanyohan/Documents/Programs/personal/scion/.worktrees/everest",
+  "techStack": {
+    "languages": [
+      {
+        "name": "Go",
+        "version": null,
+        "confidence": "high",
+        "markers": [
+          "go.mod"
+        ]
+      },
+      {
+        "name": "C/C++",
+        "version": null,
+        "confidence": "high",
+        "markers": [
+          "Makefile"
+        ]
+      }
+    ],
+    "frameworks": [],
+    "packageManager": "go",
+    "runtime": null
+  },
+  "build": {
+    "buildCommand": "make build",
+    "testCommand": "make test",
+    "lintCommand": null,
+    "devCommand": null,
+    "scripts": {}
+  },
+  "conventions": {
+    "namingStyle": null,
+    "importStyle": null,
+    "testPattern": null,
+    "fileOrganization": null
+  },
+  "structure": {
+    "isMonorepo": false,
+    "workspaces": [],
+    "mainDirectories": [
+      "examples",
+      "scripts"
+    ],
+    "gitBranches": {
+      "defaultBranch": "main",
+      "branchingStrategy": null
+    }
+  },
+  "customNotes": [],
+  "directoryMap": {
+    "changelog": {
+      "path": "changelog",
+      "purpose": null,
+      "fileCount": 43,
+      "lastAccessed": 1775793250141,
+      "keyFiles": [
+        "2026-02-19-changelog.md",
+        "2026-02-20-changelog.md",
+        "2026-02-21-changelog.md",
+        "2026-02-22-changelog.md",
+        "2026-02-23-changelog.md"
+      ]
+    },
+    "cmd": {
+      "path": "cmd",
+      "purpose": null,
+      "fileCount": 83,
+      "lastAccessed": 1775793250142,
+      "keyFiles": [
+        "attach.go",
+        "broker.go",
+        "broker_test.go",
+        "cdw.go",
+        "clean.go"
+      ]
+    },
+    "docs-repo": {
+      "path": "docs-repo",
+      "purpose": null,
+      "fileCount": 2,
+      "lastAccessed": 1775793250143,
+      "keyFiles": [
+        "code-of-conduct.md",
+        "contributing.md"
+      ]
+    },
+    "docs-site": {
+      "path": "docs-site",
+      "purpose": null,
+      "fileCount": 13,
+      "lastAccessed": 1775793250145,
+      "keyFiles": [
+        "AGENTS.md",
+        "Dockerfile",
+        "README.md",
+        "astro.config.mjs",
+        "check-d2.sh"
+      ]
+    },
+    "examples": {
+      "path": "examples",
+      "purpose": "Example code",
+      "fileCount": 0,
+      "lastAccessed": 1775793250147,
+      "keyFiles": []
+    },
+    "extras": {
+      "path": "extras",
+      "purpose": null,
+      "fileCount": 0,
+      "lastAccessed": 1775793250150,
+      "keyFiles": []
+    },
+    "hack": {
+      "path": "hack",
+      "purpose": null,
+      "fileCount": 12,
+      "lastAccessed": 1775793250152,
+      "keyFiles": [
+        "README.md",
+        "cleanup.sh",
+        "create-cluster.sh",
+        "dist.sh",
+        "install.sh"
+      ]
+    },
+    "image-build": {
+      "path": "image-build",
+      "purpose": null,
+      "fileCount": 6,
+      "lastAccessed": 1775793250155,
+      "keyFiles": [
+        "README.md",
+        "cloudbuild-common.yaml",
+        "cloudbuild-core-base.yaml",
+        "cloudbuild-harnesses.yaml",
+        "cloudbuild-scion-base.yaml"
+      ]
+    },
+    "pkg": {
+      "path": "pkg",
+      "purpose": null,
+      "fileCount": 0,
+      "lastAccessed": 1775793250156,
+      "keyFiles": []
+    },
+    "scripts": {
+      "path": "scripts",
+      "purpose": "Build/utility scripts",
+      "fileCount": 5,
+      "lastAccessed": 1775793250159,
+      "keyFiles": [
+        "README.md",
+        "checktemplate-2.sh",
+        "hub-env-integration-test.sh",
+        "hub-secret-integration-test.sh",
+        "template-integration-test.sh"
+      ]
+    },
+    "skills": {
+      "path": "skills",
+      "purpose": null,
+      "fileCount": 1,
+      "lastAccessed": 1775793250162,
+      "keyFiles": [
+        "README.md"
+      ]
+    },
+    "web": {
+      "path": "web",
+      "purpose": null,
+      "fileCount": 13,
+      "lastAccessed": 1775793250166,
+      "keyFiles": [
+        "AGENTS.md",
+        "OAUTH_LOCAL_WALKTHROUGH.md",
+        "README.md",
+        "embed.go",
+        "embed_stub.go"
+      ]
+    },
+    "pkg/api": {
+      "path": "pkg/api",
+      "purpose": "API routes",
+      "fileCount": 9,
+      "lastAccessed": 1775793250178,
+      "keyFiles": [
+        "content.go",
+        "content_test.go",
+        "harness.go"
+      ]
+    },
+    "pkg/config": {
+      "path": "pkg/config",
+      "purpose": "Configuration files",
+      "fileCount": 42,
+      "lastAccessed": 1775793250179,
+      "keyFiles": [
+        "agent_settings.go",
+        "agent_settings_test.go",
+        "auth.go"
+      ]
+    },
+    "web/dist": {
+      "path": "web/dist",
+      "purpose": "Distribution/build output",
+      "fileCount": 0,
+      "lastAccessed": 1775793250181,
+      "keyFiles": []
+    }
+  },
+  "hotPaths": [],
+  "userDirectives": []
+}

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -320,13 +320,14 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		if opts.BrokerMode {
 			harness.OverlayFileSecrets(&auth, opts.ResolvedSecrets)
 		}
-		util.Debugf("auth: gathered credentials — selectedType=%q, hasGeminiKey=%t, hasGoogleKey=%t, hasOAuth=%t, hasADC=%t, hasAnthropicKey=%t, cloudProject=%q, gcpMetadataMode=%q, brokerMode=%t",
+		util.Debugf("auth: gathered credentials — selectedType=%q, hasGeminiKey=%t, hasGoogleKey=%t, hasOAuth=%t, hasADC=%t, hasAnthropicKey=%t, hasClaudeOAuthToken=%t, cloudProject=%q, gcpMetadataMode=%q, brokerMode=%t",
 			auth.SelectedType,
 			auth.GeminiAPIKey != "",
 			auth.GoogleAPIKey != "",
 			auth.OAuthCreds != "",
 			auth.GoogleAppCredentials != "",
 			auth.AnthropicAPIKey != "",
+			auth.ClaudeOAuthToken != "",
 			auth.GoogleCloudProject,
 			auth.GCPMetadataMode,
 			opts.BrokerMode,

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -996,6 +996,8 @@ func authFileKind(name, target string) string {
 		return "codex-auth"
 	case name == "OPENCODE_AUTH" || strings.HasSuffix(target, "/opencode/auth.json"):
 		return "opencode-auth"
+	case name == "CLAUDE_CREDENTIALS" || strings.HasSuffix(target, "/.claude/.credentials.json"):
+		return "claude-credentials"
 	default:
 		return ""
 	}

--- a/pkg/api/harness_capabilities.go
+++ b/pkg/api/harness_capabilities.go
@@ -50,9 +50,10 @@ type HarnessPromptCapabilities struct {
 
 // HarnessAuthCapabilities describes support for auth mode selections.
 type HarnessAuthCapabilities struct {
-	APIKey   CapabilityField `json:"api_key"`
-	AuthFile CapabilityField `json:"auth_file"`
-	VertexAI CapabilityField `json:"vertex_ai"`
+	APIKey     CapabilityField `json:"api_key"`
+	OAuthToken CapabilityField `json:"oauth_token"`
+	AuthFile   CapabilityField `json:"auth_file"`
+	VertexAI   CapabilityField `json:"vertex_ai"`
 }
 
 // HarnessAdvancedCapabilities describes advanced field support for a harness.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -366,7 +366,8 @@ type AuthConfig struct {
 	OAuthCreds           string
 
 	// Anthropic auth
-	AnthropicAPIKey string
+	AnthropicAPIKey  string
+	ClaudeOAuthToken string
 
 	// OpenAI/Codex auth
 	OpenAIAPIKey     string

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -366,8 +366,9 @@ type AuthConfig struct {
 	OAuthCreds           string
 
 	// Anthropic auth
-	AnthropicAPIKey  string
-	ClaudeOAuthToken string
+	AnthropicAPIKey       string
+	ClaudeOAuthToken      string
+	ClaudeCredentialsFile string // Path to ~/.claude/.credentials.json
 
 	// OpenAI/Codex auth
 	OpenAIAPIKey     string

--- a/pkg/harness/auth.go
+++ b/pkg/harness/auth.go
@@ -54,11 +54,12 @@ func GatherAuthWithEnv(env map[string]string, localSources bool) api.AuthConfig 
 
 	auth := api.AuthConfig{
 		// Env-var sourced fields
-		GeminiAPIKey:    lookup("GEMINI_API_KEY"),
-		GoogleAPIKey:    lookup("GOOGLE_API_KEY"),
-		AnthropicAPIKey: lookup("ANTHROPIC_API_KEY"),
-		OpenAIAPIKey:    lookup("OPENAI_API_KEY"),
-		CodexAPIKey:     lookup("CODEX_API_KEY"),
+		GeminiAPIKey:     lookup("GEMINI_API_KEY"),
+		GoogleAPIKey:     lookup("GOOGLE_API_KEY"),
+		AnthropicAPIKey:  lookup("ANTHROPIC_API_KEY"),
+		ClaudeOAuthToken: lookup("CLAUDE_CODE_OAUTH_TOKEN"),
+		OpenAIAPIKey:     lookup("OPENAI_API_KEY"),
+		CodexAPIKey:      lookup("CODEX_API_KEY"),
 		GoogleCloudProject: util.FirstNonEmpty(
 			lookup("GOOGLE_CLOUD_PROJECT"),
 			lookup("GCP_PROJECT"),
@@ -269,7 +270,14 @@ func DetectAuthTypeFromFileSecrets(harnessName string, fileSecretNames map[strin
 // so vertex-ai auth can be used without a gcloud-adc file secret.
 func DetectAuthTypeFromEnvVars(harnessName string, envKeys map[string]struct{}) string {
 	switch harnessName {
-	case "claude", "gemini":
+	case "claude":
+		if _, ok := envKeys["CLAUDE_CODE_OAUTH_TOKEN"]; ok {
+			return "oauth-token"
+		}
+		if _, ok := envKeys["GOOGLE_APPLICATION_CREDENTIALS"]; ok {
+			return "vertex-ai"
+		}
+	case "gemini":
 		if _, ok := envKeys["GOOGLE_APPLICATION_CREDENTIALS"]; ok {
 			return "vertex-ai"
 		}
@@ -312,6 +320,8 @@ func RequiredAuthEnvKeys(harnessName, authSelectedType string) [][]string {
 		switch effectiveType {
 		case "api-key":
 			return [][]string{{"ANTHROPIC_API_KEY"}}
+		case "oauth-token":
+			return [][]string{{"CLAUDE_CODE_OAUTH_TOKEN"}}
 		case "vertex-ai":
 			return [][]string{{"GOOGLE_CLOUD_PROJECT"}, {"GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"}}
 		}

--- a/pkg/harness/auth.go
+++ b/pkg/harness/auth.go
@@ -100,10 +100,43 @@ func GatherAuthWithEnv(env map[string]string, localSources bool) api.AuthConfig 
 			if _, err := os.Stat(opencodePath); err == nil {
 				auth.OpenCodeAuthFile = opencodePath
 			}
+
+			// Check for Claude credentials file and extract OAuth token if present
+			claudeCredsPath := filepath.Join(home, ".claude", ".credentials.json")
+			if _, err := os.Stat(claudeCredsPath); err == nil {
+				auth.ClaudeCredentialsFile = claudeCredsPath
+				// Extract the access token from the credentials file if not already set via env
+				if auth.ClaudeOAuthToken == "" {
+					if token := extractClaudeOAuthToken(claudeCredsPath); token != "" {
+						auth.ClaudeOAuthToken = token
+					}
+				}
+			}
 		}
 	}
 
 	return auth
+}
+
+// extractClaudeOAuthToken reads the Claude credentials file and extracts
+// the OAuth access token from the claudeAiOauth.accessToken field.
+func extractClaudeOAuthToken(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+
+	var creds struct {
+		ClaudeAiOauth struct {
+			AccessToken string `json:"accessToken"`
+		} `json:"claudeAiOauth"`
+	}
+
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return ""
+	}
+
+	return creds.ClaudeAiOauth.AccessToken
 }
 
 // OverlayFileSecrets bridges file-type ResolvedSecrets from the hub into
@@ -132,6 +165,9 @@ func OverlayFileSecrets(auth *api.AuthConfig, secrets []api.ResolvedSecret) {
 		case name == "OPENCODE_AUTH" ||
 			strings.HasSuffix(target, "/opencode/auth.json"):
 			auth.OpenCodeAuthFile = target
+		case name == "CLAUDE_CREDENTIALS" ||
+			strings.HasSuffix(target, "/.claude/.credentials.json"):
+			auth.ClaudeCredentialsFile = target
 		}
 	}
 }

--- a/pkg/harness/auth_test.go
+++ b/pkg/harness/auth_test.go
@@ -139,6 +139,10 @@ func TestGatherAuth_FileDiscovery(t *testing.T) {
 	os.MkdirAll(filepath.Dir(opencodePath), 0755)
 	os.WriteFile(opencodePath, []byte(`{"dummy":"opencode"}`), 0644)
 
+	claudeCredsPath := filepath.Join(tmpHome, ".claude", ".credentials.json")
+	os.MkdirAll(filepath.Dir(claudeCredsPath), 0755)
+	os.WriteFile(claudeCredsPath, []byte(`{"claudeAiOauth":{"accessToken":"sk-ant-oat01-test-token"}}`), 0600)
+
 	auth := GatherAuth()
 
 	if auth.GoogleAppCredentials != adcPath {
@@ -152,6 +156,12 @@ func TestGatherAuth_FileDiscovery(t *testing.T) {
 	}
 	if auth.OpenCodeAuthFile != opencodePath {
 		t.Errorf("OpenCodeAuthFile = %q, want %q", auth.OpenCodeAuthFile, opencodePath)
+	}
+	if auth.ClaudeCredentialsFile != claudeCredsPath {
+		t.Errorf("ClaudeCredentialsFile = %q, want %q", auth.ClaudeCredentialsFile, claudeCredsPath)
+	}
+	if auth.ClaudeOAuthToken != "sk-ant-oat01-test-token" {
+		t.Errorf("ClaudeOAuthToken = %q, want %q", auth.ClaudeOAuthToken, "sk-ant-oat01-test-token")
 	}
 }
 
@@ -204,6 +214,12 @@ func TestGatherAuth_NoFiles(t *testing.T) {
 	}
 	if auth.OpenCodeAuthFile != "" {
 		t.Errorf("OpenCodeAuthFile = %q, want empty", auth.OpenCodeAuthFile)
+	}
+	if auth.ClaudeCredentialsFile != "" {
+		t.Errorf("ClaudeCredentialsFile = %q, want empty", auth.ClaudeCredentialsFile)
+	}
+	if auth.ClaudeOAuthToken != "" {
+		t.Errorf("ClaudeOAuthToken = %q, want empty", auth.ClaudeOAuthToken)
 	}
 }
 
@@ -886,6 +902,28 @@ func TestOverlayFileSecrets(t *testing.T) {
 			},
 		},
 		{
+			name: "Claude credentials by name",
+			secrets: []api.ResolvedSecret{
+				{Name: "CLAUDE_CREDENTIALS", Type: "file", Target: "/home/gemini/.claude/.credentials.json"},
+			},
+			check: func(t *testing.T, auth api.AuthConfig) {
+				if auth.ClaudeCredentialsFile != "/home/gemini/.claude/.credentials.json" {
+					t.Errorf("ClaudeCredentialsFile = %q, want claude credentials path", auth.ClaudeCredentialsFile)
+				}
+			},
+		},
+		{
+			name: "Claude credentials by target suffix",
+			secrets: []api.ResolvedSecret{
+				{Name: "my-claude-creds", Type: "file", Target: "/home/gemini/.claude/.credentials.json"},
+			},
+			check: func(t *testing.T, auth api.AuthConfig) {
+				if auth.ClaudeCredentialsFile != "/home/gemini/.claude/.credentials.json" {
+					t.Errorf("ClaudeCredentialsFile = %q, want claude credentials path", auth.ClaudeCredentialsFile)
+				}
+			},
+		},
+		{
 			name: "non-file secrets are skipped",
 			secrets: []api.ResolvedSecret{
 				{Name: "gcloud-adc", Type: "environment", Target: "gcloud-adc", Value: "/some/path"},
@@ -904,5 +942,65 @@ func TestOverlayFileSecrets(t *testing.T) {
 			OverlayFileSecrets(&auth, tt.secrets)
 			tt.check(t, auth)
 		})
+	}
+}
+
+func TestExtractClaudeOAuthToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name:     "valid credentials file",
+			content:  `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-test-token"}}`,
+			expected: "sk-ant-oat01-test-token",
+		},
+		{
+			name:     "valid credentials with extra fields",
+			content:  `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-abc123","refreshToken":"refresh-xyz","expiresAt":1739781600000}}`,
+			expected: "sk-ant-oat01-abc123",
+		},
+		{
+			name:     "missing accessToken",
+			content:  `{"claudeAiOauth":{"refreshToken":"refresh-xyz"}}`,
+			expected: "",
+		},
+		{
+			name:     "missing claudeAiOauth object",
+			content:  `{"otherField":"value"}`,
+			expected: "",
+		},
+		{
+			name:     "invalid JSON",
+			content:  `{"invalid json`,
+			expected: "",
+		},
+		{
+			name:     "empty JSON object",
+			content:  `{}`,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpFile := filepath.Join(t.TempDir(), ".credentials.json")
+			if err := os.WriteFile(tmpFile, []byte(tt.content), 0600); err != nil {
+				t.Fatalf("failed to write test file: %v", err)
+			}
+
+			result := extractClaudeOAuthToken(tmpFile)
+			if result != tt.expected {
+				t.Errorf("extractClaudeOAuthToken() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractClaudeOAuthToken_FileNotFound(t *testing.T) {
+	result := extractClaudeOAuthToken("/nonexistent/path/.credentials.json")
+	if result != "" {
+		t.Errorf("extractClaudeOAuthToken() = %q, want empty string for non-existent file", result)
 	}
 }

--- a/pkg/harness/claude_code.go
+++ b/pkg/harness/claude_code.go
@@ -53,9 +53,10 @@ func (c *ClaudeCode) AdvancedCapabilities() api.HarnessAdvancedCapabilities {
 			AgentInstructions: api.CapabilityField{Support: api.SupportYes},
 		},
 		Auth: api.HarnessAuthCapabilities{
-			APIKey:   api.CapabilityField{Support: api.SupportYes},
-			AuthFile: api.CapabilityField{Support: api.SupportNo, Reason: "Claude does not support auth-file mode"},
-			VertexAI: api.CapabilityField{Support: api.SupportYes},
+			APIKey:     api.CapabilityField{Support: api.SupportYes},
+			OAuthToken: api.CapabilityField{Support: api.SupportYes},
+			AuthFile:   api.CapabilityField{Support: api.SupportNo, Reason: "Claude does not support auth-file mode"},
+			VertexAI:   api.CapabilityField{Support: api.SupportYes},
 		},
 	}
 }
@@ -335,17 +336,27 @@ func (c *ClaudeCode) ResolveAuth(auth api.AuthConfig) (*api.ResolvedAuth, error)
 					"ANTHROPIC_API_KEY": auth.AnthropicAPIKey,
 				},
 			}, nil
+		case "oauth-token":
+			if auth.ClaudeOAuthToken == "" {
+				return nil, fmt.Errorf("claude: auth type %q selected but no token found; set CLAUDE_CODE_OAUTH_TOKEN (generate via 'claude setup-token')", auth.SelectedType)
+			}
+			return &api.ResolvedAuth{
+				Method: "oauth-token",
+				EnvVars: map[string]string{
+					"CLAUDE_CODE_OAUTH_TOKEN": auth.ClaudeOAuthToken,
+				},
+			}, nil
 		case "vertex-ai":
 			if auth.GoogleCloudProject == "" || auth.GoogleCloudRegion == "" {
 				return nil, fmt.Errorf("claude: auth type %q selected but GOOGLE_CLOUD_PROJECT and/or GOOGLE_CLOUD_REGION not set", auth.SelectedType)
 			}
 			return c.resolveVertexAI(auth), nil
 		default:
-			return nil, fmt.Errorf("claude: unknown auth type %q; valid types are: api-key, vertex-ai", auth.SelectedType)
+			return nil, fmt.Errorf("claude: unknown auth type %q; valid types are: api-key, oauth-token, vertex-ai", auth.SelectedType)
 		}
 	}
 
-	// Auto-detect preference order: API key → Vertex AI → error
+	// Auto-detect preference order: API key → OAuth token → Vertex AI → error
 
 	// 1. Anthropic API key (direct)
 	if auth.AnthropicAPIKey != "" {
@@ -357,14 +368,24 @@ func (c *ClaudeCode) ResolveAuth(auth api.AuthConfig) (*api.ResolvedAuth, error)
 		}, nil
 	}
 
-	// 2. Vertex AI — requires project + region, plus either ADC file or
+	// 2. OAuth token (subscription users via 'claude setup-token')
+	if auth.ClaudeOAuthToken != "" {
+		return &api.ResolvedAuth{
+			Method: "oauth-token",
+			EnvVars: map[string]string{
+				"CLAUDE_CODE_OAUTH_TOKEN": auth.ClaudeOAuthToken,
+			},
+		}, nil
+	}
+
+	// 3. Vertex AI — requires project + region, plus either ADC file or
 	//    a GCP service account via the metadata server (assign mode).
 	hasVertexCreds := auth.GoogleAppCredentials != "" || auth.GCPMetadataMode == "assign"
 	if hasVertexCreds && auth.GoogleCloudProject != "" && auth.GoogleCloudRegion != "" {
 		return c.resolveVertexAI(auth), nil
 	}
 
-	return nil, fmt.Errorf("claude: no valid auth method found; set ANTHROPIC_API_KEY for direct API access, or provide ADC (gcloud-adc secret, GCP service account, or ~/.config/gcloud/application_default_credentials.json) + GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_REGION for Vertex AI")
+	return nil, fmt.Errorf("claude: no valid auth method found; set ANTHROPIC_API_KEY for direct API access, CLAUDE_CODE_OAUTH_TOKEN for subscription auth (generate via 'claude setup-token'), or provide ADC + GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_REGION for Vertex AI")
 }
 
 func (c *ClaudeCode) resolveVertexAI(auth api.AuthConfig) *api.ResolvedAuth {

--- a/pkg/harness/claude_code_test.go
+++ b/pkg/harness/claude_code_test.go
@@ -414,6 +414,83 @@ func TestClaudeResolveAuth_APIKey(t *testing.T) {
 	}
 }
 
+func TestClaudeResolveAuth_OAuthToken(t *testing.T) {
+	c := &ClaudeCode{}
+	auth := api.AuthConfig{ClaudeOAuthToken: "cco_test-token-123"}
+	result, err := c.ResolveAuth(auth)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Method != "oauth-token" {
+		t.Errorf("Method = %q, want %q", result.Method, "oauth-token")
+	}
+	if result.EnvVars["CLAUDE_CODE_OAUTH_TOKEN"] != "cco_test-token-123" {
+		t.Errorf("CLAUDE_CODE_OAUTH_TOKEN = %q, want %q", result.EnvVars["CLAUDE_CODE_OAUTH_TOKEN"], "cco_test-token-123")
+	}
+	if len(result.Files) != 0 {
+		t.Errorf("expected no files, got %d", len(result.Files))
+	}
+}
+
+func TestClaudeResolveAuth_OAuthToken_Explicit(t *testing.T) {
+	c := &ClaudeCode{}
+	auth := api.AuthConfig{
+		SelectedType:     "oauth-token",
+		ClaudeOAuthToken: "cco_explicit-token",
+	}
+	result, err := c.ResolveAuth(auth)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Method != "oauth-token" {
+		t.Errorf("Method = %q, want %q", result.Method, "oauth-token")
+	}
+}
+
+func TestClaudeResolveAuth_OAuthToken_ExplicitMissing(t *testing.T) {
+	c := &ClaudeCode{}
+	auth := api.AuthConfig{SelectedType: "oauth-token"}
+	_, err := c.ResolveAuth(auth)
+	if err == nil {
+		t.Fatal("expected error for explicit oauth-token with no token")
+	}
+	if !strings.Contains(err.Error(), "CLAUDE_CODE_OAUTH_TOKEN") {
+		t.Errorf("error should mention CLAUDE_CODE_OAUTH_TOKEN: %v", err)
+	}
+}
+
+func TestClaudeResolveAuth_APIKeyWinsOverOAuth(t *testing.T) {
+	c := &ClaudeCode{}
+	auth := api.AuthConfig{
+		AnthropicAPIKey:  "sk-ant-key",
+		ClaudeOAuthToken: "cco_token",
+	}
+	result, err := c.ResolveAuth(auth)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Method != "api-key" {
+		t.Errorf("API key should win over OAuth token; Method = %q, want %q", result.Method, "api-key")
+	}
+}
+
+func TestClaudeResolveAuth_OAuthWinsOverVertex(t *testing.T) {
+	c := &ClaudeCode{}
+	auth := api.AuthConfig{
+		ClaudeOAuthToken:     "cco_token",
+		GoogleAppCredentials: "/path/to/adc.json",
+		GoogleCloudProject:   "my-project",
+		GoogleCloudRegion:    "us-central1",
+	}
+	result, err := c.ResolveAuth(auth)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Method != "oauth-token" {
+		t.Errorf("OAuth token should win over Vertex; Method = %q, want %q", result.Method, "oauth-token")
+	}
+}
+
 func TestClaudeResolveAuth_VertexAI(t *testing.T) {
 	c := &ClaudeCode{}
 	auth := api.AuthConfig{
@@ -494,6 +571,9 @@ func TestClaudeResolveAuth_NoCreds(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "ANTHROPIC_API_KEY") {
 		t.Errorf("error should mention ANTHROPIC_API_KEY: %v", err)
+	}
+	if !strings.Contains(err.Error(), "CLAUDE_CODE_OAUTH_TOKEN") {
+		t.Errorf("error should mention CLAUDE_CODE_OAUTH_TOKEN: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #64

- Add `CLAUDE_CODE_OAUTH_TOKEN` env var support to `GatherAuthWithEnv`
- Add `ClaudeOAuthToken` field to `AuthConfig` and `OAuthToken` capability to `HarnessAuthCapabilities`
- Implement `oauth-token` auth method in Claude harness `ResolveAuth` with auto-detect priority: API key → OAuth token → Vertex AI
- Add `DetectAuthTypeFromEnvVars` support for the new auth type
- Add `RequiredAuthEnvKeys` entry for `oauth-token`
- Include debug logging for the new credential field
- Add comprehensive tests: auto-detect, explicit selection, missing token error, priority ordering (API key > OAuth > Vertex), and updated no-creds error message

## Test plan

- [ ] `make test` passes — all new and existing auth tests green
- [ ] Set `CLAUDE_CODE_OAUTH_TOKEN` and verify agent starts with `oauth-token` method
- [ ] Confirm API key still takes priority when both are set
- [ ] Confirm Vertex AI still works when OAuth token is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)