### PR TITLE
Fallback to GitHub for device flow auth

### DIFF
--- a/cmd/hub_auth.go
+++ b/cmd/hub_auth.go
@@ -136,7 +136,7 @@ func runHubAuthLogin(cmd *cobra.Command, args []string) error {
 	}
 
 	if hubAuthNoBrowser || util.IsHeadlessEnvironment() {
-		provider, err := resolveHubAuthProvider(cmd.Context(), client.Auth(), hubclient.OAuthClientTypeDevice, provider)
+		provider, err := resolveExplicitDeviceFlowProvider(cmd.Context(), client.Auth(), provider)
 		if err != nil {
 			return err
 		}
@@ -155,6 +155,13 @@ func runHubAuthLogin(cmd *cobra.Command, args []string) error {
 	}
 
 	return storeTokenAndPrintResult(hubURL, tokenResp)
+}
+
+func resolveExplicitDeviceFlowProvider(ctx context.Context, authSvc hubclient.AuthService, requestedProvider string) (string, error) {
+	if strings.TrimSpace(requestedProvider) == "" {
+		return "", nil
+	}
+	return resolveHubAuthProvider(ctx, authSvc, hubclient.OAuthClientTypeDevice, requestedProvider)
 }
 
 // runBrowserAuthFlow performs the browser-based OAuth flow.

