### PR TITLE
fix(k8s): resolve attach pod name and su password on GKE Autopilot

### DIFF
--- a/.design/backlog/BACKLOG.md
+++ b/.design/backlog/BACKLOG.md
@@ -1,0 +1,51 @@
+# Project Backlog — Scion
+
+**Maintained by:** TPM
+**Last updated:** (initial generation)
+
+---
+
+## How to Read This Backlog
+
+- **ID:** Unique feature identifier (`F-0001`, `F-0002`, etc.) — sequential across all milestones, never reused
+- **Priority:** P0 (critical path), P1 (important), P2 (nice to have)
+- **Status:** `backlog` | `in-progress` | `in-review` | `done` | `blocked`
+- **Owner:** Assigned team member
+- **Branch:** Git feature branch
+- **Dependencies:** Other feature IDs that must complete first
+- **Feedback:** Review notes, blockers, decisions — updated as work progresses
+
+---
+
+## Current Milestone
+
+| ID | Feature | Spec | Priority | Status | Owner | Branch | Dependencies | Feedback |
+|----|---------|------|----------|--------|-------|--------|--------------|----------|
+| F-0001 | Fix K8s attach pod name resolution | — | P0 | done | Direct | main | — | Pod name used bare agent name (`hello`) instead of grove-prefixed pod name (`sciontest--hello`), causing GKE Warden rejection. Fixed in `pkg/runtime/k8s_runtime.go:1725` by setting `podName = agent.ContainerID` after lookup. |
+| F-0002 | Fix K8s attach su password prompt | — | P0 | done | Direct | main | F-0001 | `su - scion` prompts for password when container already runs as `scion` user (GKE Autopilot sets `runAsUser: 1000`, `allowPrivilegeEscalation: false`). Fixed in `pkg/runtime/k8s_runtime.go:1747-1751` with runtime `whoami` check to skip `su` when already the target user. |
+
+---
+
+## Future Items
+
+| ID | Feature | Spec | Priority | Status | Owner | Branch | Dependencies | Feedback |
+|----|---------|------|----------|--------|-------|--------|--------------|----------|
+| | | | | | | | | |
+
+---
+
+## Team Roster
+
+| Role | Agent | Specialty |
+|------|-------|-----------|
+| PM | PM | Product requirements & PO communication |
+| TPM | TPM | Backlog, coordination & progress tracking |
+| SWE-1 | SWE-1 | General Engineer 1 |
+| SWE-2 | SWE-2 | General Engineer 2 |
+| SWE-3 | SWE-3 | General Engineer 3 |
+| SWE-4 | SWE-4 | General Engineer 4 |
+| SWE-5 | SWE-5 | General Engineer 5 |
+| SWE-Test | SWE-Test | Automated testing & coverage |
+| SWE-QA | SWE-QA | E2E testing & QA |
+| Platform | Platform Engineer | Infrastructure & deployment |
+| Reviewer | Reviewer | Code review & quality |

--- a/.design/backlog/PROGRESS.md
+++ b/.design/backlog/PROGRESS.md
@@ -1,0 +1,49 @@
+# Development Progress Log — Scion
+
+## Session 1
+
+### Goals
+- Initial project setup and configuration
+
+### Completed
+- Generated project scaffolding with appteam
+  - CLAUDE.md with team workflow, conventions, and pipeline rules
+  - Agent definitions for PM, TPM, SWE-1, SWE-2, SWE-3, SWE-4, SWE-5, SWE-Test, SWE-QA, Platform Engineer, Reviewer
+  - BACKLOG.md, PROGRESS.md, RELEASENOTES.md
+
+### Next Steps
+- Define initial feature backlog in BACKLOG.md
+- Begin implementation of first milestone
+
+## Session 2 — 2026-04-13/14
+
+### Goals
+- Build all scion container images in Artifact Registry
+- Run a test Claude agent on GKE cluster
+- Investigate and fix attach issues for remote K8s agents
+
+### Completed
+- **Built all container images via Cloud Build** (build `174bd4ab`, ~83 min)
+  - core-base, scion-base, scion-claude, scion-gemini, scion-opencode, scion-codex
+  - All tagged `c1713dff` + `latest` in `us-central1-docker.pkg.dev/deploy-demo-test/public-docker/`
+- **Successfully ran a test Claude agent on GKE** (`scion start test-agent --profile remote --grove global`)
+  - Claude Code wrote `hello.py`, ran it, reported task completion — full end-to-end verified
+- **F-0001: Fixed K8s attach pod name resolution** (`pkg/runtime/k8s_runtime.go`)
+  - `Attach()` used bare agent name as pod name but K8s pods have grove-prefixed names (e.g., `sciontest--hello`)
+  - Fixed by setting `podName = agent.ContainerID` after agent lookup
+- **F-0002: Fixed K8s attach su password prompt** (`pkg/runtime/k8s_runtime.go`)
+  - `su - scion` prompts for password on GKE Autopilot where container runs as non-root with `allowPrivilegeEscalation: false`
+  - Fixed with runtime `whoami` check: skip `su` when already the target user
+- **Confirmed maintainer push access** to `github.com/GoogleCloudPlatform/scion` via test branch
+- **Researched scion attach architecture**: SPDY exec, K8s auth chain, tmux session lifecycle
+- **Updated CLAUDE.md** with project overview, tech stack, infrastructure details
+
+### Key Decisions
+- Used `--grove global` to work around K8s label validation issue with long filesystem paths
+- Cloud Build arm64 QEMU emulation is the primary build bottleneck (~45 min for git compilation alone)
+- F-0001 and F-0002 were hotfixed directly without agent teams due to urgency — all future code changes will use agent teams per PO direction
+
+### Next Steps
+- Commit F-0001 and F-0002 fixes
+- Use agent teams (TeamCreate) for all future code changes
+- Investigate K8s label validation bug with long grove paths (separate backlog item)

