### PR TITLE
feat: auto-prefix bare email recipients with user: in scion message

### DIFF
--- a/cmd/message.go
+++ b/cmd/message.go
@@ -93,9 +93,7 @@ Examples:
 			} else if strings.HasPrefix(recipient, "user:") {
 				userRecipient = recipient
 			} else if strings.Contains(recipient, "@") && !strings.HasPrefix(recipient, "agent:") {
-				// Bare email address without user: prefix — return a clear error
-				// instead of silently converting, which can lead to undelivered messages.
-				return fmt.Errorf("recipient %q looks like an email address but is missing the \"user:\" prefix.\n\nDid you mean?\n  scion message user:%s %q", recipient, recipient, message)
+				userRecipient = "user:" + recipient
 			} else {
 				// Strip optional "agent:" prefix for backwards compatibility
 				agentName = api.Slugify(strings.TrimPrefix(recipient, "agent:"))

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -981,29 +981,22 @@ func TestSendMessageViaHub_WakePassedThrough(t *testing.T) {
 	mu.Unlock()
 }
 
-func TestBareEmailRecipientReturnsError(t *testing.T) {
+func TestBareEmailRecipientAutoPrefix(t *testing.T) {
 	tests := []struct {
-		name        string
-		args        []string
-		wantErr     string
-		wantSuggest string
+		name string
+		args []string
 	}{
 		{
-			name:        "bare email returns error with suggestion",
-			args:        []string{"alice@example.com", "hello"},
-			wantErr:     `looks like an email address but is missing the "user:" prefix`,
-			wantSuggest: "user:alice@example.com",
+			name: "bare email is accepted without user: prefix",
+			args: []string{"alice@example.com", "hello"},
 		},
 		{
-			name:        "bare email with subdomain",
-			args:        []string{"bob@corp.example.com", "check this out"},
-			wantErr:     `looks like an email address but is missing the "user:" prefix`,
-			wantSuggest: "user:bob@corp.example.com",
+			name: "bare email with subdomain is accepted",
+			args: []string{"bob@corp.example.com", "check this out"},
 		},
 		{
-			name:    "user-prefixed email is accepted (no error at parse stage)",
-			args:    []string{"user:alice@example.com", "hello"},
-			wantErr: "", // no parse error — fails later for other reasons (Hub, etc.)
+			name: "user-prefixed email is still accepted",
+			args: []string{"user:alice@example.com", "hello"},
 		},
 	}
 
@@ -1032,19 +1025,12 @@ func TestBareEmailRecipientReturnsError(t *testing.T) {
 
 			err := messageCmd.RunE(messageCmd, tc.args)
 
-			if tc.wantErr == "" {
-				// We expect no error at the recipient parsing stage.
-				// The command will still fail (Hub not configured, etc.)
-				// but NOT with our email-specific error.
-				if err != nil {
-					assert.NotContains(t, err.Error(), "looks like an email address")
-				}
-			} else {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.wantErr)
-				if tc.wantSuggest != "" {
-					assert.Contains(t, err.Error(), tc.wantSuggest)
-				}
+			// No error at the recipient parsing stage.
+			// The command may still fail (Hub not configured, etc.)
+			// but NOT with an email-specific error.
+			if err != nil {
+				assert.NotContains(t, err.Error(), "looks like an email address")
+				assert.NotContains(t, err.Error(), "missing the \"user:\" prefix")
 			}
 		})
 	}


### PR DESCRIPTION
Instead of returning an error when a bare email address (without the "user:" prefix) is passed as a recipient to `scion message`, auto-resolve it as a user recipient by internally prepending "user:". This matches the existing behavior of classifyRecipient() for group (set[]) recipients.

Fixes #159

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
