### PR TITLE
Reconcile terminal Kubernetes agent state

### DIFF
--- a/pkg/agent/list.go
+++ b/pkg/agent/list.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,7 +106,12 @@ func (m *AgentManager) List(ctx context.Context, filter map[string]string) ([]ap
 			if terminalPhase != "" {
 				agents[i].Phase = terminalPhase
 				agents[i].Activity = ""
-				_ = persistAgentInfoState(agentInfoJSON, terminalPhase, "")
+				// Terminal pod phases mean the harness should already be exiting,
+				// so this is a best-effort convergence write rather than a
+				// continuously contended state update.
+				if err := persistAgentInfoState(agentInfoJSON, terminalPhase, ""); err != nil {
+					slog.Debug("failed to persist terminal agent state", "path", agentInfoJSON, "err", err)
+				}
 			}
 
 			// Use agent-info.json mtime as LastSeen for local agents
@@ -275,6 +281,10 @@ func persistAgentInfoState(path, phase, activity string) error {
 	if err != nil {
 		return err
 	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
 
 	var info api.AgentInfo
 	if err := json.Unmarshal(data, &info); err != nil {
@@ -292,5 +302,10 @@ func persistAgentInfoState(path, phase, activity string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, updated, 0644)
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, updated, fi.Mode()); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }

--- a/pkg/agent/list.go
+++ b/pkg/agent/list.go
@@ -25,7 +25,10 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	scionruntime "github.com/GoogleCloudPlatform/scion/pkg/runtime"
 )
+
+const legacyFailedContainerStatusPrefix = "failed"
 
 func (m *AgentManager) List(ctx context.Context, filter map[string]string) ([]api.AgentInfo, error) {
 	agents, err := m.Runtime.List(ctx, filter)
@@ -257,11 +260,11 @@ func terminalRuntimePhase(agent api.AgentInfo) string {
 		state.PhaseStarting, state.PhaseRunning, state.PhaseStopping:
 		return ""
 	}
-	if agent.Phase != "ended" {
+	if agent.Phase != scionruntime.LegacyAgentPhaseEnded {
 		return ""
 	}
 	containerStatus := strings.ToLower(agent.ContainerStatus)
-	if strings.Contains(containerStatus, "failed") {
+	if strings.Contains(containerStatus, legacyFailedContainerStatusPrefix) {
 		return string(state.PhaseError)
 	}
 	return string(state.PhaseStopped)

--- a/pkg/agent/list.go
+++ b/pkg/agent/list.go
@@ -73,13 +73,16 @@ func (m *AgentManager) List(ctx context.Context, filter map[string]string) ([]ap
 			scionJSON := filepath.Join(agentDir, "scion-agent.json")
 			agentHome := config.GetAgentHomePath(agents[i].GrovePath, agents[i].Name)
 			agentInfoJSON := filepath.Join(agentHome, "agent-info.json")
+			terminalPhase := terminalRuntimePhase(agents[i])
 
 			// Try agent-info.json first for latest status from container
 			if data, err := os.ReadFile(agentInfoJSON); err == nil {
 				var info api.AgentInfo
 				if err := json.Unmarshal(data, &info); err == nil {
-					agents[i].Phase = info.Phase
-					agents[i].Activity = info.Activity
+					if terminalPhase == "" {
+						agents[i].Phase = info.Phase
+						agents[i].Activity = info.Activity
+					}
 					if agents[i].Runtime == "" {
 						agents[i].Runtime = info.Runtime
 					}
@@ -94,6 +97,12 @@ func (m *AgentManager) List(ctx context.Context, filter map[string]string) ([]ap
 						agents[i].Detail = info.Detail
 					}
 				}
+			}
+
+			if terminalPhase != "" {
+				agents[i].Phase = terminalPhase
+				agents[i].Activity = ""
+				_ = persistAgentInfoState(agentInfoJSON, terminalPhase, "")
 			}
 
 			// Use agent-info.json mtime as LastSeen for local agents
@@ -238,4 +247,47 @@ func (m *AgentManager) List(ctx context.Context, filter map[string]string) ([]ap
 	}
 
 	return agents, nil
+}
+
+func terminalRuntimePhase(agent api.AgentInfo) string {
+	switch state.Phase(agent.Phase) {
+	case state.PhaseStopped, state.PhaseError:
+		return agent.Phase
+	case state.PhaseCreated, state.PhaseProvisioning, state.PhaseCloning,
+		state.PhaseStarting, state.PhaseRunning, state.PhaseStopping:
+		return ""
+	}
+	if agent.Phase != "ended" {
+		return ""
+	}
+	containerStatus := strings.ToLower(agent.ContainerStatus)
+	if strings.Contains(containerStatus, "failed") {
+		return string(state.PhaseError)
+	}
+	return string(state.PhaseStopped)
+}
+
+func persistAgentInfoState(path, phase, activity string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var info api.AgentInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return err
+	}
+
+	if info.Phase == phase && info.Activity == activity {
+		return nil
+	}
+
+	info.Phase = phase
+	info.Activity = activity
+
+	updated, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, updated, 0644)
 }

--- a/pkg/agent/list_test.go
+++ b/pkg/agent/list_test.go
@@ -391,3 +391,103 @@ func TestListReconcilesPhaseWithContainerStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestListPreservesRuntimeTerminalStateForKubernetes(t *testing.T) {
+	tests := []struct {
+		name            string
+		runtimePhase    string
+		containerStatus string
+		wantPhase       string
+	}{
+		{
+			name:            "legacy ended maps completed pod to stopped",
+			runtimePhase:    "ended",
+			containerStatus: "Succeeded (Completed)",
+			wantPhase:       string(state.PhaseStopped),
+		},
+		{
+			name:            "legacy ended maps failed pod to error",
+			runtimePhase:    "ended",
+			containerStatus: "Failed (Error)",
+			wantPhase:       string(state.PhaseError),
+		},
+		{
+			name:            "structured stopped phase wins over stale info",
+			runtimePhase:    string(state.PhaseStopped),
+			containerStatus: "Succeeded (Completed)",
+			wantPhase:       string(state.PhaseStopped),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			grovePath := filepath.Join(tmpDir, ".scion")
+			agentName := "k8s-agent"
+			agentHome := filepath.Join(grovePath, "agents", agentName, "home")
+			if err := os.MkdirAll(agentHome, 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			info := api.AgentInfo{
+				Name:     agentName,
+				Phase:    string(state.PhaseRunning),
+				Activity: string(state.ActivityThinking),
+				Runtime:  "kubernetes",
+			}
+			infoData, _ := json.MarshalIndent(info, "", "  ")
+			infoPath := filepath.Join(agentHome, "agent-info.json")
+			if err := os.WriteFile(infoPath, infoData, 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(grovePath, "agents", agentName, "scion-agent.json"), []byte("{}"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			mock := &runtime.MockRuntime{
+				ListFunc: func(_ context.Context, _ map[string]string) ([]api.AgentInfo, error) {
+					return []api.AgentInfo{
+						{
+							Name:            agentName,
+							GrovePath:       grovePath,
+							Runtime:         "kubernetes",
+							Phase:           tc.runtimePhase,
+							ContainerStatus: tc.containerStatus,
+						},
+					}, nil
+				},
+			}
+
+			mgr := NewManager(mock)
+			agents, err := mgr.List(context.Background(), nil)
+			if err != nil {
+				t.Fatalf("List() error: %v", err)
+			}
+
+			if len(agents) != 1 {
+				t.Fatalf("expected 1 agent, got %d", len(agents))
+			}
+			if agents[0].Phase != tc.wantPhase {
+				t.Errorf("Phase = %q, want %q", agents[0].Phase, tc.wantPhase)
+			}
+			if agents[0].Activity != "" {
+				t.Errorf("Activity = %q, want empty", agents[0].Activity)
+			}
+
+			updatedData, err := os.ReadFile(infoPath)
+			if err != nil {
+				t.Fatalf("failed to read updated agent-info.json: %v", err)
+			}
+			var updated api.AgentInfo
+			if err := json.Unmarshal(updatedData, &updated); err != nil {
+				t.Fatalf("failed to decode updated agent-info.json: %v", err)
+			}
+			if updated.Phase != tc.wantPhase {
+				t.Errorf("persisted Phase = %q, want %q", updated.Phase, tc.wantPhase)
+			}
+			if updated.Activity != "" {
+				t.Errorf("persisted Activity = %q, want empty", updated.Activity)
+			}
+		})
+	}
+}

--- a/pkg/agent/list_test.go
+++ b/pkg/agent/list_test.go
@@ -491,3 +491,51 @@ func TestListPreservesRuntimeTerminalStateForKubernetes(t *testing.T) {
 		})
 	}
 }
+
+func TestPersistAgentInfoState_AtomicallyRewritesAndPreservesMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	infoPath := filepath.Join(tmpDir, "agent-info.json")
+
+	info := api.AgentInfo{
+		Name:     "agent",
+		Phase:    string(state.PhaseRunning),
+		Activity: string(state.ActivityThinking),
+	}
+	data, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(infoPath, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := persistAgentInfoState(infoPath, string(state.PhaseStopped), ""); err != nil {
+		t.Fatalf("persistAgentInfoState() error = %v", err)
+	}
+
+	updatedData, err := os.ReadFile(infoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var updated api.AgentInfo
+	if err := json.Unmarshal(updatedData, &updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Phase != string(state.PhaseStopped) {
+		t.Fatalf("Phase = %q, want %q", updated.Phase, state.PhaseStopped)
+	}
+	if updated.Activity != "" {
+		t.Fatalf("Activity = %q, want empty", updated.Activity)
+	}
+
+	fi, err := os.Stat(infoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode().Perm() != 0600 {
+		t.Fatalf("mode = %o, want %o", fi.Mode().Perm(), os.FileMode(0600))
+	}
+	if _, err := os.Stat(infoPath + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("temp file should not remain, stat err = %v", err)
+	}
+}

--- a/pkg/agent/list_test.go
+++ b/pkg/agent/list_test.go
@@ -401,13 +401,13 @@ func TestListPreservesRuntimeTerminalStateForKubernetes(t *testing.T) {
 	}{
 		{
 			name:            "legacy ended maps completed pod to stopped",
-			runtimePhase:    "ended",
+			runtimePhase:    runtime.LegacyAgentPhaseEnded,
 			containerStatus: "Succeeded (Completed)",
 			wantPhase:       string(state.PhaseStopped),
 		},
 		{
 			name:            "legacy ended maps failed pod to error",
-			runtimePhase:    "ended",
+			runtimePhase:    runtime.LegacyAgentPhaseEnded,
 			containerStatus: "Failed (Error)",
 			wantPhase:       string(state.PhaseError),
 		},

--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -78,4 +78,8 @@ const (
 	SyncTo          SyncDirection = "to"
 	SyncFrom        SyncDirection = "from"
 	SyncUnspecified SyncDirection = ""
+
+	// LegacyAgentPhaseEnded is the historical terminal phase returned by some
+	// runtime list implementations before Scion standardized on stopped/error.
+	LegacyAgentPhaseEnded = "ended"
 )

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -30,6 +30,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/gcp"
 	"github.com/GoogleCloudPlatform/scion/pkg/k8s"
@@ -1569,8 +1570,14 @@ func (r *KubernetesRuntime) List(ctx context.Context, labelFilter map[string]str
 
 		status := string(p.Status.Phase)
 		agentStatus := ""
-		if p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
-			agentStatus = "ended"
+		switch p.Status.Phase {
+		case corev1.PodSucceeded:
+			agentStatus = string(state.PhaseStopped)
+		case corev1.PodFailed:
+			agentStatus = string(state.PhaseError)
+		case corev1.PodPending, corev1.PodRunning, corev1.PodUnknown:
+			// Non-terminal pod phases are represented via ContainerStatus and
+			// local agent-info state until the agent exits.
 		}
 
 		// Try to get more detail from container status
@@ -1581,7 +1588,11 @@ func (r *KubernetesRuntime) List(ctx context.Context, labelFilter map[string]str
 				} else if cs.State.Terminated != nil {
 					status = fmt.Sprintf("%s (%s)", p.Status.Phase, cs.State.Terminated.Reason)
 					if agentStatus == "" {
-						agentStatus = "ended"
+						if cs.State.Terminated.ExitCode == 0 {
+							agentStatus = string(state.PhaseStopped)
+						} else {
+							agentStatus = string(state.PhaseError)
+						}
 					}
 				}
 				break

--- a/pkg/runtime/k8s_runtime_test.go
+++ b/pkg/runtime/k8s_runtime_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +29,7 @@ import (
 
 func TestKubernetesRuntime_List(t *testing.T) {
 	// Create a fake clientset
-	clientset := k8sfake.NewSimpleClientset()
+	clientset := k8sfake.NewClientset()
 
 	// Create a pod that mimics what we expect
 	pod := &corev1.Pod{
@@ -88,8 +89,100 @@ func TestKubernetesRuntime_List(t *testing.T) {
 	}
 }
 
+func TestKubernetesRuntime_List_TerminalPhases(t *testing.T) {
+	clientset := k8sfake.NewClientset()
+	scheme := k8sruntime.NewScheme()
+	fc := fake.NewSimpleDynamicClient(scheme)
+	client := k8s.NewTestClient(fc, clientset)
+	r := NewKubernetesRuntime(client)
+
+	pods := []*corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "completed-agent",
+				Namespace: "default",
+				Labels: map[string]string{
+					"scion.name": "completed-agent",
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodSucceeded,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "agent",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								Reason:   "Completed",
+								ExitCode: 0,
+							},
+						},
+					},
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Image: "test-image"}},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "failed-agent",
+				Namespace: "default",
+				Labels: map[string]string{
+					"scion.name": "failed-agent",
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodFailed,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "agent",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								Reason:   "Error",
+								ExitCode: 1,
+							},
+						},
+					},
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Image: "test-image"}},
+			},
+		},
+	}
+
+	for _, pod := range pods {
+		if _, err := clientset.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("failed to create pod %q: %v", pod.Name, err)
+		}
+	}
+
+	agents, err := r.List(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+
+	got := map[string]api.AgentInfo{}
+	for _, agent := range agents {
+		got[agent.Name] = agent
+	}
+
+	if got["completed-agent"].Phase != "stopped" {
+		t.Errorf("completed-agent phase = %q, want %q", got["completed-agent"].Phase, "stopped")
+	}
+	if got["completed-agent"].ContainerStatus != "Succeeded (Completed)" {
+		t.Errorf("completed-agent container status = %q, want %q", got["completed-agent"].ContainerStatus, "Succeeded (Completed)")
+	}
+	if got["failed-agent"].Phase != "error" {
+		t.Errorf("failed-agent phase = %q, want %q", got["failed-agent"].Phase, "error")
+	}
+	if got["failed-agent"].ContainerStatus != "Failed (Error)" {
+		t.Errorf("failed-agent container status = %q, want %q", got["failed-agent"].ContainerStatus, "Failed (Error)")
+	}
+}
+
 func TestKubernetesRuntime_BuildPod_Env(t *testing.T) {
-	clientset := k8sfake.NewSimpleClientset()
+	clientset := k8sfake.NewClientset()
 	scheme := k8sruntime.NewScheme()
 	fc := fake.NewSimpleDynamicClient(scheme)
 	client := k8s.NewTestClient(fc, clientset)


### PR DESCRIPTION
## Summary
- map terminal Kubernetes pod states to structured Scion phases
- prevent stale agent-info state from overriding completed Kubernetes runtime state
- persist the reconciled terminal phase back into agent-info.json so broker and hub views converge

## Testing
- go test ./pkg/agent -run 'TestList(ReconcilesPhaseWithContainerStatus|PreservesRuntimeTerminalStateForKubernetes|EnrichesTemplateAndHarnessFromAgentInfo|DoesNotOverrideRuntimeTemplate|SetsLastSeenFromAgentInfoMtime|NonRunningAgentIncludesHarnessConfig)$'
- go test ./pkg/runtime -run 'TestKubernetesRuntime_(List|List_TerminalPhases)$'
- make build
 
## Context
- This is intentionally limited to terminal-state reconciliation. It does not attempt to solve durable workspace sync-back for completed Kubernetes pods.