### PR TITLE
fix: Maintain user ID when running Podman rootless

### DIFF
--- a/.design/podman-runtime.md
+++ b/.design/podman-runtime.md
@@ -65,12 +65,18 @@ Scion's existing UID/GID synchronization mechanism in `sciontool init` (`cmd/sci
 **Rootful Podman**: This flow works identically to Docker — the container starts as real root and `sciontool init` can freely modify users and drop privileges.
 
 **Rootless Podman**: This is where the key difference lies. In rootless mode:
-- The container runs inside a user namespace where the invoking user is mapped to UID 0 (root) inside the container.
+- The container runs inside a user namespace where the invoking user is mapped to UID 0 (root) inside the container by default.
 - `usermod`/`groupmod` operate on `/etc/passwd` and `/etc/group` inside the container's filesystem layer, which still works within the user namespace.
 - Bind-mounted files appear owned by the mapped UID. By default, the host user's UID maps to root (UID 0) inside the container.
-- The `--userns=keep-id` flag can map the host user's UID to the same UID inside the container instead of to root, but this conflicts with Scion's "start as root, then drop privileges" model.
 
-**Decision**: Use the default user namespace mapping (host UID → container UID 0) and let `sciontool init` handle the remapping as it does today. The `SCION_HOST_UID`/`SCION_HOST_GID` values passed will be the host user's actual UID/GID. Since `usermod`/`groupmod` modify the in-container user database (which is writable in the overlay), this works even in a user namespace. The bind-mounted files will be accessible because rootless Podman maps the host user to container root, and `sciontool init` runs as that mapped root. Do **not** use `--userns=keep-id`.
+The default mapping (host UID → container UID 0) allows `sciontool init` to run privileged operations (usermod, chown) and then drop to the remapped scion user. However, there is a fundamental flaw: after remapping the scion user to the host UID (e.g., 1000), container UID 1000 maps to a **subordinate host UID** (e.g., 100999), not to the actual host user. This makes bind-mounted files unreadable by the host user after the container exits.
+
+**Decision**: Use `--userns=keep-id:uid=1000,gid=1000` to map the host user's UID directly to container UID 1000 (the scion user). This ensures:
+1. Bind-mounted files have correct host-user ownership on both sides.
+2. The container process runs as the scion user (UID 1000), so harness config in `/home/scion` is accessible without remapping.
+3. Works for any host UID (e.g., 501 on macOS, 1000 on Linux) because the `uid=1000` parameter explicitly maps the host user to container UID 1000.
+
+The trade-off is that `sciontool init` cannot perform privileged operations (usermod, groupmod, chown) since PID 1 is no longer root. This is acceptable because with keep-id mapping, the process is already running as the correct container user — no remapping or privilege drop is needed. `setupHostUser()` detects this case (not root, but running as the scion user) and signals `rootless=true` to the supervisor, which sets HOME/USER/LOGNAME without attempting a credential drop.
 
 **Decision**: `PodmanRuntime` should detect rootless mode (via `podman info`) and log the mode at **debug** level. This aids troubleshooting without adding noise at normal log levels.
 
@@ -194,7 +200,7 @@ If CI runs in a container or restricted environment, rootless Podman may not be 
 | 2 | **Rootless diagnostics** | Detect rootless mode via `podman info` and log at debug level. |
 | 3 | **Podman Machine mount validation** | Validate workspace is within `$HOME` on macOS; error with guidance if not. |
 | 4 | **Code structure** | Independent implementation (duplicate from Docker) for clean separation. |
-| 5 | **Rootless UID/GID strategy** | Use default user namespace mapping; let `sciontool init` handle remapping. No `--userns=keep-id`. |
+| 5 | **Rootless UID/GID strategy** | Use `--userns=keep-id:uid=1000,gid=1000` to map host user to container scion user (UID 1000). `sciontool init` detects the non-root scion user and skips privilege operations. |
 | 6 | **Image registry compatibility** | Not an issue — harness configs provide fully-qualified image names. |
 | 7 | **Podman version floor** | Podman 4.x+ minimum; check version during detection and error on older versions. |
 

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -96,7 +96,7 @@ func runInit(args []string) int {
 	}
 
 	// Log startup
