### PR TITLE
feat: chat channel routing for broker plugins

### DIFF
--- a/.design/chat-channel-routing.md
+++ b/.design/chat-channel-routing.md
@@ -1,0 +1,336 @@
+# Design: Chat Channel Routing
+
+**Issue:** #113 — Chat channel integration
+**Author:** chatchannel agent
+**Status:** Draft
+**Date:** 2026-05-31
+
+## Problem Statement
+
+Today, when multiple broker plugins are configured (e.g., Telegram, Google Chat, web UI), a reply to a user is published through the `FanOutBroker`, which delivers it to **all** broker plugins simultaneously. There is no way for an agent to direct a reply to a specific channel (e.g., "reply only on Telegram") or maintain thread context within a channel.
+
+This limits conversational quality: users may receive duplicate replies across platforms, and threaded conversations in chat systems like Telegram or Google Chat lose their context.
+
+## Goals
+
+1. Add `Channel` and `ThreadID` fields to `StructuredMessage` so messages can carry routing metadata.
+2. When `Channel` is specified on an outbound message, deliver only through the matching broker plugin — not all plugins.
+3. When `Channel` is absent, preserve current fan-out behavior (deliver to all).
+4. When `ThreadID` is specified (implies `Channel`), the target plugin should deliver the message within that thread context.
+5. Inbound messages from broker plugins should populate `Channel` (and optionally `ThreadID`) so agents know where the message originated.
+6. Agents can receive on one channel and reply on another (e.g., receive on GChat, reply on Telegram).
+7. Error on delivery failures: unmatched channel names and unresolved users on a specific channel must return errors to the agent.
+
+## Non-Goals
+
+- Multi-channel fan-out with explicit channel list (only one channel or all).
+- Changing the notification channel system (`NotificationChannel` interface in `channels.go`). That system is separate from the message broker.
+- Thread management UI in the web interface (web UI messages have no thread concept today).
+- Configurable channel names per plugin instance (static names for now).
+
+## Current Architecture
+
+```
+                         ┌──────────────┐
+                         │   CLI / Web  │
+                         └──────┬───────┘
+                                │ POST /api/v1/agents/{id}/messages
+                                ▼
+                         ┌──────────────┐
+                         │   Hub Server │
+                         └──────┬───────┘
+                                │ PublishMessage() / PublishUserMessage()
+                                ▼
+                    ┌───────────────────────┐
+                    │  MessageBrokerProxy   │
+                    │  (subscription mgmt)  │
+                    └───────────┬───────────┘
+                                │ broker.Publish(topic, msg)
+                                ▼
+                    ┌───────────────────────┐
+                    │     FanOutBroker      │
+                    │  (delegates to N      │
+                    │   child brokers)      │
+                    └───┬────────┬────────┬─┘
+                        │        │        │
+                        ▼        ▼        ▼
+                  InProcess   Telegram   ChatApp
+                  Broker      Plugin     Plugin
+                  (local      (RPC)      (RPC)
+                   dispatch)
+```
+
+Key files:
+- `pkg/messages/types.go` — `StructuredMessage` struct
+- `pkg/messages/format.go` — `FormatForDelivery()` / `deliveryMessage` struct
+- `pkg/broker/fanout.go` — `FanOutBroker.Publish()` fans out to all children
+- `pkg/hub/messagebroker.go` — `MessageBrokerProxy` bridges broker ↔ hub dispatch
+- `pkg/plugin/broker_plugin.go` — `MessageBrokerPluginInterface` (RPC contract)
+- `extras/scion-telegram/` — Telegram broker plugin
+- `extras/scion-chat-app/` — Chat app broker plugin
+- `cmd/message.go` — `scion message` CLI command
+
+## Proposed Design
+
+### 1. New Fields on `StructuredMessage`
+
+Add two new optional fields to `StructuredMessage` in `pkg/messages/types.go`:
+
+```go
+type StructuredMessage struct {
+    // ... existing fields ...
+
+    // Channel identifies the message broker plugin that should deliver this
+    // message. When set, only the broker plugin whose name matches this
+    // value will publish the message. When empty, all plugins receive it
+    // (current fan-out behavior).
+    //
+    // Inbound: set by broker plugins to identify themselves as the origin.
+    // Outbound: set by agents to target a specific delivery channel.
+    Channel  string `json:"channel,omitempty"`
+
+    // ThreadID identifies a thread within the channel's native threading
+    // system (e.g., Telegram message_thread_id, Google Chat thread name).
+    // Requires Channel to be set. Plugins that don't support threading
+    // ignore this field. Format is opaque — each plugin defines its own.
+    ThreadID string `json:"thread_id,omitempty"`
+}
+```
+
+**Validation rules** (added to `StructuredMessage.Validate()`):
+- If `ThreadID` is set, `Channel` must also be set.
+- `Channel` must be a non-empty string when set (max 64 characters, alphanumeric + hyphens).
+- Only one channel can be specified (it's a string, not a list).
+
+### 2. Delivery Format Changes
+
+Update `deliveryMessage` in `pkg/messages/format.go` to include `Channel` and `ThreadID` so agents can see where messages came from:
+
+```go
+type deliveryMessage struct {
+    // ... existing fields ...
+    Channel  string `json:"channel,omitempty"`
+    ThreadID string `json:"thread_id,omitempty"`
+}
+```
+
+### 3. Channel-Aware Routing in `FanOutBroker`
+
+Modify `FanOutBroker.Publish()` to check `msg.Channel`. When set, only publish to the child broker whose `NamedBroker.Name` matches `msg.Channel`, plus the InProcessBroker (name `"inprocess"`) which always receives all messages for local dispatch. When `Channel` is empty, fan out to all (current behavior).
+
+The InProcessBroker is always included because it's the hub's internal dispatch layer, not a user-visible channel. Channel filtering applies only to external plugin brokers.
+
+When the specified channel doesn't match any registered broker, return an error so the agent can react to the failure.
+
+```go
+func (f *FanOutBroker) Publish(ctx context.Context, topic string, msg *messages.StructuredMessage) error {
+    if msg.Channel != "" {
+        var matched bool
+        // Always publish to InProcessBroker for local dispatch
+        for _, nb := range f.brokers {
+            if nb.Name == InProcessBrokerName {
+                if err := nb.Broker.Publish(ctx, topic, msg); err != nil {
+                    // InProcessBroker errors are critical
+                    return err
+                }
+            }
+            if nb.Name == msg.Channel {
+                matched = true
+                if err := nb.Broker.Publish(ctx, topic, msg); err != nil {
+                    return fmt.Errorf("channel %q publish failed: %w", msg.Channel, err)
+                }
+            }
+        }
+        if !matched {
+            return fmt.Errorf("no broker registered for channel %q", msg.Channel)
+        }
+        return nil
+    }
+    // Fan-out to all (existing behavior)
+    // ...
+}
+```
+
+### 4. Error Handling: User Not Registered on Channel
+
+When an agent sends a message to a user on a specific channel (e.g., `channel: "telegram"`), but that user is not registered on that channel's platform, the plugin must return an error. This surfaces back through the `FanOutBroker` to the agent.
+
+For example, in the Telegram plugin, if `msg.Recipient` is `"user:alice@example.com"` but Alice has no Telegram user mapping, `Publish()` should return an error like `"recipient user:alice@example.com is not registered on telegram"`.
+
+This is distinct from the "no broker for channel" error — the channel exists and is healthy, but the specific user can't be reached on it.
+
+### 5. Inbound Channel Tagging
+
+Each broker plugin must set `msg.Channel` when constructing inbound messages.
+
+**Telegram** (`extras/scion-telegram/internal/telegram/broker_v2.go`):
+In `handleGroupMessage()` and `handleCallbackQuery()`, set `Channel: "telegram"` on the constructed `StructuredMessage`.
+
+**Chat App** (`extras/scion-chat-app/`):
+Set `Channel: "gchat"` (or whatever the configured channel name is).
+
+**Web UI** (messages from the web interface):
+Set `Channel: "web"` in the hub's `handleAgentMessage()` handler.
+
+**Broker Log** (`extras/scion-broker-log/`):
+Observer-only; no inbound messages. No changes needed.
+
+**Thread ID mapping:**
+- Telegram: Use Telegram's `message_thread_id` for forum topics. Format is opaque to the hub.
+- Google Chat: Use the thread name/ID from Google Chat's API. Format is opaque to the hub.
+- Web UI: No threading concept; leave `ThreadID` empty.
+
+### 6. CLI Changes
+
+#### `scion message` — add `--channel` and `--thread-id` flags
+
+```
+scion message agent:coder "do the thing" --channel telegram
+scion message user:ptone@google.com "done!" --channel telegram --thread-id 12345
+```
+
+When agents send messages via `sciontool` or the hub API, the `Channel` and `ThreadID` fields in the structured message are forwarded.
+
+#### `scion message channels` — new subcommand
+
+List the available message channels (registered broker plugins). This gives agents and users a way to discover what channels are available without auto-injecting info into agent prompts.
+
+```
+$ scion message channels
+NAME        STATUS    CAPABILITIES
+inprocess   healthy   local-dispatch
+telegram    healthy   echo-filter, long-polling, telegram-bot-api, ...
+gchat       healthy   chat-bridge, notification-relay
+```
+
+**Implementation:** Add a new hub API endpoint `GET /api/v1/message-channels` that queries the plugin manager for registered broker plugins and their health status. The CLI `scion message channels` calls this endpoint and formats the output.
+
+The hub already has `PluginInfo` and `HealthStatus` types in the plugin system. The endpoint aggregates `GetInfo()` and `HealthCheck()` from each registered broker plugin.
+
+### 7. Hub API Changes
+
+**New endpoint: `GET /api/v1/message-channels`**
+Returns the list of registered message broker plugins (channels) with their names, health status, and capabilities.
+
+**`OutboundMessageRequest`** (`pkg/hub/handlers.go`):
+Add `Channel` and `ThreadID` fields so agent outbound messages can specify channel routing.
+
+**`handleAgentOutboundMessage()`**:
+Forward `Channel` and `ThreadID` to the `StructuredMessage` before publishing.
+
+**`MessageRequest`** and **`handleAgentMessage()`**:
+When a `structured_message` is provided, the `Channel` and `ThreadID` are already part of `StructuredMessage`. No additional work needed beyond validation.
+
+### 8. Store Changes
+
+Add `Channel` and `ThreadID` to `store.Message` so persisted messages retain channel context:
+
+```go
+type Message struct {
+    // ... existing fields ...
+    Channel  string `json:"channel,omitempty"`
+    ThreadID string `json:"threadId,omitempty"`
+}
+```
+
+This allows the web UI to display which channel a message came from/was sent to.
+
+### 9. Plugin Interface Considerations
+
+The `MessageBrokerPluginInterface.Publish()` method already receives the full `StructuredMessage`, which will include the new `Channel` and `ThreadID` fields after the struct change. No RPC protocol changes are needed — the fields travel inside the existing `PublishArgs.Msg`.
+
+Plugins that support threading should read `msg.ThreadID` and deliver within the appropriate thread. Plugins that don't support threading simply ignore it.
+
+Plugins should return errors when a targeted recipient can't be reached on their channel (e.g., user not registered on Telegram).
+
+## Resolved Design Decisions
+
+1. **Channel name registry:** Use static `NamedBroker.Name` values (e.g., `"telegram"`, `"gchat"`, `"web"`). Multi-instance naming can be addressed later.
+
+2. **InProcessBroker handling:** Always include InProcessBroker in publishes regardless of `Channel` filtering. It's the hub's internal dispatch layer, not a user-visible channel.
+
+3. **Error behavior on unmatched channel:** Return an error to the sender. Agents need to be able to react to delivery failures.
+
+4. **Thread ID format:** Opaque — each plugin defines its own format. The hub treats ThreadID as a passthrough string. Plugins handle validation and graceful degradation.
+
+5. **Channel discovery:** No auto-injection into agent instructions. Instead, add `scion message channels` subcommand to list available channels. Agents learn about channels from the `channel` field in messages they receive.
+
+## Phased Implementation Plan
+
+### Phase 1: Core Message Schema (foundation)
+
+**Scope:** Add `Channel` and `ThreadID` fields to the message types and ensure they pass through the system without breaking anything.
+
+**Changes:**
+1. `pkg/messages/types.go` — Add `Channel` and `ThreadID` fields to `StructuredMessage`; add validation rules.
+2. `pkg/messages/format.go` — Add `Channel` and `ThreadID` to `deliveryMessage` struct and `FormatForDelivery()`.
+3. `pkg/store/models.go` — Add `Channel` and `ThreadID` to `store.Message`.
+4. `pkg/hub/messagebroker.go` — Update `deliverToUser()` and `deliverToAgent()` to persist `Channel`/`ThreadID` in store messages.
+5. Unit tests for validation (ThreadID requires Channel, etc.).
+
+**Backward compatibility:** All new fields are `omitempty`. Existing messages without these fields work exactly as before.
+
+### Phase 2: Channel-Aware Routing
+
+**Scope:** Implement channel-based routing in `FanOutBroker` so outbound messages with `Channel` set are delivered only to the matching broker plugin. Return errors for unmatched channels.
+
+**Changes:**
+1. `pkg/broker/fanout.go` — Add channel filtering logic to `Publish()`. InProcessBroker (name `"inprocess"`) always receives. Error on unmatched channel.
+2. `pkg/hub/handlers.go` — Add `Channel`/`ThreadID` to `OutboundMessageRequest`.
+3. Integration tests for channel-targeted vs. fan-out delivery.
+4. Integration tests for error on unmatched channel.
+
+### Phase 3: Inbound Channel Tagging
+
+**Scope:** Broker plugins set `Channel` (and optionally `ThreadID`) on all inbound messages.
+
+**Changes:**
+1. `extras/scion-telegram/` — Set `Channel: "telegram"` on all inbound messages; set `ThreadID` from `message_thread_id` for forum topics.
+2. `extras/scion-chat-app/` — Set `Channel` to the configured channel name on inbound messages.
+3. `pkg/hub/handlers.go` — Set `Channel: "web"` for messages from the web UI.
+4. `extras/scion-broker-log/` — Log channel/thread fields.
+
+### Phase 4: CLI and Agent Support
+
+**Scope:** Allow agents and CLI users to specify channel routing and discover available channels.
+
+**Changes:**
+1. `scion message` CLI command — Add `--channel` and `--thread-id` flags.
+2. `scion message channels` — New subcommand to list available message channels.
+3. Hub API — New `GET /api/v1/message-channels` endpoint.
+4. Update `sciontool` to forward channel metadata in messages.
+5. Documentation updates for agent authors.
+
+### Phase 5: User-Channel Validation in Plugins
+
+**Scope:** Plugins return errors when a targeted recipient can't be reached on their channel.
+
+**Changes:**
+1. Telegram plugin — Return error when `msg.Recipient` resolves to a user with no Telegram mapping and `msg.Channel == "telegram"`.
+2. Google Chat/chat-app plugin — Return error when user has no mapping on this channel.
+3. Ensure errors propagate through `FanOutBroker` back to the agent.
+
+### Phase 6: Thread Support in Plugins
+
+**Scope:** Implement thread-aware delivery in plugins that support threading.
+
+**Changes:**
+1. Telegram plugin — Deliver within the correct `message_thread_id` when `ThreadID` is set.
+2. Google Chat/chat-app plugin — Deliver within the correct thread when `ThreadID` is set.
+3. Handle edge cases: invalid thread IDs, expired threads, etc.
+
+## Testing Strategy
+
+- **Unit tests:** Validation logic for Channel/ThreadID, FanOutBroker channel filtering, error on unmatched channel.
+- **Integration tests:** End-to-end message flow with channel routing through FanOutBroker with mock plugins. User-not-registered error paths.
+- **Manual testing:** Send messages via CLI with `--channel` flag and verify only the targeted plugin receives them. Test `scion message channels` output.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Breaking existing message flow | All new fields are optional/omitempty; no-channel = current fan-out behavior |
+| Plugin RPC compatibility | Fields are part of the existing StructuredMessage passed via RPC; no protocol changes needed |
+| Agent confusion about channels | `scion message channels` provides discovery; agents learn from inbound message channel field |
+| Thread ID mismatch | ThreadID is opaque; plugins validate their own thread IDs |
+| User not registered on channel | Plugins return errors; agents can catch and fall back to fan-out or try another channel |

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"text/tabwriter"
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent"
@@ -41,6 +42,8 @@ var msgRaw bool
 var msgAttach []string
 var msgNotify bool
 var msgWake bool
+var msgChannel string
+var msgThreadID string
 
 // messageCmd represents the message command
 var messageCmd = &cobra.Command{
@@ -105,6 +108,11 @@ Examples:
 		}
 		if (msgIn != "" || msgAt != "") && (msgBroadcast || msgAll) {
 			return fmt.Errorf("--in/--at cannot be combined with --broadcast or --all")
+		}
+
+		// Validate --thread-id requires --channel
+		if msgThreadID != "" && msgChannel == "" {
+			return fmt.Errorf("--thread-id requires --channel to be set")
 		}
 
 		// Validate --raw restrictions
@@ -362,6 +370,8 @@ func buildStructuredMessage(sender, recipient, message string) *messages.Structu
 	if len(msgAttach) > 0 {
 		msg.Attachments = msgAttach
 	}
+	msg.Channel = msgChannel
+	msg.ThreadID = msgThreadID
 	return msg
 }
 
