### PR TITLE
fix: pre-trust workspace and remove @default model suffix in Claude harness

### DIFF
--- a/pkg/harness/claude/embeds/settings.json
+++ b/pkg/harness/claude/embeds/settings.json
@@ -1,7 +1,7 @@
 {
     "env": {
-    "ANTHROPIC_MODEL":"claude-opus-4-6@default",
-    "ANTHROPIC_SMALL_FAST_MODEL": "claude-haiku-4-5@20251001"
+    "ANTHROPIC_MODEL":"claude-opus-4-6",
+    "ANTHROPIC_SMALL_FAST_MODEL": "claude-haiku-4-5"
   },
   "autoUpdater": {
     "disabled": true

--- a/pkg/harness/claude_code.go
+++ b/pkg/harness/claude_code.go
@@ -173,9 +173,15 @@ func (c *ClaudeCode) provisionClaudeJSON(agentHome, agentWorkspace string) error
 		return err
 	}
 
-	repoRoot, err := util.RepoRoot()
 	containerWorkspace := "/workspace"
-	if err == nil {
+	// Derive the container workspace path from the agent directory structure.
+	// The host path is like .../grove/.scion/agents/<name>/workspace and maps
+	// to /repo-root/.scion/agents/<name>/workspace inside the container.
+	// Use the .scion/agents/ segment as a reliable anchor rather than
+	// util.RepoRoot() which depends on the broker's working directory.
+	if idx := strings.Index(agentWorkspace, "/.scion/agents/"); idx >= 0 {
+		containerWorkspace = "/repo-root" + agentWorkspace[idx:]
+	} else if repoRoot, err := util.RepoRoot(); err == nil {
 		relWorkspace, err := filepath.Rel(repoRoot, agentWorkspace)
 		if err == nil && !strings.HasPrefix(relWorkspace, "..") && relWorkspace != "." {
 			containerWorkspace = filepath.Join("/repo-root", relWorkspace)
@@ -202,7 +208,7 @@ func (c *ClaudeCode) provisionClaudeJSON(agentHome, agentWorkspace string) error
 			"mcpServers":                              map[string]interface{}{},
 			"enabledMcpjsonServers":                   []interface{}{},
 			"disabledMcpjsonServers":                  []interface{}{},
-			"hasTrustDialogAccepted":                  false,
+			"hasTrustDialogAccepted":                  true,
 			"projectOnboardingSeenCount":              1,
 			"hasClaudeMdExternalIncludesApproved":     false,
 			"hasClaudeMdExternalIncludesWarningShown": false,


### PR DESCRIPTION
## Summary

- Derive container workspace path from `.scion/agents/` directory structure instead of `util.RepoRoot()`. When the broker runs as a systemd service, its CWD is not a git repo, so `RepoRoot()` fails and the trust entry is provisioned for `/workspace` while the actual WORKDIR is `/repo-root/.scion/agents/<name>/workspace`. The mismatch causes Claude to prompt for directory authorization on every session.
- Set `hasTrustDialogAccepted: true` when provisioning new workspace project entries in `.claude.json`.
- Remove `@default` / `@20251001` suffixes from `ANTHROPIC_MODEL` and `ANTHROPIC_SMALL_FAST_MODEL` in embedded `settings.json`. Claude Code does not recognise the `@provider` suffix format and reports the model as invalid.

Fixes #125

## Test plan

- [ ] Start agent via hub with broker running as systemd service
- [ ] Verify no trust dialog on first terminal access
- [ ] Verify Claude uses correct model without manual `/model` selection
- [ ] Verify agent can be used, terminal closed, and re-opened without issues