-	log.Info("sciontool init starting as PID %d", os.Getpid())
+	log.Info("sciontool init starting as PID %d (uid=%d, gid=%d, euid=%d, egid=%d)", os.Getpid(), os.Getuid(), os.Getgid(), os.Geteuid(), os.Getegid())
 	log.Info("Child command: %v", childArgs)
 	log.Info("Grace period: %s", gracePeriod)
 
@@ -113,6 +113,7 @@ func runInit(args []string) int {
 
 	// Set up scion user UID/GID to match host user
 	targetUID, targetGID, rootless := setupHostUser()
+	log.Info("setupHostUser result: targetUID=%d, targetGID=%d, rootless=%v (now euid=%d, egid=%d)", targetUID, targetGID, rootless, os.Geteuid(), os.Getegid())
 
 	// Chown the log file so the scion user can write to it even if it was created by root
 	if targetUID != 0 {
@@ -327,6 +328,22 @@ func runInit(args []string) int {
 		}
 	}
 
+	// Pre-flight checks: verify key paths are accessible before launching child
+	if rootless {
+		if _, err := os.Stat(agentHome); err != nil {
+			log.Error("Pre-flight: agent home %s is not accessible: %v", agentHome, err)
+		} else if f, err := os.CreateTemp(agentHome, ".scion-preflight-*"); err != nil {
+			log.Error("Pre-flight: cannot write to agent home %s: %v (uid=%d)", agentHome, err, os.Geteuid())
+		} else {
+			os.Remove(f.Name())
+			f.Close()
+			log.Debug("Pre-flight: agent home %s is writable (uid=%d)", agentHome, os.Geteuid())
+		}
+		if _, err := exec.LookPath("tmux"); err != nil {
+			log.Error("Pre-flight: tmux not found on PATH: %v", err)
+		}
+	}
+
 	// Create supervisor with configuration
 	config := supervisor.Config{
 		GracePeriod: gracePeriod,
@@ -375,14 +392,15 @@ func runInit(args []string) int {
 
 	// Wait a moment for process to start, then run post-start hooks
 	// Use a short timeout to detect immediate startup failures
+	log.Debug("Waiting for child process startup (100ms check)...")
 	select {
 	case result := <-exitChan:
 		// Child exited immediately - likely a startup error
 		if result.err != nil {
-			log.Error("Supervisor error: %v", result.err)
+			log.Error("Child exited immediately with error: %v (uid=%d, gid=%d)", result.err, os.Geteuid(), os.Getegid())
 			return 1
 		}
-		log.Info("Child exited with code %d", result.code)
+		log.Info("Child exited immediately with code %d (uid=%d, gid=%d)", result.code, os.Geteuid(), os.Getegid())
 		return result.code
 	case <-time.After(100 * time.Millisecond):
 		// Process appears to be running, execute post-start hooks
@@ -784,8 +802,21 @@ func watchLimitsTriggerFile(ctx context.Context, ch chan<- struct{}) {
 }
 
 func setupHostUser() (int, int, bool) {
-	// Only run if we're root and env vars are set
+	// Only run privilege operations if we're root. When running under
+	// --userns=keep-id (rootless Podman), PID 1 starts as the scion user
+	// (UID 1000) rather than root. In that case, no usermod/groupmod/chown
+	// is needed — the UID already matches the scion user and bind-mounted
+	// files have correct host ownership via the keep-id mapping. We return
+	// rootless=true so the supervisor sets HOME/USER/LOGNAME without
+	// attempting a credential drop.
 	if os.Getuid() != 0 {
+		if scionUser, err := user.Lookup("scion"); err == nil {
+			scionUID, _ := strconv.Atoi(scionUser.Uid)
+			if os.Getuid() == scionUID {
+				log.Info("Already running as scion user (UID %d) in rootless mode, skipping privilege operations", scionUID)
+				return 0, 0, true
+			}
+		}
 		log.Debug("Not running as root, skipping user setup")
 		return 0, 0, false
 	}
@@ -809,10 +840,53 @@ func setupHostUser() (int, int, bool) {
 		return 0, 0, false
 	}
 
+	// Check if the runtime signaled a keep-id user namespace mapping via
+	// SCION_KEEPID_UID (e.g. --userns=keep-id:uid=1000,gid=1000). In this
+	// case, container UID 1000 (scion) already maps to the host user's UID,
+	// so bind-mount ownership is correct without remapping.
+	// However, PID 1 is still UID 0 (from the Dockerfile), which maps to a
+	// subordinate UID in the nested namespace — NOT the host user. Container
+	// UID 0 therefore cannot write to the bind-mounted /home/scion (owned by
+	// the host user). We must drop privileges to the scion user early so
+	// that init's own writes (agent-info.json, scion-env, etc.) succeed.
+	//
+	// Note: We cannot derive this from /proc/self/uid_map because rootless
+	// Podman uses nested namespaces — the uid_map shows the mapping to the
+	// immediate parent namespace, not the host.
+	if keepIDStr := os.Getenv("SCION_KEEPID_UID"); keepIDStr != "" {
+		log.Debug("Keep-id env detected: SCION_KEEPID_UID=%s, current euid=%d, egid=%d", keepIDStr, os.Geteuid(), os.Getegid())
+		keepIDUID, parseErr := strconv.Atoi(keepIDStr)
+		if parseErr == nil {
+			if scionUser, err := user.Lookup("scion"); err == nil {
+				scionUID, _ := strconv.Atoi(scionUser.Uid)
+				scionGID, _ := strconv.Atoi(scionUser.Gid)
+				log.Debug("Keep-id: scion user lookup: UID=%d, GID=%d, keepIDUID=%d", scionUID, scionGID, keepIDUID)
+				if keepIDUID == scionUID {
+					log.Info("Keep-id mode: host user mapped to scion (container UID %d); performing early privilege drop", scionUID)
+					if err := syscall.Setgroups([]int{scionGID}); err != nil {
+						log.Error("Failed to setgroups([%d]): %v", scionGID, err)
+					}
+					if err := syscall.Setgid(scionGID); err != nil {
+						log.Error("Failed to setgid(%d): %v — continuing as root, writes to /home/scion may fail", scionGID, err)
+					}
+					if err := syscall.Setuid(scionUID); err != nil {
+						log.Error("Failed to setuid(%d): %v — continuing as root, writes to /home/scion may fail", scionUID, err)
+					}
+					log.Info("Keep-id privilege drop complete: now euid=%d, egid=%d", os.Geteuid(), os.Getegid())
+					return 0, 0, true
+				}
+			} else {
+				log.Error("Keep-id: failed to look up scion user: %v", err)
+			}
+		} else {
+			log.Error("Keep-id: failed to parse SCION_KEEPID_UID=%q: %v", keepIDStr, parseErr)
+		}
+	}
+
 	// Check if the target UID is mapped in the current user namespace.
-	// In rootless Podman, the host user's UID is mapped to container UID 0,
-	// and only a limited range of subordinate UIDs are available inside the
-	// container. If the target UID falls outside any mapped range, chown
+	// In rootless Podman without keep-id, the host user's UID is mapped to
+	// container UID 0, and only a limited range of subordinate UIDs are
+	// available. If the target UID falls outside any mapped range, chown
 	// and credential-based exec would fail with EINVAL. In this case, skip
 	// remapping and run as container root (which IS the host user).
 	if !isUIDMapped(uid) {

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -308,6 +308,22 @@ func buildCommonRunArgs(config RunConfig) ([]string, error) {
 		}
 	}
 
+	// Pre-create parent directories on the host for any volume targeting a
+	// path under the container home directory.  When the home dir is itself a
+	// bind mount, the container runtime (crun/runc) will try to mkdir the
+	// mount-point inside that mount.  On rootless Podman with VirtioFS (macOS)
+	// this fails with "Permission denied" unless the directory already exists.
+	if config.HomeDir != "" {
+		containerHome := util.GetHomeDir(config.UnixUsername)
+		for _, tgt := range volumeOrder {
+			if strings.HasPrefix(tgt, containerHome+"/") {
+				rel := strings.TrimPrefix(tgt, containerHome+"/")
+				hostDir := filepath.Join(config.HomeDir, rel)
+				_ = os.MkdirAll(hostDir, 0755)
+			}
+		}
+	}
+
 	// Add all registered volumes
 	for _, tgt := range volumeOrder {
 		addArg("-v", volumeMap[tgt])

--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -66,9 +66,9 @@ type Runtime interface {
 	// GetWorkspacePath returns the host path to the container's /workspace mount.
 	// This is used for workspace sync operations.
 	GetWorkspacePath(ctx context.Context, id string) (string, error)
-	// ExecUser returns the container user for exec/attach commands. Most
-	// runtimes return "scion". Rootless Podman returns "root" because the
-	// child process runs as UID 0 (which maps to the unprivileged host user).
+	// ExecUser returns the container user for exec/attach commands.
+	// All runtimes return "scion" — the tmux session runs under the scion
+	// user after sciontool init sets up the environment.
 	ExecUser() string
 }
 

--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -153,10 +153,25 @@ func (r *PodmanRuntime) Run(ctx context.Context, config RunConfig) (string, erro
 	// so we don't use --init to avoid competing init processes.
 	newArgs := []string{"run", "-t"}
 
-	// In rootless mode, map the host user's UID into the container so that
-	// bind-mounted files have the correct ownership on both sides.
+	// In rootless mode, map the host user's UID into the container as UID
+	// 1000 (the scion user created in the Dockerfile). This ensures:
+	//  1. Bind-mounted files have correct host-user ownership on both sides.
+	//  2. The process runs as the scion user (UID 1000) inside the container,
+	//     so harness config in /home/scion is accessible.
+	// Without the uid/gid mapping, --userns=keep-id would only work when the
+	// host user happens to be UID 1000. The explicit mapping handles any host
+	// UID (e.g., 501 on macOS).
+	//
+	// SCION_KEEPID_UID tells sciontool init that the host user is mapped to
+	// this container UID via keep-id, so it should drop privileges to that
+	// UID early instead of trying to remap the scion user via usermod.
+	// This env var is necessary because /proc/self/uid_map inside the
+	// container only shows the mapping to the immediate parent namespace
+	// (Podman's namespace), not the host — so init cannot derive this from
+	// the uid_map alone.
 	if r.Rootless {
-		newArgs = append(newArgs, "--userns=keep-id")
+		newArgs = append(newArgs, "--userns=keep-id:uid=1000,gid=1000")
+		newArgs = append(newArgs, "-e", "SCION_KEEPID_UID=1000")
 	}
 
 	// Apply resource constraints from config.

--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -153,6 +153,12 @@ func (r *PodmanRuntime) Run(ctx context.Context, config RunConfig) (string, erro
 	// so we don't use --init to avoid competing init processes.
 	newArgs := []string{"run", "-t"}
 
+	// In rootless mode, map the host user's UID into the container so that
+	// bind-mounted files have the correct ownership on both sides.
+	if r.Rootless {
+		newArgs = append(newArgs, "--userns=keep-id")
+	}
+
 	// Apply resource constraints from config.
 	if config.Resources != nil {
 		if config.Resources.Limits.Memory != "" {

--- a/pkg/runtime/podman_test.go
+++ b/pkg/runtime/podman_test.go
@@ -124,6 +124,57 @@ func TestPodmanRuntime_ExecUserMethod(t *testing.T) {
 	})
 }
 
+func TestPodmanRuntime_Run_RootlessKeepID(t *testing.T) {
+	tmpDir := t.TempDir()
+	mockPodman := filepath.Join(tmpDir, "mock-podman")
+
+	script := `#!/bin/sh
+echo "$@"
+`
+	if err := os.WriteFile(mockPodman, []byte(script), 0755); err != nil {
+		t.Fatalf("failed to write mock podman: %v", err)
+	}
+
+	t.Run("rootless adds --userns=keep-id with uid/gid mapping and env var", func(t *testing.T) {
+		rt := &PodmanRuntime{Command: mockPodman, Rootless: true}
+		config := RunConfig{
+			Harness:      &harness.GeminiCLI{},
+			Name:         "test-agent",
+			UnixUsername: "scion",
+			Image:        "scion-agent:latest",
+			Task:         "hello",
+		}
+		out, err := rt.Run(context.Background(), config)
+		if err != nil {
+			t.Fatalf("runtime.Run failed: %v", err)
+		}
+		if !strings.Contains(out, "--userns=keep-id:uid=1000,gid=1000") {
+			t.Errorf("expected '--userns=keep-id:uid=1000,gid=1000' in output, got %q", out)
+		}
+		if !strings.Contains(out, "SCION_KEEPID_UID=1000") {
+			t.Errorf("expected 'SCION_KEEPID_UID=1000' env var in output, got %q", out)
+		}
+	})
+
+	t.Run("rootful omits --userns=keep-id", func(t *testing.T) {
+		rt := &PodmanRuntime{Command: mockPodman, Rootless: false}
+		config := RunConfig{
+			Harness:      &harness.GeminiCLI{},
+			Name:         "test-agent",
+			UnixUsername: "scion",
+			Image:        "scion-agent:latest",
+			Task:         "hello",
+		}
+		out, err := rt.Run(context.Background(), config)
+		if err != nil {
+			t.Fatalf("runtime.Run failed: %v", err)
+		}
+		if strings.Contains(out, "--userns=keep-id") {
+			t.Errorf("did not expect '--userns=keep-id' in output, got %q", out)
+		}
+	})
+}
+
 func TestPodmanRuntime_List_JSONArray(t *testing.T) {
 	// Create a mock podman that returns Podman-style JSON array output
 	tmpDir := t.TempDir()

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -2022,22 +2022,24 @@ func (s *Server) resolveRuntimeForAgent(ctx context.Context, id, groveID string)
 }
 
 // resolveManagerForOpts returns the appropriate agent.Manager for the given
-// start options. If opts.Profile resolves to a different runtime than the
-// broker's default, a temporary manager is created with the profile-specific
-// runtime. Otherwise the broker's shared manager is returned.
+// start options. It loads the grove's settings to determine the effective
+// runtime. If the resolved runtime differs from the broker's default, a
+// temporary manager is created and cached. Otherwise the broker's shared
+// manager is returned.
+//
+// When opts.Profile is empty, the grove's active profile (from settings.yaml)
+// is used. This ensures the broker respects the grove's configured runtime
+// even when no explicit --profile flag is passed.
 func (s *Server) resolveManagerForOpts(opts api.StartOptions) agent.Manager {
-	if opts.Profile == "" {
-		return s.manager
-	}
-
-	// Load settings to check if the profile explicitly specifies a different runtime.
-	// If no settings exist or the profile isn't defined, stick with the default manager.
+	// Load settings to check if the profile/active-profile specifies a
+	// different runtime than the broker's auto-detected default.
 	projectDir, _ := config.GetResolvedProjectDir(opts.GrovePath)
 	vs, _, _ := config.LoadEffectiveSettings(projectDir)
 	if vs == nil {
 		return s.manager
 	}
 
+	// ResolveRuntime("") uses vs.ActiveProfile as the fallback.
 	_, runtimeType, err := vs.ResolveRuntime(opts.Profile)
 	if err != nil {
 		// Profile or its runtime not found in settings; use default
@@ -2048,14 +2050,19 @@ func (s *Server) resolveManagerForOpts(opts api.StartOptions) agent.Manager {
 		return s.manager
 	}
 
-	// Profile specifies a different runtime - resolve and create a manager.
+	// Settings specify a different runtime - resolve and create a manager.
 	// Cache it as an auxiliary manager so LookupContainerID can find agents
 	// created on non-default runtimes (e.g. K8s pods when default is docker).
+	//
+	// Use opts.Profile for ResolveRuntime so it picks up the same profile
+	// that was just checked. When empty, GetRuntime falls back to settings
+	// the same way ResolveRuntime does.
 	resolved := agent.ResolveRuntime(opts.GrovePath, opts.Name, opts.Profile)
 
 	if s.config.Debug {
-		s.agentLifecycleLog.Debug("Profile resolved to different runtime",
+		s.agentLifecycleLog.Debug("Settings resolved to different runtime",
 			"agent", opts.Name, "profile", opts.Profile,
+			"activeProfile", vs.ActiveProfile,
 			"defaultRuntime", s.runtime.Name(),
 			"resolvedRuntime", resolved.Name(),
 		)


### PR DESCRIPTION
Fixes #105

- [x] Tests pass
- [N/A for bug fix] Appropriate changes to documentation are included in the PR

---

Previously, when running as podman in rootless mode, many files and attributes were owned by UID 0 which then the agent was unable to read or update unless filesystem permissions were updated. Notably, the gemini-cli agent was unable to read the oauth_config.json credential and immediately stopped running.