### PR TITLE
Support '!' prefix in broker messages as inline interrupt

### DIFF
--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -498,9 +498,12 @@ func (p *MessageBrokerProxy) deliverToAgent(ctx context.Context, projectID, agen
 	// A leading "!" in the message body acts as an inline interrupt signal:
 	// strip the prefix and promote to urgent so the harness is interrupted
 	// before delivery — equivalent to --interrupt on the CLI.
+	// Shallow-copy to avoid mutating the event-bus pointer shared across subscribers.
 	if strings.HasPrefix(msg.Msg, "!") {
-		msg.Msg = msg.Msg[1:]
-		msg.Urgent = true
+		stripped := *msg
+		stripped.Msg = msg.Msg[1:]
+		stripped.Urgent = true
+		msg = &stripped
 	}
 
 	dispatcher := p.getDispatcher()

--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -495,6 +495,14 @@ func (p *MessageBrokerProxy) deliverToAgent(ctx context.Context, projectID, agen
 		return
 	}
 
+	// A leading "!" in the message body acts as an inline interrupt signal:
+	// strip the prefix and promote to urgent so the harness is interrupted
+	// before delivery — equivalent to --interrupt on the CLI.
+	if strings.HasPrefix(msg.Msg, "!") {
+		msg.Msg = msg.Msg[1:]
+		msg.Urgent = true
+	}
+
 	dispatcher := p.getDispatcher()
 	if dispatcher == nil {
 		p.log.Warn("No dispatcher available, cannot deliver broker message",

--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -499,9 +499,13 @@ func (p *MessageBrokerProxy) deliverToAgent(ctx context.Context, projectID, agen
 	// strip the prefix and promote to urgent so the harness is interrupted
 	// before delivery — equivalent to --interrupt on the CLI.
 	// Shallow-copy to avoid mutating the event-bus pointer shared across subscribers.
-	if strings.HasPrefix(msg.Msg, "!") {
+	if trimmed := strings.TrimSpace(msg.Msg); strings.HasPrefix(trimmed, "!") {
 		stripped := *msg
-		stripped.Msg = msg.Msg[1:]
+		content := strings.TrimSpace(trimmed[1:])
+		if content == "" {
+			content = "interrupt"
+		}
+		stripped.Msg = content
 		stripped.Urgent = true
 		msg = &stripped
 	}

--- a/pkg/hub/messagebroker_test.go
+++ b/pkg/hub/messagebroker_test.go
@@ -274,6 +274,66 @@ func TestMessageBrokerProxy_InterruptPrefixNotStrippedWithoutBang(t *testing.T) 
 	}
 }
 
+func TestMessageBrokerProxy_InterruptPrefixEdgeCases(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantMsg      string
+		wantInterrupt bool
+		wantUrgent   bool
+	}{
+		{"bare bang", "!", "interrupt", true, true},
+		{"bang with trailing spaces", "!   ", "interrupt", true, true},
+		{"leading whitespace before bang", "  !restart", "restart", true, true},
+		{"whitespace between bang and content", "!  restart", "restart", true, true},
+		{"leading and inner whitespace", "  !  restart now  ", "restart now", true, true},
+		{"normal message no prefix", "hello", "hello", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newBrokerTestStore(t)
+			projectID := setupBrokerTestProject(t, s)
+			setupBrokerTestAgent(t, s, projectID, "test-agent", "running")
+
+			events := NewChannelEventPublisher()
+			defer events.Close()
+
+			bus := eventbus.NewInProcessEventBus(slog.Default())
+			defer bus.Close()
+
+			dispatcher := &brokerMockDispatcher{}
+
+			proxy := NewMessageBrokerProxy(bus, s, events, func() AgentDispatcher { return dispatcher }, slog.Default())
+			proxy.Start()
+			defer proxy.Stop()
+
+			proxy.subscribeAgent(projectID, "test-agent")
+
+			msg := messages.NewInstruction("user:alice", "agent:test-agent", tt.input)
+			if err := proxy.PublishMessage(context.Background(), projectID, msg); err != nil {
+				t.Fatal(err)
+			}
+
+			time.Sleep(100 * time.Millisecond)
+
+			dispatched := dispatcher.getMessages()
+			if len(dispatched) != 1 {
+				t.Fatalf("expected 1 dispatched message, got %d", len(dispatched))
+			}
+			if dispatched[0].msg != tt.wantMsg {
+				t.Errorf("msg = %q, want %q", dispatched[0].msg, tt.wantMsg)
+			}
+			if dispatched[0].interrupt != tt.wantInterrupt {
+				t.Errorf("interrupt = %v, want %v", dispatched[0].interrupt, tt.wantInterrupt)
+			}
+			if dispatched[0].structured.Urgent != tt.wantUrgent {
+				t.Errorf("Urgent = %v, want %v", dispatched[0].structured.Urgent, tt.wantUrgent)
+			}
+		})
+	}
+}
+
 func TestMessageBrokerProxy_InterruptPrefixPersistence(t *testing.T) {
 	s := newBrokerTestStore(t)
 	projectID := setupBrokerTestProject(t, s)

--- a/pkg/hub/messagebroker_test.go
+++ b/pkg/hub/messagebroker_test.go
@@ -276,11 +276,11 @@ func TestMessageBrokerProxy_InterruptPrefixNotStrippedWithoutBang(t *testing.T) 
 
 func TestMessageBrokerProxy_InterruptPrefixEdgeCases(t *testing.T) {
 	tests := []struct {
-		name         string
-		input        string
-		wantMsg      string
+		name          string
+		input         string
+		wantMsg       string
 		wantInterrupt bool
-		wantUrgent   bool
+		wantUrgent    bool
 	}{
 		{"bare bang", "!", "interrupt", true, true},
 		{"bang with trailing spaces", "!   ", "interrupt", true, true},

--- a/pkg/hub/messagebroker_test.go
+++ b/pkg/hub/messagebroker_test.go
@@ -204,7 +204,7 @@ func TestMessageBrokerProxy_InterruptPrefix(t *testing.T) {
 	defer events.Close()
 
 	b := eventbus.NewInProcessEventBus(slog.Default())
-	defer b.Close()
+	t.Cleanup(func() { _ = b.Close() })
 
 	dispatcher := &brokerMockDispatcher{}
 
@@ -245,7 +245,7 @@ func TestMessageBrokerProxy_InterruptPrefixNotStrippedWithoutBang(t *testing.T) 
 	defer events.Close()
 
 	b := eventbus.NewInProcessEventBus(slog.Default())
-	defer b.Close()
+	t.Cleanup(func() { _ = b.Close() })
 
 	dispatcher := &brokerMockDispatcher{}
 
@@ -300,7 +300,7 @@ func TestMessageBrokerProxy_InterruptPrefixEdgeCases(t *testing.T) {
 			defer events.Close()
 
 			bus := eventbus.NewInProcessEventBus(slog.Default())
-			defer bus.Close()
+			t.Cleanup(func() { _ = bus.Close() })
 
 			dispatcher := &brokerMockDispatcher{}
 
@@ -343,7 +343,7 @@ func TestMessageBrokerProxy_InterruptPrefixPersistence(t *testing.T) {
 	defer events.Close()
 
 	b := eventbus.NewInProcessEventBus(slog.Default())
-	defer b.Close()
+	t.Cleanup(func() { _ = b.Close() })
 
 	dispatcher := &brokerMockDispatcher{}
 

--- a/pkg/hub/messagebroker_test.go
+++ b/pkg/hub/messagebroker_test.go
@@ -195,6 +195,130 @@ func TestMessageBrokerProxy_DirectMessage(t *testing.T) {
 	}
 }
 
+func TestMessageBrokerProxy_InterruptPrefix(t *testing.T) {
+	s := newBrokerTestStore(t)
+	projectID := setupBrokerTestProject(t, s)
+	setupBrokerTestAgent(t, s, projectID, "test-agent", "running")
+
+	events := NewChannelEventPublisher()
+	defer events.Close()
+
+	b := eventbus.NewInProcessEventBus(slog.Default())
+	defer b.Close()
+
+	dispatcher := &brokerMockDispatcher{}
+
+	proxy := NewMessageBrokerProxy(b, s, events, func() AgentDispatcher { return dispatcher }, slog.Default())
+	proxy.Start()
+	defer proxy.Stop()
+
+	proxy.subscribeAgent(projectID, "test-agent")
+
+	msg := messages.NewInstruction("user:alice", "agent:test-agent", "!restart now")
+	if err := proxy.PublishMessage(context.Background(), projectID, msg); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	dispatched := dispatcher.getMessages()
+	if len(dispatched) != 1 {
+		t.Fatalf("expected 1 dispatched message, got %d", len(dispatched))
+	}
+	if dispatched[0].msg != "restart now" {
+		t.Errorf("expected message 'restart now' (! stripped), got %q", dispatched[0].msg)
+	}
+	if !dispatched[0].interrupt {
+		t.Error("expected interrupt=true for !-prefixed message")
+	}
+	if !dispatched[0].structured.Urgent {
+		t.Error("expected structured message Urgent=true for !-prefixed message")
+	}
+}
+
+func TestMessageBrokerProxy_InterruptPrefixNotStrippedWithoutBang(t *testing.T) {
+	s := newBrokerTestStore(t)
+	projectID := setupBrokerTestProject(t, s)
+	setupBrokerTestAgent(t, s, projectID, "test-agent", "running")
+
+	events := NewChannelEventPublisher()
+	defer events.Close()
+
+	b := eventbus.NewInProcessEventBus(slog.Default())
+	defer b.Close()
+
+	dispatcher := &brokerMockDispatcher{}
+
+	proxy := NewMessageBrokerProxy(b, s, events, func() AgentDispatcher { return dispatcher }, slog.Default())
+	proxy.Start()
+	defer proxy.Stop()
+
+	proxy.subscribeAgent(projectID, "test-agent")
+
+	msg := messages.NewInstruction("user:alice", "agent:test-agent", "hello agent")
+	if err := proxy.PublishMessage(context.Background(), projectID, msg); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	dispatched := dispatcher.getMessages()
+	if len(dispatched) != 1 {
+		t.Fatalf("expected 1 dispatched message, got %d", len(dispatched))
+	}
+	if dispatched[0].msg != "hello agent" {
+		t.Errorf("expected message 'hello agent' unchanged, got %q", dispatched[0].msg)
+	}
+	if dispatched[0].interrupt {
+		t.Error("expected interrupt=false for non-!-prefixed message")
+	}
+}
+
+func TestMessageBrokerProxy_InterruptPrefixPersistence(t *testing.T) {
+	s := newBrokerTestStore(t)
+	projectID := setupBrokerTestProject(t, s)
+	agent := setupBrokerTestAgent(t, s, projectID, "persist-agent", "running")
+
+	events := NewChannelEventPublisher()
+	defer events.Close()
+
+	b := eventbus.NewInProcessEventBus(slog.Default())
+	defer b.Close()
+
+	dispatcher := &brokerMockDispatcher{}
+
+	proxy := NewMessageBrokerProxy(b, s, events, func() AgentDispatcher { return dispatcher }, slog.Default())
+	proxy.Start()
+	defer proxy.Stop()
+
+	proxy.subscribeAgent(projectID, "persist-agent")
+
+	msg := messages.NewInstruction("user:alice", "agent:persist-agent", "!urgent task")
+	msg.SenderID = "user-alice-id"
+	msg.RecipientID = agent.ID
+	if err := proxy.PublishMessage(context.Background(), projectID, msg); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify the persisted message has the stripped content and urgent flag
+	ctx := context.Background()
+	result, err := s.ListMessages(ctx, store.MessageFilter{AgentID: agent.ID}, store.ListOptions{})
+	if err != nil {
+		t.Fatalf("failed to list messages: %v", err)
+	}
+	if len(result.Items) != 1 {
+		t.Fatalf("expected 1 persisted message, got %d", len(result.Items))
+	}
+	if result.Items[0].Msg != "urgent task" {
+		t.Errorf("expected persisted msg 'urgent task', got %q", result.Items[0].Msg)
+	}
+	if !result.Items[0].Urgent {
+		t.Error("expected persisted message Urgent=true")
+	}
+}
+
 func TestMessageBrokerProxy_ProjectBroadcast(t *testing.T) {
 	s := newBrokerTestStore(t)
 	projectID := setupBrokerTestProject(t, s)

--- a/pkg/hub/signing_key_shared_test.go
+++ b/pkg/hub/signing_key_shared_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !no_sqlite
+
 package hub
 
 import (


### PR DESCRIPTION
## Summary
- Messages arriving via the broker (Telegram, webhooks, direct messages) that start with `!` are now treated as interrupt messages
- The `!` prefix is stripped from the message body before delivery
- The message is delivered with `urgent=true` / interrupt semantics, equivalent to `--interrupt` on the CLI
- Detection happens in `deliverToAgent` in the message broker proxy, before persistence and dispatch, so both the stored message and the delivered message reflect the stripped content and urgent flag

## Test plan
- [x] `TestMessageBrokerProxy_InterruptPrefix` — verifies `!`-prefixed message is stripped and dispatched with interrupt=true
- [x] `TestMessageBrokerProxy_InterruptPrefixNotStrippedWithoutBang` — verifies normal messages are unaffected
- [x] `TestMessageBrokerProxy_InterruptPrefixPersistence` — verifies the persisted message has stripped content and urgent=true
- [x] All existing message broker tests continue to pass
