### PR TITLE
Fix Telegram mention parsing for hyphenated agent names

### DIFF
--- a/.design/project-log/2026-05-31-telegram-hyphenated-mention-fix.md
+++ b/.design/project-log/2026-05-31-telegram-hyphenated-mention-fix.md
@@ -1,0 +1,50 @@
+# Fix Telegram mention parsing for hyphenated agent names
+
+**Date:** 2026-05-31
+**Author:** dev-telegram-mention agent
+
+## Problem
+
+When a user mentions an agent with a hyphen in its name (e.g., `@deploy-agent`),
+Telegram's entity system may create a mention entity covering only the portion
+before the hyphen (e.g., `@deploy`), because hyphens are not valid characters in
+Telegram usernames. This caused two issues:
+
+1. **`hasNonBotUserMention`** incorrectly classified partial entities (like `@deploy`
+   from `@deploy-agent`) as non-bot user mentions, potentially blocking fallback
+   routing to the default agent.
+
+2. **`resolveUserMentions`** could corrupt message text by replacing only the
+   entity-covered portion with a scion identity, leaving the hyphenated suffix
+   dangling (e.g., `user:email-agent` instead of `@deploy-agent`).
+
+The text-based mention extraction (`extractAgentMentions`) already handled hyphens
+correctly via `strings.Fields` tokenization and explicit `-` exclusion in
+`TrimRightFunc`.
+
+## Solution
+
+Added `isPartialMentionEntity()` helper that detects when a Telegram mention entity
+covers only part of a longer token by checking if the character immediately after
+the entity boundary is a valid agent-slug character (letter, digit, hyphen, or
+underscore).
+
+Applied the check in:
+- `hasNonBotUserMention()` — skip partial entities so they don't block routing
+- `resolveUserMentions()` — skip partial entities to prevent text corruption
+
+## Files Changed
+
+- `extras/scion-telegram/internal/telegram/mentions.go` — added `isPartialMentionEntity`, fixed `hasNonBotUserMention`
+- `extras/scion-telegram/internal/telegram/broker_v2.go` — fixed `resolveUserMentions`
+- `extras/scion-telegram/internal/telegram/mentions_test.go` — 26 new tests
+
+## Testing
+
+All existing tests continue to pass. New tests cover:
+- `isPartialMentionEntity` with hyphens, underscores, letters, digits, spaces, end-of-string, commas, emoji
+- `hasNonBotUserMention` with hyphenated agent entities
+- `resolveTargetAgents` with hyphenated agents (with and without Telegram entities)
+- `extractAgentMentions` with multiple hyphens, trailing punctuation, dots, multiple agents
+- `stripMentions` with hyphenated agents
+- `extractUnresolvedMentions` with hyphenated known/unknown agents

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -1858,6 +1858,13 @@ func (b *TelegramBrokerV2) resolveUserMentions(ctx context.Context, tgMsg *TGMes
 			if !ok {
 				continue
 			}
+			// Skip if the entity is a partial match — Telegram may truncate
+			// at a hyphen in agent names like "@agent-dev", creating an entity
+			// covering only "@agent". Replacing partial text would corrupt the
+			// message (e.g., "user:email-dev" instead of "@agent-dev").
+			if isPartialMentionEntity(tgMsg.Text, ent.Offset, ent.Length) {
+				continue
+			}
 			username := strings.TrimPrefix(mention, "@")
 			if username == "" {
 				continue

--- a/extras/scion-telegram/internal/telegram/mentions.go
+++ b/extras/scion-telegram/internal/telegram/mentions.go
@@ -142,14 +142,26 @@ func utf16CodeUnits(r rune) int {
 // creates a mention entity for just the valid-username prefix (e.g., "@agent"
 // for "@agent-dev"). Returns true if the character immediately after the entity
 // in the text is a valid agent-slug character (letter, digit, hyphen, or
-// underscore), indicating the entity is a partial match.
+// underscore), indicating the entity is a partial match. For dots, a lookahead
+// is used: "@agent.dev" is partial, but "@agent." at end-of-token is not (the
+// dot is sentence punctuation).
 func isPartialMentionEntity(text string, entOffset, entLength int) bool {
 	_, end, ok := utf16ByteRange(text, entOffset, entLength)
 	if !ok || end >= len(text) {
 		return false
 	}
 	r, _ := utf8.DecodeRuneInString(text[end:])
-	return r == '-' || r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+	if r == '-' || r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r) {
+		return true
+	}
+	// Dot followed by a letter or digit indicates a dotted slug (e.g., "agent.dev").
+	// A trailing dot (end of string, before space, or before punctuation) is
+	// treated as sentence punctuation, not part of the name.
+	if r == '.' && end+1 < len(text) {
+		nextR, _ := utf8.DecodeRuneInString(text[end+1:])
+		return unicode.IsLetter(nextR) || unicode.IsDigit(nextR)
+	}
+	return false
 }
 
 // isBotMentioned checks Telegram's structured entities for a mention matching the bot's username.

--- a/extras/scion-telegram/internal/telegram/mentions.go
+++ b/extras/scion-telegram/internal/telegram/mentions.go
@@ -18,6 +18,7 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // resolveTargetAgents determines which agents a message should be routed to.
@@ -133,6 +134,22 @@ func utf16CodeUnits(r rune) int {
 		return 2 // supplementary plane → surrogate pair
 	}
 	return 1
+}
+
+// isPartialMentionEntity checks whether a Telegram mention entity covers only
+// part of a longer token in the message text. This happens when agent names
+// contain characters not valid in Telegram usernames (e.g., hyphens): Telegram
+// creates a mention entity for just the valid-username prefix (e.g., "@agent"
+// for "@agent-dev"). Returns true if the character immediately after the entity
+// in the text is a valid agent-slug character (letter, digit, hyphen, or
+// underscore), indicating the entity is a partial match.
+func isPartialMentionEntity(text string, entOffset, entLength int) bool {
+	_, end, ok := utf16ByteRange(text, entOffset, entLength)
+	if !ok || end >= len(text) {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(text[end:])
+	return r == '-' || r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
 }
 
 // isBotMentioned checks Telegram's structured entities for a mention matching the bot's username.
@@ -257,6 +274,12 @@ func hasNonBotUserMention(msg *TGMessage, botUsername string, knownAgents []stri
 		case "mention":
 			mention, ok := utf16Extract(msg.Text, ent.Offset, ent.Length)
 			if !ok {
+				continue
+			}
+			// Skip if the entity is a partial match — Telegram may truncate
+			// at a hyphen because hyphens are not valid in Telegram usernames.
+			// For example, "@agent-dev" produces an entity covering only "@agent".
+			if isPartialMentionEntity(msg.Text, ent.Offset, ent.Length) {
 				continue
 			}
 			username := strings.ToLower(strings.TrimPrefix(mention, "@"))

--- a/extras/scion-telegram/internal/telegram/mentions_test.go
+++ b/extras/scion-telegram/internal/telegram/mentions_test.go
@@ -591,6 +591,97 @@ func TestHasNonBotUserMention_CaseInsensitive(t *testing.T) {
 	assert.False(t, hasNonBotUserMention(msg, "ScionHubBot", []string{"coder"}))
 }
 
+// --- isPartialMentionEntity tests ---
+
+func TestIsPartialMentionEntity_HyphenAfterEntity(t *testing.T) {
+	// "@agent-dev" — entity covers "@agent" (offset 0, length 6), next char is '-'
+	assert.True(t, isPartialMentionEntity("@agent-dev hello", 0, 6))
+}
+
+func TestIsPartialMentionEntity_UnderscoreAfterEntity(t *testing.T) {
+	// "@agent_dev" — entity covers "@agent" (offset 0, length 6), next char is '_'
+	assert.True(t, isPartialMentionEntity("@agent_dev hello", 0, 6))
+}
+
+func TestIsPartialMentionEntity_LetterAfterEntity(t *testing.T) {
+	// In theory, if Telegram truncated mid-word.
+	assert.True(t, isPartialMentionEntity("@agentdev hello", 0, 4))
+}
+
+func TestIsPartialMentionEntity_SpaceAfterEntity(t *testing.T) {
+	// "@agent hello" — entity covers "@agent", next char is space. Not partial.
+	assert.False(t, isPartialMentionEntity("@agent hello", 0, 6))
+}
+
+func TestIsPartialMentionEntity_EndOfString(t *testing.T) {
+	// "@agent" — entity covers entire string. Not partial.
+	assert.False(t, isPartialMentionEntity("@agent", 0, 6))
+}
+
+func TestIsPartialMentionEntity_CommaAfterEntity(t *testing.T) {
+	// "@agent, hello" — entity covers "@agent", next char is comma. Not partial.
+	assert.False(t, isPartialMentionEntity("@agent, hello", 0, 6))
+}
+
+func TestIsPartialMentionEntity_MidTextHyphen(t *testing.T) {
+	// "hey @agent-dev" — entity at offset 4 covers "@agent", next char is '-'
+	assert.True(t, isPartialMentionEntity("hey @agent-dev", 4, 6))
+}
+
+func TestIsPartialMentionEntity_EmojiBeforeHyphenatedMention(t *testing.T) {
+	// "🎉 @agent-dev" — emoji is 2 UTF-16 code units, space is 1. Entity at offset 3.
+	assert.True(t, isPartialMentionEntity("🎉 @agent-dev", 3, 6))
+}
+
+func TestIsPartialMentionEntity_DigitAfterEntity(t *testing.T) {
+	// "@agent2dev" — entity covers "@agent", next char is '2' (digit).
+	assert.True(t, isPartialMentionEntity("@agent2dev hello", 0, 6))
+}
+
+func TestIsPartialMentionEntity_MultipleHyphens(t *testing.T) {
+	// "@my-cool-agent" — entity covers "@my" (offset 0, length 3), next char is '-'
+	assert.True(t, isPartialMentionEntity("@my-cool-agent check", 0, 3))
+}
+
+// --- hasNonBotUserMention with hyphenated agent names ---
+
+func TestHasNonBotUserMention_HyphenatedAgentEntityAtStart(t *testing.T) {
+	// Telegram creates entity for "@agent" but the user typed "@agent-dev".
+	// Since the entity is partial (next char is '-'), it should NOT be treated
+	// as a non-bot user mention.
+	msg := &TGMessage{
+		Text: "@agent-dev hello",
+		Entities: []MessageEntity{
+			{Type: "mention", Offset: 0, Length: 6}, // covers "@agent"
+		},
+	}
+	assert.False(t, hasNonBotUserMention(msg, "ScionHubBot", []string{"agent-dev"}))
+}
+
+func TestHasNonBotUserMention_HyphenatedNonAgentEntityAtStart(t *testing.T) {
+	// Same partial entity, but agent-dev is not known. Still should not be
+	// classified as a user mention since the entity is partial.
+	msg := &TGMessage{
+		Text: "@agent-dev hello",
+		Entities: []MessageEntity{
+			{Type: "mention", Offset: 0, Length: 6}, // covers "@agent"
+		},
+	}
+	assert.False(t, hasNonBotUserMention(msg, "ScionHubBot", []string{"coder"}))
+}
+
+func TestHasNonBotUserMention_NonPartialUserMention(t *testing.T) {
+	// "@alice hello" — entity covers "@alice" and next char is space.
+	// This is a genuine user mention, not partial.
+	msg := &TGMessage{
+		Text: "@alice hello",
+		Entities: []MessageEntity{
+			{Type: "mention", Offset: 0, Length: 6}, // covers "@alice"
+		},
+	}
+	assert.True(t, hasNonBotUserMention(msg, "ScionHubBot", []string{"coder"}))
+}
+
 // --- entityMentionSet tests ---
 
 func TestEntityMentionSet_RealUserMention(t *testing.T) {
@@ -763,4 +854,88 @@ func TestTypoDetection_MixedTypoAndRealUser(t *testing.T) {
 		}
 	}
 	assert.Equal(t, []string{"@agent-typo"}, typos)
+}
+
+// --- Comprehensive hyphenated agent name tests ---
+
+func TestResolveTargetAgents_HyphenatedAgent(t *testing.T) {
+	msg := &TGMessage{
+		Text: "@deploy-agent run the deploy",
+	}
+	result, isAll := resolveTargetAgents(msg, "ScionHubBot", "coder", []string{"coder", "deploy-agent"})
+	assert.Equal(t, []string{"deploy-agent"}, result)
+	assert.False(t, isAll)
+}
+
+func TestResolveTargetAgents_HyphenatedAgentWithEntity(t *testing.T) {
+	// Telegram creates a partial entity for "@deploy" but the user typed "@deploy-agent".
+	msg := &TGMessage{
+		Text: "@deploy-agent run the deploy",
+		Entities: []MessageEntity{
+			{Type: "mention", Offset: 0, Length: 7}, // covers "@deploy"
+		},
+	}
+	result, isAll := resolveTargetAgents(msg, "ScionHubBot", "coder", []string{"coder", "deploy-agent"})
+	assert.Equal(t, []string{"deploy-agent"}, result)
+	assert.False(t, isAll)
+}
+
+func TestResolveTargetAgents_MultipleHyphens(t *testing.T) {
+	msg := &TGMessage{
+		Text: "@my-cool-agent help me",
+	}
+	result, isAll := resolveTargetAgents(msg, "ScionHubBot", "coder", []string{"coder", "my-cool-agent"})
+	assert.Equal(t, []string{"my-cool-agent"}, result)
+	assert.False(t, isAll)
+}
+
+func TestExtractAgentMentions_MultipleHyphens(t *testing.T) {
+	agents, hasAll := extractAgentMentions("@my-cool-agent check", []string{"my-cool-agent", "coder"})
+	assert.False(t, hasAll)
+	assert.Equal(t, []string{"my-cool-agent"}, agents)
+}
+
+func TestExtractAgentMentions_HyphenatedWithTrailingPunctuation(t *testing.T) {
+	agents, hasAll := extractAgentMentions("@deploy-agent, please check", []string{"deploy-agent", "coder"})
+	assert.False(t, hasAll)
+	assert.Equal(t, []string{"deploy-agent"}, agents)
+}
+
+func TestExtractAgentMentions_MultipleHyphenatedAgents(t *testing.T) {
+	agents, hasAll := extractAgentMentions("@deploy-agent @code-reviewer check", []string{"deploy-agent", "code-reviewer", "coder"})
+	assert.False(t, hasAll)
+	assert.Equal(t, []string{"deploy-agent", "code-reviewer"}, agents)
+}
+
+func TestExtractAgentMentions_WithDot(t *testing.T) {
+	agents, hasAll := extractAgentMentions("@agent.dev check", []string{"agent.dev", "coder"})
+	assert.False(t, hasAll)
+	assert.Equal(t, []string{"agent.dev"}, agents)
+}
+
+func TestStripMentions_HyphenatedAgent(t *testing.T) {
+	result := stripMentions("@ScionHubBot @deploy-agent please review this", "ScionHubBot", []string{"deploy-agent"})
+	assert.Equal(t, "please review this", result)
+}
+
+func TestStripMentions_HyphenatedAgentWithTrailingPunctuation(t *testing.T) {
+	result := stripMentions("@deploy-agent, please help", "ScionHubBot", []string{"deploy-agent"})
+	assert.Equal(t, ", please help", result)
+}
+
+func TestStripMentions_MultipleHyphenatedAgents(t *testing.T) {
+	result := stripMentions("@deploy-agent @code-reviewer check this", "ScionHubBot", []string{"deploy-agent", "code-reviewer"})
+	assert.Equal(t, "check this", result)
+}
+
+func TestExtractUnresolvedMentions_HyphenatedKnownAgent(t *testing.T) {
+	// Known hyphenated agent should NOT appear in unresolved.
+	result := extractUnresolvedMentions("@deploy-agent hello", "ScionHubBot", []string{"deploy-agent"})
+	assert.Nil(t, result)
+}
+
+func TestExtractUnresolvedMentions_HyphenatedUnknownAgent(t *testing.T) {
+	// Unknown hyphenated agent should appear in unresolved with full name.
+	result := extractUnresolvedMentions("@deploy-agent hello", "ScionHubBot", []string{"coder"})
+	assert.Equal(t, []string{"deploy-agent"}, result)
 }

--- a/extras/scion-telegram/internal/telegram/mentions_test.go
+++ b/extras/scion-telegram/internal/telegram/mentions_test.go
@@ -643,6 +643,21 @@ func TestIsPartialMentionEntity_MultipleHyphens(t *testing.T) {
 	assert.True(t, isPartialMentionEntity("@my-cool-agent check", 0, 3))
 }
 
+func TestIsPartialMentionEntity_DotAfterEntity(t *testing.T) {
+	// "@agent.dev" — entity covers "@agent" (offset 0, length 6), next char is '.' followed by 'd'
+	assert.True(t, isPartialMentionEntity("@agent.dev hello", 0, 6))
+}
+
+func TestIsPartialMentionEntity_TrailingDot(t *testing.T) {
+	// "@agent." — entity covers "@agent", next char is '.' but nothing after it. Not partial.
+	assert.False(t, isPartialMentionEntity("@agent.", 0, 6))
+}
+
+func TestIsPartialMentionEntity_DotThenSpace(t *testing.T) {
+	// "@agent. hello" — entity covers "@agent", next char is '.' followed by space. Not partial.
+	assert.False(t, isPartialMentionEntity("@agent. hello", 0, 6))
+}
+
 // --- hasNonBotUserMention with hyphenated agent names ---
 
 func TestHasNonBotUserMention_HyphenatedAgentEntityAtStart(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix bug where `@agent-dev` style mentions with hyphens could be incorrectly tokenized by Telegram's entity system, which truncates at the hyphen (creating an entity for just `@agent`)
- Add `isPartialMentionEntity()` helper that detects when a Telegram mention entity covers only part of a longer token by checking the character after the entity boundary
- Fix `hasNonBotUserMention()` to skip partial entities so hyphenated agent names don't get misclassified as user mentions, which could block message routing
- Fix `resolveUserMentions()` to skip partial entities to prevent text corruption (e.g., replacing `@agent` portion with `user:email`, leaving `-dev` dangling)
- Add 26 new tests covering hyphenated names across `isPartialMentionEntity`, `hasNonBotUserMention`, `resolveTargetAgents`, `extractAgentMentions`, `stripMentions`, and `extractUnresolvedMentions`

## Test plan

- [x] All existing mention tests pass (no regressions)
- [x] New `TestIsPartialMentionEntity_*` tests verify partial entity detection for hyphens, underscores, letters, digits, spaces, end-of-string, commas, emoji
- [x] New `TestHasNonBotUserMention_Hyphenated*` tests verify partial entities are skipped in routing decisions
- [x] New `TestResolveTargetAgents_Hyphenated*` tests verify end-to-end routing with hyphenated agent names and partial Telegram entities
- [x] New `TestExtractAgentMentions_*` tests verify text-based extraction for multi-hyphen, trailing punctuation, multiple agents, dots
- [x] New `TestStripMentions_*` tests verify mention stripping for hyphenated agents
- [x] New `TestExtractUnresolvedMentions_*` tests verify typo detection with hyphenated names
- [x] Full test suite passes: `go test ./internal/telegram/ -count=1`