### PR TITLE
clean up k8s starter manifests

### DIFF
--- a/hack/k8s/.gitignore
+++ b/hack/k8s/.gitignore
@@ -1,0 +1,1 @@
+auth-secret.yaml

--- a/hack/k8s/README.md
+++ b/hack/k8s/README.md
@@ -1,0 +1,84 @@
+This directory contains a generic starter deployment for running Scion in Kubernetes.
+
+The base deploys a single Scion combo pod in the `scion` namespace with:
+
+- Hub API
+- Runtime Broker
+- Web dashboard
+- SQLite and local template storage on a PVC
+- a `ClusterIP` service intended for `kubectl port-forward`
+- development auth enabled by default for evaluation and local testing
+
+The base intentionally does not assume any cluster-specific ingress, TLS, telemetry,
+network policy, private registry, or node scheduling setup.
+
+## Prerequisites
+
+Scion does not currently publish pre-built images. Build and push the images you
+want the cluster to use first.
+
+For a quick start:
+
+```bash
+image-build/scripts/build-images.sh \
+  --registry ghcr.io/<your-org> \
+  --target all \
+  --platform linux/amd64 \
+  --push
+```
+
+If your cluster is multi-arch, use `--platform all` instead.
+
+## Configure the base
+
+1. Set the Scion server image:
+
+   ```bash
+   cd hack/k8s
+   kustomize edit set image scion-server=ghcr.io/<your-org>/scion-server:latest
+   ```
+
+2. Edit `settings.yaml`:
+   - set `image_registry` to the registry where your Scion harness images were pushed
+   - keep `server.hub.public_url` as `http://127.0.0.1:8080` if you plan to access Scion through `kubectl port-forward`
+   - change `server.hub.public_url` and `server.auth.dev_mode` before exposing Scion outside the cluster
+
+3. If you want stable web sessions or OAuth, copy `auth-secret.example.yaml` to
+   `auth-secret.yaml`, fill in the values, and apply it before the deployment:
+
+   ```bash
+   cp auth-secret.example.yaml auth-secret.yaml
+   kubectl apply -f auth-secret.yaml
+   ```
+
+The deployment loads `scion-auth` as an optional secret, so the base still works
+without it.
+
+## Deploy
+
+```bash
+kubectl apply -k hack/k8s
+kubectl -n scion rollout status deploy/scion
+kubectl -n scion port-forward svc/scion 8080:80
+```
+
+Open <http://127.0.0.1:8080>.
+
+With the default `dev_mode: true` setting, the web UI can be used without OAuth.
+For CLI access, export the Hub endpoint and the generated dev token:
+
+```bash
+export SCION_HUB_ENDPOINT=http://127.0.0.1:8080
+export SCION_DEV_TOKEN="$(kubectl -n scion exec deploy/scion -- cat /home/scion/.scion/dev-token)"
+```
+
+## Productionizing
+
+Before using this outside a trusted environment:
+
+- set `server.auth.dev_mode: false` in `settings.yaml`
+- create `scion-auth` from `auth-secret.example.yaml`
+- change `server.hub.public_url` to the external URL that users will visit
+- add ingress or Gateway API resources for your cluster
+- add image pull secrets if your server or harness images live in a private registry
+- add network policies that match your cluster's API server, DNS, and egress rules

--- a/hack/k8s/auth-secret.example.yaml
+++ b/hack/k8s/auth-secret.example.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scion-auth
+  namespace: scion
+type: Opaque
+stringData:
+  # Optional but recommended if you want login sessions to survive pod restarts.
+  SCION_SERVER_SESSION_SECRET: "<openssl rand -base64 32>"
+
+  # Example GitHub OAuth credentials. Remove these keys if you are not using GitHub.
+  SCION_SERVER_OAUTH_WEB_GITHUB_CLIENTID: "<github-web-client-id>"
+  SCION_SERVER_OAUTH_WEB_GITHUB_CLIENTSECRET: "<github-web-client-secret>"
+  SCION_SERVER_OAUTH_CLI_GITHUB_CLIENTID: "<github-cli-client-id>"
+  SCION_SERVER_OAUTH_CLI_GITHUB_CLIENTSECRET: "<github-cli-client-secret>"
+
+  # Optional if you want device-flow login.
+  SCION_SERVER_OAUTH_DEVICE_GITHUB_CLIENTID: "<github-device-client-id>"
+  SCION_SERVER_OAUTH_DEVICE_GITHUB_CLIENTSECRET: "<github-device-client-secret>"

