### PR TITLE
fix(hub): replica-portable JWT signing keys and web sessions

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -861,13 +861,21 @@ func parseAdminEmails(cfg *config.GlobalConfig) []string {
 
 // resolveSessionSecret resolves the deployment-wide session secret from the
 // --session-secret flag, falling back to the SCION_SERVER_SESSION_SECRET env
-// var. The same value backs both the web session cookie store and the hub JWT
-// signing keys so that all replicas behind the load balancer agree.
+// var (then SESSION_SECRET for compatibility). The same value backs both the
+// web session cookie store and the hub JWT signing keys so that all replicas
+// behind the load balancer agree.
 func resolveSessionSecret() string {
-	if webSessionSecret != "" {
-		return webSessionSecret
+	secret := webSessionSecret
+	if secret == "" {
+		secret = os.Getenv("SCION_SERVER_SESSION_SECRET")
 	}
-	return os.Getenv("SCION_SERVER_SESSION_SECRET")
+	if secret == "" {
+		secret = os.Getenv("SESSION_SECRET")
+	}
+	if secret == "" && hostedMode {
+		slog.Warn("No session secret configured in hosted mode! Replicas will not be able to share sessions or agree on JWT signing keys, leading to login loops.")
+	}
+	return secret
 }
 
 // initHubServer creates and configures the Hub server.

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -1358,6 +1358,7 @@ func TestSessionStore_DifferentSecretCannotDecode(t *testing.T) {
 		reqC.AddCookie(c)
 	}
 	sessC, err := replicaC.sessionStore.Get(reqC, webSessionName)
+	require.NotNil(t, sessC)
 	// A cookie authenticated/encrypted with a different secret fails to decode:
 	// gorilla returns a decode error together with a fresh, empty session.
 	// Either way, the state must not leak across mismatched secrets.


### PR DESCRIPTION
## Summary
- **426adc3b** — Make web session cookie store replica-portable by deriving it from the shared `SESSION_SECRET` instead of per-host keys
- **4224077c** — Derive JWT signing keys (agent + user) from the same `SESSION_SECRET` so all replicas behind a load balancer agree on the signing key

Without these fixes, a hub restart (or cross-replica request) generates new random JWT keys, invalidating all existing agent tokens and causing a login loop (`go-jose: error in cryptographic primitive`).

## Test plan
- [x] Verified on scion-gteam: after restart, agent tokens are stable and don't fail verification
- [x] Cross-replica scenario covered in unit tests (different hubID + same secret → identical keys)
