### PR TITLE
add directory to opencode system-prompt/instructions writing

### DIFF
--- a/pkg/harness/opencode.go
+++ b/pkg/harness/opencode.go
@@ -108,7 +108,7 @@ func (o *OpenCode) GetTelemetryEnv() map[string]string {
 }
 
 func (o *OpenCode) InjectAgentInstructions(agentHome string, content []byte) error {
-	target := filepath.Join(agentHome, "AGENTS.md")
+	target := filepath.Join(agentHome, ".config/opencode", "AGENTS.md")
 	return os.WriteFile(target, content, 0644)
 }
 
@@ -184,7 +184,7 @@ func (o *OpenCode) ResolveAuth(auth api.AuthConfig) (*api.ResolvedAuth, error) {
 
 func (o *OpenCode) InjectSystemPrompt(agentHome string, content []byte) error {
 	// OpenCode has no native system prompt support — downgrade by prepending to AGENTS.md
-	agentsPath := filepath.Join(agentHome, "AGENTS.md")
+	agentsPath := filepath.Join(agentHome, ".config/opencode", "AGENTS.md")
 	header := fmt.Sprintf("# System Prompt\n\n%s\n\n---\n\n", string(content))
 
 	existing, err := os.ReadFile(agentsPath)

--- a/pkg/harness/opencode.go
+++ b/pkg/harness/opencode.go
@@ -108,7 +108,11 @@ func (o *OpenCode) GetTelemetryEnv() map[string]string {
 }
 
 func (o *OpenCode) InjectAgentInstructions(agentHome string, content []byte) error {
-	target := filepath.Join(agentHome, ".config/opencode", "AGENTS.md")
+	dir := filepath.Join(agentHome, o.DefaultConfigDir())
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+	target := filepath.Join(dir, "AGENTS.md")
 	return os.WriteFile(target, content, 0644)
 }
 
@@ -184,7 +188,11 @@ func (o *OpenCode) ResolveAuth(auth api.AuthConfig) (*api.ResolvedAuth, error) {
 
 func (o *OpenCode) InjectSystemPrompt(agentHome string, content []byte) error {
 	// OpenCode has no native system prompt support — downgrade by prepending to AGENTS.md
-	agentsPath := filepath.Join(agentHome, ".config/opencode", "AGENTS.md")
+	dir := filepath.Join(agentHome, o.DefaultConfigDir())
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+	agentsPath := filepath.Join(dir, "AGENTS.md")
 	header := fmt.Sprintf("# System Prompt\n\n%s\n\n---\n\n", string(content))
 
 	existing, err := os.ReadFile(agentsPath)

--- a/pkg/harness/opencode_test.go
+++ b/pkg/harness/opencode_test.go
@@ -58,7 +58,7 @@ func TestOpenCodeInjectSystemPrompt(t *testing.T) {
 		t.Fatalf("InjectSystemPrompt failed: %v", err)
 	}
 
-	target := filepath.Join(agentHome, "AGENTS.md")
+	target := filepath.Join(agentHome, o.DefaultConfigDir(), "AGENTS.md")
 	data, err := os.ReadFile(target)
 	if err != nil {
 		t.Fatalf("expected file at %s: %v", target, err)


### PR DESCRIPTION
Makes the file location consistent with other harnesses, was not being picked up by `opencode` because it ended up in `$HOME` instead of `$HOME/.config/opencode`