### PR TITLE
fix: use canonical project endpoints in remaining test fixtures and mocks

### DIFF
--- a/cmd/common_envgather_test.go
+++ b/cmd/common_envgather_test.go
@@ -173,7 +173,7 @@ func TestStartAgentViaHub_EnvGatherFailureCleansUp(t *testing.T) {
 		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
 			json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/groves/"+projectID+"/agents":
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/projects/"+projectID+"/agents":
 			// CreateAgent — return 202 with env-gather requirements
 			w.WriteHeader(http.StatusAccepted)
 			json.NewEncoder(w).Encode(map[string]interface{}{
@@ -190,7 +190,7 @@ func TestStartAgentViaHub_EnvGatherFailureCleansUp(t *testing.T) {
 			deleteCalled = true
 			w.WriteHeader(http.StatusNoContent)
 
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/groves":
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects":
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"groves": []map[string]interface{}{{"id": projectID, "name": "test"}},
 			})
@@ -245,12 +245,12 @@ func TestStartAgentViaHub_GlobalGroveSkipsWorkspaceBootstrap(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/groves/"+projectID:
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects/"+projectID:
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"id":   projectID,
 				"name": "global",
 			})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/groves/"+projectID+"/agents":
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/projects/"+projectID+"/agents":
 			var req hubclient.CreateAgentRequest
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 			captured = &req

--- a/cmd/common_envgather_test.go
+++ b/cmd/common_envgather_test.go
@@ -192,7 +192,7 @@ func TestStartAgentViaHub_EnvGatherFailureCleansUp(t *testing.T) {
 
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/projects":
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"groves": []map[string]interface{}{{"id": projectID, "name": "test"}},
+				"projects": []map[string]interface{}{{"id": projectID, "name": "test"}},
 			})
 
 		default:

--- a/cmd/hub_env_test.go
+++ b/cmd/hub_env_test.go
@@ -257,14 +257,14 @@ func newEnvProjectResolveMockServer(t *testing.T, projectID, projectName, projec
 		case r.URL.Path == "/api/v1/projects" && r.Method == http.MethodGet:
 			slug := r.URL.Query().Get("slug")
 			name := r.URL.Query().Get("name")
-			var groves []map[string]interface{}
+			var projects []map[string]interface{}
 			if slug == projectSlug || name == projectName {
-				groves = []map[string]interface{}{
+				projects = []map[string]interface{}{
 					{"id": projectID, "name": projectName, "slug": projectSlug},
 				}
 			}
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"groves": groves,
+				"projects": projects,
 			})
 
 		case r.URL.Path == "/api/v1/env" && r.Method == http.MethodGet:

--- a/cmd/hub_env_test.go
+++ b/cmd/hub_env_test.go
@@ -247,14 +247,14 @@ func newEnvProjectResolveMockServer(t *testing.T, projectID, projectName, projec
 		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
 			json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 
-		case r.URL.Path == "/api/v1/groves/"+projectID && r.Method == http.MethodGet:
+		case r.URL.Path == "/api/v1/projects/"+projectID && r.Method == http.MethodGet:
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"id":   projectID,
 				"name": projectName,
 				"slug": projectSlug,
 			})
 
-		case r.URL.Path == "/api/v1/groves" && r.Method == http.MethodGet:
+		case r.URL.Path == "/api/v1/projects" && r.Method == http.MethodGet:
 			slug := r.URL.Query().Get("slug")
 			name := r.URL.Query().Get("name")
 			var groves []map[string]interface{}

