### PR TITLE
fix: add backward compat for template groveId in store and hub handlers

### DIFF
--- a/.design/project-log/2026-05-13-fix-template-link.md
+++ b/.design/project-log/2026-05-13-fix-template-link.md
@@ -1,0 +1,31 @@
+# Fix Template Link Backward Compatibility
+
+**Date:** 2026-05-13  
+**Branch:** `scion/fix-template-link`  
+**Commit:** b0d8fde
+
+## Problem
+
+After the grove-to-project rename (commit 675a58b), existing projects on hubs lost their template links. The rename added backward-compatible `MarshalJSON`/`UnmarshalJSON` methods to virtually all persistence models (`Agent`, `Project`, `Notification`, etc.) but missed two models: `store.Template` and `store.SubscriptionTemplate`.
+
+Additionally, hub-side handler request types (`CreateTemplateRequest`, `CloneTemplateRequest`, `createTemplateRequest`) did not accept the legacy `groveId` field — so older clients sending `groveId` in template creation/cloning requests silently lost the project association.
+
+## Root Cause
+
+The previous fix (675a58b) focused on `hubclient` types (client-side) but missed the `store` and `hub` (server-side) types for templates.
+
+## Changes
+
+1. **`pkg/store/models.go`** — Added `MarshalJSON`/`UnmarshalJSON` to `store.Template` and `store.SubscriptionTemplate` following the exact pattern used by other models.
+
+2. **`pkg/hub/template_handlers.go`** — Added `UnmarshalJSON` to `CreateTemplateRequest` and `CloneTemplateRequest` to accept `groveId` from older clients.
+
+3. **`pkg/hub/handlers_notifications.go`** — Added `UnmarshalJSON` to `createTemplateRequest` for subscription template creation backward compat.
+
+4. **Tests** — Added 17 new test cases across `pkg/store/models_backward_compat_test.go` and `pkg/hub/capability_marshal_test.go` covering marshal/unmarshal round-trips, `groveId` fallback, and `projectId` precedence.
+
+## Verification
+
+- `go build ./...` — passes
+- `go vet ./...` — passes
+- `go test ./pkg/store/... ./pkg/hub/... ./pkg/hubclient/...` — all pass

--- a/pkg/hub/capability_marshal_test.go
+++ b/pkg/hub/capability_marshal_test.go
@@ -263,3 +263,87 @@ func TestTemplateWithCapabilities_UnmarshalJSON(t *testing.T) {
 		assert.Equal(t, "p1", tmpl.ProjectID)
 	})
 }
