### PR TITLE
fix(broker): apply #159's whoami-skip-su pattern to remaining su call sites

### DIFF
--- a/pkg/runtime/exec_user.go
+++ b/pkg/runtime/exec_user.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+// ExecAsUserCmd returns a /bin/sh command vector that runs cmd as user.
+//
+// If the container already runs as user (no su needed — common on GKE
+// Autopilot or any image with a non-root USER directive in the Dockerfile),
+// the wrapper execs cmd directly. Otherwise it falls back to
+// `su - user -c cmd` for legacy images that start as root.
+//
+// This avoids the PAM password prompt that occurs when root tries to su
+// to another user on container images whose /etc/pam.d/su lacks the
+// `auth sufficient pam_rootok.so` line — the default in node:20-slim and
+// other Debian-derived bases. On those images, a non-interactive
+// `su - <user> -c ...` exits with "Authentication failure" and the
+// caller (typically a readiness probe or PTY exec) misinterprets the
+// failure as the target service not being ready.
+//
+// See PR #159 for the original inline fix in KubernetesRuntime.Attach
+// that this helper generalizes to all su-wrapping call sites in the
+// broker and runtime packages.
+//
+// Both branches route the cmd through a fresh `sh -c` invocation, and
+// user/cmd are passed as positional shell arguments ($1/$2) rather
+// than interpolated into the script body. The shell's argv machinery
+// preserves them verbatim — no Go-side shell quoting, no risk of
+// double-quoted expansion in the outer wrapper. The inner shell
+// then parses cmd as a normal command line: leading env-var
+// assignments work (e.g. "TERM=xterm-256color tmux attach-session
+// -t scion"), shell metacharacters are interpreted by the inner
+// shell, and $VAR references resolve against that inner shell's
+// environment.
+func ExecAsUserCmd(user, cmd string) []string {
+	// Per `sh -c <script> <arg0> <arg1> ...`: arg0 becomes $0
+	// (conventionally the script name, which surfaces in ps and
+	// error messages), arg1 becomes $1, etc. We label $0 as
+	// "exec-as-user" so any diagnostic that prints it is
+	// self-describing.
+	const script = `if [ "$(whoami)" = "$1" ]; then exec sh -c "$2"; else exec su - "$1" -c "$2"; fi`
+	return []string{"sh", "-c", script, "exec-as-user", user, cmd}
+}

--- a/pkg/runtime/exec_user.go
+++ b/pkg/runtime/exec_user.go
@@ -14,6 +14,15 @@
 
 package runtime
 
+import "regexp"
+
+// ValidExecUserName matches usernames that are safe to interpolate
+// into shell command lines built by ExecAsUserCmd. Compiled once at
+// package init so callers (e.g. KubernetesRuntime.Attach) avoid a
+// per-invocation regexp.MustCompile, and so the broker's
+// sanitizeExecUser shares one source of truth for the rule.
+var ValidExecUserName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
 // ExecAsUserCmd returns a /bin/sh command vector that runs cmd as user.
 //
 // If the container already runs as user (no su needed — common on GKE

--- a/pkg/runtime/exec_user_test.go
+++ b/pkg/runtime/exec_user_test.go
@@ -236,3 +236,25 @@ func TestExecAsUserCmd_CallSiteShapes(t *testing.T) {
 		})
 	}
 }
