### PR TITLE
feat: add MappingDialect and harness type passthrough

### DIFF
--- a/cmd/sciontool/commands/hook.go
+++ b/cmd/sciontool/commands/hook.go
@@ -175,6 +175,13 @@ func processHookData(data []byte) error {
 	// Register built-in dialects.
 	dialects.RegisterBuiltins(processor)
 
+	// Discover data-driven dialect from harness bundle if not built-in.
+	if _, ok := processor.Dialects[hookDialect]; !ok {
+		if md, err := dialects.DiscoverMappingDialect(hookDialect); err == nil {
+			processor.RegisterDialect(md)
+		}
+	}
+
 	// Register handlers
 	statusHandler := handlers.NewStatusHandler()
 	loggingHandler := handlers.NewLoggingHandler()

--- a/pkg/hub/harness_capabilities.go
+++ b/pkg/hub/harness_capabilities.go
@@ -58,6 +58,9 @@ func (s *Server) resolveHarnessTypeFromConfigRef(ctx context.Context, projectID,
 			if inferred := inferHarnessFromName(hc.Harness); inferred != "" {
 				return inferred
 			}
+			if hc.Harness != "" {
+				return hc.Harness
+			}
 		}
 	}
 
@@ -68,6 +71,9 @@ func (s *Server) resolveHarnessTypeFromConfigRef(ctx context.Context, projectID,
 		}
 		if inferred := inferHarnessFromName(hc.Harness); inferred != "" {
 			return inferred
+		}
+		if hc.Harness != "" {
+			return hc.Harness
 		}
 	}
 
@@ -85,6 +91,9 @@ func (s *Server) resolveAgentHarnessType(ctx context.Context, agent *store.Agent
 	if agent.AppliedConfig != nil && agent.AppliedConfig.InlineConfig != nil {
 		if h := canonicalHarnessName(agent.AppliedConfig.InlineConfig.Harness); h != "" {
 			return h
+		}
+		if agent.AppliedConfig.InlineConfig.Harness != "" {
+			return agent.AppliedConfig.InlineConfig.Harness
 		}
 	}
 

--- a/pkg/hub/harness_capabilities_test.go
+++ b/pkg/hub/harness_capabilities_test.go
@@ -121,3 +121,28 @@ func TestUpdateAgent_AllowsMaxDurationForAllHarnesses(t *testing.T) {
 	require.NotNil(t, updated.AppliedConfig.InlineConfig)
 	assert.Equal(t, "10m", updated.AppliedConfig.InlineConfig.MaxDuration)
 }
+
+func TestGetAgent_CustomHarnessTypeFromHarnessConfig(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	hc := &store.HarnessConfig{
+		ID:         "hc-custom",
+		Name:       "custom-harness",
+		Slug:       "custom-harness",
+		Harness:    "custom-harness",
+		Scope:      store.HarnessConfigScopeGlobal,
+		Status:     store.HarnessConfigStatusActive,
+		Visibility: store.VisibilityPublic,
+	}
+	require.NoError(t, s.CreateHarnessConfig(ctx, hc))
+
+	agent := seedCreatedAgentForHarnessTest(t, s, "custom-type", "custom-harness")
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/agents/"+agent.ID, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got AgentWithCapabilities
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "custom-harness", got.ResolvedHarness, "custom harness type should pass through from Hub DB harness config")
+}

