### PR TITLE
Add project/grove compatibility boundary

### DIFF
--- a/extras/scion-a2a-bridge/go.mod
+++ b/extras/scion-a2a-bridge/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/scion/extras/scion-a2a-bridge
 
-go 1.25.4
+go 1.26.1
 
 require (
 	cloud.google.com/go/secretmanager v1.16.0
@@ -9,6 +9,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-plugin v1.7.0
 	github.com/mattn/go-sqlite3 v1.14.28
+	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -33,8 +35,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/run v1.1.0 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.2 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/extras/scion-a2a-bridge/go.sum
+++ b/extras/scion-a2a-bridge/go.sum
@@ -59,10 +59,14 @@ github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
+github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
+github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
@@ -112,6 +116,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
 go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=

--- a/extras/scion-a2a-bridge/internal/bridge/bridge.go
+++ b/extras/scion-a2a-bridge/internal/bridge/bridge.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/extras/scion-a2a-bridge/internal/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 )
 
 var (
@@ -267,12 +268,12 @@ func (b *Bridge) SendMessage(ctx context.Context, projectSlug, agentSlug, contex
 	scionMsg.Metadata = map[string]string{"a2aTaskId": taskID}
 
 	if b.broker != nil {
-		pattern := fmt.Sprintf("scion.project.%s.user.%s.messages", agentCtx.ProjectID, b.config.Hub.User)
+		pattern := projectcompat.UserTopic(agentCtx.ProjectID, b.config.Hub.User)
 		if err := b.broker.RequestSubscription(pattern); err != nil {
 			b.log.Warn("failed to request subscription", "pattern", pattern, "error", err)
 		}
 		// Subscribe to legacy grove topic as well during transition.
-		legacyPattern := fmt.Sprintf("scion.grove.%s.user.%s.messages", agentCtx.ProjectID, b.config.Hub.User)
+		legacyPattern := projectcompat.LegacyUserTopic(agentCtx.ProjectID, b.config.Hub.User)
 		if err := b.broker.RequestSubscription(legacyPattern); err != nil {
 			b.log.Warn("failed to request legacy subscription", "pattern", legacyPattern, "error", err)
 		}
@@ -937,19 +938,16 @@ func (b *Bridge) removeWaiter(taskID string) {
 }
 
 // parseTopic extracts project and agent identifiers from a broker topic string.
-// Expected format: scion.project.<projectID>.user.<user>.messages (6 segments).
-// The 5-segment agent form (scion.project.<g>.agent.<a>) is parsed but currently
-// unused — the bridge only subscribes to user-scoped topics.
+// Canonical scion.project topics and legacy scion.grove topics are accepted.
 func parseTopic(topic string) (projectID, agentSlug string, err error) {
-	parts := strings.Split(topic, ".")
-	if len(parts) < 3 || parts[0] != "scion" || (parts[1] != "project" && parts[1] != "grove") {
+	parsed, err := projectcompat.ParseTopic(topic)
+	if err != nil {
 		return "", "", fmt.Errorf("malformed topic: %s", topic)
 	}
-	projectID = parts[2]
-	if len(parts) >= 5 && parts[3] == "agent" {
-		agentSlug = parts[4]
+	if parsed.Kind == projectcompat.TopicKindAgent {
+		agentSlug = parsed.Actor
 	}
-	return projectID, agentSlug, nil
+	return parsed.ProjectID, agentSlug, nil
 }
 
 func extractProjectIDFromTopic(topic string) string {

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/plugin"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 )
 
 const (
@@ -290,7 +291,7 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 				if hc == nil {
 					continue
 				}
-				if err := hc.RequestSubscription("scion.project.>"); err != nil {
+				if err := hc.RequestSubscription(projectcompat.AllProjectsPattern()); err != nil {
 					b.log.Warn("Failed to request bootstrap subscription", "error", err)
 					continue
 				}
@@ -915,7 +916,7 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 			b.log.Warn("Failed to save conversation context", "error", err)
 		}
 
-		topic := fmt.Sprintf("scion.project.%s.agent.%s.messages", link.ProjectID, agentSlug)
+		topic := projectcompat.AgentTopic(link.ProjectID, agentSlug)
 		recipient := "agent:" + agentSlug
 
 		msg := &messages.StructuredMessage{
@@ -1066,7 +1067,7 @@ func (b *DiscordBroker) getProjectAgents(ctx context.Context, projectID string) 
 // --- Dynamic subscription management ---
 
 func (b *DiscordBroker) subscribeForProject(projectID string) {
-	pattern := fmt.Sprintf("scion.project.%s.>", projectID)
+	pattern := projectcompat.ProjectPattern(projectID)
 
 	b.mu.RLock()
 	hc := b.hostCallbacks
@@ -1081,7 +1082,7 @@ func (b *DiscordBroker) subscribeForProject(projectID string) {
 }
 
 func (b *DiscordBroker) unsubscribeForProject(projectID string) {
-	pattern := fmt.Sprintf("scion.project.%s.>", projectID)
+	pattern := projectcompat.ProjectPattern(projectID)
 
 	b.mu.RLock()
 	hc := b.hostCallbacks
@@ -1162,19 +1163,24 @@ func (b *DiscordBroker) resolveStaleChannelSlugs(ctx context.Context) {
 
 // --- Topic parsing ---
 
-// parseTopicComponents extracts projectID and agentSlug from a topic string.
-// Example: "scion.project.myproj.agent.coder.messages" -> ("myproj", "coder")
+// parseTopicComponents extracts projectID and agentSlug from a broker topic.
+// Legacy scion.grove topics are accepted by projectcompat at this adapter boundary.
 func parseTopicComponents(topic string) (projectID, agentSlug string) {
-	parts := strings.Split(topic, ".")
-	for i, part := range parts {
-		if part == "grove" && i+1 < len(parts) {
-			projectID = parts[i+1]
+	parsed, err := projectcompat.ParseTopic(topic)
+	if err == nil {
+		projectID = parsed.ProjectID
+		if parsed.Kind == projectcompat.TopicKindAgent {
+			agentSlug = parsed.Actor
 		}
-		if part == "project" && i+1 < len(parts) {
-			projectID = parts[i+1]
-		}
-		if part == "agent" && i+1 < len(parts) {
-			agentSlug = parts[i+1]
+	} else {
+		parts := strings.Split(topic, ".")
+		for i, part := range parts {
+			if (part == "grove" || part == "project") && i+1 < len(parts) {
+				projectID = parts[i+1]
+			}
+			if part == "agent" && i+1 < len(parts) {
+				agentSlug = parts[i+1]
+			}
 		}
 	}
 	if projectID == "" {

--- a/extras/scion-discord/internal/discord/callbacks.go
+++ b/extras/scion-discord/internal/discord/callbacks.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 )
 
 // CallbackHandler processes Discord message component interactions (buttons, selects).
@@ -412,7 +413,7 @@ func (h *CallbackHandler) deliverAskUserResponse(ctx context.Context, i *discord
 		sender = "user:" + mapping.ScionEmail
 	}
 
-	topic := fmt.Sprintf("scion.project.%s.agent.%s.messages", pending.ProjectID, pending.AgentSlug)
+	topic := projectcompat.AgentTopic(pending.ProjectID, pending.AgentSlug)
 	recipient := "agent:" + pending.AgentSlug
 
 	msg := &messages.StructuredMessage{

--- a/extras/scion-discord/internal/discord/modals.go
+++ b/extras/scion-discord/internal/discord/modals.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 )
 
 // OpenAskUserModal responds to a component interaction by presenting a modal
@@ -115,7 +116,7 @@ func HandleModalSubmit(
 			sender = "user:" + mapping.ScionEmail
 		}
 
-		topic := fmt.Sprintf("scion.project.%s.agent.%s.messages", pending.ProjectID, pending.AgentSlug)
+		topic := projectcompat.AgentTopic(pending.ProjectID, pending.AgentSlug)
 		recipient := "agent:" + pending.AgentSlug
 
 		msg := &messages.StructuredMessage{

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -37,6 +37,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/plugin"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 )
 
 const (
@@ -447,19 +448,24 @@ func (b *TelegramBrokerV2) importV1UserMappings(ctx context.Context, mappingsJSO
 	}
 }
 
-// parseTopicComponents extracts projectID and agentSlug from a topic string.
-// Example: "scion.grove.myproj.agent.coder.messages" → ("myproj", "coder")
+// parseTopicComponents extracts projectID and agentSlug from a broker topic.
+// Legacy scion.grove topics are accepted by projectcompat at this adapter boundary.
 func parseTopicComponents(topic string) (projectID, agentSlug string) {
-	parts := strings.Split(topic, ".")
-	for i, part := range parts {
-		if part == "grove" && i+1 < len(parts) {
-			projectID = parts[i+1]
+	parsed, err := projectcompat.ParseTopic(topic)
+	if err == nil {
+		projectID = parsed.ProjectID
+		if parsed.Kind == projectcompat.TopicKindAgent {
+			agentSlug = parsed.Actor
 		}
-		if part == "project" && i+1 < len(parts) {
-			projectID = parts[i+1]
-		}
-		if part == "agent" && i+1 < len(parts) {
-			agentSlug = parts[i+1]
+	} else {
+		parts := strings.Split(topic, ".")
+		for i, part := range parts {
+			if (part == "grove" || part == "project") && i+1 < len(parts) {
+				projectID = parts[i+1]
+			}
+			if part == "agent" && i+1 < len(parts) {
+				agentSlug = parts[i+1]
+			}
 		}
 	}
 	if projectID == "" {
@@ -1793,7 +1799,7 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 			}
 		}
 
-		topic := fmt.Sprintf("scion.project.%s.agent.%s.messages", link.ProjectID, agentSlug)
+		topic := projectcompat.AgentTopic(link.ProjectID, agentSlug)
 		recipient := "agent:" + agentSlug
 
 		msg := &messages.StructuredMessage{
@@ -2033,7 +2039,7 @@ func (b *TelegramBrokerV2) handleCallbackQuery(ctx context.Context, cb *Callback
 	}
 
 	// Deliver the ask-user response to the hub.
-	topic := fmt.Sprintf("scion.project.%s.agent.%s.messages", resp.ProjectID, resp.AgentSlug)
+	topic := projectcompat.AgentTopic(resp.ProjectID, resp.AgentSlug)
 
 	// Determine sender identity from the callback user.
 	sender := "telegram:unknown"
@@ -2106,7 +2112,7 @@ func (b *TelegramBrokerV2) getProjectAgents(ctx context.Context, projectID strin
 // --- Dynamic subscription management ---
 
 func (b *TelegramBrokerV2) subscribeForProject(projectID string) {
-	pattern := fmt.Sprintf("scion.project.%s.>", projectID)
+	pattern := projectcompat.ProjectPattern(projectID)
 
 	b.mu.RLock()
 	hc := b.hostCallbacks
@@ -2121,7 +2127,7 @@ func (b *TelegramBrokerV2) subscribeForProject(projectID string) {
 }
 
 func (b *TelegramBrokerV2) unsubscribeForProject(projectID string) {
-	pattern := fmt.Sprintf("scion.project.%s.>", projectID)
+	pattern := projectcompat.ProjectPattern(projectID)
 
 	b.mu.RLock()
 	hc := b.hostCallbacks

--- a/hack/check-project-compat-literals.sh
+++ b/hack/check-project-compat-literals.sh
@@ -6,6 +6,11 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+if ! command -v rg >/dev/null 2>&1; then
+  echo "Error: ripgrep (rg) is required to run this script but was not found in PATH." >&2
+  exit 1
+fi
+
 tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
 

--- a/hack/check-project-compat-literals.sh
+++ b/hack/check-project-compat-literals.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Flags legacy grove literals outside known compatibility, test, fixture, and
+# documentation surfaces. This starts broad by design; tighten the allowlist as
+# projectcompat adoption expands.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+rg -n 'grove|Grove|scion\.grove|grove_id|groveId|/groves' \
+  cmd pkg extras \
+  --glob '*.go' \
+  --glob '!pkg/ent/**' >"$tmp" || true
+
+if [[ ! -s "$tmp" ]]; then
+  exit 0
+fi
+
+allowlist='(^pkg/projectcompat/)|(_test\.go:)|(^cmd/)|(^pkg/agent/)|(^pkg/api/)|(^pkg/brokerclient/)|(^pkg/config/)|(^pkg/hub/)|(^pkg/hubclient/)|(^pkg/hubsync/)|(^pkg/plugin/refbroker/)|(^pkg/runtime/)|(^pkg/runtimebroker/)|(^pkg/sciontool/)|(^pkg/storage/)|(^pkg/store/)|(^pkg/util/logging/)|(^pkg/wsprotocol/)|(^extras/)'
+
+violations="$(grep -Ev "$allowlist" "$tmp" || true)"
+if [[ -n "$violations" ]]; then
+  echo "Legacy grove literals found outside the project compatibility allowlist:" >&2
+  echo "$violations" >&2
+  echo >&2
+  echo "Use project vocabulary for new code, or route legacy handling through pkg/projectcompat." >&2
+  exit 1
+fi

--- a/pkg/eventbus/eventbus.go
+++ b/pkg/eventbus/eventbus.go
@@ -23,8 +23,8 @@
 //
 // Topic hierarchy:
 //
-//	scion.grove.<grove-id>.agent.<agent-slug>.messages   - direct messages to an agent
-//	scion.grove.<grove-id>.broadcast                      - project-wide broadcasts
+//	scion.project.<project-id>.agent.<agent-slug>.messages - direct messages to an agent
+//	scion.project.<project-id>.broadcast                    - project-wide broadcasts
 //	scion.global.broadcast                                - global broadcasts
 package eventbus
 
@@ -32,6 +32,7 @@ import (
 	"context"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 )
 
 // EventBus abstracts message routing and delivery.
@@ -61,12 +62,12 @@ type Subscription interface {
 
 // TopicAgentMessages returns the topic for direct messages to an agent.
 func TopicAgentMessages(projectID, agentSlug string) string {
-	return "scion.grove." + projectID + ".agent." + agentSlug + ".messages"
+	return projectcompat.AgentTopic(projectID, agentSlug)
 }
 
 // TopicProjectBroadcast returns the topic for project-wide broadcast messages.
 func TopicProjectBroadcast(projectID string) string {
-	return "scion.grove." + projectID + ".broadcast"
+	return projectcompat.BroadcastTopic(projectID)
 }
 
 // TopicGlobalBroadcast returns the topic for global broadcast messages.
@@ -77,16 +78,16 @@ func TopicGlobalBroadcast() string {
 // TopicAllAgentMessages returns a wildcard pattern matching all agent message
 // topics in a project.
 func TopicAllAgentMessages(projectID string) string {
-	return "scion.grove." + projectID + ".agent.*.messages"
+	return projectcompat.AllAgentTopic(projectID)
 }
 
 // TopicUserMessages returns the topic for messages directed at a specific user in a project.
 func TopicUserMessages(projectID, userID string) string {
-	return "scion.grove." + projectID + ".user." + userID + ".messages"
+	return projectcompat.UserTopic(projectID, userID)
 }
 
 // TopicAllUserMessages returns a wildcard pattern matching all user message
 // topics in a project.
 func TopicAllUserMessages(projectID string) string {
-	return "scion.grove." + projectID + ".user.*.messages"
+	return projectcompat.AllUserTopic(projectID)
 }

--- a/pkg/eventbus/eventbus_test.go
+++ b/pkg/eventbus/eventbus_test.go
@@ -38,7 +38,7 @@ func TestInProcessEventBus_PublishSubscribe(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	_, err := b.Subscribe("scion.grove.g1.agent.myagent.messages", func(ctx context.Context, topic string, msg *messages.StructuredMessage) {
+	_, err := b.Subscribe("scion.project.g1.agent.myagent.messages", func(ctx context.Context, topic string, msg *messages.StructuredMessage) {
 		receivedTopic = topic
 		received = msg
 		wg.Done()
@@ -48,7 +48,7 @@ func TestInProcessEventBus_PublishSubscribe(t *testing.T) {
 	}
 
 	msg := messages.NewInstruction("user:alice", "agent:myagent", "hello")
-	err = b.Publish(context.Background(), "scion.grove.g1.agent.myagent.messages", msg)
+	err = b.Publish(context.Background(), "scion.project.g1.agent.myagent.messages", msg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,8 +61,8 @@ func TestInProcessEventBus_PublishSubscribe(t *testing.T) {
 	if received.Msg != "hello" {
 		t.Errorf("expected msg 'hello', got %q", received.Msg)
 	}
-	if receivedTopic != "scion.grove.g1.agent.myagent.messages" {
-		t.Errorf("expected topic 'scion.grove.g1.agent.myagent.messages', got %q", receivedTopic)
+	if receivedTopic != "scion.project.g1.agent.myagent.messages" {
+		t.Errorf("expected topic 'scion.project.g1.agent.myagent.messages', got %q", receivedTopic)
 	}
 }
 
@@ -74,7 +74,7 @@ func TestInProcessEventBus_WildcardSubscribe(t *testing.T) {
 	var received []string
 
 	// Subscribe with wildcard — match all agent messages in project g1
-	_, err := b.Subscribe("scion.grove.g1.agent.*.messages", func(ctx context.Context, topic string, msg *messages.StructuredMessage) {
+	_, err := b.Subscribe("scion.project.g1.agent.*.messages", func(ctx context.Context, topic string, msg *messages.StructuredMessage) {
 		mu.Lock()
 		received = append(received, msg.Msg)
 		mu.Unlock()
@@ -87,12 +87,12 @@ func TestInProcessEventBus_WildcardSubscribe(t *testing.T) {
 	msg1 := messages.NewInstruction("user:alice", "agent:a1", "msg1")
 	msg2 := messages.NewInstruction("user:alice", "agent:a2", "msg2")
 
-	b.Publish(ctx, "scion.grove.g1.agent.a1.messages", msg1)
-	b.Publish(ctx, "scion.grove.g1.agent.a2.messages", msg2)
+	b.Publish(ctx, "scion.project.g1.agent.a1.messages", msg1)
+	b.Publish(ctx, "scion.project.g1.agent.a2.messages", msg2)
 
 	// Should NOT match a different project
 	msg3 := messages.NewInstruction("user:alice", "agent:a3", "msg3")
-	b.Publish(ctx, "scion.grove.g2.agent.a3.messages", msg3)
+	b.Publish(ctx, "scion.project.g2.agent.a3.messages", msg3)
 
 	// Wait for delivery
 	time.Sleep(50 * time.Millisecond)
@@ -112,7 +112,7 @@ func TestInProcessEventBus_GreaterThanWildcard(t *testing.T) {
 	var received []string
 
 	// Subscribe with > wildcard — match everything under project g1
-	_, err := b.Subscribe("scion.grove.g1.>", func(ctx context.Context, topic string, msg *messages.StructuredMessage) {
+	_, err := b.Subscribe("scion.project.g1.>", func(ctx context.Context, topic string, msg *messages.StructuredMessage) {
 		mu.Lock()
 		received = append(received, topic)
 		mu.Unlock()
@@ -122,9 +122,9 @@ func TestInProcessEventBus_GreaterThanWildcard(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	b.Publish(ctx, "scion.grove.g1.agent.a1.messages", messages.NewInstruction("u:a", "a:b", "m1"))
-	b.Publish(ctx, "scion.grove.g1.broadcast", messages.NewInstruction("u:a", "grove:g1", "m2"))
-	b.Publish(ctx, "scion.grove.g2.broadcast", messages.NewInstruction("u:a", "grove:g2", "m3")) // should NOT match
+	b.Publish(ctx, "scion.project.g1.agent.a1.messages", messages.NewInstruction("u:a", "a:b", "m1"))
+	b.Publish(ctx, "scion.project.g1.broadcast", messages.NewInstruction("u:a", "project:g1", "m2"))
+	b.Publish(ctx, "scion.project.g2.broadcast", messages.NewInstruction("u:a", "project:g2", "m3")) // should NOT match
 
 	time.Sleep(50 * time.Millisecond)
 
@@ -144,7 +144,7 @@ func TestInProcessEventBus_BroadcastTopic(t *testing.T) {
 
 	// Two subscribers listening to the project broadcast topic
 	for i := 0; i < 2; i++ {
-		_, err := b.Subscribe("scion.grove.g1.broadcast", func(ctx context.Context, topic string, msg *messages.StructuredMessage) {
+		_, err := b.Subscribe("scion.project.g1.broadcast", func(ctx context.Context, topic string, msg *messages.StructuredMessage) {
 			wg.Done()
 		})
 		if err != nil {
@@ -152,9 +152,9 @@ func TestInProcessEventBus_BroadcastTopic(t *testing.T) {
 		}
 	}
 
-	msg := messages.NewInstruction("agent:lead", "grove:g1", "hello all")
+	msg := messages.NewInstruction("agent:lead", "project:g1", "hello all")
 	msg.Broadcasted = true
-	b.Publish(context.Background(), "scion.grove.g1.broadcast", msg)
+	b.Publish(context.Background(), "scion.project.g1.broadcast", msg)
 
 	wg.Wait()
 }
@@ -171,7 +171,7 @@ func TestInProcessEventBus_PropagatesPublisherContext(t *testing.T) {
 	const key ctxKey = "trace"
 
 	got := make(chan string, 1)
-	_, err := b.Subscribe("scion.grove.g1.broadcast", func(ctx context.Context, topic string, msg *messages.StructuredMessage) {
+	_, err := b.Subscribe("scion.project.g1.broadcast", func(ctx context.Context, topic string, msg *messages.StructuredMessage) {
 		v, _ := ctx.Value(key).(string)
 		got <- v
 	})
@@ -180,8 +180,8 @@ func TestInProcessEventBus_PropagatesPublisherContext(t *testing.T) {
 	}
 
 	ctx := context.WithValue(context.Background(), key, "abc123")
-	msg := messages.NewInstruction("u:a", "grove:g1", "hi")
-	if err := b.Publish(ctx, "scion.grove.g1.broadcast", msg); err != nil {
+	msg := messages.NewInstruction("u:a", "project:g1", "hi")
+	if err := b.Publish(ctx, "scion.project.g1.broadcast", msg); err != nil {
 		t.Fatal(err)
 	}
 
@@ -200,7 +200,7 @@ func TestInProcessEventBus_Unsubscribe(t *testing.T) {
 	defer b.Close()
 
 	var callCount atomic.Int32
-	sub, err := b.Subscribe("scion.grove.g1.broadcast", func(ctx context.Context, topic string, msg *messages.StructuredMessage) {
+	sub, err := b.Subscribe("scion.project.g1.broadcast", func(ctx context.Context, topic string, msg *messages.StructuredMessage) {
 		callCount.Add(1)
 	})
 	if err != nil {
@@ -208,7 +208,7 @@ func TestInProcessEventBus_Unsubscribe(t *testing.T) {
 	}
 
 	msg := messages.NewInstruction("u:a", "g:g1", "m1")
-	b.Publish(context.Background(), "scion.grove.g1.broadcast", msg)
+	b.Publish(context.Background(), "scion.project.g1.broadcast", msg)
 	time.Sleep(50 * time.Millisecond)
 
 	if callCount.Load() != 1 {
@@ -217,7 +217,7 @@ func TestInProcessEventBus_Unsubscribe(t *testing.T) {
 
 	sub.Unsubscribe()
 
-	b.Publish(context.Background(), "scion.grove.g1.broadcast", msg)
+	b.Publish(context.Background(), "scion.project.g1.broadcast", msg)
 	time.Sleep(50 * time.Millisecond)
 
 	if callCount.Load() != 1 {
@@ -238,7 +238,7 @@ func TestInProcessEventBus_CloseStopsDelivery(t *testing.T) {
 
 	b.Close()
 
-	err = b.Publish(context.Background(), "scion.grove.g1.broadcast",
+	err = b.Publish(context.Background(), "scion.project.g1.broadcast",
 		messages.NewInstruction("u:a", "g:g1", "after close"))
 	if err != ErrEventBusClosed {
 		t.Fatalf("expected ErrEventBusClosed, got %v", err)
@@ -255,14 +255,14 @@ func TestInProcessEventBus_NoMatchNoDelivery(t *testing.T) {
 	defer b.Close()
 
 	callCount := 0
-	_, err := b.Subscribe("scion.grove.g1.agent.specific.messages", func(ctx context.Context, topic string, msg *messages.StructuredMessage) {
+	_, err := b.Subscribe("scion.project.g1.agent.specific.messages", func(ctx context.Context, topic string, msg *messages.StructuredMessage) {
 		callCount++
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	b.Publish(context.Background(), "scion.grove.g1.agent.other.messages",
+	b.Publish(context.Background(), "scion.project.g1.agent.other.messages",
 		messages.NewInstruction("u:a", "a:other", "should not match"))
 	time.Sleep(50 * time.Millisecond)
 
@@ -277,10 +277,10 @@ func TestTopicHelpers(t *testing.T) {
 		got      string
 		expected string
 	}{
-		{"agent messages", TopicAgentMessages("g1", "myagent"), "scion.grove.g1.agent.myagent.messages"},
-		{"project broadcast", TopicProjectBroadcast("g1"), "scion.grove.g1.broadcast"},
+		{"agent messages", TopicAgentMessages("g1", "myagent"), "scion.project.g1.agent.myagent.messages"},
+		{"project broadcast", TopicProjectBroadcast("g1"), "scion.project.g1.broadcast"},
 		{"global broadcast", TopicGlobalBroadcast(), "scion.global.broadcast"},
-		{"all agent messages", TopicAllAgentMessages("g1"), "scion.grove.g1.agent.*.messages"},
+		{"all agent messages", TopicAllAgentMessages("g1"), "scion.project.g1.agent.*.messages"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -306,9 +306,9 @@ func TestSubjectMatchesPattern(t *testing.T) {
 		{"a.>", "a.b.c", true},
 		{"a.>", "a.b.c.d", true},
 		{"a.>", "b.c", false},
-		{"scion.grove.*.broadcast", "scion.grove.g1.broadcast", true},
-		{"scion.grove.g1.agent.*.messages", "scion.grove.g1.agent.myagent.messages", true},
-		{"scion.grove.g1.agent.*.messages", "scion.grove.g2.agent.myagent.messages", false},
+		{"scion.project.*.broadcast", "scion.project.g1.broadcast", true},
+		{"scion.project.g1.agent.*.messages", "scion.project.g1.agent.myagent.messages", true},
+		{"scion.project.g1.agent.*.messages", "scion.project.g2.agent.myagent.messages", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.pattern+"_"+tt.subject, func(t *testing.T) {

--- a/pkg/hub/handlers_broker_inbound.go
+++ b/pkg/hub/handlers_broker_inbound.go
@@ -18,9 +18,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 )
 
 // inboundMessageRequest is the JSON body sent by broker plugins to deliver
@@ -37,8 +37,9 @@ type inboundMessageRequest struct {
 // Authentication: Requires broker HMAC authentication (X-Scion-Broker-ID header
 // validated by BrokerAuthMiddleware).
 //
-// The topic string is parsed to extract the project ID and agent slug using the
-// standard topic format: scion.project.<projectID>.agent.<agentSlug>.messages
+// The topic string is parsed to extract the project ID and agent slug. Canonical
+// broker topics use scion.project; legacy scion.grove topics are accepted here
+// as an external compatibility adapter.
 func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		MethodNotAllowed(w)
@@ -145,15 +146,15 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 }
 
 // parseAgentMessageTopic extracts the project ID and agent slug from a topic string.
-// Expected format: scion.project.<projectID>.agent.<agentSlug>.messages
+// Expected canonical format: scion.project.<projectID>.agent.<agentSlug>.messages.
+// Legacy scion.grove topics are accepted at this adapter boundary.
 func parseAgentMessageTopic(topic string) (projectID, agentSlug string, err error) {
-	parts := strings.Split(topic, ".")
-	// scion.project.<projectID>.agent.<agentSlug>.messages = 6 parts
-	if len(parts) != 6 {
-		return "", "", fmt.Errorf("expected format scion.project.<projectId>.agent.<agentSlug>.messages, got %d segments", len(parts))
+	parsed, err := projectcompat.ParseTopic(topic)
+	if err != nil {
+		return "", "", err
 	}
-	if parts[0] != "scion" || parts[1] != "project" || parts[3] != "agent" || parts[5] != "messages" {
+	if parsed.Kind != projectcompat.TopicKindAgent {
 		return "", "", fmt.Errorf("expected format scion.project.<projectId>.agent.<agentSlug>.messages")
 	}
-	return parts[2], parts[4], nil
+	return parsed.ProjectID, parsed.Actor, nil
 }

--- a/pkg/hub/handlers_broker_inbound_test.go
+++ b/pkg/hub/handlers_broker_inbound_test.go
@@ -42,6 +42,12 @@ func TestParseAgentMessageTopic(t *testing.T) {
 			agentSlug: "code-reviewer",
 		},
 		{
+			name:      "legacy grove topic",
+			topic:     "scion.grove.my-project-123.agent.coder.messages",
+			projectID: "my-project-123",
+			agentSlug: "coder",
+		},
+		{
 			name:    "too few segments",
 			topic:   "scion.project.g1.agent.coder",
 			wantErr: true,

--- a/pkg/projectcompat/labels.go
+++ b/pkg/projectcompat/labels.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projectcompat
+
+import "strings"
+
+func ProjectIDFromLabels(labels map[string]string) string {
+	if labels == nil {
+		return ""
+	}
+	if projectID := labels[LabelProjectID]; projectID != "" {
+		return projectID
+	}
+	return labels[LabelGroveID]
+}
+
+func ProjectIDLabels(projectID string, includeLegacy bool) map[string]string {
+	labels := map[string]string{
+		LabelProjectID: projectID,
+	}
+	if includeLegacy {
+		labels[LabelGroveID] = projectID
+	}
+	return labels
+}
+
+func CanonicalFieldAliases(key string) (canonical string, legacy bool) {
+	switch key {
+	case "project", "projects", "projectId", "project_id":
+		return key, false
+	case "grove":
+		return "project", true
+	case "groves":
+		return "projects", true
+	case "groveId":
+		return "projectId", true
+	case "grove_id":
+		return "project_id", true
+	case "hub.grove_id":
+		return "hub.project_id", true
+	case "hub.groveId":
+		return "hub.projectId", true
+	default:
+		return key, false
+	}
+}
+
+func DeprecatedGroveRoute(path string) bool {
+	return path == "/api/v1/groves" || strings.HasPrefix(path, "/api/v1/groves/")
+}

--- a/pkg/projectcompat/labels_test.go
+++ b/pkg/projectcompat/labels_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projectcompat
+
+import "testing"
+
+func TestProjectIDFromLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{"nil", nil, ""},
+		{"canonical", map[string]string{LabelProjectID: "p1"}, "p1"},
+		{"legacy", map[string]string{LabelGroveID: "p1"}, "p1"},
+		{"canonical wins", map[string]string{LabelProjectID: "p1", LabelGroveID: "old"}, "p1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ProjectIDFromLabels(tt.labels); got != tt.want {
+				t.Fatalf("ProjectIDFromLabels() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectIDLabels(t *testing.T) {
+	labels := ProjectIDLabels("p1", true)
+	if labels[LabelProjectID] != "p1" || labels[LabelGroveID] != "p1" {
+		t.Fatalf("ProjectIDLabels(includeLegacy=true) = %#v", labels)
+	}
+
+	labels = ProjectIDLabels("p1", false)
+	if labels[LabelProjectID] != "p1" {
+		t.Fatalf("ProjectIDLabels(includeLegacy=false) missing canonical label: %#v", labels)
+	}
+	if _, ok := labels[LabelGroveID]; ok {
+		t.Fatalf("ProjectIDLabels(includeLegacy=false) included legacy label: %#v", labels)
+	}
+}
+
+func TestCanonicalFieldAliases(t *testing.T) {
+	tests := []struct {
+		in        string
+		canonical string
+		legacy    bool
+	}{
+		{"projectId", "projectId", false},
+		{"groveId", "projectId", true},
+		{"grove_id", "project_id", true},
+		{"hub.grove_id", "hub.project_id", true},
+		{"unrelated", "unrelated", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			canonical, legacy := CanonicalFieldAliases(tt.in)
+			if canonical != tt.canonical || legacy != tt.legacy {
+				t.Fatalf("CanonicalFieldAliases(%q) = %q, %v; want %q, %v", tt.in, canonical, legacy, tt.canonical, tt.legacy)
+			}
+		})
+	}
+}
+
+func TestDeprecatedGroveRoute(t *testing.T) {
+	for _, path := range []string{"/api/v1/groves", "/api/v1/groves/p1/agents"} {
+		if !DeprecatedGroveRoute(path) {
+			t.Fatalf("DeprecatedGroveRoute(%q) = false, want true", path)
+		}
+	}
+	for _, path := range []string{"/api/v1/projects", "/api/v1/groves-old"} {
+		if DeprecatedGroveRoute(path) {
+			t.Fatalf("DeprecatedGroveRoute(%q) = true, want false", path)
+		}
+	}
+}

--- a/pkg/projectcompat/topics.go
+++ b/pkg/projectcompat/topics.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package projectcompat centralizes bounded compatibility for legacy grove
+// strings. New code should use project terminology and call these helpers at
+// explicit adapter points when old clients, config, labels, topics, or routes
+// may still provide grove names.
+package projectcompat
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	CanonicalTopicPrefix = "scion.project"
+	LegacyTopicPrefix    = "scion.grove"
+
+	LabelProjectID = "scion.project_id"
+	LabelGroveID   = "scion.grove_id"
+)
+
+type TopicKind string
+
+const (
+	TopicKindAgent     TopicKind = "agent"
+	TopicKindUser      TopicKind = "user"
+	TopicKindBroadcast TopicKind = "broadcast"
+)
+
+type Topic struct {
+	ProjectID string
+	Kind      TopicKind
+	Actor     string
+	Legacy    bool
+}
+
+func AgentTopic(projectID, agentSlug string) string {
+	return CanonicalTopicPrefix + "." + projectID + ".agent." + agentSlug + ".messages"
+}
+
+func UserTopic(projectID, userID string) string {
+	return CanonicalTopicPrefix + "." + projectID + ".user." + userID + ".messages"
+}
+
+func BroadcastTopic(projectID string) string {
+	return CanonicalTopicPrefix + "." + projectID + ".broadcast"
+}
+
+func AllAgentTopic(projectID string) string {
+	return CanonicalTopicPrefix + "." + projectID + ".agent.*.messages"
+}
+
+func AllUserTopic(projectID string) string {
+	return CanonicalTopicPrefix + "." + projectID + ".user.*.messages"
+}
+
+func ProjectPattern(projectID string) string {
+	return CanonicalTopicPrefix + "." + projectID + ".>"
+}
+
+func AllProjectsPattern() string {
+	return CanonicalTopicPrefix + ".>"
+}
+
+func LegacyUserTopic(projectID, userID string) string {
+	return LegacyTopicPrefix + "." + projectID + ".user." + userID + ".messages"
+}
+
+func ParseTopic(topic string) (Topic, error) {
+	parts := strings.Split(topic, ".")
+	if len(parts) < 4 || parts[0] != "scion" {
+		return Topic{}, fmt.Errorf("malformed topic %q", topic)
+	}
+
+	var legacy bool
+	switch parts[1] {
+	case "project":
+	case "grove":
+		legacy = true
+	default:
+		return Topic{}, fmt.Errorf("expected project or legacy grove topic, got %q", topic)
+	}
+
+	t := Topic{ProjectID: parts[2], Legacy: legacy}
+	if t.ProjectID == "" {
+		return Topic{}, fmt.Errorf("missing project id in topic %q", topic)
+	}
+
+	switch parts[3] {
+	case "agent":
+		if len(parts) != 6 || parts[5] != "messages" || parts[4] == "" {
+			return Topic{}, fmt.Errorf("expected %s.<projectId>.agent.<agentSlug>.messages", CanonicalTopicPrefix)
+		}
+		t.Kind = TopicKindAgent
+		t.Actor = parts[4]
+	case "user":
+		if len(parts) != 6 || parts[5] != "messages" || parts[4] == "" {
+			return Topic{}, fmt.Errorf("expected %s.<projectId>.user.<userId>.messages", CanonicalTopicPrefix)
+		}
+		t.Kind = TopicKindUser
+		t.Actor = parts[4]
+	case "broadcast":
+		if len(parts) != 4 {
+			return Topic{}, fmt.Errorf("expected %s.<projectId>.broadcast", CanonicalTopicPrefix)
+		}
+		t.Kind = TopicKindBroadcast
+	default:
+		return Topic{}, fmt.Errorf("unknown topic kind %q", parts[3])
+	}
+	return t, nil
+}

--- a/pkg/projectcompat/topics_test.go
+++ b/pkg/projectcompat/topics_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projectcompat
+
+import "testing"
+
+func TestTopicBuildersUseCanonicalProjectPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"agent", AgentTopic("p1", "coder"), "scion.project.p1.agent.coder.messages"},
+		{"user", UserTopic("p1", "alice"), "scion.project.p1.user.alice.messages"},
+		{"broadcast", BroadcastTopic("p1"), "scion.project.p1.broadcast"},
+		{"all agents", AllAgentTopic("p1"), "scion.project.p1.agent.*.messages"},
+		{"all users", AllUserTopic("p1"), "scion.project.p1.user.*.messages"},
+		{"project pattern", ProjectPattern("p1"), "scion.project.p1.>"},
+		{"all projects pattern", AllProjectsPattern(), "scion.project.>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("got %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTopicAcceptsCanonicalAndLegacy(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want Topic
+	}{
+		{
+			name: "canonical agent",
+			in:   "scion.project.p1.agent.coder.messages",
+			want: Topic{ProjectID: "p1", Kind: TopicKindAgent, Actor: "coder"},
+		},
+		{
+			name: "legacy agent",
+			in:   "scion.grove.p1.agent.coder.messages",
+			want: Topic{ProjectID: "p1", Kind: TopicKindAgent, Actor: "coder", Legacy: true},
+		},
+		{
+			name: "canonical user wildcard",
+			in:   "scion.project.p1.user.*.messages",
+			want: Topic{ProjectID: "p1", Kind: TopicKindUser, Actor: "*"},
+		},
+		{
+			name: "legacy broadcast",
+			in:   "scion.grove.p1.broadcast",
+			want: Topic{ProjectID: "p1", Kind: TopicKindBroadcast, Legacy: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseTopic(tt.in)
+			if err != nil {
+				t.Fatalf("ParseTopic(%q) error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseTopic(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTopicRejectsMalformedTopics(t *testing.T) {
+	for _, topic := range []string{
+		"",
+		"scion.global.broadcast",
+		"scion.project",
+		"scion.project..broadcast",
+		"scion.project.p1.agent.coder",
+		"scion.project.p1.agent.coder.messages.extra",
+		"scion.project.p1.user..messages",
+		"scion.project.p1.unknown",
+	} {
+		t.Run(topic, func(t *testing.T) {
+			if _, err := ParseTopic(topic); err == nil {
+				t.Fatalf("ParseTopic(%q) succeeded, want error", topic)
+			}
+		})
+	}
+}

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -418,9 +418,8 @@ func buildCommonRunArgs(config RunConfig) ([]string, error) {
 		addArg("--label", fmt.Sprintf("scion.grove=%s", config.Project))
 	}
 	if config.ProjectID != "" {
-		for k, v := range projectcompat.ProjectIDLabels(config.ProjectID, true) {
-			addArg("--label", fmt.Sprintf("%s=%s", k, v))
-		}
+		addArg("--label", fmt.Sprintf("%s=%s", projectcompat.LabelProjectID, config.ProjectID))
+		addArg("--label", fmt.Sprintf("%s=%s", projectcompat.LabelGroveID, config.ProjectID))
 	}
 
 	if config.Template != "" {

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 )
 
@@ -417,8 +418,9 @@ func buildCommonRunArgs(config RunConfig) ([]string, error) {
 		addArg("--label", fmt.Sprintf("scion.grove=%s", config.Project))
 	}
 	if config.ProjectID != "" {
-		addArg("--label", fmt.Sprintf("scion.project_id=%s", config.ProjectID))
-		addArg("--label", fmt.Sprintf("scion.grove_id=%s", config.ProjectID))
+		for k, v := range projectcompat.ProjectIDLabels(config.ProjectID, true) {
+			addArg("--label", fmt.Sprintf("%s=%s", k, v))
+		}
 	}
 
 	if config.Template != "" {

--- a/pkg/runtime/docker.go
+++ b/pkg/runtime/docker.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/gcp"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 )
 
@@ -211,12 +212,7 @@ func (r *DockerRuntime) List(ctx context.Context, labelFilter map[string]string)
 					}
 					return labels["scion.grove"]
 				}(),
-				ProjectID: func() string {
-					if p := labels["scion.project_id"]; p != "" {
-						return p
-					}
-					return labels["scion.grove_id"]
-				}(),
+				ProjectID: projectcompat.ProjectIDFromLabels(labels),
 				ProjectPath: func() string {
 					if p := labels["scion.project_path"]; p != "" {
 						return p

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -34,6 +34,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/gcp"
 	"github.com/GoogleCloudPlatform/scion/pkg/k8s"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"golang.org/x/term"
 	corev1 "k8s.io/api/core/v1"
@@ -761,10 +762,7 @@ func (r *KubernetesRuntime) createSharedDirPVCs(ctx context.Context, namespace s
 		return nil
 	}
 
-	projectID := config.Labels["scion.project_id"]
-	if projectID == "" {
-		projectID = config.Labels["scion.grove_id"]
-	}
+	projectID := projectcompat.ProjectIDFromLabels(config.Labels)
 
 	projectName := config.Labels["scion.project"]
 	if projectName == "" {
@@ -838,8 +836,9 @@ func (r *KubernetesRuntime) ensureProjectRWXClaim(
 	}
 
 	if projectID != "" {
-		pvc.Labels["scion.project_id"] = projectID
-		pvc.Labels["scion.grove_id"] = projectID
+		for k, v := range projectcompat.ProjectIDLabels(projectID, true) {
+			pvc.Labels[k] = v
+		}
 	}
 
 	if storageClass != "" {

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -33,6 +33,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/gcp"
 	"github.com/GoogleCloudPlatform/scion/pkg/harness"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	scionrt "github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/templatecache"
@@ -50,8 +51,9 @@ func matchesAgent(a api.AgentInfo, id, projectID string) bool {
 	if projectID == "" {
 		return true
 	}
-	// Check grove_id label first (authoritative), then ProjectID field
-	if labelProjectID := a.Labels["scion.grove_id"]; labelProjectID != "" {
+	// Check runtime labels first (canonical project_id, then legacy grove_id),
+	// then ProjectID field.
+	if labelProjectID := projectcompat.ProjectIDFromLabels(a.Labels); labelProjectID != "" {
 		return labelProjectID == projectID
 	}
 	if a.ProjectID != "" {
@@ -249,10 +251,7 @@ func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 	agentKey := func(a api.AgentInfo) string {
 		pid := a.ProjectID
 		if pid == "" {
-			pid = a.Labels["scion.project_id"]
-		}
-		if pid == "" {
-			pid = a.Labels["scion.grove_id"]
+			pid = projectcompat.ProjectIDFromLabels(a.Labels)
 		}
 		return a.Name + "\x00" + pid
 	}

--- a/pkg/runtimebroker/heartbeat.go
+++ b/pkg/runtimebroker/heartbeat.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 )
 
 // heartbeatAgentKey returns a key that uniquely identifies an agent within the
@@ -35,10 +36,7 @@ import (
 func heartbeatAgentKey(a api.AgentInfo) string {
 	pid := a.ProjectID
 	if pid == "" {
-		pid = a.Labels["scion.project_id"]
-	}
-	if pid == "" {
-		pid = a.Labels["scion.grove_id"]
+		pid = projectcompat.ProjectIDFromLabels(a.Labels)
 	}
 	return a.Name + "\x00" + pid
 }

--- a/pkg/runtimebroker/server.go
+++ b/pkg/runtimebroker/server.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent"
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/brokercredentials"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
@@ -1016,21 +1017,11 @@ func (s *Server) LookupContainerID(ctx context.Context, slug, projectID string) 
 	slug = strings.ToLower(slug)
 
 	filter := map[string]string{"scion.name": slug}
-	if projectID != "" {
-		filter[projectcompat.LabelProjectID] = projectID
-	}
-
 	agents, err := s.manager.List(ctx, filter)
 	if err != nil {
 		return "", fmt.Errorf("failed to list agents: %w", err)
 	}
-	if len(agents) == 0 && projectID != "" {
-		legacyFilter := map[string]string{"scion.name": slug, projectcompat.LabelGroveID: projectID}
-		agents, err = s.manager.List(ctx, legacyFilter)
-		if err != nil {
-			return "", fmt.Errorf("failed to list agents with legacy project label: %w", err)
-		}
-	}
+	agents = agentsForProject(agents, projectID)
 
 	// Fall back to auxiliary runtimes (e.g. kubernetes when default is docker)
 	if len(agents) == 0 {
@@ -1043,9 +1034,8 @@ func (s *Server) LookupContainerID(ctx context.Context, slug, projectID string) 
 
 		for rtName, aux := range auxRuntimes {
 			auxAgents, auxErr := aux.Manager.List(ctx, filter)
-			if auxErr == nil && len(auxAgents) == 0 && projectID != "" {
-				legacyFilter := map[string]string{"scion.name": slug, projectcompat.LabelGroveID: projectID}
-				auxAgents, auxErr = aux.Manager.List(ctx, legacyFilter)
+			if auxErr == nil {
+				auxAgents = agentsForProject(auxAgents, projectID)
 			}
 			if auxErr == nil && len(auxAgents) > 0 {
 				agents = auxAgents
@@ -1116,22 +1106,13 @@ func (s *Server) LookupAgent(ctx context.Context, slug, projectID string) (*Agen
 
 	slug = strings.ToLower(slug)
 	filter := map[string]string{"scion.name": slug}
-	if projectID != "" {
-		filter[projectcompat.LabelProjectID] = projectID
-	}
 
 	// Try default manager first
 	agents, err := s.manager.List(ctx, filter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list agents: %w", err)
 	}
-	if len(agents) == 0 && projectID != "" {
-		legacyFilter := map[string]string{"scion.name": slug, projectcompat.LabelGroveID: projectID}
-		agents, err = s.manager.List(ctx, legacyFilter)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list agents with legacy project label: %w", err)
-		}
-	}
+	agents = agentsForProject(agents, projectID)
 
 	runtimeName := s.runtime.Name()
 	var matchedRuntime scionrt.Runtime
@@ -1147,9 +1128,8 @@ func (s *Server) LookupAgent(ctx context.Context, slug, projectID string) (*Agen
 
 		for rtName, aux := range auxRuntimes {
 			auxAgents, auxErr := aux.Manager.List(ctx, filter)
-			if auxErr == nil && len(auxAgents) == 0 && projectID != "" {
-				legacyFilter := map[string]string{"scion.name": slug, projectcompat.LabelGroveID: projectID}
-				auxAgents, auxErr = aux.Manager.List(ctx, legacyFilter)
+			if auxErr == nil {
+				auxAgents = agentsForProject(auxAgents, projectID)
 			}
 			if auxErr == nil && len(auxAgents) > 0 {
 				agents = auxAgents
@@ -1239,6 +1219,19 @@ func (s *Server) LookupAgent(ctx context.Context, slug, projectID string) (*Agen
 	}
 
 	return result, nil
+}
+
+func agentsForProject(agents []api.AgentInfo, projectID string) []api.AgentInfo {
+	if projectID == "" {
+		return agents
+	}
+	filtered := make([]api.AgentInfo, 0, len(agents))
+	for _, agent := range agents {
+		if projectcompat.ProjectIDFromLabels(agent.Labels) == projectID {
+			filtered = append(filtered, agent)
+		}
+	}
+	return filtered
 }
 
 // RuntimeCommand implements AgentLookup interface.

--- a/pkg/runtimebroker/server.go
+++ b/pkg/runtimebroker/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/brokercredentials"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	scionrt "github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/templatecache"
@@ -1016,12 +1017,19 @@ func (s *Server) LookupContainerID(ctx context.Context, slug, projectID string) 
 
 	filter := map[string]string{"scion.name": slug}
 	if projectID != "" {
-		filter["scion.grove_id"] = projectID
+		filter[projectcompat.LabelProjectID] = projectID
 	}
 
 	agents, err := s.manager.List(ctx, filter)
 	if err != nil {
 		return "", fmt.Errorf("failed to list agents: %w", err)
+	}
+	if len(agents) == 0 && projectID != "" {
+		legacyFilter := map[string]string{"scion.name": slug, projectcompat.LabelGroveID: projectID}
+		agents, err = s.manager.List(ctx, legacyFilter)
+		if err != nil {
+			return "", fmt.Errorf("failed to list agents with legacy project label: %w", err)
+		}
 	}
 
 	// Fall back to auxiliary runtimes (e.g. kubernetes when default is docker)
@@ -1035,6 +1043,10 @@ func (s *Server) LookupContainerID(ctx context.Context, slug, projectID string) 
 
 		for rtName, aux := range auxRuntimes {
 			auxAgents, auxErr := aux.Manager.List(ctx, filter)
+			if auxErr == nil && len(auxAgents) == 0 && projectID != "" {
+				legacyFilter := map[string]string{"scion.name": slug, projectcompat.LabelGroveID: projectID}
+				auxAgents, auxErr = aux.Manager.List(ctx, legacyFilter)
+			}
 			if auxErr == nil && len(auxAgents) > 0 {
 				agents = auxAgents
 				slog.Debug("Agent found via auxiliary runtime", "slug", slug, "runtime", rtName)
@@ -1105,13 +1117,20 @@ func (s *Server) LookupAgent(ctx context.Context, slug, projectID string) (*Agen
 	slug = strings.ToLower(slug)
 	filter := map[string]string{"scion.name": slug}
 	if projectID != "" {
-		filter["scion.grove_id"] = projectID
+		filter[projectcompat.LabelProjectID] = projectID
 	}
 
 	// Try default manager first
 	agents, err := s.manager.List(ctx, filter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list agents: %w", err)
+	}
+	if len(agents) == 0 && projectID != "" {
+		legacyFilter := map[string]string{"scion.name": slug, projectcompat.LabelGroveID: projectID}
+		agents, err = s.manager.List(ctx, legacyFilter)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list agents with legacy project label: %w", err)
+		}
 	}
 
 	runtimeName := s.runtime.Name()
@@ -1128,6 +1147,10 @@ func (s *Server) LookupAgent(ctx context.Context, slug, projectID string) (*Agen
 
 		for rtName, aux := range auxRuntimes {
 			auxAgents, auxErr := aux.Manager.List(ctx, filter)
+			if auxErr == nil && len(auxAgents) == 0 && projectID != "" {
+				legacyFilter := map[string]string{"scion.name": slug, projectcompat.LabelGroveID: projectID}
+				auxAgents, auxErr = aux.Manager.List(ctx, legacyFilter)
+			}
 			if auxErr == nil && len(auxAgents) > 0 {
 				agents = auxAgents
 				runtimeName = rtName


### PR DESCRIPTION

## Summary
- Add pkg/projectcompat as the explicit boundary for legacy grove compatibility, with canonical project topic builders, legacy topic parsing, label helpers, field aliases, route detection, and tests.
- Switch eventbus topic helpers to emit canonical scion.project topics while preserving legacy parsing at adapter boundaries.
- Migrate low-risk Telegram, Discord, A2A, runtime, and runtimebroker call sites to shared topic/label helpers.
- Add a broad allowlist guardrail script for tracking remaining legacy grove literals.

## Test Plan
- hack/check-project-compat-literals.sh
- go test ./pkg/projectcompat ./pkg/eventbus ./pkg/runtime ./pkg/runtimebroker
- go test ./pkg/hub -run 'TestParseAgentMessageTopic|TestMessageBrokerProxy'\n- (cd extras/scion-telegram && go test ./internal/telegram)\n- (cd extras/scion-discord && go test ./internal/discord)\n- (cd extras/scion-a2a-bridge && go test ./internal/bridge)\n\n## Notes\n- Full go test ./pkg/hub still has an unrelated existing failure in TestBrokerHeartbeat_RejectsPhaseRegression due to invalid UUID fixture proj-hb-regress.