### PR TITLE
Harness observability: content-type filtering for assistant responses

### DIFF
--- a/.design/project-log/2026-05-31-content-type-filtering.md
+++ b/.design/project-log/2026-05-31-content-type-filtering.md
@@ -1,0 +1,65 @@
+# Content-Type Filtering for Harness Observability
+
+**Date:** 2026-05-31
+**Issue:** #28
+**Branch:** scion/dev-issue-28
+
+## Summary
+
+Implemented content-type filtering to prevent thinking/reasoning content from leaking into user-facing chat messages. The solution follows the design doc's recommended approach (Option A + C): filter at the source in the ClaudeDialect, and add content classification to the messaging pipeline.
+
+## Root Cause
+
+The `last_assistant_message` field from Claude Code's Stop hook was treated as an opaque string. When Claude Code includes extended thinking/reasoning content in this field, it passes through the entire pipeline (ClaudeDialect → HubHandler → Hub API → broker → chat app) with zero filtering. No layer in the pipeline inspected or classified the content.
+
+## Changes
+
+### Content Classification Types (`pkg/sciontool/hooks/types.go`)
+- Added `ContentBlock` struct with `Type` field (text, thinking, tool_use, tool_result, error)
+- Added `AssistantContent` struct with `Blocks []ContentBlock` to hold classified content
+- Added `TextOnly()` method that returns only user-visible text blocks
+- Added `HasThinking()` method for downstream classification checks
+- Added `AssistantContent` field to `EventData` alongside existing `AssistantText`
+
+### Content-Type Filtering in ClaudeDialect (`pkg/sciontool/hooks/dialects/claude.go`)
+- New `extractAssistantContentFromPayload()` handles three input formats:
+  - Plain string: treated as a single text block
+  - JSON-encoded array: parsed and classified by block type
+  - Native array (`[]interface{}`): classified by block type
+- `classifyContentBlock()` maps raw content blocks to typed ContentBlocks
+- `extractFinalAssistantContentFromTranscript()` replaces the text-only transcript path with a content-type-aware version
+- `AssistantText` now contains only filtered text (thinking stripped)
+- `AssistantContent` preserves the full typed structure for verbose consumers
+
+### Visibility Tagging (`pkg/messages/types.go`)
+- Added `Visibility` field to `StructuredMessage` (normal, verbose, full)
+- `normal`: explicit agent→user messages (scion message, ask_user)
+- `verbose`: automatic assistant replies from hooks (thinking filtered)
+- `full`: everything including thinking traces (for ACP/debugging)
+
+### Hub Handler Updates (`pkg/sciontool/hooks/handlers/hub.go`)
+- Outbound assistant-reply messages tagged with `visibility: "verbose"`
+- Content classification metadata added: `source=hook`, `has_thinking` flag
+
+### Message Pipeline (`pkg/hub/handlers.go`, `pkg/sciontool/hub/client.go`)
+- Added `Visibility` and `Metadata` fields to both `OutboundMessage` (client) and `OutboundMessageRequest` (server)
+- Visibility and metadata propagated through to `StructuredMessage` for downstream consumers
+
+## Design Decisions
+
+1. **Filter at source, not at sink**: Filtering in the ClaudeDialect (earliest layer) prevents thinking content from propagating through any downstream handler. This is more robust than filtering at each consumer.
+
+2. **Preserve structure for verbose consumers**: The full `AssistantContent` with typed blocks is preserved alongside the filtered `AssistantText`. This enables future verbose/debug views without re-parsing.
+
+3. **Backward compatible**: Plain string `last_assistant_message` without content blocks works exactly as before — treated as a single text block. The transcript fallback path is also preserved.
+
+4. **Visibility as a message-level concern**: Rather than filtering at the broker topic level, visibility is a field on the message itself. This lets each consumer decide its own fidelity level.
+
+## Test Coverage
+
+- Content block parsing: plain strings, JSON arrays, native arrays, invalid JSON, arrays without type fields
+- Thinking filtering: thinking-only, mixed blocks, multiple text blocks
+- AssistantContent methods: TextOnly(), HasThinking() with nil/empty
+- Transcript classification with thinking blocks
+- Backward compatibility: all existing behavior preserved
+- HubHandler: verbose visibility tag, has_thinking metadata

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -1921,12 +1921,14 @@ func (s *Server) handleAgentTokenRefresh(w http.ResponseWriter, r *http.Request,
 
 // OutboundMessageRequest is the request body for POST /api/v1/agents/{id}/outbound-message.
 type OutboundMessageRequest struct {
-	Recipient   string   `json:"recipient,omitempty"`
-	RecipientID string   `json:"recipient_id,omitempty"`
-	Msg         string   `json:"msg"`
-	Type        string   `json:"type,omitempty"`
-	Urgent      bool     `json:"urgent,omitempty"`
-	Attachments []string `json:"attachments,omitempty"`
+	Recipient   string            `json:"recipient,omitempty"`
+	RecipientID string            `json:"recipient_id,omitempty"`
+	Msg         string            `json:"msg"`
+	Type        string            `json:"type,omitempty"`
+	Urgent      bool              `json:"urgent,omitempty"`
+	Attachments []string          `json:"attachments,omitempty"`
+	Visibility  string            `json:"visibility,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
 // handleAgentOutboundMessage handles POST /api/v1/agents/{id}/outbound-message.
@@ -2051,6 +2053,8 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		Type:        storeMsg.Type,
 		Urgent:      storeMsg.Urgent,
 		Attachments: req.Attachments,
+		Visibility:  req.Visibility,
+		Metadata:    req.Metadata,
 	}
 
 	// Route through broker when available; otherwise persist and publish

--- a/pkg/messages/types.go
+++ b/pkg/messages/types.go
@@ -47,6 +47,26 @@ const (
 	TypeGroupSet       = "group-set"
 )
 
+// Visibility constants control which consumers see a message.
+// Downstream consumers (chat apps, web UI, broker plugins) filter
+// messages by visibility level to avoid surfacing raw agent output
+// (e.g. thinking traces) in normal chat views.
+const (
+	// VisibilityNormal — always shown. Used for explicit agent→user
+	// messages (scion message, ask_user) and user→agent instructions.
+	VisibilityNormal = "normal"
+
+	// VisibilityVerbose — shown in verbose mode. Used for automatic
+	// assistant replies from hook events (agent turn output without
+	// thinking content).
+	VisibilityVerbose = "verbose"
+
+	// VisibilityFull — shown only in full-fidelity mode. Used for
+	// content that includes thinking/reasoning traces and raw tool
+	// output. Intended for ACP streams and debugging interfaces.
+	VisibilityFull = "full"
+)
+
 // validTypes is the set of valid message types.
 var validTypes = map[string]bool{
 	TypeInstruction:    true,
@@ -75,6 +95,11 @@ type StructuredMessage struct {
 	Status       string            `json:"status,omitempty"`
 	Attachments  []string          `json:"attachments,omitempty"`
 	Metadata     map[string]string `json:"metadata,omitempty"`
+
+	// Visibility controls which consumers see this message.
+	// One of VisibilityNormal, VisibilityVerbose, or VisibilityFull.
+	// Empty defaults to VisibilityNormal for backward compatibility.
+	Visibility string `json:"visibility,omitempty"`
 }
 
 // ValidateType returns an error if the message type is not in the closed enum.

--- a/pkg/sciontool/hooks/dialects/claude.go
+++ b/pkg/sciontool/hooks/dialects/claude.go
@@ -96,6 +96,12 @@ func (d *ClaudeDialect) Parse(data map[string]interface{}) (*hooks.Event, error)
 	// can surface it as an outbound agent→user message. Subagent turns
 	// are internal to the harness and should not drive scion agent state.
 	//
+	// Content-type filtering: the extraction pipeline classifies content
+	// blocks by type (text, thinking, tool_use, etc.) and stores them in
+	// AssistantContent. AssistantText receives only user-visible "text"
+	// blocks — thinking/reasoning content is filtered out to prevent it
+	// from leaking into chat messages.
+	//
 	// Preferred source: the top-level "last_assistant_message" field,
 	// which Claude Code 2.1+ includes in the Stop hook payload directly.
 	// This is authoritative and race-free: the payload is handed to the
@@ -109,11 +115,15 @@ func (d *ClaudeDialect) Parse(data map[string]interface{}) (*hooks.Event, error)
 	// transcript. It is racy against the harness's own writes, so it is
 	// strictly a fallback, not the primary path.
 	if event.Name == hooks.EventAgentEnd {
-		if text := strings.TrimSpace(getString(data, "last_assistant_message")); text != "" {
+		text, content := extractAssistantContentFromPayload(data)
+		if text != "" {
 			event.Data.AssistantText = text
+			event.Data.AssistantContent = content
 		} else if path := getString(data, "transcript_path"); path != "" {
-			if text := extractFinalAssistantText(path); text != "" {
+			text, content := extractFinalAssistantContentFromTranscript(path)
+			if text != "" {
 				event.Data.AssistantText = text
+				event.Data.AssistantContent = content
 			}
 		}
 	}
@@ -217,6 +227,246 @@ func assistantContentText(content json.RawMessage) string {
 		}
 	}
 	return strings.TrimSpace(strings.Join(parts, ""))
+}
+
+// extractAssistantContentFromPayload extracts and classifies content from
+// the last_assistant_message field in the hook payload. The field value may be:
+//
+//   - A string: treated as plain text (single text block), or parsed as a
+//     JSON array of typed content blocks if it looks like JSON.
+//   - A []interface{}: a structured array of content blocks with type fields.
+//
+// Returns the filtered user-visible text (thinking blocks stripped) and the
+// full classified AssistantContent. Returns ("", nil) if no content is found.
+func extractAssistantContentFromPayload(data map[string]interface{}) (string, *hooks.AssistantContent) {
+	val, ok := data["last_assistant_message"]
+	if !ok {
+		return "", nil
+	}
+
+	switch v := val.(type) {
+	case string:
+		text := strings.TrimSpace(v)
+		if text == "" {
+			return "", nil
+		}
+		// Try to parse as a JSON array of typed content blocks.
+		// Claude Code may send structured blocks as a JSON-encoded string.
+		if blocks := parseContentBlocksFromJSON(text); len(blocks) > 0 {
+			content := &hooks.AssistantContent{Blocks: blocks}
+			return content.TextOnly(), content
+		}
+		// Plain string — treat as a single text block.
+		content := &hooks.AssistantContent{
+			Blocks: []hooks.ContentBlock{{Type: hooks.ContentBlockText, Text: text}},
+		}
+		return text, content
+
+	case []interface{}:
+		// Structured array of content blocks (already parsed from JSON).
+		blocks := parseContentBlocksFromArray(v)
+		if len(blocks) == 0 {
+			return "", nil
+		}
+		content := &hooks.AssistantContent{Blocks: blocks}
+		return content.TextOnly(), content
+
+	default:
+		return "", nil
+	}
+}
+
+// parseContentBlocksFromJSON attempts to parse a string as a JSON array of
+// typed content blocks. Returns nil if the string is not valid JSON or not
+// an array of objects with "type" fields.
+func parseContentBlocksFromJSON(s string) []hooks.ContentBlock {
+	// Quick check: must look like a JSON array.
+	if len(s) < 2 || s[0] != '[' {
+		return nil
+	}
+
+	var rawBlocks []map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &rawBlocks); err != nil {
+		return nil
+	}
+
+	// Validate that at least one entry has a "type" field — this
+	// distinguishes a content block array from arbitrary JSON arrays.
+	hasType := false
+	for _, b := range rawBlocks {
+		if _, ok := b["type"]; ok {
+			hasType = true
+			break
+		}
+	}
+	if !hasType {
+		return nil
+	}
+
+	var blocks []hooks.ContentBlock
+	for _, b := range rawBlocks {
+		block := classifyContentBlock(b)
+		if block.Type != "" {
+			blocks = append(blocks, block)
+		}
+	}
+	return blocks
+}
+
+// parseContentBlocksFromArray converts a []interface{} (from JSON
+// unmarshalling) into classified ContentBlocks.
+func parseContentBlocksFromArray(arr []interface{}) []hooks.ContentBlock {
+	var blocks []hooks.ContentBlock
+	for _, item := range arr {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		block := classifyContentBlock(m)
+		if block.Type != "" {
+			blocks = append(blocks, block)
+		}
+	}
+	return blocks
+}
+
+// classifyContentBlock converts a raw content block map into a typed
+// ContentBlock. Supported block types:
+//   - "text": user-visible text (text field)
+//   - "thinking": reasoning/thinking traces (thinking field)
+//   - "tool_use": tool invocations (name + input)
+//   - "tool_result": tool outputs (content field)
+func classifyContentBlock(m map[string]interface{}) hooks.ContentBlock {
+	blockType := getString(m, "type")
+	switch blockType {
+	case "text":
+		return hooks.ContentBlock{
+			Type: hooks.ContentBlockText,
+			Text: getString(m, "text"),
+		}
+	case "thinking":
+		// Claude's thinking blocks use "thinking" field, not "text".
+		text := getString(m, "thinking")
+		if text == "" {
+			text = getString(m, "text")
+		}
+		return hooks.ContentBlock{
+			Type: hooks.ContentBlockThinking,
+			Text: text,
+		}
+	case "tool_use":
+		// Summarize as "tool_name: <name>" for downstream consumers.
+		name := getString(m, "name")
+		return hooks.ContentBlock{
+			Type: hooks.ContentBlockToolUse,
+			Text: name,
+		}
+	case "tool_result":
+		text := getString(m, "content")
+		if text == "" {
+			text = getString(m, "text")
+		}
+		return hooks.ContentBlock{
+			Type: hooks.ContentBlockToolResult,
+			Text: text,
+		}
+	default:
+		if blockType == "" {
+			return hooks.ContentBlock{}
+		}
+		// Unknown block type — preserve with original type string.
+		text := getString(m, "text")
+		if text == "" {
+			text = getString(m, "content")
+		}
+		return hooks.ContentBlock{Type: blockType, Text: text}
+	}
+}
+
+// extractFinalAssistantContentFromTranscript reads a Claude Code transcript
+// JSONL file and returns both filtered text and classified content blocks
+// from the final assistant turn. This is the content-type-aware version of
+// extractFinalAssistantText that populates AssistantContent.
+func extractFinalAssistantContentFromTranscript(path string) (string, *hooks.AssistantContent) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", nil
+	}
+	defer f.Close()
+
+	var turnBlocks []hooks.ContentBlock
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var entry struct {
+			Type    string `json:"type"`
+			Message struct {
+				Role    string          `json:"role"`
+				Content json.RawMessage `json:"content"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+		entryType := entry.Type
+		if entryType == "" {
+			entryType = entry.Message.Role
+		}
+
+		switch entryType {
+		case "user":
+			turnBlocks = turnBlocks[:0]
+		case "assistant":
+			blocks := classifyTranscriptContent(entry.Message.Content)
+			turnBlocks = append(turnBlocks, blocks...)
+		}
+	}
+
+	if len(turnBlocks) == 0 {
+		return "", nil
+	}
+
+	content := &hooks.AssistantContent{Blocks: turnBlocks}
+	return content.TextOnly(), content
+}
+
+// classifyTranscriptContent parses assistant message content from a transcript
+// entry and returns classified ContentBlocks. Content may be a JSON array of
+// typed blocks or (rarely) a plain string.
+func classifyTranscriptContent(content json.RawMessage) []hooks.ContentBlock {
+	if len(content) == 0 {
+		return nil
+	}
+
+	// Plain string content (older/simpler transcript shape).
+	var s string
+	if err := json.Unmarshal(content, &s); err == nil {
+		text := strings.TrimSpace(s)
+		if text == "" {
+			return nil
+		}
+		return []hooks.ContentBlock{{Type: hooks.ContentBlockText, Text: text}}
+	}
+
+	// Typed block array.
+	var rawBlocks []map[string]interface{}
+	if err := json.Unmarshal(content, &rawBlocks); err != nil {
+		return nil
+	}
+
+	var blocks []hooks.ContentBlock
+	for _, b := range rawBlocks {
+		block := classifyContentBlock(b)
+		if block.Type != "" {
+			blocks = append(blocks, block)
+		}
+	}
+	return blocks
 }
 
 // normalizeEventName maps Claude Code event names to normalized names.

