### PR TITLE
fix: suppress commentary (TypeAssistantReply) messages in Discord

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -455,14 +455,20 @@ func (b *DiscordBroker) Publish(ctx context.Context, topic string, msg *messages
 		return nil
 	}
 
+	// Always suppress commentary messages — Discord has no user toggle for this.
+	if msg != nil && msg.Type == messages.TypeAssistantReply {
+		b.log.Debug("Filtering assistant-reply message (commentary always suppressed in Discord)")
+		return nil
+	}
+
 	// Determine whether this message should be sent via webhook (agent identity)
 	// or via the bot API. Webhook routing applies when:
 	//   - Sender is an agent (starts with "agent:")
-	//   - Message type is TypeAssistantReply or TypeInstruction
+	//   - Message type is TypeInstruction
 	// State changes and input-needed messages keep the bot identity (embed style).
 	useWebhook := webhooks != nil &&
 		strings.HasPrefix(msg.Sender, "agent:") &&
-		(msg.Type == messages.TypeAssistantReply || msg.Type == messages.TypeInstruction)
+		msg.Type == messages.TypeInstruction
 
 	// Extract agent slug from sender for webhook username.
 	senderSlug := agentSlug
@@ -480,12 +486,6 @@ func (b *DiscordBroker) Publish(ctx context.Context, topic string, msg *messages
 		text = formatMessage(msg, agentSlug)
 	}
 	if text == "" {
-		return nil
-	}
-
-	// Always suppress commentary messages — Discord has no user toggle for this.
-	if msg != nil && msg.Type == messages.TypeAssistantReply {
-		b.log.Debug("Filtering assistant-reply message (commentary always suppressed in Discord)")
 		return nil
 	}
 

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -483,13 +483,18 @@ func (b *DiscordBroker) Publish(ctx context.Context, topic string, msg *messages
 		return nil
 	}
 
+	// Always suppress commentary messages — Discord has no user toggle for this.
+	if msg != nil && msg.Type == messages.TypeAssistantReply {
+		b.log.Debug("Filtering assistant-reply message (commentary always suppressed in Discord)")
+		return nil
+	}
+
 	// Per-channel filtering based on channel link settings.
 	isAgentToAgent := msg != nil &&
 		strings.HasPrefix(msg.Sender, "agent:") &&
 		strings.HasPrefix(msg.Recipient, "agent:")
 	isStateChange := msg != nil && msg.Type == messages.TypeStateChange
-	isAssistantReply := msg != nil && msg.Type == messages.TypeAssistantReply
-	needsFilter := isAgentToAgent || isStateChange || isAssistantReply
+	needsFilter := isAgentToAgent || isStateChange
 
 	// Send to each target channel.
 	var errs []error
@@ -503,10 +508,6 @@ func (b *DiscordBroker) Publish(ctx context.Context, topic string, msg *messages
 				}
 				if isStateChange && !link.ShowStateChanges {
 					b.log.Debug("Filtering state change notification", "channel_id", channelID)
-					continue
-				}
-				if isAssistantReply && !link.ShowAssistantReply {
-					b.log.Debug("Filtering assistant-reply message", "channel_id", channelID)
 					continue
 				}
 			}

--- a/extras/scion-discord/internal/discord/callbacks.go
+++ b/extras/scion-discord/internal/discord/callbacks.go
@@ -190,7 +190,7 @@ func (h *CallbackHandler) saveChannelLink(ctx context.Context, i *discordgo.Inte
 		LinkedBy:           linkedBy,
 		LinkedAt:           time.Now(),
 		Active:             true,
-		ShowAssistantReply: true,
+		ShowAssistantReply: false,
 		ShowStateChanges:   true,
 		NotifyInGroup:      true,
 	}

