### PR TITLE
feat(web): add Skill Bank web UI pages

### DIFF
--- a/pkg/hub/skill_registry_handlers.go
+++ b/pkg/hub/skill_registry_handlers.go
@@ -71,8 +71,15 @@ func (s *Server) handleSkillRegistryByID(w http.ResponseWriter, r *http.Request)
 	}
 
 	if parts := strings.SplitN(id, "/", 2); len(parts) == 2 {
-		if parts[1] == "pin" {
+		switch parts[1] {
+		case "pin":
 			s.pinSkillHash(w, r, parts[0])
+			return
+		case "pins":
+			s.listPinnedHashes(w, r, parts[0])
+			return
+		case "unpin":
+			s.unpinSkillHash(w, r, parts[0])
 			return
 		}
 	}
@@ -80,7 +87,7 @@ func (s *Server) handleSkillRegistryByID(w http.ResponseWriter, r *http.Request)
 	switch r.Method {
 	case http.MethodGet:
 		s.getSkillRegistry(w, r, id)
-	case http.MethodPut:
+	case http.MethodPut, http.MethodPatch:
 		s.updateSkillRegistry(w, r, id)
 	case http.MethodDelete:
 		s.deleteSkillRegistry(w, r, id)
@@ -339,4 +346,83 @@ func (s *Server) pinSkillHash(w http.ResponseWriter, r *http.Request, id string)
 		"uri":    req.URI,
 		"hash":   req.Hash,
 	})
+}
+
+func (s *Server) listPinnedHashes(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+
+	ctx := r.Context()
+	registry, err := s.store.GetSkillRegistry(ctx, id)
+	if err != nil {
+		registry, err = s.store.GetSkillRegistryByName(ctx, id)
+		if err != nil {
+			NotFound(w, "Skill Registry")
+			return
+		}
+	}
+
+	hashes, err := s.store.ListPinnedHashes(ctx, registry.ID)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	type pinEntry struct {
+		URI  string `json:"uri"`
+		Hash string `json:"hash"`
+	}
+
+	pins := make([]pinEntry, 0, len(hashes))
+	for uri, hash := range hashes {
+		pins = append(pins, pinEntry{URI: uri, Hash: hash})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"pins": pins})
+}
+
+func (s *Server) unpinSkillHash(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w)
+		return
+	}
+
+	if _, ok := s.requireAdmin(w, r); !ok {
+		return
+	}
+
+	ctx := r.Context()
+	registry, err := s.store.GetSkillRegistry(ctx, id)
+	if err != nil {
+		registry, err = s.store.GetSkillRegistryByName(ctx, id)
+		if err != nil {
+			NotFound(w, "Skill Registry")
+			return
+		}
+	}
+
+	var req struct {
+		URI string `json:"uri"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		BadRequest(w, "Invalid request body: "+err.Error())
+		return
+	}
+	if req.URI == "" {
+		ValidationError(w, "uri is required", nil)
+		return
+	}
+
+	if err := s.store.UnpinSkillHash(ctx, registry.ID, req.URI); err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "unpinned", "uri": req.URI})
 }

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -829,6 +829,10 @@ func resolveAPIPath(urlPath string) string {
 	case strings.HasPrefix(p, "/projects/") && strings.Count(p, "/") == 2:
 		// /projects/{id} -> /api/v1/projects/{id}
 		return "/api/v1" + p
+	case p == "/skills":
+		return "/api/v1/skills"
+	case strings.HasPrefix(p, "/skills/") && strings.Count(p, "/") == 2:
+		return "/api/v1" + p
 	default:
 		return ""
 	}

--- a/pkg/store/entadapter/skill_registry_store.go
+++ b/pkg/store/entadapter/skill_registry_store.go
@@ -237,6 +237,64 @@ func (s *SkillRegistryStore) PinSkillHash(ctx context.Context, registryID string
 	return mapError(tx.Commit())
 }
 
+func (s *SkillRegistryStore) UnpinSkillHash(ctx context.Context, registryID string, uri string) error {
+	uid, err := parseUUID(registryID)
+	if err != nil {
+		return store.ErrNotFound
+	}
+
+	tx, err := s.client.Tx(ctx)
+	if err != nil {
+		return mapError(err)
+	}
+	defer tx.Rollback()
+
+	query := tx.SkillRegistry.Query().
+		Where(entskillregistry.ID(uid))
+	if s.client.Driver().Dialect() == dialect.Postgres {
+		query = query.ForUpdate()
+	}
+	e, err := query.Only(ctx)
+	if err != nil {
+		return mapError(err)
+	}
+
+	hashes := make(map[string]string)
+	if e.PinnedHashes != "" {
+		_ = json.Unmarshal([]byte(e.PinnedHashes), &hashes)
+	}
+	delete(hashes, uri)
+
+	b, _ := json.Marshal(hashes)
+	_, err = tx.SkillRegistry.UpdateOneID(uid).
+		SetPinnedHashes(string(b)).
+		Save(ctx)
+	if err != nil {
+		return mapError(err)
+	}
+
+	return mapError(tx.Commit())
+}
+
+func (s *SkillRegistryStore) ListPinnedHashes(ctx context.Context, registryID string) (map[string]string, error) {
+	uid, err := parseUUID(registryID)
+	if err != nil {
+		return nil, store.ErrNotFound
+	}
+	e, err := s.client.SkillRegistry.Get(ctx, uid)
+	if err != nil {
+		return nil, mapError(err)
+	}
+
+	hashes := make(map[string]string)
+	if e.PinnedHashes != "" {
+		if err := json.Unmarshal([]byte(e.PinnedHashes), &hashes); err != nil {
+			return hashes, nil
+		}
+	}
+	return hashes, nil
+}
+
 func (s *SkillRegistryStore) GetPinnedHash(ctx context.Context, registryID string, uri string) (string, error) {
 	uid, err := parseUUID(registryID)
 	if err != nil {

--- a/pkg/store/entadapter/skill_registry_store.go
+++ b/pkg/store/entadapter/skill_registry_store.go
@@ -289,7 +289,7 @@ func (s *SkillRegistryStore) ListPinnedHashes(ctx context.Context, registryID st
 	hashes := make(map[string]string)
 	if e.PinnedHashes != "" {
 		if err := json.Unmarshal([]byte(e.PinnedHashes), &hashes); err != nil {
-			return hashes, nil
+			return nil, mapError(err)
 		}
 	}
 	return hashes, nil

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1287,5 +1287,7 @@ type SkillRegistryStore interface {
 	DeleteSkillRegistry(ctx context.Context, id string) error
 	ListSkillRegistries(ctx context.Context, opts ListOptions) (*ListResult[SkillRegistry], error)
 	PinSkillHash(ctx context.Context, registryID string, uri string, hash string) error
+	UnpinSkillHash(ctx context.Context, registryID string, uri string) error
 	GetPinnedHash(ctx context.Context, registryID string, uri string) (string, error)
+	ListPinnedHashes(ctx context.Context, registryID string) (map[string]string, error)
 }

--- a/web/scripts/copy-shoelace-icons.mjs
+++ b/web/scripts/copy-shoelace-icons.mjs
@@ -62,6 +62,7 @@ const USED_ICONS = [
   'clipboard',
   'clipboard-check',
   'clock',
+  'cloud-arrow-down',
   'clock-history',
   'code',
   'code-square',

--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -133,6 +133,11 @@ const ROUTES: RouteConfig[] = [
   { pattern: /^\/agents$/, tag: 'scion-page-agents', load: () => import('../components/pages/agents.js') },
   { pattern: /^\/brokers$/, tag: 'scion-page-brokers', load: () => import('../components/pages/brokers.js') },
   { pattern: /^\/brokers\/[^/]+$/, tag: 'scion-page-broker-detail', load: () => import('../components/pages/broker-detail.js') },
+  { pattern: /^\/skills$/, tag: 'scion-page-skills', load: () => import('../components/pages/skills.js') },
+  { pattern: /^\/skills\/new$/, tag: 'scion-page-skill-create', load: () => import('../components/pages/skill-create.js') },
+  { pattern: /^\/skills\/[^/]+$/, tag: 'scion-page-skill-detail', load: () => import('../components/pages/skill-detail.js') },
+  { pattern: /^\/admin\/skill-registries$/, tag: 'scion-page-admin-skill-registries', load: () => import('../components/pages/admin-skill-registries.js') },
+  { pattern: /^\/admin\/skill-registries\/[^/]+$/, tag: 'scion-page-admin-skill-registry-detail', load: () => import('../components/pages/admin-skill-registry-detail.js') },
   { pattern: /^\/admin\/scheduler$/, tag: 'scion-page-admin-scheduler', load: () => import('../components/pages/admin-scheduler.js') },
   { pattern: /^\/admin\/users$/, tag: 'scion-page-admin-users', load: () => import('../components/pages/admin-users.js') },
   { pattern: /^\/admin\/groups$/, tag: 'scion-page-admin-groups', load: () => import('../components/pages/admin-groups.js') },
@@ -175,7 +180,7 @@ const PROFILE_ROUTES = new Set(['scion-page-profile-env-vars', 'scion-page-profi
 /**
  * Routes that require admin role. Non-admin users are redirected to dashboard.
  */
-const ADMIN_ROUTES = new Set(['scion-page-settings', 'scion-page-admin-scheduler', 'scion-page-admin-maintenance', 'scion-page-admin-users', 'scion-page-admin-groups', 'scion-page-admin-group-detail', 'scion-page-admin-server-config']);
+const ADMIN_ROUTES = new Set(['scion-page-settings', 'scion-page-admin-scheduler', 'scion-page-admin-maintenance', 'scion-page-admin-users', 'scion-page-admin-groups', 'scion-page-admin-group-detail', 'scion-page-admin-server-config', 'scion-page-admin-skill-registries', 'scion-page-admin-skill-registry-detail']);
 
 /**
  * Initialize the client-side application

--- a/web/src/components/pages/admin-skill-registries.ts
+++ b/web/src/components/pages/admin-skill-registries.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('scion-page-admin-skill-registries')
+export class ScionPageAdminSkillRegistries extends LitElement {
+  override render() {
+    return html`<p>Skill Registries — coming soon</p>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-page-admin-skill-registries': ScionPageAdminSkillRegistries;
+  }
+}

--- a/web/src/components/pages/admin-skill-registries.ts
+++ b/web/src/components/pages/admin-skill-registries.ts
@@ -14,13 +14,494 @@
  * limitations under the License.
  */
 