--- a/pkg/sciontool/hooks/dialects/claude.go
+++ b/pkg/sciontool/hooks/dialects/claude.go
@@ -116,12 +116,12 @@ func (d *ClaudeDialect) Parse(data map[string]interface{}) (*hooks.Event, error)
 	// strictly a fallback, not the primary path.
 	if event.Name == hooks.EventAgentEnd {
 		text, content := extractAssistantContentFromPayload(data)
-		if text != "" {
+		if content != nil {
 			event.Data.AssistantText = text
 			event.Data.AssistantContent = content
 		} else if path := getString(data, "transcript_path"); path != "" {
 			text, content := extractFinalAssistantContentFromTranscript(path)
-			if text != "" {
+			if content != nil {
 				event.Data.AssistantText = text
 				event.Data.AssistantContent = content
 			}

--- a/pkg/sciontool/hooks/dialects/claude_test.go
+++ b/pkg/sciontool/hooks/dialects/claude_test.go
@@ -337,6 +337,229 @@ func TestClaudeDialect_ParseFilePath(t *testing.T) {
 	})
 }
 
+// --- Content-type filtering tests ---
+
+func TestExtractAssistantContentFromPayload_PlainString(t *testing.T) {
+	d := NewClaudeDialect()
+	event, err := d.Parse(map[string]interface{}{
+		"hook_event_name":        "Stop",
+		"last_assistant_message": "Hello, here is my response.",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, here is my response.", event.Data.AssistantText)
+	require.NotNil(t, event.Data.AssistantContent)
+	assert.Len(t, event.Data.AssistantContent.Blocks, 1)
+	assert.Equal(t, hooks.ContentBlockText, event.Data.AssistantContent.Blocks[0].Type)
+	assert.False(t, event.Data.AssistantContent.HasThinking())
+}
+
+func TestExtractAssistantContentFromPayload_JSONArrayBlocks(t *testing.T) {
+	// last_assistant_message is a JSON-encoded array of content blocks.
+	d := NewClaudeDialect()
+	blocksJSON := `[{"type":"thinking","thinking":"Let me reason about this..."},{"type":"text","text":"Here is my answer."}]`
+	event, err := d.Parse(map[string]interface{}{
+		"hook_event_name":        "Stop",
+		"last_assistant_message": blocksJSON,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Here is my answer.", event.Data.AssistantText,
+		"AssistantText should contain only text blocks, not thinking")
+	require.NotNil(t, event.Data.AssistantContent)
+	assert.Len(t, event.Data.AssistantContent.Blocks, 2)
+	assert.Equal(t, hooks.ContentBlockThinking, event.Data.AssistantContent.Blocks[0].Type)
+	assert.Equal(t, "Let me reason about this...", event.Data.AssistantContent.Blocks[0].Text)
+	assert.Equal(t, hooks.ContentBlockText, event.Data.AssistantContent.Blocks[1].Type)
+	assert.Equal(t, "Here is my answer.", event.Data.AssistantContent.Blocks[1].Text)
+	assert.True(t, event.Data.AssistantContent.HasThinking())
+}
+
+func TestExtractAssistantContentFromPayload_NativeArray(t *testing.T) {
+	// last_assistant_message is already parsed as []interface{} (native array).
+	d := NewClaudeDialect()
+	event, err := d.Parse(map[string]interface{}{
+		"hook_event_name": "Stop",
+		"last_assistant_message": []interface{}{
+			map[string]interface{}{"type": "thinking", "thinking": "Deep reasoning here"},
+			map[string]interface{}{"type": "text", "text": "User-visible output"},
+			map[string]interface{}{"type": "tool_use", "name": "Bash"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "User-visible output", event.Data.AssistantText,
+		"Only text blocks should appear in AssistantText")
+	require.NotNil(t, event.Data.AssistantContent)
+	assert.Len(t, event.Data.AssistantContent.Blocks, 3)
+	assert.Equal(t, hooks.ContentBlockThinking, event.Data.AssistantContent.Blocks[0].Type)
+	assert.Equal(t, hooks.ContentBlockText, event.Data.AssistantContent.Blocks[1].Type)
+	assert.Equal(t, hooks.ContentBlockToolUse, event.Data.AssistantContent.Blocks[2].Type)
+	assert.True(t, event.Data.AssistantContent.HasThinking())
+}
+
+func TestExtractAssistantContentFromPayload_ThinkingOnlyBlocks(t *testing.T) {
+	// Edge case: only thinking blocks, no text blocks.
+	d := NewClaudeDialect()
+	blocksJSON := `[{"type":"thinking","thinking":"I need to think about this carefully"}]`
+	event, err := d.Parse(map[string]interface{}{
+		"hook_event_name":        "Stop",
+		"last_assistant_message": blocksJSON,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, event.Data.AssistantText,
+		"AssistantText should be empty when only thinking blocks exist")
+	// When text is empty, AssistantContent is not set since the whole extraction returns ""
+}
+
+func TestExtractAssistantContentFromPayload_MultipleTextBlocks(t *testing.T) {
+	d := NewClaudeDialect()
+	blocksJSON := `[{"type":"thinking","thinking":"Planning..."},{"type":"text","text":"Part 1"},{"type":"tool_use","name":"Read"},{"type":"text","text":"Part 2"}]`
+	event, err := d.Parse(map[string]interface{}{
+		"hook_event_name":        "Stop",
+		"last_assistant_message": blocksJSON,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Part 1Part 2", event.Data.AssistantText,
+		"Multiple text blocks should be concatenated")
+	require.NotNil(t, event.Data.AssistantContent)
+	assert.Len(t, event.Data.AssistantContent.Blocks, 4)
+}
+
+func TestExtractAssistantContentFromPayload_EmptyString(t *testing.T) {
+	d := NewClaudeDialect()
+	event, err := d.Parse(map[string]interface{}{
+		"hook_event_name":        "Stop",
+		"last_assistant_message": "",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, event.Data.AssistantText)
+	assert.Nil(t, event.Data.AssistantContent)
+}
+
+func TestExtractAssistantContentFromPayload_InvalidJSON(t *testing.T) {
+	// A string that starts with '[' but isn't valid JSON should be
+	// treated as a plain text block.
+	d := NewClaudeDialect()
+	event, err := d.Parse(map[string]interface{}{
+		"hook_event_name":        "Stop",
+		"last_assistant_message": "[not valid json at all",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "[not valid json at all", event.Data.AssistantText)
+	require.NotNil(t, event.Data.AssistantContent)
+	assert.Len(t, event.Data.AssistantContent.Blocks, 1)
+	assert.Equal(t, hooks.ContentBlockText, event.Data.AssistantContent.Blocks[0].Type)
+}
+
+func TestExtractAssistantContentFromPayload_JSONArrayNoTypeField(t *testing.T) {
+	// A valid JSON array that doesn't have "type" fields should be
+	// treated as a plain text block (not a content block array).
+	d := NewClaudeDialect()
+	event, err := d.Parse(map[string]interface{}{
+		"hook_event_name":        "Stop",
+		"last_assistant_message": `["just","a","list"]`,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, `["just","a","list"]`, event.Data.AssistantText)
+}
+
+func TestExtractFinalAssistantContentFromTranscript_WithThinking(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	content := `{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}` + "\n" +
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"Let me think..."},{"type":"text","text":"Hello!"}]}}` + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	d := NewClaudeDialect()
+	event, err := d.Parse(map[string]interface{}{
+		"hook_event_name": "Stop",
+		"transcript_path": path,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Hello!", event.Data.AssistantText,
+		"Thinking should be filtered from AssistantText via transcript path")
+	require.NotNil(t, event.Data.AssistantContent)
+	assert.True(t, event.Data.AssistantContent.HasThinking())
+	assert.Len(t, event.Data.AssistantContent.Blocks, 2)
+}
+
+func TestAssistantContent_TextOnly(t *testing.T) {
+	content := &hooks.AssistantContent{
+		Blocks: []hooks.ContentBlock{
+			{Type: hooks.ContentBlockThinking, Text: "reasoning"},
+			{Type: hooks.ContentBlockText, Text: "visible"},
+			{Type: hooks.ContentBlockToolUse, Text: "Bash"},
+			{Type: hooks.ContentBlockText, Text: " output"},
+		},
+	}
+	assert.Equal(t, "visible output", content.TextOnly())
+}
+
+func TestAssistantContent_TextOnly_EmptyContent(t *testing.T) {
+	var nilContent *hooks.AssistantContent
+	assert.Equal(t, "", nilContent.TextOnly())
+
+	emptyContent := &hooks.AssistantContent{}
+	assert.Equal(t, "", emptyContent.TextOnly())
+}
+
+func TestAssistantContent_HasThinking(t *testing.T) {
+	assert.False(t, (*hooks.AssistantContent)(nil).HasThinking())
+	assert.False(t, (&hooks.AssistantContent{}).HasThinking())
+	assert.False(t, (&hooks.AssistantContent{
+		Blocks: []hooks.ContentBlock{{Type: hooks.ContentBlockText, Text: "hi"}},
+	}).HasThinking())
+	assert.True(t, (&hooks.AssistantContent{
+		Blocks: []hooks.ContentBlock{
+			{Type: hooks.ContentBlockThinking, Text: "reasoning"},
+			{Type: hooks.ContentBlockText, Text: "answer"},
+		},
+	}).HasThinking())
+}
+
+// TestClaudeDialect_BackwardCompatibility verifies that the existing
+// behavior is preserved: plain-string last_assistant_message without
+// thinking content still works exactly as before.
+func TestClaudeDialect_BackwardCompatibility(t *testing.T) {
+	d := NewClaudeDialect()
+
+	t.Run("plain string still works", func(t *testing.T) {
+		event, err := d.Parse(map[string]interface{}{
+			"hook_event_name":        "Stop",
+			"last_assistant_message": "Simple response text",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "Simple response text", event.Data.AssistantText)
+	})
+
+	t.Run("transcript fallback still works", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "t.jsonl")
+		content := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"From transcript"}]}}` + "\n"
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		event, err := d.Parse(map[string]interface{}{
+			"hook_event_name": "Stop",
+			"transcript_path": path,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "From transcript", event.Data.AssistantText)
+	})
+
+	t.Run("payload still preferred over transcript", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "t.jsonl")
+		content := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"from transcript"}]}}` + "\n"
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		event, err := d.Parse(map[string]interface{}{
+			"hook_event_name":        "Stop",
+			"last_assistant_message": "from payload",
+			"transcript_path":        path,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "from payload", event.Data.AssistantText)
+	})
+}
+
 func TestClaudeDialect_ParseTokens(t *testing.T) {
 	d := NewClaudeDialect()
 

--- a/pkg/sciontool/hooks/dialects/claude_test.go
+++ b/pkg/sciontool/hooks/dialects/claude_test.go
@@ -397,6 +397,10 @@ func TestExtractAssistantContentFromPayload_NativeArray(t *testing.T) {
 
 func TestExtractAssistantContentFromPayload_ThinkingOnlyBlocks(t *testing.T) {
 	// Edge case: only thinking blocks, no text blocks.
+	// AssistantText should be empty (no user-visible text), but
+	// AssistantContent must still be populated so downstream consumers
+	// can access the thinking blocks and the code doesn't fall back to
+	// the racy transcript path.
 	d := NewClaudeDialect()
 	blocksJSON := `[{"type":"thinking","thinking":"I need to think about this carefully"}]`
 	event, err := d.Parse(map[string]interface{}{
@@ -406,7 +410,10 @@ func TestExtractAssistantContentFromPayload_ThinkingOnlyBlocks(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, event.Data.AssistantText,
 		"AssistantText should be empty when only thinking blocks exist")
-	// When text is empty, AssistantContent is not set since the whole extraction returns ""
+	require.NotNil(t, event.Data.AssistantContent,
+		"AssistantContent must be populated even with no text blocks")
+	assert.Len(t, event.Data.AssistantContent.Blocks, 1)
+	assert.Equal(t, hooks.ContentBlockThinking, event.Data.AssistantContent.Blocks[0].Type)
 }
 
 func TestExtractAssistantContentFromPayload_MultipleTextBlocks(t *testing.T) {

--- a/pkg/sciontool/hooks/handlers/hub.go
+++ b/pkg/sciontool/hooks/handlers/hub.go
@@ -129,6 +129,12 @@ func (h *HubHandler) Handle(event *hooks.Event) error {
 		// store as an outbound agent→user reply. This is what makes
 		// assistant responses show up in the Messages tab. Best-effort:
 		// failure here must not break the status update flow below.
+		//
+		// Content-type filtering: AssistantText is pre-filtered by the
+		// dialect layer (thinking/reasoning blocks stripped). The
+		// message is tagged with "verbose" visibility so chat consumers
+		// can distinguish automatic assistant replies from explicit
+		// agent→user messages.
 		if event.Name == hooks.EventAgentEnd && event.Data.AssistantText != "" {
 			text := event.Data.AssistantText
 			// Guard against very large assistant responses (e.g. full file
@@ -138,15 +144,26 @@ func (h *HubHandler) Handle(event *hooks.Event) error {
 				text = text[:maxAssistantTextBytes] + "\n[truncated]"
 			}
 
+			// Build metadata tags for content classification.
+			metadata := map[string]string{
+				"source": "hook",
+			}
+			if event.Data.AssistantContent != nil && event.Data.AssistantContent.HasThinking() {
+				metadata["has_thinking"] = "true"
+			}
+
 			msgCtx, msgCancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer msgCancel()
 			if msgErr := h.client.SendOutboundMessage(msgCtx, hub.OutboundMessage{
-				Msg:  text,
-				Type: "assistant-reply",
+				Msg:        text,
+				Type:       "assistant-reply",
+				Visibility: "verbose",
+				Metadata:   metadata,
 			}); msgErr != nil {
 				log.Error("Hub: outbound assistant reply failed: %v", msgErr)
 			} else {
-				log.Debug("Hub: Forwarded assistant reply to message store (%d bytes)", len(text))
+				log.Debug("Hub: Forwarded assistant reply to message store (%d bytes, thinking_filtered=%v)",
+					len(text), event.Data.AssistantContent != nil && event.Data.AssistantContent.HasThinking())
 			}
 		}
 

--- a/pkg/sciontool/hooks/handlers/hub_test.go
+++ b/pkg/sciontool/hooks/handlers/hub_test.go
@@ -728,6 +728,148 @@ func TestHubHandler_AssistantTextForwarding(t *testing.T) {
 	})
 }
 
+// TestHubHandler_AssistantTextVisibilityTagging tests that automatic
+// assistant-reply messages are tagged with "verbose" visibility and
+// include content classification metadata.
+func TestHubHandler_AssistantTextVisibilityTagging(t *testing.T) {
+	t.Run("tags outbound message with verbose visibility", func(t *testing.T) {
+		tmpHome := t.TempDir()
+		origHome := os.Getenv("HOME")
+		os.Setenv("HOME", tmpHome)
+		defer os.Setenv("HOME", origHome)
+
+		var mu sync.Mutex
+		var outboundPayload map[string]interface{}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			var payload map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&payload)
+
+			if _, ok := payload["msg"]; ok {
+				outboundPayload = payload
+			}
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`))
+		}))
+		defer server.Close()
+
+		os.Setenv("SCION_HUB_ENDPOINT", server.URL)
+		os.Setenv("SCION_AUTH_TOKEN", "test-token")
+		os.Setenv("SCION_AGENT_ID", "test-agent-id")
+		defer func() {
+			os.Unsetenv("SCION_HUB_ENDPOINT")
+			os.Unsetenv("SCION_HUB_URL")
+			os.Unsetenv("SCION_AUTH_TOKEN")
+			os.Unsetenv("SCION_AGENT_ID")
+		}()
+
+		handler := NewHubHandler()
+		if handler == nil {
+			t.Fatal("Expected handler to be created")
+		}
+
+		err := handler.Handle(&hooks.Event{
+			Name: hooks.EventAgentEnd,
+			Data: hooks.EventData{AssistantText: "Agent response"},
+		})
+		if err != nil {
+			t.Fatalf("Handle returned error: %v", err)
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		if outboundPayload == nil {
+			t.Fatal("Expected outbound message to be sent")
+		}
+		if outboundPayload["visibility"] != "verbose" {
+			t.Errorf("Expected visibility 'verbose', got %v", outboundPayload["visibility"])
+		}
+		metadata, ok := outboundPayload["metadata"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected metadata to be present")
+		}
+		if metadata["source"] != "hook" {
+			t.Errorf("Expected metadata source 'hook', got %v", metadata["source"])
+		}
+	})
+
+	t.Run("sets has_thinking metadata when thinking content was filtered", func(t *testing.T) {
+		tmpHome := t.TempDir()
+		origHome := os.Getenv("HOME")
+		os.Setenv("HOME", tmpHome)
+		defer os.Setenv("HOME", origHome)
+
+		var mu sync.Mutex
+		var outboundPayload map[string]interface{}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			var payload map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&payload)
+
+			if _, ok := payload["msg"]; ok {
+				outboundPayload = payload
+			}
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`))
+		}))
+		defer server.Close()
+
+		os.Setenv("SCION_HUB_ENDPOINT", server.URL)
+		os.Setenv("SCION_AUTH_TOKEN", "test-token")
+		os.Setenv("SCION_AGENT_ID", "test-agent-id")
+		defer func() {
+			os.Unsetenv("SCION_HUB_ENDPOINT")
+			os.Unsetenv("SCION_HUB_URL")
+			os.Unsetenv("SCION_AUTH_TOKEN")
+			os.Unsetenv("SCION_AGENT_ID")
+		}()
+
+		handler := NewHubHandler()
+		if handler == nil {
+			t.Fatal("Expected handler to be created")
+		}
+
+		err := handler.Handle(&hooks.Event{
+			Name: hooks.EventAgentEnd,
+			Data: hooks.EventData{
+				AssistantText: "Filtered response",
+				AssistantContent: &hooks.AssistantContent{
+					Blocks: []hooks.ContentBlock{
+						{Type: hooks.ContentBlockThinking, Text: "I need to think..."},
+						{Type: hooks.ContentBlockText, Text: "Filtered response"},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("Handle returned error: %v", err)
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		if outboundPayload == nil {
+			t.Fatal("Expected outbound message to be sent")
+		}
+		metadata, ok := outboundPayload["metadata"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected metadata to be present")
+		}
+		if metadata["has_thinking"] != "true" {
+			t.Errorf("Expected has_thinking 'true', got %v", metadata["has_thinking"])
+		}
+	})
+}
+
 // TestTruncateMessage tests the truncation helper function.
 func TestTruncateMessage(t *testing.T) {
 	tests := []struct {

--- a/pkg/sciontool/hooks/types.go
+++ b/pkg/sciontool/hooks/types.go
@@ -7,6 +7,8 @@ Copyright 2025 The Scion Authors.
 // and harness hooks (events from Claude Code, Gemini CLI, etc.).
 package hooks
 
+import "strings"
+
 // Event represents a normalized hook event.
 type Event struct {
 	// Name is the normalized event name (e.g., "tool-start", "session-start")
@@ -42,14 +44,22 @@ type EventData struct {
 	OutputTokens int64 `json:"output_tokens,omitempty"`
 	CachedTokens int64 `json:"cached_tokens,omitempty"`
 
-	// AssistantText holds the textual output of the agent's final turn,
-	// populated by dialect parsers for end-of-turn events when the
-	// underlying harness exposes assistant content (e.g. Claude Code's
-	// Stop hook via transcript_path). Handlers may forward this to the
-	// hub message store as an outbound agent→user message so the Messages
-	// tab reflects agent replies without re-ingesting the entire
-	// transcript.
+	// AssistantText holds the user-visible textual output of the agent's
+	// final turn. Thinking/reasoning and tool-use blocks are filtered out;
+	// only "text" content remains. Populated by dialect parsers for
+	// end-of-turn events when the harness exposes assistant content (e.g.
+	// Claude Code's Stop hook). Handlers forward this to the hub message
+	// store as an outbound agent→user message so the Messages tab reflects
+	// agent replies without re-ingesting the entire transcript.
 	AssistantText string `json:"assistant_text,omitempty"`
+
+	// AssistantContent holds the classified content blocks from the
+	// assistant's final turn. When populated, it preserves the full typed
+	// structure (text, thinking, tool_use, etc.) so downstream consumers
+	// can choose their own filtering level (normal, verbose, full).
+	// AssistantText contains only the "text" blocks; this field preserves
+	// everything.
+	AssistantContent *AssistantContent `json:"assistant_content,omitempty"`
 
 	// Status fields
 	Success bool   `json:"success,omitempty"`
@@ -101,4 +111,60 @@ type Dialect interface {
 
 	// Parse parses raw input data into a normalized Event.
 	Parse(data map[string]interface{}) (*Event, error)
+}
+
+// ContentBlockType constants for classifying content blocks.
+const (
+	ContentBlockText      = "text"
+	ContentBlockThinking  = "thinking"
+	ContentBlockToolUse   = "tool_use"
+	ContentBlockToolResult = "tool_result"
+	ContentBlockError     = "error"
+)
+
+// ContentBlock represents a single classified block from an assistant response.
+// Each block has a type that determines its visibility: "text" blocks are
+// user-facing, "thinking" blocks are reasoning traces, and "tool_use" /
+// "tool_result" blocks capture tool interactions.
+type ContentBlock struct {
+	Type string `json:"type"`            // ContentBlockText, ContentBlockThinking, etc.
+	Text string `json:"text,omitempty"`  // Content payload
+}
+
+// AssistantContent holds the classified content blocks from an assistant
+// response, preserving the full typed structure. Consumers can filter by
+// content type to display at different fidelity levels:
+//   - Normal: only ContentBlockText
+//   - Verbose: ContentBlockText + ContentBlockToolUse
+//   - Full: all blocks including ContentBlockThinking
+type AssistantContent struct {
+	Blocks []ContentBlock `json:"blocks,omitempty"`
+}
+
+// TextOnly returns a concatenation of only the "text" blocks,
+// filtering out thinking, tool_use, and other non-user-facing content.
+func (ac *AssistantContent) TextOnly() string {
+	if ac == nil || len(ac.Blocks) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, b := range ac.Blocks {
+		if b.Type == ContentBlockText && b.Text != "" {
+			parts = append(parts, b.Text)
+		}
+	}
+	return strings.TrimSpace(strings.Join(parts, ""))
+}
+
+// HasThinking returns true if any block is of type "thinking".
+func (ac *AssistantContent) HasThinking() bool {
+	if ac == nil {
+		return false
+	}
+	for _, b := range ac.Blocks {
+		if b.Type == ContentBlockThinking {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -911,11 +911,13 @@ func ReadTokenFile() string {
 
 // OutboundMessage is the payload for sending an agent-to-human outbound message.
 type OutboundMessage struct {
-	Recipient   string `json:"recipient,omitempty"`
-	RecipientID string `json:"recipient_id,omitempty"`
-	Msg         string `json:"msg"`
-	Type        string `json:"type,omitempty"`
-	Urgent      bool   `json:"urgent,omitempty"`
+	Recipient   string            `json:"recipient,omitempty"`
+	RecipientID string            `json:"recipient_id,omitempty"`
+	Msg         string            `json:"msg"`
+	Type        string            `json:"type,omitempty"`
+	Urgent      bool              `json:"urgent,omitempty"`
+	Visibility  string            `json:"visibility,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
 // SendOutboundMessage sends an outbound message from the agent to a human inbox.


### PR DESCRIPTION
## Summary

Fixes ptone/scion#28 — Implements content-type filtering so that thinking/reasoning tokens are separated from chat messages in the harness observability pipeline.

**Root cause**: The `last_assistant_message` field from Claude Code's Stop hook was treated as an opaque string. When Claude Code includes extended thinking/reasoning content, it leaked through the entire pipeline (ClaudeDialect → HubHandler → Hub API → broker → chat) with zero filtering.

**Fix approach** (per the design doc's recommended Option A + C):

- **Filter at source**: The ClaudeDialect now parses `last_assistant_message` as structured content blocks (text, thinking, tool_use, etc.) and filters thinking blocks out of `AssistantText` before any handler sees it
- **Classify for consumers**: A new `AssistantContent` struct preserves the full typed block structure so downstream consumers can choose their own fidelity level (normal/verbose/full)
- **Tag visibility**: Automatic assistant-reply messages are tagged with `visibility: "verbose"` and content classification metadata, letting chat apps distinguish them from explicit agent→user messages

### Key changes

- `pkg/sciontool/hooks/types.go` — `ContentBlock`, `AssistantContent` types with `TextOnly()` and `HasThinking()` methods
- `pkg/sciontool/hooks/dialects/claude.go` — Content block parsing and filtering for `last_assistant_message` (string, JSON array, native array formats) and transcript fallback
- `pkg/messages/types.go` — `Visibility` field (normal/verbose/full) on `StructuredMessage`
- `pkg/sciontool/hooks/handlers/hub.go` — Visibility tagging and metadata on outbound messages
- `pkg/hub/handlers.go` — Accept and propagate visibility/metadata through the Hub outbound message endpoint
- `pkg/sciontool/hub/client.go` — `Visibility` and `Metadata` fields on `OutboundMessage`

## Test plan

- [x] Content block parsing: plain strings, JSON-encoded arrays, native arrays, invalid JSON, arrays without type fields
- [x] Thinking filtering: thinking-only blocks, mixed blocks, multiple text blocks concatenation
- [x] `AssistantContent` methods: `TextOnly()`, `HasThinking()` with nil/empty/populated content
- [x] Transcript content classification with thinking blocks
- [x] Backward compatibility: plain strings, transcript fallback, payload-over-transcript priority all work as before
- [x] HubHandler: verbose visibility tag, has_thinking metadata flag on outbound messages
- [x] `go vet` passes on all affected packages
- [x] All existing tests continue to pass