### PR TITLE
Run Kubernetes agent pods as non-root

### DIFF
--- a/pkg/runtime/k8s_hardening_test.go
+++ b/pkg/runtime/k8s_hardening_test.go
@@ -154,6 +154,12 @@ func TestBuildPod_SecurityContext_FSGroup(t *testing.T) {
 	if pod.Spec.SecurityContext.FSGroup == nil {
 		t.Fatal("expected FSGroup to be set")
 	}
+	if pod.Spec.SecurityContext.RunAsUser == nil || *pod.Spec.SecurityContext.RunAsUser != 1000 {
+		t.Fatalf("expected RunAsUser=1000, got %v", pod.Spec.SecurityContext.RunAsUser)
+	}
+	if pod.Spec.SecurityContext.RunAsGroup == nil || *pod.Spec.SecurityContext.RunAsGroup != 1000 {
+		t.Fatalf("expected RunAsGroup=1000, got %v", pod.Spec.SecurityContext.RunAsGroup)
+	}
 	if pod.Spec.SecurityContext.RunAsNonRoot == nil || !*pod.Spec.SecurityContext.RunAsNonRoot {
 		t.Fatal("expected RunAsNonRoot=true to be set")
 	}
@@ -694,6 +700,12 @@ func TestBuildPod_FullConfig_Stage2(t *testing.T) {
 	// Verify all Stage 2 features are applied
 	if pod.Spec.SecurityContext == nil || pod.Spec.SecurityContext.FSGroup == nil {
 		t.Error("expected FSGroup security context")
+	}
+	if pod.Spec.SecurityContext.RunAsUser == nil || *pod.Spec.SecurityContext.RunAsUser != 1000 {
+		t.Errorf("expected RunAsUser=1000, got %v", pod.Spec.SecurityContext.RunAsUser)
+	}
+	if pod.Spec.SecurityContext.RunAsGroup == nil || *pod.Spec.SecurityContext.RunAsGroup != 1000 {
+		t.Errorf("expected RunAsGroup=1000, got %v", pod.Spec.SecurityContext.RunAsGroup)
 	}
 	if pod.Spec.SecurityContext.RunAsNonRoot == nil || !*pod.Spec.SecurityContext.RunAsNonRoot {
 		t.Error("expected RunAsNonRoot=true")

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -541,7 +541,8 @@ func (r *KubernetesRuntime) createSecretProviderClass(ctx context.Context, names
 	return spcName, nil
 }
 
-func boolPtr(b bool) *bool { return &b }
+func boolPtr(b bool) *bool    { return &b }
+func int64Ptr(v int64) *int64 { return &v }
 
 // toStringInterfaceMap converts map[string]string to map[string]interface{} for unstructured objects.
 func toStringInterfaceMap(m map[string]string) map[string]interface{} {
@@ -964,16 +965,27 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 		envVars = append(envVars, corev1.EnvVar{Name: telemetryGCPCredentialsEnvVar, Value: credPath})
 	}
 
+	containerHome := fmt.Sprintf("/home/%s", config.UnixUsername)
+
 	// Pass host user UID/GID for container user synchronization
 	envVars = append(envVars, corev1.EnvVar{Name: "SCION_HOST_UID", Value: fmt.Sprintf("%d", os.Getuid())})
 	envVars = append(envVars, corev1.EnvVar{Name: "SCION_HOST_GID", Value: fmt.Sprintf("%d", os.Getgid())})
+	envVars = append(envVars,
+		corev1.EnvVar{Name: "HOME", Value: containerHome},
+		corev1.EnvVar{Name: "USER", Value: config.UnixUsername},
+		corev1.EnvVar{Name: "LOGNAME", Value: config.UnixUsername},
+	)
 
-	// Security context: set FSGroup from host GID for volume permission alignment.
+	// Security context: run agent pods as the image's non-root scion user and
+	// keep FSGroup aligned with the broker user so synced files remain writable.
+	const containerUID int64 = 1000
 	hostGID := int64(os.Getgid())
 	runAsNonRoot := true
 	allowPrivilegeEscalation := false
 	podSecurityContext := &corev1.PodSecurityContext{
 		FSGroup:      &hostGID,
+		RunAsUser:    int64Ptr(containerUID),
+		RunAsGroup:   int64Ptr(containerUID),
 		RunAsNonRoot: &runAsNonRoot,
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,

--- a/pkg/runtime/k8s_runtime_test.go
+++ b/pkg/runtime/k8s_runtime_test.go
@@ -189,20 +189,33 @@ func TestKubernetesRuntime_BuildPod_Env(t *testing.T) {
 	r := NewKubernetesRuntime(client)
 
 	config := RunConfig{
-		Name:  "test-agent",
-		Image: "test-image",
+		Name:         "test-agent",
+		Image:        "test-image",
+		UnixUsername: "scion",
 	}
 
 	pod, _ := r.buildPod("default", config)
 
 	foundUID := false
 	foundGID := false
+	foundHome := false
+	foundUser := false
+	foundLogname := false
 	for _, env := range pod.Spec.Containers[0].Env {
 		if env.Name == "SCION_HOST_UID" {
 			foundUID = true
 		}
 		if env.Name == "SCION_HOST_GID" {
 			foundGID = true
+		}
+		if env.Name == "HOME" && env.Value == "/home/scion" {
+			foundHome = true
+		}
+		if env.Name == "USER" && env.Value == "scion" {
+			foundUser = true
+		}
+		if env.Name == "LOGNAME" && env.Value == "scion" {
+			foundLogname = true
 		}
 	}
 
@@ -211,5 +224,14 @@ func TestKubernetesRuntime_BuildPod_Env(t *testing.T) {
 	}
 	if !foundGID {
 		t.Errorf("SCION_HOST_GID not found in pod env")
+	}
+	if !foundHome {
+		t.Errorf("HOME not found in pod env")
+	}
+	if !foundUser {
+		t.Errorf("USER not found in pod env")
+	}
+	if !foundLogname {
+		t.Errorf("LOGNAME not found in pod env")
 	}
 }


### PR DESCRIPTION
## Summary
- run Kubernetes agent pods as the image's non-root scion user
- keep fsGroup aligned with the broker host gid so synchronized files remain writable
- add focused runtime tests for the pod security context and env setup

## Validation
- go test ./pkg/runtime
- golangci-lint run --config /Users/mfreeman/src/scion/.golangci.yml --new-from-rev=main ./pkg/runtime