### PR TITLE
Fix CI failures from grove-to-project rename

### DIFF
--- a/cmd/completion_helper.go
+++ b/cmd/completion_helper.go
@@ -93,7 +93,7 @@ func completeAgentNames(cmd *cobra.Command, args []string, toComplete string) ([
 	}
 
 	// Try to get project path from flag if specified by user in the command line so far
-	currentProjectPath, _ := cmd.Flags().GetString("grove")
+	currentProjectPath, _ := cmd.Flags().GetString("project")
 
 	// If global flag is set
 	global, _ := cmd.Flags().GetBool("global")

--- a/cmd/completion_helper_test.go
+++ b/cmd/completion_helper_test.go
@@ -70,11 +70,13 @@ func TestGetAgentNames(t *testing.T) {
 
 	// Mock command
 	cmd := &cobra.Command{}
-	cmd.Flags().String("grove", "", "")
+	cmd.Flags().String("project", "", "")
 	cmd.Flags().Bool("global", false, "")
 
 	// Test with explicit project path
-	cmd.Flags().Set("grove", projectDir)
+	if err := cmd.Flags().Set("project", projectDir); err != nil {
+		t.Fatal(err)
+	}
 
 	t.Run("Complete all agents", func(t *testing.T) {
 		names, _ := getAgentNames(cmd, []string{}, "")

--- a/web/src/components/pages/profile-telegram.ts
+++ b/web/src/components/pages/profile-telegram.ts
@@ -36,9 +36,6 @@ export class ScionPageProfileTelegram extends LitElement {
   @state()
   private _message = '';
 
-  @state()
-  private _linkedTelegramId = '';
-
   override connectedCallback(): void {
     super.connectedCallback();
     const params = new URLSearchParams(window.location.search);
@@ -63,13 +60,8 @@ export class ScionPageProfileTelegram extends LitElement {
       });
 
       if (resp.ok) {
-        const data = (await resp.json()) as {
-          status: string;
-          telegramUserId: string;
-          user: { id: string; email: string };
-        };
+        await resp.json();
         this._status = 'success';
-        this._linkedTelegramId = data.telegramUserId;
         this._message = 'Telegram account linked successfully! You can close this page and return to Telegram.';
         this._code = '';
       } else {
@@ -222,13 +214,8 @@ export class ScionPageProfileTelegram extends LitElement {
       });
 
       if (resp.ok) {
-        const data = (await resp.json()) as {
-          status: string;
-          telegramUserId: string;
-          user: { id: string; email: string };
-        };
+        await resp.json();
         this._status = 'success';
-        this._linkedTelegramId = data.telegramUserId;
         this._message = 'Telegram account linked successfully! You can close this page and return to Telegram.';
         this._code = '';
       } else {


### PR DESCRIPTION
## Summary
- Remove unused `_linkedTelegramId` state property in `profile-telegram.ts` that was causing TypeScript TS6133 error ("declared but never read")
- Update `completion_helper.go` to read the renamed `--project` flag instead of deprecated `--grove`, fixing a mismatch left from #281
- Update `completion_helper_test.go` to use the `--project` flag and check the error return from `FlagSet.Set`, fixing the golangci-lint errcheck violation

## Test plan
- [x] `go test ./cmd/ -run TestGetAgentNames` passes
- [x] `npx tsc --noEmit` passes in web/
- [x] golangci-lint no longer flags `completion_helper_test.go:77`