### PR TITLE
Route Hub agent exec through the runtime dispatcher

### DIFF
--- a/pkg/api/agent_actions.go
+++ b/pkg/api/agent_actions.go
@@ -1,0 +1,35 @@
+package api
+
+import "net/http"
+
+const (
+	AgentActionStatus            = "status"
+	AgentActionStart             = "start"
+	AgentActionStop              = "stop"
+	AgentActionRestart           = "restart"
+	AgentActionMessage           = "message"
+	AgentActionMessages          = "messages"
+	AgentActionExec              = "exec"
+	AgentActionRestore           = "restore"
+	AgentActionEnv               = "env"
+	AgentActionTokenRefresh      = "token/refresh"
+	AgentActionRefreshToken      = "refresh-token"
+	AgentActionOutboundMessage   = "outbound-message"
+	AgentActionMessageLogs       = "message-logs"
+	AgentActionMessageLogsStream = "message-logs/stream"
+	AgentActionLogs              = "logs"
+	AgentActionStats             = "stats"
+	AgentActionHasPrompt         = "has-prompt"
+	AgentActionFinalizeEnv       = "finalize-env"
+)
+
+func RuntimeBrokerAgentActionMethod(action string) (string, bool) {
+	switch action {
+	case AgentActionLogs, AgentActionStats, AgentActionHasPrompt:
+		return http.MethodGet, true
+	case AgentActionStart, AgentActionStop, AgentActionRestart, AgentActionMessage, AgentActionExec, AgentActionFinalizeEnv:
+		return http.MethodPost, true
+	default:
+		return "", false
+	}
+}

--- a/pkg/api/agent_actions.go
+++ b/pkg/api/agent_actions.go
@@ -20,4 +20,3 @@ const (
 	AgentActionHasPrompt         = "has-prompt"
 	AgentActionFinalizeEnv       = "finalize-env"
 )
-

--- a/pkg/api/agent_actions.go
+++ b/pkg/api/agent_actions.go
@@ -1,7 +1,5 @@
 package api
 
