### PR TITLE
feat(hub): hub-store SSE stream for per-agent Messages tab

### DIFF
--- a/pkg/api/agent_actions.go
+++ b/pkg/api/agent_actions.go
@@ -9,6 +9,7 @@ const (
 	AgentActionRestart           = "restart"
 	AgentActionMessage           = "message"
 	AgentActionMessages          = "messages"
+	AgentActionMessagesStream    = "messages/stream"
 	AgentActionExec              = "exec"
 	AgentActionRestore           = "restore"
 	AgentActionEnv               = "env"

--- a/pkg/hub/events.go
+++ b/pkg/hub/events.go
@@ -413,8 +413,16 @@ func (p *ChannelEventPublisher) PublishNotification(_ context.Context, notif *st
 	p.publish("notification.created", evt)
 }
 
-// PublishUserMessage publishes a user.message event when an agent sends a message
-// to a human. The event is published to user-specific and grove-scoped subjects.
+// PublishUserMessage publishes a user.message event when a message involving
+// a human user is persisted — either an agent→user reply (from
+// handleAgentOutboundMessage) or a user→agent instruction (from
+// handleAgentMessage). The event is fanned out to several subjects so
+// different consumers can subscribe at the granularity they need:
+//
+//   - user.<recipientID>.message — inbox-tray for the message's addressee
+//   - grove.<groveID>.user.message — grove-level user-message feeds
+//   - agent.<agentID>.message — per-agent conversation streams (both
+//     directions; subscribers filter by user participation themselves)
 func (p *ChannelEventPublisher) PublishUserMessage(_ context.Context, msg *store.Message) {
 	evt := UserMessageEvent{
 		ID:          msg.ID,
@@ -434,6 +442,9 @@ func (p *ChannelEventPublisher) PublishUserMessage(_ context.Context, msg *store
 	}
 	if msg.GroveID != "" {
 		p.publish("grove."+msg.GroveID+".user.message", evt)
+	}
+	if msg.AgentID != "" {
+		p.publish("agent."+msg.AgentID+".message", evt)
 	}
 }
 

--- a/pkg/hub/events_test.go
+++ b/pkg/hub/events_test.go
@@ -266,6 +266,57 @@ func TestChannelEventPublisher_PublishGroveCreated(t *testing.T) {
 	}
 }
 
+func TestChannelEventPublisher_PublishUserMessage_FanOut(t *testing.T) {
+	// Verify a single PublishUserMessage call fans out to all three
+	// subjects: user.<recipient>.message, grove.<grove>.user.message,
+	// and agent.<agent>.message (the last one is what the per-agent
+	// Messages tab stream subscribes to).
+	pub := NewChannelEventPublisher()
+	defer pub.Close()
+
+	userCh, unsubUser := pub.Subscribe("user.u1.message")
+	defer unsubUser()
+	groveCh, unsubGrove := pub.Subscribe("grove.g1.user.message")
+	defer unsubGrove()
+	agentCh, unsubAgent := pub.Subscribe("agent.a1.message")
+	defer unsubAgent()
+
+	msg := &store.Message{
+		ID:          "m1",
+		GroveID:     "g1",
+		Sender:      "agent:coder",
+		SenderID:    "a1",
+		Recipient:   "user:alice",
+		RecipientID: "u1",
+		Msg:         "All done.",
+		Type:        "assistant-reply",
+		AgentID:     "a1",
+		CreatedAt:   time.Now().UTC(),
+	}
+
+	pub.PublishUserMessage(context.Background(), msg)
+
+	for name, ch := range map[string]<-chan Event{
+		"user":  userCh,
+		"grove": groveCh,
+		"agent": agentCh,
+	} {
+		select {
+		case evt := <-ch:
+			var payload UserMessageEvent
+			if err := json.Unmarshal(evt.Data, &payload); err != nil {
+				t.Fatalf("%s: unmarshal: %v", name, err)
+			}
+			if payload.ID != "m1" || payload.AgentID != "a1" ||
+				payload.RecipientID != "u1" || payload.Msg != "All done." {
+				t.Errorf("%s: unexpected payload: %+v", name, payload)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("%s: timeout waiting for user message event", name)
+		}
+	}
+}
+
 func TestChannelEventPublisher_PublishBrokerConnected(t *testing.T) {
 	pub := NewChannelEventPublisher()
 	defer pub.Close()

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -1375,9 +1375,14 @@ func (s *Server) handleAgentByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Handle per-agent messages list (GET, handled before the POST-only
-	// action gate). Returns the bidirectional conversation between the
-	// authenticated user and this agent from the hub message store.
+	// Handle per-agent messages (GET endpoints, handled before the
+	// POST-only action gate). Both the list and the real-time stream
+	// are backed by the hub message store / event bus and work without
+	// Cloud Logging being configured.
+	if action == api.AgentActionMessagesStream {
+		s.handleAgentMessagesStream(w, r, id)
+		return
+	}
 	if action == api.AgentActionMessages {
 		s.handleAgentMessages(w, r, id)
 		return
@@ -2291,6 +2296,10 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
 			s.messageLog.Error("Failed to persist message", "error", err)
 		}
+		// Publish SSE event so connected browser clients can update the
+		// per-agent conversation view in real time — mirrors the agent→user
+		// publish path in handleAgentOutboundMessage.
+		s.events.PublishUserMessage(ctx, storeMsg)
 	}
 
 	// If a dispatcher is available, dispatch the message to the runtime broker

--- a/pkg/hub/handlers_messages.go
+++ b/pkg/hub/handlers_messages.go
@@ -273,6 +273,11 @@ func (s *Server) handleAgentMessagesStream(w http.ResponseWriter, r *http.Reques
 	heartbeat := time.NewTicker(30 * time.Second)
 	defer heartbeat.Stop()
 
+	// Server-side timeout matching handlers_logs.go: tell the client to
+	// reconnect after 10 minutes so long-lived connections don't accumulate.
+	timeout := time.NewTimer(10 * time.Minute)
+	defer timeout.Stop()
+
 	for {
 		select {
 		case evt, ok := <-ch:
@@ -294,6 +299,10 @@ func (s *Server) handleAgentMessagesStream(w http.ResponseWriter, r *http.Reques
 		case <-heartbeat.C:
 			fmt.Fprintf(w, ":heartbeat %d\n\n", time.Now().UnixMilli())
 			flusher.Flush()
+		case <-timeout.C:
+			fmt.Fprintf(w, "event: timeout\ndata: {\"message\":\"stream timeout, please reconnect\"}\n\n")
+			flusher.Flush()
+			return
 		case <-ctx.Done():
 			return
 		}

--- a/pkg/hub/handlers_messages.go
+++ b/pkg/hub/handlers_messages.go
@@ -15,9 +15,12 @@
 package hub
 
 import (
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
@@ -198,4 +201,101 @@ func (s *Server) handleAgentMessages(w http.ResponseWriter, r *http.Request, age
 	}
 
 	writeJSON(w, http.StatusOK, result)
+}
+
+// handleAgentMessagesStream handles GET /api/v1/agents/{id}/messages/stream.
+// Streams new messages involving a specific agent in real time, scoped to
+// the conversation between the current authenticated user and the agent.
+// Unlike /message-logs/stream this does not depend on Cloud Logging: it
+// subscribes to the in-process event bus that handleAgentOutboundMessage
+// and handleAgentMessage already publish to, so it works on any hub
+// deployment with no additional configuration.
+func (s *Server) handleAgentMessagesStream(w http.ResponseWriter, r *http.Request, agentID string) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	ctx := r.Context()
+	user := GetUserIdentityFromContext(ctx)
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	agent, err := s.store.GetAgent(ctx, agentID)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	decision := s.authzService.CheckAccess(ctx, user, agentResource(agent), ActionRead)
+	if !decision.Allowed {
+		writeError(w, http.StatusForbidden, ErrCodeForbidden, "Access denied", nil)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	// The event bus is an interface; only ChannelEventPublisher supports
+	// subscription. A hub configured with a noop publisher has no source
+	// of real-time events to stream, so surface a clear 501 instead of
+	// silently returning an empty stream.
+	ep, ok := s.events.(*ChannelEventPublisher)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "not_implemented",
+			"Real-time message streaming is not available on this hub", nil)
+		return
+	}
+
+	// Clear the server's write deadline for this long-lived connection —
+	// without this the global WriteTimeout will kill the stream and cause
+	// reconnection churn, matching the pattern in web.go's SSE handler.
+	rc := http.NewResponseController(w)
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+		slog.Debug("Failed to clear write deadline for messages stream", "error", err)
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	flusher.Flush()
+
+	ch, unsubscribe := ep.Subscribe("agent." + agent.ID + ".message")
+	defer unsubscribe()
+
+	userID := user.ID()
+	heartbeat := time.NewTicker(30 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case evt, ok := <-ch:
+			if !ok {
+				return
+			}
+			// Filter: only forward events where the current user is a
+			// participant. Without this the stream would include messages
+			// from every other user's conversation with this agent.
+			var payload UserMessageEvent
+			if err := json.Unmarshal(evt.Data, &payload); err != nil {
+				continue
+			}
+			if payload.SenderID != userID && payload.RecipientID != userID {
+				continue
+			}
+			fmt.Fprintf(w, "event: message\ndata: %s\n\n", evt.Data)
+			flusher.Flush()
+		case <-heartbeat.C:
+			fmt.Fprintf(w, ":heartbeat %d\n\n", time.Now().UnixMilli())
+			flusher.Flush()
+		case <-ctx.Done():
+			return
+		}
+	}
 }

--- a/web/src/components/shared/agent-message-viewer.ts
+++ b/web/src/components/shared/agent-message-viewer.ts
@@ -393,6 +393,16 @@ export class ScionAgentMessageViewer extends LitElement {
 
   private get resolvedStreamUrl(): string {
     if (this.streamUrl) return this.streamUrl;
+    if (!this.agentId) return '';
+    // Prefer the hub-store-backed per-agent stream, which works on any
+    // deployment regardless of Cloud Logging. The older
+    // /message-logs/stream endpoint is Cloud Logging only and is kept
+    // as a fallback for deployments that explicitly enable that.
+    return `/api/v1/agents/${this.agentId}/messages/stream`;
+  }
+
+  private get resolvedMessageLogsStreamUrl(): string {
+    if (this.streamUrl) return this.streamUrl;
     if (this.agentId) return `/api/v1/agents/${this.agentId}/message-logs/stream`;
     return '';
   }
@@ -572,6 +582,19 @@ export class ScionAgentMessageViewer extends LitElement {
 
     this.eventSource = new EventSource(url);
 
+    // Hub-store-backed stream: emits "message" events with a full
+    // UserMessageEvent payload (hub store record) per message.
+    this.eventSource.addEventListener('message', (event: Event) => {
+      try {
+        const msg = JSON.parse((event as MessageEvent).data) as Message;
+        this.mergeHubMessages([msg]);
+      } catch {
+        // Skip unparseable entries
+      }
+    });
+
+    // Cloud-Logging-backed stream (fallback path via /message-logs/stream
+    // when explicitly opted in): emits "log" events with raw log entries.
     this.eventSource.addEventListener('log', (event: Event) => {
       try {
         const entry = JSON.parse((event as MessageEvent).data) as MessageLogEntry;
@@ -761,11 +784,6 @@ export class ScionAgentMessageViewer extends LitElement {
   }
 
   private renderToolbar() {
-    // The Stream toggle subscribes to /message-logs/stream, which is a
-    // Cloud-Logging-only endpoint. Only show it when Cloud Logging (or a
-    // custom streamUrl override) is available, otherwise the toggle would
-    // silently fail for non-CL deployments.
-    const streamAvailable = this.cloudLogging || this.streamUrl !== '';
     return html`
       <div class="toolbar">
         ${this.streaming
@@ -781,7 +799,7 @@ export class ScionAgentMessageViewer extends LitElement {
           <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
           Refresh
         </sl-button>
-        ${streamAvailable
+        ${this.resolvedStreamUrl
           ? html`
               <span class="toolbar-label">Stream</span>
               <sl-switch


### PR DESCRIPTION
## Summary

The Messages tab on the agent detail page has a Stream toggle that subscribes to \`/api/v1/agents/{id}/message-logs/stream\`. That endpoint is Cloud-Logging-only and returns 501 when \`logQueryService\` is nil, so real-time updates never reach the per-agent view on deployments that don't opt in to Cloud Logging. The tab's fetch path was migrated to the hub message store in #54d67ad1; this PR brings the streaming path along with it.

Related: #142 decouples the tab itself from \`cloudLogging\`; #143 wires Claude's assistant replies into the hub message store via the Stop hook. Both surface the same gap — real-time streaming doesn't work without Cloud Logging. This PR closes it.

## Server side

**\`pkg/api/agent_actions.go\`** — new \`AgentActionMessagesStream\` constant (\`messages/stream\`) alongside the existing \`Messages\` action.

**\`pkg/hub/events.go\`** — \`PublishUserMessage\` now fans out to a third subject, \`agent.<agentID>.message\`, in addition to the existing \`user.<recipientID>.message\` and \`grove.<groveID>.user.message\`. Same event payload, same delivery mechanism — just adds a subscription granularity for per-agent consumers. No behaviour change for existing subscribers.

**\`pkg/hub/handlers.go\`** — two fixes:

1. \`handleAgentMessage\` (the user→agent POST path) was persisting messages to the store but never calling \`PublishUserMessage\`. Effect: inbox-tray and any per-agent stream would never see user-sent messages — only agent→user replies. Added the publish call after \`store.CreateMessage\`, mirroring \`handleAgentOutboundMessage\`.
2. Routed \`GET /api/v1/agents/{id}/messages/stream\` before the POST-only action gate in \`handleAgentByID\`, matching the existing pattern for \`cloud-logs\`, \`message-logs\`, and the per-agent messages list.

**\`pkg/hub/handlers_messages.go\`** — new \`handleAgentMessagesStream\` function:

- Authenticates the user and checks agent read access via \`authzService.CheckAccess\` (mirrors \`handleAgentMessageLogsStream\` in \`handlers_logs.go\`).
- Casts \`s.events\` to \`*ChannelEventPublisher\` (the concrete publisher that supports subscriptions) and downgrades to 501 \`not_implemented\` on hubs configured with a noop publisher, instead of silently returning an empty stream.
- Subscribes to \`agent.<id>.message\` on the event bus.
- Filters events so only the current user's participation is streamed (\`payload.SenderID == user.ID() || payload.RecipientID == user.ID()\`).
- Emits standard SSE with \`event: message\` frames and 30s heartbeats. Clears the server's write deadline for the long-lived connection, matching the pattern in \`web.go\`'s SSE handler.

## Client side

**\`web/src/components/shared/agent-message-viewer.ts\`**:

- \`resolvedStreamUrl\` now points at \`/api/v1/agents/{id}/messages/stream\` by default. The Cloud Logging stream (\`/message-logs/stream\`) remains reachable via an explicit \`streamUrl\` override and is exposed via \`resolvedMessageLogsStreamUrl\` for symmetry.
- \`startStream\` adds a \`message\` event listener that deserialises the hub-store \`UserMessageEvent\` shape and merges via the existing \`mergeHubMessages\` path. The existing \`log\` listener is retained so Cloud Logging deployments keep working via \`streamUrl\`.
- \`renderToolbar\` gates the Stream toggle on \`resolvedStreamUrl\` instead of hiding it unconditionally. The toggle renders whenever a stream URL is resolvable — true on any per-agent view — and only hides in degenerate cases (e.g. grove-level viewer with no custom URL).

## Verification

Tested end-to-end on a self-hosted hub without Cloud Logging, with a running Claude agent:

- Opening the Messages tab surfaces the Stream toggle ✓
- Toggling Stream on opens a persistent \`text/event-stream\` EventSource to \`/messages/stream\` (200, not 501) ✓
- Sending a message from the compose box appears in the tab **instantly**, not just on refresh ✓
- The agent's reply (wired via #143's Claude Stop-hook bridge) appears instantly too ✓
- Heartbeats flow every 30s, connection stays open, no reconnection churn ✓

## Test plan

- [x] \`TestChannelEventPublisher_PublishUserMessage_FanOut\` — verifies a single \`PublishUserMessage\` call fans out to all three subjects with matching payloads
- [x] \`go build ./...\`
- [x] Existing hub tests pass (modulo pre-existing \`TestNotificationDispatcher_*\` flake unrelated to this change)
- [x] Live end-to-end on Claude agent
- [x] Cherry-pick to our combined branch, full hub rebuild, smoke test on deployed hub — real-time chat confirmed working without refresh

cc @ptone — this is the third of a three-PR arc on the Messages tab (#142 unhides it, #143 wires the reply bridge + fixes the fetch path, #143 + this close the stream path). The three could in principle be combined, but they touch different concerns and review differently, so I've kept them separate unless you'd prefer otherwise.