### PR TITLE
feat: add set[] composite recipient for multi-target messages

### DIFF
--- a/cmd/message.go
+++ b/cmd/message.go
@@ -606,6 +606,12 @@ func sendSetMessageViaHub(hubCtx *HubContext, recipients []messages.SetRecipient
 		fmt.Printf("Set delivery complete: %d/%d delivered.\n", delivered, len(recipients))
 	}
 
+	if delivered == 0 {
+		return fmt.Errorf("set delivery failed: 0/%d recipients received the message", len(recipients))
+	}
+	if delivered < len(recipients) {
+		return fmt.Errorf("set delivery partially failed: %d/%d delivered", delivered, len(recipients))
+	}
 	return nil
 }
 

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -52,20 +52,26 @@ Recipients:
   <agent-name>       Send to an agent (default, same as agent:<name>)
   agent:<name>       Send to an agent explicitly
   user:<name>        Send to a user's inbox (Hub mode only)
+  set[a,b,...]       Send to multiple recipients (Hub mode only)
 
 If --broadcast is used, the recipient can be omitted and the message will be sent to all running agents.
 
 Examples:
   scion message my-agent "Please review the PR"
-  scion message user:alice "I need clarification on the auth module"`,
+  scion message user:alice "I need clarification on the auth module"
+  scion message "set[agent:reviewer,user:alice,deploy-bot]" "Release v2 is ready"`,
 	Args:              cobra.MinimumNArgs(1),
 	ValidArgsFunction: getAgentNames,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var agentName string
 		var userRecipient string
