### PR TITLE
Centralize config project compatibility keys

### DIFF
--- a/pkg/config/koanf.go
+++ b/pkg/config/koanf.go
@@ -22,6 +22,7 @@ import (
 	goruntime "runtime"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/knadh/koanf/parsers/json"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/confmap"
@@ -74,23 +75,19 @@ func LoadSettingsKoanf(projectPath string) (*Settings, error) {
 	//       SCION_HUB_BROKER_ID -> hub.brokerId
 	//       SCION_HUB_BROKER_TOKEN -> hub.brokerToken
 	_ = k.Load(env.Provider("SCION_", ".", func(s string) string {
+		if mapped, ok := projectcompat.EnvProjectIDConfigKey(s, true); ok {
+			return mapped
+		}
 		key := strings.ToLower(strings.TrimPrefix(s, "SCION_"))
 		// Handle nested bucket keys
 		if strings.HasPrefix(key, "bucket_") {
 			return "bucket." + strings.TrimPrefix(key, "bucket_")
-		}
-		// Handle legacy grove_id
-		if key == "grove_id" {
-			return "project_id"
 		}
 		// Handle nested hub keys
 		if strings.HasPrefix(key, "hub_") {
 			subkey := strings.TrimPrefix(key, "hub_")
 			// Convert snake_case to camelCase for specific keys
 			switch subkey {
-			case "grove_id", "project_id":
-				// SCION_HUB_GROVE_ID or SCION_HUB_PROJECT_ID maps to top-level project_id, not hub.projectId
-				return "project_id"
 			case "api_key":
 				return "hub.apiKey"
 			case "broker_id":
@@ -114,24 +111,24 @@ func LoadSettingsKoanf(projectPath string) (*Settings, error) {
 	// take precedence over any top-level project_id inherited from global.
 	// Support both hub.grove_id and hub.project_id from v1 settings.
 	hubProjectID := ""
-	if k.Exists("hub.project_id") {
-		hubProjectID = k.String("hub.project_id")
-	} else if k.Exists("hub.grove_id") {
-		hubProjectID = k.String("hub.grove_id")
+	if k.Exists(projectcompat.ConfigHubProjectIDKey) {
+		hubProjectID = k.String(projectcompat.ConfigHubProjectIDKey)
+	} else if k.Exists(projectcompat.ConfigHubGroveIDKey) {
+		hubProjectID = k.String(projectcompat.ConfigHubGroveIDKey)
 	}
 
 	if hubProjectID != "" {
 		_ = k.Load(confmap.Provider(map[string]interface{}{
-			"project_id": hubProjectID,
+			projectcompat.ConfigProjectIDKey: hubProjectID,
 		}, "."), nil)
 		// Also remap to hub.projectId (camelCase) so the legacy
 		// HubClientConfig.ProjectID field (koanf tag "projectId") is populated.
 		// Without this, GetHubProjectID() returns "" for V1 settings, causing
 		// EnsureHubReady to fall back to the local project_id and loop on
 		// project registration when the hub project ID differs from the local ID.
-		if !k.Exists("hub.projectId") {
+		if !k.Exists(projectcompat.ConfigHubProjectIDJSON) {
 			_ = k.Load(confmap.Provider(map[string]interface{}{
-				"hub.projectId": hubProjectID,
+				projectcompat.ConfigHubProjectIDJSON: hubProjectID,
 			}, "."), nil)
 		}
 	}
@@ -144,7 +141,7 @@ func LoadSettingsKoanf(projectPath string) (*Settings, error) {
 	if projectPath != "" && projectPath != globalDir {
 		if projectID, err := ReadProjectID(projectPath); err == nil && projectID != "" {
 			_ = k.Load(confmap.Provider(map[string]interface{}{
-				"project_id": projectID,
+				projectcompat.ConfigProjectIDKey: projectID,
 			}, "."), nil)
 		}
 	}

--- a/pkg/config/paths.go
+++ b/pkg/config/paths.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 )
 
@@ -27,10 +28,10 @@ const (
 	DotScion  = ".scion"
 	GlobalDir = ".scion"
 
-	ProjectConfigsDir = "project-configs"
-	ProjectsDir       = "projects"
-	GroveConfigsDir   = "grove-configs"
-	GrovesDir         = "groves"
+	ProjectConfigsDir = projectcompat.ProjectConfigsDir
+	ProjectsDir       = projectcompat.ProjectsDir
+	GroveConfigsDir   = projectcompat.GroveConfigsDir
+	GrovesDir         = projectcompat.GrovesDir
 )
 
 // FindProjectRoot walks up the directory tree to find the .scion directory or marker file.

--- a/pkg/config/project_marker.go
+++ b/pkg/config/project_marker.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"gopkg.in/yaml.v3"
 )
 
@@ -186,8 +187,8 @@ func IsOldStyleNonGitProject(scionPath string) bool {
 func IsHubContext() bool {
 	return os.Getenv("SCION_HUB_ENDPOINT") != "" ||
 		os.Getenv("SCION_HUB_URL") != "" ||
-		os.Getenv("SCION_GROVE_ID") != "" ||
-		os.Getenv("SCION_PROJECT_ID") != ""
+		os.Getenv(projectcompat.EnvGroveID) != "" ||
+		os.Getenv(projectcompat.EnvProjectID) != ""
 }
 
 // WriteWorkspaceMarker writes a minimal .scion marker file into a workspace
@@ -219,7 +220,7 @@ func ExtractSlugFromExternalDir(dirName string) string {
 // Checks project-id first, then falls back to grove-id for legacy projects.
 func ReadProjectID(projectDir string) (string, error) {
 	// 1. Try project-id
-	data, err := os.ReadFile(filepath.Join(projectDir, "project-id"))
+	data, err := os.ReadFile(filepath.Join(projectDir, projectcompat.ProjectIDFile))
 	if err == nil {
 		return strings.TrimSpace(string(data)), nil
 	}
@@ -228,7 +229,7 @@ func ReadProjectID(projectDir string) (string, error) {
 	}
 
 	// 2. Fallback to legacy grove-id
-	data, err = os.ReadFile(filepath.Join(projectDir, "grove-id"))
+	data, err = os.ReadFile(filepath.Join(projectDir, projectcompat.GroveIDFile))
 	if err != nil {
 		return "", err
 	}
@@ -237,7 +238,7 @@ func ReadProjectID(projectDir string) (string, error) {
 
 // WriteProjectID writes a project-id file to a git project's .scion directory.
 func WriteProjectID(projectDir string, projectID string) error {
-	return os.WriteFile(filepath.Join(projectDir, "project-id"), []byte(projectID+"\n"), 0644)
+	return os.WriteFile(filepath.Join(projectDir, projectcompat.ProjectIDFile), []byte(projectID+"\n"), 0644)
 }
 
 // GetGitProjectExternalConfigDir returns the external config directory for a git project.

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 	"gopkg.in/yaml.v3"
 )
@@ -552,8 +553,8 @@ func UpdateSetting(projectPath string, key string, value string, global bool) er
 		// Phase 5: Migrate .scion/grove-id to project-id if it exists.
 		// This ensures that subsequent reads prefer the new filename.
 		if projectPath != "" {
-			legacyIDFile := filepath.Join(projectPath, "grove-id")
-			projectIDFile := filepath.Join(projectPath, "project-id")
+			legacyIDFile := filepath.Join(projectPath, projectcompat.GroveIDFile)
+			projectIDFile := filepath.Join(projectPath, projectcompat.ProjectIDFile)
 			if _, err := os.Stat(legacyIDFile); err == nil {
 				if _, err := os.Stat(projectIDFile); os.IsNotExist(err) {
 					_ = os.Rename(legacyIDFile, projectIDFile)
@@ -615,121 +616,123 @@ func updateSettingLegacy(dir string, key string, value string) error {
 	}
 
 	// Update the field
-	switch key {
-	case "project_id", "grove_id":
+	if projectcompat.IsProjectIDConfigKey(key) {
 		current.ProjectID = value
-	case "active_profile":
-		current.ActiveProfile = value
-	case "default_template":
-		current.DefaultTemplate = value
-	case "workspace_path":
-		current.WorkspacePath = value
-	case "bucket.provider":
-		if current.Bucket == nil {
-			current.Bucket = &BucketConfig{}
-		}
-		current.Bucket.Provider = value
-	case "bucket.name":
-		if current.Bucket == nil {
-			current.Bucket = &BucketConfig{}
-		}
-		current.Bucket.Name = value
-	case "bucket.prefix":
-		if current.Bucket == nil {
-			current.Bucket = &BucketConfig{}
-		}
-		current.Bucket.Prefix = value
-	case "hub.endpoint":
-		if current.Hub == nil {
-			current.Hub = &HubClientConfig{}
-		}
-		current.Hub.Endpoint = value
-	case "hub.token":
-		if current.Hub == nil {
-			current.Hub = &HubClientConfig{}
-		}
-		current.Hub.Token = value
-	case "hub.apiKey":
-		if current.Hub == nil {
-			current.Hub = &HubClientConfig{}
-		}
-		current.Hub.APIKey = value
-	case "hub.projectId", "hub.groveId":
+	} else if projectcompat.IsHubProjectIDConfigKey(key) {
 		if current.Hub == nil {
 			current.Hub = &HubClientConfig{}
 		}
 		current.Hub.ProjectID = value
-	case "hub.brokerId":
-		if current.Hub == nil {
-			current.Hub = &HubClientConfig{}
-		}
-		current.Hub.BrokerID = value
-	case "hub.brokerToken":
-		if current.Hub == nil {
-			current.Hub = &HubClientConfig{}
-		}
-		current.Hub.BrokerToken = value
-	case "hub.brokerNickname":
-		if current.Hub == nil {
-			current.Hub = &HubClientConfig{}
-		}
-		current.Hub.BrokerNickname = value
-	case "hub.enabled":
-		if current.Hub == nil {
-			current.Hub = &HubClientConfig{}
-		}
-		enabled := value == "true"
-		current.Hub.Enabled = &enabled
-	case "hub.linked":
-		if current.Hub == nil {
-			current.Hub = &HubClientConfig{}
-		}
-		linked := value == "true"
-		current.Hub.Linked = &linked
-	case "hub.local_only":
-		if current.Hub == nil {
-			current.Hub = &HubClientConfig{}
-		}
-		localOnly := value == "true"
-		current.Hub.LocalOnly = &localOnly
-	case "hub.lastSyncedAt":
-		if current.Hub == nil {
-			current.Hub = &HubClientConfig{}
-		}
-		current.Hub.LastSyncedAt = value
-	case "cli.autohelp":
-		if current.CLI == nil {
-			current.CLI = &CLIConfig{}
-		}
-		autohelp := value == "true"
-		current.CLI.AutoHelp = &autohelp
-	case "cli.mode":
-		if current.CLI == nil {
-			current.CLI = &CLIConfig{}
-		}
-		current.CLI.Mode = value
-	default:
-		// Handle hub_connections.<name>.endpoint keys
-		if strings.HasPrefix(key, "hub_connections.") {
-			parts := strings.SplitN(key, ".", 3)
-			if len(parts) != 3 {
-				return fmt.Errorf("invalid hub_connections key: %s (expected hub_connections.<name>.<field>)", key)
+	} else {
+		switch key {
+		case "active_profile":
+			current.ActiveProfile = value
+		case "default_template":
+			current.DefaultTemplate = value
+		case "workspace_path":
+			current.WorkspacePath = value
+		case "bucket.provider":
+			if current.Bucket == nil {
+				current.Bucket = &BucketConfig{}
 			}
-			connName := parts[1]
-			field := parts[2]
+			current.Bucket.Provider = value
+		case "bucket.name":
+			if current.Bucket == nil {
+				current.Bucket = &BucketConfig{}
+			}
+			current.Bucket.Name = value
+		case "bucket.prefix":
+			if current.Bucket == nil {
+				current.Bucket = &BucketConfig{}
+			}
+			current.Bucket.Prefix = value
+		case "hub.endpoint":
+			if current.Hub == nil {
+				current.Hub = &HubClientConfig{}
+			}
+			current.Hub.Endpoint = value
+		case "hub.token":
+			if current.Hub == nil {
+				current.Hub = &HubClientConfig{}
+			}
+			current.Hub.Token = value
+		case "hub.apiKey":
+			if current.Hub == nil {
+				current.Hub = &HubClientConfig{}
+			}
+			current.Hub.APIKey = value
+		case "hub.brokerId":
+			if current.Hub == nil {
+				current.Hub = &HubClientConfig{}
+			}
+			current.Hub.BrokerID = value
+		case "hub.brokerToken":
+			if current.Hub == nil {
+				current.Hub = &HubClientConfig{}
+			}
+			current.Hub.BrokerToken = value
+		case "hub.brokerNickname":
+			if current.Hub == nil {
+				current.Hub = &HubClientConfig{}
+			}
+			current.Hub.BrokerNickname = value
+		case "hub.enabled":
+			if current.Hub == nil {
+				current.Hub = &HubClientConfig{}
+			}
+			enabled := value == "true"
+			current.Hub.Enabled = &enabled
+		case "hub.linked":
+			if current.Hub == nil {
+				current.Hub = &HubClientConfig{}
+			}
+			linked := value == "true"
+			current.Hub.Linked = &linked
+		case "hub.local_only":
+			if current.Hub == nil {
+				current.Hub = &HubClientConfig{}
+			}
+			localOnly := value == "true"
+			current.Hub.LocalOnly = &localOnly
+		case "hub.lastSyncedAt":
+			if current.Hub == nil {
+				current.Hub = &HubClientConfig{}
+			}
+			current.Hub.LastSyncedAt = value
+		case "cli.autohelp":
+			if current.CLI == nil {
+				current.CLI = &CLIConfig{}
+			}
+			autohelp := value == "true"
+			current.CLI.AutoHelp = &autohelp
+		case "cli.mode":
+			if current.CLI == nil {
+				current.CLI = &CLIConfig{}
+			}
+			current.CLI.Mode = value
+		default:
+			// Handle hub_connections.<name>.endpoint keys
+			if strings.HasPrefix(key, "hub_connections.") {
+				parts := strings.SplitN(key, ".", 3)
+				if len(parts) != 3 {
+					return fmt.Errorf("invalid hub_connections key: %s (expected hub_connections.<name>.<field>)", key)
+				}
+				connName := parts[1]
+				field := parts[2]
 
-			if field != "endpoint" {
-				return fmt.Errorf("unknown hub_connections field: %s (supported: endpoint)", field)
-			}
+				if field != "endpoint" {
+					return fmt.Errorf("unknown hub_connections field: %s (supported: endpoint)", field)
+				}
 
-			if current.HubConnections == nil {
-				current.HubConnections = make(map[string]HubConnectionConfig)
+				if current.HubConnections == nil {
+					current.HubConnections = make(map[string]HubConnectionConfig)
+				}
+				conn := current.HubConnections[connName]
+				conn.Endpoint = value
+				current.HubConnections[connName] = conn
+			} else {
+				return fmt.Errorf("unknown or complex setting key: %s (manual edit recommended for registries)", key)
 			}
-			conn := current.HubConnections[connName]
-			conn.Endpoint = value
-			current.HubConnections[connName] = conn
-		} else {
-			return fmt.Errorf("unknown or complex setting key: %s (manual edit recommended for registries)", key)
 		}
 	}
 
@@ -754,9 +757,16 @@ func updateSettingLegacy(dir string, key string, value string) error {
 }
 
 func GetSettingValue(s *Settings, key string) (string, error) {
-	switch key {
-	case "project_id", "grove_id":
+	if projectcompat.IsProjectIDConfigKey(key) {
 		return s.ProjectID, nil
+	}
+	if projectcompat.IsHubProjectIDConfigKey(key) {
+		if s.Hub != nil {
+			return s.Hub.ProjectID, nil
+		}
+		return "", nil
+	}
+	switch key {
 	case "active_profile":
 		return s.ActiveProfile, nil
 	case "default_template":
@@ -789,11 +799,6 @@ func GetSettingValue(s *Settings, key string) (string, error) {
 	case "hub.apiKey":
 		if s.Hub != nil {
 			return s.Hub.APIKey, nil
-		}
-		return "", nil
-	case "hub.projectId", "hub.groveId":
-		if s.Hub != nil {
-			return s.Hub.ProjectID, nil
 		}
 		return "", nil
 	case "hub.brokerId":

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/confmap"
 	"github.com/knadh/koanf/providers/env"
@@ -898,7 +899,7 @@ func LoadVersionedSettings(projectPath string) (*VersionedSettings, error) {
 		if projectPath != globalDir {
 			if projectID, err := ReadProjectID(projectPath); err == nil && projectID != "" {
 				_ = k.Load(confmap.Provider(map[string]interface{}{
-					"hub.grove_id": projectID,
+					projectcompat.ConfigHubGroveIDKey: projectID,
 				}, "."), nil)
 			}
 		}
@@ -906,9 +907,9 @@ func LoadVersionedSettings(projectPath string) (*VersionedSettings, error) {
 
 	// Remap hub.project_id to hub.grove_id for backward compatibility with V1 structs.
 	// SCION_HUB_PROJECT_ID maps to hub.project_id via versionedEnvKeyMapper.
-	if k.Exists("hub.project_id") && !k.Exists("hub.grove_id") {
+	if k.Exists(projectcompat.ConfigHubProjectIDKey) && !k.Exists(projectcompat.ConfigHubGroveIDKey) {
 		_ = k.Load(confmap.Provider(map[string]interface{}{
-			"hub.grove_id": k.String("hub.project_id"),
+			projectcompat.ConfigHubGroveIDKey: k.String(projectcompat.ConfigHubProjectIDKey),
 		}, "."), nil)
 	}
 
@@ -929,6 +930,9 @@ func LoadVersionedSettings(projectPath string) (*VersionedSettings, error) {
 // versionedEnvKeyMapper maps SCION_* environment variables to versioned settings keys.
 // All keys are snake_case so no camelCase conversion is needed.
 func versionedEnvKeyMapper(s string) string {
+	if mapped, ok := projectcompat.EnvProjectIDConfigKey(s, false); ok {
+		return mapped
+	}
 	key := strings.ToLower(strings.TrimPrefix(s, "SCION_"))
 
 	// Handle nested hub keys (single level: hub.endpoint, hub.grove_id, etc.)
@@ -1908,6 +1912,14 @@ func UpdateVersionedSetting(dir string, key string, value string) error {
 		return err
 	}
 
+	if projectcompat.IsProjectIDConfigKey(key) || projectcompat.IsHubProjectIDConfigKey(key) {
+		if vs.Hub == nil {
+			vs.Hub = &V1HubClientConfig{}
+		}
+		vs.Hub.ProjectID = value
+		return SaveVersionedSettings(dir, vs)
+	}
+
 	switch key {
 	// --- Direct mappings (same in both formats) ---
 	case "active_profile":
@@ -1927,13 +1939,6 @@ func UpdateVersionedSetting(dir string, key string, value string) error {
 		autohelp := value == "true"
 		vs.CLI.AutoHelp = &autohelp
 
-	// --- grove_id: top-level in legacy, hub.grove_id in v1 ---
-	case "project_id", "grove_id":
-		if vs.Hub == nil {
-			vs.Hub = &V1HubClientConfig{}
-		}
-		vs.Hub.ProjectID = value
-
 	// --- Hub client settings ---
 	case "hub.enabled":
 		if vs.Hub == nil {
@@ -1952,11 +1957,6 @@ func UpdateVersionedSetting(dir string, key string, value string) error {
 			vs.Hub = &V1HubClientConfig{}
 		}
 		vs.Hub.Endpoint = value
-	case "hub.project_id", "hub.grove_id", "hub.projectId", "hub.groveId":
-		if vs.Hub == nil {
-			vs.Hub = &V1HubClientConfig{}
-		}
-		vs.Hub.ProjectID = value
 	case "hub.local_only":
 		if vs.Hub == nil {
 			vs.Hub = &V1HubClientConfig{}
@@ -2014,6 +2014,13 @@ func UpdateVersionedSetting(dir string, key string, value string) error {
 // GetVersionedSettingValue retrieves a specific setting value from a VersionedSettings struct.
 // It mirrors the keys supported by UpdateVersionedSetting for read access.
 func GetVersionedSettingValue(vs *VersionedSettings, key string) (string, error) {
+	if projectcompat.IsProjectIDConfigKey(key) || projectcompat.IsHubProjectIDConfigKey(key) {
+		if vs.Hub != nil {
+			return vs.Hub.ProjectID, nil
+		}
+		return "", nil
+	}
+
 	switch key {
 	case "active_profile":
 		return vs.ActiveProfile, nil
@@ -2031,11 +2038,6 @@ func GetVersionedSettingValue(vs *VersionedSettings, key string) (string, error)
 				return "true", nil
 			}
 			return "false", nil
-		}
-		return "", nil
-	case "project_id", "grove_id":
-		if vs.Hub != nil {
-			return vs.Hub.ProjectID, nil
 		}
 		return "", nil
 	case "hub.enabled":
@@ -2057,11 +2059,6 @@ func GetVersionedSettingValue(vs *VersionedSettings, key string) (string, error)
 	case "hub.endpoint":
 		if vs.Hub != nil {
 			return vs.Hub.Endpoint, nil
-		}
-		return "", nil
-	case "hub.project_id", "hub.grove_id", "hub.projectId", "hub.groveId":
-		if vs.Hub != nil {
-			return vs.Hub.ProjectID, nil
 		}
 		return "", nil
 	case "hub.local_only":

--- a/pkg/projectcompat/config.go
+++ b/pkg/projectcompat/config.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projectcompat
+
+const (
+	ConfigProjectIDKey     = "project_id"
+	ConfigGroveIDKey       = "grove_id"
+	ConfigHubProjectIDKey  = "hub.project_id"
+	ConfigHubProjectIDJSON = "hub.projectId"
+	ConfigHubGroveIDKey    = "hub.grove_id"
+	ConfigHubGroveIDJSON   = "hub.groveId"
+
+	EnvProjectID    = "SCION_PROJECT_ID"
+	EnvGroveID      = "SCION_GROVE_ID"
+	EnvHubProjectID = "SCION_HUB_PROJECT_ID"
+	EnvHubGroveID   = "SCION_HUB_GROVE_ID"
+
+	ProjectIDFile = "project-id"
+	GroveIDFile   = "grove-id"
+
+	ProjectConfigsDir = "project-configs"
+	GroveConfigsDir   = "grove-configs"
+	ProjectsDir       = "projects"
+	GrovesDir         = "groves"
+)
+
+func IsProjectIDConfigKey(key string) bool {
+	return key == ConfigProjectIDKey || key == ConfigGroveIDKey
+}
+
+func IsHubProjectIDConfigKey(key string) bool {
+	switch key {
+	case ConfigHubProjectIDKey, ConfigHubProjectIDJSON, ConfigHubGroveIDKey, ConfigHubGroveIDJSON:
+		return true
+	default:
+		return false
+	}
+}
+
+func CanonicalConfigKey(key string) (canonical string, legacy bool) {
+	switch {
+	case IsProjectIDConfigKey(key):
+		return ConfigProjectIDKey, key == ConfigGroveIDKey
+	case IsHubProjectIDConfigKey(key):
+		return ConfigHubProjectIDKey, key == ConfigHubGroveIDKey || key == ConfigHubGroveIDJSON
+	default:
+		return CanonicalFieldAliases(key)
+	}
+}
+
+func EnvProjectIDConfigKey(envName string, hubProjectAsTopLevel bool) (string, bool) {
+	switch envName {
+	case EnvProjectID, EnvGroveID:
+		if envName == EnvGroveID && !hubProjectAsTopLevel {
+			return ConfigGroveIDKey, true
+		}
+		return ConfigProjectIDKey, true
+	case EnvHubProjectID, EnvHubGroveID:
+		if hubProjectAsTopLevel {
+			return ConfigProjectIDKey, true
+		}
+		if envName == EnvHubGroveID {
+			return ConfigHubGroveIDKey, true
+		}
+		return ConfigHubProjectIDKey, true
+	default:
+		return "", false
+	}
+}

--- a/pkg/projectcompat/config_test.go
+++ b/pkg/projectcompat/config_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projectcompat
+
+import "testing"
+
+func TestCanonicalConfigKey(t *testing.T) {
+	tests := []struct {
+		key       string
+		canonical string
+		legacy    bool
+	}{
+		{ConfigProjectIDKey, ConfigProjectIDKey, false},
+		{ConfigGroveIDKey, ConfigProjectIDKey, true},
+		{ConfigHubProjectIDKey, ConfigHubProjectIDKey, false},
+		{ConfigHubProjectIDJSON, ConfigHubProjectIDKey, false},
+		{ConfigHubGroveIDKey, ConfigHubProjectIDKey, true},
+		{ConfigHubGroveIDJSON, ConfigHubProjectIDKey, true},
+		{"hub.endpoint", "hub.endpoint", false},
+	}
+
+	for _, tt := range tests {
+		canonical, legacy := CanonicalConfigKey(tt.key)
+		if canonical != tt.canonical || legacy != tt.legacy {
+			t.Fatalf("CanonicalConfigKey(%q) = (%q, %v), want (%q, %v)", tt.key, canonical, legacy, tt.canonical, tt.legacy)
+		}
+	}
+}
+
+func TestEnvProjectIDConfigKey(t *testing.T) {
+	tests := []struct {
+		name                 string
+		hubProjectAsTopLevel bool
+		want                 string
+		ok                   bool
+	}{
+		{EnvProjectID, true, ConfigProjectIDKey, true},
+		{EnvGroveID, true, ConfigProjectIDKey, true},
+		{EnvHubProjectID, true, ConfigProjectIDKey, true},
+		{EnvHubGroveID, true, ConfigProjectIDKey, true},
+		{EnvProjectID, false, ConfigProjectIDKey, true},
+		{EnvGroveID, false, ConfigGroveIDKey, true},
+		{EnvHubProjectID, false, ConfigHubProjectIDKey, true},
+		{EnvHubGroveID, false, ConfigHubGroveIDKey, true},
+		{"SCION_HUB_ENDPOINT", false, "", false},
+	}
+
+	for _, tt := range tests {
+		got, ok := EnvProjectIDConfigKey(tt.name, tt.hubProjectAsTopLevel)
+		if got != tt.want || ok != tt.ok {
+			t.Fatalf("EnvProjectIDConfigKey(%q, %v) = (%q, %v), want (%q, %v)", tt.name, tt.hubProjectAsTopLevel, got, ok, tt.want, tt.ok)
+		}
+	}
+}


### PR DESCRIPTION
Summary\n- add config-facing project/grove compatibility constants and helper predicates in pkg/projectcompat\n- route config env mapping, settings get/update project ID checks, and marker filename/path constants through shared helpers\n- preserve existing v1 behavior, including legacy hub.grove_id persistence and legacy marker/env acceptance\n\nTracking: #217\n\n## Verification\n- env -u SCION_PROJECT_ID -u SCION_HUB_PROJECT_ID -u SCION_GROVE_ID -u SCION_HUB_GROVE_ID go test ./pkg/projectcompat ./pkg/config\n- hack/check-project-compat-literals.sh