### PR TITLE
feat(hooks): bridge Claude assistant replies into the hub message store

### DIFF
--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -1375,6 +1375,14 @@ func (s *Server) handleAgentByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Handle per-agent messages list (GET, handled before the POST-only
+	// action gate). Returns the bidirectional conversation between the
+	// authenticated user and this agent from the hub message store.
+	if action == api.AgentActionMessages {
+		s.handleAgentMessages(w, r, id)
+		return
+	}
+
 	// Handle actions
 	if action != "" {
 		s.handleAgentAction(w, r, id, action)

--- a/pkg/hub/handlers_messages.go
+++ b/pkg/hub/handlers_messages.go
@@ -144,16 +144,34 @@ func (s *Server) handleMessageRoutes(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleAgentMessages handles GET /api/v1/agents/{id}/messages.
-// Returns messages involving a specific agent, scoped to the authenticated user.
+// Returns both sides of the conversation between the authenticated user
+// and the specified agent (messages where the user is either the sender
+// or the recipient, scoped to this agent). Authorisation is enforced via
+// the agent read permission rather than a per-row recipient check, so
+// agents' outbound replies and the user's own sent messages both render
+// in the viewer.
 func (s *Server) handleAgentMessages(w http.ResponseWriter, r *http.Request, agentID string) {
 	if r.Method != http.MethodGet {
 		MethodNotAllowed(w)
 		return
 	}
 
-	user := GetUserIdentityFromContext(r.Context())
+	ctx := r.Context()
+	user := GetUserIdentityFromContext(ctx)
 	if user == nil {
 		Forbidden(w)
+		return
+	}
+
+	agent, err := s.store.GetAgent(ctx, agentID)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	decision := s.authzService.CheckAccess(ctx, user, agentResource(agent), ActionRead)
+	if !decision.Allowed {
+		writeError(w, http.StatusForbidden, ErrCodeForbidden, "Access denied", nil)
 		return
 	}
 
@@ -169,11 +187,11 @@ func (s *Server) handleAgentMessages(w http.ResponseWriter, r *http.Request, age
 	}
 
 	filter := store.MessageFilter{
-		AgentID:     agentID,
-		RecipientID: user.ID(),
+		AgentID:       agentID,
+		ParticipantID: user.ID(),
 	}
 
-	result, err := s.store.ListMessages(r.Context(), filter, opts)
+	result, err := s.store.ListMessages(ctx, filter, opts)
 	if err != nil {
 		writeErrorFromErr(w, err, "")
 		return

--- a/pkg/sciontool/hooks/dialects/claude.go
+++ b/pkg/sciontool/hooks/dialects/claude.go
@@ -91,13 +91,26 @@ func (d *ClaudeDialect) Parse(data map[string]interface{}) (*hooks.Event, error)
 	// Extract file_path from tool_input/tool_response objects
 	extractFilePath(data, &event.Data)
 
-	// For end-of-turn events (Stop / SubagentStop), Claude Code passes a
-	// transcript_path to the JSONL conversation log. Extract the text
-	// content of the final assistant turn so downstream handlers can
-	// surface it as an outbound agent→user message without having to
-	// re-ingest the whole transcript themselves.
+	// For end-of-turn events (Stop / SubagentStop), Claude Code passes
+	// the final assistant text so downstream handlers can surface it as
+	// an outbound agent→user message.
+	//
+	// Preferred source: the top-level "last_assistant_message" field,
+	// which Claude Code 2.1+ includes in the Stop hook payload directly.
+	// This is authoritative and race-free: the payload is handed to the
+	// hook process as structured JSON, not via a file that may still be
+	// flushing when we read it.
+	//
+	// Fallback: read "transcript_path" (a JSONL conversation log) and
+	// collect text from the trailing contiguous run of assistant entries.
+	// The transcript fallback covers older Claude Code versions that
+	// omit last_assistant_message and any harness that exposes only the
+	// transcript. It is racy against the harness's own writes, so it is
+	// strictly a fallback, not the primary path.
 	if event.Name == hooks.EventAgentEnd {
-		if path := getString(data, "transcript_path"); path != "" {
+		if text := strings.TrimSpace(getString(data, "last_assistant_message")); text != "" {
+			event.Data.AssistantText = text
+		} else if path := getString(data, "transcript_path"); path != "" {
 			if text := extractFinalAssistantText(path); text != "" {
 				event.Data.AssistantText = text
 			}

--- a/pkg/sciontool/hooks/dialects/claude.go
+++ b/pkg/sciontool/hooks/dialects/claude.go
@@ -6,6 +6,11 @@ Copyright 2025 The Scion Authors.
 package dialects
 
 import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"strings"
+
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hooks"
 )
 
@@ -86,7 +91,115 @@ func (d *ClaudeDialect) Parse(data map[string]interface{}) (*hooks.Event, error)
 	// Extract file_path from tool_input/tool_response objects
 	extractFilePath(data, &event.Data)
 
+	// For end-of-turn events (Stop / SubagentStop), Claude Code passes a
+	// transcript_path to the JSONL conversation log. Extract the text
+	// content of the final assistant turn so downstream handlers can
+	// surface it as an outbound agent→user message without having to
+	// re-ingest the whole transcript themselves.
+	if event.Name == hooks.EventAgentEnd {
+		if path := getString(data, "transcript_path"); path != "" {
+			if text := extractFinalAssistantText(path); text != "" {
+				event.Data.AssistantText = text
+			}
+		}
+	}
+
 	return event, nil
+}
+
+// extractFinalAssistantText reads a Claude Code transcript JSONL file and
+// returns the concatenated text blocks from the final assistant turn. A
+// "final turn" is the contiguous run of assistant entries at the end of the
+// transcript, stopped at the first preceding user entry. Tool-use and other
+// non-text content blocks are skipped. On any error the function returns an
+// empty string — callers must treat absence as "no assistant text
+// available" rather than a failure condition.
+func extractFinalAssistantText(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	// Collect text from contiguous assistant entries at the tail of the
+	// transcript. Iterate forward once (Claude transcripts are small
+	// enough that double-pass or reverse-scan overhead is unnecessary);
+	// reset the collected text whenever a user entry is seen so that by
+	// the end of the scan we hold exactly the final assistant turn.
+	var turnParts []string
+	scanner := bufio.NewScanner(f)
+	// Transcript lines can contain very long tool outputs; raise the
+	// scanner buffer so we don't silently truncate them.
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var entry struct {
+			Type    string `json:"type"`
+			Message struct {
+				Role    string          `json:"role"`
+				Content json.RawMessage `json:"content"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+		entryType := entry.Type
+		if entryType == "" {
+			entryType = entry.Message.Role
+		}
+
+		switch entryType {
+		case "user":
+			// A user entry ends any prior assistant turn.
+			turnParts = turnParts[:0]
+		case "assistant":
+			if text := assistantContentText(entry.Message.Content); text != "" {
+				turnParts = append(turnParts, text)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(strings.Join(turnParts, "\n\n"))
+}
+
+// assistantContentText extracts text from an assistant message's content
+// field, which in Claude transcripts is either a JSON array of typed blocks
+// or (rarely) a plain string. Only "text" blocks contribute; tool_use and
+// other block types are ignored.
+func assistantContentText(content json.RawMessage) string {
+	if len(content) == 0 {
+		return ""
+	}
+
+	// Plain string content (older/simpler transcript shape).
+	var s string
+	if err := json.Unmarshal(content, &s); err == nil {
+		return strings.TrimSpace(s)
+	}
+
+	// Typed block array.
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		return ""
+	}
+
+	var parts []string
+	for _, b := range blocks {
+		if b.Type == "text" && b.Text != "" {
+			parts = append(parts, b.Text)
+		}
+	}
+	return strings.TrimSpace(strings.Join(parts, ""))
 }
 
 // normalizeEventName maps Claude Code event names to normalized names.

--- a/pkg/sciontool/hooks/dialects/claude_test.go
+++ b/pkg/sciontool/hooks/dialects/claude_test.go
@@ -101,12 +101,52 @@ func TestClaudeDialect_StopEventExtractsAssistantText(t *testing.T) {
 	assert.Equal(t, "All done.", event.Data.AssistantText)
 }
 
+func TestClaudeDialect_StopEventPrefersLastAssistantMessage(t *testing.T) {
+	// Claude Code 2.1+ includes the final assistant text directly in
+	// the Stop hook payload. When present, we must use it in preference
+	// to reading the transcript file (which may be mid-flush when the
+	// hook fires, producing an empty or stale extraction).
+	dir := t.TempDir()
+	transcriptPath := filepath.Join(dir, "t.jsonl")
+	// Write a transcript that would yield "from transcript" if read.
+	content := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"from transcript"}]}}` + "\n"
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(content), 0o600))
+
+	d := NewClaudeDialect()
+	event, err := d.Parse(map[string]interface{}{
+		"hook_event_name":        "Stop",
+		"transcript_path":        transcriptPath,
+		"last_assistant_message": "from payload",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "from payload", event.Data.AssistantText,
+		"payload field must win over transcript extraction")
+}
+
+func TestClaudeDialect_StopEventFallsBackToTranscript(t *testing.T) {
+	// When last_assistant_message is absent (older Claude Code or other
+	// harnesses), fall back to reading the transcript file.
+	dir := t.TempDir()
+	transcriptPath := filepath.Join(dir, "t.jsonl")
+	content := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"fallback text"}]}}` + "\n"
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(content), 0o600))
+
+	d := NewClaudeDialect()
+	event, err := d.Parse(map[string]interface{}{
+		"hook_event_name": "Stop",
+		"transcript_path": transcriptPath,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "fallback text", event.Data.AssistantText)
+}
+
 func TestClaudeDialect_NonStopEventDoesNotExtract(t *testing.T) {
 	d := NewClaudeDialect()
 	event, err := d.Parse(map[string]interface{}{
-		"hook_event_name": "PreToolUse",
-		"transcript_path": "/does/not/exist",
-		"tool_name":       "Read",
+		"hook_event_name":        "PreToolUse",
+		"transcript_path":        "/does/not/exist",
+		"last_assistant_message": "ignored",
+		"tool_name":              "Read",
 	})
 	require.NoError(t, err)
 	assert.Empty(t, event.Data.AssistantText)

--- a/pkg/sciontool/hooks/dialects/claude_test.go
+++ b/pkg/sciontool/hooks/dialects/claude_test.go
@@ -5,6 +5,8 @@ Copyright 2025 The Scion Authors.
 package dialects
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hooks"
@@ -15,6 +17,99 @@ import (
 func TestClaudeDialect_Name(t *testing.T) {
 	d := NewClaudeDialect()
 	assert.Equal(t, "claude", d.Name())
+}
+
+func TestExtractFinalAssistantText(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(t *testing.T, name, content string) string {
+		t.Helper()
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+		return path
+	}
+
+	t.Run("single assistant turn with text block", func(t *testing.T) {
+		path := write(t, "single.jsonl",
+			`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}`+"\n"+
+				`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello there"}]}}`+"\n",
+		)
+		assert.Equal(t, "Hello there", extractFinalAssistantText(path))
+	})
+
+	t.Run("multiple blocks in final assistant message", func(t *testing.T) {
+		path := write(t, "multiblock.jsonl",
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Thinking..."},{"type":"tool_use","id":"t1","name":"Read","input":{}},{"type":"text","text":"Done."}]}}`+"\n",
+		)
+		assert.Equal(t, "Thinking...Done.", extractFinalAssistantText(path))
+	})
+
+	t.Run("contiguous assistant entries concatenated", func(t *testing.T) {
+		path := write(t, "contiguous.jsonl",
+			`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"go"}]}}`+"\n"+
+				`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"First"}]}}`+"\n"+
+				`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read","input":{}}]}}`+"\n"+
+				`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"..."}]}}`+"\n"+
+				`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Second"}]}}`+"\n"+
+				`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Third"}]}}`+"\n",
+		)
+		assert.Equal(t, "Second\n\nThird", extractFinalAssistantText(path))
+	})
+
+	t.Run("tool-use only final turn yields empty", func(t *testing.T) {
+		path := write(t, "toolonly.jsonl",
+			`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"go"}]}}`+"\n"+
+				`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read","input":{}}]}}`+"\n",
+		)
+		assert.Equal(t, "", extractFinalAssistantText(path))
+	})
+
+	t.Run("plain string content", func(t *testing.T) {
+		path := write(t, "plainstr.jsonl",
+			`{"type":"assistant","message":{"role":"assistant","content":"Legacy shape"}}`+"\n",
+		)
+		assert.Equal(t, "Legacy shape", extractFinalAssistantText(path))
+	})
+
+	t.Run("missing file returns empty", func(t *testing.T) {
+		assert.Equal(t, "", extractFinalAssistantText(filepath.Join(dir, "nope.jsonl")))
+	})
+
+	t.Run("malformed lines are skipped", func(t *testing.T) {
+		path := write(t, "malformed.jsonl",
+			`not json at all`+"\n"+
+				`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Survived"}]}}`+"\n"+
+				`{"type":"assistant","broken`+"\n",
+		)
+		assert.Equal(t, "Survived", extractFinalAssistantText(path))
+	})
+}
+
+func TestClaudeDialect_StopEventExtractsAssistantText(t *testing.T) {
+	dir := t.TempDir()
+	transcriptPath := filepath.Join(dir, "t.jsonl")
+	content := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"All done."}]}}` + "\n"
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(content), 0o600))
+
+	d := NewClaudeDialect()
+	event, err := d.Parse(map[string]interface{}{
+		"hook_event_name": "Stop",
+		"transcript_path": transcriptPath,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, hooks.EventAgentEnd, event.Name)
+	assert.Equal(t, "All done.", event.Data.AssistantText)
+}
+
+func TestClaudeDialect_NonStopEventDoesNotExtract(t *testing.T) {
+	d := NewClaudeDialect()
+	event, err := d.Parse(map[string]interface{}{
+		"hook_event_name": "PreToolUse",
+		"transcript_path": "/does/not/exist",
+		"tool_name":       "Read",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, event.Data.AssistantText)
 }
 
 func TestClaudeDialect_Parse(t *testing.T) {

--- a/pkg/sciontool/hooks/handlers/hub.go
+++ b/pkg/sciontool/hooks/handlers/hub.go
@@ -124,6 +124,24 @@ func (h *HubHandler) Handle(event *hooks.Event) error {
 		})
 
 	case hooks.EventToolEnd, hooks.EventAgentEnd, hooks.EventModelEnd:
+		// Forward assistant text (when the dialect extracted it — e.g.
+		// Claude's Stop hook via transcript_path) to the hub message
+		// store as an outbound agent→user reply. This is what makes
+		// assistant responses show up in the Messages tab. Best-effort:
+		// failure here must not break the status update flow below.
+		if event.Name == hooks.EventAgentEnd && event.Data.AssistantText != "" {
+			msgCtx, msgCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if msgErr := h.client.SendOutboundMessage(msgCtx, hub.OutboundMessage{
+				Msg:  event.Data.AssistantText,
+				Type: "assistant-reply",
+			}); msgErr != nil {
+				log.Error("Hub: outbound assistant reply failed: %v", msgErr)
+			} else {
+				log.Debug("Hub: Forwarded assistant reply to message store (%d bytes)", len(event.Data.AssistantText))
+			}
+			msgCancel()
+		}
+
 		// Check if local activity is sticky before sending idle
 		if h.isLocalActivitySticky() {
 			log.Debug("Hub: Skipping idle (local activity is sticky)")

--- a/pkg/sciontool/hooks/types.go
+++ b/pkg/sciontool/hooks/types.go
@@ -42,6 +42,15 @@ type EventData struct {
 	OutputTokens int64 `json:"output_tokens,omitempty"`
 	CachedTokens int64 `json:"cached_tokens,omitempty"`
 
+	// AssistantText holds the textual output of the agent's final turn,
+	// populated by dialect parsers for end-of-turn events when the
+	// underlying harness exposes assistant content (e.g. Claude Code's
+	// Stop hook via transcript_path). Handlers may forward this to the
+	// hub message store as an outbound agent→user message so the Messages
+	// tab reflects agent replies without re-ingesting the entire
+	// transcript.
+	AssistantText string `json:"assistant_text,omitempty"`
+
 	// Status fields
 	Success bool   `json:"success,omitempty"`
 	Error   string `json:"error,omitempty"`

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -1020,8 +1020,16 @@ type MessageFilter struct {
 	AgentID     string // Filter by involved agent
 	RecipientID string // Filter by recipient
 	SenderID    string // Filter by sender
-	OnlyUnread  bool   // Only unread messages
-	Type        string // Filter by message type
+	// ParticipantID matches messages where the given ID is either the
+	// recipient or the sender — i.e. "messages this user participated
+	// in". Exactly what you want when rendering a bidirectional
+	// conversation view. Combined with AgentID this returns both sides
+	// of the chat between the user and an agent. Ignored when empty.
+	// Evaluated independently of RecipientID/SenderID; callers
+	// generally pick one approach or the other.
+	ParticipantID string
+	OnlyUnread    bool   // Only unread messages
+	Type          string // Filter by message type
 }
 
 // =============================================================================

--- a/pkg/store/sqlite/messages.go
+++ b/pkg/store/sqlite/messages.go
@@ -107,6 +107,10 @@ func (s *SQLiteStore) ListMessages(ctx context.Context, filter store.MessageFilt
 		conditions = append(conditions, "sender_id = ?")
 		args = append(args, filter.SenderID)
 	}
+	if filter.ParticipantID != "" {
+		conditions = append(conditions, "(recipient_id = ? OR sender_id = ?)")
+		args = append(args, filter.ParticipantID, filter.ParticipantID)
+	}
 	if filter.OnlyUnread {
 		conditions = append(conditions, "read = 0")
 	}

--- a/pkg/store/sqlite/messages_test.go
+++ b/pkg/store/sqlite/messages_test.go
@@ -162,6 +162,66 @@ func TestListMessages(t *testing.T) {
 	assert.Equal(t, 0, result.TotalCount)
 }
 
+func TestListMessages_ParticipantID(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	groveID, agentID := createTestGroveAndAgent(t, s)
+	userID := "user-uuid-alice"
+
+	// Inbound: user → agent. Sender=user, recipient=agent.
+	inbound := newTestMessage(groveID, agentID)
+	inbound.SenderID = userID
+	inbound.RecipientID = agentID
+	require.NoError(t, s.CreateMessage(ctx, inbound))
+
+	// Outbound: agent → user. Sender=agent, recipient=user.
+	outbound := &store.Message{
+		ID:          api.NewUUID(),
+		GroveID:     groveID,
+		Sender:      "agent:coder",
+		SenderID:    agentID,
+		Recipient:   "user:alice",
+		RecipientID: userID,
+		Msg:         "Done — here's the patch.",
+		Type:        "assistant-reply",
+		AgentID:     agentID,
+		CreatedAt:   time.Now().UTC().Truncate(time.Second),
+	}
+	require.NoError(t, s.CreateMessage(ctx, outbound))
+
+	// Unrelated message in the same grove/agent with a different user.
+	other := &store.Message{
+		ID:          api.NewUUID(),
+		GroveID:     groveID,
+		Sender:      "user:bob",
+		SenderID:    "user-uuid-bob",
+		Recipient:   "agent:coder",
+		RecipientID: agentID,
+		Msg:         "Bob's message",
+		Type:        "instruction",
+		AgentID:     agentID,
+		CreatedAt:   time.Now().UTC().Truncate(time.Second),
+	}
+	require.NoError(t, s.CreateMessage(ctx, other))
+
+	// ParticipantID + AgentID returns both sides of the alice↔agent chat
+	// but not bob's message.
+	result, err := s.ListMessages(ctx, store.MessageFilter{
+		AgentID:       agentID,
+		ParticipantID: userID,
+	}, store.ListOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.TotalCount)
+	gotIDs := map[string]bool{}
+	for _, m := range result.Items {
+		gotIDs[m.ID] = true
+	}
+	assert.True(t, gotIDs[inbound.ID], "inbound (user→agent) should match")
+	assert.True(t, gotIDs[outbound.ID], "outbound (agent→user) should match")
+	assert.False(t, gotIDs[other.ID], "bob's message should not match alice's participant filter")
+}
+
 func TestPurgeOldMessages(t *testing.T) {
 	s := setupTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

The hub already exposes a per-agent Messages tab with compose/interrupt, backed by \`POST /api/v1/agents/{id}/outbound-message\` for agent→user replies and the \`MessageBrokerProxy\` event bus for real-time delivery to the inbox tray. What was missing: **nothing in any harness actually called that endpoint when an agent finished a turn**, so the "received" half of the chat stayed permanently empty even after the Messages tab was unhidden (#142).

This PR wires the reply bridge for Claude Code, and fixes two pre-existing bugs in the per-agent messages endpoint that the bridge surfaced.

## The bridge (commit 1)

\`pkg/sciontool/hooks/types.go\` gets a new \`EventData.AssistantText\` field — harness-populated, end-of-turn only.

\`pkg/sciontool/hooks/dialects/claude.go\` populates it on \`EventAgentEnd\` (mapped from Claude's Stop / SubagentStop hooks). Initial implementation read \`transcript_path\` and walked the JSONL to extract the final contiguous assistant turn; commit 4 later replaced this with the simpler \`last_assistant_message\` payload field (see below).

\`pkg/sciontool/hooks/handlers/hub.go\` forwards \`AssistantText\` via \`hub.Client.SendOutboundMessage()\` with \`Type: \"assistant-reply\"\` when non-empty. The outbound endpoint already handles recipient defaulting, SSE publishing, and external channel dispatch — this is a five-line plumbing change once the text is in hand. Failure is logged but non-fatal: it must never break the existing hook chain.

Other harnesses are unaffected. Gemini and Codex can adopt the same pattern without further handler changes once their hook schemas gain equivalent end-of-turn context.

## Per-agent endpoint fixes (commits 2 and 3)

Testing the bridge on a live deployment surfaced two existing bugs in the Messages tab's fetch path, both pre-dating this PR:

### Commit 2: Bidirectional chat filter

\`handleAgentMessages\` filtered on \`AgentID = ? AND RecipientID = user.ID()\`. That ANDs out every user→agent message, since those are stored with \`recipient_id = agent.ID\`. Effect: even with populated data, the tab returned only agent→user replies (and only when the OIDC \`user.ID()\` exactly matched the canonical \`users.id\` UUID at persistence time, which it didn't always).

Replace with:
- Explicit agent read authorisation via \`authzService.CheckAccess\` (mirroring \`handleAgentMessageLogsStream\` in \`handlers_logs.go\`)
- A new \`MessageFilter.ParticipantID\` field that generates \`(recipient_id = ? OR sender_id = ?)\` in the SQL

The resulting filter returns the full bidirectional conversation between the current user and the current agent. \`ParticipantID\` is additive — existing callers of \`RecipientID\`/\`SenderID\` are unchanged.

Test: \`TestListMessages_ParticipantID\` with a cross-matrix of inbound, outbound, and third-party messages to verify the user's own conversation is isolated from bob's.

### Commit 3: Route GET before the POST-only action gate

\`handleAgentAction\` rejects any non-POST up front with 405 and then dispatches via a switch statement. \`AgentActionMessages\` was wired into that switch, so \`GET /api/v1/agents/{id}/messages\` returned **405 regardless of store contents** — the handler was never reachable.

\`handleAgentByID\` already has the right pattern for GET-friendly actions: cloud-logs, cloud-logs/stream, message-logs, and message-logs/stream are all dispatched before falling through to the action gate (the existing comment says as much). Messages was supposed to be in that list — add it now. The stale switch case in \`handleAgentAction\` is left in place as defence-in-depth but is unreachable.

## Payload field over transcript read (commit 4)

The initial bridge implementation read \`transcript_path\` from the hook payload and walked the JSONL file. On a live deployment this raced against Claude Code's own writes: Claude appends the assistant entry to the transcript and fires the Stop hook milliseconds later, and on my test deployment the extractor reliably saw either an empty file or a transcript missing the final entry. Manually invoking the hook with the same captured payload a second later always succeeded because by then the file was flushed.

Claude Code 2.1+ (confirmed on 2.1.104) includes the final assistant text directly in the Stop hook payload as the top-level \`last_assistant_message\` field. This is authoritative and race-free — it's handed to the hook process as structured JSON at invocation time, not read from a file that may still be flushing.

Switch the dialect to prefer \`last_assistant_message\` and fall back to \`transcript_path\` reading when the field is absent (older Claude Code or future harnesses that only expose a transcript).

## Verification

Tested end-to-end on a self-hosted hub with no Cloud Logging:
- Send from the Messages tab → reaches Claude's tmux via the existing \`tmux send-keys\` path ✓
- Claude responds → Stop hook fires → \`sciontool hook --dialect=claude\` reads stdin → dialect extracts \`last_assistant_message\` → hub handler calls \`SendOutboundMessage\` → stored with \`type=\"assistant-reply\"\` ✓
- Inbox tray receives the reply in real time via \`PublishUserMessage\` SSE ✓
- Per-agent Messages tab GET returns both sides of the conversation on refresh ✓

Known follow-up (not addressed here, worth a separate small PR): the per-agent Messages tab's Stream toggle uses the Cloud-Logging-only \`/message-logs/stream\` endpoint, so live updates don't reach the tab on non-CL deployments (refresh works). Wiring per-agent streaming to the existing \`MessageBrokerProxy\` event bus would close that gap and match the inbox tray's real-time behaviour.

## Test plan

- [x] \`go test ./pkg/sciontool/hooks/...\`
- [x] \`go test ./pkg/store/sqlite/ -run TestListMessages\`
- [x] Live end-to-end with Claude Code 2.1.104 — user→agent and agent→user in Messages tab + inbox tray
- [x] Cherry-pick to our combined branch, full image chain rebuild, smoke test on the deployed hub

cc @ptone — related to #142 (which decouples the Messages tab from \`cloudLogging\`). Happy to combine the two if preferred, but they touch different layers so kept them separate for review clarity.