### PR TITLE
fix(web): auto-link chat accounts when code is in URL params (#264)

### DIFF
--- a/web/src/components/pages/profile-discord.ts
+++ b/web/src/components/pages/profile-discord.ts
@@ -17,8 +17,9 @@
 /**
  * Profile Discord linking page
  *
- * Allows users to link their Discord account by entering a 6-character
- * code provided by the Discord bot.
+ * When opened via the bot's registration link (?code=…), automatically
+ * verifies the code and shows a confirmation. Otherwise shows a manual
+ * code-entry form.
  */
 
 import { LitElement, html, css, nothing } from 'lit';
@@ -39,6 +40,9 @@ export class ScionPageProfileDiscord extends LitElement {
   @state()
   private _discordUsername = '';
 
+  @state()
+  private _autoLinked = false;
+
   override connectedCallback(): void {
     super.connectedCallback();
     const params = new URLSearchParams(window.location.search);
@@ -50,6 +54,7 @@ export class ScionPageProfileDiscord extends LitElement {
     if (code) {
       this._code = code.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 6);
       if (this._code.length === 6) {
+        this._autoLinked = true;
         this._autoSubmit();
       }
     }
@@ -57,7 +62,9 @@ export class ScionPageProfileDiscord extends LitElement {
 
   private async _autoSubmit(): Promise<void> {
     this._status = 'submitting';
-    this._message = 'Linking your account…';
+    this._message = this._discordUsername
+      ? `Linking Discord account for ${this._discordUsername}…`
+      : 'Linking your Discord account…';
 
     try {
       const resp = await apiFetch('/api/v1/discord/link/verify', {
@@ -202,6 +209,15 @@ export class ScionPageProfileDiscord extends LitElement {
       color: var(--sl-color-danger-700, #b91c1c);
       border: 1px solid var(--sl-color-danger-200, #fecaca);
     }
+
+    .auto-link-status {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 0.9375rem;
+      color: var(--scion-text-muted, #64748b);
+      padding: 0.5rem 0;
+    }
   `;
 
   private _handleInput(e: Event): void {
@@ -246,15 +262,44 @@ export class ScionPageProfileDiscord extends LitElement {
     }
   }
 
-  override render() {
+  private _renderAutoLink() {
     return html`
-      <div class="page-header">
-        <div class="page-header-info">
-          <h1>Discord</h1>
-          <p>Link your Discord account to receive notifications and interact with agents.</p>
-        </div>
-      </div>
+      <div class="settings-card">
+        <h2 class="section-title">
+          <sl-icon name="link-45deg"></sl-icon>
+          Link Discord Account
+        </h2>
 
+        ${this._status === 'submitting'
+          ? html`
+              <div class="auto-link-status">
+                <sl-spinner></sl-spinner>
+                <span>${this._message}</span>
+              </div>
+            `
+          : nothing}
+        ${this._status === 'success'
+          ? html`
+              <div class="result-message result-success">
+                <sl-icon name="check-circle"></sl-icon>
+                ${this._message}
+              </div>
+            `
+          : nothing}
+        ${this._status === 'error'
+          ? html`
+              <div class="result-message result-error">
+                <sl-icon name="exclamation-circle"></sl-icon>
+                ${this._message}
+              </div>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private _renderForm() {
+    return html`
       <div class="settings-card">
         <h2 class="section-title">
           <sl-icon name="link-45deg"></sl-icon>
@@ -312,6 +357,19 @@ export class ScionPageProfileDiscord extends LitElement {
             `
           : nothing}
       </div>
+    `;
+  }
+
+  override render() {
+    return html`
+      <div class="page-header">
+        <div class="page-header-info">
+          <h1>Discord</h1>
+          <p>Link your Discord account to receive notifications and interact with agents.</p>
+        </div>
+      </div>
+
+      ${this._autoLinked ? this._renderAutoLink() : this._renderForm()}
     `;
   }
 }

--- a/web/src/components/pages/profile-telegram.ts
+++ b/web/src/components/pages/profile-telegram.ts
@@ -17,8 +17,9 @@
 /**
  * Profile Telegram linking page
  *
- * Allows users to link their Telegram account by entering a 6-character
- * code provided by the Telegram bot.
+ * When opened via the bot's registration link (?code=…), automatically
+ * verifies the code and shows a confirmation. Otherwise shows a manual
+ * code-entry form.
  */
 
 import { LitElement, html, css, nothing } from 'lit';
@@ -36,6 +37,9 @@ export class ScionPageProfileTelegram extends LitElement {
   @state()
   private _message = '';
 
+  @state()
+  private _autoLinked = false;
+
   override connectedCallback(): void {
     super.connectedCallback();
     const params = new URLSearchParams(window.location.search);
@@ -43,6 +47,7 @@ export class ScionPageProfileTelegram extends LitElement {
     if (code) {
       this._code = code.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 6);
       if (this._code.length === 6) {
+        this._autoLinked = true;
         this._autoSubmit();
       }
     }
@@ -50,7 +55,7 @@ export class ScionPageProfileTelegram extends LitElement {
 
   private async _autoSubmit(): Promise<void> {
     this._status = 'submitting';
-    this._message = 'Linking your account…';
+    this._message = 'Linking your Telegram account…';
 
     try {
       const resp = await apiFetch('/api/v1/telegram/link/verify', {
@@ -186,6 +191,15 @@ export class ScionPageProfileTelegram extends LitElement {
       color: var(--sl-color-danger-700, #b91c1c);
       border: 1px solid var(--sl-color-danger-200, #fecaca);
     }
+
+    .auto-link-status {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 0.9375rem;
+      color: var(--scion-text-muted, #64748b);
+      padding: 0.5rem 0;
+    }
   `;
 
   private _handleInput(e: Event): void {
@@ -231,15 +245,44 @@ export class ScionPageProfileTelegram extends LitElement {
     }
   }
 
-  override render() {
+  private _renderAutoLink() {
     return html`
-      <div class="page-header">
-        <div class="page-header-info">
-          <h1>Telegram</h1>
-          <p>Link your Telegram account to receive notifications and interact with agents.</p>
-        </div>
-      </div>
+      <div class="settings-card">
+        <h2 class="section-title">
+          <sl-icon name="link-45deg"></sl-icon>
+          Link Telegram Account
+        </h2>
 
+        ${this._status === 'submitting'
+          ? html`
+              <div class="auto-link-status">
+                <sl-spinner></sl-spinner>
+                <span>${this._message}</span>
+              </div>
+            `
+          : nothing}
+        ${this._status === 'success'
+          ? html`
+              <div class="result-message result-success">
+                <sl-icon name="check-circle"></sl-icon>
+                ${this._message}
+              </div>
+            `
+          : nothing}
+        ${this._status === 'error'
+          ? html`
+              <div class="result-message result-error">
+                <sl-icon name="exclamation-circle"></sl-icon>
+                ${this._message}
+              </div>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private _renderForm() {
+    return html`
       <div class="settings-card">
         <h2 class="section-title">
           <sl-icon name="link-45deg"></sl-icon>
@@ -293,6 +336,19 @@ export class ScionPageProfileTelegram extends LitElement {
             `
           : nothing}
       </div>
+    `;
+  }
+
+  override render() {
+    return html`
+      <div class="page-header">
+        <div class="page-header-info">
+          <h1>Telegram</h1>
+          <p>Link your Telegram account to receive notifications and interact with agents.</p>
+        </div>
+      </div>
+
+      ${this._autoLinked ? this._renderAutoLink() : this._renderForm()}
     `;
   }
 }


### PR DESCRIPTION
When users arrive via bot registration links (which include ?code=…), show a clean "Linking…" → "Success!" flow instead of the manual code-entry form. The form is still available when navigating to the page directly without a code parameter.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