--- a/pkg/sciontool/hooks/dialects/mapping.go
+++ b/pkg/sciontool/hooks/dialects/mapping.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2026 The Scion Authors.
+*/
+
+package dialects
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hooks"
+	"gopkg.in/yaml.v3"
+)
+
+// MappingDialectSpec defines a data-driven dialect loaded from a YAML file.
+// It maps harness-specific event names to normalized Scion event names and
+// optionally extracts fields from the event payload using dotted paths.
+type MappingDialectSpec struct {
+	Dialect        string                      `yaml:"dialect"`
+	EventNameField string                      `yaml:"event_name_field"`
+	Mappings       map[string]MappingEntrySpec `yaml:"mappings"`
+}
+
+// MappingEntrySpec defines how a single harness event maps to a normalized event.
+type MappingEntrySpec struct {
+	Event  string            `yaml:"event"`
+	Fields map[string]string `yaml:"fields,omitempty"`
+}
+
+// MappingDialect implements hooks.Dialect using a data-driven spec loaded from YAML.
+type MappingDialect struct {
+	spec MappingDialectSpec
+}
+
+// NewMappingDialect creates a MappingDialect from a parsed spec.
+func NewMappingDialect(spec MappingDialectSpec) *MappingDialect {
+	return &MappingDialect{spec: spec}
+}
+
+// Name returns the dialect name as declared in the spec.
+func (d *MappingDialect) Name() string {
+	return d.spec.Dialect
+}
+
+// Parse converts a harness event payload into a normalized Event using the
+// mapping spec. Common fields (prompt, tool_name, message, etc.) are always
+// extracted from top-level data. Custom field paths from the mapping entry
+// override those defaults.
+func (d *MappingDialect) Parse(data map[string]interface{}) (*hooks.Event, error) {
+	rawName := getString(data, d.spec.EventNameField)
+
+	normalizedName := rawName
+	var entry *MappingEntrySpec
+	if m, ok := d.spec.Mappings[rawName]; ok {
+		normalizedName = m.Event
+		entry = &m
+	}
+
+	event := &hooks.Event{
+		Name:    normalizedName,
+		RawName: rawName,
+		Dialect: d.spec.Dialect,
+		Data: hooks.EventData{
+			Prompt:    getString(data, "prompt"),
+			ToolName:  getString(data, "tool_name"),
+			Message:   getString(data, "message"),
+			Reason:    getString(data, "reason"),
+			Source:    getString(data, "source"),
+			SessionID: getString(data, "session_id"),
+			Raw:       data,
+		},
+	}
+
+	// Extract tool input/output if available as strings
+	if val, ok := data["tool_input"]; ok {
+		if str, ok := val.(string); ok {
+			event.Data.ToolInput = str
+		}
+	}
+	if val, ok := data["tool_output"]; ok {
+		if str, ok := val.(string); ok {
+			event.Data.ToolOutput = str
+		}
+	}
+
+	// Extract status fields
+	if val, ok := data["success"]; ok {
+		if b, ok := val.(bool); ok {
+			event.Data.Success = b
+		}
+	}
+	if val, ok := data["error"]; ok {
+		if str, ok := val.(string); ok {
+			event.Data.Error = str
+		}
+	}
+
+	// Apply custom field paths from the mapping entry, overriding defaults.
+	if entry != nil {
+		for field, path := range entry.Fields {
+			applyFieldPath(data, field, path, &event.Data)
+		}
+	}
+
+	// Run common token and file path extraction (shared with all dialects).
+	extractTokens(data, &event.Data)
+	extractFilePath(data, &event.Data)
+
+	return event, nil
+}
+
+// applyFieldPath resolves a dotted path in the data and assigns the result
+// to the named field on EventData.
+func applyFieldPath(data map[string]interface{}, field, path string, ed *hooks.EventData) {
+	switch field {
+	case "tool_name":
+		if v := resolveFieldPath(data, path); v != "" {
+			ed.ToolName = v
+		}
+	case "tool_input":
+		if v := resolveFieldPathRaw(data, path); v != "" {
+			ed.ToolInput = v
+		}
+	case "tool_output":
+		if v := resolveFieldPathRaw(data, path); v != "" {
+			ed.ToolOutput = v
+		}
+	case "prompt":
+		if v := resolveFieldPath(data, path); v != "" {
+			ed.Prompt = v
+		}
+	case "message":
+		if v := resolveFieldPath(data, path); v != "" {
+			ed.Message = v
+		}
+	case "reason":
+		if v := resolveFieldPath(data, path); v != "" {
+			ed.Reason = v
+		}
+	case "source":
+		if v := resolveFieldPath(data, path); v != "" {
+			ed.Source = v
+		}
+	case "session_id":
+		if v := resolveFieldPath(data, path); v != "" {
+			ed.SessionID = v
+		}
+	case "error":
+		if v := resolveFieldPath(data, path); v != "" {
+			ed.Error = v
+		}
+	case "file_path":
+		if v := resolveFieldPath(data, path); v != "" {
+			ed.FilePath = v
+		}
+	case "success":
+		if val, found := resolveFieldPathBool(data, path); found {
+			ed.Success = val
+		}
+	}
+}
+
+// resolveFieldPath walks a dotted path (e.g. ".toolCall.name") through nested
+// maps and returns the string value at the terminal key. Returns "" on any
+// miss or non-string terminal.
+func resolveFieldPath(data map[string]interface{}, path string) string {
+	val := walkPath(data, path)
+	if val == nil {
+		return ""
+	}
+	if str, ok := val.(string); ok {
+		return str
+	}
+	return ""
+}
+
+// resolveFieldPathRaw walks a dotted path and returns the value as a string.
+// Non-string terminal values are JSON-serialized (useful for tool_input which
+// may be an object).
+func resolveFieldPathRaw(data map[string]interface{}, path string) string {
+	val := walkPath(data, path)
+	if val == nil {
+		return ""
+	}
+	if str, ok := val.(string); ok {
+		return str
+	}
+	b, err := json.Marshal(val)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// resolveFieldPathBool walks a dotted path and returns a boolean value.
+func resolveFieldPathBool(data map[string]interface{}, path string) (bool, bool) {
+	val := walkPath(data, path)
+	if val == nil {
+		return false, false
+	}
+	if b, ok := val.(bool); ok {
+		return b, true
+	}
+	return false, false
+}
+
+// walkPath navigates nested maps following a dotted path like ".toolCall.name".
+func walkPath(data map[string]interface{}, path string) interface{} {
+	path = strings.TrimPrefix(path, ".")
+	if path == "" {
+		return nil
+	}
+	segments := strings.Split(path, ".")
+	var current interface{} = data
+	for _, seg := range segments {
+		m, ok := current.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		current, ok = m[seg]
+		if !ok {
+			return nil
+		}
+	}
+	return current
+}
+
+// LoadMappingDialect reads a dialect.yaml file and returns a MappingDialect.
+func LoadMappingDialect(path string) (*MappingDialect, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading dialect spec: %w", err)
+	}
+
+	var spec MappingDialectSpec
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("parsing dialect spec: %w", err)
+	}
+
+	if spec.Dialect == "" {
+		return nil, fmt.Errorf("dialect spec missing required 'dialect' field")
+	}
+	if spec.EventNameField == "" {
+		return nil, fmt.Errorf("dialect spec missing required 'event_name_field' field")
+	}
+
+	return NewMappingDialect(spec), nil
+}
+
+// DiscoverMappingDialect looks for a dialect.yaml in the well-known harness
+// bundle path ($HOME/.scion/harness/dialect.yaml) and loads it if the declared
+// dialect name matches the requested name.
+func DiscoverMappingDialect(dialectName string) (*MappingDialect, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine home directory: %w", err)
+	}
+
+	path := filepath.Join(home, ".scion", "harness", "dialect.yaml")
+	md, err := LoadMappingDialect(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if md.Name() != dialectName {
+		return nil, fmt.Errorf("dialect.yaml declares dialect %q but %q was requested", md.Name(), dialectName)
+	}
+
+	return md, nil
+}