-import { LitElement, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+/**
+ * Admin Skill Registries list page
+ *
+ * Table-only admin page showing all skill registries with CRUD via inline dialog.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+
+import type { SkillRegistry } from '../../shared/types.js';
+import { apiFetch, extractApiError } from '../../client/api.js';
+import '../shared/status-badge.js';
 
 @customElement('scion-page-admin-skill-registries')
 export class ScionPageAdminSkillRegistries extends LitElement {
+  @state() private loading = true;
+  @state() private registries: SkillRegistry[] = [];
+  @state() private error: string | null = null;
+
+  // Create dialog state
+  @state() private createOpen = false;
+  @state() private createForm = { name: '', endpoint: '', type: 'hub', trustLevel: 'trusted', description: '', authToken: '', resolvePath: '' };
+  @state() private createError: string | null = null;
+  @state() private creating = false;
+
+  static override styles = css`
+    :host { display: block; }
+
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 1.5rem;
+    }
+    .header h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--scion-text, #1e293b);
+      margin: 0;
+    }
+
+    .table-container {
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--scion-radius-lg, 0.75rem);
+      overflow: hidden;
+    }
+    table { width: 100%; border-collapse: collapse; }
+    th {
+      text-align: left;
+      padding: 0.75rem 1rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--scion-text-muted, #64748b);
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+    }
+    td {
+      padding: 0.75rem 1rem;
+      font-size: 0.875rem;
+      color: var(--scion-text, #1e293b);
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      vertical-align: middle;
+    }
+    tr:last-child td { border-bottom: none; }
+    tr.clickable { cursor: pointer; }
+    tr.clickable:hover td { background: var(--scion-bg-subtle, #f1f5f9); }
+
+    .endpoint-text {
+      font-family: var(--scion-font-mono, monospace);
+      font-size: 0.8125rem;
+      color: var(--scion-text-muted, #64748b);
+      max-width: 300px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .type-badge, .trust-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 500;
+    }
+    .type-badge {
+      background: var(--sl-color-primary-100, #dbeafe);
+      color: var(--sl-color-primary-700, #1d4ed8);
+    }
+    .trust-badge.trusted {
+      background: var(--sl-color-success-100, #dcfce7);
+      color: var(--sl-color-success-700, #15803d);
+    }
+    .trust-badge.pinned {
+      background: var(--sl-color-warning-100, #fef3c7);
+      color: var(--sl-color-warning-700, #a16207);
+    }
+
+    .meta-text {
+      font-size: 0.8125rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 4rem 2rem;
+      background: var(--scion-surface, #ffffff);
+      border: 1px dashed var(--scion-border, #e2e8f0);
+      border-radius: var(--scion-radius-lg, 0.75rem);
+    }
+    .empty-state > sl-icon {
+      font-size: 4rem;
+      color: var(--scion-text-muted, #64748b);
+      opacity: 0.5;
+      margin-bottom: 1rem;
+    }
+    .empty-state h2 {
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+      margin: 0 0 0.5rem 0;
+    }
+    .empty-state p {
+      color: var(--scion-text-muted, #64748b);
+      margin: 0 0 1rem 0;
+    }
+
+    .loading-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 4rem 2rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+    .loading-state sl-spinner { font-size: 2rem; margin-bottom: 1rem; }
+
+    .error-state {
+      text-align: center;
+      padding: 3rem 2rem;
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--sl-color-danger-200, #fecaca);
+      border-radius: var(--scion-radius-lg, 0.75rem);
+    }
+    .error-state sl-icon {
+      font-size: 3rem;
+      color: var(--sl-color-danger-500, #ef4444);
+      margin-bottom: 1rem;
+    }
+    .error-state h2 {
+      font-size: 1.25rem; font-weight: 600;
+      color: var(--scion-text, #1e293b); margin: 0 0 0.5rem 0;
+    }
+    .error-state p { color: var(--scion-text-muted, #64748b); margin: 0 0 1rem 0; }
+    .error-details {
+      font-family: var(--scion-font-mono, monospace);
+      font-size: 0.875rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      padding: 0.75rem 1rem;
+      border-radius: var(--scion-radius, 0.5rem);
+      color: var(--sl-color-danger-700, #b91c1c);
+      margin-bottom: 1rem;
+    }
+
+    .error-banner {
+      background: var(--sl-color-danger-50, #fef2f2);
+      border: 1px solid var(--sl-color-danger-200, #fecaca);
+      border-radius: var(--scion-radius, 0.5rem);
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      display: flex;
+      align-items: flex-start;
+      gap: 0.5rem;
+      color: var(--sl-color-danger-700, #b91c1c);
+      font-size: 0.875rem;
+    }
+    .error-banner sl-icon {
+      flex-shrink: 0;
+      margin-top: 0.125rem;
+    }
+
+    .form-field {
+      margin-bottom: 1rem;
+    }
+    .form-field label {
+      display: block;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+      margin-bottom: 0.375rem;
+    }
+    .form-field .hint {
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+      margin-top: 0.25rem;
+    }
+  `;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    void this.loadRegistries();
+  }
+
+  private async loadRegistries(): Promise<void> {
+    this.loading = true;
+    this.error = null;
+    try {
+      const res = await apiFetch('/api/v1/skill-registries');
+      if (!res.ok) {
+        throw new Error(await extractApiError(res, `HTTP ${res.status}`));
+      }
+      const data = (await res.json()) as { items?: SkillRegistry[]; registries?: SkillRegistry[] } | SkillRegistry[];
+      if (Array.isArray(data)) {
+        this.registries = data;
+      } else {
+        this.registries = data.items || data.registries || [];
+      }
+    } catch (err) {
+      console.error('Failed to load registries:', err);
+      this.error = err instanceof Error ? err.message : 'Failed to load registries';
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private formatRelativeTime(dateString: string): string {
+    try {
+      const date = new Date(dateString);
+      if (isNaN(date.getTime())) return '—';
+      const diffMs = Date.now() - date.getTime();
+      if (diffMs < 0) return 'just now';
+      const seconds = Math.floor(diffMs / 1000);
+      if (seconds < 60) return 'just now';
+      const minutes = Math.floor(seconds / 60);
+      if (minutes < 60) return `${minutes}m ago`;
+      const hours = Math.floor(minutes / 60);
+      if (hours < 24) return `${hours}h ago`;
+      const days = Math.floor(hours / 24);
+      return `${days}d ago`;
+    } catch { return dateString; }
+  }
+
+  private async handleCreate(): Promise<void> {
+    if (!this.createForm.name.trim() || !this.createForm.endpoint.trim()) {
+      this.createError = 'Name and endpoint are required.';
+      return;
+    }
+
+    this.creating = true;
+    this.createError = null;
+
+    try {
+      const body: Record<string, unknown> = {
+        name: this.createForm.name.trim(),
+        endpoint: this.createForm.endpoint.trim(),
+        type: this.createForm.type,
+        trustLevel: this.createForm.trustLevel,
+      };
+      if (this.createForm.description.trim()) body.description = this.createForm.description.trim();
+      if (this.createForm.authToken.trim()) body.authToken = this.createForm.authToken.trim();
+      if (this.createForm.resolvePath.trim()) body.resolvePath = this.createForm.resolvePath.trim();
+
+      const res = await apiFetch('/api/v1/skill-registries', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        throw new Error(await extractApiError(res, 'Failed to create registry'));
+      }
+
+      this.createOpen = false;
+      this.createForm = { name: '', endpoint: '', type: 'hub', trustLevel: 'trusted', description: '', authToken: '', resolvePath: '' };
+      void this.loadRegistries();
+    } catch (err) {
+      this.createError = err instanceof Error ? err.message : 'Failed to create registry';
+    } finally {
+      this.creating = false;
+    }
+  }
+
+  private navigateToDetail(id: string): void {
+    window.history.pushState({}, '', `/admin/skill-registries/${id}`);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }
+
   override render() {
-    return html`<p>Skill Registries — coming soon</p>`;
+    return html`
+      <div class="header">
+        <h1>Skill Registries</h1>
+        <sl-button variant="primary" size="small" @click=${() => { this.createOpen = true; }}>
+          <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+          Create Registry
+        </sl-button>
+      </div>
+
+      ${this.loading ? this.renderLoading()
+        : this.error ? this.renderError()
+        : this.registries.length === 0 ? this.renderEmpty()
+        : this.renderTable()}
+
+      ${this.renderCreateDialog()}
+    `;
+  }
+
+  private renderTable() {
+    return html`
+      <div class="table-container">
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Endpoint</th>
+              <th>Type</th>
+              <th>Trust</th>
+              <th>Status</th>
+              <th>Created</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${this.registries.map((r) => html`
+              <tr class="clickable" @click=${() => this.navigateToDetail(r.id)}>
+                <td><strong>${r.name}</strong></td>
+                <td><span class="endpoint-text">${r.endpoint}</span></td>
+                <td><span class="type-badge">${r.type}</span></td>
+                <td><span class="trust-badge ${r.trustLevel}">${r.trustLevel}</span></td>
+                <td>
+                  <scion-status-badge
+                    status=${r.status === 'active' ? 'success' : 'danger'}
+                    label=${r.status}
+                    size="small"
+                  ></scion-status-badge>
+                </td>
+                <td><span class="meta-text">${this.formatRelativeTime(r.created)}</span></td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  private renderCreateDialog() {
+    return html`
+      <sl-dialog
+        label="Create Skill Registry"
+        ?open=${this.createOpen}
+        @sl-after-hide=${() => { this.createOpen = false; this.createError = null; }}
+        style="--width: 500px;"
+      >
+        ${this.createError ? html`
+          <div class="error-banner">
+            <sl-icon name="exclamation-triangle"></sl-icon>
+            <span>${this.createError}</span>
+          </div>
+        ` : nothing}
+
+        <div class="form-field">
+          <label>Name</label>
+          <sl-input
+            placeholder="production-hub"
+            .value=${this.createForm.name}
+            @sl-input=${(e: Event) => { this.createForm = { ...this.createForm, name: (e.target as HTMLElement & { value: string }).value }; }}
+            required
+          ></sl-input>
+        </div>
+
+        <div class="form-field">
+          <label>Endpoint</label>
+          <sl-input
+            placeholder="https://registry.example.com"
+            .value=${this.createForm.endpoint}
+            @sl-input=${(e: Event) => { this.createForm = { ...this.createForm, endpoint: (e.target as HTMLElement & { value: string }).value }; }}
+            required
+          ></sl-input>
+        </div>
+
+        <div class="form-field">
+          <label>Type</label>
+          <sl-select
+            .value=${this.createForm.type}
+            @sl-change=${(e: Event) => { this.createForm = { ...this.createForm, type: (e.target as HTMLElement & { value: string }).value }; }}
+          >
+            <sl-option value="hub">Hub</sl-option>
+            <sl-option value="gcp">GCP</sl-option>
+          </sl-select>
+        </div>
+
+        <div class="form-field">
+          <label>Trust Level</label>
+          <sl-select
+            .value=${this.createForm.trustLevel}
+            @sl-change=${(e: Event) => { this.createForm = { ...this.createForm, trustLevel: (e.target as HTMLElement & { value: string }).value }; }}
+          >
+            <sl-option value="trusted">Trusted</sl-option>
+            <sl-option value="pinned">Pinned</sl-option>
+          </sl-select>
+          <div class="hint">
+            ${this.createForm.trustLevel === 'trusted'
+              ? 'All content from this registry is trusted.'
+              : 'Only content with pinned hashes is trusted.'}
+          </div>
+        </div>
+
+        <div class="form-field">
+          <label>Description (optional)</label>
+          <sl-textarea
+            .value=${this.createForm.description}
+            @sl-input=${(e: Event) => { this.createForm = { ...this.createForm, description: (e.target as HTMLElement & { value: string }).value }; }}
+            rows="2"
+          ></sl-textarea>
+        </div>
+
+        <div class="form-field">
+          <label>Auth Token (optional)</label>
+          <sl-input
+            type="password"
+            .value=${this.createForm.authToken}
+            @sl-input=${(e: Event) => { this.createForm = { ...this.createForm, authToken: (e.target as HTMLElement & { value: string }).value }; }}
+            toggle-password
+          ></sl-input>
+        </div>
+
+        <div class="form-field">
+          <label>Resolve Path (optional)</label>
+          <sl-input
+            placeholder="/api/v1/skills/resolve"
+            .value=${this.createForm.resolvePath}
+            @sl-input=${(e: Event) => { this.createForm = { ...this.createForm, resolvePath: (e.target as HTMLElement & { value: string }).value }; }}
+          ></sl-input>
+        </div>
+
+        <sl-button slot="footer" variant="default" @click=${() => { this.createOpen = false; }}>
+          Cancel
+        </sl-button>
+        <sl-button
+          slot="footer"
+          variant="primary"
+          ?loading=${this.creating}
+          ?disabled=${this.creating || !this.createForm.name.trim() || !this.createForm.endpoint.trim()}
+          @click=${() => this.handleCreate()}
+        >
+          Create
+        </sl-button>
+      </sl-dialog>
+    `;
+  }
+
+  private renderLoading() {
+    return html`
+      <div class="loading-state">
+        <sl-spinner></sl-spinner>
+        <p>Loading registries...</p>
+      </div>
+    `;
+  }
+
+  private renderError() {
+    return html`
+      <div class="error-state">
+        <sl-icon name="exclamation-triangle"></sl-icon>
+        <h2>Failed to Load Registries</h2>
+        <p>There was a problem connecting to the API.</p>
+        <div class="error-details">${this.error}</div>
+        <sl-button variant="primary" @click=${() => this.loadRegistries()}>
+          <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+          Retry
+        </sl-button>
+      </div>
+    `;
+  }
+
+  private renderEmpty() {
+    return html`
+      <div class="empty-state">
+        <sl-icon name="cloud-arrow-down"></sl-icon>
+        <h2>No Registries</h2>
+        <p>No skill registries have been configured yet.</p>
+        <sl-button variant="primary" @click=${() => { this.createOpen = true; }}>
+          <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+          Create Registry
+        </sl-button>
+      </div>
+    `;
   }
 }
 

--- a/web/src/components/pages/admin-skill-registry-detail.ts
+++ b/web/src/components/pages/admin-skill-registry-detail.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('scion-page-admin-skill-registry-detail')
+export class ScionPageAdminSkillRegistryDetail extends LitElement {
+  override render() {
+    return html`<p>Skill Registry detail — coming soon</p>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-page-admin-skill-registry-detail': ScionPageAdminSkillRegistryDetail;
+  }
+}

--- a/web/src/components/pages/admin-skill-registry-detail.ts
+++ b/web/src/components/pages/admin-skill-registry-detail.ts
@@ -14,13 +14,760 @@
  * limitations under the License.
  */
 
-import { LitElement, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+/**
+ * Admin Skill Registry detail page
+ *
+ * Configuration card with inline edit + pinned hashes section for pinned-trust registries.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+
+import type { SkillRegistry } from '../../shared/types.js';
+import { apiFetch, extractApiError } from '../../client/api.js';
+import '../shared/status-badge.js';
+import '../shared/hash-display.js';
+
+interface PinnedHash {
+  uri: string;
+  hash: string;
+}
 
 @customElement('scion-page-admin-skill-registry-detail')
 export class ScionPageAdminSkillRegistryDetail extends LitElement {
+  @state() private loading = true;
+  @state() private registry: SkillRegistry | null = null;
+  @state() private error: string | null = null;
+  @state() private registryId = '';
+
+  // Edit mode
+  @state() private editing = false;
+  @state() private editForm: Partial<{ name: string; endpoint: string; description: string; type: string; trustLevel: string; resolvePath: string; authToken: string }> = {};
+  @state() private saving = false;
+
+  // Pinned hashes
+  @state() private pinnedHashes: PinnedHash[] = [];
+  @state() private pinnedLoading = false;
+  @state() private pinDialogOpen = false;
+  @state() private pinUri = '';
+  @state() private pinHash = '';
+  @state() private pinning = false;
+
+  // Actions
+  @state() private actionLoading: Record<string, boolean> = {};
+
+  static override styles = css`
+    :host { display: block; }
+
+    .back-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--scion-text-muted, #64748b);
+      text-decoration: none;
+      font-size: 0.875rem;
+      margin-bottom: 1rem;
+    }
+    .back-link:hover { color: var(--scion-primary, #3b82f6); }
+
+    .header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      margin-bottom: 1.5rem;
+      gap: 1rem;
+    }
+    .header h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--scion-text, #1e293b);
+      margin: 0;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+    .header-actions {
+      display: flex;
+      gap: 0.5rem;
+      flex-shrink: 0;
+    }
+
+    .card {
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--scion-radius-lg, 0.75rem);
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    .card-title-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 1rem;
+      padding-bottom: 0.75rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+    }
+    .card-title {
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+      margin: 0;
+    }
+
+    .info-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 1.5rem;
+    }
+    .info-item { display: flex; flex-direction: column; }
+    .info-label {
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.25rem;
+    }
+    .info-value {
+      font-size: 1rem;
+      color: var(--scion-text, #1e293b);
+    }
+    .info-value.mono {
+      font-family: var(--scion-font-mono, monospace);
+      font-size: 0.875rem;
+    }
+
+    .type-badge, .trust-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.8125rem;
+      font-weight: 500;
+    }
+    .type-badge {
+      background: var(--sl-color-primary-100, #dbeafe);
+      color: var(--sl-color-primary-700, #1d4ed8);
+    }
+    .trust-badge.trusted {
+      background: var(--sl-color-success-100, #dcfce7);
+      color: var(--sl-color-success-700, #15803d);
+    }
+    .trust-badge.pinned {
+      background: var(--sl-color-warning-100, #fef3c7);
+      color: var(--sl-color-warning-700, #a16207);
+    }
+
+    .edit-field { margin-bottom: 1rem; }
+    .edit-field label {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--scion-text-muted, #64748b);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.375rem;
+    }
+    .edit-actions {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 1rem;
+    }
+
+    .pin-table {
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--scion-radius-lg, 0.75rem);
+      overflow: hidden;
+    }
+    .pin-table table { width: 100%; border-collapse: collapse; }
+    .pin-table th {
+      text-align: left;
+      padding: 0.75rem 1rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--scion-text-muted, #64748b);
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+    }
+    .pin-table td {
+      padding: 0.75rem 1rem;
+      font-size: 0.875rem;
+      color: var(--scion-text, #1e293b);
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      vertical-align: middle;
+    }
+    .pin-table tr:last-child td { border-bottom: none; }
+
+    .empty-pins {
+      text-align: center;
+      padding: 2rem;
+      color: var(--scion-text-muted, #64748b);
+      font-size: 0.875rem;
+    }
+
+    .loading-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 4rem 2rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+    .loading-state sl-spinner { font-size: 2rem; margin-bottom: 1rem; }
+
+    .error-state {
+      text-align: center;
+      padding: 3rem 2rem;
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--sl-color-danger-200, #fecaca);
+      border-radius: var(--scion-radius-lg, 0.75rem);
+    }
+    .error-state sl-icon {
+      font-size: 3rem;
+      color: var(--sl-color-danger-500, #ef4444);
+      margin-bottom: 1rem;
+    }
+    .error-state h2 {
+      font-size: 1.25rem; font-weight: 600;
+      color: var(--scion-text, #1e293b); margin: 0 0 0.5rem 0;
+    }
+    .error-state p { color: var(--scion-text-muted, #64748b); margin: 0 0 1rem 0; }
+    .error-details {
+      font-family: var(--scion-font-mono, monospace);
+      font-size: 0.875rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      padding: 0.75rem 1rem;
+      border-radius: var(--scion-radius, 0.5rem);
+      color: var(--sl-color-danger-700, #b91c1c);
+      margin-bottom: 1rem;
+    }
+
+    .form-field {
+      margin-bottom: 1rem;
+    }
+    .form-field label {
+      display: block;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+      margin-bottom: 0.375rem;
+    }
+  `;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (typeof window !== 'undefined') {
+      const match = window.location.pathname.match(/\/admin\/skill-registries\/([^/]+)/);
+      if (match) this.registryId = match[1];
+    }
+    void this.loadRegistry();
+  }
+
+  private async loadRegistry(): Promise<void> {
+    this.loading = true;
+    this.error = null;
+    try {
+      const res = await apiFetch(`/api/v1/skill-registries/${this.registryId}`);
+      if (!res.ok) {
+        throw new Error(await extractApiError(res, `HTTP ${res.status}`));
+      }
+      this.registry = (await res.json()) as SkillRegistry;
+
+      if (this.registry.trustLevel === 'pinned') {
+        void this.loadPinnedHashes();
+      }
+    } catch (err) {
+      console.error('Failed to load registry:', err);
+      this.error = err instanceof Error ? err.message : 'Failed to load registry';
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private async loadPinnedHashes(): Promise<void> {
+    this.pinnedLoading = true;
+    try {
+      const res = await apiFetch(`/api/v1/skill-registries/${this.registryId}/pins`);
+      if (res.ok) {
+        const data = (await res.json()) as { pins?: PinnedHash[]; items?: PinnedHash[] } | PinnedHash[];
+        if (Array.isArray(data)) {
+          this.pinnedHashes = data;
+        } else {
+          this.pinnedHashes = data.pins || data.items || [];
+        }
+      }
+    } catch {
+      // Endpoint may not exist yet
+    } finally {
+      this.pinnedLoading = false;
+    }
+  }
+
+  private formatRelativeTime(dateString: string): string {
+    try {
+      const date = new Date(dateString);
+      if (isNaN(date.getTime())) return '—';
+      const diffMs = Date.now() - date.getTime();
+      if (diffMs < 0) return 'just now';
+      const seconds = Math.floor(diffMs / 1000);
+      if (seconds < 60) return 'just now';
+      const minutes = Math.floor(seconds / 60);
+      if (minutes < 60) return `${minutes}m ago`;
+      const hours = Math.floor(minutes / 60);
+      if (hours < 24) return `${hours}h ago`;
+      const days = Math.floor(hours / 24);
+      return `${days}d ago`;
+    } catch { return dateString; }
+  }
+
+  // -- Edit mode --
+
+  private startEditing(): void {
+    if (!this.registry) return;
+    this.editForm = {
+      name: this.registry.name,
+      endpoint: this.registry.endpoint,
+      description: this.registry.description || '',
+      type: this.registry.type,
+      trustLevel: this.registry.trustLevel,
+      resolvePath: this.registry.resolvePath || '',
+      authToken: '',
+    };
+    this.editing = true;
+  }
+
+  private cancelEditing(): void {
+    this.editing = false;
+    this.editForm = {};
+  }
+
+  private async saveEdit(): Promise<void> {
+    if (!this.registry) return;
+    this.saving = true;
+    try {
+      const body: Record<string, unknown> = {};
+      if (this.editForm.name !== undefined && this.editForm.name !== this.registry.name) body.name = this.editForm.name;
+      if (this.editForm.endpoint !== undefined && this.editForm.endpoint !== this.registry.endpoint) body.endpoint = this.editForm.endpoint;
+      if (this.editForm.description !== undefined) body.description = this.editForm.description;
+      if (this.editForm.type !== undefined && this.editForm.type !== this.registry.type) body.type = this.editForm.type;
+      if (this.editForm.trustLevel !== undefined && this.editForm.trustLevel !== this.registry.trustLevel) body.trustLevel = this.editForm.trustLevel;
+      if (this.editForm.resolvePath !== undefined) body.resolvePath = this.editForm.resolvePath;
+      if (this.editForm.authToken) body.authToken = this.editForm.authToken;
+
+      const res = await apiFetch(`/api/v1/skill-registries/${this.registryId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        throw new Error(await extractApiError(res, 'Failed to update registry'));
+      }
+      this.registry = (await res.json()) as SkillRegistry;
+      this.editing = false;
+
+      if (this.registry.trustLevel === 'pinned') {
+        void this.loadPinnedHashes();
+      }
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to save');
+    } finally {
+      this.saving = false;
+    }
+  }
+
+  // -- Toggle status --
+
+  private async toggleStatus(): Promise<void> {
+    if (!this.registry) return;
+    const newStatus = this.registry.status === 'active' ? 'disabled' : 'active';
+    this.actionLoading = { ...this.actionLoading, toggle: true };
+    try {
+      const res = await apiFetch(`/api/v1/skill-registries/${this.registryId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: newStatus }),
+      });
+      if (!res.ok) {
+        throw new Error(await extractApiError(res, 'Failed to update status'));
+      }
+      this.registry = (await res.json()) as SkillRegistry;
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to toggle status');
+    } finally {
+      this.actionLoading = { ...this.actionLoading, toggle: false };
+    }
+  }
+
+  // -- Delete --
+
+  private async handleDelete(): Promise<void> {
+    if (!confirm('Are you sure you want to delete this registry?')) return;
+    this.actionLoading = { ...this.actionLoading, delete: true };
+    try {
+      const res = await apiFetch(`/api/v1/skill-registries/${this.registryId}`, { method: 'DELETE' });
+      if (!res.ok) {
+        throw new Error(await extractApiError(res, 'Failed to delete registry'));
+      }
+      window.history.pushState({}, '', '/admin/skill-registries');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to delete');
+    } finally {
+      this.actionLoading = { ...this.actionLoading, delete: false };
+    }
+  }
+
+  // -- Pin/Unpin --
+
+  private async handlePin(): Promise<void> {
+    if (!this.pinUri.trim() || !this.pinHash.trim()) return;
+    this.pinning = true;
+    try {
+      const res = await apiFetch(`/api/v1/skill-registries/${this.registryId}/pin`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uri: this.pinUri.trim(), hash: this.pinHash.trim() }),
+      });
+      if (!res.ok) {
+        throw new Error(await extractApiError(res, 'Failed to pin hash'));
+      }
+      this.pinDialogOpen = false;
+      this.pinUri = '';
+      this.pinHash = '';
+      void this.loadPinnedHashes();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to pin');
+    } finally {
+      this.pinning = false;
+    }
+  }
+
+  private async handleUnpin(uri: string): Promise<void> {
+    if (!confirm(`Unpin "${uri}"?`)) return;
+    try {
+      const res = await apiFetch(`/api/v1/skill-registries/${this.registryId}/unpin`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uri }),
+      });
+      if (!res.ok) {
+        throw new Error(await extractApiError(res, 'Failed to unpin'));
+      }
+      void this.loadPinnedHashes();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to unpin');
+    }
+  }
+
+  // -- Render --
+
   override render() {
-    return html`<p>Skill Registry detail — coming soon</p>`;
+    if (this.loading) return this.renderLoading();
+    if (this.error || !this.registry) return this.renderError();
+
+    return html`
+      <a href="/admin/skill-registries" class="back-link">
+        <sl-icon name="arrow-left"></sl-icon>
+        Back to Registries
+      </a>
+
+      ${this.renderHeader()}
+      ${this.editing ? this.renderEditMode() : this.renderConfigCard()}
+      ${this.registry.trustLevel === 'pinned' ? this.renderPinnedSection() : nothing}
+      ${this.renderPinDialog()}
+    `;
+  }
+
+  private renderHeader() {
+    const r = this.registry!;
+    return html`
+      <div class="header">
+        <div>
+          <h1>
+            <sl-icon name="cloud-arrow-down"></sl-icon>
+            ${r.name}
+          </h1>
+        </div>
+        <div class="header-actions">
+          <sl-button variant="default" size="small" outline @click=${() => this.startEditing()}>
+            <sl-icon slot="prefix" name="pencil"></sl-icon>
+            Edit
+          </sl-button>
+          <sl-button
+            variant=${r.status === 'active' ? 'warning' : 'success'}
+            size="small"
+            outline
+            ?loading=${this.actionLoading['toggle']}
+            @click=${() => this.toggleStatus()}
+          >
+            ${r.status === 'active' ? 'Disable' : 'Enable'}
+          </sl-button>
+          <sl-button
+            variant="danger"
+            size="small"
+            outline
+            ?loading=${this.actionLoading['delete']}
+            @click=${() => this.handleDelete()}
+          >
+            <sl-icon slot="prefix" name="trash"></sl-icon>
+            Delete
+          </sl-button>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderConfigCard() {
+    const r = this.registry!;
+    return html`
+      <div class="card">
+        <div class="card-title-row">
+          <h3 class="card-title">Configuration</h3>
+        </div>
+        <div class="info-grid">
+          <div class="info-item">
+            <span class="info-label">Name</span>
+            <span class="info-value">${r.name}</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">Endpoint</span>
+            <span class="info-value mono">${r.endpoint}</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">Type</span>
+            <span class="info-value"><span class="type-badge">${r.type}</span></span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">Trust Level</span>
+            <span class="info-value"><span class="trust-badge ${r.trustLevel}">${r.trustLevel}</span></span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">Status</span>
+            <span class="info-value">
+              <scion-status-badge
+                status=${r.status === 'active' ? 'success' : 'danger'}
+                label=${r.status}
+                size="small"
+              ></scion-status-badge>
+            </span>
+          </div>
+          ${r.description ? html`
+            <div class="info-item">
+              <span class="info-label">Description</span>
+              <span class="info-value">${r.description}</span>
+            </div>
+          ` : nothing}
+          ${r.resolvePath ? html`
+            <div class="info-item">
+              <span class="info-label">Resolve Path</span>
+              <span class="info-value mono">${r.resolvePath}</span>
+            </div>
+          ` : nothing}
+          <div class="info-item">
+            <span class="info-label">Created</span>
+            <span class="info-value">${this.formatRelativeTime(r.created)}</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">Updated</span>
+            <span class="info-value">${this.formatRelativeTime(r.updated)}</span>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderEditMode() {
+    return html`
+      <div class="card">
+        <div class="card-title-row">
+          <h3 class="card-title">Edit Configuration</h3>
+        </div>
+        <div class="edit-field">
+          <label>Name</label>
+          <sl-input
+            .value=${this.editForm.name || ''}
+            @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, name: (e.target as HTMLElement & { value: string }).value }; }}
+          ></sl-input>
+        </div>
+        <div class="edit-field">
+          <label>Endpoint</label>
+          <sl-input
+            .value=${this.editForm.endpoint || ''}
+            @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, endpoint: (e.target as HTMLElement & { value: string }).value }; }}
+          ></sl-input>
+        </div>
+        <div class="edit-field">
+          <label>Type</label>
+          <sl-select
+            .value=${this.editForm.type || 'hub'}
+            @sl-change=${(e: Event) => { this.editForm = { ...this.editForm, type: (e.target as HTMLElement & { value: string }).value }; }}
+          >
+            <sl-option value="hub">Hub</sl-option>
+            <sl-option value="gcp">GCP</sl-option>
+          </sl-select>
+        </div>
+        <div class="edit-field">
+          <label>Trust Level</label>
+          <sl-select
+            .value=${this.editForm.trustLevel || 'trusted'}
+            @sl-change=${(e: Event) => { this.editForm = { ...this.editForm, trustLevel: (e.target as HTMLElement & { value: string }).value }; }}
+          >
+            <sl-option value="trusted">Trusted</sl-option>
+            <sl-option value="pinned">Pinned</sl-option>
+          </sl-select>
+        </div>
+        <div class="edit-field">
+          <label>Description</label>
+          <sl-textarea
+            .value=${this.editForm.description || ''}
+            @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, description: (e.target as HTMLElement & { value: string }).value }; }}
+            rows="2"
+          ></sl-textarea>
+        </div>
+        <div class="edit-field">
+          <label>Resolve Path</label>
+          <sl-input
+            .value=${this.editForm.resolvePath || ''}
+            @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, resolvePath: (e.target as HTMLElement & { value: string }).value }; }}
+          ></sl-input>
+        </div>
+        <div class="edit-field">
+          <label>Auth Token (leave blank to keep current)</label>
+          <sl-input
+            type="password"
+            .value=${this.editForm.authToken || ''}
+            @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, authToken: (e.target as HTMLElement & { value: string }).value }; }}
+            toggle-password
+          ></sl-input>
+        </div>
+        <div class="edit-actions">
+          <sl-button variant="primary" size="small" ?loading=${this.saving} @click=${() => this.saveEdit()}>
+            Save
+          </sl-button>
+          <sl-button variant="default" size="small" ?disabled=${this.saving} @click=${() => this.cancelEditing()}>
+            Cancel
+          </sl-button>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderPinnedSection() {
+    return html`
+      <div class="card">
+        <div class="card-title-row">
+          <h3 class="card-title">Pinned Hashes</h3>
+          <sl-button size="small" variant="default" outline @click=${() => { this.pinDialogOpen = true; }}>
+            <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+            Pin Hash
+          </sl-button>
+        </div>
+
+        ${this.pinnedLoading ? html`
+          <div style="text-align: center; padding: 1rem;">
+            <sl-spinner></sl-spinner>
+          </div>
+        ` : this.pinnedHashes.length === 0 ? html`
+          <div class="empty-pins">
+            <p>No pinned hashes. Pin specific skill hashes to restrict which content is trusted from this registry.</p>
+          </div>
+        ` : html`
+          <div class="pin-table">
+            <table>
+              <thead>
+                <tr>
+                  <th>URI</th>
+                  <th>Hash</th>
+                  <th style="text-align: right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${this.pinnedHashes.map((p) => html`
+                  <tr>
+                    <td style="font-family: var(--scion-font-mono, monospace); font-size: 0.875rem;">${p.uri}</td>
+                    <td><scion-hash-display .hash=${p.hash} max-width="20ch"></scion-hash-display></td>
+                    <td style="text-align: right">
+                      <sl-button size="small" variant="danger" outline @click=${() => this.handleUnpin(p.uri)}>
+                        Unpin
+                      </sl-button>
+                    </td>
+                  </tr>
+                `)}
+              </tbody>
+            </table>
+          </div>
+        `}
+      </div>
+    `;
+  }
+
+  private renderPinDialog() {
+    return html`
+      <sl-dialog
+        label="Pin Hash"
+        ?open=${this.pinDialogOpen}
+        @sl-after-hide=${() => { this.pinDialogOpen = false; }}
+      >
+        <div class="form-field">
+          <label>Skill URI</label>
+          <sl-input
+            placeholder="global:my-skill@1.0.0"
+            .value=${this.pinUri}
+            @sl-input=${(e: Event) => { this.pinUri = (e.target as HTMLElement & { value: string }).value; }}
+          ></sl-input>
+        </div>
+        <div class="form-field">
+          <label>Content Hash</label>
+          <sl-input
+            placeholder="sha256:abc123..."
+            .value=${this.pinHash}
+            @sl-input=${(e: Event) => { this.pinHash = (e.target as HTMLElement & { value: string }).value; }}
+          ></sl-input>
+        </div>
+        <sl-button slot="footer" variant="default" @click=${() => { this.pinDialogOpen = false; }}>
+          Cancel
+        </sl-button>
+        <sl-button
+          slot="footer"
+          variant="primary"
+          ?loading=${this.pinning}
+          ?disabled=${this.pinning || !this.pinUri.trim() || !this.pinHash.trim()}
+          @click=${() => this.handlePin()}
+        >
+          Pin
+        </sl-button>
+      </sl-dialog>
+    `;
+  }
+
+  private renderLoading() {
+    return html`
+      <div class="loading-state">
+        <sl-spinner></sl-spinner>
+        <p>Loading registry...</p>
+      </div>
+    `;
+  }
+
+  private renderError() {
+    return html`
+      <a href="/admin/skill-registries" class="back-link">
+        <sl-icon name="arrow-left"></sl-icon>
+        Back to Registries
+      </a>
+      <div class="error-state">
+        <sl-icon name="exclamation-triangle"></sl-icon>
+        <h2>Failed to Load Registry</h2>
+        <p>There was a problem loading this registry.</p>
+        <div class="error-details">${this.error || 'Registry not found'}</div>
+        <sl-button variant="primary" @click=${() => this.loadRegistry()}>
+          <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+          Retry
+        </sl-button>
+      </div>
+    `;
   }
 }
 

--- a/web/src/components/pages/admin-skill-registry-detail.ts
+++ b/web/src/components/pages/admin-skill-registry-detail.ts
@@ -42,7 +42,7 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
 
   // Edit mode
   @state() private editing = false;
-  @state() private editForm: Partial<{ name: string; endpoint: string; description: string; type: string; trustLevel: string; resolvePath: string; authToken: string }> = {};
+  @state() private editForm: Partial<{ endpoint: string; description: string; trustLevel: string; resolvePath: string; authToken: string }> = {};
   @state() private saving = false;
 
   // Pinned hashes
@@ -327,10 +327,8 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
   private startEditing(): void {
     if (!this.registry) return;
     this.editForm = {
-      name: this.registry.name,
       endpoint: this.registry.endpoint,
       description: this.registry.description || '',
-      type: this.registry.type,
       trustLevel: this.registry.trustLevel,
       resolvePath: this.registry.resolvePath || '',
       authToken: '',
@@ -348,10 +346,8 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
     this.saving = true;
     try {
       const body: Record<string, unknown> = {};
-      if (this.editForm.name !== undefined && this.editForm.name !== this.registry.name) body.name = this.editForm.name;
       if (this.editForm.endpoint !== undefined && this.editForm.endpoint !== this.registry.endpoint) body.endpoint = this.editForm.endpoint;
       if (this.editForm.description !== undefined) body.description = this.editForm.description;
-      if (this.editForm.type !== undefined && this.editForm.type !== this.registry.type) body.type = this.editForm.type;
       if (this.editForm.trustLevel !== undefined && this.editForm.trustLevel !== this.registry.trustLevel) body.trustLevel = this.editForm.trustLevel;
       if (this.editForm.resolvePath !== undefined) body.resolvePath = this.editForm.resolvePath;
       if (this.editForm.authToken) body.authToken = this.editForm.authToken;
@@ -586,10 +582,11 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
         </div>
         <div class="edit-field">
           <label>Name</label>
-          <sl-input
-            .value=${this.editForm.name || ''}
-            @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, name: (e.target as HTMLElement & { value: string }).value }; }}
-          ></sl-input>
+          <span class="info-value">${this.registry!.name}</span>
+        </div>
+        <div class="edit-field">
+          <label>Type</label>
+          <span class="info-value"><span class="type-badge">${this.registry!.type}</span></span>
         </div>
         <div class="edit-field">
           <label>Endpoint</label>
@@ -597,16 +594,6 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
             .value=${this.editForm.endpoint || ''}
             @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, endpoint: (e.target as HTMLElement & { value: string }).value }; }}
           ></sl-input>
-        </div>
-        <div class="edit-field">
-          <label>Type</label>
-          <sl-select
-            .value=${this.editForm.type || 'hub'}
-            @sl-change=${(e: Event) => { this.editForm = { ...this.editForm, type: (e.target as HTMLElement & { value: string }).value }; }}
-          >
-            <sl-option value="hub">Hub</sl-option>
-            <sl-option value="gcp">GCP</sl-option>
-          </sl-select>
         </div>
         <div class="edit-field">
           <label>Trust Level</label>
@@ -624,6 +611,7 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
             .value=${this.editForm.description || ''}
             @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, description: (e.target as HTMLElement & { value: string }).value }; }}
             rows="2"
+            help-text="Once set, this field cannot be cleared."
           ></sl-textarea>
         </div>
         <div class="edit-field">
@@ -631,6 +619,7 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
           <sl-input
             .value=${this.editForm.resolvePath || ''}
             @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, resolvePath: (e.target as HTMLElement & { value: string }).value }; }}
+            help-text="Once set, this field cannot be cleared."
           ></sl-input>
         </div>
         <div class="edit-field">

--- a/web/src/components/pages/skill-create.ts
+++ b/web/src/components/pages/skill-create.ts
@@ -14,13 +14,342 @@
  * limitations under the License.
  */
 
-import { LitElement, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+/**
+ * Skill creation page component
+ *
+ * Form for creating a new skill with name, scope, visibility, description, and tags.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+
+import { apiFetch, extractApiError } from '../../client/api.js';
 
 @customElement('scion-page-skill-create')
 export class ScionPageSkillCreate extends LitElement {
+  @state() private submitting = false;
+  @state() private error: string | null = null;
+  @state() private name = '';
+  @state() private description = '';
+  @state() private scope: 'global' | 'project' | 'user' = 'global';
+  @state() private scopeId = '';
+  @state() private visibility: 'private' | 'public' = 'private';
+  @state() private tagsInput = '';
+
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    .back-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--scion-text-muted, #64748b);
+      text-decoration: none;
+      font-size: 0.875rem;
+      margin-bottom: 1rem;
+    }
+
+    .back-link:hover {
+      color: var(--scion-primary, #3b82f6);
+    }
+
+    .page-header {
+      margin-bottom: 1.5rem;
+    }
+
+    .page-header h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--scion-text, #1e293b);
+      margin: 0 0 0.25rem 0;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .page-header h1 sl-icon {
+      color: var(--scion-primary, #3b82f6);
+      font-size: 1.5rem;
+    }
+
+    .page-header p {
+      color: var(--scion-text-muted, #64748b);
+      margin: 0;
+      font-size: 0.875rem;
+    }
+
+    .form-card {
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--scion-radius-lg, 0.75rem);
+      padding: 1.5rem;
+      max-width: 640px;
+    }
+
+    .form-field {
+      margin-bottom: 1.25rem;
+    }
+
+    .form-field label {
+      display: block;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+      margin-bottom: 0.375rem;
+    }
+
+    .form-field .hint {
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+      margin-top: 0.25rem;
+    }
+
+    .form-field sl-input,
+    .form-field sl-textarea,
+    .form-field sl-select,
+    .form-field sl-radio-group {
+      width: 100%;
+    }
+
+    .form-actions {
+      display: flex;
+      gap: 0.75rem;
+      margin-top: 1.5rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--scion-border, #e2e8f0);
+    }
+
+    .error-banner {
+      background: var(--sl-color-danger-50, #fef2f2);
+      border: 1px solid var(--sl-color-danger-200, #fecaca);
+      border-radius: var(--scion-radius, 0.5rem);
+      padding: 0.75rem 1rem;
+      margin-bottom: 1.25rem;
+      display: flex;
+      align-items: flex-start;
+      gap: 0.5rem;
+      color: var(--sl-color-danger-700, #b91c1c);
+      font-size: 0.875rem;
+    }
+
+    .error-banner sl-icon {
+      flex-shrink: 0;
+      margin-top: 0.125rem;
+    }
+
+    .tag-chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.375rem;
+      margin-top: 0.5rem;
+    }
+
+    .tag-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      font-size: 0.75rem;
+      padding: 0.125rem 0.5rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 9999px;
+      color: var(--scion-text, #1e293b);
+    }
+  `;
+
+  private get parsedTags(): string[] {
+    if (!this.tagsInput.trim()) return [];
+    return this.tagsInput
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0);
+  }
+
+  private async handleSubmit(): Promise<void> {
+    if (!this.name.trim()) {
+      this.error = 'Skill name is required.';
+      return;
+    }
+
+    this.submitting = true;
+    this.error = null;
+
+    try {
+      const body: Record<string, unknown> = {
+        name: this.name.trim(),
+        scope: this.scope,
+        visibility: this.visibility,
+      };
+
+      if (this.description.trim()) {
+        body.description = this.description.trim();
+      }
+
+      if (this.scopeId.trim() && (this.scope === 'project' || this.scope === 'user')) {
+        body.scopeId = this.scopeId.trim();
+      }
+
+      const tags = this.parsedTags;
+      if (tags.length > 0) {
+        body.tags = tags;
+      }
+
+      const response = await apiFetch('/api/v1/skills', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        throw new Error(await extractApiError(response, `HTTP ${response.status}`));
+      }
+
+      const result = (await response.json()) as { skill?: { id: string }; id?: string };
+      const skillId = result.skill?.id || result.id;
+
+      if (!skillId) {
+        throw new Error('No skill ID in response');
+      }
+
+      window.history.pushState({}, '', `/skills/${skillId}`);
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    } catch (err) {
+      console.error('Failed to create skill:', err);
+      this.error = err instanceof Error ? err.message : 'Failed to create skill';
+    } finally {
+      this.submitting = false;
+    }
+  }
+
   override render() {
-    return html`<p>Create skill — coming soon</p>`;
+    return html`
+      <a href="/skills" class="back-link">
+        <sl-icon name="arrow-left"></sl-icon>
+        Back to Skills
+      </a>
+
+      <div class="page-header">
+        <h1>
+          <sl-icon name="lightning-charge"></sl-icon>
+          Create Skill
+        </h1>
+        <p>Define a new reusable skill for your agents.</p>
+      </div>
+
+      <div class="form-card">
+        ${this.error
+          ? html`
+              <div class="error-banner">
+                <sl-icon name="exclamation-triangle"></sl-icon>
+                <span>${this.error}</span>
+              </div>
+            `
+          : nothing}
+
+        <div>
+          <div class="form-field">
+            <label for="name">Name</label>
+            <sl-input
+              id="name"
+              placeholder="my-skill"
+              .value=${this.name}
+              @sl-input=${(e: Event) => { this.name = (e.target as HTMLElement & { value: string }).value; }}
+              required
+            ></sl-input>
+          </div>
+
+          <div class="form-field">
+            <label for="description">Description</label>
+            <sl-textarea
+              id="description"
+              placeholder="What does this skill do?"
+              .value=${this.description}
+              @sl-input=${(e: Event) => { this.description = (e.target as HTMLElement & { value: string }).value; }}
+              maxlength="500"
+              rows="3"
+            ></sl-textarea>
+          </div>
+
+          <div class="form-field">
+            <label for="scope">Scope</label>
+            <sl-select
+              id="scope"
+              .value=${this.scope}
+              @sl-change=${(e: Event) => { this.scope = (e.target as HTMLElement & { value: string }).value as 'global' | 'project' | 'user'; }}
+            >
+              <sl-option value="global">Global</sl-option>
+              <sl-option value="project">Project</sl-option>
+              <sl-option value="user">User</sl-option>
+            </sl-select>
+            <div class="hint">
+              ${this.scope === 'global'
+                ? 'Available to all projects and agents.'
+                : this.scope === 'project'
+                  ? 'Scoped to a specific project.'
+                  : 'Scoped to a specific user.'}
+            </div>
+          </div>
+
+          ${this.scope === 'project' || this.scope === 'user' ? html`
+            <div class="form-field">
+              <label for="scopeId">${this.scope === 'project' ? 'Project ID' : 'User ID'}</label>
+              <sl-input
+                id="scopeId"
+                placeholder="${this.scope === 'project' ? 'project-uuid' : 'user-uuid'}"
+                .value=${this.scopeId}
+                @sl-input=${(e: Event) => { this.scopeId = (e.target as HTMLElement & { value: string }).value; }}
+              ></sl-input>
+            </div>
+          ` : nothing}
+
+          <div class="form-field">
+            <label>Visibility</label>
+            <sl-radio-group
+              .value=${this.visibility}
+              @sl-change=${(e: Event) => { this.visibility = (e.target as HTMLElement & { value: string }).value as 'private' | 'public'; }}
+            >
+              <sl-radio-button value="private">Private</sl-radio-button>
+              <sl-radio-button value="public">Public</sl-radio-button>
+            </sl-radio-group>
+          </div>
+
+          <div class="form-field">
+            <label for="tags">Tags</label>
+            <sl-input
+              id="tags"
+              placeholder="cli, automation, testing"
+              .value=${this.tagsInput}
+              @sl-input=${(e: Event) => { this.tagsInput = (e.target as HTMLElement & { value: string }).value; }}
+            ></sl-input>
+            <div class="hint">Comma-separated list of tags.</div>
+            ${this.parsedTags.length > 0 ? html`
+              <div class="tag-chips">
+                ${this.parsedTags.map((tag) => html`<span class="tag-chip">${tag}</span>`)}
+              </div>
+            ` : nothing}
+          </div>
+
+          <div class="form-actions">
+            <sl-button
+              variant="primary"
+              ?loading=${this.submitting}
+              ?disabled=${this.submitting}
+              @click=${() => this.handleSubmit()}
+            >
+              <sl-icon slot="prefix" name="lightning-charge"></sl-icon>
+              Create Skill
+            </sl-button>
+            <a href="/skills" style="text-decoration: none;">
+              <sl-button variant="default" ?disabled=${this.submitting}>
+                Cancel
+              </sl-button>
+            </a>
+          </div>
+        </div>
+      </div>
+    `;
   }
 }
 

--- a/web/src/components/pages/skill-create.ts
+++ b/web/src/components/pages/skill-create.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('scion-page-skill-create')
+export class ScionPageSkillCreate extends LitElement {
+  override render() {
+    return html`<p>Create skill — coming soon</p>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-page-skill-create': ScionPageSkillCreate;
+  }
+}

--- a/web/src/components/pages/skill-create.ts
+++ b/web/src/components/pages/skill-create.ts
@@ -23,10 +23,14 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
+import type { Capabilities } from '../../shared/types.js';
+import { can } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 
 @customElement('scion-page-skill-create')
 export class ScionPageSkillCreate extends LitElement {
+  @state() private loading = true;
+  @state() private canCreate = false;
   @state() private submitting = false;
   @state() private error: string | null = null;
   @state() private name = '';
@@ -159,6 +163,26 @@ export class ScionPageSkillCreate extends LitElement {
     }
   `;
 
+  override connectedCallback(): void {
+    super.connectedCallback();
+    void this.checkCapabilities();
+  }
+
+  private async checkCapabilities(): Promise<void> {
+    this.loading = true;
+    try {
+      const res = await apiFetch('/api/v1/skills');
+      if (res.ok) {
+        const data = (await res.json()) as { _capabilities?: Capabilities };
+        this.canCreate = can(data._capabilities, 'create');
+      }
+    } catch {
+      // fail-closed
+    } finally {
+      this.loading = false;
+    }
+  }
+
   private get parsedTags(): string[] {
     if (!this.tagsInput.trim()) return [];
     return this.tagsInput
@@ -224,6 +248,35 @@ export class ScionPageSkillCreate extends LitElement {
   }
 
   override render() {
+    if (this.loading) {
+      return html`
+        <div style="display: flex; flex-direction: column; align-items: center; padding: 4rem 2rem; color: var(--scion-text-muted, #64748b);">
+          <sl-spinner style="font-size: 2rem; margin-bottom: 1rem;"></sl-spinner>
+          <p>Loading...</p>
+        </div>
+      `;
+    }
+
+    if (!this.canCreate) {
+      return html`
+        <a href="/skills" class="back-link">
+          <sl-icon name="arrow-left"></sl-icon>
+          Back to Skills
+        </a>
+        <div style="text-align: center; padding: 3rem 2rem; background: var(--scion-surface, #ffffff); border: 1px solid var(--scion-border, #e2e8f0); border-radius: var(--scion-radius-lg, 0.75rem);">
+          <sl-icon name="shield-lock" style="font-size: 3rem; color: var(--scion-text-muted, #64748b); margin-bottom: 1rem;"></sl-icon>
+          <h2 style="font-size: 1.25rem; font-weight: 600; color: var(--scion-text, #1e293b); margin: 0 0 0.5rem 0;">Access Denied</h2>
+          <p style="color: var(--scion-text-muted, #64748b); margin: 0 0 1rem 0;">You do not have permission to create skills.</p>
+          <a href="/skills" style="text-decoration: none;">
+            <sl-button variant="primary">
+              <sl-icon slot="prefix" name="arrow-left"></sl-icon>
+              Back to Skills
+            </sl-button>
+          </a>
+        </div>
+      `;
+    }
+
     return html`
       <a href="/skills" class="back-link">
         <sl-icon name="arrow-left"></sl-icon>

--- a/web/src/components/pages/skill-create.ts
+++ b/web/src/components/pages/skill-create.ts
@@ -197,6 +197,11 @@ export class ScionPageSkillCreate extends LitElement {
       return;
     }
 
+    if ((this.scope === 'project' || this.scope === 'user') && !this.scopeId.trim()) {
+      this.error = `${this.scope === 'project' ? 'Project' : 'User'} ID is required for ${this.scope} scope.`;
+      return;
+    }
+
     this.submitting = true;
     this.error = null;
 

--- a/web/src/components/pages/skill-detail.ts
+++ b/web/src/components/pages/skill-detail.ts
@@ -14,13 +14,981 @@
  * limitations under the License.
  */
 
-import { LitElement, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+/**
+ * Skill detail page component
+ *
+ * Tabbed layout with Overview, Versions, and Files tabs.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+import type { PageData, Skill, SkillVersion, SkillDownloadUrl } from '../../shared/types.js';
+import { can } from '../../shared/types.js';
+import type { StatusType } from '../shared/status-badge.js';
+import { apiFetch, extractApiError } from '../../client/api.js';
+import '../shared/status-badge.js';
+import '../shared/hash-display.js';
 
 @customElement('scion-page-skill-detail')
 export class ScionPageSkillDetail extends LitElement {
+  @property({ type: Object }) pageData: PageData | null = null;
+  @property({ type: String }) skillId = '';
+
+  @state() private loading = true;
+  @state() private skill: Skill | null = null;
+  @state() private versions: SkillVersion[] = [];
+  @state() private error: string | null = null;
+  @state() private editing = false;
+  @state() private editForm: Partial<{ name: string; description: string; visibility: string; tags: string }> = {};
+  @state() private saving = false;
+  @state() private actionLoading: Record<string, boolean> = {};
+
+  // Deprecate dialog state
+  @state() private deprecateVersionId: string | null = null;
+  @state() private deprecateMessage = '';
+  @state() private deprecateReplacement = '';
+  @state() private deprecateLoading = false;
+
+  // Files tab state
+  @state() private selectedVersionForFiles = '';
+  @state() private fileUrls: SkillDownloadUrl[] = [];
+  @state() private filesLoading = false;
+
+  static override styles = css`
+    :host { display: block; }
+
+    .back-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--scion-text-muted, #64748b);
+      text-decoration: none;
+      font-size: 0.875rem;
+      margin-bottom: 1rem;
+    }
+    .back-link:hover { color: var(--scion-primary, #3b82f6); }
+
+    .header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      margin-bottom: 1.5rem;
+      gap: 1rem;
+    }
+    .header-info { flex: 1; }
+    .header-title {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 0.5rem;
+    }
+    .header-title sl-icon {
+      color: var(--scion-primary, #3b82f6);
+      font-size: 1.5rem;
+    }
+    .header h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--scion-text, #1e293b);
+      margin: 0;
+    }
+    .header-meta {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-top: 0.5rem;
+    }
+    .header-actions {
+      display: flex;
+      gap: 0.5rem;
+      flex-shrink: 0;
+    }
+
+    sl-tab-group { --track-color: var(--scion-border, #e2e8f0); }
+    sl-tab-group::part(body) { padding-top: 1.5rem; }
+
+    .card {
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--scion-radius-lg, 0.75rem);
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    .card-title-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 1rem;
+      padding-bottom: 0.75rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+    }
+    .card-title {
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+      margin: 0;
+    }
+
+    .info-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 1.5rem;
+    }
+    .info-item { display: flex; flex-direction: column; }
+    .info-label {
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.25rem;
+    }
+    .info-value {
+      font-size: 1rem;
+      color: var(--scion-text, #1e293b);
+    }
+    .info-value.mono {
+      font-family: var(--scion-font-mono, monospace);
+      font-size: 0.875rem;
+    }
+
+    .tag-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.375rem;
+    }
+    .tag-item {
+      display: inline-block;
+      font-size: 0.75rem;
+      padding: 0.125rem 0.5rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 9999px;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .scope-badge, .visibility-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.8125rem;
+      font-weight: 500;
+    }
+    .scope-badge {
+      background: var(--scion-bg-subtle, #f1f5f9);
+      color: var(--scion-text-muted, #64748b);
+    }
+    .visibility-badge.public {
+      background: var(--sl-color-success-100, #dcfce7);
+      color: var(--sl-color-success-700, #15803d);
+    }
+    .visibility-badge.private {
+      background: var(--scion-bg-subtle, #f1f5f9);
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .uri-copy {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-family: var(--scion-font-mono, monospace);
+      font-size: 0.875rem;
+      padding: 0.25rem 0.5rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border-radius: var(--scion-radius, 0.5rem);
+      cursor: pointer;
+    }
+    .uri-copy:hover {
+      background: var(--scion-border, #e2e8f0);
+    }
+    .uri-copy sl-icon {
+      font-size: 0.875rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .edit-field { margin-bottom: 1rem; }
+    .edit-field label {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--scion-text-muted, #64748b);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.375rem;
+    }
+    .edit-actions {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 1rem;
+    }
+
+    .version-table {
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--scion-radius-lg, 0.75rem);
+      overflow: hidden;
+    }
+    .version-table table { width: 100%; border-collapse: collapse; }
+    .version-table th {
+      text-align: left;
+      padding: 0.75rem 1rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--scion-text-muted, #64748b);
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+    }
+    .version-table td {
+      padding: 0.75rem 1rem;
+      font-size: 0.875rem;
+      color: var(--scion-text, #1e293b);
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      vertical-align: middle;
+    }
+    .version-table tr:last-child td { border-bottom: none; }
+    .version-table .actions-cell { text-align: right; white-space: nowrap; }
+
+    .file-table {
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--scion-radius-lg, 0.75rem);
+      overflow: hidden;
+    }
+    .file-table table { width: 100%; border-collapse: collapse; }
+    .file-table th {
+      text-align: left;
+      padding: 0.75rem 1rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--scion-text-muted, #64748b);
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+    }
+    .file-table td {
+      padding: 0.75rem 1rem;
+      font-size: 0.875rem;
+      color: var(--scion-text, #1e293b);
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      vertical-align: middle;
+    }
+    .file-table tr:last-child td { border-bottom: none; }
+
+    .version-selector {
+      margin-bottom: 1rem;
+    }
+
+    .loading-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 4rem 2rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+    .loading-state sl-spinner { font-size: 2rem; margin-bottom: 1rem; }
+
+    .error-state {
+      text-align: center;
+      padding: 3rem 2rem;
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--sl-color-danger-200, #fecaca);
+      border-radius: var(--scion-radius-lg, 0.75rem);
+    }
+    .error-state sl-icon {
+      font-size: 3rem;
+      color: var(--sl-color-danger-500, #ef4444);
+      margin-bottom: 1rem;
+    }
+    .error-state h2 {
+      font-size: 1.25rem; font-weight: 600;
+      color: var(--scion-text, #1e293b); margin: 0 0 0.5rem 0;
+    }
+    .error-state p { color: var(--scion-text-muted, #64748b); margin: 0 0 1rem 0; }
+    .error-details {
+      font-family: var(--scion-font-mono, monospace);
+      font-size: 0.875rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      padding: 0.75rem 1rem;
+      border-radius: var(--scion-radius, 0.5rem);
+      color: var(--sl-color-danger-700, #b91c1c);
+      margin-bottom: 1rem;
+    }
+
+    .empty-versions {
+      text-align: center;
+      padding: 2rem;
+      color: var(--scion-text-muted, #64748b);
+      font-size: 0.875rem;
+    }
+  `;
+
+  private relativeTimeInterval: ReturnType<typeof setInterval> | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (!this.skillId && typeof window !== 'undefined') {
+      const match = window.location.pathname.match(/\/skills\/([^/]+)/);
+      if (match) this.skillId = match[1];
+    }
+    void this.loadData();
+    this.relativeTimeInterval = setInterval(() => this.requestUpdate(), 15000);
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this.relativeTimeInterval) {
+      clearInterval(this.relativeTimeInterval);
+      this.relativeTimeInterval = null;
+    }
+  }
+
+  private async loadData(): Promise<void> {
+    this.loading = true;
+    this.error = null;
+
+    try {
+      const ssrSkill = this.pageData?.data as Skill | undefined;
+      if (ssrSkill && ssrSkill.id === this.skillId) {
+        this.skill = ssrSkill;
+      } else {
+        const res = await apiFetch(`/api/v1/skills/${this.skillId}`);
+        if (!res.ok) {
+          throw new Error(await extractApiError(res, `HTTP ${res.status}: ${res.statusText}`));
+        }
+        this.skill = (await res.json()) as Skill;
+      }
+
+      const versionsRes = await apiFetch(`/api/v1/skills/${this.skillId}/versions`);
+      if (versionsRes.ok) {
+        const data = (await versionsRes.json()) as { items?: SkillVersion[]; versions?: SkillVersion[] } | SkillVersion[];
+        if (Array.isArray(data)) {
+          this.versions = data;
+        } else {
+          this.versions = data.items || data.versions || [];
+        }
+      }
+    } catch (err) {
+      console.error('Failed to load skill:', err);
+      this.error = err instanceof Error ? err.message : 'Failed to load skill';
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private formatRelativeTime(dateString: string): string {
+    try {
+      const date = new Date(dateString);
+      if (isNaN(date.getTime())) return '—';
+      const diffMs = Date.now() - date.getTime();
+      if (diffMs < 0) return 'just now';
+      const seconds = Math.floor(diffMs / 1000);
+      if (seconds < 60) return 'just now';
+      const minutes = Math.floor(seconds / 60);
+      if (minutes < 60) return `${minutes}m ago`;
+      const hours = Math.floor(minutes / 60);
+      if (hours < 24) return `${hours}h ago`;
+      const days = Math.floor(hours / 24);
+      return `${days}d ago`;
+    } catch { return dateString; }
+  }
+
+  private formatFileSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  private versionStatusType(status: string): StatusType {
+    switch (status) {
+      case 'published': return 'success' as StatusType;
+      case 'deprecated': return 'warning' as StatusType;
+      case 'archived': return 'danger' as StatusType;
+      default: return 'default' as StatusType;
+    }
+  }
+
+  private getSkillUri(): string {
+    if (!this.skill) return '';
+    return `${this.skill.scope}:${this.skill.slug}@latest`;
+  }
+
+  private async copyUri(): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(this.getSkillUri());
+    } catch { /* ignore */ }
+  }
+
+  // -- Edit mode --
+
+  private startEditing(): void {
+    if (!this.skill) return;
+    this.editForm = {
+      name: this.skill.name,
+      description: this.skill.description || '',
+      visibility: this.skill.visibility,
+      tags: this.skill.tags?.join(', ') || '',
+    };
+    this.editing = true;
+  }
+
+  private cancelEditing(): void {
+    this.editing = false;
+    this.editForm = {};
+  }
+
+  private async saveEdit(): Promise<void> {
+    if (!this.skill) return;
+    this.saving = true;
+
+    try {
+      const body: Record<string, unknown> = {};
+      if (this.editForm.name !== undefined && this.editForm.name !== this.skill.name) {
+        body.name = this.editForm.name;
+      }
+      if (this.editForm.description !== undefined) {
+        body.description = this.editForm.description;
+      }
+      if (this.editForm.visibility !== undefined && this.editForm.visibility !== this.skill.visibility) {
+        body.visibility = this.editForm.visibility;
+      }
+      if (this.editForm.tags !== undefined) {
+        body.tags = this.editForm.tags.split(',').map((t) => t.trim()).filter((t) => t);
+      }
+
+      const res = await apiFetch(`/api/v1/skills/${this.skillId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        throw new Error(await extractApiError(res, 'Failed to update skill'));
+      }
+
+      this.skill = (await res.json()) as Skill;
+      this.editing = false;
+    } catch (err) {
+      console.error('Failed to save skill:', err);
+      alert(err instanceof Error ? err.message : 'Failed to save skill');
+    } finally {
+      this.saving = false;
+    }
+  }
+
+  // -- Archive --
+
+  private async handleArchive(): Promise<void> {
+    if (!confirm('Are you sure you want to archive this skill?')) return;
+    this.actionLoading = { ...this.actionLoading, archive: true };
+
+    try {
+      const res = await apiFetch(`/api/v1/skills/${this.skillId}`, { method: 'DELETE' });
+      if (!res.ok) {
+        throw new Error(await extractApiError(res, 'Failed to archive skill'));
+      }
+      window.history.pushState({}, '', '/skills');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    } catch (err) {
+      console.error('Failed to archive skill:', err);
+      alert(err instanceof Error ? err.message : 'Failed to archive skill');
+    } finally {
+      this.actionLoading = { ...this.actionLoading, archive: false };
+    }
+  }
+
+  // -- Deprecate --
+
+  private async handleDeprecate(): Promise<void> {
+    if (!this.deprecateVersionId || !this.deprecateMessage.trim()) return;
+    this.deprecateLoading = true;
+
+    try {
+      const body: Record<string, unknown> = {
+        message: this.deprecateMessage.trim(),
+      };
+      if (this.deprecateReplacement.trim()) {
+        body.replacementUri = this.deprecateReplacement.trim();
+      }
+
+      const res = await apiFetch(
+        `/api/v1/skills/${this.skillId}/versions/${this.deprecateVersionId}/deprecate`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        }
+      );
+
+      if (!res.ok) {
+        throw new Error(await extractApiError(res, 'Failed to deprecate version'));
+      }
+
+      this.deprecateVersionId = null;
+      this.deprecateMessage = '';
+      this.deprecateReplacement = '';
+      void this.loadData();
+    } catch (err) {
+      console.error('Failed to deprecate version:', err);
+      alert(err instanceof Error ? err.message : 'Failed to deprecate version');
+    } finally {
+      this.deprecateLoading = false;
+    }
+  }
+
+  // -- Files tab --
+
+  private async loadFiles(version: string): Promise<void> {
+    this.filesLoading = true;
+    try {
+      const res = await apiFetch(`/api/v1/skills/${this.skillId}/download?version=${encodeURIComponent(version)}`);
+      if (res.ok) {
+        const data = (await res.json()) as { files?: SkillDownloadUrl[]; urls?: SkillDownloadUrl[] } | SkillDownloadUrl[];
+        if (Array.isArray(data)) {
+          this.fileUrls = data;
+        } else {
+          this.fileUrls = data.files || data.urls || [];
+        }
+      } else {
+        this.fileUrls = [];
+      }
+    } catch {
+      this.fileUrls = [];
+    } finally {
+      this.filesLoading = false;
+    }
+  }
+
+  private onFilesVersionChange(e: Event): void {
+    const version = (e.target as HTMLElement & { value: string }).value;
+    this.selectedVersionForFiles = version;
+    if (version) void this.loadFiles(version);
+  }
+
+  private handleTabShow(e: CustomEvent<{ name: string }>): void {
+    if (e.detail.name === 'files' && !this.selectedVersionForFiles) {
+      const published = this.versions.filter((v) => v.status === 'published');
+      if (published.length > 0) {
+        this.selectedVersionForFiles = published[0].version;
+        void this.loadFiles(published[0].version);
+      }
+    }
+  }
+
+  // -- Render --
+
   override render() {
-    return html`<p>Skill detail — coming soon</p>`;
+    if (this.loading) return this.renderLoading();
+    if (this.error || !this.skill) return this.renderError();
+
+    return html`
+      <a href="/skills" class="back-link">
+        <sl-icon name="arrow-left"></sl-icon>
+        Back to Skills
+      </a>
+
+      ${this.renderHeader()}
+
+      <sl-tab-group @sl-tab-show=${this.handleTabShow}>
+        <sl-tab slot="nav" panel="overview">Overview</sl-tab>
+        <sl-tab slot="nav" panel="versions">Versions</sl-tab>
+        <sl-tab slot="nav" panel="files">Files</sl-tab>
+
+        <sl-tab-panel name="overview">${this.renderOverviewTab()}</sl-tab-panel>
+        <sl-tab-panel name="versions">${this.renderVersionsTab()}</sl-tab-panel>
+        <sl-tab-panel name="files">${this.renderFilesTab()}</sl-tab-panel>
+      </sl-tab-group>
+
+      ${this.renderDeprecateDialog()}
+    `;
+  }
+
+  private renderHeader() {
+    const skill = this.skill!;
+    return html`
+      <div class="header">
+        <div class="header-info">
+          <div class="header-title">
+            <sl-icon name="lightning-charge"></sl-icon>
+            <h1>${skill.name}</h1>
+            <scion-status-badge
+              status=${skill.status as StatusType}
+              label=${skill.status}
+            ></scion-status-badge>
+          </div>
+          <div class="header-meta">
+            <span class="scope-badge">${skill.scope}</span>
+            <span class="visibility-badge ${skill.visibility}">${skill.visibility}</span>
+          </div>
+        </div>
+        <div class="header-actions">
+          ${can(skill._capabilities, 'update') ? html`
+            <sl-button variant="default" size="small" outline @click=${() => this.startEditing()}>
+              <sl-icon slot="prefix" name="pencil"></sl-icon>
+              Edit
+            </sl-button>
+          ` : nothing}
+          ${can(skill._capabilities, 'update') ? html`
+            <sl-button
+              variant="primary"
+              size="small"
+              @click=${() => {
+                const dialog = this.shadowRoot?.querySelector('scion-skill-publish-dialog') as HTMLElement & { open: boolean } | null;
+                if (dialog) dialog.open = true;
+              }}
+            >
+              <sl-icon slot="prefix" name="upload"></sl-icon>
+              Publish Version
+            </sl-button>
+          ` : nothing}
+          ${can(skill._capabilities, 'delete') ? html`
+            <sl-button
+              variant="danger"
+              size="small"
+              outline
+              ?loading=${this.actionLoading['archive']}
+              ?disabled=${this.actionLoading['archive']}
+              @click=${() => this.handleArchive()}
+            >
+              <sl-icon slot="prefix" name="trash"></sl-icon>
+              Archive
+            </sl-button>
+          ` : nothing}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderOverviewTab() {
+    const skill = this.skill!;
+
+    if (this.editing) {
+      return this.renderEditMode();
+    }
+
+    return html`
+      <div class="card">
+        <h3 class="card-title">Skill Details</h3>
+        <div class="info-grid">
+          <div class="info-item">
+            <span class="info-label">Name</span>
+            <span class="info-value">${skill.name}</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">Slug</span>
+            <span class="info-value mono">${skill.slug}</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">URI</span>
+            <span class="info-value">
+              <span class="uri-copy" @click=${() => this.copyUri()} title="Click to copy">
+                ${this.getSkillUri()}
+                <sl-icon name="clipboard"></sl-icon>
+              </span>
+            </span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">Description</span>
+            <span class="info-value">${skill.description || html`<span style="color: var(--scion-text-muted);">No description</span>`}</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">Scope</span>
+            <span class="info-value"><span class="scope-badge">${skill.scope}</span></span>
+          </div>
+          ${skill.scopeId ? html`
+            <div class="info-item">
+              <span class="info-label">Scope ID</span>
+              <span class="info-value mono">${skill.scopeId}</span>
+            </div>
+          ` : nothing}
+          <div class="info-item">
+            <span class="info-label">Visibility</span>
+            <span class="info-value"><span class="visibility-badge ${skill.visibility}">${skill.visibility}</span></span>
+          </div>
+          ${skill.ownerId ? html`
+            <div class="info-item">
+              <span class="info-label">Owner</span>
+              <span class="info-value">${skill.ownerId}</span>
+            </div>
+          ` : nothing}
+          <div class="info-item">
+            <span class="info-label">Tags</span>
+            <span class="info-value">
+              ${skill.tags?.length
+                ? html`<div class="tag-list">${skill.tags.map((t) => html`<span class="tag-item">${t}</span>`)}</div>`
+                : html`<span style="color: var(--scion-text-muted);">No tags</span>`}
+            </span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">Status</span>
+            <span class="info-value">
+              <scion-status-badge status=${skill.status as StatusType} label=${skill.status} size="small"></scion-status-badge>
+            </span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">Created</span>
+            <span class="info-value">${this.formatRelativeTime(skill.created)}</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">Updated</span>
+            <span class="info-value">${this.formatRelativeTime(skill.updated)}</span>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderEditMode() {
+    return html`
+      <div class="card">
+        <h3 class="card-title">Edit Skill</h3>
+        <div class="edit-field">
+          <label>Name</label>
+          <sl-input
+            .value=${this.editForm.name || ''}
+            @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, name: (e.target as HTMLElement & { value: string }).value }; }}
+          ></sl-input>
+        </div>
+        <div class="edit-field">
+          <label>Description</label>
+          <sl-textarea
+            .value=${this.editForm.description || ''}
+            @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, description: (e.target as HTMLElement & { value: string }).value }; }}
+            rows="3"
+          ></sl-textarea>
+        </div>
+        <div class="edit-field">
+          <label>Visibility</label>
+          <sl-radio-group
+            .value=${this.editForm.visibility || 'private'}
+            @sl-change=${(e: Event) => { this.editForm = { ...this.editForm, visibility: (e.target as HTMLElement & { value: string }).value }; }}
+          >
+            <sl-radio-button value="private">Private</sl-radio-button>
+            <sl-radio-button value="public">Public</sl-radio-button>
+          </sl-radio-group>
+        </div>
+        <div class="edit-field">
+          <label>Tags</label>
+          <sl-input
+            .value=${this.editForm.tags || ''}
+            @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, tags: (e.target as HTMLElement & { value: string }).value }; }}
+            placeholder="comma-separated tags"
+          ></sl-input>
+        </div>
+        <div class="edit-actions">
+          <sl-button variant="primary" size="small" ?loading=${this.saving} @click=${() => this.saveEdit()}>
+            Save
+          </sl-button>
+          <sl-button variant="default" size="small" ?disabled=${this.saving} @click=${() => this.cancelEditing()}>
+            Cancel
+          </sl-button>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderVersionsTab() {
+    if (this.versions.length === 0) {
+      return html`
+        <div class="empty-versions">
+          <p>No versions published yet.</p>
+          ${can(this.skill?._capabilities, 'update') ? html`
+            <p>Use the "Publish Version" button to upload the first version.</p>
+          ` : nothing}
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="version-table">
+        <table>
+          <thead>
+            <tr>
+              <th>Version</th>
+              <th>Status</th>
+              <th class="hide-mobile">Content Hash</th>
+              <th class="hide-mobile">Files</th>
+              <th class="hide-mobile">Downloads</th>
+              <th class="hide-mobile">Published</th>
+              <th class="actions-cell">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${this.versions.map((v) => this.renderVersionRow(v))}
+          </tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  private renderVersionRow(v: SkillVersion) {
+    return html`
+      <tr>
+        <td><strong>${v.version}</strong></td>
+        <td>
+          <scion-status-badge
+            status=${this.versionStatusType(v.status)}
+            label=${v.status}
+            size="small"
+          ></scion-status-badge>
+        </td>
+        <td class="hide-mobile">
+          ${v.contentHash
+            ? html`<scion-hash-display .hash=${v.contentHash} max-width="14ch"></scion-hash-display>`
+            : '—'}
+        </td>
+        <td class="hide-mobile">${v.files?.length ?? 0} files</td>
+        <td class="hide-mobile">${v.downloadCount}</td>
+        <td class="hide-mobile">${this.formatRelativeTime(v.created)}</td>
+        <td class="actions-cell">
+          ${v.status === 'published' && can(this.skill?._capabilities, 'update') ? html`
+            <sl-button size="small" variant="warning" outline @click=${() => { this.deprecateVersionId = v.id; }}>
+              Deprecate
+            </sl-button>
+          ` : nothing}
+        </td>
+      </tr>
+    `;
+  }
+
+  private renderFilesTab() {
+    const published = this.versions.filter((v) => v.status === 'published');
+
+    if (published.length === 0) {
+      return html`
+        <div class="empty-versions">
+          <p>No published versions available. Publish a version to see its files.</p>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="version-selector">
+        <sl-select
+          size="small"
+          .value=${this.selectedVersionForFiles}
+          @sl-change=${(e: Event) => this.onFilesVersionChange(e)}
+          style="max-width: 200px;"
+        >
+          ${published.map((v) => html`<sl-option value=${v.version}>${v.version}</sl-option>`)}
+        </sl-select>
+      </div>
+
+      ${this.filesLoading ? html`
+        <div class="loading-state" style="padding: 2rem;">
+          <sl-spinner></sl-spinner>
+          <p>Loading files...</p>
+        </div>
+      ` : this.fileUrls.length === 0 ? html`
+        <div class="empty-versions">
+          <p>No files found for this version.</p>
+        </div>
+      ` : html`
+        <div class="file-table">
+          <table>
+            <thead>
+              <tr>
+                <th>Path</th>
+                <th>Size</th>
+                <th class="hide-mobile">Hash</th>
+                <th style="text-align: right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${this.fileUrls.map((f) => html`
+                <tr>
+                  <td>
+                    <span style="display: flex; align-items: center; gap: 0.5rem;">
+                      <sl-icon name="file-earmark"></sl-icon>
+                      ${f.path}
+                    </span>
+                  </td>
+                  <td>${this.formatFileSize(f.size)}</td>
+                  <td class="hide-mobile">
+                    ${f.hash
+                      ? html`<scion-hash-display .hash=${f.hash} max-width="14ch"></scion-hash-display>`
+                      : '—'}
+                  </td>
+                  <td style="text-align: right">
+                    <sl-button size="small" variant="default" outline @click=${() => window.open(f.url, '_blank')}>
+                      <sl-icon slot="prefix" name="download"></sl-icon>
+                      Download
+                    </sl-button>
+                  </td>
+                </tr>
+              `)}
+            </tbody>
+          </table>
+        </div>
+      `}
+    `;
+  }
+
+  private renderDeprecateDialog() {
+    return html`
+      <sl-dialog
+        label="Deprecate Version"
+        ?open=${this.deprecateVersionId !== null}
+        @sl-after-hide=${() => { this.deprecateVersionId = null; }}
+      >
+        <div style="display: flex; flex-direction: column; gap: 1rem;">
+          <sl-textarea
+            label="Deprecation Message"
+            placeholder="Reason for deprecation..."
+            .value=${this.deprecateMessage}
+            @sl-input=${(e: Event) => { this.deprecateMessage = (e.target as HTMLElement & { value: string }).value; }}
+            required
+          ></sl-textarea>
+          <sl-input
+            label="Replacement URI (optional)"
+            placeholder="global:replacement-skill@1.0.0"
+            .value=${this.deprecateReplacement}
+            @sl-input=${(e: Event) => { this.deprecateReplacement = (e.target as HTMLElement & { value: string }).value; }}
+          ></sl-input>
+        </div>
+        <sl-button
+          slot="footer"
+          variant="warning"
+          ?loading=${this.deprecateLoading}
+          ?disabled=${this.deprecateLoading || !this.deprecateMessage.trim()}
+          @click=${() => this.handleDeprecate()}
+        >
+          Deprecate
+        </sl-button>
+      </sl-dialog>
+    `;
+  }
+
+  private renderLoading() {
+    return html`
+      <div class="loading-state">
+        <sl-spinner></sl-spinner>
+        <p>Loading skill...</p>
+      </div>
+    `;
+  }
+
+  private renderError() {
+    return html`
+      <a href="/skills" class="back-link">
+        <sl-icon name="arrow-left"></sl-icon>
+        Back to Skills
+      </a>
+      <div class="error-state">
+        <sl-icon name="exclamation-triangle"></sl-icon>
+        <h2>Failed to Load Skill</h2>
+        <p>There was a problem loading this skill.</p>
+        <div class="error-details">${this.error || 'Skill not found'}</div>
+        <sl-button variant="primary" @click=${() => this.loadData()}>
+          <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+          Retry
+        </sl-button>
+      </div>
+    `;
   }
 }
 

--- a/web/src/components/pages/skill-detail.ts
+++ b/web/src/components/pages/skill-detail.ts
@@ -761,6 +761,7 @@ export class ScionPageSkillDetail extends LitElement {
             .value=${this.editForm.description || ''}
             @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, description: (e.target as HTMLElement & { value: string }).value }; }}
             rows="3"
+            help-text="Once set, this field cannot be cleared."
           ></sl-textarea>
         </div>
         <div class="edit-field">
@@ -920,7 +921,13 @@ export class ScionPageSkillDetail extends LitElement {
                       : '—'}
                   </td>
                   <td style="text-align: right">
-                    <sl-button size="small" variant="default" outline @click=${() => window.open(f.url, '_blank')}>
+                    <sl-button size="small" variant="default" outline @click=${() => {
+                      const a = document.createElement('a');
+                      a.href = f.url;
+                      a.target = '_blank';
+                      a.rel = 'noopener noreferrer';
+                      a.click();
+                    }}>
                       <sl-icon slot="prefix" name="download"></sl-icon>
                       Download
                     </sl-button>

--- a/web/src/components/pages/skill-detail.ts
+++ b/web/src/components/pages/skill-detail.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('scion-page-skill-detail')
+export class ScionPageSkillDetail extends LitElement {
+  override render() {
+    return html`<p>Skill detail — coming soon</p>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-page-skill-detail': ScionPageSkillDetail;
+  }
+}

