### PR TITLE
Add channel and thread filtering to message broker

### DIFF
--- a/.design/telegram-per-topic-default.md
+++ b/.design/telegram-per-topic-default.md
@@ -1,0 +1,152 @@
+# Design: Per-Topic Default Agent in Telegram
+
+**Date:** 2026-06-01
+**Branch:** chat-channels
+**Status:** Exploration
+
+## Current Behavior
+
+The `/default` command sets a single default agent per Telegram group chat. The flow:
+
+1. User types `/default` in a group → `handleDefault()` (`commands.go:194`) fetches the `GroupLink` by `chat_id` and presents an inline keyboard of agents.
+2. User taps an agent button → `handleDefaultCallback()` (`callbacks.go:314`) writes `link.DefaultAgent = agentSlug` and calls `SaveGroupLink()`.
+3. On inbound messages, `handleGroupMessage()` (`broker_v2.go:1607-1615`) falls back to `link.DefaultAgent` when no @-mention, reply-to, or conversation context resolves a target.
+
+**Storage:** The `group_links` table has `chat_id INTEGER PRIMARY KEY` and a single `default_agent TEXT` column. One default per chat.
+
+## Thread/Topic Context in Telegram
+
+Telegram forum-mode groups have named topics. Each topic has a `message_thread_id` (int64). The General topic is thread ID 1 (or 0 in some API versions). The plugin already captures this:
+
+- **Inbound:** `TGMessage.MessageThreadID` is populated by the Telegram Bot API. At `broker_v2.go:1757-1759`, it's stored as `msg.ThreadID`.
+- **Outbound:** `Publish()` reads `msg.ThreadID` and passes it back as `SendOption{MessageThreadID: tid}` so replies land in the correct topic.
+- **Commands:** When `/default` is typed inside a topic, `msg.MessageThreadID` carries the thread ID. The `CallbackQuery.Message` also has `MessageThreadID`, so the callback knows which topic the button was pressed in.
+
+**Key insight:** All the thread context is already flowing through the system — it's just not used for default-agent scoping.
+
+## Proposed Changes
+
+### 1. Storage: New `topic_defaults` Table
+
+Add a new table rather than modifying `group_links`:
+
+```sql
+CREATE TABLE IF NOT EXISTS topic_defaults (
+    chat_id    INTEGER NOT NULL,
+    thread_id  INTEGER NOT NULL,
+    agent_slug TEXT NOT NULL,
+    PRIMARY KEY (chat_id, thread_id)
+);
+```
+
+The existing `group_links.default_agent` stays as the chat-level fallback. This avoids a schema migration and keeps the two concepts cleanly separated.
+
+**Store methods to add:**
+- `GetTopicDefault(ctx, chatID, threadID) (string, error)`
+- `SetTopicDefault(ctx, chatID, threadID, agentSlug) error`
+- `DeleteTopicDefault(ctx, chatID, threadID) error`
+
+### 2. Command Handling Changes
+
+**`handleDefault()` in `commands.go`:**
+- Read `msg.MessageThreadID`.
+- If nonzero (i.e., inside a topic), pass it through to the keyboard builder and callback data.
+- The keyboard prompt changes to: "Select the default agent for this topic:" (vs. the current "for @-mentions:").
+- If zero (General topic or non-forum group), behave as today (chat-level default).
+
+**Callback data format:**
+- Current: `dflt:<agentSlug>` (e.g., `dflt:coder`)
+- New: `dflt:<agentSlug>:<threadID>` (e.g., `dflt:coder:42`)
+- When `threadID` is empty or "0", it's a chat-level default (backward-compatible).
+
+**`handleDefaultCallback()` in `callbacks.go`:**
+- Parse the optional `threadID` from callback data parts.
+- If present and nonzero: call `SetTopicDefault(ctx, chatID, threadID, agentSlug)`.
+- If `__none__`: call `DeleteTopicDefault(ctx, chatID, threadID)`.
+- Otherwise: set chat-level default as today.
+
+### 3. Routing Logic Changes
+
+**`handleGroupMessage()` in `broker_v2.go` (around line 1607):**
+
+Replace the current fallback:
+```go
+if len(targets) == 0 && link.DefaultAgent != "" {
+```
+
+With a two-tier lookup:
+```go
+if len(targets) == 0 {
+    defaultAgent := ""
+    if tgMsg.MessageThreadID != 0 {
+        topicDefault, _ := b.store.GetTopicDefault(ctx, chatID, tgMsg.MessageThreadID)
+        if topicDefault != "" {
+            defaultAgent = topicDefault
+        }
+    }
+    if defaultAgent == "" {
+        defaultAgent = link.DefaultAgent
+    }
+    if defaultAgent != "" {
+        // existing routing logic
+    }
+}
+```
+
+Fallback chain: **topic default → chat default → no default**.
+
+### 4. UX for Querying/Clearing
+
+**Showing current default:** When `/default` is invoked in a topic, the keyboard should show the topic-level default (if set) with a checkmark, falling back to showing the chat-level default with a "(chat default)" label.
+
+**Clearing a topic default:** The "No default agent" button in topic context removes the topic override, reverting to the chat-level fallback. It does NOT clear the chat-level default.
+
+**Showing all topic defaults:** Consider adding a `/defaults` command (or a flag like `/default list`) that shows all topic-specific overrides for the group. This is a nice-to-have, not required for v1.
+
+## UX Flows
+
+### Setting a per-topic default
+1. User navigates to the "Backend" topic in a forum group.
+2. Types `/default`.
+3. Sees keyboard: "Select the default agent for this topic:" with agent buttons.
+4. Taps "coder" → "Default agent for this topic set to @coder."
+
+### Clearing a per-topic default
+1. In the same topic, types `/default`.
+2. Keyboard shows "✓ coder (current)" and "No default agent (use chat default)".
+3. Taps "No default agent" → "Topic default removed. Messages will use the chat default (@designer)."
+
+### Non-forum group (no change)
+1. `/default` works exactly as today.
+2. `MessageThreadID` is 0, so all code paths hit the chat-level branch.
+
+## Complexity Assessment
+
+**This is a small, contained change.** Estimated at 1-2 days of implementation + testing.
+
+| Area | Scope |
+|------|-------|
+| New table + 3 store methods | ~40 lines |
+| `handleDefault()` thread-awareness | ~10 lines changed |
+| Callback data + `handleDefaultCallback()` | ~15 lines changed |
+| Routing fallback in `handleGroupMessage()` | ~10 lines changed |
+| Keyboard label tweaks in `cards.go` | ~10 lines changed |
+| **Total new/changed code** | **~85 lines** |
+
+No changes needed to:
+- The outbound message flow (thread routing already works)
+- The `GroupLink` struct or `group_links` table
+- The Telegram Bot API client
+- Any other command handlers
+
+## Risks and Edge Cases
+
+1. **General topic ambiguity:** Telegram uses thread ID 1 for the General topic in forum groups, but non-forum groups have thread ID 0. The code should treat `MessageThreadID == 0` as "no topic" (chat-level default). Thread ID 1 (General) should be a valid topic for per-topic defaults.
+
+2. **Topic deletion:** If a topic is deleted, its `topic_defaults` row becomes orphaned but harmless — no messages will arrive with that thread ID. Could add periodic cleanup, but not necessary.
+
+3. **Callback data length:** Telegram limits callback data to 64 bytes. Current format `dflt:agentSlug` uses ~15-25 bytes. Adding `:threadID` (max 20 digits) stays well within limits. If using the `callback_lookups` short-ID system already in the codebase, this is a non-issue.
+
+4. **Race between topic and chat defaults:** A user might set a chat default expecting it to apply everywhere, not realizing a topic has an override. The `/default` command should clearly indicate when a topic override exists.
+
+5. **Forum mode toggled off:** If a group admin disables forum mode, all topics collapse. Topic defaults become inert (messages arrive with thread ID 0). The chat-level default takes over naturally. No data loss; if forum mode is re-enabled, the topic defaults resume working.

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -348,9 +348,10 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 							log.Printf("Warning: failed to generate secret for broker plugin %q: %v", bt, secretErr)
 						} else {
 							hubCreds := map[string]string{
-								"hub_url":   hubEndpoint,
-								"hmac_key":  secretKey,
-								"broker_id": brokerID,
+								"hub_url":     hubEndpoint,
+								"hmac_key":    secretKey,
+								"broker_id":   brokerID,
+								"plugin_name": bt,
 							}
 							// Inject project slug map so hub-managed plugins can resolve
 							// human-readable project names without user-level API access.

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -378,10 +378,11 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 				}
 
 				observer := isObserverBroker(pluginMgr, bt)
