### PR TITLE
Storage provisioning PR3: Cloud Run runtime + Tier-3 mount types (issue 169)

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -249,14 +249,18 @@ type VolumeMount struct {
 	Source   string `json:"source" yaml:"source"`
 	Target   string `json:"target" yaml:"target"`
 	ReadOnly bool   `json:"read_only,omitempty" yaml:"read_only,omitempty"`
-	// Tier-3 seam: future vendor mount types (e.g. "cloudrun-volume",
-	// "gke-shared-volume") will be added as new Type values here. "nfs"
-	// remains the literal NFS protocol mount.
-	Type   string `json:"type,omitempty" yaml:"type,omitempty"`     // "local" (default), "gcs", or "nfs"
-	Bucket string `json:"bucket,omitempty" yaml:"bucket,omitempty"` // For GCS
-	Prefix string `json:"prefix,omitempty" yaml:"prefix,omitempty"` // For GCS
-	Mode   string `json:"mode,omitempty" yaml:"mode,omitempty"`     // Mount options
-	Server string `json:"server,omitempty" yaml:"server,omitempty"` // NFS: server host/IP
+	// Type discriminates the volume kind:
+	//   "local" (default) — host bind mount; requires Source.
+	//   "gcs"             — GCS FUSE mount; requires Bucket.
+	//   "nfs"             — literal NFS protocol mount; requires Server, Source.
+	//   "cloudrun-volume" — Cloud Run managed volume; requires VolumeName.
+	//   "gke-shared-volume" — GKE-provided shared volume (e.g. Filestore CSI PVC); requires VolumeName.
+	Type       string `json:"type,omitempty" yaml:"type,omitempty"`
+	Bucket     string `json:"bucket,omitempty" yaml:"bucket,omitempty"`           // GCS bucket name
+	Prefix     string `json:"prefix,omitempty" yaml:"prefix,omitempty"`           // GCS object prefix
+	Mode       string `json:"mode,omitempty" yaml:"mode,omitempty"`               // Mount options
+	Server     string `json:"server,omitempty" yaml:"server,omitempty"`           // NFS: server host/IP
+	VolumeName string `json:"volume_name,omitempty" yaml:"volume_name,omitempty"` // Cloud Run / GKE volume name
 }
 
 // Validate checks that a VolumeMount has the required fields and valid values.
@@ -282,8 +286,16 @@ func (v VolumeMount) Validate() error {
 		if v.Source == "" {
 			return fmt.Errorf("NFS volume mount for target %q missing required field: source (server export path)", v.Target)
 		}
+	case "cloudrun-volume":
+		if v.VolumeName == "" {
+			return fmt.Errorf("cloudrun-volume mount for target %q missing required field: volume_name", v.Target)
+		}
+	case "gke-shared-volume":
+		if v.VolumeName == "" {
+			return fmt.Errorf("gke-shared-volume mount for target %q missing required field: volume_name", v.Target)
+		}
 	default:
-		return fmt.Errorf("volume mount for target %q has invalid type %q (must be \"local\", \"gcs\", or \"nfs\")", v.Target, v.Type)
+		return fmt.Errorf("volume mount for target %q has invalid type %q (must be \"local\", \"gcs\", \"nfs\", \"cloudrun-volume\", or \"gke-shared-volume\")", v.Target, v.Type)
 	}
 
 	return nil

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -218,6 +218,42 @@ func TestVolumeMountValidate(t *testing.T) {
 			},
 			wantErr: "missing required field: bucket",
 		},
