### PR TITLE
Enable heartbeats for colocated brokers

### DIFF
--- a/pkg/runtimebroker/hub_connection.go
+++ b/pkg/runtimebroker/hub_connection.go
@@ -56,8 +56,7 @@ type HubConnection struct {
 	ControlChannel *ControlChannelClient
 
 	// IsColocated indicates this connection is to a co-located hub running in
-	// the same process. Co-located connections skip HTTP heartbeat because an
-	// internal database heartbeat loop handles status updates directly.
+	// the same process.
 	IsColocated bool
 
 	// TemplatesDir is the local filesystem path to the templates directory
@@ -89,9 +88,7 @@ func (hc *HubConnection) Start(ctx context.Context, server *Server) error {
 	hasValidCredentials := hc.Credentials != nil && hc.Credentials.SecretKey != ""
 
 	// Start heartbeat service if enabled.
-	// Co-located connections skip HTTP heartbeat because an internal
-	// database heartbeat loop handles status updates directly.
-	if server.config.HeartbeatEnabled && !hc.IsColocated && hc.HubClient != nil && hc.BrokerID != "" {
+	if server.config.HeartbeatEnabled && hc.HubClient != nil && hc.BrokerID != "" {
 		if !hasValidCredentials {
 			slog.Warn("Skipping heartbeat for connection: no valid credentials", "name", hc.Name)
 		} else {

--- a/pkg/runtimebroker/hub_connection_test.go
+++ b/pkg/runtimebroker/hub_connection_test.go
@@ -919,9 +919,9 @@ func TestHubConnection_Stop(t *testing.T) {
 // Phase 3: Co-located + Remote Combo Tests
 // ============================================================================
 
-func TestColocated_LocalConnection_SkipsHeartbeat(t *testing.T) {
-	// When a connection is marked as IsColocated, Start() should NOT create
-	// a heartbeat service (the internal DB loop handles it instead).
+func TestColocated_LocalConnection_GetsHeartbeat(t *testing.T) {
+	// Co-located connections still need the broker heartbeat path so the hub
+	// receives lifecycle updates from the embedded runtime broker.
 	creds := makeTestCreds("local", "broker-1", "http://localhost:8080")
 	srv := newTestServerWithInMemoryCreds(creds)
 
@@ -937,7 +937,7 @@ func TestColocated_LocalConnection_SkipsHeartbeat(t *testing.T) {
 		t.Error("expected 'local' connection to be marked as co-located")
 	}
 
-	// Start the connection (heartbeat should be skipped for co-located)
+	// Start the connection and verify the heartbeat service is created.
 	cfg := srv.config
 	cfg.HeartbeatEnabled = true
 	cfg.ControlChannelEnabled = false // disable control channel for this test
@@ -950,8 +950,8 @@ func TestColocated_LocalConnection_SkipsHeartbeat(t *testing.T) {
 		t.Fatalf("Start failed: %v", err)
 	}
 
-	if conn.Heartbeat != nil {
-		t.Error("expected co-located connection to NOT have heartbeat service")
+	if conn.Heartbeat == nil {
+		t.Error("expected co-located connection to have heartbeat service")
 	}
 }
 
@@ -995,8 +995,8 @@ func TestColocated_RemoteConnection_GetsHeartbeat(t *testing.T) {
 }
 
 func TestColocated_ComboMode_HeartbeatPerConnection(t *testing.T) {
-	// In combo mode (co-located local + remote), verify that only the remote
-	// connection gets heartbeat while local is skipped.
+	// In combo mode (co-located local + remote), verify that both connections
+	// get heartbeat services.
 	tmpDir := t.TempDir()
 	credDir := filepath.Join(tmpDir, "hub-credentials")
 	if err := os.MkdirAll(credDir, 0700); err != nil {
@@ -1054,7 +1054,7 @@ func TestColocated_ComboMode_HeartbeatPerConnection(t *testing.T) {
 	}
 	srv.hubMu.RUnlock()
 
-	// Verify: local has no heartbeat, remote does
+	// Verify: both local and remote connections have heartbeat services.
 	srv.hubMu.RLock()
 	localConn := srv.hubConnections["local"]
 	remoteConn := srv.hubConnections["hub-prod"]
@@ -1068,8 +1068,8 @@ func TestColocated_ComboMode_HeartbeatPerConnection(t *testing.T) {
 		t.Error("expected 'local' to be co-located")
 	}
 
-	if localConn.Heartbeat != nil {
-		t.Error("expected co-located 'local' connection to NOT have heartbeat")
+	if localConn.Heartbeat == nil {
+		t.Error("expected co-located 'local' connection to have heartbeat")
 	}
 
 	if remoteConn.IsColocated {


### PR DESCRIPTION
## Summary
- start the broker heartbeat service for colocated hub connections
- keep combo-mode broker status propagation using the same path as remote brokers
- update colocated heartbeat expectations in runtimebroker tests

## Testing
- go test ./pkg/runtimebroker -run 'TestColocated_(LocalConnection_GetsHeartbeat|RemoteConnection_GetsHeartbeat|ComboMode_HeartbeatPerConnection)$'
- make build

## Context
This is intentionally narrow. The change only fixes lifecycle status propagation for colocated hub+broker mode; it does not alter control-channel behavior or broader broker auth flow.