### PR TITLE
Use canonical project endpoints in integrations

### DIFF
--- a/extras/scion-discord/internal/discord/hubclient.go
+++ b/extras/scion-discord/internal/discord/hubclient.go
@@ -49,7 +49,7 @@ type hubAgent struct {
 }
 
 func (c *httpHubClient) ListProjects(ctx context.Context) ([]ProjectOption, error) {
-	url := c.hubURL + "/api/v1/groves"
+	url := c.hubURL + "/api/v1/projects"
 
 	slog.Debug("Listing projects from hub", "url", url, "broker_id", c.brokerID)
 
@@ -127,7 +127,7 @@ func (c *httpHubClient) ListProjectsFresh(ctx context.Context) ([]ProjectOption,
 }
 
 func (c *httpHubClient) ListProjectsForUser(ctx context.Context, ownerID string) ([]ProjectOption, error) {
-	url := c.hubURL + "/api/v1/groves?ownerId=" + ownerID
+	url := c.hubURL + "/api/v1/projects?ownerId=" + ownerID
 
 	slog.Debug("Listing projects for user from hub", "url", url, "owner_id", ownerID)
 
@@ -163,7 +163,7 @@ func (c *httpHubClient) ListProjectsForUser(ctx context.Context, ownerID string)
 }
 
 func (c *httpHubClient) ListAgents(ctx context.Context, projectID string) ([]AgentInfo, error) {
-	url := fmt.Sprintf("%s/api/v1/groves/%s/agents", c.hubURL, projectID)
+	url := fmt.Sprintf("%s/api/v1/projects/%s/agents", c.hubURL, projectID)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {

--- a/extras/scion-telegram/internal/telegram/commands.go
+++ b/extras/scion-telegram/internal/telegram/commands.go
@@ -646,7 +646,7 @@ type hubAgent struct {
 }
 
 func (c *httpHubClient) ListProjects(ctx context.Context) ([]ProjectOption, error) {
-	url := c.hubURL + "/api/v1/groves"
+	url := c.hubURL + "/api/v1/projects"
 
 	slog.Debug("Listing projects from hub", "url", url, "broker_id", c.brokerID)
 
@@ -724,7 +724,7 @@ func (c *httpHubClient) ListProjectsFresh(ctx context.Context) ([]ProjectOption,
 }
 
 func (c *httpHubClient) ListProjectsForUser(ctx context.Context, ownerID string) ([]ProjectOption, error) {
-	url := c.hubURL + "/api/v1/groves?ownerId=" + ownerID
+	url := c.hubURL + "/api/v1/projects?ownerId=" + ownerID
 
 	slog.Debug("Listing projects for user from hub", "url", url, "owner_id", ownerID)
 
@@ -760,7 +760,7 @@ func (c *httpHubClient) ListProjectsForUser(ctx context.Context, ownerID string)
 }
 
 func (c *httpHubClient) ListAgents(ctx context.Context, projectID string) ([]AgentInfo, error) {
-	url := fmt.Sprintf("%s/api/v1/groves/%s/agents", c.hubURL, projectID)
+	url := fmt.Sprintf("%s/api/v1/projects/%s/agents", c.hubURL, projectID)
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create list agents request: %w", err)


### PR DESCRIPTION

Suggested title: fix: migrate Telegram/Discord Hub clients from /api/v1/groves to /api/v1/projects

What changed: 3 httpHubClient methods in Discord and Telegram migrated from the legacy groves endpoint to the projects endpoint. +6/-6 lines, purely mechanical, no behavioral changes.

Review: APPROVED. One medium non-blocking note: PR description references test functions that don't exist in the codebase (TestParseAgentMessageTopic, TestMessageBrokerProxy) — worth correcting the description before merge.