### PR TITLE
Mark failed local agent launches as error

### DIFF
--- a/pkg/agent/error_prop_test.go
+++ b/pkg/agent/error_prop_test.go
@@ -17,6 +17,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -231,9 +232,11 @@ func TestStart_ErrorPropagation_Tmux_Missing(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 
-	// Verify the error message
-	// Should wrap in "failed to launch container: tmux binary not found..."
-	expectedPart := "failed to launch container: tmux binary not found"
+	if !errors.Is(err, ErrTmuxBinaryNotFound) {
+		t.Fatalf("expected ErrTmuxBinaryNotFound, got: %v", err)
+	}
+
+	expectedPart := "failed to launch container"
 	if !strings.Contains(err.Error(), expectedPart) {
 		t.Errorf("Expected error to contain '%s', but got: %v", expectedPart, err)
 	}

--- a/pkg/agent/error_prop_test.go
+++ b/pkg/agent/error_prop_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -200,8 +201,8 @@ func TestStart_ErrorPropagation_Tmux_Missing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Setup MockRuntime with "executable file not found" error
-	originalErr := fmt.Errorf("container run failed: executable file not found in $PATH")
+	// Setup MockRuntime with exec.ErrNotFound
+	originalErr := fmt.Errorf("container run failed: %w", exec.ErrNotFound)
 	mockRuntime := &runtime.MockRuntime{
 		RunFunc: func(ctx context.Context, config runtime.RunConfig) (string, error) {
 			return "", originalErr

--- a/pkg/agent/error_prop_test.go
+++ b/pkg/agent/error_prop_test.go
@@ -16,6 +16,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
 )
 
@@ -234,6 +236,100 @@ func TestStart_ErrorPropagation_Tmux_Missing(t *testing.T) {
 	expectedPart := "failed to launch container: tmux binary not found"
 	if !strings.Contains(err.Error(), expectedPart) {
 		t.Errorf("Expected error to contain '%s', but got: %v", expectedPart, err)
+	}
+}
+
+func TestStart_RunFailureMarksAgentInfoError(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "scion-test-run-failure")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	originalHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", originalHome)
+	os.Setenv("HOME", tmpDir)
+
+	globalScionDir := filepath.Join(tmpDir, ".scion")
+	globalTemplatesDir := filepath.Join(globalScionDir, "templates")
+	if err := os.MkdirAll(globalTemplatesDir, 0755); err != nil {
+		t.Fatalf("failed to create global templates dir: %v", err)
+	}
+
+	tplDir := filepath.Join(globalTemplatesDir, "gemini")
+	if err := os.MkdirAll(tplDir, 0755); err != nil {
+		t.Fatalf("failed to create gemini template dir: %v", err)
+	}
+	tplConfig := `{"default_harness_config": "generic"}`
+	if err := os.WriteFile(filepath.Join(tplDir, "scion-agent.json"), []byte(tplConfig), 0644); err != nil {
+		t.Fatalf("failed to write template config: %v", err)
+	}
+
+	seedTestHarnessConfig(t, globalScionDir, "generic", "generic")
+
+	projectDir := filepath.Join(tmpDir, "project")
+	projectScionDir := filepath.Join(projectDir, ".scion")
+	if err := os.MkdirAll(projectScionDir, 0755); err != nil {
+		t.Fatalf("failed to create project .scion dir: %v", err)
+	}
+
+	settingsJSON := `
+{
+  "runtimes": {
+    "mock": {}
+  },
+  "profiles": {
+    "test": {
+      "runtime": "mock"
+    }
+  }
+}
+`
+	if err := os.WriteFile(filepath.Join(projectScionDir, "settings.json"), []byte(settingsJSON), 0644); err != nil {
+		t.Fatalf("failed to write settings.json: %v", err)
+	}
+
+	mockRuntime := &runtime.MockRuntime{
+		RunFunc: func(ctx context.Context, config runtime.RunConfig) (string, error) {
+			return "", fmt.Errorf("container run failed: pod security rejected")
+		},
+		ListFunc: func(ctx context.Context, labelFilter map[string]string) ([]api.AgentInfo, error) {
+			return nil, nil
+		},
+		ImageExistsFunc: func(ctx context.Context, image string) (bool, error) {
+			return true, nil
+		},
+	}
+
+	manager := &AgentManager{Runtime: mockRuntime}
+
+	_, err = manager.Start(context.Background(), api.StartOptions{
+		Name:      "test-agent",
+		GrovePath: projectScionDir,
+		Profile:   "test",
+		Task:      "do something",
+		Template:  "gemini",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	agentInfoPath := filepath.Join(config.GetAgentHomePath(projectScionDir, "test-agent"), "agent-info.json")
+	data, err := os.ReadFile(agentInfoPath)
+	if err != nil {
+		t.Fatalf("failed to read agent-info.json: %v", err)
+	}
+
+	var info api.AgentInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		t.Fatalf("failed to unmarshal agent-info.json: %v", err)
+	}
+
+	if info.Phase != "error" {
+		t.Fatalf("expected phase error after launch failure, got %q", info.Phase)
+	}
+	if info.Runtime != "mock" {
+		t.Fatalf("expected runtime mock after launch failure, got %q", info.Runtime)
 	}
 }
 

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -42,7 +42,7 @@ func classifyLaunchRuntimeError(err error, resolvedImage string) error {
 		return nil
 	}
 	if errors.Is(err, exec.ErrNotFound) || isTmuxShellNotFoundError(err) {
-		return fmt.Errorf("failed to launch container: %w in image %q: %w", ErrTmuxBinaryNotFound, resolvedImage, err)
+		return fmt.Errorf("failed to launch container in image %q: %w: %w", resolvedImage, ErrTmuxBinaryNotFound, err)
 	}
 	return fmt.Errorf("failed to launch container: %w", err)
 }

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -779,6 +779,11 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 	}
 	id, err := m.Runtime.Run(ctx, runCfg)
 	if err != nil {
+		// Provisioning writes agent-info.json in "created" state before the
+		// runtime launch. If the launch itself fails, keep the provisioned
+		// workspace but flip the local state to "error" so list/status do not
+		// report a phantom created agent forever.
+		_ = UpdateAgentConfig(opts.Name, opts.GrovePath, "error", m.Runtime.Name(), profileName)
 		if strings.Contains(err.Error(), "executable file not found") ||
 			strings.Contains(err.Error(), "tmux: command not found") ||
 			strings.Contains(err.Error(), "tmux: not found") {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -783,7 +783,9 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		// runtime launch. If the launch itself fails, keep the provisioned
 		// workspace but flip the local state to "error" so list/status do not
 		// report a phantom created agent forever.
-		_ = UpdateAgentConfig(opts.Name, opts.GrovePath, "error", m.Runtime.Name(), profileName)
+		if updateErr := UpdateAgentConfig(opts.Name, opts.GrovePath, "error", m.Runtime.Name(), profileName); updateErr != nil {
+			util.Debugf("Start: failed to mark agent error in local config: %v", updateErr)
+		}
 		if strings.Contains(err.Error(), "executable file not found") ||
 			strings.Contains(err.Error(), "tmux: command not found") ||
 			strings.Contains(err.Error(), "tmux: not found") {
@@ -797,7 +799,9 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 	if opts.Resume {
 		status = "resumed"
 	}
-	_ = UpdateAgentConfig(opts.Name, opts.GrovePath, status, m.Runtime.Name(), profileName)
+	if updateErr := UpdateAgentConfig(opts.Name, opts.GrovePath, status, m.Runtime.Name(), profileName); updateErr != nil {
+		util.Debugf("Start: failed to update local agent status to %q: %v", status, updateErr)
+	}
 
 	// Fetch fresh info and verify the container is actually running
 	allAgents, err := m.Runtime.List(ctx, map[string]string{"scion.name": slug})

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -17,6 +17,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -32,6 +33,21 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 )
+
+var ErrTmuxBinaryNotFound = errors.New("tmux binary not found")
+
+func classifyLaunchRuntimeError(err error, resolvedImage string) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "executable file not found") ||
+		strings.Contains(msg, "tmux: command not found") ||
+		strings.Contains(msg, "tmux: not found") {
+		return fmt.Errorf("failed to launch container: %w in image %q: %w", ErrTmuxBinaryNotFound, resolvedImage, err)
+	}
+	return fmt.Errorf("failed to launch container: %w", err)
+}
 
 func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.AgentInfo, error) {
 	// Resolve grove name early so we can scope the container lookup below.
@@ -786,13 +802,7 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		if updateErr := UpdateAgentConfig(opts.Name, opts.GrovePath, "error", m.Runtime.Name(), profileName); updateErr != nil {
 			util.Debugf("Start: failed to mark agent error in local config: %v", updateErr)
 		}
-		if strings.Contains(err.Error(), "executable file not found") ||
-			strings.Contains(err.Error(), "tmux: command not found") ||
-			strings.Contains(err.Error(), "tmux: not found") {
-			return nil, fmt.Errorf("failed to launch container: tmux binary not found in image '%s'. "+
-				"Ensure the image has tmux installed. Error: %w", resolvedImage, err)
-		}
-		return nil, fmt.Errorf("failed to launch container: %w", err)
+		return nil, classifyLaunchRuntimeError(err, resolvedImage)
 	}
 
 	status := "running"

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
 	"sort"
