### PR TITLE
feat: add image_pinned to skip registry rewrite for custom images

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -309,7 +309,12 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 	// Apply image_registry rewrite to whatever image was resolved above.
 	// This rewrites the registry prefix for scion-* images. An explicit
 	// --image flag below takes full precedence (no rewrite).
-	if settings != nil && resolvedImage != "" {
+	// When image_pinned is set in the agent/template config, the image is
+	// used as-is without registry rewriting.
+	imagePinned := finalScionCfg != nil && finalScionCfg.ImagePinned
+	if imagePinned {
+		util.Debugf("image resolution: image_pinned=true, skipping registry rewrite")
+	} else if settings != nil && resolvedImage != "" {
 		imageRegistry := settings.ResolveImageRegistry(opts.Profile)
 		if imageRegistry != "" {
 			rewritten := config.RewriteImageRegistry(resolvedImage, imageRegistry)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -447,8 +447,9 @@ type ScionConfig struct {
 	Kubernetes       *KubernetesConfig `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
 	AuthSelectedType string            `json:"auth_selectedType,omitempty" yaml:"auth_selectedType,omitempty"`
 	Resources        *ResourceSpec     `json:"resources,omitempty" yaml:"resources,omitempty"`
-	Image            string            `json:"image,omitempty" yaml:"image,omitempty"`
-	Services         []ServiceSpec     `json:"services,omitempty" yaml:"services,omitempty"`
+	Image       string        `json:"image,omitempty" yaml:"image,omitempty"`
+	ImagePinned bool          `json:"image_pinned,omitempty" yaml:"image_pinned,omitempty"`
+	Services    []ServiceSpec `json:"services,omitempty" yaml:"services,omitempty"`
 	// MCPServers is the universal MCP server map. Keys are server names; values
 	// are the transport-agnostic config translated by each harness's
 	// container-side provisioner into native format.


### PR DESCRIPTION
## Problem

Templates with custom images (e.g. `ghcr.io/myorg/scion-elixir:latest`) get silently rewritten by `RewriteImageRegistry()` to point at the broker's registry. If you don't have push access to the broker's registry, there's no way to use a custom image — even though you specified the exact reference you wanted.

## Solution

Add an opt-in `image_pinned: true` field to `scion-agent.yaml`. When set, the registry rewrite is skipped and the image reference is used as-is.

```yaml
image: ghcr.io/myorg/scion-custom-image:latest
image_pinned: true
```

**This is a 9-line, 2-file change.** Start with `pkg/agent/run.go` (the guard clause) — the rest is the struct field in `pkg/api/types.go`.

## Non-goals

- No changes to the registry rewrite logic itself
- No CLI flags — this is template-author-facing only

## Risk

- **Backward compatible**: `image_pinned` defaults to `false`; existing templates behave identically
- No migration needed