### PR TITLE
feat: add MappingDialect and harness type passthrough

### DIFF
--- a/pkg/sciontool/hooks/dialects/mapping.go
+++ b/pkg/sciontool/hooks/dialects/mapping.go
@@ -51,6 +51,9 @@ func (d *MappingDialect) Name() string {
 // override those defaults.
 func (d *MappingDialect) Parse(data map[string]interface{}) (*hooks.Event, error) {
 	rawName := getString(data, d.spec.EventNameField)
+	if rawName == "" {
+		return nil, fmt.Errorf("event name field %q missing or empty in input data", d.spec.EventNameField)
+	}
 
 	normalizedName := rawName
 	var entry *MappingEntrySpec
@@ -156,6 +159,22 @@ func applyFieldPath(data map[string]interface{}, field, path string, ed *hooks.E
 		if v := resolveFieldPath(data, path); v != "" {
 			ed.FilePath = v
 		}
+	case "assistant_text":
+		if v := resolveFieldPath(data, path); v != "" {
+			ed.AssistantText = v
+		}
+	case "input_tokens":
+		if v := resolveFieldPathInt64(data, path); v > 0 {
+			ed.InputTokens = v
+		}
+	case "output_tokens":
+		if v := resolveFieldPathInt64(data, path); v > 0 {
+			ed.OutputTokens = v
+		}
+	case "cached_tokens":
+		if v := resolveFieldPathInt64(data, path); v > 0 {
+			ed.CachedTokens = v
+		}
 	case "success":
 		if val, found := resolveFieldPathBool(data, path); found {
 			ed.Success = val
@@ -205,6 +224,24 @@ func resolveFieldPathBool(data map[string]interface{}, path string) (bool, bool)
 		return b, true
 	}
 	return false, false
+}
+
+// resolveFieldPathInt64 walks a dotted path and returns an int64 value.
+// JSON numbers arrive as float64, so both float64 and integer types are handled.
+func resolveFieldPathInt64(data map[string]interface{}, path string) int64 {
+	val := walkPath(data, path)
+	if val == nil {
+		return 0
+	}
+	switch v := val.(type) {
+	case float64:
+		return int64(v)
+	case int64:
+		return v
+	case int:
+		return int64(v)
+	}
+	return 0
 }
 
 // walkPath navigates nested maps following a dotted path like ".toolCall.name".

--- a/pkg/sciontool/hooks/dialects/mapping_test.go
+++ b/pkg/sciontool/hooks/dialects/mapping_test.go
@@ -186,6 +186,95 @@ func TestMappingDialect_Parse_FieldExtraction(t *testing.T) {
 	})
 }
 
+func TestMappingDialect_Parse_MissingEventName(t *testing.T) {
+	md := NewMappingDialect(MappingDialectSpec{
+		Dialect:        "test",
+		EventNameField: "hook_event_name",
+		Mappings:       map[string]MappingEntrySpec{},
+	})
+
+	t.Run("missing event name field returns error", func(t *testing.T) {
+		_, err := md.Parse(map[string]interface{}{
+			"some_other_field": "value",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "hook_event_name")
+		assert.Contains(t, err.Error(), "missing or empty")
+	})
+
+	t.Run("empty event name returns error", func(t *testing.T) {
+		_, err := md.Parse(map[string]interface{}{
+			"hook_event_name": "",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing or empty")
+	})
+
+	t.Run("non-string event name returns error", func(t *testing.T) {
+		_, err := md.Parse(map[string]interface{}{
+			"hook_event_name": 42,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing or empty")
+	})
+}
+
+func TestMappingDialect_Parse_AssistantTextField(t *testing.T) {
+	spec := MappingDialectSpec{
+		Dialect:        "test",
+		EventNameField: "event",
+		Mappings: map[string]MappingEntrySpec{
+			"AgentStop": {
+				Event: hooks.EventAgentEnd,
+				Fields: map[string]string{
+					"assistant_text": ".response.text",
+				},
+			},
+		},
+	}
+	md := NewMappingDialect(spec)
+
+	event, err := md.Parse(map[string]interface{}{
+		"event": "AgentStop",
+		"response": map[string]interface{}{
+			"text": "Here is the answer.",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Here is the answer.", event.Data.AssistantText)
+}
+
+func TestMappingDialect_Parse_TokenFieldMappings(t *testing.T) {
+	spec := MappingDialectSpec{
+		Dialect:        "test",
+		EventNameField: "event",
+		Mappings: map[string]MappingEntrySpec{
+			"ModelDone": {
+				Event: hooks.EventModelEnd,
+				Fields: map[string]string{
+					"input_tokens":  ".stats.promptTokens",
+					"output_tokens": ".stats.completionTokens",
+					"cached_tokens": ".stats.cachedTokens",
+				},
+			},
+		},
+	}
+	md := NewMappingDialect(spec)
+
+	event, err := md.Parse(map[string]interface{}{
+		"event": "ModelDone",
+		"stats": map[string]interface{}{
+			"promptTokens":     float64(200),
+			"completionTokens": float64(75),
+			"cachedTokens":     float64(50),
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(200), event.Data.InputTokens)
+	assert.Equal(t, int64(75), event.Data.OutputTokens)
+	assert.Equal(t, int64(50), event.Data.CachedTokens)
+}
+
 func TestMappingDialect_Parse_TokenExtraction(t *testing.T) {
 	md := NewMappingDialect(MappingDialectSpec{
 		Dialect:        "test",


### PR DESCRIPTION
Add a data-driven MappingDialect for hook event translation that reads field mappings from a dialect.yaml file, enabling new harness integrations without writing Go code.

Fix custom harness type passthrough from Hub DB so non-canonical harness names are used directly instead of falling back to empty string.

