### PR TITLE
Merge Kubernetes template config fields

### DIFF
--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -788,14 +788,16 @@ func mergeKubernetesConfig(base, override *api.KubernetesConfig) *api.Kubernetes
 		result.ServiceAccountName = override.ServiceAccountName
 	}
 	if override.Resources != nil {
-		result.Resources = override.Resources
+		if result.Resources == nil {
+			result.Resources = &api.K8sResources{}
+		}
+		result.Resources = &api.K8sResources{
+			Requests: mergeMaps(result.Resources.Requests, override.Resources.Requests),
+			Limits:   mergeMaps(result.Resources.Limits, override.Resources.Limits),
+		}
 	}
 	if override.NodeSelector != nil {
-		nodeSelector := make(map[string]string, len(override.NodeSelector))
-		for k, v := range override.NodeSelector {
-			nodeSelector[k] = v
-		}
-		result.NodeSelector = nodeSelector
+		result.NodeSelector = mergeMaps(result.NodeSelector, override.NodeSelector)
 	}
 	if override.Tolerations != nil {
 		result.Tolerations = append([]api.K8sToleration(nil), override.Tolerations...)

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -666,22 +666,7 @@ func MergeScionConfig(base, override *api.ScionConfig) *api.ScionConfig {
 		result.Model = override.Model
 	}
 	if override.Kubernetes != nil {
-		if result.Kubernetes == nil {
-			result.Kubernetes = override.Kubernetes
-		} else {
-			if override.Kubernetes.Context != "" {
-				result.Kubernetes.Context = override.Kubernetes.Context
-			}
-			if override.Kubernetes.Namespace != "" {
-				result.Kubernetes.Namespace = override.Kubernetes.Namespace
-			}
-			if override.Kubernetes.RuntimeClassName != "" {
-				result.Kubernetes.RuntimeClassName = override.Kubernetes.RuntimeClassName
-			}
-			if override.Kubernetes.Resources != nil {
-				result.Kubernetes.Resources = override.Kubernetes.Resources
-			}
-		}
+		result.Kubernetes = mergeKubernetesConfig(result.Kubernetes, override.Kubernetes)
 	}
 	if override.Resources != nil {
 		result.Resources = MergeResourceSpec(result.Resources, override.Resources)
@@ -774,6 +759,55 @@ func MergeScionConfig(base, override *api.ScionConfig) *api.ScionConfig {
 			}
 			result.Info = &infoCopy
 		}
+	}
+
+	return &result
+}
+
+func mergeKubernetesConfig(base, override *api.KubernetesConfig) *api.KubernetesConfig {
+	if override == nil {
+		return base
+	}
+
+	if base == nil {
+		base = &api.KubernetesConfig{}
+	}
+
+	result := *base
+
+	if override.Context != "" {
+		result.Context = override.Context
+	}
+	if override.Namespace != "" {
+		result.Namespace = override.Namespace
+	}
+	if override.RuntimeClassName != "" {
+		result.RuntimeClassName = override.RuntimeClassName
+	}
+	if override.ServiceAccountName != "" {
+		result.ServiceAccountName = override.ServiceAccountName
+	}
+	if override.Resources != nil {
+		result.Resources = override.Resources
+	}
+	if override.NodeSelector != nil {
+		nodeSelector := make(map[string]string, len(override.NodeSelector))
+		for k, v := range override.NodeSelector {
+			nodeSelector[k] = v
+		}
+		result.NodeSelector = nodeSelector
+	}
+	if override.Tolerations != nil {
+		result.Tolerations = append([]api.K8sToleration(nil), override.Tolerations...)
+	}
+	if override.ImagePullPolicy != "" {
+		result.ImagePullPolicy = override.ImagePullPolicy
+	}
+	if override.SharedDirStorageClass != "" {
+		result.SharedDirStorageClass = override.SharedDirStorageClass
+	}
+	if override.SharedDirSize != "" {
+		result.SharedDirSize = override.SharedDirSize
 	}
 
 	return &result

--- a/pkg/config/templates_test.go
+++ b/pkg/config/templates_test.go
@@ -805,10 +805,14 @@ func TestMergeScionConfig_NewFields(t *testing.T) {
 	t.Run("kubernetes override merges all supported fields", func(t *testing.T) {
 		base := &api.ScionConfig{
 			Kubernetes: &api.KubernetesConfig{
-				Context:               "base-ctx",
-				Namespace:             "base-ns",
-				RuntimeClassName:      "base-runtime",
-				ServiceAccountName:    "base-sa",
+				Context:            "base-ctx",
+				Namespace:          "base-ns",
+				RuntimeClassName:   "base-runtime",
+				ServiceAccountName: "base-sa",
+				Resources: &api.K8sResources{
+					Requests: map[string]string{"cpu": "250m"},
+					Limits:   map[string]string{"memory": "512Mi"},
+				},
 				NodeSelector:          map[string]string{"base": "true"},
 				Tolerations:           []api.K8sToleration{{Key: "base", Operator: "Exists"}},
 				ImagePullPolicy:       "IfNotPresent",
@@ -818,10 +822,14 @@ func TestMergeScionConfig_NewFields(t *testing.T) {
 		}
 		override := &api.ScionConfig{
 			Kubernetes: &api.KubernetesConfig{
-				Context:               "override-ctx",
-				Namespace:             "override-ns",
-				RuntimeClassName:      "override-runtime",
-				ServiceAccountName:    "override-sa",
+				Context:            "override-ctx",
+				Namespace:          "override-ns",
+				RuntimeClassName:   "override-runtime",
+				ServiceAccountName: "override-sa",
+				Resources: &api.K8sResources{
+					Requests: map[string]string{"memory": "1Gi"},
+					Limits:   map[string]string{"cpu": "500m"},
+				},
 				NodeSelector:          map[string]string{"override": "true"},
 				Tolerations:           []api.K8sToleration{{Key: "override", Operator: "Equal", Value: "true"}},
 				ImagePullPolicy:       "Never",
@@ -855,8 +863,17 @@ func TestMergeScionConfig_NewFields(t *testing.T) {
 		if got.Kubernetes.SharedDirSize != "20Gi" {
 			t.Errorf("expected SharedDirSize override, got %q", got.Kubernetes.SharedDirSize)
 		}
-		if len(got.Kubernetes.NodeSelector) != 1 || got.Kubernetes.NodeSelector["override"] != "true" {
-			t.Errorf("expected NodeSelector override, got %#v", got.Kubernetes.NodeSelector)
+		if got.Kubernetes.Resources == nil {
+			t.Fatal("expected Resources override to be present")
+		}
+		if got.Kubernetes.Resources.Requests["cpu"] != "250m" || got.Kubernetes.Resources.Requests["memory"] != "1Gi" {
+			t.Errorf("expected Requests maps merged, got %#v", got.Kubernetes.Resources.Requests)
+		}
+		if got.Kubernetes.Resources.Limits["memory"] != "512Mi" || got.Kubernetes.Resources.Limits["cpu"] != "500m" {
+			t.Errorf("expected Limits maps merged, got %#v", got.Kubernetes.Resources.Limits)
+		}
+		if len(got.Kubernetes.NodeSelector) != 2 || got.Kubernetes.NodeSelector["base"] != "true" || got.Kubernetes.NodeSelector["override"] != "true" {
+			t.Errorf("expected NodeSelector merged, got %#v", got.Kubernetes.NodeSelector)
 		}
 		if len(got.Kubernetes.Tolerations) != 1 || got.Kubernetes.Tolerations[0].Key != "override" {
 			t.Errorf("expected Tolerations override, got %#v", got.Kubernetes.Tolerations)

--- a/pkg/config/templates_test.go
+++ b/pkg/config/templates_test.go
@@ -802,6 +802,98 @@ func TestValidateAgnosticTemplate_ValidTemplate(t *testing.T) {
 }
 
 func TestMergeScionConfig_NewFields(t *testing.T) {
+	t.Run("kubernetes override merges all supported fields", func(t *testing.T) {
+		base := &api.ScionConfig{
+			Kubernetes: &api.KubernetesConfig{
+				Context:               "base-ctx",
+				Namespace:             "base-ns",
+				RuntimeClassName:      "base-runtime",
+				ServiceAccountName:    "base-sa",
+				NodeSelector:          map[string]string{"base": "true"},
+				Tolerations:           []api.K8sToleration{{Key: "base", Operator: "Exists"}},
+				ImagePullPolicy:       "IfNotPresent",
+				SharedDirStorageClass: "base-sc",
+				SharedDirSize:         "10Gi",
+			},
+		}
+		override := &api.ScionConfig{
+			Kubernetes: &api.KubernetesConfig{
+				Context:               "override-ctx",
+				Namespace:             "override-ns",
+				RuntimeClassName:      "override-runtime",
+				ServiceAccountName:    "override-sa",
+				NodeSelector:          map[string]string{"override": "true"},
+				Tolerations:           []api.K8sToleration{{Key: "override", Operator: "Equal", Value: "true"}},
+				ImagePullPolicy:       "Never",
+				SharedDirStorageClass: "override-sc",
+				SharedDirSize:         "20Gi",
+			},
+		}
+
+		got := MergeScionConfig(base, override)
+		if got.Kubernetes == nil {
+			t.Fatal("expected Kubernetes config to be present")
+		}
+		if got.Kubernetes.Context != "override-ctx" {
+			t.Errorf("expected Context override, got %q", got.Kubernetes.Context)
+		}
+		if got.Kubernetes.Namespace != "override-ns" {
+			t.Errorf("expected Namespace override, got %q", got.Kubernetes.Namespace)
+		}
+		if got.Kubernetes.RuntimeClassName != "override-runtime" {
+			t.Errorf("expected RuntimeClassName override, got %q", got.Kubernetes.RuntimeClassName)
+		}
+		if got.Kubernetes.ServiceAccountName != "override-sa" {
+			t.Errorf("expected ServiceAccountName override, got %q", got.Kubernetes.ServiceAccountName)
+		}
+		if got.Kubernetes.ImagePullPolicy != "Never" {
+			t.Errorf("expected ImagePullPolicy override, got %q", got.Kubernetes.ImagePullPolicy)
+		}
+		if got.Kubernetes.SharedDirStorageClass != "override-sc" {
+			t.Errorf("expected SharedDirStorageClass override, got %q", got.Kubernetes.SharedDirStorageClass)
+		}
+		if got.Kubernetes.SharedDirSize != "20Gi" {
+			t.Errorf("expected SharedDirSize override, got %q", got.Kubernetes.SharedDirSize)
+		}
+		if len(got.Kubernetes.NodeSelector) != 1 || got.Kubernetes.NodeSelector["override"] != "true" {
+			t.Errorf("expected NodeSelector override, got %#v", got.Kubernetes.NodeSelector)
+		}
+		if len(got.Kubernetes.Tolerations) != 1 || got.Kubernetes.Tolerations[0].Key != "override" {
+			t.Errorf("expected Tolerations override, got %#v", got.Kubernetes.Tolerations)
+		}
+		if base.Kubernetes.ImagePullPolicy != "IfNotPresent" {
+			t.Errorf("expected base Kubernetes config to remain unchanged, got %q", base.Kubernetes.ImagePullPolicy)
+		}
+	})
+
+	t.Run("kubernetes empty override keeps base values", func(t *testing.T) {
+		base := &api.ScionConfig{
+			Kubernetes: &api.KubernetesConfig{
+				ServiceAccountName:    "base-sa",
+				ImagePullPolicy:       "Never",
+				SharedDirStorageClass: "base-sc",
+				SharedDirSize:         "10Gi",
+			},
+		}
+
+		got := MergeScionConfig(base, &api.ScionConfig{Kubernetes: &api.KubernetesConfig{}})
+		if got.Kubernetes == nil {
+			t.Fatal("expected Kubernetes config to be preserved")
+		}
+		if got.Kubernetes.ServiceAccountName != "base-sa" {
+			t.Errorf("expected ServiceAccountName preserved, got %q", got.Kubernetes.ServiceAccountName)
+		}
+		if got.Kubernetes.ImagePullPolicy != "Never" {
+			t.Errorf("expected ImagePullPolicy preserved, got %q", got.Kubernetes.ImagePullPolicy)
+		}
+		if got.Kubernetes.SharedDirStorageClass != "base-sc" {
+			t.Errorf("expected SharedDirStorageClass preserved, got %q", got.Kubernetes.SharedDirStorageClass)
+		}
+		if got.Kubernetes.SharedDirSize != "10Gi" {
+			t.Errorf("expected SharedDirSize preserved, got %q", got.Kubernetes.SharedDirSize)
+		}
+	})
+
 	t.Run("agent_instructions override replaces base", func(t *testing.T) {
 		base := &api.ScionConfig{AgentInstructions: "base-agents.md"}
 		override := &api.ScionConfig{AgentInstructions: "override-agents.md"}


### PR DESCRIPTION
## Summary
- preserve nested Kubernetes template config fields during merge instead of replacing the whole block
- keep inline config overrides and telemetry/task flags intact when template config is merged
- add focused merge coverage for the Kubernetes and telemetry cases used by the integration stack

## Testing
- go test ./pkg/config -run 'TestMergeScionConfig_(NewFields|InlineConfigFields|TaskFlag|Telemetry)' -count=1