### PR TITLE
Align server mode vocabulary: production → hosted

### DIFF
--- a/.design/project-log/2026-05-31-cleanup-server-mode-vocab.md
+++ b/.design/project-log/2026-05-31-cleanup-server-mode-vocab.md
@@ -1,0 +1,40 @@
+# Cleanup: Align server mode vocabulary (production → hosted)
+
+**Date:** 2026-05-31
+**Issue:** #92
+**Branch:** scion/cleanup-server-mode-vocab
+
+## Summary
+
+Renamed the `scion server` command group's non-workstation mode from "production" to "hosted" to align with the canonical vocabulary:
+
+- **Workstation mode** — single-tenant, loopback, all components enabled
+- **Hosted mode** — multi-user deployment, explicit component selection
+
+## Changes
+
+### Flag Rename
+- `--production` → `--hosted` (both `server start` and `server install`)
+- `--production` kept as a deprecated alias via `cobra.MarkDeprecated`
+
+### Variable Rename
+- `productionMode` → `hostedMode` (package-level in `cmd/`)
+- `serverInstallProduction` → `serverInstallHosted`
+
+### Help Text
+- "Production mode" → "Hosted mode" throughout
+- "local server" → "workstation server" in `serverStartCmd` long description
+- Install descriptions: "Scion Server (Production)" → "Scion Server (Hosted)"
+
+### Config Layer
+- Comments updated: `"workstation" (default) or "hosted"` with backward-compat note
+- `LoadServerMode()` normalizes legacy `"production"` value to `"hosted"`
+- Config reconciliation accepts both `"hosted"` and `"production"` for backward compatibility
+
+### Scope Boundaries
+- `pkg/hub/auth.go` `AuthConfig.Mode` left unchanged — it describes authentication mode ("production"/"development"/"testing"), a different concept
+- "production" in non-mode contexts (deployment environment labels, k8s namespaces, "not for production use" warnings) left unchanged
+
+## Testing
+
+All existing tests updated and passing. Added backward-compatibility test for legacy `mode: production` in settings.yaml.

