### PR TITLE
fix: resolve hub endpoint from --base-url flag

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -621,33 +621,41 @@ func initDevAuth(cfg *config.GlobalConfig, globalDir string) (string, error) {
 
 // resolveHubEndpoint determines the Hub's public endpoint URL.
 func resolveHubEndpoint(cfg *config.GlobalConfig, brokerSettings *config.Settings) string {
-	hubEndpoint := cfg.Hub.Endpoint
-	if hubEndpoint == "" && enableHub {
-		if webBaseURL != "" {
-			hubEndpoint = strings.TrimRight(webBaseURL, "/")
-			if enableDebug {
-				log.Printf("Hub endpoint resolved from --base-url flag: %s", hubEndpoint)
-			}
-		} else if baseURL := os.Getenv("SCION_SERVER_BASE_URL"); baseURL != "" {
-			hubEndpoint = strings.TrimRight(baseURL, "/")
-			if enableDebug {
-				log.Printf("Hub endpoint resolved from SCION_SERVER_BASE_URL: %s", hubEndpoint)
-			}
-		} else {
-			port := cfg.Hub.Port
-			if enableWeb {
-				port = webPort
-			}
-			hubEndpoint = fmt.Sprintf("http://localhost:%d", port)
-			if enableDebug {
-				log.Printf("Auto-computed hub endpoint for combo mode: %s", hubEndpoint)
-			}
-		}
-	} else if hubEndpoint == "" {
-		hubEndpoint = brokerSettings.GetHubEndpoint()
+	if cfg.Hub.Endpoint != "" {
+		return cfg.Hub.Endpoint
+	}
+
+	if !enableHub {
+		hubEndpoint := brokerSettings.GetHubEndpoint()
 		if hubEndpoint != "" && enableDebug {
 			log.Printf("Hub endpoint resolved from grove settings: %s", hubEndpoint)
 		}
+		return hubEndpoint
+	}
+
+	if webBaseURL != "" {
+		hubEndpoint := strings.TrimRight(webBaseURL, "/")
+		if enableDebug {
+			log.Printf("Hub endpoint resolved from --base-url flag: %s", hubEndpoint)
+		}
+		return hubEndpoint
+	}
+
+	if baseURL := os.Getenv("SCION_SERVER_BASE_URL"); baseURL != "" {
+		hubEndpoint := strings.TrimRight(baseURL, "/")
+		if enableDebug {
+			log.Printf("Hub endpoint resolved from SCION_SERVER_BASE_URL: %s", hubEndpoint)
+		}
+		return hubEndpoint
+	}
+
+	port := cfg.Hub.Port
+	if enableWeb {
+		port = webPort
+	}
+	hubEndpoint := fmt.Sprintf("http://localhost:%d", port)
+	if enableDebug {
+		log.Printf("Auto-computed hub endpoint for combo mode: %s", hubEndpoint)
 	}
 	return hubEndpoint
 }

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -623,7 +623,12 @@ func initDevAuth(cfg *config.GlobalConfig, globalDir string) (string, error) {
 func resolveHubEndpoint(cfg *config.GlobalConfig, brokerSettings *config.Settings) string {
 	hubEndpoint := cfg.Hub.Endpoint
 	if hubEndpoint == "" && enableHub {
-		if baseURL := os.Getenv("SCION_SERVER_BASE_URL"); baseURL != "" {
+		if webBaseURL != "" {
+			hubEndpoint = strings.TrimRight(webBaseURL, "/")
+			if enableDebug {
+				log.Printf("Hub endpoint resolved from --base-url flag: %s", hubEndpoint)
+			}
+		} else if baseURL := os.Getenv("SCION_SERVER_BASE_URL"); baseURL != "" {
 			hubEndpoint = strings.TrimRight(baseURL, "/")
 			if enableDebug {
 				log.Printf("Hub endpoint resolved from SCION_SERVER_BASE_URL: %s", hubEndpoint)


### PR DESCRIPTION
## Summary

Fixes #104 — Hub endpoint ignores `--base-url` flag, falls back to `localhost:8080`.

`resolveHubEndpoint()` checks `cfg.Hub.Endpoint` and `SCION_SERVER_BASE_URL` env but ignores the `--base-url` CLI flag. When neither config nor env is set, it falls back to `http://localhost:<webPort>`, causing containers to receive the wrong hub endpoint.

**Fix:** Check `webBaseURL` (the `--base-url` flag) first, before the env var and localhost fallback. One line added.

## Test plan

- [x] `go build` / `go vet` clean
- [ ] Start hub with `--base-url https://example.com` — verify `SCION_HUB_ENDPOINT` in containers matches
- [ ] Start hub without `--base-url` — verify fallback to localhost still works
- [ ] Start hub with `SCION_SERVER_BASE_URL` env — verify env var still works