### PR TITLE
fix(ci): resolve golangci-lint errcheck and gofmt failures

### DIFF
--- a/cmd/sciontool/commands/provision_test.go
+++ b/cmd/sciontool/commands/provision_test.go
@@ -93,7 +93,7 @@ func TestProvisionCmd_WaitForSentinel_DelayedWrite(t *testing.T) {
 	go func() {
 		time.Sleep(2 * time.Second)
 		sentinelPath := filepath.Join(dir, ".scion-provisioned")
-		os.WriteFile(sentinelPath, []byte("provisioned_at=test\n"), 0644)
+		_ = os.WriteFile(sentinelPath, []byte("provisioned_at=test\n"), 0644)
 	}()
 
 	if err := runWaitForSentinel(context.Background()); err != nil {

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -49,7 +49,7 @@ const (
 type Config struct {
 	BotToken       string
 	ApplicationID  string
-	PublicKey       string
+	PublicKey      string
 	GuildID        string // empty = global commands
 	DBPath         string
 	MentionRouting bool
@@ -57,7 +57,7 @@ type Config struct {
 
 // inboundPayload is the JSON body sent to the hub API inbound endpoint.
 type inboundPayload struct {
-	Topic   string                     `json:"topic"`
+	Topic   string                      `json:"topic"`
 	Message *messages.StructuredMessage `json:"message"`
 }
 
@@ -172,8 +172,8 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 		cfg := &Config{
 			BotToken:       botToken,
 			ApplicationID:  config["application_id"],
-			PublicKey:       config["public_key"],
-			GuildID:         config["guild_id"],
+			PublicKey:      config["public_key"],
+			GuildID:        config["guild_id"],
 			MentionRouting: true, // default
 		}
 

--- a/extras/scion-discord/internal/discord/callbacks.go
+++ b/extras/scion-discord/internal/discord/callbacks.go
@@ -427,8 +427,8 @@ func (h *CallbackHandler) deliverAskUserResponse(ctx context.Context, i *discord
 		Type:      messages.TypeInstruction,
 		Metadata: map[string]string{
 			"discord_channel_id": pending.ChannelID,
-			"project_id":        pending.ProjectID,
-			"ask_request_id":    pending.RequestID,
+			"project_id":         pending.ProjectID,
+			"ask_request_id":     pending.RequestID,
 		},
 	}
 

--- a/extras/scion-discord/internal/discord/format.go
+++ b/extras/scion-discord/internal/discord/format.go
@@ -38,13 +38,13 @@ const (
 
 // Embed sidebar colors keyed by activity/status string.
 const (
-	colorCompleted  = 0x2ECC71 // Green
-	colorInputWait  = 0xF1C40F // Yellow
-	colorError      = 0xE74C3C // Red
-	colorStalled    = 0xE67E22 // Orange
-	colorDeleted    = 0x95A5A6 // Gray
-	colorRunning    = 0x3498DB // Blue
-	colorDefault    = 0x1A1A2E // Dark
+	colorCompleted = 0x2ECC71 // Green
+	colorInputWait = 0xF1C40F // Yellow
+	colorError     = 0xE74C3C // Red
+	colorStalled   = 0xE67E22 // Orange
+	colorDeleted   = 0x95A5A6 // Gray
+	colorRunning   = 0x3498DB // Blue
+	colorDefault   = 0x1A1A2E // Dark
 )
 
 // FormatMessage converts a StructuredMessage to Discord-compatible text.

--- a/extras/scion-discord/internal/discord/modals.go
+++ b/extras/scion-discord/internal/discord/modals.go
@@ -130,8 +130,8 @@ func HandleModalSubmit(
 			Type:      messages.TypeInstruction,
 			Metadata: map[string]string{
 				"discord_channel_id": pending.ChannelID,
-				"project_id":        pending.ProjectID,
-				"ask_request_id":    pending.RequestID,
+				"project_id":         pending.ProjectID,
+				"ask_request_id":     pending.RequestID,
 			},
 		}
 

--- a/extras/scion-discord/internal/discord/register.go
+++ b/extras/scion-discord/internal/discord/register.go
@@ -37,7 +37,7 @@ type RegistrationHandler struct {
 type pendingLinkReg struct {
 	Code             string
 	DiscordUserID    string
-	DiscordUsername   string
+	DiscordUsername  string
 	ChannelID        string
 	InteractionToken string // for follow-up messages
 	ExpiresAt        time.Time
@@ -52,7 +52,7 @@ type discordLinkRequest struct {
 
 // identityLinkStatusResponse is the JSON response from checking a linking status.
 type identityLinkStatusResponse struct {
-	Status string           `json:"status"` // "pending", "confirmed", "expired", "not_found"
+	Status string            `json:"status"` // "pending", "confirmed", "expired", "not_found"
 	User   *identityLinkUser `json:"user,omitempty"`
 }
 
@@ -145,7 +145,7 @@ func (h *RegistrationHandler) HandleRegister(s *discordgo.Session, i *discordgo.
 	reg := &pendingLinkReg{
 		Code:             code,
 		DiscordUserID:    discordUserID,
-		DiscordUsername:   discordUsername,
+		DiscordUsername:  discordUsername,
 		ChannelID:        i.ChannelID,
 		InteractionToken: i.Token,
 		ExpiresAt:        time.Now().Add(linkingCodeExpiry),
@@ -264,11 +264,11 @@ func (h *RegistrationHandler) completeRegistration(s *discordgo.Session, interac
 	defer cancel()
 
 	mapping := &DiscordUserMapping{
-		DiscordUserID:  reg.DiscordUserID,
+		DiscordUserID:   reg.DiscordUserID,
 		DiscordUsername: reg.DiscordUsername,
-		ScionUserID:    statusResp.User.ID,
-		ScionEmail:     statusResp.User.Email,
-		LinkedAt:       time.Now(),
+		ScionUserID:     statusResp.User.ID,
+		ScionEmail:      statusResp.User.Email,
+		LinkedAt:        time.Now(),
 	}
 
 	if err := h.store.CreateUserMapping(ctx, mapping); err != nil {

--- a/extras/scion-discord/internal/discord/sendqueue.go
+++ b/extras/scion-discord/internal/discord/sendqueue.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	defaultSendQueueSize = 100
-	defaultSendMinDelay  = 50 * time.Millisecond
+	defaultSendQueueSize   = 100
+	defaultSendMinDelay    = 50 * time.Millisecond
 	defaultSendIdleTimeout = 5 * time.Minute
 )
 

--- a/extras/scion-discord/internal/discord/store.go
+++ b/extras/scion-discord/internal/discord/store.go
@@ -77,11 +77,11 @@ type ChannelLink struct {
 
 // DiscordUserMapping links a Discord user to a Scion user identity.
 type DiscordUserMapping struct {
-	DiscordUserID  string
+	DiscordUserID   string
 	DiscordUsername string
-	ScionUserID    string
-	ScionEmail     string
-	LinkedAt       time.Time
+	ScionUserID     string
+	ScionEmail      string
+	LinkedAt        time.Time
 }
 
 // ConversationContext tracks the last chat context for a user+project+agent tuple.

--- a/extras/scion-discord/internal/discord/store_test.go
+++ b/extras/scion-discord/internal/discord/store_test.go
@@ -252,11 +252,11 @@ func TestUserMappingCRUD(t *testing.T) {
 		ctx := context.Background()
 
 		mapping := &DiscordUserMapping{
-			DiscordUserID:  "456789012345678901",
+			DiscordUserID:   "456789012345678901",
 			DiscordUsername: "alice",
-			ScionUserID:    "user-123",
-			ScionEmail:     "alice@example.com",
-			LinkedAt:       time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			ScionUserID:     "user-123",
+			ScionEmail:      "alice@example.com",
+			LinkedAt:        time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
 		}
 		require.NoError(t, store.CreateUserMapping(ctx, mapping))
 
@@ -323,17 +323,17 @@ func TestUserMappingCRUD(t *testing.T) {
 		ctx := context.Background()
 
 		require.NoError(t, store.CreateUserMapping(ctx, &DiscordUserMapping{
-			DiscordUserID:  "456",
+			DiscordUserID:   "456",
 			DiscordUsername: "alice",
-			ScionEmail:     "alice@old.com",
-			LinkedAt:       time.Now().UTC(),
+			ScionEmail:      "alice@old.com",
+			LinkedAt:        time.Now().UTC(),
 		}))
 
 		require.NoError(t, store.CreateUserMapping(ctx, &DiscordUserMapping{
-			DiscordUserID:  "456",
+			DiscordUserID:   "456",
 			DiscordUsername: "alice_new",
-			ScionEmail:     "alice@new.com",
-			LinkedAt:       time.Now().UTC(),
+			ScionEmail:      "alice@new.com",
+			LinkedAt:        time.Now().UTC(),
 		}))
 
 		got, err := store.GetUserMapping(ctx, "456")

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -511,13 +511,13 @@ func writeSentinel(path string) error {
 	// Write a timestamp for debugging.
 	_, _ = fmt.Fprintf(tmp, "provisioned_at=%s\n", time.Now().UTC().Format(time.RFC3339))
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName)
 		return fmt.Errorf("close temp sentinel: %w", err)
 	}
 
 	// Atomic rename.
 	if err := os.Rename(tmpName, path); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName)
 		return fmt.Errorf("rename sentinel: %w", err)
 	}
 	return nil

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -1014,8 +1014,8 @@ const DefaultHeartbeatTimeout = 10 * time.Second
 var tokenHomeResolver = resolveTokenHome
 
 var (
-	resolvedTokenHome     string
-	resolveTokenHomeOnce  sync.Once
+	resolvedTokenHome    string
+	resolveTokenHomeOnce sync.Once
 )
 
 // resolveTokenHome returns the home directory to use for the token file.


### PR DESCRIPTION
## Summary
- Suppress unchecked `os.Remove` and `os.WriteFile` error returns in cleanup/test paths to satisfy golangci-lint's errcheck linter
- Run `gofmt` on 9 unformatted files (discord plugin + hub client) to pass the CI format check

## Upstream CI failures addressed
Both **Build & Test** (format check step) and **golangci-lint** jobs were failing on `GoogleCloudPlatform/scion` main. This PR includes the upstream commits that introduced the issues plus the two fix commits.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet` passes on affected packages
- [x] `go test ./cmd/sciontool/commands/ -run TestProvision` passes
- [x] `gofmt -l .` returns no files
