### PR TITLE
fix(templates): normalize scope from grove to project in CLI

### DIFF
--- a/cmd/harness_config_install.go
+++ b/cmd/harness_config_install.go
@@ -163,7 +163,7 @@ func normalizeHarnessConfigSourceURL(raw string) string {
 func installToHub(hubCtx *HubContext, name, localPath, harnessType string) error {
 	PrintUsingHub(hubCtx.Endpoint)
 
-	scope := "grove"
+	scope := "project"
 	scopeID := ""
 
 	if globalMode {

--- a/cmd/template_resolution.go
+++ b/cmd/template_resolution.go
@@ -111,8 +111,8 @@ func parseTemplateScope(templateName string) (scope, name string) {
 		// Check if it's a known scope prefix
 		switch prefix {
 		case "global", "grove", "project", "user":
-			if prefix == "project" {
-				return "grove", templateName[idx+1:]
+			if prefix == "grove" {
+				return "project", templateName[idx+1:]
 			}
 			return prefix, templateName[idx+1:]
 		}
@@ -132,8 +132,8 @@ func findTemplateOnHub(ctx context.Context, hubCtx *HubContext, name, scope, pro
 	// If explicit scope is provided, search only that scope
 	if scope != "" {
 		effectiveScope := scope
-		if effectiveScope == "project" {
-			effectiveScope = "grove"
+		if effectiveScope == "grove" {
+			effectiveScope = "project"
 		}
 
 		opts := &hubclient.ListTemplatesOptions{
@@ -141,7 +141,7 @@ func findTemplateOnHub(ctx context.Context, hubCtx *HubContext, name, scope, pro
 			Scope:  effectiveScope,
 			Status: "active",
 		}
-		if effectiveScope == "grove" && projectID != "" {
+		if effectiveScope == "project" && projectID != "" {
 			opts.ProjectID = projectID
 		}
 
@@ -165,7 +165,7 @@ func findTemplateOnHub(ctx context.Context, hubCtx *HubContext, name, scope, pro
 	if projectID != "" {
 		opts := &hubclient.ListTemplatesOptions{
 			Name:    name,
-			Scope:   "grove",
+			Scope:   "project",
 			ProjectID: projectID,
 			Status:  "active",
 		}
@@ -310,7 +310,7 @@ func promptForLocalTemplateUpload(ctx context.Context, hubCtx *HubContext, local
 		effectiveScope = templateScope
 	}
 	if effectiveScope == "" {
-		effectiveScope = "grove"
+		effectiveScope = "project"
 	}
 
 	fmt.Printf("\nTemplate '%s' was not found on the Hub but exists locally at:\n", localTemplate.Name)
@@ -368,10 +368,10 @@ func uploadLocalTemplate(ctx context.Context, hubCtx *HubContext, localTemplate 
 		effectiveScope = templateScope
 	}
 	if effectiveScope == "" {
-		effectiveScope = "grove"
+		effectiveScope = "project"
 	}
-	if effectiveScope == "project" {
-		effectiveScope = "grove"
+	if effectiveScope == "grove" {
+		effectiveScope = "project"
 	}
 
 	fmt.Printf("Uploading template '%s' to Hub (%s scope)...\n", localTemplate.Name, effectiveScope)

--- a/cmd/template_resolution_test.go
+++ b/cmd/template_resolution_test.go
@@ -47,15 +47,15 @@ func TestParseTemplateScope(t *testing.T) {
 			expectedName:  "claude",
 		},
 		{
-			name:          "grove scope prefix",
+			name:          "grove scope prefix (normalized to project)",
 			input:         "grove:custom-template",
-			expectedScope: "grove",
+			expectedScope: "project",
 			expectedName:  "custom-template",
 		},
 		{
-			name:          "project scope prefix (synonym for grove)",
+			name:          "project scope prefix",
 			input:         "project:custom-template",
-			expectedScope: "grove",
+			expectedScope: "project",
 			expectedName:  "custom-template",
 		},
 		{
@@ -73,7 +73,7 @@ func TestParseTemplateScope(t *testing.T) {
 		{
 			name:          "multiple colons",
 			input:         "grove:my:template",
-			expectedScope: "grove",
+			expectedScope: "project",
 			expectedName:  "my:template",
 		},
 		{

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -31,7 +31,7 @@ import (
 type Template struct {
 	Name  string
 	Path  string
-	Scope string // "global" or "grove"
+	Scope string // "global" or "project"
 }
 
 // ResolveContent resolves a template field value to its content bytes.
@@ -241,7 +241,7 @@ func FindTemplateWithContext(ctx context.Context, name string) (*Template, error
 }
 
 // FindTemplateInScope finds a template by name in a specific scope only.
-// Scope must be "global" or "grove". Returns nil if not found in that scope.
+// Scope must be "global" or "project". Returns nil if not found in that scope.
 func FindTemplateInScope(name, scope string) *Template {
 	var dir string
 	var err error
@@ -249,7 +249,7 @@ func FindTemplateInScope(name, scope string) *Template {
 	switch scope {
 	case "global":
 		dir, err = GetGlobalTemplatesDir()
-	case "grove":
+	case "project", "grove":
 		dir, err = GetProjectTemplatesDir()
 	default:
 		return nil
@@ -374,7 +374,7 @@ func FindTemplateInProjectPath(name, projectPath string) (*Template, error) {
 	projectTemplatesDir := filepath.Join(projectPath, "templates")
 	path := filepath.Join(projectTemplatesDir, name)
 	if info, err := os.Stat(path); err == nil && info.IsDir() {
-		return &Template{Name: name, Path: path, Scope: "grove"}, nil
+		return &Template{Name: name, Path: path, Scope: "project"}, nil
 	}
 
 	// Fall back to global templates
@@ -560,7 +560,7 @@ func ListTemplatesGrouped() (global []*Template, project []*Template, err error)
 
 	// Scan project templates
 	if projectDir, err := GetProjectTemplatesDir(); err == nil {
-		project = scan(projectDir, "grove")
+		project = scan(projectDir, "project")
 	}
 
 	// Sort both lists by name for consistent output
@@ -602,7 +602,7 @@ func ListTemplates() ([]*Template, error) {
 
 	// 2. Scan project templates (higher precedence)
 	if projectDir, err := GetProjectTemplatesDir(); err == nil {
-		scan(projectDir, "grove")
+		scan(projectDir, "project")
 	}
 
 	var list []*Template

--- a/pkg/config/templates_test.go
+++ b/pkg/config/templates_test.go
@@ -497,8 +497,8 @@ func TestFindTemplateInProjectPath(t *testing.T) {
 		if tpl.Path != groveTplDir {
 			t.Errorf("expected path %q, got %q", groveTplDir, tpl.Path)
 		}
-		if tpl.Scope != "grove" {
-			t.Errorf("expected scope 'grove', got %q", tpl.Scope)
+		if tpl.Scope != "project" {
+			t.Errorf("expected scope 'project', got %q", tpl.Scope)
 		}
 	})
 
@@ -572,8 +572,8 @@ func TestFindTemplateInProjectPath_GitGroveInRepoTemplates(t *testing.T) {
 	if tpl.Path != inRepoTplDir {
 		t.Errorf("expected template path %q, got %q", inRepoTplDir, tpl.Path)
 	}
-	if tpl.Scope != "grove" {
-		t.Errorf("expected scope 'grove', got %q", tpl.Scope)
+	if tpl.Scope != "project" {
+		t.Errorf("expected scope 'project', got %q", tpl.Scope)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes V50 migration gap where CLI template resolution still hardcoded `"grove"` as the scope value instead of `"project"`
- `parseTemplateScope` now normalizes `grove:` prefix to `project` scope
- Template discovery and install functions all emit `"project"` scope for project-level templates
- Tests updated to match new scope values

Part of the V50 grove-to-project rename migration cleanup.

## Files changed
- `cmd/template_resolution.go` — scope normalization and resolution
- `cmd/harness_config_install.go` — hub install scope
- `pkg/config/templates.go` — template discovery scope
- `cmd/template_resolution_test.go` — test expectations
- `pkg/config/templates_test.go` — test expectations

## Test plan
- [x] `go build ./...` passes
- [x] `TestParseTemplateScope` — all cases pass including grove-to-project normalization
- [x] `TestFindTemplateInProjectPath` — scope assertions updated and passing