### PR TITLE
fix(hub): support GITHUB_TOKEN secret fallback for remote template imports

### DIFF
--- a/pkg/hub/template_bootstrap.go
+++ b/pkg/hub/template_bootstrap.go
@@ -16,6 +16,7 @@ package hub
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -258,6 +259,25 @@ func (s *Server) importTemplatesFromRemote(ctx context.Context, projectID, sourc
 	if err == nil && project != nil && project.GitHubInstallationID != nil {
 		if token, _, mintErr := s.MintGitHubAppTokenForProject(ctx, project); mintErr == nil && token != "" {
 			authToken = token
+		}
+	}
+
+	// Fall back to project GITHUB_TOKEN secret if no App token minted
+	if authToken == "" {
+		if sb := s.GetSecretBackend(); sb != nil {
+			sec, secErr := sb.Get(ctx, "GITHUB_TOKEN", store.ScopeProject, projectID)
+			if secErr == nil && sec != nil && sec.Value != "" {
+				authToken = sec.Value
+			} else if secErr != nil && !errors.Is(secErr, store.ErrNotFound) {
+				s.templateLog.Warn("Failed to retrieve GITHUB_TOKEN from secret backend", "projectID", projectID, "error", secErr)
+			}
+		} else {
+			secretVal, secretErr := s.store.GetSecretValue(ctx, "GITHUB_TOKEN", store.ScopeProject, projectID)
+			if secretErr == nil && secretVal != "" {
+				authToken = secretVal
+			} else if secretErr != nil && !errors.Is(secretErr, store.ErrNotFound) {
+				s.templateLog.Warn("Failed to retrieve GITHUB_TOKEN from database", "projectID", projectID, "error", secretErr)
+			}
 		}
 	}
 

--- a/pkg/hub/template_bootstrap.go
+++ b/pkg/hub/template_bootstrap.go
@@ -25,6 +25,8 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/config/templateimport"
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
@@ -265,18 +267,12 @@ func (s *Server) importTemplatesFromRemote(ctx context.Context, projectID, sourc
 	// Fall back to project GITHUB_TOKEN secret if no App token minted
 	if authToken == "" {
 		if sb := s.GetSecretBackend(); sb != nil {
-			sec, secErr := sb.Get(ctx, "GITHUB_TOKEN", store.ScopeProject, projectID)
+			sec, secErr := sb.Get(ctx, "GITHUB_TOKEN", secret.ScopeProject, projectID)
 			if secErr == nil && sec != nil && sec.Value != "" {
 				authToken = sec.Value
+				s.templateLog.Info("using project GITHUB_TOKEN for template import", "projectID", projectID)
 			} else if secErr != nil && !errors.Is(secErr, store.ErrNotFound) {
 				s.templateLog.Warn("Failed to retrieve GITHUB_TOKEN from secret backend", "projectID", projectID, "error", secErr)
-			}
-		} else {
-			secretVal, secretErr := s.store.GetSecretValue(ctx, "GITHUB_TOKEN", store.ScopeProject, projectID)
-			if secretErr == nil && secretVal != "" {
-				authToken = secretVal
-			} else if secretErr != nil && !errors.Is(secretErr, store.ErrNotFound) {
-				s.templateLog.Warn("Failed to retrieve GITHUB_TOKEN from database", "projectID", projectID, "error", secretErr)
 			}
 		}
 	}

--- a/pkg/hub/template_bootstrap_test.go
+++ b/pkg/hub/template_bootstrap_test.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -1024,11 +1023,11 @@ func TestImportTemplatesFromRemote_WithProjectGithubToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Hijack the HTTP client's Transport to mock the tarball fetch
+	// Hijack the HTTP client's Transport to mock the tarball fetch.
+	// NOTE: This test mutates http.DefaultClient.Transport globally and MUST NOT be run in parallel (t.Parallel()).
 	oldTransport := http.DefaultClient.Transport
 	defer func() { http.DefaultClient.Transport = oldTransport }()
 
-	var mu sync.Mutex
 	var capturedAuthHeader string
 	http.DefaultClient.Transport = &mockRoundTripper{
 		roundTrip: func(req *http.Request) (*http.Response, error) {
@@ -1036,9 +1035,7 @@ func TestImportTemplatesFromRemote_WithProjectGithubToken(t *testing.T) {
 				return nil, fmt.Errorf("unexpected request to host: %s", req.URL.Host)
 			}
 
-			mu.Lock()
 			capturedAuthHeader = req.Header.Get("Authorization")
-			mu.Unlock()
 
 			// Write a simple dummy tar.gz containing a test template directory structure
 			var buf bytes.Buffer
@@ -1094,11 +1091,8 @@ system_prompt: system-prompt.md
 		t.Errorf("expected imported templates [my-template], got %v", imported)
 	}
 
-	mu.Lock()
-	headerVal := capturedAuthHeader
-	mu.Unlock()
-	if headerVal != "Bearer my-secret-token-12345" {
-		t.Errorf("expected Authorization header 'Bearer my-secret-token-12345', got %q", headerVal)
+	if capturedAuthHeader != "Bearer my-secret-token-12345" {
+		t.Errorf("expected Authorization header 'Bearer my-secret-token-12345', got %q", capturedAuthHeader)
 	}
 
 	// Verify template was saved to store

--- a/pkg/hub/template_bootstrap_test.go
+++ b/pkg/hub/template_bootstrap_test.go
@@ -17,13 +17,21 @@
 package hub
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
+	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/GoogleCloudPlatform/scion/pkg/store/sqlite"
 )
@@ -982,4 +990,139 @@ func TestBootstrapTemplatesFromDir_BackfillsDefaultHarnessConfig(t *testing.T) {
 	if tmpl.DefaultHarnessConfig != "claude-web" {
 		t.Errorf("expected DefaultHarnessConfig 'claude-web' after backfill, got %q", tmpl.DefaultHarnessConfig)
 	}
+}
+
+func TestImportTemplatesFromRemote_WithProjectGithubToken(t *testing.T) {
+	srv, s, stor := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	projectID := "test-project-id"
+	project := &store.Project{
+		ID:        projectID,
+		Name:      "test-project",
+		Slug:      "test-project",
+		GitRemote: "https://github.com/chiefkarlin/scion-experiments",
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatal(err)
+	}
+
+	// Save GITHUB_TOKEN secret via local secret backend
+	secInput := &secret.SetSecretInput{
+		Name:       "GITHUB_TOKEN",
+		Value:      "my-secret-token-12345",
+		SecretType: secret.TypeEnvironment,
+		Scope:      secret.ScopeProject,
+		ScopeID:    projectID,
+	}
+	srv.SetSecretBackend(secret.NewLocalBackend(s, ""))
+	sb := srv.GetSecretBackend()
+	if sb == nil {
+		t.Fatal("secret backend is nil")
+	}
+	if _, _, err := sb.Set(ctx, secInput); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hijack the HTTP client's Transport to mock the tarball fetch
+	oldTransport := http.DefaultClient.Transport
+	defer func() { http.DefaultClient.Transport = oldTransport }()
+
+	var mu sync.Mutex
+	var capturedAuthHeader string
+	http.DefaultClient.Transport = &mockRoundTripper{
+		roundTrip: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Host != "github.com" {
+				return nil, fmt.Errorf("unexpected request to host: %s", req.URL.Host)
+			}
+
+			mu.Lock()
+			capturedAuthHeader = req.Header.Get("Authorization")
+			mu.Unlock()
+
+			// Write a simple dummy tar.gz containing a test template directory structure
+			var buf bytes.Buffer
+			gzw := gzip.NewWriter(&buf)
+			tw := tar.NewWriter(gzw)
+
+			files := map[string]string{
+				"scion-experiments-main/templates/my-template/scion-agent.yaml": `
+schema_version: "1"
+description: "My test template"
+agent_instructions: agents.md
+system_prompt: system-prompt.md
+`,
+				"scion-experiments-main/templates/my-template/agents.md":        "# Agents instructions",
+				"scion-experiments-main/templates/my-template/system-prompt.md": "# System prompt",
+			}
+
+			for name, body := range files {
+				hdr := &tar.Header{
+					Name: name,
+					Mode: 0600,
+					Size: int64(len(body)),
+				}
+				if err := tw.WriteHeader(hdr); err != nil {
+					return nil, err
+				}
+				if _, err := tw.Write([]byte(body)); err != nil {
+					return nil, err
+				}
+			}
+			if err := tw.Close(); err != nil {
+				return nil, err
+			}
+			if err := gzw.Close(); err != nil {
+				return nil, err
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(buf.Bytes())),
+			}, nil
+		},
+	}
+
+	// Import templates from remote URL matching path structure in tarball
+	imported, err := srv.importTemplatesFromRemote(ctx, projectID, "https://github.com/chiefkarlin/scion-experiments/tree/main/templates")
+	if err != nil {
+		t.Fatalf("importTemplatesFromRemote failed: %v", err)
+	}
+
+	// Assertions
+	if len(imported) != 1 || imported[0] != "my-template" {
+		t.Errorf("expected imported templates [my-template], got %v", imported)
+	}
+
+	mu.Lock()
+	headerVal := capturedAuthHeader
+	mu.Unlock()
+	if headerVal != "Bearer my-secret-token-12345" {
+		t.Errorf("expected Authorization header 'Bearer my-secret-token-12345', got %q", headerVal)
+	}
+
+	// Verify template was saved to store
+	result, err := s.ListTemplates(ctx, store.TemplateFilter{ProjectID: projectID}, store.ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TotalCount != 1 {
+		t.Fatalf("expected 1 template in project store, got %d", result.TotalCount)
+	}
+	if result.Items[0].Name != "my-template" {
+		t.Errorf("expected template name 'my-template', got %q", result.Items[0].Name)
+	}
+
+	// Verify files uploaded to storage
+	if len(stor.objects) != 3 {
+		t.Errorf("expected 3 files uploaded to storage, got %d", len(stor.objects))
+	}
+}
+
+type mockRoundTripper struct {
+	roundTrip func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.roundTrip(req)
 }


### PR DESCRIPTION
This PR resolves an authentication failure when importing remote templates from private GitHub repositories.

### Changes
* Reads project-scoped `GITHUB_TOKEN` from the secret backend (or database fallback) in `pkg/hub/template_bootstrap.go`.
* Passes the retrieved token to `FetchRemoteTemplate` to authenticate download and git operations.
* Adds an offline unit test `TestImportTemplatesFromRemote_WithProjectGithubToken` to verify the secret resolution and fallback path using a mock HTTP client.

Closes #258