--- a/cmd/notifications_test.go
+++ b/cmd/notifications_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestResolveAgentIDForSubscription_Found(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/groves/grove-1/agents" && r.Method == http.MethodGet {
+		if r.URL.Path == "/api/v1/projects/grove-1/agents" && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"agents": []map[string]interface{}{
@@ -58,7 +58,7 @@ func TestResolveAgentIDForSubscription_Found(t *testing.T) {
 
 func TestResolveAgentIDForSubscription_NotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/groves/grove-1/agents" && r.Method == http.MethodGet {
+		if r.URL.Path == "/api/v1/projects/grove-1/agents" && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"agents": []map[string]interface{}{
@@ -84,7 +84,7 @@ func TestResolveAgentIDForSubscription_NotFound(t *testing.T) {
 
 func TestResolveAgentIDForSubscription_BySlugified(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/groves/grove-1/agents" && r.Method == http.MethodGet {
+		if r.URL.Path == "/api/v1/projects/grove-1/agents" && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"agents": []map[string]interface{}{

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestResolveAgentID_AgentFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/groves/grove-1/agents" && r.Method == http.MethodGet {
+		if r.URL.Path == "/api/v1/projects/grove-1/agents" && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"agents": []map[string]interface{}{
@@ -60,7 +60,7 @@ func TestResolveAgentID_AgentFound(t *testing.T) {
 
 func TestResolveAgentID_AgentNotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/groves/grove-1/agents" && r.Method == http.MethodGet {
+		if r.URL.Path == "/api/v1/projects/grove-1/agents" && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"agents": []map[string]interface{}{
@@ -89,7 +89,7 @@ func TestResolveAgentID_AgentNotFound(t *testing.T) {
 
 func TestResolveAgentID_AgentNotRunning(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/groves/grove-1/agents" && r.Method == http.MethodGet {
+		if r.URL.Path == "/api/v1/projects/grove-1/agents" && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"agents": []map[string]interface{}{

--- a/cmd/template_resolution_test.go
+++ b/cmd/template_resolution_test.go
@@ -315,7 +315,7 @@ func TestBrokerHasLocalAccess(t *testing.T) {
 	t.Run("returns true when broker has local path", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			if r.URL.Path == "/api/v1/groves/"+projectID+"/providers" && r.Method == http.MethodGet {
+			if r.URL.Path == "/api/v1/projects/"+projectID+"/providers" && r.Method == http.MethodGet {
 				json.NewEncoder(w).Encode(map[string]interface{}{
 					"providers": []map[string]interface{}{
 						{
@@ -350,7 +350,7 @@ func TestBrokerHasLocalAccess(t *testing.T) {
 	t.Run("returns false when broker has no local path", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			if r.URL.Path == "/api/v1/groves/"+projectID+"/providers" && r.Method == http.MethodGet {
+			if r.URL.Path == "/api/v1/projects/"+projectID+"/providers" && r.Method == http.MethodGet {
 				json.NewEncoder(w).Encode(map[string]interface{}{
 					"providers": []map[string]interface{}{
 						{
@@ -384,7 +384,7 @@ func TestBrokerHasLocalAccess(t *testing.T) {
 	t.Run("returns false when broker ID does not match", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			if r.URL.Path == "/api/v1/groves/"+projectID+"/providers" && r.Method == http.MethodGet {
+			if r.URL.Path == "/api/v1/projects/"+projectID+"/providers" && r.Method == http.MethodGet {
 				json.NewEncoder(w).Encode(map[string]interface{}{
 					"providers": []map[string]interface{}{
 						{

--- a/cmd/templates_test.go
+++ b/cmd/templates_test.go
@@ -129,7 +129,7 @@ func TestRunTemplateDelete_ProtectedTemplate(t *testing.T) {
 
 // newMockHubServer creates a mock Hub server that handles the endpoints
 // required by CheckHubAvailabilityWithOptions and template operations.
-// projectID is the grove ID to recognize. templates is the list of templates to return.
+// projectID is the project ID to recognize. templates is the list of templates to return.
 // Returns the server and a pointer to a bool that tracks if delete was called.
 func newMockHubServer(t *testing.T, projectID string, templates []map[string]interface{}) (*httptest.Server, *bool) {
 	t.Helper()
@@ -143,11 +143,11 @@ func newMockHubServer(t *testing.T, projectID string, templates []map[string]int
 		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
 			json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 
-		// Project lookup (for isGroveRegistered)
-		case strings.HasPrefix(r.URL.Path, "/api/v1/groves/") && r.Method == http.MethodGet:
+		// Project lookup.
+		case strings.HasPrefix(r.URL.Path, "/api/v1/projects/") && r.Method == http.MethodGet:
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"id":   projectID,
-				"name": "test-grove",
+				"name": "test-project",
 			})
 
 		// Template list
@@ -333,10 +333,10 @@ func newMockHubServerForSync(t *testing.T, projectID string, existingTemplates [
 		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
 			json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 
-		case strings.HasPrefix(r.URL.Path, "/api/v1/groves/") && r.Method == http.MethodGet:
+		case strings.HasPrefix(r.URL.Path, "/api/v1/projects/") && r.Method == http.MethodGet:
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"id":   projectID,
-				"name": "test-grove",
+				"name": "test-project",
 			})
 
 		case r.URL.Path == "/api/v1/templates" && r.Method == http.MethodGet:

--- a/extras/scion-chat-app/cmd/scion-chat-app/main.go
+++ b/extras/scion-chat-app/cmd/scion-chat-app/main.go
@@ -350,7 +350,7 @@ func verifyHubConnectivity(ctx context.Context, log *slog.Logger, minter *identi
 
 	// Step 4: Make an HTTP-level request to confirm connectivity & auth,
 	// logging request/response details.
-	verifyURL := strings.TrimRight(hubEndpoint, "/") + "/api/v1/groves"
+	verifyURL := strings.TrimRight(hubEndpoint, "/") + "/api/v1/projects"
 	log.Info("hub-verify: sending manual HTTP GET", "url", verifyURL)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, verifyURL, nil)

--- a/extras/scion-discord/internal/discord/hubclient.go
+++ b/extras/scion-discord/internal/discord/hubclient.go
@@ -49,7 +49,7 @@ type hubAgent struct {
 }
 
 func (c *httpHubClient) ListProjects(ctx context.Context) ([]ProjectOption, error) {
-	url := c.hubURL + "/api/v1/groves"
+	url := c.hubURL + "/api/v1/projects"
 
 	slog.Debug("Listing projects from hub", "url", url, "broker_id", c.brokerID)
 
@@ -127,7 +127,7 @@ func (c *httpHubClient) ListProjectsFresh(ctx context.Context) ([]ProjectOption,
 }
 
 func (c *httpHubClient) ListProjectsForUser(ctx context.Context, ownerID string) ([]ProjectOption, error) {
-	url := c.hubURL + "/api/v1/groves?ownerId=" + ownerID
+	url := c.hubURL + "/api/v1/projects?ownerId=" + ownerID
 
 	slog.Debug("Listing projects for user from hub", "url", url, "owner_id", ownerID)
 
@@ -163,7 +163,7 @@ func (c *httpHubClient) ListProjectsForUser(ctx context.Context, ownerID string)
 }
 
 func (c *httpHubClient) ListAgents(ctx context.Context, projectID string) ([]AgentInfo, error) {
-	url := fmt.Sprintf("%s/api/v1/groves/%s/agents", c.hubURL, projectID)
+	url := fmt.Sprintf("%s/api/v1/projects/%s/agents", c.hubURL, projectID)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {

--- a/extras/scion-telegram/internal/telegram/commands.go
+++ b/extras/scion-telegram/internal/telegram/commands.go
@@ -646,7 +646,7 @@ type hubAgent struct {
 }
 
 func (c *httpHubClient) ListProjects(ctx context.Context) ([]ProjectOption, error) {
-	url := c.hubURL + "/api/v1/groves"
+	url := c.hubURL + "/api/v1/projects"
 
 	slog.Debug("Listing projects from hub", "url", url, "broker_id", c.brokerID)
 
@@ -724,7 +724,7 @@ func (c *httpHubClient) ListProjectsFresh(ctx context.Context) ([]ProjectOption,
 }
 
 func (c *httpHubClient) ListProjectsForUser(ctx context.Context, ownerID string) ([]ProjectOption, error) {
-	url := c.hubURL + "/api/v1/groves?ownerId=" + ownerID
+	url := c.hubURL + "/api/v1/projects?ownerId=" + ownerID
 
 	slog.Debug("Listing projects for user from hub", "url", url, "owner_id", ownerID)
 
@@ -760,7 +760,7 @@ func (c *httpHubClient) ListProjectsForUser(ctx context.Context, ownerID string)
 }
 
 func (c *httpHubClient) ListAgents(ctx context.Context, projectID string) ([]AgentInfo, error) {
-	url := fmt.Sprintf("%s/api/v1/groves/%s/agents", c.hubURL, projectID)
+	url := fmt.Sprintf("%s/api/v1/projects/%s/agents", c.hubURL, projectID)
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create list agents request: %w", err)

--- a/pkg/hubsync/resolve_test.go
+++ b/pkg/hubsync/resolve_test.go
@@ -99,7 +99,7 @@ func TestIsHubProjectRef_PathSeparator(t *testing.T) {
 func TestResolveProjectOnHub_ByUUID(t *testing.T) {
 	projectID := "550e8400-e29b-41d4-a716-446655440000"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/groves/"+projectID {
+		if r.URL.Path == "/api/v1/projects/"+projectID {
 			json.NewEncoder(w).Encode(hubclient.Project{
 				ID:   projectID,
 				Name: "Test Project",
@@ -122,11 +122,11 @@ func TestResolveProjectOnHub_ByUUID(t *testing.T) {
 
 func TestResolveProjectOnHub_BySlug(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/groves" {
+		if r.URL.Path == "/api/v1/projects" {
 			slug := r.URL.Query().Get("slug")
 			if slug == "my-project" {
 				json.NewEncoder(w).Encode(map[string]interface{}{
-					"groves": []hubclient.Project{
+					"projects": []hubclient.Project{
 						{ID: "abc-123", Name: "My Project", Slug: "my-project"},
 					},
 					"totalCount": 1,
@@ -135,7 +135,7 @@ func TestResolveProjectOnHub_BySlug(t *testing.T) {
 			}
 			// Empty for name fallback
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"groves":     []hubclient.Project{},
+				"projects":   []hubclient.Project{},
 				"totalCount": 0,
 			})
 			return
@@ -155,20 +155,20 @@ func TestResolveProjectOnHub_BySlug(t *testing.T) {
 
 func TestResolveProjectOnHub_ByName(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/groves" {
+		if r.URL.Path == "/api/v1/projects" {
 			name := r.URL.Query().Get("name")
 			slug := r.URL.Query().Get("slug")
 			if slug != "" {
 				// Slug query returns nothing
 				json.NewEncoder(w).Encode(map[string]interface{}{
-					"groves":     []hubclient.Project{},
+					"projects":   []hubclient.Project{},
 					"totalCount": 0,
 				})
 				return
 			}
 			if name == "My Project" {
 				json.NewEncoder(w).Encode(map[string]interface{}{
-					"groves": []hubclient.Project{
+					"projects": []hubclient.Project{
 						{ID: "abc-456", Name: "My Project", Slug: "my-project"},
 					},
 					"totalCount": 1,
@@ -176,7 +176,7 @@ func TestResolveProjectOnHub_ByName(t *testing.T) {
 				return
 			}
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"groves":     []hubclient.Project{},
+				"projects":   []hubclient.Project{},
 				"totalCount": 0,
 			})
 			return
@@ -195,11 +195,11 @@ func TestResolveProjectOnHub_ByName(t *testing.T) {
 
 func TestResolveProjectOnHub_ByGitURL(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/groves" {
+		if r.URL.Path == "/api/v1/projects" {
 			gitRemote := r.URL.Query().Get("gitRemote")
 			if gitRemote != "" {
 				json.NewEncoder(w).Encode(map[string]interface{}{
-					"groves": []hubclient.Project{
+					"projects": []hubclient.Project{
 						{ID: "git-grove-1", Name: "Git Project", Slug: "git-project"},
 					},
 					"totalCount": 1,
@@ -207,7 +207,7 @@ func TestResolveProjectOnHub_ByGitURL(t *testing.T) {
 				return
 			}
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"groves":     []hubclient.Project{},
+				"projects":   []hubclient.Project{},
 				"totalCount": 0,
 			})
 			return
@@ -226,9 +226,9 @@ func TestResolveProjectOnHub_ByGitURL(t *testing.T) {
 
 func TestResolveProjectOnHub_NotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/groves" {
+		if r.URL.Path == "/api/v1/projects" {
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"groves":     []hubclient.Project{},
+				"projects":   []hubclient.Project{},
 				"totalCount": 0,
 			})
 			return
@@ -247,19 +247,19 @@ func TestResolveProjectOnHub_NotFound(t *testing.T) {
 
 func TestResolveProjectOnHub_MultipleByName(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/groves" {
+		if r.URL.Path == "/api/v1/projects" {
 			slug := r.URL.Query().Get("slug")
 			if slug != "" {
 				// No slug match
 				json.NewEncoder(w).Encode(map[string]interface{}{
-					"groves":     []hubclient.Project{},
+					"projects":   []hubclient.Project{},
 					"totalCount": 0,
 				})
 				return
 			}
 			// Name returns multiple
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"groves": []hubclient.Project{
+				"projects": []hubclient.Project{
 					{ID: "id-1", Name: "dupe", Slug: "dupe-1"},
 					{ID: "id-2", Name: "dupe", Slug: "dupe-2"},
 				},

--- a/pkg/hubsync/sync_test.go
+++ b/pkg/hubsync/sync_test.go
@@ -51,7 +51,7 @@ func TestEnsureHubReady_GlobalFallbackWithHubEnabled(t *testing.T) {
 		switch {
 		case r.URL.Path == "/healthz":
 			json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
-		case r.URL.Path == "/api/v1/groves/"+projectID:
+		case r.URL.Path == "/api/v1/projects/"+projectID:
 			// Project is already registered
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"id":   projectID,
@@ -127,7 +127,7 @@ func TestEnsureHubReady_EndpointOverrideBeatsSettings(t *testing.T) {
 		switch {
 		case r.URL.Path == "/healthz":
 			json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
-		case r.URL.Path == "/api/v1/groves/"+projectID:
+		case r.URL.Path == "/api/v1/projects/"+projectID:
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"id":   projectID,
 				"name": "Override",
@@ -310,7 +310,7 @@ func TestEnsureHubReady_HubContextSkipsSyncAndRegistration(t *testing.T) {
 		switch {
 		case r.URL.Path == "/healthz":
 			json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
-		case r.URL.Path == "/api/v1/groves/"+projectID:
+		case r.URL.Path == "/api/v1/projects/"+projectID:
 			// Project lookup — should not reach here in container context
 			registrationCalled = true
 			json.NewEncoder(w).Encode(map[string]interface{}{
@@ -1426,7 +1426,7 @@ func TestCreateHubClient_FallsBackToDevAuth(t *testing.T) {
 func TestIsProjectRegistered_Found(t *testing.T) {
 	projectID := "test-project-uuid-1234"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/groves/"+projectID {
+		if r.URL.Path == "/api/v1/projects/"+projectID {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]string{"id": projectID, "name": "my-project"})
 			return
@@ -1509,7 +1509,7 @@ func TestIsProjectRegistered_NonNotFoundError(t *testing.T) {
 func TestFindProjectByID_Found(t *testing.T) {
 	projectID := "exact-match-uuid-5678"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/groves/"+projectID {
+		if r.URL.Path == "/api/v1/projects/"+projectID {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]string{
 				"id":   projectID,


### PR DESCRIPTION

What changed: switched remaining non-compat client/test fixtures to /api/v1/projects — chat app manual verify, hubsync/command mocks, and fixed the 'groves' response body key in common_envgather_test.go caught in review.

Review: APPROVED (minor fix applied before submission).
