### PR TITLE
feat(a2a-bridge): advertise multi-turn capabilities

### DIFF
--- a/extras/scion-a2a-bridge/README.md
+++ b/extras/scion-a2a-bridge/README.md
@@ -269,10 +269,10 @@ docker run -p 8443:8443 -p 9090:9090 \
 
 The container runs as non-root user `bridge` (UID 1000). The state database directory `/var/lib/scion-a2a-bridge/` is writable by this user inside the container (mode `0700`). To persist state across restarts, mount a volume at that path.
 
-## Known Limitations (MVP)
+## Known Limitations
 
-- **Single-turn only.** The bridge treats the first non-state-change message from an agent as the final response and closes the task. Multi-turn agents that emit interim content (clarifying questions, progress updates) will have their task closed prematurely. Agents using `input-required` → `completed` flows are not supported yet. Agent cards advertise `streaming: false` and `pushNotifications: false` to reflect this constraint. Streaming requests (`message/stream`) are accepted but emit a runtime warning because multi-turn dispatch is not implemented.
-- **Blocking-mode `input-required` flows never resolve.** State-change messages are intentionally skipped for blocking waiters so the actual content reply is delivered. This means a blocking `message/send` call against an agent that transitions to `input-required` will time out (default 120s) because the state change is suppressed and no content reply follows.
+- **No gRPC or REST transport.** The bridge only supports JSON-RPC 2.0 over HTTP. gRPC and HTTP+JSON/REST transports are not implemented.
+- **Blocking-mode `input-required` flows.** In blocking mode, state-change messages are skipped for waiters so the actual content reply is delivered. A blocking `message/send` against an agent that transitions to `input-required` without sending content will time out (default 120s). Use non-blocking mode with push notifications or SSE for `input-required` flows.
 
 ## Security considerations
 

