### PR TITLE
feat(hub): auth proxy mode (Google IAP)

### DIFF
--- a/.design/auth-proxy-mode.md
+++ b/.design/auth-proxy-mode.md
@@ -1,0 +1,502 @@
+# Auth Proxy Mode (IAP-style header auth)
+
+## Status: Approach approved by @ptone (2026-06-05) — ready for implementation
+
+All open design decisions are resolved (see "Resolved Decisions"). Scope: add an
+exclusive **proxy** human-auth mode (Google IAP first) with verified-assertion
+provisioning, plus a hub-minted **transport-auth** layer that lets agents traverse
+the IAP / Cloud Run-invoker front door (generalizing PR #307).
+
+## Problem Statement
+
+The hub supports two human auth modes today:
+
+1. **Developer / local-workstation auth** — single-user; auth is short-circuited
+   through a locally-minted dev token (`scion_dev_*`). See `pkg/hub/devauth.go`,
+   `pkg/hub/auth.go:163`.
+2. **OAuth login** — full browser/CLI/device flows against Google and GitHub
+   (plus a partial custom OIDC provider). The hub exchanges an authorization code
+   for provider userinfo, provisions the user, and mints its own session JWT.
+   See `pkg/hub/oauth.go`, `pkg/hub/handlers_auth.go`.
+
+We want to add a **third mode: authenticating-proxy mode**, where the hub sits
+behind a trusted proxy that has already authenticated the user, and the hub
+derives the current user from proxy-supplied request headers. The first concrete
+target is **Google IAP** with its signed-header (JWT assertion) format:
+https://docs.cloud.google.com/iap/docs/signed-headers-howto
+
+Unlike OAuth, proxy mode has **no login step and no hub-minted session** — the
+proxy re-asserts the identity on *every* request. The design must reconcile this
+with the hub's existing login-time provisioning/authorization logic.
+
+## Goals
+
+- Verify Google IAP signed headers (`X-Goog-IAP-JWT-Assertion`) cryptographically
+  on each request and derive the current user from the verified assertion.
+- Provision a user on first sight if they don't exist, subject to the **existing**
+  access controls: `admin_emails`, `authorized_domains`, and
+  `user_access_mode` (`open` / `domain_restricted` / `invite_only`).
+- Make the proxy layer pluggable so non-IAP proxies (Cloudflare Access, ALB OIDC,
+  a self-managed sidecar) can be added later without touching the middleware.
+- Reuse — not duplicate — the OAuth path's provisioning and authorization logic.
+
+## Non-Goals
+
+- Replacing OAuth or dev auth. Proxy mode is an additional, independently
+  selectable mode.
+- Implementing the agent/CLI ingress story behind IAP beyond documenting it
+  (see Open Question 1). Initial scope is **human web users**.
+- A generic SAML/arbitrary-IdP integration.
+
+## Background: what already exists (and its limits)
+
+There is already a shallow proxy path in `UnifiedAuthMiddleware`
+(`pkg/hub/auth.go:139-159`):
+
+```go
+// Step 3: if no bearer token AND the request came from a trusted-proxy IP,
+// build an identity directly from X-Forwarded-User-* headers.
+if len(trustedNets) > 0 && isTrustedProxy(r, trustedNets) {
+    if user := extractProxyUser(r); user != nil { ... }
+}
+```
+
+`extractProxyUser` (`pkg/hub/auth.go:379`) reads `X-Forwarded-User-Id/Email/Name/Role`
+and synthesizes an `AuthenticatedUser`. The plumbing is useful but **insufficient
+for IAP**:
+
+- **No signature verification.** Trust is based solely on the source IP CIDR
+  (`TrustedProxies`). IAP instead hands us a *signed* JWT we should verify; IP
+  trust alone is brittle (NAT, mesh, misconfig) and is not what IAP expects.
+- **No provisioning.** It fabricates an identity from headers and never consults
+  the user store — no canonical user UUID, role, or `status` (suspended?) lookup,
+  and no create-if-not-exists.
+- **No access control.** `domain_restricted` / `invite_only` / `admin_emails` are
+  never applied on this path.
+- **Header trust mismatch.** IAP's *unsigned* convenience headers
+  (`X-Goog-Authenticated-User-Email` / `-Id`) must **not** be trusted; only the
+  signed assertion is safe.
+
+Good news — the pieces we need to reuse already exist and are factored:
+
+- Authorization: `checkUserAuthorized(ctx, email, authorizedDomains, adminEmails, accessMode, store)`
+  (`pkg/hub/handlers_auth.go:1268`) — admin bypass, domain match, allow-list.
+- Role assignment: `determineUserRole(email, adminEmails)` via
+  `Server.getUserRole` (`handlers_auth.go`).
+- Identity model already reserves a proxy slot: `AuthTypeProxy = "proxy"`
+  (`pkg/hub/identity.go:202`).
+
+The find-or-create user block is currently **duplicated** in the OAuth handlers
+(`handlers_auth.go:257-292` and `401-436`). This design extracts it so the proxy
+path and both OAuth call sites share one implementation.
+
+## Google IAP signed-header primer
+
+- **Header:** `X-Goog-IAP-JWT-Assertion`, value is a compact JWT.
+- **Algorithm:** `ES256` (ECDSA P-256).
+- **Public keys:** JWKS at `https://www.gstatic.com/iap/verify/public_key-jwk`,
+  selected by the JWT `kid`. Must be cached and periodically refreshed (keys rotate).
+- **`iss`:** `https://cloud.google.com/iap`.
+- **`aud`:** deployment-specific and **must** be validated:
+  - GCE/GKE backend service: `/projects/PROJECT_NUMBER/global/backendServices/BACKEND_SERVICE_ID`
+  - App Engine: `/projects/PROJECT_NUMBER/apps/PROJECT_ID`
+- **Claims:** `sub` = `accounts.google.com:<numeric-id>`, `email` =
+  `accounts.google.com:<address>` (note the IdP prefix — must be stripped),
+  optional `hd` (Workspace hosted domain), `iat`/`exp` (validate with small skew).
+- The unsigned `X-Goog-Authenticated-User-{Email,Id}` headers are spoofable if a
+  request ever reaches the hub without traversing IAP; we ignore them entirely.
+
+## Proposed Design
+
+### 1. A `ProxyAuthenticator` abstraction
+
+Introduce a small interface so the middleware is provider-agnostic:
+
+```go
+// ProxyUserInfo is the verified identity extracted from proxy headers.
+type ProxyUserInfo struct {
+    Subject     string // stable provider subject (IdP prefix stripped)
+    Email       string // verified email (IdP prefix stripped, lowercased)
+    DisplayName string // best-effort; may be empty for IAP
+    Domain      string // hd claim, if present
+}
+
+// ProxyAuthenticator verifies proxy-supplied auth on a request and returns the
+// verified user. (nil, nil) = "no proxy assertion present" (fall through);
+// (nil, err) = assertion present but invalid (reject).
+type ProxyAuthenticator interface {
+    Authenticate(r *http.Request) (*ProxyUserInfo, error)
+    Name() string // for logging/metrics, e.g. "iap"
+}
+```
+
+Implementations:
+
+- **`IAPAuthenticator`** (new) — verifies `X-Goog-IAP-JWT-Assertion`:
+  parse JWT → look up `kid` in cached JWKS → verify ES256 signature → check
+  `iss`, `aud` (against configured audience), `exp`/`iat` (±skew) → strip
+  `accounts.google.com:` prefixes → return `ProxyUserInfo`.
+  JWKS is fetched lazily and cached with periodic refresh + on-miss refresh for
+  rotated `kid`s.
+- **`HeaderProxyAuthenticator`** (refactor of today's `extractProxyUser`) — keeps
+  the `X-Forwarded-User-*` + IP-trust behavior for self-managed proxies, now
+  routed through the same provisioning path. Not the initial focus but preserved.
+
+Selecting an external JWT library: prefer an already-vendored one. Decision point
+— see Open Question 3.
+
+### 2. User provisioning service (shared)
+
+Extract the duplicated find-or-create block into one method on `Server`:
+
+```go
+// provisionUser resolves a verified external identity to a stored user,
+// applying access controls and creating the user on first sight.
+// Returns (nil, errAccessDenied) when the user is not authorized.
+func (s *Server) provisionUser(ctx context.Context, info ExternalUserInfo) (*store.User, error)
+```
+
+Behavior (identical to today's OAuth path, just centralized):
+
+1. `checkUserAuthorized(...)` → deny if not permitted.
+2. `GetUserByEmail`; if missing, `CreateUser` with `Role = getUserRole(email)`,
+   `Status = "active"`.
+3. If found: refresh `LastLogin`, backfill display/avatar, promote to admin if
+   newly listed, reject if `Status == "suspended"`.
+4. `ensureHubMembership(ctx, store, user.ID)`.
+
+Both OAuth call sites (`handlers_auth.go:257`, `:401`) are refactored to call this,
+removing the duplication. The proxy middleware calls the same method.
+
+### 3. Middleware integration & precedence
+
+Add a proxy step to `UnifiedAuthMiddleware` (`pkg/hub/auth.go`). Precedence,
+highest first:
+
+1. Agent token (`X-Scion-Agent-Token` / agent JWT) — unchanged.
+2. Broker HMAC (`X-Scion-Broker-ID`) — unchanged.
+3. Bearer token (dev / UAT / user JWT) — unchanged.
+4. **Proxy authenticator** (new) — runs when configured and no higher-priority
+   credential matched. Replaces the current IP-only `extractProxyUser` branch.
+
+Keeping bearer/agent ahead of proxy means internal/non-IAP ingress (agents, CLI,
+service tokens) still works even when the proxy front-end is enabled — important
+for the agent-ingress question below.
+
+On a verified proxy assertion the middleware calls `provisionUser`, then sets the
+identity (canonical stored user — real UUID/role, not header-derived) and
+`AuthTypeProxy`. To avoid a DB round-trip on every request, wrap the resolution
+in a short-TTL cache keyed by verified email (e.g. 30–60s); the signature check
+still runs every request, only the store lookup is cached. Cache TTL is a tuning
+knob — Open Question 4.
+
+### 4. Configuration
+
+New `Auth.Proxy` section in `pkg/config/hub_config.go`, surfaced through
+`ServerConfig`/`AuthConfig` and wired in `cmd/server_foreground.go` (alongside the
+existing `DevAuthToken`/`UserAccessMode` wiring at `:868`, `:1132`):
+
+```yaml
+auth:
+  mode: proxy              # oauth | proxy | dev  — exclusive human auth mode
+  proxy:
+    # consulted only when mode == proxy
+    provider: iap            # iap | header
+    iap:
+      audience: "/projects/123456789/global/backendServices/987654321"
+      # issuer + JWKS URL default to Google's; overridable for testing
+    requireTrustedProxyIP: false   # optional defense-in-depth IP allowlist
+  # transport (outer/platform) auth the hub instructs agents to carry.
+  # Drives which entries the refresh endpoint returns (see "Generalized token refresh").
+  transport:
+    mode: iap                # none | cloudrun_invoker | iap
+    oidcAudience: ""         # IAP client ID (iap) or hub URL (invoker); empty = derive
+    platformAuthSA: "scion-transport-auth@PROJECT.iam.gserviceaccount.com"
+  # reuses existing knobs for provisioning:
+  userAccessMode: domain_restricted
+  authorizedDomains: ["example.com"]
+  adminEmails: ["admin@example.com"]
+```
+
+`auth.mode` is an **exclusive** selector — `proxy` and `oauth` are never both
+active (Decision 4). In `proxy` mode the OAuth handlers and `/auth/providers` are
+disabled. `user_access_mode`, `authorized_domains`, `admin_emails` are **reused
+as-is** for proxy provisioning — no new access-control concepts.
+`auth.transport.mode` (distinct from `auth.mode`) is the server-side source of
+truth for which transport tokens the refresh endpoint hands back to agents.
+
+### 5. Logout / session semantics
+
+In proxy mode the hub does not own the session, so hub `/logout` cannot end it.
+`/api/v1/auth/logout` should become a no-op (or redirect to IAP's
+`/_gcp_iap/clear_login_cookie`). Because mode is exclusive, the login UI renders a
+proxy-mode view with **no** OAuth provider buttons (extend the existing
+`devAuthEnabled` gate at `web.go:1549` with the active `auth.mode`); `/auth/providers`
+returns empty/unavailable in proxy mode.
+
+## Security Considerations
+
+- **Verify, don't trust headers.** Only the signed assertion is authoritative;
+  the unsigned `X-Goog-Authenticated-User-*` headers are ignored.
+- **Audience binding** is mandatory — without it, a JWT minted for a different
+  IAP-protected service would be accepted.
+- **Bypass risk.** The hub must be reachable *only* through IAP for the human
+  surface; any path that reaches the hub directly could spoof headers — except
+  the verified-JWT path is safe regardless, since forged assertions fail the
+  signature check. The optional `requireTrustedProxyIP` adds belt-and-suspenders.
+- **Key rotation / availability.** Cache JWKS; refresh on unknown `kid`; tolerate
+  transient JWKS-endpoint failures by serving the last good key set.
+- **Clock skew.** Allow a small leeway on `exp`/`iat`.
+- **Suspended users.** `provisionUser` must reject `status == "suspended"` even
+  though IAP would still authenticate them upstream.
+
+## Dual-layer auth: agent/service ingress (resolved — generalize PR #307)
+
+Agents do **not** need a separate non-proxied ingress. They traverse the same
+front door using a two-layer credential, generalizing the Cloud Run pattern from
+[PR #307](https://github.com/GoogleCloudPlatform/scion/pull/307):
+
+- **Outer (platform) layer** — `Authorization: Bearer <Google OIDC identity token>`,
+  fetched from the GCE metadata server by `pkg/sciontool/hub/oidc.go`. This
+  satisfies the platform guard (Cloud Run invoker IAM, or IAP programmatic access).
+- **App layer** — `X-Scion-Agent-Token: <scion JWT>`, the existing hub agent auth.
+  Because it's a custom header, it never collides with the outer `Authorization`.
+
+The two scenarios differ **only in the OIDC audience**:
+
+- **Cloud Run invoker:** `aud` = the hub URL (current default in `oidc.go`).
+- **IAP:** `aud` = the **IAP OAuth client ID**. IAP validates the token, then
+  injects `X-Goog-IAP-JWT-Assertion` asserting the *service account's* identity.
+
+`oidc.go` already supports this via `SCION_HUB_OIDC_AUDIENCE`. Generalization work:
+formalize audience selection so an IAP deployment sets the IAP client ID (config /
+env), rather than defaulting to the hub URL. No three-layer case to handle — per
+the deployment owner, when IAP and invoker guards are both present the IAP service
+agent carries the invoker role, so the agent still sends a single outer token.
+
+**Hub-side consequence (important precedence rule):** an agent request arriving
+through IAP carries *both* `X-Goog-IAP-JWT-Assertion` (the service account) *and*
+`X-Scion-Agent-Token`. The middleware checks the agent token **first** (Step 1),
+so the request is identified as the agent. When any app-layer credential
+(agent/broker/bearer) is present, the proxy assertion is treated as **transport
+only** and is **not** used to provision a user — we never create user records for
+service-account identities. The proxy authenticator runs only when no app-layer
+credential matched (i.e. genuine human IAP traffic). This is already the ordering
+in §3.
+
+**One residual nuance to be aware of:** `Authorization`-based *scion* credentials
+(user JWT, `scion_pat_` UAT) cannot coexist with an outer Google OIDC token behind
+a Cloud Run invoker, because there is only one `Authorization` header. This only
+affects a human CLI hitting an invoker-guarded hub directly; it does not affect
+agents (custom header) or IAP human traffic (assertion header). Out of initial
+scope, but noted — a future option is to also accept UATs via a custom header.
+
+## Agent OIDC identity & bootstrap (resolved)
+
+### How PR #307 makes first contact today
+
+PR #307 has **no** chicken-egg because it uses the agent's **ambient** GCP
+identity: `oidc.go` calls the local metadata server
+(`instance/service-accounts/default/identity?audience=<hub URL>`). This works on
+the very first request because the GKE pod already has a workload-identity SA
+attached and that SA was pre-granted the Cloud Run invoker role. The cost is
+exactly what we want to avoid:
+
+- **Policy sprawl:** every agent's compute SA, across every project, must hold the
+  invoker (or IAP-access) role — or we lean on a broad
+  `principalSet://…/type/ServiceAccount` grant per project.
+- **Coupling to agent GCP identity:** it only works in `passthrough` metadata
+  mode. It is wrong in `assign` mode (grants platform-auth to the agent's
+  app-purposed SA) and impossible in `block` mode (`GCPMetadataMode`,
+  `pkg/api/types.go:489`).
+
+### Goal: a hub-managed SA, decoupled from agent GCP identity
+
+Treat the outer OIDC layer as **strictly a hub-auth concern**: one hub-managed
+service account used for the platform layer by all agents in all projects,
+independent of whether the agent's own GCP identity is `block`/`passthrough`/
+`assign`. Avoid distributing a keyfile (more sensitive than the telemetry key,
+and we don't want another keyfile to manage).
+
+### Bootstrap vs. steady-state refresh (corrected — only first contact is cold)
+
+An earlier draft of this section over-claimed that "you can't refresh the
+front-door key through the front door." That is wrong for steady state, and the
+agent's own scion JWT already proves it: sciontool refreshes the scion JWT by
+calling the **hub directly** (not the broker), and it works because the refresh
+happens while the *current* credential is still valid — a sliding window. The
+same applies to the outer OIDC token:
+
+> As long as the agent refreshes **before** the current OIDC expires, the request
+> reaches the hub on the old (still-valid) token; the hub mints a fresh OIDC (it
+> manages the SA) and returns it in the response body. The platform validated the
+> inbound request; the response is just data carrying the next token.
+
+So the side channel is required **only for the genuinely cold case** — the very
+first token, before the agent has ever connected. Everything after that rides the
+front door, exactly like the scion JWT.
+
+Two distinct phases:
+
+1. **First contact (cold — side channel required).** The agent has no OIDC yet, so
+   it cannot call the hub. The hub mints the initial OIDC token at dispatch
+   (impersonating the hub-managed SA) and includes it in the **dispatch payload**,
+   which already flows hub → broker → agent env injection alongside
+   `SCION_AUTH_TOKEN` (`cmd/hub.go:449`). That path is hub-originated and not behind
+   IAP. One-time, no chicken-egg.
+2. **Steady-state refresh (warm — through the hub).** The agent maintains a rolling
+   OIDC via a background ticker that refreshes well before the ~1h expiry. Simplest
+   surface: **piggyback on the existing scion-JWT refresh** — the refresh response
+   returns both a new scion access token *and* a fresh OIDC token, sliding both
+   layers in one call. The refresh is authenticated by the agent's scion identity,
+   so only legitimately-connected agents get fresh platform tokens. No broker
+   involvement; matches how the scion JWT already works.
+
+Google ID tokens are fixed ~1h with no refresh-token concept, so the background
+ticker (sub-1h cadence) is what keeps a long-running *idle* agent from ever
+letting the OIDC lapse. A stopped/restarted agent simply re-bootstraps via dispatch
+(phase 1) — the same way it re-acquires its scion token.
+
+### Options for who holds the minting capability
+
+- **A — Keyfile for the hub-managed SA.** Inject the SA JSON key; agent self-mints
+  ID tokens. Trivial, but a long-lived auth-grade secret in every agent container.
+  **Rejected** (per deployment owner).
+- **B — Impersonate via the agent's own GCP identity.** Agent's ambient SA gets
+  `serviceAccountTokenCreator` on the hub SA. Re-introduces per-SA IAM and
+  re-couples to GCP identity — breaks in `block` mode. **Not recommended.**
+- **C — Hub mints (recommended).** The **hub** impersonates the single hub-managed
+  SA for both phase 1 (dispatch) and phase 2 (refresh response). The auth-grade
+  minting capability lives **only in the hub**; agents hold no SA credential and
+  need no GCP identity (works even in `block` mode). The **broker is just the
+  dispatch conduit** it already is — it needs **no** token-minting IAM grant. Only
+  the hub's runtime SA needs `serviceAccountTokenCreator` on the managed SA.
+
+This is simpler than the earlier "broker mints / broker relays" variants, which the
+corrected refresh model makes unnecessary: the broker never mints. (The broker's
+*own* control channel to the hub still authenticates with the broker's ambient infra
+SA — one invoker grant on that SA — but that is a small, fixed, infra-managed set,
+not the per-agent sprawl we're avoiding.)
+
+**Decoupling:** the agent needs no GCP identity for hub auth; the sensitive
+credential never leaves the hub. Strictly better than the telemetry-key model.
+
+**Generalizing `oidc.go`:** make its token source pluggable —
+`metadataTokenSource` (PR #307 / passthrough) vs an `injectedTokenSource` (phase 1)
+that is then refreshed via the hub (phase 2). Audience is set per scenario (IAP
+client ID, or hub URL for invoker).
+
+**Sub-decisions (resolved):**
+
+- **Dedicated platform/transport-auth SA — confirmed.** A dedicated service account
+  used *only* for the invoker/IAP transport layer, **owned and managed by the hub
+  SA** (the hub SA holds `serviceAccountTokenCreator`/`getOpenIdToken` on it and
+  impersonates it to mint agent ID tokens). It is never used for anything but the
+  platform guard; its asserted identity is ignored as transport at the app layer
+  (per §"Dual-layer auth").
+- **Piggyback on the refresh endpoint — confirmed, generalized to an array.** Refactor
+  the refresh response to return an **array of updated tokens** rather than a single
+  token pair. The set of tokens returned is driven by a **server config setting**
+  that declares the system's overall auth/transport configuration, so the client is
+  config-light and learns what to maintain from the server. See §"Generalized token
+  refresh" below.
+
+### Generalized token refresh (array payload)
+
+The agent refresh endpoint is refactored from "return a scion access/refresh token"
+to "return the set of credentials this deployment requires the client to maintain."
+
+```jsonc
+// Response from the agent token refresh endpoint
+{
+  "tokens": [
+    { "layer": "app",       "type": "scion_access",   "value": "...", "expiresIn": 900 },
+    { "layer": "app",       "type": "scion_refresh",  "value": "...", "expiresIn": 604800 },
+    // present only when transport auth is configured (IAP / Cloud Run invoker):
+    { "layer": "transport", "type": "google_oidc",    "value": "...",
+      "audience": "<iap-client-id|hub-url>", "expiresIn": 3600 }
+  ]
+}
+```
+
+- Which entries appear is decided **server-side** from a config setting describing
+  the deployment's transport mode (e.g. `none` / `cloudrun_invoker` / `iap`), so the
+  same client binary works across deployments without per-mode flags.
+- The client applies each entry to the right place by `layer`/`type`: app tokens to
+  the scion-token store; `transport: google_oidc` to the OIDC transport's token
+  source (`oidc.go`), which sets `Authorization: Bearer` on outbound hub requests.
+- A `transport` token is minted by the hub via the dedicated SA with the configured
+  audience. The background ticker drives refresh on the shortest-lived entry.
+- First contact (dispatch payload) uses the **same** token-array shape, so phase 1
+  and phase 2 share one schema.
+
+## Resolved Decisions
+
+1. **Provisioning trigger — lazy, allow-list-gated.** On the first verified human
+   IAP request, `provisionUser` runs `checkUserAuthorized` and **auto-creates** the
+   user iff the email is already permitted (admin / authorized domain / for
+   `invite_only`, already allow-listed). No separate redeem/claim step; if not
+   permitted, return 403. (`invite_only` allow-listing is populated as today, via
+   admin/invite-code redemption — that just isn't part of the request-time path.)
+
+2. **JWT/JWKS — reuse `go-jose/go-jose/v4` (no new dep).** It is already vendored
+   (`go.mod`) with its `/jwt` subpackage and natively supports **ES256** and JWKS
+   (`jose.JSONWebKeySet`). `IAPAuthenticator` verifies the assertion with go-jose;
+   only a thin JWKS fetch+cache wrapper around the gstatic endpoint is new.
+
+3. **Resolution cache TTL — 60s.** Acceptable staleness for role/suspension under
+   proxy mode (deemed near-inconsequential).
+
+4. **Mode is exclusive — proxy XOR OAuth, never both.** A deployment selects *one*
+   human auth mode. Implication: a single `auth.mode` selector (e.g.
+   `oauth` | `proxy` | `dev`) gates which login surface is active; in `proxy` mode
+   the OAuth handlers and `/auth/providers` are disabled and the login UI shows no
+   provider buttons (the front door is the proxy). This is cleaner than the
+   "coexist + hide buttons" idea and removes the headless-CLI-via-device-flow
+   ambiguity — headless/agent access in proxy deployments uses the transport-token
+   path (§"Agent OIDC identity"), not OAuth device flow.
+
+## Implementation Plan (phased)
+
+**Phase 0 — refactor (no behavior change, lands independently):**
+1. Extract `provisionUser` from the two OAuth call sites
+   (`handlers_auth.go:257`, `:401`) and refactor both onto it.
+
+**Phase 1 — inbound proxy (human IAP auth):**
+2. `pkg/hub/proxyauth.go`: `ProxyAuthenticator` interface + `IAPAuthenticator`
+   (verify with `go-jose/v4`, ES256, gstatic JWKS fetch+cache) + unit tests using a
+   test key pair with overridable issuer/JWKS URL.
+3. `auth.mode` + `auth.proxy` config in `hub_config.go`/`settings_v1.go`; wire into
+   `ServerConfig`/`AuthConfig` in `cmd/server_foreground.go`.
+4. Replace the IP-only proxy branch in `UnifiedAuthMiddleware` with the
+   authenticator → `provisionUser` (allow-list-gated) → 60s resolution cache; set
+   `AuthTypeProxy`.
+5. Web login-UI: exclusive-mode gating (proxy view, no OAuth buttons),
+   `/auth/providers` disabled, logout no-op/redirect.
+
+**Phase 2 — outbound transport auth (agents through the front door):**
+6. Hub-side issuance: dedicated transport-auth SA (owned/impersonated by hub SA);
+   `auth.transport` config; mint the initial token into the dispatch payload.
+7. Refactor the agent token refresh response to the `tokens[]` array shape, driven
+   by `auth.transport.mode`; same shape reused for the dispatch payload.
+8. Agent-side (`pkg/sciontool/hub/oidc.go`): consume the `transport` token from the
+   refresh/dispatch array (pluggable source vs the PR #307 metadata source);
+   background ticker refreshes on the shortest-lived entry.
+
+**Phase 3 — docs:**
+9. Deployment guide for the IAP + Cloud Run-invoker topology.
+
+Phase 1 (inbound IAP) and Phase 2 (outbound transport) are independent and can be
+built in parallel once Phase 0 lands; Phase 2 builds on PR #307.
+
+## Files in scope
+
+- `pkg/hub/auth.go` — middleware integration, retire IP-only `extractProxyUser`.
+- `pkg/hub/proxyauth.go` *(new)* — `ProxyAuthenticator`, `IAPAuthenticator`, JWKS.
+- `pkg/hub/handlers_auth.go` — extract `provisionUser`, dedupe OAuth call sites.
+- `pkg/hub/identity.go` — reuse `AuthTypeProxy`; proxy identity wrapper if needed.
+- `pkg/config/hub_config.go`, `pkg/config/settings_v1.go` — `Auth.Proxy` config.
+- `cmd/server_foreground.go` — wiring into `ServerConfig`/`AuthConfig`.
+- `pkg/hub/web.go` — proxy-mode login-UI flag; logout semantics.
+- `pkg/sciontool/hub/oidc.go` — agent-side dual-layer transport; audience
+  selection for IAP (builds on PR #307).

--- a/.design/project-log/2026-06-05-auth-proxy-mode-phase1.md
+++ b/.design/project-log/2026-06-05-auth-proxy-mode-phase1.md
@@ -1,0 +1,102 @@
+# Auth Proxy Mode — Phase 1 Implementation
+
+**Date:** 2026-06-05  
+**Branch:** scion/auth-proxy-mode  
+**Author:** Scion Agent (auth-proxy-phase1)
+
+## Summary
+
+Implemented Phase 1 (inbound human IAP auth) of the auth-proxy-mode feature,
+delivering items 2–5 of the design plan in `.design/auth-proxy-mode.md`.
+
+## Files Added/Changed
+
+### New
+- `pkg/hub/proxyauth.go` — ProxyAuthenticator interface, ProxyUserInfo struct,
+  IAPAuthenticator (ES256 JWT verification via go-jose/v4), JWKS cache
+- `pkg/hub/proxyauth_test.go` — 13 unit tests
+
+### Modified
+- `pkg/config/hub_config.go` — Added `Mode`, `Proxy` (ProxyAuthConfig/IAPAuthConfig)
+  to DevAuthConfig
+- `pkg/config/settings_v1.go` — Added `Mode`, `Proxy` (V1ProxyConfig/V1IAPConfig)
+  to V1AuthConfig; updated both conversion functions; extended compound fields
+  and section names for env var mapping
+- `pkg/hub/auth.go` — Replaced IP-only extractProxyUser branch with
+  ProxyAuthenticator path; added ProxyUserCache (60s TTL);
+  MakeProxyUserProvisioner; added ProxyAuthenticator/ProxyUserProvisioner
+  fields to AuthConfig
+- `pkg/hub/handlers_auth.go` — Added ErrUserSuspended; suspended-user gate in
+  provisionUser; updated all 4 provisionUser callers to handle ErrUserSuspended
+- `pkg/hub/server.go` — Added AuthMode/ProxyAuth to ServerConfig; wired into
+  authConfig with MakeProxyUserProvisioner
+- `pkg/hub/web.go` — Added AuthMode to WebServerConfig; handleAuthProviders
+  returns empty in proxy mode; handleLogout redirects to IAP clear_login_cookie
+  in proxy mode
+- `cmd/server_foreground.go` — Construct IAPAuthenticator when mode==proxy &&
+  provider==iap; wire AuthMode into hub and web configs
+
+## Design Decisions
+
+### Audience/Issuer/Exp Validation
+- **Audience**: mandatory binding — IAPAuthenticator.Audience must be set,
+  validated against JWT aud claim
+- **Issuer**: defaults to `https://cloud.google.com/iap`, overridable via
+  struct field for testing
+- **Clock skew**: ±30s leeway on exp/iat
+- **JWKS URL**: defaults to gstatic, overridable for testing
+
+### JWKS Cache Design
+- Lazy fetch on first request
+- Proactive background refresh when cache > 1 hour old
+- On-miss refresh for unknown kid (key rotation)
+- Transient failure tolerance: serves last-good keys if fetch fails
+- 5s debounce to prevent stampede
+
+### Resolution Cache
+- 60s TTL keyed by verified email (per design Decision 3)
+- JWT signature verification runs every request — only the provisionUser
+  store lookup is cached
+- Implemented as ProxyUserCache (sync.RWMutex + map)
+
+### Suspended User Gate
+- Added to provisionUser — rejects Status=="suspended" with ErrUserSuspended
+- Intentional behavior change closing the pre-existing OAuth suspended-login gap
+  documented in Phase 0's NOTE comment
+- All 4 provisionUser callers updated to surface 403 "user_suspended"
+
+### Proxy Precedence
+- Proxy authenticator runs AFTER agent token (step 1), broker HMAC (step 2),
+  and bearer token (step 3) — ensuring app-layer credentials take priority
+- When no ProxyAuthenticator is configured, legacy extractProxyUser (IP-trust)
+  is preserved for backward compatibility
+
+## Test Results
+
+### New Tests (all passing)
+13 tests in proxyauth_test.go:
+- Valid assertion → correct ProxyUserInfo
+- Missing header → (nil, nil) fall-through
+- Bad signature → error
+- Wrong audience → error
+- Wrong issuer → error
+- Expired token → error
+- Custom issuer override
+- Unknown kid triggers JWKS refresh
+- Strip prefix
+- Email lowercasing
+- HD claim
+- Name() returns "iap"
+- JWKS transient failure tolerance
+
+### Pre-existing Failures (unchanged)
+~15 pre-existing "invalid UUID" failures in other hub tests (unrelated to auth):
+TestCreateAgent_ResumeFromStoppedStatus, TestPopulateAgentConfig_*, etc.
+~5 pre-existing config test failures from leaked SCION_ env vars in sandbox.
+
+## Flags / Notes
+
+- **HeaderProxyAuthenticator** (refactoring extractProxyUser behind the
+  interface) was left as a TODO — the legacy path is preserved but not
+  refactored behind the interface. Lower priority per design doc.
+- **No new dependencies** — uses already-vendored go-jose/go-jose/v4.

--- a/.design/project-log/2026-06-05-extract-provision-user.md
+++ b/.design/project-log/2026-06-05-extract-provision-user.md
@@ -1,0 +1,51 @@
+# Extract provisionUser — Phase 0 auth-proxy-mode
+
+**Date**: 2026-06-05
+**Branch**: scion/auth-proxy-mode
+**Commit**: refactor(hub): extract provisionUser, dedupe OAuth find-or-create
+
+## What changed
+
+Extracted four identical find-or-create-user blocks from OAuth handlers
+into a single `provisionUser` method on `Server` in `handlers_auth.go`.
+
+### Call sites refactored (all four)
+1. `handleAuthLogin` (~line 258) — device flow login
+2. `handleAuthToken` (~line 402) — OAuth code exchange (web/CLI)
+3. `handleCLIAuthToken` (~line 936) — CLI-specific OAuth code exchange
+4. `completeOAuthLogin` (~line 1192) — shared device flow completion
+
+All four were semantically identical — same auth check, same find-or-create
+logic, same profile backfill, same admin promotion, same hub membership
+enrollment. No differences that prevented safe consolidation.
+
+### New types
+- `ExternalUserInfo` struct (Email, DisplayName, AvatarURL) — decoupled
+  from `OAuthUserInfo` so the proxy middleware can reuse it
+- `ErrAccessDenied` sentinel error — callers map to HTTP 403
+
+### Tests added
+8 subtests in `TestProvisionUser`: create, update, backfill, admin
+promotion, domain restriction, invite-only, admin bypass, idempotency.
+
+## Suspended-user finding
+
+**None of the four OAuth blocks check `user.Status == "suspended"`.**
+A suspended user can currently log in via any OAuth path and receive
+valid tokens. The design doc says provisionUser should reject suspended
+users, but adding this check would change existing OAuth behavior.
+
+**Decision**: do NOT add the check in Phase 0. Phase 1 (proxy auth) will
+add it if needed, after a separate decision on whether to also gate the
+OAuth path.
+
+## Pre-existing test failures
+
+15 tests in `pkg/hub` fail with "invalid UUID" errors (e.g.
+`TestCreateAgent_ResumeFromStoppedStatus`). These are pre-existing and
+unrelated to this change — they use non-UUID string IDs that the store
+now validates. All auth-related tests pass.
+
+## Net impact
+- 2 files changed, 342 insertions, 175 deletions
+- ~75 fewer lines of production code (4x35 duplicated → 1x45 shared)

--- a/.design/project-log/auth-proxy-mode-phase2.md
+++ b/.design/project-log/auth-proxy-mode-phase2.md
@@ -1,0 +1,75 @@
+# Auth Proxy Mode — Phase 2 Implementation
+
+**Date:** 2026-06-05
+**Branch:** scion/auth-proxy-mode
+**Pushed SHA:** e9776f09
+
+## Summary
+
+Implemented Phase 2 (outbound transport auth) of the auth-proxy-mode feature.
+This enables agents to traverse IAP / Cloud Run invoker front doors using
+hub-minted Google OIDC ID tokens alongside their existing scion agent tokens.
+
+## Commits (5 logical chunks)
+
+1. **a34bf6e** — config: add auth.transport config types
+2. **a488b96** — hub: add TransportTokenMinter interface and implementations
+3. **b617c84** — hub: wire transport token minter into ServerConfig and dispatch
+4. **e6a11f6** — hub: extend token refresh response with generalized tokens[] array
+5. **e9776f0** — sciontool: add pluggable OIDC transport for agent outbound auth
+
+## Key Design Decisions
+
+### TransportTokenMinter interface
+- `MintIDToken(ctx, audience) (token, expiry, error)` — clean interface
+- `gcpTransportMinter`: uses IAM Credentials API (`generateIdToken`) via
+  already-vendored `google.golang.org/api/iamcredentials/v1`
+- `noopTransportMinter`: returns error when transport mode == "none"
+- `FakeTransportMinter`: exported test double
+- When mode == "none" or unset: minter is nil everywhere → zero impact
+
+### tokens[] backward compatibility
+- Response keeps existing `token` + `expires_at` fields alongside `tokens[]`
+- Old clients ignore `tokens[]`; new clients use both
+- No breaking change for existing RefreshToken parsers
+
+### Dispatch vs refresh schema
+- Dispatch uses individual env vars: `SCION_TRANSPORT_TOKEN`,
+  `SCION_TRANSPORT_AUDIENCE`, `SCION_TRANSPORT_TOKEN_EXPIRY`
+- Refresh uses the `tokens[]` JSON array in the response
+- Pragmatic deviation from "same schema" in the design doc — env vars match
+  existing dispatch conventions (SCION_AUTH_TOKEN, GITHUB_TOKEN, etc.)
+
+### Agent-side pluggable token source
+- `injectedTokenSource`: hub-provided token from dispatch env var, refreshed
+  via tokens[] array on subsequent refreshes
+- `metadataTokenSource`: GCE metadata server (PR #307 pattern, passthrough mode)
+- Selection: SCION_TRANSPORT_TOKEN env → injected; on GCE → metadata; else → disabled
+- Background ticker: uses shortest-lived token to drive refresh (5-min margin
+  for transport tokens vs 2h for scion tokens)
+
+## Files Changed
+
+| File | Action |
+|------|--------|
+| `pkg/config/hub_config.go` | Edit — add TransportAuthConfig |
+| `pkg/config/settings_v1.go` | Edit — add V1TransportConfig, conversion, env mapping |
+| `pkg/hub/transport_token.go` | **New** — minter interface, implementations, RefreshTokenEntry |
+| `pkg/hub/transport_token_test.go` | **New** — 11 tests |
+| `pkg/hub/server.go` | Edit — add transport fields to ServerConfig + Server |
+| `pkg/hub/httpdispatcher.go` | Edit — add minter field, setter, inject in 3 dispatch paths |
+| `pkg/hub/handlers.go` | Edit — extend handleAgentTokenRefresh with tokens[] |
+| `cmd/server_foreground.go` | Edit — construct minter from config |
+| `pkg/sciontool/hub/oidc.go` | **New** — pluggable OIDC sources + transport |
+| `pkg/sciontool/hub/oidc_test.go` | **New** — 23 tests |
+| `pkg/sciontool/hub/client.go` | Edit — oidcSource, RefreshTokenEntry, applyRefreshTokens |
+
+## Test Results
+
+- `go build ./...` — clean
+- `go vet ./pkg/hub/... ./pkg/config/... ./pkg/sciontool/...` — clean
+- `go test ./pkg/sciontool/hub/...` — PASS (all tests including 23 new)
+- `go test ./pkg/hub/... -run Transport|JWT|Refresh` — PASS (11 new tests)
+- `go test ./pkg/config/...` — 5 pre-existing failures (TestIsInsideProject etc.)
+- `go test ./pkg/hub/...` — 15 pre-existing 'invalid UUID' failures
+- No new failures introduced

--- a/.design/project-log/auth-proxy-mode-phase3.md
+++ b/.design/project-log/auth-proxy-mode-phase3.md
@@ -1,0 +1,88 @@
+# Auth Proxy Mode — Phase 3 Implementation (Deployment Docs)
+
+**Date:** 2026-06-05
+**Branch:** scion/auth-proxy-mode
+**Author:** Scion Agent (auth-proxy-phase3)
+
+## Summary
+
+Created the deployment guide for the IAP + Cloud Run-invoker topology,
+completing Phase 3 (the final phase) of the auth-proxy-mode feature.
+
+## Files Added/Changed
+
+| File | Action |
+|------|--------|
+| `docs-site/src/content/docs/hub-admin/auth-proxy-iap.md` | **New** — Full deployment guide |
+| `docs-site/astro.config.mjs` | Edit — Added sidebar entry under Hub Administration |
+| `.design/project-log/auth-proxy-mode-phase3.md` | **New** — This project log |
+
+## Documentation Coverage
+
+The guide covers all five deliverable sections:
+
+1. **Overview** — Three exclusive auth modes (`oauth`, `proxy`, `dev`) and when to
+   pick proxy/IAP.
+2. **Inbound (human IAP)** — `auth.mode=proxy` + `auth.proxy` config with full YAML
+   examples; audience format for GCE/GKE backend services vs App Engine; issuer/JWKS
+   overrides; `require_trusted_proxy_ip`; middleware precedence; provisioning behavior
+   (lazy, allow-list-gated, auto-create); suspended user rejection; logout semantics.
+3. **Outbound (agent transport auth)** — Dual-layer model (outer OIDC + inner
+   X-Scion-Agent-Token); `auth.transport` config (`mode`, `oidc_audience`,
+   `platform_auth_sa`); dispatch env vars (`SCION_TRANSPORT_TOKEN`,
+   `SCION_TRANSPORT_AUDIENCE`, `SCION_TRANSPORT_TOKEN_EXPIRY`); refresh `tokens[]`
+   array; agent-side token source selection (injected vs metadata vs disabled);
+   audience selection for IAP vs Cloud Run invoker.
+4. **Security notes** — Signed-only trust model; audience binding; IAP-only reachability;
+   JWKS rotation; clock skew; suspended users.
+5. **End-to-end GCP setup checklist** — IAP enablement, OAuth client/audience,
+   transport SA creation, IAM bindings, hub config, verification steps, reference
+   to cloudrun scripts.
+
+## Config Key Verification
+
+All config keys and env vars were verified against the shipped code:
+
+### Settings.yaml keys (V1 snake_case format)
+- `auth.mode` — V1AuthConfig.Mode
+- `auth.proxy.provider` — V1ProxyConfig.Provider
+- `auth.proxy.iap.audience` — V1IAPConfig.Audience
+- `auth.proxy.iap.issuer` — V1IAPConfig.Issuer
+- `auth.proxy.iap.jwks_url` — V1IAPConfig.JWKSURL
+- `auth.proxy.require_trusted_proxy_ip` — V1ProxyConfig.RequireTrustedProxyIP
+- `auth.transport.mode` — V1TransportConfig.Mode
+- `auth.transport.oidc_audience` — V1TransportConfig.OIDCAudience
+- `auth.transport.platform_auth_sa` — V1TransportConfig.PlatformAuthSA
+- `auth.user_access_mode` — V1AuthConfig.UserAccessMode
+- `auth.authorized_domains` — V1AuthConfig.AuthorizedDomains
+- `hub.admin_emails` — V1ServerHubConfig.AdminEmails
+
+### Env vars (dispatch payload)
+- `SCION_TRANSPORT_TOKEN` — httpdispatcher.go
+- `SCION_TRANSPORT_AUDIENCE` — httpdispatcher.go
+- `SCION_TRANSPORT_TOKEN_EXPIRY` — httpdispatcher.go
+
+### Agent-side env vars
+- `SCION_HUB_OIDC_AUDIENCE` — oidc.go:EnvHubOIDCAudience
+- `SCION_TRANSPORT_TOKEN` — oidc.go:EnvTransportToken
+- `SCION_TRANSPORT_AUDIENCE` — oidc.go:EnvTransportAudience
+
+## Discrepancies Between Design Doc and Shipped Code
+
+### No discrepancies found
+All config keys, env vars, and behavior documented in the guide match the
+shipped implementation. Minor differences noted:
+
+- **Dispatch schema**: The design doc proposed using the same `tokens[]` JSON
+  shape for both dispatch and refresh. The shipped implementation uses individual
+  env vars for dispatch (`SCION_TRANSPORT_TOKEN`, `SCION_TRANSPORT_AUDIENCE`,
+  `SCION_TRANSPORT_TOKEN_EXPIRY`) and `tokens[]` JSON array for refresh. This was
+  already documented in the Phase 2 project log as a pragmatic deviation matching
+  existing dispatch conventions.
+
+## Build Verification
+
+- Docs build (`npm run build`) could not be run — requires Node.js ≥22.12.0,
+  only v20.20.2 available in the sandbox.
+- Frontmatter format verified manually against sibling pages (title + description).
+- Sidebar entry added to `astro.config.mjs` matching the existing pattern.

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -883,6 +883,7 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 		CORSAllowedMethods:    cfg.Hub.CORSAllowedMethods,
 		CORSAllowedHeaders:    cfg.Hub.CORSAllowedHeaders,
 		CORSMaxAge:            cfg.Hub.CORSMaxAge,
+		AuthMode:              cfg.Auth.Mode,
 		DevAuthToken:          devAuthToken,
 		Debug:                 enableDebug,
 		AuthorizedDomains:     cfg.Auth.AuthorizedDomains,
@@ -946,6 +947,27 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 		// HubID. Without this, a JWT minted by one replica fails validation on
 		// another (cross-replica "session_expired" login loop).
 		SharedSigningSecret: resolveSessionSecret(),
+	}
+
+	// Construct proxy authenticator when auth mode is "proxy"
+	if cfg.Auth.Mode == "proxy" && cfg.Auth.Proxy != nil {
+		switch cfg.Auth.Proxy.Provider {
+		case "iap":
+			if cfg.Auth.Proxy.IAP == nil || cfg.Auth.Proxy.IAP.Audience == "" {
+				return nil, fmt.Errorf("auth.proxy.iap.audience is required when auth.mode=proxy and provider=iap")
+			}
+			hubCfg.ProxyAuth = &hub.IAPAuthenticator{
+				Audience: cfg.Auth.Proxy.IAP.Audience,
+				Issuer:   cfg.Auth.Proxy.IAP.Issuer,
+				JWKSURL:  cfg.Auth.Proxy.IAP.JWKSURL,
+			}
+			log.Printf("Proxy auth configured: provider=iap, audience=%s", cfg.Auth.Proxy.IAP.Audience)
+		case "header":
+			// TODO: HeaderProxyAuthenticator (refactor of extractProxyUser)
+			log.Printf("Proxy auth configured: provider=header (legacy IP-trust mode)")
+		default:
+			return nil, fmt.Errorf("unsupported auth.proxy.provider: %q", cfg.Auth.Proxy.Provider)
+		}
 	}
 
 	hubSrv, err := hub.New(hubCfg, s)
@@ -1174,6 +1196,7 @@ func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 		SessionSecret:      sessionSecret,
 		BaseURL:            baseURL,
 		DevAuthToken:       devAuthToken,
+		AuthMode:           cfg.Auth.Mode,
 		AuthorizedDomains:  webAuthorizedDomains,
 		AdminEmails:        webAdminEmails,
 		UserAccessMode:     cfg.Auth.UserAccessMode,

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -970,6 +970,26 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 		}
 	}
 
+	// Construct transport token minter when auth.transport is configured
+	if cfg.Auth.Transport != nil && cfg.Auth.Transport.Mode != "" && cfg.Auth.Transport.Mode != "none" {
+		if cfg.Auth.Transport.PlatformAuthSA == "" {
+			return nil, fmt.Errorf("auth.transport.platformAuthSA is required when auth.transport.mode=%q", cfg.Auth.Transport.Mode)
+		}
+		audience := cfg.Auth.Transport.OIDCAudience
+		if audience == "" && cfg.Auth.Transport.Mode == "cloudrun_invoker" {
+			// Derive audience from hub endpoint for Cloud Run invoker mode
+			audience = hubEndpoint
+		}
+		if audience == "" {
+			return nil, fmt.Errorf("auth.transport.oidcAudience is required when auth.transport.mode=%q", cfg.Auth.Transport.Mode)
+		}
+		hubCfg.TransportMode = cfg.Auth.Transport.Mode
+		hubCfg.TransportAudience = audience
+		hubCfg.TransportMinter = hub.NewGCPTransportMinter(cfg.Auth.Transport.PlatformAuthSA, "")
+		log.Printf("Transport auth configured: mode=%s, audience=%s, sa=%s",
+			cfg.Auth.Transport.Mode, audience, cfg.Auth.Transport.PlatformAuthSA)
+	}
+
 	hubSrv, err := hub.New(hubCfg, s)
 	if err != nil {
 		return nil, fmt.Errorf("hub server initialization failed: %w", err)

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -84,6 +84,7 @@ export default defineConfig({
 						{ label: 'Hub Setup (GCE)', slug: 'hub-admin/hub-setup-gce' },
 						{ label: 'Kubernetes', slug: 'hub-admin/kubernetes' },
 						{ label: 'Security', slug: 'hub-admin/auth' },
+						{ label: 'Proxy Auth (IAP)', slug: 'hub-admin/auth-proxy-iap' },
 						{ label: 'Permissions', slug: 'hub-admin/permissions' },
 						{ label: 'Observability', slug: 'hub-admin/observability' },
 						{ label: 'Metrics', slug: 'hub-admin/metrics' },

--- a/docs-site/src/content/docs/hub-admin/auth-proxy-iap.md
+++ b/docs-site/src/content/docs/hub-admin/auth-proxy-iap.md
@@ -1,0 +1,343 @@
+---
+title: Proxy Auth (Google IAP)
+description: Deploying the Scion Hub behind Google IAP with transport auth for agents.
+---
+
+This guide covers deploying a Scion Hub behind **Google Cloud Identity-Aware Proxy (IAP)**, using IAP for human authentication and hub-minted OIDC tokens for agent transport auth.
+
+## Authentication modes
+
+The Hub supports three **mutually exclusive** human authentication modes, selected by `auth.mode`:
+
+| Mode | Use case |
+|------|----------|
+| `oauth` (default) | Hub runs its own OAuth flows (Google / GitHub). |
+| `proxy` | Hub sits behind a trusted authenticating proxy (Google IAP, Cloudflare Access, etc.). |
+| `dev` | Single-user local development with auto-generated dev tokens. |
+
+Only one mode is active at a time. When `auth.mode` is `proxy`, the OAuth login UI, `/auth/providers`, and device-flow handlers are disabled. Human identity is derived entirely from the proxy's verified assertion.
+
+Choose **proxy / IAP** when the Hub is already fronted by IAP (e.g., on Cloud Run with IAP enabled, or behind a GCE/GKE IAP-protected backend service) and you want to eliminate a separate OAuth integration.
+
+## Inbound: human IAP authentication
+
+### How it works
+
+1. A user's browser request passes through IAP, which authenticates the user and injects a **signed JWT** in the `X-Goog-IAP-JWT-Assertion` header.
+2. The Hub verifies the JWT signature (ES256, via Google's JWKS endpoint), validates `iss`, `aud`, and `exp` claims, then extracts the user's email from the verified assertion.
+3. On first verified request, the Hub **provisions** the user — applying the same access controls as the OAuth path (`user_access_mode`, `authorized_domains`, `admin_emails`). If the user is not permitted, the request is rejected with 403.
+4. Suspended users are rejected regardless of IAP status.
+
+The unsigned convenience headers `X-Goog-Authenticated-User-Email` and `X-Goog-Authenticated-User-Id` are **ignored** — only the cryptographically signed assertion is trusted.
+
+### Middleware precedence
+
+The proxy authenticator runs **after** higher-priority app-layer credentials:
+
+1. Agent token (`X-Scion-Agent-Token` / agent JWT)
+2. Broker HMAC (`X-Scion-Broker-ID`)
+3. Bearer token (dev token / PAT / user JWT)
+4. **Proxy authenticator** (IAP assertion) — runs only when no app-layer credential matched
+
+This means agents and brokers traversing IAP are identified by their own credentials, not by the IAP service-account assertion.
+
+### Configuration
+
+In `settings.yaml` (under the `server` key):
+
+```yaml
+server:
+  auth:
+    mode: proxy
+    proxy:
+      provider: iap
+      iap:
+        # MANDATORY — the IAP audience for your backend.
+        # GCE/GKE backend service format:
+        #   /projects/<PROJECT_NUMBER>/global/backendServices/<BACKEND_SERVICE_ID>
+        # App Engine format:
+        #   /projects/<PROJECT_NUMBER>/apps/<PROJECT_ID>
+        audience: "/projects/123456789/global/backendServices/987654321"
+
+        # Optional overrides (defaults are correct for production IAP):
+        # issuer: "https://cloud.google.com/iap"
+        # jwks_url: "https://www.gstatic.com/iap/verify/public_key-jwk"
+
+      # Optional defense-in-depth: also verify source IP is a trusted proxy.
+      # Uses the existing trusted_proxies CIDR list.
+      require_trusted_proxy_ip: false
+
+    # Access controls — same as for OAuth mode:
+    user_access_mode: domain_restricted  # open | domain_restricted | invite_only
+    authorized_domains:
+      - example.com
+    # admin_emails is set at the hub level:
+  hub:
+    admin_emails:
+      - admin@example.com
+```
+
+#### IAP audience format
+
+The `audience` value must match the audience claim (`aud`) in the IAP-signed JWT. The format depends on the backend type:
+
+- **GCE/GKE backend service**: `/projects/<PROJECT_NUMBER>/global/backendServices/<BACKEND_SERVICE_ID>`
+- **App Engine**: `/projects/<PROJECT_NUMBER>/apps/<PROJECT_ID>`
+
+You can find this value in the Google Cloud Console under **Security → Identity-Aware Proxy** → select your backend → **Signed Header JWT Audience**.
+
+#### Issuer and JWKS overrides
+
+The defaults match Google's production IAP:
+
+| Field | Default |
+|-------|---------|
+| `issuer` | `https://cloud.google.com/iap` |
+| `jwks_url` | `https://www.gstatic.com/iap/verify/public_key-jwk` |
+
+Override these only for testing with a mock IAP issuer.
+
+### User provisioning
+
+Provisioning in proxy mode works identically to OAuth — lazy, allow-list-gated, auto-create on first verified request:
+
+- **`open`**: any verified email is allowed.
+- **`domain_restricted`**: email domain must be in `authorized_domains`.
+- **`invite_only`**: email must be pre-registered (via admin invite-code flow).
+- Emails in `admin_emails` are always allowed and auto-promoted to admin role.
+- If not permitted, the request returns **403**.
+- Suspended users are rejected even though IAP authenticates them upstream.
+
+A **60-second resolution cache** (keyed by verified email) avoids a database lookup on every request. The JWT signature is verified on every request — only the provisioning/store lookup is cached.
+
+### Logout behavior
+
+In proxy mode, the Hub does not own the session. The `/auth/logout` endpoint:
+
+- **Browser requests**: redirect to `/_gcp_iap/clear_login_cookie` (IAP's cookie-clearing endpoint).
+- **API requests**: return `200 OK` with `{"success": true, "message": "proxy mode: session is managed by the authenticating proxy"}`.
+
+## Outbound: agent transport auth
+
+When the Hub is behind IAP (or a Cloud Run invoker-only service), agents need a way to reach the Hub through the platform guard. This is solved with a **dual-layer credential model**:
+
+| Layer | Header | Purpose |
+|-------|--------|---------|
+| **Outer (transport)** | `Authorization: Bearer <Google OIDC ID token>` | Satisfies the platform guard (IAP or Cloud Run invoker IAM check). |
+| **Inner (app)** | `X-Scion-Agent-Token: <scion JWT>` | Existing Hub agent authentication. Carried as a custom header so it never collides with the outer `Authorization`. |
+
+### How it works
+
+1. **Cold start (dispatch)**: The Hub mints an initial Google OIDC ID token (impersonating a dedicated transport service account) and includes it in the agent's dispatch payload as environment variables.
+2. **Steady-state refresh**: The agent piggybacks on its existing scion-token refresh cycle. The refresh response includes a `tokens[]` array with both the new scion access token and a fresh OIDC transport token. The agent applies each token to the appropriate layer.
+3. **Background ticker**: The agent-side client drives refresh on the shortest-lived token (transport tokens have a 5-minute refresh margin vs. the ~1h Google ID token TTL).
+
+### Dispatch environment variables
+
+When transport auth is configured, the Hub injects these environment variables into the agent container at dispatch time:
+
+| Variable | Description |
+|----------|-------------|
+| `SCION_TRANSPORT_TOKEN` | Initial Google OIDC ID token for the transport layer. |
+| `SCION_TRANSPORT_AUDIENCE` | Audience the transport token was minted for (IAP client ID or hub URL). |
+| `SCION_TRANSPORT_TOKEN_EXPIRY` | Token expiry in RFC 3339 format. |
+
+### Refresh response: `tokens[]` array
+
+The agent token refresh endpoint (`POST /api/v1/agents/{id}/token/refresh`) returns a generalized `tokens[]` array alongside the legacy single-token fields for backward compatibility:
+
+```json
+{
+  "token": "...",
+  "expires_at": "2026-06-05T12:00:00Z",
+  "tokens": [
+    {
+      "layer": "app",
+      "type": "scion_access",
+      "value": "...",
+      "expiresIn": 900
+    },
+    {
+      "layer": "transport",
+      "type": "google_oidc",
+      "value": "...",
+      "expiresIn": 3600,
+      "audience": "1234567890.apps.googleusercontent.com"
+    }
+  ]
+}
+```
+
+The `transport` entry is only present when `auth.transport` is configured on the Hub. Old clients ignore `tokens[]`; new clients consume both layers.
+
+### Agent-side token source selection
+
+The agent (`pkg/sciontool/hub`) selects an OIDC token source automatically:
+
+1. **`SCION_TRANSPORT_TOKEN` env var set** → **Injected mode**: uses the hub-provided token from dispatch, refreshed via `tokens[]` on subsequent refresh calls.
+2. **Running on GCP (metadata server available)** → **Metadata mode**: fetches OIDC from the GCE metadata server using the ambient SA identity (the PR #307 pattern). Audience is set via `SCION_HUB_OIDC_AUDIENCE` or defaults to the hub URL.
+3. **Neither** → No OIDC transport (agent uses plain HTTP).
+
+Injected mode (option 1) is the recommended path for IAP deployments — it decouples agent transport auth from the agent's own GCP identity.
+
+### Transport configuration
+
+```yaml
+server:
+  auth:
+    transport:
+      # Transport auth mode:
+      #   none (default) — no transport tokens issued
+      #   cloudrun_invoker — audience = hub URL
+      #   iap — audience = IAP OAuth client ID
+      mode: iap
+
+      # OIDC audience for the transport token.
+      # For IAP:              the IAP OAuth client ID (e.g., "1234567890.apps.googleusercontent.com")
+      # For cloudrun_invoker: the hub URL (auto-derived from hub.public_url if empty)
+      oidc_audience: "1234567890.apps.googleusercontent.com"
+
+      # Dedicated service account for transport-layer auth.
+      # The hub's runtime SA impersonates this SA to mint OIDC ID tokens.
+      platform_auth_sa: "scion-transport@my-project.iam.gserviceaccount.com"
+```
+
+#### What audience to set
+
+| Transport mode | `oidc_audience` value |
+|---------------|----------------------|
+| `iap` | The **IAP OAuth client ID** (found in Cloud Console → Security → IAP → your backend → OAuth client). Format: `<client-id>.apps.googleusercontent.com` |
+| `cloudrun_invoker` | The **Hub's URL** (e.g., `https://hub.example.com`). If left empty, derived from `hub.public_url`. |
+
+:::note
+When both IAP and Cloud Run invoker guards are present on the same service, the IAP service agent carries the Cloud Run invoker role automatically. Agents send a single outer token targeting the IAP audience — no three-layer case.
+:::
+
+### Hub-managed transport SA (Option C)
+
+The Hub uses a dedicated service account solely for transport-layer auth. The Hub's runtime SA impersonates this SA via the IAM Credentials API (`generateIdToken`) to mint OIDC ID tokens for agents. This design:
+
+- Keeps the auth-grade minting capability in the Hub only — agents hold no SA credential.
+- Works regardless of the agent's GCP metadata mode (`block`, `passthrough`, or `assign`).
+- Avoids distributing service account key files.
+
+**Required IAM bindings:**
+
+| Principal | Role | Target |
+|-----------|------|--------|
+| Hub's runtime SA | `roles/iam.serviceAccountTokenCreator` | Transport SA (`platform_auth_sa`) |
+| Transport SA | IAP-secured web user **or** Cloud Run invoker | The Hub's backend service |
+
+## Security notes
+
+1. **Only the signed assertion is trusted.** The unsigned `X-Goog-Authenticated-User-Email` and `X-Goog-Authenticated-User-Id` headers are completely ignored.
+2. **Audience binding is mandatory.** Without it, a JWT minted for a different IAP-protected service would be accepted. The `auth.proxy.iap.audience` field must always be set.
+3. **The Hub must be reachable only through IAP for the human surface.** Any path that reaches the Hub directly could bypass proxy authentication. The verified-JWT path is safe against header spoofing (forged assertions fail the signature check), but direct access bypasses IAP entirely. Use VPC networking, firewall rules, or Cloud Run ingress settings to enforce this.
+4. **JWKS key rotation** is handled automatically: keys are cached with hourly background refresh and on-miss refresh for rotated key IDs. Transient JWKS endpoint failures are tolerated by serving the last-good key set.
+5. **Clock skew** of ±30 seconds is allowed on `exp` and `iat` claims.
+6. **Suspended users** are rejected at the provisioning layer even though IAP still authenticates them upstream.
+
+## End-to-end GCP setup checklist
+
+### Prerequisites
+
+- A GCP project with billing enabled.
+- The Hub deployed on Cloud Run (or behind a GCE/GKE load balancer).
+- `gcloud` CLI configured with appropriate permissions.
+
+### 1. Enable IAP and create an OAuth consent screen
+
+```bash
+# Enable the IAP API
+gcloud services enable iap.googleapis.com
+
+# Configure the OAuth consent screen (if not already done)
+# Go to: Console → APIs & Services → OAuth consent screen
+```
+
+### 2. Enable IAP on the backend service
+
+```bash
+# For Cloud Run behind a load balancer:
+gcloud iap web enable \
+  --resource-type=backend-services \
+  --service=YOUR_BACKEND_SERVICE_NAME
+```
+
+Note the **IAP OAuth client ID** (found in Console → Security → IAP → your backend → click the three dots → Edit OAuth Client). You will need it for both `auth.proxy.iap.audience` and `auth.transport.oidc_audience`.
+
+Note the **signed header JWT audience** (found in Console → Security → IAP → your backend). This goes into `auth.proxy.iap.audience`.
+
+### 3. Create the transport service account
+
+```bash
+# Create a dedicated SA for transport auth
+gcloud iam service-accounts create scion-transport \
+  --display-name="Scion Transport Auth"
+
+# Grant the Hub's runtime SA permission to impersonate the transport SA
+gcloud iam service-accounts add-iam-policy-binding \
+  scion-transport@PROJECT_ID.iam.gserviceaccount.com \
+  --member="serviceAccount:HUB_RUNTIME_SA@PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountTokenCreator"
+```
+
+### 4. Grant the transport SA access to the platform guard
+
+For **IAP**:
+```bash
+# Grant IAP-secured web user access to the transport SA
+gcloud iap web add-iam-policy-binding \
+  --resource-type=backend-services \
+  --service=YOUR_BACKEND_SERVICE_NAME \
+  --member="serviceAccount:scion-transport@PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/iap.httpsResourceAccessor"
+```
+
+For **Cloud Run invoker**:
+```bash
+gcloud run services add-iam-policy-binding YOUR_SERVICE_NAME \
+  --member="serviceAccount:scion-transport@PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/run.invoker" \
+  --region=YOUR_REGION
+```
+
+### 5. Configure the Hub
+
+Create or update the `settings.yaml`:
+
+```yaml
+schema_version: "1"
+server:
+  mode: hosted
+  hub:
+    public_url: "https://hub.example.com"
+    admin_emails:
+      - admin@example.com
+  auth:
+    mode: proxy
+    proxy:
+      provider: iap
+      iap:
+        audience: "/projects/123456789/global/backendServices/987654321"
+    transport:
+      mode: iap
+      oidc_audience: "1234567890.apps.googleusercontent.com"
+      platform_auth_sa: "scion-transport@my-project.iam.gserviceaccount.com"
+    user_access_mode: domain_restricted
+    authorized_domains:
+      - example.com
+  database:
+    driver: postgres
+    url: "postgres://..."
+```
+
+### 6. Verify
+
+1. Access the Hub URL in a browser — IAP should prompt for Google login, then the Hub should show your identity.
+2. Dispatch an agent and verify it can communicate back to the Hub (check agent logs for OIDC transport messages).
+3. Check Hub logs for `Proxy auth configured: provider=iap` and `Transport auth configured: mode=iap` at startup.
+
+### Reference scripts
+
+The `scripts/cloudrun/` directory on the `pr/cloudrun-hub` branch contains reference deployment scripts (deploy.sh, entrypoint.sh, hub-settings-template.yaml) for a Cloud Run + IAP topology that can serve as a starting point.

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -183,8 +183,10 @@ func (d DatabaseConfig) ConnMaxIdleTimeDuration() (time.Duration, error) {
 	return dur, nil
 }
 
-// DevAuthConfig holds development authentication settings.
+// DevAuthConfig holds authentication settings.
 type DevAuthConfig struct {
+	// Mode selects the exclusive human auth mode: "oauth" (default), "proxy", or "dev".
+	Mode string `json:"mode,omitempty" yaml:"mode,omitempty" koanf:"mode"`
 	// Enabled indicates whether development authentication is enabled.
 	// WARNING: Not for production use.
 	Enabled bool `json:"devMode" yaml:"devMode" koanf:"devMode"`
@@ -199,6 +201,28 @@ type DevAuthConfig struct {
 	// UserAccessMode controls how user access is evaluated at login time.
 	// Values: "open" (default), "domain_restricted", "invite_only".
 	UserAccessMode string `json:"userAccessMode" yaml:"userAccessMode" koanf:"userAccessMode"`
+	// Proxy holds proxy authentication settings (consulted when Mode == "proxy").
+	Proxy *ProxyAuthConfig `json:"proxy,omitempty" yaml:"proxy,omitempty" koanf:"proxy"`
+}
+
+// ProxyAuthConfig holds proxy authentication settings.
+type ProxyAuthConfig struct {
+	// Provider selects the proxy auth provider: "iap" or "header".
+	Provider string `json:"provider" yaml:"provider" koanf:"provider"`
+	// IAP holds Google IAP-specific settings.
+	IAP *IAPAuthConfig `json:"iap,omitempty" yaml:"iap,omitempty" koanf:"iap"`
+	// RequireTrustedProxyIP enables defense-in-depth IP allowlisting.
+	RequireTrustedProxyIP bool `json:"requireTrustedProxyIP,omitempty" yaml:"requireTrustedProxyIP,omitempty" koanf:"requireTrustedProxyIP"`
+}
+
+// IAPAuthConfig holds Google IAP-specific settings.
+type IAPAuthConfig struct {
+	// Audience is the expected audience claim — MANDATORY for IAP.
+	Audience string `json:"audience" yaml:"audience" koanf:"audience"`
+	// Issuer overrides the default IAP issuer (for testing).
+	Issuer string `json:"issuer,omitempty" yaml:"issuer,omitempty" koanf:"issuer"`
+	// JWKSURL overrides the default IAP JWKS URL (for testing).
+	JWKSURL string `json:"jwksURL,omitempty" yaml:"jwksURL,omitempty" koanf:"jwksURL"`
 }
 
 // OAuthProviderConfig holds OAuth credentials for a single provider.

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -203,6 +203,25 @@ type DevAuthConfig struct {
 	UserAccessMode string `json:"userAccessMode" yaml:"userAccessMode" koanf:"userAccessMode"`
 	// Proxy holds proxy authentication settings (consulted when Mode == "proxy").
 	Proxy *ProxyAuthConfig `json:"proxy,omitempty" yaml:"proxy,omitempty" koanf:"proxy"`
+	// Transport holds transport-layer auth settings for agent outbound requests.
+	// Controls which transport tokens the hub issues to agents (dispatch + refresh).
+	Transport *TransportAuthConfig `json:"transport,omitempty" yaml:"transport,omitempty" koanf:"transport"`
+}
+
+// TransportAuthConfig holds transport-layer (outer/platform) auth settings.
+// This controls how agents authenticate to the platform guard (IAP or Cloud Run invoker)
+// when making outbound requests to the hub.
+type TransportAuthConfig struct {
+	// Mode selects the transport auth mode: "none" (default), "cloudrun_invoker", or "iap".
+	Mode string `json:"mode" yaml:"mode" koanf:"mode"`
+	// OIDCAudience is the OIDC audience for the transport token.
+	// For IAP: the IAP OAuth client ID. For cloudrun_invoker: the hub URL.
+	// Empty means derive from hub endpoint (cloudrun_invoker only).
+	OIDCAudience string `json:"oidcAudience" yaml:"oidcAudience" koanf:"oidcAudience"`
+	// PlatformAuthSA is the email of the dedicated service account used for
+	// transport-layer auth. The hub's runtime SA must hold serviceAccountTokenCreator
+	// on this SA to impersonate it via the IAM Credentials API.
+	PlatformAuthSA string `json:"platformAuthSA" yaml:"platformAuthSA" koanf:"platformAuthSA"`
 }
 
 // ProxyAuthConfig holds proxy authentication settings.

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -400,9 +400,9 @@ type V1AuthConfig struct {
 // V1ProxyConfig holds proxy authentication settings (consulted when auth.mode == "proxy").
 type V1ProxyConfig struct {
 	// Provider selects the proxy auth provider: "iap" or "header".
-	Provider string       `json:"provider,omitempty" yaml:"provider,omitempty" koanf:"provider"`
+	Provider string `json:"provider,omitempty" yaml:"provider,omitempty" koanf:"provider"`
 	// IAP holds Google IAP-specific settings.
-	IAP      *V1IAPConfig `json:"iap,omitempty" yaml:"iap,omitempty" koanf:"iap"`
+	IAP *V1IAPConfig `json:"iap,omitempty" yaml:"iap,omitempty" koanf:"iap"`
 	// RequireTrustedProxyIP enables defense-in-depth IP allowlisting.
 	RequireTrustedProxyIP bool `json:"require_trusted_proxy_ip,omitempty" yaml:"require_trusted_proxy_ip,omitempty" koanf:"require_trusted_proxy_ip"`
 }

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -394,7 +394,18 @@ type V1AuthConfig struct {
 	DevTokenFile      string         `json:"dev_token_file,omitempty" yaml:"dev_token_file,omitempty" koanf:"dev_token_file"`
 	AuthorizedDomains []string       `json:"authorized_domains,omitempty" yaml:"authorized_domains,omitempty" koanf:"authorized_domains"`
 	UserAccessMode    string         `json:"user_access_mode,omitempty" yaml:"user_access_mode,omitempty" koanf:"user_access_mode"`
-	Proxy             *V1ProxyConfig `json:"proxy,omitempty" yaml:"proxy,omitempty" koanf:"proxy"`
+	Proxy             *V1ProxyConfig     `json:"proxy,omitempty" yaml:"proxy,omitempty" koanf:"proxy"`
+	Transport         *V1TransportConfig `json:"transport,omitempty" yaml:"transport,omitempty" koanf:"transport"`
+}
+
+// V1TransportConfig holds transport-layer auth settings for agent outbound requests.
+type V1TransportConfig struct {
+	// Mode selects the transport auth mode: "none" (default), "cloudrun_invoker", or "iap".
+	Mode string `json:"mode,omitempty" yaml:"mode,omitempty" koanf:"mode"`
+	// OIDCAudience is the OIDC audience for transport tokens.
+	OIDCAudience string `json:"oidc_audience,omitempty" yaml:"oidc_audience,omitempty" koanf:"oidc_audience"`
+	// PlatformAuthSA is the dedicated SA email used for transport-layer auth.
+	PlatformAuthSA string `json:"platform_auth_sa,omitempty" yaml:"platform_auth_sa,omitempty" koanf:"platform_auth_sa"`
 }
 
 // V1ProxyConfig holds proxy authentication settings (consulted when auth.mode == "proxy").
@@ -918,6 +929,8 @@ var knownCompoundFields = []string{
 	"soft_delete_retain_files",
 	"soft_delete_retention",
 	"authorized_domains",
+	"platform_auth_sa",
+	"oidc_audience",
 	"jwks_url",
 	"broker_nickname",
 	"allowed_origins",
@@ -1011,7 +1024,7 @@ func mapEnvKeyRecursive(key string) string {
 func isSectionName(name string) bool {
 	switch name {
 	case "hub", "broker", "database", "auth", "oauth", "storage", "secrets", "cors",
-		"web", "cli", "device", "google", "github", "proxy", "iap":
+		"web", "cli", "device", "google", "github", "proxy", "iap", "transport":
 		return true
 	}
 	return false
@@ -1286,6 +1299,13 @@ func ConvertV1ServerToGlobalConfig(v1 *V1ServerConfig) *GlobalConfig {
 				}
 			}
 		}
+		if v1.Auth.Transport != nil {
+			gc.Auth.Transport = &TransportAuthConfig{
+				Mode:           v1.Auth.Transport.Mode,
+				OIDCAudience:   v1.Auth.Transport.OIDCAudience,
+				PlatformAuthSA: v1.Auth.Transport.PlatformAuthSA,
+			}
+		}
 	}
 
 	// OAuth config
@@ -1457,6 +1477,13 @@ func ConvertGlobalToV1ServerConfig(gc *GlobalConfig) *V1ServerConfig {
 				Issuer:   gc.Auth.Proxy.IAP.Issuer,
 				JWKSURL:  gc.Auth.Proxy.IAP.JWKSURL,
 			}
+		}
+	}
+	if gc.Auth.Transport != nil {
+		v1.Auth.Transport = &V1TransportConfig{
+			Mode:           gc.Auth.Transport.Mode,
+			OIDCAudience:   gc.Auth.Transport.OIDCAudience,
+			PlatformAuthSA: gc.Auth.Transport.PlatformAuthSA,
 		}
 	}
 

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -384,13 +384,37 @@ type V1DatabaseConfig struct {
 	ConnMaxIdleTime string `json:"conn_max_idle_time,omitempty" yaml:"conn_max_idle_time,omitempty" koanf:"conn_max_idle_time"`
 }
 
-// V1AuthConfig holds development authentication settings.
+// V1AuthConfig holds authentication settings.
 type V1AuthConfig struct {
-	DevMode           bool     `json:"dev_mode,omitempty" yaml:"dev_mode,omitempty" koanf:"dev_mode"`
-	DevToken          string   `json:"dev_token,omitempty" yaml:"dev_token,omitempty" koanf:"dev_token"`
-	DevTokenFile      string   `json:"dev_token_file,omitempty" yaml:"dev_token_file,omitempty" koanf:"dev_token_file"`
-	AuthorizedDomains []string `json:"authorized_domains,omitempty" yaml:"authorized_domains,omitempty" koanf:"authorized_domains"`
-	UserAccessMode    string   `json:"user_access_mode,omitempty" yaml:"user_access_mode,omitempty" koanf:"user_access_mode"`
+	// Mode selects the exclusive human auth mode: "oauth" (default), "proxy", or "dev".
+	// In proxy mode, OAuth handlers are disabled; in dev mode, dev token auth is used.
+	Mode              string         `json:"mode,omitempty" yaml:"mode,omitempty" koanf:"mode"`
+	DevMode           bool           `json:"dev_mode,omitempty" yaml:"dev_mode,omitempty" koanf:"dev_mode"`
+	DevToken          string         `json:"dev_token,omitempty" yaml:"dev_token,omitempty" koanf:"dev_token"`
+	DevTokenFile      string         `json:"dev_token_file,omitempty" yaml:"dev_token_file,omitempty" koanf:"dev_token_file"`
+	AuthorizedDomains []string       `json:"authorized_domains,omitempty" yaml:"authorized_domains,omitempty" koanf:"authorized_domains"`
+	UserAccessMode    string         `json:"user_access_mode,omitempty" yaml:"user_access_mode,omitempty" koanf:"user_access_mode"`
+	Proxy             *V1ProxyConfig `json:"proxy,omitempty" yaml:"proxy,omitempty" koanf:"proxy"`
+}
+
+// V1ProxyConfig holds proxy authentication settings (consulted when auth.mode == "proxy").
+type V1ProxyConfig struct {
+	// Provider selects the proxy auth provider: "iap" or "header".
+	Provider string       `json:"provider,omitempty" yaml:"provider,omitempty" koanf:"provider"`
+	// IAP holds Google IAP-specific settings.
+	IAP      *V1IAPConfig `json:"iap,omitempty" yaml:"iap,omitempty" koanf:"iap"`
+	// RequireTrustedProxyIP enables defense-in-depth IP allowlisting.
+	RequireTrustedProxyIP bool `json:"require_trusted_proxy_ip,omitempty" yaml:"require_trusted_proxy_ip,omitempty" koanf:"require_trusted_proxy_ip"`
+}
+
+// V1IAPConfig holds Google IAP-specific settings.
+type V1IAPConfig struct {
+	// Audience is the expected audience claim — MANDATORY for IAP.
+	Audience string `json:"audience,omitempty" yaml:"audience,omitempty" koanf:"audience"`
+	// Issuer overrides the default IAP issuer (for testing).
+	Issuer string `json:"issuer,omitempty" yaml:"issuer,omitempty" koanf:"issuer"`
+	// JWKSURL overrides the default IAP JWKS URL (for testing).
+	JWKSURL string `json:"jwks_url,omitempty" yaml:"jwks_url,omitempty" koanf:"jwks_url"`
 }
 
 // V1OAuthConfig holds OAuth provider configurations.
@@ -890,9 +914,11 @@ func versionedEnvKeyMapper(s string) string {
 // These must be recognized as single fields rather than split into nested keys.
 // IMPORTANT: Sorted longest-first so that "dev_token_file" matches before "dev_token".
 var knownCompoundFields = []string{
+	"require_trusted_proxy_ip",
 	"soft_delete_retain_files",
 	"soft_delete_retention",
 	"authorized_domains",
+	"jwks_url",
 	"broker_nickname",
 	"allowed_origins",
 	"allowed_methods",
@@ -985,7 +1011,7 @@ func mapEnvKeyRecursive(key string) string {
 func isSectionName(name string) bool {
 	switch name {
 	case "hub", "broker", "database", "auth", "oauth", "storage", "secrets", "cors",
-		"web", "cli", "device", "google", "github":
+		"web", "cli", "device", "google", "github", "proxy", "iap":
 		return true
 	}
 	return false
@@ -1235,6 +1261,9 @@ func ConvertV1ServerToGlobalConfig(v1 *V1ServerConfig) *GlobalConfig {
 
 	// Auth config
 	if v1.Auth != nil {
+		if v1.Auth.Mode != "" {
+			gc.Auth.Mode = v1.Auth.Mode
+		}
 		gc.Auth.Enabled = v1.Auth.DevMode
 		gc.Auth.Token = v1.Auth.DevToken
 		gc.Auth.TokenFile = v1.Auth.DevTokenFile
@@ -1243,6 +1272,19 @@ func ConvertV1ServerToGlobalConfig(v1 *V1ServerConfig) *GlobalConfig {
 		}
 		if v1.Auth.UserAccessMode != "" {
 			gc.Auth.UserAccessMode = v1.Auth.UserAccessMode
+		}
+		if v1.Auth.Proxy != nil {
+			gc.Auth.Proxy = &ProxyAuthConfig{
+				Provider:              v1.Auth.Proxy.Provider,
+				RequireTrustedProxyIP: v1.Auth.Proxy.RequireTrustedProxyIP,
+			}
+			if v1.Auth.Proxy.IAP != nil {
+				gc.Auth.Proxy.IAP = &IAPAuthConfig{
+					Audience: v1.Auth.Proxy.IAP.Audience,
+					Issuer:   v1.Auth.Proxy.IAP.Issuer,
+					JWKSURL:  v1.Auth.Proxy.IAP.JWKSURL,
+				}
+			}
 		}
 	}
 
@@ -1397,11 +1439,25 @@ func ConvertGlobalToV1ServerConfig(gc *GlobalConfig) *V1ServerConfig {
 
 	// Auth config
 	v1.Auth = &V1AuthConfig{
+		Mode:              gc.Auth.Mode,
 		DevMode:           gc.Auth.Enabled,
 		DevToken:          gc.Auth.Token,
 		DevTokenFile:      gc.Auth.TokenFile,
 		AuthorizedDomains: gc.Auth.AuthorizedDomains,
 		UserAccessMode:    gc.Auth.UserAccessMode,
+	}
+	if gc.Auth.Proxy != nil {
+		v1.Auth.Proxy = &V1ProxyConfig{
+			Provider:              gc.Auth.Proxy.Provider,
+			RequireTrustedProxyIP: gc.Auth.Proxy.RequireTrustedProxyIP,
+		}
+		if gc.Auth.Proxy.IAP != nil {
+			v1.Auth.Proxy.IAP = &V1IAPConfig{
+				Audience: gc.Auth.Proxy.IAP.Audience,
+				Issuer:   gc.Auth.Proxy.IAP.Issuer,
+				JWKSURL:  gc.Auth.Proxy.IAP.JWKSURL,
+			}
+		}
 	}
 
 	// OAuth config

--- a/pkg/hub/auth.go
+++ b/pkg/hub/auth.go
@@ -16,10 +16,13 @@ package hub
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
 )
@@ -40,6 +43,15 @@ type AuthConfig struct {
 	UATSvc *UserAccessTokenService
 	// TrustedProxies is a list of trusted proxy IPs/CIDRs
 	TrustedProxies []string
+	// ProxyAuthenticator is the configured proxy authenticator (for proxy auth mode).
+	// When set, it replaces the legacy IP-only extractProxyUser path.
+	ProxyAuthenticator ProxyAuthenticator
+	// ProxyUserProvisioner is a function that provisions a user from a verified
+	// proxy identity. It runs provisionUser and returns the stored user.
+	// Required when ProxyAuthenticator is set.
+	ProxyUserProvisioner func(ctx context.Context, info *ProxyUserInfo) (UserIdentity, error)
+	// AuthMode is the exclusive human auth mode: "oauth", "proxy", "dev".
+	AuthMode string
 	// Debug enables verbose logging
 	Debug bool
 	// Logger is the subsystem logger for auth middleware (defaults to slog.Default())
@@ -139,14 +151,57 @@ func UnifiedAuthMiddleware(cfg AuthConfig) func(http.Handler) http.Handler {
 			// Step 3: Extract bearer token
 			token := extractBearerToken(r)
 			if token == "" {
-				// Check for trusted proxy headers
-				if len(trustedNets) > 0 && isTrustedProxy(r, trustedNets) {
+				// Step 3a: Try proxy authenticator (new verified-assertion path)
+				if cfg.ProxyAuthenticator != nil {
+					proxyUser, proxyErr := cfg.ProxyAuthenticator.Authenticate(r)
+					if proxyErr != nil {
+						// Assertion present but invalid — reject
+						if cfg.Debug {
+							log.Debug("Proxy auth rejected", "provider", cfg.ProxyAuthenticator.Name(), "error", proxyErr)
+						}
+						writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized,
+							"invalid proxy assertion: "+proxyErr.Error(), nil)
+						return
+					}
+					if proxyUser != nil {
+						// Verified proxy identity — provision the user
+						identity, err := cfg.ProxyUserProvisioner(ctx, proxyUser)
+						if err != nil {
+							if cfg.Debug {
+								log.Debug("Proxy user provisioning failed", "email", proxyUser.Email, "error", err)
+							}
+							if errors.Is(err, ErrAccessDenied) {
+								writeError(w, http.StatusForbidden, ErrCodeForbidden,
+									"access denied: email not authorized", nil)
+							} else if errors.Is(err, ErrUserSuspended) {
+								writeError(w, http.StatusForbidden, "user_suspended",
+									"access denied: user account is suspended", nil)
+							} else {
+								writeError(w, http.StatusInternalServerError, "internal_error",
+									"user provisioning failed", nil)
+							}
+							return
+						}
+						ctx = context.WithValue(ctx, userContextKey{}, identity)
+						ctx = contextWithIdentity(ctx, identity)
+						ctx = contextWithAuthType(ctx, AuthTypeProxy)
+						if cfg.Debug {
+							log.Debug("Proxy user authenticated", "provider", cfg.ProxyAuthenticator.Name(), "email", proxyUser.Email)
+						}
+						next.ServeHTTP(w, r.WithContext(ctx))
+						return
+					}
+					// (nil, nil) = no assertion present, fall through
+				}
+
+				// Step 3b: Legacy trusted proxy headers (backward compat when no ProxyAuthenticator)
+				if cfg.ProxyAuthenticator == nil && len(trustedNets) > 0 && isTrustedProxy(r, trustedNets) {
 					if user := extractProxyUser(r); user != nil {
 						ctx = context.WithValue(ctx, userContextKey{}, user)
 						ctx = contextWithIdentity(ctx, user)
 						ctx = contextWithAuthType(ctx, AuthTypeProxy)
 						if cfg.Debug {
-							log.Debug("Proxy user authenticated", "email", user.Email())
+							log.Debug("Proxy user authenticated (legacy)", "email", user.Email())
 						}
 						next.ServeHTTP(w, r.WithContext(ctx))
 						return
@@ -444,5 +499,86 @@ func RequireRole(roles ...string) func(http.Handler) http.Handler {
 
 			next.ServeHTTP(w, r)
 		})
+	}
+}
+
+// ---- Proxy user resolution cache ----
+
+const proxyUserCacheTTL = 60 * time.Second
+
+// proxyUserCacheEntry holds a cached provisioned user identity.
+type proxyUserCacheEntry struct {
+	identity  UserIdentity
+	expiresAt time.Time
+}
+
+// ProxyUserCache is a short-TTL cache keyed by verified email wrapping the
+// provisionUser store lookup. The JWT signature verification still runs every
+// request; only the store round-trip is cached.
+type ProxyUserCache struct {
+	mu    sync.RWMutex
+	cache map[string]*proxyUserCacheEntry
+}
+
+// NewProxyUserCache creates a new proxy user resolution cache.
+func NewProxyUserCache() *ProxyUserCache {
+	return &ProxyUserCache{
+		cache: make(map[string]*proxyUserCacheEntry),
+	}
+}
+
+// Get returns a cached user identity if present and not expired.
+func (c *ProxyUserCache) Get(email string) (UserIdentity, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.cache[email]
+	if !ok || time.Now().After(entry.expiresAt) {
+		return nil, false
+	}
+	return entry.identity, true
+}
+
+// Set stores a user identity in the cache.
+func (c *ProxyUserCache) Set(email string, identity UserIdentity) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cache[email] = &proxyUserCacheEntry{
+		identity:  identity,
+		expiresAt: time.Now().Add(proxyUserCacheTTL),
+	}
+}
+
+// MakeProxyUserProvisioner creates the ProxyUserProvisioner function that
+// wraps provisionUser with a short-TTL cache. It converts the stored user
+// to the canonical UserIdentity (real UUID/role from the store).
+func MakeProxyUserProvisioner(server *Server) func(ctx context.Context, info *ProxyUserInfo) (UserIdentity, error) {
+	cache := NewProxyUserCache()
+
+	return func(ctx context.Context, info *ProxyUserInfo) (UserIdentity, error) {
+		// Check cache first (keyed by verified email)
+		if identity, ok := cache.Get(info.Email); ok {
+			return identity, nil
+		}
+
+		// Provision: authorize + find-or-create + hub membership
+		user, err := server.provisionUser(ctx, &ExternalUserInfo{
+			Email:       info.Email,
+			DisplayName: info.DisplayName,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		// Build canonical identity from stored user
+		identity := NewAuthenticatedUser(
+			user.ID,
+			user.Email,
+			user.DisplayName,
+			user.Role,
+			string(ClientTypeWeb),
+		)
+
+		cache.Set(info.Email, identity)
+		return identity, nil
 	}
 }

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -1917,9 +1917,43 @@ func (s *Server) handleAgentTokenRefresh(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
+	// Build the generalized tokens[] array.
+	// App tokens are always present; transport tokens are added when
+	// the hub has a transport minter configured.
+	tokens := []RefreshTokenEntry{
+		{
+			Layer:     "app",
+			Type:      "scion_access",
+			Value:     newToken,
+			ExpiresIn: int(time.Until(expiresAt).Seconds()),
+		},
+	}
+
+	// Mint a transport token if transport auth is configured
+	if s.transportMinter != nil && s.transportAudience != "" {
+		tToken, tExpiry, tErr := s.transportMinter.MintIDToken(r.Context(), s.transportAudience)
+		if tErr != nil {
+			// Log but don't fail the refresh — app token is still valid
+			slog.Warn("Failed to mint transport token during refresh",
+				"agent_id", id, "error", tErr)
+		} else if tToken != "" {
+			tokens = append(tokens, RefreshTokenEntry{
+				Layer:     "transport",
+				Type:      "google_oidc",
+				Value:     tToken,
+				ExpiresIn: int(time.Until(tExpiry).Seconds()),
+				Audience:  s.transportAudience,
+			})
+		}
+	}
+
+	// Response includes both the legacy single-token fields (backward compat)
+	// and the generalized tokens[] array. Old clients ignore tokens[];
+	// new clients prefer tokens[].
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"token":      newToken,
 		"expires_at": expiresAt.UTC().Format(time.RFC3339),
+		"tokens":     tokens,
 	})
 }
 

--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -267,6 +267,11 @@ func (s *Server) handleAuthLogin(w http.ResponseWriter, r *http.Request) {
 				"your email domain is not authorized", nil)
 			return
 		}
+		if errors.Is(err, ErrUserSuspended) {
+			writeError(w, http.StatusForbidden, "user_suspended",
+				"your account has been suspended", nil)
+			return
+		}
 		InternalError(w)
 		return
 	}
@@ -376,6 +381,11 @@ func (s *Server) handleAuthToken(w http.ResponseWriter, r *http.Request) {
 		if errors.Is(err, ErrAccessDenied) {
 			writeError(w, http.StatusForbidden, "unauthorized_domain",
 				"your email domain is not authorized", nil)
+			return
+		}
+		if errors.Is(err, ErrUserSuspended) {
+			writeError(w, http.StatusForbidden, "user_suspended",
+				"your account has been suspended", nil)
 			return
 		}
 		InternalError(w)
@@ -488,7 +498,14 @@ func (s *Server) handleAuthValidate(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleAuthLogout handles POST /api/v1/auth/logout.
+// In proxy mode, this is a no-op (the proxy owns the session).
 func (s *Server) handleAuthLogout(w http.ResponseWriter, r *http.Request) {
+	// In proxy mode, the hub does not own the session.
+	if s.config.AuthMode == "proxy" {
+		writeJSON(w, http.StatusOK, AuthLogoutResponse{Success: true})
+		return
+	}
+
 	var req AuthLogoutRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		// Empty body is fine for logout
@@ -808,7 +825,8 @@ func (s *Server) handleCLIAuthProviders(w http.ResponseWriter, r *http.Request) 
 		ClientType: clientTypeParam,
 		Providers:  []string{},
 	}
-	if s.oauthService != nil {
+	// In proxy mode, no OAuth providers are available.
+	if s.config.AuthMode != "proxy" && s.oauthService != nil {
 		resp.Providers = s.oauthService.ConfiguredProvidersForClient(clientType)
 	}
 
@@ -877,6 +895,11 @@ func (s *Server) handleCLIAuthToken(w http.ResponseWriter, r *http.Request) {
 		if errors.Is(err, ErrAccessDenied) {
 			writeError(w, http.StatusForbidden, "unauthorized_domain",
 				"your email domain is not authorized", nil)
+			return
+		}
+		if errors.Is(err, ErrUserSuspended) {
+			writeError(w, http.StatusForbidden, "user_suspended",
+				"your account has been suspended", nil)
 			return
 		}
 		InternalError(w)
@@ -1102,6 +1125,11 @@ func (s *Server) completeOAuthLogin(w http.ResponseWriter, r *http.Request, user
 				"your email domain is not authorized", nil)
 			return
 		}
+		if errors.Is(err, ErrUserSuspended) {
+			writeError(w, http.StatusForbidden, "user_suspended",
+				"your account has been suspended", nil)
+			return
+		}
 		InternalError(w)
 		return
 	}
@@ -1134,13 +1162,13 @@ func (s *Server) completeOAuthLogin(w http.ResponseWriter, r *http.Request, user
 	})
 }
 
+// ErrUserSuspended is returned by provisionUser when the user's account is suspended.
+var ErrUserSuspended = errors.New("user account is suspended")
+
 // provisionUser authorizes the external user, then finds or creates the
 // corresponding store.User. It returns ErrAccessDenied when the email is not
-// authorized. On success it also ensures hub-members group membership.
-//
-// NOTE: this method does not check user.Status (e.g. suspended). The current
-// OAuth flow has no such check either. A suspended-user gate will be added in
-// Phase 1 (proxy auth) if needed.
+// authorized, or ErrUserSuspended when the user is suspended.
+// On success it also ensures hub-members group membership.
 func (s *Server) provisionUser(ctx context.Context, info *ExternalUserInfo) (*store.User, error) {
 	// Authorization check
 	if !s.isUserAuthorized(ctx, info.Email) {
@@ -1170,6 +1198,12 @@ func (s *Server) provisionUser(ctx context.Context, info *ExternalUserInfo) (*st
 			return nil, fmt.Errorf("create user: %w", err)
 		}
 	} else {
+		// Reject suspended users (covers both OAuth and proxy auth paths)
+		if user.Status == "suspended" {
+			slog.Warn("login rejected: user is suspended", "email", info.Email, "user_id", user.ID)
+			return nil, ErrUserSuspended
+		}
+
 		// Update last login and backfill profile
 		user.LastLogin = time.Now()
 		if info.AvatarURL != "" && user.AvatarURL == "" {

--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -181,6 +181,19 @@ func (t TokenResponse) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// ExternalUserInfo carries the provider-verified identity fields needed to
+// provision a user. It is a subset of OAuthUserInfo, decoupled from the
+// OAuth layer so that provisionUser can serve both OAuth and proxy callers.
+type ExternalUserInfo struct {
+	Email       string
+	DisplayName string
+	AvatarURL   string
+}
+
+// ErrAccessDenied is returned by provisionUser when the user's email is not
+// authorized to log in (domain restriction, invite-only, etc.).
+var ErrAccessDenied = errors.New("access denied")
+
 // handleAuth routes auth-related requests.
 func (s *Server) handleAuth(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path
@@ -241,55 +254,22 @@ func (s *Server) handleAuthLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if user is authorized (admin bypass, domain check, access mode)
+	// Provision user (authorize + find-or-create + hub membership)
 	ctx := r.Context()
-	if !s.isUserAuthorized(ctx, userInfo.Email) {
-		reason := "not_on_allow_list"
-		if s.config.UserAccessMode != "invite_only" {
-			reason = "domain_not_authorized"
-		}
-		LogInviteAuditFailure(ctx, s.auditLogger, InviteAuditLoginDenied, userInfo.Email, reason)
-		writeError(w, http.StatusForbidden, "unauthorized_domain",
-			"your email domain is not authorized", nil)
-		return
-	}
-
-	// Find or create user
-	user, err := s.store.GetUserByEmail(ctx, userInfo.Email)
+	user, err := s.provisionUser(ctx, &ExternalUserInfo{
+		Email:       userInfo.Email,
+		DisplayName: userInfo.DisplayName,
+		AvatarURL:   userInfo.AvatarURL,
+	})
 	if err != nil {
-		// Create new user
-		user = &store.User{
-			ID:          generateID(),
-			Email:       userInfo.Email,
-			DisplayName: userInfo.DisplayName,
-			AvatarURL:   userInfo.AvatarURL,
-			Role:        s.getUserRole(userInfo.Email),
-			Status:      "active",
-			Created:     time.Now(),
-			LastLogin:   time.Now(),
-		}
-		if err := s.store.CreateUser(ctx, user); err != nil {
-			InternalError(w)
+		if errors.Is(err, ErrAccessDenied) {
+			writeError(w, http.StatusForbidden, "unauthorized_domain",
+				"your email domain is not authorized", nil)
 			return
 		}
-	} else {
-		// Update last login
-		user.LastLogin = time.Now()
-		if userInfo.AvatarURL != "" && user.AvatarURL == "" {
-			user.AvatarURL = userInfo.AvatarURL
-		}
-		if userInfo.DisplayName != "" && user.DisplayName == "" {
-			user.DisplayName = userInfo.DisplayName
-		}
-		// Check if user should be promoted to admin (in case admin list changed)
-		if user.Role != "admin" && s.getUserRole(userInfo.Email) == "admin" {
-			user.Role = "admin"
-		}
-		_ = s.store.UpdateUser(ctx, user)
+		InternalError(w)
+		return
 	}
-
-	// Ensure user is a member of the hub-members group
-	ensureHubMembership(ctx, s.store, user.ID)
 
 	// Generate tokens
 	if s.userTokenService == nil {
@@ -386,54 +366,21 @@ func (s *Server) handleAuthToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if user is authorized (admin bypass, domain check, access mode)
-	if !s.isUserAuthorized(ctx, userInfo.Email) {
-		reason := "not_on_allow_list"
-		if s.config.UserAccessMode != "invite_only" {
-			reason = "domain_not_authorized"
-		}
-		LogInviteAuditFailure(ctx, s.auditLogger, InviteAuditLoginDenied, userInfo.Email, reason)
-		writeError(w, http.StatusForbidden, "unauthorized_domain",
-			"your email domain is not authorized", nil)
-		return
-	}
-
-	// Find or create user
-	user, err := s.store.GetUserByEmail(ctx, userInfo.Email)
+	// Provision user (authorize + find-or-create + hub membership)
+	user, err := s.provisionUser(ctx, &ExternalUserInfo{
+		Email:       userInfo.Email,
+		DisplayName: userInfo.DisplayName,
+		AvatarURL:   userInfo.AvatarURL,
+	})
 	if err != nil {
-		// Create new user
-		user = &store.User{
-			ID:          generateID(),
-			Email:       userInfo.Email,
-			DisplayName: userInfo.DisplayName,
-			AvatarURL:   userInfo.AvatarURL,
-			Role:        s.getUserRole(userInfo.Email),
-			Status:      "active",
-			Created:     time.Now(),
-			LastLogin:   time.Now(),
-		}
-		if err := s.store.CreateUser(ctx, user); err != nil {
-			InternalError(w)
+		if errors.Is(err, ErrAccessDenied) {
+			writeError(w, http.StatusForbidden, "unauthorized_domain",
+				"your email domain is not authorized", nil)
 			return
 		}
-	} else {
-		// Update last login
-		user.LastLogin = time.Now()
-		if userInfo.AvatarURL != "" && user.AvatarURL == "" {
-			user.AvatarURL = userInfo.AvatarURL
-		}
-		if userInfo.DisplayName != "" && user.DisplayName == "" {
-			user.DisplayName = userInfo.DisplayName
-		}
-		// Check if user should be promoted to admin (in case admin list changed)
-		if user.Role != "admin" && s.getUserRole(userInfo.Email) == "admin" {
-			user.Role = "admin"
-		}
-		_ = s.store.UpdateUser(ctx, user)
+		InternalError(w)
+		return
 	}
-
-	// Ensure user is a member of the hub-members group
-	ensureHubMembership(ctx, s.store, user.ID)
 
 	// Generate tokens
 	if s.userTokenService == nil {
@@ -920,54 +867,21 @@ func (s *Server) handleCLIAuthToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if user is authorized (admin bypass, domain check, access mode)
-	if !s.isUserAuthorized(ctx, userInfo.Email) {
-		reason := "not_on_allow_list"
-		if s.config.UserAccessMode != "invite_only" {
-			reason = "domain_not_authorized"
-		}
-		LogInviteAuditFailure(ctx, s.auditLogger, InviteAuditLoginDenied, userInfo.Email, reason)
-		writeError(w, http.StatusForbidden, "unauthorized_domain",
-			"your email domain is not authorized", nil)
-		return
-	}
-
-	// Find or create user
-	user, err := s.store.GetUserByEmail(ctx, userInfo.Email)
+	// Provision user (authorize + find-or-create + hub membership)
+	user, err := s.provisionUser(ctx, &ExternalUserInfo{
+		Email:       userInfo.Email,
+		DisplayName: userInfo.DisplayName,
+		AvatarURL:   userInfo.AvatarURL,
+	})
 	if err != nil {
-		// Create new user
-		user = &store.User{
-			ID:          generateID(),
-			Email:       userInfo.Email,
-			DisplayName: userInfo.DisplayName,
-			AvatarURL:   userInfo.AvatarURL,
-			Role:        s.getUserRole(userInfo.Email),
-			Status:      "active",
-			Created:     time.Now(),
-			LastLogin:   time.Now(),
-		}
-		if err := s.store.CreateUser(ctx, user); err != nil {
-			InternalError(w)
+		if errors.Is(err, ErrAccessDenied) {
+			writeError(w, http.StatusForbidden, "unauthorized_domain",
+				"your email domain is not authorized", nil)
 			return
 		}
-	} else {
-		// Update last login and profile info
-		user.LastLogin = time.Now()
-		if userInfo.AvatarURL != "" && user.AvatarURL == "" {
-			user.AvatarURL = userInfo.AvatarURL
-		}
-		if userInfo.DisplayName != "" && user.DisplayName == "" {
-			user.DisplayName = userInfo.DisplayName
-		}
-		// Check if user should be promoted to admin (in case admin list changed)
-		if user.Role != "admin" && s.getUserRole(userInfo.Email) == "admin" {
-			user.Role = "admin"
-		}
-		_ = s.store.UpdateUser(ctx, user)
+		InternalError(w)
+		return
 	}
-
-	// Ensure user is a member of the hub-members group
-	ensureHubMembership(ctx, s.store, user.ID)
 
 	// Generate Hub tokens (CLI type for longer duration)
 	if s.userTokenService == nil {
@@ -1176,53 +1090,21 @@ func (s *Server) getDeviceFlowUserInfo(ctx context.Context, provider, accessToke
 func (s *Server) completeOAuthLogin(w http.ResponseWriter, r *http.Request, userInfo *OAuthUserInfo) {
 	ctx := r.Context()
 
-	// Check if user is authorized (admin bypass, domain check, access mode)
-	if !s.isUserAuthorized(ctx, userInfo.Email) {
-		reason := "not_on_allow_list"
-		if s.config.UserAccessMode != "invite_only" {
-			reason = "domain_not_authorized"
-		}
-		LogInviteAuditFailure(ctx, s.auditLogger, InviteAuditLoginDenied, userInfo.Email, reason)
-		writeError(w, http.StatusForbidden, "unauthorized_domain",
-			"your email domain is not authorized", nil)
-		return
-	}
-
-	// Find or create user
-	user, err := s.store.GetUserByEmail(ctx, userInfo.Email)
+	// Provision user (authorize + find-or-create + hub membership)
+	user, err := s.provisionUser(ctx, &ExternalUserInfo{
+		Email:       userInfo.Email,
+		DisplayName: userInfo.DisplayName,
+		AvatarURL:   userInfo.AvatarURL,
+	})
 	if err != nil {
-		// Create new user
-		user = &store.User{
-			ID:          generateID(),
-			Email:       userInfo.Email,
-			DisplayName: userInfo.DisplayName,
-			AvatarURL:   userInfo.AvatarURL,
-			Role:        s.getUserRole(userInfo.Email),
-			Status:      "active",
-			Created:     time.Now(),
-			LastLogin:   time.Now(),
-		}
-		if err := s.store.CreateUser(ctx, user); err != nil {
-			InternalError(w)
+		if errors.Is(err, ErrAccessDenied) {
+			writeError(w, http.StatusForbidden, "unauthorized_domain",
+				"your email domain is not authorized", nil)
 			return
 		}
-	} else {
-		// Update last login and profile info
-		user.LastLogin = time.Now()
-		if userInfo.AvatarURL != "" && user.AvatarURL == "" {
-			user.AvatarURL = userInfo.AvatarURL
-		}
-		if userInfo.DisplayName != "" && user.DisplayName == "" {
-			user.DisplayName = userInfo.DisplayName
-		}
-		if user.Role != "admin" && s.getUserRole(userInfo.Email) == "admin" {
-			user.Role = "admin"
-		}
-		_ = s.store.UpdateUser(ctx, user)
+		InternalError(w)
+		return
 	}
-
-	// Ensure user is a member of the hub-members group
-	ensureHubMembership(ctx, s.store, user.ID)
 
 	// Generate Hub tokens (CLI type for longer duration)
 	if s.userTokenService == nil {
@@ -1250,6 +1132,63 @@ func (s *Server) completeOAuthLogin(w http.ResponseWriter, r *http.Request, user
 			AvatarURL:   user.AvatarURL,
 		},
 	})
+}
+
+// provisionUser authorizes the external user, then finds or creates the
+// corresponding store.User. It returns ErrAccessDenied when the email is not
+// authorized. On success it also ensures hub-members group membership.
+//
+// NOTE: this method does not check user.Status (e.g. suspended). The current
+// OAuth flow has no such check either. A suspended-user gate will be added in
+// Phase 1 (proxy auth) if needed.
+func (s *Server) provisionUser(ctx context.Context, info *ExternalUserInfo) (*store.User, error) {
+	// Authorization check
+	if !s.isUserAuthorized(ctx, info.Email) {
+		reason := "not_on_allow_list"
+		if s.config.UserAccessMode != "invite_only" {
+			reason = "domain_not_authorized"
+		}
+		LogInviteAuditFailure(ctx, s.auditLogger, InviteAuditLoginDenied, info.Email, reason)
+		return nil, ErrAccessDenied
+	}
+
+	// Find or create user
+	user, err := s.store.GetUserByEmail(ctx, info.Email)
+	if err != nil {
+		// Create new user
+		user = &store.User{
+			ID:          generateID(),
+			Email:       info.Email,
+			DisplayName: info.DisplayName,
+			AvatarURL:   info.AvatarURL,
+			Role:        s.getUserRole(info.Email),
+			Status:      "active",
+			Created:     time.Now(),
+			LastLogin:   time.Now(),
+		}
+		if err := s.store.CreateUser(ctx, user); err != nil {
+			return nil, fmt.Errorf("create user: %w", err)
+		}
+	} else {
+		// Update last login and backfill profile
+		user.LastLogin = time.Now()
+		if info.AvatarURL != "" && user.AvatarURL == "" {
+			user.AvatarURL = info.AvatarURL
+		}
+		if info.DisplayName != "" && user.DisplayName == "" {
+			user.DisplayName = info.DisplayName
+		}
+		// Promote to admin if config changed
+		if user.Role != "admin" && s.getUserRole(info.Email) == "admin" {
+			user.Role = "admin"
+		}
+		_ = s.store.UpdateUser(ctx, user)
+	}
+
+	// Ensure user is a member of the hub-members group
+	ensureHubMembership(ctx, s.store, user.ID)
+
+	return user, nil
 }
 
 // generateID generates a new UUID.

--- a/pkg/hub/handlers_auth_test.go
+++ b/pkg/hub/handlers_auth_test.go
@@ -19,6 +19,7 @@ package hub
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -488,4 +489,231 @@ func TestCLIDeviceToken_MethodNotAllowed(t *testing.T) {
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("expected status 405 for GET, got %d", rec.Code)
 	}
+}
+
+func TestProvisionUser(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("creates new user", func(t *testing.T) {
+		srv, s := testServer(t)
+
+		info := &ExternalUserInfo{
+			Email:       "new@example.com",
+			DisplayName: "New User",
+			AvatarURL:   "https://example.com/avatar.png",
+		}
+
+		user, err := srv.provisionUser(ctx, info)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if user.Email != "new@example.com" {
+			t.Errorf("expected email new@example.com, got %q", user.Email)
+		}
+		if user.DisplayName != "New User" {
+			t.Errorf("expected display name 'New User', got %q", user.DisplayName)
+		}
+		if user.AvatarURL != "https://example.com/avatar.png" {
+			t.Errorf("expected avatar URL, got %q", user.AvatarURL)
+		}
+		if user.Status != "active" {
+			t.Errorf("expected status 'active', got %q", user.Status)
+		}
+		if user.ID == "" {
+			t.Error("expected non-empty user ID")
+		}
+
+		// Verify persisted in store
+		stored, err := s.GetUserByEmail(ctx, "new@example.com")
+		if err != nil {
+			t.Fatalf("user not found in store: %v", err)
+		}
+		if stored.ID != user.ID {
+			t.Errorf("stored user ID mismatch: %q vs %q", stored.ID, user.ID)
+		}
+	})
+
+	t.Run("updates existing user last login", func(t *testing.T) {
+		srv, s := testServer(t)
+
+		// Pre-create user
+		original := &store.User{
+			ID:          generateID(),
+			Email:       "existing@example.com",
+			DisplayName: "Original Name",
+			AvatarURL:   "https://example.com/original.png",
+			Role:        "member",
+			Status:      "active",
+			Created:     time.Now().Add(-24 * time.Hour),
+			LastLogin:   time.Now().Add(-24 * time.Hour),
+		}
+		if err := s.CreateUser(ctx, original); err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+
+		beforeLogin := time.Now()
+		info := &ExternalUserInfo{
+			Email:       "existing@example.com",
+			DisplayName: "Updated Name",
+			AvatarURL:   "https://example.com/updated.png",
+		}
+
+		user, err := srv.provisionUser(ctx, info)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// LastLogin should be updated
+		if user.LastLogin.Before(beforeLogin) {
+			t.Error("expected LastLogin to be updated")
+		}
+		// DisplayName should NOT be updated (original was non-empty)
+		if user.DisplayName != "Original Name" {
+			t.Errorf("expected display name 'Original Name', got %q", user.DisplayName)
+		}
+		// AvatarURL should NOT be updated (original was non-empty)
+		if user.AvatarURL != "https://example.com/original.png" {
+			t.Errorf("expected original avatar URL, got %q", user.AvatarURL)
+		}
+	})
+
+	t.Run("backfills empty display name and avatar", func(t *testing.T) {
+		srv, s := testServer(t)
+
+		// Pre-create user with empty display name and avatar
+		original := &store.User{
+			ID:      generateID(),
+			Email:   "backfill@example.com",
+			Role:    "member",
+			Status:  "active",
+			Created: time.Now().Add(-1 * time.Hour),
+		}
+		if err := s.CreateUser(ctx, original); err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+
+		info := &ExternalUserInfo{
+			Email:       "backfill@example.com",
+			DisplayName: "Backfilled Name",
+			AvatarURL:   "https://example.com/backfilled.png",
+		}
+
+		user, err := srv.provisionUser(ctx, info)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if user.DisplayName != "Backfilled Name" {
+			t.Errorf("expected backfilled display name, got %q", user.DisplayName)
+		}
+		if user.AvatarURL != "https://example.com/backfilled.png" {
+			t.Errorf("expected backfilled avatar URL, got %q", user.AvatarURL)
+		}
+	})
+
+	t.Run("promotes member to admin when config changes", func(t *testing.T) {
+		srv, s := testServer(t)
+
+		// Pre-create user as member
+		original := &store.User{
+			ID:      generateID(),
+			Email:   "admin@example.com",
+			Role:    "member",
+			Status:  "active",
+			Created: time.Now(),
+		}
+		if err := s.CreateUser(ctx, original); err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+
+		// Configure server to recognize this email as admin
+		srv.config.AdminEmails = []string{"admin@example.com"}
+
+		info := &ExternalUserInfo{Email: "admin@example.com"}
+		user, err := srv.provisionUser(ctx, info)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if user.Role != "admin" {
+			t.Errorf("expected role 'admin', got %q", user.Role)
+		}
+	})
+
+	t.Run("returns ErrAccessDenied for unauthorized domain", func(t *testing.T) {
+		srv, _ := testServer(t)
+
+		// Configure domain restriction
+		srv.config.AuthorizedDomains = []string{"allowed.com"}
+		srv.config.UserAccessMode = "domain_restricted"
+
+		info := &ExternalUserInfo{Email: "user@forbidden.com"}
+		_, err := srv.provisionUser(ctx, info)
+		if !errors.Is(err, ErrAccessDenied) {
+			t.Errorf("expected ErrAccessDenied, got %v", err)
+		}
+	})
+
+	t.Run("returns ErrAccessDenied for invite-only mode", func(t *testing.T) {
+		srv, _ := testServer(t)
+
+		// Configure invite-only mode (user not on allow list)
+		srv.config.UserAccessMode = "invite_only"
+
+		info := &ExternalUserInfo{Email: "user@example.com"}
+		_, err := srv.provisionUser(ctx, info)
+		if !errors.Is(err, ErrAccessDenied) {
+			t.Errorf("expected ErrAccessDenied, got %v", err)
+		}
+	})
+
+	t.Run("admin bypasses domain restriction", func(t *testing.T) {
+		srv, _ := testServer(t)
+
+		// Configure domain restriction but also add admin email
+		srv.config.AuthorizedDomains = []string{"allowed.com"}
+		srv.config.UserAccessMode = "domain_restricted"
+		srv.config.AdminEmails = []string{"admin@other.com"}
+
+		info := &ExternalUserInfo{Email: "admin@other.com"}
+		user, err := srv.provisionUser(ctx, info)
+		if err != nil {
+			t.Fatalf("expected admin bypass, got error: %v", err)
+		}
+		if user.Role != "admin" {
+			t.Errorf("expected role 'admin', got %q", user.Role)
+		}
+	})
+
+	t.Run("idempotent - calling twice does not duplicate", func(t *testing.T) {
+		srv, s := testServer(t)
+
+		info := &ExternalUserInfo{
+			Email:       "idempotent@example.com",
+			DisplayName: "First Call",
+		}
+
+		user1, err := srv.provisionUser(ctx, info)
+		if err != nil {
+			t.Fatalf("first call failed: %v", err)
+		}
+
+		user2, err := srv.provisionUser(ctx, info)
+		if err != nil {
+			t.Fatalf("second call failed: %v", err)
+		}
+
+		if user1.ID != user2.ID {
+			t.Errorf("expected same user ID across calls, got %q and %q", user1.ID, user2.ID)
+		}
+
+		// Verify only one user exists
+		u, err := s.GetUserByEmail(ctx, "idempotent@example.com")
+		if err != nil {
+			t.Fatalf("user not found: %v", err)
+		}
+		if u.ID != user1.ID {
+			t.Error("store user ID does not match")
+		}
+	})
 }

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -134,9 +134,11 @@ type HTTPAgentDispatcher struct {
 	githubAppMinter GitHubAppTokenMinter // Optional GitHub App token minter
 	hubEndpoint     string               // Hub endpoint URL for agents to call back
 	hubID           string               // Hub instance ID for hub-scoped queries
-	devAuthToken    string               // Dev auth token to inject into agent env (dev-auth mode only)
-	debug           bool
-	log             *slog.Logger
+	devAuthToken      string               // Dev auth token to inject into agent env (dev-auth mode only)
+	transportMinter   TransportTokenMinter // Optional transport token minter for OIDC dispatch
+	transportAudience string               // OIDC audience for transport tokens
+	debug             bool
+	log               *slog.Logger
 
 	// Cross-node dispatch deps (B4-2). When events + commandBus are non-nil
 	// and client.StartAgent/StopAgent/RestartAgent returns ErrLifecycleDeferred,
@@ -197,6 +199,13 @@ func (d *HTTPAgentDispatcher) SetDevAuthToken(token string) {
 // SetAuthzService sets the authorization service for progeny secret verification.
 func (d *HTTPAgentDispatcher) SetAuthzService(a *AuthzService) {
 	d.authzService = a
+}
+
+// SetTransportMinter sets the transport token minter and audience for injecting
+// transport-layer OIDC tokens into agent dispatch payloads.
+func (d *HTTPAgentDispatcher) SetTransportMinter(minter TransportTokenMinter, audience string) {
+	d.transportMinter = minter
+	d.transportAudience = audience
 }
 
 // SetGitHubAppMinter sets the GitHub App token minter for resolving
@@ -510,6 +519,23 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 			req.ResolvedEnv = make(map[string]string)
 		}
 		req.ResolvedEnv["SCION_DEV_TOKEN"] = d.devAuthToken
+	}
+
+	// Transport token minting for platform-layer auth (IAP / Cloud Run invoker)
+	if d.transportMinter != nil && d.transportAudience != "" {
+		tToken, tExpiry, tErr := d.transportMinter.MintIDToken(ctx, d.transportAudience)
+		if tErr != nil {
+			if d.debug {
+				d.log.Warn("buildCreateRequest: failed to mint transport token", "error", tErr)
+			}
+		} else if tToken != "" {
+			if req.ResolvedEnv == nil {
+				req.ResolvedEnv = make(map[string]string)
+			}
+			req.ResolvedEnv["SCION_TRANSPORT_TOKEN"] = tToken
+			req.ResolvedEnv["SCION_TRANSPORT_AUDIENCE"] = d.transportAudience
+			req.ResolvedEnv["SCION_TRANSPORT_TOKEN_EXPIRY"] = tExpiry.UTC().Format(time.RFC3339)
+		}
 	}
 
 	return req, nil
@@ -1056,6 +1082,20 @@ func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *sto
 		}
 	}
 
+	// Transport token minting for platform-layer auth (IAP / Cloud Run invoker)
+	if d.transportMinter != nil && d.transportAudience != "" {
+		tToken, tExpiry, tErr := d.transportMinter.MintIDToken(ctx, d.transportAudience)
+		if tErr != nil {
+			if d.debug {
+				d.log.Warn("DispatchAgentStart: failed to mint transport token", "error", tErr)
+			}
+		} else if tToken != "" {
+			resolvedEnv["SCION_TRANSPORT_TOKEN"] = tToken
+			resolvedEnv["SCION_TRANSPORT_AUDIENCE"] = d.transportAudience
+			resolvedEnv["SCION_TRANSPORT_TOKEN_EXPIRY"] = tExpiry.UTC().Format(time.RFC3339)
+		}
+	}
+
 	// GitHub App token minting for agent start
 	if d.githubAppMinter != nil && agent.ProjectID != "" {
 		project, projectErr := d.store.GetProject(ctx, agent.ProjectID)
@@ -1200,6 +1240,20 @@ func (d *HTTPAgentDispatcher) DispatchAgentRestart(ctx context.Context, agent *s
 			}
 		} else if token != "" {
 			resolvedEnv["SCION_AUTH_TOKEN"] = token
+		}
+	}
+
+	// Transport token minting for platform-layer auth (IAP / Cloud Run invoker)
+	if d.transportMinter != nil && d.transportAudience != "" {
+		tToken, tExpiry, tErr := d.transportMinter.MintIDToken(ctx, d.transportAudience)
+		if tErr != nil {
+			if d.debug {
+				d.log.Warn("DispatchAgentRestart: failed to mint transport token", "error", tErr)
+			}
+		} else if tToken != "" {
+			resolvedEnv["SCION_TRANSPORT_TOKEN"] = tToken
+			resolvedEnv["SCION_TRANSPORT_AUDIENCE"] = d.transportAudience
+			resolvedEnv["SCION_TRANSPORT_TOKEN_EXPIRY"] = tExpiry.UTC().Format(time.RFC3339)
 		}
 	}
 

--- a/pkg/hub/proxyauth.go
+++ b/pkg/hub/proxyauth.go
@@ -202,11 +202,15 @@ func (a *IAPAuthenticator) resolveJWKSURL() string {
 	return DefaultIAPJWKSURL
 }
 
+// defaultJWKSHTTPClient is used for JWKS fetches when no custom client is provided.
+// It has a reasonable timeout to prevent hanging on unresponsive endpoints.
+var defaultJWKSHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
 func (a *IAPAuthenticator) resolveHTTPClient() *http.Client {
 	if a.HTTPClient != nil {
 		return a.HTTPClient
 	}
-	return http.DefaultClient
+	return defaultJWKSHTTPClient
 }
 
 func (a *IAPAuthenticator) init() {
@@ -229,9 +233,11 @@ type jwksCache struct {
 	url    string
 	client *http.Client
 
-	mu          sync.RWMutex
-	keys        map[string]jose.JSONWebKey // kid -> key
-	lastFetched time.Time
+	mu            sync.RWMutex
+	keys          map[string]jose.JSONWebKey // kid -> key
+	lastFetched   time.Time                 // last successful fetch
+	lastAttempted time.Time                 // last fetch attempt (success or failure), for stampede prevention
+	refreshing    bool                      // true while a refresh is in-flight
 }
 
 // GetKey returns the public key for the given kid. If the kid is not found
@@ -275,18 +281,41 @@ func (c *jwksCache) GetKey(kid string) (interface{}, error) {
 	return nil, fmt.Errorf("unknown kid %q after JWKS refresh", kid)
 }
 
+// jwksDebounceInterval is the minimum time between refresh attempts (success or failure)
+// to prevent stampedes during JWKS endpoint outages.
+const jwksDebounceInterval = 5 * time.Second
+
 // refresh fetches the JWKS from the endpoint and updates the cache.
 // On transient failure, the last-good keys are preserved.
+// Concurrent calls are coalesced: if a refresh is already in-flight, subsequent
+// callers return immediately (nil error) and rely on cached keys.
 func (c *jwksCache) refresh() error {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 
-	// Debounce: don't re-fetch if we just fetched very recently
-	if time.Since(c.lastFetched) < 5*time.Second {
+	// Debounce: skip if a refresh was attempted (success OR failure) very recently.
+	if time.Since(c.lastAttempted) < jwksDebounceInterval {
+		c.mu.Unlock()
 		return nil
 	}
 
+	// Prevent concurrent in-flight refreshes.
+	if c.refreshing {
+		c.mu.Unlock()
+		return nil
+	}
+	c.refreshing = true
+	c.lastAttempted = time.Now()
+	c.mu.Unlock()
+
+	// Perform the network fetch outside the lock to avoid holding it across I/O.
 	resp, err := c.client.Get(c.url)
+
+	c.mu.Lock()
+	defer func() {
+		c.refreshing = false
+		c.mu.Unlock()
+	}()
+
 	if err != nil {
 		slog.Warn("jwks fetch failed, serving last-good keys", "url", c.url, "error", err)
 		return err

--- a/pkg/hub/proxyauth.go
+++ b/pkg/hub/proxyauth.go
@@ -1,0 +1,324 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+)
+
+// ProxyUserInfo is the verified identity extracted from proxy headers/assertions.
+type ProxyUserInfo struct {
+	Subject     string // stable provider subject (IdP prefix stripped)
+	Email       string // verified email (IdP prefix stripped, lowercased)
+	DisplayName string // best-effort; may be empty for IAP
+	Domain      string // hd claim, if present
+}
+
+// ProxyAuthenticator verifies proxy-supplied auth on a request and returns the
+// verified user. (nil, nil) = "no proxy assertion present" (fall through);
+// (nil, err) = assertion present but invalid (reject).
+type ProxyAuthenticator interface {
+	Authenticate(r *http.Request) (*ProxyUserInfo, error)
+	Name() string // for logging/metrics, e.g. "iap"
+}
+
+// ---- Google IAP Authenticator ----
+
+const (
+	// IAPAssertionHeader is the header containing the IAP signed JWT.
+	IAPAssertionHeader = "X-Goog-IAP-JWT-Assertion"
+
+	// DefaultIAPIssuer is the expected issuer for IAP JWTs.
+	DefaultIAPIssuer = "https://cloud.google.com/iap"
+
+	// DefaultIAPJWKSURL is the URL for IAP public keys.
+	DefaultIAPJWKSURL = "https://www.gstatic.com/iap/verify/public_key-jwk"
+
+	// iapClockSkew is the allowed clock skew for exp/iat validation.
+	iapClockSkew = 30 * time.Second
+
+	// jwksRefreshInterval is how often the JWKS cache proactively refreshes.
+	jwksRefreshInterval = 1 * time.Hour
+
+	// iapIdPPrefix is the IdP prefix stripped from IAP sub/email claims.
+	iapIdPPrefix = "accounts.google.com:"
+)
+
+// IAPAuthenticator verifies Google IAP signed JWTs (X-Goog-IAP-JWT-Assertion).
+type IAPAuthenticator struct {
+	// Audience is the expected audience claim — MANDATORY.
+	Audience string
+
+	// Issuer is the expected issuer (defaults to DefaultIAPIssuer).
+	Issuer string
+
+	// JWKSURL is the JWKS endpoint (defaults to DefaultIAPJWKSURL).
+	JWKSURL string
+
+	// HTTPClient is the HTTP client for fetching JWKS (defaults to http.DefaultClient).
+	HTTPClient *http.Client
+
+	jwksCache *jwksCache
+	initOnce  sync.Once
+}
+
+// Name returns "iap" for logging/metrics.
+func (a *IAPAuthenticator) Name() string { return "iap" }
+
+// Authenticate reads the IAP assertion header, verifies the JWT, and returns
+// the verified ProxyUserInfo. Returns (nil, nil) if no assertion is present.
+func (a *IAPAuthenticator) Authenticate(r *http.Request) (*ProxyUserInfo, error) {
+	a.initOnce.Do(a.init)
+
+	assertion := r.Header.Get(IAPAssertionHeader)
+	if assertion == "" {
+		return nil, nil // no assertion present, fall through
+	}
+
+	// Parse the JWT (compact serialization)
+	tok, err := jwt.ParseSigned(assertion, []jose.SignatureAlgorithm{jose.ES256})
+	if err != nil {
+		return nil, fmt.Errorf("iap: failed to parse JWT: %w", err)
+	}
+
+	// Look up the signing key by kid
+	if len(tok.Headers) == 0 {
+		return nil, fmt.Errorf("iap: JWT has no headers")
+	}
+	kid := tok.Headers[0].KeyID
+	if kid == "" {
+		return nil, fmt.Errorf("iap: JWT has no kid")
+	}
+
+	key, err := a.jwksCache.GetKey(kid)
+	if err != nil {
+		return nil, fmt.Errorf("iap: JWKS key lookup failed for kid %q: %w", kid, err)
+	}
+
+	// Verify signature and extract claims
+	var claims iapClaims
+	if err := tok.Claims(key, &claims); err != nil {
+		return nil, fmt.Errorf("iap: JWT signature verification failed: %w", err)
+	}
+
+	// Validate standard claims
+	expectedIssuer := a.resolveIssuer()
+	now := time.Now()
+
+	if err := a.validateClaims(&claims, expectedIssuer, now); err != nil {
+		return nil, err
+	}
+
+	// Strip IdP prefix and build ProxyUserInfo
+	return &ProxyUserInfo{
+		Subject:     stripIAPPrefix(claims.Subject),
+		Email:       strings.ToLower(stripIAPPrefix(claims.Email)),
+		DisplayName: "", // IAP does not provide display name
+		Domain:      claims.HD,
+	}, nil
+}
+
+// iapClaims are the JWT claims from an IAP assertion.
+type iapClaims struct {
+	Issuer   string           `json:"iss"`
+	Subject  string           `json:"sub"`
+	Audience jwt.Audience     `json:"aud"`
+	IssuedAt *jwt.NumericDate `json:"iat"`
+	Expiry   *jwt.NumericDate `json:"exp"`
+	Email    string           `json:"email"`
+	HD       string           `json:"hd,omitempty"` // hosted domain
+}
+
+func (a *IAPAuthenticator) validateClaims(claims *iapClaims, expectedIssuer string, now time.Time) error {
+	// Issuer
+	if claims.Issuer != expectedIssuer {
+		return fmt.Errorf("iap: invalid issuer %q, expected %q", claims.Issuer, expectedIssuer)
+	}
+
+	// Audience (mandatory binding)
+	if !claims.Audience.Contains(a.Audience) {
+		return fmt.Errorf("iap: audience mismatch: got %v, expected %q", claims.Audience, a.Audience)
+	}
+
+	// Expiry
+	if claims.Expiry == nil {
+		return fmt.Errorf("iap: missing exp claim")
+	}
+	if now.After(claims.Expiry.Time().Add(iapClockSkew)) {
+		return fmt.Errorf("iap: token expired at %v", claims.Expiry.Time())
+	}
+
+	// Issued-at (with skew: reject if iat is too far in the future)
+	if claims.IssuedAt != nil {
+		if claims.IssuedAt.Time().After(now.Add(iapClockSkew)) {
+			return fmt.Errorf("iap: token issued in the future: iat=%v", claims.IssuedAt.Time())
+		}
+	}
+
+	// Subject and email must be present
+	if claims.Subject == "" {
+		return fmt.Errorf("iap: missing sub claim")
+	}
+	if claims.Email == "" {
+		return fmt.Errorf("iap: missing email claim")
+	}
+
+	return nil
+}
+
+func (a *IAPAuthenticator) resolveIssuer() string {
+	if a.Issuer != "" {
+		return a.Issuer
+	}
+	return DefaultIAPIssuer
+}
+
+func (a *IAPAuthenticator) resolveJWKSURL() string {
+	if a.JWKSURL != "" {
+		return a.JWKSURL
+	}
+	return DefaultIAPJWKSURL
+}
+
+func (a *IAPAuthenticator) resolveHTTPClient() *http.Client {
+	if a.HTTPClient != nil {
+		return a.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+func (a *IAPAuthenticator) init() {
+	a.jwksCache = &jwksCache{
+		url:    a.resolveJWKSURL(),
+		client: a.resolveHTTPClient(),
+	}
+}
+
+// stripIAPPrefix removes the "accounts.google.com:" prefix from IAP claims.
+func stripIAPPrefix(s string) string {
+	return strings.TrimPrefix(s, iapIdPPrefix)
+}
+
+// ---- JWKS Cache ----
+
+// jwksCache manages a cached set of JWKS keys with lazy fetch, periodic refresh,
+// and on-miss refresh for unknown key IDs.
+type jwksCache struct {
+	url    string
+	client *http.Client
+
+	mu          sync.RWMutex
+	keys        map[string]jose.JSONWebKey // kid -> key
+	lastFetched time.Time
+}
+
+// GetKey returns the public key for the given kid. If the kid is not found
+// in the cache, a refresh is triggered. If the JWKS endpoint is temporarily
+// unavailable, the last-good keys are served.
+func (c *jwksCache) GetKey(kid string) (interface{}, error) {
+	// Try cached key first
+	c.mu.RLock()
+	if c.keys != nil {
+		if k, ok := c.keys[kid]; ok {
+			needsRefresh := time.Since(c.lastFetched) > jwksRefreshInterval
+			c.mu.RUnlock()
+			// Proactive background refresh (non-blocking)
+			if needsRefresh {
+				go c.refresh()
+			}
+			return k.Key, nil
+		}
+	}
+	c.mu.RUnlock()
+
+	// Kid not found — refresh and retry
+	if err := c.refresh(); err != nil {
+		// If we have stale keys but not this kid, it's a genuine miss
+		c.mu.RLock()
+		hasKeys := len(c.keys) > 0
+		c.mu.RUnlock()
+		if !hasKeys {
+			return nil, fmt.Errorf("jwks fetch failed and no cached keys: %w", err)
+		}
+		// Stale keys but kid still not found after failed refresh
+		return nil, fmt.Errorf("unknown kid %q (jwks refresh failed: %v)", kid, err)
+	}
+
+	// Check again after refresh
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if k, ok := c.keys[kid]; ok {
+		return k.Key, nil
+	}
+	return nil, fmt.Errorf("unknown kid %q after JWKS refresh", kid)
+}
+
+// refresh fetches the JWKS from the endpoint and updates the cache.
+// On transient failure, the last-good keys are preserved.
+func (c *jwksCache) refresh() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Debounce: don't re-fetch if we just fetched very recently
+	if time.Since(c.lastFetched) < 5*time.Second {
+		return nil
+	}
+
+	resp, err := c.client.Get(c.url)
+	if err != nil {
+		slog.Warn("jwks fetch failed, serving last-good keys", "url", c.url, "error", err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		slog.Warn("jwks fetch non-200", "url", c.url, "status", resp.StatusCode, "body", string(body))
+		return fmt.Errorf("jwks fetch returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB limit
+	if err != nil {
+		return fmt.Errorf("jwks read body: %w", err)
+	}
+
+	var jwks jose.JSONWebKeySet
+	if err := json.Unmarshal(body, &jwks); err != nil {
+		return fmt.Errorf("jwks parse: %w", err)
+	}
+
+	newKeys := make(map[string]jose.JSONWebKey, len(jwks.Keys))
+	for _, k := range jwks.Keys {
+		if k.KeyID != "" {
+			newKeys[k.KeyID] = k
+		}
+	}
+
+	c.keys = newKeys
+	c.lastFetched = time.Now()
+
+	slog.Debug("jwks cache refreshed", "url", c.url, "keyCount", len(newKeys))
+	return nil
+}

--- a/pkg/hub/proxyauth_test.go
+++ b/pkg/hub/proxyauth_test.go
@@ -376,10 +376,11 @@ func TestIAPAuthenticator_UnknownKidTriggersRefresh(t *testing.T) {
 	bothData, _ := json.Marshal(bothKeys)
 	currentJWKS = bothData
 
-	// Reset the cache's last fetch time to force refresh on unknown kid
+	// Reset the cache's fetch times to force refresh on unknown kid
 	auth.initOnce.Do(func() {}) // ensure init ran
 	auth.jwksCache.mu.Lock()
-	auth.jwksCache.lastFetched = time.Time{} // force refresh
+	auth.jwksCache.lastFetched = time.Time{}   // force proactive refresh
+	auth.jwksCache.lastAttempted = time.Time{} // clear debounce window
 	auth.jwksCache.mu.Unlock()
 
 	// Second request with new key — should trigger JWKS refresh and succeed
@@ -526,9 +527,10 @@ func TestJWKSCache_TransientFailure(t *testing.T) {
 		t.Fatal("first GetKey returned nil key")
 	}
 
-	// Force refresh by clearing lastFetched
+	// Force refresh by clearing lastFetched and lastAttempted
 	cache.mu.Lock()
 	cache.lastFetched = time.Time{}
+	cache.lastAttempted = time.Time{}
 	cache.mu.Unlock()
 
 	// Second fetch with same kid still works (returns cached key even though refresh fails)
@@ -538,5 +540,67 @@ func TestJWKSCache_TransientFailure(t *testing.T) {
 	}
 	if key2 == nil {
 		t.Fatal("second GetKey returned nil key")
+	}
+}
+
+func TestJWKSCache_StampedePreventionDuringOutage(t *testing.T) {
+	kp := newTestKeyPair(t, "test-key-1")
+
+	fetchCount := 0
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount++
+		if fetchCount <= 1 {
+			// First call succeeds — populate the cache
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(kp.jwksJSON(t))
+		} else {
+			// All subsequent calls fail (simulating a persistent outage)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(jwksSrv.Close)
+
+	cache := &jwksCache{url: jwksSrv.URL, client: jwksSrv.Client()}
+
+	// Populate cache with a successful fetch
+	key, err := cache.GetKey(kp.kid)
+	if err != nil {
+		t.Fatalf("initial GetKey failed: %v", err)
+	}
+	if key == nil {
+		t.Fatal("initial GetKey returned nil key")
+	}
+	if fetchCount != 1 {
+		t.Fatalf("expected 1 fetch after initial GetKey, got %d", fetchCount)
+	}
+
+	// Reset lastAttempted to allow the next refresh attempt, but keep lastFetched
+	// old enough that proactive refresh is desired
+	cache.mu.Lock()
+	cache.lastFetched = time.Time{}
+	cache.lastAttempted = time.Time{}
+	cache.mu.Unlock()
+
+	// Now make multiple GetKey calls for an unknown kid during the outage.
+	// Each call triggers refresh() (kid miss), but debounce should prevent
+	// more than one actual fetch within the debounce window.
+	unknownKid := "unknown-kid"
+	for i := 0; i < 5; i++ {
+		_, _ = cache.GetKey(unknownKid)
+	}
+
+	// Expect exactly 2 fetches total: 1 initial success + 1 failed attempt
+	// within the debounce window. The remaining 4 calls should be debounced.
+	if fetchCount != 2 {
+		t.Errorf("expected 2 total fetches (1 initial + 1 debounced attempt), got %d", fetchCount)
+	}
+
+	// Verify the cache still serves the last-good key
+	key2, err := cache.GetKey(kp.kid)
+	if err != nil {
+		t.Fatalf("GetKey for cached kid during outage failed: %v", err)
+	}
+	if key2 == nil {
+		t.Fatal("expected last-good key to be served during outage")
 	}
 }

--- a/pkg/hub/proxyauth_test.go
+++ b/pkg/hub/proxyauth_test.go
@@ -413,7 +413,7 @@ func TestIAPAuthenticator_StripPrefix(t *testing.T) {
 	}{
 		{"accounts.google.com:12345", "12345"},
 		{"accounts.google.com:user@example.com", "user@example.com"},
-		{"12345", "12345"},                   // no prefix
+		{"12345", "12345"},                       // no prefix
 		{"user@example.com", "user@example.com"}, // no prefix
 		{"", ""},
 	}

--- a/pkg/hub/proxyauth_test.go
+++ b/pkg/hub/proxyauth_test.go
@@ -1,0 +1,542 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+)
+
+// testKeyPair holds a self-generated ES256 key pair for testing.
+type testKeyPair struct {
+	privateKey *ecdsa.PrivateKey
+	kid        string
+}
+
+func newTestKeyPair(t *testing.T, kid string) *testKeyPair {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate ES256 key: %v", err)
+	}
+	return &testKeyPair{privateKey: key, kid: kid}
+}
+
+// jwksJSON returns the JWKS JSON containing the public key.
+func (kp *testKeyPair) jwksJSON(t *testing.T) []byte {
+	t.Helper()
+	jwk := jose.JSONWebKey{
+		Key:       &kp.privateKey.PublicKey,
+		KeyID:     kp.kid,
+		Algorithm: string(jose.ES256),
+		Use:       "sig",
+	}
+	jwks := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}}
+	data, err := json.Marshal(jwks)
+	if err != nil {
+		t.Fatalf("failed to marshal JWKS: %v", err)
+	}
+	return data
+}
+
+// signJWT creates a signed JWT compact serialization.
+func (kp *testKeyPair) signJWT(t *testing.T, claims interface{}) string {
+	t.Helper()
+	signerKey := jose.SigningKey{Algorithm: jose.ES256, Key: kp.privateKey}
+	opts := (&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", kp.kid)
+	signer, err := jose.NewSigner(signerKey, opts)
+	if err != nil {
+		t.Fatalf("failed to create signer: %v", err)
+	}
+	raw, err := jwt.Signed(signer).Claims(claims).Serialize()
+	if err != nil {
+		t.Fatalf("failed to sign JWT: %v", err)
+	}
+	return raw
+}
+
+// startJWKSServer starts a test HTTP server serving the given JWKS JSON.
+func startJWKSServer(t *testing.T, jwksData []byte) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jwksData)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func makeTestClaims(sub, email, iss, aud string, iat, exp time.Time) map[string]interface{} {
+	claims := map[string]interface{}{
+		"iss":   iss,
+		"sub":   sub,
+		"aud":   aud,
+		"email": email,
+		"iat":   iat.Unix(),
+		"exp":   exp.Unix(),
+	}
+	return claims
+}
+
+func TestIAPAuthenticator_ValidAssertion(t *testing.T) {
+	kp := newTestKeyPair(t, "test-key-1")
+	jwksSrv := startJWKSServer(t, kp.jwksJSON(t))
+
+	now := time.Now()
+	claims := makeTestClaims(
+		"accounts.google.com:12345",
+		"accounts.google.com:user@example.com",
+		"https://cloud.google.com/iap",
+		"/projects/123/global/backendServices/456",
+		now.Add(-1*time.Minute),
+		now.Add(5*time.Minute),
+	)
+	assertion := kp.signJWT(t, claims)
+
+	auth := &IAPAuthenticator{
+		Audience: "/projects/123/global/backendServices/456",
+		JWKSURL:  jwksSrv.URL,
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set(IAPAssertionHeader, assertion)
+
+	info, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected ProxyUserInfo, got nil")
+	}
+	if info.Subject != "12345" {
+		t.Errorf("expected subject '12345', got %q", info.Subject)
+	}
+	if info.Email != "user@example.com" {
+		t.Errorf("expected email 'user@example.com', got %q", info.Email)
+	}
+}
+
+func TestIAPAuthenticator_MissingHeader(t *testing.T) {
+	auth := &IAPAuthenticator{
+		Audience: "/projects/123/global/backendServices/456",
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	// No assertion header set
+
+	info, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("expected nil error for missing header, got: %v", err)
+	}
+	if info != nil {
+		t.Fatal("expected nil info for missing header")
+	}
+}
+
+func TestIAPAuthenticator_BadSignature(t *testing.T) {
+	kp1 := newTestKeyPair(t, "test-key-1")
+	kp2 := newTestKeyPair(t, "test-key-1") // different key, same kid
+
+	// JWKS has kp2's public key
+	jwksSrv := startJWKSServer(t, kp2.jwksJSON(t))
+
+	now := time.Now()
+	claims := makeTestClaims(
+		"accounts.google.com:12345",
+		"accounts.google.com:user@example.com",
+		"https://cloud.google.com/iap",
+		"/projects/123/global/backendServices/456",
+		now.Add(-1*time.Minute),
+		now.Add(5*time.Minute),
+	)
+	// Sign with kp1's private key
+	assertion := kp1.signJWT(t, claims)
+
+	auth := &IAPAuthenticator{
+		Audience: "/projects/123/global/backendServices/456",
+		JWKSURL:  jwksSrv.URL,
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set(IAPAssertionHeader, assertion)
+
+	info, err := auth.Authenticate(req)
+	if err == nil {
+		t.Fatal("expected error for bad signature, got nil")
+	}
+	if info != nil {
+		t.Fatal("expected nil info for bad signature")
+	}
+}
+
+func TestIAPAuthenticator_WrongAudience(t *testing.T) {
+	kp := newTestKeyPair(t, "test-key-1")
+	jwksSrv := startJWKSServer(t, kp.jwksJSON(t))
+
+	now := time.Now()
+	claims := makeTestClaims(
+		"accounts.google.com:12345",
+		"accounts.google.com:user@example.com",
+		"https://cloud.google.com/iap",
+		"/projects/WRONG/global/backendServices/WRONG",
+		now.Add(-1*time.Minute),
+		now.Add(5*time.Minute),
+	)
+	assertion := kp.signJWT(t, claims)
+
+	auth := &IAPAuthenticator{
+		Audience: "/projects/123/global/backendServices/456",
+		JWKSURL:  jwksSrv.URL,
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set(IAPAssertionHeader, assertion)
+
+	info, err := auth.Authenticate(req)
+	if err == nil {
+		t.Fatal("expected error for wrong audience, got nil")
+	}
+	if info != nil {
+		t.Fatal("expected nil info for wrong audience")
+	}
+	t.Logf("expected error: %v", err)
+}
+
+func TestIAPAuthenticator_WrongIssuer(t *testing.T) {
+	kp := newTestKeyPair(t, "test-key-1")
+	jwksSrv := startJWKSServer(t, kp.jwksJSON(t))
+
+	now := time.Now()
+	claims := makeTestClaims(
+		"accounts.google.com:12345",
+		"accounts.google.com:user@example.com",
+		"https://evil.example.com/iap",
+		"/projects/123/global/backendServices/456",
+		now.Add(-1*time.Minute),
+		now.Add(5*time.Minute),
+	)
+	assertion := kp.signJWT(t, claims)
+
+	auth := &IAPAuthenticator{
+		Audience: "/projects/123/global/backendServices/456",
+		JWKSURL:  jwksSrv.URL,
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set(IAPAssertionHeader, assertion)
+
+	info, err := auth.Authenticate(req)
+	if err == nil {
+		t.Fatal("expected error for wrong issuer, got nil")
+	}
+	if info != nil {
+		t.Fatal("expected nil info for wrong issuer")
+	}
+	t.Logf("expected error: %v", err)
+}
+
+func TestIAPAuthenticator_ExpiredToken(t *testing.T) {
+	kp := newTestKeyPair(t, "test-key-1")
+	jwksSrv := startJWKSServer(t, kp.jwksJSON(t))
+
+	now := time.Now()
+	claims := makeTestClaims(
+		"accounts.google.com:12345",
+		"accounts.google.com:user@example.com",
+		"https://cloud.google.com/iap",
+		"/projects/123/global/backendServices/456",
+		now.Add(-10*time.Minute),
+		now.Add(-5*time.Minute), // expired 5 minutes ago (well past 30s skew)
+	)
+	assertion := kp.signJWT(t, claims)
+
+	auth := &IAPAuthenticator{
+		Audience: "/projects/123/global/backendServices/456",
+		JWKSURL:  jwksSrv.URL,
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set(IAPAssertionHeader, assertion)
+
+	info, err := auth.Authenticate(req)
+	if err == nil {
+		t.Fatal("expected error for expired token, got nil")
+	}
+	if info != nil {
+		t.Fatal("expected nil info for expired token")
+	}
+	t.Logf("expected error: %v", err)
+}
+
+func TestIAPAuthenticator_CustomIssuer(t *testing.T) {
+	kp := newTestKeyPair(t, "test-key-1")
+	jwksSrv := startJWKSServer(t, kp.jwksJSON(t))
+
+	now := time.Now()
+	customIssuer := "https://test.example.com/iap"
+	claims := makeTestClaims(
+		"accounts.google.com:12345",
+		"accounts.google.com:user@test.com",
+		customIssuer,
+		"/projects/123/global/backendServices/456",
+		now.Add(-1*time.Minute),
+		now.Add(5*time.Minute),
+	)
+	assertion := kp.signJWT(t, claims)
+
+	auth := &IAPAuthenticator{
+		Audience: "/projects/123/global/backendServices/456",
+		Issuer:   customIssuer,
+		JWKSURL:  jwksSrv.URL,
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set(IAPAssertionHeader, assertion)
+
+	info, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("expected no error with custom issuer, got: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected ProxyUserInfo, got nil")
+	}
+	if info.Email != "user@test.com" {
+		t.Errorf("expected email 'user@test.com', got %q", info.Email)
+	}
+}
+
+func TestIAPAuthenticator_UnknownKidTriggersRefresh(t *testing.T) {
+	kp1 := newTestKeyPair(t, "old-key")
+	kp2 := newTestKeyPair(t, "new-key")
+
+	// Start JWKS server initially with only old key
+	var currentJWKS []byte
+	currentJWKS = kp1.jwksJSON(t)
+
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(currentJWKS)
+	}))
+	t.Cleanup(jwksSrv.Close)
+
+	auth := &IAPAuthenticator{
+		Audience: "/projects/123/global/backendServices/456",
+		JWKSURL:  jwksSrv.URL,
+	}
+
+	// First request with old key works
+	now := time.Now()
+	claims1 := makeTestClaims(
+		"accounts.google.com:12345",
+		"accounts.google.com:user@example.com",
+		"https://cloud.google.com/iap",
+		"/projects/123/global/backendServices/456",
+		now.Add(-1*time.Minute),
+		now.Add(5*time.Minute),
+	)
+	assertion1 := kp1.signJWT(t, claims1)
+	req1 := httptest.NewRequest("GET", "/", nil)
+	req1.Header.Set(IAPAssertionHeader, assertion1)
+	info1, err := auth.Authenticate(req1)
+	if err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+	if info1 == nil {
+		t.Fatal("first request returned nil info")
+	}
+
+	// Now "rotate" keys — JWKS server returns both keys
+	bothKeys := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{Key: &kp1.privateKey.PublicKey, KeyID: kp1.kid, Algorithm: string(jose.ES256), Use: "sig"},
+			{Key: &kp2.privateKey.PublicKey, KeyID: kp2.kid, Algorithm: string(jose.ES256), Use: "sig"},
+		},
+	}
+	bothData, _ := json.Marshal(bothKeys)
+	currentJWKS = bothData
+
+	// Reset the cache's last fetch time to force refresh on unknown kid
+	auth.initOnce.Do(func() {}) // ensure init ran
+	auth.jwksCache.mu.Lock()
+	auth.jwksCache.lastFetched = time.Time{} // force refresh
+	auth.jwksCache.mu.Unlock()
+
+	// Second request with new key — should trigger JWKS refresh and succeed
+	claims2 := makeTestClaims(
+		"accounts.google.com:67890",
+		"accounts.google.com:user2@example.com",
+		"https://cloud.google.com/iap",
+		"/projects/123/global/backendServices/456",
+		now.Add(-1*time.Minute),
+		now.Add(5*time.Minute),
+	)
+	assertion2 := kp2.signJWT(t, claims2)
+	req2 := httptest.NewRequest("GET", "/", nil)
+	req2.Header.Set(IAPAssertionHeader, assertion2)
+	info2, err := auth.Authenticate(req2)
+	if err != nil {
+		t.Fatalf("second request (new kid) failed: %v", err)
+	}
+	if info2 == nil {
+		t.Fatal("second request returned nil info")
+	}
+	if info2.Subject != "67890" {
+		t.Errorf("expected subject '67890', got %q", info2.Subject)
+	}
+}
+
+func TestIAPAuthenticator_StripPrefix(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"accounts.google.com:12345", "12345"},
+		{"accounts.google.com:user@example.com", "user@example.com"},
+		{"12345", "12345"},                   // no prefix
+		{"user@example.com", "user@example.com"}, // no prefix
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := stripIAPPrefix(tt.input)
+		if got != tt.expected {
+			t.Errorf("stripIAPPrefix(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestIAPAuthenticator_EmailLowercased(t *testing.T) {
+	kp := newTestKeyPair(t, "test-key-1")
+	jwksSrv := startJWKSServer(t, kp.jwksJSON(t))
+
+	now := time.Now()
+	claims := makeTestClaims(
+		"accounts.google.com:12345",
+		"accounts.google.com:User@EXAMPLE.COM",
+		"https://cloud.google.com/iap",
+		"/projects/123/global/backendServices/456",
+		now.Add(-1*time.Minute),
+		now.Add(5*time.Minute),
+	)
+	assertion := kp.signJWT(t, claims)
+
+	auth := &IAPAuthenticator{
+		Audience: "/projects/123/global/backendServices/456",
+		JWKSURL:  jwksSrv.URL,
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set(IAPAssertionHeader, assertion)
+
+	info, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Email != "user@example.com" {
+		t.Errorf("expected lowercased email 'user@example.com', got %q", info.Email)
+	}
+}
+
+func TestIAPAuthenticator_HDClaim(t *testing.T) {
+	kp := newTestKeyPair(t, "test-key-1")
+	jwksSrv := startJWKSServer(t, kp.jwksJSON(t))
+
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":   "https://cloud.google.com/iap",
+		"sub":   "accounts.google.com:12345",
+		"aud":   "/projects/123/global/backendServices/456",
+		"email": "accounts.google.com:user@example.com",
+		"hd":    "example.com",
+		"iat":   now.Add(-1 * time.Minute).Unix(),
+		"exp":   now.Add(5 * time.Minute).Unix(),
+	}
+	assertion := kp.signJWT(t, claims)
+
+	auth := &IAPAuthenticator{
+		Audience: "/projects/123/global/backendServices/456",
+		JWKSURL:  jwksSrv.URL,
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set(IAPAssertionHeader, assertion)
+
+	info, err := auth.Authenticate(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Domain != "example.com" {
+		t.Errorf("expected domain 'example.com', got %q", info.Domain)
+	}
+}
+
+func TestIAPAuthenticator_Name(t *testing.T) {
+	auth := &IAPAuthenticator{}
+	if auth.Name() != "iap" {
+		t.Errorf("expected Name()='iap', got %q", auth.Name())
+	}
+}
+
+func TestJWKSCache_TransientFailure(t *testing.T) {
+	kp := newTestKeyPair(t, "test-key-1")
+
+	// Start a failing server
+	failCount := 0
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		failCount++
+		if failCount <= 1 {
+			// First call succeeds
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(kp.jwksJSON(t))
+		} else {
+			// Subsequent calls fail
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(jwksSrv.Close)
+
+	cache := &jwksCache{url: jwksSrv.URL, client: http.DefaultClient}
+
+	// First fetch succeeds
+	key, err := cache.GetKey(kp.kid)
+	if err != nil {
+		t.Fatalf("first GetKey failed: %v", err)
+	}
+	if key == nil {
+		t.Fatal("first GetKey returned nil key")
+	}
+
+	// Force refresh by clearing lastFetched
+	cache.mu.Lock()
+	cache.lastFetched = time.Time{}
+	cache.mu.Unlock()
+
+	// Second fetch with same kid still works (returns cached key even though refresh fails)
+	key2, err := cache.GetKey(kp.kid)
+	if err != nil {
+		t.Fatalf("second GetKey failed: %v", err)
+	}
+	if key2 == nil {
+		t.Fatal("second GetKey returned nil key")
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -87,6 +87,10 @@ type ServerConfig struct {
 	// other replica behind the load balancer. When empty, signing keys fall
 	// back to per-hub storage in the secret backend / store.
 	SharedSigningSecret string
+	// AuthMode is the exclusive human auth mode: "oauth" (default), "proxy", "dev".
+	AuthMode string
+	// ProxyAuthenticator is the configured proxy authenticator (when AuthMode == "proxy").
+	ProxyAuth ProxyAuthenticator
 	// TrustedProxies is a list of trusted proxy IPs/CIDRs for forwarded headers.
 	TrustedProxies []string
 	// Debug enables verbose debug logging.
@@ -800,15 +804,21 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 
 	// Build unified auth configuration
 	srv.authConfig = AuthConfig{
-		Mode:           "production",
-		DevAuthEnabled: cfg.DevAuthToken != "",
-		DevAuthToken:   cfg.DevAuthToken,
-		AgentTokenSvc:  srv.agentTokenService,
-		UserTokenSvc:   srv.userTokenService,
-		UATSvc:         srv.uatService,
-		TrustedProxies: cfg.TrustedProxies,
-		Debug:          cfg.Debug,
-		Logger:         srv.authLog,
+		Mode:               "production",
+		DevAuthEnabled:     cfg.DevAuthToken != "",
+		DevAuthToken:       cfg.DevAuthToken,
+		AgentTokenSvc:      srv.agentTokenService,
+		UserTokenSvc:       srv.userTokenService,
+		UATSvc:             srv.uatService,
+		TrustedProxies:     cfg.TrustedProxies,
+		ProxyAuthenticator: cfg.ProxyAuth,
+		AuthMode:           cfg.AuthMode,
+		Debug:              cfg.Debug,
+		Logger:             srv.authLog,
+	}
+	// Wire the proxy user provisioner (wraps provisionUser with 60s cache)
+	if cfg.ProxyAuth != nil {
+		srv.authConfig.ProxyUserProvisioner = MakeProxyUserProvisioner(srv)
 	}
 
 	// Initialize Cloud Logging query service (optional, gated on GCP project ID)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -154,6 +154,15 @@ type ServerConfig struct {
 	// GCPMintCapGlobal is the maximum total number of minted service accounts across all projects.
 	// Zero means unlimited (default).
 	GCPMintCapGlobal int
+	// TransportMode is the transport-layer auth mode: "none" (default), "cloudrun_invoker", "iap".
+	// Controls which transport tokens the hub issues to agents.
+	TransportMode string
+	// TransportAudience is the OIDC audience for transport tokens.
+	// For IAP: the IAP OAuth client ID. For cloudrun_invoker: the hub URL.
+	TransportAudience string
+	// TransportMinter mints transport-layer OIDC tokens for agents.
+	// Nil when TransportMode == "none" or unset.
+	TransportMinter TransportTokenMinter
 }
 
 // MaintenanceConfig holds configuration for routine maintenance operation executors.
@@ -536,6 +545,10 @@ type Server struct {
 	// Channel registry for external notification delivery (nil = disabled)
 	channelRegistry *ChannelRegistry
 
+	// Transport token minter for agent outbound auth (nil = transport auth disabled)
+	transportMinter   TransportTokenMinter
+	transportAudience string
+
 	// GCP token generator for agent identity (nil = GCP identity disabled)
 	gcpTokenGenerator GCPTokenGenerator
 
@@ -716,6 +729,15 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 		srv.brokerAuthService = NewBrokerAuthService(cfg.BrokerAuthConfig, s)
 		srv.metrics = NewBrokerAuthMetrics()
 		slog.Info("Broker HMAC authentication enabled")
+	}
+
+	// Store transport token minter if configured
+	if cfg.TransportMinter != nil {
+		srv.transportMinter = cfg.TransportMinter
+		srv.transportAudience = cfg.TransportAudience
+		slog.Info("Transport token minter configured",
+			"mode", cfg.TransportMode,
+			"audience", cfg.TransportAudience)
 	}
 
 	// Initialize control channel manager
@@ -1547,6 +1569,11 @@ func (s *Server) CreateAuthenticatedDispatcher() *HTTPAgentDispatcher {
 	dispatcher.SetCrossNodeDeps(s.events, s.commandBus)
 	if s.dispatchMetrics != nil {
 		dispatcher.SetDispatchMetrics(s.dispatchMetrics)
+	}
+
+	// Configure transport token minter if available
+	if s.transportMinter != nil && s.transportAudience != "" {
+		dispatcher.SetTransportMinter(s.transportMinter, s.transportAudience)
 	}
 
 	return dispatcher

--- a/pkg/hub/transport_token.go
+++ b/pkg/hub/transport_token.go
@@ -19,6 +19,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"sync"
 	"time"
 
 	"google.golang.org/api/iamcredentials/v1"
@@ -61,6 +63,11 @@ type gcpTransportMinter struct {
 	// iamEndpoint overrides the IAM Credentials API endpoint (for testing).
 	// Empty uses the default Google endpoint.
 	iamEndpoint string
+
+	// svcOnce guards lazy initialization of the cached IAM credentials service.
+	svcOnce sync.Once
+	svc     *iamcredentials.Service
+	svcErr  error
 }
 
 // NewGCPTransportMinter creates a new GCP transport token minter.
@@ -73,6 +80,19 @@ func NewGCPTransportMinter(serviceAccountEmail, iamEndpoint string) *gcpTranspor
 	}
 }
 
+// getOrCreateService lazily creates and caches the IAM credentials service client.
+// Uses context.Background() for the long-lived client; per-call ctx is passed to .Do().
+func (m *gcpTransportMinter) getOrCreateService() (*iamcredentials.Service, error) {
+	m.svcOnce.Do(func() {
+		var opts []option.ClientOption
+		if m.iamEndpoint != "" {
+			opts = append(opts, option.WithEndpoint(m.iamEndpoint))
+		}
+		m.svc, m.svcErr = iamcredentials.NewService(context.Background(), opts...)
+	})
+	return m.svc, m.svcErr
+}
+
 // MintIDToken impersonates the configured SA to mint a Google OIDC ID token
 // with the given audience via the IAM Credentials API.
 func (m *gcpTransportMinter) MintIDToken(ctx context.Context, audience string) (string, time.Time, error) {
@@ -80,12 +100,7 @@ func (m *gcpTransportMinter) MintIDToken(ctx context.Context, audience string) (
 		return "", time.Time{}, fmt.Errorf("transport minter: service account email not configured")
 	}
 
-	var opts []option.ClientOption
-	if m.iamEndpoint != "" {
-		opts = append(opts, option.WithEndpoint(m.iamEndpoint))
-	}
-
-	svc, err := iamcredentials.NewService(ctx, opts...)
+	svc, err := m.getOrCreateService()
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("transport minter: failed to create IAM credentials client: %w", err)
 	}
@@ -118,7 +133,7 @@ func (m *gcpTransportMinter) MintIDToken(ctx context.Context, audience string) (
 // parseJWTExpiry extracts the expiry time from a JWT without validating the signature.
 // This is safe for scheduling purposes since the token will be validated by the platform.
 func parseJWTExpiry(tokenString string) (time.Time, error) {
-	parts := splitJWT(tokenString)
+	parts := strings.Split(tokenString, ".")
 	if len(parts) != 3 {
 		return time.Time{}, fmt.Errorf("invalid JWT format: expected 3 parts, got %d", len(parts))
 	}
@@ -140,20 +155,6 @@ func parseJWTExpiry(tokenString string) (time.Time, error) {
 	}
 
 	return time.Unix(claims.Exp, 0), nil
-}
-
-// splitJWT splits a JWT string into its three dot-separated parts.
-func splitJWT(token string) []string {
-	parts := make([]string, 0, 3)
-	start := 0
-	for i := 0; i < len(token); i++ {
-		if token[i] == '.' {
-			parts = append(parts, token[start:i])
-			start = i + 1
-		}
-	}
-	parts = append(parts, token[start:])
-	return parts
 }
 
 // fakeTransportMinter is a test double for TransportTokenMinter.

--- a/pkg/hub/transport_token.go
+++ b/pkg/hub/transport_token.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"google.golang.org/api/iamcredentials/v1"
+	"google.golang.org/api/option"
+)
+
+// TransportTokenMinter mints Google OIDC ID tokens for the transport layer.
+// The hub uses this to issue tokens that let agents traverse platform guards
+// (IAP or Cloud Run invoker) on outbound requests.
+type TransportTokenMinter interface {
+	// MintIDToken mints a Google OIDC ID token for the given audience.
+	// Returns the token string, its expiry time, and any error.
+	MintIDToken(ctx context.Context, audience string) (token string, expiry time.Time, err error)
+}
+
+// RefreshTokenEntry represents a single token in the generalized refresh response.
+// Used in both the refresh endpoint response and internally for dispatch payload construction.
+type RefreshTokenEntry struct {
+	Layer     string `json:"layer"`               // "app" | "transport"
+	Type      string `json:"type"`                // "scion_access" | "scion_refresh" | "google_oidc"
+	Value     string `json:"value"`               // the token value
+	ExpiresIn int    `json:"expiresIn"`           // seconds until expiry
+	Audience  string `json:"audience,omitempty"`  // only for transport tokens
+}
+
+// noopTransportMinter is used when transport auth is disabled (mode == "none").
+// It always returns an error indicating transport auth is not configured.
+type noopTransportMinter struct{}
+
+func (m *noopTransportMinter) MintIDToken(_ context.Context, _ string) (string, time.Time, error) {
+	return "", time.Time{}, fmt.Errorf("transport auth is disabled (mode=none)")
+}
+
+// gcpTransportMinter mints Google OIDC ID tokens by impersonating a dedicated
+// service account via the IAM Credentials API (generateIdToken).
+// The hub's runtime SA must hold serviceAccountTokenCreator on the target SA.
+type gcpTransportMinter struct {
+	// serviceAccountEmail is the email of the SA to impersonate.
+	serviceAccountEmail string
+	// iamEndpoint overrides the IAM Credentials API endpoint (for testing).
+	// Empty uses the default Google endpoint.
+	iamEndpoint string
+}
+
+// NewGCPTransportMinter creates a new GCP transport token minter.
+// serviceAccountEmail is the dedicated platform-auth SA to impersonate.
+// iamEndpoint overrides the IAM Credentials API endpoint (empty uses the default).
+func NewGCPTransportMinter(serviceAccountEmail, iamEndpoint string) *gcpTransportMinter {
+	return &gcpTransportMinter{
+		serviceAccountEmail: serviceAccountEmail,
+		iamEndpoint:         iamEndpoint,
+	}
+}
+
+// MintIDToken impersonates the configured SA to mint a Google OIDC ID token
+// with the given audience via the IAM Credentials API.
+func (m *gcpTransportMinter) MintIDToken(ctx context.Context, audience string) (string, time.Time, error) {
+	if m.serviceAccountEmail == "" {
+		return "", time.Time{}, fmt.Errorf("transport minter: service account email not configured")
+	}
+
+	var opts []option.ClientOption
+	if m.iamEndpoint != "" {
+		opts = append(opts, option.WithEndpoint(m.iamEndpoint))
+	}
+
+	svc, err := iamcredentials.NewService(ctx, opts...)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("transport minter: failed to create IAM credentials client: %w", err)
+	}
+
+	name := fmt.Sprintf("projects/-/serviceAccounts/%s", m.serviceAccountEmail)
+	req := &iamcredentials.GenerateIdTokenRequest{
+		Audience:     audience,
+		IncludeEmail: true,
+	}
+
+	resp, err := svc.Projects.ServiceAccounts.GenerateIdToken(name, req).Context(ctx).Do()
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("transport minter: generateIdToken failed: %w", err)
+	}
+
+	if resp.Token == "" {
+		return "", time.Time{}, fmt.Errorf("transport minter: empty token in response")
+	}
+
+	// Parse expiry from the JWT token
+	expiry, err := parseJWTExpiry(resp.Token)
+	if err != nil {
+		// Fall back to 1 hour default TTL if we can't parse the expiry
+		expiry = time.Now().Add(1 * time.Hour)
+	}
+
+	return resp.Token, expiry, nil
+}
+
+// parseJWTExpiry extracts the expiry time from a JWT without validating the signature.
+// This is safe for scheduling purposes since the token will be validated by the platform.
+func parseJWTExpiry(tokenString string) (time.Time, error) {
+	parts := splitJWT(tokenString)
+	if len(parts) != 3 {
+		return time.Time{}, fmt.Errorf("invalid JWT format: expected 3 parts, got %d", len(parts))
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to decode JWT payload: %w", err)
+	}
+
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse JWT claims: %w", err)
+	}
+
+	if claims.Exp == 0 {
+		return time.Time{}, fmt.Errorf("token has no expiry claim")
+	}
+
+	return time.Unix(claims.Exp, 0), nil
+}
+
+// splitJWT splits a JWT string into its three dot-separated parts.
+func splitJWT(token string) []string {
+	parts := make([]string, 0, 3)
+	start := 0
+	for i := 0; i < len(token); i++ {
+		if token[i] == '.' {
+			parts = append(parts, token[start:i])
+			start = i + 1
+		}
+	}
+	parts = append(parts, token[start:])
+	return parts
+}
+
+// fakeTransportMinter is a test double for TransportTokenMinter.
+// Exported for use in other test packages.
+type FakeTransportMinter struct {
+	Token     string
+	Expiry    time.Time
+	Err       error
+	CallCount int
+}
+
+func (f *FakeTransportMinter) MintIDToken(_ context.Context, _ string) (string, time.Time, error) {
+	f.CallCount++
+	return f.Token, f.Expiry, f.Err
+}

--- a/pkg/hub/transport_token_test.go
+++ b/pkg/hub/transport_token_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeTestJWTWithExpiry builds a minimal JWT with the given expiry for testing.
+func makeTestJWTWithExpiry(exp time.Time) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload, _ := json.Marshal(map[string]interface{}{"exp": exp.Unix(), "iss": "test"})
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payload)
+	sig := base64.RawURLEncoding.EncodeToString([]byte("fakesig"))
+	return fmt.Sprintf("%s.%s.%s", header, payloadB64, sig)
+}
+
+func TestNoopTransportMinter_ReturnsError(t *testing.T) {
+	m := &noopTransportMinter{}
+	token, expiry, err := m.MintIDToken(context.Background(), "https://example.com")
+	assert.Empty(t, token)
+	assert.True(t, expiry.IsZero())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "disabled")
+}
+
+func TestFakeTransportMinter(t *testing.T) {
+	testToken := makeTestJWTWithExpiry(time.Now().Add(1 * time.Hour))
+	testExpiry := time.Now().Add(1 * time.Hour)
+
+	m := &FakeTransportMinter{
+		Token:  testToken,
+		Expiry: testExpiry,
+	}
+
+	token, expiry, err := m.MintIDToken(context.Background(), "https://example.com")
+	require.NoError(t, err)
+	assert.Equal(t, testToken, token)
+	assert.Equal(t, testExpiry, expiry)
+	assert.Equal(t, 1, m.CallCount)
+}
+
+func TestFakeTransportMinter_Error(t *testing.T) {
+	m := &FakeTransportMinter{
+		Err: fmt.Errorf("test error"),
+	}
+
+	_, _, err := m.MintIDToken(context.Background(), "https://example.com")
+	assert.Error(t, err)
+	assert.Equal(t, "test error", err.Error())
+}
+
+func TestGCPTransportMinter_MintIDToken(t *testing.T) {
+	testExpiry := time.Now().Add(1 * time.Hour).Truncate(time.Second)
+	testToken := makeTestJWTWithExpiry(testExpiry)
+	testSA := "transport-auth@project.iam.gserviceaccount.com"
+
+	// Fake IAM Credentials API server
+	iamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request path matches the expected SA
+		assert.Contains(t, r.URL.Path, testSA)
+		assert.Equal(t, "POST", r.Method)
+
+		// Parse request body
+		var req struct {
+			Audience     string `json:"audience"`
+			IncludeEmail bool   `json:"includeEmail"`
+		}
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, "https://hub.example.com", req.Audience)
+		assert.True(t, req.IncludeEmail)
+
+		// Return a valid response
+		resp := map[string]string{"token": testToken}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer iamServer.Close()
+
+	m := NewGCPTransportMinter(testSA, iamServer.URL)
+
+	token, expiry, err := m.MintIDToken(context.Background(), "https://hub.example.com")
+	require.NoError(t, err)
+	assert.Equal(t, testToken, token)
+	assert.Equal(t, testExpiry, expiry)
+}
+
+func TestGCPTransportMinter_EmptySA(t *testing.T) {
+	m := NewGCPTransportMinter("", "")
+
+	_, _, err := m.MintIDToken(context.Background(), "https://hub.example.com")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "service account email not configured")
+}
+
+func TestGCPTransportMinter_APIError(t *testing.T) {
+	iamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprintln(w, `{"error": {"code": 403, "message": "Permission denied"}}`)
+	}))
+	defer iamServer.Close()
+
+	m := NewGCPTransportMinter("sa@project.iam.gserviceaccount.com", iamServer.URL)
+
+	_, _, err := m.MintIDToken(context.Background(), "https://hub.example.com")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "generateIdToken failed")
+}
+
+func TestParseJWTExpiry(t *testing.T) {
+	expected := time.Now().Add(1 * time.Hour).Truncate(time.Second)
+	token := makeTestJWTWithExpiry(expected)
+
+	expiry, err := parseJWTExpiry(token)
+	require.NoError(t, err)
+	assert.Equal(t, expected, expiry)
+}
+
+func TestParseJWTExpiry_InvalidFormat(t *testing.T) {
+	_, err := parseJWTExpiry("not-a-jwt")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected 3 parts")
+}
+
+func TestParseJWTExpiry_NoExpClaim(t *testing.T) {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"iss":"test"}`))
+	sig := base64.RawURLEncoding.EncodeToString([]byte("sig"))
+	token := fmt.Sprintf("%s.%s.%s", header, payload, sig)
+
+	_, err := parseJWTExpiry(token)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no expiry claim")
+}
+
+func TestRefreshTokenEntry_JSON(t *testing.T) {
+	entry := RefreshTokenEntry{
+		Layer:     "transport",
+		Type:      "google_oidc",
+		Value:     "token-value",
+		ExpiresIn: 3600,
+		Audience:  "https://hub.example.com",
+	}
+
+	data, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	var parsed RefreshTokenEntry
+	err = json.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+	assert.Equal(t, entry, parsed)
+}
+
+func TestRefreshTokenEntry_JSON_OmitAudience(t *testing.T) {
+	entry := RefreshTokenEntry{
+		Layer:     "app",
+		Type:      "scion_access",
+		Value:     "token-value",
+		ExpiresIn: 36000,
+	}
+
+	data, err := json.Marshal(entry)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "audience")
+}

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -124,6 +124,9 @@ type WebServerConfig struct {
 	BaseURL string
 	// DevAuthToken is the dev token for auto-login (empty = disabled).
 	DevAuthToken string
+	// AuthMode is the exclusive human auth mode: "oauth" (default), "proxy", "dev".
+	// In proxy mode, OAuth providers are not shown and logout behavior changes.
+	AuthMode string
 	// AuthorizedDomains is the list of allowed email domains (empty = all allowed).
 	AuthorizedDomains []string
 	// AdminEmails is the list of bootstrap admin emails (bypass domain check).
@@ -1475,8 +1478,26 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 }
 
 // handleLogout clears the session and redirects to login (or returns JSON for API).
+// In proxy mode, logout is a no-op (the proxy owns the session) — optionally
+// redirect to IAP's clear_login_cookie endpoint.
 // Route: GET /auth/logout, POST /auth/logout
 func (ws *WebServer) handleLogout(w http.ResponseWriter, r *http.Request) {
+	// In proxy mode, the hub does not own the session.
+	if ws.config.AuthMode == "proxy" {
+		if isBrowserRequest(r) {
+			// Redirect to IAP's clear login cookie endpoint
+			http.Redirect(w, r, "/_gcp_iap/clear_login_cookie", http.StatusFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": true,
+			"message": "proxy mode: session is managed by the authenticating proxy",
+		})
+		return
+	}
+
 	session, err := ws.sessionStore.Get(r, webSessionName)
 	if err != nil {
 		session, _ = ws.sessionStore.New(r, webSessionName)
@@ -1543,11 +1564,14 @@ func (ws *WebServer) handleAuthMe(w http.ResponseWriter, r *http.Request) {
 // handleAuthProviders returns which OAuth providers are enabled for web login.
 // Route: GET /auth/providers
 func (ws *WebServer) handleAuthProviders(w http.ResponseWriter, r *http.Request) {
-	resp := map[string]bool{
+	resp := map[string]interface{}{
 		"google": false,
 		"github": false,
 	}
-	if ws.oauthService != nil {
+	// In proxy mode, no OAuth providers are active (auth is handled by the proxy).
+	if ws.config.AuthMode == "proxy" {
+		resp["authMode"] = "proxy"
+	} else if ws.oauthService != nil {
 		resp["google"] = ws.oauthService.IsProviderConfiguredForClient(OAuthClientTypeWeb, "google")
 		resp["github"] = ws.oauthService.IsProviderConfiguredForClient(OAuthClientTypeWeb, "github")
 	}
@@ -1574,6 +1598,7 @@ func (ws *WebServer) handleAuthDebug(w http.ResponseWriter, r *http.Request) {
 		"hasAccessToken": session.Values[sessKeyHubAccessToken] != nil,
 		"config": map[string]interface{}{
 			"baseURL":         ws.config.BaseURL,
+			"authMode":        ws.config.AuthMode,
 			"devAuthEnabled":  ws.config.DevAuthToken != "",
 			"oauthConfigured": ws.oauthService != nil,
 			"storeConfigured": ws.store != nil,

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -151,6 +151,7 @@ type Client struct {
 	maxRetries     int
 	retryBaseDelay time.Duration
 	retryMaxDelay  time.Duration
+	oidcSource     oidcTokenSource // transport-layer OIDC token source (nil = disabled)
 }
 
 // NewClient creates a new Hub client from environment variables.
@@ -175,7 +176,7 @@ func NewClient() *Client {
 		return nil
 	}
 
-	return &Client{
+	c := &Client{
 		hubURL:         hubURL,
 		token:          token,
 		agentID:        agentID,
@@ -186,6 +187,8 @@ func NewClient() *Client {
 			Timeout: DefaultTimeout,
 		},
 	}
+	c.configureOIDCTransport()
+	return c
 }
 
 // NewClientWithConfig creates a new Hub client with explicit configuration.
@@ -333,10 +336,23 @@ func (c *Client) ReportState(ctx context.Context, phase state.Phase, activity st
 	})
 }
 
+// RefreshTokenEntry represents a single token in the generalized refresh response.
+// Mirrors the hub's RefreshTokenEntry type.
+type RefreshTokenEntry struct {
+	Layer     string `json:"layer"`              // "app" | "transport"
+	Type      string `json:"type"`               // "scion_access" | "scion_refresh" | "google_oidc"
+	Value     string `json:"value"`              // the token value
+	ExpiresIn int    `json:"expiresIn"`          // seconds until expiry
+	Audience  string `json:"audience,omitempty"` // only for transport tokens
+}
+
 // RefreshTokenResponse is the response from the token refresh endpoint.
+// Includes both legacy single-token fields (backward compat) and the
+// generalized tokens[] array.
 type RefreshTokenResponse struct {
-	Token     string `json:"token"`
-	ExpiresAt string `json:"expires_at"`
+	Token     string              `json:"token"`
+	ExpiresAt string              `json:"expires_at"`
+	Tokens    []RefreshTokenEntry `json:"tokens,omitempty"`
 }
 
 // RefreshToken calls the Hub to refresh the agent's authentication token.
@@ -398,7 +414,56 @@ func (c *Client) RefreshToken(ctx context.Context) (string, time.Time, error) {
 		_ = err
 	}
 
+	// Process the generalized tokens[] array if present.
+	// Apply each entry to the appropriate subsystem by layer/type.
+	if len(result.Tokens) > 0 {
+		c.applyRefreshTokens(result.Tokens)
+	}
+
 	return result.Token, expiresAt, nil
+}
+
+// applyRefreshTokens processes the tokens[] array from a refresh response,
+// applying each entry to the appropriate subsystem.
+func (c *Client) applyRefreshTokens(tokens []RefreshTokenEntry) {
+	for _, entry := range tokens {
+		switch {
+		case entry.Layer == "transport" && entry.Type == "google_oidc":
+			// Update the OIDC transport's token source
+			if c.oidcSource != nil {
+				entryExpiry := time.Now().Add(time.Duration(entry.ExpiresIn) * time.Second)
+				c.oidcSource.setToken(entry.Value, entryExpiry)
+			}
+		// app/scion_access is already handled via the legacy token field above
+		}
+	}
+}
+
+// adjustRefreshForTransportTokens checks if the OIDC source has a shorter
+// expiry than the proposed refresh time and returns the earlier of the two.
+// Transport tokens (~1h) use a 5-minute refresh margin vs the app token's
+// 2-hour margin.
+func (c *Client) adjustRefreshForTransportTokens(proposed time.Time) time.Time {
+	if c.oidcSource == nil {
+		return proposed
+	}
+
+	// Read the transport token expiry from the source
+	switch src := c.oidcSource.(type) {
+	case *injectedTokenSource:
+		src.mu.RLock()
+		expiry := src.expiresAt
+		src.mu.RUnlock()
+		if !expiry.IsZero() {
+			transportRefresh := expiry.Add(-oidcRefreshMargin)
+			if transportRefresh.Before(proposed) {
+				return transportRefresh
+			}
+		}
+	case *metadataTokenSource:
+		// Metadata source self-refreshes; no need to drive refresh from here.
+	}
+	return proposed
 }
 
 // TokenRefreshConfig configures the token refresh loop.
@@ -496,8 +561,13 @@ func (c *Client) StartTokenRefresh(ctx context.Context, config *TokenRefreshConf
 				config.OnRefreshed(newExpiry)
 			}
 
-			// Schedule next refresh: 2 hours before new expiry
+			// Schedule next refresh: 2 hours before new expiry for the app token.
 			refreshAt = newExpiry.Add(-2 * time.Hour)
+
+			// If transport tokens are present, use the shortest-lived entry
+			// to drive refresh timing (transport tokens ~1h need a tighter margin).
+			refreshAt = c.adjustRefreshForTransportTokens(refreshAt)
+
 			if refreshAt.Before(time.Now()) {
 				// Token duration is very short; refresh in 1 minute
 				refreshAt = time.Now().Add(1 * time.Minute)

--- a/pkg/sciontool/hub/oidc.go
+++ b/pkg/sciontool/hub/oidc.go
@@ -1,0 +1,240 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/compute/metadata"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/log"
+)
+
+const (
+	// EnvHubOIDCAudience overrides the audience claim in the OIDC identity token.
+	EnvHubOIDCAudience = "SCION_HUB_OIDC_AUDIENCE"
+
+	// EnvTransportToken is the env var for the hub-provided transport OIDC token.
+	EnvTransportToken = "SCION_TRANSPORT_TOKEN"
+
+	// EnvTransportAudience is the env var for the transport token audience.
+	EnvTransportAudience = "SCION_TRANSPORT_AUDIENCE"
+
+	gcpMetadataBaseURL = "http://metadata.google.internal"
+
+	oidcRefreshMargin = 5 * time.Minute
+	oidcDefaultTTL    = 1 * time.Hour
+	oidcFetchTimeout  = 2 * time.Second
+)
+
+// isOnGCPFunc detects whether we're running on GCP. Override in tests.
+var isOnGCPFunc = func() bool { return metadata.OnGCE() }
+
+// oidcTokenSource provides OIDC identity tokens for transport-layer auth.
+// Implementations are thread-safe.
+type oidcTokenSource interface {
+	// getToken returns a valid OIDC token, refreshing if necessary.
+	getToken() (string, error)
+	// setToken updates the cached token and expiry. Used by the refresh path
+	// to inject hub-provided tokens.
+	setToken(token string, expiry time.Time)
+}
+
+// --- metadataTokenSource: fetches OIDC from GCE metadata server ---
+
+// metadataTokenSource fetches and caches Google OIDC identity tokens from the
+// GCE metadata server. Used in passthrough/on-GCE mode (the PR #307 pattern).
+type metadataTokenSource struct {
+	audience        string
+	metadataBaseURL string
+	httpClient      *http.Client
+
+	mu        sync.RWMutex
+	token     string
+	expiresAt time.Time
+}
+
+func (s *metadataTokenSource) getToken() (string, error) {
+	s.mu.RLock()
+	if s.token != "" && time.Now().Before(s.expiresAt.Add(-oidcRefreshMargin)) {
+		tok := s.token
+		s.mu.RUnlock()
+		return tok, nil
+	}
+	s.mu.RUnlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Double-check after acquiring write lock.
+	if s.token != "" && time.Now().Before(s.expiresAt.Add(-oidcRefreshMargin)) {
+		return s.token, nil
+	}
+
+	url := fmt.Sprintf("%s/computeMetadata/v1/instance/service-accounts/default/identity?audience=%s&format=full",
+		s.metadataBaseURL, s.audience)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("oidc: build request: %w", err)
+	}
+	req.Header.Set("Metadata-Flavor", "Google")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("oidc: metadata fetch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("oidc: metadata server returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("oidc: read response: %w", err)
+	}
+
+	tok := strings.TrimSpace(string(body))
+	expiry, err := ParseTokenExpiry(tok)
+	if err != nil {
+		expiry = time.Now().Add(oidcDefaultTTL)
+	}
+
+	s.token = tok
+	s.expiresAt = expiry
+	return tok, nil
+}
+
+func (s *metadataTokenSource) setToken(token string, expiry time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.token = token
+	s.expiresAt = expiry
+}
+
+// --- injectedTokenSource: hub-provided token refreshed via tokens[] ---
+
+// injectedTokenSource holds a transport token injected by the hub via the
+// dispatch payload (cold start) and refreshed via the tokens[] array on
+// subsequent refresh calls.
+type injectedTokenSource struct {
+	mu        sync.RWMutex
+	token     string
+	expiresAt time.Time
+}
+
+func (s *injectedTokenSource) getToken() (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.token == "" {
+		return "", fmt.Errorf("oidc: no transport token available")
+	}
+
+	// Check if the token is within the refresh margin of expiry.
+	// We still return it (it may still be valid), but log a warning.
+	if !s.expiresAt.IsZero() && time.Now().After(s.expiresAt.Add(-oidcRefreshMargin)) {
+		log.Debug("OIDC transport token is near expiry or expired, returning anyway")
+	}
+
+	return s.token, nil
+}
+
+func (s *injectedTokenSource) setToken(token string, expiry time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.token = token
+	s.expiresAt = expiry
+}
+
+// --- oidcTransport: RoundTripper that injects Authorization: Bearer ---
+
+// oidcTransport is an http.RoundTripper that injects a Google OIDC identity
+// token as an Authorization header on outgoing requests.
+type oidcTransport struct {
+	base   http.RoundTripper
+	source oidcTokenSource
+}
+
+func (t *oidcTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("Authorization") == "" {
+		tok, err := t.source.getToken()
+		if err != nil {
+			log.Debug("OIDC token fetch failed, skipping Authorization header: %v", err)
+		} else {
+			req = req.Clone(req.Context())
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
+	}
+	return t.base.RoundTrip(req)
+}
+
+// newOIDCTransport creates an oidcTransport wrapping the base transport.
+func newOIDCTransport(base http.RoundTripper, source oidcTokenSource) *oidcTransport {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &oidcTransport{
+		base:   base,
+		source: source,
+	}
+}
+
+// configureOIDCTransport sets up the OIDC transport layer on the client.
+// Token source selection:
+//  1. If SCION_TRANSPORT_TOKEN env var is set → injected mode (hub-provided token).
+//  2. Else if running on GCP → metadata server mode (ambient SA identity).
+//  3. Else → no OIDC transport (agent uses plain HTTP).
+func (c *Client) configureOIDCTransport() {
+	// Check for hub-injected transport token (dispatch payload / cold start)
+	if tok := os.Getenv(EnvTransportToken); tok != "" {
+		source := &injectedTokenSource{}
+		expiry, err := ParseTokenExpiry(tok)
+		if err != nil {
+			expiry = time.Now().Add(oidcDefaultTTL)
+		}
+		source.setToken(tok, expiry)
+		c.oidcSource = source
+		c.client.Transport = newOIDCTransport(c.client.Transport, source)
+		log.Debug("Configured OIDC transport: injected mode (hub-provided token)")
+		return
+	}
+
+	// Fall back to GCE metadata server if on GCP
+	if !isOnGCPFunc() {
+		return
+	}
+
+	audience := os.Getenv(EnvHubOIDCAudience)
+	if audience == "" {
+		audience = c.hubURL
+	}
+
+	source := &metadataTokenSource{
+		audience:        audience,
+		metadataBaseURL: gcpMetadataBaseURL,
+		httpClient:      &http.Client{Timeout: oidcFetchTimeout},
+	}
+	c.oidcSource = source
+	c.client.Transport = newOIDCTransport(c.client.Transport, source)
+	log.Debug("Configured OIDC transport: metadata mode (audience=%s)", audience)
+}

--- a/pkg/sciontool/hub/oidc_test.go
+++ b/pkg/sciontool/hub/oidc_test.go
@@ -1,0 +1,525 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeTestJWT builds a minimal JWT with the given expiry for testing.
+func makeTestJWT(exp time.Time) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload, _ := json.Marshal(map[string]interface{}{"exp": exp.Unix(), "iss": "test"})
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payload)
+	sig := base64.RawURLEncoding.EncodeToString([]byte("fakesig"))
+	return fmt.Sprintf("%s.%s.%s", header, payloadB64, sig)
+}
+
+func overrideGCPDetection(val bool) func() {
+	orig := isOnGCPFunc
+	isOnGCPFunc = func() bool { return val }
+	return func() { isOnGCPFunc = orig }
+}
+
+// --- injectedTokenSource tests ---
+
+func TestInjectedTokenSource_SetAndGet(t *testing.T) {
+	src := &injectedTokenSource{}
+	token := makeTestJWT(time.Now().Add(1 * time.Hour))
+	expiry := time.Now().Add(1 * time.Hour)
+
+	src.setToken(token, expiry)
+
+	got, err := src.getToken()
+	require.NoError(t, err)
+	assert.Equal(t, token, got)
+}
+
+func TestInjectedTokenSource_Empty(t *testing.T) {
+	src := &injectedTokenSource{}
+	_, err := src.getToken()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no transport token")
+}
+
+func TestInjectedTokenSource_NearExpiry(t *testing.T) {
+	src := &injectedTokenSource{}
+	token := makeTestJWT(time.Now().Add(2 * time.Minute))
+	expiry := time.Now().Add(2 * time.Minute) // within 5-min margin
+
+	src.setToken(token, expiry)
+
+	// Should still return the token (with a debug log warning)
+	got, err := src.getToken()
+	require.NoError(t, err)
+	assert.Equal(t, token, got)
+}
+
+func TestInjectedTokenSource_UpdateToken(t *testing.T) {
+	src := &injectedTokenSource{}
+	token1 := makeTestJWT(time.Now().Add(1 * time.Hour))
+	token2 := makeTestJWT(time.Now().Add(2 * time.Hour))
+
+	src.setToken(token1, time.Now().Add(1*time.Hour))
+	got1, _ := src.getToken()
+	assert.Equal(t, token1, got1)
+
+	src.setToken(token2, time.Now().Add(2*time.Hour))
+	got2, _ := src.getToken()
+	assert.Equal(t, token2, got2)
+}
+
+// --- metadataTokenSource tests ---
+
+func TestMetadataTokenSource_FetchAndCache(t *testing.T) {
+	var fetchCount atomic.Int32
+	token := makeTestJWT(time.Now().Add(1 * time.Hour))
+
+	metaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Google", r.Header.Get("Metadata-Flavor"))
+		assert.Contains(t, r.URL.Query().Get("audience"), "https://hub.example.com")
+		assert.Equal(t, "full", r.URL.Query().Get("format"))
+		fetchCount.Add(1)
+		fmt.Fprint(w, token)
+	}))
+	defer metaSrv.Close()
+
+	src := &metadataTokenSource{
+		audience:        "https://hub.example.com",
+		metadataBaseURL: metaSrv.URL,
+		httpClient:      &http.Client{Timeout: 2 * time.Second},
+	}
+
+	tok1, err := src.getToken()
+	require.NoError(t, err)
+	assert.Equal(t, token, tok1)
+
+	tok2, err := src.getToken()
+	require.NoError(t, err)
+	assert.Equal(t, token, tok2)
+
+	assert.Equal(t, int32(1), fetchCount.Load(), "second call should use cache")
+}
+
+func TestMetadataTokenSource_RefreshExpired(t *testing.T) {
+	var fetchCount atomic.Int32
+	token1 := makeTestJWT(time.Now().Add(1 * time.Hour))
+	token2 := makeTestJWT(time.Now().Add(2 * time.Hour))
+
+	metaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fetchCount.Add(1) == 1 {
+			fmt.Fprint(w, token1)
+		} else {
+			fmt.Fprint(w, token2)
+		}
+	}))
+	defer metaSrv.Close()
+
+	src := &metadataTokenSource{
+		audience:        "https://hub.example.com",
+		metadataBaseURL: metaSrv.URL,
+		httpClient:      &http.Client{Timeout: 2 * time.Second},
+	}
+
+	tok, err := src.getToken()
+	require.NoError(t, err)
+	assert.Equal(t, token1, tok)
+
+	// Simulate expiry
+	src.mu.Lock()
+	src.expiresAt = time.Now().Add(-1 * time.Minute)
+	src.mu.Unlock()
+
+	tok, err = src.getToken()
+	require.NoError(t, err)
+	assert.Equal(t, token2, tok)
+	assert.Equal(t, int32(2), fetchCount.Load())
+}
+
+func TestMetadataTokenSource_RefreshWithinMargin(t *testing.T) {
+	var fetchCount atomic.Int32
+	token1 := makeTestJWT(time.Now().Add(1 * time.Hour))
+	token2 := makeTestJWT(time.Now().Add(2 * time.Hour))
+
+	metaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fetchCount.Add(1) == 1 {
+			fmt.Fprint(w, token1)
+		} else {
+			fmt.Fprint(w, token2)
+		}
+	}))
+	defer metaSrv.Close()
+
+	src := &metadataTokenSource{
+		audience:        "https://hub.example.com",
+		metadataBaseURL: metaSrv.URL,
+		httpClient:      &http.Client{Timeout: 2 * time.Second},
+	}
+
+	tok, err := src.getToken()
+	require.NoError(t, err)
+	assert.Equal(t, token1, tok)
+
+	// Set expiry within the 5-minute refresh margin
+	src.mu.Lock()
+	src.expiresAt = time.Now().Add(3 * time.Minute)
+	src.mu.Unlock()
+
+	tok, err = src.getToken()
+	require.NoError(t, err)
+	assert.Equal(t, token2, tok, "should re-fetch when within refresh margin")
+}
+
+func TestMetadataTokenSource_SetToken(t *testing.T) {
+	src := &metadataTokenSource{
+		audience:        "https://hub.example.com",
+		metadataBaseURL: "http://127.0.0.1:1", // unreachable
+		httpClient:      &http.Client{Timeout: 100 * time.Millisecond},
+	}
+
+	token := makeTestJWT(time.Now().Add(1 * time.Hour))
+	expiry := time.Now().Add(1 * time.Hour)
+	src.setToken(token, expiry)
+
+	// Should return the set token without hitting metadata server
+	got, err := src.getToken()
+	require.NoError(t, err)
+	assert.Equal(t, token, got)
+}
+
+// --- oidcTransport tests ---
+
+func TestOIDCTransport_InjectsHeader(t *testing.T) {
+	var receivedAuth string
+	hubSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hubSrv.Close()
+
+	token := makeTestJWT(time.Now().Add(1 * time.Hour))
+	source := &injectedTokenSource{}
+	source.setToken(token, time.Now().Add(1*time.Hour))
+
+	transport := newOIDCTransport(http.DefaultTransport, source)
+	client := &http.Client{Transport: transport}
+
+	req, _ := http.NewRequest("GET", hubSrv.URL+"/test", nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, "Bearer "+token, receivedAuth)
+}
+
+func TestOIDCTransport_DoesNotOverrideExistingAuth(t *testing.T) {
+	var receivedAuth string
+	hubSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hubSrv.Close()
+
+	source := &injectedTokenSource{}
+	source.setToken("should-not-be-used", time.Now().Add(1*time.Hour))
+
+	transport := newOIDCTransport(http.DefaultTransport, source)
+	client := &http.Client{Transport: transport}
+
+	req, _ := http.NewRequest("GET", hubSrv.URL+"/test", nil)
+	req.Header.Set("Authorization", "Bearer existing-token")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, "Bearer existing-token", receivedAuth)
+}
+
+func TestOIDCTransport_GracefulDegradation(t *testing.T) {
+	var requestReceived bool
+	hubSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestReceived = true
+		assert.Empty(t, r.Header.Get("Authorization"), "no auth header when source has no token")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hubSrv.Close()
+
+	// Source with no token → getToken() returns error
+	source := &injectedTokenSource{}
+	transport := newOIDCTransport(http.DefaultTransport, source)
+	client := &http.Client{Transport: transport}
+
+	req, _ := http.NewRequest("GET", hubSrv.URL+"/test", nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.True(t, requestReceived, "request should proceed even when token unavailable")
+}
+
+func TestOIDCTransport_WithMetadataSource(t *testing.T) {
+	token := makeTestJWT(time.Now().Add(1 * time.Hour))
+	metaSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, token)
+	}))
+	defer metaSrv.Close()
+
+	var receivedAuth string
+	hubSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hubSrv.Close()
+
+	source := &metadataTokenSource{
+		audience:        "https://hub.example.com",
+		metadataBaseURL: metaSrv.URL,
+		httpClient:      &http.Client{Timeout: 2 * time.Second},
+	}
+	transport := newOIDCTransport(http.DefaultTransport, source)
+	client := &http.Client{Transport: transport}
+
+	req, _ := http.NewRequest("GET", hubSrv.URL+"/test", nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, "Bearer "+token, receivedAuth)
+}
+
+// --- configureOIDCTransport tests ---
+
+func TestConfigureOIDCTransport_InjectedMode(t *testing.T) {
+	token := makeTestJWT(time.Now().Add(1 * time.Hour))
+	os.Setenv(EnvTransportToken, token)
+	defer os.Unsetenv(EnvTransportToken)
+
+	c := &Client{
+		hubURL: "https://hub.example.com",
+		client: &http.Client{Timeout: DefaultTimeout},
+	}
+
+	c.configureOIDCTransport()
+
+	require.NotNil(t, c.oidcSource)
+	_, ok := c.oidcSource.(*injectedTokenSource)
+	assert.True(t, ok, "should use injectedTokenSource")
+	require.NotNil(t, c.client.Transport)
+	_, ok = c.client.Transport.(*oidcTransport)
+	assert.True(t, ok, "transport should be oidcTransport")
+}
+
+func TestConfigureOIDCTransport_MetadataMode(t *testing.T) {
+	cleanup := overrideGCPDetection(true)
+	defer cleanup()
+
+	// Ensure no injected token
+	os.Unsetenv(EnvTransportToken)
+
+	c := &Client{
+		hubURL: "https://hub.example.com",
+		client: &http.Client{Timeout: DefaultTimeout},
+	}
+
+	c.configureOIDCTransport()
+
+	require.NotNil(t, c.oidcSource)
+	src, ok := c.oidcSource.(*metadataTokenSource)
+	assert.True(t, ok, "should use metadataTokenSource")
+	assert.Equal(t, "https://hub.example.com", src.audience)
+}
+
+func TestConfigureOIDCTransport_MetadataMode_AudienceOverride(t *testing.T) {
+	cleanup := overrideGCPDetection(true)
+	defer cleanup()
+
+	os.Unsetenv(EnvTransportToken)
+	os.Setenv(EnvHubOIDCAudience, "https://custom-audience.example.com")
+	defer os.Unsetenv(EnvHubOIDCAudience)
+
+	c := &Client{
+		hubURL: "https://hub.example.com",
+		client: &http.Client{Timeout: DefaultTimeout},
+	}
+
+	c.configureOIDCTransport()
+
+	require.NotNil(t, c.oidcSource)
+	src := c.oidcSource.(*metadataTokenSource)
+	assert.Equal(t, "https://custom-audience.example.com", src.audience)
+}
+
+func TestConfigureOIDCTransport_NotOnGCP(t *testing.T) {
+	cleanup := overrideGCPDetection(false)
+	defer cleanup()
+
+	os.Unsetenv(EnvTransportToken)
+
+	c := &Client{
+		hubURL: "https://hub.example.com",
+		client: &http.Client{Timeout: DefaultTimeout},
+	}
+
+	c.configureOIDCTransport()
+
+	assert.Nil(t, c.oidcSource, "should not configure OIDC when not on GCP and no injected token")
+	assert.Nil(t, c.client.Transport, "transport should not be wrapped")
+}
+
+func TestConfigureOIDCTransport_InjectedPriority(t *testing.T) {
+	// When both injected token and GCE are available, injected should win
+	cleanup := overrideGCPDetection(true)
+	defer cleanup()
+
+	token := makeTestJWT(time.Now().Add(1 * time.Hour))
+	os.Setenv(EnvTransportToken, token)
+	defer os.Unsetenv(EnvTransportToken)
+
+	c := &Client{
+		hubURL: "https://hub.example.com",
+		client: &http.Client{Timeout: DefaultTimeout},
+	}
+
+	c.configureOIDCTransport()
+
+	require.NotNil(t, c.oidcSource)
+	_, ok := c.oidcSource.(*injectedTokenSource)
+	assert.True(t, ok, "injected should take priority over metadata")
+}
+
+// --- E2E: both agent + OIDC headers ---
+
+func TestOIDC_EndToEnd_BothHeaders(t *testing.T) {
+	cleanup := overrideGCPDetection(false)
+	defer cleanup()
+
+	token := makeTestJWT(time.Now().Add(1 * time.Hour))
+	os.Setenv(EnvTransportToken, token)
+	defer os.Unsetenv(EnvTransportToken)
+
+	var gotAuth, gotAgentToken string
+	hubSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotAgentToken = r.Header.Get("X-Scion-Agent-Token")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer hubSrv.Close()
+
+	c := &Client{
+		hubURL:         hubSrv.URL,
+		token:          "test-agent-token",
+		agentID:        "test-agent-123",
+		maxRetries:     1,
+		retryBaseDelay: 10 * time.Millisecond,
+		retryMaxDelay:  10 * time.Millisecond,
+		client: &http.Client{
+			Timeout: DefaultTimeout,
+		},
+	}
+	c.configureOIDCTransport()
+
+	err := c.UpdateStatus(context.Background(), StatusUpdate{
+		Status:  "running",
+		Message: "test",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer "+token, gotAuth, "OIDC Authorization header should be set")
+	assert.Equal(t, "test-agent-token", gotAgentToken, "X-Scion-Agent-Token should still be set")
+}
+
+// --- applyRefreshTokens tests ---
+
+func TestApplyRefreshTokens_TransportToken(t *testing.T) {
+	source := &injectedTokenSource{}
+	c := &Client{oidcSource: source}
+
+	newToken := makeTestJWT(time.Now().Add(1 * time.Hour))
+	tokens := []RefreshTokenEntry{
+		{Layer: "app", Type: "scion_access", Value: "app-token", ExpiresIn: 36000},
+		{Layer: "transport", Type: "google_oidc", Value: newToken, ExpiresIn: 3600, Audience: "https://hub.example.com"},
+	}
+
+	c.applyRefreshTokens(tokens)
+
+	got, err := source.getToken()
+	require.NoError(t, err)
+	assert.Equal(t, newToken, got)
+}
+
+func TestApplyRefreshTokens_NoOIDCSource(t *testing.T) {
+	c := &Client{} // no oidcSource
+
+	tokens := []RefreshTokenEntry{
+		{Layer: "transport", Type: "google_oidc", Value: "token", ExpiresIn: 3600},
+	}
+
+	// Should not panic
+	c.applyRefreshTokens(tokens)
+}
+
+// --- adjustRefreshForTransportTokens tests ---
+
+func TestAdjustRefreshForTransportTokens_ShorterTransport(t *testing.T) {
+	source := &injectedTokenSource{}
+	transportExpiry := time.Now().Add(50 * time.Minute) // short-lived
+	source.setToken("tok", transportExpiry)
+
+	c := &Client{oidcSource: source}
+
+	// App token would refresh 2h before a 10h expiry (8h from now)
+	appRefresh := time.Now().Add(8 * time.Hour)
+	adjusted := c.adjustRefreshForTransportTokens(appRefresh)
+
+	// Transport refresh should be ~45 min from now (50min - 5min margin)
+	expectedTransportRefresh := transportExpiry.Add(-oidcRefreshMargin)
+	assert.WithinDuration(t, expectedTransportRefresh, adjusted, 1*time.Second,
+		"should use transport token's earlier refresh time")
+}
+
+func TestAdjustRefreshForTransportTokens_LongerTransport(t *testing.T) {
+	source := &injectedTokenSource{}
+	transportExpiry := time.Now().Add(10 * time.Hour) // long-lived
+	source.setToken("tok", transportExpiry)
+
+	c := &Client{oidcSource: source}
+
+	// App token would refresh 30 min from now
+	appRefresh := time.Now().Add(30 * time.Minute)
+	adjusted := c.adjustRefreshForTransportTokens(appRefresh)
+
+	assert.WithinDuration(t, appRefresh, adjusted, 1*time.Second,
+		"should keep app token's earlier refresh time")
+}
+
+func TestAdjustRefreshForTransportTokens_NoSource(t *testing.T) {
+	c := &Client{} // no oidcSource
+	proposed := time.Now().Add(8 * time.Hour)
+	adjusted := c.adjustRefreshForTransportTokens(proposed)
+	assert.Equal(t, proposed, adjusted)
+}


### PR DESCRIPTION
## Summary

Adds an exclusive **proxy** human-auth mode (Google IAP first) with verified-assertion provisioning, plus a hub-minted **transport-auth** layer that lets agents traverse the IAP / Cloud Run-invoker front door.

Design doc: [`.design/auth-proxy-mode.md`](.design/auth-proxy-mode.md) (approach approved by @ptone 2026-06-05).

> **Staging PR — do not merge.** Opened against this fork's `main` for review only.

## What's included (phased)

- **Phase 0 — `provisionUser` refactor (no behavior change):** extracts the find-or-create user block into `Server.provisionUser` and dedupes **all four** OAuth call sites onto it.
- **Phase 1 — inbound Google IAP human auth:**
  - `pkg/hub/proxyauth.go`: `ProxyAuthenticator` interface + `IAPAuthenticator` (go-jose/v4 ES256, gstatic JWKS fetch+cache with rotation/on-miss refresh + stale-tolerance).
  - Mandatory `aud` binding, exact `iss`, `exp`/`iat` with clock skew; unsigned `X-Goog-Authenticated-User-*` headers ignored; empty audience fails closed.
  - `auth.mode` (`oauth`|`proxy`|`dev`, exclusive) + `auth.proxy` config; middleware integration (proxy runs last → transport-only when an app-layer credential is present); 60s resolution cache over the store lookup only.
  - Proxy-mode web login UI (no OAuth buttons), `/auth/providers` disabled, logout no-op / `clear_login_cookie`.
  - Suspended-user gate added to `provisionUser` (also closes a pre-existing OAuth suspended-login gap).
- **Phase 2 — outbound transport auth (agents through the front door):**
  - `TransportTokenMinter` interface (impersonated `generateIdToken` via already-vendored `iamcredentials/v1` — no new dependency; no-op when disabled; fake for tests).
  - `auth.transport` config (`none`|`cloudrun_invoker`|`iap`); cold-start token injected at dispatch; agent token refresh response extended to a **backward-compatible** `tokens[]` array.
  - Agent-side pluggable OIDC source (injected vs metadata) + `oidcTransport` RoundTripper.
- **Phase 3 — docs:** IAP + Cloud Run-invoker deployment guide (`docs-site/.../hub-admin/auth-proxy-iap.md`).

## Testing

- `go build ./...` clean; `go vet` clean.
- New tests: 13 (IAP), 11 (transport minter), 23 (agent OIDC), plus `TestProvisionUser`. All pass.
- Pre-existing sandbox test failures (15 in `pkg/hub`, 5 in `pkg/config`: UUID generation / project-path discovery) are present identically at the pre-feature baseline — **zero regressions** introduced.

## Notes / follow-ups (non-blocking)

1. Cold-start dispatch carries the transport token via env vars (`SCION_TRANSPORT_TOKEN`/`_AUDIENCE`/`_TOKEN_EXPIRY`) rather than the `tokens[]` JSON shape used by the warm refresh path. Functionally fine; could be unified.
2. GCP SA-impersonation is unit-tested with a fake but not integration-tested (no live IAP project in CI) — recommend a smoke test before any upstream merge.
3. Patterns referenced from PR #307 (`pr/cloudrun-hub`); `oidc.go` was reimplemented clean. #307 not landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
