### PR TITLE
feat: add download as ZIP for shared directories

### DIFF
--- a/.design/project-log/2026-05-12-pr58-review-fixes.md
+++ b/.design/project-log/2026-05-12-pr58-review-fixes.md
@@ -1,0 +1,18 @@
+# PR #58 Review Feedback Fixes
+
+**Date:** 2026-05-12
+**PR:** #58 (feat: add download as ZIP for shared directories)
+**Branch:** scion/fix-issue-39
+
+## What changed
+
+Addressed two medium-severity review comments from Gemini Code Assist and scion-gteam:
+
+1. **Extracted `writeDirectoryToZip` helper** — The zip streaming logic in `handleProjectWorkspaceArchive` and `handleProjectSharedDirArchive` was nearly identical. Extracted it into a shared `writeDirectoryToZip(zw *zip.Writer, dirPath string) error` function to reduce duplication and improve maintainability.
+
+2. **Added `slog.WarnContext` on archive streaming errors** — Both archive handlers now log a warning when `WalkDir` fails mid-stream. Since HTTP headers are already sent at that point, the client receives a truncated ZIP with no way to report the error via HTTP status. Server-side logging ensures these failures are visible for debugging.
+
+## Verification
+
+- `go build ./...` — passes
+- `go test ./pkg/hub/...` — all tests pass

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -4135,7 +4135,9 @@ func (s *Server) handleProjectRoutes(w http.ResponseWriter, r *http.Request) {
 			if len(parts) > 1 {
 				rest = parts[1]
 			}
-			if strings.HasPrefix(rest, "files") {
+			if rest == "archive" {
+				s.handleProjectSharedDirArchive(w, r, projectID, name)
+			} else if strings.HasPrefix(rest, "files") {
 				filePath := strings.TrimPrefix(rest, "files")
 				filePath = strings.TrimPrefix(filePath, "/")
 				s.handleSharedDirFiles(w, r, projectID, name, filePath)

--- a/pkg/hub/project_workspace_handlers.go
+++ b/pkg/hub/project_workspace_handlers.go
@@ -555,6 +555,107 @@ func (s *Server) handleProjectWorkspaceArchive(w http.ResponseWriter, r *http.Re
 	}
 }
 
+// handleProjectSharedDirArchive creates a zip archive of a shared directory and serves it for download.
+func (s *Server) handleProjectSharedDirArchive(w http.ResponseWriter, r *http.Request, projectID, dirName string) {
+	ctx := r.Context()
+
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	project, err := s.store.GetProject(ctx, projectID)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Verify the shared dir is declared on this project
+	found := false
+	for _, d := range project.SharedDirs {
+		if d.Name == dirName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		NotFound(w, "Shared directory")
+		return
+	}
+
+	resolution, resolveErr := s.resolveSharedDirPath(ctx, project, dirName)
+	if resolveErr != nil {
+		Conflict(w, resolveErr.Error())
+		return
+	}
+	sharedDirPath := resolution.Path
+
+	if _, err := os.Stat(sharedDirPath); err != nil {
+		if os.IsNotExist(err) {
+			NotFound(w, "Shared directory")
+			return
+		}
+		InternalError(w)
+		return
+	}
+
+	archiveName := project.Slug + "-" + dirName + ".zip"
+	w.Header().Set("Content-Type", "application/zip")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, archiveName))
+
+	zw := zip.NewWriter(w)
+	defer zw.Close()
+
+	err = filepath.WalkDir(sharedDirPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(sharedDirPath, path)
+		if err != nil {
+			return err
+		}
+
+		if relPath == "." {
+			return nil
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+		header.Name = relPath
+		header.Method = zip.Deflate
+
+		writer, err := zw.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		_, err = io.Copy(writer, f)
+		return err
+	})
+
+	if err != nil {
+		return
+	}
+}
+
 // ProjectWorkspaceWriteRequest is the request body for writing file content.
 type ProjectWorkspaceWriteRequest struct {
 	Content         string `json:"content"`

--- a/pkg/hub/project_workspace_handlers.go
+++ b/pkg/hub/project_workspace_handlers.go
@@ -461,52 +461,15 @@ func (s *Server) handleProjectWorkspaceDownload(w http.ResponseWriter, r *http.R
 	io.Copy(w, f)
 }
 
-// handleProjectWorkspaceArchive creates a zip archive of the entire workspace and serves it for download.
-func (s *Server) handleProjectWorkspaceArchive(w http.ResponseWriter, r *http.Request, projectID string) {
-	ctx := r.Context()
-
-	if r.Method != http.MethodGet {
-		MethodNotAllowed(w)
-		return
-	}
-
-	// Look up the project
-	project, err := s.store.GetProject(ctx, projectID)
-	if err != nil {
-		writeErrorFromErr(w, err, "")
-		return
-	}
-
-	// Resolve workspace path — supports hub-native, shared-workspace, and linked projects
-	workspacePath, err := s.resolveProjectWebDAVPath(ctx, project)
-	if err != nil {
-		Conflict(w, err.Error())
-		return
-	}
-
-	// Check workspace directory exists
-	if _, err := os.Stat(workspacePath); err != nil {
-		if os.IsNotExist(err) {
-			NotFound(w, "Workspace")
-			return
-		}
-		InternalError(w)
-		return
-	}
-
-	archiveName := project.Slug + "-workspace.zip"
-	w.Header().Set("Content-Type", "application/zip")
-	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, archiveName))
-
-	zw := zip.NewWriter(w)
-	defer zw.Close()
-
-	err = filepath.WalkDir(workspacePath, func(path string, d fs.DirEntry, err error) error {
+// writeDirectoryToZip walks dirPath and writes all files into the given zip.Writer,
+// preserving directory structure relative to dirPath.
+func writeDirectoryToZip(zw *zip.Writer, dirPath string) error {
+	return filepath.WalkDir(dirPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		relPath, err := filepath.Rel(workspacePath, path)
+		relPath, err := filepath.Rel(dirPath, path)
 		if err != nil {
 			return err
 		}
@@ -547,10 +510,52 @@ func (s *Server) handleProjectWorkspaceArchive(w http.ResponseWriter, r *http.Re
 		_, err = io.Copy(writer, f)
 		return err
 	})
+}
 
+// handleProjectWorkspaceArchive creates a zip archive of the entire workspace and serves it for download.
+func (s *Server) handleProjectWorkspaceArchive(w http.ResponseWriter, r *http.Request, projectID string) {
+	ctx := r.Context()
+
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	// Look up the project
+	project, err := s.store.GetProject(ctx, projectID)
 	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Resolve workspace path — supports hub-native, shared-workspace, and linked projects
+	workspacePath, err := s.resolveProjectWebDAVPath(ctx, project)
+	if err != nil {
+		Conflict(w, err.Error())
+		return
+	}
+
+	// Check workspace directory exists
+	if _, err := os.Stat(workspacePath); err != nil {
+		if os.IsNotExist(err) {
+			NotFound(w, "Workspace")
+			return
+		}
+		InternalError(w)
+		return
+	}
+
+	archiveName := project.Slug + "-workspace.zip"
+	w.Header().Set("Content-Type", "application/zip")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, archiveName))
+
+	zw := zip.NewWriter(w)
+	defer zw.Close()
+
+	if err := writeDirectoryToZip(zw, workspacePath); err != nil {
 		// At this point we've already started writing, so we can't send an error response.
 		// The zip will be truncated/corrupt, which the client will notice.
+		slog.WarnContext(ctx, "failed to complete workspace archive", "project_id", projectID, "error", err)
 		return
 	}
 }