-import "net/http"
-
 const (
 	AgentActionStatus            = "status"
 	AgentActionStart             = "start"
@@ -23,13 +21,3 @@ const (
 	AgentActionFinalizeEnv       = "finalize-env"
 )
 
-func RuntimeBrokerAgentActionMethod(action string) (string, bool) {
-	switch action {
-	case AgentActionLogs, AgentActionStats, AgentActionHasPrompt:
-		return http.MethodGet, true
-	case AgentActionStart, AgentActionStop, AgentActionRestart, AgentActionMessage, AgentActionExec, AgentActionFinalizeEnv:
-		return http.MethodPost, true
-	default:
-		return "", false
-	}
-}

--- a/pkg/hub/agent_actions.go
+++ b/pkg/hub/agent_actions.go
@@ -1,0 +1,33 @@
+package hub
+
+import (
+	"errors"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+const (
+	agentActionStatus            = "status"
+	agentActionStart             = "start"
+	agentActionStop              = "stop"
+	agentActionRestart           = "restart"
+	agentActionMessage           = "message"
+	agentActionMessages          = "messages"
+	agentActionExec              = "exec"
+	agentActionRestore           = "restore"
+	agentActionEnv               = "env"
+	agentActionTokenRefresh      = "token/refresh"
+	agentActionRefreshToken      = "refresh-token"
+	agentActionOutboundMessage   = "outbound-message"
+	agentActionMessageLogs       = "message-logs"
+	agentActionMessageLogsStream = "message-logs/stream"
+)
+
+var errNoRuntimeBrokerAssigned = errors.New("agent has no runtime broker assigned")
+
+func requireRuntimeBrokerAssigned(agent *store.Agent) error {
+	if agent.RuntimeBrokerID == "" {
+		return errNoRuntimeBrokerAssigned
+	}
+	return nil
+}

--- a/pkg/hub/agent_actions.go
+++ b/pkg/hub/agent_actions.go
@@ -6,23 +6,6 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
-const (
-	agentActionStatus            = "status"
-	agentActionStart             = "start"
-	agentActionStop              = "stop"
-	agentActionRestart           = "restart"
-	agentActionMessage           = "message"
-	agentActionMessages          = "messages"
-	agentActionExec              = "exec"
-	agentActionRestore           = "restore"
-	agentActionEnv               = "env"
-	agentActionTokenRefresh      = "token/refresh"
-	agentActionRefreshToken      = "refresh-token"
-	agentActionOutboundMessage   = "outbound-message"
-	agentActionMessageLogs       = "message-logs"
-	agentActionMessageLogsStream = "message-logs/stream"
-)
-
 var errNoRuntimeBrokerAssigned = errors.New("agent has no runtime broker assigned")
 
 func requireRuntimeBrokerAssigned(agent *store.Agent) error {

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -150,6 +150,9 @@ func (d *mockDispatcher) DispatchAgentCreateWithGather(_ context.Context, agent 
 func (d *mockDispatcher) DispatchAgentLogs(_ context.Context, _ *store.Agent, _ int) (string, error) {
 	return "", nil
 }
+func (d *mockDispatcher) DispatchAgentExec(_ context.Context, _ *store.Agent, _ []string, _ int) (string, error) {
+	return "", nil
+}
 func (d *mockDispatcher) DispatchFinalizeEnv(_ context.Context, _ *store.Agent, _ map[string]string) error {
 	return nil
 }

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -150,8 +150,8 @@ func (d *mockDispatcher) DispatchAgentCreateWithGather(_ context.Context, agent 
 func (d *mockDispatcher) DispatchAgentLogs(_ context.Context, _ *store.Agent, _ int) (string, error) {
 	return "", nil
 }
-func (d *mockDispatcher) DispatchAgentExec(_ context.Context, _ *store.Agent, _ []string, _ int) (string, error) {
-	return "", nil
+func (d *mockDispatcher) DispatchAgentExec(_ context.Context, _ *store.Agent, _ []string, _ int) (string, int, error) {
+	return "", 0, nil
 }
 func (d *mockDispatcher) DispatchFinalizeEnv(_ context.Context, _ *store.Agent, _ map[string]string) error {
 	return nil

--- a/pkg/hub/broker_http_transport.go
+++ b/pkg/hub/broker_http_transport.go
@@ -411,6 +411,38 @@ func (t *brokerHTTPTransport) GetAgentLogs(ctx context.Context, brokerID, broker
 	return string(body), nil
 }
 
+func (t *brokerHTTPTransport) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, error) {
+	endpoint := fmt.Sprintf("%s/api/v1/agents/%s/exec", strings.TrimSuffix(brokerEndpoint, "/"), url.PathEscape(agentID))
+	if groveID != "" {
+		endpoint += "?groveId=" + url.QueryEscape(groveID)
+	}
+
+	body, err := json.Marshal(map[string]interface{}{
+		"command": command,
+		"timeout": timeout,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := t.doRequest(ctx, brokerID, http.MethodPost, endpoint, body)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return "", brokerHTTPError(resp)
+	}
+
+	var result struct {
+		Output string `json:"output"`
+	}
+	if err := t.decodeResponse(resp, &result); err != nil {
+		return "", err
+	}
+	return result.Output, nil
+}
+
 func (t *brokerHTTPTransport) CleanupGrove(ctx context.Context, brokerID, brokerEndpoint, groveSlug string) error {
 	endpoint := fmt.Sprintf("%s/api/v1/groves/%s", strings.TrimSuffix(brokerEndpoint, "/"), url.PathEscape(groveSlug))
 	resp, err := t.doRequest(ctx, brokerID, http.MethodDelete, endpoint, nil)

--- a/pkg/hub/broker_http_transport.go
+++ b/pkg/hub/broker_http_transport.go
@@ -411,7 +411,7 @@ func (t *brokerHTTPTransport) GetAgentLogs(ctx context.Context, brokerID, broker
 	return string(body), nil
 }
 
-func (t *brokerHTTPTransport) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, error) {
+func (t *brokerHTTPTransport) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, int, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/agents/%s/exec", strings.TrimSuffix(brokerEndpoint, "/"), url.PathEscape(agentID))
 	if groveID != "" {
 		endpoint += "?groveId=" + url.QueryEscape(groveID)
@@ -422,25 +422,26 @@ func (t *brokerHTTPTransport) ExecAgent(ctx context.Context, brokerID, brokerEnd
 		"timeout": timeout,
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal request: %w", err)
+		return "", 0, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
 	resp, err := t.doRequest(ctx, brokerID, http.MethodPost, endpoint, body)
 	if err != nil {
-		return "", fmt.Errorf("failed to send request: %w", err)
+		return "", 0, fmt.Errorf("failed to send request: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		return "", brokerHTTPError(resp)
+		return "", 0, brokerHTTPError(resp)
 	}
 
 	var result struct {
-		Output string `json:"output"`
+		Output   string `json:"output"`
+		ExitCode int    `json:"exitCode"`
 	}
 	if err := t.decodeResponse(resp, &result); err != nil {
-		return "", err
+		return "", 0, err
 	}
-	return result.Output, nil
+	return result.Output, result.ExitCode, nil
 }
 
 func (t *brokerHTTPTransport) CleanupGrove(ctx context.Context, brokerID, brokerEndpoint, groveSlug string) error {

--- a/pkg/hub/brokerclient.go
+++ b/pkg/hub/brokerclient.go
@@ -84,7 +84,7 @@ func (c *AuthenticatedBrokerClient) GetAgentLogs(ctx context.Context, brokerID, 
 }
 
 // ExecAgent executes a command in an agent on a remote runtime broker with HMAC authentication.
-func (c *AuthenticatedBrokerClient) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, error) {
+func (c *AuthenticatedBrokerClient) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, int, error) {
 	return c.transport.ExecAgent(ctx, brokerID, brokerEndpoint, agentID, groveID, command, timeout)
 }
 

--- a/pkg/hub/brokerclient.go
+++ b/pkg/hub/brokerclient.go
@@ -83,6 +83,11 @@ func (c *AuthenticatedBrokerClient) GetAgentLogs(ctx context.Context, brokerID, 
 	return c.transport.GetAgentLogs(ctx, brokerID, brokerEndpoint, agentID, groveID, tail)
 }
 
+// ExecAgent executes a command in an agent on a remote runtime broker with HMAC authentication.
+func (c *AuthenticatedBrokerClient) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, error) {
+	return c.transport.ExecAgent(ctx, brokerID, brokerEndpoint, agentID, groveID, command, timeout)
+}
+
 // CleanupGrove asks a broker to remove its local hub-native grove directory with HMAC authentication.
 func (c *AuthenticatedBrokerClient) CleanupGrove(ctx context.Context, brokerID, brokerEndpoint, groveSlug string) error {
 	return c.transport.CleanupGrove(ctx, brokerID, brokerEndpoint, groveSlug)

--- a/pkg/hub/controlchannel_client.go
+++ b/pkg/hub/controlchannel_client.go
@@ -292,7 +292,7 @@ func (c *ControlChannelBrokerClient) GetAgentLogs(ctx context.Context, brokerID,
 }
 
 // ExecAgent executes a command in an agent via control channel.
-func (c *ControlChannelBrokerClient) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, error) {
+func (c *ControlChannelBrokerClient) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, int, error) {
 	_ = brokerEndpoint
 	path := fmt.Sprintf("/api/v1/agents/%s/exec", url.PathEscape(agentID))
 	query := ""
@@ -305,21 +305,22 @@ func (c *ControlChannelBrokerClient) ExecAgent(ctx context.Context, brokerID, br
 		"timeout": timeout,
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal request: %w", err)
+		return "", 0, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
 	resp, err := c.doRequest(ctx, brokerID, "POST", path, query, body)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 
 	var result struct {
-		Output string `json:"output"`
+		Output   string `json:"output"`
+		ExitCode int    `json:"exitCode"`
 	}
 	if err := json.Unmarshal(resp.Body, &result); err != nil {
-		return "", fmt.Errorf("failed to decode response: %w", err)
+		return "", 0, fmt.Errorf("failed to decode response: %w", err)
 	}
-	return result.Output, nil
+	return result.Output, result.ExitCode, nil
 }
 
 func (c *ControlChannelBrokerClient) CleanupGrove(ctx context.Context, brokerID, brokerEndpoint, groveSlug string) error {
@@ -541,7 +542,7 @@ func (c *HybridBrokerClient) GetAgentLogs(ctx context.Context, brokerID, brokerE
 }
 
 // ExecAgent executes a command in an agent, preferring control channel.
-func (c *HybridBrokerClient) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, error) {
+func (c *HybridBrokerClient) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, int, error) {
 	if c.useControlChannel(brokerID) {
 		return c.controlChannel.ExecAgent(ctx, brokerID, brokerEndpoint, agentID, groveID, command, timeout)
 	}

--- a/pkg/hub/controlchannel_client.go
+++ b/pkg/hub/controlchannel_client.go
@@ -291,6 +291,37 @@ func (c *ControlChannelBrokerClient) GetAgentLogs(ctx context.Context, brokerID,
 	return string(resp.Body), nil
 }
 
+// ExecAgent executes a command in an agent via control channel.
+func (c *ControlChannelBrokerClient) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, error) {
+	_ = brokerEndpoint
+	path := fmt.Sprintf("/api/v1/agents/%s/exec", url.PathEscape(agentID))
+	query := ""
+	if groveID != "" {
+		query = "groveId=" + url.QueryEscape(groveID)
+	}
+
+	body, err := json.Marshal(map[string]interface{}{
+		"command": command,
+		"timeout": timeout,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := c.doRequest(ctx, brokerID, "POST", path, query, body)
+	if err != nil {
+		return "", err
+	}
+
+	var result struct {
+		Output string `json:"output"`
+	}
+	if err := json.Unmarshal(resp.Body, &result); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+	return result.Output, nil
+}
+
 func (c *ControlChannelBrokerClient) CleanupGrove(ctx context.Context, brokerID, brokerEndpoint, groveSlug string) error {
 	_ = brokerEndpoint
 	path := fmt.Sprintf("/api/v1/groves/%s", url.PathEscape(groveSlug))
@@ -507,6 +538,14 @@ func (c *HybridBrokerClient) GetAgentLogs(ctx context.Context, brokerID, brokerE
 		return c.controlChannel.GetAgentLogs(ctx, brokerID, brokerEndpoint, agentID, groveID, tail)
 	}
 	return c.httpClient.GetAgentLogs(ctx, brokerID, brokerEndpoint, agentID, groveID, tail)
+}
+
+// ExecAgent executes a command in an agent, preferring control channel.
+func (c *HybridBrokerClient) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, error) {
+	if c.useControlChannel(brokerID) {
+		return c.controlChannel.ExecAgent(ctx, brokerID, brokerEndpoint, agentID, groveID, command, timeout)
+	}
+	return c.httpClient.ExecAgent(ctx, brokerID, brokerEndpoint, agentID, groveID, command, timeout)
 }
 
 func (c *HybridBrokerClient) CleanupGrove(ctx context.Context, brokerID, brokerEndpoint, groveSlug string) error {

--- a/pkg/hub/events_integration_test.go
+++ b/pkg/hub/events_integration_test.go
@@ -59,6 +59,9 @@ func (noopDispatcher) DispatchAgentCreateWithGather(_ context.Context, agent *st
 func (noopDispatcher) DispatchAgentLogs(_ context.Context, _ *store.Agent, _ int) (string, error) {
 	return "", nil
 }
+func (noopDispatcher) DispatchAgentExec(_ context.Context, _ *store.Agent, _ []string, _ int) (string, error) {
+	return "", nil
+}
 func (noopDispatcher) DispatchFinalizeEnv(_ context.Context, _ *store.Agent, _ map[string]string) error {
 	return nil
 }

--- a/pkg/hub/events_integration_test.go
+++ b/pkg/hub/events_integration_test.go
@@ -59,8 +59,8 @@ func (noopDispatcher) DispatchAgentCreateWithGather(_ context.Context, agent *st
 func (noopDispatcher) DispatchAgentLogs(_ context.Context, _ *store.Agent, _ int) (string, error) {
 	return "", nil
 }
-func (noopDispatcher) DispatchAgentExec(_ context.Context, _ *store.Agent, _ []string, _ int) (string, error) {
-	return "", nil
+func (noopDispatcher) DispatchAgentExec(_ context.Context, _ *store.Agent, _ []string, _ int) (string, int, error) {
+	return "", 0, nil
 }
 func (noopDispatcher) DispatchFinalizeEnv(_ context.Context, _ *store.Agent, _ map[string]string) error {
 	return nil

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -1302,11 +1302,11 @@ func (s *Server) handleAgentByID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Handle message-logs (GET endpoints for message audit log)
-	if action == agentActionMessageLogs {
+	if action == api.AgentActionMessageLogs {
 		s.handleAgentMessageLogs(w, r, id)
 		return
 	}
-	if action == agentActionMessageLogsStream {
+	if action == api.AgentActionMessageLogsStream {
 		s.handleAgentMessageLogsStream(w, r, id)
 		return
 	}
@@ -1632,10 +1632,10 @@ func (s *Server) handleAgentAction(w http.ResponseWriter, r *http.Request, id, a
 	// For actions other than status/token refresh and outbound-message
 	// (self-access), we require user or agent authentication
 	// with appropriate scopes. Self-access endpoints enforce their own auth checks.
-	if action != agentActionStatus &&
-		action != agentActionTokenRefresh &&
-		action != agentActionRefreshToken &&
-		action != agentActionOutboundMessage {
+	if action != api.AgentActionStatus &&
+		action != api.AgentActionTokenRefresh &&
+		action != api.AgentActionRefreshToken &&
+		action != api.AgentActionOutboundMessage {
 		userIdent := GetUserIdentityFromContext(r.Context())
 		agentIdent := GetAgentIdentityFromContext(r.Context())
 		if userIdent == nil && agentIdent == nil {
@@ -1676,23 +1676,23 @@ func (s *Server) handleAgentAction(w http.ResponseWriter, r *http.Request, id, a
 	}
 
 	switch action {
-	case agentActionStatus:
+	case api.AgentActionStatus:
 		s.updateAgentStatus(w, r, id)
-	case agentActionStart, agentActionStop, agentActionRestart:
+	case api.AgentActionStart, api.AgentActionStop, api.AgentActionRestart:
 		s.handleAgentLifecycle(w, r, id, action)
-	case agentActionMessage:
+	case api.AgentActionMessage:
 		s.handleAgentMessage(w, r, id)
-	case agentActionExec:
+	case api.AgentActionExec:
 		s.handleAgentExec(w, r, id)
-	case agentActionRestore:
+	case api.AgentActionRestore:
 		s.restoreAgent(w, r, id)
-	case agentActionTokenRefresh:
+	case api.AgentActionTokenRefresh:
 		s.handleAgentTokenRefresh(w, r, id)
-	case agentActionRefreshToken:
+	case api.AgentActionRefreshToken:
 		s.handleAgentGitHubTokenRefresh(w, r, id)
-	case agentActionOutboundMessage:
+	case api.AgentActionOutboundMessage:
 		s.handleAgentOutboundMessage(w, r, id)
-	case agentActionMessages:
+	case api.AgentActionMessages:
 		s.handleAgentMessages(w, r, id)
 	default:
 		NotFound(w, "Action")
@@ -2444,7 +2444,7 @@ func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id
 	dispatcher := s.GetDispatcher()
 
 	switch action {
-	case agentActionStart:
+	case api.AgentActionStart:
 		newPhase = string(state.PhaseRunning)
 		if dispatcher != nil && agent.RuntimeBrokerID != "" {
 			dispatchErr = dispatcher.DispatchAgentStart(ctx, agent, "")
@@ -2454,7 +2454,7 @@ func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id
 				newPhase = agent.Phase
 			}
 		}
-	case agentActionStop:
+	case api.AgentActionStop:
 		newPhase = string(state.PhaseStopped)
 		if dispatcher != nil && agent.RuntimeBrokerID != "" {
 			// Before stopping, sync workspace back for hub-native groves on remote brokers.
@@ -2462,7 +2462,7 @@ func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id
 			s.syncWorkspaceOnStop(ctx, agent)
 			dispatchErr = dispatcher.DispatchAgentStop(ctx, agent)
 		}
-	case agentActionRestart:
+	case api.AgentActionRestart:
 		newPhase = string(state.PhaseRunning)
 		if dispatcher != nil && agent.RuntimeBrokerID != "" {
 			// Restart is implemented as stop + start so that env vars
@@ -2495,12 +2495,12 @@ func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id
 	}
 	// When stopping, also update container status so the hub immediately
 	// reflects the stopped state without waiting for the next heartbeat.
-	if action == agentActionStop {
+	if action == api.AgentActionStop {
 		statusUpdate.ContainerStatus = "stopped"
 		statusUpdate.Activity = ""
 	}
 	// When starting or restarting, propagate container status from broker response
-	if (action == agentActionStart || action == agentActionRestart) && agent.ContainerStatus != "" {
+	if (action == api.AgentActionStart || action == api.AgentActionRestart) && agent.ContainerStatus != "" {
 		statusUpdate.ContainerStatus = agent.ContainerStatus
 	}
 	if err := s.store.UpdateAgentStatus(ctx, id, statusUpdate); err != nil {
@@ -3794,11 +3794,11 @@ func (s *Server) handleGroveRoutes(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check for nested /message-logs path (grove-level message audit log)
-	if subPath == agentActionMessageLogs {
+	if subPath == api.AgentActionMessageLogs {
 		s.handleGroveMessageLogs(w, r, groveID)
 		return
 	}
-	if subPath == agentActionMessageLogsStream {
+	if subPath == api.AgentActionMessageLogsStream {
 		s.handleGroveMessageLogsStream(w, r, groveID)
 		return
 	}
@@ -4256,13 +4256,13 @@ func (s *Server) handleGroveAgentAction(w http.ResponseWriter, r *http.Request, 
 	}
 
 	// Message-logs actions are GET endpoints; handle before the POST-only gate.
-	if action == agentActionMessageLogs || action == agentActionMessageLogsStream {
+	if action == api.AgentActionMessageLogs || action == api.AgentActionMessageLogsStream {
 		resolvedAgent, err := s.resolveGroveAgent(r.Context(), groveID, agentID)
 		if err != nil {
 			writeErrorFromErr(w, err, "")
 			return
 		}
-		if action == agentActionMessageLogs {
+		if action == api.AgentActionMessageLogs {
 			s.handleAgentMessageLogs(w, r, resolvedAgent.ID)
 		} else {
 			s.handleAgentMessageLogsStream(w, r, resolvedAgent.ID)
@@ -4298,7 +4298,7 @@ func (s *Server) handleGroveAgentAction(w http.ResponseWriter, r *http.Request, 
 
 	// For interactive actions, enforce policy-based authorization (owner or admin only)
 	switch action {
-	case agentActionStart, agentActionStop, agentActionRestart, agentActionMessage, agentActionExec:
+	case api.AgentActionStart, api.AgentActionStop, api.AgentActionRestart, api.AgentActionMessage, api.AgentActionExec:
 		if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
 			decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), ActionAttach)
 			if !decision.Allowed {
@@ -4310,19 +4310,19 @@ func (s *Server) handleGroveAgentAction(w http.ResponseWriter, r *http.Request, 
 	}
 
 	switch action {
-	case agentActionStatus:
+	case api.AgentActionStatus:
 		s.updateAgentStatus(w, r, agent.ID)
-	case agentActionStart, agentActionStop, agentActionRestart:
+	case api.AgentActionStart, api.AgentActionStop, api.AgentActionRestart:
 		s.handleAgentLifecycle(w, r, agent.ID, action)
-	case agentActionMessage:
+	case api.AgentActionMessage:
 		s.handleAgentMessage(w, r, agent.ID)
-	case agentActionExec:
+	case api.AgentActionExec:
 		s.handleAgentExec(w, r, agent.ID)
-	case agentActionEnv:
+	case api.AgentActionEnv:
 		s.submitAgentEnv(w, r, groveID, agentID)
-	case agentActionRestore:
+	case api.AgentActionRestore:
 		s.restoreAgent(w, r, agent.ID)
-	case agentActionOutboundMessage:
+	case api.AgentActionOutboundMessage:
 		s.handleAgentOutboundMessage(w, r, agent.ID)
 	default:
 		NotFound(w, "Action")

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -1679,6 +1679,8 @@ func (s *Server) handleAgentAction(w http.ResponseWriter, r *http.Request, id, a
 		s.handleAgentLifecycle(w, r, id, action)
 	case "message":
 		s.handleAgentMessage(w, r, id)
+	case "exec":
+		s.handleAgentExec(w, r, id)
 	case "restore":
 		s.restoreAgent(w, r, id)
 	case "token/refresh":
@@ -1692,6 +1694,50 @@ func (s *Server) handleAgentAction(w http.ResponseWriter, r *http.Request, id, a
 	default:
 		NotFound(w, "Action")
 	}
+}
+
+func (s *Server) handleAgentExec(w http.ResponseWriter, r *http.Request, id string) {
+	ctx := r.Context()
+
+	var req struct {
+		Command []string `json:"command"`
+		Timeout int      `json:"timeout,omitempty"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		BadRequest(w, "Invalid request body: "+err.Error())
+		return
+	}
+	if len(req.Command) == 0 {
+		ValidationError(w, "command is required", nil)
+		return
+	}
+
+	dispatcher := s.GetDispatcher()
+	if dispatcher == nil {
+		ServiceNotReady(w, "Exec dispatch is not available yet — the server may still be starting up")
+		return
+	}
+
+	agent, err := s.store.GetAgent(ctx, id)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+	if agent.RuntimeBrokerID == "" {
+		ServiceNotReady(w, "Agent has no runtime broker assigned — the server may still be starting up")
+		return
+	}
+
+	output, err := dispatcher.DispatchAgentExec(ctx, agent, req.Command, req.Timeout)
+	if err != nil {
+		RuntimeError(w, "Failed to execute command on runtime broker: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"output":   output,
+		"exitCode": 0,
+	})
 }
 
 // handleAgentTokenRefresh handles POST /api/v1/agents/{id}/token/refresh.

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -1302,11 +1302,11 @@ func (s *Server) handleAgentByID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Handle message-logs (GET endpoints for message audit log)
-	if action == "message-logs" {
+	if action == agentActionMessageLogs {
 		s.handleAgentMessageLogs(w, r, id)
 		return
 	}
-	if action == "message-logs/stream" {
+	if action == agentActionMessageLogsStream {
 		s.handleAgentMessageLogsStream(w, r, id)
 		return
 	}
@@ -1629,10 +1629,13 @@ func (s *Server) handleAgentAction(w http.ResponseWriter, r *http.Request, id, a
 		return
 	}
 
-	// For actions other than "status", "token/refresh", "refresh-token", and
-	// "outbound-message" (self-access), we require user or agent authentication
+	// For actions other than status/token refresh and outbound-message
+	// (self-access), we require user or agent authentication
 	// with appropriate scopes. Self-access endpoints enforce their own auth checks.
-	if action != "status" && action != "token/refresh" && action != "refresh-token" && action != "outbound-message" {
+	if action != agentActionStatus &&
+		action != agentActionTokenRefresh &&
+		action != agentActionRefreshToken &&
+		action != agentActionOutboundMessage {
 		userIdent := GetUserIdentityFromContext(r.Context())
 		agentIdent := GetAgentIdentityFromContext(r.Context())
 		if userIdent == nil && agentIdent == nil {
@@ -1673,23 +1676,23 @@ func (s *Server) handleAgentAction(w http.ResponseWriter, r *http.Request, id, a
 	}
 
 	switch action {
-	case "status":
+	case agentActionStatus:
 		s.updateAgentStatus(w, r, id)
-	case "start", "stop", "restart":
+	case agentActionStart, agentActionStop, agentActionRestart:
 		s.handleAgentLifecycle(w, r, id, action)
-	case "message":
+	case agentActionMessage:
 		s.handleAgentMessage(w, r, id)
-	case "exec":
+	case agentActionExec:
 		s.handleAgentExec(w, r, id)
-	case "restore":
+	case agentActionRestore:
 		s.restoreAgent(w, r, id)
-	case "token/refresh":
+	case agentActionTokenRefresh:
 		s.handleAgentTokenRefresh(w, r, id)
-	case "refresh-token":
+	case agentActionRefreshToken:
 		s.handleAgentGitHubTokenRefresh(w, r, id)
-	case "outbound-message":
+	case agentActionOutboundMessage:
 		s.handleAgentOutboundMessage(w, r, id)
-	case "messages":
+	case agentActionMessages:
 		s.handleAgentMessages(w, r, id)
 	default:
 		NotFound(w, "Action")
@@ -2441,7 +2444,7 @@ func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id
 	dispatcher := s.GetDispatcher()
 
 	switch action {
-	case "start":
+	case agentActionStart:
 		newPhase = string(state.PhaseRunning)
 		if dispatcher != nil && agent.RuntimeBrokerID != "" {
 			dispatchErr = dispatcher.DispatchAgentStart(ctx, agent, "")
@@ -2451,7 +2454,7 @@ func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id
 				newPhase = agent.Phase
 			}
 		}
-	case "stop":
+	case agentActionStop:
 		newPhase = string(state.PhaseStopped)
 		if dispatcher != nil && agent.RuntimeBrokerID != "" {
 			// Before stopping, sync workspace back for hub-native groves on remote brokers.
@@ -2459,7 +2462,7 @@ func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id
 			s.syncWorkspaceOnStop(ctx, agent)
 			dispatchErr = dispatcher.DispatchAgentStop(ctx, agent)
 		}
-	case "restart":
+	case agentActionRestart:
 		newPhase = string(state.PhaseRunning)
 		if dispatcher != nil && agent.RuntimeBrokerID != "" {
 			// Restart is implemented as stop + start so that env vars
@@ -2492,12 +2495,12 @@ func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id
 	}
 	// When stopping, also update container status so the hub immediately
 	// reflects the stopped state without waiting for the next heartbeat.
-	if action == "stop" {
+	if action == agentActionStop {
 		statusUpdate.ContainerStatus = "stopped"
 		statusUpdate.Activity = ""
 	}
 	// When starting or restarting, propagate container status from broker response
-	if (action == "start" || action == "restart") && agent.ContainerStatus != "" {
+	if (action == agentActionStart || action == agentActionRestart) && agent.ContainerStatus != "" {
 		statusUpdate.ContainerStatus = agent.ContainerStatus
 	}
 	if err := s.store.UpdateAgentStatus(ctx, id, statusUpdate); err != nil {
@@ -3791,11 +3794,11 @@ func (s *Server) handleGroveRoutes(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check for nested /message-logs path (grove-level message audit log)
-	if subPath == "message-logs" {
+	if subPath == agentActionMessageLogs {
 		s.handleGroveMessageLogs(w, r, groveID)
 		return
 	}
-	if subPath == "message-logs/stream" {
+	if subPath == agentActionMessageLogsStream {
 		s.handleGroveMessageLogsStream(w, r, groveID)
 		return
 	}
@@ -4253,13 +4256,13 @@ func (s *Server) handleGroveAgentAction(w http.ResponseWriter, r *http.Request, 
 	}
 
 	// Message-logs actions are GET endpoints; handle before the POST-only gate.
-	if action == "message-logs" || action == "message-logs/stream" {
+	if action == agentActionMessageLogs || action == agentActionMessageLogsStream {
 		resolvedAgent, err := s.resolveGroveAgent(r.Context(), groveID, agentID)
 		if err != nil {
 			writeErrorFromErr(w, err, "")
 			return
 		}
-		if action == "message-logs" {
+		if action == agentActionMessageLogs {
 			s.handleAgentMessageLogs(w, r, resolvedAgent.ID)
 		} else {
 			s.handleAgentMessageLogsStream(w, r, resolvedAgent.ID)
@@ -4295,7 +4298,7 @@ func (s *Server) handleGroveAgentAction(w http.ResponseWriter, r *http.Request, 
 
 	// For interactive actions, enforce policy-based authorization (owner or admin only)
 	switch action {
-	case "start", "stop", "restart", "message":
+	case agentActionStart, agentActionStop, agentActionRestart, agentActionMessage:
 		if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
 			decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), ActionAttach)
 			if !decision.Allowed {
@@ -4307,17 +4310,17 @@ func (s *Server) handleGroveAgentAction(w http.ResponseWriter, r *http.Request, 
 	}
 
 	switch action {
-	case "status":
+	case agentActionStatus:
 		s.updateAgentStatus(w, r, agent.ID)
-	case "start", "stop", "restart":
+	case agentActionStart, agentActionStop, agentActionRestart:
 		s.handleAgentLifecycle(w, r, agent.ID, action)
-	case "message":
+	case agentActionMessage:
 		s.handleAgentMessage(w, r, agent.ID)
-	case "env":
+	case agentActionEnv:
 		s.submitAgentEnv(w, r, groveID, agentID)
-	case "restore":
+	case agentActionRestore:
 		s.restoreAgent(w, r, agent.ID)
-	case "outbound-message":
+	case agentActionOutboundMessage:
 		s.handleAgentOutboundMessage(w, r, agent.ID)
 	default:
 		NotFound(w, "Action")

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -1714,6 +1714,10 @@ func (s *Server) handleAgentExec(w http.ResponseWriter, r *http.Request, id stri
 		ValidationError(w, "command is required", nil)
 		return
 	}
+	if req.Timeout < 0 {
+		ValidationError(w, "timeout must be non-negative", nil)
+		return
+	}
 
 	dispatcher := s.GetDispatcher()
 	if dispatcher == nil {
@@ -1726,20 +1730,23 @@ func (s *Server) handleAgentExec(w http.ResponseWriter, r *http.Request, id stri
 		writeErrorFromErr(w, err, "")
 		return
 	}
-	if agent.RuntimeBrokerID == "" {
+	if err := requireRuntimeBrokerAssigned(agent); err != nil {
 		ServiceNotReady(w, "Agent has no runtime broker assigned — the server may still be starting up")
 		return
 	}
 
-	output, err := dispatcher.DispatchAgentExec(ctx, agent, req.Command, req.Timeout)
+	output, exitCode, err := dispatcher.DispatchAgentExec(ctx, agent, req.Command, req.Timeout)
 	if err != nil {
 		RuntimeError(w, "Failed to execute command on runtime broker: "+err.Error())
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"output":   output,
-		"exitCode": 0,
+	writeJSON(w, http.StatusOK, struct {
+		Output   string `json:"output"`
+		ExitCode int    `json:"exitCode"`
+	}{
+		Output:   output,
+		ExitCode: exitCode,
 	})
 }
 

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -4298,7 +4298,7 @@ func (s *Server) handleGroveAgentAction(w http.ResponseWriter, r *http.Request, 
 
 	// For interactive actions, enforce policy-based authorization (owner or admin only)
 	switch action {
-	case agentActionStart, agentActionStop, agentActionRestart, agentActionMessage:
+	case agentActionStart, agentActionStop, agentActionRestart, agentActionMessage, agentActionExec:
 		if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
 			decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), ActionAttach)
 			if !decision.Allowed {
@@ -4316,6 +4316,8 @@ func (s *Server) handleGroveAgentAction(w http.ResponseWriter, r *http.Request, 
 		s.handleAgentLifecycle(w, r, agent.ID, action)
 	case agentActionMessage:
 		s.handleAgentMessage(w, r, agent.ID)
+	case agentActionExec:
+		s.handleAgentExec(w, r, agent.ID)
 	case agentActionEnv:
 		s.submitAgentEnv(w, r, groveID, agentID)
 	case agentActionRestore:

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -4006,3 +4006,55 @@ func TestHandleAgentExec_DispatchesToRuntimeBroker(t *testing.T) {
 	assert.Equal(t, "terminal output", resp.Output)
 	assert.Equal(t, 0, resp.ExitCode)
 }
+
+func TestHandleGroveAgentExec_DispatchesToRuntimeBroker(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	grove := &store.Grove{
+		ID:   "grove-exec-grove-route",
+		Name: "Exec Grove Route",
+		Slug: "exec-grove-route",
+	}
+	require.NoError(t, s.CreateGrove(ctx, grove))
+
+	broker := &store.RuntimeBroker{
+		ID:     "broker-exec-grove-route",
+		Name:   "Exec Broker Grove Route",
+		Slug:   "exec-broker-grove-route",
+		Status: store.BrokerStatusOnline,
+	}
+	require.NoError(t, s.CreateRuntimeBroker(ctx, broker))
+	require.NoError(t, s.AddGroveProvider(ctx, &store.GroveProvider{
+		GroveID:    grove.ID,
+		BrokerID:   broker.ID,
+		BrokerName: broker.Name,
+		Status:     store.BrokerStatusOnline,
+	}))
+
+	agent := &store.Agent{
+		ID:              "agent-exec-grove-route",
+		Slug:            "agent-exec-grove-route",
+		Name:            "Exec Agent Grove Route",
+		GroveID:         grove.ID,
+		RuntimeBrokerID: broker.ID,
+		Phase:           string(state.PhaseRunning),
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	srv.SetDispatcher(&createAgentDispatcher{execOutput: "terminal output"})
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/groves/"+grove.ID+"/agents/"+agent.Slug+"/exec", map[string]interface{}{
+		"command": []string{"echo", "hello"},
+		"timeout": 10,
+	})
+	require.Equal(t, http.StatusOK, rec.Code, "response body: %s", rec.Body.String())
+
+	var resp struct {
+		Output   string `json:"output"`
+		ExitCode int    `json:"exitCode"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "terminal output", resp.Output)
+	assert.Equal(t, 0, resp.ExitCode)
+}

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -753,6 +753,7 @@ type createAgentDispatcher struct {
 	createPhase  string // status to set on agent during DispatchAgentCreate
 	deleteCalled bool
 	deleteErr    error
+	execOutput   string
 }
 
 func (d *createAgentDispatcher) DispatchAgentCreate(_ context.Context, agent *store.Agent) error {
@@ -809,6 +810,9 @@ func (d *failingCreateDispatcher) DispatchAgentDelete(_ context.Context, _ *stor
 }
 func (d *createAgentDispatcher) DispatchAgentLogs(_ context.Context, _ *store.Agent, _ int) (string, error) {
 	return "", nil
+}
+func (d *createAgentDispatcher) DispatchAgentExec(_ context.Context, _ *store.Agent, _ []string, _ int) (string, error) {
+	return d.execOutput, nil
 }
 func (d *createAgentDispatcher) DispatchFinalizeEnv(_ context.Context, _ *store.Agent, _ map[string]string) error {
 	return nil
@@ -3949,4 +3953,56 @@ func TestPreserveTerminalPhase(t *testing.T) {
 
 		assert.Equal(t, string(state.PhaseRunning), agent.Phase)
 	})
+}
+
+func TestHandleAgentExec_DispatchesToRuntimeBroker(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	grove := &store.Grove{
+		ID:   "grove-exec",
+		Name: "Exec Grove",
+		Slug: "exec-grove",
+	}
+	require.NoError(t, s.CreateGrove(ctx, grove))
+
+	broker := &store.RuntimeBroker{
+		ID:     "broker-exec",
+		Name:   "Exec Broker",
+		Slug:   "exec-broker",
+		Status: store.BrokerStatusOnline,
+	}
+	require.NoError(t, s.CreateRuntimeBroker(ctx, broker))
+	require.NoError(t, s.AddGroveProvider(ctx, &store.GroveProvider{
+		GroveID:    grove.ID,
+		BrokerID:   broker.ID,
+		BrokerName: broker.Name,
+		Status:     store.BrokerStatusOnline,
+	}))
+
+	agent := &store.Agent{
+		ID:              "agent-exec-1",
+		Slug:            "agent-exec-1",
+		Name:            "Exec Agent",
+		GroveID:         grove.ID,
+		RuntimeBrokerID: broker.ID,
+		Phase:           string(state.PhaseRunning),
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	srv.SetDispatcher(&createAgentDispatcher{execOutput: "terminal output"})
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/agents/"+agent.ID+"/exec", map[string]interface{}{
+		"command": []string{"echo", "hello"},
+		"timeout": 10,
+	})
+	require.Equal(t, http.StatusOK, rec.Code, "response body: %s", rec.Body.String())
+
+	var resp struct {
+		Output   string `json:"output"`
+		ExitCode int    `json:"exitCode"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "terminal output", resp.Output)
+	assert.Equal(t, 0, resp.ExitCode)
 }

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -754,6 +754,7 @@ type createAgentDispatcher struct {
 	deleteCalled bool
 	deleteErr    error
 	execOutput   string
+	execExitCode int
 }
 
 func (d *createAgentDispatcher) DispatchAgentCreate(_ context.Context, agent *store.Agent) error {
@@ -811,8 +812,8 @@ func (d *failingCreateDispatcher) DispatchAgentDelete(_ context.Context, _ *stor
 func (d *createAgentDispatcher) DispatchAgentLogs(_ context.Context, _ *store.Agent, _ int) (string, error) {
 	return "", nil
 }
-func (d *createAgentDispatcher) DispatchAgentExec(_ context.Context, _ *store.Agent, _ []string, _ int) (string, error) {
-	return d.execOutput, nil
+func (d *createAgentDispatcher) DispatchAgentExec(_ context.Context, _ *store.Agent, _ []string, _ int) (string, int, error) {
+	return d.execOutput, d.execExitCode, nil
 }
 func (d *createAgentDispatcher) DispatchFinalizeEnv(_ context.Context, _ *store.Agent, _ map[string]string) error {
 	return nil

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -586,8 +586,8 @@ func (d *HTTPAgentDispatcher) applyBrokerResponse(agent *store.Agent, resp *Remo
 
 // DispatchAgentCreate creates and starts an agent on the runtime broker.
 func (d *HTTPAgentDispatcher) DispatchAgentCreate(ctx context.Context, agent *store.Agent) error {
-	if agent.RuntimeBrokerID == "" {
-		return fmt.Errorf("agent has no runtime broker assigned")
+	if err := requireRuntimeBrokerAssigned(agent); err != nil {
+		return err
 	}
 
 	endpoint, err := d.getBrokerEndpoint(ctx, agent.RuntimeBrokerID)
@@ -611,8 +611,8 @@ func (d *HTTPAgentDispatcher) DispatchAgentCreate(ctx context.Context, agent *st
 
 // DispatchAgentProvision provisions an agent on the runtime broker without starting it.
 func (d *HTTPAgentDispatcher) DispatchAgentProvision(ctx context.Context, agent *store.Agent) error {
-	if agent.RuntimeBrokerID == "" {
-		return fmt.Errorf("agent has no runtime broker assigned")
+	if err := requireRuntimeBrokerAssigned(agent); err != nil {
+		return err
 	}
 
 	endpoint, err := d.getBrokerEndpoint(ctx, agent.RuntimeBrokerID)
@@ -656,8 +656,8 @@ func (d *HTTPAgentDispatcher) DispatchAgentProvision(ctx context.Context, agent 
 // If the broker returns 202 with env requirements, it returns the requirements
 // as the first value instead of an error.
 func (d *HTTPAgentDispatcher) DispatchAgentCreateWithGather(ctx context.Context, agent *store.Agent) (*RemoteEnvRequirementsResponse, error) {
-	if agent.RuntimeBrokerID == "" {
-		return nil, fmt.Errorf("agent has no runtime broker assigned")
+	if err := requireRuntimeBrokerAssigned(agent); err != nil {
+		return nil, err
 	}
 
 	endpoint, err := d.getBrokerEndpoint(ctx, agent.RuntimeBrokerID)
@@ -691,8 +691,8 @@ func (d *HTTPAgentDispatcher) DispatchAgentCreateWithGather(ctx context.Context,
 
 // DispatchFinalizeEnv sends gathered env vars to the broker to complete agent creation.
 func (d *HTTPAgentDispatcher) DispatchFinalizeEnv(ctx context.Context, agent *store.Agent, env map[string]string) error {
-	if agent.RuntimeBrokerID == "" {
-		return fmt.Errorf("agent has no runtime broker assigned")
+	if err := requireRuntimeBrokerAssigned(agent); err != nil {
+		return err
 	}
 
 	endpoint, err := d.getBrokerEndpoint(ctx, agent.RuntimeBrokerID)
@@ -859,8 +859,8 @@ func (d *HTTPAgentDispatcher) buildEnvSources(ctx context.Context, agent *store.
 
 // DispatchAgentStart starts an agent on the runtime broker.
 func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *store.Agent, task string) error {
-	if agent.RuntimeBrokerID == "" {
-		return fmt.Errorf("agent has no runtime broker assigned")
+	if err := requireRuntimeBrokerAssigned(agent); err != nil {
+		return err
 	}
 
 	endpoint, err := d.getBrokerEndpoint(ctx, agent.RuntimeBrokerID)
@@ -1050,8 +1050,8 @@ func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *sto
 
 // DispatchAgentStop stops an agent on the runtime broker.
 func (d *HTTPAgentDispatcher) DispatchAgentStop(ctx context.Context, agent *store.Agent) error {
-	if agent.RuntimeBrokerID == "" {
-		return fmt.Errorf("agent has no runtime broker assigned")
+	if err := requireRuntimeBrokerAssigned(agent); err != nil {
+		return err
 	}
 
 	endpoint, err := d.getBrokerEndpoint(ctx, agent.RuntimeBrokerID)
@@ -1066,8 +1066,8 @@ func (d *HTTPAgentDispatcher) DispatchAgentStop(ctx context.Context, agent *stor
 // It generates a fresh auth token so the restarted container has valid
 // Hub credentials, preventing auth loss across container restarts.
 func (d *HTTPAgentDispatcher) DispatchAgentRestart(ctx context.Context, agent *store.Agent) error {
-	if agent.RuntimeBrokerID == "" {
-		return fmt.Errorf("agent has no runtime broker assigned")
+	if err := requireRuntimeBrokerAssigned(agent); err != nil {
+		return err
 	}
 
 	endpoint, err := d.getBrokerEndpoint(ctx, agent.RuntimeBrokerID)
@@ -1117,8 +1117,8 @@ func (d *HTTPAgentDispatcher) DispatchAgentRestart(ctx context.Context, agent *s
 
 // DispatchAgentDelete deletes an agent from the runtime broker.
 func (d *HTTPAgentDispatcher) DispatchAgentDelete(ctx context.Context, agent *store.Agent, deleteFiles, removeBranch, softDelete bool, deletedAt time.Time) error {
-	if agent.RuntimeBrokerID == "" {
-		return fmt.Errorf("agent has no runtime broker assigned")
+	if err := requireRuntimeBrokerAssigned(agent); err != nil {
+		return err
 	}
 
 	endpoint, err := d.getBrokerEndpoint(ctx, agent.RuntimeBrokerID)
@@ -1131,8 +1131,8 @@ func (d *HTTPAgentDispatcher) DispatchAgentDelete(ctx context.Context, agent *st
 
 // DispatchAgentMessage sends a message to an agent on the runtime broker.
 func (d *HTTPAgentDispatcher) DispatchAgentMessage(ctx context.Context, agent *store.Agent, message string, interrupt bool, structuredMsg *messages.StructuredMessage) error {
-	if agent.RuntimeBrokerID == "" {
-		return fmt.Errorf("agent has no runtime broker assigned")
+	if err := requireRuntimeBrokerAssigned(agent); err != nil {
+		return err
 	}
 
 	endpoint, err := d.getBrokerEndpoint(ctx, agent.RuntimeBrokerID)
@@ -1145,8 +1145,8 @@ func (d *HTTPAgentDispatcher) DispatchAgentMessage(ctx context.Context, agent *s
 
 // DispatchAgentLogs retrieves agent.log content from the runtime broker.
 func (d *HTTPAgentDispatcher) DispatchAgentLogs(ctx context.Context, agent *store.Agent, tail int) (string, error) {
-	if agent.RuntimeBrokerID == "" {
-		return "", fmt.Errorf("agent has no runtime broker assigned")
+	if err := requireRuntimeBrokerAssigned(agent); err != nil {
+		return "", err
 	}
 
 	endpoint, err := d.getBrokerEndpoint(ctx, agent.RuntimeBrokerID)
@@ -1159,8 +1159,8 @@ func (d *HTTPAgentDispatcher) DispatchAgentLogs(ctx context.Context, agent *stor
 
 // DispatchAgentExec executes a command in an agent on the runtime broker.
 func (d *HTTPAgentDispatcher) DispatchAgentExec(ctx context.Context, agent *store.Agent, command []string, timeout int) (string, error) {
-	if agent.RuntimeBrokerID == "" {
-		return "", fmt.Errorf("agent has no runtime broker assigned")
+	if err := requireRuntimeBrokerAssigned(agent); err != nil {
+		return "", err
 	}
 
 	endpoint, err := d.getBrokerEndpoint(ctx, agent.RuntimeBrokerID)
@@ -1173,8 +1173,8 @@ func (d *HTTPAgentDispatcher) DispatchAgentExec(ctx context.Context, agent *stor
 
 // DispatchCheckAgentPrompt checks if an agent has a non-empty prompt.md file.
 func (d *HTTPAgentDispatcher) DispatchCheckAgentPrompt(ctx context.Context, agent *store.Agent) (bool, error) {
-	if agent.RuntimeBrokerID == "" {
-		return false, fmt.Errorf("agent has no runtime broker assigned")
+	if err := requireRuntimeBrokerAssigned(agent); err != nil {
+		return false, err
 	}
 
 	endpoint, err := d.getBrokerEndpoint(ctx, agent.RuntimeBrokerID)

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -91,6 +91,10 @@ func (c *HTTPRuntimeBrokerClient) GetAgentLogs(ctx context.Context, brokerID, br
 	return c.transport.GetAgentLogs(ctx, brokerID, brokerEndpoint, agentID, groveID, tail)
 }
 
+func (c *HTTPRuntimeBrokerClient) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, error) {
+	return c.transport.ExecAgent(ctx, brokerID, brokerEndpoint, agentID, groveID, command, timeout)
+}
+
 func (c *HTTPRuntimeBrokerClient) CleanupGrove(ctx context.Context, brokerID, brokerEndpoint, groveSlug string) error {
 	return c.transport.CleanupGrove(ctx, brokerID, brokerEndpoint, groveSlug)
 }
@@ -1151,6 +1155,20 @@ func (d *HTTPAgentDispatcher) DispatchAgentLogs(ctx context.Context, agent *stor
 	}
 
 	return d.client.GetAgentLogs(ctx, agent.RuntimeBrokerID, endpoint, agent.Slug, agent.GroveID, tail)
+}
+
+// DispatchAgentExec executes a command in an agent on the runtime broker.
+func (d *HTTPAgentDispatcher) DispatchAgentExec(ctx context.Context, agent *store.Agent, command []string, timeout int) (string, error) {
+	if agent.RuntimeBrokerID == "" {
+		return "", fmt.Errorf("agent has no runtime broker assigned")
+	}
+
+	endpoint, err := d.getBrokerEndpoint(ctx, agent.RuntimeBrokerID)
+	if err != nil {
+		return "", err
+	}
+
+	return d.client.ExecAgent(ctx, agent.RuntimeBrokerID, endpoint, agent.Slug, agent.GroveID, command, timeout)
 }
 
 // DispatchCheckAgentPrompt checks if an agent has a non-empty prompt.md file.

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -91,7 +91,7 @@ func (c *HTTPRuntimeBrokerClient) GetAgentLogs(ctx context.Context, brokerID, br
 	return c.transport.GetAgentLogs(ctx, brokerID, brokerEndpoint, agentID, groveID, tail)
 }
 
-func (c *HTTPRuntimeBrokerClient) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, error) {
+func (c *HTTPRuntimeBrokerClient) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, int, error) {
 	return c.transport.ExecAgent(ctx, brokerID, brokerEndpoint, agentID, groveID, command, timeout)
 }
 
@@ -1158,14 +1158,14 @@ func (d *HTTPAgentDispatcher) DispatchAgentLogs(ctx context.Context, agent *stor
 }
 
 // DispatchAgentExec executes a command in an agent on the runtime broker.
-func (d *HTTPAgentDispatcher) DispatchAgentExec(ctx context.Context, agent *store.Agent, command []string, timeout int) (string, error) {
+func (d *HTTPAgentDispatcher) DispatchAgentExec(ctx context.Context, agent *store.Agent, command []string, timeout int) (string, int, error) {
 	if err := requireRuntimeBrokerAssigned(agent); err != nil {
-		return "", err
+		return "", 0, err
 	}
 
 	endpoint, err := d.getBrokerEndpoint(ctx, agent.RuntimeBrokerID)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 
 	return d.client.ExecAgent(ctx, agent.RuntimeBrokerID, endpoint, agent.Slug, agent.GroveID, command, timeout)

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -147,6 +147,16 @@ func (m *mockRuntimeBrokerClient) DeleteAgent(ctx context.Context, brokerID, bro
 	return m.returnErr
 }
 
+func (m *mockRuntimeBrokerClient) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, error) {
+	m.lastBrokerID = brokerID
+	m.lastEndpoint = brokerEndpoint
+	m.lastAgentID = agentID
+	if m.returnErr != nil {
+		return "", m.returnErr
+	}
+	return "mock exec output", nil
+}
+
 func (m *mockRuntimeBrokerClient) MessageAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID, message string, interrupt bool, structuredMsg *messages.StructuredMessage) error {
 	m.messageCalled = true
 	m.lastBrokerID = brokerID

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -147,14 +147,14 @@ func (m *mockRuntimeBrokerClient) DeleteAgent(ctx context.Context, brokerID, bro
 	return m.returnErr
 }
 
-func (m *mockRuntimeBrokerClient) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, error) {
+func (m *mockRuntimeBrokerClient) ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, int, error) {
 	m.lastBrokerID = brokerID
 	m.lastEndpoint = brokerEndpoint
 	m.lastAgentID = agentID
 	if m.returnErr != nil {
-		return "", m.returnErr
+		return "", 0, m.returnErr
 	}
-	return "mock exec output", nil
+	return "mock exec output", 0, nil
 }
 
 func (m *mockRuntimeBrokerClient) MessageAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID, message string, interrupt bool, structuredMsg *messages.StructuredMessage) error {

--- a/pkg/hub/messagebroker_test.go
+++ b/pkg/hub/messagebroker_test.go
@@ -81,8 +81,8 @@ func (d *brokerMockDispatcher) DispatchAgentCreateWithGather(ctx context.Context
 func (d *brokerMockDispatcher) DispatchAgentLogs(_ context.Context, _ *store.Agent, _ int) (string, error) {
 	return "", nil
 }
-func (d *brokerMockDispatcher) DispatchAgentExec(_ context.Context, _ *store.Agent, _ []string, _ int) (string, error) {
-	return "", nil
+func (d *brokerMockDispatcher) DispatchAgentExec(_ context.Context, _ *store.Agent, _ []string, _ int) (string, int, error) {
+	return "", 0, nil
 }
 func (d *brokerMockDispatcher) DispatchFinalizeEnv(ctx context.Context, agent *store.Agent, env map[string]string) error {
 	return nil

--- a/pkg/hub/messagebroker_test.go
+++ b/pkg/hub/messagebroker_test.go
@@ -81,6 +81,9 @@ func (d *brokerMockDispatcher) DispatchAgentCreateWithGather(ctx context.Context
 func (d *brokerMockDispatcher) DispatchAgentLogs(_ context.Context, _ *store.Agent, _ int) (string, error) {
 	return "", nil
 }
+func (d *brokerMockDispatcher) DispatchAgentExec(_ context.Context, _ *store.Agent, _ []string, _ int) (string, error) {
+	return "", nil
+}
 func (d *brokerMockDispatcher) DispatchFinalizeEnv(ctx context.Context, agent *store.Agent, env map[string]string) error {
 	return nil
 }

--- a/pkg/hub/notifications_test.go
+++ b/pkg/hub/notifications_test.go
@@ -89,8 +89,8 @@ func (d *recordingDispatcher) DispatchAgentCreateWithGather(_ context.Context, _
 func (d *recordingDispatcher) DispatchAgentLogs(_ context.Context, _ *store.Agent, _ int) (string, error) {
 	return "", nil
 }
-func (d *recordingDispatcher) DispatchAgentExec(_ context.Context, _ *store.Agent, _ []string, _ int) (string, error) {
-	return "", nil
+func (d *recordingDispatcher) DispatchAgentExec(_ context.Context, _ *store.Agent, _ []string, _ int) (string, int, error) {
+	return "", 0, nil
 }
 func (d *recordingDispatcher) DispatchFinalizeEnv(_ context.Context, _ *store.Agent, _ map[string]string) error {
 	return nil

--- a/pkg/hub/notifications_test.go
+++ b/pkg/hub/notifications_test.go
@@ -89,6 +89,9 @@ func (d *recordingDispatcher) DispatchAgentCreateWithGather(_ context.Context, _
 func (d *recordingDispatcher) DispatchAgentLogs(_ context.Context, _ *store.Agent, _ int) (string, error) {
 	return "", nil
 }
+func (d *recordingDispatcher) DispatchAgentExec(_ context.Context, _ *store.Agent, _ []string, _ int) (string, error) {
+	return "", nil
+}
 func (d *recordingDispatcher) DispatchFinalizeEnv(_ context.Context, _ *store.Agent, _ map[string]string) error {
 	return nil
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -223,6 +223,9 @@ type AgentDispatcher interface {
 	// DispatchAgentLogs retrieves agent.log content from the runtime broker.
 	DispatchAgentLogs(ctx context.Context, agent *store.Agent, tail int) (string, error)
 
+	// DispatchAgentExec executes a command in an agent on the runtime broker.
+	DispatchAgentExec(ctx context.Context, agent *store.Agent, command []string, timeout int) (string, error)
+
 	// DispatchCheckAgentPrompt checks if an agent has a non-empty prompt.md file.
 	DispatchCheckAgentPrompt(ctx context.Context, agent *store.Agent) (bool, error)
 
@@ -294,6 +297,11 @@ type RuntimeBrokerClient interface {
 	// brokerID is used for HMAC authentication lookup.
 	// groveID scopes the lookup to a specific grove (required for uniqueness).
 	GetAgentLogs(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, tail int) (string, error)
+
+	// ExecAgent executes a command in an agent on a remote runtime broker.
+	// brokerID is used for HMAC authentication lookup.
+	// groveID scopes the lookup to a specific grove (required for uniqueness).
+	ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, error)
 
 	// CleanupGrove asks a broker to remove its local hub-native grove directory.
 	// brokerID is used for HMAC authentication lookup.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -224,7 +224,8 @@ type AgentDispatcher interface {
 	DispatchAgentLogs(ctx context.Context, agent *store.Agent, tail int) (string, error)
 
 	// DispatchAgentExec executes a command in an agent on the runtime broker.
-	DispatchAgentExec(ctx context.Context, agent *store.Agent, command []string, timeout int) (string, error)
+	// Returns the command output, exit code, and any error.
+	DispatchAgentExec(ctx context.Context, agent *store.Agent, command []string, timeout int) (string, int, error)
 
 	// DispatchCheckAgentPrompt checks if an agent has a non-empty prompt.md file.
 	DispatchCheckAgentPrompt(ctx context.Context, agent *store.Agent) (bool, error)
@@ -301,7 +302,8 @@ type RuntimeBrokerClient interface {
 	// ExecAgent executes a command in an agent on a remote runtime broker.
 	// brokerID is used for HMAC authentication lookup.
 	// groveID scopes the lookup to a specific grove (required for uniqueness).
-	ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, error)
+	// Returns the command output, exit code, and any error.
+	ExecAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, groveID string, command []string, timeout int) (string, int, error)
 
 	// CleanupGrove asks a broker to remove its local hub-native grove directory.
 	// brokerID is used for HMAC authentication lookup.

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -1279,6 +1279,13 @@ func (s *Server) execCommand(w http.ResponseWriter, r *http.Request, id string) 
 		return
 	}
 
+	// Apply timeout if specified.
+	if req.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(req.Timeout)*time.Second)
+		defer cancel()
+	}
+
 	// Resolve the correct runtime for this agent (may be on an auxiliary runtime like K8s).
 	// Exec doesn't receive groveID from query params (internal operation).
 	rt := s.resolveRuntimeForAgent(ctx, id, "")

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -895,12 +895,7 @@ func (s *Server) deleteAgent(w http.ResponseWriter, r *http.Request, id, groveID
 }
 
 func (s *Server) handleAgentAction(w http.ResponseWriter, r *http.Request, id, groveID, action string) {
-	method, ok := api.RuntimeBrokerAgentActionMethod(action)
-	if !ok {
-		NotFound(w, "Action")
-		return
-	}
-	if r.Method != method {
+	if r.Method != http.MethodPost {
 		MethodNotAllowed(w)
 		return
 	}

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -895,29 +895,34 @@ func (s *Server) deleteAgent(w http.ResponseWriter, r *http.Request, id, groveID
 }
 
 func (s *Server) handleAgentAction(w http.ResponseWriter, r *http.Request, id, groveID, action string) {
-	if r.Method != http.MethodPost {
+	method, ok := api.RuntimeBrokerAgentActionMethod(action)
+	if !ok {
+		NotFound(w, "Action")
+		return
+	}
+	if r.Method != method {
 		MethodNotAllowed(w)
 		return
 	}
 
 	switch action {
-	case "start":
+	case api.AgentActionStart:
 		s.startAgent(w, r, id, groveID)
-	case "stop":
+	case api.AgentActionStop:
 		s.stopAgent(w, r, id, groveID)
-	case "restart":
+	case api.AgentActionRestart:
 		s.restartAgent(w, r, id, groveID)
-	case "message":
+	case api.AgentActionMessage:
 		s.sendMessage(w, r, id, groveID)
-	case "exec":
+	case api.AgentActionExec:
 		s.execCommand(w, r, id)
-	case "logs":
+	case api.AgentActionLogs:
 		s.getLogs(w, r, id, groveID)
-	case "stats":
+	case api.AgentActionStats:
 		s.getStats(w, r, id, groveID)
-	case "has-prompt":
+	case api.AgentActionHasPrompt:
 		s.checkAgentPrompt(w, r, id, groveID)
-	case "finalize-env":
+	case api.AgentActionFinalizeEnv:
 		s.finalizeEnv(w, r, id)
 	default:
 		NotFound(w, "Action")


### PR DESCRIPTION
## Summary
- add Hub-side agent exec dispatch support so `/api/v1/agents/{id}/exec` works
- wire exec through the existing HTTP/control-channel runtime broker clients
- add focused handler and dispatcher coverage for the new exec path

## Validation
- `go test ./pkg/hub -run '^TestHandleAgentExec_DispatchesToRuntimeBroker$|^TestHTTPAgentDispatcher_DispatchAgentMessage$|^TestHTTPAgentDispatcher_DispatchAgentStart_WithGroveProviderPath$|^TestHTTPAgentDispatcher_DispatchAgentMessage_UsesSlugNotName$'`

## Context
This fixes the Hub-side 404 seen from `scion look` against hosted agents: the client already called the Hub exec endpoint, but the server never handled the `exec` action.