### PR TITLE
feat(worktree): adapt Phase 1 onto pkg/provision (post-#169)

### DIFF
--- a/.design/worktree-per-agent-phase1-plan.md
+++ b/.design/worktree-per-agent-phase1-plan.md
@@ -1,0 +1,189 @@
+# Phase 1 Implementation Plan: Worktree-Per-Agent (Docker × node-local)
+
+**Branch:** `scion/worktree-per-agent`
+**Scope:** Design doc §12 Phase 1 only — Docker × node-local. NFS parity (Phase 2)
+and K8s (Phase 3) are out of scope here.
+**Tracking:** #158 (parent), #168 (shared-worktree refcount — Q7, deferred to a later phase).
+
+---
+
+## Post-Phase-0 baseline (rebased onto `scion/storage-provisioning-phase0`)
+
+Phase 0 of epic #169 (PR #170) landed the universal-provisioning extraction. This branch
+is rebased on it. The seam Phase 1 builds against is now:
+
+- `WorkspaceBackend` interface = **Resolve + Realize + Name** only. `Provision` was
+  **removed** (`pkg/runtime/workspace_backend.go`).
+- `provisionShared(in ProvisionInput) error` — the standalone Tier-1 universal function
+  (`pkg/runtime/workspace_provision.go`). It does clone + `ensureWorktree` + advisory
+  lock + sentinel. **Still unwired** — no live caller yet.
+- `localBackend` / `nfsBackend` = Resolve + Realize; provisioning content all moved into
+  `provisionShared`.
+
+Two things in the extracted code are NFS-shaped and are Phase-1's job to fix:
+
+1. **`ensureWorktree` uses plain `git worktree add -b` — no `--relative-paths`**
+   (`workspace_provision.go:283`). Mandatory for container path-identity (design §6);
+   `util.CreateWorktree` already does this correctly and should be reused.
+2. **No Q1 layout** — it clones into `Resolved.HostPath` and nests `worktrees/<agentID>`
+   under it, leaving `HostPath` checked out on the default branch. Q1 requires the base to
+   hold **no** branch (so a coordinator can own `main`).
+
+Also cosmetic: every error string in `provisionShared` still says `"nfsBackend.Provision:"`
+(extraction leftover) — fix to neutral `"provisionShared:"`.
+
+Consequence: "broker dispatch branches on mode" (design §4.3, §5) remains the heaviest
+task — it is the **first real wiring** of `provisionShared` + the backend abstraction into
+the Docker node-local lifecycle. No non-test caller of `SelectWorkspaceBackend` or
+`provisionShared` exists yet; NFS provisioning still runs via the separate k8s
+init-container path (`k8s_runtime.go`), whose unification is #169 PR2, not this work.
+
+What already exists and is reused as-is:
+- `util.CheckGitVersion()` / `CompareGitVersion()` — git ≥ 2.47 gate (`pkg/util/git.go`).
+- `util.CreateWorktree()` — already uses `--relative-paths` + reuse-branch fallback.
+- Dual-mount recipe — `pkg/runtime/common.go:188-222` (`.git` at `/repo-root/.git` +
+  worktree at `/repo-root/<rel>`), gated on `RepoRoot`+`Workspace` set and `GitClone==nil`.
+- `SCION_HOST_UID` guard forcing `isGit=false` in-container (`provision.go:303-309`).
+- Teardown: `RemoveWorktree` / `PruneWorktreesIn` / `DeleteBranchIn` (`provision.go:35-146`).
+- Advisory lock + sentinel guard (`workspace_backend_nfs.go:141-268`).
+
+---
+
+## Target node-local layout (Phase 1)
+
+**Layout decision (path-identity constraint, design §6).** The container dual-mount in
+`common.go:188-222` only fires when `filepath.Rel(RepoRoot, Workspace)` does **not** start
+with `..` — i.e. the worktree must live **inside** the repo root, exactly how the proven
+local-repo case nests worktrees. The design doc's sibling `base/` + `worktrees/` layout
+(§3) would make `rel = ../worktrees/<id>` and `common.go` rejects it. So Phase 1 mirrors
+the local case rather than the §3 diagram:
+
+```
+~/.scion.projects/<slug>/        # localBackend project root == RepoRoot (the base checkout)
+  .git/                          # shared object store + packed-refs; gc.auto=0
+  <base working tree>            # cloned, then `git switch --detach` → owns NO branch
+  worktrees/<agentID>/           # per-agent worktree nested inside repo root
+    .git                         #   FILE: relative gitdir (via --relative-paths)
+  .scion-provisioned             # sentinel: base clone complete
+```
+
+Base detached at default HEAD so `main` is free for an optional coordinator worktree (Q1).
+`worktrees/` is added to `.git/info/exclude` so it never shows as untracked in the base.
+
+> **Sentinel-location refinement (P1.4b).** `ProvisionShared` writes its sentinel at
+> `filepath.Dir(HostPath)`. To give a per-project sentinel (not a node-shared one),
+> `localBackend.Resolve` returns `HostPath = <ProjectDir>/workspace` for worktree mode, so
+> the base checkout lives at `~/.scion.projects/<slug>/workspace` and the sentinel at
+> `~/.scion.projects/<slug>/.scion-provisioned`. Worktrees nest at
+> `<ProjectDir>/workspace/worktrees/<agentID>`. This matches `ProvisionShared`'s NFS-shaped
+> contract (HostPath's parent is the per-project root).
+Per-agent non-workspace state (prompt.md, scion-agent.json, home/) continues to live in
+external split storage — unchanged from shared-workspace mode.
+
+> Revisiting the §3 sibling layout (no base working tree) is deferred: it requires teaching
+> `common.go` to mount a common parent at `/repo-root` and handle a `..`-relative worktree.
+> Out of Phase 1 scope; noted for follow-up.
+
+---
+
+## Sub-tasks
+
+Each is sized to commit+push within the agent 3-turn limit. Dependencies in brackets.
+
+### P1.1 — Bring `provisionShared`'s worktree path to the Phase-1 layout
+Edit `ensureWorktree` (and the base-clone step) in `pkg/runtime/workspace_provision.go`.
+Responsibilities (design §4.1, §4.2, §4.2a, §6):
+- After the base clone into `Resolved.HostPath`, `git -C <HostPath> switch --detach` so
+  the base owns no branch; set `git config gc.auto 0`; add `worktrees/` to
+  `.git/info/exclude`.
+- Replace the plain `git worktree add -b` with **`--relative-paths`** (mandatory, §6).
+  Prefer reusing `util.CreateWorktree` / `sanitizeBranchName` so there is one worktree-add
+  implementation. Keep the reuse-branch fallback (attach existing branch instead of `-b`)
+  for the coordinator/`main` case (§4.2a). Worktree stays nested:
+  `<HostPath>/worktrees/<agentID>`.
+- Write `.scion` workspace marker into the worktree (`config.WriteWorkspaceMarker`).
+- Single-worktree-per-branch invariant: clear error if the branch is already checked out
+  elsewhere (don't let raw git fail opaquely).
+- Clean up the `"nfsBackend.Provision:"` error strings in `provisionShared` →
+  `"provisionShared:"` (neutral, now that it is the shared Tier-1 fn).
+- Update the worktree tests in `workspace_provision_test.go` to the new layout
+  (detached base, `--relative-paths` `.git` pointer). **SharedPlain and ClonePerAgent
+  tests stay untouched and green.**
+
+### P1.2 — `localBackend.Resolve` for worktree mode  [needs P1.1]
+(No `backend.Provision` anymore — provisioning is the standalone `provisionShared`, invoked
+by the broker in P1.4.)
+- `Resolve`: when `Mode == WorktreePerAgent`, return `HostPath` = the node-local project
+  root (the base checkout / `RepoRoot`). The worktree path
+  (`<HostPath>/worktrees/<agentID>`) is derived by `provisionShared`. Other modes
+  unchanged (zero behavior change).
+- Confirm `Realize` still emits the plain local bind mount; the **dual-mount** (`.git` +
+  worktree) is contributed by `common.go` when the broker sets `RepoRoot`+`Workspace`
+  (P1.4), not by `Realize`.
+- Unit tests for the worktree-mode Resolve path.
+
+### P1.3 — git-version gate + clone-per-agent fallback
+- Decision helper (e.g. `worktreeEligible() (bool, reason string)`) wrapping
+  `util.CheckGitVersion()`. On git < 2.47: log a warning and signal fallback to
+  clone-per-agent (design §6, §9.1).
+- Unit test the decision (inject version).
+
+### P1.4 — Broker dispatch branches on mode  [needs P1.2, P1.3]
+The core wiring. In `pkg/runtimebroker/start_context.go` (where `opts.GitClone` is set,
+~437-454) and/or the dispatch handler:
+- Resolve sharing mode for the dispatch (from threaded mode — see P1.5).
+- If `worktree-per-agent` **and** git ≥ 2.47:
+  - `resolved := SelectWorkspaceBackend(cfg, mode).Resolve(...)`, then
+    `provisionShared(ProvisionInput{Resolved: resolved, Mode, GitClone, AgentID,
+    AgentName, Locker, ...})` on the host (base clone + worktree).
+  - Set `opts.Workspace = <HostPath>/worktrees/<agentID>` and `RepoRoot = <HostPath>`
+    (the detached base) so `common.go` takes the **dual-mount** path; **do not** set
+    `opts.GitClone` (suppress in-container clone).
+- Else: existing clone-per-agent path (set `GitClone`, clone in container).
+- Keep the `SCION_HOST_UID` guard intact.
+
+### P1.5 — Hub: permit worktree-per-agent on git hub-managed projects  [supports P1.4]
+- Allow/stamp `scion.dev/workspace-mode = worktree-per-agent` for git-backed
+  hub-managed projects (`pkg/hub/handlers.go`); update the "reserved for Phase 1+"
+  doc comment on `pkg/store/models.go`.
+- Thread the resolved mode into the dispatch request (`pkg/runtimebroker/types.go`
+  `RunRequest`) so the broker (P1.4) can branch without re-deriving from labels.
+
+### P1.6 — Verification + suite green  [needs P1.4, P1.5]
+- Docker × node-local end-to-end: create 2 agents on one git project → confirm a single
+  base clone, two `worktrees/<id>` with distinct branches, dual-mount resolves inside
+  the container, `git status` clean in each. Optional coordinator with `--branch main`.
+- Full `go build ./...` + `go test ./...` green.
+- Open PR against `main` (do **not** merge).
+
+---
+
+## Sequencing & orchestration
+
+```
+P1.1 ─┬─> P1.2 ─┐
+      │         ├─> P1.4 ─┐
+      └  P1.3 ──┘         ├─> P1.6 (verify + PR)
+         P1.5 ────────────┘
+```
+
+- One developer agent per sub-task, in dependency order; P1.3 and P1.5 can run parallel
+  to the P1.1→P1.2 chain.
+- Each agent commits **and pushes** after its sub-task (3-turn-limit workaround).
+- Manager reports to coordinator at each milestone (P1.1, P1.2/P1.3, P1.4/P1.5, P1.6+PR).
+
+## Resolved through design dialogue (2026-06-07, thread 155)
+- **Provisioning abstraction** — extracted to standalone Tier-1 `provisionShared` in
+  epic #169 PR1 (Phase 0), now merged-to-branch and rebased under this work. P1.1 builds on
+  it; no NFS layout reconciliation needed in this phase (NFS validation is #169 / NFS
+  Phase 2).
+- **Mode threading (P1.5)** — add an explicit mode field to `RunRequest` rather than
+  re-deriving from labels in the broker.
+- **Layout** — Phase 1 uses the nested-worktree layout (base checkout = repo root, detached;
+  worktrees nested inside) to satisfy `common.go`'s path-identity constraint; the §3 sibling
+  layout is a deferred follow-up. See "Target node-local layout" above.
+
+## Remaining open point
+- **Coordinator UX** — Phase 1 only needs the reuse-branch path working for `--branch main`;
+  the Hub's single-owner-per-branch enforcement (§4.2a) can be a thin check now, hardened
+  later. (Proposed; confirm if it needs more in Phase 1.)

--- a/.design/worktree-per-agent.md
+++ b/.design/worktree-per-agent.md
@@ -1,0 +1,413 @@
+# Design: Worktree-Per-Agent Mode for Hub-Managed Workspaces
+
+**Branch:** `scion/worktree-per-agent`
+**Date:** 2026-06-06
+**Author:** worktree-designer agent
+**Status:** Design proposal — initial draft for review
+**Vocabulary:** follows `GLOSSARY.md` (Runtime Broker, Project, workspace sharing modes)
+**Reviewers:** @ptone
+**Tracking issue:** https://github.com/ptone/scion/issues/158
+
+**Inputs (verified against source):**
+`pkg/store/models.go`, `pkg/runtime/workspace_backend.go`,
+`pkg/runtime/workspace_backend_local.go`, `pkg/runtime/workspace_backend_nfs.go`,
+`pkg/agent/provision.go`, `pkg/runtime/common.go`, `pkg/api/types.go`,
+`.design/nfs-workspace.md`, `.design/worktree-guards.md`,
+`.design/hub-shared-workspace-isolation.md`, `.design/git-workspace-hybrid.md`.
+
+---
+
+## 1. Problem statement
+
+In hub-managed mode, every agent created against a git-backed project performs its
+**own full clone** of the project's remote. The Hub dispatches a `GitCloneConfig`
+(`pkg/api/types.go`) and `sciontool` clones the repository into the agent's workspace
+**inside the container** at startup (the `gitClone != nil` branch in
+`pkg/agent/provision.go:371-396`). Concretely:
+
+1. Hub computes the workspace mode for the project and builds a dispatch carrying
+   `GitClone` (URL + branch + depth).
+2. The Runtime Broker prepares an empty per-agent workspace dir and mounts it.
+3. `sciontool` clones into `/workspace` when the container starts.
+
+This is simple and isolates agents perfectly, but it scales badly:
+
+- **Startup latency** is dominated by a network clone, paid **per agent**.
+- **Disk amplification** — N agents on a node hold ≈ N full copies of the same
+  history and working tree.
+- **No cheap coordination** — two agents working the same repo can't see each
+  other's branches/objects without round-tripping to the remote.
+
+The canonical mode that fixes this already exists in the type system —
+`SharingModeWorktreePerAgent` (`pkg/store/models.go:208-212`) — but its doc comment
+states it is *"not yet on Hub-managed projects — reserved for Phase 1+"*, and backend
+routing only wires it to **NFS**:
+
+```go
+// pkg/runtime/workspace_backend.go:200-210
+func SelectWorkspaceBackend(cfg *config.V1WorkspaceStorageConfig, mode store.WorkspaceSharingMode) WorkspaceBackend {
+	if cfg != nil && cfg.Backend == "nfs" {
+		switch mode {
+		case store.SharingModeSharedPlain, store.SharingModeWorktreePerAgent:
+			return NewNFSBackend(cfg.NFS)
+		}
+	}
+	return NewLocalBackend()
+}
+```
+
+The node-local `localBackend.Provision` is a **no-op**
+(`pkg/runtime/workspace_backend_local.go:65-70`), so there is no worktree-per-agent
+path for the common single-node, node-local hub-managed deployment.
+
+**Goal:** the Hub/Runtime Broker maintains **one shared base clone per node** for a
+project, and each agent gets its own **git worktree** (own branch, own working tree)
+over that shared `.git` object store — instead of a full clone. First agent pays the
+clone; every subsequent agent pays only a cheap `git worktree add`.
+
+### 1.1 The mechanism already exists for *local* git projects
+
+This is not a from-scratch effort. For **local** (non-hub) git projects, Scion already:
+
+- Creates host-side `--relative-paths` worktrees per agent at
+  `.scion/agents/<name>/workspace` via `util.CreateWorktree`
+  (`pkg/agent/provision.go:449-485`, Case 2 at lines 412-434).
+- Dual-mounts the shared `.git` and the per-agent worktree into the container so the
+  relative gitdir pointer resolves (`pkg/runtime/common.go:181-189`):
+
+  ```go
+  registerMount(filepath.Join(config.RepoRoot, ".git"), "/repo-root/.git", false, true)
+  containerWorkspace := filepath.Join("/repo-root", relWorkspace)
+  registerMount(config.Workspace, containerWorkspace, false, true)
+  ```
+
+- Tears worktrees + branches down on delete with pruning of stale records
+  (`util.RemoveWorktree`, `PruneWorktreesIn`, `DeleteBranchIn` —
+  `pkg/agent/provision.go:35-146`).
+
+So worktree-per-agent **already runs in production** for the local-repo case. The work
+is to bring this model to **hub-managed** projects (which today take the
+clone-in-container path) and to formalize it as the `worktree-per-agent` sharing mode
+on node-local storage, reusing the NFS backend's `ensureWorktree` logic where it fits.
+
+### 1.2 Non-goals
+
+- **Auto-migrating** existing full-clone agents to worktrees. New mode applies to new
+  projects/agents; live conversion is out of scope.
+- **A distributed lock manager.** Reuse the existing advisory-lock + sentinel guard.
+- **Cross-node base sharing on node-local storage.** A node-local base is per-node by
+  definition; cross-node sharing is the NFS backend's job (§7).
+- **Replacing clone-per-agent.** It remains the right default when agents need fully
+  independent histories or must survive base-repo corruption.
+
+---
+
+## 2. Background: the three sharing modes
+
+`pkg/store/models.go:197-231` defines the canonical modes and the label mapping
+(`scion.dev/workspace-mode`, `ResolveWorkspaceSharingMode`):
+
+| Mode | Constant | Storage today | Isolation |
+|------|----------|---------------|-----------|
+| Shared plain | `SharingModeSharedPlain` (`shared`) | one dir, all agents mount it | none |
+| Clone per agent | `SharingModeClonePerAgent` (`per-agent`) | full clone per agent (node-local) | full |
+| **Worktree per agent** | `SharingModeWorktreePerAgent` | **NFS only today** | per-branch working tree, shared object store |
+
+This design makes the third row a first-class option for **hub-managed projects on
+node-local storage**, and aligns it with the NFS implementation so a single code path
+serves both backends.
+
+---
+
+## 3. Target layout
+
+Per node, per project, the broker maintains a single **base repo** and a `worktrees/`
+subtree, mirroring the NFS backend's layout (`workspace_backend_nfs.go:331-332`):
+
+```
+<project-root>/                         # e.g. ~/.scion.projects/<slug>/
+  base/                                 # the one shared clone (.git lives here)
+    .git/                               #   shared object store + packed-refs
+    <checked-out files of base branch>
+  worktrees/
+    <agentID>/                          # per-agent worktree (own branch + working tree)
+      .git                              #   FILE: gitdir pointer (relative) → base/.git/worktrees/<id>
+      <agent's working tree>
+  .scion-provisioned                    # sentinel: base clone complete
+```
+
+Per-agent **non-workspace** state (prompt.md, scion-agent.json, home/) stays in the
+external split-storage location, exactly as shared-workspace mode does today
+(`.design/hub-shared-workspace-isolation.md`, `provision.go:120-143`), so siblings
+never see each other's prompts through a shared mount.
+
+> Naming note: `.design/worktree-guards.md` calls out that every agent worktree using
+> the basename `workspace` causes git to auto-suffix entries (`workspace`, `workspace1`,
+> …). Using `worktrees/<agentID>` as the worktree path gives each a **unique basename**
+> (the agent UUID), eliminating that ambiguity. Scion associates worktrees by branch
+> (`FindWorktreeByBranch`) regardless, but unique basenames make `git worktree list`
+> legible.
+
+---
+
+## 4. Provisioning flow
+
+### 4.1 First agent (base clone)
+
+When the first agent for a project lands on a node in worktree-per-agent mode:
+
+1. **Acquire the per-project advisory lock** (`store.AdvisoryLocker` /
+   `LockWorkspaceProvision`, keyed by a stable project hash — same guard the NFS
+   backend uses, `workspace_backend_nfs.go:227-268`). On Postgres this is
+   `pg_try_advisory_lock`; on SQLite/single-node it serializes naturally.
+2. **Check the `.scion-provisioned` sentinel.** If present, skip to §4.2.
+3. **Clone the remote once** into `base/` using the dispatched `GitCloneConfig`
+   (URL/branch/depth). This is the *only* network clone for the project on this node.
+4. **Write the sentinel** atomically, release the lock.
+
+This is the `localBackend` analogue of `nfsBackend.Provision`
+(`workspace_backend_nfs.go:141-225`); the difference is the root path (node-local
+project dir vs NFS export) — the guard logic is identical and should be **shared**.
+
+### 4.2 Every agent (worktree add)
+
+Under the same per-project lock (worktree add/remove mutates shared `.git` metadata —
+`workspace_backend_nfs.go:318-376`, design §9.2):
+
+1. Compute `worktreePath = <project-root>/worktrees/<agentID>`.
+2. If it already exists, no-op (idempotent restart).
+3. Derive branch: `branch = sanitizeBranchName(agentName)` /
+   `api.Slugify(agentName)`. If the branch already exists, attach to it instead of
+   `-b` (the reuse fallback at `workspace_backend_nfs.go:363-371`).
+4. `git -C base worktree add --relative-paths -b <branch> <worktreePath>`.
+   `--relative-paths` (git ≥ 2.47) is **mandatory** so the gitdir pointer survives the
+   container mount remap (§6).
+5. Write the `.scion` workspace marker into the worktree
+   (`config.WriteWorkspaceMarker`, as `provision.go:475-484` does) so the in-container
+   CLI can discover project context — worktrees don't carry `.scion`.
+
+### 4.2a The coordinator / `main` agent (Q1 resolved)
+
+The base is cloned **non-bare** then **detached** at the default-branch HEAD
+(`git -C base switch --detach`), so the base's own working tree never holds a branch and
+stays clean — a pure object-store + refs directory. `main` (the default branch) is
+therefore free to be attached by a *linked* worktree like any other branch.
+
+A user may create one **coordinator agent** with an explicit `--branch main`. It is not a
+special code path: it is simply the agent whose worktree owns the `main` branch (attached
+via the reuse path, not `-b`). Because every agent branch lives in the shared object
+store, this coordinator can `git merge <agent-branch>` **locally** with no remote round
+trip — the in-hub analogue of "a non-agent merges to main" in local-use mode.
+
+**Single-worktree-per-branch invariant.** Git forbids the same branch checked out in two
+worktrees, so at most one worktree may *own* a given branch (e.g. `main`). The Hub
+enforces this and returns a clear error rather than letting a raw `git worktree add`
+fail. See Q7 for the explicitly-requested **shared-mount** exception, which lets >1 agent
+attach to the *same* worktree directory without violating this invariant.
+
+### 4.3 Reconciling with the clone-in-container dispatch path
+
+Today hub dispatch sets `GitClone` and the clone happens **inside** the container at
+startup. Worktree-per-agent inverts this: the worktree is created **on the host/broker**
+(where the base `.git` lives) *before* the container starts, then mounted in. So:
+
+- When mode is `worktree-per-agent`, the broker provisions the worktree on the host and
+  takes the **dual-mount** path (`common.go:181-189`) instead of passing `GitClone`
+  through to sciontool.
+- `GitCloneConfig` is still used by `Provision` (§4.1) to perform the *base* clone, but
+  it is consumed broker-side, not container-side.
+- The `SCION_HOST_UID` guard that forces `isGit = false` inside containers
+  (`provision.go:303-309`) stays — agents must **never** create worktrees from inside
+  the container (see §6, `.design/worktree-guards.md`).
+
+---
+
+## 5. Backend selection changes
+
+`SelectWorkspaceBackend` (`workspace_backend.go:200-210`) currently sends
+`worktree-per-agent` to local **only** by falling through (which is a no-op backend).
+Two changes:
+
+1. **Implement `localBackend.Provision`** to perform the §4 base-clone + worktree-add
+   when `in.Mode == SharingModeWorktreePerAgent`, factoring the shared guard/worktree
+   logic out of `nfsBackend` into a helper both backends call (e.g.
+   `ensureBaseAndWorktree(root, in)`).
+2. **Route node-local worktree-per-agent to `localBackend`** (already the fall-through),
+   and keep NFS worktree-per-agent on `nfsBackend`. The mode is now valid on **both**
+   backends; the backend only decides *where the root lives*, not *whether worktrees are
+   supported*.
+
+`localBackend.Realize` already emits a bind mount (`workspace_backend_local.go:74-85`);
+the runtime layer adds the **second** mount (shared `base/.git`) per `common.go:181-189`
+when the resolved workspace is a worktree.
+
+---
+
+## 6. Isolation & the container path-identity constraint
+
+This is the sharpest constraint, documented in `.design/worktree-guards.md` §3.
+
+A worktree's `.git` is a **file** containing `gitdir: <path>` pointing at
+`base/.git/worktrees/<id>`. For that pointer to resolve inside the container, the base
+`.git` and the worktree must keep the **same relative distance** across the mount
+boundary. The proven recipe (`common.go:181-189`):
+
+- Mount shared git dir at a fixed container path (`/repo-root/.git`).
+- Mount the worktree at `/repo-root/<relWorkspace>` preserving the host relative path.
+- Worktrees created with `--relative-paths` then resolve identically on host and in
+  container.
+
+Hard rules that fall out:
+
+- **git ≥ 2.47** on the broker host (for `--relative-paths`). Gate provisioning on a
+  version check; fall back to clone-per-agent with a logged warning if absent.
+- **No in-container worktree creation.** Relative paths computed against the container
+  namespace are meaningless on the host (`.design/worktree-guards.md` §3). The existing
+  `SCION_HOST_UID` guard enforces this; keep it.
+
+Other shared-state isolation concerns:
+
+- **Object store & packed-refs are shared.** Concurrent ref updates are safe (git locks
+  refs), but a `git gc` in one worktree repacks objects for all. Recommendation:
+  **disable auto-gc** in the base (`git config gc.auto 0`) and run GC only during a
+  controlled "last agent" teardown or maintenance window.
+- **`.git/config` is shared.** Per-agent git identity/credentials must live in the
+  agent's `$HOME/.gitconfig` (already the pattern for shared-workspace mode,
+  `provision.go:881-901`), never written into the shared base.
+- **Per-agent non-workspace state** (prompt.md, scion-agent.json) uses external split
+  storage (§3) so it isn't visible through the shared tree.
+
+---
+
+## 7. How the Hub manages the shared base repo
+
+- **Mode selection.** Hub stamps the project label
+  `scion.dev/workspace-mode = worktree-per-agent` at project-create time (parallel to
+  the existing `shared` stamping in `pkg/hub/handlers.go`). `ResolveWorkspaceSharingMode`
+  already maps the wire value (`models.go:225-226`).
+- **Dispatch.** Hub keeps sending `GitCloneConfig` (URL/branch/depth); the broker
+  decides — based on resolved mode — whether to consume it as a base clone (worktree
+  mode) or pass it through for in-container clone (clone-per-agent mode).
+- **Base lifecycle.** The base is **per node**. The Hub does not track base repos
+  directly; the broker owns them via the sentinel + advisory lock. The Hub's role is
+  mode selection and ensuring agents for a worktree-mode project are dispatched
+  consistently.
+- **Multi-node.** Two nodes each keep their own base clone (acceptable — clone cost is
+  amortized per node, not per agent). True cross-node base sharing requires the **NFS
+  backend**, where the base + all worktrees live on a single export and
+  `nfsBackend.ensureWorktree` already implements §4.2. The mode is identical; only the
+  root path differs — which is exactly why §5 factors the logic into a shared helper.
+
+Backend × runtime matrix:
+
+| | Docker / VM | Kubernetes |
+|---|---|---|
+| **node-local** | base clone on host, dual bind-mount (§6) | base on node, worktrees per pod via hostPath/emptyDir — **needs validation** |
+| **NFS** | base + worktrees on export, NFS mount | base + worktrees on RWX PVC + subPath (existing NFS design §9) |
+
+The K8s × node-local cell is the least-proven and may be restricted to NFS in v1.
+
+---
+
+## 8. Lifecycle & cleanup
+
+Agent deletion already does the right thing for worktrees
+(`pkg/agent/provision.go:35-146`):
+
+1. `util.RemoveWorktree(agentWorkspace, removeBranch)` — removes the worktree and
+   optionally its branch.
+2. `util.PruneWorktreesIn(repoRoot)` — clears stale `.git/worktrees/<id>` records.
+3. `util.DeleteBranchIn(repoRoot, branchName)` fallback by slugified name.
+4. External per-agent state dir removed (with podman-unshare fallback).
+
+New work for the base repo:
+
+- **Last-agent teardown.** When the final worktree for a project is removed on a node,
+  optionally GC and/or remove `base/` (policy: keep for fast re-provision vs reclaim
+  disk). Guard the decision under the same advisory lock.
+- **Orphan base detection.** A maintenance sweep that prunes worktrees and, if none
+  remain, applies the teardown policy — analogous to existing project-prune flows.
+
+---
+
+## 9. Limitations
+
+1. **git ≥ 2.47 required** on the broker host (`--relative-paths`). Older hosts fall
+   back to clone-per-agent.
+2. **No nested / in-container worktrees.** Enforced by the `SCION_HOST_UID` guard;
+   agents that try to `git worktree add` inside the container get path-identity
+   corruption (`.design/worktree-guards.md`).
+3. **Shared object store is a shared fate.** Corruption or an ill-timed `gc` in the base
+   affects all agents on that node. Clone-per-agent remains the choice when independence
+   matters more than speed.
+4. **Node-local base is per node.** Cross-node sharing needs NFS; the disk win is
+   per-node, not global.
+5. **Working-tree-only isolation.** Agents share history and refs; a force-push or a
+   shared-ref rewrite is visible to siblings. Branch-per-agent contains *normal*
+   workflows, not adversarial ones.
+6. **K8s node-local path unproven** — may be NFS-only in v1 (§7).
+
+---
+
+## 10. Reuse map (what already exists)
+
+| Need | Existing primitive | Location |
+|------|--------------------|----------|
+| Worktree add (host, relative) | `util.CreateWorktree` | `pkg/util/git.go`, `provision.go:470` |
+| Worktree add (NFS, with reuse) | `nfsBackend.ensureWorktree` | `workspace_backend_nfs.go:318-376` |
+| Branch name from agent | `api.Slugify` / `sanitizeBranchName` | `workspace_backend_nfs.go:378-393` |
+| First-access guard | sentinel + `store.AdvisoryLocker` | `workspace_backend_nfs.go:141-268` |
+| Dual mount (`.git` + worktree) | runtime mount registration | `common.go:181-189` |
+| Worktree teardown + prune | `RemoveWorktree`/`PruneWorktreesIn`/`DeleteBranchIn` | `provision.go:35-146` |
+| In-container worktree guard | `SCION_HOST_UID` → `isGit=false` | `provision.go:303-309` |
+| Per-agent state isolation | external split storage | `.design/hub-shared-workspace-isolation.md` |
+| Backend abstraction | `WorkspaceBackend` Resolve/Provision/Realize | `workspace_backend.go:33-64` |
+
+The net new code is small and concentrated: implement `localBackend.Provision` for the
+worktree case, factor `ensureBaseAndWorktree` out of the NFS backend so both backends
+share it, branch the broker dispatch on mode (host worktree vs in-container clone), add
+the git-version gate, and define base-repo teardown.
+
+---
+
+## 11. Open questions
+
+1. **Q1 — Base branch policy. [RESOLVED 2026-06-06]** Base is cloned **non-bare** then
+   **detached** at default-branch HEAD; it never checks out a working branch and stays
+   clean. The `main` branch is owned by an optional **coordinator agent** created with an
+   explicit `--branch main`, which holds the `main` worktree like any other agent and can
+   merge sibling branches locally from the shared object store. The Hub enforces a
+   single owner per branch (see §4.2a). Bare-base variant deferred as a later refinement.
+2. **Q2 — GC policy.** Disable auto-gc entirely and GC only on teardown, or allow
+   scheduled GC under the project lock?
+3. **Q3 — Base teardown.** Keep `base/` after the last agent (fast re-provision) or
+   reclaim disk immediately? Configurable via settings?
+4. **Q4 — K8s node-local.** Support node-local worktrees on K8s in v1, or restrict
+   worktree-per-agent to NFS on K8s?
+5. **Q5 — Migration.** Any opt-in path to convert a running clone-per-agent project to
+   worktree-per-agent, or strictly new-projects-only?
+6. **Q6 — Default mode.** Should worktree-per-agent become the default for new
+   git-backed hub-managed projects once proven, with clone-per-agent as opt-out?
+7. **Q7 — Explicit shared worktree (multi-agent mount).** Requirement (maintainer,
+   2026-06-06): support **>1 agent mounting the same branch/worktree** when explicitly
+   requested. Since git forbids the same branch in two *separate* worktrees, this means N
+   agents **bind-mount the same worktree directory** into their containers (shared
+   working tree + shared branch), rather than each creating its own. Open sub-questions:
+   how it is requested (e.g. `--branch <b> --shared` or attaching to an existing agent's
+   worktree); concurrency/write-conflict expectations within the shared tree (this is
+   shared-plain semantics scoped to one branch — cf. `.design/hub-shared-workspace-isolation.md`);
+   how per-agent home/prompt state stays isolated while the workspace is shared; and
+   refcounted teardown so the worktree is removed only when the last mounting agent exits.
+   To be taken up as its own question after Q2–Q6.
+
+---
+
+## 12. Phased rollout (proposed)
+
+- **Phase 0 (this doc).** Design + issue #158.
+- **Phase 1.** Factor `ensureBaseAndWorktree`; implement `localBackend.Provision` for
+  worktree mode; broker dispatch branches on mode; git-version gate. Docker × node-local
+  only.
+- **Phase 2.** NFS parity validated end-to-end (largely existing); base teardown +
+  orphan sweep.
+- **Phase 3.** K8s story (NFS-first); decide default-mode question (Q6).

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -3324,7 +3324,7 @@ type CreateProjectRequest struct {
 	Slug          string            `json:"slug,omitempty"`
 	Name          string            `json:"name"`
 	GitRemote     string            `json:"gitRemote,omitempty"`
-	WorkspaceMode string            `json:"workspaceMode,omitempty"` // "shared" or "per-agent" (default); only meaningful when gitRemote is set
+	WorkspaceMode string            `json:"workspaceMode,omitempty"` // "shared", "worktree-per-agent", or "per-agent" (default); only meaningful when gitRemote is set
 	Visibility    string            `json:"visibility,omitempty"`
 	Labels        map[string]string `json:"labels,omitempty"`
 	GitHubToken   string            `json:"githubToken,omitempty"`
@@ -3578,12 +3578,15 @@ func (s *Server) createProject(w http.ResponseWriter, r *http.Request) {
 		displayName = api.DisplayNameWithSerial(req.Name, slug, baseSlug)
 	}
 
-	// Apply workspace mode label for git projects with shared workspace mode.
-	if normalizedRemote != "" && req.WorkspaceMode == store.WorkspaceModeShared {
-		if req.Labels == nil {
-			req.Labels = make(map[string]string)
+	// Apply workspace mode label for git projects with explicit workspace mode.
+	if normalizedRemote != "" {
+		switch req.WorkspaceMode {
+		case store.WorkspaceModeShared, store.WorkspaceModeWorktreePerAgent:
+			if req.Labels == nil {
+				req.Labels = make(map[string]string)
+			}
+			req.Labels[store.LabelWorkspaceMode] = req.WorkspaceMode
 		}
-		req.Labels[store.LabelWorkspaceMode] = store.WorkspaceModeShared
 	}
 
 	project := &store.Project{

--- a/pkg/hub/handlers_project_test.go
+++ b/pkg/hub/handlers_project_test.go
@@ -1528,6 +1528,45 @@ func TestCreateProject_PerAgentGit_NoWorkspaceLabel(t *testing.T) {
 	assert.False(t, project.IsSharedWorkspace())
 }
 
+func TestCreateProject_WorktreePerAgent_StampsLabel(t *testing.T) {
+	srv, _ := testServer(t)
+
+	body := CreateProjectRequest{
+		Name:          "Worktree Project",
+		GitRemote:     "github.com/test/worktree",
+		WorkspaceMode: "worktree-per-agent",
+	}
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects", body)
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+
+	var project store.Project
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&project))
+
+	assert.Equal(t, store.WorkspaceModeWorktreePerAgent, project.Labels[store.LabelWorkspaceMode],
+		"worktree-per-agent label should be stamped")
+	assert.True(t, project.IsWorktreePerAgent(), "project should report as worktree-per-agent")
+	assert.False(t, project.IsSharedWorkspace(), "project should not report as shared workspace")
+}
+
+func TestCreateProject_WorktreePerAgent_NonGit_NoLabel(t *testing.T) {
+	srv, _ := testServer(t)
+
+	body := CreateProjectRequest{
+		Name:          "Non-Git Worktree",
+		WorkspaceMode: "worktree-per-agent",
+	}
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects", body)
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+
+	var project store.Project
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&project))
+
+	assert.Empty(t, project.Labels[store.LabelWorkspaceMode],
+		"worktree-per-agent label should not be set on non-git projects")
+}
+
 func TestPopulateAgentConfig_SharedWorkspace_SetsWorkspaceNotClone(t *testing.T) {
 	srv, _ := testServer(t)
 
@@ -1612,6 +1651,35 @@ func TestPopulateAgentConfig_SharedWorkspace_DefaultsBranch(t *testing.T) {
 
 	assert.Equal(t, "main", agent3.AppliedConfig.Branch,
 		"Branch should default to 'main' when no default-branch label is set")
+}
+
+func TestPopulateAgentConfig_WorktreePerAgent_SetsCloneNotWorkspace(t *testing.T) {
+	srv, _ := testServer(t)
+
+	project := &store.Project{
+		ID:        tid("project-wt"),
+		Name:      "Worktree Project",
+		Slug:      "worktree-proj",
+		GitRemote: "github.com/test/worktree",
+		Labels: map[string]string{
+			store.LabelWorkspaceMode:   store.WorkspaceModeWorktreePerAgent,
+			"scion.dev/default-branch": "main",
+		},
+	}
+
+	agent := &store.Agent{
+		ID:            "agent-worktree",
+		AppliedConfig: &store.AgentAppliedConfig{},
+	}
+
+	srv.populateAgentConfig(context.Background(), agent, project, nil)
+
+	assert.NotNil(t, agent.AppliedConfig.GitClone,
+		"GitClone should be set for worktree-per-agent projects (broker decides how to use it)")
+	assert.Contains(t, agent.AppliedConfig.GitClone.URL, "worktree",
+		"GitClone URL should reference the project remote")
+	assert.Empty(t, agent.AppliedConfig.Workspace,
+		"Workspace should NOT be set for worktree-per-agent projects")
 }
 
 func TestCloneSharedWorkspaceProject_Success(t *testing.T) {

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -253,16 +253,17 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 
 	// Build the remote create request
 	req := &RemoteCreateAgentRequest{
-		RequestID:   api.NewUUID(),
-		ID:          agent.ID,
-		Slug:        agent.Slug,
-		Name:        agent.Name,
-		ProjectID:   agent.ProjectID,
-		UserID:      agent.OwnerID,
-		HubEndpoint: d.hubEndpoint,
-		ProjectPath: projectInfo.projectPath,
-		ProjectSlug: projectInfo.projectSlug,
-		SharedDirs:  projectInfo.sharedDirs,
+		RequestID:     api.NewUUID(),
+		ID:            agent.ID,
+		Slug:          agent.Slug,
+		Name:          agent.Name,
+		ProjectID:     agent.ProjectID,
+		UserID:        agent.OwnerID,
+		HubEndpoint:   d.hubEndpoint,
+		ProjectPath:   projectInfo.projectPath,
+		ProjectSlug:   projectInfo.projectSlug,
+		SharedDirs:    projectInfo.sharedDirs,
+		WorkspaceMode: projectInfo.workspaceMode,
 	}
 
 	// Propagate attach mode from applied config
@@ -550,7 +551,8 @@ type projectDispatchInfo struct {
 	projectPath     string
 	projectSlug     string
 	sharedDirs      []api.SharedDir
-	sharedWorkspace bool // true for git-workspace hybrid projects
+	sharedWorkspace bool   // true for git-workspace hybrid projects
+	workspaceMode   string // resolved workspace mode label (e.g. "shared", "worktree-per-agent")
 }
 
 func (d *HTTPAgentDispatcher) resolveDispatchProjectPath(ctx context.Context, agent *store.Agent) (string, string) {
@@ -577,6 +579,7 @@ func (d *HTTPAgentDispatcher) resolveDispatchProjectInfo(ctx context.Context, ag
 
 	info.sharedDirs = project.SharedDirs
 	info.sharedWorkspace = project.IsSharedWorkspace()
+	info.workspaceMode = project.Labels[store.LabelWorkspaceMode]
 
 	// First check if the broker has a registered local path for this project.
 	if agent.RuntimeBrokerID != "" {

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -603,6 +603,59 @@ func TestHTTPAgentDispatcher_DispatchAgentCreate_WithProjectProviderPath(t *test
 	}
 }
 
+func TestHTTPAgentDispatcher_DispatchAgentCreate_ThreadsWorkspaceMode(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	project := &store.Project{
+		ID:        tid("project-wt"),
+		Name:      "worktree-project",
+		Slug:      "worktree-project",
+		GitRemote: "https://github.com/example/repo.git",
+		Labels: map[string]string{
+			store.LabelWorkspaceMode: store.WorkspaceModeWorktreePerAgent,
+		},
+	}
+	if err := memStore.CreateProject(ctx, project); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-wt"),
+		Name:     "test-broker",
+		Slug:     "test-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+
+	agent := &store.Agent{
+		ID:              tid("agent-wt"),
+		Name:            "test-agent",
+		Slug:            "test-agent",
+		ProjectID:       tid("project-wt"),
+		RuntimeBrokerID: tid("broker-wt"),
+	}
+
+	err := dispatcher.DispatchAgentCreate(ctx, agent)
+	if err != nil {
+		t.Fatalf("DispatchAgentCreate failed: %v", err)
+	}
+
+	if !mockClient.createCalled {
+		t.Fatal("expected CreateAgent to be called")
+	}
+	if mockClient.lastCreateReq.WorkspaceMode != store.WorkspaceModeWorktreePerAgent {
+		t.Errorf("expected WorkspaceMode %q, got %q",
+			store.WorkspaceModeWorktreePerAgent, mockClient.lastCreateReq.WorkspaceMode)
+	}
+}
+
 func TestHTTPAgentDispatcher_DispatchAgentCreate_MissingBrokerEndpoint(t *testing.T) {
 	// When a broker has no HTTP endpoint configured (e.g. control-channel-only
 	// brokers behind NAT), the dispatcher should still pass the call through

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -421,6 +421,11 @@ type RemoteCreateAgentRequest struct {
 	// Resolved by the Hub from the project record and passed to the broker
 	// so it can provision host-side directories and inject volume mounts.
 	SharedDirs []api.SharedDir `json:"sharedDirs,omitempty"`
+
+	// WorkspaceMode is the resolved workspace sharing mode for the project
+	// (e.g. "shared", "per-agent", "worktree-per-agent"). Threaded from the
+	// Hub so the broker can branch dispatch without re-deriving from labels.
+	WorkspaceMode string `json:"workspaceMode,omitempty"`
 }
 
 // ResolvedSecret represents a secret resolved by the Hub for projection into an agent container.

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -503,8 +503,12 @@ func appendGitExclude(hostPath, pattern string) error {
 		return fmt.Errorf("mkdir .git/info: %w", err)
 	}
 	data, _ := os.ReadFile(excludePath)
-	if strings.Contains(string(data), pattern) {
-		return nil
+	// Exact line match — strings.Contains would false-positive on e.g.
+	// "my-worktrees/" or "worktrees/agent-1" and skip appending the pattern.
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == strings.TrimSpace(pattern) {
+			return nil
+		}
 	}
 	f, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -222,6 +222,13 @@ func ProvisionShared(in ProvisionInput) error {
 		}
 	}
 
+	// For worktree-per-agent: detach HEAD, disable gc, exclude worktrees/.
+	if in.Mode == store.SharingModeWorktreePerAgent {
+		if err := prepareBaseForWorktrees(ctx, in.Resolved.HostPath); err != nil {
+			return fmt.Errorf("ProvisionShared: prepare base: %w", err)
+		}
+	}
+
 	// Chown to stable NFS UID/GID (design §9.1). This is a ONE-TIME operation
 	// under the advisory lock — per-start chown is skipped for NFS (see N1-5).
 	//
@@ -373,6 +380,12 @@ func removeDirContents(dir string) error {
 	return nil
 }
 
+// WorktreePath returns the canonical worktree path for a given agent within
+// a shared base checkout: <hostPath>/worktrees/<agentID>.
+func WorktreePath(hostPath, agentID string) string {
+	return filepath.Join(hostPath, "worktrees", agentID)
+}
+
 // ensureWorktree creates a per-agent worktree if the mode is WorktreePerAgent.
 // For SharedPlain mode this is a no-op.
 // The worktree add is done under the already-held advisory lock (design §9.2:
@@ -386,8 +399,7 @@ func ensureWorktree(ctx context.Context, in ProvisionInput) error {
 		return fmt.Errorf("ProvisionShared: AgentID is required for WorktreePerAgent mode")
 	}
 
-	// Worktree path: <workspace>/worktrees/<agentID>
-	worktreePath := filepath.Join(in.Resolved.HostPath, "worktrees", in.AgentID)
+	worktreePath := WorktreePath(in.Resolved.HostPath, in.AgentID)
 
 	// If the worktree already exists, skip.
 	if _, err := os.Stat(worktreePath); err == nil {
@@ -409,28 +421,103 @@ func ensureWorktree(ctx context.Context, in ProvisionInput) error {
 		branchName = sanitizeBranchName(in.AgentName)
 	}
 
+	// Ensure worktrees parent directory exists.
+	worktreesDir := filepath.Join(in.Resolved.HostPath, "worktrees")
+	if err := os.MkdirAll(worktreesDir, 0770); err != nil {
+		return fmt.Errorf("ProvisionShared: mkdir worktrees dir: %w", err)
+	}
+
 	slog.Info("ProvisionShared: creating worktree",
 		"agent_id", in.AgentID, "branch", branchName, "path", worktreePath)
 
-	// git worktree add <path> -b <branch>
-	cmd := exec.CommandContext(ctx, "git", "worktree", "add", "-b", branchName, worktreePath)
+	// git worktree add --relative-paths -b <branch> <path>
+	// --relative-paths is mandatory for container path-identity (design §6).
+	cmd := exec.CommandContext(ctx, "git", "worktree", "add", "--relative-paths", "-b", branchName, worktreePath)
 	cmd.Dir = in.Resolved.HostPath
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		outputStr := strings.TrimSpace(string(output))
-		// If branch already exists, try without -b.
+		// If the branch is already checked out in another worktree, surface a
+		// clear error instead of a confusing git message.
+		if strings.Contains(outputStr, "already checked out") || strings.Contains(outputStr, "already used by worktree") {
+			return fmt.Errorf("git worktree add: branch %q is already checked out in another worktree: %s",
+				branchName, outputStr)
+		}
+		// If branch already exists, try without -b (reuse existing branch).
 		if strings.Contains(outputStr, "already exists") {
-			cmd = exec.CommandContext(ctx, "git", "worktree", "add", worktreePath, branchName)
+			cmd = exec.CommandContext(ctx, "git", "worktree", "add", "--relative-paths", worktreePath, branchName)
 			cmd.Dir = in.Resolved.HostPath
 			output, err = cmd.CombinedOutput()
 			if err != nil {
-				return fmt.Errorf("git worktree add (reuse branch): %s", strings.TrimSpace(string(output)))
+				reuse := strings.TrimSpace(string(output))
+				if strings.Contains(reuse, "already checked out") || strings.Contains(reuse, "already used by worktree") {
+					return fmt.Errorf("git worktree add: branch %q is already checked out in another worktree: %s",
+						branchName, reuse)
+				}
+				return fmt.Errorf("git worktree add (reuse branch): %s", reuse)
 			}
 			return nil
 		}
 		return fmt.Errorf("git worktree add: %s", outputStr)
 	}
 	return nil
+}
+
+// prepareBaseForWorktrees configures a freshly cloned base checkout for
+// worktree-per-agent use: detaches HEAD (so no branch is "owned" by the base),
+// disables auto-gc, and excludes worktrees/ from untracked file lists.
+func prepareBaseForWorktrees(ctx context.Context, hostPath string) error {
+	if err := gitDetach(ctx, hostPath); err != nil {
+		return err
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "-C", hostPath, "config", "gc.auto", "0")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git config gc.auto 0: %s", strings.TrimSpace(string(output)))
+	}
+
+	return appendGitExclude(hostPath, "worktrees/")
+}
+
+// gitDetach detaches HEAD in the repo at hostPath so the base checkout owns
+// no branch. Tries 'git switch --detach' first, falls back to 'git checkout
+// --detach' for older git versions.
+func gitDetach(ctx context.Context, hostPath string) error {
+	cmd := exec.CommandContext(ctx, "git", "-C", hostPath, "switch", "--detach")
+	if _, err := cmd.CombinedOutput(); err == nil {
+		return nil
+	}
+	cmd = exec.CommandContext(ctx, "git", "-C", hostPath, "checkout", "--detach")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git detach: %s", strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// appendGitExclude appends a pattern to .git/info/exclude if not already present.
+func appendGitExclude(hostPath, pattern string) error {
+	excludePath := filepath.Join(hostPath, ".git", "info", "exclude")
+	if err := os.MkdirAll(filepath.Dir(excludePath), 0755); err != nil {
+		return fmt.Errorf("mkdir .git/info: %w", err)
+	}
+	data, _ := os.ReadFile(excludePath)
+	if strings.Contains(string(data), pattern) {
+		return nil
+	}
+	f, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		if _, err := f.WriteString("\n"); err != nil {
+			return err
+		}
+	}
+	_, err = f.WriteString(pattern + "\n")
+	return err
 }
 
 // sanitizeBranchName produces a git-safe branch name from an agent name.

--- a/pkg/provision/provision_test.go
+++ b/pkg/provision/provision_test.go
@@ -16,16 +16,113 @@ package provision
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// testLocker is a mock AdvisoryLocker for testing.
+type testLocker struct {
+	mu       sync.Mutex
+	held     map[lockKey]bool
+	acquires int64
+}
+
+type lockKey struct {
+	classID int64
+	objID   int32
+	single  bool
+}
+
+func newTestLocker() *testLocker {
+	return &testLocker{held: make(map[lockKey]bool)}
+}
+
+func (l *testLocker) TryAdvisoryLock(ctx context.Context, key store.AdvisoryLockKey) (bool, func() error, error) {
+	k := lockKey{classID: int64(key), single: true}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.held[k] {
+		return false, func() error { return nil }, nil
+	}
+	l.held[k] = true
+	atomic.AddInt64(&l.acquires, 1)
+	return true, func() error {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		delete(l.held, k)
+		return nil
+	}, nil
+}
+
+func (l *testLocker) TryAdvisoryLockObject(ctx context.Context, classID store.AdvisoryLockKey, objID int32) (bool, func() error, error) {
+	k := lockKey{classID: int64(classID), objID: objID}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.held[k] {
+		return false, func() error { return nil }, nil
+	}
+	l.held[k] = true
+	atomic.AddInt64(&l.acquires, 1)
+	return true, func() error {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		delete(l.held, k)
+		return nil
+	}, nil
+}
+
+// initBareGitRepo creates a bare git repo at a temporary path for cloning from.
+func initBareGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	bareDir := filepath.Join(dir, "bare.git")
+	run(t, "git", "init", "--bare", "--initial-branch=main", bareDir)
+
+	workDir := filepath.Join(dir, "work")
+	run(t, "git", "clone", bareDir, workDir)
+
+	f := filepath.Join(workDir, "README.md")
+	if err := os.WriteFile(f, []byte("# Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runIn(t, workDir, "git", "add", "README.md")
+	runIn(t, workDir, "git", "-c", "user.name=test", "-c", "user.email=test@test.com",
+		"commit", "-m", "initial")
+	runIn(t, workDir, "git", "push", "origin", "main")
+
+	return bareDir
+}
+
+func run(t *testing.T, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%s %v: %s\n%s", name, args, err, output)
+	}
+}
+
+func runIn(t *testing.T, dir, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%s %v (in %s): %s\n%s", name, args, dir, err, output)
+	}
+}
 
 // --- ClonePerAgent rejection ---
 
@@ -178,4 +275,326 @@ func TestAcquireProvisionLock_ContextCancellation(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "context cancelled")
 	assert.Less(t, elapsed, 2*time.Second, "should return promptly on context cancellation, not wait for all retries")
+}
+
+// --- WorktreePerAgent: creates worktree on shared checkout ---
+
+func TestProvision_WorktreePerAgent(t *testing.T) {
+	t.Setenv("SCION_HOST_UID", "")
+	locker := newTestLocker()
+	bareRepo := initBareGitRepo(t)
+
+	projectDir := t.TempDir()
+	hostPath := filepath.Join(projectDir, "workspace")
+
+	err := ProvisionShared(ProvisionInput{
+		Resolved:  ResolvedWorkspace{HostPath: hostPath, Backend: "local"},
+		ProjectID: "proj-wt-1",
+		AgentID:   "agent-wt-1",
+		AgentName: "test-agent",
+		Mode:      store.SharingModeWorktreePerAgent,
+		Locker:    locker,
+		GitClone: &api.GitCloneConfig{
+			URL:    bareRepo,
+			Branch: "main",
+			Depth:  0,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	// Verify base HEAD is detached.
+	cmd := exec.Command("git", "-C", hostPath, "symbolic-ref", "HEAD")
+	if err := cmd.Run(); err == nil {
+		t.Error("expected HEAD to be detached in base, but symbolic-ref succeeded")
+	}
+
+	// Verify gc.auto is disabled.
+	out, err := exec.Command("git", "-C", hostPath, "config", "gc.auto").Output()
+	if err != nil || strings.TrimSpace(string(out)) != "0" {
+		t.Errorf("expected gc.auto=0 in base repo, got %q (err=%v)", strings.TrimSpace(string(out)), err)
+	}
+
+	// Verify worktree was created.
+	worktreePath := WorktreePath(hostPath, "agent-wt-1")
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Fatalf("worktree not created at %s: %v", worktreePath, err)
+	}
+
+	// Verify .git is a file (pointer), not a directory.
+	gitFile := filepath.Join(worktreePath, ".git")
+	fi, err := os.Lstat(gitFile)
+	if err != nil {
+		t.Fatalf("worktree .git not found: %v", err)
+	}
+	if fi.IsDir() {
+		t.Error("worktree .git should be a file (pointer), not a directory")
+	}
+
+	// Verify .git pointer uses a relative path (--relative-paths).
+	data, err := os.ReadFile(gitFile)
+	if err != nil {
+		t.Fatalf("read worktree .git: %v", err)
+	}
+	gitdirLine := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(gitdirLine, "gitdir: ") {
+		t.Fatalf("unexpected .git content: %s", gitdirLine)
+	}
+	gitdirPath := strings.TrimPrefix(gitdirLine, "gitdir: ")
+	if filepath.IsAbs(gitdirPath) {
+		t.Errorf("worktree .git should use a relative path, got: %s", gitdirPath)
+	}
+}
+
+// --- WorktreePerAgent: second agent gets independent worktree ---
+
+func TestProvision_WorktreePerAgent_TwoAgents(t *testing.T) {
+	t.Setenv("SCION_HOST_UID", "")
+	locker := newTestLocker()
+	bareRepo := initBareGitRepo(t)
+
+	projectDir := t.TempDir()
+	hostPath := filepath.Join(projectDir, "workspace")
+
+	// First agent.
+	err := ProvisionShared(ProvisionInput{
+		Resolved:  ResolvedWorkspace{HostPath: hostPath, Backend: "local"},
+		ProjectID: "proj-wt-2",
+		AgentID:   "agent-1",
+		AgentName: "first-agent",
+		Mode:      store.SharingModeWorktreePerAgent,
+		Locker:    locker,
+		GitClone: &api.GitCloneConfig{
+			URL:    bareRepo,
+			Branch: "main",
+			Depth:  0,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Provision agent-1: %v", err)
+	}
+
+	// Second agent (sentinel exists, so clone is skipped — just adds worktree).
+	err = ProvisionShared(ProvisionInput{
+		Resolved:  ResolvedWorkspace{HostPath: hostPath, Backend: "local"},
+		ProjectID: "proj-wt-2",
+		AgentID:   "agent-2",
+		AgentName: "second-agent",
+		Mode:      store.SharingModeWorktreePerAgent,
+		Locker:    locker,
+		GitClone: &api.GitCloneConfig{
+			URL:    bareRepo,
+			Branch: "main",
+			Depth:  0,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Provision agent-2: %v", err)
+	}
+
+	// Both worktrees exist and are independent.
+	wt1 := WorktreePath(hostPath, "agent-1")
+	wt2 := WorktreePath(hostPath, "agent-2")
+	if _, err := os.Stat(wt1); err != nil {
+		t.Errorf("worktree agent-1 not found: %v", err)
+	}
+	if _, err := os.Stat(wt2); err != nil {
+		t.Errorf("worktree agent-2 not found: %v", err)
+	}
+
+	// Verify both worktrees have relative .git pointers.
+	for _, wt := range []string{wt1, wt2} {
+		data, err := os.ReadFile(filepath.Join(wt, ".git"))
+		if err != nil {
+			t.Errorf("read .git in %s: %v", wt, err)
+			continue
+		}
+		gitdirLine := strings.TrimSpace(string(data))
+		if !strings.HasPrefix(gitdirLine, "gitdir: ") {
+			t.Errorf("unexpected .git content in %s: %s", wt, gitdirLine)
+			continue
+		}
+		gitdirPath := strings.TrimPrefix(gitdirLine, "gitdir: ")
+		if filepath.IsAbs(gitdirPath) {
+			t.Errorf("worktree %s .git should use relative path, got: %s", wt, gitdirPath)
+		}
+	}
+}
+
+// --- Two projects sharing a parent dir: independent sentinels ---
+
+func TestProvision_WorktreePerAgent_TwoProjects(t *testing.T) {
+	t.Setenv("SCION_HOST_UID", "")
+	locker := newTestLocker()
+	bareRepoA := initBareGitRepo(t)
+	bareRepoB := initBareGitRepo(t)
+
+	parentDir := t.TempDir()
+	projectDirA := filepath.Join(parentDir, "project-alpha")
+	projectDirB := filepath.Join(parentDir, "project-beta")
+	if err := os.MkdirAll(projectDirA, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(projectDirB, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	hostPathA := filepath.Join(projectDirA, "workspace")
+	hostPathB := filepath.Join(projectDirB, "workspace")
+
+	// --- Project A ---
+	err := ProvisionShared(ProvisionInput{
+		Resolved:  ResolvedWorkspace{HostPath: hostPathA, Backend: "local"},
+		ProjectID: "proj-alpha",
+		AgentID:   "agent-a1",
+		AgentName: "alpha-agent",
+		Mode:      store.SharingModeWorktreePerAgent,
+		Locker:    locker,
+		GitClone:  &api.GitCloneConfig{URL: bareRepoA, Branch: "main", Depth: 0},
+	})
+	if err != nil {
+		t.Fatalf("Provision project A: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(hostPathA, ".git")); err != nil {
+		t.Fatalf("project A: .git not found: %v", err)
+	}
+	if _, err := os.Stat(WorktreePath(hostPathA, "agent-a1")); err != nil {
+		t.Fatalf("project A: worktree not created: %v", err)
+	}
+
+	// --- Project B ---
+	err = ProvisionShared(ProvisionInput{
+		Resolved:  ResolvedWorkspace{HostPath: hostPathB, Backend: "local"},
+		ProjectID: "proj-beta",
+		AgentID:   "agent-b1",
+		AgentName: "beta-agent",
+		Mode:      store.SharingModeWorktreePerAgent,
+		Locker:    locker,
+		GitClone:  &api.GitCloneConfig{URL: bareRepoB, Branch: "main", Depth: 0},
+	})
+	if err != nil {
+		t.Fatalf("Provision project B: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(hostPathB, ".git")); err != nil {
+		t.Fatalf("project B: .git not found — sentinel collision?")
+	}
+	if _, err := os.Stat(WorktreePath(hostPathB, "agent-b1")); err != nil {
+		t.Fatalf("project B: worktree not created: %v", err)
+	}
+
+	// Sentinels must be per-project.
+	sentinelA := filepath.Join(projectDirA, ProvisionSentinelFile)
+	sentinelB := filepath.Join(projectDirB, ProvisionSentinelFile)
+	if _, err := os.Stat(sentinelA); err != nil {
+		t.Errorf("project A sentinel missing at %s", sentinelA)
+	}
+	if _, err := os.Stat(sentinelB); err != nil {
+		t.Errorf("project B sentinel missing at %s", sentinelB)
+	}
+	parentSentinel := filepath.Join(parentDir, ProvisionSentinelFile)
+	if _, err := os.Stat(parentSentinel); err == nil {
+		t.Errorf("sentinel found in shared parent dir %s — sentinel collision", parentDir)
+	}
+}
+
+// --- Concurrent same-project provisioning ---
+
+func TestProvision_WorktreePerAgent_ConcurrentSameProject(t *testing.T) {
+	t.Setenv("SCION_HOST_UID", "")
+	locker := newTestLocker()
+	bareRepo := initBareGitRepo(t)
+
+	projectDir := t.TempDir()
+	hostPath := filepath.Join(projectDir, "workspace")
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			agentID := fmt.Sprintf("agent-concurrent-%d", idx)
+			errs[idx] = ProvisionShared(ProvisionInput{
+				Resolved:  ResolvedWorkspace{HostPath: hostPath, Backend: "local"},
+				ProjectID: "proj-concurrent-1",
+				AgentID:   agentID,
+				AgentName: fmt.Sprintf("concurrent-agent-%d", idx),
+				Mode:      store.SharingModeWorktreePerAgent,
+				Locker:    locker,
+				GitClone: &api.GitCloneConfig{
+					URL:    bareRepo,
+					Branch: "main",
+					Depth:  0,
+				},
+			})
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d failed: %v", i, err)
+		}
+	}
+
+	for i := 0; i < 2; i++ {
+		wt := WorktreePath(hostPath, fmt.Sprintf("agent-concurrent-%d", i))
+		if _, err := os.Stat(wt); err != nil {
+			t.Errorf("worktree agent-concurrent-%d not found at %s: %v", i, wt, err)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(hostPath, ".git")); err != nil {
+		t.Fatalf("shared base .git not found: %v", err)
+	}
+}
+
+// --- Full clone depth for worktree mode ---
+
+func TestProvision_WorktreePerAgent_FullCloneDepth(t *testing.T) {
+	t.Setenv("SCION_HOST_UID", "")
+	locker := newTestLocker()
+	bareRepo := initBareGitRepo(t)
+
+	projectDir := t.TempDir()
+	hostPath := filepath.Join(projectDir, "workspace")
+
+	// Depth -1 means full clone (no --depth flag).
+	err := ProvisionShared(ProvisionInput{
+		Resolved:  ResolvedWorkspace{HostPath: hostPath, Backend: "local"},
+		ProjectID: "proj-depth-1",
+		AgentID:   "agent-depth-1",
+		AgentName: "depth-agent",
+		Mode:      store.SharingModeWorktreePerAgent,
+		Locker:    locker,
+		GitClone: &api.GitCloneConfig{
+			URL:    bareRepo,
+			Branch: "main",
+			Depth:  -1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Provision with Depth=-1: %v", err)
+	}
+
+	// Verify the clone is NOT shallow (full history).
+	shallowFile := filepath.Join(hostPath, ".git", "shallow")
+	if _, err := os.Stat(shallowFile); err == nil {
+		t.Error("expected full clone (no .git/shallow), but shallow file exists")
+	}
+}
+
+// --- WorktreePath ---
+
+func TestWorktreePath(t *testing.T) {
+	got := WorktreePath("/srv/nfs/proj/workspace", "agent-42")
+	want := "/srv/nfs/proj/workspace/worktrees/agent-42"
+	if got != want {
+		t.Errorf("WorktreePath() = %q, want %q", got, want)
+	}
 }

--- a/pkg/runtime/workspace_backend_local.go
+++ b/pkg/runtime/workspace_backend_local.go
@@ -16,8 +16,10 @@ package runtime
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
 // localBackend wraps today's node-local workspace behavior. Resolve delegates
@@ -40,8 +42,17 @@ func (b *localBackend) Resolve(in ResolveInput) (ResolvedWorkspace, error) {
 		return ResolvedWorkspace{}, fmt.Errorf("localBackend.Resolve: ProjectDir is required")
 	}
 
+	hostPath := in.ProjectDir
+	// For worktree-per-agent mode, the shared base checkout lives under a
+	// "workspace" subdirectory within the project dir. This gives
+	// ProvisionShared a per-project sentinel dir (filepath.Dir(HostPath)
+	// == ProjectDir) so different projects don't collide.
+	if in.Mode == store.SharingModeWorktreePerAgent {
+		hostPath = filepath.Join(in.ProjectDir, "workspace")
+	}
+
 	res := ResolvedWorkspace{
-		HostPath:   in.ProjectDir,
+		HostPath:   hostPath,
 		Backend:    "local",
 		SharedDirs: make(map[string]ResolvedSharedDir, len(in.SharedDirNames)),
 	}

--- a/pkg/runtime/workspace_backend_test.go
+++ b/pkg/runtime/workspace_backend_test.go
@@ -491,6 +491,16 @@ func TestLocalBackendResolve(t *testing.T) {
 			wantBackend: "local",
 		},
 		{
+			name: "worktree-per-agent uses workspace subdir",
+			input: ResolveInput{
+				ProjectDir: "/home/user/.scion.projects/my-project",
+				ProjectID:  "proj1",
+				Mode:       store.SharingModeWorktreePerAgent,
+			},
+			wantPath:    "/home/user/.scion.projects/my-project/workspace",
+			wantBackend: "local",
+		},
+		{
 			name: "missing ProjectDir",
 			input: ResolveInput{
 				ProjectID: "proj1",

--- a/pkg/runtime/worktree_eligibility.go
+++ b/pkg/runtime/worktree_eligibility.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/util"
+)
+
+// WorktreeModeEligible reports whether the host environment supports
+// worktree-per-agent mode. It returns (true, "") when git >= 2.47 is
+// available (required for --relative-paths), or (false, reason) with a
+// human-readable explanation when the check fails.
+//
+// The caller is responsible for logging and for choosing the fallback
+// (typically clone-per-agent).
+func WorktreeModeEligible() (bool, string) {
+	version, _, err := util.GetGitVersion()
+	if err != nil {
+		return false, fmt.Sprintf("unable to determine git version: %v", err)
+	}
+	return worktreeEligibleForVersion(version)
+}
+
+// worktreeEligibleForVersion is the testable core: it checks whether the
+// given version string satisfies the git >= 2.47 requirement.
+func worktreeEligibleForVersion(version string) (bool, string) {
+	if err := util.CompareGitVersion(version, 2, 47); err != nil {
+		return false, fmt.Sprintf(
+			"git >= 2.47.0 required for worktree-per-agent mode (--relative-paths), found %s",
+			version,
+		)
+	}
+	return true, ""
+}

--- a/pkg/runtime/worktree_eligibility_test.go
+++ b/pkg/runtime/worktree_eligibility_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWorktreeEligibleForVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		wantOK  bool
+		wantSub string // substring expected in reason when !ok
+	}{
+		{
+			name:    "below minimum",
+			version: "2.46.0",
+			wantOK:  false,
+			wantSub: "2.46.0",
+		},
+		{
+			name:   "exact minimum",
+			version: "2.47.0",
+			wantOK:  true,
+		},
+		{
+			name:   "above minimum",
+			version: "2.54.1",
+			wantOK:  true,
+		},
+		{
+			name:    "malformed version",
+			version: "not-a-version",
+			wantOK:  false,
+			wantSub: "not-a-version",
+		},
+		{
+			name:   "major version ahead",
+			version: "3.0.0",
+			wantOK:  true,
+		},
+		{
+			name:    "empty string",
+			version: "",
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ok, reason := worktreeEligibleForVersion(tt.version)
+			if ok != tt.wantOK {
+				t.Errorf("worktreeEligibleForVersion(%q) ok = %v, want %v (reason: %s)", tt.version, ok, tt.wantOK, reason)
+			}
+			if !ok && tt.wantSub != "" && !strings.Contains(reason, tt.wantSub) {
+				t.Errorf("reason %q should contain %q", reason, tt.wantSub)
+			}
+			if ok && reason != "" {
+				t.Errorf("expected empty reason when eligible, got %q", reason)
+			}
+		})
+	}
+}

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -594,6 +594,7 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 		ResolvedEnv:     req.ResolvedEnv,
 		ResolvedSecrets: req.ResolvedSecrets,
 		Attach:          req.Attach,
+		WorkspaceMode:   req.WorkspaceMode,
 		HTTPRequest:     r,
 	})
 	if err != nil {

--- a/pkg/runtimebroker/server.go
+++ b/pkg/runtimebroker/server.go
@@ -225,6 +225,12 @@ type Server struct {
 	auxiliaryRuntimes   map[string]auxiliaryRuntime
 	auxiliaryRuntimesMu sync.RWMutex
 
+	// projectProvisionMu serializes worktree provisioning per project on this
+	// node. Without this, concurrent agent creations for the same project could
+	// race inside ProvisionShared (double-clone / corrupt .git state).
+	// Key: ProjectID (or ProjectPath if ID is empty).
+	projectProvisionMu sync.Map
+
 	// NFS mount reconciler (nil when backend != "nfs")
 	nfsMountReconciler *NFSMountReconciler
 

--- a/pkg/runtimebroker/start_context.go
+++ b/pkg/runtimebroker/start_context.go
@@ -16,15 +16,20 @@ package runtimebroker
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/provision"
+	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
 // startContext holds all the resolved state needed to start an agent.
@@ -71,6 +76,11 @@ type startContextInputs struct {
 
 	// Behavior
 	Attach bool
+
+	// WorkspaceMode is the resolved workspace sharing mode for the project
+	// (e.g. "worktree-per-agent"). Threaded from CreateAgentRequest so the
+	// broker can branch dispatch without re-deriving from labels.
+	WorkspaceMode string
 
 	// HTTP request (for hub connection resolution)
 	HTTPRequest *http.Request
@@ -433,8 +443,19 @@ func (s *Server) buildStartContext(ctx context.Context, in startContextInputs) (
 		}
 	}
 
+	// --- Worktree-per-agent mode ---
+	// When the hub sets WorkspaceMode to worktree-per-agent and the project
+	// is git-backed, provision a shared base clone + per-agent worktree on
+	// the host BEFORE the container starts, then dual-mount it. This avoids
+	// the full in-container clone. Falls through to clone-per-agent on error
+	// or if git is too old (< 2.47).
+	worktreeProvisioned := false
+	if in.Config != nil && in.Config.GitClone != nil && in.WorkspaceMode == store.WorkspaceModeWorktreePerAgent {
+		worktreeProvisioned = s.tryProvisionWorktree(ctx, in, &opts, env)
+	}
+
 	// --- Git clone mode ---
-	if in.Config != nil && in.Config.GitClone != nil {
+	if !worktreeProvisioned && in.Config != nil && in.Config.GitClone != nil {
 		gc := in.Config.GitClone
 		env["SCION_GIT_CLONE_URL"] = gc.URL
 		if gc.Branch != "" {
@@ -494,6 +515,180 @@ type startContextError struct {
 
 func (e *startContextError) Error() string {
 	return e.Message
+}
+
+// tryProvisionWorktree attempts to provision a per-agent worktree on the host
+// for worktree-per-agent mode. On success it sets opts.Workspace to the
+// worktree path and returns true (opts.GitClone is NOT set, suppressing the
+// in-container clone). On failure or if git is too old, it logs a warning and
+// returns false so the caller falls through to clone-per-agent.
+func (s *Server) tryProvisionWorktree(ctx context.Context, in startContextInputs, opts *api.StartOptions, env map[string]string) bool {
+	result := resolveWorktreeProvision(worktreeProvisionInput{
+		WorkspaceMode: in.WorkspaceMode,
+		GitClone:      in.Config.GitClone,
+		ProjectPath:   in.ProjectPath,
+		ProjectID:     in.ProjectID,
+		ProjectSlug:   in.ProjectSlug,
+		AgentID:       in.AgentID,
+		AgentName:     in.Name,
+		Branch:        in.Config.Branch,
+	})
+
+	if !result.ShouldProvision {
+		if result.Reason != "" {
+			slog.Warn("worktree-per-agent: falling back to clone-per-agent",
+				"agent_id", in.AgentID, "reason", result.Reason)
+		}
+		return false
+	}
+
+	// Set Ctx from the buildStartContext context.
+	result.ProvisionInput.Ctx = ctx
+
+	// Serialize same-project provisioning on this node to prevent concurrent
+	// ProvisionShared calls from racing on the shared base clone.
+	mu := s.projectProvisionMutex(in.ProjectID, in.ProjectPath)
+	mu.Lock()
+	defer mu.Unlock()
+
+	if err := provision.ProvisionShared(result.ProvisionInput); err != nil {
+		slog.Warn("worktree-per-agent: provisioning failed, falling back to clone-per-agent",
+			"agent_id", in.AgentID, "error", err)
+		// Clean up partially-provisioned base so a later attempt re-clones
+		// cleanly instead of reusing broken state.
+		if result.ProvisionInput.Resolved.HostPath != "" {
+			if cleanErr := os.RemoveAll(result.ProvisionInput.Resolved.HostPath); cleanErr != nil {
+				slog.Warn("worktree-per-agent: failed to clean up partial provision",
+					"agent_id", in.AgentID, "path", result.ProvisionInput.Resolved.HostPath, "error", cleanErr)
+			} else {
+				slog.Info("worktree-per-agent: cleaned up partial provision",
+					"agent_id", in.AgentID, "path", result.ProvisionInput.Resolved.HostPath)
+			}
+		}
+		return false
+	}
+
+	// Write .scion workspace marker so the in-container CLI discovers project context.
+	if in.ProjectID != "" && in.ProjectSlug != "" {
+		if err := config.WriteWorkspaceMarker(result.WorktreePath, in.ProjectID, in.ProjectSlug, in.ProjectSlug); err != nil {
+			slog.Warn("worktree-per-agent: failed to write workspace marker (non-fatal)",
+				"path", result.WorktreePath, "error", err)
+		}
+	}
+
+	opts.Workspace = result.WorktreePath
+	if s.config.Debug {
+		s.agentLifecycleLog.Debug("Worktree-per-agent mode enabled",
+			"agent_id", in.AgentID,
+			"workspace", result.WorktreePath,
+			"project_root", result.ProjectRoot)
+	}
+	return true
+}
+
+// projectProvisionMutex returns the per-project mutex for serializing worktree
+// provisioning. Uses ProjectID as key, falling back to ProjectPath if empty.
+func (s *Server) projectProvisionMutex(projectID, projectPath string) *sync.Mutex {
+	key := projectID
+	if key == "" {
+		key = projectPath
+	}
+	actual, _ := s.projectProvisionMu.LoadOrStore(key, &sync.Mutex{})
+	return actual.(*sync.Mutex)
+}
+
+// worktreeProvisionInput holds the fields needed to decide whether to
+// provision a worktree and to build the ProvisionInput. Factored out
+// for testability (no Server dependency).
+type worktreeProvisionInput struct {
+	WorkspaceMode string
+	GitClone      *api.GitCloneConfig
+	ProjectPath   string
+	ProjectID     string
+	ProjectSlug   string
+	AgentID       string
+	AgentName     string
+	Branch        string
+
+	// eligibilityOverride, when non-nil, replaces the runtime.WorktreeModeEligible
+	// check. Used in tests to simulate git-too-old without requiring a specific
+	// git binary.
+	eligibilityOverride func() (bool, string)
+}
+
+// worktreeProvisionResult holds the outcome of resolveWorktreeProvision.
+type worktreeProvisionResult struct {
+	ShouldProvision bool
+	Reason          string
+	ProvisionInput  provision.ProvisionInput
+	WorktreePath    string
+	ProjectRoot     string
+}
+
+// resolveWorktreeProvision is the pure decision function: given the dispatch
+// inputs, it determines whether worktree provisioning should proceed and
+// builds the ProvisionInput. It checks the git-version gate and resolves
+// the workspace backend. No side effects — all provisioning happens in the
+// caller.
+func resolveWorktreeProvision(in worktreeProvisionInput) worktreeProvisionResult {
+	if in.WorkspaceMode != store.WorkspaceModeWorktreePerAgent {
+		return worktreeProvisionResult{Reason: "workspace mode is not worktree-per-agent"}
+	}
+	if in.GitClone == nil {
+		return worktreeProvisionResult{Reason: "project is not git-backed"}
+	}
+
+	eligCheck := runtime.WorktreeModeEligible
+	if in.eligibilityOverride != nil {
+		eligCheck = in.eligibilityOverride
+	}
+	eligible, reason := eligCheck()
+	if !eligible {
+		return worktreeProvisionResult{Reason: reason}
+	}
+
+	mode := store.SharingModeWorktreePerAgent
+	backend := runtime.SelectWorkspaceBackend(nil, mode)
+	resolved, err := backend.Resolve(runtime.ResolveInput{
+		ProjectDir: in.ProjectPath,
+		ProjectID:  in.ProjectID,
+		AgentID:    in.AgentID,
+		Mode:       mode,
+	})
+	if err != nil {
+		return worktreeProvisionResult{Reason: "backend resolve failed: " + err.Error()}
+	}
+
+	agentName := in.AgentName
+	if in.Branch != "" {
+		agentName = in.Branch
+	}
+	if agentName == "" {
+		agentName = in.AgentID
+	}
+
+	worktreePath := provision.WorktreePath(resolved.HostPath, in.AgentID)
+
+	// Copy GitClone config so we don't mutate the shared pointer, and force a
+	// full clone (Depth -1 ≡ no --depth flag). The shared base needs full
+	// history for coordinator merges, git log, and git blame (design §4.2a).
+	gcCopy := *in.GitClone
+	gcCopy.Depth = -1
+
+	return worktreeProvisionResult{
+		ShouldProvision: true,
+		ProvisionInput: provision.ProvisionInput{
+			Resolved:  resolved,
+			Mode:      mode,
+			GitClone:  &gcCopy,
+			ProjectID: in.ProjectID,
+			AgentID:   in.AgentID,
+			AgentName: agentName,
+			Locker:    nil,
+		},
+		WorktreePath: worktreePath,
+		ProjectRoot:  resolved.HostPath,
+	}
 }
 
 // hasWorkspaceContent returns true if dir exists and contains meaningful

--- a/pkg/runtimebroker/start_context.go
+++ b/pkg/runtimebroker/start_context.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -554,17 +555,31 @@ func (s *Server) tryProvisionWorktree(ctx context.Context, in startContextInputs
 	if err := provision.ProvisionShared(result.ProvisionInput); err != nil {
 		slog.Warn("worktree-per-agent: provisioning failed, falling back to clone-per-agent",
 			"agent_id", in.AgentID, "error", err)
-		// Clean up ONLY this agent's partial worktree — never Resolved.HostPath,
-		// which is the shared base clone holding the common .git and every other
-		// agent's worktree under worktrees/<agentID>. Removing it would destroy
-		// the workspaces of all other running agents for this project. A partial
-		// base clone is self-healed by provision.gitCloneWorkspace on retry.
-		if result.WorktreePath != "" {
-			if cleanErr := os.RemoveAll(result.WorktreePath); cleanErr != nil {
-				slog.Warn("worktree-per-agent: failed to clean up partial worktree",
-					"agent_id", in.AgentID, "path", result.WorktreePath, "error", cleanErr)
+		// Clean up ONLY this agent's partial worktree — never result.ProjectRoot,
+		// the shared base clone holding the common .git and every other agent's
+		// worktree under worktrees/<agentID>. Removing the base would destroy the
+		// workspaces of all other running agents for this project. A partial base
+		// clone is self-healed by provision.gitCloneWorkspace on retry.
+		//
+		// Use `git worktree remove --force` so the worktree's admin metadata in
+		// the base's .git/worktrees/<id> is unregistered too — a bare os.RemoveAll
+		// would leave a stale registration that makes git refuse to recreate the
+		// worktree at that path on retry. Fall back to os.RemoveAll + prune.
+		if result.WorktreePath != "" && result.ProjectRoot != "" {
+			rm := exec.CommandContext(ctx, "git", "-C", result.ProjectRoot,
+				"worktree", "remove", "--force", result.WorktreePath)
+			if out, rmErr := rm.CombinedOutput(); rmErr != nil {
+				slog.Warn("worktree-per-agent: git worktree remove failed, falling back to os.RemoveAll+prune",
+					"agent_id", in.AgentID, "path", result.WorktreePath,
+					"error", rmErr, "output", strings.TrimSpace(string(out)))
+				if cleanErr := os.RemoveAll(result.WorktreePath); cleanErr != nil {
+					slog.Warn("worktree-per-agent: failed to clean up partial worktree",
+						"agent_id", in.AgentID, "path", result.WorktreePath, "error", cleanErr)
+				}
+				// Prune the now-stale .git/worktrees/<id> registration so retries succeed.
+				_ = exec.CommandContext(ctx, "git", "-C", result.ProjectRoot, "worktree", "prune").Run()
 			} else {
-				slog.Info("worktree-per-agent: cleaned up partial worktree",
+				slog.Info("worktree-per-agent: cleaned up partial worktree and unregistered from git",
 					"agent_id", in.AgentID, "path", result.WorktreePath)
 			}
 		}

--- a/pkg/runtimebroker/start_context.go
+++ b/pkg/runtimebroker/start_context.go
@@ -554,15 +554,18 @@ func (s *Server) tryProvisionWorktree(ctx context.Context, in startContextInputs
 	if err := provision.ProvisionShared(result.ProvisionInput); err != nil {
 		slog.Warn("worktree-per-agent: provisioning failed, falling back to clone-per-agent",
 			"agent_id", in.AgentID, "error", err)
-		// Clean up partially-provisioned base so a later attempt re-clones
-		// cleanly instead of reusing broken state.
-		if result.ProvisionInput.Resolved.HostPath != "" {
-			if cleanErr := os.RemoveAll(result.ProvisionInput.Resolved.HostPath); cleanErr != nil {
-				slog.Warn("worktree-per-agent: failed to clean up partial provision",
-					"agent_id", in.AgentID, "path", result.ProvisionInput.Resolved.HostPath, "error", cleanErr)
+		// Clean up ONLY this agent's partial worktree — never Resolved.HostPath,
+		// which is the shared base clone holding the common .git and every other
+		// agent's worktree under worktrees/<agentID>. Removing it would destroy
+		// the workspaces of all other running agents for this project. A partial
+		// base clone is self-healed by provision.gitCloneWorkspace on retry.
+		if result.WorktreePath != "" {
+			if cleanErr := os.RemoveAll(result.WorktreePath); cleanErr != nil {
+				slog.Warn("worktree-per-agent: failed to clean up partial worktree",
+					"agent_id", in.AgentID, "path", result.WorktreePath, "error", cleanErr)
 			} else {
-				slog.Info("worktree-per-agent: cleaned up partial provision",
-					"agent_id", in.AgentID, "path", result.ProvisionInput.Resolved.HostPath)
+				slog.Info("worktree-per-agent: cleaned up partial worktree",
+					"agent_id", in.AgentID, "path", result.WorktreePath)
 			}
 		}
 		return false

--- a/pkg/runtimebroker/start_context_test.go
+++ b/pkg/runtimebroker/start_context_test.go
@@ -19,11 +19,13 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
 func newTestServerForStartContext(t *testing.T, cfg ServerConfig) *Server {
@@ -672,5 +674,189 @@ func TestBuildStartContext_GCPMetadataPassthroughFromResolvedEnv(t *testing.T) {
 	}
 	if sc.Opts.Env["GCE_METADATA_HOST"] != "" {
 		t.Errorf("expected no GCE_METADATA_HOST for passthrough, got %q", sc.Opts.Env["GCE_METADATA_HOST"])
+	}
+}
+
+// --- resolveWorktreeProvision tests ---
+
+func TestResolveWorktreeProvision_Eligible(t *testing.T) {
+	projectDir := t.TempDir()
+
+	result := resolveWorktreeProvision(worktreeProvisionInput{
+		WorkspaceMode: store.WorkspaceModeWorktreePerAgent,
+		GitClone: &api.GitCloneConfig{
+			URL:    "https://github.com/org/repo.git",
+			Branch: "main",
+			Depth:  1,
+		},
+		ProjectPath: projectDir,
+		ProjectID:   "proj-1",
+		ProjectSlug: "my-project",
+		AgentID:     "agent-1",
+		AgentName:   "test-agent",
+	})
+
+	eligible, _ := runtime.WorktreeModeEligible()
+	if !eligible {
+		if result.ShouldProvision {
+			t.Fatal("expected ShouldProvision=false when git is too old")
+		}
+		t.Skip("git < 2.47, worktree mode not eligible on this host")
+	}
+
+	if !result.ShouldProvision {
+		t.Fatalf("expected ShouldProvision=true, got false (reason: %s)", result.Reason)
+	}
+
+	expectedPath := filepath.Join(projectDir, "workspace", "worktrees", "agent-1")
+	if result.WorktreePath != expectedPath {
+		t.Errorf("expected WorktreePath=%q, got %q", expectedPath, result.WorktreePath)
+	}
+
+	expectedRoot := filepath.Join(projectDir, "workspace")
+	if result.ProjectRoot != expectedRoot {
+		t.Errorf("expected ProjectRoot=%q, got %q", expectedRoot, result.ProjectRoot)
+	}
+
+	pi := result.ProvisionInput
+	if pi.Mode != store.SharingModeWorktreePerAgent {
+		t.Errorf("expected Mode=worktree-per-agent, got %v", pi.Mode)
+	}
+	if pi.ProjectID != "proj-1" {
+		t.Errorf("expected ProjectID='proj-1', got %q", pi.ProjectID)
+	}
+	if pi.AgentID != "agent-1" {
+		t.Errorf("expected AgentID='agent-1', got %q", pi.AgentID)
+	}
+	if pi.GitClone == nil || pi.GitClone.URL != "https://github.com/org/repo.git" {
+		t.Errorf("expected GitClone.URL set, got %v", pi.GitClone)
+	}
+	if pi.Locker != nil {
+		t.Error("expected Locker=nil for node-local single-broker")
+	}
+}
+
+func TestResolveWorktreeProvision_BranchOverridesAgentName(t *testing.T) {
+	projectDir := t.TempDir()
+	eligible, _ := runtime.WorktreeModeEligible()
+	if !eligible {
+		t.Skip("git < 2.47, worktree mode not eligible on this host")
+	}
+
+	result := resolveWorktreeProvision(worktreeProvisionInput{
+		WorkspaceMode: store.WorkspaceModeWorktreePerAgent,
+		GitClone:      &api.GitCloneConfig{URL: "https://example.com/repo.git"},
+		ProjectPath:   projectDir,
+		ProjectID:     "proj-1",
+		AgentID:       "agent-1",
+		AgentName:     "test-agent",
+		Branch:        "feature-branch",
+	})
+
+	if !result.ShouldProvision {
+		t.Fatalf("expected ShouldProvision=true, reason: %s", result.Reason)
+	}
+	if result.ProvisionInput.AgentName != "feature-branch" {
+		t.Errorf("expected AgentName='feature-branch' (from Branch), got %q", result.ProvisionInput.AgentName)
+	}
+}
+
+func TestResolveWorktreeProvision_WrongMode(t *testing.T) {
+	result := resolveWorktreeProvision(worktreeProvisionInput{
+		WorkspaceMode: store.WorkspaceModePerAgent,
+		GitClone:      &api.GitCloneConfig{URL: "https://example.com/repo.git"},
+		ProjectPath:   "/some/path",
+		ProjectID:     "proj-1",
+		AgentID:       "agent-1",
+	})
+
+	if result.ShouldProvision {
+		t.Fatal("expected ShouldProvision=false for non-worktree mode")
+	}
+	if !strings.Contains(result.Reason, "not worktree-per-agent") {
+		t.Errorf("expected reason to mention mode mismatch, got %q", result.Reason)
+	}
+}
+
+func TestResolveWorktreeProvision_NoGitClone(t *testing.T) {
+	result := resolveWorktreeProvision(worktreeProvisionInput{
+		WorkspaceMode: store.WorkspaceModeWorktreePerAgent,
+		GitClone:      nil,
+		ProjectPath:   "/some/path",
+		ProjectID:     "proj-1",
+		AgentID:       "agent-1",
+	})
+
+	if result.ShouldProvision {
+		t.Fatal("expected ShouldProvision=false when GitClone is nil")
+	}
+	if !strings.Contains(result.Reason, "not git-backed") {
+		t.Errorf("expected reason to mention non-git, got %q", result.Reason)
+	}
+}
+
+func TestResolveWorktreeProvision_GitTooOld_Fallback(t *testing.T) {
+	projectDir := t.TempDir()
+
+	result := resolveWorktreeProvision(worktreeProvisionInput{
+		WorkspaceMode: store.WorkspaceModeWorktreePerAgent,
+		GitClone: &api.GitCloneConfig{
+			URL:    "https://github.com/org/repo.git",
+			Branch: "main",
+			Depth:  1,
+		},
+		ProjectPath: projectDir,
+		ProjectID:   "proj-1",
+		ProjectSlug: "my-project",
+		AgentID:     "agent-1",
+		AgentName:   "test-agent",
+		eligibilityOverride: func() (bool, string) {
+			return false, "git >= 2.47.0 required for worktree-per-agent mode (--relative-paths), found 2.39.0"
+		},
+	})
+
+	if result.ShouldProvision {
+		t.Fatal("expected ShouldProvision=false when git is too old")
+	}
+	if !strings.Contains(result.Reason, "2.47") {
+		t.Errorf("expected reason to mention git 2.47 requirement, got %q", result.Reason)
+	}
+	if result.ProvisionInput.ProjectID != "" {
+		t.Error("expected empty ProvisionInput when ineligible")
+	}
+}
+
+func TestResolveWorktreeProvision_FullCloneDepth(t *testing.T) {
+	eligible, _ := runtime.WorktreeModeEligible()
+	if !eligible {
+		t.Skip("git < 2.47, worktree mode not eligible on this host")
+	}
+
+	projectDir := t.TempDir()
+	originalGC := &api.GitCloneConfig{
+		URL:    "https://github.com/org/repo.git",
+		Branch: "main",
+		Depth:  1,
+	}
+
+	result := resolveWorktreeProvision(worktreeProvisionInput{
+		WorkspaceMode: store.WorkspaceModeWorktreePerAgent,
+		GitClone:      originalGC,
+		ProjectPath:   projectDir,
+		ProjectID:     "proj-1",
+		ProjectSlug:   "my-project",
+		AgentID:       "agent-1",
+	})
+
+	if !result.ShouldProvision {
+		t.Fatalf("expected ShouldProvision=true, reason: %s", result.Reason)
+	}
+
+	if result.ProvisionInput.GitClone.Depth != -1 {
+		t.Errorf("expected GitClone.Depth=-1 (full clone), got %d", result.ProvisionInput.GitClone.Depth)
+	}
+
+	if originalGC.Depth != 1 {
+		t.Errorf("original GitClone.Depth was mutated: got %d, want 1", originalGC.Depth)
 	}
 }

--- a/pkg/runtimebroker/start_context_test.go
+++ b/pkg/runtimebroker/start_context_test.go
@@ -18,12 +18,14 @@ import (
 	"context"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/provision"
 	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
@@ -858,5 +860,102 @@ func TestResolveWorktreeProvision_FullCloneDepth(t *testing.T) {
 
 	if originalGC.Depth != 1 {
 		t.Errorf("original GitClone.Depth was mutated: got %d, want 1", originalGC.Depth)
+	}
+}
+
+// initBareRepoWithCommit creates a bare git repo (default branch main) seeded
+// with one commit, and returns its path for use as a GitClone URL.
+func initBareRepoWithCommit(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	bare := filepath.Join(dir, "remote.git")
+	wc := filepath.Join(dir, "wc")
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s", args, strings.TrimSpace(string(out)))
+		}
+	}
+	run("init", "--bare", "-b", "main", bare)
+	run("clone", bare, wc)
+	if err := os.WriteFile(filepath.Join(wc, "README.md"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("-C", wc, "add", "-A")
+	run("-C", wc, "commit", "-m", "init")
+	run("-C", wc, "push", "origin", "main")
+	return bare
+}
+
+// TestTryProvisionWorktree_FailureDoesNotDeleteSharedBase is the regression for
+// the critical review finding on upstream PR #350: when provisioning fails for
+// one agent, only that agent's worktree may be removed — never the shared base
+// clone (Resolved.HostPath), which holds the common .git and every sibling
+// agent's worktree. Deleting it would destroy all other agents' workspaces.
+func TestTryProvisionWorktree_FailureDoesNotDeleteSharedBase(t *testing.T) {
+	t.Setenv("SCION_HOST_UID", "")
+
+	cfg := DefaultServerConfig()
+	cfg.StateDir = t.TempDir()
+	srv := newTestServerForStartContext(t, cfg)
+
+	bare := initBareRepoWithCommit(t)
+	gc := &api.GitCloneConfig{URL: bare, Branch: "main", Depth: 0}
+
+	projectPath := filepath.Join(t.TempDir(), "proj")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up the shared base + a sibling worktree owning branch "agent-a".
+	resolved, err := runtime.NewLocalBackend().Resolve(runtime.ResolveInput{
+		ProjectDir: projectPath, ProjectID: "p1", AgentID: "agent-a",
+		Mode: store.SharingModeWorktreePerAgent,
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := provision.ProvisionShared(provision.ProvisionInput{
+		Resolved: resolved, Mode: store.SharingModeWorktreePerAgent,
+		ProjectID: "p1", AgentID: "agent-a", AgentName: "agent-a", GitClone: gc,
+	}); err != nil {
+		t.Fatalf("setup agent-a: %v", err)
+	}
+	base := resolved.HostPath
+	siblingWt := provision.WorktreePath(base, "agent-a")
+	if _, err := os.Stat(filepath.Join(base, ".git")); err != nil {
+		t.Fatalf("base .git missing after setup: %v", err)
+	}
+	if _, err := os.Stat(siblingWt); err != nil {
+		t.Fatalf("sibling worktree missing after setup: %v", err)
+	}
+
+	// Provision agent-b with a branch colliding with agent-a's → ensureWorktree
+	// fails ("already checked out"), exercising the cleanup-on-failure path.
+	opts := &api.StartOptions{}
+	ok := srv.tryProvisionWorktree(context.Background(), startContextInputs{
+		Name: "agent-b", AgentID: "agent-b",
+		ProjectID: "p1", ProjectSlug: "proj", ProjectPath: projectPath,
+		WorkspaceMode: store.WorkspaceModeWorktreePerAgent,
+		Config:        &CreateAgentConfig{GitClone: gc, Branch: "agent-a"},
+	}, opts, map[string]string{})
+
+	if ok {
+		t.Fatal("expected provisioning to fail (branch collision) and fall back, got ok=true")
+	}
+
+	// CRITICAL: the shared base and the sibling worktree must survive.
+	if _, err := os.Stat(filepath.Join(base, ".git")); err != nil {
+		t.Errorf("shared base .git was destroyed by a failed sibling provision: %v", err)
+	}
+	if _, err := os.Stat(siblingWt); err != nil {
+		t.Errorf("sibling agent-a worktree was destroyed by a failed sibling provision: %v", err)
+	}
+	// Only the failing agent's partial worktree should be cleaned up.
+	if _, err := os.Stat(provision.WorktreePath(base, "agent-b")); !os.IsNotExist(err) {
+		t.Errorf("agent-b partial worktree should have been cleaned up, stat err=%v", err)
 	}
 }

--- a/pkg/runtimebroker/start_context_test.go
+++ b/pkg/runtimebroker/start_context_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/provision"
 	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/GoogleCloudPlatform/scion/pkg/util"
 )
 
 func newTestServerForStartContext(t *testing.T, cfg ServerConfig) *Server {
@@ -957,5 +958,70 @@ func TestTryProvisionWorktree_FailureDoesNotDeleteSharedBase(t *testing.T) {
 	// Only the failing agent's partial worktree should be cleaned up.
 	if _, err := os.Stat(provision.WorktreePath(base, "agent-b")); !os.IsNotExist(err) {
 		t.Errorf("agent-b partial worktree should have been cleaned up, stat err=%v", err)
+	}
+}
+
+// TestWorktreeWorkspace_RepoRootDerivesToBase validates that the container
+// dual-mount inputs resolve correctly for the worktree layout WITHOUT any
+// explicit opts.RepoRoot (api.StartOptions has no such field). pkg/agent/run.go
+// derives repoRoot from the workspace itself: IsGitRepoDir(worktree) is true
+// (git rev-parse --is-inside-work-tree works through the worktree .git pointer
+// file), and GetCommonGitDir(worktree) returns the SHARED base .git, so
+// repoRoot = filepath.Dir(commonDir) == the base checkout. The worktree then
+// sits at <base>/worktrees/<id>, giving a non-".." relative path that triggers
+// common.go's .git + worktree dual-mount. (Regression guard for the #350 review
+// claim that opts.RepoRoot must be set explicitly.)
+func TestWorktreeWorkspace_RepoRootDerivesToBase(t *testing.T) {
+	t.Setenv("SCION_HOST_UID", "")
+
+	bare := initBareRepoWithCommit(t)
+	gc := &api.GitCloneConfig{URL: bare, Branch: "main", Depth: 0}
+
+	projectPath := filepath.Join(t.TempDir(), "proj")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := runtime.NewLocalBackend().Resolve(runtime.ResolveInput{
+		ProjectDir: projectPath, ProjectID: "p1", AgentID: "agent-a",
+		Mode: store.SharingModeWorktreePerAgent,
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := provision.ProvisionShared(provision.ProvisionInput{
+		Resolved: resolved, Mode: store.SharingModeWorktreePerAgent,
+		ProjectID: "p1", AgentID: "agent-a", AgentName: "agent-a", GitClone: gc,
+	}); err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+
+	base := resolved.HostPath // <projectPath>/workspace — the shared base checkout
+	worktree := provision.WorktreePath(base, "agent-a")
+
+	// Replicate pkg/agent/run.go's repoRoot derivation from the workspace.
+	if !util.IsGitRepoDir(worktree) {
+		t.Fatal("IsGitRepoDir(worktree) = false; run.go would not derive repoRoot from the worktree")
+	}
+	commonDir, err := util.GetCommonGitDir(worktree)
+	if err != nil {
+		t.Fatalf("GetCommonGitDir(worktree): %v", err)
+	}
+	repoRoot := filepath.Dir(commonDir)
+	if repoRoot != base {
+		t.Errorf("derived repoRoot = %q, want base %q", repoRoot, base)
+	}
+
+	// The dual-mount in common.go only fires when rel(repoRoot, workspace) is a
+	// non-".." subpath — confirm the worktree is nested inside the base.
+	rel, err := filepath.Rel(repoRoot, worktree)
+	if err != nil {
+		t.Fatalf("Rel: %v", err)
+	}
+	if rel != filepath.Join("worktrees", "agent-a") {
+		t.Errorf("rel(repoRoot, worktree) = %q, want %q", rel, filepath.Join("worktrees", "agent-a"))
+	}
+	if strings.HasPrefix(rel, "..") {
+		t.Errorf("rel %q starts with .. — common.go dual-mount would NOT fire", rel)
 	}
 }

--- a/pkg/runtimebroker/types.go
+++ b/pkg/runtimebroker/types.go
@@ -321,6 +321,11 @@ type CreateAgentRequest struct {
 	// Resolved by the Hub from the project record and passed to the broker
 	// so it can provision host-side directories and inject volume mounts.
 	SharedDirs []api.SharedDir `json:"sharedDirs,omitempty"`
+
+	// WorkspaceMode is the resolved workspace sharing mode for the project
+	// (e.g. "shared", "per-agent", "worktree-per-agent"). Threaded from the
+	// Hub so the broker can branch dispatch without re-deriving from labels.
+	WorkspaceMode string `json:"workspaceMode,omitempty"`
 }
 
 // UnmarshalJSON implements custom unmarshaling to support legacy grove fields.

--- a/pkg/runtimebroker/types_test.go
+++ b/pkg/runtimebroker/types_test.go
@@ -420,3 +420,34 @@ func TestAgentInfoToResponseProfile(t *testing.T) {
 		t.Errorf("Profile = %q, want %q", resp.Profile, "docker-dev")
 	}
 }
+
+func TestCreateAgentRequest_WorkspaceMode_JSON(t *testing.T) {
+	req := CreateAgentRequest{
+		Name:          "test-agent",
+		ProjectID:     "project-1",
+		WorkspaceMode: "worktree-per-agent",
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var decoded CreateAgentRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if decoded.WorkspaceMode != "worktree-per-agent" {
+		t.Errorf("WorkspaceMode = %q, want %q", decoded.WorkspaceMode, "worktree-per-agent")
+	}
+
+	// Verify omitempty: field should be absent when empty
+	req2 := CreateAgentRequest{Name: "agent-no-mode"}
+	data2, _ := json.Marshal(req2)
+	var m map[string]interface{}
+	if err := json.Unmarshal(data2, &m); err != nil {
+		t.Fatalf("Unmarshal map failed: %v", err)
+	}
+	if _, exists := m["workspaceMode"]; exists {
+		t.Error("workspaceMode should be omitted when empty")
+	}
+}

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -184,9 +184,10 @@ const (
 // When a git project has the workspace mode label set to "shared", it uses a
 // single shared clone mounted by all agents instead of per-agent clones.
 const (
-	LabelWorkspaceMode    = "scion.dev/workspace-mode"
-	WorkspaceModeShared   = "shared"
-	WorkspaceModePerAgent = "per-agent"
+	LabelWorkspaceMode             = "scion.dev/workspace-mode"
+	WorkspaceModeShared            = "shared"
+	WorkspaceModePerAgent          = "per-agent"
+	WorkspaceModeWorktreePerAgent  = "worktree-per-agent"
 )
 
 // WorkspaceSharingMode is the canonical set of workspace sharing modes from the
@@ -222,7 +223,7 @@ func ResolveWorkspaceSharingMode(label string) WorkspaceSharingMode {
 		return SharingModeSharedPlain
 	case WorkspaceModePerAgent, "clone-per-agent":
 		return SharingModeClonePerAgent
-	case "worktree-per-agent":
+	case WorkspaceModeWorktreePerAgent:
 		return SharingModeWorktreePerAgent
 	default:
 		// Empty or unrecognized: default to shared-plain.
@@ -322,6 +323,12 @@ func (p *Project) UnmarshalJSON(data []byte) error {
 // single shared workspace clone instead of per-agent clones.
 func (p *Project) IsSharedWorkspace() bool {
 	return p.GitRemote != "" && p.Labels[LabelWorkspaceMode] == WorkspaceModeShared
+}
+
+// IsWorktreePerAgent returns true if this is a git project configured to use
+// per-agent git worktrees over a shared base clone.
+func (p *Project) IsWorktreePerAgent() bool {
+	return p.GitRemote != "" && p.Labels[LabelWorkspaceMode] == WorkspaceModeWorktreePerAgent
 }
 
 // RuntimeBroker represents a compute node in the Hub database.

--- a/pkg/store/models_test.go
+++ b/pkg/store/models_test.go
@@ -70,4 +70,61 @@ func TestWorkspaceSharingMode_Constants(t *testing.T) {
 	if SharingModeWorktreePerAgent != "worktree-per-agent" {
 		t.Errorf("SharingModeWorktreePerAgent = %q, want %q", SharingModeWorktreePerAgent, "worktree-per-agent")
 	}
+	if WorkspaceModeWorktreePerAgent != "worktree-per-agent" {
+		t.Errorf("WorkspaceModeWorktreePerAgent = %q, want %q", WorkspaceModeWorktreePerAgent, "worktree-per-agent")
+	}
+}
+
+func TestProject_IsWorktreePerAgent(t *testing.T) {
+	tests := []struct {
+		name    string
+		project Project
+		want    bool
+	}{
+		{
+			name: "worktree-per-agent git project",
+			project: Project{
+				GitRemote: "github.com/test/repo",
+				Labels:    map[string]string{LabelWorkspaceMode: WorkspaceModeWorktreePerAgent},
+			},
+			want: true,
+		},
+		{
+			name: "shared git project",
+			project: Project{
+				GitRemote: "github.com/test/repo",
+				Labels:    map[string]string{LabelWorkspaceMode: WorkspaceModeShared},
+			},
+			want: false,
+		},
+		{
+			name: "per-agent git project",
+			project: Project{
+				GitRemote: "github.com/test/repo",
+				Labels:    map[string]string{LabelWorkspaceMode: WorkspaceModePerAgent},
+			},
+			want: false,
+		},
+		{
+			name: "worktree label but no git remote",
+			project: Project{
+				Labels: map[string]string{LabelWorkspaceMode: WorkspaceModeWorktreePerAgent},
+			},
+			want: false,
+		},
+		{
+			name:    "no labels",
+			project: Project{GitRemote: "github.com/test/repo"},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.project.IsWorktreePerAgent()
+			if got != tt.want {
+				t.Errorf("IsWorktreePerAgent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Port worktree-per-agent Phase 1 from the pre-#169 branch onto the refactored codebase where provisioning lives in the config-free pkg/provision leaf package.

What moved where:
- pkg/provision/provision.go: prepareBaseForWorktrees, gitDetach, appendGitExclude (stdlib/exec only — no util/config imports), WorktreePath export, ensureWorktree enhanced with --relative-paths and clear branch-collision errors
- pkg/runtime/worktree_eligibility.go: git >= 2.47 gate (uses util)
- pkg/runtime/workspace_backend_local.go: Resolve returns <projectDir>/workspace for WorktreePerAgent mode
- pkg/runtimebroker/start_context.go: tryProvisionWorktree, resolveWorktreeProvision, projectProvisionMutex, worktree dispatch before git-clone fallback; broker writes .scion marker via config.WriteWorkspaceMarker (broker already imports config)
- pkg/store/models.go: WorkspaceModeWorktreePerAgent const, IsWorktreePerAgent helper, ResolveWorkspaceSharingMode updated
- pkg/hub: createProject stamps worktree-per-agent label, httpdispatcher threads workspaceMode, RemoteCreateAgentRequest carries WorkspaceMode field
- .design/: worktree-per-agent design doc and Phase 1 plan

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
