### PR TITLE
fix: make V53 migration resilient to missing allow_list table

### DIFF
--- a/.design/project-log/2026-05-13-fix-v53-migration.md
+++ b/.design/project-log/2026-05-13-fix-v53-migration.md
@@ -1,0 +1,28 @@
+# Fix V53 Migration Crash
+
+**Date**: 2026-05-13
+**Task**: Fix V53 migration crash due to missing allow_list table
+
+## Problem
+
+Migration V53 (`CREATE INDEX ... ON allow_list`) crashed on existing databases because the `allow_list` table did not exist, despite V48 being recorded as applied in `schema_migrations`.
+
+## Root Cause
+
+Migrations V48 (allow_list table) and V49 (invite_codes table) were inserted into the migration sequence, pushing the grove-to-project rename migration from position 48 to position 50. Databases created before this insertion already had version 48 recorded (for the rename migration). When running the new code, the migration system skips V48 (already applied), so the `allow_list` table is never created. V53 then fails trying to create an index on a nonexistent table.
+
+Evidence: The `foreignKeysOffMigrations` map had `48: true` with the comment "V48 renames tables and columns" — but the current V48 only creates a table. That comment describes the V50 rename migration, confirming V48 and V49 were inserted.
+
+## Fix
+
+1. **V53 now creates `allow_list` and `invite_codes` tables** (with `IF NOT EXISTS`) before adding the index. This is a no-op on fresh databases (tables already exist from V48/V49) but creates the missing tables on upgraded databases.
+2. **Removed stale `foreignKeysOffMigrations[48]`** entry. The current V48 (`CREATE TABLE`) does not need `PRAGMA foreign_keys=OFF`; that was only needed when position 48 held the rename migration.
+
+## Testing
+
+- Added `TestMigrationV53_AllowListMissing` regression test that simulates the bug (drops allow_list, resets schema_migrations to version 48, verifies Migrate succeeds and creates the table + index).
+- All existing migration tests continue to pass.
+
+## Key Insight
+
+Inserting migrations into the middle of a numbered sequence is dangerous when existing databases have already applied versions at those positions. The inserted migrations will be silently skipped on upgrade. Future migrations that depend on the inserted ones (like V53 depending on V48's table) will crash.

--- a/pkg/store/sqlite/sqlite.go
+++ b/pkg/store/sqlite/sqlite.go
@@ -172,7 +172,6 @@ func (s *SQLiteStore) Migrate(ctx context.Context) error {
 	// DROP TABLE on a parent table triggers ON DELETE CASCADE on child tables.
 	foreignKeysOffMigrations := map[int]bool{
 		40: true, // V40 drops and recreates the projects table
-		48: true, // V48 renames tables and columns
 	}
 
 	// Apply pending migrations
@@ -1342,7 +1341,32 @@ UPDATE agents SET stalled_from_activity = 'working' WHERE stalled_from_activity 
 `
 
 // migrationV53 adds an index on (created, id) to allow_list for efficient keyset pagination.
+// It also ensures the allow_list table exists, because databases created before V48/V49 were
+// inserted into the migration sequence already have version 48 recorded with different content
+// (the grove-to-project rename that is now V50). On those databases V48 is skipped, so the
+// allow_list table was never created.
 const migrationV53 = `
+CREATE TABLE IF NOT EXISTS allow_list (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE COLLATE NOCASE,
+    note TEXT NOT NULL DEFAULT '',
+    added_by TEXT NOT NULL,
+    invite_id TEXT NOT NULL DEFAULT '',
+    created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE IF NOT EXISTS invite_codes (
+    id TEXT PRIMARY KEY,
+    code_hash TEXT NOT NULL UNIQUE,
+    code_prefix TEXT NOT NULL,
+    max_uses INTEGER NOT NULL DEFAULT 1,
+    use_count INTEGER NOT NULL DEFAULT 0,
+    expires_at DATETIME NOT NULL,
+    revoked INTEGER NOT NULL DEFAULT 0,
+    created_by TEXT NOT NULL,
+    note TEXT NOT NULL DEFAULT '',
+    created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_invite_codes_expires ON invite_codes(expires_at);
 CREATE INDEX IF NOT EXISTS idx_allow_list_created_id ON allow_list (created DESC, id DESC);
 `
 

--- a/pkg/store/sqlite/sqlite_test.go
+++ b/pkg/store/sqlite/sqlite_test.go
@@ -18,6 +18,7 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 	"testing"
@@ -2020,6 +2021,58 @@ func TestMigrationV40PreservesAgents(t *testing.T) {
 	agent, err = s.GetAgent(ctx, agentID)
 	require.NoError(t, err)
 	assert.Equal(t, "Test Agent", agent.Name)
+}
+
+func TestMigrationV53_AllowListMissing(t *testing.T) {
+	// Regression test: V48 and V49 were inserted into the migration sequence,
+	// pushing the grove-to-project rename from V48 to V50. Databases that
+	// already applied the old V48 (the rename) have version 48 recorded in
+	// schema_migrations, so the new V48 (CREATE TABLE allow_list) is skipped.
+	// V53 must create the allow_list table if it doesn't exist before adding
+	// the index.
+	s, err := New(":memory:")
+	require.NoError(t, err)
+	defer s.Close()
+
+	ctx := context.Background()
+
+	// Run all migrations normally first.
+	err = s.Migrate(ctx)
+	require.NoError(t, err)
+
+	// Simulate the bug: drop allow_list (as if V48 was a different migration
+	// when it was originally applied) and roll back schema_migrations so V53
+	// will re-run.
+	_, err = s.db.ExecContext(ctx, `
+		DROP TABLE IF EXISTS allow_list;
+		DELETE FROM schema_migrations WHERE version >= 53;
+	`)
+	require.NoError(t, err)
+
+	// Verify allow_list doesn't exist.
+	var tableName string
+	err = s.db.QueryRowContext(ctx,
+		"SELECT name FROM sqlite_master WHERE type='table' AND name='allow_list'",
+	).Scan(&tableName)
+	require.ErrorIs(t, err, sql.ErrNoRows,
+		"allow_list should not exist before re-migration")
+
+	// Re-run Migrate. V53 should succeed by creating the allow_list table
+	// before adding the index.
+	err = s.Migrate(ctx)
+	require.NoError(t, err, "Migrate must succeed even when allow_list was never created by V48")
+
+	// Verify allow_list table now exists and is usable.
+	_, err = s.db.ExecContext(ctx,
+		"INSERT INTO allow_list (id, email, added_by) VALUES ('test-id', 'test@example.com', 'admin')")
+	require.NoError(t, err, "allow_list table should be usable after migration")
+
+	// Verify the index exists.
+	var indexName string
+	err = s.db.QueryRowContext(ctx,
+		"SELECT name FROM sqlite_master WHERE type='index' AND name='idx_allow_list_created_id'",
+	).Scan(&indexName)
+	require.NoError(t, err, "idx_allow_list_created_id index should exist")
 }
 
 func TestPing(t *testing.T) {


### PR DESCRIPTION
## Summary

- **V53 migration crashed** on existing databases because `allow_list` table was missing despite V48 being recorded as applied
- **Root cause**: V48 (allow_list) and V49 (invite_codes) were inserted into the migration sequence, pushing the grove-to-project rename from position 48 to 50. Databases with the old V48 already applied silently skip the new V48, so `allow_list` is never created
- **Fix**: V53 now creates `allow_list` and `invite_codes` tables (IF NOT EXISTS) before the index, handling both fresh and upgraded databases
- Removed stale `foreignKeysOffMigrations[48]` entry that was left over from when position 48 held the rename migration

## Test plan

- [x] Added `TestMigrationV53_AllowListMissing` regression test simulating the bug scenario
- [x] All existing migration tests pass (`TestMigration`, `TestMigrationV40PreservesAgents`, `TestDropTableCascadesWithForeignKeysOn`)
- [x] Full `go test ./pkg/store/sqlite/` passes
- [x] `go build ./...` succeeds