### PR TITLE
fix: include templates and harness_configs in V50 scope migration

### DIFF
--- a/pkg/store/sqlite/sqlite.go
+++ b/pkg/store/sqlite/sqlite.go
@@ -1269,6 +1269,8 @@ UPDATE gcp_service_accounts SET scope = 'project' WHERE scope = 'grove';
 UPDATE groups SET group_type = 'project_agents' WHERE group_type = 'grove_agents';
 UPDATE notification_subscriptions SET scope = 'project' WHERE scope = 'grove';
 UPDATE subscription_templates SET scope = 'project' WHERE scope = 'grove';
+UPDATE templates SET scope = 'project' WHERE scope = 'grove';
+UPDATE harness_configs SET scope = 'project' WHERE scope = 'grove';
 `
 	if _, err := tx.ExecContext(ctx, dataUpdates); err != nil {
 		return fmt.Errorf("updating data values: %w", err)


### PR DESCRIPTION
## Summary
- The V50 migration (`migrateV50`) updates scope values from `grove` to `project` across many tables but missed `templates.scope` and `harness_configs.scope`
- This caused a split-brain where pre-migration rows kept `scope="grove"` while new rows got `scope="project"`, making them invisible to scope-filtered queries
- Adds two UPDATE statements to the existing idempotent data migration block

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/store/...` passes
- [ ] Verify on a database with pre-existing `scope='grove'` rows in `templates` and `harness_configs` that they are updated to `scope='project'` after migration