### PR TITLE
fix: only match help command when it is the sole argument

### DIFF
--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -144,8 +144,11 @@ func (r *CommandRouter) handleCommand(ctx context.Context, event *ChatEvent) (*E
 
 	switch sub {
 	case "help":
-		r.log.Info("scion command (help)", "space", event.SpaceID, "user", event.UserID)
-		return r.cmdScionHelp(ctx, event)
+		if len(parts) == 1 {
+			r.log.Info("scion command (help)", "space", event.SpaceID, "user", event.UserID)
+			return r.cmdScionHelp(ctx, event)
+		}
+		return r.cmdMessage(ctx, event, parts)
 	case "message", "msg":
 		r.log.Info("scion command (message)", "args", strings.Join(parts[1:], " "), "space", event.SpaceID, "user", event.UserID)
 		return r.cmdMessage(ctx, event, parts[1:])
@@ -204,7 +207,12 @@ func (r *CommandRouter) handleAdminCommand(ctx context.Context, event *ChatEvent
 	case "set-default":
 		resp, err = r.cmdSetDefault(ctx, event, args)
 	case "help":
-		resp, err = r.cmdAdminHelp(ctx, event)
+		if len(args) == 0 {
+			resp, err = r.cmdAdminHelp(ctx, event)
+		} else {
+			r.log.Warn("unknown admin command", "subcommand", strings.Join(parts, " "))
+			resp = textResponse(event, fmt.Sprintf("Unknown command: `%s`. Use `/scionAdmin help` for available commands.", strings.Join(parts, " ")))
+		}
 	default:
 		r.log.Warn("unknown admin command", "subcommand", subcommand)
 		resp = textResponse(event, fmt.Sprintf("Unknown command: `%s`. Use `/scionAdmin help` for available commands.", subcommand))

--- a/extras/scion-chat-app/internal/chatapp/commands_test.go
+++ b/extras/scion-chat-app/internal/chatapp/commands_test.go
@@ -68,6 +68,18 @@ func TestHandleEvent_CommandRouting(t *testing.T) {
 			args:        "bogus",
 			wantContain: "Unknown command",
 		},
+		{
+			name:        "scion help with extra args falls through to messaging",
+			command:     "scion",
+			args:        "help me understand X",
+			wantContain: "not linked",
+		},
+		{
+			name:        "scionAdmin help with extra args returns unknown command",
+			command:     "scionAdmin",
+			args:        "help something",
+			wantContain: "Unknown command",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- `/scion help` was matching eagerly — typing `/scion help me understand X` showed help text instead of sending a message
- Fixed `handleCommand()` to only trigger help when `help` is the sole argument; otherwise falls through to message sending
- Applied the same fix to `handleAdminCommand()`

Fixes #27

## Test plan
- [x] Verified build (pre-existing failures unrelated to this change)
- [ ] Test `/scion help` still shows help text
- [ ] Test `/scion help me understand X` sends a message instead of showing help
- [ ] Test `/scionAdmin help` still shows admin help
- [ ] Test `/scionAdmin help something` returns unknown command error