--- a/pkg/sciontool/hooks/dialects/mapping_test.go
+++ b/pkg/sciontool/hooks/dialects/mapping_test.go
@@ -1,0 +1,452 @@
+/*
+Copyright 2026 The Scion Authors.
+*/
+
+package dialects
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hooks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMappingDialect_Name(t *testing.T) {
+	md := NewMappingDialect(MappingDialectSpec{
+		Dialect:        "test-harness",
+		EventNameField: "event",
+	})
+	assert.Equal(t, "test-harness", md.Name())
+}
+
+func TestMappingDialect_Parse_SimpleMapping(t *testing.T) {
+	spec := MappingDialectSpec{
+		Dialect:        "test",
+		EventNameField: "hook_event_name",
+		Mappings: map[string]MappingEntrySpec{
+			"SessionBegin": {Event: hooks.EventSessionStart},
+			"SessionDone":  {Event: hooks.EventSessionEnd},
+			"BeforeTool":   {Event: hooks.EventToolStart},
+			"AfterTool":    {Event: hooks.EventToolEnd},
+		},
+	}
+	md := NewMappingDialect(spec)
+
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		wantName string
+	}{
+		{
+			name:     "SessionBegin maps to session-start",
+			input:    map[string]interface{}{"hook_event_name": "SessionBegin"},
+			wantName: hooks.EventSessionStart,
+		},
+		{
+			name:     "SessionDone maps to session-end",
+			input:    map[string]interface{}{"hook_event_name": "SessionDone"},
+			wantName: hooks.EventSessionEnd,
+		},
+		{
+			name:     "BeforeTool maps to tool-start",
+			input:    map[string]interface{}{"hook_event_name": "BeforeTool", "tool_name": "shell"},
+			wantName: hooks.EventToolStart,
+		},
+		{
+			name:     "AfterTool maps to tool-end",
+			input:    map[string]interface{}{"hook_event_name": "AfterTool"},
+			wantName: hooks.EventToolEnd,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event, err := md.Parse(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantName, event.Name)
+			assert.Equal(t, "test", event.Dialect)
+		})
+	}
+}
+
+func TestMappingDialect_Parse_UnknownEvent(t *testing.T) {
+	md := NewMappingDialect(MappingDialectSpec{
+		Dialect:        "test",
+		EventNameField: "hook_event_name",
+		Mappings:       map[string]MappingEntrySpec{},
+	})
+
+	event, err := md.Parse(map[string]interface{}{
+		"hook_event_name": "UnmappedEvent",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "UnmappedEvent", event.Name, "unmapped events should pass through")
+	assert.Equal(t, "UnmappedEvent", event.RawName)
+}
+
+func TestMappingDialect_Parse_CommonFields(t *testing.T) {
+	md := NewMappingDialect(MappingDialectSpec{
+		Dialect:        "test",
+		EventNameField: "event",
+		Mappings: map[string]MappingEntrySpec{
+			"test": {Event: "test-event"},
+		},
+	})
+
+	event, err := md.Parse(map[string]interface{}{
+		"event":      "test",
+		"prompt":     "hello world",
+		"tool_name":  "bash",
+		"message":    "some message",
+		"reason":     "done",
+		"source":     "user",
+		"session_id": "abc-123",
+		"error":      "oops",
+		"success":    true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", event.Data.Prompt)
+	assert.Equal(t, "bash", event.Data.ToolName)
+	assert.Equal(t, "some message", event.Data.Message)
+	assert.Equal(t, "done", event.Data.Reason)
+	assert.Equal(t, "user", event.Data.Source)
+	assert.Equal(t, "abc-123", event.Data.SessionID)
+	assert.Equal(t, "oops", event.Data.Error)
+	assert.True(t, event.Data.Success)
+}
+
+func TestMappingDialect_Parse_FieldExtraction(t *testing.T) {
+	spec := MappingDialectSpec{
+		Dialect:        "test",
+		EventNameField: "hook_event_name",
+		Mappings: map[string]MappingEntrySpec{
+			"ToolCall": {
+				Event: hooks.EventToolStart,
+				Fields: map[string]string{
+					"tool_name":  ".toolCall.name",
+					"tool_input": ".toolCall.args",
+				},
+			},
+			"ToolResult": {
+				Event: hooks.EventToolEnd,
+				Fields: map[string]string{
+					"tool_name": ".toolCall.name",
+					"error":     ".error",
+					"success":   ".result.ok",
+				},
+			},
+		},
+	}
+	md := NewMappingDialect(spec)
+
+	t.Run("nested field extraction", func(t *testing.T) {
+		event, err := md.Parse(map[string]interface{}{
+			"hook_event_name": "ToolCall",
+			"toolCall": map[string]interface{}{
+				"name": "write_to_file",
+				"args": map[string]interface{}{
+					"TargetFile": "/tmp/test.txt",
+					"Content":    "hello",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, hooks.EventToolStart, event.Name)
+		assert.Equal(t, "write_to_file", event.Data.ToolName)
+		assert.Contains(t, event.Data.ToolInput, "TargetFile")
+	})
+
+	t.Run("boolean field extraction", func(t *testing.T) {
+		event, err := md.Parse(map[string]interface{}{
+			"hook_event_name": "ToolResult",
+			"toolCall": map[string]interface{}{
+				"name": "shell",
+			},
+			"result": map[string]interface{}{
+				"ok": true,
+			},
+			"error": "",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, hooks.EventToolEnd, event.Name)
+		assert.Equal(t, "shell", event.Data.ToolName)
+		assert.True(t, event.Data.Success)
+	})
+
+	t.Run("missing nested path returns empty", func(t *testing.T) {
+		event, err := md.Parse(map[string]interface{}{
+			"hook_event_name": "ToolCall",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, hooks.EventToolStart, event.Name)
+		assert.Empty(t, event.Data.ToolName)
+	})
+}
+
+func TestMappingDialect_Parse_TokenExtraction(t *testing.T) {
+	md := NewMappingDialect(MappingDialectSpec{
+		Dialect:        "test",
+		EventNameField: "event",
+		Mappings: map[string]MappingEntrySpec{
+			"model_done": {Event: hooks.EventModelEnd},
+		},
+	})
+
+	event, err := md.Parse(map[string]interface{}{
+		"event": "model_done",
+		"usage": map[string]interface{}{
+			"input_tokens":  float64(100),
+			"output_tokens": float64(50),
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), event.Data.InputTokens)
+	assert.Equal(t, int64(50), event.Data.OutputTokens)
+}
+
+func TestLoadMappingDialect(t *testing.T) {
+	t.Run("valid spec", func(t *testing.T) {
+		dir := t.TempDir()
+		specPath := filepath.Join(dir, "dialect.yaml")
+		err := os.WriteFile(specPath, []byte(`
+dialect: my-harness
+event_name_field: event_type
+mappings:
+  Start:
+    event: session-start
+  Stop:
+    event: agent-end
+    fields:
+      reason: .terminationReason
+`), 0644)
+		require.NoError(t, err)
+
+		md, err := LoadMappingDialect(specPath)
+		require.NoError(t, err)
+		assert.Equal(t, "my-harness", md.Name())
+		assert.Equal(t, "event_type", md.spec.EventNameField)
+		assert.Len(t, md.spec.Mappings, 2)
+		assert.Equal(t, "session-start", md.spec.Mappings["Start"].Event)
+		assert.Equal(t, ".terminationReason", md.spec.Mappings["Stop"].Fields["reason"])
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := LoadMappingDialect("/nonexistent/dialect.yaml")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "reading dialect spec")
+	})
+
+	t.Run("malformed YAML", func(t *testing.T) {
+		dir := t.TempDir()
+		specPath := filepath.Join(dir, "dialect.yaml")
+		err := os.WriteFile(specPath, []byte("not: valid: yaml: ["), 0644)
+		require.NoError(t, err)
+
+		_, err = LoadMappingDialect(specPath)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "parsing dialect spec")
+	})
+
+	t.Run("missing dialect field", func(t *testing.T) {
+		dir := t.TempDir()
+		specPath := filepath.Join(dir, "dialect.yaml")
+		err := os.WriteFile(specPath, []byte(`
+event_name_field: event
+mappings:
+  Start:
+    event: session-start
+`), 0644)
+		require.NoError(t, err)
+
+		_, err = LoadMappingDialect(specPath)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required 'dialect' field")
+	})
+
+	t.Run("missing event_name_field", func(t *testing.T) {
+		dir := t.TempDir()
+		specPath := filepath.Join(dir, "dialect.yaml")
+		err := os.WriteFile(specPath, []byte(`
+dialect: test
+mappings:
+  Start:
+    event: session-start
+`), 0644)
+		require.NoError(t, err)
+
+		_, err = LoadMappingDialect(specPath)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required 'event_name_field' field")
+	})
+}
+
+func TestDiscoverMappingDialect(t *testing.T) {
+	t.Run("found and name matches", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		bundleDir := filepath.Join(home, ".scion", "harness")
+		require.NoError(t, os.MkdirAll(bundleDir, 0755))
+		err := os.WriteFile(filepath.Join(bundleDir, "dialect.yaml"), []byte(`
+dialect: my-harness
+event_name_field: event
+mappings:
+  Ping:
+    event: notification
+`), 0644)
+		require.NoError(t, err)
+
+		md, err := DiscoverMappingDialect("my-harness")
+		require.NoError(t, err)
+		assert.Equal(t, "my-harness", md.Name())
+	})
+
+	t.Run("name mismatch", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		bundleDir := filepath.Join(home, ".scion", "harness")
+		require.NoError(t, os.MkdirAll(bundleDir, 0755))
+		err := os.WriteFile(filepath.Join(bundleDir, "dialect.yaml"), []byte(`
+dialect: other-harness
+event_name_field: event
+mappings: {}
+`), 0644)
+		require.NoError(t, err)
+
+		_, err = DiscoverMappingDialect("my-harness")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "declares dialect \"other-harness\" but \"my-harness\" was requested")
+	})
+
+	t.Run("no dialect.yaml present", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		_, err := DiscoverMappingDialect("anything")
+		assert.Error(t, err)
+	})
+}
+
+func TestMappingDialect_FullHarnessEvents(t *testing.T) {
+	spec := MappingDialectSpec{
+		Dialect:        "example-harness",
+		EventNameField: "hook_event_name",
+		Mappings: map[string]MappingEntrySpec{
+			"PreInvocation":  {Event: hooks.EventModelStart},
+			"PostInvocation": {Event: hooks.EventModelEnd},
+			"PreToolUse": {
+				Event: hooks.EventToolStart,
+				Fields: map[string]string{
+					"tool_name": ".toolCall.name",
+				},
+			},
+			"PostToolUse": {
+				Event: hooks.EventToolEnd,
+				Fields: map[string]string{
+					"tool_name": ".toolCall.name",
+					"error":     ".error",
+				},
+			},
+			"Stop": {
+				Event: hooks.EventAgentEnd,
+				Fields: map[string]string{
+					"reason": ".terminationReason",
+					"error":  ".error",
+				},
+			},
+		},
+	}
+	md := NewMappingDialect(spec)
+
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		wantName string
+		wantTool string
+		check    func(t *testing.T, e *hooks.Event)
+	}{
+		{
+			name: "PreInvocation",
+			input: map[string]interface{}{
+				"hook_event_name": "PreInvocation",
+				"conversationId":  "uuid-123",
+				"invocationNum":   float64(0),
+			},
+			wantName: hooks.EventModelStart,
+		},
+		{
+			name: "PostInvocation",
+			input: map[string]interface{}{
+				"hook_event_name": "PostInvocation",
+				"conversationId":  "uuid-123",
+				"invocationNum":   float64(1),
+			},
+			wantName: hooks.EventModelEnd,
+		},
+		{
+			name: "PreToolUse with nested toolCall",
+			input: map[string]interface{}{
+				"hook_event_name": "PreToolUse",
+				"stepIdx":         float64(3),
+				"toolCall": map[string]interface{}{
+					"name": "write_to_file",
+					"args": map[string]interface{}{
+						"TargetFile":  "/tmp/hello.txt",
+						"CodeContent": "Hello",
+					},
+				},
+			},
+			wantName: hooks.EventToolStart,
+			wantTool: "write_to_file",
+		},
+		{
+			name: "PostToolUse with error",
+			input: map[string]interface{}{
+				"hook_event_name": "PostToolUse",
+				"stepIdx":         float64(3),
+				"toolCall": map[string]interface{}{
+					"name": "run_command",
+				},
+				"error": "command failed",
+			},
+			wantName: hooks.EventToolEnd,
+			wantTool: "run_command",
+			check: func(t *testing.T, e *hooks.Event) {
+				assert.Equal(t, "command failed", e.Data.Error)
+			},
+		},
+		{
+			name: "Stop",
+			input: map[string]interface{}{
+				"hook_event_name":   "Stop",
+				"terminationReason": "NO_TOOL_CALL",
+				"fullyIdle":         true,
+				"executionNum":      float64(0),
+				"error":             "",
+			},
+			wantName: hooks.EventAgentEnd,
+			check: func(t *testing.T, e *hooks.Event) {
+				assert.Equal(t, "NO_TOOL_CALL", e.Data.Reason)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event, err := md.Parse(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantName, event.Name)
+			assert.Equal(t, "example-harness", event.Dialect)
+			if tt.wantTool != "" {
+				assert.Equal(t, tt.wantTool, event.Data.ToolName)
+			}
+			if tt.check != nil {
+				tt.check(t, event)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a data-driven MappingDialect for hook event translation that reads field mappings from a dialect.yaml file, enabling new harness integrations without writing Go code.

Fix custom harness type passthrough from Hub DB so non-canonical harness names are used directly instead of falling back to empty string.

