### PR TITLE
Allow GET for runtime broker agent logs

### DIFF
--- a/pkg/api/agent_actions.go
+++ b/pkg/api/agent_actions.go
@@ -23,6 +23,9 @@ const (
 	AgentActionFinalizeEnv       = "finalize-env"
 )
 
+// RuntimeBrokerAgentActionMethod returns the HTTP method for actions routed
+// through runtimebroker handleAgentAction. It intentionally does not cover
+// every agent action defined in this package.
 func RuntimeBrokerAgentActionMethod(action string) (string, bool) {
 	switch action {
 	case AgentActionLogs, AgentActionStats, AgentActionHasPrompt:

--- a/pkg/api/agent_actions.go
+++ b/pkg/api/agent_actions.go
@@ -1,5 +1,7 @@
 package api
 
+import "net/http"
+
 const (
 	AgentActionStatus            = "status"
 	AgentActionStart             = "start"
@@ -20,3 +22,14 @@ const (
 	AgentActionHasPrompt         = "has-prompt"
 	AgentActionFinalizeEnv       = "finalize-env"
 )
+
+func RuntimeBrokerAgentActionMethod(action string) (string, bool) {
+	switch action {
+	case AgentActionLogs, AgentActionStats, AgentActionHasPrompt:
+		return http.MethodGet, true
+	case AgentActionStart, AgentActionStop, AgentActionRestart, AgentActionMessage, AgentActionExec, AgentActionFinalizeEnv:
+		return http.MethodPost, true
+	default:
+		return "", false
+	}
+}

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -895,7 +895,12 @@ func (s *Server) deleteAgent(w http.ResponseWriter, r *http.Request, id, groveID
 }
 
 func (s *Server) handleAgentAction(w http.ResponseWriter, r *http.Request, id, groveID, action string) {
-	if r.Method != http.MethodPost {
+	method, ok := api.RuntimeBrokerAgentActionMethod(action)
+	if !ok {
+		NotFound(w, "Action")
+		return
+	}
+	if r.Method != method {
 		MethodNotAllowed(w)
 		return
 	}
@@ -919,8 +924,6 @@ func (s *Server) handleAgentAction(w http.ResponseWriter, r *http.Request, id, g
 		s.checkAgentPrompt(w, r, id, groveID)
 	case api.AgentActionFinalizeEnv:
 		s.finalizeEnv(w, r, id)
-	default:
-		NotFound(w, "Action")
 	}
 }
 

--- a/pkg/runtimebroker/handlers_test.go
+++ b/pkg/runtimebroker/handlers_test.go
@@ -505,6 +505,22 @@ func TestMethodNotAllowed(t *testing.T) {
 	}
 }
 
+func TestAgentLogsAllowsGet(t *testing.T) {
+	srv := newTestServer()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agents/test-agent-1/logs", nil)
+	w := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+	if body := strings.TrimSpace(w.Body.String()); body != "mock logs" {
+		t.Fatalf("expected body %q, got %q", "mock logs", body)
+	}
+}
+
 // envCapturingManager captures the environment variables passed to Start().
 // Used for testing that Hub credentials are properly set.
 type envCapturingManager struct {


### PR DESCRIPTION
## Summary
- allow GET for read-only runtime broker agent actions
- keep mutating agent actions restricted to POST
- add coverage for GET agent logs requests

## Testing
- go test ./pkg/runtimebroker -run 'Test(MethodNotAllowed|AgentLogsAllowsGet)$' -count=1