### PR TITLE
Fix file badge size inconsistency and missing settings page titles

### DIFF
--- a/web/src/components/app-shell.ts
+++ b/web/src/components/app-shell.ts
@@ -339,6 +339,12 @@ export class ScionApp extends LitElement {
     if (this.currentPath.startsWith('/brokers/')) {
       return 'Broker';
     }
+    if (this.currentPath.match(/^\/settings\/harness-configs\/[^/]+$/)) {
+      return 'Harness Config';
+    }
+    if (this.currentPath.match(/^\/settings\/templates\/[^/]+$/)) {
+      return 'Template';
+    }
     if (this.currentPath.match(/^\/admin\/groups\/[^/]+$/)) {
       return 'Group';
     }

--- a/web/src/components/shared/file-browser.ts
+++ b/web/src/components/shared/file-browser.ts
@@ -1018,7 +1018,8 @@ export class ScionFileBrowser extends LitElement {
       countLabel = `${this.files.length.toLocaleString()} of ${this.totalCount.toLocaleString()} files${sizeStr} · most recent`;
     } else {
       const n = base.length;
-      const sizeStr = this.totalSize > 0 ? ` (${formatFileSize(this.totalSize)})` : '';
+      const visibleSize = base.reduce((sum, f) => sum + f.size, 0);
+      const sizeStr = visibleSize > 0 ? ` (${formatFileSize(visibleSize)})` : '';
       countLabel = `${n} file${n !== 1 ? 's' : ''}${sizeStr}`;
     }
 

--- a/web/src/components/shared/file-browser.ts
+++ b/web/src/components/shared/file-browser.ts
@@ -1018,7 +1018,7 @@ export class ScionFileBrowser extends LitElement {
       countLabel = `${this.files.length.toLocaleString()} of ${this.totalCount.toLocaleString()} files${sizeStr} · most recent`;
     } else {
       const n = base.length;
-      const visibleSize = base.reduce((sum, f) => sum + f.size, 0);
+      const visibleSize = base.reduce((sum, f) => sum + (f.size ?? 0), 0);
       const sizeStr = visibleSize > 0 ? ` (${formatFileSize(visibleSize)})` : '';
       countLabel = `${n} file${n !== 1 ? 's' : ''}${sizeStr}`;
     }


### PR DESCRIPTION
Compute displayed file size from the visible (filtered) file list instead of the unfiltered API total, so count and size stay consistent when dot files are hidden. Add getPageTitle() patterns for /settings/harness-configs and /settings/templates detail routes to avoid "Page Not Found" flash.

Closes #222

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
