### PR TITLE
fix: add legacy /groves route wrapper and request body compatibility adapter

### DIFF
--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -3429,12 +3429,10 @@ type RegisterProjectRequest struct {
 	Labels    map[string]string          `json:"labels,omitempty"`
 }
 
-// UnmarshalJSON implements custom unmarshaling to support legacy groveId keys.
+// UnmarshalJSON accepts legacy grove ID aliases at the Hub JSON adapter boundary.
 func (r *RegisterProjectRequest) UnmarshalJSON(data []byte) error {
 	type Alias RegisterProjectRequest
 	aux := &struct {
-		GroveID  string `json:"groveId"`
-		Grove_ID string `json:"grove_id"`
 		*Alias
 	}{
 		Alias: (*Alias)(r),
@@ -3443,11 +3441,11 @@ func (r *RegisterProjectRequest) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if r.ID == "" {
-		if aux.Grove_ID != "" {
-			r.ID = aux.Grove_ID
-		} else if aux.GroveID != "" {
-			r.ID = aux.GroveID
+		legacyID, err := legacyProjectIDFromJSON(data)
+		if err != nil {
+			return err
 		}
+		r.ID = legacyID
 	}
 	return nil
 }

--- a/pkg/hub/handlers_project_test.go
+++ b/pkg/hub/handlers_project_test.go
@@ -2063,3 +2063,51 @@ func TestCreateProject_ListByGitRemote_ReturnsMultiple(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.Len(t, resp.Projects, 2, "listing by git remote should return all matching projects")
 }
+
+func TestProjectRouteDeprecationHeaders(t *testing.T) {
+	srv, _ := testServer(t)
+
+	canonical := doRequest(t, srv, http.MethodGet, "/api/v1/projects", nil)
+	require.Equal(t, http.StatusOK, canonical.Code, "body: %s", canonical.Body.String())
+	assert.Empty(t, canonical.Header().Get("Deprecation"))
+	assert.Empty(t, canonical.Header().Get("Sunset"))
+	assert.Empty(t, canonical.Header().Get("Link"))
+
+	legacy := doRequest(t, srv, http.MethodGet, "/api/v1/groves", nil)
+	require.Equal(t, http.StatusOK, legacy.Code, "body: %s", legacy.Body.String())
+	assert.Equal(t, "true", legacy.Header().Get("Deprecation"))
+	assert.Equal(t, legacyGroveRouteSunset, legacy.Header().Get("Sunset"))
+	assert.Contains(t, legacy.Header().Get("Link"), "/api/v1/projects/")
+}
+
+func TestRegisterProjectRequestLegacyIDAliases(t *testing.T) {
+	var legacyCamel RegisterProjectRequest
+	require.NoError(t, json.Unmarshal([]byte(`{"name":"Legacy","gitRemote":"github.com/acme/legacy","groveId":"legacy-camel"}`), &legacyCamel))
+	assert.Equal(t, "legacy-camel", legacyCamel.ID)
+
+	var legacySnake RegisterProjectRequest
+	require.NoError(t, json.Unmarshal([]byte(`{"name":"Legacy","gitRemote":"github.com/acme/legacy","grove_id":"legacy-snake"}`), &legacySnake))
+	assert.Equal(t, "legacy-snake", legacySnake.ID)
+
+	var canonicalWins RegisterProjectRequest
+	require.NoError(t, json.Unmarshal([]byte(`{"id":"canonical","name":"Canonical","gitRemote":"github.com/acme/canonical","groveId":"legacy"}`), &canonicalWins))
+	assert.Equal(t, "canonical", canonicalWins.ID)
+}
+
+func TestProjectRegisterAcceptsLegacyJSONID(t *testing.T) {
+	srv, _ := testServer(t)
+
+	body := map[string]interface{}{
+		"groveId":   tid("legacy_register_id"),
+		"gitRemote": "https://github.com/test/legacy-register.git",
+		"name":      "Legacy Register",
+	}
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects/register", body)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp RegisterProjectResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.NotNil(t, resp.Project)
+	assert.Equal(t, tid("legacy_register_id"), resp.Project.ID)
+}

--- a/pkg/hub/project_compat.go
+++ b/pkg/hub/project_compat.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
+)
+
+const legacyGroveRouteSunset = "Sun, 01 Nov 2026 00:00:00 GMT"
+
+// handleLegacyGroveRoute marks legacy /api/v1/groves endpoints as deprecated
+// while preserving their existing behavior through the canonical project
+// handlers.
+func (s *Server) handleLegacyGroveRoute(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if projectcompat.DeprecatedGroveRoute(r.URL.Path) {
+			w.Header().Set("Deprecation", "true")
+			w.Header().Set("Sunset", legacyGroveRouteSunset)
+			w.Header().Set("Link", `</api/v1/projects/>; rel="successor-version"`)
+		}
+		h(w, r)
+	}
+}
+
+// legacyProjectIDFromJSON returns the project ID supplied through legacy grove
+// JSON fields. Canonical fields remain decoded by the request-specific struct.
+func legacyProjectIDFromJSON(data []byte) (string, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return "", err
+	}
+
+	for _, key := range []string{"grove_id", "groveId"} {
+		canonical, legacy := projectcompat.CanonicalFieldAliases(key)
+		if !legacy || (canonical != "project_id" && canonical != "projectId") {
+			continue
+		}
+		raw, ok := fields[key]
+		if !ok {
+			continue
+		}
+		var value string
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return "", err
+		}
+		if value != "" {
+			return value, nil
+		}
+	}
+	return "", nil
+}

