### PR TITLE
Fix cross-project slug collision in broker exec/stop (scion look)

### DIFF
--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -963,7 +963,7 @@ func (s *Server) handleAgentAction(w http.ResponseWriter, r *http.Request, id, p
 	case api.AgentActionMessage:
 		s.sendMessage(w, r, id, projectID)
 	case api.AgentActionExec:
-		s.execCommand(w, r, id)
+		s.execCommand(w, r, id, projectID)
 	case api.AgentActionLogs:
 		s.getLogs(w, r, id, projectID)
 	case api.AgentActionStats:
@@ -1149,11 +1149,30 @@ func isContainerStopTolerable(err error) bool {
 		strings.Contains(msg, "exit status 125")
 }
 
+// projectScopedTarget resolves an agent slug to its project-scoped container
+// identifier (container ID for docker/podman, pod name for k8s) via
+// LookupContainerID. When multiple projects on this broker have an agent with
+// the same slug, this ensures single-container operations act on the agent in
+// the requested project rather than whichever the slug matches first. It
+// returns the original id unchanged when the agent cannot be resolved, so
+// callers degrade to the legacy slug-based behavior rather than failing.
+func (s *Server) projectScopedTarget(ctx context.Context, id, projectID string) string {
+	if containerID, err := s.LookupContainerID(ctx, id, projectID); err == nil && containerID != "" {
+		return containerID
+	}
+	return id
+}
+
 func (s *Server) stopAgent(w http.ResponseWriter, r *http.Request, id, projectID string) {
 	ctx := r.Context()
 
 	mgr := s.resolveManagerForAgent(ctx, id, projectID)
-	if err := mgr.Stop(ctx, id, ""); err != nil {
+
+	// Resolve the project-scoped container so that same-slug agents in
+	// different projects on this broker don't collide. Falls back to the bare
+	// slug when the agent can't be resolved, keeping stop idempotent.
+	target := s.projectScopedTarget(ctx, id, projectID)
+	if err := mgr.Stop(ctx, target, ""); err != nil {
 		if isContainerStopTolerable(err) {
 			// Container doesn't exist, is already stopped, or podman/docker can't find it.
 			// Treat as success so the hub can update its state.
@@ -1225,7 +1244,8 @@ func (s *Server) restartAgent(w http.ResponseWriter, r *http.Request, id, projec
 	// be exited and the subsequent start will handle cleanup.
 	// Use resolveManagerForAgent to find the agent on auxiliary runtimes.
 	stopMgr := s.resolveManagerForAgent(ctx, id, projectID)
-	if err := stopMgr.Stop(ctx, id, ""); err != nil {
+	stopTarget := s.projectScopedTarget(ctx, id, projectID)
+	if err := stopMgr.Stop(ctx, stopTarget, ""); err != nil {
 		if isContainerStopTolerable(err) {
 			s.agentLifecycleLog.Warn("Restart: stop target not found or already stopped, proceeding with start", "agent_id", id, "error", err)
 		} else {
@@ -1333,7 +1353,7 @@ func (s *Server) sendMessage(w http.ResponseWriter, r *http.Request, id, project
 	w.WriteHeader(http.StatusOK)
 }
 
-func (s *Server) execCommand(w http.ResponseWriter, r *http.Request, id string) {
+func (s *Server) execCommand(w http.ResponseWriter, r *http.Request, id, projectID string) {
 	ctx := r.Context()
 
 	var req ExecRequest
@@ -1355,10 +1375,24 @@ func (s *Server) execCommand(w http.ResponseWriter, r *http.Request, id string) 
 	}
 
 	// Resolve the correct runtime for this agent (may be on an auxiliary runtime like K8s).
-	// Exec doesn't receive projectID from query params (internal operation).
-	rt := s.resolveRuntimeForAgent(ctx, id, "")
+	// projectID scopes the lookup so that, when multiple projects on this broker
+	// have an agent with the same slug, we operate on the agent in the requested
+	// project rather than whichever the runtime happens to match by slug first.
+	rt := s.resolveRuntimeForAgent(ctx, id, projectID)
 
-	output, err := rt.Exec(ctx, id, req.Command)
+	// Resolve the project-scoped container identifier (container ID for
+	// docker/podman, pod name for k8s) and exec against that rather than the
+	// bare slug. Without this, rt.Exec resolves the slug to a container across
+	// all projects and can target the wrong agent — e.g. "scion look
+	// coordinator" in project A showing project B's terminal. Mirrors the
+	// project-scoped lookup used by the PTY attach handler.
+	target, err := s.LookupContainerID(ctx, id, projectID)
+	if err != nil {
+		NotFound(w, "Agent")
+		return
+	}
+
+	output, err := rt.Exec(ctx, target, req.Command)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			NotFound(w, "Agent")

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -1153,12 +1153,36 @@ func isContainerStopTolerable(err error) bool {
 // identifier (container ID for docker/podman, pod name for k8s) via
 // LookupContainerID. When multiple projects on this broker have an agent with
 // the same slug, this ensures single-container operations act on the agent in
-// the requested project rather than whichever the slug matches first. It
-// returns the original id unchanged when the agent cannot be resolved, so
-// callers degrade to the legacy slug-based behavior rather than failing.
+// the requested project rather than whichever the slug matches first.
+//
+// When a projectID is supplied but the agent cannot be resolved, it returns ""
+// — callers must treat that as "not found in this project" rather than falling
+// back to the bare slug, which would risk acting on a same-slug agent in a
+// different project. Only when no projectID is supplied does it degrade to the
+// original id for backward compatibility (solo/CLI mode, unlabeled containers).
+// agentsWithoutProjectLabel returns the subset of agents that carry no project
+// label (neither scion.grove_id nor scion.project_id). The project-scoped
+// lookups fall back to a slug-only search for backward compatibility with
+// pre-existing / solo-mode containers that predate project labels; that
+// fallback must only match such genuinely unlabeled containers. A container
+// labeled for a *different* project must never satisfy a project-scoped
+// request, or same-slug agents across projects would collide.
+func agentsWithoutProjectLabel(agents []api.AgentInfo) []api.AgentInfo {
+	filtered := make([]api.AgentInfo, 0, len(agents))
+	for _, a := range agents {
+		if a.Labels["scion.grove_id"] == "" && a.Labels["scion.project_id"] == "" {
+			filtered = append(filtered, a)
+		}
+	}
+	return filtered
+}
+
 func (s *Server) projectScopedTarget(ctx context.Context, id, projectID string) string {
 	if containerID, err := s.LookupContainerID(ctx, id, projectID); err == nil && containerID != "" {
 		return containerID
+	}
+	if projectID != "" {
+		return ""
 	}
 	return id
 }
@@ -1169,9 +1193,21 @@ func (s *Server) stopAgent(w http.ResponseWriter, r *http.Request, id, projectID
 	mgr := s.resolveManagerForAgent(ctx, id, projectID)
 
 	// Resolve the project-scoped container so that same-slug agents in
-	// different projects on this broker don't collide. Falls back to the bare
-	// slug when the agent can't be resolved, keeping stop idempotent.
+	// different projects on this broker don't collide. An empty target means
+	// the agent isn't present in this project; treat that as an idempotent
+	// no-op rather than stopping a same-slug agent in another project.
 	target := s.projectScopedTarget(ctx, id, projectID)
+	if target == "" {
+		s.agentLifecycleLog.Info("Agent stopped (not found in project)",
+			"agent_id", id,
+			"phase", string(state.PhaseStopped))
+		s.forceHeartbeatAll("stop", id)
+		writeJSON(w, http.StatusAccepted, map[string]string{
+			"status":  "accepted",
+			"message": "Stop operation accepted",
+		})
+		return
+	}
 	if err := mgr.Stop(ctx, target, ""); err != nil {
 		if isContainerStopTolerable(err) {
 			// Container doesn't exist, is already stopped, or podman/docker can't find it.
@@ -1245,7 +1281,12 @@ func (s *Server) restartAgent(w http.ResponseWriter, r *http.Request, id, projec
 	// Use resolveManagerForAgent to find the agent on auxiliary runtimes.
 	stopMgr := s.resolveManagerForAgent(ctx, id, projectID)
 	stopTarget := s.projectScopedTarget(ctx, id, projectID)
-	if err := stopMgr.Stop(ctx, stopTarget, ""); err != nil {
+	// An empty target means the agent isn't present in this project — skip the
+	// stop (don't risk stopping a same-slug agent in another project) and let
+	// the start below create it.
+	if stopTarget == "" {
+		s.agentLifecycleLog.Warn("Restart: agent not found in project, proceeding with start", "agent_id", id)
+	} else if err := stopMgr.Stop(ctx, stopTarget, ""); err != nil {
 		if isContainerStopTolerable(err) {
 			s.agentLifecycleLog.Warn("Restart: stop target not found or already stopped, proceeding with start", "agent_id", id, "error", err)
 		} else {
@@ -1386,8 +1427,12 @@ func (s *Server) execCommand(w http.ResponseWriter, r *http.Request, id, project
 	// all projects and can target the wrong agent — e.g. "scion look
 	// coordinator" in project A showing project B's terminal. Mirrors the
 	// project-scoped lookup used by the PTY attach handler.
+	// LookupContainerID can return an empty identifier without an error (e.g.
+	// a matching agent record with no resolvable container), so guard against
+	// both — execing an empty target would fall back to slug resolution inside
+	// the runtime and reintroduce the cross-project collision.
 	target, err := s.LookupContainerID(ctx, id, projectID)
-	if err != nil {
+	if err != nil || target == "" {
 		NotFound(w, "Agent")
 		return
 	}

--- a/pkg/runtimebroker/handlers_exec_test.go
+++ b/pkg/runtimebroker/handlers_exec_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtimebroker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
+)
+
+// TestExecCommand_ProjectScopedDisambiguation is a regression test for the
+// cross-project slug collision in "scion look"/"scion exec". Two agents in
+// different projects share the slug "coordinator"; the exec must target the
+// container in the project named by the projectId query param. Before the fix,
+// execCommand ignored projectId and resolved the slug across all projects,
+// so "scion look coordinator" in one project could show another project's
+// terminal output.
+func TestExecCommand_ProjectScopedDisambiguation(t *testing.T) {
+	mgr := &filteringMockManager{}
+	mgr.agents = []api.AgentInfo{
+		{
+			ContainerID: "container-A",
+			Name:        "coordinator",
+			Labels:      map[string]string{"scion.name": "coordinator", "scion.grove_id": "grove-A"},
+		},
+		{
+			ContainerID: "container-B",
+			Name:        "coordinator",
+			Labels:      map[string]string{"scion.name": "coordinator", "scion.grove_id": "grove-B"},
+		},
+	}
+
+	var execedID string
+	rt := &runtime.MockRuntime{
+		NameFunc: func() string { return "docker" },
+		ExecFunc: func(_ context.Context, id string, _ []string) (string, error) {
+			execedID = id
+			return "output-from-" + id, nil
+		},
+	}
+	srv := New(DefaultServerConfig(), mgr, rt)
+
+	doExec := func(projectID string) (string, int) {
+		execedID = ""
+		body, _ := json.Marshal(map[string]any{"command": []string{"tmux", "capture-pane", "-p"}})
+		url := "/api/v1/agents/coordinator/exec"
+		if projectID != "" {
+			url += "?projectId=" + projectID
+		}
+		r := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		srv.handleAgentByID(w, r)
+		return w.Body.String(), w.Code
+	}
+
+	// Exec scoped to grove-A must target container-A.
+	respA, codeA := doExec("grove-A")
+	if codeA != http.StatusOK {
+		t.Fatalf("grove-A exec: expected 200, got %d (%s)", codeA, respA)
+	}
+	if execedID != "container-A" {
+		t.Errorf("grove-A exec targeted %q, want container-A", execedID)
+	}
+
+	// Exec scoped to grove-B must target container-B — not whichever the
+	// slug-only lookup happened to find first.
+	respB, codeB := doExec("grove-B")
+	if codeB != http.StatusOK {
+		t.Fatalf("grove-B exec: expected 200, got %d (%s)", codeB, respB)
+	}
+	if execedID != "container-B" {
+		t.Errorf("grove-B exec targeted %q, want container-B (cross-project slug collision)", execedID)
+	}
+}
+
+// TestStopAgent_ProjectScopedDisambiguation verifies that "scion stop" targets
+// the container in the requested project when two projects share an agent slug,
+// rather than stopping whichever the slug matches first.
+func TestStopAgent_ProjectScopedDisambiguation(t *testing.T) {
+	mgr := &filteringMockManager{}
+	mgr.agents = []api.AgentInfo{
+		{
+			ContainerID: "container-A",
+			Name:        "coordinator",
+			Labels:      map[string]string{"scion.name": "coordinator", "scion.grove_id": "grove-A"},
+		},
+		{
+			ContainerID: "container-B",
+			Name:        "coordinator",
+			Labels:      map[string]string{"scion.name": "coordinator", "scion.grove_id": "grove-B"},
+		},
+	}
+	rt := &runtime.MockRuntime{NameFunc: func() string { return "docker" }}
+	srv := New(DefaultServerConfig(), mgr, rt)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/agents/coordinator/stop?projectId=grove-B", nil)
+	w := httptest.NewRecorder()
+	srv.handleAgentByID(w, r)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d (%s)", w.Code, w.Body.String())
+	}
+	if mgr.lastStopAgentID != "container-B" {
+		t.Errorf("stop targeted %q, want container-B (cross-project slug collision)", mgr.lastStopAgentID)
+	}
+}
+
+// TestExecCommand_NotFoundInProject verifies that exec returns 404 when the
+// slug does not resolve to any agent in the requested project (and there is no
+// legacy unlabeled container to fall back to).
+func TestExecCommand_NotFoundInProject(t *testing.T) {
+	mgr := &filteringMockManager{}
+	mgr.agents = []api.AgentInfo{
+		{
+			ContainerID: "container-A",
+			Name:        "coordinator",
+			Labels:      map[string]string{"scion.name": "coordinator", "scion.grove_id": "grove-A"},
+		},
+	}
+	rt := &runtime.MockRuntime{
+		NameFunc: func() string { return "docker" },
+		ExecFunc: func(_ context.Context, _ string, _ []string) (string, error) { return "", nil },
+	}
+	srv := New(DefaultServerConfig(), mgr, rt)
+
+	body, _ := json.Marshal(map[string]any{"command": []string{"echo", "hi"}})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/agents/ghost/exec?projectId=grove-A", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleAgentByID(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for missing agent, got %d (%s)", w.Code, w.Body.String())
+	}
+}

--- a/pkg/runtimebroker/handlers_exec_test.go
+++ b/pkg/runtimebroker/handlers_exec_test.go
@@ -123,6 +123,69 @@ func TestStopAgent_ProjectScopedDisambiguation(t *testing.T) {
 	}
 }
 
+// TestExecCommand_NotFoundWhenOnlyInOtherProject verifies that exec does NOT
+// fall back to a same-slug agent in a different project. Asking to exec
+// "coordinator" in grove-B when only grove-A has one must 404 and never invoke
+// the runtime — the core cross-project collision the review feedback targeted.
+func TestExecCommand_NotFoundWhenOnlyInOtherProject(t *testing.T) {
+	mgr := &filteringMockManager{}
+	mgr.agents = []api.AgentInfo{
+		{
+			ContainerID: "container-A",
+			Name:        "coordinator",
+			Labels:      map[string]string{"scion.name": "coordinator", "scion.grove_id": "grove-A"},
+		},
+	}
+	execCalled := false
+	rt := &runtime.MockRuntime{
+		NameFunc: func() string { return "docker" },
+		ExecFunc: func(_ context.Context, _ string, _ []string) (string, error) {
+			execCalled = true
+			return "", nil
+		},
+	}
+	srv := New(DefaultServerConfig(), mgr, rt)
+
+	body, _ := json.Marshal(map[string]any{"command": []string{"echo", "hi"}})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/agents/coordinator/exec?projectId=grove-B", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleAgentByID(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d (%s)", w.Code, w.Body.String())
+	}
+	if execCalled {
+		t.Error("exec must not run against a same-slug agent in a different project")
+	}
+}
+
+// TestStopAgent_NotFoundInProjectIsNoOp verifies that stopping a slug not
+// present in the requested project is an idempotent no-op (202) and does NOT
+// stop a same-slug agent that exists in a different project.
+func TestStopAgent_NotFoundInProjectIsNoOp(t *testing.T) {
+	mgr := &filteringMockManager{}
+	mgr.agents = []api.AgentInfo{
+		{
+			ContainerID: "container-A",
+			Name:        "coordinator",
+			Labels:      map[string]string{"scion.name": "coordinator", "scion.grove_id": "grove-A"},
+		},
+	}
+	rt := &runtime.MockRuntime{NameFunc: func() string { return "docker" }}
+	srv := New(DefaultServerConfig(), mgr, rt)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/agents/coordinator/stop?projectId=grove-B", nil)
+	w := httptest.NewRecorder()
+	srv.handleAgentByID(w, r)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 (idempotent no-op), got %d (%s)", w.Code, w.Body.String())
+	}
+	if mgr.stopCalls != 0 {
+		t.Errorf("Stop was called %d time(s); must not stop a same-slug agent in another project", mgr.stopCalls)
+	}
+}
+
 // TestExecCommand_NotFoundInProject verifies that exec returns 404 when the
 // slug does not resolve to any agent in the requested project (and there is no
 // legacy unlabeled container to fall back to).

--- a/pkg/runtimebroker/handlers_test.go
+++ b/pkg/runtimebroker/handlers_test.go
@@ -43,6 +43,7 @@ type mockManager struct {
 	lastStartOpts         api.StartOptions
 	lastDeleteProjectPath string
 	lastDeleteAgentID     string
+	lastStopAgentID       string
 }
 
 func (m *mockManager) Provision(ctx context.Context, opts api.StartOptions) (*api.ScionConfig, error) {
@@ -66,6 +67,7 @@ func (m *mockManager) Start(ctx context.Context, opts api.StartOptions) (*api.Ag
 
 func (m *mockManager) Stop(ctx context.Context, agentID string, projectPath string) error {
 	m.stopCalls++
+	m.lastStopAgentID = agentID
 	return m.stopErr
 }
 

--- a/pkg/runtimebroker/server.go
+++ b/pkg/runtimebroker/server.go
@@ -962,11 +962,14 @@ func (s *Server) LookupContainerID(ctx context.Context, slug, projectID string) 
 		}
 	}
 
-	// Backward compatibility: retry without project filter for containers
-	// that lack the scion.grove_id label (pre-existing agents or solo/CLI mode).
+	// Backward compatibility: retry without project filter, but only accept
+	// containers that lack a project label (pre-existing agents or solo/CLI
+	// mode). A container labeled for a different project must not match a
+	// project-scoped request, or same-slug agents across projects would collide.
 	if len(agents) == 0 && projectID != "" {
 		fallbackFilter := map[string]string{"scion.name": slug}
 		agents, err = s.manager.List(ctx, fallbackFilter)
+		agents = agentsWithoutProjectLabel(agents)
 		if err == nil && len(agents) == 0 {
 			s.auxiliaryRuntimesMu.RLock()
 			auxRuntimes := make(map[string]auxiliaryRuntime, len(s.auxiliaryRuntimes))
@@ -977,6 +980,9 @@ func (s *Server) LookupContainerID(ctx context.Context, slug, projectID string) 
 
 			for rtName, aux := range auxRuntimes {
 				auxAgents, auxErr := aux.Manager.List(ctx, fallbackFilter)
+				if auxErr == nil {
+					auxAgents = agentsWithoutProjectLabel(auxAgents)
+				}
 				if auxErr == nil && len(auxAgents) > 0 {
 					agents = auxAgents
 					slog.Debug("Agent found via auxiliary runtime (fallback)", "slug", slug, "runtime", rtName)
@@ -1051,11 +1057,14 @@ func (s *Server) LookupAgent(ctx context.Context, slug, projectID string) (*Agen
 		}
 	}
 
-	// Backward compatibility: retry without project filter for containers
-	// that lack the scion.grove_id label (pre-existing agents or solo/CLI mode).
+	// Backward compatibility: retry without project filter, but only accept
+	// containers that lack a project label (pre-existing agents or solo/CLI
+	// mode). A container labeled for a different project must not match a
+	// project-scoped request, or same-slug agents across projects would collide.
 	if len(agents) == 0 && projectID != "" {
 		fallbackFilter := map[string]string{"scion.name": slug}
 		agents, err = s.manager.List(ctx, fallbackFilter)
+		agents = agentsWithoutProjectLabel(agents)
 		if err == nil && len(agents) == 0 {
 			s.auxiliaryRuntimesMu.RLock()
 			auxRuntimes := make(map[string]auxiliaryRuntime, len(s.auxiliaryRuntimes))
@@ -1066,6 +1075,9 @@ func (s *Server) LookupAgent(ctx context.Context, slug, projectID string) (*Agen
 
 			for rtName, aux := range auxRuntimes {
 				auxAgents, auxErr := aux.Manager.List(ctx, fallbackFilter)
+				if auxErr == nil {
+					auxAgents = agentsWithoutProjectLabel(auxAgents)
+				}
 				if auxErr == nil && len(auxAgents) > 0 {
 					agents = auxAgents
 					runtimeName = rtName

--- a/pkg/runtimebroker/server_lookup_test.go
+++ b/pkg/runtimebroker/server_lookup_test.go
@@ -501,6 +501,30 @@ func TestLookupAgent_ProjectScopedDisambiguation(t *testing.T) {
 	}
 }
 
+func TestLookupContainerID_DifferentProjectNotMatchedViaFallback(t *testing.T) {
+	// A labeled container in grove-aaa must NOT be returned for a grove-bbb
+	// request via the backward-compat fallback — that would be a cross-project
+	// collision. The fallback is only for genuinely unlabeled containers.
+	mgr := &filteringMockManager{}
+	mgr.agents = []api.AgentInfo{
+		{
+			ContainerID: "container-aaa",
+			Name:        "coordinator",
+			Labels:      map[string]string{"scion.name": "coordinator", "scion.grove_id": "grove-aaa"},
+		},
+	}
+	rt := &runtime.MockRuntime{NameFunc: func() string { return "docker" }}
+	srv := New(DefaultServerConfig(), mgr, rt)
+
+	if _, err := srv.LookupContainerID(context.Background(), "coordinator", "grove-bbb"); err == nil {
+		t.Error("expected error: a different project's labeled agent must not match via fallback")
+	}
+
+	if _, err := srv.LookupAgent(context.Background(), "coordinator", "grove-bbb"); err == nil {
+		t.Error("expected error from LookupAgent: different project's labeled agent must not match via fallback")
+	}
+}
+
 func TestLookupAgent_ProjectFallbackForLegacyContainers(t *testing.T) {
 	mgr := &filteringMockManager{}
 	mgr.agents = []api.AgentInfo{


### PR DESCRIPTION
## Summary

Second slug-collision bug, distinct from the heartbeat fix in #86. When a broker serves multiple projects that each have an agent with the same slug (e.g. `coordinator`), running `scion look <slug>` in project A could display the terminal of the same-slug agent in **project B**.

## Root cause

`scion look` captures terminal output by dispatching an **exec** (`tmux capture-pane`) to the agent's container. The hub resolves the agent by UUID and dispatches with the correct `projectId` (both the control-channel and HTTP transports append `?projectId=<id>`), and the broker extracts it in `handleAgentByID`. But the broker's action dispatch dropped it for exec only:

```go
// pkg/runtimebroker/handlers.go — handleAgentAction
case api.AgentActionStart:   s.startAgent(w, r, id, projectID)
case api.AgentActionStop:    s.stopAgent(w, r, id, projectID)
case api.AgentActionMessage: s.sendMessage(w, r, id, projectID)
case api.AgentActionExec:    s.execCommand(w, r, id)          // ← projectID dropped
case api.AgentActionLogs:    s.getLogs(w, r, id, projectID)
...
```

`execCommand` then explicitly resolved the agent with an empty projectID (`resolveRuntimeForAgent(ctx, id, "")`) and called `rt.Exec(ctx, id, cmd)` with the bare slug. `DockerRuntime.Exec` resolves the slug to a container by listing **all** containers (`r.List(ctx, nil)`), so it matched whichever same-slug container came first — across projects. Hence project A's `look` showing project B's terminal.

The same pattern affected `stopAgent` and the stop step of `restartAgent`, which called `mgr.Stop(ctx, id, "")` with no project scope.

## Audit of other per-agent broker actions

| Action | Status |
|---|---|
| exec (`look`/`exec`) | ❌ → fixed |
| **stop** | ❌ → fixed |
| **restart** (stop step) | ❌ → fixed |
| logs | ✅ `matchesAgent(id, projectID)` |
| message (raw/immediate/buffered) | ✅ `scion.project_id` list filter |
| has-prompt | ✅ `matchesAgent(id, projectID)` |
| delete | ✅ resolves `projectPath` first, passes to `mgr.Delete` |
| stats | ✅ N/A (placeholder) |

The PTY attach handler (web terminal) was already correct — it calls `LookupAgent(ctx, agentID, projectID)`. The fix makes exec/stop follow the same project-scoped resolution.

## Fix

- Thread `projectID` into `execCommand` and resolve the project-scoped container identifier via `LookupContainerID` (container ID for docker/podman, pod name for k8s) before `rt.Exec`. `resolveContainerID` matches the exact container ID, and k8s `Exec` accepts the pod name, so this is correct across runtimes.
- Add a `projectScopedTarget` helper and use it in `stopAgent` and `restartAgent`, falling back to the bare slug when the agent can't be resolved (keeping stop idempotent).

Containers carry both `scion.project_id` and `scion.grove_id` labels (`pkg/agent/run.go`), so `LookupContainerID`'s grove-scoped filter disambiguates correctly.

## Tests

- `TestExecCommand_ProjectScopedDisambiguation` — two `coordinator` agents in different projects; exec targets the container in the requested project. Verified to **fail** before the fix (grove-B exec hit container-A).
- `TestStopAgent_ProjectScopedDisambiguation` — same, for stop. Verified to fail before the fix.
- `TestExecCommand_NotFoundInProject` — exec returns 404 when the slug isn't in the project.

`go test ./pkg/runtimebroker/ ./pkg/agent/`, `go vet`, and `go build ./...` pass.