### PR TITLE
Decode file-backed secrets in Kubernetes runtime

### DIFF
--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -380,7 +380,11 @@ func (r *KubernetesRuntime) createAgentSecret(ctx context.Context, namespace, ag
 		case "environment":
 			data[s.Name] = []byte(s.Value)
 		case "file":
-			data[s.Name] = []byte(s.Value)
+			decoded, err := base64.StdEncoding.DecodeString(s.Value)
+			if err != nil {
+				decoded = []byte(s.Value)
+			}
+			data[s.Name] = decoded
 		case "variable":
 			varSecrets[s.Target] = s.Value
 		}

--- a/pkg/runtime/k8s_secrets_test.go
+++ b/pkg/runtime/k8s_secrets_test.go
@@ -16,6 +16,7 @@ package runtime
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"os"
 	"testing"
@@ -347,7 +348,8 @@ func TestCreateAgentSecret(t *testing.T) {
 
 	secrets := []api.ResolvedSecret{
 		{Name: "API_KEY", Type: "environment", Target: "API_KEY", Value: "sk-123", Source: "user"},
-		{Name: "TLS_CERT", Type: "file", Target: "/etc/ssl/cert.pem", Value: "cert-data", Source: "user"},
+		{Name: "TLS_CERT", Type: "file", Target: "/etc/ssl/cert.pem", Value: base64.StdEncoding.EncodeToString([]byte("cert-content")), Source: "user"},
+		{Name: "RAW_FILE", Type: "file", Target: "/etc/ssl/raw.pem", Value: "raw-content", Source: "user"},
 		{Name: "CONFIG", Type: "variable", Target: "config", Value: `{"key":"val"}`, Source: "user"},
 	}
 
@@ -375,8 +377,11 @@ func TestCreateAgentSecret(t *testing.T) {
 	if string(secret.Data["API_KEY"]) != "sk-123" {
 		t.Errorf("expected API_KEY=sk-123, got %s", string(secret.Data["API_KEY"]))
 	}
-	if string(secret.Data["TLS_CERT"]) != "cert-data" {
-		t.Errorf("expected TLS_CERT=cert-data, got %s", string(secret.Data["TLS_CERT"]))
+	if string(secret.Data["TLS_CERT"]) != "cert-content" {
+		t.Errorf("expected decoded TLS_CERT=cert-content, got %s", string(secret.Data["TLS_CERT"]))
+	}
+	if string(secret.Data["RAW_FILE"]) != "raw-content" {
+		t.Errorf("expected RAW_FILE=raw-content, got %s", string(secret.Data["RAW_FILE"]))
 	}
 
 	// Check secrets.json for variable secrets


### PR DESCRIPTION
## Summary
- decode file-backed secrets before writing them into fallback Kubernetes Secrets
- preserve raw values when the secret payload is not base64-encoded
- add regression coverage for decoded and raw file-secret content

## Validation
- go test ./pkg/runtime -run 'Test(CreateAgentSecret|BuildPod_FallbackSecrets_File|CreateAgentSecret_AlreadyExists)$'
- golangci-lint run --config /Users/mfreeman/src/scion/.golangci.yml --new-from-rev=origin/main ./pkg/runtime

Closes #94