### PR TITLE
Reflect sudo permissions when writing shell completions to /etc

### DIFF
--- a/docs-site/src/content/docs/advanced-local/completions.md
+++ b/docs-site/src/content/docs/advanced-local/completions.md
@@ -42,8 +42,8 @@ source <(scion completion bash)
 To load completions for each session, execute once:
 ```bash
 # Linux:
-scion completion bash > /etc/bash_completion.d/scion
+scion completion bash | sudo tee /etc/bash_completion.d/scion
 
 # macOS:
-scion completion bash > /usr/local/etc/bash_completion.d/scion
+scion completion bash | sudo tee /usr/local/etc/bash_completion.d/scion
 ```


### PR DESCRIPTION
We probably don't want to encourage running all provided commands as `root`