### PR TITLE
fix: add issues:write to default GitHub App token permissions

### DIFF
--- a/pkg/hub/githubapp/githubapp.go
+++ b/pkg/hub/githubapp/githubapp.go
@@ -68,6 +68,7 @@ func DefaultTokenPermissions() TokenPermissions {
 	return TokenPermissions{
 		Contents:     "write",
 		PullRequests: "write",
+		Issues:       "write",
 		Metadata:     "read",
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `issues: "write"` to `DefaultTokenPermissions()` in `pkg/hub/githubapp/githubapp.go`
- Fixes agents being unable to close/edit issues on repos where no custom per-project `GitHubPermissions` are configured

## Root Cause

`DefaultTokenPermissions()` only requested `contents:write`, `pull_requests:write`, and `metadata:read`. GitHub requires the `issues:write` scope specifically for issue mutations (close, edit, label) — `pull_requests:write` is not sufficient for non-PR issues.

This caused `closeIssue` GraphQL mutations and `PATCH /issues/{n}` REST calls to fail with `403 Resource not accessible by integration` on any project using default permissions.

## Pre-requisite

The GitHub App must also have `issues: write` enabled in its app-level settings (Settings → Permissions & events → Repository permissions → Issues → Read & write), and each installation must have approved the permission.

## Test plan

- [x] `go test ./pkg/hub/githubapp/` — all tests pass
- [x] `go test ./pkg/hub/ -run Sync` — permission sync tests pass
- [x] `go build ./pkg/hub/githubapp/` — compiles cleanly