### PR TITLE
feat: restore harness-config build UI and executor

### DIFF
--- a/pkg/hub/admin_maintenance.go
+++ b/pkg/hub/admin_maintenance.go
@@ -293,6 +293,16 @@ func (s *Server) resolveMaintenanceExecutor(key string) (MaintenanceExecutor, er
 		return &RebuildContainerBinariesExecutor{
 			repoPath: mc.RepoPath,
 		}, nil
+	case "build-harness-config-image":
+		log.Debug("Resolved build-harness-config-image executor",
+			"runtime_bin", mc.RuntimeBin, "registry", mc.ImageRegistry, "tag", mc.ImageTag)
+		return &BuildHarnessConfigImageExecutor{
+			store:      s.store,
+			storage:    s.GetStorage(),
+			runtimeBin: mc.RuntimeBin,
+			registry:   mc.ImageRegistry,
+			tag:        mc.ImageTag,
+		}, nil
 	default:
 		return nil, fmt.Errorf("no executor registered for operation %q", key)
 	}

--- a/pkg/hub/maintenance_executors.go
+++ b/pkg/hub/maintenance_executors.go
@@ -27,6 +27,7 @@ import (
 
 	scionruntime "github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
 )
@@ -425,6 +426,162 @@ func (e *RebuildContainerBinariesExecutor) Run(ctx context.Context, logger io.Wr
 
 	log.Info("Container binaries rebuild complete")
 	fmt.Fprintln(logger, "\nContainer binaries rebuild complete.")
+	return nil
+}
+
+// BuildHarnessConfigImageExecutor builds a container image from a harness-config's Dockerfile.
+type BuildHarnessConfigImageExecutor struct {
+	store      store.Store
+	storage    storage.Storage
+	runtimeBin string
+	registry   string
+	tag        string
+}
+
+func (e *BuildHarnessConfigImageExecutor) Run(ctx context.Context, logger io.Writer, params map[string]string) error {
+	log := logging.Subsystem("hub.maintenance.build-harness-config-image")
+
+	harnessConfigID := params["harness_config_id"]
+	if harnessConfigID == "" {
+		return fmt.Errorf("missing required parameter: harness_config_id")
+	}
+
+	tag := e.tag
+	if tag == "" {
+		tag = "latest"
+	}
+	if v := params["tag"]; v != "" {
+		tag = v
+	}
+
+	registry := e.registry
+	if v := params["registry"]; v != "" {
+		registry = v
+	}
+	registry = strings.TrimSuffix(registry, "/")
+
+	hc, err := e.store.GetHarnessConfig(ctx, harnessConfigID)
+	if err != nil {
+		return fmt.Errorf("failed to load harness-config %q: %w", harnessConfigID, err)
+	}
+
+	hasDockerfile := false
+	for _, f := range hc.Files {
+		if f.Path == "Dockerfile" {
+			hasDockerfile = true
+			break
+		}
+	}
+	if !hasDockerfile {
+		return fmt.Errorf("harness-config %q does not contain a Dockerfile", hc.Name)
+	}
+
+	if e.storage == nil {
+		return fmt.Errorf("storage not configured")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "scion-build-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	fmt.Fprintf(logger, "Materializing %d file(s) from harness-config %q...\n", len(hc.Files), hc.Name)
+	for _, f := range hc.Files {
+		objectPath := hc.StoragePath + "/" + f.Path
+		reader, _, err := e.storage.Download(ctx, objectPath)
+		if err != nil {
+			return fmt.Errorf("failed to download %q from storage: %w", f.Path, err)
+		}
+
+		destPath := filepath.Join(tmpDir, f.Path)
+		if !strings.HasPrefix(destPath, tmpDir+string(os.PathSeparator)) {
+			_ = reader.Close()
+			return fmt.Errorf("invalid file path %q: escapes build directory", f.Path)
+		}
+		if dir := filepath.Dir(destPath); dir != tmpDir {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				_ = reader.Close()
+				return fmt.Errorf("failed to create directory for %q: %w", f.Path, err)
+			}
+		}
+
+		outFile, err := os.Create(destPath)
+		if err != nil {
+			_ = reader.Close()
+			return fmt.Errorf("failed to create file %q: %w", f.Path, err)
+		}
+		_, err = io.Copy(outFile, reader)
+		_ = reader.Close()
+		_ = outFile.Close()
+		if err != nil {
+			return fmt.Errorf("failed to write file %q: %w", f.Path, err)
+		}
+
+		if f.Mode != "" {
+			mode := os.FileMode(0o644)
+			if _, err := fmt.Sscanf(f.Mode, "%o", &mode); err == nil {
+				_ = os.Chmod(destPath, mode)
+			}
+		}
+	}
+
+	baseImage := "scion-base:" + tag
+	if registry != "" {
+		baseImage = registry + "/scion-base:" + tag
+	}
+	fmt.Fprintf(logger, "Base image: %s\n", baseImage)
+
+	runtimeBin := e.runtimeBin
+	if runtimeBin == "" {
+		runtimeBin = scionruntime.DetectContainerRuntime()
+	}
+	if runtimeBin == "" {
+		return fmt.Errorf("no container runtime found (tried docker, podman)")
+	}
+
+	imageName := hc.Slug
+	if imageName == "" {
+		imageName = hc.Name
+	}
+	outputImage := imageName + ":" + tag
+	fmt.Fprintf(logger, "Building %s from harness-config %q...\n", outputImage, hc.Name)
+	log.Debug("Starting container build",
+		"image", outputImage, "base_image", baseImage,
+		"runtime", runtimeBin, "harness_config", hc.Name)
+
+	cmd := exec.CommandContext(ctx, runtimeBin, "build",
+		"--build-arg", "BASE_IMAGE="+baseImage,
+		"-t", outputImage,
+		tmpDir)
+	cmd.Stdout = logger
+	cmd.Stderr = logger
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("build failed: %w", err)
+	}
+
+	if params["push"] == "true" && registry != "" {
+		pushImage := registry + "/" + outputImage
+		fmt.Fprintf(logger, "Tagging %s as %s...\n", outputImage, pushImage)
+		tagCmd := exec.CommandContext(ctx, runtimeBin, "tag", outputImage, pushImage)
+		tagCmd.Stdout = logger
+		tagCmd.Stderr = logger
+		if err := tagCmd.Run(); err != nil {
+			return fmt.Errorf("tag failed: %w", err)
+		}
+
+		fmt.Fprintf(logger, "Pushing %s...\n", pushImage)
+		pushCmd := exec.CommandContext(ctx, runtimeBin, "push", pushImage)
+		pushCmd.Stdout = logger
+		pushCmd.Stderr = logger
+		if err := pushCmd.Run(); err != nil {
+			return fmt.Errorf("push failed: %w", err)
+		}
+		outputImage = pushImage
+	}
+
+	fmt.Fprintf(logger, "\nBuild complete: %s\n", outputImage)
+	log.Info("Build complete", "image", outputImage, "harness_config", hc.Name)
 	return nil
 }
 