--- a/cmd/hub_auth.go
+++ b/cmd/hub_auth.go
@@ -141,7 +141,7 @@ func runHubAuthLogin(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		// Device authorization flow for headless environments
-		deviceAuth := auth.NewDeviceFlowAuth(client.Auth(), provider)
+		deviceAuth := newDeviceFlowAuth(client.Auth(), provider)
 		tokenResp, err = deviceAuth.Authenticate(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("device flow authentication failed: %w", err)
@@ -155,6 +155,13 @@ func runHubAuthLogin(cmd *cobra.Command, args []string) error {
 	}
 
 	return storeTokenAndPrintResult(hubURL, tokenResp)
+}
+
+func newDeviceFlowAuth(authSvc hubclient.AuthService, provider string) *auth.DeviceFlowAuth {
+	if strings.TrimSpace(provider) == "" {
+		return auth.NewDeviceFlowAuth(authSvc)
+	}
+	return auth.NewDeviceFlowAuth(authSvc, provider)
 }
 
 func resolveExplicitDeviceFlowProvider(ctx context.Context, authSvc hubclient.AuthService, requestedProvider string) (string, error) {

--- a/cmd/hub_auth_test.go
+++ b/cmd/hub_auth_test.go
@@ -146,3 +146,36 @@ func TestResolveHubAuthProvider_NoProviders(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestResolveExplicitDeviceFlowProvider_ImplicitProviderSkipsResolution(t *testing.T) {
+	t.Parallel()
+
+	authSvc := &mockHubAuthService{
+		providersResp: &hubclient.AuthProvidersResponse{
+			ClientType: string(hubclient.OAuthClientTypeDevice),
+			Providers:  hubclient.OAuthProviderOrder(),
+		},
+	}
+
+	got, err := resolveExplicitDeviceFlowProvider(context.Background(), authSvc, "")
+	if err != nil {
+		t.Fatalf("resolveExplicitDeviceFlowProvider returned error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("resolveExplicitDeviceFlowProvider = %q, want empty string", got)
+	}
+}
+
+func TestResolveExplicitDeviceFlowProvider_ExplicitProviderUsesValidation(t *testing.T) {
+	t.Parallel()
+
+	authSvc := &mockHubAuthService{}
+
+	got, err := resolveExplicitDeviceFlowProvider(context.Background(), authSvc, "GitHub")
+	if err != nil {
+		t.Fatalf("resolveExplicitDeviceFlowProvider returned error: %v", err)
+	}
+	if got != "github" {
+		t.Fatalf("resolveExplicitDeviceFlowProvider = %q, want github", got)
+	}
+}

--- a/cmd/hub_auth_test.go
+++ b/cmd/hub_auth_test.go
@@ -16,15 +16,21 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 )
 
 type mockHubAuthService struct {
-	providersResp *hubclient.AuthProvidersResponse
-	providersErr  error
+	providersResp         *hubclient.AuthProvidersResponse
+	providersErr          error
+	requestDeviceCodeFunc func(ctx context.Context, provider string) (*hubclient.DeviceCodeResponse, error)
+	pollDeviceTokenFunc   func(ctx context.Context, deviceCode, provider string) (*hubclient.DeviceTokenPollResponse, error)
+	requestedProviders    []string
+	polledProviders       []string
 }
 
 type mockHubAuthNotImplementedError struct{}
@@ -58,9 +64,17 @@ func (m *mockHubAuthService) ExchangeCode(ctx context.Context, code, callbackURL
 	return nil, mockHubAuthNotImplementedError{}
 }
 func (m *mockHubAuthService) RequestDeviceCode(ctx context.Context, provider string) (*hubclient.DeviceCodeResponse, error) {
+	m.requestedProviders = append(m.requestedProviders, provider)
+	if m.requestDeviceCodeFunc != nil {
+		return m.requestDeviceCodeFunc(ctx, provider)
+	}
 	return nil, mockHubAuthNotImplementedError{}
 }
 func (m *mockHubAuthService) PollDeviceToken(ctx context.Context, deviceCode, provider string) (*hubclient.DeviceTokenPollResponse, error) {
+	m.polledProviders = append(m.polledProviders, provider)
+	if m.pollDeviceTokenFunc != nil {
+		return m.pollDeviceTokenFunc(ctx, deviceCode, provider)
+	}
 	return nil, mockHubAuthNotImplementedError{}
 }
 
@@ -177,5 +191,62 @@ func TestResolveExplicitDeviceFlowProvider_ExplicitProviderUsesValidation(t *tes
 	}
 	if got != "github" {
 		t.Fatalf("resolveExplicitDeviceFlowProvider = %q, want github", got)
+	}
+}
+
+func TestNewDeviceFlowAuth_ImplicitProviderUsesFallbackPath(t *testing.T) {
+	t.Parallel()
+
+	authSvc := &mockHubAuthService{
+		requestDeviceCodeFunc: func(ctx context.Context, provider string) (*hubclient.DeviceCodeResponse, error) {
+			if provider == "google" {
+				return nil, &apiclient.APIError{
+					StatusCode: 400,
+					Code:       apiclient.ErrCodeValidationError,
+					Message:    "OAuth provider not configured for device flow: google",
+				}
+			}
+			if provider == "github" {
+				return &hubclient.DeviceCodeResponse{
+					DeviceCode:      "github-device-code",
+					UserCode:        "GH-1234",
+					VerificationURL: "https://github.com/login/device",
+					ExpiresIn:       300,
+					Interval:        1,
+				}, nil
+			}
+			return nil, fmt.Errorf("unexpected provider: %s", provider)
+		},
+		pollDeviceTokenFunc: func(ctx context.Context, deviceCode, provider string) (*hubclient.DeviceTokenPollResponse, error) {
+			if provider != "github" {
+				return nil, fmt.Errorf("expected github provider during polling, got %s", provider)
+			}
+			return &hubclient.DeviceTokenPollResponse{
+				AccessToken: "github-access-token",
+				ExpiresIn:   3600,
+			}, nil
+		},
+	}
+
+	deviceAuth := newDeviceFlowAuth(authSvc, "")
+
+	resp, err := deviceAuth.Authenticate(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.AccessToken != "github-access-token" {
+		t.Fatalf("expected github access token, got %q", resp.AccessToken)
+	}
+	if got, want := len(authSvc.requestedProviders), 2; got != want {
+		t.Fatalf("expected %d provider attempts, got %d (%v)", want, got, authSvc.requestedProviders)
+	}
+	if authSvc.requestedProviders[0] != "google" || authSvc.requestedProviders[1] != "github" {
+		t.Fatalf("expected provider fallback google -> github, got %v", authSvc.requestedProviders)
+	}
+	if got, want := len(authSvc.polledProviders), 1; got != want {
+		t.Fatalf("expected %d poll provider, got %d (%v)", want, got, authSvc.polledProviders)
+	}
+	if authSvc.polledProviders[0] != "github" {
+		t.Fatalf("expected github polling provider, got %v", authSvc.polledProviders)
 	}
 }

--- a/pkg/hub/auth/device_flow.go
+++ b/pkg/hub/auth/device_flow.go
@@ -121,7 +121,7 @@ func (d *DeviceFlowAuth) Authenticate(ctx context.Context) (*hubclient.CLITokenR
 }
 
 func (d *DeviceFlowAuth) requestDeviceCode(ctx context.Context) (*hubclient.DeviceCodeResponse, string, error) {
-	providers := []string{"google", "github"}
+	providers := hubclient.OAuthProviderOrder()
 	if d.providerExplicit {
 		providers = []string{d.provider}
 	}
@@ -138,9 +138,6 @@ func (d *DeviceFlowAuth) requestDeviceCode(ctx context.Context) (*hubclient.Devi
 		lastErr = err
 	}
 
-	if lastErr == nil {
-		lastErr = fmt.Errorf("no device flow providers available")
-	}
 	return nil, "", lastErr
 }
 

--- a/pkg/hub/auth/device_flow.go
+++ b/pkg/hub/auth/device_flow.go
@@ -40,6 +40,9 @@ type DeviceFlowAuth struct {
 
 // NewDeviceFlowAuth creates a new DeviceFlowAuth.
 func NewDeviceFlowAuth(client hubclient.AuthService, provider ...string) *DeviceFlowAuth {
+	if len(provider) > 1 {
+		panic("NewDeviceFlowAuth accepts at most one provider")
+	}
 	selectedProvider := ""
 	providerExplicit := false
 	if len(provider) > 0 {
@@ -143,7 +146,10 @@ func (d *DeviceFlowAuth) requestDeviceCode(ctx context.Context) (*hubclient.Devi
 
 func isProviderNotConfiguredError(err error) bool {
 	var apiErr *apiclient.APIError
+	// Fallback is intentionally keyed off the current server-side validation
+	// message until the API exposes a dedicated error code for this condition.
+	// Match a shorter substring to reduce coupling to exact wording.
 	return errors.As(err, &apiErr) &&
 		apiErr.Code == apiclient.ErrCodeValidationError &&
-		strings.Contains(apiErr.Message, "OAuth provider not configured for device flow")
+		strings.Contains(strings.ToLower(apiErr.Message), "provider not configured")
 }

--- a/pkg/hub/auth/device_flow.go
+++ b/pkg/hub/auth/device_flow.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 )
 
@@ -31,17 +32,25 @@ var errDeviceFlowProviderRequired = errors.New("device flow provider is required
 // DeviceFlowAuth handles the OAuth 2.0 Device Authorization Grant flow
 // for headless environments where a browser cannot be opened directly.
 type DeviceFlowAuth struct {
-	client   hubclient.AuthService
-	output   io.Writer
-	provider string
+	client           hubclient.AuthService
+	output           io.Writer
+	provider         string
+	providerExplicit bool
 }
 
 // NewDeviceFlowAuth creates a new DeviceFlowAuth.
-func NewDeviceFlowAuth(client hubclient.AuthService, provider string) *DeviceFlowAuth {
+func NewDeviceFlowAuth(client hubclient.AuthService, provider ...string) *DeviceFlowAuth {
+	selectedProvider := ""
+	providerExplicit := false
+	if len(provider) > 0 {
+		selectedProvider = strings.TrimSpace(provider[0])
+		providerExplicit = true
+	}
 	return &DeviceFlowAuth{
-		client:   client,
-		output:   os.Stdout,
-		provider: provider,
+		client:           client,
+		output:           os.Stdout,
+		provider:         selectedProvider,
+		providerExplicit: providerExplicit,
 	}
 }
 
@@ -51,17 +60,15 @@ func NewDeviceFlowAuth(client hubclient.AuthService, provider string) *DeviceFlo
 // 3. Polls for authorization completion
 // 4. Returns the token response on success
 func (d *DeviceFlowAuth) Authenticate(ctx context.Context) (*hubclient.CLITokenResponse, error) {
-	if strings.TrimSpace(d.provider) == "" {
+	if d.providerExplicit && d.provider == "" {
 		return nil, errDeviceFlowProviderRequired
 	}
 
-	// Request device code
-	codeResp, err := d.client.RequestDeviceCode(ctx, d.provider)
+	codeResp, provider, err := d.requestDeviceCode(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to request device code: %w", err)
 	}
 
-	// Display instructions
 	fmt.Fprintf(d.output, "\nTo authenticate, visit:\n\n  %s\n\n", codeResp.VerificationURL)
 	fmt.Fprintf(d.output, "And enter the code: %s\n\n", codeResp.UserCode)
 	if codeResp.VerificationURLComplete != "" {
@@ -69,7 +76,6 @@ func (d *DeviceFlowAuth) Authenticate(ctx context.Context) (*hubclient.CLITokenR
 	}
 	fmt.Fprintf(d.output, "Waiting for authorization...\n")
 
-	// Poll for token
 	interval := time.Duration(codeResp.Interval) * time.Second
 	if interval == 0 {
 		interval = 5 * time.Second
@@ -88,7 +94,7 @@ func (d *DeviceFlowAuth) Authenticate(ctx context.Context) (*hubclient.CLITokenR
 			return nil, fmt.Errorf("device authorization expired")
 		}
 
-		pollResp, err := d.client.PollDeviceToken(ctx, codeResp.DeviceCode, d.provider)
+		pollResp, err := d.client.PollDeviceToken(ctx, codeResp.DeviceCode, provider)
 		if err != nil {
 			return nil, fmt.Errorf("failed to poll device token: %w", err)
 		}
@@ -102,7 +108,6 @@ func (d *DeviceFlowAuth) Authenticate(ctx context.Context) (*hubclient.CLITokenR
 		case "expired_token":
 			return nil, fmt.Errorf("device authorization expired")
 		case "":
-			// Success — no status means we got tokens
 			return &hubclient.CLITokenResponse{
 				AccessToken:  pollResp.AccessToken,
 				RefreshToken: pollResp.RefreshToken,
@@ -113,4 +118,35 @@ func (d *DeviceFlowAuth) Authenticate(ctx context.Context) (*hubclient.CLITokenR
 			return nil, fmt.Errorf("unexpected device token status: %s", pollResp.Status)
 		}
 	}
+}
+
+func (d *DeviceFlowAuth) requestDeviceCode(ctx context.Context) (*hubclient.DeviceCodeResponse, string, error) {
+	providers := []string{"google", "github"}
+	if d.providerExplicit {
+		providers = []string{d.provider}
+	}
+
+	var lastErr error
+	for _, provider := range providers {
+		codeResp, err := d.client.RequestDeviceCode(ctx, provider)
+		if err == nil {
+			return codeResp, provider, nil
+		}
+		if !isProviderNotConfiguredError(err) {
+			return nil, "", err
+		}
+		lastErr = err
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no device flow providers available")
+	}
+	return nil, "", lastErr
+}
+
+func isProviderNotConfiguredError(err error) bool {
+	var apiErr *apiclient.APIError
+	return errors.As(err, &apiErr) &&
+		apiErr.Code == apiclient.ErrCodeValidationError &&
+		strings.Contains(apiErr.Message, "OAuth provider not configured for device flow")
 }

--- a/pkg/hub/auth/device_flow_test.go
+++ b/pkg/hub/auth/device_flow_test.go
@@ -21,18 +21,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 )
 
 // mockAuthService implements hubclient.AuthService for testing.
 type mockAuthService struct {
-	deviceCodeResp     *hubclient.DeviceCodeResponse
-	deviceCodeErr      error
-	pollResponses      []*hubclient.DeviceTokenPollResponse
-	pollErrors         []error
-	pollIndex          int
-	requestedProviders []string
-	polledProviders    []string
+	deviceCodeResp        *hubclient.DeviceCodeResponse
+	deviceCodeErr         error
+	requestDeviceCodeFunc func(ctx context.Context, provider string) (*hubclient.DeviceCodeResponse, error)
+	pollResponses         []*hubclient.DeviceTokenPollResponse
+	pollErrors            []error
+	pollIndex             int
+	pollDeviceTokenFunc   func(ctx context.Context, deviceCode, provider string) (*hubclient.DeviceTokenPollResponse, error)
+	requestedProviders    []string
+	polledProviders       []string
 }
 
 type mockDeviceFlowNotImplementedError struct{}
@@ -68,11 +71,17 @@ func (m *mockAuthService) ExchangeCode(ctx context.Context, code, callbackURL, p
 
 func (m *mockAuthService) RequestDeviceCode(ctx context.Context, provider string) (*hubclient.DeviceCodeResponse, error) {
 	m.requestedProviders = append(m.requestedProviders, provider)
+	if m.requestDeviceCodeFunc != nil {
+		return m.requestDeviceCodeFunc(ctx, provider)
+	}
 	return m.deviceCodeResp, m.deviceCodeErr
 }
 
 func (m *mockAuthService) PollDeviceToken(ctx context.Context, deviceCode, provider string) (*hubclient.DeviceTokenPollResponse, error) {
 	m.polledProviders = append(m.polledProviders, provider)
+	if m.pollDeviceTokenFunc != nil {
+		return m.pollDeviceTokenFunc(ctx, deviceCode, provider)
+	}
 	if m.pollIndex >= len(m.pollResponses) {
 		return nil, fmt.Errorf("no more poll responses")
 	}
@@ -92,7 +101,7 @@ func TestDeviceFlowAuth_Success(t *testing.T) {
 			UserCode:        "ABCD-1234",
 			VerificationURL: "https://example.com/device",
 			ExpiresIn:       300,
-			Interval:        1, // 1 second for fast test
+			Interval:        1,
 		},
 		pollResponses: []*hubclient.DeviceTokenPollResponse{
 			{Status: "authorization_pending"},
@@ -122,10 +131,10 @@ func TestDeviceFlowAuth_Success(t *testing.T) {
 	}
 
 	if resp.AccessToken != "test-access-token" {
-		t.Errorf("expected access token 'test-access-token', got %q", resp.AccessToken)
+		t.Errorf("expected access token %q, got %q", "test-access-token", resp.AccessToken)
 	}
 	if resp.RefreshToken != "test-refresh-token" {
-		t.Errorf("expected refresh token 'test-refresh-token', got %q", resp.RefreshToken)
+		t.Errorf("expected refresh token %q, got %q", "test-refresh-token", resp.RefreshToken)
 	}
 	if resp.User == nil || resp.User.Email != "test@example.com" {
 		t.Error("expected user email 'test@example.com'")
@@ -139,7 +148,6 @@ func TestDeviceFlowAuth_Success(t *testing.T) {
 		}
 	}
 
-	// Check output contains the user code
 	output := buf.String()
 	if !bytes.Contains([]byte(output), []byte("ABCD-1234")) {
 		t.Error("expected output to contain user code")
@@ -176,7 +184,7 @@ func TestDeviceFlowAuth_SlowDown(t *testing.T) {
 	}
 
 	if resp.AccessToken != "token" {
-		t.Errorf("expected access token 'token', got %q", resp.AccessToken)
+		t.Errorf("expected access token %q, got %q", "token", resp.AccessToken)
 	}
 }
 
@@ -189,9 +197,7 @@ func TestDeviceFlowAuth_ExpiredToken(t *testing.T) {
 			ExpiresIn:       300,
 			Interval:        1,
 		},
-		pollResponses: []*hubclient.DeviceTokenPollResponse{
-			{Status: "expired_token"},
-		},
+		pollResponses: []*hubclient.DeviceTokenPollResponse{{Status: "expired_token"}},
 	}
 
 	d := NewDeviceFlowAuth(mock, "google")
@@ -236,7 +242,6 @@ func TestDeviceFlowAuth_ContextCancellation(t *testing.T) {
 			ExpiresIn:       300,
 			Interval:        1,
 		},
-		// No poll responses — context will cancel before we poll
 		pollResponses: []*hubclient.DeviceTokenPollResponse{},
 	}
 
@@ -244,7 +249,6 @@ func TestDeviceFlowAuth_ContextCancellation(t *testing.T) {
 	d.output = &bytes.Buffer{}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	// Cancel immediately
 	cancel()
 
 	_, err := d.Authenticate(ctx)
@@ -257,9 +261,7 @@ func TestDeviceFlowAuth_ContextCancellation(t *testing.T) {
 }
 
 func TestDeviceFlowAuth_DeviceCodeError(t *testing.T) {
-	mock := &mockAuthService{
-		deviceCodeErr: fmt.Errorf("network error"),
-	}
+	mock := &mockAuthService{deviceCodeErr: fmt.Errorf("network error")}
 
 	d := NewDeviceFlowAuth(mock, "google")
 	d.output = &bytes.Buffer{}
@@ -267,5 +269,55 @@ func TestDeviceFlowAuth_DeviceCodeError(t *testing.T) {
 	_, err := d.Authenticate(context.Background())
 	if err == nil {
 		t.Fatal("expected error from device code request")
+	}
+}
+
+func TestDeviceFlowAuth_FallsBackToGitHubWhenGoogleUnavailable(t *testing.T) {
+	mock := &mockAuthService{
+		requestDeviceCodeFunc: func(ctx context.Context, provider string) (*hubclient.DeviceCodeResponse, error) {
+			if provider == "google" {
+				return nil, &apiclient.APIError{
+					StatusCode: 400,
+					Code:       apiclient.ErrCodeValidationError,
+					Message:    "OAuth provider not configured for device flow: google",
+				}
+			}
+			if provider == "github" {
+				return &hubclient.DeviceCodeResponse{
+					DeviceCode:      "github-device-code",
+					UserCode:        "GH-1234",
+					VerificationURL: "https://github.com/login/device",
+					ExpiresIn:       300,
+					Interval:        1,
+				}, nil
+			}
+			return nil, fmt.Errorf("unexpected provider: %s", provider)
+		},
+		pollDeviceTokenFunc: func(ctx context.Context, deviceCode, provider string) (*hubclient.DeviceTokenPollResponse, error) {
+			if provider != "github" {
+				return nil, fmt.Errorf("expected github provider during polling, got %s", provider)
+			}
+			return &hubclient.DeviceTokenPollResponse{
+				AccessToken: "github-access-token",
+				ExpiresIn:   3600,
+			}, nil
+		},
+	}
+
+	d := NewDeviceFlowAuth(mock)
+	d.output = &bytes.Buffer{}
+
+	resp, err := d.Authenticate(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.AccessToken != "github-access-token" {
+		t.Fatalf("expected github access token, got %q", resp.AccessToken)
+	}
+	if got, want := mock.requestedProviders, []string{"google", "github"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("expected provider fallback google -> github, got %v", mock.requestedProviders)
+	}
+	if got, want := mock.polledProviders, []string{"github"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("expected github polling provider, got %v", mock.polledProviders)
 	}
 }


### PR DESCRIPTION
## Summary
- fall back to GitHub when the configured OAuth provider is not available for device flow
- keep the fallback narrowly scoped to the provider-not-configured case
- add focused coverage for the fallback path

## Testing
- go test ./pkg/hub/auth -run "TestDeviceFlowAuth_" -count=1