### PR TITLE
Skip image registry checks for Hub commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -145,7 +145,10 @@ return an error instead of blocking.`,
 		case "config", "doctor":
 			requiresRegistry = false
 		}
-		if parentName == "config" {
+		if commandInSubtree(cmd, "config") {
+			requiresRegistry = false
+		}
+		if commandInSubtree(cmd, "hub") {
 			requiresRegistry = false
 		}
 		if requiresRegistry && config.IsHubContext() {
@@ -196,6 +199,15 @@ func Execute() {
 		}
 		os.Exit(1)
 	}
+}
+
+func commandInSubtree(cmd *cobra.Command, name string) bool {
+	for current := cmd; current != nil; current = current.Parent() {
+		if current.Name() == name {
+			return true
+		}
+	}
+	return false
 }
 
 func init() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -129,6 +129,47 @@ func TestFormatFlagCheck(t *testing.T) {
 	}
 }
 
+func TestHubAuthLoginDoesNotRequireImageRegistry(t *testing.T) {
+	origGlobalMode := globalMode
+	origGrovePath := grovePath
+	origProfile := profile
+	origOutputFormat := outputFormat
+	origNoHub := noHub
+	origHubEndpoint := hubEndpoint
+	origNonInteractive := nonInteractive
+	origAutoConfirm := autoConfirm
+	defer func() {
+		globalMode = origGlobalMode
+		grovePath = origGrovePath
+		profile = origProfile
+		outputFormat = origOutputFormat
+		noHub = origNoHub
+		hubEndpoint = origHubEndpoint
+		nonInteractive = origNonInteractive
+		autoConfirm = origAutoConfirm
+	}()
+
+	t.Setenv("SCION_HOST_UID", "")
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".scion"), 0755); err != nil {
+		t.Fatalf("failed to create test global scion dir: %v", err)
+	}
+
+	globalMode = true
+	grovePath = ""
+	profile = ""
+	outputFormat = ""
+	noHub = false
+	hubEndpoint = "http://127.0.0.1:8080"
+	nonInteractive = true
+	autoConfirm = true
+
+	err := rootCmd.PersistentPreRunE(hubAuthLoginCmd, []string{})
+	assert.NoError(t, err)
+}
+
 func TestDevAuthWarning(t *testing.T) {
 	// Save and restore original flags
 	origNoHub := noHub


### PR DESCRIPTION
## Summary
- skip `image_registry` preflight validation for the `scion hub` command tree
- keep container-launch commands gated on `image_registry` as before
- add a regression test for `scion hub auth login` in a clean global setup

## Testing
- `go test ./cmd -run 'Test(HubAuthLoginDoesNotRequireImageRegistry|FormatFlagCheck|DevAuthWarning|NonInteractiveImpliesAutoConfirm)$'`\n