### PR TITLE
Fix resume creating new agents instead of restarting stopped ones

### DIFF
--- a/.design/project-log/2026-05-31-fix-resume-stopped-agents.md
+++ b/.design/project-log/2026-05-31-fix-resume-stopped-agents.md
@@ -1,0 +1,36 @@
+# Fix: scion resume creates new agents instead of resuming stopped ones
+
+**Date:** 2026-05-31
+**Issue:** #61
+**PR:** #85
+**Agent:** dev-issue-61
+
+## Problem
+
+When using `scion resume <agent-name>` on agents stopped with `scion stop`, the Hub server destroyed the existing agent record and created a brand new one. This caused:
+- New agent ID assigned (old one deleted)
+- Template association lost (blank template column)
+- Fresh container uptime (newly created container)
+
+## Root Cause
+
+The Hub server's `CreateAgentRequest` struct in `pkg/hub/handlers.go` was missing the `Resume` field that the CLI client sends via `pkg/hubclient/agents.go`. The Hub therefore ignored the resume intent entirely.
+
+In `handleExistingAgent()`, stopped agents always fell through to the "stale cleanup" path which deletes the agent from the database and recreates it from scratch. Only suspended agents had the in-place restart path.
+
+## Fix
+
+1. Added `Resume bool` field to the Hub's `CreateAgentRequest` struct
+2. Added a new condition block in `handleExistingAgent` that checks `req.Resume && existingAgent.Phase == PhaseStopped` and handles it like the suspended path: restart in-place via `DispatchAgentStart`, preserving the agent record
+3. The existing delete+recreate behavior for `scion start` (without Resume flag) is preserved unchanged
+
+## Tests Added
+
+- `TestCreateAgent_ResumeFromStoppedStatus` — resume returns 200 with preserved agent ID
+- `TestCreateAgent_StartFromStoppedStatus_NoResume` — start still recreates with 201
+- `TestCreateProjectAgent_ResumeFromStoppedStatus` — project-scoped resume test
+
+## Observations
+
+- The suspended vs stopped distinction is purely at the phase-marker level; both use the same `docker stop` under the hood. The broker already handles starting stopped containers correctly.
+- The CLI intentionally sets harness-level resume to false for stopped agents (fresh session), which is correct since stopped harness state is unrecoverable. The fix only affects the Hub-level agent record preservation.

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -8852,7 +8852,10 @@ func (s *Server) handleExistingAgent(
 			return existingAgentErrored
 		}
 
