### PR TITLE
fix: remove unused _linkedDiscordId property to fix typecheck CI

### DIFF
--- a/web/src/components/pages/profile-discord.ts
+++ b/web/src/components/pages/profile-discord.ts
@@ -37,9 +37,6 @@ export class ScionPageProfileDiscord extends LitElement {
   private _message = '';
 
   @state()
-  private _linkedDiscordId = '';
-
-  @state()
   private _discordUsername = '';
 
   override connectedCallback(): void {
@@ -70,13 +67,7 @@ export class ScionPageProfileDiscord extends LitElement {
       });
 
       if (resp.ok) {
-        const data = (await resp.json()) as {
-          status: string;
-          discordUserId: string;
-          user: { id: string; email: string };
-        };
         this._status = 'success';
-        this._linkedDiscordId = data.discordUserId;
         this._message = 'Discord account linked successfully! You can close this page and return to Discord.';
         this._code = '';
       } else {
@@ -239,13 +230,7 @@ export class ScionPageProfileDiscord extends LitElement {
       });
 
       if (resp.ok) {
-        const data = (await resp.json()) as {
-          status: string;
-          discordUserId: string;
-          user: { id: string; email: string };
-        };
         this._status = 'success';
-        this._linkedDiscordId = data.discordUserId;
         this._message = 'Discord account linked successfully! You can close this page and return to Discord.';
         this._code = '';
       } else {


### PR DESCRIPTION
The _linkedDiscordId @state() property was declared and assigned but never read in the template, causing TS6133 and failing the Verify Web Types CI step.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
