### PR TITLE
fix(web): decouple Messages tab from cloudLogging gate

### DIFF
--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -933,6 +933,7 @@ export class ScionPageAgentDetail extends LitElement {
             agentId=${this.agentId}
             agentName=${this.agent.name || ''}
             ?canSend=${can(this.agent._capabilities, 'message')}
+            ?cloudLogging=${this.agent.cloudLogging || false}
           ></scion-agent-message-viewer>
         </sl-tab-panel>
         <sl-tab-panel name="configuration">${this.renderConfigurationTab()}</sl-tab-panel>

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -909,9 +909,7 @@ export class ScionPageAgentDetail extends LitElement {
       <sl-tab-group @sl-tab-show=${this.handleTabShow}>
         <sl-tab slot="nav" panel="status">Status</sl-tab>
         ${this.agent.cloudLogging ? html`<sl-tab slot="nav" panel="logs">Logs</sl-tab>` : nothing}
-        ${this.agent.cloudLogging
-          ? html`<sl-tab slot="nav" panel="messages">Messages</sl-tab>`
-          : nothing}
+        <sl-tab slot="nav" panel="messages">Messages</sl-tab>
         <sl-tab slot="nav" panel="configuration">Configuration</sl-tab>
 
         <sl-tab-panel name="status">${this.renderStatusTab()}</sl-tab-panel>
@@ -930,17 +928,13 @@ export class ScionPageAgentDetail extends LitElement {
               </sl-tab-panel>
             `
           : nothing}
-        ${this.agent.cloudLogging
-          ? html`
-              <sl-tab-panel name="messages">
-                <scion-agent-message-viewer
-                  agentId=${this.agentId}
-                  agentName=${this.agent.name || ''}
-                  ?canSend=${can(this.agent._capabilities, 'message')}
-                ></scion-agent-message-viewer>
-              </sl-tab-panel>
-            `
-          : nothing}
+        <sl-tab-panel name="messages">
+          <scion-agent-message-viewer
+            agentId=${this.agentId}
+            agentName=${this.agent.name || ''}
+            ?canSend=${can(this.agent._capabilities, 'message')}
+          ></scion-agent-message-viewer>
+        </sl-tab-panel>
         <sl-tab-panel name="configuration">${this.renderConfigurationTab()}</sl-tab-panel>
       </sl-tab-group>
     `;

--- a/web/src/components/shared/agent-message-viewer.ts
+++ b/web/src/components/shared/agent-message-viewer.ts
@@ -74,6 +74,15 @@ export class ScionAgentMessageViewer extends LitElement {
   canSend = false;
 
   /**
+   * Whether Cloud Logging is available for this agent. When false, the
+   * viewer skips Cloud-Logging-only paths: the fallback fetch from
+   * /message-logs and the SSE stream from /message-logs/stream. The hub
+   * message store path still works and is the primary source regardless.
+   */
+  @property({ type: Boolean })
+  cloudLogging = false;
+
+  /**
    * Custom API URL for fetching message logs.
    * When set, overrides the default agent-scoped URL.
    * Query params (tail, since) are appended automatically.
@@ -406,7 +415,11 @@ export class ScionAgentMessageViewer extends LitElement {
         }
       }
 
-      // Fallback: Cloud Logging proxy (for pre-migration records or when Hub is unavailable)
+      // Fallback: Cloud Logging proxy (for pre-migration records or when Hub is unavailable).
+      // Skipped when Cloud Logging is unavailable — the /message-logs endpoint returns 501
+      // in that case, which would turn an empty hub-store result into a user-facing error
+      // instead of the intended "No messages found" empty state.
+      if (!this.cloudLogging && !this.logsUrl) return;
       const baseUrl = this.resolvedLogsUrl;
       if (!baseUrl) return;
 
@@ -748,6 +761,11 @@ export class ScionAgentMessageViewer extends LitElement {
   }
 
   private renderToolbar() {
+    // The Stream toggle subscribes to /message-logs/stream, which is a
+    // Cloud-Logging-only endpoint. Only show it when Cloud Logging (or a
+    // custom streamUrl override) is available, otherwise the toggle would
+    // silently fail for non-CL deployments.
+    const streamAvailable = this.cloudLogging || this.streamUrl !== '';
     return html`
       <div class="toolbar">
         ${this.streaming
@@ -763,12 +781,16 @@ export class ScionAgentMessageViewer extends LitElement {
           <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
           Refresh
         </sl-button>
-        <span class="toolbar-label">Stream</span>
-        <sl-switch
-          size="small"
-          ?checked=${this.streaming}
-          @sl-change=${this.handleStreamToggle}
-        ></sl-switch>
+        ${streamAvailable
+          ? html`
+              <span class="toolbar-label">Stream</span>
+              <sl-switch
+                size="small"
+                ?checked=${this.streaming}
+                @sl-change=${this.handleStreamToggle}
+              ></sl-switch>
+            `
+          : nothing}
       </div>
     `;
   }


### PR DESCRIPTION
## Summary

The Messages tab on the agent detail page is currently hidden unless the agent has Cloud Logging enabled, even though the primary message source has been the hub store since #54d67ad1.

- The tab was originally added in d2b2ca87 with Cloud Logging as its only data source, so gating on \`cloudLogging\` was correct at the time.
- Commit 54d67ad1 (\"feat(messages): implement Phase 5 web frontend inbox tray\") migrated \`agent-message-viewer\` to use \`GET /api/v1/agents/{id}/messages\` as the primary source, with Cloud Logging as a fallback for pre-migration records. The gate in \`agent-detail.ts\` was not updated at the time.
- The result is that any deployment not opted in to Cloud Logging (per the [observability docs](https://googlecloudplatform.github.io/scion/hub-admin/observability/), Cloud Logging is optional) has no way to see or use the Messages tab, even though the hub-store fetch path works fine and \`tmux send-keys\` delivery via the existing broker path is fully functional.

This PR drops the \`cloudLogging\` gate on the Messages tab specifically. The Logs tab stays gated because \`scion-agent-log-viewer\` only queries Cloud Logging endpoints and has no hub-store equivalent.

## Verification

Tested on a self-hosted hub with no Cloud Logging configured:

- Messages tab appears on the agent detail page as expected
- Sending a message from the compose box reaches the agent via the broker's \`tmux send-keys\` path and the agent responds in its terminal
- Fetch path uses \`/api/v1/agents/{id}/messages\` (hub store) successfully
- Empty state displays correctly when no messages exist

Known limitation not addressed by this PR: the Stream toggle in the viewer hits \`/message-logs/stream\` which returns 501 when \`logQueryService\` is nil. That's a separate migration gap from the same Phase 5 change — worth a follow-up PR to wire the per-agent stream to the existing \`MessageBrokerProxy\` event bus that \`inbox-tray\` already consumes. Happy to open that as a second PR if the approach is agreed.

## Test plan

- [x] Messages tab visible on agent detail page without Cloud Logging
- [x] Send message succeeds and reaches the agent
- [x] Logs tab still gated on \`cloudLogging\` (unchanged)
- [x] No regressions on agents with Cloud Logging enabled (Messages tab still works, Cloud Logging fallback path in viewer still intact)

cc @ptone since both the original tab addition (d2b2ca87) and the Phase 5 migration (54d67ad1) were yours — this is a small cleanup of that migration.