### PR TITLE
fix: rename ActivityIdle to ActivityWorking for clearer state reporting

### DIFF
--- a/.design/project-log/2026-05-13-pr59-review-fixes.md
+++ b/.design/project-log/2026-05-13-pr59-review-fixes.md
@@ -1,0 +1,33 @@
+# PR #59 Review Feedback Fixes
+
+**Date:** 2026-05-13
+**PR:** #59 (scion/fix-issue-36) - Rename idle state to working
+**Commit:** a1602edb
+
+## Summary
+
+Addressed review feedback on PR #59 from code review.
+
+## Issues Addressed
+
+### Medium: Revert old migration modifications (migrationV20, migrationV21)
+
+The PR had modified SQL strings in existing migration functions (`migrationV20`, `migrationV21`) to change `idle` to `working`. Migrations should be treated as immutable historical records. Since `migrationV51` (newly added by the PR) already handles the idle-to-working data transformation at runtime, the older migrations were reverted to their original values.
+
+**Changes:**
+- `migrationV20`: Restored `activity = 'idle'` for `status = 'running'` and `status = 'idle'` backfill lines
+- `migrationV21`: Restored original backfill line with `'idle'` in the IN clause, removed the separate `'working'` mapping line
+
+### Already Handled: COMPLETED mapping in translate.go (HIGH)
+
+The reviewer flagged a missing `COMPLETED` case in `MapActivityToTaskState()`. This was already present in the code (line 90-91) but outside the diff context window shown to the reviewer.
+
+### Already Handled: COMPLETED test case in translate_test.go (MEDIUM)
+
+The reviewer suggested adding a test for `COMPLETED` mapping. This test already existed (line 32).
+
+## Verification
+
+- `go build ./...` - passed
+- `go test ./pkg/store/...` - passed
+- `go test ./extras/scion-a2a-bridge/internal/bridge/...` - passed

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -385,7 +385,7 @@ func formatLastSeen(t time.Time) string {
 // formatLastActivity formats a status and timestamp as a combined "activity, time ago" string.
 func formatLastActivity(status string, t time.Time) string {
 	timePart := formatLastSeen(t)
-	if status == "" || status == "IDLE" || status == "idle" {
+	if status == "" || status == "WORKING" || status == "working" {
 		return timePart
 	}
 	if timePart == "-" {

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -82,8 +82,8 @@ func TestFormatLastActivity(t *testing.T) {
 		{"activity with time", "thinking", now.Add(-30 * time.Second), "thinking, 30 seconds ago"},
 		{"phase with time", "stopped", now.Add(-2 * time.Hour), "stopped, 2 hours ago"},
 		{"empty status with time", "", now.Add(-5 * time.Minute), "5 minutes ago"},
-		{"IDLE status with time", "IDLE", now.Add(-5 * time.Minute), "5 minutes ago"},
-		{"idle status with time", "idle", now.Add(-5 * time.Minute), "5 minutes ago"},
+		{"WORKING status with time", "WORKING", now.Add(-5 * time.Minute), "5 minutes ago"},
+		{"working status with time", "working", now.Add(-5 * time.Minute), "5 minutes ago"},
 		{"activity with zero time", "running", time.Time{}, "running"},
 		{"empty status with zero time", "", time.Time{}, "-"},
 	}

--- a/cmd/sciontool/commands/hook_test.go
+++ b/cmd/sciontool/commands/hook_test.go
@@ -106,7 +106,7 @@ func TestProcessHookData_SessionEvents(t *testing.T) {
 	statusData, _ := os.ReadFile(statusPath)
 	var status map[string]interface{}
 	json.Unmarshal(statusData, &status)
-	assert.Equal(t, "idle", status["activity"]) // session-start sets idle activity
+	assert.Equal(t, "working", status["activity"]) // session-start sets working activity
 	assert.Nil(t, status["status"])             // legacy field removed
 
 	// Test SessionEnd

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -466,10 +466,10 @@ func runInit(args []string) int {
 			hubCtx, hubCancel := context.WithTimeout(context.Background(), 10*time.Second)
 			startedAtStr := time.Now().UTC().Format(time.RFC3339)
 			zeroCount := 0
-			s := state.AgentState{Phase: state.PhaseRunning, Activity: state.ActivityIdle}
+			s := state.AgentState{Phase: state.PhaseRunning, Activity: state.ActivityWorking}
 			if err := hubClient.UpdateStatus(hubCtx, hub.StatusUpdate{
 				Phase:             state.PhaseRunning,
-				Activity:          state.ActivityIdle,
+				Activity:          state.ActivityWorking,
 				Status:            s.DisplayStatus(),
 				Message:           "Agent started",
 				StartedAt:         startedAtStr,

--- a/docs-site/src/content/docs/concepts.md
+++ b/docs-site/src/content/docs/concepts.md
@@ -61,7 +61,7 @@ Agent state uses a **layered model** with three dimensions:
   `created` → `provisioning` → `cloning` → `starting` → `running` → `stopping` → `stopped` (or `error`)
 
 - **Activity** — What the agent is doing within the `running` phase:
-  `idle`, `thinking`, `executing`, `waiting_for_input`, `blocked`, `completed`, `limits_exceeded`, `offline`
+  `working`, `thinking`, `executing`, `waiting_for_input`, `blocked`, `completed`, `limits_exceeded`, `offline`
 
 - **Detail** — Freeform context about the current activity (tool name, message, task summary).
 

--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -26,7 +26,7 @@ Most endpoints require a `Bearer` token in the `Authorization` header.
 
 Agent state uses a layered model:
 - **Phase**: Lifecycle stage (`created`, `provisioning`, `cloning`, `running`, `stopped`, `error`).
-- **Activity**: Runtime activity within the `running` phase (`idle`, `thinking`, `executing`, `waiting_for_input`, `completed`, `limits_exceeded`, `offline`). Note: `offline` occurs when an agent heartbeat has not been heard for some time, often due to an expired auth token that the agent failed to refresh.
+- **Activity**: Runtime activity within the `running` phase (`working`, `thinking`, `executing`, `waiting_for_input`, `completed`, `limits_exceeded`, `offline`). Note: `offline` occurs when an agent heartbeat has not been heard for some time, often due to an expired auth token that the agent failed to refresh.
 - **Detail**: Freeform context (tool name, message, task summary).
 
 #### Projects (`/api/v1/projects`)

--- a/examples/adk_scion_agent/callbacks.py
+++ b/examples/adk_scion_agent/callbacks.py
@@ -47,6 +47,6 @@ async def after_tool_callback(tool, args, tool_context, tool_response):
 
 
 async def after_agent_callback(callback_context):
-    """Agent turn complete — set activity to idle."""
-    sciontool.write_agent_status("idle")
+    """Agent turn complete — set activity to working."""
+    sciontool.write_agent_status("working")
     return None

--- a/examples/adk_scion_agent/sciontool.py
+++ b/examples/adk_scion_agent/sciontool.py
@@ -82,7 +82,7 @@ def write_agent_status(activity: str) -> None:
     blocked, completed, or limits_exceeded.
 
     Args:
-        activity: One of "thinking", "executing", "idle" (or other transient
+        activity: One of "thinking", "executing", "working" (or other transient
             activities). Values are lowercase to match scion's StatusHandler.
     """
     try:

--- a/extras/agent-viz/internal/logparser/parser.go
+++ b/extras/agent-viz/internal/logparser/parser.go
@@ -569,7 +569,7 @@ func extractEventsOpt(entries []GCPLogEntry, agents []AgentInfo, skipFileEvents 
 			Data: AgentStateEvent{
 				AgentID:  agentID,
 				Phase:    "running",
-				Activity: "idle",
+				Activity: "working",
 			},
 		})
 	}
@@ -597,7 +597,7 @@ func extractEventsOpt(entries []GCPLogEntry, agents []AgentInfo, skipFileEvents 
 					Data: AgentStateEvent{
 						AgentID:  aid,
 						Phase:    "running",
-						Activity: "idle",
+						Activity: "working",
 					},
 				})
 			case "agent.session.end":
@@ -625,7 +625,7 @@ func extractEventsOpt(entries []GCPLogEntry, agents []AgentInfo, skipFileEvents 
 					Timestamp: ts,
 					Data: AgentStateEvent{
 						AgentID:  aid,
-						Activity: "idle",
+						Activity: "working",
 					},
 				})
 			case "agent.tool.call":

--- a/extras/agent-viz/internal/playback/engine_test.go
+++ b/extras/agent-viz/internal/playback/engine_test.go
@@ -40,7 +40,7 @@ func TestNewEngine(t *testing.T) {
 				Data: logparser.AgentStateEvent{
 					AgentID:  "a1",
 					Phase:    "running",
-					Activity: "idle",
+					Activity: "working",
 				},
 			},
 			{
@@ -88,7 +88,7 @@ func TestPlaybackSpeed(t *testing.T) {
 			{
 				Type:      "agent_state",
 				Timestamp: "2026-03-22T16:30:01.000Z",
-				Data:      logparser.AgentStateEvent{AgentID: "a1", Activity: "idle"},
+				Data:      logparser.AgentStateEvent{AgentID: "a1", Activity: "working"},
 			},
 		},
 	}

--- a/extras/agent-viz/web/src/agents.ts
+++ b/extras/agent-viz/web/src/agents.ts
@@ -61,7 +61,7 @@ export class AgentRing {
         x: this.centerX + Math.cos(angle) * this.ringRadius,
         y: this.centerY + Math.sin(angle) * this.ringRadius,
         phase: 'created',
-        activity: 'idle',
+        activity: 'working',
         toolName: '',
         enterTime: Date.now(),
       });
@@ -99,7 +99,7 @@ export class AgentRing {
       x: this.centerX + Math.cos(angle) * this.ringRadius,
       y: this.centerY + Math.sin(angle) * this.ringRadius,
       phase: 'created',
-      activity: 'idle',
+      activity: 'working',
       toolName: '',
       enterTime: now,
     });

--- a/extras/agent-viz/web/src/icons.ts
+++ b/extras/agent-viz/web/src/icons.ts
@@ -19,7 +19,7 @@
 
 const ICON_PATHS: Record<string, { path: string; color: string; pulse?: boolean }> = {
   // Activity icons
-  idle: {
+  working: {
     path: 'M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16z',
     color: '#198754',
   },
@@ -102,5 +102,5 @@ export function getIconForState(
     return { path: icon.path, color: icon.color, pulse: icon.pulse ?? false };
   }
   // Default
-  return { path: ICON_PATHS.idle.path, color: ICON_PATHS.idle.color, pulse: false };
+  return { path: ICON_PATHS.working.path, color: ICON_PATHS.working.color, pulse: false };
 }

--- a/extras/agent-viz/web/src/main.ts
+++ b/extras/agent-viz/web/src/main.ts
@@ -224,7 +224,7 @@ function handleEventInstant(evt: PlaybackEvent): void {
       agentRing.updateState({
         agentId: lifecycle.agentId,
         phase: 'created',
-        activity: 'idle',
+        activity: 'working',
       });
       break;
     }
@@ -285,7 +285,7 @@ function handleEvent(evt: PlaybackEvent): void {
             agentRing.updateState({
               agentId: lifecycle.agentId,
               phase: 'created',
-              activity: 'idle',
+              activity: 'working',
             });
           }, 900); // BEAM_CHARGE + BEAM_TRAVEL duration
           break;
@@ -296,7 +296,7 @@ function handleEvent(evt: PlaybackEvent): void {
       agentRing.updateState({
         agentId: lifecycle.agentId,
         phase: 'created',
-        activity: 'idle',
+        activity: 'working',
       });
       break;
     }

--- a/extras/scion-a2a-bridge/internal/bridge/stream_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/stream_test.go
@@ -325,7 +325,7 @@ func TestBlockingTaskIgnoresActiveDispatch(t *testing.T) {
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 		Sender:    "agent:agent-a",
 		Recipient: "user:test-user",
-		Msg:       "IDLE",
+		Msg:       "WORKING",
 		Type:      messages.TypeStateChange,
 		Metadata:  map[string]string{"a2aTaskId": taskID},
 	}

--- a/extras/scion-a2a-bridge/internal/bridge/translate.go
+++ b/extras/scion-a2a-bridge/internal/bridge/translate.go
@@ -81,8 +81,8 @@ type TaskResult struct {
 // MapActivityToTaskState maps a Scion agent activity string to an A2A task state.
 func MapActivityToTaskState(activity string) string {
 	switch strings.ToUpper(activity) {
-	case "IDLE":
-		return TaskStateCompleted
+	case "WORKING":
+		return TaskStateWorking
 	case "THINKING", "EXECUTING":
 		return TaskStateWorking
 	case "WAITING_FOR_INPUT":

--- a/extras/scion-a2a-bridge/internal/bridge/translate_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/translate_test.go
@@ -25,7 +25,7 @@ func TestMapActivityToTaskState(t *testing.T) {
 		activity string
 		want     string
 	}{
-		{"IDLE", TaskStateCompleted},
+		{"WORKING", TaskStateWorking},
 		{"THINKING", TaskStateWorking},
 		{"EXECUTING", TaskStateWorking},
 		{"WAITING_FOR_INPUT", TaskStateInputRequired},
@@ -35,7 +35,7 @@ func TestMapActivityToTaskState(t *testing.T) {
 		{"LIMITS_EXCEEDED", TaskStateFailed},
 		{"OFFLINE", TaskStateFailed},
 		{"UNKNOWN_ACTIVITY", TaskStateWorking},
-		{"idle", TaskStateCompleted},
+		{"working", TaskStateWorking},
 	}
 
 	for _, tt := range tests {

--- a/pkg/agent/state/state.go
+++ b/pkg/agent/state/state.go
@@ -82,7 +82,7 @@ func (p Phase) Validate() error {
 type Activity string
 
 const (
-	ActivityIdle            Activity = "idle"
+	ActivityWorking         Activity = "working"
 	ActivityThinking        Activity = "thinking"
 	ActivityExecuting       Activity = "executing"
 	ActivityWaitingForInput Activity = "waiting_for_input"
@@ -96,7 +96,7 @@ const (
 
 // allActivities is the internal list; Activities() returns a copy.
 var allActivities = []Activity{
-	ActivityIdle,
+	ActivityWorking,
 	ActivityThinking,
 	ActivityExecuting,
 	ActivityWaitingForInput,

--- a/pkg/agent/state/state_test.go
+++ b/pkg/agent/state/state_test.go
@@ -77,7 +77,7 @@ func TestActivityIsValid(t *testing.T) {
 		want     bool
 	}{
 		// All 10 valid activities.
-		{ActivityIdle, true},
+		{ActivityWorking, true},
 		{ActivityThinking, true},
 		{ActivityExecuting, true},
 		{ActivityWaitingForInput, true},
@@ -113,8 +113,8 @@ func TestActivityIsValid(t *testing.T) {
 }
 
 func TestActivityValidate(t *testing.T) {
-	if err := ActivityIdle.Validate(); err != nil {
-		t.Errorf("ActivityIdle.Validate() returned unexpected error: %v", err)
+	if err := ActivityWorking.Validate(); err != nil {
+		t.Errorf("ActivityWorking.Validate() returned unexpected error: %v", err)
 	}
 	if err := Activity("").Validate(); err != nil {
 		t.Errorf("Activity(\"\").Validate() returned unexpected error: %v", err)
@@ -140,7 +140,7 @@ func TestActivityIsSticky(t *testing.T) {
 		{ActivityCompleted, true},
 		{ActivityLimitsExceeded, true},
 		{ActivityCrashed, true},
-		{ActivityIdle, false},
+		{ActivityWorking, false},
 		{ActivityThinking, false},
 		{ActivityExecuting, false},
 		{ActivityStalled, false},
@@ -168,7 +168,7 @@ func TestActivityIsPlatformSet(t *testing.T) {
 	}{
 		{ActivityStalled, true},
 		{ActivityOffline, true},
-		{ActivityIdle, false},
+		{ActivityWorking, false},
 		{ActivityThinking, false},
 		{ActivityExecuting, false},
 		{ActivityWaitingForInput, false},
@@ -199,7 +199,7 @@ func TestActivityIsTerminal(t *testing.T) {
 	}{
 		{ActivityCrashed, true},
 		{ActivityLimitsExceeded, true},
-		{ActivityIdle, false},
+		{ActivityWorking, false},
 		{ActivityThinking, false},
 		{ActivityExecuting, false},
 		{ActivityWaitingForInput, false},
@@ -298,7 +298,7 @@ func TestAgentStateValidate(t *testing.T) {
 	}{
 		{
 			name:    "valid running with activity",
-			state:   AgentState{Phase: PhaseRunning, Activity: ActivityIdle},
+			state:   AgentState{Phase: PhaseRunning, Activity: ActivityWorking},
 			wantErr: false,
 		},
 		{
@@ -323,7 +323,7 @@ func TestAgentStateValidate(t *testing.T) {
 		},
 		{
 			name:    "invalid: activity with suspended phase",
-			state:   AgentState{Phase: PhaseSuspended, Activity: ActivityIdle},
+			state:   AgentState{Phase: PhaseSuspended, Activity: ActivityWorking},
 			wantErr: true,
 		},
 		{
@@ -338,7 +338,7 @@ func TestAgentStateValidate(t *testing.T) {
 		},
 		{
 			name:    "invalid: non-terminal activity with stopped phase",
-			state:   AgentState{Phase: PhaseStopped, Activity: ActivityIdle},
+			state:   AgentState{Phase: PhaseStopped, Activity: ActivityWorking},
 			wantErr: true,
 		},
 		{

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -542,7 +542,7 @@ type AgentInfo struct {
 	// Status fields
 	ContainerStatus string       `json:"containerStatus,omitempty"` // Container status (e.g., Up 2 hours)
 	Phase           string       `json:"phase,omitempty"`           // Lifecycle phase (created, provisioning, running, stopped, error)
-	Activity        string       `json:"activity,omitempty"`        // Runtime activity (idle, thinking, executing, waiting_for_input, completed)
+	Activity        string       `json:"activity,omitempty"`        // Runtime activity (working, thinking, executing, waiting_for_input, completed)
 	Detail          *AgentDetail `json:"detail,omitempty"`          // Freeform context about the current activity
 
 	// Runtime configuration

--- a/pkg/hub/events_test.go
+++ b/pkg/hub/events_test.go
@@ -160,7 +160,7 @@ func TestChannelEventPublisher_PublishAgentCreated(t *testing.T) {
 		Slug:            "test-agent",
 		Template:        "claude",
 		Phase:           "created",
-		Activity:        "idle",
+		Activity:        "working",
 		ContainerStatus: "running",
 		Image:           "scion-claude:latest",
 		Runtime:         "docker",
@@ -180,7 +180,7 @@ func TestChannelEventPublisher_PublishAgentCreated(t *testing.T) {
 		if data.AgentID != "a1" || data.Name != "test-agent" || data.Template != "claude" {
 			t.Errorf("unexpected identity data: %+v", data)
 		}
-		if data.Phase != "created" || data.Activity != "idle" || data.ContainerStatus != "running" {
+		if data.Phase != "created" || data.Activity != "working" || data.ContainerStatus != "running" {
 			t.Errorf("unexpected status data: %+v", data)
 		}
 		if data.Image != "scion-claude:latest" || data.Runtime != "docker" || data.RuntimeBrokerID != "b1" {

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -5865,7 +5865,7 @@ func (p *brokerProjectHeartbeat) UnmarshalJSON(data []byte) error {
 // brokerAgentHeartbeat is per-agent status in a heartbeat.
 type brokerAgentHeartbeat struct {
 	Slug            string `json:"slug"`   // Agent's URL-safe identifier (name)
-	Status          string `json:"status"` // Session status (IDLE, THINKING, etc.)
+	Status          string `json:"status"` // Session status (WORKING, THINKING, etc.)
 	Phase           string `json:"phase,omitempty"`
 	Activity        string `json:"activity,omitempty"`
 	ContainerStatus string `json:"containerStatus,omitempty"`

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -76,7 +76,7 @@ func TestAgentStatusUpdate_Authorization(t *testing.T) {
 
 	t.Run("Agent 1 can update its own status", func(t *testing.T) {
 		status := store.AgentStatusUpdate{
-			Activity: "idle",
+			Activity: "working",
 			Message:  "Waiting for user input",
 		}
 		body, _ := json.Marshal(status)
@@ -92,7 +92,7 @@ func TestAgentStatusUpdate_Authorization(t *testing.T) {
 		// Verify update in store
 		updated, err := s.GetAgent(ctx, agent1.ID)
 		require.NoError(t, err)
-		assert.Equal(t, "idle", updated.Activity)
+		assert.Equal(t, "working", updated.Activity)
 		assert.Equal(t, "Waiting for user input", updated.Message)
 	})
 
@@ -3089,41 +3089,41 @@ func TestBrokerHeartbeat_StalledAgentRecoveredByNewActivity(t *testing.T) {
 	assert.Empty(t, updated.StalledFromActivity, "stalled_from_activity should be cleared on recovery")
 }
 
-func TestBrokerHeartbeat_StalledIdleAgentNotOverwrittenBySameActivity(t *testing.T) {
+func TestBrokerHeartbeat_StalledWorkingAgentNotOverwrittenBySameActivity(t *testing.T) {
 	srv, s := testServer(t)
 	ctx := context.Background()
 
-	project := &store.Project{ID: "project-stall-idle", Name: "Stall Idle Project", Slug: "stall-idle-project"}
+	project := &store.Project{ID: "project-stall-working", Name: "Stall Working Project", Slug: "stall-working-project"}
 	require.NoError(t, s.CreateProject(ctx, project))
 
 	broker := &store.RuntimeBroker{
-		ID: "broker-stall-idle", Name: "Stall Idle Broker", Slug: "stall-idle-broker",
+		ID: "broker-stall-working", Name: "Stall Working Broker", Slug: "stall-working-broker",
 		Status: store.BrokerStatusOnline,
 	}
 	require.NoError(t, s.CreateRuntimeBroker(ctx, broker))
 
 	agent := &store.Agent{
-		ID: "agent-stall-idle", Slug: "stall-idle-slug", Name: "Stall Idle Agent",
+		ID: "agent-stall-working", Slug: "stall-working-slug", Name: "Stall Working Agent",
 		ProjectID: project.ID, RuntimeBrokerID: broker.ID,
 		Phase: string(state.PhaseRunning),
 	}
 	require.NoError(t, s.CreateAgent(ctx, agent))
 
-	// Set agent to running+idle
+	// Set agent to running+working
 	require.NoError(t, s.UpdateAgentStatus(ctx, agent.ID, store.AgentStatusUpdate{
 		Phase:    string(state.PhaseRunning),
-		Activity: string(state.ActivityIdle),
+		Activity: string(state.ActivityWorking),
 	}))
 
-	// Simulate stalled detection: mark agent stalled with stalled_from_activity = idle
+	// Simulate stalled detection: mark agent stalled with stalled_from_activity = working
 	db := s.(*sqlite.SQLiteStore).DB()
 	staleActivity := time.Now().Add(-10 * time.Minute)
 	_, err := db.ExecContext(ctx,
-		"UPDATE agents SET activity = 'stalled', stalled_from_activity = 'idle', last_activity_event = ?, last_seen = ? WHERE id = ?",
+		"UPDATE agents SET activity = 'stalled', stalled_from_activity = 'working', last_activity_event = ?, last_seen = ? WHERE id = ?",
 		staleActivity, time.Now().Add(-10*time.Second), agent.ID)
 	require.NoError(t, err)
 
-	// Send heartbeat still reporting "idle" — should NOT clear the stall
+	// Send heartbeat still reporting "working" — should NOT clear the stall
 	hb := brokerHeartbeatRequest{
 		Status: "online",
 		Projects: []brokerProjectHeartbeat{{
@@ -3132,7 +3132,7 @@ func TestBrokerHeartbeat_StalledIdleAgentNotOverwrittenBySameActivity(t *testing
 			Agents: []brokerAgentHeartbeat{{
 				Slug:     agent.Slug,
 				Phase:    string(state.PhaseRunning),
-				Activity: "idle",
+				Activity: "working",
 			}},
 		}},
 	}
@@ -3141,8 +3141,8 @@ func TestBrokerHeartbeat_StalledIdleAgentNotOverwrittenBySameActivity(t *testing
 
 	updated, err := s.GetAgent(ctx, agent.ID)
 	require.NoError(t, err)
-	assert.Equal(t, "stalled", updated.Activity, "agent should remain stalled when heartbeat reports same pre-stall idle activity")
-	assert.Equal(t, "idle", updated.StalledFromActivity, "stalled_from_activity should be preserved")
+	assert.Equal(t, "stalled", updated.Activity, "agent should remain stalled when heartbeat reports same pre-stall working activity")
+	assert.Equal(t, "working", updated.StalledFromActivity, "stalled_from_activity should be preserved")
 }
 
 func TestBrokerHeartbeat_DoesNotRevertStoppedAgent(t *testing.T) {
@@ -3330,7 +3330,7 @@ func TestBrokerHeartbeat_DoesNotOverwriteTerminalActivityWithNonTerminal(t *test
 			Agents: []brokerAgentHeartbeat{{
 				Slug:     agent.Slug,
 				Phase:    string(state.PhaseStopped),
-				Activity: string(state.ActivityIdle),
+				Activity: string(state.ActivityWorking),
 			}},
 		}},
 	}
@@ -4324,7 +4324,7 @@ func TestPreserveTerminalPhase(t *testing.T) {
 
 		// Simulate broker response setting phase to running on the in-memory agent
 		agent.Phase = string(state.PhaseRunning)
-		agent.Activity = string(state.ActivityIdle)
+		agent.Activity = string(state.ActivityWorking)
 
 		// preserveTerminalPhase should detect the DB has error and preserve it
 		srv.preserveTerminalPhase(ctx, agent)

--- a/pkg/hub/notifications_integration_test.go
+++ b/pkg/hub/notifications_integration_test.go
@@ -162,7 +162,7 @@ func (env *integrationTestEnv) updateStatusViaAPI(t *testing.T, agentID, status,
 	case "running", "stopped", "error", "provisioning", "created":
 		statusUpdate.Phase = status
 	default:
-		// Activities: completed, waiting_for_input, idle, limits_exceeded, etc.
+		// Activities: completed, waiting_for_input, working, limits_exceeded, etc.
 		statusUpdate.Activity = status
 	}
 	body, _ := json.Marshal(statusUpdate)
@@ -440,7 +440,7 @@ func TestIntegration_StatusNormalization_NonTriggerStatusNoNotification(t *testi
 
 	// Status updates that should NOT trigger notifications
 	env.updateStatusViaAPI(t, child.ID, "running", "", "")
-	env.updateStatusViaAPI(t, child.ID, "idle", "", "")
+	env.updateStatusViaAPI(t, child.ID, "working", "", "")
 
 	time.Sleep(300 * time.Millisecond)
 

--- a/pkg/hub/stalled_detection_test.go
+++ b/pkg/hub/stalled_detection_test.go
@@ -352,7 +352,7 @@ func TestAgentStalledDetectionHandler_IdleAgentMarkedStalled(t *testing.T) {
 	project := &store.Project{
 		ID:         api.NewUUID(),
 		Name:       "Idle Stalled Project",
-		Slug:       "idle-stalled-project",
+		Slug:       "working-stalled-project",
 		Visibility: store.VisibilityPrivate,
 	}
 	if err := s.CreateProject(ctx, project); err != nil {
@@ -361,7 +361,7 @@ func TestAgentStalledDetectionHandler_IdleAgentMarkedStalled(t *testing.T) {
 
 	agent := &store.Agent{
 		ID:         api.NewUUID(),
-		Slug:       "idle-agent",
+		Slug:       "working-agent",
 		Name:       "Idle Agent",
 		Template:   "claude",
 		ProjectID:    project.ID,
@@ -372,15 +372,15 @@ func TestAgentStalledDetectionHandler_IdleAgentMarkedStalled(t *testing.T) {
 		t.Fatalf("failed to create agent: %v", err)
 	}
 
-	// Set to running with idle activity
+	// Set to running with working activity
 	if err := s.UpdateAgentStatus(ctx, agent.ID, store.AgentStatusUpdate{
 		Phase:    string(state.PhaseRunning),
-		Activity: string(state.ActivityIdle),
+		Activity: string(state.ActivityWorking),
 	}); err != nil {
 		t.Fatalf("failed to update agent status: %v", err)
 	}
 
-	// Make activity stale but keep heartbeat recent (process alive but stuck at idle)
+	// Make activity stale but keep heartbeat recent (process alive but stuck at working)
 	staleActivity := time.Now().Add(-10 * time.Minute)
 	recentHB := time.Now().Add(-30 * time.Second)
 	db := s.(*sqlite.SQLiteStore).DB()
@@ -390,13 +390,13 @@ func TestAgentStalledDetectionHandler_IdleAgentMarkedStalled(t *testing.T) {
 		t.Fatalf("failed to set stale activity: %v", err)
 	}
 
-	// Run stalled detection — should mark this idle agent as stalled
+	// Run stalled detection — should mark this working agent as stalled
 	handler := srv.agentStalledDetectionHandler()
 	handler(ctx)
 
 	published := ep.publishedAgents()
 	if len(published) != 1 {
-		t.Fatalf("expected 1 published event (idle agent should be stalled), got %d", len(published))
+		t.Fatalf("expected 1 published event (working agent should be stalled), got %d", len(published))
 	}
 	if published[0].Activity != string(state.ActivityStalled) {
 		t.Errorf("published agent activity = %q, want %q", published[0].Activity, string(state.ActivityStalled))
@@ -410,8 +410,8 @@ func TestAgentStalledDetectionHandler_IdleAgentMarkedStalled(t *testing.T) {
 	if a.Activity != string(state.ActivityStalled) {
 		t.Errorf("agent activity = %q, want %q", a.Activity, string(state.ActivityStalled))
 	}
-	if a.StalledFromActivity != string(state.ActivityIdle) {
-		t.Errorf("stalled_from_activity = %q, want %q", a.StalledFromActivity, string(state.ActivityIdle))
+	if a.StalledFromActivity != string(state.ActivityWorking) {
+		t.Errorf("stalled_from_activity = %q, want %q", a.StalledFromActivity, string(state.ActivityWorking))
 	}
 }
 

--- a/pkg/hubclient/types.go
+++ b/pkg/hubclient/types.go
@@ -33,7 +33,7 @@ type Agent struct {
 	Labels            map[string]string `json:"labels,omitempty"`
 	Annotations       map[string]string `json:"annotations,omitempty"`
 	Phase             string            `json:"phase,omitempty"`    // Lifecycle phase (created, provisioning, running, stopped, error)
-	Activity          string            `json:"activity,omitempty"` // Runtime activity (idle, thinking, executing, waiting_for_input, completed)
+	Activity          string            `json:"activity,omitempty"` // Runtime activity (working, thinking, executing, waiting_for_input, completed)
 	Status            string            `json:"status"`             // Legacy/fallback status field
 	ConnectionState   string            `json:"connectionState,omitempty"`
 	ContainerStatus   string            `json:"containerStatus,omitempty"`

--- a/pkg/sciontool/hooks/handlers/hub.go
+++ b/pkg/sciontool/hooks/handlers/hub.go
@@ -48,9 +48,9 @@ func (h *HubHandler) Handle(event *hooks.Event) error {
 	var err error
 	switch event.Name {
 	case hooks.EventSessionStart:
-		// Session starting - report running phase with idle activity (clears any sticky)
-		log.Debug("Hub: Reporting running/idle (session start)")
-		err = h.client.ReportState(ctx, state.PhaseRunning, state.ActivityIdle, "Session started")
+		// Session starting - report running phase with working activity (clears any sticky)
+		log.Debug("Hub: Reporting running/working (session start)")
+		err = h.client.ReportState(ctx, state.PhaseRunning, state.ActivityWorking, "Session started")
 
 	case hooks.EventPromptSubmit, hooks.EventAgentStart:
 		// New work events - always clear sticky status
@@ -150,15 +150,15 @@ func (h *HubHandler) Handle(event *hooks.Event) error {
 			}
 		}
 
-		// Check if local activity is sticky before sending idle
+		// Check if local activity is sticky before sending working
 		if h.isLocalActivitySticky() {
-			log.Debug("Hub: Skipping idle (local activity is sticky)")
+			log.Debug("Hub: Skipping working (local activity is sticky)")
 			return nil
 		}
-		log.Debug("Hub: Reporting idle (step completed)")
-		as := state.AgentState{Phase: state.PhaseRunning, Activity: state.ActivityIdle}
+		log.Debug("Hub: Reporting working (step completed)")
+		as := state.AgentState{Phase: state.PhaseRunning, Activity: state.ActivityWorking}
 		err = h.client.UpdateStatus(ctx, hub.StatusUpdate{
-			Activity: state.ActivityIdle,
+			Activity: state.ActivityWorking,
 			Status:   as.DisplayStatus(),
 			Message:  "Ready",
 		})

--- a/pkg/sciontool/hooks/handlers/hub_test.go
+++ b/pkg/sciontool/hooks/handlers/hub_test.go
@@ -26,10 +26,10 @@ func TestHubHandler_EventMapping(t *testing.T) {
 		expectedStatus string
 	}{
 		{
-			name:           "session start sends idle (running phase)",
+			name:           "session start sends working (running phase)",
 			eventName:      hooks.EventSessionStart,
 			expectCall:     true,
-			expectedStatus: "idle",
+			expectedStatus: "working",
 		},
 		{
 			name:           "prompt submit sends thinking",
@@ -51,16 +51,16 @@ func TestHubHandler_EventMapping(t *testing.T) {
 			expectedStatus: "executing",
 		},
 		{
-			name:           "tool end sends idle",
+			name:           "tool end sends working",
 			eventName:      hooks.EventToolEnd,
 			expectCall:     true,
-			expectedStatus: "idle",
+			expectedStatus: "working",
 		},
 		{
-			name:           "agent end sends idle",
+			name:           "agent end sends working",
 			eventName:      hooks.EventAgentEnd,
 			expectCall:     true,
-			expectedStatus: "idle",
+			expectedStatus: "working",
 		},
 		{
 			name:           "notification sends waiting_for_input",
@@ -293,11 +293,11 @@ func TestHubHandler_StickyStatus(t *testing.T) {
 			expectCall:    false,
 		},
 		{
-			name:           "tool-end sends idle when local activity is idle",
-			localActivity:  "idle",
+			name:           "tool-end sends working when local activity is working",
+			localActivity:  "working",
 			eventName:      hooks.EventToolEnd,
 			expectCall:     true,
-			expectedStatus: "idle",
+			expectedStatus: "working",
 		},
 		{
 			name:          "agent-end skipped when local activity is waiting_for_input",
@@ -324,8 +324,8 @@ func TestHubHandler_StickyStatus(t *testing.T) {
 			expectCall:    false,
 		},
 		{
-			name:           "model-start sends thinking when local activity is idle",
-			localActivity:  "idle",
+			name:           "model-start sends thinking when local activity is working",
+			localActivity:  "working",
 			eventName:      hooks.EventModelStart,
 			expectCall:     true,
 			expectedStatus: "thinking",
@@ -338,8 +338,8 @@ func TestHubHandler_StickyStatus(t *testing.T) {
 			expectCall:    false,
 		},
 		{
-			name:           "tool-start sends executing when local activity is idle",
-			localActivity:  "idle",
+			name:           "tool-start sends executing when local activity is working",
+			localActivity:  "working",
 			eventName:      hooks.EventToolStart,
 			eventData:      hooks.EventData{ToolName: "Bash"},
 			expectCall:     true,
@@ -360,11 +360,11 @@ func TestHubHandler_StickyStatus(t *testing.T) {
 			expectedStatus: "thinking",
 		},
 		{
-			name:           "session-start always sends idle (clears sticky)",
+			name:           "session-start always sends working (clears sticky)",
 			localActivity:  "waiting_for_input",
 			eventName:      hooks.EventSessionStart,
 			expectCall:     true,
-			expectedStatus: "idle",
+			expectedStatus: "working",
 		},
 	}
 
@@ -656,7 +656,7 @@ func TestHubHandler_AssistantTextForwarding(t *testing.T) {
 			t.Errorf("Expected outbound type %q, got %q", "assistant-reply", outboundType)
 		}
 		if statusCalls != 1 {
-			t.Errorf("Expected 1 status call (idle), got %d", statusCalls)
+			t.Errorf("Expected 1 status call (working), got %d", statusCalls)
 		}
 	})
 

--- a/pkg/sciontool/hooks/handlers/logging.go
+++ b/pkg/sciontool/hooks/handlers/logging.go
@@ -45,11 +45,11 @@ func (h *LoggingHandler) eventToTag(event *hooks.Event) string {
 	case hooks.EventModelStart:
 		return string(state.ActivityThinking)
 	case hooks.EventModelEnd:
-		return string(state.ActivityIdle)
+		return string(state.ActivityWorking)
 	case hooks.EventToolStart:
 		return string(state.ActivityExecuting)
 	case hooks.EventToolEnd, hooks.EventAgentEnd:
-		return string(state.ActivityIdle)
+		return string(state.ActivityWorking)
 	case hooks.EventNotification:
 		return string(state.ActivityWaitingForInput)
 	case hooks.EventResponseComplete:
@@ -59,11 +59,11 @@ func (h *LoggingHandler) eventToTag(event *hooks.Event) string {
 	case hooks.EventPreStart:
 		return string(state.PhaseStarting)
 	case hooks.EventPostStart:
-		return string(state.ActivityIdle)
+		return string(state.ActivityWorking)
 	case hooks.EventPreStop:
 		return string(state.PhaseStopping)
 	default:
-		return string(state.ActivityIdle)
+		return string(state.ActivityWorking)
 	}
 }
 

--- a/pkg/sciontool/hooks/handlers/status.go
+++ b/pkg/sciontool/hooks/handlers/status.go
@@ -275,11 +275,11 @@ func eventToPhaseActivity(event *hooks.Event) *eventResult {
 		return &eventResult{phase: state.PhaseStarting, isPhase: true}
 
 	case hooks.EventPostStart:
-		return &eventResult{phase: state.PhaseRunning, activity: state.ActivityIdle, isPhase: true}
+		return &eventResult{phase: state.PhaseRunning, activity: state.ActivityWorking, isPhase: true}
 
 	case hooks.EventSessionStart:
-		// session-start clears sticky — treated as activity-only (idle)
-		return &eventResult{activity: state.ActivityIdle}
+		// session-start clears sticky — treated as activity-only (working)
+		return &eventResult{activity: state.ActivityWorking}
 
 	case hooks.EventPromptSubmit, hooks.EventAgentStart:
 		return &eventResult{activity: state.ActivityThinking}
@@ -288,13 +288,13 @@ func eventToPhaseActivity(event *hooks.Event) *eventResult {
 		return &eventResult{activity: state.ActivityThinking}
 
 	case hooks.EventModelEnd:
-		return &eventResult{activity: state.ActivityIdle}
+		return &eventResult{activity: state.ActivityWorking}
 
 	case hooks.EventToolStart:
 		return &eventResult{activity: state.ActivityExecuting}
 
 	case hooks.EventToolEnd, hooks.EventAgentEnd:
-		return &eventResult{activity: state.ActivityIdle}
+		return &eventResult{activity: state.ActivityWorking}
 
 	case hooks.EventResponseComplete:
 		return &eventResult{activity: state.ActivityCompleted}

--- a/pkg/sciontool/hooks/handlers/status_test.go
+++ b/pkg/sciontool/hooks/handlers/status_test.go
@@ -52,12 +52,12 @@ func TestStatusHandler_UpdatePhase(t *testing.T) {
 	assert.Equal(t, "starting", info.Phase)
 	assert.Equal(t, "", info.Activity)
 
-	err = h.UpdatePhase(state.PhaseRunning, state.ActivityIdle, "")
+	err = h.UpdatePhase(state.PhaseRunning, state.ActivityWorking, "")
 	require.NoError(t, err)
 
 	info = readAgentInfo(t, statusPath)
 	assert.Equal(t, "running", info.Phase)
-	assert.Equal(t, "idle", info.Activity)
+	assert.Equal(t, "working", info.Activity)
 }
 
 func TestStatusHandler_Handle(t *testing.T) {
@@ -81,15 +81,15 @@ func TestStatusHandler_Handle(t *testing.T) {
 			wantActivity: "",
 		},
 		{
-			name:         "PostStart sets running/idle",
+			name:         "PostStart sets running/working",
 			event:        &hooks.Event{Name: hooks.EventPostStart},
 			wantPhase:    "running",
-			wantActivity: "idle",
+			wantActivity: "working",
 		},
 		{
-			name:         "SessionStart sets idle activity",
+			name:         "SessionStart sets working activity",
 			event:        &hooks.Event{Name: hooks.EventSessionStart},
-			wantActivity: "idle",
+			wantActivity: "working",
 		},
 		{
 			name:         "PreStop sets stopping phase",
@@ -108,14 +108,14 @@ func TestStatusHandler_Handle(t *testing.T) {
 			wantActivity: "executing",
 		},
 		{
-			name:         "ToolEnd sets idle",
+			name:         "ToolEnd sets working",
 			event:        &hooks.Event{Name: hooks.EventToolEnd},
-			wantActivity: "idle",
+			wantActivity: "working",
 		},
 		{
-			name:         "AgentEnd sets idle",
+			name:         "AgentEnd sets working",
 			event:        &hooks.Event{Name: hooks.EventAgentEnd},
-			wantActivity: "idle",
+			wantActivity: "working",
 		},
 		{
 			name:         "SessionEnd sets stopped phase",
@@ -159,7 +159,7 @@ func TestStatusHandler_ToolStartSetsToolName(t *testing.T) {
 	require.NoError(t, err)
 
 	info = readAgentInfo(t, statusPath)
-	assert.Equal(t, "idle", info.Activity)
+	assert.Equal(t, "working", info.Activity)
 	assert.Equal(t, "", info.ToolName)
 }
 
@@ -509,8 +509,8 @@ func TestStatusHandler_PreservesExtraFields(t *testing.T) {
 	// Seed agent-info.json with extra fields (as written at provisioning time)
 	initial := map[string]interface{}{
 		"phase":         "running",
-		"activity":      "idle",
-		"status":        "idle",
+		"activity":      "working",
+		"status":        "working",
 		"template":      "my-template",
 		"harnessConfig": "claude",
 		"runtime":       "docker",
@@ -556,8 +556,8 @@ func TestStatusHandler_RemovesLegacyFields(t *testing.T) {
 	// Seed agent-info.json with legacy status and sessionStatus fields
 	initial := map[string]interface{}{
 		"phase":         "running",
-		"activity":      "idle",
-		"status":        "idle",
+		"activity":      "working",
+		"status":        "working",
 		"sessionStatus": "WAITING_FOR_INPUT",
 	}
 	data, err := json.Marshal(initial)

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -313,7 +313,7 @@ func (c *Client) calculateBackoff(attempt int) time.Duration {
 
 // Heartbeat sends a heartbeat to the Hub.
 // Note: Heartbeat only updates last_seen timestamp, it does not change the agent's status.
-// This allows the actual status (idle, busy, etc.) to be preserved between heartbeats.
+// This allows the actual status (working, busy, etc.) to be preserved between heartbeats.
 func (c *Client) Heartbeat(ctx context.Context) error {
 	return c.UpdateStatus(ctx, StatusUpdate{
 		Heartbeat: true,

--- a/pkg/sciontool/hub/client_test.go
+++ b/pkg/sciontool/hub/client_test.go
@@ -169,16 +169,16 @@ func TestClient_UpdateStatus(t *testing.T) {
 
 	err := client.UpdateStatus(context.Background(), StatusUpdate{
 		Phase:    state.PhaseRunning,
-		Activity: state.ActivityIdle,
-		Status:   "idle",
+		Activity: state.ActivityWorking,
+		Status:   "working",
 		Message:  "test message",
 	})
 
 	require.NoError(t, err)
 	assert.Equal(t, "test-token", receivedToken)
 	assert.Equal(t, state.PhaseRunning, receivedStatus.Phase)
-	assert.Equal(t, state.ActivityIdle, receivedStatus.Activity)
-	assert.Equal(t, "idle", receivedStatus.Status)
+	assert.Equal(t, state.ActivityWorking, receivedStatus.Activity)
+	assert.Equal(t, "working", receivedStatus.Status)
 	assert.Equal(t, "test message", receivedStatus.Message)
 }
 
@@ -224,11 +224,11 @@ func TestClient_ReportState(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("running/idle", func(t *testing.T) {
-		err := client.ReportState(ctx, state.PhaseRunning, state.ActivityIdle, "ready")
+		err := client.ReportState(ctx, state.PhaseRunning, state.ActivityWorking, "ready")
 		require.NoError(t, err)
 		assert.Equal(t, "running", lastPayload["phase"])
-		assert.Equal(t, "idle", lastPayload["activity"])
-		assert.Equal(t, "idle", lastPayload["status"])
+		assert.Equal(t, "working", lastPayload["activity"])
+		assert.Equal(t, "working", lastPayload["status"])
 		assert.Equal(t, "ready", lastPayload["message"])
 	})
 
@@ -309,8 +309,8 @@ func TestClient_RetryLogic(t *testing.T) {
 		client.retryMaxDelay = 50 * time.Millisecond
 
 		err := client.UpdateStatus(context.Background(), StatusUpdate{
-			Activity: state.ActivityIdle,
-			Status:   "idle",
+			Activity: state.ActivityWorking,
+			Status:   "working",
 		})
 		require.NoError(t, err)
 		assert.Equal(t, 3, attempts, "should have retried until success")
@@ -329,8 +329,8 @@ func TestClient_RetryLogic(t *testing.T) {
 		client.retryBaseDelay = 10 * time.Millisecond
 
 		err := client.UpdateStatus(context.Background(), StatusUpdate{
-			Activity: state.ActivityIdle,
-			Status:   "idle",
+			Activity: state.ActivityWorking,
+			Status:   "working",
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "400")
@@ -351,8 +351,8 @@ func TestClient_RetryLogic(t *testing.T) {
 		client.retryBaseDelay = 10 * time.Millisecond
 
 		err := client.UpdateStatus(context.Background(), StatusUpdate{
-			Activity: state.ActivityIdle,
-			Status:   "idle",
+			Activity: state.ActivityWorking,
+			Status:   "working",
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "3 attempts")
@@ -375,8 +375,8 @@ func TestClient_RetryLogic(t *testing.T) {
 		defer cancel()
 
 		err := client.UpdateStatus(ctx, StatusUpdate{
-			Activity: state.ActivityIdle,
-			Status:   "idle",
+			Activity: state.ActivityWorking,
+			Status:   "working",
 		})
 		require.Error(t, err)
 		assert.True(t, attempts < 5, "should have stopped early due to context timeout")

--- a/pkg/store/sqlite/sqlite.go
+++ b/pkg/store/sqlite/sqlite.go
@@ -736,11 +736,11 @@ ALTER TABLE agents ADD COLUMN tool_name TEXT DEFAULT '';
 UPDATE agents SET phase = 'created' WHERE status IN ('created', 'pending');
 UPDATE agents SET phase = 'provisioning' WHERE status = 'provisioning';
 UPDATE agents SET phase = 'cloning' WHERE status = 'cloning';
-UPDATE agents SET phase = 'running', activity = 'working' WHERE status = 'running';
+UPDATE agents SET phase = 'running', activity = 'idle' WHERE status = 'running';
 UPDATE agents SET phase = 'stopped' WHERE status = 'stopped';
 UPDATE agents SET phase = 'error' WHERE status = 'error';
 UPDATE agents SET phase = 'running', activity = 'thinking' WHERE status = 'busy';
-UPDATE agents SET phase = 'running', activity = 'working' WHERE status = 'idle';
+UPDATE agents SET phase = 'running', activity = 'idle' WHERE status = 'idle';
 UPDATE agents SET phase = 'running', activity = 'waiting_for_input' WHERE status = 'waiting_for_input';
 UPDATE agents SET phase = 'running', activity = 'completed' WHERE status = 'completed';
 UPDATE agents SET phase = 'running', activity = 'limits_exceeded' WHERE status = 'limits_exceeded';
@@ -760,8 +760,7 @@ UPDATE agents SET phase = 'created' WHERE (phase = '' OR phase IS NULL) AND stat
 UPDATE agents SET phase = 'stopped' WHERE (phase = '' OR phase IS NULL) AND status = 'deleted';
 
 -- Backfill activity from status for running agents
-UPDATE agents SET activity = status WHERE phase = 'running' AND (activity = '' OR activity IS NULL) AND status IN ('waiting_for_input','completed','limits_exceeded','offline');
-UPDATE agents SET activity = 'working' WHERE phase = 'running' AND (activity = '' OR activity IS NULL) AND status = 'idle';
+UPDATE agents SET activity = status WHERE phase = 'running' AND (activity = '' OR activity IS NULL) AND status IN ('idle','waiting_for_input','completed','limits_exceeded','offline');
 UPDATE agents SET activity = 'thinking' WHERE phase = 'running' AND (activity = '' OR activity IS NULL) AND status = 'busy';
 
 -- Update soft-delete index: rely on deleted_at instead of status

--- a/pkg/store/sqlite/sqlite.go
+++ b/pkg/store/sqlite/sqlite.go
@@ -145,6 +145,7 @@ func (s *SQLiteStore) Migrate(ctx context.Context) error {
 		migrationV49,
 		migrateV50,
 		migrationV51,
+		migrationV52,
 	}
 
 	// Create migrations table if not exists
@@ -735,11 +736,11 @@ ALTER TABLE agents ADD COLUMN tool_name TEXT DEFAULT '';
 UPDATE agents SET phase = 'created' WHERE status IN ('created', 'pending');
 UPDATE agents SET phase = 'provisioning' WHERE status = 'provisioning';
 UPDATE agents SET phase = 'cloning' WHERE status = 'cloning';
-UPDATE agents SET phase = 'running', activity = 'idle' WHERE status = 'running';
+UPDATE agents SET phase = 'running', activity = 'working' WHERE status = 'running';
 UPDATE agents SET phase = 'stopped' WHERE status = 'stopped';
 UPDATE agents SET phase = 'error' WHERE status = 'error';
 UPDATE agents SET phase = 'running', activity = 'thinking' WHERE status = 'busy';
-UPDATE agents SET phase = 'running', activity = 'idle' WHERE status = 'idle';
+UPDATE agents SET phase = 'running', activity = 'working' WHERE status = 'idle';
 UPDATE agents SET phase = 'running', activity = 'waiting_for_input' WHERE status = 'waiting_for_input';
 UPDATE agents SET phase = 'running', activity = 'completed' WHERE status = 'completed';
 UPDATE agents SET phase = 'running', activity = 'limits_exceeded' WHERE status = 'limits_exceeded';
@@ -759,7 +760,8 @@ UPDATE agents SET phase = 'created' WHERE (phase = '' OR phase IS NULL) AND stat
 UPDATE agents SET phase = 'stopped' WHERE (phase = '' OR phase IS NULL) AND status = 'deleted';
 
 -- Backfill activity from status for running agents
-UPDATE agents SET activity = status WHERE phase = 'running' AND (activity = '' OR activity IS NULL) AND status IN ('idle','waiting_for_input','completed','limits_exceeded','offline');
+UPDATE agents SET activity = status WHERE phase = 'running' AND (activity = '' OR activity IS NULL) AND status IN ('waiting_for_input','completed','limits_exceeded','offline');
+UPDATE agents SET activity = 'working' WHERE phase = 'running' AND (activity = '' OR activity IS NULL) AND status = 'idle';
 UPDATE agents SET activity = 'thinking' WHERE phase = 'running' AND (activity = '' OR activity IS NULL) AND status = 'busy';
 
 -- Update soft-delete index: rely on deleted_at instead of status
@@ -1331,6 +1333,12 @@ CREATE INDEX IF NOT EXISTS idx_gcp_sa_project ON gcp_service_accounts(project_id
 // migrationV51 adds group_id to messages for correlating set[] deliveries.
 const migrationV51 = `
 ALTER TABLE messages ADD COLUMN group_id TEXT NOT NULL DEFAULT '';
+`
+
+// migrationV52 renames the idle activity to working for clearer agent state reporting.
+const migrationV52 = `
+UPDATE agents SET activity = 'working' WHERE activity = 'idle';
+UPDATE agents SET stalled_from_activity = 'working' WHERE stalled_from_activity = 'idle';
 `
 
 // tableExists checks whether a table with the given name exists in the database.

--- a/pkg/store/sqlite/sqlite_test.go
+++ b/pkg/store/sqlite/sqlite_test.go
@@ -371,16 +371,16 @@ func TestAgentStatusUpdate(t *testing.T) {
 	assert.Equal(t, "executing", retrieved.Activity)
 	assert.Equal(t, "Bash", retrieved.ToolName)
 
-	// Change activity from executing to idle → toolName is cleared
+	// Change activity from executing to working → toolName is cleared
 	err = s.UpdateAgentStatus(ctx, agent.ID, store.AgentStatusUpdate{
 		Phase:    "running",
-		Activity: "idle",
+		Activity: "working",
 	})
 	require.NoError(t, err)
 
 	retrieved, err = s.GetAgent(ctx, agent.ID)
 	require.NoError(t, err)
-	assert.Equal(t, "idle", retrieved.Activity)
+	assert.Equal(t, "working", retrieved.Activity)
 	assert.Equal(t, "", retrieved.ToolName, "toolName should be cleared when activity changes away from executing")
 
 	// Set only activity (phase preserved from previous update)
@@ -425,7 +425,7 @@ func TestAgentStatusUpdate_PhaseActivityRoundTrip(t *testing.T) {
 		Template:   "claude",
 		ProjectID:  project.ID,
 		Phase:      "running",
-		Activity:   "idle",
+		Activity:   "working",
 		Visibility: store.VisibilityPrivate,
 	}
 	require.NoError(t, s.CreateAgent(ctx, agent))
@@ -434,20 +434,20 @@ func TestAgentStatusUpdate_PhaseActivityRoundTrip(t *testing.T) {
 	retrieved, err := s.GetAgent(ctx, agent.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "running", retrieved.Phase)
-	assert.Equal(t, "idle", retrieved.Activity)
+	assert.Equal(t, "working", retrieved.Activity)
 
 	// Verify round-trip through GetBySlug
 	retrieved, err = s.GetAgentBySlug(ctx, project.ID, "roundtrip-agent")
 	require.NoError(t, err)
 	assert.Equal(t, "running", retrieved.Phase)
-	assert.Equal(t, "idle", retrieved.Activity)
+	assert.Equal(t, "working", retrieved.Activity)
 
 	// Verify round-trip through List
 	result, err := s.ListAgents(ctx, store.AgentFilter{ProjectID: project.ID}, store.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, result.Items, 1)
 	assert.Equal(t, "running", result.Items[0].Phase)
-	assert.Equal(t, "idle", result.Items[0].Activity)
+	assert.Equal(t, "working", result.Items[0].Activity)
 }
 
 func TestSoftDeleteFilterExclusion(t *testing.T) {
@@ -2245,7 +2245,7 @@ func TestMarkStaleAgentsOffline(t *testing.T) {
 	threshold := time.Now().Add(-2 * time.Minute)
 
 	// These agents have phase=running with non-sticky activities → should be marked offline
-	activeActivities := []string{"idle", "thinking", "executing", "waiting_for_input"}
+	activeActivities := []string{"working", "thinking", "executing", "waiting_for_input"}
 
 	var expectedIDs []string
 	for i, activity := range activeActivities {
@@ -2320,7 +2320,7 @@ func TestMarkStaleAgentsOffline(t *testing.T) {
 	}
 	require.NoError(t, s.CreateAgent(ctx, recentAgent))
 	require.NoError(t, s.UpdateAgentStatus(ctx, recentAgent.ID, store.AgentStatusUpdate{
-		Phase: "running", Activity: "idle",
+		Phase: "running", Activity: "working",
 	}))
 	// last_seen is set to now by UpdateAgentStatus, which is within the threshold
 
@@ -2358,7 +2358,7 @@ func TestMarkStaleAgentsOffline(t *testing.T) {
 	// Verify recent agent was NOT affected
 	a, err = s.GetAgent(ctx, recentAgent.ID)
 	require.NoError(t, err)
-	assert.Equal(t, "idle", a.Activity)
+	assert.Equal(t, "working", a.Activity)
 }
 
 func TestMarkStaleAgentsOffline_Idempotent(t *testing.T) {
@@ -2383,7 +2383,7 @@ func TestMarkStaleAgentsOffline_Idempotent(t *testing.T) {
 	}
 	require.NoError(t, s.CreateAgent(ctx, agent))
 	require.NoError(t, s.UpdateAgentStatus(ctx, agent.ID, store.AgentStatusUpdate{
-		Phase: "running", Activity: "idle",
+		Phase: "running", Activity: "working",
 	}))
 	_, err := s.db.ExecContext(ctx, "UPDATE agents SET last_seen = ? WHERE id = ?", staleTime, agent.ID)
 	require.NoError(t, err)
@@ -2433,7 +2433,7 @@ func TestMarkStalledAgents(t *testing.T) {
 	heartbeatRecency := time.Now().Add(-2 * time.Minute)
 
 	// --- Should be marked stalled: stale activity + recent heartbeat ---
-	stalledActivities := []string{"thinking", "executing", "idle"}
+	stalledActivities := []string{"thinking", "executing", "working"}
 	var expectedIDs []string
 	for _, activity := range stalledActivities {
 		agent := &store.Agent{
@@ -2463,7 +2463,7 @@ func TestMarkStalledAgents(t *testing.T) {
 	}
 	require.NoError(t, s.CreateAgent(ctx, recentAgent))
 	require.NoError(t, s.UpdateAgentStatus(ctx, recentAgent.ID, store.AgentStatusUpdate{
-		Phase: "running", Activity: "idle",
+		Phase: "running", Activity: "working",
 	}))
 	// last_activity_event is set to now by UpdateAgentStatus, which is within threshold
 
@@ -2475,7 +2475,7 @@ func TestMarkStalledAgents(t *testing.T) {
 	}
 	require.NoError(t, s.CreateAgent(ctx, offlineAgent))
 	require.NoError(t, s.UpdateAgentStatus(ctx, offlineAgent.ID, store.AgentStatusUpdate{
-		Phase: "running", Activity: "idle",
+		Phase: "running", Activity: "working",
 	}))
 	staleHeartbeat := time.Now().Add(-5 * time.Minute)
 	_, err := s.db.ExecContext(ctx,
@@ -2583,11 +2583,11 @@ func TestMarkStalledAgents(t *testing.T) {
 	// Verify excluded agents were NOT affected
 	a, err := s.GetAgent(ctx, recentAgent.ID)
 	require.NoError(t, err)
-	assert.Equal(t, "idle", a.Activity)
+	assert.Equal(t, "working", a.Activity)
 
 	a, err = s.GetAgent(ctx, offlineAgent.ID)
 	require.NoError(t, err)
-	assert.Equal(t, "idle", a.Activity, "stale heartbeat agent should not be stalled")
+	assert.Equal(t, "working", a.Activity, "stale heartbeat agent should not be stalled")
 
 	a, err = s.GetAgent(ctx, completedAgent.ID)
 	require.NoError(t, err)
@@ -2742,7 +2742,7 @@ func TestUpdateAgentStatus_ProtectsTerminalActivity(t *testing.T) {
 
 	// Non-terminal activity should not overwrite crashed
 	require.NoError(t, s.UpdateAgentStatus(ctx, agent.ID, store.AgentStatusUpdate{
-		Activity: string(state.ActivityIdle),
+		Activity: string(state.ActivityWorking),
 	}))
 
 	a, err := s.GetAgent(ctx, agent.ID)

--- a/web/src/client/state.ts
+++ b/web/src/client/state.ts
@@ -29,7 +29,7 @@ import { SSEClient } from './sse-client.js';
 import type { SSEUpdateEvent } from './sse-client.js';
 import type { Agent, Project, RuntimeBroker } from '../shared/types.js';
 
-/** Activities that should not be overwritten by idle/empty transitions */
+/** Activities that should not be overwritten by working/empty transitions */
 const STICKY_ACTIVITIES = new Set(['waiting_for_input', 'completed', 'limits_exceeded']);
 
 /** Subscription scope matches view context */
@@ -297,12 +297,12 @@ export class StateManager extends EventTarget {
         }
       }
 
-      // Preserve sticky activities: if the incoming activity is idle/empty
+      // Preserve sticky activities: if the incoming activity is working/empty
       // but the existing activity is sticky, keep the existing value.
       const incomingActivity = delta.activity as string | undefined;
       if (
         incomingActivity !== undefined &&
-        (incomingActivity === 'idle' || incomingActivity === '') &&
+        (incomingActivity === 'working' || incomingActivity === '') &&
         base.activity &&
         STICKY_ACTIVITIES.has(base.activity)
       ) {

--- a/web/src/components/shared/status-badge.ts
+++ b/web/src/components/shared/status-badge.ts
@@ -50,7 +50,7 @@ export type StatusType =
   | 'created'
   | 'suspended'
   // Agent activity states
-  | 'idle'
+  | 'working'
   | 'thinking'
   | 'executing'
   | 'waiting_for_input'

--- a/web/src/shared/agent-state-display.ts
+++ b/web/src/shared/agent-state-display.ts
@@ -67,7 +67,7 @@ export const PHASE_DISPLAY: Record<AgentPhase, StateDisplay> = {
 // ---------------------------------------------------------------------------
 
 export const ACTIVITY_DISPLAY: Record<AgentActivity, StateDisplay> = {
-  idle: { emoji: '💤', icon: 'circle-fill', variant: 'success', pulse: false },
+  working: { emoji: '🔄', icon: 'circle-fill', variant: 'success', pulse: false },
   thinking: { emoji: '💭', icon: 'lightning-charge', variant: 'primary', pulse: true },
   executing: { emoji: '⚙️', icon: 'gear', variant: 'primary', pulse: true },
   waiting_for_input: {

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -191,7 +191,7 @@ export type AgentPhase =
  * Agent runtime activity (only meaningful when phase=running)
  */
 export type AgentActivity =
-  | 'idle'
+  | 'working'
   | 'thinking'
   | 'executing'
   | 'waiting_for_input'


### PR DESCRIPTION
## Summary
- Renames `ActivityIdle` ("idle") to `ActivityWorking` ("working") across the entire codebase to resolve ambiguity in agent state reporting. An agent previously shown as "idle" could be between tool calls (still active) or truly finished — "working" makes it clear the agent is in an active turn.
- Updates all Go source, tests, TypeScript/web UI, CLI formatting, A2A bridge mapping, agent-viz, and SQL migrations (including a new V51 migration to convert existing database rows from "idle" to "working").
- The `ActivityCompleted` / "completed" state remains the definitive "truly done" signal.

Fixes #36

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/agent/state/` — all pass
- [x] `go test ./pkg/sciontool/hooks/handlers/` — all pass
- [x] `go test ./cmd/ -run TestFormatLastActivity` — all pass
- [x] `go test ./pkg/sciontool/hub/` — all pass
- [x] `go test ./pkg/hub/ -run 'Stalled|Heartbeat'` — all pass
- [x] `go test ./pkg/store/sqlite/ -run 'UpdateAgentStatus|ActivityToolName'` — all pass
- [x] A2A bridge tests pass (extras/scion-a2a-bridge)
- [ ] Verify web UI shows "working" instead of "idle" for active agents
- [ ] Verify `scion list` output shows "working" for active agents