### PR TITLE
fix: treat signal-killed child as clean exit during intentional shutdown

### DIFF
--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -405,9 +406,13 @@ func runInit(args []string) int {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Set up signal handling with pre-stop hook for graceful shutdown
+	// Set up signal handling with pre-stop hook for graceful shutdown.
+	// requestedShutdown tracks whether the process received an intentional
+	// SIGTERM/SIGINT so classifyExit can distinguish a clean stop from a crash.
+	var requestedShutdown atomic.Bool
 	sigHandler := supervisor.NewSignalHandler(sup, cancel).
 		WithPreStopHook(func() error {
+			requestedShutdown.Store(true)
 			log.Info("Running pre-stop hooks...")
 			return lifecycleManager.RunPreStop()
 		})
@@ -816,7 +821,7 @@ waitLoop:
 		log.Info("Recovered harness exit code %d from %s", *harnessCode, state.HarnessExitCodeFile)
 	}
 
-	outcome := classifyExit(result.code, result.err, harnessCode, limitsExceeded)
+	outcome := classifyExit(result.code, result.err, harnessCode, limitsExceeded, requestedShutdown.Load())
 	finalCode := outcome.exitCode
 	limitsExceeded = outcome.limitsExceeded
 
@@ -917,13 +922,16 @@ type exitOutcome struct {
 //
 //   - limitsExceeded                  → stopped + limits_exceeded (handled by caller)
 //   - clean exit (code 0, no error)   → stopped
+//   - requestedShutdown + code -1     → stopped (signal-killed by intentional SIGTERM)
 //   - unexpected non-zero exit/error  → error (crash), restartable
 //
 // harnessCode, when non-nil, is the authoritative harness exit code recovered
 // from the exit-code file and overrides the supervised child's code for the
 // crash decision. supervisorErr is the supervisor's own error (a synthetic
-// failure not reflected in supervisedCode).
-func classifyExit(supervisedCode int, supervisorErr error, harnessCode *int, limitsExceeded bool) exitOutcome {
+// failure not reflected in supervisedCode). requestedShutdown is true when
+// init received SIGTERM/SIGINT, indicating the container was intentionally
+// stopped — a signal-killed child (exit code -1) is expected, not a crash.
+func classifyExit(supervisedCode int, supervisorErr error, harnessCode *int, limitsExceeded bool, requestedShutdown bool) exitOutcome {
 	if !limitsExceeded && supervisedCode == handlers.ExitCodeLimitsExceeded {
 		limitsExceeded = true
 	}
@@ -937,6 +945,12 @@ func classifyExit(supervisedCode int, supervisorErr error, harnessCode *int, lim
 
 	if limitsExceeded {
 		return exitOutcome{exitCode: handlers.ExitCodeLimitsExceeded, limitsExceeded: true}
+	}
+
+	// When init was told to shut down (SIGTERM/SIGINT), the child is killed by
+	// signal and Go reports exit code -1. This is expected, not a crash.
+	if requestedShutdown && finalCode == -1 {
+		return exitOutcome{exitCode: 0}
 	}
 
 	// A supervisor error with a zero exit code is itself a failure.

--- a/cmd/sciontool/commands/init_crash_test.go
+++ b/cmd/sciontool/commands/init_crash_test.go
@@ -17,15 +17,16 @@ func intPtr(i int) *int { return &i }
 
 func TestClassifyExit(t *testing.T) {
 	tests := []struct {
-		name           string
-		supervisedCode int
-		supervisorErr  error
-		harnessCode    *int
-		limitsExceeded bool
-		wantCode       int
-		wantCrash      bool
-		wantLimits     bool
-		wantMsg        string
+		name              string
+		supervisedCode    int
+		supervisorErr     error
+		harnessCode       *int
+		limitsExceeded    bool
+		requestedShutdown bool
+		wantCode          int
+		wantCrash         bool
+		wantLimits        bool
+		wantMsg           string
 	}{
 		{
 			name:           "clean exit code 0",
@@ -78,11 +79,41 @@ func TestClassifyExit(t *testing.T) {
 			wantCrash:      true,
 			wantMsg:        "Agent crashed (supervisor error: boom)",
 		},
+		{
+			name:              "signal-killed without requested shutdown is crash",
+			supervisedCode:    -1,
+			wantCode:          -1,
+			wantCrash:         true,
+			wantMsg:           "Agent crashed with exit code -1",
+		},
+		{
+			name:              "signal-killed with requested shutdown is clean stop",
+			supervisedCode:    -1,
+			requestedShutdown: true,
+			wantCode:          0,
+			wantCrash:         false,
+		},
+		{
+			name:              "requested shutdown with non-signal exit code is still crash",
+			supervisedCode:    1,
+			requestedShutdown: true,
+			wantCode:          1,
+			wantCrash:         true,
+			wantMsg:           "Agent crashed with exit code 1",
+		},
+		{
+			name:              "harness code -1 with requested shutdown is clean stop",
+			supervisedCode:    0,
+			harnessCode:       intPtr(-1),
+			requestedShutdown: true,
+			wantCode:          0,
+			wantCrash:         false,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := classifyExit(tc.supervisedCode, tc.supervisorErr, tc.harnessCode, tc.limitsExceeded)
+			got := classifyExit(tc.supervisedCode, tc.supervisorErr, tc.harnessCode, tc.limitsExceeded, tc.requestedShutdown)
 			if got.exitCode != tc.wantCode {
 				t.Errorf("exitCode = %d, want %d", got.exitCode, tc.wantCode)
 			}


### PR DESCRIPTION
When stopping or suspending an agent, the container receives SIGTERM, which kills the child process. Go reports exit code -1 for signal-terminated processes. classifyExit was treating this as a crash, causing the agent to cycle through PhaseError before reaching its intended terminal state (stopped/suspended).

Add a requestedShutdown flag (set when init receives SIGTERM/SIGINT) so classifyExit can distinguish an intentional stop from an unexpected crash. Exit code -1 with requestedShutdown=true is now classified as a clean exit.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
