### PR TITLE
Project visibility via membership (subtractive model)

### DIFF
--- a/.design/project-log/2026-06-05-wp0-agent-schema-visibility-cleanup.md
+++ b/.design/project-log/2026-06-05-wp0-agent-schema-visibility-cleanup.md
@@ -1,0 +1,39 @@
+# WP-0: Agent Schema — project_id Index + Drop Inert Visibility
+
+**Date**: 2026-06-05
+**Branch**: `design/project-visibility-membership`
+**Scope**: Ent schema + codegen foundation for the project-visibility feature
+
+## Changes
+
+### Schema (`pkg/ent/schema/agent.go`)
+- Added standalone index `index.Fields("project_id")` — enables efficient queries filtering agents by project without requiring the slug in the predicate. The existing unique composite `index.Fields("slug", "project_id").Unique()` is preserved.
+- Removed the inert `field.String("visibility").Default("private")` from the Agent schema. This field was hardcoded to "private" at creation, never user-settable, never enforced in access control, and never used for filtering.
+
+### Generated Code (`pkg/ent/**`)
+- Regenerated via `go generate ./pkg/ent/...` — removes all Visibility-related generated helpers (SetVisibility, where predicates, mutation methods) from the Agent entity. The new project_id index appears in `migrate/schema.go`.
+
+### Reference Cleanup (25 files total)
+- `pkg/store/models.go` — removed `Visibility` field from `Agent` struct and `ToAgentInfo()` conversion
+- `pkg/api/types.go` — removed `Visibility` from `AgentInfo`
+- `pkg/hub/events.go` — removed `Visibility` from `AgentCreatedEvent` struct and population
+- `pkg/hub/handlers.go` — removed `Visibility: store.VisibilityPrivate` from agent creation
+- `pkg/store/entadapter/agent_store.go` — removed all Visibility read/write in the Ent adapter
+- `cmd/list.go` — removed Visibility from agent-to-AgentInfo mapping
+- 12 test files across `pkg/hub/` and `pkg/store/storetest/` — removed `Visibility` from `store.Agent` struct literals
+
+### Untouched (intentionally)
+- Project visibility (`pkg/ent/schema/project.go`, `store.Project`, `api.ProjectInfo`) — remains
+- Template and HarnessConfig visibility — remains
+- `api.NormalizeVisibility` — not added (out of scope; belongs to another WP)
+- `web/`, broker, seed.go, authz — out of scope
+
+## Build & Test Results
+- `go build ./...` — PASS
+- `make test-fast` — all test packages pass except pre-existing failures:
+  - `pkg/hub` — `command_bus_test.go` build failure (undefined `recExec`/`requirePostgres`, pre-existing on main)
+  - `pkg/store/entadapter` — `broker_affinity_test.go` build failure (undefined helpers, pre-existing on main)
+  - `pkg/config` — 5 test failures (env-var leakage from container, pre-existing)
+  - `pkg/hubsync` — 2 test failures (pre-existing)
+
+No new test failures introduced by this change.

--- a/.design/project-log/2026-06-06-wp-d-frontend-visibility.md
+++ b/.design/project-log/2026-06-06-wp-d-frontend-visibility.md
@@ -1,0 +1,43 @@
+# WP-D: Frontend Visibility UI Changes
+
+**Date:** 2026-06-06
+**Branch:** design/project-visibility-membership
+**Commit:** fa2fb68
+
+## Summary
+
+Implemented WP-D from the project-visibility implementation plan — the frontend
+portion of the membership-based visibility model.
+
+## Changes
+
+### 1. `web/src/components/pages/project-create.ts`
+- Removed the `visibility` `@state` property (was `'private'` default)
+- Removed `visibility` from the POST request body
+- Removed the entire visibility `<sl-select>` markup (Private/Team/Public options)
+- New projects now default to creator-only; visibility is emergent from membership
+
+### 2. `web/src/components/shared/group-member-editor.ts`
+- Added `showProjectMembersHint` boolean property (opt-in, default false)
+- Added CSS for `.project-members-hint` styled hint box
+- In compact mode (used by project settings), renders an info hint:
+  "To make this project visible to all hub users, add the **hub-members** group."
+- Hint is scoped to project-members context only — does not appear on the admin
+  group detail page or any other usage of the editor.
+
+### 3. `web/src/components/pages/project-settings.ts`
+- Set `showProjectMembersHint` on the `<scion-group-member-editor>` instance
+- Updated `sectionDescription` from "create and manage agents" to
+  "access this project and its agents" to reflect the new access model
+
+## Verification
+
+- `npm run typecheck` — passes cleanly (zero errors)
+- `npm run lint` — all errors are pre-existing (confirmed by stash-checking
+  the same files before changes); no new lint issues introduced
+- No Go files were touched
+
+## Observations
+
+- The lint configuration has widespread pre-existing prettier/formatting issues
+  across the web codebase. These are not related to this change.

