### PR TITLE
feat(wake): add --wake flag to scion message command

### DIFF
--- a/cmd/message.go
+++ b/cmd/message.go
@@ -40,6 +40,7 @@ var msgPlain bool
 var msgRaw bool
 var msgAttach []string
 var msgNotify bool
+var msgWake bool
 
 // messageCmd represents the message command
 var messageCmd = &cobra.Command{
@@ -155,6 +156,22 @@ Examples:
 			}
 		}
 
+		// Validate --wake restrictions
+		if msgWake {
+			if msgBroadcast || msgAll {
+				return fmt.Errorf("--wake cannot be combined with --broadcast or --all")
+			}
+			if msgIn != "" || msgAt != "" {
+				return fmt.Errorf("--wake cannot be combined with --in or --at")
+			}
+			if msgRaw {
+				return fmt.Errorf("--wake cannot be combined with --raw")
+			}
+			if userRecipient != "" {
+				return fmt.Errorf("--wake cannot be used with user recipients")
+			}
+		}
+
 		// Validate attachments
 		if len(msgAttach) > messages.MaxAttachments {
 			return fmt.Errorf("too many attachments: %d (max %d)", len(msgAttach), messages.MaxAttachments)
@@ -217,7 +234,12 @@ Examples:
 		}
 
 		if hubCtx != nil {
-			return sendMessageViaHub(hubCtx, agentName, message, msgInterrupt, msgBroadcast, msgAll, msgNotify)
+			return sendMessageViaHub(hubCtx, agentName, message, msgInterrupt, msgBroadcast, msgAll, msgNotify, msgWake)
+		}
+
+		// --wake requires Hub mode
+		if msgWake {
+			return fmt.Errorf("--wake requires Hub mode (use 'scion hub enable' first)")
 		}
 
 		// Local mode — structured messages are only available in Hub mode,
@@ -342,7 +364,7 @@ func buildStructuredMessage(sender, recipient, message string) *messages.Structu
 	return msg
 }
 
