### PR TITLE
fix: use correct query param for message listing

### DIFF
--- a/pkg/hubclient/messages.go
+++ b/pkg/hubclient/messages.go
@@ -119,7 +119,7 @@ func (s *messageService) List(ctx context.Context, opts *ListMessagesOptions) (*
 			query.Set("agent", opts.AgentID)
 		}
 		if opts.ProjectID != "" {
-			query.Set("grove", opts.ProjectID)
+			query.Set("project", opts.ProjectID)
 		}
 		if opts.Type != "" {
 			query.Set("type", opts.Type)


### PR DESCRIPTION
## Summary
- The hub client sent the project ID as query parameter `grove` (`pkg/hubclient/messages.go:122`), but the server handler reads `project` (`pkg/hub/handlers_messages.go:50`)
- This caused the project filter on message listing to be silently ignored, returning messages from all projects regardless of scope
- Changed `query.Set("grove", ...)` to `query.Set("project", ...)` to match the server

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/hubclient/...` passes
- [ ] Verify that listing messages with a project scope now correctly filters to that project only