### PR TITLE
feat: add hub-managed port pool for agent containers

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2019,7 +2019,7 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 			if err != nil {
 				log.Printf("Warning: invalid port_pool range %q: %v", portRange, err)
 			} else {
-				mgr.PortPool = runtime.NewPortPool(pMin, pMax, perAgent, pp.HostURL)
+				mgr.PortPool = runtime.NewPortPool(pMin, pMax, perAgent, strings.TrimRight(pp.HostURL, "/"))
 				log.Printf("Port pool initialized: range %d-%d, %d ports per agent, host_url=%q", pMin, pMax, perAgent, pp.HostURL)
 			}
 		}

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2019,8 +2019,14 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 			if err != nil {
 				log.Printf("Warning: invalid port_pool range %q: %v", portRange, err)
 			} else {
-				mgr.PortPool = runtime.NewPortPool(pMin, pMax, perAgent, strings.TrimRight(pp.HostURL, "/"))
-				log.Printf("Port pool initialized: range %d-%d, %d ports per agent, host_url=%q", pMin, pMax, perAgent, pp.HostURL)
+				pool, poolErr := runtime.NewPortPool(pMin, pMax, perAgent, strings.TrimRight(pp.HostURL, "/"))
+				if poolErr != nil {
+					log.Printf("Warning: failed to initialize port pool: %v", poolErr)
+				} else {
+					mgr.PortPool = pool
+					log.Printf("Port pool initialized: range %d-%d (%d ports, %d agents max), %d per agent, host_url=%q",
+						pMin, pMax, pool.Total(), pool.Total()/perAgent, perAgent, pp.HostURL)
+				}
 			}
 		}
 	}

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2000,6 +2000,31 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 	statelessCloudRunBroker := enableHub && !simulateRemoteBroker && rt != nil && rt.Name() == "cloudrun"
 
 	mgr := agent.NewManager(rt)
+
+	// Initialize port pool from broker settings
+	if versionedSettings, _, err := config.LoadEffectiveSettings(""); err == nil &&
+		versionedSettings != nil && versionedSettings.Server != nil &&
+		versionedSettings.Server.Broker != nil && versionedSettings.Server.Broker.PortPool != nil {
+		pp := versionedSettings.Server.Broker.PortPool
+		if pp.Enabled == nil || *pp.Enabled {
+			portRange := pp.Range
+			if portRange == "" {
+				portRange = "8000-9000"
+			}
+			perAgent := pp.PortsPerAgent
+			if perAgent <= 0 {
+				perAgent = 2
+			}
+			pMin, pMax, err := api.ParsePortRange(portRange)
+			if err != nil {
+				log.Printf("Warning: invalid port_pool range %q: %v", portRange, err)
+			} else {
+				mgr.PortPool = runtime.NewPortPool(pMin, pMax, perAgent, pp.HostURL)
+				log.Printf("Port pool initialized: range %d-%d, %d ports per agent, host_url=%q", pMin, pMax, perAgent, pp.HostURL)
+			}
+		}
+	}
+
 	settings := brokerSettings
 
 	// Try loading versioned settings to get broker identity from server.broker

--- a/pkg/agent/manager.go
+++ b/pkg/agent/manager.go
@@ -118,7 +118,11 @@ func (m *AgentManager) Stop(ctx context.Context, agentID string, projectPath str
 					return stopErr
 				}
 				if m.PortPool != nil {
-					m.PortPool.Release(a.Name)
+					// Release using the user-facing agent name (agentID),
+					// which matches the key used in Start()'s Allocate call.
+					// a.Name is the container name (e.g. "project--agent")
+					// and would never match the port pool key.
+					m.PortPool.Release(agentID)
 				}
 				return nil
 			}

--- a/pkg/agent/manager.go
+++ b/pkg/agent/manager.go
@@ -67,6 +67,7 @@ type Manager interface {
 
 type AgentManager struct {
 	Runtime   runtime.Runtime
+	PortPool  *runtime.PortPool
 	msgBuffer *MessageBuffer
 }
 
@@ -74,7 +75,7 @@ type AgentManager struct {
 // Messages arriving within this window are coalesced into a single delivery.
 const defaultBufferDelay = 2 * time.Second
 
-func NewManager(rt runtime.Runtime) Manager {
+func NewManager(rt runtime.Runtime) *AgentManager {
 	mgr := &AgentManager{
 		Runtime: rt,
 	}
@@ -113,13 +114,25 @@ func (m *AgentManager) Stop(ctx context.Context, agentID string, projectPath str
 				if stopProjectName != "" && !matchAgentProject(a, stopProjectName, "") {
 					continue
 				}
-				return m.Runtime.Stop(ctx, a.ContainerID)
+				if stopErr := m.Runtime.Stop(ctx, a.ContainerID); stopErr != nil {
+					return stopErr
+				}
+				if m.PortPool != nil {
+					m.PortPool.Release(a.Name)
+				}
+				return nil
 			}
 		}
 	}
 	// Fallback: agentID may already be a container ID, or the list
 	// failed — pass it through directly.
-	return m.Runtime.Stop(ctx, agentID)
+	if stopErr := m.Runtime.Stop(ctx, agentID); stopErr != nil {
+		return stopErr
+	}
+	if m.PortPool != nil {
+		m.PortPool.Release(agentID)
+	}
+	return nil
 }
 
 func (m *AgentManager) Delete(ctx context.Context, agentID string, deleteFiles bool, projectPath string, removeBranch bool) (bool, error) {
@@ -171,6 +184,9 @@ func (m *AgentManager) Delete(ctx context.Context, agentID string, deleteFiles b
 			return false, fmt.Errorf("failed to delete container: %w", err)
 		}
 		util.Debugf("delete: runtime delete completed for container %s", targetID)
+		if m.PortPool != nil {
+			m.PortPool.Release(agentID)
+		}
 	}
 
 	if deleteFiles {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -912,6 +912,16 @@ authDone:
 		}
 	}
 
