### PR TITLE
Fix delete test failure in hub environment (issue 71)

### DIFF
--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -394,7 +394,7 @@ func TestDeleteAgentsViaHub_LocalCleanupFailureCreatesStaleLocalNotToRegister(t 
 
 func TestDeleteStopped_RequiresGroveContext(t *testing.T) {
 	// Unset Hub context to avoid synthetic project root detection
-	for _, e := range []string{"SCION_HUB_ENDPOINT", "SCION_HUB_URL", "SCION_GROVE_ID"} {
+	for _, e := range []string{"SCION_HUB_ENDPOINT", "SCION_HUB_URL", "SCION_GROVE_ID", "SCION_PROJECT_ID"} {
 		if val, ok := os.LookupEnv(e); ok {
 			os.Unsetenv(e)
 			defer os.Setenv(e, val)


### PR DESCRIPTION
## Summary
- Fix `TestDeleteStopped_RequiresGroveContext` failing when `SCION_PROJECT_ID` is set in the environment (e.g., inside hub-connected containers)
- The test was unsetting `SCION_HUB_ENDPOINT`, `SCION_HUB_URL`, and `SCION_GROVE_ID` to disable hub context detection, but `IsHubContext()` also checks `SCION_PROJECT_ID` — the missing unset caused `FindProjectRoot()` to return a synthetic path instead of failing, leading to a Docker call that errors in environments without Docker

Refs issue 71

## Test plan
- [x] `go test ./cmd/...` passes
- [x] `go test ./pkg/hub/...` passes
- [x] Verified `TestDeleteStopped_RequiresGroveContext` passes in isolation
- [x] Verified `TestDeleteStopped_AcceptsGlobalFlag` still passes
