### PR TITLE
Agent state & container lifecycle fixes

### DIFF
--- a/.design/agent-state-lifecycle-fixes.md
+++ b/.design/agent-state-lifecycle-fixes.md
@@ -157,32 +157,86 @@ Part 2 / task #4; not fixed here.
 
 ## Part 2 — Crashes never produce an error state
 
-### What we found
-Two distinct gaps:
+### What we found (corrected after deeper survey)
 
-1. **The supervised child is `tmux`, not the harness.** `sciontool init` runs
-   `childArgs`, which is the tmux command (`init.go:1683` comment; `common.go:444`
-   builds `tmux new-session ... '<harness>'`). tmux exits with **its own** status, not
-   the harness pane's. A harness crash (non-zero exit) is masked → `result.code == 0` →
-   `isCrash` is false (`init.go:814`). So the crash path is essentially never taken.
-2. **Even when detected, "crash" ≠ "error".** The crash path sets phase=`stopped` +
-   activity=`crashed` (`init.go:831`), not `PhaseError`. The user expects an *error
-   state*. (**OPEN Q4** — should a crash be terminal `error`, or `stopped`+`crashed`?)
-3. **Local Docker has no supervisor at all.** The local `docker run` CMD is
-   `sh -c "tmux ..."` (`common.go:465`) with no `sciontool init` wrapping, so none of
-   the crash-detection logic runs for local runs.
+**Correction:** `sciontool init` IS the supervisor on ALL runtimes, including local Docker
+— the agent image sets `ENTRYPOINT ["sciontool","init","--"]`
+(`image-build/scion-base/Dockerfile:101`), so `docker run … sh -c "tmux …"` actually runs
+`sciontool init -- sh -c "tmux …"`. The earlier "local Docker has no supervisor" claim was
+wrong. This makes the fix unified across runtimes.
 
