### PR TITLE
Worktree-per-agent on Kubernetes

### DIFF
--- a/.design/worktree-per-agent-phase3-plan.md
+++ b/.design/worktree-per-agent-phase3-plan.md
@@ -1,0 +1,45 @@
+# Phase 3 Plan: Worktree-Per-Agent on Kubernetes (NFS-only)
+
+**Branch:** `scion/worktree-phase3-k8s` (off upstream `main` b40cd057 — has Phase 1+2+#168).
+**Tracking:** #158. Final planned phase.
+**Q4 RESOLVED (ptone, 2026-06-08): NFS-only on K8s in v1.**
+
+## Scope (small — guardrail + validation + docs)
+worktree-per-agent on K8s is supported **only** with the NFS backend. Node-local worktrees
+on K8s are **not** supported in v1 and must be rejected cleanly (or fall back to
+clone-per-agent) rather than producing a broken host-bind mount (the broker's host-side
+`ProvisionShared` + dual-mount is a Docker/VM mechanism; a K8s pod can't bind-mount a host
+worktree).
+
+### T1 — Guardrail: reject node-local worktree-per-agent on K8s
+- Where: broker dispatch (`pkg/runtimebroker/start_context.go` `tryProvisionWorktree` /
+  `resolveWorktreeProvision`) and/or the K8s runtime path. Investigate the exact flow first.
+- Behavior: when the runtime is **Kubernetes** AND mode is **worktree-per-agent** AND the
+  backend is **not NFS** (i.e. node-local) → do NOT take the host-side worktree-provision
+  path. Fall back to clone-per-agent with a clear `slog.Warn` (recommended — graceful), or
+  return a clear error. Decide per how the existing eligibility/fallback is structured
+  (mirror `WorktreeModeEligible` git-version fallback).
+- K8s + **NFS** + worktree-per-agent must continue to use the existing NFS init-container
+  provisioning path (#169) unchanged.
+
+### T2 — Validate K8s × NFS worktree-per-agent
+- Confirm (with a test where feasible) that on K8s + NFS, worktree-per-agent provisions the
+  base once on the RWX export, each agent gets its worktree, and the pod mount (PVC +
+  subPath) resolves to the worktree. Phase 2 T3 validated `nfsBackend.Resolve` +
+  `ProvisionShared` for NFS; extend to the K8s pod-spec/mount layer
+  (`pkg/runtime/k8s_runtime.go` / `k8s_nfs_test.go`) — assert the worktree subPath mount is
+  produced and the node-local-on-K8s guardrail rejects.
+
+### T3 — Docs
+- Already updated in `worktree-per-agent.md` (Q4 RESOLVED, §7 matrix, limitations). Ensure
+  any user-facing note (UI helper text / README) reflects "K8s worktree-per-agent requires
+  NFS" if such copy exists.
+
+## Out of scope
+Node-local worktrees on K8s (the unproven hostPath/emptyDir cell); Q5 migration path
+(still open, low priority — not in this phase unless ptone asks).
+
+## Orchestration
+One developer agent: investigate the K8s worktree flow, add the guardrail (T1), add/extend
+the validation test (T2), confirm docs (T3). Manager verifies (build + tests + the
+config-free-leaf invariant) before landing. PR on the fork → upstream compare URL for ptone.

--- a/.design/worktree-per-agent.md
+++ b/.design/worktree-per-agent.md
@@ -305,7 +305,9 @@ Backend × runtime matrix:
 | **node-local** | base clone on host, dual bind-mount (§6) | base on node, worktrees per pod via hostPath/emptyDir — **needs validation** |
 | **NFS** | base + worktrees on export, NFS mount | base + worktrees on RWX PVC + subPath (existing NFS design §9) |
 
-The K8s × node-local cell is the least-proven and may be restricted to NFS in v1.
+The K8s × node-local cell is **NOT supported in v1** (Q4 RESOLVED — NFS-only on K8s):
+worktree-per-agent on Kubernetes requires the NFS backend; node-local-on-K8s is rejected
+with a clear error (or falls back to clone-per-agent).
 
 ---
 
@@ -388,8 +390,12 @@ the git-version gate, and define base-repo teardown.
    "last-agent teardown / remove base" work in §8 is therefore **deferred** — the
    broker only ever tears down per-agent worktrees, never the base. An orphan-base
    maintenance sweep may revisit disk reclamation later, but it is out of scope.
-4. **Q4 — K8s node-local.** Support node-local worktrees on K8s in v1, or restrict
-   worktree-per-agent to NFS on K8s? (Open — Phase 3.)
+4. **Q4 — K8s node-local. [RESOLVED 2026-06-08 — ptone] NFS-only on K8s in v1.**
+   worktree-per-agent on Kubernetes is supported **only** with the NFS backend
+   (base + worktrees on the RWX export, provisioned by the init-container path from
+   #169). **Node-local worktrees on K8s are NOT supported in v1** — that combination
+   must be rejected (or fall back to clone-per-agent) with a clear message rather than
+   producing a broken host-bind mount. Phase 3 = that guardrail + K8s×NFS validation.
 5. **Q5 — Migration.** Any opt-in path to convert a running clone-per-agent project to
    worktree-per-agent, or strictly new-projects-only? (Open.)
 6. **Q6 — Default mode. [RESOLVED 2026-06-07 — ptone]** **Clone-per-agent remains

--- a/pkg/runtime/k8s_nfs_test.go
+++ b/pkg/runtime/k8s_nfs_test.go
@@ -1164,6 +1164,41 @@ func TestCreateSharedDirPVCs_LocalBackend_CreatesPVCs(t *testing.T) {
 	}
 }
 
+// --- Phase 3 guardrail regression: K8s + NFS + worktree-per-agent ---
+
+func TestBuildPod_NFSBackend_WorktreeSubPath_StillRouted(t *testing.T) {
+	r := newNFSTestK8sRuntime()
+	config := RunConfig{
+		Name:                 "test-nfs-worktree",
+		Image:                "test-image",
+		UnixUsername:         "scion",
+		WorkspaceBackendName: "nfs",
+		NFSPVClaimName:       "scion-workspaces",
+		NFSSubPath:           "projects/proj-123/workspace/worktrees/agent-1",
+		GitCloneForInit: &api.GitCloneConfig{
+			URL:    "https://github.com/org/repo.git",
+			Branch: "main",
+		},
+	}
+
+	pod, err := r.buildPod("default", config)
+	require.NoError(t, err)
+
+	wsVol := findVolume(pod, "workspace")
+	require.NotNil(t, wsVol, "workspace volume must exist")
+	require.NotNil(t, wsVol.VolumeSource.PersistentVolumeClaim,
+		"NFS worktree backend must use PVC, not EmptyDir")
+	assert.Equal(t, "scion-workspaces", wsVol.VolumeSource.PersistentVolumeClaim.ClaimName)
+
+	wsMount := findVolumeMount(&pod.Spec.Containers[0], "workspace")
+	require.NotNil(t, wsMount, "workspace mount must exist")
+	assert.Equal(t, "projects/proj-123/workspace/worktrees/agent-1", wsMount.SubPath,
+		"worktree subPath must route through NFS PVC")
+
+	require.NotEmpty(t, pod.Spec.InitContainers,
+		"NFS+worktree must still inject the provisioning init container")
+}
+
 // findVolume finds a volume by name in a pod spec.
 func findVolume(pod *corev1.Pod, name string) *corev1.Volume {
 	for i := range pod.Spec.Volumes {

--- a/pkg/runtimebroker/start_context.go
+++ b/pkg/runtimebroker/start_context.go
@@ -524,6 +524,11 @@ func (e *startContextError) Error() string {
 // in-container clone). On failure or if git is too old, it logs a warning and
 // returns false so the caller falls through to clone-per-agent.
 func (s *Server) tryProvisionWorktree(ctx context.Context, in startContextInputs, opts *api.StartOptions, env map[string]string) bool {
+	runtimeName := ""
+	if s.runtime != nil {
+		runtimeName = s.runtime.Name()
+	}
+
 	result := resolveWorktreeProvision(worktreeProvisionInput{
 		WorkspaceMode: in.WorkspaceMode,
 		GitClone:      in.Config.GitClone,
@@ -533,6 +538,7 @@ func (s *Server) tryProvisionWorktree(ctx context.Context, in startContextInputs
 		AgentID:       in.AgentID,
 		AgentName:     in.Name,
 		Branch:        in.Config.Branch,
+		RuntimeName:   runtimeName,
 	})
 
 	if !result.ShouldProvision {
@@ -640,6 +646,12 @@ type worktreeProvisionInput struct {
 	AgentName     string
 	Branch        string
 
+	// RuntimeName is the name of the container runtime ("kubernetes", "docker",
+	// etc.) from runtime.Name(). Used to reject host-side worktree provisioning
+	// on Kubernetes where pods cannot bind-mount host worktrees — worktree-per-agent
+	// on K8s requires the NFS backend (init-container path).
+	RuntimeName string
+
 	// eligibilityOverride, when non-nil, replaces the runtime.WorktreeModeEligible
 	// check. Used in tests to simulate git-too-old without requiring a specific
 	// git binary.
@@ -675,6 +687,18 @@ func resolveWorktreeProvision(in worktreeProvisionInput) worktreeProvisionResult
 	eligible, reason := eligCheck()
 	if !eligible {
 		return worktreeProvisionResult{Reason: reason}
+	}
+
+	// On Kubernetes, host-side worktree provisioning does not work: pods
+	// cannot bind-mount a host worktree. Worktree-per-agent on K8s is
+	// supported only via the NFS backend (init-container path in
+	// k8s_runtime.go). When the broker's host-side path is reached for a
+	// K8s runtime, fall back to clone-per-agent.
+	if in.RuntimeName == "kubernetes" {
+		return worktreeProvisionResult{
+			Reason: "worktree-per-agent on Kubernetes requires the NFS backend; " +
+				"node-local host-side provisioning is not supported (pods cannot bind-mount host worktrees)",
+		}
 	}
 
 	mode := store.SharingModeWorktreePerAgent

--- a/pkg/runtimebroker/start_context_test.go
+++ b/pkg/runtimebroker/start_context_test.go
@@ -829,6 +829,92 @@ func TestResolveWorktreeProvision_GitTooOld_Fallback(t *testing.T) {
 	}
 }
 
+func TestResolveWorktreeProvision_KubernetesNodeLocal_Rejected(t *testing.T) {
+	projectDir := t.TempDir()
+
+	result := resolveWorktreeProvision(worktreeProvisionInput{
+		WorkspaceMode: store.WorkspaceModeWorktreePerAgent,
+		GitClone: &api.GitCloneConfig{
+			URL:    "https://github.com/org/repo.git",
+			Branch: "main",
+		},
+		ProjectPath: projectDir,
+		ProjectID:   "proj-1",
+		ProjectSlug: "my-project",
+		AgentID:     "agent-1",
+		AgentName:   "test-agent",
+		RuntimeName: "kubernetes",
+		eligibilityOverride: func() (bool, string) {
+			return true, ""
+		},
+	})
+
+	if result.ShouldProvision {
+		t.Fatal("expected ShouldProvision=false for Kubernetes without NFS backend")
+	}
+	if !strings.Contains(result.Reason, "Kubernetes") {
+		t.Errorf("expected reason to mention Kubernetes, got %q", result.Reason)
+	}
+	if !strings.Contains(result.Reason, "NFS") {
+		t.Errorf("expected reason to mention NFS requirement, got %q", result.Reason)
+	}
+	if result.ProvisionInput.ProjectID != "" {
+		t.Error("expected empty ProvisionInput when rejected")
+	}
+}
+
+func TestResolveWorktreeProvision_DockerRuntime_NotRejected(t *testing.T) {
+	eligible, _ := runtime.WorktreeModeEligible()
+	if !eligible {
+		t.Skip("git < 2.47, worktree mode not eligible on this host")
+	}
+
+	projectDir := t.TempDir()
+
+	result := resolveWorktreeProvision(worktreeProvisionInput{
+		WorkspaceMode: store.WorkspaceModeWorktreePerAgent,
+		GitClone: &api.GitCloneConfig{
+			URL:    "https://github.com/org/repo.git",
+			Branch: "main",
+		},
+		ProjectPath: projectDir,
+		ProjectID:   "proj-1",
+		ProjectSlug: "my-project",
+		AgentID:     "agent-1",
+		AgentName:   "test-agent",
+		RuntimeName: "docker",
+	})
+
+	if !result.ShouldProvision {
+		t.Fatalf("expected ShouldProvision=true for Docker runtime, got false (reason: %s)", result.Reason)
+	}
+}
+
+func TestResolveWorktreeProvision_EmptyRuntime_NotRejected(t *testing.T) {
+	eligible, _ := runtime.WorktreeModeEligible()
+	if !eligible {
+		t.Skip("git < 2.47, worktree mode not eligible on this host")
+	}
+
+	projectDir := t.TempDir()
+
+	result := resolveWorktreeProvision(worktreeProvisionInput{
+		WorkspaceMode: store.WorkspaceModeWorktreePerAgent,
+		GitClone: &api.GitCloneConfig{
+			URL:    "https://github.com/org/repo.git",
+			Branch: "main",
+		},
+		ProjectPath: projectDir,
+		ProjectID:   "proj-1",
+		AgentID:     "agent-1",
+		RuntimeName: "",
+	})
+
+	if !result.ShouldProvision {
+		t.Fatalf("expected ShouldProvision=true for empty RuntimeName, got false (reason: %s)", result.Reason)
+	}
+}
+
 func TestResolveWorktreeProvision_FullCloneDepth(t *testing.T) {
 	eligible, _ := runtime.WorktreeModeEligible()
 	if !eligible {

--- a/web/src/components/pages/project-create.ts
+++ b/web/src/components/pages/project-create.ts
@@ -566,7 +566,7 @@ export class ScionPageProjectCreate extends LitElement {
                   ${this.gitWorkspaceMode === 'worktree-per-agent'
                     ? html`<div class="workspace-mode-note">
                         A single base clone is created, and each agent gets a lightweight git worktree.
-                        Requires git ≥ 2.47 on the node.
+                        Requires git ≥ 2.47 on the node. On Kubernetes, requires the NFS backend.
                       </div>`
                     : this.gitWorkspaceMode === 'shared'
                       ? html`<div class="workspace-mode-note">


### PR DESCRIPTION
## Worktree-per-agent on Kubernetes: NFS-only guardrail (Phase 3)'

What's in it (small, focused):
- Guardrail: when runtime=='kubernetes', the broker's host-side worktree provisioning is skipped and dispatch falls back to clone-per-agent (a pod can't bind-mount a host worktree). K8s+NFS worktree-per-agent (the #169 init-container path) is unaffected and still works.
- Tests: K8s node-local rejected; Docker + empty-runtime not rejected; K8s+NFS worktree subPath still routed.
- Docs (Q4 RESOLVED + §7 matrix) and the UI helper text ('On Kubernetes, requires the NFS backend') updated.
Verified: build clean; pkg/runtime + pkg/runtimebroker tests green; pkg/provision still config/util-free.

WORKTREE WORKSTREAM (#158) is now functionally COMPLETE end-to-end: Phase 1 (Docker node-local, #350), Phase 2 (lifecycle, #351), #168 shared-worktree refcount (#353), the .git nit, and Phase 3 (K8s NFS-only, this PR). Only Q5 (opt-in migration of existing clone-per-agent projects) remains open and is low-priority — want that as a follow-up, or call #158 done after this merges?
