### PR TITLE
fix(ci): add missing !no_sqlite build tag to signing_key_shared_test.go

### DIFF
--- a/pkg/hub/signing_key_shared_test.go
+++ b/pkg/hub/signing_key_shared_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !no_sqlite
+
 package hub
 
 import (


### PR DESCRIPTION
## Summary
- `signing_key_shared_test.go` (introduced in PR 328) calls `newTestStore()` which is only defined in `!no_sqlite`-gated files
- Missing the `//go:build !no_sqlite` tag causes `go vet -tags no_sqlite` to fail with `undefined: newTestStore`
- Same pattern fixed in PR 150 for `command_bus_test.go` and `broker_affinity_test.go`

## Test plan
- [x] `go vet -tags no_sqlite ./pkg/hub/...` passes
- [x] `gofmt -l .` returns no files
- [ ] CI should pass on this PR
