### PR TITLE
feat(agent-viz): render comms transcript as Markdown with per-message collapse

### DIFF
--- a/extras/agent-viz/web/index.html
+++ b/extras/agent-viz/web/index.html
@@ -345,6 +345,114 @@
       line-height: 1.45;
       color: #c9d1d9;
       word-break: break-word;
+      display: none;       /* collapsed by default — click a message to expand */
+      margin-top: 4px;
+    }
+
+    /* Per-message collapse: show a one-line summary until the user expands. */
+    .comms-msg-header { cursor: pointer; }
+    .comms-msg-toggle {
+      display: inline-block;
+      width: 9px;
+      color: rgba(255,255,255,0.45);
+      transition: transform 0.12s ease;
+    }
+    .comms-msg.expanded .comms-msg-toggle { transform: rotate(90deg); }
+    .comms-summary {
+      font-size: 11px;
+      color: rgba(255,255,255,0.5);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .comms-msg.expanded .comms-summary { display: none; }
+    .comms-msg.expanded .comms-content { display: block; }
+
+    /* Markdown rendered inside a comms message. Kept compact for the narrow,
+       dark panel: tight margins, no first/last spacing, scrollable code. */
+    .comms-content.markdown > *:first-child { margin-top: 0; }
+    .comms-content.markdown > *:last-child { margin-bottom: 0; }
+
+    .comms-content.markdown p { margin: 0 0 6px; }
+
+    .comms-content.markdown h1,
+    .comms-content.markdown h2,
+    .comms-content.markdown h3,
+    .comms-content.markdown h4 {
+      font-weight: 700;
+      line-height: 1.3;
+      margin: 8px 0 4px;
+      color: #e6edf3;
+    }
+    .comms-content.markdown h1 { font-size: 13px; }
+    .comms-content.markdown h2 { font-size: 12.5px; }
+    .comms-content.markdown h3 { font-size: 12px; }
+    .comms-content.markdown h4 { font-size: 11.5px; }
+
+    .comms-content.markdown ul,
+    .comms-content.markdown ol {
+      margin: 0 0 6px;
+      padding-left: 18px;
+    }
+    .comms-content.markdown ul { list-style: disc; }
+    .comms-content.markdown ol { list-style: decimal; }
+    .comms-content.markdown li { margin: 1px 0; }
+
+    .comms-content.markdown strong { color: #e6edf3; font-weight: 700; }
+    .comms-content.markdown em { font-style: italic; }
+
+    .comms-content.markdown a {
+      color: #58a6ff;
+      text-decoration: none;
+    }
+    .comms-content.markdown a:hover { text-decoration: underline; }
+
+    .comms-content.markdown code {
+      font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 10.5px;
+      background: rgba(255,255,255,0.08);
+      padding: 1px 4px;
+      border-radius: 3px;
+    }
+
+    .comms-content.markdown pre {
+      margin: 0 0 6px;
+      padding: 7px 9px;
+      background: rgba(0,0,0,0.35);
+      border: 1px solid rgba(255,255,255,0.08);
+      border-radius: 5px;
+      overflow-x: auto;
+      scrollbar-width: thin;
+    }
+    .comms-content.markdown pre code {
+      background: none;
+      padding: 0;
+      font-size: 10.5px;
+      line-height: 1.4;
+    }
+
+    .comms-content.markdown blockquote {
+      margin: 0 0 6px;
+      padding-left: 8px;
+      border-left: 2px solid rgba(255,255,255,0.15);
+      color: rgba(255,255,255,0.65);
+    }
+
+    .comms-content.markdown table {
+      border-collapse: collapse;
+      margin: 0 0 6px;
+      font-size: 10.5px;
+    }
+    .comms-content.markdown th,
+    .comms-content.markdown td {
+      border: 1px solid rgba(255,255,255,0.12);
+      padding: 2px 6px;
+    }
+
+    .comms-content.markdown hr {
+      border: none;
+      border-top: 1px solid rgba(255,255,255,0.12);
+      margin: 8px 0;
     }
 
     @keyframes commsFadeIn {

--- a/extras/agent-viz/web/package-lock.json
+++ b/extras/agent-viz/web/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "d3-force": "^3.0.0",
-        "force-graph": "^1.47.0"
+        "force-graph": "^1.47.0",
+        "marked": "^18.0.5"
       },
       "devDependencies": {
         "typescript": "~5.7.0",
@@ -1232,6 +1233,18 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",

--- a/extras/agent-viz/web/package.json
+++ b/extras/agent-viz/web/package.json
@@ -13,7 +13,8 @@
     "vite": "~6.4.2"
   },
   "dependencies": {
+    "d3-force": "^3.0.0",
     "force-graph": "^1.47.0",
-    "d3-force": "^3.0.0"
+    "marked": "^18.0.5"
   }
 }

--- a/extras/agent-viz/web/src/comms.ts
+++ b/extras/agent-viz/web/src/comms.ts
@@ -21,7 +21,7 @@ import type { AgentRing } from './agents';
 
 // Render message bodies as inline-friendly HTML: no leading <h1> ids, GitHub-style
 // line breaks so single newlines in agent output become visible breaks.
-marked.setOptions({ breaks: true, gfm: true });
+marked.use({ breaks: true, gfm: true });
 
 /**
  * Window (in event-time ms) for collapsing duplicate broadcast deliveries into a
@@ -171,16 +171,16 @@ export class CommsPanel {
       : '';
     const bcastBadge = broadcast ? '<span class="comms-badge">BROADCAST</span>' : '';
 
-    // Render the message body as Markdown. `marked.parse` is synchronous and
-    // HTML-escapes the text it emits, so agent output like "## Plan" shows as a
-    // heading instead of literal "## Plan". This is a local dev tool rendering
-    // trusted agent output, so injecting the result via innerHTML is acceptable
-    // and we don't pull in a sanitizer (e.g. DOMPurify).
-    const contentHtml = marked.parse(event.content ?? '') as string;
+    // The raw message body. Rendered as Markdown lazily on first expand (below), so
+    // collapsed cards — the default, and every card during snapshot replay — pay no
+    // parse cost.
+    const rawContent = event.content ?? '';
 
-    // A one-line plain-text summary shown while the message is collapsed (the default). Strips
-    // markdown punctuation + collapses whitespace so long bodies (e.g. JSON) stay one line.
-    const summary = (event.content ?? '')
+    // A one-line plain-text summary shown while the message is collapsed (the default).
+    // Slice first so a huge payload (e.g. a large JSON blob) can't block the main thread
+    // in the regex; strip markdown punctuation + collapse whitespace to keep it one line.
+    const summary = rawContent
+      .slice(0, 1000)
       .replace(/[#*`>_~\[\]]/g, '')
       .replace(/\s+/g, ' ')
       .trim()
@@ -202,10 +202,19 @@ export class CommsPanel {
         </div>
         <div class="comms-summary">${escapeHtml(summary)}</div>
       </div>
-      <div class="comms-content markdown">${contentHtml}</div>
+      <div class="comms-content markdown"></div>
     `;
-    // Collapsed by default — clicking the header toggles the full markdown content.
+    // Collapsed by default. Parse + render the Markdown only on first expand, escaping the
+    // raw body first: marked does NOT strip raw HTML, so escaping neutralizes any
+    // <script>/<img onerror> in agent output before it reaches innerHTML. (Trade-off: `>`
+    // is escaped too, so Markdown blockquotes render as literal text — acceptable here.)
+    let rendered = false;
     card.querySelector('.comms-msg-header')?.addEventListener('click', () => {
+      if (!rendered) {
+        const contentEl = card.querySelector('.comms-content');
+        if (contentEl) contentEl.innerHTML = marked.parse(escapeHtml(rawContent)) as string;
+        rendered = true;
+      }
       card.classList.toggle('expanded');
     });
     return card;

--- a/extras/agent-viz/web/src/comms.ts
+++ b/extras/agent-viz/web/src/comms.ts
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
+import { marked } from 'marked';
+
 import type { MessageEvent } from './types';
 import type { AgentRing } from './agents';
+
+// Render message bodies as inline-friendly HTML: no leading <h1> ids, GitHub-style
+// line breaks so single newlines in agent output become visible breaks.
+marked.setOptions({ breaks: true, gfm: true });
 
 /**
  * Window (in event-time ms) for collapsing duplicate broadcast deliveries into a
@@ -165,20 +171,43 @@ export class CommsPanel {
       : '';
     const bcastBadge = broadcast ? '<span class="comms-badge">BROADCAST</span>' : '';
 
+    // Render the message body as Markdown. `marked.parse` is synchronous and
+    // HTML-escapes the text it emits, so agent output like "## Plan" shows as a
+    // heading instead of literal "## Plan". This is a local dev tool rendering
+    // trusted agent output, so injecting the result via innerHTML is acceptable
+    // and we don't pull in a sanitizer (e.g. DOMPurify).
+    const contentHtml = marked.parse(event.content ?? '') as string;
+
+    // A one-line plain-text summary shown while the message is collapsed (the default). Strips
+    // markdown punctuation + collapses whitespace so long bodies (e.g. JSON) stay one line.
+    const summary = (event.content ?? '')
+      .replace(/[#*`>_~\[\]]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 120);
+
     card.innerHTML = `
-      <div class="comms-msg-meta">
-        <span class="comms-time">${this.formatTime(timestamp)}</span>
-        ${bcastBadge}
-        <span class="comms-index">#${this.count + 1}</span>
+      <div class="comms-msg-header">
+        <div class="comms-msg-meta">
+          <span class="comms-time">${this.formatTime(timestamp)}</span>
+          ${bcastBadge}
+          <span class="comms-index">#${this.count + 1}</span>
+        </div>
+        <div class="comms-route">
+          <span class="comms-msg-toggle">▸</span>
+          <span style="color:${senderColor}">${escapeHtml(event.sender || '?')}</span>
+          <span class="comms-arrow">${arrow}</span>
+          <span style="color:${recipientColor}">${escapeHtml(recipientLabel)}</span>
+          ${typeTag}
+        </div>
+        <div class="comms-summary">${escapeHtml(summary)}</div>
       </div>
-      <div class="comms-route">
-        <span style="color:${senderColor}">${escapeHtml(event.sender || '?')}</span>
-        <span class="comms-arrow">${arrow}</span>
-        <span style="color:${recipientColor}">${escapeHtml(recipientLabel)}</span>
-        ${typeTag}
-      </div>
-      <div class="comms-content">${escapeHtml(event.content ?? '')}</div>
+      <div class="comms-content markdown">${contentHtml}</div>
     `;
+    // Collapsed by default — clicking the header toggles the full markdown content.
+    card.querySelector('.comms-msg-header')?.addEventListener('click', () => {
+      card.classList.toggle('expanded');
+    });
     return card;
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #342 (the **Agent Communications** transcript panel in `extras/agent-viz`).
Renders inter-agent message bodies as **Markdown** instead of plain escaped text, and
collapses each message to a one-line summary by default — expanding the full
formatted body on click.

Agent output is frequently Markdown (`## Plan`, bullet lists, fenced code, tables).
Previously it showed as literal `##`/`*` characters in a flat block; now it renders
as formatted HTML, which is much more readable for longer multi-agent runs and demos.

## What it does

- **Markdown rendering** of each message body via `marked` (`gfm: true`, `breaks: true`,
  so single newlines in agent output become visible line breaks).
- **Per-message collapse**: each card shows a one-line plain-text summary by default and
  expands to the full Markdown on header click. This is distinct from, and coexists with,
  the existing panel-level collapse toggle from #342.
- The collapsed summary strips Markdown punctuation and collapses whitespace, so
  **non-Markdown logs still show a clean single line** and only render as Markdown once
  expanded.
- Compact Markdown CSS tuned for the narrow dark panel (tight margins, scrollable code
  blocks, small headings).

## Dependencies

This **adds one runtime dependency**: [`marked`](https://github.com/markedjs/marked)
(`^18.0.5`, MIT, requires Node ≥ 20). I'm calling this out explicitly because #342
intentionally shipped with no new runtime deps — happy to vendor a minimal renderer or
drop back to a hand-rolled subset if maintainers would prefer to keep agent-viz
dependency-free.

## Security note

`marked` output is injected via `innerHTML` **without a sanitizer** (no DOMPurify).
agent-viz is a local dev/visualization tool rendering trusted local agent output, so this
is acceptable here; a sanitizer should be added if the panel is ever pointed at untrusted
content. This is documented inline in `comms.ts`.

## Testing

- `npm run typecheck` ✅
- `npm run build` (tsc + vite) ✅
- Verified the existing #342 behaviors are unchanged: sender→recipient cards, broadcast
  highlight + dedup, agent-ring color matching, `T+m:ss` timestamps, panel collapse, and
  snapshot/seek replay.
- Verified plain-text (non-Markdown) messages still render cleanly (line breaks preserved;
  summary line unaffected).

## Files

- `web/src/comms.ts` — Markdown render + per-message collapse/summary
- `web/index.html` — collapse + Markdown styling
- `web/package.json` / `package-lock.json` — add `marked`
