### PR TITLE
fix: use podman unshare to clean up rootless home directories

### DIFF
--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -127,9 +127,11 @@ func DeleteAgentFiles(agentName string, grovePath string, removeBranch bool) (bo
 			util.Debugf("delete: removing external agent home: %s", externalAgentDir)
 			if err := util.RemoveAllSafe(externalAgentDir); err != nil {
 				util.Debugf("delete: standard removal failed, trying podman unshare: %v", err)
-				if unshareErr := exec.Command("podman", "unshare", "rm", "-rf", externalAgentDir).Run(); unshareErr != nil {
+				unshareCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				if unshareErr := exec.CommandContext(unshareCtx, "podman", "unshare", "rm", "-rf", externalAgentDir).Run(); unshareErr != nil {
 					util.Debugf("delete: podman unshare removal also failed: %v", unshareErr)
 				}
+				cancel()
 			}
 		}
 	}

--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -117,11 +118,18 @@ func DeleteAgentFiles(agentName string, grovePath string, removeBranch bool) (bo
 	}
 
 	// Phase 3: remove external agent home (git grove split storage).
+	// In podman rootless mode, files created as root inside the container are
+	// owned by a mapped subuid on the host, making them inaccessible to the
+	// normal user. If standard removal fails, try `podman unshare rm -rf`
+	// which enters the user namespace where the mapped UIDs are accessible.
 	if externalAgentDir != "" {
 		if _, err := os.Stat(externalAgentDir); err == nil {
 			util.Debugf("delete: removing external agent home: %s", externalAgentDir)
 			if err := util.RemoveAllSafe(externalAgentDir); err != nil {
-				util.Debugf("delete: external home removal failed: %v", err)
+				util.Debugf("delete: standard removal failed, trying podman unshare: %v", err)
+				if unshareErr := exec.Command("podman", "unshare", "rm", "-rf", externalAgentDir).Run(); unshareErr != nil {
+					util.Debugf("delete: podman unshare removal also failed: %v", unshareErr)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #105 — Agent deletion fails to clean up home directory in podman rootless mode.

In podman rootless mode, files created as root inside the container are owned by a mapped subuid on the host. `DeleteAgentFiles()` calls `RemoveAllSafe()` on the external home directory, but this fails silently because the host user can't remove mapped-UID files.

**Fix:** When `RemoveAllSafe()` fails, fall back to `podman unshare rm -rf <path>`. This enters the user namespace where the mapped UIDs are accessible, allowing cleanup without sudo.

This is the Podman equivalent of the `chown -R` pattern already used in the K8s runtime (`pkg/runtime/k8s_runtime.go:302-308`).

## Test plan

- [x] `go build` / `go vet` clean
- [ ] Delete agent in podman rootless mode — verify home directory is cleaned up
- [ ] Delete agent on Docker or podman rootful — verify standard removal still works (podman unshare not called)
- [ ] Verify `podman unshare` failure is non-fatal (graceful degradation if podman not available)