### PR TITLE
Select the agent container for Kubernetes logs

### DIFF
--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -1661,7 +1661,14 @@ func (r *KubernetesRuntime) GetLogs(ctx context.Context, id string) (string, err
 		namespace = r.resolveNamespace(ctx, podName)
 	}
 
-	req := r.Client.Clientset.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{})
+	pod, err := r.Client.Clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	req := r.Client.Clientset.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+		Container: selectLogContainer(pod),
+	})
 	podLogs, err := req.Stream(ctx)
 	if err != nil {
 		return "", err
@@ -1674,6 +1681,21 @@ func (r *KubernetesRuntime) GetLogs(ctx context.Context, id string) (string, err
 	}
 
 	return string(data), nil
+}
+
+func selectLogContainer(pod *corev1.Pod) string {
+	if pod == nil || len(pod.Spec.Containers) == 0 {
+		return ""
+	}
+	if len(pod.Spec.Containers) == 1 {
+		return pod.Spec.Containers[0].Name
+	}
+	for _, container := range pod.Spec.Containers {
+		if container.Name == "agent" {
+			return container.Name
+		}
+	}
+	return pod.Spec.Containers[0].Name
 }
 
 func (r *KubernetesRuntime) Attach(ctx context.Context, id string) error {

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -1691,6 +1691,8 @@ func selectLogContainer(pod *corev1.Pod) string {
 		return pod.Spec.Containers[0].Name
 	}
 	for _, container := range pod.Spec.Containers {
+		// Hosted pods may include sidecars, but the interactive Scion process runs
+		// in the container named "agent". Prefer that container when present.
 		if container.Name == "agent" {
 			return container.Name
 		}

--- a/pkg/runtime/k8s_runtime_test.go
+++ b/pkg/runtime/k8s_runtime_test.go
@@ -235,3 +235,58 @@ func TestKubernetesRuntime_BuildPod_Env(t *testing.T) {
 		t.Errorf("LOGNAME not found in pod env")
 	}
 }
+
+func TestSelectLogContainer(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want string
+	}{
+		{
+			name: "single container",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "agent"}},
+				},
+			},
+			want: "agent",
+		},
+		{
+			name: "prefers agent container in multi-container pod",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "sync-helper"},
+						{Name: "agent"},
+					},
+				},
+			},
+			want: "agent",
+		},
+		{
+			name: "falls back to first container",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "main"},
+						{Name: "sidecar"},
+					},
+				},
+			},
+			want: "main",
+		},
+		{
+			name: "empty pod",
+			pod:  &corev1.Pod{},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := selectLogContainer(tt.pod); got != tt.want {
+				t.Fatalf("selectLogContainer() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- pick the main agent container when fetching logs from multi-container Kubernetes pods
- avoid log retrieval failures that require an explicit container name
- add focused container selection coverage

## Testing
- go test ./pkg/runtime -run 'TestSelectLogContainer$' -count=1