### PR TITLE
fix: use recursive glob in sparse checkout to include home/ subdirectory

### DIFF
--- a/pkg/config/remote_templates.go
+++ b/pkg/config/remote_templates.go
@@ -394,9 +394,9 @@ func sparseGitCheckout(ctx context.Context, parts *GitHubURLParts, destPath stri
 	}
 
 	// If there's a path, only check out that path; otherwise, check out everything
-	sparsePattern := "/*"
+	sparsePattern := "/**"
 	if parts.Path != "" {
-		sparsePattern = parts.Path + "/*"
+		sparsePattern = parts.Path + "/**"
 	}
 	if err := os.WriteFile(sparseCheckoutPath, []byte(sparsePattern+"\n"), 0644); err != nil {
 		return fmt.Errorf("failed to write sparse-checkout config: %w", err)


### PR DESCRIPTION
The sparse-checkout pattern used /* which only matches immediate children of the target path. Nested directories like home/ were silently skipped. Switching to /** ensures all subdirectories are checked out recursively.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
