### PR TITLE
feat: add test-login endpoint for integration testing

### DIFF
--- a/cmd/schedule.go
+++ b/cmd/schedule.go
@@ -74,16 +74,16 @@ var scheduleCancelCmd = &cobra.Command{
 var scheduleCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a one-shot scheduled event",
-	Long: `Create a one-shot scheduled event. Requires timing (--in or --at), --agent, and --message.`,
-	RunE: runScheduleCreate,
+	Long:  `Create a one-shot scheduled event. Requires timing (--in or --at), --agent, and --message.`,
+	RunE:  runScheduleCreate,
 }
 
 // scheduleCreateRecurringCmd creates a new recurring schedule.
 var scheduleCreateRecurringCmd = &cobra.Command{
 	Use:   "create-recurring",
 	Short: "Create a recurring schedule",
-	Long: `Create a recurring schedule with a cron expression. Requires --name, --cron, --agent, and --message.`,
-	RunE: runScheduleCreateRecurring,
+	Long:  `Create a recurring schedule with a cron expression. Requires --name, --cron, --agent, and --message.`,
+	RunE:  runScheduleCreateRecurring,
 }
 
 // schedulePauseCmd pauses an active recurring schedule.

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -31,6 +31,7 @@ var (
 	dbURL               string
 	noAutoMigrate       bool
 	enableDevAuth       bool
+	enableTestLogin     bool
 	enableDebug         bool
 	storageBucket       string
 	storageDir          string
@@ -247,6 +248,7 @@ func init() {
 
 	// Auth flags
 	serverStartCmd.Flags().BoolVar(&enableDevAuth, "dev-auth", false, "Enable development authentication (auto-generates token)")
+	serverStartCmd.Flags().BoolVar(&enableTestLogin, "enable-test-login", false, "Enable the test-login endpoint for integration testing (do not use in production)")
 
 	// Debug flags
 	serverStartCmd.Flags().BoolVar(&enableDebug, "debug", false, "Enable debug logging (verbose output)")

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1255,6 +1255,7 @@ func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 		UserAccessMode:     cfg.Auth.UserAccessMode,
 		AdminMode:          adminMode,
 		MaintenanceMessage: maintenanceMessage,
+		EnableTestLogin:    enableTestLogin,
 	}
 	webSrv := hub.NewWebServer(webCfg)
 	webSrv.SetRequestLogger(requestLogger)

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1257,6 +1257,9 @@ func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 		MaintenanceMessage: maintenanceMessage,
 		EnableTestLogin:    enableTestLogin,
 	}
+	if enableTestLogin {
+		slog.Warn("Test login endpoint is enabled (--enable-test-login). This allows bypass of authentication and MUST NOT be used in production!")
+	}
 	webSrv := hub.NewWebServer(webCfg)
 	webSrv.SetRequestLogger(requestLogger)
 

