### PR TITLE
feat: unify allow list and invite management UX

### DIFF
--- a/.design/project-log/2026-05-13-pr240-feedback-fixes.md
+++ b/.design/project-log/2026-05-13-pr240-feedback-fixes.md
@@ -1,0 +1,30 @@
+# PR #240 Feedback Fixes
+
+**Date:** 2026-05-13
+**Branch:** scion/fix-invite-ux
+**Task:** Address medium-severity feedback items from upstream PR #240
+
+## Changes Made
+
+### 1. Keyset Pagination Subquery Optimization
+**Files:** `pkg/store/sqlite/sqlite.go`
+
+Both `ListAllowListEntries` and `ListAllowListEntriesWithInvites` used inline subqueries to look up the cursor's `created` timestamp, resulting in the subquery executing twice per page load (once for `<` comparison, once for `=` comparison).
+
+**Fix:** Added a separate `QueryRowContext` call to look up the cursor timestamp once before the main query, then pass the resolved `time.Time` value as bind parameters. This reduces the number of subqueries from 2 to 0 per paginated request.
+
+### 2. Missing Index on allow_list(created, id)
+**Files:** `pkg/store/sqlite/sqlite.go`
+
+The `ORDER BY a.created DESC, a.id DESC` clause had no supporting index. Added migration V53 to create a composite index `idx_allow_list_created_id` on `(created DESC, id DESC)`.
+
+### 3. Server-Side Invite Expiry Computation
+**Files:** `pkg/store/models.go`, `pkg/hub/admin_allow_list.go`, `web/src/components/pages/admin-users.ts`
+
+The frontend was computing invite expiry using `new Date()`, which is unreliable if the user's local clock is skewed. Added an `InviteExpired` boolean field to `AllowListEntryWithInvite`, computed server-side in `handleAdminAllowListGet` before sending the response. The frontend now uses `entry.inviteExpired` instead of comparing timestamps locally.
+
+## Verification
+- `go build ./...` — passes
+- `go test ./pkg/store/sqlite/ -run AllowList` — all 7 tests pass
+- `tsc --noEmit` — TypeScript compiles cleanly
+- Rebased onto origin/main — no conflicts

--- a/.design/project-log/2026-05-13-unify-invite-ux.md
+++ b/.design/project-log/2026-05-13-unify-invite-ux.md
@@ -1,0 +1,40 @@
+# Unify Allow List & Invite Management UX
+
+**Date:** 2026-05-13
+**Agent:** fix-invite-ux
+**Branch:** scion/fix-invite-ux
+
+## Summary
+
+Unified the previously separate Allow List and Invites tabs in the admin Users page into a single "Members" view with inline invite management. The flow is now: add member → generate their invite → share the link.
+
+## Changes
+
+### Backend
+- Added `AllowListEntryWithInvite` model that enriches allow-list entries with joined invite code details
+- Added `UpdateAllowListEntryInviteID` store method to link invites to allow-list entries at creation time
+- Added `ListAllowListEntriesWithInvites` store method using LEFT JOIN for efficient enriched queries
+- Extended `InviteCreateRequest` with optional `Email` field — when provided, the invite is linked to the matching allow-list entry
+- Updated the allow-list GET endpoint to return enriched data with inline invite status
+
+### Frontend
+- Renamed "Allow List" tab → "Members", "Invites" tab → "All Invites"
+- Each member row now shows inline invite status (active/expired/revoked/exhausted)
+- Per-row dropdown with: Generate Invite, Revoke Invite, Remove
+- Create-invite dialog shows contextual header when generating for a specific member
+- After adding a new member, the invite dialog opens automatically pre-filled
+
+### Testing
+- 7 new tests in `pkg/store/sqlite/allow_list_invite_test.go` covering:
+  - UpdateAllowListEntryInviteID: success, case-insensitive, not-found
+  - ListAllowListEntriesWithInvites: no invite, with linked invite, revoked, mixed entries
+
+## Design Decisions
+
+1. **LEFT JOIN approach**: Rather than N+1 queries to load invite details per row, the enriched list uses a single SQL LEFT JOIN between `allow_list` and `invite_codes`.
+
+2. **Best-effort linking**: When creating an invite with an email, the allow-list entry update is best-effort — if the email isn't on the allow list, the invite is still created. This avoids coupling the two operations.
+
+3. **Kept "All Invites" tab**: Rather than removing the invites tab entirely, it's preserved as a secondary view for bulk invite management and viewing invites not linked to specific members.
+
+4. **Auto-open invite dialog after add**: When a new member is added, the invite dialog opens immediately. This gives the "add member and generate invite in one flow" experience.

--- a/pkg/hub/admin_allow_list.go
+++ b/pkg/hub/admin_allow_list.go
@@ -45,9 +45,9 @@ type AllowListBulkAddResponse struct {
 }
 
 type AllowListResponse struct {
-	Items      []store.AllowListEntry `json:"items"`
-	TotalCount int                    `json:"totalCount"`
-	NextCursor string                 `json:"nextCursor,omitempty"`
+	Items      []store.AllowListEntryWithInvite `json:"items"`
+	TotalCount int                              `json:"totalCount"`
+	NextCursor string                           `json:"nextCursor,omitempty"`
 }
 
 // handleAdminAllowList handles GET/POST /api/v1/admin/allow-list.