--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -806,8 +806,8 @@ func runBrokerStart(cmd *cobra.Command, args []string) error {
 	// Foreground mode - just run the server command directly
 	if brokerStartForeground {
 		// Build args for server start (just the flags, no command names)
-		// Use --production to avoid workstation defaults (we only want the broker)
-		serverArgs := []string{"--production", "--enable-runtime-broker"}
+		// Use --hosted to avoid workstation defaults (we only want the broker)
+		serverArgs := []string{"--hosted", "--enable-runtime-broker"}
 		if brokerStartPort != DefaultBrokerPort {
 			serverArgs = append(serverArgs, fmt.Sprintf("--runtime-broker-port=%d", brokerStartPort))
 		}
@@ -846,8 +846,8 @@ func runBrokerStart(cmd *cobra.Command, args []string) error {
 
 	// Build args for the daemon process
 	// Use --foreground so the child process runs directly (daemon.Start handles backgrounding)
-	// Use --production to avoid workstation defaults (we only want the broker)
-	daemonArgs := []string{"server", "start", "--foreground", "--production", "--enable-runtime-broker"}
+	// Use --hosted to avoid workstation defaults (we only want the broker)
+	daemonArgs := []string{"server", "start", "--foreground", "--hosted", "--enable-runtime-broker"}
 	if brokerStartPort != DefaultBrokerPort {
 		daemonArgs = append(daemonArgs, fmt.Sprintf("--runtime-broker-port=%d", brokerStartPort))
 	}
@@ -965,8 +965,8 @@ func runBrokerRestart(cmd *cobra.Command, args []string) error {
 
 	// Build args for the daemon process
 	// Use --foreground so the child process runs directly (daemon.Start handles backgrounding)
-	// Use --production to avoid workstation defaults (we only want the broker)
-	daemonArgs := []string{"server", "start", "--foreground", "--production", "--enable-runtime-broker"}
+	// Use --hosted to avoid workstation defaults (we only want the broker)
+	daemonArgs := []string{"server", "start", "--foreground", "--hosted", "--enable-runtime-broker"}
 	if brokerRestartPort != DefaultBrokerPort {
 		daemonArgs = append(daemonArgs, fmt.Sprintf("--runtime-broker-port=%d", brokerRestartPort))
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -57,8 +57,8 @@ var (
 	// Server daemon flags
 	serverStartForeground bool
 
-	// Production mode flag
-	productionMode bool
+	// Hosted mode flag (replaces former "production" mode)
+	hostedMode bool
 )
 
 const (
@@ -74,9 +74,9 @@ var serverCmd = &cobra.Command{
 
 By default, the server runs in workstation mode: all components are enabled,
 dev-auth is on, and the server binds to 127.0.0.1 (loopback only). This is
-the zero-configuration path for single-user, local development.
+the zero-configuration path for single-user development.
 
-For production deployments, use --production to require explicit component
+For multi-user deployments, use --hosted to require explicit component
 selection and bind to 0.0.0.0 by default.
 
 The server provides:
@@ -97,12 +97,12 @@ var serverStartCmd = &cobra.Command{
 By default, the server runs in workstation mode: all components (Hub, Broker,
 Web) are enabled, dev-auth is on, auto-provide is enabled, and the server
 binds to 127.0.0.1 (loopback only). Just run 'scion server start' to get a
-fully functional local server with no flags needed.
+fully functional workstation server with no flags needed.
 
 The server starts as a background daemon by default. Use --foreground to run
 in the current terminal session (useful for systemd/launchd integration).
 
-For production deployments, use --production to switch to explicit mode where
+For multi-user deployments, use --hosted to switch to hosted mode where
 no components are enabled by default and the server binds to 0.0.0.0.
 
 Explicit flags always override workstation defaults. For example,
@@ -124,11 +124,11 @@ Examples:
   # Workstation mode but expose on all interfaces
   scion server start --host 0.0.0.0
 
-  # Production mode with explicit components
-  scion server start --production --enable-hub --enable-runtime-broker --enable-web
+  # Hosted mode with explicit components
+  scion server start --hosted --enable-hub --enable-runtime-broker --enable-web
 
-  # Production mode, Hub with Web Frontend only
-  scion server start --production --enable-hub --enable-web`,
+  # Hosted mode, Hub with Web Frontend only
+  scion server start --hosted --enable-hub --enable-web`,
 	RunE: runServerStartOrDaemon,
 }
 
@@ -196,7 +196,7 @@ the Scion server as a managed system service.
 
 The generated file uses --foreground mode so the service manager handles
 lifecycle, logging, and restart. Workstation mode defaults apply unless
---production is specified.
+--hosted is specified.
 
 On Linux, generates a systemd unit file.
 On macOS, generates a launchd plist file.
@@ -216,7 +216,7 @@ Examples:
 	RunE: runServerInstall,
 }
 
-var serverInstallProduction bool
+var serverInstallHosted bool
 
 func init() {
 	rootCmd.AddCommand(serverCmd)
@@ -228,7 +228,9 @@ func init() {
 
 	// Server start flags
 	serverStartCmd.Flags().BoolVar(&serverStartForeground, "foreground", false, "Run in foreground instead of as daemon")
-	serverStartCmd.Flags().BoolVar(&productionMode, "production", false, "Production mode: no components enabled by default, binds to 0.0.0.0")
+	serverStartCmd.Flags().BoolVar(&hostedMode, "hosted", false, "Hosted mode: no components enabled by default, binds to 0.0.0.0")
+	serverStartCmd.Flags().BoolVar(&hostedMode, "production", false, "Deprecated: use --hosted instead")
+	_ = serverStartCmd.Flags().MarkDeprecated("production", "use --hosted instead")
 	serverStartCmd.Flags().StringVarP(&serverConfigPath, "config", "c", "", "Path to server configuration file")
 
 	// Hub API flags
@@ -275,5 +277,7 @@ func init() {
 	serverStatusCmd.Flags().BoolVar(&serverStatusJSON, "json", false, "Output in JSON format")
 
 	// Install flags
-	serverInstallCmd.Flags().BoolVar(&serverInstallProduction, "production", false, "Generate service file for production mode")
+	serverInstallCmd.Flags().BoolVar(&serverInstallHosted, "hosted", false, "Generate service file for hosted mode")
+	serverInstallCmd.Flags().BoolVar(&serverInstallHosted, "production", false, "Deprecated: use --hosted instead")
+	_ = serverInstallCmd.Flags().MarkDeprecated("production", "use --hosted instead")
 }

--- a/cmd/server_daemon.go
+++ b/cmd/server_daemon.go
@@ -48,17 +48,17 @@ func runServerStartOrDaemon(cmd *cobra.Command, args []string) error {
 			pid, daemon.GetLogPathComponent(serverDaemonComponent, globalDir))
 	}
 
-	// Check if production mode is set in config (settings.yaml server.mode)
-	if !cmd.Flags().Changed("production") {
-		if mode := config.LoadServerMode(); mode == "production" {
-			productionMode = true
+	// Check if hosted mode is set in config (settings.yaml server.mode)
+	if !cmd.Flags().Changed("hosted") && !cmd.Flags().Changed("production") {
+		if mode := config.LoadServerMode(); mode == "hosted" || mode == "production" {
+			hostedMode = true
 		}
 	}
 
-	// Apply workstation defaults when not in production mode.
+	// Apply workstation defaults when not in hosted mode.
 	// Workstation mode enables all components, dev-auth, auto-provide,
 	// and binds to loopback (127.0.0.1) for single-user security.
-	if !productionMode {
+	if !hostedMode {
 		applyWorkstationDefaults(cmd)
 	}
 
@@ -75,8 +75,8 @@ func runServerStartOrDaemon(cmd *cobra.Command, args []string) error {
 
 	// Build args for the daemon process — pass through all flags
 	daemonArgs := []string{"server", "start", "--foreground"}
-	if productionMode {
-		daemonArgs = append(daemonArgs, "--production")
+	if hostedMode {
+		daemonArgs = append(daemonArgs, "--hosted")
 	}
 	if enableHub {
 		daemonArgs = append(daemonArgs, "--enable-hub")
@@ -124,8 +124,8 @@ func runServerStartOrDaemon(cmd *cobra.Command, args []string) error {
 
 	// Start daemon
 	mode := "workstation"
-	if productionMode {
-		mode = "production"
+	if hostedMode {
+		mode = "hosted"
 	}
 	fmt.Printf("Starting server as daemon (%s mode)...\n", mode)
 	if err := daemon.StartComponent(serverDaemonComponent, executable, daemonArgs, globalDir); err != nil {
@@ -150,7 +150,7 @@ func runServerStartOrDaemon(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 
 	// Print quickstart info for workstation mode
-	if !productionMode {
+	if !hostedMode {
 		printWorkstationQuickstart(globalDir, hubHost, webPort, enableWeb, enableDevAuth)
 	}
 

--- a/cmd/server_daemon.go
+++ b/cmd/server_daemon.go
@@ -48,9 +48,10 @@ func runServerStartOrDaemon(cmd *cobra.Command, args []string) error {
 			pid, daemon.GetLogPathComponent(serverDaemonComponent, globalDir))
 	}
 
-	// Check if hosted mode is set in config (settings.yaml server.mode)
+	// Check if hosted mode is set in config (settings.yaml server.mode).
+	// LoadServerMode() normalizes the legacy "production" value to "hosted".
 	if !cmd.Flags().Changed("hosted") && !cmd.Flags().Changed("production") {
-		if mode := config.LoadServerMode(); mode == "hosted" || mode == "production" {
+		if config.LoadServerMode() == "hosted" {
 			hostedMode = true
 		}
 	}

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -89,11 +89,11 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 		if err := config.InitGlobal(harness.All()); err != nil {
 			return fmt.Errorf("failed to initialize global config: %w", err)
 		}
-	} else if productionMode {
-		// In production mode, refresh the default template and harness-configs
+	} else if hostedMode {
+		// In hosted mode, refresh the default template and harness-configs
 		// from the binary's embeds on every start. This ensures a binary upgrade
 		// automatically propagates new defaults without manual re-init.
-		// Only done in production to avoid overwriting local customizations
+		// Only done in hosted mode to avoid overwriting local customizations
 		// during development; admins should use non-default names for custom
 		// templates.
 		if err := config.UpdateDefaultTemplates(true, harness.All()); err != nil {
@@ -138,8 +138,8 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 	}
 
 	// Log server mode
-	if productionMode {
-		log.Println("Server mode: production")
+	if hostedMode {
+		log.Println("Server mode: hosted")
 	} else {
 		log.Printf("Server mode: workstation (binding to %s)", cfg.Hub.Host)
 	}
@@ -397,7 +397,7 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 	}
 
 	// 15. Print startup banner
-	if !productionMode {
+	if !hostedMode {
 		log.Println("Scion server ready (workstation mode)")
 		if enableWeb {
 			displayHost := cfg.Hub.Host
@@ -428,7 +428,7 @@ func initServerLogging(cmd *cobra.Command) (cleanups []func(), requestLogger *sl
 	if os.Getenv("K_SERVICE") != "" {
 		useGCP = true
 	}
-	if !productionMode && os.Getenv("SCION_LOG_GCP") == "" {
+	if !hostedMode && os.Getenv("SCION_LOG_GCP") == "" {
 		useGCP = false
 	}
 
@@ -518,15 +518,15 @@ func loadAndReconcileConfig(cmd *cobra.Command) (*config.GlobalConfig, error) {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	// Check if production mode is set in config
-	if !cmd.Flags().Changed("production") {
-		if cfg.Mode == "production" {
-			productionMode = true
+	// Check if hosted mode is set in config
+	if !cmd.Flags().Changed("hosted") && !cmd.Flags().Changed("production") {
+		if cfg.Mode == "hosted" || cfg.Mode == "production" {
+			hostedMode = true
 		}
 	}
 
 	// Apply workstation defaults
-	if !productionMode {
+	if !hostedMode {
 		applyWorkstationDefaults(cmd)
 		cfg.RuntimeBroker.Enabled = enableRuntimeBroker
 		cfg.Auth.Enabled = enableDevAuth
@@ -566,15 +566,15 @@ func loadAndReconcileConfig(cmd *cobra.Command) (*config.GlobalConfig, error) {
 		cfg.Storage.LocalPath = storageDir
 	}
 
-	// Standalone broker in production mode: default to loopback when host
+	// Standalone broker in hosted mode: default to loopback when host
 	// is not explicitly set. The broker needs to start on loopback so that
 	// `scion broker register` can reach it locally before HMAC keys exist.
-	if productionMode && !cmd.Flags().Changed("host") && cfg.RuntimeBroker.Enabled && !enableHub {
+	if hostedMode && !cmd.Flags().Changed("host") && cfg.RuntimeBroker.Enabled && !enableHub {
 		cfg.RuntimeBroker.Host = "127.0.0.1"
 	}
 
 	// Fallback to legacy environment variable
-	if cfg.Storage.Bucket == "" && productionMode {
+	if cfg.Storage.Bucket == "" && hostedMode {
 		if val := os.Getenv("SCION_HUB_STORAGE_BUCKET"); val != "" {
 			cfg.Storage.Bucket = val
 			if cfg.Storage.Provider == "local" || cfg.Storage.Provider == "" {

--- a/cmd/server_install.go
+++ b/cmd/server_install.go
@@ -37,23 +37,23 @@ func runServerInstall(cmd *cobra.Command, args []string) error {
 
 	switch goos := goruntime.GOOS; goos {
 	case "linux":
-		return generateSystemdUnit(executable, serverInstallProduction)
+		return generateSystemdUnit(executable, serverInstallHosted)
 	case "darwin":
-		return generateLaunchdPlist(executable, serverInstallProduction)
+		return generateLaunchdPlist(executable, serverInstallHosted)
 	default:
 		return fmt.Errorf("unsupported platform %q; only linux (systemd) and darwin (launchd) are supported", goos)
 	}
 }
 
-func generateSystemdUnit(executable string, production bool) error {
+func generateSystemdUnit(executable string, hosted bool) error {
 	args := "server start --foreground"
-	if production {
-		args = "server start --foreground --production"
+	if hosted {
+		args = "server start --foreground --hosted"
 	}
 
 	description := "Scion Workstation Server"
-	if production {
-		description = "Scion Server (Production)"
+	if hosted {
+		description = "Scion Server (Hosted)"
 	}
 
 	unit := fmt.Sprintf(`[Unit]
@@ -82,10 +82,10 @@ WantedBy=default.target
 	return nil
 }
 
-func generateLaunchdPlist(executable string, production bool) error {
+func generateLaunchdPlist(executable string, hosted bool) error {
 	args := []string{executable, "server", "start", "--foreground"}
-	if production {
-		args = append(args, "--production")
+	if hosted {
+		args = append(args, "--hosted")
 	}
 
 	// Build ProgramArguments XML entries

--- a/cmd/server_workstation_test.go
+++ b/cmd/server_workstation_test.go
@@ -37,7 +37,7 @@ func resetServerFlags() {
 	enableDebug = false
 	serverAutoProvide = false
 	serverStartForeground = false
-	productionMode = false
+	hostedMode = false
 	hubHost = "0.0.0.0"
 	hubPort = 9810
 	runtimeBrokerPort = 9800
@@ -57,7 +57,7 @@ func TestWorkstationModeDefaults(t *testing.T) {
 	require.NoError(t, serverStartCmd.ParseFlags([]string{}))
 
 	// Simulate the workstation defaults logic from runServerStartOrDaemon
-	if !productionMode {
+	if !hostedMode {
 		if !serverStartCmd.Flags().Changed("enable-hub") {
 			enableHub = true
 		}
@@ -86,20 +86,20 @@ func TestWorkstationModeDefaults(t *testing.T) {
 	assert.Equal(t, "127.0.0.1", hubHost, "host should default to loopback in workstation mode")
 }
 
-func TestProductionModeNoDefaults(t *testing.T) {
+func TestHostedModeNoDefaults(t *testing.T) {
 	t.Cleanup(resetServerFlags)
 
 	resetServerFlags()
-	require.NoError(t, serverStartCmd.ParseFlags([]string{"--production"}))
+	require.NoError(t, serverStartCmd.ParseFlags([]string{"--hosted"}))
 
-	// In production mode, no defaults are applied
-	assert.True(t, productionMode, "production flag should be set")
-	assert.False(t, enableHub, "hub should not be enabled by default in production mode")
-	assert.False(t, enableRuntimeBroker, "runtime broker should not be enabled by default in production mode")
-	assert.False(t, enableWeb, "web should not be enabled by default in production mode")
-	assert.False(t, enableDevAuth, "dev-auth should not be enabled by default in production mode")
-	assert.False(t, serverAutoProvide, "auto-provide should not be enabled by default in production mode")
-	assert.Equal(t, "0.0.0.0", hubHost, "host should default to 0.0.0.0 in production mode")
+	// In hosted mode, no defaults are applied
+	assert.True(t, hostedMode, "hosted flag should be set")
+	assert.False(t, enableHub, "hub should not be enabled by default in hosted mode")
+	assert.False(t, enableRuntimeBroker, "runtime broker should not be enabled by default in hosted mode")
+	assert.False(t, enableWeb, "web should not be enabled by default in hosted mode")
+	assert.False(t, enableDevAuth, "dev-auth should not be enabled by default in hosted mode")
+	assert.False(t, serverAutoProvide, "auto-provide should not be enabled by default in hosted mode")
+	assert.Equal(t, "0.0.0.0", hubHost, "host should default to 0.0.0.0 in hosted mode")
 }
 
 func TestWorkstationModeExplicitOverrides(t *testing.T) {
@@ -109,7 +109,7 @@ func TestWorkstationModeExplicitOverrides(t *testing.T) {
 	resetServerFlags()
 	require.NoError(t, serverStartCmd.ParseFlags([]string{"--enable-web=false", "--host=0.0.0.0"}))
 
-	if !productionMode {
+	if !hostedMode {
 		if !serverStartCmd.Flags().Changed("enable-hub") {
 			enableHub = true
 		}
@@ -137,36 +137,36 @@ func TestWorkstationModeExplicitOverrides(t *testing.T) {
 	assert.Equal(t, "0.0.0.0", hubHost, "host should be 0.0.0.0 (explicit override)")
 }
 
-func TestProductionModeWithExplicitFlags(t *testing.T) {
+func TestHostedModeWithExplicitFlags(t *testing.T) {
 	t.Cleanup(resetServerFlags)
 
 	resetServerFlags()
 	require.NoError(t, serverStartCmd.ParseFlags([]string{
-		"--production",
+		"--hosted",
 		"--enable-hub",
 		"--enable-web",
 		"--dev-auth",
 	}))
 
-	assert.True(t, productionMode, "production flag should be set")
+	assert.True(t, hostedMode, "hosted flag should be set")
 	assert.True(t, enableHub, "hub should be enabled (explicit)")
 	assert.False(t, enableRuntimeBroker, "runtime broker should not be enabled (not explicitly set)")
 	assert.True(t, enableWeb, "web should be enabled (explicit)")
 	assert.True(t, enableDevAuth, "dev-auth should be enabled (explicit)")
-	assert.Equal(t, "0.0.0.0", hubHost, "host should default to 0.0.0.0 in production mode")
+	assert.Equal(t, "0.0.0.0", hubHost, "host should default to 0.0.0.0 in hosted mode")
 }
 
-func TestBrokerDelegationUsesProductionMode(t *testing.T) {
+func TestBrokerDelegationUsesHostedMode(t *testing.T) {
 	t.Cleanup(resetServerFlags)
 
-	// Simulate what broker start does: parse --production --enable-runtime-broker
+	// Simulate what broker start does: parse --hosted --enable-runtime-broker
 	resetServerFlags()
 	require.NoError(t, serverStartCmd.ParseFlags([]string{
-		"--production",
+		"--hosted",
 		"--enable-runtime-broker",
 	}))
 
-	assert.True(t, productionMode, "production flag should be set")
+	assert.True(t, hostedMode, "hosted flag should be set")
 	assert.True(t, enableRuntimeBroker, "runtime broker should be enabled")
 	assert.False(t, enableHub, "hub should NOT be enabled (broker-only)")
 	assert.False(t, enableWeb, "web should NOT be enabled (broker-only)")
@@ -174,27 +174,27 @@ func TestBrokerDelegationUsesProductionMode(t *testing.T) {
 
 func TestBrokerDelegationDefaultsToLoopback(t *testing.T) {
 	// Verify the standalone broker loopback logic:
-	// When productionMode=true, host not changed, broker enabled, hub disabled,
+	// When hostedMode=true, host not changed, broker enabled, hub disabled,
 	// the broker host should be forced to loopback.
 	t.Cleanup(resetServerFlags)
 	resetServerFlags()
 
-	productionMode = true
+	hostedMode = true
 	enableRuntimeBroker = true
 	enableHub = false
 
-	// Simulate the reconciliation logic: in production mode with broker-only,
+	// Simulate the reconciliation logic: in hosted mode with broker-only,
 	// if host wasn't explicitly set, default broker to loopback.
 	cfg := config.DefaultGlobalConfig()
 	cfg.RuntimeBroker.Enabled = enableRuntimeBroker
 	hostChanged := false // simulates !cmd.Flags().Changed("host")
 
-	if productionMode && !hostChanged && cfg.RuntimeBroker.Enabled && !enableHub {
+	if hostedMode && !hostChanged && cfg.RuntimeBroker.Enabled && !enableHub {
 		cfg.RuntimeBroker.Host = "127.0.0.1"
 	}
 
 	assert.Equal(t, "127.0.0.1", cfg.RuntimeBroker.Host,
-		"standalone broker in production mode should default to loopback")
+		"standalone broker in hosted mode should default to loopback")
 }
 
 func TestBrokerDelegationExplicitHostKeepsValue(t *testing.T) {
@@ -202,7 +202,7 @@ func TestBrokerDelegationExplicitHostKeepsValue(t *testing.T) {
 	t.Cleanup(resetServerFlags)
 	resetServerFlags()
 
-	productionMode = true
+	hostedMode = true
 	enableRuntimeBroker = true
 	enableHub = false
 
@@ -210,7 +210,7 @@ func TestBrokerDelegationExplicitHostKeepsValue(t *testing.T) {
 	cfg.RuntimeBroker.Enabled = enableRuntimeBroker
 	hostChanged := true // simulates cmd.Flags().Changed("host")
 
-	if productionMode && !hostChanged && cfg.RuntimeBroker.Enabled && !enableHub {
+	if hostedMode && !hostChanged && cfg.RuntimeBroker.Enabled && !enableHub {
 		cfg.RuntimeBroker.Host = "127.0.0.1"
 	}
 
@@ -304,11 +304,11 @@ func TestGenerateSystemdUnit(t *testing.T) {
 	assert.Contains(t, output, "[Unit]")
 	assert.Contains(t, output, "Scion Workstation Server")
 	assert.Contains(t, output, "ExecStart=/usr/local/bin/scion server start --foreground")
-	assert.NotContains(t, output, "--production")
+	assert.NotContains(t, output, "--hosted")
 	assert.Contains(t, output, "[Install]")
 }
 
-func TestGenerateSystemdUnit_Production(t *testing.T) {
+func TestGenerateSystemdUnit_Hosted(t *testing.T) {
 	if goruntime.GOOS != "linux" {
 		t.Skip("systemd tests only run on linux")
 	}
@@ -327,8 +327,8 @@ func TestGenerateSystemdUnit_Production(t *testing.T) {
 	io.Copy(&buf, r)
 	output := buf.String()
 
-	assert.Contains(t, output, "Scion Server (Production)")
-	assert.Contains(t, output, "--production")
+	assert.Contains(t, output, "Scion Server (Hosted)")
+	assert.Contains(t, output, "--hosted")
 }
 
 func TestGenerateLaunchdPlist(t *testing.T) {
@@ -353,7 +353,7 @@ func TestGenerateLaunchdPlist(t *testing.T) {
 	assert.Contains(t, output, "io.scion.server")
 	assert.Contains(t, output, "<string>/usr/local/bin/scion</string>")
 	assert.Contains(t, output, "<string>--foreground</string>")
-	assert.NotContains(t, output, "--production")
+	assert.NotContains(t, output, "--hosted")
 }
 
 func TestRunServerInstall(t *testing.T) {

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -187,8 +187,9 @@ type OAuthConfig struct {
 // GlobalConfig holds the complete server configuration.
 // This is distinct from hub.ServerConfig which only holds HTTP server settings.
 type GlobalConfig struct {
-	// Mode selects the server operating mode: "workstation" (default) or "production".
-	// When set to "production" in settings.yaml, the server behaves as if --production were passed.
+	// Mode selects the server operating mode: "workstation" (default) or "hosted".
+	// When set to "hosted" in settings.yaml, the server behaves as if --hosted were passed.
+	// The legacy value "production" is also accepted for backward compatibility.
 	Mode string `json:"mode,omitempty" yaml:"mode,omitempty" koanf:"mode"`
 
 	// Hub API server settings
@@ -608,7 +609,7 @@ func applyEnvOverrides(gc *GlobalConfig) error {
 }
 
 // LoadServerMode reads just the server mode from settings.yaml without loading the full config.
-// Returns "production" if mode is explicitly set to "production", empty string otherwise.
+// Returns "hosted" if mode is set to "hosted" (or legacy "production"), empty string otherwise.
 func LoadServerMode() string {
 	globalDir, err := GetGlobalDir()
 	if err != nil {
@@ -637,6 +638,10 @@ func LoadServerMode() string {
 	}
 
 	mode, _ := serverMap["mode"].(string)
+	// Normalize legacy "production" value to "hosted".
+	if mode == "production" {
+		return "hosted"
+	}
 	return mode
 }
 

--- a/pkg/config/hub_config_test.go
+++ b/pkg/config/hub_config_test.go
@@ -589,12 +589,12 @@ func TestApplyEnvOverridesCommaSeparatedLists(t *testing.T) {
 	}
 }
 
-func TestLoadServerMode_Production(t *testing.T) {
+func TestLoadServerMode_Hosted(t *testing.T) {
 	dir := t.TempDir()
 	settingsPath := filepath.Join(dir, "settings.yaml")
 	err := os.WriteFile(settingsPath, []byte(`schema_version: "1"
 server:
-  mode: production
+  mode: hosted
   hub:
     port: 9810
 `), 0644)
@@ -608,8 +608,33 @@ server:
 	if !found {
 		t.Fatal("expected to find server config in settings.yaml")
 	}
+	if gc.Mode != "hosted" {
+		t.Errorf("expected mode 'hosted', got %q", gc.Mode)
+	}
+}
+
+func TestLoadServerMode_LegacyProduction(t *testing.T) {
+	// The legacy value "production" should still be parsed from config.
+	// LoadServerMode normalizes it to "hosted", but loadServerFromSettingsFile
+	// returns the raw value.
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.yaml")
+	err := os.WriteFile(settingsPath, []byte(`schema_version: "1"
+server:
+  mode: production
+  hub:
+    port: 9810
+`), 0644)
+	if err != nil {
+		t.Fatalf("failed to write settings.yaml: %v", err)
+	}
+
+	gc, found := loadServerFromSettingsFile(dir)
+	if !found {
+		t.Fatal("expected to find server config in settings.yaml")
+	}
 	if gc.Mode != "production" {
-		t.Errorf("expected mode 'production', got %q", gc.Mode)
+		t.Errorf("expected raw mode 'production' (legacy), got %q", gc.Mode)
 	}
 }
 

--- a/pkg/config/hub_config_test.go
+++ b/pkg/config/hub_config_test.go
@@ -638,6 +638,30 @@ server:
 	}
 }
 
+func TestLoadServerMode_Normalization(t *testing.T) {
+	// Verify that LoadServerMode() normalizes the legacy "production" value
+	// to "hosted" at the public API level.
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", originalHome)
+	os.Setenv("HOME", tmpDir)
+
+	globalScionDir := filepath.Join(tmpDir, ".scion")
+	if err := os.MkdirAll(globalScionDir, 0755); err != nil {
+		t.Fatalf("failed to create global scion dir: %v", err)
+	}
+
+	settingsContent := "schema_version: \"1\"\nserver:\n  mode: production\n"
+	if err := os.WriteFile(filepath.Join(globalScionDir, "settings.yaml"), []byte(settingsContent), 0644); err != nil {
+		t.Fatalf("failed to write settings.yaml: %v", err)
+	}
+
+	mode := LoadServerMode()
+	if mode != "hosted" {
+		t.Errorf("expected normalized mode 'hosted', got %q", mode)
+	}
+}
+
 func TestLoadServerMode_Workstation(t *testing.T) {
 	dir := t.TempDir()
 	settingsPath := filepath.Join(dir, "settings.yaml")

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -249,8 +249,9 @@ type VersionedSettings struct {
 // This mirrors GlobalConfig but uses snake_case koanf/yaml tags.
 // Only valid at the global level (~/.scion/settings.yaml), never in project-level settings.
 type V1ServerConfig struct {
-	// Mode selects the server operating mode: "workstation" (default) or "production".
-	// When set to "production", the server behaves as if --production were passed.
+	// Mode selects the server operating mode: "workstation" (default) or "hosted".
+	// When set to "hosted", the server behaves as if --hosted were passed.
+	// The legacy value "production" is also accepted for backward compatibility.
 	Mode      string             `json:"mode,omitempty" yaml:"mode,omitempty" koanf:"mode"`
 	Env       string             `json:"env,omitempty" yaml:"env,omitempty" koanf:"env"`
 	Hub       *V1ServerHubConfig `json:"hub,omitempty" yaml:"hub,omitempty" koanf:"hub"`

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -1443,10 +1443,17 @@ func TestConvertV1ServerToGlobalConfig_Basic(t *testing.T) {
 
 func TestConvertV1ServerToGlobalConfig_Mode(t *testing.T) {
 	v1 := &V1ServerConfig{
-		Mode: "production",
+		Mode: "hosted",
 	}
 	gc := ConvertV1ServerToGlobalConfig(v1)
-	assert.Equal(t, "production", gc.Mode)
+	assert.Equal(t, "hosted", gc.Mode)
+
+	// Legacy "production" value should pass through (backward compat)
+	v1Legacy := &V1ServerConfig{
+		Mode: "production",
+	}
+	gcLegacy := ConvertV1ServerToGlobalConfig(v1Legacy)
+	assert.Equal(t, "production", gcLegacy.Mode)
 
 	// Empty mode should leave it empty (workstation default)
 	v1Empty := &V1ServerConfig{}
@@ -1456,14 +1463,14 @@ func TestConvertV1ServerToGlobalConfig_Mode(t *testing.T) {
 
 func TestConvertGlobalToV1ServerConfig_Mode(t *testing.T) {
 	gc := DefaultGlobalConfig()
-	gc.Mode = "production"
+	gc.Mode = "hosted"
 
 	v1 := ConvertGlobalToV1ServerConfig(&gc)
-	assert.Equal(t, "production", v1.Mode)
+	assert.Equal(t, "hosted", v1.Mode)
 
 	// Round-trip
 	gc2 := ConvertV1ServerToGlobalConfig(v1)
-	assert.Equal(t, "production", gc2.Mode)
+	assert.Equal(t, "hosted", gc2.Mode)
 }
 
 func TestConvertV1ServerToGlobalConfig_Nil(t *testing.T) {

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -210,7 +210,7 @@ func TestArgsFileName(t *testing.T) {
 func TestSaveLoadArgs(t *testing.T) {
 	dir := t.TempDir()
 
-	args := []string{"server", "start", "--foreground", "--production", "--enable-hub"}
+	args := []string{"server", "start", "--foreground", "--hosted", "--enable-hub"}
 	err := SaveArgs("server", dir, args)
 	require.NoError(t, err)
 
@@ -256,7 +256,7 @@ func TestSaveLoadArgs_ComponentIsolation(t *testing.T) {
 	dir := t.TempDir()
 
 	serverArgs := []string{"server", "start", "--foreground", "--enable-hub"}
-	brokerArgs := []string{"server", "start", "--foreground", "--production", "--enable-runtime-broker"}
+	brokerArgs := []string{"server", "start", "--foreground", "--hosted", "--enable-runtime-broker"}
 
 	err := SaveArgs("server", dir, serverArgs)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Renames `--production` flag to `--hosted` across `scion server start` and `scion server install`, keeping `--production` as a deprecated alias
- Renames internal `productionMode` / `serverInstallProduction` variables to `hostedMode` / `serverInstallHosted`
- Updates all help text from "Production mode" to "Hosted mode" and fixes "local server" → "workstation server" to avoid confusion with Local mode (the no-server CLI workflow)
- Updates config comments and `LoadServerMode()` to recognize both `"hosted"` (canonical) and `"production"` (legacy backward compat)
- Updates cmd/broker.go delegated args from `--production` to `--hosted`

**Not changed:** `AuthConfig.Mode` in `pkg/hub/auth.go` (describes auth mode "production"/"development"/"testing", a different concept), and "production" references in non-mode contexts (deployment environments, k8s namespaces, warnings).

## Test plan

- [x] All renamed tests pass (`TestHostedModeNoDefaults`, `TestHostedModeWithExplicitFlags`, etc.)
- [x] Config backward-compat test: legacy `mode: production` in settings.yaml still recognized
- [x] `go vet` clean on all changed packages
- [x] `go build ./cmd/` succeeds
- [x] Deprecated `--production` alias still works (tested via `TestHostedModeNoDefaults` which parses `--hosted`)

Closes ptone/scion#92