### PR TITLE
Fix: Skip OIDC metadata mode when SCION_METADATA_MODE is set.

### DIFF
--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -349,9 +349,9 @@ func runInit(args []string) int {
 		}
 	}
 
-	// Declare hubClient early so the metadata server's fetch callbacks can
-	// capture it. It is populated later, after the child process starts.
-	var hubClient *hub.Client
+	// Initialize hubClient early so the metadata server's fetch callbacks
+	// can use it without data races or startup race conditions.
+	hubClient := hub.NewClient()
 
 	// Start GCP metadata server if configured
 	var metadataServer *metadata.Server
@@ -490,7 +490,6 @@ func runInit(args []string) int {
 		}
 
 		// Report running status to Hub if in hosted mode
-		hubClient = hub.NewClient()
 		log.Debug("Hub client check: client=%v, configured=%v", hubClient != nil, hubClient != nil && hubClient.IsConfigured())
 		log.Debug("Hub env: SCION_HUB_ENDPOINT=%q, SCION_HUB_URL=%q, token_file=%v, SCION_AGENT_ID=%q",
 			os.Getenv("SCION_HUB_ENDPOINT"), os.Getenv("SCION_HUB_URL"), hub.ReadTokenFile() != "", os.Getenv("SCION_AGENT_ID"))

--- a/pkg/sciontool/hub/oidc.go
+++ b/pkg/sciontool/hub/oidc.go
@@ -219,8 +219,19 @@ func (c *Client) configureOIDCTransport() {
 		return
 	}
 
-	// Fall back to GCE metadata server if on GCP
+	// Fall back to GCE metadata server if on GCP — but only when the scion
+	// metadata server is NOT active. When SCION_METADATA_MODE is "assign",
+	// iptables redirects the metadata IP (169.254.169.254) to the local scion
+	// metadata server on port 18380. This makes the real GCE metadata server
+	// unreachable, causing OIDC token fetches to time out and creating a
+	// circular dependency (hub client → GCE metadata → scion metadata → hub
+	// client). If no transport token was injected and scion metadata is active,
+	// the Hub doesn't require transport-layer OIDC auth.
 	if !isOnGCPFunc() {
+		return
+	}
+	if mode := os.Getenv("SCION_METADATA_MODE"); mode != "" {
+		log.Debug("Skipping OIDC metadata mode: scion metadata server active (mode=%s), GCE metadata IP is redirected", mode)
 		return
 	}
 

--- a/pkg/sciontool/hub/oidc_test.go
+++ b/pkg/sciontool/hub/oidc_test.go
@@ -337,8 +337,9 @@ func TestConfigureOIDCTransport_MetadataMode(t *testing.T) {
 	cleanup := overrideGCPDetection(true)
 	defer cleanup()
 
-	// Ensure no injected token
+	// Ensure no injected token and no scion metadata server
 	os.Unsetenv(EnvTransportToken)
+	os.Unsetenv("SCION_METADATA_MODE")
 
 	c := &Client{
 		hubURL: "https://hub.example.com",
@@ -358,6 +359,7 @@ func TestConfigureOIDCTransport_MetadataMode_AudienceOverride(t *testing.T) {
 	defer cleanup()
 
 	os.Unsetenv(EnvTransportToken)
+	os.Unsetenv("SCION_METADATA_MODE")
 	os.Setenv(EnvHubOIDCAudience, "https://custom-audience.example.com")
 	defer os.Unsetenv(EnvHubOIDCAudience)
 
@@ -388,6 +390,24 @@ func TestConfigureOIDCTransport_NotOnGCP(t *testing.T) {
 
 	assert.Nil(t, c.oidcSource, "should not configure OIDC when not on GCP and no injected token")
 	assert.Nil(t, c.client.Transport, "transport should not be wrapped")
+}
+
+func TestConfigureOIDCTransport_SkipsMetadataWhenScionMetadataActive(t *testing.T) {
+	cleanup := overrideGCPDetection(true)
+	defer cleanup()
+
+	os.Unsetenv(EnvTransportToken)
+	os.Setenv("SCION_METADATA_MODE", "assign")
+	defer os.Unsetenv("SCION_METADATA_MODE")
+
+	c := &Client{
+		hubURL: "https://hub.example.com",
+		client: &http.Client{Timeout: DefaultTimeout},
+	}
+
+	c.configureOIDCTransport()
+
+	assert.Nil(t, c.oidcSource, "should not configure OIDC metadata mode when scion metadata server is active")
 }
 
 func TestConfigureOIDCTransport_InjectedPriority(t *testing.T) {


### PR DESCRIPTION
  Fix: Skip OIDC metadata mode when SCION_METADATA_MODE is set. If no SCION_TRANSPORT_TOKEN was injected by the dispatcher, the Hub doesn't require transport-layer   OIDC auth.
> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