+		// cloudrun-volume tests
+		{
+			name: "valid cloudrun-volume",
+			vol: VolumeMount{
+				Target:     "/workspace",
+				Type:       "cloudrun-volume",
+				VolumeName: "workspace-vol",
+			},
+			wantErr: "",
+		},
+		{
+			name: "cloudrun-volume missing volume_name",
+			vol: VolumeMount{
+				Target: "/workspace",
+				Type:   "cloudrun-volume",
+			},
+			wantErr: "missing required field: volume_name",
+		},
+		// gke-shared-volume tests
+		{
+			name: "valid gke-shared-volume",
+			vol: VolumeMount{
+				Target:     "/workspace",
+				Type:       "gke-shared-volume",
+				VolumeName: "shared-ws",
+			},
+			wantErr: "",
+		},
+		{
+			name: "gke-shared-volume missing volume_name",
+			vol: VolumeMount{
+				Target: "/workspace",
+				Type:   "gke-shared-volume",
+			},
+			wantErr: "missing required field: volume_name",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -660,6 +660,14 @@ type V1TelemetrySamplingConfig struct {
 	Rates   map[string]float64 `json:"rates,omitempty" yaml:"rates,omitempty" koanf:"rates"`
 }
 
+// V1CloudRunConfig holds Cloud Run runtime settings.
+type V1CloudRunConfig struct {
+	// Project is the GCP project ID for Cloud Run API calls.
+	Project string `json:"project,omitempty" yaml:"project,omitempty" koanf:"project"`
+	// Region is the GCP region for Cloud Run services (e.g. "us-central1").
+	Region string `json:"region,omitempty" yaml:"region,omitempty" koanf:"region"`
+}
+
 // V1RuntimeConfig extends RuntimeConfig with a Type field.
 type V1RuntimeConfig struct {
 	Type              string            `json:"type,omitempty" yaml:"type,omitempty" koanf:"type"`
@@ -670,6 +678,8 @@ type V1RuntimeConfig struct {
 	Sync              string            `json:"sync,omitempty" yaml:"sync,omitempty" koanf:"sync"`
 	GKE               bool              `json:"gke,omitempty" yaml:"gke,omitempty" koanf:"gke"`
 	ListAllNamespaces bool              `json:"list_all_namespaces,omitempty" yaml:"list_all_namespaces,omitempty" koanf:"list_all_namespaces"`
+	// CloudRun holds Cloud Run-specific settings when Type is "cloudrun".
+	CloudRun *V1CloudRunConfig `json:"cloudrun,omitempty" yaml:"cloudrun,omitempty" koanf:"cloudrun"`
 }
 
 // HarnessConfigEntry defines a harness configuration entry in versioned settings.

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -457,9 +457,12 @@ type V1StorageConfig struct {
 // V1WorkspaceStorageConfig selects the workspace storage backend.
 // Backend defaults to "local" (today's node-local behavior). When set to "nfs",
 // the NFS sub-block configures shared network-attached workspace storage.
+// "cloudrun-volume" and "gke-shared-volume" select vendor-managed volume backends.
 type V1WorkspaceStorageConfig struct {
-	Backend string       `json:"backend,omitempty" yaml:"backend,omitempty" koanf:"backend"` // "local" (default) | "nfs"
-	NFS     *V1NFSConfig `json:"nfs,omitempty" yaml:"nfs,omitempty" koanf:"nfs"`
+	Backend         string                   `json:"backend,omitempty" yaml:"backend,omitempty" koanf:"backend"` // "local" | "nfs" | "cloudrun-volume" | "gke-shared-volume"
+	NFS             *V1NFSConfig             `json:"nfs,omitempty" yaml:"nfs,omitempty" koanf:"nfs"`
+	CloudRunVolume  *V1CloudRunVolumeConfig  `json:"cloudrun_volume,omitempty" yaml:"cloudrun_volume,omitempty" koanf:"cloudrun_volume"`
+	GKESharedVolume *V1GKESharedVolumeConfig `json:"gke_shared_volume,omitempty" yaml:"gke_shared_volume,omitempty" koanf:"gke_shared_volume"`
 }
 
 // V1NFSConfig holds NFS workspace storage settings.
@@ -489,6 +492,27 @@ type V1NFSShare struct {
 	Server string `json:"server,omitempty" yaml:"server,omitempty" koanf:"server"`    // e.g. 10.0.0.2 or Filestore IP
 	Export string `json:"export,omitempty" yaml:"export,omitempty" koanf:"export"`    // server export path, e.g. /scion-workspaces
 	PVName string `json:"pv_name,omitempty" yaml:"pv_name,omitempty" koanf:"pv_name"` // K8s static PV+subPath strategy
+}
+
+// V1CloudRunVolumeConfig holds Cloud Run managed volume settings.
+// Cloud Run volumes are declared in the service spec and mounted by the
+// platform — no host path or NFS server is needed.
+type V1CloudRunVolumeConfig struct {
+	// VolumeName is the Cloud Run volume resource name declared in the service YAML.
+	VolumeName string `json:"volume_name,omitempty" yaml:"volume_name,omitempty" koanf:"volume_name"`
+	// SubPathRoot is the sub-directory prefix within the volume. Default "projects".
+	SubPathRoot string `json:"subpath_root,omitempty" yaml:"subpath_root,omitempty" koanf:"subpath_root"`
+}
+
+// V1GKESharedVolumeConfig holds GKE-provided shared volume settings
+// (e.g. a Filestore CSI-backed PVC that GKE manages).
+type V1GKESharedVolumeConfig struct {
+	// VolumeName is the K8s volume name referencing the PVC.
+	VolumeName string `json:"volume_name,omitempty" yaml:"volume_name,omitempty" koanf:"volume_name"`
+	// PVClaimName is the PVC name bound to the GKE-managed shared storage.
+	PVClaimName string `json:"pv_claim_name,omitempty" yaml:"pv_claim_name,omitempty" koanf:"pv_claim_name"`
+	// SubPathRoot is the sub-directory prefix within the volume. Default "projects".
+	SubPathRoot string `json:"subpath_root,omitempty" yaml:"subpath_root,omitempty" koanf:"subpath_root"`
 }
 
 // ApplyNFSDefaults fills default values for NFS sub-fields when Backend is "nfs".

--- a/pkg/runtime/cloudrun_runtime.go
+++ b/pkg/runtime/cloudrun_runtime.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// CloudRunRuntime implements the Runtime interface for Google Cloud Run.
+//
+// Cloud Run with a host-mounted share (or managed volume) calls Tier-1
+// ProvisionShared DIRECTLY broker-side — no init container is needed
+// because the broker provisions before deploying the Cloud Run service.
+//
+// Lifecycle methods (deploy/exec/logs via the Cloud Run Admin API) are
+// deferred to a follow-up PR — this implementation focuses on the
+// provisioning + mount-realization wiring that PR3 requires. Lifecycle
+// methods return a descriptive "not yet implemented" error.
+type CloudRunRuntime struct {
+	// Project is the GCP project ID for Cloud Run API calls.
+	Project string
+
+	// Region is the GCP region for Cloud Run services (e.g. "us-central1").
+	Region string
+
+	// WorkspaceStorage holds the workspace storage configuration, used to
+	// select the workspace backend and realize mount descriptors.
+	WorkspaceStorage *config.V1WorkspaceStorageConfig
+}
+
+// NewCloudRunRuntime returns a new CloudRunRuntime.
+func NewCloudRunRuntime(cfg *config.V1CloudRunConfig) *CloudRunRuntime {
+	rt := &CloudRunRuntime{}
+	if cfg != nil {
+		rt.Project = cfg.Project
+		rt.Region = cfg.Region
+	}
+	return rt
+}
+
+func (r *CloudRunRuntime) Name() string { return "cloudrun" }
+
+func (r *CloudRunRuntime) ExecUser() string { return "scion" }
+
+// Run provisions the workspace broker-side using Tier-1 ProvisionShared,
+// then would deploy a Cloud Run service. The deployment step is deferred.
+//
+// This is the broker-side direct provisioning path: Cloud Run with a
+// host-mounted share calls ProvisionShared directly (no init container),
+// because the broker has access to the mounted filesystem before the
+// container is deployed.
+func (r *CloudRunRuntime) Run(ctx context.Context, cfg RunConfig) (string, error) {
+	if err := r.provisionWorkspace(ctx, cfg); err != nil {
+		return "", fmt.Errorf("cloudrun: workspace provisioning failed: %w", err)
+	}
+
+	// TODO(PR-followup): Deploy Cloud Run service via Admin API.
+	// The service spec would reference the workspace volume (cloudrun-volume
+	// or NFS mount) with the realized MountDescriptor fields.
+	return "", fmt.Errorf("cloudrun: Run not yet implemented — workspace provisioned, but Cloud Run service deployment requires the Admin API (follow-up PR)")
+}
+
+// provisionWorkspace performs broker-side direct provisioning for the Cloud
+// Run runtime. It selects the workspace backend, resolves paths, and calls
+// ProvisionShared (Tier 1) directly — no init container. The context is
+// propagated so provisioning (git clone, chown) is cancellable.
+func (r *CloudRunRuntime) provisionWorkspace(ctx context.Context, cfg RunConfig) error {
+	if cfg.ProjectID == "" {
+		return fmt.Errorf("ProjectID is required for workspace provisioning")
+	}
+
+	mode := store.SharingModeSharedPlain
+	backend := SelectWorkspaceBackend(r.WorkspaceStorage, mode)
+
+	slog.Info("cloudrun: provisioning workspace broker-side",
+		"project_id", cfg.ProjectID,
+		"backend", backend.Name())
+
+	resolved, err := backend.Resolve(ResolveInput{
+		ProjectID:  cfg.ProjectID,
+		ProjectDir: cfg.Workspace,
+		Mode:       mode,
+	})
+	if err != nil {
+		return fmt.Errorf("resolve workspace: %w", err)
+	}
+
+	// Only call ProvisionShared for backends with a host path (NFS, local
+	// with shared storage). Cloud Run managed volumes are provisioned by the
+	// platform, not the broker.
+	if resolved.HostPath != "" {
+		err = ProvisionShared(ProvisionInput{
+			Ctx:       ctx,
+			Resolved:  resolved,
+			ProjectID: cfg.ProjectID,
+			AgentID:   cfg.Labels["agent_id"],
+			AgentName: cfg.Name,
+			Mode:      mode,
+			GitClone:  cfg.GitClone,
+			Locker:    cfg.Locker,
+			NFSUID:    cfg.NFSUID,
+			NFSGID:    cfg.NFSGID,
+		})
+		if err != nil {
+			return fmt.Errorf("ProvisionShared: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *CloudRunRuntime) Stop(ctx context.Context, id string) error {
+	return fmt.Errorf("cloudrun: Stop not yet implemented")
+}
+
+func (r *CloudRunRuntime) Delete(ctx context.Context, id string) error {
+	return fmt.Errorf("cloudrun: Delete not yet implemented")
+}
+
+func (r *CloudRunRuntime) List(ctx context.Context, labelFilter map[string]string) ([]api.AgentInfo, error) {
+	return nil, fmt.Errorf("cloudrun: List not yet implemented")
+}
+
+func (r *CloudRunRuntime) GetLogs(ctx context.Context, id string) (string, error) {
+	return "", fmt.Errorf("cloudrun: GetLogs not yet implemented")
+}
+
+func (r *CloudRunRuntime) Attach(ctx context.Context, id string) error {
+	return fmt.Errorf("cloudrun: Attach not yet implemented")
+}
+
+func (r *CloudRunRuntime) ImageExists(ctx context.Context, image string) (bool, error) {
+	return false, fmt.Errorf("cloudrun: ImageExists not yet implemented")
+}
+
+func (r *CloudRunRuntime) PullImage(ctx context.Context, image string) error {
+	return fmt.Errorf("cloudrun: PullImage not yet implemented")
+}
+
+func (r *CloudRunRuntime) Sync(ctx context.Context, id string, direction SyncDirection) error {
+	return fmt.Errorf("cloudrun: Sync not yet implemented")
+}
+
+func (r *CloudRunRuntime) Exec(ctx context.Context, id string, cmd []string) (string, error) {
+	return "", fmt.Errorf("cloudrun: Exec not yet implemented")
+}
+
+func (r *CloudRunRuntime) GetWorkspacePath(ctx context.Context, id string) (string, error) {
+	return "", fmt.Errorf("cloudrun: GetWorkspacePath not yet implemented")
+}

--- a/pkg/runtime/cloudrun_runtime.go
+++ b/pkg/runtime/cloudrun_runtime.go
@@ -87,6 +87,10 @@ func (r *CloudRunRuntime) provisionWorkspace(ctx context.Context, cfg RunConfig)
 		return fmt.Errorf("ProjectID is required for workspace provisioning")
 	}
 
+	// Cloud Run uses a shared, plain workspace for now: the initial runtime
+	// scope provisions a single broker-side workspace per project. Per-agent
+	// worktrees (SharingModeWorktreePerAgent) are a follow-up once Cloud Run
+	// multi-agent lifecycle lands, so the mode is fixed rather than derived.
 	mode := store.SharingModeSharedPlain
 	backend := SelectWorkspaceBackend(r.WorkspaceStorage, mode)
 

--- a/pkg/runtime/cloudrun_runtime_test.go
+++ b/pkg/runtime/cloudrun_runtime_test.go
@@ -1,0 +1,292 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+func TestCloudRunRuntime_Name(t *testing.T) {
+	rt := NewCloudRunRuntime(nil)
+	if rt.Name() != "cloudrun" {
+		t.Errorf("Name() = %q, want %q", rt.Name(), "cloudrun")
+	}
+}
+
+func TestCloudRunRuntime_ExecUser(t *testing.T) {
+	rt := NewCloudRunRuntime(nil)
+	if rt.ExecUser() != "scion" {
+		t.Errorf("ExecUser() = %q, want %q", rt.ExecUser(), "scion")
+	}
+}
+
+func TestCloudRunRuntime_NewWithConfig(t *testing.T) {
+	cfg := &config.V1CloudRunConfig{
+		Project: "my-gcp-project",
+		Region:  "us-central1",
+	}
+	rt := NewCloudRunRuntime(cfg)
+	if rt.Project != "my-gcp-project" {
+		t.Errorf("Project = %q, want %q", rt.Project, "my-gcp-project")
+	}
+	if rt.Region != "us-central1" {
+		t.Errorf("Region = %q, want %q", rt.Region, "us-central1")
+	}
+}
+
+func TestCloudRunRuntime_NewWithNilConfig(t *testing.T) {
+	rt := NewCloudRunRuntime(nil)
+	if rt.Project != "" {
+		t.Errorf("Project = %q, want empty", rt.Project)
+	}
+	if rt.Region != "" {
+		t.Errorf("Region = %q, want empty", rt.Region)
+	}
+}
+
+func TestCloudRunRuntime_LifecycleMethodsReturnNotImplemented(t *testing.T) {
+	rt := NewCloudRunRuntime(nil)
+	ctx := context.Background()
+
+	methods := []struct {
+		name string
+		fn   func() error
+	}{
+		{"Stop", func() error { return rt.Stop(ctx, "x") }},
+		{"Delete", func() error { return rt.Delete(ctx, "x") }},
+		{"Attach", func() error { return rt.Attach(ctx, "x") }},
+		{"PullImage", func() error { return rt.PullImage(ctx, "x") }},
+		{"Sync", func() error { return rt.Sync(ctx, "x", SyncTo) }},
+	}
+
+	for _, m := range methods {
+		t.Run(m.name, func(t *testing.T) {
+			err := m.fn()
+			if err == nil || !strings.Contains(err.Error(), "not yet implemented") {
+				t.Errorf("%s() error = %v, want 'not yet implemented'", m.name, err)
+			}
+		})
+	}
+
+	t.Run("List", func(t *testing.T) {
+		_, err := rt.List(ctx, nil)
+		if err == nil || !strings.Contains(err.Error(), "not yet implemented") {
+			t.Errorf("List() error = %v, want 'not yet implemented'", err)
+		}
+	})
+
+	t.Run("GetLogs", func(t *testing.T) {
+		_, err := rt.GetLogs(ctx, "x")
+		if err == nil || !strings.Contains(err.Error(), "not yet implemented") {
+			t.Errorf("GetLogs() error = %v, want 'not yet implemented'", err)
+		}
+	})
+
+	t.Run("ImageExists", func(t *testing.T) {
+		_, err := rt.ImageExists(ctx, "x")
+		if err == nil || !strings.Contains(err.Error(), "not yet implemented") {
+			t.Errorf("ImageExists() error = %v, want 'not yet implemented'", err)
+		}
+	})
+
+	t.Run("Exec", func(t *testing.T) {
+		_, err := rt.Exec(ctx, "x", []string{"ls"})
+		if err == nil || !strings.Contains(err.Error(), "not yet implemented") {
+			t.Errorf("Exec() error = %v, want 'not yet implemented'", err)
+		}
+	})
+
+	t.Run("GetWorkspacePath", func(t *testing.T) {
+		_, err := rt.GetWorkspacePath(ctx, "x")
+		if err == nil || !strings.Contains(err.Error(), "not yet implemented") {
+			t.Errorf("GetWorkspacePath() error = %v, want 'not yet implemented'", err)
+		}
+	})
+}
+
+func TestCloudRunRuntime_Run_BrokerSideProvisioning(t *testing.T) {
+	tmpDir := t.TempDir()
+	mountRoot := filepath.Join(tmpDir, "nfs")
+	shareDir := filepath.Join(mountRoot, "share1")
+	if err := os.MkdirAll(shareDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := NewCloudRunRuntime(&config.V1CloudRunConfig{
+		Project: "test-project",
+		Region:  "us-central1",
+	})
+	rt.WorkspaceStorage = &config.V1WorkspaceStorageConfig{
+		Backend: "nfs",
+		NFS: &config.V1NFSConfig{
+			MountRoot:   mountRoot,
+			SubPathRoot: "projects",
+			Shares: []config.V1NFSShare{
+				{ID: "share1", Server: "10.0.0.2", Export: "/ws"},
+			},
+		},
+	}
+
+	cfg := RunConfig{
+		Name:      "test-agent",
+		ProjectID: "proj-123",
+		Workspace: tmpDir,
+		Labels:    map[string]string{"agent_id": "agent-1"},
+	}
+
+	// Run will provision the workspace then fail with "not yet implemented"
+	// for the deploy step — that's expected.
+	_, err := rt.Run(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected 'not yet implemented' error from Run")
+	}
+	if !strings.Contains(err.Error(), "not yet implemented") {
+		t.Fatalf("Run() error = %q, want containing 'not yet implemented'", err.Error())
+	}
+
+	// Verify workspace was provisioned (directory created + sentinel)
+	wsPath := filepath.Join(mountRoot, "share1", "projects", "proj-123", "workspace")
+	if _, err := os.Stat(wsPath); os.IsNotExist(err) {
+		t.Errorf("workspace directory %q was not created by broker-side provisioning", wsPath)
+	}
+
+	sentinelPath := filepath.Join(mountRoot, "share1", "projects", "proj-123", ".scion-provisioned")
+	if _, err := os.Stat(sentinelPath); os.IsNotExist(err) {
+		t.Errorf("sentinel %q was not written — ProvisionShared did not run", sentinelPath)
+	}
+}
+
+func TestCloudRunRuntime_Run_CloudRunVolume_SkipsProvisionShared(t *testing.T) {
+	rt := NewCloudRunRuntime(&config.V1CloudRunConfig{
+		Project: "test-project",
+		Region:  "us-central1",
+	})
+	rt.WorkspaceStorage = &config.V1WorkspaceStorageConfig{
+		Backend: "cloudrun-volume",
+		CloudRunVolume: &config.V1CloudRunVolumeConfig{
+			VolumeName:  "workspace-vol",
+			SubPathRoot: "projects",
+		},
+	}
+
+	cfg := RunConfig{
+		Name:      "test-agent",
+		ProjectID: "proj-456",
+		Labels:    map[string]string{"agent_id": "agent-2"},
+	}
+
+	// With cloudrun-volume backend, Resolve returns no HostPath, so
+	// ProvisionShared is skipped (platform provisions the volume).
+	// Run still fails at the deploy step.
+	_, err := rt.Run(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected 'not yet implemented' error from Run")
+	}
+	if !strings.Contains(err.Error(), "not yet implemented") {
+		t.Fatalf("Run() error = %q, want containing 'not yet implemented'", err.Error())
+	}
+}
+
+func TestCloudRunRuntime_Run_MissingProjectID(t *testing.T) {
+	rt := NewCloudRunRuntime(nil)
+	_, err := rt.Run(context.Background(), RunConfig{})
+	if err == nil || !strings.Contains(err.Error(), "ProjectID is required") {
+		t.Errorf("Run() without ProjectID: error = %v, want 'ProjectID is required'", err)
+	}
+}
+
+func TestGetRuntime_CloudRun(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	globalDir := filepath.Join(tmpHome, ".scion")
+	if err := os.MkdirAll(globalDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	settings := `{
+		"schema_version": "1",
+		"active_profile": "cloud",
+		"runtimes": {
+			"cloudrun": {
+				"type": "cloudrun",
+				"cloudrun": {
+					"project": "my-project",
+					"region": "us-east1"
+				}
+			}
+		},
+		"profiles": {
+			"cloud": {
+				"runtime": "cloudrun"
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(globalDir, "settings.json"), []byte(settings), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, _ := os.Getwd()
+	tmpWd := t.TempDir()
+	if err := os.Chdir(tmpWd); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	r := GetRuntime("", "")
+	cr, ok := r.(*CloudRunRuntime)
+	if !ok {
+		t.Fatalf("expected *CloudRunRuntime, got %T", r)
+	}
+	if cr.Project != "my-project" {
+		t.Errorf("Project = %q, want %q", cr.Project, "my-project")
+	}
+	if cr.Region != "us-east1" {
+		t.Errorf("Region = %q, want %q", cr.Region, "us-east1")
+	}
+}
+
+func TestGetRuntime_CloudRun_DirectProfileName(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("SCION_GROVE", "")
+
+	globalDir := filepath.Join(tmpHome, ".scion")
+	if err := os.MkdirAll(globalDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, _ := os.Getwd()
+	tmpWd := t.TempDir()
+	if err := os.Chdir(tmpWd); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	r := GetRuntime("", "cloudrun")
+	if _, ok := r.(*CloudRunRuntime); !ok {
+		t.Fatalf("expected *CloudRunRuntime from direct profile name, got %T", r)
+	}
+}

--- a/pkg/runtime/factory.go
+++ b/pkg/runtime/factory.go
@@ -45,7 +45,7 @@ func GetRuntime(projectPath string, profileName string) Runtime {
 			util.Debugf("GetRuntime: ResolveRuntime failed: %v", err)
 			// If profile resolution fails, we might be passed a direct runtime type
 			// Fallback to legacy behavior for now if profileName matches a known type
-			if profileName == "docker" || profileName == "podman" || profileName == "kubernetes" || profileName == "k8s" || profileName == "container" || profileName == "remote" || profileName == "local" {
+			if profileName == "docker" || profileName == "podman" || profileName == "kubernetes" || profileName == "k8s" || profileName == "container" || profileName == "remote" || profileName == "local" || profileName == "cloudrun" {
 				runtimeType = profileName
 				util.Debugf("GetRuntime: using profileName as runtimeType: %s", runtimeType)
 			} else {
@@ -129,6 +129,12 @@ func GetRuntime(projectPath string, profileName string) Runtime {
 			util.Debugf("GetRuntime: auto-detected GKE cluster, enabling Autopilot scheduling tolerance")
 		}
 		rt.ListAllNamespaces = rtConfig.ListAllNamespaces
+		return rt
+	case "cloudrun":
+		rt := NewCloudRunRuntime(rtConfig.CloudRun)
+		if vs != nil && vs.Server != nil {
+			rt.WorkspaceStorage = vs.Server.WorkspaceStorage
+		}
 		return rt
 	}
 

--- a/pkg/runtime/workspace_backend.go
+++ b/pkg/runtime/workspace_backend.go
@@ -100,15 +100,22 @@ type RealizeInput struct {
 
 // MountDescriptor describes how the container runtime should mount the
 // workspace. It is intentionally expressive enough to cover Docker bind
-// mounts (HostPath → Target), K8s PVC+subPath, and Cloud Run NFS volumes.
+// mounts (HostPath → Target), K8s PVC+subPath, Cloud Run NFS volumes,
+// and vendor-managed volume types.
+//
+// Type values:
+//   - "local":             Docker bind mount. Fields: HostPath, Target.
+//   - "nfs":               Literal NFS protocol mount (server + export).
+//     Fields: HostPath, Target, NFSServer, NFSExportPath, SubPath, PVClaimName.
+//   - "cloudrun-volume":   Cloud Run managed volume (in-memory or NFS-backed).
+//     Fields: Target, VolumeName, SubPath.
+//   - "gke-shared-volume": GKE-provided shared volume (e.g. Filestore CSI).
+//     Fields: Target, VolumeName, SubPath, PVClaimName.
 type MountDescriptor struct {
-	// Type is "local" for a host bind mount or "nfs" for a direct NFS mount.
-	// Tier-3 seam: future vendor mount types (e.g. "cloudrun-volume",
-	// "gke-shared-volume") will be added here as new Type values. "nfs"
-	// remains the literal NFS protocol mount.
+	// Type discriminates the mount kind. See type-level doc for valid values.
 	Type string
 
-	// HostPath is the source for a Docker bind mount (populated for local).
+	// HostPath is the source for a Docker bind mount (populated for local/nfs).
 	HostPath string
 
 	// Target is the container-side mount path (e.g. "/workspace").
@@ -120,11 +127,17 @@ type MountDescriptor struct {
 	// NFSExportPath is the server-side export path (populated for nfs type).
 	NFSExportPath string
 
-	// SubPath is the sub-path within the volume (K8s PVC subPath).
+	// SubPath is the sub-path within the volume (K8s PVC subPath,
+	// Cloud Run volume subPath, or GKE shared volume subPath).
 	SubPath string
 
-	// PVClaimName is the K8s PVC name for NFS-backed mounts.
+	// PVClaimName is the K8s PVC name (populated for nfs and gke-shared-volume).
 	PVClaimName string
+
+	// VolumeName is the Cloud Run volume name or GKE volume name.
+	// For cloudrun-volume: the Cloud Run volume resource name.
+	// For gke-shared-volume: the volume name referencing the PVC.
+	VolumeName string
 }
 
 // SelectWorkspaceBackend returns the appropriate WorkspaceBackend based on

--- a/pkg/runtime/workspace_backend.go
+++ b/pkg/runtime/workspace_backend.go
@@ -144,17 +144,31 @@ type MountDescriptor struct {
 // configuration and workspace sharing mode. The selection rules (design §3.1):
 //
 //   - nfsBackend when cfg.Backend == "nfs" AND mode is SharedPlain or WorktreePerAgent.
-//   - localBackend otherwise — including ClonePerAgent even when Backend=nfs
+//   - cloudrunVolumeBackend when cfg.Backend == "cloudrun-volume" AND mode is SharedPlain or WorktreePerAgent.
+//   - gkeSharedVolumeBackend when cfg.Backend == "gke-shared-volume" AND mode is SharedPlain or WorktreePerAgent.
+//   - localBackend otherwise — including ClonePerAgent even when Backend is a shared type
 //     (the deliberate node-local escape hatch).
 //   - Backend empty or "local" always yields localBackend.
 func SelectWorkspaceBackend(cfg *config.V1WorkspaceStorageConfig, mode store.WorkspaceSharingMode) WorkspaceBackend {
-	if cfg != nil && cfg.Backend == "nfs" {
-		switch mode {
-		case store.SharingModeSharedPlain, store.SharingModeWorktreePerAgent:
-			return NewNFSBackend(cfg.NFS)
+	if cfg != nil {
+		switch cfg.Backend {
+		case "nfs":
+			switch mode {
+			case store.SharingModeSharedPlain, store.SharingModeWorktreePerAgent:
+				return NewNFSBackend(cfg.NFS)
+			}
+		case "cloudrun-volume":
+			switch mode {
+			case store.SharingModeSharedPlain, store.SharingModeWorktreePerAgent:
+				return NewCloudRunVolumeBackend(cfg.CloudRunVolume)
+			}
+		case "gke-shared-volume":
+			switch mode {
+			case store.SharingModeSharedPlain, store.SharingModeWorktreePerAgent:
+				return NewGKESharedVolumeBackend(cfg.GKESharedVolume)
+			}
 		}
-		// ClonePerAgent (and any unknown mode) → local, even when Backend=nfs.
 	}
-	// Backend empty, "local", or nil config → local.
+	// Backend empty, "local", nil config, or ClonePerAgent → local.
 	return NewLocalBackend()
 }

--- a/pkg/runtime/workspace_backend_cloudrun_volume.go
+++ b/pkg/runtime/workspace_backend_cloudrun_volume.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// cloudrunVolumeBackend resolves and realizes workspace mounts using a
+// Cloud Run managed volume. Cloud Run volumes are declared in the service
+// spec and mounted by the platform — no host path or NFS server is needed.
+// The backend emits MountDescriptor with Type "cloudrun-volume".
+type cloudrunVolumeBackend struct {
+	cfg *config.V1CloudRunVolumeConfig
+}
+
+// NewCloudRunVolumeBackend returns a WorkspaceBackend for Cloud Run managed volumes.
+func NewCloudRunVolumeBackend(cfg *config.V1CloudRunVolumeConfig) WorkspaceBackend {
+	return &cloudrunVolumeBackend{cfg: cfg}
+}
+
+func (b *cloudrunVolumeBackend) Name() string { return "cloudrun-volume" }
+
+// Resolve computes workspace paths within the Cloud Run volume.
+// There is no host path — the volume is platform-managed. ServerRelativePath
+// holds the sub-path within the volume for the project workspace.
+func (b *cloudrunVolumeBackend) Resolve(in ResolveInput) (ResolvedWorkspace, error) {
+	if in.ProjectID == "" {
+		return ResolvedWorkspace{}, fmt.Errorf("cloudrunVolumeBackend.Resolve: ProjectID is required")
+	}
+	if b.cfg == nil {
+		return ResolvedWorkspace{}, fmt.Errorf("cloudrunVolumeBackend.Resolve: CloudRunVolume config is nil")
+	}
+	if b.cfg.VolumeName == "" {
+		return ResolvedWorkspace{}, fmt.Errorf("cloudrunVolumeBackend.Resolve: volume_name is required")
+	}
+
+	subPathRoot := b.cfg.SubPathRoot
+	if subPathRoot == "" {
+		subPathRoot = "projects"
+	}
+
+	workspaceRelPath := filepath.Join(subPathRoot, in.ProjectID, "workspace")
+
+	res := ResolvedWorkspace{
+		ServerRelativePath: workspaceRelPath,
+		Backend:            "cloudrun-volume",
+		SharedDirs:         make(map[string]ResolvedSharedDir, len(in.SharedDirNames)),
+	}
+
+	for _, name := range in.SharedDirNames {
+		sdRelPath := filepath.Join(subPathRoot, in.ProjectID, "shared-dirs", name)
+		res.SharedDirs[name] = ResolvedSharedDir{
+			ServerRelativePath: sdRelPath,
+		}
+	}
+
+	return res, nil
+}
+
+// Realize emits a cloudrun-volume MountDescriptor with the volume name and
+// sub-path. Cloud Run wires the actual mount — the runtime just declares it.
+func (b *cloudrunVolumeBackend) Realize(in RealizeInput) (MountDescriptor, error) {
+	target := in.ContainerWorkspace
+	if target == "" {
+		target = "/workspace"
+	}
+
+	if b.cfg == nil || b.cfg.VolumeName == "" {
+		return MountDescriptor{}, fmt.Errorf("cloudrunVolumeBackend.Realize: volume_name is required")
+	}
+
+	return MountDescriptor{
+		Type:       "cloudrun-volume",
+		Target:     target,
+		VolumeName: b.cfg.VolumeName,
+		SubPath:    in.Resolved.ServerRelativePath,
+	}, nil
+}

--- a/pkg/runtime/workspace_backend_gke_shared_volume.go
+++ b/pkg/runtime/workspace_backend_gke_shared_volume.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// gkeSharedVolumeBackend resolves and realizes workspace mounts using a
+// GKE-provided shared volume (e.g. a Filestore CSI-backed PVC). The PVC
+// is managed by GKE — the backend emits MountDescriptor with Type
+// "gke-shared-volume" containing the volume name, PVC name, and sub-path.
+type gkeSharedVolumeBackend struct {
+	cfg *config.V1GKESharedVolumeConfig
+}
+
+// NewGKESharedVolumeBackend returns a WorkspaceBackend for GKE-managed shared volumes.
+func NewGKESharedVolumeBackend(cfg *config.V1GKESharedVolumeConfig) WorkspaceBackend {
+	return &gkeSharedVolumeBackend{cfg: cfg}
+}
+
+func (b *gkeSharedVolumeBackend) Name() string { return "gke-shared-volume" }
+
+// Resolve computes workspace paths within the GKE shared volume.
+// ServerRelativePath holds the sub-path for the project workspace within
+// the PVC. There is no HostPath — the volume is PVC-managed.
+func (b *gkeSharedVolumeBackend) Resolve(in ResolveInput) (ResolvedWorkspace, error) {
+	if in.ProjectID == "" {
+		return ResolvedWorkspace{}, fmt.Errorf("gkeSharedVolumeBackend.Resolve: ProjectID is required")
+	}
+	if b.cfg == nil {
+		return ResolvedWorkspace{}, fmt.Errorf("gkeSharedVolumeBackend.Resolve: GKESharedVolume config is nil")
+	}
+	if b.cfg.VolumeName == "" {
+		return ResolvedWorkspace{}, fmt.Errorf("gkeSharedVolumeBackend.Resolve: volume_name is required")
+	}
+
+	subPathRoot := b.cfg.SubPathRoot
+	if subPathRoot == "" {
+		subPathRoot = "projects"
+	}
+
+	workspaceRelPath := filepath.Join(subPathRoot, in.ProjectID, "workspace")
+
+	res := ResolvedWorkspace{
+		ServerRelativePath: workspaceRelPath,
+		Backend:            "gke-shared-volume",
+		SharedDirs:         make(map[string]ResolvedSharedDir, len(in.SharedDirNames)),
+	}
+
+	for _, name := range in.SharedDirNames {
+		sdRelPath := filepath.Join(subPathRoot, in.ProjectID, "shared-dirs", name)
+		res.SharedDirs[name] = ResolvedSharedDir{
+			ServerRelativePath: sdRelPath,
+		}
+	}
+
+	return res, nil
+}
+
+// Realize emits a gke-shared-volume MountDescriptor with the volume name,
+// PVC claim name, and sub-path. K8s/GKE wires the actual mount.
+func (b *gkeSharedVolumeBackend) Realize(in RealizeInput) (MountDescriptor, error) {
+	target := in.ContainerWorkspace
+	if target == "" {
+		target = "/workspace"
+	}
+
+	if b.cfg == nil || b.cfg.VolumeName == "" {
+		return MountDescriptor{}, fmt.Errorf("gkeSharedVolumeBackend.Realize: volume_name is required")
+	}
+
+	return MountDescriptor{
+		Type:        "gke-shared-volume",
+		Target:      target,
+		VolumeName:  b.cfg.VolumeName,
+		PVClaimName: b.cfg.PVClaimName,
+		SubPath:     in.Resolved.ServerRelativePath,
+	}, nil
+}

--- a/pkg/runtime/workspace_backend_test.go
+++ b/pkg/runtime/workspace_backend_test.go
@@ -655,6 +655,283 @@ func TestBackendNames(t *testing.T) {
 	}
 }
 
+// --- SelectWorkspaceBackend tests for new backends ---
+
+func TestSelectWorkspaceBackend_CloudRunVolume(t *testing.T) {
+	cfg := &config.V1WorkspaceStorageConfig{
+		Backend: "cloudrun-volume",
+		CloudRunVolume: &config.V1CloudRunVolumeConfig{
+			VolumeName:  "workspace-vol",
+			SubPathRoot: "projects",
+		},
+	}
+
+	tests := []struct {
+		name        string
+		mode        store.WorkspaceSharingMode
+		wantBackend string
+	}{
+		{"SharedPlain", store.SharingModeSharedPlain, "cloudrun-volume"},
+		{"WorktreePerAgent", store.SharingModeWorktreePerAgent, "cloudrun-volume"},
+		{"ClonePerAgent", store.SharingModeClonePerAgent, "local"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := SelectWorkspaceBackend(cfg, tt.mode)
+			if got := b.Name(); got != tt.wantBackend {
+				t.Errorf("SelectWorkspaceBackend(cloudrun-volume, %s) = %q, want %q", tt.mode, got, tt.wantBackend)
+			}
+		})
+	}
+}
+
+func TestSelectWorkspaceBackend_GKESharedVolume(t *testing.T) {
+	cfg := &config.V1WorkspaceStorageConfig{
+		Backend: "gke-shared-volume",
+		GKESharedVolume: &config.V1GKESharedVolumeConfig{
+			VolumeName:  "shared-ws",
+			PVClaimName: "shared-pvc",
+			SubPathRoot: "projects",
+		},
+	}
+
+	tests := []struct {
+		name        string
+		mode        store.WorkspaceSharingMode
+		wantBackend string
+	}{
+		{"SharedPlain", store.SharingModeSharedPlain, "gke-shared-volume"},
+		{"WorktreePerAgent", store.SharingModeWorktreePerAgent, "gke-shared-volume"},
+		{"ClonePerAgent", store.SharingModeClonePerAgent, "local"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := SelectWorkspaceBackend(cfg, tt.mode)
+			if got := b.Name(); got != tt.wantBackend {
+				t.Errorf("SelectWorkspaceBackend(gke-shared-volume, %s) = %q, want %q", tt.mode, got, tt.wantBackend)
+			}
+		})
+	}
+}
+
+// --- CloudRunVolume Backend tests ---
+
+func TestCloudRunVolumeBackendResolve(t *testing.T) {
+	cfg := &config.V1CloudRunVolumeConfig{
+		VolumeName:  "workspace-vol",
+		SubPathRoot: "projects",
+	}
+
+	b := NewCloudRunVolumeBackend(cfg)
+	res, err := b.Resolve(ResolveInput{
+		ProjectID:      "proj-abc-123",
+		Mode:           store.SharingModeSharedPlain,
+		SharedDirNames: []string{"data"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if res.Backend != "cloudrun-volume" {
+		t.Errorf("Backend = %q, want %q", res.Backend, "cloudrun-volume")
+	}
+	wantRelPath := filepath.Join("projects", "proj-abc-123", "workspace")
+	if res.ServerRelativePath != wantRelPath {
+		t.Errorf("ServerRelativePath = %q, want %q", res.ServerRelativePath, wantRelPath)
+	}
+	if res.HostPath != "" {
+		t.Errorf("HostPath = %q, want empty for cloudrun-volume", res.HostPath)
+	}
+
+	sd, ok := res.SharedDirs["data"]
+	if !ok {
+		t.Fatal("shared dir 'data' not found")
+	}
+	wantSDRel := filepath.Join("projects", "proj-abc-123", "shared-dirs", "data")
+	if sd.ServerRelativePath != wantSDRel {
+		t.Errorf("SharedDirs[data].ServerRelativePath = %q, want %q", sd.ServerRelativePath, wantSDRel)
+	}
+}
+
+func TestCloudRunVolumeBackendResolve_Errors(t *testing.T) {
+	t.Run("missing ProjectID", func(t *testing.T) {
+		b := NewCloudRunVolumeBackend(&config.V1CloudRunVolumeConfig{VolumeName: "v"})
+		_, err := b.Resolve(ResolveInput{Mode: store.SharingModeSharedPlain})
+		if err == nil {
+			t.Error("expected error for missing ProjectID")
+		}
+	})
+	t.Run("nil config", func(t *testing.T) {
+		b := NewCloudRunVolumeBackend(nil)
+		_, err := b.Resolve(ResolveInput{ProjectID: "p", Mode: store.SharingModeSharedPlain})
+		if err == nil {
+			t.Error("expected error for nil config")
+		}
+	})
+	t.Run("missing volume_name", func(t *testing.T) {
+		b := NewCloudRunVolumeBackend(&config.V1CloudRunVolumeConfig{})
+		_, err := b.Resolve(ResolveInput{ProjectID: "p", Mode: store.SharingModeSharedPlain})
+		if err == nil {
+			t.Error("expected error for missing volume_name")
+		}
+	})
+}
+
+func TestCloudRunVolumeBackendRealize(t *testing.T) {
+	cfg := &config.V1CloudRunVolumeConfig{
+		VolumeName:  "workspace-vol",
+		SubPathRoot: "projects",
+	}
+
+	b := NewCloudRunVolumeBackend(cfg)
+	desc, err := b.Realize(RealizeInput{
+		Resolved: ResolvedWorkspace{
+			ServerRelativePath: "projects/proj1/workspace",
+			Backend:            "cloudrun-volume",
+		},
+		ContainerWorkspace: "/workspace",
+	})
+	if err != nil {
+		t.Fatalf("Realize: %v", err)
+	}
+
+	if desc.Type != "cloudrun-volume" {
+		t.Errorf("Type = %q, want %q", desc.Type, "cloudrun-volume")
+	}
+	if desc.VolumeName != "workspace-vol" {
+		t.Errorf("VolumeName = %q, want %q", desc.VolumeName, "workspace-vol")
+	}
+	if desc.SubPath != "projects/proj1/workspace" {
+		t.Errorf("SubPath = %q, want %q", desc.SubPath, "projects/proj1/workspace")
+	}
+	if desc.Target != "/workspace" {
+		t.Errorf("Target = %q, want %q", desc.Target, "/workspace")
+	}
+	if desc.HostPath != "" {
+		t.Errorf("HostPath = %q, want empty for cloudrun-volume", desc.HostPath)
+	}
+}
+
+// --- GKESharedVolume Backend tests ---
+
+func TestGKESharedVolumeBackendResolve(t *testing.T) {
+	cfg := &config.V1GKESharedVolumeConfig{
+		VolumeName:  "shared-ws",
+		PVClaimName: "shared-pvc",
+		SubPathRoot: "projects",
+	}
+
+	b := NewGKESharedVolumeBackend(cfg)
+	res, err := b.Resolve(ResolveInput{
+		ProjectID:      "proj-abc-123",
+		Mode:           store.SharingModeSharedPlain,
+		SharedDirNames: []string{"cache"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if res.Backend != "gke-shared-volume" {
+		t.Errorf("Backend = %q, want %q", res.Backend, "gke-shared-volume")
+	}
+	wantRelPath := filepath.Join("projects", "proj-abc-123", "workspace")
+	if res.ServerRelativePath != wantRelPath {
+		t.Errorf("ServerRelativePath = %q, want %q", res.ServerRelativePath, wantRelPath)
+	}
+	if res.HostPath != "" {
+		t.Errorf("HostPath = %q, want empty for gke-shared-volume", res.HostPath)
+	}
+
+	sd, ok := res.SharedDirs["cache"]
+	if !ok {
+		t.Fatal("shared dir 'cache' not found")
+	}
+	wantSDRel := filepath.Join("projects", "proj-abc-123", "shared-dirs", "cache")
+	if sd.ServerRelativePath != wantSDRel {
+		t.Errorf("SharedDirs[cache].ServerRelativePath = %q, want %q", sd.ServerRelativePath, wantSDRel)
+	}
+}
+
+func TestGKESharedVolumeBackendResolve_Errors(t *testing.T) {
+	t.Run("missing ProjectID", func(t *testing.T) {
+		b := NewGKESharedVolumeBackend(&config.V1GKESharedVolumeConfig{VolumeName: "v"})
+		_, err := b.Resolve(ResolveInput{Mode: store.SharingModeSharedPlain})
+		if err == nil {
+			t.Error("expected error for missing ProjectID")
+		}
+	})
+	t.Run("nil config", func(t *testing.T) {
+		b := NewGKESharedVolumeBackend(nil)
+		_, err := b.Resolve(ResolveInput{ProjectID: "p", Mode: store.SharingModeSharedPlain})
+		if err == nil {
+			t.Error("expected error for nil config")
+		}
+	})
+	t.Run("missing volume_name", func(t *testing.T) {
+		b := NewGKESharedVolumeBackend(&config.V1GKESharedVolumeConfig{})
+		_, err := b.Resolve(ResolveInput{ProjectID: "p", Mode: store.SharingModeSharedPlain})
+		if err == nil {
+			t.Error("expected error for missing volume_name")
+		}
+	})
+}
+
+func TestGKESharedVolumeBackendRealize(t *testing.T) {
+	cfg := &config.V1GKESharedVolumeConfig{
+		VolumeName:  "shared-ws",
+		PVClaimName: "shared-pvc",
+		SubPathRoot: "projects",
+	}
+
+	b := NewGKESharedVolumeBackend(cfg)
+	desc, err := b.Realize(RealizeInput{
+		Resolved: ResolvedWorkspace{
+			ServerRelativePath: "projects/proj1/workspace",
+			Backend:            "gke-shared-volume",
+		},
+		ContainerWorkspace: "/workspace",
+	})
+	if err != nil {
+		t.Fatalf("Realize: %v", err)
+	}
+
+	if desc.Type != "gke-shared-volume" {
+		t.Errorf("Type = %q, want %q", desc.Type, "gke-shared-volume")
+	}
+	if desc.VolumeName != "shared-ws" {
+		t.Errorf("VolumeName = %q, want %q", desc.VolumeName, "shared-ws")
+	}
+	if desc.PVClaimName != "shared-pvc" {
+		t.Errorf("PVClaimName = %q, want %q", desc.PVClaimName, "shared-pvc")
+	}
+	if desc.SubPath != "projects/proj1/workspace" {
+		t.Errorf("SubPath = %q, want %q", desc.SubPath, "projects/proj1/workspace")
+	}
+	if desc.Target != "/workspace" {
+		t.Errorf("Target = %q, want %q", desc.Target, "/workspace")
+	}
+	if desc.HostPath != "" {
+		t.Errorf("HostPath = %q, want empty for gke-shared-volume", desc.HostPath)
+	}
+}
+
+func TestGKESharedVolumeBackendRealize_DefaultTarget(t *testing.T) {
+	cfg := &config.V1GKESharedVolumeConfig{VolumeName: "v"}
+	b := NewGKESharedVolumeBackend(cfg)
+	desc, err := b.Realize(RealizeInput{
+		Resolved:           ResolvedWorkspace{Backend: "gke-shared-volume"},
+		ContainerWorkspace: "",
+	})
+	if err != nil {
+		t.Fatalf("Realize: %v", err)
+	}
+	if desc.Target != "/workspace" {
+		t.Errorf("Target = %q, want /workspace (default)", desc.Target)
+	}
+}
+
 // --- ProvisionShared tests (from workspace_backend_test.go) ---
 
 func TestProvisionShared_NonGit(t *testing.T) {


### PR DESCRIPTION
## Summary

PR3 of the storage provisioning architecture epic (issue 169). Stacked on PR1 PR 170 (independent of PR2).

### Mount types added
- **`cloudrun-volume`**: Cloud Run managed volume. Required field: `volume_name`. Used when the platform provisions and mounts the volume — no host path needed.
- **`gke-shared-volume`**: GKE-provided shared volume (e.g. Filestore CSI PVC). Required field: `volume_name`. Carries `pv_claim_name` for K8s PVC binding.
- Both types added as recognized values in `MountDescriptor.Type` (runtime-level) and `api.VolumeMount.Type` (config-level) with validation.
- `"nfs"` remains the literal NFS protocol mount (server + export only).

### Realize variants
- **`cloudrunVolumeBackend`**: resolves and realizes `cloudrun-volume` descriptors (VolumeName + SubPath, no HostPath).
- **`gkeSharedVolumeBackend`**: resolves and realizes `gke-shared-volume` descriptors (VolumeName + PVClaimName + SubPath).
- `SelectWorkspaceBackend` extended to route `"cloudrun-volume"` and `"gke-shared-volume"` backend values (SharedPlain/WorktreePerAgent → vendor backend, ClonePerAgent → local escape hatch).

### Broker-side direct provisioning
- Cloud Run runtime calls `provisionShared` (Tier 1) **directly broker-side** — no init container needed.
- When `Resolve` returns a `HostPath` (NFS or local), `provisionShared` runs (mkdir, git clone, chown, sentinel).
- When `Resolve` returns no `HostPath` (cloudrun-volume), provisioning is skipped — the platform manages the volume.

### Cloud Run runtime
- `CloudRunRuntime` implements the full `Runtime` interface, registered as `"cloudrun"` in `factory.go` `GetRuntime`.
- Config: `V1CloudRunConfig` (project, region) nested under `V1RuntimeConfig.CloudRun`.
- **Lifecycle methods deferred**: `Run` completes provisioning then returns a "not yet implemented" error for the Cloud Run Admin API deploy step. All other lifecycle methods (`Stop`, `Delete`, `List`, `GetLogs`, `Attach`, `Exec`, etc.) return descriptive "not yet implemented" errors.
- Follow-up scope: full Cloud Run service deploy/exec/logs via the Admin API.

### Config additions
- `V1CloudRunVolumeConfig` (volume_name, subpath_root) under `V1WorkspaceStorageConfig.CloudRunVolume`
- `V1GKESharedVolumeConfig` (volume_name, pv_claim_name, subpath_root) under `V1WorkspaceStorageConfig.GKESharedVolume`
- `V1CloudRunConfig` (project, region) under `V1RuntimeConfig.CloudRun`

### Tests
- `api.VolumeMount.Validate()`: valid + missing-required-field cases for both new types
- `SelectWorkspaceBackend`: cloudrun-volume and gke-shared-volume selection truth tables
- `cloudrunVolumeBackend`: Resolve, Realize, error cases
- `gkeSharedVolumeBackend`: Resolve, Realize, error cases, default target
- `CloudRunRuntime`: name, user, config plumbing, factory selection (settings-based + direct profile name)
- Broker-side provisioning: verifies workspace directory + sentinel created via `provisionShared`
- Cloud Run volume skip path: verifies `provisionShared` skipped when platform provisions the volume
- All lifecycle methods: verify "not yet implemented" errors

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/runtime/ ./pkg/api/ -count=1` all green
- [x] `go vet ./pkg/runtime/... ./pkg/api/...` clean
- [x] `gofmt -w` applied to all touched files
- [x] Pre-existing `pkg/config` test failures verified on base branch (unrelated)

Ref: issue 169
Stacked on: PR 170
