### PR TITLE
Resource import refactor: factoring, hub-level import, name fix, progress & performance

### DIFF
--- a/.design/resource-import-refactor.md
+++ b/.design/resource-import-refactor.md
@@ -606,10 +606,58 @@ Ordered so each phase is independently shippable and the user-visible fixes land
   HTTP error). Full `pkg/hub` suite + `go vet` + `go build ./...` pass; web
   typecheck + build pass.
 
-### Phase 4 — Performance
+### Phase 4 — Performance — **Status: DONE**
 - Parallelize the per-resource import loop (bounded pool), then per-file uploads.
 - Optional: cache `FetchRemoteTemplate` by commit SHA / ETag.
 - Validate against a multi-template repo; record before/after timings.
+
+**Implementation notes (Phase 4):**
+- **Per-resource loop parallelized** (`importResourceDirs`, `pkg/hub/resource_import.go`):
+  the discovered dirs now import through a bounded `errgroup` pool
+  (`resourceImportConcurrency = 6`). Each worker writes its outcome into a
+  per-index slot, so the returned/reported `imported` and `failed` lists stay in
+  discovery order (compacted via the new `compactNames`); the monotonic
+  `completed` counter is an `atomic.Int64` so the aggregate carried on each
+  progress event is consistent across workers. This is exactly the model Phase 3
+  set up (single mutex-serialized event sink + monotonic counter), so no progress
+  changes were needed — the streaming handler's mutex already makes
+  `importProgressFunc` goroutine-safe.
+- **Per-file uploads parallelized** (`uploadResourceFiles`,
+  `pkg/hub/storage_helpers.go`): files upload through a bounded `errgroup` pool
+  (`fileUploadConcurrency = 8`), each writing its manifest entry into its own slot
+  so the manifest preserves input order without locking. Storage backends (GCS /
+  local FS) are safe for concurrent uploads to distinct object paths. This speeds
+  up the single-large-resource case and, because every import path (templates,
+  harness-configs, bundled, project + global) routes through
+  `ResourceStore.Bootstrap → uploadResourceFiles`, all of them benefit.
+- **Bundled harness-config loop parallelized** (`importTemplateHarnessConfigs`,
+  `pkg/hub/template_bootstrap.go`): a bounded `errgroup`
+  (`bundledHarnessConfigConcurrency = 4`, kept small because this runs *inside* a
+  per-resource import goroutine, so effective concurrency is the product of the
+  two pools).
+- **Test infra:** `mockStorage` (`pkg/hub/bootstrap_test.go`) gained a mutex
+  guarding its `objects` map, since the import path now exercises storage
+  concurrently (and must be clean under `go test -race`).
+- **Concurrency bounds rationale (Q7):** imports are ≤ ~a dozen items, so small
+  bounds are both safe and sufficient; the SQLite store already runs WAL +
+  `busy_timeout(5000)` + a 4-conn pool, so concurrent DB writes serialize
+  gracefully, and real backends (Postgres / GCS) are concurrency-safe.
+- **Tests:** added `TestImportTemplatesFromWorkspace_ParallelManyTemplates`
+  (12 templates × multiple files, asserts every resource imported exactly once,
+  order preserved, all files uploaded). The import-path tests pass under
+  `go test -race`; the full `pkg/hub` suite passes (the full suite under `-race`
+  exceeds the default 10-min binary timeout, so race-cleanliness was verified on
+  the import-path subset).
+- **Validation / timings:** measured with a latency-injecting storage wrapper
+  (25 ms/upload) importing 12 templates × 4 files = 48 uploads. Sequential lower
+  bound ≈ 1.2 s; parallel actual ≈ 63 ms — a **~19× speedup** for the
+  multi-resource case the user reported as slow. (Measured with a throwaway
+  timing test; not committed to avoid a flaky wall-clock assertion in CI.)
+- **Deferred (optional):** caching `FetchRemoteTemplate` by commit SHA / ETag was
+  left out. It is explicitly optional and lower-priority in §4.5 (the user's
+  slowness is dominated by uploads, now parallelized), and a content/ETag cache
+  touches the fetch signature + invalidation semantics with little expected
+  payoff here. Tracked as a follow-up if repeated same-URL imports become common.
 
 ---
 

