### PR TITLE
feat(harness): add OAuth token and credentials-file auth for Claude

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -321,10 +321,10 @@ func RunAgent(cmd *cobra.Command, args []string, resume bool) error {
 	// Validate --harness-auth value
 	if harnessAuthFlag != "" {
 		switch harnessAuthFlag {
-		case "api-key", "vertex-ai", "auth-file":
+		case "api-key", "oauth-token", "auth-file", "vertex-ai":
 			// valid
 		default:
-			return fmt.Errorf("invalid --harness-auth value %q: must be one of api-key, vertex-ai, auth-file", harnessAuthFlag)
+			return fmt.Errorf("invalid --harness-auth value %q: must be one of api-key, oauth-token, auth-file, vertex-ai", harnessAuthFlag)
 		}
 	}
 

--- a/cmd/config_schema.go
+++ b/cmd/config_schema.go
@@ -66,7 +66,7 @@ func configSchemaFields() []schemaField {
 		{Name: "image", Type: "string", Description: "Container image"},
 		{Name: "model", Type: "string", Description: "LLM model to use"},
 		{Name: "user", Type: "string", Description: "Container unix user"},
-		{Name: "auth_selected_type", Type: "string", Description: "Auth method (api-key, vertex-ai, auth-file)"},
+		{Name: "auth_selected_type", Type: "string", Description: "Auth method (api-key, oauth-token, auth-file, vertex-ai)"},
 		{Name: "task", Type: "string", Description: "Task prompt for the agent"},
 		{Name: "branch", Type: "string", Description: "Git branch for the agent workspace"},
 		{Name: "system_prompt", Type: "string", Description: "System prompt (inline text or file:// URI)"},

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -50,10 +50,10 @@ arguments are provided, an empty prompt.md is created for later editing.`,
 		// Validate --harness-auth value
 		if harnessAuthFlag != "" {
 			switch harnessAuthFlag {
-			case "api-key", "vertex-ai", "auth-file":
+			case "api-key", "oauth-token", "auth-file", "vertex-ai":
 				// valid
 			default:
-				return fmt.Errorf("invalid --harness-auth value %q: must be one of api-key, vertex-ai, auth-file", harnessAuthFlag)
+				return fmt.Errorf("invalid --harness-auth value %q: must be one of api-key, oauth-token, auth-file, vertex-ai", harnessAuthFlag)
 			}
 		}
 
@@ -282,7 +282,7 @@ func init() {
 	createCmd.Flags().StringVar(&harnessConfigFlag, "harness-config", "", "Named harness configuration to use")
 	createCmd.Flags().StringVar(&harnessConfigFlag, "harness", "h", "Named harness configuration to use (alias for --harness-config)")
 
-	createCmd.Flags().StringVar(&harnessAuthFlag, "harness-auth", "", "Override auth method for the harness (api-key, vertex-ai, auth-file)")
+	createCmd.Flags().StringVar(&harnessAuthFlag, "harness-auth", "", "Override auth method for the harness (api-key, oauth-token, auth-file, vertex-ai)")
 
 	// Template resolution flags for Hub mode (Section 9.4)
 	createCmd.Flags().BoolVar(&uploadTemplate, "upload-template", false, "Automatically upload local template to Hub if not found")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -56,7 +56,7 @@ func init() {
 	startCmd.Flags().StringVar(&harnessConfigFlag, "harness-config", "", "Named harness configuration to use")
 	startCmd.Flags().StringVar(&harnessConfigFlag, "harness", "", "Named harness configuration to use (alias for --harness-config)")
 
-	startCmd.Flags().StringVar(&harnessAuthFlag, "harness-auth", "", "Override auth method for the harness (api-key, vertex-ai, auth-file)")
+	startCmd.Flags().StringVar(&harnessAuthFlag, "harness-auth", "", "Override auth method for the harness (api-key, oauth-token, auth-file, vertex-ai)")
 
 	// Notification flag
 	startCmd.Flags().BoolVar(&notify, "notify", false, "Get notified when the spawned agent reaches a terminal state")

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -363,13 +363,15 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		if opts.BrokerMode {
 			harness.OverlayFileSecrets(&auth, opts.ResolvedSecrets)
 		}
-		util.Debugf("auth: gathered credentials — selectedType=%q, hasGeminiKey=%t, hasGoogleKey=%t, hasOAuth=%t, hasADC=%t, hasAnthropicKey=%t, cloudProject=%q, gcpMetadataMode=%q, brokerMode=%t",
+		util.Debugf("auth: gathered credentials — selectedType=%q, hasGeminiKey=%t, hasGoogleKey=%t, hasOAuth=%t, hasADC=%t, hasAnthropicKey=%t, hasClaudeOAuthToken=%t, hasClaudeAuthFile=%t, cloudProject=%q, gcpMetadataMode=%q, brokerMode=%t",
 			auth.SelectedType,
 			auth.GeminiAPIKey != "",
 			auth.GoogleAPIKey != "",
 			auth.OAuthCreds != "",
 			auth.GoogleAppCredentials != "",
 			auth.AnthropicAPIKey != "",
+			auth.ClaudeOAuthToken != "",
+			auth.ClaudeAuthFile != "",
 			auth.GoogleCloudProject,
 			auth.GCPMetadataMode,
 			opts.BrokerMode,
@@ -1064,6 +1066,7 @@ func isAuthEnvKey(key string) bool {
 	case "GEMINI_API_KEY",
 		"GOOGLE_API_KEY",
 		"ANTHROPIC_API_KEY",
+		"CLAUDE_CODE_OAUTH_TOKEN",
 		"OPENAI_API_KEY",
 		"CODEX_API_KEY",
 		"GOOGLE_CLOUD_PROJECT",
@@ -1088,6 +1091,8 @@ func authFileKind(name, target string) string {
 		return "codex-auth"
 	case name == "OPENCODE_AUTH" || strings.HasSuffix(target, "/opencode/auth.json"):
 		return "opencode-auth"
+	case name == "CLAUDE_AUTH" || strings.HasSuffix(target, "/.claude/.credentials.json"):
+		return "claude-auth"
 	default:
 		return ""
 	}

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -407,6 +407,26 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		}
 		resolvedAuth = resolved
 		opts.ResolvedSecrets = filterResolvedSecretsForResolvedAuth(opts.ResolvedSecrets, &resolvedForSecretFilter)
+		// The hub pre-merges environment-type secrets into ResolvedEnv before
+		// dispatching to the broker (see pkg/hub/httpdispatcher.go), so auth
+		// env keys copied into opts.Env via start_context's ResolvedEnv merge
+		// would otherwise slip through even after ResolvedSecrets filtering.
+		// Drop auth-candidate env keys that the resolved auth method does not
+		// use, mirroring the ResolvedSecrets filter.
+		if len(opts.Env) > 0 {
+			requiredAuthEnv := make(map[string]struct{}, len(resolvedForSecretFilter.EnvVars))
+			for k := range resolvedForSecretFilter.EnvVars {
+				requiredAuthEnv[k] = struct{}{}
+			}
+			for k := range opts.Env {
+				if !isAuthEnvKey(k) {
+					continue
+				}
+				if _, required := requiredAuthEnv[k]; !required {
+					delete(opts.Env, k)
+				}
+			}
+		}
 
 		// Persist the resolved auth method so it can be reported to the Hub.
 		// For auto-detected auth, opts.HarnessAuth may be empty; capture the

--- a/pkg/api/harness_capabilities.go
+++ b/pkg/api/harness_capabilities.go
@@ -50,9 +50,10 @@ type HarnessPromptCapabilities struct {
 
 // HarnessAuthCapabilities describes support for auth mode selections.
 type HarnessAuthCapabilities struct {
-	APIKey   CapabilityField `json:"api_key"`
-	AuthFile CapabilityField `json:"auth_file"`
-	VertexAI CapabilityField `json:"vertex_ai"`
+	APIKey     CapabilityField `json:"api_key"`
+	AuthFile   CapabilityField `json:"auth_file"`
+	OAuthToken CapabilityField `json:"oauth_token"`
+	VertexAI   CapabilityField `json:"vertex_ai"`
 }
 
 // HarnessAdvancedCapabilities describes advanced field support for a harness.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -367,7 +367,9 @@ type AuthConfig struct {
 	OAuthCreds           string
 
 	// Anthropic auth
-	AnthropicAPIKey string
+	AnthropicAPIKey  string
+	ClaudeOAuthToken string // CLAUDE_CODE_OAUTH_TOKEN (long-lived, from `claude setup-token`)
+	ClaudeAuthFile   string // ~/.claude/.credentials.json path (rotating refresh-token store)
 
 	// OpenAI/Codex auth
 	OpenAIAPIKey     string
@@ -410,7 +412,7 @@ type AgentInfo struct {
 	Name          string `json:"name"`                  // Human-friendly display name
 	Template      string `json:"template"`
 	HarnessConfig string `json:"harnessConfig,omitempty"` // Resolved harness-config name
-	HarnessAuth   string `json:"harnessAuth,omitempty"`   // Resolved harness auth method (api-key, vertex-ai, auth-file)
+	HarnessAuth   string `json:"harnessAuth,omitempty"`   // Resolved harness auth method (api-key, oauth-token, auth-file, vertex-ai)
 
 	// Grove association
 	Grove     string `json:"grove"`               // Grove name (legacy, simple string)
@@ -568,7 +570,7 @@ type StartOptions struct {
 	TemplateName      string // Human-friendly template slug (overrides Template for labels when hydration replaces Template with a cache path)
 	Profile           string
 	HarnessConfig     string
-	HarnessAuth       string // Late-binding override for auth_selected_type (api-key, vertex-ai, auth-file)
+	HarnessAuth       string // Late-binding override for auth_selected_type (api-key, oauth-token, auth-file, vertex-ai)
 	Image             string
 	GrovePath         string
 	Env               map[string]string

--- a/pkg/config/schemas/agent-v1.schema.json
+++ b/pkg/config/schemas/agent-v1.schema.json
@@ -90,8 +90,8 @@
     },
     "auth_selectedType": {
       "type": "string",
-      "enum": ["api-key", "auth-file", "vertex-ai"],
-      "description": "Authentication mechanism to use (e.g., api-key, vertex-ai, auth-file)."
+      "enum": ["api-key", "oauth-token", "auth-file", "vertex-ai"],
+      "description": "Authentication mechanism to use (e.g., api-key, oauth-token, vertex-ai, auth-file)."
     },
     "hub": {
       "type": "object",

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -263,8 +263,8 @@
         },
         "auth_selected_type": {
           "type": "string",
-          "enum": ["api-key", "auth-file", "vertex-ai"],
-          "description": "Authentication mechanism to use (e.g., api-key, vertex-ai, auth-file)."
+          "enum": ["api-key", "oauth-token", "auth-file", "vertex-ai"],
+          "description": "Authentication mechanism to use (e.g., api-key, oauth-token, vertex-ai, auth-file)."
         },
         "secrets": {
           "type": "array",
@@ -332,7 +332,7 @@
         "resources": { "$ref": "#/$defs/resourceSpec" },
         "auth_selected_type": {
           "type": "string",
-          "enum": ["api-key", "auth-file", "vertex-ai"]
+          "enum": ["api-key", "oauth-token", "auth-file", "vertex-ai"]
         }
       },
       "additionalProperties": false

--- a/pkg/harness/auth.go
+++ b/pkg/harness/auth.go
@@ -54,11 +54,12 @@ func GatherAuthWithEnv(env map[string]string, localSources bool) api.AuthConfig 
 
 	auth := api.AuthConfig{
 		// Env-var sourced fields
-		GeminiAPIKey:    lookup("GEMINI_API_KEY"),
-		GoogleAPIKey:    lookup("GOOGLE_API_KEY"),
-		AnthropicAPIKey: lookup("ANTHROPIC_API_KEY"),
-		OpenAIAPIKey:    lookup("OPENAI_API_KEY"),
-		CodexAPIKey:     lookup("CODEX_API_KEY"),
+		GeminiAPIKey:     lookup("GEMINI_API_KEY"),
+		GoogleAPIKey:     lookup("GOOGLE_API_KEY"),
+		AnthropicAPIKey:  lookup("ANTHROPIC_API_KEY"),
+		ClaudeOAuthToken: lookup("CLAUDE_CODE_OAUTH_TOKEN"),
+		OpenAIAPIKey:     lookup("OPENAI_API_KEY"),
+		CodexAPIKey:      lookup("CODEX_API_KEY"),
 		GoogleCloudProject: util.FirstNonEmpty(
 			lookup("GOOGLE_CLOUD_PROJECT"),
 			lookup("GCP_PROJECT"),
@@ -99,6 +100,16 @@ func GatherAuthWithEnv(env map[string]string, localSources bool) api.AuthConfig 
 			if _, err := os.Stat(opencodePath); err == nil {
 				auth.OpenCodeAuthFile = opencodePath
 			}
+
+			// Claude Code's rotating credentials store. Unlike Gemini/Codex/
+			// OpenCode we do NOT parse this file — we treat it as an opaque
+			// file to mount into the container so Claude Code can read and
+			// refresh it natively. The access token inside rotates; scraping
+			// it at gather time would hand the container a stale snapshot.
+			claudeCredsPath := filepath.Join(home, ".claude", ".credentials.json")
+			if _, err := os.Stat(claudeCredsPath); err == nil {
+				auth.ClaudeAuthFile = claudeCredsPath
+			}
 		}
 	}
 
@@ -131,6 +142,9 @@ func OverlayFileSecrets(auth *api.AuthConfig, secrets []api.ResolvedSecret) {
 		case name == "OPENCODE_AUTH" ||
 			strings.HasSuffix(target, "/opencode/auth.json"):
 			auth.OpenCodeAuthFile = target
+		case name == "CLAUDE_AUTH" ||
+			strings.HasSuffix(target, "/.claude/.credentials.json"):
+			auth.ClaudeAuthFile = target
 		}
 	}
 }
@@ -247,7 +261,10 @@ func DetectAuthTypeFromFileSecrets(harnessName string, fileSecretNames map[strin
 			return "vertex-ai"
 		}
 	case "claude":
-		// Auto-detect priority: api-key → ADC (vertex-ai)
+		// Auto-detect priority: api-key → oauth-token (env) → auth-file → ADC (vertex-ai)
+		if _, ok := fileSecretNames["CLAUDE_AUTH"]; ok {
+			return "auth-file"
+		}
 		if _, ok := fileSecretNames["gcloud-adc"]; ok {
 			return "vertex-ai"
 		}
@@ -269,7 +286,14 @@ func DetectAuthTypeFromFileSecrets(harnessName string, fileSecretNames map[strin
 // so vertex-ai auth can be used without a gcloud-adc file secret.
 func DetectAuthTypeFromEnvVars(harnessName string, envKeys map[string]struct{}) string {
 	switch harnessName {
-	case "claude", "gemini":
+	case "claude":
+		if _, ok := envKeys["CLAUDE_CODE_OAUTH_TOKEN"]; ok {
+			return "oauth-token"
+		}
+		if _, ok := envKeys["GOOGLE_APPLICATION_CREDENTIALS"]; ok {
+			return "vertex-ai"
+		}
+	case "gemini":
 		if _, ok := envKeys["GOOGLE_APPLICATION_CREDENTIALS"]; ok {
 			return "vertex-ai"
 		}
@@ -312,6 +336,10 @@ func RequiredAuthEnvKeys(harnessName, authSelectedType string) [][]string {
 		switch effectiveType {
 		case "api-key":
 			return [][]string{{"ANTHROPIC_API_KEY"}}
+		case "oauth-token":
+			return [][]string{{"CLAUDE_CODE_OAUTH_TOKEN"}}
+		case "auth-file":
+			return nil
 		case "vertex-ai":
 			return [][]string{{"GOOGLE_CLOUD_PROJECT"}, {"GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"}}
 		}

--- a/pkg/harness/auth_test.go
+++ b/pkg/harness/auth_test.go
@@ -28,6 +28,7 @@ func TestGatherAuth_EnvVars(t *testing.T) {
 	t.Setenv("GEMINI_API_KEY", "gemini-key")
 	t.Setenv("GOOGLE_API_KEY", "google-key")
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-key")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "claude-oauth-tok")
 	t.Setenv("OPENAI_API_KEY", "openai-key")
 	t.Setenv("CODEX_API_KEY", "codex-key")
 	t.Setenv("GOOGLE_CLOUD_PROJECT", "my-project")
@@ -44,6 +45,9 @@ func TestGatherAuth_EnvVars(t *testing.T) {
 	}
 	if auth.AnthropicAPIKey != "anthropic-key" {
 		t.Errorf("AnthropicAPIKey = %q, want %q", auth.AnthropicAPIKey, "anthropic-key")
+	}
+	if auth.ClaudeOAuthToken != "claude-oauth-tok" {
+		t.Errorf("ClaudeOAuthToken = %q, want %q", auth.ClaudeOAuthToken, "claude-oauth-tok")
 	}
 	if auth.OpenAIAPIKey != "openai-key" {
 		t.Errorf("OpenAIAPIKey = %q, want %q", auth.OpenAIAPIKey, "openai-key")
@@ -139,6 +143,10 @@ func TestGatherAuth_FileDiscovery(t *testing.T) {
 	os.MkdirAll(filepath.Dir(opencodePath), 0755)
 	os.WriteFile(opencodePath, []byte(`{"dummy":"opencode"}`), 0644)
 
+	claudeCredsPath := filepath.Join(tmpHome, ".claude", ".credentials.json")
+	os.MkdirAll(filepath.Dir(claudeCredsPath), 0755)
+	os.WriteFile(claudeCredsPath, []byte(`{"claudeAiOauth":{"accessToken":"rotating"}}`), 0644)
+
 	auth := GatherAuth()
 
 	if auth.GoogleAppCredentials != adcPath {
@@ -152,6 +160,15 @@ func TestGatherAuth_FileDiscovery(t *testing.T) {
 	}
 	if auth.OpenCodeAuthFile != opencodePath {
 		t.Errorf("OpenCodeAuthFile = %q, want %q", auth.OpenCodeAuthFile, opencodePath)
+	}
+	if auth.ClaudeAuthFile != claudeCredsPath {
+		t.Errorf("ClaudeAuthFile = %q, want %q", auth.ClaudeAuthFile, claudeCredsPath)
+	}
+	// The file must be treated opaquely — we must NOT have read/parsed
+	// any content out of it into ClaudeOAuthToken. That field only comes
+	// from the CLAUDE_CODE_OAUTH_TOKEN env var.
+	if auth.ClaudeOAuthToken != "" {
+		t.Errorf("ClaudeOAuthToken = %q, want empty (must not scrape from credentials file)", auth.ClaudeOAuthToken)
 	}
 }
 
@@ -204,6 +221,9 @@ func TestGatherAuth_NoFiles(t *testing.T) {
 	}
 	if auth.OpenCodeAuthFile != "" {
 		t.Errorf("OpenCodeAuthFile = %q, want empty", auth.OpenCodeAuthFile)
+	}
+	if auth.ClaudeAuthFile != "" {
+		t.Errorf("ClaudeAuthFile = %q, want empty", auth.ClaudeAuthFile)
 	}
 }
 
@@ -369,6 +389,7 @@ func TestRequiredAuthEnvKeys(t *testing.T) {
 	}{
 		// Claude
 		{"claude api-key", "claude", "api-key", [][]string{{"ANTHROPIC_API_KEY"}}},
+		{"claude oauth-token", "claude", "oauth-token", [][]string{{"CLAUDE_CODE_OAUTH_TOKEN"}}},
 		{"claude auth-file", "claude", "auth-file", nil},
 		{"claude vertex-ai", "claude", "vertex-ai", [][]string{{"GOOGLE_CLOUD_PROJECT"}, {"GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"}}},
 
@@ -524,7 +545,10 @@ func TestDetectAuthTypeFromEnvVars(t *testing.T) {
 		wantType string
 	}{
 		{"claude with GAC", "claude", map[string]struct{}{"GOOGLE_APPLICATION_CREDENTIALS": {}}, "vertex-ai"},
+		{"claude with CLAUDE_CODE_OAUTH_TOKEN", "claude", map[string]struct{}{"CLAUDE_CODE_OAUTH_TOKEN": {}}, "oauth-token"},
+		{"claude prefers OAuth token over GAC", "claude", map[string]struct{}{"CLAUDE_CODE_OAUTH_TOKEN": {}, "GOOGLE_APPLICATION_CREDENTIALS": {}}, "oauth-token"},
 		{"gemini with GAC", "gemini", map[string]struct{}{"GOOGLE_APPLICATION_CREDENTIALS": {}}, "vertex-ai"},
+		{"gemini with CLAUDE_CODE_OAUTH_TOKEN", "gemini", map[string]struct{}{"CLAUDE_CODE_OAUTH_TOKEN": {}}, ""},
 		{"claude without GAC", "claude", map[string]struct{}{}, ""},
 		{"gemini without GAC", "gemini", map[string]struct{}{}, ""},
 		{"opencode with GAC", "opencode", map[string]struct{}{"GOOGLE_APPLICATION_CREDENTIALS": {}}, ""},
@@ -591,6 +615,18 @@ func TestDetectAuthTypeFromFileSecrets(t *testing.T) {
 			"claude",
 			map[string]struct{}{"gcloud-adc": {}},
 			"vertex-ai",
+		},
+		{
+			"claude with CLAUDE_AUTH",
+			"claude",
+			map[string]struct{}{"CLAUDE_AUTH": {}},
+			"auth-file",
+		},
+		{
+			"claude prefers CLAUDE_AUTH over gcloud-adc",
+			"claude",
+			map[string]struct{}{"CLAUDE_AUTH": {}, "gcloud-adc": {}},
+			"auth-file",
 		},
 		{
 			"claude with no file secrets",
@@ -822,6 +858,9 @@ func TestGatherAuthWithEnv_BrokerMode(t *testing.T) {
 	if auth.OAuthCreds != "" {
 		t.Errorf("OAuthCreds = %q, want empty (filesystem should not be scanned)", auth.OAuthCreds)
 	}
+	if auth.ClaudeAuthFile != "" {
+		t.Errorf("ClaudeAuthFile = %q, want empty (filesystem should not be scanned)", auth.ClaudeAuthFile)
+	}
 }
 
 func TestOverlayFileSecrets(t *testing.T) {
@@ -882,6 +921,28 @@ func TestOverlayFileSecrets(t *testing.T) {
 			check: func(t *testing.T, auth api.AuthConfig) {
 				if auth.OpenCodeAuthFile != "/home/gemini/.local/share/opencode/auth.json" {
 					t.Errorf("OpenCodeAuthFile = %q, want opencode path", auth.OpenCodeAuthFile)
+				}
+			},
+		},
+		{
+			name: "Claude credentials by name",
+			secrets: []api.ResolvedSecret{
+				{Name: "CLAUDE_AUTH", Type: "file", Target: "/home/agent/.claude/.credentials.json"},
+			},
+			check: func(t *testing.T, auth api.AuthConfig) {
+				if auth.ClaudeAuthFile != "/home/agent/.claude/.credentials.json" {
+					t.Errorf("ClaudeAuthFile = %q, want credentials path", auth.ClaudeAuthFile)
+				}
+			},
+		},
+		{
+			name: "Claude credentials by target suffix",
+			secrets: []api.ResolvedSecret{
+				{Name: "my-claude-creds", Type: "file", Target: "/home/agent/.claude/.credentials.json"},
+			},
+			check: func(t *testing.T, auth api.AuthConfig) {
+				if auth.ClaudeAuthFile == "" {
+					t.Error("ClaudeAuthFile should be set from target suffix match")
 				}
 			},
 		},

--- a/pkg/harness/capabilities_test.go
+++ b/pkg/harness/capabilities_test.go
@@ -47,7 +47,7 @@ func TestAdvancedCapabilitiesDefaults(t *testing.T) {
 			expectMaxTurns:      api.SupportYes,
 			expectMaxModelCalls: api.SupportNo,
 			expectMaxDuration:   api.SupportYes,
-			expectAuthFile:      api.SupportNo,
+			expectAuthFile:      api.SupportYes,
 			expectVertexAI:      api.SupportYes,
 			expectSystemPrompt:  api.SupportYes,
 		},

--- a/pkg/harness/claude_code.go
+++ b/pkg/harness/claude_code.go
@@ -53,9 +53,10 @@ func (c *ClaudeCode) AdvancedCapabilities() api.HarnessAdvancedCapabilities {
 			AgentInstructions: api.CapabilityField{Support: api.SupportYes},
 		},
 		Auth: api.HarnessAuthCapabilities{
-			APIKey:   api.CapabilityField{Support: api.SupportYes},
-			AuthFile: api.CapabilityField{Support: api.SupportNo, Reason: "Claude does not support auth-file mode"},
-			VertexAI: api.CapabilityField{Support: api.SupportYes},
+			APIKey:     api.CapabilityField{Support: api.SupportYes},
+			AuthFile:   api.CapabilityField{Support: api.SupportYes},
+			OAuthToken: api.CapabilityField{Support: api.SupportYes},
+			VertexAI:   api.CapabilityField{Support: api.SupportYes},
 		},
 	}
 }
@@ -121,6 +122,12 @@ func (c *ClaudeCode) Provision(ctx context.Context, agentName, agentDir, agentHo
 	switch cfg.AuthSelectedType {
 	case "api-key":
 		envUpdates = map[string]string{"ANTHROPIC_API_KEY": "${ANTHROPIC_API_KEY}"}
+	case "oauth-token":
+		envUpdates = map[string]string{"CLAUDE_CODE_OAUTH_TOKEN": "${CLAUDE_CODE_OAUTH_TOKEN}"}
+	case "auth-file":
+		// No env updates — the credentials file is mounted into the
+		// container at ~/.claude/.credentials.json and Claude Code reads
+		// and refreshes it natively.
 	case "vertex-ai":
 		// NOTE: gcloud credentials are mounted by buildCommonRunArgs in
 		// pkg/runtime/common.go, gated on !BrokerMode.  Do NOT add a
@@ -341,17 +348,37 @@ func (c *ClaudeCode) ResolveAuth(auth api.AuthConfig) (*api.ResolvedAuth, error)
 					"ANTHROPIC_API_KEY": auth.AnthropicAPIKey,
 				},
 			}, nil
+		case "oauth-token":
+			if auth.ClaudeOAuthToken == "" {
+				return nil, fmt.Errorf("claude: auth type %q selected but no OAuth token found; set CLAUDE_CODE_OAUTH_TOKEN (generate with `claude setup-token`)", auth.SelectedType)
+			}
+			return &api.ResolvedAuth{
+				Method: "oauth-token",
+				EnvVars: map[string]string{
+					"CLAUDE_CODE_OAUTH_TOKEN": auth.ClaudeOAuthToken,
+				},
+			}, nil
+		case "auth-file":
+			if auth.ClaudeAuthFile == "" {
+				return nil, fmt.Errorf("claude: auth type %q selected but no credentials file found; expected ~/.claude/.credentials.json", auth.SelectedType)
+			}
+			return &api.ResolvedAuth{
+				Method: "auth-file",
+				Files: []api.FileMapping{
+					{SourcePath: auth.ClaudeAuthFile, ContainerPath: "~/.claude/.credentials.json"},
+				},
+			}, nil
 		case "vertex-ai":
 			if auth.GoogleCloudProject == "" || auth.GoogleCloudRegion == "" {
 				return nil, fmt.Errorf("claude: auth type %q selected but GOOGLE_CLOUD_PROJECT and/or GOOGLE_CLOUD_REGION not set", auth.SelectedType)
 			}
 			return c.resolveVertexAI(auth), nil
 		default:
-			return nil, fmt.Errorf("claude: unknown auth type %q; valid types are: api-key, vertex-ai", auth.SelectedType)
+			return nil, fmt.Errorf("claude: unknown auth type %q; valid types are: api-key, oauth-token, auth-file, vertex-ai", auth.SelectedType)
 		}
 	}
 
-	// Auto-detect preference order: API key → Vertex AI → error
+	// Auto-detect preference order: API key → OAuth token → credentials file → Vertex AI → error
 
 	// 1. Anthropic API key (direct)
 	if auth.AnthropicAPIKey != "" {
@@ -363,14 +390,38 @@ func (c *ClaudeCode) ResolveAuth(auth api.AuthConfig) (*api.ResolvedAuth, error)
 		}, nil
 	}
 
-	// 2. Vertex AI — requires project + region, plus either ADC file or
+	// 2. CLAUDE_CODE_OAUTH_TOKEN (long-lived subscription token from
+	//    `claude setup-token`). Higher priority than the credentials file
+	//    because it does not rotate and therefore survives long sessions.
+	if auth.ClaudeOAuthToken != "" {
+		return &api.ResolvedAuth{
+			Method: "oauth-token",
+			EnvVars: map[string]string{
+				"CLAUDE_CODE_OAUTH_TOKEN": auth.ClaudeOAuthToken,
+			},
+		}, nil
+	}
+
+	// 3. ~/.claude/.credentials.json — rotating refresh-token store managed
+	//    by Claude Code. We mount the file into the container so Claude Code
+	//    can read and refresh it natively rather than scraping a snapshot.
+	if auth.ClaudeAuthFile != "" {
+		return &api.ResolvedAuth{
+			Method: "auth-file",
+			Files: []api.FileMapping{
+				{SourcePath: auth.ClaudeAuthFile, ContainerPath: "~/.claude/.credentials.json"},
+			},
+		}, nil
+	}
+
+	// 4. Vertex AI — requires project + region, plus either ADC file or
 	//    a GCP service account via the metadata server (assign mode).
 	hasVertexCreds := auth.GoogleAppCredentials != "" || auth.GCPMetadataMode == "assign"
 	if hasVertexCreds && auth.GoogleCloudProject != "" && auth.GoogleCloudRegion != "" {
 		return c.resolveVertexAI(auth), nil
 	}
 
-	return nil, fmt.Errorf("claude: no valid auth method found; set ANTHROPIC_API_KEY for direct API access, or provide ADC (gcloud-adc secret, GCP service account, or ~/.config/gcloud/application_default_credentials.json) + GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_REGION for Vertex AI")
+	return nil, fmt.Errorf("claude: no valid auth method found; set ANTHROPIC_API_KEY for direct API access, CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`) or ~/.claude/.credentials.json for subscription auth, or provide ADC (gcloud-adc secret, GCP service account, or ~/.config/gcloud/application_default_credentials.json) + GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_REGION for Vertex AI")
 }
 
 func (c *ClaudeCode) resolveVertexAI(auth api.AuthConfig) *api.ResolvedAuth {

--- a/pkg/harness/claude_code_test.go
+++ b/pkg/harness/claude_code_test.go
@@ -543,6 +543,166 @@ func TestClaudeResolveAuth_VertexAI_ExplicitWithGCPSA(t *testing.T) {
 	}
 }
 
