### PR TITLE
fix(hub): carry channel and thread_id through outbound message API

### DIFF
--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -2002,6 +2002,8 @@ type OutboundMessageRequest struct {
 	Type        string   `json:"type,omitempty"`
 	Urgent      bool     `json:"urgent,omitempty"`
 	Attachments []string `json:"attachments,omitempty"`
+	Channel     string   `json:"channel,omitempty"`
+	ThreadID    string   `json:"thread_id,omitempty"`
 }
 
 // handleAgentOutboundMessage handles POST /api/v1/agents/{id}/outbound-message.
@@ -2113,6 +2115,8 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		Type:        req.Type,
 		Urgent:      req.Urgent,
 		AgentID:     agent.ID,
+		Channel:     req.Channel,
+		ThreadID:    req.ThreadID,
 		CreatedAt:   time.Now(),
 	}
 
@@ -2126,6 +2130,8 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		Type:        storeMsg.Type,
 		Urgent:      storeMsg.Urgent,
 		Attachments: req.Attachments,
+		Channel:     req.Channel,
+		ThreadID:    req.ThreadID,
 	}
 
 	// Route through broker when available; otherwise persist and publish

--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -450,6 +450,8 @@ func (p *MessageBrokerProxy) deliverToUser(ctx context.Context, projectID, topic
 		Urgent:      msg.Urgent,
 		Broadcasted: msg.Broadcasted,
 		AgentID:     agentID,
+		Channel:     msg.Channel,
+		ThreadID:    msg.ThreadID,
 		CreatedAt:   time.Now(),
 	}
 	if err := p.store.CreateMessage(ctx, storeMsg); err != nil {


### PR DESCRIPTION
The OutboundMessageRequest struct in the hub handler was missing Channel and ThreadID fields, causing the JSON deserializer to silently drop them when agents send messages with --channel and --thread-id flags. This meant the Telegram plugin never received the thread_id, so forum-thread replies landed in the General topic instead of the target thread.

Add Channel and ThreadID to the hub-side OutboundMessageRequest, copy them into both the StructuredMessage (for broker dispatch) and the store.Message (for persistence), and also fix deliverToUser in the message broker proxy to persist these fields from inbound structured messages.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
