### PR TITLE
Centralize runtime project label compatibility

### DIFF
--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/harness"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/GoogleCloudPlatform/scion/pkg/provision"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 )
@@ -296,8 +297,8 @@ func migrateLegacyAgentState(legacyDir, externalDir string) {
 // clean up containers before removing the project config directory.
 func StopProjectContainers(ctx context.Context, mgr Manager, projectName string, agentNames []string) []string {
 	containers, err := mgr.List(ctx, map[string]string{
-		"scion.agent": "true",
-		"scion.grove": projectName,
+		"scion.agent":              "true",
+		projectcompat.LabelProject: projectName,
 	})
 	if err != nil {
 		util.Debugf("StopProjectContainers: failed to list containers for project %s: %v", projectName, err)

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/harness"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 )
@@ -65,12 +66,12 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 	projectName := config.GetProjectName(projectDir)
 
 	// Determine the project ID for label-based filtering. In broker/hosted mode
-	// this comes from the SCION_GROVE_ID env var injected by the hub dispatcher.
+	// this comes from env injected by the hub dispatcher.
 	projectID := ""
 	if opts.Env != nil {
-		projectID = opts.Env["SCION_GROVE_ID"]
+		projectID = opts.Env["SCION_PROJECT_ID"]
 		if projectID == "" {
-			projectID = opts.Env["SCION_PROJECT_ID"]
+			projectID = opts.Env["SCION_GROVE_ID"]
 		}
 	}
 
@@ -894,28 +895,22 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 			l := map[string]string{
 				"scion.agent":          "true",
 				"scion.name":           api.Slugify(opts.Name),
-				"scion.project":        projectName,
-				"scion.grove":          projectName,
 				"scion.template":       template,
 				"scion.harness_config": harnessConfigName,
 				"scion.harness_auth":   opts.HarnessAuth,
 			}
+			for k, v := range projectcompat.ProjectNameLabels(projectName, true) {
+				l[k] = v
+			}
 			// Add project_id label for project-scoped agent isolation.
-			// In broker/hosted mode this comes from the SCION_GROVE_ID or
-			// SCION_PROJECT_ID env var injected by the hub dispatcher.
-			if projectID := opts.Env["SCION_GROVE_ID"]; projectID != "" {
-				l["scion.project_id"] = projectID
-				l["scion.grove_id"] = projectID
-			} else if projectID := opts.Env["SCION_PROJECT_ID"]; projectID != "" {
-				l["scion.project_id"] = projectID
-				l["scion.grove_id"] = projectID
+			if projectID != "" {
+				for k, v := range projectcompat.ProjectIDLabels(projectID, true) {
+					l[k] = v
+				}
 			}
 			return l
 		}(),
-		Annotations: map[string]string{
-			"scion.project_path": projectDir,
-			"scion.grove_path":   projectDir,
-		},
+		Annotations: projectcompat.ProjectPathLabels(projectDir, true),
 	}
 	id, err := m.Runtime.Run(ctx, runCfg)
 	if err != nil {
@@ -1005,12 +1000,9 @@ func filterWorkspaceVolume(volumes []api.VolumeMount) []api.VolumeMount {
 // It checks the project_id label first (authoritative in hosted mode), then
 // falls back to the project name label.
 func matchAgentProject(a api.AgentInfo, projectName, projectID string) bool {
-	// If we have a projectID, check the scion.project_id or scion.grove_id label (authoritative, grove_id for backward compat)
+	// If we have a projectID, check the canonical project label first.
 	if projectID != "" {
-		if labelProjectID := a.Labels["scion.project_id"]; labelProjectID != "" {
-			return labelProjectID == projectID
-		}
-		if labelProjectID := a.Labels["scion.grove_id"]; labelProjectID != "" {
+		if labelProjectID := projectcompat.ProjectIDFromLabels(a.Labels); labelProjectID != "" {
 			return labelProjectID == projectID
 		}
 		if a.ProjectID != "" {
@@ -1019,10 +1011,7 @@ func matchAgentProject(a api.AgentInfo, projectName, projectID string) bool {
 	}
 	// Fall back to project name matching
 	if projectName != "" {
-		if labelProject := a.Labels["scion.project"]; labelProject != "" {
-			return labelProject == projectName
-		}
-		if labelProject := a.Labels["scion.grove"]; labelProject != "" {
+		if labelProject := projectcompat.ProjectNameFromLabels(a.Labels); labelProject != "" {
 			return labelProject == projectName
 		}
 		if a.Project != "" {

--- a/pkg/projectcompat/labels.go
+++ b/pkg/projectcompat/labels.go
@@ -26,12 +26,52 @@ func ProjectIDFromLabels(labels map[string]string) string {
 	return labels[LabelGroveID]
 }
 
+func ProjectNameFromLabels(labels map[string]string) string {
+	if labels == nil {
+		return ""
+	}
+	if projectName := labels[LabelProject]; projectName != "" {
+		return projectName
+	}
+	return labels[LabelGrove]
+}
+
+func ProjectPathFromLabels(labels map[string]string) string {
+	if labels == nil {
+		return ""
+	}
+	if projectPath := labels[LabelProjectPath]; projectPath != "" {
+		return projectPath
+	}
+	return labels[LabelGrovePath]
+}
+
 func ProjectIDLabels(projectID string, includeLegacy bool) map[string]string {
 	labels := map[string]string{
 		LabelProjectID: projectID,
 	}
 	if includeLegacy {
 		labels[LabelGroveID] = projectID
+	}
+	return labels
+}
+
+func ProjectNameLabels(projectName string, includeLegacy bool) map[string]string {
+	labels := map[string]string{
+		LabelProject: projectName,
+	}
+	if includeLegacy {
+		labels[LabelGrove] = projectName
+	}
+	return labels
+}
+
+func ProjectPathLabels(projectPath string, includeLegacy bool) map[string]string {
+	labels := map[string]string{
+		LabelProjectPath: projectPath,
+	}
+	if includeLegacy {
+		labels[LabelGrovePath] = projectPath
 	}
 	return labels
 }

--- a/pkg/projectcompat/labels_test.go
+++ b/pkg/projectcompat/labels_test.go
@@ -51,6 +51,64 @@ func TestProjectIDLabels(t *testing.T) {
 	}
 }
 
+func TestProjectNameFromLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{"nil", nil, ""},
+		{"canonical", map[string]string{LabelProject: "p1"}, "p1"},
+		{"legacy", map[string]string{LabelGrove: "p1"}, "p1"},
+		{"canonical wins", map[string]string{LabelProject: "p1", LabelGrove: "old"}, "p1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ProjectNameFromLabels(tt.labels); got != tt.want {
+				t.Fatalf("ProjectNameFromLabels() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectPathFromLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{"nil", nil, ""},
+		{"canonical", map[string]string{LabelProjectPath: "/projects/p1"}, "/projects/p1"},
+		{"legacy", map[string]string{LabelGrovePath: "/groves/p1"}, "/groves/p1"},
+		{"canonical wins", map[string]string{LabelProjectPath: "/projects/p1", LabelGrovePath: "/groves/p1"}, "/projects/p1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ProjectPathFromLabels(tt.labels); got != tt.want {
+				t.Fatalf("ProjectPathFromLabels() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectNameAndPathLabels(t *testing.T) {
+	nameLabels := ProjectNameLabels("p1", true)
+	if nameLabels[LabelProject] != "p1" || nameLabels[LabelGrove] != "p1" {
+		t.Fatalf("ProjectNameLabels(includeLegacy=true) = %#v", nameLabels)
+	}
+	if _, ok := ProjectNameLabels("p1", false)[LabelGrove]; ok {
+		t.Fatalf("ProjectNameLabels(includeLegacy=false) included legacy label")
+	}
+
+	pathLabels := ProjectPathLabels("/projects/p1", true)
+	if pathLabels[LabelProjectPath] != "/projects/p1" || pathLabels[LabelGrovePath] != "/projects/p1" {
+		t.Fatalf("ProjectPathLabels(includeLegacy=true) = %#v", pathLabels)
+	}
+	if _, ok := ProjectPathLabels("/projects/p1", false)[LabelGrovePath]; ok {
+		t.Fatalf("ProjectPathLabels(includeLegacy=false) included legacy label")
+	}
+}
+
 func TestCanonicalFieldAliases(t *testing.T) {
 	tests := []struct {
 		in        string

--- a/pkg/projectcompat/topics.go
+++ b/pkg/projectcompat/topics.go
@@ -27,8 +27,12 @@ const (
 	CanonicalTopicPrefix = "scion.project"
 	LegacyTopicPrefix    = "scion.grove"
 
-	LabelProjectID = "scion.project_id"
-	LabelGroveID   = "scion.grove_id"
+	LabelProjectID   = "scion.project_id"
+	LabelGroveID     = "scion.grove_id"
+	LabelProject     = "scion.project"
+	LabelGrove       = "scion.grove"
+	LabelProjectPath = "scion.project_path"
+	LabelGrovePath   = "scion.grove_path"
 )
 
 type TopicKind string

--- a/pkg/runtime/apple_container.go
+++ b/pkg/runtime/apple_container.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 )
 
@@ -191,7 +192,18 @@ func (r *AppleContainerRuntime) List(ctx context.Context, labelFilter map[string
 		if len(labelFilter) > 0 {
 			match := true
 			for k, v := range labelFilter {
-				if lv, ok := c.Configuration.Labels[k]; !ok || lv != v {
+				actual := c.Configuration.Labels[k]
+				if actual == "" {
+					switch k {
+					case projectcompat.LabelProject:
+						actual = projectcompat.ProjectNameFromLabels(c.Configuration.Labels)
+					case projectcompat.LabelProjectID:
+						actual = projectcompat.ProjectIDFromLabels(c.Configuration.Labels)
+					case projectcompat.LabelProjectPath:
+						actual = projectcompat.ProjectPathFromLabels(c.Configuration.Labels)
+					}
+				}
+				if actual != v {
 					match = false
 					break
 				}
@@ -207,9 +219,9 @@ func (r *AppleContainerRuntime) List(ctx context.Context, labelFilter map[string
 			Template:        c.Configuration.Labels["scion.template"],
 			HarnessConfig:   c.Configuration.Labels["scion.harness_config"],
 			HarnessAuth:     c.Configuration.Labels["scion.harness_auth"],
-			Project:         c.Configuration.Labels["scion.grove"],
-			ProjectID:       c.Configuration.Labels["scion.grove_id"],
-			ProjectPath:     c.Configuration.Labels["scion.grove_path"],
+			Project:         projectcompat.ProjectNameFromLabels(c.Configuration.Labels),
+			ProjectID:       projectcompat.ProjectIDFromLabels(c.Configuration.Labels),
+			ProjectPath:     projectcompat.ProjectPathFromLabels(c.Configuration.Labels),
 			Labels:          c.Configuration.Labels,
 			Annotations:     c.Configuration.Labels,
 			ContainerStatus: c.Status,

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -414,8 +414,8 @@ func buildCommonRunArgs(config RunConfig) ([]string, error) {
 
 	// Phase 5: Standard project labels
 	if config.Project != "" {
-		addArg("--label", fmt.Sprintf("scion.project=%s", config.Project))
-		addArg("--label", fmt.Sprintf("scion.grove=%s", config.Project))
+		addArg("--label", fmt.Sprintf("%s=%s", projectcompat.LabelProject, config.Project))
+		addArg("--label", fmt.Sprintf("%s=%s", projectcompat.LabelGrove, config.Project))
 	}
 	if config.ProjectID != "" {
 		addArg("--label", fmt.Sprintf("%s=%s", projectcompat.LabelProjectID, config.ProjectID))

--- a/pkg/runtime/docker.go
+++ b/pkg/runtime/docker.go
@@ -174,12 +174,12 @@ func (r *DockerRuntime) List(ctx context.Context, labelFilter map[string]string)
 			// Fallback for project labels
 			if actual == "" {
 				switch k {
-				case "scion.project":
-					actual = labels["scion.grove"]
-				case "scion.project_id":
-					actual = labels["scion.grove_id"]
-				case "scion.project_path":
-					actual = labels["scion.grove_path"]
+				case projectcompat.LabelProject:
+					actual = projectcompat.ProjectNameFromLabels(labels)
+				case projectcompat.LabelProjectID:
+					actual = projectcompat.ProjectIDFromLabels(labels)
+				case projectcompat.LabelProjectPath:
+					actual = projectcompat.ProjectPathFromLabels(labels)
 				}
 			}
 
@@ -206,20 +206,10 @@ func (r *DockerRuntime) List(ctx context.Context, labelFilter map[string]string)
 				Template:        labels["scion.template"],
 				HarnessConfig:   labels["scion.harness_config"],
 				HarnessAuth:     labels["scion.harness_auth"],
-				Project: func() string {
-					if p := labels["scion.project"]; p != "" {
-						return p
-					}
-					return labels["scion.grove"]
-				}(),
-				ProjectID: projectcompat.ProjectIDFromLabels(labels),
-				ProjectPath: func() string {
-					if p := labels["scion.project_path"]; p != "" {
-						return p
-					}
-					return labels["scion.grove_path"]
-				}(),
-				Runtime: r.Name(),
+				Project:         projectcompat.ProjectNameFromLabels(labels),
+				ProjectID:       projectcompat.ProjectIDFromLabels(labels),
+				ProjectPath:     projectcompat.ProjectPathFromLabels(labels),
+				Runtime:         r.Name(),
 			})
 		}
 	}

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -764,11 +764,7 @@ func (r *KubernetesRuntime) createSharedDirPVCs(ctx context.Context, namespace s
 
 	projectID := projectcompat.ProjectIDFromLabels(config.Labels)
 
-	projectName := config.Labels["scion.project"]
-	if projectName == "" {
-		projectName = config.Labels["scion.grove"]
-	}
-
+	projectName := projectcompat.ProjectNameFromLabels(config.Labels)
 	if projectName == "" {
 		return fmt.Errorf("cannot create shared dir PVCs: missing scion.project or scion.grove label")
 	}
@@ -820,8 +816,6 @@ func (r *KubernetesRuntime) ensureProjectRWXClaim(
 			Name:      pvcName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"scion.project":    projectName,
-				"scion.grove":      projectName,
 				"scion.shared-dir": dirName,
 			},
 		},
@@ -835,6 +829,9 @@ func (r *KubernetesRuntime) ensureProjectRWXClaim(
 		},
 	}
 
+	for k, v := range projectcompat.ProjectNameLabels(projectName, true) {
+		pvc.Labels[k] = v
+	}
 	if projectID != "" {
 		for k, v := range projectcompat.ProjectIDLabels(projectID, true) {
 			pvc.Labels[k] = v
@@ -1423,7 +1420,7 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 			})
 		} else {
 			// Local backend: each shared dir gets its own PVC (existing behavior).
-			projectName := config.Labels["scion.grove"]
+			projectName := projectcompat.ProjectNameFromLabels(config.Labels)
 			pvcName := sharedDirPVCName(projectName, sd.Name)
 			volName := fmt.Sprintf("shared-dir-%d", i)
 
@@ -1842,12 +1839,12 @@ func (r *KubernetesRuntime) List(ctx context.Context, labelFilter map[string]str
 			// Since new pods have both labels and old pods only have grove labels,
 			// filtering by the grove label variant finds both.
 			switch k {
-			case "scion.project":
-				key = "scion.grove"
-			case "scion.project_id":
-				key = "scion.grove_id"
-			case "scion.project_path":
-				key = "scion.grove_path"
+			case projectcompat.LabelProject:
+				key = projectcompat.LabelGrove
+			case projectcompat.LabelProjectID:
+				key = projectcompat.LabelGroveID
+			case projectcompat.LabelProjectPath:
+				key = projectcompat.LabelGrovePath
 			}
 			selectors = append(selectors, fmt.Sprintf("%s=%s", key, v))
 		}
@@ -1903,15 +1900,9 @@ func (r *KubernetesRuntime) List(ctx context.Context, labelFilter map[string]str
 			}
 		}
 
-		projectPath := p.Annotations["scion.project_path"]
+		projectPath := projectcompat.ProjectPathFromLabels(p.Annotations)
 		if projectPath == "" {
-			projectPath = p.Labels["scion.project_path"]
-		}
-		if projectPath == "" {
-			projectPath = p.Annotations["scion.grove_path"]
-		}
-		if projectPath == "" {
-			projectPath = p.Labels["scion.grove_path"]
+			projectPath = projectcompat.ProjectPathFromLabels(p.Labels)
 		}
 
 		var agentImage string
@@ -1923,21 +1914,11 @@ func (r *KubernetesRuntime) List(ctx context.Context, labelFilter map[string]str
 		}
 
 		agents = append(agents, api.AgentInfo{
-			ContainerID: p.Name, // Pod name serves as the container identifier
-			Name:        p.Labels["scion.name"],
-			Template:    p.Labels["scion.template"],
-			Project: func() string {
-				if p := p.Labels["scion.project"]; p != "" {
-					return p
-				}
-				return p.Labels["scion.grove"]
-			}(),
-			ProjectID: func() string {
-				if p := p.Labels["scion.project_id"]; p != "" {
-					return p
-				}
-				return p.Labels["scion.grove_id"]
-			}(),
+			ContainerID:     p.Name, // Pod name serves as the container identifier
+			Name:            p.Labels["scion.name"],
+			Template:        p.Labels["scion.template"],
+			Project:         projectcompat.ProjectNameFromLabels(p.Labels),
+			ProjectID:       projectcompat.ProjectIDFromLabels(p.Labels),
 			ProjectPath:     projectPath,
 			Labels:          p.Labels,
 			Annotations:     p.Annotations,

--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/gcp"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 )
 
@@ -284,7 +285,18 @@ func (r *PodmanRuntime) List(ctx context.Context, labelFilter map[string]string)
 		// Filter by labels if requested
 		match := true
 		for k, v := range labelFilter {
-			if labels[k] != v {
+			actual := labels[k]
+			if actual == "" {
+				switch k {
+				case projectcompat.LabelProject:
+					actual = projectcompat.ProjectNameFromLabels(labels)
+				case projectcompat.LabelProjectID:
+					actual = projectcompat.ProjectIDFromLabels(labels)
+				case projectcompat.LabelProjectPath:
+					actual = projectcompat.ProjectPathFromLabels(labels)
+				}
+			}
+			if actual != v {
 				match = false
 				break
 			}
@@ -310,9 +322,9 @@ func (r *PodmanRuntime) List(ctx context.Context, labelFilter map[string]string)
 				Template:        labels["scion.template"],
 				HarnessConfig:   labels["scion.harness_config"],
 				HarnessAuth:     labels["scion.harness_auth"],
-				Project:         labels["scion.grove"],
-				ProjectID:       labels["scion.grove_id"],
-				ProjectPath:     labels["scion.grove_path"],
+				Project:         projectcompat.ProjectNameFromLabels(labels),
+				ProjectID:       projectcompat.ProjectIDFromLabels(labels),
+				ProjectPath:     projectcompat.ProjectPathFromLabels(labels),
 				Runtime:         r.Name(),
 			})
 		}


### PR DESCRIPTION


What changed: added projectcompat helpers for project name/path labels; normalized Docker, Podman, Apple Container, and Kubernetes runtime label reads/filter handling; consistent canonical-then-legacy dual-write ordering; updated agent launch/match label handling. Bonus: Apple Container/Podman filter fallback bug fixed.

Review: APPROVED (after H1 env var priority fix, M1 simplification, M2 missed site — all resolved).