### PR TITLE
Retry dispatched agent updates on conflict

### DIFF
--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -811,7 +811,7 @@ func (s *Server) createAgentInGrove(
 				} else if envReqs != nil {
 					// Broker returned 202: needs env gather
 					agent.Phase = string(state.PhaseProvisioning)
-					if err := s.store.UpdateAgent(ctx, agent); err != nil {
+					if err := s.updateAgentAfterDispatch(ctx, agent); err != nil {
 						s.agentLifecycleLog.Warn("Failed to update agent phase for env-gather", "agent_id", agent.ID, "error", err)
 					}
 
@@ -869,7 +869,7 @@ func (s *Server) createAgentInGrove(
 				warnings = append(warnings, "Failed to provision on runtime broker: "+err.Error())
 			} else {
 				agent.Phase = string(state.PhaseCreated)
-				if err := s.store.UpdateAgent(ctx, agent); err != nil {
+				if err := s.updateAgentAfterDispatch(ctx, agent); err != nil {
 					warnings = append(warnings, "Failed to update agent phase: "+err.Error())
 				}
 			}
@@ -919,6 +919,10 @@ func (s *Server) preserveTerminalPhase(ctx context.Context, agent *store.Agent) 
 }
 
 func (s *Server) updateAgentAfterDispatch(ctx context.Context, agent *store.Agent) error {
+	// One retry is intentional here: we only need to recover the common case
+	// where a single concurrent status update bumps StateVersion while dispatch
+	// is in flight. If a second write wins the race too, return the conflict to
+	// the caller rather than spinning in a longer CAS loop inside the request.
 	err := s.store.UpdateAgent(ctx, agent)
 	if err == nil || !errors.Is(err, store.ErrVersionConflict) {
 		return err

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -831,7 +831,7 @@ func (s *Server) createAgentInGrove(
 					if agent.Phase == string(state.PhaseCreated) {
 						agent.Phase = string(state.PhaseProvisioning)
 					}
-					if err := s.store.UpdateAgent(ctx, agent); err != nil {
+					if err := s.updateAgentAfterDispatch(ctx, agent); err != nil {
 						warnings = append(warnings, "Failed to update agent phase: "+err.Error())
 					}
 				}
@@ -858,7 +858,7 @@ func (s *Server) createAgentInGrove(
 					if agent.Phase == string(state.PhaseCreated) {
 						agent.Phase = string(state.PhaseProvisioning)
 					}
-					if err := s.store.UpdateAgent(ctx, agent); err != nil {
+					if err := s.updateAgentAfterDispatch(ctx, agent); err != nil {
 						warnings = append(warnings, "Failed to update agent phase: "+err.Error())
 					}
 				}
@@ -915,6 +915,74 @@ func (s *Server) preserveTerminalPhase(ctx context.Context, agent *store.Agent) 
 		agent.Activity = current.Activity
 		agent.Message = current.Message
 		agent.StateVersion = current.StateVersion
+	}
+}
+
+func (s *Server) updateAgentAfterDispatch(ctx context.Context, agent *store.Agent) error {
+	err := s.store.UpdateAgent(ctx, agent)
+	if err == nil || !errors.Is(err, store.ErrVersionConflict) {
+		return err
+	}
+
+	latest, getErr := s.store.GetAgent(ctx, agent.ID)
+	if getErr != nil {
+		return getErr
+	}
+
+	mergeDispatchedAgent(latest, agent)
+	return s.store.UpdateAgent(ctx, latest)
+}
+
+func mergeDispatchedAgent(dst, src *store.Agent) {
+	if src.Template != "" {
+		dst.Template = src.Template
+	}
+	if src.Image != "" {
+		dst.Image = src.Image
+	}
+	if src.Runtime != "" {
+		dst.Runtime = src.Runtime
+	}
+	if src.AppliedConfig != nil {
+		dst.AppliedConfig = src.AppliedConfig
+	}
+	if src.Message != "" {
+		dst.Message = src.Message
+	}
+	if src.TaskSummary != "" {
+		dst.TaskSummary = src.TaskSummary
+	}
+
+	if isTerminalAgentPhase(dst.Phase) {
+		return
+	}
+	if src.Phase != "" {
+		dst.Phase = src.Phase
+	}
+	if src.Activity != "" {
+		dst.Activity = src.Activity
+	}
+	if src.ContainerStatus != "" {
+		dst.ContainerStatus = src.ContainerStatus
+	}
+	if src.RuntimeState != "" {
+		dst.RuntimeState = src.RuntimeState
+	}
+}
+
+func isTerminalAgentPhase(phase string) bool {
+	switch state.Phase(phase) {
+	case state.PhaseStopped, state.PhaseError:
+		return true
+	case state.PhaseCreated,
+		state.PhaseProvisioning,
+		state.PhaseCloning,
+		state.PhaseStarting,
+		state.PhaseRunning,
+		state.PhaseStopping:
+		return false
+	default:
+		return false
 	}
 }
 
@@ -1092,7 +1160,7 @@ func (s *Server) submitAgentEnv(w http.ResponseWriter, r *http.Request, groveID,
 	if agent.Phase == string(state.PhaseProvisioning) || agent.Phase == string(state.PhaseCreated) {
 		agent.Phase = string(state.PhaseRunning)
 	}
-	if err := s.store.UpdateAgent(ctx, agent); err != nil {
+	if err := s.updateAgentAfterDispatch(ctx, agent); err != nil {
 		s.agentLifecycleLog.Warn("Failed to update agent phase after env submit", "agent_id", agent.ID, "error", err)
 	}
 

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -753,6 +753,7 @@ type createAgentDispatcher struct {
 	createPhase   string // status to set on agent during DispatchAgentCreate
 	createRuntime string
 	createStatus  string
+	envReqs       *RemoteEnvRequirementsResponse
 	deleteCalled  bool
 	deleteErr     error
 }
@@ -793,7 +794,10 @@ func (d *createAgentDispatcher) DispatchCheckAgentPrompt(_ context.Context, _ *s
 	return false, nil
 }
 func (d *createAgentDispatcher) DispatchAgentCreateWithGather(_ context.Context, agent *store.Agent) (*RemoteEnvRequirementsResponse, error) {
-	return nil, d.DispatchAgentCreate(context.Background(), agent)
+	if err := d.DispatchAgentCreate(context.Background(), agent); err != nil {
+		return nil, err
+	}
+	return d.envReqs, nil
 }
 
 // failingCreateDispatcher is a mock dispatcher whose DispatchAgentCreateWithGather
@@ -948,9 +952,64 @@ func TestCreateAgent_RetriesVersionConflictAfterDispatch(t *testing.T) {
 
 	persisted, err := wrapped.GetAgent(ctx, resp.Agent.ID)
 	require.NoError(t, err)
+	assert.False(t, wrapped.failNextUpdate, "test should exercise the conflict retry path")
 	assert.Equal(t, "kubernetes", persisted.Runtime)
 	assert.Equal(t, "Running", persisted.ContainerStatus)
 	assert.Equal(t, string(state.PhaseRunning), persisted.Phase)
+}
+
+func TestCreateAgent_EnvGatherRetriesVersionConflict(t *testing.T) {
+	disp := &createAgentDispatcher{
+		envReqs: &RemoteEnvRequirementsResponse{
+			Required: []string{"API_TOKEN"},
+			Needs:    []string{"API_TOKEN"},
+		},
+	}
+	srv, baseStore, grove := setupCreateAgentServer(t, disp)
+	wrapped := &conflictOnceStore{Store: baseStore, failNextUpdate: true}
+	srv.store = wrapped
+	ctx := context.Background()
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/agents", CreateAgentRequest{
+		Name:      "env-gather-conflict-agent",
+		GroveID:   grove.ID,
+		Task:      "do something",
+		GatherEnv: true,
+	})
+
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	var resp CreateAgentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Agent)
+	require.NotNil(t, resp.EnvGather)
+
+	persisted, err := wrapped.GetAgent(ctx, resp.Agent.ID)
+	require.NoError(t, err)
+	assert.Equal(t, string(state.PhaseProvisioning), persisted.Phase)
+	assert.False(t, wrapped.failNextUpdate, "test should exercise the conflict retry path")
+}
+
+func TestCreateAgent_ProvisionOnlyRetriesVersionConflict(t *testing.T) {
+	disp := &createAgentDispatcher{createPhase: string(state.PhaseRunning)}
+	srv, baseStore, grove := setupCreateAgentServer(t, disp)
+	wrapped := &conflictOnceStore{Store: baseStore, failNextUpdate: true}
+	srv.store = wrapped
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/agents", CreateAgentRequest{
+		Name:          "provision-only-conflict-agent",
+		GroveID:       grove.ID,
+		Task:          "some task",
+		ProvisionOnly: true,
+	})
+
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var resp CreateAgentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Agent)
+	assert.Empty(t, resp.Warnings)
+	assert.False(t, wrapped.failNextUpdate, "test should exercise the conflict retry path")
 }
 
 func TestCreateAgent_StartsWithoutTask(t *testing.T) {

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -750,7 +750,9 @@ func TestDeleteGroveAgent_BrokerOffline(t *testing.T) {
 // createAgentDispatcher is a mock dispatcher for createAgent handler tests.
 // It allows controlling the status that DispatchAgentCreate reports back.
 type createAgentDispatcher struct {
-	createPhase  string // status to set on agent during DispatchAgentCreate
+	createPhase   string // status to set on agent during DispatchAgentCreate
+	createRuntime string
+	createStatus  string
 	deleteCalled bool
 	deleteErr    error
 }
@@ -758,6 +760,12 @@ type createAgentDispatcher struct {
 func (d *createAgentDispatcher) DispatchAgentCreate(_ context.Context, agent *store.Agent) error {
 	if d.createPhase != "" {
 		agent.Phase = d.createPhase
+	}
+	if d.createRuntime != "" {
+		agent.Runtime = d.createRuntime
+	}
+	if d.createStatus != "" {
+		agent.ContainerStatus = d.createStatus
 	}
 	return nil
 }
@@ -899,6 +907,50 @@ func TestCreateAgent_FallbackToProvisioningWhenNoBrokerStatus(t *testing.T) {
 	// When broker doesn't report a status, should fall back to "provisioning"
 	assert.Equal(t, string(state.PhaseProvisioning), resp.Agent.Phase,
 		"agent status should fall back to provisioning when broker doesn't report status")
+}
+
+type conflictOnceStore struct {
+	store.Store
+	failNextUpdate bool
+}
+
+func (s *conflictOnceStore) UpdateAgent(ctx context.Context, agent *store.Agent) error {
+	if s.failNextUpdate {
+		s.failNextUpdate = false
+		return store.ErrVersionConflict
+	}
+	return s.Store.UpdateAgent(ctx, agent)
+}
+
+func TestCreateAgent_RetriesVersionConflictAfterDispatch(t *testing.T) {
+	disp := &createAgentDispatcher{
+		createPhase:   string(state.PhaseRunning),
+		createRuntime: "kubernetes",
+		createStatus:  "Running",
+	}
+	srv, baseStore, grove := setupCreateAgentServer(t, disp)
+	wrapped := &conflictOnceStore{Store: baseStore, failNextUpdate: true}
+	srv.store = wrapped
+	ctx := context.Background()
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/agents", CreateAgentRequest{
+		Name:    "version-conflict-agent",
+		GroveID: grove.ID,
+		Task:    "do something",
+	})
+
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var resp CreateAgentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Agent)
+	require.Empty(t, resp.Warnings)
+
+	persisted, err := wrapped.GetAgent(ctx, resp.Agent.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "kubernetes", persisted.Runtime)
+	assert.Equal(t, "Running", persisted.ContainerStatus)
+	assert.Equal(t, string(state.PhaseRunning), persisted.Phase)
 }
 
 func TestCreateAgent_StartsWithoutTask(t *testing.T) {

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -753,8 +753,8 @@ type createAgentDispatcher struct {
 	createPhase   string // status to set on agent during DispatchAgentCreate
 	createRuntime string
 	createStatus  string
-	deleteCalled bool
-	deleteErr    error
+	deleteCalled  bool
+	deleteErr     error
 }
 
 func (d *createAgentDispatcher) DispatchAgentCreate(_ context.Context, agent *store.Agent) error {


### PR DESCRIPTION
## Summary
- retry post-dispatch agent updates when the hub hits a version conflict
- merge broker-returned runtime and container fields into the latest stored row instead of dropping them
- add a focused create-agent regression test for the conflict path

## Validation
- go test ./pkg/hub -run 'TestCreateAgent_(BrokerStatusPreserved|FallbackToProvisioningWhenNoBrokerStatus|RetriesVersionConflictAfterDispatch)$'