@@ -136,7 +136,7 @@ func (s *Server) handleAdminAllowListGet(w http.ResponseWriter, r *http.Request)
 		opts.Cursor = q.Get("cursor")
 	}
 
-	result, err := s.store.ListAllowListEntries(r.Context(), opts)
+	result, err := s.store.ListAllowListEntriesWithInvites(r.Context(), opts)
 	if err != nil {
 		InternalError(w)
 		return

--- a/pkg/hub/admin_allow_list.go
+++ b/pkg/hub/admin_allow_list.go
@@ -142,6 +142,14 @@ func (s *Server) handleAdminAllowListGet(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	now := time.Now()
+	for i := range result.Items {
+		entry := &result.Items[i]
+		if !entry.InviteExpiresAt.IsZero() && now.After(entry.InviteExpiresAt) {
+			entry.InviteExpired = true
+		}
+	}
+
 	writeJSON(w, http.StatusOK, AllowListResponse{
 		Items:      result.Items,
 		TotalCount: result.TotalCount,

--- a/pkg/hub/admin_invites.go
+++ b/pkg/hub/admin_invites.go
@@ -28,6 +28,7 @@ type InviteCreateRequest struct {
 	ExpiresIn string `json:"expiresIn"`
 	MaxUses   int    `json:"maxUses"`
 	Note      string `json:"note"`
+	Email     string `json:"email,omitempty"` // Optional: link invite to allow-list entry
 }
 
 type InviteCreateResponse struct {
@@ -167,6 +168,19 @@ func (s *Server) handleAdminInvitesCreate(w http.ResponseWriter, r *http.Request
 		slog.Error("failed to create invite", "error", err)
 		InternalError(w)
 		return
+	}
+
+	// If email is provided, link the invite to the allow-list entry.
+	if req.Email != "" {
+		emailLower := strings.ToLower(strings.TrimSpace(req.Email))
+		if err := s.store.UpdateAllowListEntryInviteID(r.Context(), emailLower, invite.ID); err != nil {
+			// Log but don't fail — the invite was created successfully.
+			slog.Warn("failed to link invite to allow-list entry",
+				"email", emailLower,
+				"invite_id", invite.ID,
+				"error", err,
+			)
+		}
 	}
 
 	inviteURL := s.config.HubEndpoint + "/invite?code=" + code

--- a/pkg/hubclient/allow_list.go
+++ b/pkg/hubclient/allow_list.go
@@ -35,14 +35,19 @@ type allowListService struct {
 	c *client
 }
 
-// AllowListEntry represents an email on the allow list.
+// AllowListEntry represents an email on the allow list, optionally enriched with invite details.
 type AllowListEntry struct {
-	ID       string    `json:"id"`
-	Email    string    `json:"email"`
-	Note     string    `json:"note"`
-	AddedBy  string    `json:"addedBy"`
-	InviteID string    `json:"inviteId,omitempty"`
-	Created  time.Time `json:"created"`
+	ID               string    `json:"id"`
+	Email            string    `json:"email"`
+	Note             string    `json:"note"`
+	AddedBy          string    `json:"addedBy"`
+	InviteID         string    `json:"inviteId,omitempty"`
+	Created          time.Time `json:"created"`
+	InviteCodePrefix string    `json:"inviteCodePrefix,omitempty"`
+	InviteMaxUses    int       `json:"inviteMaxUses,omitempty"`
+	InviteUseCount   int       `json:"inviteUseCount,omitempty"`
+	InviteExpiresAt  time.Time `json:"inviteExpiresAt,omitempty"`
+	InviteRevoked    bool      `json:"inviteRevoked,omitempty"`
 }
 
 // AllowListResponse is the response from listing allow list entries.

--- a/pkg/hubclient/invites.go
+++ b/pkg/hubclient/invites.go
@@ -53,6 +53,7 @@ type InviteCreateRequest struct {
 	ExpiresIn string `json:"expiresIn"`
 	MaxUses   int    `json:"maxUses"`
 	Note      string `json:"note"`
+	Email     string `json:"email,omitempty"` // Optional: link invite to allow-list entry
 }
 
 // InviteCreateResponse is the response from creating an invite code.

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -607,6 +607,16 @@ type AllowListEntry struct {
 	Created  time.Time `json:"created"`
 }
 
+// AllowListEntryWithInvite enriches an AllowListEntry with associated invite code details.
+type AllowListEntryWithInvite struct {
+	AllowListEntry
+	InviteCodePrefix string    `json:"inviteCodePrefix,omitempty"`
+	InviteMaxUses    int       `json:"inviteMaxUses,omitempty"`
+	InviteUseCount   int       `json:"inviteUseCount,omitempty"`
+	InviteExpiresAt  time.Time `json:"inviteExpiresAt,omitempty"`
+	InviteRevoked    bool      `json:"inviteRevoked,omitempty"`
+}
+
 // =============================================================================
 // Invite Codes
 // =============================================================================

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -615,6 +615,7 @@ type AllowListEntryWithInvite struct {
 	InviteUseCount   int       `json:"inviteUseCount,omitempty"`
 	InviteExpiresAt  time.Time `json:"inviteExpiresAt,omitempty"`
 	InviteRevoked    bool      `json:"inviteRevoked,omitempty"`
+	InviteExpired    bool      `json:"inviteExpired,omitempty"`
 }
 
 // =============================================================================

--- a/pkg/store/sqlite/allow_list_invite_test.go
+++ b/pkg/store/sqlite/allow_list_invite_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateAllowListEntryInviteID(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	// Add an allow-list entry
+	entry := &store.AllowListEntry{
+		ID:      uuid.New().String(),
+		Email:   "user@example.com",
+		Note:    "test user",
+		AddedBy: "admin-1",
+	}
+	require.NoError(t, s.AddAllowListEntry(ctx, entry))
+
+	// Update its invite ID
+	inviteID := uuid.New().String()
+	err := s.UpdateAllowListEntryInviteID(ctx, "user@example.com", inviteID)
+	require.NoError(t, err)
+
+	// Verify the update
+	got, err := s.GetAllowListEntry(ctx, "user@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, inviteID, got.InviteID)
+}
+
+func TestUpdateAllowListEntryInviteID_CaseInsensitive(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	entry := &store.AllowListEntry{
+		ID:      uuid.New().String(),
+		Email:   "user@example.com",
+		Note:    "test",
+		AddedBy: "admin-1",
+	}
+	require.NoError(t, s.AddAllowListEntry(ctx, entry))
+
+	inviteID := uuid.New().String()
+	err := s.UpdateAllowListEntryInviteID(ctx, "User@Example.COM", inviteID)
+	require.NoError(t, err)
+
+	got, err := s.GetAllowListEntry(ctx, "user@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, inviteID, got.InviteID)
+}
+
+func TestUpdateAllowListEntryInviteID_NotFound(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	err := s.UpdateAllowListEntryInviteID(ctx, "nonexistent@example.com", "some-id")
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestListAllowListEntriesWithInvites_NoInvite(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	entry := &store.AllowListEntry{
+		ID:      uuid.New().String(),
+		Email:   "user@example.com",
+		Note:    "test",
+		AddedBy: "admin-1",
+	}
+	require.NoError(t, s.AddAllowListEntry(ctx, entry))
+
+	result, err := s.ListAllowListEntriesWithInvites(ctx, store.ListOptions{Limit: 50})
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+
+	item := result.Items[0]
+	assert.Equal(t, "user@example.com", item.Email)
+	assert.Empty(t, item.InviteCodePrefix)
+	assert.Zero(t, item.InviteMaxUses)
+	assert.False(t, item.InviteRevoked)
+}
+
+func TestListAllowListEntriesWithInvites_WithLinkedInvite(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	// Create an invite code
+	invite := &store.InviteCode{
+		ID:         uuid.New().String(),
+		CodeHash:   "testhash123",
+		CodePrefix: "scion_inv_abcdefgh",
+		MaxUses:    1,
+		UseCount:   0,
+		ExpiresAt:  time.Now().Add(24 * time.Hour),
+		CreatedBy:  "admin-1",
+		Note:       "test invite",
+		Created:    time.Now(),
+	}
+	require.NoError(t, s.CreateInviteCode(ctx, invite))
+
+	// Create an allow-list entry linked to the invite
+	entry := &store.AllowListEntry{
+		ID:       uuid.New().String(),
+		Email:    "user@example.com",
+		Note:     "test",
+		AddedBy:  "admin-1",
+		InviteID: invite.ID,
+	}
+	require.NoError(t, s.AddAllowListEntry(ctx, entry))
+
+	result, err := s.ListAllowListEntriesWithInvites(ctx, store.ListOptions{Limit: 50})
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+
+	item := result.Items[0]
+	assert.Equal(t, "user@example.com", item.Email)
+	assert.Equal(t, invite.ID, item.InviteID)
+	assert.Equal(t, "scion_inv_abcdefgh", item.InviteCodePrefix)
+	assert.Equal(t, 1, item.InviteMaxUses)
+	assert.Equal(t, 0, item.InviteUseCount)
+	assert.False(t, item.InviteRevoked)
+	assert.False(t, item.InviteExpiresAt.IsZero())
+}
+
+func TestListAllowListEntriesWithInvites_RevokedInvite(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	invite := &store.InviteCode{
+		ID:         uuid.New().String(),
+		CodeHash:   "testhash456",
+		CodePrefix: "scion_inv_xyz12345",
+		MaxUses:    1,
+		ExpiresAt:  time.Now().Add(24 * time.Hour),
+		Revoked:    true,
+		CreatedBy:  "admin-1",
+		Created:    time.Now(),
+	}
+	require.NoError(t, s.CreateInviteCode(ctx, invite))
+
+	entry := &store.AllowListEntry{
+		ID:       uuid.New().String(),
+		Email:    "revoked@example.com",
+		Note:     "test",
+		AddedBy:  "admin-1",
+		InviteID: invite.ID,
+	}
+	require.NoError(t, s.AddAllowListEntry(ctx, entry))
+
+	result, err := s.ListAllowListEntriesWithInvites(ctx, store.ListOptions{Limit: 50})
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+	assert.True(t, result.Items[0].InviteRevoked)
+}
+
+func TestListAllowListEntriesWithInvites_MixedEntries(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	// Create an invite
+	invite := &store.InviteCode{
+		ID:         uuid.New().String(),
+		CodeHash:   "testhash789",
+		CodePrefix: "scion_inv_mixed123",
+		MaxUses:    5,
+		UseCount:   2,
+		ExpiresAt:  time.Now().Add(48 * time.Hour),
+		CreatedBy:  "admin-1",
+		Created:    time.Now(),
+	}
+	require.NoError(t, s.CreateInviteCode(ctx, invite))
+
+	// Entry with invite
+	entry1 := &store.AllowListEntry{
+		ID:       uuid.New().String(),
+		Email:    "with-invite@example.com",
+		Note:     "has invite",
+		AddedBy:  "admin-1",
+		InviteID: invite.ID,
+	}
+	require.NoError(t, s.AddAllowListEntry(ctx, entry1))
+
+	// Entry without invite
+	entry2 := &store.AllowListEntry{
+		ID:      uuid.New().String(),
+		Email:   "no-invite@example.com",
+		Note:    "no invite",
+		AddedBy: "admin-1",
+	}
+	require.NoError(t, s.AddAllowListEntry(ctx, entry2))
+
+	result, err := s.ListAllowListEntriesWithInvites(ctx, store.ListOptions{Limit: 50})
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.TotalCount)
+	require.Len(t, result.Items, 2)
+
+	// Find the entry with invite
+	var withInvite, withoutInvite store.AllowListEntryWithInvite
+	for _, item := range result.Items {
+		if item.Email == "with-invite@example.com" {
+			withInvite = item
+		} else {
+			withoutInvite = item
+		}
+	}
+
+	assert.Equal(t, "scion_inv_mixed123", withInvite.InviteCodePrefix)
+	assert.Equal(t, 5, withInvite.InviteMaxUses)
+	assert.Equal(t, 2, withInvite.InviteUseCount)
+
+	assert.Empty(t, withoutInvite.InviteCodePrefix)
+	assert.Zero(t, withoutInvite.InviteMaxUses)
+}

--- a/pkg/store/sqlite/sqlite.go
+++ b/pkg/store/sqlite/sqlite.go
@@ -146,6 +146,7 @@ func (s *SQLiteStore) Migrate(ctx context.Context) error {
 		migrateV50,
 		migrationV51,
 		migrationV52,
+		migrationV53,
 	}
 
 	// Create migrations table if not exists
@@ -1338,6 +1339,11 @@ ALTER TABLE messages ADD COLUMN group_id TEXT NOT NULL DEFAULT '';
 const migrationV52 = `
 UPDATE agents SET activity = 'working' WHERE activity = 'idle';
 UPDATE agents SET stalled_from_activity = 'working' WHERE stalled_from_activity = 'idle';
+`
+
+// migrationV53 adds an index on (created, id) to allow_list for efficient keyset pagination.
+const migrationV53 = `
+CREATE INDEX IF NOT EXISTS idx_allow_list_created_id ON allow_list (created DESC, id DESC);
 `
 
 // tableExists checks whether a table with the given name exists in the database.
@@ -3794,9 +3800,12 @@ func (s *SQLiteStore) ListAllowListEntries(ctx context.Context, opts store.ListO
 	var args []interface{}
 
 	if opts.Cursor != "" {
-		conditions = append(conditions, `(created < (SELECT created FROM allow_list WHERE id = ?)
-			OR (created = (SELECT created FROM allow_list WHERE id = ?) AND id < ?))`)
-		args = append(args, opts.Cursor, opts.Cursor, opts.Cursor)
+		var cursorCreated time.Time
+		if err := s.db.QueryRowContext(ctx, "SELECT created FROM allow_list WHERE id = ?", opts.Cursor).Scan(&cursorCreated); err != nil {
+			return nil, fmt.Errorf("invalid cursor: %w", err)
+		}
+		conditions = append(conditions, `(created < ? OR (created = ? AND id < ?))`)
+		args = append(args, cursorCreated, cursorCreated, opts.Cursor)
 	}
 
 	whereClause := ""
@@ -3885,9 +3894,12 @@ func (s *SQLiteStore) ListAllowListEntriesWithInvites(ctx context.Context, opts 
 	var args []interface{}
 
 	if opts.Cursor != "" {
-		conditions = append(conditions, `(a.created < (SELECT created FROM allow_list WHERE id = ?)
-			OR (a.created = (SELECT created FROM allow_list WHERE id = ?) AND a.id < ?))`)
-		args = append(args, opts.Cursor, opts.Cursor, opts.Cursor)
+		var cursorCreated time.Time
+		if err := s.db.QueryRowContext(ctx, "SELECT created FROM allow_list WHERE id = ?", opts.Cursor).Scan(&cursorCreated); err != nil {
+			return nil, fmt.Errorf("invalid cursor: %w", err)
+		}
+		conditions = append(conditions, `(a.created < ? OR (a.created = ? AND a.id < ?))`)
+		args = append(args, cursorCreated, cursorCreated, opts.Cursor)
 	}
 
 	whereClause := ""

--- a/pkg/store/sqlite/sqlite.go
+++ b/pkg/store/sqlite/sqlite.go
@@ -3853,6 +3853,112 @@ func (s *SQLiteStore) IsEmailAllowListed(ctx context.Context, email string) (boo
 	return count > 0, nil
 }
 
+func (s *SQLiteStore) UpdateAllowListEntryInviteID(ctx context.Context, email string, inviteID string) error {
+	result, err := s.db.ExecContext(ctx,
+		"UPDATE allow_list SET invite_id = ? WHERE email = ?",
+		inviteID, strings.ToLower(email))
+	if err != nil {
+		return err
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLiteStore) ListAllowListEntriesWithInvites(ctx context.Context, opts store.ListOptions) (*store.ListResult[store.AllowListEntryWithInvite], error) {
+	var totalCount int
+	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM allow_list").Scan(&totalCount); err != nil {
+		return nil, err
+	}
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+
+	var conditions []string
+	var args []interface{}
+
+	if opts.Cursor != "" {
+		conditions = append(conditions, `(a.created < (SELECT created FROM allow_list WHERE id = ?)
+			OR (a.created = (SELECT created FROM allow_list WHERE id = ?) AND a.id < ?))`)
+		args = append(args, opts.Cursor, opts.Cursor, opts.Cursor)
+	}
+
+	whereClause := ""
+	if len(conditions) > 0 {
+		whereClause = "WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	query := fmt.Sprintf(`
+		SELECT a.id, a.email, a.note, a.added_by, a.invite_id, a.created,
+		       i.code_prefix, i.max_uses, i.use_count, i.expires_at, i.revoked
+		FROM allow_list a
+		LEFT JOIN invite_codes i ON a.invite_id = i.id AND a.invite_id != ''
+		%s ORDER BY a.created DESC, a.id DESC LIMIT ?
+	`, whereClause)
+	args = append(args, limit+1)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var entries []store.AllowListEntryWithInvite
+	for rows.Next() {
+		var entry store.AllowListEntryWithInvite
+		var codePrefix sql.NullString
+		var maxUses, useCount, revoked sql.NullInt64
+		var expiresAt sql.NullTime
+		if err := rows.Scan(
+			&entry.ID, &entry.Email, &entry.Note, &entry.AddedBy, &entry.InviteID, &entry.Created,
+			&codePrefix, &maxUses, &useCount, &expiresAt, &revoked,
+		); err != nil {
+			return nil, err
+		}
+		if codePrefix.Valid {
+			entry.InviteCodePrefix = codePrefix.String
+		}
+		if maxUses.Valid {
+			entry.InviteMaxUses = int(maxUses.Int64)
+		}
+		if useCount.Valid {
+			entry.InviteUseCount = int(useCount.Int64)
+		}
+		if expiresAt.Valid {
+			entry.InviteExpiresAt = expiresAt.Time
+		}
+		if revoked.Valid {
+			entry.InviteRevoked = revoked.Int64 != 0
+		}
+		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if entries == nil {
+		entries = []store.AllowListEntryWithInvite{}
+	}
+
+	var nextCursor string
+	if len(entries) > limit {
+		nextCursor = entries[limit-1].ID
+		entries = entries[:limit]
+	}
+
+	return &store.ListResult[store.AllowListEntryWithInvite]{
+		Items:      entries,
+		TotalCount: totalCount,
+		NextCursor: nextCursor,
+	}, nil
+}
+
 func (s *SQLiteStore) BulkAddAllowListEntries(ctx context.Context, entries []*store.AllowListEntry) (int, int, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -438,6 +438,8 @@ type AllowListStore interface {
 	IsEmailAllowListed(ctx context.Context, email string) (bool, error)
 	BulkAddAllowListEntries(ctx context.Context, entries []*AllowListEntry) (added int, skipped int, err error)
 	ListEmailDomains(ctx context.Context) ([]string, error)
+	UpdateAllowListEntryInviteID(ctx context.Context, email string, inviteID string) error
+	ListAllowListEntriesWithInvites(ctx context.Context, opts ListOptions) (*ListResult[AllowListEntryWithInvite], error)
 }
 
 // InviteCodeStore defines operations for invite code management.

--- a/web/scripts/copy-shoelace-icons.mjs
+++ b/web/scripts/copy-shoelace-icons.mjs
@@ -70,6 +70,7 @@ const USED_ICONS = [
   'download',
   'emoji-frown',
   'envelope',
+  'envelope-open',
   'exclamation-circle-fill',
   'exclamation-octagon',
   'exclamation-triangle',

--- a/web/src/components/pages/admin-users.ts
+++ b/web/src/components/pages/admin-users.ts
@@ -53,6 +53,7 @@ interface AllowListEntry {
   inviteUseCount?: number;
   inviteExpiresAt?: string;
   inviteRevoked?: boolean;
+  inviteExpired?: boolean;
 }
 
 interface InviteCodeEntry {
@@ -1258,7 +1259,7 @@ export class ScionPageAdminUsers extends LitElement {
   private getAllowListInviteStatus(entry: AllowListEntry): string | null {
     if (!entry.inviteId || !entry.inviteCodePrefix) return null;
     if (entry.inviteRevoked) return 'revoked';
-    if (entry.inviteExpiresAt && new Date() > new Date(entry.inviteExpiresAt)) return 'expired';
+    if (entry.inviteExpired) return 'expired';
     if (entry.inviteMaxUses && entry.inviteMaxUses > 0
         && entry.inviteUseCount !== undefined
         && entry.inviteUseCount >= entry.inviteMaxUses) return 'exhausted';

--- a/web/src/components/pages/admin-users.ts
+++ b/web/src/components/pages/admin-users.ts
@@ -47,6 +47,12 @@ interface AllowListEntry {
   addedBy: string;
   inviteId?: string;
   created: string;
+  // Enriched invite details from joined query
+  inviteCodePrefix?: string;
+  inviteMaxUses?: number;
+  inviteUseCount?: number;
+  inviteExpiresAt?: string;
+  inviteRevoked?: boolean;
 }
 
 interface InviteCodeEntry {
@@ -182,6 +188,9 @@ export class ScionPageAdminUsers extends LitElement {
 
   @state()
   private createdInviteResult: InviteCreateResult | null = null;
+
+  @state()
+  private generateInviteForEmail: string | null = null;
 
   @state()
   private inviteCopied = false;
@@ -949,14 +958,14 @@ export class ScionPageAdminUsers extends LitElement {
           aria-controls="panel-allow-list"
           class="tab-btn ${this.activeTab === 'allow-list' ? 'active' : ''}"
           @click=${() => { this.activeTab = 'allow-list'; this.loadAllowList(); }}
-        >Allow List ${this.allowListTotalCount > 0 ? `(${this.allowListTotalCount})` : ''}</button>
+        >Members ${this.allowListTotalCount > 0 ? `(${this.allowListTotalCount})` : ''}</button>
         <button
           role="tab"
           aria-selected=${this.activeTab === 'invites'}
           aria-controls="panel-invites"
           class="tab-btn ${this.activeTab === 'invites' ? 'active' : ''}"
           @click=${() => { this.activeTab = 'invites'; this.loadInvites(); }}
-        >Invites ${this.invitesTotalCount > 0 ? `(${this.invitesTotalCount})` : ''}</button>
+        >All Invites ${this.invitesTotalCount > 0 ? `(${this.invitesTotalCount})` : ''}</button>
       </div>
 
       ${this.activeTab === 'users'
@@ -1221,6 +1230,8 @@ export class ScionPageAdminUsers extends LitElement {
       this.addEmailValue = '';
       this.addEmailNote = '';
       void this.loadAllowList();
+      // Immediately offer to generate an invite for the new member
+      this.openGenerateInviteForMember(email);
     } catch (err) {
       this.showFeedback('danger', err instanceof Error ? err.message : 'Failed to add email');
     } finally {
@@ -1244,6 +1255,29 @@ export class ScionPageAdminUsers extends LitElement {
     }
   }
 
+  private getAllowListInviteStatus(entry: AllowListEntry): string | null {
+    if (!entry.inviteId || !entry.inviteCodePrefix) return null;
+    if (entry.inviteRevoked) return 'revoked';
+    if (entry.inviteExpiresAt && new Date() > new Date(entry.inviteExpiresAt)) return 'expired';
+    if (entry.inviteMaxUses && entry.inviteMaxUses > 0
+        && entry.inviteUseCount !== undefined
+        && entry.inviteUseCount >= entry.inviteMaxUses) return 'exhausted';
+    return 'active';
+  }
+
+  private canGenerateInvite(entry: AllowListEntry): boolean {
+    const status = this.getAllowListInviteStatus(entry);
+    return status === null || status === 'expired' || status === 'revoked' || status === 'exhausted';
+  }
+
+  private openGenerateInviteForMember(email: string): void {
+    this.generateInviteForEmail = email;
+    this.createInviteMaxUses = 1;
+    this.createInviteNote = email;
+    this.createInviteExpiry = '24h';
+    this.showCreateInviteDialog = true;
+  }
+
   private renderAllowListTab() {
     if (this.allowListLoading) {
       return this.renderLoading();
@@ -1251,7 +1285,7 @@ export class ScionPageAdminUsers extends LitElement {
 
     return html`
       <div class="allow-list-header">
-        <span>${this.allowListTotalCount} email${this.allowListTotalCount !== 1 ? 's' : ''} on the allow list</span>
+        <span>${this.allowListTotalCount} member${this.allowListTotalCount !== 1 ? 's' : ''} on the allow list</span>
         <div style="display: flex; gap: 0.5rem">
           <sl-button size="small" variant="default" @click=${() => { this.showImportDialog = true; }}>
             <sl-icon slot="prefix" name="upload"></sl-icon>
@@ -1259,7 +1293,7 @@ export class ScionPageAdminUsers extends LitElement {
           </sl-button>
           <sl-button size="small" variant="primary" @click=${() => { this.showAddEmailDialog = true; this.loadEmailDomains(); }}>
             <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-            Add Email
+            Add Member
           </sl-button>
         </div>
       </div>
@@ -1268,8 +1302,8 @@ export class ScionPageAdminUsers extends LitElement {
         ? html`
             <div class="empty-state">
               <sl-icon name="shield-lock"></sl-icon>
-              <h2>No Allow List Entries</h2>
-              <p>When invite-only mode is enabled, only emails on this list (and admin emails) can log in.</p>
+              <h2>No Members</h2>
+              <p>When invite-only mode is enabled, only emails on this list (and admin emails) can log in. Add a member and generate their invite link.</p>
             </div>
           `
         : html`
@@ -1278,6 +1312,7 @@ export class ScionPageAdminUsers extends LitElement {
                 <thead>
                   <tr>
                     <th>Email</th>
+                    <th>Invite</th>
                     <th class="hide-mobile">Note</th>
                     <th class="hide-mobile">Added</th>
                     <th class="actions-cell"></th>
@@ -1285,27 +1320,56 @@ export class ScionPageAdminUsers extends LitElement {
                 </thead>
                 <tbody>
                   ${this.allowListEntries.map(
-                    (entry) => html`
-                      <tr>
-                        <td>${entry.email}</td>
-                        <td class="hide-mobile"><span class="meta-text">${entry.note || '-'}</span></td>
-                        <td class="hide-mobile"><span class="meta-text">${this.formatRelativeTime(entry.created)}</span></td>
-                        <td class="actions-cell">
-                          <sl-button
-                            size="small"
-                            variant="text"
-                            @click=${() => this.removeFromAllowList(entry.email)}
-                          >
-                            <sl-icon name="trash" style="color: var(--sl-color-danger-600, #dc2626)"></sl-icon>
-                          </sl-button>
-                        </td>
-                      </tr>
-                    `,
+                    (entry) => this.renderAllowListRow(entry),
                   )}
                 </tbody>
               </table>
             </div>
           `}
+    `;
+  }
+
+  private renderAllowListRow(entry: AllowListEntry) {
+    const inviteStatus = this.getAllowListInviteStatus(entry);
+    const canGenerate = this.canGenerateInvite(entry);
+
+    return html`
+      <tr>
+        <td>${entry.email}</td>
+        <td>
+          ${inviteStatus
+            ? html`<span class="invite-status ${inviteStatus}">${inviteStatus}</span>`
+            : html`<span class="meta-text">—</span>`}
+        </td>
+        <td class="hide-mobile"><span class="meta-text">${entry.note || '-'}</span></td>
+        <td class="hide-mobile"><span class="meta-text">${this.formatRelativeTime(entry.created)}</span></td>
+        <td class="actions-cell">
+          <sl-dropdown placement="bottom-end" hoist>
+            <sl-button slot="trigger" size="small" variant="text" caret>
+              <sl-icon name="three-dots-vertical"></sl-icon>
+            </sl-button>
+            <sl-menu>
+              ${canGenerate
+                ? html`<sl-menu-item @click=${() => this.openGenerateInviteForMember(entry.email)}>
+                    <sl-icon slot="prefix" name="send"></sl-icon>
+                    Generate Invite
+                  </sl-menu-item>`
+                : nothing}
+              ${inviteStatus === 'active' && entry.inviteId
+                ? html`<sl-menu-item @click=${() => this.revokeInvite(entry.inviteId!)}>
+                    <sl-icon slot="prefix" name="slash-circle"></sl-icon>
+                    Revoke Invite
+                  </sl-menu-item>`
+                : nothing}
+              ${canGenerate || inviteStatus === 'active' ? html`<sl-divider></sl-divider>` : nothing}
+              <sl-menu-item class="menu-item-danger" @click=${() => this.removeFromAllowList(entry.email)}>
+                <sl-icon slot="prefix" name="trash"></sl-icon>
+                Remove
+              </sl-menu-item>
+            </sl-menu>
+          </sl-dropdown>
+        </td>
+      </tr>
     `;
   }
 
@@ -1320,7 +1384,7 @@ export class ScionPageAdminUsers extends LitElement {
 
     return html`
       <sl-dialog
-        label="Add Email to Allow List"
+        label="Add Member"
         open
         @sl-request-close=${() => { if (!this.addEmailInProgress) this.showAddEmailDialog = false; }}
       >
@@ -1510,15 +1574,19 @@ export class ScionPageAdminUsers extends LitElement {
   private async createInvite(): Promise<void> {
     this.createInviteInProgress = true;
     try {
+      const body: Record<string, unknown> = {
+        expiresIn: this.createInviteExpiry,
+        maxUses: this.createInviteMaxUses,
+        note: this.createInviteNote,
+      };
+      if (this.generateInviteForEmail) {
+        body.email = this.generateInviteForEmail;
+      }
       const response = await fetch('/api/v1/admin/invites', {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          expiresIn: this.createInviteExpiry,
-          maxUses: this.createInviteMaxUses,
-          note: this.createInviteNote,
-        }),
+        body: JSON.stringify(body),
       });
       if (!response.ok) {
         throw new Error(await extractApiError(response, `HTTP ${response.status}`));
@@ -1529,7 +1597,12 @@ export class ScionPageAdminUsers extends LitElement {
       this.createInviteExpiry = '1h';
       this.createInviteMaxUses = 1;
       this.createInviteNote = '';
+      this.generateInviteForEmail = null;
       void this.loadInvites();
+      // Also refresh allow list to show updated inline invite status
+      if (this.activeTab === 'allow-list') {
+        void this.loadAllowList();
+      }
     } catch (err) {
       this.showFeedback('danger', err instanceof Error ? err.message : 'Failed to create invite');
     } finally {
@@ -1548,6 +1621,10 @@ export class ScionPageAdminUsers extends LitElement {
       }
       this.showFeedback('success', 'Invite code revoked.');
       void this.loadInvites();
+      // Also refresh allow list to update inline invite status
+      if (this.activeTab === 'allow-list') {
+        void this.loadAllowList();
+      }
     } catch (err) {
       this.showFeedback('danger', err instanceof Error ? err.message : 'Failed to revoke invite');
     }
@@ -1677,13 +1754,21 @@ export class ScionPageAdminUsers extends LitElement {
 
   private renderCreateInviteDialog() {
     if (!this.showCreateInviteDialog) return nothing;
+    const dialogLabel = this.generateInviteForEmail
+      ? `Generate Invite`
+      : 'Create Invite Code';
     return html`
       <sl-dialog
-        label="Create Invite Code"
+        label=${dialogLabel}
         open
-        @sl-request-close=${() => { if (!this.createInviteInProgress) this.showCreateInviteDialog = false; }}
+        @sl-request-close=${() => { if (!this.createInviteInProgress) { this.showCreateInviteDialog = false; this.generateInviteForEmail = null; } }}
       >
         <div class="create-invite-form">
+          ${this.generateInviteForEmail
+            ? html`<p style="margin: 0; font-size: 0.875rem; color: var(--scion-text-muted, #64748b)">
+                Generating invite for <strong style="color: var(--scion-text, #1e293b)">${this.generateInviteForEmail}</strong>
+              </p>`
+            : nothing}
           <sl-select
             label="Expiration"
             .value=${this.createInviteExpiry}
@@ -1715,14 +1800,14 @@ export class ScionPageAdminUsers extends LitElement {
           slot="footer"
           variant="default"
           ?disabled=${this.createInviteInProgress}
-          @click=${() => { this.showCreateInviteDialog = false; }}
+          @click=${() => { this.showCreateInviteDialog = false; this.generateInviteForEmail = null; }}
         >Cancel</sl-button>
         <sl-button
           slot="footer"
           variant="primary"
           ?loading=${this.createInviteInProgress}
           @click=${() => this.createInvite()}
-        >Create</sl-button>
+        >${this.generateInviteForEmail ? 'Generate' : 'Create'}</sl-button>
       </sl-dialog>
     `;
   }


### PR DESCRIPTION
## Summary

- Merges the separate Allow List and Invites tabs into a unified "Members" view with inline invite management
- Each member row now shows invite status (active/expired/revoked/exhausted) and provides per-row actions (Generate Invite, Revoke, Remove)
- After adding a new member, the invite dialog opens automatically so admins can generate and share an invite link in one flow
- Backend enriches the allow-list API response with joined invite details via LEFT JOIN, and supports linking invites to members at creation time via an optional `email` field on the invite create endpoint

## Changes

### Backend (Go)
- **Store layer:** Added `AllowListEntryWithInvite` model, `UpdateAllowListEntryInviteID` and `ListAllowListEntriesWithInvites` methods (interface + SQLite impl)
- **Hub handlers:** Extended `InviteCreateRequest` with optional `Email` field; updated allow-list GET to return enriched data
- **Hubclient:** Updated `AllowListEntry` and `InviteCreateRequest` types to match

### Frontend (Lit/TypeScript)
- Renamed "Allow List" tab → "Members", "Invites" tab → "All Invites"
- Added inline invite status badge per member row
- Added per-row dropdown menu with Generate Invite, Revoke Invite, Remove
- Create-invite dialog shows contextual header when generating for a specific member
- After adding a new member, invite dialog opens automatically pre-filled
- Fixed missing `envelope-open` icon registration in Shoelace icon list

### Tests
- 7 new tests in `pkg/store/sqlite/allow_list_invite_test.go` covering both new store methods

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./pkg/store/sqlite/ ./pkg/hub/...` passes (all existing + 7 new tests)
- [x] `go build ./...` compiles cleanly
- [x] TypeScript typecheck (`tsc --noEmit`) passes
- [ ] Manual: navigate to `/admin/users` → "Members" tab shows allow-list entries with inline invite status
- [ ] Manual: click "Generate Invite" on a member row → dialog opens pre-filled, creates invite, shows copyable link
- [ ] Manual: add new member via "Add Member" → invite dialog opens automatically after add
- [ ] Manual: "All Invites" tab still functions as before