+
+func TestValidExecUserName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{name: "scion accepted", in: "scion", want: true},
+		{name: "alphanumeric with hyphen and underscore accepted", in: "agent-1_x", want: true},
+		{name: "empty rejected", in: "", want: false},
+		{name: "shell metachar rejected", in: "scion;rm -rf /", want: false},
+		{name: "command substitution rejected", in: "$(whoami)", want: false},
+		{name: "embedded space rejected", in: "two words", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ValidExecUserName.MatchString(tc.in); got != tc.want {
+				t.Errorf("ValidExecUserName.MatchString(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/runtime/exec_user_test.go
+++ b/pkg/runtime/exec_user_test.go
@@ -1,0 +1,238 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"os/exec"
+	"os/user"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestExecAsUserCmd_Shape(t *testing.T) {
+	user := "scion"
+	cmd := "tmux has-session -t scion"
+	got := ExecAsUserCmd(user, cmd)
+
+	// The vector is [sh, -c, <script>, "exec-as-user", <user>, <cmd>].
+	// Per `sh -c <script> <arg0> <arg1> ...`, arg0 becomes $0
+	// (script name), arg1 becomes $1, arg2 becomes $2 — so user
+	// is referenced inside the script as $1 and cmd as $2, not
+	// interpolated into the script body.
+	if len(got) != 6 {
+		t.Fatalf("expected 6-element command vector, got %d: %v", len(got), got)
+	}
+	if got[0] != "sh" || got[1] != "-c" {
+		t.Errorf("expected command to start with [sh -c], got: %v", got[:2])
+	}
+	if got[3] != "exec-as-user" {
+		t.Errorf("expected got[3] to be the script-name label \"exec-as-user\", got %q", got[3])
+	}
+	if got[4] != user {
+		t.Errorf("expected user at got[4] verbatim, got %q want %q", got[4], user)
+	}
+	if got[5] != cmd {
+		t.Errorf("expected cmd at got[5] verbatim, got %q want %q", got[5], cmd)
+	}
+
+	// The script body itself is fixed and references $1/$2 — it
+	// must not leak the user or cmd values into its text.
+	script := got[2]
+	if !strings.Contains(script, `[ "$(whoami)" = "$1" ]`) {
+		t.Errorf("expected script to compare whoami against $1, got: %s", script)
+	}
+	if !strings.Contains(script, `exec sh -c "$2"`) {
+		t.Errorf("expected whoami branch to exec sh -c \"$2\", got: %s", script)
+	}
+	if !strings.Contains(script, `exec su - "$1" -c "$2"`) {
+		t.Errorf("expected else branch to invoke su - \"$1\" -c \"$2\", got: %s", script)
+	}
+	if strings.Contains(script, user) || strings.Contains(script, cmd) {
+		t.Errorf("script body should not contain literal user or cmd values (use $1/$2), got: %s", script)
+	}
+}
+
+func TestExecAsUserCmd_PreservesShellQuoting(t *testing.T) {
+	// The tmux window-name query embeds single-quoted shell tokens
+	// (`'#{window_name}'`) — they must survive the helper untouched
+	// because cmd is passed verbatim as a positional shell argument
+	// rather than interpolated through any quoting layer.
+	cmd := `tmux display-message -t scion -p '#{window_name}'`
+	got := ExecAsUserCmd("scion", cmd)
+	if got[5] != cmd {
+		t.Errorf("expected cmd to be passed verbatim as got[5], got %q want %q", got[5], cmd)
+	}
+}
+
+func TestExecAsUserCmd_PassesUsernameVerbatim(t *testing.T) {
+	// Usernames are passed as a positional shell argument ($1) and
+	// referenced inside the script as "$1" (double-quoted), so any
+	// character — including shell metacharacters — survives the
+	// helper without word-splitting or expansion. Defense against
+	// shell injection from untrusted metadata still belongs at the
+	// caller (see runtimebroker.sanitizeExecUser); the helper just
+	// guarantees it does not introduce a quoting hazard.
+	weird := `weird"user;rm -rf /`
+	got := ExecAsUserCmd(weird, "echo hi")
+	if got[4] != weird {
+		t.Errorf("expected user to be passed verbatim as got[4], got %q want %q", got[4], weird)
+	}
+	if strings.Contains(got[2], weird) {
+		t.Errorf("script body should not contain the raw user value, got: %s", got[2])
+	}
+}
+
+// TestExecAsUserCmd_RuntimeWhoamiBranch is an execution-based smoke
+// test: it actually runs the wrapper through /bin/sh against the
+// current process's username and asserts the whoami branch is taken
+// (i.e., the cmd is exec'd directly without invoking su).
+func TestExecAsUserCmd_RuntimeWhoamiBranch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX /bin/sh")
+	}
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("sh not found in PATH: %v", err)
+	}
+
+	u, err := user.Current()
+	if err != nil {
+		t.Skipf("could not determine current user: %v", err)
+	}
+
+	// Use a sentinel that will only be printed by the whoami branch.
+	// The else branch would invoke `su -`, which (a) likely isn't
+	// installed in CI environments and (b) would prompt for a
+	// password. If the whoami branch is correctly taken, we should
+	// see the sentinel on stdout.
+	wrapped := ExecAsUserCmd(u.Username, "echo whoami-branch-ok")
+	out, err := exec.Command(wrapped[0], wrapped[1:]...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("wrapper failed: %v (output: %s)", err, out)
+	}
+	if !strings.Contains(string(out), "whoami-branch-ok") {
+		t.Errorf("expected whoami branch to run echo, got output: %s", out)
+	}
+}
+
+// TestExecAsUserCmd_EnvPrefixedCmd locks in support for cmds that
+// begin with one or more "VAR=value" env-prefix assignments —
+// valid POSIX shell syntax that the whoami branch must honor.
+//
+// Regression: an earlier draft of the helper used `exec %s` in
+// the whoami branch, which fails because `exec` is a special
+// builtin that does NOT parse leading env-prefix assignments.
+// The current helper routes cmd through `exec sh -c "$1"` so
+// the inner shell does the parsing.
+//
+// The two PTY attach call sites in pty_handlers.go pass
+// "TERM=xterm-256color tmux attach-session -t scion", so this
+// test prevents regressions there.
+func TestExecAsUserCmd_EnvPrefixedCmd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX /bin/sh")
+	}
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("sh not found in PATH: %v", err)
+	}
+	u, err := user.Current()
+	if err != nil {
+		t.Skipf("could not determine current user: %v", err)
+	}
+
+	// Use `env` (which prints the env it actually receives) rather
+	// than echoing $VAR — that directly tests whether the
+	// env-prefix assignment was honored when the inner command was
+	// invoked. Mirrors the real call sites' "TERM=xterm-256color
+	// tmux ..." shape.
+	wrapped := ExecAsUserCmd(u.Username, `MARKER=hello env`)
+	out, err := exec.Command(wrapped[0], wrapped[1:]...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("wrapper failed: %v (output: %s)", err, out)
+	}
+	if !strings.Contains(string(out), "MARKER=hello") {
+		t.Errorf("expected env-prefixed cmd to set MARKER=hello in env, got: %s", out)
+	}
+}
+
+// TestExecAsUserCmd_CallSiteShapes is a table-driven end-to-end test
+// that exercises each cmd shape used by the production call sites in
+// pkg/runtimebroker/pty_handlers.go and pkg/runtime/k8s_runtime.go.
+//
+// Real call sites invoke `tmux ...` which is not installed in CI;
+// each test case substitutes a portable equivalent (`true`, `printf`,
+// `env`) that preserves the relevant shell-shape feature being
+// tested (env prefix, single-quoted token, plain command, etc.).
+// This guards against future regressions in the helper's quoting
+// logic that would only surface at one specific call site.
+func TestExecAsUserCmd_CallSiteShapes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX /bin/sh")
+	}
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("sh not found in PATH: %v", err)
+	}
+	u, err := user.Current()
+	if err != nil {
+		t.Skipf("could not determine current user: %v", err)
+	}
+
+	cases := []struct {
+		name       string
+		cmd        string
+		wantStdout string // substring expected in CombinedOutput
+		callSite   string // where this shape is used
+	}{
+		{
+			name:       "tmux_has_session_shape",
+			cmd:        `true && printf has-session-ok`,
+			wantStdout: "has-session-ok",
+			callSite:   "pty_handlers.go waitForTmuxSession (readiness probe)",
+		},
+		{
+			name:       "tmux_attach_with_env_prefix_shape",
+			cmd:        `TERM=xterm-256color env`,
+			wantStdout: "TERM=xterm-256color",
+			callSite:   "pty_handlers.go runK8sExec PTY attach paths",
+		},
+		{
+			name:       "tmux_display_message_with_single_quotes_shape",
+			cmd:        `printf '#{window_name}'`,
+			wantStdout: "#{window_name}",
+			callSite:   "pty_handlers.go queryTmuxActiveWindowK8s",
+		},
+		{
+			name:       "k8s_exec_quoted_join_shape",
+			cmd:        `'printf' 'hello world'`,
+			wantStdout: "hello world",
+			callSite:   "k8s_runtime.go Exec (joins shell-quoted argv)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapped := ExecAsUserCmd(u.Username, tc.cmd)
+			out, err := exec.Command(wrapped[0], wrapped[1:]...).CombinedOutput()
+			if err != nil {
+				t.Fatalf("wrapper failed for %s shape (used at %s): %v\nwrapped: %v\noutput: %s",
+					tc.name, tc.callSite, err, wrapped, out)
+			}
+			if !strings.Contains(string(out), tc.wantStdout) {
+				t.Errorf("expected output to contain %q for %s shape, got: %s",
+					tc.wantStdout, tc.name, out)
+			}
+		})
+	}
+}

