### PR TITLE
fix: pass dispatch InlineConfig to GetAgent so volumes are applied

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -82,12 +82,19 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		ctx = api.ContextWithGitClone(ctx, opts.GitClone)
 	}
 
-	// Build inline config for GetAgent, ensuring --harness-auth is applied
-	// before harness Provision() runs (which reads auth_selectedType to decide
-	// which env vars to inject).
+	// Build inline config for GetAgent by merging the dispatch InlineConfig
+	// (which carries volumes, env, image, etc. from templates/harness configs)
+	// with any --harness-auth override. Without this merge, custom volumes
+	// from hub-dispatched agents are silently dropped.
 	var startInlineConfig *api.ScionConfig
+	if opts.InlineConfig != nil {
+		startInlineConfig = opts.InlineConfig
+	}
 	if opts.HarnessAuth != "" {
-		startInlineConfig = &api.ScionConfig{AuthSelectedType: opts.HarnessAuth}
+		if startInlineConfig == nil {
+			startInlineConfig = &api.ScionConfig{}
+		}
+		startInlineConfig.AuthSelectedType = opts.HarnessAuth
 	}
 
 	util.Debugf("Start: calling GetAgent name=%s template=%q image=%q harnessConfig=%q grovePath=%q profile=%q",


### PR DESCRIPTION
## Summary

Fixes #101 — Hub-dispatched agents do not apply harness config or template volumes.

**Root cause:** When `AgentManager.Start()` builds the `startInlineConfig` to pass to `GetAgent()`, it only extracts `HarnessAuth` from `opts`, discarding `opts.InlineConfig` entirely. The InlineConfig carries volumes, env vars, image, and other settings from templates and harness configs that the hub sends via the dispatch request.

The broker correctly receives the InlineConfig from the hub (via `buildStartContext` in `start_context.go`), and `GetAgent` already merges it via `config.MergeScionConfig` — but the connection between the two was missing.

**Fix:** Use `opts.InlineConfig` as the base for `startInlineConfig`, then overlay `HarnessAuth` on top. This is a 7-line change in `pkg/agent/run.go`.

### Before
```go
var startInlineConfig *api.ScionConfig
if opts.HarnessAuth != "" {
    startInlineConfig = &api.ScionConfig{AuthSelectedType: opts.HarnessAuth}
}
```

### After
```go
var startInlineConfig *api.ScionConfig
if opts.InlineConfig != nil {
    startInlineConfig = opts.InlineConfig
}
if opts.HarnessAuth != "" {
    if startInlineConfig == nil {
        startInlineConfig = &api.ScionConfig{}
    }
    startInlineConfig.AuthSelectedType = opts.HarnessAuth
}
```

## Test plan

- [x] `go build ./pkg/agent/...` — compiles cleanly
- [x] `go vet ./pkg/agent/...` — no warnings
- [x] Tested with self-hosted hub + remote broker — custom volumes (vault mount, SSH agent, model cache) now appear in the container
- [ ] Verify local mode (`--no-hub`) still works (InlineConfig is nil, no change in behavior)
- [ ] Verify HarnessAuth override still takes precedence