### PR TITLE
fix: route metadata server GCP token requests through hub client

### DIFF
--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -349,6 +349,10 @@ func runInit(args []string) int {
 		}
 	}
 
+	// Declare hubClient early so the metadata server's fetch callbacks can
+	// capture it. It is populated later, after the child process starts.
+	var hubClient *hub.Client
+
 	// Start GCP metadata server if configured
 	var metadataServer *metadata.Server
 	if metaCfg := metadata.ConfigFromEnv(); metaCfg != nil {
@@ -363,6 +367,34 @@ func runInit(args []string) int {
 		// uses the latest agent token after refresh, not the startup value.
 		metaCfg.TokenFunc = func() string {
 			return hub.ReadTokenFile()
+		}
+		// Delegate GCP token fetching to the hub client so the metadata
+		// server uses the correct auth headers (X-Scion-Agent-Token) and
+		// OIDC transport layer. The hub client is created after the metadata
+		// server starts, so the closures capture the hubClient variable
+		// which is set later. Token requests only arrive after the child
+		// process has started, so the hub client is always available by then.
+		metaCfg.FetchGCPToken = func(ctx context.Context, scopes []string) (*metadata.GCPAccessTokenResponse, error) {
+			hc := hubClient
+			if hc == nil || !hc.IsConfigured() {
+				return nil, fmt.Errorf("hub client not initialized")
+			}
+			hubResp, err := hc.FetchGCPToken(ctx, scopes)
+			if err != nil {
+				return nil, err
+			}
+			return &metadata.GCPAccessTokenResponse{
+				AccessToken: hubResp.AccessToken,
+				ExpiresIn:   hubResp.ExpiresIn,
+				TokenType:   hubResp.TokenType,
+			}, nil
+		}
+		metaCfg.FetchGCPIdentityToken = func(ctx context.Context, audience string) (string, error) {
+			hc := hubClient
+			if hc == nil || !hc.IsConfigured() {
+				return "", fmt.Errorf("hub client not initialized")
+			}
+			return hc.FetchGCPIdentityToken(ctx, audience)
 		}
 		metadataServer = metadata.New(*metaCfg)
 		metaCtx := context.Background()
@@ -430,7 +462,6 @@ func runInit(args []string) int {
 	}()
 
 	// Heartbeat and token refresh control variables - declared here so they're accessible during shutdown and auth reset
-	var hubClient *hub.Client
 	var heartbeatCancel context.CancelFunc
 	var heartbeatDone <-chan struct{}
 	var tokenRefreshCancel context.CancelFunc

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -1256,3 +1256,100 @@ func (c *Client) StartHeartbeat(ctx context.Context, config *HeartbeatConfig) <-
 
 	return done
 }
+
+// GCPAccessTokenResponse is the Hub's response for a GCP access token request.
+type GCPAccessTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+	TokenType   string `json:"token_type"`
+}
+
+// FetchGCPToken obtains a GCP access token from the Hub's /api/v1/agent/gcp-token
+// endpoint. Uses the hub client's OIDC transport and X-Scion-Agent-Token auth.
+func (c *Client) FetchGCPToken(ctx context.Context, scopes []string) (*GCPAccessTokenResponse, error) {
+	if !c.IsConfigured() {
+		return nil, fmt.Errorf("hub client not configured")
+	}
+
+	endpoint := fmt.Sprintf("%s/api/v1/agent/gcp-token",
+		strings.TrimSuffix(c.hubURL, "/"))
+
+	body, _ := json.Marshal(map[string][]string{
+		"scopes": scopes,
+	})
+
+	c.tokenMu.RLock()
+	currentToken := c.token
+	c.tokenMu.RUnlock()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Scion-Agent-Token", currentToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("hub request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("hub returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var token GCPAccessTokenResponse
+	if err := json.Unmarshal(respBody, &token); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return &token, nil
+}
+
+// FetchGCPIdentityToken obtains a GCP identity token from the Hub's
+// /api/v1/agent/gcp-identity-token endpoint.
+func (c *Client) FetchGCPIdentityToken(ctx context.Context, audience string) (string, error) {
+	if !c.IsConfigured() {
+		return "", fmt.Errorf("hub client not configured")
+	}
+
+	endpoint := fmt.Sprintf("%s/api/v1/agent/gcp-identity-token",
+		strings.TrimSuffix(c.hubURL, "/"))
+
+	body, _ := json.Marshal(map[string]string{
+		"audience": audience,
+	})
+
+	c.tokenMu.RLock()
+	currentToken := c.token
+	c.tokenMu.RUnlock()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Scion-Agent-Token", currentToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("hub request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("hub returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("parse response: %w", err)
+	}
+
+	return result.Token, nil
+}

--- a/pkg/sciontool/metadata/server.go
+++ b/pkg/sciontool/metadata/server.go
@@ -56,6 +56,16 @@ type Config struct {
 	// When "host", iptables interception is skipped to avoid leaking
 	// redirect rules into the host's network namespace.
 	NetworkMode string
+
+	// FetchGCPToken, if set, is called to obtain a GCP access token from the
+	// Hub instead of making a direct HTTP call. This allows the metadata
+	// server to use the hub client's OIDC transport and correct auth headers.
+	// If nil, the server falls back to direct HTTP requests.
+	FetchGCPToken func(ctx context.Context, scopes []string) (*GCPAccessTokenResponse, error)
+
+	// FetchGCPIdentityToken, if set, is called to obtain a GCP identity
+	// token from the Hub. Same motivation as FetchGCPToken.
+	FetchGCPIdentityToken func(ctx context.Context, audience string) (string, error)
 }
 
 const (
@@ -105,7 +115,7 @@ type Server struct {
 
 	// Token cache
 	mu          sync.RWMutex
-	cachedToken *cachedAccessToken
+	cachedToken *GCPAccessTokenResponse
 	// Identity token cache (keyed by audience)
 	idTokenMu      sync.RWMutex
 	cachedIDTokens map[string]*cachedIDToken
@@ -141,7 +151,8 @@ func (s *Server) authToken() string {
 	return s.config.AuthToken
 }
 
-type cachedAccessToken struct {
+// GCPAccessTokenResponse is the response from a GCP access token fetch.
+type GCPAccessTokenResponse struct {
 	AccessToken string    `json:"access_token"`
 	ExpiresIn   int       `json:"expires_in"`
 	TokenType   string    `json:"token_type"`
@@ -656,7 +667,30 @@ func (s *Server) handleIdentityToken(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, token.Token)
 }
 
-func (s *Server) fetchAccessToken(ctx context.Context) (*cachedAccessToken, error) {
+func (s *Server) fetchAccessToken(ctx context.Context) (*GCPAccessTokenResponse, error) {
+	var token *GCPAccessTokenResponse
+	var err error
+
+	if s.config.FetchGCPToken != nil {
+		token, err = s.config.FetchGCPToken(ctx, []string{"https://www.googleapis.com/auth/cloud-platform"})
+	} else {
+		token, err = s.fetchAccessTokenDirect(ctx)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	token.FetchedAt = time.Now()
+
+	s.mu.Lock()
+	s.cachedToken = token
+	s.mu.Unlock()
+
+	return token, nil
+}
+
+func (s *Server) fetchAccessTokenDirect(ctx context.Context) (*GCPAccessTokenResponse, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/agent/gcp-token", strings.TrimSuffix(s.config.HubURL, "/"))
 
 	body, _ := json.Marshal(map[string][]string{
@@ -682,16 +716,10 @@ func (s *Server) fetchAccessToken(ctx context.Context) (*cachedAccessToken, erro
 		return nil, fmt.Errorf("hub returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	var token cachedAccessToken
+	var token GCPAccessTokenResponse
 	if err := json.Unmarshal(respBody, &token); err != nil {
 		return nil, fmt.Errorf("parse response: %w", err)
 	}
-	token.FetchedAt = time.Now()
-
-	// Cache
-	s.mu.Lock()
-	s.cachedToken = &token
-	s.mu.Unlock()
 
 	return &token, nil
 }
@@ -701,38 +729,23 @@ type hubIDTokenResponse struct {
 }
 
 func (s *Server) fetchIdentityToken(ctx context.Context, audience string) (*cachedIDToken, error) {
-	endpoint := fmt.Sprintf("%s/api/v1/agent/gcp-identity-token", strings.TrimSuffix(s.config.HubURL, "/"))
+	var tokenStr string
+	var err error
 
-	body, _ := json.Marshal(map[string]string{"audience": audience})
+	if s.config.FetchGCPIdentityToken != nil {
+		tokenStr, err = s.config.FetchGCPIdentityToken(ctx, audience)
+	} else {
+		tokenStr, err = s.fetchIdentityTokenDirect(ctx, audience)
+	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+s.authToken())
-
-	resp, err := s.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("hub request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("hub returned %d: %s", resp.StatusCode, string(respBody))
-	}
-
-	var result hubIDTokenResponse
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, fmt.Errorf("parse response: %w", err)
+		return nil, err
 	}
 
 	cached := &cachedIDToken{
-		Token:     result.Token,
+		Token:     tokenStr,
 		FetchedAt: time.Now(),
-		ExpiresAt: time.Now().Add(55 * time.Minute), // Conservative: ID tokens are ~1hr
+		ExpiresAt: time.Now().Add(55 * time.Minute),
 	}
 
 	s.idTokenMu.Lock()
@@ -740,6 +753,38 @@ func (s *Server) fetchIdentityToken(ctx context.Context, audience string) (*cach
 	s.idTokenMu.Unlock()
 
 	return cached, nil
+}
+
+func (s *Server) fetchIdentityTokenDirect(ctx context.Context, audience string) (string, error) {
+	endpoint := fmt.Sprintf("%s/api/v1/agent/gcp-identity-token", strings.TrimSuffix(s.config.HubURL, "/"))
+
+	body, _ := json.Marshal(map[string]string{"audience": audience})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+s.authToken())
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("hub request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("hub returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result hubIDTokenResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("parse response: %w", err)
+	}
+
+	return result.Token, nil
 }
 
 func (s *Server) proactiveRefreshLoop(ctx context.Context) {


### PR DESCRIPTION
The metadata server's direct HTTP calls to the Hub's /api/v1/agent/gcp-token endpoint used Authorization: Bearer with the app token, which conflicts with OIDC transport auth (IAP/Cloud Run) and uses the wrong header convention.

Route these calls through the hub client instead, which correctly uses X-Scion-Agent-Token for app auth and has OIDC transport configured. This fixes GCP auth failures on resumed agents where the metadata server returned 502 despite the scion auth token being valid.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