--- a/hack/k8s/deployment.yaml
+++ b/hack/k8s/deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scion
+  labels:
+    app.kubernetes.io/name: scion
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: scion
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: scion
+    spec:
+      serviceAccountName: scion
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: scion
+          image: scion-server:latest
+          imagePullPolicy: Always
+          command:
+            - /usr/local/bin/scion
+          args:
+            - server
+            - start
+            - --foreground
+            - --production
+            - --enable-hub
+            - --enable-runtime-broker
+            - --enable-web
+            - --web-port=8080
+            - --runtime-broker-port=9800
+            - --auto-provide
+          env:
+            - name: HOME
+              value: /home/scion
+            - name: SCION_LOG_LEVEL
+              value: info
+          envFrom:
+            - secretRef:
+                name: scion-auth
+                optional: true
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: broker
+              containerPort: 9800
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: state
+              mountPath: /home/scion/.scion
+            - name: settings
+              mountPath: /home/scion/.scion/settings.yaml
+              subPath: settings.yaml
+              readOnly: true
+      volumes:
+        - name: state
+          persistentVolumeClaim:
+            claimName: scion-state
+        - name: settings
+          configMap:
+            name: scion-settings

--- a/hack/k8s/kustomization.yaml
+++ b/hack/k8s/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: scion
+
+configMapGenerator:
+  - name: scion-settings
+    files:
+      - settings.yaml
+
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - rbac.yaml
+  - state-pvc.yaml
+  - deployment.yaml
+  - service.yaml

--- a/hack/k8s/namespace.yaml
+++ b/hack/k8s/namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: scion
+  labels:
+    app.kubernetes.io/name: scion
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/hack/k8s/rbac.yaml
+++ b/hack/k8s/rbac.yaml
@@ -1,0 +1,50 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: scion-runtime-manager
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+      - list
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: scion-runtime-manager
+subjects:
+  - kind: ServiceAccount
+    name: scion
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: scion-runtime-manager

--- a/hack/k8s/service.yaml
+++ b/hack/k8s/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: scion
+spec:
+  selector:
+    app.kubernetes.io/name: scion
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+    - name: broker
+      port: 9800
+      targetPort: broker
+      protocol: TCP

--- a/hack/k8s/serviceaccount.yaml
+++ b/hack/k8s/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scion

--- a/hack/k8s/settings.yaml
+++ b/hack/k8s/settings.yaml
@@ -1,0 +1,40 @@
+schema_version: "1"
+
+active_profile: remote
+
+# Replace this with the registry where you pushed the Scion harness images.
+image_registry: ghcr.io/example
+
+runtimes:
+  kubernetes:
+    type: kubernetes
+    namespace: scion
+    list_all_namespaces: false
+
+profiles:
+  remote:
+    runtime: kubernetes
+
+server:
+  hub:
+    host: 0.0.0.0
+    # This default matches `kubectl port-forward svc/scion 8080:80`.
+    public_url: http://127.0.0.1:8080
+  broker:
+    enabled: true
+    hub_endpoint: http://127.0.0.1:8080
+    # Agent pods need a cluster-reachable endpoint, not the port-forward URL.
+    container_hub_endpoint: http://scion.scion.svc.cluster.local
+    broker_name: scion-k8s
+    broker_nickname: scion
+  database:
+    driver: sqlite
+    url: /home/scion/.scion/hub.db
+  storage:
+    provider: local
+    local_path: /home/scion/.scion/storage
+  auth:
+    # Convenient for evaluation. Disable this before exposing Scion publicly.
+    dev_mode: true
+  secrets:
+    backend: local

--- a/hack/k8s/state-pvc.yaml
+++ b/hack/k8s/state-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: scion-state
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi


### PR DESCRIPTION
## What changed

This replaces the environment-specific `hack/k8s` deployment snapshot with a generic Kubernetes starter for Scion.

The new base:
- deploys a single combo pod with the Hub, runtime broker, and web UI
- uses a simple `ClusterIP` service plus `kubectl port-forward` as the default access path
- keeps local SQLite and template storage on a PVC
- enables dev auth by default for evaluation so the base can run without preconfigured OAuth
- loads an optional `scion-auth` secret for stable sessions and OAuth credentials

It also removes the CarverAuto-specific ingress, Gateway API, telemetry, sealed secret, pull secret, template seeding, and network policy assumptions.

## Why

The previous manifests were tied to one production deployment and were not suitable for upstream use. They encoded private registry paths, sealed secrets, company-specific hostnames, OTLP mTLS wiring, cluster-specific Gateway resources, and node scheduling details.

That made `hack/k8s` hard to reuse and hard to document as a supported starting point for other Kubernetes users.

## User impact

Users now get a smaller starter that can be applied with `kubectl apply -k hack/k8s` after setting their image and registry values.

Clusters with custom ingress, TLS, private registries, OAuth, or network policy requirements can layer those concerns on top of the base instead of having to unwind an opinionated deployment snapshot first.

## Validation

- `kubectl kustomize hack/k8s`
- `kubectl kustomize hack/k8s | kubectl apply --dry-run=client -f -`
