### PR TITLE
Harden Kubernetes agent pod security

### DIFF
--- a/pkg/runtime/k8s_hardening_test.go
+++ b/pkg/runtime/k8s_hardening_test.go
@@ -154,6 +154,47 @@ func TestBuildPod_SecurityContext_FSGroup(t *testing.T) {
 	if pod.Spec.SecurityContext.FSGroup == nil {
 		t.Fatal("expected FSGroup to be set")
 	}
+	if pod.Spec.SecurityContext.RunAsNonRoot == nil || !*pod.Spec.SecurityContext.RunAsNonRoot {
+		t.Fatal("expected RunAsNonRoot=true to be set")
+	}
+	if pod.Spec.SecurityContext.SeccompProfile == nil {
+		t.Fatal("expected SeccompProfile to be set")
+	}
+	if pod.Spec.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Fatalf("expected SeccompProfile RuntimeDefault, got %q", pod.Spec.SecurityContext.SeccompProfile.Type)
+	}
+}
+
+func TestBuildPod_ContainerSecurityContextRestrictedDefaults(t *testing.T) {
+	rt, _, _ := newTestK8sRuntime()
+
+	config := RunConfig{
+		Name:         "test-agent",
+		Image:        "test:latest",
+		UnixUsername: "scion",
+	}
+
+	pod, err := rt.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	if len(pod.Spec.Containers) != 1 {
+		t.Fatalf("expected exactly one container, got %d", len(pod.Spec.Containers))
+	}
+	securityContext := pod.Spec.Containers[0].SecurityContext
+	if securityContext == nil {
+		t.Fatal("expected container SecurityContext to be set")
+	}
+	if securityContext.AllowPrivilegeEscalation == nil || *securityContext.AllowPrivilegeEscalation {
+		t.Fatal("expected AllowPrivilegeEscalation=false to be set")
+	}
+	if securityContext.Capabilities == nil {
+		t.Fatal("expected container capabilities to be set")
+	}
+	if len(securityContext.Capabilities.Drop) != 1 || securityContext.Capabilities.Drop[0] != corev1.Capability("ALL") {
+		t.Fatalf("expected capabilities.drop=[ALL], got %v", securityContext.Capabilities.Drop)
+	}
 }
 
 func TestBuildPod_NodeSelector(t *testing.T) {
@@ -654,6 +695,12 @@ func TestBuildPod_FullConfig_Stage2(t *testing.T) {
 	if pod.Spec.SecurityContext == nil || pod.Spec.SecurityContext.FSGroup == nil {
 		t.Error("expected FSGroup security context")
 	}
+	if pod.Spec.SecurityContext.RunAsNonRoot == nil || !*pod.Spec.SecurityContext.RunAsNonRoot {
+		t.Error("expected RunAsNonRoot=true")
+	}
+	if pod.Spec.SecurityContext.SeccompProfile == nil || pod.Spec.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Error("expected SeccompProfile RuntimeDefault")
+	}
 	if pod.Spec.RuntimeClassName == nil || *pod.Spec.RuntimeClassName != "gvisor" {
 		t.Error("expected RuntimeClassName gvisor")
 	}
@@ -668,6 +715,16 @@ func TestBuildPod_FullConfig_Stage2(t *testing.T) {
 	}
 	if len(pod.Spec.Tolerations) != 1 {
 		t.Errorf("expected 1 toleration, got %d", len(pod.Spec.Tolerations))
+	}
+	containerSecurityContext := pod.Spec.Containers[0].SecurityContext
+	if containerSecurityContext == nil {
+		t.Fatal("expected container security context")
+	}
+	if containerSecurityContext.AllowPrivilegeEscalation == nil || *containerSecurityContext.AllowPrivilegeEscalation {
+		t.Error("expected AllowPrivilegeEscalation=false")
+	}
+	if containerSecurityContext.Capabilities == nil || len(containerSecurityContext.Capabilities.Drop) != 1 || containerSecurityContext.Capabilities.Drop[0] != corev1.Capability("ALL") {
+		t.Errorf("expected capabilities.drop=[ALL], got %v", containerSecurityContext.Capabilities)
 	}
 
 	// Check resource values

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -169,6 +169,13 @@ func isSyncTransientError(err error) bool {
 	return false
 }
 
+func ensureAnnotations(annotations map[string]string) map[string]string {
+	if annotations != nil {
+		return annotations
+	}
+	return make(map[string]string)
+}
+
 func (r *KubernetesRuntime) Run(ctx context.Context, config RunConfig) (string, error) {
 	fmt.Printf("Starting agent '%s' on Kubernetes...\n", config.Name)
 	namespace := r.DefaultNamespace
@@ -194,32 +201,24 @@ func (r *KubernetesRuntime) Run(ctx context.Context, config RunConfig) (string, 
 
 	// Persist workspace path in annotations for later sync
 	if config.Workspace != "" {
-		if config.Annotations == nil {
-			config.Annotations = make(map[string]string)
-		}
+		config.Annotations = ensureAnnotations(config.Annotations)
 		config.Annotations["scion.workspace"] = config.Workspace
 	}
 
 	if config.GitClone != nil {
-		if config.Annotations == nil {
-			config.Annotations = make(map[string]string)
-		}
+		config.Annotations = ensureAnnotations(config.Annotations)
 		config.Annotations["scion.git_clone"] = "true"
 		config.Annotations["scion.git_clone_url"] = config.GitClone.URL
 	}
 
 	if config.HomeDir != "" {
-		if config.Annotations == nil {
-			config.Annotations = make(map[string]string)
-		}
+		config.Annotations = ensureAnnotations(config.Annotations)
 		config.Annotations["scion.homedir"] = config.HomeDir
 		config.Annotations["scion.username"] = config.UnixUsername
 	}
 
 	// Persist the resolved namespace as an annotation for lifecycle operations
-	if config.Annotations == nil {
-		config.Annotations = make(map[string]string)
-	}
+	config.Annotations = ensureAnnotations(config.Annotations)
 	config.Annotations["scion.namespace"] = namespace
 
 	// Pre-clean stale resources from a previous agent with the same name.
@@ -1198,9 +1197,7 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 				ReadOnly:  v.ReadOnly,
 			})
 
-			if pod.Annotations == nil {
-				pod.Annotations = make(map[string]string)
-			}
+			pod.Annotations = ensureAnnotations(pod.Annotations)
 			pod.Annotations["gke-gcsfuse/volumes"] = "true"
 
 			gcsVolumes = append(gcsVolumes, gcsVolInfo{
@@ -1228,9 +1225,7 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 	if len(gcsVolumes) > 0 {
 		if data, err := json.Marshal(gcsVolumes); err == nil {
 			encoded := base64.StdEncoding.EncodeToString(data)
-			if pod.Annotations == nil {
-				pod.Annotations = make(map[string]string)
-			}
+			pod.Annotations = ensureAnnotations(pod.Annotations)
 			pod.Annotations["scion.gcs_volumes"] = encoded
 		}
 	}

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -970,8 +970,14 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 
 	// Security context: set FSGroup from host GID for volume permission alignment.
 	hostGID := int64(os.Getgid())
+	runAsNonRoot := true
+	allowPrivilegeEscalation := false
 	podSecurityContext := &corev1.PodSecurityContext{
-		FSGroup: &hostGID,
+		FSGroup:      &hostGID,
+		RunAsNonRoot: &runAsNonRoot,
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
 	}
 
 	// Determine image pull policy
@@ -1008,6 +1014,12 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 					WorkingDir:      "/workspace",
 					Stdin:           true,
 					TTY:             true,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{Name: "workspace", MountPath: "/workspace"},
 					},


### PR DESCRIPTION
## Summary
- make Kubernetes agent pods conform to restricted pod security defaults
- drop privilege escalation and capabilities, and set the expected pod security fields
- keep the change focused on generated pod specs rather than deployment-specific policy

## Validation
- go test ./pkg/runtime
- golangci-lint run --config /Users/mfreeman/src/scion/.golangci.yml --new-from-rev=main ./pkg/runtime