### PR TITLE
Fix agent slug collision across projects in broker heartbeat

### DIFF
--- a/pkg/runtimebroker/heartbeat.go
+++ b/pkg/runtimebroker/heartbeat.go
@@ -23,8 +23,25 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent"
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 )
+
+// heartbeatAgentKey returns a key that uniquely identifies an agent within the
+// broker for deduplication purposes. It combines the agent's slug (name) with
+// its project ID so agents that share a slug across different projects are not
+// collapsed into one entry. This matches the dedup key used by the agent-list
+// handler (see runtimebroker/handlers.go).
+func heartbeatAgentKey(a api.AgentInfo) string {
+	pid := a.ProjectID
+	if pid == "" {
+		pid = a.Labels["scion.project_id"]
+	}
+	if pid == "" {
+		pid = a.Labels["scion.grove_id"]
+	}
+	return a.Name + "\x00" + pid
+}
 
 const (
 	// DefaultHeartbeatInterval is the default interval between heartbeats.
@@ -200,11 +217,18 @@ func (s *HeartbeatService) gatherProjectAgents() []hubclient.ProjectHeartbeat {
 		return nil
 	}
 
-	// Also include agents from auxiliary runtimes (e.g. Kubernetes)
+	// Also include agents from auxiliary runtimes (e.g. Kubernetes).
+	// Dedup by name+projectID (not name alone) to prevent collision across
+	// projects while still deduplicating the same agent found on multiple
+	// runtimes. Keying by name alone would drop an auxiliary-runtime agent
+	// whenever a different project has a default-runtime agent with the same
+	// slug — that agent would then never be reported in heartbeats and its
+	// status on the Hub would go stale (e.g. stuck at "starting"). This
+	// mirrors the dedup key used by the agent-list handler.
 	if s.auxiliaryManagers != nil {
 		seen := make(map[string]bool)
 		for _, ag := range agents {
-			seen[ag.Name] = true
+			seen[heartbeatAgentKey(ag)] = true
 		}
 		for _, auxMgr := range s.auxiliaryManagers() {
 			auxAgents, auxErr := auxMgr.List(context.Background(), nil)
@@ -212,8 +236,9 @@ func (s *HeartbeatService) gatherProjectAgents() []hubclient.ProjectHeartbeat {
 				continue
 			}
 			for _, ag := range auxAgents {
-				if !seen[ag.Name] {
-					seen[ag.Name] = true
+				k := heartbeatAgentKey(ag)
+				if !seen[k] {
+					seen[k] = true
 					agents = append(agents, ag)
 				}
 			}

--- a/pkg/runtimebroker/heartbeat_test.go
+++ b/pkg/runtimebroker/heartbeat_test.go
@@ -449,3 +449,99 @@ func TestHeartbeatService_IncludesAuxiliaryRuntimes(t *testing.T) {
 		t.Error("Expected k8s-agent from auxiliary runtime in heartbeat")
 	}
 }
+
+// TestHeartbeatService_AuxiliaryRuntimeSlugCollisionAcrossProjects is a
+// regression test for cross-project agent slug collisions. When a
+// default-runtime agent and an auxiliary-runtime agent share the same slug but
+// belong to different projects, both must be reported in the heartbeat.
+// Previously the auxiliary agent was deduplicated away by slug alone, so its
+// status never reached the Hub and it appeared stuck at its last-known phase
+// (e.g. "starting") forever.
+func TestHeartbeatService_AuxiliaryRuntimeSlugCollisionAcrossProjects(t *testing.T) {
+	client := &mockRuntimeBrokerService{}
+
+	// Default-runtime "coordinator" lives in grove-1.
+	defaultMgr := &heartbeatMockManager{
+		agents: []api.AgentInfo{
+			{Name: "coordinator", ProjectID: "grove-1", Phase: "running", Activity: "thinking"},
+		},
+	}
+
+	// Auxiliary-runtime "coordinator" lives in a different project, grove-2.
+	auxMgr := &heartbeatMockManager{
+		agents: []api.AgentInfo{
+			{Name: "coordinator", ProjectID: "grove-2", Phase: "running", Activity: "working"},
+		},
+	}
+
+	svc := NewHeartbeatService(client, "test-host", time.Hour, defaultMgr, nil, slog.Default())
+	svc.auxiliaryManagers = func() []agent.Manager { return []agent.Manager{auxMgr} }
+
+	if err := svc.ForceHeartbeat(context.Background()); err != nil {
+		t.Fatalf("ForceHeartbeat failed: %v", err)
+	}
+
+	calls := client.getHeartbeatCalls()
+	if len(calls) != 1 {
+		t.Fatalf("Expected 1 heartbeat call, got %d", len(calls))
+	}
+
+	heartbeat := calls[0].Heartbeat
+	if len(heartbeat.Projects) != 2 {
+		t.Fatalf("Expected 2 projects (grove-1 and grove-2), got %d", len(heartbeat.Projects))
+	}
+
+	// Both projects must report their "coordinator" agent with its own status.
+	byProject := make(map[string][]hubclient.AgentHeartbeat)
+	for _, p := range heartbeat.Projects {
+		byProject[p.ProjectID] = p.Agents
+	}
+
+	g1 := byProject["grove-1"]
+	if len(g1) != 1 || g1[0].Slug != "coordinator" || g1[0].Activity != "thinking" {
+		t.Errorf("grove-1 coordinator missing or wrong status: %+v", g1)
+	}
+
+	g2 := byProject["grove-2"]
+	if len(g2) != 1 || g2[0].Slug != "coordinator" || g2[0].Activity != "working" {
+		t.Errorf("grove-2 coordinator missing or wrong status (dropped by slug-only dedup?): %+v", g2)
+	}
+}
+
+// TestHeartbeatService_AuxiliaryRuntimeDedupSameAgent verifies the dedup still
+// collapses the *same* agent (same slug and project) reported by both the
+// default and auxiliary managers, so it is not double-counted.
+func TestHeartbeatService_AuxiliaryRuntimeDedupSameAgent(t *testing.T) {
+	client := &mockRuntimeBrokerService{}
+
+	defaultMgr := &heartbeatMockManager{
+		agents: []api.AgentInfo{
+			{Name: "coordinator", ProjectID: "grove-1", Phase: "running"},
+		},
+	}
+	auxMgr := &heartbeatMockManager{
+		agents: []api.AgentInfo{
+			{Name: "coordinator", ProjectID: "grove-1", Phase: "running"},
+		},
+	}
+
+	svc := NewHeartbeatService(client, "test-host", time.Hour, defaultMgr, nil, slog.Default())
+	svc.auxiliaryManagers = func() []agent.Manager { return []agent.Manager{auxMgr} }
+
+	if err := svc.ForceHeartbeat(context.Background()); err != nil {
+		t.Fatalf("ForceHeartbeat failed: %v", err)
+	}
+
+	calls := client.getHeartbeatCalls()
+	if len(calls) != 1 {
+		t.Fatalf("Expected 1 heartbeat call, got %d", len(calls))
+	}
+
+	heartbeat := calls[0].Heartbeat
+	if len(heartbeat.Projects) != 1 {
+		t.Fatalf("Expected 1 project, got %d", len(heartbeat.Projects))
+	}
+	if got := heartbeat.Projects[0].AgentCount; got != 1 {
+		t.Errorf("Expected the same agent to be deduplicated to 1, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a UI bug where agent statuses glitch when multiple projects on the same hub have agents sharing a slug (e.g. \`coordinator\` in 3+ projects):

1. **Status bleed across projects** — an agent's status display reflects a different project's same-slug agent.
2. **Stuck status** — an agent that has been running for a while shows \`starting\` (or another stale phase) and never updates.

## Root cause

The investigation traced the symptoms to the **runtime broker heartbeat**, which is what periodically reports per-agent status to the Hub.

In \`pkg/runtimebroker/heartbeat.go\`, \`gatherProjectAgents()\` merges agents from the default runtime with agents from auxiliary runtimes (e.g. Kubernetes) and deduplicates them — but it keyed the dedup set by the agent **slug (name) alone**:

\`\`\`go
seen := make(map[string]bool)
for _, ag := range agents {
    seen[ag.Name] = true          // ← slug only, not project-scoped
}
...
if !seen[ag.Name] { ... }
\`\`\`

When a broker serves multiple projects that each have an agent with the same slug, an auxiliary-runtime agent (say \`coordinator\` in project B) is silently dropped because a default-runtime \`coordinator\` in project A already occupies \`seen["coordinator"]\`. The dropped agent's status is never sent to the Hub, so it stays frozen at its last-known phase (e.g. \`starting\`), and the surviving same-slug agent is the only \`coordinator\` the Hub hears about — producing the apparent cross-project bleed.

Note the agent-list handler (\`pkg/runtimebroker/handlers.go\`) already had this exact fix — it dedups by \`name + projectID\` with a comment explaining the collision. The heartbeat path was simply missed.

The rest of the stack is correctly keyed: Hub SSE events (\`pkg/hub/events.go\`) publish per agent UUID + projectID, \`GetAgentBySlug\` is project-scoped, the broker's \`LookupContainerID\`/\`LookupAgent\` filter by \`scion.grove_id\`, and the web frontend keys all agent state by UUID.

## Fix

Dedup by \`(name, projectID)\` in the heartbeat, via a \`heartbeatAgentKey\` helper that mirrors the agent-list handler's key (falls back to \`scion.project_id\` / \`scion.grove_id\` labels when \`ProjectID\` is unset).

## Tests

- \`TestHeartbeatService_AuxiliaryRuntimeSlugCollisionAcrossProjects\` — two same-slug \`coordinator\` agents in different projects (one default-runtime, one auxiliary) are both reported with their own status. Verified to **fail** before the fix (only 1 project reported) and pass after.
- \`TestHeartbeatService_AuxiliaryRuntimeDedupSameAgent\` — the same agent reported by both runtimes is still collapsed to one entry (dedup not over-broadened).

\`go test ./pkg/runtimebroker/\` and \`go vet\` pass.