### PR TITLE
feat: add relative timestamp to activity badge in agent detail

### DIFF
--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -1153,7 +1153,9 @@ export class ScionPageAgentDetail extends LitElement {
                     status=${agent.activity as StatusType}
                     label=${agent.activity}
                     size="small"
-                  ></scion-status-badge>`
+                  ></scion-status-badge>${(agent.updated || agent.updatedAt)
+                    ? html`<span style="color: var(--scion-text-muted, #64748b); font-size: 0.85em; margin-left: 0.5em;">${this.formatRelativeTime((agent.updated || agent.updatedAt)!)}</span>`
+                    : ''}`
                 : html`<span style="color: var(--scion-text-muted, #64748b);">—</span>`}
             </span>
           </div>


### PR DESCRIPTION
Adds a relative timestamp (e.g. '2 minutes ago') next to the activity status badge in the agent detail Current State card, using the existing updated/updatedAt timestamp and formatRelativeTime(). Auto-refreshes via the 15-second update interval.