+	// Allocate ports from the pool if available
+	var allocatedPorts []int
+	if m.PortPool != nil {
+		ports, err := m.PortPool.Allocate(opts.Name, m.PortPool.PerAgent())
+		if err != nil {
+			return nil, fmt.Errorf("port allocation failed: %w", err)
+		}
+		allocatedPorts = ports
+	}
+
 	runCfg := runtime.RunConfig{
 		Name:               containerName(projectName, opts.Name),
 		Template:           template,
@@ -1000,6 +1010,13 @@ authDone:
 		MetadataInterception: hasMetadataInterception(agentEnv),
 		ExtraHosts:           mergeExtraHosts(opts.ExtraHosts, runtime.BridgeExtraHosts(m.Runtime.Name(), agentEnv)),
 		NetworkMode:          networkMode,
+		AllocatedPorts:       allocatedPorts,
+		PortHostURL: func() string {
+			if m.PortPool != nil {
+				return m.PortPool.HostURL()
+			}
+			return ""
+		}(),
 		Labels: func() map[string]string {
 			l := map[string]string{
 				"scion.agent":          "true",
@@ -1023,6 +1040,9 @@ authDone:
 	}
 	id, err := m.Runtime.Run(ctx, runCfg)
 	if err != nil {
+		if m.PortPool != nil {
+			m.PortPool.Release(opts.Name)
+		}
 		// Provisioning writes agent-info.json in "created" state before the
 		// runtime launch. If the launch itself fails, keep the provisioned
 		// workspace but flip the local state to "error" so list/status do not

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -1078,6 +1078,9 @@ authDone:
 					// Try to get logs for diagnosis
 					logs, _ := m.Runtime.GetLogs(ctx, id)
 					_ = m.Runtime.Delete(ctx, id)
+					if m.PortPool != nil {
+						m.PortPool.Release(opts.Name)
+					}
 					return nil, fmt.Errorf("container started but exited immediately (status: %s). Container logs:\n%s", a.ContainerStatus, logs)
 				}
 				a.Detached = detached

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -915,6 +915,12 @@ authDone:
 	// Allocate ports from the pool if available
 	var allocatedPorts []int
 	if m.PortPool != nil {
+		// Release any previously allocated ports for this agent name.
+		// This handles the restart case (stop + start) where the old
+		// ports were never freed because the previous run didn't go
+		// through Delete. Release is idempotent — a no-op if the name
+		// has no allocation.
+		m.PortPool.Release(opts.Name)
 		ports, err := m.PortPool.Allocate(opts.Name, m.PortPool.PerAgent())
 		if err != nil {
 			return nil, fmt.Errorf("port allocation failed: %w", err)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -352,6 +353,37 @@ type ResourceList struct {
 	Memory string `json:"memory,omitempty" yaml:"memory,omitempty"`
 }
 
+// PortPoolConfig controls the hub-managed port pool that allocates unique host
+// ports for agent containers.
+type PortPoolConfig struct {
+	Enabled       *bool  `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Range         string `json:"range,omitempty" yaml:"range,omitempty"` // e.g. "8000-9000"
+	PortsPerAgent int    `json:"ports_per_agent,omitempty" yaml:"ports_per_agent,omitempty"`
+}
+
+// ParsePortRange parses a "min-max" range string into its integer bounds.
+func ParsePortRange(s string) (min, max int, err error) {
+	parts := strings.SplitN(s, "-", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid port range %q: expected format \"min-max\"", s)
+	}
+	min, err = strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid port range %q: bad min: %w", s, err)
+	}
+	max, err = strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid port range %q: bad max: %w", s, err)
+	}
+	if min < 1 || max > 65535 {
+		return 0, 0, fmt.Errorf("invalid port range %q: ports must be between 1 and 65535", s)
+	}
+	if min > max {
+		return 0, 0, fmt.Errorf("invalid port range %q: min (%d) > max (%d)", s, min, max)
+	}
+	return min, max, nil
+}
+
 // AgentHubConfig holds hub connection settings that can be specified per-agent
 // or per-template in scion-agent.yaml. When set, these take highest priority
 // for the agent's hub endpoint, overriding project settings and server config.
@@ -462,7 +494,8 @@ type ScionConfig struct {
 	Hub           *AgentHubConfig            `json:"hub,omitempty" yaml:"hub,omitempty"`
 	Telemetry     *TelemetryConfig           `json:"telemetry,omitempty" yaml:"telemetry,omitempty"`
 
-	Secrets []RequiredSecret `json:"secrets,omitempty" yaml:"secrets,omitempty"`
+	PortPool *PortPoolConfig  `json:"port_pool,omitempty" yaml:"port_pool,omitempty"`
+	Secrets  []RequiredSecret `json:"secrets,omitempty" yaml:"secrets,omitempty"`
 
 	// Skills declares skill references to resolve at provision time.
 	Skills []SkillReference `json:"skills,omitempty" yaml:"skills,omitempty" koanf:"skills"`

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -477,6 +477,51 @@ func TestValidateServices(t *testing.T) {
 	}
 }
 
+func TestParsePortRange(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		wantMin        int
+		wantMax        int
+		wantErr        bool
+		wantErrContain string
+	}{
+		{"valid range", "8000-9000", 8000, 9000, false, ""},
+		{"single port", "8080-8080", 8080, 8080, false, ""},
+		{"edge low", "1-100", 1, 100, false, ""},
+		{"edge high", "65000-65535", 65000, 65535, false, ""},
+		{"with spaces", " 8000 - 9000 ", 8000, 9000, false, ""},
+		{"missing dash", "8000", 0, 0, true, "expected format"},
+		{"empty string", "", 0, 0, true, "expected format"},
+		{"non-numeric min", "abc-9000", 0, 0, true, "bad min"},
+		{"non-numeric max", "8000-xyz", 0, 0, true, "bad max"},
+		{"min zero", "0-9000", 0, 0, true, "must be between 1 and 65535"},
+		{"max exceeds 65535", "8000-70000", 0, 0, true, "must be between 1 and 65535"},
+		{"min > max", "9000-8000", 0, 0, true, "min (9000) > max (8000)"},
+		{"negative min", "-1-9000", 0, 0, true, "bad min"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			min, max, err := ParsePortRange(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParsePortRange(%q) = (%d, %d, nil), want error", tt.input, min, max)
+				}
+				if tt.wantErrContain != "" && !strings.Contains(err.Error(), tt.wantErrContain) {
+					t.Errorf("error %q does not contain %q", err, tt.wantErrContain)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParsePortRange(%q) unexpected error: %v", tt.input, err)
+			}
+			if min != tt.wantMin || max != tt.wantMax {
+				t.Errorf("ParsePortRange(%q) = (%d, %d), want (%d, %d)", tt.input, min, max, tt.wantMin, tt.wantMax)
+			}
+		})
+	}
+}
+
 func TestParseDuration(t *testing.T) {
 	tests := []struct {
 		input string

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -471,6 +471,15 @@ type V1BrokerConfig struct {
 	// dispatch agents whose harness-config declares container-script
 	// provisioning. Defaults to true; set false to block container-script dispatches.
 	AllowContainerScriptHarnesses *bool `json:"allow_container_script_harnesses,omitempty" yaml:"allow_container_script_harnesses,omitempty" koanf:"allow_container_script_harnesses"`
+
+	PortPool *V1PortPoolConfig `json:"port_pool,omitempty" yaml:"port_pool,omitempty" koanf:"port_pool"`
+}
+
+type V1PortPoolConfig struct {
+	Enabled       *bool  `json:"enabled,omitempty" yaml:"enabled,omitempty" koanf:"enabled"`
+	Range         string `json:"range,omitempty" yaml:"range,omitempty" koanf:"range"`
+	PortsPerAgent int    `json:"ports_per_agent,omitempty" yaml:"ports_per_agent,omitempty" koanf:"ports_per_agent"`
+	HostURL       string `json:"host_url,omitempty" yaml:"host_url,omitempty" koanf:"host_url"`
 }
 
 // V1DatabaseConfig holds database settings.

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -360,6 +360,15 @@ func buildCommonRunArgs(config RunConfig) ([]string, error) {
 		}
 	}
 
+	for i, port := range config.AllocatedPorts {
+		suffix := string(rune('A' + i))
+		addEnv(fmt.Sprintf("AVAILABLE_LOCALHOST_PORT_%s", suffix), fmt.Sprintf("%d", port))
+		addArg("-p", fmt.Sprintf("%d:%d", port, port))
+		if config.PortHostURL != "" {
+			addEnv(fmt.Sprintf("AVAILABLE_LOCALHOST_URL_%s", suffix), fmt.Sprintf("%s:%d", config.PortHostURL, port))
+		}
+	}
+
 	// Inject environment-type resolved secrets
 	for _, s := range config.ResolvedSecrets {
 		if s.Type == "environment" || s.Type == "" {

--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -55,6 +55,7 @@ type RunConfig struct {
 	NetworkMode          string   // Container network mode (e.g. "host" for --network=host)
 	Project              string   // Project name (e.g., "global" or "my-project")
 	ProjectID            string   // Project ID (e.g., "550e8400-e29b-41d4-a716-446655440000")
+<<<<<<< HEAD
 
 	// WorkspaceBackendName is "local" or "nfs", set by the workspace backend
 	// selector. Used to branch UID/GID injection and skip per-start chown
@@ -101,6 +102,9 @@ type RunConfig struct {
 	// wait-for-sentinel init container instead of the cloning one.
 	// Callers should not set this field.
 	nfsProvisionLockLost bool
+
+	AllocatedPorts       []int    // Host ports allocated from the port pool, published as -p and injected as env vars
+	PortHostURL          string   // Base URL for constructing agent port URLs (e.g. "http://35.232.118.211")
 }
 
 type Runtime interface {

--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -55,7 +55,6 @@ type RunConfig struct {
 	NetworkMode          string   // Container network mode (e.g. "host" for --network=host)
 	Project              string   // Project name (e.g., "global" or "my-project")
 	ProjectID            string   // Project ID (e.g., "550e8400-e29b-41d4-a716-446655440000")
-<<<<<<< HEAD
 
 	// WorkspaceBackendName is "local" or "nfs", set by the workspace backend
 	// selector. Used to branch UID/GID injection and skip per-start chown

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -990,6 +990,20 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 		}
 	}
 
+	for i, port := range config.AllocatedPorts {
+		suffix := string(rune('A' + i))
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  fmt.Sprintf("AVAILABLE_LOCALHOST_PORT_%s", suffix),
+			Value: fmt.Sprintf("%d", port),
+		})
+		if config.PortHostURL != "" {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  fmt.Sprintf("AVAILABLE_LOCALHOST_URL_%s", suffix),
+				Value: fmt.Sprintf("%s:%d", config.PortHostURL, port),
+			})
+		}
+	}
+
 	// Secret mounting: determine strategy and inject secrets
 	var extraVolumes []corev1.Volume
 	var extraVolumeMounts []corev1.VolumeMount

--- a/pkg/runtime/portpool.go
+++ b/pkg/runtime/portpool.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+	"sync"
+)
+
+type PortPool struct {
+	mu        sync.Mutex
+	min       int
+	max       int
+	perAgent  int
+	hostURL   string
+	allocated map[int]string // port -> agentName
+}
+
+func NewPortPool(min, max, perAgent int, hostURL string) *PortPool {
+	return &PortPool{
+		min:       min,
+		max:       max,
+		perAgent:  perAgent,
+		hostURL:   hostURL,
+		allocated: make(map[int]string),
+	}
+}
+
+// HostURL returns the base URL for constructing agent port URLs.
+func (p *PortPool) HostURL() string {
+	return p.hostURL
+}
+
+// PerAgent returns the default number of ports allocated per agent.
+func (p *PortPool) PerAgent() int {
+	return p.perAgent
+}
+
+// Allocate picks the lowest available ports for the given agent.
+func (p *PortPool) Allocate(agentName string, count int) ([]int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	var ports []int
+	for port := p.min; port <= p.max && len(ports) < count; port++ {
+		if _, taken := p.allocated[port]; !taken {
+			ports = append(ports, port)
+		}
+	}
+	if len(ports) < count {
+		return nil, fmt.Errorf("port pool exhausted: need %d ports, only %d available", count, len(ports))
+	}
+	for _, port := range ports {
+		p.allocated[port] = agentName
+	}
+	return ports, nil
+}
+
+// Release frees all ports allocated to the given agent.
+func (p *PortPool) Release(agentName string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for port, name := range p.allocated {
+		if name == agentName {
+			delete(p.allocated, port)
+		}
+	}
+}
+
+// AllocatedPorts returns the ports currently allocated to the given agent.
+func (p *PortPool) AllocatedPorts(agentName string) []int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	var ports []int
+	for port := p.min; port <= p.max; port++ {
+		if p.allocated[port] == agentName {
+			ports = append(ports, port)
+		}
+	}
+	return ports
+}

--- a/pkg/runtime/portpool.go
+++ b/pkg/runtime/portpool.go
@@ -28,14 +28,26 @@ type PortPool struct {
 	allocated map[int]string // port -> agentName
 }
 
-func NewPortPool(min, max, perAgent int, hostURL string) *PortPool {
+func NewPortPool(min, max, perAgent int, hostURL string) (*PortPool, error) {
+	if min < 1 || max > 65535 {
+		return nil, fmt.Errorf("port range [%d, %d] out of bounds (must be 1–65535)", min, max)
+	}
+	if min > max {
+		return nil, fmt.Errorf("port range min (%d) > max (%d)", min, max)
+	}
+	if perAgent <= 0 {
+		return nil, fmt.Errorf("perAgent must be positive, got %d", perAgent)
+	}
+	if perAgent > 26 {
+		return nil, fmt.Errorf("perAgent must be ≤ 26 (env var suffixes use A–Z), got %d", perAgent)
+	}
 	return &PortPool{
 		min:       min,
 		max:       max,
 		perAgent:  perAgent,
 		hostURL:   hostURL,
 		allocated: make(map[int]string),
-	}
+	}, nil
 }
 
 // HostURL returns the base URL for constructing agent port URLs.
@@ -50,6 +62,13 @@ func (p *PortPool) PerAgent() int {
 
 // Allocate picks the lowest available ports for the given agent.
 func (p *PortPool) Allocate(agentName string, count int) ([]int, error) {
+	if agentName == "" {
+		return nil, fmt.Errorf("agent name must not be empty")
+	}
+	if count <= 0 {
+		return nil, fmt.Errorf("count must be positive, got %d", count)
+	}
+
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -81,6 +100,7 @@ func (p *PortPool) Release(agentName string) {
 }
 
 // AllocatedPorts returns the ports currently allocated to the given agent.
+// The returned slice is sorted in ascending order.
 func (p *PortPool) AllocatedPorts(agentName string) []int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -92,4 +112,17 @@ func (p *PortPool) AllocatedPorts(agentName string) []int {
 		}
 	}
 	return ports
+}
+
+// Total returns the total number of ports in the pool (allocated + free).
+func (p *PortPool) Total() int {
+	return p.max - p.min + 1
+}
+
+// Available returns the number of unallocated ports.
+func (p *PortPool) Available() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.Total() - len(p.allocated)
 }

--- a/pkg/runtime/portpool_test.go
+++ b/pkg/runtime/portpool_test.go
@@ -16,9 +16,20 @@ package runtime
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 )
+
+// mustNewPortPool creates a PortPool or fails the test.
+func mustNewPortPool(t *testing.T, min, max, perAgent int, hostURL string) *PortPool {
+	t.Helper()
+	pool, err := NewPortPool(min, max, perAgent, hostURL)
+	if err != nil {
+		t.Fatalf("NewPortPool(%d, %d, %d, %q) = %v", min, max, perAgent, hostURL, err)
+	}
+	return pool
+}
 
 func TestPortPoolAllocate(t *testing.T) {
 	tests := []struct {
@@ -70,7 +81,7 @@ func TestPortPoolAllocate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pool := NewPortPool(tt.min, tt.max, tt.perAgent, "")
+			pool := mustNewPortPool(t, tt.min, tt.max, tt.perAgent, "")
 			ports, err := pool.Allocate(tt.agent, tt.count)
 			if tt.wantErr {
 				if err == nil {
@@ -94,7 +105,7 @@ func TestPortPoolAllocate(t *testing.T) {
 }
 
 func TestPortPoolAllocateMultipleAgents(t *testing.T) {
-	pool := NewPortPool(8000, 8005, 2, "")
+	pool := mustNewPortPool(t, 8000, 8005, 2, "")
 
 	ports1, err := pool.Allocate("agent-1", 2)
 	if err != nil {
@@ -128,7 +139,7 @@ func TestPortPoolAllocateMultipleAgents(t *testing.T) {
 }
 
 func TestPortPoolRelease(t *testing.T) {
-	pool := NewPortPool(8000, 8003, 2, "")
+	pool := mustNewPortPool(t, 8000, 8003, 2, "")
 
 	pool.Allocate("agent-1", 2)
 	pool.Allocate("agent-2", 2)
@@ -146,13 +157,13 @@ func TestPortPoolRelease(t *testing.T) {
 }
 
 func TestPortPoolReleaseNonexistent(t *testing.T) {
-	pool := NewPortPool(8000, 8001, 2, "")
+	pool := mustNewPortPool(t, 8000, 8001, 2, "")
 	// Should not panic
 	pool.Release("does-not-exist")
 }
 
 func TestPortPoolAllocatedPorts(t *testing.T) {
-	pool := NewPortPool(8000, 8005, 2, "")
+	pool := mustNewPortPool(t, 8000, 8005, 2, "")
 
 	pool.Allocate("agent-1", 2)
 	pool.Allocate("agent-2", 3)
@@ -189,9 +200,9 @@ func TestPortPoolHostURLTrailingSlash(t *testing.T) {
 			want:    "http://example.com",
 		},
 		{
-			name:    "trailing slash trimmed by caller",
-			hostURL: "http://example.com",
-			want:    "http://example.com",
+			name:    "trailing slash preserved (caller trims)",
+			hostURL: "http://example.com/",
+			want:    "http://example.com/",
 		},
 		{
 			name:    "empty host URL",
@@ -202,7 +213,7 @@ func TestPortPoolHostURLTrailingSlash(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pool := NewPortPool(8000, 9000, 2, tt.hostURL)
+			pool := mustNewPortPool(t, 8000, 9000, 2, tt.hostURL)
 			if got := pool.HostURL(); got != tt.want {
 				t.Errorf("HostURL() = %q, want %q", got, tt.want)
 			}
@@ -211,7 +222,7 @@ func TestPortPoolHostURLTrailingSlash(t *testing.T) {
 }
 
 func TestPortPoolConcurrency(t *testing.T) {
-	pool := NewPortPool(8000, 8099, 2, "")
+	pool := mustNewPortPool(t, 8000, 8099, 2, "")
 
 	var wg sync.WaitGroup
 	errs := make(chan error, 50)
@@ -249,5 +260,155 @@ func TestPortPoolConcurrency(t *testing.T) {
 			}
 			seen[p] = true
 		}
+	}
+}
+
+func TestNewPortPoolValidation(t *testing.T) {
+	tests := []struct {
+		name             string
+		min, max         int
+		perAgent         int
+		wantErrSubstring string
+	}{
+		{"min > max", 9000, 8000, 2, "min (9000) > max (8000)"},
+		{"min zero", 0, 8000, 2, "out of bounds"},
+		{"max exceeds 65535", 1, 70000, 2, "out of bounds"},
+		{"perAgent zero", 8000, 9000, 0, "perAgent must be positive"},
+		{"perAgent negative", 8000, 9000, -1, "perAgent must be positive"},
+		{"perAgent exceeds 26", 8000, 9000, 27, "must be ≤ 26"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool, err := NewPortPool(tt.min, tt.max, tt.perAgent, "")
+			if err == nil {
+				t.Fatalf("expected error containing %q, got pool %+v", tt.wantErrSubstring, pool)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrSubstring) {
+				t.Errorf("error %q does not contain %q", err, tt.wantErrSubstring)
+			}
+		})
+	}
+}
+
+func TestAllocateValidation(t *testing.T) {
+	pool := mustNewPortPool(t, 8000, 9000, 2, "")
+
+	// Empty agent name
+	if _, err := pool.Allocate("", 2); err == nil {
+		t.Fatal("expected error for empty agent name")
+	}
+
+	// Zero count
+	if _, err := pool.Allocate("agent-a", 0); err == nil {
+		t.Fatal("expected error for count=0")
+	}
+
+	// Negative count
+	if _, err := pool.Allocate("agent-b", -1); err == nil {
+		t.Fatal("expected error for count=-1")
+	}
+}
+
+func TestAllocateDoubleAllocateSameAgent(t *testing.T) {
+	pool := mustNewPortPool(t, 8000, 8005, 2, "")
+
+	ports1, err := pool.Allocate("agent-1", 2)
+	if err != nil {
+		t.Fatalf("first allocate: %v", err)
+	}
+	if ports1[0] != 8000 || ports1[1] != 8001 {
+		t.Errorf("first allocate got %v, want [8000 8001]", ports1)
+	}
+
+	// Second allocation for the same agent gets new ports
+	ports2, err := pool.Allocate("agent-1", 2)
+	if err != nil {
+		t.Fatalf("second allocate: %v", err)
+	}
+	if ports2[0] != 8002 || ports2[1] != 8003 {
+		t.Errorf("second allocate got %v, want [8002 8003]", ports2)
+	}
+
+	// All four ports are listed for agent-1
+	all := pool.AllocatedPorts("agent-1")
+	if len(all) != 4 {
+		t.Fatalf("expected 4 ports for agent-1, got %d: %v", len(all), all)
+	}
+}
+
+func TestAllocatedPortsAfterRelease(t *testing.T) {
+	pool := mustNewPortPool(t, 8000, 8003, 2, "")
+	pool.Allocate("agent-1", 2)
+
+	pool.Release("agent-1")
+
+	// After release, AllocatedPorts should return nil
+	if ports := pool.AllocatedPorts("agent-1"); ports != nil {
+		t.Errorf("expected nil after release, got %v", ports)
+	}
+}
+
+func TestPortPoolTotalAndAvailable(t *testing.T) {
+	pool := mustNewPortPool(t, 8000, 8009, 2, "")
+
+	if pool.Total() != 10 {
+		t.Errorf("Total() = %d, want 10", pool.Total())
+	}
+	if pool.Available() != 10 {
+		t.Errorf("Available() = %d, want 10", pool.Available())
+	}
+
+	pool.Allocate("agent-1", 3)
+
+	if pool.Available() != 7 {
+		t.Errorf("Available() after allocating 3 = %d, want 7", pool.Available())
+	}
+
+	pool.Release("agent-1")
+
+	if pool.Available() != 10 {
+		t.Errorf("Available() after release = %d, want 10", pool.Available())
+	}
+}
+
+func TestPortPoolConcurrentAllocateRelease(t *testing.T) {
+	// Stress test: 20 goroutines each allocate 2 ports, release, and re-allocate.
+	// The pool has 100 ports (8000-8099), so 50 concurrent 2-port allocations
+	// are the max. By releasing between rounds, we exercise the concurrent
+	// interleaving of allocate and release.
+	pool := mustNewPortPool(t, 8000, 8099, 2, "")
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 200)
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			name := fmt.Sprintf("agent-%d", idx)
+			for round := 0; round < 5; round++ {
+				ports, err := pool.Allocate(name, 2)
+				if err != nil {
+					errs <- fmt.Errorf("agent-%d round %d allocate: %w", idx, round, err)
+					return
+				}
+				if len(ports) != 2 {
+					errs <- fmt.Errorf("agent-%d round %d: got %d ports", idx, round, len(ports))
+					return
+				}
+				pool.Release(name)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+
+	// After all releases, pool should be fully available
+	if pool.Available() != 100 {
+		t.Errorf("Available() = %d, want 100 after all releases", pool.Available())
 	}
 }

--- a/pkg/runtime/portpool_test.go
+++ b/pkg/runtime/portpool_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestPortPoolAllocate(t *testing.T) {
+	tests := []struct {
+		name      string
+		min, max  int
+		perAgent  int
+		agent     string
+		count     int
+		wantPorts []int
+		wantErr   bool
+	}{
+		{
+			name:      "allocate two ports",
+			min:       8000,
+			max:       9000,
+			perAgent:  2,
+			agent:     "agent-a",
+			count:     2,
+			wantPorts: []int{8000, 8001},
+		},
+		{
+			name:      "allocate one port",
+			min:       8000,
+			max:       9000,
+			perAgent:  1,
+			agent:     "agent-b",
+			count:     1,
+			wantPorts: []int{8000},
+		},
+		{
+			name:     "pool too small",
+			min:      8000,
+			max:      8000,
+			perAgent: 2,
+			agent:    "agent-c",
+			count:    2,
+			wantErr:  true,
+		},
+		{
+			name:      "exact fit",
+			min:       8000,
+			max:       8001,
+			perAgent:  2,
+			agent:     "agent-d",
+			count:     2,
+			wantPorts: []int{8000, 8001},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool := NewPortPool(tt.min, tt.max, tt.perAgent, "")
+			ports, err := pool.Allocate(tt.agent, tt.count)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got ports %v", ports)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(ports) != len(tt.wantPorts) {
+				t.Fatalf("got %d ports, want %d", len(ports), len(tt.wantPorts))
+			}
+			for i, p := range ports {
+				if p != tt.wantPorts[i] {
+					t.Errorf("port[%d] = %d, want %d", i, p, tt.wantPorts[i])
+				}
+			}
+		})
+	}
+}
+
+func TestPortPoolAllocateMultipleAgents(t *testing.T) {
+	pool := NewPortPool(8000, 8005, 2, "")
+
+	ports1, err := pool.Allocate("agent-1", 2)
+	if err != nil {
+		t.Fatalf("agent-1 allocate: %v", err)
+	}
+	if ports1[0] != 8000 || ports1[1] != 8001 {
+		t.Errorf("agent-1 got %v, want [8000 8001]", ports1)
+	}
+
+	ports2, err := pool.Allocate("agent-2", 2)
+	if err != nil {
+		t.Fatalf("agent-2 allocate: %v", err)
+	}
+	if ports2[0] != 8002 || ports2[1] != 8003 {
+		t.Errorf("agent-2 got %v, want [8002 8003]", ports2)
+	}
+
+	ports3, err := pool.Allocate("agent-3", 2)
+	if err != nil {
+		t.Fatalf("agent-3 allocate: %v", err)
+	}
+	if ports3[0] != 8004 || ports3[1] != 8005 {
+		t.Errorf("agent-3 got %v, want [8004 8005]", ports3)
+	}
+
+	// Pool should be exhausted now
+	_, err = pool.Allocate("agent-4", 2)
+	if err == nil {
+		t.Fatal("expected error when pool exhausted")
+	}
+}
+
+func TestPortPoolRelease(t *testing.T) {
+	pool := NewPortPool(8000, 8003, 2, "")
+
+	pool.Allocate("agent-1", 2)
+	pool.Allocate("agent-2", 2)
+
+	pool.Release("agent-1")
+
+	// agent-1's ports (8000, 8001) should now be available
+	ports, err := pool.Allocate("agent-3", 2)
+	if err != nil {
+		t.Fatalf("allocate after release: %v", err)
+	}
+	if ports[0] != 8000 || ports[1] != 8001 {
+		t.Errorf("got %v, want [8000 8001] (recycled from agent-1)", ports)
+	}
+}
+
+func TestPortPoolReleaseNonexistent(t *testing.T) {
+	pool := NewPortPool(8000, 8001, 2, "")
+	// Should not panic
+	pool.Release("does-not-exist")
+}
+
+func TestPortPoolAllocatedPorts(t *testing.T) {
+	pool := NewPortPool(8000, 8005, 2, "")
+
+	pool.Allocate("agent-1", 2)
+	pool.Allocate("agent-2", 3)
+
+	got := pool.AllocatedPorts("agent-2")
+	want := []int{8002, 8003, 8004}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("port[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+
+	// Non-existent agent returns nil
+	if ports := pool.AllocatedPorts("no-agent"); ports != nil {
+		t.Errorf("expected nil for unknown agent, got %v", ports)
+	}
+}
+
+func TestPortPoolConcurrency(t *testing.T) {
+	pool := NewPortPool(8000, 8099, 2, "")
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 50)
+
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			name := fmt.Sprintf("agent-%d", idx)
+			_, err := pool.Allocate(name, 2)
+			if err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("concurrent allocate error: %v", err)
+	}
+
+	// Verify no duplicate allocations: 50 agents * 2 ports = 100 ports (range 8000-8099)
+	seen := make(map[int]bool)
+	for i := 0; i < 50; i++ {
+		name := fmt.Sprintf("agent-%d", i)
+		ports := pool.AllocatedPorts(name)
+		if len(ports) != 2 {
+			t.Errorf("agent-%d: got %d ports, want 2", i, len(ports))
+			continue
+		}
+		for _, p := range ports {
+			if seen[p] {
+				t.Errorf("duplicate port %d", p)
+			}
+			seen[p] = true
+		}
+	}
+}

--- a/pkg/runtime/portpool_test.go
+++ b/pkg/runtime/portpool_test.go
@@ -174,6 +174,42 @@ func TestPortPoolAllocatedPorts(t *testing.T) {
 	}
 }
 
+func TestPortPoolHostURLTrailingSlash(t *testing.T) {
+	// Verify that NewPortPool stores hostURL as-is; the caller
+	// (server_foreground.go) is responsible for trimming trailing slashes
+	// before constructing the pool.  This test documents the contract.
+	tests := []struct {
+		name    string
+		hostURL string
+		want    string
+	}{
+		{
+			name:    "no trailing slash",
+			hostURL: "http://example.com",
+			want:    "http://example.com",
+		},
+		{
+			name:    "trailing slash trimmed by caller",
+			hostURL: "http://example.com",
+			want:    "http://example.com",
+		},
+		{
+			name:    "empty host URL",
+			hostURL: "",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool := NewPortPool(8000, 9000, 2, tt.hostURL)
+			if got := pool.HostURL(); got != tt.want {
+				t.Errorf("HostURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPortPoolConcurrency(t *testing.T) {
 	pool := NewPortPool(8000, 8099, 2, "")
 


### PR DESCRIPTION
## Problem

Agents that need to run local web servers (dev servers, preview apps, browser-based verification) have no way to get unique, non-colliding host ports. With multiple agents on the same broker, exported ports collide. Agents also can't tell users a URL to reach a locally running service.

## Solution

A broker-managed port pool that allocates unique host ports per agent at container creation time, exposed as environment variables:

- `AVAILABLE_LOCALHOST_PORT_A`, `AVAILABLE_LOCALHOST_PORT_B` — raw port numbers
- `AVAILABLE_LOCALHOST_URL_A`, `AVAILABLE_LOCALHOST_URL_B` — full URLs (when `host_url` is configured)

Ports are published via `docker -p` and released on stop/delete/start-failure.

### Configuration

```yaml
server:
  broker:
    port_pool:
      enabled: true
      range: "8000-9000"
      ports_per_agent: 2
      host_url: "http://35.232.118.211"  # optional, enables URL env vars
```

## Reviewability roadmap

**Start with `pkg/runtime/portpool.go`** — the thread-safe allocator (~150 lines, sync.Mutex, lowest-available selection). Everything else is wiring and tests:

1. `pkg/runtime/portpool.go` + `portpool_test.go` — core allocator + table-driven tests (50-goroutine concurrency test)
2. `pkg/runtime/common.go` — env var injection + `-p` port publishing in `buildCommonRunArgs()`
3. `pkg/agent/run.go` / `manager.go` — allocation on start, release on stop/delete
4. `pkg/api/types.go`, `pkg/config/settings_v1.go` — config structs
5. `cmd/server_foreground.go` — pool init from broker settings

## Non-goals

- No port persistence across broker restarts (in-memory only — ports reclaimed on restart)
- No dynamic port requests from agents at runtime — allocation is at container creation only

## Risk

- **No behavior change for existing agents**: the pool is `nil` unless `port_pool` is explicitly configured in broker settings. Zero impact on agents that don't use port config.
- All runtimes supported: Docker, Podman, Apple Container, Kubernetes