### PR TITLE
fix: prevent test suite from leaking hub status updates and telemetry

### DIFF
--- a/cmd/sciontool/commands/hook_test.go
+++ b/cmd/sciontool/commands/hook_test.go
@@ -15,12 +15,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// scrubScionEnv clears all Hub and telemetry environment variables for the
+// duration of the test, preventing accidental communication with a real Hub
+// or telemetry backend when tests run inside an agent container.
+func scrubScionEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"SCION_HUB_ENDPOINT",
+		"SCION_HUB_URL",
+		"SCION_AUTH_TOKEN",
+		"SCION_AGENT_ID",
+		"SCION_AGENT_MODE",
+		"SCION_TELEMETRY_ENABLED",
+		"SCION_TELEMETRY_CLOUD_ENABLED",
+		"SCION_OTEL_ENDPOINT",
+		"SCION_OTEL_GCP_CREDENTIALS",
+		"SCION_GCP_PROJECT_ID",
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
 func TestProcessHookData_Claude(t *testing.T) {
 	// Set up temp home directory for status/log files
 	tmpDir := t.TempDir()
 	oldHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", oldHome)
+	scrubScionEnv(t)
 	log.SetLogPath(filepath.Join(tmpDir, "agent.log"))
 
 	hookDialect = "claude"
@@ -58,6 +81,7 @@ func TestProcessHookData_Gemini(t *testing.T) {
 	oldHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", oldHome)
+	scrubScionEnv(t)
 	log.SetLogPath(filepath.Join(tmpDir, "agent.log"))
 
 	hookDialect = "gemini"
@@ -88,6 +112,7 @@ func TestProcessHookData_SessionEvents(t *testing.T) {
 	oldHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", oldHome)
+	scrubScionEnv(t)
 	log.SetLogPath(filepath.Join(tmpDir, "agent.log"))
 
 	hookDialect = "claude"
@@ -130,6 +155,7 @@ func TestProcessHookData_CodexCompletion(t *testing.T) {
 	oldHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", oldHome)
+	scrubScionEnv(t)
 	log.SetLogPath(filepath.Join(tmpDir, "agent.log"))
 
 	hookDialect = "codex"

--- a/cmd/sciontool/commands/status_test.go
+++ b/cmd/sciontool/commands/status_test.go
@@ -21,6 +21,7 @@ func TestStatusCommand(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tempDir)
 	defer os.Setenv("HOME", originalHome)
+	scrubScionEnv(t)
 
 	tests := []struct {
 		name            string
@@ -127,6 +128,7 @@ func TestStatusCommandUnknownType(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tempDir)
 	defer os.Setenv("HOME", originalHome)
+	scrubScionEnv(t)
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)

--- a/pkg/sciontool/hooks/handlers/limits_test.go
+++ b/pkg/sciontool/hooks/handlers/limits_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestInitLimitsFile(t *testing.T) {
+	scrubHubEnv(t)
 	tmpDir := t.TempDir()
 	limitsPath := filepath.Join(tmpDir, "agent-limits.json")
 
@@ -37,6 +38,7 @@ func TestInitLimitsFile(t *testing.T) {
 }
 
 func TestInitLimitsFile_ZeroValues(t *testing.T) {
+	scrubHubEnv(t)
 	tmpDir := t.TempDir()
 	limitsPath := filepath.Join(tmpDir, "agent-limits.json")
 
@@ -55,6 +57,7 @@ func TestInitLimitsFile_ZeroValues(t *testing.T) {
 }
 
 func TestLimitsHandler_TurnCounting(t *testing.T) {
+	scrubHubEnv(t)
 	tmpDir := t.TempDir()
 	limitsPath := filepath.Join(tmpDir, "agent-limits.json")
 
@@ -82,6 +85,7 @@ func TestLimitsHandler_TurnCounting(t *testing.T) {
 }
 
 func TestLimitsHandler_ModelCallCounting(t *testing.T) {
+	scrubHubEnv(t)
 	tmpDir := t.TempDir()
 	limitsPath := filepath.Join(tmpDir, "agent-limits.json")
 
@@ -107,6 +111,7 @@ func TestLimitsHandler_ModelCallCounting(t *testing.T) {
 }
 
 func TestLimitsHandler_IgnoresIrrelevantEvents(t *testing.T) {
+	scrubHubEnv(t)
 	tmpDir := t.TempDir()
 	limitsPath := filepath.Join(tmpDir, "agent-limits.json")
 
@@ -140,12 +145,14 @@ func TestLimitsHandler_IgnoresIrrelevantEvents(t *testing.T) {
 }
 
 func TestLimitsHandler_NilHandler(t *testing.T) {
+	scrubHubEnv(t)
 	var h *LimitsHandler
 	err := h.Handle(&hooks.Event{Name: hooks.EventAgentEnd})
 	assert.NoError(t, err)
 }
 
 func TestLimitsHandler_NoLimitsConfigured(t *testing.T) {
+	scrubHubEnv(t)
 	// When maxTurns=0 and maxModelCalls=0, events are silently ignored
 	tmpDir := t.TempDir()
 	limitsPath := filepath.Join(tmpDir, "agent-limits.json")
@@ -174,6 +181,7 @@ func TestLimitsHandler_NoLimitsConfigured(t *testing.T) {
 }
 
 func TestLimitsHandler_TurnLimitDetection(t *testing.T) {
+	scrubHubEnv(t)
 	// Test that the handler detects when the turn limit is reached.
 	// We can't test the SIGUSR1 signal in unit tests (it would kill the test process),
 	// so we verify the status file is updated and the limits file has the right count.
@@ -216,6 +224,7 @@ func TestLimitsHandler_TurnLimitDetection(t *testing.T) {
 }
 
 func TestLimitsHandler_ModelCallLimitDetection(t *testing.T) {
+	scrubHubEnv(t)
 	tmpDir := t.TempDir()
 	limitsPath := filepath.Join(tmpDir, "agent-limits.json")
 	statusPath := filepath.Join(tmpDir, "agent-info.json")
@@ -250,6 +259,7 @@ func TestLimitsHandler_ModelCallLimitDetection(t *testing.T) {
 }
 
 func TestLimitsHandler_BothLimitsIndependent(t *testing.T) {
+	scrubHubEnv(t)
 	// Verify both counters are tracked independently
 	tmpDir := t.TempDir()
 	limitsPath := filepath.Join(tmpDir, "agent-limits.json")
@@ -282,6 +292,7 @@ func TestLimitsHandler_BothLimitsIndependent(t *testing.T) {
 }
 
 func TestLimitsHandler_MissingLimitsFile(t *testing.T) {
+	scrubHubEnv(t)
 	tmpDir := t.TempDir()
 	limitsPath := filepath.Join(tmpDir, "nonexistent", "agent-limits.json")
 
@@ -347,6 +358,7 @@ func TestExitCodeLimitsExceeded(t *testing.T) {
 }
 
 func TestWriteLimitsState_AtomicWrite(t *testing.T) {
+	scrubHubEnv(t)
 	tmpDir := t.TempDir()
 	limitsPath := filepath.Join(tmpDir, "agent-limits.json")
 
@@ -381,6 +393,7 @@ func TestLimitsTriggerFileConstant(t *testing.T) {
 }
 
 func TestSignalLimitsExceeded_CreatesTriggerFile(t *testing.T) {
+	scrubHubEnv(t)
 	tmpDir := t.TempDir()
 	triggerPath := filepath.Join(tmpDir, "scion-limits-exceeded")
 

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -168,12 +168,22 @@ type Client struct {
 // The token is read from the canonical token file (~/.scion/scion-token), falling
 // back to the SCION_AUTH_TOKEN env var for bootstrap (before init has run).
 // Returns nil if the required environment variables are not set.
+//
+// Defense-in-depth: when running under `go test`, refuses to create a client
+// that would talk to a non-localhost hub. Tests that need a hub client must
+// scrub SCION_* env vars and point at an httptest server (see scrubHubEnv
+// in hub_test.go). Without this guard, a test that forgets env sandboxing
+// leaks real status updates to the hub under the container's agent identity.
 func NewClient() *Client {
 	hubURL := os.Getenv(EnvHubEndpoint)
 	if hubURL == "" {
 		hubURL = os.Getenv(EnvHubURL)
 	}
 	agentID := os.Getenv(EnvAgentID)
+
+	if testing.Testing() && !hubTestSandboxed && hubURL != "" && !isLocalhostURL(hubURL) {
+		return nil
+	}
 
 	// Prefer the canonical token file; fall back to env var for bootstrap.
 	token := ReadTokenFile()
@@ -991,6 +1001,22 @@ func ParseTokenExpiry(tokenString string) (time.Time, error) {
 	return time.Unix(claims.Exp, 0), nil
 }
 
+// isLocalhostURL returns true if the URL points to localhost or 127.0.0.1,
+// indicating a test server rather than a real hub endpoint.
+func isLocalhostURL(rawURL string) bool {
+	lower := strings.ToLower(rawURL)
+	for _, prefix := range []string{
+		"http://localhost", "https://localhost",
+		"http://127.0.0.1", "https://127.0.0.1",
+		"http://[::1]", "https://[::1]",
+	} {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // HeartbeatConfig configures the heartbeat loop.
 type HeartbeatConfig struct {
 	// Interval is the time between heartbeats. Default: 30 seconds.
@@ -1036,6 +1062,22 @@ func resolveTokenHome() string {
 		}
 	})
 	return resolvedTokenHome
+}
+
+// hubTestSandboxed reports whether the calling test has explicitly declared
+// that it has sandboxed the hub environment (e.g. by calling scrubHubEnv and
+// setting test values). NewClient refuses to connect to a non-localhost hub
+// under `go test` unless this flag is set, preventing accidental leakage of
+// status updates to a real hub when tests run inside an agent container.
+var hubTestSandboxed bool
+
+// SetHubTestSandboxed marks the current test as having properly sandboxed the
+// hub environment. Call this in tests that deliberately set non-localhost hub
+// URLs (e.g. for verifying URL preference logic). Returns a cleanup function.
+func SetHubTestSandboxed() func() {
+	orig := hubTestSandboxed
+	hubTestSandboxed = true
+	return func() { hubTestSandboxed = orig }
 }
 
 // tokenHomeOverridden reports whether SetTokenHome has installed a test

--- a/pkg/sciontool/hub/client_test.go
+++ b/pkg/sciontool/hub/client_test.go
@@ -60,6 +60,7 @@ func scrubHubEnv(t *testing.T) {
 	} {
 		t.Setenv(key, "")
 	}
+	t.Cleanup(SetHubTestSandboxed())
 }
 
 func TestNewClient_FromEnvironment(t *testing.T) {

--- a/pkg/sciontool/telemetry/config.go
+++ b/pkg/sciontool/telemetry/config.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"testing"
 )
 
 // Environment variable names for telemetry configuration.
@@ -113,7 +114,25 @@ type FilterConfig struct {
 // As a fallback, LoadConfig probes this path when the env var is absent.
 const WellKnownGCPCredentialsPath = ".scion/telemetry-gcp-credentials.json"
 
+// telemetryTestSandboxed reports whether the calling test has explicitly
+// declared that it has sandboxed the telemetry environment. LoadConfig
+// force-disables cloud export under `go test` unless this flag is set.
+var telemetryTestSandboxed bool
+
+// SetTelemetryTestSandboxed marks the current test as having properly
+// sandboxed the telemetry environment. Returns a cleanup function.
+func SetTelemetryTestSandboxed() func() {
+	orig := telemetryTestSandboxed
+	telemetryTestSandboxed = true
+	return func() { telemetryTestSandboxed = orig }
+}
+
 // LoadConfig loads telemetry configuration from environment variables.
+//
+// Defense-in-depth: when running under `go test`, cloud telemetry export is
+// force-disabled to prevent test code from accidentally exporting spans/logs
+// to a real backend under a live agent identity. Local telemetry (receiver,
+// pipeline) remains available for tests that need it.
 func LoadConfig() *Config {
 	cfg := &Config{
 		Enabled:      parseBoolEnv(EnvEnabled, true),
@@ -178,6 +197,16 @@ func LoadConfig() *Config {
 	// Apply default hash fields if not explicitly set
 	if len(cfg.Redaction.Hash) == 0 && os.Getenv(EnvHashFields) == "" {
 		cfg.Redaction.Hash = DefaultHashFields
+	}
+
+	// Defense-in-depth: force-disable cloud export under `go test` so that
+	// a test running inside an agent container never ships spans to a real
+	// backend under the container's agent identity. Tests that specifically
+	// need to verify cloud config behavior should call SetTelemetryTestSandboxed.
+	if testing.Testing() && !telemetryTestSandboxed {
+		cfg.CloudEnabled = false
+		cfg.Endpoint = ""
+		cfg.GCPCredentialsFile = ""
 	}
 
 	return cfg

--- a/pkg/sciontool/telemetry/config_test.go
+++ b/pkg/sciontool/telemetry/config_test.go
@@ -576,4 +576,6 @@ func clearTelemetryEnv() {
 	os.Unsetenv(EnvGCPCredentials)
 	os.Unsetenv(EnvCloudProvider)
 	os.Unsetenv(EnvMetricsDebug)
+	// Mark as sandboxed so LoadConfig's test guard doesn't force-disable cloud.
+	telemetryTestSandboxed = true
 }


### PR DESCRIPTION
When `go test ./...` runs inside an agent container, tests in hook_test.go, status_test.go, and limits_test.go call real hub API and telemetry export paths without sandboxing SCION_*/OTEL_* env vars. This causes spurious LIMITS_EXCEEDED, COMPLETED, and WAITING_FOR_INPUT notifications to appear on the hub under the running agent's identity.

Fix (two layers):

1. Hermetic tests: add scrubScionEnv()/scrubHubEnv() calls to all leaking tests, matching the existing pattern in hub_test.go.

2. Runtime guards (defense-in-depth):
   - hub.NewClient() refuses to connect to non-localhost hubs under testing.Testing() unless SetHubTestSandboxed() was called.
   - telemetry.LoadConfig() force-disables cloud export under testing.Testing() unless SetTelemetryTestSandboxed() was called.

Root cause analysis: /scion-volumes/scratchpad/limits-exceeded-investigation.md

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
