### PR TITLE
fix(worktree): accept .git file (not just dir) when detecting shared …

### DIFF
--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -52,7 +52,10 @@ func DeleteAgentFiles(agentName string, projectPath string, removeBranch bool) (
 			projectRoot = filepath.Dir(projectDir)
 		}
 		sharedBase := filepath.Join(projectRoot, "workspace")
-		if info, statErr := os.Stat(filepath.Join(sharedBase, ".git")); statErr == nil && info.IsDir() {
+		// Accept .git as either a directory (normal clone) or a file (gitdir
+		// pointer, e.g. if the base is itself a linked worktree/submodule) —
+		// existence is enough to identify a valid repo root. (upstream #351 review)
+		if _, statErr := os.Stat(filepath.Join(sharedBase, ".git")); statErr == nil {
 			repoRoot = sharedBase
 			wtPath := filepath.Join(sharedBase, "worktrees", agentName)
 			if _, statErr := os.Stat(wtPath); statErr == nil {


### PR DESCRIPTION
…base

Delete-path teardown identified the worktree-per-agent shared base by os.Stat of <base>/.git AND info.IsDir(). A base whose own .git is a file (gitdir pointer — base is itself a linked worktree or submodule) is still a valid repo root, so check existence only. Addresses upstream #351 review (discussion r3370136446).

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
