### PR TITLE
fix: podman rootless ExecUser should return scion, not root

### DIFF
--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -109,18 +109,18 @@ func (r *PodmanRuntime) Name() string {
 	return "podman"
 }
 
-// execUser returns the user to pass to podman exec. In rootless mode, the
-// child process runs as root (UID 0) inside the container because the host
-// user's UID is mapped to container UID 0 and privilege drop is skipped.
-// Exec must match that UID so it can find the tmux session and access the
-// same files.
-// ExecUser implements Runtime. In rootless mode, the child process runs as
-// root (UID 0) because the host user is mapped to container UID 0 and
-// privilege drop is skipped. Exec must match that UID.
+// ExecUser implements Runtime. Always returns "scion" because sciontool
+// init drops privileges to the scion user (via SCION_HOST_UID) before
+// launching the tmux session — even in rootless mode. The exec user must
+// match the tmux socket owner (UID 1000 = scion), not the container's
+// initial PID 1 user.
+//
+// The previous behaviour returned "root" for rootless podman, assuming
+// the host UID mapped to container UID 0 and no privilege drop occurred.
+// This was incorrect when the image starts as root (USER root) and
+// sciontool drops to scion, placing the tmux socket at /tmp/tmux-1000/
+// while the broker looked at /tmp/tmux-0/.
 func (r *PodmanRuntime) ExecUser() string {
-	if r.Rootless {
-		return "root"
-	}
 	return "scion"
 }
 

--- a/pkg/runtime/podman_test.go
+++ b/pkg/runtime/podman_test.go
@@ -91,7 +91,7 @@ echo "$@"
 		}
 	})
 
-	t.Run("rootless uses root user", func(t *testing.T) {
+	t.Run("rootless uses scion user", func(t *testing.T) {
 		rt := &PodmanRuntime{
 			Command:  mockPodman,
 			Rootless: true,
@@ -102,11 +102,8 @@ echo "$@"
 			t.Fatalf("runtime.Exec failed: %v", err)
 		}
 
-		if !strings.Contains(out, "--user root") {
-			t.Errorf("expected '--user root' in exec output, got %q", out)
-		}
-		if strings.Contains(out, "--user scion") {
-			t.Errorf("should not contain '--user scion' in rootless mode, got %q", out)
+		if !strings.Contains(out, "--user scion") {
+			t.Errorf("expected '--user scion' in exec output, got %q", out)
 		}
 	})
 }
@@ -119,10 +116,10 @@ func TestPodmanRuntime_ExecUserMethod(t *testing.T) {
 		}
 	})
 
-	t.Run("rootless returns root", func(t *testing.T) {
+	t.Run("rootless returns scion", func(t *testing.T) {
 		rt := &PodmanRuntime{Rootless: true}
-		if got := rt.ExecUser(); got != "root" {
-			t.Errorf("expected 'root', got %q", got)
+		if got := rt.ExecUser(); got != "scion" {
+			t.Errorf("expected 'scion', got %q", got)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- `PodmanRuntime.ExecUser()` now returns `"scion"` unconditionally instead of `"root"` in rootless mode
- sciontool always drops privileges to scion before launching tmux, so the exec user must match

Fixes #96

## Test plan

- [x] Updated `TestPodmanRuntime_ExecUserMethod` — rootless case now expects `"scion"`
- [x] Updated `TestPodmanRuntime_Exec` — rootless exec test expects `--user scion`
- [x] All existing tests pass