### PR TITLE
Fix dashboard counts to update on load

### DIFF
--- a/web/src/client/state.ts
+++ b/web/src/client/state.ts
@@ -389,28 +389,40 @@ export class StateManager extends EventTarget {
    * complete baseline data. Does not trigger notifications — the
    * calling component already holds the data from its own fetch.
    */
-  seedAgents(agents: Agent[]): void {
+  seedAgents(agents: Agent[], clear = false): void {
+    if (clear) {
+      this.state.agents.clear();
+    }
     for (const agent of agents) {
       this.state.agents.set(agent.id, agent);
     }
+    this.notify('agents-updated');
   }
 
   /**
    * Seed the groves map with full objects from a REST API response.
    */
-  seedGroves(groves: Grove[]): void {
+  seedGroves(groves: Grove[], clear = false): void {
+    if (clear) {
+      this.state.groves.clear();
+    }
     for (const grove of groves) {
       this.state.groves.set(grove.id, grove);
     }
+    this.notify('groves-updated');
   }
 
   /**
    * Seed the brokers map with full objects from a REST API response.
    */
-  seedBrokers(brokers: RuntimeBroker[]): void {
+  seedBrokers(brokers: RuntimeBroker[], clear = false): void {
+    if (clear) {
+      this.state.brokers.clear();
+    }
     for (const broker of brokers) {
       this.state.brokers.set(broker.id, broker);
     }
+    this.notify('brokers-updated');
   }
 
   /** Expose the SSE client for debug instrumentation */

--- a/web/src/client/state.ts
+++ b/web/src/client/state.ts
@@ -386,8 +386,7 @@ export class StateManager extends EventTarget {
   /**
    * Seed the agents map with full objects from a REST API response.
    * Called after initial data fetch so that SSE delta merging has
-   * complete baseline data. Does not trigger notifications — the
-   * calling component already holds the data from its own fetch.
+   * complete baseline data. Triggers notifications to all listeners.
    */
   seedAgents(agents: Agent[], clear = false): void {
     if (clear) {

--- a/web/src/client/state.ts
+++ b/web/src/client/state.ts
@@ -386,42 +386,33 @@ export class StateManager extends EventTarget {
   /**
    * Seed the agents map with full objects from a REST API response.
    * Called after initial data fetch so that SSE delta merging has
-   * complete baseline data. Triggers notifications to all listeners.
+   * complete baseline data. Does not trigger notifications — the
+   * calling component already holds the data from its own fetch.
    */
-  seedAgents(agents: Agent[], clear = false): void {
-    if (clear) {
-      this.state.agents.clear();
-    }
+  seedAgents(agents: Agent[]): void {
     for (const agent of agents) {
       this.state.agents.set(agent.id, agent);
     }
-    this.notify('agents-updated');
   }
 
   /**
    * Seed the groves map with full objects from a REST API response.
+   * Does not trigger notifications.
    */
-  seedGroves(groves: Grove[], clear = false): void {
-    if (clear) {
-      this.state.groves.clear();
-    }
+  seedGroves(groves: Grove[]): void {
     for (const grove of groves) {
       this.state.groves.set(grove.id, grove);
     }
-    this.notify('groves-updated');
   }
 
   /**
    * Seed the brokers map with full objects from a REST API response.
+   * Does not trigger notifications.
    */
-  seedBrokers(brokers: RuntimeBroker[], clear = false): void {
-    if (clear) {
-      this.state.brokers.clear();
-    }
+  seedBrokers(brokers: RuntimeBroker[]): void {
     for (const broker of brokers) {
       this.state.brokers.set(broker.id, broker);
     }
-    this.notify('brokers-updated');
   }
 
   /** Expose the SSE client for debug instrumentation */

--- a/web/src/components/pages/home.ts
+++ b/web/src/components/pages/home.ts
@@ -21,10 +21,13 @@
  */
 
 import { LitElement, html, css } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 
-import type { PageData } from '../../shared/types.js';
+import type { PageData, Agent, Grove } from '../../shared/types.js';
+import { isAgentRunning } from '../../shared/types.js';
 import '../shared/status-badge.js';
+import { stateManager } from '../../client/state.js';
+import { apiFetch } from '../../client/api.js';
 
 @customElement('scion-page-home')
 export class ScionPageHome extends LitElement {
@@ -33,6 +36,65 @@ export class ScionPageHome extends LitElement {
    */
   @property({ type: Object })
   pageData: PageData | null = null;
+
+  @state()
+  private agents: Agent[] = [];
+
+  @state()
+  private groves: Grove[] = [];
+
+  private boundOnAgentsUpdated = this.onAgentsUpdated.bind(this);
+  private boundOnGrovesUpdated = this.onGrovesUpdated.bind(this);
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    stateManager.setScope({ type: 'dashboard' });
+    
+    this.agents = stateManager.getAgents();
+    this.groves = stateManager.getGroves();
+
+    stateManager.addEventListener('agents-updated', this.boundOnAgentsUpdated as EventListener);
+    stateManager.addEventListener('groves-updated', this.boundOnGrovesUpdated as EventListener);
+
+    void this.loadData();
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    stateManager.removeEventListener('agents-updated', this.boundOnAgentsUpdated as EventListener);
+    stateManager.removeEventListener('groves-updated', this.boundOnGrovesUpdated as EventListener);
+  }
+
+  private onAgentsUpdated(): void {
+    this.agents = stateManager.getAgents();
+  }
+
+  private onGrovesUpdated(): void {
+    this.groves = stateManager.getGroves();
+  }
+
+  private async loadData(): Promise<void> {
+    try {
+      const [agentsResp, grovesResp] = await Promise.all([
+        apiFetch('/api/v1/agents'),
+        apiFetch('/api/v1/groves')
+      ]);
+
+      if (agentsResp.ok) {
+        const data = await agentsResp.json();
+        this.agents = Array.isArray(data) ? data : data.agents || [];
+        stateManager.seedAgents(this.agents);
+      }
+
+      if (grovesResp.ok) {
+        const data = await grovesResp.json();
+        this.groves = Array.isArray(data) ? data : data.groves || [];
+        stateManager.seedGroves(this.groves);
+      }
+    } catch (err) {
+      console.error('Failed to load data for dashboard:', err);
+    }
+  }
 
   static override styles = css`
     :host {
@@ -242,7 +304,7 @@ export class ScionPageHome extends LitElement {
         <div class="stat-card">
           <h3>Active Agents</h3>
           <div class="stat-value">
-            <span>--</span>
+            <span>${this.agents.filter(a => isAgentRunning(a)).length}</span>
           </div>
           <div class="stat-change">
             <scion-status-badge status="success" label="Ready" size="small"></scion-status-badge>
@@ -250,7 +312,7 @@ export class ScionPageHome extends LitElement {
         </div>
         <div class="stat-card">
           <h3>Groves</h3>
-          <div class="stat-value">--</div>
+          <div class="stat-value">${this.groves.length}</div>
           <div class="stat-change">Project workspaces</div>
         </div>
         <div class="stat-card">

--- a/web/src/components/pages/home.ts
+++ b/web/src/components/pages/home.ts
@@ -80,16 +80,18 @@ export class ScionPageHome extends LitElement {
         apiFetch('/api/v1/groves')
       ]);
 
+      if (!this.isConnected) return;
+
       if (agentsResp.ok) {
         const data = await agentsResp.json();
-        this.agents = Array.isArray(data) ? data : data.agents || [];
-        stateManager.seedAgents(this.agents);
+        const agents = Array.isArray(data) ? data : data.agents || [];
+        stateManager.seedAgents(agents);
       }
 
       if (grovesResp.ok) {
         const data = await grovesResp.json();
-        this.groves = Array.isArray(data) ? data : data.groves || [];
-        stateManager.seedGroves(this.groves);
+        const groves = Array.isArray(data) ? data : data.groves || [];
+        stateManager.seedGroves(groves);
       }
     } catch (err) {
       console.error('Failed to load data for dashboard:', err);

--- a/web/src/components/pages/home.ts
+++ b/web/src/components/pages/home.ts
@@ -84,7 +84,7 @@ export class ScionPageHome extends LitElement {
         apiFetch('/api/v1/groves')
       ]);
 
-      if (!this.isConnected) return;
+      if (!this.isConnected || stateManager.currentScope?.type !== 'dashboard') return;
 
       if (agentsResp.ok) {
         const data = await agentsResp.json();

--- a/web/src/components/pages/home.ts
+++ b/web/src/components/pages/home.ts
@@ -73,6 +73,10 @@ export class ScionPageHome extends LitElement {
     this.groves = stateManager.getGroves();
   }
 
+  private get activeAgentCount(): number {
+    return this.agents.filter(a => isAgentRunning(a)).length;
+  }
+
   private async loadData(): Promise<void> {
     try {
       const [agentsResp, grovesResp] = await Promise.all([
@@ -85,12 +89,14 @@ export class ScionPageHome extends LitElement {
       if (agentsResp.ok) {
         const data = await agentsResp.json();
         const agents = Array.isArray(data) ? data : data.agents || [];
+        this.agents = agents;
         stateManager.seedAgents(agents);
       }
 
       if (grovesResp.ok) {
         const data = await grovesResp.json();
         const groves = Array.isArray(data) ? data : data.groves || [];
+        this.groves = groves;
         stateManager.seedGroves(groves);
       }
     } catch (err) {
@@ -306,7 +312,7 @@ export class ScionPageHome extends LitElement {
         <div class="stat-card">
           <h3>Active Agents</h3>
           <div class="stat-value">
-            <span>${this.agents.filter(a => isAgentRunning(a)).length}</span>
+            <span>${this.activeAgentCount}</span>
           </div>
           <div class="stat-change">
             <scion-status-badge status="success" label="Ready" size="small"></scion-status-badge>


### PR DESCRIPTION
## Description
This PR updates the Dashboard page (`/`) to make the "Active Agents" and "Groves" counts dynamic.
Previously, these values were hardcoded as `--` and did not update on load.

Changes:
- Subscribed to `dashboard` scope in `stateManager`.
- Added initial data fetch in `connectedCallback` via a new `loadData` method.
- Added event listeners for `agents-updated` and `groves-updated` to keep counts fresh.

## Tests
- Manual verification: Confirmed that counts are populated immediately on load and reflect the actual number of running agents and groves.
- No automated tests were added as this is a UI behavior enhancement relying on existing state management.

---
Fixes #154

> It's a good idea to open an issue first for discussion.

- [x] Tests pass (Manual verification)
- [ ] Appropriate changes to documentation are included in the PR