--- a/pkg/store/entadapter/maintenance_store.go
+++ b/pkg/store/entadapter/maintenance_store.go
@@ -74,6 +74,12 @@ var defaultSeedOperations = []store.MaintenanceOperation{
 		Description: "Rebuilds scion and sciontool binaries for Linux containers (make container-binaries). Only available when SCION_DEV_BINARIES is set. Binaries are written to .build/container/ in the source checkout.",
 		Category:    store.MaintenanceCategoryOperation,
 	},
+	{
+		Key:         "build-harness-config-image",
+		Title:       "Build Harness Config Image",
+		Description: "Builds a container image from a harness-config's bundled Dockerfile. The base image is resolved from the configured image registry.",
+		Category:    store.MaintenanceCategoryOperation,
+	},
 }
 
 // ============================================================================

--- a/web/src/components/pages/harness-config-detail.ts
+++ b/web/src/components/pages/harness-config-detail.ts
@@ -70,8 +70,37 @@ export class ScionPageHarnessConfigDetail extends LitElement {
   @state()
   private editorInitialPreview = false;
 
+  @state()
+  private hasDockerfile = false;
+
+  @state()
+  private buildDialogOpen = false;
+
+  @state()
+  private buildRunning = false;
+
+  @state()
+  private buildTag = 'latest';
+
+  @state()
+  private buildPush = false;
+
+  @state()
+  private buildLog = '';
+
+  @state()
+  private buildStatus = '';
+
+  @state()
+  private buildRunId = '';
+
+  @state()
+  private buildError = '';
+
   private fileBrowserDataSource: FileBrowserDataSource | null = null;
   private fileEditorDataSource: FileEditorDataSource | null = null;
+  private buildPollTimer: ReturnType<typeof setTimeout> | null = null;
+  private buildPollErrors = 0;
 
   static override styles = css`
     :host {
@@ -155,6 +184,52 @@ export class ScionPageHarnessConfigDetail extends LitElement {
       margin-bottom: 0.5rem;
     }
 
+    .header-actions {
+      margin-left: auto;
+    }
+
+    .build-log-section {
+      margin-top: 1.5rem;
+    }
+    .build-log-section h3 {
+      font-size: 0.95rem;
+      font-weight: 600;
+      margin: 0 0 0.5rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .build-log {
+      background: var(--sl-color-neutral-50);
+      border: 1px solid var(--sl-color-neutral-200);
+      border-radius: var(--sl-border-radius-medium);
+      padding: 1rem;
+      font-family: var(--sl-font-mono);
+      font-size: 0.8rem;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-all;
+      max-height: 400px;
+      overflow-y: auto;
+    }
+
+    .build-status-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+    }
+    .build-status-badge.running { color: var(--sl-color-primary-600); }
+    .build-status-badge.completed { color: var(--sl-color-success-600); }
+    .build-status-badge.failed { color: var(--sl-color-danger-600); }
+
+    .build-error {
+      color: var(--sl-color-danger-600);
+      font-size: 0.85rem;
+      margin-top: 0.5rem;
+    }
+
     .error-state,
     .loading-state {
       text-align: center;
@@ -214,6 +289,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
         throw new Error(await extractApiError(response, `HTTP ${response.status}`));
       }
       this.harnessConfig = (await response.json()) as HarnessConfig;
+      this.hasDockerfile = this.harnessConfig.files?.some(f => f.path === 'Dockerfile') ?? false;
       dispatchPageTitle(
         this,
         this.harnessConfig.displayName || this.harnessConfig.name || this.harnessConfigId,
@@ -293,7 +369,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
         )}
       </div>
 
-      ${this.renderHeader()} ${this.renderFilesSection()}
+      ${this.renderHeader()} ${this.renderFilesSection()} ${this.renderBuildDialog()} ${this.renderBuildLog()}
     `;
   }
 
