### PR TITLE
Preserve explicit grove clone URLs

### DIFF
--- a/pkg/hub/clone_url.go
+++ b/pkg/hub/clone_url.go
@@ -1,0 +1,40 @@
+package hub
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/util"
+)
+
+// normalizeCloneURLLabel preserves explicit clone URL overrides while still
+// normalizing schemeless git remotes stored in grove labels.
+func normalizeCloneURLLabel(cloneURL string) string {
+	if cloneURL == "" {
+		return ""
+	}
+
+	lower := strings.ToLower(cloneURL)
+	for _, prefix := range []string{"http://", "https://", "ssh://", "git://"} {
+		if strings.HasPrefix(lower, prefix) {
+			return cloneURL
+		}
+	}
+	if strings.HasPrefix(cloneURL, "git@") {
+		return cloneURL
+	}
+	if filepath.IsAbs(cloneURL) || strings.HasPrefix(cloneURL, "./") || strings.HasPrefix(cloneURL, "../") {
+		return cloneURL
+	}
+
+	return util.ToHTTPSCloneURL(cloneURL)
+}
+
+func resolveCloneURL(override, gitRemote string) string {
+	override = normalizeCloneURLLabel(override)
+	if override != "" {
+		return override
+	}
+
+	return normalizeCloneURLLabel(gitRemote)
+}

--- a/pkg/hub/clone_url_test.go
+++ b/pkg/hub/clone_url_test.go
@@ -1,0 +1,90 @@
+package hub
+
+import "testing"
+
+func TestNormalizeCloneURLLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "preserves local path",
+			input: "/tmp/source-repo",
+			want:  "/tmp/source-repo",
+		},
+		{
+			name:  "normalizes schemeless remote",
+			input: "github.com/example/repo",
+			want:  "https://github.com/example/repo.git",
+		},
+		{
+			name:  "preserves explicit http override",
+			input: "http://forgejo-http.forgejo.svc.cluster.local:3000/carverauto/serviceradar.git",
+			want:  "http://forgejo-http.forgejo.svc.cluster.local:3000/carverauto/serviceradar.git",
+		},
+		{
+			name:  "preserves explicit ssh shorthand override",
+			input: "git@github.com:example/repo.git",
+			want:  "git@github.com:example/repo.git",
+		},
+	}
+
+	for i := range tests {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeCloneURLLabel(tt.input); got != tt.want {
+				t.Fatalf("normalizeCloneURLLabel(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveCloneURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		override  string
+		gitRemote string
+		want      string
+	}{
+		{
+			name:      "uses explicit http override",
+			override:  "http://forgejo-http.forgejo.svc.cluster.local:3000/carverauto/serviceradar.git",
+			gitRemote: "github.com/example/repo",
+			want:      "http://forgejo-http.forgejo.svc.cluster.local:3000/carverauto/serviceradar.git",
+		},
+		{
+			name:      "falls back to normalized git remote",
+			override:  "",
+			gitRemote: "github.com/example/repo",
+			want:      "https://github.com/example/repo.git",
+		},
+		{
+			name:      "falls back to explicit ssh remote without rewriting",
+			override:  "",
+			gitRemote: "git@github.com:example/repo.git",
+			want:      "git@github.com:example/repo.git",
+		},
+		{
+			name:      "falls back to local path without rewriting",
+			override:  "",
+			gitRemote: "/tmp/source-repo",
+			want:      "/tmp/source-repo",
+		},
+	}
+
+	for i := range tests {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveCloneURL(tt.override, tt.gitRemote); got != tt.want {
+				t.Fatalf("resolveCloneURL(%q, %q) = %q, want %q", tt.override, tt.gitRemote, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -3137,12 +3137,7 @@ func (s *Server) cloneSharedWorkspaceGrove(ctx context.Context, grove *store.Gro
 	// Build clone URL from the grove's git remote.
 	// The clone-url label may be an explicit override (e.g. local path for testing).
 	// Only convert to HTTPS if the URL looks like a remote git URL.
-	cloneURL := grove.Labels["scion.dev/clone-url"]
-	if cloneURL == "" {
-		cloneURL = util.ToHTTPSCloneURL(grove.GitRemote)
-	} else if util.IsGitURL(cloneURL) {
-		cloneURL = util.ToHTTPSCloneURL(cloneURL)
-	}
+	cloneURL := resolveCloneURL(grove.Labels["scion.dev/clone-url"], grove.GitRemote)
 
 	defaultBranch := grove.Labels["scion.dev/default-branch"]
 	if defaultBranch == "" {
@@ -7776,15 +7771,7 @@ func (s *Server) populateAgentConfig(agent *store.Agent, grove *store.Grove, res
 	// Populate GitClone config for git-anchored groves (per-agent clone mode).
 	// Shared-workspace git groves skip clone — agents mount the shared workspace instead.
 	if grove != nil && grove.GitRemote != "" && !grove.IsSharedWorkspace() {
-		cloneURL := grove.Labels["scion.dev/clone-url"]
-		if cloneURL == "" {
-			cloneURL = "https://" + grove.GitRemote + ".git"
-		} else {
-			// Normalize: the label may have been stored without a scheme
-			// (e.g. "github.com/org/repo" from the web UI). Ensure it is
-			// always a valid HTTPS clone URL.
-			cloneURL = util.ToHTTPSCloneURL(cloneURL)
-		}
+		cloneURL := resolveCloneURL(grove.Labels["scion.dev/clone-url"], grove.GitRemote)
 		defaultBranch := grove.Labels["scion.dev/default-branch"]
 		if defaultBranch == "" {
 			defaultBranch = "main"


### PR DESCRIPTION
## Summary
- preserve explicit grove clone URL overrides instead of normalizing every value to HTTPS
- keep schemeless remote labels normalized for consistency
- add focused coverage for local paths and explicit http/ssh overrides

## Testing
- `go test ./pkg/hub -run 'TestNormalizeCloneURLLabel|Test.*Clone.*URL|Test.*Grove.*Create.*Clone'`\n