+func TestClaudeResolveAuth_OAuthToken(t *testing.T) {
+	c := &ClaudeCode{}
+	auth := api.AuthConfig{ClaudeOAuthToken: "sk-ant-oat-test"}
+	result, err := c.ResolveAuth(auth)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Method != "oauth-token" {
+		t.Errorf("Method = %q, want %q", result.Method, "oauth-token")
+	}
+	if result.EnvVars["CLAUDE_CODE_OAUTH_TOKEN"] != "sk-ant-oat-test" {
+		t.Errorf("CLAUDE_CODE_OAUTH_TOKEN = %q, want %q", result.EnvVars["CLAUDE_CODE_OAUTH_TOKEN"], "sk-ant-oat-test")
+	}
+	if len(result.Files) != 0 {
+		t.Errorf("expected no files for oauth-token, got %d", len(result.Files))
+	}
+}
+
+func TestClaudeResolveAuth_OAuthToken_Explicit(t *testing.T) {
+	c := &ClaudeCode{}
+	auth := api.AuthConfig{
+		SelectedType:     "oauth-token",
+		ClaudeOAuthToken: "sk-ant-oat-test",
+	}
+	result, err := c.ResolveAuth(auth)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Method != "oauth-token" {
+		t.Errorf("Method = %q, want %q", result.Method, "oauth-token")
+	}
+}
+
+func TestClaudeResolveAuth_OAuthToken_ExplicitMissing(t *testing.T) {
+	c := &ClaudeCode{}
+	auth := api.AuthConfig{SelectedType: "oauth-token"}
+	_, err := c.ResolveAuth(auth)
+	if err == nil {
+		t.Fatal("expected error for oauth-token with no token")
+	}
+	if !strings.Contains(err.Error(), "CLAUDE_CODE_OAUTH_TOKEN") {
+		t.Errorf("error should mention CLAUDE_CODE_OAUTH_TOKEN: %v", err)
+	}
+}
+
+func TestClaudeResolveAuth_CredentialsFile(t *testing.T) {
+	c := &ClaudeCode{}
+	auth := api.AuthConfig{ClaudeAuthFile: "/host/home/.claude/.credentials.json"}
+	result, err := c.ResolveAuth(auth)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Method != "auth-file" {
+		t.Errorf("Method = %q, want %q", result.Method, "auth-file")
+	}
+	if len(result.EnvVars) != 0 {
+		t.Errorf("expected no env vars for auth-file, got %v", result.EnvVars)
+	}
+	if len(result.Files) != 1 {
+		t.Fatalf("expected 1 file mapping, got %d", len(result.Files))
+	}
+	if result.Files[0].SourcePath != "/host/home/.claude/.credentials.json" {
+		t.Errorf("SourcePath = %q", result.Files[0].SourcePath)
+	}
+	if result.Files[0].ContainerPath != "~/.claude/.credentials.json" {
+		t.Errorf("ContainerPath = %q, want ~/.claude/.credentials.json", result.Files[0].ContainerPath)
+	}
+}
+
+func TestClaudeResolveAuth_CredentialsFile_Explicit(t *testing.T) {
+	c := &ClaudeCode{}
+	auth := api.AuthConfig{
+		SelectedType:   "auth-file",
+		ClaudeAuthFile: "/host/home/.claude/.credentials.json",
+	}
+	result, err := c.ResolveAuth(auth)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Method != "auth-file" {
+		t.Errorf("Method = %q, want %q", result.Method, "auth-file")
+	}
+}
+
+func TestClaudeResolveAuth_CredentialsFile_ExplicitMissing(t *testing.T) {
+	c := &ClaudeCode{}
+	auth := api.AuthConfig{SelectedType: "auth-file"}
+	_, err := c.ResolveAuth(auth)
+	if err == nil {
+		t.Fatal("expected error for auth-file with no credentials file")
+	}
+	if !strings.Contains(err.Error(), ".credentials.json") {
+		t.Errorf("error should mention .credentials.json: %v", err)
+	}
+}
+
+func TestClaudeResolveAuth_Priority(t *testing.T) {
+	// Auto-detect priority: API key → OAuth token → credentials file → Vertex AI.
+	c := &ClaudeCode{}
+
+	// API key wins over everything else
+	auth := api.AuthConfig{
+		AnthropicAPIKey:      "sk-ant-apikey",
+		ClaudeOAuthToken:     "sk-ant-oat",
+		ClaudeAuthFile:       "/host/.claude/.credentials.json",
+		GoogleAppCredentials: "/host/adc.json",
+		GoogleCloudProject:   "proj",
+		GoogleCloudRegion:    "us-central1",
+	}
+	result, err := c.ResolveAuth(auth)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Method != "api-key" {
+		t.Errorf("api-key should win; Method = %q", result.Method)
+	}
+
+	// OAuth token wins over credentials file and Vertex
+	auth = api.AuthConfig{
+		ClaudeOAuthToken:     "sk-ant-oat",
+		ClaudeAuthFile:       "/host/.claude/.credentials.json",
+		GoogleAppCredentials: "/host/adc.json",
+		GoogleCloudProject:   "proj",
+		GoogleCloudRegion:    "us-central1",
+	}
+	result, err = c.ResolveAuth(auth)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Method != "oauth-token" {
+		t.Errorf("oauth-token should win over auth-file/vertex; Method = %q", result.Method)
+	}
+
+	// Credentials file wins over Vertex
+	auth = api.AuthConfig{
+		ClaudeAuthFile:       "/host/.claude/.credentials.json",
+		GoogleAppCredentials: "/host/adc.json",
+		GoogleCloudProject:   "proj",
+		GoogleCloudRegion:    "us-central1",
+	}
+	result, err = c.ResolveAuth(auth)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Method != "auth-file" {
+		t.Errorf("auth-file should win over vertex-ai; Method = %q", result.Method)
+	}
+}
+
+func TestClaudeResolveAuth_UnknownType(t *testing.T) {
+	c := &ClaudeCode{}
+	_, err := c.ResolveAuth(api.AuthConfig{SelectedType: "bogus"})
+	if err == nil {
+		t.Fatal("expected error for unknown auth type")
+	}
+	if !strings.Contains(err.Error(), "oauth-token") || !strings.Contains(err.Error(), "auth-file") {
+		t.Errorf("error should list valid types including oauth-token and auth-file: %v", err)
+	}
+}
+
 func TestClaudeResolveAuth_APIKeyWinsOverGCPSA(t *testing.T) {
 	c := &ClaudeCode{}
 	auth := api.AuthConfig{

--- a/pkg/hub/harness_capabilities.go
+++ b/pkg/hub/harness_capabilities.go
@@ -148,6 +148,10 @@ func validateConfigAgainstHarnessCapabilities(cfg *api.ScionConfig, caps api.Har
 			if caps.Auth.APIKey.Support == api.SupportNo {
 				issues["auth_selectedType"] = supportReason(caps.Auth.APIKey)
 			}
+		case "oauth-token":
+			if caps.Auth.OAuthToken.Support == api.SupportNo {
+				issues["auth_selectedType"] = supportReason(caps.Auth.OAuthToken)
+			}
 		case "auth-file":
 			if caps.Auth.AuthFile.Support == api.SupportNo {
 				issues["auth_selectedType"] = supportReason(caps.Auth.AuthFile)

--- a/pkg/runtimebroker/handlers_envgather_test.go
+++ b/pkg/runtimebroker/handlers_envgather_test.go
@@ -31,6 +31,12 @@ import (
 func newTestServerWithGrovePath(t *testing.T, settingsYAML string) (*Server, *envCapturingManager, string) {
 	t.Helper()
 
+	// Isolate HOME so LoadEffectiveSettings does not merge the developer's
+	// personal ~/.scion/settings.yaml (which may declare harness-config
+	// auth_selected_type values that would override the test fixture).
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+
 	// Create temp grove directory with settings
 	// LoadEffectiveSettings expects a dir that contains settings.yaml directly
 	groveDir := t.TempDir()
@@ -478,6 +484,12 @@ func TestCreateAgent_IdempotentByRequestID(t *testing.T) {
 // that has a harness-config directory and optional settings YAML.
 func newTestServerWithHarnessConfig(t *testing.T, harnessConfigName, configYAML, settingsYAML string) (*Server, *envCapturingManager, string) {
 	t.Helper()
+
+	// Isolate HOME so LoadEffectiveSettings does not merge the developer's
+	// personal ~/.scion/settings.yaml (which may declare harness-config
+	// auth_selected_type values that would override the test fixture).
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
 
 	groveDir := t.TempDir()
 

--- a/web/src/components/pages/agent-configure.ts
+++ b/web/src/components/pages/agent-configure.ts
@@ -148,6 +148,8 @@ export class ScionPageAgentConfigure extends LitElement {
     switch (method) {
       case 'api-key':
         return authCaps.api_key;
+      case 'oauth-token':
+        return authCaps.oauth_token;
       case 'auth-file':
         return authCaps.auth_file;
       case 'vertex-ai':
@@ -778,6 +780,7 @@ export class ScionPageAgentConfigure extends LitElement {
 
   private renderGeneralTab() {
     const authFileCap = this.harnessCapabilities?.auth.auth_file;
+    const oauthTokenCap = this.harnessCapabilities?.auth.oauth_token;
     const vertexCap = this.harnessCapabilities?.auth.vertex_ai;
     const telemetryCap = this.harnessCapabilities?.telemetry.enabled;
     const selectedAuthCap = this.authFieldForMethod(this.authMethod);
@@ -828,6 +831,7 @@ export class ScionPageAgentConfigure extends LitElement {
         >
           <sl-option value="">Auto Detected</sl-option>
           <sl-option value="api-key">Provider API Key</sl-option>
+          <sl-option value="oauth-token" ?disabled=${this.isUnsupported(oauthTokenCap)}>OAuth Token (env var)</sl-option>
           <sl-option value="vertex-ai" ?disabled=${this.isUnsupported(vertexCap)}>Vertex Model Garden</sl-option>
           <sl-option value="auth-file" ?disabled=${this.isUnsupported(authFileCap)}>Harness credential file</sl-option>
         </sl-select>

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -1157,6 +1157,7 @@ export class ScionPageAgentCreate extends LitElement {
             >
               <sl-option value="">Auto Detected</sl-option>
               <sl-option value="api-key">Provider API Key</sl-option>
+              <sl-option value="oauth-token">OAuth Token (env var)</sl-option>
               <sl-option value="vertex-ai">Vertex Model Garden</sl-option>
               <sl-option value="auth-file">Harness credential file</sl-option>
             </sl-select>

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -352,6 +352,7 @@ export interface HarnessAdvancedCapabilities {
   auth: {
     api_key: CapabilityField;
     auth_file: CapabilityField;
+    oauth_token: CapabilityField;
     vertex_ai: CapabilityField;
   };
 }


### PR DESCRIPTION
Closes #64.

## Summary

Adds two new auth methods to the Claude harness so Claude subscription users can run SCION agents without an Anthropic API key or Vertex AI setup:

1. **`oauth-token`** — long-lived token from `claude setup-token`, passed via the `CLAUDE_CODE_OAUTH_TOKEN` env var. Safe to share across concurrent agents; equivalent in scope to API-key auth (inference only).
2. **`auth-file`** — projects `~/.claude/.credentials.json` into the container as an opaque file via a `CLAUDE_AUTH` hub file secret, matching the existing pattern for Gemini OAuth, Codex, and OpenCode. Claude Code reads and refreshes the file natively inside the container, enabling full-scope subscription features like Remote Control that the inference-only token cannot access.

## Credit and context

This PR stands on the shoulders of #66 by @donovan-yohan, which opened this conversation and implemented the `oauth-token` half end-to-end. Thanks for getting the ball rolling — the env-var plumbing here follows the same shape and wouldn't have been this quick to put together without it.

Filing this as a new PR rather than pushing changes into #66 because working through the implementation end-to-end led to a meaningfully different approach on the credentials-file path (see below). Keeping the two approaches in separate PRs lets them be reviewed on their merits side-by-side.

## How this differs from #66

#66's first commit adds `CLAUDE_CODE_OAUTH_TOKEN` env-var support. This PR keeps that approach verbatim — it's the right solution for users who want a stable long-lived token and don't need Remote Control.

#66's second commit (`feat: add implicit auth auto-detection for Claude credentials file`) reads `~/.claude/.credentials.json` on the host, extracts the `accessToken` field, and funnels it through the same `CLAUDE_CODE_OAUTH_TOKEN` env-var path. This PR takes a different approach on that half, for three reasons:

1. **The access token in `.credentials.json` rotates.** Claude Code refreshes it every few hours using the refresh token, and the file is rewritten in place. Scraping the access token at gather time hands the container a snapshot that will expire mid-session, with no refresh path (the container can't write back to the host file). Long-running agents would silently start 401'ing when the snapshot ages out.

2. **Full-scope subscription features need the file, not a token.** Remote Control in particular is gated on the credentials file being present: tokens delivered via `CLAUDE_CODE_OAUTH_TOKEN` are treated as inference-only regardless of their origin. Claude Code prefers the env var over the file when both are set, so scraping the token and re-injecting it as env silently downgrades auth-file users back to the inference-only path — `/remote-control` never appears inside the agent session even when a valid credentials file is reachable.

3. **The issue's own "Alternatives Considered" section rules this approach out.** From #64:
   > *Reading the token file (`~/.claude/oauth_token`) directly from the container filesystem — but this couples the harness to Claude Code's internal file layout and doesn't work well across container boundaries. An env var is more portable.*

Instead, this PR treats `.credentials.json` as an opaque file and projects it into the container via SCION's existing file-secret machinery — the same pattern @ptone pointed at in his comment on #64 (*"the general 'harness credential file' that is in other harness types"*). Slotting into the established precedent:

| Harness             | Hub file secret name | Container mount path                |
| ------------------- | -------------------- | ----------------------------------- |
| gemini              | `GEMINI_OAUTH_CREDS` | `~/.gemini/oauth_creds.json`        |
| codex               | `CODEX_AUTH`         | `~/.codex/auth.json`                |
| opencode            | `OPENCODE_AUTH`      | `~/.local/share/opencode/auth.json` |
| **claude** (new)    | **`CLAUDE_AUTH`**    | **`~/.claude/.credentials.json`**   |

SCION itself never parses the file — it's handed to Claude Code intact, and Claude Code's own refresh loop runs inside the container against its own copy. This also means `auth-file` scales cleanly across multiple concurrent agents: each one gets its own snapshot from the hub at start time, refreshes are container-local, and there's no host-side rotation race.

The two methods (`oauth-token` and `auth-file`) are deliberately distinct. Auto-detect priority is:

    api-key → oauth-token → auth-file → vertex-ai → error

API key wins over both subscription paths because it's the most stable. `oauth-token` wins over `auth-file` because the long-lived setup-token doesn't rotate underneath a long-running session. `auth-file` is auto-detected in non-broker mode by `stat`'ing `~/.claude/.credentials.json` (never read or parsed); in broker mode, it's selected when a `CLAUDE_AUTH` hub file secret is present.

## What's in the PR

Three commits:

1. **`feat(harness): add oauth-token and auth-file support for Claude`** — the main change. Adds the new auth fields to `api.AuthConfig`, the `OAuthToken` field to `HarnessAuthCapabilities`, the `oauth-token`/`auth-file` branches in Claude's `ResolveAuth`, the detection rules in `DetectAuthTypeFromEnvVars` / `DetectAuthTypeFromFileSecrets`, the `CLAUDE_AUTH` mapping in `OverlayFileSecrets`, the `CLAUDE_CODE_OAUTH_TOKEN` entry in `isAuthEnvKey`, the `claude-auth` kind in `authFileKind`, and the `RequiredAuthEnvKeys` entries for the new methods. Also wires the new auth type through every place that enumerates the valid set: the hub validator in `pkg/hub/harness_capabilities.go` (previously fell through to "Unknown auth type"), the `agent-v1`/`settings-v1` JSON schemas, the dashboard type definitions and dropdowns in `web/src/`, and the CLI validators + flag help in `cmd/`. Tests cover gather (env + file discovery), overlay (hub file secrets), broker-mode isolation, `ResolveAuth` (explicit selection, auto-detect, missing-creds errors, priority ordering, unknown-type error message), and capability defaults.

2. **`fix(agent): drop auth-candidate env keys from opts.Env after auth resolution`** — a real correctness bug surfaced while validating the above. `filterResolvedSecretsForResolvedAuth` correctly filtered `opts.ResolvedSecrets`, but `pkg/hub/httpdispatcher.go` pre-merges environment-type secrets into the dispatch request's `ResolvedEnv` map before the broker ever sees them, and `start_context.go`'s `BuildStartContext` copies `ResolvedEnv` straight into `opts.Env`. By the time the filter runs, any auth env secret the hub already pre-merged is sitting in `opts.Env` and untouched. Selecting `auth-file` for Claude would therefore still inject a stale `CLAUDE_CODE_OAUTH_TOKEN` env var alongside the mounted credentials file, and Claude Code's env-over-file preference would silently defeat the whole point. Mirroring the filter onto `opts.Env` after auth resolution closes the gap — and tightens auth isolation for `vertex-ai` and `api-key` on all harnesses as a side benefit.

3. **`test(runtimebroker): isolate HOME in env-gather test helpers`** — a pre-existing test fragility, surfaced while landing the rest of this work. `LoadEffectiveSettings` merges the developer's personal `~/.scion/settings.yaml` on top of the test grove's settings, so a developer with a user-scoped `harness_configs.<harness>.auth_selected_type` would see env-gather tests resolve their personal auth type instead of the fixture's. `main` hides this by accident (unknown auth types fall through to nil required-env-keys, so the tests return 201 anyway), but real support for `oauth-token` surfaces it. `t.Setenv("HOME", t.TempDir())` in both test helpers fixes it and, as a side effect, also fixes the pre-existing `TestEnvGather_AutoDetectVertexAI_FromGACEnvVar` flake on dev machines with user-level Claude auth settings.

## Test plan

- [x] `make test` — new tests green; no new failures on touched packages.
- [x] Deployed end-to-end against a real hub + broker + containerised Claude Code agent:
  - [x] Existing `oauth-token` agents continue to authenticate and round-trip messages unchanged against an existing `CLAUDE_CODE_OAUTH_TOKEN` hub secret. Filter correctly keeps the secret when `oauth-token` is the selected method.
  - [x] `auth-file` agent with `CLAUDE_AUTH` hub file secret:
    - `~/.claude/.credentials.json` is present inside the container (owned by the container user, mode 0600).
    - `CLAUDE_CODE_OAUTH_TOKEN` is correctly absent from the container env (filter working).
    - Claude Code banner shows "Claude Max" — full-scope subscription auth, not inference-only.
    - `/remote-control` slash command is available inside the agent session for the first time.
  - [x] Dashboard agent-create and agent-configure pages show the new "OAuth Token" dropdown option and validate correctly against the hub.