--- a/extras/scion-a2a-bridge/internal/bridge/bridge.go
+++ b/extras/scion-a2a-bridge/internal/bridge/bridge.go
@@ -730,8 +730,8 @@ func (b *Bridge) GenerateAgentCard(ctx context.Context, projectSlug, agentSlug s
 		"url":         agentURL,
 		"version":     "1.0.0",
 		"capabilities": map[string]bool{
-			"streaming":         false,
-			"pushNotifications": false,
+			"streaming":         true,
+			"pushNotifications": true,
 		},
 		"defaultInputModes":  []string{"text/plain", "application/json"},
 		"defaultOutputModes": []string{"text/plain", "application/json"},

--- a/extras/scion-a2a-bridge/internal/bridge/server.go
+++ b/extras/scion-a2a-bridge/internal/bridge/server.go
@@ -224,8 +224,8 @@ func (s *Server) handleWellKnownAgentCard(w http.ResponseWriter, r *http.Request
 		"url":         s.config.Bridge.ExternalURL,
 		"version":     "1.0.0",
 		"capabilities": map[string]bool{
-			"streaming":         false,
-			"pushNotifications": false,
+			"streaming":         true,
+			"pushNotifications": true,
 		},
 	}
 
@@ -487,9 +487,6 @@ func (s *Server) handleCancelTask(w http.ResponseWriter, r *http.Request, req JS
 }
 
 func (s *Server) handleStreamMessage(w http.ResponseWriter, r *http.Request, req JSONRPCRequest, projectSlug, agentSlug string) {
-	s.log.Warn("message/stream request received — MVP limitation: streaming treats the first content message as terminal; multi-turn agents will break",
-		"project", projectSlug, "agent", agentSlug)
-
 	var params SendMessageParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		s.log.Warn("invalid StreamMessage params", "error", err)

--- a/extras/scion-a2a-bridge/internal/bridge/server_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/server_test.go
@@ -16,6 +16,7 @@ package bridge
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -162,6 +163,17 @@ func TestWellKnownAgentCard(t *testing.T) {
 	if provider["organization"] != "Test Org" {
 		t.Errorf("provider.organization = %q, want %q", provider["organization"], "Test Org")
 	}
+
+	caps, ok := card["capabilities"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected capabilities object in card")
+	}
+	if caps["streaming"] != true {
+		t.Errorf("capabilities.streaming = %v, want true", caps["streaming"])
+	}
+	if caps["pushNotifications"] != true {
+		t.Errorf("capabilities.pushNotifications = %v, want true", caps["pushNotifications"])
+	}
 }
 
 func TestPerAgentCard(t *testing.T) {
@@ -187,6 +199,17 @@ func TestPerAgentCard(t *testing.T) {
 	expectedURL := "https://a2a.test.example.com/projects/test-grove/agents/test-agent"
 	if card["url"] != expectedURL {
 		t.Errorf("url = %q, want %q", card["url"], expectedURL)
+	}
+
+	caps, ok := card["capabilities"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected capabilities object in per-agent card")
+	}
+	if caps["streaming"] != true {
+		t.Errorf("capabilities.streaming = %v, want true", caps["streaming"])
+	}
+	if caps["pushNotifications"] != true {
+		t.Errorf("capabilities.pushNotifications = %v, want true", caps["pushNotifications"])
 	}
 }
 
@@ -778,6 +801,92 @@ func TestNewRPCMethods(t *testing.T) {
 				t.Errorf("method %q should be registered but got method not found", method)
 			}
 		})
+	}
+}
+
+func TestGenerateAgentCardCapabilities(t *testing.T) {
+	dir := t.TempDir()
+	store, err := state.New(filepath.Join(dir, "caps-test.db"))
+	if err != nil {
+		t.Fatalf("state.New: %v", err)
+	}
+	defer store.Close()
+
+	cfg := &Config{
+		Bridge: BridgeConfig{
+			ExternalURL: "https://a2a.test.example.com",
+		},
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bridge := New(store, nil, nil, cfg, nil, log)
+
+	card := bridge.GenerateAgentCard(context.Background(), "test-project", "test-agent")
+
+	caps, ok := card["capabilities"].(map[string]bool)
+	if !ok {
+		t.Fatal("expected capabilities to be map[string]bool")
+	}
+	if !caps["streaming"] {
+		t.Error("capabilities.streaming should be true")
+	}
+	if !caps["pushNotifications"] {
+		t.Error("capabilities.pushNotifications should be true")
+	}
+
+	// Verify other required fields are present.
+	if card["name"] != "test-agent" {
+		t.Errorf("name = %q, want %q", card["name"], "test-agent")
+	}
+	expectedURL := "https://a2a.test.example.com/projects/test-project/agents/test-agent"
+	if card["url"] != expectedURL {
+		t.Errorf("url = %q, want %q", card["url"], expectedURL)
+	}
+	if card["version"] != "1.0.0" {
+		t.Errorf("version = %q, want %q", card["version"], "1.0.0")
+	}
+}
+
+func TestRegistryAndPerAgentCardCapabilitiesMatch(t *testing.T) {
+	_, ts, _ := newTestServer(t)
+
+	// Fetch registry card.
+	resp, err := http.Get(ts.URL + "/.well-known/agent-card.json")
+	if err != nil {
+		t.Fatalf("GET registry card: %v", err)
+	}
+	defer resp.Body.Close()
+	var registryCard map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&registryCard)
+
+	registryCaps, ok := registryCard["capabilities"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected capabilities in registry card")
+	}
+
+	// Fetch per-agent card.
+	resp2, err := http.Get(ts.URL + "/projects/test-grove/agents/test-agent/.well-known/agent-card.json")
+	if err != nil {
+		t.Fatalf("GET per-agent card: %v", err)
+	}
+	defer resp2.Body.Close()
+	var agentCard map[string]interface{}
+	json.NewDecoder(resp2.Body).Decode(&agentCard)
+
+	agentCaps, ok := agentCard["capabilities"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected capabilities in per-agent card")
+	}
+
+	// Capabilities should be identical.
+	for key, regVal := range registryCaps {
+		if agentCaps[key] != regVal {
+			t.Errorf("capability %q: registry=%v, agent=%v", key, regVal, agentCaps[key])
+		}
+	}
+	for key, agentVal := range agentCaps {
+		if registryCaps[key] != agentVal {
+			t.Errorf("capability %q: agent=%v, registry=%v", key, agentVal, registryCaps[key])
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Update agent cards to advertise streaming and push notification support now that multi-turn conversations are implemented (PRs #314, #315).

## Changes

- Registry card: `streaming: true`, `pushNotifications: true`
- Per-agent card: `streaming: true`, `pushNotifications: true`
- Remove MVP streaming warning from `handleStreamMessage`
- README: Remove single-turn limitation, update known limitations

## Review history

- **Round 1:** 4 new tests (capability values, drift prevention)
- **Rounds 2-3:** 3 clean cycles each, no changes
- Rebased on upstream/main

## Merge order

Merge **after** #314 and #315.