### PR TITLE
fix(scion-telegram): update group_links on supergroup migration inste…

### DIFF
--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -722,9 +722,32 @@ func (b *TelegramBrokerV2) Publish(ctx context.Context, topic string, msg *messa
 				continue
 			}
 			if errors.As(err, &apiErr) && apiErr.IsMigrated() {
-				b.log.Warn("Group upgraded to supergroup, skipping message",
-					"old_chat_id", chatID, "new_chat_id", apiErr.MigrateToChatID)
-				continue // TODO: migrate group_links record to new chat_id
+				newChatID := apiErr.MigrateToChatID
+				b.log.Info("Group upgraded to supergroup, migrating",
+					"old_chat_id", chatID, "new_chat_id", newChatID)
+				if store != nil {
+					if merr := store.MigrateGroupLink(ctx, chatID, newChatID); merr != nil {
+						b.log.Error("Failed to migrate group_link", "error", merr)
+					}
+				}
+				// Retry send with the new chat_id.
+				if sq != nil {
+					var keyboard *InlineKeyboardMarkup
+					if replyToMsgID > 0 {
+						_, err = sq.Send(ctx, newChatID, text, "", keyboard, replyToMsgID, threadOpts...)
+					} else {
+						_, err = sq.Send(ctx, newChatID, text, "", nil, 0, threadOpts...)
+					}
+				} else if replyToMsgID > 0 {
+					_, err = api.SendMessageWithKeyboard(ctx, newChatID, text, "", nil, replyToMsgID, threadOpts...)
+				} else {
+					_, err = api.SendMessage(ctx, newChatID, text, "", threadOpts...)
+				}
+				if err != nil {
+					b.log.Error("Retry after migration failed", "chat_id", newChatID, "error", err)
+					errs = append(errs, err)
+				}
+				continue
 			}
 			b.log.Error("Failed to send Telegram message",
 				"chat_id", chatID, "error", err)
@@ -864,9 +887,42 @@ func (b *TelegramBrokerV2) publishInputNeeded(ctx context.Context, api *Telegram
 				continue
 			}
 			if errors.As(err, &apiErr) && apiErr.IsMigrated() {
-				b.log.Warn("Group upgraded to supergroup, skipping input-needed",
-					"old_chat_id", chatID, "new_chat_id", apiErr.MigrateToChatID)
-				continue // TODO: migrate group_links record to new chat_id
+				newChatID := apiErr.MigrateToChatID
+				b.log.Info("Group upgraded to supergroup, migrating",
+					"old_chat_id", chatID, "new_chat_id", newChatID)
+				if b.store != nil {
+					if merr := b.store.MigrateGroupLink(ctx, chatID, newChatID); merr != nil {
+						b.log.Error("Failed to migrate group_link", "error", merr)
+					}
+				}
+				// Retry send with the new chat_id.
+				keyboard = buildAskUserKeyboard(requestID, choices)
+				if sq != nil {
+					sent, err = sq.Send(ctx, newChatID, text, "", keyboard, 0)
+				} else if keyboard == nil {
+					sent, err = api.SendMessage(ctx, newChatID, text, "")
+				} else {
+					sent, err = api.SendMessageWithKeyboard(ctx, newChatID, text, "", keyboard, 0)
+				}
+				if err != nil {
+					b.log.Error("Retry after migration failed", "chat_id", newChatID, "error", err)
+					errs = append(errs, err)
+					continue
+				}
+				// Save PendingAskUser with the new chat_id.
+				pending := &PendingAskUser{
+					RequestID: requestID,
+					MessageID: sent.MessageID,
+					ChatID:    newChatID,
+					AgentSlug: agentSlug,
+					ProjectID: projectID,
+					Choices:   choices,
+					ExpiresAt: time.Now().Add(askUserExpiry),
+				}
+				if perr := b.store.SavePendingAskUser(ctx, pending); perr != nil {
+					b.log.Error("Failed to save pending ask user after migration", "error", perr)
+				}
+				continue
 			}
 			b.log.Error("Failed to send input-needed message",
 				"chat_id", chatID, "error", err)

--- a/extras/scion-telegram/internal/telegram/store.go
+++ b/extras/scion-telegram/internal/telegram/store.go
@@ -72,6 +72,10 @@ type Store interface {
 	SetTopicDefault(ctx context.Context, chatID int64, threadID int64, agentSlug string) error
 	DeleteTopicDefault(ctx context.Context, chatID int64, threadID int64) error
 
+	// MigrateGroupLink atomically moves a group_link and its topic_defaults
+	// from oldChatID to newChatID (used when Telegram upgrades a group to a supergroup).
+	MigrateGroupLink(ctx context.Context, oldChatID, newChatID int64) error
+
 	// Lifecycle
 	Close() error
 }
@@ -315,6 +319,44 @@ func (s *sqliteStore) GetAllGroupLinks(ctx context.Context) ([]*GroupLink, error
 func (s *sqliteStore) DeleteGroupLink(ctx context.Context, chatID int64) error {
 	_, err := s.db.ExecContext(ctx, `DELETE FROM group_links WHERE chat_id = ?`, chatID)
 	return err
+}
+
+func (s *sqliteStore) MigrateGroupLink(ctx context.Context, oldChatID, newChatID int64) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Copy the group_link to the new chat_id.
+	_, err = tx.ExecContext(ctx, `
+INSERT OR REPLACE INTO group_links
+  (chat_id, chat_title, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, notify_in_group, show_assistant_reply)
+SELECT ?, chat_title, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, notify_in_group, show_assistant_reply
+FROM group_links WHERE chat_id = ?`, newChatID, oldChatID)
+	if err != nil {
+		return fmt.Errorf("copy group_link: %w", err)
+	}
+
+	_, err = tx.ExecContext(ctx, `DELETE FROM group_links WHERE chat_id = ?`, oldChatID)
+	if err != nil {
+		return fmt.Errorf("delete old group_link: %w", err)
+	}
+
+	// Migrate any topic_defaults rows to the new chat_id.
+	_, err = tx.ExecContext(ctx, `
+INSERT OR REPLACE INTO topic_defaults (chat_id, thread_id, agent_slug)
+SELECT ?, thread_id, agent_slug FROM topic_defaults WHERE chat_id = ?`, newChatID, oldChatID)
+	if err != nil {
+		return fmt.Errorf("copy topic_defaults: %w", err)
+	}
+
+	_, err = tx.ExecContext(ctx, `DELETE FROM topic_defaults WHERE chat_id = ?`, oldChatID)
+	if err != nil {
+		return fmt.Errorf("delete old topic_defaults: %w", err)
+	}
+
+	return tx.Commit()
 }
 
 // --- ConversationContext ---


### PR DESCRIPTION
…ad of dropping messages

When Telegram upgrades a group to a supergroup the chat_id changes and the API returns migrate_to_chat_id. Previously the plugin logged a warning and silently dropped the outbound message. Now it atomically migrates the group_links and topic_defaults records to the new chat_id and retries the send, preserving thread_id routing.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