--- a/pkg/hub/auth.go
+++ b/pkg/hub/auth.go
@@ -372,6 +372,8 @@ func isUnauthenticatedEndpoint(path string) bool {
 		return true
 	case "/api/v1/auth/cli/device/token": // CLI device flow token polling
 		return true
+	case "/api/v1/auth/test-login": // Test-login for integration testing (gated by --enable-test-login)
+		return true
 	case "/api/v1/brokers/join": // Broker registration bootstrap (uses join token)
 		return true
 	case "/api/v1/webhooks/github": // GitHub App webhook (uses webhook signature verification)

--- a/pkg/hub/handlers_test_login.go
+++ b/pkg/hub/handlers_test_login.go
@@ -106,7 +106,9 @@ func (ws *WebServer) handleTestLogin(w http.ResponseWriter, r *http.Request) {
 		if req.DisplayName != user.Email {
 			user.DisplayName = req.DisplayName
 		}
-		_ = ws.store.UpdateUser(ctx, user)
+		if err := ws.store.UpdateUser(ctx, user); err != nil {
+			slog.Warn("test-login: failed to update user", "email", req.Email, "error", err)
+		}
 	}
 
 	ensureHubMembership(ctx, ws.store, user.ID)

--- a/pkg/hub/handlers_test_login.go
+++ b/pkg/hub/handlers_test_login.go
@@ -144,9 +144,7 @@ func (ws *WebServer) handleTestLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(TestLoginResponse{
+	writeJSON(w, http.StatusOK, TestLoginResponse{
 		User: &UserResponse{
 			ID:          user.ID,
 			Email:       user.Email,

--- a/pkg/hub/handlers_test_login.go
+++ b/pkg/hub/handlers_test_login.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// TestLoginRequest is the request body for POST /api/v1/auth/test-login.
+type TestLoginRequest struct {
+	Email       string `json:"email"`
+	Role        string `json:"role"`
+	DisplayName string `json:"displayName"`
+}
+
+// TestLoginResponse is the response for POST /api/v1/auth/test-login.
+type TestLoginResponse struct {
+	User         *UserResponse `json:"user"`
+	AccessToken  string        `json:"accessToken"`
+	RefreshToken string        `json:"refreshToken"`
+	ExpiresIn    int64         `json:"expiresIn"`
+}
+
+// handleTestLogin handles POST /api/v1/auth/test-login.
+// It provisions a test user and creates a web session, bypassing OAuth.
+// Gated behind --enable-test-login (WebServerConfig.EnableTestLogin).
+func (ws *WebServer) handleTestLogin(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if !ws.config.EnableTestLogin {
+		http.Error(w, "test-login is not enabled", http.StatusForbidden)
+		return
+	}
+
+	if ws.store == nil || ws.userTokenSvc == nil {
+		http.Error(w, "hub services not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req TestLoginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.Email == "" {
+		http.Error(w, "email is required", http.StatusBadRequest)
+		return
+	}
+
+	switch req.Role {
+	case "admin", "member", "viewer":
+	case "":
+		req.Role = "member"
+	default:
+		http.Error(w, "role must be admin, member, or viewer", http.StatusBadRequest)
+		return
+	}
+
+	if req.DisplayName == "" {
+		req.DisplayName = req.Email
+	}
+
+	ctx := r.Context()
+
+	// Find or create user
+	user, err := ws.store.GetUserByEmail(ctx, req.Email)
+	if err != nil {
+		user = &store.User{
+			ID:          generateID(),
+			Email:       req.Email,
+			DisplayName: req.DisplayName,
+			Role:        req.Role,
+			Status:      "active",
+			Created:     time.Now(),
+			LastLogin:   time.Now(),
+		}
+		if err := ws.store.CreateUser(ctx, user); err != nil {
+			slog.Error("test-login: failed to create user", "email", req.Email, "error", err)
+			http.Error(w, "failed to create user", http.StatusInternalServerError)
+			return
+		}
+	} else {
+		user.LastLogin = time.Now()
+		user.Role = req.Role
+		if req.DisplayName != user.Email {
+			user.DisplayName = req.DisplayName
+		}
+		_ = ws.store.UpdateUser(ctx, user)
+	}
+
+	ensureHubMembership(ctx, ws.store, user.ID)
+
+	// Generate tokens
+	accessToken, refreshToken, expiresIn, err := ws.userTokenSvc.GenerateTokenPair(
+		user.ID, user.Email, user.DisplayName, user.Role, ClientTypeWeb,
+	)
+	if err != nil {
+		slog.Error("test-login: failed to generate tokens", "error", err)
+		http.Error(w, "failed to generate tokens", http.StatusInternalServerError)
+		return
+	}
+
+	// Populate session cookie (same pattern as handleOAuthCallback)
+	session, err := ws.sessionStore.Get(r, webSessionName)
+	if err != nil {
+		session, _ = ws.sessionStore.New(r, webSessionName)
+	}
+
+	session.Values[sessKeyUserID] = user.ID
+	session.Values[sessKeyUserEmail] = user.Email
+	session.Values[sessKeyUserName] = user.DisplayName
+	session.Values[sessKeyUserAvatar] = ""
+	session.Values[sessKeyUserRole] = user.Role
+	session.Values[sessKeyHubAccessToken] = accessToken
+	session.Values[sessKeyHubRefreshToken] = refreshToken
+	session.Values[sessKeyHubTokenExpiry] = time.Now().Add(time.Duration(expiresIn) * time.Second).UnixMilli()
+
+	if err := session.Save(r, w); err != nil {
+		slog.Error("test-login: failed to save session", "error", err)
+		http.Error(w, "failed to save session", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(TestLoginResponse{
+		User: &UserResponse{
+			ID:          user.ID,
+			Email:       user.Email,
+			DisplayName: user.DisplayName,
+			Role:        user.Role,
+		},
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		ExpiresIn:    expiresIn,
+	})
+}

--- a/pkg/hub/handlers_test_login_test.go
+++ b/pkg/hub/handlers_test_login_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testLoginStore struct {
+	store.Store
+	users map[string]*store.User
+}
+
+func newTestLoginStore() *testLoginStore {
+	return &testLoginStore{users: make(map[string]*store.User)}
+}
+
+func (s *testLoginStore) GetUserByEmail(_ context.Context, email string) (*store.User, error) {
+	if u, ok := s.users[email]; ok {
+		return u, nil
+	}
+	return nil, fmt.Errorf("user not found")
+}
+
+func (s *testLoginStore) CreateUser(_ context.Context, user *store.User) error {
+	s.users[user.Email] = user
+	return nil
+}
+
+func (s *testLoginStore) UpdateUser(_ context.Context, user *store.User) error {
+	s.users[user.Email] = user
+	return nil
+}
+
+func (s *testLoginStore) GetGroupBySlug(_ context.Context, _ string) (*store.Group, error) {
+	return nil, fmt.Errorf("not found")
+}
+
+func newTestLoginWebServer(t *testing.T, enableTestLogin bool) *WebServer {
+	t.Helper()
+	cfg := WebServerConfig{
+		EnableTestLogin: enableTestLogin,
+	}
+	ws := NewWebServer(cfg)
+	tokenSvc, err := NewUserTokenService(UserTokenConfig{})
+	require.NoError(t, err)
+	ws.SetUserTokenService(tokenSvc)
+	ws.SetStore(newTestLoginStore())
+	return ws
+}
+
+func TestHandleTestLogin_Success(t *testing.T) {
+	ws := newTestLoginWebServer(t, true)
+
+	body := `{"email":"test@example.com","role":"admin","displayName":"Test User"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	ws.handleTestLogin(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp TestLoginResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	assert.Equal(t, "test@example.com", resp.User.Email)
+	assert.Equal(t, "admin", resp.User.Role)
+	assert.Equal(t, "Test User", resp.User.DisplayName)
+	assert.NotEmpty(t, resp.AccessToken)
+	assert.NotEmpty(t, resp.RefreshToken)
+	assert.Greater(t, resp.ExpiresIn, int64(0))
+
+	cookies := rec.Result().Cookies()
+	var found bool
+	for _, c := range cookies {
+		if c.Name == webSessionName {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "session cookie should be set")
+}
+
+func TestHandleTestLogin_DefaultRole(t *testing.T) {
+	ws := newTestLoginWebServer(t, true)
+
+	body := `{"email":"member@example.com"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	ws.handleTestLogin(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp TestLoginResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "member", resp.User.Role)
+	assert.Equal(t, "member@example.com", resp.User.DisplayName)
+}
+
+func TestHandleTestLogin_Disabled(t *testing.T) {
+	ws := newTestLoginWebServer(t, false)
+
+	body := `{"email":"test@example.com","role":"admin"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	ws.handleTestLogin(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestHandleTestLogin_MethodNotAllowed(t *testing.T) {
+	ws := newTestLoginWebServer(t, true)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/test-login", nil)
+	rec := httptest.NewRecorder()
+
+	ws.handleTestLogin(rec, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestHandleTestLogin_MissingEmail(t *testing.T) {
+	ws := newTestLoginWebServer(t, true)
+
+	body := `{"role":"admin"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	ws.handleTestLogin(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleTestLogin_InvalidRole(t *testing.T) {
+	ws := newTestLoginWebServer(t, true)
+
+	body := `{"email":"test@example.com","role":"superadmin"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	ws.handleTestLogin(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleTestLogin_InvalidJSON(t *testing.T) {
+	ws := newTestLoginWebServer(t, true)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	ws.handleTestLogin(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleTestLogin_ExistingUser(t *testing.T) {
+	ws := newTestLoginWebServer(t, true)
+
+	// Pre-populate a user
+	mockStore := ws.store.(*testLoginStore)
+	mockStore.users["existing@example.com"] = &store.User{
+		ID:          "existing-id",
+		Email:       "existing@example.com",
+		DisplayName: "Old Name",
+		Role:        "member",
+		Status:      "active",
+		Created:     time.Now().Add(-24 * time.Hour),
+	}
+
+	body := `{"email":"existing@example.com","role":"admin","displayName":"New Name"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	ws.handleTestLogin(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp TestLoginResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "existing-id", resp.User.ID)
+	assert.Equal(t, "admin", resp.User.Role)
+}
+
+func TestHandleTestLogin_AllRoles(t *testing.T) {
+	for _, role := range []string{"admin", "member", "viewer"} {
+		t.Run(role, func(t *testing.T) {
+			ws := newTestLoginWebServer(t, true)
+
+			body := fmt.Sprintf(`{"email":"user@example.com","role":"%s"}`, role)
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			ws.handleTestLogin(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var resp TestLoginResponse
+			require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+			assert.Equal(t, role, resp.User.Role)
+		})
+	}
+}

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -137,6 +137,10 @@ type WebServerConfig struct {
 	AdminMode bool
 	// MaintenanceMessage is the custom message shown during admin mode.
 	MaintenanceMessage string
+	// EnableTestLogin enables the POST /api/v1/auth/test-login endpoint
+	// for integration testing. Disabled by default; must never be enabled
+	// in production.
+	EnableTestLogin bool
 }
 
 // WebServer serves the web frontend SPA shell and static assets.
@@ -683,6 +687,8 @@ func (ws *WebServer) registerRoutes() {
 	ws.mux.HandleFunc("/auth/me", ws.handleAuthMe)
 	ws.mux.HandleFunc("/auth/providers", ws.handleAuthProviders)
 	ws.mux.HandleFunc("/auth/debug", ws.handleAuthDebug)
+	// Test-login endpoint for integration testing (gated by EnableTestLogin)
+	ws.mux.HandleFunc("/api/v1/auth/test-login", ws.handleTestLogin)
 	// SSE event stream (protected by session auth middleware)
 	ws.mux.HandleFunc("/events", ws.handleSSE)
 	// SPA catch-all (protected by session auth middleware)


### PR DESCRIPTION
Add POST /api/v1/auth/test-login gated behind --enable-test-login flag. The endpoint provisions a test user, generates JWTs, and sets a session cookie — enabling Playwright and browser-based integration tests without requiring OAuth. Separate from --dev-auth to keep workstation mode clean.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