@@ -606,52 +611,8 @@ func (s *Server) handleProjectSharedDirArchive(w http.ResponseWriter, r *http.Re
 	zw := zip.NewWriter(w)
 	defer zw.Close()
 
-	err = filepath.WalkDir(sharedDirPath, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		relPath, err := filepath.Rel(sharedDirPath, path)
-		if err != nil {
-			return err
-		}
-
-		if relPath == "." {
-			return nil
-		}
-
-		if d.IsDir() {
-			return nil
-		}
-
-		info, err := d.Info()
-		if err != nil {
-			return err
-		}
-
-		header, err := zip.FileInfoHeader(info)
-		if err != nil {
-			return err
-		}
-		header.Name = relPath
-		header.Method = zip.Deflate
-
-		writer, err := zw.CreateHeader(header)
-		if err != nil {
-			return err
-		}
-
-		f, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-
-		_, err = io.Copy(writer, f)
-		return err
-	})
-
-	if err != nil {
+	if err := writeDirectoryToZip(zw, sharedDirPath); err != nil {
+		slog.WarnContext(ctx, "failed to complete shared dir archive", "project_id", projectID, "dir", dirName, "error", err)
 		return
 	}
 }

--- a/web/src/components/pages/project-detail.ts
+++ b/web/src/components/pages/project-detail.ts
@@ -1290,7 +1290,7 @@ export class ScionPageProjectDetail extends LitElement {
                           data-tab=${tab.key}
                           .dataSource=${this.getTabDataSource(tab.key)}
                           ?editable=${isEditable}
-                          ?showArchive=${tab.key === 'workspace'}
+                          ?showArchive=${true}
                           @file-edit-requested=${this.handleFileEditRequested}
                           @file-preview-requested=${this.handleFilePreviewRequested}
                           @file-create-requested=${this.handleFileCreateRequested}

--- a/web/src/components/shared/file-browser.ts
+++ b/web/src/components/shared/file-browser.ts
@@ -174,8 +174,12 @@ export class WorkspaceFileBrowserDataSource implements FileBrowserDataSource {
  */
 export class SharedDirFileBrowserDataSource implements FileBrowserDataSource {
   private readonly basePath: string;
+  private readonly projectId: string;
+  private readonly dirName: string;
 
   constructor(projectId: string, dirName: string) {
+    this.projectId = projectId;
+    this.dirName = dirName;
     this.basePath = `/api/v1/projects/${projectId}/shared-dirs/${encodeURIComponent(dirName)}/files`;
   }
 
@@ -232,7 +236,7 @@ export class SharedDirFileBrowserDataSource implements FileBrowserDataSource {
   }
 
   getArchiveUrl(): string | null {
-    return null;
+    return `/api/v1/projects/${this.projectId}/shared-dirs/${encodeURIComponent(this.dirName)}/archive`;
   }
 }
 


### PR DESCRIPTION
## Summary
- Added `GET /api/v1/projects/{id}/shared-dirs/{name}/archive` endpoint that streams a zip archive of a shared directory, reusing the same zip-streaming pattern as the existing workspace archive handler
- Updated `SharedDirFileBrowserDataSource.getArchiveUrl()` to return the new endpoint URL instead of `null`
- Enabled the "Download Zip" button on all file browser tabs (not just the workspace tab)

Closes #39

## Test plan
- [ ] Verify workspace archive download still works on the workspace tab
- [ ] Create a project with a shared directory containing files
- [ ] Verify the "Download Zip" button appears on the shared directory tab
- [ ] Click "Download Zip" and verify a valid zip file is downloaded containing the shared directory contents
- [ ] Verify the archive endpoint returns 404 for non-existent shared directories
- [ ] Verify the archive endpoint returns 405 for non-GET methods