### PR TITLE
fix: update scion-env on GitHub token refresh to prevent gh CLI 401s

### DIFF
--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -627,6 +627,7 @@ func runInit(args []string) int {
 							ChownGID:  targetGID,
 							OnRefreshed: func(newToken string, newExpiry time.Time) {
 								log.Info("GitHub token refreshed, new expiry: %s", newExpiry.Format(time.RFC3339))
+								writeEnvFile(agentHome, targetUID, targetGID)
 							},
 							OnError: func(err error) {
 								log.Error("GitHub token refresh failed: %v", err)

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -1731,8 +1731,14 @@ func writeEnvFile(agentHome string, uid, gid int) {
 	}
 
 	envPath := filepath.Join(scionDir, "scion-env")
-	if err := os.WriteFile(envPath, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
-		log.Error("Failed to write scion-env file: %v", err)
+	tmpPath := envPath + ".tmp"
+	if err := os.WriteFile(tmpPath, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+		log.Error("Failed to write temporary scion-env file: %v", err)
+		return
+	}
+	if err := os.Rename(tmpPath, envPath); err != nil {
+		log.Error("Failed to atomically rename scion-env file: %v", err)
+		os.Remove(tmpPath)
 		return
 	}
 

--- a/cmd/sciontool/commands/init_test.go
+++ b/cmd/sciontool/commands/init_test.go
@@ -734,6 +734,41 @@ func TestWriteEnvFile_IncludesGitHubToken(t *testing.T) {
 	}
 }
 
+func TestWriteEnvFile_ReflectsUpdatedGitHubToken(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	t.Setenv("GITHUB_TOKEN", "ghs_initial_token_abc123")
+
+	writeEnvFile(tmpHome, 0, 0)
+
+	envPath := filepath.Join(tmpHome, ".scion", "scion-env")
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("failed to read scion-env file: %v", err)
+	}
+	if !strings.Contains(string(data), `export GITHUB_TOKEN="ghs_initial_token_abc123"`) {
+		t.Fatalf("expected initial GITHUB_TOKEN in env file, got:\n%s", string(data))
+	}
+
+	// Simulate what StartGitHubTokenRefresh does: os.Setenv then OnRefreshed calls writeEnvFile
+	t.Setenv("GITHUB_TOKEN", "ghs_refreshed_token_xyz789")
+
+	writeEnvFile(tmpHome, 0, 0)
+
+	data, err = os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("failed to read scion-env file after refresh: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, `export GITHUB_TOKEN="ghs_refreshed_token_xyz789"`) {
+		t.Errorf("expected refreshed GITHUB_TOKEN in env file, got:\n%s", content)
+	}
+	if strings.Contains(content, "ghs_initial_token_abc123") {
+		t.Errorf("stale initial token should not appear in env file after refresh")
+	}
+}
+
 func TestGitCloneWorkspace_DefaultEnvValues(t *testing.T) {
 	// Set SCION_GIT_CLONE_URL to trigger the clone path, but use a URL
 	// that will cause a predictable early failure (non-existent host).

--- a/pkg/sciontool/hub/client_test.go
+++ b/pkg/sciontool/hub/client_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1271,6 +1272,46 @@ func TestStartGitHubTokenRefresh_WritesExpiryFile(t *testing.T) {
 
 	// Token should not be considered expired
 	assert.False(t, IsGitHubTokenExpired(tokenPath))
+}
+
+func TestStartGitHubTokenRefresh_CallsOnRefreshedAfterEnvUpdate(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenPath := tmpDir + "/github-token"
+
+	t.Setenv("GITHUB_TOKEN", "ghs_original_stale")
+
+	futureExpiry := time.Now().Add(1 * time.Hour).UTC()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{
+			"token":      "ghs_fresh_token",
+			"expires_at": futureExpiry.Format(time.RFC3339),
+		})
+	}))
+	defer server.Close()
+
+	client := NewClientWithConfig(server.URL, "hub-token", "agent-123")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	var callbackToken string
+	done := client.StartGitHubTokenRefresh(ctx, &GitHubTokenRefreshConfig{
+		RefreshAt: time.Now(),
+		TokenPath: tokenPath,
+		OnRefreshed: func(newToken string, newExpiry time.Time) {
+			// At callback time, GITHUB_TOKEN env var should already be updated
+			callbackToken = newToken
+			assert.Equal(t, "ghs_fresh_token", os.Getenv("GITHUB_TOKEN"),
+				"GITHUB_TOKEN env var should be updated before OnRefreshed is called")
+		},
+	})
+
+	<-done
+
+	assert.Equal(t, "ghs_fresh_token", callbackToken,
+		"OnRefreshed callback should have been called with the new token")
 }
 
 func TestClient_StartHeartbeat_DefaultConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes the `gh` CLI returning HTTP 401 after GitHub App installation token expiry (~1 hour)
- Root cause: the token refresh loop updates `/tmp/.github-token` and PID 1's env, but never updates `~/.scion/scion-env` — which is what `.bashrc` sources to set `GITHUB_TOKEN` for child processes (including `gh`)
- Adds `writeEnvFile()` call in the `OnRefreshed` callback so subsequent shell invocations pick up the fresh token

Fixes issue 155

## Test plan

- [x] `TestWriteEnvFile_ReflectsUpdatedGitHubToken` — verifies `writeEnvFile` picks up the new `GITHUB_TOKEN` after `os.Setenv`, matching the refresh flow
- [x] `TestStartGitHubTokenRefresh_CallsOnRefreshedAfterEnvUpdate` — verifies `OnRefreshed` is called after `GITHUB_TOKEN` env var is updated, confirming the callback can safely call `writeEnvFile`
- [x] All existing `TestWriteEnvFile*` and `TestStartGitHubTokenRefresh*` tests pass
