### PR TITLE
Prepare agent home for non-root harness startup

### DIFF
--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -1002,10 +1002,10 @@ func gitCloneWorkspace(uid, gid int, agentHome string) error {
 		}
 	}
 
-	// Ensure the workspace directory is owned by the target user. The
-	// directory may have been created on the host by a root broker process
-	// and bind-mounted into the container as root-owned.
-	if uid > 0 {
+	// Ensure the workspace directory is owned by the target user when running
+	// as root. Non-root containers cannot chown, and Kubernetes pods may
+	// already be running as the correct user/group via securityContext.
+	if uid > 0 && os.Getuid() == 0 {
 		if err := os.Chown(workspacePath, uid, gid); err != nil {
 			log.Error("Failed to chown workspace to UID=%d GID=%d: %v", uid, gid, err)
 		}
@@ -1026,15 +1026,7 @@ func gitCloneWorkspace(uid, gid int, agentHome string) error {
 	// interactive credential prompts so git fails immediately instead of
 	// hanging when authentication is required but no token is available.
 	setupGitCmd := func(cmd *exec.Cmd) {
-		cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
-		if uid > 0 {
-			cmd.SysProcAttr = &syscall.SysProcAttr{
-				Credential: &syscall.Credential{
-					Uid: uint32(uid),
-					Gid: uint32(gid),
-				},
-			}
-		}
+		configureGitCommand(cmd, uid, gid)
 	}
 
 	// Report cloning status to Hub
@@ -1273,6 +1265,29 @@ func configureSharedWorkspaceGit(agentHome string) {
 		if out, err := cmd.CombinedOutput(); err != nil {
 			log.Error("Failed to set git config %s: %s %v", cfg.key, string(out), err)
 		}
+	}
+}
+
+func configureGitCommand(cmd *exec.Cmd, uid, gid int) {
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if uid <= 0 {
+		return
+	}
+
+	currentUID := os.Getuid()
+	currentGID := os.Getgid()
+	if currentUID == uid && currentGID == gid {
+		return
+	}
+	if currentUID != 0 {
+		return
+	}
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Credential: &syscall.Credential{
+			Uid: uint32(uid),
+			Gid: uint32(gid),
+		},
 	}
 }
 

--- a/cmd/sciontool/commands/init_test.go
+++ b/cmd/sciontool/commands/init_test.go
@@ -6,9 +6,11 @@ package commands
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -741,5 +743,34 @@ func TestGitCloneWorkspace_NonZeroUIDChownsWorkspace(t *testing.T) {
 	errMsg := err.Error()
 	if !strings.Contains(errMsg, "git clone failed") && !strings.Contains(errMsg, "git init failed") && !strings.Contains(errMsg, "git remote add failed") && !strings.Contains(errMsg, "failed") {
 		t.Errorf("expected a git failure error, got: %v", err)
+	}
+}
+
+func TestConfigureGitCommand_SkipsCredentialOverrideWhenAlreadyRunningAsTargetUser(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "git", "status")
+
+	configureGitCommand(cmd, os.Getuid(), os.Getgid())
+
+	if !slices.Contains(cmd.Env, "GIT_TERMINAL_PROMPT=0") {
+		t.Fatal("expected GIT_TERMINAL_PROMPT=0 to be set")
+	}
+	if cmd.SysProcAttr != nil {
+		t.Fatalf("expected no credential override when already running as target user, got %#v", cmd.SysProcAttr)
+	}
+}
+
+func TestConfigureGitCommand_SkipsCredentialOverrideForNonRootDifferentTarget(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("test only covers non-root behavior")
+	}
+
+	cmd := exec.CommandContext(context.Background(), "git", "status")
+	configureGitCommand(cmd, os.Getuid()+1, os.Getgid())
+
+	if !slices.Contains(cmd.Env, "GIT_TERMINAL_PROMPT=0") {
+		t.Fatal("expected GIT_TERMINAL_PROMPT=0 to be set")
+	}
+	if cmd.SysProcAttr != nil {
+		t.Fatalf("expected no credential override for non-root process, got %#v", cmd.SysProcAttr)
 	}
 }

--- a/image-build/codex/Dockerfile
+++ b/image-build/codex/Dockerfile
@@ -21,8 +21,9 @@ ARG CODEX_CLI_VERSION=latest
 RUN mkdir -p /home/scion/.codex /home/scion/.codex/skills && \
   chown -R scion:scion /home/scion/.codex
 
-# install codex and clean up
+# install codex, expose it on standard shell PATH, and clean up
 RUN npm install -g @openai/codex@${CODEX_CLI_VERSION} \
+  && ln -sf /usr/local/share/npm-global/bin/codex /usr/local/bin/codex \
   && npm cache clean --force
 
 # default entrypoint when none specified

--- a/image-build/codex/Dockerfile
+++ b/image-build/codex/Dockerfile
@@ -18,6 +18,9 @@ FROM ${BASE_IMAGE}
 
 ARG CODEX_CLI_VERSION=latest
 
+RUN mkdir -p /home/scion/.codex /home/scion/.codex/skills && \
+  chown -R scion:scion /home/scion/.codex
+
 # install codex and clean up
 RUN npm install -g @openai/codex@${CODEX_CLI_VERSION} \
   && npm cache clean --force

--- a/image-build/gemini/Dockerfile
+++ b/image-build/gemini/Dockerfile
@@ -18,6 +18,9 @@ FROM ${BASE_IMAGE}
 
 ARG GEMINI_CLI_VERSION=latest
 
+RUN mkdir -p /home/scion/.gemini /home/scion/.gemini/skills && \
+  chown -R scion:scion /home/scion/.gemini
+
 # install gemini-cli and clean up
 RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION} \
   && npm cache clean --force

--- a/image-build/opencode/Dockerfile
+++ b/image-build/opencode/Dockerfile
@@ -16,6 +16,9 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+RUN mkdir -p /home/scion/.local/share/opencode && \
+  chown -R scion:scion /home/scion/.local
+
 # Install OpenCode
 # RUN curl -fsSL https://opencode.ai/install | bash
 RUN npm install -g opencode-ai \

--- a/image-build/scion-base/Dockerfile
+++ b/image-build/scion-base/Dockerfile
@@ -71,6 +71,11 @@ RUN useradd -m -s /bin/zsh -u 1000 scion && \
     echo "scion ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/scion && \
     chmod 0440 /etc/sudoers.d/scion
 
+# Precreate shared Scion home state so mounted file secrets and runtime
+# config writes do not force root-owned parent directories at startup.
+RUN mkdir -p /home/scion/.scion && \
+    chown -R scion:scion /home/scion
+
 # Set ownership for npm global directory
 # TODO: Consider making npm-global world read-write (chmod) instead of chown
 # to scion. This would decouple it from the scion UID and avoid any ownership


### PR DESCRIPTION
## Summary
- precreate harness-specific home directories and the shared `~/.scion` directory in the runtime images
- skip root-only init/git setup when agents already run as a non-root user and expose Codex on the standard shell `PATH`
- avoid hosted permission failures during non-root harness bootstrap, especially around `scion-env` and synchronized home state

## Problem
Hosted non-root agents can fail during startup because the synchronized home layout assumes a few writable directories and init-time behaviors that only work cleanly as root. In practice this showed up as permission failures writing shared Scion state and initializing harness-specific home content.

## Validation
- `go test ./cmd/sciontool/commands`
- hosted Kubernetes proof using `registry.carverauto.dev/scion/scion-codex:home-dirs-a20a5f7b`
  - `Failed to write scion-env file` absent
  - `Error loading configuration: Permission denied` absent
