### PR TITLE
fix(docs): resolve Astro 6 build errors and modernize Starlight dependencies

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -25,7 +25,7 @@ export default defineConfig({
 	site: 'https://googlecloudplatform.github.io',
 	base: '/scion',
 	integrations: [
-		d2(),
+		d2({ experimental: { useD2js: true } }),
 		starlight({
 			plugins: [starlightLinksValidator()],
 			title: 'Scion',

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -12,11 +12,14 @@
         "@astrojs/starlight": "^0.38.3",
         "astro": "^6.1.8",
         "sharp": "^0.34.2",
-        "starlight-links-validator": "^0.19.2",
+        "starlight-links-validator": "^0.23.0",
         "typescript": "^5.9.3"
       },
       "devDependencies": {
-        "astro-d2": "^0.8.1"
+        "astro-d2": "^0.10.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@astrojs/check": {
@@ -2042,6 +2045,13 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@terrastruct/d2": {
+      "version": "0.1.33",
+      "resolved": "https://registry.npmjs.org/@terrastruct/d2/-/d2-0.1.33.tgz",
+      "integrity": "sha512-eK5hyfGIJFolC7sUsiKvWdY9xGFctTe3d+PSijo09IYDso8psztC+A4SammizXtlwYZpnnW0AtDjfBYauceSeA==",
+      "dev": true,
+      "license": "MPL-2.0"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2121,9 +2131,9 @@
       }
     },
     "node_modules/@types/picomatch": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-3.0.2.tgz",
-      "integrity": "sha512-n0i8TD3UDB7paoMMxA3Y65vUncFJXjcUf7lQY7YyKGl6031FNjfsLs6pdLFCy2GNFxItPJG8GvvpbZc2skH7WA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==",
       "license": "MIT"
     },
     "node_modules/@types/sax": {
@@ -2446,21 +2456,22 @@
       }
     },
     "node_modules/astro-d2": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/astro-d2/-/astro-d2-0.8.1.tgz",
-      "integrity": "sha512-r2Y4KbRQ+hOFV+YR7i9dDBWbPFVh8hvz2aM4u+wc+uLwxQ03CvoC5VD6c2x+jKhMRYJH9KblKzydalaxXsgoBg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/astro-d2/-/astro-d2-0.10.0.tgz",
+      "integrity": "sha512-KL2N3BcPvuk7orPJsXVeMVMYd70eimLdxslbwR6M80hXIDj6EWd0SAJlx961qepIvXMwh3FxKkb6S6sWYuRjBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@terrastruct/d2": "^0.1.33",
         "hast-util-from-html": "^2.0.3",
-        "hast-util-to-html": "^9.0.4",
-        "unist-util-visit": "^5.0.0"
+        "hast-util-to-html": "^9.0.5",
+        "unist-util-visit": "^5.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22.12.0"
       },
       "peerDependencies": {
-        "astro": ">=5.0.0"
+        "astro": ">=6.0.0"
       }
     },
     "node_modules/astro-expressive-code": {
@@ -4026,12 +4037,12 @@
       }
     },
     "node_modules/is-absolute-url": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
-      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-5.0.0.tgz",
+      "integrity": "sha512-sdJyNpBnQHuVnBunfzjAecOhZr2+A30ywfFvu3EnxtKLUWfwGgyWUmqHbGZiU6vTfHpCPm5GvLe4BAvlU9n8VQ==",
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6309,38 +6320,28 @@
       }
     },
     "node_modules/starlight-links-validator": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/starlight-links-validator/-/starlight-links-validator-0.19.2.tgz",
-      "integrity": "sha512-IHeK3R78fsmv53VfRkGbXkwK1CQEUBHM9QPzBEyoAxjZ/ssi5gjV+F4oNNUppTR48iPp+lEY0MTAmvkX7yNnkw==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/starlight-links-validator/-/starlight-links-validator-0.23.0.tgz",
+      "integrity": "sha512-dpKJdNv170+jyw8HDgPKGIW/MnXUxa3v8RqJrER47jx4fbxvLsITIw0/Y76xzTTrDv8LhQ7t/ExFutUDQqm3FQ==",
       "license": "MIT",
       "dependencies": {
-        "@types/picomatch": "^3.0.1",
+        "@types/picomatch": "^4.0.2",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
-        "hast-util-has-property": "^3.0.0",
-        "is-absolute-url": "^4.0.1",
-        "kleur": "^4.1.5",
-        "mdast-util-mdx-jsx": "^3.1.3",
-        "mdast-util-to-string": "^4.0.0",
-        "picomatch": "^4.0.2",
+        "is-absolute-url": "^5.0.0",
+        "mdast-util-mdx-jsx": "^3.2.0",
+        "mdast-util-to-hast": "^13.2.1",
+        "picomatch": "^4.0.3",
         "terminal-link": "^5.0.0",
-        "unist-util-visit": "^5.0.0"
+        "unist-util-visit": "^5.1.0",
+        "yaml": "^2.8.3"
       },
       "engines": {
-        "node": ">=18.17.1"
+        "node": ">=22.12.0"
       },
       "peerDependencies": {
-        "@astrojs/starlight": ">=0.32.0",
-        "astro": ">=5.1.5"
-      }
-    },
-    "node_modules/starlight-links-validator/node_modules/kleur": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
+        "@astrojs/starlight": ">=0.38.0",
+        "astro": ">=6.0.0"
       }
     },
     "node_modules/stream-replace-string": {
@@ -7264,9 +7265,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -15,11 +15,11 @@
     "@astrojs/starlight": "^0.38.3",
     "astro": "^6.1.8",
     "sharp": "^0.34.2",
-    "starlight-links-validator": "^0.19.2",
+    "starlight-links-validator": "^0.23.0",
     "typescript": "^5.9.3"
   },
   "devDependencies": {
-    "astro-d2": "^0.8.1"
+    "astro-d2": "^0.10.0"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
This PR addresses several build-breaking issues in the docs-site introduced by the migration to Astro 6. It resolves Zod-related configuration errors and streamlines the diagram generation process.

**Root Causes**
  [The primary failure ](https://github.com/GoogleCloudPlatform/scion/actions/runs/24965686109/job/73099936592)was a `z.function(...).args is not a function `error during the Astro configuration phase. This was caused by an incompatibility between the older versions of Starlight plugins and the version of Zod bundled with Astro 6. Additionally, the astro-d2 integration encountered issues parsing configuration defaults in the new environment.

**Changes**
   * Dependency Updates:
       * Upgraded starlight-links-validator from ^0.19.2 to ^0.23.0 to restore compatibility with Astro 6's schema validation.
       * Upgraded astro-d2 from ^0.8.1 to ^0.10.0.
   * Portability Improvement:
       * Enabled the experimental useD2js mode in astro.config.mjs. This switches diagram generation to a WASM-based engine (D2.js), removing the requirement for a local d2 binary to be installed on the host system or CI runner.
   * Build Stability:
       * Synchronized package-lock.json to ensure clean, reproducible builds across environments.

**Verification Results**
   * Build Success: npm run build completes without errors.
   * Link Validation: starlight-links-validator correctly validates all internal links.
   * Diagram Generation: Confirmed that .svg diagrams are successfully generated in public/d2/ using the new WASM engine without a local d2 installation.

**Checklist**
   - [x] npm run build passes locally.
   - [x] No system-level binaries (like d2) are required for the build.
   - [x] package-lock.json is synchronized with package.json.