### PR TITLE
fix: derive agent phase from container status in runtime List methods

### DIFF
--- a/pkg/runtime/apple_container.go
+++ b/pkg/runtime/apple_container.go
@@ -211,7 +211,7 @@ func (r *AppleContainerRuntime) List(ctx context.Context, labelFilter map[string
 			Labels:          c.Configuration.Labels,
 			Annotations:     c.Configuration.Labels,
 			ContainerStatus: c.Status,
-			Phase:           "created", // Default phase, updated by AgentManager logic
+			Phase:           phaseFromContainerStatus(c.Status),
 			Image:           c.Configuration.Image.Reference,
 			Runtime:         r.Name(),
 		})

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -739,3 +739,20 @@ func writeSecretMap(homeDir string, containerHome string, secrets []api.Resolved
 
 	return os.WriteFile(filepath.Join(secretsDir, "secret-map.json"), data, 0600)
 }
+
+// phaseFromContainerStatus derives an agent phase from a container status string.
+// Container runtimes (podman, docker, apple) report status strings like
+// "Up 5 minutes", "Exited (0) 3 hours ago", or "Created". This function
+// maps those to lifecycle phases so heartbeats report accurate state
+// regardless of whether agent-info.json has been updated.
+func phaseFromContainerStatus(status string) string {
+	lower := strings.ToLower(status)
+	switch {
+	case strings.HasPrefix(lower, "up") || lower == "running":
+		return "running"
+	case strings.HasPrefix(lower, "exited") || lower == "stopped":
+		return "stopped"
+	default:
+		return "created"
+	}
+}

--- a/pkg/runtime/docker.go
+++ b/pkg/runtime/docker.go
@@ -185,7 +185,7 @@ func (r *DockerRuntime) List(ctx context.Context, labelFilter map[string]string)
 				ContainerID:     d.ID,
 				Name:            agentName,
 				ContainerStatus: d.Status,
-				Phase:           "created", // Default phase, updated by AgentManager logic
+				Phase:           phaseFromContainerStatus(d.Status),
 				Image:           d.Image,
 				Labels:          labels,
 				Annotations:     labels,

--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -269,7 +269,7 @@ func (r *PodmanRuntime) List(ctx context.Context, labelFilter map[string]string)
 				ContainerID:     c.Id,
 				Name:            name,
 				ContainerStatus: c.Status,
-				Phase:           "created",
+				Phase:           phaseFromContainerStatus(c.Status),
 				Image:           c.Image,
 				Labels:          labels,
 				Annotations:     labels,


### PR DESCRIPTION
## Summary

- Podman, Docker, and Apple container runtimes hardcode `Phase: "created"` for all containers in `List()`
- When `agent-info.json` loses its phase field (e.g. harness overwrites it with only the activity), the heartbeat sends `created` to the hub, reverting running agents
- Derive phase from container status instead: `Up ...` → `running`, `Exited ...` → `stopped`, else `created`
- Matches the hub's own legacy derivation logic at `pkg/hub/handlers.go:5280-5293`

Fixes #123

## Test plan

- [ ] Start an agent, verify hub shows `running`
- [ ] Interact with agent terminal (triggering harness to overwrite `agent-info.json`)
- [ ] Verify phase stays `running` through subsequent heartbeats
- [ ] Stop agent, verify phase becomes `stopped`