@@ -40,13 +41,19 @@ func classifyLaunchRuntimeError(err error, resolvedImage string) error {
 	if err == nil {
 		return nil
 	}
-	msg := err.Error()
-	if strings.Contains(msg, "executable file not found") ||
-		strings.Contains(msg, "tmux: command not found") ||
-		strings.Contains(msg, "tmux: not found") {
+	if errors.Is(err, exec.ErrNotFound) || isTmuxShellNotFoundError(err) {
 		return fmt.Errorf("failed to launch container: %w in image %q: %w", ErrTmuxBinaryNotFound, resolvedImage, err)
 	}
 	return fmt.Errorf("failed to launch container: %w", err)
+}
+
+func isTmuxShellNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "tmux: command not found") ||
+		strings.Contains(msg, "tmux: not found")
 }
 
 func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.AgentInfo, error) {
@@ -144,7 +151,9 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		task = promptFileContent
 	} else if task != "" {
 		// Explicit prompt always wins — write/overwrite prompt.md
-		_ = os.WriteFile(promptFile, []byte(task), 0644)
+		if writeErr := os.WriteFile(promptFile, []byte(task), 0644); writeErr != nil {
+			return nil, fmt.Errorf("failed to write prompt file %s: %w", promptFile, writeErr)
+		}
 	}
 
 	// Load settings for registry resolution