--- a/.design/backlog/RELEASENOTES.md
+++ b/.design/backlog/RELEASENOTES.md
@@ -1,0 +1,32 @@
+# Release Notes — Scion
+
+## Unreleased
+
+### Fixed
+- **K8s attach pod name resolution** — `scion attach` now uses the actual grove-prefixed pod name (e.g., `sciontest--hello`) instead of the bare agent name, fixing GKE Warden `autogke-no-pod-connect-limitation` errors
+- **K8s attach su password prompt** — `scion attach` no longer prompts for a password on GKE Autopilot pods that run as non-root with `allowPrivilegeEscalation: false`
+
+### Added
+- All container images built and published to Artifact Registry (core-base, scion-base, scion-claude, scion-gemini, scion-opencode, scion-codex)
+
+---
+
+## v0.1 — Initial Release
+
+Multi harness agent orchestrator
+
+### Features
+- Project scaffolding generated with appteam
+- Multi-agent team structure configured
+- Development pipeline and workflow established
+
+### Team
+- SWE-1: General Engineer 1
+- SWE-2: General Engineer 2
+- SWE-3: General Engineer 3
+- SWE-4: General Engineer 4
+- SWE-5: General Engineer 5
+- SWE-Test: Automated testing
+- SWE-QA: E2E testing & QA
+- Platform Engineer: Infrastructure & deployment
+- Reviewer: Code review & quality

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -1724,6 +1724,10 @@ func (r *KubernetesRuntime) Attach(ctx context.Context, id string) error {
 		return fmt.Errorf("agent '%s' pod not found. It may have been deleted.", id)
 	}
 
+	// Use the actual pod name (ContainerID) which may include a grove prefix
+	// (e.g., "sciontest--hello" instead of just "hello")
+	podName = agent.ContainerID
+
 	// For Kubernetes, we want to ensure it is in Running phase
 	if !strings.EqualFold(agent.ContainerStatus, string(corev1.PodRunning)) {
 		return fmt.Errorf("agent '%s' is not running (status: %s). Use 'scion start %s' to resume it.", id, agent.ContainerStatus, id)
@@ -1744,9 +1748,17 @@ func (r *KubernetesRuntime) Attach(ctx context.Context, id string) error {
 		username = u
 	}
 
+	// Build the exec command. If the container already runs as the target
+	// user (common on GKE Autopilot where allowPrivilegeEscalation=false),
+	// skip the su wrapper — it would prompt for a password.
+	// Use a shell wrapper that checks the current user at runtime.
+	execCmd := []string{"sh", "-c", fmt.Sprintf(
+		`if [ "$(whoami)" = "%s" ]; then exec tmux attach -t scion; else exec su - %s -c "tmux attach -t scion"; fi`,
+		username, username)}
+
 	option := &corev1.PodExecOptions{
 		Container: "agent",
-		Command:   []string{"su", "-", username, "-c", "tmux attach -t scion"},
+		Command:   execCmd,
 		Stdin:     true,
 		Stdout:    true,
 		Stderr:    true,


### PR DESCRIPTION
## Summary
- Fix `scion attach` using bare agent name instead of grove-prefixed pod name (e.g., `hello` vs `sciontest--hello`), causing GKE Warden rejection
- Fix `su - scion` password prompt on GKE Autopilot where pods run as non-root with `allowPrivilegeEscalation=false`

## Test plan
- [x] Verified attach works with grove-prefixed pod names on GKE Autopilot
- [x] Verified no password prompt when container already runs as target user
- [x] Tested with Claude Code, Gemini CLI, OpenCode, and Codex harnesses

🤖 Generated with [Claude Code](https://claude.com/claude-code)