### PR TITLE
docs: add external channels, GCE hub setup, and multi-broker guides

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -74,11 +74,14 @@ export default defineConfig({
 				                { label: 'Secret Management', slug: 'hub-user/secrets' },
 				                { label: 'Runtime Broker', slug: 'hub-user/runtime-broker' },
 				                { label: 'Messaging & Notifications', slug: 'hub-user/messaging' },
+				                { label: 'External Channels', slug: 'hub-user/external-channels' },
+				                { label: 'Multi-Broker Setup', slug: 'hub-user/multi-broker' },
 				        ],
 				},
 				{
 				        label: 'Hub Administration',					items: [
 						{ label: 'Hub Setup', slug: 'hub-admin/hub-server' },
+						{ label: 'Hub Setup (GCE)', slug: 'hub-admin/hub-setup-gce' },
 						{ label: 'Kubernetes', slug: 'hub-admin/kubernetes' },
 						{ label: 'Security', slug: 'hub-admin/auth' },
 						{ label: 'Permissions', slug: 'hub-admin/permissions' },

--- a/docs-site/src/content/docs/hub-admin/hub-setup-gce.md
+++ b/docs-site/src/content/docs/hub-admin/hub-setup-gce.md
@@ -1,0 +1,76 @@
+---
+title: Hub Setup on GCE
+description: Deploy a Scion Hub on a Google Compute Engine VM using the starter scripts.
+---
+
+## Overview
+
+The quickest path to a deployed Scion Hub is a single Google Compute Engine VM using the starter scripts in `scripts/starter-hub/`. These scripts automate VM provisioning, repository setup, TLS configuration, and Hub startup.
+
+## Prerequisites
+
+- A **GCP project** with billing enabled.
+- The **gcloud CLI** installed and configured (`gcloud auth login`, project set).
+- A **domain name** (optional but recommended for HTTPS/TLS).
+
+## Steps
+
+The starter scripts are designed to be run in sequence from your local machine.
+
+### 1. Provision the VM
+
+```bash
+./scripts/starter-hub/gce-demo-provision.sh
+```
+
+Creates a GCE VM with the necessary machine type, disk, firewall rules, and service account.
+
+### 2. Set Up the Repository
+
+```bash
+./scripts/starter-hub/gce-demo-setup-repo.sh
+```
+
+SSHs into the VM and clones the Scion repository, installing required dependencies.
+
+### 3. Build and Deploy
+
+```bash
+./scripts/starter-hub/gce-demo-deploy.sh
+```
+
+Builds the Hub server and its dependencies on the VM.
+
+### 4. Configure TLS (Optional)
+
+```bash
+./scripts/starter-hub/gce-certs.sh
+```
+
+Sets up Caddy as a reverse proxy with automatic TLS certificate provisioning. Requires a domain name pointed at the VM's external IP.
+
+### 5. Generate Hub Configuration
+
+```bash
+./scripts/starter-hub/hub-config.sh
+```
+
+Generates the `settings.yaml` file with your chosen options (domain, auth settings, etc.).
+
+### 6. Start the Hub
+
+```bash
+./scripts/starter-hub/gce-start-hub.sh
+```
+
+Starts the Hub service on the VM. The Hub is now ready to accept connections.
+
+## Post-Setup
+
+Once the Hub is running:
+
+1. **Access the Web Dashboard** — Navigate to your domain (or the VM's external IP) in a browser.
+2. **Create your first project** — Use the dashboard or `scion project create` from the CLI.
+3. **Register a Runtime Broker** — Connect a machine to execute agents. See [Runtime Broker](/scion/hub-user/runtime-broker/) for details on registering your local machine or a remote VM.
+
+For ongoing Hub administration (auth, permissions, observability), see the other guides in the Hub Administration section.

--- a/docs-site/src/content/docs/hub-user/external-channels.md
+++ b/docs-site/src/content/docs/hub-user/external-channels.md
@@ -1,0 +1,63 @@
+---
+title: External Channels
+description: Connect Scion to Telegram, Discord, and A2A for external messaging and notifications.
+---
+
+## Overview
+
+Scion can relay agent messages and notifications to external platforms, extending communication beyond the CLI and Web Dashboard. Three channels are available: **Telegram** (bidirectional group chat), **Discord** (outbound webhook notifications), and **A2A protocol** (expose agents as A2A endpoints for programmatic interaction).
+
+## Telegram
+
+The Telegram integration provides **bidirectional messaging** — users can message agents from Telegram groups and receive replies directly in the chat.
+
+### How It Works
+
+- A Telegram bot (created via [@BotFather](https://core.telegram.org/bots#botfather)) acts as the bridge between Telegram groups and the Scion Hub.
+- The bot runs as a Hub plugin (`scion-plugin-telegram`), which must be built and configured in the Hub's `settings.yaml`.
+- **Group linking:** Use the `/setup` bot command in a Telegram group to link it to a Scion project.
+- **Identity linking:** Use `/register` to associate your Telegram account with your Scion Hub identity.
+
+### Routing & Commands
+
+- **@-mention routing:** Mention a specific agent (e.g., `@mybot agent-name message`) to route a message to that agent.
+- **Default agent:** Set a default agent with `/default` so untagged messages route automatically.
+- Available bot commands: `/agents` (list agents), `/default` (set default), `/settings` (configure group), `/notifications` (toggle notification types).
+
+### Group Settings
+
+Each linked group can be configured via `/settings`:
+
+- **Observer mode (`a2a`):** Show agent-to-agent messages in the group, so you can watch how agents coordinate.
+- **Commentary:** Show agent reply messages (responses to other agents) in the group.
+- **Group notifications (`grp`):** Post agent state change notifications (completed, error, waiting for input) in the group chat.
+
+For full setup instructions, bot configuration, and troubleshooting, see [extras/scion-telegram/README.md](https://github.com/GoogleCloudPlatform/scion/tree/main/extras/scion-telegram).
+
+## Discord
+
+Discord integration provides **outbound-only** webhook notifications — agents can push messages to a Discord channel, but cannot receive inbound messages from Discord.
+
+- **Severity-based color coding:** Messages are color-coded by severity (info, warning, error, urgent).
+- **@mentions:** Urgent messages and explicit `ask_user` requests can trigger `@user` or `@role` mentions.
+
+### Configuration
+
+Set the webhook URL in one of two ways:
+
+- **settings.yaml:** Set `server.discord_webhook_url` in the Hub configuration.
+- **Environment variable:** Set `SCION_DISCORD_WEBHOOK_URL`.
+
+For more details, see [Hub Setup — Discord Integration](/scion/hub-admin/hub-server/#discord-integration).
+
+## A2A Protocol Bridge
+
+The A2A (Agent-to-Agent protocol) bridge exposes Scion agents as **standard A2A endpoints**, allowing external A2A clients to discover and interact with them programmatically.
+
+- **Discovery:** External clients can query available agents and their capabilities via the A2A protocol.
+- **Interaction modes:** Supports blocking (synchronous), SSE streaming, and push notification delivery.
+- **Standalone service:** Runs as a separate bridge process alongside the Hub (see `extras/scion-a2a-bridge`).
+
+This is useful for integrating Scion agents into larger multi-agent systems or exposing them to third-party A2A-compatible clients.
+
+For setup and configuration, see [extras/scion-a2a-bridge/README.md](https://github.com/GoogleCloudPlatform/scion/tree/main/extras/scion-a2a-bridge).

--- a/docs-site/src/content/docs/hub-user/multi-broker.md
+++ b/docs-site/src/content/docs/hub-user/multi-broker.md
@@ -1,0 +1,59 @@
+---
+title: Multi-Broker Setup
+description: Connect multiple machines to a single Scion Hub for distributed agent execution.
+---
+
+## Overview
+
+A single Scion Hub can dispatch agents to **multiple Runtime Brokers**. Each broker is a machine — a laptop, cloud VM, or Kubernetes cluster — that runs agent containers. This lets teams pool compute resources and target specific machines for specific workloads.
+
+## Architecture
+
+```
+                    ┌──────────┐
+       ┌────────────┤ Scion Hub├────────────┐
+       │            └────┬─────┘            │
+       │                 │                  │
+  ┌────▼─────┐    ┌──────▼───┐    ┌────────▼──────┐
+  │ Broker A  │    │ Broker B │    │   Broker C    │
+  │ (laptop)  │    │(cloud VM)│    │ (K8s cluster) │
+  └───────────┘    └──────────┘    └───────────────┘
+```
+
+Each broker maintains a persistent WebSocket connection to the Hub. The Hub acts as the control plane; brokers handle container execution locally.
+
+## Adding a Broker
+
+On each machine you want to register:
+
+1. **Install Scion** and configure the Hub endpoint (`scion login`).
+2. **Register the broker** with the Hub:
+   ```bash
+   scion broker register
+   ```
+3. **Authorize projects** the broker should serve:
+   ```bash
+   scion broker provide <project>
+   ```
+
+Repeat for each machine. See [Runtime Broker](/scion/hub-user/runtime-broker/) for detailed setup.
+
+## Broker Selection
+
+When starting an agent, the Hub selects an available broker automatically. You can override this:
+
+- **Target a specific broker** with the `--broker` flag:
+  ```bash
+  scion start --broker my-cloud-vm
+  ```
+- **Check broker availability** across all registered brokers:
+  ```bash
+  scion broker status
+  ```
+
+## Considerations
+
+- Each broker manages its own **port pools, container images, and local storage**. Images must be available on each broker independently.
+- **Shared directories** (mounted volumes) only work within a single broker — agents on different brokers cannot share a local directory.
+- **Workspace strategy** may differ per broker: local brokers typically use git worktrees (`.scion_worktrees/`), while hub-hosted git projects use a single workspace checkout.
+- Broker capacity is determined by the machine's resources. The Hub does not enforce cross-broker resource limits.


### PR DESCRIPTION
Three new documentation pages:

- External Channels: covers Telegram (bidirectional group chat), Discord (outbound webhooks), and A2A protocol bridge in one page. Summarizes concepts and links to detailed READMEs in extras/.

- Hub Setup on GCE: step-by-step walkthrough of deploying a hub using the starter-hub scripts. Covers provisioning, repo setup, TLS, and post-setup next steps.

- Multi-Broker Setup: how to connect multiple machines to a single hub for distributed agent execution. Covers architecture, broker registration, selection, and cross-broker considerations.

Sidebar updated to include all three pages.
