### PR TITLE
Allow broker to start without HMAC keys for registration bootstrap

### DIFF
--- a/pkg/runtimebroker/hub_connection_test.go
+++ b/pkg/runtimebroker/hub_connection_test.go
@@ -862,7 +862,7 @@ func TestRuntimeBroker_DefaultAuth_DeniesUnauthenticatedRequests(t *testing.T) {
 	}
 }
 
-func TestValidateBrokerAuthStartup_HubModeWithoutKeysFails(t *testing.T) {
+func TestValidateBrokerAuthStartup_HubModeWithoutKeysAllowsBootstrap(t *testing.T) {
 	cfg := DefaultServerConfig()
 	cfg.Host = "127.0.0.1"
 	cfg.HubEnabled = true
@@ -870,8 +870,8 @@ func TestValidateBrokerAuthStartup_HubModeWithoutKeysFails(t *testing.T) {
 	cfg.InMemoryCredentials = nil
 
 	srv := New(cfg, &mockManager{}, &runtime.MockRuntime{})
-	if err := srv.validateBrokerAuthStartup(); err == nil {
-		t.Fatal("expected startup validation to fail when hub mode has no HMAC keys")
+	if err := srv.validateBrokerAuthStartup(); err != nil {
+		t.Fatalf("expected startup validation to succeed for registration bootstrap, got: %v", err)
 	}
 }
 

--- a/pkg/runtimebroker/server.go
+++ b/pkg/runtimebroker/server.go
@@ -629,9 +629,16 @@ func (s *Server) validateBrokerAuthStartup() error {
 	hasKeys := s.authKeyCount() > 0
 	loopbackOnly := isLoopbackHost(s.config.Host)
 
-	// Hub-connected brokers must have usable HMAC keys for inbound request auth.
+	// Hub-connected brokers without HMAC keys are allowed to start in a
+	// degraded state so that 'scion broker register' can complete the
+	// bootstrap. Without this, the broker cannot start (needs keys) and
+	// cannot register (needs running broker).
 	if s.config.HubEnabled && !hasKeys {
-		return fmt.Errorf("runtime broker hub mode requires HMAC auth keys, but none are available")
+		slog.Warn("Runtime Broker starting without HMAC auth keys — run 'scion broker register' then restart",
+			"host", s.config.Host,
+			"hubEnabled", s.config.HubEnabled,
+		)
+		return nil
 	}
 
 	// Non-loopback listeners must not run without strict broker auth and keys.


### PR DESCRIPTION
## Summary
- Allow hub-connected brokers to start without HMAC auth keys, logging a warning instead of failing
- After `scion broker register` obtains the keys, a restart brings the broker to full auth
- This breaks the circular dependency where `broker start` needs keys and `broker register` needs a running broker

Fixes #70