### PR TITLE
fix: use net/mail.ParseAddress for stricter email validation

### DIFF
--- a/pkg/hub/handlers_test_login.go
+++ b/pkg/hub/handlers_test_login.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/mail"
 	"strings"
 	"time"
 
@@ -90,8 +91,8 @@ func (ws *WebServer) handleTestLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !strings.Contains(req.Email, "@") {
-		http.Error(w, "email must contain @", http.StatusBadRequest)
+	if _, err := mail.ParseAddress(req.Email); err != nil {
+		http.Error(w, "invalid email address", http.StatusBadRequest)
 		return
 	}
 

--- a/pkg/hub/handlers_test_login_test.go
+++ b/pkg/hub/handlers_test_login_test.go
@@ -193,7 +193,7 @@ func TestHandleTestLogin_InvalidEmail(t *testing.T) {
 	ws.handleTestLogin(rec, req)
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
-	assert.Contains(t, rec.Body.String(), "email must contain @")
+	assert.Contains(t, rec.Body.String(), "invalid email address")
 }
 
 func TestHandleTestLogin_DBError(t *testing.T) {


### PR DESCRIPTION
Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
