### PR TITLE
fix(web): enforce asset compilation at build-time and fix runtime 404s

### DIFF
--- a/docs-site/src/content/docs/getting-started/install.md
+++ b/docs-site/src/content/docs/getting-started/install.md
@@ -70,7 +70,7 @@ make all
 # You can add ~/.local/bin/ to your PATH, or `mv` the binary to another directory in your PATH
 ```
 
-Alternatively, if you don't need the web UI, you can use `make build` to only compile the CLI into `./build/scion` (the web UI will show a placeholder page).
+Alternatively, if you don't need the web UI, you can build the CLI-only version using the no_embed_web tag: go build -tags no_embed_web -o ./build/scion ./cmd/scion (the web UI will show a placeholder page).
 
 To verify your installation, run:
 

--- a/docs-site/src/content/docs/getting-started/install.md
+++ b/docs-site/src/content/docs/getting-started/install.md
@@ -64,11 +64,13 @@ Ensure your `$GOPATH/bin` (typically `~/go/bin`) is in your system `$PATH`.
 If you have the repository cloned, you can use the provided `Makefile`:
 
 ```bash
-make build
-# This creates a 'scion' binary in the build directory.
-# You can move it to a directory in your PATH:
-sudo mv ./build/scion /usr/local/bin/
+make all
+# This builds the web frontend and installs the 'scion' binary
+# to ~/.local/bin/ with the UI assets embedded.
+# You can add ~/.local/bin/ to your PATH, or `mv` the binary to another directory in your PATH
 ```
+
+Alternatively, if you don't need the web UI, you can use `make build` to only compile the CLI into `./build/scion` (the web UI will show a placeholder page).
 
 To verify your installation, run:
 

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -870,9 +870,20 @@ func (ws *WebServer) prefetchPageData(r *http.Request) template.JS {
 }
 
 // hasWebAssets reports whether the server has web assets available to serve,
-// either from an embedded FS or a filesystem directory.
+// either from an embedded FS or a filesystem directory. It verifies the
+// presence of the core entry point (assets/main.js) to ensure the UI is
+// actually built and ready to serve.
 func (ws *WebServer) hasWebAssets() bool {
-	return ws.assets != nil || ws.assetsDisk != ""
+	if ws.assetsDisk != "" {
+		p := filepath.Join(ws.assetsDisk, "assets", "main.js")
+		_, err := os.Stat(p)
+		return err == nil
+	}
+	if ws.assets != nil {
+		_, err := fs.Stat(ws.assets, "assets/main.js")
+		return err == nil
+	}
+	return false
 }
 
 // spaHandler returns the SPA shell HTML for any route not matched by other handlers.

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/GoogleCloudPlatform/scion/web"
 	"github.com/gorilla/securecookie"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,6 +41,15 @@ type mockWebStore struct {
 
 func newTestWebServer(t *testing.T, cfg WebServerConfig) *WebServer {
 	t.Helper()
+	// Ensure hasWebAssets() returns true for tests unless they explicitly want
+	// to test the "no assets" case.
+	if cfg.AssetsDir == "" && !web.AssetsEmbedded {
+		tmpDir := t.TempDir()
+		assetsDir := filepath.Join(tmpDir, "assets")
+		os.MkdirAll(assetsDir, 0755)
+		os.WriteFile(filepath.Join(assetsDir, "main.js"), []byte("// test"), 0644)
+		cfg.AssetsDir = tmpDir
+	}
 	return NewWebServer(cfg)
 }
 
@@ -53,7 +63,7 @@ func newDevAuthWebServer(t *testing.T, overrides ...func(*WebServerConfig)) *Web
 	for _, fn := range overrides {
 		fn(&cfg)
 	}
-	return NewWebServer(cfg)
+	return newTestWebServer(t, cfg)
 }
 
 func TestSPAShellHandler(t *testing.T) {
@@ -286,8 +296,13 @@ func TestSPAHandler_NoAssets_APIStillWorks(t *testing.T) {
 }
 
 func TestSPAHandler_WithAssets_ServesNormalShell(t *testing.T) {
+	tmpDir := t.TempDir()
+	assetsDir := filepath.Join(tmpDir, "assets")
+	os.MkdirAll(assetsDir, 0755)
+	os.WriteFile(filepath.Join(assetsDir, "main.js"), []byte("// test"), 0644)
+
 	ws := newDevAuthWebServer(t, func(cfg *WebServerConfig) {
-		cfg.AssetsDir = t.TempDir()
+		cfg.AssetsDir = tmpDir
 	})
 
 	req := httptest.NewRequest("GET", "/", nil)

--- a/web/embed.go
+++ b/web/embed.go
@@ -25,5 +25,15 @@ import "embed"
 //go:embed all:dist/client
 var ClientAssets embed.FS
 
+// sentinel forces a compile-time error if the web assets have not been built.
+// If you see an error here, run 'make web' or build with '-tags no_embed_web'.
+//
+//go:embed dist/client/assets/main.js
+var sentinel []byte
+
 // AssetsEmbedded indicates whether client assets are embedded in the binary.
 var AssetsEmbedded = true
+
+func init() {
+	_ = sentinel // Mark as used
+}


### PR DESCRIPTION
This PR ensures that Scion binaries built from source have correctly compiled web assets embedded, or fail at compile-time with a helpful error message. It also fixes a runtime bug where the server would return a 404 error if the web directory was present but empty.

## Key Changes
- Compile-Time Enforcement: Added a sentinel `//go:embed` directive in `web/embed.go` for `assets/main.js`. Building the project now fails immediately if the web assets haven't been built (`make web`), preventing the creation of "broken" binaries.
- Improved Runtime Asset Detection: Modified `hasWebAssets()` in `pkg/hub/web.go` to verify the presence of `assets/main.js` before attempting to serve the SPA shell. This allows the server to gracefully fall back to a "Web UI Not Available" page even if an empty assets directory is provided via `--web-assets-dir`.
- Streamlined Onboarding: Updated the installation documentation (`install.md`) to recommend `make all`, which handles both the web build and installation to `~/.local/bin` in a single command.
- Test Setup: Updated `pkg/hub/web_test.go` to automatically provision dummy assets for web tests, ensuring CI remains green even when running without a full frontend build (e.g., using `-tags no_embed_web`).

## Why this is needed
Previously, because `web/dist/client` contained a `.gitkeep` file, the Go compiler would successfully embed an effectively empty directory. At runtime, the server would find this directory, serve the main HTML shell, and then fail to load the actual JavaScript, leading to a confusing 404 error (visible only in the browser console) and a blank page for users building from source.

## Testing Performed
- [x] Verified make build fails when assets are missing.
- [x] Verified make all successfully builds and installs a functional binary.
- [x] Verified go build -tags no_embed_web still works for CLI-only builds.
- [x] Verified all pkg/hub tests pass.