### PR TITLE
Fix bare email recipient in message command to return error

### DIFF
--- a/.design/project-log/2026-05-31-fix-81-bare-email-message.md
+++ b/.design/project-log/2026-05-31-fix-81-bare-email-message.md
@@ -1,0 +1,31 @@
+# Fix #81: Bare email recipient in message command fails silently
+
+**Date:** 2026-05-31
+**Issue:** #81
+
+## Problem
+
+`scion message someone@example.com "hello"` (without the `user:` prefix) silently converted the recipient to `user:someone@example.com` and reported "Message sent" with exit code 0, even when the message was never delivered.
+
+## Fix
+
+Changed the bare email detection branch in `cmd/message.go` to return an explicit error with guidance instead of silently converting:
+
+```
+Error: recipient "someone@example.com" looks like an email address but is missing the "user:" prefix.
+
+Did you mean?
+  scion message user:someone@example.com "hello"
+```
+
+## Files Changed
+
+- `cmd/message.go` — replaced silent auto-conversion with error + suggestion
+- `cmd/message_test.go` — added `TestBareEmailRecipientReturnsError` with 3 sub-tests
+
+## Design Decision
+
+Chose Option 2 (explicit error) over Option 1 (auto-fix) because:
+- It teaches users the correct syntax rather than hiding complexity
+- It avoids the ambiguity of silent conversions that may silently fail downstream
+- It follows the principle of least surprise for CLI tools

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -90,8 +90,9 @@ Examples:
 			} else if strings.HasPrefix(recipient, "user:") {
 				userRecipient = recipient
 			} else if strings.Contains(recipient, "@") && !strings.HasPrefix(recipient, "agent:") {
-				// Bare email address — treat as user recipient
-				userRecipient = "user:" + recipient
+				// Bare email address without user: prefix — return a clear error
+				// instead of silently converting, which can lead to undelivered messages.
+				return fmt.Errorf("recipient %q looks like an email address but is missing the \"user:\" prefix.\n\nDid you mean?\n  scion message user:%s %q", recipient, recipient, message)
 			} else {
 				// Strip optional "agent:" prefix for backwards compatibility
 				agentName = api.Slugify(strings.TrimPrefix(recipient, "agent:"))

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -981,6 +981,75 @@ func TestSendMessageViaHub_WakePassedThrough(t *testing.T) {
 	mu.Unlock()
 }
 
+func TestBareEmailRecipientReturnsError(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantErr     string
+		wantSuggest string
+	}{
+		{
+			name:        "bare email returns error with suggestion",
+			args:        []string{"alice@example.com", "hello"},
+			wantErr:     `looks like an email address but is missing the "user:" prefix`,
+			wantSuggest: "user:alice@example.com",
+		},
+		{
+			name:        "bare email with subdomain",
+			args:        []string{"bob@corp.example.com", "check this out"},
+			wantErr:     `looks like an email address but is missing the "user:" prefix`,
+			wantSuggest: "user:bob@corp.example.com",
+		},
+		{
+			name:    "user-prefixed email is accepted (no error at parse stage)",
+			args:    []string{"user:alice@example.com", "hello"},
+			wantErr: "", // no parse error — fails later for other reasons (Hub, etc.)
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset flags to defaults
+			origRaw := msgRaw
+			origIn := msgIn
+			origBroadcast, origAll := msgBroadcast, msgAll
+			origNotify := msgNotify
+			origWake := msgWake
+			defer func() {
+				msgRaw = origRaw
+				msgIn = origIn
+				msgBroadcast = origBroadcast
+				msgAll = origAll
+				msgNotify = origNotify
+				msgWake = origWake
+			}()
+			msgRaw = false
+			msgIn = ""
+			msgBroadcast = false
+			msgAll = false
+			msgNotify = false
+			msgWake = false
+
+			err := messageCmd.RunE(messageCmd, tc.args)
+
+			if tc.wantErr == "" {
+				// We expect no error at the recipient parsing stage.
+				// The command will still fail (Hub not configured, etc.)
+				// but NOT with our email-specific error.
+				if err != nil {
+					assert.NotContains(t, err.Error(), "looks like an email address")
+				}
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				if tc.wantSuggest != "" {
+					assert.Contains(t, err.Error(), tc.wantSuggest)
+				}
+			}
+		})
+	}
+}
+
 func TestNotifyFlagValidation(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION


## Summary

- When `scion message someone@example.com "hello"` is used without the `user:` prefix, the CLI now returns a clear error with a suggestion instead of silently converting and reporting success when the message is never delivered
- Added `TestBareEmailRecipientReturnsError` with 3 sub-tests covering bare emails, subdomain emails, and verifying `user:` prefixed emails still work

## Before (broken)
```
$ scion message alice@example.com "hello"
Message sent to user:alice@example.com via Hub.    # exit 0, but never delivered
```

## After (fixed)
```
$ scion message alice@example.com "hello"
Error: recipient "alice@example.com" looks like an email address but is missing the "user:" prefix.

Did you mean?
  scion message user:alice@example.com "hello"
```

## Test plan
- [x] `TestBareEmailRecipientReturnsError/bare_email_returns_error_with_suggestion` — verifies bare email returns error with correct message
- [x] `TestBareEmailRecipientReturnsError/bare_email_with_subdomain` — verifies subdomain emails also caught
- [x] `TestBareEmailRecipientReturnsError/user-prefixed_email_is_accepted` — verifies `user:` prefix still works
- [x] All existing message tests pass (no regressions)