### PR TITLE
Support hub IDs in versioned server config

### DIFF
--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -376,6 +376,11 @@
       "properties": {
         "port": { "type": "integer", "default": 9810, "x-env-var": "SCION_SERVER_HUB_PORT" },
         "host": { "type": "string", "default": "0.0.0.0", "x-env-var": "SCION_SERVER_HUB_HOST" },
+        "hub_id": {
+          "type": "string",
+          "description": "Stable hub instance identifier used for hub-scoped secret namespacing.",
+          "x-env-var": "SCION_SERVER_HUB_HUBID"
+        },
         "public_url": {
           "type": "string",
           "format": "uri",

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -335,6 +335,7 @@ type V1PluginEntry struct {
 type V1ServerHubConfig struct {
 	Port         int           `json:"port,omitempty" yaml:"port,omitempty" koanf:"port"`
 	Host         string        `json:"host,omitempty" yaml:"host,omitempty" koanf:"host"`
+	HubID        string        `json:"hub_id,omitempty" yaml:"hub_id,omitempty" koanf:"hub_id"`
 	PublicURL    string        `json:"public_url,omitempty" yaml:"public_url,omitempty" koanf:"public_url"`
 	ReadTimeout  string        `json:"read_timeout,omitempty" yaml:"read_timeout,omitempty" koanf:"read_timeout"`
 	WriteTimeout string        `json:"write_timeout,omitempty" yaml:"write_timeout,omitempty" koanf:"write_timeout"`
@@ -896,6 +897,9 @@ func ConvertV1ServerToGlobalConfig(v1 *V1ServerConfig) *GlobalConfig {
 		if v1.Hub.Host != "" {
 			gc.Hub.Host = v1.Hub.Host
 		}
+		if v1.Hub.HubID != "" {
+			gc.Hub.HubID = v1.Hub.HubID
+		}
 		if v1.Hub.PublicURL != "" {
 			gc.Hub.Endpoint = v1.Hub.PublicURL
 		}
@@ -1099,6 +1103,7 @@ func ConvertGlobalToV1ServerConfig(gc *GlobalConfig) *V1ServerConfig {
 	v1Hub := &V1ServerHubConfig{
 		Port:         gc.Hub.Port,
 		Host:         gc.Hub.Host,
+		HubID:        gc.Hub.HubID,
 		PublicURL:    gc.Hub.Endpoint,
 		ReadTimeout:  gc.Hub.ReadTimeout.String(),
 		WriteTimeout: gc.Hub.WriteTimeout.String(),

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -1312,6 +1312,7 @@ func TestV1ServerConfig_YAMLRoundTrip(t *testing.T) {
 		Hub: &V1ServerHubConfig{
 			Port:         9810,
 			Host:         "0.0.0.0",
+			HubID:        "test-hub-id",
 			PublicURL:    "https://hub.example.com",
 			ReadTimeout:  "30s",
 			WriteTimeout: "60s",
@@ -1377,6 +1378,7 @@ func TestConvertV1ServerToGlobalConfig_Basic(t *testing.T) {
 		Hub: &V1ServerHubConfig{
 			Port:         9810,
 			Host:         "0.0.0.0",
+			HubID:        "test-hub-id",
 			PublicURL:    "https://hub.example.com",
 			ReadTimeout:  "30s",
 			WriteTimeout: "60s",
@@ -1419,6 +1421,7 @@ func TestConvertV1ServerToGlobalConfig_Basic(t *testing.T) {
 	assert.Equal(t, "debug", gc.LogLevel)
 	assert.Equal(t, "json", gc.LogFormat)
 	assert.Equal(t, 9810, gc.Hub.Port)
+	assert.Equal(t, "test-hub-id", gc.Hub.HubID)
 	assert.Equal(t, "https://hub.example.com", gc.Hub.Endpoint)
 	assert.Equal(t, true, gc.Hub.CORSEnabled)
 	assert.Equal(t, 3600, gc.Hub.CORSMaxAge)
@@ -1474,6 +1477,7 @@ func TestConvertGlobalToV1ServerConfig_RoundTrip(t *testing.T) {
 	gc := DefaultGlobalConfig()
 	gc.LogLevel = "debug"
 	gc.Hub.Port = 9999
+	gc.Hub.HubID = "roundtrip-hub-id"
 	gc.RuntimeBroker.Enabled = true
 	gc.RuntimeBroker.BrokerID = "broker-abc"
 	gc.RuntimeBroker.BrokerName = "test-broker"
@@ -1485,6 +1489,7 @@ func TestConvertGlobalToV1ServerConfig_RoundTrip(t *testing.T) {
 
 	assert.Equal(t, "debug", v1.LogLevel)
 	assert.Equal(t, 9999, v1.Hub.Port)
+	assert.Equal(t, "roundtrip-hub-id", v1.Hub.HubID)
 	assert.Equal(t, true, v1.Broker.Enabled)
 	assert.Equal(t, "broker-abc", v1.Broker.BrokerID)
 	assert.Equal(t, "test-broker", v1.Broker.BrokerName)
@@ -1496,6 +1501,7 @@ func TestConvertGlobalToV1ServerConfig_RoundTrip(t *testing.T) {
 	gc2 := ConvertV1ServerToGlobalConfig(v1)
 	assert.Equal(t, gc.LogLevel, gc2.LogLevel)
 	assert.Equal(t, gc.Hub.Port, gc2.Hub.Port)
+	assert.Equal(t, gc.Hub.HubID, gc2.Hub.HubID)
 	assert.Equal(t, gc.RuntimeBroker.Enabled, gc2.RuntimeBroker.Enabled)
 	assert.Equal(t, gc.RuntimeBroker.BrokerID, gc2.RuntimeBroker.BrokerID)
 	assert.Equal(t, gc.RuntimeBroker.BrokerName, gc2.RuntimeBroker.BrokerName)
@@ -1525,6 +1531,7 @@ server:
   hub:
     port: 9999
     host: "0.0.0.0"
+    hub_id: "settings-hub-id"
   broker:
     enabled: true
     port: 8888
@@ -1544,6 +1551,7 @@ server:
 	assert.Equal(t, "debug", gc.LogLevel)
 	assert.Equal(t, "json", gc.LogFormat)
 	assert.Equal(t, 9999, gc.Hub.Port)
+	assert.Equal(t, "settings-hub-id", gc.Hub.HubID)
 	assert.Equal(t, true, gc.RuntimeBroker.Enabled)
 	assert.Equal(t, 8888, gc.RuntimeBroker.Port)
 	assert.Equal(t, "test-broker-id", gc.RuntimeBroker.BrokerID)


### PR DESCRIPTION
## Summary

- add `hub_id` to `V1ServerHubConfig`
- preserve it when converting between versioned settings and `GlobalConfig`
- document it in the settings schema and cover it with focused config tests

## Problem

Versioned `settings.yaml` currently drops `server.hub.hub_id`, so deployments that rely on versioned server config cannot pin a stable Hub ID through that path.

## Validation

- `go test ./pkg/config -run 'TestConvertV1ServerToGlobalConfig_Basic|TestConvertGlobalToV1ServerConfig_RoundTrip|TestLoadGlobalConfig_FromSettingsYAML'`

 
Refs #91