### PR TITLE
fix(hub): inject SCION_DEV_TOKEN in DispatchAgentStart

### DIFF
--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -1011,6 +1011,15 @@ func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *sto
 		}
 	}
 
+	// In dev-auth mode, inject the dev token so the in-container scion CLI can
+	// authenticate to the Hub. buildCreateRequest does the same for the
+	// create+start path; without it here, agents started via the start-existing
+	// path (e.g. `scion start <created-agent>`, broker re-dispatch on resume)
+	// reach the Hub with no usable credential and every hub call returns 401.
+	if d.devAuthToken != "" {
+		resolvedEnv["SCION_DEV_TOKEN"] = d.devAuthToken
+	}
+
 	if d.debug {
 		configEnvCount := 0
 		if agent.AppliedConfig != nil {

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -1659,6 +1659,101 @@ func TestHTTPAgentDispatcher_DispatchAgentCreate_DevTokenMergesWithExistingEnv(t
 	}
 }
 
+// TestHTTPAgentDispatcher_DispatchAgentStart_InjectsDevToken verifies that
+// DispatchAgentStart injects SCION_DEV_TOKEN into resolvedEnv when dev-auth
+// mode is configured, so agents started via the start-existing path (e.g.
+// `scion start <created-agent>`) auth to the Hub the same way as agents
+// started through the create+start path (which already injects the token via
+// buildCreateRequest).
+func TestHTTPAgentDispatcher_DispatchAgentStart_InjectsDevToken(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       "broker-1",
+		Name:     "test-broker",
+		Slug:     "test-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	dispatcher.SetDevAuthToken("my-dev-token")
+
+	agent := &store.Agent{
+		ID:              "agent-1",
+		Name:            "test-agent",
+		Slug:            "test-agent",
+		GroveID:         "grove-1",
+		RuntimeBrokerID: "broker-1",
+		AppliedConfig: &store.AgentAppliedConfig{
+			HarnessConfig: "claude",
+			Env: map[string]string{
+				"EXISTING_VAR": "existing-value",
+			},
+		},
+	}
+
+	if err := dispatcher.DispatchAgentStart(ctx, agent, ""); err != nil {
+		t.Fatalf("DispatchAgentStart failed: %v", err)
+	}
+
+	if !mockClient.startCalled {
+		t.Fatal("expected StartAgent to be called")
+	}
+	if mockClient.lastResolvedEnv["SCION_DEV_TOKEN"] != "my-dev-token" {
+		t.Errorf("expected SCION_DEV_TOKEN='my-dev-token', got %q",
+			mockClient.lastResolvedEnv["SCION_DEV_TOKEN"])
+	}
+	// Existing env should still be present alongside the dev token.
+	if mockClient.lastResolvedEnv["EXISTING_VAR"] != "existing-value" {
+		t.Errorf("expected EXISTING_VAR='existing-value', got %q",
+			mockClient.lastResolvedEnv["EXISTING_VAR"])
+	}
+}
+
+// TestHTTPAgentDispatcher_DispatchAgentStart_NoDevToken verifies that
+// SCION_DEV_TOKEN is not injected when dev-auth mode is not configured.
+func TestHTTPAgentDispatcher_DispatchAgentStart_NoDevToken(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       "broker-1",
+		Name:     "test-broker",
+		Slug:     "test-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	// Do NOT set dev auth token.
+
+	agent := &store.Agent{
+		ID:              "agent-1",
+		Name:            "test-agent",
+		Slug:            "test-agent",
+		GroveID:         "grove-1",
+		RuntimeBrokerID: "broker-1",
+	}
+
+	if err := dispatcher.DispatchAgentStart(ctx, agent, ""); err != nil {
+		t.Fatalf("DispatchAgentStart failed: %v", err)
+	}
+
+	if _, exists := mockClient.lastResolvedEnv["SCION_DEV_TOKEN"]; exists {
+		t.Error("expected SCION_DEV_TOKEN NOT to be present when devAuthToken is empty")
+	}
+}
+
 func TestHTTPAgentDispatcher_DispatchAgentStart_AppliesBrokerResponse(t *testing.T) {
 	ctx := context.Background()
 	memStore := createTestStore(t)


### PR DESCRIPTION
## Summary

In dev-auth mode, agents started through the start-existing path (e.g.
`scion start <name>` on an agent previously provisioned with
`scion create`, or any broker re-dispatch routed through
`DispatchAgentStart`) reach the Hub with no usable credential. Inside
the container every hub-touching `scion` command fails with:

```
Error: authentication failed, login to hub with 'scion hub auth login'
Exit code: 1
```

`buildCreateRequest` (used by `DispatchAgentCreate` /
`DispatchAgentProvision`) injects `SCION_DEV_TOKEN = d.devAuthToken`
into `ResolvedEnv`. `DispatchAgentStart` did not. This PR adds the
matching injection so the start-existing path produces the same
in-container auth state as the create+start path.

## Reproduction (before this PR)

Same hub, same broker, same template, same operator dev token. Only
the provisioning path differs.

```sh
# Works — in-container `scion list` exits 0
scion start authtest -t pika

# Also works — restart preserves the scion-token written at first launch
scion stop authtest && scion resume authtest

# Fails — in-container `scion list` exits 1 with the auth error above
scion create devauth6 -t pika -y
scion start devauth6
```

After the fix, the third case behaves like the first.

## Code path

- `pkg/hub/httpdispatcher.go` — `buildCreateRequest` already injects
  `SCION_DEV_TOKEN` when `d.devAuthToken != ""` (around the existing
  block near line 469). `DispatchAgentStart` builds its own
  `resolvedEnv` separately and lacked the equivalent block.
- The change adds the same conditional injection at the end of
  `DispatchAgentStart`'s env-resolution section, before the debug
  summary log.

## Tests

- `TestHTTPAgentDispatcher_DispatchAgentStart_InjectsDevToken` —
  verifies `SCION_DEV_TOKEN` is set when `SetDevAuthToken` was called,
  and that existing env vars are preserved.
- `TestHTTPAgentDispatcher_DispatchAgentStart_NoDevToken` — verifies
  no `SCION_DEV_TOKEN` is set when `devAuthToken` is empty.

These mirror the existing
`TestHTTPAgentDispatcher_DispatchAgentCreate_InjectsDevToken` /
`_NoDevToken` tests.

Full `pkg/hub` test suite (1716 tests) passes locally.

## Test plan

- [x] `go test ./pkg/hub/...` passes
- [ ] Manual repro (above) flips from exit 1 to exit 0 against a
      hub running on the patched server build