### PR TITLE
fix: unescape literal \n sequences in Telegram message formatting

### DIFF
--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -2274,7 +2274,7 @@ func FormatMessageV2(msg *messages.StructuredMessage, agentSlug string, recipien
 	}
 
 	b.WriteString("\n\n")
-	b.WriteString(msg.Msg)
+	b.WriteString(unescapeNewlines(msg.Msg))
 
 	text := b.String()
 	return truncateMessage(text)

--- a/extras/scion-telegram/internal/telegram/format.go
+++ b/extras/scion-telegram/internal/telegram/format.go
@@ -67,7 +67,7 @@ func FormatMessage(msg *messages.StructuredMessage) string {
 
 	// Add message body
 	b.WriteString("\n\n")
-	b.WriteString(msg.Msg)
+	b.WriteString(unescapeNewlines(msg.Msg))
 
 	// Add call-to-action for input-needed
 	if msg.Type == messages.TypeInputNeeded {
@@ -330,6 +330,14 @@ func truncateHTMLMessage(text string) string {
 		}
 	}
 	return truncated + truncationSuffix
+}
+
+// unescapeNewlines replaces literal escape sequences (\n, \t) with their actual
+// characters. Message text may arrive with these sequences when it passes through
+// JSON encoding (e.g. FormatForDelivery) and is later forwarded without decoding,
+// or when shell arguments carry un-interpreted backslash escapes.
+func unescapeNewlines(s string) string {
+	return strings.NewReplacer(`\n`, "\n", `\t`, "\t").Replace(s)
 }
 
 // truncateMessage ensures the text does not exceed Telegram's message limit.

--- a/extras/scion-telegram/internal/telegram/format.go
+++ b/extras/scion-telegram/internal/telegram/format.go
@@ -332,12 +332,14 @@ func truncateHTMLMessage(text string) string {
 	return truncated + truncationSuffix
 }
 
-// unescapeNewlines replaces literal escape sequences (\n, \t) with their actual
+// newlineReplacer replaces literal escape sequences (\n, \t) with their actual
 // characters. Message text may arrive with these sequences when it passes through
 // JSON encoding (e.g. FormatForDelivery) and is later forwarded without decoding,
 // or when shell arguments carry un-interpreted backslash escapes.
+var newlineReplacer = strings.NewReplacer(`\n`, "\n", `\t`, "\t")
+
 func unescapeNewlines(s string) string {
-	return strings.NewReplacer(`\n`, "\n", `\t`, "\t").Replace(s)
+	return newlineReplacer.Replace(s)
 }
 
 // truncateMessage ensures the text does not exceed Telegram's message limit.

--- a/extras/scion-telegram/internal/telegram/format_test.go
+++ b/extras/scion-telegram/internal/telegram/format_test.go
@@ -123,6 +123,47 @@ func TestFormatMessage_Nil(t *testing.T) {
 	assert.Equal(t, "", text)
 }
 
+func TestFormatMessage_UnescapesLiteralNewlines(t *testing.T) {
+	msg := messages.NewInstruction("agent:coder", "user:alice", `Found issues:\n\n1. Bug A\n2. Bug B`)
+	text := FormatMessage(msg)
+	assert.Contains(t, text, "Found issues:\n\n1. Bug A\n2. Bug B")
+	assert.NotContains(t, text, `\n`)
+}
+
+func TestFormatMessageV2_UnescapesLiteralNewlines(t *testing.T) {
+	msg := &messages.StructuredMessage{
+		Version:   messages.Version,
+		Sender:    "agent:coder",
+		Recipient: "user:alice",
+		Msg:       `Hello\n\nWorld`,
+	}
+	text := FormatMessageV2(msg, "coder")
+	assert.Contains(t, text, "Hello\n\nWorld")
+	assert.NotContains(t, text, `\n`)
+}
+
+func TestUnescapeNewlines(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"no escapes", "hello world", "hello world"},
+		{"single newline", `hello\nworld`, "hello\nworld"},
+		{"double newline", `hello\n\nworld`, "hello\n\nworld"},
+		{"tab", `col1\tcol2`, "col1\tcol2"},
+		{"mixed", `line1\n\tindented`, "line1\n\tindented"},
+		{"actual newlines unchanged", "hello\nworld", "hello\nworld"},
+		{"empty string", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := unescapeNewlines(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // --- FormatStateChangeCard tests ---
 
 func TestFormatStateChangeCard_Running(t *testing.T) {


### PR DESCRIPTION
Message text arriving at the Telegram formatter can contain literal backslash-n escape sequences instead of actual newlines — either from JSON encoding round-trips (FormatForDelivery) or from shell arguments that don't interpret \n. Apply unescapeNewlines in FormatMessage and FormatMessageV2 so Telegram displays proper line breaks.

Closes #48

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
