### PR TITLE
Respect explicit Hub endpoint during sync preflight

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -213,6 +213,7 @@ func CheckHubAvailabilityForAgents(grovePath string, excludedAgents []string, sk
 	opts := hubsync.EnsureHubReadyOptions{
 		AutoConfirm:    autoConfirm,
 		NoHub:          noHub,
+		EndpointOverride: hubEndpoint,
 		SkipSync:       skipSync,
 		TargetAgent:    targetAgent,
 		ExcludedAgents: excludedAgents,

--- a/pkg/hubsync/resolve.go
+++ b/pkg/hubsync/resolve.go
@@ -106,7 +106,10 @@ func resolveHubGroveRef(ref string, opts EnsureHubReadyOptions) (*HubContext, er
 			"Enable with: scion config set hub.enabled true")
 	}
 
-	endpoint := getEndpoint(settings)
+	endpoint := opts.EndpointOverride
+	if endpoint == "" {
+		endpoint = getEndpoint(settings)
+	}
 	if endpoint == "" {
 		return nil, fmt.Errorf("hub is enabled but no endpoint configured\n\nConfigure via: scion config set hub.endpoint <url>")
 	}

--- a/pkg/hubsync/sync.go
+++ b/pkg/hubsync/sync.go
@@ -144,6 +144,9 @@ type EnsureHubReadyOptions struct {
 	AutoConfirm bool
 	// NoHub disables Hub integration for this invocation.
 	NoHub bool
+	// EndpointOverride is the explicit Hub endpoint supplied by the caller.
+	// It takes precedence over grove/global settings for this invocation.
+	EndpointOverride string
 	// SkipSync skips agent synchronization check.
 	SkipSync bool
 	// TargetAgent is the agent being operated on. If set, this agent is excluded
@@ -227,7 +230,10 @@ func EnsureHubReady(grovePath string, opts EnsureHubReadyOptions) (*HubContext, 
 	}
 
 	// Hub is enabled - from here on, any failure is an error (no silent fallback)
-	endpoint := getEndpoint(settings)
+	endpoint := opts.EndpointOverride
+	if endpoint == "" {
+		endpoint = getEndpoint(settings)
+	}
 	// In hub context, settings loading may not pick up the env var (e.g. if the
 	// grove path resolves to a synthetic or tmpfs directory without a settings file
 	// and koanf doesn't populate the pointer struct). Fall back to the env var.

--- a/pkg/hubsync/sync_test.go
+++ b/pkg/hubsync/sync_test.go
@@ -112,6 +112,72 @@ hub:
 	}
 }
 
+func TestEnsureHubReady_EndpointOverrideBeatsSettings(t *testing.T) {
+	groveID := "test-override-grove-id"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/healthz":
+			json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		case r.URL.Path == "/api/v1/groves/"+groveID:
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":   groveID,
+				"name": "Override",
+			})
+		case strings.Contains(r.URL.Path, "/agents"):
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"agents":     []interface{}{},
+				"serverTime": time.Now().UTC().Format(time.RFC3339Nano),
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	tmpHome := t.TempDir()
+	globalDir := filepath.Join(tmpHome, ".scion")
+	if err := os.MkdirAll(globalDir, 0755); err != nil {
+		t.Fatalf("Failed to create global dir: %v", err)
+	}
+
+	settingsContent := fmt.Sprintf(`grove_id: %s
+hub:
+  enabled: true
+  endpoint: http://localhost:8080
+`, groveID)
+	if err := os.WriteFile(filepath.Join(globalDir, "settings.yaml"), []byte(settingsContent), 0644); err != nil {
+		t.Fatalf("Failed to write settings: %v", err)
+	}
+
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("SCION_DEV_TOKEN", "test-dev-token")
+	t.Setenv("SCION_AUTH_TOKEN", "")
+	t.Setenv("SCION_HUB_ENDPOINT", "")
+
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpHome); err != nil {
+		t.Fatalf("Failed to chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	hubCtx, err := EnsureHubReady("", EnsureHubReadyOptions{
+		AutoConfirm:      true,
+		SkipSync:         true,
+		EndpointOverride: server.URL,
+	})
+	if err != nil {
+		t.Fatalf("EnsureHubReady returned error: %v", err)
+	}
+	if hubCtx == nil {
+		t.Fatal("EnsureHubReady returned nil; expected hub context when override is set")
+	}
+	if hubCtx.Endpoint != server.URL {
+		t.Fatalf("Endpoint = %q, want %q", hubCtx.Endpoint, server.URL)
+	}
+}
+
 func TestEnsureHubReady_GlobalFallbackWithHubDisabled(t *testing.T) {
 	// When grovePath="" and the resolution falls back to global with hub NOT
 	// enabled, EnsureHubReady should return (nil, nil) - same behavior as before.


### PR DESCRIPTION
## Summary
- honor an explicit --hub endpoint during sync preflight instead of falling back to settings
- thread the selected endpoint through hub sync resolution
- add focused regression coverage for endpoint override behavior

## Testing
- go test ./pkg/hubsync -run 'TestEnsureHubReady_(GlobalFallbackWithHubEnabled|EndpointOverrideBeatsSettings)$' -count=1
- go test ./cmd -run 'Test.*Flag.*Hub.*|TestGetHubEndpoint.*' -count=1