--- a/web/src/components/pages/skill-detail.ts
+++ b/web/src/components/pages/skill-detail.ts
@@ -29,6 +29,7 @@ import type { StatusType } from '../shared/status-badge.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import '../shared/status-badge.js';
 import '../shared/hash-display.js';
+import '../shared/skill-publish-dialog.js';
 
 @customElement('scion-page-skill-detail')
 export class ScionPageSkillDetail extends LitElement {
@@ -43,6 +44,9 @@ export class ScionPageSkillDetail extends LitElement {
   @state() private editForm: Partial<{ name: string; description: string; visibility: string; tags: string }> = {};
   @state() private saving = false;
   @state() private actionLoading: Record<string, boolean> = {};
+
+  // Publish dialog state
+  @state() private publishDialogOpen = false;
 
   // Deprecate dialog state
   @state() private deprecateVersionId: string | null = null;
@@ -604,6 +608,7 @@ export class ScionPageSkillDetail extends LitElement {
       </sl-tab-group>
 
       ${this.renderDeprecateDialog()}
+      ${this.renderPublishDialog()}
     `;
   }
 
@@ -636,10 +641,7 @@ export class ScionPageSkillDetail extends LitElement {
             <sl-button
               variant="primary"
               size="small"
-              @click=${() => {
-                const dialog = this.shadowRoot?.querySelector('scion-skill-publish-dialog') as HTMLElement & { open: boolean } | null;
-                if (dialog) dialog.open = true;
-              }}
+              @click=${() => { this.publishDialogOpen = true; }}
             >
               <sl-icon slot="prefix" name="upload"></sl-icon>
               Publish Version
@@ -960,6 +962,25 @@ export class ScionPageSkillDetail extends LitElement {
           Deprecate
         </sl-button>
       </sl-dialog>
+    `;
+  }
+
+  private get latestPublishedVersion(): string {
+    const published = this.versions
+      .filter((v) => v.status === 'published')
+      .sort((a, b) => (b.created || '').localeCompare(a.created || ''));
+    return published.length > 0 ? published[0].version : '';
+  }
+
+  private renderPublishDialog() {
+    return html`
+      <scion-skill-publish-dialog
+        .skillId=${this.skillId}
+        ?open=${this.publishDialogOpen}
+        .latestVersion=${this.latestPublishedVersion}
+        @sl-after-hide=${() => { this.publishDialogOpen = false; }}
+        @skill-version-published=${() => { this.publishDialogOpen = false; void this.loadData(); }}
+      ></scion-skill-publish-dialog>
     `;
   }
 

--- a/web/src/components/pages/skill-detail.ts
+++ b/web/src/components/pages/skill-detail.ts
@@ -869,15 +869,19 @@ export class ScionPageSkillDetail extends LitElement {
     }
 
     return html`
-      <div class="version-selector">
+      <div class="version-selector" style="display: flex; align-items: center; gap: 0.75rem;">
         <sl-select
           size="small"
           .value=${this.selectedVersionForFiles}
           @sl-change=${(e: Event) => this.onFilesVersionChange(e)}
           style="max-width: 200px;"
+          placeholder="Select version"
         >
-          ${published.map((v) => html`<sl-option value=${v.version}>${v.version}</sl-option>`)}
+          ${published.map((v) => html`<sl-option value=${v.version}>v${v.version}</sl-option>`)}
         </sl-select>
+        ${!this.filesLoading && this.fileUrls.length > 0 ? html`
+          <span style="font-size: 0.875rem; color: var(--scion-text-muted, #64748b);">${this.fileUrls.length} file${this.fileUrls.length !== 1 ? 's' : ''}</span>
+        ` : nothing}
       </div>
 
       ${this.filesLoading ? html`

--- a/web/src/components/pages/skills.ts
+++ b/web/src/components/pages/skills.ts
@@ -188,6 +188,14 @@ export class ScionPageSkills extends LitElement {
     `,
   ];
 
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this.searchTimer) {
+      clearTimeout(this.searchTimer);
+      this.searchTimer = null;
+    }
+  }
+
   override connectedCallback(): void {
     super.connectedCallback();
 

--- a/web/src/components/pages/skills.ts
+++ b/web/src/components/pages/skills.ts
@@ -14,13 +14,528 @@
  * limitations under the License.
  */
 
-import { LitElement, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+/**
+ * Skills list page component
+ *
+ * Displays all skills with grid/table views, search, scope filter, and sorting.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+import type { PageData, Skill, SkillScope, Capabilities } from '../../shared/types.js';
+import { can } from '../../shared/types.js';
+import { apiFetch, extractApiError } from '../../client/api.js';
+import { listPageStyles } from '../shared/resource-styles.js';
+import type { ViewMode } from '../shared/view-toggle.js';
+import '../shared/status-badge.js';
+import '../shared/view-toggle.js';
+
+type SkillSortField = 'name' | 'updated' | 'created';
+type SortDir = 'asc' | 'desc';
 
 @customElement('scion-page-skills')
 export class ScionPageSkills extends LitElement {
+  @property({ type: Object })
+  pageData: PageData | null = null;
+
+  @state() private loading = true;
+  @state() private error: string | null = null;
+  @state() private skills: Skill[] = [];
+  @state() private scopeCapabilities: Capabilities | undefined;
+  @state() private viewMode: ViewMode = 'grid';
+  @state() private searchQuery = '';
+  @state() private scopeFilter: SkillScope | '' = '';
+  @state() private sortField: SkillSortField = 'updated';
+  @state() private sortDir: SortDir = 'desc';
+
+  private searchTimer: ReturnType<typeof setTimeout> | null = null;
+
+  static override styles = [
+    listPageStyles,
+    css`
+      .skill-card {
+        background: var(--scion-surface, #ffffff);
+        border: 1px solid var(--scion-border, #e2e8f0);
+        border-radius: var(--scion-radius-lg, 0.75rem);
+        padding: 1.5rem;
+        transition: all var(--scion-transition-fast, 150ms ease);
+        cursor: pointer;
+        text-decoration: none;
+        color: inherit;
+        display: block;
+      }
+
+      .skill-card:hover {
+        border-color: var(--scion-primary, #3b82f6);
+        box-shadow: var(--scion-shadow-md, 0 4px 6px -1px rgba(0, 0, 0, 0.1));
+        transform: translateY(-2px);
+      }
+
+      .skill-header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        margin-bottom: 0.5rem;
+      }
+
+      .skill-meta {
+        font-size: 0.813rem;
+        color: var(--scion-text-muted, #64748b);
+        display: flex;
+        gap: 0.75rem;
+        margin-top: 0.25rem;
+      }
+
+      .skill-description {
+        font-size: 0.875rem;
+        color: var(--scion-text, #1e293b);
+        margin-top: 0.75rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+      }
+
+      .skill-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.375rem;
+        margin-top: 0.75rem;
+      }
+
+      .skill-tag {
+        display: inline-block;
+        font-size: 0.6875rem;
+        padding: 0.125rem 0.5rem;
+        background: var(--scion-bg-subtle, #f1f5f9);
+        border: 1px solid var(--scion-border, #e2e8f0);
+        border-radius: 9999px;
+        color: var(--scion-text-muted, #64748b);
+      }
+
+      .skill-footer {
+        font-size: 0.75rem;
+        color: var(--scion-text-muted, #64748b);
+        margin-top: 0.75rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid var(--scion-border, #e2e8f0);
+      }
+
+      .scope-badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.125rem 0.5rem;
+        border-radius: 9999px;
+        font-size: 0.6875rem;
+        font-weight: 500;
+        background: var(--scion-bg-subtle, #f1f5f9);
+        color: var(--scion-text-muted, #64748b);
+      }
+
+      .visibility-badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.125rem 0.5rem;
+        border-radius: 9999px;
+        font-size: 0.6875rem;
+        font-weight: 500;
+      }
+
+      .visibility-badge.public {
+        background: var(--sl-color-success-100, #dcfce7);
+        color: var(--sl-color-success-700, #15803d);
+      }
+
+      .visibility-badge.private {
+        background: var(--scion-bg-subtle, #f1f5f9);
+        color: var(--scion-text-muted, #64748b);
+      }
+
+      .filter-bar {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        margin-bottom: 1rem;
+        flex-wrap: wrap;
+      }
+
+      .filter-bar .search-input {
+        min-width: 200px;
+      }
+
+      th.sortable {
+        cursor: pointer;
+        user-select: none;
+      }
+
+      th.sortable:hover {
+        color: var(--scion-text, #1e293b);
+      }
+
+      .sort-indicator {
+        display: inline-block;
+        margin-left: 0.25rem;
+        font-size: 0.625rem;
+        vertical-align: middle;
+        opacity: 0.4;
+      }
+
+      th.sorted .sort-indicator {
+        opacity: 1;
+      }
+    `,
+  ];
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    const stored = localStorage.getItem('scion-view-skills') as ViewMode | null;
+    if (stored === 'grid' || stored === 'list') {
+      this.viewMode = stored;
+    }
+
+    const storedSort = localStorage.getItem('scion-sort-skills');
+    if (storedSort) {
+      try {
+        const parsed = JSON.parse(storedSort);
+        if (
+          parsed &&
+          (parsed.field === 'name' || parsed.field === 'updated' || parsed.field === 'created') &&
+          (parsed.dir === 'asc' || parsed.dir === 'desc')
+        ) {
+          this.sortField = parsed.field;
+          this.sortDir = parsed.dir;
+        }
+      } catch { /* ignore */ }
+    }
+
+    const ssrData = this.pageData?.data as { skills?: Skill[]; _capabilities?: Capabilities } | undefined;
+    if (ssrData?.skills && this.scopeFilter === '' && !this.searchQuery) {
+      this.skills = ssrData.skills;
+      this.scopeCapabilities = ssrData._capabilities;
+      this.loading = false;
+    } else {
+      void this.loadSkills();
+    }
+  }
+
+  private async loadSkills(): Promise<void> {
+    this.loading = true;
+    this.error = null;
+
+    try {
+      const params = new URLSearchParams();
+      params.set('status', 'active');
+      if (this.scopeFilter) params.set('scope', this.scopeFilter);
+      if (this.searchQuery) params.set('search', this.searchQuery);
+
+      const response = await apiFetch(`/api/v1/skills?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+      }
+
+      const data = (await response.json()) as { skills?: Skill[]; items?: Skill[]; _capabilities?: Capabilities } | Skill[];
+      if (Array.isArray(data)) {
+        this.skills = data;
+        this.scopeCapabilities = undefined;
+      } else {
+        this.skills = data.skills || data.items || [];
+        this.scopeCapabilities = data._capabilities;
+      }
+    } catch (err) {
+      console.error('Failed to load skills:', err);
+      this.error = err instanceof Error ? err.message : 'Failed to load skills';
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private get displaySkills(): Skill[] {
+    const sorted = [...this.skills];
+    sorted.sort((a, b) => {
+      let cmp = 0;
+      switch (this.sortField) {
+        case 'name':
+          cmp = (a.name || '').localeCompare(b.name || '');
+          break;
+        case 'updated':
+          cmp = (a.updated || '').localeCompare(b.updated || '');
+          break;
+        case 'created':
+          cmp = (a.created || '').localeCompare(b.created || '');
+          break;
+      }
+      return this.sortDir === 'asc' ? cmp : -cmp;
+    });
+    return sorted;
+  }
+
+  private formatRelativeTime(isoString: string): string {
+    const date = new Date(isoString);
+    if (isNaN(date.getTime())) return '—';
+    const now = Date.now();
+    const diffMs = now - date.getTime();
+    if (diffMs < 0) return 'just now';
+    const seconds = Math.floor(diffMs / 1000);
+    if (seconds < 60) return 'just now';
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    return `${days}d ago`;
+  }
+
+  private onViewChange(e: CustomEvent<{ view: ViewMode }>): void {
+    this.viewMode = e.detail.view;
+  }
+
+  private onSearchInput(e: Event): void {
+    const value = (e.target as HTMLElement & { value: string }).value;
+    if (this.searchTimer) clearTimeout(this.searchTimer);
+    this.searchTimer = setTimeout(() => {
+      this.searchQuery = value;
+      void this.loadSkills();
+    }, 300);
+  }
+
+  private onScopeFilterChange(e: Event): void {
+    this.scopeFilter = (e.target as HTMLElement & { value: string }).value as SkillScope | '';
+    void this.loadSkills();
+  }
+
+  private toggleSort(field: SkillSortField): void {
+    if (this.sortField === field) {
+      this.sortDir = this.sortDir === 'asc' ? 'desc' : 'asc';
+    } else {
+      this.sortField = field;
+      this.sortDir = field === 'name' ? 'asc' : 'desc';
+    }
+    localStorage.setItem('scion-sort-skills', JSON.stringify({ field: this.sortField, dir: this.sortDir }));
+  }
+
+  private sortIndicator(field: SkillSortField): string {
+    return this.sortField === field ? (this.sortDir === 'asc' ? '▲' : '▼') : '▲';
+  }
+
   override render() {
-    return html`<p>Skills page — coming soon</p>`;
+    return html`
+      <div class="header">
+        <h1>Skills</h1>
+        <div class="header-actions">
+          <scion-view-toggle
+            .view=${this.viewMode}
+            storageKey="scion-view-skills"
+            @view-change=${this.onViewChange}
+          ></scion-view-toggle>
+          ${can(this.scopeCapabilities, 'create') ? html`
+            <a href="/skills/new" style="text-decoration: none;">
+              <sl-button variant="primary" size="small">
+                <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+                Create Skill
+              </sl-button>
+            </a>
+          ` : nothing}
+        </div>
+      </div>
+
+      ${this.loading ? this.renderLoading() : this.error ? this.renderError() : html`
+        ${this.renderFilterBar()}
+        ${this.renderSkills()}
+      `}
+    `;
+  }
+
+  private renderFilterBar() {
+    return html`
+      <div class="filter-bar">
+        <sl-input
+          class="search-input"
+          size="small"
+          placeholder="Search skills..."
+          clearable
+          @sl-input=${(e: Event) => this.onSearchInput(e)}
+        >
+          <sl-icon slot="prefix" name="search"></sl-icon>
+        </sl-input>
+        <sl-select
+          size="small"
+          placeholder="All scopes"
+          clearable
+          .value=${this.scopeFilter}
+          @sl-change=${(e: Event) => this.onScopeFilterChange(e)}
+          style="min-width: 140px;"
+        >
+          <sl-option value="core">Core</sl-option>
+          <sl-option value="global">Global</sl-option>
+          <sl-option value="project">Project</sl-option>
+          <sl-option value="user">User</sl-option>
+        </sl-select>
+        ${this.viewMode === 'grid' ? html`
+          <sl-dropdown>
+            <sl-button slot="trigger" size="small" outline>
+              <sl-icon slot="prefix" name=${this.sortDir === 'asc' ? 'sort-alpha-down' : 'sort-alpha-down-alt'}></sl-icon>
+              Sort: ${this.sortField}
+            </sl-button>
+            <sl-menu @sl-select=${(e: CustomEvent<{ item: { value: string } }>) => this.toggleSort(e.detail.item.value as SkillSortField)}>
+              <sl-menu-item value="name" ?checked=${this.sortField === 'name'}>Name</sl-menu-item>
+              <sl-menu-item value="created" ?checked=${this.sortField === 'created'}>Created</sl-menu-item>
+              <sl-menu-item value="updated" ?checked=${this.sortField === 'updated'}>Updated</sl-menu-item>
+            </sl-menu>
+          </sl-dropdown>
+        ` : nothing}
+      </div>
+    `;
+  }
+
+  private renderLoading() {
+    return html`
+      <div class="loading-state">
+        <sl-spinner></sl-spinner>
+        <p>Loading skills...</p>
+      </div>
+    `;
+  }
+
+  private renderError() {
+    return html`
+      <div class="error-state">
+        <sl-icon name="exclamation-triangle"></sl-icon>
+        <h2>Failed to Load Skills</h2>
+        <p>There was a problem connecting to the API.</p>
+        <div class="error-details">${this.error}</div>
+        <sl-button variant="primary" @click=${() => this.loadSkills()}>
+          <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+          Retry
+        </sl-button>
+      </div>
+    `;
+  }
+
+  private renderSkills() {
+    if (this.skills.length === 0) {
+      return this.renderEmptyState();
+    }
+
+    const filtered = this.displaySkills;
+    if (filtered.length === 0) {
+      return html`
+        <div class="empty-state">
+          <sl-icon name="funnel"></sl-icon>
+          <h2>No Matching Skills</h2>
+          <p>No skills match the current filters.</p>
+        </div>
+      `;
+    }
+
+    return this.viewMode === 'grid' ? this.renderGrid() : this.renderTable();
+  }
+
+  private renderEmptyState() {
+    return html`
+      <div class="empty-state">
+        <sl-icon name="lightning-charge"></sl-icon>
+        <h2>No Skills Found</h2>
+        <p>
+          Skills are reusable capabilities for agents.${can(this.scopeCapabilities, 'create') ? ' Create your first skill to get started.' : ''}
+        </p>
+        ${can(this.scopeCapabilities, 'create') ? html`
+          <a href="/skills/new" style="text-decoration: none;">
+            <sl-button variant="primary">
+              <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+              Create Skill
+            </sl-button>
+          </a>
+        ` : nothing}
+      </div>
+    `;
+  }
+
+  private renderGrid() {
+    return html`
+      <div class="resource-grid">${this.displaySkills.map((skill) => this.renderSkillCard(skill))}</div>
+    `;
+  }
+
+  private renderSkillCard(skill: Skill) {
+    return html`
+      <a href="/skills/${skill.id}" class="skill-card">
+        <div class="skill-header">
+          <div>
+            <h3 class="resource-name">
+              <sl-icon name="lightning-charge"></sl-icon>
+              ${skill.name}
+            </h3>
+            <div class="skill-meta">
+              <span class="scope-badge">${skill.scope}</span>
+              <span class="visibility-badge ${skill.visibility}">${skill.visibility}</span>
+            </div>
+          </div>
+        </div>
+
+        ${skill.description ? html`<div class="skill-description">${skill.description}</div>` : nothing}
+
+        ${skill.tags?.length ? html`
+          <div class="skill-tags">
+            ${skill.tags.map((tag) => html`<span class="skill-tag">${tag}</span>`)}
+          </div>
+        ` : nothing}
+
+        <div class="skill-footer">
+          Updated ${this.formatRelativeTime(skill.updated)}
+        </div>
+      </a>
+    `;
+  }
+
+  private renderTable() {
+    return html`
+      <div class="resource-table-container">
+        <table>
+          <thead>
+            <tr>
+              <th
+                class="sortable ${this.sortField === 'name' ? 'sorted' : ''}"
+                @click=${() => this.toggleSort('name')}
+              >Name <span class="sort-indicator">${this.sortIndicator('name')}</span></th>
+              <th>Scope</th>
+              <th class="hide-mobile">Visibility</th>
+              <th class="hide-mobile">Tags</th>
+              <th
+                class="sortable ${this.sortField === 'updated' ? 'sorted' : ''}"
+                @click=${() => this.toggleSort('updated')}
+              >Updated <span class="sort-indicator">${this.sortIndicator('updated')}</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            ${this.displaySkills.map((skill) => this.renderSkillRow(skill))}
+          </tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  private renderSkillRow(skill: Skill) {
+    return html`
+      <tr class="clickable" @click=${() => { window.history.pushState({}, '', `/skills/${skill.id}`); window.dispatchEvent(new PopStateEvent('popstate')); }}>
+        <td>
+          <span class="name-cell">
+            <sl-icon name="lightning-charge"></sl-icon>
+            <a href="/skills/${skill.id}">${skill.name}</a>
+          </span>
+        </td>
+        <td><span class="scope-badge">${skill.scope}</span></td>
+        <td class="hide-mobile"><span class="visibility-badge ${skill.visibility}">${skill.visibility}</span></td>
+        <td class="hide-mobile">
+          ${skill.tags?.length
+            ? skill.tags.map((tag) => html`<span class="skill-tag">${tag}</span> `)
+            : '—'}
+        </td>
+        <td>${skill.updated ? this.formatRelativeTime(skill.updated) : '—'}</td>
+      </tr>
+    `;
   }
 }
 

--- a/web/src/components/pages/skills.ts
+++ b/web/src/components/pages/skills.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LitElement, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('scion-page-skills')
+export class ScionPageSkills extends LitElement {
+  override render() {
+    return html`<p>Skills page — coming soon</p>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-page-skills': ScionPageSkills;
+  }
+}

--- a/web/src/components/shared/nav.ts
+++ b/web/src/components/shared/nav.ts
@@ -50,6 +50,7 @@ const NAV_SECTIONS: NavSection[] = [
       { path: '/projects', label: 'Projects', icon: 'folder' },
       { path: '/agents', label: 'Agents', icon: 'cpu' },
       { path: '/brokers', label: 'Brokers', icon: 'hdd-rack' },
+      { path: '/skills', label: 'Skills', icon: 'lightning-charge' },
     ],
   },
 ];
@@ -66,6 +67,7 @@ const ADMIN_SECTION: NavSection = {
     { path: '/admin/users', label: 'Users', icon: 'people' },
     { path: '/admin/groups', label: 'Groups', icon: 'diagram-3' },
     { path: '/admin/maintenance', label: 'Maintenance', icon: 'wrench-adjustable' },
+    { path: '/admin/skill-registries', label: 'Skill Registries', icon: 'cloud-arrow-down' },
   ],
 };
 

--- a/web/src/components/shared/skill-publish-dialog.ts
+++ b/web/src/components/shared/skill-publish-dialog.ts
@@ -196,6 +196,7 @@ export class ScionSkillPublishDialog extends LitElement {
   `;
 
   override updated(changed: Map<PropertyKey, unknown>): void {
+    super.updated(changed);
     if (changed.has('open') && this.open) {
       this.reset();
       if (this.latestVersion) {
@@ -397,6 +398,10 @@ export class ScionSkillPublishDialog extends LitElement {
   }
 
   private async uploadFiles(uploadUrls: SkillUploadUrl[], indices?: number[]): Promise<void> {
+    if (!window.crypto || !window.crypto.subtle) {
+      throw new Error('Cryptography APIs (crypto.subtle) are not available. This feature requires a secure context (HTTPS or localhost).');
+    }
+
     const concurrency = 4;
     const queue = indices ?? Array.from({ length: this.selectedFiles.length }, (_, i) => i);
     let queuePos = 0;

--- a/web/src/components/shared/skill-publish-dialog.ts
+++ b/web/src/components/shared/skill-publish-dialog.ts
@@ -396,13 +396,14 @@ export class ScionSkillPublishDialog extends LitElement {
     }
   }
 
-  private async uploadFiles(uploadUrls: SkillUploadUrl[]): Promise<void> {
+  private async uploadFiles(uploadUrls: SkillUploadUrl[], indices?: number[]): Promise<void> {
     const concurrency = 4;
-    let index = 0;
+    const queue = indices ?? Array.from({ length: this.selectedFiles.length }, (_, i) => i);
+    let queuePos = 0;
 
     const uploadOne = async (): Promise<void> => {
-      while (index < this.selectedFiles.length) {
-        const i = index++;
+      while (queuePos < queue.length) {
+        const i = queue[queuePos++];
         const sf = this.selectedFiles[i];
         const urlInfo = uploadUrls.find((u) => u.path === sf.path);
         if (!urlInfo) {
@@ -459,7 +460,7 @@ export class ScionSkillPublishDialog extends LitElement {
       }
     };
 
-    const workers = Array.from({ length: Math.min(concurrency, this.selectedFiles.length) }, () => uploadOne());
+    const workers = Array.from({ length: Math.min(concurrency, queue.length) }, () => uploadOne());
     await Promise.all(workers);
   }
 
@@ -473,7 +474,7 @@ export class ScionSkillPublishDialog extends LitElement {
       .filter((x) => x.result.status === 'failed');
 
     try {
-      const filesPayload = failedFiles.map((x) => ({ path: x.file.path, size: x.file.size }));
+      const filesPayload = failedFiles.map((x) => ({ path: x.file.path, size: x.file.file.size }));
       const createRes = await apiFetch(`/api/v1/skills/${this.skillId}/versions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -489,12 +490,15 @@ export class ScionSkillPublishDialog extends LitElement {
 
       // Reset failed to pending
       for (const f of failedFiles) {
-        this.uploadResults = this.uploadResults.map((r, ri) =>
-          ri === f.index ? { ...r, status: 'pending' as const, error: undefined } : r
-        );
+        this.uploadResults = this.uploadResults.map((r, ri) => {
+          if (ri !== f.index) return r;
+          const { error: _, ...rest } = r;
+          return { ...rest, status: 'pending' as const };
+        });
       }
 
-      await this.uploadFiles(uploadUrls);
+      const failedIndices = failedFiles.map((f) => f.index);
+      await this.uploadFiles(uploadUrls, failedIndices);
 
       const stillFailed = this.uploadResults.filter((r) => r.status === 'failed');
       if (stillFailed.length > 0) {

--- a/web/src/components/shared/skill-publish-dialog.ts
+++ b/web/src/components/shared/skill-publish-dialog.ts
@@ -1,0 +1,728 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Multi-step publish version dialog for skills.
+ *
+ * Flow: file select → upload (parallel, concurrency-limited) → finalize.
+ * Uses the backend's 2-phase signed-URL upload pattern.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+import type { SkillVersion, SkillUploadUrl } from '../../shared/types.js';
+import { apiFetch, extractApiError } from '../../client/api.js';
+
+type DialogStep = 'input' | 'uploading' | 'finalizing' | 'done' | 'error';
+
+interface SelectedFile {
+  file: File;
+  path: string;
+}
+
+interface UploadResult {
+  path: string;
+  size: number;
+  hash: string;
+  status: 'pending' | 'uploading' | 'done' | 'failed';
+  error?: string;
+}
+
+@customElement('scion-skill-publish-dialog')
+export class ScionSkillPublishDialog extends LitElement {
+  @property({ type: String }) skillId = '';
+  @property({ type: Boolean, reflect: true }) open = false;
+  @property({ type: String }) latestVersion = '';
+
+  @state() private step: DialogStep = 'input';
+  @state() private version = '';
+  @state() private selectedFiles: SelectedFile[] = [];
+  @state() private validationError: string | null = null;
+  @state() private uploadResults: UploadResult[] = [];
+  @state() private uploadedCount = 0;
+  @state() private error: string | null = null;
+  @state() private createdVersion: SkillVersion | null = null;
+
+  private fileInputRef: HTMLInputElement | null = null;
+
+  static override styles = css`
+    :host { display: contents; }
+
+    .step-content {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .form-field label {
+      display: block;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+      margin-bottom: 0.375rem;
+    }
+
+    .drop-zone {
+      border: 2px dashed var(--scion-border, #e2e8f0);
+      border-radius: var(--scion-radius, 0.5rem);
+      padding: 2rem;
+      text-align: center;
+      cursor: pointer;
+      transition: all 150ms ease;
+      color: var(--scion-text-muted, #64748b);
+      font-size: 0.875rem;
+    }
+    .drop-zone:hover, .drop-zone.dragover {
+      border-color: var(--scion-primary, #3b82f6);
+      background: var(--sl-color-primary-50, #eff6ff);
+      color: var(--scion-primary, #3b82f6);
+    }
+    .drop-zone sl-icon {
+      font-size: 2rem;
+      display: block;
+      margin: 0 auto 0.5rem;
+    }
+
+    .file-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.375rem;
+    }
+    .file-item {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.5rem 0.75rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border-radius: var(--scion-radius, 0.5rem);
+      font-size: 0.875rem;
+    }
+    .file-info {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      min-width: 0;
+    }
+    .file-name {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .file-size {
+      color: var(--scion-text-muted, #64748b);
+      font-size: 0.75rem;
+      flex-shrink: 0;
+    }
+    .file-status {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+      flex-shrink: 0;
+    }
+    .file-status.done { color: var(--sl-color-success-600, #16a34a); }
+    .file-status.failed { color: var(--sl-color-danger-600, #dc2626); }
+    .file-status.uploading { color: var(--scion-primary, #3b82f6); }
+
+    .remove-btn {
+      cursor: pointer;
+      background: none;
+      border: none;
+      padding: 0.25rem;
+      color: var(--scion-text-muted, #64748b);
+      line-height: 1;
+    }
+    .remove-btn:hover { color: var(--sl-color-danger-600, #dc2626); }
+
+    .validation-error, .error-banner {
+      background: var(--sl-color-danger-50, #fef2f2);
+      border: 1px solid var(--sl-color-danger-200, #fecaca);
+      border-radius: var(--scion-radius, 0.5rem);
+      padding: 0.75rem 1rem;
+      display: flex;
+      align-items: flex-start;
+      gap: 0.5rem;
+      color: var(--sl-color-danger-700, #b91c1c);
+      font-size: 0.875rem;
+    }
+    .validation-error sl-icon, .error-banner sl-icon {
+      flex-shrink: 0;
+      margin-top: 0.125rem;
+    }
+
+    .progress-section {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+    .progress-label {
+      font-size: 0.875rem;
+      color: var(--scion-text, #1e293b);
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .success-banner {
+      background: var(--sl-color-success-50, #f0fdf4);
+      border: 1px solid var(--sl-color-success-200, #bbf7d0);
+      border-radius: var(--scion-radius, 0.5rem);
+      padding: 1rem;
+      text-align: center;
+      color: var(--sl-color-success-700, #15803d);
+    }
+    .success-banner sl-icon {
+      font-size: 2rem;
+      display: block;
+      margin: 0 auto 0.5rem;
+    }
+
+    input[type="file"] { display: none; }
+  `;
+
+  override updated(changed: Map<PropertyKey, unknown>): void {
+    if (changed.has('open') && this.open) {
+      this.reset();
+      if (this.latestVersion) {
+        this.version = this.bumpPatch(this.latestVersion);
+      }
+    }
+  }
+
+  private reset(): void {
+    this.step = 'input';
+    this.version = '';
+    this.selectedFiles = [];
+    this.validationError = null;
+    this.uploadResults = [];
+    this.uploadedCount = 0;
+    this.error = null;
+    this.createdVersion = null;
+  }
+
+  private bumpPatch(ver: string): string {
+    const parts = ver.replace(/^v/, '').split('.');
+    if (parts.length < 3) return ver;
+    const patch = parseInt(parts[2], 10);
+    if (isNaN(patch)) return ver;
+    return `${parts[0]}.${parts[1]}.${patch + 1}`;
+  }
+
+  private formatFileSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  private validateSemver(v: string): boolean {
+    return /^\d+\.\d+\.\d+(-[\w.]+)?$/.test(v.replace(/^v/, ''));
+  }
+
+  // -- File handling --
+
+  private onDropZoneClick(): void {
+    if (!this.fileInputRef) {
+      this.fileInputRef = document.createElement('input');
+      this.fileInputRef.type = 'file';
+      this.fileInputRef.multiple = true;
+      this.fileInputRef.addEventListener('change', () => this.onFilesSelected());
+    }
+    this.fileInputRef.click();
+  }
+
+  private onFilesSelected(): void {
+    if (!this.fileInputRef?.files) return;
+    const newFiles: SelectedFile[] = [];
+    for (const file of Array.from(this.fileInputRef.files)) {
+      const path = file.webkitRelativePath || file.name;
+      if (!this.selectedFiles.some((f) => f.path === path)) {
+        newFiles.push({ file, path });
+      }
+    }
+    this.selectedFiles = [...this.selectedFiles, ...newFiles];
+    this.validationError = null;
+    this.fileInputRef.value = '';
+  }
+
+  private onDrop(e: DragEvent): void {
+    e.preventDefault();
+    const target = e.currentTarget as HTMLElement;
+    target.classList.remove('dragover');
+    if (!e.dataTransfer?.files) return;
+    const newFiles: SelectedFile[] = [];
+    for (const file of Array.from(e.dataTransfer.files)) {
+      const path = file.name;
+      if (!this.selectedFiles.some((f) => f.path === path)) {
+        newFiles.push({ file, path });
+      }
+    }
+    this.selectedFiles = [...this.selectedFiles, ...newFiles];
+    this.validationError = null;
+  }
+
+  private onDragOver(e: DragEvent): void {
+    e.preventDefault();
+    (e.currentTarget as HTMLElement).classList.add('dragover');
+  }
+
+  private onDragLeave(e: DragEvent): void {
+    (e.currentTarget as HTMLElement).classList.remove('dragover');
+  }
+
+  private removeFile(index: number): void {
+    this.selectedFiles = this.selectedFiles.filter((_, i) => i !== index);
+  }
+
+  // -- Validation --
+
+  private validate(): string | null {
+    if (!this.version.trim()) return 'Version is required.';
+    if (!this.validateSemver(this.version.trim())) return 'Version must be valid semver (e.g. 1.0.0).';
+    if (this.selectedFiles.length === 0) return 'At least one file is required.';
+    if (!this.selectedFiles.some((f) => f.path.toLowerCase() === 'skill.md'))
+      return 'SKILL.md is required.';
+    if (this.selectedFiles.length > 50) return 'Maximum 50 files allowed.';
+    const maxSize = 10 * 1024 * 1024;
+    const oversize = this.selectedFiles.find((f) => f.file.size > maxSize);
+    if (oversize) return `File "${oversize.path}" exceeds 10 MB limit.`;
+    const totalSize = this.selectedFiles.reduce((sum, f) => sum + f.file.size, 0);
+    if (totalSize > 50 * 1024 * 1024) return `Total file size exceeds 50 MB limit.`;
+    return null;
+  }
+
+  // -- Upload flow --
+
+  private async startPublish(): Promise<void> {
+    const err = this.validate();
+    if (err) {
+      this.validationError = err;
+      return;
+    }
+
+    this.step = 'uploading';
+    this.error = null;
+    this.uploadedCount = 0;
+    this.uploadResults = this.selectedFiles.map((f) => ({
+      path: f.path,
+      size: f.file.size,
+      hash: '',
+      status: 'pending' as const,
+    }));
+
+    try {
+      // Step 1: Create draft version and get upload URLs
+      const filesPayload = this.selectedFiles.map((f) => ({ path: f.path, size: f.file.size }));
+      const createRes = await apiFetch(`/api/v1/skills/${this.skillId}/versions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ version: this.version.trim(), files: filesPayload }),
+      });
+
+      if (!createRes.ok) {
+        const msg = await extractApiError(createRes, `HTTP ${createRes.status}`);
+        throw new Error(msg);
+      }
+
+      const createData = (await createRes.json()) as {
+        version?: SkillVersion;
+        uploadUrls?: SkillUploadUrl[];
+        urls?: SkillUploadUrl[];
+      };
+
+      const uploadUrls = createData.uploadUrls || createData.urls || [];
+
+      // Step 2: Upload files with concurrency limit
+      await this.uploadFiles(uploadUrls);
+
+      // Check for failures
+      const failed = this.uploadResults.filter((r) => r.status === 'failed');
+      if (failed.length > 0) {
+        this.step = 'error';
+        this.error = `${failed.length} file(s) failed to upload. You can retry.`;
+        return;
+      }
+
+      // Step 3: Finalize
+      this.step = 'finalizing';
+      const manifest = {
+        files: this.uploadResults.map((r) => ({
+          path: r.path,
+          size: r.size,
+          hash: r.hash,
+        })),
+      };
+
+      const finalizeRes = await apiFetch(`/api/v1/skills/${this.skillId}/finalize`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ version: this.version.trim(), manifest }),
+      });
+
+      if (!finalizeRes.ok) {
+        const msg = await extractApiError(finalizeRes, `HTTP ${finalizeRes.status}`);
+        throw new Error(msg);
+      }
+
+      const finalData = (await finalizeRes.json()) as { version?: SkillVersion } | SkillVersion;
+      this.createdVersion = ('version' in finalData && finalData.version)
+        ? finalData.version as SkillVersion
+        : finalData as SkillVersion;
+      this.step = 'done';
+
+      this.dispatchEvent(new CustomEvent('skill-version-published', {
+        detail: { version: this.createdVersion },
+        bubbles: true,
+        composed: true,
+      }));
+    } catch (err) {
+      console.error('Publish failed:', err);
+      this.step = 'error';
+      this.error = err instanceof Error ? err.message : 'Publish failed';
+    }
+  }
+
+  private async uploadFiles(uploadUrls: SkillUploadUrl[]): Promise<void> {
+    const concurrency = 4;
+    let index = 0;
+
+    const uploadOne = async (): Promise<void> => {
+      while (index < this.selectedFiles.length) {
+        const i = index++;
+        const sf = this.selectedFiles[i];
+        const urlInfo = uploadUrls.find((u) => u.path === sf.path);
+        if (!urlInfo) {
+          this.uploadResults = this.uploadResults.map((r, ri) =>
+            ri === i ? { ...r, status: 'failed' as const, error: 'No upload URL' } : r
+          );
+          continue;
+        }
+
+        this.uploadResults = this.uploadResults.map((r, ri) =>
+          ri === i ? { ...r, status: 'uploading' as const } : r
+        );
+        this.requestUpdate();
+
+        try {
+          // Compute SHA-256 hash
+          const buffer = await sf.file.arrayBuffer();
+          const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
+          const hashArray = Array.from(new Uint8Array(hashBuffer));
+          const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+          const hash = `sha256:${hashHex}`;
+
+          // Upload
+          const headers: Record<string, string> = urlInfo.headers || {};
+          let res = await fetch(urlInfo.url, {
+            method: urlInfo.method || 'PUT',
+            headers,
+            body: buffer,
+          });
+
+          // Retry once on failure
+          if (!res.ok) {
+            res = await fetch(urlInfo.url, {
+              method: urlInfo.method || 'PUT',
+              headers,
+              body: buffer,
+            });
+          }
+
+          if (!res.ok) {
+            throw new Error(`Upload failed: ${res.status}`);
+          }
+
+          this.uploadResults = this.uploadResults.map((r, ri) =>
+            ri === i ? { ...r, status: 'done' as const, hash } : r
+          );
+          this.uploadedCount++;
+        } catch (err) {
+          this.uploadResults = this.uploadResults.map((r, ri) =>
+            ri === i ? { ...r, status: 'failed' as const, error: err instanceof Error ? err.message : 'Upload failed' } : r
+          );
+        }
+        this.requestUpdate();
+      }
+    };
+
+    const workers = Array.from({ length: Math.min(concurrency, this.selectedFiles.length) }, () => uploadOne());
+    await Promise.all(workers);
+  }
+
+  private async retryFailed(): Promise<void> {
+    this.error = null;
+    this.step = 'uploading';
+
+    // Re-create version to get fresh upload URLs for failed files
+    const failedFiles = this.uploadResults
+      .map((r, i) => ({ result: r, index: i, file: this.selectedFiles[i] }))
+      .filter((x) => x.result.status === 'failed');
+
+    try {
+      const filesPayload = failedFiles.map((x) => ({ path: x.file.path, size: x.file.size }));
+      const createRes = await apiFetch(`/api/v1/skills/${this.skillId}/versions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ version: this.version.trim(), files: filesPayload }),
+      });
+
+      if (!createRes.ok) {
+        throw new Error(await extractApiError(createRes, 'Failed to get upload URLs'));
+      }
+
+      const data = (await createRes.json()) as { uploadUrls?: SkillUploadUrl[]; urls?: SkillUploadUrl[] };
+      const uploadUrls = data.uploadUrls || data.urls || [];
+
+      // Reset failed to pending
+      for (const f of failedFiles) {
+        this.uploadResults = this.uploadResults.map((r, ri) =>
+          ri === f.index ? { ...r, status: 'pending' as const, error: undefined } : r
+        );
+      }
+
+      await this.uploadFiles(uploadUrls);
+
+      const stillFailed = this.uploadResults.filter((r) => r.status === 'failed');
+      if (stillFailed.length > 0) {
+        this.step = 'error';
+        this.error = `${stillFailed.length} file(s) still failed.`;
+      } else {
+        // All done — proceed to finalize
+        this.step = 'finalizing';
+        const manifest = {
+          files: this.uploadResults.map((r) => ({ path: r.path, size: r.size, hash: r.hash })),
+        };
+        const finalizeRes = await apiFetch(`/api/v1/skills/${this.skillId}/finalize`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ version: this.version.trim(), manifest }),
+        });
+
+        if (!finalizeRes.ok) {
+          throw new Error(await extractApiError(finalizeRes, 'Finalize failed'));
+        }
+
+        const finalData = (await finalizeRes.json()) as { version?: SkillVersion } | SkillVersion;
+        this.createdVersion = ('version' in finalData && finalData.version)
+          ? finalData.version as SkillVersion
+          : finalData as SkillVersion;
+        this.step = 'done';
+
+        this.dispatchEvent(new CustomEvent('skill-version-published', {
+          detail: { version: this.createdVersion },
+          bubbles: true,
+          composed: true,
+        }));
+      }
+    } catch (err) {
+      this.step = 'error';
+      this.error = err instanceof Error ? err.message : 'Retry failed';
+    }
+  }
+
+  // -- Dialog events --
+
+  private onDialogHide(): void {
+    this.open = false;
+    this.dispatchEvent(new CustomEvent('sl-after-hide'));
+  }
+
+  // -- Render --
+
+  override render() {
+    return html`
+      <sl-dialog
+        label="Publish New Version"
+        ?open=${this.open}
+        @sl-after-hide=${() => this.onDialogHide()}
+        style="--width: 540px;"
+      >
+        ${this.step === 'input' ? this.renderInput() : nothing}
+        ${this.step === 'uploading' ? this.renderUploading() : nothing}
+        ${this.step === 'finalizing' ? this.renderFinalizing() : nothing}
+        ${this.step === 'done' ? this.renderDone() : nothing}
+        ${this.step === 'error' ? this.renderError() : nothing}
+      </sl-dialog>
+    `;
+  }
+
+  private renderInput() {
+    return html`
+      <div class="step-content">
+        ${this.validationError ? html`
+          <div class="validation-error">
+            <sl-icon name="exclamation-triangle"></sl-icon>
+            <span>${this.validationError}</span>
+          </div>
+        ` : nothing}
+
+        <div class="form-field">
+          <label>Version</label>
+          <sl-input
+            placeholder="1.0.0"
+            .value=${this.version}
+            @sl-input=${(e: Event) => { this.version = (e.target as HTMLElement & { value: string }).value; }}
+          ></sl-input>
+        </div>
+
+        <div class="form-field">
+          <label>Files</label>
+          <div
+            class="drop-zone"
+            @click=${() => this.onDropZoneClick()}
+            @drop=${(e: DragEvent) => this.onDrop(e)}
+            @dragover=${(e: DragEvent) => this.onDragOver(e)}
+            @dragleave=${(e: DragEvent) => this.onDragLeave(e)}
+          >
+            <sl-icon name="upload"></sl-icon>
+            Drop files here or click to browse
+          </div>
+        </div>
+
+        ${this.selectedFiles.length > 0 ? html`
+          <ul class="file-list">
+            ${this.selectedFiles.map((sf, i) => html`
+              <li class="file-item">
+                <div class="file-info">
+                  <sl-icon name="file-earmark"></sl-icon>
+                  <span class="file-name">${sf.path}</span>
+                  <span class="file-size">${this.formatFileSize(sf.file.size)}</span>
+                </div>
+                <button class="remove-btn" @click=${() => this.removeFile(i)} title="Remove">
+                  <sl-icon name="x-lg"></sl-icon>
+                </button>
+              </li>
+            `)}
+          </ul>
+        ` : nothing}
+      </div>
+
+      <sl-button slot="footer" variant="default" @click=${() => { this.open = false; }}>
+        Cancel
+      </sl-button>
+      <sl-button
+        slot="footer"
+        variant="primary"
+        @click=${() => this.startPublish()}
+        ?disabled=${this.selectedFiles.length === 0 || !this.version.trim()}
+      >
+        <sl-icon slot="prefix" name="upload"></sl-icon>
+        Upload &amp; Publish
+      </sl-button>
+    `;
+  }
+
+  private renderUploading() {
+    const total = this.uploadResults.length;
+    const done = this.uploadResults.filter((r) => r.status === 'done').length;
+    const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+
+    return html`
+      <div class="step-content">
+        <div class="progress-section">
+          <div class="progress-label">
+            <span>Uploading files...</span>
+            <span>${done} / ${total}</span>
+          </div>
+          <sl-progress-bar value=${pct}></sl-progress-bar>
+        </div>
+
+        <ul class="file-list">
+          ${this.uploadResults.map((r) => html`
+            <li class="file-item">
+              <div class="file-info">
+                <sl-icon name="file-earmark"></sl-icon>
+                <span class="file-name">${r.path}</span>
+                <span class="file-size">${this.formatFileSize(r.size)}</span>
+              </div>
+              <div class="file-status ${r.status}">
+                ${r.status === 'done' ? html`<sl-icon name="check-circle"></sl-icon>` : nothing}
+                ${r.status === 'uploading' ? html`<sl-spinner style="font-size: 1rem;"></sl-spinner>` : nothing}
+                ${r.status === 'failed' ? html`<sl-icon name="x-circle"></sl-icon>` : nothing}
+                ${r.status === 'pending' ? html`<sl-icon name="clock"></sl-icon>` : nothing}
+              </div>
+            </li>
+          `)}
+        </ul>
+      </div>
+    `;
+  }
+
+  private renderFinalizing() {
+    return html`
+      <div class="step-content" style="text-align: center; padding: 2rem 0;">
+        <sl-spinner style="font-size: 2rem;"></sl-spinner>
+        <p style="margin-top: 1rem; color: var(--scion-text-muted, #64748b);">Finalizing version ${this.version}...</p>
+      </div>
+    `;
+  }
+
+  private renderDone() {
+    return html`
+      <div class="step-content">
+        <div class="success-banner">
+          <sl-icon name="check-circle"></sl-icon>
+          <p><strong>Version ${this.version} published successfully!</strong></p>
+        </div>
+      </div>
+      <sl-button slot="footer" variant="primary" @click=${() => { this.open = false; }}>
+        Close
+      </sl-button>
+    `;
+  }
+
+  private renderError() {
+    return html`
+      <div class="step-content">
+        <div class="error-banner">
+          <sl-icon name="exclamation-triangle"></sl-icon>
+          <span>${this.error}</span>
+        </div>
+
+        ${this.uploadResults.some((r) => r.status === 'failed') ? html`
+          <ul class="file-list">
+            ${this.uploadResults.filter((r) => r.status === 'failed').map((r) => html`
+              <li class="file-item">
+                <div class="file-info">
+                  <sl-icon name="file-earmark"></sl-icon>
+                  <span class="file-name">${r.path}</span>
+                </div>
+                <div class="file-status failed">
+                  <sl-icon name="x-circle"></sl-icon>
+                  <span style="font-size: 0.75rem;">${r.error || 'Failed'}</span>
+                </div>
+              </li>
+            `)}
+          </ul>
+        ` : nothing}
+      </div>
+      <sl-button slot="footer" variant="default" @click=${() => { this.open = false; }}>
+        Cancel
+      </sl-button>
+      <sl-button slot="footer" variant="primary" @click=${() => this.retryFailed()}>
+        <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+        Retry Failed
+      </sl-button>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-skill-publish-dialog': ScionSkillPublishDialog;
+  }
+}

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -771,6 +771,67 @@ export interface PolicyConditions {
   delegatedFromGroup?: string;
 }
 
+// ---------------------------------------------------------------------------
+// Skills
+// ---------------------------------------------------------------------------
+
+export type SkillScope = 'core' | 'global' | 'project' | 'user';
+export type SkillVisibility = 'public' | 'private';
+export type SkillVersionStatus = 'draft' | 'published' | 'deprecated' | 'archived';
+
+export interface Skill {
+  id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  tags?: string[];
+  scope: SkillScope;
+  scopeId?: string;
+  status: string;
+  ownerId?: string;
+  createdBy?: string;
+  visibility: SkillVisibility;
+  created: string;
+  updated: string;
+  _capabilities?: Capabilities;
+}
+
+export interface SkillVersion {
+  id: string;
+  skillId: string;
+  version: string;
+  status: SkillVersionStatus;
+  contentHash?: string;
+  files?: SkillFile[];
+  publisherId?: string;
+  deprecationMessage?: string;
+  replacementUri?: string;
+  downloadCount: number;
+  created: string;
+}
+
+export interface SkillFile {
+  path: string;
+  size: number;
+  hash?: string;
+  mode?: string;
+}
+
+export interface SkillUploadUrl {
+  path: string;
+  url: string;
+  method: string;
+  headers?: Record<string, string>;
+  expires: string;
+}
+
+export interface SkillDownloadUrl {
+  path: string;
+  url: string;
+  size: number;
+  hash?: string;
+}
+
 /**
  * Policy effect: allow or deny.
  */

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -832,6 +832,26 @@ export interface SkillDownloadUrl {
   hash?: string;
 }
 
+// Skill Registry types (admin only)
+
+export type SkillRegistryStatus = 'active' | 'disabled';
+export type SkillRegistryTrustLevel = 'trusted' | 'pinned';
+export type SkillRegistryType = 'hub' | 'gcp';
+
+export interface SkillRegistry {
+  id: string;
+  name: string;
+  endpoint: string;
+  description?: string;
+  type: SkillRegistryType;
+  trustLevel: SkillRegistryTrustLevel;
+  resolvePath?: string;
+  status: SkillRegistryStatus;
+  createdBy?: string;
+  created: string;
+  updated: string;
+}
+
 /**
  * Policy effect: allow or deny.
  */


### PR DESCRIPTION
## Summary

Adds the complete web UI for the Skill Bank feature to the Scion hub.

- **Skills list page** (`/skills`) — grid/table views, search, scope filter, sort, capability-gated create button
- **Skill create page** (`/skills/new`) — form with name validation, scope selection, tags, visibility
- **Skill detail page** (`/skills/{id}`) — tabbed view with Overview (inline edit), Versions (deprecation), and Files (download) tabs
- **Publish version dialog** — file picker with drag-and-drop, parallel upload with progress, SHA-256 hashing, finalize
- **Skill registries admin pages** (`/admin/skill-registries`) — list + detail with config editing, pin/unpin management
- **Backend additions** — `GET /api/v1/skill-registries/{id}/pins`, `POST /api/v1/skill-registries/{id}/unpin`, `PATCH` support for registry updates, `ListPinnedHashes` and `UnpinSkillHash` store methods
- **SSR prefetch** for `/skills` and `/skills/{id}` routes
- **Nav entries** — "Skills" in Management section, "Skill Registries" in Admin section

All mutating UI actions are capability-gated. No new frontend dependencies.

Design doc: `/scion-volumes/scratchpad/projects/skill-bank/web-ui-design.md`

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] `go test ./pkg/hub -run 'Skill|SkillRegistry'` passes
- [ ] `go test ./pkg/store/entadapter -run 'Skill|SkillRegistry'` passes
- [ ] Manual: navigate to /skills, verify list page renders with grid/table toggle
- [ ] Manual: create a skill via /skills/new, verify redirect to detail
- [ ] Manual: verify skill detail tabs (overview, versions, files)
- [ ] Manual: publish a version via dialog (file upload + finalize)
- [ ] Manual: admin user sees Skill Registries in sidebar, non-admin does not
- [ ] Manual: verify registry CRUD and pin/unpin operations