-		if req.Task != "" && existingAgent.AppliedConfig != nil {
+		if existingAgent.AppliedConfig == nil {
+			existingAgent.AppliedConfig = &store.AgentAppliedConfig{}
+		}
+		if req.Task != "" {
 			existingAgent.AppliedConfig.Task = req.Task
 			existingAgent.AppliedConfig.Attach = req.Attach
 		}

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -207,6 +207,11 @@ type CreateAgentRequest struct {
 	// GatherEnv enables the env-gather flow where the broker evaluates env
 	// completeness and may return a 202 requiring the CLI to supply missing values.
 	GatherEnv bool `json:"gatherEnv,omitempty"`
+	// Resume signals that the caller wants to resume an existing stopped agent
+	// in-place rather than deleting and recreating it. When true and the
+	// existing agent is in PhaseStopped, the agent record is preserved and
+	// the broker is asked to restart the container.
+	Resume bool `json:"resume,omitempty"`
 	// Notify subscribes the creating agent/user to status notifications for the new agent.
 	Notify bool `json:"notify,omitempty"`
 	// CleanupMode controls stale-existing-agent cleanup behavior during create:
@@ -8761,10 +8766,12 @@ func (s *Server) createNotifySubscription(ctx context.Context, agentID, projectI
 // already exists when a create/start request arrives.
 //
 // Phases:
-//  1. Stale cleanup (running/stopped/error + not provision-only): dispatch delete, remove from DB → deleted
-//  2. Env-gather re-provisioning (provisioning + GatherEnv): dispatch delete, remove from DB → deleted
-//  3. Restart (created/provisioning/pending + not provision-only): recover broker ID, update config, dispatch start → started
-//  4. Otherwise: none (caller decides what to do)
+//  0. Resume from suspended (suspended): recover broker, dispatch start, update in-place → started
+//  1. Resume from stopped (stopped + Resume flag): recover broker, dispatch start, update in-place → started
+//  2. Stale cleanup (running/stopped/error + not resume + not provision-only): dispatch delete, remove from DB → deleted
+//  3. Env-gather re-provisioning (provisioning + GatherEnv): dispatch delete, remove from DB → deleted
+//  4. Restart (created/provisioning/pending + not provision-only): recover broker ID, update config, dispatch start → started
+//  5. Otherwise: none (caller decides what to do)
 func (s *Server) handleExistingAgent(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -8817,6 +8824,47 @@ func (s *Server) handleExistingAgent(
 		}
 		if err := s.store.UpdateAgent(ctx, existingAgent); err != nil {
 			s.agentLifecycleLog.Warn("Failed to update agent status after resume", "agent_id", existingAgent.ID, "error", err)
+		}
+
+		if req.Notify {
+			s.createNotifySubscription(ctx, existingAgent.ID, existingAgent.ProjectID, notifySubscriberType, notifySubscriberID, createdBy)
+		}
+
+		s.enrichAgent(ctx, existingAgent, project, nil)
+		writeJSON(w, http.StatusOK, CreateAgentResponse{
+			Agent: existingAgent,
+		})
+		return existingAgentStarted
+	}
+
+	// Stopped agents resumed in-place when the caller explicitly requests resume.
+	// This preserves the agent ID, metadata, and template association. The broker
+	// will recreate the container but the hub-level record stays the same.
+	if !req.ProvisionOnly && req.Resume && existingAgent.Phase == string(state.PhaseStopped) {
+		if existingAgent.RuntimeBrokerID == "" && runtimeBrokerID != "" {
+			existingAgent.RuntimeBrokerID = runtimeBrokerID
+		}
+
+		dispatcher := s.GetDispatcher()
+		if dispatcher == nil || existingAgent.RuntimeBrokerID == "" {
+			writeError(w, http.StatusBadRequest, ErrCodeValidationError,
+				"cannot resume agent: no runtime broker available", nil)
+			return existingAgentErrored
+		}
+
+		if req.Task != "" && existingAgent.AppliedConfig != nil {
+			existingAgent.AppliedConfig.Task = req.Task
+			existingAgent.AppliedConfig.Attach = req.Attach
+		}
+
+		if err := dispatcher.DispatchAgentStart(ctx, existingAgent, req.Task); err != nil {
+			RuntimeError(w, "Failed to resume stopped agent: "+err.Error())
+			return existingAgentErrored
+		}
+
+		existingAgent.Phase = string(state.PhaseRunning)
+		if err := s.store.UpdateAgent(ctx, existingAgent); err != nil {
+			s.agentLifecycleLog.Warn("Failed to update agent status after resume from stopped", "agent_id", existingAgent.ID, "error", err)
 		}
 
 		if req.Notify {

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -756,6 +756,7 @@ type createAgentDispatcher struct {
 	envReqs       *RemoteEnvRequirementsResponse
 	deleteCalled  bool
 	deleteErr     error
+	startCalled   bool
 	execOutput    string
 	execExitCode  int
 }
@@ -777,6 +778,7 @@ func (d *createAgentDispatcher) DispatchAgentProvision(_ context.Context, agent 
 	return nil
 }
 func (d *createAgentDispatcher) DispatchAgentStart(_ context.Context, _ *store.Agent, _ string) error {
+	d.startCalled = true
 	return nil
 }
 func (d *createAgentDispatcher) DispatchAgentStop(_ context.Context, _ *store.Agent) error {
@@ -1220,6 +1222,81 @@ func TestCreateAgent_RecreateFromStoppedStatus(t *testing.T) {
 
 	_, err := s.GetAgent(ctx, "agent-stopped")
 	assert.ErrorIs(t, err, store.ErrNotFound, "old stopped agent should be deleted")
+}
+
+// TestCreateAgent_ResumeFromStoppedStatus verifies that sending Resume=true for a
+// stopped agent restarts it in-place (preserving the agent ID and record) rather
+// than deleting and recreating it.
+func TestCreateAgent_ResumeFromStoppedStatus(t *testing.T) {
+	disp := &createAgentDispatcher{createPhase: string(state.PhaseRunning)}
+	srv, s, project := setupCreateAgentServer(t, disp)
+	ctx := context.Background()
+
+	// Pre-create an agent in "stopped" status
+	stoppedAgent := &store.Agent{
+		ID:              "agent-resume-stopped",
+		Slug:            "resume-stopped-agent",
+		Name:            "resume-stopped-agent",
+		ProjectID:       project.ID,
+		RuntimeBrokerID: "broker-create",
+		Phase:           string(state.PhaseStopped),
+	}
+	require.NoError(t, s.CreateAgent(ctx, stoppedAgent))
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/agents", CreateAgentRequest{
+		Name:      "resume-stopped-agent",
+		ProjectID: project.ID,
+		Resume:    true,
+		Task:      "resume after stop",
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code,
+		"resuming a stopped agent should return 200 (existing agent reused)")
+
+	// The original agent should still exist in the store
+	agent, err := s.GetAgent(ctx, "agent-resume-stopped")
+	require.NoError(t, err, "original agent should still exist after resume")
+	assert.Equal(t, string(state.PhaseRunning), agent.Phase, "resumed agent should be in running phase")
+
+	// DispatchAgentStart should have been called (not delete+create)
+	assert.True(t, disp.startCalled, "DispatchAgentStart should be called for resume")
+	assert.False(t, disp.deleteCalled, "DispatchAgentDelete should NOT be called for resume")
+}
+
+// TestCreateAgent_StartFromStoppedStatus_NoResume verifies that without Resume=true,
+// a stopped agent is still deleted and recreated (the existing behavior).
+func TestCreateAgent_StartFromStoppedStatus_NoResume(t *testing.T) {
+	disp := &createAgentDispatcher{createPhase: string(state.PhaseRunning)}
+	srv, s, project := setupCreateAgentServer(t, disp)
+	ctx := context.Background()
+
+	// Pre-create an agent in "stopped" status
+	stoppedAgent := &store.Agent{
+		ID:              "agent-start-stopped",
+		Slug:            "start-stopped-agent",
+		Name:            "start-stopped-agent",
+		ProjectID:       project.ID,
+		RuntimeBrokerID: "broker-create",
+		Phase:           string(state.PhaseStopped),
+	}
+	require.NoError(t, s.CreateAgent(ctx, stoppedAgent))
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/agents", CreateAgentRequest{
+		Name:      "start-stopped-agent",
+		ProjectID: project.ID,
+		// Resume is NOT set — this is a "start" not a "resume"
+		Task: "restart after stop",
+	})
+
+	require.Equal(t, http.StatusCreated, rec.Code,
+		"starting (not resuming) a stopped agent should recreate with 201")
+
+	// The old agent should be deleted
+	_, err := s.GetAgent(ctx, "agent-start-stopped")
+	assert.ErrorIs(t, err, store.ErrNotFound, "old stopped agent should be deleted when not resuming")
+
+	// DispatchAgentDelete should have been called
+	assert.True(t, disp.deleteCalled, "DispatchAgentDelete should be called when not resuming")
 }
 
 // TestAgentCreate_LocalTemplateWithLocalBroker tests that agent creation succeeds
@@ -2318,6 +2395,42 @@ func TestCreateProjectAgent_RecreateFromStoppedStatus(t *testing.T) {
 
 	_, err := s.GetAgent(ctx, "project-agent-stopped")
 	assert.ErrorIs(t, err, store.ErrNotFound, "old stopped agent should be deleted")
+}
+
+// TestCreateProjectAgent_ResumeFromStoppedStatus verifies that sending Resume=true
+// for a stopped project-scoped agent restarts it in-place, preserving the agent record.
+func TestCreateProjectAgent_ResumeFromStoppedStatus(t *testing.T) {
+	disp := &createAgentDispatcher{createPhase: string(state.PhaseRunning)}
+	srv, s, project := setupCreateAgentServer(t, disp)
+	ctx := context.Background()
+
+	stoppedAgent := &store.Agent{
+		ID:              "project-agent-resume-stopped",
+		Slug:            "resume-stopped-project-agent",
+		Name:            "resume-stopped-project-agent",
+		ProjectID:       project.ID,
+		RuntimeBrokerID: "broker-create",
+		Phase:           string(state.PhaseStopped),
+	}
+	require.NoError(t, s.CreateAgent(ctx, stoppedAgent))
+
+	rec := doRequest(t, srv, http.MethodPost,
+		fmt.Sprintf("/api/v1/projects/%s/agents", project.ID),
+		CreateAgentRequest{
+			Name:   "resume-stopped-project-agent",
+			Resume: true,
+			Task:   "resume after stop",
+		})
+
+	require.Equal(t, http.StatusOK, rec.Code,
+		"resuming a stopped project agent should return 200 (existing agent reused)")
+
+	agent, err := s.GetAgent(ctx, "project-agent-resume-stopped")
+	require.NoError(t, err, "original project agent should still exist after resume")
+	assert.Equal(t, string(state.PhaseRunning), agent.Phase, "resumed agent should be in running phase")
+
+	assert.True(t, disp.startCalled, "DispatchAgentStart should be called for resume")
+	assert.False(t, disp.deleteCalled, "DispatchAgentDelete should NOT be called for resume")
 }
 
 func TestCreateProjectAgent_RecreateFromErrorStatus(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes ptone/scion#61 — `scion resume` was creating new agents instead of resuming stopped ones.

- **Root cause**: The Hub server's `CreateAgentRequest` struct was missing the `Resume` field that the CLI client sends. All stopped agents were treated as "stale" and deleted+recreated, losing the agent ID, template association, and metadata.
- **Fix**: Added the `Resume` field to the Hub's `CreateAgentRequest` and added a new handler path in `handleExistingAgent` that restarts stopped agents in-place when `Resume=true`, mirroring the existing suspended-agent path.
- **Preserved behavior**: `scion start` on a stopped agent (without `Resume`) still deletes and recreates — only `scion resume` triggers the in-place restart.

## Test plan

- [x] `TestCreateAgent_ResumeFromStoppedStatus` — verifies resume returns 200, preserves agent ID, calls `DispatchAgentStart` (not delete+create)
- [x] `TestCreateAgent_StartFromStoppedStatus_NoResume` — verifies start (no resume flag) still recreates with 201
- [x] `TestCreateProjectAgent_ResumeFromStoppedStatus` — same resume test through project-scoped endpoint
- [x] Existing `TestCreateAgent_RecreateFromStoppedStatus` still passes (no regression)
- [x] Full `go test ./pkg/hub/...` passes
- [x] `go vet ./...` and `go build ./...` pass