### PR TITLE
Add collapsible side panel to Hub web UI

### DIFF
--- a/web/src/components/app-shell.ts
+++ b/web/src/components/app-shell.ts
@@ -93,8 +93,6 @@ export class ScionApp extends LitElement {
       position: sticky;
       top: 0;
       height: 100vh;
-      transition: width var(--scion-transition-normal, 250ms ease);
-      overflow: hidden;
     }
 
     @media (max-width: 768px) {
@@ -273,6 +271,7 @@ export class ScionApp extends LitElement {
         <scion-nav
           .user=${this.user}
           .currentPath=${this.currentPath}
+          .hideCollapse=${true}
           @nav-click=${(): void => this.handleNavClick()}
         ></scion-nav>
       </sl-drawer>

--- a/web/src/components/app-shell.ts
+++ b/web/src/components/app-shell.ts
@@ -192,7 +192,11 @@ export class ScionApp extends LitElement {
     window.addEventListener('scion:access-denied', this._accessDeniedHandler as EventListener);
     this.addEventListener(PAGE_TITLE_EVENT, this._pageTitleHandler as EventListener);
     this.updateDocumentTitle();
-    this._sidebarCollapsed = localStorage.getItem('scion-sidebar-collapsed') === 'true';
+    try {
+      this._sidebarCollapsed = localStorage.getItem('scion-sidebar-collapsed') === 'true';
+    } catch {
+      // localStorage may be unavailable (SecurityError in restricted contexts)
+    }
   }
 
   override disconnectedCallback(): void {
@@ -348,7 +352,11 @@ export class ScionApp extends LitElement {
 
   private handleSidebarToggle(): void {
     this._sidebarCollapsed = !this._sidebarCollapsed;
-    localStorage.setItem('scion-sidebar-collapsed', String(this._sidebarCollapsed));
+    try {
+      localStorage.setItem('scion-sidebar-collapsed', String(this._sidebarCollapsed));
+    } catch {
+      // localStorage may be unavailable (SecurityError in restricted contexts)
+    }
   }
 
   private handleMobileMenuToggle(): void {

--- a/web/src/components/app-shell.ts
+++ b/web/src/components/app-shell.ts
@@ -71,6 +71,9 @@ export class ScionApp extends LitElement {
   @state()
   _drawerOpen = false;
 
+  @state()
+  _sidebarCollapsed = false;
+
   /** Bound listener references for cleanup */
   private _accessDeniedHandler = this.handleAccessDenied.bind(this);
   private _pageTitleHandler = this.handlePageTitle.bind(this);
@@ -90,6 +93,8 @@ export class ScionApp extends LitElement {
       position: sticky;
       top: 0;
       height: 100vh;
+      transition: width var(--scion-transition-normal, 250ms ease);
+      overflow: hidden;
     }
 
     @media (max-width: 768px) {
@@ -187,6 +192,7 @@ export class ScionApp extends LitElement {
     window.addEventListener('scion:access-denied', this._accessDeniedHandler as EventListener);
     this.addEventListener(PAGE_TITLE_EVENT, this._pageTitleHandler as EventListener);
     this.updateDocumentTitle();
+    this._sidebarCollapsed = localStorage.getItem('scion-sidebar-collapsed') === 'true';
   }
 
   override disconnectedCallback(): void {
@@ -245,7 +251,12 @@ export class ScionApp extends LitElement {
     return html`
       <!-- Desktop Sidebar -->
       <aside class="sidebar">
-        <scion-nav .user=${this.user} .currentPath=${this.currentPath}></scion-nav>
+        <scion-nav
+          .user=${this.user}
+          .currentPath=${this.currentPath}
+          ?collapsed=${this._sidebarCollapsed}
+          @sidebar-toggle=${(): void => this.handleSidebarToggle()}
+        ></scion-nav>
       </aside>
 
       <!-- Mobile Drawer -->
@@ -335,9 +346,11 @@ export class ScionApp extends LitElement {
     return 'Page Not Found';
   }
 
-  /**
-   * Handle mobile menu toggle
-   */
+  private handleSidebarToggle(): void {
+    this._sidebarCollapsed = !this._sidebarCollapsed;
+    localStorage.setItem('scion-sidebar-collapsed', String(this._sidebarCollapsed));
+  }
+
   private handleMobileMenuToggle(): void {
     this._drawerOpen = !this._drawerOpen;
   }

--- a/web/src/components/profile/profile-nav.ts
+++ b/web/src/components/profile/profile-nav.ts
@@ -65,6 +65,9 @@ export class ScionProfileNav extends LitElement {
   @property({ type: String })
   currentPath = '/profile';
 
+  @property({ type: Boolean, reflect: true })
+  collapsed = false;
+
   @state()
   private githubAppUrl: string | null = null;
 
@@ -291,6 +294,107 @@ export class ScionProfileNav extends LitElement {
       margin-left: auto;
       opacity: 0.6;
     }
+
+    /* Collapsed state */
+    :host {
+      transition: width var(--scion-transition-normal, 250ms ease);
+    }
+
+    :host([collapsed]) {
+      width: var(--scion-sidebar-collapsed-width, 64px);
+    }
+
+    :host([collapsed]) .logo-text {
+      display: none;
+    }
+
+    :host([collapsed]) .return-link {
+      justify-content: center;
+      padding: 0.75rem;
+      gap: 0;
+    }
+
+    :host([collapsed]) .return-link span {
+      display: none;
+    }
+
+    :host([collapsed]) .user-info {
+      justify-content: center;
+      padding: 0.75rem;
+    }
+
+    :host([collapsed]) .user-details {
+      display: none;
+    }
+
+    :host([collapsed]) .nav-section-title {
+      display: none;
+    }
+
+    :host([collapsed]) .nav-link {
+      justify-content: center;
+      padding: 0.75rem;
+    }
+
+    :host([collapsed]) .nav-link-text {
+      display: none;
+    }
+
+    :host([collapsed]) .nav-link-external {
+      justify-content: center;
+      padding: 0.75rem;
+    }
+
+    :host([collapsed]) .nav-link-external .nav-link-text {
+      display: none;
+    }
+
+    :host([collapsed]) .nav-link-external .external-icon {
+      display: none;
+    }
+
+    /* Collapse toggle */
+    .collapse-toggle {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      margin: 0.75rem;
+      padding: 0.625rem 0.75rem;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.5rem;
+      background: transparent;
+      color: var(--scion-text-muted, #64748b);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: all 0.15s ease;
+    }
+
+    .collapse-toggle:hover {
+      background: var(--scion-bg-subtle, #f1f5f9);
+      color: var(--scion-text, #1e293b);
+    }
+
+    .collapse-toggle sl-icon {
+      font-size: 1.125rem;
+      flex-shrink: 0;
+      transition: transform var(--scion-transition-normal, 250ms ease);
+    }
+
+    :host([collapsed]) .collapse-toggle sl-icon {
+      transform: rotate(180deg);
+    }
+
+    .collapse-toggle-text {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    :host([collapsed]) .collapse-toggle-text {
+      display: none;
+    }
   `;
 
   override connectedCallback(): void {
@@ -331,7 +435,7 @@ export class ScionProfileNav extends LitElement {
 
       <a href="/" class="return-link">
         <sl-icon name="arrow-left-circle"></sl-icon>
-        Return to Hub
+        <span>Return to Hub</span>
       </a>
 
       ${this.user
@@ -388,7 +492,26 @@ export class ScionProfileNav extends LitElement {
           `
         )}
       </nav>
+
+      <button
+        class="collapse-toggle"
+        @click=${(): void => this.handleCollapseToggle()}
+        aria-label=${this.collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        title=${this.collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+      >
+        <sl-icon name="chevron-left"></sl-icon>
+        <span class="collapse-toggle-text">Collapse</span>
+      </button>
     `;
+  }
+
+  private handleCollapseToggle(): void {
+    this.dispatchEvent(
+      new CustomEvent('sidebar-toggle', {
+        bubbles: true,
+        composed: true,
+      })
+    );
   }
 
   private isActive(path: string): boolean {

--- a/web/src/components/profile/profile-nav.ts
+++ b/web/src/components/profile/profile-nav.ts
@@ -68,6 +68,9 @@ export class ScionProfileNav extends LitElement {
   @property({ type: Boolean, reflect: true })
   collapsed = false;
 
+  @property({ type: Boolean })
+  hideCollapse = false;
+
   @state()
   private githubAppUrl: string | null = null;
 
@@ -370,7 +373,7 @@ export class ScionProfileNav extends LitElement {
       justify-content: center;
       gap: 0.75rem;
       margin: 0.5rem;
-      padding: 0.5rem 0.75rem;
+      padding: 0.5rem;
       border: 1px solid var(--scion-border, #e2e8f0);
       border-radius: 0.5rem;
       background: transparent;
@@ -443,7 +446,7 @@ export class ScionProfileNav extends LitElement {
         </div>
       </div>
 
-      <a href="/" class="return-link">
+      <a href="/" class="return-link" aria-label="Return to Hub" title="Return to Hub">
         <sl-icon name="arrow-left-circle"></sl-icon>
         <span>Return to Hub</span>
       </a>
@@ -503,15 +506,19 @@ export class ScionProfileNav extends LitElement {
         )}
       </nav>
 
-      <button
-        class="collapse-toggle"
-        @click=${(): void => this.handleCollapseToggle()}
-        aria-label=${this.collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-        title=${this.collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-      >
-        <sl-icon name="chevron-left"></sl-icon>
-        <span class="collapse-toggle-text">Collapse</span>
-      </button>
+      ${this.hideCollapse
+        ? ''
+        : html`
+            <button
+              class="collapse-toggle"
+              @click=${(): void => this.handleCollapseToggle()}
+              aria-label=${this.collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+              title=${this.collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            >
+              <sl-icon name="chevron-left"></sl-icon>
+              <span class="collapse-toggle-text">Collapse</span>
+            </button>
+          `}
     `;
   }
 

--- a/web/src/components/profile/profile-nav.ts
+++ b/web/src/components/profile/profile-nav.ts
@@ -107,6 +107,8 @@ export class ScionProfileNav extends LitElement {
       display: flex;
       flex-direction: column;
       overflow: hidden;
+      opacity: 1;
+      transition: opacity var(--scion-transition-normal, 250ms ease);
     }
 
     .logo-text h1 {
@@ -149,6 +151,13 @@ export class ScionProfileNav extends LitElement {
       flex-shrink: 0;
     }
 
+    .return-link span {
+      overflow: hidden;
+      white-space: nowrap;
+      opacity: 1;
+      transition: opacity var(--scion-transition-normal, 250ms ease);
+    }
+
     .user-info {
       padding: 1rem;
       border-bottom: 1px solid var(--scion-border, #e2e8f0);
@@ -177,6 +186,9 @@ export class ScionProfileNav extends LitElement {
       display: flex;
       flex-direction: column;
       min-width: 0;
+      overflow: hidden;
+      opacity: 1;
+      transition: opacity var(--scion-transition-normal, 250ms ease);
     }
 
     .user-name {
@@ -221,6 +233,10 @@ export class ScionProfileNav extends LitElement {
       color: var(--scion-text-muted, #64748b);
       margin-bottom: 0.5rem;
       padding: 0 0.75rem;
+      opacity: 1;
+      overflow: hidden;
+      white-space: nowrap;
+      transition: opacity var(--scion-transition-normal, 250ms ease);
     }
 
     .nav-list {
@@ -268,6 +284,8 @@ export class ScionProfileNav extends LitElement {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+      opacity: 1;
+      transition: opacity var(--scion-transition-normal, 250ms ease);
     }
 
     .nav-link-external {
@@ -313,7 +331,9 @@ export class ScionProfileNav extends LitElement {
     }
 
     :host([collapsed]) .logo-text {
-      display: none;
+      opacity: 0;
+      width: 0;
+      pointer-events: none;
     }
 
     :host([collapsed]) .return-link {
@@ -324,7 +344,10 @@ export class ScionProfileNav extends LitElement {
     }
 
     :host([collapsed]) .return-link span {
-      display: none;
+      opacity: 0;
+      width: 0;
+      overflow: hidden;
+      pointer-events: none;
     }
 
     :host([collapsed]) .user-info {
@@ -333,7 +356,10 @@ export class ScionProfileNav extends LitElement {
     }
 
     :host([collapsed]) .user-details {
-      display: none;
+      opacity: 0;
+      width: 0;
+      overflow: hidden;
+      pointer-events: none;
     }
 
     :host([collapsed]) .nav-container {
@@ -341,7 +367,11 @@ export class ScionProfileNav extends LitElement {
     }
 
     :host([collapsed]) .nav-section-title {
-      display: none;
+      opacity: 0;
+      height: 0;
+      margin: 0;
+      padding: 0;
+      pointer-events: none;
     }
 
     :host([collapsed]) .nav-link {
@@ -350,7 +380,9 @@ export class ScionProfileNav extends LitElement {
     }
 
     :host([collapsed]) .nav-link-text {
-      display: none;
+      opacity: 0;
+      width: 0;
+      pointer-events: none;
     }
 
     :host([collapsed]) .nav-link-external {
@@ -359,11 +391,15 @@ export class ScionProfileNav extends LitElement {
     }
 
     :host([collapsed]) .nav-link-external .nav-link-text {
-      display: none;
+      opacity: 0;
+      width: 0;
+      pointer-events: none;
     }
 
     :host([collapsed]) .nav-link-external .external-icon {
-      display: none;
+      opacity: 0;
+      width: 0;
+      pointer-events: none;
     }
 
     /* Collapse toggle */
@@ -403,10 +439,14 @@ export class ScionProfileNav extends LitElement {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+      opacity: 1;
+      transition: opacity var(--scion-transition-normal, 250ms ease);
     }
 
     :host([collapsed]) .collapse-toggle-text {
-      display: none;
+      opacity: 0;
+      width: 0;
+      pointer-events: none;
     }
   `;
 

--- a/web/src/components/profile/profile-nav.ts
+++ b/web/src/components/profile/profile-nav.ts
@@ -304,13 +304,19 @@ export class ScionProfileNav extends LitElement {
       width: var(--scion-sidebar-collapsed-width, 64px);
     }
 
+    :host([collapsed]) .logo {
+      justify-content: center;
+      padding: 1.25rem 0.5rem;
+    }
+
     :host([collapsed]) .logo-text {
       display: none;
     }
 
     :host([collapsed]) .return-link {
       justify-content: center;
-      padding: 0.75rem;
+      padding: 0.5rem;
+      margin: 0.5rem;
       gap: 0;
     }
 
@@ -320,11 +326,15 @@ export class ScionProfileNav extends LitElement {
 
     :host([collapsed]) .user-info {
       justify-content: center;
-      padding: 0.75rem;
+      padding: 0.5rem;
     }
 
     :host([collapsed]) .user-details {
       display: none;
+    }
+
+    :host([collapsed]) .nav-container {
+      padding: 0.5rem 0.25rem;
     }
 
     :host([collapsed]) .nav-section-title {
@@ -333,7 +343,7 @@ export class ScionProfileNav extends LitElement {
 
     :host([collapsed]) .nav-link {
       justify-content: center;
-      padding: 0.75rem;
+      padding: 0.5rem;
     }
 
     :host([collapsed]) .nav-link-text {
@@ -342,7 +352,7 @@ export class ScionProfileNav extends LitElement {
 
     :host([collapsed]) .nav-link-external {
       justify-content: center;
-      padding: 0.75rem;
+      padding: 0.5rem;
     }
 
     :host([collapsed]) .nav-link-external .nav-link-text {
@@ -359,8 +369,8 @@ export class ScionProfileNav extends LitElement {
       align-items: center;
       justify-content: center;
       gap: 0.75rem;
-      margin: 0.75rem;
-      padding: 0.625rem 0.75rem;
+      margin: 0.5rem;
+      padding: 0.5rem 0.75rem;
       border: 1px solid var(--scion-border, #e2e8f0);
       border-radius: 0.5rem;
       background: transparent;

--- a/web/src/components/profile/profile-shell.ts
+++ b/web/src/components/profile/profile-shell.ts
@@ -130,7 +130,11 @@ export class ScionProfileShell extends LitElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this._sidebarCollapsed = localStorage.getItem('scion-sidebar-collapsed') === 'true';
+    try {
+      this._sidebarCollapsed = localStorage.getItem('scion-sidebar-collapsed') === 'true';
+    } catch {
+      // localStorage may be unavailable (SecurityError in restricted contexts)
+    }
   }
 
   override updated(changedProperties: Map<string, unknown>): void {
@@ -193,7 +197,11 @@ export class ScionProfileShell extends LitElement {
 
   private handleSidebarToggle(): void {
     this._sidebarCollapsed = !this._sidebarCollapsed;
-    localStorage.setItem('scion-sidebar-collapsed', String(this._sidebarCollapsed));
+    try {
+      localStorage.setItem('scion-sidebar-collapsed', String(this._sidebarCollapsed));
+    } catch {
+      // localStorage may be unavailable (SecurityError in restricted contexts)
+    }
   }
 
   private handleMobileMenuToggle(): void {

--- a/web/src/components/profile/profile-shell.ts
+++ b/web/src/components/profile/profile-shell.ts
@@ -50,6 +50,9 @@ export class ScionProfileShell extends LitElement {
   @state()
   _drawerOpen = false;
 
+  @state()
+  _sidebarCollapsed = false;
+
   static override styles = css`
     :host {
       display: flex;
@@ -64,6 +67,8 @@ export class ScionProfileShell extends LitElement {
       position: sticky;
       top: 0;
       height: 100vh;
+      transition: width var(--scion-transition-normal, 250ms ease);
+      overflow: hidden;
     }
 
     @media (max-width: 768px) {
@@ -123,6 +128,11 @@ export class ScionProfileShell extends LitElement {
     }
   `;
 
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this._sidebarCollapsed = localStorage.getItem('scion-sidebar-collapsed') === 'true';
+  }
+
   override updated(changedProperties: Map<string, unknown>): void {
     if (changedProperties.has('currentPath')) {
       this.updateDocumentTitle();
@@ -139,7 +149,12 @@ export class ScionProfileShell extends LitElement {
 
     return html`
       <aside class="sidebar">
-        <scion-profile-nav .user=${this.user} .currentPath=${this.currentPath}></scion-profile-nav>
+        <scion-profile-nav
+          .user=${this.user}
+          .currentPath=${this.currentPath}
+          ?collapsed=${this._sidebarCollapsed}
+          @sidebar-toggle=${(): void => this.handleSidebarToggle()}
+        ></scion-profile-nav>
       </aside>
 
       <sl-drawer
@@ -174,6 +189,11 @@ export class ScionProfileShell extends LitElement {
 
   private getPageTitle(): string {
     return PROFILE_TITLES[this.currentPath] || 'Profile';
+  }
+
+  private handleSidebarToggle(): void {
+    this._sidebarCollapsed = !this._sidebarCollapsed;
+    localStorage.setItem('scion-sidebar-collapsed', String(this._sidebarCollapsed));
   }
 
   private handleMobileMenuToggle(): void {

--- a/web/src/components/profile/profile-shell.ts
+++ b/web/src/components/profile/profile-shell.ts
@@ -67,8 +67,6 @@ export class ScionProfileShell extends LitElement {
       position: sticky;
       top: 0;
       height: 100vh;
-      transition: width var(--scion-transition-normal, 250ms ease);
-      overflow: hidden;
     }
 
     @media (max-width: 768px) {
@@ -167,7 +165,7 @@ export class ScionProfileShell extends LitElement {
         placement="start"
         @sl-hide=${(): void => this.handleDrawerClose()}
       >
-        <scion-profile-nav .user=${this.user} .currentPath=${this.currentPath}></scion-profile-nav>
+        <scion-profile-nav .user=${this.user} .currentPath=${this.currentPath} .hideCollapse=${true}></scion-profile-nav>
       </sl-drawer>
 
       <main class="main">

--- a/web/src/components/shared/nav.ts
+++ b/web/src/components/shared/nav.ts
@@ -89,6 +89,12 @@ export class ScionNav extends LitElement {
   @property({ type: Boolean, reflect: true })
   collapsed = false;
 
+  /**
+   * Hide the collapse toggle (e.g. inside mobile drawer)
+   */
+  @property({ type: Boolean })
+  hideCollapse = false;
+
   static override styles = css`
     :host {
       display: flex;
@@ -255,7 +261,7 @@ export class ScionNav extends LitElement {
       justify-content: center;
       gap: 0.75rem;
       margin: 0.5rem;
-      padding: 0.5rem 0.75rem;
+      padding: 0.5rem;
       border: 1px solid var(--scion-border, #e2e8f0);
       border-radius: 0.5rem;
       background: transparent;
@@ -358,15 +364,19 @@ export class ScionNav extends LitElement {
           : ''}
       </nav>
 
-      <button
-        class="collapse-toggle"
-        @click=${(): void => this.handleCollapseToggle()}
-        aria-label=${this.collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-        title=${this.collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-      >
-        <sl-icon name="chevron-left"></sl-icon>
-        <span class="collapse-toggle-text">Collapse</span>
-      </button>
+      ${this.hideCollapse
+        ? ''
+        : html`
+            <button
+              class="collapse-toggle"
+              @click=${(): void => this.handleCollapseToggle()}
+              aria-label=${this.collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+              title=${this.collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            >
+              <sl-icon name="chevron-left"></sl-icon>
+              <span class="collapse-toggle-text">Collapse</span>
+            </button>
+          `}
     `;
   }
 

--- a/web/src/components/shared/nav.ts
+++ b/web/src/components/shared/nav.ts
@@ -132,6 +132,8 @@ export class ScionNav extends LitElement {
       display: flex;
       flex-direction: column;
       overflow: hidden;
+      opacity: 1;
+      transition: opacity var(--scion-transition-normal, 250ms ease);
     }
 
     :host([collapsed]) .logo {
@@ -140,7 +142,9 @@ export class ScionNav extends LitElement {
     }
 
     :host([collapsed]) .logo-text {
-      display: none;
+      opacity: 0;
+      width: 0;
+      pointer-events: none;
     }
 
     .logo-text h1 {
@@ -188,6 +192,10 @@ export class ScionNav extends LitElement {
       color: var(--scion-text-muted, #64748b);
       margin-bottom: 0.5rem;
       padding: 0 0.75rem;
+      opacity: 1;
+      overflow: hidden;
+      white-space: nowrap;
+      transition: opacity var(--scion-transition-normal, 250ms ease);
     }
 
     :host([collapsed]) .nav-container {
@@ -195,7 +203,11 @@ export class ScionNav extends LitElement {
     }
 
     :host([collapsed]) .nav-section-title {
-      display: none;
+      opacity: 0;
+      height: 0;
+      margin: 0;
+      padding: 0;
+      pointer-events: none;
     }
 
     .nav-list {
@@ -248,10 +260,14 @@ export class ScionNav extends LitElement {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+      opacity: 1;
+      transition: opacity var(--scion-transition-normal, 250ms ease);
     }
 
     :host([collapsed]) .nav-link-text {
-      display: none;
+      opacity: 0;
+      width: 0;
+      pointer-events: none;
     }
 
     /* Collapse toggle */
@@ -291,10 +307,14 @@ export class ScionNav extends LitElement {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+      opacity: 1;
+      transition: opacity var(--scion-transition-normal, 250ms ease);
     }
 
     :host([collapsed]) .collapse-toggle-text {
-      display: none;
+      opacity: 0;
+      width: 0;
+      pointer-events: none;
     }
 
     /* Smooth width transition */

--- a/web/src/components/shared/nav.ts
+++ b/web/src/components/shared/nav.ts
@@ -128,6 +128,11 @@ export class ScionNav extends LitElement {
       overflow: hidden;
     }
 
+    :host([collapsed]) .logo {
+      justify-content: center;
+      padding: 1.25rem 0.5rem;
+    }
+
     :host([collapsed]) .logo-text {
       display: none;
     }
@@ -179,6 +184,10 @@ export class ScionNav extends LitElement {
       padding: 0 0.75rem;
     }
 
+    :host([collapsed]) .nav-container {
+      padding: 0.5rem 0.25rem;
+    }
+
     :host([collapsed]) .nav-section-title {
       display: none;
     }
@@ -208,7 +217,7 @@ export class ScionNav extends LitElement {
 
     :host([collapsed]) .nav-link {
       justify-content: center;
-      padding: 0.75rem;
+      padding: 0.5rem;
     }
 
     .nav-link:hover {
@@ -245,8 +254,8 @@ export class ScionNav extends LitElement {
       align-items: center;
       justify-content: center;
       gap: 0.75rem;
-      margin: 0.75rem;
-      padding: 0.625rem 0.75rem;
+      margin: 0.5rem;
+      padding: 0.5rem 0.75rem;
       border: 1px solid var(--scion-border, #e2e8f0);
       border-radius: 0.5rem;
       background: transparent;

--- a/web/src/components/shared/nav.ts
+++ b/web/src/components/shared/nav.ts
@@ -239,6 +239,53 @@ export class ScionNav extends LitElement {
       display: none;
     }
 
+    /* Collapse toggle */
+    .collapse-toggle {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      margin: 0.75rem;
+      padding: 0.625rem 0.75rem;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.5rem;
+      background: transparent;
+      color: var(--scion-text-muted, #64748b);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: all 0.15s ease;
+    }
+
+    .collapse-toggle:hover {
+      background: var(--scion-bg-subtle, #f1f5f9);
+      color: var(--scion-text, #1e293b);
+    }
+
+    .collapse-toggle sl-icon {
+      font-size: 1.125rem;
+      flex-shrink: 0;
+      transition: transform var(--scion-transition-normal, 250ms ease);
+    }
+
+    :host([collapsed]) .collapse-toggle sl-icon {
+      transform: rotate(180deg);
+    }
+
+    .collapse-toggle-text {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    :host([collapsed]) .collapse-toggle-text {
+      display: none;
+    }
+
+    /* Smooth width transition */
+    :host {
+      transition: width var(--scion-transition-normal, 250ms ease);
+    }
   `;
 
   override render() {
@@ -301,6 +348,16 @@ export class ScionNav extends LitElement {
             `
           : ''}
       </nav>
+
+      <button
+        class="collapse-toggle"
+        @click=${(): void => this.handleCollapseToggle()}
+        aria-label=${this.collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        title=${this.collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+      >
+        <sl-icon name="chevron-left"></sl-icon>
+        <span class="collapse-toggle-text">Collapse</span>
+      </button>
     `;
   }
 
@@ -314,11 +371,15 @@ export class ScionNav extends LitElement {
     return this.currentPath.startsWith(path);
   }
 
-  /**
-   * Handle navigation link click.
-   * Prevents default browser navigation and dispatches a custom event
-   * so the client-side router can handle it without a full page reload.
-   */
+  private handleCollapseToggle(): void {
+    this.dispatchEvent(
+      new CustomEvent('sidebar-toggle', {
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
   private handleNavClick(e: Event, path: string): void {
     e.preventDefault();
     // Dispatch a custom event for the app shell and router to handle


### PR DESCRIPTION
## Summary

Fixes GoogleCloudPlatform/scion#249

- Adds a collapse toggle button (chevron icon) at the bottom of the sidebar navigation
- Sidebar toggles between expanded (260px, full text labels) and collapsed (64px, icon-only strip)
- Smooth CSS transition animation on collapse/expand using theme transition variables
- State persists to `localStorage` (`scion-sidebar-collapsed`) across page reloads
- Implemented in both the main app shell (`scion-nav` / `app-shell.ts`) and profile shell (`profile-nav` / `profile-shell.ts`)
- Works correctly in both light and dark themes
- Chevron icon rotates 180° when collapsed to indicate expand direction
- Proper `aria-label` and `title` attributes update based on state for accessibility

### Visual States

**Expanded (default):**
Full sidebar with text labels and "Collapse" button at the bottom.

**Collapsed:**
Narrow icon-only strip with rotated chevron. Main content area expands to fill available space.

### Files Changed

| File | Change |
|------|--------|
| `web/src/components/shared/nav.ts` | Added collapse toggle button, CSS transitions, and `sidebar-toggle` event |
| `web/src/components/app-shell.ts` | Added `_sidebarCollapsed` state, localStorage persistence, toggle handler |
| `web/src/components/profile/profile-nav.ts` | Added `collapsed` property, collapsed CSS styles, toggle button |
| `web/src/components/profile/profile-shell.ts` | Added `_sidebarCollapsed` state, localStorage persistence, toggle handler |

## Test plan

- [ ] Verify sidebar collapses to icon-only strip when toggle button is clicked
- [ ] Verify sidebar expands back to full width when toggle is clicked again
- [ ] Verify collapsed state persists across page reloads (localStorage)
- [ ] Verify smooth CSS transition animation on collapse/expand
- [ ] Verify chevron icon rotates correctly in both states
- [ ] Verify works in both light and dark themes
- [ ] Verify mobile drawer is unaffected (hidden on desktop, shows on mobile)
- [ ] Verify profile sidebar collapse works independently
- [ ] Run `npm run typecheck` — passes
- [ ] Run `npm run build` — passes