### PR TITLE
fix: render action buttons for agents added via realtime SSE

### DIFF
--- a/web/src/components/pages/grove-detail.ts
+++ b/web/src/components/pages/grove-detail.ts
@@ -613,14 +613,27 @@ export class ScionPageGroveDetail extends LitElement {
     const updatedAgents = stateManager.getAgents();
     // Merge SSE agent deltas into local agent list
     const agentMap = new Map(this.agents.map((a) => [a.id, a]));
+    // Lazily derive scope capabilities from existing agents if not yet set.
+    if (!this.agentScopeCapabilities) {
+      for (const a of agentMap.values()) {
+        if (a._capabilities) {
+          this.agentScopeCapabilities = a._capabilities;
+          break;
+        }
+      }
+    }
     for (const agent of updatedAgents) {
       if (agent.groveId === this.groveId || agentMap.has(agent.id)) {
         const existing = agentMap.get(agent.id);
         const merged = { ...existing, ...agent } as Agent;
         // New agents from SSE don't carry per-resource _capabilities.
         // Inherit scope-level capabilities so action buttons render.
-        if (!merged._capabilities && this.agentScopeCapabilities) {
-          merged._capabilities = this.agentScopeCapabilities;
+        if (!merged._capabilities) {
+          if (existing?._capabilities) {
+            merged._capabilities = existing._capabilities;
+          } else if (this.agentScopeCapabilities) {
+            merged._capabilities = this.agentScopeCapabilities;
+          }
         }
         agentMap.set(agent.id, merged);
       }
@@ -668,6 +681,11 @@ export class ScionPageGroveDetail extends LitElement {
         } else {
           this.agents = agentsData.agents || [];
           this.agentScopeCapabilities = agentsData._capabilities;
+        }
+        // Derive scope capabilities from per-agent capabilities when the
+        // response doesn't include a top-level _capabilities field.
+        if (!this.agentScopeCapabilities) {
+          this.agentScopeCapabilities = this.agents.find(a => a._capabilities)?._capabilities;
         }
       } else {
         // Fallback: if grove-scoped agents endpoint fails, try filtering from all agents
@@ -722,6 +740,9 @@ export class ScionPageGroveDetail extends LitElement {
     } else {
       this.agents = data.agents || [];
       this.agentScopeCapabilities = data._capabilities;
+    }
+    if (!this.agentScopeCapabilities) {
+      this.agentScopeCapabilities = this.agents.find(a => a._capabilities)?._capabilities;
     }
     stateManager.seedAgents(this.agents);
   }


### PR DESCRIPTION
SSE agent events don't carry _capabilities, so action buttons (start, stop, delete, terminal) were missing for newly created agents until page reload. The existing fallback to agentScopeCapabilities only worked when the API returned scope-level capabilities — when only per-agent capabilities were present, the scope field stayed undefined.

Three fixes:
- Derive agentScopeCapabilities from per-agent capabilities in loadData and fetchAndMergeAgents when scope-level capabilities are absent
- Lazily derive scope capabilities from existing agents during SSE update handling
- Preserve existing per-agent capabilities during SSE merges

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