-### Proposed scope (draft)
-- Make the harness exit code observable to the supervisor. Options:
-  - (a) Run the harness with `tmux ... ; echo $? > /exit-code` style capture, or set
-    `set-option remain-on-exit` + poll pane dead status + `#{pane_dead_status}`.
-  - (b) Have the harness invoked under a thin wrapper that writes its real exit code to
-    a known file that `sciontool init` reads after tmux returns.
-  - (c) Longer-term: don't wrap the supervised harness in detached tmux for exit-code
-    purposes — supervise the harness directly and attach tmux as a viewer.
-- Decide the target state (Q4) and wire it consistently into Hub status + DB + display.
-- Decide whether local Docker runs need crash→error parity (**OPEN Q5**), since they
-  lack the supervisor today.
+The real, universal gap:
+1. **The supervised child is `sh -c "tmux new-session -d …"`, not the harness.** Because
+   the tmux session is detached (`-d`) and the command chain ends with `attach-session`,
+   the supervised `sh` exits with tmux/attach's status — never the harness pane's. So
+   `result.code == 0` even when the harness exits non-zero → `isCrash` is false
+   (`init.go:814`) → the crash path is essentially never taken. This is why crashes are
+   never surfaced. (`pkg/runtime/common.go:444`, `pkg/sciontool/supervisor/supervisor.go`
+   captures the child=sh exit code faithfully — it's just the wrong process.)
+2. **"crash" ≠ "error" today.** Even when `isCrash` fires, it sets phase=`stopped` +
+   activity=`crashed` (`init.go:831`), not `PhaseError`. `PhaseError` is currently set
+   only on provisioning/clone failures (`pkg/agent/list.go:174`), never on a running-agent
+   crash. (**OPEN Q4** — see below.)
+3. **False crash observed:** the hub showed `activity=crashed`, `exit code -1` while the
+   agent ran fine. Source not yet found in code (no `-1` literal; `runtimebroker/
+   handlers.go:1611` hardcodes `ExitCode:0 // TODO`). Needs live log evidence from a real
+   crash test on the VM. Likely a container-exit inspection or a stale report from a prior
+   container instance landing after a (re)start.
+
+### Q4 DECISION (hybrid)
+Crash target state is hybrid: clean exit (code 0) → `stopped`; limits → `stopped` +
+`limits_exceeded`; unexpected non-zero exit → **`PhaseError`** (restartable — `start`
+clears it and runs a fresh session). To avoid state-validation conflicts (`crashed` is only
+valid on `stopped`), represent a crash as `Phase=error`, activity cleared, with
+`message="Agent crashed with exit code N"` and the exit code recorded. `PhaseError` is
+already protected by `preserveTerminalPhase`, so it won't be reverted by async updates.
+
+### Fix plan (Part 2)
+- **Recover the harness's real exit code from tmux** (the core fix, all runtimes). Cleanest
+  option: wrap the harness inside the tmux window so it writes its exit code to a known
+  file — e.g. `tmux new-session -d -s scion -n agent 'sh -c "<harness>; echo $? >
+  ~/.scion/agent-exit-code"'`. After the supervised `sh` returns, `sciontool init` reads
+  that file and uses it as `finalCode` for the `isCrash` decision (fall back to the
+  supervised code if the file is missing). Localized to `pkg/runtime/common.go` (tmux
+  command) + `cmd/sciontool/commands/init.go` (read the file). Apply the same wrapping in
+  the k8s tmux command (`pkg/runtime/k8s_runtime.go:901`).
+- **Target state (pending Q4):** wire the chosen crash representation consistently through
+  init.go → Hub status → DB → DisplayStatus.
+- **False crash:** find and fix the path that sets crashed/-1 without a real harness exit
+  (attribute crash reports to a specific container instance so stale reports are ignored).
+- **Distinguish exit kinds:** clean exit (0) → stopped; limits → stopped+limits_exceeded;
+  unexpected non-zero → the Q4 target. (Q5 about local-Docker parity is now moot — same
+  path.)
+
+### VM crash-evidence findings (instance-manager, commit a3c8ece)
+- Process tree confirmed: `sciontool(PID1) → sh → tmux-client → tmux-server → claude`.
+  The harness is a tmux **grandchild**, so its exit code is structurally invisible to the
+  supervisor — confirms the exit-code-file fix is the right bridge.
+- **`-1` source identified:** when killed by signal, **tmux-server is reaped as a zombie
+  with exit code -1** by sciontool's zombie reaper. That's the spurious `-1` seen earlier.
+  The fix (read a real exit-code file + use Docker `State.ExitCode`) avoids surfacing the
+  reaper's -1.
+- **Hard crash (SIGKILL claude → container exit 137):** the container DOES exit (session
+  collapses → sh exits). But the hub ended up `phase=stopped`, **`activity=stalled`**
+  (stale — a stopped agent should never be `stalled`), `message="Agent crashed with exit
+  code 137"`. The message came from the **broker heartbeat inspecting Docker `Exited(137)`**
+  — because sciontool's own status/shutdown report **401'd** (see below). So even today's
+  partial crash signal comes from the broker, not sciontool.
+- Implications for the fix:
+  - The **broker-heartbeat path** that derives state from Docker `Exited(code)` must set
+    the crash target (Q4) + `crashed` activity when `ExitCode != 0`, since it's the path
+    that works even when sciontool can't report. Find where Docker exited-status is mapped
+    to phase and enhance it.
+  - On transition to stopped/error on crash, **clear a stale `stalled` activity** (replace
+    with `crashed`). The `stalled` overwrite is a sticky-activity bug.
+
+### Separate bug found: resumed containers get a malformed hub token (401)
+Resumed containers logged persistent `401 invalid agent token: ... compact JWS format must
+have three parts` on every sciontool status/heartbeat call. The harness ran fine (Part 1
+works), but the resumed agent cannot report status/heartbeat → broken observability, and it
+exacerbates crash invisibility. May be a dev-auth-mode artifact on the VM or a real resume
+token-provisioning gap. Tracked as its own task; needs isolation (does it occur with real
+auth, or only dev-auth?).
 
 ---
 

--- a/.design/agent-state-lifecycle-fixes.md
+++ b/.design/agent-state-lifecycle-fixes.md
@@ -132,6 +132,27 @@ Thread an explicit `resume bool` from the hub (source of truth) to `RunConfig.Re
    message. (Flag if this turns out larger than expected.)
 Optional follow-up: add a first-class `AgentActionResume` + `/resume` route for clarity.
 
+### Fix plan (Part 1b) — phase-overwrite race (found during verification of 80c1579)
+
+The threading fix is correct but its precondition fails: the hub sets `phase=suspended`
+*after* dispatching the stop, then the dying container's async sciontool `/status` report
+(and/or a broker heartbeat) reports `stopped`/`crashed` and overwrites `suspended` back to
+`stopped` before the start handler reads it — so `resume := phase==suspended` is false.
+The existing regression guards are ordinal-based and only cover *active* phases; both
+`suspended` and `stopped` are ordinal 0, so the transition slips through.
+
+Make `suspended` sticky against async status updates (explicit lifecycle start/stop bypass
+these guards, so they can still leave suspended):
+1. `pkg/hub/handlers.go` `guardAgentPhaseTransition` (~2988): if current phase is
+   `suspended`, drop `status.Phase` and `status.Activity` from async `/status` reports.
+2. `pkg/hub/handlers.go` broker-heartbeat path (~6345): treat `suspended` like a sticky
+   phase — do not let a heartbeat-reported phase/terminal-activity revert it.
+Add unit tests (suspended stickiness for both paths).
+
+NOTE: a related but broader issue (stale reports from the OLD container landing AFTER a
+resume and falsely setting `crashed` — the "false crash" side finding) is tracked under
+Part 2 / task #4; not fixed here.
+
 ---
 
 ## Part 2 — Crashes never produce an error state

--- a/.design/agent-state-lifecycle-fixes.md
+++ b/.design/agent-state-lifecycle-fixes.md
@@ -36,10 +36,10 @@ questions are flagged inline and consolidated at the end.
 - Access is proxied by the `state-fix-instance-manager` agent (this workstream lacks
   compute perms on the project). Deploy loop: push branch → instance-manager pulls on
   VM, `go build -o scion ./cmd/scion`, swap binary, restart hub.
-- **OPEN — branch base:** state-fixes is currently `== origin/main`. The integration VM
-  runs the Postgres branch, so a main-based binary may not run cleanly against the
-  existing Postgres DB. Decide whether to base state-fixes on `main` or on
-  `postgres/wave-b-integration`.
+- **Branch base — DECIDED:** state-fixes is based on `main` (currently zero code delta).
+  `postgres/wave-b-integration` was an unrelated project and is being replaced on the VM.
+  Workflow: push `scion/state-fixes` → redeploy on the integration VM → retest. The VM's
+  Postgres DB from the wave-b work is reset as needed for a clean main-based deploy.
 
 ## Background: how state works today
 
@@ -88,17 +88,49 @@ flag is missing" but one or more of:
    the resume args are mis-quoted or the harness re-execs with a filtered env, the
    resume flag could be dropped. Needs runtime-specific confirmation.
 
-### Proposed scope (draft)
-- Reproduce on each runtime (Docker, k8s, Cloud Run) and pin down which failure mode(s)
-  actually bite. (**OPEN Q1** — which runtime is the user seeing this on?)
-- If home-loss is the cause: make harness session state survive resume. Options:
-  - (a) Persist agent home to NFS / a dedicated NFS subpath (ties into Part 3).
-  - (b) Sync home to GCS on suspend, restore on resume.
-  - (c) Restart the *existing* stopped container (`docker start`) instead of recreating,
-    where the runtime supports it — but this doesn't help k8s/Cloud Run.
-- Add an explicit post-resume assertion: verify the harness actually attached to a prior
-  session (e.g., detect "no conversation found" and surface it instead of silently
-  starting fresh).
+### CONFIRMED ROOT CAUSE (Docker, hub/broker path — repro on the integration VM, June 2026)
+
+The resume flag is accepted at the API layer (`CreateAgentRequest.Resume`) but is **never
+threaded through the hub→broker→runtime pipeline**, so `Harness.GetCommand` is called with
+`resume=false` and `--continue` is never added. The resumed container runs the identical
+command as a fresh start (and even re-injects the original task). Everything else is
+correct: the new container reuses the same home bind-mount, the workspace/cwd is identical
+(`/workspace`, encoded `-workspace`), and the prior Claude session `.jsonl` survives in
+`~/.claude/projects/-workspace/` — only the flag is missing.
+
+Trace of the gap:
+- `pkg/hub/handlers.go` CreateAgent handler (~9149-9170) and wake handler (~2399) call
+  `dispatcher.DispatchAgentStart(ctx, agent, task)` **without** any resume intent. No
+  special handling for `suspended` agents.
+- `pkg/hub/httpdispatcher.go` `DispatchAgentStart` (~966) has no resume param; calls
+  `client.StartAgent(...)` (~1165) without it. `dispatch_args.go` `StartDispatchArgs` has
+  only `Task`.
+- `pkg/hub/broker_http_transport.go` `StartAgent` (~164) builds a payload with no
+  `resume` field. `pkg/hub/brokerclient.go` interface (~47) signature lacks it.
+- `pkg/runtimebroker/handlers.go` `startAgent` (~1128) has a fallback: read
+  `GetSavedPhase` from disk and set `opts.Resume=true` if `suspended` (~1208-1214) — but
+  this only works for local-filesystem projects, NOT hub-managed projects, so it fails on
+  the deployed hub.
+- `pkg/runtime/common.go:428` `GetCommand(task, config.Resume, args)` and the Claude
+  harness (`pkg/harness/claude_code.go:78`, adds `--continue` when resume) are already
+  correct — they just never receive `resume=true`.
+- There is no `AgentActionResume` and no `/resume` HTTP route — start and resume are the
+  same action (explains the `/resume` 404).
+
+### Fix plan (Part 1)
+Thread an explicit `resume bool` from the hub (source of truth) to `RunConfig.Resume`:
+1. Hub computes `resume := existingAgent.Phase == PhaseSuspended` (mirrors local
+   `effectiveResume`: suspended→resume, stopped→fresh) in the CreateAgent and wake paths,
+   and passes it to `DispatchAgentStart`.
+2. Add `resume` param through `DispatchAgentStart` → `StartDispatchArgs` →
+   `BrokerClient.StartAgent` → HTTP payload (`"resume": true`).
+3. Broker `startReq` gains `Resume bool`; handler sets `opts.Resume` from it (keep the
+   `GetSavedPhase` read as a fallback only).
+4. `opts.Resume → RunConfig.Resume → GetCommand` is already wired — no change needed.
+5. On a pure resume (no new message), do **not** re-inject the original creation task
+   (pass empty task so the harness just continues); a wake-with-message still passes that
+   message. (Flag if this turns out larger than expected.)
+Optional follow-up: add a first-class `AgentActionResume` + `/resume` route for clarity.
 
 ---
 

--- a/.design/agent-state-lifecycle-fixes.md
+++ b/.design/agent-state-lifecycle-fixes.md
@@ -230,6 +230,27 @@ already protected by `preserveTerminalPhase`, so it won't be reverted by async u
   - On transition to stopped/error on crash, **clear a stale `stalled` activity** (replace
     with `crashed`). The `stalled` overwrite is a sticky-activity bug.
 
+### Resume 401 — ROOT CAUSE CONFIRMED
+`DispatchAgentStart` mints a valid agent JWT and places it in
+`resolvedEnv["SCION_AUTH_TOKEN"]` (`pkg/hub/httpdispatcher.go:1086`). The broker's
+`startAgent` passes `ResolvedEnv` into `buildStartContext` but does **not** set
+`AgentToken` (`pkg/runtimebroker/handlers.go:1169`). In `buildStartContext`
+(`pkg/runtimebroker/start_context.go:192-221`): step 1 copies the valid token from
+`resolvedEnv` into `env`, then step 3 — because `in.AgentToken == ""` — takes the `else`
+branch and **overwrites** `env["SCION_AUTH_TOKEN"]` with the broker's OWN
+`os.Getenv("SCION_AUTH_TOKEN")` (a dev token that is not a valid 3-part JWT) → 401. The
+CreateAgent path sets `req.AgentToken` (`handlers.go:592`), so initial start works; the
+resume/start path doesn't, so it's clobbered. In production (broker has no
+`SCION_AUTH_TOKEN`) the resolvedEnv token survives — so it manifests only under dev-auth,
+but the start-vs-create asymmetry is a real latent bug.
+
+**Recommended fix (minimal, provisioning-time):** in `buildStartContext`, only apply the
+broker's dev `SCION_AUTH_TOKEN` when `env` does NOT already have one — i.e. never clobber a
+hub-resolved token with the dev fallback. (Optionally also set `AgentToken` from
+`resolvedEnv["SCION_AUTH_TOKEN"]` in the broker start path for parity with create.) This is
+cleaner than a post-resume re-inject; the existing reset-auth/SIGUSR2 path
+(`handlers.go:1617`) stays for genuine hub-disruption recovery.
+
 ### Separate bug found: resumed containers get a malformed hub token (401)
 Resumed containers logged persistent `401 invalid agent token: ... compact JWS format must
 have three parts` on every sciontool status/heartbeat call. The harness ran fine (Part 1

--- a/.design/agent-state-lifecycle-fixes.md
+++ b/.design/agent-state-lifecycle-fixes.md
@@ -263,6 +263,35 @@ auth, or only dev-auth?).
 
 ## Part 3 — Auto-suspend (hibernate) stalled agents to reclaim resources
 
+### DECISIONS (user)
+- **Q6 home persistence: DEFER sync for now**, presume GCS later. Key realization: on
+  Docker the agent home is a host bind-mount that survives container removal, so reclaiming
+  the container and later resuming works WITHOUT any sync — the now-fixed suspend/resume
+  handles it. GCS sync only matters for runtimes with ephemeral home (k8s/Cloud Run), which
+  are gated on NFS anyway. So Part 3 on Docker needs no home-persistence work.
+- **Q7 policy: hardwired** — auto-suspend after an ADDITIONAL 5 min of being stalled (≈10
+  min total inactivity = StalledThreshold + 5m). Not configurable yet.
+- **Deploy tip (user):** `make container-binaries` + `export SCION_DEV_BINARIES=<.build/
+  container>` makes the hub bind-mount dev `scion`+`sciontool` into agent containers
+  (`pkg/runtime/common.go:358`), so sciontool changes can be side-loaded WITHOUT an image
+  rebuild. There's also an admin maintenance action that runs the rebuild.
+
+### Implementation plan (Part 3, minimal)
+- Add a recurring scheduler handler (mirror `agentStalledDetectionHandler` in
+  `pkg/hub/server.go`): find agents with `activity==stalled` whose `last_activity_event` is
+  older than `StalledThreshold + 5m`, heartbeat still recent (alive/resumable), and whose
+  harness supports resume; auto-suspend them.
+- Factor the suspend core out of `handleAgentLifecycle` (case `AgentActionSuspend`,
+  ~handlers.go:3052) into a reusable internal `suspendAgent(ctx, agent)` (validate resume
+  capability, set phase=suspended, syncWorkspaceOnStop, DispatchAgentStop) called by both
+  the HTTP handler and the scheduler.
+- Guardrails: only `running`+`stalled` agents; skip harnesses without resume support (can't
+  hibernate what we can't resume — leave them stalled); `blocked`/`waiting_for_input` are
+  already not `stalled`.
+- Hardwired `autoSuspendStalledGrace = 5 * time.Minute`.
+
+### Original survey notes
+
 ### What we found
 - Stall detection already exists and is reliable (`MarkStalledAgents`), distinguishing
   `stalled` (alive but idle) from `offline` (no heartbeat) and exempting `blocked`.

--- a/.design/agent-state-lifecycle-fixes.md
+++ b/.design/agent-state-lifecycle-fixes.md
@@ -1,0 +1,181 @@
+# Agent State & Container Lifecycle Fixes
+
+## Status
+**Preliminary draft / survey** | branch `scion/state-fixes` | June 2026
+
+This is an initial survey + scoped-work draft covering three related problems in how
+agent state is represented and kept current across lifecycle transitions, and how that
+ties to the underlying container lifecycle. It is intentionally incomplete — open
+questions are flagged inline and consolidated at the end.
+
+## Decisions (from user Q&A)
+
+- **Q1 — Target runtime.** Docker is the primary runtime today and the place to fix
+  things first (multiple integration environments available for repro). **Other runtimes
+  must not be allowed without NFS** — gate them on NFS being configured. The design must
+  still *plan* for all deploy modes and runtimes, but Docker is the proving ground.
+  - Implication for Part 1: on Docker the home + workspace are host bind-mounts that
+    survive container recreation, AND the resume-flag flow is correct end-to-end
+    (suspend writes `phase=suspended`; `GetSavedPhase` reads it; `effectiveResume=true`;
+    `claude --continue` is emitted). So the Docker resume failure is NOT home-loss — it
+    needs a live reproduction in an integration env to pin the true cause (candidates:
+    `--continue` not matching the prior session by cwd, flag/quoting interference in the
+    tmux wrapper, or a non-obvious symptom).
+
+- **Q2 — Resume success criterion.** Resume must be a true **harness continuation of
+  the last conversation**, using the harness-specific resume flag as implemented in the
+  harness config adapter (Claude `--continue`, etc.). "Container back with files intact
+  but a fresh session" is NOT acceptable.
+
+## Test environment
+
+- VM `scion-integration` (project `deploy-demo-test`, zone `us-central1-a`); hub at
+  `https://integration.projects.scion-ai.dev` (Caddy → localhost:8080). Built from
+  `scripts/starter-hub`. Currently running branch `postgres/wave-b-integration` on a
+  Postgres DB.
+- Access is proxied by the `state-fix-instance-manager` agent (this workstream lacks
+  compute perms on the project). Deploy loop: push branch → instance-manager pulls on
+  VM, `go build -o scion ./cmd/scion`, swap binary, restart hub.
+- **OPEN — branch base:** state-fixes is currently `== origin/main`. The integration VM
+  runs the Postgres branch, so a main-based binary may not run cleanly against the
+  existing Postgres DB. Decide whether to base state-fixes on `main` or on
+  `postgres/wave-b-integration`.
+
+## Background: how state works today
+
+- **State model** (`pkg/agent/state/state.go`): two orthogonal axes.
+  - `Phase` (infrastructure lifecycle): `created → provisioning → cloning → starting →
+    running → {suspended} → stopping → stopped`, plus terminal `error`.
+  - `Activity` (what a running agent is doing): `working, thinking, executing,
+    waiting_for_input, blocked, completed, limits_exceeded, stalled, offline, crashed`.
+  - Source of truth: in-container `agent-info.json` (written by hook handlers), relayed
+    to the Hub via heartbeat; Hub DB is authoritative once stopped.
+- **Suspend/resume** (`.design/suspend-resume-design.md`, `cmd/suspend.go`,
+  `cmd/resume.go`, `cmd/common.go`): suspend = `docker stop` + phase=`suspended`.
+  Resume = `RunAgent(resume=true)` → `mgr.Start` which **deletes the stopped container
+  and creates a new one** (`pkg/agent/run.go:101`), passing the harness resume flag.
+- **Crash/exit handling** (`cmd/sciontool/commands/init.go:802-869`,
+  `pkg/sciontool/supervisor/supervisor.go`): `sciontool init` supervises a child,
+  captures its exit code, and on non-zero maps to phase=`stopped` + activity=`crashed`.
+- **Stall detection** (`pkg/hub/server.go`, `MarkStalledAgents`): a scheduler marks an
+  agent `stalled` when `last_activity_event` is older than `StalledThreshold` (default
+  5m) AND heartbeat is recent (<2m). `blocked` agents are exempt. No action is taken
+  beyond setting the status.
+
+---
+
+## Part 1 — Resume does not correctly restart the container with the resume flag
+
+### What we found
+The resume flag **is** plumbed end-to-end:
+`cmd/resume.go` → `RunAgent(resume=true)` → `effectiveResume` (`cmd/common.go:459`) →
+`api.StartOptions.Resume` → `runtime.RunConfig.Resume` (`pkg/agent/run.go:889`) →
+`config.Harness.GetCommand(task, resume, args)` (`pkg/runtime/common.go:428`) →
+harness adds `--continue` (Claude) / `--resume` (Gemini).
+
+So the flag reaches the harness. The likely failure modes are therefore **not** "the
+flag is missing" but one or more of:
+
+1. **Resume recreates the container instead of restarting it.** `mgr.Start` deletes the
+   stopped container and `docker run`s a fresh one (`run.go:100-104`). Harness session
+   continuity depends entirely on session files surviving in the agent **home**.
+2. **Agent home is ephemeral on hub runtimes.** Home is a host bind-mount on Docker/
+   Podman (survives), but on **Kubernetes and Cloud Run the home is in-image/in-pod and
+   NOT NFS-backed** (storage survey). When the pod is deleted on resume, the harness
+   session history is gone, so `--continue` starts a fresh session — looking like
+   "resume didn't work."
+3. **tmux wrapping.** The harness runs inside `tmux new-session` (`common.go:444`); if
+   the resume args are mis-quoted or the harness re-execs with a filtered env, the
+   resume flag could be dropped. Needs runtime-specific confirmation.
+
+### Proposed scope (draft)
+- Reproduce on each runtime (Docker, k8s, Cloud Run) and pin down which failure mode(s)
+  actually bite. (**OPEN Q1** — which runtime is the user seeing this on?)
+- If home-loss is the cause: make harness session state survive resume. Options:
+  - (a) Persist agent home to NFS / a dedicated NFS subpath (ties into Part 3).
+  - (b) Sync home to GCS on suspend, restore on resume.
+  - (c) Restart the *existing* stopped container (`docker start`) instead of recreating,
+    where the runtime supports it — but this doesn't help k8s/Cloud Run.
+- Add an explicit post-resume assertion: verify the harness actually attached to a prior
+  session (e.g., detect "no conversation found" and surface it instead of silently
+  starting fresh).
+
+---
+
+## Part 2 — Crashes never produce an error state
+
+### What we found
+Two distinct gaps:
+
+1. **The supervised child is `tmux`, not the harness.** `sciontool init` runs
+   `childArgs`, which is the tmux command (`init.go:1683` comment; `common.go:444`
+   builds `tmux new-session ... '<harness>'`). tmux exits with **its own** status, not
+   the harness pane's. A harness crash (non-zero exit) is masked → `result.code == 0` →
+   `isCrash` is false (`init.go:814`). So the crash path is essentially never taken.
+2. **Even when detected, "crash" ≠ "error".** The crash path sets phase=`stopped` +
+   activity=`crashed` (`init.go:831`), not `PhaseError`. The user expects an *error
+   state*. (**OPEN Q4** — should a crash be terminal `error`, or `stopped`+`crashed`?)
+3. **Local Docker has no supervisor at all.** The local `docker run` CMD is
+   `sh -c "tmux ..."` (`common.go:465`) with no `sciontool init` wrapping, so none of
+   the crash-detection logic runs for local runs.
+
+### Proposed scope (draft)
+- Make the harness exit code observable to the supervisor. Options:
+  - (a) Run the harness with `tmux ... ; echo $? > /exit-code` style capture, or set
+    `set-option remain-on-exit` + poll pane dead status + `#{pane_dead_status}`.
+  - (b) Have the harness invoked under a thin wrapper that writes its real exit code to
+    a known file that `sciontool init` reads after tmux returns.
+  - (c) Longer-term: don't wrap the supervised harness in detached tmux for exit-code
+    purposes — supervise the harness directly and attach tmux as a viewer.
+- Decide the target state (Q4) and wire it consistently into Hub status + DB + display.
+- Decide whether local Docker runs need crash→error parity (**OPEN Q5**), since they
+  lack the supervisor today.
+
+---
+
+## Part 3 — Auto-suspend (hibernate) stalled agents to reclaim resources
+
+### What we found
+- Stall detection already exists and is reliable (`MarkStalledAgents`), distinguishing
+  `stalled` (alive but idle) from `offline` (no heartbeat) and exempting `blocked`.
+- There is **no** action wired to stall today — it's purely a status.
+- Auto-suspend is already named as a "Future Consideration" in the suspend/resume design.
+- The blocker for hibernation is **home persistence** (same as Part 1): to reclaim the
+  container we must be able to restore the agent home on resume.
+
+### Proposed scope (draft)
+- Add a configurable policy: after an agent is `stalled` for `AutoSuspendThreshold` AND
+  its harness supports resume, transition it to `suspended` and reclaim the container.
+- Preserve agent home before reclaiming. Storage options (**OPEN Q6**):
+  - (a) Sync home → GCS (reuse `pkg/gcp/storage.go` rclone helpers), restore on wake.
+  - (b) Dedicated NFS subpath for home (reuse NFS backend; needs per-agent isolation).
+  - (c) Hybrid: NFS for hub clusters that already mount it, GCS otherwise.
+- Wake path: on next message to a hibernated agent, restore home, resume container,
+  reattach harness session. Reuse the existing Hub wake flow (`handleAgentMessage`
+  Wake=true).
+- Guardrails: never auto-suspend `blocked` or `waiting_for_input` agents; make threshold
+  and the whole feature opt-in (**OPEN Q7**).
+
+---
+
+## Consolidated open questions
+
+1. **Resume bug — which runtime?** Where have you observed resume failing — local Docker,
+   Kubernetes, or Cloud Run? (Determines whether home-loss is the cause.)
+2. **Resume success criterion.** When resume "works," what should the user observe — the
+   harness literally continuing the prior conversation, or just the container coming back
+   with working files intact?
+3. **Home persistence preference.** For preserving the agent home (needed for both robust
+   resume and hibernation): GCS sync, a dedicated NFS subpath, or hybrid? Any existing
+   bucket/NFS share we should target?
+4. **Crash target state.** Should a harness/container crash land in terminal `error`, or
+   in `stopped` + `crashed`? Is `error` meant to be recoverable (restartable) or purely
+   a dead-end signal?
+5. **Local Docker parity.** Do crash→error and auto-suspend need to work for local Docker
+   runs, or are these hub/k8s/Cloud-Run concerns only? (Local Docker has no supervisor.)
+6. **Hibernation storage.** Same as Q3 but specifically for the auto-suspend flow — is GCS
+   acceptable for home snapshots, including any latency on wake?
+7. **Auto-suspend policy.** What idle threshold feels right (the stall threshold is 5m)?
+   Should auto-suspend be global, per-template, or per-agent? Opt-in or default-on?
+8. **Sequencing.** Confirm the intended order: (1) fix resume, (2) fix crash→error,
+   (3) auto-suspend/hibernate — with home-persistence as shared infrastructure for 1 & 3.

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -805,31 +805,30 @@ waitLoop:
 	if !limitsExceeded && result.code == handlers.ExitCodeLimitsExceeded {
 		limitsExceeded = true
 	}
-	finalCode := result.code
-	if limitsExceeded {
-		finalCode = handlers.ExitCodeLimitsExceeded
-	} else if result.err != nil && result.code == 0 {
-		finalCode = 1
-	}
-	isCrash := !limitsExceeded && finalCode != 0
 
-	// Build crash message: distinguish real child exit codes from
-	// synthetic ones produced by supervisor errors.
-	var crashMsg string
-	if isCrash {
-		if result.err != nil && result.code == 0 {
-			crashMsg = fmt.Sprintf("Agent crashed (supervisor error: %v)", result.err)
-		} else {
-			crashMsg = fmt.Sprintf("Agent crashed with exit code %d", finalCode)
-		}
+	// The harness runs as a tmux grandchild, so the supervised child's exit
+	// code (result.code) reflects sh/tmux, not the harness itself. The tmux
+	// agent-window wrapper records the harness's real exit code to a fixed
+	// file; prefer it when present. If absent (e.g. the container was SIGKILLed
+	// or OOM-killed before the harness could write), fall back to result.code.
+	harnessCode := readHarnessExitCode()
+	if harnessCode != nil {
+		log.Info("Recovered harness exit code %d from %s", *harnessCode, harnessExitCodeFile)
 	}
+
+	outcome := classifyExit(result.code, result.err, harnessCode, limitsExceeded)
+	finalCode := outcome.exitCode
+	limitsExceeded = outcome.limitsExceeded
 
 	// Update local agent-info.json BEFORE the Hub report so the broker
 	// heartbeat can relay crash/limits state even if the Hub call is slow
 	// or fails entirely.
-	if isCrash {
-		statusHandler.UpdatePhase(state.PhaseStopped, state.ActivityCrashed, "")
-		statusHandler.SetMessage(crashMsg)
+	if outcome.isCrash {
+		// HYBRID mapping: an unexpected non-zero exit becomes PhaseError with
+		// the activity cleared (crash detail lives in the message + exitCode).
+		// `crashed` activity is only valid on PhaseStopped per state validation.
+		statusHandler.UpdatePhase(state.PhaseError, "", "")
+		statusHandler.SetMessage(outcome.message)
 	} else if limitsExceeded {
 		statusHandler.UpdatePhase(state.PhaseStopped, state.ActivityLimitsExceeded, "")
 		statusHandler.SetMessage("limits exceeded")
@@ -839,13 +838,13 @@ waitLoop:
 	if hubClient := hub.NewClient(); hubClient != nil && hubClient.IsConfigured() {
 		hubCtx, hubCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		var hubErr error
-		if isCrash {
-			s := state.AgentState{Phase: state.PhaseStopped, Activity: state.ActivityCrashed}
+		if outcome.isCrash {
+			s := state.AgentState{Phase: state.PhaseError}
 			hubErr = hubClient.UpdateStatus(hubCtx, hub.StatusUpdate{
-				Phase:    state.PhaseStopped,
-				Activity: state.ActivityCrashed,
+				Phase:    state.PhaseError,
+				Activity: "",
 				Status:   s.DisplayStatus(),
-				Message:  crashMsg,
+				Message:  outcome.message,
 				ExitCode: &finalCode,
 			})
 		} else if limitsExceeded {
@@ -863,7 +862,7 @@ waitLoop:
 		if hubErr != nil {
 			log.Error("Failed to report final status to Hub: %v", hubErr)
 		} else {
-			log.Info("Reported final status to Hub (exitCode=%d, crash=%v)", finalCode, isCrash)
+			log.Info("Reported final status to Hub (exitCode=%d, crash=%v)", finalCode, outcome.isCrash)
 		}
 		hubCancel()
 	}
@@ -873,6 +872,14 @@ waitLoop:
 		return handlers.ExitCodeLimitsExceeded
 	}
 
+	if outcome.isCrash {
+		// Propagate the authoritative crash code (which may have come from the
+		// harness exit-code file rather than the supervised child) so the
+		// container's exit status reflects the real failure.
+		log.Error("Agent crashed with exit code %d", finalCode)
+		return finalCode
+	}
+
 	if result.err != nil {
 		log.Error("Supervisor error: %v", result.err)
 		return 1
@@ -880,6 +887,81 @@ waitLoop:
 
 	log.Info("Child exited with code %d", result.code)
 	return result.code
+}
+
+// harnessExitCodeFile is the container-local path where the tmux agent-window
+// wrapper records the harness's real exit code (see pkg/runtime). It must match
+// the path used when building the tmux command.
+const harnessExitCodeFile = "/tmp/scion-harness-exit-code"
+
+// readHarnessExitCode reads and parses the harness exit-code file written by the
+// tmux agent-window wrapper. Returns nil if the file is missing or unparseable
+// (e.g. the container was SIGKILLed/OOM-killed before the harness could write).
+func readHarnessExitCode() *int {
+	data, err := os.ReadFile(harnessExitCodeFile)
+	if err != nil {
+		return nil
+	}
+	code, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return nil
+	}
+	return &code
+}
+
+// exitOutcome captures the classified result of a supervised agent exit.
+type exitOutcome struct {
+	exitCode       int
+	limitsExceeded bool
+	isCrash        bool
+	message        string
+}
+
+// classifyExit applies the HYBRID exit mapping. It is a pure function so it can
+// be unit-tested independently of the supervisor/hub machinery.
+//
+//   - limitsExceeded                  → stopped + limits_exceeded (handled by caller)
+//   - clean exit (code 0, no error)   → stopped
+//   - unexpected non-zero exit/error  → error (crash), restartable
+//
+// harnessCode, when non-nil, is the authoritative harness exit code recovered
+// from the exit-code file and overrides the supervised child's code for the
+// crash decision. supervisorErr is the supervisor's own error (a synthetic
+// failure not reflected in supervisedCode).
+func classifyExit(supervisedCode int, supervisorErr error, harnessCode *int, limitsExceeded bool) exitOutcome {
+	if !limitsExceeded && supervisedCode == handlers.ExitCodeLimitsExceeded {
+		limitsExceeded = true
+	}
+
+	// Choose the authoritative exit code: prefer the harness file, then the
+	// supervised child code.
+	finalCode := supervisedCode
+	if harnessCode != nil {
+		finalCode = *harnessCode
+	}
+
+	if limitsExceeded {
+		return exitOutcome{exitCode: handlers.ExitCodeLimitsExceeded, limitsExceeded: true}
+	}
+
+	// A supervisor error with a zero exit code is itself a failure.
+	supervisorFailed := supervisorErr != nil && finalCode == 0
+	if supervisorFailed {
+		finalCode = 1
+	}
+
+	isCrash := finalCode != 0
+	if !isCrash {
+		return exitOutcome{exitCode: 0}
+	}
+
+	var msg string
+	if supervisorFailed {
+		msg = fmt.Sprintf("Agent crashed (supervisor error: %v)", supervisorErr)
+	} else {
+		msg = fmt.Sprintf("Agent crashed with exit code %d", finalCode)
+	}
+	return exitOutcome{exitCode: finalCode, isCrash: true, message: msg}
 }
 
 // handleLimitsExceeded is called when a limit is exceeded (duration timer or SIGUSR1).

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -813,7 +813,7 @@ waitLoop:
 	// or OOM-killed before the harness could write), fall back to result.code.
 	harnessCode := readHarnessExitCode()
 	if harnessCode != nil {
-		log.Info("Recovered harness exit code %d from %s", *harnessCode, harnessExitCodeFile)
+		log.Info("Recovered harness exit code %d from %s", *harnessCode, state.HarnessExitCodeFile)
 	}
 
 	outcome := classifyExit(result.code, result.err, harnessCode, limitsExceeded)
@@ -889,16 +889,11 @@ waitLoop:
 	return result.code
 }
 
-// harnessExitCodeFile is the container-local path where the tmux agent-window
-// wrapper records the harness's real exit code (see pkg/runtime). It must match
-// the path used when building the tmux command.
-const harnessExitCodeFile = "/tmp/scion-harness-exit-code"
-
 // readHarnessExitCode reads and parses the harness exit-code file written by the
 // tmux agent-window wrapper. Returns nil if the file is missing or unparseable
 // (e.g. the container was SIGKILLed/OOM-killed before the harness could write).
 func readHarnessExitCode() *int {
-	data, err := os.ReadFile(harnessExitCodeFile)
+	data, err := os.ReadFile(state.HarnessExitCodeFile)
 	if err != nil {
 		return nil
 	}

--- a/cmd/sciontool/commands/init_crash_test.go
+++ b/cmd/sciontool/commands/init_crash_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2025 The Scion Authors.
+*/
+
+package commands
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hooks/handlers"
+)
+
+func intPtr(i int) *int { return &i }
+
+func TestClassifyExit(t *testing.T) {
+	tests := []struct {
+		name           string
+		supervisedCode int
+		supervisorErr  error
+		harnessCode    *int
+		limitsExceeded bool
+		wantCode       int
+		wantCrash      bool
+		wantLimits     bool
+		wantMsg        string
+	}{
+		{
+			name:           "clean exit code 0",
+			supervisedCode: 0,
+			wantCode:       0,
+			wantCrash:      false,
+		},
+		{
+			name:           "harness file reports non-zero while supervised child is 0 -> crash",
+			supervisedCode: 0,
+			harnessCode:    intPtr(42),
+			wantCode:       42,
+			wantCrash:      true,
+			wantMsg:        "Agent crashed with exit code 42",
+		},
+		{
+			name:           "harness file reports 0 while supervised child is 0 -> clean",
+			supervisedCode: 0,
+			harnessCode:    intPtr(0),
+			wantCode:       0,
+			wantCrash:      false,
+		},
+		{
+			name:           "no harness file, supervised child non-zero -> crash (SIGKILL fallback)",
+			supervisedCode: 137,
+			wantCode:       137,
+			wantCrash:      true,
+			wantMsg:        "Agent crashed with exit code 137",
+		},
+		{
+			name:           "limits exceeded via flag",
+			supervisedCode: 0,
+			limitsExceeded: true,
+			wantCode:       handlers.ExitCodeLimitsExceeded,
+			wantLimits:     true,
+			wantCrash:      false,
+		},
+		{
+			name:           "limits exceeded via child exit code",
+			supervisedCode: handlers.ExitCodeLimitsExceeded,
+			wantCode:       handlers.ExitCodeLimitsExceeded,
+			wantLimits:     true,
+			wantCrash:      false,
+		},
+		{
+			name:           "supervisor error with zero code -> crash code 1",
+			supervisedCode: 0,
+			supervisorErr:  errors.New("boom"),
+			wantCode:       1,
+			wantCrash:      true,
+			wantMsg:        "Agent crashed (supervisor error: boom)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyExit(tc.supervisedCode, tc.supervisorErr, tc.harnessCode, tc.limitsExceeded)
+			if got.exitCode != tc.wantCode {
+				t.Errorf("exitCode = %d, want %d", got.exitCode, tc.wantCode)
+			}
+			if got.isCrash != tc.wantCrash {
+				t.Errorf("isCrash = %v, want %v", got.isCrash, tc.wantCrash)
+			}
+			if got.limitsExceeded != tc.wantLimits {
+				t.Errorf("limitsExceeded = %v, want %v", got.limitsExceeded, tc.wantLimits)
+			}
+			if tc.wantMsg != "" && got.message != tc.wantMsg {
+				t.Errorf("message = %q, want %q", got.message, tc.wantMsg)
+			}
+			if tc.wantMsg == "" && got.message != "" {
+				t.Errorf("message = %q, want empty", got.message)
+			}
+		})
+	}
+}
+
+func TestReadHarnessExitCode(t *testing.T) {
+	// Missing file -> nil.
+	_ = os.Remove(harnessExitCodeFile)
+	if got := readHarnessExitCode(); got != nil {
+		t.Errorf("expected nil for missing file, got %v", *got)
+	}
+
+	// Valid code.
+	if err := os.WriteFile(harnessExitCodeFile, []byte("137\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(harnessExitCodeFile) })
+	got := readHarnessExitCode()
+	if got == nil || *got != 137 {
+		t.Errorf("expected 137, got %v", got)
+	}
+
+	// Unparseable -> nil.
+	if err := os.WriteFile(harnessExitCodeFile, []byte("garbage"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := readHarnessExitCode(); got != nil {
+		t.Errorf("expected nil for garbage, got %v", *got)
+	}
+}

--- a/cmd/sciontool/commands/init_crash_test.go
+++ b/cmd/sciontool/commands/init_crash_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hooks/handlers"
 )
 
@@ -103,23 +104,23 @@ func TestClassifyExit(t *testing.T) {
 
 func TestReadHarnessExitCode(t *testing.T) {
 	// Missing file -> nil.
-	_ = os.Remove(harnessExitCodeFile)
+	_ = os.Remove(state.HarnessExitCodeFile)
 	if got := readHarnessExitCode(); got != nil {
 		t.Errorf("expected nil for missing file, got %v", *got)
 	}
 
 	// Valid code.
-	if err := os.WriteFile(harnessExitCodeFile, []byte("137\n"), 0o644); err != nil {
+	if err := os.WriteFile(state.HarnessExitCodeFile, []byte("137\n"), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	t.Cleanup(func() { _ = os.Remove(harnessExitCodeFile) })
+	t.Cleanup(func() { _ = os.Remove(state.HarnessExitCodeFile) })
 	got := readHarnessExitCode()
 	if got == nil || *got != 137 {
 		t.Errorf("expected 137, got %v", got)
 	}
 
 	// Unparseable -> nil.
-	if err := os.WriteFile(harnessExitCodeFile, []byte("garbage"), 0o644); err != nil {
+	if err := os.WriteFile(state.HarnessExitCodeFile, []byte("garbage"), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 	if got := readHarnessExitCode(); got != nil {

--- a/pkg/agent/list.go
+++ b/pkg/agent/list.go
@@ -166,10 +166,19 @@ func (m *AgentManager) List(ctx context.Context, filter map[string]string) ([]ap
 			agents[i].Phase = string(state.PhaseRunning)
 		}
 		if isContainerStopped {
+			// A non-zero exit code means the agent crashed; map to error
+			// (restartable) rather than a clean stop. A zero exit (or a plain
+			// "stopped" with no embedded code) is a clean stop.
+			exitCode, hasCode := scionruntime.ExitCodeFromContainerStatus(agents[i].ContainerStatus)
+			crashed := hasCode && exitCode != 0
 			p := state.Phase(agents[i].Phase)
 			switch p {
 			case state.PhaseRunning:
-				agents[i].Phase = string(state.PhaseStopped)
+				if crashed {
+					agents[i].Phase = string(state.PhaseError)
+				} else {
+					agents[i].Phase = string(state.PhaseStopped)
+				}
 				agents[i].Activity = ""
 			case state.PhaseCloning, state.PhaseStarting, state.PhaseProvisioning:
 				// Container exited during a pre-running phase (e.g. clone failure

--- a/pkg/agent/state/state.go
+++ b/pkg/agent/state/state.go
@@ -19,6 +19,14 @@ package state
 
 import "fmt"
 
+// HarnessExitCodeFile is the container-local path where the tmux agent-window
+// wrapper records the harness's real exit code, read by `sciontool init`.
+// There is one agent per container, so a fixed path is safe. It is a shared
+// contract: the runtime writes the file and `sciontool init` reads it to
+// recover the authoritative harness exit code (the harness runs as a tmux
+// grandchild whose exit code is otherwise invisible to the supervisor).
+const HarnessExitCodeFile = "/tmp/scion-harness-exit-code"
+
 // Phase represents the infrastructure lifecycle phase of an agent.
 // Phase is controlled by platform operations (broker commands, heartbeats,
 // container events) — not by the LLM agent itself.

--- a/pkg/hub/auto_suspend_test.go
+++ b/pkg/hub/auto_suspend_test.go
@@ -134,6 +134,14 @@ func TestAgentAutoSuspendHandler_SuspendsStalledBeyondGrace(t *testing.T) {
 	if published[0].Phase != string(state.PhaseSuspended) {
 		t.Errorf("published phase = %q, want %q", published[0].Phase, string(state.PhaseSuspended))
 	}
+	// The published event must reflect the persisted container_status/activity,
+	// not stale values from before the suspend.
+	if published[0].ContainerStatus != "stopped" {
+		t.Errorf("published container status = %q, want %q", published[0].ContainerStatus, "stopped")
+	}
+	if published[0].Activity != "" {
+		t.Errorf("published activity = %q, want empty", published[0].Activity)
+	}
 }
 
 func TestAgentAutoSuspendHandler_NotSuspendedWithinGrace(t *testing.T) {

--- a/pkg/hub/auto_suspend_test.go
+++ b/pkg/hub/auto_suspend_test.go
@@ -1,0 +1,215 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/GoogleCloudPlatform/scion/pkg/store/entadapter"
+)
+
+// setupAutoSuspendTestServer mirrors setupStalledTestServer but also wires the
+// agentLifecycleLog that the auto-suspend handler logs through.
+func setupAutoSuspendTestServer(t *testing.T) (*Server, store.Store, *trackingEventPublisher) {
+	t.Helper()
+
+	s, err := newTestStore(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("failed to migrate test store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	ep := &trackingEventPublisher{}
+
+	srv := &Server{
+		store:             s,
+		events:            ep,
+		agentLifecycleLog: slog.Default(),
+		config: ServerConfig{
+			StalledThreshold: 5 * time.Minute,
+		},
+	}
+
+	return srv, s, ep
+}
+
+// makeStalledAgent creates a running agent in the "stalled" activity with the
+// given harness, then forces last_activity_event / last_seen to the supplied
+// times so the auto-suspend finder can select (or reject) it.
+func makeStalledAgent(t *testing.T, s store.Store, slug, harnessConfig string, lastActivity, lastSeen time.Time) *store.Agent {
+	t.Helper()
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "Auto Suspend Project " + slug,
+		Slug:       "auto-suspend-" + slug,
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	agent := &store.Agent{
+		ID:         api.NewUUID(),
+		Slug:       slug,
+		Name:       slug,
+		Template:   "claude",
+		ProjectID:  project.ID,
+		Phase:      string(state.PhaseCreated),
+		Visibility: store.VisibilityPrivate,
+		AppliedConfig: &store.AgentAppliedConfig{
+			HarnessConfig: harnessConfig,
+		},
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("failed to create agent: %v", err)
+	}
+
+	// Mark running + stalled (the activity the auto-suspend finder requires).
+	if err := s.UpdateAgentStatus(ctx, agent.ID, store.AgentStatusUpdate{
+		Phase:    string(state.PhaseRunning),
+		Activity: string(state.ActivityStalled),
+	}); err != nil {
+		t.Fatalf("failed to update agent status: %v", err)
+	}
+
+	db := s.(*entadapter.CompositeStore).DB()
+	if _, err := db.ExecContext(ctx,
+		"UPDATE agents SET last_activity_event = ?, last_seen = ? WHERE id = ?",
+		lastActivity, lastSeen, agent.ID); err != nil {
+		t.Fatalf("failed to set timing: %v", err)
+	}
+
+	return agent
+}
+
+func TestAgentAutoSuspendHandler_SuspendsStalledBeyondGrace(t *testing.T) {
+	srv, s, ep := setupAutoSuspendTestServer(t)
+	ctx := context.Background()
+
+	// Stalled longer than StalledThreshold (5m) + grace (5m) = 10m, with a
+	// recent heartbeat and a resume-capable harness (claude).
+	staleActivity := time.Now().Add(-15 * time.Minute)
+	recentHB := time.Now().Add(-30 * time.Second)
+	agent := makeStalledAgent(t, s, "stalled-beyond-grace", "claude", staleActivity, recentHB)
+
+	srv.agentAutoSuspendHandler()(ctx)
+
+	a, err := s.GetAgent(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("failed to get agent: %v", err)
+	}
+	if a.Phase != string(state.PhaseSuspended) {
+		t.Errorf("phase = %q, want %q", a.Phase, string(state.PhaseSuspended))
+	}
+
+	published := ep.publishedAgents()
+	if len(published) != 1 {
+		t.Fatalf("expected 1 published event, got %d", len(published))
+	}
+	if published[0].Phase != string(state.PhaseSuspended) {
+		t.Errorf("published phase = %q, want %q", published[0].Phase, string(state.PhaseSuspended))
+	}
+}
+
+func TestAgentAutoSuspendHandler_NotSuspendedWithinGrace(t *testing.T) {
+	srv, s, ep := setupAutoSuspendTestServer(t)
+	ctx := context.Background()
+
+	// Stalled past StalledThreshold (5m) but NOT past the +5m grace (total 10m):
+	// 7 minutes stale should not be auto-suspended.
+	staleActivity := time.Now().Add(-7 * time.Minute)
+	recentHB := time.Now().Add(-30 * time.Second)
+	agent := makeStalledAgent(t, s, "within-grace", "claude", staleActivity, recentHB)
+
+	srv.agentAutoSuspendHandler()(ctx)
+
+	a, err := s.GetAgent(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("failed to get agent: %v", err)
+	}
+	if a.Phase != string(state.PhaseRunning) {
+		t.Errorf("phase = %q, want %q (still running, within grace)", a.Phase, string(state.PhaseRunning))
+	}
+	if a.Activity != string(state.ActivityStalled) {
+		t.Errorf("activity = %q, want %q", a.Activity, string(state.ActivityStalled))
+	}
+	if len(ep.publishedAgents()) != 0 {
+		t.Errorf("expected 0 published events, got %d", len(ep.publishedAgents()))
+	}
+}
+
+func TestAgentAutoSuspendHandler_NotSuspendedWhenHarnessNoResume(t *testing.T) {
+	srv, s, ep := setupAutoSuspendTestServer(t)
+	ctx := context.Background()
+
+	// Stalled beyond grace and online, but the generic harness cannot resume,
+	// so the agent must be left stalled.
+	staleActivity := time.Now().Add(-15 * time.Minute)
+	recentHB := time.Now().Add(-30 * time.Second)
+	agent := makeStalledAgent(t, s, "no-resume", "generic", staleActivity, recentHB)
+
+	srv.agentAutoSuspendHandler()(ctx)
+
+	a, err := s.GetAgent(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("failed to get agent: %v", err)
+	}
+	if a.Phase != string(state.PhaseRunning) {
+		t.Errorf("phase = %q, want %q (harness cannot resume)", a.Phase, string(state.PhaseRunning))
+	}
+	if a.Activity != string(state.ActivityStalled) {
+		t.Errorf("activity = %q, want %q", a.Activity, string(state.ActivityStalled))
+	}
+	if len(ep.publishedAgents()) != 0 {
+		t.Errorf("expected 0 published events, got %d", len(ep.publishedAgents()))
+	}
+}
+
+func TestAgentAutoSuspendHandler_NotSuspendedWhenOffline(t *testing.T) {
+	srv, s, ep := setupAutoSuspendTestServer(t)
+	ctx := context.Background()
+
+	// Stalled beyond grace and resume-capable, but heartbeat is stale (>2m):
+	// the container is presumed gone, so do not auto-suspend.
+	staleActivity := time.Now().Add(-15 * time.Minute)
+	staleHB := time.Now().Add(-10 * time.Minute)
+	agent := makeStalledAgent(t, s, "offline", "claude", staleActivity, staleHB)
+
+	srv.agentAutoSuspendHandler()(ctx)
+
+	a, err := s.GetAgent(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("failed to get agent: %v", err)
+	}
+	if a.Phase != string(state.PhaseRunning) {
+		t.Errorf("phase = %q, want %q (offline, not selected)", a.Phase, string(state.PhaseRunning))
+	}
+	if len(ep.publishedAgents()) != 0 {
+		t.Errorf("expected 0 published events, got %d", len(ep.publishedAgents()))
+	}
+}

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -150,7 +150,7 @@ func (d *mockDispatcher) DispatchAgentProvision(_ context.Context, agent *store.
 	agent.Phase = string(state.PhaseCreated)
 	return nil
 }
-func (d *mockDispatcher) DispatchAgentStart(_ context.Context, agent *store.Agent, _ string) error {
+func (d *mockDispatcher) DispatchAgentStart(_ context.Context, agent *store.Agent, _ string, _ bool) error {
 	d.startedAgents = append(d.startedAgents, agent)
 	return nil
 }

--- a/pkg/hub/broker_http_transport.go
+++ b/pkg/hub/broker_http_transport.go
@@ -161,7 +161,7 @@ func (t *brokerHTTPTransport) CreateAgent(ctx context.Context, brokerID, brokerE
 	return &result, nil
 }
 
-func (t *brokerHTTPTransport) StartAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig string, resolvedEnv map[string]string, resolvedSecrets []ResolvedSecret, inlineConfig *api.ScionConfig, sharedDirs []api.SharedDir, sharedWorkspace bool) (*RemoteAgentResponse, error) {
+func (t *brokerHTTPTransport) StartAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig string, resolvedEnv map[string]string, resolvedSecrets []ResolvedSecret, inlineConfig *api.ScionConfig, sharedDirs []api.SharedDir, sharedWorkspace, resume bool) (*RemoteAgentResponse, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/agents/%s/start", strings.TrimSuffix(brokerEndpoint, "/"), url.PathEscape(agentID))
 	if projectID != "" {
 		endpoint += "?projectId=" + url.QueryEscape(projectID)
@@ -193,6 +193,9 @@ func (t *brokerHTTPTransport) StartAgent(ctx context.Context, brokerID, brokerEn
 	}
 	if sharedWorkspace {
 		payload["sharedWorkspace"] = true
+	}
+	if resume {
+		payload["resume"] = true
 	}
 
 	var body []byte

--- a/pkg/hub/broker_routing_test.go
+++ b/pkg/hub/broker_routing_test.go
@@ -40,7 +40,7 @@ func (f *fakeHTTPClient) MessageAgent(context.Context, string, string, string, s
 func (f *fakeHTTPClient) CreateAgent(context.Context, string, string, *RemoteCreateAgentRequest) (*RemoteAgentResponse, error) {
 	return nil, nil
 }
-func (f *fakeHTTPClient) StartAgent(context.Context, string, string, string, string, string, string, string, string, map[string]string, []ResolvedSecret, *api.ScionConfig, []api.SharedDir, bool) (*RemoteAgentResponse, error) {
+func (f *fakeHTTPClient) StartAgent(context.Context, string, string, string, string, string, string, string, string, map[string]string, []ResolvedSecret, *api.ScionConfig, []api.SharedDir, bool, bool) (*RemoteAgentResponse, error) {
 	return nil, nil
 }
 func (f *fakeHTTPClient) StopAgent(context.Context, string, string, string, string) error {

--- a/pkg/hub/brokerclient.go
+++ b/pkg/hub/brokerclient.go
@@ -44,8 +44,8 @@ func (c *AuthenticatedBrokerClient) CreateAgent(ctx context.Context, brokerID, b
 }
 
 // StartAgent starts an agent on a remote runtime broker with HMAC authentication.
-func (c *AuthenticatedBrokerClient) StartAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig string, resolvedEnv map[string]string, resolvedSecrets []ResolvedSecret, inlineConfig *api.ScionConfig, sharedDirs []api.SharedDir, sharedWorkspace bool) (*RemoteAgentResponse, error) {
-	return c.transport.StartAgent(ctx, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig, resolvedEnv, resolvedSecrets, inlineConfig, sharedDirs, sharedWorkspace)
+func (c *AuthenticatedBrokerClient) StartAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig string, resolvedEnv map[string]string, resolvedSecrets []ResolvedSecret, inlineConfig *api.ScionConfig, sharedDirs []api.SharedDir, sharedWorkspace, resume bool) (*RemoteAgentResponse, error) {
+	return c.transport.StartAgent(ctx, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig, resolvedEnv, resolvedSecrets, inlineConfig, sharedDirs, sharedWorkspace, resume)
 }
 
 // StopAgent stops an agent on a remote runtime broker with HMAC authentication.

--- a/pkg/hub/brokerclient_test.go
+++ b/pkg/hub/brokerclient_test.go
@@ -211,7 +211,7 @@ func TestAuthenticatedBrokerClient_StartAgent(t *testing.T) {
 	client := NewAuthenticatedBrokerClient(db, false)
 
 	// Make request
-	resp, err := client.StartAgent(context.Background(), brokerID, server.URL, "my-agent", "", "", "", "", "", nil, nil, nil, nil, false)
+	resp, err := client.StartAgent(context.Background(), brokerID, server.URL, "my-agent", "", "", "", "", "", nil, nil, nil, nil, false, false)
 	if err != nil {
 		t.Fatalf("StartAgent failed: %v", err)
 	}
@@ -404,7 +404,7 @@ func TestAuthenticatedBrokerClient_StartAgent_InvalidJSONFails(t *testing.T) {
 	defer server.Close()
 
 	client := NewAuthenticatedBrokerClient(db, false)
-	_, err = client.StartAgent(context.Background(), brokerID, server.URL, tid("agent-1"), "", "", "", "", "", nil, nil, nil, nil, false)
+	_, err = client.StartAgent(context.Background(), brokerID, server.URL, tid("agent-1"), "", "", "", "", "", nil, nil, nil, nil, false, false)
 	if err == nil {
 		t.Fatal("expected StartAgent to fail on invalid JSON response")
 	}
@@ -492,7 +492,7 @@ func TestAuthenticatedBrokerClient_AllOperations(t *testing.T) {
 		t.Errorf("CreateAgent failed: %v", err)
 	}
 
-	_, err = client.StartAgent(ctx, brokerID, server.URL, "test-agent", "", "", "", "", "", nil, nil, nil, nil, false)
+	_, err = client.StartAgent(ctx, brokerID, server.URL, "test-agent", "", "", "", "", "", nil, nil, nil, nil, false, false)
 	if err != nil {
 		t.Errorf("StartAgent failed: %v", err)
 	}

--- a/pkg/hub/controlchannel_client.go
+++ b/pkg/hub/controlchannel_client.go
@@ -75,7 +75,7 @@ func (c *ControlChannelBrokerClient) CreateAgent(ctx context.Context, brokerID, 
 }
 
 // StartAgent starts an agent via control channel.
-func (c *ControlChannelBrokerClient) StartAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig string, resolvedEnv map[string]string, resolvedSecrets []ResolvedSecret, inlineConfig *api.ScionConfig, sharedDirs []api.SharedDir, sharedWorkspace bool) (*RemoteAgentResponse, error) {
+func (c *ControlChannelBrokerClient) StartAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig string, resolvedEnv map[string]string, resolvedSecrets []ResolvedSecret, inlineConfig *api.ScionConfig, sharedDirs []api.SharedDir, sharedWorkspace, resume bool) (*RemoteAgentResponse, error) {
 	_ = brokerEndpoint
 	path := fmt.Sprintf("/api/v1/agents/%s/start", url.PathEscape(agentID))
 	if projectID != "" {
@@ -109,6 +109,9 @@ func (c *ControlChannelBrokerClient) StartAgent(ctx context.Context, brokerID, b
 	}
 	if sharedWorkspace {
 		payload["sharedWorkspace"] = true
+	}
+	if resume {
+		payload["resume"] = true
 	}
 
 	var body []byte
@@ -508,12 +511,12 @@ func (c *HybridBrokerClient) CreateAgent(ctx context.Context, brokerID, brokerEn
 // routeLocal uses the control-channel tunnel (unchanged fast path), routeHTTP
 // falls back to the broker's HTTP endpoint, and routeForward/routeUndeliverable
 // return ErrLifecycleDeferred so the caller can write durable intent + wait.
-func (c *HybridBrokerClient) StartAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig string, resolvedEnv map[string]string, resolvedSecrets []ResolvedSecret, inlineConfig *api.ScionConfig, sharedDirs []api.SharedDir, sharedWorkspace bool) (*RemoteAgentResponse, error) {
+func (c *HybridBrokerClient) StartAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig string, resolvedEnv map[string]string, resolvedSecrets []ResolvedSecret, inlineConfig *api.ScionConfig, sharedDirs []api.SharedDir, sharedWorkspace, resume bool) (*RemoteAgentResponse, error) {
 	switch c.route(ctx, brokerID, brokerEndpoint) {
 	case routeLocal:
-		return c.controlChannel.StartAgent(ctx, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig, resolvedEnv, resolvedSecrets, inlineConfig, sharedDirs, sharedWorkspace)
+		return c.controlChannel.StartAgent(ctx, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig, resolvedEnv, resolvedSecrets, inlineConfig, sharedDirs, sharedWorkspace, resume)
 	case routeHTTP:
-		return c.httpClient.StartAgent(ctx, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig, resolvedEnv, resolvedSecrets, inlineConfig, sharedDirs, sharedWorkspace)
+		return c.httpClient.StartAgent(ctx, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig, resolvedEnv, resolvedSecrets, inlineConfig, sharedDirs, sharedWorkspace, resume)
 	default:
 		return nil, ErrLifecycleDeferred
 	}

--- a/pkg/hub/controlchannel_client_test.go
+++ b/pkg/hub/controlchannel_client_test.go
@@ -116,6 +116,7 @@ func TestControlChannelBrokerClient_StartAgentSignsTunneledRequest(t *testing.T)
 		nil,
 		nil,
 		false,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("StartAgent returned error: %v", err)

--- a/pkg/hub/dispatch_args.go
+++ b/pkg/hub/dispatch_args.go
@@ -25,7 +25,8 @@ import (
 // DispatchAgentStart (all hub instances share the same store + secret
 // backend), so resolved env/secrets are NOT serialized here.
 type StartDispatchArgs struct {
-	Task string `json:"task,omitempty"`
+	Task   string `json:"task,omitempty"`
+	Resume bool   `json:"resume,omitempty"`
 }
 
 // RestartDispatchArgs is intentionally empty — the owner's

--- a/pkg/hub/dispatch_exec_test.go
+++ b/pkg/hub/dispatch_exec_test.go
@@ -56,7 +56,7 @@ func (d *lifecycleTestDispatcher) DispatchAgentCreate(context.Context, *store.Ag
 func (d *lifecycleTestDispatcher) DispatchAgentProvision(context.Context, *store.Agent) error {
 	return nil
 }
-func (d *lifecycleTestDispatcher) DispatchAgentStart(_ context.Context, _ *store.Agent, task string) error {
+func (d *lifecycleTestDispatcher) DispatchAgentStart(_ context.Context, _ *store.Agent, task string, _ bool) error {
 	d.startCalled.Add(1)
 	d.lastTask = task
 	return nil
@@ -258,7 +258,7 @@ type deferredTestClient struct {
 	startCalled atomic.Int32
 }
 
-func (c *deferredTestClient) StartAgent(_ context.Context, brokerID, _, _, _, _, _, _, _ string, _ map[string]string, _ []ResolvedSecret, _ *api.ScionConfig, _ []api.SharedDir, _ bool) (*RemoteAgentResponse, error) {
+func (c *deferredTestClient) StartAgent(_ context.Context, brokerID, _, _, _, _, _, _, _ string, _ map[string]string, _ []ResolvedSecret, _ *api.ScionConfig, _ []api.SharedDir, _, _ bool) (*RemoteAgentResponse, error) {
 	c.startCalled.Add(1)
 	if brokerID != c.localBroker {
 		return nil, ErrLifecycleDeferred
@@ -304,7 +304,7 @@ func TestDeferredStart_WritesIntentAndWaits(t *testing.T) {
 		events.PublishAgentStatus(ctx, &updatedAgent)
 	}()
 
-	err := dispatcher.DispatchAgentStart(ctx, agent, "my-task")
+	err := dispatcher.DispatchAgentStart(ctx, agent, "my-task", false)
 	require.NoError(t, err, "deferred start should succeed when 'running' event arrives")
 
 	// Verify a broker_dispatch row was written (intent is durable). No owner
@@ -340,7 +340,7 @@ func TestDeferredStart_ReturnsErrorOnErrorPhase(t *testing.T) {
 		events.PublishAgentStatus(ctx, &updatedAgent)
 	}()
 
-	err := dispatcher.DispatchAgentStart(ctx, agent, "")
+	err := dispatcher.DispatchAgentStart(ctx, agent, "", false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "error phase")
 }
@@ -361,7 +361,7 @@ func TestLocalStart_SkipsIntentRow(t *testing.T) {
 
 	agent := seedAgentWithBrokerID(t, cs, localBroker)
 
-	err := dispatcher.DispatchAgentStart(ctx, agent, "local-task")
+	err := dispatcher.DispatchAgentStart(ctx, agent, "local-task", false)
 	require.NoError(t, err, "local start should succeed directly")
 
 	// Verify no broker_dispatch row was written (local path skips intent).

--- a/pkg/hub/dispatch_lifecycle_test.go
+++ b/pkg/hub/dispatch_lifecycle_test.go
@@ -47,13 +47,13 @@ func TestHybridBrokerClient_StartAgent_RouteGate(t *testing.T) {
 
 	t.Run("routeForward returns ErrLifecycleDeferred", func(t *testing.T) {
 		c.SetAffinityLookup(func(context.Context, string) (string, bool) { return "hubA", true })
-		_, err := c.StartAgent(context.Background(), remoteBroker, "", "a1", "p1", "", "", "", "", nil, nil, nil, nil, false)
+		_, err := c.StartAgent(context.Background(), remoteBroker, "", "a1", "p1", "", "", "", "", nil, nil, nil, nil, false, false)
 		assert.ErrorIs(t, err, ErrLifecycleDeferred)
 	})
 
 	t.Run("routeUndeliverable returns ErrLifecycleDeferred", func(t *testing.T) {
 		c.SetAffinityLookup(func(context.Context, string) (string, bool) { return "", false })
-		_, err := c.StartAgent(context.Background(), remoteBroker, "", "a1", "p1", "", "", "", "", nil, nil, nil, nil, false)
+		_, err := c.StartAgent(context.Background(), remoteBroker, "", "a1", "p1", "", "", "", "", nil, nil, nil, nil, false, false)
 		assert.ErrorIs(t, err, ErrLifecycleDeferred)
 	})
 }

--- a/pkg/hub/events_integration_test.go
+++ b/pkg/hub/events_integration_test.go
@@ -38,7 +38,7 @@ func (noopDispatcher) DispatchAgentCreate(_ context.Context, agent *store.Agent)
 	return nil
 }
 func (noopDispatcher) DispatchAgentProvision(_ context.Context, _ *store.Agent) error { return nil }
-func (noopDispatcher) DispatchAgentStart(_ context.Context, _ *store.Agent, _ string) error {
+func (noopDispatcher) DispatchAgentStart(_ context.Context, _ *store.Agent, _ string, _ bool) error {
 	return nil
 }
 func (noopDispatcher) DispatchAgentStop(_ context.Context, _ *store.Agent) error      { return nil }

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -2988,6 +2988,19 @@ func (s *Server) updateAgentStatus(w http.ResponseWriter, r *http.Request, id st
 func guardAgentPhaseTransition(agent *store.Agent, status *store.AgentStatusUpdate) {
 	currentPhase := state.Phase(agent.Phase)
 
+	// Guard 0: suspended is sticky against async status updates. When an agent
+	// is suspended, its container is being torn down, and the dying container's
+	// async sciontool /status POST (e.g. phase=stopped, activity=crashed) must
+	// not clobber the suspended phase — otherwise a subsequent /start would not
+	// see suspended and would skip the harness --continue (resume) flag.
+	// Only explicit start/stop lifecycle actions may leave the suspended phase,
+	// and those write phase directly without going through this guard.
+	if currentPhase == state.PhaseSuspended {
+		status.Phase = ""
+		status.Activity = ""
+		return
+	}
+
 	// Guard 1: reject phase regressions within the forward-progress lifecycle.
 	if status.Phase != "" {
 		newPhase := state.Phase(status.Phase)
@@ -6348,8 +6361,20 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 			agentInTerminalPhase := agent.Phase == string(state.PhaseStopped) ||
 				agent.Phase == string(state.PhaseError)
 
+			// Suspended is sticky: a suspended agent's container is being torn
+			// down, so a racing heartbeat reporting stopped/crashed must not
+			// revert the suspended phase (which would defeat resume on the next
+			// /start). Like the terminal case, suppress any phase change and any
+			// terminal activity (crashed, etc.) from the heartbeat. Only explicit
+			// start/stop lifecycle actions may leave the suspended phase.
+			agentSuspended := agent.Phase == string(state.PhaseSuspended)
+
 			if agentHB.Phase != "" {
-				if agentInTerminalPhase {
+				if agentSuspended {
+					// Do not let the heartbeat change the phase or propagate
+					// terminal activities while suspended; leave statusUpdate.Phase
+					// unset so the hub's authoritative suspended phase is kept.
+				} else if agentInTerminalPhase {
 					// Keep the hub's authoritative terminal phase; only
 					// allow the heartbeat to confirm it (not revert it).
 					if agentHB.Phase == agent.Phase {
@@ -6396,13 +6421,13 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 						}
 					}
 				}
-			} else if !agentInTerminalPhase {
+			} else if !agentInTerminalPhase && !agentSuspended {
 				// Legacy path: no structured fields, derive from ContainerStatus
 				// Derive phase from container status to ensure agents
 				// registered via sync (not started via hub) get proper state.
 				// Terminal container states (exited/stopped) override agent phase.
-				// Skipped when agent is already in a terminal phase to avoid
-				// reverting an authoritative hub-set state.
+				// Skipped when agent is already in a terminal phase or suspended
+				// to avoid reverting an authoritative hub-set state.
 				if agentHB.ContainerStatus != "" {
 					containerStatusLower := strings.ToLower(agentHB.ContainerStatus)
 					switch {

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -2396,7 +2396,9 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 				return
 			}
 
-			if err := dispatcher.DispatchAgentStart(ctx, agent, ""); err != nil {
+			// Wake always resumes a suspended agent, so the harness must
+			// continue its prior session.
+			if err := dispatcher.DispatchAgentStart(ctx, agent, "", true); err != nil {
 				RuntimeError(w, "Failed to wake agent: "+err.Error())
 				return
 			}
@@ -3030,7 +3032,9 @@ func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id
 	case api.AgentActionStart:
 		newPhase = string(state.PhaseRunning)
 		if dispatcher != nil && agent.RuntimeBrokerID != "" {
-			dispatchErr = dispatcher.DispatchAgentStart(ctx, agent, "")
+			// Resume the harness session only when the agent was suspended.
+			resume := agent.Phase == string(state.PhaseSuspended)
+			dispatchErr = dispatcher.DispatchAgentStart(ctx, agent, "", resume)
 			// DispatchAgentStart applies the broker response in-place;
 			// use the broker-reported phase if it was set.
 			if dispatchErr == nil && agent.Phase != "" {
@@ -3082,7 +3086,8 @@ func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id
 				slog.Warn("Restart: stop dispatch failed, proceeding with start",
 					"agent_id", id, "error", stopErr)
 			}
-			dispatchErr = dispatcher.DispatchAgentStart(ctx, agent, "")
+			// Restart is stop + start: a fresh harness session, not a resume.
+			dispatchErr = dispatcher.DispatchAgentStart(ctx, agent, "", false)
 			// DispatchAgentStart applies the broker response in-place;
 			// use the broker-reported phase if it was set.
 			if dispatchErr == nil && agent.Phase != "" {
@@ -9119,7 +9124,10 @@ func (s *Server) handleExistingAgent(
 			existingAgent.AppliedConfig.Attach = req.Attach
 		}
 
-		if err := dispatcher.DispatchAgentStart(ctx, existingAgent, req.Task); err != nil {
+		// This branch only runs for suspended agents, so resume the harness
+		// session (Claude --continue) rather than starting fresh.
+		resume := existingAgent.Phase == string(state.PhaseSuspended)
+		if err := dispatcher.DispatchAgentStart(ctx, existingAgent, req.Task, resume); err != nil {
 			RuntimeError(w, "Failed to resume suspended agent: "+err.Error())
 			return existingAgentErrored
 		}
@@ -9170,7 +9178,9 @@ func (s *Server) handleExistingAgent(
 				existingAgent.AppliedConfig.Attach = req.Attach
 			}
 
-			if err := dispatcher.DispatchAgentStart(ctx, existingAgent, req.Task); err != nil {
+			// A stopped agent restarts with a fresh harness session even when
+			// resume was requested (mirrors the local CLI's effectiveResume).
+			if err := dispatcher.DispatchAgentStart(ctx, existingAgent, req.Task, false); err != nil {
 				RuntimeError(w, "Failed to resume stopped agent: "+err.Error())
 				return existingAgentErrored
 			}
@@ -9239,7 +9249,8 @@ func (s *Server) handleExistingAgent(
 
 		// Dispatch start action — DispatchAgentStart applies the broker's
 		// response (status, container info) onto existingAgent in-place.
-		if err := dispatcher.DispatchAgentStart(ctx, existingAgent, req.Task); err != nil {
+		// A created/provisioning agent has no prior session to resume.
+		if err := dispatcher.DispatchAgentStart(ctx, existingAgent, req.Task, false); err != nil {
 			RuntimeError(w, "Failed to start agent: "+err.Error())
 			return existingAgentErrored
 		}

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -6306,6 +6306,33 @@ type brokerAgentHeartbeat struct {
 	Profile         string `json:"profile,omitempty"`     // Settings profile used
 }
 
+// exitCodeFromContainerStatus extracts the exit code from a container-runtime
+// status string such as "Exited (137) 2 minutes ago" (Docker/Podman). It
+// returns (code, true) when an exited status with a parseable code is present,
+// otherwise (0, false). A plain "stopped" (no embedded code) yields (0, false).
+func exitCodeFromContainerStatus(status string) (int, bool) {
+	lower := strings.ToLower(status)
+	idx := strings.Index(lower, "exited")
+	if idx < 0 {
+		return 0, false
+	}
+	rest := status[idx+len("exited"):]
+	open := strings.Index(rest, "(")
+	if open < 0 {
+		return 0, false
+	}
+	close := strings.Index(rest[open:], ")")
+	if close < 0 {
+		return 0, false
+	}
+	numStr := strings.TrimSpace(rest[open+1 : open+close])
+	code, err := strconv.Atoi(numStr)
+	if err != nil {
+		return 0, false
+	}
+	return code, true
+}
+
 func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, id string) {
 	ctx := r.Context()
 
@@ -6395,6 +6422,25 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 					// must not move a running agent back to starting/etc.
 					hbPhase := state.Phase(agentHB.Phase)
 					curPhase := state.Phase(agent.Phase)
+
+					// Derive a crash from the container exit code even when the
+					// broker reports a plain "stopped" (its phase derivation is
+					// based on the container being exited, not on the exit code).
+					// A non-zero exit means the agent crashed → error, with the
+					// exit code recorded so the UI can show it. This works even
+					// if sciontool's own crash report never reached the hub.
+					if hbPhase == state.PhaseStopped {
+						if code, ok := exitCodeFromContainerStatus(agentHB.ContainerStatus); ok && code != 0 {
+							hbPhase = state.PhaseError
+							agentHB.Phase = string(state.PhaseError)
+							c := code
+							statusUpdate.ExitCode = &c
+							if statusUpdate.Message == "" {
+								statusUpdate.Message = fmt.Sprintf("Agent crashed with exit code %d", code)
+							}
+						}
+					}
+
 					if curPhase.IsActivePhase() && hbPhase.IsActivePhase() &&
 						hbPhase.Ordinal() < curPhase.Ordinal() {
 						// Suppress the regression — keep the hub's phase.
@@ -6434,7 +6480,18 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 					case strings.HasPrefix(containerStatusLower, "up") || containerStatusLower == "running":
 						statusUpdate.Phase = string(state.PhaseRunning)
 					case strings.HasPrefix(containerStatusLower, "exited") || containerStatusLower == "stopped":
-						statusUpdate.Phase = string(state.PhaseStopped)
+						// A non-zero exit code means the agent crashed → error
+						// (restartable); a zero/absent code is a clean stop.
+						if code, ok := exitCodeFromContainerStatus(agentHB.ContainerStatus); ok && code != 0 {
+							statusUpdate.Phase = string(state.PhaseError)
+							c := code
+							statusUpdate.ExitCode = &c
+							if statusUpdate.Message == "" {
+								statusUpdate.Message = fmt.Sprintf("Agent crashed with exit code %d", code)
+							}
+						} else {
+							statusUpdate.Phase = string(state.PhaseStopped)
+						}
 						statusUpdate.Activity = ""
 					case containerStatusLower == "created":
 						// Don't downgrade a running agent to provisioning — the

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -36,6 +36,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/hub/githubapp"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	scionruntime "github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/secret"
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
@@ -6375,33 +6376,6 @@ type brokerAgentHeartbeat struct {
 	Profile         string `json:"profile,omitempty"`     // Settings profile used
 }
 
-// exitCodeFromContainerStatus extracts the exit code from a container-runtime
-// status string such as "Exited (137) 2 minutes ago" (Docker/Podman). It
-// returns (code, true) when an exited status with a parseable code is present,
-// otherwise (0, false). A plain "stopped" (no embedded code) yields (0, false).
-func exitCodeFromContainerStatus(status string) (int, bool) {
-	lower := strings.ToLower(status)
-	idx := strings.Index(lower, "exited")
-	if idx < 0 {
-		return 0, false
-	}
-	rest := status[idx+len("exited"):]
-	open := strings.Index(rest, "(")
-	if open < 0 {
-		return 0, false
-	}
-	close := strings.Index(rest[open:], ")")
-	if close < 0 {
-		return 0, false
-	}
-	numStr := strings.TrimSpace(rest[open+1 : open+close])
-	code, err := strconv.Atoi(numStr)
-	if err != nil {
-		return 0, false
-	}
-	return code, true
-}
-
 func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, id string) {
 	ctx := r.Context()
 
@@ -6499,7 +6473,7 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 					// exit code recorded so the UI can show it. This works even
 					// if sciontool's own crash report never reached the hub.
 					if hbPhase == state.PhaseStopped {
-						if code, ok := exitCodeFromContainerStatus(agentHB.ContainerStatus); ok && code != 0 {
+						if code, ok := scionruntime.ExitCodeFromContainerStatus(agentHB.ContainerStatus); ok && code != 0 {
 							hbPhase = state.PhaseError
 							agentHB.Phase = string(state.PhaseError)
 							c := code
@@ -6551,7 +6525,7 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 					case strings.HasPrefix(containerStatusLower, "exited") || containerStatusLower == "stopped":
 						// A non-zero exit code means the agent crashed → error
 						// (restartable); a zero/absent code is a clean stop.
-						if code, ok := exitCodeFromContainerStatus(agentHB.ContainerStatus); ok && code != 0 {
+						if code, ok := scionruntime.ExitCodeFromContainerStatus(agentHB.ContainerStatus); ok && code != 0 {
 							statusUpdate.Phase = string(state.PhaseError)
 							c := code
 							statusUpdate.ExitCode = &c

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -3022,6 +3022,72 @@ func guardAgentPhaseTransition(agent *store.Agent, status *store.AgentStatusUpda
 	}
 }
 
+// errHarnessNoResume is returned by suspendAgent when the agent's harness does
+// not support session resume, so suspending would strand it. The wrapped reason
+// carries harness-supplied context for the caller's error message.
+type errHarnessNoResume struct {
+	reason string
+}
+
+func (e *errHarnessNoResume) Error() string {
+	if e.reason != "" {
+		return e.reason
+	}
+	return "harness does not support session resume"
+}
+
+// harnessSupportsResume reports whether the agent's configured harness supports
+// resuming a session. An empty harness name (no applied config) is treated as
+// supported, matching the HTTP suspend handler's prior behavior of only
+// rejecting when a harness was explicitly resolved and declared SupportNo.
+func (s *Server) harnessSupportsResume(agent *store.Agent) (bool, string) {
+	harnessName := ""
+	if agent.AppliedConfig != nil {
+		harnessName = agent.AppliedConfig.HarnessConfig
+	}
+	if harnessName == "" {
+		return true, ""
+	}
+	caps := harness.New(harnessName).AdvancedCapabilities()
+	if caps.Resume.Support == api.SupportNo {
+		return false, caps.Resume.Reason
+	}
+	return true, ""
+}
+
+// suspendAgent performs the core SUSPEND action shared by the HTTP lifecycle
+// handler and the auto-suspend scheduler: it validates harness resume support,
+// syncs the workspace on stop, dispatches the container stop to the runtime
+// broker, persists phase=suspended (container_status=stopped, activity cleared),
+// and publishes the resulting status event. It returns *errHarnessNoResume when
+// the harness cannot resume so callers can decline to suspend.
+func (s *Server) suspendAgent(ctx context.Context, agent *store.Agent) error {
+	if ok, reason := s.harnessSupportsResume(agent); !ok {
+		return &errHarnessNoResume{reason: reason}
+	}
+
+	dispatcher := s.GetDispatcher()
+	if dispatcher != nil && agent.RuntimeBrokerID != "" {
+		s.syncWorkspaceOnStop(ctx, agent)
+		if err := dispatcher.DispatchAgentStop(ctx, agent); err != nil {
+			return err
+		}
+	}
+
+	newPhase := string(state.PhaseSuspended)
+	if err := s.store.UpdateAgentStatus(ctx, agent.ID, store.AgentStatusUpdate{
+		Phase:           newPhase,
+		ContainerStatus: "stopped",
+		Activity:        "",
+	}); err != nil {
+		return err
+	}
+
+	agent.Phase = newPhase
+	s.events.PublishAgentStatus(ctx, agent)
+	return nil
+}
+
 func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id, action string) {
 	ctx := r.Context()
 
@@ -3063,29 +3129,21 @@ func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id
 			dispatchErr = dispatcher.DispatchAgentStop(ctx, agent)
 		}
 	case api.AgentActionSuspend:
-		// Validate that the agent's harness supports session resume.
-		harnessName := ""
-		if agent.AppliedConfig != nil {
-			harnessName = agent.AppliedConfig.HarnessConfig
-		}
-		if harnessName != "" {
-			h := harness.New(harnessName)
-			caps := h.AdvancedCapabilities()
-			if caps.Resume.Support == api.SupportNo {
-				reason := caps.Resume.Reason
-				if reason == "" {
-					reason = "harness does not support session resume"
-				}
+		// Suspend is fully handled by the shared suspendAgent helper, which
+		// validates harness resume support, dispatches the stop, persists
+		// phase=suspended, and publishes the status event.
+		if err := s.suspendAgent(ctx, agent); err != nil {
+			var noResume *errHarnessNoResume
+			if errors.As(err, &noResume) {
 				writeError(w, http.StatusBadRequest, ErrCodeValidationError,
-					fmt.Sprintf("Cannot suspend agent: %s. Use 'stop' instead.", reason), nil)
+					fmt.Sprintf("Cannot suspend agent: %s. Use 'stop' instead.", noResume.Error()), nil)
 				return
 			}
+			RuntimeError(w, "Failed to dispatch to runtime broker: "+err.Error())
+			return
 		}
-		newPhase = string(state.PhaseSuspended)
-		if dispatcher != nil && agent.RuntimeBrokerID != "" {
-			s.syncWorkspaceOnStop(ctx, agent)
-			dispatchErr = dispatcher.DispatchAgentStop(ctx, agent)
-		}
+		writeJSON(w, http.StatusOK, agent)
+		return
 	case api.AgentActionRestart:
 		newPhase = string(state.PhaseRunning)
 		if dispatcher != nil && agent.RuntimeBrokerID != "" {
@@ -3118,9 +3176,10 @@ func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id
 	statusUpdate := store.AgentStatusUpdate{
 		Phase: newPhase,
 	}
-	// When stopping or suspending, also update container status so the hub immediately
+	// When stopping, also update container status so the hub immediately
 	// reflects the stopped state without waiting for the next heartbeat.
-	if action == api.AgentActionStop || action == api.AgentActionSuspend {
+	// (Suspend is handled earlier via suspendAgent and returns before here.)
+	if action == api.AgentActionStop {
 		statusUpdate.ContainerStatus = "stopped"
 		statusUpdate.Activity = ""
 	}

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -3084,6 +3084,8 @@ func (s *Server) suspendAgent(ctx context.Context, agent *store.Agent) error {
 	}
 
 	agent.Phase = newPhase
+	agent.ContainerStatus = "stopped"
+	agent.Activity = ""
 	s.events.PublishAgentStatus(ctx, agent)
 	return nil
 }
@@ -3129,6 +3131,14 @@ func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id
 			dispatchErr = dispatcher.DispatchAgentStop(ctx, agent)
 		}
 	case api.AgentActionSuspend:
+		// Only running agents can be suspended via the HTTP lifecycle handler.
+		// (The auto-suspend scheduler calls suspendAgent directly and already
+		// restricts itself to running+stalled agents.)
+		if agent.Phase != string(state.PhaseRunning) {
+			writeError(w, http.StatusBadRequest, ErrCodeValidationError,
+				fmt.Sprintf("Cannot suspend agent in phase %q. Only running agents can be suspended.", agent.Phase), nil)
+			return
+		}
 		// Suspend is fully handled by the shared suspendAgent helper, which
 		// validates harness resume support, dispatches the stop, persists
 		// phase=suspended, and publishes the status event.

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -5043,3 +5043,42 @@ func TestBrokerHeartbeat_DoesNotRevertSuspendedAgent(t *testing.T) {
 	assert.NotEqual(t, string(state.ActivityCrashed), updated.Activity,
 		"heartbeat should not stick crashed activity on a suspended agent")
 }
+
+// TestAgentLifecycleSuspend_RejectsNonRunningAgent verifies that the suspend
+// lifecycle action returns HTTP 400 for an agent that is not in the running
+// phase, and does not change the agent's phase.
+func TestAgentLifecycleSuspend_RejectsNonRunningAgent(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:   tid("proj-susp-guard"),
+		Name: "Suspend Guard Project",
+		Slug: "susp-guard-project",
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	agent := &store.Agent{
+		ID:        tid("agent-susp-guard"),
+		Slug:      "susp-guard-slug",
+		Name:      "Suspend Guard Agent",
+		ProjectID: project.ID,
+		Phase:     string(state.PhaseStopped),
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+agent.ID+"/suspend", nil)
+	req.Header.Set("Authorization", "Bearer "+testDevToken)
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code,
+		"suspending a non-running agent should return 400")
+
+	// Phase must be unchanged.
+	updated, err := s.GetAgent(ctx, agent.ID)
+	require.NoError(t, err)
+	assert.Equal(t, string(state.PhaseStopped), updated.Phase,
+		"rejected suspend must not change the agent's phase")
+}

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -781,7 +781,7 @@ func (d *createAgentDispatcher) DispatchAgentProvision(_ context.Context, agent 
 	agent.Phase = string(state.PhaseCreated)
 	return nil
 }
-func (d *createAgentDispatcher) DispatchAgentStart(_ context.Context, _ *store.Agent, _ string) error {
+func (d *createAgentDispatcher) DispatchAgentStart(_ context.Context, _ *store.Agent, _ string, _ bool) error {
 	d.startCalled = true
 	return nil
 }

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -4870,3 +4870,97 @@ func TestBrokerHeartbeat_RejectsPhaseRegression(t *testing.T) {
 	assert.Equal(t, string(state.PhaseRunning), updated.Phase,
 		"heartbeat should not regress phase from running to starting")
 }
+
+// TestAgentStatusUpdate_SuspendedIsStickyAgainstStatusPost verifies that a
+// dying container's async sciontool /status POST (phase=stopped,
+// activity=crashed) cannot clobber a suspended agent's phase. If it did, a
+// subsequent /start would not see suspended and would skip the harness
+// --continue (resume) flag.
+func TestAgentStatusUpdate_SuspendedIsStickyAgainstStatusPost(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{ID: tid("proj-susp-status"), Name: "Suspend Status Project", Slug: "susp-status-project"}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	agent := &store.Agent{
+		ID: tid("agent-susp-status"), Slug: "susp-status-slug", Name: "Suspend Status Agent",
+		ProjectID: project.ID, Phase: string(state.PhaseSuspended),
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	tokenSvc := srv.GetAgentTokenService()
+	require.NotNil(t, tokenSvc)
+	token, err := tokenSvc.GenerateAgentToken(agent.ID, project.ID, []AgentTokenScope{ScopeAgentStatusUpdate}, nil)
+	require.NoError(t, err)
+
+	// The dying container reports stopped+crashed via the async status POST.
+	status := store.AgentStatusUpdate{
+		Phase:    string(state.PhaseStopped),
+		Activity: string(state.ActivityCrashed),
+	}
+	body, _ := json.Marshal(status)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+agent.ID+"/status", bytes.NewReader(body))
+	req.Header.Set("X-Scion-Agent-Token", token)
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Phase should remain suspended and no crashed activity should stick.
+	updated, err := s.GetAgent(ctx, agent.ID)
+	require.NoError(t, err)
+	assert.Equal(t, string(state.PhaseSuspended), updated.Phase,
+		"suspended phase must be sticky against async status POST")
+	assert.NotEqual(t, string(state.ActivityCrashed), updated.Activity,
+		"crashed activity must not stick on a suspended agent")
+}
+
+// TestBrokerHeartbeat_DoesNotRevertSuspendedAgent verifies that a racing broker
+// heartbeat reporting stopped/crashed for a suspended agent leaves it suspended.
+func TestBrokerHeartbeat_DoesNotRevertSuspendedAgent(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{ID: tid("proj-susp-hb"), Name: "Suspend HB Project", Slug: "susp-hb-project"}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	broker := &store.RuntimeBroker{
+		ID: tid("broker-susp-hb"), Name: "Suspend HB Broker", Slug: "susp-hb-broker",
+		Status: store.BrokerStatusOnline,
+	}
+	require.NoError(t, s.CreateRuntimeBroker(ctx, broker))
+
+	agent := &store.Agent{
+		ID: tid("agent-susp-hb"), Slug: "susp-hb-slug", Name: "Suspend HB Agent",
+		ProjectID: project.ID, RuntimeBrokerID: broker.ID,
+		Phase: string(state.PhaseSuspended),
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	// The dying container's broker reports stopped+crashed via heartbeat.
+	hb := brokerHeartbeatRequest{
+		Status: "online",
+		Projects: []brokerProjectHeartbeat{{
+			ProjectID:  project.ID,
+			AgentCount: 1,
+			Agents: []brokerAgentHeartbeat{{
+				Slug:            agent.Slug,
+				Phase:           string(state.PhaseStopped),
+				Activity:        string(state.ActivityCrashed),
+				ContainerStatus: "exited",
+			}},
+		}},
+	}
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/runtime-brokers/"+broker.ID+"/heartbeat", hb)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Agent should remain suspended — heartbeat must not revert the suspended phase.
+	updated, err := s.GetAgent(ctx, agent.ID)
+	require.NoError(t, err)
+	assert.Equal(t, string(state.PhaseSuspended), updated.Phase,
+		"heartbeat should not revert suspended phase")
+	assert.NotEqual(t, string(state.ActivityCrashed), updated.Activity,
+		"heartbeat should not stick crashed activity on a suspended agent")
+}

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -3094,6 +3094,85 @@ func TestBrokerHeartbeat_PublishesActivitySSE(t *testing.T) {
 	}
 }
 
+// TestBrokerHeartbeat_ContainerExitedDerivesCrash verifies that a broker
+// heartbeat reporting a non-zero container exit code is mapped to PhaseError
+// (with the exit code recorded), while a clean (zero) exit maps to PhaseStopped.
+// This works even if sciontool's own crash report never reached the hub.
+func TestBrokerHeartbeat_ContainerExitedDerivesCrash(t *testing.T) {
+	cases := []struct {
+		name            string
+		containerStatus string
+		hbPhase         string
+		wantPhase       string
+		wantMessage     string
+	}{
+		{
+			name:            "non-zero exit -> error",
+			containerStatus: "Exited (137) 2 minutes ago",
+			hbPhase:         string(state.PhaseStopped),
+			wantPhase:       string(state.PhaseError),
+			wantMessage:     "Agent crashed with exit code 137",
+		},
+		{
+			name:            "zero exit -> stopped",
+			containerStatus: "Exited (0) 3 hours ago",
+			hbPhase:         string(state.PhaseStopped),
+			wantPhase:       string(state.PhaseStopped),
+		},
+		{
+			name:            "non-zero exit, legacy path (no structured phase) -> error",
+			containerStatus: "Exited (1) 5 seconds ago",
+			hbPhase:         "",
+			wantPhase:       string(state.PhaseError),
+			wantMessage:     "Agent crashed with exit code 1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, s := testServer(t)
+			ctx := context.Background()
+
+			project := &store.Project{ID: tid("project-hb-crash"), Name: "P", Slug: "hb-crash-project"}
+			require.NoError(t, s.CreateProject(ctx, project))
+			broker := &store.RuntimeBroker{
+				ID: tid("broker-hb-crash"), Name: "B", Slug: "hb-crash-broker",
+				Status: store.BrokerStatusOnline,
+			}
+			require.NoError(t, s.CreateRuntimeBroker(ctx, broker))
+			agent := &store.Agent{
+				ID: tid("agent-hb-crash"), Slug: "agent-hb-crash-slug", Name: "A",
+				ProjectID: project.ID, RuntimeBrokerID: broker.ID,
+				Phase: string(state.PhaseRunning),
+			}
+			require.NoError(t, s.CreateAgent(ctx, agent))
+
+			heartbeat := brokerHeartbeatRequest{
+				Status: "online",
+				Projects: []brokerProjectHeartbeat{{
+					ProjectID:  project.ID,
+					AgentCount: 1,
+					Agents: []brokerAgentHeartbeat{{
+						Slug:            agent.Slug,
+						Phase:           tc.hbPhase,
+						ContainerStatus: tc.containerStatus,
+					}},
+				}},
+			}
+
+			rec := doRequest(t, srv, http.MethodPost, "/api/v1/runtime-brokers/"+broker.ID+"/heartbeat", heartbeat)
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			updated, err := s.GetAgent(ctx, agent.ID)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantPhase, updated.Phase)
+			if tc.wantMessage != "" {
+				assert.Equal(t, tc.wantMessage, updated.Message)
+			}
+		})
+	}
+}
+
 func TestBrokerHeartbeat_RepeatedActivityDoesNotRefreshLastActivityEvent(t *testing.T) {
 	srv, s := testServer(t)
 	ctx := context.Background()

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -54,8 +54,8 @@ func (c *HTTPRuntimeBrokerClient) CreateAgent(ctx context.Context, brokerID, bro
 	return c.transport.CreateAgent(ctx, brokerID, brokerEndpoint, req)
 }
 
-func (c *HTTPRuntimeBrokerClient) StartAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig string, resolvedEnv map[string]string, resolvedSecrets []ResolvedSecret, inlineConfig *api.ScionConfig, sharedDirs []api.SharedDir, sharedWorkspace bool) (*RemoteAgentResponse, error) {
-	return c.transport.StartAgent(ctx, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig, resolvedEnv, resolvedSecrets, inlineConfig, sharedDirs, sharedWorkspace)
+func (c *HTTPRuntimeBrokerClient) StartAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig string, resolvedEnv map[string]string, resolvedSecrets []ResolvedSecret, inlineConfig *api.ScionConfig, sharedDirs []api.SharedDir, sharedWorkspace, resume bool) (*RemoteAgentResponse, error) {
+	return c.transport.StartAgent(ctx, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig, resolvedEnv, resolvedSecrets, inlineConfig, sharedDirs, sharedWorkspace, resume)
 }
 
 func (c *HTTPRuntimeBrokerClient) StopAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID string) error {
@@ -965,8 +965,12 @@ func (d *HTTPAgentDispatcher) buildEnvSources(ctx context.Context, agent *store.
 	return sources
 }
 
-// DispatchAgentStart starts an agent on the runtime broker.
-func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *store.Agent, task string) error {
+// DispatchAgentStart starts an agent on the runtime broker. When resume is
+// true, the harness is asked to continue its prior session (e.g. Claude
+// --continue) instead of starting a fresh conversation. The hub is the source
+// of truth for resume: callers compute it from the agent's stored phase
+// (suspended → resume).
+func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *store.Agent, task string, resume bool) error {
 	if err := requireRuntimeBrokerAssigned(agent); err != nil {
 		return err
 	}
@@ -976,8 +980,11 @@ func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *sto
 		return err
 	}
 
-	// If no explicit task provided, fall back to the agent's applied config task
-	if task == "" && agent.AppliedConfig != nil {
+	// If no explicit task provided, fall back to the agent's applied config
+	// task. Skip this on a pure resume (no new message): the harness should
+	// just continue its prior session rather than be re-handed the original
+	// creation task. A wake-with-message still passes that message as task.
+	if task == "" && !resume && agent.AppliedConfig != nil {
 		task = agent.AppliedConfig.Task
 	}
 
@@ -1165,10 +1172,11 @@ func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *sto
 		inlineConfig = agent.AppliedConfig.InlineConfig
 	}
 
-	resp, err := d.client.StartAgent(ctx, agent.RuntimeBrokerID, endpoint, agent.Slug, agent.ProjectID, task, projectPath, projectSlug, harnessConfig, resolvedEnv, resolvedSecrets, inlineConfig, projectInfo.sharedDirs, projectInfo.sharedWorkspace)
+	resp, err := d.client.StartAgent(ctx, agent.RuntimeBrokerID, endpoint, agent.Slug, agent.ProjectID, task, projectPath, projectSlug, harnessConfig, resolvedEnv, resolvedSecrets, inlineConfig, projectInfo.sharedDirs, projectInfo.sharedWorkspace, resume)
 	if errors.Is(err, ErrLifecycleDeferred) {
 		return d.deferredStart(ctx, agent, &StartDispatchArgs{
-			Task: task,
+			Task:   task,
+			Resume: resume,
 		})
 	}
 	if err != nil {

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -94,7 +94,7 @@ func (m *mockRuntimeBrokerClient) CreateAgent(ctx context.Context, brokerID, bro
 	}, nil
 }
 
-func (m *mockRuntimeBrokerClient) StartAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig string, resolvedEnv map[string]string, resolvedSecrets []ResolvedSecret, inlineConfig *api.ScionConfig, sharedDirs []api.SharedDir, sharedWorkspace bool) (*RemoteAgentResponse, error) {
+func (m *mockRuntimeBrokerClient) StartAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig string, resolvedEnv map[string]string, resolvedSecrets []ResolvedSecret, inlineConfig *api.ScionConfig, sharedDirs []api.SharedDir, sharedWorkspace, resume bool) (*RemoteAgentResponse, error) {
 	m.startCalled = true
 	m.lastBrokerID = brokerID
 	m.lastEndpoint = brokerEndpoint
@@ -446,7 +446,7 @@ func TestHTTPRuntimeBrokerClient_StartAgent_InvalidJSONFails(t *testing.T) {
 	defer server.Close()
 
 	client := NewHTTPRuntimeBrokerClient()
-	_, err := client.StartAgent(context.Background(), tid("host-1"), server.URL, "test-agent", "", "", "", "", "", nil, nil, nil, nil, false)
+	_, err := client.StartAgent(context.Background(), tid("host-1"), server.URL, "test-agent", "", "", "", "", "", nil, nil, nil, nil, false, false)
 	if err == nil {
 		t.Fatal("expected StartAgent to fail on invalid JSON response")
 	}
@@ -1124,7 +1124,7 @@ func TestHTTPAgentDispatcher_DispatchAgentStart_WithProjectProviderPath(t *testi
 		RuntimeBrokerID: tid("broker-1"),
 	}
 
-	err := dispatcher.DispatchAgentStart(ctx, agent, "do task")
+	err := dispatcher.DispatchAgentStart(ctx, agent, "do task", false)
 	if err != nil {
 		t.Fatalf("DispatchAgentStart failed: %v", err)
 	}
@@ -1199,7 +1199,7 @@ func TestHTTPAgentDispatcher_DispatchAgentStart_IncludesAgentIdentity(t *testing
 		RuntimeBrokerID: tid("broker-1"),
 	}
 
-	err := dispatcher.DispatchAgentStart(ctx, agent, "")
+	err := dispatcher.DispatchAgentStart(ctx, agent, "", false)
 	if err != nil {
 		t.Fatalf("DispatchAgentStart failed: %v", err)
 	}
@@ -1268,7 +1268,7 @@ func TestHTTPAgentDispatcher_DispatchAgentStart_HubManagedProject(t *testing.T) 
 		RuntimeBrokerID: tid("broker-1"),
 	}
 
-	err := dispatcher.DispatchAgentStart(ctx, agent, "")
+	err := dispatcher.DispatchAgentStart(ctx, agent, "", false)
 	if err != nil {
 		t.Fatalf("DispatchAgentStart failed: %v", err)
 	}
@@ -1325,7 +1325,7 @@ func TestHTTPAgentDispatcher_DispatchAgentStart_ProjectSlugSetForGitRemoteWithou
 		RuntimeBrokerID: tid("broker-1"),
 	}
 
-	err := dispatcher.DispatchAgentStart(ctx, agent, "")
+	err := dispatcher.DispatchAgentStart(ctx, agent, "", false)
 	if err != nil {
 		t.Fatalf("DispatchAgentStart failed: %v", err)
 	}
@@ -1416,7 +1416,7 @@ func TestHTTPAgentDispatcher_DispatchAgentStart_ResolvesEnvFromStorage(t *testin
 		},
 	}
 
-	err := dispatcher.DispatchAgentStart(ctx, agent, "")
+	err := dispatcher.DispatchAgentStart(ctx, agent, "", false)
 	if err != nil {
 		t.Fatalf("DispatchAgentStart failed: %v", err)
 	}
@@ -1497,7 +1497,7 @@ func TestHTTPAgentDispatcher_DispatchAgentStart_ConfigEnvTakesPrecedence(t *test
 		},
 	}
 
-	err := dispatcher.DispatchAgentStart(ctx, agent, "")
+	err := dispatcher.DispatchAgentStart(ctx, agent, "", false)
 	if err != nil {
 		t.Fatalf("DispatchAgentStart failed: %v", err)
 	}
@@ -1564,7 +1564,7 @@ func TestHTTPAgentDispatcher_DispatchAgentStart_StorageOverridesEmptyConfigEnv(t
 		},
 	}
 
-	err := dispatcher.DispatchAgentStart(ctx, agent, "")
+	err := dispatcher.DispatchAgentStart(ctx, agent, "", false)
 	if err != nil {
 		t.Fatalf("DispatchAgentStart failed: %v", err)
 	}
@@ -1756,7 +1756,7 @@ func TestHTTPAgentDispatcher_DispatchAgentStart_AppliesBrokerResponse(t *testing
 		Phase:           string(state.PhaseCreated),
 	}
 
-	err := dispatcher.DispatchAgentStart(ctx, agent, "")
+	err := dispatcher.DispatchAgentStart(ctx, agent, "", false)
 	if err != nil {
 		t.Fatalf("DispatchAgentStart failed: %v", err)
 	}
@@ -2726,7 +2726,7 @@ func TestHTTPAgentDispatcher_DispatchAgentStart_IncludesAgentIDAndSlug(t *testin
 		},
 	}
 
-	err := dispatcher.DispatchAgentStart(ctx, agent, "do something")
+	err := dispatcher.DispatchAgentStart(ctx, agent, "do something", false)
 	if err != nil {
 		t.Fatalf("DispatchAgentStart failed: %v", err)
 	}
@@ -2804,7 +2804,7 @@ func TestHTTPAgentDispatcher_DispatchAgentStart_IncludesInlineConfig(t *testing.
 		},
 	}
 
-	err := dispatcher.DispatchAgentStart(ctx, agent, "")
+	err := dispatcher.DispatchAgentStart(ctx, agent, "", false)
 	if err != nil {
 		t.Fatalf("DispatchAgentStart failed: %v", err)
 	}
@@ -2855,7 +2855,7 @@ func TestDispatchAgentStart_IncludesHubEndpoint(t *testing.T) {
 		},
 	}
 
-	err := dispatcher.DispatchAgentStart(ctx, agent, "")
+	err := dispatcher.DispatchAgentStart(ctx, agent, "", false)
 	if err != nil {
 		t.Fatalf("DispatchAgentStart failed: %v", err)
 	}
@@ -3006,7 +3006,7 @@ func TestHTTPAgentDispatcher_DispatchAgentStart_InjectsGCPIdentityEnv(t *testing
 		},
 	}
 
-	err := dispatcher.DispatchAgentStart(ctx, agent, "")
+	err := dispatcher.DispatchAgentStart(ctx, agent, "", false)
 	if err != nil {
 		t.Fatalf("DispatchAgentStart failed: %v", err)
 	}
@@ -3079,7 +3079,7 @@ func TestHTTPAgentDispatcher_DispatchAgentStart_GCPBlockMode(t *testing.T) {
 		},
 	}
 
-	err := dispatcher.DispatchAgentStart(ctx, agent, "")
+	err := dispatcher.DispatchAgentStart(ctx, agent, "", false)
 	if err != nil {
 		t.Fatalf("DispatchAgentStart failed: %v", err)
 	}

--- a/pkg/hub/messagebroker_test.go
+++ b/pkg/hub/messagebroker_test.go
@@ -48,7 +48,7 @@ func (d *brokerMockDispatcher) DispatchAgentCreate(ctx context.Context, agent *s
 func (d *brokerMockDispatcher) DispatchAgentProvision(ctx context.Context, agent *store.Agent) error {
 	return nil
 }
-func (d *brokerMockDispatcher) DispatchAgentStart(ctx context.Context, agent *store.Agent, task string) error {
+func (d *brokerMockDispatcher) DispatchAgentStart(ctx context.Context, agent *store.Agent, task string, _ bool) error {
 	return nil
 }
 func (d *brokerMockDispatcher) DispatchAgentStop(ctx context.Context, agent *store.Agent) error {

--- a/pkg/hub/notifications_test.go
+++ b/pkg/hub/notifications_test.go
@@ -69,7 +69,7 @@ func (d *recordingDispatcher) DispatchAgentCreate(_ context.Context, _ *store.Ag
 func (d *recordingDispatcher) DispatchAgentProvision(_ context.Context, _ *store.Agent) error {
 	return nil
 }
-func (d *recordingDispatcher) DispatchAgentStart(_ context.Context, _ *store.Agent, _ string) error {
+func (d *recordingDispatcher) DispatchAgentStart(_ context.Context, _ *store.Agent, _ string, _ bool) error {
 	return nil
 }
 func (d *recordingDispatcher) DispatchAgentStop(_ context.Context, _ *store.Agent) error { return nil }

--- a/pkg/hub/reconcile.go
+++ b/pkg/hub/reconcile.go
@@ -165,14 +165,16 @@ func (s *Server) execDispatchStart(ctx context.Context, d store.BrokerDispatch) 
 		return "", fmt.Errorf("no dispatcher available")
 	}
 	var task string
+	var resume bool
 	if d.Args != "" {
 		args, err := UnmarshalStartArgs(d.Args)
 		if err != nil {
 			return "", fmt.Errorf("unmarshal start args: %w", err)
 		}
 		task = args.Task
+		resume = args.Resume
 	}
-	if err := dispatcher.DispatchAgentStart(ctx, agent, task); err != nil {
+	if err := dispatcher.DispatchAgentStart(ctx, agent, task, resume); err != nil {
 		return "", fmt.Errorf("dispatch start: %w", err)
 	}
 	return "", nil

--- a/pkg/hub/reconcile_test.go
+++ b/pkg/hub/reconcile_test.go
@@ -216,7 +216,7 @@ func (d *reconcileTestDispatcher) DispatchAgentCreate(context.Context, *store.Ag
 func (d *reconcileTestDispatcher) DispatchAgentProvision(context.Context, *store.Agent) error {
 	return nil
 }
-func (d *reconcileTestDispatcher) DispatchAgentStart(context.Context, *store.Agent, string) error {
+func (d *reconcileTestDispatcher) DispatchAgentStart(context.Context, *store.Agent, string, bool) error {
 	return nil
 }
 func (d *reconcileTestDispatcher) DispatchAgentStop(context.Context, *store.Agent) error { return nil }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1768,7 +1768,14 @@ func (s *Server) agentAutoSuspendHandler() func(ctx context.Context) {
 				continue
 			}
 
-			if err := s.suspendAgent(ctx, agent); err != nil {
+			// Bound each suspension with its own timeout so a slow or
+			// unresponsive broker cannot block the whole scheduler loop.
+			err := func() error {
+				childCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+				defer cancel()
+				return s.suspendAgent(childCtx, agent)
+			}()
+			if err != nil {
 				s.agentLifecycleLog.Warn("Scheduler: auto-suspend failed",
 					"agent_id", agent.ID, "error", err)
 				continue

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -243,7 +243,9 @@ type AgentDispatcher interface {
 
 	// DispatchAgentStart resumes a stopped agent on the runtime broker.
 	// task is an optional task string to pass to the agent on start.
-	DispatchAgentStart(ctx context.Context, agent *store.Agent, task string) error
+	// resume requests harness session continuation (e.g. Claude --continue);
+	// callers compute it from the agent's stored phase (suspended → resume).
+	DispatchAgentStart(ctx context.Context, agent *store.Agent, task string, resume bool) error
 
 	// DispatchAgentStop stops a running agent on the runtime broker.
 	DispatchAgentStop(ctx context.Context, agent *store.Agent) error
@@ -304,7 +306,7 @@ type RuntimeBrokerClient interface {
 	// sharedWorkspace indicates the project uses a shared workspace mount
 	// (hub-project / git-workspace hybrid) so the broker must not create a
 	// per-agent worktree on (re-)start.
-	StartAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig string, resolvedEnv map[string]string, resolvedSecrets []ResolvedSecret, inlineConfig *api.ScionConfig, sharedDirs []api.SharedDir, sharedWorkspace bool) (*RemoteAgentResponse, error)
+	StartAgent(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID, task, projectPath, projectSlug, harnessConfig string, resolvedEnv map[string]string, resolvedSecrets []ResolvedSecret, inlineConfig *api.ScionConfig, sharedDirs []api.SharedDir, sharedWorkspace, resume bool) (*RemoteAgentResponse, error)
 
 	// StopAgent stops an agent on a remote runtime broker.
 	// brokerID is used for HMAC authentication lookup.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1705,6 +1705,11 @@ func (s *Server) agentHeartbeatTimeoutHandler() func(ctx context.Context) {
 	}
 }
 
+// autoSuspendStalledGrace is the extra time an agent must remain stalled,
+// beyond StalledThreshold, before it is automatically suspended to reclaim its
+// container. The agent resumes correctly on its next message.
+const autoSuspendStalledGrace = 5 * time.Minute
+
 // agentStalledDetectionHandler returns a recurring handler function that marks
 // agents as stalled when their last activity event exceeds the stalled threshold
 // but they still have a recent heartbeat (process alive but hung).
@@ -1728,6 +1733,54 @@ func (s *Server) agentStalledDetectionHandler() func(ctx context.Context) {
 		if len(agents) > 0 {
 			slog.Info("Scheduler: marked stalled agents",
 				"count", len(agents), "threshold", s.config.StalledThreshold)
+		}
+	}
+}
+
+// agentAutoSuspendHandler returns a recurring handler function that reclaims the
+// container backing an agent that has been stalled for an extra grace period
+// beyond StalledThreshold. It suspends the agent (stops the container, sets
+// phase=suspended); the agent resumes correctly on its next message. Agents
+// whose harness cannot resume are never auto-suspended and are left stalled.
+func (s *Server) agentAutoSuspendHandler() func(ctx context.Context) {
+	return func(ctx context.Context) {
+		// Require the agent to have been stalled an additional grace period
+		// beyond the stall threshold before reclaiming its container.
+		activityThreshold := time.Now().Add(-(s.config.StalledThreshold + autoSuspendStalledGrace))
+		// Only reclaim agents whose container is still alive/resumable, using
+		// the same heartbeat recency window as the stall detector.
+		heartbeatRecency := time.Now().Add(-2 * time.Minute)
+
+		candidates, err := s.store.FindAutoSuspendCandidates(ctx, activityThreshold, heartbeatRecency)
+		if err != nil {
+			slog.Error("Scheduler: auto-suspend candidate lookup failed", "error", err)
+			return
+		}
+
+		suspended := 0
+		for i := range candidates {
+			agent := &candidates[i]
+
+			// Never auto-suspend an agent we cannot resume; leave it stalled.
+			if ok, reason := s.harnessSupportsResume(agent); !ok {
+				slog.Info("Scheduler: skipping auto-suspend, harness does not support resume",
+					"agent_id", agent.ID, "reason", reason)
+				continue
+			}
+
+			if err := s.suspendAgent(ctx, agent); err != nil {
+				s.agentLifecycleLog.Warn("Scheduler: auto-suspend failed",
+					"agent_id", agent.ID, "error", err)
+				continue
+			}
+			suspended++
+			s.agentLifecycleLog.Info("Scheduler: auto-suspended stalled agent",
+				"agent_id", agent.ID, "threshold", s.config.StalledThreshold+autoSuspendStalledGrace)
+		}
+
+		if suspended > 0 {
+			slog.Info("Scheduler: auto-suspended stalled agents",
+				"count", suspended, "threshold", s.config.StalledThreshold+autoSuspendStalledGrace)
 		}
 	}
 }
@@ -2096,6 +2149,7 @@ func (s *Server) StartBackgroundServices(ctx context.Context) {
 	// CONCURRENCY-AUDIT.md §"Singleton / leader".
 	s.scheduler.RegisterRecurringSingleton("agent-heartbeat-timeout", 1, store.LockAgentHeartbeatTimeout, s.agentHeartbeatTimeoutHandler())
 	s.scheduler.RegisterRecurringSingleton("agent-stalled-detection", 1, store.LockAgentStalledDetection, s.agentStalledDetectionHandler())
+	s.scheduler.RegisterRecurringSingleton("agent-auto-suspend", 1, store.LockAgentAutoSuspend, s.agentAutoSuspendHandler())
 	if s.config.SoftDeleteRetention > 0 {
 		s.scheduler.RegisterRecurringSingleton("soft-delete-purge", 60, store.LockSoftDeletePurge, s.purgeHandler())
 	}

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 )
@@ -69,13 +70,6 @@ func ResolveContainerWorkspace(repoRoot, workspace string, gitClone *api.GitClon
 	}
 	return "/workspace"
 }
-
-// harnessExitCodeFile is the container-local path where the harness's real
-// exit code is recorded by the tmux agent-window wrapper. There is one agent
-// per container, so a fixed path is safe. `sciontool init` reads this file to
-// recover the authoritative harness exit code (the harness runs as a tmux
-// grandchild whose exit code is otherwise invisible to the supervisor).
-const harnessExitCodeFile = "/tmp/scion-harness-exit-code"
 
 // shellQuote returns s quoted for safe embedding in a POSIX shell command.
 // It uses single quotes, which prevent all shell interpretation (variable
@@ -454,7 +448,7 @@ func buildCommonRunArgs(config RunConfig) ([]string, error) {
 	// the sh/container exit code). Writing $? lets init read the authoritative
 	// harness exit code and report crashes correctly. The whole wrapper is
 	// single-quoted again so tmux's command parser treats it as one word.
-	agentWindowCmd := "sh -c " + shellQuote(cmdLine+"; echo $? > "+harnessExitCodeFile)
+	agentWindowCmd := "sh -c " + shellQuote(cmdLine+"; echo $? > "+state.HarnessExitCodeFile)
 
 	// Build tmux command: create session with "agent" window running the harness,
 	// then add a "shell" window and switch back to the agent window.

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -67,6 +69,13 @@ func ResolveContainerWorkspace(repoRoot, workspace string, gitClone *api.GitClon
 	}
 	return "/workspace"
 }
+
+// harnessExitCodeFile is the container-local path where the harness's real
+// exit code is recorded by the tmux agent-window wrapper. There is one agent
+// per container, so a fixed path is safe. `sciontool init` reads this file to
+// recover the authoritative harness exit code (the harness runs as a tmux
+// grandchild whose exit code is otherwise invisible to the supervisor).
+const harnessExitCodeFile = "/tmp/scion-harness-exit-code"
 
 // shellQuote returns s quoted for safe embedding in a POSIX shell command.
 // It uses single quotes, which prevent all shell interpretation (variable
@@ -439,11 +448,19 @@ func buildCommonRunArgs(config RunConfig) ([]string, error) {
 	}
 	cmdLine := strings.Join(quotedArgs, " ")
 
+	// Wrap the harness in a shell that records its real exit code to a fixed
+	// file. The harness runs as a tmux grandchild, so its exit code is
+	// otherwise invisible to the `sciontool init` supervisor (which only sees
+	// the sh/container exit code). Writing $? lets init read the authoritative
+	// harness exit code and report crashes correctly. The whole wrapper is
+	// single-quoted again so tmux's command parser treats it as one word.
+	agentWindowCmd := "sh -c " + shellQuote(cmdLine+"; echo $? > "+harnessExitCodeFile)
+
 	// Build tmux command: create session with "agent" window running the harness,
 	// then add a "shell" window and switch back to the agent window.
 	tmuxCmd := fmt.Sprintf(
 		"tmux new-session -d -s scion -n agent %s \\; set-option -g window-size latest \\; new-window -t scion -n shell \\; select-window -t scion:agent \\; attach-session -t scion",
-		cmdLine,
+		agentWindowCmd,
 	)
 
 	if len(fuseMounts) > 0 {
@@ -851,4 +868,24 @@ func phaseFromContainerStatus(status string) string {
 	default:
 		return "created"
 	}
+}
+
+// exitedStatusRe matches the exit code in container-runtime status strings such
+// as "Exited (137) 2 minutes ago" (Docker/Podman) or "exited (0)".
+var exitedStatusRe = regexp.MustCompile(`(?i)exited\s*\((\d+)\)`)
+
+// ExitCodeFromContainerStatus extracts the exit code from a container status
+// string like "Exited (137) 2 minutes ago". It returns (code, true) when an
+// exited status with a parseable code is present, otherwise (0, false). A plain
+// "stopped" (no embedded code) yields (0, false).
+func ExitCodeFromContainerStatus(status string) (int, bool) {
+	m := exitedStatusRe.FindStringSubmatch(status)
+	if m == nil {
+		return 0, false
+	}
+	code, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, false
+	}
+	return code, true
 }

--- a/pkg/runtime/common_test.go
+++ b/pkg/runtime/common_test.go
@@ -268,7 +268,11 @@ func TestBuildCommonRunArgs(t *testing.T) {
 			},
 			wantIn: []string{
 				"-e FOO=BAR",
-				"tmux new-session -d -s scion -n agent 'gemini' '--yolo' '--resume' '--prompt-interactive' 'hello'",
+				// The harness now runs inside an `sh -c` wrapper that captures
+				// its exit code to a fixed file (see harnessExitCodeFile).
+				"tmux new-session -d -s scion -n agent sh -c ",
+				`'\''gemini'\'' '\''--yolo'\'' '\''--resume'\'' '\''--prompt-interactive'\'' '\''hello'\''`,
+				"; echo $? > /tmp/scion-harness-exit-code",
 			},
 		},
 		{
@@ -281,7 +285,9 @@ func TestBuildCommonRunArgs(t *testing.T) {
 				Resume:  true,
 			},
 			wantIn: []string{
-				"tmux new-session -d -s scion -n agent 'gemini' '--yolo' '--resume' '--prompt-interactive' 'hello'",
+				"tmux new-session -d -s scion -n agent sh -c ",
+				`'\''gemini'\'' '\''--yolo'\'' '\''--resume'\'' '\''--prompt-interactive'\'' '\''hello'\''`,
+				"; echo $? > /tmp/scion-harness-exit-code",
 			},
 		},
 		{
@@ -1449,11 +1455,48 @@ func TestBuildCommonRunArgs_ShellMetacharsInPrompt(t *testing.T) {
 			}
 
 			// The last arg is the tmux command passed to "sh -c".
-			// Verify the prompt is single-quoted (not double-quoted).
+			// Verify the prompt is single-quoted (not double-quoted). The harness
+			// arg is single-quoted once (shellQuote), and the whole agent-window
+			// script is single-quoted again for the `sh -c` exit-code wrapper, so
+			// the inner single quotes are re-escaped as '\''.
 			shCmd := args[len(args)-1]
 			quoted := shellQuote(tt.task)
-			if !strings.Contains(shCmd, quoted) {
-				t.Errorf("expected single-quoted prompt %q in sh -c arg, got: %s", quoted, shCmd)
+			reEscaped := strings.ReplaceAll(quoted, "'", `'\''`)
+			if !strings.Contains(shCmd, reEscaped) {
+				t.Errorf("expected re-escaped single-quoted prompt %q in sh -c arg, got: %s", reEscaped, shCmd)
+			}
+			// Ensure the prompt is never double-quoted (which would let the shell
+			// interpret metacharacters like $ and backticks).
+			if strings.Contains(shCmd, `"`+tt.task+`"`) {
+				t.Errorf("prompt was double-quoted in sh -c arg, got: %s", shCmd)
+			}
+		})
+	}
+}
+
+func TestExitCodeFromContainerStatus(t *testing.T) {
+	tests := []struct {
+		status   string
+		wantCode int
+		wantOK   bool
+	}{
+		{"Exited (0) 3 hours ago", 0, true},
+		{"Exited (137) 2 minutes ago", 137, true},
+		{"exited (1)", 1, true},
+		{"Up 5 minutes", 0, false},
+		{"running", 0, false},
+		{"stopped", 0, false},
+		{"Created", 0, false},
+		{"", 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.status, func(t *testing.T) {
+			code, ok := ExitCodeFromContainerStatus(tc.status)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if code != tc.wantCode {
+				t.Errorf("code = %d, want %d", code, tc.wantCode)
 			}
 		})
 	}

--- a/pkg/runtime/common_test.go
+++ b/pkg/runtime/common_test.go
@@ -269,7 +269,7 @@ func TestBuildCommonRunArgs(t *testing.T) {
 			wantIn: []string{
 				"-e FOO=BAR",
 				// The harness now runs inside an `sh -c` wrapper that captures
-				// its exit code to a fixed file (see harnessExitCodeFile).
+				// its exit code to a fixed file (see state.HarnessExitCodeFile).
 				"tmux new-session -d -s scion -n agent sh -c ",
 				`'\''gemini'\'' '\''--yolo'\'' '\''--resume'\'' '\''--prompt-interactive'\'' '\''hello'\''`,
 				"; echo $? > /tmp/scion-harness-exit-code",

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -897,10 +897,14 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 		quotedArgs = append(quotedArgs, shellQuote(a))
 	}
 	cmdLine := strings.Join(quotedArgs, " ")
+	// Wrap the harness so it records its real exit code to a fixed file (see
+	// harnessExitCodeFile / buildCommonRunArgs for rationale). `sciontool init`
+	// reads this to report crashes accurately.
+	agentWindowCmd := "sh -c " + shellQuote(cmdLine+"; echo $? > "+harnessExitCodeFile)
 	// Create session with "agent" window running the harness, plus a "shell" window.
 	tmuxCmd := fmt.Sprintf(
 		"tmux new-session -d -s scion -n agent %s \\; set-option -g window-size latest \\; new-window -t scion -n shell \\; select-window -t scion:agent \\; attach-session -t scion",
-		cmdLine,
+		agentWindowCmd,
 	)
 	// --- K8s Startup Gate ---
 	//

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -898,9 +898,9 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 	}
 	cmdLine := strings.Join(quotedArgs, " ")
 	// Wrap the harness so it records its real exit code to a fixed file (see
-	// harnessExitCodeFile / buildCommonRunArgs for rationale). `sciontool init`
+	// state.HarnessExitCodeFile / buildCommonRunArgs for rationale). `sciontool init`
 	// reads this to report crashes accurately.
-	agentWindowCmd := "sh -c " + shellQuote(cmdLine+"; echo $? > "+harnessExitCodeFile)
+	agentWindowCmd := "sh -c " + shellQuote(cmdLine+"; echo $? > "+state.HarnessExitCodeFile)
 	// Create session with "agent" window running the harness, plus a "shell" window.
 	tmuxCmd := fmt.Sprintf(
 		"tmux new-session -d -s scion -n agent %s \\; set-option -g window-size latest \\; new-window -t scion -n shell \\; select-window -t scion:agent \\; attach-session -t scion",

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -1143,6 +1143,10 @@ func (s *Server) startAgent(w http.ResponseWriter, r *http.Request, id, projectI
 		// share a single git checkout instead of being given a worktree, and
 		// without this flag the broker would create a worktree on restart.
 		SharedWorkspace bool `json:"sharedWorkspace,omitempty"`
+		// Resume requests harness session continuation (e.g. Claude
+		// --continue). The hub is the source of truth and sets this from the
+		// agent's stored phase; when unset we fall back to GetSavedPhase below.
+		Resume bool `json:"resume,omitempty"`
 	}
 	if r.Body != nil && r.ContentLength != 0 {
 		if err := json.NewDecoder(r.Body).Decode(&startReq); err != nil {
@@ -1206,8 +1210,13 @@ func (s *Server) startAgent(w http.ResponseWriter, r *http.Request, id, projectI
 		opts.Profile = agent.GetSavedProfile(id, opts.ProjectPath)
 	}
 
-	// If the agent was suspended, resume with harness session preservation.
-	if opts.ProjectPath != "" {
+	// The hub is the source of truth for resume intent: when it sets
+	// req.Resume the harness must continue its prior session. We still fall
+	// back to reading the saved phase from disk when the hub did not specify
+	// resume (e.g. the local CLI path, which does not send this flag).
+	if startReq.Resume {
+		opts.Resume = true
+	} else if opts.ProjectPath != "" {
 		savedPhase := agent.GetSavedPhase(id, opts.ProjectPath)
 		if savedPhase == string(state.PhaseSuspended) {
 			opts.Resume = true

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -1167,6 +1167,13 @@ func (s *Server) startAgent(w http.ResponseWriter, r *http.Request, id, projectI
 		}
 	}
 
+	// Parity with the create path: populate the dedicated AgentToken field from
+	// the hub-minted token in ResolvedEnv so buildStartContext treats it as an
+	// explicit token rather than relying on the resolvedEnv-kept fallback. The
+	// precedence in buildStartContext step 3 keeps this token regardless, but
+	// setting it here makes the start path behave like create.
+	startContextAgentToken := startReq.ResolvedEnv["SCION_AUTH_TOKEN"]
+
 	sc, err := s.buildStartContext(ctx, startContextInputs{
 		Name:            id,
 		ProjectPath:     startReq.ProjectPath,
@@ -1175,6 +1182,7 @@ func (s *Server) startAgent(w http.ResponseWriter, r *http.Request, id, projectI
 		ResolvedEnv:     startReq.ResolvedEnv,
 		ResolvedSecrets: startReq.ResolvedSecrets,
 		SharedDirs:      startReq.SharedDirs,
+		AgentToken:      startContextAgentToken,
 		HTTPRequest:     r,
 	})
 	if err != nil {

--- a/pkg/runtimebroker/start_context.go
+++ b/pkg/runtimebroker/start_context.go
@@ -218,11 +218,24 @@ func (s *Server) buildStartContext(ctx context.Context, in startContextInputs) (
 		}
 	}
 
-	// 3. Hub auth token
+	// 3. Hub auth token. Precedence (highest first):
+	//   1. in.AgentToken — the explicit hub-provided dedicated field (create path).
+	//   2. an existing env["SCION_AUTH_TOKEN"] already populated from in.ResolvedEnv
+	//      above — on the start/resume path the hub mints the agent JWT into
+	//      resolvedEnv, so it is already present here and must be kept.
+	//   3. the broker's own dev SCION_AUTH_TOKEN — last resort only.
+	// The dev-token fallback must NOT clobber a token resolved from the hub:
+	// resume mints a valid JWT into resolvedEnv, and overwriting it with the
+	// broker's dev token caused 401s ("compact JWS format must have three parts").
 	if in.AgentToken != "" {
 		env["SCION_AUTH_TOKEN"] = in.AgentToken
 		if s.config.Debug {
 			s.agentLifecycleLog.Debug("SCION_AUTH_TOKEN set from agent token", "agent_id", in.AgentID, "length", len(in.AgentToken))
+		}
+	} else if env["SCION_AUTH_TOKEN"] != "" {
+		// Token already resolved from the hub via resolvedEnv (start/resume path); keep it.
+		if s.config.Debug {
+			s.agentLifecycleLog.Debug("SCION_AUTH_TOKEN kept from resolved env", "agent_id", in.AgentID, "length", len(env["SCION_AUTH_TOKEN"]))
 		}
 	} else if devToken := os.Getenv("SCION_AUTH_TOKEN"); devToken != "" {
 		env["SCION_AUTH_TOKEN"] = devToken

--- a/pkg/runtimebroker/start_context_test.go
+++ b/pkg/runtimebroker/start_context_test.go
@@ -168,6 +168,92 @@ func TestBuildStartContext_EnvMerging(t *testing.T) {
 	}
 }
 
+// TestBuildStartContext_AuthTokenPrecedence verifies the SCION_AUTH_TOKEN
+// resolution precedence in buildStartContext step 3:
+//  1. in.AgentToken (explicit hub-provided field) wins.
+//  2. an existing token from ResolvedEnv (start/resume path) is kept and must
+//     NOT be clobbered by the broker's own dev SCION_AUTH_TOKEN. This is the
+//     regression case for the resume 401 ("compact JWS format must have three
+//     parts").
+//  3. the broker dev token is used only when neither of the above is present.
+func TestBuildStartContext_AuthTokenPrecedence(t *testing.T) {
+	// Valid-looking JWT (three dot-separated parts) minted by the hub.
+	const hubToken = "header.payload.signature"
+	const devToken = "broker-dev-token"
+	const explicitToken = "explicit.agent.token"
+
+	t.Run("resolvedEnv token kept over broker dev token", func(t *testing.T) {
+		// Broker has its own (invalid-as-JWT) dev token in the environment.
+		t.Setenv("SCION_AUTH_TOKEN", devToken)
+
+		cfg := DefaultServerConfig()
+		cfg.StateDir = t.TempDir()
+		srv := newTestServerForStartContext(t, cfg)
+
+		r := httptest.NewRequest("POST", "/api/v1/agents", nil)
+		sc, err := srv.buildStartContext(context.Background(), startContextInputs{
+			Name: "agent-resume",
+			// Hub minted the agent JWT into resolvedEnv on the start/resume path.
+			ResolvedEnv: map[string]string{
+				"SCION_AUTH_TOKEN": hubToken,
+			},
+			// AgentToken intentionally empty (start/resume path).
+			HTTPRequest: r,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := sc.Opts.Env["SCION_AUTH_TOKEN"]; got != hubToken {
+			t.Errorf("expected SCION_AUTH_TOKEN to keep hub-minted token %q, got %q (broker dev token must not clobber)", hubToken, got)
+		}
+	})
+
+	t.Run("explicit AgentToken wins", func(t *testing.T) {
+		t.Setenv("SCION_AUTH_TOKEN", devToken)
+
+		cfg := DefaultServerConfig()
+		cfg.StateDir = t.TempDir()
+		srv := newTestServerForStartContext(t, cfg)
+
+		r := httptest.NewRequest("POST", "/api/v1/agents", nil)
+		sc, err := srv.buildStartContext(context.Background(), startContextInputs{
+			Name:       "agent-create",
+			AgentToken: explicitToken,
+			ResolvedEnv: map[string]string{
+				"SCION_AUTH_TOKEN": hubToken,
+			},
+			HTTPRequest: r,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := sc.Opts.Env["SCION_AUTH_TOKEN"]; got != explicitToken {
+			t.Errorf("expected SCION_AUTH_TOKEN=%q (explicit AgentToken wins), got %q", explicitToken, got)
+		}
+	})
+
+	t.Run("broker dev token used as last resort", func(t *testing.T) {
+		t.Setenv("SCION_AUTH_TOKEN", devToken)
+
+		cfg := DefaultServerConfig()
+		cfg.StateDir = t.TempDir()
+		srv := newTestServerForStartContext(t, cfg)
+
+		r := httptest.NewRequest("POST", "/api/v1/agents", nil)
+		sc, err := srv.buildStartContext(context.Background(), startContextInputs{
+			Name: "agent-plain-broker",
+			// No AgentToken and no SCION_AUTH_TOKEN in resolvedEnv.
+			HTTPRequest: r,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := sc.Opts.Env["SCION_AUTH_TOKEN"]; got != devToken {
+			t.Errorf("expected SCION_AUTH_TOKEN=%q (broker dev fallback), got %q", devToken, got)
+		}
+	})
+}
+
 func TestBuildStartContext_TelemetryOverride(t *testing.T) {
 	cfg := DefaultServerConfig()
 	cfg.StateDir = t.TempDir()

--- a/pkg/store/concurrency.go
+++ b/pkg/store/concurrency.go
@@ -48,6 +48,9 @@ const (
 	LockAgentHeartbeatTimeout AdvisoryLockKey = 0x5C100002
 	// LockAgentStalledDetection guards the stalled-agent sweep.
 	LockAgentStalledDetection AdvisoryLockKey = 0x5C100003
+	// LockAgentAutoSuspend guards the auto-suspend sweep that reclaims
+	// containers backing agents stalled beyond the extra grace period.
+	LockAgentAutoSuspend AdvisoryLockKey = 0x5C100008
 	// LockSoftDeletePurge guards the soft-deleted-agent / old-event purge.
 	LockSoftDeletePurge AdvisoryLockKey = 0x5C100004
 	// LockGitHubAppHealthCheck guards the periodic GitHub App installation

--- a/pkg/store/concurrency_test.go
+++ b/pkg/store/concurrency_test.go
@@ -59,6 +59,7 @@ func TestAdvisoryLockKeys_NonOverlapping(t *testing.T) {
 		LockScheduleEvaluator,
 		LockAgentHeartbeatTimeout,
 		LockAgentStalledDetection,
+		LockAgentAutoSuspend,
 		LockSoftDeletePurge,
 		LockGitHubAppHealthCheck,
 	}

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -723,6 +723,32 @@ func (s *AgentStore) MarkStalledAgents(ctx context.Context, activityThreshold, h
 	return updated, nil
 }
 
+// FindAutoSuspendCandidates returns running agents currently marked "stalled"
+// whose last activity event predates activityThreshold (the stall threshold
+// plus the auto-suspend grace) but whose heartbeat is still recent
+// (last_seen >= heartbeatRecency). These are agents whose container is still
+// alive and can be reclaimed via suspend. This is a read-only query; the caller
+// performs the actual suspension after verifying harness resume support.
+func (s *AgentStore) FindAutoSuspendCandidates(ctx context.Context, activityThreshold, heartbeatRecency time.Time) ([]store.Agent, error) {
+	candidates, err := s.client.Agent.Query().Where(
+		agent.LastActivityEventNotNil(),
+		agent.LastActivityEventLT(activityThreshold),
+		agent.LastSeenNotNil(),
+		agent.LastSeenGTE(heartbeatRecency),
+		agent.PhaseEQ("running"),
+		agent.ActivityEQ("stalled"),
+	).All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]store.Agent, 0, len(candidates))
+	for _, a := range candidates {
+		result = append(result, *entAgentToStore(a))
+	}
+	return result, nil
+}
+
 // --- helpers ---
 
 // isTerminalActivity reports whether the activity is a terminal/sticky state

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -560,6 +560,19 @@ func (s *AgentStore) UpdateAgentStatus(ctx context.Context, id string, su store.
 		}
 	}
 
+	// A (re)start — a transition from a terminal phase (stopped/error) to running
+	// — clears terminal remnants from the prior stop/crash: the stale crash/stop
+	// message and any leftover stalled marker. This is gated on the CURRENT phase
+	// being terminal so routine running→running heartbeats (which carry their own
+	// sticky-stalled rules in the broker handler) are left untouched. An explicit
+	// message in the same update (su.Message != "") wins and is set below.
+	if su.Phase == "running" && (current.Phase == "stopped" || current.Phase == "error") {
+		if su.Message == "" {
+			upd.SetMessage("")
+		}
+		upd.SetStalledFromActivity("")
+	}
+
 	if su.Message != "" {
 		upd.SetMessage(su.Message)
 	}

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -547,6 +547,17 @@ func (s *AgentStore) UpdateAgentStatus(ctx context.Context, id string, su store.
 		upd.SetStalledFromActivity("")
 		upd.SetLastActivityEvent(now)
 		upd.SetToolName(su.ToolName)
+	} else if su.Phase == "stopped" || su.Phase == "error" {
+		// Transitioning to a terminal phase without an explicit activity: clear
+		// any leftover live activity (e.g. a lingering "stalled" set by the
+		// platform) so a stopped/crashed agent never displays a stale activity.
+		// A terminal activity (crashed/limits_exceeded) carries information about
+		// HOW the agent stopped and is preserved.
+		if current.Activity != "" && !isTerminalActivity(current.Activity) {
+			upd.SetActivity("")
+			upd.SetStalledFromActivity("")
+			upd.SetToolName("")
+		}
 	}
 
 	if su.Message != "" {

--- a/pkg/store/entadapter/agent_store_test.go
+++ b/pkg/store/entadapter/agent_store_test.go
@@ -459,6 +459,53 @@ func TestAgentStore_MarkStalledAgents(t *testing.T) {
 	assert.Equal(t, "executing", gotActive.Activity)
 }
 
+func TestAgentStore_FindAutoSuspendCandidates(t *testing.T) {
+	ctx := context.Background()
+	s, projectID := newTestAgentStore(t)
+
+	now := time.Now()
+	// Stall threshold (5m) + grace (5m) = 10m back.
+	activityThreshold := now.Add(-10 * time.Minute)
+	heartbeatRecency := now.Add(-2 * time.Minute)
+
+	// Stalled beyond grace with a recent heartbeat -> candidate.
+	candidate := makeAgent(projectID, "candidate")
+	candidate.Phase = "running"
+	candidate.Activity = "stalled"
+	candidate.LastActivityEvent = now.Add(-30 * time.Minute)
+	candidate.LastSeen = now
+	require.NoError(t, s.CreateAgent(ctx, candidate))
+
+	// Stalled but only within the grace window -> not yet a candidate.
+	withinGrace := makeAgent(projectID, "within-grace")
+	withinGrace.Phase = "running"
+	withinGrace.Activity = "stalled"
+	withinGrace.LastActivityEvent = now.Add(-7 * time.Minute)
+	withinGrace.LastSeen = now
+	require.NoError(t, s.CreateAgent(ctx, withinGrace))
+
+	// Stalled beyond grace but heartbeat is stale (offline) -> not a candidate.
+	offline := makeAgent(projectID, "offline")
+	offline.Phase = "running"
+	offline.Activity = "stalled"
+	offline.LastActivityEvent = now.Add(-30 * time.Minute)
+	offline.LastSeen = now.Add(-30 * time.Minute)
+	require.NoError(t, s.CreateAgent(ctx, offline))
+
+	// Stale but not yet marked stalled (still executing) -> not a candidate.
+	executing := makeAgent(projectID, "executing")
+	executing.Phase = "running"
+	executing.Activity = "executing"
+	executing.LastActivityEvent = now.Add(-30 * time.Minute)
+	executing.LastSeen = now
+	require.NoError(t, s.CreateAgent(ctx, executing))
+
+	got, err := s.FindAutoSuspendCandidates(ctx, activityThreshold, heartbeatRecency)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, candidate.ID, got[0].ID)
+}
+
 func TestAgentStore_PurgeDeletedAgents(t *testing.T) {
 	ctx := context.Background()
 	s, projectID := newTestAgentStore(t)

--- a/pkg/store/entadapter/agent_store_test.go
+++ b/pkg/store/entadapter/agent_store_test.go
@@ -288,6 +288,58 @@ func TestAgentStore_UpdateAgentStatus(t *testing.T) {
 	assert.ErrorIs(t, s.UpdateAgentStatus(ctx, uuid.NewString(), store.AgentStatusUpdate{Phase: "running"}), store.ErrNotFound)
 }
 
+// TestAgentStore_TerminalPhaseClearsStalledActivity verifies that transitioning
+// to a terminal phase (stopped/error) without an explicit activity clears a
+// lingering live activity such as "stalled", while preserving terminal
+// activities like "crashed".
+func TestAgentStore_TerminalPhaseClearsStalledActivity(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("stalled cleared on stop", func(t *testing.T) {
+		s, projectID := newTestAgentStore(t)
+		a := makeAgent(projectID, "stalled-stop")
+		a.Phase = "running"
+		a.Activity = "stalled"
+		require.NoError(t, s.CreateAgent(ctx, a))
+
+		require.NoError(t, s.UpdateAgentStatus(ctx, a.ID, store.AgentStatusUpdate{Phase: "stopped"}))
+		got, err := s.GetAgent(ctx, a.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "stopped", got.Phase)
+		assert.Equal(t, "", got.Activity, "stalled activity must be cleared on stop")
+	})
+
+	t.Run("stalled cleared on error", func(t *testing.T) {
+		s, projectID := newTestAgentStore(t)
+		a := makeAgent(projectID, "stalled-error")
+		a.Phase = "running"
+		a.Activity = "stalled"
+		require.NoError(t, s.CreateAgent(ctx, a))
+
+		require.NoError(t, s.UpdateAgentStatus(ctx, a.ID, store.AgentStatusUpdate{Phase: "error"}))
+		got, err := s.GetAgent(ctx, a.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "error", got.Phase)
+		assert.Equal(t, "", got.Activity, "stalled activity must be cleared on error")
+	})
+
+	t.Run("terminal activity preserved when explicitly provided", func(t *testing.T) {
+		s, projectID := newTestAgentStore(t)
+		a := makeAgent(projectID, "crashed-keep")
+		a.Phase = "running"
+		a.Activity = "stalled"
+		require.NoError(t, s.CreateAgent(ctx, a))
+
+		require.NoError(t, s.UpdateAgentStatus(ctx, a.ID, store.AgentStatusUpdate{
+			Phase:    "stopped",
+			Activity: "crashed",
+		}))
+		got, err := s.GetAgent(ctx, a.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "crashed", got.Activity, "explicit terminal activity must be kept")
+	})
+}
+
 func TestAgentStore_MarkStaleAgentsOffline(t *testing.T) {
 	ctx := context.Background()
 	s, projectID := newTestAgentStore(t)

--- a/pkg/store/entadapter/agent_store_test.go
+++ b/pkg/store/entadapter/agent_store_test.go
@@ -340,6 +340,50 @@ func TestAgentStore_TerminalPhaseClearsStalledActivity(t *testing.T) {
 	})
 }
 
+// TestAgentStore_RunningPhaseClearsStaleMessage verifies that a (re)start to the
+// running phase clears a lingering terminal message (e.g. a crash message) and
+// any leftover stalled marker, while an explicit message in the same update is
+// preserved.
+func TestAgentStore_RunningPhaseClearsStaleMessage(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("crash message cleared on restart", func(t *testing.T) {
+		s, projectID := newTestAgentStore(t)
+		a := makeAgent(projectID, "crash-clear")
+		a.Phase = "error"
+		a.Activity = "crashed"
+		a.Message = "Agent crashed with exit code 1"
+		a.StalledFromActivity = "working"
+		require.NoError(t, s.CreateAgent(ctx, a))
+
+		require.NoError(t, s.UpdateAgentStatus(ctx, a.ID, store.AgentStatusUpdate{
+			Phase:    "running",
+			Activity: "working",
+		}))
+		got, err := s.GetAgent(ctx, a.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "running", got.Phase)
+		assert.Equal(t, "", got.Message, "stale crash message must be cleared on restart")
+		assert.Equal(t, "", got.StalledFromActivity, "stalled marker must be cleared on restart")
+	})
+
+	t.Run("explicit message preserved on restart", func(t *testing.T) {
+		s, projectID := newTestAgentStore(t)
+		a := makeAgent(projectID, "msg-keep")
+		a.Phase = "error"
+		a.Message = "Agent crashed with exit code 1"
+		require.NoError(t, s.CreateAgent(ctx, a))
+
+		require.NoError(t, s.UpdateAgentStatus(ctx, a.ID, store.AgentStatusUpdate{
+			Phase:   "running",
+			Message: "Restarting",
+		}))
+		got, err := s.GetAgent(ctx, a.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "Restarting", got.Message, "explicit message must be kept on restart")
+	})
+}
+
 func TestAgentStore_MarkStaleAgentsOffline(t *testing.T) {
 	ctx := context.Background()
 	s, projectID := newTestAgentStore(t)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -160,6 +160,14 @@ type AgentStore interface {
 	// whose activity is not a terminal sticky state or already stalled/offline.
 	// Returns the updated agent records for event publishing.
 	MarkStalledAgents(ctx context.Context, activityThreshold, heartbeatRecency time.Time) ([]Agent, error)
+
+	// FindAutoSuspendCandidates returns running agents already marked stalled
+	// whose last activity event is older than activityThreshold (stall threshold
+	// plus the auto-suspend grace) but whose heartbeat is still recent
+	// (last_seen >= heartbeatRecency), i.e. the container is still alive and
+	// resumable. It is a read-only finder; the caller decides which agents to
+	// suspend (e.g. after checking harness resume support).
+	FindAutoSuspendCandidates(ctx context.Context, activityThreshold, heartbeatRecency time.Time) ([]Agent, error)
 }
 
 // AgentFilter defines criteria for filtering agents.


### PR DESCRIPTION
## Agent state & container lifecycle fixes

Fixes how an agent's state is represented and kept current across transitions, and how that ties to container lifecycle. All changes E2E-verified on the scion-integration VM.

**Part 1 — suspend/resume now continues the harness session**
- Thread the resume flag hub->broker->runtime so the harness gets its resume flag (claude --continue) on resume.
- Make the `suspended` phase sticky against async status/heartbeat updates that were overwriting it to `stopped` (which silently defeated resume).

**Part 2 — container/agent crashes surface as a restartable error state**
- Capture the harness's real exit code (previously hidden because the harness runs as a tmux grandchild) via an exit-code file read by sciontool init.
- Hybrid mapping: clean exit -> stopped; limits -> stopped+limits_exceeded; non-zero -> error (restartable). Broker heartbeat also derives error from a non-zero container exit; stale `stalled` cleared on stop/error.

**Part 3 — auto-suspend stalled agents to reclaim resources**
- Recurring scheduler suspends agents stalled past StalledThreshold + 5m grace (resume-capable harness + live container only); they resume on next message. On Docker the home bind-mount persists, so no sync is needed (GCS deferred for ephemeral-home runtimes).

**Supporting fixes**
- Resume 401: stop the broker dev token from clobbering the hub-minted agent token on the start/resume path.
- Clear the stale crash message when an agent restarts.

Related: #178 (Claude onboarding flag drift, separate maintenance item).

Note: a handful of pre-existing pkg/hub test failures (resources-import, harness-config, phase-regression status tests) fail on main as well and are unrelated to this branch.