--- a/pkg/runtime/k8s_parity_test.go
+++ b/pkg/runtime/k8s_parity_test.go
@@ -374,26 +374,46 @@ func TestCreateAuthFileSecret(t *testing.T) {
 // --- K8s exec user context parity (matches Docker/Podman --user scion) ---
 
 func TestK8sExec_WrapsCommandWithSu(t *testing.T) {
-	// Verify that Exec wraps commands with su to run as the scion user,
+	// Verify that Exec wraps commands so they run as the scion user,
 	// matching the --user scion flag used by Docker/Podman runtimes.
+	// The wrapper uses ExecAsUserCmd (sh -c with whoami fallback)
+	// instead of a bare `su -` invocation, so it works on container
+	// images whose /etc/pam.d/su lacks pam_rootok.so. ExecAsUserCmd
+	// passes user/cmd as positional shell arguments, so the joined
+	// shell-quoted cmd appears verbatim as the trailing argv entry.
 	cmd := []string{"tmux", "send-keys", "-t", "scion:0", "hello world", "Enter"}
 
-	// Simulate the wrapping logic from Exec
+	// Simulate the wrapping logic from Exec.
 	quoted := make([]string, len(cmd))
 	for i, arg := range cmd {
 		quoted[i] = fmt.Sprintf("'%s'", strings.ReplaceAll(arg, "'", "'\"'\"'"))
 	}
-	suCmd := []string{"su", "-", "scion", "-c", strings.Join(quoted, " ")}
+	joined := strings.Join(quoted, " ")
+	wrapped := ExecAsUserCmd("scion", joined)
 
-	if suCmd[0] != "su" || suCmd[1] != "-" || suCmd[2] != "scion" || suCmd[3] != "-c" {
-		t.Fatalf("expected su - scion -c prefix, got: %v", suCmd[:4])
+	if len(wrapped) != 6 || wrapped[0] != "sh" || wrapped[1] != "-c" {
+		t.Fatalf("expected [sh -c <script> <name> <user> <cmd>] wrapper, got: %v", wrapped)
 	}
 
-	// The -c argument should contain all original args, properly quoted
-	shellCmd := suCmd[4]
+	// The script must retain a su fallback so legacy
+	// root-entrypoint images keep working.
+	script := wrapped[2]
+	if !strings.Contains(script, `su - "$1" -c "$2"`) {
+		t.Errorf("expected script to retain su fallback, got: %s", script)
+	}
+
+	// User and cmd are passed as positional argv ($1, $2 — $0 is
+	// the script-name label) — both must round-trip through the
+	// helper untouched.
+	if wrapped[4] != "scion" {
+		t.Errorf("expected user at wrapped[4] to be \"scion\", got %q", wrapped[4])
+	}
+	if wrapped[5] != joined {
+		t.Errorf("expected joined cmd at wrapped[5] verbatim, got %q want %q", wrapped[5], joined)
+	}
 	for _, arg := range cmd {
-		if !strings.Contains(shellCmd, arg) {
-			t.Errorf("shell command %q should contain argument %q", shellCmd, arg)
+		if !strings.Contains(wrapped[5], arg) {
+			t.Errorf("joined cmd %q should contain argument %q", wrapped[5], arg)
 		}
 	}
 }

--- a/pkg/runtime/k8s_podexec_test.go
+++ b/pkg/runtime/k8s_podexec_test.go
@@ -75,7 +75,7 @@ func TestPodExec_TargetsAgentContainer(t *testing.T) {
 			name: "Exec",
 			opts: &corev1.PodExecOptions{
 				Container: agentContainerName,
-				Command:   []string{"su", "-", "scion", "-c", "echo hi"},
+				Command:   ExecAsUserCmd("scion", "echo hi"),
 				Stdout:    true,
 				Stderr:    true,
 			},

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -1771,13 +1771,11 @@ func (r *KubernetesRuntime) Attach(ctx context.Context, id string) error {
 		return fmt.Errorf("invalid username in pod annotation: %q", username)
 	}
 
-	// Build the exec command. If the container already runs as the target
-	// user (common on GKE Autopilot where allowPrivilegeEscalation=false),
-	// skip the su wrapper — it would prompt for a password.
-	// Use a shell wrapper that checks the current user at runtime.
-	execCmd := []string{"sh", "-c", fmt.Sprintf(
-		`target=%q; if [ "$(whoami)" = "$target" ]; then exec tmux attach -t scion; else exec su - "$target" -c "tmux attach -t scion"; fi`,
-		username)}
+	// Wrap the exec command with the whoami-skip-su helper so it works
+	// on both root-entrypoint images (where su is needed) and non-root
+	// entrypoint images (where su would prompt for a password). See
+	// ExecAsUserCmd godoc for the underlying PAM rationale.
+	execCmd := ExecAsUserCmd(username, "tmux attach -t scion")
 
 	option := &corev1.PodExecOptions{
 		Container: agentContainerName,
@@ -2035,13 +2033,16 @@ func (r *KubernetesRuntime) Exec(ctx context.Context, id string, cmd []string) (
 		Namespace(namespace).
 		SubResource("exec")
 
-	// Wrap command with su to run as the scion user (K8s exec has no --user flag).
-	// Shell-quote each argument to handle spaces and special characters.
+	// Wrap command to run as the scion user (K8s exec has no --user flag).
+	// Shell-quote each argument to handle spaces and special characters,
+	// then wrap with the whoami-skip-su helper so it works on images that
+	// run as root (su needed) and images that run as scion (su would
+	// prompt for a password — see ExecAsUserCmd godoc).
 	quoted := make([]string, len(cmd))
 	for i, arg := range cmd {
 		quoted[i] = fmt.Sprintf("'%s'", strings.ReplaceAll(arg, "'", "'\"'\"'"))
 	}
-	suCmd := []string{"su", "-", "scion", "-c", strings.Join(quoted, " ")}
+	suCmd := ExecAsUserCmd("scion", strings.Join(quoted, " "))
 
 	option := &corev1.PodExecOptions{
 		Container: agentContainerName,

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -26,7 +26,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -1767,7 +1766,7 @@ func (r *KubernetesRuntime) Attach(ctx context.Context, id string) error {
 	}
 
 	// Validate username to prevent shell injection via pod annotations.
-	if !regexp.MustCompile(`^[a-zA-Z0-9_-]+$`).MatchString(username) {
+	if !ValidExecUserName.MatchString(username) {
 		return fmt.Errorf("invalid username in pod annotation: %q", username)
 	}
 
@@ -2042,7 +2041,7 @@ func (r *KubernetesRuntime) Exec(ctx context.Context, id string, cmd []string) (
 	for i, arg := range cmd {
 		quoted[i] = fmt.Sprintf("'%s'", strings.ReplaceAll(arg, "'", "'\"'\"'"))
 	}
-	suCmd := ExecAsUserCmd("scion", strings.Join(quoted, " "))
+	suCmd := ExecAsUserCmd(r.ExecUser(), strings.Join(quoted, " "))
 
 	option := &corev1.PodExecOptions{
 		Container: agentContainerName,

--- a/pkg/runtimebroker/pty_handlers.go
+++ b/pkg/runtimebroker/pty_handlers.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -56,23 +55,18 @@ const (
 	ptyMaxDataSize = 32 * 1024 // 32KB max per message
 )
 
-// execUserPattern matches the set of usernames the broker is willing
-// to interpolate into shell command lines (via runtime.ExecAsUserCmd
-// and the runtime --user flag). The character set mirrors the
-// validation in pkg/runtime/k8s_runtime.go:Attach so the broker and
-// runtime apply the same defense-in-depth check against shell
-// injection from agent metadata that crosses a trust boundary.
-var execUserPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
-
-// sanitizeExecUser returns user if it matches execUserPattern,
+// sanitizeExecUser returns user if it matches runtime.ValidExecUserName,
 // otherwise returns "scion" and logs a warning. Callers default to
 // "scion" already when the value is empty, so passing an empty
-// string is harmless.
+// string is harmless. The shared regex enforces the same
+// defense-in-depth check against shell injection from agent metadata
+// that KubernetesRuntime.Attach applies, so values flowing into
+// runtime.ExecAsUserCmd are validated by exactly one rule.
 func sanitizeExecUser(user string) string {
 	if user == "" {
 		return "scion"
 	}
-	if !execUserPattern.MatchString(user) {
+	if !runtime.ValidExecUserName.MatchString(user) {
 		slog.Warn("Invalid exec user, falling back to 'scion'", "user", user)
 		return "scion"
 	}
@@ -417,11 +411,12 @@ func (s *LocalPTYSession) runK8sExec() error {
 		Namespace(namespace).
 		SubResource("exec")
 
-	// Run as scion user: the tmux session is owned by the scion user
-	// (sciontool init drops privileges), so root can't see the session.
+	// Run as the configured exec user (default "scion"): the tmux
+	// session is owned by that user (sciontool init drops privileges),
+	// so root can't see the session.
 	req.VersionedParams(&corev1.PodExecOptions{
 		Container: "agent",
-		Command:   runtime.ExecAsUserCmd("scion", tmuxAttachCmd),
+		Command:   runtime.ExecAsUserCmd(s.execUser, tmuxAttachCmd),
 		Stdin:     true,
 		Stdout:    true,
 		Stderr:    true,
@@ -768,11 +763,12 @@ func (h *StreamPTYHandler) runK8sExec() error {
 		Namespace(namespace).
 		SubResource("exec")
 
-	// Run as scion user: the tmux session is owned by the scion user
-	// (sciontool init drops privileges), so root can't see the session.
+	// Run as the configured exec user (default "scion"): the tmux
+	// session is owned by that user (sciontool init drops privileges),
+	// so root can't see the session.
 	req.VersionedParams(&corev1.PodExecOptions{
 		Container: "agent",
-		Command:   runtime.ExecAsUserCmd("scion", tmuxAttachCmd),
+		Command:   runtime.ExecAsUserCmd(h.execUser, tmuxAttachCmd),
 		Stdin:     true,
 		Stdout:    true,
 		Stderr:    true,

--- a/pkg/runtimebroker/pty_handlers.go
+++ b/pkg/runtimebroker/pty_handlers.go
@@ -24,10 +24,12 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/wsprotocol"
 	"github.com/creack/pty"
 	"github.com/gorilla/websocket"
@@ -41,12 +43,41 @@ import (
 const (
 	tmuxSessionWaitTimeout  = 30 * time.Second
 	tmuxSessionPollInterval = 500 * time.Millisecond
+
+	// tmuxAttachCmd is the shell cmd that attaches to the agent's
+	// tmux session for an interactive PTY stream. The TERM env
+	// prefix is required so tmux negotiates the right terminfo for
+	// xterm-style sequences from the web terminal client.
+	tmuxAttachCmd = "TERM=xterm-256color tmux attach-session -t scion"
 )
 
 // PTY endpoint configuration
 const (
 	ptyMaxDataSize = 32 * 1024 // 32KB max per message
 )
+
+// execUserPattern matches the set of usernames the broker is willing
+// to interpolate into shell command lines (via runtime.ExecAsUserCmd
+// and the runtime --user flag). The character set mirrors the
+// validation in pkg/runtime/k8s_runtime.go:Attach so the broker and
+// runtime apply the same defense-in-depth check against shell
+// injection from agent metadata that crosses a trust boundary.
+var execUserPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// sanitizeExecUser returns user if it matches execUserPattern,
+// otherwise returns "scion" and logs a warning. Callers default to
+// "scion" already when the value is empty, so passing an empty
+// string is harmless.
+func sanitizeExecUser(user string) string {
+	if user == "" {
+		return "scion"
+	}
+	if !execUserPattern.MatchString(user) {
+		slog.Warn("Invalid exec user, falling back to 'scion'", "user", user)
+		return "scion"
+	}
+	return user
+}
 
 // activeWindowOSC builds an OSC 7337 escape sequence encoding the active tmux
 // window name. The web terminal client parses this to sync its toolbar selector.
@@ -87,7 +118,7 @@ func queryTmuxActiveWindowK8s(ctx context.Context, config *rest.Config, clientse
 
 	req.VersionedParams(&corev1.PodExecOptions{
 		Container: "agent",
-		Command:   []string{"su", "-", execUser, "-c", "tmux display-message -t scion -p '#{window_name}'"},
+		Command:   runtime.ExecAsUserCmd(execUser, "tmux display-message -t scion -p '#{window_name}'"),
 		Stdin:     false,
 		Stdout:    true,
 		Stderr:    false,
@@ -122,9 +153,7 @@ func waitForTmuxSession(ctx context.Context, runtimeCmd, containerID, namespace,
 	ticker := time.NewTicker(tmuxSessionPollInterval)
 	defer ticker.Stop()
 
-	if execUser == "" {
-		execUser = "scion"
-	}
+	execUser = sanitizeExecUser(execUser)
 
 	isK8s := runtimeCmd == "kubernetes" || runtimeCmd == "k8s"
 
@@ -137,7 +166,7 @@ func waitForTmuxSession(ctx context.Context, runtimeCmd, containerID, namespace,
 			if isK8s && k8sConfig != nil && k8sClientset != nil {
 				// The tmux session runs as the scion user (via sciontool init privilege drop),
 				// so we must check as that user — root can't see scion's tmux socket.
-				checkErr = k8sExecCheck(ctx, k8sConfig, k8sClientset, namespace, containerID, []string{"su", "-", execUser, "-c", "tmux has-session -t scion"})
+				checkErr = k8sExecCheck(ctx, k8sConfig, k8sClientset, namespace, containerID, runtime.ExecAsUserCmd(execUser, "tmux has-session -t scion"))
 			} else {
 				cmd := exec.CommandContext(ctx, runtimeCmd, "exec", "--user", execUser, containerID, "tmux", "has-session", "-t", "scion")
 				checkErr = cmd.Run()
@@ -297,9 +326,7 @@ func newLocalPTYSession(ctx context.Context, agentID, containerID, runtimeCmd, e
 	if runtimeCmd == "" {
 		runtimeCmd = "docker"
 	}
-	if execUser == "" {
-		execUser = "scion"
-	}
+	execUser = sanitizeExecUser(execUser)
 	ctx, cancel := context.WithCancel(ctx)
 	return &LocalPTYSession{
 		ctx:          ctx,
@@ -394,7 +421,7 @@ func (s *LocalPTYSession) runK8sExec() error {
 	// (sciontool init drops privileges), so root can't see the session.
 	req.VersionedParams(&corev1.PodExecOptions{
 		Container: "agent",
-		Command:   []string{"su", "-", "scion", "-c", "TERM=xterm-256color tmux attach-session -t scion"},
+		Command:   runtime.ExecAsUserCmd("scion", tmuxAttachCmd),
 		Stdin:     true,
 		Stdout:    true,
 		Stderr:    true,
@@ -638,9 +665,7 @@ type StreamPTYHandler struct {
 // NewStreamPTYHandler creates a handler for a PTY stream from the control channel.
 func NewStreamPTYHandler(client *ControlChannelClient, handler *StreamHandler, containerID, runtimeCmd, execUser, namespace string, cols, rows int, k8sConfig *rest.Config, k8sClientset kubernetes.Interface) *StreamPTYHandler {
 	ctx, cancel := context.WithCancel(context.Background())
-	if execUser == "" {
-		execUser = "scion"
-	}
+	execUser = sanitizeExecUser(execUser)
 	return &StreamPTYHandler{
 		client:       client,
 		handler:      handler,
@@ -747,7 +772,7 @@ func (h *StreamPTYHandler) runK8sExec() error {
 	// (sciontool init drops privileges), so root can't see the session.
 	req.VersionedParams(&corev1.PodExecOptions{
 		Container: "agent",
-		Command:   []string{"su", "-", "scion", "-c", "TERM=xterm-256color tmux attach-session -t scion"},
+		Command:   runtime.ExecAsUserCmd("scion", tmuxAttachCmd),
 		Stdin:     true,
 		Stdout:    true,
 		Stderr:    true,

--- a/pkg/runtimebroker/pty_handlers_test.go
+++ b/pkg/runtimebroker/pty_handlers_test.go
@@ -180,3 +180,28 @@ func TestK8sSizeQueue_ReturnsNilOnClose(t *testing.T) {
 		t.Errorf("expected nil on close, got %+v", size)
 	}
 }
+
+func TestSanitizeExecUser(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty falls back", in: "", want: "scion"},
+		{name: "valid scion", in: "scion", want: "scion"},
+		{name: "valid root", in: "root", want: "root"},
+		{name: "valid alphanumeric with hyphen", in: "agent-user_1", want: "agent-user_1"},
+		{name: "shell metachar rejected", in: "scion;rm -rf /", want: "scion"},
+		{name: "command substitution rejected", in: "$(whoami)", want: "scion"},
+		{name: "quote rejected", in: `bad"name`, want: "scion"},
+		{name: "space rejected", in: "two words", want: "scion"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeExecUser(tc.in)
+			if got != tc.want {
+				t.Errorf("sanitizeExecUser(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Following the pattern from #159, this extends the whoami-skip-su fix to the remaining `su -` call sites the original PR didn't cover, and factors the shared logic into a `runtime.ExecAsUserCmd` helper used by all six sites (the five being newly fixed plus #159's inline fix in `Attach`, opportunistically migrated to the helper for consistency).

## Background

PR #159 fixed `scion attach` on GKE Autopilot by checking `$(whoami)` before invoking `su - scion`, which prompts for a password when the container's `/etc/pam.d/su` lacks `pam_rootok.so` (the case on Debian slim bases like `node:20-slim` that the upstream `image-build/scion-base` chain extends). That fix landed only in `KubernetesRuntime.Attach`; the runtime-broker PTY paths and the K8s `Exec` wrapper kept the old shape.

## Symptom in cluster mode

Hub + runtime-broker on K8s, agents in separate pods: the dashboard's live terminal stream never connects. Hub logs show:

```
ERROR PTY stream error: timed out waiting for tmux session in container '<pod>' to become ready
```

…even though the tmux session **is** running fine inside the agent container. The agent works (Vertex calls succeed, harness responds, telemetry flows), but operators can't see the live PTY.

Verified on a GKE cluster:

```
$ kubectl exec <pod> -c agent -- ps -eo user,pid,comm
scion          1 sciontool
scion         78 tmux: server         ← session running fine
scion         79 claude

$ kubectl exec <pod> -c agent -- su - scion -c "tmux has-session -t scion"
Password: su: Authentication failure   ← the broker's exact probe command
```

The probe is the broker's `tmux has-session` check at `pkg/runtimebroker/pty_handlers.go:140`, which used the same `su - <user> -c ...` shape that #159 patched in the runtime package.

## Affected call sites

| File | Site | Action |
|---|---|---|
| `pkg/runtimebroker/pty_handlers.go` (4 sites) | window query, readiness probe, two PTY attach paths | **fixed** |
| `pkg/runtime/k8s_runtime.go` (Exec) | K8s exec wrapper | **fixed** |
| `pkg/runtime/k8s_runtime.go` (Attach) | the #159 site | **opportunistically migrated to the shared helper** |
| `pkg/runtime/k8s_podexec_test.go` | test asserting old `su -` command shape | updated to use the helper |
| `pkg/runtime/k8s_parity_test.go` | test asserting old `suCmd` shape | updated to use the helper |

## Helper design

Rather than open-coding the `sh -c if-then-else` block at each site, the fix introduces `runtime.ExecAsUserCmd(user, cmd string) []string`:

```go
func ExecAsUserCmd(user, cmd string) []string {
    const script = `if [ "$(whoami)" = "$1" ]; then exec sh -c "$2"; else exec su - "$1" -c "$2"; fi`
    return []string{"sh", "-c", script, "exec-as-user", user, cmd}
}
```

Three design notes:

1. **Both branches route the cmd through a fresh `sh -c`.** `exec` is a POSIX special builtin that does not parse leading `VAR=value` env-prefix assignments — without an inner shell, the PTY attach call sites that pass `TERM=xterm-256color tmux attach-session -t scion` would fail with exit code 127 (`exec: TERM=xterm-256color: not found`) once `whoami` matches the target user. Routing through `exec sh -c "$2"` makes both branches symmetric so any shell syntax valid in the `su -c` branch is also valid in the `whoami` branch.

2. **`user` and `cmd` are passed as positional shell arguments (`$1`/`$2`)** rather than interpolated into the script body via `fmt.Sprintf` + shell quoting. The shell's own argv machinery preserves them verbatim — no Go-side quoting layer that could disagree with what the inner shell expects. Cmds containing `$VAR`, backticks, or backslashes survive verbatim.

3. **`$0` is a script-name label (`"exec-as-user"`)** so anything that prints `$0` for diagnostics (shell error messages, `ps`) is self-describing.

## Defense-in-depth additions on the broker side

- A `sanitizeExecUser` helper in `pty_handlers.go` applies the same `^[a-zA-Z0-9_-]+$` regex that `KubernetesRuntime.Attach` uses for the username it derives from agent annotations. Invalid values fall back to `"scion"` with a logged warning. Used by both PTY constructors and `waitForTmuxSession`.
- The duplicated `"TERM=xterm-256color tmux attach-session -t scion"` literal in `pty_handlers.go` is extracted to a `tmuxAttachCmd` package const.

## Tests

- `ExecAsUserCmd` unit tests cover shape, single-quote preservation, username verbatim round-trip, an execution-based smoke test that proves the whoami branch runs the cmd directly, an env-prefix regression test that prevents reintroducing the `exec %s` bug, and a table-driven end-to-end test that runs each production cmd shape (env-prefixed, single-quoted token, plain, shell-quoted argv join) through the helper + `/bin/sh`.
- `sanitizeExecUser` table test covers empty fallback, valid users, shell metacharacter rejection, command substitution rejection, quoted-name rejection, and whitespace rejection.
- Existing tests in `k8s_podexec_test.go` and `k8s_parity_test.go` are updated to use the helper rather than hardcoding the shell string.

## Verification

End-to-end on GKE: the dashboard PTY now streams immediately once the tmux session is up, on agent images that previously hit the PAM-prompt bug.

Local CI:

- `make fmt-check` ✅
- `make lint` ✅
- `make build` ✅
- `make golangci-lint` ✅ (`0 issues` vs main)
- `go test ./pkg/runtime/... ./pkg/runtimebroker/...` ✅ (excluding the pre-existing macOS `/var` ↔ `/private/var` symlink failure in `TestCreateAgentGroveSlugInitializesScionDir`, which reproduces on bare `upstream/main`)

## Out of scope

- The unrelated `failed to look up existing grove members group by slug` warning that may appear in hub logs.
- The `Signing key not found in any source, generating new key` ephemeral-secrets bug.
- Any changes to agent container Dockerfiles, pod specs, or Workload Identity setup.
- Shell scripts in `image-build/` — strictly the Go call sites.
