### PR TITLE
fix(a2a-bridge): preserve input-required state on content messages an…

### DIFF
--- a/extras/scion-a2a-bridge/internal/bridge/bridge.go
+++ b/extras/scion-a2a-bridge/internal/bridge/bridge.go
@@ -408,11 +408,11 @@ func (b *Bridge) sendFollowUp(ctx context.Context, projectSlug, agentSlug, taskI
 	// Re-request broker subscriptions in case the broker reconnected since
 	// the original task was created (subscriptions may have been lost).
 	if b.broker != nil {
-		pattern := fmt.Sprintf("scion.project.%s.user.%s.messages", task.ProjectID, b.config.Hub.User)
+		pattern := projectcompat.UserTopic(task.ProjectID, b.config.Hub.User)
 		if err := b.broker.RequestSubscription(pattern); err != nil {
 			b.log.Warn("failed to re-request subscription for follow-up", "pattern", pattern, "error", err)
 		}
-		legacyPattern := fmt.Sprintf("scion.grove.%s.user.%s.messages", task.ProjectID, b.config.Hub.User)
+		legacyPattern := projectcompat.LegacyUserTopic(task.ProjectID, b.config.Hub.User)
 		if err := b.broker.RequestSubscription(legacyPattern); err != nil {
 			b.log.Warn("failed to re-request legacy subscription for follow-up", "pattern", legacyPattern, "error", err)
 		}
@@ -430,7 +430,7 @@ func (b *Bridge) sendFollowUp(ctx context.Context, projectSlug, agentSlug, taskI
 		defer b.removeWaiter(taskID)
 		defer b.unregisterActiveTask(taskID, aKey)
 
-		if err := b.hubClient.Agents().SendStructuredMessage(ctx, agentID, scionMsg, false, false, false); err != nil {
+		if _, err := b.hubClient.Agents().SendStructuredMessage(ctx, agentID, scionMsg, false, false, false); err != nil {
 			b.failFollowUpTask(taskID)
 			return nil, fmt.Errorf("send follow-up to agent: %w", err)
 		}
@@ -471,7 +471,7 @@ func (b *Bridge) sendFollowUp(ctx context.Context, projectSlug, agentSlug, taskI
 		defer b.wg.Done()
 		sendCtx, cancel := context.WithTimeout(b.shutdownCtx, 30*time.Second)
 		defer cancel()
-		if err := b.hubClient.Agents().SendStructuredMessage(sendCtx, agentID, scionMsg, false, false, false); err != nil {
+		if _, err := b.hubClient.Agents().SendStructuredMessage(sendCtx, agentID, scionMsg, false, false, false); err != nil {
 			b.log.Error("non-blocking follow-up send failed", "error", err, "task_id", taskID)
 			b.failFollowUpTask(taskID)
 			b.unregisterActiveTask(taskID, aKey)
@@ -758,9 +758,19 @@ func (b *Bridge) dispatchToActiveTask(ctx context.Context, taskID, agentSlug str
 	// Task lifecycle is driven by state-change messages, not content.
 	// Touch the DB timestamp so the janitor doesn't reap active tasks
 	// whose only recent activity is content messages.
+	// Use TouchTask (not UpdateTaskState) to preserve the current state —
+	// content messages must not overwrite input-required.
 	a2aMsg, artifacts := TranslateScionToA2A(msg)
 
-	if err := b.store.UpdateTaskState(taskID, TaskStateWorking); err != nil {
+	currentState := TaskStateWorking
+	if task, err := b.store.GetTask(taskID); err != nil {
+		b.log.Error("failed to get task for content message",
+			"task_id", taskID, "error", err)
+	} else if task != nil {
+		currentState = task.State
+	}
+
+	if err := b.store.TouchTask(taskID); err != nil {
 		b.log.Error("failed to refresh task timestamp for content message",
 			"task_id", taskID, "error", err)
 	}
@@ -779,7 +789,7 @@ func (b *Bridge) dispatchToActiveTask(ctx context.Context, taskID, agentSlug str
 		StatusUpdate: &TaskStatusUpdate{
 			TaskID: taskID,
 			Status: TaskStatus{
-				State:   TaskStateWorking,
+				State:   currentState,
 				Message: &a2aMsg,
 			},
 			Final: false,

--- a/extras/scion-a2a-bridge/internal/bridge/followup_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/followup_test.go
@@ -37,15 +37,15 @@ import (
 
 // mockAgentService implements hubclient.AgentService for testing.
 type mockAgentService struct {
-	sendFn func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error
+	sendFn func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error)
 	listFn func(ctx context.Context, opts *hubclient.ListAgentsOptions) (*hubclient.ListAgentsResponse, error)
 }
 
-func (m *mockAgentService) SendStructuredMessage(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error {
+func (m *mockAgentService) SendStructuredMessage(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
 	if m.sendFn != nil {
 		return m.sendFn(ctx, agentID, msg, interrupt, notify, wake)
 	}
-	return nil
+	return nil, nil
 }
 
 func (m *mockAgentService) List(ctx context.Context, opts *hubclient.ListAgentsOptions) (*hubclient.ListAgentsResponse, error) {
@@ -88,8 +88,8 @@ func (m *mockAgentService) StopAll(ctx context.Context) (*hubclient.StopAllRespo
 func (m *mockAgentService) SendMessage(ctx context.Context, agentID string, message string, interrupt bool) error {
 	return fmt.Errorf("not implemented")
 }
-func (m *mockAgentService) BroadcastMessage(ctx context.Context, msg *messages.StructuredMessage, interrupt bool) error {
-	return fmt.Errorf("not implemented")
+func (m *mockAgentService) BroadcastMessage(ctx context.Context, msg *messages.StructuredMessage, interrupt bool) (*hubclient.BroadcastResponse, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 func (m *mockAgentService) SubmitEnv(ctx context.Context, agentID string, req *hubclient.SubmitEnvRequest) (*hubclient.CreateAgentResponse, error) {
 	return nil, fmt.Errorf("not implemented")
@@ -138,7 +138,9 @@ func (m *mockHubClient) Schedules(string) hubclient.ScheduleService { return nil
 func (m *mockHubClient) GCPServiceAccounts(string) hubclient.GCPServiceAccountService { return nil }
 func (m *mockHubClient) Messages() hubclient.MessageService       { return nil }
 func (m *mockHubClient) AllowList() hubclient.AllowListService     { return nil }
-func (m *mockHubClient) Invites() hubclient.InviteService          { return nil }
+func (m *mockHubClient) Invites() hubclient.InviteService               { return nil }
+func (m *mockHubClient) Skills() hubclient.SkillService                 { return nil }
+func (m *mockHubClient) SkillRegistries() hubclient.SkillRegistryService { return nil }
 func (m *mockHubClient) Health(ctx context.Context) (*hubclient.HealthResponse, error) {
 	return &hubclient.HealthResponse{}, nil
 }
@@ -205,12 +207,12 @@ func TestSendFollowUp_ValidTaskRoutesMessage(t *testing.T) {
 	}
 
 	agents := &mockAgentService{
-		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error {
+		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
 			captured.mu.Lock()
 			defer captured.mu.Unlock()
 			captured.agentID = agentID
 			captured.msg = msg
-			return nil
+			return nil, nil
 		},
 	}
 	b, store := newFollowUpTestBridge(t, agents)
@@ -332,8 +334,8 @@ func TestSendFollowUp_WrongAgentReturnsError(t *testing.T) {
 
 func TestSendFollowUp_UpdatesTaskStateToWorking(t *testing.T) {
 	agents := &mockAgentService{
-		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error {
-			return nil
+		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
+			return nil, nil
 		},
 	}
 	b, store := newFollowUpTestBridge(t, agents)
@@ -357,8 +359,8 @@ func TestSendFollowUp_UpdatesTaskStateToWorking(t *testing.T) {
 func TestSendFollowUp_BlockingTimeout_CleansUpActiveTask(t *testing.T) {
 	// Create a send function that succeeds but never triggers a response.
 	agents := &mockAgentService{
-		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error {
-			return nil
+		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
+			return nil, nil
 		},
 	}
 
@@ -422,8 +424,8 @@ func TestSendFollowUp_BlockingTimeout_CleansUpActiveTask(t *testing.T) {
 func TestSendFollowUp_BlockingSendFailure_CleansUpActiveTask(t *testing.T) {
 	sendErr := fmt.Errorf("hub unreachable")
 	agents := &mockAgentService{
-		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error {
-			return sendErr
+		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
+			return nil, sendErr
 		},
 	}
 	b, store := newFollowUpTestBridge(t, agents)
@@ -455,9 +457,9 @@ func TestSendFollowUp_BlockingSendFailure_CleansUpActiveTask(t *testing.T) {
 func TestSendFollowUp_NonBlocking_RegistersActiveTask(t *testing.T) {
 	sendCh := make(chan struct{})
 	agents := &mockAgentService{
-		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error {
+		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
 			<-sendCh // Block until test releases
-			return nil
+			return nil, nil
 		},
 	}
 	b, store := newFollowUpTestBridge(t, agents)
@@ -503,8 +505,8 @@ func TestSendFollowUp_NonBlocking_RegistersActiveTask(t *testing.T) {
 
 func TestSendFollowUp_NonBlocking_SendFailure_CleansUp(t *testing.T) {
 	agents := &mockAgentService{
-		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error {
-			return fmt.Errorf("connection refused")
+		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
+			return nil, fmt.Errorf("connection refused")
 		},
 	}
 	b, store := newFollowUpTestBridge(t, agents)
@@ -550,8 +552,8 @@ func TestSendFollowUp_NonBlocking_SendFailure_CleansUp(t *testing.T) {
 
 func TestSendFollowUp_BlockingSuccess_CleansUpActiveTask(t *testing.T) {
 	agents := &mockAgentService{
-		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error {
-			return nil
+		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
+			return nil, nil
 		},
 	}
 	b, store := newFollowUpTestBridge(t, agents)
@@ -636,8 +638,8 @@ func TestSendFollowUp_BlockingSuccess_CleansUpActiveTask(t *testing.T) {
 
 func TestSendFollowUp_BlockingContextCancel_CleansUp(t *testing.T) {
 	agents := &mockAgentService{
-		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error {
-			return nil
+		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
+			return nil, nil
 		},
 	}
 	b, store := newFollowUpTestBridge(t, agents)
@@ -698,8 +700,8 @@ func TestSendFollowUp_BlockingContextCancel_CleansUp(t *testing.T) {
 
 func TestSendFollowUp_InputRequiredToWorking(t *testing.T) {
 	agents := &mockAgentService{
-		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error {
-			return nil
+		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
+			return nil, nil
 		},
 	}
 	b, store := newFollowUpTestBridge(t, agents)
@@ -725,8 +727,8 @@ func TestSendFollowUp_InputRequiredToWorking(t *testing.T) {
 
 func TestSendFollowUp_SubmittedStateAllowed(t *testing.T) {
 	agents := &mockAgentService{
-		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error {
-			return nil
+		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
+			return nil, nil
 		},
 	}
 	b, store := newFollowUpTestBridge(t, agents)
@@ -742,11 +744,11 @@ func TestSendFollowUp_ResolvesAgentIDViaLookup(t *testing.T) {
 	var mu sync.Mutex
 	var capturedAgentID string
 	agents := &mockAgentService{
-		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error {
+		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			capturedAgentID = agentID
-			return nil
+			return nil, nil
 		},
 		listFn: func(ctx context.Context, opts *hubclient.ListAgentsOptions) (*hubclient.ListAgentsResponse, error) {
 			return &hubclient.ListAgentsResponse{
@@ -802,11 +804,11 @@ func TestHandleSendMessage_PassesTaskIDToSendMessage(t *testing.T) {
 	var mu sync.Mutex
 	var capturedMeta map[string]string
 	agents := &mockAgentService{
-		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error {
+		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			capturedMeta = msg.Metadata
-			return nil
+			return nil, nil
 		},
 	}
 
@@ -980,8 +982,8 @@ func TestHandleSendMessage_NoTaskID_RoutesToNewTask(t *testing.T) {
 				},
 			}, nil
 		},
-		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error {
-			return nil
+		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
+			return nil, nil
 		},
 	}
 	cfg := &Config{
@@ -1051,11 +1053,11 @@ func TestSendFollowUp_ConcurrentFollowUps_SameTask(t *testing.T) {
 	var mu sync.Mutex
 	sendCount := 0
 	agents := &mockAgentService{
-		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error {
+		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			sendCount++
-			return nil
+			return nil, nil
 		},
 	}
 	b, store := newFollowUpTestBridge(t, agents)
@@ -1110,9 +1112,9 @@ func TestSendFollowUp_MessageContentTranslated(t *testing.T) {
 	// Verify the A2A parts are correctly translated to Scion format.
 	var capturedMsg *messages.StructuredMessage
 	agents := &mockAgentService{
-		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) error {
+		sendFn: func(ctx context.Context, agentID string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
 			capturedMsg = msg
-			return nil
+			return nil, nil
 		},
 	}
 	b, store := newFollowUpTestBridge(t, agents)

--- a/extras/scion-a2a-bridge/internal/bridge/lifecycle_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/lifecycle_test.go
@@ -68,7 +68,7 @@ func withMetrics(m *Metrics) func(*lifecycleTestOpts) {
 
 // seedTask creates and registers a task in both the store and the bridge's
 // activeTasks map, mimicking what SendMessage does for non-blocking sends.
-func seedTask(t *testing.T, b *Bridge, store *state.Store, taskID, projectID, agentSlug string) {
+func seedLifecycleTask(t *testing.T, b *Bridge, store *state.Store, taskID, projectID, agentSlug string) {
 	t.Helper()
 	now := time.Now()
 	if err := store.CreateTask(&state.Task{
@@ -92,7 +92,7 @@ func seedTask(t *testing.T, b *Bridge, store *state.Store, taskID, projectID, ag
 func TestContentMessageDoesNotCompleteTask(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "content-no-complete-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 
 	// Subscribe to the task's stream.
 	ch, cleanup, err := b.streams.Subscribe(taskID)
@@ -161,10 +161,82 @@ func TestContentMessageDoesNotCompleteTask(t *testing.T) {
 	}
 }
 
+func TestContentMessagePreservesInputRequiredState(t *testing.T) {
+	b, store := newLifecycleTestBridge(t)
+	taskID := "content-preserves-ir-1"
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
+
+	ch, cleanup, err := b.streams.Subscribe(taskID)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer cleanup()
+
+	topic := "scion.project.proj1.user.test-user.messages"
+
+	// Transition to input-required via state-change.
+	stateMsg := &messages.StructuredMessage{
+		Version:   1,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Sender:    "agent:agent-a",
+		Recipient: "user:test-user",
+		Msg:       "WAITING_FOR_INPUT",
+		Type:      messages.TypeStateChange,
+		Metadata:  map[string]string{"a2aTaskId": taskID},
+	}
+	if err := b.HandleBrokerMessage(context.Background(), topic, stateMsg); err != nil {
+		t.Fatalf("HandleBrokerMessage(state): %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	// Send a content message while in input-required state.
+	contentMsg := &messages.StructuredMessage{
+		Version:   1,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Sender:    "agent:agent-a",
+		Recipient: "user:test-user",
+		Msg:       "Please provide more details",
+		Type:      messages.TypeAssistantReply,
+		Metadata:  map[string]string{"a2aTaskId": taskID},
+	}
+	if err := b.HandleBrokerMessage(context.Background(), topic, contentMsg); err != nil {
+		t.Fatalf("HandleBrokerMessage(content): %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	// State must still be input-required — content must not overwrite it.
+	task, err := store.GetTask(taskID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if task.State != TaskStateInputRequired {
+		t.Errorf("task state = %q, want %q — content message must not overwrite input-required",
+			task.State, TaskStateInputRequired)
+	}
+
+	// The streamed status update for the content message must also carry input-required.
+	var events []StreamEvent
+	drainLoop(ch, &events)
+
+	var foundContentStatus bool
+	for _, ev := range events {
+		if ev.StatusUpdate != nil && ev.StatusUpdate.Status.Message != nil {
+			if ev.StatusUpdate.Status.State != TaskStateInputRequired {
+				t.Errorf("content StatusUpdate.State = %q, want %q",
+					ev.StatusUpdate.Status.State, TaskStateInputRequired)
+			}
+			foundContentStatus = true
+		}
+	}
+	if !foundContentStatus {
+		t.Error("no StatusUpdate with message content found in stream events")
+	}
+}
+
 func TestContentMessageBroadcastsWorkingNonFinal(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "broadcast-working-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 
 	ch, cleanup, err := b.streams.Subscribe(taskID)
 	if err != nil {
@@ -223,7 +295,7 @@ func TestContentMessageBroadcastsWorkingNonFinal(t *testing.T) {
 func TestMultipleContentMessagesKeepTaskAlive(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "multi-content-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 
 	ch, cleanup, err := b.streams.Subscribe(taskID)
 	if err != nil {
@@ -290,7 +362,7 @@ func TestMultipleContentMessagesKeepTaskAlive(t *testing.T) {
 func TestStateChangeCompletedAfterContentClosesTask(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "complete-after-content-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 
 	ch, cleanup, err := b.streams.Subscribe(taskID)
 	if err != nil {
@@ -366,7 +438,7 @@ func TestStateChangeCompletedAfterContentClosesTask(t *testing.T) {
 func TestStateChangeInputRequiredKeepsTaskAlive(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "input-required-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 
 	ch, cleanup, err := b.streams.Subscribe(taskID)
 	if err != nil {
@@ -427,7 +499,7 @@ func TestStateChangeInputRequiredKeepsTaskAlive(t *testing.T) {
 func TestStateChangeFailedClosesTask(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "failed-close-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 
 	failMsg := &messages.StructuredMessage{
 		Version:   1,
@@ -586,7 +658,7 @@ func TestBlockingSendMessageErrorCleansUpActiveTask(t *testing.T) {
 func TestFullMultiTurnLifecycle(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "multi-turn-full-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 
 	ch, cleanup, err := b.streams.Subscribe(taskID)
 	if err != nil {
@@ -717,7 +789,7 @@ func TestFullMultiTurnLifecycle(t *testing.T) {
 func TestSlugFallbackContentDoesNotCloseTask(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "slug-fallback-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 
 	// Send a content message WITHOUT a2aTaskId (slug-based correlation).
 	contentMsg := &messages.StructuredMessage{
@@ -814,7 +886,7 @@ func TestContentMessageDoesNotIncrementCompletedMetric(t *testing.T) {
 	b, store := newLifecycleTestBridge(t, withMetrics(metrics))
 
 	taskID := "no-metric-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 
 	contentMsg := &messages.StructuredMessage{
 		Version:   1,
@@ -843,7 +915,7 @@ func TestContentMessageDoesNotIncrementCompletedMetric(t *testing.T) {
 func TestContentAfterCompletedIsIgnored(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "content-after-complete-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 	topic := "scion.project.proj1.user.test-user.messages"
 
 	// First complete the task via state-change.
@@ -898,7 +970,7 @@ func TestContentAfterCompletedIsIgnored(t *testing.T) {
 func TestDoubleCompletedIsIdempotent(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "double-complete-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 	topic := "scion.project.proj1.user.test-user.messages"
 
 	for i := 0; i < 2; i++ {
@@ -935,7 +1007,7 @@ func TestDoubleCompletedIsIdempotent(t *testing.T) {
 func TestNonBlockingSendKeepsTaskAlive(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "nonblock-alive-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 	topic := "scion.project.proj1.user.test-user.messages"
 
 	// Send content message to a task registered the non-blocking way.
@@ -970,7 +1042,7 @@ func TestNonBlockingSendKeepsTaskAlive(t *testing.T) {
 func TestStateChangeWorkingDoesNotCloseTask(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "working-nonterminal-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 	topic := "scion.project.proj1.user.test-user.messages"
 
 	// WORKING state-change is non-terminal.
@@ -1005,8 +1077,8 @@ func TestMultipleAgentTasksContentDoesNotClose(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID1 := "multi-agent-task-1"
 	taskID2 := "multi-agent-task-2"
-	seedTask(t, b, store, taskID1, "proj1", "agent-a")
-	seedTask(t, b, store, taskID2, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID1, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID2, "proj1", "agent-a")
 	topic := "scion.project.proj1.user.test-user.messages"
 
 	// Send content without a2aTaskId — slug fallback should hit both tasks.
@@ -1091,7 +1163,7 @@ func TestStateChangeTerminalityTableDriven(t *testing.T) {
 		t.Run(tc.activity, func(t *testing.T) {
 			b, store := newLifecycleTestBridge(t)
 			taskID := "term-" + tc.activity
-			seedTask(t, b, store, taskID, "proj1", "agent-a")
+			seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 
 			ch, cleanup, err := b.streams.Subscribe(taskID)
 			if err != nil {
@@ -1153,7 +1225,7 @@ func TestStateChangeTerminalityTableDriven(t *testing.T) {
 func TestTerminalStateClosesStreamChannel(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "stream-close-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 
 	ch, cleanup, err := b.streams.Subscribe(taskID)
 	if err != nil {
@@ -1208,7 +1280,7 @@ func TestTerminalStateClosesStreamChannel(t *testing.T) {
 func TestTerminalStateFailedClosesStreamChannel(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "stream-close-fail-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 
 	ch, cleanup, err := b.streams.Subscribe(taskID)
 	if err != nil {
@@ -1249,7 +1321,7 @@ func TestTerminalStateFailedClosesStreamChannel(t *testing.T) {
 func TestDispatchToWaiterPersistsTerminalState(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "waiter-persist-terminal-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 
 	// Set up a blocking waiter as SendMessage would.
 	responseCh := make(chan *messages.StructuredMessage, 1)
@@ -1292,7 +1364,7 @@ func TestDispatchToWaiterPersistsTerminalState(t *testing.T) {
 func TestDispatchToWaiterDoesNotPersistNonTerminalState(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "waiter-no-persist-nonterminal-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 
 	responseCh := make(chan *messages.StructuredMessage, 1)
 	b.addWaiter(taskID, &waiter{
@@ -1327,7 +1399,7 @@ func TestDispatchToWaiterDoesNotPersistNonTerminalState(t *testing.T) {
 func TestContentMessageRefreshesTimestamp(t *testing.T) {
 	b, store := newLifecycleTestBridge(t)
 	taskID := "timestamp-refresh-1"
-	seedTask(t, b, store, taskID, "proj1", "agent-a")
+	seedLifecycleTask(t, b, store, taskID, "proj1", "agent-a")
 
 	// Record the initial timestamp.
 	taskBefore, err := store.GetTask(taskID)

--- a/extras/scion-a2a-bridge/internal/bridge/stream.go
+++ b/extras/scion-a2a-bridge/internal/bridge/stream.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/GoogleCloudPlatform/scion/extras/scion-a2a-bridge/internal/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 )
 
 // ErrTooManySubscribers is returned when the SSE connection limit is reached.
@@ -220,7 +221,7 @@ func (b *Bridge) SendStreamingMessage(ctx context.Context, projectSlug, agentSlu
 	scionMsg.Metadata = map[string]string{"a2aTaskId": taskID}
 
 	if b.broker != nil {
-		pattern := fmt.Sprintf("scion.project.%s.user.%s.messages", agentCtx.ProjectID, b.config.Hub.User)
+		pattern := projectcompat.UserTopic(agentCtx.ProjectID, b.config.Hub.User)
 		if err := b.broker.RequestSubscription(pattern); err != nil {
 			b.log.Warn("failed to request subscription", "pattern", pattern, "error", err)
 		}

--- a/extras/scion-a2a-bridge/internal/state/state.go
+++ b/extras/scion-a2a-bridge/internal/state/state.go
@@ -176,6 +176,20 @@ func (s *Store) GetTask(id string) (*Task, error) {
 	return t, nil
 }
 
+// TouchTask updates only the updated_at timestamp without changing state.
+// Use this for content messages that should keep the task alive for the
+// janitor without overwriting the current state (e.g. input-required).
+func (s *Store) TouchTask(id string) error {
+	_, err := s.db.Exec(
+		`UPDATE tasks SET updated_at = ? WHERE id = ?`,
+		time.Now(), id,
+	)
+	if err != nil {
+		return fmt.Errorf("touch task: %w", err)
+	}
+	return nil
+}
+
 // UpdateTaskState updates a task's state and updated_at timestamp.
 // Terminal states (completed, failed, canceled, rejected) are protected:
 // once a task reaches a terminal state, further updates are silently ignored.


### PR DESCRIPTION
…d use topic helpers

Address review feedback from merged A2A PRs #314 and #315:

- Add TouchTask store method to refresh timestamps without changing state
- Guard dispatchToActiveTask so content messages read and preserve the current task state instead of unconditionally resetting to working
- Replace hardcoded fmt.Sprintf topic patterns in sendFollowUp and SendStreamingMessage with projectcompat.UserTopic/LegacyUserTopic
- Fix SendStructuredMessage call sites missing second return value
- Update followup_test.go mocks to match current hubclient interfaces

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
