### PR TITLE
fix: drop version field from message delivery payload

### DIFF
--- a/.design/project-log/2026-05-12-pr55-review-feedback.md
+++ b/.design/project-log/2026-05-12-pr55-review-feedback.md
@@ -1,0 +1,20 @@
+# PR #55 Review Feedback Fix
+
+**Date:** 2026-05-12
+**Branch:** scion/fix-issue-45
+**PR:** #55
+
+## Changes
+
+Addressed three code review items on PR #55 (version field removal from delivery payload):
+
+1. **Field alignment** — Restored tab padding on the `Timestamp` field in both the `deliveryMessage` struct definition and the struct literal in `FormatForDelivery()`. When `Version` was removed, `Timestamp` lost its alignment with the other fields.
+
+2. **Doc-comment update** — Updated both doc-comments (on the struct and on `FormatForDelivery`) to mention that "version" is also stripped at delivery time, not just "recipient".
+
+3. **Negative test assertion** — Added `strings.Contains(result, "version")` check in `TestFormatForDelivery_Structured`, matching the existing pattern for the "recipient" assertion.
+
+## Verification
+
+- `go build ./...` — passed
+- `go test ./pkg/messages/ -v` — all 14 tests passed

--- a/pkg/messages/format.go
+++ b/pkg/messages/format.go
@@ -27,8 +27,7 @@ const (
 // deliveryMessage is the subset of StructuredMessage fields delivered to the agent.
 // The recipient field is stripped to save tokens.
 type deliveryMessage struct {
-	Version     int      `json:"version"`
-	Timestamp   string   `json:"timestamp"`
+	Timestamp string `json:"timestamp"`
 	Sender      string   `json:"sender"`
 	Msg         string   `json:"msg"`
 	Type        string   `json:"type"`
@@ -46,8 +45,7 @@ func FormatForDelivery(msg *StructuredMessage) string {
 	}
 
 	dm := deliveryMessage{
-		Version:     msg.Version,
-		Timestamp:   msg.Timestamp,
+		Timestamp: msg.Timestamp,
 		Sender:      msg.Sender,
 		Msg:         msg.Msg,
 		Type:        msg.Type,

--- a/pkg/messages/format.go
+++ b/pkg/messages/format.go
@@ -25,9 +25,9 @@ const (
 )
 
 // deliveryMessage is the subset of StructuredMessage fields delivered to the agent.
-// The recipient field is stripped to save tokens.
+// The recipient and version fields are stripped to save tokens.
 type deliveryMessage struct {
-	Timestamp string `json:"timestamp"`
+	Timestamp   string   `json:"timestamp"`
 	Sender      string   `json:"sender"`
 	Msg         string   `json:"msg"`
 	Type        string   `json:"type"`
@@ -38,14 +38,14 @@ type deliveryMessage struct {
 
 // FormatForDelivery formats a structured message for delivery to an agent via tmux.
 // If the message has plain=true, only the raw msg text is returned.
-// The recipient field is stripped before delivery.
+// The recipient and version fields are stripped before delivery.
 func FormatForDelivery(msg *StructuredMessage) string {
 	if msg.Plain || msg.Raw {
 		return msg.Msg
 	}
 
 	dm := deliveryMessage{
-		Timestamp: msg.Timestamp,
+		Timestamp:   msg.Timestamp,
 		Sender:      msg.Sender,
 		Msg:         msg.Msg,
 		Type:        msg.Type,

--- a/pkg/messages/format_test.go
+++ b/pkg/messages/format_test.go
@@ -73,9 +73,12 @@ func TestFormatForDelivery_Structured(t *testing.T) {
 		t.Error("missing urgent in output")
 	}
 
-	// Should NOT contain recipient (stripped)
+	// Should NOT contain recipient or version (stripped)
 	if strings.Contains(result, `"recipient"`) {
 		t.Error("recipient should be stripped from delivery")
+	}
+	if strings.Contains(result, `"version"`) {
+		t.Error("version should be stripped from delivery")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove `Version` field from the `deliveryMessage` struct in `pkg/messages/format.go` so it is no longer included in messages sent to agents via tmux
- The `Version` field remains in `StructuredMessage` (data model) — only the delivery payload is affected
- Saves agent context window tokens since agents do not use the version field

Fixes #45

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/messages/...` passes