--- a/.design/resource-import-refactor.md
+++ b/.design/resource-import-refactor.md
@@ -1,0 +1,547 @@
+# Resource Import Refactor: Factoring, Hub-Level Import, Name Fix, Progress & Performance
+
+**Status:** Reviewed — all open questions resolved (see §4.6); ready for implementation
+**Created:** 2026-06-01
+**Author:** Agent (template-harness-refactor)
+**Related:** [template-import-refactor.md](./template-import-refactor.md), [template-import.md](./template-import.md), [hub-template-admin.md](./hub-template-admin.md), [template-techdebt-cleanup.md](./template-techdebt-cleanup.md), [grove-level-templates.md](./grove-level-templates.md), [agnostic-template-design.md](./agnostic-template-design.md)
+
+---
+
+## 1. Overview
+
+Scion can import two kinds of file-based resources from a remote URL or a workspace
+path into the Hub's database + storage backend:
+
+- **Templates** — full agent definitions (`scion-agent.yaml` + `home/` + optional bundled `harness-configs/`).
+- **Harness-configs** — harness-specific config directories (`config.yaml` + files).
+
+Today this import is exposed **only at the project level** (Project Settings →
+Resources). This document proposes:
+
+1. **Factor** the import mechanism so the template and harness-config paths stop
+   duplicating fetch / discover / name / loop logic, and so the CLI and Hub share
+   the same name-derivation rules.
+2. **Expose import in the global "Hub Resources" view** so global-scoped templates
+   and harness-configs can be imported from the web UI (today they can only be
+   seeded at boot or via CLI).
+3. **Fix the name bug** where importing a single resource from a deep URL
+   (e.g. `…/tree/main/antigravity`) yields a cache-hash name instead of `antigravity`.
+4. **Improve the import progress UX** — replace the generic spinner with per-resource
+   progress ("Importing antigravity (2/5)…").
+5. **Make import faster** where it is safely parallelizable.
+
+This builds directly on the prior `ResourceStore` consolidation (the "§7.3" work in
+`pkg/hub/resource_store.go`) and the `hub-template-admin.md` draft, which already
+sketched a hub-level import endpoint but was never implemented.
+
+---
+
+## 2. Current State (as built)
+
+### 2.1 Server-side import flow
+
+| Concern | Templates | Harness-configs |
+|---------|-----------|-----------------|
+| HTTP handler | `handleProjectImportTemplates` (`pkg/hub/handlers.go:9314`) | `handleProjectImportHarnessConfigs` (`pkg/hub/handlers.go:9413`) |
+| Route | `POST /api/v1/projects/{projectID}/import-templates` | `POST /api/v1/projects/{projectID}/import-harness-configs` |
+| Remote import | `importTemplatesFromRemote` (`template_bootstrap.go:248`) | `importHarnessConfigsFromRemote` (`harness_config_bootstrap.go:130`) |
+| Workspace import | `importTemplatesFromWorkspace` (`template_bootstrap.go:344`) | `importHarnessConfigsFromWorkspace` (`harness_config_bootstrap.go:170`) |
+| Dir discovery | inline (`template_bootstrap.go:288-308`, `374-393`) | `discoverHarnessConfigDirs` (`harness_config_bootstrap.go:216`) |
+| Create / sync one | `ResourceStore.Bootstrap` via `templateStore()` | `ResourceStore.Bootstrap` via `harnessConfigStore()` |
+| Response | `{ templates: string[], count }` (sync) | `{ harnessConfigs: string[], count }` (sync) |
+
+**What is already well-factored:** `ResourceStore.Bootstrap` (`resource_store.go:121`)
+is a clean, kind-generic create-or-sync used by both kinds. The per-kind quirks
+(template harness detection, bundled harness-config import, DefaultHarnessConfig
+backfill) live behind the `resourcePersistence` interface. This layer is good and
+should be kept.
+
+**What is NOT well-factored — the duplication sits one level up**, in the
+`import*FromRemote` / `import*FromWorkspace` functions. The two `…FromRemote`
+functions are near-identical: auth-token minting → `FetchRemoteTemplate` → discover
+dirs → loop `GetBySlug` + create-or-sync → collect names. The two `…FromWorkspace`
+functions are likewise near-identical. The dir-discovery "is the root itself a
+resource, else scan children" logic is copied **three times** (once per import fn
+family, plus `discoverHarnessConfigDirs`).
+
+Concrete inconsistencies caused by the duplication:
+
+- The template remote path falls back to a project `GITHUB_TOKEN` secret
+  (`template_bootstrap.go:267-278`); the harness-config remote path **does not**
+  (`harness_config_bootstrap.go:140-147`). Same operation, different auth behavior.
+- The name bug (below) had to be fixed-or-not in each copy independently.
+
+### 2.2 The name bug (root cause confirmed)
+
+`FetchRemoteTemplate` (`pkg/config/remote_templates.go:164`) caches the fetched
+content at `…/cache/remote-templates/<sha256-prefix>` and copies the URL's
+**sub-path contents directly into that hash directory** (`remote_templates.go:294-299`).
+It returns only that hash path; the original leaf segment (`antigravity`) is discarded.
+
+When the URL points directly at a single resource, the discovery code names the
+resource after the cache directory:
+
+- `template_bootstrap.go:293` — `templateDir{filepath.Base(cachePath), cachePath}` → name = `<hash>`
+- `harness_config_bootstrap.go:218` — `{filepath.Base(root), root}` → name = `<hash>`
+
+So `…/tree/main/antigravity` imports as e.g. `a1b2c3d4e5f6a7b8` instead of `antigravity`.
+(The multi-resource case — URL points at a directory of resources — is correct,
+because those names come from `entry.Name()`.)
+
+**The fix already exists in the CLI but isn't shared.** `deriveHarnessConfigName`
+(`cmd/harness_config_install.go:236`) correctly does `path.Base(u.Path)` on the
+source URL — for `…/tree/main/antigravity` that yields `antigravity`. The Hub import
+path simply doesn't call it. The workspace single-resource case has a milder variant
+of the same bug (`filepath.Base(templatesDir)` yields e.g. `templates`).
+
+### 2.3 Web UI
+
+- **Project Settings** (`web/src/components/pages/project-settings.ts`) has both
+  importers: `renderTemplatesContent` (1853) / `handleSyncTemplates` (1025) and
+  `renderHarnessConfigsContent` (1957) / `handleImportHarnessConfigs` (1057). Both
+  support URL and workspace modes. Progress is a single Shoelace `<sl-spinner>` with
+  a static "Importing … from <url>…" message (`project-settings.ts:1921`, `2028`) —
+  **no per-resource detail, no streaming**.
+- **Hub Resources** (`web/src/components/pages/settings.ts`, route `/settings`) shows
+  global templates and harness-configs via read-only `<scion-resource-list>` tabs.
+  **There is no import button at the hub level.**
+- SSE infrastructure exists (`web/src/client/sse-client.ts`) for agent/terminal
+  streams but is **not** used for import.
+
+### 2.4 Performance characteristics
+
+- Remote fetch is a single repo tarball download + extract (`fetchGitHubTarball`),
+  which is reasonable for one repo. Fallback is sparse git checkout.
+- Per-resource work in the import loops is **sequential**: each resource does
+  `GetBySlug` → `CollectFiles` → upload every file → DB create + update
+  (`resource_store.go:130-208`). For a repo with several templates, each containing a
+  bundled harness-config (`importTemplateHarnessConfigs`, also sequential), the
+  per-file storage uploads dominate wall-clock and are the most likely cause of the
+  "taking a while" the user reports.
+- `FetchRemoteTemplate` always wipes and re-fetches (`remote_templates.go:178-180`);
+  no caching across imports.
+
+---
+
+## 3. Goals & Non-Goals
+
+### Goals
+- One shared import pipeline for both resource kinds and both sources (remote /
+  workspace), with one name-derivation rule shared with the CLI.
+- Correct resource names from deep URLs (the `antigravity` case) and workspace paths.
+- Hub-level (global-scope) import from the Hub Resources view, reusing the project
+  import UI pattern.
+- Per-resource progress in the UI for multi-resource imports.
+- Measurable import speedup via safe parallelism.
+
+### Non-Goals
+- Changing the `ResourceStore` / `resourcePersistence` design (keep as-is).
+- Template/harness-config data-model changes.
+- The broader admin template-management page from `hub-template-admin.md` (list /
+  delete / lock / clone). This doc covers only the **import** slice of that view.
+- Cross-harness translation, template authoring wizard, versioning.
+
+---
+
+## 4. Design
+
+### 4.1 Factor the import pipeline
+
+Introduce a single kind-generic, source-generic import driver that sits **above**
+`ResourceStore.Bootstrap` and **replaces** the four `import*From*` functions.
+
+Proposed shape (in a new `pkg/hub/resource_import.go`):
+
+```go
+// resourceImportSpec describes one import request, independent of kind/source.
+type resourceImportSpec struct {
+    kind     storage.ResourceKind // template | harness-config
+    scope    string               // project | global
+    scopeID  string               // projectID for project scope, "" for global
+}
+
+// resourceDir pairs a derived resource name with its on-disk directory.
+type resourceDir struct{ name, path string }
+
+// importResources runs the shared pipeline: discover dirs under root, then
+// create-or-sync each via the kind's ResourceStore, reporting progress.
+func (s *Server) importResources(
+    ctx context.Context, root string, spec resourceImportSpec,
+    isResourceDir func(string) bool,
+    newStore func(dir string) (*ResourceStore, error),
+    progress func(ResourceImportEvent),
+) ([]string, error)
+```
+
+- **Discovery** is unified into one `discoverResourceDirs(root, sourceURL, marker)`
+  helper that owns BOTH the leaf-vs-parent decision AND per-branch naming (§4.2.1).
+  It is the single place that classifies folders by the presence of a **marker file**
+  (`scion-agent.yaml` for templates, `config.yaml` for harness-configs).
+- **Fetch + auth** is unified into one `fetchRemoteForImport(ctx, projectID, url)`
+  that does the GitHub-App-token → `GITHUB_TOKEN`-secret fallback once, for both kinds
+  (fixing the harness-config auth gap).
+- **Per-kind differences** stay where they already live: `isResourceDir`
+  (`IsScionTemplate` vs `isHarnessConfigDir`) and `newStore` (`templateStore()` vs
+  `harnessConfigStore(harness)`), both passed in as small closures.
+
+The four public `import*From*` methods collapse to two thin wrappers
+(`importFromRemote`, `importFromWorkspace`) parameterized by kind. The CLI
+(`cmd/template_import.go`, `cmd/harness_config_install.go`) is migrated to call the
+same `pkg/config`-level name derivation (§4.2) so there is exactly one rule.
+
+**Alternatives considered:**
+- **A. Minimal — just fix the bug in place.** Patch the three `filepath.Base` sites,
+  leave the duplication. Lowest risk, fastest, but leaves the auth inconsistency and
+  the per-copy maintenance burden, and the user explicitly asked to "make sure this
+  is well factored" first.
+- **B. Shared driver above `ResourceStore` (recommended).** Removes the duplication
+  the user is worried about without touching the well-tested `Bootstrap` core.
+- **C. Push everything into `pkg/config/templateimport`** as a kind-agnostic library
+  the CLI and Hub both call. Most thorough, but the Hub stages (storage upload, DB,
+  auth-token minting) are Hub-specific and don't belong in `pkg/config`. Over-reach.
+
+> Recommendation: **B**, with the name-derivation helper extracted to `pkg/config`
+> (the one piece genuinely shared with the CLI). See Open Question Q1.
+
+### 4.2 Fix resource naming
+
+Add a shared, tested helper in `pkg/config` (next to `FetchRemoteTemplate`):
+
+```go
+// DeriveResourceName returns the intended resource name from a source URL or
+// path: the last meaningful path segment (e.g. ".../tree/main/antigravity" -> "antigravity").
+func DeriveResourceName(source string) string
+```
+
+This generalizes the existing CLI `deriveHarnessConfigName` (which already handles
+`file://`, rclone `:backend:path`, and http(s) URLs). The CLI switches to it; the
+Hub import path uses it for the single-resource case.
+
+#### 4.2.1 Leaf vs parent detection drives naming
+
+A source URL/path resolves to one of two shapes, distinguished by the **marker file**:
+
+- **Leaf** — the fetched root *itself* contains the marker file. It is a single
+  resource. Its name must come from the **URL's leaf segment** (`DeriveResourceName`),
+  because the cache directory is a hash and the leaf's contents were copied into it.
+  (Workspace leaf: use the real directory's `filepath.Base`, not a hash.)
+- **Parent** — the fetched root is a directory whose *children* may each contain a
+  marker file. Each valid child is one resource named by its **own directory name**
+  (`entry.Name()` — already correct). Children without the marker are **skipped**
+  (these are the "invalid resource folders"). The URL leaf here is the parent folder
+  name (e.g. `templates`) and must **not** be used as a resource name.
+
+So the URL-derived leaf name is consumed **only on the leaf branch**. Detection itself
+works on the fetched cache contents and is unaffected by the hash-directory issue —
+the hash only costs us the leaf name. This is why detection + naming belong together in
+one `discoverResourceDirs` helper rather than being split across the fetch function and
+the caller.
+
+Two layered options for *where* the name ultimately comes from (not mutually
+exclusive):
+
+1. **URL/path leaf (primary).** Use `DeriveResourceName(sourceURL)` for the
+   single-resource case; use `entry.Name()` for the multi-resource case (already
+   correct). Fixes the reported bug directly. For the workspace single-resource case,
+   use `filepath.Base(absolutePath)` of the *real* directory (not the cache hash).
+2. **Explicit `name:` in the resource config (secondary, optional).** If a
+   `scion-agent.yaml` / `config.yaml` carries an explicit name field, prefer it over
+   the derived name. This makes a resource self-describing regardless of how it was
+   fetched. Requires a small schema addition. See Open Question Q2.
+
+A subtlety for `FetchRemoteTemplate`: rather than re-parsing the URL at every call
+site, we can change it to return a small struct (`RemoteFetch{ CachePath, LeafName }`)
+so the leaf name is computed once where the URL is known. This is cleaner but touches
+the function's signature and all callers. See Open Question Q3.
+
+### 4.3 Hub-level (global) import
+
+Follow `hub-template-admin.md` §2.6 / §3.2: add hub-scoped import that reuses the
+shared pipeline with `scope = global`, `scopeID = ""`.
+
+**Endpoint options:**
+- **A. Dedicated endpoints** `POST /api/v1/templates/import` and
+  `POST /api/v1/harness-configs/import` (body `{ sourceUrl }`). Clean separation;
+  must register before the `/{id}` wildcard routes. (This is what `hub-template-admin.md`
+  recommended.)
+- **B. One unified endpoint** `POST /api/v1/resources/import` with body
+  `{ kind, scope, scopeId, sourceUrl }`. Fewer routes, matches the unified pipeline,
+  and naturally supports a future "import into project X from the admin view".
+- **C. Extend the existing project endpoints** with an optional `scope=global`. Muddies
+  project-scoped semantics; rejected in the prior doc too.
+
+> **Decision (Q4): B.** One unified endpoint `POST /api/v1/resources/import` with body
+> `{ kind, scope, scopeId, sourceUrl }`. `kind` is always supplied by the UI — the two
+> kinds are presented and imported separately (no mixed-kind tree), so the endpoint
+> imports exactly one kind per call and scans for that kind's marker file. The response
+> is per-kind (imported / skipped / failed names).
+
+**Authorization:** global import requires hub-admin (consistent with the Hub Resources
+view already living under the admin nav section). Workspace-path mode is **not**
+available for global import (no project workspace to resolve) — URL only, matching
+`hub-template-admin.md` §2.6.
+
+**Web UI:** add an "Import" affordance to the Hub Resources tabs
+(`web/src/components/pages/settings.ts`) that reuses the same import form component as
+project settings, with the scope fixed to global and the workspace-mode option hidden.
+Factoring the project-settings import form into a shared `<scion-resource-import>`
+component avoids a third copy of the import UI. See Open Question Q5.
+
+### 4.4 Progress UX
+
+The import is currently one blocking POST. To show "what is being imported right now"
+we need the server to emit per-resource progress and the client to render it. Options:
+
+- **A. Streaming response (NDJSON / chunked).** The import endpoint streams one JSON
+  line per lifecycle event (`discovered`, `importing <name> i/N`, `imported <name>`,
+  `done`). The client reads the stream and updates the spinner label. Self-contained
+  to the request; no job store. Works with the existing fetch in the UI (switch to a
+  streamed reader). **Recommended** — smallest moving-parts cost for the UX win.
+- **B. SSE channel.** Reuse `sse-client.ts`. More infra (channel naming, correlation
+  IDs); better if multiple viewers should see the same import. Overkill for a
+  user-initiated action.
+- **C. Async job + poll.** `POST` returns a job ID; client polls `GET …/import-jobs/{id}`.
+  Most robust for very long imports (survives navigation), but introduces a job model
+  and store. Heavier than the problem warrants today.
+- **D. Two-phase (discover then import-each).** `POST …/discover` returns the resource
+  list; client then imports each with its own request, driving the progress bar
+  client-side. No streaming needed, naturally parallelizable from the client, but
+  chattier and reorders error handling.
+
+> Recommendation: **A** for the progress feature; revisit **C** only if imports grow
+> large enough to outlive a page session. See Open Question Q6.
+
+The event payload carries per-item `name` and `status` plus an aggregate
+`completed`/`total` so the UI can render "Imported 2/5…" and a final summary (imported /
+skipped / failed). This also lets us surface per-resource failures instead of a single
+opaque error. Under parallelism the aggregate counter is the source of truth for the
+progress bar — see "Concurrency + progress reporting" below for the exact event model.
+
+**Concurrency + progress reporting.** Once the per-resource loop is parallelized
+(§4.5), items finish out of order, so a discovery-position "i/N" index is no longer
+meaningful. The progress model must therefore separate the **aggregate** from the
+per-item detail:
+
+- `discovered` — carries `total` (N) and the full list of discovered names.
+- `started` — `{ name }` when a worker picks up a resource (lets the UI show which
+  items are currently in flight, e.g. "Importing: antigravity, foo, bar…").
+- `completed` / `failed` / `skipped` — `{ name, completed, total }`, where `completed`
+  is a **monotonic counter** of finished items (any terminal status), assigned by the
+  emitter as each finishes — independent of start/discovery order.
+- `done` — final summary: imported / skipped / failed name lists.
+
+Because events originate from multiple goroutines, they funnel through a **single event
+sink** (one channel, or a mutex-guarded writer) that (a) serializes writes to the NDJSON
+stream and (b) owns the `completed` counter so the aggregate is always consistent. The
+UI renders a progress bar from `completed/total` plus the in-flight names — both correct
+regardless of how many workers run concurrently. This keeps the user-facing "X/Y
+imported" accurate under parallelism, which was the specific concern raised in review.
+
+**Multi-node control plane.** Streaming (A) is the *best* fit for a future stateless,
+multi-node hub API, not merely a tolerable one. The whole import is a single HTTP
+request: the load balancer pins that one connection to one node, and both the work
+(fetch → upload → DB) and the progress emission happen in that handler. There is **no
+cross-request state** to share between nodes — which is exactly the cost (C) incurs,
+where the starting `POST` and the polling `GET`s can land on different nodes and thus
+require a shared job store (DB/Redis) reachable by all of them. Two caveats to note for
+(A) under multi-node: (1) the LB / reverse proxy must allow long-lived streaming
+responses (NDJSON emits frequently, so the connection is never idle, but proxy
+read/idle timeouts should still be verified); (2) if the connection drops mid-import,
+the client loses visibility into the final state — but the import is **idempotent by
+slug** (create-or-sync via `ResourceStore.Bootstrap`), so simply re-running it is safe
+and converges. Durable resumability (surviving a navigation/refresh) remains the one
+thing only (C) buys; revisit if imports grow long enough to need it.
+
+### 4.5 Performance
+
+Layered, each independently shippable:
+
+1. **Parallelize per-resource import** within one request. The resource loop in the
+   import pipeline (and the bundled `importTemplateHarnessConfigs` loop) is
+   embarrassingly parallel — each resource is an independent DB row + storage prefix.
+   Use a bounded worker pool (`errgroup` with a small limit) over the discovered dirs.
+   Per Q7, imports are ≤ ~a dozen items, so a small bound (≈6–8) — or simply all of
+   them — is safe; no backend constraint forces a tighter cap. This is the biggest
+   expected win for the multi-resource case the user reported as slow.
+2. **Parallelize per-file uploads** inside `uploadResourceFiles` with a bounded pool.
+   Helps the single-large-resource case (many files). Independent of #1.
+3. **Cache the remote fetch.** `FetchRemoteTemplate` currently always re-downloads.
+   Add a content/ETag- or commit-SHA-keyed cache with a short TTL so repeated imports
+   of the same URL skip the tarball download. Lower priority; the user's slowness is
+   more likely uploads than fetch.
+
+> Parallelism interacts with the progress design: events must be emitted safely from
+> workers (serialize through a channel). The streaming approach (§4.4 A) handles this
+> naturally.
+
+---
+
+## 4.6 Resolved decisions (from review)
+
+- **Q1 → A.** Adopt the shared driver above `ResourceStore` (§4.1 Alternative B);
+  collapse the four `import*From*` functions into one kind/source-generic pipeline.
+- **Q2 → A.** Name stays source-derived (URL leaf / dir name); no `name:` field in the
+  resource config for now. **Follow-up (deferred):** allow renaming a resource record
+  in the DB once it's on the hub (a post-import, hub-side rename — distinct from the
+  config-declared name in Q2 option B). Tracked in §8 Follow-ups.
+- **Q3 → C.** Leaf-vs-parent detection AND naming live together in one shared
+  `discoverResourceDirs(root, sourceURL, marker)`; `FetchRemoteTemplate` returns the
+  cache path (plus optionally the parsed URL parts). Leaf → `DeriveResourceName(URL)`;
+  parent → child dir names; children without the marker file are skipped.
+- **Q4 → B (machinery only).** Unified, kind-generic import pipeline behind one
+  endpoint `POST /api/v1/resources/import` with body `{ kind, scope, scopeId, sourceUrl }`.
+  **`kind` is always supplied by the UI** — templates and harness-configs are always
+  presented and imported as **distinct kinds**. There is **no mixed-kind discovery**:
+  authors won't create directories mixing both kinds, so each import scans for exactly
+  one marker file. (This resolves the mixed-kind half of Q9: **no**.)
+- **Q5 → A.** Hub Resources import is **global-scope only** (`scope=global`,
+  `scopeId=""`). Project-scoped import stays in each project's settings page. URL is the
+  only source mode at the hub level. A project picker in the hub view is a possible
+  later addition (§8 Follow-ups).
+- **Q6 → A.** Streaming NDJSON progress response. Confirmed multi-node-friendly: the
+  import is one request pinned to one node with no cross-request shared state (see §4.4
+  "Multi-node control plane"). Re-import is idempotent by slug, so a dropped connection
+  is safe to retry. Async-job+poll (C) deferred unless imports need durable resumability.
+- **Q7 → concurrency is fine.** Imports are rarely more than ~a dozen items, so a small
+  bounded worker pool over the per-resource loop is safe and sufficient. No special
+  backend constraints to design around; I'll still read the store/storage layers and
+  pick a conservative default bound (≈6–8, or simply "all of them" given the small N).
+  Under parallelism the user-facing aggregate "X/Y imported" is driven by a monotonic
+  completed-counter funneled through a single event sink (see §4.4 "Concurrency +
+  progress reporting").
+- **Q8 → A.** This doc covers **only the import slice**. The broader hub admin
+  management view (list / filter / delete / lock / clone / archive) is **future work**,
+  tracked in [hub-template-admin.md](./hub-template-admin.md); this effort implements
+  the import portion of that doc's §2.6 / §3.2 and supersedes those import sections. See
+  §8 Follow-ups for the cross-reference.
+- **Q9 → one level + stream-reported skips.** In the parent case, scan **only the
+  immediate children** of the root for the marker file (no recursion); this matches how
+  `.scion/templates` and `.scion/harness-configs` are laid out today. Recursion is a
+  later addition only if a real use case appears. Child folders lacking the marker file
+  are **skipped and reported** via the progress stream (a `skipped` event per folder)
+  and in the final summary, e.g. "Imported 3, skipped 2 (no scion-agent.yaml)".
+
+---
+
+## 5. Open Questions / Ambiguities (all resolved — see §4.6)
+
+> All nine questions below were reviewed and resolved with the project owner; the
+> resolutions are consolidated in §4.6 and folded into the design above. They are kept
+> here for traceability of what was decided and why.
+
+
+1. **Factoring depth (Q1).** Adopt the shared driver above `ResourceStore`
+   (Alternative B in §4.1), or just patch the bug minimally (A) and defer the
+   refactor? The task framing ("make sure this is well factored *then* …") suggests B.
+2. **Explicit name field (Q2).** Should a resource's config (`scion-agent.yaml` /
+   `config.yaml`) be able to declare its own `name`, taking precedence over the
+   URL/dir-derived name? Adds self-describing resources but is a (small) schema change.
+3. **Where naming lives (Q3, reframed).** Given leaf-vs-parent detection (§4.2.1), the
+   URL leaf name is only used on the leaf branch. Options: (A) re-derive at the call
+   site and pass into discovery; (B) have `FetchRemoteTemplate` return a `LeafName`
+   (misleading — fetch can't know if it grabbed a leaf or a parent); (C) keep fetch
+   returning the cache path (+ optionally the parsed URL parts) and let the shared
+   `discoverResourceDirs(root, sourceURL, marker)` own all naming. Lean: **C**.
+4. **Hub import endpoint shape (Q4).** Dedicated per-kind endpoints (A, matches prior
+   doc), or one unified `/api/v1/resources/import` (B, matches the unified pipeline)?
+5. **Hub import scope selector (Q5).** At the hub level, import global-only, or also
+   offer "import into project X" from the Hub Resources view (per `hub-template-admin.md`
+   §2.6, which had a Global/Grove selector)?
+6. **Progress mechanism (Q6).** Streaming NDJSON response (A) vs async job + poll (C).
+   Streaming is lighter; async survives navigation. Which fits expected import sizes?
+7. **Concurrency safety (Q7).** Any known constraint in the store / storage backend
+   (Postgres pool limits, GCS rate limits, non-reentrant code) that caps how
+   aggressively the per-resource loop can be parallelized?
+8. **Scope of this doc vs hub-template-admin.md (Q8).** Should this doc also pull in
+   the read/list/delete admin view, or stay strictly the import slice and let the rest
+   of `hub-template-admin.md` proceed separately?
+9. **Scan depth & skipped-folder reporting (Q9).** (Mixed-kind discovery resolved =
+   no, per Q4.) In the parent case, do we scan only one level of children (current
+   behavior) or recurse to find resources nested deeper? And how do we report
+   invalid/skipped folders (children lacking the kind's marker file) so the user
+   understands what was and wasn't imported?
+
+---
+
+## 6. Phases
+
+Ordered so each phase is independently shippable and the user-visible fixes land early.
+
+### Phase 0 — Name fix (smallest, highest signal) — **Status: DONE**
+- Extract `DeriveResourceName` into `pkg/config`; unit-test the `antigravity`,
+  `/tree/main/...`, archive, rclone, and bare-repo cases.
+- Use it in the three Hub single-resource discovery sites (and the workspace variant).
+- Migrate the CLI `deriveHarnessConfigName` to the shared helper.
+- Result: `…/tree/main/antigravity` imports as `antigravity`. No API/UI change.
+
+**Implementation notes (Phase 0):**
+- `DeriveResourceName` added in `pkg/config/resource_name.go` (+ tests in
+  `pkg/config/resource_name_test.go`): handles `file://`, rclone `:backend:path`,
+  http(s)/bare-`github.com` URLs, archives, and plain paths.
+- Hub remote leaf naming now uses it: `template_bootstrap.go`
+  (`importTemplatesFromRemote`) and `harness_config_bootstrap.go`
+  (`discoverHarnessConfigDirs` gained an optional `sourceURL` param; the remote
+  caller passes the URL, the workspace caller passes `""` so the real dir's
+  `filepath.Base` is still used). The workspace template leaf already used the real
+  directory's base name and was left unchanged.
+- CLI `deriveHarnessConfigName` (`cmd/harness_config_install.go`) now delegates to
+  `config.DeriveResourceName`; existing CLI tests still pass.
+- Drive-by: removed a pre-existing unused `storage` import in `template_bootstrap.go`
+  that was breaking `go build ./...` on the branch.
+
+### Phase 1 — Factor the import pipeline
+- Add `pkg/hub/resource_import.go` shared driver (discover + fetch/auth + loop).
+- Collapse the four `import*From*` functions into kind-parameterized wrappers.
+- Fix the harness-config `GITHUB_TOKEN` auth gap by sharing the fetch path.
+- Pure refactor: behavior-preserving, covered by existing + new tests.
+
+### Phase 2 — Hub-level import (backend + UI)
+- Add the hub import endpoint(s) (shape per Q4) with admin authz, URL-only.
+- Factor the project-settings import form into a shared `<scion-resource-import>`
+  component; mount it in the Hub Resources tabs with scope=global.
+
+### Phase 3 — Progress UX
+- Server emits per-resource progress events (mechanism per Q6).
+- Client renders "Importing <name> (i/N)…" and a final imported/skipped/failed summary,
+  in both project and hub import surfaces.
+
+### Phase 4 — Performance
+- Parallelize the per-resource import loop (bounded pool), then per-file uploads.
+- Optional: cache `FetchRemoteTemplate` by commit SHA / ETag.
+- Validate against a multi-template repo; record before/after timings.
+
+---
+
+## 7. Key Files
+
+| Area | File |
+|------|------|
+| Remote fetch + name derivation | `pkg/config/remote_templates.go`; new `DeriveResourceName` |
+| Template import | `pkg/hub/template_bootstrap.go` |
+| Harness-config import | `pkg/hub/harness_config_bootstrap.go` |
+| Shared create/sync core (keep) | `pkg/hub/resource_store.go` |
+| New shared import driver | `pkg/hub/resource_import.go` (new) |
+| HTTP handlers + routes | `pkg/hub/handlers.go` (`~4526`, `9314`, `9413`) |
+| CLI import | `cmd/template_import.go`, `cmd/harness_config_install.go` |
+| Project import UI | `web/src/components/pages/project-settings.ts` |
+| Hub Resources UI | `web/src/components/pages/settings.ts` |
+| Shared resource list | `web/src/components/shared/resource-list.ts` |
+| New shared import form | `web/src/components/shared/resource-import.ts` (new) |
+| Nav / routes | `web/src/components/shared/nav.ts`, `web/src/client/main.ts` |
+
+---
+
+## 8. Follow-ups (out of scope for the phases above)
+
+- **Hub-side resource rename.** Let an admin rename a template / harness-config record
+  in the DB after it's on the hub (updates the display name / slug without re-import).
+  Raised during review of Q2; distinct from a config-declared name. Needs a rename
+  endpoint + slug-collision handling + UI affordance on the resource detail/list page.
+- **Remaining `hub-template-admin.md` slice (future work).** The admin resource
+  management view — list with filters/sorting/pagination, delete (with file cleanup),
+  lock/unlock, clone, archive, usage indicators — as specified in
+  [hub-template-admin.md](./hub-template-admin.md) §2.2–2.5, §2.4, §4, and Phases 1–2/4.
+  **This doc supersedes that doc's import sections** (§2.6 hub-level import, §3.2 import
+  endpoint, Phase 3) — when picking up the admin view, treat import as already designed
+  here and build the management actions around it. Cross-reference back to this doc from
+  `hub-template-admin.md` when that work starts.

--- a/.design/resource-import-refactor.md
+++ b/.design/resource-import-refactor.md
@@ -524,10 +524,47 @@ Ordered so each phase is independently shippable and the user-visible fixes land
 - Note: `pkg/config` has pre-existing env-dependent test failures in this sandbox
   (hub-context env vars set); unrelated to this phase, which touches only `pkg/hub`.
 
-### Phase 2 — Hub-level import (backend + UI)
+### Phase 2 — Hub-level import (backend + UI) — **Status: DONE**
 - Add the hub import endpoint(s) (shape per Q4) with admin authz, URL-only.
 - Factor the project-settings import form into a shared `<scion-resource-import>`
   component; mount it in the Hub Resources tabs with scope=global.
+
+**Implementation notes (Phase 2):**
+- New unified endpoint `POST /api/v1/resources/import` (`handleResourcesImport`
+  in `pkg/hub/handlers.go`, registered in `server.go`) with body
+  `{ kind, scope, scopeId, sourceUrl }` per Q4→B. It resolves the kind to the
+  shared `resourceImportKind` (template / harness-config) and runs the Phase-1
+  `importFromRemote` driver. URL is the only source mode (no workspace) — matching
+  the hub-level import design.
+  - **Global scope** (`scope=global`, `scopeId=""`) is hub-admin-only: it runs
+    `authzService.CheckAccess` on an ownerless/parentless `{Type: template |
+    harness_config}` resource with `ActionCreate`, which grants only on the admin
+    bypass (or an explicit hub-wide policy). projectID is `""`, so no project
+    GitHub auth is attempted.
+  - **Project scope** is also supported (the endpoint is genuinely unified, per
+    the "future import into project X" note): `scopeId` is required and authz
+    mirrors the per-project import handlers via the shared `authorizeProjectImport`
+    helper. The existing per-project endpoints (which still own workspace-mode
+    import) are unchanged.
+- `fetchRemoteForImport` now treats `projectID == ""` as an unauthenticated
+  (global) fetch — it skips both the GitHub App token mint and the project
+  `GITHUB_TOKEN` secret fallback, which are project-scoped.
+- Web: new shared `web/src/components/shared/resource-import.ts`
+  (`<scion-resource-import>`) renders the mode toggle + source input + button +
+  status, posting to the per-project endpoint (project scope, URL/workspace) or
+  the unified endpoint (global scope, URL-only), and emits a `resource-imported`
+  event so the host refreshes its list. It replaces the two inline import blocks
+  in `project-settings.ts` (removing the now-dead sync/hcImport state + handlers)
+  and is mounted in the Hub Resources tabs (`settings.ts`) with `scope=global`.
+  The Hub Resources page is already admin-gated at the router level
+  (`ADMIN_ROUTES`), so the import UI shows there unconditionally; the backend
+  still enforces admin.
+- Tests: `pkg/hub/resource_import_handler_test.go` covers global import as admin
+  (lands a global-scoped template), global forbidden for a member (403, nothing
+  imported), invalid kind (400), and missing sourceUrl (400). Web typecheck +
+  build pass.
+- Note: progress UX is intentionally still the simple spinner/success/error model
+  here — per-resource streaming progress is Phase 3.
 
 ### Phase 3 — Progress UX
 - Server emits per-resource progress events (mechanism per Q6).

--- a/.design/resource-import-refactor.md
+++ b/.design/resource-import-refactor.md
@@ -566,10 +566,45 @@ Ordered so each phase is independently shippable and the user-visible fixes land
 - Note: progress UX is intentionally still the simple spinner/success/error model
   here — per-resource streaming progress is Phase 3.
 
-### Phase 3 — Progress UX
+### Phase 3 — Progress UX — **Status: DONE**
 - Server emits per-resource progress events (mechanism per Q6).
 - Client renders "Importing <name> (i/N)…" and a final imported/skipped/failed summary,
   in both project and hub import surfaces.
+
+**Implementation notes (Phase 3):**
+- Server progress model (`pkg/hub/resource_import.go`): added `ResourceImportEvent`
+  (+ `ResourceImportEventType` constants `discovered`/`started`/`completed`/`failed`/
+  `skipped`/`done`/`error`) and an `importProgressFunc` callback threaded through
+  `importFromRemote` / `importFromWorkspace` / `importResourceDirs`. `discoverResourceDirs`
+  now also returns the child folders it skipped (those lacking the kind's marker file)
+  so they can be reported. The per-resource loop emits `discovered` (total + names),
+  a `skipped` event per non-marker folder, `started` per resource, then `completed`/
+  `failed` with a **monotonic completed counter** (assigned as each item finishes, so it
+  stays correct once Phase 4 parallelizes the loop), and a final `done` summary. The
+  marker filename moved onto `resourceImportKind.marker` for skip reasons. The four thin
+  `import*From*` wrappers pass `nil` progress, preserving their signatures (and all
+  existing tests).
+- Streaming transport (`pkg/hub/handlers.go`): new `streamImport` helper writes NDJSON
+  (one JSON event per line via `json.Encoder`, flushed) behind an `http.Flusher`, with
+  events serialized through a mutex (parallel-safe for Phase 4). It is **content-
+  negotiated**: `handleResourcesImport` and both per-project import handlers stream only
+  when the client sends `Accept: application/x-ndjson`; otherwise they return the
+  existing buffered JSON summary (keeping the CLI / existing tests working). All
+  pre-flight validation + authz runs before the stream is committed, so those still
+  return proper HTTP status codes; failures reached after the stream starts (fetch
+  failure, nothing found) surface as an in-band `error` event.
+- Web (`web/src/components/shared/resource-import.ts`): the shared import component now
+  requests NDJSON, reads the stream, and renders an `<sl-progress-bar>` driven by
+  `completed/total` plus the in-flight resource name(s) ("Importing antigravity
+  (2/5)…"), then a final "Imported X, skipped Y, failed Z" summary with the skipped/
+  failed name lists. Falls back to the single-JSON path when the response isn't streamed.
+  Registered `sl-progress-bar` in `web/src/client/main.ts`. Works for both the project
+  settings and Hub Resources surfaces (same component).
+- Tests: `pkg/hub/resource_import_handler_test.go` gains `…_StreamsProgress` (asserts the
+  discovered→completed→done sequence and that the resource still lands) and
+  `…_StreamErrorEvent` (a post-stream failure is reported as an `error` event, not an
+  HTTP error). Full `pkg/hub` suite + `go vet` + `go build ./...` pass; web
+  typecheck + build pass.
 
 ### Phase 4 — Performance
 - Parallelize the per-resource import loop (bounded pool), then per-file uploads.

--- a/.design/resource-import-refactor.md
+++ b/.design/resource-import-refactor.md
@@ -489,11 +489,40 @@ Ordered so each phase is independently shippable and the user-visible fixes land
 - Drive-by: removed a pre-existing unused `storage` import in `template_bootstrap.go`
   that was breaking `go build ./...` on the branch.
 
-### Phase 1 — Factor the import pipeline
+### Phase 1 — Factor the import pipeline — **Status: DONE**
 - Add `pkg/hub/resource_import.go` shared driver (discover + fetch/auth + loop).
 - Collapse the four `import*From*` functions into kind-parameterized wrappers.
 - Fix the harness-config `GITHUB_TOKEN` auth gap by sharing the fetch path.
 - Pure refactor: behavior-preserving, covered by existing + new tests.
+
+**Implementation notes (Phase 1):**
+- New `pkg/hub/resource_import.go` holds the shared, kind/source-generic driver:
+  - `resourceImportKind` bundles the per-kind knobs (`noun` for logs/errors,
+    `isResourceDir` marker check, `newStore` factory). Built via
+    `Server.templateImportKind()` / `Server.harnessConfigImportKind()`. The
+    harness-config `newStore` loads `config.yaml` to resolve the harness type and
+    skips a dir if that fails.
+  - `importFromRemote` / `importFromWorkspace` are the two source-generic entry
+    points; `fetchRemoteForImport` does the GitHub-App-token → `GITHUB_TOKEN`-secret
+    fallback once for **both** kinds (closing the harness-config auth gap);
+    `discoverResourceDirs` owns the leaf-vs-parent decision + naming (leaf →
+    `DeriveResourceName(URL)`, workspace leaf → real `filepath.Base`, parent →
+    child dir names, non-marker children skipped); `importResourceDirs` runs the
+    create-or-sync loop.
+- The loop now calls `ResourceStore.Bootstrap(..., force=true)` directly per dir,
+  dropping the redundant pre-loop `GetBySlug` + create-vs-sync branch (Bootstrap
+  already does that internally; for a re-import the prior code always force-synced).
+- The four `import*From*` methods in `template_bootstrap.go` /
+  `harness_config_bootstrap.go` are now one-line wrappers over the shared driver.
+  Removed the now-dead `discoverHarnessConfigDirs`, `importHarnessConfigDirs`, and
+  the `harnessConfigDir` type, plus the duplicated three-times inline discovery.
+  Workspace path validation is unified on the stricter `filepath.Rel` check
+  (the template path previously used a looser `strings.HasPrefix`).
+- Tests: existing template/harness-config import + workspace tests still pass;
+  added `TestImportHarnessConfigsFromRemote_WithProjectGithubToken` guarding the
+  newly-shared `GITHUB_TOKEN` fallback for harness-config remote import.
+- Note: `pkg/config` has pre-existing env-dependent test failures in this sandbox
+  (hub-context env vars set); unrelated to this phase, which touches only `pkg/hub`.
 
 ### Phase 2 — Hub-level import (backend + UI)
 - Add the hub import endpoint(s) (shape per Q4) with admin authz, URL-only.

--- a/cmd/harness_config_install.go
+++ b/cmd/harness_config_install.go
@@ -17,9 +17,7 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -232,32 +230,11 @@ func installLocally(name, sourcePath, projectPath string, force bool, harnessTyp
 	return nil
 }
 
-// deriveHarnessConfigName extracts a harness-config name from a source URL or path.
+// deriveHarnessConfigName extracts a harness-config name from a source URL or
+// path. It delegates to the shared config.DeriveResourceName so the CLI and the
+// Hub import path use exactly one name-derivation rule.
 func deriveHarnessConfigName(source string) string {
-	if strings.HasPrefix(source, "file://") {
-		localPath := strings.TrimPrefix(source, "file://")
-		return filepath.Base(filepath.Clean(localPath))
-	}
-
-	if strings.HasPrefix(source, ":") {
-		parts := strings.SplitN(source, ":", 3)
-		if len(parts) == 3 {
-			return path.Base(strings.TrimRight(parts[2], "/"))
-		}
-		return ""
-	}
-
-	normalized := normalizeHarnessConfigSourceURL(source)
-	u, err := url.Parse(normalized)
-	if err != nil {
-		return filepath.Base(filepath.Clean(source))
-	}
-
-	cleanPath := strings.TrimRight(u.Path, "/")
-	if cleanPath == "" {
-		return filepath.Base(filepath.Clean(source))
-	}
-	return path.Base(cleanPath)
+	return config.DeriveResourceName(source)
 }
 
 func init() {

--- a/pkg/config/resource_name.go
+++ b/pkg/config/resource_name.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"net/url"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// DeriveResourceName returns the intended resource name from a source URL or
+// path: the last meaningful path segment. For example:
+//
+//	https://github.com/org/repo/tree/main/antigravity -> "antigravity"
+//	:gcs:my-bucket/harness-configs/prod-claude        -> "prod-claude"
+//	file:///path/to/my-config                         -> "my-config"
+//
+// It handles file:// URLs, rclone connection strings (":backend:path"), http(s)
+// URLs (including bare "github.com/..." shorthands), and plain local paths.
+// Returns "" if no name can be derived.
+//
+// This is the single shared rule used by both the CLI and the Hub import path so
+// that a deep URL such as ".../tree/main/antigravity" yields "antigravity"
+// rather than the cache-hash directory name.
+func DeriveResourceName(source string) string {
+	if strings.HasPrefix(source, "file://") {
+		localPath := strings.TrimPrefix(source, "file://")
+		return filepath.Base(filepath.Clean(localPath))
+	}
+
+	// rclone connection string, e.g. ":gcs:bucket/path".
+	if strings.HasPrefix(source, ":") {
+		parts := strings.SplitN(source, ":", 3)
+		if len(parts) == 3 {
+			return path.Base(strings.TrimRight(parts[2], "/"))
+		}
+		return ""
+	}
+
+	normalized := normalizeResourceSourceURL(source)
+	u, err := url.Parse(normalized)
+	if err != nil {
+		return filepath.Base(filepath.Clean(source))
+	}
+
+	cleanPath := strings.TrimRight(u.Path, "/")
+	if cleanPath == "" {
+		return filepath.Base(filepath.Clean(source))
+	}
+	return path.Base(cleanPath)
+}
+
+// normalizeResourceSourceURL prepends "https://" for bare hostnames (e.g.
+// "github.com/org/repo/...") so the leaf segment can be extracted via url.Parse.
+// Unlike NormalizeTemplateSourceURL it does not append a default templates path;
+// it only fixes the scheme so naming is consistent across sources.
+func normalizeResourceSourceURL(raw string) string {
+	s := strings.TrimSpace(raw)
+	if strings.HasPrefix(s, "file://") {
+		return s
+	}
+	if !strings.HasPrefix(s, ":") && !strings.HasPrefix(s, "http://") && !strings.HasPrefix(s, "https://") {
+		if strings.Contains(s, "github.com") || strings.Contains(s, "/") && strings.Contains(strings.SplitN(s, "/", 2)[0], ".") {
+			s = "https://" + s
+		}
+	}
+	return s
+}

--- a/pkg/config/resource_name.go
+++ b/pkg/config/resource_name.go
@@ -36,16 +36,21 @@ import (
 // that a deep URL such as ".../tree/main/antigravity" yields "antigravity"
 // rather than the cache-hash directory name.
 func DeriveResourceName(source string) string {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return ""
+	}
+
 	if strings.HasPrefix(source, "file://") {
 		localPath := strings.TrimPrefix(source, "file://")
-		return filepath.Base(filepath.Clean(localPath))
+		return sanitizeDerivedName(filepath.Base(filepath.Clean(localPath)))
 	}
 
 	// rclone connection string, e.g. ":gcs:bucket/path".
 	if strings.HasPrefix(source, ":") {
 		parts := strings.SplitN(source, ":", 3)
 		if len(parts) == 3 {
-			return path.Base(strings.TrimRight(parts[2], "/"))
+			return sanitizeDerivedName(path.Base(strings.TrimRight(parts[2], "/")))
 		}
 		return ""
 	}
@@ -53,14 +58,26 @@ func DeriveResourceName(source string) string {
 	normalized := normalizeResourceSourceURL(source)
 	u, err := url.Parse(normalized)
 	if err != nil {
-		return filepath.Base(filepath.Clean(source))
+		return sanitizeDerivedName(filepath.Base(filepath.Clean(source)))
 	}
 
 	cleanPath := strings.TrimRight(u.Path, "/")
 	if cleanPath == "" {
-		return filepath.Base(filepath.Clean(source))
+		return sanitizeDerivedName(filepath.Base(filepath.Clean(source)))
 	}
-	return path.Base(cleanPath)
+	return sanitizeDerivedName(path.Base(cleanPath))
+}
+
+// sanitizeDerivedName drops base-name results that carry no real name —
+// filepath.Base/path.Base yield "." for empty/relative input and "/" (or the
+// platform separator) for a root path. Returning those as a resource name would
+// produce a nonsense slug, so collapse them to "" (callers treat "" as "no name
+// derived" and fall back to the on-disk directory name).
+func sanitizeDerivedName(name string) string {
+	if name == "." || name == "/" || name == `\` {
+		return ""
+	}
+	return name
 }
 
 // normalizeResourceSourceURL prepends "https://" for bare hostnames (e.g.

--- a/pkg/config/resource_name_test.go
+++ b/pkg/config/resource_name_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "testing"
+
+func TestDeriveResourceName(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "github deep URL single resource (antigravity bug)",
+			source: "https://github.com/org/repo/tree/main/antigravity",
+			want:   "antigravity",
+		},
+		{
+			name:   "github tree path nested",
+			source: "https://github.com/org/repo/tree/main/harness-configs/custom-claude",
+			want:   "custom-claude",
+		},
+		{
+			name:   "github shorthand without scheme",
+			source: "github.com/org/repo/tree/main/harness-configs/prod-config",
+			want:   "prod-config",
+		},
+		{
+			name:   "bare github repo",
+			source: "https://github.com/org/repo",
+			want:   "repo",
+		},
+		{
+			name:   "https archive URL",
+			source: "https://example.com/downloads/custom-harness.tgz",
+			want:   "custom-harness.tgz",
+		},
+		{
+			name:   "rclone GCS URI",
+			source: ":gcs:my-bucket/harness-configs/prod-claude",
+			want:   "prod-claude",
+		},
+		{
+			name:   "rclone GCS trailing slash",
+			source: ":gcs:my-bucket/harness-configs/prod-claude/",
+			want:   "prod-claude",
+		},
+		{
+			name:   "file URL absolute",
+			source: "file:///path/to/my-config",
+			want:   "my-config",
+		},
+		{
+			name:   "file URL trailing slash",
+			source: "file:///path/to/my-config/",
+			want:   "my-config",
+		},
+		{
+			name:   "plain absolute path",
+			source: "/home/user/configs/my-harness",
+			want:   "my-harness",
+		},
+		{
+			name:   "relative local path",
+			source: "configs/my-harness",
+			want:   "my-harness",
+		},
+		{
+			name:   "github URL trailing slash on leaf",
+			source: "https://github.com/org/repo/tree/main/antigravity/",
+			want:   "antigravity",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DeriveResourceName(tt.source); got != tt.want {
+				t.Errorf("DeriveResourceName(%q) = %q, want %q", tt.source, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/config/resource_name_test.go
+++ b/pkg/config/resource_name_test.go
@@ -82,6 +82,26 @@ func TestDeriveResourceName(t *testing.T) {
 			source: "https://github.com/org/repo/tree/main/antigravity/",
 			want:   "antigravity",
 		},
+		{
+			name:   "empty string",
+			source: "",
+			want:   "",
+		},
+		{
+			name:   "whitespace only",
+			source: "   ",
+			want:   "",
+		},
+		{
+			name:   "root path",
+			source: "/",
+			want:   "",
+		},
+		{
+			name:   "dot",
+			source: ".",
+			want:   "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -41,7 +42,12 @@ const testBootstrapDevToken = "scion_dev_bootstrap_test_token_1234567890"
 
 // mockStorage implements storage.Storage for testing.
 type mockStorage struct {
-	bucket  string
+	bucket string
+	// mu guards objects: the Phase-4 import path uploads files and resources
+	// concurrently, so real backends (GCS / local FS) are exercised concurrently
+	// and the mock must be safe for concurrent access too (and race-clean under
+	// `go test -race`).
+	mu      sync.Mutex
 	objects map[string]*storage.Object // objectPath -> Object
 }
 
@@ -65,6 +71,8 @@ func (m *mockStorage) GenerateSignedURL(_ context.Context, objectPath string, op
 }
 
 func (m *mockStorage) GetObject(_ context.Context, objectPath string) (*storage.Object, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	obj, ok := m.objects[objectPath]
 	if !ok {
 		return nil, fmt.Errorf("object not found: %s", objectPath)
@@ -73,6 +81,8 @@ func (m *mockStorage) GetObject(_ context.Context, objectPath string) (*storage.
 }
 
 func (m *mockStorage) Exists(_ context.Context, objectPath string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	_, ok := m.objects[objectPath]
 	return ok, nil
 }
@@ -82,7 +92,9 @@ func (m *mockStorage) Upload(_ context.Context, objectPath string, _ io.Reader, 
 		Name:     objectPath,
 		Metadata: opts.Metadata,
 	}
+	m.mu.Lock()
 	m.objects[objectPath] = obj
+	m.mu.Unlock()
 	return obj, nil
 }
 
@@ -91,12 +103,16 @@ func (m *mockStorage) Download(_ context.Context, _ string) (io.ReadCloser, *sto
 }
 
 func (m *mockStorage) Delete(_ context.Context, objectPath string) error {
+	m.mu.Lock()
 	delete(m.objects, objectPath)
+	m.mu.Unlock()
 	return nil
 }
 
 func (m *mockStorage) DeletePrefix(_ context.Context, _ string) error { return nil }
 func (m *mockStorage) List(_ context.Context, opts storage.ListOptions) (*storage.ListResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	res := &storage.ListResult{}
 	for path, obj := range m.objects {
 		if opts.Prefix != "" && !strings.HasPrefix(path, opts.Prefix) {

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -9372,13 +9372,25 @@ func (s *Server) handleProjectImportTemplates(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	var imported []string
+	kind := s.templateImportKind()
+	var run func(progress importProgressFunc) ([]string, error)
 	if req.WorkspacePath != "" {
-		imported, err = s.importTemplatesFromWorkspace(ctx, project, req.WorkspacePath)
+		run = func(progress importProgressFunc) ([]string, error) {
+			return s.importFromWorkspace(ctx, project, req.WorkspacePath, store.TemplateScopeProject, kind, progress)
+		}
 	} else {
-		req.SourceURL = config.NormalizeTemplateSourceURL(req.SourceURL)
-		imported, err = s.importTemplatesFromRemote(ctx, projectID, req.SourceURL)
+		sourceURL := config.NormalizeTemplateSourceURL(req.SourceURL)
+		run = func(progress importProgressFunc) ([]string, error) {
+			return s.importFromRemote(ctx, projectID, sourceURL, store.TemplateScopeProject, kind, progress)
+		}
 	}
+
+	if importAcceptsNDJSON(r) {
+		s.streamImport(w, run)
+		return
+	}
+
+	imported, err := run(nil)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "import_failed", err.Error(), nil)
 		return
@@ -9477,13 +9489,25 @@ func (s *Server) handleProjectImportHarnessConfigs(w http.ResponseWriter, r *htt
 		return
 	}
 
-	var imported []string
+	kind := s.harnessConfigImportKind()
+	var run func(progress importProgressFunc) ([]string, error)
 	if req.WorkspacePath != "" {
-		imported, err = s.importHarnessConfigsFromWorkspace(ctx, project, req.WorkspacePath)
+		run = func(progress importProgressFunc) ([]string, error) {
+			return s.importFromWorkspace(ctx, project, req.WorkspacePath, store.HarnessConfigScopeProject, kind, progress)
+		}
 	} else {
-		req.SourceURL = config.NormalizeTemplateSourceURL(req.SourceURL)
-		imported, err = s.importHarnessConfigsFromRemote(ctx, projectID, req.SourceURL)
+		sourceURL := config.NormalizeTemplateSourceURL(req.SourceURL)
+		run = func(progress importProgressFunc) ([]string, error) {
+			return s.importFromRemote(ctx, projectID, sourceURL, store.HarnessConfigScopeProject, kind, progress)
+		}
 	}
+
+	if importAcceptsNDJSON(r) {
+		s.streamImport(w, run)
+		return
+	}
+
+	imported, err := run(nil)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "import_failed", err.Error(), nil)
 		return
@@ -9569,8 +9593,11 @@ func (s *Server) handleResourcesImport(w http.ResponseWriter, r *http.Request) {
 
 	sourceURL := config.NormalizeTemplateSourceURL(req.SourceURL)
 
-	var imported []string
-	var err error
+	// Resolve scope-specific authz and bind the import call. All pre-flight
+	// checks (authz, project existence) run here, before any response is
+	// committed, so they can still return proper HTTP status codes even on the
+	// streaming path.
+	var projectID, scope string
 	switch req.Scope {
 	case "global", "":
 		// Global import is hub-admin only. CheckAccess on an ownerless,
@@ -9587,7 +9614,7 @@ func (s *Server) handleResourcesImport(w http.ResponseWriter, r *http.Request) {
 				"You don't have permission to import global "+kind.noun, nil)
 			return
 		}
-		imported, err = s.importFromRemote(ctx, "", sourceURL, "global", kind)
+		projectID, scope = "", "global"
 
 	case "project":
 		if req.ScopeID == "" {
@@ -9607,7 +9634,7 @@ func (s *Server) handleResourcesImport(w http.ResponseWriter, r *http.Request) {
 			writeErrorFromErr(w, perr, "")
 			return
 		}
-		imported, err = s.importFromRemote(ctx, req.ScopeID, sourceURL, "project", kind)
+		projectID, scope = req.ScopeID, "project"
 
 	default:
 		writeError(w, http.StatusBadRequest, "invalid_request",
@@ -9615,16 +9642,68 @@ func (s *Server) handleResourcesImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	run := func(progress importProgressFunc) ([]string, error) {
+		return s.importFromRemote(ctx, projectID, sourceURL, scope, kind, progress)
+	}
+
+	if importAcceptsNDJSON(r) {
+		s.streamImport(w, run)
+		return
+	}
+
+	imported, err := run(nil)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "import_failed", err.Error(), nil)
 		return
 	}
-
 	writeJSON(w, http.StatusOK, ImportResourcesResponse{
 		Kind:     req.Kind,
 		Imported: imported,
 		Count:    len(imported),
 	})
+}
+
+// importAcceptsNDJSON reports whether the client opted into a streaming
+// per-resource progress response via the Accept header.
+func importAcceptsNDJSON(r *http.Request) bool {
+	return strings.Contains(r.Header.Get("Accept"), "application/x-ndjson")
+}
+
+// streamImport runs an import that may emit progress events, streaming them to
+// the client as newline-delimited JSON (NDJSON). It writes a 200 and the stream
+// headers up front, so per-resource and fetch errors are reported as an `error`
+// event in-band rather than via HTTP status (the caller must do all pre-flight
+// validation/authz before calling this). Events are serialized through a mutex
+// so they remain correct once the per-resource loop is parallelized (Phase 4).
+func (s *Server) streamImport(w http.ResponseWriter, run func(progress importProgressFunc) ([]string, error)) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming_unsupported", "streaming not supported", nil)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	var mu sync.Mutex
+	enc := json.NewEncoder(w)
+	progress := func(ev ResourceImportEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		_ = enc.Encode(ev) // Encode appends a newline → NDJSON framing.
+		flusher.Flush()
+	}
+
+	if _, err := run(progress); err != nil {
+		// The import failed before reaching the per-resource phase (e.g. fetch
+		// failure or nothing found); report it in-band since the status line is
+		// already committed.
+		progress(ResourceImportEvent{Type: ImportEventError, Reason: err.Error()})
+	}
 }
 
 // authorizeProjectImport checks that the caller may import resources into the

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -9495,6 +9495,170 @@ func (s *Server) handleProjectImportHarnessConfigs(w http.ResponseWriter, r *htt
 	})
 }
 
+// ============================================================================
+// Unified Resource Import (kind/scope-generic)
+// ============================================================================
+
+// ImportResourcesRequest is the body for the unified import endpoint
+// (POST /api/v1/resources/import). It imports a single kind of resource from a
+// remote source URL into the given scope.
+type ImportResourcesRequest struct {
+	// Kind is the resource kind: "template" or "harness-config".
+	Kind string `json:"kind"`
+	// Scope is "global" (hub-level) or "project".
+	Scope string `json:"scope"`
+	// ScopeID is the project id for project scope; empty for global scope.
+	ScopeID string `json:"scopeId"`
+	// SourceURL is the remote URL to import from. Workspace-path import is not
+	// available on this endpoint (see the per-project endpoints for that).
+	SourceURL string `json:"sourceUrl"`
+}
+
+// ImportResourcesResponse reports the result of a unified import.
+type ImportResourcesResponse struct {
+	Kind     string   `json:"kind"`
+	Imported []string `json:"imported"`
+	Count    int      `json:"count"`
+}
+
+// handleResourcesImport handles POST /api/v1/resources/import: a single,
+// kind/scope-generic import endpoint sitting over the shared import driver
+// (resource_import.go). Global-scope import requires hub-admin; project-scope
+// import requires create access in the target project. URL is the only source
+// (no workspace mode) — matching the hub-level import design.
+func (s *Server) handleResourcesImport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	var req ImportResourcesRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "Invalid request body", nil)
+		return
+	}
+
+	// Resolve the kind knobs and the authz resource type for the kind.
+	var kind resourceImportKind
+	var authzType string
+	switch storage.ResourceKind(req.Kind) {
+	case storage.ResourceKindTemplate:
+		kind = s.templateImportKind()
+		authzType = "template"
+	case storage.ResourceKindHarnessConfig:
+		kind = s.harnessConfigImportKind()
+		authzType = "harness_config"
+	default:
+		writeError(w, http.StatusBadRequest, "invalid_request",
+			"kind must be 'template' or 'harness-config'", nil)
+		return
+	}
+
+	if req.SourceURL == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "sourceUrl is required", nil)
+		return
+	}
+
+	if s.GetStorage() == nil {
+		writeError(w, http.StatusServiceUnavailable, "storage_unavailable",
+			"Resource storage is not configured", nil)
+		return
+	}
+
+	sourceURL := config.NormalizeTemplateSourceURL(req.SourceURL)
+
+	var imported []string
+	var err error
+	switch req.Scope {
+	case "global", "":
+		// Global import is hub-admin only. CheckAccess on an ownerless,
+		// parentless global resource grants only on admin bypass (or an explicit
+		// hub-wide policy), which is exactly the hub-admin gate we want.
+		userIdent := GetUserIdentityFromContext(ctx)
+		if userIdent == nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required", nil)
+			return
+		}
+		decision := s.authzService.CheckAccess(ctx, userIdent, Resource{Type: authzType}, ActionCreate)
+		if !decision.Allowed {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden,
+				"You don't have permission to import global "+kind.noun, nil)
+			return
+		}
+		imported, err = s.importFromRemote(ctx, "", sourceURL, "global", kind)
+
+	case "project":
+		if req.ScopeID == "" {
+			writeError(w, http.StatusBadRequest, "invalid_request",
+				"scopeId (project id) is required for project scope", nil)
+			return
+		}
+		if !s.authorizeProjectImport(ctx, w, req.ScopeID, kind.noun) {
+			return
+		}
+		// Verify project exists before fetching.
+		if _, perr := s.store.GetProject(ctx, req.ScopeID); perr != nil {
+			if perr == store.ErrNotFound {
+				NotFound(w, "Project")
+				return
+			}
+			writeErrorFromErr(w, perr, "")
+			return
+		}
+		imported, err = s.importFromRemote(ctx, req.ScopeID, sourceURL, "project", kind)
+
+	default:
+		writeError(w, http.StatusBadRequest, "invalid_request",
+			"scope must be 'global' or 'project'", nil)
+		return
+	}
+
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "import_failed", err.Error(), nil)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, ImportResourcesResponse{
+		Kind:     req.Kind,
+		Imported: imported,
+		Count:    len(imported),
+	})
+}
+
+// authorizeProjectImport checks that the caller may import resources into the
+// given project, mirroring the per-project import handlers. It writes the error
+// response and returns false when access is denied.
+func (s *Server) authorizeProjectImport(ctx context.Context, w http.ResponseWriter, projectID, noun string) bool {
+	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+		if !agentIdent.HasScope(ScopeAgentCreate) {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Missing required scope: project:agent:create", nil)
+			return false
+		}
+		if projectID != agentIdent.ProjectID() {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agents can only import "+noun+" within their own project", nil)
+			return false
+		}
+		return true
+	}
+	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+		decision := s.authzService.CheckAccess(ctx, userIdent, Resource{
+			Type:       "agent",
+			ParentType: "project",
+			ParentID:   projectID,
+		}, ActionCreate)
+		if !decision.Allowed {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden,
+				"You don't have permission to import "+noun+" in this project", nil)
+			return false
+		}
+		return true
+	}
+	writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required", nil)
+	return false
+}
+
 // handleMessageChannels handles GET /api/v1/message-channels.
 func (s *Server) handleMessageChannels(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/pkg/hub/harness_config_bootstrap.go
+++ b/pkg/hub/harness_config_bootstrap.go
@@ -130,7 +130,7 @@ func isHarnessConfigDir(dir string) bool {
 // routing through it also gives harness-config remote import the GITHUB_TOKEN
 // secret fallback that templates already had.
 func (s *Server) importHarnessConfigsFromRemote(ctx context.Context, projectID, sourceURL string) ([]string, error) {
-	return s.importFromRemote(ctx, projectID, sourceURL, store.HarnessConfigScopeProject, s.harnessConfigImportKind())
+	return s.importFromRemote(ctx, projectID, sourceURL, store.HarnessConfigScopeProject, s.harnessConfigImportKind(), nil)
 }
 
 // importHarnessConfigsFromWorkspace imports harness-configs from a path within
@@ -139,7 +139,7 @@ func (s *Server) importHarnessConfigsFromRemote(ctx context.Context, projectID, 
 //
 // This is a thin wrapper over the shared import driver (resource_import.go).
 func (s *Server) importHarnessConfigsFromWorkspace(ctx context.Context, project *store.Project, workspacePath string) ([]string, error) {
-	return s.importFromWorkspace(ctx, project, workspacePath, store.HarnessConfigScopeProject, s.harnessConfigImportKind())
+	return s.importFromWorkspace(ctx, project, workspacePath, store.HarnessConfigScopeProject, s.harnessConfigImportKind(), nil)
 }
 
 // syncExistingHarnessConfig re-syncs a local harness config directory through

--- a/pkg/hub/harness_config_bootstrap.go
+++ b/pkg/hub/harness_config_bootstrap.go
@@ -16,10 +16,8 @@ package hub
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
@@ -127,162 +125,21 @@ func isHarnessConfigDir(dir string) bool {
 // importHarnessConfigsFromRemote fetches a remote source URL, discovers
 // harness-configs within it, and registers each one into the Hub store scoped to
 // the given project. Returns the names of all configs imported or updated.
+//
+// This is a thin wrapper over the shared import driver (resource_import.go);
+// routing through it also gives harness-config remote import the GITHUB_TOKEN
+// secret fallback that templates already had.
 func (s *Server) importHarnessConfigsFromRemote(ctx context.Context, projectID, sourceURL string) ([]string, error) {
-	if !config.IsRemoteURI(sourceURL) {
-		return nil, fmt.Errorf("source must be a remote URI (http://, https://, or rclone)")
-	}
-
-	stor := s.GetStorage()
-	if stor == nil {
-		return nil, fmt.Errorf("harness-config storage is not configured")
-	}
-
-	// If the project has a GitHub App installation, mint a token for authenticated access.
-	var authToken string
-	project, err := s.store.GetProject(ctx, projectID)
-	if err == nil && project != nil && project.GitHubInstallationID != nil {
-		if token, _, mintErr := s.MintGitHubAppTokenForProject(ctx, project); mintErr == nil && token != "" {
-			authToken = token
-		}
-	}
-
-	// Fetch to a temporary directory.
-	cachePath, err := config.FetchRemoteTemplate(ctx, sourceURL, authToken)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch remote harness-configs: %w", err)
-	}
-	defer func() { _ = os.RemoveAll(cachePath) }()
-
-	dirs, err := discoverHarnessConfigDirs(cachePath, sourceURL)
-	if err != nil {
-		return nil, err
-	}
-	if len(dirs) == 0 {
-		return nil, fmt.Errorf("no scion harness-configs found at %s", sourceURL)
-	}
-
-	return s.importHarnessConfigDirs(ctx, dirs, projectID), nil
+	return s.importFromRemote(ctx, projectID, sourceURL, store.HarnessConfigScopeProject, s.harnessConfigImportKind())
 }
 
 // importHarnessConfigsFromWorkspace imports harness-configs from a path within
 // the project's workspace filesystem. The workspacePath is relative to the
 // project's workspace root (e.g. "/.scion/harness-configs").
-func (s *Server) importHarnessConfigsFromWorkspace(ctx context.Context, project *store.Project, workspacePath string) ([]string, error) {
-	stor := s.GetStorage()
-	if stor == nil {
-		return nil, fmt.Errorf("harness-config storage is not configured")
-	}
-
-	// Resolve the project's workspace root on disk.
-	projectRoot, err := s.resolveProjectWebDAVPath(ctx, project)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve project workspace: %w", err)
-	}
-
-	// Clean and join the workspace path to the project root.
-	rel := strings.TrimPrefix(filepath.Clean(workspacePath), "/")
-	configsDir := filepath.Join(projectRoot, rel)
-
-	// Validate the resolved path is within the project root.
-	absRoot, _ := filepath.Abs(projectRoot)
-	absDir, _ := filepath.Abs(configsDir)
-	relPath, err := filepath.Rel(absRoot, absDir)
-	if err != nil || strings.HasPrefix(relPath, "..") {
-		return nil, fmt.Errorf("workspace path must be within the project workspace")
-	}
-
-	info, err := os.Stat(configsDir)
-	if err != nil || !info.IsDir() {
-		return nil, fmt.Errorf("workspace path not found or not a directory: %s", workspacePath)
-	}
-
-	dirs, err := discoverHarnessConfigDirs(configsDir, "")
-	if err != nil {
-		return nil, err
-	}
-	if len(dirs) == 0 {
-		return nil, fmt.Errorf("no scion harness-configs found at workspace path %s", workspacePath)
-	}
-
-	return s.importHarnessConfigDirs(ctx, dirs, project.ID), nil
-}
-
-// harnessConfigDir pairs a config's directory name with its on-disk path.
-type harnessConfigDir struct{ name, path string }
-
-// discoverHarnessConfigDirs returns the harness-config directories at root. If
-// root itself is a harness-config it is returned directly; otherwise its
-// immediate subdirectories are scanned.
 //
-// sourceURL is the original remote source (if any). When root is a single
-// harness-config fetched from a remote URL, root is a content-hash cache dir, so
-// the name is derived from the URL's leaf segment instead. For workspace imports
-// pass "" so the real directory's base name is used.
-func discoverHarnessConfigDirs(root, sourceURL string) ([]harnessConfigDir, error) {
-	if isHarnessConfigDir(root) {
-		name := filepath.Base(root)
-		if sourceURL != "" {
-			if derived := config.DeriveResourceName(sourceURL); derived != "" {
-				name = derived
-			}
-		}
-		return []harnessConfigDir{{name, root}}, nil
-	}
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		return nil, err
-	}
-	var dirs []harnessConfigDir
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		dir := filepath.Join(root, entry.Name())
-		if isHarnessConfigDir(dir) {
-			dirs = append(dirs, harnessConfigDir{entry.Name(), dir})
-		}
-	}
-	return dirs, nil
-}
-
-// importHarnessConfigDirs imports or force-syncs each discovered harness-config
-// directory into the project scope. Configs that fail to load or import are
-// logged and skipped. Returns the names successfully imported or updated.
-func (s *Server) importHarnessConfigDirs(ctx context.Context, dirs []harnessConfigDir, projectID string) []string {
-	stor := s.GetStorage()
-	var imported []string
-	for _, hc := range dirs {
-		hcDir, err := config.LoadHarnessConfigDir(hc.path)
-		if err != nil {
-			s.templateLog.Warn("harness-config import: failed to load config, skipping",
-				"config", hc.name, "error", err)
-			continue
-		}
-
-		slug := api.Slugify(hc.name)
-		existing, err := s.store.GetHarnessConfigBySlug(ctx, slug, store.HarnessConfigScopeProject, projectID)
-		if err != nil && err != store.ErrNotFound {
-			s.templateLog.Warn("harness-config import: failed to look up config, skipping",
-				"config", hc.name, "error", err)
-			continue
-		}
-
-		if existing == nil {
-			if err := s.bootstrapSingleHarnessConfigScoped(ctx, hc.name, hc.path, hcDir, stor, store.HarnessConfigScopeProject, projectID); err != nil {
-				s.templateLog.Warn("harness-config import: failed to import config, skipping",
-					"config", hc.name, "error", err)
-				continue
-			}
-		} else {
-			if _, err := s.syncExistingHarnessConfig(ctx, existing, hc.path, hcDir, stor, true); err != nil {
-				s.templateLog.Warn("harness-config import: failed to sync config, skipping",
-					"config", hc.name, "error", err)
-				continue
-			}
-		}
-		imported = append(imported, hc.name)
-	}
-	return imported
+// This is a thin wrapper over the shared import driver (resource_import.go).
+func (s *Server) importHarnessConfigsFromWorkspace(ctx context.Context, project *store.Project, workspacePath string) ([]string, error) {
+	return s.importFromWorkspace(ctx, project, workspacePath, store.HarnessConfigScopeProject, s.harnessConfigImportKind())
 }
 
 // syncExistingHarnessConfig re-syncs a local harness config directory through

--- a/pkg/hub/harness_config_bootstrap.go
+++ b/pkg/hub/harness_config_bootstrap.go
@@ -153,7 +153,7 @@ func (s *Server) importHarnessConfigsFromRemote(ctx context.Context, projectID, 
 	}
 	defer func() { _ = os.RemoveAll(cachePath) }()
 
-	dirs, err := discoverHarnessConfigDirs(cachePath)
+	dirs, err := discoverHarnessConfigDirs(cachePath, sourceURL)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func (s *Server) importHarnessConfigsFromWorkspace(ctx context.Context, project 
 		return nil, fmt.Errorf("workspace path not found or not a directory: %s", workspacePath)
 	}
 
-	dirs, err := discoverHarnessConfigDirs(configsDir)
+	dirs, err := discoverHarnessConfigDirs(configsDir, "")
 	if err != nil {
 		return nil, err
 	}
@@ -213,9 +213,20 @@ type harnessConfigDir struct{ name, path string }
 // discoverHarnessConfigDirs returns the harness-config directories at root. If
 // root itself is a harness-config it is returned directly; otherwise its
 // immediate subdirectories are scanned.
-func discoverHarnessConfigDirs(root string) ([]harnessConfigDir, error) {
+//
+// sourceURL is the original remote source (if any). When root is a single
+// harness-config fetched from a remote URL, root is a content-hash cache dir, so
+// the name is derived from the URL's leaf segment instead. For workspace imports
+// pass "" so the real directory's base name is used.
+func discoverHarnessConfigDirs(root, sourceURL string) ([]harnessConfigDir, error) {
 	if isHarnessConfigDir(root) {
-		return []harnessConfigDir{{filepath.Base(root), root}}, nil
+		name := filepath.Base(root)
+		if sourceURL != "" {
+			if derived := config.DeriveResourceName(sourceURL); derived != "" {
+				name = derived
+			}
+		}
+		return []harnessConfigDir{{name, root}}, nil
 	}
 	entries, err := os.ReadDir(root)
 	if err != nil {

--- a/pkg/hub/resource_import.go
+++ b/pkg/hub/resource_import.go
@@ -21,12 +21,23 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/config/templateimport"
 	"github.com/GoogleCloudPlatform/scion/pkg/secret"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
+
+// resourceImportConcurrency bounds how many resources import in parallel within
+// one request (Phase 4). Each resource is an independent DB row + storage
+// prefix, so the per-resource loop is embarrassingly parallel; imports are
+// rarely more than ~a dozen items (design Q7), so a small bound is both safe and
+// sufficient. Per-resource file uploads parallelize independently
+// (fileUploadConcurrency).
+const resourceImportConcurrency = 6
 
 // resource_import.go is the Phase-1 landing of the resource-import refactor: a
 // single kind-generic, source-generic import driver that sits *above* the
@@ -320,8 +331,16 @@ func discoverResourceDirs(root, sourceURL string, kind resourceImportKind) ([]re
 // not-yet-existing resource the force flag is irrelevant — Bootstrap creates it.
 //
 // The progress model separates the aggregate (a monotonic completed counter over
-// total) from per-item detail so it stays correct once the loop is parallelized
-// (Phase 4): completed is assigned as each item finishes, independent of order.
+// total) from per-item detail so it stays correct under parallelism (Phase 4):
+// completed is assigned as each item finishes, independent of order.
+//
+// The per-resource loop runs concurrently with a bounded worker pool
+// (resourceImportConcurrency). Each worker writes its outcome into per-index
+// slots, so the returned (and reported) imported/failed lists stay in discovery
+// order; the completed counter is an atomic so the aggregate reported on each
+// event is consistent across workers. Progress events themselves are serialized
+// by the streaming handler's mutex (importProgressFunc is documented
+// goroutine-safe), so emit may be called from any worker.
 func (s *Server) importResourceDirs(ctx context.Context, dirs []resourceDir, skipped []skippedDir, scope, scopeID string, kind resourceImportKind, progress importProgressFunc) []string {
 	total := len(dirs)
 	names := make([]string, 0, total)
@@ -336,36 +355,61 @@ func (s *Server) importResourceDirs(ctx context.Context, dirs []resourceDir, ski
 		emit(progress, ResourceImportEvent{Type: ImportEventSkipped, Name: sd.name, Reason: sd.reason})
 	}
 
-	var imported []string
-	var failed []string
-	completed := 0
-	for _, rd := range dirs {
-		emit(progress, ResourceImportEvent{Type: ImportEventStarted, Name: rd.name})
+	importedSlots := make([]string, total)
+	failedSlots := make([]string, total)
+	var completed atomic.Int64
 
-		rstore, err := kind.newStore(rd.path)
-		if err == nil {
-			_, err = rstore.Bootstrap(ctx, rd.name, rd.path, scope, scopeID, true)
-		}
-		completed++
-		if err != nil {
-			s.templateLog.Warn(kind.noun+" import: failed to import resource, skipping",
-				"name", rd.name, "error", err)
-			failed = append(failed, rd.name)
+	var g errgroup.Group
+	g.SetLimit(resourceImportConcurrency)
+	for i, rd := range dirs {
+		i, rd := i, rd
+		g.Go(func() error {
+			emit(progress, ResourceImportEvent{Type: ImportEventStarted, Name: rd.name})
+
+			rstore, err := kind.newStore(rd.path)
+			if err == nil {
+				_, err = rstore.Bootstrap(ctx, rd.name, rd.path, scope, scopeID, true)
+			}
+			done := int(completed.Add(1))
+			if err != nil {
+				s.templateLog.Warn(kind.noun+" import: failed to import resource, skipping",
+					"name", rd.name, "error", err)
+				failedSlots[i] = rd.name
+				emit(progress, ResourceImportEvent{
+					Type: ImportEventFailed, Name: rd.name, Reason: err.Error(),
+					Completed: done, Total: total,
+				})
+				return nil
+			}
+			importedSlots[i] = rd.name
 			emit(progress, ResourceImportEvent{
-				Type: ImportEventFailed, Name: rd.name, Reason: err.Error(),
-				Completed: completed, Total: total,
+				Type: ImportEventCompleted, Name: rd.name,
+				Completed: done, Total: total,
 			})
-			continue
-		}
-		imported = append(imported, rd.name)
-		emit(progress, ResourceImportEvent{
-			Type: ImportEventCompleted, Name: rd.name,
-			Completed: completed, Total: total,
+			return nil
 		})
 	}
+	_ = g.Wait()
+
+	imported := compactNames(importedSlots)
+	failed := compactNames(failedSlots)
 
 	emit(progress, ResourceImportEvent{
 		Type: ImportEventDone, Imported: imported, Skipped: skippedNames, Failed: failed,
 	})
 	return imported
+}
+
+// compactNames returns the non-empty entries of slots, preserving order. The
+// parallel import loop writes each resource's name into its own slot (empty if
+// it took the other branch), so compacting yields the imported/failed lists in
+// discovery order.
+func compactNames(slots []string) []string {
+	out := make([]string, 0, len(slots))
+	for _, n := range slots {
+		if n != "" {
+			out = append(out, n)
+		}
+	}
+	return out
 }

--- a/pkg/hub/resource_import.go
+++ b/pkg/hub/resource_import.go
@@ -160,19 +160,24 @@ func (s *Server) importFromWorkspace(ctx context.Context, project *store.Project
 // GITHUB_TOKEN secret. The fallback applies to both resource kinds — closing the
 // gap where harness-config remote import previously skipped the secret fallback.
 // The caller owns the returned cache path and must remove it.
+//
+// projectID may be "" for global-scope (hub-level) imports, which have no project
+// to authenticate against; in that case the fetch is unauthenticated.
 func (s *Server) fetchRemoteForImport(ctx context.Context, projectID, sourceURL string) (string, error) {
 	var authToken string
 
-	// Prefer a GitHub App installation token if the project has one.
-	project, err := s.store.GetProject(ctx, projectID)
-	if err == nil && project != nil && project.GitHubInstallationID != nil {
-		if token, _, mintErr := s.MintGitHubAppTokenForProject(ctx, project); mintErr == nil && token != "" {
-			authToken = token
+	if projectID != "" {
+		// Prefer a GitHub App installation token if the project has one.
+		project, err := s.store.GetProject(ctx, projectID)
+		if err == nil && project != nil && project.GitHubInstallationID != nil {
+			if token, _, mintErr := s.MintGitHubAppTokenForProject(ctx, project); mintErr == nil && token != "" {
+				authToken = token
+			}
 		}
 	}
 
 	// Fall back to the project GITHUB_TOKEN secret if no App token was minted.
-	if authToken == "" {
+	if authToken == "" && projectID != "" {
 		if sb := s.GetSecretBackend(); sb != nil {
 			sec, secErr := sb.Get(ctx, "GITHUB_TOKEN", secret.ScopeProject, projectID)
 			if secErr == nil && sec != nil && sec.Value != "" {

--- a/pkg/hub/resource_import.go
+++ b/pkg/hub/resource_import.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/config/templateimport"
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// resource_import.go is the Phase-1 landing of the resource-import refactor: a
+// single kind-generic, source-generic import driver that sits *above* the
+// shared ResourceStore.Bootstrap and *replaces* the four near-identical
+// import*From{Remote,Workspace} functions that templates and harness-configs
+// used to carry separately.
+//
+// The per-kind quirks stay in small closures bundled in resourceImportKind
+// (which marker file identifies a resource directory, and which ResourceStore
+// persists it); everything else — remote fetch + auth, discovery, leaf-vs-parent
+// naming, the create-or-sync loop — is shared here.
+
+// resourceDir pairs a derived resource name with its on-disk directory.
+type resourceDir struct{ name, path string }
+
+// resourceImportKind bundles the per-kind knobs the shared import driver needs.
+// Construct one via Server.templateImportKind / Server.harnessConfigImportKind.
+type resourceImportKind struct {
+	// noun names the kind in log lines and "no scion <noun> found" errors
+	// (e.g. "templates", "harness-configs").
+	noun string
+	// isResourceDir reports whether a directory is a resource of this kind, by
+	// checking for the kind's marker file (scion-agent.yaml / config.yaml).
+	isResourceDir func(dir string) bool
+	// newStore builds the ResourceStore that persists a directory of this kind.
+	// For harness-configs this loads config.yaml to resolve the harness type, so
+	// it can fail; failures cause that directory to be skipped.
+	newStore func(dir string) (*ResourceStore, error)
+}
+
+// templateImportKind returns the import knobs for templates.
+func (s *Server) templateImportKind() resourceImportKind {
+	return resourceImportKind{
+		noun:          "templates",
+		isResourceDir: templateimport.IsScionTemplate,
+		newStore:      func(string) (*ResourceStore, error) { return s.templateStore(), nil },
+	}
+}
+
+// harnessConfigImportKind returns the import knobs for harness-configs.
+func (s *Server) harnessConfigImportKind() resourceImportKind {
+	return resourceImportKind{
+		noun:          "harness-configs",
+		isResourceDir: isHarnessConfigDir,
+		newStore: func(dir string) (*ResourceStore, error) {
+			hcDir, err := config.LoadHarnessConfigDir(dir)
+			if err != nil {
+				return nil, err
+			}
+			return s.harnessConfigStore(hcDir.Config.Harness), nil
+		},
+	}
+}
+
+// importFromRemote fetches a remote source URL, discovers resources of the given
+// kind within it, and create-or-syncs each into the store under the project
+// scope. Returns the names of all resources imported or updated.
+func (s *Server) importFromRemote(ctx context.Context, projectID, sourceURL, scope string, kind resourceImportKind) ([]string, error) {
+	if !config.IsRemoteURI(sourceURL) {
+		return nil, fmt.Errorf("source must be a remote URI (http://, https://, or rclone)")
+	}
+	if s.GetStorage() == nil {
+		return nil, fmt.Errorf("%s storage is not configured", kind.noun)
+	}
+
+	cachePath, err := s.fetchRemoteForImport(ctx, projectID, sourceURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch remote %s: %w", kind.noun, err)
+	}
+	defer func() { _ = os.RemoveAll(cachePath) }()
+
+	dirs, err := discoverResourceDirs(cachePath, sourceURL, kind.isResourceDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(dirs) == 0 {
+		return nil, fmt.Errorf("no scion %s found at %s", kind.noun, sourceURL)
+	}
+
+	return s.importResourceDirs(ctx, dirs, scope, projectID, kind), nil
+}
+
+// importFromWorkspace imports resources of the given kind from a path within the
+// project's workspace filesystem. workspacePath is relative to the project's
+// workspace root (e.g. "/.scion/templates").
+func (s *Server) importFromWorkspace(ctx context.Context, project *store.Project, workspacePath, scope string, kind resourceImportKind) ([]string, error) {
+	if s.GetStorage() == nil {
+		return nil, fmt.Errorf("%s storage is not configured", kind.noun)
+	}
+
+	// Resolve the project's workspace root on disk.
+	projectRoot, err := s.resolveProjectWebDAVPath(ctx, project)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve project workspace: %w", err)
+	}
+
+	// Clean and join the workspace path to the project root. Strip the leading
+	// slash so it joins relative to the root.
+	rel := strings.TrimPrefix(filepath.Clean(workspacePath), "/")
+	resourcesDir := filepath.Join(projectRoot, rel)
+
+	// Validate the resolved path is within the project root.
+	absRoot, _ := filepath.Abs(projectRoot)
+	absDir, _ := filepath.Abs(resourcesDir)
+	relPath, err := filepath.Rel(absRoot, absDir)
+	if err != nil || strings.HasPrefix(relPath, "..") {
+		return nil, fmt.Errorf("workspace path must be within the project workspace")
+	}
+
+	info, err := os.Stat(resourcesDir)
+	if err != nil || !info.IsDir() {
+		return nil, fmt.Errorf("workspace path not found or not a directory: %s", workspacePath)
+	}
+
+	// Workspace dirs are real directories, so pass "" as sourceURL: the leaf's
+	// own base name is correct (no content-hash cache directory in play).
+	dirs, err := discoverResourceDirs(resourcesDir, "", kind.isResourceDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(dirs) == 0 {
+		return nil, fmt.Errorf("no scion %s found at workspace path %s", kind.noun, workspacePath)
+	}
+
+	return s.importResourceDirs(ctx, dirs, scope, project.ID, kind), nil
+}
+
+// fetchRemoteForImport fetches a remote source URL to a local cache directory,
+// authenticating against GitHub when possible. It first tries a GitHub App
+// installation token for the project, then falls back to the project's
+// GITHUB_TOKEN secret. The fallback applies to both resource kinds — closing the
+// gap where harness-config remote import previously skipped the secret fallback.
+// The caller owns the returned cache path and must remove it.
+func (s *Server) fetchRemoteForImport(ctx context.Context, projectID, sourceURL string) (string, error) {
+	var authToken string
+
+	// Prefer a GitHub App installation token if the project has one.
+	project, err := s.store.GetProject(ctx, projectID)
+	if err == nil && project != nil && project.GitHubInstallationID != nil {
+		if token, _, mintErr := s.MintGitHubAppTokenForProject(ctx, project); mintErr == nil && token != "" {
+			authToken = token
+		}
+	}
+
+	// Fall back to the project GITHUB_TOKEN secret if no App token was minted.
+	if authToken == "" {
+		if sb := s.GetSecretBackend(); sb != nil {
+			sec, secErr := sb.Get(ctx, "GITHUB_TOKEN", secret.ScopeProject, projectID)
+			if secErr == nil && sec != nil && sec.Value != "" {
+				authToken = sec.Value
+				s.templateLog.Info("using project GITHUB_TOKEN for resource import", "projectID", projectID)
+			} else if secErr != nil && !errors.Is(secErr, store.ErrNotFound) {
+				s.templateLog.Warn("Failed to retrieve GITHUB_TOKEN from secret backend", "projectID", projectID, "error", secErr)
+			}
+		}
+	}
+
+	return config.FetchRemoteTemplate(ctx, sourceURL, authToken)
+}
+
+// discoverResourceDirs returns the resource directories at root, classifying by
+// the kind's marker file (via isResourceDir). It owns both the leaf-vs-parent
+// decision and per-branch naming:
+//
+//   - Leaf: root itself is a resource. Its name comes from the source URL's leaf
+//     segment when sourceURL is set (the remote cache dir is a content hash, so
+//     filepath.Base(root) would be the hash); for workspace imports pass
+//     sourceURL == "" so the real directory's base name is used.
+//   - Parent: root's immediate children are scanned; each child that is a
+//     resource is named by its own directory name. Children without the marker
+//     file are skipped.
+func discoverResourceDirs(root, sourceURL string, isResourceDir func(string) bool) ([]resourceDir, error) {
+	if isResourceDir(root) {
+		name := filepath.Base(root)
+		if sourceURL != "" {
+			if derived := config.DeriveResourceName(sourceURL); derived != "" {
+				name = derived
+			}
+		}
+		return []resourceDir{{name, root}}, nil
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+	var dirs []resourceDir
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dir := filepath.Join(root, entry.Name())
+		if isResourceDir(dir) {
+			dirs = append(dirs, resourceDir{entry.Name(), dir})
+		}
+	}
+	return dirs, nil
+}
+
+// importResourceDirs create-or-syncs each discovered directory into the store
+// under the given scope. Directories that fail to build a store (e.g. an
+// unreadable harness config.yaml) or fail to import are logged and skipped.
+// Returns the names successfully imported or updated.
+//
+// Each directory is force-synced (force=true): a re-import always re-uploads and
+// reconciles storage, matching the prior direct-import behavior. For a
+// not-yet-existing resource the force flag is irrelevant — Bootstrap creates it.
+func (s *Server) importResourceDirs(ctx context.Context, dirs []resourceDir, scope, scopeID string, kind resourceImportKind) []string {
+	var imported []string
+	for _, rd := range dirs {
+		rstore, err := kind.newStore(rd.path)
+		if err != nil {
+			s.templateLog.Warn(kind.noun+" import: failed to load resource, skipping",
+				"name", rd.name, "error", err)
+			continue
+		}
+		if _, err := rstore.Bootstrap(ctx, rd.name, rd.path, scope, scopeID, true); err != nil {
+			s.templateLog.Warn(kind.noun+" import: failed to import resource, skipping",
+				"name", rd.name, "error", err)
+			continue
+		}
+		imported = append(imported, rd.name)
+	}
+	return imported
+}

--- a/pkg/hub/resource_import.go
+++ b/pkg/hub/resource_import.go
@@ -42,12 +42,82 @@ import (
 // resourceDir pairs a derived resource name with its on-disk directory.
 type resourceDir struct{ name, path string }
 
+// skippedDir pairs a child directory name with the reason it was skipped during
+// discovery (e.g. it lacks the kind's marker file, so it is not a resource).
+type skippedDir struct{ name, reason string }
+
+// ResourceImportEventType enumerates the lifecycle events emitted during an
+// import (see ResourceImportEvent).
+type ResourceImportEventType string
+
+const (
+	// ImportEventDiscovered is emitted once after discovery with the total count
+	// and the names of all resources that will be imported.
+	ImportEventDiscovered ResourceImportEventType = "discovered"
+	// ImportEventStarted is emitted when a worker begins importing a resource.
+	ImportEventStarted ResourceImportEventType = "started"
+	// ImportEventCompleted is emitted when a resource finishes importing.
+	ImportEventCompleted ResourceImportEventType = "completed"
+	// ImportEventFailed is emitted when a discovered resource fails to import.
+	ImportEventFailed ResourceImportEventType = "failed"
+	// ImportEventSkipped is emitted for a child folder that is not a resource of
+	// the kind (no marker file); these do not count toward the total.
+	ImportEventSkipped ResourceImportEventType = "skipped"
+	// ImportEventDone is the final event carrying the imported/skipped/failed
+	// name lists.
+	ImportEventDone ResourceImportEventType = "done"
+	// ImportEventError is emitted when the import fails before reaching the
+	// per-resource phase (e.g. fetch failure, nothing found). Carries Reason.
+	ImportEventError ResourceImportEventType = "error"
+)
+
+// ResourceImportEvent is one progress event emitted during a resource import.
+// Events are serialized to NDJSON on the streaming import endpoints; the field
+// set used depends on Type (see the constants above).
+type ResourceImportEvent struct {
+	Type ResourceImportEventType `json:"type"`
+	// Name is the resource (or skipped folder) the event concerns; unset on
+	// discovered/done/error.
+	Name string `json:"name,omitempty"`
+	// Reason carries the failure/skip explanation on failed/skipped/error.
+	Reason string `json:"reason,omitempty"`
+	// Completed is the monotonic count of finished resources (any terminal
+	// status) at the time of the event; set on completed/failed.
+	Completed int `json:"completed,omitempty"`
+	// Total is the number of resources to import (excludes skipped folders); set
+	// on discovered/completed/failed.
+	Total int `json:"total,omitempty"`
+	// Names lists the resources to import; set on discovered.
+	Names []string `json:"names,omitempty"`
+	// Imported/Skipped/Failed are the final name lists; set on done.
+	Imported []string `json:"imported,omitempty"`
+	Skipped  []string `json:"skipped,omitempty"`
+	Failed   []string `json:"failed,omitempty"`
+}
+
+// importProgressFunc receives import progress events. It may be nil (the
+// non-streaming JSON callers pass nil and rely on the returned name slice).
+// Implementations must be safe to call from multiple goroutines, since the
+// per-resource loop may run concurrently (the streaming handler serializes
+// writes through a mutex).
+type importProgressFunc func(ResourceImportEvent)
+
+// emit invokes progress if it is non-nil.
+func emit(progress importProgressFunc, ev ResourceImportEvent) {
+	if progress != nil {
+		progress(ev)
+	}
+}
+
 // resourceImportKind bundles the per-kind knobs the shared import driver needs.
 // Construct one via Server.templateImportKind / Server.harnessConfigImportKind.
 type resourceImportKind struct {
 	// noun names the kind in log lines and "no scion <noun> found" errors
 	// (e.g. "templates", "harness-configs").
 	noun string
+	// marker names the kind's marker file (scion-agent.yaml / config.yaml); used
+	// in skipped-folder reasons.
+	marker string
 	// isResourceDir reports whether a directory is a resource of this kind, by
 	// checking for the kind's marker file (scion-agent.yaml / config.yaml).
 	isResourceDir func(dir string) bool
@@ -61,6 +131,7 @@ type resourceImportKind struct {
 func (s *Server) templateImportKind() resourceImportKind {
 	return resourceImportKind{
 		noun:          "templates",
+		marker:        "scion-agent.yaml",
 		isResourceDir: templateimport.IsScionTemplate,
 		newStore:      func(string) (*ResourceStore, error) { return s.templateStore(), nil },
 	}
@@ -70,6 +141,7 @@ func (s *Server) templateImportKind() resourceImportKind {
 func (s *Server) harnessConfigImportKind() resourceImportKind {
 	return resourceImportKind{
 		noun:          "harness-configs",
+		marker:        "config.yaml",
 		isResourceDir: isHarnessConfigDir,
 		newStore: func(dir string) (*ResourceStore, error) {
 			hcDir, err := config.LoadHarnessConfigDir(dir)
@@ -83,8 +155,9 @@ func (s *Server) harnessConfigImportKind() resourceImportKind {
 
 // importFromRemote fetches a remote source URL, discovers resources of the given
 // kind within it, and create-or-syncs each into the store under the project
-// scope. Returns the names of all resources imported or updated.
-func (s *Server) importFromRemote(ctx context.Context, projectID, sourceURL, scope string, kind resourceImportKind) ([]string, error) {
+// scope. Returns the names of all resources imported or updated. When progress
+// is non-nil, lifecycle events are emitted as the import proceeds.
+func (s *Server) importFromRemote(ctx context.Context, projectID, sourceURL, scope string, kind resourceImportKind, progress importProgressFunc) ([]string, error) {
 	if !config.IsRemoteURI(sourceURL) {
 		return nil, fmt.Errorf("source must be a remote URI (http://, https://, or rclone)")
 	}
@@ -98,7 +171,7 @@ func (s *Server) importFromRemote(ctx context.Context, projectID, sourceURL, sco
 	}
 	defer func() { _ = os.RemoveAll(cachePath) }()
 
-	dirs, err := discoverResourceDirs(cachePath, sourceURL, kind.isResourceDir)
+	dirs, skipped, err := discoverResourceDirs(cachePath, sourceURL, kind)
 	if err != nil {
 		return nil, err
 	}
@@ -106,13 +179,14 @@ func (s *Server) importFromRemote(ctx context.Context, projectID, sourceURL, sco
 		return nil, fmt.Errorf("no scion %s found at %s", kind.noun, sourceURL)
 	}
 
-	return s.importResourceDirs(ctx, dirs, scope, projectID, kind), nil
+	return s.importResourceDirs(ctx, dirs, skipped, scope, projectID, kind, progress), nil
 }
 
 // importFromWorkspace imports resources of the given kind from a path within the
 // project's workspace filesystem. workspacePath is relative to the project's
-// workspace root (e.g. "/.scion/templates").
-func (s *Server) importFromWorkspace(ctx context.Context, project *store.Project, workspacePath, scope string, kind resourceImportKind) ([]string, error) {
+// workspace root (e.g. "/.scion/templates"). When progress is non-nil,
+// lifecycle events are emitted as the import proceeds.
+func (s *Server) importFromWorkspace(ctx context.Context, project *store.Project, workspacePath, scope string, kind resourceImportKind, progress importProgressFunc) ([]string, error) {
 	if s.GetStorage() == nil {
 		return nil, fmt.Errorf("%s storage is not configured", kind.noun)
 	}
@@ -143,7 +217,7 @@ func (s *Server) importFromWorkspace(ctx context.Context, project *store.Project
 
 	// Workspace dirs are real directories, so pass "" as sourceURL: the leaf's
 	// own base name is correct (no content-hash cache directory in play).
-	dirs, err := discoverResourceDirs(resourcesDir, "", kind.isResourceDir)
+	dirs, skipped, err := discoverResourceDirs(resourcesDir, "", kind)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +225,7 @@ func (s *Server) importFromWorkspace(ctx context.Context, project *store.Project
 		return nil, fmt.Errorf("no scion %s found at workspace path %s", kind.noun, workspacePath)
 	}
 
-	return s.importResourceDirs(ctx, dirs, scope, project.ID, kind), nil
+	return s.importResourceDirs(ctx, dirs, skipped, scope, project.ID, kind, progress), nil
 }
 
 // fetchRemoteForImport fetches a remote source URL to a local cache directory,
@@ -202,58 +276,96 @@ func (s *Server) fetchRemoteForImport(ctx context.Context, projectID, sourceURL 
 //     sourceURL == "" so the real directory's base name is used.
 //   - Parent: root's immediate children are scanned; each child that is a
 //     resource is named by its own directory name. Children without the marker
-//     file are skipped.
-func discoverResourceDirs(root, sourceURL string, isResourceDir func(string) bool) ([]resourceDir, error) {
-	if isResourceDir(root) {
+//     file are returned as skipped (reported to the user) rather than imported.
+func discoverResourceDirs(root, sourceURL string, kind resourceImportKind) ([]resourceDir, []skippedDir, error) {
+	if kind.isResourceDir(root) {
 		name := filepath.Base(root)
 		if sourceURL != "" {
 			if derived := config.DeriveResourceName(sourceURL); derived != "" {
 				name = derived
 			}
 		}
-		return []resourceDir{{name, root}}, nil
+		return []resourceDir{{name, root}}, nil, nil
 	}
 
 	entries, err := os.ReadDir(root)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var dirs []resourceDir
+	var skipped []skippedDir
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
 		dir := filepath.Join(root, entry.Name())
-		if isResourceDir(dir) {
+		if kind.isResourceDir(dir) {
 			dirs = append(dirs, resourceDir{entry.Name(), dir})
+		} else {
+			skipped = append(skipped, skippedDir{entry.Name(), "no " + kind.marker})
 		}
 	}
-	return dirs, nil
+	return dirs, skipped, nil
 }
 
 // importResourceDirs create-or-syncs each discovered directory into the store
-// under the given scope. Directories that fail to build a store (e.g. an
-// unreadable harness config.yaml) or fail to import are logged and skipped.
-// Returns the names successfully imported or updated.
+// under the given scope, emitting progress events. Directories that fail to
+// build a store (e.g. an unreadable harness config.yaml) or fail to import are
+// logged and reported as failed; child folders lacking the marker file
+// (skippedDirs from discovery) are reported as skipped. Returns the names
+// successfully imported or updated.
 //
 // Each directory is force-synced (force=true): a re-import always re-uploads and
 // reconciles storage, matching the prior direct-import behavior. For a
 // not-yet-existing resource the force flag is irrelevant — Bootstrap creates it.
-func (s *Server) importResourceDirs(ctx context.Context, dirs []resourceDir, scope, scopeID string, kind resourceImportKind) []string {
-	var imported []string
+//
+// The progress model separates the aggregate (a monotonic completed counter over
+// total) from per-item detail so it stays correct once the loop is parallelized
+// (Phase 4): completed is assigned as each item finishes, independent of order.
+func (s *Server) importResourceDirs(ctx context.Context, dirs []resourceDir, skipped []skippedDir, scope, scopeID string, kind resourceImportKind, progress importProgressFunc) []string {
+	total := len(dirs)
+	names := make([]string, 0, total)
 	for _, rd := range dirs {
+		names = append(names, rd.name)
+	}
+	emit(progress, ResourceImportEvent{Type: ImportEventDiscovered, Total: total, Names: names})
+
+	skippedNames := make([]string, 0, len(skipped))
+	for _, sd := range skipped {
+		skippedNames = append(skippedNames, sd.name)
+		emit(progress, ResourceImportEvent{Type: ImportEventSkipped, Name: sd.name, Reason: sd.reason})
+	}
+
+	var imported []string
+	var failed []string
+	completed := 0
+	for _, rd := range dirs {
+		emit(progress, ResourceImportEvent{Type: ImportEventStarted, Name: rd.name})
+
 		rstore, err := kind.newStore(rd.path)
-		if err != nil {
-			s.templateLog.Warn(kind.noun+" import: failed to load resource, skipping",
-				"name", rd.name, "error", err)
-			continue
+		if err == nil {
+			_, err = rstore.Bootstrap(ctx, rd.name, rd.path, scope, scopeID, true)
 		}
-		if _, err := rstore.Bootstrap(ctx, rd.name, rd.path, scope, scopeID, true); err != nil {
+		completed++
+		if err != nil {
 			s.templateLog.Warn(kind.noun+" import: failed to import resource, skipping",
 				"name", rd.name, "error", err)
+			failed = append(failed, rd.name)
+			emit(progress, ResourceImportEvent{
+				Type: ImportEventFailed, Name: rd.name, Reason: err.Error(),
+				Completed: completed, Total: total,
+			})
 			continue
 		}
 		imported = append(imported, rd.name)
+		emit(progress, ResourceImportEvent{
+			Type: ImportEventCompleted, Name: rd.name,
+			Completed: completed, Total: total,
+		})
 	}
+
+	emit(progress, ResourceImportEvent{
+		Type: ImportEventDone, Imported: imported, Skipped: skippedNames, Failed: failed,
+	})
 	return imported
 }

--- a/pkg/hub/resource_import.go
+++ b/pkg/hub/resource_import.go
@@ -309,6 +309,12 @@ func discoverResourceDirs(root, sourceURL string, kind resourceImportKind) ([]re
 		if !entry.IsDir() {
 			continue
 		}
+		// Skip hidden/system directories (e.g. .git, .github, .scion). These are
+		// never resources and reporting them as "skipped (no marker)" would be
+		// noise, so drop them silently.
+		if strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
 		dir := filepath.Join(root, entry.Name())
 		if kind.isResourceDir(dir) {
 			dirs = append(dirs, resourceDir{entry.Name(), dir})
@@ -364,6 +370,19 @@ func (s *Server) importResourceDirs(ctx context.Context, dirs []resourceDir, ski
 	for i, rd := range dirs {
 		i, rd := i, rd
 		g.Go(func() error {
+			// Stop starting new imports once the request is cancelled (e.g. the
+			// client disconnected mid-stream); report the rest as failed so the
+			// completed counter still reaches total.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				done := int(completed.Add(1))
+				failedSlots[i] = rd.name
+				emit(progress, ResourceImportEvent{
+					Type: ImportEventFailed, Name: rd.name, Reason: ctxErr.Error(),
+					Completed: done, Total: total,
+				})
+				return nil
+			}
+
 			emit(progress, ResourceImportEvent{Type: ImportEventStarted, Name: rd.name})
 
 			rstore, err := kind.newStore(rd.path)

--- a/pkg/hub/resource_import_handler_test.go
+++ b/pkg/hub/resource_import_handler_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// mockTemplateTarball installs a mock HTTP transport that serves a gzip tarball
+// containing a single template under templates/my-template, and returns a
+// cleanup func that restores the previous transport. It must not be used with
+// t.Parallel() (it mutates http.DefaultClient.Transport globally).
+func mockTemplateTarball(t *testing.T) func() {
+	t.Helper()
+	old := http.DefaultClient.Transport
+	http.DefaultClient.Transport = &mockRoundTripper{
+		roundTrip: func(req *http.Request) (*http.Response, error) {
+			var buf bytes.Buffer
+			gzw := gzip.NewWriter(&buf)
+			tw := tar.NewWriter(gzw)
+			files := map[string]string{
+				"repo-main/templates/my-template/scion-agent.yaml": "schema_version: \"1\"\nharness: claude\n",
+				"repo-main/templates/my-template/README.md":        "hello",
+			}
+			for name, body := range files {
+				if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0600, Size: int64(len(body))}); err != nil {
+					return nil, err
+				}
+				if _, err := tw.Write([]byte(body)); err != nil {
+					return nil, err
+				}
+			}
+			if err := tw.Close(); err != nil {
+				return nil, err
+			}
+			if err := gzw.Close(); err != nil {
+				return nil, err
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(buf.Bytes()))}, nil
+		},
+	}
+	return func() { http.DefaultClient.Transport = old }
+}
+
+// TestHandleResourcesImport_GlobalAsAdmin verifies an admin can import a
+// global-scoped template via the unified endpoint and that it lands in the
+// store with global scope.
+func TestHandleResourcesImport_GlobalAsAdmin(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	admin := &store.User{ID: "user-admin", Email: "admin@test.com", DisplayName: "Admin", Role: store.UserRoleAdmin}
+	if err := s.CreateUser(ctx, admin); err != nil {
+		t.Fatal(err)
+	}
+	ensureHubMembership(ctx, s, admin.ID)
+
+	defer mockTemplateTarball(t)()
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, "/api/v1/resources/import", ImportResourcesRequest{
+		Kind:      "template",
+		Scope:     "global",
+		SourceURL: "https://github.com/acme/repo/tree/main/templates",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp ImportResourcesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Count != 1 || len(resp.Imported) != 1 || resp.Imported[0] != "my-template" {
+		t.Fatalf("expected [my-template], got %+v", resp)
+	}
+
+	result, err := s.ListTemplates(ctx, store.TemplateFilter{Scope: store.TemplateScopeGlobal}, store.ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TotalCount != 1 {
+		t.Fatalf("expected 1 global template, got %d", result.TotalCount)
+	}
+	if result.Items[0].Scope != store.TemplateScopeGlobal {
+		t.Errorf("expected global scope, got %q", result.Items[0].Scope)
+	}
+}
+
+// TestHandleResourcesImport_GlobalForbiddenForMember verifies a non-admin user
+// cannot import global resources.
+func TestHandleResourcesImport_GlobalForbiddenForMember(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	member := &store.User{ID: "user-member", Email: "member@test.com", DisplayName: "Member", Role: store.UserRoleMember}
+	if err := s.CreateUser(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+	ensureHubMembership(ctx, s, member.ID)
+
+	rec := doRequestAsUser(t, srv, member, http.MethodPost, "/api/v1/resources/import", ImportResourcesRequest{
+		Kind:      "template",
+		Scope:     "global",
+		SourceURL: "https://github.com/acme/repo/tree/main/templates",
+	})
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	result, err := s.ListTemplates(ctx, store.TemplateFilter{Scope: store.TemplateScopeGlobal}, store.ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TotalCount != 0 {
+		t.Fatalf("expected no templates imported, got %d", result.TotalCount)
+	}
+}
+
+// TestHandleResourcesImport_InvalidKind verifies an unknown kind is rejected.
+func TestHandleResourcesImport_InvalidKind(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	admin := &store.User{ID: "user-admin", Email: "admin@test.com", DisplayName: "Admin", Role: store.UserRoleAdmin}
+	if err := s.CreateUser(ctx, admin); err != nil {
+		t.Fatal(err)
+	}
+	ensureHubMembership(ctx, s, admin.ID)
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, "/api/v1/resources/import", ImportResourcesRequest{
+		Kind:      "not-a-kind",
+		Scope:     "global",
+		SourceURL: "https://github.com/acme/repo/tree/main/templates",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleResourcesImport_MissingSourceURL verifies sourceUrl is required.
+func TestHandleResourcesImport_MissingSourceURL(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	admin := &store.User{ID: "user-admin", Email: "admin@test.com", DisplayName: "Admin", Role: store.UserRoleAdmin}
+	if err := s.CreateUser(ctx, admin); err != nil {
+		t.Fatal(err)
+	}
+	ensureHubMembership(ctx, s, admin.ID)
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, "/api/v1/resources/import", ImportResourcesRequest{
+		Kind:  "template",
+		Scope: "global",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/pkg/hub/resource_import_handler_test.go
+++ b/pkg/hub/resource_import_handler_test.go
@@ -22,6 +22,8 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
@@ -104,6 +106,178 @@ func TestHandleResourcesImport_GlobalAsAdmin(t *testing.T) {
 	}
 	if result.Items[0].Scope != store.TemplateScopeGlobal {
 		t.Errorf("expected global scope, got %q", result.Items[0].Scope)
+	}
+}
+
+// doStreamRequestAsUser issues a request as user with Accept:
+// application/x-ndjson so the import endpoint streams progress events, and
+// returns the recorder for parsing.
+func doStreamRequestAsUser(t *testing.T, srv *Server, user *store.User, method, path string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+
+	token, _, _, err := srv.userTokenService.GenerateTokenPair(
+		user.ID, user.Email, user.DisplayName, user.Role, ClientTypeWeb,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var bodyBytes []byte
+	if body != nil {
+		bodyBytes, err = json.Marshal(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	req := httptest.NewRequest(method, path, bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/x-ndjson")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+// parseImportEvents splits an NDJSON body into ResourceImportEvents.
+func parseImportEvents(t *testing.T, body string) []ResourceImportEvent {
+	t.Helper()
+	var events []ResourceImportEvent
+	for _, line := range strings.Split(strings.TrimSpace(body), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var ev ResourceImportEvent
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("failed to parse event line %q: %v", line, err)
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+// TestHandleResourcesImport_StreamsProgress verifies the unified endpoint emits
+// NDJSON progress events (discovered → started → completed → done) when the
+// client opts in via Accept: application/x-ndjson.
+func TestHandleResourcesImport_StreamsProgress(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	admin := &store.User{ID: "user-admin", Email: "admin@test.com", DisplayName: "Admin", Role: store.UserRoleAdmin}
+	if err := s.CreateUser(ctx, admin); err != nil {
+		t.Fatal(err)
+	}
+	ensureHubMembership(ctx, s, admin.ID)
+
+	defer mockTemplateTarball(t)()
+
+	rec := doStreamRequestAsUser(t, srv, admin, http.MethodPost, "/api/v1/resources/import", ImportResourcesRequest{
+		Kind:      "template",
+		Scope:     "global",
+		SourceURL: "https://github.com/acme/repo/tree/main/templates",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/x-ndjson") {
+		t.Fatalf("expected NDJSON content type, got %q", ct)
+	}
+
+	events := parseImportEvents(t, rec.Body.String())
+	if len(events) == 0 {
+		t.Fatal("expected progress events, got none")
+	}
+
+	var discovered, done *ResourceImportEvent
+	var completedNames []string
+	for i := range events {
+		switch events[i].Type {
+		case ImportEventDiscovered:
+			discovered = &events[i]
+		case ImportEventCompleted:
+			completedNames = append(completedNames, events[i].Name)
+		case ImportEventError:
+			t.Fatalf("unexpected error event: %s", events[i].Reason)
+		case ImportEventDone:
+			done = &events[i]
+		}
+	}
+
+	if discovered == nil {
+		t.Fatal("missing discovered event")
+	}
+	if discovered.Total != 1 || len(discovered.Names) != 1 || discovered.Names[0] != "my-template" {
+		t.Fatalf("unexpected discovered event: %+v", discovered)
+	}
+	if len(completedNames) != 1 || completedNames[0] != "my-template" {
+		t.Fatalf("expected my-template completed, got %v", completedNames)
+	}
+	if done == nil {
+		t.Fatal("missing done event")
+	}
+	if len(done.Imported) != 1 || done.Imported[0] != "my-template" {
+		t.Fatalf("unexpected done summary: %+v", done)
+	}
+
+	// The import still lands in the store.
+	result, err := s.ListTemplates(ctx, store.TemplateFilter{Scope: store.TemplateScopeGlobal}, store.ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TotalCount != 1 {
+		t.Fatalf("expected 1 global template, got %d", result.TotalCount)
+	}
+}
+
+// TestHandleResourcesImport_StreamErrorEvent verifies that a failure reached
+// after the stream has started (here: nothing found at the URL) is reported as
+// an in-band error event rather than an HTTP error status.
+func TestHandleResourcesImport_StreamErrorEvent(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	admin := &store.User{ID: "user-admin", Email: "admin@test.com", DisplayName: "Admin", Role: store.UserRoleAdmin}
+	if err := s.CreateUser(ctx, admin); err != nil {
+		t.Fatal(err)
+	}
+	ensureHubMembership(ctx, s, admin.ID)
+
+	// Serve an empty tarball: no resource dirs are discovered.
+	old := http.DefaultClient.Transport
+	http.DefaultClient.Transport = &mockRoundTripper{
+		roundTrip: func(req *http.Request) (*http.Response, error) {
+			var buf bytes.Buffer
+			gzw := gzip.NewWriter(&buf)
+			tw := tar.NewWriter(gzw)
+			_ = tw.WriteHeader(&tar.Header{Name: "repo-main/", Mode: 0700, Typeflag: tar.TypeDir})
+			_ = tw.Close()
+			_ = gzw.Close()
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(buf.Bytes()))}, nil
+		},
+	}
+	defer func() { http.DefaultClient.Transport = old }()
+
+	rec := doStreamRequestAsUser(t, srv, admin, http.MethodPost, "/api/v1/resources/import", ImportResourcesRequest{
+		Kind:      "template",
+		Scope:     "global",
+		SourceURL: "https://github.com/acme/repo/tree/main/templates",
+	})
+	// Stream already committed a 200; the failure surfaces as an error event.
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 (stream started), got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	events := parseImportEvents(t, rec.Body.String())
+	var sawError bool
+	for _, ev := range events {
+		if ev.Type == ImportEventError {
+			sawError = true
+		}
+	}
+	if !sawError {
+		t.Fatalf("expected an error event, got events: %+v", events)
 	}
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2045,6 +2045,9 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/harness-configs", s.handleHarnessConfigs)
 	s.mux.HandleFunc("/api/v1/harness-configs/", s.handleHarnessConfigByID)
 
+	// Unified, kind/scope-generic resource import (templates + harness-configs).
+	s.mux.HandleFunc("/api/v1/resources/import", s.handleResourcesImport)
+
 	s.mux.HandleFunc("/api/v1/users", s.handleUsers)
 	s.mux.HandleFunc("/api/v1/users/", s.handleUserByID)
 

--- a/pkg/hub/storage_helpers.go
+++ b/pkg/hub/storage_helpers.go
@@ -151,6 +151,15 @@ func uploadResourceFiles(ctx context.Context, stor storage.Storage, storagePath 
 	for i, fi := range files {
 		i, fi := i, fi
 		g.Go(func() error {
+			// Abort early if the group's context is already cancelled — either the
+			// request was cancelled (client disconnected) or a sibling upload
+			// failed. Returning the error keeps the fail-fast contract: a cancelled
+			// upload must not produce a partial manifest. (g.Wait reports the first
+			// error, so the original upload failure still wins over this Canceled.)
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
 			objectPath := storagePath + "/" + fi.Path
 
 			f, err := os.Open(fi.FullPath)

--- a/pkg/hub/storage_helpers.go
+++ b/pkg/hub/storage_helpers.go
@@ -23,10 +23,20 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/GoogleCloudPlatform/scion/pkg/transfer"
 )
+
+// fileUploadConcurrency bounds how many of a resource's files upload at once
+// (Phase 4). Storage backends (GCS / local FS) are safe for concurrent uploads
+// to distinct object paths, so this is the only cap; a small bound keeps a
+// single large resource fast without overwhelming the backend. Combined with the
+// per-resource pool (resourceImportConcurrency) the worst-case concurrent upload
+// count stays modest for the ≤~dozen-item imports this serves.
+const fileUploadConcurrency = 8
 
 // generateUploadURLs generates signed PUT URLs for a list of files under basePath.
 // Returns the upload URL infos, a manifest URL (if possible), and any error.
@@ -123,30 +133,58 @@ func toResourceFiles(files []transfer.FileInfo) []store.TemplateFile {
 // This is shared bootstrap mechanics for the resource-storage refactor (§7.3):
 // templates and harness-configs both route their import/sync upload loop through
 // it, and it is the basis for a future ResourceStore.Bootstrap.
+//
+// Uploads run concurrently with a bounded worker pool (fileUploadConcurrency,
+// Phase 4) since each file is an independent object; errgroup.WithContext
+// cancels the in-flight uploads as soon as one fails, preserving the fail-fast
+// contract above. Each worker writes its result into its own slot, so the
+// returned manifest preserves input order without locking.
 func uploadResourceFiles(ctx context.Context, stor storage.Storage, storagePath string, files []transfer.FileInfo, label string) ([]store.TemplateFile, map[string]struct{}, error) {
-	var uploaded []store.TemplateFile
-	written := make(map[string]struct{}, len(files))
-	for _, fi := range files {
-		objectPath := storagePath + "/" + fi.Path
+	type uploadResult struct {
+		file       store.TemplateFile
+		objectPath string
+	}
+	results := make([]uploadResult, len(files))
 
-		f, err := os.Open(fi.FullPath)
-		if err != nil {
-			return nil, nil, fmt.Errorf("%s: failed to open file %s: %w", label, fi.Path, err)
-		}
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(fileUploadConcurrency)
+	for i, fi := range files {
+		i, fi := i, fi
+		g.Go(func() error {
+			objectPath := storagePath + "/" + fi.Path
 
-		_, err = stor.Upload(ctx, objectPath, f, storage.UploadOptions{})
-		_ = f.Close()
-		if err != nil {
-			return nil, nil, fmt.Errorf("%s: failed to upload file %s: %w", label, fi.Path, err)
-		}
+			f, err := os.Open(fi.FullPath)
+			if err != nil {
+				return fmt.Errorf("%s: failed to open file %s: %w", label, fi.Path, err)
+			}
 
-		uploaded = append(uploaded, store.TemplateFile{
-			Path: fi.Path,
-			Size: fi.Size,
-			Hash: fi.Hash,
-			Mode: fi.Mode,
+			_, err = stor.Upload(ctx, objectPath, f, storage.UploadOptions{})
+			_ = f.Close()
+			if err != nil {
+				return fmt.Errorf("%s: failed to upload file %s: %w", label, fi.Path, err)
+			}
+
+			results[i] = uploadResult{
+				file: store.TemplateFile{
+					Path: fi.Path,
+					Size: fi.Size,
+					Hash: fi.Hash,
+					Mode: fi.Mode,
+				},
+				objectPath: objectPath,
+			}
+			return nil
 		})
-		written[objectPath] = struct{}{}
+	}
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
+	}
+
+	uploaded := make([]store.TemplateFile, 0, len(files))
+	written := make(map[string]struct{}, len(files))
+	for _, r := range results {
+		uploaded = append(uploaded, r.file)
+		written[r.objectPath] = struct{}{}
 	}
 	return uploaded, written, nil
 }

--- a/pkg/hub/template_bootstrap.go
+++ b/pkg/hub/template_bootstrap.go
@@ -243,7 +243,7 @@ func (s *Server) importTemplateHarnessConfigs(ctx context.Context, templatePath,
 //
 // This is a thin wrapper over the shared import driver (resource_import.go).
 func (s *Server) importTemplatesFromRemote(ctx context.Context, projectID, sourceURL string) ([]string, error) {
-	return s.importFromRemote(ctx, projectID, sourceURL, store.TemplateScopeProject, s.templateImportKind())
+	return s.importFromRemote(ctx, projectID, sourceURL, store.TemplateScopeProject, s.templateImportKind(), nil)
 }
 
 // importTemplatesFromWorkspace imports templates from a path within the
@@ -252,5 +252,5 @@ func (s *Server) importTemplatesFromRemote(ctx context.Context, projectID, sourc
 //
 // This is a thin wrapper over the shared import driver (resource_import.go).
 func (s *Server) importTemplatesFromWorkspace(ctx context.Context, project *store.Project, workspacePath string) ([]string, error) {
-	return s.importFromWorkspace(ctx, project, workspacePath, store.TemplateScopeProject, s.templateImportKind())
+	return s.importFromWorkspace(ctx, project, workspacePath, store.TemplateScopeProject, s.templateImportKind(), nil)
 }

--- a/pkg/hub/template_bootstrap.go
+++ b/pkg/hub/template_bootstrap.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
@@ -200,42 +202,58 @@ func (s *Server) importTemplateHarnessConfigs(ctx context.Context, templatePath,
 		hcScope = store.HarnessConfigScopeProject
 	}
 
+	// Each bundled harness-config is an independent DB row + storage prefix, so
+	// import them concurrently with a bounded pool (Phase 4). This runs inside a
+	// per-resource import goroutine, so the bound is kept small to limit nesting.
+	var g errgroup.Group
+	g.SetLimit(bundledHarnessConfigConcurrency)
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
-		name := entry.Name()
-		dirPath := filepath.Join(hcDir, name)
-		slug := api.Slugify(name)
+		entry := entry
+		g.Go(func() error {
+			name := entry.Name()
+			dirPath := filepath.Join(hcDir, name)
+			slug := api.Slugify(name)
 
-		hcDirCfg, err := config.LoadHarnessConfigDir(dirPath)
-		if err != nil {
-			s.templateLog.Debug("template harness-config import: failed to load config, skipping",
-				"config", name, "error", err)
-			continue
-		}
-
-		existing, err := s.store.GetHarnessConfigBySlug(ctx, slug, hcScope, scopeID)
-		if err != nil && err != store.ErrNotFound {
-			continue
-		}
-
-		if existing == nil {
-			if err := s.bootstrapSingleHarnessConfigScoped(ctx, name, dirPath, hcDirCfg, stor, hcScope, scopeID); err != nil {
-				s.templateLog.Warn("template harness-config import: failed to import, skipping",
+			hcDirCfg, err := config.LoadHarnessConfigDir(dirPath)
+			if err != nil {
+				s.templateLog.Debug("template harness-config import: failed to load config, skipping",
 					"config", name, "error", err)
-				continue
+				return nil
 			}
-			s.templateLog.Info("template harness-config import: imported config",
-				"config", name, "harness", hcDirCfg.Config.Harness, "scope", hcScope)
-		} else {
-			if _, err := s.syncExistingHarnessConfig(ctx, existing, dirPath, hcDirCfg, stor, false); err != nil {
-				s.templateLog.Warn("template harness-config import: failed to sync, skipping",
-					"config", name, "error", err)
+
+			existing, err := s.store.GetHarnessConfigBySlug(ctx, slug, hcScope, scopeID)
+			if err != nil && err != store.ErrNotFound {
+				return nil
 			}
-		}
+
+			if existing == nil {
+				if err := s.bootstrapSingleHarnessConfigScoped(ctx, name, dirPath, hcDirCfg, stor, hcScope, scopeID); err != nil {
+					s.templateLog.Warn("template harness-config import: failed to import, skipping",
+						"config", name, "error", err)
+					return nil
+				}
+				s.templateLog.Info("template harness-config import: imported config",
+					"config", name, "harness", hcDirCfg.Config.Harness, "scope", hcScope)
+			} else {
+				if _, err := s.syncExistingHarnessConfig(ctx, existing, dirPath, hcDirCfg, stor, false); err != nil {
+					s.templateLog.Warn("template harness-config import: failed to sync, skipping",
+						"config", name, "error", err)
+				}
+			}
+			return nil
+		})
 	}
+	_ = g.Wait()
 }
+
+// bundledHarnessConfigConcurrency bounds how many harness-configs bundled inside
+// a template import in parallel (Phase 4). It is kept small because this loop
+// runs within a per-resource import goroutine (resourceImportConcurrency), so
+// the effective concurrency is the product of the two pools.
+const bundledHarnessConfigConcurrency = 4
 
 // importTemplatesFromRemote fetches a remote source URL, discovers scion
 // templates within it, and registers each one into the Hub store scoped

--- a/pkg/hub/template_bootstrap.go
+++ b/pkg/hub/template_bootstrap.go
@@ -16,16 +16,12 @@ package hub
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
-	"github.com/GoogleCloudPlatform/scion/pkg/config/templateimport"
-	"github.com/GoogleCloudPlatform/scion/pkg/secret"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
@@ -244,186 +240,17 @@ func (s *Server) importTemplateHarnessConfigs(ctx context.Context, templatePath,
 // importTemplatesFromRemote fetches a remote source URL, discovers scion
 // templates within it, and registers each one into the Hub store scoped
 // to the given project. Returns the names of all templates imported or updated.
+//
+// This is a thin wrapper over the shared import driver (resource_import.go).
 func (s *Server) importTemplatesFromRemote(ctx context.Context, projectID, sourceURL string) ([]string, error) {
-	if !config.IsRemoteURI(sourceURL) {
-		return nil, fmt.Errorf("source must be a remote URI (http://, https://, or rclone)")
-	}
-
-	stor := s.GetStorage()
-	if stor == nil {
-		return nil, fmt.Errorf("template storage is not configured")
-	}
-
-	// If the project has a GitHub App installation, mint a token for authenticated access
-	var authToken string
-	project, err := s.store.GetProject(ctx, projectID)
-	if err == nil && project != nil && project.GitHubInstallationID != nil {
-		if token, _, mintErr := s.MintGitHubAppTokenForProject(ctx, project); mintErr == nil && token != "" {
-			authToken = token
-		}
-	}
-
-	// Fall back to project GITHUB_TOKEN secret if no App token minted
-	if authToken == "" {
-		if sb := s.GetSecretBackend(); sb != nil {
-			sec, secErr := sb.Get(ctx, "GITHUB_TOKEN", secret.ScopeProject, projectID)
-			if secErr == nil && sec != nil && sec.Value != "" {
-				authToken = sec.Value
-				s.templateLog.Info("using project GITHUB_TOKEN for template import", "projectID", projectID)
-			} else if secErr != nil && !errors.Is(secErr, store.ErrNotFound) {
-				s.templateLog.Warn("Failed to retrieve GITHUB_TOKEN from secret backend", "projectID", projectID, "error", secErr)
-			}
-		}
-	}
-
-	// Fetch to a temporary directory
-	cachePath, err := config.FetchRemoteTemplate(ctx, sourceURL, authToken)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch remote templates: %w", err)
-	}
-	defer func() { _ = os.RemoveAll(cachePath) }()
-
-	// Collect template directories to import
-	type templateDir struct{ name, path string }
-	var dirs []templateDir
-
-	if templateimport.IsScionTemplate(cachePath) {
-		// URL pointed directly at a single template directory. The cache dir is a
-		// content hash, so derive the name from the source URL's leaf segment
-		// (e.g. ".../tree/main/antigravity" -> "antigravity").
-		name := config.DeriveResourceName(sourceURL)
-		if name == "" {
-			name = filepath.Base(cachePath)
-		}
-		dirs = append(dirs, templateDir{name, cachePath})
-	} else {
-		entries, err := os.ReadDir(cachePath)
-		if err != nil {
-			return nil, err
-		}
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				continue
-			}
-			dir := filepath.Join(cachePath, entry.Name())
-			if templateimport.IsScionTemplate(dir) {
-				dirs = append(dirs, templateDir{entry.Name(), dir})
-			}
-		}
-	}
-
-	if len(dirs) == 0 {
-		return nil, fmt.Errorf("no scion templates found at %s", sourceURL)
-	}
-
-	var imported []string
-	for _, td := range dirs {
-		slug := api.Slugify(td.name)
-		existing, err := s.store.GetTemplateBySlug(ctx, slug, store.TemplateScopeProject, projectID)
-		if err != nil && err != store.ErrNotFound {
-			s.templateLog.Warn("template import: failed to look up template, skipping",
-				"name", td.name, "error", err)
-			continue
-		}
-		if existing == nil {
-			if err := s.bootstrapSingleTemplate(ctx, td.name, td.path, store.TemplateScopeProject, projectID); err != nil {
-				s.templateLog.Warn("template import: failed to import template, skipping",
-					"name", td.name, "error", err)
-				continue
-			}
-		} else {
-			if _, err := s.syncExistingTemplate(ctx, existing, td.path, true); err != nil {
-				s.templateLog.Warn("template import: failed to sync template, skipping",
-					"name", td.name, "error", err)
-				continue
-			}
-		}
-		imported = append(imported, td.name)
-	}
-	return imported, nil
+	return s.importFromRemote(ctx, projectID, sourceURL, store.TemplateScopeProject, s.templateImportKind())
 }
 
 // importTemplatesFromWorkspace imports templates from a path within the
 // project's workspace filesystem. The workspacePath is relative to the project's
 // workspace root (e.g. "/.scion/templates" or "/my/custom/path").
+//
+// This is a thin wrapper over the shared import driver (resource_import.go).
 func (s *Server) importTemplatesFromWorkspace(ctx context.Context, project *store.Project, workspacePath string) ([]string, error) {
-	stor := s.GetStorage()
-	if stor == nil {
-		return nil, fmt.Errorf("template storage is not configured")
-	}
-
-	// Resolve the project's workspace root on disk
-	projectRoot, err := s.resolveProjectWebDAVPath(ctx, project)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve project workspace: %w", err)
-	}
-
-	// Clean and join the workspace path to the project root.
-	// Strip leading slash so it joins correctly.
-	rel := strings.TrimPrefix(filepath.Clean(workspacePath), "/")
-	templatesDir := filepath.Join(projectRoot, rel)
-
-	// Validate the resolved path is within the project root
-	absRoot, _ := filepath.Abs(projectRoot)
-	absDir, _ := filepath.Abs(templatesDir)
-	if !strings.HasPrefix(absDir, absRoot) {
-		return nil, fmt.Errorf("workspace path must be within the project workspace")
-	}
-
-	info, err := os.Stat(templatesDir)
-	if err != nil || !info.IsDir() {
-		return nil, fmt.Errorf("workspace path not found or not a directory: %s", workspacePath)
-	}
-
-	// Collect template directories to import (same logic as importTemplatesFromRemote)
-	type templateDir struct{ name, path string }
-	var dirs []templateDir
-
-	if templateimport.IsScionTemplate(templatesDir) {
-		dirs = append(dirs, templateDir{filepath.Base(templatesDir), templatesDir})
-	} else {
-		entries, readErr := os.ReadDir(templatesDir)
-		if readErr != nil {
-			return nil, readErr
-		}
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				continue
-			}
-			dir := filepath.Join(templatesDir, entry.Name())
-			if templateimport.IsScionTemplate(dir) {
-				dirs = append(dirs, templateDir{entry.Name(), dir})
-			}
-		}
-	}
-
-	if len(dirs) == 0 {
-		return nil, fmt.Errorf("no scion templates found at workspace path %s", workspacePath)
-	}
-
-	var imported []string
-	for _, td := range dirs {
-		slug := api.Slugify(td.name)
-		existing, lookupErr := s.store.GetTemplateBySlug(ctx, slug, store.TemplateScopeProject, project.ID)
-		if lookupErr != nil && lookupErr != store.ErrNotFound {
-			s.templateLog.Warn("workspace template import: failed to look up template, skipping",
-				"name", td.name, "error", lookupErr)
-			continue
-		}
-		if existing == nil {
-			if bootstrapErr := s.bootstrapSingleTemplate(ctx, td.name, td.path, store.TemplateScopeProject, project.ID); bootstrapErr != nil {
-				s.templateLog.Warn("workspace template import: failed to import template, skipping",
-					"name", td.name, "error", bootstrapErr)
-				continue
-			}
-		} else {
-			if _, syncErr := s.syncExistingTemplate(ctx, existing, td.path, true); syncErr != nil {
-				s.templateLog.Warn("workspace template import: failed to sync template, skipping",
-					"name", td.name, "error", syncErr)
-				continue
-			}
-		}
-		imported = append(imported, td.name)
-	}
-	return imported, nil
+	return s.importFromWorkspace(ctx, project, workspacePath, store.TemplateScopeProject, s.templateImportKind())
 }

--- a/pkg/hub/template_bootstrap.go
+++ b/pkg/hub/template_bootstrap.go
@@ -288,8 +288,14 @@ func (s *Server) importTemplatesFromRemote(ctx context.Context, projectID, sourc
 	var dirs []templateDir
 
 	if templateimport.IsScionTemplate(cachePath) {
-		// URL pointed directly at a single template directory
-		dirs = append(dirs, templateDir{filepath.Base(cachePath), cachePath})
+		// URL pointed directly at a single template directory. The cache dir is a
+		// content hash, so derive the name from the source URL's leaf segment
+		// (e.g. ".../tree/main/antigravity" -> "antigravity").
+		name := config.DeriveResourceName(sourceURL)
+		if name == "" {
+			name = filepath.Base(cachePath)
+		}
+		dirs = append(dirs, templateDir{name, cachePath})
 	} else {
 		entries, err := os.ReadDir(cachePath)
 		if err != nil {

--- a/pkg/hub/template_bootstrap_test.go
+++ b/pkg/hub/template_bootstrap_test.go
@@ -948,6 +948,67 @@ func TestImportTemplatesFromWorkspace_MultipleTemplates(t *testing.T) {
 	}
 }
 
+// TestImportTemplatesFromWorkspace_ParallelManyTemplates exercises the Phase-4
+// bounded-pool parallelism: importing more templates than the per-resource
+// worker bound, each with several files, must import every resource exactly
+// once, preserve discovery order in the returned list, and upload all files.
+// Run under `go test -race` this also guards the storage/store concurrency
+// assumptions the parallel loop relies on.
+func TestImportTemplatesFromWorkspace_ParallelManyTemplates(t *testing.T) {
+	srv, s, project, wsRoot := setupWorkspaceProject(t, "ws-parallel")
+	ctx := context.Background()
+
+	// More templates than resourceImportConcurrency so the bounded pool actually
+	// queues work; os.ReadDir returns entries sorted by name, so zero-padded
+	// names give a deterministic discovery order to assert against.
+	const n = 12
+	want := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("tmpl-%02d", i)
+		want = append(want, name)
+		dir := filepath.Join(wsRoot, "templates", name)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "scion-agent.yaml"), []byte("harness: claude\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		// A few files each, to also exercise per-file upload parallelism.
+		for _, f := range []string{"README.md", "home/.bashrc", "system-prompt.md"} {
+			full := filepath.Join(dir, f)
+			if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(full, []byte(name+":"+f), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	imported, err := srv.importTemplatesFromWorkspace(ctx, project, "/templates")
+	if err != nil {
+		t.Fatalf("import failed: %v", err)
+	}
+
+	// Every template imported exactly once, in discovery order.
+	if len(imported) != n {
+		t.Fatalf("expected %d imported, got %d: %v", n, len(imported), imported)
+	}
+	for i := range want {
+		if imported[i] != want[i] {
+			t.Fatalf("imported order mismatch at %d: got %q want %q (full: %v)", i, imported[i], want[i], imported)
+		}
+	}
+
+	result, err := s.ListTemplates(ctx, store.TemplateFilter{ProjectID: project.ID}, store.ListOptions{Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TotalCount != n {
+		t.Fatalf("expected %d templates in store, got %d", n, result.TotalCount)
+	}
+}
+
 func TestBootstrapTemplatesFromDir_ImportsDefaultHarnessConfig(t *testing.T) {
 	srv, s, _ := testTemplateBootstrapServer(t)
 	ctx := context.Background()

--- a/pkg/hub/template_bootstrap_test.go
+++ b/pkg/hub/template_bootstrap_test.go
@@ -1009,6 +1009,51 @@ func TestImportTemplatesFromWorkspace_ParallelManyTemplates(t *testing.T) {
 	}
 }
 
+// TestImportTemplatesFromWorkspace_SkipsHiddenDirs verifies discovery ignores
+// hidden/system directories (.git, .github, .scion) when scanning a parent
+// directory for resources, importing only the real template and not reporting
+// the hidden dirs as skipped.
+func TestImportTemplatesFromWorkspace_SkipsHiddenDirs(t *testing.T) {
+	srv, s, project, wsRoot := setupWorkspaceProject(t, "ws-hidden")
+	ctx := context.Background()
+
+	base := filepath.Join(wsRoot, "templates")
+	// A real template plus hidden/system dirs that must be ignored.
+	tmpl := filepath.Join(base, "real-template")
+	if err := os.MkdirAll(tmpl, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpl, "scion-agent.yaml"), []byte("harness: claude\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, hidden := range []string{".git", ".github", ".scion"} {
+		d := filepath.Join(base, hidden)
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Put a file inside so the dir is non-empty (e.g. .git/config).
+		if err := os.WriteFile(filepath.Join(d, "config"), []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	imported, err := srv.importTemplatesFromWorkspace(ctx, project, "/templates")
+	if err != nil {
+		t.Fatalf("import failed: %v", err)
+	}
+	if len(imported) != 1 || imported[0] != "real-template" {
+		t.Fatalf("expected [real-template], got %v", imported)
+	}
+
+	result, err := s.ListTemplates(ctx, store.TemplateFilter{ProjectID: project.ID}, store.ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TotalCount != 1 {
+		t.Fatalf("expected 1 template, got %d", result.TotalCount)
+	}
+}
+
 func TestBootstrapTemplatesFromDir_ImportsDefaultHarnessConfig(t *testing.T) {
 	srv, s, _ := testTemplateBootstrapServer(t)
 	ctx := context.Background()

--- a/pkg/hub/template_bootstrap_test.go
+++ b/pkg/hub/template_bootstrap_test.go
@@ -1159,6 +1159,100 @@ system_prompt: system-prompt.md
 	}
 }
 
+// TestImportHarnessConfigsFromRemote_WithProjectGithubToken exercises the
+// GITHUB_TOKEN secret fallback for harness-config remote import. Before the
+// Phase-1 refactor routed both kinds through the shared fetch path, the
+// harness-config remote import skipped this fallback (it only minted GitHub App
+// tokens). This test guards that the fallback is now applied.
+func TestImportHarnessConfigsFromRemote_WithProjectGithubToken(t *testing.T) {
+	srv, s, stor := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	projectID := "test-project-id"
+	project := &store.Project{
+		ID:        projectID,
+		Name:      "test-project",
+		Slug:      "test-project",
+		GitRemote: "https://github.com/chiefkarlin/scion-experiments",
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatal(err)
+	}
+
+	// Save GITHUB_TOKEN secret via local secret backend.
+	srv.SetSecretBackend(secret.NewLocalBackend(s, ""))
+	if _, _, err := srv.GetSecretBackend().Set(ctx, &secret.SetSecretInput{
+		Name:       "GITHUB_TOKEN",
+		Value:      "my-secret-token-12345",
+		SecretType: secret.TypeEnvironment,
+		Scope:      secret.ScopeProject,
+		ScopeID:    projectID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hijack the HTTP client's Transport to mock the tarball fetch.
+	// NOTE: mutates http.DefaultClient.Transport globally; MUST NOT run in parallel.
+	oldTransport := http.DefaultClient.Transport
+	defer func() { http.DefaultClient.Transport = oldTransport }()
+
+	var capturedAuthHeader string
+	http.DefaultClient.Transport = &mockRoundTripper{
+		roundTrip: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Host != "github.com" {
+				return nil, fmt.Errorf("unexpected request to host: %s", req.URL.Host)
+			}
+			capturedAuthHeader = req.Header.Get("Authorization")
+
+			var buf bytes.Buffer
+			gzw := gzip.NewWriter(&buf)
+			tw := tar.NewWriter(gzw)
+			files := map[string]string{
+				"scion-experiments-main/harness-configs/my-config/config.yaml": "harness: claude\n",
+				"scion-experiments-main/harness-configs/my-config/CLAUDE.md":   "# Claude instructions",
+			}
+			for name, body := range files {
+				if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0600, Size: int64(len(body))}); err != nil {
+					return nil, err
+				}
+				if _, err := tw.Write([]byte(body)); err != nil {
+					return nil, err
+				}
+			}
+			if err := tw.Close(); err != nil {
+				return nil, err
+			}
+			if err := gzw.Close(); err != nil {
+				return nil, err
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(buf.Bytes()))}, nil
+		},
+	}
+
+	imported, err := srv.importHarnessConfigsFromRemote(ctx, projectID, "https://github.com/chiefkarlin/scion-experiments/tree/main/harness-configs")
+	if err != nil {
+		t.Fatalf("importHarnessConfigsFromRemote failed: %v", err)
+	}
+
+	if len(imported) != 1 || imported[0] != "my-config" {
+		t.Errorf("expected imported harness-configs [my-config], got %v", imported)
+	}
+	if capturedAuthHeader != "Bearer my-secret-token-12345" {
+		t.Errorf("expected Authorization header 'Bearer my-secret-token-12345', got %q", capturedAuthHeader)
+	}
+
+	existing, err := s.GetHarnessConfigBySlug(ctx, "my-config", store.HarnessConfigScopeProject, projectID)
+	if err != nil {
+		t.Fatalf("expected harness-config saved to store: %v", err)
+	}
+	if existing.Harness != "claude" {
+		t.Errorf("expected harness 'claude', got %q", existing.Harness)
+	}
+	if len(stor.objects) != 2 {
+		t.Errorf("expected 2 files uploaded to storage, got %d", len(stor.objects))
+	}
+}
+
 type mockRoundTripper struct {
 	roundTrip func(req *http.Request) (*http.Response, error)
 }

--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -57,6 +57,7 @@ import '@shoelace-style/shoelace/dist/components/input/input.js';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/spinner/spinner.js';
+import '@shoelace-style/shoelace/dist/components/progress-bar/progress-bar.js';
 import '@shoelace-style/shoelace/dist/components/textarea/textarea.js';
 import '@shoelace-style/shoelace/dist/components/tooltip/tooltip.js';
 import '@shoelace-style/shoelace/dist/components/dialog/dialog.js';

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -36,6 +36,7 @@ import '../shared/scheduled-event-list.js';
 import '../shared/subscription-manager.js';
 import '../shared/schedule-list.js';
 import '../shared/resource-list.js';
+import '../shared/resource-import.js';
 
 
 interface ProjectResourceSpec {
@@ -89,37 +90,6 @@ export class ScionPageProjectSettings extends LitElement {
 
   @state()
   private deleteLoading = false;
-
-
-  @state()
-  private syncLoading = false;
-
-  @state()
-  private syncError: string | null = null;
-
-  @state()
-  private syncSuccess: string | null = null;
-
-  @state()
-  private syncRepoUrl = '';
-
-  @state()
-  private importMode: 'url' | 'workspace' = 'url';
-
-  @state()
-  private hcImportLoading = false;
-
-  @state()
-  private hcImportError: string | null = null;
-
-  @state()
-  private hcImportSuccess: string | null = null;
-
-  @state()
-  private hcImportUrl = '';
-
-  @state()
-  private hcImportMode: 'url' | 'workspace' = 'url';
 
   @state()
   private membersGroup: AdminGroup | null = null;
@@ -783,10 +753,8 @@ export class ScionPageProjectSettings extends LitElement {
 
       this.project = (await response.json()) as Project;
       dispatchPageTitle(this, 'Settings', this.project.name || this.projectId);
-      // Pre-populate template import URL with the project's git remote when set
-      if (this.project.gitRemote && !this.syncRepoUrl) {
-        this.syncRepoUrl = this.project.gitRemote;
-      }
+      // The template/harness-config import forms prefill their URL from the
+      // project's git remote (passed as the gitRemote property).
       // Populate GitHub App fields from project data
       this.githubAppInstallationId = this.project.githubInstallationId ?? null;
       this.githubAppStatus = this.project.githubAppStatus ?? null;
@@ -1019,71 +987,6 @@ export class ScionPageProjectSettings extends LitElement {
       this.settingsError = err instanceof Error ? err.message : 'Failed to save settings';
     } finally {
       this.settingsSaving = false;
-    }
-  }
-
-  private async handleSyncTemplates(): Promise<void> {
-    this.syncLoading = true;
-    this.syncError = null;
-    this.syncSuccess = null;
-
-    try {
-      const body =
-        this.importMode === 'workspace'
-          ? { workspacePath: this.syncRepoUrl || '/.scion/templates' }
-          : { sourceUrl: this.syncRepoUrl };
-      const response = await apiFetch(`/api/v1/projects/${this.projectId}/import-templates`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-
-      if (!response.ok) {
-        throw new Error(await extractApiError(response, `Failed to import templates: HTTP ${response.status}`));
-      }
-
-      const data = (await response.json()) as { templates: string[]; count: number };
-      this.refreshTemplatesList();
-      await this.loadDropdownTemplates();
-      this.syncSuccess = `${data.count} template${data.count !== 1 ? 's' : ''} imported successfully.`;
-    } catch (err) {
-      console.error('Failed to import templates:', err);
-      this.syncError = err instanceof Error ? err.message : 'Failed to import templates';
-    } finally {
-      this.syncLoading = false;
-    }
-  }
-
-  private async handleImportHarnessConfigs(): Promise<void> {
-    this.hcImportLoading = true;
-    this.hcImportError = null;
-    this.hcImportSuccess = null;
-
-    try {
-      const body =
-        this.hcImportMode === 'workspace'
-          ? { workspacePath: this.hcImportUrl || '/.scion/harness-configs' }
-          : { sourceUrl: this.hcImportUrl };
-      const response = await apiFetch(`/api/v1/projects/${this.projectId}/import-harness-configs`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-
-      if (!response.ok) {
-        throw new Error(
-          await extractApiError(response, `Failed to import harness-configs: HTTP ${response.status}`)
-        );
-      }
-
-      const data = (await response.json()) as { harnessConfigs: string[]; count: number };
-      this.refreshHarnessConfigsList();
-      this.hcImportSuccess = `${data.count} harness-config${data.count !== 1 ? 's' : ''} imported successfully.`;
-    } catch (err) {
-      console.error('Failed to import harness-configs:', err);
-      this.hcImportError = err instanceof Error ? err.message : 'Failed to import harness-configs';
-    } finally {
-      this.hcImportLoading = false;
     }
   }
 
@@ -1857,93 +1760,19 @@ export class ScionPageProjectSettings extends LitElement {
         <div class="section-header-text">
           <p style="margin: 0;">Project-scoped agent templates imported into the Hub.</p>
         </div>
-        ${canSync
-          ? html`
-              <sl-button
-                size="small"
-                variant="default"
-                ?loading=${this.syncLoading}
-                ?disabled=${this.syncLoading || (this.importMode === 'url' && !this.syncRepoUrl)}
-                @click=${() => this.handleSyncTemplates()}
-              >
-                <sl-icon slot="prefix" name="download"></sl-icon>
-                Import Templates
-              </sl-button>
-            `
-          : ''}
       </div>
-      ${canSync
-        ? html`
-            <div style="margin-bottom: 1rem;">
-              <sl-radio-group
-                size="small"
-                value=${this.importMode}
-                style="margin-bottom: 0.5rem;"
-                @sl-change=${(e: Event) => {
-                  this.importMode = (e.target as HTMLInputElement).value as 'url' | 'workspace';
-                  this.syncRepoUrl = '';
-                  this.syncError = null;
-                  this.syncSuccess = null;
-                  if (this.importMode === 'url' && this.project?.gitRemote) {
-                    this.syncRepoUrl = this.project.gitRemote;
-                  }
-                }}
-              >
-                <sl-radio-button value="url">Import from URL</sl-radio-button>
-                <sl-radio-button value="workspace">Import from workspace</sl-radio-button>
-              </sl-radio-group>
-              <sl-input
-                placeholder=${this.importMode === 'workspace'
-                  ? '/.scion/templates'
-                  : 'https://github.com/org/repo/tree/main/.scion/templates'}
-                size="small"
-                clearable
-                .value=${this.syncRepoUrl}
-                ?disabled=${this.syncLoading}
-                @sl-input=${(e: Event) => {
-                  this.syncRepoUrl = (e.target as HTMLInputElement).value;
-                }}
-                @sl-clear=${() => {
-                  this.syncRepoUrl = '';
-                }}
-              >
-                <sl-icon slot="prefix" name=${this.importMode === 'workspace' ? 'folder' : 'github'}></sl-icon>
-              </sl-input>
-              <div style="margin-top: 0.25rem; font-size: 0.75rem; color: var(--sl-color-neutral-500);">
-                ${this.importMode === 'workspace'
-                  ? 'Path within the project workspace — the default will be used if no path is provided'
-                  : 'GitHub URL to a template or templates directory — supports arbitrary deep paths'}
-              </div>
-            </div>
-          `
-        : ''}
-
-      ${this.syncLoading
-        ? html`
-            <div class="sync-status syncing">
-              <sl-spinner style="font-size: 0.875rem;"></sl-spinner>
-              ${this.importMode === 'workspace'
-                ? `Importing templates from workspace ${this.syncRepoUrl || '/.scion/templates'}...`
-                : `Importing templates from ${this.syncRepoUrl}...`}
-            </div>
-          `
-        : ''}
-      ${this.syncError
-        ? html`
-            <div class="sync-status error">
-              <sl-icon name="exclamation-triangle"></sl-icon>
-              ${this.syncError}
-            </div>
-          `
-        : ''}
-      ${this.syncSuccess
-        ? html`
-            <div class="sync-status success">
-              <sl-icon name="check-circle"></sl-icon>
-              ${this.syncSuccess}
-            </div>
-          `
-        : ''}
+      <scion-resource-import
+        kind="template"
+        scope="project"
+        .scopeId=${this.projectId}
+        ?canImport=${canSync}
+        allowWorkspace
+        gitRemote=${this.project?.gitRemote ?? ''}
+        @resource-imported=${() => {
+          this.refreshTemplatesList();
+          void this.loadDropdownTemplates();
+        }}
+      ></scion-resource-import>
       <scion-resource-list
         id="templates-resource-list"
         kind="template"
@@ -1964,93 +1793,16 @@ export class ScionPageProjectSettings extends LitElement {
             and edit its files.
           </p>
         </div>
-        ${canSync
-          ? html`
-              <sl-button
-                size="small"
-                variant="default"
-                ?loading=${this.hcImportLoading}
-                ?disabled=${this.hcImportLoading || (this.hcImportMode === 'url' && !this.hcImportUrl)}
-                @click=${() => this.handleImportHarnessConfigs()}
-              >
-                <sl-icon slot="prefix" name="download"></sl-icon>
-                Import Harness Configs
-              </sl-button>
-            `
-          : ''}
       </div>
-      ${canSync
-        ? html`
-            <div style="margin-bottom: 1rem;">
-              <sl-radio-group
-                size="small"
-                value=${this.hcImportMode}
-                style="margin-bottom: 0.5rem;"
-                @sl-change=${(e: Event) => {
-                  this.hcImportMode = (e.target as HTMLInputElement).value as 'url' | 'workspace';
-                  this.hcImportUrl = '';
-                  this.hcImportError = null;
-                  this.hcImportSuccess = null;
-                  if (this.hcImportMode === 'url' && this.project?.gitRemote) {
-                    this.hcImportUrl = this.project.gitRemote;
-                  }
-                }}
-              >
-                <sl-radio-button value="url">Import from URL</sl-radio-button>
-                <sl-radio-button value="workspace">Import from workspace</sl-radio-button>
-              </sl-radio-group>
-              <sl-input
-                placeholder=${this.hcImportMode === 'workspace'
-                  ? '/.scion/harness-configs'
-                  : 'https://github.com/org/repo/tree/main/.scion/harness-configs'}
-                size="small"
-                clearable
-                .value=${this.hcImportUrl}
-                ?disabled=${this.hcImportLoading}
-                @sl-input=${(e: Event) => {
-                  this.hcImportUrl = (e.target as HTMLInputElement).value;
-                }}
-                @sl-clear=${() => {
-                  this.hcImportUrl = '';
-                }}
-              >
-                <sl-icon slot="prefix" name=${this.hcImportMode === 'workspace' ? 'folder' : 'github'}></sl-icon>
-              </sl-input>
-              <div style="margin-top: 0.25rem; font-size: 0.75rem; color: var(--sl-color-neutral-500);">
-                ${this.hcImportMode === 'workspace'
-                  ? 'Path within the project workspace — the default will be used if no path is provided'
-                  : 'GitHub URL to a harness-config or harness-configs directory — supports arbitrary deep paths'}
-              </div>
-            </div>
-          `
-        : ''}
-
-      ${this.hcImportLoading
-        ? html`
-            <div class="sync-status syncing">
-              <sl-spinner style="font-size: 0.875rem;"></sl-spinner>
-              ${this.hcImportMode === 'workspace'
-                ? `Importing harness-configs from workspace ${this.hcImportUrl || '/.scion/harness-configs'}...`
-                : `Importing harness-configs from ${this.hcImportUrl}...`}
-            </div>
-          `
-        : ''}
-      ${this.hcImportError
-        ? html`
-            <div class="sync-status error">
-              <sl-icon name="exclamation-triangle"></sl-icon>
-              ${this.hcImportError}
-            </div>
-          `
-        : ''}
-      ${this.hcImportSuccess
-        ? html`
-            <div class="sync-status success">
-              <sl-icon name="check-circle"></sl-icon>
-              ${this.hcImportSuccess}
-            </div>
-          `
-        : ''}
+      <scion-resource-import
+        kind="harness-config"
+        scope="project"
+        .scopeId=${this.projectId}
+        ?canImport=${canSync}
+        allowWorkspace
+        gitRemote=${this.project?.gitRemote ?? ''}
+        @resource-imported=${() => this.refreshHarnessConfigsList()}
+      ></scion-resource-import>
       <scion-resource-list
         id="harness-configs-resource-list"
         kind="harness-config"

--- a/web/src/components/pages/settings.ts
+++ b/web/src/components/pages/settings.ts
@@ -28,6 +28,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '../shared/env-var-list.js';
 import '../shared/secret-list.js';
 import '../shared/resource-list.js';
+import '../shared/resource-import.js';
 
 @customElement('scion-page-settings')
 export class ScionPageSettings extends LitElement {
@@ -110,6 +111,14 @@ export class ScionPageSettings extends LitElement {
     }
   }
 
+  /** Refresh a resource list (by element id) after an import. */
+  private refreshList(id: string): void {
+    const list = this.shadowRoot?.querySelector(`#${id}`) as
+      | import('../shared/resource-list.js').ScionResourceList
+      | null;
+    void list?.load();
+  }
+
   override render() {
     return html`
       <div class="header">
@@ -147,7 +156,14 @@ export class ScionPageSettings extends LitElement {
 
           <sl-tab-panel name="templates">
             <p class="tab-intro">Global agent templates. Open one to browse and edit its files.</p>
+            <scion-resource-import
+              kind="template"
+              scope="global"
+              canImport
+              @resource-imported=${() => this.refreshList('templates-list')}
+            ></scion-resource-import>
             <scion-resource-list
+              id="templates-list"
               kind="template"
               scope="global"
               detailBasePath="/settings"
@@ -158,7 +174,14 @@ export class ScionPageSettings extends LitElement {
             <p class="tab-intro">
               Global harness configurations. Open one to browse and edit its files.
             </p>
+            <scion-resource-import
+              kind="harness-config"
+              scope="global"
+              canImport
+              @resource-imported=${() => this.refreshList('harness-configs-list')}
+            ></scion-resource-import>
             <scion-resource-list
+              id="harness-configs-list"
               kind="harness-config"
               scope="global"
               detailBasePath="/settings"

--- a/web/src/components/shared/resource-import.ts
+++ b/web/src/components/shared/resource-import.ts
@@ -38,6 +38,33 @@ import { apiFetch, extractApiError } from '../../client/api.js';
 
 export type ResourceImportKind = 'template' | 'harness-config';
 
+/** One progress event from the streaming (NDJSON) import endpoints. */
+interface ImportEvent {
+  type: 'discovered' | 'started' | 'completed' | 'failed' | 'skipped' | 'done' | 'error';
+  name?: string;
+  reason?: string;
+  completed?: number;
+  total?: number;
+  names?: string[];
+  imported?: string[];
+  skipped?: string[];
+  failed?: string[];
+}
+
+/** Live progress state rendered while a streaming import is in flight. */
+interface ImportProgress {
+  total: number;
+  completed: number;
+  inFlight: string[];
+}
+
+/** Final per-resource summary after a streaming import completes. */
+interface ImportSummary {
+  imported: string[];
+  skipped: string[];
+  failed: string[];
+}
+
 @customElement('scion-resource-import')
 export class ScionResourceImport extends LitElement {
   /** Which resource type to import. */
@@ -69,6 +96,8 @@ export class ScionResourceImport extends LitElement {
   @state() private loading = false;
   @state() private error: string | null = null;
   @state() private success: string | null = null;
+  @state() private progress: ImportProgress | null = null;
+  @state() private summary: ImportSummary | null = null;
 
   static override styles = css`
     :host {
@@ -115,6 +144,24 @@ export class ScionResourceImport extends LitElement {
     .sync-status.success {
       color: var(--sl-color-success-600, #16a34a);
     }
+
+    .progress {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      padding: 0.5rem 0;
+    }
+
+    .progress-label {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.875rem;
+    }
+
+    sl-progress-bar {
+      --height: 6px;
+    }
   `;
 
   private get noun(): string {
@@ -146,12 +193,16 @@ export class ScionResourceImport extends LitElement {
     this.source = mode === 'url' && this.gitRemote ? this.gitRemote : '';
     this.error = null;
     this.success = null;
+    this.progress = null;
+    this.summary = null;
   }
 
   private async handleImport(): Promise<void> {
     this.loading = true;
     this.error = null;
     this.success = null;
+    this.progress = null;
+    this.summary = null;
 
     try {
       let endpoint: string;
@@ -169,9 +220,11 @@ export class ScionResourceImport extends LitElement {
             : { sourceUrl: this.source };
       }
 
+      // Opt into streaming NDJSON progress; the server falls back to a single
+      // JSON summary for clients that don't ask for it.
       const response = await apiFetch(endpoint, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', Accept: 'application/x-ndjson' },
         body: JSON.stringify(body),
       });
 
@@ -181,23 +234,98 @@ export class ScionResourceImport extends LitElement {
         );
       }
 
-      const data = (await response.json()) as { count: number };
-      const count = data.count ?? 0;
-      const singular = this.kind === 'template' ? 'template' : 'harness-config';
-      this.success = `${count} ${singular}${count !== 1 ? 's' : ''} imported successfully.`;
-      this.dispatchEvent(
-        new CustomEvent('resource-imported', {
-          detail: { count },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      const contentType = response.headers.get('Content-Type') ?? '';
+      if (contentType.includes('application/x-ndjson') && response.body) {
+        await this.consumeStream(response.body);
+      } else {
+        // Non-streaming fallback: single JSON summary.
+        const data = (await response.json()) as { count?: number; imported?: string[] };
+        this.finishSummary({ imported: data.imported ?? [], skipped: [], failed: [] }, data.count);
+      }
     } catch (err) {
       console.error(`Failed to import ${this.noun}:`, err);
       this.error = err instanceof Error ? err.message : `Failed to import ${this.noun}`;
     } finally {
       this.loading = false;
+      this.progress = null;
     }
+  }
+
+  /** Read an NDJSON stream of {@link ImportEvent}s, updating progress state. */
+  private async consumeStream(stream: ReadableStream<Uint8Array>): Promise<void> {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    const dispatchLine = (line: string): void => {
+      const trimmed = line.trim();
+      if (trimmed) this.handleEvent(JSON.parse(trimmed) as ImportEvent);
+    };
+
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let nl: number;
+      while ((nl = buffer.indexOf('\n')) >= 0) {
+        dispatchLine(buffer.slice(0, nl));
+        buffer = buffer.slice(nl + 1);
+      }
+    }
+    dispatchLine(buffer);
+  }
+
+  /** Fold one streamed import event into the live progress / summary state. */
+  private handleEvent(ev: ImportEvent): void {
+    switch (ev.type) {
+      case 'discovered':
+        this.progress = { total: ev.total ?? 0, completed: 0, inFlight: [] };
+        break;
+      case 'started':
+        if (this.progress && ev.name) {
+          this.progress = { ...this.progress, inFlight: [...this.progress.inFlight, ev.name] };
+        }
+        break;
+      case 'completed':
+      case 'failed':
+        if (this.progress) {
+          this.progress = {
+            ...this.progress,
+            completed: ev.completed ?? this.progress.completed,
+            inFlight: this.progress.inFlight.filter((n) => n !== ev.name),
+          };
+        }
+        break;
+      case 'done':
+        this.finishSummary({
+          imported: ev.imported ?? [],
+          skipped: ev.skipped ?? [],
+          failed: ev.failed ?? [],
+        });
+        break;
+      case 'error':
+        this.error = ev.reason ?? `Failed to import ${this.noun}`;
+        break;
+      // 'skipped' is folded into the final summary's `skipped` list via 'done'.
+    }
+  }
+
+  /** Record the final summary and notify the host to refresh its list. */
+  private finishSummary(summary: ImportSummary, countOverride?: number): void {
+    this.summary = summary;
+    const count = countOverride ?? summary.imported.length;
+    const singular = this.kind === 'template' ? 'template' : 'harness-config';
+    let msg = `${count} ${singular}${count !== 1 ? 's' : ''} imported successfully.`;
+    if (summary.skipped.length > 0) msg += ` ${summary.skipped.length} skipped.`;
+    if (summary.failed.length > 0) msg += ` ${summary.failed.length} failed.`;
+    this.success = msg;
+    this.dispatchEvent(
+      new CustomEvent('resource-imported', {
+        detail: { count },
+        bubbles: true,
+        composed: true,
+      })
+    );
   }
 
   override render() {
@@ -256,24 +384,56 @@ export class ScionResourceImport extends LitElement {
         </div>
       </div>
 
-      ${this.loading
-        ? html`<div class="sync-status">
-            <sl-spinner style="font-size: 0.875rem;"></sl-spinner>
-            ${this.mode === 'workspace'
-              ? `Importing ${this.noun} from workspace ${this.source || this.defaultWorkspacePath}...`
-              : `Importing ${this.noun} from ${this.source}...`}
-          </div>`
-        : ''}
+      ${this.loading ? this.renderProgress() : ''}
       ${this.error
         ? html`<div class="sync-status error">
             <sl-icon name="exclamation-triangle"></sl-icon>${this.error}
           </div>`
         : ''}
-      ${this.success
+      ${!this.loading && this.success
         ? html`<div class="sync-status success">
-            <sl-icon name="check-circle"></sl-icon>${this.success}
-          </div>`
+              <sl-icon name="check-circle"></sl-icon>${this.success}
+            </div>
+            ${this.renderSummaryDetail()}`
         : ''}
+    `;
+  }
+
+  /** Render the skipped/failed resource names from the final summary, if any. */
+  private renderSummaryDetail() {
+    const s = this.summary;
+    if (!s || (s.skipped.length === 0 && s.failed.length === 0)) return '';
+    return html`
+      <div class="hint">
+        ${s.failed.length > 0 ? html`<div>Failed: ${s.failed.join(', ')}</div>` : ''}
+        ${s.skipped.length > 0 ? html`<div>Skipped: ${s.skipped.join(', ')}</div>` : ''}
+      </div>
+    `;
+  }
+
+  /** Render the in-flight import status: a per-resource progress bar once the
+   * resource list is known, or an indeterminate spinner during fetch/discovery. */
+  private renderProgress() {
+    const p = this.progress;
+    if (!p || p.total === 0) {
+      return html`<div class="sync-status">
+        <sl-spinner style="font-size: 0.875rem;"></sl-spinner>
+        ${this.mode === 'workspace'
+          ? `Importing ${this.noun} from workspace ${this.source || this.defaultWorkspacePath}...`
+          : `Fetching ${this.noun} from ${this.source}...`}
+      </div>`;
+    }
+
+    const pct = Math.round((p.completed / p.total) * 100);
+    const current = p.inFlight.length > 0 ? p.inFlight.join(', ') : '…';
+    return html`
+      <div class="progress">
+        <div class="progress-label">
+          <sl-spinner style="font-size: 0.875rem;"></sl-spinner>
+          <span>Importing ${current} (${p.completed}/${p.total})…</span>
+        </div>
+        <sl-progress-bar value=${pct}></sl-progress-bar>
+      </div>
     `;
   }
 }

--- a/web/src/components/shared/resource-import.ts
+++ b/web/src/components/shared/resource-import.ts
@@ -1,0 +1,285 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared resource import form
+ *
+ * Renders the import affordance (mode toggle + source input + button + status)
+ * for file-based resources (templates / harness-configs). Used by both the
+ * project settings Resources section and the Hub Resources page so the import UI
+ * is defined once.
+ *
+ * - Project scope posts to the per-project endpoint and supports both URL and
+ *   workspace-path modes.
+ * - Global scope posts to the unified `/api/v1/resources/import` endpoint and is
+ *   URL-only (no project workspace to resolve).
+ *
+ * On a successful import it dispatches a `resource-imported` CustomEvent (with
+ * `{ count }` detail) so the host page can refresh its resource list.
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+import { apiFetch, extractApiError } from '../../client/api.js';
+
+export type ResourceImportKind = 'template' | 'harness-config';
+
+@customElement('scion-resource-import')
+export class ScionResourceImport extends LitElement {
+  /** Which resource type to import. */
+  @property({ type: String })
+  kind: ResourceImportKind = 'template';
+
+  /** Resource scope: 'project' or 'global'. */
+  @property({ type: String })
+  scope: 'project' | 'global' = 'project';
+
+  /** Scope id (project id) — required for project scope, omitted for global. */
+  @property({ type: String })
+  scopeId = '';
+
+  /** Whether the workspace-path import mode is offered (project scope only). */
+  @property({ type: Boolean })
+  allowWorkspace = false;
+
+  /** Whether the caller may import — gates the whole form when false. */
+  @property({ type: Boolean })
+  canImport = false;
+
+  /** Optional URL prefill (e.g. the project's git remote). */
+  @property({ type: String })
+  gitRemote = '';
+
+  @state() private mode: 'url' | 'workspace' = 'url';
+  @state() private source = '';
+  @state() private loading = false;
+  @state() private error: string | null = null;
+  @state() private success: string | null = null;
+
+  static override styles = css`
+    :host {
+      display: block;
+      margin-bottom: 1rem;
+    }
+
+    .header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-bottom: 1rem;
+    }
+
+    .header p {
+      margin: 0;
+      font-size: 0.875rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .controls {
+      margin-bottom: 1rem;
+    }
+
+    .hint {
+      margin-top: 0.25rem;
+      font-size: 0.75rem;
+      color: var(--sl-color-neutral-500, #64748b);
+    }
+
+    .sync-status {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.875rem;
+      padding: 0.5rem 0;
+    }
+
+    .sync-status.error {
+      color: var(--sl-color-danger-600, #dc2626);
+    }
+
+    .sync-status.success {
+      color: var(--sl-color-success-600, #16a34a);
+    }
+  `;
+
+  private get noun(): string {
+    return this.kind === 'template' ? 'templates' : 'harness-configs';
+  }
+
+  private get label(): string {
+    return this.kind === 'template' ? 'Templates' : 'Harness Configs';
+  }
+
+  private get defaultWorkspacePath(): string {
+    return this.kind === 'template' ? '/.scion/templates' : '/.scion/harness-configs';
+  }
+
+  private get placeholder(): string {
+    if (this.mode === 'workspace') return this.defaultWorkspacePath;
+    return `https://github.com/org/repo/tree/main/${this.defaultWorkspacePath.replace(/^\//, '')}`;
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (this.scope === 'project' && this.gitRemote && !this.source) {
+      this.source = this.gitRemote;
+    }
+  }
+
+  private onModeChange(mode: 'url' | 'workspace'): void {
+    this.mode = mode;
+    this.source = mode === 'url' && this.gitRemote ? this.gitRemote : '';
+    this.error = null;
+    this.success = null;
+  }
+
+  private async handleImport(): Promise<void> {
+    this.loading = true;
+    this.error = null;
+    this.success = null;
+
+    try {
+      let endpoint: string;
+      let body: Record<string, string>;
+
+      if (this.scope === 'global') {
+        endpoint = '/api/v1/resources/import';
+        body = { kind: this.kind, scope: 'global', sourceUrl: this.source };
+      } else {
+        const path = this.kind === 'template' ? 'import-templates' : 'import-harness-configs';
+        endpoint = `/api/v1/projects/${this.scopeId}/${path}`;
+        body =
+          this.mode === 'workspace'
+            ? { workspacePath: this.source || this.defaultWorkspacePath }
+            : { sourceUrl: this.source };
+      }
+
+      const response = await apiFetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          await extractApiError(response, `Failed to import ${this.noun}: HTTP ${response.status}`)
+        );
+      }
+
+      const data = (await response.json()) as { count: number };
+      const count = data.count ?? 0;
+      const singular = this.kind === 'template' ? 'template' : 'harness-config';
+      this.success = `${count} ${singular}${count !== 1 ? 's' : ''} imported successfully.`;
+      this.dispatchEvent(
+        new CustomEvent('resource-imported', {
+          detail: { count },
+          bubbles: true,
+          composed: true,
+        })
+      );
+    } catch (err) {
+      console.error(`Failed to import ${this.noun}:`, err);
+      this.error = err instanceof Error ? err.message : `Failed to import ${this.noun}`;
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  override render() {
+    if (!this.canImport) return html``;
+
+    const importDisabled = this.loading || (this.mode === 'url' && !this.source);
+
+    return html`
+      <div class="header">
+        <sl-button
+          size="small"
+          variant="default"
+          ?loading=${this.loading}
+          ?disabled=${importDisabled}
+          @click=${() => this.handleImport()}
+        >
+          <sl-icon slot="prefix" name="download"></sl-icon>
+          Import ${this.label}
+        </sl-button>
+      </div>
+
+      <div class="controls">
+        ${this.allowWorkspace
+          ? html`
+              <sl-radio-group
+                size="small"
+                value=${this.mode}
+                style="margin-bottom: 0.5rem;"
+                @sl-change=${(e: Event) =>
+                  this.onModeChange((e.target as HTMLInputElement).value as 'url' | 'workspace')}
+              >
+                <sl-radio-button value="url">Import from URL</sl-radio-button>
+                <sl-radio-button value="workspace">Import from workspace</sl-radio-button>
+              </sl-radio-group>
+            `
+          : ''}
+        <sl-input
+          placeholder=${this.placeholder}
+          size="small"
+          clearable
+          .value=${this.source}
+          ?disabled=${this.loading}
+          @sl-input=${(e: Event) => {
+            this.source = (e.target as HTMLInputElement).value;
+          }}
+          @sl-clear=${() => {
+            this.source = '';
+          }}
+        >
+          <sl-icon slot="prefix" name=${this.mode === 'workspace' ? 'folder' : 'github'}></sl-icon>
+        </sl-input>
+        <div class="hint">
+          ${this.mode === 'workspace'
+            ? 'Path within the project workspace — the default will be used if no path is provided'
+            : `GitHub URL to a ${this.kind} or ${this.noun} directory — supports arbitrary deep paths`}
+        </div>
+      </div>
+
+      ${this.loading
+        ? html`<div class="sync-status">
+            <sl-spinner style="font-size: 0.875rem;"></sl-spinner>
+            ${this.mode === 'workspace'
+              ? `Importing ${this.noun} from workspace ${this.source || this.defaultWorkspacePath}...`
+              : `Importing ${this.noun} from ${this.source}...`}
+          </div>`
+        : ''}
+      ${this.error
+        ? html`<div class="sync-status error">
+            <sl-icon name="exclamation-triangle"></sl-icon>${this.error}
+          </div>`
+        : ''}
+      ${this.success
+        ? html`<div class="sync-status success">
+            <sl-icon name="check-circle"></sl-icon>${this.success}
+          </div>`
+        : ''}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-resource-import': ScionResourceImport;
+  }
+}

--- a/web/src/components/shared/resource-import.ts
+++ b/web/src/components/shared/resource-import.ts
@@ -272,6 +272,9 @@ export class ScionResourceImport extends LitElement {
         buffer = buffer.slice(nl + 1);
       }
     }
+    // Flush any bytes still held inside the decoder (e.g. a trailing multi-byte
+    // UTF-8 sequence split across reads) before dispatching the final line.
+    buffer += decoder.decode();
     dispatchLine(buffer);
   }
 


### PR DESCRIPTION
## Resource Import Refactor — factoring, hub-level import, name fix, progress & performance

Implements the full plan in [`.design/resource-import-refactor.md`](.design/resource-import-refactor.md). Scion can import two kinds of file-based resources (templates, harness-configs) from a remote URL or workspace path into the Hub's DB + storage backend. This branch factors that machinery, fixes a naming bug, exposes hub-level import, adds per-resource progress, and parallelizes the pipeline — across five independently-shippable phases.

### Phase 0 — Name fix (`41ec02b`)
- New shared `config.DeriveResourceName` (`pkg/config/resource_name.go`, tested): last meaningful path segment from a URL/path, handling `file://`, rclone `:backend:path`, http(s)/bare-`github.com`, archives, and plain paths.
- Fixes the bug where importing a single resource from a deep URL (e.g. `.../tree/main/antigravity`) named it after the content-hash cache dir instead of `antigravity`. CLI `deriveHarnessConfigName` now delegates to the shared helper, so CLI and Hub share one rule.

### Phase 1 — Factor the import pipeline (`c61711a`)
- New `pkg/hub/resource_import.go`: one kind-generic, source-generic driver sitting above the existing `ResourceStore.Bootstrap`, replacing the four near-identical `import*From{Remote,Workspace}` functions.
- Per-kind quirks isolated in small closures (`resourceImportKind`: marker file + store factory); shared fetch+auth, discovery, leaf-vs-parent naming, and the create-or-sync loop live in one place.
- Closes the harness-config `GITHUB_TOKEN` auth gap by sharing the fetch path. Behavior-preserving; the four `import*From*` methods are now thin wrappers.

### Phase 2 — Hub-level (global) import (`d5f21df`)
- New unified endpoint `POST /api/v1/resources/import` with body `{ kind, scope, scopeId, sourceUrl }`. Global scope is hub-admin-only and URL-only; project scope is also supported and mirrors the existing per-project authz.
- New shared `<scion-resource-import>` web component replaces the two inline import blocks in project settings and is mounted in the Hub Resources tabs (scope=global), removing a third copy of the import UI.

### Phase 3 — Progress UX (`8e52b92`)
- Server emits per-resource progress events (`discovered`/`started`/`completed`/`failed`/`skipped`/`done`/`error`) over a content-negotiated NDJSON stream (`Accept: application/x-ndjson`); non-streaming callers (CLI, existing tests) still get the buffered JSON summary.
- Events funnel through a single mutex-serialized sink with a monotonic completed counter (parallel-safe by design). The shared web component renders an `<sl-progress-bar>` ("Importing antigravity (2/5)…") and a final imported/skipped/failed summary.

### Phase 4 — Performance (`4e89179`)
- **Per-resource loop** parallelized via a bounded `errgroup` pool (`resourceImportConcurrency=6`); per-index slots keep imported/failed lists in discovery order, atomic counter feeds the Phase-3 progress model unchanged.
- **Per-file uploads** parallelized (`fileUploadConcurrency=8`), order-preserving. Every import path routes through `ResourceStore.Bootstrap → uploadResourceFiles`, so all benefit.
- **Bundled harness-config loop** parallelized (`bundledHarnessConfigConcurrency=4`, small since it nests under the per-resource pool).
- `mockStorage` made concurrency-safe (mutex) for race-clean tests.
- **Measured ~19× speedup** (48 uploads @25ms latency: ~1.2s sequential → ~63ms parallel). Deferred the optional `FetchRemoteTemplate` ETag/SHA cache (low priority per §4.5).

### Testing
- Full `pkg/hub` suite passes; import-path tests pass under `go test -race`. `go build ./...` and `go vet ./pkg/hub` clean.
- New tests across phases: name derivation, harness-config `GITHUB_TOKEN` fallback, unified endpoint authz/validation, streaming progress, and `TestImportTemplatesFromWorkspace_ParallelManyTemplates`.

> Note: fork PR — staging only, do not merge.
