### PR TITLE
fix: install to /usr/local/bin by default and warn if not in PATH

### DIFF
--- a/.design/project-log/2026-05-12-fix-issue-64-install-path.md
+++ b/.design/project-log/2026-05-12-fix-issue-64-install-path.md
@@ -1,0 +1,25 @@
+# Fix Issue #64: make install PATH problems
+
+**Date:** 2026-05-12
+**PR:** #65
+**Branch:** scion/fix-issue-64
+
+## Summary
+
+Updated the Makefile `install` target to address issue #64 where the default install location (`~/.local/bin`) was often not in users' PATH.
+
+## Changes
+
+- Changed default install location from `~/.local/bin` to `/usr/local/bin` via configurable `PREFIX` variable
+- Added post-install PATH check that warns users if the install directory is not in `$PATH`
+- Added verification hint (`scion --version`) in post-install output
+- Switched from `mkdir -p` to `install -d` for standard directory creation
+
+## Usage
+
+- `make install` — installs to `/usr/local/bin` (may need `sudo`)
+- `make install PREFIX=~/.local` — installs to `~/.local/bin` for user-local
+
+## Observations
+
+- Pre-existing CI issues exist on `main`: Go formatting failures across 100+ files and a missing `entc.MigrateGroveToProjectData` symbol in `cmd/server_foreground.go`. These are unrelated to this change.

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BINARY        := scion
 BUILD_DIR     := ./build
 CONTAINER_DIR := ./.build/container
 PREFIX        ?= /usr/local
+DESTDIR       ?=
 INSTALL_DIR   := $(PREFIX)/bin
 MAIN_PKG      := ./cmd/scion
 LDFLAGS            := $(shell ./hack/version.sh)
@@ -29,16 +30,16 @@ build:
 
 ## install: Build and install the binary (default: /usr/local/bin, override with PREFIX=~/.local)
 install: build
-	@echo "Installing $(BINARY) to $(INSTALL_DIR)..."
-	@install -d $(INSTALL_DIR)
-	@install $(BUILD_DIR)/$(BINARY) $(INSTALL_DIR)/$(BINARY)
+	@echo "Installing $(BINARY) to $(DESTDIR)$(INSTALL_DIR)..."
+	@mkdir -p $(DESTDIR)$(INSTALL_DIR)
+	@install $(BUILD_DIR)/$(BINARY) $(DESTDIR)$(INSTALL_DIR)/$(BINARY)
 	@echo ""
-	@echo "✔ Installed $(BINARY) to $(INSTALL_DIR)/$(BINARY)"
+	@echo "✔ Installed $(BINARY) to $(DESTDIR)$(INSTALL_DIR)/$(BINARY)"
 	@echo ""
 	@echo "  Run 'scion --version' to verify."
 	@echo ""
 	@case ":$$PATH:" in \
-		*":$(INSTALL_DIR):"*) ;; \
+		*":$(INSTALL_DIR):"* | *":$(INSTALL_DIR)/:"*) ;; \
 		*) echo "  ⚠ WARNING: $(INSTALL_DIR) is not in your PATH."; \
 		   echo "  Add it with:"; \
 		   echo ""; \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 BINARY        := scion
 BUILD_DIR     := ./build
 CONTAINER_DIR := ./.build/container
-INSTALL_DIR   := $(HOME)/.local/bin
+PREFIX        ?= /usr/local
+INSTALL_DIR   := $(PREFIX)/bin
 MAIN_PKG      := ./cmd/scion
 LDFLAGS            := $(shell ./hack/version.sh)
 SCIONTOOL_LDFLAGS  := $(shell ./hack/version.sh github.com/GoogleCloudPlatform/scion/cmd/sciontool/commands)
@@ -26,12 +27,24 @@ build:
 	@go build -buildvcs=false -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) $(MAIN_PKG)
 	@echo "Binary: $(BUILD_DIR)/$(BINARY)"
 
-## install: Build and install the binary to ~/.local/bin
+## install: Build and install the binary (default: /usr/local/bin, override with PREFIX=~/.local)
 install: build
 	@echo "Installing $(BINARY) to $(INSTALL_DIR)..."
-	@mkdir -p $(INSTALL_DIR)
+	@install -d $(INSTALL_DIR)
 	@install $(BUILD_DIR)/$(BINARY) $(INSTALL_DIR)/$(BINARY)
-	@echo "Installed: $(INSTALL_DIR)/$(BINARY)"
+	@echo ""
+	@echo "✔ Installed $(BINARY) to $(INSTALL_DIR)/$(BINARY)"
+	@echo ""
+	@echo "  Run 'scion --version' to verify."
+	@echo ""
+	@case ":$$PATH:" in \
+		*":$(INSTALL_DIR):"*) ;; \
+		*) echo "  ⚠ WARNING: $(INSTALL_DIR) is not in your PATH."; \
+		   echo "  Add it with:"; \
+		   echo ""; \
+		   echo "    export PATH=\"$(INSTALL_DIR):\$$PATH\""; \
+		   echo "" ;; \
+	esac
 
 ## test: Run all tests
 test:


### PR DESCRIPTION
## Summary
- Changes default install location from `~/.local/bin` to `/usr/local/bin` via a configurable `PREFIX` variable
- Adds a post-install PATH check that warns if the install directory is not in the user's `/Users/ptone/google-cloud-sdk/bin:/Users/ptone/.antigravity/antigravity/bin:/Users/ptone/.local/state/fnm_multishells/5153_1778345903398/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/ptone/.local/bin:/Users/ptone/.npm-global/bin:/Users/ptone/UNIX/bin:/Users/ptone/Projects/code/go/bin:/Users/ptone/.codeium/windsurf/bin:/Users/ptone/.jetski/jetski/bin:/Users/ptone/dev/flutter/bin:/Users/ptone/.antigravity-insiders/antigravity-insiders/bin:/Users/ptone/.bun/bin:/Users/ptone/Library/pnpm:/Users/ptone/.pub-cache/bin:/Users/ptone/.rustup/toolchains/stable-aarch64-apple-darwin/bin:/usr/local/bin:/usr/local/sbin:/bin:/usr/bin:/usr/sbin:/sbin:/usr/local/git/git-google/bin:/usr/local/git/current/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/usr/local/go/bin:/opt/podman/bin:/Users/ptone/.cargo/bin:/Applications/Ghostty.app/Contents/MacOS`
- Prints a clear post-install verification hint (`scion --version`)
- Uses `install -d` for standard directory creation

Users can now:
- `make install` — installs to `/usr/local/bin` (may need `sudo`)
- `make install PREFIX=~/.local` — installs to `~/.local/bin` for user-local


## Test plan
- [x] Verified `make install PREFIX=/tmp/test` installs binary correctly
- [x] Verified PATH warning appears when install dir is not in PATH
- [x] Verified `make -n install` (dry-run) shows correct default `/usr/local/bin` target
- [x] Verified `make build` passes