--- a/pkg/agent/caching_skill_resolver_test.go
+++ b/pkg/agent/caching_skill_resolver_test.go
@@ -52,7 +52,7 @@ func TestCachingSkillResolver_InjectsCache(t *testing.T) {
 
 	var capturedCtx context.Context
 	inner := &ctxCapturingResolver{
-		inner: &mockResolver{resolved: []ResolvedSkill{{Name: "s", Hash: "h"}}},
+		inner:   &mockResolver{resolved: []ResolvedSkill{{Name: "s", Hash: "h"}}},
 		capture: func(ctx context.Context) { capturedCtx = ctx },
 	}
 

--- a/pkg/agent/skill_resolver.go
+++ b/pkg/agent/skill_resolver.go
@@ -390,7 +390,9 @@ func buildSkillEntry(skill ResolvedSkill, dest, skillsDest string) (*SkillResolu
 }
 
 // populateSkillCache stores downloaded skill files in the cache.
-func populateSkillCache(cache interface{ Put(string, map[string][]byte) (string, error) }, skill ResolvedSkill, installedDir string) {
+func populateSkillCache(cache interface {
+	Put(string, map[string][]byte) (string, error)
+}, skill ResolvedSkill, installedDir string) {
 	files := make(map[string][]byte, len(skill.Files))
 	for _, f := range skill.Files {
 		content, err := os.ReadFile(filepath.Join(installedDir, f.Path))

--- a/pkg/api/skill_uri.go
+++ b/pkg/api/skill_uri.go
@@ -31,10 +31,10 @@ type SkillURI struct {
 }
 
 const (
-	skillURIScheme   = "skill://"
-	defaultRegistry  = "scion"
-	defaultVersion   = "latest"
-	maxSkillNameLen  = 64
+	skillURIScheme  = "skill://"
+	defaultRegistry = "scion"
+	defaultVersion  = "latest"
+	maxSkillNameLen = 64
 )
 
 var validScopes = map[string]bool{

--- a/pkg/hub/skill_handlers.go
+++ b/pkg/hub/skill_handlers.go
@@ -59,7 +59,7 @@ type SkillWithCapabilities struct {
 
 // PublishVersionRequest is the request body for creating a skill version.
 type PublishVersionRequest struct {
-	Version string            `json:"version"`
+	Version string              `json:"version"`
 	Files   []FileUploadRequest `json:"files,omitempty"`
 }
 
@@ -779,7 +779,7 @@ func (s *Server) handleSkillUpload(w http.ResponseWriter, r *http.Request, skill
 	}
 
 	var req struct {
-		Version string            `json:"version"`
+		Version string              `json:"version"`
 		Files   []FileUploadRequest `json:"files"`
 	}
 	if err := readJSON(r, &req); err != nil {

--- a/pkg/hubclient/skills.go
+++ b/pkg/hubclient/skills.go
@@ -160,7 +160,7 @@ type UpdateSkillRequest struct {
 
 // PublishVersionRequest is the request for creating a skill version.
 type PublishVersionRequest struct {
-	Version string            `json:"version"`
+	Version string              `json:"version"`
 	Files   []FileUploadRequest `json:"files,omitempty"`
 }
 
@@ -172,7 +172,7 @@ type PublishVersionResponse struct {
 
 // FinalizeSkillVersionRequest is the request for finalizing a skill version.
 type FinalizeSkillVersionRequest struct {
-	Version  string        `json:"version"`
+	Version  string         `json:"version"`
 	Manifest *SkillManifest `json:"manifest"`
 }
 
@@ -201,7 +201,7 @@ type ResolveSkillRef struct {
 
 // ResolveSkillsResponse is the response for batch skill resolution.
 type ResolveSkillsResponse struct {
-	Resolved []ResolvedSkill    `json:"resolved"`
+	Resolved []ResolvedSkill     `json:"resolved"`
 	Errors   []ResolveSkillError `json:"errors,omitempty"`
 }
 
@@ -343,7 +343,7 @@ func (s *skillService) FinalizeVersion(ctx context.Context, skillID string, req 
 // RequestUploadURLs requests signed upload URLs for a skill version's files.
 func (s *skillService) RequestUploadURLs(ctx context.Context, skillID string, version string, files []FileUploadRequest) (*UploadResponse, error) {
 	req := struct {
-		Version string            `json:"version"`
+		Version string              `json:"version"`
 		Files   []FileUploadRequest `json:"files"`
 	}{
 		Version: version,

--- a/pkg/store/entadapter/skill_store.go
+++ b/pkg/store/entadapter/skill_store.go
@@ -22,11 +22,11 @@ import (
 	"time"
 
 	entsql "entgo.io/ent/dialect/sql"
-	"github.com/Masterminds/semver/v3"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent"
 	entskill "github.com/GoogleCloudPlatform/scion/pkg/ent/skill"
 	entskillversion "github.com/GoogleCloudPlatform/scion/pkg/ent/skillversion"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/Masterminds/semver/v3"
 )
 
 // SkillStore implements store.SkillStore using Ent ORM.


### PR DESCRIPTION
Add unconditional early return in broker.Publish() to filter TypeAssistantReply before per-channel logic, covering all channels including those with ShowAssistantReply=true from the buggy setup default. Fix the setup default to false for new channel links. Clean up now-dead per-channel isAssistantReply check.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