@@ -580,7 +589,10 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		finalScionCfg.AuthSelectedType = opts.HarnessAuth
 		cfgData, marshalErr := json.MarshalIndent(finalScionCfg, "", "  ")
 		if marshalErr == nil {
-			_ = os.WriteFile(filepath.Join(agentDir, "scion-agent.json"), cfgData, 0644)
+			configPath := filepath.Join(agentDir, "scion-agent.json")
+			if writeErr := os.WriteFile(configPath, cfgData, 0644); writeErr != nil {
+				return nil, fmt.Errorf("failed to write agent config %s: %w", configPath, writeErr)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- mark provisioned local agents as `error` when the runtime launch fails after `agent-info.json` has already been written
- preserve the provisioned workspace/home for diagnosis instead of leaving a phantom `created` agent in list/status output
- add focused regression coverage for the launch-failure state transition

## Problem
The local `scion start` path provisions agent state before attempting the runtime launch. If `Runtime.Run` then fails, the provisioned `agent-info.json` stays in `created` state forever even though no container ever started. In practice that leaves stale phantom agents behind in list output after launch failures.

## Validation
- `go test ./pkg/agent -run 'TestStart_(ErrorPropagation_Tmux|ErrorPropagation_Tmux_Missing|RunFailureMarksAgentInfoError)$'`
