### PR TITLE
Add challenge token auth to test-login endpoint

### DIFF
--- a/pkg/hub/handlers_test_login.go
+++ b/pkg/hub/handlers_test_login.go
@@ -61,12 +61,15 @@ func (ws *WebServer) handleTestLogin(w http.ResponseWriter, r *http.Request) {
 	// Validate test-login challenge token.
 	// Callers must present a short-lived JWT signed with the hub's user
 	// signing key and scoped to the "scion-test-login" audience.
+	// Per RFC 7235 the auth scheme is case-insensitive; we also tolerate
+	// multiple spaces between scheme and token via strings.Fields.
 	authHeader := r.Header.Get("Authorization")
-	if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
+	authParts := strings.Fields(authHeader)
+	if len(authParts) != 2 || !strings.EqualFold(authParts[0], "bearer") {
 		http.Error(w, "authorization required: Bearer <test-login-token>", http.StatusUnauthorized)
 		return
 	}
-	challengeToken := strings.TrimPrefix(authHeader, "Bearer ")
+	challengeToken := authParts[1]
 	if err := ws.userTokenSvc.ValidateTestLoginToken(challengeToken); err != nil {
 		slog.Debug("test-login: invalid challenge token", "error", err)
 		http.Error(w, "invalid test-login token", http.StatusUnauthorized)

--- a/pkg/hub/handlers_test_login.go
+++ b/pkg/hub/handlers_test_login.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
@@ -54,6 +55,21 @@ func (ws *WebServer) handleTestLogin(w http.ResponseWriter, r *http.Request) {
 
 	if ws.store == nil || ws.userTokenSvc == nil {
 		http.Error(w, "hub services not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	// Validate test-login challenge token.
+	// Callers must present a short-lived JWT signed with the hub's user
+	// signing key and scoped to the "scion-test-login" audience.
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
+		http.Error(w, "authorization required: Bearer <test-login-token>", http.StatusUnauthorized)
+		return
+	}
+	challengeToken := strings.TrimPrefix(authHeader, "Bearer ")
+	if err := ws.userTokenSvc.ValidateTestLoginToken(challengeToken); err != nil {
+		slog.Debug("test-login: invalid challenge token", "error", err)
+		http.Error(w, "invalid test-login token", http.StatusUnauthorized)
 		return
 	}
 

--- a/pkg/hub/handlers_test_login_test.go
+++ b/pkg/hub/handlers_test_login_test.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,7 +61,9 @@ func (s *testLoginStore) GetGroupBySlug(_ context.Context, _ string) (*store.Gro
 	return nil, fmt.Errorf("not found")
 }
 
-func newTestLoginWebServer(t *testing.T, enableTestLogin bool) *WebServer {
+// newTestLoginWebServer creates a WebServer for test-login tests and returns
+// the UserTokenService so callers can mint challenge tokens.
+func newTestLoginWebServer(t *testing.T, enableTestLogin bool) (*WebServer, *UserTokenService) {
 	t.Helper()
 	cfg := WebServerConfig{
 		EnableTestLogin: enableTestLogin,
@@ -69,15 +73,25 @@ func newTestLoginWebServer(t *testing.T, enableTestLogin bool) *WebServer {
 	require.NoError(t, err)
 	ws.SetUserTokenService(tokenSvc)
 	ws.SetStore(newTestLoginStore())
-	return ws
+	return ws, tokenSvc
+}
+
+// testLoginAuthHeader mints a valid test-login challenge token and returns
+// the value for the Authorization header ("Bearer <token>").
+func testLoginAuthHeader(t *testing.T, svc *UserTokenService) string {
+	t.Helper()
+	token, err := svc.GenerateTestLoginToken("test")
+	require.NoError(t, err)
+	return "Bearer " + token
 }
 
 func TestHandleTestLogin_Success(t *testing.T) {
-	ws := newTestLoginWebServer(t, true)
+	ws, tokenSvc := newTestLoginWebServer(t, true)
 
 	body := `{"email":"test@example.com","role":"admin","displayName":"Test User"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", testLoginAuthHeader(t, tokenSvc))
 	rec := httptest.NewRecorder()
 
 	ws.handleTestLogin(rec, req)
@@ -106,11 +120,12 @@ func TestHandleTestLogin_Success(t *testing.T) {
 }
 
 func TestHandleTestLogin_DefaultRole(t *testing.T) {
-	ws := newTestLoginWebServer(t, true)
+	ws, tokenSvc := newTestLoginWebServer(t, true)
 
 	body := `{"email":"member@example.com"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", testLoginAuthHeader(t, tokenSvc))
 	rec := httptest.NewRecorder()
 
 	ws.handleTestLogin(rec, req)
@@ -124,11 +139,12 @@ func TestHandleTestLogin_DefaultRole(t *testing.T) {
 }
 
 func TestHandleTestLogin_Disabled(t *testing.T) {
-	ws := newTestLoginWebServer(t, false)
+	ws, tokenSvc := newTestLoginWebServer(t, false)
 
 	body := `{"email":"test@example.com","role":"admin"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", testLoginAuthHeader(t, tokenSvc))
 	rec := httptest.NewRecorder()
 
 	ws.handleTestLogin(rec, req)
@@ -137,7 +153,7 @@ func TestHandleTestLogin_Disabled(t *testing.T) {
 }
 
 func TestHandleTestLogin_MethodNotAllowed(t *testing.T) {
-	ws := newTestLoginWebServer(t, true)
+	ws, _ := newTestLoginWebServer(t, true)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/test-login", nil)
 	rec := httptest.NewRecorder()
@@ -148,11 +164,12 @@ func TestHandleTestLogin_MethodNotAllowed(t *testing.T) {
 }
 
 func TestHandleTestLogin_MissingEmail(t *testing.T) {
-	ws := newTestLoginWebServer(t, true)
+	ws, tokenSvc := newTestLoginWebServer(t, true)
 
 	body := `{"role":"admin"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", testLoginAuthHeader(t, tokenSvc))
 	rec := httptest.NewRecorder()
 
 	ws.handleTestLogin(rec, req)
@@ -161,11 +178,12 @@ func TestHandleTestLogin_MissingEmail(t *testing.T) {
 }
 
 func TestHandleTestLogin_InvalidRole(t *testing.T) {
-	ws := newTestLoginWebServer(t, true)
+	ws, tokenSvc := newTestLoginWebServer(t, true)
 
 	body := `{"email":"test@example.com","role":"superadmin"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", testLoginAuthHeader(t, tokenSvc))
 	rec := httptest.NewRecorder()
 
 	ws.handleTestLogin(rec, req)
@@ -174,10 +192,11 @@ func TestHandleTestLogin_InvalidRole(t *testing.T) {
 }
 
 func TestHandleTestLogin_InvalidJSON(t *testing.T) {
-	ws := newTestLoginWebServer(t, true)
+	ws, tokenSvc := newTestLoginWebServer(t, true)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", testLoginAuthHeader(t, tokenSvc))
 	rec := httptest.NewRecorder()
 
 	ws.handleTestLogin(rec, req)
@@ -186,7 +205,7 @@ func TestHandleTestLogin_InvalidJSON(t *testing.T) {
 }
 
 func TestHandleTestLogin_ExistingUser(t *testing.T) {
-	ws := newTestLoginWebServer(t, true)
+	ws, tokenSvc := newTestLoginWebServer(t, true)
 
 	// Pre-populate a user
 	mockStore := ws.store.(*testLoginStore)
@@ -202,6 +221,7 @@ func TestHandleTestLogin_ExistingUser(t *testing.T) {
 	body := `{"email":"existing@example.com","role":"admin","displayName":"New Name"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", testLoginAuthHeader(t, tokenSvc))
 	rec := httptest.NewRecorder()
 
 	ws.handleTestLogin(rec, req)
@@ -217,11 +237,12 @@ func TestHandleTestLogin_ExistingUser(t *testing.T) {
 func TestHandleTestLogin_AllRoles(t *testing.T) {
 	for _, role := range []string{"admin", "member", "viewer"} {
 		t.Run(role, func(t *testing.T) {
-			ws := newTestLoginWebServer(t, true)
+			ws, tokenSvc := newTestLoginWebServer(t, true)
 
 			body := fmt.Sprintf(`{"email":"user@example.com","role":"%s"}`, role)
 			req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", testLoginAuthHeader(t, tokenSvc))
 			rec := httptest.NewRecorder()
 
 			ws.handleTestLogin(rec, req)
@@ -233,4 +254,130 @@ func TestHandleTestLogin_AllRoles(t *testing.T) {
 			assert.Equal(t, role, resp.User.Role)
 		})
 	}
+}
+
+// --- Auth failure tests ---
+
+func TestHandleTestLogin_MissingAuth(t *testing.T) {
+	ws, _ := newTestLoginWebServer(t, true)
+
+	body := `{"email":"test@example.com","role":"admin"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	// No Authorization header
+	rec := httptest.NewRecorder()
+
+	ws.handleTestLogin(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "authorization required")
+}
+
+func TestHandleTestLogin_InvalidToken(t *testing.T) {
+	ws, _ := newTestLoginWebServer(t, true)
+
+	body := `{"email":"test@example.com","role":"admin"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer not-a-valid-jwt")
+	rec := httptest.NewRecorder()
+
+	ws.handleTestLogin(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid test-login token")
+}
+
+func TestHandleTestLogin_WrongSigningKey(t *testing.T) {
+	ws, _ := newTestLoginWebServer(t, true)
+
+	// Mint a token with a different signing key
+	otherSvc, err := NewUserTokenService(UserTokenConfig{})
+	require.NoError(t, err)
+	token, err := otherSvc.GenerateTestLoginToken("attacker")
+	require.NoError(t, err)
+
+	body := `{"email":"test@example.com","role":"admin"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	ws.handleTestLogin(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid test-login token")
+}
+
+func TestHandleTestLogin_WrongAudience(t *testing.T) {
+	ws, tokenSvc := newTestLoginWebServer(t, true)
+
+	// Mint a regular user access token (audience "scion-hub-api") instead of
+	// a test-login token (audience "scion-test-login").
+	userToken, _, _, err := tokenSvc.GenerateTokenPair(
+		"uid", "test@example.com", "Test", "admin", ClientTypeWeb,
+	)
+	require.NoError(t, err)
+
+	body := `{"email":"test@example.com","role":"admin"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+userToken)
+	rec := httptest.NewRecorder()
+
+	ws.handleTestLogin(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid test-login token")
+}
+
+func TestHandleTestLogin_ExpiredToken(t *testing.T) {
+	ws, _ := newTestLoginWebServer(t, true)
+
+	// Manually create an expired test-login token using the same signing key.
+	// We reach into the UserTokenService's signer to build an expired JWT.
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.HS256, Key: ws.userTokenSvc.config.SigningKey},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	require.NoError(t, err)
+
+	past := time.Now().Add(-10 * time.Minute)
+	claims := jwt.Claims{
+		Issuer:    UserTokenIssuer,
+		Subject:   "test",
+		Audience:  jwt.Audience{TestLoginAudience},
+		IssuedAt:  jwt.NewNumericDate(past),
+		Expiry:    jwt.NewNumericDate(past.Add(5 * time.Minute)), // expired 5 min ago
+		NotBefore: jwt.NewNumericDate(past),
+		ID:        "expired-test-id",
+	}
+	token, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+
+	body := `{"email":"test@example.com","role":"admin"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	ws.handleTestLogin(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid test-login token")
+}
+
+func TestHandleTestLogin_AuthNotBearer(t *testing.T) {
+	ws, _ := newTestLoginWebServer(t, true)
+
+	body := `{"email":"test@example.com","role":"admin"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	rec := httptest.NewRecorder()
+
+	ws.handleTestLogin(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "authorization required")
 }

--- a/pkg/hub/handlers_test_login_test.go
+++ b/pkg/hub/handlers_test_login_test.go
@@ -381,3 +381,58 @@ func TestHandleTestLogin_AuthNotBearer(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	assert.Contains(t, rec.Body.String(), "authorization required")
 }
+
+func TestHandleTestLogin_BearerCaseInsensitive(t *testing.T) {
+	ws, tokenSvc := newTestLoginWebServer(t, true)
+
+	token, err := tokenSvc.GenerateTestLoginToken("test")
+	require.NoError(t, err)
+
+	// RFC 7235: auth scheme is case-insensitive
+	for _, scheme := range []string{"bearer", "BEARER", "Bearer"} {
+		t.Run(scheme, func(t *testing.T) {
+			body := `{"email":"ci@example.com","role":"member"}`
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", scheme+" "+token)
+			rec := httptest.NewRecorder()
+
+			ws.handleTestLogin(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Code, "scheme %q should be accepted", scheme)
+		})
+	}
+}
+
+func TestHandleTestLogin_NoExpiryClaim(t *testing.T) {
+	ws, _ := newTestLoginWebServer(t, true)
+
+	// Craft a token with no exp claim to verify it is rejected.
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.HS256, Key: ws.userTokenSvc.config.SigningKey},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	require.NoError(t, err)
+
+	now := time.Now()
+	claims := jwt.Claims{
+		Issuer:   UserTokenIssuer,
+		Subject:  "test",
+		Audience: jwt.Audience{TestLoginAudience},
+		IssuedAt: jwt.NewNumericDate(now),
+		// Expiry intentionally omitted
+	}
+	token, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+
+	body := `{"email":"test@example.com","role":"admin"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/test-login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	ws.handleTestLogin(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid test-login token")
+}

--- a/pkg/hub/usertoken.go
+++ b/pkg/hub/usertoken.go
@@ -328,6 +328,13 @@ func (s *UserTokenService) ValidateTestLoginToken(tokenString string) error {
 		return fmt.Errorf("failed to verify token: %w", err)
 	}
 
+	// go-jose only validates exp when it is present — a token without exp
+	// would pass and never expire. Require it explicitly so a challenge
+	// token cannot be replayed indefinitely.
+	if claims.Expiry == nil {
+		return fmt.Errorf("token validation failed: missing exp claim")
+	}
+
 	expected := jwt.Expected{
 		Issuer:      UserTokenIssuer,
 		AnyAudience: jwt.Audience{TestLoginAudience},

--- a/pkg/hub/usertoken.go
+++ b/pkg/hub/usertoken.go
@@ -32,12 +32,20 @@ const (
 	UserTokenIssuer = "scion-hub"
 	// UserTokenAudience is the audience claim for user tokens.
 	UserTokenAudience = "scion-hub-api"
+	// TestLoginAudience is the audience claim for test-login challenge tokens.
+	// It is distinct from UserTokenAudience so a test-login token cannot be
+	// used as a regular access token and vice versa.
+	TestLoginAudience = "scion-test-login"
 	// DefaultAccessTokenDuration is the default validity for access tokens.
 	DefaultAccessTokenDuration = 15 * time.Minute
 	// DefaultCLIAccessTokenDuration is the longer validity for CLI access tokens.
 	DefaultCLIAccessTokenDuration = 30 * 24 * time.Hour // 30 days
 	// DefaultRefreshTokenDuration is the default validity for refresh tokens.
 	DefaultRefreshTokenDuration = 7 * 24 * time.Hour // 7 days
+	// DefaultTestLoginTokenDuration is the default validity for test-login
+	// challenge tokens. Kept short because these are single-use-ish tokens
+	// minted immediately before calling the test-login endpoint.
+	DefaultTestLoginTokenDuration = 5 * time.Minute
 )
 
 // UserTokenType represents the type of user token.
@@ -279,6 +287,58 @@ func (s *UserTokenService) GetTokenExpiry(tokenString string) (time.Time, error)
 	}
 
 	return claims.Expiry.Time(), nil
+}
+
+// GenerateTestLoginToken mints a short-lived JWT for authenticating to the
+// test-login endpoint. The token uses the same signing key as user tokens
+// but a dedicated audience ("scion-test-login") so it cannot be used as a
+// regular access token and vice versa.
+func (s *UserTokenService) GenerateTestLoginToken(subject string) (string, error) {
+	now := time.Now()
+
+	claims := jwt.Claims{
+		Issuer:    UserTokenIssuer,
+		Subject:   subject,
+		Audience:  jwt.Audience{TestLoginAudience},
+		IssuedAt:  jwt.NewNumericDate(now),
+		Expiry:    jwt.NewNumericDate(now.Add(DefaultTestLoginTokenDuration)),
+		NotBefore: jwt.NewNumericDate(now),
+		ID:        generateUserTokenID(),
+	}
+
+	token, err := jwt.Signed(s.signer).Claims(claims).Serialize()
+	if err != nil {
+		return "", fmt.Errorf("failed to sign test-login token: %w", err)
+	}
+
+	return token, nil
+}
+
+// ValidateTestLoginToken validates a test-login challenge JWT. It verifies
+// the signature, issuer, audience ("scion-test-login"), and expiry. Returns
+// nil on success or an error describing the validation failure.
+func (s *UserTokenService) ValidateTestLoginToken(tokenString string) error {
+	token, err := jwt.ParseSigned(tokenString, []jose.SignatureAlgorithm{jose.HS256})
+	if err != nil {
+		return fmt.Errorf("failed to parse token: %w", err)
+	}
+
+	var claims jwt.Claims
+	if err := token.Claims(s.config.SigningKey, &claims); err != nil {
+		return fmt.Errorf("failed to verify token: %w", err)
+	}
+
+	expected := jwt.Expected{
+		Issuer:      UserTokenIssuer,
+		AnyAudience: jwt.Audience{TestLoginAudience},
+		Time:        time.Now(),
+	}
+
+	if err := claims.Validate(expected); err != nil {
+		return fmt.Errorf("token validation failed: %w", err)
+	}
+
+	return nil
 }
 
 // generateUserTokenID generates a unique token ID.


### PR DESCRIPTION
The test-login endpoint (POST /api/v1/auth/test-login) was protected only by the --enable-test-login feature flag, with no request-level authentication. Any client that could reach the hub could create users with arbitrary roles.

Add a JWT-based challenge token requirement: callers must present a short-lived token (5min TTL) signed with the hub's user signing key and scoped to the "scion-test-login" audience. The dedicated audience provides cryptographic domain separation — a regular user access token cannot be used as a test-login token and vice versa.

- Add GenerateTestLoginToken/ValidateTestLoginToken to UserTokenService
- Validate Authorization: Bearer header in handleTestLogin
- Add 6 new auth failure tests (missing, invalid, wrong key, wrong audience, expired, non-Bearer scheme)
- Update all existing test cases with valid challenge tokens

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
