### PR TITLE
fix: reclaim metadata server port from stale instance on resume

### DIFF
--- a/pkg/sciontool/metadata/server.go
+++ b/pkg/sciontool/metadata/server.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -28,6 +29,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/log"
@@ -178,10 +180,13 @@ func (s *Server) buildMux() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", s.handleRoot)
 	mux.HandleFunc("/computeMetadata/v1/", s.handleMetadata)
+	mux.HandleFunc("/_scion/shutdown", s.handleShutdown)
 	return s.requireMetadataFlavor(mux)
 }
 
 // Start starts the metadata server in the background. Returns immediately.
+// If the port is already in use (e.g. a stale metadata server from a previous
+// init cycle), Start attempts to gracefully shut it down and retry.
 func (s *Server) Start(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	s.cancel = cancel
@@ -193,6 +198,21 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	ln, err := net.Listen("tcp", addr)
+	if err != nil && errors.Is(err, syscall.EADDRINUSE) {
+		log.Info("Metadata server port %d already in use, attempting to reclaim", s.config.Port)
+		s.shutdownExisting()
+		for attempt := 1; attempt <= 3; attempt++ {
+			time.Sleep(time.Duration(attempt) * 250 * time.Millisecond)
+			ln, err = net.Listen("tcp", addr)
+			if err == nil {
+				log.Info("Reclaimed metadata server port %d after %d retries", s.config.Port, attempt)
+				break
+			}
+			if !errors.Is(err, syscall.EADDRINUSE) {
+				break
+			}
+		}
+	}
 	if err != nil {
 		cancel()
 		return fmt.Errorf("metadata server listen: %w", err)
@@ -290,6 +310,42 @@ func (s *Server) Stop() {
 	if s.cancel != nil {
 		s.cancel()
 	}
+}
+
+// shutdownExisting tries to shut down an existing metadata server on the port
+// by sending a POST to its /_scion/shutdown endpoint. This handles the case
+// where a stale server from a previous init cycle holds the port.
+func (s *Server) shutdownExisting() {
+	client := &http.Client{Timeout: 2 * time.Second}
+	url := fmt.Sprintf("http://127.0.0.1:%d/_scion/shutdown", s.config.Port)
+	req, err := http.NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		return
+	}
+	req.Header.Set("Metadata-Flavor", "Google")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Debug("Could not reach existing metadata server for shutdown: %v", err)
+		return
+	}
+	resp.Body.Close()
+	log.Info("Sent shutdown request to existing metadata server on port %d (status=%d)", s.config.Port, resp.StatusCode)
+}
+
+// handleShutdown handles POST /_scion/shutdown requests, allowing a new
+// metadata server instance to reclaim the port from a stale server.
+func (s *Server) handleShutdown(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	log.Info("Shutdown requested via /_scion/shutdown, stopping metadata server")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, "shutting down")
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		s.Stop()
+	}()
 }
 
 func (s *Server) probeHealth() bool {

--- a/pkg/sciontool/metadata/server_test.go
+++ b/pkg/sciontool/metadata/server_test.go
@@ -716,3 +716,120 @@ func TestMetadataServer_RestartLimit(t *testing.T) {
 		t.Fatal("expected server to be marked abandoned")
 	}
 }
+
+func TestMetadataServer_ShutdownEndpoint(t *testing.T) {
+	port := freePort(t)
+	srv := New(Config{
+		Mode:      "block",
+		Port:      port,
+		ProjectID: "test-project",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := srv.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Stop()
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify server is running
+	if !srv.probeHealth() {
+		t.Fatal("expected server to be healthy")
+	}
+
+	// GET should be rejected
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/_scion/shutdown", port), nil)
+	req.Header.Set("Metadata-Flavor", "Google")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for GET, got %d", resp.StatusCode)
+	}
+
+	// POST without Metadata-Flavor header should be rejected
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/_scion/shutdown", port), nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 without Metadata-Flavor, got %d", resp.StatusCode)
+	}
+
+	// POST with Metadata-Flavor should succeed and shut down
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/_scion/shutdown", port), nil)
+	req.Header.Set("Metadata-Flavor", "Google")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if string(body) != "shutting down" {
+		t.Fatalf("expected 'shutting down', got %q", string(body))
+	}
+
+	// Wait for shutdown to complete
+	time.Sleep(200 * time.Millisecond)
+
+	// Server should no longer be reachable
+	if srv.probeHealth() {
+		t.Fatal("expected server to be unreachable after shutdown")
+	}
+}
+
+func TestMetadataServer_StartReclaimsPort(t *testing.T) {
+	port := freePort(t)
+
+	// Start a first metadata server on the port
+	srv1 := New(Config{
+		Mode:      "block",
+		Port:      port,
+		ProjectID: "old-project",
+	})
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+
+	if err := srv1.Start(ctx1); err != nil {
+		t.Fatal(err)
+	}
+	defer srv1.Stop()
+	time.Sleep(50 * time.Millisecond)
+
+	if !srv1.probeHealth() {
+		t.Fatal("first server not healthy")
+	}
+
+	// Start a second server on the same port — should reclaim it
+	srv2 := New(Config{
+		Mode:      "block",
+		Port:      port,
+		ProjectID: "new-project",
+	})
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	if err := srv2.Start(ctx2); err != nil {
+		t.Fatalf("second Start() should succeed by reclaiming port: %v", err)
+	}
+	defer srv2.Stop()
+	time.Sleep(50 * time.Millisecond)
+
+	// The new server should be serving with the new config
+	resp, body := metadataGet(t, port, "/computeMetadata/v1/project/project-id")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if body != "new-project" {
+		t.Fatalf("expected new-project from replacement server, got %q", body)
+	}
+}


### PR DESCRIPTION
On agent resume, a stale metadata server from a previous init cycle may still hold port 18380. The new init can't bind the port, leaving the agent with a metadata server that has outdated config (no hub client callbacks), causing GCP token fetches to fail.

Add a /_scion/shutdown endpoint to the metadata server and retry logic in Start(): when net.Listen fails with EADDRINUSE, POST to the stale server's shutdown endpoint, wait for it to release the port, and retry up to 3 times with backoff.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