+
+func TestCreateTemplateRequest_UnmarshalJSON(t *testing.T) {
+	t.Run("HandleProjectID", func(t *testing.T) {
+		data := `{"name":"tmpl","scope":"project","projectId":"p1"}`
+		var req CreateTemplateRequest
+		err := json.Unmarshal([]byte(data), &req)
+		require.NoError(t, err)
+		assert.Equal(t, "tmpl", req.Name)
+		assert.Equal(t, "p1", req.ProjectID)
+	})
+
+	t.Run("HandleGroveID", func(t *testing.T) {
+		data := `{"name":"tmpl","scope":"project","groveId":"p1"}`
+		var req CreateTemplateRequest
+		err := json.Unmarshal([]byte(data), &req)
+		require.NoError(t, err)
+		assert.Equal(t, "tmpl", req.Name)
+		assert.Equal(t, "p1", req.ProjectID)
+	})
+
+	t.Run("ProjectIDTakesPrecedence", func(t *testing.T) {
+		data := `{"name":"tmpl","scope":"project","projectId":"p1","groveId":"p2"}`
+		var req CreateTemplateRequest
+		err := json.Unmarshal([]byte(data), &req)
+		require.NoError(t, err)
+		assert.Equal(t, "p1", req.ProjectID)
+	})
+}
+
+func TestCloneTemplateRequest_UnmarshalJSON(t *testing.T) {
+	t.Run("HandleProjectID", func(t *testing.T) {
+		data := `{"name":"clone","scope":"project","projectId":"p1"}`
+		var req CloneTemplateRequest
+		err := json.Unmarshal([]byte(data), &req)
+		require.NoError(t, err)
+		assert.Equal(t, "clone", req.Name)
+		assert.Equal(t, "p1", req.ProjectID)
+	})
+
+	t.Run("HandleGroveID", func(t *testing.T) {
+		data := `{"name":"clone","scope":"project","groveId":"p1"}`
+		var req CloneTemplateRequest
+		err := json.Unmarshal([]byte(data), &req)
+		require.NoError(t, err)
+		assert.Equal(t, "clone", req.Name)
+		assert.Equal(t, "p1", req.ProjectID)
+	})
+
+	t.Run("ProjectIDTakesPrecedence", func(t *testing.T) {
+		data := `{"name":"clone","scope":"project","projectId":"p1","groveId":"p2"}`
+		var req CloneTemplateRequest
+		err := json.Unmarshal([]byte(data), &req)
+		require.NoError(t, err)
+		assert.Equal(t, "p1", req.ProjectID)
+	})
+}
+
+func TestCreateNotificationTemplateRequest_UnmarshalJSON(t *testing.T) {
+	t.Run("HandleProjectID", func(t *testing.T) {
+		data := `{"name":"notif","scope":"project","projectId":"p1","triggerActivities":["agent.started"]}`
+		var req createTemplateRequest
+		err := json.Unmarshal([]byte(data), &req)
+		require.NoError(t, err)
+		assert.Equal(t, "notif", req.Name)
+		assert.Equal(t, "p1", req.ProjectID)
+	})
+
+	t.Run("HandleGroveID", func(t *testing.T) {
+		data := `{"name":"notif","scope":"project","groveId":"p1","triggerActivities":["agent.started"]}`
+		var req createTemplateRequest
+		err := json.Unmarshal([]byte(data), &req)
+		require.NoError(t, err)
+		assert.Equal(t, "notif", req.Name)
+		assert.Equal(t, "p1", req.ProjectID)
+	})
+
+	t.Run("ProjectIDTakesPrecedence", func(t *testing.T) {
+		data := `{"name":"notif","scope":"project","projectId":"p1","groveId":"p2","triggerActivities":["agent.started"]}`
+		var req createTemplateRequest
+		err := json.Unmarshal([]byte(data), &req)
+		require.NoError(t, err)
+		assert.Equal(t, "p1", req.ProjectID)
+	})
+}