--- a/.design/project-visibility-implementation-plan.md
+++ b/.design/project-visibility-implementation-plan.md
@@ -1,0 +1,252 @@
+# Project Visibility — Implementation Plan
+
+Companion to `project-visibility-membership.md` (approved design). This plan
+sequences the work into work-packages (WPs) with concrete file anchors, names the
+one real architectural decision the design left implicit, and orders the WPs by
+dependency so they can be parallelized across developer agents safely.
+
+Branch: `design/project-visibility-membership` (all work; PR at end, no merge).
+
+---
+
+## 0. The one architectural decision to confirm: how "role-aware" is enforced
+
+The design (§3.3, OQ2→B) wants: **member = read-only, admin = create/manage,
+owner = full**, all on the *single* members group. But the policy engine today
+**cannot condition a policy binding on a member's role** — `PolicyBinding` is just
+`(PrincipalType, PrincipalID)` (`pkg/store/models.go:1232`), and
+`GetEffectiveGroups` returns group IDs only, dropping role
+(`pkg/store/entadapter/group_store.go:735`).
+
+There are two ways to get role-aware behavior:
+
+- **(Recommended) Reuse the existing role bypass — purely subtractive.** Read is
+  granted by a project-scoped read policy bound to the members group → *everyone
+  in the group (any role) can read*. Create/stop/manage is **already** gated by
+  `isProjectOwnerOrAdmin` (`pkg/hub/authz.go:461`), which explicitly checks
+  `membership.Role == owner || admin`. So we **remove `create, stop_all` from the
+  members-group policy** and let the existing admin/owner bypass grant them. Net
+  effect: member→read-only, admin/owner→create/manage, with **no policy-engine
+  changes**. This is why the migration "bump members→admin" is needed: today every
+  member gets create via the group policy; after this change only admin/owner do.
+  - **Known limitation (flag, don't fix now):** `isProjectOwnerOrAdmin` checks the
+    user's *direct* membership row on the project members group. A user who is
+    admin only via a **nested** team group would get read (nesting resolves) but
+    not create. Acceptable for v1; note as follow-up.
+
+- **(Deferred alternative) Extend the policy engine** with a `role` on
+  `PolicyBinding`, carry role through `GetEffectiveGroups`, and filter on it in
+  `evaluatePolicies`. More expressive (role survives nesting) but invasive and not
+  required to meet the approved spec. Out of scope for this pass.
+
+**This plan assumes the recommended approach.** If ptone prefers the engine
+extension, WP-B grows substantially — calling it out before we build.
+
+---
+
+## 1. Work-package sequence & dependencies
+
+```
+WP-0 (schema/codegen, SOLO first)
+        │
+        ├──► WP-B (authz/policy/enforcement/migration)  ← behavior-changing core
+        ├──► WP-A (agent-list filter + caching)
+        ├──► WP-C (broker read scoping)
+        └──► WP-D (UI wiring)            ← independent, can start anytime
+```
+
+WP-0 lands first and alone because it regenerates `pkg/ent/**` (codegen); doing it
+once avoids merge conflicts in generated files. WP-A/B/C/D then run in parallel.
+**WP-B is the only behavior-changing package** — its sub-steps (narrow read-all +
+add project read + enforcement gaps) must land *together* and be tested as a unit,
+or members lose visibility to their own projects mid-rollout.
+
+---
+
+## WP-0 — Schema & codegen foundation (solo, lands first)
+
+1. **Add `project_id` index on agents** — `pkg/ent/schema/agent.go:176` `Indexes()`
+   currently has only `index.Fields("slug","project_id").Unique()`. Add
+   `index.Fields("project_id")`. Makes the `project_id IN (...)` filter (§3.5)
+   efficient.
+2. **Drop the inert per-agent `visibility` field** — `pkg/ent/schema/agent.go:63`
+   (`field.String("visibility").Default("private")`). Remove the field and all code
+   references. NOTE: ent auto-migration does **not** drop the DB column by default,
+   so the column is left orphaned/harmless; a `WithDropColumn` cleanup can follow
+   later. Verify no code reads agent visibility for decisions (it's hardcoded
+   "private" today, so safe).
+3. **Regenerate:** `go generate ./pkg/ent/...` (runs the `ent generate` in
+   `pkg/ent/generate.go:17`). Commit generated changes.
+4. Leave the **project** `visibility` field in place (`project.go:74`) — the design
+   says it may be retired or repurposed; retiring the column is not required and we
+   stop authoring it from the UI in WP-D. Document it as internal/legacy.
+
+Verify: `make test-fast build`.
+
+---
+
+## WP-B — Authz / policy / enforcement core (the behavior change)
+
+All in `pkg/hub`. Land these together.
+
+### B1 — Narrow the global read-all grant (§3.1)
+`pkg/hub/seed.go:50` seeds `hub-member-read-all` with `ResourceType:"*"`,
+`actions:[read,list]`. Replace the single `"*"` policy with **explicit per-type
+allow policies** bound to `hub-members`:
+- **KEEP** (hub-readable directory/catalog): `user`, `group`, `template`,
+  `harness_config` → seed read/list allows for these.
+- **GATE** (remove from global read): `project`, `agent`, `broker` → no hub-wide
+  allow; visibility comes from membership.
+- **SENSITIVE** (tighten): `policy`, `gcp_service_account`,
+  `secret`/`environment`/`variable` → no hub-wide read. Project-scoped instances
+  derive from associated-project membership (same gating as agents via the
+  project read policy in B2 where they share scope); hub-level ones stay
+  admin/owner-only (admin bypass already covers admins).
+- Seeding is idempotent by policy name; ensure re-seed replaces the old wildcard
+  (delete-by-name or upsert) so existing hubs migrate.
+
+### B2 — Add project-scoped member read + role-aware create (§3.2, §3.3)
+`createProjectMembersGroupAndPolicy` (`pkg/hub/handlers.go:3633`):
+- **Add** a project-scoped read policy bound to the members group:
+  `scope=project, scopeID=<project.ID>, resourceType=project` and one for
+  `agent`, `actions:[read,list], effect=allow`. (Agents derive from project, §3.7
+  — granting agent read at project scope to the members group is the mechanism.)
+- **Remove `create, stop_all`** from the existing
+  `project:<slug>:member-create-agents` policy (handlers.go:3730). Create/stop now
+  flow from the admin/owner role bypass (`isProjectOwnerOrAdmin`). Rename the
+  policy to `project:<slug>:member-read` to match its new role.
+- Idempotency: on re-run, replace the old create-policy with the read-policy
+  (handle existing hubs).
+
+### B3 — Migration backfill: bump existing members → admin (§3.3, §6)
+`createProjectMembersGroupAndPolicy` already runs at startup for every project
+(`pkg/hub/server.go:777` seedDefaultPoliciesAndGroups loop) and has a backfill
+block (handlers.go:~3706 promotes sole member→owner). Add a **one-time, idempotent
+bump**: any group member currently at `role=member` who predates this change →
+`role=admin`, to preserve their create-agent ability. Guard so it runs once (e.g.
+skip if any admin/owner already present beyond the creator, or gate on a stored
+"migrated" marker / version). New members added post-migration default to `member`
+(read-only) per `addGroupMember` default (`handlers_groups.go:509`) — unchanged.
+- **Care:** do not bump the `hub-members` group's members (that would make everyone
+  admin everywhere). Only bump per-project `project:<slug>:members` groups.
+
+### B4 — Close enforcement gaps (§3.4)
+- **getProject** (`pkg/hub/handlers.go:5104`) does not gate read. Add
+  `CheckAccess(ctx, identity, Resource{Type:"project", ID, OwnerID}, ActionRead)`;
+  403/404 on deny. Same for **getProjectAgent** (`handlers.go:4827`) — add a read
+  check (derives from project per §3.7).
+- **Fail closed on nil identity:** `listProjects` (handlers.go:3289),
+  `listAgents` (handlers.go:276), `getProject`, single-agent GET currently treat
+  `identity == nil` as "skip filter / return everything." Change to: nil identity →
+  empty result or 401 (no anonymous read). `CheckAccess` already denies unknown
+  identity (`authz.go:95` default deny) — lean on it for the GETs; for the LISTs,
+  short-circuit to empty/401 when identity is nil.
+
+Verify: targeted tests for member-can-read-own-project, non-member-cannot,
+hub-members-added→all-can-read, nil-identity→empty.
+
+---
+
+## WP-A — Cross-project agent list filter + per-request caching (§3.5)
+
+`pkg/hub/handlers.go` `listAgents` (276):
+- Apply `filter.MemberProjectIDs = resolveUserProjectIDs(...)` for the **default**
+  scope, not just `scope=shared` (currently only shared/mine set it). Default scope
+  = "agents in my projects." The SQL IN predicate already exists
+  (`agent_store.go:450` → `agent.ProjectIDIn`).
+- **Cache `resolveUserProjectIDs`** (handlers.go:5960) once per request in
+  `r.Context()` (it does a BFS via `GetEffectiveGroups` + `GetGroupsByIDs`). Add a
+  context key + memoizing wrapper; reuse across listAgents/listProjects/capability
+  batches in the same request.
+- Pagination stays SQL-honest (no post-hoc drop). `totalCount`/cursors remain
+  correct.
+
+(Depends on WP-0's `project_id` index for efficiency; logic itself is independent
+of WP-B but should be tested after B so the filter semantics match.)
+
+---
+
+## WP-C — Broker read scoping (§4)
+
+`pkg/hub` broker handlers + `handlers_broker_projects.go`:
+- **Broker read** = owner OR hub admin OR member of ANY project the broker
+  contributes to. Resolve via `ProjectContributor` (project_id ↔ broker_id;
+  `pkg/ent/schema/projectcontributor.go`). Add a `CheckAccess`/derive helper that
+  loads contributing project IDs for a broker and tests intersection with the
+  caller's project set (`resolveUserProjectIDs`).
+- **Broker list** scoped the same way: brokers you own + brokers contributing to a
+  project you're a member of. Add a filter keyed off `ProjectContributor`.
+  `broker_id` index already exists on `ProjectContributor` (no new index needed —
+  confirm during impl).
+- Freshly-registered broker not yet linked → visible to owner/admins only.
+- `handleBrokerProjects` (`handlers_broker_projects.go:30`) is broker-HMAC-authed
+  (broker enumerating its own projects) — leave as-is; this WP is about *user*
+  read of brokers.
+
+---
+
+## WP-D — UI wiring (§3.6)
+
+- **Remove the visibility selector** from `web/src/components/pages/project-create.ts`
+  (markup at `:609-622`, the `visibility` `@state` at `:64`, and drop `visibility`
+  from the POST body at `:371`). New projects default to creator-only.
+- **Members-card hint:** in the project-settings Members card
+  (`web/src/components/shared/group-member-editor.ts`, used for
+  `project:<slug>:members`), add a small hint: *"To make this project visible to
+  all hub users, add the hub-members group."* Scope the hint to the project members
+  context (don't show it on unrelated group editors).
+- Verify: `cd web && npm run typecheck && npm run lint`.
+
+---
+
+## 2. Deferred follow-ups (track, do not implement here)
+
+- **OQ9 templates & harness configs** — keep globally listable now (WP-B KEEPs
+  `template`/`harness_config`); their own visibility + grove-attachment design is a
+  separate pass.
+- **Grove→project terminology cleanup** — DELIVERED as standalone branch
+  `scion/grove-cleanup` (commit 230ca7f, by visibility-explorer): adds
+  `api.NormalizeVisibility()` (legacy `grove`/`project` → `team`) applied at
+  write entry points for Templates, HarnessConfigs, and Projects; fixes stale
+  comments; leaves wire-compat shims (`groveId/grove*` JSON, NATS subjects,
+  `SCION_GROVE_ID`, container labels) intentionally untouched. **Direction (ptone,
+  2026-06-05): pull it into THIS stream, not a standalone PR.** It lands as a
+  discrete cherry-picked commit (`230ca7f`) on the branch, applied AFTER WP-0 and
+  BEFORE wave 2 so the backend agent builds on top of it (no `handlers.go`
+  conflict). Logical separation is preserved by keeping it as its own commit. The
+  project-visibility normalization it adds is **interim/superseded** (project
+  visibility becomes membership-derived and is no longer UI-authored after WP-D),
+  so that portion goes inert; the Template/HarnessConfig normalization stands.
+  Backend agent is told NormalizeVisibility is already present — do not re-add it.
+- **Normalize-on-read / one-time migration for historical `"project"` rows**
+  (ptone deciding) — recommendation: **write-path only for now**. Templates/harness
+  are deferred (their migration rides with the OQ9 follow-up), and the *project*
+  visibility column is being retired from authoring, so a read-normalization or
+  backfill for project rows is wasted effort. Revisit only if the column is
+  repurposed as a derived cache.
+- **Finer-grained permissions / role-in-policy engine** — the deferred alternative
+  in §0; revisit if nested-group admins or per-action grants are needed.
+- **Drop the orphaned `agent.visibility` (and possibly `project.visibility`) DB
+  columns** via `WithDropColumn` once the field removal has soaked.
+
+---
+
+## 3. Test & verification gates
+
+- Go: `make test-fast` then `make build` per WP; add unit tests for the new
+  enforcement paths in WP-B (the critical, behavior-changing package).
+- Web: `npm run typecheck && npm run lint` for WP-D.
+- Integration smoke (manual / verify skill): private project invisible to
+  non-member; add user→visible; add `hub-members`→visible to all; non-member can
+  still open an "everyone" project's agents on demand; top-level agent firehose
+  shows only your projects.
+- Final: `make ci-full` before opening the PR.
+
+---
+
+## 4. Rollout ordering (single branch)
+
+1. WP-0 (schema/codegen) → commit.
+2. WP-B (all sub-steps together) + WP-A + WP-C + WP-D in parallel.
+3. Integration smoke + `make ci-full`.
+4. Open PR on `design/project-visibility-membership`. **Do not merge.**

--- a/.design/project-visibility-membership.md
+++ b/.design/project-visibility-membership.md
@@ -1,0 +1,323 @@
+# Project Visibility via Membership (Subtractive Model)
+
+## Status
+**Approved (design)** — all 9 open questions resolved with ptone@google.com on
+2026-06-05; ready for an implementation-planning pass. Supersedes the core
+approach of `access-visibility.md` (visibility-as-stored-enum). Preserves that
+doc's terminology feedback and agent-inheritance notes; reframes the mechanism
+around group/role membership.
+
+### Resolved decisions (summary)
+- **OQ2** read-only tier → role-aware single members group: member=read-only,
+  admin=create/manage, owner=full; migrate existing members → admin.
+- **OQ3** agents are team members → agent read derives from project; drop per-agent
+  visibility.
+- **OQ4** "everyone" = `hub-members` added as a real member row; "public" term and
+  the visibility dropdown removed; Members-card hint added.
+- **OQ5** top-level agent list = caller's projects only (`IN` filter + new
+  `project_id` index); no denormalization.
+- **OQ1** narrow read-all via explicit per-type allows; GATE {project, agent,
+  broker}; KEEP {user, group, template, harness_config}; tighten sensitive
+  {policy, gcp_service_account, secret/env/variable} (project-scoped derive from
+  associated project; hub-level admin/owner-only).
+- **OQ6** broker read = owner + admins + members of any contributing project.
+- **OQ7** terminology dissolved (no user-facing visibility labels remain).
+- **OQ9** templates/harness configs deferred to a follow-up; grove-cleanup agent
+  spawned for legacy terminology.
+- **OQ8** fail closed — no anonymous access; auth always required.
+
+---
+
+## 1. Problem & Key Finding
+
+The Hub create-project dialog offers private/team/public, but visibility is
+**stored and never enforced** — and, more importantly, *everyone can already see
+everyone's projects*. The reason is not "unimplemented default-open"; it is an
+explicit global grant.
+
+**Root cause (the load-bearing fact):** `pkg/hub/seed.go` seeds a hub-wide
+policy `hub-member-read-all`:
+
+```
+scope=hub, resourceType="*", actions=[read, list], effect=allow
+```
+
+bound to the `hub-members` group. Every user is auto-enrolled into `hub-members`
+on login (`ensureHubMembership`). So one policy grants every user read+list on
+**every resource type**, projects included. This is why visibility is currently
+moot.
+
+**Consequence:** Implementing visibility is primarily a **subtractive** change —
+*stop globally granting read*, then let membership decide who sees what.
+
+---
+
+## 2. Core Principle: Visibility is Emergent from Membership
+
+Visibility is **not** a fixed attribute chosen at project creation. It is a live
+reflection of the project's current membership/role state, which can change over
+time. We remove the creation-time selector entirely.
+
+The existing membership plumbing already supports this with **one source of
+truth**:
+
+- The project "Members" panel in the web UI *is* the auto-created
+  `project:<slug>:members` group (`<scion-group-member-editor>` bound to that
+  group's ID). List/add/remove all go through `/api/v1/groups/{id}/members` →
+  `GroupMembership`. No second collection to sync.
+- Groups can contain **other groups** (memberType="group", cycle-checked via
+  `WouldCreateCycle`), and `GetEffectiveGroups` resolves nesting transitively
+  (BFS up `parent_groups`). So a reusable cross-project team group can be dropped
+  into many projects.
+- The "all hub users" group already exists: **`hub-members`** (seeded, every user
+  auto-joined). It is GroupType `explicit` with login-time auto-enrollment
+  (materialized rows), not a virtual group — but functionally it is "everyone on
+  the hub," and `GetEffectiveGroups` + the policy engine honor it natively.
+
+### 2.1 The three levels expressed as membership
+
+| Level | Meaning | Mechanism |
+|-------|---------|-----------|
+| **private** | Owner (+ explicitly added members) only | Default. Members group has only the owner. |
+| **team** | The project's collaborators | Members group has users and/or nested groups. |
+| **everyone** (public) | All hub users (read-only) | Add the **`hub-members`** group to the project, at a read-only role. |
+
+"public" deliberately means **everyone on the hub**, never outside it
+(per terminology feedback in `access-visibility.md`: prefer "everyone" over
+"public"; "grove-team"/"project-team" over "team"). Visibility is read-only;
+mutations remain guarded by role/policy.
+
+No creation-time choice is required for any of these. private↔team is just "who's
+in the members group"; everyone is "is `hub-members` one of the members."
+
+---
+
+## 3. Required Changes
+
+### 3.1 Narrow the global read-all grant (the core subtractive step)
+
+`hub-member-read-all` must stop granting read on membership-gated resource types.
+Per ptone: at minimum **projects, agents, brokers**.
+
+**Decision (ptone, 2026-06-05) — RESOLVED:**
+- **Mechanism (a):** replace the `"*"` allow with **explicit per-type read/list
+  allow policies**, only for the types that stay hub-readable. (Rejected the
+  keep-wildcard-with-denies approach.)
+- **GATE (membership-derived, removed from global read):** project, agent, broker.
+- **KEEP globally member-readable (directory/catalog):** user, group, template,
+  harness_config. (template/harness_config later honor their own visibility +
+  grove attachment — OQ9.)
+- **SENSITIVE — tighten now:** policy, gcp_service_account, secret / environment /
+  variable. These were world-readable via the wildcard and should not be. Per
+  ptone, the project-scoped sensitive resources should derive access from the
+  project(s) they're associated with (same membership-gating as agents), and many
+  have no UI outside project settings anyway — so project-membership-scoped read
+  is the right model for them; hub-level ones (e.g. global policies) go
+  admin/owner-only.
+
+### 3.2 Add project-scoped read for members (required, not optional)
+
+The per-project members policy currently grants only `agent: create, stop_all`
+(`project:<slug>:member-create-agents`) — **not read**. Members can read today
+*only* because of the global grant. After 3.1, we must add a project-scoped read
+grant so members keep visibility into their own projects:
+
+```
+scope=project, scopeID=<project>, resourceType=project|agent, actions=[read,list],
+effect=allow  → bound to project:<slug>:members group
+```
+
+When `hub-members` is added to the project (everyone/public), it inherits this
+same read grant → all hub users can read that project. This is exactly the "add
+the all-users group to a role" model.
+
+### 3.3 Read-only role tier (the "everyone is safe" prerequisite) — RESOLVED → B
+
+**Decision (ptone, 2026-06-05): Option B — role-aware policies on the single
+members group**, keeping one group / one Members panel / one source of truth.
+Three roles to start (explicitly noted as a starting point; fine-grained
+permissions may be refined later):
+
+| Role | Grants |
+|------|--------|
+| **member** | read-only (read/list project + its agents) |
+| **admin** | member + create/manage agents (today's "member-create-agents") |
+| **owner** | admin + manage membership and visibility |
+
+**Enforcement decision (ptone, 2026-06-05): subtractive-only for now.** The policy
+engine cannot condition a `PolicyBinding` on a member's role today
+(`PolicyBinding` is `(PrincipalType, PrincipalID)` only; `GetEffectiveGroups`
+returns group IDs, dropping role). Rather than extend the engine, we reuse the
+existing `isProjectOwnerOrAdmin` role bypass (`pkg/hub/authz.go`, already checks
+`role==admin||owner`): read is granted by a project-scoped policy bound to the
+members group (all roles read), and `create/stop_all` is **removed** from that
+policy so create/manage flows from the admin/owner bypass. No policy-engine change.
+This is why existing members are bumped to `admin` on migration.
+
+> **Future improvement (deferred):** make policies genuinely role-aware by adding a
+> `role` field to `PolicyBinding`, carrying role through `GetEffectiveGroups`, and
+> filtering on it during policy evaluation. This would let role survive group
+> nesting (the subtractive approach's one gap: a user who is admin only via a
+> *nested* team group gets read but not create) and enable finer per-action grants.
+> Not required to meet this design; revisit when nested-admin or per-action
+> permissions are needed.
+
+Implications:
+- "everyone/public" = add `hub-members` at role=**member** (read-only) — safe.
+- Read-only sharing of an individual/group = add at role=member; collaborators who
+  can act = admin.
+- **Migration cost:** existing members currently get create-agent via the members
+  policy; to preserve that, bump existing `member` rows to `admin` during rollout
+  (one-time backfill). New default for added members is read-only.
+- The per-project policy set becomes role-conditioned (read bound to all roles;
+  create/stop bound to admin+owner; member/visibility management to owner).
+
+### 3.4 Close the two enforcement gaps
+
+- `getProject` (single GET by id) does **not** enforce read today — add a
+  `CheckAccess(ActionRead)` gate. Same for single-agent GET if similarly open.
+- `listProjects`/`listAgents` return everything when identity is nil. **RESOLVED
+  (OQ8): fail closed** — a nil/unauthenticated identity sees nothing (empty/401);
+  authentication is always required. No anonymous read surface.
+
+### 3.5 Cross-project agent list filtering + performance
+
+The top-level agent list must return only agents in projects the user can see
+(member/owner) **plus** agents in "everyone" projects. Findings:
+
+- `AgentFilter.MemberProjectIDs` already pushes a `project_id IN (...)` predicate
+  into SQL — good. The handler already computes `resolveUserProjectIDs` and
+  applies it for `scope=shared`; we extend it to the default scope.
+- **Missing index:** the agents table only has a composite unique
+  `(slug, project_id)` index; there is no standalone `project_id` index. Add
+  `index.Fields("project_id")` — cheap, makes the IN filter efficient.
+- `resolveUserProjectIDs` cost is the BFS in `GetEffectiveGroups` (≈2–15 queries
+  depending on group nesting) + `GetGroupsByIDs`. Compute once per request and
+  cache in request context.
+- **Agent-list scope (RESOLVED → A, ptone 2026-06-05):** the top-level
+  cross-project agent list shows only agents in projects the caller is a
+  member/owner of — `WHERE project_id IN (your project set)`. **No denormalization
+  needed.** Agents in "everyone"/hub-members projects the caller hasn't joined are
+  still fully readable on demand via the per-project agent list and single-agent
+  GET (both use derived project read); they simply don't appear in the personal
+  cross-project firehose.
+- Concrete plan: (1) always apply `MemberProjectIDs` for the default scope (not
+  just `scope=shared`); (2) add `index.Fields("project_id")` to the agent schema;
+  (3) cache `resolveUserProjectIDs` once per request in context.
+- Pagination stays honest because filtering is in SQL (no post-hoc drop), so
+  `totalCount` and cursors remain accurate.
+
+### 3.6 Retire the creation-time visibility input (RESOLVED)
+
+**Decision (ptone, 2026-06-05):** Remove the visibility selector from the
+create-project dialog entirely, and retire the user-facing term "public." New
+projects default to creator-only (private by emergence). "Everyone" visibility is
+achieved post-creation by adding the `hub-members` group as a member (OQ4,
+option 1). The project-settings **Members card** gets a small hint, e.g. "To make
+this project visible to all hub users, add the hub-members group." The DB
+`visibility` column is no longer authored by the user; it may be retired or
+repurposed only as a derived cache feeding §3.5's denormalized agent flag (see
+OQ5).
+
+---
+
+### 3.7 Agents derive from project (RESOLVED)
+
+**Decision (ptone, 2026-06-05): agents are team members.** Agent read access is
+derived entirely from the parent project — if you can read the project, you see
+all its agents; otherwise none. The per-agent `visibility` field (currently inert,
+hardcoded "private") is dropped. Owner bypass still lets a creator see their own
+agent; admin/owner roles still gate create/stop/manage. This removes the
+project-vs-agent visibility-ceiling rules from the old design. It also simplifies
+the cross-project agent list (§3.5): an agent's readability == its project's
+readability, which is what makes the denormalized `project_public` flag on agents
+(OQ5) a complete predicate.
+
+## 4. Brokers (RESOLVED → a)
+
+**Decision (ptone, 2026-06-05):** Brokers are hub-level and linked to projects
+many-to-many via `ProjectContributor`. Broker **read = owner + hub admins +
+members of ANY project the broker contributes to** (resolve via
+`ProjectContributor`). Read-only for plain members; create/attach/manage stays
+admin/owner-gated.
+- Cross-broker list scopes the same way (brokers you own + brokers contributing to
+  a project you're a member of) — analogous to the agent-list filter but keyed off
+  the broker↔project link table; add a filter and likely an index on
+  `ProjectContributor`.
+- A freshly-registered broker not yet linked to any project is visible to its
+  owner/registrant and admins only until attached.
+
+---
+
+## 5. Open Questions (to resolve one-by-one)
+
+- **OQ1 — Scope of read-all narrowing.** RESOLVED → explicit per-type allows;
+  GATE {project, agent, broker}; KEEP {user, group, template, harness_config};
+  tighten sensitive {policy, gcp_service_account, secret/env/variable} now —
+  project-scoped ones derive from associated-project membership, hub-level ones
+  admin/owner-only. See §3.1.
+- **OQ2 — Read-only tier shape.** RESOLVED → B (role-aware single members group;
+  member=read-only, admin=create/manage, owner=full). Migrate existing members →
+  admin. See §3.3.
+- **OQ3 — Agent access derivation.** RESOLVED → agents are team members. Agent read
+  derives purely from project membership (read the project ⇒ see all its agents);
+  drop the inert per-agent visibility field. Creator/owner bypass still applies;
+  admin/owner roles still gate create/stop/manage. See §3.7.
+- **OQ4 — Everyone/public maintenance.** RESOLVED → option 1: "everyone" is the
+  `hub-members` group added as a real member row (role=member). The word "public"
+  is retired and the visibility dropdown is removed from project creation. The
+  Members card gets a hint: "to make this visible to all hub users, add the
+  hub-members group." See §3.6.
+- **OQ5 — Denormalization for the agent list.** RESOLVED → A: top-level list =
+  caller's projects only (`project_id IN (mine)`); no denormalization. Add the
+  `project_id` index; cache `resolveUserProjectIDs` per request. "Everyone"
+  projects' agents readable on demand via project/single-agent views. See §3.5.
+- **OQ6 — Broker visibility model.** RESOLVED → a: broker read = owner + admins +
+  members of any contributing project; list scoped the same way. See §4.
+- **OQ7 — Terminology.** RESOLVED (dissolved by OQ4/OQ6): the visibility dropdown
+  is removed and "public" is retired, so there are no user-facing visibility-level
+  labels left to rename. User-facing vocabulary is now just project roles
+  (member/admin/owner) and the informal "all hub users" in the Members-card hint.
+  The legacy `visibility` constants/column become internal-only/retired.
+- **OQ8 — Unauthenticated access.** RESOLVED → fail closed: nil/unauthenticated
+  identity sees nothing (empty/401); auth always required; no anonymous read. See
+  §3.4.
+- **OQ9 — Other visibility-bearing resources.** RESOLVED → DEFER. Templates &
+  harness configs (visibility + grove-attachment semantics) are out of scope for
+  this pass and get their own follow-up design. They stay globally listable for
+  now (KEEP list, §3.1) so nothing breaks. Separately, ptone asked to spin up a
+  dedicated agent to clean up legacy "grove" terminology in this area (see note
+  below).
+
+> **Follow-up agent (grove→project cleanup):** spawned to assess/clean legacy
+> "grove" references — primarily the Template/HarnessConfig visibility middle-tier
+> value `"grove"` (→ `team`/`project`), and to evaluate the broader
+> `groveId/groveName/grove/grovePath` JSON aliases in `pkg/store/models.go`,
+> `pkg/api/types.go`, `pkg/hub/template_handlers.go`. Caution: many of those JSON
+> tags are intentional wire backward-compat — rename cosmetic/internal uses, but
+> flag (don't silently remove) anything that changes the API wire format.
+
+---
+
+## 6. Migration Notes
+
+- Removing `hub-member-read-all` (for the 3 types) is the only behavior-changing
+  step; everything else is additive (new project-scoped read grants, index,
+  resolver caching).
+- Existing projects: backfill the project-scoped member read policy (idempotent,
+  alongside the existing `createProjectMembersGroupAndPolicy`).
+- No user-facing visibility data migration needed if the column is retired; if
+  repurposed as a cache, derive it from membership on first access.
+
+---
+
+## 7. References
+
+- `access-visibility.md` — prior (stored-enum) design + inline ptone feedback.
+- `pkg/hub/seed.go` — `hub-member-read-all`, `hub-members`, `ensureHubMembership`.
+- `pkg/hub/authz.go` — CheckAccess flow, effective-group resolution.
+- `pkg/hub/handlers.go` — listProjects/listAgents, getProject, resolveUserProjectIDs,
+  createProjectMembersGroupAndPolicy.
+- `pkg/store/entadapter/{group_store,agent_store,project_store}.go` — filters,
+  GetEffectiveGroups, indexes.
+- `pkg/ent/schema/{group,agent,project}.go` — schemas/indexes.

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -243,7 +243,6 @@ func hubAgentToAgentInfo(a hubclient.Agent) api.AgentInfo {
 		DeletedAt:         a.DeletedAt,
 		CreatedBy:         a.CreatedBy,
 		OwnerID:           a.OwnerID,
-		Visibility:        a.Visibility,
 		StateVersion:      a.StateVersion,
 	}
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -814,6 +814,17 @@ const (
 	VisibilityPublic  = "public"  // Anyone can access (read-only)
 )
 
+// NormalizeVisibility maps legacy visibility values to their canonical form.
+// "grove" and "project" are accepted as aliases for "team" for backward compatibility.
+func NormalizeVisibility(v string) string {
+	switch v {
+	case "grove", "project":
+		return VisibilityTeam
+	default:
+		return v
+	}
+}
+
 // ProjectInfo contains metadata about a project (project/agent group).
 // It supports both local/solo mode and hosted/distributed mode.
 type ProjectInfo struct {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -568,10 +568,9 @@ type AgentInfo struct {
 	DeletedAt time.Time `json:"deletedAt,omitempty"` // When the agent was soft-deleted
 
 	// Ownership & access
-	CreatedBy  string   `json:"createdBy,omitempty"`  // User/system that created the agent
-	OwnerID    string   `json:"ownerId,omitempty"`    // Current owner user ID
-	Visibility string   `json:"visibility,omitempty"` // Access level: private, team, public
-	Ancestry   []string `json:"ancestry,omitempty"`   // Ordered ancestor chain [root, ..., parent] for transitive access
+	CreatedBy string   `json:"createdBy,omitempty"` // User/system that created the agent
+	OwnerID   string   `json:"ownerId,omitempty"`   // Current owner user ID
+	Ancestry  []string `json:"ancestry,omitempty"`  // Ordered ancestor chain [root, ..., parent] for transitive access
 
 	// Hosted/distributed mode fields
 	RuntimeBrokerID   string `json:"runtimeBrokerId,omitempty"`   // ID of the Runtime Broker managing this agent

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -486,3 +486,23 @@ func TestScionConfig_ParseMaxDuration(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeVisibility(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"private", "private"},
+		{"team", "team"},
+		{"public", "public"},
+		{"grove", "team"},
+		{"project", "team"},
+		{"", ""},
+		{"unknown", "unknown"},
+	}
+	for _, tt := range tests {
+		if got := NormalizeVisibility(tt.input); got != tt.want {
+			t.Errorf("NormalizeVisibility(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/pkg/ent/agent.go
+++ b/pkg/ent/agent.go
@@ -36,8 +36,6 @@ type Agent struct {
 	OwnerID *uuid.UUID `json:"owner_id,omitempty"`
 	// DelegationEnabled holds the value of the "delegation_enabled" field.
 	DelegationEnabled bool `json:"delegation_enabled,omitempty"`
-	// Visibility holds the value of the "visibility" field.
-	Visibility string `json:"visibility,omitempty"`
 	// Labels holds the value of the "labels" field.
 	Labels map[string]string `json:"labels,omitempty"`
 	// Annotations holds the value of the "annotations" field.
@@ -153,7 +151,7 @@ func (*Agent) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullBool)
 		case agent.FieldCurrentTurns, agent.FieldCurrentModelCalls, agent.FieldStateVersion:
 			values[i] = new(sql.NullInt64)
-		case agent.FieldSlug, agent.FieldName, agent.FieldTemplate, agent.FieldStatus, agent.FieldVisibility, agent.FieldPhase, agent.FieldActivity, agent.FieldToolName, agent.FieldConnectionState, agent.FieldContainerStatus, agent.FieldRuntimeState, agent.FieldStalledFromActivity, agent.FieldImage, agent.FieldRuntime, agent.FieldRuntimeBrokerID, agent.FieldTaskSummary, agent.FieldMessage, agent.FieldAppliedConfig:
+		case agent.FieldSlug, agent.FieldName, agent.FieldTemplate, agent.FieldStatus, agent.FieldPhase, agent.FieldActivity, agent.FieldToolName, agent.FieldConnectionState, agent.FieldContainerStatus, agent.FieldRuntimeState, agent.FieldStalledFromActivity, agent.FieldImage, agent.FieldRuntime, agent.FieldRuntimeBrokerID, agent.FieldTaskSummary, agent.FieldMessage, agent.FieldAppliedConfig:
 			values[i] = new(sql.NullString)
 		case agent.FieldCreated, agent.FieldUpdated, agent.FieldLastSeen, agent.FieldLastActivityEvent, agent.FieldStartedAt, agent.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -229,12 +227,6 @@ func (_m *Agent) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field delegation_enabled", values[i])
 			} else if value.Valid {
 				_m.DelegationEnabled = value.Bool
-			}
-		case agent.FieldVisibility:
-			if value, ok := values[i].(*sql.NullString); !ok {
-				return fmt.Errorf("unexpected type %T for field visibility", values[i])
-			} else if value.Valid {
-				_m.Visibility = value.String
 			}
 		case agent.FieldLabels:
 			if value, ok := values[i].(*[]byte); !ok {
@@ -486,9 +478,6 @@ func (_m *Agent) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("delegation_enabled=")
 	builder.WriteString(fmt.Sprintf("%v", _m.DelegationEnabled))
-	builder.WriteString(", ")
-	builder.WriteString("visibility=")
-	builder.WriteString(_m.Visibility)
 	builder.WriteString(", ")
 	builder.WriteString("labels=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Labels))

--- a/pkg/ent/agent/agent.go
+++ b/pkg/ent/agent/agent.go
@@ -32,8 +32,6 @@ const (
 	FieldOwnerID = "owner_id"
 	// FieldDelegationEnabled holds the string denoting the delegation_enabled field in the database.
 	FieldDelegationEnabled = "delegation_enabled"
-	// FieldVisibility holds the string denoting the visibility field in the database.
-	FieldVisibility = "visibility"
 	// FieldLabels holds the string denoting the labels field in the database.
 	FieldLabels = "labels"
 	// FieldAnnotations holds the string denoting the annotations field in the database.
@@ -130,7 +128,6 @@ var Columns = []string{
 	FieldCreatedBy,
 	FieldOwnerID,
 	FieldDelegationEnabled,
-	FieldVisibility,
 	FieldLabels,
 	FieldAnnotations,
 	FieldPhase,
@@ -177,8 +174,6 @@ var (
 	NameValidator func(string) error
 	// DefaultDelegationEnabled holds the default value on creation for the "delegation_enabled" field.
 	DefaultDelegationEnabled bool
-	// DefaultVisibility holds the default value on creation for the "visibility" field.
-	DefaultVisibility string
 	// DefaultCurrentTurns holds the default value on creation for the "current_turns" field.
 	DefaultCurrentTurns int
 	// DefaultCurrentModelCalls holds the default value on creation for the "current_model_calls" field.
@@ -278,11 +273,6 @@ func ByOwnerID(opts ...sql.OrderTermOption) OrderOption {
 // ByDelegationEnabled orders the results by the delegation_enabled field.
 func ByDelegationEnabled(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDelegationEnabled, opts...).ToFunc()
-}
-
-// ByVisibility orders the results by the visibility field.
-func ByVisibility(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldVisibility, opts...).ToFunc()
 }
 
 // ByPhase orders the results by the phase field.

--- a/pkg/ent/agent/where.go
+++ b/pkg/ent/agent/where.go
@@ -91,11 +91,6 @@ func DelegationEnabled(v bool) predicate.Agent {
 	return predicate.Agent(sql.FieldEQ(FieldDelegationEnabled, v))
 }
 
-// Visibility applies equality check predicate on the "visibility" field. It's identical to VisibilityEQ.
-func Visibility(v string) predicate.Agent {
-	return predicate.Agent(sql.FieldEQ(FieldVisibility, v))
-}
-
 // Phase applies equality check predicate on the "phase" field. It's identical to PhaseEQ.
 func Phase(v string) predicate.Agent {
 	return predicate.Agent(sql.FieldEQ(FieldPhase, v))
@@ -569,71 +564,6 @@ func DelegationEnabledEQ(v bool) predicate.Agent {
 // DelegationEnabledNEQ applies the NEQ predicate on the "delegation_enabled" field.
 func DelegationEnabledNEQ(v bool) predicate.Agent {
 	return predicate.Agent(sql.FieldNEQ(FieldDelegationEnabled, v))
-}
-
-// VisibilityEQ applies the EQ predicate on the "visibility" field.
-func VisibilityEQ(v string) predicate.Agent {
-	return predicate.Agent(sql.FieldEQ(FieldVisibility, v))
-}
-
-// VisibilityNEQ applies the NEQ predicate on the "visibility" field.
-func VisibilityNEQ(v string) predicate.Agent {
-	return predicate.Agent(sql.FieldNEQ(FieldVisibility, v))
-}
-
-// VisibilityIn applies the In predicate on the "visibility" field.
-func VisibilityIn(vs ...string) predicate.Agent {
-	return predicate.Agent(sql.FieldIn(FieldVisibility, vs...))
-}
-
-// VisibilityNotIn applies the NotIn predicate on the "visibility" field.
-func VisibilityNotIn(vs ...string) predicate.Agent {
-	return predicate.Agent(sql.FieldNotIn(FieldVisibility, vs...))
-}
-
-// VisibilityGT applies the GT predicate on the "visibility" field.
-func VisibilityGT(v string) predicate.Agent {
-	return predicate.Agent(sql.FieldGT(FieldVisibility, v))
-}
-
-// VisibilityGTE applies the GTE predicate on the "visibility" field.
-func VisibilityGTE(v string) predicate.Agent {
-	return predicate.Agent(sql.FieldGTE(FieldVisibility, v))
-}
-
-// VisibilityLT applies the LT predicate on the "visibility" field.
-func VisibilityLT(v string) predicate.Agent {
-	return predicate.Agent(sql.FieldLT(FieldVisibility, v))
-}
-
-// VisibilityLTE applies the LTE predicate on the "visibility" field.
-func VisibilityLTE(v string) predicate.Agent {
-	return predicate.Agent(sql.FieldLTE(FieldVisibility, v))
-}
-
-// VisibilityContains applies the Contains predicate on the "visibility" field.
-func VisibilityContains(v string) predicate.Agent {
-	return predicate.Agent(sql.FieldContains(FieldVisibility, v))
-}
-
-// VisibilityHasPrefix applies the HasPrefix predicate on the "visibility" field.
-func VisibilityHasPrefix(v string) predicate.Agent {
-	return predicate.Agent(sql.FieldHasPrefix(FieldVisibility, v))
-}
-
-// VisibilityHasSuffix applies the HasSuffix predicate on the "visibility" field.
-func VisibilityHasSuffix(v string) predicate.Agent {
-	return predicate.Agent(sql.FieldHasSuffix(FieldVisibility, v))
-}
-
-// VisibilityEqualFold applies the EqualFold predicate on the "visibility" field.
-func VisibilityEqualFold(v string) predicate.Agent {
-	return predicate.Agent(sql.FieldEqualFold(FieldVisibility, v))
-}
-
-// VisibilityContainsFold applies the ContainsFold predicate on the "visibility" field.
-func VisibilityContainsFold(v string) predicate.Agent {
-	return predicate.Agent(sql.FieldContainsFold(FieldVisibility, v))
 }
 
 // LabelsIsNil applies the IsNil predicate on the "labels" field.

--- a/pkg/ent/agent_create.go
+++ b/pkg/ent/agent_create.go
@@ -115,20 +115,6 @@ func (_c *AgentCreate) SetNillableDelegationEnabled(v *bool) *AgentCreate {
 	return _c
 }
 
-// SetVisibility sets the "visibility" field.
-func (_c *AgentCreate) SetVisibility(v string) *AgentCreate {
-	_c.mutation.SetVisibility(v)
-	return _c
-}
-
-// SetNillableVisibility sets the "visibility" field if the given value is not nil.
-func (_c *AgentCreate) SetNillableVisibility(v *string) *AgentCreate {
-	if v != nil {
-		_c.SetVisibility(*v)
-	}
-	return _c
-}
-
 // SetLabels sets the "labels" field.
 func (_c *AgentCreate) SetLabels(v map[string]string) *AgentCreate {
 	_c.mutation.SetLabels(v)
@@ -575,10 +561,6 @@ func (_c *AgentCreate) defaults() {
 		v := agent.DefaultDelegationEnabled
 		_c.mutation.SetDelegationEnabled(v)
 	}
-	if _, ok := _c.mutation.Visibility(); !ok {
-		v := agent.DefaultVisibility
-		_c.mutation.SetVisibility(v)
-	}
 	if _, ok := _c.mutation.CurrentTurns(); !ok {
 		v := agent.DefaultCurrentTurns
 		_c.mutation.SetCurrentTurns(v)
@@ -644,9 +626,6 @@ func (_c *AgentCreate) check() error {
 	}
 	if _, ok := _c.mutation.DelegationEnabled(); !ok {
 		return &ValidationError{Name: "delegation_enabled", err: errors.New(`ent: missing required field "Agent.delegation_enabled"`)}
-	}
-	if _, ok := _c.mutation.Visibility(); !ok {
-		return &ValidationError{Name: "visibility", err: errors.New(`ent: missing required field "Agent.visibility"`)}
 	}
 	if _, ok := _c.mutation.CurrentTurns(); !ok {
 		return &ValidationError{Name: "current_turns", err: errors.New(`ent: missing required field "Agent.current_turns"`)}
@@ -735,10 +714,6 @@ func (_c *AgentCreate) createSpec() (*Agent, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.DelegationEnabled(); ok {
 		_spec.SetField(agent.FieldDelegationEnabled, field.TypeBool, value)
 		_node.DelegationEnabled = value
-	}
-	if value, ok := _c.mutation.Visibility(); ok {
-		_spec.SetField(agent.FieldVisibility, field.TypeString, value)
-		_node.Visibility = value
 	}
 	if value, ok := _c.mutation.Labels(); ok {
 		_spec.SetField(agent.FieldLabels, field.TypeJSON, value)
@@ -1060,18 +1035,6 @@ func (u *AgentUpsert) SetDelegationEnabled(v bool) *AgentUpsert {
 // UpdateDelegationEnabled sets the "delegation_enabled" field to the value that was provided on create.
 func (u *AgentUpsert) UpdateDelegationEnabled() *AgentUpsert {
 	u.SetExcluded(agent.FieldDelegationEnabled)
-	return u
-}
-
-// SetVisibility sets the "visibility" field.
-func (u *AgentUpsert) SetVisibility(v string) *AgentUpsert {
-	u.Set(agent.FieldVisibility, v)
-	return u
-}
-
-// UpdateVisibility sets the "visibility" field to the value that was provided on create.
-func (u *AgentUpsert) UpdateVisibility() *AgentUpsert {
-	u.SetExcluded(agent.FieldVisibility)
 	return u
 }
 
@@ -1706,20 +1669,6 @@ func (u *AgentUpsertOne) SetDelegationEnabled(v bool) *AgentUpsertOne {
 func (u *AgentUpsertOne) UpdateDelegationEnabled() *AgentUpsertOne {
 	return u.Update(func(s *AgentUpsert) {
 		s.UpdateDelegationEnabled()
-	})
-}
-
-// SetVisibility sets the "visibility" field.
-func (u *AgentUpsertOne) SetVisibility(v string) *AgentUpsertOne {
-	return u.Update(func(s *AgentUpsert) {
-		s.SetVisibility(v)
-	})
-}
-
-// UpdateVisibility sets the "visibility" field to the value that was provided on create.
-func (u *AgentUpsertOne) UpdateVisibility() *AgentUpsertOne {
-	return u.Update(func(s *AgentUpsert) {
-		s.UpdateVisibility()
 	})
 }
 
@@ -2596,20 +2545,6 @@ func (u *AgentUpsertBulk) SetDelegationEnabled(v bool) *AgentUpsertBulk {
 func (u *AgentUpsertBulk) UpdateDelegationEnabled() *AgentUpsertBulk {
 	return u.Update(func(s *AgentUpsert) {
 		s.UpdateDelegationEnabled()
-	})
-}
-
-// SetVisibility sets the "visibility" field.
-func (u *AgentUpsertBulk) SetVisibility(v string) *AgentUpsertBulk {
-	return u.Update(func(s *AgentUpsert) {
-		s.SetVisibility(v)
-	})
-}
-
-// UpdateVisibility sets the "visibility" field to the value that was provided on create.
-func (u *AgentUpsertBulk) UpdateVisibility() *AgentUpsertBulk {
-	return u.Update(func(s *AgentUpsert) {
-		s.UpdateVisibility()
 	})
 }
 

--- a/pkg/ent/agent_update.go
+++ b/pkg/ent/agent_update.go
@@ -163,20 +163,6 @@ func (_u *AgentUpdate) SetNillableDelegationEnabled(v *bool) *AgentUpdate {
 	return _u
 }
 
-// SetVisibility sets the "visibility" field.
-func (_u *AgentUpdate) SetVisibility(v string) *AgentUpdate {
-	_u.mutation.SetVisibility(v)
-	return _u
-}
-
-// SetNillableVisibility sets the "visibility" field if the given value is not nil.
-func (_u *AgentUpdate) SetNillableVisibility(v *string) *AgentUpdate {
-	if v != nil {
-		_u.SetVisibility(*v)
-	}
-	return _u
-}
-
 // SetLabels sets the "labels" field.
 func (_u *AgentUpdate) SetLabels(v map[string]string) *AgentUpdate {
 	_u.mutation.SetLabels(v)
@@ -845,9 +831,6 @@ func (_u *AgentUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	if value, ok := _u.mutation.DelegationEnabled(); ok {
 		_spec.SetField(agent.FieldDelegationEnabled, field.TypeBool, value)
 	}
-	if value, ok := _u.mutation.Visibility(); ok {
-		_spec.SetField(agent.FieldVisibility, field.TypeString, value)
-	}
 	if value, ok := _u.mutation.Labels(); ok {
 		_spec.SetField(agent.FieldLabels, field.TypeJSON, value)
 	}
@@ -1265,20 +1248,6 @@ func (_u *AgentUpdateOne) SetDelegationEnabled(v bool) *AgentUpdateOne {
 func (_u *AgentUpdateOne) SetNillableDelegationEnabled(v *bool) *AgentUpdateOne {
 	if v != nil {
 		_u.SetDelegationEnabled(*v)
-	}
-	return _u
-}
-
-// SetVisibility sets the "visibility" field.
-func (_u *AgentUpdateOne) SetVisibility(v string) *AgentUpdateOne {
-	_u.mutation.SetVisibility(v)
-	return _u
-}
-
-// SetNillableVisibility sets the "visibility" field if the given value is not nil.
-func (_u *AgentUpdateOne) SetNillableVisibility(v *string) *AgentUpdateOne {
-	if v != nil {
-		_u.SetVisibility(*v)
 	}
 	return _u
 }
@@ -1980,9 +1949,6 @@ func (_u *AgentUpdateOne) sqlSave(ctx context.Context) (_node *Agent, err error)
 	}
 	if value, ok := _u.mutation.DelegationEnabled(); ok {
 		_spec.SetField(agent.FieldDelegationEnabled, field.TypeBool, value)
-	}
-	if value, ok := _u.mutation.Visibility(); ok {
-		_spec.SetField(agent.FieldVisibility, field.TypeString, value)
 	}
 	if value, ok := _u.mutation.Labels(); ok {
 		_spec.SetField(agent.FieldLabels, field.TypeJSON, value)

--- a/pkg/ent/migrate/schema.go
+++ b/pkg/ent/migrate/schema.go
@@ -44,7 +44,6 @@ var (
 		{Name: "created_by", Type: field.TypeUUID, Nullable: true},
 		{Name: "owner_id", Type: field.TypeUUID, Nullable: true},
 		{Name: "delegation_enabled", Type: field.TypeBool, Default: false},
-		{Name: "visibility", Type: field.TypeString, Default: "private"},
 		{Name: "labels", Type: field.TypeJSON, Nullable: true},
 		{Name: "annotations", Type: field.TypeJSON, Nullable: true},
 		{Name: "phase", Type: field.TypeString, Nullable: true},
@@ -82,7 +81,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "agents_projects_agents",
-				Columns:    []*schema.Column{AgentsColumns[36]},
+				Columns:    []*schema.Column{AgentsColumns[35]},
 				RefColumns: []*schema.Column{ProjectsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -91,7 +90,12 @@ var (
 			{
 				Name:    "agent_slug_project_id",
 				Unique:  true,
-				Columns: []*schema.Column{AgentsColumns[1], AgentsColumns[36]},
+				Columns: []*schema.Column{AgentsColumns[1], AgentsColumns[35]},
+			},
+			{
+				Name:    "agent_project_id",
+				Unique:  false,
+				Columns: []*schema.Column{AgentsColumns[35]},
 			},
 		},
 	}

--- a/pkg/ent/mutation.go
+++ b/pkg/ent/mutation.go
@@ -1491,7 +1491,6 @@ type AgentMutation struct {
 	created_by             *uuid.UUID
 	owner_id               *uuid.UUID
 	delegation_enabled     *bool
-	visibility             *string
 	labels                 *map[string]string
 	annotations            *map[string]string
 	phase                  *string
@@ -1966,42 +1965,6 @@ func (m *AgentMutation) OldDelegationEnabled(ctx context.Context) (v bool, err e
 // ResetDelegationEnabled resets all changes to the "delegation_enabled" field.
 func (m *AgentMutation) ResetDelegationEnabled() {
 	m.delegation_enabled = nil
-}
-
-// SetVisibility sets the "visibility" field.
-func (m *AgentMutation) SetVisibility(s string) {
-	m.visibility = &s
-}
-
-// Visibility returns the value of the "visibility" field in the mutation.
-func (m *AgentMutation) Visibility() (r string, exists bool) {
-	v := m.visibility
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldVisibility returns the old "visibility" field's value of the Agent entity.
-// If the Agent object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *AgentMutation) OldVisibility(ctx context.Context) (v string, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldVisibility is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldVisibility requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldVisibility: %w", err)
-	}
-	return oldValue.Visibility, nil
-}
-
-// ResetVisibility resets all changes to the "visibility" field.
-func (m *AgentMutation) ResetVisibility() {
-	m.visibility = nil
 }
 
 // SetLabels sets the "labels" field.
@@ -3481,7 +3444,7 @@ func (m *AgentMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *AgentMutation) Fields() []string {
-	fields := make([]string, 0, 36)
+	fields := make([]string, 0, 35)
 	if m.slug != nil {
 		fields = append(fields, agent.FieldSlug)
 	}
@@ -3505,9 +3468,6 @@ func (m *AgentMutation) Fields() []string {
 	}
 	if m.delegation_enabled != nil {
 		fields = append(fields, agent.FieldDelegationEnabled)
-	}
-	if m.visibility != nil {
-		fields = append(fields, agent.FieldVisibility)
 	}
 	if m.labels != nil {
 		fields = append(fields, agent.FieldLabels)
@@ -3614,8 +3574,6 @@ func (m *AgentMutation) Field(name string) (ent.Value, bool) {
 		return m.OwnerID()
 	case agent.FieldDelegationEnabled:
 		return m.DelegationEnabled()
-	case agent.FieldVisibility:
-		return m.Visibility()
 	case agent.FieldLabels:
 		return m.Labels()
 	case agent.FieldAnnotations:
@@ -3695,8 +3653,6 @@ func (m *AgentMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldOwnerID(ctx)
 	case agent.FieldDelegationEnabled:
 		return m.OldDelegationEnabled(ctx)
-	case agent.FieldVisibility:
-		return m.OldVisibility(ctx)
 	case agent.FieldLabels:
 		return m.OldLabels(ctx)
 	case agent.FieldAnnotations:
@@ -3815,13 +3771,6 @@ func (m *AgentMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetDelegationEnabled(v)
-		return nil
-	case agent.FieldVisibility:
-		v, ok := value.(string)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetVisibility(v)
 		return nil
 	case agent.FieldLabels:
 		v, ok := value.(map[string]string)
@@ -4264,9 +4213,6 @@ func (m *AgentMutation) ResetField(name string) error {
 		return nil
 	case agent.FieldDelegationEnabled:
 		m.ResetDelegationEnabled()
-		return nil
-	case agent.FieldVisibility:
-		m.ResetVisibility()
 		return nil
 	case agent.FieldLabels:
 		m.ResetLabels()

--- a/pkg/ent/runtime.go
+++ b/pkg/ent/runtime.go
@@ -86,38 +86,34 @@ func init() {
 	agentDescDelegationEnabled := agentFields[8].Descriptor()
 	// agent.DefaultDelegationEnabled holds the default value on creation for the delegation_enabled field.
 	agent.DefaultDelegationEnabled = agentDescDelegationEnabled.Default.(bool)
-	// agentDescVisibility is the schema descriptor for visibility field.
-	agentDescVisibility := agentFields[9].Descriptor()
-	// agent.DefaultVisibility holds the default value on creation for the visibility field.
-	agent.DefaultVisibility = agentDescVisibility.Default.(string)
 	// agentDescCurrentTurns is the schema descriptor for current_turns field.
-	agentDescCurrentTurns := agentFields[19].Descriptor()
+	agentDescCurrentTurns := agentFields[18].Descriptor()
 	// agent.DefaultCurrentTurns holds the default value on creation for the current_turns field.
 	agent.DefaultCurrentTurns = agentDescCurrentTurns.Default.(int)
 	// agentDescCurrentModelCalls is the schema descriptor for current_model_calls field.
-	agentDescCurrentModelCalls := agentFields[20].Descriptor()
+	agentDescCurrentModelCalls := agentFields[19].Descriptor()
 	// agent.DefaultCurrentModelCalls holds the default value on creation for the current_model_calls field.
 	agent.DefaultCurrentModelCalls = agentDescCurrentModelCalls.Default.(int)
 	// agentDescDetached is the schema descriptor for detached field.
-	agentDescDetached := agentFields[22].Descriptor()
+	agentDescDetached := agentFields[21].Descriptor()
 	// agent.DefaultDetached holds the default value on creation for the detached field.
 	agent.DefaultDetached = agentDescDetached.Default.(bool)
 	// agentDescWebPtyEnabled is the schema descriptor for web_pty_enabled field.
-	agentDescWebPtyEnabled := agentFields[25].Descriptor()
+	agentDescWebPtyEnabled := agentFields[24].Descriptor()
 	// agent.DefaultWebPtyEnabled holds the default value on creation for the web_pty_enabled field.
 	agent.DefaultWebPtyEnabled = agentDescWebPtyEnabled.Default.(bool)
 	// agentDescCreated is the schema descriptor for created field.
-	agentDescCreated := agentFields[30].Descriptor()
+	agentDescCreated := agentFields[29].Descriptor()
 	// agent.DefaultCreated holds the default value on creation for the created field.
 	agent.DefaultCreated = agentDescCreated.Default.(func() time.Time)
 	// agentDescUpdated is the schema descriptor for updated field.
-	agentDescUpdated := agentFields[31].Descriptor()
+	agentDescUpdated := agentFields[30].Descriptor()
 	// agent.DefaultUpdated holds the default value on creation for the updated field.
 	agent.DefaultUpdated = agentDescUpdated.Default.(func() time.Time)
 	// agent.UpdateDefaultUpdated holds the default value on update for the updated field.
 	agent.UpdateDefaultUpdated = agentDescUpdated.UpdateDefault.(func() time.Time)
 	// agentDescStateVersion is the schema descriptor for state_version field.
-	agentDescStateVersion := agentFields[36].Descriptor()
+	agentDescStateVersion := agentFields[35].Descriptor()
 	// agent.DefaultStateVersion holds the default value on creation for the state_version field.
 	agent.DefaultStateVersion = agentDescStateVersion.Default.(int64)
 	// agentDescID is the schema descriptor for id field.

--- a/pkg/ent/schema/agent.go
+++ b/pkg/ent/schema/agent.go
@@ -27,10 +27,10 @@ import (
 // Agent holds the schema definition for the Agent entity.
 //
 // The agent entity carries both the principal-relevant fields used by the
-// authorization layer (created_by, owner_id, delegation_enabled, visibility)
-// and the full set of operational fields required to back store.Agent through
-// the Ent adapter (P2-port-agent). Together they give the Ent-backed agent
-// store parity with the former raw-SQL store implementation.
+// authorization layer (created_by, owner_id, delegation_enabled) and the full
+// set of operational fields required to back store.Agent through the Ent
+// adapter (P2-port-agent). Together they give the Ent-backed agent store
+// parity with the former raw-SQL store implementation.
 type Agent struct {
 	ent.Schema
 }
@@ -66,9 +66,6 @@ func (Agent) Fields() []ent.Field {
 			Nillable(),
 		field.Bool("delegation_enabled").
 			Default(false),
-		field.String("visibility").
-			Default("private"),
-
 		// --- Metadata (stored as JSON) ---
 		field.JSON("labels", map[string]string{}).
 			Optional(),
@@ -175,5 +172,6 @@ func (Agent) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("slug", "project_id").
 			Unique(),
+		index.Fields("project_id"),
 	}
 }

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -729,7 +729,6 @@ func TestSyncToFinalize_BootstrapMode(t *testing.T) {
 		ProjectID:       projectID,
 		RuntimeBrokerID: tid("broker_bootstrap_test"),
 		Phase:           string(state.PhaseProvisioning),
-		Visibility:      store.VisibilityPrivate,
 		AppliedConfig: &store.AgentAppliedConfig{
 			Task: "test task",
 		},
@@ -815,7 +814,6 @@ func TestSyncToFinalize_BootstrapMode_MissingFile(t *testing.T) {
 		ProjectID:       projectID,
 		RuntimeBrokerID: tid("broker_bootstrap_test"),
 		Phase:           string(state.PhaseProvisioning),
-		Visibility:      store.VisibilityPrivate,
 	}
 	if err := s.CreateAgent(ctx, agent); err != nil {
 		t.Fatalf("failed to create agent: %v", err)
@@ -859,7 +857,6 @@ func TestSyncToFinalize_RejectsStoppedAgent(t *testing.T) {
 		ProjectID:       projectID,
 		RuntimeBrokerID: tid("broker_bootstrap_test"),
 		Phase:           string(state.PhaseStopped),
-		Visibility:      store.VisibilityPrivate,
 	}
 	if err := s.CreateAgent(ctx, agent); err != nil {
 		t.Fatalf("failed to create agent: %v", err)
@@ -909,7 +906,6 @@ func TestSyncToFinalize_BootstrapMode_NoDispatcher(t *testing.T) {
 		ProjectID:       projectID,
 		RuntimeBrokerID: tid("broker_bootstrap_test"),
 		Phase:           string(state.PhaseProvisioning),
-		Visibility:      store.VisibilityPrivate,
 	}
 	if err := s.CreateAgent(ctx, agent); err != nil {
 		t.Fatalf("failed to create agent: %v", err)

--- a/pkg/hub/demo_policy_test.go
+++ b/pkg/hub/demo_policy_test.go
@@ -416,14 +416,23 @@ func TestDemoPolicy_SeedGroupsAndPolicies(t *testing.T) {
 	assert.Equal(t, "Hub Members", group.Name)
 	assert.Equal(t, store.GroupTypeExplicit, group.GroupType)
 
-	// Verify seed policies exist
+	// Verify seed policies exist — per-type read policies replaced the old hub-member-read-all wildcard
+	for _, name := range []string{
+		"hub-member-read-user",
+		"hub-member-read-group",
+		"hub-member-read-template",
+		"hub-member-read-harness-config",
+		"hub-member-create-projects",
+	} {
+		policies, err := s.ListPolicies(ctx, store.PolicyFilter{Name: name}, store.ListOptions{Limit: 1})
+		require.NoError(t, err)
+		assert.Equal(t, 1, policies.TotalCount, "%s policy should exist", name)
+	}
+
+	// The old wildcard policy should NOT exist
 	policies, err := s.ListPolicies(ctx, store.PolicyFilter{Name: "hub-member-read-all"}, store.ListOptions{Limit: 1})
 	require.NoError(t, err)
-	assert.Equal(t, 1, policies.TotalCount, "hub-member-read-all policy should exist")
-
-	policies, err = s.ListPolicies(ctx, store.PolicyFilter{Name: "hub-member-create-projects"}, store.ListOptions{Limit: 1})
-	require.NoError(t, err)
-	assert.Equal(t, 1, policies.TotalCount, "hub-member-create-projects policy should exist")
+	assert.Equal(t, 0, policies.TotalCount, "hub-member-read-all policy should be retired")
 }
 
 func TestDemoPolicy_ProjectCreationSetsUpMembersGroupAndPolicy(t *testing.T) {

--- a/pkg/hub/demo_policy_test.go
+++ b/pkg/hub/demo_policy_test.go
@@ -458,12 +458,22 @@ func TestDemoPolicy_ProjectCreationSetsUpMembersGroupAndPolicy(t *testing.T) {
 	_, err = s.GetGroupMembership(ctx, membersGroup.ID, store.GroupMemberTypeUser, alice.ID)
 	assert.NoError(t, err, "project creator should be a member of the project members group")
 
-	// Verify project-level agent creation policy was created
+	// Verify project-level read policies were created (member-read-project and member-read-agents)
+	for _, suffix := range []string{"member-read-project", "member-read-agents"} {
+		policyName := "project:" + createdProject.Slug + ":" + suffix
+		policies, err := s.ListPolicies(ctx,
+			store.PolicyFilter{Name: policyName},
+			store.ListOptions{Limit: 1})
+		require.NoError(t, err)
+		assert.Equal(t, 1, policies.TotalCount, "%s policy should exist", policyName)
+	}
+
+	// The old member-create-agents policy should NOT exist
 	policies, err := s.ListPolicies(ctx,
 		store.PolicyFilter{Name: "project:" + createdProject.Slug + ":member-create-agents"},
 		store.ListOptions{Limit: 1})
 	require.NoError(t, err)
-	assert.Equal(t, 1, policies.TotalCount, "project member-create-agents policy should exist")
+	assert.Equal(t, 0, policies.TotalCount, "old member-create-agents policy should not exist")
 }
 
 // TestDemoPolicy_EndToEnd_ProjectCreatorCanCreateAgent tests the complete flow:

--- a/pkg/hub/demo_policy_test.go
+++ b/pkg/hub/demo_policy_test.go
@@ -679,15 +679,18 @@ func TestDemoPolicy_ProjectDeleteCleansUpGroupsAndPolicies(t *testing.T) {
 	var project store.Project
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&project))
 
-	// Verify groups and policy exist
+	// Verify groups and policies exist before deletion
 	_, err := s.GetGroupBySlug(ctx, "project:"+project.Slug+":members")
 	require.NoError(t, err, "members group should exist before deletion")
 
-	policies, err := s.ListPolicies(ctx,
-		store.PolicyFilter{Name: "project:" + project.Slug + ":member-create-agents"},
-		store.ListOptions{Limit: 1})
-	require.NoError(t, err)
-	assert.Equal(t, 1, policies.TotalCount, "policy should exist before deletion")
+	for _, suffix := range []string{"member-read-project", "member-read-agents"} {
+		policyName := "project:" + project.Slug + ":" + suffix
+		policies, err := s.ListPolicies(ctx,
+			store.PolicyFilter{Name: policyName},
+			store.ListOptions{Limit: 1})
+		require.NoError(t, err)
+		assert.Equal(t, 1, policies.TotalCount, "%s should exist before deletion", policyName)
+	}
 
 	// Delete project
 	delRec := doRequestAsUser(t, srv, alice, http.MethodDelete, "/api/v1/projects/"+project.ID, nil)
@@ -697,10 +700,13 @@ func TestDemoPolicy_ProjectDeleteCleansUpGroupsAndPolicies(t *testing.T) {
 	_, err = s.GetGroupBySlug(ctx, "project:"+project.Slug+":members")
 	assert.Error(t, err, "members group should be deleted after project deletion")
 
-	// Verify policy is cleaned up
-	policies, err = s.ListPolicies(ctx,
-		store.PolicyFilter{Name: "project:" + project.Slug + ":member-create-agents"},
-		store.ListOptions{Limit: 1})
-	require.NoError(t, err)
-	assert.Equal(t, 0, policies.TotalCount, "policy should be deleted after project deletion")
+	// Verify policies are cleaned up
+	for _, suffix := range []string{"member-read-project", "member-read-agents"} {
+		policyName := "project:" + project.Slug + ":" + suffix
+		policies, err := s.ListPolicies(ctx,
+			store.PolicyFilter{Name: policyName},
+			store.ListOptions{Limit: 1})
+		require.NoError(t, err)
+		assert.Equal(t, 0, policies.TotalCount, "%s should be deleted after project deletion", policyName)
+	}
 }

--- a/pkg/hub/events.go
+++ b/pkg/hub/events.go
@@ -126,7 +126,6 @@ type AgentCreatedEvent struct {
 	Runtime         string `json:"runtime,omitempty"`
 	RuntimeBrokerID string `json:"runtimeBrokerId,omitempty"`
 	CreatedBy       string `json:"createdBy,omitempty"`
-	Visibility      string `json:"visibility,omitempty"`
 	TaskSummary     string `json:"taskSummary,omitempty"`
 	Created         string `json:"created,omitempty"`
 }
@@ -384,7 +383,6 @@ func (p *eventBuilder) PublishAgentCreated(_ context.Context, agent *store.Agent
 		Runtime:         agent.Runtime,
 		RuntimeBrokerID: agent.RuntimeBrokerID,
 		CreatedBy:       agent.CreatedBy,
-		Visibility:      agent.Visibility,
 		TaskSummary:     agent.TaskSummary,
 	}
 	if !agent.Created.IsZero() {

--- a/pkg/hub/events_test.go
+++ b/pkg/hub/events_test.go
@@ -166,7 +166,6 @@ func TestChannelEventPublisher_PublishAgentCreated(t *testing.T) {
 		Runtime:         "docker",
 		RuntimeBrokerID: "b1",
 		CreatedBy:       "user1",
-		Visibility:      "private",
 	}
 
 	pub.PublishAgentCreated(context.Background(), agent)

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -627,7 +627,6 @@ func (s *Server) createAgentInProject(
 		RuntimeBrokerID: runtimeBrokerID,
 		Phase:           string(state.PhaseCreated),
 		Labels:          req.Labels,
-		Visibility:      store.VisibilityPrivate,
 		CreatedBy:       createdBy,
 		OwnerID:         createdBy,
 		Ancestry:        ancestry,

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -3735,7 +3735,7 @@ func (s *Server) createProjectGroup(ctx context.Context, project *store.Project)
 }
 
 // createProjectMembersGroupAndPolicy creates an explicit members group for a project
-// and a policy allowing members to create agents. Best-effort; failures are logged.
+// and read policies for project/agent visibility. Best-effort; failures are logged.
 // If the group already exists (e.g., project was deleted and recreated with the same
 // slug), the existing group is reused and the creator is still added as a member.
 // callerUserID, when non-empty, is also added as an owner of the members group
@@ -3837,67 +3837,69 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 		}
 	}
 
-	// Create project-level policy for member agent creation and stop-all
-	policyName := "project:" + project.Slug + ":member-create-agents"
-	policy := &store.Policy{
-		ID:           api.NewUUID(),
-		Name:         policyName,
-		Description:  "Allow project members to create and stop agents",
-		ScopeType:    "project",
-		ScopeID:      project.ID,
-		ResourceType: "agent",
-		Actions:      []string{"create", "stop_all"},
-		Effect:       "allow",
-	}
-	if err := s.store.CreatePolicy(ctx, policy); err != nil {
-		if !errors.Is(err, store.ErrAlreadyExists) {
-			slog.Warn("failed to create project member policy",
-				"project_id", project.ID, "policy", policyName, "error", err.Error())
-			return
-		}
-		// Policy already exists — look it up and update its scope ID in case the
-		// project was recreated. Also ensure the binding to the current members group.
-		existing, lookupErr := s.store.ListPolicies(ctx, store.PolicyFilter{Name: policyName}, store.ListOptions{Limit: 1})
-		if lookupErr != nil || len(existing.Items) == 0 {
-			slog.Warn("failed to look up existing project member policy",
-				"project_id", project.ID, "policy", policyName, "error", lookupErr)
-			return
-		}
-		policy = &existing.Items[0]
-		needsUpdate := false
-		if policy.ScopeID != project.ID {
-			policy.ScopeID = project.ID
-			needsUpdate = true
-		}
-		// Backfill: ensure stop_all action is present for existing projects
-		hasStopAll := false
-		for _, a := range policy.Actions {
-			if a == "stop_all" {
-				hasStopAll = true
-				break
+	// WP-B2/B3 migration: the old 'member-create-agents' policy is the
+	// "not yet migrated" marker.  If present → bump user members to admin
+	// (preserving create ability via isProjectOwnerOrAdmin bypass), then
+	// retire the old policy.  Create/stop_all are no longer policy-granted;
+	// they flow from the admin/owner role bypass.
+	oldPolicyName := "project:" + project.Slug + ":member-create-agents"
+	oldPolicies, lookupErr := s.store.ListPolicies(ctx, store.PolicyFilter{Name: oldPolicyName}, store.ListOptions{Limit: 1})
+	if lookupErr == nil && len(oldPolicies.Items) > 0 {
+		// B3: bump every USER member with role=member → admin
+		members, mErr := s.store.GetGroupMembers(ctx, membersGroup.ID)
+		if mErr == nil {
+			for _, m := range members {
+				if m.MemberType == store.GroupMemberTypeUser && m.Role == store.GroupMemberRoleMember {
+					if promErr := s.store.UpdateGroupMemberRole(ctx, membersGroup.ID,
+						m.MemberType, m.MemberID, store.GroupMemberRoleAdmin); promErr != nil {
+						slog.Warn("failed to bump member to admin during migration",
+							"project_id", project.ID, "user", m.MemberID, "error", promErr.Error())
+					} else {
+						slog.Info("migrated project member to admin",
+							"project_id", project.ID, "user", m.MemberID)
+					}
+				}
 			}
 		}
-		if !hasStopAll {
-			policy.Actions = append(policy.Actions, "stop_all")
-			needsUpdate = true
-		}
-		if needsUpdate {
-			if updateErr := s.store.UpdatePolicy(ctx, policy); updateErr != nil {
-				slog.Warn("failed to update existing project member policy",
-					"project_id", project.ID, "policy", policyName, "error", updateErr.Error())
-			}
+
+		// Remove old policy
+		oldP := oldPolicies.Items[0]
+		_ = s.store.RemovePolicyBinding(ctx, oldP.ID, "group", membersGroup.ID)
+		if delErr := s.store.DeletePolicy(ctx, oldP.ID); delErr != nil {
+			slog.Warn("failed to delete old create-agents policy",
+				"project_id", project.ID, "error", delErr.Error())
+		} else {
+			slog.Info("retired old member-create-agents policy",
+				"project_id", project.ID, "policy", oldPolicyName)
 		}
 	}
 
-	// Bind policy to the members group
-	if err := s.store.AddPolicyBinding(ctx, &store.PolicyBinding{
-		PolicyID:      policy.ID,
-		PrincipalType: "group",
-		PrincipalID:   membersGroup.ID,
-	}); err != nil && !errors.Is(err, store.ErrAlreadyExists) {
-		slog.Warn("failed to bind project member policy",
-			"project_id", project.ID, "policy", policyName, "error", err.Error())
-	}
+	// Seed project-scoped read policies bound to the members group.
+	// ResourceID is pinned for the project policy because project resources
+	// have empty ParentType — without pinning, matchesResource would leak
+	// read to other projects.
+	seedPolicy(ctx, s.store, membersGroup.ID, &store.Policy{
+		ID:           api.NewUUID(),
+		Name:         "project:" + project.Slug + ":member-read-project",
+		Description:  "Allow project members to read this project",
+		ScopeType:    "project",
+		ScopeID:      project.ID,
+		ResourceType: "project",
+		ResourceID:   project.ID,
+		Actions:      []string{"read", "list"},
+		Effect:       "allow",
+	})
+
+	seedPolicy(ctx, s.store, membersGroup.ID, &store.Policy{
+		ID:           api.NewUUID(),
+		Name:         "project:" + project.Slug + ":member-read-agents",
+		Description:  "Allow project members to read agents in this project",
+		ScopeType:    "project",
+		ScopeID:      project.ID,
+		ResourceType: "agent",
+		Actions:      []string{"read", "list"},
+		Effect:       "allow",
+	})
 }
 
 // hubManagedProjectPath returns the filesystem path for a hub-managed project workspace.

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -3585,7 +3585,7 @@ func (s *Server) createProject(w http.ResponseWriter, r *http.Request) {
 		Slug:       slug,
 		GitRemote:  normalizedRemote,
 		Labels:     req.Labels,
-		Visibility: req.Visibility,
+		Visibility: api.NormalizeVisibility(req.Visibility),
 	}
 
 	if project.Visibility == "" {
@@ -5309,7 +5309,7 @@ func (s *Server) updateProject(w http.ResponseWriter, r *http.Request, id string
 		project.Labels = updates.Labels
 	}
 	if updates.Visibility != "" {
-		project.Visibility = updates.Visibility
+		project.Visibility = api.NormalizeVisibility(updates.Visibility)
 	}
 	if updates.DefaultRuntimeBrokerID != "" {
 		project.DefaultRuntimeBrokerID = updates.DefaultRuntimeBrokerID
@@ -6623,6 +6623,7 @@ func (s *Server) createTemplate(w http.ResponseWriter, r *http.Request) {
 	if template.Scope == "" {
 		template.Scope = "global"
 	}
+	template.Visibility = api.NormalizeVisibility(template.Visibility)
 	if template.Visibility == "" {
 		template.Visibility = store.VisibilityPrivate
 	}

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -275,6 +275,13 @@ func (s *Server) handleAgents(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+
+	identity := GetIdentityFromContext(ctx)
+	if identity == nil {
+		Unauthorized(w)
+		return
+	}
+
 	query := r.URL.Query()
 
 	filter := store.AgentFilter{
@@ -331,36 +338,22 @@ func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 	// Enrich agents with project and broker names
 	s.enrichAgents(ctx, result.Items)
 
-	// Compute per-item and scope capabilities
-	identity := GetIdentityFromContext(ctx)
+	// Compute per-item and scope capabilities (identity guaranteed non-nil)
 	agents := make([]AgentWithCapabilities, 0, len(result.Items))
-	if identity != nil {
-		resources := make([]Resource, len(result.Items))
-		for i := range result.Items {
-			resources[i] = agentResource(&result.Items[i])
+	resources := make([]Resource, len(result.Items))
+	for i := range result.Items {
+		resources[i] = agentResource(&result.Items[i])
+	}
+	caps := s.authzService.ComputeCapabilitiesBatch(ctx, identity, resources, "agent")
+	for i := range result.Items {
+		if !capabilityAllows(caps[i], ActionRead) {
+			continue
 		}
-		caps := s.authzService.ComputeCapabilitiesBatch(ctx, identity, resources, "agent")
-		for i := range result.Items {
-			if !capabilityAllows(caps[i], ActionRead) {
-				continue
-			}
-			agents = append(agents, AgentWithCapabilities{Agent: result.Items[i], Cap: caps[i]})
-		}
-	} else {
-		for i := range result.Items {
-			agents = append(agents, AgentWithCapabilities{Agent: result.Items[i]})
-		}
+		agents = append(agents, AgentWithCapabilities{Agent: result.Items[i], Cap: caps[i]})
 	}
 
-	var scopeCap *Capabilities
-	if identity != nil {
-		scopeCap = s.authzService.ComputeScopeCapabilities(ctx, identity, "", "", "agent")
-	}
-
-	totalCount := result.TotalCount
-	if identity != nil {
-		totalCount = len(agents)
-	}
+	scopeCap := s.authzService.ComputeScopeCapabilities(ctx, identity, "", "", "agent")
+	totalCount := len(agents)
 
 	writeJSON(w, http.StatusOK, ListAgentsResponse{
 		Agents:       agents,
@@ -3399,6 +3392,13 @@ func (s *Server) handleProjects(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) listProjects(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+
+	identity := GetIdentityFromContext(ctx)
+	if identity == nil {
+		Unauthorized(w)
+		return
+	}
+
 	query := r.URL.Query()
 
 	filter := store.ProjectFilter{
@@ -3424,12 +3424,10 @@ func (s *Server) listProjects(w http.ResponseWriter, r *http.Request) {
 				filter.MemberProjectIDs = projectIDs
 				filter.ExcludeOwnerID = userIdent.ID()
 			} else {
-				// User has no group memberships — return empty result
 				filter.MemberProjectIDs = []string{"__none__"}
 			}
 		}
 	default:
-		// Legacy mine=true support
 		if query.Get("mine") == "true" {
 			if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
 				filter.OwnerID = userIdent.ID()
@@ -3459,36 +3457,22 @@ func (s *Server) listProjects(w http.ResponseWriter, r *http.Request) {
 	// Enrich owner display names
 	s.enrichProjectOwnerNames(ctx, result.Items)
 
-	// Compute per-item and scope capabilities
-	identity := GetIdentityFromContext(ctx)
+	// Compute per-item and scope capabilities (identity guaranteed non-nil)
 	projects := make([]ProjectWithCapabilities, 0, len(result.Items))
-	if identity != nil {
-		resources := make([]Resource, len(result.Items))
-		for i := range result.Items {
-			resources[i] = projectResource(&result.Items[i])
+	resources := make([]Resource, len(result.Items))
+	for i := range result.Items {
+		resources[i] = projectResource(&result.Items[i])
+	}
+	caps := s.authzService.ComputeCapabilitiesBatch(ctx, identity, resources, "project")
+	for i := range result.Items {
+		if !capabilityAllows(caps[i], ActionRead) {
+			continue
 		}
-		caps := s.authzService.ComputeCapabilitiesBatch(ctx, identity, resources, "project")
-		for i := range result.Items {
-			if !capabilityAllows(caps[i], ActionRead) {
-				continue
-			}
-			projects = append(projects, ProjectWithCapabilities{Project: result.Items[i], Cap: caps[i]})
-		}
-	} else {
-		for i := range result.Items {
-			projects = append(projects, ProjectWithCapabilities{Project: result.Items[i]})
-		}
+		projects = append(projects, ProjectWithCapabilities{Project: result.Items[i], Cap: caps[i]})
 	}
 
-	var scopeCap *Capabilities
-	if identity != nil {
-		scopeCap = s.authzService.ComputeScopeCapabilities(ctx, identity, "", "", "project")
-	}
-
-	totalCount := result.TotalCount
-	if identity != nil {
-		totalCount = len(projects)
-	}
+	scopeCap := s.authzService.ComputeScopeCapabilities(ctx, identity, "", "", "project")
+	totalCount := len(projects)
 
 	writeJSON(w, http.StatusOK, ListProjectsResponse{
 		Projects:     projects,
@@ -4945,6 +4929,12 @@ func (s *Server) createProjectAgent(w http.ResponseWriter, r *http.Request, proj
 func (s *Server) getProjectAgent(w http.ResponseWriter, r *http.Request, projectID, agentID string) {
 	ctx := r.Context()
 
+	identity := GetIdentityFromContext(ctx)
+	if identity == nil {
+		Unauthorized(w)
+		return
+	}
+
 	// Try to get by slug first (more common case)
 	agent, err := s.store.GetAgentBySlug(ctx, projectID, agentID)
 	if err != nil {
@@ -4964,6 +4954,13 @@ func (s *Server) getProjectAgent(w http.ResponseWriter, r *http.Request, project
 			writeErrorFromErr(w, err, "")
 			return
 		}
+	}
+
+	// Gate read access
+	decision := s.authzService.CheckAccess(ctx, identity, agentResource(agent), ActionRead)
+	if !decision.Allowed {
+		NotFound(w, "Agent")
+		return
 	}
 
 	// Enrich agent with project and broker names
@@ -5221,9 +5218,23 @@ func (s *Server) handleProjectByID(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) getProject(w http.ResponseWriter, r *http.Request, id string) {
 	ctx := r.Context()
+
+	identity := GetIdentityFromContext(ctx)
+	if identity == nil {
+		Unauthorized(w)
+		return
+	}
+
 	project, err := s.store.GetProject(ctx, id)
 	if err != nil {
 		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Gate read access
+	decision := s.authzService.CheckAccess(ctx, identity, projectResource(project), ActionRead)
+	if !decision.Allowed {
+		NotFound(w, "Project")
 		return
 	}
 
@@ -5244,9 +5255,7 @@ func (s *Server) getProject(w http.ResponseWriter, r *http.Request, id string) {
 	}
 
 	resp := ProjectWithCapabilities{Project: *project, CloudLogging: s.logQueryService != nil}
-	if identity := GetIdentityFromContext(ctx); identity != nil {
-		resp.Cap = s.authzService.ComputeCapabilities(ctx, identity, projectResource(project))
-	}
+	resp.Cap = s.authzService.ComputeCapabilities(ctx, identity, projectResource(project))
 
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -324,13 +324,13 @@ func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		} else {
-			// Default scope: restrict to user's projects (membership-gated)
+			// Default scope: agents in the user's projects OR owned by the user
+			// (membership-gated). OwnerID is always set so a user with no group
+			// memberships still sees the agents they own (mirrors listProjects).
 			if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+				filter.OwnerID = userIdent.ID()
 				if projectIDs := s.resolveUserProjectIDsCached(ctx, userIdent.ID()); len(projectIDs) > 0 {
 					filter.MemberOrOwnerProjectIDs = projectIDs
-					filter.OwnerID = userIdent.ID()
-				} else {
-					filter.MemberProjectIDs = []string{"__none__"}
 				}
 			}
 		}
@@ -3918,6 +3918,38 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 	})
 }
 
+// backfillProjectVisibility iterates every existing project and ensures its
+// groups and project-scoped member read policies exist, and that the one-time
+// members→admin migration has run (createProjectMembersGroupAndPolicy is
+// idempotent and uses the legacy create-agents policy as its migration marker).
+// Run once at startup so the read gates in getProject/getProjectAgent evaluate
+// correctly for existing projects from the first request. Best-effort.
+func (s *Server) backfillProjectVisibility(ctx context.Context) {
+	const pageSize = 200
+	cursor := ""
+	migrated := 0
+	for {
+		result, err := s.store.ListProjects(ctx, store.ProjectFilter{}, store.ListOptions{Limit: pageSize, Cursor: cursor})
+		if err != nil {
+			slog.Warn("project visibility backfill: failed to list projects", "error", err.Error())
+			return
+		}
+		for i := range result.Items {
+			project := &result.Items[i]
+			s.createProjectGroup(ctx, project)
+			s.createProjectMembersGroupAndPolicy(ctx, project)
+			migrated++
+		}
+		if result.NextCursor == "" {
+			break
+		}
+		cursor = result.NextCursor
+	}
+	if migrated > 0 {
+		slog.Info("project visibility backfill complete", "projects", migrated)
+	}
+}
+
 // hubManagedProjectPath returns the filesystem path for a hub-managed project workspace.
 // It prefers groves/<slug> (the actual git checkout mounted as /workspace in agents)
 // over projects/<slug> (which only contains project metadata).
@@ -5263,17 +5295,21 @@ func (s *Server) getProject(w http.ResponseWriter, r *http.Request, id string) {
 		return
 	}
 
-	// Gate read access
+	// Ensure associated groups exist (backfill for projects created before
+	// group support was added). These calls are idempotent and also seed the
+	// project-scoped member read policies + run the one-time members→admin
+	// migration. They MUST run before the read gate below, otherwise a member
+	// of a not-yet-backfilled project would be spuriously denied because the
+	// read policy would not exist yet.
+	s.createProjectGroup(ctx, project)
+	s.createProjectMembersGroupAndPolicy(ctx, project)
+
+	// Gate read access (after backfill, so member read policies are in place).
 	decision := s.authzService.CheckAccess(ctx, identity, projectResource(project), ActionRead)
 	if !decision.Allowed {
 		NotFound(w, "Project")
 		return
 	}
-
-	// Ensure associated groups exist (backfill for projects created before
-	// group support was added). These calls are idempotent.
-	s.createProjectGroup(ctx, project)
-	s.createProjectMembersGroupAndPolicy(ctx, project)
 
 	// Enrich owner display name
 	if project.OwnerID != "" {

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -291,8 +291,15 @@ func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 		IncludeDeleted:  query.Get("includeDeleted") == "true",
 	}
 
+	// Pre-compute and cache the user's project IDs for reuse within this request.
+	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+		r = s.storeUserProjectIDsInContext(r, userIdent.ID())
+		ctx = r.Context()
+	}
+
 	// scope=mine: agents the current user created
 	// scope=shared: agents in projects the user is a member of, but not created by them
+	// default (no scope): agents in the user's projects (membership-gated)
 	// mine=true (legacy): agents the user created or in projects they own/are a member of
 	switch query.Get("scope") {
 	case "mine":
@@ -301,7 +308,7 @@ func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 		}
 	case "shared":
 		if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-			if projectIDs := s.resolveUserProjectIDs(ctx, userIdent.ID()); len(projectIDs) > 0 {
+			if projectIDs := s.resolveUserProjectIDsCached(ctx, userIdent.ID()); len(projectIDs) > 0 {
 				filter.MemberProjectIDs = projectIDs
 				filter.ExcludeOwnerID = userIdent.ID()
 			} else {
@@ -312,8 +319,18 @@ func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 		if query.Get("mine") == "true" {
 			if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
 				filter.OwnerID = userIdent.ID()
-				if projectIDs := s.resolveUserProjectIDs(ctx, userIdent.ID()); len(projectIDs) > 0 {
+				if projectIDs := s.resolveUserProjectIDsCached(ctx, userIdent.ID()); len(projectIDs) > 0 {
 					filter.MemberOrOwnerProjectIDs = projectIDs
+				}
+			}
+		} else {
+			// Default scope: restrict to user's projects (membership-gated)
+			if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+				if projectIDs := s.resolveUserProjectIDsCached(ctx, userIdent.ID()); len(projectIDs) > 0 {
+					filter.MemberOrOwnerProjectIDs = projectIDs
+					filter.OwnerID = userIdent.ID()
+				} else {
+					filter.MemberProjectIDs = []string{"__none__"}
 				}
 			}
 		}
@@ -3410,8 +3427,15 @@ func (s *Server) listProjects(w http.ResponseWriter, r *http.Request) {
 		Slug:       query.Get("slug"),
 	}
 
+	// Pre-compute and cache the user's project IDs for reuse within this request.
+	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+		r = s.storeUserProjectIDsInContext(r, userIdent.ID())
+		ctx = r.Context()
+	}
+
 	// scope=mine: projects the current user owns
 	// scope=shared: projects where the user is a member/admin but not the owner
+	// default (no scope): projects the user owns or is a member of (membership-gated)
 	// mine=true (legacy): projects the user owns or is a member of
 	switch query.Get("scope") {
 	case "mine":
@@ -3420,7 +3444,7 @@ func (s *Server) listProjects(w http.ResponseWriter, r *http.Request) {
 		}
 	case "shared":
 		if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-			if projectIDs := s.resolveUserProjectIDs(ctx, userIdent.ID()); len(projectIDs) > 0 {
+			if projectIDs := s.resolveUserProjectIDsCached(ctx, userIdent.ID()); len(projectIDs) > 0 {
 				filter.MemberProjectIDs = projectIDs
 				filter.ExcludeOwnerID = userIdent.ID()
 			} else {
@@ -3431,7 +3455,15 @@ func (s *Server) listProjects(w http.ResponseWriter, r *http.Request) {
 		if query.Get("mine") == "true" {
 			if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
 				filter.OwnerID = userIdent.ID()
-				if projectIDs := s.resolveUserProjectIDs(ctx, userIdent.ID()); len(projectIDs) > 0 {
+				if projectIDs := s.resolveUserProjectIDsCached(ctx, userIdent.ID()); len(projectIDs) > 0 {
+					filter.MemberOrOwnerIDs = projectIDs
+				}
+			}
+		} else {
+			// Default scope: restrict to user's projects (membership-gated)
+			if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+				filter.OwnerID = userIdent.ID()
+				if projectIDs := s.resolveUserProjectIDsCached(ctx, userIdent.ID()); len(projectIDs) > 0 {
 					filter.MemberOrOwnerIDs = projectIDs
 				}
 			}
@@ -6199,6 +6231,26 @@ func (s *Server) enrichProjectOwnerNames(ctx context.Context, projects []store.P
 			projects[i].OwnerName = name
 		}
 	}
+}
+
+type projectIDsCacheKey struct{}
+
+// resolveUserProjectIDsCached returns resolveUserProjectIDs results, cached in
+// the request context so the BFS is run at most once per HTTP request.
+func (s *Server) resolveUserProjectIDsCached(ctx context.Context, userID string) []string {
+	if cached, ok := ctx.Value(projectIDsCacheKey{}).([]string); ok {
+		return cached
+	}
+	ids := s.resolveUserProjectIDs(ctx, userID)
+	return ids
+}
+
+// storeUserProjectIDsInContext computes and stores the user's project IDs in the
+// request context for reuse within the same request.
+func (s *Server) storeUserProjectIDsInContext(r *http.Request, userID string) *http.Request {
+	ids := s.resolveUserProjectIDs(r.Context(), userID)
+	ctx := context.WithValue(r.Context(), projectIDsCacheKey{}, ids)
+	return r.WithContext(ctx)
 }
 
 // resolveUserProjectIDs returns project IDs from the user's group memberships,

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -5791,6 +5791,19 @@ func (s *Server) handleRuntimeBrokers(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) listRuntimeBrokers(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+
+	ident := GetIdentityFromContext(ctx)
+	if ident == nil {
+		Unauthorized(w)
+		return
+	}
+
+	// Pre-compute and cache the user's project IDs for canReadBroker checks.
+	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+		r = s.storeUserProjectIDsInContext(r, userIdent.ID())
+		ctx = r.Context()
+	}
+
 	query := r.URL.Query()
 
 	projectID := query.Get("projectId")
@@ -5816,91 +5829,81 @@ func (s *Server) listRuntimeBrokers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Batch-resolve CreatedByName for all brokers
-	s.enrichBrokerCreatorNames(ctx, result.Items)
+	// Filter to brokers the user can read (owner, admin, or member of a contributing project)
+	readable := make([]store.RuntimeBroker, 0, len(result.Items))
+	for i := range result.Items {
+		if s.canReadBroker(ctx, ident, &result.Items[i]) {
+			readable = append(readable, result.Items[i])
+		}
+	}
+
+	// Batch-resolve CreatedByName for readable brokers
+	s.enrichBrokerCreatorNames(ctx, readable)
 
 	// Compute capabilities for the requesting user
-	ident := GetIdentityFromContext(ctx)
-	var caps []*Capabilities
-	if ident != nil {
-		resources := make([]Resource, len(result.Items))
-		for i := range result.Items {
-			resources[i] = brokerResource(&result.Items[i])
-		}
-		caps = s.authzService.ComputeCapabilitiesBatch(ctx, ident, resources, "broker")
-		// Auto-provide brokers grant dispatch to all authenticated users.
-		for i, broker := range result.Items {
-			if broker.AutoProvide && i < len(caps) && !capabilityAllows(caps[i], ActionDispatch) {
-				caps[i].Actions = append(caps[i].Actions, string(ActionDispatch))
-			}
+	resources := make([]Resource, len(readable))
+	for i := range readable {
+		resources[i] = brokerResource(&readable[i])
+	}
+	caps := s.authzService.ComputeCapabilitiesBatch(ctx, ident, resources, "broker")
+	for i, broker := range readable {
+		if broker.AutoProvide && i < len(caps) && !capabilityAllows(caps[i], ActionDispatch) {
+			caps[i].Actions = append(caps[i].Actions, string(ActionDispatch))
 		}
 	}
 
 	// If filtering by projectId, include project-specific provider data (like localPath)
 	if projectID != "" {
-		// Get provider data for this project to include localPath
 		providers, err := s.store.GetProjectProviders(ctx, projectID)
 		if err != nil {
 			writeErrorFromErr(w, err, "")
 			return
 		}
 
-		// Build a map of brokerId -> localPath for quick lookup
 		brokerLocalPaths := make(map[string]string)
 		for _, p := range providers {
 			brokerLocalPaths[p.BrokerID] = p.LocalPath
 		}
 
-		// Build extended broker list with provider data
-		extendedBrokers := make([]RuntimeBrokerWithProvider, 0, len(result.Items))
-		for i, broker := range result.Items {
-			if caps != nil && !capabilityAllows(caps[i], ActionRead) {
+		extendedBrokers := make([]RuntimeBrokerWithProvider, 0, len(readable))
+		for i, broker := range readable {
+			if !capabilityAllows(caps[i], ActionRead) {
 				continue
 			}
 			eb := RuntimeBrokerWithProvider{
 				RuntimeBroker: broker,
 				LocalPath:     brokerLocalPaths[broker.ID],
 			}
-			if caps != nil && i < len(caps) {
+			if i < len(caps) {
 				eb.Cap = caps[i]
 			}
 			extendedBrokers = append(extendedBrokers, eb)
 		}
 
-		totalCount := result.TotalCount
-		if ident != nil {
-			totalCount = len(extendedBrokers)
-		}
-
 		writeJSON(w, http.StatusOK, ListRuntimeBrokersWithProviderResponse{
 			Brokers:    extendedBrokers,
 			NextCursor: result.NextCursor,
-			TotalCount: totalCount,
+			TotalCount: len(extendedBrokers),
 		})
 		return
 	}
 
-	brokersWithCaps := make([]RuntimeBrokerWithCapabilities, 0, len(result.Items))
-	for i, broker := range result.Items {
-		if caps != nil && !capabilityAllows(caps[i], ActionRead) {
+	brokersWithCaps := make([]RuntimeBrokerWithCapabilities, 0, len(readable))
+	for i, broker := range readable {
+		if !capabilityAllows(caps[i], ActionRead) {
 			continue
 		}
 		resp := RuntimeBrokerWithCapabilities{RuntimeBroker: broker}
-		if caps != nil && i < len(caps) {
+		if i < len(caps) {
 			resp.Cap = caps[i]
 		}
 		brokersWithCaps = append(brokersWithCaps, resp)
 	}
 
-	totalCount := result.TotalCount
-	if ident != nil {
-		totalCount = len(brokersWithCaps)
-	}
-
 	writeJSON(w, http.StatusOK, ListRuntimeBrokersWithCapsResponse{
 		Brokers:    brokersWithCaps,
 		NextCursor: result.NextCursor,
-		TotalCount: totalCount,
+		TotalCount: len(brokersWithCaps),
 	})
 }
 
@@ -6009,11 +6012,53 @@ func (s *Server) handleRuntimeBrokerByID(w http.ResponseWriter, r *http.Request)
 	}
 }
 
+// canReadBroker checks whether the user can read a broker: owner, hub admin,
+// or member of any project the broker contributes to.
+func (s *Server) canReadBroker(ctx context.Context, identity Identity, broker *store.RuntimeBroker) bool {
+	// Admin bypass
+	if user, ok := identity.(UserIdentity); ok && user.Role() == "admin" {
+		return true
+	}
+	// Owner bypass
+	if broker.CreatedBy != "" && broker.CreatedBy == identity.ID() {
+		return true
+	}
+	// Check if the broker contributes to any project the user is a member of
+	providers, err := s.store.GetBrokerProjects(ctx, broker.ID)
+	if err != nil || len(providers) == 0 {
+		return false
+	}
+	userProjectIDs := s.resolveUserProjectIDsCached(ctx, identity.ID())
+	userProjectSet := make(map[string]struct{}, len(userProjectIDs))
+	for _, pid := range userProjectIDs {
+		userProjectSet[pid] = struct{}{}
+	}
+	for _, p := range providers {
+		if _, ok := userProjectSet[p.ProjectID]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Server) getRuntimeBroker(w http.ResponseWriter, r *http.Request, id string) {
 	ctx := r.Context()
+
+	identity := GetIdentityFromContext(ctx)
+	if identity == nil {
+		Unauthorized(w)
+		return
+	}
+
 	broker, err := s.store.GetRuntimeBroker(ctx, id)
 	if err != nil {
 		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Gate read access
+	if !s.canReadBroker(ctx, identity, broker) {
+		NotFound(w, "RuntimeBroker")
 		return
 	}
 
@@ -6030,12 +6075,9 @@ func (s *Server) getRuntimeBroker(w http.ResponseWriter, r *http.Request, id str
 
 	// Compute capabilities for the requesting user
 	resp := RuntimeBrokerWithCapabilities{RuntimeBroker: *broker}
-	if ident := GetIdentityFromContext(ctx); ident != nil {
-		resp.Cap = s.authzService.ComputeCapabilities(ctx, ident, brokerResource(broker))
-		// Auto-provide brokers grant dispatch to all authenticated users.
-		if broker.AutoProvide && !capabilityAllows(resp.Cap, ActionDispatch) {
-			resp.Cap.Actions = append(resp.Cap.Actions, string(ActionDispatch))
-		}
+	resp.Cap = s.authzService.ComputeCapabilities(ctx, identity, brokerResource(broker))
+	if broker.AutoProvide && !capabilityAllows(resp.Cap, ActionDispatch) {
+		resp.Cap.Actions = append(resp.Cap.Actions, string(ActionDispatch))
 	}
 
 	writeJSON(w, http.StatusOK, resp)
@@ -6532,10 +6574,21 @@ type ListBrokerProjectsResponse struct {
 func (s *Server) getBrokerProjects(w http.ResponseWriter, r *http.Request, brokerID string) {
 	ctx := r.Context()
 
-	// Verify broker exists
-	_, err := s.store.GetRuntimeBroker(ctx, brokerID)
+	identity := GetIdentityFromContext(ctx)
+	if identity == nil {
+		Unauthorized(w)
+		return
+	}
+
+	broker, err := s.store.GetRuntimeBroker(ctx, brokerID)
 	if err != nil {
 		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Gate read access on the broker itself
+	if !s.canReadBroker(ctx, identity, broker) {
+		NotFound(w, "RuntimeBroker")
 		return
 	}
 

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -3880,7 +3880,10 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 
 		// Remove old policy
 		oldP := oldPolicies.Items[0]
-		_ = s.store.RemovePolicyBinding(ctx, oldP.ID, "group", membersGroup.ID)
+		if unbindErr := s.store.RemovePolicyBinding(ctx, oldP.ID, "group", membersGroup.ID); unbindErr != nil {
+			slog.Warn("failed to remove binding for retired create-agents policy",
+				"project_id", project.ID, "error", unbindErr.Error())
+		}
 		if delErr := s.store.DeletePolicy(ctx, oldP.ID); delErr != nil {
 			slog.Warn("failed to delete old create-agents policy",
 				"project_id", project.ID, "error", delErr.Error())
@@ -5295,16 +5298,10 @@ func (s *Server) getProject(w http.ResponseWriter, r *http.Request, id string) {
 		return
 	}
 
-	// Ensure associated groups exist (backfill for projects created before
-	// group support was added). These calls are idempotent and also seed the
-	// project-scoped member read policies + run the one-time members→admin
-	// migration. They MUST run before the read gate below, otherwise a member
-	// of a not-yet-backfilled project would be spuriously denied because the
-	// read policy would not exist yet.
-	s.createProjectGroup(ctx, project)
-	s.createProjectMembersGroupAndPolicy(ctx, project)
-
-	// Gate read access (after backfill, so member read policies are in place).
+	// Gate read access. The project's groups + member read policies are seeded
+	// at project-creation time and backfilled for all existing projects at
+	// startup (backfillProjectVisibility), so they are guaranteed present here —
+	// no need to run the write-heavy backfill on this read path.
 	decision := s.authzService.CheckAccess(ctx, identity, projectResource(project), ActionRead)
 	if !decision.Allowed {
 		NotFound(w, "Project")
@@ -5865,11 +5862,23 @@ func (s *Server) listRuntimeBrokers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Filter to brokers the user can read (owner, admin, or member of a contributing project)
+	// Filter to brokers the user can read (owner, admin, or member of a
+	// contributing project). To avoid an N+1 (one GetBrokerProjects per broker),
+	// resolve the set of broker IDs reachable through the caller's projects once.
+	isHubAdmin := false
+	if u, ok := ident.(UserIdentity); ok && u.Role() == "admin" {
+		isHubAdmin = true
+	}
+	readableViaProjects := s.readableBrokerIDsForUser(ctx, ident.ID())
 	readable := make([]store.RuntimeBroker, 0, len(result.Items))
 	for i := range result.Items {
-		if s.canReadBroker(ctx, ident, &result.Items[i]) {
-			readable = append(readable, result.Items[i])
+		b := &result.Items[i]
+		if isHubAdmin || (b.CreatedBy != "" && b.CreatedBy == ident.ID()) {
+			readable = append(readable, *b)
+			continue
+		}
+		if _, ok := readableViaProjects[b.ID]; ok {
+			readable = append(readable, *b)
 		}
 	}
 
@@ -6048,8 +6057,26 @@ func (s *Server) handleRuntimeBrokerByID(w http.ResponseWriter, r *http.Request)
 	}
 }
 
+// readableBrokerIDsForUser returns the set of broker IDs that contribute to any
+// project the user is a member of. It resolves user→projects→brokers once (one
+// GetProjectProviders per user project), avoiding an N+1 over the broker list.
+func (s *Server) readableBrokerIDsForUser(ctx context.Context, userID string) map[string]struct{} {
+	set := make(map[string]struct{})
+	for _, pid := range s.resolveUserProjectIDsCached(ctx, userID) {
+		providers, err := s.store.GetProjectProviders(ctx, pid)
+		if err != nil {
+			continue
+		}
+		for _, p := range providers {
+			set[p.BrokerID] = struct{}{}
+		}
+	}
+	return set
+}
+
 // canReadBroker checks whether the user can read a broker: owner, hub admin,
-// or member of any project the broker contributes to.
+// or member of any project the broker contributes to. Used on single-broker
+// read paths; the list path uses readableBrokerIDsForUser to avoid an N+1.
 func (s *Server) canReadBroker(ctx context.Context, identity Identity, broker *store.RuntimeBroker) bool {
 	// Admin bypass
 	if user, ok := identity.(UserIdentity); ok && user.Role() == "admin" {
@@ -6313,21 +6340,32 @@ func (s *Server) enrichProjectOwnerNames(ctx context.Context, projects []store.P
 
 type projectIDsCacheKey struct{}
 
-// resolveUserProjectIDsCached returns resolveUserProjectIDs results, cached in
-// the request context so the BFS is run at most once per HTTP request.
-func (s *Server) resolveUserProjectIDsCached(ctx context.Context, userID string) []string {
-	if cached, ok := ctx.Value(projectIDsCacheKey{}).([]string); ok {
-		return cached
-	}
-	ids := s.resolveUserProjectIDs(ctx, userID)
-	return ids
+// projectIDsCache lazily memoizes a user's resolved project IDs for the lifetime
+// of a single request. The BFS runs at most once, on first use.
+type projectIDsCache struct {
+	once sync.Once
+	ids  []string
 }
 
-// storeUserProjectIDsInContext computes and stores the user's project IDs in the
-// request context for reuse within the same request.
-func (s *Server) storeUserProjectIDsInContext(r *http.Request, userID string) *http.Request {
-	ids := s.resolveUserProjectIDs(r.Context(), userID)
-	ctx := context.WithValue(r.Context(), projectIDsCacheKey{}, ids)
+// resolveUserProjectIDsCached returns resolveUserProjectIDs results, cached in
+// the request context so the BFS is run at most once per HTTP request. The cache
+// is lazy and self-populating: if the context carries a cache it is filled on
+// first use; if not, it falls back to an uncached resolve.
+func (s *Server) resolveUserProjectIDsCached(ctx context.Context, userID string) []string {
+	if cache, ok := ctx.Value(projectIDsCacheKey{}).(*projectIDsCache); ok {
+		cache.once.Do(func() {
+			cache.ids = s.resolveUserProjectIDs(ctx, userID)
+		})
+		return cache.ids
+	}
+	return s.resolveUserProjectIDs(ctx, userID)
+}
+
+// storeUserProjectIDsInContext installs a lazy project-IDs cache in the request
+// context. The BFS is not run here — it runs on the first resolveUserProjectIDsCached
+// call, so handlers that return early never pay for it.
+func (s *Server) storeUserProjectIDsInContext(r *http.Request, _ string) *http.Request {
+	ctx := context.WithValue(r.Context(), projectIDsCacheKey{}, &projectIDsCache{})
 	return r.WithContext(ctx)
 }
 

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -4595,11 +4595,13 @@ func TestListAgents_GlobalEndpointReturnsAllAgents(t *testing.T) {
 	srv, s := testServer(t)
 	ctx := context.Background()
 
-	// Create two projects with agents in each
-	project1 := &store.Project{ID: tid("project-global-1"), Name: "Project One", Slug: "project-one"}
-	project2 := &store.Project{ID: tid("project-global-2"), Name: "Project Two", Slug: "project-two"}
+	// Create two projects owned by the dev user (list is membership-gated)
+	project1 := &store.Project{ID: tid("project-global-1"), Name: "Project One", Slug: "project-one", OwnerID: DevUserID, CreatedBy: DevUserID}
+	project2 := &store.Project{ID: tid("project-global-2"), Name: "Project Two", Slug: "project-two", OwnerID: DevUserID, CreatedBy: DevUserID}
 	require.NoError(t, s.CreateProject(ctx, project1))
 	require.NoError(t, s.CreateProject(ctx, project2))
+	srv.createProjectMembersGroupAndPolicy(ctx, project1)
+	srv.createProjectMembersGroupAndPolicy(ctx, project2)
 
 	agent1 := &store.Agent{
 		ID: tid("agent-g1"), Slug: tid("agent-g1"), Name: "Agent G1",
@@ -4619,7 +4621,7 @@ func TestListAgents_GlobalEndpointReturnsAllAgents(t *testing.T) {
 	var resp ListAgentsResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 
-	assert.Len(t, resp.Agents, 2, "global list should return agents from all projects")
+	assert.Len(t, resp.Agents, 2, "global list should return agents from the user's projects")
 	assert.Equal(t, 2, resp.TotalCount, "TotalCount should match number of agents")
 
 	// Verify both agents are present

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -2177,11 +2177,14 @@ func TestListAgents_HarnessConfigEnriched(t *testing.T) {
 	ctx := context.Background()
 
 	project := &store.Project{
-		ID:   tid("project-harness-enrich"),
-		Name: "Harness Enrichment Project",
-		Slug: "harness-enrich-project",
+		ID:        tid("project-harness-enrich"),
+		Name:      "Harness Enrichment Project",
+		Slug:      "harness-enrich-project",
+		OwnerID:   DevUserID,
+		CreatedBy: DevUserID,
 	}
 	require.NoError(t, s.CreateProject(ctx, project))
+	srv.createProjectMembersGroupAndPolicy(ctx, project)
 
 	agent := &store.Agent{
 		ID:        tid("agent-harness-enrich"),

--- a/pkg/hub/handlers_authz_remediation_test.go
+++ b/pkg/hub/handlers_authz_remediation_test.go
@@ -100,6 +100,7 @@ func TestAuthzRemediation_ListEndpointsFilterUnauthorizedItems(t *testing.T) {
 		Updated:   time.Now(),
 	}
 	require.NoError(t, s.CreateProject(ctx, visibleProject))
+	srv.createProjectMembersGroupAndPolicy(ctx, visibleProject)
 
 	hiddenProject := &store.Project{
 		ID:        tid("project-hidden-authz"),
@@ -121,6 +122,13 @@ func TestAuthzRemediation_ListEndpointsFilterUnauthorizedItems(t *testing.T) {
 		CreatedBy: tid("owner-outside-user"),
 	}
 	require.NoError(t, s.CreateRuntimeBroker(ctx, visibleBroker))
+	// Link visible broker to visible project so member can see it via project membership
+	require.NoError(t, s.AddProjectProvider(ctx, &store.ProjectProvider{
+		ProjectID:  visibleProject.ID,
+		BrokerID:   visibleBroker.ID,
+		BrokerName: visibleBroker.Name,
+		Status:     store.BrokerStatusOnline,
+	}))
 
 	hiddenBroker := &store.RuntimeBroker{
 		ID:        tid("broker-hidden-authz"),
@@ -151,6 +159,16 @@ func TestAuthzRemediation_ListEndpointsFilterUnauthorizedItems(t *testing.T) {
 		Phase:     string(state.PhaseRunning),
 	}
 	require.NoError(t, s.CreateAgent(ctx, hiddenAgent))
+
+	// Add the member to the visible project's members group (membership-gated listing)
+	visibleMembersGroup, err := s.GetGroupBySlug(ctx, "project:"+visibleProject.Slug+":members")
+	require.NoError(t, err)
+	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
+		GroupID:    visibleMembersGroup.ID,
+		MemberType: store.GroupMemberTypeUser,
+		MemberID:   member.ID,
+		Role:       store.GroupMemberRoleMember,
+	}))
 
 	grantUserActionOnResource(t, s, member.ID, "project", visibleProject.ID, ActionRead)
 	grantUserActionOnResource(t, s, member.ID, "agent", visibleAgent.ID, ActionRead)

--- a/pkg/hub/handlers_broker_test.go
+++ b/pkg/hub/handlers_broker_test.go
@@ -189,6 +189,12 @@ func TestBrokerAuthz_Dispatch_AutoProvide_NonOwnerAllowed(t *testing.T) {
 	srv, s, _, bob, _, project, broker := setupBrokerAuthzTest(t)
 	ctx := context.Background()
 
+	// Promote Bob to admin in the project so he can create agents (role=member is
+	// read-only under the new model; create/stop require admin/owner).
+	membersGroup, err := s.GetGroupBySlug(ctx, "project:"+project.Slug+":members")
+	require.NoError(t, err)
+	require.NoError(t, s.UpdateGroupMemberRole(ctx, membersGroup.ID, store.GroupMemberTypeUser, bob.ID, store.GroupMemberRoleAdmin))
+
 	// Mark the broker as auto-provide — shared infrastructure available to all users
 	broker.AutoProvide = true
 	require.NoError(t, s.UpdateRuntimeBroker(ctx, broker))

--- a/pkg/hub/handlers_permissions_test.go
+++ b/pkg/hub/handlers_permissions_test.go
@@ -51,7 +51,7 @@ func permSeedAgent(t *testing.T, ctx context.Context, s store.Store, id string) 
 	_ = s.CreateProject(ctx, &store.Project{ID: projectID, Name: "Perm Agent Project", Slug: "perm-agent-project"})
 	err := s.CreateAgent(ctx, &store.Agent{
 		ID: id, Name: "Seed Agent", Slug: "seed-agent-" + id[:8],
-		ProjectID: projectID, Phase: "stopped", Visibility: store.VisibilityPrivate,
+		ProjectID: projectID, Phase: "stopped",
 	})
 	if err != nil && !errors.Is(err, store.ErrAlreadyExists) {
 		t.Fatalf("seed agent %s: %v", id, err)

--- a/pkg/hub/handlers_permissions_test.go
+++ b/pkg/hub/handlers_permissions_test.go
@@ -1239,9 +1239,9 @@ func TestPolicyList(t *testing.T) {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	// 3 test policies + 2 seeded policies (hub-member-read-all, hub-member-create-projects) = 5
-	if len(resp.Policies) != 5 {
-		t.Errorf("expected 5 policies (3 test + 2 seeded), got %d", len(resp.Policies))
+	// 3 test policies + 5 seeded policies (hub-member-read-{user,group,template,harness-config}, hub-member-create-projects) = 8
+	if len(resp.Policies) != 8 {
+		t.Errorf("expected 8 policies (3 test + 5 seeded), got %d", len(resp.Policies))
 	}
 }
 

--- a/pkg/hub/handlers_project_test.go
+++ b/pkg/hub/handlers_project_test.go
@@ -1981,12 +1981,13 @@ func TestCreateProject_ListByGitRemote_ReturnsMultiple(t *testing.T) {
 	srv, s := testServer(t)
 	ctx := context.Background()
 
-	// Pre-create two projects for the same git remote.
+	// Pre-create two projects for the same git remote, owned by the dev user.
 	for _, g := range []*store.Project{
-		{ID: tid("g1"), Name: "widgets", Slug: "widgets", GitRemote: "github.com/acme/widgets"},
-		{ID: tid("g2"), Name: "widgets (1)", Slug: "widgets-1", GitRemote: "github.com/acme/widgets"},
+		{ID: tid("g1"), Name: "widgets", Slug: "widgets", GitRemote: "github.com/acme/widgets", OwnerID: DevUserID, CreatedBy: DevUserID},
+		{ID: tid("g2"), Name: "widgets (1)", Slug: "widgets-1", GitRemote: "github.com/acme/widgets", OwnerID: DevUserID, CreatedBy: DevUserID},
 	} {
 		require.NoError(t, s.CreateProject(ctx, g))
+		srv.createProjectMembersGroupAndPolicy(ctx, g)
 	}
 
 	// List projects by git remote should return both.

--- a/pkg/hub/handlers_test.go
+++ b/pkg/hub/handlers_test.go
@@ -860,12 +860,15 @@ func TestProjectList(t *testing.T) {
 			Slug:      tid("project-" + string(rune('a'+i))),
 			Name:      "Project " + string(rune('A'+i)),
 			GitRemote: "https://github.com/test/repo" + string(rune('a'+i)),
+			OwnerID:   DevUserID,
+			CreatedBy: DevUserID,
 			Created:   time.Now(),
 			Updated:   time.Now(),
 		}
 		if err := s.CreateProject(ctx, project); err != nil {
 			t.Fatalf("failed to create project: %v", err)
 		}
+		srv.createProjectMembersGroupAndPolicy(ctx, project)
 	}
 
 	rec := doRequest(t, srv, http.MethodGet, "/api/v1/projects", nil)

--- a/pkg/hub/handlers_test.go
+++ b/pkg/hub/handlers_test.go
@@ -181,18 +181,21 @@ func TestAgentList(t *testing.T) {
 	srv, s := testServer(t)
 	ctx := context.Background()
 
-	// Create a project first (agents reference projects)
+	// Create a project owned by the dev user (list is membership-gated)
 	project := &store.Project{
 		ID:        tid("project_test123"),
 		Slug:      "test-project",
 		Name:      "Test Project",
 		GitRemote: "https://github.com/test/repo",
+		OwnerID:   DevUserID,
+		CreatedBy: DevUserID,
 		Created:   time.Now(),
 		Updated:   time.Now(),
 	}
 	if err := s.CreateProject(ctx, project); err != nil {
 		t.Fatalf("failed to create project: %v", err)
 	}
+	srv.createProjectMembersGroupAndPolicy(ctx, project)
 
 	// Create some test agents
 	for i := 0; i < 3; i++ {

--- a/pkg/hub/handlers_test.go
+++ b/pkg/hub/handlers_test.go
@@ -2899,7 +2899,6 @@ func TestOutboundMessage_UnknownRecipient(t *testing.T) {
 		ProjectID:       project.ID,
 		Phase:           "running",
 		RuntimeBrokerID: tid("broker-msg"),
-		Visibility:      store.VisibilityPrivate,
 	}
 	if err := s.CreateAgent(ctx, agent); err != nil {
 		t.Fatal(err)

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -165,7 +165,7 @@ func (s *Server) createHarnessConfig(w http.ResponseWriter, r *http.Request) {
 		Config:      req.Config,
 		Scope:       req.Scope,
 		ScopeID:     req.ScopeID,
-		Visibility:  req.Visibility,
+		Visibility:  api.NormalizeVisibility(req.Visibility),
 		Status:      store.HarnessConfigStatusPending,
 	}
 
@@ -351,7 +351,7 @@ func (s *Server) patchHarnessConfig(w http.ResponseWriter, r *http.Request, id s
 		existing.Description = updates.Description
 	}
 	if updates.Visibility != "" {
-		existing.Visibility = updates.Visibility
+		existing.Visibility = api.NormalizeVisibility(updates.Visibility)
 	}
 
 	if err := s.store.UpdateHarnessConfig(ctx, existing); err != nil {

--- a/pkg/hub/heartbeat_timeout_test.go
+++ b/pkg/hub/heartbeat_timeout_test.go
@@ -100,7 +100,6 @@ func TestAgentHeartbeatTimeoutHandler_MarksStaleAgents(t *testing.T) {
 		Template:   "claude",
 		ProjectID:  project.ID,
 		Phase:      string(state.PhaseCreated),
-		Visibility: store.VisibilityPrivate,
 	}
 	if err := s.CreateAgent(ctx, staleAgent); err != nil {
 		t.Fatalf("failed to create agent: %v", err)
@@ -121,7 +120,6 @@ func TestAgentHeartbeatTimeoutHandler_MarksStaleAgents(t *testing.T) {
 		Template:   "claude",
 		ProjectID:  project.ID,
 		Phase:      string(state.PhaseStopped),
-		Visibility: store.VisibilityPrivate,
 	}
 	if err := s.CreateAgent(ctx, stoppedAgent); err != nil {
 		t.Fatalf("failed to create stopped agent: %v", err)
@@ -189,7 +187,6 @@ func TestAgentHeartbeatTimeoutHandler_ClearedBySubsequentHeartbeat(t *testing.T)
 		Template:  "claude",
 		ProjectID: project.ID,
 		Phase:     string(state.PhaseRunning), Activity: string(state.ActivityOffline),
-		Visibility: store.VisibilityPrivate,
 	}
 	if err := s.CreateAgent(ctx, agent); err != nil {
 		t.Fatalf("failed to create agent: %v", err)

--- a/pkg/hub/messagebroker_test.go
+++ b/pkg/hub/messagebroker_test.go
@@ -149,7 +149,6 @@ func setupBrokerTestAgent(t *testing.T, s store.Store, projectID, slug, phase st
 		ProjectID:       projectID,
 		Phase:           phase,
 		RuntimeBrokerID: tid("broker-1"),
-		Visibility:      store.VisibilityPrivate,
 	}
 	if err := s.CreateAgent(context.Background(), agent); err != nil {
 		t.Fatalf("failed to create agent: %v", err)

--- a/pkg/hub/notifications_integration_test.go
+++ b/pkg/hub/notifications_integration_test.go
@@ -196,7 +196,6 @@ func TestIntegration_AgentCreatesAgentWithNotify_FullFlow(t *testing.T) {
 		ProjectID:       env.project.ID,
 		Phase:           string(state.PhaseRunning),
 		RuntimeBrokerID: env.broker.ID,
-		Visibility:      store.VisibilityPrivate,
 	}
 	require.NoError(t, env.store.CreateAgent(ctx, parent))
 
@@ -252,7 +251,6 @@ func TestIntegration_AgentCreatesAgentWithNotify_WaitingForInput(t *testing.T) {
 		ProjectID:       env.project.ID,
 		Phase:           string(state.PhaseRunning),
 		RuntimeBrokerID: env.broker.ID,
-		Visibility:      store.VisibilityPrivate,
 	}
 	require.NoError(t, env.store.CreateAgent(ctx, parent))
 
@@ -300,7 +298,6 @@ func TestIntegration_AgentCreatesAgentWithNotify_MultipleStatusChanges(t *testin
 		ProjectID:       env.project.ID,
 		Phase:           string(state.PhaseRunning),
 		RuntimeBrokerID: env.broker.ID,
-		Visibility:      store.VisibilityPrivate,
 	}
 	require.NoError(t, env.store.CreateAgent(ctx, parent))
 
@@ -358,7 +355,6 @@ func TestIntegration_StatusNormalization_LowercaseEventMatchesUppercaseTrigger(t
 		ProjectID:       env.project.ID,
 		Phase:           string(state.PhaseRunning),
 		RuntimeBrokerID: env.broker.ID,
-		Visibility:      store.VisibilityPrivate,
 	}
 	require.NoError(t, env.store.CreateAgent(ctx, parent))
 
@@ -395,7 +391,6 @@ func TestIntegration_StatusNormalization_DedupAcrossCaseBoundaries(t *testing.T)
 		ProjectID:       env.project.ID,
 		Phase:           string(state.PhaseRunning),
 		RuntimeBrokerID: env.broker.ID,
-		Visibility:      store.VisibilityPrivate,
 	}
 	require.NoError(t, env.store.CreateAgent(ctx, parent))
 
@@ -436,7 +431,6 @@ func TestIntegration_StatusNormalization_NonTriggerStatusNoNotification(t *testi
 		ProjectID:       env.project.ID,
 		Phase:           string(state.PhaseRunning),
 		RuntimeBrokerID: env.broker.ID,
-		Visibility:      store.VisibilityPrivate,
 	}
 	require.NoError(t, env.store.CreateAgent(ctx, parent))
 
@@ -486,7 +480,6 @@ func TestIntegration_SubscriptionCleanup_HardDeleteCascades(t *testing.T) {
 		ProjectID:       env.project.ID,
 		Phase:           string(state.PhaseRunning),
 		RuntimeBrokerID: env.broker.ID,
-		Visibility:      store.VisibilityPrivate,
 	}
 	require.NoError(t, env.store.CreateAgent(ctx, parent))
 
@@ -538,7 +531,6 @@ func TestIntegration_SubscriptionCleanup_SoftDeleteRetainsSubscriptions(t *testi
 		ProjectID:       env.project.ID,
 		Phase:           string(state.PhaseRunning),
 		RuntimeBrokerID: env.broker.ID,
-		Visibility:      store.VisibilityPrivate,
 	}
 	require.NoError(t, env.store.CreateAgent(ctx, parent))
 
@@ -751,7 +743,6 @@ func TestIntegration_MultipleSubscribers_AgentAndUser(t *testing.T) {
 		ProjectID:       env.project.ID,
 		Phase:           string(state.PhaseRunning),
 		RuntimeBrokerID: env.broker.ID,
-		Visibility:      store.VisibilityPrivate,
 	}
 	require.NoError(t, env.store.CreateAgent(ctx, parent))
 
@@ -812,7 +803,6 @@ func TestIntegration_NoNotifyFlag_NoSubscription(t *testing.T) {
 		ProjectID:       env.project.ID,
 		Phase:           string(state.PhaseRunning),
 		RuntimeBrokerID: env.broker.ID,
-		Visibility:      store.VisibilityPrivate,
 	}
 	require.NoError(t, env.store.CreateAgent(ctx, parent))
 

--- a/pkg/hub/notifications_test.go
+++ b/pkg/hub/notifications_test.go
@@ -189,7 +189,6 @@ func setupNotificationTest(t *testing.T) *notificationTestEnv {
 		ProjectID:       project.ID,
 		Phase:           string(state.PhaseRunning),
 		RuntimeBrokerID: tid("broker-1"),
-		Visibility:      store.VisibilityPrivate,
 	}
 	require.NoError(t, s.CreateAgent(ctx, watched))
 
@@ -201,7 +200,6 @@ func setupNotificationTest(t *testing.T) *notificationTestEnv {
 		ProjectID:       project.ID,
 		Phase:           string(state.PhaseRunning),
 		RuntimeBrokerID: tid("broker-1"),
-		Visibility:      store.VisibilityPrivate,
 	}
 	require.NoError(t, s.CreateAgent(ctx, subscriber))
 

--- a/pkg/hub/seed.go
+++ b/pkg/hub/seed.go
@@ -47,18 +47,32 @@ func seedDefaultPoliciesAndGroups(ctx context.Context, s store.Store) {
 		slog.Info("seeded hub-members group", "id", group.ID)
 	}
 
-	// 2. Seed hub-member-read-all policy
-	seedPolicy(ctx, s, group.ID, &store.Policy{
-		ID:           api.NewUUID(),
-		Name:         "hub-member-read-all",
-		Description:  "Allow hub members to read all resources",
-		ScopeType:    "hub",
-		ResourceType: "*",
-		Actions:      []string{"read", "list"},
-		Effect:       "allow",
-	})
+	// 2. Migrate: remove legacy hub-member-read-all wildcard policy if present.
+	// This policy granted read/list on ResourceType:"*" which is too broad —
+	// project, agent, broker visibility is now membership-gated.
+	retirePolicy(ctx, s, group.ID, "hub-member-read-all")
 
-	// 3. Seed hub-member-create-projects policy
+	// 3. Seed explicit per-type read/list policies for hub-readable types only.
+	// GATE (membership-derived, NOT seeded here): project, agent, broker.
+	// SENSITIVE (NOT seeded here): policy, gcp_service_account, secret, environment, variable.
+	for _, rt := range []struct{ name, desc, resourceType string }{
+		{"hub-member-read-user", "Allow hub members to read users", "user"},
+		{"hub-member-read-group", "Allow hub members to read groups", "group"},
+		{"hub-member-read-template", "Allow hub members to read templates", "template"},
+		{"hub-member-read-harness-config", "Allow hub members to read harness configs", "harness_config"},
+	} {
+		seedPolicy(ctx, s, group.ID, &store.Policy{
+			ID:           api.NewUUID(),
+			Name:         rt.name,
+			Description:  rt.desc,
+			ScopeType:    "hub",
+			ResourceType: rt.resourceType,
+			Actions:      []string{"read", "list"},
+			Effect:       "allow",
+		})
+	}
+
+	// 4. Seed hub-member-create-projects policy
 	seedPolicy(ctx, s, group.ID, &store.Policy{
 		ID:           api.NewUUID(),
 		Name:         "hub-member-create-projects",
@@ -68,6 +82,24 @@ func seedDefaultPoliciesAndGroups(ctx context.Context, s store.Store) {
 		Actions:      []string{"create"},
 		Effect:       "allow",
 	})
+}
+
+// retirePolicy removes a policy by name and its binding to the given group.
+// No-op if the policy does not exist.
+func retirePolicy(ctx context.Context, s store.Store, groupID, policyName string) {
+	existing, err := s.ListPolicies(ctx, store.PolicyFilter{Name: policyName}, store.ListOptions{Limit: 1})
+	if err != nil || existing.TotalCount == 0 {
+		return
+	}
+	p := existing.Items[0]
+	if err := s.RemovePolicyBinding(ctx, p.ID, "group", groupID); err != nil {
+		slog.Warn("failed to remove binding for retired policy", "name", policyName, "error", err)
+	}
+	if err := s.DeletePolicy(ctx, p.ID); err != nil {
+		slog.Warn("failed to delete retired policy", "name", policyName, "error", err)
+	} else {
+		slog.Info("retired legacy policy", "name", policyName, "id", p.ID)
+	}
 }
 
 // seedPolicy creates a policy and binds it to the given group, skipping

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -831,6 +831,13 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 	// Seed default policies and groups (idempotent)
 	seedDefaultPoliciesAndGroups(ctx, s)
 
+	// Backfill project visibility policies for existing projects (idempotent).
+	// This seeds the project-scoped member read policies and runs the one-time
+	// members→admin migration for every existing project, so the read gates in
+	// getProject/getProjectAgent evaluate correctly from the first request
+	// (a member must not be locked out waiting for a lazy backfill).
+	srv.backfillProjectVisibility(ctx)
+
 	// Seed the dev user when dev-auth is enabled so that Ent FK constraints
 	// on owner_id are satisfied when the dev user creates projects/groups.
 	if cfg.DevAuthToken != "" {

--- a/pkg/hub/stalled_detection_test.go
+++ b/pkg/hub/stalled_detection_test.go
@@ -75,7 +75,6 @@ func TestAgentStalledDetectionHandler_MarksStalledAgents(t *testing.T) {
 		Template:   "claude",
 		ProjectID:  project.ID,
 		Phase:      string(state.PhaseCreated),
-		Visibility: store.VisibilityPrivate,
 	}
 	if err := s.CreateAgent(ctx, agent); err != nil {
 		t.Fatalf("failed to create agent: %v", err)
@@ -160,7 +159,6 @@ func TestAgentStalledDetectionHandler_ClearedByActivityEvent(t *testing.T) {
 		Template:   "claude",
 		ProjectID:  project.ID,
 		Phase:      string(state.PhaseCreated),
-		Visibility: store.VisibilityPrivate,
 	}
 	if err := s.CreateAgent(ctx, agent); err != nil {
 		t.Fatalf("failed to create agent: %v", err)
@@ -221,7 +219,6 @@ func TestAgentStalledDetectionHandler_StalledFromActivityIsPreserved(t *testing.
 		Template:   "claude",
 		ProjectID:  project.ID,
 		Phase:      string(state.PhaseCreated),
-		Visibility: store.VisibilityPrivate,
 	}
 	if err := s.CreateAgent(ctx, agent); err != nil {
 		t.Fatalf("failed to create agent: %v", err)
@@ -302,7 +299,6 @@ func TestAgentStalledDetectionHandler_BlockedAgentNotStalled(t *testing.T) {
 		Template:   "claude",
 		ProjectID:  project.ID,
 		Phase:      string(state.PhaseCreated),
-		Visibility: store.VisibilityPrivate,
 	}
 	if err := s.CreateAgent(ctx, agent); err != nil {
 		t.Fatalf("failed to create agent: %v", err)
@@ -366,7 +362,6 @@ func TestAgentStalledDetectionHandler_IdleAgentMarkedStalled(t *testing.T) {
 		Template:   "claude",
 		ProjectID:  project.ID,
 		Phase:      string(state.PhaseCreated),
-		Visibility: store.VisibilityPrivate,
 	}
 	if err := s.CreateAgent(ctx, agent); err != nil {
 		t.Fatalf("failed to create agent: %v", err)

--- a/pkg/hub/template_handlers.go
+++ b/pkg/hub/template_handlers.go
@@ -268,7 +268,7 @@ func (s *Server) createTemplateV2(w http.ResponseWriter, r *http.Request) {
 		ScopeID:      scopeID,
 		ProjectID:    scopeID, // Keep for backwards compat
 		BaseTemplate: req.BaseTemplate,
-		Visibility:   req.Visibility,
+		Visibility:   api.NormalizeVisibility(req.Visibility),
 		Status:       store.TemplateStatusPending, // Start as pending until files uploaded
 	}
 
@@ -467,7 +467,7 @@ func (s *Server) patchTemplateV2(w http.ResponseWriter, r *http.Request, id stri
 		existing.Description = updates.Description
 	}
 	if updates.Visibility != "" {
-		existing.Visibility = updates.Visibility
+		existing.Visibility = api.NormalizeVisibility(updates.Visibility)
 	}
 
 	if err := s.store.UpdateTemplate(ctx, existing); err != nil {
@@ -790,7 +790,7 @@ func (s *Server) handleTemplateClone(w http.ResponseWriter, r *http.Request, id 
 		ScopeID:      scopeID,
 		ProjectID:    scopeID,
 		BaseTemplate: source.ID, // Track the source template
-		Visibility:   req.Visibility,
+		Visibility:   api.NormalizeVisibility(req.Visibility),
 		Status:       store.TemplateStatusPending,
 	}
 

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -108,7 +108,6 @@ func entAgentToStore(a *ent.Agent) *store.Agent {
 		Message:             a.Message,
 		Created:             a.Created,
 		Updated:             a.Updated,
-		Visibility:          a.Visibility,
 		Ancestry:            a.Ancestry,
 		StateVersion:        a.StateVersion,
 	}
@@ -181,9 +180,6 @@ func (s *AgentStore) CreateAgent(ctx context.Context, a *store.Agent) error {
 		SetUpdated(now).
 		SetStateVersion(a.StateVersion)
 
-	if a.Visibility != "" {
-		create.SetVisibility(a.Visibility)
-	}
 	if a.Labels != nil {
 		create.SetLabels(a.Labels)
 	}
@@ -295,7 +291,6 @@ func (s *AgentStore) UpdateAgent(ctx context.Context, a *store.Agent) error {
 		SetWebPtyEnabled(a.WebPTYEnabled).
 		SetTaskSummary(a.TaskSummary).
 		SetMessage(a.Message).
-		SetVisibility(a.Visibility).
 		SetUpdated(now).
 		SetStateVersion(newVersion)
 

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -469,7 +469,7 @@ type Template struct {
 	OwnerID    string `json:"ownerId,omitempty"`
 	CreatedBy  string `json:"createdBy,omitempty"`
 	UpdatedBy  string `json:"updatedBy,omitempty"`
-	Visibility string `json:"visibility"` // private, project, public
+	Visibility string `json:"visibility"` // private, team, public
 
 	// Timestamps
 	Created time.Time `json:"created"`
@@ -562,7 +562,7 @@ type HarnessConfig struct {
 	OwnerID    string `json:"ownerId,omitempty"`
 	CreatedBy  string `json:"createdBy,omitempty"`
 	UpdatedBy  string `json:"updatedBy,omitempty"`
-	Visibility string `json:"visibility"` // private, project, public
+	Visibility string `json:"visibility"` // private, team, public
 
 	// Timestamps
 	Created time.Time `json:"created"`

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -81,9 +81,8 @@ type Agent struct {
 	DeletedAt         time.Time `json:"deletedAt,omitempty"`
 
 	// Ownership
-	CreatedBy  string `json:"createdBy,omitempty"`
-	OwnerID    string `json:"ownerId,omitempty"`
-	Visibility string `json:"visibility"` // private, team, public
+	CreatedBy string `json:"createdBy,omitempty"`
+	OwnerID   string `json:"ownerId,omitempty"`
 
 	// Ancestry chain for transitive access control.
 	// Ordered list of ancestor IDs: [root, ..., parent].
@@ -1659,10 +1658,9 @@ func (a *Agent) ToAPI() *api.AgentInfo {
 		DeletedAt: a.DeletedAt,
 
 		// Ownership
-		CreatedBy:  a.CreatedBy,
-		OwnerID:    a.OwnerID,
-		Visibility: a.Visibility,
-		Ancestry:   a.Ancestry,
+		CreatedBy: a.CreatedBy,
+		OwnerID:   a.OwnerID,
+		Ancestry:  a.Ancestry,
 
 		// Optimistic locking
 		StateVersion: a.StateVersion,

--- a/pkg/store/storetest/domains.go
+++ b/pkg/store/storetest/domains.go
@@ -442,8 +442,7 @@ func newOracleAgent(slug string) *store.Agent {
 		Name:       slug,
 		Template:   "default",
 		ProjectID:  agentDomainProjectID,
-		Phase:      "running",
-		Visibility: "private",
+		Phase: "running",
 	}
 }
 
@@ -477,10 +476,9 @@ func AgentDomain() Domain[store.Agent] {
 				Name:       fmt.Sprintf("Agent %d", seq),
 				Template:   "default",
 				ProjectID:  agentDomainProjectID,
-				Phase:      "running",
-				Activity:   "thinking",
-				Visibility: "private",
-				Labels:     map[string]string{"seq": fmt.Sprintf("%d", seq)},
+				Phase:    "running",
+				Activity: "thinking",
+				Labels:   map[string]string{"seq": fmt.Sprintf("%d", seq)},
 			}
 		},
 		GetID: func(a *store.Agent) string { return a.ID },

--- a/web/src/components/pages/project-create.ts
+++ b/web/src/components/pages/project-create.ts
@@ -61,9 +61,6 @@ export class ScionPageProjectCreate extends LitElement {
   private branch = 'main';
 
   @state()
-  private visibility = 'private';
-
-  @state()
   private mode: ProjectMode = 'hub';
 
   @state()
@@ -370,7 +367,6 @@ export class ScionPageProjectCreate extends LitElement {
     try {
       const body: Record<string, unknown> = {
         name: this.name.trim(),
-        visibility: this.visibility,
       };
 
       if (this.slug.trim()) {
@@ -605,21 +601,6 @@ export class ScionPageProjectCreate extends LitElement {
                 </div>
               `
             : nothing}
-
-          <div class="form-field">
-            <label for="visibility">Visibility</label>
-            <sl-select
-              id="visibility"
-              .value=${this.visibility}
-              @sl-change=${(e: Event) => {
-                this.visibility = (e.target as HTMLElement & { value: string }).value;
-              }}
-            >
-              <sl-option value="private">Private</sl-option>
-              <sl-option value="team">Team</sl-option>
-              <sl-option value="public">Public</sl-option>
-            </sl-select>
-          </div>
 
           <div class="form-actions">
             <sl-button

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -1054,8 +1054,9 @@ export class ScionPageProjectSettings extends LitElement {
               groupId=${this.membersGroup.id}
               ?readOnly=${!canAny(this.project._capabilities, 'update', 'manage')}
               compact
+              showProjectMembersHint
               sectionTitle="Members"
-              sectionDescription="Users and groups who can create and manage agents in this project."
+              sectionDescription="Users and groups who can access this project and its agents."
             ></scion-group-member-editor>
           `
         : ''}

--- a/web/src/components/shared/group-member-editor.ts
+++ b/web/src/components/shared/group-member-editor.ts
@@ -47,6 +47,9 @@ export class ScionGroupMemberEditor extends LitElement {
   /** Section description override */
   @property() sectionDescription = '';
 
+  /** Show a hint about adding hub-members group for project-wide visibility */
+  @property({ type: Boolean }) showProjectMembersHint = false;
+
   @state() private loading = true;
   @state() private members: GroupMember[] = [];
   @state() private error: string | null = null;
@@ -406,6 +409,23 @@ export class ScionGroupMemberEditor extends LitElement {
       color: var(--scion-text-muted, #64748b);
     }
 
+    .project-members-hint {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.5rem;
+      font-size: 0.8125rem;
+      color: var(--scion-text-muted, #64748b);
+      padding: 0.625rem 0.75rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border-radius: var(--scion-radius, 0.5rem);
+      margin-top: 1rem;
+    }
+
+    .project-members-hint sl-icon {
+      flex-shrink: 0;
+      margin-top: 0.125rem;
+    }
+
     @media (max-width: 768px) {
       .hide-mobile {
         display: none;
@@ -706,6 +726,14 @@ export class ScionGroupMemberEditor extends LitElement {
           : this.members.length === 0
             ? this.renderEmptyMembers()
             : this.renderMembersTable()}
+        ${this.showProjectMembersHint
+          ? html`
+              <div class="project-members-hint">
+                <sl-icon name="info-circle"></sl-icon>
+                <span>To make this project visible to all hub users, add the <strong>hub-members</strong> group.</span>
+              </div>
+            `
+          : nothing}
         ${this.renderAddDialog()}
       </div>
     `;


### PR DESCRIPTION
## Project Visibility via Membership (subtractive model)

Implements the approved design in `.design/project-visibility-membership.md` (+ `.design/project-visibility-implementation-plan.md`). Visibility (private / team / everyone) is **emergent from the project members group**, not a stored enum. "Everyone/all hub users" = adding the existing `hub-members` group as a project member.

**Do not merge yet** — opening for review per the engagement.

### What changed
- **Narrow the global read-all grant** (`seed.go`): the `hub-member-read-all` wildcard (`resourceType:"*"`) is retired and replaced with explicit per-type read/list policies for directory/catalog types only — `user`, `group`, `template`, `harness_config`. `project`/`agent`/`broker` are now membership-gated; sensitive types (`policy`, `gcp_service_account`, `secret`/`environment`/`variable`) are no longer world-readable. Existing hubs migrate automatically (old policy found by name, unbound, deleted).
- **Project-scoped member read** (`createProjectMembersGroupAndPolicy`): members get `member-read-project` (ResourceID-pinned to avoid cross-project leakage) and `member-read-agents` policies. The old `member-create-agents` policy is retired.
- **Role-aware (subtractive)**: read is granted to the whole members group; create/manage flows from the existing `isProjectOwnerOrAdmin` role bypass (admin/owner). No policy-engine change. (Role-in-`PolicyBinding` recorded as a future improvement in the design doc.)
- **Members→admin migration**: one-time, idempotent — uses the presence of the legacy `member-create-agents` policy as the "not yet migrated" marker; only touches `project:<slug>:members` groups (never `hub-members`). Plus a startup `backfillProjectVisibility` loop so all existing projects are migrated/seeded before the first request.
- **Enforcement gaps closed**: `getProject` and `getProjectAgent` now gate reads via `CheckAccess(ActionRead)`; `listProjects`/`listAgents`/`getProject`/`getProjectAgent`/broker reads **fail closed** on nil identity (401). No anonymous read surface.
- **Cross-project agent list**: default scope is now membership-gated in SQL (`project_id IN (...) OR owner_id`), with `resolveUserProjectIDs` cached per request. (Agent `project_id` index added in WP-0.)
- **Brokers**: read = owner ∨ hub admin ∨ member of any contributing project (`canReadBroker` via `ProjectContributor`); cross-broker list scoped the same; freshly-registered brokers are owner-only until attached.
- **Frontend (WP-D)**: visibility selector removed from create-project; Members card gains a hint to add `hub-members` for hub-wide visibility.
- **WP-0 (schema)**: agent `project_id` index added; inert agent `visibility` field dropped + regenerated.
- **grove-cleanup**: legacy `grove`/`project` visibility normalization cherry-picked in as a discrete commit (templates/harness keep their visibility field; wire-compat shims untouched).

### Testing
- `go build ./...` ✅, `go vet ./pkg/hub/...` ✅
- Hub test suite: all behavior-change tests updated to the new model (real membership setup, not weakened assertions); **zero regressions** vs. the branch base.
- 16 hub failures are **pre-existing/sandbox-only** (network/credential-dependent: `*ImportFromRemote*`, `*ResourcesImport*`, etc.) — confirmed identical on `origin/main`, unrelated to this branch.
- Web `tsc --noEmit` (typecheck) ✅. (Repo-wide ESLint/gofmt debt pre-exists on `main`; this branch adds none on its changed lines.)

### Deferred (follow-ups, per design)
- Templates/harness-config visibility + grove-attachment semantics (OQ9).
- Finer-grained / role-in-policy engine; project-scoped derivation for sensitive resources beyond the admin/owner bypass.