--- a/pkg/hub/project_compat.go
+++ b/pkg/hub/project_compat.go
@@ -46,10 +46,6 @@ func legacyProjectIDFromJSON(data []byte) (string, error) {
 	}
 
 	for _, key := range []string{"grove_id", "groveId"} {
-		canonical, legacy := projectcompat.CanonicalFieldAliases(key)
-		if !legacy || (canonical != "project_id" && canonical != "projectId") {
-			continue
-		}
 		raw, ok := fields[key]
 		if !ok {
 			continue

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2436,10 +2436,11 @@ func (s *Server) registerRoutes() {
 	// This handler must come before the generic project-by-id handler
 	s.mux.HandleFunc("/api/v1/projects/", s.handleProjectRoutes)
 
-	// Aliases for /api/v1/groves -> /api/v1/projects (Phase 3)
-	s.mux.HandleFunc("/api/v1/groves", s.deprecateLegacyEndpoint(s.handleProjects))
-	s.mux.HandleFunc("/api/v1/groves/register", s.deprecateLegacyEndpoint(s.handleProjectRegister))
-	s.mux.HandleFunc("/api/v1/groves/", s.deprecateLegacyEndpoint(s.handleProjectRoutes))
+	// Legacy /api/v1/groves aliases are external compatibility adapters for
+	// the canonical /api/v1/projects handlers.
+	s.mux.HandleFunc("/api/v1/groves", s.handleLegacyGroveRoute(s.handleProjects))
+	s.mux.HandleFunc("/api/v1/groves/register", s.handleLegacyGroveRoute(s.handleProjectRegister))
+	s.mux.HandleFunc("/api/v1/groves/", s.handleLegacyGroveRoute(s.handleProjectRoutes))
 
 	s.mux.HandleFunc("/api/v1/runtime-brokers", s.handleRuntimeBrokers)
 	s.mux.HandleFunc("/api/v1/runtime-brokers/", s.handleRuntimeBrokerRoutes)
@@ -2772,17 +2773,6 @@ func extractAction(r *http.Request, prefix string) (id, action string) {
 		action = parts[1]
 	}
 	return
-}
-
-// deprecateLegacyEndpoint wraps an http.HandlerFunc with deprecation headers
-// for legacy /groves/ endpoints that have been renamed to /projects/.
-func (s *Server) deprecateLegacyEndpoint(h http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Deprecation", "true")
-		w.Header().Set("Sunset", "Sun, 01 Nov 2026 00:00:00 GMT")
-		w.Header().Set("Link", `</api/v1/projects/>; rel="successor-version"`)
-		h(w, r)
-	}
 }
 
 // handleRuntimeBrokerConnect handles WebSocket upgrade for Runtime Broker control channel.


### PR DESCRIPTION
fix: add legacy /groves route wrapper and request body compatibility adapter

What changed: named legacy /api/v1/groves route wrapper with deprecation headers; centralized groveId/grove_id JSON normalization via Hub adapter helper; focused route/header and legacy JSON tests. Behavior-preserving.
