### PR TITLE
Recover hosted grove IDs from workspace markers

### DIFF
--- a/pkg/config/grove_discovery.go
+++ b/pkg/config/grove_discovery.go
@@ -190,10 +190,30 @@ func groveInfoFromGitExternalWithConfig(configPath, agentsDir, dirName, slug str
 	if settings, err := LoadSettings(configPath); err == nil {
 		gi.GroveID = settings.GroveID
 	}
+	if gi.GroveID == "" {
+		if marker, workspacePath, err := readWorkspaceMarkerForSlug(slug); err == nil {
+			gi.GroveID = marker.GroveID
+			gi.WorkspacePath = workspacePath
+		}
+	}
 	if gi.AgentCount == 0 {
 		gi.Status = GroveStatusOrphaned
 	}
 	return gi
+}
+
+func readWorkspaceMarkerForSlug(slug string) (*GroveMarker, string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, "", err
+	}
+	workspacePath := filepath.Join(home, GlobalDir, "groves", slug)
+	markerPath := filepath.Join(workspacePath, DotScion)
+	marker, err := ReadGroveMarker(markerPath)
+	if err != nil {
+		return nil, "", err
+	}
+	return marker, workspacePath, nil
 }
 
 // groveInfoFromGitExternal builds a GroveInfo for a legacy git grove's external agents

--- a/pkg/config/grove_discovery_test.go
+++ b/pkg/config/grove_discovery_test.go
@@ -500,6 +500,60 @@ func TestDiscoverGroves_GitGroveWithExternalConfig(t *testing.T) {
 	}
 }
 
+func TestDiscoverGroves_GitGroveWithExternalConfigUsesWorkspaceMarkerGroveID(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", tmpHome); err != nil {
+		t.Fatalf("Setenv HOME failed: %v", err)
+	}
+	defer func() {
+		if err := os.Setenv("HOME", origHome); err != nil {
+			t.Fatalf("restore HOME failed: %v", err)
+		}
+	}()
+
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".scion"), 0755); err != nil {
+		t.Fatalf("mkdir .scion: %v", err)
+	}
+
+	groveDir := filepath.Join(tmpHome, ".scion", "grove-configs", "newrepo__ccdd1122")
+	scionDir := filepath.Join(groveDir, ".scion")
+	agentsDir := filepath.Join(scionDir, "agents", "worker1", "home")
+	if err := os.MkdirAll(agentsDir, 0755); err != nil {
+		t.Fatalf("mkdir agents dir: %v", err)
+	}
+
+	workspaceDir := filepath.Join(tmpHome, ".scion", "groves", "newrepo")
+	if err := os.MkdirAll(workspaceDir, 0755); err != nil {
+		t.Fatalf("mkdir workspace dir: %v", err)
+	}
+	if err := WriteWorkspaceMarker(workspaceDir, "3c619ec9-517e-4321-8c6a-4757f6a95607", "newrepo", "newrepo"); err != nil {
+		t.Fatalf("WriteWorkspaceMarker failed: %v", err)
+	}
+
+	groves, err := DiscoverGroves()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var gitGrove *GroveInfo
+	for i := range groves {
+		if groves[i].Name == "newrepo" {
+			gitGrove = &groves[i]
+			break
+		}
+	}
+	if gitGrove == nil {
+		t.Fatal("expected to find git grove with external config")
+	}
+	if gitGrove.GroveID != "3c619ec9-517e-4321-8c6a-4757f6a95607" {
+		t.Fatalf("GroveID = %q, want %q", gitGrove.GroveID, "3c619ec9-517e-4321-8c6a-4757f6a95607")
+	}
+	if gitGrove.WorkspacePath != workspaceDir {
+		t.Fatalf("WorkspacePath = %q, want %q", gitGrove.WorkspacePath, workspaceDir)
+	}
+}
+
 func TestDiscoverGroves_GroveConfigNoScionNoAgents(t *testing.T) {
 	tmpHome := t.TempDir()
 	origHome := os.Getenv("HOME")

--- a/pkg/config/grove_discovery_test.go
+++ b/pkg/config/grove_discovery_test.go
@@ -516,6 +516,17 @@ func TestDiscoverGroves_GitGroveWithExternalConfigUsesWorkspaceMarkerGroveID(t *
 		t.Fatalf("mkdir .scion: %v", err)
 	}
 
+	if groveID, ok := os.LookupEnv("SCION_GROVE_ID"); ok {
+		if err := os.Unsetenv("SCION_GROVE_ID"); err != nil {
+			t.Fatalf("Unsetenv SCION_GROVE_ID failed: %v", err)
+		}
+		defer func() {
+			if err := os.Setenv("SCION_GROVE_ID", groveID); err != nil {
+				t.Fatalf("restore SCION_GROVE_ID failed: %v", err)
+			}
+		}()
+	}
+
 	groveDir := filepath.Join(tmpHome, ".scion", "grove-configs", "newrepo__ccdd1122")
 	scionDir := filepath.Join(groveDir, ".scion")
 	agentsDir := filepath.Join(scionDir, "agents", "worker1", "home")


### PR DESCRIPTION
## Summary
- recover hosted grove IDs from workspace marker metadata when external grove config does not have settings.yaml
- preserve the hosted grove identity used by broker reconciliation and heartbeat paths
- add focused grove discovery tests for the workspace-marker fallback

## Validation
- go test ./pkg/config -run 'TestDiscoverGroves_(GitGroveWithExternalConfigUsesWorkspaceMarkerGroveID|GroveConfigNoScionNoAgents)$'