--- a/pkg/hub/handlers_notifications.go
+++ b/pkg/hub/handlers_notifications.go
@@ -15,6 +15,7 @@
 package hub
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -457,6 +458,22 @@ type createTemplateRequest struct {
 	Scope             string   `json:"scope"`
 	TriggerActivities []string `json:"triggerActivities"`
 	ProjectID         string   `json:"projectId"`
+}
+
+// UnmarshalJSON implements backward compatibility for the grove-to-project rename.
+func (r *createTemplateRequest) UnmarshalJSON(data []byte) error {
+	type Alias createTemplateRequest
+	aux := &struct {
+		GroveID string `json:"groveId"`
+		*Alias
+	}{Alias: (*Alias)(r)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	if r.ProjectID == "" && aux.GroveID != "" {
+		r.ProjectID = aux.GroveID
+	}
+	return nil
 }
 
 // handleSubscriptionTemplateRoutes handles CRUD for subscription templates.

--- a/pkg/hub/template_handlers.go
+++ b/pkg/hub/template_handlers.go
@@ -17,6 +17,7 @@ package hub
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"net/http"
 	"sort"
 	"strconv"
@@ -45,6 +46,24 @@ type CreateTemplateRequest struct {
 	BaseTemplate string                `json:"baseTemplate,omitempty"`
 	Visibility   string                `json:"visibility,omitempty"`
 	Files        []FileUploadRequest   `json:"files,omitempty"`
+}
+
+// UnmarshalJSON implements custom unmarshaling to support legacy groveId field.
+func (r *CreateTemplateRequest) UnmarshalJSON(data []byte) error {
+	type Alias CreateTemplateRequest
+	aux := &struct {
+		GroveID string `json:"groveId"`
+		*Alias
+	}{
+		Alias: (*Alias)(r),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if r.ProjectID == "" && aux.GroveID != "" {
+		r.ProjectID = aux.GroveID
+	}
+	return nil
 }
 
 // FileUploadRequest describes a file to upload.
@@ -114,6 +133,22 @@ type CloneTemplateRequest struct {
 	ScopeID    string `json:"scopeId,omitempty"`
 	ProjectID  string `json:"projectId,omitempty"` // Deprecated
 	Visibility string `json:"visibility,omitempty"`
+}
+
+// UnmarshalJSON implements backward compatibility for the grove-to-project rename.
+func (r *CloneTemplateRequest) UnmarshalJSON(data []byte) error {
+	type Alias CloneTemplateRequest
+	aux := &struct {
+		GroveID string `json:"groveId"`
+		*Alias
+	}{Alias: (*Alias)(r)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	if r.ProjectID == "" && aux.GroveID != "" {
+		r.ProjectID = aux.GroveID
+	}
+	return nil
 }
 
 // handleTemplatesV2 handles the /api/v1/templates endpoint with storage support.

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -427,6 +427,36 @@ type Template struct {
 	Updated time.Time `json:"updated"`
 }
 
+// MarshalJSON implements custom marshaling to support legacy groveId field.
+func (t Template) MarshalJSON() ([]byte, error) {
+	type Alias Template
+	return json.Marshal(&struct {
+		Alias
+		GroveID string `json:"groveId,omitempty"`
+	}{
+		Alias:   Alias(t),
+		GroveID: t.ProjectID,
+	})
+}
+
+// UnmarshalJSON implements custom unmarshaling to support legacy groveId field.
+func (t *Template) UnmarshalJSON(data []byte) error {
+	type Alias Template
+	aux := &struct {
+		GroveID string `json:"groveId"`
+		*Alias
+	}{
+		Alias: (*Alias)(t),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if t.ProjectID == "" && aux.GroveID != "" {
+		t.ProjectID = aux.GroveID
+	}
+	return nil
+}
+
 // TemplateFile represents a file within a template.
 type TemplateFile struct {
 	Path string `json:"path"`           // Relative path (e.g., "home/.bashrc")
@@ -791,6 +821,36 @@ type SubscriptionTemplate struct {
 	TriggerActivities []string `json:"triggerActivities"` // Pre-configured trigger set
 	ProjectID         string   `json:"projectId"`         // Project scope (empty = global)
 	CreatedBy         string   `json:"createdBy"`
+}
+
+// MarshalJSON implements custom marshaling to support legacy groveId field.
+func (t SubscriptionTemplate) MarshalJSON() ([]byte, error) {
+	type Alias SubscriptionTemplate
+	return json.Marshal(&struct {
+		Alias
+		GroveID string `json:"groveId,omitempty"`
+	}{
+		Alias:   Alias(t),
+		GroveID: t.ProjectID,
+	})
+}
+
+// UnmarshalJSON implements custom unmarshaling to support legacy groveId field.
+func (t *SubscriptionTemplate) UnmarshalJSON(data []byte) error {
+	type Alias SubscriptionTemplate
+	aux := &struct {
+		GroveID string `json:"groveId"`
+		*Alias
+	}{
+		Alias: (*Alias)(t),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if t.ProjectID == "" && aux.GroveID != "" {
+		t.ProjectID = aux.GroveID
+	}
+	return nil
 }
 
 // Notification represents a notification record generated from a subscription match.

--- a/pkg/store/models_backward_compat_test.go
+++ b/pkg/store/models_backward_compat_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplate_MarshalJSON_EmitsGroveID(t *testing.T) {
+	tmpl := Template{
+		ID:        "t-1",
+		Name:      "test-template",
+		ProjectID: "p-1",
+		Scope:     "project",
+		Status:    "active",
+	}
+
+	data, err := json.Marshal(tmpl)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	err = json.Unmarshal(data, &m)
+	require.NoError(t, err)
+
+	assert.Equal(t, "p-1", m["projectId"])
+	assert.Equal(t, "p-1", m["groveId"])
+}
+
+func TestTemplate_MarshalJSON_EmptyProjectID(t *testing.T) {
+	tmpl := Template{
+		ID:     "t-1",
+		Name:   "global-template",
+		Scope:  "global",
+		Status: "active",
+	}
+
+	data, err := json.Marshal(tmpl)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	err = json.Unmarshal(data, &m)
+	require.NoError(t, err)
+
+	// Both projectId and groveId should be omitted when empty
+	_, hasProjectID := m["projectId"]
+	_, hasGroveID := m["groveId"]
+	assert.False(t, hasProjectID, "projectId should be omitted when empty")
+	assert.False(t, hasGroveID, "groveId should be omitted when empty")
+}
+
+func TestTemplate_UnmarshalJSON_FromProjectID(t *testing.T) {
+	data := `{"id":"t-1","name":"test","projectId":"p-1","scope":"project","status":"active"}`
+
+	var tmpl Template
+	err := json.Unmarshal([]byte(data), &tmpl)
+	require.NoError(t, err)
+
+	assert.Equal(t, "t-1", tmpl.ID)
+	assert.Equal(t, "p-1", tmpl.ProjectID)
+}
+
+func TestTemplate_UnmarshalJSON_FromGroveID(t *testing.T) {
+	data := `{"id":"t-1","name":"test","groveId":"p-1","scope":"project","status":"active"}`
+
+	var tmpl Template
+	err := json.Unmarshal([]byte(data), &tmpl)
+	require.NoError(t, err)
+
+	assert.Equal(t, "t-1", tmpl.ID)
+	assert.Equal(t, "p-1", tmpl.ProjectID)
+}
+
+func TestTemplate_UnmarshalJSON_ProjectIDTakesPrecedence(t *testing.T) {
+	data := `{"id":"t-1","name":"test","projectId":"p-1","groveId":"p-2","scope":"project","status":"active"}`
+
+	var tmpl Template
+	err := json.Unmarshal([]byte(data), &tmpl)
+	require.NoError(t, err)
+
+	assert.Equal(t, "p-1", tmpl.ProjectID, "projectId should take precedence over groveId")
+}
+
+func TestSubscriptionTemplate_MarshalJSON_EmitsGroveID(t *testing.T) {
+	st := SubscriptionTemplate{
+		ID:        "st-1",
+		Name:      "test-sub-template",
+		ProjectID: "p-1",
+	}
+
+	data, err := json.Marshal(st)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	err = json.Unmarshal(data, &m)
+	require.NoError(t, err)
+
+	assert.Equal(t, "p-1", m["projectId"])
+	assert.Equal(t, "p-1", m["groveId"])
+}
+
+func TestSubscriptionTemplate_UnmarshalJSON_FromGroveID(t *testing.T) {
+	data := `{"id":"st-1","name":"test-sub","groveId":"p-1"}`
+
+	var st SubscriptionTemplate
+	err := json.Unmarshal([]byte(data), &st)
+	require.NoError(t, err)
+
+	assert.Equal(t, "st-1", st.ID)
+	assert.Equal(t, "p-1", st.ProjectID)
+}
+
+func TestSubscriptionTemplate_UnmarshalJSON_ProjectIDTakesPrecedence(t *testing.T) {
+	data := `{"id":"st-1","name":"test-sub","projectId":"p-1","groveId":"p-2"}`
+
+	var st SubscriptionTemplate
+	err := json.Unmarshal([]byte(data), &st)
+	require.NoError(t, err)
+
+	assert.Equal(t, "p-1", st.ProjectID, "projectId should take precedence over groveId")
+}


### PR DESCRIPTION
## Summary

- Add `MarshalJSON`/`UnmarshalJSON` backward compatibility to `store.Template` and `store.SubscriptionTemplate` — these were the only two persistence models missing the `groveId` ↔ `projectId` compat after the grove-to-project rename (675a58b)
- Add `UnmarshalJSON` to hub-side request types (`CreateTemplateRequest`, `CloneTemplateRequest`, `createTemplateRequest`) so older clients sending `groveId` don't silently lose the project association
- Add 17 new test cases covering marshal/unmarshal round-trips, `groveId` fallback, and `projectId` precedence

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/store/...` — all pass (8 new backward compat tests)
- [x] `go test ./pkg/hub/...` — all pass (9 new backward compat tests)
- [x] `go test ./pkg/hubclient/...` — all pass (no regressions)