### PR TITLE
Shared-worktree refcount / last-sharer teardown (#168)

### DIFF
--- a/.design/shared-worktree-refcount.md
+++ b/.design/shared-worktree-refcount.md
@@ -19,7 +19,12 @@ Shared worktrees (N agents on one branch) use an **implicit owner model with no 
 A real **last-sharer teardown**: a shared worktree (and its branch) is removed only when the
 final mounting agent exits. Apply uniformly to **local + hub-managed**.
 
-## Decisions needed (recommendations in **bold**)
+## Decisions — RESOLVED 2026-06-08 (ptone)
+- **D1 = marker file** in the shared base (no schema migration; unified local + hub).
+- **D2 = project owns the worktree** (ownerless; last sharer tears down).
+- **D3 = include hub-join** (a 2nd `--branch` agent attaches to the existing worktree).
+
+## Decisions (original options, for reference; recommendations in **bold**)
 
 ### D1 — How to track the agent→worktree association
 - **(A) Refs marker file in the shared base** — a small file per worktree (e.g.

--- a/.design/shared-worktree-refcount.md
+++ b/.design/shared-worktree-refcount.md
@@ -1,0 +1,73 @@
+# Design: Shared-Worktree Refcount / Last-Sharer Teardown (#168, Q7)
+
+**Branch:** `scion/shared-worktree-refcount` (off upstream `main`)
+**Tracking:** #168 (child of #158). Q7 in `worktree-per-agent.md`.
+**Status:** proposal — decisions teed up for @ptone.
+
+## Problem (from #168)
+Shared worktrees (N agents on one branch) use an **implicit owner model with no refcount**:
+- **Local mode** already supports sharing: a *joiner* created with `--branch <b>` (when `<b>`
+  already has a worktree) gets the owner's worktree bind-mounted (`provision.go:422-428`,
+  `run.go:758-763`); the joiner's own dir holds no `.git`.
+- **Bug:** deleting the **owner** runs `RemoveWorktree` (+ branch) **out from under live
+  joiners**. Deleting a joiner is already safe (no `.git` at its path).
+- **Hub-managed mode (Phase 1):** a 2nd agent with `--branch <existing>` does **not** join —
+  `ensureWorktree` hits "already checked out" and the broker falls back to clone-per-agent
+  (`provision.go:442`, `start_context.go`). So hub has no sharing yet.
+
+## Goal
+A real **last-sharer teardown**: a shared worktree (and its branch) is removed only when the
+final mounting agent exits. Apply uniformly to **local + hub-managed**.
+
+## Decisions needed (recommendations in **bold**)
+
+### D1 — How to track the agent→worktree association
+- **(A) Refs marker file in the shared base** — a small file per worktree (e.g.
+  `<base>/.git/worktrees/<id>/scion-sharers` or `<base>/worktrees/.sharers/<branch>`) listing
+  sharer agent IDs; append on attach, remove on delete, teardown when empty. **Unified for
+  local + hub** (both have the base on disk), no schema migration, naturally co-located with
+  the worktree. Concurrency via the existing per-project advisory lock / provision mutex.
+- (B) store/ent schema (a sharers table) — durable + queryable, but DB-only (doesn't cover
+  local non-hub use) and adds a migration; would still need a filesystem path for local.
+- (C) Enumerate agents at delete time — scan all project agents, check who references the
+  branch/worktree; no new state but O(n) and fragile.
+
+**Recommend (A)** — simplest mechanism that satisfies "local + hub uniformly" without a
+schema change. (#168 mentions ent; flagging that (A) avoids it. Your call.)
+
+### D2 — Ownership model
+- **Ownerless worktree** — drop the owner/joiner asymmetry: the worktree belongs to the
+  *project*, every mounting agent is just a sharer in the refcount; last sharer out tears it
+  down. Eliminates the "delete owner = nuke joiners" footgun entirely.
+- (alt) Deferred ownership / hand-off on owner delete — more moving parts, keeps asymmetry.
+
+**Recommend ownerless** (matches #168's "make the worktree ownerless").
+
+### D3 — Hub-managed join enablement (scope check)
+Refcount is meaningless in hub mode until a 2nd `--branch <existing>` agent can actually
+**join** (bind-mount the existing worktree) instead of falling back to clone-per-agent. So
+#168 for hub implies enabling the join:
+- detect an existing worktree for the requested branch → set the new agent's
+  `opts.Workspace` to that existing worktree path (bind-mount), skip `git worktree add`;
+- register the agent as a sharer (D1).
+
+**Recommend including hub-join enablement in this work** (it's the precondition for hub
+refcount). If you'd rather scope #168 to teardown-only and keep hub sharing for a follow-up,
+say so and I'll split it.
+
+## Proposed implementation (pending D1–D3)
+1. **Sharer registry** (D1): helper to add/remove/list sharers for a worktree, guarded by the
+   per-project lock. Local + hub call the same helper.
+2. **Attach path:** local already attaches (`provision.go:422-428`) — add sharer registration.
+   Hub (`start_context.go` `resolveWorktreeProvision`): when the branch's worktree already
+   exists, attach (bind-mount existing) + register, instead of failing/falling back.
+3. **Teardown** (`DeleteAgentFiles`): deregister the agent; only `RemoveWorktree` (+ branch
+   when `removeBranch`) if it was the **last** sharer; otherwise just detach (remove the
+   agent's own dirs, leave the shared worktree). Honor refcount rather than keying on
+   `agents/<name>/workspace/.git` presence.
+4. **Tests:** create owner + joiner (local and hub); both see the same tree; delete owner →
+   worktree persists; delete last → worktree + branch removed; concurrent attach/delete under
+   the lock.
+
+## Out of scope
+GC/base teardown (Q2/Q3 — keep base); K8s node-local (Phase 3, Q4); migration (Q5).

--- a/pkg/agent/delete_test.go
+++ b/pkg/agent/delete_test.go
@@ -395,3 +395,265 @@ func TestDeleteAgentFiles_WorktreePerAgent_DeletesOnlyTargetWorktree(t *testing.
 		t.Errorf("agent-a config dir should survive: %v", err)
 	}
 }
+
+// TestDeleteAgentFiles_SharedWorktree_DeleteCreatorWhileJoinerRemains verifies
+// that deleting the creator agent of a shared worktree does NOT remove the
+// shared worktree or branch when another sharer (joiner) remains.
+func TestDeleteAgentFiles_SharedWorktree_DeleteCreatorWhileJoinerRemains(t *testing.T) {
+	t.Setenv("SCION_HOST_UID", "")
+
+	tmpDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(tmpDir)
+	t.Setenv("HOME", tmpDir)
+
+	bare := initBareRepo(t)
+	gc := &api.GitCloneConfig{URL: bare, Branch: "main", Depth: 0}
+
+	projectPath := filepath.Join(tmpDir, "proj")
+	scionDir := filepath.Join(projectPath, config.DotScion)
+	if err := os.MkdirAll(filepath.Join(scionDir, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	base := filepath.Join(projectPath, "workspace")
+	resolved := provision.ResolvedWorkspace{HostPath: base, Backend: "local"}
+
+	// Agent A creates worktree on branch "shared-branch".
+	if err := provision.ProvisionShared(provision.ProvisionInput{
+		Resolved: resolved, Mode: store.SharingModeWorktreePerAgent,
+		ProjectID: "p1", AgentID: "agent-a", AgentName: "shared-branch",
+		GitClone: gc,
+	}); err != nil {
+		t.Fatalf("provision agent-a: %v", err)
+	}
+
+	// Agent B joins the same branch "shared-branch".
+	if err := provision.ProvisionShared(provision.ProvisionInput{
+		Resolved: resolved, Mode: store.SharingModeWorktreePerAgent,
+		ProjectID: "p1", AgentID: "agent-b", AgentName: "shared-branch",
+		GitClone: gc,
+	}); err != nil {
+		t.Fatalf("provision agent-b: %v", err)
+	}
+
+	// The shared worktree lives under agent-a's path (it was the creator).
+	wtA := provision.WorktreePath(base, "agent-a")
+	if _, err := os.Stat(wtA); err != nil {
+		t.Fatalf("setup: shared worktree should exist at %s: %v", wtA, err)
+	}
+
+	// Sanity: both are registered.
+	sharers, _, err := provision.ListSharers(base, "shared-branch")
+	if err != nil || len(sharers) != 2 {
+		t.Fatalf("setup: expected 2 sharers, got %v (err=%v)", sharers, err)
+	}
+
+	// Create agent config dirs (as the broker would).
+	for _, name := range []string{"agent-a", "agent-b"} {
+		if err := os.MkdirAll(filepath.Join(scionDir, "agents", name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Delete agent-a (the creator) while agent-b (joiner) remains.
+	branchDeleted, err := DeleteAgentFiles("agent-a", projectPath, true)
+	if err != nil {
+		t.Fatalf("DeleteAgentFiles(agent-a): %v", err)
+	}
+
+	// 1. Shared worktree PERSISTS (dir + .git still present).
+	if _, err := os.Stat(wtA); err != nil {
+		t.Errorf("shared worktree should persist while joiner remains: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(wtA, ".git")); err != nil {
+		t.Errorf("shared worktree .git should persist: %v", err)
+	}
+
+	// 2. Branch NOT deleted.
+	if branchDeleted {
+		t.Error("branch should NOT be deleted while other sharers remain")
+	}
+	branchCheck := exec.Command("git", "-C", base, "branch", "--list", "shared-branch")
+	if out, _ := branchCheck.Output(); strings.TrimSpace(string(out)) == "" {
+		t.Error("branch 'shared-branch' should still exist in the repo")
+	}
+
+	// 3. agent-b is still registered as a sharer.
+	sharers, _, err = provision.ListSharers(base, "shared-branch")
+	if err != nil {
+		t.Fatalf("ListSharers after delete: %v", err)
+	}
+	if len(sharers) != 1 || sharers[0] != "agent-b" {
+		t.Errorf("expected sharers=[agent-b], got %v", sharers)
+	}
+
+	// 4. agent-a is no longer registered.
+	_, _, found, _ := provision.FindBranchForAgent(base, "agent-a")
+	if found {
+		t.Error("agent-a should no longer be in the sharer registry")
+	}
+
+	// 5. agent-a's config dir is removed.
+	if _, err := os.Stat(filepath.Join(scionDir, "agents", "agent-a")); !os.IsNotExist(err) {
+		t.Errorf("agent-a config dir should be removed, stat err=%v", err)
+	}
+}
+
+// TestDeleteAgentFiles_SharedWorktree_DeleteLastSharer_RemovesWorktree verifies
+// that deleting the last remaining sharer removes the shared worktree and
+// optionally the branch.
+func TestDeleteAgentFiles_SharedWorktree_DeleteLastSharer_RemovesWorktree(t *testing.T) {
+	t.Setenv("SCION_HOST_UID", "")
+
+	tmpDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(tmpDir)
+	t.Setenv("HOME", tmpDir)
+
+	bare := initBareRepo(t)
+	gc := &api.GitCloneConfig{URL: bare, Branch: "main", Depth: 0}
+
+	projectPath := filepath.Join(tmpDir, "proj")
+	scionDir := filepath.Join(projectPath, config.DotScion)
+	if err := os.MkdirAll(filepath.Join(scionDir, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	base := filepath.Join(projectPath, "workspace")
+	resolved := provision.ResolvedWorkspace{HostPath: base, Backend: "local"}
+
+	// Agent A creates, Agent B joins.
+	for _, id := range []string{"agent-a", "agent-b"} {
+		if err := provision.ProvisionShared(provision.ProvisionInput{
+			Resolved: resolved, Mode: store.SharingModeWorktreePerAgent,
+			ProjectID: "p1", AgentID: id, AgentName: "shared-branch",
+			GitClone: gc,
+		}); err != nil {
+			t.Fatalf("provision %s: %v", id, err)
+		}
+		if err := os.MkdirAll(filepath.Join(scionDir, "agents", id), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	wtA := provision.WorktreePath(base, "agent-a")
+
+	// Delete agent-a first (not last → detach only).
+	if _, err := DeleteAgentFiles("agent-a", projectPath, true); err != nil {
+		t.Fatalf("DeleteAgentFiles(agent-a): %v", err)
+	}
+
+	// Worktree should still exist.
+	if _, err := os.Stat(wtA); err != nil {
+		t.Fatalf("worktree should persist after deleting first sharer: %v", err)
+	}
+
+	// Now delete agent-b (last sharer) with removeBranch=true.
+	branchDeleted, err := DeleteAgentFiles("agent-b", projectPath, true)
+	if err != nil {
+		t.Fatalf("DeleteAgentFiles(agent-b): %v", err)
+	}
+
+	// 1. Shared worktree is removed.
+	if _, err := os.Stat(wtA); !os.IsNotExist(err) {
+		t.Errorf("shared worktree should be removed after last sharer deleted, stat err=%v", err)
+	}
+
+	// 2. Branch is deleted.
+	if !branchDeleted {
+		t.Error("expected branch to be deleted when last sharer is removed with removeBranch=true")
+	}
+	branchCheck := exec.Command("git", "-C", base, "branch", "--list", "shared-branch")
+	if out, _ := branchCheck.Output(); strings.TrimSpace(string(out)) != "" {
+		t.Errorf("branch 'shared-branch' should be gone, got: %s", strings.TrimSpace(string(out)))
+	}
+
+	// 3. Sharer registry is empty.
+	sharers, _, err := provision.ListSharers(base, "shared-branch")
+	if err != nil {
+		t.Fatalf("ListSharers: %v", err)
+	}
+	if len(sharers) != 0 {
+		t.Errorf("expected no sharers remaining, got %v", sharers)
+	}
+
+	// 4. agent-b's config dir is removed.
+	if _, err := os.Stat(filepath.Join(scionDir, "agents", "agent-b")); !os.IsNotExist(err) {
+		t.Errorf("agent-b config dir should be removed, stat err=%v", err)
+	}
+}
+
+// TestDeleteAgentFiles_SharedWorktree_SoleSharer_DeleteRemoves verifies that a
+// unique-branch agent (sole sharer in the registry) still has its worktree
+// removed on delete — no regression from the refcount path.
+func TestDeleteAgentFiles_SharedWorktree_SoleSharer_DeleteRemoves(t *testing.T) {
+	t.Setenv("SCION_HOST_UID", "")
+
+	tmpDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(tmpDir)
+	t.Setenv("HOME", tmpDir)
+
+	bare := initBareRepo(t)
+	gc := &api.GitCloneConfig{URL: bare, Branch: "main", Depth: 0}
+
+	projectPath := filepath.Join(tmpDir, "proj")
+	scionDir := filepath.Join(projectPath, config.DotScion)
+	if err := os.MkdirAll(filepath.Join(scionDir, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	base := filepath.Join(projectPath, "workspace")
+	resolved := provision.ResolvedWorkspace{HostPath: base, Backend: "local"}
+
+	// Provision a single agent with a unique branch name.
+	if err := provision.ProvisionShared(provision.ProvisionInput{
+		Resolved: resolved, Mode: store.SharingModeWorktreePerAgent,
+		ProjectID: "p1", AgentID: "solo-agent", AgentName: "solo-agent",
+		GitClone: gc,
+	}); err != nil {
+		t.Fatalf("provision solo-agent: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(scionDir, "agents", "solo-agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	wtPath := provision.WorktreePath(base, "solo-agent")
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("setup: worktree should exist at %s: %v", wtPath, err)
+	}
+
+	// Delete the sole sharer.
+	branchDeleted, err := DeleteAgentFiles("solo-agent", projectPath, true)
+	if err != nil {
+		t.Fatalf("DeleteAgentFiles(solo-agent): %v", err)
+	}
+
+	// Worktree is removed.
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Errorf("sole agent's worktree should be removed, stat err=%v", err)
+	}
+
+	// Branch is deleted.
+	if !branchDeleted {
+		t.Error("expected branch to be deleted for sole sharer")
+	}
+
+	// No sharers remain.
+	sharers, _, err := provision.ListSharers(base, "solo-agent")
+	if err != nil {
+		t.Fatalf("ListSharers: %v", err)
+	}
+	if len(sharers) != 0 {
+		t.Errorf("expected no sharers remaining, got %v", sharers)
+	}
+
+	// Shared base .git survives.
+	if _, err := os.Stat(filepath.Join(base, ".git")); err != nil {
+		t.Errorf("shared base .git should survive: %v", err)
+	}
+}

--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -61,10 +61,13 @@ func DeleteAgentFiles(agentName string, projectPath string, removeBranch bool) (
 			}
 		}
 
-		// Fallback: resolve repo root from the project's parent directory
-		// (clone-per-agent layout where each agent workspace is a full clone).
+		// Fallback: resolve repo root from projectDir itself. Passing projectDir
+		// (not its parent) is robust for both local projects (where projectDir is
+		// the repo root) and hub-managed projects (where it is the .scion subdir).
+		// MUST match the base used at sharer registration (ProvisionAgent), or the
+		// refcount lookup (FindBranchForAgent/UnregisterSharer) would miss.
 		if repoRoot == "" {
-			if root, err := util.RepoRootDir(filepath.Dir(projectDir)); err == nil {
+			if root, err := util.RepoRootDir(projectDir); err == nil {
 				repoRoot = root
 			}
 		}
@@ -121,6 +124,14 @@ func DeleteAgentFiles(agentName string, projectPath string, removeBranch bool) (
 				} else {
 					util.Debugf("delete: shared worktree removal failed in %v: %v", time.Since(worktreeStart), err)
 					_ = util.RemoveAllSafe(wtPath)
+					// Worktree removal failed, so the branch wasn't deleted by it —
+					// fall back to deleting the branch by name (like the legacy path).
+					if removeBranch && !branchDeleted {
+						if util.DeleteBranchIn(repoRoot, branch) {
+							branchDeleted = true
+							util.Debugf("delete: deleted branch %s via fallback after worktree removal failure", branch)
+						}
+					}
 				}
 			} else {
 				util.Debugf("delete: %d sharers remain for branch %s, detaching agent %s", len(remaining), branch, agentName)
@@ -523,7 +534,7 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 				fmt.Printf("Warning: Relying on existing worktree for branch '%s' at '%s'\n", targetBranch, existingPath)
 				// Register as sharer for refcounted teardown (I3). Fail loudly:
 				// an untracked agent breaks the refcount (premature/leaked removal).
-				root, rootErr := util.RepoRootDir(filepath.Dir(projectDir))
+				root, rootErr := util.RepoRootDir(projectDir)
 				if rootErr != nil {
 					return "", "", nil, fmt.Errorf("resolve repo root for sharer registration: %w", rootErr)
 				}
@@ -578,7 +589,7 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 		util.Debugf("provision: worktree created in %s", time.Since(worktreeStart))
 		// Register as sharer for refcounted teardown (I3). Fail loudly:
 		// an untracked agent breaks the refcount (premature/leaked removal).
-		root, rootErr := util.RepoRootDir(filepath.Dir(projectDir))
+		root, rootErr := util.RepoRootDir(projectDir)
 		if rootErr != nil {
 			return "", "", nil, fmt.Errorf("resolve repo root for sharer registration: %w", rootErr)
 		}

--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -98,28 +98,34 @@ func DeleteAgentFiles(agentName string, projectPath string, removeBranch bool) (
 	// which has no advisory locker.
 	refcountHandled := false
 	if repoRoot != "" {
-		if branch, _, found, findErr := provision.FindBranchForAgent(repoRoot, agentName); findErr == nil && found {
+		// Do NOT silently swallow registry errors and fall through to the legacy
+		// path — that path could delete the shared worktree out from under live
+		// joiners. On a real registry I/O error, fail loudly instead.
+		branch, _, found, findErr := provision.FindBranchForAgent(repoRoot, agentName)
+		if findErr != nil {
+			return branchDeleted, fmt.Errorf("delete: FindBranchForAgent for %s: %w", agentName, findErr)
+		}
+		if found {
 			remaining, wtPath, unregErr := provision.UnregisterSharer(repoRoot, branch, agentName)
-			if unregErr == nil {
-				if len(remaining) == 0 {
-					util.Debugf("delete: last sharer for branch %s, removing worktree at %s", branch, wtPath)
-					worktreeStart := time.Now()
-					if deleted, err := util.RemoveWorktree(wtPath, removeBranch); err == nil {
-						if deleted {
-							branchDeleted = true
-						}
-						util.Debugf("delete: shared worktree removal completed in %v (branch deleted: %v)", time.Since(worktreeStart), deleted)
-					} else {
-						util.Debugf("delete: shared worktree removal failed in %v: %v", time.Since(worktreeStart), err)
-						_ = util.RemoveAllSafe(wtPath)
-					}
-				} else {
-					util.Debugf("delete: %d sharers remain for branch %s, detaching agent %s", len(remaining), branch, agentName)
-				}
-				refcountHandled = true
-			} else {
-				util.Debugf("delete: UnregisterSharer failed for branch %s agent %s: %v", branch, agentName, unregErr)
+			if unregErr != nil {
+				return branchDeleted, fmt.Errorf("delete: UnregisterSharer for branch %s agent %s: %w", branch, agentName, unregErr)
 			}
+			if len(remaining) == 0 {
+				util.Debugf("delete: last sharer for branch %s, removing worktree at %s", branch, wtPath)
+				worktreeStart := time.Now()
+				if deleted, err := util.RemoveWorktree(wtPath, removeBranch); err == nil {
+					if deleted {
+						branchDeleted = true
+					}
+					util.Debugf("delete: shared worktree removal completed in %v (branch deleted: %v)", time.Since(worktreeStart), deleted)
+				} else {
+					util.Debugf("delete: shared worktree removal failed in %v: %v", time.Since(worktreeStart), err)
+					_ = util.RemoveAllSafe(wtPath)
+				}
+			} else {
+				util.Debugf("delete: %d sharers remain for branch %s, detaching agent %s", len(remaining), branch, agentName)
+			}
+			refcountHandled = true
 		}
 	}
 
@@ -515,9 +521,14 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 				agentWorkspace = "" // Using external worktree
 				usedExistingWorktree = true
 				fmt.Printf("Warning: Relying on existing worktree for branch '%s' at '%s'\n", targetBranch, existingPath)
-				// Register as sharer for refcounted teardown (I3).
-				if root, rootErr := util.RepoRootDir(filepath.Dir(projectDir)); rootErr == nil {
-					_ = provision.RegisterSharer(root, targetBranch, existingPath, agentName)
+				// Register as sharer for refcounted teardown (I3). Fail loudly:
+				// an untracked agent breaks the refcount (premature/leaked removal).
+				root, rootErr := util.RepoRootDir(filepath.Dir(projectDir))
+				if rootErr != nil {
+					return "", "", nil, fmt.Errorf("resolve repo root for sharer registration: %w", rootErr)
+				}
+				if regErr := provision.RegisterSharer(root, targetBranch, existingPath, agentName); regErr != nil {
+					return "", "", nil, fmt.Errorf("register sharer (attach): %w", regErr)
 				}
 			}
 		}
@@ -565,9 +576,14 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 			return "", "", nil, fmt.Errorf("failed to create git worktree: %w", err)
 		}
 		util.Debugf("provision: worktree created in %s", time.Since(worktreeStart))
-		// Register as sharer for refcounted teardown (I3).
-		if root, rootErr := util.RepoRootDir(filepath.Dir(projectDir)); rootErr == nil {
-			_ = provision.RegisterSharer(root, worktreeBranch, agentWorkspace, agentName)
+		// Register as sharer for refcounted teardown (I3). Fail loudly:
+		// an untracked agent breaks the refcount (premature/leaked removal).
+		root, rootErr := util.RepoRootDir(filepath.Dir(projectDir))
+		if rootErr != nil {
+			return "", "", nil, fmt.Errorf("resolve repo root for sharer registration: %w", rootErr)
+		}
+		if regErr := provision.RegisterSharer(root, worktreeBranch, agentWorkspace, agentName); regErr != nil {
+			return "", "", nil, fmt.Errorf("register sharer (create): %w", regErr)
 		}
 
 		// Write a .scion project marker into the worktree so in-container CLI

--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/harness"
+	"github.com/GoogleCloudPlatform/scion/pkg/provision"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 )
 
@@ -471,6 +472,10 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 				agentWorkspace = "" // Using external worktree
 				usedExistingWorktree = true
 				fmt.Printf("Warning: Relying on existing worktree for branch '%s' at '%s'\n", targetBranch, existingPath)
+				// Register as sharer for refcounted teardown (I3).
+				if root, rootErr := util.RepoRootDir(filepath.Dir(projectDir)); rootErr == nil {
+					_ = provision.RegisterSharer(root, targetBranch, existingPath, agentName)
+				}
 			}
 		}
 
@@ -517,6 +522,10 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 			return "", "", nil, fmt.Errorf("failed to create git worktree: %w", err)
 		}
 		util.Debugf("provision: worktree created in %s", time.Since(worktreeStart))
+		// Register as sharer for refcounted teardown (I3).
+		if root, rootErr := util.RepoRootDir(filepath.Dir(projectDir)); rootErr == nil {
+			_ = provision.RegisterSharer(root, worktreeBranch, agentWorkspace, agentName)
+		}
 
 		// Write a .scion project marker into the worktree so in-container CLI
 		// can discover the project context. Worktrees don't contain .scion

--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -84,10 +84,50 @@ func DeleteAgentFiles(agentName string, projectPath string, removeBranch bool) (
 	// in a goroutine that could block git subprocess I/O system-wide.
 	var dirsToDelete []string
 
+	// --- Refcount path: shared-worktree teardown (#168 I3) ---
+	//
+	// Before the legacy worktree-removal blocks, check the sharer registry.
+	// If this agent is registered as a sharer, unregister it and decide
+	// whether to remove the shared worktree based on remaining sharers.
+	//
+	// NOTE: teardown does not hold the per-project advisory lock. The
+	// provisioning path (ensureWorktree / ProvisionShared) holds the lock
+	// during registration. A concurrent provision+delete race on the same
+	// branch is unlikely in practice (the hub serialises agent lifecycle)
+	// but not structurally excluded. Acceptable for single-node local mode
+	// which has no advisory locker.
+	refcountHandled := false
+	if repoRoot != "" {
+		if branch, _, found, findErr := provision.FindBranchForAgent(repoRoot, agentName); findErr == nil && found {
+			remaining, wtPath, unregErr := provision.UnregisterSharer(repoRoot, branch, agentName)
+			if unregErr == nil {
+				if len(remaining) == 0 {
+					util.Debugf("delete: last sharer for branch %s, removing worktree at %s", branch, wtPath)
+					worktreeStart := time.Now()
+					if deleted, err := util.RemoveWorktree(wtPath, removeBranch); err == nil {
+						if deleted {
+							branchDeleted = true
+						}
+						util.Debugf("delete: shared worktree removal completed in %v (branch deleted: %v)", time.Since(worktreeStart), deleted)
+					} else {
+						util.Debugf("delete: shared worktree removal failed in %v: %v", time.Since(worktreeStart), err)
+						_ = util.RemoveAllSafe(wtPath)
+					}
+				} else {
+					util.Debugf("delete: %d sharers remain for branch %s, detaching agent %s", len(remaining), branch, agentName)
+				}
+				refcountHandled = true
+			} else {
+				util.Debugf("delete: UnregisterSharer failed for branch %s agent %s: %v", branch, agentName, unregErr)
+			}
+		}
+	}
+
 	// Worktree-per-agent: remove the agent's worktree from the shared base.
 	// The worktree lives at <projectDir>/workspace/worktrees/<agentName>,
 	// separate from the agent config dir under agents/.
-	if worktreeDir != "" {
+	// Skip when the refcount path already handled removal/detach.
+	if worktreeDir != "" && !refcountHandled {
 		if _, err := os.Stat(filepath.Join(worktreeDir, ".git")); err == nil {
 			util.Debugf("delete: removing worktree-per-agent workspace at %s", worktreeDir)
 			worktreeStart := time.Now()
@@ -112,21 +152,22 @@ func DeleteAgentFiles(agentName string, projectPath string, removeBranch bool) (
 		}
 
 		agentWorkspace := filepath.Join(agentDir, "workspace")
-		// Check if it's a worktree before trying to remove it
-		if _, err := os.Stat(filepath.Join(agentWorkspace, ".git")); err == nil {
-			util.Debugf("delete: removing workspace at %s", agentWorkspace)
-			worktreeStart := time.Now()
-			if deleted, err := util.RemoveWorktree(agentWorkspace, removeBranch); err == nil {
-				if deleted {
-					branchDeleted = true
+		// Check if it's a worktree before trying to remove it.
+		// Skip when the refcount path already handled removal/detach —
+		// the shared worktree must not be removed while other sharers remain.
+		if !refcountHandled {
+			if _, err := os.Stat(filepath.Join(agentWorkspace, ".git")); err == nil {
+				util.Debugf("delete: removing workspace at %s", agentWorkspace)
+				worktreeStart := time.Now()
+				if deleted, err := util.RemoveWorktree(agentWorkspace, removeBranch); err == nil {
+					if deleted {
+						branchDeleted = true
+					}
+					util.Debugf("delete: worktree removal completed in %v (branch deleted: %v)", time.Since(worktreeStart), deleted)
+				} else {
+					util.Debugf("delete: worktree removal failed in %v: %v", time.Since(worktreeStart), err)
+					_ = util.RemoveAllSafe(agentWorkspace)
 				}
-				util.Debugf("delete: worktree removal completed in %v (branch deleted: %v)", time.Since(worktreeStart), deleted)
-			} else {
-				util.Debugf("delete: worktree removal failed in %v: %v", time.Since(worktreeStart), err)
-				// Ensure the workspace directory is gone even if worktree
-				// removal only partially succeeded, so that PruneWorktreesIn
-				// can detect the stale .git/worktrees entry.
-				_ = util.RemoveAllSafe(agentWorkspace)
 			}
 		}
 
@@ -144,7 +185,9 @@ func DeleteAgentFiles(agentName string, projectPath string, removeBranch bool) (
 
 		// If the branch wasn't already deleted via RemoveWorktree (e.g. because
 		// the workspace .git file didn't exist), try to delete it by name.
-		if removeBranch && !branchDeleted {
+		// Skip when refcount handled teardown — branch lifecycle is managed
+		// by the refcount path (last-sharer removes; others detach).
+		if removeBranch && !branchDeleted && !refcountHandled {
 			branchName := api.Slugify(agentName)
 			if util.DeleteBranchIn(repoRoot, branchName) {
 				branchDeleted = true

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -386,8 +386,16 @@ func WorktreePath(hostPath, agentID string) string {
 	return filepath.Join(hostPath, "worktrees", agentID)
 }
 
-// ensureWorktree creates a per-agent worktree if the mode is WorktreePerAgent.
-// For SharedPlain mode this is a no-op.
+// ensureWorktree creates or attaches to a per-agent worktree if the mode is
+// WorktreePerAgent. For SharedPlain mode this is a no-op.
+//
+// Create-or-attach logic (D3 hub-join):
+//   - If a worktree for the requested branch already exists (found via the
+//     sharer registry or git worktree list), the agent ATTACHES to it (JOIN)
+//     and registers as a sharer — no second worktree is created.
+//   - Otherwise, a new worktree is created and the agent registers as its
+//     first sharer.
+//
 // The worktree add is done under the already-held advisory lock (design §9.2:
 // worktree add/remove touches shared .git metadata).
 func ensureWorktree(ctx context.Context, in ProvisionInput) error {
@@ -399,21 +407,8 @@ func ensureWorktree(ctx context.Context, in ProvisionInput) error {
 		return fmt.Errorf("ProvisionShared: AgentID is required for WorktreePerAgent mode")
 	}
 
-	worktreePath := WorktreePath(in.Resolved.HostPath, in.AgentID)
-
-	// If the worktree already exists, skip.
-	if _, err := os.Stat(worktreePath); err == nil {
-		slog.Debug("ProvisionShared: worktree already exists",
-			"agent_id", in.AgentID, "path", worktreePath)
-		return nil
-	}
-
-	// Verify the shared checkout exists (.git dir present).
-	gitDir := filepath.Join(in.Resolved.HostPath, ".git")
-	if _, err := os.Stat(gitDir); err != nil {
-		return fmt.Errorf("ProvisionShared: shared checkout .git not found at %s — "+
-			"cannot create worktree without a cloned repository", gitDir)
-	}
+	base := in.Resolved.HostPath
+	worktreePath := WorktreePath(base, in.AgentID)
 
 	// Derive a branch name from the agent name or ID.
 	branchName := in.AgentID
@@ -421,8 +416,49 @@ func ensureWorktree(ctx context.Context, in ProvisionInput) error {
 		branchName = sanitizeBranchName(in.AgentName)
 	}
 
-	// Ensure worktrees parent directory exists.
-	worktreesDir := filepath.Join(in.Resolved.HostPath, "worktrees")
+	// If this agent's own worktree directory already exists, register
+	// (idempotent) and return.
+	if _, err := os.Stat(worktreePath); err == nil {
+		slog.Debug("ProvisionShared: worktree already exists",
+			"agent_id", in.AgentID, "path", worktreePath)
+		return RegisterSharer(base, branchName, worktreePath, in.AgentID)
+	}
+
+	// Verify the shared checkout exists (.git dir present).
+	gitDir := filepath.Join(base, ".git")
+	if _, err := os.Stat(gitDir); err != nil {
+		return fmt.Errorf("ProvisionShared: shared checkout .git not found at %s — "+
+			"cannot create worktree without a cloned repository", gitDir)
+	}
+
+	// --- JOIN check: does a worktree for this branch already exist? ---
+
+	// 1. Check the sharer registry.
+	sharers, existingWtPath, err := ListSharers(base, branchName)
+	if err != nil {
+		return fmt.Errorf("ProvisionShared: list sharers for branch %q: %w", branchName, err)
+	}
+	if len(sharers) > 0 && existingWtPath != "" {
+		if _, statErr := os.Stat(existingWtPath); statErr == nil {
+			slog.Info("ProvisionShared: joining existing worktree (registry)",
+				"agent_id", in.AgentID, "branch", branchName, "path", existingWtPath,
+				"existing_sharers", sharers)
+			return RegisterSharer(base, branchName, existingWtPath, in.AgentID)
+		}
+		slog.Warn("ProvisionShared: registry points to missing path, will create new worktree",
+			"agent_id", in.AgentID, "branch", branchName, "stale_path", existingWtPath)
+	}
+
+	// 2. Check git worktree list for a prior-run worktree without a registry entry.
+	if existingPath, findErr := findWorktreeForBranch(ctx, base, branchName); findErr == nil && existingPath != "" {
+		slog.Info("ProvisionShared: joining pre-existing worktree (git)",
+			"agent_id", in.AgentID, "branch", branchName, "path", existingPath)
+		return RegisterSharer(base, branchName, existingPath, in.AgentID)
+	}
+
+	// --- CREATE: no existing worktree for this branch ---
+
+	worktreesDir := filepath.Join(base, "worktrees")
 	if err := os.MkdirAll(worktreesDir, 0770); err != nil {
 		return fmt.Errorf("ProvisionShared: mkdir worktrees dir: %w", err)
 	}
@@ -433,34 +469,71 @@ func ensureWorktree(ctx context.Context, in ProvisionInput) error {
 	// git worktree add --relative-paths -b <branch> <path>
 	// --relative-paths is mandatory for container path-identity (design §6).
 	cmd := exec.CommandContext(ctx, "git", "worktree", "add", "--relative-paths", "-b", branchName, worktreePath)
-	cmd.Dir = in.Resolved.HostPath
+	cmd.Dir = base
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		outputStr := strings.TrimSpace(string(output))
-		// If the branch is already checked out in another worktree, surface a
-		// clear error instead of a confusing git message.
+
+		// Branch collision: the proactive JOIN checks above should catch this,
+		// but handle defensively in case of a race or stale state.
 		if strings.Contains(outputStr, "already checked out") || strings.Contains(outputStr, "already used by worktree") {
-			return fmt.Errorf("git worktree add: branch %q is already checked out in another worktree: %s",
+			if attachPath, findErr := findWorktreeForBranch(ctx, base, branchName); findErr == nil && attachPath != "" {
+				slog.Info("ProvisionShared: attaching to existing worktree (git fallback)",
+					"agent_id", in.AgentID, "branch", branchName, "path", attachPath)
+				return RegisterSharer(base, branchName, attachPath, in.AgentID)
+			}
+			return fmt.Errorf("git worktree add: branch %q already checked out but cannot find existing worktree: %s",
 				branchName, outputStr)
 		}
-		// If branch already exists, try without -b (reuse existing branch).
+
+		// If branch already exists (but not checked out), try without -b.
 		if strings.Contains(outputStr, "already exists") {
 			cmd = exec.CommandContext(ctx, "git", "worktree", "add", "--relative-paths", worktreePath, branchName)
-			cmd.Dir = in.Resolved.HostPath
+			cmd.Dir = base
 			output, err = cmd.CombinedOutput()
 			if err != nil {
 				reuse := strings.TrimSpace(string(output))
 				if strings.Contains(reuse, "already checked out") || strings.Contains(reuse, "already used by worktree") {
-					return fmt.Errorf("git worktree add: branch %q is already checked out in another worktree: %s",
-						branchName, reuse)
+					if attachPath, findErr := findWorktreeForBranch(ctx, base, branchName); findErr == nil && attachPath != "" {
+						slog.Info("ProvisionShared: attaching to existing worktree (reuse fallback)",
+							"agent_id", in.AgentID, "branch", branchName, "path", attachPath)
+						return RegisterSharer(base, branchName, attachPath, in.AgentID)
+					}
+					return fmt.Errorf("git worktree add: branch %q already checked out: %s", branchName, reuse)
 				}
 				return fmt.Errorf("git worktree add (reuse branch): %s", reuse)
 			}
-			return nil
+			return RegisterSharer(base, branchName, worktreePath, in.AgentID)
 		}
+
 		return fmt.Errorf("git worktree add: %s", outputStr)
 	}
-	return nil
+
+	return RegisterSharer(base, branchName, worktreePath, in.AgentID)
+}
+
+// findWorktreeForBranch parses 'git worktree list --porcelain' output to find
+// the worktree path for a given branch. Returns "" if no worktree has that
+// branch checked out.
+func findWorktreeForBranch(ctx context.Context, repoDir, branch string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "worktree", "list", "--porcelain")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git worktree list: %w", err)
+	}
+	var currentPath string
+	for _, line := range strings.Split(string(output), "\n") {
+		if strings.HasPrefix(line, "worktree ") {
+			currentPath = strings.TrimPrefix(line, "worktree ")
+		}
+		if strings.HasPrefix(line, "branch refs/heads/") {
+			b := strings.TrimPrefix(line, "branch refs/heads/")
+			if b == branch {
+				return currentPath, nil
+			}
+		}
+	}
+	return "", nil
 }
 
 // prepareBaseForWorktrees configures a freshly cloned base checkout for

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -516,6 +516,9 @@ func ensureWorktree(ctx context.Context, in ProvisionInput) error {
 // the worktree path for a given branch. Returns "" if no worktree has that
 // branch checked out.
 func findWorktreeForBranch(ctx context.Context, repoDir, branch string) (string, error) {
+	// Prune first so a worktree dir removed on disk (but not unregistered in git)
+	// isn't returned as a stale join target pointing at a non-existent path.
+	_ = exec.CommandContext(ctx, "git", "-C", repoDir, "worktree", "prune").Run()
 	cmd := exec.CommandContext(ctx, "git", "-C", repoDir, "worktree", "list", "--porcelain")
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/provision/provision_test.go
+++ b/pkg/provision/provision_test.go
@@ -598,3 +598,150 @@ func TestWorktreePath(t *testing.T) {
 		t.Errorf("WorktreePath() = %q, want %q", got, want)
 	}
 }
+
+// --- Create-or-Attach + Sharer Registration ---
+
+func TestProvision_WorktreePerAgent_CreateAndJoin(t *testing.T) {
+	t.Setenv("SCION_HOST_UID", "")
+	locker := newTestLocker()
+	bareRepo := initBareGitRepo(t)
+
+	projectDir := t.TempDir()
+	hostPath := filepath.Join(projectDir, "workspace")
+
+	// Agent A creates worktree on branch "shared-branch".
+	err := ProvisionShared(ProvisionInput{
+		Resolved:  ResolvedWorkspace{HostPath: hostPath, Backend: "local"},
+		ProjectID: "proj-join-1",
+		AgentID:   "agent-a",
+		AgentName: "shared-branch",
+		Mode:      store.SharingModeWorktreePerAgent,
+		Locker:    locker,
+		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: -1},
+	})
+	require.NoError(t, err)
+
+	// Verify worktree created for A.
+	wtA := WorktreePath(hostPath, "agent-a")
+	require.DirExists(t, wtA)
+
+	// Verify sharers=[A].
+	sharers, wtPath, err := ListSharers(hostPath, "shared-branch")
+	require.NoError(t, err)
+	assert.Equal(t, wtA, wtPath)
+	assert.Equal(t, []string{"agent-a"}, sharers)
+
+	// Agent B joins same branch "shared-branch" (JOIN).
+	err = ProvisionShared(ProvisionInput{
+		Resolved:  ResolvedWorkspace{HostPath: hostPath, Backend: "local"},
+		ProjectID: "proj-join-1",
+		AgentID:   "agent-b",
+		AgentName: "shared-branch",
+		Mode:      store.SharingModeWorktreePerAgent,
+		Locker:    locker,
+		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: -1},
+	})
+	require.NoError(t, err)
+
+	// Verify NO second worktree created for B.
+	wtB := WorktreePath(hostPath, "agent-b")
+	_, statErr := os.Stat(wtB)
+	assert.True(t, os.IsNotExist(statErr), "JOIN should NOT create a second worktree at %s", wtB)
+
+	// Verify sharers=[A,B] and B's registered path == A's path.
+	sharers, wtPath, err = ListSharers(hostPath, "shared-branch")
+	require.NoError(t, err)
+	assert.Equal(t, wtA, wtPath, "B's resolved worktree path should equal A's")
+	assert.Len(t, sharers, 2)
+	assert.Contains(t, sharers, "agent-a")
+	assert.Contains(t, sharers, "agent-b")
+}
+
+func TestProvision_WorktreePerAgent_UniqueBranches_SoleSharers(t *testing.T) {
+	t.Setenv("SCION_HOST_UID", "")
+	locker := newTestLocker()
+	bareRepo := initBareGitRepo(t)
+
+	projectDir := t.TempDir()
+	hostPath := filepath.Join(projectDir, "workspace")
+
+	// Agent A with unique branch.
+	err := ProvisionShared(ProvisionInput{
+		Resolved:  ResolvedWorkspace{HostPath: hostPath, Backend: "local"},
+		ProjectID: "proj-unique-1",
+		AgentID:   "agent-a",
+		AgentName: "agent-alpha",
+		Mode:      store.SharingModeWorktreePerAgent,
+		Locker:    locker,
+		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: -1},
+	})
+	require.NoError(t, err)
+
+	// Agent B with unique branch.
+	err = ProvisionShared(ProvisionInput{
+		Resolved:  ResolvedWorkspace{HostPath: hostPath, Backend: "local"},
+		ProjectID: "proj-unique-1",
+		AgentID:   "agent-b",
+		AgentName: "agent-beta",
+		Mode:      store.SharingModeWorktreePerAgent,
+		Locker:    locker,
+		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: -1},
+	})
+	require.NoError(t, err)
+
+	// Both have their own worktrees.
+	wtA := WorktreePath(hostPath, "agent-a")
+	wtB := WorktreePath(hostPath, "agent-b")
+	require.DirExists(t, wtA)
+	require.DirExists(t, wtB)
+	assert.NotEqual(t, wtA, wtB)
+
+	// Each is sole sharer of its own branch.
+	sharersA, pathA, err := ListSharers(hostPath, "agent-alpha")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"agent-a"}, sharersA)
+	assert.Equal(t, wtA, pathA)
+
+	sharersB, pathB, err := ListSharers(hostPath, "agent-beta")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"agent-b"}, sharersB)
+	assert.Equal(t, wtB, pathB)
+}
+
+func TestProvision_WorktreePerAgent_ExistingRegistration_Idempotent(t *testing.T) {
+	t.Setenv("SCION_HOST_UID", "")
+	locker := newTestLocker()
+	bareRepo := initBareGitRepo(t)
+
+	projectDir := t.TempDir()
+	hostPath := filepath.Join(projectDir, "workspace")
+
+	// Provision agent once.
+	err := ProvisionShared(ProvisionInput{
+		Resolved:  ResolvedWorkspace{HostPath: hostPath, Backend: "local"},
+		ProjectID: "proj-idem-1",
+		AgentID:   "agent-a",
+		AgentName: "idem-branch",
+		Mode:      store.SharingModeWorktreePerAgent,
+		Locker:    locker,
+		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: -1},
+	})
+	require.NoError(t, err)
+
+	// Provision the same agent again (idempotent).
+	err = ProvisionShared(ProvisionInput{
+		Resolved:  ResolvedWorkspace{HostPath: hostPath, Backend: "local"},
+		ProjectID: "proj-idem-1",
+		AgentID:   "agent-a",
+		AgentName: "idem-branch",
+		Mode:      store.SharingModeWorktreePerAgent,
+		Locker:    locker,
+		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: -1},
+	})
+	require.NoError(t, err)
+
+	// Should still have exactly one sharer.
+	sharers, _, err := ListSharers(hostPath, "idem-branch")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"agent-a"}, sharers)
+}

--- a/pkg/provision/sharers.go
+++ b/pkg/provision/sharers.go
@@ -64,11 +64,22 @@ func writeMarkerAtomic(path string, m *sharerMarker) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	// Unique temp file (not a static path+".tmp") so concurrent writers don't
+	// clobber each other's temp data before the atomic rename.
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
 }
 
 // RegisterSharer adds agentID to the sharer list for the given branch

--- a/pkg/provision/sharers.go
+++ b/pkg/provision/sharers.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provision
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+)
+
+// sharerMarker is the on-disk JSON shape stored per shared branch.
+type sharerMarker struct {
+	Branch       string   `json:"branch"`
+	WorktreePath string   `json:"worktreePath"`
+	Sharers      []string `json:"sharers"`
+}
+
+const sharerDir = "scion-sharers"
+
+// sharerPath returns the marker file path for a branch under the base repo.
+func sharerPath(base, branch string) string {
+	return filepath.Join(base, ".git", sharerDir, sanitizeBranchName(branch)+".json")
+}
+
+// readMarker loads the marker file for a branch. Returns nil (no error) when
+// the file does not exist.
+func readMarker(path string) (*sharerMarker, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var m sharerMarker
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// writeMarkerAtomic writes the marker via a temp file + rename to avoid torn
+// reads. The caller MUST hold the per-project advisory lock / provision mutex.
+func writeMarkerAtomic(path string, m *sharerMarker) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// RegisterSharer adds agentID to the sharer list for the given branch
+// worktree. The call is idempotent: re-registering an already-present agent is
+// a no-op. worktreePath is recorded (and kept) so that teardown can locate the
+// worktree directory even after the last sharer unregisters.
+//
+// Callers MUST hold the per-project advisory lock / provision mutex.
+func RegisterSharer(base, branch, worktreePath, agentID string) error {
+	p := sharerPath(base, branch)
+	m, err := readMarker(p)
+	if err != nil {
+		return err
+	}
+	if m == nil {
+		m = &sharerMarker{Branch: branch, WorktreePath: worktreePath}
+	}
+	if worktreePath != "" {
+		m.WorktreePath = worktreePath
+	}
+	if !slices.Contains(m.Sharers, agentID) {
+		m.Sharers = append(m.Sharers, agentID)
+	}
+	return writeMarkerAtomic(p, m)
+}
+
+// UnregisterSharer removes agentID from the sharer list for the given branch.
+// It returns the remaining sharers and the recorded worktreePath. When the
+// sharer list becomes empty the marker file is deleted, but worktreePath is
+// still returned so the caller can remove the worktree directory.
+//
+// Unregistering an agent that is not in the list is a no-op (returns the
+// current state). If no marker exists, remaining is nil and worktreePath is "".
+//
+// Callers MUST hold the per-project advisory lock / provision mutex.
+func UnregisterSharer(base, branch, agentID string) (remaining []string, worktreePath string, err error) {
+	p := sharerPath(base, branch)
+	m, err := readMarker(p)
+	if err != nil {
+		return nil, "", err
+	}
+	if m == nil {
+		return nil, "", nil
+	}
+	m.Sharers = slices.DeleteFunc(m.Sharers, func(s string) bool { return s == agentID })
+	if len(m.Sharers) == 0 {
+		if rerr := os.Remove(p); rerr != nil && !errors.Is(rerr, fs.ErrNotExist) {
+			return nil, m.WorktreePath, rerr
+		}
+		return []string{}, m.WorktreePath, nil
+	}
+	if err := writeMarkerAtomic(p, m); err != nil {
+		return nil, m.WorktreePath, err
+	}
+	return m.Sharers, m.WorktreePath, nil
+}
+
+// ListSharers returns the current sharer agent IDs and worktreePath for a
+// branch. If no marker exists, sharers is nil and worktreePath is "".
+func ListSharers(base, branch string) ([]string, string, error) {
+	p := sharerPath(base, branch)
+	m, err := readMarker(p)
+	if err != nil {
+		return nil, "", err
+	}
+	if m == nil {
+		return nil, "", nil
+	}
+	return m.Sharers, m.WorktreePath, nil
+}
+
+// FindBranchForAgent scans all marker files under base to find which branch
+// (and worktree path) agentID is sharing. Returns found=false when the agent
+// is not present in any marker.
+func FindBranchForAgent(base, agentID string) (branch, worktreePath string, found bool, err error) {
+	dir := filepath.Join(base, ".git", sharerDir)
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", "", false, nil
+	}
+	if err != nil {
+		return "", "", false, err
+	}
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		m, err := readMarker(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return "", "", false, err
+		}
+		if m != nil && slices.Contains(m.Sharers, agentID) {
+			return m.Branch, m.WorktreePath, true, nil
+		}
+	}
+	return "", "", false, nil
+}

--- a/pkg/provision/sharers.go
+++ b/pkg/provision/sharers.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -169,7 +170,12 @@ func FindBranchForAgent(base, agentID string) (branch, worktreePath string, foun
 		}
 		m, err := readMarker(filepath.Join(dir, e.Name()))
 		if err != nil {
-			return "", "", false, err
+			// A single corrupted/unreadable marker must not block the whole
+			// scan (and thus all agent deletions). Skip it and keep looking;
+			// dir-level failures are still returned above.
+			slog.Warn("FindBranchForAgent: skipping unreadable sharer marker",
+				"file", e.Name(), "error", err)
+			continue
 		}
 		if m != nil && slices.Contains(m.Sharers, agentID) {
 			return m.Branch, m.WorktreePath, true, nil

--- a/pkg/provision/sharers_test.go
+++ b/pkg/provision/sharers_test.go
@@ -1,0 +1,218 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provision
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// setupBase creates a temp dir with a .git subdirectory to simulate a repo base.
+func setupBase(t *testing.T) string {
+	t.Helper()
+	base := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(base, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return base
+}
+
+func TestRegisterAndListSharers(t *testing.T) {
+	base := setupBase(t)
+	branch := "feature/foo"
+	wt := "/workspace/wt-foo"
+
+	if err := RegisterSharer(base, branch, wt, "agent-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := RegisterSharer(base, branch, wt, "agent-2"); err != nil {
+		t.Fatal(err)
+	}
+
+	sharers, path, err := ListSharers(base, branch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != wt {
+		t.Errorf("worktreePath = %q, want %q", path, wt)
+	}
+	if len(sharers) != 2 {
+		t.Fatalf("len(sharers) = %d, want 2", len(sharers))
+	}
+	if !slices.Contains(sharers, "agent-1") || !slices.Contains(sharers, "agent-2") {
+		t.Errorf("sharers = %v, want [agent-1 agent-2]", sharers)
+	}
+}
+
+func TestUnregisterSharer_OneRemaining(t *testing.T) {
+	base := setupBase(t)
+	branch := "feature/bar"
+	wt := "/workspace/wt-bar"
+
+	RegisterSharer(base, branch, wt, "agent-1")
+	RegisterSharer(base, branch, wt, "agent-2")
+
+	remaining, path, err := UnregisterSharer(base, branch, "agent-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != wt {
+		t.Errorf("worktreePath = %q, want %q", path, wt)
+	}
+	if len(remaining) != 1 || remaining[0] != "agent-2" {
+		t.Errorf("remaining = %v, want [agent-2]", remaining)
+	}
+
+	// Marker file should still exist.
+	p := sharerPath(base, branch)
+	if _, err := os.Stat(p); err != nil {
+		t.Errorf("marker file should still exist: %v", err)
+	}
+}
+
+func TestUnregisterSharer_LastRemoves(t *testing.T) {
+	base := setupBase(t)
+	branch := "feature/baz"
+	wt := "/workspace/wt-baz"
+
+	RegisterSharer(base, branch, wt, "agent-1")
+
+	remaining, path, err := UnregisterSharer(base, branch, "agent-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != wt {
+		t.Errorf("worktreePath = %q, want %q", path, wt)
+	}
+	if len(remaining) != 0 {
+		t.Errorf("remaining = %v, want []", remaining)
+	}
+
+	// Marker file should be deleted.
+	p := sharerPath(base, branch)
+	if _, err := os.Stat(p); !os.IsNotExist(err) {
+		t.Errorf("marker file should be removed, got err = %v", err)
+	}
+}
+
+func TestFindBranchForAgent(t *testing.T) {
+	base := setupBase(t)
+
+	RegisterSharer(base, "feature/alpha", "/wt/alpha", "agent-A")
+	RegisterSharer(base, "feature/beta", "/wt/beta", "agent-B")
+
+	branch, wt, found, err := FindBranchForAgent(base, "agent-A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("expected found=true for agent-A")
+	}
+	if branch != "feature/alpha" {
+		t.Errorf("branch = %q, want %q", branch, "feature/alpha")
+	}
+	if wt != "/wt/alpha" {
+		t.Errorf("worktreePath = %q, want %q", wt, "/wt/alpha")
+	}
+
+	_, _, found, err = FindBranchForAgent(base, "agent-missing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Error("expected found=false for agent-missing")
+	}
+}
+
+func TestIdempotentRegister(t *testing.T) {
+	base := setupBase(t)
+	branch := "feature/idem"
+	wt := "/wt/idem"
+
+	RegisterSharer(base, branch, wt, "agent-1")
+	RegisterSharer(base, branch, wt, "agent-1")
+	RegisterSharer(base, branch, wt, "agent-1")
+
+	sharers, _, err := ListSharers(base, branch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sharers) != 1 {
+		t.Errorf("len(sharers) = %d after idempotent register, want 1", len(sharers))
+	}
+}
+
+func TestListSharers_NoMarker(t *testing.T) {
+	base := setupBase(t)
+
+	sharers, path, err := ListSharers(base, "nonexistent-branch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sharers != nil {
+		t.Errorf("sharers = %v, want nil", sharers)
+	}
+	if path != "" {
+		t.Errorf("worktreePath = %q, want empty", path)
+	}
+}
+
+func TestUnregisterSharer_NoMarker(t *testing.T) {
+	base := setupBase(t)
+
+	remaining, path, err := UnregisterSharer(base, "nonexistent", "agent-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if remaining != nil {
+		t.Errorf("remaining = %v, want nil", remaining)
+	}
+	if path != "" {
+		t.Errorf("worktreePath = %q, want empty", path)
+	}
+}
+
+func TestUnregisterSharer_AgentNotInList(t *testing.T) {
+	base := setupBase(t)
+	branch := "feature/noop"
+	wt := "/wt/noop"
+
+	RegisterSharer(base, branch, wt, "agent-1")
+
+	remaining, path, err := UnregisterSharer(base, branch, "agent-unknown")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remaining) != 1 || remaining[0] != "agent-1" {
+		t.Errorf("remaining = %v, want [agent-1]", remaining)
+	}
+	if path != wt {
+		t.Errorf("worktreePath = %q, want %q", path, wt)
+	}
+}
+
+func TestFindBranchForAgent_NoDir(t *testing.T) {
+	base := setupBase(t)
+
+	_, _, found, err := FindBranchForAgent(base, "agent-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Error("expected found=false when scion-sharers dir does not exist")
+	}
+}

--- a/pkg/runtimebroker/start_context.go
+++ b/pkg/runtimebroker/start_context.go
@@ -586,15 +586,27 @@ func (s *Server) tryProvisionWorktree(ctx context.Context, in startContextInputs
 		return false
 	}
 
+	// Source the authoritative worktree path from the sharer registry.
+	// For a JOIN, the agent shares an existing worktree rather than having
+	// its own at WorktreePath(base, agentID).
+	actualWorkspace := result.WorktreePath
+	branch := result.ProvisionInput.AgentName
+	if branch == "" {
+		branch = in.AgentID
+	}
+	if _, regPath, err := provision.ListSharers(result.ProjectRoot, branch); err == nil && regPath != "" {
+		actualWorkspace = regPath
+	}
+
 	// Write .scion workspace marker so the in-container CLI discovers project context.
 	if in.ProjectID != "" && in.ProjectSlug != "" {
-		if err := config.WriteWorkspaceMarker(result.WorktreePath, in.ProjectID, in.ProjectSlug, in.ProjectSlug); err != nil {
+		if err := config.WriteWorkspaceMarker(actualWorkspace, in.ProjectID, in.ProjectSlug, in.ProjectSlug); err != nil {
 			slog.Warn("worktree-per-agent: failed to write workspace marker (non-fatal)",
-				"path", result.WorktreePath, "error", err)
+				"path", actualWorkspace, "error", err)
 		}
 	}
 
-	opts.Workspace = result.WorktreePath
+	opts.Workspace = actualWorkspace
 	if s.config.Debug {
 		s.agentLifecycleLog.Debug("Worktree-per-agent mode enabled",
 			"agent_id", in.AgentID,

--- a/pkg/runtimebroker/start_context_test.go
+++ b/pkg/runtimebroker/start_context_test.go
@@ -891,12 +891,11 @@ func initBareRepoWithCommit(t *testing.T) string {
 	return bare
 }
 
-// TestTryProvisionWorktree_FailureDoesNotDeleteSharedBase is the regression for
-// the critical review finding on upstream PR #350: when provisioning fails for
-// one agent, only that agent's worktree may be removed — never the shared base
-// clone (Resolved.HostPath), which holds the common .git and every sibling
-// agent's worktree. Deleting it would destroy all other agents' workspaces.
-func TestTryProvisionWorktree_FailureDoesNotDeleteSharedBase(t *testing.T) {
+// TestTryProvisionWorktree_JoinResolvesSharedPath verifies that when agent-b
+// is provisioned with --branch pointing to an already-checked-out branch
+// (agent-a's), provisioning succeeds as a JOIN and opts.Workspace is set to
+// agent-a's worktree path (not WorktreePath(base, agent-b)).
+func TestTryProvisionWorktree_JoinResolvesSharedPath(t *testing.T) {
 	t.Setenv("SCION_HOST_UID", "")
 
 	cfg := DefaultServerConfig()
@@ -911,7 +910,7 @@ func TestTryProvisionWorktree_FailureDoesNotDeleteSharedBase(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Set up the shared base + a sibling worktree owning branch "agent-a".
+	// Set up the shared base + agent-a's worktree on branch "agent-a".
 	resolved, err := runtime.NewLocalBackend().Resolve(runtime.ResolveInput{
 		ProjectDir: projectPath, ProjectID: "p1", AgentID: "agent-a",
 		Mode: store.SharingModeWorktreePerAgent,
@@ -926,16 +925,12 @@ func TestTryProvisionWorktree_FailureDoesNotDeleteSharedBase(t *testing.T) {
 		t.Fatalf("setup agent-a: %v", err)
 	}
 	base := resolved.HostPath
-	siblingWt := provision.WorktreePath(base, "agent-a")
-	if _, err := os.Stat(filepath.Join(base, ".git")); err != nil {
-		t.Fatalf("base .git missing after setup: %v", err)
-	}
-	if _, err := os.Stat(siblingWt); err != nil {
-		t.Fatalf("sibling worktree missing after setup: %v", err)
+	agentAWt := provision.WorktreePath(base, "agent-a")
+	if _, err := os.Stat(agentAWt); err != nil {
+		t.Fatalf("agent-a worktree missing after setup: %v", err)
 	}
 
-	// Provision agent-b with a branch colliding with agent-a's → ensureWorktree
-	// fails ("already checked out"), exercising the cleanup-on-failure path.
+	// Provision agent-b with --branch "agent-a" → should JOIN, not fail.
 	opts := &api.StartOptions{}
 	ok := srv.tryProvisionWorktree(context.Background(), startContextInputs{
 		Name: "agent-b", AgentID: "agent-b",
@@ -944,20 +939,39 @@ func TestTryProvisionWorktree_FailureDoesNotDeleteSharedBase(t *testing.T) {
 		Config:        &CreateAgentConfig{GitClone: gc, Branch: "agent-a"},
 	}, opts, map[string]string{})
 
-	if ok {
-		t.Fatal("expected provisioning to fail (branch collision) and fall back, got ok=true")
+	if !ok {
+		t.Fatal("expected JOIN to succeed, got ok=false (fell back to clone-per-agent)")
 	}
 
-	// CRITICAL: the shared base and the sibling worktree must survive.
+	// opts.Workspace must point to agent-a's worktree (the shared path).
+	if opts.Workspace != agentAWt {
+		t.Errorf("opts.Workspace = %q, want %q (agent-a's worktree)", opts.Workspace, agentAWt)
+	}
+
+	// No separate worktree created for agent-b.
+	agentBWt := provision.WorktreePath(base, "agent-b")
+	if _, err := os.Stat(agentBWt); !os.IsNotExist(err) {
+		t.Errorf("agent-b should NOT have its own worktree, stat err=%v", err)
+	}
+
+	// Both agents registered as sharers.
+	sharers, wtPath, err := provision.ListSharers(base, "agent-a")
+	if err != nil {
+		t.Fatalf("ListSharers: %v", err)
+	}
+	if wtPath != agentAWt {
+		t.Errorf("registry worktreePath = %q, want %q", wtPath, agentAWt)
+	}
+	if len(sharers) != 2 {
+		t.Fatalf("expected 2 sharers, got %d: %v", len(sharers), sharers)
+	}
+
+	// Shared base and agent-a worktree are intact.
 	if _, err := os.Stat(filepath.Join(base, ".git")); err != nil {
-		t.Errorf("shared base .git was destroyed by a failed sibling provision: %v", err)
+		t.Errorf("shared base .git was destroyed: %v", err)
 	}
-	if _, err := os.Stat(siblingWt); err != nil {
-		t.Errorf("sibling agent-a worktree was destroyed by a failed sibling provision: %v", err)
-	}
-	// Only the failing agent's partial worktree should be cleaned up.
-	if _, err := os.Stat(provision.WorktreePath(base, "agent-b")); !os.IsNotExist(err) {
-		t.Errorf("agent-b partial worktree should have been cleaned up, stat err=%v", err)
+	if _, err := os.Stat(agentAWt); err != nil {
+		t.Errorf("agent-a worktree was destroyed: %v", err)
 	}
 }
 


### PR DESCRIPTION
- Sharer registry (pkg/provision/sharers.go): branch-keyed marker in the base, ownerless model (D1/D2).
- Create-or-attach incl. HUB-JOIN (D3): a 2nd --branch agent attaches to the existing worktree + registers, instead of falling back to clone-per-agent; broker mounts the shared path from the registry.
- Refcounted teardown: deleting an agent unregisters it; the shared worktree+branch is removed only when the LAST sharer exits, else the agent just detaches. e2e tests cover creator-deleted-while-joiner-remains (worktree persists), last-sharer removal, and sole-sharer (no regression).
Verified: build+vet clean; pkg/agent / pkg/provision / pkg/runtimebroker tests green; pkg/provision stays config/util-free.
One documented limitation: teardown doesn't hold the per-project advisory lock (acceptable single-node; hub serializes lifecycle) — noted in code.