+				channelID := pluginChannelID(pluginMgr, bt)
 				namedBuses = append(namedBuses, eventbus.NamedEventBus{
-					Name: bt, Bus: b, Observer: observer,
+					Name: bt, Bus: b, Observer: observer, ChannelID: channelID,
 				})
-				log.Printf("Message broker spoke added: name=%s observer=%v", bt, observer)
+				log.Printf("Message broker spoke added: name=%s channel_id=%s observer=%v", bt, channelID, observer)
 			}
 
 			fanout := eventbus.NewFanOutEventBus(namedBuses, logging.Subsystem("hub.eventbus.fanout"))
@@ -1249,6 +1250,25 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 	}
 
 	return nil
+}
+
+// pluginChannelID returns the channel identifier reported by a broker plugin
+// via GetInfo().ChannelID. Returns "" if the plugin does not report one, in
+// which case the bus Name is used for channel routing.
+func pluginChannelID(pluginMgr *scionplugin.Manager, name string) string {
+	raw, err := pluginMgr.Get(scionplugin.PluginTypeBroker, name)
+	if err != nil {
+		return ""
+	}
+	rpc, ok := raw.(*scionplugin.BrokerRPCClient)
+	if !ok {
+		return ""
+	}
+	info, err := rpc.GetInfo()
+	if err != nil || info == nil {
+		return ""
+	}
+	return info.ChannelID
 }
 
 // isObserverBroker determines whether a broker plugin should be treated as an

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1260,7 +1260,10 @@ func pluginChannelID(pluginMgr *scionplugin.Manager, name string) string {
 	if err != nil {
 		return ""
 	}
-	rpc, ok := raw.(*scionplugin.BrokerRPCClient)
+	type infoer interface {
+		GetInfo() (*scionplugin.PluginInfo, error)
+	}
+	rpc, ok := raw.(infoer)
 	if !ok {
 		return ""
 	}
@@ -1277,7 +1280,10 @@ func pluginChannelID(pluginMgr *scionplugin.Manager, name string) string {
 func isObserverBroker(pluginMgr *scionplugin.Manager, name string) bool {
 	raw, err := pluginMgr.Get(scionplugin.PluginTypeBroker, name)
 	if err == nil {
-		if rpc, ok := raw.(*scionplugin.BrokerRPCClient); ok {
+		type infoer interface {
+			GetInfo() (*scionplugin.PluginInfo, error)
+		}
+		if rpc, ok := raw.(infoer); ok {
 			if info, infoErr := rpc.GetInfo(); infoErr == nil && info != nil {
 				for _, cap := range info.Capabilities {
 					if strings.EqualFold(cap, "observer") {

--- a/extras/scion-chat-app/go.mod
+++ b/extras/scion-chat-app/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/scion/extras/scion-chat-app
 
-go 1.25.4
+go 1.26.1
 
 require (
 	cloud.google.com/go/secretmanager v1.16.0

--- a/extras/scion-chat-app/internal/chatapp/broker.go
+++ b/extras/scion-chat-app/internal/chatapp/broker.go
@@ -79,17 +79,25 @@ func (b *BrokerServer) Configure(config map[string]string) error {
 
 // Publish receives a message from the Hub and routes it to the handler.
 func (b *BrokerServer) Publish(ctx context.Context, topic string, msg *messages.StructuredMessage) error {
-	if msg != nil {
-		b.log.Debug("received message via broker",
-			"topic", topic,
-			"sender", msg.Sender,
-			"type", msg.Type,
-		)
+	if msg == nil {
+		return nil
 	}
+	b.log.Debug("received message via broker",
+		"topic", topic,
+		"sender", msg.Sender,
+		"type", msg.Type,
+	)
 	if b.handler != nil {
 		return b.handler(ctx, topic, msg)
 	}
 	return nil
+}
+
+// ChannelName returns the configured channel name in a thread-safe manner.
+func (b *BrokerServer) ChannelName() string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.channelName
 }
 
 // Subscribe registers a topic pattern for receiving messages.
@@ -121,7 +129,7 @@ func (b *BrokerServer) GetInfo() (*plugin.PluginInfo, error) {
 	return &plugin.PluginInfo{
 		Name:         "scion-chat-app",
 		Version:      "1.0.0",
-		ChannelID:    "gchat",
+		ChannelID:    b.ChannelName(),
 		Capabilities: []string{"chat-bridge", "notification-relay"},
 	}, nil
 }

--- a/extras/scion-chat-app/internal/chatapp/broker.go
+++ b/extras/scion-chat-app/internal/chatapp/broker.go
@@ -40,6 +40,7 @@ type BrokerServer struct {
 	mu            sync.RWMutex
 	subscriptions map[string]bool
 	configured    bool
+	channelName   string
 }
 
 // Compile-time interface checks.
@@ -66,12 +67,27 @@ func (b *BrokerServer) Configure(config map[string]string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.configured = true
+	if v, ok := config["plugin_name"]; ok && v != "" {
+		b.channelName = v
+	}
 	b.log.Info("broker plugin configured", "config_keys", len(config))
 	return nil
 }
 
 // Publish receives a message from the Hub and routes it to the handler.
 func (b *BrokerServer) Publish(ctx context.Context, topic string, msg *messages.StructuredMessage) error {
+	// Skip messages explicitly targeted at a different channel.
+	if msg != nil && msg.Channel != "" {
+		b.mu.RLock()
+		name := b.channelName
+		b.mu.RUnlock()
+		if name != "" && msg.Channel != name {
+			b.log.Debug("skipping message for different channel",
+				"channel", msg.Channel, "plugin", name, "topic", topic)
+			return nil
+		}
+	}
+
 	b.log.Debug("received message via broker",
 		"topic", topic,
 		"sender", msg.Sender,

--- a/extras/scion-chat-app/internal/chatapp/broker.go
+++ b/extras/scion-chat-app/internal/chatapp/broker.go
@@ -79,18 +79,6 @@ func (b *BrokerServer) Configure(config map[string]string) error {
 
 // Publish receives a message from the Hub and routes it to the handler.
 func (b *BrokerServer) Publish(ctx context.Context, topic string, msg *messages.StructuredMessage) error {
-	// Skip messages explicitly targeted at a different channel.
-	if msg != nil && msg.Channel != "" {
-		b.mu.RLock()
-		name := b.channelName
-		b.mu.RUnlock()
-		if name != "" && msg.Channel != name {
-			b.log.Debug("skipping message for different channel",
-				"channel", msg.Channel, "plugin", name, "topic", topic)
-			return nil
-		}
-	}
-
 	if msg != nil {
 		b.log.Debug("received message via broker",
 			"topic", topic,

--- a/extras/scion-chat-app/internal/chatapp/broker.go
+++ b/extras/scion-chat-app/internal/chatapp/broker.go
@@ -67,6 +67,9 @@ func (b *BrokerServer) Configure(config map[string]string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.configured = true
+	if b.channelName == "" {
+		b.channelName = "gchat"
+	}
 	if v, ok := config["plugin_name"]; ok && v != "" {
 		b.channelName = v
 	}
@@ -128,6 +131,7 @@ func (b *BrokerServer) GetInfo() (*plugin.PluginInfo, error) {
 	return &plugin.PluginInfo{
 		Name:         "scion-chat-app",
 		Version:      "1.0.0",
+		ChannelID:    "gchat",
 		Capabilities: []string{"chat-bridge", "notification-relay"},
 	}, nil
 }

--- a/extras/scion-chat-app/internal/chatapp/broker.go
+++ b/extras/scion-chat-app/internal/chatapp/broker.go
@@ -91,11 +91,13 @@ func (b *BrokerServer) Publish(ctx context.Context, topic string, msg *messages.
 		}
 	}
 
-	b.log.Debug("received message via broker",
-		"topic", topic,
-		"sender", msg.Sender,
-		"type", msg.Type,
-	)
+	if msg != nil {
+		b.log.Debug("received message via broker",
+			"topic", topic,
+			"sender", msg.Sender,
+			"type", msg.Type,
+		)
+	}
 	if b.handler != nil {
 		return b.handler(ctx, topic, msg)
 	}

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -320,7 +320,11 @@ func (r *CommandRouter) handleDialogSubmit(ctx context.Context, event *ChatEvent
 			return r.reply(ctx, event, fmt.Sprintf("Failed to create client: %v", err))
 		}
 
-		msg := messages.NewInstruction("user:"+mapping.HubUserEmail, agentID, responseText)
+		senderEmail := mapping.HubUserEmail
+		if senderEmail == "" {
+			return r.reply(ctx, event, "Your user mapping is missing a valid email address.")
+		}
+		msg := messages.NewInstruction("user:"+senderEmail, agentID, responseText)
 		msg.Channel = r.broker.ChannelName()
 		if event.ThreadID != "" {
 			msg.ThreadID = event.ThreadID

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -308,7 +308,11 @@ func (r *CommandRouter) handleDialogSubmit(ctx context.Context, event *ChatEvent
 		}
 
 		mapping, err := r.idMapper.ResolveOrAutoRegister(ctx, &eventUserLookup{event}, event.UserID, event.Platform)
-		if err != nil || mapping == nil {
+		if err != nil {
+			r.log.Error("Failed to resolve user mapping", "error", err, "userID", event.UserID)
+			return r.reply(ctx, event, "Something went wrong, please try again later.")
+		}
+		if mapping == nil {
 			return r.reply(ctx, event, "Authentication required. Use `/scionAdmin register` first.")
 		}
 		client, err := r.idMapper.ClientFor(ctx, mapping)

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -321,7 +321,7 @@ func (r *CommandRouter) handleDialogSubmit(ctx context.Context, event *ChatEvent
 		}
 
 		msg := messages.NewInstruction("user:"+mapping.HubUserEmail, agentID, responseText)
-		msg.Channel = "gchat"
+		msg.Channel = r.broker.ChannelName()
 		if event.ThreadID != "" {
 			msg.ThreadID = event.ThreadID
 		}
@@ -1076,7 +1076,7 @@ func (r *CommandRouter) cmdMessage(ctx context.Context, event *ChatEvent, args [
 
 	// Use the hub user email with "user:" prefix so agents can address replies
 	msg := messages.NewInstruction("user:"+mapping.HubUserEmail, agentSlug, messageText)
-	msg.Channel = "gchat"
+	msg.Channel = r.broker.ChannelName()
 	if threadID != "" {
 		msg.ThreadID = threadID
 	} else if event.ThreadID != "" {

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -307,12 +307,18 @@ func (r *CommandRouter) handleDialogSubmit(ctx context.Context, event *ChatEvent
 			return r.reply(ctx, event, "This space is not linked to a project.")
 		}
 
-		client, err := r.clientForUser(ctx, event)
-		if err != nil {
+		mapping, err := r.idMapper.ResolveOrAutoRegister(ctx, &eventUserLookup{event}, event.UserID, event.Platform)
+		if err != nil || mapping == nil {
 			return r.reply(ctx, event, "Authentication required. Use `/scionAdmin register` first.")
 		}
+		client, err := r.idMapper.ClientFor(ctx, mapping)
+		if err != nil {
+			return r.reply(ctx, event, fmt.Sprintf("Failed to create client: %v", err))
+		}
 
-		if err := client.ProjectAgents(link.ProjectID).SendMessage(ctx, agentID, responseText, false); err != nil {
+		msg := messages.NewInstruction("user:"+mapping.HubUserEmail, agentID, responseText)
+		msg.Channel = "gchat"
+		if err := client.ProjectAgents(link.ProjectID).SendStructuredMessage(ctx, agentID, msg, false, false, false); err != nil {
 			return r.reply(ctx, event, fmt.Sprintf("Failed to send response to agent: %v", err))
 		}
 		return r.reply(ctx, event, fmt.Sprintf("Response sent to agent `%s`.", agentID))

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -318,6 +318,9 @@ func (r *CommandRouter) handleDialogSubmit(ctx context.Context, event *ChatEvent
 
 		msg := messages.NewInstruction("user:"+mapping.HubUserEmail, agentID, responseText)
 		msg.Channel = "gchat"
+		if event.ThreadID != "" {
+			msg.ThreadID = event.ThreadID
+		}
 		if err := client.ProjectAgents(link.ProjectID).SendStructuredMessage(ctx, agentID, msg, false, false, false); err != nil {
 			return r.reply(ctx, event, fmt.Sprintf("Failed to send response to agent: %v", err))
 		}
@@ -1072,6 +1075,8 @@ func (r *CommandRouter) cmdMessage(ctx context.Context, event *ChatEvent, args [
 	msg.Channel = "gchat"
 	if threadID != "" {
 		msg.ThreadID = threadID
+	} else if event.ThreadID != "" {
+		msg.ThreadID = event.ThreadID
 	}
 
 	if err := client.ProjectAgents(link.ProjectID).SendStructuredMessage(ctx, agentSlug, msg, false, false, false); err != nil {

--- a/extras/scion-chat-app/internal/chatapp/notifications.go
+++ b/extras/scion-chat-app/internal/chatapp/notifications.go
@@ -181,9 +181,10 @@ func (n *NotificationRelay) handleUserMessage(ctx context.Context, projectID str
 		mentions := n.buildMentions(mapping.PlatformUserID, agentSlug, link)
 
 		if _, err := n.messenger.SendMessage(ctx, SendMessageRequest{
-			SpaceID: link.SpaceID,
-			Text:    mentions,
-			Card:    &card,
+			SpaceID:  link.SpaceID,
+			ThreadID: msg.ThreadID,
+			Text:     mentions,
+			Card:     &card,
 		}); err != nil {
 			n.log.Error("failed to relay user message",
 				"space_id", link.SpaceID,

--- a/extras/scion-telegram/go.mod
+++ b/extras/scion-telegram/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/scion/extras/scion-telegram
 
-go 1.25.4
+go 1.26.1
 
 require (
 	github.com/GoogleCloudPlatform/scion v0.0.0-00010101000000-000000000000

--- a/extras/scion-telegram/internal/telegram/api.go
+++ b/extras/scion-telegram/internal/telegram/api.go
@@ -187,9 +187,10 @@ type CallbackQuery struct {
 
 // sendMessageRequest is the JSON body for the sendMessage API call.
 type sendMessageRequest struct {
-	ChatID    int64  `json:"chat_id"`
-	Text      string `json:"text"`
-	ParseMode string `json:"parse_mode,omitempty"`
+	ChatID          int64  `json:"chat_id"`
+	Text            string `json:"text"`
+	ParseMode       string `json:"parse_mode,omitempty"`
+	MessageThreadID int64  `json:"message_thread_id,omitempty"`
 }
 
 // sendMessageWithKeyboardRequest is the JSON body for sendMessage with an inline keyboard.
@@ -199,6 +200,7 @@ type sendMessageWithKeyboardRequest struct {
 	ParseMode        string                `json:"parse_mode,omitempty"`
 	ReplyMarkup      *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 	ReplyToMessageID int64                 `json:"reply_to_message_id,omitempty"`
+	MessageThreadID  int64                 `json:"message_thread_id,omitempty"`
 }
 
 // ForceReply instructs Telegram clients to display a reply interface to the
@@ -211,10 +213,11 @@ type ForceReply struct {
 // sendMessageForceReplyRequest is the JSON body for sendMessage with
 // ForceReply markup and an optional inline keyboard.
 type sendMessageForceReplyRequest struct {
-	ChatID      int64           `json:"chat_id"`
-	Text        string          `json:"text"`
-	ParseMode   string          `json:"parse_mode,omitempty"`
-	ReplyMarkup json.RawMessage `json:"reply_markup,omitempty"`
+	ChatID          int64           `json:"chat_id"`
+	Text            string          `json:"text"`
+	ParseMode       string          `json:"parse_mode,omitempty"`
+	ReplyMarkup     json.RawMessage `json:"reply_markup,omitempty"`
+	MessageThreadID int64           `json:"message_thread_id,omitempty"`
 }
 
 // editMessageTextRequest is the JSON body for the editMessageText API call.
@@ -458,12 +461,20 @@ func (c *TelegramAPIClient) GetUpdates(ctx context.Context, offset int64, timeou
 	return updates, nil
 }
 
+// SendOption provides optional parameters for send methods.
+type SendOption struct {
+	MessageThreadID int64
+}
+
 // SendMessage sends a text message to the specified chat.
-func (c *TelegramAPIClient) SendMessage(ctx context.Context, chatID int64, text, parseMode string) (*TGMessage, error) {
+func (c *TelegramAPIClient) SendMessage(ctx context.Context, chatID int64, text, parseMode string, opts ...SendOption) (*TGMessage, error) {
 	body := sendMessageRequest{
 		ChatID:    chatID,
 		Text:      text,
 		ParseMode: parseMode,
+	}
+	for _, o := range opts {
+		body.MessageThreadID = o.MessageThreadID
 	}
 
 	jsonBody, err := json.Marshal(body)
@@ -506,13 +517,16 @@ func (c *TelegramAPIClient) SendMessage(ctx context.Context, chatID int64, text,
 }
 
 // SendMessageWithKeyboard sends a text message with an inline keyboard and optional reply.
-func (c *TelegramAPIClient) SendMessageWithKeyboard(ctx context.Context, chatID int64, text, parseMode string, keyboard *InlineKeyboardMarkup, replyToMessageID int64) (*TGMessage, error) {
+func (c *TelegramAPIClient) SendMessageWithKeyboard(ctx context.Context, chatID int64, text, parseMode string, keyboard *InlineKeyboardMarkup, replyToMessageID int64, opts ...SendOption) (*TGMessage, error) {
 	body := sendMessageWithKeyboardRequest{
 		ChatID:           chatID,
 		Text:             text,
 		ParseMode:        parseMode,
 		ReplyMarkup:      keyboard,
 		ReplyToMessageID: replyToMessageID,
+	}
+	for _, o := range opts {
+		body.MessageThreadID = o.MessageThreadID
 	}
 
 	jsonBody, err := json.Marshal(body)

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -486,6 +486,13 @@ func (b *TelegramBrokerV2) Publish(ctx context.Context, topic string, msg *messa
 		return fmt.Errorf("telegram v2 broker not configured")
 	}
 
+	// Channel filter: skip messages explicitly targeted at a different channel.
+	if msg != nil && msg.Channel != "" && msg.Channel != b.pluginName {
+		b.log.Debug("Skipping message for different channel",
+			"channel", msg.Channel, "plugin", b.pluginName)
+		return nil
+	}
+
 	// Dedup check.
 	dedupKey := msgDedupKey(msg)
 	if dedupKey != "" {
@@ -689,21 +696,28 @@ func (b *TelegramBrokerV2) Publish(ctx context.Context, topic string, msg *messa
 		}
 	}
 
+	// Determine thread ID for Telegram forum topics.
+	var threadOpts []SendOption
+	if msg != nil && msg.ThreadID != "" {
+		if tid, err := strconv.ParseInt(msg.ThreadID, 10, 64); err == nil && tid != 0 {
+			threadOpts = append(threadOpts, SendOption{MessageThreadID: tid})
+		}
+	}
+
 	var errs []error
 	for _, chatID := range chatIDs {
 		var err error
 		if sq != nil {
 			var keyboard *InlineKeyboardMarkup
 			if replyToMsgID > 0 {
-				// Pass nil keyboard but use replyTo.
-				_, err = sq.Send(ctx, chatID, text, "", keyboard, replyToMsgID)
+				_, err = sq.Send(ctx, chatID, text, "", keyboard, replyToMsgID, threadOpts...)
 			} else {
-				_, err = sq.Send(ctx, chatID, text, "", nil, 0)
+				_, err = sq.Send(ctx, chatID, text, "", nil, 0, threadOpts...)
 			}
 		} else if replyToMsgID > 0 {
-			_, err = api.SendMessageWithKeyboard(ctx, chatID, text, "", nil, replyToMsgID)
+			_, err = api.SendMessageWithKeyboard(ctx, chatID, text, "", nil, replyToMsgID, threadOpts...)
 		} else {
-			_, err = api.SendMessage(ctx, chatID, text, "")
+			_, err = api.SendMessage(ctx, chatID, text, "", threadOpts...)
 		}
 		if err != nil {
 			var apiErr *APIError

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -1549,8 +1549,16 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 	}
 	b.mu.RUnlock()
 
+	// Resolve effective default agent: topic-level override first, then chat-level.
+	effectiveDefault := link.DefaultAgent
+	if tgMsg.MessageThreadID != 0 {
+		if topicDefault, _ := b.store.GetTopicDefault(ctx, chatID, tgMsg.MessageThreadID); topicDefault != "" {
+			effectiveDefault = topicDefault
+		}
+	}
+
 	// Resolve target agents from @-mentions.
-	targets, isAll := resolveTargetAgents(tgMsg, botUsername, link.DefaultAgent, agents)
+	targets, isAll := resolveTargetAgents(tgMsg, botUsername, effectiveDefault, agents)
 
 	// Fallback 1: reply-to-bot-message — extract the agent from the replied-to message.
 	if len(targets) == 0 && tgMsg.ReplyToMessage != nil {
@@ -1604,13 +1612,13 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 	// Telegram user — that's a user-to-user message. Mentions embedded
 	// later (offset>0) do not block default routing; resolveUserMentions
 	// injects the resolved scion identity for those.
-	if len(targets) == 0 && link.DefaultAgent != "" {
+	if len(targets) == 0 && effectiveDefault != "" {
 		hasAttachment := tgMsg.Photo != nil || tgMsg.Document != nil
 		text := strings.TrimSpace(tgMsg.Text)
 		textRoutes := text != "" && !strings.HasPrefix(text, "/") && !strings.HasPrefix(text, "@") && !hasNonBotUserMention(tgMsg, botUsername, agents)
 		if textRoutes || hasAttachment {
-			b.log.Debug("Using default agent", "agent", link.DefaultAgent)
-			targets = []string{link.DefaultAgent}
+			b.log.Debug("Using default agent", "agent", effectiveDefault)
+			targets = []string{effectiveDefault}
 		}
 	}
 

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -486,13 +486,6 @@ func (b *TelegramBrokerV2) Publish(ctx context.Context, topic string, msg *messa
 		return fmt.Errorf("telegram v2 broker not configured")
 	}
 
-	// Channel filter: skip messages explicitly targeted at a different channel.
-	if msg != nil && msg.Channel != "" && msg.Channel != b.pluginName {
-		b.log.Debug("Skipping message for different channel",
-			"channel", msg.Channel, "plugin", b.pluginName)
-		return nil
-	}
-
 	// Dedup check.
 	dedupKey := msgDedupKey(msg)
 	if dedupKey != "" {
@@ -1552,7 +1545,9 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 	// Resolve effective default agent: topic-level override first, then chat-level.
 	effectiveDefault := link.DefaultAgent
 	if tgMsg.MessageThreadID != 0 {
-		if topicDefault, _ := b.store.GetTopicDefault(ctx, chatID, tgMsg.MessageThreadID); topicDefault != "" {
+		if topicDefault, err := b.store.GetTopicDefault(ctx, chatID, tgMsg.MessageThreadID); err != nil {
+			b.log.Error("Failed to get topic default", "error", err)
+		} else if topicDefault != "" {
 			effectiveDefault = topicDefault
 		}
 	}

--- a/extras/scion-telegram/internal/telegram/callbacks.go
+++ b/extras/scion-telegram/internal/telegram/callbacks.go
@@ -83,6 +83,19 @@ func (h *CallbackHandler) HandleCallback(ctx context.Context, cb *CallbackQuery)
 		return nil, nil
 	}
 
+	if strings.HasPrefix(cb.Data, callbackLookupPrefix) {
+		shortID := strings.TrimPrefix(cb.Data, callbackLookupPrefix)
+		lookup, err := h.store.GetCallbackLookup(ctx, shortID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve callback lookup %s: %w", shortID, err)
+		}
+		if lookup == nil {
+			h.answerCallback(ctx, cb.ID, "This button has expired. Please try the command again.", false)
+			return nil, nil
+		}
+		cb.Data = lookup.FullData
+	}
+
 	parts := strings.SplitN(cb.Data, ":", 4)
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("invalid callback data: %s", cb.Data)

--- a/extras/scion-telegram/internal/telegram/callbacks.go
+++ b/extras/scion-telegram/internal/telegram/callbacks.go
@@ -324,10 +324,20 @@ func (h *CallbackHandler) handleDefaultCallback(ctx context.Context, cb *Callbac
 		messageID = cb.Message.MessageID
 	}
 
+	// Parse optional thread ID for topic-scoped defaults.
+	var threadID int64
+	if len(parts) >= 2 {
+		threadID, _ = strconv.ParseInt(parts[1], 10, 64)
+	}
+
 	link, err := h.store.GetGroupLink(ctx, chatID)
 	if err != nil || link == nil {
 		h.answerCallback(ctx, cb.ID, "Group is not linked to a project.", false)
 		return err
+	}
+
+	if threadID != 0 {
+		return h.handleTopicDefaultCallback(ctx, cb, chatID, messageID, threadID, agentSlug, link)
 	}
 
 	if agentSlug == "__none__" {
@@ -348,6 +358,32 @@ func (h *CallbackHandler) handleDefaultCallback(ctx context.Context, cb *Callbac
 		h.editMessage(ctx, chatID, messageID,
 			fmt.Sprintf("Default agent set to @%s.", agentSlug), nil)
 		h.answerCallback(ctx, cb.ID, fmt.Sprintf("Default: @%s", agentSlug), false)
+	}
+	return nil
+}
+
+func (h *CallbackHandler) handleTopicDefaultCallback(ctx context.Context, cb *CallbackQuery, chatID, messageID, threadID int64, agentSlug string, link *GroupLink) error {
+	if agentSlug == "__none__" {
+		if err := h.store.DeleteTopicDefault(ctx, chatID, threadID); err != nil {
+			h.log.Error("Failed to delete topic default", "chat_id", chatID, "thread_id", threadID, "error", err)
+			h.answerCallback(ctx, cb.ID, "Failed to update topic default.", false)
+			return err
+		}
+		fallbackMsg := "Topic default removed."
+		if link.DefaultAgent != "" {
+			fallbackMsg += fmt.Sprintf(" Messages will use the chat default (@%s).", link.DefaultAgent)
+		}
+		h.editMessage(ctx, chatID, messageID, fallbackMsg, nil)
+		h.answerCallback(ctx, cb.ID, "Topic default: none", false)
+	} else {
+		if err := h.store.SetTopicDefault(ctx, chatID, threadID, agentSlug); err != nil {
+			h.log.Error("Failed to set topic default", "chat_id", chatID, "thread_id", threadID, "error", err)
+			h.answerCallback(ctx, cb.ID, "Failed to update topic default.", false)
+			return err
+		}
+		h.editMessage(ctx, chatID, messageID,
+			fmt.Sprintf("Default agent for this topic set to @%s.", agentSlug), nil)
+		h.answerCallback(ctx, cb.ID, fmt.Sprintf("Topic default: @%s", agentSlug), false)
 	}
 	return nil
 }

--- a/extras/scion-telegram/internal/telegram/cards.go
+++ b/extras/scion-telegram/internal/telegram/cards.go
@@ -16,6 +16,7 @@ package telegram
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 )
 
@@ -90,7 +91,7 @@ func buildDefaultAgentKeyboard(agents []string, currentDefault string, threadID 
 	if suffix != "" {
 		for i, row := range kb.InlineKeyboard {
 			for j, btn := range row {
-				kb.InlineKeyboard[i][j].CallbackData = truncateCallback(btn.CallbackData + suffix)
+				kb.InlineKeyboard[i][j].CallbackData = fitCallback(btn.CallbackData, suffix)
 			}
 		}
 	}
@@ -106,7 +107,7 @@ func buildDefaultAgentKeyboard(agents []string, currentDefault string, threadID 
 		}
 	}
 	kb.InlineKeyboard = append(kb.InlineKeyboard, []InlineKeyboardButton{
-		{Text: noneLabel, CallbackData: truncateCallback("dflt:__none__" + suffix)},
+		{Text: noneLabel, CallbackData: fitCallback("dflt:__none__", suffix)},
 	})
 	return kb
 }
@@ -262,5 +263,25 @@ func truncateCallback(data string) string {
 	if len(data) <= maxCallbackData {
 		return data
 	}
+	slog.Warn("callback_data exceeds 64-byte Telegram limit, truncating",
+		"len", len(data), "data", data)
 	return data[:maxCallbackData]
+}
+
+// fitCallback truncates the prefix portion of callback data to make room for
+// a required suffix (e.g. a threadID) that must not be corrupted. If the
+// prefix alone already exceeds the limit, it falls back to simple truncation
+// of the combined string.
+func fitCallback(prefix, suffix string) string {
+	combined := prefix + suffix
+	if len(combined) <= maxCallbackData {
+		return combined
+	}
+	maxPrefix := maxCallbackData - len(suffix)
+	if maxPrefix > 0 {
+		slog.Warn("callback_data exceeds 64-byte Telegram limit, truncating prefix to preserve suffix",
+			"len", len(combined), "prefix", prefix, "suffix", suffix)
+		return prefix[:maxPrefix] + suffix
+	}
+	return truncateCallback(combined)
 }

--- a/extras/scion-telegram/internal/telegram/cards.go
+++ b/extras/scion-telegram/internal/telegram/cards.go
@@ -15,9 +15,13 @@
 package telegram
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"strconv"
+	"time"
 )
 
 // ProjectOption represents a project choice for keyboard selection.
@@ -73,6 +77,11 @@ func buildProjectSelectionKeyboard(projects []ProjectOption) *InlineKeyboardMark
 // Callback data format: setup:dflt:<agentSlug>
 func buildAgentSelectionKeyboard(agents []string, currentDefault string) *InlineKeyboardMarkup {
 	kb := buildAgentKeyboard(agents, currentDefault, "setup:dflt")
+	for i, row := range kb.InlineKeyboard {
+		for j, btn := range row {
+			kb.InlineKeyboard[i][j].CallbackData = truncateCallback(btn.CallbackData)
+		}
+	}
 	kb.InlineKeyboard = append(kb.InlineKeyboard, []InlineKeyboardButton{
 		{Text: "No default agent", CallbackData: "setup:dflt:"},
 	})
@@ -81,18 +90,18 @@ func buildAgentSelectionKeyboard(agents []string, currentDefault string) *Inline
 
 // buildDefaultAgentKeyboard creates an inline keyboard for /default command.
 // Callback data format: dflt:<agentSlug> or dflt:<agentSlug>:<threadID> for topic-scoped defaults.
-func buildDefaultAgentKeyboard(agents []string, currentDefault string, threadID int64) *InlineKeyboardMarkup {
+// When the callback data exceeds Telegram's 64-byte limit, it is stored in
+// callback_lookups and replaced with a short cblu:<id> reference.
+func buildDefaultAgentKeyboard(ctx context.Context, store Store, agents []string, currentDefault string, threadID int64) *InlineKeyboardMarkup {
 	suffix := ""
 	if threadID != 0 {
 		suffix = ":" + strconv.FormatInt(threadID, 10)
 	}
 	prefix := "dflt"
 	kb := buildAgentKeyboard(agents, currentDefault, prefix)
-	if suffix != "" {
-		for i, row := range kb.InlineKeyboard {
-			for j, btn := range row {
-				kb.InlineKeyboard[i][j].CallbackData = fitCallback(btn.CallbackData, suffix)
-			}
+	for i, row := range kb.InlineKeyboard {
+		for j, btn := range row {
+			kb.InlineKeyboard[i][j].CallbackData = callbackOrLookup(ctx, store, btn.CallbackData+suffix)
 		}
 	}
 	noneLabel := "No default agent"
@@ -107,7 +116,7 @@ func buildDefaultAgentKeyboard(agents []string, currentDefault string, threadID 
 		}
 	}
 	kb.InlineKeyboard = append(kb.InlineKeyboard, []InlineKeyboardButton{
-		{Text: noneLabel, CallbackData: fitCallback("dflt:__none__", suffix)},
+		{Text: noneLabel, CallbackData: callbackOrLookup(ctx, store, "dflt:__none__"+suffix)},
 	})
 	return kb
 }
@@ -123,7 +132,7 @@ func buildAgentKeyboard(agents []string, currentDefault string, prefix string) *
 		}
 		btn := InlineKeyboardButton{
 			Text:         label,
-			CallbackData: truncateCallback(fmt.Sprintf("%s:%s", prefix, agent)),
+			CallbackData: fmt.Sprintf("%s:%s", prefix, agent),
 		}
 		row = append(row, btn)
 		if len(row) == 2 {
@@ -268,20 +277,35 @@ func truncateCallback(data string) string {
 	return data[:maxCallbackData]
 }
 
-// fitCallback truncates the prefix portion of callback data to make room for
-// a required suffix (e.g. a threadID) that must not be corrupted. If the
-// prefix alone already exceeds the limit, it falls back to simple truncation
-// of the combined string.
-func fitCallback(prefix, suffix string) string {
-	combined := prefix + suffix
-	if len(combined) <= maxCallbackData {
-		return combined
+// callbackLookupPrefix identifies callback data that is stored in the
+// callback_lookups table rather than inline.
+const callbackLookupPrefix = "cblu:"
+
+// callbackLookupTTL is how long a stored callback lookup remains valid.
+const callbackLookupTTL = 24 * time.Hour
+
+// callbackOrLookup returns data as-is when it fits within Telegram's 64-byte
+// callback_data limit. When data exceeds the limit, the full payload is
+// persisted via the store's callback_lookups table and a short cblu:<id>
+// reference is returned instead.
+func callbackOrLookup(ctx context.Context, store Store, data string) string {
+	if len(data) <= maxCallbackData {
+		return data
 	}
-	maxPrefix := maxCallbackData - len(suffix)
-	if maxPrefix > 0 {
-		slog.Warn("callback_data exceeds 64-byte Telegram limit, truncating prefix to preserve suffix",
-			"len", len(combined), "prefix", prefix, "suffix", suffix)
-		return prefix[:maxPrefix] + suffix
+	idBytes := make([]byte, 8)
+	if _, err := rand.Read(idBytes); err != nil {
+		slog.Error("failed to generate callback lookup ID", "error", err)
+		return truncateCallback(data)
 	}
-	return truncateCallback(combined)
+	shortID := hex.EncodeToString(idBytes)
+	lookup := &CallbackLookup{
+		ShortID:   shortID,
+		FullData:  data,
+		ExpiresAt: time.Now().Add(callbackLookupTTL),
+	}
+	if err := store.SaveCallbackLookup(ctx, lookup); err != nil {
+		slog.Error("failed to save callback lookup", "error", err, "data", data)
+		return truncateCallback(data)
+	}
+	return callbackLookupPrefix + shortID
 }

--- a/extras/scion-telegram/internal/telegram/cards.go
+++ b/extras/scion-telegram/internal/telegram/cards.go
@@ -14,7 +14,10 @@
 
 package telegram
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+)
 
 // ProjectOption represents a project choice for keyboard selection.
 type ProjectOption struct {
@@ -76,15 +79,34 @@ func buildAgentSelectionKeyboard(agents []string, currentDefault string) *Inline
 }
 
 // buildDefaultAgentKeyboard creates an inline keyboard for /default command.
-// Callback data format: dflt:<agentSlug>
-func buildDefaultAgentKeyboard(agents []string, currentDefault string) *InlineKeyboardMarkup {
-	kb := buildAgentKeyboard(agents, currentDefault, "dflt")
+// Callback data format: dflt:<agentSlug> or dflt:<agentSlug>:<threadID> for topic-scoped defaults.
+func buildDefaultAgentKeyboard(agents []string, currentDefault string, threadID int64) *InlineKeyboardMarkup {
+	suffix := ""
+	if threadID != 0 {
+		suffix = ":" + strconv.FormatInt(threadID, 10)
+	}
+	prefix := "dflt"
+	kb := buildAgentKeyboard(agents, currentDefault, prefix)
+	if suffix != "" {
+		for i, row := range kb.InlineKeyboard {
+			for j, btn := range row {
+				kb.InlineKeyboard[i][j].CallbackData = truncateCallback(btn.CallbackData + suffix)
+			}
+		}
+	}
 	noneLabel := "No default agent"
+	if threadID != 0 {
+		noneLabel = "No default agent (use chat default)"
+	}
 	if currentDefault == "" {
-		noneLabel = "✓ No default agent (current)"
+		if threadID != 0 {
+			noneLabel = "✓ No default agent (current, using chat default)"
+		} else {
+			noneLabel = "✓ No default agent (current)"
+		}
 	}
 	kb.InlineKeyboard = append(kb.InlineKeyboard, []InlineKeyboardButton{
-		{Text: noneLabel, CallbackData: "dflt:__none__"},
+		{Text: noneLabel, CallbackData: truncateCallback("dflt:__none__" + suffix)},
 	})
 	return kb
 }

--- a/extras/scion-telegram/internal/telegram/cards_test.go
+++ b/extras/scion-telegram/internal/telegram/cards_test.go
@@ -15,7 +15,9 @@
 package telegram
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,7 +98,8 @@ func TestBuildAgentSelectionKeyboard_NoDefault(t *testing.T) {
 }
 
 func TestBuildDefaultAgentKeyboard_CallbackFormat(t *testing.T) {
-	kb := buildDefaultAgentKeyboard([]string{"coder", "reviewer"}, "coder", 0)
+	store := newTestStore(t)
+	kb := buildDefaultAgentKeyboard(context.Background(), store, []string{"coder", "reviewer"}, "coder", 0)
 	assert.Equal(t, "dflt:coder", kb.InlineKeyboard[0][0].CallbackData)
 	assert.Equal(t, "✓ coder (current)", kb.InlineKeyboard[0][0].Text)
 	assert.Equal(t, "dflt:reviewer", kb.InlineKeyboard[0][1].CallbackData)
@@ -104,7 +107,8 @@ func TestBuildDefaultAgentKeyboard_CallbackFormat(t *testing.T) {
 }
 
 func TestBuildDefaultAgentKeyboard_TopicScoped(t *testing.T) {
-	kb := buildDefaultAgentKeyboard([]string{"coder", "reviewer"}, "coder", 42)
+	store := newTestStore(t)
+	kb := buildDefaultAgentKeyboard(context.Background(), store, []string{"coder", "reviewer"}, "coder", 42)
 	assert.Equal(t, "dflt:coder:42", kb.InlineKeyboard[0][0].CallbackData)
 	assert.Equal(t, "✓ coder (current)", kb.InlineKeyboard[0][0].Text)
 	assert.Equal(t, "dflt:reviewer:42", kb.InlineKeyboard[0][1].CallbackData)
@@ -112,6 +116,24 @@ func TestBuildDefaultAgentKeyboard_TopicScoped(t *testing.T) {
 	lastRow := kb.InlineKeyboard[len(kb.InlineKeyboard)-1]
 	assert.Equal(t, "dflt:__none__:42", lastRow[0].CallbackData)
 	assert.Contains(t, lastRow[0].Text, "use chat default")
+}
+
+func TestBuildDefaultAgentKeyboard_LongSlugUsesLookup(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	longSlug := "this-is-a-very-long-agent-slug-that-will-exceed-sixty-four-bytes"
+	kb := buildDefaultAgentKeyboard(ctx, store, []string{longSlug}, "", 99999999)
+
+	cbData := kb.InlineKeyboard[0][0].CallbackData
+	assert.True(t, strings.HasPrefix(cbData, callbackLookupPrefix),
+		"expected callback lookup prefix, got %q", cbData)
+	assert.LessOrEqual(t, len(cbData), maxCallbackData)
+
+	shortID := strings.TrimPrefix(cbData, callbackLookupPrefix)
+	lookup, err := store.GetCallbackLookup(ctx, shortID)
+	require.NoError(t, err)
+	require.NotNil(t, lookup)
+	assert.Equal(t, fmt.Sprintf("dflt:%s:99999999", longSlug), lookup.FullData)
 }
 
 func TestBuildAskUserKeyboard_WithChoices(t *testing.T) {

--- a/extras/scion-telegram/internal/telegram/cards_test.go
+++ b/extras/scion-telegram/internal/telegram/cards_test.go
@@ -96,11 +96,22 @@ func TestBuildAgentSelectionKeyboard_NoDefault(t *testing.T) {
 }
 
 func TestBuildDefaultAgentKeyboard_CallbackFormat(t *testing.T) {
-	kb := buildDefaultAgentKeyboard([]string{"coder", "reviewer"}, "coder")
+	kb := buildDefaultAgentKeyboard([]string{"coder", "reviewer"}, "coder", 0)
 	assert.Equal(t, "dflt:coder", kb.InlineKeyboard[0][0].CallbackData)
 	assert.Equal(t, "✓ coder (current)", kb.InlineKeyboard[0][0].Text)
 	assert.Equal(t, "dflt:reviewer", kb.InlineKeyboard[0][1].CallbackData)
 	assert.Equal(t, "reviewer", kb.InlineKeyboard[0][1].Text)
+}
+
+func TestBuildDefaultAgentKeyboard_TopicScoped(t *testing.T) {
+	kb := buildDefaultAgentKeyboard([]string{"coder", "reviewer"}, "coder", 42)
+	assert.Equal(t, "dflt:coder:42", kb.InlineKeyboard[0][0].CallbackData)
+	assert.Equal(t, "✓ coder (current)", kb.InlineKeyboard[0][0].Text)
+	assert.Equal(t, "dflt:reviewer:42", kb.InlineKeyboard[0][1].CallbackData)
+
+	lastRow := kb.InlineKeyboard[len(kb.InlineKeyboard)-1]
+	assert.Equal(t, "dflt:__none__:42", lastRow[0].CallbackData)
+	assert.Contains(t, lastRow[0].Text, "use chat default")
 }
 
 func TestBuildAskUserKeyboard_WithChoices(t *testing.T) {

--- a/extras/scion-telegram/internal/telegram/commands.go
+++ b/extras/scion-telegram/internal/telegram/commands.go
@@ -239,7 +239,7 @@ func (h *CommandHandler) handleDefault(msg *TGMessage) {
 		}
 	}
 
-	kb := buildDefaultAgentKeyboard(agentSlugs(agents), currentDefault, threadID)
+	kb := buildDefaultAgentKeyboard(ctx, h.store, agentSlugs(agents), currentDefault, threadID)
 	h.replyWithKeyboardInThread(chatID, threadID, promptText, kb)
 }
 

--- a/extras/scion-telegram/internal/telegram/commands.go
+++ b/extras/scion-telegram/internal/telegram/commands.go
@@ -193,6 +193,7 @@ func (h *CommandHandler) handleSetup(msg *TGMessage) {
 
 func (h *CommandHandler) handleDefault(msg *TGMessage) {
 	chatID := msg.Chat.ID
+	threadID := msg.MessageThreadID
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -222,8 +223,22 @@ func (h *CommandHandler) handleDefault(msg *TGMessage) {
 		return
 	}
 
-	kb := buildDefaultAgentKeyboard(agentSlugs(agents), link.DefaultAgent)
-	h.replyWithKeyboard(chatID, "Select the default agent for @-mentions:", kb)
+	promptText := "Select the default agent for @-mentions:"
+	currentDefault := link.DefaultAgent
+
+	if threadID != 0 {
+		topicDefault, _ := h.store.GetTopicDefault(ctx, chatID, threadID)
+		if topicDefault != "" {
+			currentDefault = topicDefault
+		}
+		promptText = "Select the default agent for this topic:"
+		if link.DefaultAgent != "" {
+			promptText += fmt.Sprintf("\nChat-wide default: @%s", link.DefaultAgent)
+		}
+	}
+
+	kb := buildDefaultAgentKeyboard(agentSlugs(agents), currentDefault, threadID)
+	h.replyWithKeyboardInThread(chatID, threadID, promptText, kb)
 }
 
 func (h *CommandHandler) handleAgents(msg *TGMessage) {
@@ -571,6 +586,18 @@ func (h *CommandHandler) replyWithKeyboard(chatID int64, text string, kb *Inline
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if _, err := h.api.SendMessageWithKeyboard(ctx, chatID, text, "", kb, 0); err != nil {
+		h.log.Error("Failed to send reply with keyboard", "chat_id", chatID, "error", err)
+	}
+}
+
+func (h *CommandHandler) replyWithKeyboardInThread(chatID int64, threadID int64, text string, kb *InlineKeyboardMarkup) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var opts []SendOption
+	if threadID != 0 {
+		opts = append(opts, SendOption{MessageThreadID: threadID})
+	}
+	if _, err := h.api.SendMessageWithKeyboard(ctx, chatID, text, "", kb, 0, opts...); err != nil {
 		h.log.Error("Failed to send reply with keyboard", "chat_id", chatID, "error", err)
 	}
 }

--- a/extras/scion-telegram/internal/telegram/commands.go
+++ b/extras/scion-telegram/internal/telegram/commands.go
@@ -227,8 +227,10 @@ func (h *CommandHandler) handleDefault(msg *TGMessage) {
 	currentDefault := link.DefaultAgent
 
 	if threadID != 0 {
-		topicDefault, _ := h.store.GetTopicDefault(ctx, chatID, threadID)
-		if topicDefault != "" {
+		topicDefault, err := h.store.GetTopicDefault(ctx, chatID, threadID)
+		if err != nil {
+			h.log.Error("Failed to get topic default", "error", err)
+		} else if topicDefault != "" {
 			currentDefault = topicDefault
 		}
 		promptText = "Select the default agent for this topic:"

--- a/extras/scion-telegram/internal/telegram/sendqueue.go
+++ b/extras/scion-telegram/internal/telegram/sendqueue.go
@@ -51,12 +51,13 @@ type chatQueue struct {
 
 // outboundMessage represents a message waiting to be sent through the queue.
 type outboundMessage struct {
-	chatID    int64
-	text      string
-	parseMode string
-	keyboard  *InlineKeyboardMarkup
-	replyTo   int64
-	result    chan<- *sendResult // caller blocks on this to receive the outcome
+	chatID          int64
+	text            string
+	parseMode       string
+	keyboard        *InlineKeyboardMarkup
+	replyTo         int64
+	messageThreadID int64
+	result          chan<- *sendResult // caller blocks on this to receive the outcome
 }
 
 // sendResult carries the outcome of a queued send back to the caller.
@@ -88,7 +89,7 @@ func NewSendQueue(api *TelegramAPIClient, log *slog.Logger, maxSize int, minDela
 
 // Send enqueues a message and blocks until it is sent (or fails).
 // It returns the Telegram API response or an error.
-func (sq *SendQueue) Send(ctx context.Context, chatID int64, text, parseMode string, keyboard *InlineKeyboardMarkup, replyTo int64) (*TGMessage, error) {
+func (sq *SendQueue) Send(ctx context.Context, chatID int64, text, parseMode string, keyboard *InlineKeyboardMarkup, replyTo int64, opts ...SendOption) (*TGMessage, error) {
 	resultCh := make(chan *sendResult, 1)
 
 	om := &outboundMessage{
@@ -98,6 +99,9 @@ func (sq *SendQueue) Send(ctx context.Context, chatID int64, text, parseMode str
 		keyboard:  keyboard,
 		replyTo:   replyTo,
 		result:    resultCh,
+	}
+	for _, o := range opts {
+		om.messageThreadID = o.MessageThreadID
 	}
 
 	ch, err := sq.enqueue(chatID, om)
@@ -235,10 +239,15 @@ func (sq *SendQueue) sendOne(om *outboundMessage) (*TGMessage, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if om.keyboard != nil || om.replyTo > 0 {
-		return sq.api.SendMessageWithKeyboard(ctx, om.chatID, om.text, om.parseMode, om.keyboard, om.replyTo)
+	var opts []SendOption
+	if om.messageThreadID != 0 {
+		opts = append(opts, SendOption{MessageThreadID: om.messageThreadID})
 	}
-	return sq.api.SendMessage(ctx, om.chatID, om.text, om.parseMode)
+
+	if om.keyboard != nil || om.replyTo > 0 {
+		return sq.api.SendMessageWithKeyboard(ctx, om.chatID, om.text, om.parseMode, om.keyboard, om.replyTo, opts...)
+	}
+	return sq.api.SendMessage(ctx, om.chatID, om.text, om.parseMode, opts...)
 }
 
 // removeQueue removes the per-chat queue from the map when the worker exits.

--- a/extras/scion-telegram/internal/telegram/store.go
+++ b/extras/scion-telegram/internal/telegram/store.go
@@ -67,6 +67,11 @@ type Store interface {
 	GetNotificationPrefs(ctx context.Context, telegramUserID string) ([]*NotificationPref, error)
 	GetNotificationPref(ctx context.Context, telegramUserID, projectID, agentSlug string) (*NotificationPref, error)
 
+	// TopicDefault — per-topic default agent overrides for forum groups
+	GetTopicDefault(ctx context.Context, chatID int64, threadID int64) (string, error)
+	SetTopicDefault(ctx context.Context, chatID int64, threadID int64, agentSlug string) error
+	DeleteTopicDefault(ctx context.Context, chatID int64, threadID int64) error
+
 	// Lifecycle
 	Close() error
 }
@@ -233,6 +238,13 @@ CREATE TABLE IF NOT EXISTS notification_prefs (
 	agent_slug       TEXT NOT NULL,
 	enabled          INTEGER NOT NULL DEFAULT 1,
 	PRIMARY KEY (telegram_user_id, project_id, agent_slug)
+);
+
+CREATE TABLE IF NOT EXISTS topic_defaults (
+	chat_id    INTEGER NOT NULL,
+	thread_id  INTEGER NOT NULL,
+	agent_slug TEXT NOT NULL,
+	PRIMARY KEY (chat_id, thread_id)
 );
 `
 	if _, err := s.db.Exec(ddl); err != nil {
@@ -609,6 +621,32 @@ func (s *sqliteStore) GetNotificationPref(ctx context.Context, telegramUserID, p
 	}
 	p.Enabled = enabled != 0
 	return &p, nil
+}
+
+// --- TopicDefault ---
+
+func (s *sqliteStore) GetTopicDefault(ctx context.Context, chatID int64, threadID int64) (string, error) {
+	const q = `SELECT agent_slug FROM topic_defaults WHERE chat_id = ? AND thread_id = ?`
+	var agentSlug string
+	err := s.db.QueryRowContext(ctx, q, chatID, threadID).Scan(&agentSlug)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return agentSlug, err
+}
+
+func (s *sqliteStore) SetTopicDefault(ctx context.Context, chatID int64, threadID int64, agentSlug string) error {
+	const q = `
+INSERT INTO topic_defaults (chat_id, thread_id, agent_slug)
+VALUES (?, ?, ?)
+ON CONFLICT(chat_id, thread_id) DO UPDATE SET agent_slug=excluded.agent_slug`
+	_, err := s.db.ExecContext(ctx, q, chatID, threadID, agentSlug)
+	return err
+}
+
+func (s *sqliteStore) DeleteTopicDefault(ctx context.Context, chatID int64, threadID int64) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM topic_defaults WHERE chat_id = ? AND thread_id = ?`, chatID, threadID)
+	return err
 }
 
 // --- scan helpers ---

--- a/extras/scion-telegram/internal/telegram/store_test.go
+++ b/extras/scion-telegram/internal/telegram/store_test.go
@@ -779,6 +779,77 @@ func TestStore_GroupLink_NotifyInGroup(t *testing.T) {
 	assert.False(t, got.NotifyInGroup)
 }
 
+// --- TopicDefault ---
+
+func TestStore_TopicDefault_SetAndGet(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Not found returns empty string.
+	slug, err := store.GetTopicDefault(ctx, -100, 42)
+	require.NoError(t, err)
+	assert.Equal(t, "", slug)
+
+	// Set and retrieve.
+	require.NoError(t, store.SetTopicDefault(ctx, -100, 42, "coder"))
+	slug, err = store.GetTopicDefault(ctx, -100, 42)
+	require.NoError(t, err)
+	assert.Equal(t, "coder", slug)
+
+	// Different thread returns empty.
+	slug, err = store.GetTopicDefault(ctx, -100, 99)
+	require.NoError(t, err)
+	assert.Equal(t, "", slug)
+}
+
+func TestStore_TopicDefault_Upsert(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.SetTopicDefault(ctx, -100, 42, "coder"))
+	require.NoError(t, store.SetTopicDefault(ctx, -100, 42, "reviewer"))
+
+	slug, err := store.GetTopicDefault(ctx, -100, 42)
+	require.NoError(t, err)
+	assert.Equal(t, "reviewer", slug)
+}
+
+func TestStore_TopicDefault_Delete(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.SetTopicDefault(ctx, -100, 42, "coder"))
+	require.NoError(t, store.DeleteTopicDefault(ctx, -100, 42))
+
+	slug, err := store.GetTopicDefault(ctx, -100, 42)
+	require.NoError(t, err)
+	assert.Equal(t, "", slug)
+
+	// Delete non-existent is not an error.
+	require.NoError(t, store.DeleteTopicDefault(ctx, -100, 99))
+}
+
+func TestStore_TopicDefault_MultipleTopics(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.SetTopicDefault(ctx, -100, 1, "coder"))
+	require.NoError(t, store.SetTopicDefault(ctx, -100, 2, "reviewer"))
+	require.NoError(t, store.SetTopicDefault(ctx, -200, 1, "designer"))
+
+	slug, err := store.GetTopicDefault(ctx, -100, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "coder", slug)
+
+	slug, err = store.GetTopicDefault(ctx, -100, 2)
+	require.NoError(t, err)
+	assert.Equal(t, "reviewer", slug)
+
+	slug, err = store.GetTopicDefault(ctx, -200, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "designer", slug)
+}
+
 // --- Store lifecycle ---
 
 func TestStore_OpenInvalidPath(t *testing.T) {

--- a/pkg/eventbus/fanout.go
+++ b/pkg/eventbus/fanout.go
@@ -72,7 +72,7 @@ func (f *FanOutEventBus) Publish(ctx context.Context, topic string, msg *message
 			if channelKey == "" {
 				channelKey = f.buses[i].Name
 			}
-			if channelKey == msg.Channel {
+			if msg != nil && channelKey == msg.Channel {
 				target = &f.buses[i]
 			}
 		}

--- a/pkg/eventbus/fanout.go
+++ b/pkg/eventbus/fanout.go
@@ -33,6 +33,12 @@ type NamedEventBus struct {
 	Name     string
 	Bus      EventBus
 	Observer bool
+	// ChannelID overrides Name for channel-based message routing. When a
+	// message has msg.Channel set, the FanOutEventBus matches it against
+	// ChannelID (if non-empty) or Name. This allows a plugin registered
+	// under one name (e.g. "chat-app") to handle a different channel
+	// identifier (e.g. "gchat").
+	ChannelID string
 }
 
 // FanOutEventBus implements EventBus by delegating to N child event buses.
@@ -58,10 +64,15 @@ func (f *FanOutEventBus) Publish(ctx context.Context, topic string, msg *message
 
 		var inproc, target *NamedEventBus
 		for i := range f.buses {
-			switch f.buses[i].Name {
-			case InProcessBusName:
+			if f.buses[i].Name == InProcessBusName {
 				inproc = &f.buses[i]
-			case msg.Channel:
+				continue
+			}
+			channelKey := f.buses[i].ChannelID
+			if channelKey == "" {
+				channelKey = f.buses[i].Name
+			}
+			if channelKey == msg.Channel {
 				target = &f.buses[i]
 			}
 		}
@@ -147,8 +158,9 @@ func (f *FanOutEventBus) Close() error {
 
 // BusChannel describes a registered event bus channel.
 type BusChannel struct {
-	Name     string
-	Observer bool
+	Name      string
+	Observer  bool
+	ChannelID string
 }
 
 // BusChannels returns the list of registered bus names (excluding InProcessBus).
@@ -159,8 +171,9 @@ func (f *FanOutEventBus) BusChannels() []BusChannel {
 			continue
 		}
 		channels = append(channels, BusChannel{
-			Name:     nb.Name,
-			Observer: nb.Observer,
+			Name:      nb.Name,
+			Observer:  nb.Observer,
+			ChannelID: nb.ChannelID,
 		})
 	}
 	return channels

--- a/pkg/eventbus/fanout_test.go
+++ b/pkg/eventbus/fanout_test.go
@@ -389,6 +389,35 @@ func TestFanOutEventBus_ChannelRoutingObserverError(t *testing.T) {
 	}
 }
 
+func TestFanOutEventBus_ChannelRoutingWithChannelID(t *testing.T) {
+	inproc := newStubEventBus()
+	chatApp := newStubEventBus()
+
+	fan := NewFanOutEventBus([]NamedEventBus{
+		{Name: InProcessBusName, Bus: inproc},
+		{Name: "chat-app", Bus: chatApp, ChannelID: "gchat"},
+	}, slog.Default())
+
+	msg := messages.NewInstruction("agent:bot", "user:alice", "hello")
+	msg.Channel = "gchat"
+
+	if err := fan.Publish(context.Background(), "test.topic", msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	inproc.mu.Lock()
+	if len(inproc.published) != 1 {
+		t.Errorf("inprocess bus: expected 1 message, got %d", len(inproc.published))
+	}
+	inproc.mu.Unlock()
+
+	chatApp.mu.Lock()
+	if len(chatApp.published) != 1 {
+		t.Errorf("chat-app bus: expected 1 message (routed via ChannelID), got %d", len(chatApp.published))
+	}
+	chatApp.mu.Unlock()
+}
+
 func TestFanOutEventBus_Subscribe(t *testing.T) {
 	b1 := newStubEventBus()
 	b2 := newStubEventBus()

--- a/pkg/hub/resource_import_handler_test.go
+++ b/pkg/hub/resource_import_handler_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !no_sqlite
+
 package hub
 
 import (

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -74,6 +74,14 @@ type PluginInfo struct {
 	// Scion logs a warning if the plugin targets a newer version.
 	MinScionVersion string
 
+	// ChannelID is the message channel identifier this broker plugin handles.
+	// When set, the FanOutEventBus uses this value (instead of the plugin's
+	// registered name) to route outbound messages with a matching
+	// msg.Channel field. For example, a plugin registered as "chat-app" can
+	// set ChannelID to "gchat" so that messages with Channel="gchat" are
+	// routed to it.
+	ChannelID string
+
 	// Capabilities lists optional capabilities the plugin supports.
 	Capabilities []string
 }


### PR DESCRIPTION
This PR adds chat channel routing support across the Telegram and Google Chat broker plugins. It fixes channel identification so Google Chat messages carry channel="gchat" (inbound and outbound), adds a ChannelID field to the broker plugin interface so fan-out routing correctly targets the right spoke by channel name rather than plugin name, threads Google Chat thread context through inbound and outbound messages for proper reply routing, and extends Telegram's /default command to support per-topic agent scoping in forum groups — allowing different default agents per Telegram topic with two-tier fallback to the chat-level default.