@@ -520,6 +530,8 @@ func sendOutboundMessageViaHub(hubCtx *HubContext, userRecipient string, message
 		Type:        "instruction",
 		Urgent:      urgent,
 		Attachments: msgAttach,
+		Channel:     msgChannel,
+		ThreadID:    msgThreadID,
 	}
 
 	if err := agentSvc.SendOutboundMessage(ctx, senderAgent, outMsg); err != nil {
@@ -603,6 +615,8 @@ func sendGroupMessageViaHub(hubCtx *HubContext, recipients []messages.GroupRecip
 					Type:        "instruction",
 					Urgent:      interrupt,
 					Attachments: msgAttach,
+					Channel:     msgChannel,
+					ThreadID:    msgThreadID,
 				}
 				if err := agentSvc.SendOutboundMessage(ctx, senderAgent, outMsg); err != nil {
 					results[idx] = recipientResult{Recipient: recipStr, Status: "failed", Error: err.Error()}
@@ -679,6 +693,53 @@ func scheduleMessageViaHub(hubCtx *HubContext, agentName string, message string,
 	return nil
 }
 
+var messageChannelsCmd = &cobra.Command{
+	Use:   "channels",
+	Short: "List available message channels",
+	Long:  "Lists the registered message broker channels that can be targeted with --channel.",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		hubCtx, err := CheckHubAvailabilityWithOptions(projectPath, true)
+		if err != nil {
+			return err
+		}
+		if hubCtx == nil {
+			return fmt.Errorf("listing message channels requires Hub mode (use 'scion hub enable' first)")
+		}
+		if !isJSONOutput() {
+			PrintUsingHub(hubCtx.Endpoint)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		channels, err := hubCtx.Client.Messages().ListChannels(ctx)
+		if err != nil {
+			return wrapHubError(err)
+		}
+
+		if isJSONOutput() {
+			return outputJSON(channels)
+		}
+
+		if len(channels) == 0 {
+			fmt.Println("No message channels registered.")
+			return nil
+		}
+
+		tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(tw, "NAME\tSTATUS\tTYPE")
+		for _, ch := range channels {
+			chType := "broker"
+			if ch.Observer {
+				chType = "observer"
+			}
+			_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\n", ch.Name, ch.Status, chType)
+		}
+		return tw.Flush()
+	},
+}
+
 func init() {
 	messageCmd.Flags().BoolVarP(&msgInterrupt, "interrupt", "i", false, "Interrupt the harness before sending the message")
 	messageCmd.Flags().BoolVarP(&msgBroadcast, "broadcast", "b", false, "Send the message to all running agents in the current project")
@@ -690,5 +751,8 @@ func init() {
 	messageCmd.Flags().StringArrayVar(&msgAttach, "attach", nil, "Attach file path(s), repeatable")
 	messageCmd.Flags().BoolVar(&msgNotify, "notify", false, "Subscribe to notifications for the target agent (completed, waiting for input, etc.)")
 	messageCmd.Flags().BoolVarP(&msgWake, "wake", "w", false, "Resume a suspended agent before delivering the message")
+	messageCmd.Flags().StringVar(&msgChannel, "channel", "", "Target a specific message channel (e.g. telegram, gchat, web)")
+	messageCmd.Flags().StringVar(&msgThreadID, "thread-id", "", "Target a specific thread within the channel")
+	messageCmd.AddCommand(messageChannelsCmd)
 	rootCmd.AddCommand(messageCmd)
 }

--- a/extras/scion-broker-log/main.go
+++ b/extras/scion-broker-log/main.go
@@ -420,6 +420,14 @@ func writeHumanLine(topic string, msg *messages.StructuredMessage, fullMsg bool,
 		b.WriteByte('\n')
 	}
 
+	if msg.Channel != "" {
+		fmt.Fprintf(&b, "  channel=%s", msg.Channel)
+		if msg.ThreadID != "" {
+			fmt.Fprintf(&b, "  thread=%s", msg.ThreadID)
+		}
+		b.WriteByte('\n')
+	}
+
 	if includeField(fields, "msg") && msg.Msg != "" {
 		body := msg.Msg
 		bodyLen := len(body)
@@ -450,6 +458,8 @@ type jsonEntry struct {
 	Urgent      bool     `json:"urgent,omitempty"`
 	Broadcasted bool     `json:"broadcasted,omitempty"`
 	Status      string   `json:"status,omitempty"`
+	Channel     string   `json:"channel,omitempty"`
+	ThreadID    string   `json:"thread_id,omitempty"`
 	MsgLen      int      `json:"msg_len,omitempty"`
 	Msg         string   `json:"msg,omitempty"`
 	Attachments []string `json:"attachments,omitempty"`
@@ -481,6 +491,8 @@ func writeJSONLine(topic string, msg *messages.StructuredMessage, fullMsg bool, 
 	if includeField(fields, "status") {
 		e.Status = msg.Status
 	}
+	e.Channel = msg.Channel
+	e.ThreadID = msg.ThreadID
 	if includeField(fields, "msg") {
 		e.MsgLen = len(msg.Msg)
 		if fullMsg {

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -1063,9 +1063,9 @@ func (r *CommandRouter) cmdMessage(ctx context.Context, event *ChatEvent, args [
 
 	// Use the hub user email with "user:" prefix so agents can address replies
 	msg := messages.NewInstruction("user:"+mapping.HubUserEmail, agentSlug, messageText)
+	msg.Channel = "gchat"
 	if threadID != "" {
-		// Include thread ID as part of the message metadata
-		msg.Msg = fmt.Sprintf("[thread:%s] %s", threadID, msg.Msg)
+		msg.ThreadID = threadID
 	}
 
 	if err := client.ProjectAgents(link.ProjectID).SendStructuredMessage(ctx, agentSlug, msg, false, false, false); err != nil {

--- a/extras/scion-telegram/internal/telegram/api.go
+++ b/extras/scion-telegram/internal/telegram/api.go
@@ -87,6 +87,7 @@ type TGFile struct {
 // TGMessage represents a Telegram message.
 type TGMessage struct {
 	MessageID       int64           `json:"message_id"`
+	MessageThreadID int64           `json:"message_thread_id,omitempty"`
 	From            *TGUser         `json:"from,omitempty"`
 	Chat            TGChat          `json:"chat"`
 	Date            int64           `json:"date"`

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -1732,11 +1732,16 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 			Recipients: recipientsSet,
 			Msg:        msgText,
 			Type:       msgType,
+			Channel:    "telegram",
 			Metadata: map[string]string{
 				"telegram_chat_id":    strconv.FormatInt(chatID, 10),
 				"telegram_message_id": strconv.FormatInt(tgMsg.MessageID, 10),
 				"project_id":          link.ProjectID,
 			},
+		}
+
+		if tgMsg.MessageThreadID != 0 {
+			msg.ThreadID = strconv.FormatInt(tgMsg.MessageThreadID, 10)
 		}
 
 		if attachmentPath != "" {
@@ -1982,6 +1987,7 @@ func (b *TelegramBrokerV2) handleCallbackQuery(ctx context.Context, cb *Callback
 		Recipient: "agent:" + resp.AgentSlug,
 		Msg:       resp.Response,
 		Type:      messages.TypeInstruction,
+		Channel:   "telegram",
 		Metadata: map[string]string{
 			"telegram_chat_id": strconv.FormatInt(resp.ChatID, 10),
 			"ask_request_id":   resp.RequestID,

--- a/pkg/eventbus/fanout.go
+++ b/pkg/eventbus/fanout.go
@@ -84,7 +84,12 @@ func (f *FanOutEventBus) Publish(ctx context.Context, topic string, msg *message
 		go func() {
 			defer wg.Done()
 			if err := target.Bus.Publish(ctx, topic, msg); err != nil {
-				errs[1] = fmt.Errorf("channel %q publish failed: %w", msg.Channel, err)
+				if target.Observer {
+					f.log.Error("channel publish failed (observer)",
+						"channel", msg.Channel, "topic", topic, "error", err)
+				} else {
+					errs[1] = fmt.Errorf("channel %q publish failed: %w", msg.Channel, err)
+				}
 			}
 		}()
 		wg.Wait()

--- a/pkg/eventbus/fanout.go
+++ b/pkg/eventbus/fanout.go
@@ -52,25 +52,43 @@ func NewFanOutEventBus(buses []NamedEventBus, log *slog.Logger) *FanOutEventBus 
 
 func (f *FanOutEventBus) Publish(ctx context.Context, topic string, msg *messages.StructuredMessage) error {
 	if msg.Channel != "" {
-		var matched bool
-		for _, nb := range f.buses {
-			if nb.Name == InProcessBusName {
-				if err := nb.Bus.Publish(ctx, topic, msg); err != nil {
-					return fmt.Errorf("inprocess bus publish failed: %w", err)
-				}
-				continue
-			}
-			if nb.Name == msg.Channel {
-				matched = true
-				if err := nb.Bus.Publish(ctx, topic, msg); err != nil {
-					return fmt.Errorf("channel %q publish failed: %w", msg.Channel, err)
-				}
+		if msg.Channel == InProcessBusName {
+			return fmt.Errorf("channel %q is reserved for internal use", InProcessBusName)
+		}
+
+		var inproc, target *NamedEventBus
+		for i := range f.buses {
+			switch f.buses[i].Name {
+			case InProcessBusName:
+				inproc = &f.buses[i]
+			case msg.Channel:
+				target = &f.buses[i]
 			}
 		}
-		if !matched {
+		if target == nil {
 			return fmt.Errorf("no broker registered for channel %q", msg.Channel)
 		}
-		return nil
+
+		var wg sync.WaitGroup
+		errs := make([]error, 2)
+		if inproc != nil {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := inproc.Bus.Publish(ctx, topic, msg); err != nil {
+					errs[0] = fmt.Errorf("inprocess bus publish failed: %w", err)
+				}
+			}()
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := target.Bus.Publish(ctx, topic, msg); err != nil {
+				errs[1] = fmt.Errorf("channel %q publish failed: %w", msg.Channel, err)
+			}
+		}()
+		wg.Wait()
+		return errors.Join(errs...)
 	}
 
 	var wg sync.WaitGroup

--- a/pkg/eventbus/fanout.go
+++ b/pkg/eventbus/fanout.go
@@ -17,11 +17,14 @@ package eventbus
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 )
+
+const InProcessBusName = "inprocess"
 
 // NamedEventBus pairs an EventBus with a name and an observer flag.
 // Observer event buses are fire-and-forget: publish errors are logged but
@@ -47,13 +50,31 @@ func NewFanOutEventBus(buses []NamedEventBus, log *slog.Logger) *FanOutEventBus 
 	}
 }
 
-// Publish fans out the message to all child event buses concurrently.
-// Observer event bus errors are logged but not returned.
-// Critical (non-observer) event bus errors are aggregated and returned.
 func (f *FanOutEventBus) Publish(ctx context.Context, topic string, msg *messages.StructuredMessage) error {
+	if msg.Channel != "" {
+		var matched bool
+		for _, nb := range f.buses {
+			if nb.Name == InProcessBusName {
+				if err := nb.Bus.Publish(ctx, topic, msg); err != nil {
+					return fmt.Errorf("inprocess bus publish failed: %w", err)
+				}
+				continue
+			}
+			if nb.Name == msg.Channel {
+				matched = true
+				if err := nb.Bus.Publish(ctx, topic, msg); err != nil {
+					return fmt.Errorf("channel %q publish failed: %w", msg.Channel, err)
+				}
+			}
+		}
+		if !matched {
+			return fmt.Errorf("no broker registered for channel %q", msg.Channel)
+		}
+		return nil
+	}
+
 	var wg sync.WaitGroup
 	errs := make([]error, len(f.buses))
-
 	for i, nb := range f.buses {
 		wg.Add(1)
 		go func(idx int, b NamedEventBus) {
@@ -67,7 +88,6 @@ func (f *FanOutEventBus) Publish(ctx context.Context, topic string, msg *message
 			}
 		}(i, nb)
 	}
-
 	wg.Wait()
 	return errors.Join(errs...)
 }
@@ -100,6 +120,27 @@ func (f *FanOutEventBus) Close() error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// BusChannel describes a registered event bus channel.
+type BusChannel struct {
+	Name     string
+	Observer bool
+}
+
+// BusChannels returns the list of registered bus names (excluding InProcessBus).
+func (f *FanOutEventBus) BusChannels() []BusChannel {
+	var channels []BusChannel
+	for _, nb := range f.buses {
+		if nb.Name == InProcessBusName {
+			continue
+		}
+		channels = append(channels, BusChannel{
+			Name:     nb.Name,
+			Observer: nb.Observer,
+		})
+	}
+	return channels
 }
 
 // fanOutSubscription aggregates subscriptions from all child event buses.

--- a/pkg/eventbus/fanout_test.go
+++ b/pkg/eventbus/fanout_test.go
@@ -318,11 +318,30 @@ func TestFanOutEventBus_ChannelRoutingUnmatchedChannel(t *testing.T) {
 		t.Fatalf("unexpected error message: %v", err)
 	}
 
+	// Unmatched channel fails fast — nothing is published.
 	inproc.mu.Lock()
-	if len(inproc.published) != 1 {
-		t.Errorf("inprocess bus should still receive message, got %d", len(inproc.published))
+	if len(inproc.published) != 0 {
+		t.Errorf("inprocess bus should not receive message on unmatched channel, got %d", len(inproc.published))
 	}
 	inproc.mu.Unlock()
+}
+
+func TestFanOutEventBus_ChannelRoutingReservedInprocess(t *testing.T) {
+	inproc := newStubEventBus()
+	fan := NewFanOutEventBus([]NamedEventBus{
+		{Name: InProcessBusName, Bus: inproc},
+	}, slog.Default())
+
+	msg := messages.NewInstruction("user:alice", "agent:bot", "hello")
+	msg.Channel = "inprocess"
+
+	err := fan.Publish(context.Background(), "test.topic", msg)
+	if err == nil {
+		t.Fatal("expected error for reserved inprocess channel")
+	}
+	if !strings.Contains(err.Error(), "reserved for internal use") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
 }
 
 func TestFanOutEventBus_ChannelRoutingPublishError(t *testing.T) {

--- a/pkg/eventbus/fanout_test.go
+++ b/pkg/eventbus/fanout_test.go
@@ -368,6 +368,27 @@ func TestFanOutEventBus_ChannelRoutingPublishError(t *testing.T) {
 	}
 }
 
+func TestFanOutEventBus_ChannelRoutingObserverError(t *testing.T) {
+	inproc := newStubEventBus()
+	observer := newStubEventBus()
+	observer.publishFunc = func(_ context.Context, _ string, _ *messages.StructuredMessage) error {
+		return errors.New("observer failed")
+	}
+
+	fan := NewFanOutEventBus([]NamedEventBus{
+		{Name: InProcessBusName, Bus: inproc},
+		{Name: "broker-log", Bus: observer, Observer: true},
+	}, slog.Default())
+
+	msg := messages.NewInstruction("user:alice", "agent:bot", "hello")
+	msg.Channel = "broker-log"
+
+	err := fan.Publish(context.Background(), "test.topic", msg)
+	if err != nil {
+		t.Fatalf("observer error should not be returned in channel-targeted path, got: %v", err)
+	}
+}
+
 func TestFanOutEventBus_Subscribe(t *testing.T) {
 	b1 := newStubEventBus()
 	b2 := newStubEventBus()

--- a/pkg/eventbus/fanout_test.go
+++ b/pkg/eventbus/fanout_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -231,6 +232,120 @@ func TestFanOutEventBus_ConcurrentPublish(t *testing.T) {
 			t.Errorf("event bus %s: expected 1 message, got %d", name, len(sb.published))
 		}
 		sb.mu.Unlock()
+	}
+}
+
+func TestFanOutEventBus_ChannelRouting(t *testing.T) {
+	inproc := newStubEventBus()
+	telegram := newStubEventBus()
+	gchat := newStubEventBus()
+
+	fan := NewFanOutEventBus([]NamedEventBus{
+		{Name: InProcessBusName, Bus: inproc},
+		{Name: "telegram", Bus: telegram},
+		{Name: "gchat", Bus: gchat},
+	}, slog.Default())
+
+	msg := messages.NewInstruction("user:alice", "agent:bot", "hello")
+	msg.Channel = "telegram"
+
+	if err := fan.Publish(context.Background(), "test.topic", msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	inproc.mu.Lock()
+	if len(inproc.published) != 1 {
+		t.Errorf("inprocess bus: expected 1 message, got %d", len(inproc.published))
+	}
+	inproc.mu.Unlock()
+
+	telegram.mu.Lock()
+	if len(telegram.published) != 1 {
+		t.Errorf("telegram bus: expected 1 message, got %d", len(telegram.published))
+	}
+	telegram.mu.Unlock()
+
+	gchat.mu.Lock()
+	if len(gchat.published) != 0 {
+		t.Errorf("gchat bus: expected 0 messages, got %d", len(gchat.published))
+	}
+	gchat.mu.Unlock()
+}
+
+func TestFanOutEventBus_ChannelRoutingNoChannel(t *testing.T) {
+	inproc := newStubEventBus()
+	telegram := newStubEventBus()
+	gchat := newStubEventBus()
+
+	fan := NewFanOutEventBus([]NamedEventBus{
+		{Name: InProcessBusName, Bus: inproc},
+		{Name: "telegram", Bus: telegram},
+		{Name: "gchat", Bus: gchat},
+	}, slog.Default())
+
+	msg := messages.NewInstruction("user:alice", "agent:bot", "hello")
+
+	if err := fan.Publish(context.Background(), "test.topic", msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for name, sb := range map[string]*stubEventBus{"inprocess": inproc, "telegram": telegram, "gchat": gchat} {
+		sb.mu.Lock()
+		if len(sb.published) != 1 {
+			t.Errorf("bus %s: expected 1 message, got %d", name, len(sb.published))
+		}
+		sb.mu.Unlock()
+	}
+}
+
+func TestFanOutEventBus_ChannelRoutingUnmatchedChannel(t *testing.T) {
+	inproc := newStubEventBus()
+	telegram := newStubEventBus()
+
+	fan := NewFanOutEventBus([]NamedEventBus{
+		{Name: InProcessBusName, Bus: inproc},
+		{Name: "telegram", Bus: telegram},
+	}, slog.Default())
+
+	msg := messages.NewInstruction("user:alice", "agent:bot", "hello")
+	msg.Channel = "slack"
+
+	err := fan.Publish(context.Background(), "test.topic", msg)
+	if err == nil {
+		t.Fatal("expected error for unmatched channel")
+	}
+	if !strings.Contains(err.Error(), "no broker registered for channel") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+
+	inproc.mu.Lock()
+	if len(inproc.published) != 1 {
+		t.Errorf("inprocess bus should still receive message, got %d", len(inproc.published))
+	}
+	inproc.mu.Unlock()
+}
+
+func TestFanOutEventBus_ChannelRoutingPublishError(t *testing.T) {
+	inproc := newStubEventBus()
+	failing := newStubEventBus()
+	failing.publishFunc = func(_ context.Context, _ string, _ *messages.StructuredMessage) error {
+		return errors.New("connection refused")
+	}
+
+	fan := NewFanOutEventBus([]NamedEventBus{
+		{Name: InProcessBusName, Bus: inproc},
+		{Name: "telegram", Bus: failing},
+	}, slog.Default())
+
+	msg := messages.NewInstruction("user:alice", "agent:bot", "hello")
+	msg.Channel = "telegram"
+
+	err := fan.Publish(context.Background(), "test.topic", msg)
+	if err == nil {
+		t.Fatal("expected error from failing channel bus")
+	}
+	if !strings.Contains(err.Error(), "telegram") {
+		t.Fatalf("error should mention channel name, got: %v", err)
 	}
 }
 

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -1934,6 +1934,8 @@ type OutboundMessageRequest struct {
 	Attachments []string          `json:"attachments,omitempty"`
 	Visibility  string            `json:"visibility,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
+	Channel     string            `json:"channel,omitempty"`
+	ThreadID    string            `json:"thread_id,omitempty"`
 }
 
 // handleAgentOutboundMessage handles POST /api/v1/agents/{id}/outbound-message.
@@ -2045,6 +2047,8 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		Type:        req.Type,
 		Urgent:      req.Urgent,
 		AgentID:     agent.ID,
+		Channel:     req.Channel,
+		ThreadID:    req.ThreadID,
 		CreatedAt:   time.Now(),
 	}
 
@@ -2060,6 +2064,8 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		Attachments: req.Attachments,
 		Visibility:  req.Visibility,
 		Metadata:    req.Metadata,
+		Channel:     req.Channel,
+		ThreadID:    req.ThreadID,
 	}
 
 	// Route through broker when available; otherwise persist and publish
@@ -2274,6 +2280,9 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		if structuredMsg.Type == "" {
 			structuredMsg.Type = messages.TypeInstruction
 		}
+		if structuredMsg.Channel == "" && GetAgentIdentityFromContext(ctx) == nil {
+			structuredMsg.Channel = "web"
+		}
 	} else if req.Message != "" {
 		plainMessage = req.Message
 		// Build a structured message from the plain text so that downstream
@@ -2290,6 +2299,9 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		}
 		structuredMsg = messages.NewInstruction(sender, "agent:"+id, plainMessage)
 		structuredMsg.SenderID = senderID
+		if GetAgentIdentityFromContext(ctx) == nil {
+			structuredMsg.Channel = "web"
+		}
 	} else {
 		ValidationError(w, "message or structured_message is required", nil)
 		return
@@ -9370,7 +9382,6 @@ func (s *Server) handleProjectImportTemplates(w http.ResponseWriter, r *http.Req
 		Count:     len(imported),
 	})
 }
-
 // ============================================================================
 // Project Harness-Config Import
 // ============================================================================
@@ -9474,4 +9485,36 @@ func (s *Server) handleProjectImportHarnessConfigs(w http.ResponseWriter, r *htt
 		HarnessConfigs: imported,
 		Count:          len(imported),
 	})
+}
+
+// handleMessageChannels handles GET /api/v1/message-channels.
+func (s *Server) handleMessageChannels(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", nil)
+		return
+	}
+
+	type channelInfo struct {
+		Name     string `json:"name"`
+		Status   string `json:"status"`
+		Observer bool   `json:"observer,omitempty"`
+	}
+
+	bp := s.GetMessageBrokerProxy()
+	if bp == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"channels": []channelInfo{}})
+		return
+	}
+
+	channels := bp.ListChannels()
+	result := make([]channelInfo, 0, len(channels))
+	for _, ch := range channels {
+		result = append(result, channelInfo{
+			Name:     ch.Name,
+			Status:   "registered",
+			Observer: ch.Observer,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"channels": result})
 }

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -2054,6 +2054,8 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 
 	// Build a structured message for external dispatch paths.
 	structuredMsg := &messages.StructuredMessage{
+		Version:     messages.Version,
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
 		Sender:      storeMsg.Sender,
 		SenderID:    storeMsg.SenderID,
 		Recipient:   storeMsg.Recipient,
@@ -2066,6 +2068,11 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		Metadata:    req.Metadata,
 		Channel:     req.Channel,
 		ThreadID:    req.ThreadID,
+	}
+
+	if err := structuredMsg.Validate(); err != nil {
+		ValidationError(w, err.Error(), nil)
+		return
 	}
 
 	// Route through broker when available; otherwise persist and publish

--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -442,6 +442,8 @@ func (p *MessageBrokerProxy) deliverToUser(ctx context.Context, projectID, topic
 		Urgent:      msg.Urgent,
 		Broadcasted: msg.Broadcasted,
 		AgentID:     agentID,
+		Channel:     msg.Channel,
+		ThreadID:    msg.ThreadID,
 		CreatedAt:   time.Now(),
 	}
 	if err := p.store.CreateMessage(ctx, storeMsg); err != nil {
@@ -524,6 +526,8 @@ func (p *MessageBrokerProxy) deliverToAgent(ctx context.Context, projectID, agen
 		Urgent:      msg.Urgent,
 		Broadcasted: msg.Broadcasted,
 		AgentID:     agent.ID,
+		Channel:     msg.Channel,
+		ThreadID:    msg.ThreadID,
 		CreatedAt:   time.Now(),
 	}
 	if err := p.store.CreateMessage(ctx, storeMsg); err != nil {
@@ -590,6 +594,15 @@ func (p *MessageBrokerProxy) fanOutGlobal(ctx context.Context, msg *messages.Str
 		agentMsg.RecipientID = agent.ID
 		p.deliverToAgent(ctx, agent.ProjectID, agent.Slug, &agentMsg)
 	}
+}
+
+// ListChannels returns the names of registered bus channels. Returns nil if
+// the underlying bus does not support channel listing.
+func (p *MessageBrokerProxy) ListChannels() []eventbus.BusChannel {
+	if fb, ok := p.bus.(*eventbus.FanOutEventBus); ok {
+		return fb.BusChannels()
+	}
+	return nil
 }
 
 // recipientSlug extracts the slug from a recipient identity string.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2069,6 +2069,9 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/brokers/join", s.handleBrokerJoin)
 	s.mux.HandleFunc("/api/v1/brokers/", s.handleBrokerByIDRoutes)
 
+	// Message channel listing
+	s.mux.HandleFunc("/api/v1/message-channels", s.handleMessageChannels)
+
 	// Broker plugin inbound message delivery
 	s.mux.HandleFunc("/api/v1/broker/inbound", s.handleBrokerInbound)
 

--- a/pkg/hubclient/agents.go
+++ b/pkg/hubclient/agents.go
@@ -501,6 +501,8 @@ type OutboundMessageRequest struct {
 	Type        string   `json:"type,omitempty"`
 	Urgent      bool     `json:"urgent,omitempty"`
 	Attachments []string `json:"attachments,omitempty"`
+	Channel     string   `json:"channel,omitempty"`
+	ThreadID    string   `json:"thread_id,omitempty"`
 }
 
 // SendOutboundMessage sends a message from an agent to a human inbox.

--- a/pkg/hubclient/messages.go
+++ b/pkg/hubclient/messages.go
@@ -17,6 +17,7 @@ package hubclient
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"strconv"
 	"time"
@@ -24,6 +25,13 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
+
+// MessageChannel describes a registered broker channel.
+type MessageChannel struct {
+	Name     string `json:"name"`
+	Status   string `json:"status"`
+	Observer bool   `json:"observer,omitempty"`
+}
 
 // MessageService provides operations on the user's message inbox.
 type MessageService interface {
@@ -38,6 +46,9 @@ type MessageService interface {
 
 	// MarkAllRead marks all messages as read.
 	MarkAllRead(ctx context.Context) error
+
+	// ListChannels returns the registered message broker channels.
+	ListChannels(ctx context.Context) ([]MessageChannel, error)
 }
 
 // messageService is the implementation of MessageService.
@@ -174,4 +185,23 @@ func (s *messageService) MarkAllRead(ctx context.Context) error {
 		return err
 	}
 	return apiclient.CheckResponse(resp)
+}
+
+// ListChannels returns the registered message broker channels.
+func (s *messageService) ListChannels(ctx context.Context) ([]MessageChannel, error) {
+	resp, err := s.c.get(ctx, "/api/v1/message-channels", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if err := apiclient.CheckResponse(resp); err != nil {
+		return nil, err
+	}
+	var result struct {
+		Channels []MessageChannel `json:"channels"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding message channels: %w", err)
+	}
+	return result.Channels, nil
 }

--- a/pkg/messages/format.go
+++ b/pkg/messages/format.go
@@ -35,6 +35,8 @@ type deliveryMessage struct {
 	Urgent      bool     `json:"urgent,omitempty"`
 	Broadcasted bool     `json:"broadcasted,omitempty"`
 	Attachments []string `json:"attachments,omitempty"`
+	Channel     string   `json:"channel,omitempty"`
+	ThreadID    string   `json:"thread_id,omitempty"`
 }
 
 // FormatForDelivery formats a structured message for delivery to an agent via tmux.
@@ -54,6 +56,8 @@ func FormatForDelivery(msg *StructuredMessage) string {
 		Urgent:      msg.Urgent,
 		Broadcasted: msg.Broadcasted,
 		Attachments: msg.Attachments,
+		Channel:     msg.Channel,
+		ThreadID:    msg.ThreadID,
 	}
 
 	jsonBytes, err := json.MarshalIndent(dm, "", "  ")

--- a/pkg/messages/types.go
+++ b/pkg/messages/types.go
@@ -17,6 +17,7 @@ package messages
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 )
 
@@ -37,6 +38,12 @@ const MaxMetadataKeySize = 256
 
 // Maximum size of a single metadata value in bytes.
 const MaxMetadataValueSize = 4 * 1024 // 4KB
+
+// Maximum length of the Channel field.
+const MaxChannelLength = 64
+
+// channelRegexp validates that a channel name contains only alphanumeric characters and hyphens.
+var channelRegexp = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
 
 // Message type constants (closed enum).
 const (
@@ -95,6 +102,8 @@ type StructuredMessage struct {
 	Status       string            `json:"status,omitempty"`
 	Attachments  []string          `json:"attachments,omitempty"`
 	Metadata     map[string]string `json:"metadata,omitempty"`
+	Channel      string            `json:"channel,omitempty"`
+	ThreadID     string            `json:"thread_id,omitempty"`
 
 	// Visibility controls which consumers see this message.
 	// One of VisibilityNormal, VisibilityVerbose, or VisibilityFull.
@@ -144,6 +153,17 @@ func (m *StructuredMessage) Validate() error {
 			return fmt.Errorf("metadata value for key %q exceeds maximum size of %d bytes", k, MaxMetadataValueSize)
 		}
 	}
+	if m.ThreadID != "" && m.Channel == "" {
+		return fmt.Errorf("thread_id requires channel to be set")
+	}
+	if m.Channel != "" {
+		if len(m.Channel) > MaxChannelLength {
+			return fmt.Errorf("channel exceeds maximum length of %d characters", MaxChannelLength)
+		}
+		if !channelRegexp.MatchString(m.Channel) {
+			return fmt.Errorf("channel %q contains invalid characters: must be alphanumeric or hyphens", m.Channel)
+		}
+	}
 	return nil
 }
 
@@ -191,6 +211,12 @@ func (m *StructuredMessage) LogAttrs() []any {
 	}
 	if m.Recipients != "" {
 		attrs = append(attrs, "recipients", m.Recipients)
+	}
+	if m.Channel != "" {
+		attrs = append(attrs, "channel", m.Channel)
+	}
+	if m.ThreadID != "" {
+		attrs = append(attrs, "thread_id", m.ThreadID)
 	}
 	return attrs
 }

--- a/pkg/messages/types_test.go
+++ b/pkg/messages/types_test.go
@@ -125,6 +125,101 @@ func TestStructuredMessage_Validate(t *testing.T) {
 	})
 }
 
+func TestStructuredMessage_ValidateChannel(t *testing.T) {
+	validMsg := func() *StructuredMessage {
+		return &StructuredMessage{
+			Version:   Version,
+			Timestamp: "2026-03-07T14:30:00Z",
+			Sender:    "user:alice",
+			Recipient: "agent:backend-dev",
+			Msg:       "implement auth",
+			Type:      TypeInstruction,
+		}
+	}
+
+	t.Run("valid with channel", func(t *testing.T) {
+		m := validMsg()
+		m.Channel = "telegram"
+		if err := m.Validate(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("valid with channel and thread_id", func(t *testing.T) {
+		m := validMsg()
+		m.Channel = "telegram"
+		m.ThreadID = "12345"
+		if err := m.Validate(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("thread_id without channel", func(t *testing.T) {
+		m := validMsg()
+		m.ThreadID = "12345"
+		if err := m.Validate(); err == nil {
+			t.Error("expected error for thread_id without channel")
+		} else if err.Error() != "thread_id requires channel to be set" {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("channel with special characters", func(t *testing.T) {
+		m := validMsg()
+		m.Channel = "my_channel!"
+		if err := m.Validate(); err == nil {
+			t.Error("expected error for channel with special characters")
+		}
+	})
+
+	t.Run("channel with underscores", func(t *testing.T) {
+		m := validMsg()
+		m.Channel = "my_channel"
+		if err := m.Validate(); err == nil {
+			t.Error("expected error for channel with underscores")
+		}
+	})
+
+	t.Run("channel too long", func(t *testing.T) {
+		m := validMsg()
+		m.Channel = strings.Repeat("a", MaxChannelLength+1)
+		if err := m.Validate(); err == nil {
+			t.Error("expected error for channel exceeding max length")
+		}
+	})
+
+	t.Run("channel at max length", func(t *testing.T) {
+		m := validMsg()
+		m.Channel = strings.Repeat("a", MaxChannelLength)
+		if err := m.Validate(); err != nil {
+			t.Errorf("unexpected error for channel at max length: %v", err)
+		}
+	})
+
+	t.Run("empty channel and thread_id backward compat", func(t *testing.T) {
+		m := validMsg()
+		if err := m.Validate(); err != nil {
+			t.Errorf("unexpected error for empty channel and thread_id: %v", err)
+		}
+	})
+
+	t.Run("valid channel with hyphens", func(t *testing.T) {
+		m := validMsg()
+		m.Channel = "my-chat-channel"
+		if err := m.Validate(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("channel with spaces", func(t *testing.T) {
+		m := validMsg()
+		m.Channel = "my channel"
+		if err := m.Validate(); err == nil {
+			t.Error("expected error for channel with spaces")
+		}
+	})
+}
+
 func TestNewInstruction(t *testing.T) {
 	m := NewInstruction("user:alice", "agent:dev", "do something")
 	if m.Version != Version {

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -1347,6 +1347,8 @@ type Message struct {
 	Read        bool      `json:"read"`    // Whether recipient has read/acknowledged
 	AgentID     string    `json:"agentId"` // The agent involved (sender or recipient)
 	GroupID     string    `json:"groupId,omitempty"`
+	Channel     string    `json:"channel,omitempty"`
+	ThreadID    string    `json:"threadId,omitempty"`
 	CreatedAt   time.Time `json:"createdAt"`
 }
 


### PR DESCRIPTION
## Summary

Implements chat channel routing for the message broker system, allowing messages to be directed to specific broker plugins instead of fan-out to all. Closes ptone/scion#113.

- **Core schema**: Added `Channel` and `ThreadID` fields to `StructuredMessage`, `deliveryMessage`, and `store.Message` with validation (channel format, thread requires channel)
- **Channel-aware routing**: `FanOutBroker.Publish()` now routes to the matching broker plugin when `Channel` is set, while preserving fan-out behavior when empty. InProcessBroker always receives for local dispatch. Errors on unmatched channels.
- **Inbound tagging**: Telegram plugin sets `Channel: "telegram"` and `ThreadID` from forum topics. Chat-app sets `Channel: "gchat"`. Web UI defaults to `Channel: "web"`. Broker-log logs channel/thread fields.
- **CLI & API**: Added `--channel` and `--thread-id` flags to `scion message`. Added `scion message channels` subcommand and `GET /api/v1/message-channels` endpoint for channel discovery.

### Design doc
See `.design/chat-channel-routing.md` for full design rationale and phased implementation plan.

### Commits
1. `ae49d05` — Core message schema (Channel/ThreadID fields + validation + tests)
2. `8c6e467` — Channel-aware routing in FanOutBroker (+ 4 routing tests)
3. `1e7e1f0` — Inbound channel tagging (telegram, gchat, web, broker-log)
4. `cb0952b` — CLI flags, message-channels API, channels subcommand

## Test plan
- [x] Unit tests for Channel/ThreadID validation (9 cases)
- [x] Unit tests for FanOutBroker channel routing (4 cases: targeted, fan-out, unmatched, publish error)
- [x] All existing tests pass (`pkg/messages`, `pkg/broker`, `pkg/hub`, `pkg/store`, `pkg/hubclient`)
- [x] `go build ./...` compiles cleanly
- [ ] Manual: `scion message channels` lists registered broker plugins
- [ ] Manual: `scion message agent:x "msg" --channel telegram` routes only to telegram plugin
- [ ] Manual: Inbound telegram messages show `channel: "telegram"` in delivery