@@ -308,6 +384,19 @@ export class ScionPageHarnessConfigDetail extends LitElement {
           ></sl-icon>
           <h1>${hc.displayName || hc.name}</h1>
           ${hc.harness ? html`<span class="harness-badge">${hc.harness}</span>` : ''}
+          ${this.hasDockerfile ? html`
+            <div class="header-actions">
+              <sl-button
+                size="small"
+                variant="primary"
+                @click=${this.openBuildDialog}
+                ?disabled=${this.buildRunning}
+              >
+                <sl-icon slot="prefix" name="hammer"></sl-icon>
+                ${this.buildRunning ? 'Building...' : 'Build Image'}
+              </sl-button>
+            </div>
+          ` : nothing}
         </div>
         ${hc.description ? html`<p class="resource-description">${hc.description}</p>` : ''}
         <div class="resource-meta-row">
@@ -360,6 +449,182 @@ export class ScionPageHarnessConfigDetail extends LitElement {
             `}
       </div>
     `;
+  }
+  // ── Build Image ──
+
+  private openBuildDialog(): void {
+    this.buildTag = 'latest';
+    this.buildPush = false;
+    this.buildError = '';
+    this.buildDialogOpen = true;
+  }
+
+  private renderBuildDialog() {
+    return html`
+      <sl-dialog
+        label="Build Image"
+        ?open=${this.buildDialogOpen}
+        @sl-request-close=${() => (this.buildDialogOpen = false)}
+      >
+        <sl-input
+          label="Image Tag"
+          .value=${this.buildTag}
+          @sl-input=${(e: Event) => (this.buildTag = (e.target as HTMLInputElement).value)}
+        ></sl-input>
+        <br />
+        <sl-checkbox ?checked=${this.buildPush} @sl-change=${(e: Event) => (this.buildPush = (e.target as HTMLInputElement).checked)}>
+          Push to registry after building
+        </sl-checkbox>
+        ${this.buildError ? html`<p class="build-error">${this.buildError}</p>` : nothing}
+        <sl-button slot="footer" variant="primary" @click=${this.startBuild} ?loading=${this.buildRunning}>
+          Build
+        </sl-button>
+        <sl-button slot="footer" variant="default" @click=${() => (this.buildDialogOpen = false)}>
+          Cancel
+        </sl-button>
+      </sl-dialog>
+    `;
+  }
+
+  private async startBuild(): Promise<void> {
+    this.buildDialogOpen = false;
+    this.buildRunning = true;
+    this.buildLog = '';
+    this.buildStatus = 'running';
+    this.buildError = '';
+    this.buildPollErrors = 0;
+
+    try {
+      const response = await apiFetch(
+        '/api/v1/admin/maintenance/operations/build-harness-config-image/run',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            params: {
+              harness_config_id: this.harnessConfigId,
+              tag: this.buildTag || 'latest',
+              push: this.buildPush ? 'true' : 'false',
+            },
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        const errMsg = await extractApiError(response, `HTTP ${response.status}`);
+        this.buildError = errMsg;
+        this.buildRunning = false;
+        this.buildStatus = 'failed';
+        return;
+      }
+
+      const result = await response.json();
+      if (!result?.runId) {
+        this.buildError = 'Build started but no run ID was returned';
+        this.buildRunning = false;
+        this.buildStatus = 'failed';
+        return;
+      }
+      this.buildRunId = result.runId;
+      this.startBuildPolling();
+    } catch (err) {
+      this.buildError = err instanceof Error ? err.message : 'Failed to start build';
+      this.buildRunning = false;
+      this.buildStatus = 'failed';
+    }
+  }
+
+  private startBuildPolling(): void {
+    if (this.buildPollTimer) return;
+    this.buildPollErrors = 0;
+    void this.pollBuildStatus();
+  }
+
+  private stopBuildPolling(): void {
+    if (this.buildPollTimer) {
+      clearTimeout(this.buildPollTimer);
+      this.buildPollTimer = null;
+    }
+  }
+
+  private async pollBuildStatus(): Promise<void> {
+    if (!this.buildRunId) return;
+
+    try {
+      const resp = await apiFetch(
+        `/api/v1/admin/maintenance/operations/build-harness-config-image/runs/${this.buildRunId}`,
+      );
+      if (!resp.ok) {
+        this.buildPollErrors++;
+        if (this.buildPollErrors >= 5) {
+          this.buildRunning = false;
+          this.buildStatus = 'failed';
+          this.buildError = 'Lost connection to build';
+          this.stopBuildPolling();
+        } else if (this.buildRunning) {
+          this.buildPollTimer = setTimeout(() => void this.pollBuildStatus(), 3000);
+        }
+        return;
+      }
+
+      this.buildPollErrors = 0;
+      const run = await resp.json();
+      this.buildLog = run.log ?? '';
+      this.buildStatus = run.status ?? '';
+      void this.updateComplete.then(() => this.scrollBuildLog());
+
+      if (run.status !== 'running') {
+        this.buildRunning = false;
+        this.stopBuildPolling();
+        if (run.status === 'completed') {
+          await this.loadHarnessConfig();
+        }
+      } else if (this.buildRunning) {
+        this.buildPollTimer = setTimeout(() => void this.pollBuildStatus(), 3000);
+      }
+    } catch {
+      this.buildPollErrors++;
+      if (this.buildPollErrors >= 5) {
+        this.buildRunning = false;
+        this.buildStatus = 'failed';
+        this.buildError = 'Lost connection to build';
+        this.stopBuildPolling();
+      } else if (this.buildRunning) {
+        this.buildPollTimer = setTimeout(() => void this.pollBuildStatus(), 3000);
+      }
+    }
+  }
+
+  private scrollBuildLog(): void {
+    const el = this.renderRoot?.querySelector('.build-log');
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }
+
+  private renderBuildLog() {
+    if (!this.buildLog && !this.buildRunning) return nothing;
+
+    const statusClass = this.buildStatus === 'completed' ? 'completed' : this.buildStatus === 'running' ? 'running' : 'failed';
+
+    return html`
+      <div class="build-log-section">
+        <h3>
+          Build Output
+          <span class="build-status-badge ${statusClass}">
+            ${this.buildStatus === 'running'
+              ? html`<sl-spinner style="font-size: 0.75rem;"></sl-spinner> Running`
+              : this.buildStatus}
+          </span>
+        </h3>
+        <pre class="build-log">${this.buildLog}</pre>
+      </div>
+    `;
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.stopBuildPolling();
   }
 }
 


### PR DESCRIPTION
Restores the build feature code that was accidentally removed by PR #412. This includes:
- BuildHarnessConfigImageExecutor in maintenance_executors.go
- build-harness-config-image seeded operation
- Executor wiring in admin_maintenance.go
- Build Image button, dialog, and log streaming UI on harness-config detail page

Originally shipped in PRs #406 and #410.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
