### PR TITLE
Address PR #359 review feedback

### DIFF
--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1810,7 +1810,12 @@ func (s *Server) autoSuspendStalledAgents(ctx context.Context, agents []store.Ag
 			}
 		}
 
-		if dispatcher != nil && agent.RuntimeBrokerID != "" {
+		if agent.RuntimeBrokerID != "" {
+			if dispatcher == nil {
+				slog.Error("Scheduler: cannot auto-suspend agent because dispatcher is nil",
+					"agent_id", agent.ID, "agent_name", agent.Name)
+				continue
+			}
 			s.syncWorkspaceOnStop(ctx, agent)
 			if err := dispatcher.DispatchAgentStop(ctx, agent); err != nil {
 				slog.Error("Scheduler: auto-suspend dispatch failed",
@@ -1831,6 +1836,8 @@ func (s *Server) autoSuspendStalledAgents(ctx context.Context, agents []store.Ag
 		}
 
 		agent.Phase = string(state.PhaseSuspended)
+		agent.ContainerStatus = "stopped"
+		agent.Activity = ""
 		s.events.PublishAgentStatus(ctx, agent)
 		suspended++
 	}

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -1518,7 +1518,7 @@ export class ScionPageAdminServerConfig extends LitElement {
               }}
               >Auto-suspend stalled agents</sl-switch
             >
-            <span class="field-description"
+            <span class="hint"
               >When enabled, agents detected as stalled are automatically
               suspended (container stopped, session preserved for
               resume).</span


### PR DESCRIPTION
- Update local agent struct fields (ContainerStatus, Activity) before publishing status event to prevent stale data reaching SSE clients
- Skip auto-suspend when dispatcher is nil but RuntimeBrokerID is set, preventing DB/container state desync
- Use standard 'hint' CSS class in admin UI for consistent styling

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
