### PR TITLE
fix: handle "project" scope in storage path functions

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -206,7 +206,7 @@ func TemplateStoragePath(scope, scopeID, templateSlug string) string {
 	switch scope {
 	case "global":
 		return "templates/global/" + templateSlug
-	case "grove":
+	case "grove", "project":
 		return "templates/groves/" + scopeID + "/" + templateSlug
 	case "user":
 		return "templates/users/" + scopeID + "/" + templateSlug
@@ -227,7 +227,7 @@ func HarnessConfigStoragePath(scope, scopeID, slug string) string {
 	switch scope {
 	case "global":
 		return "harness-configs/global/" + slug
-	case "grove":
+	case "grove", "project":
 		return "harness-configs/groves/" + scopeID + "/" + slug
 	case "user":
 		return "harness-configs/users/" + scopeID + "/" + slug


### PR DESCRIPTION
## Summary
- `TemplateStoragePath` and `HarnessConfigStoragePath` only matched `"grove"` in their scope switch, so passing `"project"` (the renamed scope value from the V50 rename) fell through to the default case and produced paths without the `scopeID`
- Added `"project"` as an alias alongside `"grove"` in both switch statements, keeping the physical GCS path as `groves/` to avoid a data migration

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/storage/...` passes
- Verified that `TemplateStoragePath("project", "id", "slug")` now returns `templates/groves/id/slug` instead of `templates/slug`
- Same fix applied to `HarnessConfigStoragePath`