### PR TITLE
Support custom OTLP CA bundles

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -255,8 +255,9 @@ type TelemetryCloudConfig struct {
 
 // TelemetryTLS holds TLS settings for OTLP export.
 type TelemetryTLS struct {
-	Enabled            *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	InsecureSkipVerify *bool `json:"insecure_skip_verify,omitempty" yaml:"insecure_skip_verify,omitempty"`
+	Enabled            *bool  `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	InsecureSkipVerify *bool  `json:"insecure_skip_verify,omitempty" yaml:"insecure_skip_verify,omitempty"`
+	CAFile             string `json:"ca_file,omitempty" yaml:"ca_file,omitempty"`
 }
 
 // TelemetryBatch holds batch export settings.

--- a/pkg/config/schemas/agent-v1.schema.json
+++ b/pkg/config/schemas/agent-v1.schema.json
@@ -241,7 +241,8 @@
               "type": "object",
               "properties": {
                 "enabled": { "type": "boolean" },
-                "insecure_skip_verify": { "type": "boolean" }
+                "insecure_skip_verify": { "type": "boolean" },
+                "ca_file": { "type": "string" }
               },
               "additionalProperties": false
             },

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -619,6 +619,12 @@
           "description": "Skip TLS certificate verification.",
           "x-env-var": "SCION_OTEL_INSECURE",
           "x-since": "1"
+        },
+        "ca_file": {
+          "type": "string",
+          "description": "Path to a PEM-encoded CA bundle used to verify the OTLP endpoint certificate.",
+          "x-env-var": "SCION_OTEL_CA_FILE",
+          "x-since": "1"
         }
       },
       "additionalProperties": false

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -462,8 +462,9 @@ type V1TelemetryCloudConfig struct {
 
 // V1TelemetryTLSConfig holds TLS settings for cloud OTLP export.
 type V1TelemetryTLSConfig struct {
-	Enabled            *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" koanf:"enabled"`
-	InsecureSkipVerify *bool `json:"insecure_skip_verify,omitempty" yaml:"insecure_skip_verify,omitempty" koanf:"insecure_skip_verify"`
+	Enabled            *bool  `json:"enabled,omitempty" yaml:"enabled,omitempty" koanf:"enabled"`
+	InsecureSkipVerify *bool  `json:"insecure_skip_verify,omitempty" yaml:"insecure_skip_verify,omitempty" koanf:"insecure_skip_verify"`
+	CAFile             string `json:"ca_file,omitempty" yaml:"ca_file,omitempty" koanf:"ca_file"`
 }
 
 // V1TelemetryBatchConfig holds batch export settings.
@@ -849,6 +850,7 @@ func mapTelemetryEnvKey(key string) string {
 //	"protocol" -> "telemetry.cloud.protocol"
 //	"headers" -> "telemetry.cloud.headers"
 //	"insecure" -> "telemetry.cloud.tls.insecure_skip_verify"
+//	"ca_file" -> "telemetry.cloud.tls.ca_file"
 func mapOtelEnvKey(key string) string {
 	switch key {
 	case "endpoint":
@@ -859,6 +861,8 @@ func mapOtelEnvKey(key string) string {
 		return "telemetry.cloud.headers"
 	case "insecure":
 		return "telemetry.cloud.tls.insecure_skip_verify"
+	case "ca_file":
+		return "telemetry.cloud.tls.ca_file"
 	default:
 		return "telemetry.cloud." + key
 	}

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -2915,6 +2915,7 @@ telemetry:
     tls:
       enabled: true
       insecure_skip_verify: false
+      ca_file: "/etc/ssl/certs/custom-root.pem"
     batch:
       max_size: 256
       timeout: "10s"
@@ -2971,6 +2972,7 @@ telemetry:
 	assert.True(t, *vs.Telemetry.Cloud.TLS.Enabled)
 	require.NotNil(t, vs.Telemetry.Cloud.TLS.InsecureSkipVerify)
 	assert.False(t, *vs.Telemetry.Cloud.TLS.InsecureSkipVerify)
+	assert.Equal(t, "/etc/ssl/certs/custom-root.pem", vs.Telemetry.Cloud.TLS.CAFile)
 
 	require.NotNil(t, vs.Telemetry.Cloud.Batch)
 	assert.Equal(t, 256, vs.Telemetry.Cloud.Batch.MaxSize)
@@ -3142,6 +3144,7 @@ func TestVersionedEnvKeyMapper_Telemetry(t *testing.T) {
 		{"SCION_OTEL_PROTOCOL", "telemetry.cloud.protocol"},
 		{"SCION_OTEL_HEADERS", "telemetry.cloud.headers"},
 		{"SCION_OTEL_INSECURE", "telemetry.cloud.tls.insecure_skip_verify"},
+		{"SCION_OTEL_CA_FILE", "telemetry.cloud.tls.ca_file"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/telemetry_convert.go
+++ b/pkg/config/telemetry_convert.go
@@ -47,6 +47,7 @@ func ConvertV1TelemetryToAPI(v1 *V1TelemetryConfig) *api.TelemetryConfig {
 			result.Cloud.TLS = &api.TelemetryTLS{
 				Enabled:            v1.Cloud.TLS.Enabled,
 				InsecureSkipVerify: v1.Cloud.TLS.InsecureSkipVerify,
+				CAFile:             v1.Cloud.TLS.CAFile,
 			}
 		}
 		if v1.Cloud.Batch != nil {
@@ -133,6 +134,9 @@ func TelemetryConfigToEnv(cfg *api.TelemetryConfig) map[string]string {
 		}
 		if cfg.Cloud.TLS != nil && cfg.Cloud.TLS.InsecureSkipVerify != nil {
 			env["SCION_OTEL_INSECURE"] = strconv.FormatBool(*cfg.Cloud.TLS.InsecureSkipVerify)
+		}
+		if cfg.Cloud.TLS != nil && cfg.Cloud.TLS.CAFile != "" {
+			env["SCION_OTEL_CA_FILE"] = cfg.Cloud.TLS.CAFile
 		}
 		if cfg.Cloud.Batch != nil {
 			if cfg.Cloud.Batch.MaxSize > 0 {

--- a/pkg/config/telemetry_convert_test.go
+++ b/pkg/config/telemetry_convert_test.go
@@ -35,6 +35,7 @@ func TestConvertV1TelemetryToAPI_Full(t *testing.T) {
 	cloudEnabled := true
 	insecure := false
 	tlsEnabled := true
+	caFile := "/etc/ssl/certs/custom-root.pem"
 	hubEnabled := true
 	localEnabled := true
 	console := false
@@ -51,6 +52,7 @@ func TestConvertV1TelemetryToAPI_Full(t *testing.T) {
 			TLS: &V1TelemetryTLSConfig{
 				Enabled:            &tlsEnabled,
 				InsecureSkipVerify: &insecure,
+				CAFile:             caFile,
 			},
 			Batch: &V1TelemetryBatchConfig{
 				MaxSize: 512,
@@ -110,6 +112,9 @@ func TestConvertV1TelemetryToAPI_Full(t *testing.T) {
 	}
 	if result.Cloud.TLS.InsecureSkipVerify == nil || *result.Cloud.TLS.InsecureSkipVerify != false {
 		t.Errorf("Cloud.TLS.InsecureSkipVerify = %v, want false", result.Cloud.TLS.InsecureSkipVerify)
+	}
+	if result.Cloud.TLS.CAFile != caFile {
+		t.Errorf("Cloud.TLS.CAFile = %q, want %q", result.Cloud.TLS.CAFile, caFile)
 	}
 	if result.Cloud.Batch == nil {
 		t.Fatal("Cloud.Batch is nil")
@@ -211,6 +216,7 @@ func TestTelemetryConfigToEnv_Full(t *testing.T) {
 	enabled := true
 	cloudEnabled := true
 	insecure := false
+	caFile := "/etc/ssl/certs/custom-root.pem"
 	hubEnabled := true
 	localEnabled := true
 	console := true
@@ -226,6 +232,7 @@ func TestTelemetryConfigToEnv_Full(t *testing.T) {
 			Headers:  map[string]string{"X-Key": "val"},
 			TLS: &api.TelemetryTLS{
 				InsecureSkipVerify: &insecure,
+				CAFile:             caFile,
 			},
 			Batch: &api.TelemetryBatch{
 				MaxSize: 256,
@@ -267,6 +274,7 @@ func TestTelemetryConfigToEnv_Full(t *testing.T) {
 		"SCION_OTEL_ENDPOINT":                       "otel.example.com:4317",
 		"SCION_OTEL_PROTOCOL":                       "grpc",
 		"SCION_OTEL_INSECURE":                       "false",
+		"SCION_OTEL_CA_FILE":                        "/etc/ssl/certs/custom-root.pem",
 		"SCION_TELEMETRY_CLOUD_BATCH_MAX_SIZE":      "256",
 		"SCION_TELEMETRY_CLOUD_BATCH_TIMEOUT":       "10s",
 		"SCION_TELEMETRY_CLOUD_PROVIDER":            "gcp",

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -817,6 +817,9 @@ func mergeTelemetryConfig(base, override *api.TelemetryConfig) *api.TelemetryCon
 			if override.Cloud.TLS.InsecureSkipVerify != nil {
 				result.Cloud.TLS.InsecureSkipVerify = override.Cloud.TLS.InsecureSkipVerify
 			}
+			if override.Cloud.TLS.CAFile != "" {
+				result.Cloud.TLS.CAFile = override.Cloud.TLS.CAFile
+			}
 		}
 		if override.Cloud.Batch != nil {
 			if result.Cloud.Batch == nil {

--- a/pkg/config/templates_test.go
+++ b/pkg/config/templates_test.go
@@ -1075,6 +1075,7 @@ func TestMergeScionConfigTelemetry(t *testing.T) {
 					TLS: &api.TelemetryTLS{
 						Enabled:            boolP(true),
 						InsecureSkipVerify: boolP(false),
+						CAFile:             "/etc/ssl/certs/base-root.pem",
 					},
 					Batch: &api.TelemetryBatch{
 						MaxSize: 512,
@@ -1109,6 +1110,7 @@ func TestMergeScionConfigTelemetry(t *testing.T) {
 					Endpoint: "https://override.example.com",
 					TLS: &api.TelemetryTLS{
 						InsecureSkipVerify: boolP(true),
+						CAFile:             "/etc/ssl/certs/override-root.pem",
 					},
 					Batch: &api.TelemetryBatch{
 						MaxSize: 256,
@@ -1156,6 +1158,9 @@ func TestMergeScionConfigTelemetry(t *testing.T) {
 		}
 		if got.Telemetry.Cloud.TLS.InsecureSkipVerify == nil || *got.Telemetry.Cloud.TLS.InsecureSkipVerify != true {
 			t.Errorf("expected InsecureSkipVerify=true overridden")
+		}
+		if got.Telemetry.Cloud.TLS.CAFile != "/etc/ssl/certs/override-root.pem" {
+			t.Errorf("expected CAFile override preserved, got %q", got.Telemetry.Cloud.TLS.CAFile)
 		}
 		// Batch max_size overridden, timeout preserved
 		if got.Telemetry.Cloud.Batch.MaxSize != 256 {

--- a/pkg/sciontool/telemetry/config.go
+++ b/pkg/sciontool/telemetry/config.go
@@ -26,6 +26,8 @@ const (
 	EnvProtocol = "SCION_OTEL_PROTOCOL"
 	// EnvInsecure controls whether TLS verification is skipped.
 	EnvInsecure = "SCION_OTEL_INSECURE"
+	// EnvCAFile is the path to a PEM-encoded CA bundle for OTLP TLS.
+	EnvCAFile = "SCION_OTEL_CA_FILE"
 	// EnvGRPCPort is the local gRPC receiver port.
 	EnvGRPCPort = "SCION_OTEL_GRPC_PORT"
 	// EnvHTTPPort is the local HTTP receiver port.
@@ -77,6 +79,8 @@ type Config struct {
 	Protocol string
 	// Insecure skips TLS verification if true.
 	Insecure bool
+	// CAFile is the path to a PEM-encoded CA bundle for OTLP TLS.
+	CAFile string
 	// GRPCPort is the local gRPC receiver port.
 	GRPCPort int
 	// HTTPPort is the local HTTP receiver port.
@@ -117,6 +121,7 @@ func LoadConfig() *Config {
 		Endpoint:     os.Getenv(EnvEndpoint),
 		Protocol:     getEnvOrDefault(EnvProtocol, DefaultProtocol),
 		Insecure:     parseBoolEnv(EnvInsecure, false),
+		CAFile:       os.Getenv(EnvCAFile),
 		GRPCPort:     parseIntEnv(EnvGRPCPort, DefaultGRPCPort),
 		HTTPPort:     parseIntEnv(EnvHTTPPort, DefaultHTTPPort),
 		ProjectID:    os.Getenv(EnvProjectID),

--- a/pkg/sciontool/telemetry/config_test.go
+++ b/pkg/sciontool/telemetry/config_test.go
@@ -34,6 +34,9 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	if cfg.Insecure {
 		t.Error("Expected Insecure to be false by default")
 	}
+	if cfg.CAFile != "" {
+		t.Errorf("Expected CAFile to be empty by default, got %q", cfg.CAFile)
+	}
 	if cfg.MetricsDebug {
 		t.Error("Expected MetricsDebug to be false by default")
 	}
@@ -51,6 +54,9 @@ func TestLoadConfig_EnvOverrides(t *testing.T) {
 	os.Setenv(EnvEndpoint, "otel.example.com:443")
 	os.Setenv(EnvProtocol, "http")
 	os.Setenv(EnvInsecure, "true")
+	if err := os.Setenv(EnvCAFile, "/etc/ssl/certs/custom-root.pem"); err != nil {
+		t.Fatalf("failed to set %s: %v", EnvCAFile, err)
+	}
 	os.Setenv(EnvGRPCPort, "14317")
 	os.Setenv(EnvHTTPPort, "14318")
 	os.Setenv(EnvProjectID, "my-project")
@@ -75,6 +81,9 @@ func TestLoadConfig_EnvOverrides(t *testing.T) {
 	}
 	if !cfg.Insecure {
 		t.Error("Expected Insecure to be true")
+	}
+	if cfg.CAFile != "/etc/ssl/certs/custom-root.pem" {
+		t.Errorf("Expected CAFile to be '/etc/ssl/certs/custom-root.pem', got %q", cfg.CAFile)
 	}
 	if cfg.GRPCPort != 14317 {
 		t.Errorf("Expected GRPCPort to be 14317, got %d", cfg.GRPCPort)
@@ -556,6 +565,9 @@ func clearTelemetryEnv() {
 	os.Unsetenv(EnvEndpoint)
 	os.Unsetenv(EnvProtocol)
 	os.Unsetenv(EnvInsecure)
+	if err := os.Unsetenv(EnvCAFile); err != nil {
+		panic(err)
+	}
 	os.Unsetenv(EnvGRPCPort)
 	os.Unsetenv(EnvHTTPPort)
 	os.Unsetenv(EnvFilterExclude)

--- a/pkg/sciontool/telemetry/exporter.go
+++ b/pkg/sciontool/telemetry/exporter.go
@@ -23,8 +23,6 @@ import (
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/oauth"
 )
 
@@ -94,7 +92,7 @@ type CloudExporter struct {
 // NewCloudExporter creates a new cloud exporter.
 // When provider=gcp, uses GCP-native APIs (Cloud Trace, Cloud Logging).
 // Otherwise, uses standard OTLP gRPC/HTTP forwarding.
-func NewCloudExporter(config *Config) (*CloudExporter, error) {
+func NewCloudExporter(ctx context.Context, config *Config) (*CloudExporter, error) {
 	if !config.IsCloudConfigured() {
 		return nil, nil
 	}
@@ -118,9 +116,9 @@ func NewCloudExporter(config *Config) (*CloudExporter, error) {
 	var err error
 	switch config.Protocol {
 	case "http":
-		err = exporter.initHTTP(config)
+		err = exporter.initHTTP(ctx, config)
 	default:
-		err = exporter.initGRPC(config)
+		err = exporter.initGRPC(ctx, config)
 	}
 
 	if err != nil {
@@ -131,31 +129,18 @@ func NewCloudExporter(config *Config) (*CloudExporter, error) {
 }
 
 // initGRPC initializes the generic OTLP gRPC exporter.
-func (e *CloudExporter) initGRPC(config *Config) error {
-	ctx := context.Background()
-
-	// Load GCP dial options if credentials are configured and TLS is enabled
-	var gcpDialOpts []grpc.DialOption
-	if config.GCPCredentialsFile != "" && !config.Insecure {
-		var err error
-		gcpDialOpts, err = loadGCPDialOptions(ctx, config.GCPCredentialsFile)
-		if err != nil {
-			return fmt.Errorf("failed to load GCP credentials: %w", err)
-		}
+func (e *CloudExporter) initGRPC(ctx context.Context, config *Config) error {
+	gcpDialOpts, err := loadSecureGCPDialOptions(ctx, config)
+	if err != nil {
+		return err
 	}
 
 	opts := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(config.Endpoint),
 	}
-
-	if config.Insecure {
-		opts = append(opts, otlptracegrpc.WithInsecure())
-	} else {
-		tlsConfig, err := loadOTLPTLSConfig(config.CAFile)
-		if err != nil {
-			return fmt.Errorf("failed to load OTLP TLS config: %w", err)
-		}
-		opts = append(opts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(tlsConfig)))
+	opts, err = appendOTLPTraceGRPCSecurityOption(opts, config)
+	if err != nil {
+		return err
 	}
 
 	for _, do := range gcpDialOpts {
@@ -170,16 +155,11 @@ func (e *CloudExporter) initGRPC(config *Config) error {
 	e.traceExporter = traceExp
 
 	// Also create a raw gRPC client for proto forwarding
-	connOpts := []grpc.DialOption{}
-	if config.Insecure {
-		connOpts = append(connOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	} else {
-		tlsConfig, err := loadOTLPTLSConfig(config.CAFile)
-		if err != nil {
-			return fmt.Errorf("failed to load OTLP TLS config: %w", err)
-		}
-		connOpts = append(connOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	transportCreds, err := otlpGRPCTransportCredentials(config)
+	if err != nil {
+		return err
 	}
+	connOpts := []grpc.DialOption{transportCreds}
 	connOpts = append(connOpts, gcpDialOpts...)
 
 	conn, err := grpc.NewClient(config.Endpoint, connOpts...)
@@ -197,22 +177,16 @@ func (e *CloudExporter) initGRPC(config *Config) error {
 }
 
 // initHTTP initializes the generic OTLP HTTP exporter.
-func (e *CloudExporter) initHTTP(config *Config) error {
+func (e *CloudExporter) initHTTP(ctx context.Context, config *Config) error {
 	opts := []otlptracehttp.Option{
 		otlptracehttp.WithEndpoint(config.Endpoint),
 	}
-
-	if config.Insecure {
-		opts = append(opts, otlptracehttp.WithInsecure())
-	} else {
-		tlsConfig, err := loadOTLPTLSConfig(config.CAFile)
-		if err != nil {
-			return fmt.Errorf("failed to load OTLP TLS config: %w", err)
-		}
-		opts = append(opts, otlptracehttp.WithTLSClientConfig(tlsConfig))
+	opts, err := appendOTLPTraceHTTPSecurityOption(opts, config)
+	if err != nil {
+		return err
 	}
 
-	traceExp, err := otlptracehttp.New(context.Background(), opts...)
+	traceExp, err := otlptracehttp.New(ctx, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP trace exporter: %w", err)
 	}

--- a/pkg/sciontool/telemetry/exporter.go
+++ b/pkg/sciontool/telemetry/exporter.go
@@ -7,6 +7,8 @@ package telemetry
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"fmt"
 	"os"
 
@@ -25,6 +27,27 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/oauth"
 )
+
+var errOTLPCACertsNotFound = errors.New("parsing OTLP CA file: no certificates found")
+
+func loadOTLPTLSConfig(caFile string) (*tls.Config, error) {
+	tlsConfig := &tls.Config{}
+	if caFile == "" {
+		return tlsConfig, nil
+	}
+
+	pemBytes, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading OTLP CA file: %w", err)
+	}
+
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(pemBytes) {
+		return nil, errOTLPCACertsNotFound
+	}
+	tlsConfig.RootCAs = roots
+	return tlsConfig, nil
+}
 
 // loadGCPDialOptions loads GCP credentials from a service account key file
 // and returns gRPC dial options for per-RPC authentication. Returns (nil, nil)
@@ -127,6 +150,12 @@ func (e *CloudExporter) initGRPC(config *Config) error {
 
 	if config.Insecure {
 		opts = append(opts, otlptracegrpc.WithInsecure())
+	} else {
+		tlsConfig, err := loadOTLPTLSConfig(config.CAFile)
+		if err != nil {
+			return fmt.Errorf("failed to load OTLP TLS config: %w", err)
+		}
+		opts = append(opts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(tlsConfig)))
 	}
 
 	for _, do := range gcpDialOpts {
@@ -145,7 +174,11 @@ func (e *CloudExporter) initGRPC(config *Config) error {
 	if config.Insecure {
 		connOpts = append(connOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
-		connOpts = append(connOpts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
+		tlsConfig, err := loadOTLPTLSConfig(config.CAFile)
+		if err != nil {
+			return fmt.Errorf("failed to load OTLP TLS config: %w", err)
+		}
+		connOpts = append(connOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	}
 	connOpts = append(connOpts, gcpDialOpts...)
 
@@ -171,6 +204,12 @@ func (e *CloudExporter) initHTTP(config *Config) error {
 
 	if config.Insecure {
 		opts = append(opts, otlptracehttp.WithInsecure())
+	} else {
+		tlsConfig, err := loadOTLPTLSConfig(config.CAFile)
+		if err != nil {
+			return fmt.Errorf("failed to load OTLP TLS config: %w", err)
+		}
+		opts = append(opts, otlptracehttp.WithTLSClientConfig(tlsConfig))
 	}
 
 	traceExp, err := otlptracehttp.New(context.Background(), opts...)

--- a/pkg/sciontool/telemetry/exporter_test.go
+++ b/pkg/sciontool/telemetry/exporter_test.go
@@ -9,11 +9,14 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
+	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestLoadGCPDialOptions_EmptyPath(t *testing.T) {
@@ -89,4 +92,83 @@ func TestLoadGCPDialOptions_ValidKey(t *testing.T) {
 	if len(opts) == 0 {
 		t.Error("expected non-empty dial options for valid key")
 	}
+}
+
+func TestLoadOTLPTLSConfig_EmptyPath(t *testing.T) {
+	tlsConfig, err := loadOTLPTLSConfig("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tlsConfig == nil {
+		t.Fatal("expected non-nil tls.Config")
+	}
+	if tlsConfig.RootCAs != nil {
+		t.Errorf("expected nil RootCAs without CA file, got %#v", tlsConfig.RootCAs)
+	}
+}
+
+func TestLoadOTLPTLSConfig_InvalidPath(t *testing.T) {
+	_, err := loadOTLPTLSConfig("/nonexistent/path/root.pem")
+	if err == nil {
+		t.Fatal("expected error for missing CA file")
+	}
+}
+
+func TestLoadOTLPTLSConfig_ValidCAFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	caPath := filepath.Join(tmpDir, "root.pem")
+	caPEM := generateTestCertificatePEM(t)
+	if err := os.WriteFile(caPath, caPEM, 0600); err != nil {
+		t.Fatalf("failed to write CA file: %v", err)
+	}
+
+	tlsConfig, err := loadOTLPTLSConfig(caPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tlsConfig.RootCAs == nil {
+		t.Fatal("expected custom RootCAs to be configured")
+	}
+	block, _ := pem.Decode(caPEM)
+	if block == nil {
+		t.Fatal("expected PEM block")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse generated certificate: %v", err)
+	}
+	if _, err := cert.Verify(x509.VerifyOptions{Roots: tlsConfig.RootCAs}); err != nil {
+		t.Fatalf("expected generated certificate to verify against loaded RootCAs: %v", err)
+	}
+}
+
+func generateTestCertificatePEM(t *testing.T) []byte {
+	t.Helper()
+
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "scion-test-root",
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &privKey.PublicKey, privKey)
+	if err != nil {
+		t.Fatalf("failed to create test certificate: %v", err)
+	}
+
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: derBytes,
+	})
 }

--- a/pkg/sciontool/telemetry/otlp_options.go
+++ b/pkg/sciontool/telemetry/otlp_options.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025 The Scion Authors.
+*/
+
+package telemetry
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func loadSecureGCPDialOptions(ctx context.Context, config *Config) ([]grpc.DialOption, error) {
+	if config.GCPCredentialsFile == "" || config.Insecure {
+		return nil, nil
+	}
+
+	dialOpts, err := loadGCPDialOptions(ctx, config.GCPCredentialsFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load GCP credentials: %w", err)
+	}
+
+	return dialOpts, nil
+}
+
+func loadSecureOTLPTLSConfig(config *Config) (*tls.Config, error) {
+	tlsConfig, err := loadOTLPTLSConfig(config.CAFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load OTLP TLS config: %w", err)
+	}
+	return tlsConfig, nil
+}
+
+func otlpGRPCTransportCredentials(config *Config) (grpc.DialOption, error) {
+	if config.Insecure {
+		return grpc.WithTransportCredentials(insecure.NewCredentials()), nil
+	}
+
+	tlsConfig, err := loadSecureOTLPTLSConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)), nil
+}
+
+func appendOTLPTraceGRPCSecurityOption(opts []otlptracegrpc.Option, config *Config) ([]otlptracegrpc.Option, error) {
+	if config.Insecure {
+		return append(opts, otlptracegrpc.WithInsecure()), nil
+	}
+
+	tlsConfig, err := loadSecureOTLPTLSConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return append(opts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(tlsConfig))), nil
+}
+
+func appendOTLPLogGRPCSecurityOption(opts []otlploggrpc.Option, config *Config) ([]otlploggrpc.Option, error) {
+	if config.Insecure {
+		return append(opts, otlploggrpc.WithInsecure()), nil
+	}
+
+	tlsConfig, err := loadSecureOTLPTLSConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return append(opts, otlploggrpc.WithTLSCredentials(credentials.NewTLS(tlsConfig))), nil
+}
+
+func appendOTLPMetricGRPCSecurityOption(opts []otlpmetricgrpc.Option, config *Config) ([]otlpmetricgrpc.Option, error) {
+	if config.Insecure {
+		return append(opts, otlpmetricgrpc.WithInsecure()), nil
+	}
+
+	tlsConfig, err := loadSecureOTLPTLSConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return append(opts, otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(tlsConfig))), nil
+}
+
+func appendOTLPTraceHTTPSecurityOption(opts []otlptracehttp.Option, config *Config) ([]otlptracehttp.Option, error) {
+	if config.Insecure {
+		return append(opts, otlptracehttp.WithInsecure()), nil
+	}
+
+	tlsConfig, err := loadSecureOTLPTLSConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return append(opts, otlptracehttp.WithTLSClientConfig(tlsConfig)), nil
+}

--- a/pkg/sciontool/telemetry/pipeline.go
+++ b/pkg/sciontool/telemetry/pipeline.go
@@ -77,7 +77,7 @@ func (p *Pipeline) Start(ctx context.Context) error {
 
 	// Create cloud exporter if configured
 	if p.config.IsCloudConfigured() {
-		exporter, err := NewCloudExporter(p.config)
+		exporter, err := NewCloudExporter(ctx, p.config)
 		if err != nil {
 			log.Error("Failed to create cloud exporter: %v", err)
 			// Continue without cloud export - receiver can still work for local debugging

--- a/pkg/sciontool/telemetry/providers.go
+++ b/pkg/sciontool/telemetry/providers.go
@@ -21,8 +21,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"google.golang.org/api/option"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 // Providers holds SDK TracerProvider, LoggerProvider, and MeterProvider for OTel export.
@@ -147,28 +145,18 @@ func newGCPProviders(ctx context.Context, config *Config, res *resource.Resource
 
 // newOTLPProviders creates providers using standard OTLP gRPC exporters.
 func newOTLPProviders(ctx context.Context, config *Config, res *resource.Resource, batch bool) (*Providers, error) {
-	// Load GCP dial options if credentials are configured
-	var gcpDialOpts []grpc.DialOption
-	if config.GCPCredentialsFile != "" && !config.Insecure {
-		var err error
-		gcpDialOpts, err = loadGCPDialOptions(ctx, config.GCPCredentialsFile)
-		if err != nil {
-			return nil, fmt.Errorf("loading GCP credentials: %w", err)
-		}
+	gcpDialOpts, err := loadSecureGCPDialOptions(ctx, config)
+	if err != nil {
+		return nil, fmt.Errorf("loading GCP credentials: %w", err)
 	}
 
 	// Create trace exporter (gRPC)
 	traceOpts := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(config.Endpoint),
 	}
-	if config.Insecure {
-		traceOpts = append(traceOpts, otlptracegrpc.WithInsecure())
-	} else {
-		tlsConfig, err := loadOTLPTLSConfig(config.CAFile)
-		if err != nil {
-			return nil, fmt.Errorf("loading OTLP TLS config: %w", err)
-		}
-		traceOpts = append(traceOpts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(tlsConfig)))
+	traceOpts, err = appendOTLPTraceGRPCSecurityOption(traceOpts, config)
+	if err != nil {
+		return nil, fmt.Errorf("loading OTLP TLS config: %w", err)
 	}
 	for _, do := range gcpDialOpts {
 		traceOpts = append(traceOpts, otlptracegrpc.WithDialOption(do))
@@ -182,15 +170,10 @@ func newOTLPProviders(ctx context.Context, config *Config, res *resource.Resourc
 	logOpts := []otlploggrpc.Option{
 		otlploggrpc.WithEndpoint(config.Endpoint),
 	}
-	if config.Insecure {
-		logOpts = append(logOpts, otlploggrpc.WithInsecure())
-	} else {
-		tlsConfig, err := loadOTLPTLSConfig(config.CAFile)
-		if err != nil {
-			_ = traceExporter.Shutdown(ctx)
-			return nil, fmt.Errorf("loading OTLP TLS config: %w", err)
-		}
-		logOpts = append(logOpts, otlploggrpc.WithTLSCredentials(credentials.NewTLS(tlsConfig)))
+	logOpts, err = appendOTLPLogGRPCSecurityOption(logOpts, config)
+	if err != nil {
+		_ = traceExporter.Shutdown(ctx)
+		return nil, fmt.Errorf("loading OTLP TLS config: %w", err)
 	}
 	for _, do := range gcpDialOpts {
 		logOpts = append(logOpts, otlploggrpc.WithDialOption(do))
@@ -205,16 +188,11 @@ func newOTLPProviders(ctx context.Context, config *Config, res *resource.Resourc
 	metricOpts := []otlpmetricgrpc.Option{
 		otlpmetricgrpc.WithEndpoint(config.Endpoint),
 	}
-	if config.Insecure {
-		metricOpts = append(metricOpts, otlpmetricgrpc.WithInsecure())
-	} else {
-		tlsConfig, err := loadOTLPTLSConfig(config.CAFile)
-		if err != nil {
-			_ = traceExporter.Shutdown(ctx)
-			_ = logExporter.Shutdown(ctx)
-			return nil, fmt.Errorf("loading OTLP TLS config: %w", err)
-		}
-		metricOpts = append(metricOpts, otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(tlsConfig)))
+	metricOpts, err = appendOTLPMetricGRPCSecurityOption(metricOpts, config)
+	if err != nil {
+		_ = traceExporter.Shutdown(ctx)
+		_ = logExporter.Shutdown(ctx)
+		return nil, fmt.Errorf("loading OTLP TLS config: %w", err)
 	}
 	for _, do := range gcpDialOpts {
 		metricOpts = append(metricOpts, otlpmetricgrpc.WithDialOption(do))

--- a/pkg/sciontool/telemetry/providers.go
+++ b/pkg/sciontool/telemetry/providers.go
@@ -214,42 +214,36 @@ func newOTLPProviders(ctx context.Context, config *Config, res *resource.Resourc
 // buildProviders constructs TracerProvider, LoggerProvider, and MeterProvider
 // from the given exporters, using either batch or sync processing.
 func buildProviders(res *resource.Resource, traceExp trace.SpanExporter, logExp log.Exporter, metricExp metric.Exporter, batch bool) *Providers {
-	var tp *trace.TracerProvider
-	var lp *log.LoggerProvider
-	var mp *metric.MeterProvider
-
-	if batch {
-		tp = trace.NewTracerProvider(
-			trace.WithResource(res),
-			trace.WithBatcher(traceExp),
-		)
-		lp = log.NewLoggerProvider(
-			log.WithResource(res),
-			log.WithProcessor(log.NewBatchProcessor(logExp)),
-		)
-		mp = metric.NewMeterProvider(
-			metric.WithResource(res),
-			metric.WithReader(metric.NewPeriodicReader(metricExp)),
-		)
-	} else {
-		tp = trace.NewTracerProvider(
-			trace.WithResource(res),
-			trace.WithSyncer(traceExp),
-		)
-		lp = log.NewLoggerProvider(
-			log.WithResource(res),
-			log.WithProcessor(log.NewSimpleProcessor(logExp)),
-		)
-		mp = metric.NewMeterProvider(
-			metric.WithResource(res),
-			metric.WithReader(metric.NewPeriodicReader(metricExp)),
-		)
+	if !batch {
+		return &Providers{
+			TracerProvider: trace.NewTracerProvider(
+				trace.WithResource(res),
+				trace.WithSyncer(traceExp),
+			),
+			LoggerProvider: log.NewLoggerProvider(
+				log.WithResource(res),
+				log.WithProcessor(log.NewSimpleProcessor(logExp)),
+			),
+			MeterProvider: metric.NewMeterProvider(
+				metric.WithResource(res),
+				metric.WithReader(metric.NewPeriodicReader(metricExp)),
+			),
+		}
 	}
 
 	return &Providers{
-		TracerProvider: tp,
-		LoggerProvider: lp,
-		MeterProvider:  mp,
+		TracerProvider: trace.NewTracerProvider(
+			trace.WithResource(res),
+			trace.WithBatcher(traceExp),
+		),
+		LoggerProvider: log.NewLoggerProvider(
+			log.WithResource(res),
+			log.WithProcessor(log.NewBatchProcessor(logExp)),
+		),
+		MeterProvider: metric.NewMeterProvider(
+			metric.WithResource(res),
+			metric.WithReader(metric.NewPeriodicReader(metricExp)),
+		),
 	}
 }
 

--- a/pkg/sciontool/telemetry/providers.go
+++ b/pkg/sciontool/telemetry/providers.go
@@ -22,6 +22,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 // Providers holds SDK TracerProvider, LoggerProvider, and MeterProvider for OTel export.
@@ -162,6 +163,12 @@ func newOTLPProviders(ctx context.Context, config *Config, res *resource.Resourc
 	}
 	if config.Insecure {
 		traceOpts = append(traceOpts, otlptracegrpc.WithInsecure())
+	} else {
+		tlsConfig, err := loadOTLPTLSConfig(config.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("loading OTLP TLS config: %w", err)
+		}
+		traceOpts = append(traceOpts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(tlsConfig)))
 	}
 	for _, do := range gcpDialOpts {
 		traceOpts = append(traceOpts, otlptracegrpc.WithDialOption(do))
@@ -177,6 +184,13 @@ func newOTLPProviders(ctx context.Context, config *Config, res *resource.Resourc
 	}
 	if config.Insecure {
 		logOpts = append(logOpts, otlploggrpc.WithInsecure())
+	} else {
+		tlsConfig, err := loadOTLPTLSConfig(config.CAFile)
+		if err != nil {
+			_ = traceExporter.Shutdown(ctx)
+			return nil, fmt.Errorf("loading OTLP TLS config: %w", err)
+		}
+		logOpts = append(logOpts, otlploggrpc.WithTLSCredentials(credentials.NewTLS(tlsConfig)))
 	}
 	for _, do := range gcpDialOpts {
 		logOpts = append(logOpts, otlploggrpc.WithDialOption(do))
@@ -193,6 +207,14 @@ func newOTLPProviders(ctx context.Context, config *Config, res *resource.Resourc
 	}
 	if config.Insecure {
 		metricOpts = append(metricOpts, otlpmetricgrpc.WithInsecure())
+	} else {
+		tlsConfig, err := loadOTLPTLSConfig(config.CAFile)
+		if err != nil {
+			_ = traceExporter.Shutdown(ctx)
+			_ = logExporter.Shutdown(ctx)
+			return nil, fmt.Errorf("loading OTLP TLS config: %w", err)
+		}
+		metricOpts = append(metricOpts, otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(tlsConfig)))
 	}
 	for _, do := range gcpDialOpts {
 		metricOpts = append(metricOpts, otlpmetricgrpc.WithDialOption(do))


### PR DESCRIPTION
## Summary
- add config support for custom OTLP CA bundle files
- thread the CA file through telemetry config conversion and exporter setup
- add focused coverage for schema/config conversion and CA-backed TLS loading
- proper context support

## Testing
- `go test ./pkg/config ./pkg/sciontool/telemetry -run 'Test.*(Telemetry|OTLP|CA|Bundle).*'`\n