### PR TITLE
fix: resolve hub auth token expiry deadlock after signing-key rotation

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -947,6 +947,12 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 		// HubID. Without this, a JWT minted by one replica fails validation on
 		// another (cross-replica "session_expired" login loop).
 		SharedSigningSecret: resolveSessionSecret(),
+		// When SCION_REQUIRE_STABLE_SIGNING_KEY is truthy, the hub refuses to
+		// start rather than silently mint a new signing key it cannot resolve
+		// (which would invalidate every live token after, e.g., a redeploy onto a
+		// new host that changed the HubID). Operators enabling this must supply a
+		// session secret or pre-provision the signing keys.
+		RequireStableSigningKey: os.Getenv("SCION_REQUIRE_STABLE_SIGNING_KEY") == "true",
 	}
 
 	// Construct proxy authenticator when auth mode is "proxy"

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -546,14 +546,14 @@ type Server struct {
 	notificationDispatcher *NotificationDispatcher // Notification dispatcher for agent status events
 	// reconcile op executors (seams): default to executeDispatch/deliverMessage;
 	// Phase 3/4 supply the real local-tunnel ops; tests override for exactly-once.
-	execDispatch func(ctx context.Context, d store.BrokerDispatch) (string, error)
-	deliverMsg   func(ctx context.Context, m *store.Message) error
-	maintenance            *MaintenanceState       // Runtime maintenance mode state
-	hubID                  string                  // Unique hub instance ID for secret namespacing
-	instanceID             string                  // Unique per-process ID (uuid); affinity key for broker dispatch
-	embeddedBrokerID       string                  // Broker ID when running in hub+broker combo mode
-	scheduler              *Scheduler              // Unified scheduler for recurring tasks
-	cleanupOnce            sync.Once               // Ensures CleanupResources runs only once
+	execDispatch     func(ctx context.Context, d store.BrokerDispatch) (string, error)
+	deliverMsg       func(ctx context.Context, m *store.Message) error
+	maintenance      *MaintenanceState // Runtime maintenance mode state
+	hubID            string            // Unique hub instance ID for secret namespacing
+	instanceID       string            // Unique per-process ID (uuid); affinity key for broker dispatch
+	embeddedBrokerID string            // Broker ID when running in hub+broker combo mode
+	scheduler        *Scheduler        // Unified scheduler for recurring tasks
+	cleanupOnce      sync.Once         // Ensures CleanupResources runs only once
 
 	logQueryService *LogQueryService // Cloud Logging query service (nil = disabled)
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -87,6 +87,16 @@ type ServerConfig struct {
 	// other replica behind the load balancer. When empty, signing keys fall
 	// back to per-hub storage in the secret backend / store.
 	SharedSigningSecret string
+	// RequireStableSigningKey makes hub startup fail rather than silently
+	// generate a brand-new signing key when no existing key can be resolved.
+	// Generating a new key invalidates every token previously issued by this
+	// hub — agents get crypto verification errors and cannot self-refresh. After
+	// a restart that changed the hub identity (e.g. a new pod hostname -> new
+	// HubID) without a SharedSigningSecret, that silently orphans every live
+	// agent. Enabling this turns that silent outage into a loud fail-fast.
+	// Operators enabling it must provide a SharedSigningSecret or pre-provision
+	// the signing keys; otherwise first boot will (correctly) refuse to start.
+	RequireStableSigningKey bool
 	// AuthMode is the exclusive human auth mode: "oauth" (default), "proxy", "dev".
 	AuthMode string
 	// ProxyAuthenticator is the configured proxy authenticator (when AuthMode == "proxy").
@@ -663,7 +673,11 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 	// Initialize agent token service
 	agentKey, err := srv.ensureSigningKey(ctx, SecretKeyAgentSigningKey, cfg.AgentTokenConfig.SigningKey)
 	if err != nil {
-		if isGCPBackend {
+		// Fail-fast for a GCP backend (production) or when stable keys are
+		// required. Otherwise a non-fatal error would fall through to
+		// NewAgentTokenService generating an ephemeral random key, reintroducing
+		// the silent token-invalidation this guard exists to prevent.
+		if isGCPBackend || cfg.RequireStableSigningKey {
 			return nil, fmt.Errorf("agent signing key: %w", err)
 		}
 		logSigningKeyFailure("agent", err)
@@ -682,7 +696,7 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 	// Initialize user token service
 	userKey, err := srv.ensureSigningKey(ctx, SecretKeyUserSigningKey, cfg.UserTokenConfig.SigningKey)
 	if err != nil {
-		if isGCPBackend {
+		if isGCPBackend || cfg.RequireStableSigningKey {
 			return nil, fmt.Errorf("user signing key: %w", err)
 		}
 		logSigningKeyFailure("user", err)
@@ -1058,7 +1072,29 @@ func (s *Server) ensureSigningKey(ctx context.Context, keyName string, existingK
 		}
 	}
 
-	// Not found anywhere, generate a new one
+	// Not found anywhere — we must generate a new key. Generating a new signing
+	// key invalidates EVERY token previously issued by this hub: live agents see
+	// "failed to verify token" crypto errors and, because the self-service
+	// refresh endpoint authenticates with the (now-invalid) token, cannot
+	// recover on their own. This is expected on genuine first boot, but after a
+	// restart that changed the hub identity (e.g. a new pod hostname -> new
+	// HubID) without a SharedSigningSecret it silently orphans every live agent.
+	//
+	// Fail-fast when the operator has opted into stable-key enforcement, and
+	// otherwise make the token-invalidating event loud (error-level) so it is
+	// alertable rather than buried in a warning.
+	if s.config.RequireStableSigningKey {
+		return nil, fmt.Errorf("refusing to generate a new signing key %q: RequireStableSigningKey is set and no existing key was found "+
+			"(generating one would invalidate all live agent/user tokens); provide a SharedSigningSecret or pre-provision the key", keyName)
+	}
+	if hasSecretBackend {
+		slog.Error("ensureSigningKey: no existing signing key found despite a configured secret backend; generating a NEW key — ALL previously issued tokens are now INVALID",
+			"key", keyName,
+			"hub_id", hubID,
+			"hint", "set a SharedSigningSecret (SESSION_SECRET) or pin a stable HubID so signing keys persist across restarts/redeploys",
+		)
+	}
+
 	slog.Warn("Signing key not found in any source, generating new key", "key", keyName, "hub_id", hubID)
 	newKey := make([]byte, 32)
 	if _, err := rand.Read(newKey); err != nil {

--- a/pkg/hub/signing_key_shared_test.go
+++ b/pkg/hub/signing_key_shared_test.go
@@ -17,8 +17,87 @@ package hub
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 )
+
+// TestEnsureSigningKey_RequireStableRefusesGeneration verifies that, with
+// RequireStableSigningKey set and no existing key resolvable, ensureSigningKey
+// fails fast instead of silently minting a new key (which would invalidate every
+// live token). This is the regression guard for the hub-restart auth deadlock.
+func TestEnsureSigningKey_RequireStableRefusesGeneration(t *testing.T) {
+	st, err := newTestStore(":memory:")
+	if err != nil {
+		t.Fatalf("newTestStore: %v", err)
+	}
+	defer st.Close()
+
+	s := &Server{
+		hubID:  "host-with-no-key",
+		store:  st,
+		config: ServerConfig{RequireStableSigningKey: true},
+	}
+
+	_, err = s.ensureSigningKey(context.Background(), SecretKeyAgentSigningKey, nil)
+	if err == nil {
+		t.Fatal("expected ensureSigningKey to refuse generating a new key when RequireStableSigningKey is set")
+	}
+	if !strings.Contains(err.Error(), "RequireStableSigningKey") {
+		t.Fatalf("error should explain the refusal, got: %v", err)
+	}
+}
+
+// TestEnsureSigningKey_RequireStableAllowsSharedSecret verifies that stable-key
+// enforcement still works when the operator supplies a SharedSigningSecret: the
+// key is derived deterministically and no generation (or store access) occurs.
+func TestEnsureSigningKey_RequireStableAllowsSharedSecret(t *testing.T) {
+	// Nil store is fine: shared-secret derivation returns before any store access.
+	s := &Server{
+		hubID:  "host1",
+		config: ServerConfig{RequireStableSigningKey: true, SharedSigningSecret: "deployment-secret"},
+	}
+
+	key, err := s.ensureSigningKey(context.Background(), SecretKeyAgentSigningKey, nil)
+	if err != nil {
+		t.Fatalf("ensureSigningKey with shared secret should succeed under require-stable, got: %v", err)
+	}
+	if len(key) != 32 {
+		t.Fatalf("expected a 32-byte derived key, got %d bytes", len(key))
+	}
+	if !bytes.Equal(key, deriveSharedSigningKey("deployment-secret", SecretKeyAgentSigningKey)) {
+		t.Fatal("require-stable should derive the same key as deriveSharedSigningKey")
+	}
+}
+
+// TestEnsureSigningKey_GeneratesWhenNotRequired verifies the default behavior is
+// preserved: without RequireStableSigningKey, a missing key is generated and
+// persisted rather than erroring.
+func TestEnsureSigningKey_GeneratesWhenNotRequired(t *testing.T) {
+	st, err := newTestStore(":memory:")
+	if err != nil {
+		t.Fatalf("newTestStore: %v", err)
+	}
+	defer st.Close()
+
+	s := &Server{hubID: "host1", store: st, config: ServerConfig{}}
+
+	key, err := s.ensureSigningKey(context.Background(), SecretKeyAgentSigningKey, nil)
+	if err != nil {
+		t.Fatalf("ensureSigningKey should generate a key by default, got: %v", err)
+	}
+	if len(key) != 32 {
+		t.Fatalf("expected a 32-byte generated key, got %d bytes", len(key))
+	}
+
+	// The generated key is persisted, so a second resolve returns the same key.
+	key2, err := s.ensureSigningKey(context.Background(), SecretKeyAgentSigningKey, nil)
+	if err != nil {
+		t.Fatalf("second ensureSigningKey: %v", err)
+	}
+	if !bytes.Equal(key, key2) {
+		t.Fatal("a generated key must persist and be returned on subsequent resolves")
+	}
+}
 
 // TestDeriveSharedSigningKey_Deterministic verifies that the derivation is
 // stable for a given (secret, keyName) pair and domain-separated across key

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -34,6 +35,14 @@ import (
 
 	state "github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 )
+
+// ErrTokenRefreshUnauthorized indicates the hub rejected the token refresh
+// request because the presented token is no longer accepted (HTTP 401/403).
+// This typically happens after a hub signing-key rotation invalidates all
+// previously-issued agent JWTs. It is terminal for the current token: retrying
+// with the same token can never succeed, so recovery requires a fresh token
+// injected out-of-band (e.g. via the broker reset-auth path / SIGUSR2).
+var ErrTokenRefreshUnauthorized = errors.New("token refresh unauthorized")
 
 const (
 	// TokenFile is the canonical token file name. The SCION_AUTH_TOKEN env var
@@ -388,6 +397,15 @@ func (c *Client) RefreshToken(ctx context.Context) (string, time.Time, error) {
 	respBody, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
+		// 401/403 mean the presented token is rejected (e.g. after a hub
+		// signing-key rotation). Tag these so the refresh loop can distinguish a
+		// terminal auth failure from a transient (network/5xx) one. The literal
+		// "token refresh failed with status %d" wording is preserved for the
+		// non-auth path because existing log-based tooling matches on it.
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return "", time.Time{}, fmt.Errorf("%w: token refresh failed with status %d: %s",
+				ErrTokenRefreshUnauthorized, resp.StatusCode, string(respBody))
+		}
 		return "", time.Time{}, fmt.Errorf("token refresh failed with status %d: %s",
 			resp.StatusCode, string(respBody))
 	}
@@ -483,15 +501,60 @@ type TokenRefreshConfig struct {
 	OnError func(error)
 	// OnAuthLost is called when auth is terminally lost (token expired, cannot refresh).
 	OnAuthLost func()
+	// RetryBaseDelay overrides the initial backoff between failed refresh
+	// attempts. Zero uses tokenRefreshRetryBaseDelay.
+	RetryBaseDelay time.Duration
+	// RetryMaxDelay overrides the cap on backoff between failed refresh attempts.
+	// Zero uses tokenRefreshRetryMaxDelay.
+	RetryMaxDelay time.Duration
 }
 
 // DefaultTokenRefreshTimeout is the default timeout for token refresh requests.
 const DefaultTokenRefreshTimeout = 30 * time.Second
 
+const (
+	// tokenRefreshRetryBaseDelay is the initial delay before retrying a failed
+	// token refresh.
+	tokenRefreshRetryBaseDelay = 30 * time.Second
+	// tokenRefreshRetryMaxDelay caps the backoff between failed refresh attempts.
+	// A persistently failing refresh (e.g. after a hub signing-key rotation that
+	// invalidates the current token) must not hot-loop, but should still retry
+	// often enough to recover promptly once the hub is healthy again or an
+	// out-of-band reset-auth injects a fresh token.
+	tokenRefreshRetryMaxDelay = 5 * time.Minute
+)
+
+// tokenRefreshBackoff returns the delay before the next refresh retry after the
+// given number of consecutive failures, using exponential backoff (starting at
+// base, doubling each attempt) capped at max.
+func tokenRefreshBackoff(consecutiveFailures int, base, max time.Duration) time.Duration {
+	if consecutiveFailures < 1 {
+		consecutiveFailures = 1
+	}
+	delay := base
+	for i := 1; i < consecutiveFailures; i++ {
+		delay *= 2
+		if delay >= max {
+			return max
+		}
+	}
+	if delay > max {
+		delay = max
+	}
+	return delay
+}
+
 // StartTokenRefresh starts a background goroutine that refreshes the agent token
 // before it expires. After a successful refresh, the next refresh is scheduled
 // based on the new token's expiry (2 hours before expiry for a 10-hour token).
-// Returns a channel that will be closed when the refresh loop exits.
+//
+// On failure the loop retries with exponential backoff (capped at
+// tokenRefreshRetryMaxDelay) instead of exiting, so the agent recovers
+// automatically once the hub is healthy again or a fresh token is injected
+// out-of-band (e.g. via reset-auth). When the current token has actually expired
+// and refresh still fails, OnAuthLost is invoked once for observability; the loop
+// keeps retrying so recovery remains possible. The loop only exits when ctx is
+// cancelled. Returns a channel that is closed when the loop exits.
 func (c *Client) StartTokenRefresh(ctx context.Context, config *TokenRefreshConfig) <-chan struct{} {
 	done := make(chan struct{})
 
@@ -500,24 +563,42 @@ func (c *Client) StartTokenRefresh(ctx context.Context, config *TokenRefreshConf
 		timeout = config.Timeout
 	}
 
+	retryBase := tokenRefreshRetryBaseDelay
+	if config != nil && config.RetryBaseDelay > 0 {
+		retryBase = config.RetryBaseDelay
+	}
+	retryMax := tokenRefreshRetryMaxDelay
+	if config != nil && config.RetryMaxDelay > 0 {
+		retryMax = config.RetryMaxDelay
+	}
+	if retryMax < retryBase {
+		retryMax = retryBase
+	}
+
 	go func() {
 		defer close(done)
 
+		// tokenExpiry tracks the actual expiry of the token currently held by the
+		// client. refreshAt (the scheduled wake time) is rewritten on every retry,
+		// so it cannot be used to decide when auth is terminally lost — we must
+		// compare against the real expiry instead. Seed it from the current token,
+		// falling back to the configured refresh time plus the standard 2h
+		// pre-expiry margin when the token is not a parseable JWT.
+		tokenExpiry := config.RefreshAt.Add(2 * time.Hour)
+		if exp, parseErr := ParseTokenExpiry(c.GetToken()); parseErr == nil {
+			tokenExpiry = exp
+		}
+
 		refreshAt := config.RefreshAt
+		consecutiveFailures := 0
+		authLostNotified := false
+
 		for {
-			now := time.Now()
-			delay := refreshAt.Sub(now)
-			if delay <= 0 {
-				// Refresh time has already passed; try immediately
+			delay := time.Until(refreshAt)
+			if delay < 0 {
 				delay = 0
 			}
-
-			var timer *time.Timer
-			if delay > 0 {
-				timer = time.NewTimer(delay)
-			} else {
-				timer = time.NewTimer(0) // fire immediately
-			}
+			timer := time.NewTimer(delay)
 
 			select {
 			case <-ctx.Done():
@@ -535,18 +616,31 @@ func (c *Client) StartTokenRefresh(ctx context.Context, config *TokenRefreshConf
 					config.OnError(err)
 				}
 
-				// If the token has already expired, auth is terminally lost
-				if time.Now().After(refreshAt.Add(2 * time.Hour)) {
+				// Once the current token has actually expired and refresh still
+				// fails, auth is lost. Surface it once (for observability and to
+				// trigger out-of-band recovery such as reset-auth) — but keep
+				// retrying with capped backoff rather than exiting, so the agent
+				// self-heals if the hub recovers (e.g. its signing key is restored)
+				// or a fresh token is injected. The previous implementation reset
+				// the expiry estimate on every retry, so OnAuthLost never fired and
+				// the loop hot-looped every 30s indefinitely.
+				if !authLostNotified && !time.Now().Before(tokenExpiry) {
+					authLostNotified = true
 					if config != nil && config.OnAuthLost != nil {
 						config.OnAuthLost()
 					}
-					return
 				}
 
-				// Retry in 30 seconds
-				refreshAt = time.Now().Add(30 * time.Second)
+				consecutiveFailures++
+				refreshAt = time.Now().Add(tokenRefreshBackoff(consecutiveFailures, retryBase, retryMax))
 				continue
 			}
+
+			// Successful refresh: reset failure tracking and clear any prior
+			// auth-lost state so a later loss is reported again.
+			consecutiveFailures = 0
+			authLostNotified = false
+			tokenExpiry = newExpiry
 
 			// Fix ownership after atomic rewrite (init runs as root).
 			if config.ChownUID > 0 {

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -452,7 +452,7 @@ func (c *Client) applyRefreshTokens(tokens []RefreshTokenEntry) {
 				entryExpiry := time.Now().Add(time.Duration(entry.ExpiresIn) * time.Second)
 				c.oidcSource.setToken(entry.Value, entryExpiry)
 			}
-		// app/scion_access is already handled via the legacy token field above
+			// app/scion_access is already handled via the legacy token field above
 		}
 	}
 }

--- a/pkg/sciontool/hub/client_test.go
+++ b/pkg/sciontool/hub/client_test.go
@@ -16,9 +16,12 @@ package hub
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,6 +29,21 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// makeJWTWithExpiry builds an unsigned JWT-shaped token whose payload carries the
+// given expiry. ParseTokenExpiry only base64-decodes the payload (it does not
+// verify the signature), so this is enough to drive the refresh loop's
+// expiry-tracking logic in tests.
+func makeJWTWithExpiry(t *testing.T, exp time.Time) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payloadJSON, err := json.Marshal(struct {
+		Exp int64 `json:"exp"`
+	}{Exp: exp.Unix()})
+	require.NoError(t, err)
+	payload := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	return header + "." + payload + ".sig"
+}
 
 // scrubHubEnv clears all Hub-related environment variables for the
 // duration of the test, preventing accidental communication with a
@@ -673,6 +691,126 @@ func TestClient_StartTokenRefresh(t *testing.T) {
 			t.Fatal("token refresh loop did not exit after context cancellation")
 		}
 	})
+
+	t.Run("retries after a transient failure then recovers", func(t *testing.T) {
+		cleanup := SetTokenHome(t.TempDir())
+		defer cleanup()
+
+		var calls int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// First attempt fails transiently (503); the second succeeds.
+			if atomic.AddInt32(&calls, 1) == 1 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				w.Write([]byte("temporarily down"))
+				return
+			}
+			futureExpiry := time.Now().Add(10 * time.Hour).UTC().Format(time.RFC3339)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"token":"recovered-token","expires_at":"` + futureExpiry + `"}`))
+		}))
+		defer server.Close()
+
+		client := NewClientWithConfig(server.URL, "old-token", "agent-123")
+
+		var errCount int32
+		refreshed := make(chan struct{}, 1)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		done := client.StartTokenRefresh(ctx, &TokenRefreshConfig{
+			RefreshAt:      time.Now(),
+			Timeout:        time.Second,
+			RetryBaseDelay: 10 * time.Millisecond,
+			RetryMaxDelay:  10 * time.Millisecond,
+			OnError:        func(error) { atomic.AddInt32(&errCount, 1) },
+			OnRefreshed: func(time.Time) {
+				select {
+				case refreshed <- struct{}{}:
+				default:
+				}
+			},
+		})
+
+		select {
+		case <-refreshed:
+			// Recovered after the transient failure.
+		case <-time.After(time.Second):
+			t.Fatal("token refresh did not recover after a transient failure")
+		}
+
+		assert.Equal(t, "recovered-token", client.GetToken())
+		assert.GreaterOrEqual(t, atomic.LoadInt32(&errCount), int32(1), "transient failure should invoke OnError")
+
+		cancel()
+		<-done
+	})
+
+	t.Run("auth lost fires once and keeps retrying", func(t *testing.T) {
+		cleanup := SetTokenHome(t.TempDir())
+		defer cleanup()
+
+		// The current token is already expired, so the first failed refresh is a
+		// terminal auth loss. The server always rejects with 401 (as it would
+		// after a hub signing-key rotation).
+		expiredToken := makeJWTWithExpiry(t, time.Now().Add(-time.Minute))
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("invalid agent token: failed to verify token"))
+		}))
+		defer server.Close()
+
+		client := NewClientWithConfig(server.URL, expiredToken, "agent-123")
+
+		var errCount, authLostCount int32
+		var sawUnauthorized atomic.Bool
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := client.StartTokenRefresh(ctx, &TokenRefreshConfig{
+			RefreshAt:      time.Now(),
+			Timeout:        time.Second,
+			RetryBaseDelay: 10 * time.Millisecond,
+			RetryMaxDelay:  10 * time.Millisecond,
+			OnError: func(err error) {
+				atomic.AddInt32(&errCount, 1)
+				if errors.Is(err, ErrTokenRefreshUnauthorized) {
+					sawUnauthorized.Store(true)
+				}
+			},
+			OnAuthLost: func() { atomic.AddInt32(&authLostCount, 1) },
+		})
+
+		// Let several retries elapse.
+		require.Eventually(t, func() bool {
+			return atomic.LoadInt32(&errCount) >= 3
+		}, time.Second, 5*time.Millisecond, "expected the loop to keep retrying")
+
+		// The loop must still be running (not exited) despite the auth loss.
+		select {
+		case <-done:
+			t.Fatal("refresh loop exited instead of continuing to retry after auth loss")
+		default:
+		}
+
+		cancel()
+		<-done
+
+		assert.Equal(t, int32(1), atomic.LoadInt32(&authLostCount), "OnAuthLost should fire exactly once")
+		assert.True(t, sawUnauthorized.Load(), "401 refresh error should wrap ErrTokenRefreshUnauthorized")
+	})
+}
+
+func TestTokenRefreshBackoff(t *testing.T) {
+	base := 30 * time.Second
+	max := 5 * time.Minute
+
+	assert.Equal(t, base, tokenRefreshBackoff(0, base, max), "non-positive failures clamps to one attempt")
+	assert.Equal(t, base, tokenRefreshBackoff(1, base, max))
+	assert.Equal(t, 2*base, tokenRefreshBackoff(2, base, max))
+	assert.Equal(t, 4*base, tokenRefreshBackoff(3, base, max))
+	assert.Equal(t, max, tokenRefreshBackoff(10, base, max), "backoff is capped at max")
 }
 
 func TestOperatingMode(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a deadlock where long-running agents become permanently un-authenticated after a hub restart that rotates the JWT signing keys, with no automatic self-recovery. Investigation details: `/scion-volumes/scratchpad/token-refresh-bug-investigation.md`.

### Root cause (two parts)

1. **Trigger — the hub silently rotated its signing keys on restart.** `ensureSigningKey` namespaces signing keys by `HubID` (= `sha256(hostname)[:12]`). A restart/redeploy onto a new host or pod changes the `HubID`, the per-hub key lookup misses, and the hub **silently generates a brand-new random key** — instantly invalidating every previously-issued agent and user token. Agents then get `failed to verify token: go-jose/go-jose: error in cryptographic primitive`.
2. **Deadlock — the only self-service refresh path needs a valid token to get a valid token.** `POST /api/v1/agents/{id}/token/refresh` authenticates with the **existing** JWT (and the hub crypto-validates it in both `AgentAuthMiddleware` and `RefreshAgentToken`). Once the JWT is invalid it can never mint its replacement → permanent 401.

On top of that, the agent's refresh loop **hot-looped every 30s forever and never surfaced `AUTH_LOST`**, because it reset its expiry estimate on every retry.

## What this PR changes

This PR addresses both the **trigger** (hub key stability) and the **agent-side recovery path**, complementing the admin bulk reset-auth added in PR 323.

### Layer A — Hub: guard against silent signing-key regeneration (`pkg/hub/server.go`)
- New `ServerConfig.RequireStableSigningKey`. When set, `ensureSigningKey` **fails fast** instead of silently minting a new key it can't resolve — turning a silent mass token-invalidation into a loud startup error. Operators enabling it must provide a `SharedSigningSecret` (deterministic derivation, returns early) or pre-provision the keys.
- The error is now propagated from `New()` for agent **and** user keys (previously it could fall through to an ephemeral random key in `NewAgentTokenService`).
- Token-invalidating key generation is now logged at **error** level (alertable) when a secret backend is configured.
- Wired via `SCION_REQUIRE_STABLE_SIGNING_KEY=true` (`cmd/server_foreground.go`).

### Layer C — Agent: make the refresh loop recover (`pkg/sciontool/hub/client.go`)
- Track the **actual token expiry** separately from the mutable refresh schedule, so `OnAuthLost` fires **exactly once** when the token has truly expired (the old `refreshAt+2h` check was always ~2h in the future after the first retry).
- **Retry with exponential backoff** (base 30s, capped 5m) and **never exit on auth loss**, so the agent self-heals automatically once the hub recovers or a fresh token is injected out-of-band (reset-auth / `SIGUSR2`) — no process restart needed.
- Tag 401/403 refresh rejections with `ErrTokenRefreshUnauthorized` so callers can distinguish terminal auth failures from transient ones.
- Added configurable `RetryBaseDelay`/`RetryMaxDelay` on `TokenRefreshConfig`.

## Tests
- `pkg/sciontool/hub/client_test.go`: transient-failure-then-recovery, single `OnAuthLost` on terminal auth loss with continued retry, `ErrTokenRefreshUnauthorized` tagging, and the backoff schedule.
- `pkg/hub/signing_key_shared_test.go`: refuse-on-require, shared-secret-allowed-under-require, and default generation behavior preserved.

All new/related tests pass (`go test ./pkg/sciontool/hub/ ./pkg/hub/ -run 'Token|SigningKey|...'`). Note: a set of pre-existing, unrelated failures in `pkg/hub` (`invalid UUID "hc-claude-1"` in harness-config/resources-import fixtures) also fail on clean `origin/main` and are not touched by this PR.

## Not included (follow-up)
Fully-automatic, hub-initiated reset-auth dispatch on detecting persistent crypto-401 was intentionally left out: PR 323 just established **admin-triggered** bulk reset-auth as the chosen remediation, and these changes (prevent the trigger + agent cooperates cleanly with reset-auth instead of livelocking) complement that approach. Automatic dispatch can be added later if desired.

🤖 Investigated and implemented by the token-refresh-investigator agent.
