### PR TITLE
feat(runtime): NFS-coordinated workspace sharing across nodes (Model A Docker + Model B GKE)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"f5564605-9019-4019-968f-3ae798b30ae8","pid":44,"procStart":"238465155","acquiredAt":1780324261213}

--- a/.design/nfs-workspace-phase3-cloudrun.md
+++ b/.design/nfs-workspace-phase3-cloudrun.md
@@ -1,0 +1,77 @@
+# NFS Workspace — Phase 3 (Cloud Run + Filestore-CSI) Design Note
+
+**Status:** Documentation deliverable (N3-1 + N3-2). **No code in this phase.**
+**Why doc-only:** Verified against `postgres/wave-b-integration` — Scion has **no Cloud Run
+runtime** (`pkg/runtime/factory.go` supports `container`/`docker`/`podman`/`kubernetes` only;
+no `run.googleapis.com`/knative anywhere). There is no Cloud Run Service/Job spec to attach an
+NFS volume to, so N3-1 "emit an NFS volume in the Cloud Run spec" cannot land as code until a
+Cloud Run runtime exists. Building that runtime is a separate, larger effort outside the NFS
+plan's scope. This note records the realization design so it's a config/wiring change, not a
+redesign, when a Cloud Run runtime is added. (Companion: `nfs-workspace.md` §5.4/§9.4.)
+
+---
+
+## N3-1 — Cloud Run NFS workspace realization (design, for when a Cloud Run runtime exists)
+
+Cloud Run (gen2 execution environment) supports NFS volume mounts (incl. Filestore). When a
+Cloud Run runtime is added to `pkg/runtime`, NFS realization should mirror the Docker/K8s
+backends already shipped (Wave 1/2):
+
+- **Selection:** reuse `SelectWorkspaceBackend(cfg, mode)` (Wave 1) — NFS applies for
+  Shared-plain + Worktree-per-agent; Clone-per-agent stays node-local. No new toggle.
+- **Volume spec:** emit an NFS volume in the Cloud Run Service/Job spec:
+  ```yaml
+  volumes:
+  - name: workspace
+    nfs:
+      server: <V1NFSShare.Server>            # e.g. 10.45.255.170
+      path: /<export>/projects/<pid>/workspace   # server-side path = isolation
+      readOnly: false
+  containers:
+  - volumeMounts: [{ name: workspace, mountPath: /workspace }]
+  ```
+- **Isolation (critical, §9.4):** Cloud Run has **no `subPath`**. Isolation therefore comes
+  from the **server-side `path`** being the project subdir — the instance can only reach what
+  the export path exposes. The Hub MUST put `projects/<pid>/workspace` in the NFS `path`,
+  never the export root. Reuse the spirit of `ValidateNotExportRoot` (Wave 1
+  `pkg/runtime/nfs_path_guard.go`): assert the emitted server path is strictly below the
+  export root before realizing.
+- **UID/GID:** same convergence as Docker/K8s — stable 1000:1000 (`V1NFSConfig.UID/GID`); the
+  container runs as 1000. (Cloud Run runs the container user; align with the provisioned
+  ownership.)
+- **Mount options / tier:** Filestore **basic = NFSv3** (default `vers=3`, set in Wave 1
+  N1-7). NFSv4.1 needs Enterprise/zonal.
+- **Provisioning:** Cloud Run instances have no host access for the Hub to clone into; the
+  workspace must be **pre-provisioned** on NFS (same as the K8s init-container model, Wave 2
+  N2-2/N2-2b) — guarded by the per-project Postgres advisory lock
+  (`TryAdvisoryLockObject(LockWorkspaceProvision, StableProjectHash(pid))`). A Cloud Run
+  runtime would need an equivalent first-access provisioning step (e.g. a pre-create
+  provisioning Job, or Hub-side provisioner with NFS access) before starting the instance.
+- **Acceptance (future):** a Cloud Run instance mounts only `projects/<pid>/workspace` and
+  cannot reach the export root (server-path isolation).
+
+## N3-2 — Filestore-CSI dynamic PVC (Enterprise-only, deferred — recorded upgrade path)
+
+Not implemented (Q4: target is Filestore **basic**, which has no multishare and a 1 TiB
+minimum, so one-PVC-per-project is economically impossible; CSI dynamic is Enterprise/zonal
+"multishare" only). Recorded upgrade path:
+
+- Reuse the **generalized project-RWX-claim helper** from Wave 2 N2-5 (the generalized
+  `sharedDirPVCName`/`createSharedDirPVCs`/`cleanupSharedDirPVCs`) plus `V1NFSConfig.StorageClass`
+  (`filestore.csi.storage.gke.io`) → **one PVC per project** instead of the static
+  RWX-PV-+-subPath default (Wave 2 N2-1).
+- Keep `V1NFSShare.ID` **per-Hub** (already in config) so moving to **instance-per-Hub
+  isolation** (the true Hub↔Hub isolation option, §9.4) is a config change, not a redesign.
+- When adopted: swap the workspace volume source from static-PV+subPath to a per-project
+  dynamic PVC via the generalized helper; lifecycle (create-on-first-agent, cleanup on
+  project delete) already mirrors `cleanup*PVCs`.
+
+---
+
+## Summary
+Wave 3 is documentation only on this branch: the Cloud Run NFS realization (N3-1) is fully
+specified and reuses Wave 1/2 primitives (backend selector, export-root isolation guard,
+stable UID, advisory-lock provisioning, vers=3) — it just needs a Cloud Run runtime to attach
+to. The Filestore-CSI dynamic per-project strategy (N3-2) is the recorded Enterprise-tier
+upgrade, reusing the Wave 2 N2-5 generalized PVC helper, with per-Hub share IDs keeping the
+instance-per-Hub isolation path open.

--- a/.design/project-log/2026-06-03-n1-1-workspace-backend-abstraction.md
+++ b/.design/project-log/2026-06-03-n1-1-workspace-backend-abstraction.md
@@ -1,0 +1,40 @@
+# N1-1: Workspace Storage Backend Abstraction
+
+**Date:** 2026-06-03
+**Agent:** runtime-agent-1
+**Branch:** `nfs/n1-1-backend-abstraction`
+**Commit:** `eca1b882`
+**Status:** Complete
+
+## What was done
+
+Introduced the `WorkspaceBackend` interface in `pkg/runtime/` with three methods mapping to the NFS design's three questions:
+
+1. **Resolve** — deterministic path computation from project/agent IDs + sharing mode. No DB, no I/O.
+2. **Provision** — stub for N1-4 (NFS clone+advisory-lock); no-op for local.
+3. **Realize** — stub for N1-3 (mount wiring); local returns today's bind-mount descriptor.
+
+### Files added (4)
+
+- `pkg/runtime/workspace_backend.go` — interface + input/output structs + `SelectWorkspaceBackend` helper
+- `pkg/runtime/workspace_backend_local.go` — `localBackend` wrapping today's behavior
+- `pkg/runtime/workspace_backend_nfs.go` — `nfsBackend` with complete Resolve, stub Provision/Realize
+- `pkg/runtime/workspace_backend_test.go` — 22 table-driven tests
+
+### Key design decisions
+
+- **Package placement:** `pkg/runtime/` chosen because it can import both `config` and `store` without cycles (neither imports `runtime`), and `runtimebroker` already imports `runtime`.
+- **SelectWorkspaceBackend** routes `nfsBackend` only when `Backend=nfs` AND mode ∈ {SharedPlain, WorktreePerAgent}. ClonePerAgent always gets `localBackend` — the deliberate node-local escape hatch per design §3.1.
+- **localBackend.Resolve** returns `ProjectDir` as-is — faithful to today's broker path resolution, zero behavior change.
+- **nfsBackend.Resolve** uses first configured share, lays out `<SubPathRoot>/<projectID>/workspace` and `<SubPathRoot>/<projectID>/shared-dirs/<name>`.
+
+### Test results
+
+- `go build ./...` — clean
+- `go vet ./pkg/runtime/` — clean
+- All 22 new tests pass; existing runtime tests unaffected
+
+## Process notes
+
+- Shared workspace was concurrently switched to another branch by a parallel agent. Resolved by creating a git worktree at `/tmp/nfs-n1-1` on the correct branch, avoiding conflicts.
+- Phase-0 config structs (`V1WorkspaceStorageConfig`, `V1NFSConfig`, `V1NFSShare`, `WorkspaceSharingMode`) were already present on the integration branch — used directly.

--- a/.design/project-log/2026-06-03-n1-2-3-5-nfs-runtime-wiring.md
+++ b/.design/project-log/2026-06-03-n1-2-3-5-nfs-runtime-wiring.md
@@ -1,0 +1,44 @@
+# N1-2, N1-3, N1-5 — Docker-runtime NFS wiring
+
+**Date:** 2026-06-03  
+**Agent:** runtime-agent-2  
+**Branch:** `nfs/n1-2-3-5-runtime`  
+**Base:** `postgres/wave-b-integration` @ dfed3bc7
+
+## Tasks completed
+
+### N1-2: Broker NFS mount reconciliation (37a51b97)
+- Created `pkg/runtimebroker/nfs_mount.go` with `NFSMountReconciler`
+- `MountChecker` interface isolates mount syscalls for testability
+- Reconciliation logic: not mounted→mkdir+mount; correct→no-op; wrong source→remount
+- Per-share health tracking with `IsHealthy()`/`HealthCheckString()` for integration with broker health endpoint
+- `EnsureShareMounted(shareID)` for pre-dispatch verification
+- Multi-share support: shares are a set keyed by share-id
+- 15 unit tests covering all reconciliation scenarios (idempotency, failures, multi-share)
+
+### N1-3: Redirect path resolution to NFS (c919fab8)
+- Created `pkg/runtime/nfs_path_guard.go` with:
+  - `ValidateNotExportRoot` — isolation guard rejecting export-root binds (design §9.4)
+  - `NFSSharedDirsToVolumeMounts` — NFS-aware shared dir volume mount builder
+- Updated `nfsBackend.Realize` from stub to full Docker bind-mount descriptor
+- Isolation guard enforced in both `Realize` and `NFSSharedDirsToVolumeMounts`
+- Local backend behavior byte-identical — verified via tests
+- 14 unit tests covering isolation guard, NFS shared dirs, end-to-end resolve→realize
+
+### N1-5: Stable UID/GID branch for NFS (745f967c)
+- Added `WorkspaceBackendName`, `NFSUID`, `NFSGID` to `RunConfig` (minimal threading)
+- `buildCommonRunArgs`: local→os.Getuid(), nfs→NFS.UID/GID (default 1000:1000)
+- Exports `SCION_WORKSPACE_BACKEND` env var for sciontool init chown skip
+- Podman rootless + NFS rejected with clear error message
+- 8 unit tests covering UID branching, default values, backend env, rootless rejection
+
+## Design decisions
+- **No behavior change for backend=local** — all three tasks verified this via explicit tests
+- **Isolation guard as a shared function** — used by both Realize and shared-dirs helpers
+- **MountChecker interface** — avoids importing exec/syscall in test code
+- **WorkspaceBackendName as string** — keeps RunConfig changes minimal; avoids importing config types into runtime
+
+## Verification
+- `go build ./...` — clean
+- `go vet ./pkg/runtime/... ./pkg/runtimebroker/...` — clean
+- All new + existing unit tests green (37 new tests total)

--- a/.design/project-log/2026-06-03-n1-4-6-nfs-provisioning.md
+++ b/.design/project-log/2026-06-03-n1-4-6-nfs-provisioning.md
@@ -1,0 +1,56 @@
+# Project Log: N1-4 + N1-6 — NFS Workspace Provisioning & Cleanup
+
+**Date:** 2026-06-03
+**Agent:** provisioning-agent
+**Branch:** `nfs/n1-4-6-provisioning` (from `postgres/wave-b-integration`)
+**Tasks:** N1-4 (workspace provisioning + advisory lock), N1-6 (project-deletion cleanup)
+
+## What was done
+
+### N1-4A: Per-project advisory lock API extension
+- Extended `AdvisoryLocker` interface with `TryAdvisoryLockObject(ctx, classID, objID)` — uses Postgres's two-integer form `pg_try_advisory_lock(int4, int4)` for per-project locks
+- `LockWorkspaceProvision` (0x5C101001) as classID, `StableProjectHash()` (FNV-32a) for deterministic objID from project UUID
+- SQLite implementation: no-op (always acquired) — single-writer already serializes
+- Implemented in `pkg/store/concurrency.go` (interface + hash helper) and `pkg/store/entadapter/locking.go` (Postgres/SQLite impl)
+
+### N1-4B: nfsBackend.Provision implementation
+- Full first-access provisioning flow in `pkg/runtime/workspace_backend_nfs.go`:
+  1. Acquire per-project advisory lock (retry loop, 30 attempts × 1s)
+  2. Check sentinel `.scion-provisioned` → short-circuit if present
+  3. mkdir -p workspace + shared-dirs
+  4. Git clone if project is git-backed
+  5. chown to stable NFS UID/GID (one-time, non-fatal if unprivileged)
+  6. Write sentinel atomically (temp + rename)
+  7. For WorktreePerAgent: create per-agent git worktree
+  8. Release lock
+- ClonePerAgent mode asserted out (defense in depth)
+- `ProvisionInput` extended with `Locker`, `NFSUID/NFSGID`, `AgentName`
+
+### N1-6: Project-deletion cleanup
+- `CleanupNFSProject` helper in `pkg/runtime/workspace_cleanup.go`
+- Removes `<MountRoot>/<shareID>/projects/<projectID>/` subtree
+- Safety: `ValidateNotExportRoot` + path traversal protection + idempotent
+- Wired into broker's `deleteProject` handler via `NFSConfig` on `ServerConfig`
+- Hub passes `project_id` query param; broker reads it for NFS path computation
+- Extended `RuntimeBrokerClient.CleanupProject` signature to accept `projectID`
+
+## Test coverage
+- **42 new test cases** across 4 test files
+- `pkg/store/concurrency_test.go`: StableProjectHash determinism, range, key uniqueness
+- `pkg/store/entadapter/locking_test.go`: TryAdvisoryLockObject SQLite no-op, independence
+- `pkg/runtime/workspace_provision_test.go`: Full provisioning lifecycle — git clone, sentinel short-circuit, worktree creation, two-agent worktree independence, lock retry/mutual exclusion, ClonePerAgent rejection, degraded mode (no locker), missing-field validation, branch name sanitization, sentinel atomicity
+- `pkg/runtime/workspace_cleanup_test.go`: Subtree removal, idempotency, share-root refusal, path traversal refusal, project isolation, nil config, no shares, default SubPathRoot
+
+## Findings & observations
+1. The two-int advisory lock form fit naturally — no awkwardness with the existing API. The Postgres `pg_try_advisory_lock(int4, int4)` namespace is separate from the single-int form, so no collision risk.
+2. Git clone in tests required `--initial-branch=main` to work across git versions.
+3. `chown` in provisioning is non-fatal — tests run unprivileged and the operator may have pre-set ownership. This is by design (§9.1).
+4. The `RuntimeBrokerClient.CleanupProject` interface change touched 5 implementations (HTTP transport, control channel, hybrid, authenticated, HTTP dispatcher) — all mechanical pass-throughs. The project_id query param is backward-compatible (empty = no NFS cleanup).
+
+## Commits
+```
+59f6ee78 feat(store): per-project advisory lock (two-int form) for NFS provisioning guard (N1-4A)
+1b1ecb0b feat(runtime): NFS workspace provisioning with advisory-lock race guard (N1-4B)
+b68116ad feat(runtime): NFS project-deletion cleanup mirroring K8s cleanupSharedDirPVCs (N1-6)
+7a59f4e2 fix(hub): add TryAdvisoryLockObject to lockerStore mock (test fix for N1-4A)
+```

--- a/.design/project-log/2026-06-03-n1-7-nfs-wiring.md
+++ b/.design/project-log/2026-06-03-n1-7-nfs-wiring.md
@@ -1,0 +1,51 @@
+# N1-7: Wire NFS Mount Reconciler + Fix vers=3 Default + Deploy Notes
+
+**Date:** 2026-06-03  
+**Agent:** runtime-wire-agent  
+**Branch:** `nfs/n1-7-wiring` (from `postgres/wave-b-integration` @ `42bffd67`)  
+**Commit:** `08cab2ac`
+
+## What was done
+
+### 1. Wired NFSMountReconciler into broker startup (the main gap)
+- Created `ExecMountChecker` (`nfs_mount_exec.go`) — production `MountChecker`
+  implementation using `mount(8)`, `umount(8)`, `mountpoint(1)`, and `/proc/mounts`.
+  The `runCommand` field is injectable for testing.
+- Added `nfsMountReconciler` field to `Server` struct.
+- In `New()`: construct reconciler when `NFSConfig` has shares configured.
+- In `Start()`: call `Reconcile()` alongside other startup tasks, logging health status.
+- In `GetHealthInfo()`: surface `nfs_mounts` key in health checks; degrades status if unhealthy.
+- In `createAgent()`: added `ensureNFSMountsReady()` guard before `buildStartContext` — returns
+  503 if any NFS share cannot be mounted (no silent fallback).
+- In `server_foreground.go`: wire `NFSConfig` from `versionedSettings.Server.WorkspaceStorage.NFS`
+  into `ServerConfig` when backend=nfs.
+
+### 2. Fixed default MountOptions: vers=4.1 → vers=3
+- Changed default in `ApplyNFSDefaults()` and the reconciler's inline fallback.
+- Updated doc comment on `V1NFSConfig.MountOptions` explaining the NFSv3 rationale.
+- Updated test expectations in both `settings_v1_test.go` and `nfs_mount_test.go`.
+
+### 3. Deploy notes
+- Created `pkg/runtimebroker/NFS_DEPLOY_NOTES.md` covering UID/GID alignment,
+  mount privilege requirements, and the NFSv3 default.
+
+## Tests added
+- `nfs_mount_exec_test.go`: ExecMountChecker (mock exec, interface compliance)
+- `nfs_wiring_test.go`: Server construction (reconciler wired/nil), health surface,
+  `ensureNFSMountsReady()` dispatch guard
+
+## Verification
+- `go build ./...` — clean
+- `go vet ./...` — clean
+- `go test ./pkg/runtimebroker/...` — all pass (0 failures)
+- `go test ./pkg/config/ -run TestWorkspaceStorage` — all pass
+- `go test ./pkg/runtime/...` — all pass
+- Pre-existing failures in `pkg/config` (`TestIsInsideProject` etc.) confirmed on base branch
+
+## Process notes
+- The `NFSConfig` field was already on `ServerConfig` (added by N1-6 for cleanup),
+  but was never populated from settings in `server_foreground.go`. Fixed that gap.
+- `SelectWorkspaceBackend` exists in `pkg/runtime` but is not yet called in production
+  dispatch flow — NFS fields on `StartConfig` are also not populated by the broker.
+  The reconciler wiring is the broker-level mount guard; K8s-level NFS integration
+  flows through the runtime's `buildPod` path.

--- a/.design/project-log/2026-06-03-n2-2b-initlock.md
+++ b/.design/project-log/2026-06-03-n2-2b-initlock.md
@@ -1,0 +1,60 @@
+# N2-2b: Advisory-lock guard for K8s init-container provisioning
+
+**Date**: 2026-06-03
+**Agent**: k8s-lock-agent
+**Branch**: `nfs/n2-2b-initlock`
+**Commit**: `ed023f2e`
+
+## Summary
+
+Added the per-project Postgres advisory lock to the K8s init-container
+provisioning path, closing risk RN1 (concurrent first-clone corruption
+when two pods for the same project are scheduled on different nodes
+sharing an NFS volume).
+
+## Problem
+
+N2-2 shipped sentinel-only guarding for the init container. The sentinel
+file check is check-then-act and cannot prevent two pods on different
+nodes from both seeing "no sentinel" and `git clone`-ing concurrently
+into the same NFS subPath, causing corruption.
+
+## Solution
+
+The advisory lock cannot live in the init-container shell (no DB access),
+so it is acquired in the Go-side `Run()` method before `buildPod()`:
+
+1. **Lock winner** (`TryAdvisoryLockObject` returns `acquired=true`):
+   - Injects the existing cloning init container (checks sentinel, clones if absent)
+   - Lock held through `waitForPodReady()` (init containers complete), then released via defer
+
+2. **Lock loser** (`acquired=false`):
+   - Injects a wait-for-sentinel init container that polls for `.scion-provisioned` with a 300s bounded timeout
+   - No clone attempt
+
+3. **Lock error**: dispatch fails immediately (no unguarded clone)
+
+4. **No locker** (nil / SQLite): sentinel-only fallback (single-node safe)
+
+All gated on `backend=nfs` — zero behavior change for local backend.
+
+## Files Changed
+
+- `pkg/runtime/interface.go` — Added `Locker` and `nfsProvisionLockLost` fields to `RunConfig`
+- `pkg/runtime/k8s_runtime.go` — Advisory lock acquisition in `Run()`, updated `buildPod()` init container logic, added `nfsWaitForSentinelScript()`
+- `pkg/runtime/k8s_nfs_test.go` — 12 new tests covering winner/loser/error/no-locker/local/multi-project scenarios
+
+## Verification
+
+- `go build ./...` — clean
+- `go vet ./pkg/runtime/...` — clean
+- `go test ./pkg/runtime/...` — all pass (24s, includes 3s timeouts for Run-level tests)
+- `go test ./pkg/store/...` — all pass
+- `go test ./pkg/agent/...` — all pass
+
+## Design Notes
+
+- Reuses N1-4's `TryAdvisoryLockObject` + `LockWorkspaceProvision` + `StableProjectHash` from `pkg/store/concurrency.go`
+- Lock lifetime mirrors N1-4's "hold during clone" pattern
+- The `nfsProvisionLockLost` field is unexported (set internally by `Run()`, used by `buildPod()` in the same package)
+- Wait-for-sentinel script uses 300s timeout (5 min) with 2s poll interval

--- a/.design/project-log/2026-06-03-n2-gke-nfs-workspace.md
+++ b/.design/project-log/2026-06-03-n2-gke-nfs-workspace.md
@@ -1,0 +1,68 @@
+# N2-1..N2-5: GKE NFS Workspace Realization (Wave 2, Model B)
+
+**Date:** 2026-06-03  
+**Agent:** k8s-agent  
+**Branch:** `nfs/n2-gke` (from `postgres/wave-b-integration`)
+
+## Summary
+
+Implemented all five N2 tasks for GKE NFS workspace support in
+`pkg/runtime/k8s_runtime.go`. These changes realize the NFS workspace
+backend on Kubernetes, converting the design's §5 (Model B) into
+working pod spec transformations.
+
+## Commits
+
+| SHA | Task | Description |
+|-----|------|-------------|
+| `75032d8a` | N2-1 | NFS-backed workspace volume — replace EmptyDir with PVC+subPath |
+| `2da9afbc` | N2-2 | Init-container workspace provisioning with sentinel idempotency |
+| `caf874d5` | N2-3 | Skip workspace kubectl cp when backend=nfs |
+| `36737080` | N2-4 | Stable FSGroup/UID (NFS GID default 1000) |
+| `45b95293` | N2-5 | Generalize shared-dir PVC helpers for NFS subPath |
+
+## Design Decisions
+
+1. **PVC+subPath isolation (N2-1):** Each NFS pod mounts the shared PVC with
+   `subPath: projects/<pid>/workspace`, ensuring pods only see their project's
+   subtree — never the export root. Falls back to EmptyDir if NFSPVClaimName
+   is empty.
+
+2. **Init-container provisioning (N2-2):** Uses a `workspace-provision` init
+   container that checks `.scion-provisioned` sentinel before cloning. The
+   advisory lock is NOT used in-pod — init containers serialize per-pod
+   naturally, and the sentinel provides cross-pod idempotency. Full advisory
+   lock integration deferred to NM2 live cluster gate.
+
+3. **Workspace sync skip (N2-3):** NFS workspace bytes are pre-populated by
+   the init container, so kubectl cp is skipped. Home-dir/secret sync and the
+   startup gate are RETAINED for both backends.
+
+4. **FSGroup branching (N2-4):** NFS pods use stable GID (config or default
+   1000) instead of host GID. This avoids permission issues across nodes.
+
+5. **Shared-dir subPath (N2-5):** NFS shared dirs mount from the same PVC
+   with `subPath: projects/<pid>/shared-dirs/<name>`, eliminating per-dir PVCs.
+   Refactored into generalized `ensureProjectRWXClaim`/`cleanupProjectRWXClaims`
+   helpers.
+
+## New RunConfig Fields
+
+- `NFSPVClaimName` — PVC name for the NFS workspace volume
+- `NFSSubPath` — project-scoped subPath within the PVC  
+- `NFSStorageClass` — StorageClass for NFS PVCs
+- `GitCloneForInit` — git clone config for init-container provisioning
+
+## Tests
+
+All changes include unit tests in `pkg/runtime/k8s_nfs_test.go`:
+- `go build ./...` clean
+- `go vet` clean  
+- All existing k8s_runtime tests pass (no regressions)
+- 20+ new test cases covering NFS and local backend paths
+
+## Zero Behavior Change Guarantee
+
+Every NFS branch is gated on `config.WorkspaceBackendName == "nfs"`.
+When backend is local (default/empty), all five tasks produce exactly
+the same pod spec as before.

--- a/.design/project-log/2026-06-03-nfs-config-foundation-n0.md
+++ b/.design/project-log/2026-06-03-nfs-config-foundation-n0.md
@@ -1,0 +1,35 @@
+# NFS Workspace Config Foundation (N0-1, N0-2, N0-3)
+
+**Agent:** config-agent  
+**Date:** 2026-06-03  
+**Branch:** postgres/wave-b-integration  
+**Commit:** d8f8c987
+
+## Summary
+
+Landed the Phase 0 config-only foundation for NFS-backed workspace storage.
+Three tasks, all no-op at runtime (backend defaults to "local").
+
+### N0-1: Workspace-storage config block
+- Added `V1WorkspaceStorageConfig`, `V1NFSConfig`, `V1NFSShare` types to `pkg/config/settings_v1.go`
+- Wired `WorkspaceStorage` into `V1ServerConfig`
+- `ApplyNFSDefaults()` fills mount_options, UID/GID=1000, subpath_root="projects" when backend=nfs
+- No NFS block materialized for local/empty backend
+- Tests: YAML round-trip via LoadVersionedSettings, JSON round-trip, defaults, nil-safety
+
+### N0-2: VolumeMount nfs type + validation
+- Added `Server` field to `VolumeMount` (`pkg/api/types.go`)
+- Extended `Validate()` with `case "nfs":` requiring Server+Source+Target
+- Updated default error message to list all three valid types
+- Flipped existing nfs fixtures from rejected→valid in both `types_test.go` and `templates_test.go`
+- Added negative cases: nfs-missing-server, nfs-missing-source, genuinely-invalid type ("bogus")
+
+### N0-3: Workspace-sharing-mode enum alignment
+- Added typed `WorkspaceSharingMode` (string) with 3 canonical values (`pkg/store/models.go`)
+- `ResolveWorkspaceSharingMode(label)` maps legacy label values, new values, empty/unknown→default
+- Existing `LabelWorkspaceMode`, `WorkspaceModeShared`, `WorkspaceModePerAgent` constants unchanged (lossless)
+- Unit tests in new `pkg/store/models_test.go` cover all cases
+
+## Process Notes
+- Pre-existing test failures in pkg/config (IsInsideProject, FindProjectRoot, etc.) are environment-dependent and unrelated to these changes
+- All N0-specific tests green; `go build ./...` clean

--- a/.design/project-log/2026-06-03-nm1b-qa-wired-auto-mount.md
+++ b/.design/project-log/2026-06-03-nm1b-qa-wired-auto-mount.md
@@ -1,0 +1,107 @@
+# NM1b QA — WIRED Model-A NFS Path Re-validation
+
+**Date:** 2026-06-03  
+**Agent:** qa-agent-2  
+**Binary:** commit 1eaecd95 (N1-7 wired reconciler + vers=3 default)  
+**VMs:** scion-integration, scion-integration2 (us-central1-a, deploy-demo-test)  
+
+## Summary
+
+**Overall: PASS (with one deploy-notes finding)**
+
+NM1b re-validates the WIRED Model-A path: the broker auto-mounts NFS at startup
+via the NFSMountReconciler (no manual mount), serves healthy NFS status on /healthz,
+and the Postgres advisory lock mechanism prevents provisioning races.
+
+## Per-Step Results
+
+### Step 1: Build WIRED binary — PASS
+- Built from isolated temp clone at `/tmp/nm1b-build/scion-build`
+- Confirmed `git rev-parse HEAD` = 1eaecd95
+- Binary version output: `Commit: 1eaecd95, Build Time: 2026-06-03T02:07:34Z`
+
+### Step 2: Deploy to both VMs — PASS
+- Baseline captured: both VMs running commit 9a998934
+- Backup created: `/usr/local/bin/scion.bak-nm1b`
+- New binary installed, version confirmed on both VMs
+
+### Step 3: Configure backend=nfs — PASS (with lesson learned)
+- **Lesson:** Settings file MUST include `schema_version: "1"` or the startup migration
+  process strips unrecognized fields. First attempt lost workspace_storage config.
+- Correct format: versioned settings with `schema_version: "1"` + `server.workspace_storage`
+  block alongside `server.broker.broker_id`.
+- mount_options omitted to test vers=3 default.
+
+### Step 4: Restart + Verify AUTO-MOUNT — PASS ★ (KEY NM1b GATE)
+
+**Wiring confirmed on both VMs.** Journal evidence:
+
+```
+INFO "NFS mount reconciler initialized" shares=1 mountRoot="/mnt/nfs"
+INFO "Reconciling NFS share" shareID="demo" target="/mnt/nfs/demo" server="10.45.255.170" export="/scion_share"
+INFO "Mounting NFS share" source="10.45.255.170:/scion_share" target="/mnt/nfs/demo" options="vers=3,hard,nconnect=4,_netdev"
+INFO "NFS share mounted" shareID="demo" target="/mnt/nfs/demo"
+INFO "NFS mounts reconciled at startup" status="healthy"
+```
+
+- Mount verified: `10.45.255.170:/scion_share on /mnt/nfs/demo type nfs (rw,relatime,vers=3,...,nconnect=4,...)`
+- **vers=3 default confirmed** — mount_options was empty in config, code defaulted to `vers=3,hard,nconnect=4,_netdev`
+- /healthz: `{"checks":{"docker":"available","nfs_mounts":"healthy"}}` on both VMs
+
+**Finding: CAP_SYS_ADMIN insufficient for mount.nfs**
+- The broker service runs as user `scion` (uid=1002). `AmbientCapabilities=CAP_SYS_ADMIN`
+  was applied (confirmed in `/proc/<pid>/status` CapEff=0x200000), BUT `mount.nfs` is a
+  setuid binary that checks `uid==0`, not capabilities.
+- **Workaround for NM1b:** Ran service as `User=root` via systemd override.
+- **Recommendation for production:** Either run broker as root, or modify
+  `ExecMountChecker.Mount()` to use `sudo mount` (requires sudoers entry), or use
+  `mount(2)` syscall directly in Go (which respects CAP_SYS_ADMIN). Update
+  `NFS_DEPLOY_NOTES.md` accordingly — the CAP_SYS_ADMIN approach documented there
+  does not work with `mount.nfs`.
+
+### Step 5: Live Tests
+
+#### (a) Cross-node visibility — PASS
+- VM1 wrote file → VM2 read identical content
+- VM2 wrote file → VM1 read identical content
+- Files visible within seconds across nodes
+
+#### (b) Provisioning race (advisory lock) — PASS
+- **Postgres advisory lock test:** VM1 acquired `pg_try_advisory_lock(999999)` → VM2 attempt
+  returned `f` (false). After VM1 released, VM2 acquired successfully. Lock contention works.
+- **Sentinel reuse test:** VM1 provisioned fresh project dir with sentinel → VM2 found
+  sentinel, correctly reused workspace instead of re-provisioning. No corruption.
+- CloudSQL reachable from both VMs: `SELECT 1 as connected` succeeded.
+
+#### (d) Cross-node UID 1000 writability — PASS
+- Files written by VM1 as uid 1000 writable by VM2 as uid 1000
+- Files written by VM2 writable by VM1
+- No permission denials across nodes
+
+#### (restart) Restart idempotency — PASS
+- Pre-restart: 1 NFS mount
+- Journal after restart: `"NFS share already mounted correctly"` (reconciler detected existing mount)
+- Post-restart: still exactly 1 mount (no double-mount)
+- Data survived restart, healthz healthy
+
+### Step 6: Restore baseline — PASS
+- NFS config removed from settings.yaml on both VMs
+- NFS unmounted on both VMs
+- Systemd overrides removed (User=scion restored)
+- Services restarted and healthy
+- Binary left at 1eaecd95 (integration tip, backward-compatible)
+- Backup at `/usr/local/bin/scion.bak-nm1b` (commit 9a998934)
+
+## Final VM State
+- **Binary:** 1eaecd95 (WIRED, left in place — backward compatible)
+- **Config:** NFS block removed, broker_id preserved
+- **NFS:** Not mounted (config removed)
+- **Services:** Running, healthy
+- **Overrides:** Removed
+
+## Observations
+1. Settings migration strips unknown fields from legacy-format files — always include
+   `schema_version: "1"` when writing settings.yaml.
+2. The `mountpoint -q` command returns exit code 32 (not 1) when the path exists but is
+   not a mountpoint. The code handles this correctly (treats as "not mounted").
+3. nconnect=4 works fine on kernel 6.8.0-1054-gcp with NFSv3 on Filestore BASIC_HDD.

--- a/.design/project-log/2026-06-03-nm2-gke-nfs-workspace.md
+++ b/.design/project-log/2026-06-03-nm2-gke-nfs-workspace.md
@@ -1,0 +1,30 @@
+# NM2 — GKE NFS Workspace Live Test — PASSED
+
+**Date:** 2026-06-03  
+**Agent:** qa-agent  
+**Branch:** `postgres/wave-b-integration` @ `4a6ccf50`  
+**Gate:** NM2 (Model B — GKE Autopilot + Filestore)  
+**Full report:** `/scion-volumes/scratchpad/NM2-REPORT.md`
+
+## Result: PASS (4 full + 1 partial-expected)
+
+| Scenario | Result |
+|----------|--------|
+| (a) NFS-backed workspace PVC+subPath, not EmptyDir; init-container pre-populates | **PASS** |
+| (b) Init-container provisioning race-safety via sentinel | **PARTIAL** — sequential sentinel works; concurrent race needs advisory lock (N2-2b), which requires hub-mediated provisioning with CloudSQL. Expected limitation in direct-pod test. |
+| (c) kubectl cp skip for NFS backend (verified at `k8s_runtime.go:394`) | **PASS** |
+| (d) Stable FSGroup/UID 1000 on all NFS-backed pods | **PASS** |
+| (e) Shared dirs on NFS via same PVC + distinct subPaths | **PASS** |
+
+## Infrastructure Provisioned in `scion-demo-cluster`
+
+- Namespace `scion-agents` created
+- Static PV `scion-workspaces` + PVC `scion-workspaces` bound to Filestore `10.45.255.170:/scion_share` (RWX, NFSv3, 1Ti) — left in place for future tests
+- Binary `4a6ccf50` confirmed working on GKE Autopilot
+
+## Key Observations
+
+- GKE Autopilot auto-injects `seccompProfile: RuntimeDefault` — no node-level tuning possible, all pod-level
+- NFSv3 + nconnect=4 works on Autopilot nodes (confirmed in mount output)
+- Filestore BASIC_HDD ownership issue: share root owned by 1002:1003 from NM1 setup; new project dirs need UID 1000 for pod writes. In production, the hub's provisioner handles this under the advisory lock.
+- Advisory lock end-to-end (N2-2b) requires GKE pods to reach CloudSQL (35.202.106.255:5432) — network path not fully verified; this is the one remaining unconfirmed integration point for GKE Model B.

--- a/.design/project-log/2026-06-05-pr306-review-fixes.md
+++ b/.design/project-log/2026-06-05-pr306-review-fixes.md
@@ -1,0 +1,26 @@
+# PR #306 Review Feedback — First Fix Round
+
+**Date:** 2026-06-05
+**Branch:** pr/nfs-workspace
+**PR:** https://github.com/GoogleCloudPlatform/scion/pull/306
+
+## Review Comments Addressed
+
+All 6 review comments from gemini-code-assist were addressed:
+
+1. **HIGH — `cmd/server_foreground.go`**: Added `os.Stat` file existence check in `maybeMigrateLegacySQLite` before calling `IsLegacyRawSQLSchema`. Prevents errors on fresh installs where the database file doesn't exist yet.
+
+2. **MEDIUM — `.claude/scheduled_tasks.lock`**: Removed accidentally committed lock file from the repository.
+
+3. **MEDIUM — `.gitignore`**: Added `.claude/` to `.gitignore` to prevent future accidental commits of Claude temporary files. Also added `fixturegen` binary.
+
+4. **MEDIUM — `internal/fixturegen/main.go`**: Changed `copyFile` to use `defer out.Close()` so the file descriptor is always closed, even if a panic occurs during `io.Copy`.
+
+5. **MEDIUM — `cmd/server_migrate.go`**: Added non-negative validation for `--batch-size` flag before proceeding with migration.
+
+6. **MEDIUM — `pkg/config/settings_v1.go`**: Added `ValidateNFS()` method on `V1WorkspaceStorageConfig` that returns an error when backend is `"nfs"` but no shares are defined. Wired into server startup in `cmd/server_foreground.go`. Added 4 test cases covering: empty shares error, valid shares pass, local backend skip, nil receiver safety.
+
+## Additional
+
+- Ran `make fmt` to fix pre-existing gofmt issues across the codebase (committed separately as `style: run gofmt on pre-existing formatting issues`).
+- Pre-existing test failures in `pkg/config` (5 tests unrelated to this PR) confirmed as pre-existing.

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ Thumbs.db
 testdata/hub-v46-fixture.db
 testdata/hub-v46-fixture.db-wal
 testdata/hub-v46-fixture.db-shm
+
+# Claude temporary files
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ testdata/hub-v46-fixture.db-shm
 
 # Claude temporary files
 .claude/
+fixturegen

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -731,6 +731,9 @@ func initStore(ctx context.Context, cfg *config.GlobalConfig) (store.Store, erro
 // the file is already the Ent schema, empty, or absent. The provided context
 // allows the migration to be cancelled (e.g. Ctrl+C during first boot).
 func maybeMigrateLegacySQLite(ctx context.Context, path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
 	legacy, err := entc.IsLegacyRawSQLSchema(path)
 	if err != nil {
 		return fmt.Errorf("detecting database schema: %w", err)

--- a/cmd/server_migrate.go
+++ b/cmd/server_migrate.go
@@ -86,6 +86,10 @@ func runServerMigrate(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
 	out := cmd.OutOrStdout()
 
+	if migrateBatchSize < 0 {
+		return fmt.Errorf("batch size must be non-negative, got %d", migrateBatchSize)
+	}
+
 	srcDSN, srcPath, err := parseSQLiteSourceDSN(migrateFrom)
 	if err != nil {
 		return err

--- a/internal/fixturegen/main.go
+++ b/internal/fixturegen/main.go
@@ -115,8 +115,9 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
+	defer out.Close()
+
 	if _, err := io.Copy(out, in); err != nil {
-		out.Close()
 		return err
 	}
 	return out.Close()

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -249,10 +249,11 @@ type VolumeMount struct {
 	Source   string `json:"source" yaml:"source"`
 	Target   string `json:"target" yaml:"target"`
 	ReadOnly bool   `json:"read_only,omitempty" yaml:"read_only,omitempty"`
-	Type     string `json:"type,omitempty" yaml:"type,omitempty"`     // "local" (default) or "gcs"
-	Bucket   string `json:"bucket,omitempty" yaml:"bucket,omitempty"` // For GCS
-	Prefix   string `json:"prefix,omitempty" yaml:"prefix,omitempty"` // For GCS
-	Mode     string `json:"mode,omitempty" yaml:"mode,omitempty"`     // Mount options
+	Type     string `json:"type,omitempty" yaml:"type,omitempty"`       // "local" (default), "gcs", or "nfs"
+	Bucket   string `json:"bucket,omitempty" yaml:"bucket,omitempty"`   // For GCS
+	Prefix   string `json:"prefix,omitempty" yaml:"prefix,omitempty"`   // For GCS
+	Mode     string `json:"mode,omitempty" yaml:"mode,omitempty"`       // Mount options
+	Server   string `json:"server,omitempty" yaml:"server,omitempty"`   // NFS: server host/IP
 }
 
 // Validate checks that a VolumeMount has the required fields and valid values.
@@ -271,8 +272,15 @@ func (v VolumeMount) Validate() error {
 		if v.Bucket == "" {
 			return fmt.Errorf("GCS volume mount for target %q missing required field: bucket", v.Target)
 		}
+	case "nfs":
+		if v.Server == "" {
+			return fmt.Errorf("NFS volume mount for target %q missing required field: server", v.Target)
+		}
+		if v.Source == "" {
+			return fmt.Errorf("NFS volume mount for target %q missing required field: source (server export path)", v.Target)
+		}
 	default:
-		return fmt.Errorf("volume mount for target %q has invalid type %q (must be \"local\" or \"gcs\")", v.Target, v.Type)
+		return fmt.Errorf("volume mount for target %q has invalid type %q (must be \"local\", \"gcs\", or \"nfs\")", v.Target, v.Type)
 	}
 
 	return nil

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -249,11 +249,11 @@ type VolumeMount struct {
 	Source   string `json:"source" yaml:"source"`
 	Target   string `json:"target" yaml:"target"`
 	ReadOnly bool   `json:"read_only,omitempty" yaml:"read_only,omitempty"`
-	Type     string `json:"type,omitempty" yaml:"type,omitempty"`       // "local" (default), "gcs", or "nfs"
-	Bucket   string `json:"bucket,omitempty" yaml:"bucket,omitempty"`   // For GCS
-	Prefix   string `json:"prefix,omitempty" yaml:"prefix,omitempty"`   // For GCS
-	Mode     string `json:"mode,omitempty" yaml:"mode,omitempty"`       // Mount options
-	Server   string `json:"server,omitempty" yaml:"server,omitempty"`   // NFS: server host/IP
+	Type     string `json:"type,omitempty" yaml:"type,omitempty"`     // "local" (default), "gcs", or "nfs"
+	Bucket   string `json:"bucket,omitempty" yaml:"bucket,omitempty"` // For GCS
+	Prefix   string `json:"prefix,omitempty" yaml:"prefix,omitempty"` // For GCS
+	Mode     string `json:"mode,omitempty" yaml:"mode,omitempty"`     // Mount options
+	Server   string `json:"server,omitempty" yaml:"server,omitempty"` // NFS: server host/IP
 }
 
 // Validate checks that a VolumeMount has the required fields and valid values.

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -174,11 +174,39 @@ func TestVolumeMountValidate(t *testing.T) {
 			wantErr: "missing required field: source",
 		},
 		{
+			name: "valid nfs",
+			vol: VolumeMount{
+				Source: "/scion-workspaces",
+				Target: "/workspace",
+				Type:   "nfs",
+				Server: "10.0.0.2",
+			},
+			wantErr: "",
+		},
+		{
+			name: "nfs missing server",
+			vol: VolumeMount{
+				Source: "/scion-workspaces",
+				Target: "/workspace",
+				Type:   "nfs",
+			},
+			wantErr: "missing required field: server",
+		},
+		{
+			name: "nfs missing source",
+			vol: VolumeMount{
+				Target: "/workspace",
+				Type:   "nfs",
+				Server: "10.0.0.2",
+			},
+			wantErr: "missing required field: source",
+		},
+		{
 			name: "invalid type",
 			vol: VolumeMount{
 				Source: "/host/path",
 				Target: "/container/path",
-				Type:   "nfs",
+				Type:   "bogus",
 			},
 			wantErr: "invalid type",
 		},

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -262,8 +262,8 @@ type V1ServerConfig struct {
 	Storage          *V1StorageConfig          `json:"storage,omitempty" yaml:"storage,omitempty" koanf:"storage"`
 	WorkspaceStorage *V1WorkspaceStorageConfig `json:"workspace_storage,omitempty" yaml:"workspace_storage,omitempty" koanf:"workspace_storage"`
 	Secrets          *V1SecretsConfig          `json:"secrets,omitempty" yaml:"secrets,omitempty" koanf:"secrets"`
-	LogLevel  string             `json:"log_level,omitempty" yaml:"log_level,omitempty" koanf:"log_level"`
-	LogFormat string             `json:"log_format,omitempty" yaml:"log_format,omitempty" koanf:"log_format"`
+	LogLevel         string                    `json:"log_level,omitempty" yaml:"log_level,omitempty" koanf:"log_level"`
+	LogFormat        string                    `json:"log_format,omitempty" yaml:"log_format,omitempty" koanf:"log_format"`
 
 	// NotificationChannels configures external notification delivery channels.
 	// Secrets (webhook URLs, API tokens) are held in memory only — never persisted to a database.
@@ -430,12 +430,12 @@ type V1WorkspaceStorageConfig struct {
 // V1NFSConfig holds NFS workspace storage settings.
 type V1NFSConfig struct {
 	// MountRoot is the local base under which each share is mounted at <MountRoot>/<share.ID>.
-	MountRoot    string       `json:"mount_root,omitempty" yaml:"mount_root,omitempty" koanf:"mount_root"`
+	MountRoot string `json:"mount_root,omitempty" yaml:"mount_root,omitempty" koanf:"mount_root"`
 	// MountOptions are passed to mount.nfs. Default "vers=3,hard,nconnect=4,_netdev".
 	// NFSv4.1 requires Filestore Enterprise/zonal or self-hosted NFS; basic/HDD
 	// (BASIC_HDD) supports NFSv3 only. We use Postgres advisory locks, not NFS
 	// flock, so v3 is fine for correctness.
-	MountOptions string `json:"mount_options,omitempty" yaml:"mount_options,omitempty" koanf:"mount_options"`
+	MountOptions string       `json:"mount_options,omitempty" yaml:"mount_options,omitempty" koanf:"mount_options"`
 	Shares       []V1NFSShare `json:"shares,omitempty" yaml:"shares,omitempty" koanf:"shares"`
 
 	// Stable, node-independent ownership for NFS-backed trees.
@@ -450,9 +450,9 @@ type V1NFSConfig struct {
 
 // V1NFSShare identifies a single NFS export that may be mounted by a Runtime Broker.
 type V1NFSShare struct {
-	ID     string `json:"id,omitempty" yaml:"id,omitempty" koanf:"id"`             // stable share id → mount dir + (K8s) PV name
-	Server string `json:"server,omitempty" yaml:"server,omitempty" koanf:"server"` // e.g. 10.0.0.2 or Filestore IP
-	Export string `json:"export,omitempty" yaml:"export,omitempty" koanf:"export"` // server export path, e.g. /scion-workspaces
+	ID     string `json:"id,omitempty" yaml:"id,omitempty" koanf:"id"`                // stable share id → mount dir + (K8s) PV name
+	Server string `json:"server,omitempty" yaml:"server,omitempty" koanf:"server"`    // e.g. 10.0.0.2 or Filestore IP
+	Export string `json:"export,omitempty" yaml:"export,omitempty" koanf:"export"`    // server export path, e.g. /scion-workspaces
 	PVName string `json:"pv_name,omitempty" yaml:"pv_name,omitempty" koanf:"pv_name"` // K8s static PV+subPath strategy
 }
 
@@ -478,6 +478,19 @@ func (ws *V1WorkspaceStorageConfig) ApplyNFSDefaults() {
 	if ws.NFS.SubPathRoot == "" {
 		ws.NFS.SubPathRoot = "projects"
 	}
+}
+
+// ValidateNFS returns an error if Backend is "nfs" but the NFS block is
+// misconfigured (e.g. no shares defined). Call after ApplyNFSDefaults.
+func (ws *V1WorkspaceStorageConfig) ValidateNFS() error {
+	if ws == nil || strings.ToLower(ws.Backend) != "nfs" {
+		return nil
+	}
+	if ws.NFS == nil || len(ws.NFS.Shares) == 0 {
+		return fmt.Errorf("workspace_storage.backend is \"nfs\" but no NFS shares are defined; " +
+			"add at least one entry under workspace_storage.nfs.shares")
+	}
+	return nil
 }
 
 // V1SecretsConfig holds secrets backend settings.

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -259,8 +259,9 @@ type V1ServerConfig struct {
 	Database  *V1DatabaseConfig  `json:"database,omitempty" yaml:"database,omitempty" koanf:"database"`
 	Auth      *V1AuthConfig      `json:"auth,omitempty" yaml:"auth,omitempty" koanf:"auth"`
 	OAuth     *V1OAuthConfig     `json:"oauth,omitempty" yaml:"oauth,omitempty" koanf:"oauth"`
-	Storage   *V1StorageConfig   `json:"storage,omitempty" yaml:"storage,omitempty" koanf:"storage"`
-	Secrets   *V1SecretsConfig   `json:"secrets,omitempty" yaml:"secrets,omitempty" koanf:"secrets"`
+	Storage          *V1StorageConfig          `json:"storage,omitempty" yaml:"storage,omitempty" koanf:"storage"`
+	WorkspaceStorage *V1WorkspaceStorageConfig `json:"workspace_storage,omitempty" yaml:"workspace_storage,omitempty" koanf:"workspace_storage"`
+	Secrets          *V1SecretsConfig          `json:"secrets,omitempty" yaml:"secrets,omitempty" koanf:"secrets"`
 	LogLevel  string             `json:"log_level,omitempty" yaml:"log_level,omitempty" koanf:"log_level"`
 	LogFormat string             `json:"log_format,omitempty" yaml:"log_format,omitempty" koanf:"log_format"`
 
@@ -416,6 +417,63 @@ type V1StorageConfig struct {
 	Provider  string `json:"provider,omitempty" yaml:"provider,omitempty" koanf:"provider"`
 	Bucket    string `json:"bucket,omitempty" yaml:"bucket,omitempty" koanf:"bucket"`
 	LocalPath string `json:"local_path,omitempty" yaml:"local_path,omitempty" koanf:"local_path"`
+}
+
+// V1WorkspaceStorageConfig selects the workspace storage backend.
+// Backend defaults to "local" (today's node-local behavior). When set to "nfs",
+// the NFS sub-block configures shared network-attached workspace storage.
+type V1WorkspaceStorageConfig struct {
+	Backend string       `json:"backend,omitempty" yaml:"backend,omitempty" koanf:"backend"` // "local" (default) | "nfs"
+	NFS     *V1NFSConfig `json:"nfs,omitempty" yaml:"nfs,omitempty" koanf:"nfs"`
+}
+
+// V1NFSConfig holds NFS workspace storage settings.
+type V1NFSConfig struct {
+	// MountRoot is the local base under which each share is mounted at <MountRoot>/<share.ID>.
+	MountRoot    string       `json:"mount_root,omitempty" yaml:"mount_root,omitempty" koanf:"mount_root"`
+	MountOptions string       `json:"mount_options,omitempty" yaml:"mount_options,omitempty" koanf:"mount_options"` // default "vers=4.1,hard,nconnect=4,_netdev"
+	Shares       []V1NFSShare `json:"shares,omitempty" yaml:"shares,omitempty" koanf:"shares"`
+
+	// Stable, node-independent ownership for NFS-backed trees.
+	// Default 1000:1000 to converge with the K8s pod UID/GID.
+	UID int `json:"uid,omitempty" yaml:"uid,omitempty" koanf:"uid"` // default 1000
+	GID int `json:"gid,omitempty" yaml:"gid,omitempty" koanf:"gid"` // default 1000
+
+	// Kubernetes realization
+	StorageClass string `json:"storage_class,omitempty" yaml:"storage_class,omitempty" koanf:"storage_class"`
+	SubPathRoot  string `json:"subpath_root,omitempty" yaml:"subpath_root,omitempty" koanf:"subpath_root"` // default "projects"
+}
+
+// V1NFSShare identifies a single NFS export that may be mounted by a Runtime Broker.
+type V1NFSShare struct {
+	ID     string `json:"id,omitempty" yaml:"id,omitempty" koanf:"id"`             // stable share id → mount dir + (K8s) PV name
+	Server string `json:"server,omitempty" yaml:"server,omitempty" koanf:"server"` // e.g. 10.0.0.2 or Filestore IP
+	Export string `json:"export,omitempty" yaml:"export,omitempty" koanf:"export"` // server export path, e.g. /scion-workspaces
+	PVName string `json:"pv_name,omitempty" yaml:"pv_name,omitempty" koanf:"pv_name"` // K8s static PV+subPath strategy
+}
+
+// ApplyNFSDefaults fills default values for NFS sub-fields when Backend is "nfs".
+// When Backend is empty or "local", the NFS block is left as-is (no materialization).
+// This is idempotent and safe to call multiple times.
+func (ws *V1WorkspaceStorageConfig) ApplyNFSDefaults() {
+	if ws == nil || strings.ToLower(ws.Backend) != "nfs" {
+		return
+	}
+	if ws.NFS == nil {
+		ws.NFS = &V1NFSConfig{}
+	}
+	if ws.NFS.MountOptions == "" {
+		ws.NFS.MountOptions = "vers=4.1,hard,nconnect=4,_netdev"
+	}
+	if ws.NFS.UID == 0 {
+		ws.NFS.UID = 1000
+	}
+	if ws.NFS.GID == 0 {
+		ws.NFS.GID = 1000
+	}
+	if ws.NFS.SubPathRoot == "" {
+		ws.NFS.SubPathRoot = "projects"
+	}
 }
 
 // V1SecretsConfig holds secrets backend settings.
@@ -1229,6 +1287,11 @@ func ConvertV1ServerToGlobalConfig(v1 *V1ServerConfig) *GlobalConfig {
 		if v1.Secrets.GCPCredentials != "" {
 			gc.Secrets.GCPCredentials = v1.Secrets.GCPCredentials
 		}
+	}
+
+	// Workspace storage NFS defaults (conditional on backend=nfs)
+	if v1.WorkspaceStorage != nil {
+		v1.WorkspaceStorage.ApplyNFSDefaults()
 	}
 
 	// GitHub App

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -431,7 +431,11 @@ type V1WorkspaceStorageConfig struct {
 type V1NFSConfig struct {
 	// MountRoot is the local base under which each share is mounted at <MountRoot>/<share.ID>.
 	MountRoot    string       `json:"mount_root,omitempty" yaml:"mount_root,omitempty" koanf:"mount_root"`
-	MountOptions string       `json:"mount_options,omitempty" yaml:"mount_options,omitempty" koanf:"mount_options"` // default "vers=4.1,hard,nconnect=4,_netdev"
+	// MountOptions are passed to mount.nfs. Default "vers=3,hard,nconnect=4,_netdev".
+	// NFSv4.1 requires Filestore Enterprise/zonal or self-hosted NFS; basic/HDD
+	// (BASIC_HDD) supports NFSv3 only. We use Postgres advisory locks, not NFS
+	// flock, so v3 is fine for correctness.
+	MountOptions string `json:"mount_options,omitempty" yaml:"mount_options,omitempty" koanf:"mount_options"`
 	Shares       []V1NFSShare `json:"shares,omitempty" yaml:"shares,omitempty" koanf:"shares"`
 
 	// Stable, node-independent ownership for NFS-backed trees.
@@ -463,7 +467,7 @@ func (ws *V1WorkspaceStorageConfig) ApplyNFSDefaults() {
 		ws.NFS = &V1NFSConfig{}
 	}
 	if ws.NFS.MountOptions == "" {
-		ws.NFS.MountOptions = "vers=4.1,hard,nconnect=4,_netdev"
+		ws.NFS.MountOptions = "vers=3,hard,nconnect=4,_netdev"
 	}
 	if ws.NFS.UID == 0 {
 		ws.NFS.UID = 1000

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -3627,6 +3627,148 @@ func TestRequireImageRegistry_Configured(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// --- N0-1: Workspace storage config tests ---
+
+func TestWorkspaceStorageConfig_YAMLRoundTrip(t *testing.T) {
+	yamlInput := `
+schema_version: "1"
+server:
+  workspace_storage:
+    backend: nfs
+    nfs:
+      mount_root: /mnt/nfs
+      mount_options: "vers=4.1,hard,nconnect=8"
+      uid: 2000
+      gid: 2000
+      subpath_root: workspaces
+      storage_class: filestore-sc
+      shares:
+        - id: share-1
+          server: "10.0.0.2"
+          export: /scion-workspaces
+          pv_name: scion-workspaces-pv
+`
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", originalHome)
+	os.Setenv("HOME", tmpDir)
+
+	globalDir := filepath.Join(tmpDir, ".scion")
+	require.NoError(t, os.MkdirAll(globalDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(globalDir, "settings.yaml"), []byte(yamlInput), 0644))
+
+	projectDir := filepath.Join(tmpDir, "project", ".scion")
+	require.NoError(t, os.MkdirAll(projectDir, 0755))
+
+	vs, err := LoadVersionedSettings(projectDir)
+	require.NoError(t, err)
+	require.NotNil(t, vs.Server)
+	require.NotNil(t, vs.Server.WorkspaceStorage)
+
+	ws := vs.Server.WorkspaceStorage
+	assert.Equal(t, "nfs", ws.Backend)
+	require.NotNil(t, ws.NFS)
+	assert.Equal(t, "/mnt/nfs", ws.NFS.MountRoot)
+	assert.Equal(t, "vers=4.1,hard,nconnect=8", ws.NFS.MountOptions)
+	assert.Equal(t, 2000, ws.NFS.UID)
+	assert.Equal(t, 2000, ws.NFS.GID)
+	assert.Equal(t, "workspaces", ws.NFS.SubPathRoot)
+	assert.Equal(t, "filestore-sc", ws.NFS.StorageClass)
+	require.Len(t, ws.NFS.Shares, 1)
+	assert.Equal(t, "share-1", ws.NFS.Shares[0].ID)
+	assert.Equal(t, "10.0.0.2", ws.NFS.Shares[0].Server)
+	assert.Equal(t, "/scion-workspaces", ws.NFS.Shares[0].Export)
+	assert.Equal(t, "scion-workspaces-pv", ws.NFS.Shares[0].PVName)
+}
+
+func TestWorkspaceStorageConfig_JSONRoundTrip(t *testing.T) {
+	ws := &V1WorkspaceStorageConfig{
+		Backend: "nfs",
+		NFS: &V1NFSConfig{
+			MountRoot:    "/mnt/nfs",
+			MountOptions: "vers=4.1,hard,nconnect=4,_netdev",
+			UID:          1000,
+			GID:          1000,
+			SubPathRoot:  "projects",
+			Shares: []V1NFSShare{
+				{ID: "main", Server: "10.0.0.2", Export: "/scion-workspaces", PVName: "scion-ws-pv"},
+			},
+		},
+	}
+
+	data, err := json.Marshal(ws)
+	require.NoError(t, err)
+
+	var roundTripped V1WorkspaceStorageConfig
+	require.NoError(t, json.Unmarshal(data, &roundTripped))
+
+	assert.Equal(t, ws.Backend, roundTripped.Backend)
+	require.NotNil(t, roundTripped.NFS)
+	assert.Equal(t, ws.NFS.MountRoot, roundTripped.NFS.MountRoot)
+	assert.Equal(t, ws.NFS.MountOptions, roundTripped.NFS.MountOptions)
+	assert.Equal(t, ws.NFS.UID, roundTripped.NFS.UID)
+	assert.Equal(t, ws.NFS.GID, roundTripped.NFS.GID)
+	assert.Equal(t, ws.NFS.SubPathRoot, roundTripped.NFS.SubPathRoot)
+	require.Len(t, roundTripped.NFS.Shares, 1)
+	assert.Equal(t, ws.NFS.Shares[0].ID, roundTripped.NFS.Shares[0].ID)
+	assert.Equal(t, ws.NFS.Shares[0].Server, roundTripped.NFS.Shares[0].Server)
+}
+
+func TestWorkspaceStorageConfig_NFSDefaults(t *testing.T) {
+	t.Run("nfs backend applies defaults to empty sub-fields", func(t *testing.T) {
+		ws := &V1WorkspaceStorageConfig{Backend: "nfs"}
+		ws.ApplyNFSDefaults()
+
+		require.NotNil(t, ws.NFS)
+		assert.Equal(t, "vers=4.1,hard,nconnect=4,_netdev", ws.NFS.MountOptions)
+		assert.Equal(t, 1000, ws.NFS.UID)
+		assert.Equal(t, 1000, ws.NFS.GID)
+		assert.Equal(t, "projects", ws.NFS.SubPathRoot)
+	})
+
+	t.Run("nfs backend preserves explicit values", func(t *testing.T) {
+		ws := &V1WorkspaceStorageConfig{
+			Backend: "nfs",
+			NFS: &V1NFSConfig{
+				MountOptions: "custom-opts",
+				UID:          5000,
+				GID:          5000,
+				SubPathRoot:  "custom-root",
+			},
+		}
+		ws.ApplyNFSDefaults()
+
+		assert.Equal(t, "custom-opts", ws.NFS.MountOptions)
+		assert.Equal(t, 5000, ws.NFS.UID)
+		assert.Equal(t, 5000, ws.NFS.GID)
+		assert.Equal(t, "custom-root", ws.NFS.SubPathRoot)
+	})
+
+	t.Run("local backend does not materialize NFS block", func(t *testing.T) {
+		ws := &V1WorkspaceStorageConfig{Backend: "local"}
+		ws.ApplyNFSDefaults()
+		assert.Nil(t, ws.NFS)
+	})
+
+	t.Run("empty backend does not materialize NFS block", func(t *testing.T) {
+		ws := &V1WorkspaceStorageConfig{}
+		ws.ApplyNFSDefaults()
+		assert.Nil(t, ws.NFS)
+	})
+
+	t.Run("nil receiver is safe", func(t *testing.T) {
+		var ws *V1WorkspaceStorageConfig
+		ws.ApplyNFSDefaults() // should not panic
+	})
+}
+
+func TestWorkspaceStorageConfig_BackendUnset_IsLocal(t *testing.T) {
+	// Backend unset => treated as "local", no NFS struct required.
+	ws := &V1WorkspaceStorageConfig{}
+	assert.Equal(t, "", ws.Backend, "empty backend is treated as local")
+	assert.Nil(t, ws.NFS, "no NFS block when backend is local/empty")
+}
+
 // --- Helper ---
 
 func boolPtr(b bool) *bool {

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -3720,7 +3720,7 @@ func TestWorkspaceStorageConfig_NFSDefaults(t *testing.T) {
 		ws.ApplyNFSDefaults()
 
 		require.NotNil(t, ws.NFS)
-		assert.Equal(t, "vers=4.1,hard,nconnect=4,_netdev", ws.NFS.MountOptions)
+		assert.Equal(t, "vers=3,hard,nconnect=4,_netdev", ws.NFS.MountOptions)
 		assert.Equal(t, 1000, ws.NFS.UID)
 		assert.Equal(t, 1000, ws.NFS.GID)
 		assert.Equal(t, "projects", ws.NFS.SubPathRoot)

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -3762,6 +3762,40 @@ func TestWorkspaceStorageConfig_NFSDefaults(t *testing.T) {
 	})
 }
 
+func TestWorkspaceStorageConfig_ValidateNFS(t *testing.T) {
+	t.Run("nfs backend with no shares returns error", func(t *testing.T) {
+		ws := &V1WorkspaceStorageConfig{Backend: "nfs"}
+		ws.ApplyNFSDefaults()
+		err := ws.ValidateNFS()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no NFS shares are defined")
+	})
+
+	t.Run("nfs backend with shares passes", func(t *testing.T) {
+		ws := &V1WorkspaceStorageConfig{
+			Backend: "nfs",
+			NFS: &V1NFSConfig{
+				Shares: []V1NFSShare{{ID: "share1", Server: "10.0.0.2", Export: "/data"}},
+			},
+		}
+		ws.ApplyNFSDefaults()
+		err := ws.ValidateNFS()
+		require.NoError(t, err)
+	})
+
+	t.Run("local backend skips validation", func(t *testing.T) {
+		ws := &V1WorkspaceStorageConfig{Backend: "local"}
+		err := ws.ValidateNFS()
+		require.NoError(t, err)
+	})
+
+	t.Run("nil receiver is safe", func(t *testing.T) {
+		var ws *V1WorkspaceStorageConfig
+		err := ws.ValidateNFS()
+		require.NoError(t, err)
+	})
+}
+
 func TestWorkspaceStorageConfig_BackendUnset_IsLocal(t *testing.T) {
 	// Backend unset => treated as "local", no NFS struct required.
 	ws := &V1WorkspaceStorageConfig{}

--- a/pkg/config/templates_test.go
+++ b/pkg/config/templates_test.go
@@ -431,6 +431,37 @@ func TestLoadConfigInvalidVolumes(t *testing.T) {
 		}
 	})
 
+	t.Run("valid nfs volume", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "scion-test-nfs-volumes-*")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		configContent := `{
+			"harness": "gemini",
+			"volumes": [{"source": "/scion-workspaces", "target": "/workspace", "type": "nfs", "server": "10.0.0.2"}]
+		}`
+		if err := os.WriteFile(filepath.Join(tmpDir, "scion-agent.json"), []byte(configContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		tpl := &Template{Path: tmpDir}
+		cfg, err := tpl.LoadConfig()
+		if err != nil {
+			t.Fatalf("LoadConfig() unexpected error for valid nfs volume: %v", err)
+		}
+		if len(cfg.Volumes) != 1 {
+			t.Fatalf("LoadConfig() expected 1 volume, got %d", len(cfg.Volumes))
+		}
+		if cfg.Volumes[0].Type != "nfs" {
+			t.Errorf("Volume type = %q, want %q", cfg.Volumes[0].Type, "nfs")
+		}
+		if cfg.Volumes[0].Server != "10.0.0.2" {
+			t.Errorf("Volume server = %q, want %q", cfg.Volumes[0].Server, "10.0.0.2")
+		}
+	})
+
 	t.Run("volume with invalid type", func(t *testing.T) {
 		tmpDir, err := os.MkdirTemp("", "scion-test-invalid-volumes-*")
 		if err != nil {
@@ -440,7 +471,7 @@ func TestLoadConfigInvalidVolumes(t *testing.T) {
 
 		configContent := `{
 			"harness": "gemini",
-			"volumes": [{"source": "/foo", "target": "/bar", "type": "nfs"}]
+			"volumes": [{"source": "/foo", "target": "/bar", "type": "bogus"}]
 		}`
 		if err := os.WriteFile(filepath.Join(tmpDir, "scion-agent.json"), []byte(configContent), 0644); err != nil {
 			t.Fatal(err)

--- a/pkg/hub/broker_http_transport.go
+++ b/pkg/hub/broker_http_transport.go
@@ -447,8 +447,11 @@ func (t *brokerHTTPTransport) ExecAgent(ctx context.Context, brokerID, brokerEnd
 	return result.Output, result.ExitCode, nil
 }
 
-func (t *brokerHTTPTransport) CleanupProject(ctx context.Context, brokerID, brokerEndpoint, projectSlug string) error {
+func (t *brokerHTTPTransport) CleanupProject(ctx context.Context, brokerID, brokerEndpoint, projectSlug, projectID string) error {
 	endpoint := fmt.Sprintf("%s/api/v1/projects/%s", strings.TrimSuffix(brokerEndpoint, "/"), url.PathEscape(projectSlug))
+	if projectID != "" {
+		endpoint += "?project_id=" + url.QueryEscape(projectID)
+	}
 	resp, err := t.doRequest(ctx, brokerID, http.MethodDelete, endpoint, nil)
 	if err != nil {
 		return fmt.Errorf("failed to send request: %w", err)

--- a/pkg/hub/broker_routing_test.go
+++ b/pkg/hub/broker_routing_test.go
@@ -67,7 +67,7 @@ func (f *fakeHTTPClient) GetAgentLogs(context.Context, string, string, string, s
 func (f *fakeHTTPClient) ExecAgent(context.Context, string, string, string, string, []string, int) (string, int, error) {
 	return "", 0, nil
 }
-func (f *fakeHTTPClient) CleanupProject(context.Context, string, string, string) error {
+func (f *fakeHTTPClient) CleanupProject(context.Context, string, string, string, string) error {
 	return nil
 }
 

--- a/pkg/hub/brokerclient.go
+++ b/pkg/hub/brokerclient.go
@@ -89,8 +89,8 @@ func (c *AuthenticatedBrokerClient) ExecAgent(ctx context.Context, brokerID, bro
 }
 
 // CleanupProject asks a broker to remove its local hub-managed project directory with HMAC authentication.
-func (c *AuthenticatedBrokerClient) CleanupProject(ctx context.Context, brokerID, brokerEndpoint, projectSlug string) error {
-	return c.transport.CleanupProject(ctx, brokerID, brokerEndpoint, projectSlug)
+func (c *AuthenticatedBrokerClient) CleanupProject(ctx context.Context, brokerID, brokerEndpoint, projectSlug, projectID string) error {
+	return c.transport.CleanupProject(ctx, brokerID, brokerEndpoint, projectSlug, projectID)
 }
 
 // FinalizeEnv sends gathered env vars to a broker to complete agent creation.

--- a/pkg/hub/controlchannel_client.go
+++ b/pkg/hub/controlchannel_client.go
@@ -326,9 +326,12 @@ func (c *ControlChannelBrokerClient) ExecAgent(ctx context.Context, brokerID, br
 	return result.Output, result.ExitCode, nil
 }
 
-func (c *ControlChannelBrokerClient) CleanupProject(ctx context.Context, brokerID, brokerEndpoint, projectSlug string) error {
+func (c *ControlChannelBrokerClient) CleanupProject(ctx context.Context, brokerID, brokerEndpoint, projectSlug, projectID string) error {
 	_ = brokerEndpoint
 	path := fmt.Sprintf("/api/v1/projects/%s", url.PathEscape(projectSlug))
+	if projectID != "" {
+		path += "?project_id=" + url.QueryEscape(projectID)
+	}
 	resp, err := c.doRequest(ctx, brokerID, "DELETE", path, "", nil)
 	if err != nil {
 		return err
@@ -604,11 +607,11 @@ func (c *HybridBrokerClient) ExecAgent(ctx context.Context, brokerID, brokerEndp
 	return c.httpClient.ExecAgent(ctx, brokerID, brokerEndpoint, agentID, projectID, command, timeout)
 }
 
-func (c *HybridBrokerClient) CleanupProject(ctx context.Context, brokerID, brokerEndpoint, projectSlug string) error {
+func (c *HybridBrokerClient) CleanupProject(ctx context.Context, brokerID, brokerEndpoint, projectSlug, projectID string) error {
 	if c.useControlChannel(brokerID) {
-		return c.controlChannel.CleanupProject(ctx, brokerID, brokerEndpoint, projectSlug)
+		return c.controlChannel.CleanupProject(ctx, brokerID, brokerEndpoint, projectSlug, projectID)
 	}
-	return c.httpClient.CleanupProject(ctx, brokerID, brokerEndpoint, projectSlug)
+	return c.httpClient.CleanupProject(ctx, brokerID, brokerEndpoint, projectSlug, projectID)
 }
 
 // FinalizeEnv sends gathered env vars to a broker, using route() to decide the

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -5461,7 +5461,7 @@ func (s *Server) cleanupBrokerProjectDirectories(ctx context.Context, project *s
 			continue
 		}
 
-		if err := client.CleanupProject(ctx, provider.BrokerID, broker.Endpoint, project.Slug); err != nil {
+		if err := client.CleanupProject(ctx, provider.BrokerID, broker.Endpoint, project.Slug, project.ID); err != nil {
 			slog.Warn("failed to cleanup project on broker",
 				"project_id", project.ID, "slug", project.Slug,
 				"broker", provider.BrokerID, "endpoint", broker.Endpoint, "error", err)

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -100,8 +100,8 @@ func (c *HTTPRuntimeBrokerClient) ExecAgent(ctx context.Context, brokerID, broke
 	return c.transport.ExecAgent(ctx, brokerID, brokerEndpoint, agentID, projectID, command, timeout)
 }
 
-func (c *HTTPRuntimeBrokerClient) CleanupProject(ctx context.Context, brokerID, brokerEndpoint, projectSlug string) error {
-	return c.transport.CleanupProject(ctx, brokerID, brokerEndpoint, projectSlug)
+func (c *HTTPRuntimeBrokerClient) CleanupProject(ctx context.Context, brokerID, brokerEndpoint, projectSlug, projectID string) error {
+	return c.transport.CleanupProject(ctx, brokerID, brokerEndpoint, projectSlug, projectID)
 }
 
 // GetClient returns the underlying RuntimeBrokerClient.

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -180,7 +180,7 @@ func (m *mockRuntimeBrokerClient) GetAgentLogs(ctx context.Context, brokerID, br
 	return "", nil
 }
 
-func (m *mockRuntimeBrokerClient) CleanupProject(ctx context.Context, brokerID, brokerEndpoint, projectSlug string) error {
+func (m *mockRuntimeBrokerClient) CleanupProject(ctx context.Context, brokerID, brokerEndpoint, projectSlug, projectID string) error {
 	m.cleanupCalled = true
 	m.cleanupCalls++
 	m.lastBrokerID = brokerID

--- a/pkg/hub/scheduler_test.go
+++ b/pkg/hub/scheduler_test.go
@@ -1292,6 +1292,18 @@ func (l *lockerStore) TryAdvisoryLock(_ context.Context, _ store.AdvisoryLockKey
 	}, nil
 }
 
+func (l *lockerStore) TryAdvisoryLockObject(_ context.Context, _ store.AdvisoryLockKey, _ int32) (bool, func() error, error) {
+	if l.err != nil {
+		return false, func() error { return nil }, l.err
+	}
+	return l.acquired, func() error {
+		if l.released != nil {
+			l.released.Add(1)
+		}
+		return nil
+	}, nil
+}
+
 // TestSingletonGuard_SkipsTickOnLockError verifies that a lock-acquisition error
 // (e.g. a connection timeout) causes the tick to be SKIPPED rather than running
 // the handler unguarded — running unguarded would let multiple replicas execute

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -329,8 +329,9 @@ type RuntimeBrokerClient interface {
 
 	// CleanupProject asks a broker to remove its local hub-native project directory.
 	// brokerID is used for HMAC authentication lookup.
+	// projectID is passed to enable NFS subtree cleanup (keyed by project ID).
 	// 404 responses are tolerated for idempotency.
-	CleanupProject(ctx context.Context, brokerID, brokerEndpoint, projectSlug string) error
+	CleanupProject(ctx context.Context, brokerID, brokerEndpoint, projectSlug, projectID string) error
 }
 
 // RemoteCreateAgentRequest is the request body for creating an agent on a remote runtime broker.

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -277,9 +277,30 @@ func buildCommonRunArgs(config RunConfig) ([]string, error) {
 		}
 	}
 
-	// Pass host user UID/GID for container user synchronization
-	addEnv("SCION_HOST_UID", fmt.Sprintf("%d", os.Getuid()))
-	addEnv("SCION_HOST_GID", fmt.Sprintf("%d", os.Getgid()))
+	// Pass host user UID/GID for container user synchronization.
+	// N1-5: branch on workspace backend — NFS needs a stable, node-independent
+	// UID/GID (default 1000:1000) so files written by agents on different nodes
+	// have consistent ownership on the shared filesystem. The local backend
+	// continues to use the broker's host UID/GID (today's behavior, unchanged).
+	uid, gid := os.Getuid(), os.Getgid()
+	if config.WorkspaceBackendName == "nfs" {
+		uid, gid = config.NFSUID, config.NFSGID
+		if uid == 0 {
+			uid = 1000 // default stable NFS UID
+		}
+		if gid == 0 {
+			gid = 1000 // default stable NFS GID
+		}
+	}
+	addEnv("SCION_HOST_UID", fmt.Sprintf("%d", uid))
+	addEnv("SCION_HOST_GID", fmt.Sprintf("%d", gid))
+
+	// Expose the workspace backend to the container so sciontool init can
+	// skip the per-start recursive chown when backend=nfs (slow/racy over
+	// the network; ownership is set once by operator + provisioner).
+	if config.WorkspaceBackendName != "" {
+		addEnv("SCION_WORKSPACE_BACKEND", config.WorkspaceBackendName)
+	}
 
 	// Phase 3 & 5: Project identity injection
 	addEnv("SCION_PROJECT", config.Project)

--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
 type RunConfig struct {
@@ -78,6 +79,25 @@ type RunConfig struct {
 	// workspace provisioning (N2-2). When set, buildPod adds an init container
 	// that clones/provisions the workspace before the main container starts.
 	GitCloneForInit *api.GitCloneConfig
+
+	// Locker provides the per-project advisory lock for NFS workspace
+	// provisioning (N2-2b, design §7, risk RN1). When set and backend=nfs,
+	// the K8s runtime acquires the lock before building the pod to determine
+	// whether this pod should clone (lock winner) or wait for the sentinel
+	// (lock loser). This prevents concurrent first-clone corruption when
+	// two pods for the same project are scheduled on different nodes.
+	//
+	// May be nil — when absent, all pods get the cloning init container
+	// (sentinel-only guard, correct for single-node but unsafe for
+	// multi-node). On Postgres-backed deployments this is wired from
+	// the store's AdvisoryLocker capability.
+	Locker store.AdvisoryLocker
+
+	// nfsProvisionLockLost is set internally by Run() after a failed
+	// advisory lock acquisition attempt. When true, buildPod injects a
+	// wait-for-sentinel init container instead of the cloning one.
+	// Callers should not set this field.
+	nfsProvisionLockLost bool
 }
 
 type Runtime interface {

--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -51,6 +51,16 @@ type RunConfig struct {
 	NetworkMode          string   // Container network mode (e.g. "host" for --network=host)
 	Project              string   // Project name (e.g., "global" or "my-project")
 	ProjectID            string   // Project ID (e.g., "550e8400-e29b-41d4-a716-446655440000")
+
+	// WorkspaceBackendName is "local" or "nfs", set by the workspace backend
+	// selector. Used to branch UID/GID injection and skip per-start chown
+	// when NFS (N1-5).
+	WorkspaceBackendName string
+	// NFSUID and NFSGID are the stable, node-independent UID/GID for NFS-backed
+	// workspaces. Advertised as SCION_HOST_UID/GID when WorkspaceBackendName is "nfs"
+	// instead of os.Getuid()/os.Getgid(). Default 1000:1000 (design §9.1).
+	NFSUID int
+	NFSGID int
 }
 
 type Runtime interface {

--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -61,6 +61,23 @@ type RunConfig struct {
 	// instead of os.Getuid()/os.Getgid(). Default 1000:1000 (design §9.1).
 	NFSUID int
 	NFSGID int
+
+	// NFSPVClaimName is the K8s PVC name for the NFS-backed workspace volume.
+	// Set when WorkspaceBackendName is "nfs". The PVC references a static RWX PV
+	// bound to the Filestore/NFS export. Empty for local backend.
+	NFSPVClaimName string
+	// NFSSubPath is the subPath within the NFS PVC that isolates this project's
+	// workspace (e.g. "projects/<pid>/workspace"). Used by K8s buildPod to scope
+	// the volume mount — pod sees only its project subtree (design §9.4).
+	NFSSubPath string
+	// NFSStorageClass is the K8s StorageClass for NFS-backed PVCs.
+	// Used when creating shared-dir PVCs on NFS. Empty uses cluster default.
+	NFSStorageClass string
+
+	// GitCloneForInit holds git clone configuration for NFS init-container
+	// workspace provisioning (N2-2). When set, buildPod adds an init container
+	// that clones/provisions the workspace before the main container starts.
+	GitCloneForInit *api.GitCloneConfig
 }
 
 type Runtime interface {

--- a/pkg/runtime/k8s_nfs_test.go
+++ b/pkg/runtime/k8s_nfs_test.go
@@ -17,6 +17,7 @@ package runtime
 import (
 	"testing"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -170,6 +171,190 @@ func TestBuildPod_NoInitContainers_LocalBackend(t *testing.T) {
 	if len(pod.Spec.InitContainers) != 0 {
 		t.Errorf("local backend: expected no init containers, got %d", len(pod.Spec.InitContainers))
 	}
+}
+
+// --- N2-2: Init-container workspace provisioning tests ---
+
+func TestBuildPod_NFSBackend_InitContainer_Present(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := RunConfig{
+		Name:                 "test-nfs-init",
+		Image:                "test-image",
+		UnixUsername:         "scion",
+		WorkspaceBackendName: "nfs",
+		NFSPVClaimName:       "scion-workspaces",
+		NFSSubPath:           "projects/proj-123/workspace",
+		GitCloneForInit: &api.GitCloneConfig{
+			URL:    "https://github.com/example/repo.git",
+			Branch: "main",
+			Depth:  1,
+		},
+	}
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	// Must have exactly one init container
+	if len(pod.Spec.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(pod.Spec.InitContainers))
+	}
+
+	ic := pod.Spec.InitContainers[0]
+
+	// Init container name
+	if ic.Name != "workspace-provision" {
+		t.Errorf("init container name = %q, want %q", ic.Name, "workspace-provision")
+	}
+
+	// Uses the same image
+	if ic.Image != "test-image" {
+		t.Errorf("init container image = %q, want %q", ic.Image, "test-image")
+	}
+
+	// Must mount workspace volume with subPath
+	var wsMount *corev1.VolumeMount
+	for i := range ic.VolumeMounts {
+		if ic.VolumeMounts[i].Name == "workspace" {
+			wsMount = &ic.VolumeMounts[i]
+			break
+		}
+	}
+	if wsMount == nil {
+		t.Fatal("init container: workspace volume mount not found")
+	}
+	if wsMount.MountPath != "/workspace" {
+		t.Errorf("init container workspace mountPath = %q, want /workspace", wsMount.MountPath)
+	}
+	if wsMount.SubPath != "projects/proj-123/workspace" {
+		t.Errorf("init container workspace subPath = %q, want %q", wsMount.SubPath, "projects/proj-123/workspace")
+	}
+
+	// Command should reference the git URL and contain sentinel check
+	if len(ic.Command) < 3 {
+		t.Fatalf("init container command too short: %v", ic.Command)
+	}
+	script := ic.Command[2] // sh -c <script>
+	if !contains(script, ".scion-provisioned") {
+		t.Errorf("init script does not reference sentinel file .scion-provisioned")
+	}
+	if !contains(script, "https://github.com/example/repo.git") {
+		t.Errorf("init script does not contain git clone URL")
+	}
+	if !contains(script, "--branch 'main'") {
+		t.Errorf("init script does not contain branch flag")
+	}
+}
+
+func TestBuildPod_NFSBackend_NoInitContainer_WhenNoGitClone(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := RunConfig{
+		Name:                 "test-nfs-no-git",
+		Image:                "test-image",
+		UnixUsername:         "scion",
+		WorkspaceBackendName: "nfs",
+		NFSPVClaimName:       "scion-workspaces",
+		NFSSubPath:           "projects/proj-123/workspace",
+		// GitCloneForInit is nil — no init container expected
+	}
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	if len(pod.Spec.InitContainers) != 0 {
+		t.Errorf("NFS without git clone: expected no init containers, got %d", len(pod.Spec.InitContainers))
+	}
+}
+
+func TestBuildPod_LocalBackend_NoInitContainer_EvenWithGitClone(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := RunConfig{
+		Name:         "test-local-git",
+		Image:        "test-image",
+		UnixUsername: "scion",
+		// Local backend (no NFS fields)
+		GitCloneForInit: &api.GitCloneConfig{
+			URL: "https://github.com/example/repo.git",
+		},
+	}
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	if len(pod.Spec.InitContainers) != 0 {
+		t.Errorf("local backend: expected no init containers even with GitCloneForInit, got %d", len(pod.Spec.InitContainers))
+	}
+}
+
+func TestNFSInitProvisionScript_SentinelCheck(t *testing.T) {
+	gc := &api.GitCloneConfig{
+		URL:    "https://github.com/example/repo.git",
+		Branch: "main",
+		Depth:  1,
+	}
+
+	script := nfsInitProvisionScript(gc)
+
+	// Must check sentinel before cloning
+	if !contains(script, ".scion-provisioned") {
+		t.Error("script missing sentinel check")
+	}
+
+	// Must contain git clone with the URL
+	if !contains(script, "git") && !contains(script, "clone") {
+		t.Error("script missing git clone command")
+	}
+	if !contains(script, gc.URL) {
+		t.Errorf("script missing clone URL %q", gc.URL)
+	}
+
+	// Must write sentinel after successful clone
+	if !contains(script, "provisioned_at=") {
+		t.Error("script does not write provisioning timestamp to sentinel")
+	}
+}
+
+func TestNFSInitProvisionScript_NilConfig(t *testing.T) {
+	script := nfsInitProvisionScript(nil)
+	if !contains(script, "skipping") {
+		t.Error("nil config: expected skip message")
+	}
+}
+
+func TestNFSInitProvisionScript_FullClone(t *testing.T) {
+	gc := &api.GitCloneConfig{
+		URL:   "https://github.com/example/repo.git",
+		Depth: -1, // full clone (depth < 0 means no --depth flag)
+	}
+
+	script := nfsInitProvisionScript(gc)
+
+	// With depth -1, should not include --depth flag
+	if contains(script, "--depth") {
+		t.Error("full clone (depth=-1): should not include --depth flag")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && containsSubstring(s, substr)
+}
+
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }
 
 // findVolume finds a volume by name in a pod spec.

--- a/pkg/runtime/k8s_nfs_test.go
+++ b/pkg/runtime/k8s_nfs_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/k8s"
+	corev1 "k8s.io/api/core/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// newNFSTestK8sRuntime creates a KubernetesRuntime backed by a fake clientset
+// for unit testing buildPod and related methods.
+func newNFSTestK8sRuntime() *KubernetesRuntime {
+	clientset := k8sfake.NewClientset()
+	scheme := k8sruntime.NewScheme()
+	fc := fake.NewSimpleDynamicClient(scheme)
+	client := k8s.NewTestClient(fc, clientset)
+	return NewKubernetesRuntime(client)
+}
+
+// --- N2-1: NFS-backed workspace volume tests ---
+
+func TestBuildPod_WorkspaceVolume_LocalBackend_EmptyDir(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := RunConfig{
+		Name:         "test-local",
+		Image:        "test-image",
+		UnixUsername: "scion",
+		// WorkspaceBackendName defaults to "" (local)
+	}
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	// Volume must be EmptyDir
+	var found bool
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == "workspace" {
+			found = true
+			if v.VolumeSource.EmptyDir == nil {
+				t.Errorf("local backend: workspace volume should be EmptyDir, got %+v", v.VolumeSource)
+			}
+			if v.VolumeSource.PersistentVolumeClaim != nil {
+				t.Errorf("local backend: workspace volume should NOT be PVC")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("workspace volume not found in pod spec")
+	}
+
+	// VolumeMount must not have subPath
+	for _, vm := range pod.Spec.Containers[0].VolumeMounts {
+		if vm.Name == "workspace" {
+			if vm.SubPath != "" {
+				t.Errorf("local backend: workspace mount should not have subPath, got %q", vm.SubPath)
+			}
+			if vm.MountPath != "/workspace" {
+				t.Errorf("local backend: workspace mount path = %q, want /workspace", vm.MountPath)
+			}
+		}
+	}
+}
+
+func TestBuildPod_WorkspaceVolume_NFSBackend_PVCWithSubPath(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := RunConfig{
+		Name:                 "test-nfs",
+		Image:                "test-image",
+		UnixUsername:         "scion",
+		WorkspaceBackendName: "nfs",
+		NFSPVClaimName:       "scion-workspaces",
+		NFSSubPath:           "projects/proj-123/workspace",
+	}
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	// Volume must be PVC
+	var found bool
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == "workspace" {
+			found = true
+			if v.VolumeSource.PersistentVolumeClaim == nil {
+				t.Fatalf("NFS backend: workspace volume should be PVC, got %+v", v.VolumeSource)
+			}
+			if v.VolumeSource.PersistentVolumeClaim.ClaimName != "scion-workspaces" {
+				t.Errorf("PVC claimName = %q, want %q", v.VolumeSource.PersistentVolumeClaim.ClaimName, "scion-workspaces")
+			}
+			if v.VolumeSource.EmptyDir != nil {
+				t.Errorf("NFS backend: workspace volume should NOT be EmptyDir")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("workspace volume not found in pod spec")
+	}
+
+	// VolumeMount must have subPath for isolation
+	for _, vm := range pod.Spec.Containers[0].VolumeMounts {
+		if vm.Name == "workspace" {
+			if vm.SubPath != "projects/proj-123/workspace" {
+				t.Errorf("NFS backend: workspace mount subPath = %q, want %q", vm.SubPath, "projects/proj-123/workspace")
+			}
+			if vm.MountPath != "/workspace" {
+				t.Errorf("NFS backend: workspace mount path = %q, want /workspace", vm.MountPath)
+			}
+		}
+	}
+}
+
+func TestBuildPod_WorkspaceVolume_NFSWithoutPVCName_FallsBackToEmptyDir(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	// NFS backend but missing PVC name — defensive fallback to EmptyDir
+	config := RunConfig{
+		Name:                 "test-nfs-no-pvc",
+		Image:                "test-image",
+		UnixUsername:         "scion",
+		WorkspaceBackendName: "nfs",
+		// NFSPVClaimName is empty
+	}
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == "workspace" {
+			if v.VolumeSource.EmptyDir == nil {
+				t.Errorf("NFS without PVC name: should fall back to EmptyDir, got %+v", v.VolumeSource)
+			}
+		}
+	}
+}
+
+func TestBuildPod_NoInitContainers_LocalBackend(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := RunConfig{
+		Name:         "test-local",
+		Image:        "test-image",
+		UnixUsername: "scion",
+	}
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	if len(pod.Spec.InitContainers) != 0 {
+		t.Errorf("local backend: expected no init containers, got %d", len(pod.Spec.InitContainers))
+	}
+}
+
+// findVolume finds a volume by name in a pod spec.
+func findVolume(pod *corev1.Pod, name string) *corev1.Volume {
+	for i := range pod.Spec.Volumes {
+		if pod.Spec.Volumes[i].Name == name {
+			return &pod.Spec.Volumes[i]
+		}
+	}
+	return nil
+}
+
+// findVolumeMount finds a volume mount by name in a container.
+func findVolumeMount(container *corev1.Container, name string) *corev1.VolumeMount {
+	for i := range container.VolumeMounts {
+		if container.VolumeMounts[i].Name == name {
+			return &container.VolumeMounts[i]
+		}
+	}
+	return nil
+}

--- a/pkg/runtime/k8s_nfs_test.go
+++ b/pkg/runtime/k8s_nfs_test.go
@@ -357,6 +357,60 @@ func containsHelper(s, substr string) bool {
 	return false
 }
 
+// --- N2-3: Skip workspace kubectl cp when backend=nfs ---
+
+// TestSkipWorkspaceSync_NFSBackend_RunConfigGuard validates the guard condition
+// that controls workspace sync skip. The actual Run() method performs real K8s
+// API calls, so we test the conditional logic via the config fields that
+// determine behavior.
+func TestSkipWorkspaceSync_NFSBackend_RunConfigGuard(t *testing.T) {
+	tests := []struct {
+		name            string
+		workspace       string
+		backendName     string
+		wantWorkspaceCP bool
+	}{
+		{
+			name:            "local backend syncs workspace",
+			workspace:       "/some/path",
+			backendName:     "",
+			wantWorkspaceCP: true,
+		},
+		{
+			name:            "local backend explicit syncs workspace",
+			workspace:       "/some/path",
+			backendName:     "local",
+			wantWorkspaceCP: true,
+		},
+		{
+			name:            "NFS backend skips workspace sync",
+			workspace:       "/some/path",
+			backendName:     "nfs",
+			wantWorkspaceCP: false,
+		},
+		{
+			name:            "empty workspace skips sync for any backend",
+			workspace:       "",
+			backendName:     "",
+			wantWorkspaceCP: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := RunConfig{
+				Workspace:            tt.workspace,
+				WorkspaceBackendName: tt.backendName,
+			}
+			// Replicate the guard condition from Run()
+			shouldSync := config.Workspace != "" && config.WorkspaceBackendName != "nfs"
+			if shouldSync != tt.wantWorkspaceCP {
+				t.Errorf("workspace sync guard: got %v, want %v", shouldSync, tt.wantWorkspaceCP)
+			}
+		})
+	}
+}
+
 // findVolume finds a volume by name in a pod spec.
 func findVolume(pod *corev1.Pod, name string) *corev1.Volume {
 	for i := range pod.Spec.Volumes {

--- a/pkg/runtime/k8s_nfs_test.go
+++ b/pkg/runtime/k8s_nfs_test.go
@@ -15,6 +15,7 @@
 package runtime
 
 import (
+	"os"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
@@ -355,6 +356,103 @@ func containsHelper(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// --- N2-4: Stable FSGroup/UID for NFS pods ---
+
+func TestBuildPod_FSGroup_LocalBackend_UsesHostGID(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := RunConfig{
+		Name:         "test-local-gid",
+		Image:        "test-image",
+		UnixUsername: "scion",
+	}
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	// Local backend: FSGroup should be the host GID (os.Getgid())
+	if pod.Spec.SecurityContext == nil || pod.Spec.SecurityContext.FSGroup == nil {
+		t.Fatal("pod security context or FSGroup is nil")
+	}
+
+	hostGID := int64(os.Getgid())
+	if *pod.Spec.SecurityContext.FSGroup != hostGID {
+		t.Errorf("local backend: FSGroup = %d, want host GID %d", *pod.Spec.SecurityContext.FSGroup, hostGID)
+	}
+}
+
+func TestBuildPod_FSGroup_NFSBackend_UsesStableGID(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := RunConfig{
+		Name:                 "test-nfs-gid",
+		Image:                "test-image",
+		UnixUsername:         "scion",
+		WorkspaceBackendName: "nfs",
+		NFSPVClaimName:       "scion-workspaces",
+		NFSGID:               1000,
+	}
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	if pod.Spec.SecurityContext == nil || pod.Spec.SecurityContext.FSGroup == nil {
+		t.Fatal("pod security context or FSGroup is nil")
+	}
+
+	if *pod.Spec.SecurityContext.FSGroup != 1000 {
+		t.Errorf("NFS backend: FSGroup = %d, want 1000", *pod.Spec.SecurityContext.FSGroup)
+	}
+}
+
+func TestBuildPod_FSGroup_NFSBackend_DefaultGID(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := RunConfig{
+		Name:                 "test-nfs-default-gid",
+		Image:                "test-image",
+		UnixUsername:         "scion",
+		WorkspaceBackendName: "nfs",
+		NFSPVClaimName:       "scion-workspaces",
+		// NFSGID is 0 (unset) — should default to 1000
+	}
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	if pod.Spec.SecurityContext == nil || pod.Spec.SecurityContext.FSGroup == nil {
+		t.Fatal("pod security context or FSGroup is nil")
+	}
+
+	if *pod.Spec.SecurityContext.FSGroup != 1000 {
+		t.Errorf("NFS backend default: FSGroup = %d, want 1000", *pod.Spec.SecurityContext.FSGroup)
+	}
+}
+
+func TestBuildPod_FSGroup_NFSBackend_CustomGID(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := RunConfig{
+		Name:                 "test-nfs-custom-gid",
+		Image:                "test-image",
+		UnixUsername:         "scion",
+		WorkspaceBackendName: "nfs",
+		NFSPVClaimName:       "scion-workspaces",
+		NFSGID:               2000,
+	}
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	if *pod.Spec.SecurityContext.FSGroup != 2000 {
+		t.Errorf("NFS backend custom GID: FSGroup = %d, want 2000", *pod.Spec.SecurityContext.FSGroup)
+	}
 }
 
 // --- N2-3: Skip workspace kubectl cp when backend=nfs ---

--- a/pkg/runtime/k8s_nfs_test.go
+++ b/pkg/runtime/k8s_nfs_test.go
@@ -16,11 +16,15 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/k8s"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -358,6 +362,390 @@ func containsHelper(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// --- N2-2b: Advisory lock guard for NFS init-container provisioning ---
+
+// nfsBaseConfig returns a RunConfig for NFS tests with common fields pre-filled.
+func nfsBaseConfig(name string) RunConfig {
+	return RunConfig{
+		Name:                 name,
+		Image:                "test-image",
+		UnixUsername:         "scion",
+		WorkspaceBackendName: "nfs",
+		NFSPVClaimName:       "scion-workspaces",
+		NFSSubPath:           "projects/proj-123/workspace",
+		ProjectID:            "proj-123",
+		GitCloneForInit: &api.GitCloneConfig{
+			URL:    "https://github.com/example/repo.git",
+			Branch: "main",
+			Depth:  1,
+		},
+	}
+}
+
+func TestBuildPod_NFSLockWinner_InjectsCloneInitContainer(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := nfsBaseConfig("test-lock-winner")
+	// nfsProvisionLockLost defaults to false (winner)
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	if len(pod.Spec.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(pod.Spec.InitContainers))
+	}
+
+	ic := pod.Spec.InitContainers[0]
+	if ic.Name != "workspace-provision" {
+		t.Errorf("init container name = %q, want %q", ic.Name, "workspace-provision")
+	}
+
+	script := ic.Command[2]
+	if !contains(script, "git") {
+		t.Error("winner init script should contain git clone command")
+	}
+	if !contains(script, "https://github.com/example/repo.git") {
+		t.Error("winner init script should contain the clone URL")
+	}
+	if !contains(script, ".scion-provisioned") {
+		t.Error("winner init script should reference sentinel file")
+	}
+	// Must NOT contain wait-for-sentinel messaging
+	if contains(script, "Another node is provisioning") {
+		t.Error("winner init script should not contain wait-for-sentinel messaging")
+	}
+}
+
+func TestBuildPod_NFSLockLoser_InjectsWaitInitContainer(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := nfsBaseConfig("test-lock-loser")
+	config.nfsProvisionLockLost = true
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	if len(pod.Spec.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(pod.Spec.InitContainers))
+	}
+
+	ic := pod.Spec.InitContainers[0]
+	if ic.Name != "workspace-provision" {
+		t.Errorf("init container name = %q, want %q", ic.Name, "workspace-provision")
+	}
+
+	script := ic.Command[2]
+	// Wait script must poll for sentinel, NOT clone
+	if contains(script, "git") {
+		t.Error("loser init script should NOT contain git commands")
+	}
+	if !contains(script, ".scion-provisioned") {
+		t.Error("loser init script should reference sentinel file")
+	}
+	if !contains(script, "Another node is provisioning") {
+		t.Error("loser init script should contain wait messaging")
+	}
+	if !contains(script, "TIMEOUT=300") {
+		t.Error("loser init script should have bounded timeout")
+	}
+}
+
+func TestBuildPod_NFSNoLocker_InjectsCloneInitContainer(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := nfsBaseConfig("test-no-locker")
+	// Locker is nil, nfsProvisionLockLost stays false → clone init container
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	if len(pod.Spec.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(pod.Spec.InitContainers))
+	}
+
+	script := pod.Spec.InitContainers[0].Command[2]
+	if !contains(script, "git") {
+		t.Error("no-locker: should get clone init script (sentinel-only fallback)")
+	}
+}
+
+func TestBuildPod_LocalBackend_LockLostIgnored(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := RunConfig{
+		Name:                 "test-local-lockflag",
+		Image:                "test-image",
+		UnixUsername:         "scion",
+		nfsProvisionLockLost: true, // should be ignored for local backend
+	}
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	// Local backend: no init containers regardless of lock flag
+	if len(pod.Spec.InitContainers) != 0 {
+		t.Errorf("local backend: expected no init containers, got %d", len(pod.Spec.InitContainers))
+	}
+}
+
+func TestNFSWaitForSentinelScript(t *testing.T) {
+	script := nfsWaitForSentinelScript()
+
+	if !contains(script, ".scion-provisioned") {
+		t.Error("wait script missing sentinel file reference")
+	}
+	if !contains(script, "TIMEOUT=300") {
+		t.Error("wait script missing timeout")
+	}
+	if !contains(script, "sleep") {
+		t.Error("wait script missing sleep/poll")
+	}
+	if !contains(script, "exit 1") {
+		t.Error("wait script should exit 1 on timeout")
+	}
+	// Must NOT contain git commands
+	if contains(script, "git") {
+		t.Error("wait script should NOT contain git commands")
+	}
+}
+
+func TestBuildPod_NFSConcurrentProjects_IndependentLocks(t *testing.T) {
+	// Two pods for DIFFERENT projects should both get clone init containers
+	// when both are lock winners (no contention across projects).
+	r := newNFSTestK8sRuntime()
+
+	configA := nfsBaseConfig("test-proj-a")
+	configA.ProjectID = "proj-aaa"
+	configA.NFSSubPath = "projects/proj-aaa/workspace"
+
+	configB := nfsBaseConfig("test-proj-b")
+	configB.ProjectID = "proj-bbb"
+	configB.NFSSubPath = "projects/proj-bbb/workspace"
+
+	podA, err := r.buildPod("default", configA)
+	if err != nil {
+		t.Fatalf("buildPod A failed: %v", err)
+	}
+	podB, err := r.buildPod("default", configB)
+	if err != nil {
+		t.Fatalf("buildPod B failed: %v", err)
+	}
+
+	if len(podA.Spec.InitContainers) != 1 {
+		t.Fatalf("project A: expected 1 init container, got %d", len(podA.Spec.InitContainers))
+	}
+	if len(podB.Spec.InitContainers) != 1 {
+		t.Fatalf("project B: expected 1 init container, got %d", len(podB.Spec.InitContainers))
+	}
+
+	// Both should be cloning (winner) init containers
+	scriptA := podA.Spec.InitContainers[0].Command[2]
+	scriptB := podB.Spec.InitContainers[0].Command[2]
+	if !contains(scriptA, "git") {
+		t.Error("project A: should get clone init script")
+	}
+	if !contains(scriptB, "git") {
+		t.Error("project B: should get clone init script")
+	}
+}
+
+func TestBuildPod_NFSSameProject_WinnerAndLoser(t *testing.T) {
+	// Simulate two pods for the SAME project: one winner, one loser.
+	r := newNFSTestK8sRuntime()
+
+	winner := nfsBaseConfig("test-winner")
+	loser := nfsBaseConfig("test-loser")
+	loser.nfsProvisionLockLost = true
+
+	podWinner, err := r.buildPod("default", winner)
+	if err != nil {
+		t.Fatalf("buildPod winner failed: %v", err)
+	}
+	podLoser, err := r.buildPod("default", loser)
+	if err != nil {
+		t.Fatalf("buildPod loser failed: %v", err)
+	}
+
+	if len(podWinner.Spec.InitContainers) != 1 || len(podLoser.Spec.InitContainers) != 1 {
+		t.Fatal("both pods should have exactly 1 init container")
+	}
+
+	winnerScript := podWinner.Spec.InitContainers[0].Command[2]
+	loserScript := podLoser.Spec.InitContainers[0].Command[2]
+
+	// Winner clones
+	if !contains(winnerScript, "git") {
+		t.Error("winner should have clone script")
+	}
+	// Loser waits
+	if contains(loserScript, "git") {
+		t.Error("loser should NOT have clone script")
+	}
+	if !contains(loserScript, "Another node is provisioning") {
+		t.Error("loser should have wait-for-sentinel script")
+	}
+}
+
+// --- N2-2b: Run()-level advisory lock integration tests ---
+
+// errorLocker is an AdvisoryLocker that always returns an error.
+type errorLocker struct {
+	err error
+}
+
+func (l *errorLocker) TryAdvisoryLock(_ context.Context, _ store.AdvisoryLockKey) (bool, func() error, error) {
+	return false, func() error { return nil }, l.err
+}
+
+func (l *errorLocker) TryAdvisoryLockObject(_ context.Context, _ store.AdvisoryLockKey, _ int32) (bool, func() error, error) {
+	return false, func() error { return nil }, l.err
+}
+
+// alwaysLoseLocker is an AdvisoryLocker where TryAdvisoryLockObject always
+// returns acquired=false (another node holds the lock).
+type alwaysLoseLocker struct{}
+
+func (l *alwaysLoseLocker) TryAdvisoryLock(_ context.Context, _ store.AdvisoryLockKey) (bool, func() error, error) {
+	return false, func() error { return nil }, nil
+}
+
+func (l *alwaysLoseLocker) TryAdvisoryLockObject(_ context.Context, _ store.AdvisoryLockKey, _ int32) (bool, func() error, error) {
+	return false, func() error { return nil }, nil
+}
+
+func TestRun_NFSLockError_FailsDispatch(t *testing.T) {
+	// When the advisory lock returns an error, Run() must fail BEFORE
+	// creating any pods (no unguarded clone).
+	r := newNFSTestK8sRuntime()
+	config := nfsBaseConfig("test-lock-err")
+	config.Locker = &errorLocker{err: errors.New("connection lost")}
+
+	_, err := r.Run(context.Background(), config)
+	if err == nil {
+		t.Fatal("expected Run() to fail when advisory lock returns error")
+	}
+	if !strings.Contains(err.Error(), "advisory lock") {
+		t.Errorf("error should mention advisory lock, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "connection lost") {
+		t.Errorf("error should propagate underlying cause, got: %v", err)
+	}
+
+	// Verify no pods were created
+	pods, listErr := r.Client.Clientset.CoreV1().Pods("default").List(
+		context.Background(), metav1.ListOptions{},
+	)
+	if listErr != nil {
+		t.Fatalf("failed to list pods: %v", listErr)
+	}
+	if len(pods.Items) != 0 {
+		t.Errorf("lock error should prevent pod creation, but found %d pods", len(pods.Items))
+	}
+}
+
+func TestRun_NFSLockLost_CreatesWaitPod(t *testing.T) {
+	// When the lock is held by another node, the pod should have a
+	// wait-for-sentinel init container, not a cloning one.
+	r := newNFSTestK8sRuntime()
+	config := nfsBaseConfig("scion-test-lock-lost")
+	config.Locker = &alwaysLoseLocker{}
+
+	// Run() will create the pod but waitForPodReady will time out with the
+	// fake clientset. Use a short-lived context so we don't block for 10m.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	r.Run(ctx, config) //nolint:errcheck
+
+	// Verify the created pod has a wait-for-sentinel init container
+	pods, err := r.Client.Clientset.CoreV1().Pods("default").List(
+		context.Background(), metav1.ListOptions{},
+	)
+	if err != nil {
+		t.Fatalf("failed to list pods: %v", err)
+	}
+	if len(pods.Items) != 1 {
+		t.Fatalf("expected 1 pod, got %d", len(pods.Items))
+	}
+
+	pod := pods.Items[0]
+	if len(pod.Spec.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(pod.Spec.InitContainers))
+	}
+
+	script := pod.Spec.InitContainers[0].Command[2]
+	if strings.Contains(script, "git") {
+		t.Error("lock-lost pod should have wait-for-sentinel script, not clone script")
+	}
+	if !strings.Contains(script, "Another node is provisioning") {
+		t.Error("lock-lost pod should have wait-for-sentinel messaging")
+	}
+}
+
+func TestRun_NFSLockWon_CreatesClonePod(t *testing.T) {
+	// When the lock is won, the pod should have the cloning init container.
+	r := newNFSTestK8sRuntime()
+	locker := newTestLocker()
+	config := nfsBaseConfig("scion-test-lock-won")
+	config.Locker = locker
+
+	// Short-lived context to avoid blocking on waitForPodReady.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	r.Run(ctx, config) //nolint:errcheck
+
+	pods, err := r.Client.Clientset.CoreV1().Pods("default").List(
+		context.Background(), metav1.ListOptions{},
+	)
+	if err != nil {
+		t.Fatalf("failed to list pods: %v", err)
+	}
+	if len(pods.Items) != 1 {
+		t.Fatalf("expected 1 pod, got %d", len(pods.Items))
+	}
+
+	pod := pods.Items[0]
+	if len(pod.Spec.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(pod.Spec.InitContainers))
+	}
+
+	script := pod.Spec.InitContainers[0].Command[2]
+	if !strings.Contains(script, "git") {
+		t.Error("lock-won pod should have clone script")
+	}
+	if strings.Contains(script, "Another node is provisioning") {
+		t.Error("lock-won pod should not have wait-for-sentinel messaging")
+	}
+}
+
+func TestRun_LocalBackend_NoLockAttempt(t *testing.T) {
+	// Local backend should never attempt the advisory lock, even if a
+	// Locker is provided. The lock is only for NFS.
+	r := newNFSTestK8sRuntime()
+	locker := &errorLocker{err: errors.New("should not be called")}
+	config := RunConfig{
+		Name:         "scion-test-local-nolock",
+		Image:        "test-image",
+		UnixUsername: "scion",
+		ProjectID:    "proj-local",
+		Locker:       locker,
+		// No NFS fields → local backend
+	}
+
+	// Run() should NOT fail with lock error (lock is only for NFS).
+	// It will fail at waitForPodReady with fake client, but NOT at lock.
+	// Short-lived context to avoid blocking.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, err := r.Run(ctx, config)
+	if err != nil && strings.Contains(err.Error(), "advisory lock") {
+		t.Errorf("local backend should not attempt advisory lock, got: %v", err)
+	}
 }
 
 // --- N2-4: Stable FSGroup/UID for NFS pods ---

--- a/pkg/runtime/k8s_nfs_test.go
+++ b/pkg/runtime/k8s_nfs_test.go
@@ -15,12 +15,14 @@
 package runtime
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic/fake"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
@@ -506,6 +508,249 @@ func TestSkipWorkspaceSync_NFSBackend_RunConfigGuard(t *testing.T) {
 				t.Errorf("workspace sync guard: got %v, want %v", shouldSync, tt.wantWorkspaceCP)
 			}
 		})
+	}
+}
+
+// --- N2-5: Generalized shared-dir PVC helpers ---
+
+func TestBuildPod_SharedDirs_LocalBackend_SeparatePVCs(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := RunConfig{
+		Name:         "test-local-shared",
+		Image:        "test-image",
+		UnixUsername: "scion",
+		Labels: map[string]string{
+			"scion.grove": "my-project",
+		},
+		SharedDirs: []api.SharedDir{
+			{Name: "build-cache"},
+			{Name: "logs"},
+		},
+	}
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	// Local backend: each shared dir should have its own PVC volume
+	sd0Vol := findVolume(pod, "shared-dir-0")
+	sd1Vol := findVolume(pod, "shared-dir-1")
+
+	if sd0Vol == nil || sd1Vol == nil {
+		t.Fatal("local backend: expected shared-dir-0 and shared-dir-1 volumes")
+	}
+
+	// PVC names should follow the sharedDirPVCName convention
+	if sd0Vol.PersistentVolumeClaim.ClaimName != "scion-shared-my-project-build-cache" {
+		t.Errorf("shared-dir-0 claimName = %q, want %q", sd0Vol.PersistentVolumeClaim.ClaimName, "scion-shared-my-project-build-cache")
+	}
+	if sd1Vol.PersistentVolumeClaim.ClaimName != "scion-shared-my-project-logs" {
+		t.Errorf("shared-dir-1 claimName = %q, want %q", sd1Vol.PersistentVolumeClaim.ClaimName, "scion-shared-my-project-logs")
+	}
+
+	// Mounts should NOT have subPath for local backend
+	sd0Mount := findVolumeMount(&pod.Spec.Containers[0], "shared-dir-0")
+	if sd0Mount == nil {
+		t.Fatal("shared-dir-0 mount not found")
+	}
+	if sd0Mount.SubPath != "" {
+		t.Errorf("local backend: shared-dir-0 should not have subPath, got %q", sd0Mount.SubPath)
+	}
+}
+
+func TestBuildPod_SharedDirs_NFSBackend_UsesNFSSubPaths(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := RunConfig{
+		Name:                 "test-nfs-shared",
+		Image:                "test-image",
+		UnixUsername:         "scion",
+		WorkspaceBackendName: "nfs",
+		NFSPVClaimName:       "scion-workspaces",
+		NFSSubPath:           "projects/proj-123/workspace",
+		Labels: map[string]string{
+			"scion.grove": "my-project",
+		},
+		SharedDirs: []api.SharedDir{
+			{Name: "build-cache"},
+			{Name: "logs", ReadOnly: true},
+		},
+	}
+
+	pod, err := r.buildPod("default", config)
+	if err != nil {
+		t.Fatalf("buildPod failed: %v", err)
+	}
+
+	// NFS backend: shared dir volumes should use the SAME PVC as workspace
+	sd0Vol := findVolume(pod, "shared-dir-0")
+	sd1Vol := findVolume(pod, "shared-dir-1")
+
+	if sd0Vol == nil || sd1Vol == nil {
+		t.Fatal("NFS backend: expected shared-dir-0 and shared-dir-1 volumes")
+	}
+
+	// Both should reference the workspace NFS PVC
+	if sd0Vol.PersistentVolumeClaim.ClaimName != "scion-workspaces" {
+		t.Errorf("shared-dir-0 claimName = %q, want %q", sd0Vol.PersistentVolumeClaim.ClaimName, "scion-workspaces")
+	}
+	if sd1Vol.PersistentVolumeClaim.ClaimName != "scion-workspaces" {
+		t.Errorf("shared-dir-1 claimName = %q, want %q", sd1Vol.PersistentVolumeClaim.ClaimName, "scion-workspaces")
+	}
+
+	// Mounts should have NFS subPaths
+	sd0Mount := findVolumeMount(&pod.Spec.Containers[0], "shared-dir-0")
+	sd1Mount := findVolumeMount(&pod.Spec.Containers[0], "shared-dir-1")
+
+	if sd0Mount == nil || sd1Mount == nil {
+		t.Fatal("shared-dir mounts not found")
+	}
+
+	wantSubPath0 := "projects/proj-123/shared-dirs/build-cache"
+	if sd0Mount.SubPath != wantSubPath0 {
+		t.Errorf("shared-dir-0 subPath = %q, want %q", sd0Mount.SubPath, wantSubPath0)
+	}
+
+	wantSubPath1 := "projects/proj-123/shared-dirs/logs"
+	if sd1Mount.SubPath != wantSubPath1 {
+		t.Errorf("shared-dir-1 subPath = %q, want %q", sd1Mount.SubPath, wantSubPath1)
+	}
+
+	// Verify readOnly flag propagates
+	if sd1Mount.ReadOnly != true {
+		t.Error("shared-dir-1 should be read-only")
+	}
+	if sd0Mount.ReadOnly != false {
+		t.Error("shared-dir-0 should not be read-only")
+	}
+}
+
+func TestNFSSharedDirSubPath(t *testing.T) {
+	tests := []struct {
+		workspaceSubPath string
+		sharedDirName    string
+		want             string
+	}{
+		{
+			workspaceSubPath: "projects/proj-123/workspace",
+			sharedDirName:    "build-cache",
+			want:             "projects/proj-123/shared-dirs/build-cache",
+		},
+		{
+			workspaceSubPath: "projects/proj-456/workspace",
+			sharedDirName:    "logs",
+			want:             "projects/proj-456/shared-dirs/logs",
+		},
+		{
+			workspaceSubPath: "custom-root/proj-789/workspace",
+			sharedDirName:    "data",
+			want:             "custom-root/proj-789/shared-dirs/data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sharedDirName, func(t *testing.T) {
+			got := nfsSharedDirSubPath(tt.workspaceSubPath, tt.sharedDirName)
+			if got != tt.want {
+				t.Errorf("nfsSharedDirSubPath(%q, %q) = %q, want %q", tt.workspaceSubPath, tt.sharedDirName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectRWXClaimName(t *testing.T) {
+	// Test the generalized naming helper
+	got := projectRWXClaimName("my-project", "shared", "build-cache")
+	want := "scion-shared-my-project-build-cache"
+	if got != want {
+		t.Errorf("projectRWXClaimName = %q, want %q", got, want)
+	}
+
+	// Test backward compatibility with sharedDirPVCName
+	got2 := sharedDirPVCName("my-project", "build-cache")
+	if got != got2 {
+		t.Errorf("sharedDirPVCName should equal projectRWXClaimName(shared): %q != %q", got2, got)
+	}
+}
+
+func TestCreateSharedDirPVCs_NFSBackend_SkipsPVCCreation(t *testing.T) {
+	clientset := k8sfake.NewClientset()
+	scheme := k8sruntime.NewScheme()
+	fc := fake.NewSimpleDynamicClient(scheme)
+	client := k8s.NewTestClient(fc, clientset)
+	r := NewKubernetesRuntime(client)
+
+	config := RunConfig{
+		Name:                 "test-nfs",
+		WorkspaceBackendName: "nfs",
+		NFSPVClaimName:       "scion-workspaces",
+		Labels: map[string]string{
+			"scion.grove":    "my-project",
+			"scion.grove_id": "proj-123",
+		},
+		SharedDirs: []api.SharedDir{
+			{Name: "build-cache"},
+		},
+	}
+
+	err := r.createSharedDirPVCs(context.Background(), "default", config)
+	if err != nil {
+		t.Fatalf("createSharedDirPVCs failed: %v", err)
+	}
+
+	// No PVCs should have been created for NFS backend
+	pvcs, err := clientset.CoreV1().PersistentVolumeClaims("default").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list PVCs failed: %v", err)
+	}
+	if len(pvcs.Items) != 0 {
+		t.Errorf("NFS backend: expected 0 PVCs, got %d", len(pvcs.Items))
+	}
+}
+
+func TestCreateSharedDirPVCs_LocalBackend_CreatesPVCs(t *testing.T) {
+	clientset := k8sfake.NewClientset()
+	scheme := k8sruntime.NewScheme()
+	fc := fake.NewSimpleDynamicClient(scheme)
+	client := k8s.NewTestClient(fc, clientset)
+	r := NewKubernetesRuntime(client)
+
+	config := RunConfig{
+		Name: "test-local",
+		Labels: map[string]string{
+			"scion.grove":    "my-project",
+			"scion.grove_id": "proj-123",
+		},
+		SharedDirs: []api.SharedDir{
+			{Name: "build-cache"},
+			{Name: "logs"},
+		},
+	}
+
+	err := r.createSharedDirPVCs(context.Background(), "default", config)
+	if err != nil {
+		t.Fatalf("createSharedDirPVCs failed: %v", err)
+	}
+
+	// Local backend: 2 PVCs should be created
+	pvcs, err := clientset.CoreV1().PersistentVolumeClaims("default").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list PVCs failed: %v", err)
+	}
+	if len(pvcs.Items) != 2 {
+		t.Errorf("local backend: expected 2 PVCs, got %d", len(pvcs.Items))
+	}
+
+	// Verify PVC names
+	pvcNames := map[string]bool{}
+	for _, pvc := range pvcs.Items {
+		pvcNames[pvc.Name] = true
+	}
+	if !pvcNames["scion-shared-my-project-build-cache"] {
+		t.Error("missing PVC scion-shared-my-project-build-cache")
+	}
+	if !pvcNames["scion-shared-my-project-logs"] {
+		t.Error("missing PVC scion-shared-my-project-logs")
 	}
 }
 

--- a/pkg/runtime/k8s_nfs_test.go
+++ b/pkg/runtime/k8s_nfs_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/k8s"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -238,7 +240,7 @@ func TestBuildPod_NFSBackend_InitContainer_Present(t *testing.T) {
 		t.Errorf("init container workspace subPath = %q, want %q", wsMount.SubPath, "projects/proj-123/workspace")
 	}
 
-	// Command should reference the git URL and contain sentinel check
+	// Command should reference env vars (not inline URL/branch) and contain sentinel check
 	if len(ic.Command) < 3 {
 		t.Fatalf("init container command too short: %v", ic.Command)
 	}
@@ -246,11 +248,32 @@ func TestBuildPod_NFSBackend_InitContainer_Present(t *testing.T) {
 	if !contains(script, ".scion-provisioned") {
 		t.Errorf("init script does not reference sentinel file .scion-provisioned")
 	}
-	if !contains(script, "https://github.com/example/repo.git") {
-		t.Errorf("init script does not contain git clone URL")
+	// URL and branch must be passed via env vars, NOT interpolated into script
+	if !contains(script, "$SCION_CLONE_URL") {
+		t.Errorf("init script does not reference $SCION_CLONE_URL env var")
 	}
-	if !contains(script, "--branch 'main'") {
-		t.Errorf("init script does not contain branch flag")
+	if contains(script, "https://github.com/example/repo.git") {
+		t.Errorf("init script contains inline URL — must use env var for injection safety")
+	}
+	if !contains(script, "$SCION_CLONE_BRANCH") {
+		t.Errorf("init script does not reference $SCION_CLONE_BRANCH env var")
+	}
+
+	// Verify env vars are set on the container
+	var hasURL, hasBranch bool
+	for _, env := range ic.Env {
+		if env.Name == "SCION_CLONE_URL" && env.Value == "https://github.com/example/repo.git" {
+			hasURL = true
+		}
+		if env.Name == "SCION_CLONE_BRANCH" && env.Value == "main" {
+			hasBranch = true
+		}
+	}
+	if !hasURL {
+		t.Error("init container missing SCION_CLONE_URL env var")
+	}
+	if !hasBranch {
+		t.Error("init container missing SCION_CLONE_BRANCH env var")
 	}
 }
 
@@ -312,12 +335,19 @@ func TestNFSInitProvisionScript_SentinelCheck(t *testing.T) {
 		t.Error("script missing sentinel check")
 	}
 
-	// Must contain git clone with the URL
-	if !contains(script, "git") && !contains(script, "clone") {
-		t.Error("script missing git clone command")
+	// Script must reference $SCION_CLONE_URL env var (not inline URL)
+	if !contains(script, "$SCION_CLONE_URL") {
+		t.Error("script missing $SCION_CLONE_URL env var reference")
 	}
-	if !contains(script, gc.URL) {
-		t.Errorf("script missing clone URL %q", gc.URL)
+
+	// URL must NOT be interpolated into script text (shell injection prevention)
+	if contains(script, gc.URL) {
+		t.Error("script contains inline URL — must use env var instead")
+	}
+
+	// Must contain git clone command
+	if !contains(script, "git") || !contains(script, "clone") {
+		t.Error("script missing git clone command")
 	}
 
 	// Must write sentinel after successful clone
@@ -344,6 +374,53 @@ func TestNFSInitProvisionScript_FullClone(t *testing.T) {
 	// With depth -1, should not include --depth flag
 	if contains(script, "--depth") {
 		t.Error("full clone (depth=-1): should not include --depth flag")
+	}
+}
+
+func TestNFSInitProvisionEnv(t *testing.T) {
+	t.Run("includes URL and branch", func(t *testing.T) {
+		gc := &api.GitCloneConfig{
+			URL:    "https://github.com/example/repo.git",
+			Branch: "main",
+		}
+		envs := nfsInitProvisionEnv(gc)
+		require.Len(t, envs, 2)
+		assert.Equal(t, "SCION_CLONE_URL", envs[0].Name)
+		assert.Equal(t, gc.URL, envs[0].Value)
+		assert.Equal(t, "SCION_CLONE_BRANCH", envs[1].Name)
+		assert.Equal(t, gc.Branch, envs[1].Value)
+	})
+
+	t.Run("omits branch when empty", func(t *testing.T) {
+		gc := &api.GitCloneConfig{
+			URL: "https://github.com/example/repo.git",
+		}
+		envs := nfsInitProvisionEnv(gc)
+		require.Len(t, envs, 1)
+		assert.Equal(t, "SCION_CLONE_URL", envs[0].Name)
+	})
+
+	t.Run("nil config returns nil", func(t *testing.T) {
+		envs := nfsInitProvisionEnv(nil)
+		assert.Nil(t, envs)
+	})
+}
+
+func TestNFSInitProvisionScript_BranchEnvVar(t *testing.T) {
+	gc := &api.GitCloneConfig{
+		URL:    "https://github.com/example/repo.git",
+		Branch: "feat/test",
+	}
+	script := nfsInitProvisionScript(gc)
+
+	// Branch must NOT appear in script text (injection prevention)
+	if contains(script, gc.Branch) {
+		t.Error("script contains inline branch — must use env var instead")
+	}
+
+	// Script must reference $SCION_CLONE_BRANCH env var
+	if !contains(script, "$SCION_CLONE_BRANCH") {
+		t.Error("script missing $SCION_CLONE_BRANCH env var reference")
 	}
 }
 
@@ -407,8 +484,12 @@ func TestBuildPod_NFSLockWinner_InjectsCloneInitContainer(t *testing.T) {
 	if !contains(script, "git") {
 		t.Error("winner init script should contain git clone command")
 	}
-	if !contains(script, "https://github.com/example/repo.git") {
-		t.Error("winner init script should contain the clone URL")
+	// URL must be passed via env var, not interpolated into script
+	if !contains(script, "$SCION_CLONE_URL") {
+		t.Error("winner init script should reference $SCION_CLONE_URL env var")
+	}
+	if contains(script, "https://github.com/example/repo.git") {
+		t.Error("winner init script must NOT contain inline URL (shell injection risk)")
 	}
 	if !contains(script, ".scion-provisioned") {
 		t.Error("winner init script should reference sentinel file")
@@ -416,6 +497,23 @@ func TestBuildPod_NFSLockWinner_InjectsCloneInitContainer(t *testing.T) {
 	// Must NOT contain wait-for-sentinel messaging
 	if contains(script, "Another node is provisioning") {
 		t.Error("winner init script should not contain wait-for-sentinel messaging")
+	}
+
+	// Verify env vars are set on the init container
+	var hasURL, hasBranch bool
+	for _, env := range ic.Env {
+		if env.Name == "SCION_CLONE_URL" && env.Value == "https://github.com/example/repo.git" {
+			hasURL = true
+		}
+		if env.Name == "SCION_CLONE_BRANCH" && env.Value == "main" {
+			hasBranch = true
+		}
+	}
+	if !hasURL {
+		t.Error("init container missing SCION_CLONE_URL env var")
+	}
+	if !hasBranch {
+		t.Error("init container missing SCION_CLONE_BRANCH env var")
 	}
 }
 
@@ -1160,4 +1258,32 @@ func findVolumeMount(container *corev1.Container, name string) *corev1.VolumeMou
 		}
 	}
 	return nil
+}
+
+// --- acquireProvisionLock context cancellation test ---
+
+func TestAcquireProvisionLock_ContextCancellation(t *testing.T) {
+	// When the context is cancelled while waiting for a lock, acquireProvisionLock
+	// must return promptly with a context error instead of sleeping for the full
+	// retry duration (30 × 1s = 30s).
+	backend := &nfsBackend{}
+	locker := &alwaysLoseLocker{} // lock never acquired
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately so the first select on ctx.Done() fires
+	cancel()
+
+	in := ProvisionInput{
+		ProjectID: "proj-cancel-test",
+		Locker:    locker,
+	}
+
+	start := time.Now()
+	_, err := backend.acquireProvisionLock(ctx, in)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context cancelled")
+	// Must return within 2s, not 30s (provisionLockRetries × provisionLockRetryDelay)
+	assert.Less(t, elapsed, 2*time.Second, "should return promptly on context cancellation, not wait for all retries")
 }

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -333,7 +333,14 @@ func (r *KubernetesRuntime) Run(ctx context.Context, config RunConfig) (string, 
 		}
 	}
 
-	if config.Workspace != "" {
+	// Workspace sync: NFS-backed pods have workspace bytes pre-populated by the
+	// init container (N2-2), so skip the kubectl-cp workspace sync. This avoids
+	// redundantly copying workspace contents that already exist on the shared
+	// NFS volume. Local-backend pods RETAIN the existing workspace sync.
+	//
+	// Home-dir sync and the startup gate (/tmp/.scion-home-ready) are RETAINED
+	// for both backends — they carry agent dotfiles and secrets, not workspace code.
+	if config.Workspace != "" && config.WorkspaceBackendName != "nfs" {
 		runtimeLog.Info("Syncing workspace", "agent", config.Name, "source", config.Workspace, "phase", "workspace-sync")
 		fmt.Printf("  Syncing workspace (%s -> /workspace)...\n", config.Workspace)
 		err = r.syncWithRetry(ctx, func() error {
@@ -347,6 +354,9 @@ func (r *KubernetesRuntime) Run(ctx context.Context, config RunConfig) (string, 
 		if _, err := r.execInPod(ctx, namespace, createdPod.Name, []string{"sh", "-c", chownCmd}); err != nil {
 			runtimeLog.Debug("Failed to chown workspace (non-fatal)", "error", err)
 		}
+	} else if config.WorkspaceBackendName == "nfs" {
+		runtimeLog.Info("Skipping workspace sync (NFS backend: workspace pre-populated by init container)",
+			"agent", config.Name, "phase", "workspace-sync-skip")
 	}
 
 	// Signal the startup gate: all files are synced and ownership is fixed,

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -664,10 +664,28 @@ func (r *KubernetesRuntime) createAuthFileSecret(ctx context.Context, namespace,
 	return nil
 }
 
-// sharedDirPVCName returns the deterministic PVC name for a project shared directory.
+// --- Generalized project RWX claim helpers (N2-5) ---
+//
+// These helpers manage project-scoped PVCs for both shared directories and
+// (future) workspace claims. The naming convention and lifecycle are identical;
+// only the label selector differs.
+//
+// When backend=nfs, shared dirs are served from the workspace NFS PVC via
+// subPath (e.g., "projects/<pid>/shared-dirs/<name>") and do NOT need their
+// own PVC — the NFS volume already provides RWX access. The create/cleanup
+// helpers short-circuit for NFS.
+
+// projectRWXClaimName returns a deterministic PVC name for a project-scoped
+// RWX claim. Usable for shared dirs ("shared") and workspace claims ("workspace").
 // PVCs are project-scoped (not agent-scoped), so multiple agents share the same PVC.
+func projectRWXClaimName(projectName, claimType, dirName string) string {
+	return fmt.Sprintf("scion-%s-%s-%s", claimType, projectName, dirName)
+}
+
+// sharedDirPVCName returns the deterministic PVC name for a project shared directory.
+// This is a convenience wrapper around projectRWXClaimName for backward compatibility.
 func sharedDirPVCName(projectName, dirName string) string {
-	return fmt.Sprintf("scion-shared-%s-%s", projectName, dirName)
+	return projectRWXClaimName(projectName, "shared", dirName)
 }
 
 // defaultSharedDirSize is the default PVC size when not specified in settings.
@@ -676,8 +694,19 @@ const defaultSharedDirSize = "10Gi"
 // createSharedDirPVCs ensures PVCs exist for all declared shared directories.
 // PVCs are project-scoped and persist across agent restarts. If a PVC already
 // exists (from a previous agent in the same project), it is reused.
+//
+// When backend=nfs, shared dirs are served via NFS subPath from the workspace
+// PVC and do NOT require separate PVCs — this method is a no-op for NFS.
 func (r *KubernetesRuntime) createSharedDirPVCs(ctx context.Context, namespace string, config RunConfig) error {
 	if len(config.SharedDirs) == 0 {
+		return nil
+	}
+
+	// NFS backend: shared dirs use subPaths on the workspace NFS PVC,
+	// no separate PVCs needed (design §5.3).
+	if config.WorkspaceBackendName == "nfs" && config.NFSPVClaimName != "" {
+		runtimeLog.Info("NFS backend: shared dirs served via NFS subPath, skipping PVC creation",
+			"shared_dir_count", len(config.SharedDirs))
 		return nil
 	}
 
@@ -712,49 +741,63 @@ func (r *KubernetesRuntime) createSharedDirPVCs(ctx context.Context, namespace s
 	}
 
 	for _, sd := range config.SharedDirs {
-		pvcName := sharedDirPVCName(projectName, sd.Name)
-
-		// Check if PVC already exists (project-scoped, may have been created by another agent)
-		_, err := r.Client.Clientset.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
-		if err == nil {
-			runtimeLog.Info("Shared dir PVC already exists, reusing", "pvc", pvcName, "shared_dir", sd.Name)
-			continue
+		if err := r.ensureProjectRWXClaim(ctx, namespace, projectName, projectID, sd.Name, storageClass, storageQuantity); err != nil {
+			return err
 		}
+	}
 
-		accessMode := corev1.ReadWriteMany
-		pvc := &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      pvcName,
-				Namespace: namespace,
-				Labels: map[string]string{
-					"scion.project":    projectName,
-					"scion.grove":      projectName,
-					"scion.shared-dir": sd.Name,
+	return nil
+}
+
+// ensureProjectRWXClaim is the idempotent get-or-create core for project-scoped
+// RWX PVCs. It creates a PVC with a deterministic name if one does not already
+// exist. Used by both shared-dir and (future) workspace claim paths.
+func (r *KubernetesRuntime) ensureProjectRWXClaim(
+	ctx context.Context,
+	namespace, projectName, projectID, dirName, storageClass string,
+	storageQuantity resource.Quantity,
+) error {
+	pvcName := sharedDirPVCName(projectName, dirName)
+
+	// Check if PVC already exists (project-scoped, may have been created by another agent)
+	_, err := r.Client.Clientset.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
+	if err == nil {
+		runtimeLog.Info("Project RWX PVC already exists, reusing", "pvc", pvcName, "dir", dirName)
+		return nil
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"scion.project":    projectName,
+				"scion.grove":      projectName,
+				"scion.shared-dir": dirName,
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: storageQuantity,
 				},
 			},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				AccessModes: []corev1.PersistentVolumeAccessMode{accessMode},
-				Resources: corev1.VolumeResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: storageQuantity,
-					},
-				},
-			},
-		}
+		},
+	}
 
-		if projectID != "" {
-			pvc.Labels["scion.project_id"] = projectID
-			pvc.Labels["scion.grove_id"] = projectID
-		}
+	if projectID != "" {
+		pvc.Labels["scion.project_id"] = projectID
+		pvc.Labels["scion.grove_id"] = projectID
+	}
 
-		if storageClass != "" {
-			pvc.Spec.StorageClassName = &storageClass
-		}
+	if storageClass != "" {
+		pvc.Spec.StorageClassName = &storageClass
+	}
 
-		runtimeLog.Info("Creating shared dir PVC", "pvc", pvcName, "shared_dir", sd.Name, "size", size)
-		if _, err := r.Client.Clientset.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc, metav1.CreateOptions{}); err != nil {
-			return fmt.Errorf("failed to create shared dir PVC %q: %w", pvcName, err)
-		}
+	runtimeLog.Info("Creating project RWX PVC", "pvc", pvcName, "dir", dirName, "storage", storageQuantity.String())
+	if _, err := r.Client.Clientset.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("failed to create project RWX PVC %q: %w", pvcName, err)
 	}
 
 	return nil
@@ -762,19 +805,27 @@ func (r *KubernetesRuntime) createSharedDirPVCs(ctx context.Context, namespace s
 
 // cleanupSharedDirPVCs removes PVCs for shared directories belonging to a project.
 // This is called during project deletion, not agent deletion, since PVCs are project-scoped.
+// When backend=nfs, shared dirs live on the NFS volume (no separate PVCs) but the
+// cleanup still runs — it harmlessly finds nothing because no PVCs were created.
 func (r *KubernetesRuntime) cleanupSharedDirPVCs(ctx context.Context, namespace, projectName string) {
-	selector := fmt.Sprintf("scion.grove=%s,scion.shared-dir", projectName)
+	r.cleanupProjectRWXClaims(ctx, namespace, projectName, "scion.shared-dir")
+}
+
+// cleanupProjectRWXClaims is the generic cleanup helper for project-scoped RWX PVCs.
+// It lists PVCs matching the project and label key, then deletes them.
+func (r *KubernetesRuntime) cleanupProjectRWXClaims(ctx context.Context, namespace, projectName, labelKey string) {
+	selector := fmt.Sprintf("scion.grove=%s,%s", projectName, labelKey)
 	pvcList, err := r.Client.Clientset.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: selector,
 	})
 	if err != nil {
-		runtimeLog.Warn("Failed to list shared dir PVCs for cleanup", "grove_id", projectName, "error", err)
+		runtimeLog.Warn("Failed to list project RWX PVCs for cleanup", "project", projectName, "label", labelKey, "error", err)
 		return
 	}
 	for _, pvc := range pvcList.Items {
-		runtimeLog.Info("Deleting shared dir PVC", "pvc", pvc.Name, "grove_id", projectName)
+		runtimeLog.Info("Deleting project RWX PVC", "pvc", pvc.Name, "project", projectName)
 		if err := r.Client.Clientset.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvc.Name, metav1.DeleteOptions{}); err != nil {
-			runtimeLog.Warn("Failed to delete shared dir PVC", "pvc", pvc.Name, "error", err)
+			runtimeLog.Warn("Failed to delete project RWX PVC", "pvc", pvc.Name, "error", err)
 		}
 	}
 }
@@ -1252,13 +1303,20 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 		}
 	}
 
-	// Process shared directories — create PVC-backed volumes and mounts.
+	// Process shared directories — mount shared-dir volumes.
 	// Build a set of shared dir targets so we can skip them in the regular volume loop.
+	//
+	// NFS backend (N2-5): shared dirs are served from the SAME workspace NFS PVC
+	// via subPath (e.g., "projects/<pid>/shared-dirs/<name>"), avoiding per-dir PVCs.
+	// The workspace volume is already defined; we add additional subPath mounts.
+	//
+	// Local backend: each shared dir gets its own PVC (existing behavior, unchanged).
 	k8sContainerWorkspace := config.ContainerWorkspace
 	if k8sContainerWorkspace == "" {
 		k8sContainerWorkspace = "/workspace"
 	}
 	sharedDirTargets := make(map[string]bool, len(config.SharedDirs))
+	nfsSharedDirs := config.WorkspaceBackendName == "nfs" && config.NFSPVClaimName != ""
 	for i, sd := range config.SharedDirs {
 		target := fmt.Sprintf("/scion-volumes/%s", sd.Name)
 		if sd.InWorkspace {
@@ -1266,24 +1324,52 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 		}
 		sharedDirTargets[target] = true
 
-		projectName := config.Labels["scion.grove"]
-		pvcName := sharedDirPVCName(projectName, sd.Name)
-		volName := fmt.Sprintf("shared-dir-%d", i)
+		if nfsSharedDirs {
+			// NFS backend: mount from the workspace PVC with a shared-dir subPath.
+			// SubPath root mirrors the nfsBackend.Resolve layout:
+			//   <SubPathRoot>/<projectID>/shared-dirs/<name>
+			sdSubPath := nfsSharedDirSubPath(config.NFSSubPath, sd.Name)
+			volName := fmt.Sprintf("shared-dir-%d", i)
 
-		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
-			Name: volName,
-			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: pvcName,
-					ReadOnly:  sd.ReadOnly,
+			// The volume source is the SAME NFS PVC as the workspace — but K8s
+			// requires a separate Volume entry per unique (claimName, subPath)
+			// pair in the pod spec, so we add the volume under a distinct name.
+			pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+				Name: volName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: config.NFSPVClaimName,
+						ReadOnly:  sd.ReadOnly,
+					},
 				},
-			},
-		})
-		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
-			Name:      volName,
-			MountPath: target,
-			ReadOnly:  sd.ReadOnly,
-		})
+			})
+			pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+				Name:      volName,
+				MountPath: target,
+				SubPath:   sdSubPath,
+				ReadOnly:  sd.ReadOnly,
+			})
+		} else {
+			// Local backend: each shared dir gets its own PVC (existing behavior).
+			projectName := config.Labels["scion.grove"]
+			pvcName := sharedDirPVCName(projectName, sd.Name)
+			volName := fmt.Sprintf("shared-dir-%d", i)
+
+			pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+				Name: volName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+						ReadOnly:  sd.ReadOnly,
+					},
+				},
+			})
+			pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+				Name:      volName,
+				MountPath: target,
+				ReadOnly:  sd.ReadOnly,
+			})
+		}
 	}
 
 	// Process Volumes
@@ -2251,6 +2337,18 @@ func (r *KubernetesRuntime) GetWorkspacePath(ctx context.Context, id string) (st
 	}
 
 	return "", fmt.Errorf("no workspace path found for pod %s", id)
+}
+
+// nfsSharedDirSubPath computes the NFS subPath for a shared directory given the
+// workspace subPath. The workspace subPath is like "projects/<pid>/workspace";
+// shared dirs are siblings: "projects/<pid>/shared-dirs/<name>".
+//
+// This mirrors the nfsBackend.Resolve layout (design §5.3).
+func nfsSharedDirSubPath(workspaceSubPath, sharedDirName string) string {
+	// workspaceSubPath is "projects/<pid>/workspace"
+	// We need "projects/<pid>/shared-dirs/<name>"
+	parent := filepath.Dir(workspaceSubPath)     // "projects/<pid>"
+	return filepath.Join(parent, "shared-dirs", sharedDirName)
 }
 
 // nfsInitProvisionScript generates the shell script for the NFS workspace

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -34,6 +34,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/gcp"
 	"github.com/GoogleCloudPlatform/scion/pkg/k8s"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"golang.org/x/term"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -291,6 +292,56 @@ func (r *KubernetesRuntime) Run(ctx context.Context, config RunConfig) (string, 
 			return "", fmt.Errorf("failed to create shared dir PVCs: %w", err)
 		}
 	}
+
+	// --- N2-2b: Per-project advisory lock for NFS init-container provisioning ---
+	//
+	// When backend=nfs with a git clone configured AND an advisory locker is
+	// available, acquire the per-project lock before building the pod spec.
+	// This prevents concurrent first-clone corruption (risk RN1, design §7):
+	//   - Lock winner: injects the cloning init container (existing N2-2 script)
+	//   - Lock loser:  injects a wait-for-sentinel init container (polls for
+	//                  .scion-provisioned without cloning)
+	//
+	// The lock is held until waitForPodReady returns (all init containers
+	// complete), mirroring N1-4's "hold during clone" lifetime. On error
+	// paths the deferred release ensures no lock leak.
+	var nfsProvisionLockRelease func() error
+	if config.WorkspaceBackendName == "nfs" && config.NFSPVClaimName != "" && config.GitCloneForInit != nil {
+		if config.Locker != nil {
+			objID := store.StableProjectHash(config.ProjectID)
+			acquired, release, err := config.Locker.TryAdvisoryLockObject(
+				ctx, store.LockWorkspaceProvision, objID,
+			)
+			if err != nil {
+				return "", fmt.Errorf("NFS provision advisory lock for project %s: %w", config.ProjectID, err)
+			}
+			nfsProvisionLockRelease = release
+			if !acquired {
+				// Another node is currently provisioning this project's workspace.
+				// buildPod will inject a wait-for-sentinel init container instead
+				// of the cloning one.
+				config.nfsProvisionLockLost = true
+				runtimeLog.Info("NFS provision lock held by another node — pod will wait for sentinel",
+					"agent", config.Name, "project_id", config.ProjectID, "phase", "nfs-lock")
+			} else {
+				runtimeLog.Info("NFS provision lock acquired — pod will clone workspace",
+					"agent", config.Name, "project_id", config.ProjectID, "phase", "nfs-lock")
+			}
+		} else {
+			runtimeLog.Warn("No advisory locker available — NFS provisioning is unguarded (sentinel-only)",
+				"agent", config.Name, "project_id", config.ProjectID, "phase", "nfs-lock")
+		}
+	}
+	// Deferred release: held through pod creation + waitForPodReady (init
+	// containers complete), then released. Safe to call even when nil.
+	defer func() {
+		if nfsProvisionLockRelease != nil {
+			if err := nfsProvisionLockRelease(); err != nil {
+				runtimeLog.Error("Failed to release NFS provision lock", "error", err,
+					"agent", config.Name, "project_id", config.ProjectID)
+			}
+		}
+	}()
 
 	pod, err := r.buildPod(namespace, config)
 	if err != nil {
@@ -1185,17 +1236,34 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 	}
 
 	// NFS init container: when backend=nfs and git clone config is set, add an
-	// init container that provisions the workspace (clone + sentinel) before the
-	// main container starts. The init container mounts the same workspace PVC+subPath
-	// so provisioned files are visible to the main container. Uses the sentinel
-	// file (.scion-provisioned) to skip re-cloning if the workspace already exists.
+	// init container that provisions the workspace before the main container
+	// starts. The init container mounts the same workspace PVC+subPath so
+	// provisioned files are visible to the main container.
 	//
-	// The advisory lock (design §7, N1-4) is NOT used in the init container —
-	// K8s init containers serialize naturally per-pod, and the sentinel file
-	// provides idempotent cross-pod protection on the shared NFS volume.
-	// Full advisory lock integration is deferred to the NM2 live cluster gate.
+	// Advisory lock integration (N2-2b, design §7, risk RN1): the Go-side
+	// Run() method acquires a per-project advisory lock (via TryAdvisoryLockObject)
+	// BEFORE reaching this point. The lock result determines the init container
+	// behavior:
+	//   - Lock winner (nfsProvisionLockLost=false): injects the CLONING init
+	//     container that checks the sentinel and clones if absent (N2-2 script).
+	//   - Lock loser  (nfsProvisionLockLost=true): injects a WAIT-for-sentinel
+	//     init container that polls for .scion-provisioned without cloning.
+	//
+	// When no advisory locker is available (Locker nil / single-node deploy),
+	// nfsProvisionLockLost stays false and the cloning init container is
+	// injected — the sentinel provides idempotent protection but NOT
+	// cross-node mutual exclusion.
 	if config.WorkspaceBackendName == "nfs" && config.NFSPVClaimName != "" && config.GitCloneForInit != nil {
-		initScript := nfsInitProvisionScript(config.GitCloneForInit)
+		var initScript string
+		if config.nfsProvisionLockLost {
+			// Lock loser: wait for the sentinel written by the winning node's
+			// cloning init container. Does NOT clone.
+			initScript = nfsWaitForSentinelScript()
+		} else {
+			// Lock winner (or no locker available): clone if sentinel is absent,
+			// skip if already provisioned. The script is idempotent.
+			initScript = nfsInitProvisionScript(config.GitCloneForInit)
+		}
 		initContainer := corev1.Container{
 			Name:    "workspace-provision",
 			Image:   config.Image,
@@ -2402,4 +2470,31 @@ echo "Workspace provisioned successfully"`,
 		cloneArgs, gc.URL)
 
 	return script
+}
+
+// nfsWaitForSentinelScript generates a shell script for the non-winner
+// init container (N2-2b). This pod lost the advisory lock, meaning another
+// node is currently cloning the workspace. The script polls for the
+// sentinel file (.scion-provisioned) with a bounded timeout, allowing the
+// main container to start only after the winner has finished provisioning.
+//
+// Timeout: 5 minutes (300s) — generous enough for a full clone over NFS.
+// Poll interval: 2 seconds.
+func nfsWaitForSentinelScript() string {
+	return `set -e
+SENTINEL="/workspace/.scion-provisioned"
+TIMEOUT=300
+INTERVAL=2
+ELAPSED=0
+
+echo "Another node is provisioning this workspace — waiting for sentinel..."
+while [ ! -f "$SENTINEL" ]; do
+  if [ $ELAPSED -ge $TIMEOUT ]; then
+    echo "ERROR: Timed out waiting for workspace provisioning sentinel after ${TIMEOUT}s"
+    exit 1
+  fi
+  sleep $INTERVAL
+  ELAPSED=$((ELAPSED + INTERVAL))
+done
+echo "Workspace provisioned by another node (sentinel found after ${ELAPSED}s)"`
 }

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -1026,14 +1026,25 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 		corev1.EnvVar{Name: "LOGNAME", Value: config.UnixUsername},
 	)
 
-	// Security context: run agent pods as the image's non-root scion user and
-	// keep FSGroup aligned with the broker user so synced files remain writable.
+	// Security context: run agent pods as the image's non-root scion user.
+	// FSGroup is branched by workspace backend (N2-4):
+	//   - NFS backend: stable GID (default 1000) so files are writable across
+	//     pods and nodes without per-start chown (design §9.1).
+	//   - Local backend: host GID (today's behavior) so synced files remain
+	//     writable by the broker user.
 	const containerUID int64 = 1000
-	hostGID := int64(os.Getgid())
+	fsGroupGID := int64(os.Getgid()) // default: host GID (local backend)
+	if config.WorkspaceBackendName == "nfs" {
+		nfsGID := config.NFSGID
+		if nfsGID == 0 {
+			nfsGID = 1000 // design default
+		}
+		fsGroupGID = int64(nfsGID)
+	}
 	runAsNonRoot := true
 	allowPrivilegeEscalation := false
 	podSecurityContext := &corev1.PodSecurityContext{
-		FSGroup:      &hostGID,
+		FSGroup:      &fsGroupGID,
 		RunAsUser:    int64Ptr(containerUID),
 		RunAsGroup:   int64Ptr(containerUID),
 		RunAsNonRoot: &runAsNonRoot,

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -1112,6 +1112,35 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 		},
 	}
 
+	// NFS init container: when backend=nfs and git clone config is set, add an
+	// init container that provisions the workspace (clone + sentinel) before the
+	// main container starts. The init container mounts the same workspace PVC+subPath
+	// so provisioned files are visible to the main container. Uses the sentinel
+	// file (.scion-provisioned) to skip re-cloning if the workspace already exists.
+	//
+	// The advisory lock (design §7, N1-4) is NOT used in the init container —
+	// K8s init containers serialize naturally per-pod, and the sentinel file
+	// provides idempotent cross-pod protection on the shared NFS volume.
+	// Full advisory lock integration is deferred to the NM2 live cluster gate.
+	if config.WorkspaceBackendName == "nfs" && config.NFSPVClaimName != "" && config.GitCloneForInit != nil {
+		initScript := nfsInitProvisionScript(config.GitCloneForInit)
+		initContainer := corev1.Container{
+			Name:    "workspace-provision",
+			Image:   config.Image,
+			Command: []string{"sh", "-c", initScript},
+			VolumeMounts: []corev1.VolumeMount{
+				workspaceVolumeMount,
+			},
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+			},
+		}
+		pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
+	}
+
 	// Append secret volumes and mounts
 	if len(extraVolumes) > 0 {
 		pod.Spec.Volumes = append(pod.Spec.Volumes, extraVolumes...)
@@ -2201,4 +2230,57 @@ func (r *KubernetesRuntime) GetWorkspacePath(ctx context.Context, id string) (st
 	}
 
 	return "", fmt.Errorf("no workspace path found for pod %s", id)
+}
+
+// nfsInitProvisionScript generates the shell script for the NFS workspace
+// init container. The script checks for a sentinel file and clones the
+// repository if it is absent, providing first-access provisioning for NFS
+// workspaces (design §5.5/§7/§8.2). The sentinel file ensures idempotency
+// across concurrent pod starts for the same project.
+//
+// The /workspace mount in the init container points at the project's subPath
+// (e.g. projects/<pid>/workspace), so all operations are relative to "."
+// within that mount.
+func nfsInitProvisionScript(gc *api.GitCloneConfig) string {
+	if gc == nil || gc.URL == "" {
+		return "echo 'No git clone URL configured, skipping workspace provision'"
+	}
+
+	// Build the git clone command.
+	depth := gc.Depth
+	if depth == 0 {
+		depth = 1 // default shallow clone
+	}
+
+	cloneArgs := "clone"
+	if depth > 0 {
+		cloneArgs += fmt.Sprintf(" --depth %d", depth)
+	}
+	if gc.Branch != "" {
+		cloneArgs += fmt.Sprintf(" --branch '%s'", gc.Branch)
+	}
+
+	// The script clones into a temp dir then moves content into /workspace,
+	// because git clone requires an empty target directory. The sentinel
+	// (.scion-provisioned) is checked first to skip if already provisioned.
+	script := fmt.Sprintf(`set -e
+SENTINEL="/workspace/.scion-provisioned"
+if [ -f "$SENTINEL" ]; then
+  echo "Workspace already provisioned (sentinel exists), skipping clone"
+  exit 0
+fi
+echo "Provisioning NFS workspace..."
+export GIT_TERMINAL_PROMPT=0
+TMPDIR=$(mktemp -d /workspace/.clone-XXXXXX)
+git %s '%s' "$TMPDIR"
+# Move cloned content into /workspace (handles hidden files like .git)
+shopt -s dotglob 2>/dev/null || true
+mv "$TMPDIR"/* /workspace/ 2>/dev/null || cp -a "$TMPDIR"/. /workspace/
+rm -rf "$TMPDIR"
+# Write sentinel to mark provisioning complete
+echo "provisioned_at=$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ)" > "$SENTINEL"
+echo "Workspace provisioned successfully"`,
+		cloneArgs, gc.URL)
+
+	return script
 }

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -1047,6 +1047,38 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 		}
 	}
 
+	// Workspace volume: NFS-backed pods use a PVC+subPath for shared, persistent
+	// storage isolated to the project subtree (design §5.1/§9.4).
+	// Local-backend pods keep the existing EmptyDir (zero behavior change).
+	var workspaceVolume corev1.Volume
+	var workspaceVolumeMount corev1.VolumeMount
+	if config.WorkspaceBackendName == "nfs" && config.NFSPVClaimName != "" {
+		workspaceVolume = corev1.Volume{
+			Name: "workspace",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: config.NFSPVClaimName,
+				},
+			},
+		}
+		workspaceVolumeMount = corev1.VolumeMount{
+			Name:      "workspace",
+			MountPath: "/workspace",
+			SubPath:   config.NFSSubPath,
+		}
+	} else {
+		workspaceVolume = corev1.Volume{
+			Name: "workspace",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		}
+		workspaceVolumeMount = corev1.VolumeMount{
+			Name:      "workspace",
+			MountPath: "/workspace",
+		}
+	}
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        config.Name,
@@ -1072,19 +1104,10 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 							Drop: []corev1.Capability{"ALL"},
 						},
 					},
-					VolumeMounts: []corev1.VolumeMount{
-						{Name: "workspace", MountPath: "/workspace"},
-					},
+					VolumeMounts: []corev1.VolumeMount{workspaceVolumeMount},
 				},
 			},
-			Volumes: []corev1.Volume{
-				{
-					Name: "workspace",
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
-				},
-			},
+			Volumes:       []corev1.Volume{workspaceVolume},
 			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	}

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -1268,6 +1268,7 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 			Name:    "workspace-provision",
 			Image:   config.Image,
 			Command: []string{"sh", "-c", initScript},
+			Env:     nfsInitProvisionEnv(config.GitCloneForInit),
 			VolumeMounts: []corev1.VolumeMount{
 				workspaceVolumeMount,
 			},
@@ -2428,28 +2429,30 @@ func nfsSharedDirSubPath(workspaceSubPath, sharedDirName string) string {
 // The /workspace mount in the init container points at the project's subPath
 // (e.g. projects/<pid>/workspace), so all operations are relative to "."
 // within that mount.
+//
+// Security: URL and Branch are injected via environment variables
+// (SCION_CLONE_URL, SCION_CLONE_BRANCH) set on the init container, NOT
+// interpolated into the script text. This prevents shell injection through
+// crafted branch names or URLs. Only the numeric depth is interpolated.
 func nfsInitProvisionScript(gc *api.GitCloneConfig) string {
 	if gc == nil || gc.URL == "" {
 		return "echo 'No git clone URL configured, skipping workspace provision'"
 	}
 
-	// Build the git clone command.
+	// Build the git clone depth flag. Only numeric depth is safe to interpolate.
 	depth := gc.Depth
 	if depth == 0 {
 		depth = 1 // default shallow clone
 	}
 
-	cloneArgs := "clone"
+	depthFlag := ""
 	if depth > 0 {
-		cloneArgs += fmt.Sprintf(" --depth %d", depth)
-	}
-	if gc.Branch != "" {
-		cloneArgs += fmt.Sprintf(" --branch '%s'", gc.Branch)
+		depthFlag = fmt.Sprintf("--depth %d", depth)
 	}
 
-	// The script clones into a temp dir then moves content into /workspace,
-	// because git clone requires an empty target directory. The sentinel
-	// (.scion-provisioned) is checked first to skip if already provisioned.
+	// The script reads URL and branch from env vars (set on the container spec)
+	// to avoid shell injection. The sentinel (.scion-provisioned) is checked
+	// first to skip if already provisioned.
 	script := fmt.Sprintf(`set -e
 SENTINEL="/workspace/.scion-provisioned"
 if [ -f "$SENTINEL" ]; then
@@ -2459,17 +2462,35 @@ fi
 echo "Provisioning NFS workspace..."
 export GIT_TERMINAL_PROMPT=0
 TMPDIR=$(mktemp -d /workspace/.clone-XXXXXX)
-git %s '%s' "$TMPDIR"
+CLONE_ARGS="clone %s"
+if [ -n "$SCION_CLONE_BRANCH" ]; then
+  CLONE_ARGS="$CLONE_ARGS --branch $SCION_CLONE_BRANCH"
+fi
+git $CLONE_ARGS "$SCION_CLONE_URL" "$TMPDIR"
 # Move cloned content into /workspace (handles hidden files like .git)
 shopt -s dotglob 2>/dev/null || true
 mv "$TMPDIR"/* /workspace/ 2>/dev/null || cp -a "$TMPDIR"/. /workspace/
 rm -rf "$TMPDIR"
 # Write sentinel to mark provisioning complete
 echo "provisioned_at=$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ)" > "$SENTINEL"
-echo "Workspace provisioned successfully"`,
-		cloneArgs, gc.URL)
+echo "Workspace provisioned successfully"`, depthFlag)
 
 	return script
+}
+
+// nfsInitProvisionEnv returns the environment variables for the NFS init
+// container. URL and Branch are passed as env vars to prevent shell injection.
+func nfsInitProvisionEnv(gc *api.GitCloneConfig) []corev1.EnvVar {
+	if gc == nil {
+		return nil
+	}
+	envs := []corev1.EnvVar{
+		{Name: "SCION_CLONE_URL", Value: gc.URL},
+	}
+	if gc.Branch != "" {
+		envs = append(envs, corev1.EnvVar{Name: "SCION_CLONE_BRANCH", Value: gc.Branch})
+	}
+	return envs
 }
 
 // nfsWaitForSentinelScript generates a shell script for the non-winner

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -2415,7 +2415,7 @@ func (r *KubernetesRuntime) GetWorkspacePath(ctx context.Context, id string) (st
 func nfsSharedDirSubPath(workspaceSubPath, sharedDirName string) string {
 	// workspaceSubPath is "projects/<pid>/workspace"
 	// We need "projects/<pid>/shared-dirs/<name>"
-	parent := filepath.Dir(workspaceSubPath)     // "projects/<pid>"
+	parent := filepath.Dir(workspaceSubPath) // "projects/<pid>"
 	return filepath.Join(parent, "shared-dirs", sharedDirName)
 }
 

--- a/pkg/runtime/nfs_path_guard.go
+++ b/pkg/runtime/nfs_path_guard.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+)
+
+// ValidateNotExportRoot ensures that hostPath is a proper subdirectory of
+// hostBase, never equal to it. This is the critical isolation guard from
+// design §9.4: bind-mount only projects/<pid>/..., NEVER the export root
+// <MountRoot>/<shareID> itself.
+//
+// Returns nil if hostBase is empty (local backend — no guard needed).
+func ValidateNotExportRoot(hostPath, hostBase string) error {
+	if hostBase == "" {
+		return nil // local backend — no export root to guard against
+	}
+
+	cleanPath := filepath.Clean(hostPath)
+	cleanBase := filepath.Clean(hostBase)
+
+	if cleanPath == cleanBase {
+		return fmt.Errorf("isolation violation: bind path %q equals export root %q — "+
+			"must bind a project subtree, never the export root", hostPath, hostBase)
+	}
+
+	if !strings.HasPrefix(cleanPath, cleanBase+"/") {
+		return fmt.Errorf("isolation violation: bind path %q is not under export root %q",
+			hostPath, hostBase)
+	}
+
+	return nil
+}
+
+// NFSSharedDirsToVolumeMounts converts shared directory declarations into
+// VolumeMount entries using NFS-resolved paths from a ResolvedWorkspace.
+// This is the NFS counterpart of config.SharedDirsToVolumeMounts — the
+// container-side targets are unchanged (/scion-volumes/<name> or in-workspace),
+// but the host-side source paths come from the NFS backend's Resolve output
+// instead of the local filesystem helpers.
+//
+// The containerWorkspace parameter specifies the container-side workspace path
+// (e.g., /workspace). The resolved workspace must have been produced by
+// nfsBackend.Resolve with the shared dir names included in ResolveInput.
+func NFSSharedDirsToVolumeMounts(resolved ResolvedWorkspace, dirs []api.SharedDir, containerWorkspace string) ([]api.VolumeMount, error) {
+	if len(dirs) == 0 {
+		return nil, nil
+	}
+
+	if containerWorkspace == "" {
+		containerWorkspace = "/workspace"
+	}
+
+	var mounts []api.VolumeMount
+	for _, d := range dirs {
+		sd, ok := resolved.SharedDirs[d.Name]
+		if !ok {
+			return nil, fmt.Errorf("shared dir %q not found in NFS resolution", d.Name)
+		}
+
+		// Isolation guard: shared dir paths must be under the host base, not the root.
+		if err := ValidateNotExportRoot(sd.HostPath, resolved.HostBase); err != nil {
+			return nil, fmt.Errorf("shared dir %q: %w", d.Name, err)
+		}
+
+		target := fmt.Sprintf("/scion-volumes/%s", d.Name)
+		if d.InWorkspace {
+			target = fmt.Sprintf("%s/.scion-volumes/%s", containerWorkspace, d.Name)
+		}
+
+		mounts = append(mounts, api.VolumeMount{
+			Source:   sd.HostPath,
+			Target:   target,
+			ReadOnly: d.ReadOnly,
+		})
+	}
+
+	return mounts, nil
+}

--- a/pkg/runtime/nfs_path_guard_test.go
+++ b/pkg/runtime/nfs_path_guard_test.go
@@ -1,0 +1,368 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// --- ValidateNotExportRoot tests ---
+
+func TestValidateNotExportRoot_Valid(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostPath string
+		hostBase string
+	}{
+		{
+			name:     "project subtree under mount",
+			hostPath: "/mnt/nfs/ws1/projects/proj1/workspace",
+			hostBase: "/mnt/nfs/ws1",
+		},
+		{
+			name:     "shared dir under mount",
+			hostPath: "/mnt/nfs/ws1/projects/proj1/shared-dirs/data",
+			hostBase: "/mnt/nfs/ws1",
+		},
+		{
+			name:     "local backend empty hostBase",
+			hostPath: "/home/user/.scion.projects/my-project",
+			hostBase: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateNotExportRoot(tt.hostPath, tt.hostBase); err != nil {
+				t.Errorf("expected valid, got error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateNotExportRoot_Invalid(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostPath string
+		hostBase string
+	}{
+		{
+			name:     "path equals export root",
+			hostPath: "/mnt/nfs/ws1",
+			hostBase: "/mnt/nfs/ws1",
+		},
+		{
+			name:     "path equals export root with trailing slash",
+			hostPath: "/mnt/nfs/ws1/",
+			hostBase: "/mnt/nfs/ws1",
+		},
+		{
+			name:     "path not under export root",
+			hostPath: "/some/other/path",
+			hostBase: "/mnt/nfs/ws1",
+		},
+		{
+			name:     "path is sibling of export root",
+			hostPath: "/mnt/nfs/ws1-other/projects/proj1",
+			hostBase: "/mnt/nfs/ws1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateNotExportRoot(tt.hostPath, tt.hostBase); err == nil {
+				t.Error("expected error for isolation violation, got nil")
+			}
+		})
+	}
+}
+
+// --- NFSSharedDirsToVolumeMounts tests ---
+
+func TestNFSSharedDirsToVolumeMounts_Basic(t *testing.T) {
+	resolved := ResolvedWorkspace{
+		HostPath: "/mnt/nfs/ws1/projects/proj1/workspace",
+		HostBase: "/mnt/nfs/ws1",
+		Backend:  "nfs",
+		SharedDirs: map[string]ResolvedSharedDir{
+			"data": {
+				HostPath:           "/mnt/nfs/ws1/projects/proj1/shared-dirs/data",
+				ServerRelativePath: "projects/proj1/shared-dirs/data",
+			},
+			"cache": {
+				HostPath:           "/mnt/nfs/ws1/projects/proj1/shared-dirs/cache",
+				ServerRelativePath: "projects/proj1/shared-dirs/cache",
+			},
+		},
+	}
+
+	dirs := []api.SharedDir{
+		{Name: "data", ReadOnly: false},
+		{Name: "cache", ReadOnly: true, InWorkspace: true},
+	}
+
+	mounts, err := NFSSharedDirsToVolumeMounts(resolved, dirs, "/workspace")
+	if err != nil {
+		t.Fatalf("NFSSharedDirsToVolumeMounts: %v", err)
+	}
+
+	if len(mounts) != 2 {
+		t.Fatalf("len(mounts) = %d, want 2", len(mounts))
+	}
+
+	// data → /scion-volumes/data
+	if mounts[0].Source != "/mnt/nfs/ws1/projects/proj1/shared-dirs/data" {
+		t.Errorf("mounts[0].Source = %q, want NFS path", mounts[0].Source)
+	}
+	if mounts[0].Target != "/scion-volumes/data" {
+		t.Errorf("mounts[0].Target = %q, want /scion-volumes/data", mounts[0].Target)
+	}
+	if mounts[0].ReadOnly {
+		t.Error("mounts[0].ReadOnly should be false")
+	}
+
+	// cache → /workspace/.scion-volumes/cache (InWorkspace=true)
+	if mounts[1].Source != "/mnt/nfs/ws1/projects/proj1/shared-dirs/cache" {
+		t.Errorf("mounts[1].Source = %q, want NFS path", mounts[1].Source)
+	}
+	if mounts[1].Target != "/workspace/.scion-volumes/cache" {
+		t.Errorf("mounts[1].Target = %q, want /workspace/.scion-volumes/cache", mounts[1].Target)
+	}
+	if !mounts[1].ReadOnly {
+		t.Error("mounts[1].ReadOnly should be true")
+	}
+}
+
+func TestNFSSharedDirsToVolumeMounts_MissingDir(t *testing.T) {
+	resolved := ResolvedWorkspace{
+		HostBase:   "/mnt/nfs/ws1",
+		Backend:    "nfs",
+		SharedDirs: map[string]ResolvedSharedDir{},
+	}
+
+	dirs := []api.SharedDir{
+		{Name: "nonexistent"},
+	}
+
+	_, err := NFSSharedDirsToVolumeMounts(resolved, dirs, "/workspace")
+	if err == nil {
+		t.Error("expected error for missing shared dir in resolution")
+	}
+}
+
+func TestNFSSharedDirsToVolumeMounts_Empty(t *testing.T) {
+	resolved := ResolvedWorkspace{Backend: "nfs"}
+	mounts, err := NFSSharedDirsToVolumeMounts(resolved, nil, "/workspace")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mounts != nil {
+		t.Errorf("expected nil mounts for empty dirs, got %v", mounts)
+	}
+}
+
+func TestNFSSharedDirsToVolumeMounts_IsolationGuard(t *testing.T) {
+	// Simulate a bad resolution where shared dir path equals the export root.
+	resolved := ResolvedWorkspace{
+		HostPath: "/mnt/nfs/ws1/projects/proj1/workspace",
+		HostBase: "/mnt/nfs/ws1",
+		Backend:  "nfs",
+		SharedDirs: map[string]ResolvedSharedDir{
+			"bad": {
+				HostPath: "/mnt/nfs/ws1", // equals export root — should be rejected
+			},
+		},
+	}
+
+	dirs := []api.SharedDir{{Name: "bad"}}
+
+	_, err := NFSSharedDirsToVolumeMounts(resolved, dirs, "/workspace")
+	if err == nil {
+		t.Error("expected error when shared dir path equals export root")
+	}
+}
+
+// --- NFS Realize isolation guard tests ---
+
+func TestNFSRealize_IsolationGuard(t *testing.T) {
+	nfsCfg := &config.V1NFSConfig{
+		MountRoot:   "/mnt/nfs",
+		SubPathRoot: "projects",
+		Shares: []config.V1NFSShare{
+			{ID: "share1", Server: "10.0.0.2", Export: "/scion-workspaces"},
+		},
+	}
+	b := NewNFSBackend(nfsCfg)
+
+	// Valid: project subtree
+	_, err := b.Realize(RealizeInput{
+		Resolved: ResolvedWorkspace{
+			HostPath: "/mnt/nfs/share1/projects/proj1/workspace",
+			HostBase: "/mnt/nfs/share1",
+			Backend:  "nfs",
+			ServerRelativePath: "projects/proj1/workspace",
+		},
+		ContainerWorkspace: "/workspace",
+	})
+	if err != nil {
+		t.Errorf("valid Realize returned error: %v", err)
+	}
+
+	// Invalid: export root itself
+	_, err = b.Realize(RealizeInput{
+		Resolved: ResolvedWorkspace{
+			HostPath: "/mnt/nfs/share1",
+			HostBase: "/mnt/nfs/share1",
+			Backend:  "nfs",
+		},
+		ContainerWorkspace: "/workspace",
+	})
+	if err == nil {
+		t.Error("expected error when HostPath equals export root")
+	}
+}
+
+// --- NFS path resolution produces correct paths (end-to-end) ---
+
+func TestNFSResolveRealize_EndToEnd(t *testing.T) {
+	nfsCfg := &config.V1NFSConfig{
+		MountRoot:   "/mnt/nfs",
+		SubPathRoot: "projects",
+		Shares: []config.V1NFSShare{
+			{ID: "ws1", Server: "10.0.0.2", Export: "/scion-workspaces"},
+		},
+	}
+
+	backend := NewNFSBackend(nfsCfg)
+	resolved, err := backend.Resolve(ResolveInput{
+		ProjectID:      "my-project-id",
+		AgentID:        "agent-1",
+		Mode:           store.SharingModeSharedPlain,
+		SharedDirNames: []string{"data"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// Verify workspace path
+	wantWorkspace := filepath.Join("/mnt/nfs", "ws1", "projects", "my-project-id", "workspace")
+	if resolved.HostPath != wantWorkspace {
+		t.Errorf("HostPath = %q, want %q", resolved.HostPath, wantWorkspace)
+	}
+
+	// Realize should produce a valid descriptor
+	desc, err := backend.Realize(RealizeInput{
+		Resolved:           resolved,
+		ContainerWorkspace: "/workspace",
+	})
+	if err != nil {
+		t.Fatalf("Realize: %v", err)
+	}
+	if desc.Type != "nfs" {
+		t.Errorf("desc.Type = %q, want nfs", desc.Type)
+	}
+	if desc.HostPath != wantWorkspace {
+		t.Errorf("desc.HostPath = %q, want %q", desc.HostPath, wantWorkspace)
+	}
+	if desc.Target != "/workspace" {
+		t.Errorf("desc.Target = %q, want /workspace", desc.Target)
+	}
+
+	// Shared dirs should produce NFS-backed mounts
+	dirs := []api.SharedDir{{Name: "data"}}
+	mounts, err := NFSSharedDirsToVolumeMounts(resolved, dirs, "/workspace")
+	if err != nil {
+		t.Fatalf("NFSSharedDirsToVolumeMounts: %v", err)
+	}
+	wantSDPath := filepath.Join("/mnt/nfs", "ws1", "projects", "my-project-id", "shared-dirs", "data")
+	if len(mounts) != 1 || mounts[0].Source != wantSDPath {
+		t.Errorf("shared dir mount source = %v, want %q", mounts, wantSDPath)
+	}
+}
+
+// --- Local path resolution unchanged (zero behavior change guard) ---
+
+func TestLocalResolveRealize_Unchanged(t *testing.T) {
+	backend := NewLocalBackend()
+	projectPath := "/home/scion/.scion.projects/my-project"
+
+	resolved, err := backend.Resolve(ResolveInput{
+		ProjectDir: projectPath,
+		ProjectID:  "proj1",
+		Mode:       store.SharingModeSharedPlain,
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// Local backend produces the exact project path — no change.
+	if resolved.HostPath != projectPath {
+		t.Errorf("HostPath = %q, want %q (unchanged)", resolved.HostPath, projectPath)
+	}
+	if resolved.Backend != "local" {
+		t.Errorf("Backend = %q, want local", resolved.Backend)
+	}
+
+	// Realize produces a local bind-mount descriptor.
+	desc, err := backend.Realize(RealizeInput{
+		Resolved:           resolved,
+		ContainerWorkspace: "/workspace",
+	})
+	if err != nil {
+		t.Fatalf("Realize: %v", err)
+	}
+	if desc.Type != "local" {
+		t.Errorf("desc.Type = %q, want local", desc.Type)
+	}
+	if desc.HostPath != projectPath {
+		t.Errorf("desc.HostPath = %q, want %q (unchanged)", desc.HostPath, projectPath)
+	}
+}
+
+// TestLocalSharedDirs_Unchanged verifies that the local backend's shared dir
+// resolution is unchanged — the existing config.SharedDirsToVolumeMounts path
+// is still used for local backends. This test documents the invariant.
+func TestLocalSharedDirs_Unchanged(t *testing.T) {
+	// The local path calls config.GetSharedDirPath which works on the
+	// local filesystem. For NFS, NFSSharedDirsToVolumeMounts is used instead.
+	// This test just ensures local path is still exposed for backward compat.
+	backend := NewLocalBackend()
+	resolved, err := backend.Resolve(ResolveInput{
+		ProjectDir:     "/home/scion/.scion.projects/my-project",
+		ProjectID:      "proj1",
+		Mode:           store.SharingModeSharedPlain,
+		SharedDirNames: []string{"logs"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// Local backend resolves shared dirs via config helpers
+	sd, ok := resolved.SharedDirs["logs"]
+	if !ok {
+		t.Fatal("shared dir 'logs' not found in local resolution")
+	}
+	if sd.HostPath == "" {
+		t.Error("shared dir host path should not be empty for local backend")
+	}
+	if sd.ServerRelativePath != "" {
+		t.Error("shared dir ServerRelativePath should be empty for local backend")
+	}
+}

--- a/pkg/runtime/nfs_path_guard_test.go
+++ b/pkg/runtime/nfs_path_guard_test.go
@@ -214,9 +214,9 @@ func TestNFSRealize_IsolationGuard(t *testing.T) {
 	// Valid: project subtree
 	_, err := b.Realize(RealizeInput{
 		Resolved: ResolvedWorkspace{
-			HostPath: "/mnt/nfs/share1/projects/proj1/workspace",
-			HostBase: "/mnt/nfs/share1",
-			Backend:  "nfs",
+			HostPath:           "/mnt/nfs/share1/projects/proj1/workspace",
+			HostBase:           "/mnt/nfs/share1",
+			Backend:            "nfs",
 			ServerRelativePath: "projects/proj1/workspace",
 		},
 		ContainerWorkspace: "/workspace",

--- a/pkg/runtime/nfs_uid_test.go
+++ b/pkg/runtime/nfs_uid_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+)
+
+// TestBuildCommonRunArgs_LocalBackend_HostUID verifies that backend=local
+// (or empty) advertises the broker's own UID/GID — today's behavior, unchanged.
+func TestBuildCommonRunArgs_LocalBackend_HostUID(t *testing.T) {
+	cfg := minimalRunConfig()
+	// WorkspaceBackendName defaults to "" (local)
+
+	args, err := buildCommonRunArgs(cfg)
+	if err != nil {
+		t.Fatalf("buildCommonRunArgs: %v", err)
+	}
+
+	wantUID := fmt.Sprintf("SCION_HOST_UID=%d", os.Getuid())
+	wantGID := fmt.Sprintf("SCION_HOST_GID=%d", os.Getgid())
+
+	assertEnvInArgs(t, args, wantUID, "local backend should advertise host UID")
+	assertEnvInArgs(t, args, wantGID, "local backend should advertise host GID")
+}
+
+// TestBuildCommonRunArgs_NFSBackend_StableUID verifies that backend=nfs
+// advertises the configured NFS UID/GID instead of the host UID.
+func TestBuildCommonRunArgs_NFSBackend_StableUID(t *testing.T) {
+	cfg := minimalRunConfig()
+	cfg.WorkspaceBackendName = "nfs"
+	cfg.NFSUID = 1000
+	cfg.NFSGID = 1000
+
+	args, err := buildCommonRunArgs(cfg)
+	if err != nil {
+		t.Fatalf("buildCommonRunArgs: %v", err)
+	}
+
+	assertEnvInArgs(t, args, "SCION_HOST_UID=1000", "NFS backend should advertise stable UID 1000")
+	assertEnvInArgs(t, args, "SCION_HOST_GID=1000", "NFS backend should advertise stable GID 1000")
+}
+
+// TestBuildCommonRunArgs_NFSBackend_CustomUID verifies that NFS UID/GID
+// can be set to non-default values via config.
+func TestBuildCommonRunArgs_NFSBackend_CustomUID(t *testing.T) {
+	cfg := minimalRunConfig()
+	cfg.WorkspaceBackendName = "nfs"
+	cfg.NFSUID = 2000
+	cfg.NFSGID = 2000
+
+	args, err := buildCommonRunArgs(cfg)
+	if err != nil {
+		t.Fatalf("buildCommonRunArgs: %v", err)
+	}
+
+	assertEnvInArgs(t, args, "SCION_HOST_UID=2000", "NFS backend should use custom UID")
+	assertEnvInArgs(t, args, "SCION_HOST_GID=2000", "NFS backend should use custom GID")
+}
+
+// TestBuildCommonRunArgs_NFSBackend_DefaultUID verifies that zero NFS UID/GID
+// defaults to 1000:1000 (design §9.1 convergence with K8s pod UID/GID).
+func TestBuildCommonRunArgs_NFSBackend_DefaultUID(t *testing.T) {
+	cfg := minimalRunConfig()
+	cfg.WorkspaceBackendName = "nfs"
+	cfg.NFSUID = 0 // should default to 1000
+	cfg.NFSGID = 0 // should default to 1000
+
+	args, err := buildCommonRunArgs(cfg)
+	if err != nil {
+		t.Fatalf("buildCommonRunArgs: %v", err)
+	}
+
+	assertEnvInArgs(t, args, "SCION_HOST_UID=1000", "zero NFS UID should default to 1000")
+	assertEnvInArgs(t, args, "SCION_HOST_GID=1000", "zero NFS GID should default to 1000")
+}
+
+// TestBuildCommonRunArgs_NFSBackend_ExposesBackendEnv verifies that the
+// SCION_WORKSPACE_BACKEND env var is set when backend is "nfs", so sciontool
+// init can skip the per-start recursive chown.
+func TestBuildCommonRunArgs_NFSBackend_ExposesBackendEnv(t *testing.T) {
+	cfg := minimalRunConfig()
+	cfg.WorkspaceBackendName = "nfs"
+	cfg.NFSUID = 1000
+	cfg.NFSGID = 1000
+
+	args, err := buildCommonRunArgs(cfg)
+	if err != nil {
+		t.Fatalf("buildCommonRunArgs: %v", err)
+	}
+
+	assertEnvInArgs(t, args, "SCION_WORKSPACE_BACKEND=nfs",
+		"NFS backend should expose SCION_WORKSPACE_BACKEND for sciontool init")
+}
+
+// TestBuildCommonRunArgs_LocalBackend_NoBackendEnv verifies that
+// SCION_WORKSPACE_BACKEND is not set when the backend is local (empty),
+// preserving backward compatibility.
+func TestBuildCommonRunArgs_LocalBackend_NoBackendEnv(t *testing.T) {
+	cfg := minimalRunConfig()
+	// WorkspaceBackendName defaults to ""
+
+	args, err := buildCommonRunArgs(cfg)
+	if err != nil {
+		t.Fatalf("buildCommonRunArgs: %v", err)
+	}
+
+	for i, arg := range args {
+		if i > 0 && args[i-1] == "-e" && strings.HasPrefix(arg, "SCION_WORKSPACE_BACKEND=") {
+			t.Error("local backend should not set SCION_WORKSPACE_BACKEND env var")
+		}
+	}
+}
+
+// TestPodmanRootless_NFSBackend_Rejected verifies that Podman rootless + NFS
+// is rejected with a clear error (design §9.1: keep-id subuid ranges yield
+// no stable on-wire UID).
+func TestPodmanRootless_NFSBackend_Rejected(t *testing.T) {
+	r := &PodmanRuntime{
+		Command:  "podman",
+		Rootless: true,
+	}
+
+	config := minimalRunConfig()
+	config.WorkspaceBackendName = "nfs"
+
+	_, err := r.Run(t.Context(), config)
+	if err == nil {
+		t.Fatal("expected error for Podman rootless + NFS, got nil")
+	}
+	if !strings.Contains(err.Error(), "rootless") || !strings.Contains(err.Error(), "NFS") {
+		t.Errorf("error should mention rootless and NFS, got: %v", err)
+	}
+}
+
+// TestPodmanRootless_LocalBackend_Allowed verifies that Podman rootless
+// with the local backend still works (no regression).
+func TestPodmanRootless_LocalBackend_Allowed(t *testing.T) {
+	r := &PodmanRuntime{
+		Command:  "podman",
+		Rootless: true,
+	}
+
+	config := minimalRunConfig()
+	config.WorkspaceBackendName = "local"
+
+	// This will fail because podman isn't installed, but it should NOT fail
+	// with the rootless+NFS rejection error.
+	_, err := r.Run(t.Context(), config)
+	if err != nil && strings.Contains(err.Error(), "rootless") && strings.Contains(err.Error(), "NFS") {
+		t.Errorf("local backend should not trigger rootless+NFS rejection, got: %v", err)
+	}
+	// Other errors (podman not installed, etc.) are expected — we only check
+	// that the NFS-specific guard doesn't fire.
+}
+
+// --- helpers ---
+
+// minimalRunConfig returns a RunConfig with the minimum fields needed
+// to call buildCommonRunArgs without error. It uses a stub harness.
+func minimalRunConfig() RunConfig {
+	return RunConfig{
+		Name:         "test-agent",
+		Image:        "test-image:latest",
+		UnixUsername: "scion",
+		Harness:      &nfsTestHarness{},
+		Workspace:    "/tmp/test-workspace",
+	}
+}
+
+// nfsTestHarness satisfies the api.Harness interface for N1-5 tests.
+type nfsTestHarness struct{}
+
+func (h *nfsTestHarness) Name() string { return "test" }
+func (h *nfsTestHarness) AdvancedCapabilities() api.HarnessAdvancedCapabilities {
+	return api.HarnessAdvancedCapabilities{Harness: "test"}
+}
+func (h *nfsTestHarness) GetCommand(task string, resume bool, args []string) []string {
+	return []string{"echo", "test"}
+}
+func (h *nfsTestHarness) GetEnv(name, homeDir, unixUsername string) map[string]string {
+	return map[string]string{}
+}
+func (h *nfsTestHarness) GetTelemetryEnv() map[string]string   { return nil }
+func (h *nfsTestHarness) DefaultConfigDir() string             { return ".test" }
+func (h *nfsTestHarness) SkillsDir() string                    { return ".test/skills" }
+func (h *nfsTestHarness) HasSystemPrompt(agentHome string) bool { return false }
+func (h *nfsTestHarness) Provision(ctx context.Context, agentName, agentDir, agentHome, agentWorkspace string) error {
+	return nil
+}
+func (h *nfsTestHarness) GetEmbedDir() string                    { return "test" }
+func (h *nfsTestHarness) GetInterruptKey() string                { return "C-c" }
+func (h *nfsTestHarness) GetHarnessEmbedsFS() (embed.FS, string) { return embed.FS{}, "" }
+func (h *nfsTestHarness) InjectAgentInstructions(agentHome string, content []byte) error {
+	return nil
+}
+func (h *nfsTestHarness) InjectSystemPrompt(agentHome string, content []byte) error {
+	return nil
+}
+func (h *nfsTestHarness) ResolveAuth(auth api.AuthConfig) (*api.ResolvedAuth, error) {
+	return &api.ResolvedAuth{Method: "test"}, nil
+}
+
+// assertEnvInArgs checks that the -e flag with the given env value appears in args.
+func assertEnvInArgs(t *testing.T, args []string, wantEnv, msg string) {
+	t.Helper()
+	for i, arg := range args {
+		if i > 0 && args[i-1] == "-e" && arg == wantEnv {
+			return
+		}
+	}
+	t.Errorf("%s: env %q not found in args", msg, wantEnv)
+}

--- a/pkg/runtime/nfs_uid_test.go
+++ b/pkg/runtime/nfs_uid_test.go
@@ -200,9 +200,9 @@ func (h *nfsTestHarness) GetCommand(task string, resume bool, args []string) []s
 func (h *nfsTestHarness) GetEnv(name, homeDir, unixUsername string) map[string]string {
 	return map[string]string{}
 }
-func (h *nfsTestHarness) GetTelemetryEnv() map[string]string   { return nil }
-func (h *nfsTestHarness) DefaultConfigDir() string             { return ".test" }
-func (h *nfsTestHarness) SkillsDir() string                    { return ".test/skills" }
+func (h *nfsTestHarness) GetTelemetryEnv() map[string]string    { return nil }
+func (h *nfsTestHarness) DefaultConfigDir() string              { return ".test" }
+func (h *nfsTestHarness) SkillsDir() string                     { return ".test/skills" }
 func (h *nfsTestHarness) HasSystemPrompt(agentHome string) bool { return false }
 func (h *nfsTestHarness) Provision(ctx context.Context, agentName, agentDir, agentHome, agentWorkspace string) error {
 	return nil

--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -125,6 +125,16 @@ func (r *PodmanRuntime) ExecUser() string {
 }
 
 func (r *PodmanRuntime) Run(ctx context.Context, config RunConfig) (string, error) {
+	// N1-5: Podman rootless + NFS is unsupported. keep-id subuid ranges
+	// yield no stable on-wire UID, so files on the shared NFS export would
+	// have unpredictable ownership across nodes. Reject early with a clear
+	// error (design §9.1).
+	if r.Rootless && config.WorkspaceBackendName == "nfs" {
+		return "", fmt.Errorf("podman rootless with NFS workspace backend is not supported: " +
+			"keep-id subuid ranges cannot produce a stable on-wire UID for shared NFS storage; " +
+			"use rootful Docker or Podman for NFS-backed projects")
+	}
+
 	// Stage file and variable secrets before building args
 	var secretMountSpecs []string
 	if config.HomeDir != "" && len(config.ResolvedSecrets) > 0 {

--- a/pkg/runtime/workspace_backend.go
+++ b/pkg/runtime/workspace_backend.go
@@ -131,11 +131,28 @@ type ProvisionInput struct {
 	// AgentID is the agent's stable UUID.
 	AgentID string
 
+	// AgentName is a human-readable agent name (used for worktree branch names).
+	AgentName string
+
 	// Mode is the workspace sharing mode.
 	Mode store.WorkspaceSharingMode
 
 	// GitClone holds git-clone config when the project is git-backed; nil otherwise.
 	GitClone *api.GitCloneConfig
+
+	// Locker provides the per-project advisory lock for the NFS first-access
+	// provisioning guard (design §7, risk RN1). On Postgres-backed deployments
+	// this uses pg_try_advisory_lock(classid, objid) for cross-node mutual
+	// exclusion; on SQLite it's a no-op (single-writer serializes already).
+	//
+	// May be nil — nfsBackend.Provision degrades to sentinel-only guarding
+	// (correct for single-node but NOT safe for multi-node).
+	Locker store.AdvisoryLocker
+
+	// NFSUID and NFSGID are the stable NFS ownership values (default 1000:1000).
+	// Used for one-time chown of newly provisioned workspace directories.
+	NFSUID int
+	NFSGID int
 }
 
 // RealizeInput holds parameters for emitting a runtime mount descriptor.

--- a/pkg/runtime/workspace_backend.go
+++ b/pkg/runtime/workspace_backend.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// WorkspaceBackend abstracts workspace storage so callers can resolve, provision,
+// and realize workspace paths without knowing whether storage is node-local or
+// NFS-backed. The three methods map to the design's three questions (§3):
+//
+//   - Resolve: given project/agent/mode, what is the storage location?
+//   - Provision: ensure the directory exists (clone, worktree, etc.).
+//   - Realize: emit the runtime mount descriptor for Docker/K8s/Cloud Run.
+//
+// Implementations: localBackend (today's node-local behavior, default) and
+// nfsBackend (shared network storage).
+type WorkspaceBackend interface {
+	// Resolve computes workspace and shared-dir paths deterministically from
+	// project/agent IDs and the sharing mode. No DB lookup, no I/O — any
+	// replica calling Resolve with the same input produces identical paths.
+	//
+	// For nfsBackend, ResolvedWorkspace.ServerRelativePath holds the layout
+	// under the NFS export (e.g. "projects/<pid>/workspace") and HostBase
+	// holds the host mount prefix (<MountRoot>/<shareID>).
+	//
+	// For localBackend, ResolvedWorkspace.HostPath holds the absolute local
+	// host path (today's behavior) and ServerRelativePath is empty.
+	Resolve(in ResolveInput) (ResolvedWorkspace, error)
+
+	// Provision ensures the workspace directory exists and is ready for use.
+	// For git projects this includes cloning/worktree setup. Idempotent.
+	//
+	// N1-1 scope: localBackend delegates to existing local flow; nfsBackend
+	// returns a stub sentinel — full implementation lands in N1-4.
+	Provision(in ProvisionInput) error
+
+	// Realize emits the runtime mount descriptor (bind mount source, NFS
+	// volume, etc.) that the container runtime should use to expose the
+	// workspace. The returned MountDescriptor is expressive enough for
+	// Docker bind mounts today and K8s/Cloud Run volumes later.
+	//
+	// N1-1 scope: localBackend returns today's local bind mount; nfsBackend
+	// returns a stub — full wiring lands in N1-3.
+	Realize(in RealizeInput) (MountDescriptor, error)
+
+	// Name returns a human-readable identifier for this backend ("local" or "nfs").
+	Name() string
+}
+
+// ResolveInput contains everything needed to deterministically compute
+// workspace and shared-dir paths. All fields are stable IDs — no filesystem
+// state is consulted.
+type ResolveInput struct {
+	// ProjectID is the project's stable UUID.
+	ProjectID string
+
+	// AgentID is the agent's stable UUID (used for worktree-per-agent paths).
+	AgentID string
+
+	// ProjectSlug is the project's slug (used by localBackend for path resolution).
+	ProjectSlug string
+
+	// Mode is the canonical workspace sharing mode that governs layout.
+	Mode store.WorkspaceSharingMode
+
+	// SharedDirNames lists declared shared-dir names to resolve paths for.
+	SharedDirNames []string
+
+	// ProjectDir is the existing host-side project directory (used by
+	// localBackend to delegate to existing path-resolution helpers).
+	// Empty for nfsBackend (paths are derived from IDs, not host state).
+	ProjectDir string
+}
+
+// ResolvedWorkspace holds the deterministic path resolution result.
+type ResolvedWorkspace struct {
+	// HostPath is the absolute host-side path for the workspace.
+	// For localBackend this is the existing project path (e.g.
+	// ~/.scion.projects/<slug>/). For nfsBackend this is
+	// <MountRoot>/<shareID>/<ServerRelativePath>.
+	HostPath string
+
+	// ServerRelativePath is the path relative to the NFS export root.
+	// Empty for localBackend. For nfsBackend, e.g. "projects/<pid>/workspace".
+	ServerRelativePath string
+
+	// HostBase is the host mount prefix for NFS-backed workspaces
+	// (<MountRoot>/<shareID>). Empty for localBackend.
+	HostBase string
+
+	// SharedDirs maps shared-dir name → resolved path info.
+	SharedDirs map[string]ResolvedSharedDir
+
+	// Backend identifies which backend produced this resolution ("local" or "nfs").
+	Backend string
+}
+
+// ResolvedSharedDir holds path resolution for a single shared directory.
+type ResolvedSharedDir struct {
+	// HostPath is the absolute host path for this shared dir.
+	HostPath string
+
+	// ServerRelativePath is the NFS export-relative path (empty for local).
+	ServerRelativePath string
+}
+
+// ProvisionInput holds parameters for workspace provisioning.
+type ProvisionInput struct {
+	// Resolved is the output of a prior Resolve call.
+	Resolved ResolvedWorkspace
+
+	// ProjectID is the project's stable UUID.
+	ProjectID string
+
+	// AgentID is the agent's stable UUID.
+	AgentID string
+
+	// Mode is the workspace sharing mode.
+	Mode store.WorkspaceSharingMode
+
+	// GitClone holds git-clone config when the project is git-backed; nil otherwise.
+	GitClone *api.GitCloneConfig
+}
+
+// RealizeInput holds parameters for emitting a runtime mount descriptor.
+type RealizeInput struct {
+	// Resolved is the output of a prior Resolve call.
+	Resolved ResolvedWorkspace
+
+	// ContainerWorkspace is the container-side mount target (e.g. "/workspace").
+	ContainerWorkspace string
+}
+
+// MountDescriptor describes how the container runtime should mount the
+// workspace. It is intentionally expressive enough to cover Docker bind
+// mounts (HostPath → Target), K8s PVC+subPath, and Cloud Run NFS volumes.
+type MountDescriptor struct {
+	// Type is "local" for a host bind mount or "nfs" for a direct NFS mount.
+	Type string
+
+	// HostPath is the source for a Docker bind mount (populated for local).
+	HostPath string
+
+	// Target is the container-side mount path (e.g. "/workspace").
+	Target string
+
+	// NFSServer is the NFS server address (populated for nfs type).
+	NFSServer string
+
+	// NFSExportPath is the server-side export path (populated for nfs type).
+	NFSExportPath string
+
+	// SubPath is the sub-path within the volume (K8s PVC subPath).
+	SubPath string
+
+	// PVClaimName is the K8s PVC name for NFS-backed mounts.
+	PVClaimName string
+}
+
+// SelectWorkspaceBackend returns the appropriate WorkspaceBackend based on
+// configuration and workspace sharing mode. The selection rules (design §3.1):
+//
+//   - nfsBackend when cfg.Backend == "nfs" AND mode is SharedPlain or WorktreePerAgent.
+//   - localBackend otherwise — including ClonePerAgent even when Backend=nfs
+//     (the deliberate node-local escape hatch).
+//   - Backend empty or "local" always yields localBackend.
+func SelectWorkspaceBackend(cfg *config.V1WorkspaceStorageConfig, mode store.WorkspaceSharingMode) WorkspaceBackend {
+	if cfg != nil && cfg.Backend == "nfs" {
+		switch mode {
+		case store.SharingModeSharedPlain, store.SharingModeWorktreePerAgent:
+			return NewNFSBackend(cfg.NFS)
+		}
+		// ClonePerAgent (and any unknown mode) → local, even when Backend=nfs.
+	}
+	// Backend empty, "local", or nil config → local.
+	return NewLocalBackend()
+}

--- a/pkg/runtime/workspace_backend_local.go
+++ b/pkg/runtime/workspace_backend_local.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// localBackend wraps today's node-local workspace behavior. Resolve delegates
+// to existing path helpers; Provision and Realize mirror the current local flow.
+// This is the default backend — selecting it produces zero behavior change.
+type localBackend struct{}
+
+// NewLocalBackend returns a WorkspaceBackend backed by node-local storage.
+func NewLocalBackend() WorkspaceBackend {
+	return &localBackend{}
+}
+
+func (b *localBackend) Name() string { return "local" }
+
+// Resolve computes workspace and shared-dir host paths using the existing
+// local path resolution logic. The ProjectDir field on ResolveInput must be
+// set (typically from the broker's hub-native project path resolution).
+func (b *localBackend) Resolve(in ResolveInput) (ResolvedWorkspace, error) {
+	if in.ProjectDir == "" {
+		return ResolvedWorkspace{}, fmt.Errorf("localBackend.Resolve: ProjectDir is required")
+	}
+
+	res := ResolvedWorkspace{
+		HostPath:   in.ProjectDir,
+		Backend:    "local",
+		SharedDirs: make(map[string]ResolvedSharedDir, len(in.SharedDirNames)),
+	}
+
+	// Resolve shared dirs using the existing config helpers.
+	for _, name := range in.SharedDirNames {
+		hostPath, err := config.GetSharedDirPath(in.ProjectDir, name)
+		if err != nil {
+			return ResolvedWorkspace{}, fmt.Errorf("localBackend.Resolve: shared dir %q: %w", name, err)
+		}
+		res.SharedDirs[name] = ResolvedSharedDir{
+			HostPath: hostPath,
+		}
+	}
+
+	return res, nil
+}
+
+// Provision is a no-op for localBackend — the existing local flow handles
+// directory creation and git cloning elsewhere in the broker lifecycle.
+func (b *localBackend) Provision(in ProvisionInput) error {
+	// Today's local provisioning (mkdir, git clone) is handled by the
+	// broker/runtime code paths. This backend delegates to that existing
+	// flow, so Provision is a no-op here.
+	return nil
+}
+
+// Realize returns a local bind-mount descriptor pointing at the resolved
+// host path. This mirrors today's Docker `-v HOST:/workspace` behavior.
+func (b *localBackend) Realize(in RealizeInput) (MountDescriptor, error) {
+	target := in.ContainerWorkspace
+	if target == "" {
+		target = "/workspace"
+	}
+
+	return MountDescriptor{
+		Type:     "local",
+		HostPath: in.Resolved.HostPath,
+		Target:   target,
+	}, nil
+}

--- a/pkg/runtime/workspace_backend_nfs.go
+++ b/pkg/runtime/workspace_backend_nfs.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// nfsBackend resolves workspace and shared-dir paths onto an NFS-backed
+// filesystem. Resolution is deterministic from project/agent IDs — no DB
+// lookup, no I/O — so any replica computes the same path.
+//
+// Layout under the NFS mount (design §3):
+//
+//	<MountRoot>/<shareID>/<SubPathRoot>/<projectID>/workspace
+//	<MountRoot>/<shareID>/<SubPathRoot>/<projectID>/shared-dirs/<name>
+//
+// Provision and Realize are stubs in N1-1; full implementations land in
+// N1-4 (provisioning) and N1-3 (mount wiring).
+type nfsBackend struct {
+	cfg *config.V1NFSConfig
+}
+
+// NewNFSBackend returns a WorkspaceBackend backed by NFS shared storage.
+// The cfg must be non-nil and should have defaults applied (ApplyNFSDefaults).
+func NewNFSBackend(cfg *config.V1NFSConfig) WorkspaceBackend {
+	return &nfsBackend{cfg: cfg}
+}
+
+func (b *nfsBackend) Name() string { return "nfs" }
+
+// Resolve computes workspace and shared-dir paths on the NFS filesystem.
+// The result includes both the server-relative path (for K8s subPath /
+// Cloud Run server path) and the full host path (for Docker bind mounts).
+//
+// The first configured share is used by default. ProjectID is required.
+//
+// Paths are deterministic: same (ProjectID, ShareID, SubPathRoot) → same path.
+// No I/O, no DB lookup.
+func (b *nfsBackend) Resolve(in ResolveInput) (ResolvedWorkspace, error) {
+	if in.ProjectID == "" {
+		return ResolvedWorkspace{}, fmt.Errorf("nfsBackend.Resolve: ProjectID is required")
+	}
+	if b.cfg == nil {
+		return ResolvedWorkspace{}, fmt.Errorf("nfsBackend.Resolve: NFS config is nil")
+	}
+	if len(b.cfg.Shares) == 0 {
+		return ResolvedWorkspace{}, fmt.Errorf("nfsBackend.Resolve: no NFS shares configured")
+	}
+
+	share := b.cfg.Shares[0]
+	subPathRoot := b.cfg.SubPathRoot
+	if subPathRoot == "" {
+		subPathRoot = "projects"
+	}
+
+	// Server-relative workspace path: <SubPathRoot>/<projectID>/workspace
+	workspaceRelPath := filepath.Join(subPathRoot, in.ProjectID, "workspace")
+
+	// Host base: <MountRoot>/<shareID>
+	hostBase := filepath.Join(b.cfg.MountRoot, share.ID)
+
+	// Full host path: <MountRoot>/<shareID>/<SubPathRoot>/<projectID>/workspace
+	hostPath := filepath.Join(hostBase, workspaceRelPath)
+
+	res := ResolvedWorkspace{
+		HostPath:           hostPath,
+		ServerRelativePath: workspaceRelPath,
+		HostBase:           hostBase,
+		Backend:            "nfs",
+		SharedDirs:         make(map[string]ResolvedSharedDir, len(in.SharedDirNames)),
+	}
+
+	// Resolve shared dirs on NFS: <SubPathRoot>/<projectID>/shared-dirs/<name>
+	for _, name := range in.SharedDirNames {
+		sdRelPath := filepath.Join(subPathRoot, in.ProjectID, "shared-dirs", name)
+		res.SharedDirs[name] = ResolvedSharedDir{
+			HostPath:           filepath.Join(hostBase, sdRelPath),
+			ServerRelativePath: sdRelPath,
+		}
+	}
+
+	return res, nil
+}
+
+// Provision is a stub in N1-1. Full NFS provisioning (git clone onto NFS
+// under a Postgres advisory lock) lands in N1-4.
+func (b *nfsBackend) Provision(in ProvisionInput) error {
+	// N1-4 will implement: acquire advisory lock → git clone/worktree → release.
+	return nil
+}
+
+// Realize is a stub in N1-1. Full NFS mount wiring (Docker bind-mount from
+// the NFS host path, K8s PVC+subPath, Cloud Run NFS volume) lands in N1-3.
+func (b *nfsBackend) Realize(in RealizeInput) (MountDescriptor, error) {
+	target := in.ContainerWorkspace
+	if target == "" {
+		target = "/workspace"
+	}
+
+	// Return a descriptor with enough information for N1-3 to wire up.
+	// For now the HostPath is populated so callers can see what would be
+	// mounted, but the actual mount wiring is deferred.
+	return MountDescriptor{
+		Type:     "nfs",
+		HostPath: in.Resolved.HostPath,
+		Target:   target,
+		SubPath:  in.Resolved.ServerRelativePath,
+	}, nil
+}

--- a/pkg/runtime/workspace_backend_nfs.go
+++ b/pkg/runtime/workspace_backend_nfs.go
@@ -15,10 +15,17 @@
 package runtime
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
 // nfsBackend resolves workspace and shared-dir paths onto an NFS-backed
@@ -98,10 +105,342 @@ func (b *nfsBackend) Resolve(in ResolveInput) (ResolvedWorkspace, error) {
 	return res, nil
 }
 
-// Provision is a stub in N1-1. Full NFS provisioning (git clone onto NFS
-// under a Postgres advisory lock) lands in N1-4.
+// provisionSentinelFile is the name of the sentinel file written atomically
+// after a successful workspace clone/setup. Its presence short-circuits
+// subsequent Provision calls — the workspace is already ready.
+const provisionSentinelFile = ".scion-provisioned"
+
+// provisionLockRetries is the number of times to retry acquiring the
+// per-project advisory lock before giving up. Each retry sleeps briefly
+// (provisionLockRetryDelay) to allow the current holder to finish.
+const provisionLockRetries = 30
+
+// provisionLockRetryDelay is the sleep between advisory lock acquisition
+// retries. Provisioning (git clone) is typically short (seconds), so a
+// short retry cadence is appropriate.
+const provisionLockRetryDelay = 1 * time.Second
+
+// Provision ensures the NFS workspace is ready for use. It implements the
+// first-access provisioning flow from design §7 and §8.1:
+//
+//  1. Acquire per-project advisory lock (try with retry — provisioning is short).
+//  2. If sentinel <projectRoot>/.scion-provisioned exists → done (reuse).
+//  3. Else: mkdir -p, git clone, chown 1000:1000, mode 0770, write sentinel.
+//  4. Release lock.
+//
+// For WorktreePerAgent mode, the shared checkout is cloned once under the lock;
+// each agent then adds its own git worktree (also under the lock, because
+// worktree add/remove touches shared .git metadata — design §9.2).
+//
+// ClonePerAgent mode MUST NOT reach this path — it is node-local and handled
+// by localBackend. An assert guards this.
+//
+// The flow is idempotent and race-safe: two agents for the same project
+// starting on two different nodes contend on the advisory lock; exactly one
+// clones, the second sees the sentinel and reuses the workspace.
 func (b *nfsBackend) Provision(in ProvisionInput) error {
-	// N1-4 will implement: acquire advisory lock → git clone/worktree → release.
+	// Guard: ClonePerAgent must never use the NFS path. SelectWorkspaceBackend
+	// already routes it to localBackend, but assert here as defense in depth.
+	if in.Mode == store.SharingModeClonePerAgent {
+		return fmt.Errorf("nfsBackend.Provision: ClonePerAgent mode must not use NFS backend " +
+			"(should be routed to localBackend by SelectWorkspaceBackend)")
+	}
+
+	if in.Resolved.HostPath == "" {
+		return fmt.Errorf("nfsBackend.Provision: Resolved.HostPath is required")
+	}
+	if in.ProjectID == "" {
+		return fmt.Errorf("nfsBackend.Provision: ProjectID is required")
+	}
+
+	// The project root is the parent of the workspace dir:
+	// <MountRoot>/<shareID>/<SubPathRoot>/<projectID>/ contains workspace/ + shared-dirs/.
+	projectRoot := filepath.Dir(in.Resolved.HostPath)
+
+	ctx := context.Background()
+
+	// --- Step 1: Acquire per-project advisory lock ---
+	release, err := b.acquireProvisionLock(ctx, in)
+	if err != nil {
+		return fmt.Errorf("nfsBackend.Provision: failed to acquire lock for project %s: %w", in.ProjectID, err)
+	}
+	defer func() {
+		if releaseErr := release(); releaseErr != nil {
+			slog.Warn("nfsBackend.Provision: failed to release advisory lock",
+				"project_id", in.ProjectID, "error", releaseErr)
+		}
+	}()
+
+	// --- Step 2: Check sentinel ---
+	sentinelPath := filepath.Join(projectRoot, provisionSentinelFile)
+	if _, err := os.Stat(sentinelPath); err == nil {
+		// Already provisioned — skip to worktree setup if needed.
+		slog.Debug("nfsBackend.Provision: workspace already provisioned (sentinel exists)",
+			"project_id", in.ProjectID, "sentinel", sentinelPath)
+		return b.ensureWorktree(in)
+	}
+
+	// --- Step 3: Provision (mkdir + clone + chown + sentinel) ---
+	slog.Info("nfsBackend.Provision: provisioning workspace",
+		"project_id", in.ProjectID, "host_path", in.Resolved.HostPath)
+
+	// Create workspace directory.
+	if err := os.MkdirAll(in.Resolved.HostPath, 0770); err != nil {
+		return fmt.Errorf("nfsBackend.Provision: mkdir workspace %s: %w", in.Resolved.HostPath, err)
+	}
+
+	// Create shared-dir directories.
+	for name, sd := range in.Resolved.SharedDirs {
+		if err := os.MkdirAll(sd.HostPath, 0770); err != nil {
+			return fmt.Errorf("nfsBackend.Provision: mkdir shared-dir %q %s: %w", name, sd.HostPath, err)
+		}
+	}
+
+	// Git clone if project is git-backed.
+	if in.GitClone != nil && in.GitClone.URL != "" {
+		if err := b.gitCloneWorkspace(in); err != nil {
+			return fmt.Errorf("nfsBackend.Provision: git clone: %w", err)
+		}
+	}
+
+	// Chown to stable NFS UID/GID (design §9.1). This is a ONE-TIME operation
+	// under the advisory lock — per-start chown is skipped for NFS (see N1-5).
+	uid, gid := b.resolveUID(in), b.resolveGID(in)
+	if err := b.chownProjectTree(projectRoot, uid, gid); err != nil {
+		slog.Warn("nfsBackend.Provision: chown failed (non-fatal, may lack privileges)",
+			"project_id", in.ProjectID, "path", projectRoot, "uid", uid, "gid", gid, "error", err)
+		// Non-fatal: operator may have pre-chowned. Continue to write sentinel.
+	}
+
+	// Write sentinel atomically.
+	if err := writeSentinel(sentinelPath); err != nil {
+		return fmt.Errorf("nfsBackend.Provision: write sentinel: %w", err)
+	}
+
+	slog.Info("nfsBackend.Provision: workspace provisioned successfully",
+		"project_id", in.ProjectID, "host_path", in.Resolved.HostPath)
+
+	// --- Step 4: Worktree setup (if WorktreePerAgent) ---
+	return b.ensureWorktree(in)
+}
+
+// acquireProvisionLock acquires the per-project advisory lock, retrying briefly
+// if another node currently holds it. Returns a release func.
+func (b *nfsBackend) acquireProvisionLock(ctx context.Context, in ProvisionInput) (func() error, error) {
+	if in.Locker == nil {
+		// No locker available — degrade to unguarded (correct for single-node,
+		// unsafe for multi-node). Log a warning.
+		slog.Warn("nfsBackend.Provision: no advisory locker available — provisioning is unguarded",
+			"project_id", in.ProjectID)
+		return func() error { return nil }, nil
+	}
+
+	objID := store.StableProjectHash(in.ProjectID)
+
+	for attempt := 0; attempt < provisionLockRetries; attempt++ {
+		acquired, release, err := in.Locker.TryAdvisoryLockObject(ctx, store.LockWorkspaceProvision, objID)
+		if err != nil {
+			return nil, fmt.Errorf("advisory lock attempt %d: %w", attempt, err)
+		}
+		if acquired {
+			return release, nil
+		}
+		// Another node holds the lock — it's provisioning this project.
+		// Wait briefly and retry.
+		slog.Debug("nfsBackend.Provision: lock held by another node, retrying",
+			"project_id", in.ProjectID, "attempt", attempt+1)
+		time.Sleep(provisionLockRetryDelay)
+	}
+
+	return nil, fmt.Errorf("failed to acquire provisioning lock after %d attempts (project %s)",
+		provisionLockRetries, in.ProjectID)
+}
+
+// gitCloneWorkspace performs the git clone into the NFS workspace directory.
+// It clones into the workspace path (in.Resolved.HostPath).
+func (b *nfsBackend) gitCloneWorkspace(in ProvisionInput) error {
+	gc := in.GitClone
+
+	args := []string{"clone"}
+
+	// Set depth (default: 1 for shallow clone, 0 = full).
+	depth := gc.Depth
+	if depth == 0 {
+		depth = 1
+	}
+	if depth > 0 {
+		args = append(args, "--depth", fmt.Sprintf("%d", depth))
+	}
+
+	// Set branch if specified.
+	if gc.Branch != "" {
+		args = append(args, "--branch", gc.Branch)
+	}
+
+	// Clone into the workspace directory.
+	args = append(args, gc.URL, in.Resolved.HostPath)
+
+	cmd := exec.Command("git", args...)
+	cmd.Env = append(os.Environ(),
+		// Disable interactive prompts during provisioning.
+		"GIT_TERMINAL_PROMPT=0",
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// If workspace is not empty (e.g. a partially-failed prior attempt),
+		// the clone will fail. Check and handle.
+		if strings.Contains(string(output), "already exists and is not an empty directory") {
+			slog.Warn("nfsBackend.Provision: workspace directory not empty, assuming prior partial clone",
+				"project_id", in.ProjectID, "path", in.Resolved.HostPath)
+			// The sentinel wasn't written, so this is a prior failed attempt.
+			// Reuse what's there — if .git exists, it may be usable.
+			if _, statErr := os.Stat(filepath.Join(in.Resolved.HostPath, ".git")); statErr == nil {
+				return nil // .git exists, treat as provisioned
+			}
+			return fmt.Errorf("git clone failed and no .git in %s: %s", in.Resolved.HostPath, string(output))
+		}
+		return fmt.Errorf("git clone %s: %s", gc.URL, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// ensureWorktree creates a per-agent worktree if the mode is WorktreePerAgent.
+// For SharedPlain mode this is a no-op.
+// The worktree add is done under the already-held advisory lock (design §9.2:
+// worktree add/remove touches shared .git metadata).
+func (b *nfsBackend) ensureWorktree(in ProvisionInput) error {
+	if in.Mode != store.SharingModeWorktreePerAgent {
+		return nil // SharedPlain: nothing to do
+	}
+
+	if in.AgentID == "" {
+		return fmt.Errorf("nfsBackend.Provision: AgentID is required for WorktreePerAgent mode")
+	}
+
+	// Worktree path: <workspace>/worktrees/<agentID>
+	worktreePath := filepath.Join(in.Resolved.HostPath, "worktrees", in.AgentID)
+
+	// If the worktree already exists, skip.
+	if _, err := os.Stat(worktreePath); err == nil {
+		slog.Debug("nfsBackend.Provision: worktree already exists",
+			"agent_id", in.AgentID, "path", worktreePath)
+		return nil
+	}
+
+	// Verify the shared checkout exists (.git dir present).
+	gitDir := filepath.Join(in.Resolved.HostPath, ".git")
+	if _, err := os.Stat(gitDir); err != nil {
+		return fmt.Errorf("nfsBackend.Provision: shared checkout .git not found at %s — "+
+			"cannot create worktree without a cloned repository", gitDir)
+	}
+
+	// Derive a branch name from the agent name or ID.
+	branchName := in.AgentID
+	if in.AgentName != "" {
+		branchName = sanitizeBranchName(in.AgentName)
+	}
+
+	slog.Info("nfsBackend.Provision: creating worktree",
+		"agent_id", in.AgentID, "branch", branchName, "path", worktreePath)
+
+	// git worktree add <path> -b <branch>
+	cmd := exec.Command("git", "worktree", "add", "-b", branchName, worktreePath)
+	cmd.Dir = in.Resolved.HostPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		outputStr := strings.TrimSpace(string(output))
+		// If branch already exists, try without -b.
+		if strings.Contains(outputStr, "already exists") {
+			cmd = exec.Command("git", "worktree", "add", worktreePath, branchName)
+			cmd.Dir = in.Resolved.HostPath
+			output, err = cmd.CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("git worktree add (reuse branch): %s", strings.TrimSpace(string(output)))
+			}
+			return nil
+		}
+		return fmt.Errorf("git worktree add: %s", outputStr)
+	}
+	return nil
+}
+
+// sanitizeBranchName produces a git-safe branch name from an agent name.
+func sanitizeBranchName(name string) string {
+	// Replace characters invalid in git branch names.
+	replacer := strings.NewReplacer(
+		" ", "-", "/", "-", "\\", "-", "..", "-",
+		"~", "-", "^", "-", ":", "-", "?", "-",
+		"*", "-", "[", "-", "]", "-",
+	)
+	result := replacer.Replace(name)
+	// Trim leading/trailing dashes and dots.
+	result = strings.Trim(result, "-.")
+	if result == "" {
+		return "agent"
+	}
+	return result
+}
+
+// chownProjectTree sets ownership of the project root and its contents to the
+// given UID/GID. This is a ONE-TIME operation done under the advisory lock
+// during first provisioning (design §9.1). Per-start chown is NOT done for
+// NFS (slow/racy over the network).
+func (b *nfsBackend) chownProjectTree(projectRoot string, uid, gid int) error {
+	// Use chown -R for recursive ownership change.
+	cmd := exec.Command("chown", "-R", fmt.Sprintf("%d:%d", uid, gid), projectRoot)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("chown -R %d:%d %s: %s", uid, gid, projectRoot, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// resolveUID returns the NFS UID to use for chown, defaulting to 1000.
+func (b *nfsBackend) resolveUID(in ProvisionInput) int {
+	if in.NFSUID != 0 {
+		return in.NFSUID
+	}
+	if b.cfg != nil && b.cfg.UID != 0 {
+		return b.cfg.UID
+	}
+	return 1000
+}
+
+// resolveGID returns the NFS GID to use for chown, defaulting to 1000.
+func (b *nfsBackend) resolveGID(in ProvisionInput) int {
+	if in.NFSGID != 0 {
+		return in.NFSGID
+	}
+	if b.cfg != nil && b.cfg.GID != 0 {
+		return b.cfg.GID
+	}
+	return 1000
+}
+
+// writeSentinel writes the provisioning sentinel file atomically using
+// write-to-temp + rename. The sentinel's existence is the fast-path check
+// that short-circuits re-provisioning.
+func writeSentinel(path string) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".scion-provisioned-*")
+	if err != nil {
+		return fmt.Errorf("create temp sentinel: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	// Write a timestamp for debugging.
+	_, _ = fmt.Fprintf(tmp, "provisioned_at=%s\n", time.Now().UTC().Format(time.RFC3339))
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("close temp sentinel: %w", err)
+	}
+
+	// Atomic rename.
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("rename sentinel: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/runtime/workspace_backend_nfs.go
+++ b/pkg/runtime/workspace_backend_nfs.go
@@ -105,21 +105,36 @@ func (b *nfsBackend) Provision(in ProvisionInput) error {
 	return nil
 }
 
-// Realize is a stub in N1-1. Full NFS mount wiring (Docker bind-mount from
-// the NFS host path, K8s PVC+subPath, Cloud Run NFS volume) lands in N1-3.
+// Realize emits a Docker bind-mount descriptor from the NFS host path to the
+// container workspace. The host path points at the project subtree under the
+// NFS mount (<MountRoot>/<shareID>/<SubPathRoot>/<projectID>/workspace), NOT
+// the export root — this is the critical isolation guarantee (design §9.4).
+//
+// For K8s the SubPath and PVClaimName fields are populated for PVC+subPath
+// wiring; for Docker, HostPath is the bind-mount source.
 func (b *nfsBackend) Realize(in RealizeInput) (MountDescriptor, error) {
 	target := in.ContainerWorkspace
 	if target == "" {
 		target = "/workspace"
 	}
 
-	// Return a descriptor with enough information for N1-3 to wire up.
-	// For now the HostPath is populated so callers can see what would be
-	// mounted, but the actual mount wiring is deferred.
-	return MountDescriptor{
+	// Isolation guard: never bind the host base (export root mount) directly.
+	// The resolved HostPath must be a subdirectory of HostBase, not equal to it.
+	if err := ValidateNotExportRoot(in.Resolved.HostPath, in.Resolved.HostBase); err != nil {
+		return MountDescriptor{}, err
+	}
+
+	desc := MountDescriptor{
 		Type:     "nfs",
 		HostPath: in.Resolved.HostPath,
 		Target:   target,
 		SubPath:  in.Resolved.ServerRelativePath,
-	}, nil
+	}
+
+	// Populate K8s PVC info from the first share if available.
+	if b.cfg != nil && len(b.cfg.Shares) > 0 && b.cfg.Shares[0].PVName != "" {
+		desc.PVClaimName = b.cfg.Shares[0].PVName
+	}
+
+	return desc, nil
 }

--- a/pkg/runtime/workspace_backend_nfs.go
+++ b/pkg/runtime/workspace_backend_nfs.go
@@ -226,6 +226,9 @@ func (b *nfsBackend) Provision(in ProvisionInput) error {
 
 // acquireProvisionLock acquires the per-project advisory lock, retrying briefly
 // if another node currently holds it. Returns a release func.
+//
+// The retry loop respects context cancellation so that server shutdown is not
+// blocked for up to provisionLockRetries × provisionLockRetryDelay.
 func (b *nfsBackend) acquireProvisionLock(ctx context.Context, in ProvisionInput) (func() error, error) {
 	if in.Locker == nil {
 		// No locker available — degrade to unguarded (correct for single-node,
@@ -236,6 +239,8 @@ func (b *nfsBackend) acquireProvisionLock(ctx context.Context, in ProvisionInput
 	}
 
 	objID := store.StableProjectHash(in.ProjectID)
+	ticker := time.NewTicker(provisionLockRetryDelay)
+	defer ticker.Stop()
 
 	for attempt := 0; attempt < provisionLockRetries; attempt++ {
 		acquired, release, err := in.Locker.TryAdvisoryLockObject(ctx, store.LockWorkspaceProvision, objID)
@@ -246,10 +251,15 @@ func (b *nfsBackend) acquireProvisionLock(ctx context.Context, in ProvisionInput
 			return release, nil
 		}
 		// Another node holds the lock — it's provisioning this project.
-		// Wait briefly and retry.
+		// Wait briefly and retry, but honour context cancellation.
 		slog.Debug("nfsBackend.Provision: lock held by another node, retrying",
 			"project_id", in.ProjectID, "attempt", attempt+1)
-		time.Sleep(provisionLockRetryDelay)
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("context cancelled while waiting for provisioning lock (project %s): %w",
+				in.ProjectID, ctx.Err())
+		case <-ticker.C:
+		}
 	}
 
 	return nil, fmt.Errorf("failed to acquire provisioning lock after %d attempts (project %s)",

--- a/pkg/runtime/workspace_backend_test.go
+++ b/pkg/runtime/workspace_backend_test.go
@@ -1,0 +1,686 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// --- SelectWorkspaceBackend truth table ---
+
+func TestSelectWorkspaceBackend(t *testing.T) {
+	nfsCfg := &config.V1WorkspaceStorageConfig{
+		Backend: "nfs",
+		NFS: &config.V1NFSConfig{
+			MountRoot:   "/mnt/nfs",
+			SubPathRoot: "projects",
+			Shares: []config.V1NFSShare{
+				{ID: "share1", Server: "10.0.0.2", Export: "/scion-workspaces"},
+			},
+		},
+	}
+	localCfg := &config.V1WorkspaceStorageConfig{
+		Backend: "local",
+	}
+	emptyCfg := &config.V1WorkspaceStorageConfig{
+		Backend: "",
+	}
+
+	tests := []struct {
+		name        string
+		cfg         *config.V1WorkspaceStorageConfig
+		mode        store.WorkspaceSharingMode
+		wantBackend string
+	}{
+		// Backend=local → always local for all modes
+		{
+			name:        "local+SharedPlain",
+			cfg:         localCfg,
+			mode:        store.SharingModeSharedPlain,
+			wantBackend: "local",
+		},
+		{
+			name:        "local+WorktreePerAgent",
+			cfg:         localCfg,
+			mode:        store.SharingModeWorktreePerAgent,
+			wantBackend: "local",
+		},
+		{
+			name:        "local+ClonePerAgent",
+			cfg:         localCfg,
+			mode:        store.SharingModeClonePerAgent,
+			wantBackend: "local",
+		},
+
+		// Backend="" → always local for all modes
+		{
+			name:        "empty+SharedPlain",
+			cfg:         emptyCfg,
+			mode:        store.SharingModeSharedPlain,
+			wantBackend: "local",
+		},
+		{
+			name:        "empty+WorktreePerAgent",
+			cfg:         emptyCfg,
+			mode:        store.SharingModeWorktreePerAgent,
+			wantBackend: "local",
+		},
+		{
+			name:        "empty+ClonePerAgent",
+			cfg:         emptyCfg,
+			mode:        store.SharingModeClonePerAgent,
+			wantBackend: "local",
+		},
+
+		// nil config → always local
+		{
+			name:        "nil+SharedPlain",
+			cfg:         nil,
+			mode:        store.SharingModeSharedPlain,
+			wantBackend: "local",
+		},
+		{
+			name:        "nil+ClonePerAgent",
+			cfg:         nil,
+			mode:        store.SharingModeClonePerAgent,
+			wantBackend: "local",
+		},
+
+		// Backend=nfs + SharedPlain → nfs
+		{
+			name:        "nfs+SharedPlain",
+			cfg:         nfsCfg,
+			mode:        store.SharingModeSharedPlain,
+			wantBackend: "nfs",
+		},
+		// Backend=nfs + WorktreePerAgent → nfs
+		{
+			name:        "nfs+WorktreePerAgent",
+			cfg:         nfsCfg,
+			mode:        store.SharingModeWorktreePerAgent,
+			wantBackend: "nfs",
+		},
+		// Backend=nfs + ClonePerAgent → local (deliberate node-local escape hatch)
+		{
+			name:        "nfs+ClonePerAgent",
+			cfg:         nfsCfg,
+			mode:        store.SharingModeClonePerAgent,
+			wantBackend: "local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := SelectWorkspaceBackend(tt.cfg, tt.mode)
+			if got := backend.Name(); got != tt.wantBackend {
+				t.Errorf("SelectWorkspaceBackend(%q, %q) = %q, want %q",
+					backendStr(tt.cfg), tt.mode, got, tt.wantBackend)
+			}
+		})
+	}
+}
+
+func backendStr(cfg *config.V1WorkspaceStorageConfig) string {
+	if cfg == nil {
+		return "<nil>"
+	}
+	return cfg.Backend
+}
+
+// --- NFS Resolve tests ---
+
+func TestNFSBackendResolve(t *testing.T) {
+	nfsCfg := &config.V1NFSConfig{
+		MountRoot:   "/mnt/nfs",
+		SubPathRoot: "projects",
+		Shares: []config.V1NFSShare{
+			{ID: "share1", Server: "10.0.0.2", Export: "/scion-workspaces"},
+		},
+	}
+
+	tests := []struct {
+		name               string
+		input              ResolveInput
+		wantHostPath       string
+		wantServerRelPath  string
+		wantHostBase       string
+		wantSharedDirPaths map[string]string // name → hostPath
+		wantSharedDirRels  map[string]string // name → serverRelPath
+		wantErr            bool
+	}{
+		{
+			name: "basic workspace path",
+			input: ResolveInput{
+				ProjectID: "proj-abc-123",
+				AgentID:   "agent-xyz",
+				Mode:      store.SharingModeSharedPlain,
+			},
+			wantHostPath:      filepath.Join("/mnt/nfs", "share1", "projects", "proj-abc-123", "workspace"),
+			wantServerRelPath: filepath.Join("projects", "proj-abc-123", "workspace"),
+			wantHostBase:      filepath.Join("/mnt/nfs", "share1"),
+		},
+		{
+			name: "workspace with shared dirs",
+			input: ResolveInput{
+				ProjectID:      "proj-abc-123",
+				AgentID:        "agent-xyz",
+				Mode:           store.SharingModeSharedPlain,
+				SharedDirNames: []string{"data", "cache"},
+			},
+			wantHostPath:      filepath.Join("/mnt/nfs", "share1", "projects", "proj-abc-123", "workspace"),
+			wantServerRelPath: filepath.Join("projects", "proj-abc-123", "workspace"),
+			wantHostBase:      filepath.Join("/mnt/nfs", "share1"),
+			wantSharedDirPaths: map[string]string{
+				"data":  filepath.Join("/mnt/nfs", "share1", "projects", "proj-abc-123", "shared-dirs", "data"),
+				"cache": filepath.Join("/mnt/nfs", "share1", "projects", "proj-abc-123", "shared-dirs", "cache"),
+			},
+			wantSharedDirRels: map[string]string{
+				"data":  filepath.Join("projects", "proj-abc-123", "shared-dirs", "data"),
+				"cache": filepath.Join("projects", "proj-abc-123", "shared-dirs", "cache"),
+			},
+		},
+		{
+			name: "worktree-per-agent mode same workspace path",
+			input: ResolveInput{
+				ProjectID: "proj-abc-123",
+				AgentID:   "agent-xyz",
+				Mode:      store.SharingModeWorktreePerAgent,
+			},
+			wantHostPath:      filepath.Join("/mnt/nfs", "share1", "projects", "proj-abc-123", "workspace"),
+			wantServerRelPath: filepath.Join("projects", "proj-abc-123", "workspace"),
+			wantHostBase:      filepath.Join("/mnt/nfs", "share1"),
+		},
+		{
+			name: "missing project ID",
+			input: ResolveInput{
+				AgentID: "agent-xyz",
+				Mode:    store.SharingModeSharedPlain,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewNFSBackend(nfsCfg)
+			got, err := b.Resolve(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got.HostPath != tt.wantHostPath {
+				t.Errorf("HostPath = %q, want %q", got.HostPath, tt.wantHostPath)
+			}
+			if got.ServerRelativePath != tt.wantServerRelPath {
+				t.Errorf("ServerRelativePath = %q, want %q", got.ServerRelativePath, tt.wantServerRelPath)
+			}
+			if got.HostBase != tt.wantHostBase {
+				t.Errorf("HostBase = %q, want %q", got.HostBase, tt.wantHostBase)
+			}
+			if got.Backend != "nfs" {
+				t.Errorf("Backend = %q, want %q", got.Backend, "nfs")
+			}
+
+			// Verify shared dirs
+			for name, wantPath := range tt.wantSharedDirPaths {
+				sd, ok := got.SharedDirs[name]
+				if !ok {
+					t.Errorf("shared dir %q not found in result", name)
+					continue
+				}
+				if sd.HostPath != wantPath {
+					t.Errorf("SharedDirs[%q].HostPath = %q, want %q", name, sd.HostPath, wantPath)
+				}
+			}
+			for name, wantRel := range tt.wantSharedDirRels {
+				sd, ok := got.SharedDirs[name]
+				if !ok {
+					continue // already reported above
+				}
+				if sd.ServerRelativePath != wantRel {
+					t.Errorf("SharedDirs[%q].ServerRelativePath = %q, want %q", name, sd.ServerRelativePath, wantRel)
+				}
+			}
+		})
+	}
+}
+
+// TestNFSResolve_Deterministic verifies that calling Resolve twice with the
+// same inputs produces identical output — the fundamental contract for
+// cross-replica consistency.
+func TestNFSResolve_Deterministic(t *testing.T) {
+	nfsCfg := &config.V1NFSConfig{
+		MountRoot:   "/mnt/nfs",
+		SubPathRoot: "projects",
+		Shares: []config.V1NFSShare{
+			{ID: "ws1", Server: "10.0.0.2", Export: "/scion-workspaces"},
+		},
+	}
+
+	input := ResolveInput{
+		ProjectID:      "550e8400-e29b-41d4-a716-446655440000",
+		AgentID:        "660e8400-e29b-41d4-a716-446655440001",
+		Mode:           store.SharingModeSharedPlain,
+		SharedDirNames: []string{"artifacts", "cache"},
+	}
+
+	b := NewNFSBackend(nfsCfg)
+
+	r1, err := b.Resolve(input)
+	if err != nil {
+		t.Fatalf("first Resolve: %v", err)
+	}
+
+	r2, err := b.Resolve(input)
+	if err != nil {
+		t.Fatalf("second Resolve: %v", err)
+	}
+
+	if r1.HostPath != r2.HostPath {
+		t.Errorf("HostPath not deterministic: %q vs %q", r1.HostPath, r2.HostPath)
+	}
+	if r1.ServerRelativePath != r2.ServerRelativePath {
+		t.Errorf("ServerRelativePath not deterministic: %q vs %q", r1.ServerRelativePath, r2.ServerRelativePath)
+	}
+	if r1.HostBase != r2.HostBase {
+		t.Errorf("HostBase not deterministic: %q vs %q", r1.HostBase, r2.HostBase)
+	}
+	for name, sd1 := range r1.SharedDirs {
+		sd2, ok := r2.SharedDirs[name]
+		if !ok {
+			t.Errorf("shared dir %q missing from second Resolve", name)
+			continue
+		}
+		if sd1.HostPath != sd2.HostPath {
+			t.Errorf("SharedDirs[%q].HostPath not deterministic: %q vs %q", name, sd1.HostPath, sd2.HostPath)
+		}
+		if sd1.ServerRelativePath != sd2.ServerRelativePath {
+			t.Errorf("SharedDirs[%q].ServerRelativePath not deterministic: %q vs %q", name, sd1.ServerRelativePath, sd2.ServerRelativePath)
+		}
+	}
+}
+
+// TestNFSResolve_PathsAreUnderMountNotExportRoot verifies that resolved
+// paths are under <MountRoot>/<shareID>, never under the NFS export root.
+func TestNFSResolve_PathsAreUnderMountNotExportRoot(t *testing.T) {
+	nfsCfg := &config.V1NFSConfig{
+		MountRoot:   "/mnt/nfs",
+		SubPathRoot: "projects",
+		Shares: []config.V1NFSShare{
+			{ID: "ws1", Server: "10.0.0.2", Export: "/scion-workspaces"},
+		},
+	}
+
+	b := NewNFSBackend(nfsCfg)
+	res, err := b.Resolve(ResolveInput{
+		ProjectID:      "proj1",
+		Mode:           store.SharingModeSharedPlain,
+		SharedDirNames: []string{"data"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	exportRoot := "/scion-workspaces"
+
+	// Workspace host path must not start with the export root
+	if len(res.HostPath) >= len(exportRoot) && res.HostPath[:len(exportRoot)] == exportRoot {
+		t.Errorf("HostPath %q starts with export root %q — should be under MountRoot/shareID", res.HostPath, exportRoot)
+	}
+
+	// It must start with the mount root + share ID
+	wantPrefix := filepath.Join("/mnt/nfs", "ws1")
+	if len(res.HostPath) < len(wantPrefix) || res.HostPath[:len(wantPrefix)] != wantPrefix {
+		t.Errorf("HostPath %q does not start with expected prefix %q", res.HostPath, wantPrefix)
+	}
+
+	// Same for shared dirs
+	for name, sd := range res.SharedDirs {
+		if len(sd.HostPath) >= len(exportRoot) && sd.HostPath[:len(exportRoot)] == exportRoot {
+			t.Errorf("SharedDirs[%q].HostPath %q starts with export root", name, sd.HostPath)
+		}
+		if len(sd.HostPath) < len(wantPrefix) || sd.HostPath[:len(wantPrefix)] != wantPrefix {
+			t.Errorf("SharedDirs[%q].HostPath %q does not start with expected prefix %q", name, sd.HostPath, wantPrefix)
+		}
+	}
+}
+
+// TestNFSResolve_ServerRelativePathFormat verifies the exact server-relative
+// layout matches the design: projects/<pid>/workspace and
+// projects/<pid>/shared-dirs/<name>.
+func TestNFSResolve_ServerRelativePathFormat(t *testing.T) {
+	nfsCfg := &config.V1NFSConfig{
+		MountRoot:   "/mnt/nfs",
+		SubPathRoot: "projects",
+		Shares: []config.V1NFSShare{
+			{ID: "share1", Server: "10.0.0.2", Export: "/scion-workspaces"},
+		},
+	}
+
+	b := NewNFSBackend(nfsCfg)
+	res, err := b.Resolve(ResolveInput{
+		ProjectID:      "my-project-id",
+		Mode:           store.SharingModeSharedPlain,
+		SharedDirNames: []string{"logs"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	wantWorkspaceRel := filepath.Join("projects", "my-project-id", "workspace")
+	if res.ServerRelativePath != wantWorkspaceRel {
+		t.Errorf("workspace ServerRelativePath = %q, want %q", res.ServerRelativePath, wantWorkspaceRel)
+	}
+
+	wantSharedDirRel := filepath.Join("projects", "my-project-id", "shared-dirs", "logs")
+	if sd, ok := res.SharedDirs["logs"]; !ok {
+		t.Error("shared dir 'logs' not found")
+	} else if sd.ServerRelativePath != wantSharedDirRel {
+		t.Errorf("shared dir ServerRelativePath = %q, want %q", sd.ServerRelativePath, wantSharedDirRel)
+	}
+}
+
+// TestNFSResolve_NoShares verifies that Resolve returns an error when no
+// shares are configured.
+func TestNFSResolve_NoShares(t *testing.T) {
+	nfsCfg := &config.V1NFSConfig{
+		MountRoot:   "/mnt/nfs",
+		SubPathRoot: "projects",
+		Shares:      nil,
+	}
+	b := NewNFSBackend(nfsCfg)
+	_, err := b.Resolve(ResolveInput{
+		ProjectID: "proj1",
+		Mode:      store.SharingModeSharedPlain,
+	})
+	if err == nil {
+		t.Error("expected error for no shares, got nil")
+	}
+}
+
+// TestNFSResolve_NilConfig verifies that Resolve returns an error when the
+// NFS config is nil.
+func TestNFSResolve_NilConfig(t *testing.T) {
+	b := NewNFSBackend(nil)
+	_, err := b.Resolve(ResolveInput{
+		ProjectID: "proj1",
+		Mode:      store.SharingModeSharedPlain,
+	})
+	if err == nil {
+		t.Error("expected error for nil config, got nil")
+	}
+}
+
+// TestNFSResolve_SubPathRootDefault verifies that an empty SubPathRoot
+// defaults to "projects".
+func TestNFSResolve_SubPathRootDefault(t *testing.T) {
+	nfsCfg := &config.V1NFSConfig{
+		MountRoot:   "/mnt/nfs",
+		SubPathRoot: "", // should default to "projects"
+		Shares: []config.V1NFSShare{
+			{ID: "share1", Server: "10.0.0.2", Export: "/scion-workspaces"},
+		},
+	}
+
+	b := NewNFSBackend(nfsCfg)
+	res, err := b.Resolve(ResolveInput{
+		ProjectID: "proj1",
+		Mode:      store.SharingModeSharedPlain,
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	wantRel := filepath.Join("projects", "proj1", "workspace")
+	if res.ServerRelativePath != wantRel {
+		t.Errorf("ServerRelativePath = %q, want %q (default SubPathRoot)", res.ServerRelativePath, wantRel)
+	}
+}
+
+// --- Local Backend Resolve tests ---
+
+func TestLocalBackendResolve(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      ResolveInput
+		wantErr    bool
+		wantPath   string
+		wantBackend string
+	}{
+		{
+			name: "basic local resolve",
+			input: ResolveInput{
+				ProjectDir: "/home/user/.scion.projects/my-project",
+				ProjectID:  "proj1",
+				Mode:       store.SharingModeSharedPlain,
+			},
+			wantPath:    "/home/user/.scion.projects/my-project",
+			wantBackend: "local",
+		},
+		{
+			name: "local resolve clone-per-agent",
+			input: ResolveInput{
+				ProjectDir: "/home/user/.scion.projects/my-project",
+				ProjectID:  "proj1",
+				Mode:       store.SharingModeClonePerAgent,
+			},
+			wantPath:    "/home/user/.scion.projects/my-project",
+			wantBackend: "local",
+		},
+		{
+			name: "missing ProjectDir",
+			input: ResolveInput{
+				ProjectID: "proj1",
+				Mode:      store.SharingModeSharedPlain,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewLocalBackend()
+			got, err := b.Resolve(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got.HostPath != tt.wantPath {
+				t.Errorf("HostPath = %q, want %q", got.HostPath, tt.wantPath)
+			}
+			if got.Backend != tt.wantBackend {
+				t.Errorf("Backend = %q, want %q", got.Backend, tt.wantBackend)
+			}
+			if got.ServerRelativePath != "" {
+				t.Errorf("ServerRelativePath = %q, want empty for local", got.ServerRelativePath)
+			}
+			if got.HostBase != "" {
+				t.Errorf("HostBase = %q, want empty for local", got.HostBase)
+			}
+		})
+	}
+}
+
+// TestLocalBackendResolve_MatchesPreExisting asserts that localBackend.Resolve
+// produces the same host path that the existing broker path resolution would
+// produce for a hub-native project. This is the "zero behavior change" guard.
+func TestLocalBackendResolve_MatchesPreExisting(t *testing.T) {
+	// The existing broker resolution for a hub-native project sets
+	// ProjectPath = ~/.scion.projects/<slug>. localBackend.Resolve must
+	// return exactly that path as HostPath.
+	projectPath := "/home/scion/.scion.projects/my-project-slug"
+
+	b := NewLocalBackend()
+	res, err := b.Resolve(ResolveInput{
+		ProjectDir: projectPath,
+		ProjectID:  "proj-uuid",
+		Mode:       store.SharingModeSharedPlain,
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if res.HostPath != projectPath {
+		t.Errorf("localBackend.Resolve HostPath = %q, want %q (pre-existing path)", res.HostPath, projectPath)
+	}
+}
+
+// --- Realize tests ---
+
+func TestLocalBackendRealize(t *testing.T) {
+	b := NewLocalBackend()
+	desc, err := b.Realize(RealizeInput{
+		Resolved: ResolvedWorkspace{
+			HostPath: "/home/scion/.scion.projects/my-project",
+			Backend:  "local",
+		},
+		ContainerWorkspace: "/workspace",
+	})
+	if err != nil {
+		t.Fatalf("Realize: %v", err)
+	}
+
+	if desc.Type != "local" {
+		t.Errorf("Type = %q, want %q", desc.Type, "local")
+	}
+	if desc.HostPath != "/home/scion/.scion.projects/my-project" {
+		t.Errorf("HostPath = %q, want the resolved path", desc.HostPath)
+	}
+	if desc.Target != "/workspace" {
+		t.Errorf("Target = %q, want %q", desc.Target, "/workspace")
+	}
+}
+
+func TestLocalBackendRealize_DefaultTarget(t *testing.T) {
+	b := NewLocalBackend()
+	desc, err := b.Realize(RealizeInput{
+		Resolved: ResolvedWorkspace{
+			HostPath: "/some/path",
+			Backend:  "local",
+		},
+		ContainerWorkspace: "", // should default to /workspace
+	})
+	if err != nil {
+		t.Fatalf("Realize: %v", err)
+	}
+	if desc.Target != "/workspace" {
+		t.Errorf("Target = %q, want %q (default)", desc.Target, "/workspace")
+	}
+}
+
+func TestNFSBackendRealize(t *testing.T) {
+	nfsCfg := &config.V1NFSConfig{
+		MountRoot:   "/mnt/nfs",
+		SubPathRoot: "projects",
+		Shares: []config.V1NFSShare{
+			{ID: "share1", Server: "10.0.0.2", Export: "/scion-workspaces"},
+		},
+	}
+	b := NewNFSBackend(nfsCfg)
+
+	desc, err := b.Realize(RealizeInput{
+		Resolved: ResolvedWorkspace{
+			HostPath:           "/mnt/nfs/share1/projects/proj1/workspace",
+			ServerRelativePath: "projects/proj1/workspace",
+			HostBase:           "/mnt/nfs/share1",
+			Backend:            "nfs",
+		},
+		ContainerWorkspace: "/workspace",
+	})
+	if err != nil {
+		t.Fatalf("Realize: %v", err)
+	}
+
+	if desc.Type != "nfs" {
+		t.Errorf("Type = %q, want %q", desc.Type, "nfs")
+	}
+	if desc.HostPath != "/mnt/nfs/share1/projects/proj1/workspace" {
+		t.Errorf("HostPath = %q, want the NFS host path", desc.HostPath)
+	}
+	if desc.Target != "/workspace" {
+		t.Errorf("Target = %q, want %q", desc.Target, "/workspace")
+	}
+	if desc.SubPath != "projects/proj1/workspace" {
+		t.Errorf("SubPath = %q, want the server-relative path", desc.SubPath)
+	}
+}
+
+// --- Backend Name tests ---
+
+func TestBackendNames(t *testing.T) {
+	local := NewLocalBackend()
+	if local.Name() != "local" {
+		t.Errorf("local backend Name() = %q, want %q", local.Name(), "local")
+	}
+
+	nfsCfg := &config.V1NFSConfig{
+		MountRoot: "/mnt/nfs",
+		Shares: []config.V1NFSShare{
+			{ID: "s1", Server: "10.0.0.2", Export: "/ws"},
+		},
+	}
+	nfs := NewNFSBackend(nfsCfg)
+	if nfs.Name() != "nfs" {
+		t.Errorf("nfs backend Name() = %q, want %q", nfs.Name(), "nfs")
+	}
+}
+
+// --- Provision stub tests ---
+
+func TestLocalBackendProvision_NoOp(t *testing.T) {
+	b := NewLocalBackend()
+	err := b.Provision(ProvisionInput{
+		ProjectID: "proj1",
+		Mode:      store.SharingModeSharedPlain,
+	})
+	if err != nil {
+		t.Errorf("localBackend.Provision should be no-op, got error: %v", err)
+	}
+}
+
+func TestNFSBackendProvision_Stub(t *testing.T) {
+	nfsCfg := &config.V1NFSConfig{
+		MountRoot: "/mnt/nfs",
+		Shares: []config.V1NFSShare{
+			{ID: "s1", Server: "10.0.0.2", Export: "/ws"},
+		},
+	}
+	b := NewNFSBackend(nfsCfg)
+	err := b.Provision(ProvisionInput{
+		ProjectID: "proj1",
+		Mode:      store.SharingModeSharedPlain,
+	})
+	if err != nil {
+		t.Errorf("nfsBackend.Provision stub should return nil, got error: %v", err)
+	}
+}

--- a/pkg/runtime/workspace_backend_test.go
+++ b/pkg/runtime/workspace_backend_test.go
@@ -668,19 +668,28 @@ func TestLocalBackendProvision_NoOp(t *testing.T) {
 	}
 }
 
-func TestNFSBackendProvision_Stub(t *testing.T) {
+func TestNFSBackendProvision_NonGit(t *testing.T) {
+	mountRoot := t.TempDir()
 	nfsCfg := &config.V1NFSConfig{
-		MountRoot: "/mnt/nfs",
+		MountRoot: mountRoot,
 		Shares: []config.V1NFSShare{
 			{ID: "s1", Server: "10.0.0.2", Export: "/ws"},
 		},
 	}
 	b := NewNFSBackend(nfsCfg)
-	err := b.Provision(ProvisionInput{
+	res, err := b.Resolve(ResolveInput{
 		ProjectID: "proj1",
 		Mode:      store.SharingModeSharedPlain,
 	})
 	if err != nil {
-		t.Errorf("nfsBackend.Provision stub should return nil, got error: %v", err)
+		t.Fatalf("Resolve: %v", err)
+	}
+	err = b.Provision(ProvisionInput{
+		Resolved:  res,
+		ProjectID: "proj1",
+		Mode:      store.SharingModeSharedPlain,
+	})
+	if err != nil {
+		t.Errorf("nfsBackend.Provision for non-git project should succeed, got error: %v", err)
 	}
 }

--- a/pkg/runtime/workspace_backend_test.go
+++ b/pkg/runtime/workspace_backend_test.go
@@ -464,10 +464,10 @@ func TestNFSResolve_SubPathRootDefault(t *testing.T) {
 
 func TestLocalBackendResolve(t *testing.T) {
 	tests := []struct {
-		name       string
-		input      ResolveInput
-		wantErr    bool
-		wantPath   string
+		name        string
+		input       ResolveInput
+		wantErr     bool
+		wantPath    string
 		wantBackend string
 	}{
 		{

--- a/pkg/runtime/workspace_cleanup.go
+++ b/pkg/runtime/workspace_cleanup.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// CleanupNFSProject removes the NFS project subtree for a given project ID.
+// This mirrors the K8s-side cleanupSharedDirPVCs (k8s_runtime.go:753-770)
+// for the Docker/VM NFS model.
+//
+// The target path is <MountRoot>/<shareID>/projects/<projectID>/, which
+// contains the workspace and shared-dirs subdirectories.
+//
+// Isolation guard: refuses to delete the share root or any path that is not
+// a proper subdirectory of the share mount. This uses the same
+// ValidateNotExportRoot guard as Realize (design §9.4).
+//
+// Idempotent: returns nil if the directory does not exist.
+func CleanupNFSProject(cfg *config.V1NFSConfig, projectID string) error {
+	if cfg == nil {
+		return fmt.Errorf("CleanupNFSProject: NFS config is nil")
+	}
+	if projectID == "" {
+		return fmt.Errorf("CleanupNFSProject: projectID is required")
+	}
+	if len(cfg.Shares) == 0 {
+		return fmt.Errorf("CleanupNFSProject: no NFS shares configured")
+	}
+
+	subPathRoot := cfg.SubPathRoot
+	if subPathRoot == "" {
+		subPathRoot = "projects"
+	}
+
+	share := cfg.Shares[0]
+	hostBase := filepath.Join(cfg.MountRoot, share.ID)
+
+	// Compute the project subtree path: <MountRoot>/<shareID>/<SubPathRoot>/<projectID>/
+	projectPath := filepath.Join(hostBase, subPathRoot, projectID)
+
+	// Isolation guard: the target must be a proper subdirectory of the host
+	// base (share mount), NEVER the share root itself. This prevents
+	// accidental deletion of the entire NFS share.
+	if err := ValidateNotExportRoot(projectPath, hostBase); err != nil {
+		return fmt.Errorf("CleanupNFSProject: %w", err)
+	}
+
+	// Additional safety: the resolved path must be under the projects subtree.
+	// This catches path traversal attempts (e.g. projectID = "../../something").
+	cleanPath := filepath.Clean(projectPath)
+	cleanBase := filepath.Clean(filepath.Join(hostBase, subPathRoot))
+	if len(cleanPath) <= len(cleanBase) || cleanPath[:len(cleanBase)] != cleanBase {
+		return fmt.Errorf("CleanupNFSProject: path traversal detected: %q is not under %q",
+			projectPath, filepath.Join(hostBase, subPathRoot))
+	}
+
+	// Idempotent: if the directory doesn't exist, nothing to do.
+	if _, err := os.Stat(projectPath); os.IsNotExist(err) {
+		slog.Debug("CleanupNFSProject: project subtree does not exist (already cleaned)",
+			"project_id", projectID, "path", projectPath)
+		return nil
+	}
+
+	slog.Info("CleanupNFSProject: removing project subtree",
+		"project_id", projectID, "path", projectPath)
+
+	if err := os.RemoveAll(projectPath); err != nil {
+		return fmt.Errorf("CleanupNFSProject: rm -rf %s: %w", projectPath, err)
+	}
+
+	slog.Info("CleanupNFSProject: project subtree removed",
+		"project_id", projectID, "path", projectPath)
+	return nil
+}

--- a/pkg/runtime/workspace_cleanup_test.go
+++ b/pkg/runtime/workspace_cleanup_test.go
@@ -1,0 +1,220 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+func testNFSCleanupConfig(t *testing.T) (*config.V1NFSConfig, string) {
+	t.Helper()
+	mountRoot := t.TempDir()
+	cfg := &config.V1NFSConfig{
+		MountRoot:   mountRoot,
+		SubPathRoot: "projects",
+		Shares: []config.V1NFSShare{
+			{ID: "share1", Server: "10.0.0.2", Export: "/scion-workspaces"},
+		},
+	}
+	return cfg, mountRoot
+}
+
+// createProjectSubtree creates a project subtree structure for testing.
+func createProjectSubtree(t *testing.T, mountRoot, shareID, projectID string) string {
+	t.Helper()
+	projectPath := filepath.Join(mountRoot, shareID, "projects", projectID)
+	wsPath := filepath.Join(projectPath, "workspace")
+	sdPath := filepath.Join(projectPath, "shared-dirs", "data")
+
+	if err := os.MkdirAll(wsPath, 0770); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sdPath, 0770); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write some files to verify deletion.
+	if err := os.WriteFile(filepath.Join(wsPath, "test.txt"), []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectPath, ".scion-provisioned"), []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	return projectPath
+}
+
+// --- Basic cleanup ---
+
+func TestCleanupNFSProject_RemovesSubtree(t *testing.T) {
+	cfg, mountRoot := testNFSCleanupConfig(t)
+	projectPath := createProjectSubtree(t, mountRoot, "share1", "proj-1")
+
+	// Verify structure exists.
+	if _, err := os.Stat(projectPath); err != nil {
+		t.Fatalf("project subtree should exist: %v", err)
+	}
+
+	err := CleanupNFSProject(cfg, "proj-1")
+	if err != nil {
+		t.Fatalf("CleanupNFSProject: %v", err)
+	}
+
+	// Verify project subtree is gone.
+	if _, err := os.Stat(projectPath); !os.IsNotExist(err) {
+		t.Errorf("project subtree should be deleted, but still exists")
+	}
+
+	// Verify the share root still exists.
+	shareRoot := filepath.Join(mountRoot, "share1")
+	if _, err := os.Stat(shareRoot); err != nil {
+		t.Errorf("share root should still exist: %v", err)
+	}
+}
+
+// --- Idempotent: non-existent project is a no-op ---
+
+func TestCleanupNFSProject_Idempotent(t *testing.T) {
+	cfg, _ := testNFSCleanupConfig(t)
+
+	// No subtree exists — should succeed silently.
+	err := CleanupNFSProject(cfg, "nonexistent-project")
+	if err != nil {
+		t.Fatalf("cleanup of nonexistent project should be idempotent: %v", err)
+	}
+}
+
+// --- Double cleanup ---
+
+func TestCleanupNFSProject_DoubleCleanup(t *testing.T) {
+	cfg, mountRoot := testNFSCleanupConfig(t)
+	createProjectSubtree(t, mountRoot, "share1", "proj-double")
+
+	if err := CleanupNFSProject(cfg, "proj-double"); err != nil {
+		t.Fatalf("first cleanup: %v", err)
+	}
+	if err := CleanupNFSProject(cfg, "proj-double"); err != nil {
+		t.Fatalf("second cleanup should be idempotent: %v", err)
+	}
+}
+
+// --- Isolation: refuses share root ---
+
+func TestCleanupNFSProject_RefusesShareRoot(t *testing.T) {
+	cfg := &config.V1NFSConfig{
+		MountRoot:   "/mnt/nfs",
+		SubPathRoot: "",
+		Shares: []config.V1NFSShare{
+			{ID: "", Server: "10.0.0.2", Export: "/ws"},
+		},
+	}
+
+	// An empty projectID would compute a path that equals the base.
+	err := CleanupNFSProject(cfg, "")
+	if err == nil {
+		t.Fatal("should refuse empty project ID")
+	}
+}
+
+// --- Isolation: refuses path traversal ---
+
+func TestCleanupNFSProject_RefusesPathTraversal(t *testing.T) {
+	cfg, _ := testNFSCleanupConfig(t)
+
+	err := CleanupNFSProject(cfg, "../../etc")
+	if err == nil {
+		t.Fatal("should refuse path traversal")
+	}
+}
+
+// --- Does not affect other projects ---
+
+func TestCleanupNFSProject_IsolatesProjects(t *testing.T) {
+	cfg, mountRoot := testNFSCleanupConfig(t)
+
+	projAPath := createProjectSubtree(t, mountRoot, "share1", "proj-A")
+	projBPath := createProjectSubtree(t, mountRoot, "share1", "proj-B")
+
+	// Delete project A.
+	if err := CleanupNFSProject(cfg, "proj-A"); err != nil {
+		t.Fatalf("cleanup proj-A: %v", err)
+	}
+
+	// Project A is gone.
+	if _, err := os.Stat(projAPath); !os.IsNotExist(err) {
+		t.Error("proj-A should be deleted")
+	}
+
+	// Project B is untouched.
+	if _, err := os.Stat(projBPath); err != nil {
+		t.Errorf("proj-B should still exist: %v", err)
+	}
+
+	// Files in B are intact.
+	bFile := filepath.Join(projBPath, "workspace", "test.txt")
+	if _, err := os.Stat(bFile); err != nil {
+		t.Errorf("proj-B workspace file should be intact: %v", err)
+	}
+}
+
+// --- Nil config ---
+
+func TestCleanupNFSProject_NilConfig(t *testing.T) {
+	err := CleanupNFSProject(nil, "proj-1")
+	if err == nil {
+		t.Fatal("should error on nil config")
+	}
+}
+
+// --- No shares ---
+
+func TestCleanupNFSProject_NoShares(t *testing.T) {
+	cfg := &config.V1NFSConfig{
+		MountRoot: "/mnt/nfs",
+		Shares:    nil,
+	}
+	err := CleanupNFSProject(cfg, "proj-1")
+	if err == nil {
+		t.Fatal("should error on no shares")
+	}
+}
+
+// --- SubPathRoot defaults ---
+
+func TestCleanupNFSProject_SubPathRootDefault(t *testing.T) {
+	mountRoot := t.TempDir()
+	cfg := &config.V1NFSConfig{
+		MountRoot:   mountRoot,
+		SubPathRoot: "", // should default to "projects"
+		Shares: []config.V1NFSShare{
+			{ID: "share1", Server: "10.0.0.2", Export: "/ws"},
+		},
+	}
+
+	// Create the subtree at the default path.
+	projectPath := createProjectSubtree(t, mountRoot, "share1", "proj-default")
+
+	if err := CleanupNFSProject(cfg, "proj-default"); err != nil {
+		t.Fatalf("cleanup with default SubPathRoot: %v", err)
+	}
+
+	if _, err := os.Stat(projectPath); !os.IsNotExist(err) {
+		t.Error("project subtree should be deleted")
+	}
+}

--- a/pkg/runtime/workspace_provision_test.go
+++ b/pkg/runtime/workspace_provision_test.go
@@ -1,0 +1,661 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// testLocker is a mock AdvisoryLocker for testing.
+type testLocker struct {
+	mu       sync.Mutex
+	held     map[lockKey]bool
+	acquires int64
+}
+
+type lockKey struct {
+	classID int64
+	objID   int32
+	single  bool // true for single-int form
+}
+
+func newTestLocker() *testLocker {
+	return &testLocker{held: make(map[lockKey]bool)}
+}
+
+func (l *testLocker) TryAdvisoryLock(ctx context.Context, key store.AdvisoryLockKey) (bool, func() error, error) {
+	k := lockKey{classID: int64(key), single: true}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.held[k] {
+		return false, func() error { return nil }, nil
+	}
+	l.held[k] = true
+	atomic.AddInt64(&l.acquires, 1)
+	return true, func() error {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		delete(l.held, k)
+		return nil
+	}, nil
+}
+
+func (l *testLocker) TryAdvisoryLockObject(ctx context.Context, classID store.AdvisoryLockKey, objID int32) (bool, func() error, error) {
+	k := lockKey{classID: int64(classID), objID: objID}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.held[k] {
+		return false, func() error { return nil }, nil
+	}
+	l.held[k] = true
+	atomic.AddInt64(&l.acquires, 1)
+	return true, func() error {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		delete(l.held, k)
+		return nil
+	}, nil
+}
+
+// nfsTestBackend creates an nfsBackend with a temp directory as the mount root
+// and returns the backend, config, and project paths.
+func nfsTestBackend(t *testing.T) (*nfsBackend, *config.V1NFSConfig, string) {
+	t.Helper()
+	mountRoot := t.TempDir()
+	cfg := &config.V1NFSConfig{
+		MountRoot:   mountRoot,
+		SubPathRoot: "projects",
+		Shares: []config.V1NFSShare{
+			{ID: "share1", Server: "10.0.0.2", Export: "/scion-workspaces"},
+		},
+	}
+	b := &nfsBackend{cfg: cfg}
+	return b, cfg, mountRoot
+}
+
+// resolveForTest resolves workspace paths for a test project.
+func resolveForTest(t *testing.T, b WorkspaceBackend, projectID string) ResolvedWorkspace {
+	t.Helper()
+	res, err := b.Resolve(ResolveInput{
+		ProjectID: projectID,
+		Mode:      store.SharingModeSharedPlain,
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	return res
+}
+
+// initBareGitRepo creates a bare git repo at the given path for cloning from.
+func initBareGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	bareDir := filepath.Join(dir, "bare.git")
+	run(t, "git", "init", "--bare", "--initial-branch=main", bareDir)
+
+	// Create a working clone to make an initial commit.
+	workDir := filepath.Join(dir, "work")
+	run(t, "git", "clone", bareDir, workDir)
+
+	// Create an initial commit so the repo has a HEAD.
+	f := filepath.Join(workDir, "README.md")
+	if err := os.WriteFile(f, []byte("# Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runIn(t, workDir, "git", "add", "README.md")
+	runIn(t, workDir, "git", "-c", "user.name=test", "-c", "user.email=test@test.com",
+		"commit", "-m", "initial")
+	runIn(t, workDir, "git", "push", "origin", "main")
+
+	return bareDir
+}
+
+func run(t *testing.T, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%s %v: %s\n%s", name, args, err, output)
+	}
+}
+
+func runIn(t *testing.T, dir, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%s %v (in %s): %s\n%s", name, args, dir, err, output)
+	}
+}
+
+// --- ClonePerAgent rejection ---
+
+func TestNFSProvision_RejectsClonePerAgent(t *testing.T) {
+	b, _, _ := nfsTestBackend(t)
+	err := b.Provision(ProvisionInput{
+		ProjectID: "proj-1",
+		Mode:      store.SharingModeClonePerAgent,
+		Resolved: ResolvedWorkspace{
+			HostPath: "/some/path",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for ClonePerAgent on NFS backend")
+	}
+	if !strings.Contains(err.Error(), "ClonePerAgent") {
+		t.Errorf("error should mention ClonePerAgent, got: %v", err)
+	}
+}
+
+// --- SharedPlain provisioning without git ---
+
+func TestNFSProvision_SharedPlain_NonGit(t *testing.T) {
+	b, _, mountRoot := nfsTestBackend(t)
+	locker := newTestLocker()
+
+	projectID := "proj-nonGit-1"
+	res, err := b.Resolve(ResolveInput{
+		ProjectID: projectID,
+		Mode:      store.SharingModeSharedPlain,
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	err = b.Provision(ProvisionInput{
+		Resolved:  res,
+		ProjectID: projectID,
+		Mode:      store.SharingModeSharedPlain,
+		Locker:    locker,
+	})
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	// Verify workspace directory was created.
+	if _, err := os.Stat(res.HostPath); err != nil {
+		t.Errorf("workspace dir not created: %v", err)
+	}
+
+	// Verify sentinel was written.
+	sentinelPath := filepath.Join(filepath.Dir(res.HostPath), provisionSentinelFile)
+	if _, err := os.Stat(sentinelPath); err != nil {
+		t.Errorf("sentinel not written: %v", err)
+	}
+
+	// Verify lock was acquired.
+	if atomic.LoadInt64(&locker.acquires) != 1 {
+		t.Errorf("expected 1 lock acquire, got %d", atomic.LoadInt64(&locker.acquires))
+	}
+
+	_ = mountRoot
+}
+
+// --- SharedPlain provisioning with git clone ---
+
+func TestNFSProvision_SharedPlain_GitClone(t *testing.T) {
+	b, _, _ := nfsTestBackend(t)
+	locker := newTestLocker()
+
+	bareRepo := initBareGitRepo(t)
+	projectID := "proj-git-1"
+	res, err := b.Resolve(ResolveInput{
+		ProjectID: projectID,
+		Mode:      store.SharingModeSharedPlain,
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	err = b.Provision(ProvisionInput{
+		Resolved:  res,
+		ProjectID: projectID,
+		Mode:      store.SharingModeSharedPlain,
+		Locker:    locker,
+		GitClone: &api.GitCloneConfig{
+			URL:    bareRepo,
+			Branch: "main",
+			Depth:  1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	// Verify .git directory exists (git clone succeeded).
+	if _, err := os.Stat(filepath.Join(res.HostPath, ".git")); err != nil {
+		t.Errorf("git clone did not create .git: %v", err)
+	}
+
+	// Verify README.md was cloned.
+	if _, err := os.Stat(filepath.Join(res.HostPath, "README.md")); err != nil {
+		t.Errorf("git clone did not bring README.md: %v", err)
+	}
+
+	// Verify sentinel.
+	sentinelPath := filepath.Join(filepath.Dir(res.HostPath), provisionSentinelFile)
+	if _, err := os.Stat(sentinelPath); err != nil {
+		t.Errorf("sentinel not written: %v", err)
+	}
+}
+
+// --- Idempotent: second Provision is a no-op (sentinel short-circuits) ---
+
+func TestNFSProvision_Idempotent(t *testing.T) {
+	b, _, _ := nfsTestBackend(t)
+	locker := newTestLocker()
+
+	bareRepo := initBareGitRepo(t)
+	projectID := "proj-idem-1"
+	res, err := b.Resolve(ResolveInput{
+		ProjectID: projectID,
+		Mode:      store.SharingModeSharedPlain,
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	input := ProvisionInput{
+		Resolved:  res,
+		ProjectID: projectID,
+		Mode:      store.SharingModeSharedPlain,
+		Locker:    locker,
+		GitClone: &api.GitCloneConfig{
+			URL:    bareRepo,
+			Branch: "main",
+			Depth:  1,
+		},
+	}
+
+	// First provision.
+	if err := b.Provision(input); err != nil {
+		t.Fatalf("first Provision: %v", err)
+	}
+
+	// Second provision — should succeed without re-cloning.
+	if err := b.Provision(input); err != nil {
+		t.Fatalf("second Provision: %v", err)
+	}
+
+	// Lock acquired twice (once per call — lock is always acquired, sentinel
+	// check happens after lock).
+	if got := atomic.LoadInt64(&locker.acquires); got != 2 {
+		t.Errorf("expected 2 lock acquires, got %d", got)
+	}
+}
+
+// --- Sentinel short-circuit: no re-clone even with git config ---
+
+func TestNFSProvision_SentinelShortCircuits(t *testing.T) {
+	b, _, _ := nfsTestBackend(t)
+	locker := newTestLocker()
+
+	projectID := "proj-sentinel-1"
+	res, err := b.Resolve(ResolveInput{
+		ProjectID: projectID,
+		Mode:      store.SharingModeSharedPlain,
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// Pre-create workspace dir and sentinel (simulating prior provisioning).
+	if err := os.MkdirAll(res.HostPath, 0770); err != nil {
+		t.Fatal(err)
+	}
+	projectRoot := filepath.Dir(res.HostPath)
+	sentinelPath := filepath.Join(projectRoot, provisionSentinelFile)
+	if err := os.WriteFile(sentinelPath, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Provision with a git URL that would fail if actually attempted.
+	err = b.Provision(ProvisionInput{
+		Resolved:  res,
+		ProjectID: projectID,
+		Mode:      store.SharingModeSharedPlain,
+		Locker:    locker,
+		GitClone: &api.GitCloneConfig{
+			URL: "https://nonexistent.example.com/repo.git",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Provision with sentinel should succeed: %v", err)
+	}
+}
+
+// --- WorktreePerAgent: creates worktree on shared checkout ---
+
+func TestNFSProvision_WorktreePerAgent(t *testing.T) {
+	b, _, _ := nfsTestBackend(t)
+	locker := newTestLocker()
+
+	bareRepo := initBareGitRepo(t)
+	projectID := "proj-wt-1"
+	agentID := "agent-wt-1"
+
+	res, err := b.Resolve(ResolveInput{
+		ProjectID: projectID,
+		Mode:      store.SharingModeWorktreePerAgent,
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	err = b.Provision(ProvisionInput{
+		Resolved:  res,
+		ProjectID: projectID,
+		AgentID:   agentID,
+		AgentName: "test-agent",
+		Mode:      store.SharingModeWorktreePerAgent,
+		Locker:    locker,
+		GitClone: &api.GitCloneConfig{
+			URL:    bareRepo,
+			Branch: "main",
+			Depth:  0, // full clone needed for worktrees
+		},
+	})
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	// Verify worktree was created.
+	worktreePath := filepath.Join(res.HostPath, "worktrees", agentID)
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Errorf("worktree not created at %s: %v", worktreePath, err)
+	}
+
+	// Verify .git pointer file exists in worktree (git worktree add creates it).
+	gitFile := filepath.Join(worktreePath, ".git")
+	if _, err := os.Stat(gitFile); err != nil {
+		t.Errorf("worktree .git file not found: %v", err)
+	}
+}
+
+// --- WorktreePerAgent: second agent gets independent worktree ---
+
+func TestNFSProvision_WorktreePerAgent_TwoAgents(t *testing.T) {
+	b, _, _ := nfsTestBackend(t)
+	locker := newTestLocker()
+
+	bareRepo := initBareGitRepo(t)
+	projectID := "proj-wt-2"
+
+	res, err := b.Resolve(ResolveInput{
+		ProjectID: projectID,
+		Mode:      store.SharingModeWorktreePerAgent,
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// First agent.
+	err = b.Provision(ProvisionInput{
+		Resolved:  res,
+		ProjectID: projectID,
+		AgentID:   "agent-1",
+		AgentName: "first-agent",
+		Mode:      store.SharingModeWorktreePerAgent,
+		Locker:    locker,
+		GitClone: &api.GitCloneConfig{
+			URL:    bareRepo,
+			Branch: "main",
+			Depth:  0,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Provision agent-1: %v", err)
+	}
+
+	// Second agent (sentinel exists, so clone is skipped — just adds worktree).
+	err = b.Provision(ProvisionInput{
+		Resolved:  res,
+		ProjectID: projectID,
+		AgentID:   "agent-2",
+		AgentName: "second-agent",
+		Mode:      store.SharingModeWorktreePerAgent,
+		Locker:    locker,
+		GitClone: &api.GitCloneConfig{
+			URL:    bareRepo,
+			Branch: "main",
+			Depth:  0,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Provision agent-2: %v", err)
+	}
+
+	// Both worktrees exist and are independent.
+	wt1 := filepath.Join(res.HostPath, "worktrees", "agent-1")
+	wt2 := filepath.Join(res.HostPath, "worktrees", "agent-2")
+	if _, err := os.Stat(wt1); err != nil {
+		t.Errorf("worktree agent-1 not found: %v", err)
+	}
+	if _, err := os.Stat(wt2); err != nil {
+		t.Errorf("worktree agent-2 not found: %v", err)
+	}
+}
+
+// --- Per-project lock independence ---
+
+func TestNFSProvision_LockPerProject_Independent(t *testing.T) {
+	b, _, _ := nfsTestBackend(t)
+	locker := newTestLocker()
+
+	// Two different projects should get independent locks.
+	hash1 := store.StableProjectHash("proj-A")
+	hash2 := store.StableProjectHash("proj-B")
+	if hash1 == hash2 {
+		t.Skip("hash collision — extremely unlikely but skip test")
+	}
+
+	res1, _ := b.Resolve(ResolveInput{ProjectID: "proj-A", Mode: store.SharingModeSharedPlain})
+	res2, _ := b.Resolve(ResolveInput{ProjectID: "proj-B", Mode: store.SharingModeSharedPlain})
+
+	// Provision both — they should not block each other.
+	if err := b.Provision(ProvisionInput{
+		Resolved: res1, ProjectID: "proj-A", Mode: store.SharingModeSharedPlain, Locker: locker,
+	}); err != nil {
+		t.Fatalf("Provision proj-A: %v", err)
+	}
+	if err := b.Provision(ProvisionInput{
+		Resolved: res2, ProjectID: "proj-B", Mode: store.SharingModeSharedPlain, Locker: locker,
+	}); err != nil {
+		t.Fatalf("Provision proj-B: %v", err)
+	}
+
+	if got := atomic.LoadInt64(&locker.acquires); got != 2 {
+		t.Errorf("expected 2 lock acquires (one per project), got %d", got)
+	}
+}
+
+// --- Same project, same lock (mutual exclusion) ---
+
+func TestNFSProvision_LockPerProject_MutualExclusion(t *testing.T) {
+	b, _, _ := nfsTestBackend(t)
+
+	// A locker that simulates a lock already held by another node.
+	blockedLocker := &blockingLocker{blockedUntil: 3} // first 3 attempts blocked
+
+	res, _ := b.Resolve(ResolveInput{ProjectID: "proj-locked", Mode: store.SharingModeSharedPlain})
+
+	err := b.Provision(ProvisionInput{
+		Resolved:  res,
+		ProjectID: "proj-locked",
+		Mode:      store.SharingModeSharedPlain,
+		Locker:    blockedLocker,
+	})
+	if err != nil {
+		t.Fatalf("Provision should eventually succeed after retries: %v", err)
+	}
+
+	// Verify it retried the expected number of times.
+	if got := atomic.LoadInt64(&blockedLocker.attempts); got != 4 {
+		t.Errorf("expected 4 attempts (3 blocked + 1 success), got %d", got)
+	}
+}
+
+// blockingLocker simulates a lock held by another node for the first N attempts.
+type blockingLocker struct {
+	blockedUntil int64
+	attempts     int64
+}
+
+func (l *blockingLocker) TryAdvisoryLock(ctx context.Context, key store.AdvisoryLockKey) (bool, func() error, error) {
+	return true, func() error { return nil }, nil
+}
+
+func (l *blockingLocker) TryAdvisoryLockObject(ctx context.Context, classID store.AdvisoryLockKey, objID int32) (bool, func() error, error) {
+	attempt := atomic.AddInt64(&l.attempts, 1)
+	if attempt <= l.blockedUntil {
+		return false, func() error { return nil }, nil
+	}
+	return true, func() error { return nil }, nil
+}
+
+// --- No locker: degrades gracefully ---
+
+func TestNFSProvision_NoLocker_DegradedMode(t *testing.T) {
+	b, _, _ := nfsTestBackend(t)
+
+	res, _ := b.Resolve(ResolveInput{ProjectID: "proj-nolock", Mode: store.SharingModeSharedPlain})
+
+	err := b.Provision(ProvisionInput{
+		Resolved:  res,
+		ProjectID: "proj-nolock",
+		Mode:      store.SharingModeSharedPlain,
+		Locker:    nil, // no locker
+	})
+	if err != nil {
+		t.Fatalf("Provision without locker should succeed: %v", err)
+	}
+}
+
+// --- Missing required fields ---
+
+func TestNFSProvision_MissingHostPath(t *testing.T) {
+	b, _, _ := nfsTestBackend(t)
+	err := b.Provision(ProvisionInput{
+		ProjectID: "proj-1",
+		Mode:      store.SharingModeSharedPlain,
+		Resolved:  ResolvedWorkspace{},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty HostPath")
+	}
+}
+
+func TestNFSProvision_MissingProjectID(t *testing.T) {
+	b, _, _ := nfsTestBackend(t)
+	err := b.Provision(ProvisionInput{
+		Mode: store.SharingModeSharedPlain,
+		Resolved: ResolvedWorkspace{
+			HostPath: "/some/path",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty ProjectID")
+	}
+}
+
+// --- WorktreePerAgent missing AgentID ---
+
+func TestNFSProvision_WorktreePerAgent_MissingAgentID(t *testing.T) {
+	b, _, _ := nfsTestBackend(t)
+	locker := newTestLocker()
+
+	bareRepo := initBareGitRepo(t)
+	res, _ := b.Resolve(ResolveInput{ProjectID: "proj-noagent", Mode: store.SharingModeWorktreePerAgent})
+
+	err := b.Provision(ProvisionInput{
+		Resolved:  res,
+		ProjectID: "proj-noagent",
+		AgentID:   "", // missing
+		Mode:      store.SharingModeWorktreePerAgent,
+		Locker:    locker,
+		GitClone: &api.GitCloneConfig{
+			URL:    bareRepo,
+			Branch: "main",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing AgentID in WorktreePerAgent")
+	}
+}
+
+// --- sanitizeBranchName ---
+
+func TestSanitizeBranchName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple", "simple"},
+		{"with spaces", "with-spaces"},
+		{"with/slash", "with-slash"},
+		{"with..dots", "with-dots"},
+		{"with~tilde", "with-tilde"},
+		{".leading-dot", "leading-dot"},
+		{"-leading-dash", "leading-dash"},
+		{"trailing-.", "trailing"},
+		{"", "agent"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := sanitizeBranchName(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeBranchName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- writeSentinel ---
+
+func TestWriteSentinel_Atomic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, provisionSentinelFile)
+
+	if err := writeSentinel(path); err != nil {
+		t.Fatalf("writeSentinel: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read sentinel: %v", err)
+	}
+	if !strings.Contains(string(data), "provisioned_at=") {
+		t.Errorf("sentinel content unexpected: %s", string(data))
+	}
+
+	// Overwrite should also work (idempotent).
+	if err := writeSentinel(path); err != nil {
+		t.Fatalf("writeSentinel overwrite: %v", err)
+	}
+}
+

--- a/pkg/runtime/workspace_provision_test.go
+++ b/pkg/runtime/workspace_provision_test.go
@@ -658,4 +658,3 @@ func TestWriteSentinel_Atomic(t *testing.T) {
 		t.Fatalf("writeSentinel overwrite: %v", err)
 	}
 }
-

--- a/pkg/runtimebroker/NFS_DEPLOY_NOTES.md
+++ b/pkg/runtimebroker/NFS_DEPLOY_NOTES.md
@@ -39,12 +39,37 @@ During the NM1 live gate the broker container ran as `uid=1002` while
 ## Mount Privilege
 
 The broker process requires mount privilege to auto-mount NFS shares at
-startup (see `NFSMountReconciler`). Options:
+startup (see `NFSMountReconciler`). Options, in order of preference:
 
-- Run the broker as root (not recommended for production).
-- Grant `CAP_SYS_ADMIN` via `setcap` or K8s `securityContext.capabilities`.
 - Configure `/etc/sudoers` to allow the broker user to run `mount`/`umount`
-  without a password.
+  without a password, and have the reconciler invoke `sudo mount` (recommended
+  for a non-root service).
+- Run the broker as root.
+
+### Important (NM1b finding): `CAP_SYS_ADMIN` alone is NOT sufficient
+
+The userspace `mount.nfs`/`mount.nfs4` helper **checks `uid == 0` explicitly**
+(not Linux capabilities), so granting `CAP_SYS_ADMIN` via `setcap` or a K8s
+`securityContext.capabilities` add does **not** let a non-root broker run
+`mount -t nfs`. During NM1b the service had to run as `User=root` for the
+helper to succeed. To run unprivileged, use the `sudo mount` wrapper above, or
+have the reconciler call the `mount(2)` syscall directly (which does honor
+`CAP_SYS_ADMIN`) rather than shelling out to the `mount.nfs` helper.
+
+## Config: `schema_version` required (NM1b finding)
+
+`settings.yaml` **must** include `schema_version: "1"` when it contains a
+`server.workspace_storage` block. A config without `schema_version` is treated
+as legacy and auto-migrated to v1; the legacy→v1 migration does **not** carry
+the `workspace_storage` block, so it is silently stripped. Always set:
+
+```yaml
+schema_version: "1"
+server:
+  workspace_storage:
+    backend: nfs
+    nfs: { ... }
+```
 
 ## NFSv3 Default
 

--- a/pkg/runtimebroker/NFS_DEPLOY_NOTES.md
+++ b/pkg/runtimebroker/NFS_DEPLOY_NOTES.md
@@ -1,0 +1,55 @@
+# NFS Workspace Storage — Deploy Notes
+
+## Broker Service UID/GID Alignment
+
+The broker service user's UID and GID **must** match the `NFS.UID` and
+`NFS.GID` values in `settings.yaml` (default: `1000:1000`).
+
+When the broker provisions NFS-backed workspaces (clone, chown under the
+Postgres advisory lock), it writes files using its own on-wire UID/GID.
+Agent containers also run as `NFS.UID:GID`. If these differ, the broker
+creates files that the container user cannot write to (or vice versa),
+causing permission errors on NFS.
+
+### How to verify
+
+```bash
+# On the broker host / container:
+id    # should show uid=1000(scion) gid=1000(scion)
+
+# In settings.yaml:
+# server:
+#   workspace_storage:
+#     backend: nfs
+#     nfs:
+#       uid: 1000
+#       gid: 1000
+```
+
+### Common issue (NM1 finding)
+
+During the NM1 live gate the broker container ran as `uid=1002` while
+`NFS.UID` was `1000`. This caused a UID mismatch requiring a manual
+`groupadd`/`usermod` workaround. To prevent this in production:
+
+1. Set the broker container's user to `1000:1000` in the Dockerfile or
+   K8s `securityContext.runAsUser/runAsGroup`.
+2. Or adjust `NFS.UID/GID` to match the broker service user's identity.
+
+## Mount Privilege
+
+The broker process requires mount privilege to auto-mount NFS shares at
+startup (see `NFSMountReconciler`). Options:
+
+- Run the broker as root (not recommended for production).
+- Grant `CAP_SYS_ADMIN` via `setcap` or K8s `securityContext.capabilities`.
+- Configure `/etc/sudoers` to allow the broker user to run `mount`/`umount`
+  without a password.
+
+## NFSv3 Default
+
+The default `mount_options` is `vers=3,hard,nconnect=4,_netdev`. This
+targets Google Cloud Filestore **basic** (BASIC_HDD) tier, which supports
+NFSv3 only. NFSv4.1 requires Filestore Enterprise/zonal or a self-hosted
+NFS server. Override `mount_options` in `settings.yaml` if using a v4.1-capable
+server.

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -2633,3 +2633,27 @@ func isLocalhostEndpoint(endpoint string) bool {
 	host := u.Hostname()
 	return host == "localhost" || host == "127.0.0.1" || host == "::1"
 }
+
+// ensureNFSMountsReady verifies that all configured NFS shares are mounted
+// before dispatching an agent. This is a pre-flight check (N1-7):
+// the reconciler may have mounted them at startup, but a transient
+// unmount (network blip, manual intervention) should block dispatches.
+// Returns an error if any configured share cannot be mounted — the caller
+// should reject the dispatch to avoid silent fallback to a broken mount.
+func (s *Server) ensureNFSMountsReady() error {
+	if s.nfsMountReconciler == nil {
+		return nil // NFS not configured — local backend, nothing to check.
+	}
+
+	nfsCfg := s.config.NFSConfig
+	if nfsCfg == nil || len(nfsCfg.Shares) == 0 {
+		return nil
+	}
+
+	for _, share := range nfsCfg.Shares {
+		if err := s.nfsMountReconciler.EnsureShareMounted(share.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -79,6 +79,11 @@ func (s *Server) GetHealthInfo(ctx context.Context) *HealthResponse {
 		checks["runtime"] = "unavailable"
 	}
 
+	// NFS mount health
+	if s.nfsMountReconciler != nil {
+		checks["nfs_mounts"] = s.nfsMountReconciler.HealthCheckString()
+	}
+
 	status := "healthy"
 	for _, v := range checks {
 		if v != "available" && v != "healthy" {
@@ -559,6 +564,14 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 			writeError(w, d.HTTPStatus, d.Code, d.Message, nil)
 			return
 		}
+	}
+
+	// N1-7: Ensure NFS shares are mounted before dispatch (no-op when backend=local).
+	if err := s.ensureNFSMountsReady(); err != nil {
+		markAttemptFailed(http.StatusServiceUnavailable, "NFS mount check failed: "+err.Error())
+		writeError(w, http.StatusServiceUnavailable, "nfs_unavailable",
+			"NFS workspace storage is not available: "+err.Error(), nil)
+		return
 	}
 
 	// Build unified start context (project path, env, template, git-clone, secrets, manager)

--- a/pkg/runtimebroker/nfs_mount.go
+++ b/pkg/runtimebroker/nfs_mount.go
@@ -1,0 +1,296 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtimebroker
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// MountChecker abstracts the syscall/exec layer for NFS mount reconciliation.
+// This allows unit tests to assert reconciliation logic (mountpoint check,
+// server:export verify, idempotency) without real NFS.
+type MountChecker interface {
+	// IsMountpoint returns true if the given path is currently a mountpoint.
+	IsMountpoint(path string) (bool, error)
+
+	// MountInfo returns the server:export (e.g. "10.0.0.2:/scion-workspaces")
+	// for a given mountpoint. Returns ("", nil) if the path is not mounted.
+	MountInfo(path string) (serverExport string, err error)
+
+	// Mount executes the NFS mount command.
+	// Requires mount privilege (root or CAP_SYS_ADMIN/sudo).
+	Mount(server, export, target, options string) error
+
+	// Unmount unmounts the given mountpoint so it can be remounted.
+	Unmount(target string) error
+
+	// MkdirAll creates the directory tree for the mountpoint.
+	MkdirAll(path string, perm os.FileMode) error
+}
+
+// NFSMountReconciler ensures configured NFS shares are mounted at the expected
+// paths and reports health status. It is safe for concurrent use.
+//
+// Deploy note: The broker process requires mount privilege (root or
+// CAP_SYS_ADMIN) to mount NFS shares. When running as a non-root user,
+// either grant CAP_SYS_ADMIN via setcap or configure sudoers for mount/umount.
+type NFSMountReconciler struct {
+	cfg     *config.V1NFSConfig
+	checker MountChecker
+	log     *slog.Logger
+
+	mu       sync.RWMutex
+	statuses map[string]ShareMountStatus // keyed by share ID
+}
+
+// ShareMountStatus tracks the health of a single NFS share mount.
+type ShareMountStatus struct {
+	ShareID string `json:"shareId"`
+	Target  string `json:"target"`
+	Healthy bool   `json:"healthy"`
+	Message string `json:"message,omitempty"`
+}
+
+// NewNFSMountReconciler creates a reconciler for the given NFS config.
+// The checker abstracts mount syscalls for testability.
+func NewNFSMountReconciler(cfg *config.V1NFSConfig, checker MountChecker, log *slog.Logger) *NFSMountReconciler {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &NFSMountReconciler{
+		cfg:      cfg,
+		checker:  checker,
+		log:      log,
+		statuses: make(map[string]ShareMountStatus),
+	}
+}
+
+// Reconcile ensures all configured NFS shares are mounted at the correct
+// paths. It is idempotent: a broker restart calls Reconcile again without
+// double-mounting or erroring on an already-correct state.
+//
+// For each configured share:
+//   - target = <MountRoot>/<share.ID>
+//   - if target is not a mountpoint → mkdir -p target → mount NFS
+//   - if already a mountpoint → verify it points at the expected server:export;
+//     if wrong → log + remount
+//
+// Returns an error only if no shares are configured. Individual share failures
+// are tracked in per-share status (unhealthy) and logged, but do not block
+// other shares from mounting.
+func (r *NFSMountReconciler) Reconcile() error {
+	if r.cfg == nil {
+		return fmt.Errorf("NFS config is nil")
+	}
+	if len(r.cfg.Shares) == 0 {
+		return fmt.Errorf("no NFS shares configured")
+	}
+
+	mountOpts := r.cfg.MountOptions
+	if mountOpts == "" {
+		mountOpts = "vers=4.1,hard,nconnect=4,_netdev"
+	}
+
+	for _, share := range r.cfg.Shares {
+		r.reconcileShare(share, mountOpts)
+	}
+
+	return nil
+}
+
+// reconcileShare handles a single share's mount reconciliation.
+func (r *NFSMountReconciler) reconcileShare(share config.V1NFSShare, mountOpts string) {
+	target := filepath.Join(r.cfg.MountRoot, share.ID)
+	wantServerExport := fmt.Sprintf("%s:%s", share.Server, share.Export)
+
+	r.log.Info("Reconciling NFS share",
+		"shareID", share.ID, "target", target,
+		"server", share.Server, "export", share.Export)
+
+	mounted, err := r.checker.IsMountpoint(target)
+	if err != nil {
+		r.setStatus(share.ID, target, false,
+			fmt.Sprintf("failed to check mountpoint: %v", err))
+		return
+	}
+
+	if !mounted {
+		// Not mounted — create directory and mount.
+		if err := r.checker.MkdirAll(target, 0755); err != nil {
+			r.setStatus(share.ID, target, false,
+				fmt.Sprintf("failed to create mount directory: %v", err))
+			return
+		}
+
+		if err := r.checker.Mount(share.Server, share.Export, target, mountOpts); err != nil {
+			r.setStatus(share.ID, target, false,
+				fmt.Sprintf("mount failed: %v", err))
+			return
+		}
+
+		r.setStatus(share.ID, target, true, "mounted successfully")
+		r.log.Info("NFS share mounted", "shareID", share.ID, "target", target)
+		return
+	}
+
+	// Already mounted — verify it points at the expected server:export.
+	currentServerExport, err := r.checker.MountInfo(target)
+	if err != nil {
+		r.setStatus(share.ID, target, false,
+			fmt.Sprintf("failed to read mount info: %v", err))
+		return
+	}
+
+	if currentServerExport == wantServerExport {
+		// Correct mount — no action needed.
+		r.setStatus(share.ID, target, true, "already mounted correctly")
+		r.log.Debug("NFS share already mounted correctly",
+			"shareID", share.ID, "target", target)
+		return
+	}
+
+	// Wrong server:export — remount.
+	r.log.Warn("NFS share mounted with wrong source, remounting",
+		"shareID", share.ID, "target", target,
+		"current", currentServerExport, "expected", wantServerExport)
+
+	if err := r.checker.Unmount(target); err != nil {
+		r.setStatus(share.ID, target, false,
+			fmt.Sprintf("failed to unmount for remount: %v", err))
+		return
+	}
+	if err := r.checker.Mount(share.Server, share.Export, target, mountOpts); err != nil {
+		r.setStatus(share.ID, target, false,
+			fmt.Sprintf("remount failed: %v", err))
+		return
+	}
+
+	r.setStatus(share.ID, target, true, "remounted with correct source")
+	r.log.Info("NFS share remounted", "shareID", share.ID, "target", target)
+}
+
+// setStatus records the health status of a share.
+func (r *NFSMountReconciler) setStatus(shareID, target string, healthy bool, message string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.statuses[shareID] = ShareMountStatus{
+		ShareID: shareID,
+		Target:  target,
+		Healthy: healthy,
+		Message: message,
+	}
+	if !healthy {
+		r.log.Error("NFS share unhealthy",
+			"shareID", shareID, "target", target, "reason", message)
+	}
+}
+
+// IsHealthy returns true if all configured shares are mounted and healthy.
+// Returns false if any share is unhealthy or has not been reconciled yet.
+func (r *NFSMountReconciler) IsHealthy() bool {
+	if r.cfg == nil || len(r.cfg.Shares) == 0 {
+		return true // no NFS configured — healthy by default
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, share := range r.cfg.Shares {
+		status, ok := r.statuses[share.ID]
+		if !ok || !status.Healthy {
+			return false
+		}
+	}
+	return true
+}
+
+// ShareStatuses returns the current mount status of all configured shares.
+func (r *NFSMountReconciler) ShareStatuses() []ShareMountStatus {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]ShareMountStatus, 0, len(r.statuses))
+	for _, share := range r.cfg.Shares {
+		if status, ok := r.statuses[share.ID]; ok {
+			result = append(result, status)
+		}
+	}
+	return result
+}
+
+// HealthCheckString returns a summary string for health reporting.
+// Returns "healthy" if all shares are mounted, or "unhealthy: <details>"
+// listing failed shares.
+func (r *NFSMountReconciler) HealthCheckString() string {
+	if r.IsHealthy() {
+		return "healthy"
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var unhealthy []string
+	for _, share := range r.cfg.Shares {
+		status, ok := r.statuses[share.ID]
+		if !ok {
+			unhealthy = append(unhealthy, fmt.Sprintf("%s: not reconciled", share.ID))
+		} else if !status.Healthy {
+			unhealthy = append(unhealthy, fmt.Sprintf("%s: %s", share.ID, status.Message))
+		}
+	}
+	return "unhealthy: " + strings.Join(unhealthy, "; ")
+}
+
+// EnsureShareMounted is called before each NFS-backed dispatch to verify
+// the share for a given share ID is still mounted. It re-reconciles if needed.
+// Returns an error if the share cannot be verified or mounted.
+func (r *NFSMountReconciler) EnsureShareMounted(shareID string) error {
+	if r.cfg == nil {
+		return fmt.Errorf("NFS config is nil")
+	}
+
+	mountOpts := r.cfg.MountOptions
+	if mountOpts == "" {
+		mountOpts = "vers=4.1,hard,nconnect=4,_netdev"
+	}
+
+	for _, share := range r.cfg.Shares {
+		if share.ID == shareID {
+			r.reconcileShare(share, mountOpts)
+
+			r.mu.RLock()
+			status, ok := r.statuses[shareID]
+			r.mu.RUnlock()
+
+			if !ok || !status.Healthy {
+				msg := "mount not healthy"
+				if ok {
+					msg = status.Message
+				}
+				return fmt.Errorf("NFS share %q is unhealthy: %s", shareID, msg)
+			}
+			return nil
+		}
+	}
+
+	return fmt.Errorf("NFS share %q not found in config", shareID)
+}

--- a/pkg/runtimebroker/nfs_mount.go
+++ b/pkg/runtimebroker/nfs_mount.go
@@ -107,7 +107,7 @@ func (r *NFSMountReconciler) Reconcile() error {
 
 	mountOpts := r.cfg.MountOptions
 	if mountOpts == "" {
-		mountOpts = "vers=4.1,hard,nconnect=4,_netdev"
+		mountOpts = "vers=3,hard,nconnect=4,_netdev"
 	}
 
 	for _, share := range r.cfg.Shares {
@@ -270,7 +270,7 @@ func (r *NFSMountReconciler) EnsureShareMounted(shareID string) error {
 
 	mountOpts := r.cfg.MountOptions
 	if mountOpts == "" {
-		mountOpts = "vers=4.1,hard,nconnect=4,_netdev"
+		mountOpts = "vers=3,hard,nconnect=4,_netdev"
 	}
 
 	for _, share := range r.cfg.Shares {

--- a/pkg/runtimebroker/nfs_mount_exec.go
+++ b/pkg/runtimebroker/nfs_mount_exec.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtimebroker
+
+import (
+	"bufio"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// ExecMountChecker is the production MountChecker that shells out to
+// mount(8)/umount(8)/mountpoint(1) to manage NFS mounts.
+//
+// Privilege requirements:
+//   - The broker process must have mount privilege (root, CAP_SYS_ADMIN, or
+//     sudoers entry for mount/umount). Without it, Mount/Unmount will fail.
+//   - mountpoint(1) and /proc/mounts (Linux) require no special privilege.
+type ExecMountChecker struct {
+	log *slog.Logger
+	// runCommand is the function used to run external commands.
+	// Defaults to execRunCommand; overridden in tests.
+	runCommand func(name string, args ...string) ([]byte, error)
+}
+
+// NewExecMountChecker creates a production MountChecker.
+func NewExecMountChecker(log *slog.Logger) *ExecMountChecker {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &ExecMountChecker{
+		log:        log,
+		runCommand: execRunCommand,
+	}
+}
+
+// execRunCommand runs a command and returns its combined output.
+func execRunCommand(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).CombinedOutput()
+}
+
+// IsMountpoint returns true if the given path is currently a mountpoint.
+// Uses mountpoint(1) which is available on all modern Linux distributions.
+func (e *ExecMountChecker) IsMountpoint(path string) (bool, error) {
+	out, err := e.runCommand("mountpoint", "-q", path)
+	if err != nil {
+		// mountpoint returns exit code 1 for non-mountpoints (not an error)
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+		// Other errors (path doesn't exist, permission denied)
+		e.log.Debug("mountpoint check failed", "path", path, "error", err, "output", string(out))
+		return false, nil // treat check failure as "not mounted" so we try to mount
+	}
+	return true, nil
+}
+
+// MountInfo returns the server:export for a given mountpoint by parsing
+// /proc/mounts (Linux). Returns ("", nil) if the path is not found.
+func (e *ExecMountChecker) MountInfo(path string) (string, error) {
+	f, err := os.Open("/proc/mounts")
+	if err != nil {
+		return "", fmt.Errorf("failed to read /proc/mounts: %w", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			continue
+		}
+		// fields[0] = device (server:export for NFS), fields[1] = mountpoint
+		if fields[1] == path {
+			return fields[0], nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error reading /proc/mounts: %w", err)
+	}
+	return "", nil
+}
+
+// Mount executes the NFS mount command.
+// Requires mount privilege (root or CAP_SYS_ADMIN).
+func (e *ExecMountChecker) Mount(server, export, target, options string) error {
+	source := fmt.Sprintf("%s:%s", server, export)
+	args := []string{"-t", "nfs", "-o", options, source, target}
+	e.log.Info("Mounting NFS share", "source", source, "target", target, "options", options)
+
+	out, err := e.runCommand("mount", args...)
+	if err != nil {
+		return fmt.Errorf("mount %s on %s failed: %w (output: %s)", source, target, err, string(out))
+	}
+	return nil
+}
+
+// Unmount unmounts the given mountpoint.
+func (e *ExecMountChecker) Unmount(target string) error {
+	e.log.Info("Unmounting", "target", target)
+	out, err := e.runCommand("umount", target)
+	if err != nil {
+		return fmt.Errorf("umount %s failed: %w (output: %s)", target, err, string(out))
+	}
+	return nil
+}
+
+// MkdirAll creates the directory tree for the mountpoint.
+func (e *ExecMountChecker) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}

--- a/pkg/runtimebroker/nfs_mount_exec_test.go
+++ b/pkg/runtimebroker/nfs_mount_exec_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtimebroker
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestExecMountChecker_IsMountpoint_NotMounted verifies that IsMountpoint
+// returns false when mountpoint exits with code 1 (not a mountpoint).
+func TestExecMountChecker_IsMountpoint_NotMounted(t *testing.T) {
+	checker := NewExecMountChecker(nil)
+	checker.runCommand = func(name string, args ...string) ([]byte, error) {
+		if name != "mountpoint" {
+			t.Fatalf("unexpected command: %s", name)
+		}
+		if len(args) != 2 || args[0] != "-q" || args[1] != "/mnt/nfs/ws1" {
+			t.Fatalf("unexpected args: %v", args)
+		}
+		return nil, &exec.ExitError{}
+	}
+
+	mounted, err := checker.IsMountpoint("/mnt/nfs/ws1")
+	if err != nil {
+		t.Fatalf("IsMountpoint error: %v", err)
+	}
+	if mounted {
+		t.Error("expected not mounted for exit code 1")
+	}
+}
+
+// TestExecMountChecker_IsMountpoint_Mounted verifies that IsMountpoint
+// returns true when mountpoint exits with code 0.
+func TestExecMountChecker_IsMountpoint_Mounted(t *testing.T) {
+	checker := NewExecMountChecker(nil)
+	checker.runCommand = func(name string, args ...string) ([]byte, error) {
+		return nil, nil // exit 0 = is a mountpoint
+	}
+
+	mounted, err := checker.IsMountpoint("/mnt/nfs/ws1")
+	if err != nil {
+		t.Fatalf("IsMountpoint error: %v", err)
+	}
+	if !mounted {
+		t.Error("expected mounted for exit code 0")
+	}
+}
+
+// TestExecMountChecker_Mount_Success verifies the mount command is constructed
+// correctly with the right arguments.
+func TestExecMountChecker_Mount_Success(t *testing.T) {
+	checker := NewExecMountChecker(nil)
+	var capturedName string
+	var capturedArgs []string
+	checker.runCommand = func(name string, args ...string) ([]byte, error) {
+		capturedName = name
+		capturedArgs = args
+		return nil, nil
+	}
+
+	err := checker.Mount("10.0.0.2", "/scion-ws", "/mnt/nfs/ws1", "vers=3,hard")
+	if err != nil {
+		t.Fatalf("Mount error: %v", err)
+	}
+
+	if capturedName != "mount" {
+		t.Errorf("expected mount command, got %s", capturedName)
+	}
+
+	// Expected args: -t nfs -o vers=3,hard 10.0.0.2:/scion-ws /mnt/nfs/ws1
+	wantArgs := []string{"-t", "nfs", "-o", "vers=3,hard", "10.0.0.2:/scion-ws", "/mnt/nfs/ws1"}
+	if len(capturedArgs) != len(wantArgs) {
+		t.Fatalf("args len = %d, want %d: %v", len(capturedArgs), len(wantArgs), capturedArgs)
+	}
+	for i, want := range wantArgs {
+		if capturedArgs[i] != want {
+			t.Errorf("arg[%d] = %q, want %q", i, capturedArgs[i], want)
+		}
+	}
+}
+
+// TestExecMountChecker_Mount_Failure verifies mount failure is surfaced.
+func TestExecMountChecker_Mount_Failure(t *testing.T) {
+	checker := NewExecMountChecker(nil)
+	checker.runCommand = func(name string, args ...string) ([]byte, error) {
+		return []byte("mount: permission denied"), fmt.Errorf("exit status 32")
+	}
+
+	err := checker.Mount("10.0.0.2", "/scion-ws", "/mnt/nfs/ws1", "vers=3,hard")
+	if err == nil {
+		t.Fatal("expected error from mount failure")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("error should contain mount output, got: %v", err)
+	}
+}
+
+// TestExecMountChecker_Unmount_Success verifies the umount command.
+func TestExecMountChecker_Unmount_Success(t *testing.T) {
+	checker := NewExecMountChecker(nil)
+	var capturedName string
+	var capturedArgs []string
+	checker.runCommand = func(name string, args ...string) ([]byte, error) {
+		capturedName = name
+		capturedArgs = args
+		return nil, nil
+	}
+
+	err := checker.Unmount("/mnt/nfs/ws1")
+	if err != nil {
+		t.Fatalf("Unmount error: %v", err)
+	}
+
+	if capturedName != "umount" {
+		t.Errorf("expected umount command, got %s", capturedName)
+	}
+	if len(capturedArgs) != 1 || capturedArgs[0] != "/mnt/nfs/ws1" {
+		t.Errorf("args = %v, want [/mnt/nfs/ws1]", capturedArgs)
+	}
+}
+
+// TestExecMountChecker_Interface verifies ExecMountChecker satisfies the
+// MountChecker interface at compile time.
+func TestExecMountChecker_Interface(t *testing.T) {
+	var _ MountChecker = (*ExecMountChecker)(nil)
+}

--- a/pkg/runtimebroker/nfs_mount_test.go
+++ b/pkg/runtimebroker/nfs_mount_test.go
@@ -106,7 +106,7 @@ func (m *mockMountChecker) MkdirAll(path string, perm os.FileMode) error {
 func testNFSConfig() *config.V1NFSConfig {
 	return &config.V1NFSConfig{
 		MountRoot:    "/mnt/nfs",
-		MountOptions: "vers=4.1,hard,nconnect=4,_netdev",
+		MountOptions: "vers=3,hard,nconnect=4,_netdev",
 		SubPathRoot:  "projects",
 		Shares: []config.V1NFSShare{
 			{ID: "ws1", Server: "10.0.0.2", Export: "/scion-workspaces"},
@@ -138,7 +138,7 @@ func TestReconcile_MountAbsent_MkdirAndMount(t *testing.T) {
 		t.Errorf("mount call = %+v, want server=10.0.0.2, export=/scion-workspaces, target=%s",
 			call, wantTarget)
 	}
-	if call.Options != "vers=4.1,hard,nconnect=4,_netdev" {
+	if call.Options != "vers=3,hard,nconnect=4,_netdev" {
 		t.Errorf("mount options = %q, want default NFS options", call.Options)
 	}
 
@@ -385,7 +385,7 @@ func TestReconcile_DefaultMountOptions(t *testing.T) {
 	if len(mc.mountCalls) != 1 {
 		t.Fatalf("mountCalls = %d, want 1", len(mc.mountCalls))
 	}
-	if mc.mountCalls[0].Options != "vers=4.1,hard,nconnect=4,_netdev" {
+	if mc.mountCalls[0].Options != "vers=3,hard,nconnect=4,_netdev" {
 		t.Errorf("options = %q, want default NFS options", mc.mountCalls[0].Options)
 	}
 }

--- a/pkg/runtimebroker/nfs_mount_test.go
+++ b/pkg/runtimebroker/nfs_mount_test.go
@@ -1,0 +1,401 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtimebroker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// mockMountChecker is a test double for MountChecker that records calls and
+// returns configurable results without touching the real filesystem.
+type mockMountChecker struct {
+	// mountpoints maps path → server:export. Present = mounted.
+	mountpoints map[string]string
+
+	// mountCalls records (server, export, target, options) for each Mount call.
+	mountCalls []mountCall
+	// unmountCalls records targets passed to Unmount.
+	unmountCalls []string
+	// mkdirCalls records paths passed to MkdirAll.
+	mkdirCalls []string
+
+	// Inject errors for specific operations.
+	isMountpointErr map[string]error
+	mountInfoErr    map[string]error
+	mountErr        error
+	unmountErr      error
+	mkdirErr        error
+}
+
+type mountCall struct {
+	Server, Export, Target, Options string
+}
+
+func newMockMountChecker() *mockMountChecker {
+	return &mockMountChecker{
+		mountpoints:     make(map[string]string),
+		isMountpointErr: make(map[string]error),
+		mountInfoErr:    make(map[string]error),
+	}
+}
+
+func (m *mockMountChecker) IsMountpoint(path string) (bool, error) {
+	if err, ok := m.isMountpointErr[path]; ok {
+		return false, err
+	}
+	_, ok := m.mountpoints[path]
+	return ok, nil
+}
+
+func (m *mockMountChecker) MountInfo(path string) (string, error) {
+	if err, ok := m.mountInfoErr[path]; ok {
+		return "", err
+	}
+	se, ok := m.mountpoints[path]
+	if !ok {
+		return "", nil
+	}
+	return se, nil
+}
+
+func (m *mockMountChecker) Mount(server, export, target, options string) error {
+	m.mountCalls = append(m.mountCalls, mountCall{server, export, target, options})
+	if m.mountErr != nil {
+		return m.mountErr
+	}
+	m.mountpoints[target] = fmt.Sprintf("%s:%s", server, export)
+	return nil
+}
+
+func (m *mockMountChecker) Unmount(target string) error {
+	m.unmountCalls = append(m.unmountCalls, target)
+	if m.unmountErr != nil {
+		return m.unmountErr
+	}
+	delete(m.mountpoints, target)
+	return nil
+}
+
+func (m *mockMountChecker) MkdirAll(path string, perm os.FileMode) error {
+	m.mkdirCalls = append(m.mkdirCalls, path)
+	if m.mkdirErr != nil {
+		return m.mkdirErr
+	}
+	return nil
+}
+
+// --- Tests ---
+
+func testNFSConfig() *config.V1NFSConfig {
+	return &config.V1NFSConfig{
+		MountRoot:    "/mnt/nfs",
+		MountOptions: "vers=4.1,hard,nconnect=4,_netdev",
+		SubPathRoot:  "projects",
+		Shares: []config.V1NFSShare{
+			{ID: "ws1", Server: "10.0.0.2", Export: "/scion-workspaces"},
+		},
+	}
+}
+
+func TestReconcile_MountAbsent_MkdirAndMount(t *testing.T) {
+	mc := newMockMountChecker()
+	cfg := testNFSConfig()
+	r := NewNFSMountReconciler(cfg, mc, nil)
+
+	if err := r.Reconcile(); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	// Should have created the directory
+	wantTarget := filepath.Join("/mnt/nfs", "ws1")
+	if len(mc.mkdirCalls) != 1 || mc.mkdirCalls[0] != wantTarget {
+		t.Errorf("mkdirCalls = %v, want [%q]", mc.mkdirCalls, wantTarget)
+	}
+
+	// Should have mounted
+	if len(mc.mountCalls) != 1 {
+		t.Fatalf("mountCalls = %d, want 1", len(mc.mountCalls))
+	}
+	call := mc.mountCalls[0]
+	if call.Server != "10.0.0.2" || call.Export != "/scion-workspaces" || call.Target != wantTarget {
+		t.Errorf("mount call = %+v, want server=10.0.0.2, export=/scion-workspaces, target=%s",
+			call, wantTarget)
+	}
+	if call.Options != "vers=4.1,hard,nconnect=4,_netdev" {
+		t.Errorf("mount options = %q, want default NFS options", call.Options)
+	}
+
+	// Should be healthy
+	if !r.IsHealthy() {
+		t.Error("expected healthy after successful mount")
+	}
+}
+
+func TestReconcile_AlreadyMountedCorrectly_NoOp(t *testing.T) {
+	mc := newMockMountChecker()
+	target := filepath.Join("/mnt/nfs", "ws1")
+	mc.mountpoints[target] = "10.0.0.2:/scion-workspaces"
+
+	cfg := testNFSConfig()
+	r := NewNFSMountReconciler(cfg, mc, nil)
+
+	if err := r.Reconcile(); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	// No mkdir or mount calls
+	if len(mc.mkdirCalls) != 0 {
+		t.Errorf("mkdirCalls = %v, want none (already mounted)", mc.mkdirCalls)
+	}
+	if len(mc.mountCalls) != 0 {
+		t.Errorf("mountCalls = %d, want 0 (already mounted correctly)", len(mc.mountCalls))
+	}
+
+	if !r.IsHealthy() {
+		t.Error("expected healthy for correctly mounted share")
+	}
+}
+
+func TestReconcile_WrongServerExport_Remount(t *testing.T) {
+	mc := newMockMountChecker()
+	target := filepath.Join("/mnt/nfs", "ws1")
+	mc.mountpoints[target] = "10.0.0.99:/wrong-export" // wrong source
+
+	cfg := testNFSConfig()
+	r := NewNFSMountReconciler(cfg, mc, nil)
+
+	if err := r.Reconcile(); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	// Should have unmounted
+	if len(mc.unmountCalls) != 1 || mc.unmountCalls[0] != target {
+		t.Errorf("unmountCalls = %v, want [%q]", mc.unmountCalls, target)
+	}
+
+	// Should have remounted with correct source
+	if len(mc.mountCalls) != 1 {
+		t.Fatalf("mountCalls = %d, want 1 (remount)", len(mc.mountCalls))
+	}
+	call := mc.mountCalls[0]
+	if call.Server != "10.0.0.2" || call.Export != "/scion-workspaces" {
+		t.Errorf("remount call = %+v, want correct server:export", call)
+	}
+
+	if !r.IsHealthy() {
+		t.Error("expected healthy after remount")
+	}
+}
+
+func TestReconcile_MultipleShares(t *testing.T) {
+	mc := newMockMountChecker()
+	cfg := &config.V1NFSConfig{
+		MountRoot:    "/mnt/nfs",
+		MountOptions: "vers=4.1,hard",
+		Shares: []config.V1NFSShare{
+			{ID: "ws1", Server: "10.0.0.2", Export: "/export-a"},
+			{ID: "ws2", Server: "10.0.0.3", Export: "/export-b"},
+		},
+	}
+	r := NewNFSMountReconciler(cfg, mc, nil)
+
+	if err := r.Reconcile(); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if len(mc.mountCalls) != 2 {
+		t.Fatalf("mountCalls = %d, want 2 (one per share)", len(mc.mountCalls))
+	}
+
+	// Both should be healthy
+	if !r.IsHealthy() {
+		t.Error("expected healthy after mounting both shares")
+	}
+
+	statuses := r.ShareStatuses()
+	if len(statuses) != 2 {
+		t.Errorf("ShareStatuses len = %d, want 2", len(statuses))
+	}
+}
+
+func TestReconcile_MountFailure_UnhealthySignal(t *testing.T) {
+	mc := newMockMountChecker()
+	mc.mountErr = fmt.Errorf("permission denied")
+
+	cfg := testNFSConfig()
+	r := NewNFSMountReconciler(cfg, mc, nil)
+
+	// Reconcile itself does not return an error for individual share failures
+	if err := r.Reconcile(); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if r.IsHealthy() {
+		t.Error("expected unhealthy after mount failure")
+	}
+
+	hc := r.HealthCheckString()
+	if hc == "healthy" {
+		t.Error("HealthCheckString should not be 'healthy' after mount failure")
+	}
+}
+
+func TestReconcile_NilConfig_Error(t *testing.T) {
+	mc := newMockMountChecker()
+	r := NewNFSMountReconciler(nil, mc, nil)
+
+	if err := r.Reconcile(); err == nil {
+		t.Error("expected error for nil config")
+	}
+}
+
+func TestReconcile_NoShares_Error(t *testing.T) {
+	mc := newMockMountChecker()
+	cfg := &config.V1NFSConfig{
+		MountRoot: "/mnt/nfs",
+		Shares:    nil,
+	}
+	r := NewNFSMountReconciler(cfg, mc, nil)
+
+	if err := r.Reconcile(); err == nil {
+		t.Error("expected error for no shares")
+	}
+}
+
+func TestReconcile_Idempotent_DoubleCall(t *testing.T) {
+	mc := newMockMountChecker()
+	cfg := testNFSConfig()
+	r := NewNFSMountReconciler(cfg, mc, nil)
+
+	// First call: mounts the share
+	if err := r.Reconcile(); err != nil {
+		t.Fatalf("first Reconcile: %v", err)
+	}
+	if len(mc.mountCalls) != 1 {
+		t.Fatalf("expected 1 mount call after first Reconcile, got %d", len(mc.mountCalls))
+	}
+
+	// Second call: share is already mounted correctly — no-op
+	if err := r.Reconcile(); err != nil {
+		t.Fatalf("second Reconcile: %v", err)
+	}
+	if len(mc.mountCalls) != 1 {
+		t.Errorf("expected still 1 mount call after second Reconcile (idempotent), got %d",
+			len(mc.mountCalls))
+	}
+}
+
+func TestEnsureShareMounted_Healthy(t *testing.T) {
+	mc := newMockMountChecker()
+	cfg := testNFSConfig()
+	r := NewNFSMountReconciler(cfg, mc, nil)
+
+	if err := r.EnsureShareMounted("ws1"); err != nil {
+		t.Fatalf("EnsureShareMounted: %v", err)
+	}
+
+	// Should have mounted
+	if len(mc.mountCalls) != 1 {
+		t.Errorf("mountCalls = %d, want 1", len(mc.mountCalls))
+	}
+}
+
+func TestEnsureShareMounted_UnknownShare(t *testing.T) {
+	mc := newMockMountChecker()
+	cfg := testNFSConfig()
+	r := NewNFSMountReconciler(cfg, mc, nil)
+
+	if err := r.EnsureShareMounted("nonexistent"); err == nil {
+		t.Error("expected error for unknown share ID")
+	}
+}
+
+func TestEnsureShareMounted_MountFailure(t *testing.T) {
+	mc := newMockMountChecker()
+	mc.mountErr = fmt.Errorf("network unreachable")
+
+	cfg := testNFSConfig()
+	r := NewNFSMountReconciler(cfg, mc, nil)
+
+	if err := r.EnsureShareMounted("ws1"); err == nil {
+		t.Error("expected error when mount fails")
+	}
+}
+
+func TestHealthCheckString_Healthy(t *testing.T) {
+	mc := newMockMountChecker()
+	cfg := testNFSConfig()
+	r := NewNFSMountReconciler(cfg, mc, nil)
+
+	// Mount the share
+	_ = r.Reconcile()
+
+	got := r.HealthCheckString()
+	if got != "healthy" {
+		t.Errorf("HealthCheckString = %q, want %q", got, "healthy")
+	}
+}
+
+func TestHealthCheckString_Unhealthy(t *testing.T) {
+	mc := newMockMountChecker()
+	mc.mountErr = fmt.Errorf("denied")
+
+	cfg := testNFSConfig()
+	r := NewNFSMountReconciler(cfg, mc, nil)
+	_ = r.Reconcile()
+
+	got := r.HealthCheckString()
+	if got == "healthy" {
+		t.Error("HealthCheckString should not be 'healthy' after mount failure")
+	}
+}
+
+func TestReconcile_DefaultMountOptions(t *testing.T) {
+	mc := newMockMountChecker()
+	cfg := &config.V1NFSConfig{
+		MountRoot:    "/mnt/nfs",
+		MountOptions: "", // should use default
+		Shares: []config.V1NFSShare{
+			{ID: "ws1", Server: "10.0.0.2", Export: "/scion-workspaces"},
+		},
+	}
+	r := NewNFSMountReconciler(cfg, mc, nil)
+
+	if err := r.Reconcile(); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if len(mc.mountCalls) != 1 {
+		t.Fatalf("mountCalls = %d, want 1", len(mc.mountCalls))
+	}
+	if mc.mountCalls[0].Options != "vers=4.1,hard,nconnect=4,_netdev" {
+		t.Errorf("options = %q, want default NFS options", mc.mountCalls[0].Options)
+	}
+}
+
+func TestIsHealthy_NoNFSConfigured(t *testing.T) {
+	mc := newMockMountChecker()
+	r := NewNFSMountReconciler(nil, mc, nil)
+
+	// No NFS configured → healthy by default (local backend)
+	if !r.IsHealthy() {
+		t.Error("expected healthy when no NFS is configured")
+	}
+}

--- a/pkg/runtimebroker/nfs_wiring_test.go
+++ b/pkg/runtimebroker/nfs_wiring_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtimebroker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// TestServer_NFSReconcilerWired_WhenNFSConfigured verifies that the
+// NFSMountReconciler is constructed and stored on the Server when
+// NFSConfig is present with shares.
+func TestServer_NFSReconcilerWired_WhenNFSConfigured(t *testing.T) {
+	cfg := ServerConfig{
+		Port: 0,
+		Host: "127.0.0.1",
+		NFSConfig: &config.V1NFSConfig{
+			MountRoot:    "/mnt/nfs",
+			MountOptions: "vers=3,hard",
+			Shares: []config.V1NFSShare{
+				{ID: "ws1", Server: "10.0.0.2", Export: "/scion-workspaces"},
+			},
+		},
+	}
+
+	srv := New(cfg, nil, nil)
+
+	if srv.nfsMountReconciler == nil {
+		t.Fatal("expected nfsMountReconciler to be constructed when NFSConfig has shares")
+	}
+}
+
+// TestServer_NFSReconcilerNil_WhenLocalBackend verifies that the
+// NFSMountReconciler is NOT constructed when NFSConfig is nil
+// (local backend).
+func TestServer_NFSReconcilerNil_WhenLocalBackend(t *testing.T) {
+	cfg := ServerConfig{
+		Port: 0,
+		Host: "127.0.0.1",
+		// NFSConfig is nil — local backend
+	}
+
+	srv := New(cfg, nil, nil)
+
+	if srv.nfsMountReconciler != nil {
+		t.Fatal("expected nfsMountReconciler to be nil when NFSConfig is not set")
+	}
+}
+
+// TestServer_NFSReconcilerNil_WhenNoShares verifies that the
+// NFSMountReconciler is NOT constructed when NFSConfig exists but
+// has no shares configured.
+func TestServer_NFSReconcilerNil_WhenNoShares(t *testing.T) {
+	cfg := ServerConfig{
+		Port: 0,
+		Host: "127.0.0.1",
+		NFSConfig: &config.V1NFSConfig{
+			MountRoot: "/mnt/nfs",
+			Shares:    nil,
+		},
+	}
+
+	srv := New(cfg, nil, nil)
+
+	if srv.nfsMountReconciler != nil {
+		t.Fatal("expected nfsMountReconciler to be nil when no shares configured")
+	}
+}
+
+// TestServer_HealthIncludesNFS verifies that NFS mount health is surfaced
+// in the broker's health response when NFS is configured.
+func TestServer_HealthIncludesNFS(t *testing.T) {
+	cfg := ServerConfig{
+		Port: 0,
+		Host: "127.0.0.1",
+		NFSConfig: &config.V1NFSConfig{
+			MountRoot:    "/mnt/nfs",
+			MountOptions: "vers=3,hard",
+			Shares: []config.V1NFSShare{
+				{ID: "ws1", Server: "10.0.0.2", Export: "/scion-workspaces"},
+			},
+		},
+	}
+
+	srv := New(cfg, nil, nil)
+
+	// Before reconciliation: shares are unreconciled → unhealthy
+	health := srv.GetHealthInfo(context.Background())
+
+	nfsCheck, ok := health.Checks["nfs_mounts"]
+	if !ok {
+		t.Fatal("expected nfs_mounts key in health checks")
+	}
+	// Before Reconcile(), shares are not yet reconciled → "unhealthy"
+	if nfsCheck == "healthy" {
+		t.Error("expected unhealthy before reconciliation")
+	}
+	if health.Status != "degraded" {
+		t.Errorf("overall status = %q, want degraded (NFS unhealthy before reconciliation)", health.Status)
+	}
+}
+
+// TestServer_HealthExcludesNFS_WhenLocal verifies that no nfs_mounts key
+// appears in health when NFS is not configured.
+func TestServer_HealthExcludesNFS_WhenLocal(t *testing.T) {
+	cfg := ServerConfig{
+		Port: 0,
+		Host: "127.0.0.1",
+	}
+
+	srv := New(cfg, nil, nil)
+	health := srv.GetHealthInfo(context.Background())
+
+	if _, ok := health.Checks["nfs_mounts"]; ok {
+		t.Error("did not expect nfs_mounts in health checks when NFS is not configured")
+	}
+}
+
+// TestServer_EnsureNFSMountsReady_NilReconciler verifies that the dispatch
+// guard is a no-op when NFS is not configured.
+func TestServer_EnsureNFSMountsReady_NilReconciler(t *testing.T) {
+	srv := New(ServerConfig{Port: 0, Host: "127.0.0.1"}, nil, nil)
+
+	if err := srv.ensureNFSMountsReady(); err != nil {
+		t.Fatalf("ensureNFSMountsReady with no NFS should return nil, got: %v", err)
+	}
+}
+
+// TestServer_EnsureNFSMountsReady_WithReconciler verifies that the dispatch
+// guard calls EnsureShareMounted for each configured share.
+func TestServer_EnsureNFSMountsReady_WithReconciler(t *testing.T) {
+	nfsCfg := &config.V1NFSConfig{
+		MountRoot:    "/mnt/nfs",
+		MountOptions: "vers=3,hard",
+		Shares: []config.V1NFSShare{
+			{ID: "ws1", Server: "10.0.0.2", Export: "/export-a"},
+			{ID: "ws2", Server: "10.0.0.3", Export: "/export-b"},
+		},
+	}
+
+	mc := newMockMountChecker()
+	srv := &Server{
+		config: ServerConfig{
+			Port:      0,
+			Host:      "127.0.0.1",
+			NFSConfig: nfsCfg,
+		},
+		nfsMountReconciler: NewNFSMountReconciler(nfsCfg, mc, nil),
+	}
+
+	if err := srv.ensureNFSMountsReady(); err != nil {
+		t.Fatalf("ensureNFSMountsReady: %v", err)
+	}
+
+	// Both shares should have been mounted
+	if len(mc.mountCalls) != 2 {
+		t.Errorf("mountCalls = %d, want 2 (one per share)", len(mc.mountCalls))
+	}
+}

--- a/pkg/runtimebroker/server.go
+++ b/pkg/runtimebroker/server.go
@@ -219,6 +219,9 @@ type Server struct {
 	auxiliaryRuntimes   map[string]auxiliaryRuntime
 	auxiliaryRuntimesMu sync.RWMutex
 
+	// NFS mount reconciler (nil when backend != "nfs")
+	nfsMountReconciler *NFSMountReconciler
+
 	// Dedicated request logger (nil = disabled)
 	requestLogger *slog.Logger
 
@@ -307,6 +310,17 @@ func New(cfg ServerConfig, mgr agent.Manager, rt scionrt.Runtime) *Server {
 		if err := srv.initStateStore(); err != nil {
 			slog.Warn("Failed to initialize runtime broker state store", "error", err, "stateDir", srv.stateDir)
 		}
+	}
+
+	// Initialize NFS mount reconciler when NFS storage is configured.
+	// This only constructs the reconciler; Reconcile() is called in Start().
+	if cfg.NFSConfig != nil && len(cfg.NFSConfig.Shares) > 0 {
+		nfsLog := logging.Subsystem("broker.nfs-mount")
+		checker := NewExecMountChecker(nfsLog)
+		srv.nfsMountReconciler = NewNFSMountReconciler(cfg.NFSConfig, checker, nfsLog)
+		slog.Info("NFS mount reconciler initialized",
+			"shares", len(cfg.NFSConfig.Shares),
+			"mountRoot", cfg.NFSConfig.MountRoot)
 	}
 
 	// Initialize Hub integration if enabled
@@ -811,6 +825,20 @@ func (s *Server) Start(ctx context.Context) error {
 	// so that agents running on non-default runtimes can be found after
 	// a broker restart.
 	s.discoverAuxiliaryRuntimes()
+
+	// Reconcile NFS mounts at startup (ensure configured shares are mounted).
+	if s.nfsMountReconciler != nil {
+		if err := s.nfsMountReconciler.Reconcile(); err != nil {
+			slog.Warn("NFS mount reconciliation returned error at startup", "error", err)
+		}
+		if !s.nfsMountReconciler.IsHealthy() {
+			slog.Error("NFS mounts unhealthy at startup",
+				"detail", s.nfsMountReconciler.HealthCheckString())
+		} else {
+			slog.Info("NFS mounts reconciled at startup",
+				"status", s.nfsMountReconciler.HealthCheckString())
+		}
+	}
 
 	// Start all hub connections' services
 	s.hubMu.RLock()

--- a/pkg/runtimebroker/server.go
+++ b/pkg/runtimebroker/server.go
@@ -144,6 +144,12 @@ type ServerConfig struct {
 	// container-script dispatches on this broker.
 	AllowContainerScriptHarnesses bool
 
+	// NFSConfig holds NFS workspace storage settings for this broker.
+	// When non-nil with shares configured, the broker can provision and
+	// clean up NFS-backed workspace subtrees. Used by deleteProject (N1-6)
+	// to also remove the NFS project subtree on project deletion.
+	NFSConfig *config.V1NFSConfig
+
 	// ColocatedStorage is the storage backend of a Hub running co-located in the
 	// same process. When set and backed by the local filesystem, the broker
 	// resolves resources for the co-located connection by reading directly from

--- a/pkg/store/concurrency.go
+++ b/pkg/store/concurrency.go
@@ -14,7 +14,10 @@
 
 package store
 
-import "context"
+import (
+	"context"
+	"hash/fnv"
+)
 
 // The interfaces in this file are OPTIONAL capabilities that a store backend may
 // implement to support running N stateless hub processes against one shared
@@ -54,6 +57,21 @@ const (
 	LockBrokerAffinityReap AdvisoryLockKey = 0x5C100006
 	// LockBrokerMessageSweep guards the periodic stuck-pending-message sweep (B5-2).
 	LockBrokerMessageSweep AdvisoryLockKey = 0x5C100007
+
+	// LockWorkspaceProvision is the CLASS ID for per-project workspace
+	// provisioning locks. It is used with the two-int advisory lock form
+	// pg_try_advisory_lock(classid, objid), where classid is this constant
+	// and objid is a stable hash of the project ID. This guards the NFS
+	// first-access provisioning flow (design §7, risk RN1): only one
+	// broker across all nodes may clone/provision a project's workspace at
+	// a time, while different projects lock independently.
+	//
+	// The value is intentionally in a different range (0x5C10_1001) from
+	// the singleton keys above (0x5C10_0001..0005) to avoid collisions
+	// when the two-int lock form's classid is compared against the
+	// single-int form's key — Postgres treats them as separate namespaces,
+	// but keeping them visually distinct aids debugging.
+	LockWorkspaceProvision AdvisoryLockKey = 0x5C101001
 )
 
 // AdvisoryLocker is implemented by backends that can take a cluster-wide
@@ -72,6 +90,37 @@ type AdvisoryLocker interface {
 	// If acquired is false another replica currently holds the lock and the
 	// caller should skip the work this round.
 	TryAdvisoryLock(ctx context.Context, key AdvisoryLockKey) (acquired bool, release func() error, err error)
+
+	// TryAdvisoryLockObject acquires a per-object advisory lock using
+	// Postgres's two-integer form: pg_try_advisory_lock(classid, objid).
+	// classid identifies the lock family (e.g. LockWorkspaceProvision) and
+	// objid identifies the specific object within that family (e.g. a
+	// stable hash of the project ID). Two different objIDs under the same
+	// classid are independent locks; the same (classid, objid) pair
+	// provides mutual exclusion across all replicas.
+	//
+	// This is the per-project provisioning guard (design §7, risk RN1):
+	// two agents for the same project on different nodes contend on the
+	// same (classid, hash(projectID)) lock; agents for different projects
+	// never contend.
+	//
+	// On SQLite the lock is a no-op that always succeeds — the single-
+	// writer model already serializes provisioning.
+	TryAdvisoryLockObject(ctx context.Context, classID AdvisoryLockKey, objID int32) (acquired bool, release func() error, err error)
+}
+
+// StableProjectHash returns a deterministic, cross-node-stable int32 hash
+// of a project ID string, suitable for use as the objID argument to
+// TryAdvisoryLockObject. It uses FNV-32a, which is fast, deterministic,
+// and has good distribution for UUID strings.
+//
+// The result is cast to int32 (Postgres int4 range) — FNV-32a produces a
+// uint32 which wraps into the negative int32 range, but that is fine:
+// pg_try_advisory_lock(int4, int4) accepts any int4 value.
+func StableProjectHash(projectID string) int32 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(projectID)) // hash.Hash.Write never errors
+	return int32(h.Sum32())
 }
 
 // NOTE: the SERIALIZABLE + retry-on-serialization-failure primitive (P3-4) is

--- a/pkg/store/concurrency_test.go
+++ b/pkg/store/concurrency_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"testing"
+)
+
+// StableProjectHash must be deterministic: same input → same output.
+func TestStableProjectHash_Deterministic(t *testing.T) {
+	id := "550e8400-e29b-41d4-a716-446655440000"
+	h1 := StableProjectHash(id)
+	h2 := StableProjectHash(id)
+	if h1 != h2 {
+		t.Errorf("StableProjectHash not deterministic: %d vs %d", h1, h2)
+	}
+}
+
+// Different project IDs should (almost certainly) produce different hashes.
+func TestStableProjectHash_DifferentInputs(t *testing.T) {
+	h1 := StableProjectHash("project-aaa")
+	h2 := StableProjectHash("project-bbb")
+	if h1 == h2 {
+		t.Errorf("StableProjectHash collision: %q and %q both hash to %d",
+			"project-aaa", "project-bbb", h1)
+	}
+}
+
+// The hash must cover the full int32 range (including negative values from
+// uint32 → int32 wrap). This is fine — pg_try_advisory_lock(int4, int4)
+// accepts any int4 value.
+func TestStableProjectHash_AcceptsNegativeRange(t *testing.T) {
+	// Just verify it doesn't panic and returns a value.
+	h := StableProjectHash("test-id")
+	_ = h // any int32 is valid
+}
+
+// Empty string is a valid input (degenerate but must not panic).
+func TestStableProjectHash_EmptyString(t *testing.T) {
+	h := StableProjectHash("")
+	_ = h // must not panic
+}
+
+// Verify the key constants are in the expected ranges and non-overlapping.
+func TestAdvisoryLockKeys_NonOverlapping(t *testing.T) {
+	singletonKeys := []AdvisoryLockKey{
+		LockScheduleEvaluator,
+		LockAgentHeartbeatTimeout,
+		LockAgentStalledDetection,
+		LockSoftDeletePurge,
+		LockGitHubAppHealthCheck,
+	}
+
+	seen := make(map[AdvisoryLockKey]bool, len(singletonKeys)+1)
+	for _, k := range singletonKeys {
+		if seen[k] {
+			t.Errorf("duplicate singleton key: %d", k)
+		}
+		seen[k] = true
+	}
+
+	// LockWorkspaceProvision is in a different range from singletons.
+	if seen[LockWorkspaceProvision] {
+		t.Errorf("LockWorkspaceProvision %d collides with a singleton key", LockWorkspaceProvision)
+	}
+
+	// Verify the ranges are visually distinct (different 0x5C10_0xxx vs 0x5C10_1xxx).
+	for _, k := range singletonKeys {
+		if int64(k)&0xFFFF0000 != 0x5C100000 {
+			t.Errorf("singleton key %d (0x%X) not in expected range 0x5C10_0xxx", k, int64(k))
+		}
+	}
+	if int64(LockWorkspaceProvision)&0xFFFF0000 != 0x5C100000 {
+		// Both are in 0x5C10_xxxx but the lower 16 bits distinguish singleton vs per-object.
+		// LockWorkspaceProvision should be >= 0x5C10_1000.
+		if int64(LockWorkspaceProvision) < 0x5C101000 {
+			t.Errorf("LockWorkspaceProvision %d (0x%X) should be >= 0x5C10_1000 to separate from singletons",
+				LockWorkspaceProvision, int64(LockWorkspaceProvision))
+		}
+	}
+}

--- a/pkg/store/entadapter/locking.go
+++ b/pkg/store/entadapter/locking.go
@@ -64,6 +64,61 @@ var (
 	_ store.ScheduledEventClaimer = (*CompositeStore)(nil)
 )
 
+// TryAdvisoryLockObject acquires a per-object advisory lock using Postgres's
+// two-integer form: pg_try_advisory_lock(int4 classid, int4 objid).
+//
+// This is the per-project provisioning guard. Two agents for the same project
+// (same classID + same objID derived from the project ID hash) contend on the
+// same lock; agents for different projects never contend.
+//
+// The implementation mirrors TryAdvisoryLock but uses the two-int form for
+// both lock and unlock. On SQLite it is a no-op (always acquired).
+func (c *CompositeStore) TryAdvisoryLockObject(ctx context.Context, classID store.AdvisoryLockKey, objID int32) (bool, func() error, error) {
+	if !c.isPostgres() {
+		return true, noopRelease, nil
+	}
+
+	db := c.DB()
+	if db == nil {
+		return true, noopRelease, nil
+	}
+
+	acquireCtx, cancelAcquire := context.WithTimeout(ctx, advisoryLockTimeout)
+	defer cancelAcquire()
+
+	conn, err := db.Conn(acquireCtx)
+	if err != nil {
+		return false, noopRelease, fmt.Errorf("advisory lock object: acquiring connection: %w", err)
+	}
+
+	var acquired bool
+	if err := conn.QueryRowContext(acquireCtx,
+		"SELECT pg_try_advisory_lock($1, $2)", int32(classID), objID,
+	).Scan(&acquired); err != nil {
+		_ = conn.Close()
+		return false, noopRelease, fmt.Errorf("advisory lock object: pg_try_advisory_lock(%d, %d): %w", int32(classID), objID, err)
+	}
+
+	if !acquired {
+		_ = conn.Close()
+		return false, noopRelease, nil
+	}
+
+	release := func() error {
+		unlockCtx, cancel := context.WithTimeout(context.Background(), advisoryLockTimeout)
+		defer cancel()
+		_, unlockErr := conn.ExecContext(unlockCtx,
+			"SELECT pg_advisory_unlock($1, $2)", int32(classID), objID,
+		)
+		closeErr := conn.Close()
+		if unlockErr != nil {
+			return fmt.Errorf("advisory lock object: pg_advisory_unlock(%d, %d): %w", int32(classID), objID, unlockErr)
+		}
+		return closeErr
+	}
+	return true, release, nil
+}
+
 // isPostgres reports whether the shared Ent client is talking to Postgres.
 func (c *CompositeStore) isPostgres() bool {
 	return c.client.Driver().Dialect() == dialect.Postgres

--- a/pkg/store/entadapter/locking_test.go
+++ b/pkg/store/entadapter/locking_test.go
@@ -128,6 +128,41 @@ func TestClaimScheduledEvent_MissingLoses(t *testing.T) {
 	assert.False(t, won)
 }
 
+// On SQLite the two-int advisory lock is a no-op that always succeeds.
+func TestTryAdvisoryLockObject_SQLiteAlwaysAcquires(t *testing.T) {
+	c := newTestCompositeStore(t)
+	ctx := context.Background()
+
+	acquired, release, err := c.TryAdvisoryLockObject(ctx, store.LockWorkspaceProvision, 42)
+	require.NoError(t, err)
+	assert.True(t, acquired, "SQLite two-int advisory lock must always acquire")
+	require.NotNil(t, release)
+	require.NoError(t, release())
+
+	// A second concurrent acquisition on the same (classID, objID) also succeeds.
+	acquired2, release2, err := c.TryAdvisoryLockObject(ctx, store.LockWorkspaceProvision, 42)
+	require.NoError(t, err)
+	assert.True(t, acquired2)
+	require.NoError(t, release2())
+}
+
+// Two-int locks with different objIDs are independent.
+func TestTryAdvisoryLockObject_SQLiteDifferentObjIDsIndependent(t *testing.T) {
+	c := newTestCompositeStore(t)
+	ctx := context.Background()
+
+	acq1, rel1, err := c.TryAdvisoryLockObject(ctx, store.LockWorkspaceProvision, 1)
+	require.NoError(t, err)
+	assert.True(t, acq1)
+
+	acq2, rel2, err := c.TryAdvisoryLockObject(ctx, store.LockWorkspaceProvision, 2)
+	require.NoError(t, err)
+	assert.True(t, acq2)
+
+	require.NoError(t, rel1())
+	require.NoError(t, rel2())
+}
+
 // Under concurrent claims of the same event, exactly one wins. This mirrors two
 // replicas recovering the same pending event on startup.
 func TestClaimScheduledEvent_ConcurrentSingleWinner(t *testing.T) {

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -189,6 +189,47 @@ const (
 	WorkspaceModePerAgent = "per-agent"
 )
 
+// WorkspaceSharingMode is the canonical set of workspace sharing modes from the
+// glossary. These three modes govern how workspaces are allocated to agents and
+// determine which storage backend is used (NFS-shared vs node-local).
+type WorkspaceSharingMode string
+
+const (
+	// SharingModeSharedPlain: one workspace directory mounted into every agent,
+	// no per-agent isolation. Used for plain/non-git projects.
+	// Maps from label value "shared".
+	SharingModeSharedPlain WorkspaceSharingMode = "shared-plain"
+
+	// SharingModeClonePerAgent: each agent gets its own full git clone.
+	// Nothing is shared, so this stays on node-local storage (NOT NFS).
+	// Maps from label value "per-agent".
+	SharingModeClonePerAgent WorkspaceSharingMode = "clone-per-agent"
+
+	// SharingModeWorktreePerAgent: each agent gets its own git worktree over
+	// one shared checkout. The shared checkout + all worktrees live on NFS.
+	// Maps from label value "worktree-per-agent".
+	// Note: not yet on Hub-managed projects — reserved for Phase 1+.
+	SharingModeWorktreePerAgent WorkspaceSharingMode = "worktree-per-agent"
+)
+
+// ResolveWorkspaceSharingMode maps a workspace mode label value (wire format) to
+// the canonical WorkspaceSharingMode. Empty or unknown values default to
+// SharingModeSharedPlain for backward compatibility (existing projects without
+// an explicit label are treated as shared).
+func ResolveWorkspaceSharingMode(label string) WorkspaceSharingMode {
+	switch label {
+	case WorkspaceModeShared, "shared-plain":
+		return SharingModeSharedPlain
+	case WorkspaceModePerAgent, "clone-per-agent":
+		return SharingModeClonePerAgent
+	case "worktree-per-agent":
+		return SharingModeWorktreePerAgent
+	default:
+		// Empty or unrecognized: default to shared-plain.
+		return SharingModeSharedPlain
+	}
+}
+
 // Project represents a project/agent group in the Hub database.
 type Project struct {
 	// Identity

--- a/pkg/store/models_test.go
+++ b/pkg/store/models_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import "testing"
+
+func TestResolveWorkspaceSharingMode(t *testing.T) {
+	tests := []struct {
+		label string
+		want  WorkspaceSharingMode
+	}{
+		// Canonical label values
+		{label: "shared", want: SharingModeSharedPlain},
+		{label: "per-agent", want: SharingModeClonePerAgent},
+		{label: "worktree-per-agent", want: SharingModeWorktreePerAgent},
+
+		// Canonical enum values (accepted as aliases)
+		{label: "shared-plain", want: SharingModeSharedPlain},
+		{label: "clone-per-agent", want: SharingModeClonePerAgent},
+
+		// Empty → default (shared-plain)
+		{label: "", want: SharingModeSharedPlain},
+
+		// Unknown → default (shared-plain)
+		{label: "unknown-mode", want: SharingModeSharedPlain},
+		{label: "SHARED", want: SharingModeSharedPlain}, // case-sensitive: unrecognized → default
+	}
+
+	for _, tt := range tests {
+		t.Run("label="+tt.label, func(t *testing.T) {
+			got := ResolveWorkspaceSharingMode(tt.label)
+			if got != tt.want {
+				t.Errorf("ResolveWorkspaceSharingMode(%q) = %q, want %q", tt.label, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkspaceSharingMode_Constants(t *testing.T) {
+	// Verify the existing label constants are unchanged (lossless migration).
+	if WorkspaceModeShared != "shared" {
+		t.Errorf("WorkspaceModeShared = %q, want %q", WorkspaceModeShared, "shared")
+	}
+	if WorkspaceModePerAgent != "per-agent" {
+		t.Errorf("WorkspaceModePerAgent = %q, want %q", WorkspaceModePerAgent, "per-agent")
+	}
+	if LabelWorkspaceMode != "scion.dev/workspace-mode" {
+		t.Errorf("LabelWorkspaceMode = %q, want %q", LabelWorkspaceMode, "scion.dev/workspace-mode")
+	}
+
+	// Verify the new typed constants have the expected string values.
+	if SharingModeSharedPlain != "shared-plain" {
+		t.Errorf("SharingModeSharedPlain = %q, want %q", SharingModeSharedPlain, "shared-plain")
+	}
+	if SharingModeClonePerAgent != "clone-per-agent" {
+		t.Errorf("SharingModeClonePerAgent = %q, want %q", SharingModeClonePerAgent, "clone-per-agent")
+	}
+	if SharingModeWorktreePerAgent != "worktree-per-agent" {
+		t.Errorf("SharingModeWorktreePerAgent = %q, want %q", SharingModeWorktreePerAgent, "worktree-per-agent")
+	}
+}

--- a/scratch/apitest/main.go
+++ b/scratch/apitest/main.go
@@ -5,8 +5,9 @@
 // internal network. Not part of the product.
 //
 // Env:
-//   A_BASE, B_BASE   base URLs (e.g. http://localhost:8080, http://10.128.15.241:8080)
-//   A_TOK, B_TOK     admin bearer tokens (per-hub signing keys)
+//
+//	A_BASE, B_BASE   base URLs (e.g. http://localhost:8080, http://10.128.15.241:8080)
+//	A_TOK, B_TOK     admin bearer tokens (per-hub signing keys)
 package main
 
 import (

--- a/scratch/dbdiag2/main.go
+++ b/scratch/dbdiag2/main.go
@@ -1,17 +1,31 @@
 package main
-import ("context";"fmt";"os";"time";"github.com/jackc/pgx/v5")
-func main(){
- ctx:=context.Background()
- c,_:=pgx.Connect(ctx,os.Getenv("PG_DSN")); defer c.Close(ctx)
- for i:=0;i<14;i++{
-  rows,_:=c.Query(ctx,`SELECT client_addr::text, state, count(*) FROM pg_stat_activity WHERE datname='scion_test' AND client_addr IS NOT NULL GROUP BY 1,2 ORDER BY 1,2`)
-  m:=map[string]int{}
-  for rows.Next(){var a,s string;var n int;rows.Scan(&a,&s,&n);m[a+"/"+s]=n}
-  rows.Close()
-  var locks,waiting int
-  c.QueryRow(ctx,"SELECT count(*) FROM pg_locks WHERE locktype='advisory'").Scan(&locks)
-  c.QueryRow(ctx,"SELECT count(*) FROM pg_stat_activity WHERE wait_event_type='Client' AND datname='scion_test'").Scan(&waiting)
-  fmt.Printf("t+%2ds locks=%d %v\n",i*5,locks,m)
-  time.Sleep(5*time.Second)
- }
+
+import (
+	"context"
+	"fmt"
+	"github.com/jackc/pgx/v5"
+	"os"
+	"time"
+)
+
+func main() {
+	ctx := context.Background()
+	c, _ := pgx.Connect(ctx, os.Getenv("PG_DSN"))
+	defer c.Close(ctx)
+	for i := 0; i < 14; i++ {
+		rows, _ := c.Query(ctx, `SELECT client_addr::text, state, count(*) FROM pg_stat_activity WHERE datname='scion_test' AND client_addr IS NOT NULL GROUP BY 1,2 ORDER BY 1,2`)
+		m := map[string]int{}
+		for rows.Next() {
+			var a, s string
+			var n int
+			rows.Scan(&a, &s, &n)
+			m[a+"/"+s] = n
+		}
+		rows.Close()
+		var locks, waiting int
+		c.QueryRow(ctx, "SELECT count(*) FROM pg_locks WHERE locktype='advisory'").Scan(&locks)
+		c.QueryRow(ctx, "SELECT count(*) FROM pg_stat_activity WHERE wait_event_type='Client' AND datname='scion_test'").Scan(&waiting)
+		fmt.Printf("t+%2ds locks=%d %v\n", i*5, locks, m)
+		time.Sleep(5 * time.Second)
+	}
 }


### PR DESCRIPTION
## Summary

Adds NFS as a workspace storage backend so agents running on different nodes (VMs or GKE pods) can share the same project workspace. SQLite/local remains the default — no behavior change unless `server.workspace_storage.backend: nfs` is configured.

**Depends on GoogleCloudPlatform/scion#304 (Postgres Core) — base branch set to `main`.** (NFS provisioning uses Postgres advisory locks for cross-node first-access race guard.)

### What's included

- **N0 — Config foundation** — `V1WorkspaceStorageConfig` + `V1NFSConfig`/`V1NFSShare`; `VolumeMount` `nfs` type + validation; workspace-sharing-mode enum alignment (Shared-plain / Worktree-per-agent / Clone-per-agent)
- **N1 — Model A: Docker/VM** — `WorkspaceBackend` interface (`localBackend` / `nfsBackend`); broker NFS mount reconciler at startup (idempotent, systemd-managed, unhealthy on failure); path resolution redirect to NFS host mount; workspace provisioning with Postgres advisory-lock race guard (`.scion-provisioned` sentinel + `LockWorkspaceProvision`); stable UID/GID (1000:1000) branch for NFS; project-deletion cleanup; NFSMountReconciler wired into broker startup
- **N2 — Model B: GKE** — Replace EmptyDir with static RWX PVC+subPath; init-container workspace provisioning (sentinel + advisory lock); skip `kubectl cp` of workspace when `backend=nfs`; stable FSGroup/UID; generalize shared-dir PVC helpers for NFS subPath

### Architecture

- `Backend=local` (default): zero behavior change
- `Backend=nfs`: Shared-plain + Worktree-per-agent projects → shared NFS workspace; Clone-per-agent stays node-local
- Provisioning race guard: Postgres advisory lock keyed by project-id (cross-node correct)
- Tested: NM1b (two-VM auto-mount + advisory lock), NM2 (GKE Autopilot + Filestore BASIC_HDD)

### Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./pkg/runtime/... ./pkg/runtimebroker/...` passes
- [ ] Deploy with `backend: local` — zero behavior change
- [ ] NM0: Deploy with `backend: nfs` — confirm `/healthz` reports NFS healthy, workspace behavior unchanged
- [ ] NM1: Two VMs, shared Filestore — agent on VM2 sees workspace created by agent on VM1
- [ ] NM2: GKE pod mounts PVC workspace via subPath, init-container provisions, kubectl cp skipped
