### PR TITLE
feat(agent-viz): add Agent Communications transcript panel

### DIFF
--- a/extras/agent-viz/README.md
+++ b/extras/agent-viz/README.md
@@ -7,6 +7,7 @@ A standalone tool that replays agent activity from Google Cloud Logging exports 
 - **File graph** -- force-directed graph of the project's file/directory tree (center)
 - **Agent ring** -- agents distributed radially around the file graph, with color-coded state icons
 - **Messages** -- transient directional pulse lines between agents, fading after ~0.5s
+- **Agent Communications panel** -- right-side scrolling transcript of inter-agent messages, kept in sync with playback (and rebuilt on seek); broadcasts are highlighted and de-duplicated. Collapse it with the −/+ button. It reads the same `message` events that drive the on-graph pulses, so no extra data source is needed.
 - **File edits** -- particles traveling from agent to file node; new files materialize with an expand effect
 - **Playback controls** -- play/pause, speed (1x--100x), time scrubber, agent and event type filters
 

--- a/extras/agent-viz/web/index.html
+++ b/extras/agent-viz/web/index.html
@@ -195,6 +195,162 @@
       flex-direction: column;
       gap: 2px;
     }
+
+    /* Agent Communications transcript panel */
+    .comms-panel {
+      position: fixed;
+      top: 52px;
+      right: 12px;
+      bottom: 110px;
+      width: 340px;
+      max-width: calc(100vw - 24px);
+      display: flex;
+      flex-direction: column;
+      background: rgba(22, 27, 34, 0.92);
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 10px;
+      box-shadow: 0 8px 30px rgba(0,0,0,0.45);
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+      overflow: hidden;
+      z-index: 15;
+    }
+
+    .comms-panel.collapsed {
+      bottom: auto;
+    }
+
+    .comms-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 8px 12px;
+      background: rgba(255,255,255,0.03);
+      border-bottom: 1px solid rgba(255,255,255,0.08);
+      flex-shrink: 0;
+    }
+
+    .comms-title {
+      font-size: 12px;
+      font-weight: 700;
+      color: #58a6ff;
+      letter-spacing: 0.3px;
+    }
+
+    .comms-subtitle {
+      font-size: 10px;
+      color: rgba(255,255,255,0.45);
+      margin-top: 1px;
+    }
+
+    .comms-toggle {
+      background: rgba(255,255,255,0.08);
+      border: 1px solid rgba(255,255,255,0.12);
+      color: #c9d1d9;
+      width: 24px;
+      height: 24px;
+      border-radius: 6px;
+      font-size: 15px;
+      line-height: 1;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+
+    .comms-toggle:hover {
+      background: rgba(255,255,255,0.16);
+    }
+
+    .comms-panel.collapsed .comms-body {
+      display: none;
+    }
+
+    .comms-body {
+      flex: 1;
+      overflow-y: auto;
+      padding: 10px 12px;
+      scrollbar-width: thin;
+      scrollbar-color: rgba(255,255,255,0.18) transparent;
+    }
+
+    .comms-msg {
+      padding: 8px 10px;
+      margin-bottom: 7px;
+      background: rgba(255,255,255,0.03);
+      border-left: 3px solid #888;
+      border-radius: 6px;
+      animation: commsFadeIn 0.32s ease-out;
+    }
+
+    .comms-msg-bcast {
+      background: rgba(34,197,94,0.10);
+      box-shadow: 0 0 14px rgba(34,197,94,0.14);
+    }
+
+    .comms-msg-meta {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 4px;
+    }
+
+    .comms-time {
+      font-size: 10px;
+      font-weight: 600;
+      color: rgba(255,255,255,0.5);
+      font-variant-numeric: tabular-nums;
+    }
+
+    .comms-index {
+      margin-left: auto;
+      font-size: 9px;
+      color: rgba(255,255,255,0.3);
+    }
+
+    .comms-badge {
+      background: rgba(34,197,94,0.2);
+      color: #86efac;
+      font-size: 8px;
+      font-weight: 700;
+      letter-spacing: 0.5px;
+      padding: 1px 5px;
+      border-radius: 3px;
+    }
+
+    .comms-route {
+      font-size: 11px;
+      font-weight: 600;
+      margin-bottom: 3px;
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      flex-wrap: wrap;
+    }
+
+    .comms-arrow {
+      color: rgba(255,255,255,0.4);
+    }
+
+    .comms-type {
+      font-size: 9px;
+      font-weight: 500;
+      color: rgba(255,255,255,0.4);
+      background: rgba(255,255,255,0.06);
+      padding: 1px 5px;
+      border-radius: 3px;
+      margin-left: auto;
+    }
+
+    .comms-content {
+      font-size: 11.5px;
+      line-height: 1.45;
+      color: #c9d1d9;
+      word-break: break-word;
+    }
+
+    @keyframes commsFadeIn {
+      from { opacity: 0; transform: translateY(6px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
   </style>
 </head>
 <body>

--- a/extras/agent-viz/web/src/comms.ts
+++ b/extras/agent-viz/web/src/comms.ts
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { MessageEvent } from './types';
+import type { AgentRing } from './agents';
+
+/**
+ * Window (in event-time ms) for collapsing duplicate broadcast deliveries into a
+ * single transcript line. A broadcast is logged once per recipient, so the same
+ * sender+content arrives several times within a short span.
+ */
+const BROADCAST_DEDUP_WINDOW_MS = 2000;
+
+interface AddOptions {
+  /**
+   * When false the card is inserted without the fade-in animation. Used while
+   * replaying a snapshot on seek, where every prior message arrives at once.
+   */
+  animate?: boolean;
+}
+
+/**
+ * CommsPanel renders a scrolling, human-readable transcript of inter-agent
+ * messages next to the force-graph. It consumes the same `message` playback
+ * events that drive the on-graph pulse lines, so it stays in sync with playback
+ * and is rebuilt from the snapshot on seek. It needs no external data source —
+ * the messages already flow through the playback stream.
+ */
+export class CommsPanel {
+  private readonly bodyEl: HTMLElement;
+  private readonly countEl: HTMLElement;
+  private readonly toggleEl: HTMLButtonElement;
+  private readonly panelEl: HTMLElement;
+  private agentRing: AgentRing | null = null;
+  private startMs: number | null = null;
+  private count = 0;
+  private collapsed = false;
+  /** Dedup state for broadcasts: `sender::content` -> last event time (ms). */
+  private readonly recentBroadcasts = new Map<string, number>();
+
+  constructor(parent: HTMLElement = document.body) {
+    const panel = document.createElement('div');
+    panel.className = 'comms-panel';
+    panel.innerHTML = `
+      <div class="comms-header">
+        <div class="comms-titles">
+          <div class="comms-title">Agent Communications</div>
+          <div class="comms-subtitle"><span class="comms-count">0</span> messages</div>
+        </div>
+        <button class="comms-toggle" title="Collapse / expand">&minus;</button>
+      </div>
+      <div class="comms-body"></div>
+    `;
+    parent.appendChild(panel);
+
+    this.panelEl = panel;
+    this.bodyEl = panel.querySelector('.comms-body') as HTMLElement;
+    this.countEl = panel.querySelector('.comms-count') as HTMLElement;
+    this.toggleEl = panel.querySelector('.comms-toggle') as HTMLButtonElement;
+
+    this.toggleEl.addEventListener('click', () => this.setCollapsed(!this.collapsed));
+  }
+
+  setAgentRing(ring: AgentRing): void {
+    this.agentRing = ring;
+  }
+
+  /** Anchor for relative `T+m:ss` timestamps (the playback start time). */
+  setStartTime(iso: string): void {
+    const ms = Date.parse(iso);
+    this.startMs = Number.isNaN(ms) ? null : ms;
+  }
+
+  /** Clear the transcript (called on a new manifest and before snapshot replay). */
+  reset(): void {
+    this.bodyEl.innerHTML = '';
+    this.count = 0;
+    this.recentBroadcasts.clear();
+    this.updateCount();
+  }
+
+  addMessage(event: MessageEvent, timestamp: string, opts: AddOptions = {}): void {
+    // Collapse duplicate broadcast deliveries (same sender+content) into one line.
+    if (event.broadcasted) {
+      const key = `${event.sender}::${event.content ?? ''}`;
+      const t = Date.parse(timestamp);
+      const prev = this.recentBroadcasts.get(key);
+      if (prev !== undefined && Math.abs(t - prev) < BROADCAST_DEDUP_WINDOW_MS) return;
+      this.recentBroadcasts.set(key, t);
+    }
+
+    // Only auto-scroll when the user is already near the bottom, so manual
+    // scroll-back to read history isn't yanked away by new arrivals.
+    const nearBottom =
+      this.bodyEl.scrollTop + this.bodyEl.clientHeight >= this.bodyEl.scrollHeight - 60;
+
+    this.bodyEl.appendChild(this.makeCard(event, timestamp, opts.animate ?? true));
+    this.count++;
+    this.updateCount();
+
+    if (nearBottom) this.bodyEl.scrollTop = this.bodyEl.scrollHeight;
+  }
+
+  private setCollapsed(collapsed: boolean): void {
+    this.collapsed = collapsed;
+    this.panelEl.classList.toggle('collapsed', collapsed);
+    this.toggleEl.innerHTML = collapsed ? '&plus;' : '&minus;';
+  }
+
+  private updateCount(): void {
+    this.countEl.textContent = String(this.count);
+  }
+
+  private makeCard(event: MessageEvent, timestamp: string, animate: boolean): HTMLElement {
+    const senderColor = this.agentRing?.getAgentColor(event.sender) ?? '#888';
+    const broadcast = event.broadcasted;
+    const recipientColor = broadcast
+      ? '#22c55e'
+      : (this.agentRing?.getAgentColor(event.recipient) ?? '#888');
+    const accent = broadcast ? '#22c55e' : senderColor;
+
+    const card = document.createElement('div');
+    card.className = broadcast ? 'comms-msg comms-msg-bcast' : 'comms-msg';
+    card.style.borderLeftColor = accent;
+    if (!animate) card.style.animation = 'none';
+
+    const recipientLabel = broadcast ? 'ALL' : event.recipient || '?';
+    const arrow = broadcast ? '↯' : '→';
+    const typeTag = event.msgType
+      ? `<span class="comms-type">${escapeHtml(event.msgType)}</span>`
+      : '';
+    const bcastBadge = broadcast ? '<span class="comms-badge">BROADCAST</span>' : '';
+
+    card.innerHTML = `
+      <div class="comms-msg-meta">
+        <span class="comms-time">${this.formatTime(timestamp)}</span>
+        ${bcastBadge}
+        <span class="comms-index">#${this.count + 1}</span>
+      </div>
+      <div class="comms-route">
+        <span style="color:${senderColor}">${escapeHtml(event.sender || '?')}</span>
+        <span class="comms-arrow">${arrow}</span>
+        <span style="color:${recipientColor}">${escapeHtml(recipientLabel)}</span>
+        ${typeTag}
+      </div>
+      <div class="comms-content">${escapeHtml(event.content ?? '')}</div>
+    `;
+    return card;
+  }
+
+  private formatTime(timestamp: string): string {
+    const t = Date.parse(timestamp);
+    if (Number.isNaN(t)) return '';
+    if (this.startMs !== null) {
+      const sec = Math.max(0, Math.floor((t - this.startMs) / 1000));
+      const m = Math.floor(sec / 60);
+      const s = sec % 60;
+      return `T+${m}:${String(s).padStart(2, '0')}`;
+    }
+    return new Date(t).toLocaleTimeString();
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}

--- a/extras/agent-viz/web/src/comms.ts
+++ b/extras/agent-viz/web/src/comms.ts
@@ -48,6 +48,8 @@ export class CommsPanel {
   private startMs: number | null = null;
   private count = 0;
   private collapsed = false;
+  /** Pending requestAnimationFrame handle for the deferred scroll-to-bottom. */
+  private scrollRafId: number | null = null;
   /** Dedup state for broadcasts: `sender::content` -> last event time (ms). */
   private readonly recentBroadcasts = new Map<string, number>();
 
@@ -86,6 +88,10 @@ export class CommsPanel {
 
   /** Clear the transcript (called on a new manifest and before snapshot replay). */
   reset(): void {
+    if (this.scrollRafId !== null) {
+      cancelAnimationFrame(this.scrollRafId);
+      this.scrollRafId = null;
+    }
     this.bodyEl.innerHTML = '';
     this.count = 0;
     this.recentBroadcasts.clear();
@@ -102,16 +108,31 @@ export class CommsPanel {
       this.recentBroadcasts.set(key, t);
     }
 
+    const animate = opts.animate ?? true;
+
     // Only auto-scroll when the user is already near the bottom, so manual
-    // scroll-back to read history isn't yanked away by new arrivals.
+    // scroll-back to read history isn't yanked away by new arrivals. Skip the
+    // layout-reading measurement during non-animated batch loads (snapshot
+    // replay on seek): interleaving these reads with appendChild in that loop
+    // would cause layout thrashing.
     const nearBottom =
+      animate &&
       this.bodyEl.scrollTop + this.bodyEl.clientHeight >= this.bodyEl.scrollHeight - 60;
 
-    this.bodyEl.appendChild(this.makeCard(event, timestamp, opts.animate ?? true));
+    this.bodyEl.appendChild(this.makeCard(event, timestamp, animate));
     this.count++;
     this.updateCount();
 
-    if (nearBottom) this.bodyEl.scrollTop = this.bodyEl.scrollHeight;
+    if (animate) {
+      if (nearBottom) this.bodyEl.scrollTop = this.bodyEl.scrollHeight;
+    } else {
+      // Defer a single scroll-to-bottom until after the synchronous replay loop.
+      if (this.scrollRafId !== null) cancelAnimationFrame(this.scrollRafId);
+      this.scrollRafId = requestAnimationFrame(() => {
+        this.bodyEl.scrollTop = this.bodyEl.scrollHeight;
+        this.scrollRafId = null;
+      });
+    }
   }
 
   private setCollapsed(collapsed: boolean): void {

--- a/extras/agent-viz/web/src/main.ts
+++ b/extras/agent-viz/web/src/main.ts
@@ -22,6 +22,7 @@ import { FileEditRenderer } from './files';
 import { DestroyBeamRenderer } from './destroy-beam';
 import { CreateBeamRenderer } from './create-beam';
 import { PlaybackControls } from './playback';
+import { CommsPanel } from './comms';
 import type {
   PlaybackManifest,
   PlaybackEvent,
@@ -41,6 +42,7 @@ let fileEditRenderer: FileEditRenderer;
 let destroyBeamRenderer: DestroyBeamRenderer;
 let createBeamRenderer: CreateBeamRenderer;
 let playbackControls: PlaybackControls;
+let commsPanel: CommsPanel;
 let overlayCanvas: HTMLCanvasElement;
 let overlayCtx: CanvasRenderingContext2D;
 let animFrameId: number;
@@ -86,6 +88,10 @@ function init(): void {
   messageRenderer.setAgentRing(agentRing);
   destroyBeamRenderer.setAgentRing(agentRing);
   createBeamRenderer.setAgentRing(agentRing);
+
+  // Agent Communications transcript panel — consumes the same message events.
+  commsPanel = new CommsPanel();
+  commsPanel.setAgentRing(agentRing);
 
   // WebSocket
   const ws = new WSClient();
@@ -157,6 +163,10 @@ function handleManifest(m: PlaybackManifest): void {
   playbackControls.setTimeRange(m.timeRange.start, m.timeRange.end);
   playbackControls.setAgents(m.agents);
 
+  // Anchor relative timestamps in the communications panel to playback start.
+  commsPanel.setStartTime(m.timeRange.start);
+  commsPanel.reset();
+
   // Update info display
   updateInfoDisplay();
 }
@@ -187,6 +197,7 @@ function resetState(): void {
   fileEditRenderer.reset();
   destroyBeamRenderer.reset();
   createBeamRenderer.reset();
+  commsPanel.reset();
 
   // Re-init empty state
   const w = overlayCanvas.width;
@@ -201,7 +212,9 @@ function handleEventInstant(evt: PlaybackEvent): void {
       agentRing.updateState(evt.data as AgentStateEvent);
       break;
     case 'message':
-      // Skip message animations during replay
+      // Skip the on-graph pulse animation during replay, but still record the
+      // message in the transcript so the panel reflects the seek position.
+      commsPanel.addMessage(evt.data as MessageEvent, evt.timestamp, { animate: false });
       break;
     case 'file_edit':
     case 'file_read': {
@@ -248,6 +261,7 @@ function handleEvent(evt: PlaybackEvent): void {
       break;
     case 'message':
       messageRenderer.addMessage(evt.data as MessageEvent, agentRing);
+      commsPanel.addMessage(evt.data as MessageEvent, evt.timestamp);
       break;
     case 'file_edit':
     case 'file_read': {


### PR DESCRIPTION
  ## Summary

  Adds a right-hand **Agent Communications** panel to `extras/agent-viz` — a
  scrolling, human-readable transcript of inter-agent messages, shown alongside
  the existing force-graph.

  Today the message flow is only visible as transient pulse lines on the graph
  (they fade after ~0.5s). This panel makes the conversation persistent and
  readable — useful for longer multi-agent runs and for recording demos.

  ## What it does

  - Renders each `message` event as a card: sender → recipient, message type,
    content, and a `T+m:ss` timestamp relative to playback start.
  - Broadcasts are highlighted (green) and de-duplicated by event time.
  - Sender/recipient names are color-matched to the agent ring.
  - Collapsible via the header toggle.

  ## How it works

  The panel consumes the **same `message` playback events** that already drive the
  on-graph pulse lines (`handleEvent` / snapshot replay in `main.ts`). As a result:

  - it stays in sync with play / pause / speed automatically,
  - it is rebuilt from the seek snapshot (the engine already includes message
    events up to the seek point), and
  - it needs **no new data source, no backend change, and nothing GCP-specific**.

  ## Notes

  - Frontend-only; **no new runtime dependencies**.
  - Styling matches the existing agent-viz dark theme (kept intentionally
    consistent rather than introducing a new design language).
  - Follows the existing `web/` convention of `tsc` typecheck + visual
    verification (the project has no frontend unit-test harness).

  ## Testing

  - `npm run build` (tsc typecheck + vite build) ✅
  - `go build ./cmd/agent-viz` ✅ (embedded assets)
  - `go test ./...` ✅ (logparser, playback)
  - Visual: ran against a synthetic GCP-shape log (8 agents, 18 messages incl.
    4 broadcasts); seeking to the end rebuilds all 18 transcript entries correctly.

  ## Files

  - `web/src/comms.ts` — new `CommsPanel` component
  - `web/src/main.ts` — wire the panel into the message / snapshot / reset paths
  - `web/index.html` — panel styling
  - `README.md` — document the panel
