### PR TITLE
fix: align secret scope constant and use SecretRef in Resolve()

### DIFF
--- a/pkg/secret/gcpbackend.go
+++ b/pkg/secret/gcpbackend.go
@@ -280,8 +280,16 @@ func (b *GCPBackend) Resolve(ctx context.Context, userID, projectID, brokerID st
 				continue
 			}
 
-			smName := b.gcpSecretName(s.Key, sc.scope, sc.scopeID)
-			value, err := b.accessLatestVersion(ctx, smName)
+			var value string
+			var secretRef string
+			if smPath, ok := extractGCPSMPath(s.SecretRef); ok {
+				value, err = b.accessLatestVersionByPath(ctx, smPath)
+				secretRef = smPath
+			} else {
+				smName := b.gcpSecretName(s.Key, sc.scope, sc.scopeID)
+				value, err = b.accessLatestVersion(ctx, smName)
+				secretRef = fmt.Sprintf("projects/%s/secrets/%s", b.projectID, smName)
+			}
 			if err != nil {
 				continue
 			}
@@ -305,7 +313,7 @@ func (b *GCPBackend) Resolve(ctx context.Context, userID, projectID, brokerID st
 					ScopeID:       sc.scopeID,
 					Description:   s.Description,
 					InjectionMode: s.InjectionMode,
-					SecretRef:     fmt.Sprintf("projects/%s/secrets/%s", b.projectID, smName),
+					SecretRef:     secretRef,
 					AllowProgeny:  s.AllowProgeny,
 					Version:       s.Version,
 					Created:       s.Created,
@@ -340,9 +348,17 @@ func (b *GCPBackend) Resolve(ctx context.Context, userID, projectID, brokerID st
 				continue
 			}
 
-			// Read value from GCP SM
-			smName := b.gcpSecretName(s.Key, s.Scope, s.ScopeID)
-			value, err := b.accessLatestVersion(ctx, smName)
+			// Read value from GCP SM, preferring stored SecretRef
+			var value string
+			var secretRef string
+			if smPath, ok := extractGCPSMPath(s.SecretRef); ok {
+				value, err = b.accessLatestVersionByPath(ctx, smPath)
+				secretRef = smPath
+			} else {
+				smName := b.gcpSecretName(s.Key, s.Scope, s.ScopeID)
+				value, err = b.accessLatestVersion(ctx, smName)
+				secretRef = fmt.Sprintf("projects/%s/secrets/%s", b.projectID, smName)
+			}
 			if err != nil {
 				continue
 			}
@@ -366,7 +382,7 @@ func (b *GCPBackend) Resolve(ctx context.Context, userID, projectID, brokerID st
 					ScopeID:       s.ScopeID,
 					Description:   s.Description,
 					InjectionMode: s.InjectionMode,
-					SecretRef:     fmt.Sprintf("projects/%s/secrets/%s", b.projectID, smName),
+					SecretRef:     secretRef,
 					AllowProgeny:  s.AllowProgeny,
 					Version:       s.Version,
 					Created:       s.Created,

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -39,7 +39,7 @@ const (
 // Scope constants define the visibility of a secret.
 const (
 	ScopeUser          = "user"
-	ScopeProject       = "grove"
+	ScopeProject       = "project"
 	ScopeRuntimeBroker = "runtime_broker"
 )
 


### PR DESCRIPTION
## Summary

- **Fixes secret injection failure on migrated hubs** after the grove→project rename
- `secret.ScopeProject` was still `"grove"` while `store.ScopeProject` was renamed to `"project"`, causing GCP SM secret name mismatches during `Resolve()`
- `Resolve()` now uses the stored `SecretRef` (canonical GCP SM path) instead of recomputing the name, matching the resilient pattern already used by `Get()`

## Root Cause

The V50 DB migration correctly updated the `secrets.scope` column from `"grove"` to `"project"`, but GCP SM secret IDs still contain `"grove"` (e.g., `scion-grove-<hash>-<name>`). `Resolve()` recomputed the GCP SM name using the new scope value `"project"`, producing `scion-project-<hash>-<name>` — a non-existent secret. Lookups failed silently (`continue` on error).

## Changes

1. `pkg/secret/secret.go`: Change `ScopeProject` from `"grove"` to `"project"` to align with `store.ScopeProject`
2. `pkg/secret/gcpbackend.go`: Update `Resolve()` (both main scope loop and progeny resolution) to prefer stored `SecretRef` over recomputed GCP SM names

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/secret/` — all tests pass
- [ ] Verify on a migrated hub that project-scoped "always" secrets are injected into agent environments
- [ ] Verify that newly created project-scoped secrets use scope `"project"` in both DB and GCP SM