### PR TITLE
fix: skip image_registry check for server subcommands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,13 +84,17 @@ return an error instead of blocking.`,
 
 		requiresGrove := true
 		switch cmdName {
-		case "help", "version", "completion", "server", "doctor":
+		case "help", "version", "completion", "doctor":
 			requiresGrove = false
 		case "init":
 			// Both top-level init and grove init don't require existing grove
 			requiresGrove = false
 		case "scion":
 			// Root command itself doesn't require grove
+			requiresGrove = false
+		}
+		// Server subcommands run the hub server and don't need a local grove
+		if commandInSubtree(cmd, "server") {
 			requiresGrove = false
 		}
 		// Grove subcommands operate on all groves, not just the current one
@@ -141,14 +145,10 @@ return an error instead of blocking.`,
 		// Skip in hub context (inside a container, the agent is already
 		// running — image_registry is not needed).
 		requiresRegistry := requiresGrove
-		switch cmdName {
-		case "config", "doctor":
-			requiresRegistry = false
-		}
 		if commandInSubtree(cmd, "config") {
 			requiresRegistry = false
 		}
-		if commandInSubtree(cmd, "hub") {
+		if commandInSubtree(cmd, "hub") || commandInSubtree(cmd, "server") {
 			requiresRegistry = false
 		}
 		if requiresRegistry && config.IsHubContext() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -170,6 +170,48 @@ func TestHubAuthLoginDoesNotRequireImageRegistry(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestServerStartDoesNotRequireImageRegistry(t *testing.T) {
+	origGlobalMode := globalMode
+	origGrovePath := grovePath
+	origProfile := profile
+	origOutputFormat := outputFormat
+	origNoHub := noHub
+	origNonInteractive := nonInteractive
+	origAutoConfirm := autoConfirm
+	defer func() {
+		globalMode = origGlobalMode
+		grovePath = origGrovePath
+		profile = origProfile
+		outputFormat = origOutputFormat
+		noHub = origNoHub
+		nonInteractive = origNonInteractive
+		autoConfirm = origAutoConfirm
+	}()
+
+	t.Setenv("SCION_HOST_UID", "")
+
+	// Create a temp home with a global .scion dir but NO image_registry
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".scion"), 0755); err != nil {
+		t.Fatalf("failed to create test global scion dir: %v", err)
+	}
+
+	globalMode = true
+	grovePath = ""
+	profile = ""
+	outputFormat = ""
+	noHub = true
+	nonInteractive = true
+	autoConfirm = true
+
+	// serverStartCmd is a subcommand of serverCmd — its Name() is "start",
+	// not "server". The PersistentPreRunE should still skip the image_registry
+	// check because it's in the server subtree.
+	err := rootCmd.PersistentPreRunE(serverStartCmd, []string{})
+	assert.NoError(t, err, "server start should not require image_registry")
+}
+
 func TestDevAuthWarning(t *testing.T) {
 	// Save and restore original flags
 	origNoHub := noHub


### PR DESCRIPTION
## Summary

- `scion server start` (and other server subcommands) fail with `image_registry is not configured` and require a grove context even though the server doesn't need either
- Root cause: `PersistentPreRunE` exempted `"server"` by matching `cmd.Name()`, but subcommands like `start` have `cmd.Name() == "start"` — so neither the grove nor registry exemption applied
- Fix: use `commandInSubtree(cmd, "server")` for both `requiresGrove` and `requiresRegistry`, matching the existing pattern for `config` and `hub`
- Clean up: remove redundant `switch` cases (`config`, `doctor`) that were already covered by upstream logic, and combine `hub`/`server` subtree checks

## Test plan

- [x] New test `TestServerStartDoesNotRequireImageRegistry` (TDD — wrote test first, verified failure, then applied fix)
- [x] Existing `TestHubAuthLoginDoesNotRequireImageRegistry` still passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)