-func sendMessageViaHub(hubCtx *HubContext, agentName string, message string, interrupt bool, broadcast bool, all bool, notify bool) error {
+func sendMessageViaHub(hubCtx *HubContext, agentName string, message string, interrupt bool, broadcast bool, all bool, notify bool, wake bool) error {
 	if !isJSONOutput() {
 		PrintUsingHub(hubCtx.Endpoint)
 	}
@@ -457,7 +479,7 @@ func sendMessageViaHub(hubCtx *HubContext, agentName string, message string, int
 	defer cancel()
 
 	msg := buildStructuredMessage(sender, "agent:"+agentName, message)
-	if err := agentSvc.SendStructuredMessage(ctx, agentName, msg, interrupt, notify, false); err != nil {
+	if err := agentSvc.SendStructuredMessage(ctx, agentName, msg, interrupt, notify, wake); err != nil {
 		return wrapHubError(fmt.Errorf("failed to send message to agent '%s' via Hub: %w", agentName, err))
 	}
 
@@ -664,5 +686,6 @@ func init() {
 	messageCmd.Flags().BoolVar(&msgRaw, "raw", false, "Send literal bytes via tmux send-keys with no trailing Enter (supports control keys like arrows and Escape)")
 	messageCmd.Flags().StringArrayVar(&msgAttach, "attach", nil, "Attach file path(s), repeatable")
 	messageCmd.Flags().BoolVar(&msgNotify, "notify", false, "Subscribe to notifications for the target agent (completed, waiting for input, etc.)")
+	messageCmd.Flags().BoolVarP(&msgWake, "wake", "w", false, "Resume a suspended agent before delivering the message")
 	rootCmd.AddCommand(messageCmd)
 }

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -570,7 +570,7 @@ func sendSetMessageViaHub(hubCtx *HubContext, recipients []messages.SetRecipient
 				slug := api.Slugify(recip.Name)
 				msg := buildStructuredMessage(sender, "agent:"+slug, message)
 				msg.Metadata = map[string]string{"group_id": groupID}
-				if err := agentSvc.SendStructuredMessage(ctx, slug, msg, interrupt, false); err != nil {
+				if err := agentSvc.SendStructuredMessage(ctx, slug, msg, interrupt, false, false); err != nil {
 					results[idx] = recipientResult{Recipient: recipStr, Status: "failed", Error: err.Error()}
 					if !isJSONOutput() {
 						fmt.Printf("  Failed: %s: %s\n", recipStr, err)

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -384,7 +384,7 @@ func sendMessageViaHub(hubCtx *HubContext, agentName string, message string, int
 				defer cancel()
 
 				msg := buildStructuredMessage(sender, "agent:"+name, message)
-				if err := agentSvc.SendStructuredMessage(ctx, name, msg, interrupt, false); err != nil {
+				if err := agentSvc.SendStructuredMessage(ctx, name, msg, interrupt, false, false); err != nil {
 					fmt.Printf("Warning: failed to send message to agent '%s' via Hub: %s\n", name, err)
 					return
 				}
@@ -429,7 +429,7 @@ func sendMessageViaHub(hubCtx *HubContext, agentName string, message string, int
 				defer cancel()
 
 				msg := buildStructuredMessage(sender, "agent:"+name, message)
-				if err := agentSvc.SendStructuredMessage(ctx, name, msg, interrupt, false); err != nil {
+				if err := agentSvc.SendStructuredMessage(ctx, name, msg, interrupt, false, false); err != nil {
 					fmt.Printf("Warning: failed to send message to agent '%s' via Hub: %s\n", name, err)
 					return
 				}
@@ -457,7 +457,7 @@ func sendMessageViaHub(hubCtx *HubContext, agentName string, message string, int
 	defer cancel()
 
 	msg := buildStructuredMessage(sender, "agent:"+agentName, message)
-	if err := agentSvc.SendStructuredMessage(ctx, agentName, msg, interrupt, notify); err != nil {
+	if err := agentSvc.SendStructuredMessage(ctx, agentName, msg, interrupt, notify, false); err != nil {
 		return wrapHubError(fmt.Errorf("failed to send message to agent '%s' via Hub: %w", agentName, err))
 	}
 

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -30,13 +30,13 @@ import (
 // messageTestState captures and restores package-level vars for test isolation.
 type messageTestState struct {
 	projectPath string
-	noHub     bool
+	noHub       bool
 }
 
 func saveMessageTestState() messageTestState {
 	return messageTestState{
 		projectPath: projectPath,
-		noHub:     noHub,
+		noHub:       noHub,
 	}
 }
 
@@ -140,9 +140,9 @@ func TestSendMessageViaHub_SingleAgent(t *testing.T) {
 	require.NoError(t, err)
 
 	hubCtx := &HubContext{
-		Client:   client,
-		Endpoint: server.URL,
-		ProjectID:  projectID,
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
 	}
 
 	err = sendMessageViaHub(hubCtx, "my-agent", "hello world", false, false, false, false, false)
@@ -170,9 +170,9 @@ func TestSendMessageViaHub_SingleAgentInterrupt(t *testing.T) {
 	require.NoError(t, err)
 
 	hubCtx := &HubContext{
-		Client:   client,
-		Endpoint: server.URL,
-		ProjectID:  projectID,
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
 	}
 
 	// Set interrupt flag for this test
@@ -208,9 +208,9 @@ func TestSendMessageViaHub_Broadcast(t *testing.T) {
 	require.NoError(t, err)
 
 	hubCtx := &HubContext{
-		Client:   client,
-		Endpoint: server.URL,
-		ProjectID:  projectID,
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
 	}
 
 	// Set broadcast flag for structured message construction
@@ -245,9 +245,9 @@ func TestSendMessageViaHub_BroadcastNoAgents(t *testing.T) {
 	require.NoError(t, err)
 
 	hubCtx := &HubContext{
-		Client:   client,
-		Endpoint: server.URL,
-		ProjectID:  projectID,
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
 	}
 
 	err = sendMessageViaHub(hubCtx, "", "hello", false, true, false, false, false)
@@ -314,9 +314,9 @@ func TestSendMessageViaHub_SingleAgentError(t *testing.T) {
 	require.NoError(t, err)
 
 	hubCtx := &HubContext{
-		Client:   client,
-		Endpoint: server.URL,
-		ProjectID:  projectID,
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
 	}
 
 	err = sendMessageViaHub(hubCtx, "my-agent", "hello", false, false, false, false, false)
@@ -450,9 +450,9 @@ func TestSendMessageViaHub_BroadcastPartialFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	hubCtx := &HubContext{
-		Client:   client,
-		Endpoint: server.URL,
-		ProjectID:  projectID,
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
 	}
 
 	// Broadcast should not return an error on partial failure
@@ -554,9 +554,9 @@ func TestSendMessageViaHub_NotifyFlag(t *testing.T) {
 	require.NoError(t, err)
 
 	hubCtx := &HubContext{
-		Client:   client,
-		Endpoint: server.URL,
-		ProjectID:  projectID,
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
 	}
 
 	err = sendMessageViaHub(hubCtx, "my-agent", "hello", false, false, false, true, false)
@@ -602,9 +602,9 @@ func TestSendMessageViaHub_NoNotifyFlag(t *testing.T) {
 	require.NoError(t, err)
 
 	hubCtx := &HubContext{
-		Client:   client,
-		Endpoint: server.URL,
-		ProjectID:  projectID,
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
 	}
 
 	// Explicit --no-notify: notify should be false
@@ -644,9 +644,9 @@ func TestSendOutboundMessageViaHub(t *testing.T) {
 	require.NoError(t, err)
 
 	hubCtx := &HubContext{
-		Client:   client,
-		Endpoint: server.URL,
-		ProjectID:  projectID,
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
 	}
 
 	t.Setenv("SCION_AGENT_NAME", "my-agent")
@@ -675,9 +675,9 @@ func TestSendOutboundMessageViaHub_RequiresAgentContext(t *testing.T) {
 	require.NoError(t, err)
 
 	hubCtx := &HubContext{
-		Client:   client,
-		Endpoint: server.URL,
-		ProjectID:  "grove-test",
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: "grove-test",
 	}
 
 	t.Setenv("SCION_AGENT_NAME", "")
@@ -967,9 +967,9 @@ func TestSendMessageViaHub_WakePassedThrough(t *testing.T) {
 	require.NoError(t, err)
 
 	hubCtx := &HubContext{
-		Client:   client,
-		Endpoint: server.URL,
-		ProjectID:  projectID,
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
 	}
 
 	// Send with wake=true

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -145,7 +145,7 @@ func TestSendMessageViaHub_SingleAgent(t *testing.T) {
 		ProjectID:  projectID,
 	}
 
-	err = sendMessageViaHub(hubCtx, "my-agent", "hello world", false, false, false, false)
+	err = sendMessageViaHub(hubCtx, "my-agent", "hello world", false, false, false, false, false)
 	require.NoError(t, err)
 
 	require.Len(t, *sent, 1)
@@ -180,7 +180,7 @@ func TestSendMessageViaHub_SingleAgentInterrupt(t *testing.T) {
 	msgInterrupt = true
 	defer func() { msgInterrupt = origInterrupt }()
 
-	err = sendMessageViaHub(hubCtx, "my-agent", "urgent", true, false, false, false)
+	err = sendMessageViaHub(hubCtx, "my-agent", "urgent", true, false, false, false, false)
 	require.NoError(t, err)
 
 	require.Len(t, *sent, 1)
@@ -218,7 +218,7 @@ func TestSendMessageViaHub_Broadcast(t *testing.T) {
 	msgBroadcast = true
 	defer func() { msgBroadcast = origBroadcast }()
 
-	err = sendMessageViaHub(hubCtx, "", "broadcast msg", false, true, false, false)
+	err = sendMessageViaHub(hubCtx, "", "broadcast msg", false, true, false, false, false)
 	require.NoError(t, err)
 
 	require.Len(t, *sent, 3)
@@ -250,7 +250,7 @@ func TestSendMessageViaHub_BroadcastNoAgents(t *testing.T) {
 		ProjectID:  projectID,
 	}
 
-	err = sendMessageViaHub(hubCtx, "", "hello", false, true, false, false)
+	err = sendMessageViaHub(hubCtx, "", "hello", false, true, false, false, false)
 	require.NoError(t, err)
 
 	// No messages should be sent
@@ -278,7 +278,7 @@ func TestSendMessageViaHub_All(t *testing.T) {
 		Endpoint: server.URL,
 	}
 
-	err = sendMessageViaHub(hubCtx, "", "all msg", false, false, true, false)
+	err = sendMessageViaHub(hubCtx, "", "all msg", false, false, true, false, false)
 	require.NoError(t, err)
 
 	require.Len(t, *sent, 2)
@@ -319,7 +319,7 @@ func TestSendMessageViaHub_SingleAgentError(t *testing.T) {
 		ProjectID:  projectID,
 	}
 
-	err = sendMessageViaHub(hubCtx, "my-agent", "hello", false, false, false, false)
+	err = sendMessageViaHub(hubCtx, "my-agent", "hello", false, false, false, false, false)
 	require.Error(t, err, "single-agent message failure should return an error")
 }
 
@@ -456,7 +456,7 @@ func TestSendMessageViaHub_BroadcastPartialFailure(t *testing.T) {
 	}
 
 	// Broadcast should not return an error on partial failure
-	err = sendMessageViaHub(hubCtx, "", "test", false, true, false, false)
+	err = sendMessageViaHub(hubCtx, "", "test", false, true, false, false, false)
 	require.NoError(t, err)
 
 	// Only the good agent should have received the message
@@ -559,7 +559,7 @@ func TestSendMessageViaHub_NotifyFlag(t *testing.T) {
 		ProjectID:  projectID,
 	}
 
-	err = sendMessageViaHub(hubCtx, "my-agent", "hello", false, false, false, true)
+	err = sendMessageViaHub(hubCtx, "my-agent", "hello", false, false, false, true, false)
 	require.NoError(t, err)
 
 	mu.Lock()
@@ -608,7 +608,7 @@ func TestSendMessageViaHub_NoNotifyFlag(t *testing.T) {
 	}
 
 	// Explicit --no-notify: notify should be false
-	err = sendMessageViaHub(hubCtx, "my-agent", "hello", false, false, false, false)
+	err = sendMessageViaHub(hubCtx, "my-agent", "hello", false, false, false, false, false)
 	require.NoError(t, err)
 
 	mu.Lock()
@@ -808,6 +808,72 @@ func TestSetRecipientFlagValidation(t *testing.T) {
 	}
 }
 
+func TestWakeFlagValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func()
+		teardown func()
+		args     []string // cobra args; nil means use default ["agent1", "hello"]
+		errMsg   string
+	}{
+		{
+			name:     "wake with broadcast",
+			setup:    func() { msgWake = true; msgBroadcast = true },
+			teardown: func() { msgWake = false; msgBroadcast = false },
+			args:     []string{"hello"},
+			errMsg:   "--wake cannot be combined with --broadcast or --all",
+		},
+		{
+			name:     "wake with all",
+			setup:    func() { msgWake = true; msgAll = true },
+			teardown: func() { msgWake = false; msgAll = false },
+			args:     []string{"hello"},
+			errMsg:   "--wake cannot be combined with --broadcast or --all",
+		},
+		{
+			name:     "wake with in",
+			setup:    func() { msgWake = true; msgIn = "5m" },
+			teardown: func() { msgWake = false; msgIn = "" },
+			errMsg:   "--wake cannot be combined with --in or --at",
+		},
+		{
+			name:     "wake with at",
+			setup:    func() { msgWake = true; msgAt = "2026-01-01T00:00:00Z" },
+			teardown: func() { msgWake = false; msgAt = "" },
+			errMsg:   "--wake cannot be combined with --in or --at",
+		},
+		{
+			name:     "wake with raw",
+			setup:    func() { msgWake = true; msgRaw = true },
+			teardown: func() { msgWake = false; msgRaw = false },
+			errMsg:   "--wake cannot be combined with --raw",
+		},
+		{
+			name:     "wake with user recipient",
+			setup:    func() { msgWake = true },
+			teardown: func() { msgWake = false },
+			args:     []string{"user:alice", "hello"},
+			errMsg:   "--wake cannot be used with user recipients",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+			defer tc.teardown()
+
+			args := tc.args
+			if args == nil {
+				args = []string{"agent1", "hello"}
+			}
+
+			err := messageCmd.RunE(messageCmd, args)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errMsg)
+		})
+	}
+}
+
 func TestSendSetMessageViaHub(t *testing.T) {
 	orig := saveMessageTestState()
 	defer orig.restore()
@@ -863,6 +929,56 @@ func TestSendSetMessageViaHub_RequiresHub(t *testing.T) {
 	// When Hub is configured but test agents don't exist, delivery fails.
 	// Either way, an error must be returned — never silent nil.
 	require.Error(t, err)
+}
+
+func TestSendMessageViaHub_WakePassedThrough(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	projectID := "grove-msg-wake"
+
+	var wakeReceived bool
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
+			json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+		case r.Method == http.MethodPost:
+			var body struct {
+				StructuredMessage *messages.StructuredMessage `json:"structured_message"`
+				Interrupt         bool                        `json:"interrupt"`
+				Notify            bool                        `json:"notify"`
+				Wake              bool                        `json:"wake"`
+			}
+			json.NewDecoder(r.Body).Decode(&body)
+			mu.Lock()
+			wakeReceived = body.Wake
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:   client,
+		Endpoint: server.URL,
+		ProjectID:  projectID,
+	}
+
+	// Send with wake=true
+	err = sendMessageViaHub(hubCtx, "my-agent", "hello", false, false, false, false, true)
+	require.NoError(t, err)
+
+	mu.Lock()
+	assert.True(t, wakeReceived, "wake should be true when passed through")
+	mu.Unlock()
 }
 
 func TestNotifyFlagValidation(t *testing.T) {

--- a/extras/scion-a2a-bridge/internal/bridge/bridge.go
+++ b/extras/scion-a2a-bridge/internal/bridge/bridge.go
@@ -286,7 +286,7 @@ func (b *Bridge) SendMessage(ctx context.Context, projectSlug, agentSlug, contex
 			defer b.wg.Done()
 			sendCtx, cancel := context.WithTimeout(b.shutdownCtx, 30*time.Second)
 			defer cancel()
-			if err := b.hubClient.Agents().SendStructuredMessage(sendCtx, agentCtx.AgentID, scionMsg, false, false); err != nil {
+			if err := b.hubClient.Agents().SendStructuredMessage(sendCtx, agentCtx.AgentID, scionMsg, false, false, false); err != nil {
 				b.log.Error("non-blocking send failed", "error", err, "task_id", taskID)
 				if err := b.store.UpdateTaskState(taskID, TaskStateFailed); err != nil {
 					b.log.Error("failed to update task state", "error", err, "task_id", taskID)
@@ -320,7 +320,7 @@ func (b *Bridge) SendMessage(ctx context.Context, projectSlug, agentSlug, contex
 	defer b.removeWaiter(taskID)
 	defer b.unregisterActiveTask(taskID, aKey)
 
-	if err := b.hubClient.Agents().SendStructuredMessage(ctx, agentCtx.AgentID, scionMsg, false, false); err != nil {
+	if err := b.hubClient.Agents().SendStructuredMessage(ctx, agentCtx.AgentID, scionMsg, false, false, false); err != nil {
 		if err := b.store.UpdateTaskState(taskID, TaskStateFailed); err != nil {
 			b.log.Error("failed to update task state", "error", err, "task_id", taskID)
 		}
@@ -441,7 +441,7 @@ func (b *Bridge) CancelTask(ctx context.Context, taskID string) (*TaskResult, er
 			Type:      messages.TypeInstruction,
 			Metadata:  map[string]string{"a2aTaskId": taskID},
 		}
-		if err := b.hubClient.Agents().SendStructuredMessage(ctx, targetAgentID, interruptMsg, true, false); err != nil {
+		if err := b.hubClient.Agents().SendStructuredMessage(ctx, targetAgentID, interruptMsg, true, false, false); err != nil {
 			b.log.Error("failed to send cancel interrupt to agent", "error", err, "task_id", taskID, "agent_id", targetAgentID)
 		}
 	}

--- a/extras/scion-a2a-bridge/internal/bridge/bridge.go
+++ b/extras/scion-a2a-bridge/internal/bridge/bridge.go
@@ -40,7 +40,7 @@ var (
 type waiter struct {
 	ch        chan *messages.StructuredMessage
 	agentSlug string
-	projectID   string
+	projectID string
 }
 
 // Bridge is the core bridge logic that ties together state management,
@@ -246,7 +246,7 @@ func (b *Bridge) SendMessage(ctx context.Context, projectSlug, agentSlug, contex
 	task := &state.Task{
 		ID:        taskID,
 		ContextID: agentCtx.ContextID,
-		ProjectID:   agentCtx.ProjectID,
+		ProjectID: agentCtx.ProjectID,
 		AgentSlug: agentCtx.AgentSlug,
 		AgentID:   agentCtx.AgentID,
 		State:     TaskStateSubmitted,
@@ -315,7 +315,7 @@ func (b *Bridge) SendMessage(ctx context.Context, projectSlug, agentSlug, contex
 	b.addWaiter(taskID, &waiter{
 		ch:        responseCh,
 		agentSlug: agentCtx.AgentSlug,
-		projectID:   agentCtx.ProjectID,
+		projectID: agentCtx.ProjectID,
 	})
 	defer b.removeWaiter(taskID)
 	defer b.unregisterActiveTask(taskID, aKey)
@@ -852,10 +852,10 @@ func (b *Bridge) resolveContext(ctx context.Context, projectSlug, agentSlug, con
 
 		b.log.Info("auto-provisioning agent", "slug", agentSlug, "project", projectSlug, "template", projectCfg.DefaultTemplate)
 		created, err := b.hubClient.Agents().Create(ctx, &hubclient.CreateAgentRequest{
-			Name:     agentSlug,
-			ProjectID:  projectSlug,
-			Template: projectCfg.DefaultTemplate,
-			Labels:   map[string]string{"a2a-bridge/auto-provisioned": "true"},
+			Name:      agentSlug,
+			ProjectID: projectSlug,
+			Template:  projectCfg.DefaultTemplate,
+			Labels:    map[string]string{"a2a-bridge/auto-provisioned": "true"},
 		})
 		if err != nil {
 			// Concurrent create may have succeeded; re-list to find the agent.
@@ -888,7 +888,7 @@ func (b *Bridge) resolveContext(ctx context.Context, projectSlug, agentSlug, con
 	now := time.Now()
 	agentCtx := &state.Context{
 		ContextID:  newContextID,
-		ProjectID:    projectID,
+		ProjectID:  projectID,
 		AgentSlug:  agentSlug,
 		AgentID:    agentID,
 		CreatedAt:  now,

--- a/extras/scion-a2a-bridge/internal/bridge/stream.go
+++ b/extras/scion-a2a-bridge/internal/bridge/stream.go
@@ -182,7 +182,7 @@ func (b *Bridge) SendStreamingMessage(ctx context.Context, projectSlug, agentSlu
 	task := &state.Task{
 		ID:        taskID,
 		ContextID: agentCtx.ContextID,
-		ProjectID:   agentCtx.ProjectID,
+		ProjectID: agentCtx.ProjectID,
 		AgentSlug: agentCtx.AgentSlug,
 		AgentID:   agentCtx.AgentID,
 		State:     TaskStateSubmitted,

--- a/extras/scion-a2a-bridge/internal/bridge/stream.go
+++ b/extras/scion-a2a-bridge/internal/bridge/stream.go
@@ -232,7 +232,7 @@ func (b *Bridge) SendStreamingMessage(ctx context.Context, projectSlug, agentSlu
 		sendCtx, cancel := context.WithTimeout(b.shutdownCtx, 30*time.Second)
 		defer cancel()
 
-		if err := b.hubClient.Agents().SendStructuredMessage(sendCtx, agentCtx.AgentID, scionMsg, false, false); err != nil {
+		if err := b.hubClient.Agents().SendStructuredMessage(sendCtx, agentCtx.AgentID, scionMsg, false, false, false); err != nil {
 			b.log.Error("streaming send failed", "error", err, "task_id", taskID)
 			if err := b.store.UpdateTaskState(taskID, TaskStateFailed); err != nil {
 				b.log.Error("failed to update task state", "error", err, "task_id", taskID)

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -1068,7 +1068,7 @@ func (r *CommandRouter) cmdMessage(ctx context.Context, event *ChatEvent, args [
 		msg.Msg = fmt.Sprintf("[thread:%s] %s", threadID, msg.Msg)
 	}
 
-	if err := client.GroveAgents(link.GroveID).SendStructuredMessage(ctx, agentSlug, msg, false, false); err != nil {
+	if err := client.GroveAgents(link.GroveID).SendStructuredMessage(ctx, agentSlug, msg, false, false, false); err != nil {
 		return textResponse(event, fmt.Sprintf("Failed to send message to `%s`: %v", agentSlug, err)), nil
 	}
 

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -188,7 +188,7 @@ type ListAgentsResponse struct {
 
 type CreateAgentRequest struct {
 	Name            string            `json:"name"`
-	ProjectID         string            `json:"projectId"`
+	ProjectID       string            `json:"projectId"`
 	RuntimeBrokerID string            `json:"runtimeBrokerId,omitempty"` // Optional: uses project's default if not specified
 	Template        string            `json:"template"`
 	HarnessConfig   string            `json:"harnessConfig,omitempty"` // Explicit harness config name (used during sync when template may not be on Hub)
@@ -274,7 +274,7 @@ func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 
 	filter := store.AgentFilter{
-		ProjectID:         query.Get("projectId"),
+		ProjectID:       query.Get("projectId"),
 		RuntimeBrokerID: query.Get("runtimeBrokerId"),
 		Phase:           query.Get("phase"),
 		IncludeDeleted:  query.Get("includeDeleted") == "true",
@@ -615,7 +615,7 @@ func (s *Server) createAgentInProject(
 		Slug:            slug,
 		Name:            slug,
 		Template:        req.Template,
-		ProjectID:         projectID,
+		ProjectID:       projectID,
 		RuntimeBrokerID: runtimeBrokerID,
 		Phase:           string(state.PhaseCreated),
 		Labels:          req.Labels,
@@ -2022,7 +2022,7 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 
 	storeMsg := &store.Message{
 		ID:          api.NewUUID(),
-		ProjectID:     agent.ProjectID,
+		ProjectID:   agent.ProjectID,
 		Sender:      "agent:" + agent.Slug,
 		SenderID:    agent.ID,
 		Recipient:   recipient,
@@ -2371,7 +2371,7 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 	if structuredMsg != nil {
 		storeMsg := &store.Message{
 			ID:          api.NewUUID(),
-			ProjectID:     agent.ProjectID,
+			ProjectID:   agent.ProjectID,
 			Sender:      structuredMsg.Sender,
 			SenderID:    structuredMsg.SenderID,
 			Recipient:   structuredMsg.Recipient,
@@ -2698,7 +2698,7 @@ func (s *Server) broadcastDirect(w http.ResponseWriter, r *http.Request, project
 
 	result, err := s.store.ListAgents(ctx, store.AgentFilter{
 		ProjectID: projectID,
-		Phase:   "running",
+		Phase:     "running",
 	}, store.ListOptions{})
 	if err != nil {
 		writeErrorFromErr(w, err, "")
@@ -2721,7 +2721,7 @@ func (s *Server) broadcastDirect(w http.ResponseWriter, r *http.Request, project
 		// Persist broadcast message per recipient (non-fatal)
 		storeMsg := &store.Message{
 			ID:          api.NewUUID(),
-			ProjectID:     projectID,
+			ProjectID:   projectID,
 			Sender:      agentMsg.Sender,
 			SenderID:    agentMsg.SenderID,
 			Recipient:   agentMsg.Recipient,
@@ -2938,7 +2938,7 @@ func (s *Server) handleStopAllAgents(w http.ResponseWriter, r *http.Request, pro
 	scope := "all"
 	filter := store.AgentFilter{
 		ProjectID: projectID,
-		Phase:   string(state.PhaseRunning),
+		Phase:     string(state.PhaseRunning),
 	}
 
 	if projectID == "" {
@@ -3064,7 +3064,7 @@ func (s *Server) handleStopAllAgents(w http.ResponseWriter, r *http.Request, pro
 // Returns "" if the user is not a member of the project.
 func (s *Server) resolveUserProjectRole(ctx context.Context, projectID, userID string) string {
 	groups, err := s.store.ListGroups(ctx, store.GroupFilter{
-		ProjectID:   projectID,
+		ProjectID: projectID,
 		GroupType: store.GroupTypeExplicit,
 	}, store.ListOptions{Limit: 10})
 	if err != nil || len(groups.Items) == 0 {
@@ -3105,14 +3105,14 @@ type CreateProjectRequest struct {
 }
 
 type RegisterProjectRequest struct {
-	ID        string              `json:"id,omitempty"` // Client-provided project ID
-	Name      string              `json:"name"`
-	GitRemote string              `json:"gitRemote"`
-	Path      string              `json:"path,omitempty"`
-	BrokerID  string              `json:"brokerId,omitempty"` // Link to existing broker (two-phase flow)
+	ID        string                     `json:"id,omitempty"` // Client-provided project ID
+	Name      string                     `json:"name"`
+	GitRemote string                     `json:"gitRemote"`
+	Path      string                     `json:"path,omitempty"`
+	BrokerID  string                     `json:"brokerId,omitempty"` // Link to existing broker (two-phase flow)
 	Broker    *RegisterProjectBrokerInfo `json:"broker,omitempty"`   // DEPRECATED: Use BrokerID with two-phase registration
-	Profiles  []string            `json:"profiles,omitempty"`
-	Labels    map[string]string   `json:"labels,omitempty"`
+	Profiles  []string                   `json:"profiles,omitempty"`
+	Labels    map[string]string          `json:"labels,omitempty"`
 }
 
 // UnmarshalJSON implements custom unmarshaling to support legacy groveId keys.
@@ -3151,7 +3151,7 @@ type RegisterProjectResponse struct {
 	LegacyProject *store.Project           `json:"grove,omitempty"`
 	Broker        *store.RuntimeBroker     `json:"broker,omitempty"`
 	Created       bool                     `json:"created"`
-	Matches       []hubclient.ProjectMatch `json:"matches,omitempty"` // Populated when multiple projects share the same git remote
+	Matches       []hubclient.ProjectMatch `json:"matches,omitempty"`     // Populated when multiple projects share the same git remote
 	BrokerToken   string                   `json:"brokerToken,omitempty"` // DEPRECATED: use two-phase registration
 	SecretKey     string                   `json:"secretKey,omitempty"`   // DEPRECATED: secrets only from /brokers/join
 }
@@ -3490,7 +3490,7 @@ func (s *Server) createProjectGroup(ctx context.Context, project *store.Project)
 		Name:      project.Name + " Agents",
 		Slug:      agentsSlug,
 		GroupType: store.GroupTypeProjectAgents,
-		ProjectID:   project.ID,
+		ProjectID: project.ID,
 		CreatedBy: project.CreatedBy,
 	}
 	if err := s.store.CreateGroup(ctx, projectGroup); err != nil {
@@ -3534,7 +3534,7 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 		Name:      project.Name + " Members",
 		Slug:      membersSlug,
 		GroupType: store.GroupTypeExplicit,
-		ProjectID:   project.ID,
+		ProjectID: project.ID,
 		OwnerID:   project.OwnerID,
 		CreatedBy: project.CreatedBy,
 	}
@@ -3752,10 +3752,10 @@ func (s *Server) initHubNativeProject(project *store.Project) error {
 
 	// Write hub connection settings into the seeded settings file.
 	settingsUpdates := map[string]string{
-		"hub.enabled":  "true",
-		"hub.endpoint": s.config.HubEndpoint,
-		"hub.projectId":  project.ID,
-		"project_id":     project.ID,
+		"hub.enabled":   "true",
+		"hub.endpoint":  s.config.HubEndpoint,
+		"hub.projectId": project.ID,
+		"project_id":    project.ID,
 	}
 	for key, value := range settingsUpdates {
 		if err := config.UpdateSetting(scionDir, key, value, false); err != nil {
@@ -3806,10 +3806,10 @@ func (s *Server) cloneSharedWorkspaceProject(ctx context.Context, project *store
 
 	// Write hub connection settings
 	settingsUpdates := map[string]string{
-		"hub.enabled":  "true",
-		"hub.endpoint": s.config.HubEndpoint,
-		"hub.projectId":  project.ID,
-		"project_id":     project.ID,
+		"hub.enabled":   "true",
+		"hub.endpoint":  s.config.HubEndpoint,
+		"hub.projectId": project.ID,
+		"project_id":    project.ID,
 	}
 	for key, value := range settingsUpdates {
 		if err := config.UpdateSetting(scionDir, key, value, false); err != nil {
@@ -4129,7 +4129,7 @@ func (s *Server) handleProjectRegister(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		provider := &store.ProjectProvider{
-			ProjectID:    project.ID,
+			ProjectID:  project.ID,
 			BrokerID:   broker.ID,
 			BrokerName: broker.Name,
 			LocalPath:  localPath,
@@ -4225,7 +4225,7 @@ func (s *Server) handleProjectRegister(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		provider := &store.ProjectProvider{
-			ProjectID:    project.ID,
+			ProjectID:  project.ID,
 			BrokerID:   broker.ID,
 			BrokerName: broker.Name,
 			LocalPath:  localPath,
@@ -4612,7 +4612,7 @@ func (s *Server) listProjectAgents(w http.ResponseWriter, r *http.Request, proje
 	query := r.URL.Query()
 
 	filter := store.AgentFilter{
-		ProjectID:         projectID,
+		ProjectID:       projectID,
 		RuntimeBrokerID: query.Get("runtimeBrokerId"),
 		Phase:           query.Get("phase"),
 		IncludeDeleted:  query.Get("includeDeleted") == "true",
@@ -5409,9 +5409,9 @@ func (s *Server) listRuntimeBrokers(w http.ResponseWriter, r *http.Request) {
 
 	projectID := query.Get("projectId")
 	filter := store.RuntimeBrokerFilter{
-		Status:  query.Get("status"),
+		Status:    query.Get("status"),
 		ProjectID: projectID,
-		Name:    query.Get("name"),
+		Name:      query.Get("name"),
 	}
 
 	limit := 50
@@ -6102,11 +6102,11 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 
 // BrokerProjectInfo describes a project from a broker's perspective.
 type BrokerProjectInfo struct {
-	ProjectID    string `json:"projectId"`
-	ProjectName  string `json:"projectName"`
-	GitRemote  string `json:"gitRemote,omitempty"`
-	AgentCount int    `json:"agentCount"`
-	LocalPath  string `json:"localPath,omitempty"`
+	ProjectID   string `json:"projectId"`
+	ProjectName string `json:"projectName"`
+	GitRemote   string `json:"gitRemote,omitempty"`
+	AgentCount  int    `json:"agentCount"`
+	LocalPath   string `json:"localPath,omitempty"`
 }
 
 // ListBrokerProjectsResponse is the response for listing projects a broker provides.
@@ -6135,7 +6135,7 @@ func (s *Server) getBrokerProjects(w http.ResponseWriter, r *http.Request, broke
 	projects := make([]BrokerProjectInfo, 0, len(providers))
 	for _, p := range providers {
 		info := BrokerProjectInfo{
-			ProjectID:   p.ProjectID,
+			ProjectID: p.ProjectID,
 			LocalPath: p.LocalPath,
 		}
 
@@ -6147,7 +6147,7 @@ func (s *Server) getBrokerProjects(w http.ResponseWriter, r *http.Request, broke
 
 		// Count agents for this project on this broker
 		agentResult, err := s.store.ListAgents(ctx, store.AgentFilter{
-			ProjectID:         p.ProjectID,
+			ProjectID:       p.ProjectID,
 			RuntimeBrokerID: brokerID,
 		}, store.ListOptions{Limit: 0})
 		if err == nil {
@@ -6156,10 +6156,11 @@ func (s *Server) getBrokerProjects(w http.ResponseWriter, r *http.Request, broke
 
 		projects = append(projects, info)
 	}
-writeJSON(w, http.StatusOK, ListBrokerProjectsResponse{
-	Projects: projects,
-})
+	writeJSON(w, http.StatusOK, ListBrokerProjectsResponse{
+		Projects: projects,
+	})
 }
+
 // ============================================================================
 // Template Endpoints
 // ============================================================================
@@ -6198,9 +6199,9 @@ func (s *Server) listTemplates(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 
 	filter := store.TemplateFilter{
-		Scope:   query.Get("scope"),
+		Scope:     query.Get("scope"),
 		ProjectID: query.Get("projectId"),
-		Harness: query.Get("harness"),
+		Harness:   query.Get("harness"),
 	}
 
 	limit := 50
@@ -7843,7 +7844,7 @@ func (s *Server) autoLinkProviders(ctx context.Context, project *store.Project) 
 
 	for _, autoBroker := range autoProviders.Items {
 		provider := &store.ProjectProvider{
-			ProjectID:    project.ID,
+			ProjectID:  project.ID,
 			BrokerID:   autoBroker.ID,
 			BrokerName: autoBroker.Name,
 			Status:     autoBroker.Status,
@@ -7961,7 +7962,7 @@ func (s *Server) addProjectProvider(w http.ResponseWriter, r *http.Request, proj
 
 	// Create provider record
 	provider := &store.ProjectProvider{
-		ProjectID:    projectID,
+		ProjectID:  projectID,
 		BrokerID:   broker.ID,
 		BrokerName: broker.Name,
 		LocalPath:  req.LocalPath,
@@ -8688,7 +8689,7 @@ func (s *Server) createNotifySubscription(ctx context.Context, agentID, projectI
 		AgentID:           agentID,
 		SubscriberType:    notifySubscriberType,
 		SubscriberID:      notifySubscriberID,
-		ProjectID:           projectID,
+		ProjectID:         projectID,
 		TriggerActivities: []string{"COMPLETED", "WAITING_FOR_INPUT", "LIMITS_EXCEEDED", "STALLED", "ERROR"},
 		CreatedAt:         time.Now(),
 		CreatedBy:         createdBy,
@@ -8950,7 +8951,7 @@ func (s *Server) resolveRuntimeBroker(ctx context.Context, w http.ResponseWriter
 		broker, err := s.findBrokerByIDOrSlug(ctx, requestedBrokerID)
 		if err == nil && broker != nil {
 			provider := &store.ProjectProvider{
-				ProjectID:    project.ID,
+				ProjectID:  project.ID,
 				BrokerID:   broker.ID,
 				BrokerName: broker.Name,
 				Status:     broker.Status,

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -2312,21 +2312,30 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 				return
 			}
 
-			newPhase := string(state.PhaseRunning)
-			statusUpdate := store.AgentStatusUpdate{
-				Phase: newPhase,
-			}
+			// Set phase to 'starting' while we wait for readiness.
+			statusUpdate := store.AgentStatusUpdate{Phase: string(state.PhaseStarting)}
 			if err := s.store.UpdateAgentStatus(ctx, id, statusUpdate); err != nil {
 				writeErrorFromErr(w, err, "")
 				return
 			}
-			agent.Phase = newPhase
+			agent.Phase = string(state.PhaseStarting)
 			s.events.PublishAgentStatus(ctx, agent)
 
 			if err := s.waitForAgentReady(ctx, id, 15*time.Second); err != nil {
+				// On failure, set agent to an error state for clarity.
+				_ = s.store.UpdateAgentStatus(ctx, id, store.AgentStatusUpdate{Phase: string(state.PhaseError), Message: "Failed to become ready after wake"})
 				RuntimeError(w, "Agent resumed but did not become ready: "+err.Error())
 				return
 			}
+
+			// Agent is ready, set phase to 'running'.
+			statusUpdate = store.AgentStatusUpdate{Phase: string(state.PhaseRunning)}
+			if err := s.store.UpdateAgentStatus(ctx, id, statusUpdate); err != nil {
+				writeErrorFromErr(w, err, "")
+				return
+			}
+			agent.Phase = string(state.PhaseRunning)
+			s.events.PublishAgentStatus(ctx, agent)
 
 		case state.PhaseRunning:
 			// no-op

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -2209,6 +2209,9 @@ type MessageRequest struct {
 	// Notify subscribes the sender to status notifications for this agent
 	// (COMPLETED, WAITING_FOR_INPUT, LIMITS_EXCEEDED, STALLED, ERROR).
 	Notify bool `json:"notify,omitempty"`
+
+	// Wake resumes a suspended agent before delivering the message.
+	Wake bool `json:"wake,omitempty"`
 }
 
 func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id string) {
@@ -2285,6 +2288,64 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 	if err != nil {
 		writeErrorFromErr(w, err, "")
 		return
+	}
+
+	// Wake handling: if requested, resume a suspended agent before message delivery.
+	if req.Wake {
+		switch state.Phase(agent.Phase) {
+		case state.PhaseSuspended:
+			if !s.checkBrokerAvailability(w, r, agent) {
+				return
+			}
+			dispatcher := s.GetDispatcher()
+			if dispatcher == nil {
+				ServiceNotReady(w, "Dispatch not available — server may still be starting up")
+				return
+			}
+			if agent.RuntimeBrokerID == "" {
+				ServiceNotReady(w, "Agent has no runtime broker assigned")
+				return
+			}
+
+			if err := dispatcher.DispatchAgentStart(ctx, agent, ""); err != nil {
+				RuntimeError(w, "Failed to wake agent: "+err.Error())
+				return
+			}
+
+			newPhase := string(state.PhaseRunning)
+			statusUpdate := store.AgentStatusUpdate{
+				Phase: newPhase,
+			}
+			if err := s.store.UpdateAgentStatus(ctx, id, statusUpdate); err != nil {
+				writeErrorFromErr(w, err, "")
+				return
+			}
+			agent.Phase = newPhase
+			s.events.PublishAgentStatus(ctx, agent)
+
+			if err := s.waitForAgentReady(ctx, id, 15*time.Second); err != nil {
+				RuntimeError(w, "Agent resumed but did not become ready: "+err.Error())
+				return
+			}
+
+		case state.PhaseRunning:
+			// no-op
+
+		case state.PhaseStopped:
+			writeError(w, http.StatusBadRequest, ErrCodeValidationError,
+				"Agent is stopped, not suspended — use 'scion start' to start a fresh session", nil)
+			return
+
+		case state.PhaseError:
+			writeError(w, http.StatusBadRequest, ErrCodeValidationError,
+				"Agent is in error state — use 'scion start' to restart", nil)
+			return
+
+		default:
+			writeError(w, http.StatusBadRequest, ErrCodeValidationError,
+				fmt.Sprintf("Agent is not yet running (phase: %s) — wait for it to reach running state", agent.Phase), nil)
+			return
+		}
 	}
 
 	// Populate recipient slug and ID from the resolved agent.

--- a/pkg/hub/wake.go
+++ b/pkg/hub/wake.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+)
+
+// waitForAgentReady polls the agent store until the agent's Activity field
+// indicates the harness has initialized after a resume, or until timeout.
+func (s *Server) waitForAgentReady(ctx context.Context, agentID string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for agent to become ready")
+		case <-ticker.C:
+			agent, err := s.store.GetAgent(ctx, agentID)
+			if err != nil {
+				return fmt.Errorf("failed to check agent status: %w", err)
+			}
+
+			phase := state.Phase(agent.Phase)
+			if phase != state.PhaseRunning {
+				return fmt.Errorf("agent entered unexpected phase %q while waiting for readiness", agent.Phase)
+			}
+
+			if agent.Activity != "" {
+				return nil // Harness has reported its first status
+			}
+		}
+	}
+}

--- a/pkg/hub/wake.go
+++ b/pkg/hub/wake.go
@@ -42,7 +42,7 @@ func (s *Server) waitForAgentReady(ctx context.Context, agentID string, timeout 
 			}
 
 			phase := state.Phase(agent.Phase)
-			if phase != state.PhaseRunning {
+			if phase != state.PhaseStarting && phase != state.PhaseRunning {
 				return fmt.Errorf("agent entered unexpected phase %q while waiting for readiness", agent.Phase)
 			}
 

--- a/pkg/hub/wake_test.go
+++ b/pkg/hub/wake_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createWakeTestFixtures creates a project, broker, project-provider and agent
+// with the given phase. It returns the server, store, and agent for further
+// assertions. The broker is always online so checkBrokerAvailability passes.
+func createWakeTestFixtures(t *testing.T, agentPhase string) (*Server, store.Store, *store.Agent) {
+	t.Helper()
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:   "project-wake-" + agentPhase,
+		Name: "Wake Test Project",
+		Slug: "wake-test-project-" + agentPhase,
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	broker := &store.RuntimeBroker{
+		ID:     "broker-wake-" + agentPhase,
+		Name:   "Wake Test Broker",
+		Slug:   "wake-test-broker-" + agentPhase,
+		Status: store.BrokerStatusOnline,
+	}
+	require.NoError(t, s.CreateRuntimeBroker(ctx, broker))
+
+	require.NoError(t, s.AddProjectProvider(ctx, &store.ProjectProvider{
+		ProjectID:  project.ID,
+		BrokerID:   broker.ID,
+		BrokerName: broker.Name,
+		Status:     store.BrokerStatusOnline,
+	}))
+
+	agent := &store.Agent{
+		ID:              "agent-wake-" + agentPhase,
+		Slug:            "agent-wake-" + agentPhase,
+		Name:            "Wake Agent",
+		ProjectID:       project.ID,
+		RuntimeBrokerID: broker.ID,
+		Phase:           agentPhase,
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	return srv, s, agent
+}
+
+// TestHandleAgentMessage_WakeStopped verifies that sending a wake message to
+// a stopped agent returns a 400 error.
+func TestHandleAgentMessage_WakeStopped(t *testing.T) {
+	srv, _, agent := createWakeTestFixtures(t, string(state.PhaseStopped))
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/agents/"+agent.ID+"/message", map[string]interface{}{
+		"message": "hello",
+		"wake":    true,
+	})
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Agent is stopped")
+}
+
+// TestHandleAgentMessage_WakeError verifies that sending a wake message to
+// an agent in error state returns a 400 error.
+func TestHandleAgentMessage_WakeError(t *testing.T) {
+	srv, _, agent := createWakeTestFixtures(t, string(state.PhaseError))
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/agents/"+agent.ID+"/message", map[string]interface{}{
+		"message": "hello",
+		"wake":    true,
+	})
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Agent is in error state")
+}
+
+// TestHandleAgentMessage_WakeRunning verifies that sending a wake message to
+// an already-running agent is a no-op (the message is delivered normally).
+func TestHandleAgentMessage_WakeRunning(t *testing.T) {
+	srv, _, agent := createWakeTestFixtures(t, string(state.PhaseRunning))
+
+	disp := &recordingDispatcher{}
+	srv.SetDispatcher(disp)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/agents/"+agent.ID+"/message", map[string]interface{}{
+		"message": "hello after wake noop",
+		"wake":    true,
+	})
+
+	assert.Equal(t, http.StatusOK, rec.Code, "response body: %s", rec.Body.String())
+
+	calls := disp.getCalls()
+	require.Len(t, calls, 1, "expected message to be dispatched")
+	assert.Equal(t, "hello after wake noop", calls[0].Message)
+}
+
+// TestHandleAgentMessage_WakeUnknownPhase verifies that sending a wake message
+// to an agent in an intermediate phase (e.g. provisioning) returns a 400 error.
+func TestHandleAgentMessage_WakeUnknownPhase(t *testing.T) {
+	srv, _, agent := createWakeTestFixtures(t, string(state.PhaseProvisioning))
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/agents/"+agent.ID+"/message", map[string]interface{}{
+		"message": "hello",
+		"wake":    true,
+	})
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Agent is not yet running")
+}
+
+// TestWaitForAgentReady_Timeout verifies that waitForAgentReady returns a
+// timeout error when the agent never reports activity.
+func TestWaitForAgentReady_Timeout(t *testing.T) {
+	srv, _, agent := createWakeTestFixtures(t, string(state.PhaseRunning))
+
+	ctx := context.Background()
+	err := srv.waitForAgentReady(ctx, agent.ID, 100*time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out waiting for agent to become ready")
+}
+
+// TestWaitForAgentReady_ActivityReported verifies that waitForAgentReady
+// returns successfully once the agent's Activity field is non-empty.
+func TestWaitForAgentReady_ActivityReported(t *testing.T) {
+	srv, s, agent := createWakeTestFixtures(t, string(state.PhaseRunning))
+	ctx := context.Background()
+
+	// In a goroutine, update the agent's activity after a short delay.
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		_ = s.UpdateAgentStatus(ctx, agent.ID, store.AgentStatusUpdate{
+			Activity: "idle",
+		})
+	}()
+
+	err := srv.waitForAgentReady(ctx, agent.ID, 2*time.Second)
+	require.NoError(t, err)
+}
+
+// TestWaitForAgentReady_UnexpectedPhase verifies that waitForAgentReady
+// returns an error when the agent transitions to an unexpected phase.
+func TestWaitForAgentReady_UnexpectedPhase(t *testing.T) {
+	srv, s, agent := createWakeTestFixtures(t, string(state.PhaseRunning))
+	ctx := context.Background()
+
+	// In a goroutine, change the agent's phase to stopped after a short delay.
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		_ = s.UpdateAgentStatus(ctx, agent.ID, store.AgentStatusUpdate{
+			Phase: string(state.PhaseStopped),
+		})
+	}()
+
+	err := srv.waitForAgentReady(ctx, agent.ID, 2*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected phase")
+}

--- a/pkg/hub/wake_test.go
+++ b/pkg/hub/wake_test.go
@@ -136,7 +136,7 @@ func TestHandleAgentMessage_WakeUnknownPhase(t *testing.T) {
 // TestWaitForAgentReady_Timeout verifies that waitForAgentReady returns a
 // timeout error when the agent never reports activity.
 func TestWaitForAgentReady_Timeout(t *testing.T) {
-	srv, _, agent := createWakeTestFixtures(t, string(state.PhaseRunning))
+	srv, _, agent := createWakeTestFixtures(t, string(state.PhaseStarting))
 
 	ctx := context.Background()
 	err := srv.waitForAgentReady(ctx, agent.ID, 100*time.Millisecond)
@@ -147,7 +147,7 @@ func TestWaitForAgentReady_Timeout(t *testing.T) {
 // TestWaitForAgentReady_ActivityReported verifies that waitForAgentReady
 // returns successfully once the agent's Activity field is non-empty.
 func TestWaitForAgentReady_ActivityReported(t *testing.T) {
-	srv, s, agent := createWakeTestFixtures(t, string(state.PhaseRunning))
+	srv, s, agent := createWakeTestFixtures(t, string(state.PhaseStarting))
 	ctx := context.Background()
 
 	// In a goroutine, update the agent's activity after a short delay.
@@ -165,7 +165,7 @@ func TestWaitForAgentReady_ActivityReported(t *testing.T) {
 // TestWaitForAgentReady_UnexpectedPhase verifies that waitForAgentReady
 // returns an error when the agent transitions to an unexpected phase.
 func TestWaitForAgentReady_UnexpectedPhase(t *testing.T) {
-	srv, s, agent := createWakeTestFixtures(t, string(state.PhaseRunning))
+	srv, s, agent := createWakeTestFixtures(t, string(state.PhaseStarting))
 	ctx := context.Background()
 
 	// In a goroutine, change the agent's phase to stopped after a short delay.

--- a/pkg/hubclient/agents.go
+++ b/pkg/hubclient/agents.go
@@ -67,7 +67,8 @@ type AgentService interface {
 
 	// SendStructuredMessage sends a structured message to an agent.
 	// If notify is true, the sender subscribes to status notifications for the target agent.
-	SendStructuredMessage(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt bool, notify bool) error
+	// If wake is true, a suspended agent will be resumed before delivering the message.
+	SendStructuredMessage(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt bool, notify bool, wake bool) error
 
 	// BroadcastMessage broadcasts a structured message to all running agents in the project.
 	// Uses the Hub's broadcast endpoint which routes through the message broker (if available)
@@ -472,15 +473,18 @@ func (s *agentService) SendMessage(ctx context.Context, agentID string, message 
 
 // SendStructuredMessage sends a structured message to an agent.
 // If notify is true, the sender subscribes to status notifications for the target agent.
-func (s *agentService) SendStructuredMessage(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt bool, notify bool) error {
+// If wake is true, a suspended agent will be resumed before delivering the message.
+func (s *agentService) SendStructuredMessage(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt bool, notify bool, wake bool) error {
 	body := struct {
 		StructuredMessage *messages.StructuredMessage `json:"structured_message"`
 		Interrupt         bool                        `json:"interrupt,omitempty"`
 		Notify            bool                        `json:"notify,omitempty"`
+		Wake              bool                        `json:"wake,omitempty"`
 	}{
 		StructuredMessage: msg,
 		Interrupt:         interrupt,
 		Notify:            notify,
+		Wake:              wake,
 	}
 	resp, err := s.c.post(ctx, s.agentPath(agentID)+"/message", body, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary

Implements the `--wake` flag for `scion message` (Issue #26), which atomically resumes a suspended agent and delivers a message in a single operation.

- **Interface plumbing**: Added `wake bool` parameter to `SendStructuredMessage` in `pkg/hubclient/agents.go` interface and implementation, updated all existing callers to pass `false`
- **CLI flag + validation**: Added `--wake` / `-w` flag to `cmd/message.go` with validation against incompatible flags (`--broadcast`, `--all`, `--in`, `--at`, `--raw`, user recipients)
- **Hub handler wake logic**: In `handleAgentMessage()`, when `wake=true`: checks agent phase, dispatches start for suspended agents, waits for readiness, then delivers message. Running agents pass through normally. Stopped/error/intermediate phases return 400 errors
- **Readiness polling helper**: Added `waitForAgentReady()` in `pkg/hub/wake.go` that polls agent activity at 500ms intervals until the harness reports its first status, with configurable timeout
- **Tests**: Comprehensive test coverage for flag validation, hub handler wake logic (stopped, error, running, unknown phase), and readiness polling (timeout, activity reported, unexpected phase)

Design doc: `.design/wake-flag-design.md` (on `scion/design-wake` branch)



## Test plan
- [x] All wake-specific tests pass (`TestWakeFlagValidation`, `TestSendMessageViaHub_WakePassedThrough`, `TestHandleAgentMessage_Wake*`, `TestWaitForAgentReady_*`)
- [x] `go build ./...` succeeds
- [x] `go vet` clean on all modified packages
- [x] gofmt clean on all modified files
- [ ] Integration test: `scion suspend <agent>` → `scion message --wake <agent> "task"` → verify agent resumes and receives message