+		var setRecipients []messages.SetRecipient
 		var message string
 
 		if msgBroadcast || msgAll {
+			if len(args) > 0 && messages.IsSetRecipient(args[0]) {
+				return fmt.Errorf("set[] recipients cannot be combined with --broadcast or --all")
+			}
 			message = strings.Join(args, " ")
 		} else {
 			if len(args) < 2 {
@@ -74,7 +80,13 @@ Examples:
 			recipient := args[0]
 			message = strings.Join(args[1:], " ")
 
-			if strings.HasPrefix(recipient, "user:") {
+			if messages.IsSetRecipient(recipient) {
+				parsed, err := messages.ParseSetRecipient(recipient)
+				if err != nil {
+					return fmt.Errorf("invalid set recipient: %w", err)
+				}
+				setRecipients = parsed
+			} else if strings.HasPrefix(recipient, "user:") {
 				userRecipient = recipient
 			} else if strings.Contains(recipient, "@") && !strings.HasPrefix(recipient, "agent:") {
 				// Bare email address — treat as user recipient
@@ -127,6 +139,22 @@ Examples:
 			}
 		}
 
+		// Validate set[] recipient restrictions
+		if len(setRecipients) > 0 {
+			if msgBroadcast || msgAll {
+				return fmt.Errorf("set[] recipients cannot be combined with --broadcast or --all")
+			}
+			if msgRaw {
+				return fmt.Errorf("--raw cannot be used with set[] recipients")
+			}
+			if msgIn != "" || msgAt != "" {
+				return fmt.Errorf("--in/--at cannot be used with set[] recipients")
+			}
+			if msgNotify {
+				return fmt.Errorf("--notify cannot be used with set[] recipients")
+			}
+		}
+
 		// Validate attachments
 		if len(msgAttach) > messages.MaxAttachments {
 			return fmt.Errorf("too many attachments: %d (max %d)", len(msgAttach), messages.MaxAttachments)
@@ -135,7 +163,10 @@ Examples:
 		// Check if Hub should be used
 		var hubCtx *HubContext
 		var err error
-		if userRecipient != "" {
+		if len(setRecipients) > 0 {
+			// Set recipients: skip sync (multiple recipients, no single agent)
+			hubCtx, err = CheckHubAvailabilityWithOptions(projectPath, true)
+		} else if userRecipient != "" {
 			// User recipient: skip sync (no agent involved)
 			hubCtx, err = CheckHubAvailabilityWithOptions(projectPath, true)
 		} else if msgAll {
@@ -150,6 +181,11 @@ Examples:
 		}
 		if err != nil {
 			return err
+		}
+
+		// Set recipients require Hub mode
+		if len(setRecipients) > 0 && hubCtx == nil {
+			return fmt.Errorf("set[] recipients require Hub mode (use 'scion hub enable' first)")
 		}
 
 		// User recipients require Hub mode
@@ -168,6 +204,11 @@ Examples:
 		// --notify requires Hub mode
 		if msgNotify && hubCtx == nil {
 			return fmt.Errorf("--notify requires Hub mode (use 'scion hub enable' first)")
+		}
+
+		// Set-targeted messages: fan out to each recipient
+		if len(setRecipients) > 0 {
+			return sendSetMessageViaHub(hubCtx, setRecipients, message, msgInterrupt)
 		}
 
 		// User-targeted messages: route to outbound-message endpoint
@@ -464,6 +505,107 @@ func sendOutboundMessageViaHub(hubCtx *HubContext, userRecipient string, message
 	if !isJSONOutput() {
 		fmt.Printf("Message sent to %s via Hub.\n", userRecipient)
 	}
+	return nil
+}
+
+func sendSetMessageViaHub(hubCtx *HubContext, recipients []messages.SetRecipient, message string, interrupt bool) error {
+	if !isJSONOutput() {
+		PrintUsingHub(hubCtx.Endpoint)
+	}
+
+	sender := resolveSenderIdentity(hubCtx)
+	groupID := api.NewUUID()
+
+	projectID, err := GetProjectID(hubCtx)
+	if err != nil {
+		return wrapHubError(err)
+	}
+	agentSvc := hubCtx.Client.ProjectAgents(projectID)
+
+	if !isJSONOutput() {
+		fmt.Printf("Sending message to %d recipients...\n", len(recipients))
+	}
+
+	type recipientResult struct {
+		Recipient string `json:"recipient"`
+		Status    string `json:"status"`
+		Error     string `json:"error,omitempty"`
+	}
+
+	results := make([]recipientResult, len(recipients))
+	var wg sync.WaitGroup
+
+	for i, r := range recipients {
+		wg.Add(1)
+		go func(idx int, recip messages.SetRecipient) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			recipStr := recip.String()
+			switch recip.Kind {
+			case messages.RecipientAgent:
+				slug := api.Slugify(recip.Name)
+				msg := buildStructuredMessage(sender, "agent:"+slug, message)
+				msg.Metadata = map[string]string{"group_id": groupID}
+				if err := agentSvc.SendStructuredMessage(ctx, slug, msg, interrupt, false); err != nil {
+					results[idx] = recipientResult{Recipient: recipStr, Status: "failed", Error: err.Error()}
+					if !isJSONOutput() {
+						fmt.Printf("  Failed: %s: %s\n", recipStr, err)
+					}
+					return
+				}
+				results[idx] = recipientResult{Recipient: recipStr, Status: "delivered"}
+				if !isJSONOutput() {
+					fmt.Printf("  Delivered: %s\n", recipStr)
+				}
+
+			case messages.RecipientUser:
+				senderAgent := os.Getenv("SCION_AGENT_NAME")
+				if senderAgent == "" {
+					results[idx] = recipientResult{Recipient: recipStr, Status: "failed", Error: "sending to users requires agent context (SCION_AGENT_NAME not set)"}
+					if !isJSONOutput() {
+						fmt.Printf("  Failed: %s: agent context required\n", recipStr)
+					}
+					return
+				}
+				userRecip := recipStr
+				if !strings.HasPrefix(userRecip, "user:") {
+					userRecip = "user:" + recip.Name
+				}
+				outMsg := &hubclient.OutboundMessageRequest{
+					Recipient: userRecip,
+					Msg:       message,
+					Type:      "instruction",
+					Urgent:    interrupt,
+				}
+				if err := agentSvc.SendOutboundMessage(ctx, senderAgent, outMsg); err != nil {
+					results[idx] = recipientResult{Recipient: recipStr, Status: "failed", Error: err.Error()}
+					if !isJSONOutput() {
+						fmt.Printf("  Failed: %s: %s\n", recipStr, err)
+					}
+					return
+				}
+				results[idx] = recipientResult{Recipient: recipStr, Status: "delivered"}
+				if !isJSONOutput() {
+					fmt.Printf("  Delivered: %s\n", recipStr)
+				}
+			}
+		}(i, r)
+	}
+	wg.Wait()
+
+	delivered := 0
+	for _, r := range results {
+		if r.Status == "delivered" {
+			delivered++
+		}
+	}
+
+	if !isJSONOutput() {
+		fmt.Printf("Set delivery complete: %d/%d delivered.\n", delivered, len(recipients))
+	}
+
 	return nil
 }
 

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -69,22 +69,26 @@ func newMessageMockHubServer(t *testing.T, projectID string, runningAgents []hub
 		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
 			json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 
-		case r.Method == http.MethodGet && (r.URL.Path == "/api/v1/groves/"+projectID+"/agents" || r.URL.Path == "/api/v1/agents"):
+		case r.Method == http.MethodGet && (r.URL.Path == "/api/v1/groves/"+projectID+"/agents" || r.URL.Path == "/api/v1/projects/"+projectID+"/agents" || r.URL.Path == "/api/v1/agents"):
 			// List agents endpoint
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"agents": runningAgents,
 			})
 
 		case r.Method == http.MethodPost:
-			// Extract agent name from path: /api/v1/groves/<projectID>/agents/<name>/message
+			// Extract agent name from path: /api/v1/projects/<projectID>/agents/<name>/message
+			// or /api/v1/groves/<projectID>/agents/<name>/message (legacy)
 			// or /api/v1/agents/<name>/message
 			var agentName string
+			projectPrefix := "/api/v1/projects/" + projectID + "/agents/"
 			grovePrefix := "/api/v1/groves/" + projectID + "/agents/"
 			globalPrefix := "/api/v1/agents/"
 			path := r.URL.Path
-			if len(path) > len(grovePrefix) && path[:len(grovePrefix)] == grovePrefix {
+			if len(path) > len(projectPrefix) && path[:len(projectPrefix)] == projectPrefix {
+				rest := path[len(projectPrefix):]
+				agentName = rest[:len(rest)-len("/message")]
+			} else if len(path) > len(grovePrefix) && path[:len(grovePrefix)] == grovePrefix {
 				rest := path[len(grovePrefix):]
-				// rest is "<name>/message"
 				agentName = rest[:len(rest)-len("/message")]
 			} else if len(path) > len(globalPrefix) && path[:len(globalPrefix)] == globalPrefix {
 				rest := path[len(globalPrefix):]
@@ -400,9 +404,17 @@ func TestSendMessageViaHub_BroadcastPartialFailure(t *testing.T) {
 		case r.Method == http.MethodGet:
 			json.NewEncoder(w).Encode(map[string]interface{}{"agents": agents})
 		case r.Method == http.MethodPost:
-			prefix := "/api/v1/groves/" + projectID + "/agents/"
-			rest := r.URL.Path[len(prefix):]
-			agentName := rest[:len(rest)-len("/message")]
+			projectPrefix := "/api/v1/projects/" + projectID + "/agents/"
+			grovePrefix := "/api/v1/groves/" + projectID + "/agents/"
+			var agentName string
+			path := r.URL.Path
+			if len(path) > len(projectPrefix) && path[:len(projectPrefix)] == projectPrefix {
+				rest := path[len(projectPrefix):]
+				agentName = rest[:len(rest)-len("/message")]
+			} else if len(path) > len(grovePrefix) && path[:len(grovePrefix)] == grovePrefix {
+				rest := path[len(grovePrefix):]
+				agentName = rest[:len(rest)-len("/message")]
+			}
 
 			if agentName == "bad-agent" {
 				w.WriteHeader(http.StatusInternalServerError)
@@ -713,6 +725,148 @@ func TestUserRecipientFlagValidation(t *testing.T) {
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.wantErr)
 		})
+	}
+}
+
+func TestSetRecipientFlagValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		raw       bool
+		broadcast bool
+		all       bool
+		in        string
+		notify    bool
+		wantErr   string
+	}{
+		{
+			name:    "set with raw not allowed",
+			args:    []string{"set[agent:a,agent:b]", "hello"},
+			raw:     true,
+			wantErr: "--raw cannot be used with set[] recipients",
+		},
+		{
+			name:      "set with broadcast not allowed",
+			args:      []string{"set[agent:a,agent:b]", "hello"},
+			broadcast: true,
+			wantErr:   "set[] recipients cannot be combined with --broadcast or --all",
+		},
+		{
+			name:    "set with all not allowed",
+			args:    []string{"set[agent:a,agent:b]", "hello"},
+			all:     true,
+			wantErr: "set[] recipients cannot be combined with --broadcast or --all",
+		},
+		{
+			name:    "set with in not allowed",
+			args:    []string{"set[agent:a,agent:b]", "hello"},
+			in:      "30m",
+			wantErr: "--in/--at cannot be used with set[] recipients",
+		},
+		{
+			name:    "set with notify not allowed",
+			args:    []string{"set[agent:a,agent:b]", "hello"},
+			notify:  true,
+			wantErr: "--notify cannot be used with set[] recipients",
+		},
+		{
+			name:    "invalid set",
+			args:    []string{"set[agent:a]", "hello"},
+			wantErr: "invalid set recipient",
+		},
+		{
+			name:    "empty set",
+			args:    []string{"set[]", "hello"},
+			wantErr: "invalid set recipient",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			origRaw := msgRaw
+			origBroadcast, origAll := msgBroadcast, msgAll
+			origIn := msgIn
+			origNotify := msgNotify
+			defer func() {
+				msgRaw = origRaw
+				msgBroadcast = origBroadcast
+				msgAll = origAll
+				msgIn = origIn
+				msgNotify = origNotify
+			}()
+
+			msgRaw = tc.raw
+			msgBroadcast = tc.broadcast
+			msgAll = tc.all
+			msgIn = tc.in
+			msgNotify = tc.notify
+
+			err := messageCmd.RunE(messageCmd, tc.args)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestSendSetMessageViaHub(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	projectID := "grove-msg-set"
+	agents := []hubclient.Agent{
+		{Name: "agent-a", Status: "running"},
+		{Name: "agent-b", Status: "running"},
+	}
+	server, sent := newMessageMockHubServer(t, projectID, agents)
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:   client,
+		Endpoint: server.URL,
+		ProjectID:  projectID,
+	}
+
+	recipients := []messages.SetRecipient{
+		{Kind: messages.RecipientAgent, Name: "agent-a"},
+		{Kind: messages.RecipientAgent, Name: "agent-b"},
+	}
+
+	err = sendSetMessageViaHub(hubCtx, recipients, "set hello", false)
+	require.NoError(t, err)
+
+	require.Len(t, *sent, 2)
+	names := make([]string, len(*sent))
+	for i, s := range *sent {
+		names[i] = s.AgentName
+		assert.Equal(t, "set hello", s.Message)
+		require.NotNil(t, s.StructuredMsg)
+		assert.NotEmpty(t, s.StructuredMsg.Metadata["group_id"])
+	}
+	assert.ElementsMatch(t, []string{"agent-a", "agent-b"}, names)
+}
+
+func TestSendSetMessageViaHub_RequiresHub(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	// set[] without Hub should fail at the RunE level, not get to sendSetMessageViaHub
+	origBroadcast, origAll := msgBroadcast, msgAll
+	defer func() { msgBroadcast = origBroadcast; msgAll = origAll }()
+	msgBroadcast = false
+	msgAll = false
+
+	err := messageCmd.RunE(messageCmd, []string{"set[agent:a,agent:b]", "hello"})
+	// This should try to check Hub availability and fail (no hub configured in test)
+	// The exact error depends on CheckHubAvailabilityWithOptions, but it should not panic
+	if err != nil {
+		// Expected: either Hub not available or set[] recipients require Hub mode
+		assert.True(t,
+			assert.ObjectsAreEqual("set[] recipients require Hub mode (use 'scion hub enable' first)", err.Error()) ||
+				err != nil, // any error is acceptable since we can't set up Hub in this test
+		)
 	}
 }
 

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -859,15 +859,10 @@ func TestSendSetMessageViaHub_RequiresHub(t *testing.T) {
 	msgAll = false
 
 	err := messageCmd.RunE(messageCmd, []string{"set[agent:a,agent:b]", "hello"})
-	// This should try to check Hub availability and fail (no hub configured in test)
-	// The exact error depends on CheckHubAvailabilityWithOptions, but it should not panic
-	if err != nil {
-		// Expected: either Hub not available or set[] recipients require Hub mode
-		assert.True(t,
-			assert.ObjectsAreEqual("set[] recipients require Hub mode (use 'scion hub enable' first)", err.Error()) ||
-				err != nil, // any error is acceptable since we can't set up Hub in this test
-		)
-	}
+	// When Hub is not configured, this should fail with "set[] recipients require Hub mode".
+	// When Hub is configured but test agents don't exist, delivery fails.
+	// Either way, an error must be returned — never silent nil.
+	require.Error(t, err)
 }
 
 func TestNotifyFlagValidation(t *testing.T) {

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -2275,6 +2275,12 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		return
 	}
 
+	// Detect set[] recipient for multi-target fan-out.
+	if structuredMsg != nil && messages.IsSetRecipient(structuredMsg.Recipient) {
+		s.handleSetMessage(w, r, id, structuredMsg, plainMessage, req.Interrupt)
+		return
+	}
+
 	agent, err := s.store.GetAgent(ctx, id)
 	if err != nil {
 		writeErrorFromErr(w, err, "")
@@ -2358,6 +2364,174 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+// SetMessageRecipientResult represents the delivery status for one recipient in a set[] delivery.
+type SetMessageRecipientResult struct {
+	Recipient string `json:"recipient"`
+	Status    string `json:"status"`
+	Error     string `json:"error,omitempty"`
+}
+
+// SetMessageResponse is the JSON response for a set[] message delivery.
+type SetMessageResponse struct {
+	GroupID    string                      `json:"group_id"`
+	Delivered int                         `json:"delivered"`
+	Failed    int                         `json:"failed"`
+	Results   []SetMessageRecipientResult `json:"results"`
+}
+
+// handleSetMessage fans out a structured message to multiple recipients parsed from set[].
+func (s *Server) handleSetMessage(w http.ResponseWriter, r *http.Request, anchorID string, msg *messages.StructuredMessage, plainMessage string, interrupt bool) {
+	ctx := r.Context()
+
+	recipients, err := messages.ParseSetRecipient(msg.Recipient)
+	if err != nil {
+		ValidationError(w, "invalid set[] recipient: "+err.Error(), nil)
+		return
+	}
+
+	// Resolve the anchor agent for project context.
+	anchorAgent, err := s.store.GetAgent(ctx, anchorID)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+	projectID := anchorAgent.ProjectID
+
+	groupID := api.NewUUID()
+	results := make([]SetMessageRecipientResult, len(recipients))
+	delivered := 0
+
+	dispatcher := s.GetDispatcher()
+
+	for i, recip := range recipients {
+		recipStr := recip.String()
+
+		switch recip.Kind {
+		case messages.RecipientAgent:
+			agent, err := s.store.GetAgentBySlug(ctx, projectID, api.Slugify(recip.Name))
+			if err != nil {
+				results[i] = SetMessageRecipientResult{Recipient: recipStr, Status: "failed", Error: "agent not found: " + recip.Name}
+				continue
+			}
+
+			agentMsg := *msg
+			agentMsg.Recipient = "agent:" + agent.Slug
+			agentMsg.RecipientID = agent.ID
+
+			storeMsg := &store.Message{
+				ID:          api.NewUUID(),
+				ProjectID:  projectID,
+				Sender:     agentMsg.Sender,
+				SenderID:   agentMsg.SenderID,
+				Recipient:  agentMsg.Recipient,
+				RecipientID: agentMsg.RecipientID,
+				Msg:        agentMsg.Msg,
+				Type:       agentMsg.Type,
+				Urgent:     agentMsg.Urgent,
+				AgentID:    agent.ID,
+				GroupID:    groupID,
+				CreatedAt:  time.Now(),
+			}
+			if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
+				s.messageLog.Error("Failed to persist set message", "recipient", recipStr, "error", err)
+			}
+			s.events.PublishUserMessage(ctx, storeMsg)
+
+			if dispatcher != nil && agent.RuntimeBrokerID != "" {
+				if err := dispatcher.DispatchAgentMessage(ctx, agent, plainMessage, interrupt, &agentMsg); err != nil {
+					results[i] = SetMessageRecipientResult{Recipient: recipStr, Status: "failed", Error: err.Error()}
+					continue
+				}
+			} else if dispatcher == nil {
+				results[i] = SetMessageRecipientResult{Recipient: recipStr, Status: "failed", Error: "dispatcher not available"}
+				continue
+			} else {
+				results[i] = SetMessageRecipientResult{Recipient: recipStr, Status: "failed", Error: "agent has no runtime broker"}
+				continue
+			}
+
+			results[i] = SetMessageRecipientResult{Recipient: recipStr, Status: "delivered"}
+			delivered++
+
+		case messages.RecipientUser:
+			userRecip := "user:" + recip.Name
+			userID := ""
+
+			// Try to resolve user by email or display name.
+			identifier := recip.Name
+			if strings.Contains(identifier, "@") {
+				if u, err := s.store.GetUserByEmail(ctx, identifier); err == nil {
+					userID = u.ID
+					name := u.DisplayName
+					if name == "" {
+						name = u.Email
+					}
+					userRecip = "user:" + name
+				}
+			}
+			if userID == "" {
+				result, lookupErr := s.store.ListUsers(ctx, store.UserFilter{Search: identifier}, store.ListOptions{Limit: 1})
+				if lookupErr == nil && len(result.Items) == 1 {
+					u := result.Items[0]
+					userID = u.ID
+					name := u.DisplayName
+					if name == "" {
+						name = u.Email
+					}
+					userRecip = "user:" + name
+				}
+			}
+
+			if userID == "" {
+				results[i] = SetMessageRecipientResult{Recipient: recipStr, Status: "failed", Error: "user not found: " + recip.Name}
+				continue
+			}
+
+			userMsg := *msg
+			userMsg.Recipient = userRecip
+			userMsg.RecipientID = userID
+
+			storeMsg := &store.Message{
+				ID:          api.NewUUID(),
+				ProjectID:  projectID,
+				Sender:     userMsg.Sender,
+				SenderID:   userMsg.SenderID,
+				Recipient:  userMsg.Recipient,
+				RecipientID: userMsg.RecipientID,
+				Msg:        userMsg.Msg,
+				Type:       userMsg.Type,
+				Urgent:     userMsg.Urgent,
+				AgentID:    anchorAgent.ID,
+				GroupID:    groupID,
+				CreatedAt:  time.Now(),
+			}
+			if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
+				s.messageLog.Error("Failed to persist set message", "recipient", recipStr, "error", err)
+			}
+			s.events.PublishUserMessage(ctx, storeMsg)
+
+			results[i] = SetMessageRecipientResult{Recipient: recipStr, Status: "delivered"}
+			delivered++
+		}
+	}
+
+	s.logMessage("set message dispatched",
+		"project_id", projectID,
+		"group_id", groupID,
+		"total", len(recipients),
+		"delivered", delivered,
+		"failed", len(recipients)-delivered,
+	)
+
+	resp := SetMessageResponse{
+		GroupID:   groupID,
+		Delivered: delivered,
+		Failed:    len(recipients) - delivered,
+		Results:   results,
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // BroadcastMessageRequest is the request body for broadcasting a message via the broker.

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -2322,6 +2322,13 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 			AgentID:     agent.ID,
 			CreatedAt:   time.Now(),
 		}
+		// Propagate GroupID from metadata so CLI-originated set[] messages
+		// preserve correlation in the store.
+		if structuredMsg.Metadata != nil {
+			if gid, ok := structuredMsg.Metadata["group_id"]; ok {
+				storeMsg.GroupID = gid
+			}
+		}
 		if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
 			s.messageLog.Error("Failed to persist message", "error", err)
 		}

--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -244,6 +244,30 @@ func (p *MessageBrokerProxy) PublishUserMessage(ctx context.Context, projectID, 
 	return p.broker.Publish(ctx, topic, msg)
 }
 
+// PublishToSet fans out a message to a parsed set of recipients, delegating
+// to PublishMessage for agents and PublishUserMessage for users.
+func (p *MessageBrokerProxy) PublishToSet(ctx context.Context, projectID string, recipients []messages.SetRecipient, msg *messages.StructuredMessage) map[string]error {
+	errs := make(map[string]error, len(recipients))
+	for _, r := range recipients {
+		recipMsg := *msg
+		recipMsg.Recipient = r.String()
+
+		switch r.Kind {
+		case messages.RecipientAgent:
+			recipMsg.Recipient = "agent:" + r.Name
+			if err := p.PublishMessage(ctx, projectID, &recipMsg); err != nil {
+				errs[r.String()] = err
+			}
+		case messages.RecipientUser:
+			recipMsg.Recipient = "user:" + r.Name
+			if err := p.PublishUserMessage(ctx, projectID, r.Name, &recipMsg); err != nil {
+				errs[r.String()] = err
+			}
+		}
+	}
+	return errs
+}
+
 // EnsureProjectSubscriptions sets up broker subscriptions for all running agents
 // in the specified project. Called when a project becomes active or a broker reconnects.
 func (p *MessageBrokerProxy) EnsureProjectSubscriptions(ctx context.Context, projectID string) error {

--- a/pkg/hub/messagebroker_test.go
+++ b/pkg/hub/messagebroker_test.go
@@ -697,6 +697,60 @@ func TestMessageBrokerProxy_ProjectSubscriptionDedup(t *testing.T) {
 	}
 }
 
+func TestMessageBrokerProxy_PublishToSet(t *testing.T) {
+	s := newBrokerTestStore(t)
+	projectID := setupBrokerTestProject(t, s)
+	setupBrokerTestAgent(t, s, projectID, "set-agent-a", "running")
+	setupBrokerTestAgent(t, s, projectID, "set-agent-b", "running")
+
+	events := NewChannelEventPublisher()
+	defer events.Close()
+
+	b := broker.NewInProcessBroker(slog.Default())
+	defer b.Close()
+
+	dispatcher := &brokerMockDispatcher{}
+
+	proxy := NewMessageBrokerProxy(b, s, events, func() AgentDispatcher { return dispatcher }, slog.Default())
+	proxy.Start()
+	defer proxy.Stop()
+
+	proxy.subscribeAgent(projectID, "set-agent-a")
+	proxy.subscribeAgent(projectID, "set-agent-b")
+
+	msg := messages.NewInstruction("user:alice", "", "hello set")
+
+	recipients := []messages.SetRecipient{
+		{Kind: messages.RecipientAgent, Name: "set-agent-a"},
+		{Kind: messages.RecipientAgent, Name: "set-agent-b"},
+	}
+
+	errs := proxy.PublishToSet(context.Background(), projectID, recipients, msg)
+	for k, err := range errs {
+		if err != nil {
+			t.Errorf("PublishToSet error for %s: %v", k, err)
+		}
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	dispatched := dispatcher.getMessages()
+	if len(dispatched) != 2 {
+		t.Fatalf("expected 2 dispatched messages from PublishToSet, got %d", len(dispatched))
+	}
+
+	slugs := map[string]bool{}
+	for _, d := range dispatched {
+		slugs[d.agentSlug] = true
+		if d.msg != "hello set" {
+			t.Errorf("expected msg 'hello set', got %q", d.msg)
+		}
+	}
+	if !slugs["set-agent-a"] || !slugs["set-agent-b"] {
+		t.Errorf("expected both set-agent-a and set-agent-b to receive messages, got %v", slugs)
+	}
+}
+
 func TestRecipientSlug(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/pkg/messages/set.go
+++ b/pkg/messages/set.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messages
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	SetPrefix        = "set["
+	SetSuffix        = "]"
+	MaxSetRecipients = 50
+)
+
+type RecipientKind string
+
+const (
+	RecipientAgent RecipientKind = "agent"
+	RecipientUser  RecipientKind = "user"
+)
+
+type SetRecipient struct {
+	Kind RecipientKind
+	Name string
+}
+
+func (r SetRecipient) String() string {
+	return string(r.Kind) + ":" + r.Name
+}
+
+func IsSetRecipient(s string) bool {
+	return strings.HasPrefix(s, SetPrefix) && strings.HasSuffix(s, SetSuffix)
+}
+
+func ParseSetRecipient(s string) ([]SetRecipient, error) {
+	if !IsSetRecipient(s) {
+		return nil, fmt.Errorf("not a set recipient: must start with %q and end with %q", SetPrefix, SetSuffix)
+	}
+
+	inner := s[len(SetPrefix) : len(s)-len(SetSuffix)]
+	if strings.Contains(inner, SetPrefix) {
+		return nil, fmt.Errorf("nested set[] recipients are not allowed")
+	}
+
+	if strings.TrimSpace(inner) == "" {
+		return nil, fmt.Errorf("empty set[] recipient")
+	}
+
+	parts := strings.Split(inner, ",")
+
+	seen := make(map[string]bool, len(parts))
+	var recipients []SetRecipient
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		r, err := classifyRecipient(part)
+		if err != nil {
+			return nil, err
+		}
+
+		key := r.String()
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		recipients = append(recipients, r)
+	}
+
+	if len(recipients) == 0 {
+		return nil, fmt.Errorf("empty set[] recipient")
+	}
+	if len(recipients) == 1 {
+		return nil, fmt.Errorf("set[] must contain at least 2 recipients; use a direct recipient instead")
+	}
+	if len(recipients) > MaxSetRecipients {
+		return nil, fmt.Errorf("set[] contains %d recipients, maximum is %d", len(recipients), MaxSetRecipients)
+	}
+
+	return recipients, nil
+}
+
+func classifyRecipient(s string) (SetRecipient, error) {
+	if strings.HasPrefix(s, "agent:") {
+		name := strings.TrimPrefix(s, "agent:")
+		if name == "" {
+			return SetRecipient{}, fmt.Errorf("empty agent name in set[] element %q", s)
+		}
+		return SetRecipient{Kind: RecipientAgent, Name: name}, nil
+	}
+	if strings.HasPrefix(s, "user:") {
+		name := strings.TrimPrefix(s, "user:")
+		if name == "" {
+			return SetRecipient{}, fmt.Errorf("empty user name in set[] element %q", s)
+		}
+		return SetRecipient{Kind: RecipientUser, Name: name}, nil
+	}
+	if strings.Contains(s, "@") {
+		return SetRecipient{Kind: RecipientUser, Name: s}, nil
+	}
+	if strings.Contains(s, ":") {
+		prefix := s[:strings.Index(s, ":")]
+		return SetRecipient{}, fmt.Errorf("unknown recipient prefix %q in set[] element %q", prefix, s)
+	}
+	return SetRecipient{Kind: RecipientAgent, Name: s}, nil
+}

--- a/pkg/messages/set_test.go
+++ b/pkg/messages/set_test.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messages
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsSetRecipient(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"set[agent:a,agent:b]", true},
+		{"set[]", true},
+		{"set[a]", true},
+		{"agent:foo", false},
+		{"user:bar", false},
+		{"set[incomplete", false},
+		{"incomplete]", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		got := IsSetRecipient(tt.input)
+		if got != tt.want {
+			t.Errorf("IsSetRecipient(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseSetRecipient_Valid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []SetRecipient
+	}{
+		{
+			name:  "two agents",
+			input: "set[agent:reviewer,agent:deploy-bot]",
+			want: []SetRecipient{
+				{Kind: RecipientAgent, Name: "reviewer"},
+				{Kind: RecipientAgent, Name: "deploy-bot"},
+			},
+		},
+		{
+			name:  "mixed agent and user",
+			input: "set[agent:reviewer,user:alice@example.com]",
+			want: []SetRecipient{
+				{Kind: RecipientAgent, Name: "reviewer"},
+				{Kind: RecipientUser, Name: "alice@example.com"},
+			},
+		},
+		{
+			name:  "bare names default to agent",
+			input: "set[reviewer,deploy-bot]",
+			want: []SetRecipient{
+				{Kind: RecipientAgent, Name: "reviewer"},
+				{Kind: RecipientAgent, Name: "deploy-bot"},
+			},
+		},
+		{
+			name:  "bare email defaults to user",
+			input: "set[agent:bot,alice@example.com]",
+			want: []SetRecipient{
+				{Kind: RecipientAgent, Name: "bot"},
+				{Kind: RecipientUser, Name: "alice@example.com"},
+			},
+		},
+		{
+			name:  "user prefix without email",
+			input: "set[user:alice,agent:bot]",
+			want: []SetRecipient{
+				{Kind: RecipientUser, Name: "alice"},
+				{Kind: RecipientAgent, Name: "bot"},
+			},
+		},
+		{
+			name:  "whitespace trimmed",
+			input: "set[ agent:a , agent:b , user:c ]",
+			want: []SetRecipient{
+				{Kind: RecipientAgent, Name: "a"},
+				{Kind: RecipientAgent, Name: "b"},
+				{Kind: RecipientUser, Name: "c"},
+			},
+		},
+		{
+			name:  "deduplication",
+			input: "set[agent:a,agent:b,agent:a]",
+			want: []SetRecipient{
+				{Kind: RecipientAgent, Name: "a"},
+				{Kind: RecipientAgent, Name: "b"},
+			},
+		},
+		{
+			name:  "three recipients all types",
+			input: "set[agent:reviewer,user:alice@example.com,deploy-bot]",
+			want: []SetRecipient{
+				{Kind: RecipientAgent, Name: "reviewer"},
+				{Kind: RecipientUser, Name: "alice@example.com"},
+				{Kind: RecipientAgent, Name: "deploy-bot"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSetRecipient(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d recipients, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i].Kind != tt.want[i].Kind || got[i].Name != tt.want[i].Name {
+					t.Errorf("recipient[%d] = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseSetRecipient_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name:    "not a set",
+			input:   "agent:foo",
+			wantErr: "not a set recipient",
+		},
+		{
+			name:    "empty set",
+			input:   "set[]",
+			wantErr: "empty set[]",
+		},
+		{
+			name:    "single element",
+			input:   "set[agent:a]",
+			wantErr: "at least 2 recipients",
+		},
+		{
+			name:    "nested set",
+			input:   "set[agent:a,set[agent:b,agent:c]]",
+			wantErr: "nested set[]",
+		},
+		{
+			name:    "unknown prefix",
+			input:   "set[foo:bar,agent:a]",
+			wantErr: "unknown recipient prefix",
+		},
+		{
+			name:    "empty agent name",
+			input:   "set[agent:,agent:b]",
+			wantErr: "empty agent name",
+		},
+		{
+			name:    "empty user name",
+			input:   "set[user:,agent:b]",
+			wantErr: "empty user name",
+		},
+		{
+			name:    "whitespace only",
+			input:   "set[  ]",
+			wantErr: "empty set[]",
+		},
+		{
+			name:    "all duplicates collapse to single",
+			input:   "set[agent:a,agent:a]",
+			wantErr: "at least 2 recipients",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseSetRecipient(tt.input)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseSetRecipient_MaxLimit(t *testing.T) {
+	parts := make([]string, MaxSetRecipients+1)
+	for i := range parts {
+		parts[i] = "agent:a" + strings.Repeat("x", 3) + string(rune('a'+i%26)) + string(rune('a'+i/26))
+	}
+	input := "set[" + strings.Join(parts, ",") + "]"
+	_, err := ParseSetRecipient(input)
+	if err == nil {
+		t.Fatal("expected error for exceeding max recipients")
+	}
+	if !strings.Contains(err.Error(), "maximum is") {
+		t.Errorf("error %q does not mention maximum", err.Error())
+	}
+}
+
+func TestSetRecipientString(t *testing.T) {
+	r := SetRecipient{Kind: RecipientAgent, Name: "reviewer"}
+	if r.String() != "agent:reviewer" {
+		t.Errorf("String() = %q, want %q", r.String(), "agent:reviewer")
+	}
+	r = SetRecipient{Kind: RecipientUser, Name: "alice"}
+	if r.String() != "user:alice" {
+		t.Errorf("String() = %q, want %q", r.String(), "user:alice")
+	}
+}

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -1268,6 +1268,7 @@ type Message struct {
 	Broadcasted bool      `json:"broadcasted,omitempty"`
 	Read        bool      `json:"read"`    // Whether recipient has read/acknowledged
 	AgentID     string    `json:"agentId"` // The agent involved (sender or recipient)
+	GroupID     string    `json:"groupId,omitempty"`
 	CreatedAt   time.Time `json:"createdAt"`
 }
 

--- a/pkg/store/sqlite/messages.go
+++ b/pkg/store/sqlite/messages.go
@@ -42,13 +42,13 @@ func (s *SQLiteStore) CreateMessage(ctx context.Context, msg *store.Message) err
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO messages (
 			id, project_id, sender, sender_id, recipient, recipient_id,
-			msg, type, urgent, broadcasted, read, agent_id, created_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			msg, type, urgent, broadcasted, read, agent_id, group_id, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		msg.ID, msg.ProjectID, msg.Sender, msg.SenderID, msg.Recipient, msg.RecipientID,
 		msg.Msg, msg.Type,
 		boolToInt(msg.Urgent), boolToInt(msg.Broadcasted), boolToInt(msg.Read),
-		msg.AgentID, msg.CreatedAt,
+		msg.AgentID, msg.GroupID, msg.CreatedAt,
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
@@ -63,7 +63,7 @@ func (s *SQLiteStore) CreateMessage(ctx context.Context, msg *store.Message) err
 func (s *SQLiteStore) GetMessage(ctx context.Context, id string) (*store.Message, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, project_id, sender, sender_id, recipient, recipient_id,
-			msg, type, urgent, broadcasted, read, agent_id, created_at
+			msg, type, urgent, broadcasted, read, agent_id, group_id, created_at
 		FROM messages
 		WHERE id = ?
 	`, id)
@@ -73,7 +73,7 @@ func (s *SQLiteStore) GetMessage(ctx context.Context, id string) (*store.Message
 	if err := row.Scan(
 		&msg.ID, &msg.ProjectID, &msg.Sender, &msg.SenderID, &msg.Recipient, &msg.RecipientID,
 		&msg.Msg, &msg.Type, &urgent, &broadcasted, &read,
-		&msg.AgentID, &msg.CreatedAt,
+		&msg.AgentID, &msg.GroupID, &msg.CreatedAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, store.ErrNotFound
@@ -140,7 +140,7 @@ func (s *SQLiteStore) ListMessages(ctx context.Context, filter store.MessageFilt
 
 	query := fmt.Sprintf(`
 		SELECT id, project_id, sender, sender_id, recipient, recipient_id,
-			msg, type, urgent, broadcasted, read, agent_id, created_at
+			msg, type, urgent, broadcasted, read, agent_id, group_id, created_at
 		FROM messages %s ORDER BY created_at DESC LIMIT ?
 	`, whereClause)
 	args = append(args, limit+1)
@@ -158,7 +158,7 @@ func (s *SQLiteStore) ListMessages(ctx context.Context, filter store.MessageFilt
 		if err := rows.Scan(
 			&msg.ID, &msg.ProjectID, &msg.Sender, &msg.SenderID, &msg.Recipient, &msg.RecipientID,
 			&msg.Msg, &msg.Type, &urgent, &broadcasted, &read,
-			&msg.AgentID, &msg.CreatedAt,
+			&msg.AgentID, &msg.GroupID, &msg.CreatedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/store/sqlite/sqlite.go
+++ b/pkg/store/sqlite/sqlite.go
@@ -144,6 +144,7 @@ func (s *SQLiteStore) Migrate(ctx context.Context) error {
 		migrationV48,
 		migrationV49,
 		migrateV50,
+		migrationV51,
 	}
 
 	// Create migrations table if not exists
@@ -1326,6 +1327,11 @@ CREATE INDEX IF NOT EXISTS idx_gcp_sa_project ON gcp_service_accounts(project_id
 
 	return nil
 }
+
+// migrationV51 adds group_id to messages for correlating set[] deliveries.
+const migrationV51 = `
+ALTER TABLE messages ADD COLUMN group_id TEXT NOT NULL DEFAULT '';
+`
 
 // tableExists checks whether a table with the given name exists in the database.
 func tableExists(ctx context.Context, tx *sql.Tx, tableName string) (bool, error) {


### PR DESCRIPTION
## Summary
- Adds `set[agent:reviewer,user:alice@example.com,agent:deploy-bot]` composite recipient type that fans out a single message to multiple recipients of mixed types
- CLI parsing with validation: rejects empty sets, single-element sets, nested sets, unknown prefixes; deduplicates; enforces 50-recipient upper bound
- Hub handler detects `set[]` in `handleAgentMessage()` and fans out with per-recipient status JSON response including GroupID for correlation
- Broker proxy gains `PublishToSet()` method for broker-level fan-out
- Message model gains `GroupID` field (migration V51) to correlate set deliveries
- Backward compatible: `set[` doesn't collide with valid agent names; `--broadcast` and `--all` remain unchanged

## Test plan
- [x] `pkg/messages/set_test.go`: parsing valid/invalid inputs, max limit, dedup, string representation
- [x] `cmd/message_test.go`: flag validation (set + broadcast/all/raw/in/notify rejected), Hub fan-out delivery
- [x] `pkg/hub/messagebroker_test.go`: `PublishToSet()` delivers to multiple agents via broker
- [x] `go build ./...` passes
- [x] All existing tests in `pkg/messages/`, `pkg/store/...`, `pkg/hub/`, `cmd/` pass

Closes #25