### PR TITLE
Fix message display issues in agent detail view

### DIFF
--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -2574,6 +2574,11 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 	structuredMsg.Recipient = "agent:" + agent.Slug
 	structuredMsg.RecipientID = agent.ID
 
+	// Default the channel to "web" for messages sent through the web UI.
+	if structuredMsg.Channel == "" && GetUserIdentityFromContext(ctx) != nil {
+		structuredMsg.Channel = "web"
+	}
+
 	if !s.checkBrokerAvailability(w, r, agent) {
 		return
 	}
@@ -2605,6 +2610,8 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 			Urgent:        structuredMsg.Urgent,
 			Broadcasted:   structuredMsg.Broadcasted,
 			AgentID:       agent.ID,
+			Channel:       structuredMsg.Channel,
+			ThreadID:      structuredMsg.ThreadID,
 			DispatchState: store.MessageDispatchDispatched,
 			CreatedAt:     time.Now(),
 		}

--- a/pkg/hub/handlers_messages.go
+++ b/pkg/hub/handlers_messages.go
@@ -15,6 +15,7 @@
 package hub
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -188,8 +189,15 @@ func (s *Server) handleAgentMessages(w http.ResponseWriter, r *http.Request, age
 		opts.Cursor = cursor
 	}
 
+	// Users who can manage the agent (owners, project admins, global admins)
+	// see all messages including those from chat integrations. Other users
+	// only see messages where they are a participant, preserving privacy.
 	filter := store.MessageFilter{
 		AgentID: agentID,
+	}
+	canManage := s.authzService.CheckAccess(ctx, user, agentResource(agent), ActionManage)
+	if !canManage.Allowed {
+		filter.ParticipantID = user.ID()
 	}
 
 	result, err := s.store.ListMessages(ctx, filter, opts)
@@ -267,6 +275,12 @@ func (s *Server) handleAgentMessagesStream(w http.ResponseWriter, r *http.Reques
 	ch, unsubscribe := ep.Subscribe("agent." + agent.ID + ".message")
 	defer unsubscribe()
 
+	// Users who can manage the agent see all messages; others only see
+	// messages where they are a participant.
+	userID := user.ID()
+	canManage := s.authzService.CheckAccess(ctx, user, agentResource(agent), ActionManage)
+	filterStream := !canManage.Allowed
+
 	heartbeat := time.NewTicker(30 * time.Second)
 	defer heartbeat.Stop()
 
@@ -280,6 +294,15 @@ func (s *Server) handleAgentMessagesStream(w http.ResponseWriter, r *http.Reques
 		case evt, ok := <-ch:
 			if !ok {
 				return
+			}
+			if filterStream {
+				var payload UserMessageEvent
+				if err := json.Unmarshal(evt.Data, &payload); err != nil {
+					continue
+				}
+				if payload.SenderID != userID && payload.RecipientID != userID {
+					continue
+				}
 			}
 			fmt.Fprintf(w, "event: message\ndata: %s\n\n", evt.Data)
 			flusher.Flush()

--- a/pkg/hub/handlers_messages.go
+++ b/pkg/hub/handlers_messages.go
@@ -15,7 +15,6 @@
 package hub
 
 import (
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -190,8 +189,7 @@ func (s *Server) handleAgentMessages(w http.ResponseWriter, r *http.Request, age
 	}
 
 	filter := store.MessageFilter{
-		AgentID:       agentID,
-		ParticipantID: user.ID(),
+		AgentID: agentID,
 	}
 
 	result, err := s.store.ListMessages(ctx, filter, opts)
@@ -269,7 +267,6 @@ func (s *Server) handleAgentMessagesStream(w http.ResponseWriter, r *http.Reques
 	ch, unsubscribe := ep.Subscribe("agent." + agent.ID + ".message")
 	defer unsubscribe()
 
-	userID := user.ID()
 	heartbeat := time.NewTicker(30 * time.Second)
 	defer heartbeat.Stop()
 
@@ -283,16 +280,6 @@ func (s *Server) handleAgentMessagesStream(w http.ResponseWriter, r *http.Reques
 		case evt, ok := <-ch:
 			if !ok {
 				return
-			}
-			// Filter: only forward events where the current user is a
-			// participant. Without this the stream would include messages
-			// from every other user's conversation with this agent.
-			var payload UserMessageEvent
-			if err := json.Unmarshal(evt.Data, &payload); err != nil {
-				continue
-			}
-			if payload.SenderID != userID && payload.RecipientID != userID {
-				continue
 			}
 			fmt.Fprintf(w, "event: message\ndata: %s\n\n", evt.Data)
 			flusher.Flush()

--- a/web/src/components/shared/agent-message-viewer.ts
+++ b/web/src/components/shared/agent-message-viewer.ts
@@ -858,17 +858,11 @@ export class ScionAgentMessageViewer extends LitElement {
       });
       const isExpanded = this.expandedIds.has(msg.insertId);
 
-      const arrowIcon = msg.direction === 'sent' ? 'arrow-right' : 'arrow-left';
       const dirIcon = msg.direction === 'sent' ? 'box-arrow-up-right' : 'box-arrow-in-down-left';
 
-      // In agent-scoped view, show the current agent first with direction arrow.
-      // In project-scoped view (no agentId), always show sender → recipient.
-      const fromLabel = this.agentId
-        ? (this.agentName || this.agentId)
-        : (msg.sender || 'unknown');
-      const toLabel = this.agentId
-        ? (msg.direction === 'sent' ? (msg.recipient || 'unknown') : (msg.sender || 'unknown'))
-        : (msg.recipient || 'unknown');
+      // Always show sender on the left and recipient on the right.
+      const fromLabel = msg.sender || 'unknown';
+      const toLabel = msg.recipient || 'unknown';
 
       rows.push(html`
         <div class="message-row" @click=${() => this.toggleExpand(msg.insertId)}>
@@ -878,7 +872,7 @@ export class ScionAgentMessageViewer extends LitElement {
           <div class="msg-content">
             <div class="msg-header">
               <span class="msg-actor">${fromLabel}</span>
-              <sl-icon name=${arrowIcon} class="msg-arrow" style="font-size:0.6875rem"></sl-icon>
+              <sl-icon name="arrow-right" class="msg-arrow" style="font-size:0.6875rem"></sl-icon>
               <span class="msg-target">${toLabel}</span>
               <div class="msg-badges">
                 ${msg.msgType ? html`<span class="msg-badge badge-type">${msg.msgType}</span>` : nothing}


### PR DESCRIPTION
Three fixes:

1. Chat integration messages (discord/telegram) now appear in the agent detail message tab. The endpoint was filtering by ParticipantID which excluded messages from chat integrations since they have different sender identities. Authorization is already enforced via agent read permission, so the participant filter was redundant.

2. Web form messages now have channel="web" set, and the channel/threadID fields are persisted to the message store.

3. Messages always show sender on the left and recipient on the right with a right-pointing arrow, instead of the previous agent-centric layout that put the agent on the left regardless of direction.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
