### PR TITLE
fix: route colocated docker agents to bridge networking via Caddy domain

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1372,12 +1372,47 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 		}
 	}
 
-	// Auto-compute ContainerHubEndpoint
+	// Auto-compute ContainerHubEndpoint.
+	//
+	// For colocated Docker agents we prefer to route them at the public domain
+	// (served by Caddy) so each agent runs in its own network namespace under
+	// bridge networking. This avoids the host-global metadata-server (:18380)
+	// and telemetry (:4317) port collisions that --network=host causes for
+	// concurrent agents. We fall back to the legacy host.docker.internal (host
+	// networking) path when:
+	//   - the escape hatch SCION_FORCE_HOST_NETWORK is set,
+	//   - the Docker daemon lacks host-gateway support, or
+	//   - no public domain is configured (can't reach Caddy without one).
 	containerHubEndpoint := cfg.RuntimeBroker.ContainerHubEndpoint
 	if containerHubEndpoint == "" && enableHub && hubEndpointForRH != "" && rt != nil {
-		if computed := containerBridgeEndpoint(hubEndpointForRH, rt.Name()); computed != "" {
-			containerHubEndpoint = computed
-			log.Printf("Auto-computed ContainerHubEndpoint for %s runtime: %s", rt.Name(), containerHubEndpoint)
+		forceHost := os.Getenv(runtime.ForceHostNetworkEnvVar) != ""
+		isDocker := rt.Name() == "docker"
+		publicDomain := ""
+		if hubEndpoint != "" && !isLocalhostURL(hubEndpoint) {
+			publicDomain = strings.TrimRight(hubEndpoint, "/")
+		}
+
+		if isDocker && !forceHost && !runtime.DockerSupportsHostGateway(ctx, "") {
+			log.Printf("WARNING: Docker daemon lacks host-gateway support; colocated agents will use host networking (re-introduces metadata-server port contention for concurrent agents). Upgrade Docker Engine to >= 20.10 to enable per-agent bridge networking.")
+			forceHost = true
+		}
+
+		switch {
+		case isDocker && !forceHost && publicDomain != "":
+			// Route agents to the public domain so they reach the hub via Caddy
+			// under bridge networking (colocatedExtraHosts maps the domain to
+			// host-gateway). applyContainerBridgeOverride returns it wholesale.
+			containerHubEndpoint = publicDomain
+			log.Printf("Colocated %s agents routed via public domain %s (bridge networking)", rt.Name(), containerHubEndpoint)
+		default:
+			if computed := containerBridgeEndpoint(hubEndpointForRH, rt.Name()); computed != "" {
+				containerHubEndpoint = computed
+				if isDocker && !forceHost {
+					// publicDomain == "" here: no domain configured to reach Caddy.
+					log.Printf("WARNING: no public domain configured for colocated Docker agents; falling back to host networking. Set SCION_SERVER_BASE_URL=https://<domain> to enable per-agent bridge networking.")
+				}
+				log.Printf("Auto-computed ContainerHubEndpoint for %s runtime: %s", rt.Name(), containerHubEndpoint)
+			}
 		}
 	}
 

--- a/pkg/agent/run_metadata_test.go
+++ b/pkg/agent/run_metadata_test.go
@@ -14,7 +14,80 @@
 
 package agent
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
+)
+
+// TestColocatedDockerNetworkComposition mirrors how run.go assembles a
+// container's RunConfig.NetworkMode and ExtraHosts (run.go:672, 891-892) for a
+// colocated Docker agent. The broker supplies the public-domain host-gateway
+// mapping via opts.ExtraHosts (from colocatedExtraHosts); the agent path
+// derives NetworkMode from ResolveDockerNetworking and merges BridgeExtraHosts.
+func TestColocatedDockerNetworkComposition(t *testing.T) {
+	const domainHostGateway = "hub.example.com:host-gateway"
+
+	tests := []struct {
+		name           string
+		forceHost      bool
+		hubEndpoint    string
+		brokerExtra    []string // opts.ExtraHosts supplied by the broker
+		wantNetMode    string
+		wantExtraHosts []string
+	}{
+		{
+			name:           "colocated docker domain uses bridge with host-gateway",
+			hubEndpoint:    "https://hub.example.com",
+			brokerExtra:    []string{domainHostGateway},
+			wantNetMode:    "",
+			wantExtraHosts: []string{domainHostGateway},
+		},
+		{
+			name:           "force-host falls back to host networking",
+			forceHost:      true,
+			hubEndpoint:    "https://hub.example.com",
+			brokerExtra:    []string{domainHostGateway},
+			wantNetMode:    "host",
+			wantExtraHosts: []string{domainHostGateway},
+		},
+		{
+			// Legacy fallback: ResolveDockerNetworking rewrites the bridge
+			// hostname back to localhost (reachable under host networking), so
+			// by the time agentEnv is built no host-gateway add-host is needed.
+			name:           "host.docker.internal fallback uses host networking",
+			hubEndpoint:    "http://host.docker.internal:8080",
+			brokerExtra:    nil,
+			wantNetMode:    "host",
+			wantExtraHosts: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.forceHost {
+				t.Setenv(runtime.ForceHostNetworkEnvVar, "1")
+			}
+			env := map[string]string{"SCION_HUB_ENDPOINT": tt.hubEndpoint}
+			gotMode := runtime.ResolveDockerNetworking("docker", env)
+			if gotMode != tt.wantNetMode {
+				t.Errorf("NetworkMode = %q, want %q", gotMode, tt.wantNetMode)
+			}
+
+			// Mirror run.go: agentEnv is built from opts.Env after the rewrite.
+			agentEnv := []string{"SCION_HUB_ENDPOINT=" + env["SCION_HUB_ENDPOINT"]}
+			gotExtra := mergeExtraHosts(tt.brokerExtra, runtime.BridgeExtraHosts("docker", agentEnv))
+			if len(gotExtra) != len(tt.wantExtraHosts) {
+				t.Fatalf("ExtraHosts = %v, want %v", gotExtra, tt.wantExtraHosts)
+			}
+			for i := range gotExtra {
+				if gotExtra[i] != tt.wantExtraHosts[i] {
+					t.Errorf("ExtraHosts[%d] = %q, want %q", i, gotExtra[i], tt.wantExtraHosts[i])
+				}
+			}
+		})
+	}
+}
 
 func TestMergeExtraHosts(t *testing.T) {
 	tests := []struct {

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -674,7 +674,12 @@ func DockerSupportsHostGateway(ctx context.Context, command string) bool {
 	if command == "" {
 		command = "docker"
 	}
-	out, err := runSimpleCommand(ctx, command, "version", "--format", "{{.Server.Version}}")
+	// Bound the probe so an unresponsive Docker daemon cannot hang server
+	// startup indefinitely; on timeout we fall through to the conservative
+	// "assume support" path below.
+	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	out, err := runSimpleCommand(probeCtx, command, "version", "--format", "{{.Server.Version}}")
 	if err != nil {
 		runtimeLog.Debug("Unable to probe Docker server version for host-gateway support", "error", err)
 		return true
@@ -692,24 +697,28 @@ func DockerSupportsHostGateway(ctx context.Context, command string) bool {
 }
 
 // parseDockerServerVersion parses the leading "major.minor" of a Docker server
-// version string (e.g. "24.0.7" or "20.10.21").
+// version string (e.g. "24.0.7" or "20.10.21"). It tolerates a leading "v"/"V"
+// prefix and scans line-by-line so daemon warnings or other noise mixed into the
+// command output (runSimpleCommand combines stdout and stderr) do not defeat the
+// probe.
 func parseDockerServerVersion(v string) (major, minor int, ok bool) {
-	if v == "" {
-		return 0, 0, false
+	for _, line := range strings.Split(v, "\n") {
+		line = strings.TrimLeft(strings.TrimSpace(line), "vV")
+		parts := strings.SplitN(line, ".", 3)
+		if len(parts) < 2 {
+			continue
+		}
+		major, err := strconv.Atoi(parts[0])
+		if err != nil {
+			continue
+		}
+		minor, err = strconv.Atoi(parts[1])
+		if err != nil {
+			continue
+		}
+		return major, minor, true
 	}
-	parts := strings.SplitN(v, ".", 3)
-	if len(parts) < 2 {
-		return 0, 0, false
-	}
-	major, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return 0, 0, false
-	}
-	minor, err = strconv.Atoi(parts[1])
-	if err != nil {
-		return 0, 0, false
-	}
-	return major, minor, true
+	return 0, 0, false
 }
 
 // BridgeExtraHosts returns the --add-host entries needed for the given runtime

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -590,12 +590,25 @@ func expandTildeTarget(target, containerHome string) string {
 	return target
 }
 
+// ForceHostNetworkEnvVar, when set to a non-empty value in the broker's
+// environment, forces colocated Docker agents back onto host networking. It is
+// the escape hatch that reverts to the pre-bridge behavior without a redeploy.
+const ForceHostNetworkEnvVar = "SCION_FORCE_HOST_NETWORK"
+
+// forceHostNetworking reports whether the host-networking escape hatch is set.
+func forceHostNetworking() bool {
+	return os.Getenv(ForceHostNetworkEnvVar) != ""
+}
+
 // ResolveDockerNetworking checks whether Docker host networking should be used
 // to allow containers to reach services on the host's loopback interface.
 // When the hub endpoint is localhost or was translated to a Docker bridge
 // hostname (host.docker.internal), it returns "host" and rewrites any bridge
 // hostnames back to localhost in the env map. This avoids the need for the
 // server to bind to 0.0.0.0.
+//
+// When the SCION_FORCE_HOST_NETWORK escape hatch is set, host networking is
+// forced regardless of the endpoint, reverting to the legacy behavior.
 //
 // For non-Docker runtimes or non-localhost endpoints, returns "" (no override).
 func ResolveDockerNetworking(runtimeName string, env map[string]string) string {
@@ -611,14 +624,17 @@ func ResolveDockerNetworking(runtimeName string, env map[string]string) string {
 		return ""
 	}
 
+	// Escape hatch: force host networking regardless of endpoint so a
+	// deployment can revert to the legacy behavior without a redeploy.
+	if forceHostNetworking() {
+		rewriteBridgeHostToLocalhost(env)
+		return "host"
+	}
+
 	// If endpoint uses the Docker bridge hostname (translated from localhost),
 	// rewrite back to localhost since host networking makes it reachable directly.
 	if strings.Contains(ep, "host.docker.internal") {
-		for _, key := range []string{"SCION_HUB_ENDPOINT", "SCION_HUB_URL"} {
-			if v, ok := env[key]; ok {
-				env[key] = strings.Replace(v, "host.docker.internal", "localhost", 1)
-			}
-		}
+		rewriteBridgeHostToLocalhost(env)
 		return "host"
 	}
 
@@ -633,6 +649,67 @@ func ResolveDockerNetworking(runtimeName string, env map[string]string) string {
 	}
 
 	return ""
+}
+
+// rewriteBridgeHostToLocalhost rewrites any host.docker.internal references in
+// the hub endpoint env vars back to localhost, since host networking makes the
+// host loopback reachable directly.
+func rewriteBridgeHostToLocalhost(env map[string]string) {
+	for _, key := range []string{"SCION_HUB_ENDPOINT", "SCION_HUB_URL"} {
+		if v, ok := env[key]; ok {
+			env[key] = strings.Replace(v, "host.docker.internal", "localhost", 1)
+		}
+	}
+}
+
+// DockerSupportsHostGateway reports whether the Docker daemon supports the
+// special "host-gateway" address used by --add-host. Support was added in
+// Docker Engine 20.10; older daemons cannot map a domain to the host, so
+// colocated bridge networking would be unable to reach Caddy and the broker
+// must fall back to host networking. On any probe failure we conservatively
+// assume support is present (the common case on modern hosts) so we don't
+// needlessly disable the fix; a genuinely old daemon will surface the missing
+// host-gateway when the container fails to start, which is rare in practice.
+func DockerSupportsHostGateway(ctx context.Context, command string) bool {
+	if command == "" {
+		command = "docker"
+	}
+	out, err := runSimpleCommand(ctx, command, "version", "--format", "{{.Server.Version}}")
+	if err != nil {
+		runtimeLog.Debug("Unable to probe Docker server version for host-gateway support", "error", err)
+		return true
+	}
+	major, minor, ok := parseDockerServerVersion(strings.TrimSpace(out))
+	if !ok {
+		runtimeLog.Debug("Unable to parse Docker server version for host-gateway support", "version", out)
+		return true
+	}
+	// host-gateway requires Docker Engine >= 20.10.
+	if major > 20 || (major == 20 && minor >= 10) {
+		return true
+	}
+	return false
+}
+
+// parseDockerServerVersion parses the leading "major.minor" of a Docker server
+// version string (e.g. "24.0.7" or "20.10.21").
+func parseDockerServerVersion(v string) (major, minor int, ok bool) {
+	if v == "" {
+		return 0, 0, false
+	}
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) < 2 {
+		return 0, 0, false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, false
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, false
+	}
+	return major, minor, true
 }
 
 // BridgeExtraHosts returns the --add-host entries needed for the given runtime

--- a/pkg/runtime/common_test.go
+++ b/pkg/runtime/common_test.go
@@ -1122,6 +1122,7 @@ func TestResolveDockerNetworking(t *testing.T) {
 		name        string
 		runtimeName string
 		env         map[string]string
+		forceHost   bool // set SCION_FORCE_HOST_NETWORK for this case
 		wantMode    string
 		wantEP      string // expected SCION_HUB_ENDPOINT after call (empty = unchanged/absent)
 	}{
@@ -1195,10 +1196,50 @@ func TestResolveDockerNetworking(t *testing.T) {
 			wantMode: "host",
 			wantEP:   "", // SCION_HUB_ENDPOINT not set
 		},
+		{
+			name:        "force-host overrides domain endpoint",
+			runtimeName: "docker",
+			env: map[string]string{
+				"SCION_HUB_ENDPOINT": "https://hub.example.com",
+			},
+			forceHost: true,
+			wantMode:  "host",
+			wantEP:    "https://hub.example.com",
+		},
+		{
+			name:        "force-host with localhost endpoint",
+			runtimeName: "docker",
+			env: map[string]string{
+				"SCION_HUB_ENDPOINT": "http://localhost:8080",
+			},
+			forceHost: true,
+			wantMode:  "host",
+			wantEP:    "http://localhost:8080",
+		},
+		{
+			name:        "force-host ignored for non-docker",
+			runtimeName: "podman",
+			env: map[string]string{
+				"SCION_HUB_ENDPOINT": "http://localhost:8080",
+			},
+			forceHost: true,
+			wantMode:  "",
+			wantEP:    "http://localhost:8080",
+		},
+		{
+			name:        "force-host with no endpoint yields no override",
+			runtimeName: "docker",
+			env:         map[string]string{},
+			forceHost:   true,
+			wantMode:    "",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.forceHost {
+				t.Setenv(ForceHostNetworkEnvVar, "1")
+			}
 			// Copy env to avoid mutation across subtests
 			env := make(map[string]string)
 			for k, v := range tt.env {
@@ -1497,6 +1538,33 @@ func TestExitCodeFromContainerStatus(t *testing.T) {
 			}
 			if code != tc.wantCode {
 				t.Errorf("code = %d, want %d", code, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestParseDockerServerVersion(t *testing.T) {
+	tests := []struct {
+		in        string
+		wantMajor int
+		wantMinor int
+		wantOK    bool
+	}{
+		{"24.0.7", 24, 0, true},
+		{"20.10.21", 20, 10, true},
+		{"19.03.15", 19, 3, true},
+		{"27.5", 27, 5, true},
+		{"", 0, 0, false},
+		{"garbage", 0, 0, false},
+		{"x.y.z", 0, 0, false},
+		{"20", 0, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			major, minor, ok := parseDockerServerVersion(tt.in)
+			if ok != tt.wantOK || major != tt.wantMajor || minor != tt.wantMinor {
+				t.Errorf("parseDockerServerVersion(%q) = (%d, %d, %v), want (%d, %d, %v)",
+					tt.in, major, minor, ok, tt.wantMajor, tt.wantMinor, tt.wantOK)
 			}
 		})
 	}

--- a/pkg/runtime/common_test.go
+++ b/pkg/runtime/common_test.go
@@ -1551,9 +1551,13 @@ func TestParseDockerServerVersion(t *testing.T) {
 		wantOK    bool
 	}{
 		{"24.0.7", 24, 0, true},
+		{"v24.0.7", 24, 0, true},
+		{"V24.0.7", 24, 0, true},
 		{"20.10.21", 20, 10, true},
 		{"19.03.15", 19, 3, true},
 		{"27.5", 27, 5, true},
+		{"  24.0.7  ", 24, 0, true},
+		{"WARNING: something\n24.0.7", 24, 0, true},
 		{"", 0, 0, false},
 		{"garbage", 0, 0, false},
 		{"x.y.z", 0, 0, false},

--- a/pkg/runtimebroker/hubenv.go
+++ b/pkg/runtimebroker/hubenv.go
@@ -100,20 +100,37 @@ func hubEndpointFromProjectSettings(projectPath string) string {
 	return projectSettings.GetHubEndpoint()
 }
 
+// bridgeHostnames are the special Docker/Podman hostnames that resolve to the
+// host's gateway. When the ContainerHubEndpoint uses one of these, the localhost
+// endpoint's port must be grafted onto it; a real public domain is used as-is.
+var bridgeHostnames = map[string]struct{}{
+	"host.docker.internal":     {},
+	"host.containers.internal": {},
+}
+
 func applyContainerBridgeOverride(endpoint, containerHubEndpoint, runtimeName string) string {
 	if containerHubEndpoint == "" || runtimeName == "kubernetes" || !isLocalhostEndpoint(endpoint) {
 		return endpoint
 	}
+	bridgeURL, err := url.Parse(containerHubEndpoint)
+	if err != nil {
+		return containerHubEndpoint
+	}
+	// When the override target is a public domain (colocated Docker routing
+	// agents at the Caddy domain) rather than a bridge hostname, use it
+	// wholesale. The domain's scheme/port (https, implicit 443) must be
+	// preserved, not replaced with the localhost endpoint's port (e.g. combo
+	// web port 8080).
+	if _, isBridge := bridgeHostnames[bridgeURL.Hostname()]; !isBridge {
+		return containerHubEndpoint
+	}
+	// Otherwise the override target is a bridge hostname (host.docker.internal).
 	// Preserve the port from the actual endpoint rather than using the
 	// pre-computed containerHubEndpoint wholesale. The containerHubEndpoint
 	// is computed once at server startup and may have a different port
 	// (e.g. standalone hub port 9810) than the endpoint being overridden
 	// (e.g. combo-mode web port 8080).
 	epURL, err := url.Parse(endpoint)
-	if err != nil {
-		return containerHubEndpoint
-	}
-	bridgeURL, err := url.Parse(containerHubEndpoint)
 	if err != nil {
 		return containerHubEndpoint
 	}

--- a/pkg/runtimebroker/hubenv_test.go
+++ b/pkg/runtimebroker/hubenv_test.go
@@ -275,6 +275,20 @@ func TestApplyContainerBridgeOverride(t *testing.T) {
 			runtimeName:          "podman",
 			want:                 "http://host.containers.internal:9810",
 		},
+		{
+			name:                 "domain container endpoint used wholesale, no port graft",
+			endpoint:             "http://localhost:8080",
+			containerHubEndpoint: "https://hub.example.com",
+			runtimeName:          "docker",
+			want:                 "https://hub.example.com",
+		},
+		{
+			name:                 "domain container endpoint preserves its own explicit port",
+			endpoint:             "http://localhost:8080",
+			containerHubEndpoint: "https://hub.example.com:8443",
+			runtimeName:          "docker",
+			want:                 "https://hub.example.com:8443",
+		},
 	}
 
 	for _, tt := range tests {

--- a/scripts/starter-hub/gce-start-hub.sh
+++ b/scripts/starter-hub/gce-start-hub.sh
@@ -189,6 +189,11 @@ EnvironmentFile=/home/scion/.scion/hub.env
 Environment=\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/google-cloud-sdk/bin\"
 Environment=\"HOME=/home/scion\"
 Environment=\"USE_GKE_GCLOUD_AUTH_PLUGIN=True\"
+# Public base URL dispatched to agents. This makes the broker route colocated
+# Docker agents through Caddy on the public domain so each runs under bridge
+# networking (own netns) instead of host networking, avoiding metadata-server
+# and telemetry port collisions between concurrent agents.
+Environment=\"SCION_SERVER_BASE_URL=https://${HUB_DOMAIN}\"
 # Use journald for log management
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
Colocated docker agents ran with --network=host, making the per-agent metadata server (127.0.0.1:18380) and telemetry OTLP receiver (:4317) host-global singletons. Only the first agent could bind them; concurrent or resumed agents got 'address already in use' -> sciontool doctor 502. Host networking also leaks GCP SA identity across agents.

Route colocated docker agents at the public Caddy domain so each runs in its own netns under bridge networking:

- ResolveDockerNetworking: add SCION_FORCE_HOST_NETWORK escape hatch; add DockerSupportsHostGateway capability probe (Engine >= 20.10).
- startRuntimeBroker: ContainerHubEndpoint autocompute prefers the public domain for colocated docker; falls back to host.docker.internal (host networking) when force-host is set, host-gateway is unsupported, or no public domain is configured (warns in the latter two cases).
- applyContainerBridgeOverride: use a public-domain ContainerHubEndpoint wholesale instead of grafting the localhost port (e.g. :8080) onto it.
- gce-start-hub.sh: export SCION_SERVER_BASE_URL=https://${HUB_DOMAIN} so the broker dispatches agents to the domain.

Scope is confined to docker + colocated; kubernetes, cloud run, podman, and remote-hub agents are unaffected. Reverting is a one-flag rollback (SCION_FORCE_HOST_NETWORK=1) with no redeploy.


