### PR TITLE
fix: chown home directory before privilege drop in sciontool

### DIFF
--- a/pkg/sciontool/supervisor/supervisor.go
+++ b/pkg/sciontool/supervisor/supervisor.go
@@ -125,8 +125,9 @@ func (s *Supervisor) Run(ctx context.Context, args []string) (int, error) {
 		err := chownRecursive(home, s.config.UID, s.config.GID)
 		if err != nil {
 			log.Error("Failed to chown home directory %s: %v", home, err)
+		} else {
+			log.Debug("Chowned %s to %d:%d", home, s.config.UID, s.config.GID)
 		}
-		log.Debug("Chowned %s to %d:%d", home, s.config.UID, s.config.GID)
 	}
 
 	// Apply SCION_EXTRA_PATH: prepend its value to PATH, then remove it from env.

--- a/pkg/sciontool/supervisor/supervisor.go
+++ b/pkg/sciontool/supervisor/supervisor.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"syscall"
 	"time"
@@ -113,6 +114,19 @@ func (s *Supervisor) Run(ctx context.Context, args []string) (int, error) {
 		env = setEnvVar(env, "LOGNAME", s.config.Username)
 		s.cmd.Env = env
 		log.Debug("Child env: HOME=%s, USER=%s, LOGNAME=%s", home, s.config.Username, s.config.Username)
+	}
+
+	// Fix ownership of the home directory when dropping privileges.
+	// Pre-start hooks run as root and may create files (e.g. .claude/, agent-info.json)
+	// that the child process needs to write to. Without this, the child (running as
+	// UID/GID from the credential drop) gets permission denied on its own home.
+	if s.config.UID > 0 && s.config.GID > 0 && s.config.Username != "" {
+		home := "/home/" + s.config.Username
+		if err := chownRecursive(home, s.config.UID, s.config.GID); err != nil {
+			log.Error("Failed to chown home directory %s: %v", home, err)
+		} else {
+			log.Debug("Chowned %s to %d:%d", home, s.config.UID, s.config.GID)
+		}
 	}
 
 	// Apply SCION_EXTRA_PATH: prepend its value to PATH, then remove it from env.
@@ -297,4 +311,14 @@ func removeEnvVar(env []string, key string) []string {
 		result = append(result, e)
 	}
 	return result
+}
+
+// chownRecursive changes ownership of a directory and all its contents.
+func chownRecursive(root string, uid, gid int) error {
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Lchown(path, uid, gid)
+	})
 }

--- a/pkg/sciontool/supervisor/supervisor.go
+++ b/pkg/sciontool/supervisor/supervisor.go
@@ -122,11 +122,11 @@ func (s *Supervisor) Run(ctx context.Context, args []string) (int, error) {
 	// UID/GID from the credential drop) gets permission denied on its own home.
 	if s.config.UID > 0 && s.config.GID > 0 && s.config.Username != "" {
 		home := "/home/" + s.config.Username
-		if err := chownRecursive(home, s.config.UID, s.config.GID); err != nil {
+		err := chownRecursive(home, s.config.UID, s.config.GID)
+		if err != nil {
 			log.Error("Failed to chown home directory %s: %v", home, err)
-		} else {
-			log.Debug("Chowned %s to %d:%d", home, s.config.UID, s.config.GID)
 		}
+		log.Debug("Chowned %s to %d:%d", home, s.config.UID, s.config.GID)
 	}
 
 	// Apply SCION_EXTRA_PATH: prepend its value to PATH, then remove it from env.


### PR DESCRIPTION
## Summary

- sciontool now recursively chowns the home directory to the target UID:GID before launching the child process
- Pre-start hooks run as root and create files (`.claude/`, `agent-info.json`, `.scion/scion-env`) that the child process needs to write to
- Without this, harnesses like Claude Code fail silently on startup because they can't write auth state or config

Fixes #97

## Test plan

- [x] Existing supervisor tests pass
- [x] Verified manually: after fix, `/home/scion/` contents are owned by scion:scion
- [x] Claude Code starts successfully and can write to `~/.claude/`