### PR TITLE
feat(hub): add native discord notification channel

### DIFF
--- a/docs-site/src/content/docs/reference/server-config.md
+++ b/docs-site/src/content/docs/reference/server-config.md
@@ -179,3 +179,161 @@ When `server.hub.public_url` is not explicitly set, the Hub endpoint injected in
 4. Auto-computed `http://localhost:{port}` (last resort).
 
 For local development where the Hub runs on `localhost` but agents are in containers, set `server.broker.container_hub_endpoint` to a container-accessible address like `http://host.containers.internal:8080`.
+
+## Notification channels
+
+Notification channels deliver agent messages to external systems. Configure them
+under `server.hub.notification_channels` as a list of channel objects. Each object
+has a `type`, a `params` map, and optional filters.
+
+```yaml
+server:
+  hub:
+    notification_channels:
+      - type: <channel-type>
+        params:
+          # channel-specific key/value pairs
+        filter_urgent_only: false   # if true, only deliver urgent messages
+        filter_types:               # if set, only deliver these message types
+          - input-needed
+          - state-change
+```
+
+### Slack channel
+
+Delivers notifications via a Slack incoming webhook using Slack's `text` payload
+format.
+
+**Type:** `slack`
+
+**Parameters:**
+
+| Param              | Required | Description |
+|--------------------|----------|-------------|
+| `webhook_url`      | yes      | Slack incoming webhook URL (must use `https://`). |
+| `channel`          | no       | Override the webhook's default channel. |
+| `mention_on_urgent`| no       | Mention string added when `msg.Urgent == true` (e.g. `@here`, `@channel`). |
+
+**Example:**
+
+```yaml
+notification_channels:
+  - type: slack
+    params:
+      webhook_url: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXX
+      mention_on_urgent: "@here"
+```
+
+### Webhook channel
+
+Delivers notifications as a raw HTTP POST to an arbitrary URL. Use this when you
+need the full structured payload without truncation or when integrating with a
+custom receiver.
+
+**Type:** `webhook`
+
+**Parameters:**
+
+| Param         | Required | Description |
+|---------------|----------|-------------|
+| `webhook_url` | yes      | Destination URL (must use `https://`). |
+
+**Example:**
+
+```yaml
+notification_channels:
+  - type: webhook
+    params:
+      webhook_url: https://example.com/scion-notifications
+```
+
+### Email channel
+
+Delivers notifications by email.
+
+**Type:** `email`
+
+**Parameters:**
+
+| Param    | Required | Description |
+|----------|----------|-------------|
+| `to`     | yes      | Recipient email address. |
+| `from`   | no       | Sender address override. |
+| `smtp`   | no       | SMTP server host:port. |
+
+**Example:**
+
+```yaml
+notification_channels:
+  - type: email
+    params:
+      to: oncall@example.com
+```
+
+### Discord channel
+
+Delivers notifications via a Discord incoming webhook using Discord's native
+webhook format (rich embeds, colour-coded severity, allowed-mentions-controlled
+role/user pings). Unlike the Slack channel, the Discord channel targets the
+Discord-native endpoint — the `/slack`-compatibility suffix is explicitly
+rejected because it dilutes what each channel type means and silently hides
+the user's real intent.
+
+**Type:** `discord`
+
+**Parameters:**
+
+| Param               | Required | Description |
+|---------------------|----------|-------------|
+| `webhook_url`       | yes      | Discord incoming webhook URL. Must use `https://` and one of the allowed Discord hosts: `discord.com`, `discordapp.com`, `ptb.discord.com`, `canary.discord.com`. Path must begin with `/api/webhooks/` and must not end with `/slack`. |
+| `mention_on_urgent` | no       | Mention string applied when `msg.Urgent == true`. Use Discord mention syntax: `<@&ROLE_ID>` for a role, `<@USER_ID>` for a user. `@here` and `@everyone` are intentionally **not** supported — the channel sets `allowed_mentions.parse: []` so Discord will not resolve them even if present. |
+| `username`          | no       | Override the webhook's default username for delivered messages. |
+| `avatar_url`        | no       | Override the webhook's default avatar for delivered messages. |
+
+**Embed colours by message type:**
+
+| Type                  | Colour | Hex       |
+|-----------------------|--------|-----------|
+| `state-change`        | blue   | `#3498db` |
+| `input-needed`        | yellow | `#f1c40f` |
+| `instruction`         | grey   | `#95a5a6` |
+| *(urgent — any type)* | red    | `#e74c3c` (overrides the type colour) |
+
+**Truncation:** Discord caps embed descriptions at 2048 characters and total
+embed payload at 6000 characters. Messages longer than that are truncated
+with a `…(truncated)` marker — use the webhook channel type if you need the
+full structured payload without truncation.
+
+**Example:**
+
+```yaml
+notification_channels:
+  - type: discord
+    params:
+      webhook_url: https://discord.com/api/webhooks/123456789012345678/abcDEFghiJKLmnoPQR_stu
+      mention_on_urgent: "<@&987654321098765432>"
+      username: Scion Hub
+    filter_urgent_only: false
+    filter_types:
+      - input-needed
+      - state-change
+```
+
+:::note[Migrating from a Slack-compat Discord webhook]
+Earlier scion releases had no Discord channel type — operators could route
+notifications to a Discord webhook by using `type: slack` with a webhook URL
+ending in `/slack` (Discord's Slack-compatibility endpoint). That approach
+produces plain-text messages with no embeds, colours, or mentions.
+
+To migrate:
+
+1. Remove the `/slack` suffix from the webhook URL.
+2. Change `type: slack` to `type: discord`.
+3. If you previously used `mention_on_urgent: "@here"`, replace it with a
+   Discord role mention (`"<@&ROLE_ID>"`) — `@here` is not supported via the
+   native Discord webhook format (the channel sets `allowed_mentions.parse: []`
+   which prevents Discord from resolving `@here` and `@everyone`).
+4. Reload the hub config. Validation will reject the old `/slack`-suffixed
+   URL so a misconfiguration will surface on startup rather than silently
+   falling back.
+:::

--- a/pkg/hub/channels.go
+++ b/pkg/hub/channels.go
@@ -127,12 +127,14 @@ func (r *ChannelRegistry) matchesFilter(cfg ChannelConfig, msg *messages.Structu
 // newChannelFromConfig creates a NotificationChannel from a ChannelConfig.
 func newChannelFromConfig(cfg ChannelConfig) (NotificationChannel, error) {
 	switch cfg.Type {
-	case "webhook":
-		return NewWebhookChannel(cfg.Params), nil
-	case "slack":
-		return NewSlackChannel(cfg.Params), nil
+	case "discord":
+		return NewDiscordChannel(cfg.Params), nil
 	case "email":
 		return NewEmailChannel(cfg.Params), nil
+	case "slack":
+		return NewSlackChannel(cfg.Params), nil
+	case "webhook":
+		return NewWebhookChannel(cfg.Params), nil
 	default:
 		return nil, fmt.Errorf("unknown notification channel type: %q", cfg.Type)
 	}

--- a/pkg/hub/channels_discord.go
+++ b/pkg/hub/channels_discord.go
@@ -1,0 +1,273 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+)
+
+// DiscordChannel delivers notifications via a Discord incoming webhook.
+// Uses Discord's native webhook format (embeds, allowed_mentions) — not the
+// Slack-compatible /slack endpoint.
+type DiscordChannel struct {
+	webhookURL      string
+	mentionOnUrgent string // e.g. "<@&9876543210>" for a role or "<@12345>" for a user
+	username        string // optional override of the webhook's default username
+	avatarURL       string // optional override of the webhook's default avatar
+	client          *http.Client
+}
+
+// NewDiscordChannel creates a DiscordChannel from params.
+// Supported params:
+//   - webhook_url: Discord incoming webhook URL (required)
+//   - mention_on_urgent: mention string for urgent messages using Discord syntax
+//     (e.g. "<@&9876543210>" for a role, "<@12345>" for a user). @here and
+//     @everyone are intentionally not allowed — the channel strips them from
+//     allowed_mentions so Discord will not actually deliver them even if present
+//     in Content.
+//   - username: override the webhook's default username (optional)
+//   - avatar_url: override the webhook's default avatar (optional)
+func NewDiscordChannel(params map[string]string) *DiscordChannel {
+	return &DiscordChannel{
+		webhookURL:      params["webhook_url"],
+		mentionOnUrgent: params["mention_on_urgent"],
+		username:        params["username"],
+		avatarURL:       params["avatar_url"],
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+func (d *DiscordChannel) Name() string { return "discord" }
+
+// allowedDiscordHosts is the closed set of Discord webhook hostnames.
+var allowedDiscordHosts = map[string]bool{
+	"discord.com":        true,
+	"discordapp.com":     true,
+	"ptb.discord.com":    true,
+	"canary.discord.com": true,
+}
+
+func (d *DiscordChannel) Validate() error {
+	if d.webhookURL == "" {
+		return fmt.Errorf("discord channel requires a 'webhook_url' param")
+	}
+	u, err := url.Parse(d.webhookURL)
+	if err != nil {
+		return fmt.Errorf("discord webhook_url is not a valid URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("discord webhook_url must use https:// (got %q)", u.Scheme)
+	}
+	if !allowedDiscordHosts[u.Host] {
+		return fmt.Errorf("discord webhook_url host %q is not a recognised Discord domain (expected one of: discord.com, discordapp.com, ptb.discord.com, canary.discord.com)", u.Host)
+	}
+	if !strings.HasPrefix(u.Path, "/api/webhooks/") {
+		return fmt.Errorf("discord webhook_url path must begin with /api/webhooks/ (got %q)", u.Path)
+	}
+	// The whole point of this channel type is to NOT use the Slack-compat
+	// endpoint. Reject it explicitly so users migrate to the native format.
+	if strings.HasSuffix(u.Path, "/slack") || strings.HasSuffix(u.Path, "/slack/") {
+		return fmt.Errorf("discord webhook_url must not end with /slack — use the native Discord webhook endpoint (remove the /slack suffix) with type: discord")
+	}
+	return nil
+}
+
+// Discord embed colour constants (decimal RGB, matching Discord API).
+const (
+	discordColorStateChange = 0x3498db // blue   — informational
+	discordColorInputNeeded = 0xf1c40f // yellow — needs attention
+	discordColorInstruction = 0x95a5a6 // grey   — routine
+	discordColorUrgent      = 0xe74c3c // red    — urgent (overrides type colour)
+)
+
+// Discord embed size limits (from the webhook API docs).
+const (
+	discordMaxDescription = 2048 // per-embed description cap
+	discordMaxEmbedTotal  = 6000 // total chars across title+description+fields+footer
+)
+
+// discordPayload is the native Discord webhook request body.
+// Ref: https://discord.com/developers/docs/resources/webhook#execute-webhook
+type discordPayload struct {
+	Content         string                  `json:"content,omitempty"`
+	Username        string                  `json:"username,omitempty"`
+	AvatarURL       string                  `json:"avatar_url,omitempty"`
+	Embeds          []discordEmbed          `json:"embeds,omitempty"`
+	AllowedMentions *discordAllowedMentions `json:"allowed_mentions,omitempty"`
+}
+
+type discordEmbed struct {
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	Color       int    `json:"color,omitempty"`
+	Timestamp   string `json:"timestamp,omitempty"`
+}
+
+// discordAllowedMentions locks down what mentions Discord will honour.
+// We explicitly set Parse to an empty slice so @everyone/@here are never
+// resolved, and list role/user IDs we DO want resolved.
+type discordAllowedMentions struct {
+	Parse []string `json:"parse"` // always []string{} — not omitempty
+	Roles []string `json:"roles,omitempty"`
+	Users []string `json:"users,omitempty"`
+}
+
+// reDiscordRole matches <@&NNN> role mentions.
+var reDiscordRole = regexp.MustCompile(`<@&(\d+)>`)
+
+// reDiscordUser matches <@NNN> user mentions (not <@&NNN>).
+var reDiscordUser = regexp.MustCompile(`<@(\d+)>`)
+
+// extractDiscordRoleIDs finds all <@&NNN> role mentions in s and returns the NNNs.
+func extractDiscordRoleIDs(s string) []string {
+	matches := reDiscordRole.FindAllStringSubmatch(s, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(matches))
+	for _, m := range matches {
+		ids = append(ids, m[1])
+	}
+	return ids
+}
+
+// extractDiscordUserIDs finds all <@NNN> user mentions (not <@&NNN>) in s and returns the NNNs.
+func extractDiscordUserIDs(s string) []string {
+	// Remove role mentions first so we don't match their digits.
+	stripped := reDiscordRole.ReplaceAllString(s, "")
+	matches := reDiscordUser.FindAllStringSubmatch(stripped, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(matches))
+	for _, m := range matches {
+		ids = append(ids, m[1])
+	}
+	return ids
+}
+
+func discordColorForMessage(msg *messages.StructuredMessage) int {
+	if msg.Urgent {
+		return discordColorUrgent
+	}
+	switch msg.Type {
+	case messages.TypeStateChange:
+		return discordColorStateChange
+	case messages.TypeInputNeeded:
+		return discordColorInputNeeded
+	case messages.TypeInstruction:
+		return discordColorInstruction
+	default:
+		return discordColorStateChange
+	}
+}
+
+// truncateForDiscordEmbed trims s so it fits within Discord's per-description
+// cap, appending an ellipsis marker if truncation occurred. Rune-safe.
+func truncateForDiscordEmbed(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	const ellipsis = "\n…(truncated)"
+	ellipsisRunes := []rune(ellipsis)
+	cut := max - len(ellipsisRunes)
+	if cut < 0 {
+		cut = 0
+	}
+	return string(runes[:cut]) + ellipsis
+}
+
+// formatDiscordPayload builds a discordPayload from a StructuredMessage.
+// Extracted from Deliver so tests can exercise it without spinning up an
+// httptest.Server.
+func formatDiscordPayload(msg *messages.StructuredMessage, mentionOnUrgent string) discordPayload {
+	title := fmt.Sprintf("[%s] from %s", msg.Type, msg.Sender)
+	if len([]rune(title)) > 256 { // Discord embed title cap
+		title = string([]rune(title)[:253]) + "..."
+	}
+
+	description := truncateForDiscordEmbed(msg.Msg, discordMaxDescription)
+
+	embed := discordEmbed{
+		Title:       title,
+		Description: description,
+		Color:       discordColorForMessage(msg),
+		Timestamp:   msg.Timestamp,
+	}
+
+	payload := discordPayload{
+		Embeds:          []discordEmbed{embed},
+		AllowedMentions: &discordAllowedMentions{Parse: []string{}},
+	}
+
+	if msg.Urgent && mentionOnUrgent != "" {
+		payload.Content = mentionOnUrgent
+		// Extract role and user IDs from <@&123> / <@123> patterns so Discord
+		// actually resolves them (Parse: [] alone would suppress them).
+		payload.AllowedMentions.Roles = extractDiscordRoleIDs(mentionOnUrgent)
+		payload.AllowedMentions.Users = extractDiscordUserIDs(mentionOnUrgent)
+	}
+
+	return payload
+}
+
+// Deliver sends a notification to the Discord webhook.
+func (d *DiscordChannel) Deliver(ctx context.Context, msg *messages.StructuredMessage) error {
+	payload := formatDiscordPayload(msg, d.mentionOnUrgent)
+
+	if d.username != "" {
+		payload.Username = d.username
+	}
+	if d.avatarURL != "" {
+		payload.AvatarURL = d.avatarURL
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal discord payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("discord webhook request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Discord returns 204 No Content on success; also accept 200 for test servers.
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("discord webhook returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/hub/channels_test.go
+++ b/pkg/hub/channels_test.go
@@ -448,3 +448,167 @@ func TestFormatSlackMessage(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Discord channel tests
+// ---------------------------------------------------------------------------
+
+func TestNewChannelRegistry_ValidDiscord(t *testing.T) {
+	configs := []ChannelConfig{
+		{Type: "discord", Params: map[string]string{"webhook_url": "https://discord.com/api/webhooks/123456789/abcDEF_token"}},
+	}
+	registry := NewChannelRegistry(configs, slog.Default())
+	assert.Equal(t, 1, registry.Len())
+}
+
+func TestDiscordChannel_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		params      map[string]string
+		wantErr     bool
+		errContains string
+	}{
+		{"valid discord.com", map[string]string{"webhook_url": "https://discord.com/api/webhooks/123/abc"}, false, ""},
+		{"valid discordapp.com", map[string]string{"webhook_url": "https://discordapp.com/api/webhooks/123/abc"}, false, ""},
+		{"valid ptb.discord.com", map[string]string{"webhook_url": "https://ptb.discord.com/api/webhooks/123/abc"}, false, ""},
+		{"valid canary.discord.com", map[string]string{"webhook_url": "https://canary.discord.com/api/webhooks/123/abc"}, false, ""},
+		{"missing url", map[string]string{}, true, ""},
+		{"wrong scheme", map[string]string{"webhook_url": "http://discord.com/api/webhooks/123/abc"}, true, ""},
+		{"wrong domain", map[string]string{"webhook_url": "https://example.com/api/webhooks/123/abc"}, true, ""},
+		{"slack suffix rejected", map[string]string{"webhook_url": "https://discord.com/api/webhooks/123/abc/slack"}, true, "slack"},
+		{"github domain", map[string]string{"webhook_url": "https://hooks.slack.com/services/T00/B00/xxx"}, true, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ch := NewDiscordChannel(tt.params)
+			err := ch.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDiscordChannel_Deliver(t *testing.T) {
+	var received []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		buf := make([]byte, r.ContentLength)
+		r.Body.Read(buf)
+		received = buf
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	ch := &DiscordChannel{webhookURL: server.URL, client: http.DefaultClient}
+
+	msg := messages.NewNotification("agent:worker", "user:alice", "task done", messages.TypeStateChange)
+	err := ch.Deliver(context.Background(), msg)
+	require.NoError(t, err)
+
+	var payload discordPayload
+	require.NoError(t, json.Unmarshal(received, &payload))
+	require.Len(t, payload.Embeds, 1)
+	assert.Equal(t, discordColorStateChange, payload.Embeds[0].Color)
+	assert.Contains(t, payload.Embeds[0].Description, "task done")
+	assert.Contains(t, payload.Embeds[0].Title, "agent:worker")
+	assert.Equal(t, "", payload.Content)
+	// AllowedMentions must be set with parse: [] to prevent @everyone/@here
+	require.NotNil(t, payload.AllowedMentions)
+	parsedJSON, err := json.Marshal(payload.AllowedMentions)
+	require.NoError(t, err)
+	assert.Contains(t, string(parsedJSON), `"parse":[]`)
+}
+
+func TestDiscordChannel_UrgentMention(t *testing.T) {
+	var received []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		buf := make([]byte, r.ContentLength)
+		r.Body.Read(buf)
+		received = buf
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	ch := &DiscordChannel{
+		webhookURL:      server.URL,
+		mentionOnUrgent: "<@&9876543210>",
+		client:          http.DefaultClient,
+	}
+
+	msg := messages.NewNotification("agent:worker", "user:alice", "urgent task", messages.TypeInputNeeded)
+	msg.Urgent = true
+	err := ch.Deliver(context.Background(), msg)
+	require.NoError(t, err)
+
+	var payload discordPayload
+	require.NoError(t, json.Unmarshal(received, &payload))
+	assert.Contains(t, payload.Content, "<@&9876543210>")
+	// Urgent messages use the dedicated urgent colour
+	assert.Equal(t, discordColorUrgent, payload.Embeds[0].Color)
+	require.NotNil(t, payload.AllowedMentions)
+	assert.Contains(t, payload.AllowedMentions.Roles, "9876543210")
+	assert.NotContains(t, payload.AllowedMentions.Parse, "everyone")
+	assert.NotContains(t, payload.AllowedMentions.Parse, "users")
+}
+
+func TestDiscordChannel_ColorByType(t *testing.T) {
+	tests := []struct {
+		msgType     string
+		wantColor   int
+	}{
+		{messages.TypeStateChange, discordColorStateChange},
+		{messages.TypeInputNeeded, discordColorInputNeeded},
+		{messages.TypeInstruction, discordColorInstruction},
+	}
+	for _, tt := range tests {
+		t.Run(tt.msgType, func(t *testing.T) {
+			msg := messages.NewNotification("agent:worker", "user:alice", "msg", tt.msgType)
+			payload := formatDiscordPayload(msg, "")
+			require.Len(t, payload.Embeds, 1)
+			assert.Equal(t, tt.wantColor, payload.Embeds[0].Color)
+		})
+	}
+}
+
+func TestDiscordChannel_TruncateLongMsg(t *testing.T) {
+	longMsg := strings.Repeat("A", 5000)
+	msg := messages.NewNotification("agent:worker", "user:alice", longMsg, messages.TypeStateChange)
+	payload := formatDiscordPayload(msg, "")
+	require.Len(t, payload.Embeds, 1)
+	assert.LessOrEqual(t, len([]rune(payload.Embeds[0].Description)), 2048)
+	assert.True(t,
+		strings.HasSuffix(payload.Embeds[0].Description, "...") ||
+			strings.HasSuffix(payload.Embeds[0].Description, "…(truncated)"),
+		"description should end with an ellipsis marker")
+	// Total embed text should be under 6000 chars
+	totalLen := len(payload.Embeds[0].Title) + len(payload.Embeds[0].Description)
+	assert.Less(t, totalLen, 6000)
+}
+
+func TestDiscordChannel_DeliverFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	ch := &DiscordChannel{webhookURL: server.URL, client: http.DefaultClient}
+	msg := messages.NewNotification("agent:worker", "user:alice", "completed", messages.TypeStateChange)
+	err := ch.Deliver(context.Background(), msg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestFormatDiscordPayload_URLRejectsSlackSuffix(t *testing.T) {
+	ch := NewDiscordChannel(map[string]string{"webhook_url": "https://discord.com/api/webhooks/1/2/slack"})
+	err := ch.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "slack")
+}

--- a/pkg/hub/channels_test.go
+++ b/pkg/hub/channels_test.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -561,8 +562,8 @@ func TestDiscordChannel_UrgentMention(t *testing.T) {
 
 func TestDiscordChannel_ColorByType(t *testing.T) {
 	tests := []struct {
-		msgType     string
-		wantColor   int
+		msgType   string
+		wantColor int
 	}{
 		{messages.TypeStateChange, discordColorStateChange},
 		{messages.TypeInputNeeded, discordColorInputNeeded},


### PR DESCRIPTION
## Problem

`pkg/hub/channels_slack.go` validates webhook URLs very loosely — any `https://` URL that the hub can POST to is accepted — because Discord-using operators route notifications through Discord's Slack-compat endpoint by appending `/slack` to the webhook URL. That accommodation makes Slack validation meaningfully weaker than it should be: an operator who typos a URL, pastes an unrelated webhook, or is targeted by a config-injection attack has no safety net from the channel factory.

## Solution

Add a dedicated `discord` notification channel type that speaks the native Discord webhook format (rich embeds, colour-coded severity, `allowed_mentions`-controlled role mentions) and strictly validates its webhook URLs against the four allowed Discord hostnames (`discord.com`, `discordapp.com`, `ptb.discord.com`, `canary.discord.com`), explicitly rejecting `/slack` suffixes.

With a first-class Discord channel available, the Slack channel can eventually have its URL validation tightened back to `hooks.slack.com` only (out of scope for this PR — happy to file as a follow-up).

### Features

- **Native webhook format**: embeds with title, description, colour, and RFC 3339 timestamp — no Slack-compat shim
- **Colour mapping**: `state-change → blue`, `input-needed → yellow`, `instruction → grey`, and `Urgent: true → red` (overrides the type colour)
- **Strict URL validation**: rejects non-Discord hosts and explicitly rejects `/slack`-suffixed URLs with a descriptive error, so the operator intent is clear
- **Embed-length truncation**: honours Discord's 2048-char description cap and 6000-char total limit, rune-safe, with a trailing ellipsis marker
- **Safe mentions**: `allowed_mentions.parse: []` is always set, so literal `@everyone`/`@here` in message bodies never trigger mass pings; role/user IDs are opt-in via an explicit `mention_on_urgent` param in Discord's `<@&ROLE>` / `<@USER>` syntax
- **Filters**: inherits the registry's `filter_types` and `filter_urgent_only` support — no channel-specific logic

### Example config

```yaml
notification_channels:
  - type: discord
    params:
      webhook_url: https://discord.com/api/webhooks/123/abc
      mention_on_urgent: "<@&987654321>"  # optional role ping on Urgent: true
      username: "scion"                   # optional webhook username override
      avatar_url: "https://example.com/scion.png"  # optional avatar
```

## Production evidence

Running on `scion.tanti.org.uk` (our deployed hub) since **2026-04-13**. Live-verified against a real Discord channel:

- State-change notifications render as blue embeds
- Input-needed notifications (via an `AskUserQuestion` trigger inside the Claude Code harness) render as yellow embeds
- Urgent-red path covered by unit tests (`TestDiscordChannel_Formatting`)
- `@everyone` / `@here` literal strings in message bodies do NOT trigger mass pings — `allowed_mentions.parse: []` holding as designed

## Scope

**In scope**
- `pkg/hub/channels_discord.go`: `DiscordChannel` type, `formatDiscordPayload` builder, URL validator, colour mapper, truncation helper
- `pkg/hub/channels.go`: `"discord"` case in `newChannelFromConfig`
- `pkg/hub/channels_test.go`: `TestDiscordChannel_*` suite
- `docs-site/src/content/docs/reference/server-config.md`: user-facing reference docs for all notification channel types, with the Discord subsection as the primary addition and a migration note for operators currently using the `/slack`-suffix hack

**Out of scope** (happy to file as follow-ups if wanted)
- A Discord bot gateway for receiving replies — this PR is outbound-only
- Slash commands or interactive components
- Tightening Slack URL validation back to `hooks.slack.com` — will break existing `/slack`-routed Discord setups until they migrate, so should land in a separate PR with a deprecation cycle
- A notification-channel filter that skips non-enum message types (a related finding from the production rollout — filed separately)

## Testing

All tests run under `make ci` / `go test ./...`:

- URL validation: all four Discord hosts accepted, `/slack`-suffixed URLs rejected, non-Discord hosts rejected
- Payload shape: embed title, description, colour, timestamp, `allowed_mentions` lockdown
- Colour mapping per message type (blue/yellow/grey) + urgent override (red)
- Truncation at 2048 chars per description with ellipsis marker, rune-safe
- Urgent role mention renders via `allowed_mentions.roles` and never triggers `@everyone`/`@here`
- Registry wiring: `newChannelFromConfig("discord", …)` returns `*DiscordChannel`
