### PR TITLE
feat(agent-viz): customizable agent colors, replay control, and richer comms summaries

### DIFF
--- a/extras/agent-viz/web/index.html
+++ b/extras/agent-viz/web/index.html
@@ -189,6 +189,21 @@
       display: inline-block;
     }
 
+    /* Per-agent colour picker in the Agents filter — a small clickable swatch. */
+    .agent-color {
+      width: 14px;
+      height: 14px;
+      padding: 0;
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      border-radius: 50%;
+      background: none;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+    .agent-color::-webkit-color-swatch-wrapper { padding: 0; }
+    .agent-color::-webkit-color-swatch { border: none; border-radius: 50%; }
+    .agent-color::-moz-color-swatch { border: none; border-radius: 50%; }
+
     .agent-filters,
     .event-filters {
       display: flex;
@@ -349,8 +364,9 @@
       margin-top: 4px;
     }
 
-    /* Per-message collapse: show a one-line summary until the user expands. */
-    .comms-msg-header { cursor: pointer; }
+    /* Per-message collapse: show a one-line summary until the user expands. Only messages with a
+       body are expandable (a contentless handoff is just its route, so no pointer/affordance). */
+    .comms-expandable .comms-msg-header { cursor: pointer; }
     .comms-msg-toggle {
       display: inline-block;
       width: 9px;

--- a/extras/agent-viz/web/src/agents.ts
+++ b/extras/agent-viz/web/src/agents.ts
@@ -308,15 +308,14 @@ export class AgentRing {
     return '#888';
   }
 
-  /** Recolour an agent (by id or name) live — the ring redraws with the new colour next frame. */
+  /** Recolour an agent (by id or name) live — the ring redraws with the new colour next frame.
+   *  Overrides are keyed by name, so recolour EVERY instance that shares the resolved name (an
+   *  agent destroyed + recreated can briefly appear twice with the same name but a different id). */
   setAgentColor(agentIdOrName: string, color: string): void {
     const byId = this.agents.get(agentIdOrName);
-    if (byId) {
-      byId.info.color = color;
-      return;
-    }
+    const name = byId ? byId.info.name : agentIdOrName;
     for (const a of this.agents.values()) {
-      if (a.info.name === agentIdOrName) a.info.color = color;
+      if (a.info.id === agentIdOrName || a.info.name === name) a.info.color = color;
     }
   }
 

--- a/extras/agent-viz/web/src/agents.ts
+++ b/extras/agent-viz/web/src/agents.ts
@@ -308,6 +308,18 @@ export class AgentRing {
     return '#888';
   }
 
+  /** Recolour an agent (by id or name) live — the ring redraws with the new colour next frame. */
+  setAgentColor(agentIdOrName: string, color: string): void {
+    const byId = this.agents.get(agentIdOrName);
+    if (byId) {
+      byId.info.color = color;
+      return;
+    }
+    for (const a of this.agents.values()) {
+      if (a.info.name === agentIdOrName) a.info.color = color;
+    }
+  }
+
   reset(): void {
     this.agents.clear();
     this.freezeCount = 0;

--- a/extras/agent-viz/web/src/comms.ts
+++ b/extras/agent-viz/web/src/comms.ts
@@ -277,11 +277,13 @@ function summarizeForCollapsed(raw: string): string {
   return s.replace(/[#*`>_~[\]]/g, '').replace(/\s+/g, ' ').trim().slice(0, 120);
 }
 
-/** A `#rrggbb` colour → an `rgba(...)` string at `alpha`, for a faint per-sender card tint. Falls
- *  back to a neutral tint when the colour isn't a 6-digit hex (e.g. a CSS name). */
+/** A hex colour → an `rgba(...)` string at `alpha`, for a faint per-sender card tint. Accepts 3- or
+ *  6-digit hex (e.g. the default `#888`); falls back to a neutral tint for anything else (e.g. a CSS
+ *  colour name). */
 function tintColor(color: string, alpha: number): string {
-  const m = /^#([0-9a-f]{6})$/i.exec(color || '');
-  if (!m) return `rgba(255,255,255,${alpha * 0.4})`;
-  const n = parseInt(m[1], 16);
+  let hex = (color || '').trim().replace(/^#/, '');
+  if (/^[0-9a-f]{3}$/i.test(hex)) hex = hex.replace(/./g, (c) => c + c);
+  if (!/^[0-9a-f]{6}$/i.test(hex)) return `rgba(255,255,255,${alpha * 0.4})`;
+  const n = parseInt(hex, 16);
   return `rgba(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}, ${alpha})`;
 }

--- a/extras/agent-viz/web/src/comms.ts
+++ b/extras/agent-viz/web/src/comms.ts
@@ -157,11 +157,14 @@ export class CommsPanel {
     const recipientColor = broadcast
       ? '#22c55e'
       : (this.agentRing?.getAgentColor(event.recipient) ?? '#888');
-    const accent = broadcast ? '#22c55e' : senderColor;
 
+    // Colour EACH message by its SENDER (left border + a faint tint of the same colour) so the
+    // transcript is scannable by who-said-what, instead of a uniform broadcast-green. The BROADCAST
+    // badge + the ↯ ALL route still mark broadcasts; broadcasts just get a slightly stronger tint.
     const card = document.createElement('div');
-    card.className = broadcast ? 'comms-msg comms-msg-bcast' : 'comms-msg';
-    card.style.borderLeftColor = accent;
+    card.className = 'comms-msg';
+    card.style.borderLeftColor = senderColor;
+    card.style.background = tintColor(senderColor, broadcast ? 0.16 : 0.09);
     if (!animate) card.style.animation = 'none';
 
     const recipientLabel = broadcast ? 'ALL' : event.recipient || '?';
@@ -176,15 +179,10 @@ export class CommsPanel {
     // parse cost.
     const rawContent = event.content ?? '';
 
-    // A one-line plain-text summary shown while the message is collapsed (the default).
-    // Slice first so a huge payload (e.g. a large JSON blob) can't block the main thread
-    // in the regex; strip markdown punctuation + collapse whitespace to keep it one line.
-    const summary = rawContent
-      .slice(0, 1000)
-      .replace(/[#*`>_~\[\]]/g, '')
-      .replace(/\s+/g, ' ')
-      .trim()
-      .slice(0, 120);
+    // A one-line summary shown while the message is collapsed (the default). Slice first so a
+    // huge payload (e.g. a large JSON blob) can't block the main thread, then derive a headline
+    // that understands structured JSON payloads (else strips markdown to one line).
+    const summary = summarizeForCollapsed(rawContent.slice(0, 1000));
 
     card.innerHTML = `
       <div class="comms-msg-header">
@@ -194,13 +192,13 @@ export class CommsPanel {
           <span class="comms-index">#${this.count + 1}</span>
         </div>
         <div class="comms-route">
-          <span class="comms-msg-toggle">▸</span>
+          ${rawContent ? '<span class="comms-msg-toggle">▸</span>' : ''}
           <span style="color:${senderColor}">${escapeHtml(event.sender || '?')}</span>
           <span class="comms-arrow">${arrow}</span>
           <span style="color:${recipientColor}">${escapeHtml(recipientLabel)}</span>
           ${typeTag}
         </div>
-        <div class="comms-summary">${escapeHtml(summary)}</div>
+        ${summary ? `<div class="comms-summary">${escapeHtml(summary)}</div>` : ''}
       </div>
       <div class="comms-content markdown"></div>
     `;
@@ -208,15 +206,19 @@ export class CommsPanel {
     // raw body first: marked does NOT strip raw HTML, so escaping neutralizes any
     // <script>/<img onerror> in agent output before it reaches innerHTML. (Trade-off: `>`
     // is escaped too, so Markdown blockquotes render as literal text — acceptable here.)
-    let rendered = false;
-    card.querySelector('.comms-msg-header')?.addEventListener('click', () => {
-      if (!rendered) {
-        const contentEl = card.querySelector('.comms-content');
-        if (contentEl) contentEl.innerHTML = marked.parse(escapeHtml(rawContent)) as string;
-        rendered = true;
-      }
-      card.classList.toggle('expanded');
-    });
+    // Only wire up expand when there's a body to reveal — a contentless handoff is just the route.
+    if (rawContent) {
+      card.classList.add('comms-expandable');
+      let rendered = false;
+      card.querySelector('.comms-msg-header')?.addEventListener('click', () => {
+        if (!rendered) {
+          const contentEl = card.querySelector('.comms-content');
+          if (contentEl) contentEl.innerHTML = marked.parse(escapeHtml(rawContent)) as string;
+          rendered = true;
+        }
+        card.classList.toggle('expanded');
+      });
+    }
     return card;
   }
 
@@ -235,4 +237,51 @@ export class CommsPanel {
 
 function escapeHtml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/** A short, meaningful one-liner for the COLLAPSED card — so a structured JSON payload shows e.g.
+ *  "12 item(s): Initial draft…" instead of a raw `[ { "title": …` dump. The full body is
+ *  still rendered as Markdown on expand. */
+function summarizeForCollapsed(raw: string): string {
+  let s = raw.trim();
+  if (!s) return '';
+  s = s.replace(/^```[a-zA-Z]*\n?/, '').replace(/\n?```$/, '').trim();
+  if (s[0] === '[' || s[0] === '{') {
+    try {
+      const data = JSON.parse(s);
+      if (Array.isArray(data)) {
+        const t = data.find((d) => d && typeof d === 'object' && d.title)?.title;
+        return (`${data.length} item(s)` + (t ? `: ${t}` : '')).slice(0, 110);
+      }
+      if (data && typeof data === 'object') {
+        const t = data.title || data.summary ||
+          Object.values(data).find((v) => typeof v === 'string' && v.trim());
+        if (t) return String(t).trim().slice(0, 110);
+      }
+    } catch {
+      // Content is often truncated (2k cap) so JSON.parse fails — salvage a title + a count.
+      // `(?:[^"\\]|\\.)*` matches across escaped quotes so a title like "treated as \"unused\""
+      // is captured whole (stop at the real closing quote), then unescape for a clean headline.
+      const unesc = (t: string) => t.replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+      const titles = [...s.matchAll(/"title"\s*:\s*"((?:[^"\\]|\\.)*)"/g)].map((m) => unesc(m[1]));
+      if (titles.length) return ((titles.length > 1 ? `${titles.length} item(s): ` : '') + titles[0]).slice(0, 110);
+      const m = s.match(/"[a-zA-Z_]+"\s*:\s*"((?:[^"\\]|\\.){3,}?)"/);
+      if (m) return unesc(m[1]).slice(0, 110);
+    }
+  }
+  // else: first meaningful (de-marked) line; fall back to a stripped slice.
+  for (const line of s.split('\n')) {
+    const ln = line.replace(/^[#>*\-\s]+/, '').trim();
+    if (ln && !/^[[\]{}(),:"' ]+$/.test(ln)) return ln.slice(0, 120);
+  }
+  return s.replace(/[#*`>_~[\]]/g, '').replace(/\s+/g, ' ').trim().slice(0, 120);
+}
+
+/** A `#rrggbb` colour → an `rgba(...)` string at `alpha`, for a faint per-sender card tint. Falls
+ *  back to a neutral tint when the colour isn't a 6-digit hex (e.g. a CSS name). */
+function tintColor(color: string, alpha: number): string {
+  const m = /^#([0-9a-f]{6})$/i.exec(color || '');
+  if (!m) return `rgba(255,255,255,${alpha * 0.4})`;
+  const n = parseInt(m[1], 16);
+  return `rgba(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}, ${alpha})`;
 }

--- a/extras/agent-viz/web/src/main.ts
+++ b/extras/agent-viz/web/src/main.ts
@@ -121,8 +121,10 @@ function init(): void {
   playbackControls.setOnAgentColorChange((id, name, color) => {
     agentRing.setAgentColor(id, color);
     saveColorOverride(name, color);
-    const a = manifest?.agents.find((x) => x.id === id || x.name === name);
-    if (a) a.color = color;
+    // Update every matching manifest entry so later resolveAgentInfo() lookups stay consistent.
+    manifest?.agents.forEach((a) => {
+      if (a.id === id || a.name === name) a.color = color;
+    });
   });
 
   ws.onMessage((msg) => {

--- a/extras/agent-viz/web/src/main.ts
+++ b/extras/agent-viz/web/src/main.ts
@@ -48,6 +48,26 @@ let overlayCtx: CanvasRenderingContext2D;
 let animFrameId: number;
 let manifest: PlaybackManifest | null = null;
 
+// Per-agent colour overrides set from the Agents filter panel, persisted by agent NAME so they
+// survive reloads + carry across runs of the same team.
+const COLOR_OVERRIDE_KEY = 'agentviz_agent_colors';
+function loadColorOverrides(): Record<string, string> {
+  try {
+    return JSON.parse(localStorage.getItem(COLOR_OVERRIDE_KEY) || '{}');
+  } catch {
+    return {};
+  }
+}
+function saveColorOverride(name: string, color: string): void {
+  const o = loadColorOverrides();
+  o[name] = color;
+  try {
+    localStorage.setItem(COLOR_OVERRIDE_KEY, JSON.stringify(o));
+  } catch {
+    /* storage unavailable — override stays in-memory for this session */
+  }
+}
+
 /**
  * Clamp a file path to the configured max depth.
  * If the path has more segments than maxDepth, truncate and return a directory path.
@@ -97,6 +117,13 @@ function init(): void {
   const ws = new WSClient();
   playbackControls = new PlaybackControls(controlsContainer, ws);
   playbackControls.setOnShowFileLabelsChange((show) => fileGraph.setShowLabels(show));
+  // Per-agent colour override (Agents filter panel) — recolour the ring live + persist by name.
+  playbackControls.setOnAgentColorChange((id, name, color) => {
+    agentRing.setAgentColor(id, color);
+    saveColorOverride(name, color);
+    const a = manifest?.agents.find((x) => x.id === id || x.name === name);
+    if (a) a.color = color;
+  });
 
   ws.onMessage((msg) => {
     if ('type' in msg) {
@@ -135,6 +162,12 @@ function init(): void {
 
 function handleManifest(m: PlaybackManifest): void {
   manifest = m;
+  // Apply saved per-agent colour overrides to the manifest so BOTH the ring (via resolveAgentInfo)
+  // and the filter dots pick them up.
+  const overrides = loadColorOverrides();
+  for (const a of m.agents) {
+    if (overrides[a.name]) a.color = overrides[a.name];
+  }
   console.log('[agent-viz] Manifest received:', {
     agents: m.agents.length,
     files: m.files.length,

--- a/extras/agent-viz/web/src/messages.ts
+++ b/extras/agent-viz/web/src/messages.ts
@@ -45,6 +45,9 @@ export class MessageRenderer {
   private agentRing: AgentRing | null = null;
   /** Tracks recently seen broadcasts for dedup: key -> timestamp of first occurrence. */
   private recentBroadcasts: Map<string, number> = new Map();
+  // summarizeContent runs in the per-frame draw loop; cache by content so we don't re-run the
+  // regex/split work at 60fps for every active message.
+  private summaryCache: Map<string, string> = new Map();
 
   setAgentRing(ring: AgentRing): void {
     this.agentRing = ring;
@@ -270,21 +273,30 @@ export class MessageRenderer {
 
   private summarizeContent(content: string): string {
     if (!content) return '';
+    const cached = this.summaryCache.get(content);
+    if (cached !== undefined) return cached;
+
     let s = content.trim().replace(/^```[a-zA-Z]*\n?/, '').replace(/\n?```$/, '').trim();
     // Legacy scion state messages: "… has reached a state of COMPLETED: …"
     const stateMatch = s.match(/state of (\w+)/i);
-    if (stateMatch) return stateMatch[1];
-    // JSON/array payload → pull a "title" if there is one, else strip the punctuation.
-    if (s[0] === '[' || s[0] === '{') {
-      const m = s.match(/"title"\s*:\s*"((?:[^"\\]|\\.)*)"/);
-      s = m ? m[1].replace(/\\"/g, '"') : s.replace(/[[\]{}"]/g, ' ').trim();
+    let result: string;
+    if (stateMatch) {
+      result = stateMatch[1];
+    } else {
+      // JSON/array payload → pull a "title" if there is one, else strip the punctuation.
+      if (s[0] === '[' || s[0] === '{') {
+        const m = s.match(/"title"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+        s = m ? m[1].replace(/\\"/g, '"') : s.replace(/[[\]{}"]/g, ' ').trim();
+      }
+      // First meaningful, de-marked line (drop leading #, >, *, - markdown).
+      for (const line of s.split('\n')) {
+        const ln = line.replace(/^[#>*\-\s]+/, '').trim();
+        if (ln) { s = ln; break; }
+      }
+      result = s.length > 26 ? s.slice(0, 25) + '…' : s;
     }
-    // First meaningful, de-marked line (drop leading #, >, *, - markdown).
-    for (const line of s.split('\n')) {
-      const ln = line.replace(/^[#>*\-\s]+/, '').trim();
-      if (ln) { s = ln; break; }
-    }
-    return s.length > 26 ? s.slice(0, 25) + '…' : s;
+    this.summaryCache.set(content, result);
+    return result;
   }
 
   private hexToRgba(hex: string, alpha: number): string {

--- a/extras/agent-viz/web/src/messages.ts
+++ b/extras/agent-viz/web/src/messages.ts
@@ -231,14 +231,16 @@ export class MessageRenderer {
       ctx.stroke();
     }
 
-    // Content label along the midpoint of the line
+    // Content label near the SOURCE end of the line (not mid-edge) — it reads as "this is what
+    // the sender just produced + is handing off", and stays clear of the recipient ring.
     if (msg.content && elapsed < LABEL_DURATION) {
       const labelAlpha = elapsed < PULSE_DURATION
         ? Math.min(1, (elapsed / PULSE_DURATION) * 2)
         : 1 - (elapsed - PULSE_DURATION) / (LABEL_DURATION - PULSE_DURATION);
 
-      const midX = (s.x + r.x) / 2;
-      const midY = (s.y + r.y) / 2;
+      const frac = 0.28; // 28% of the way from sender → recipient
+      const midX = s.x + (r.x - s.x) * frac;
+      const midY = s.y + (r.y - s.y) * frac;
 
       // Extract a short summary from content
       const label = this.summarizeContent(msg.content);
@@ -268,12 +270,21 @@ export class MessageRenderer {
 
   private summarizeContent(content: string): string {
     if (!content) return '';
-    // Extract key state from content like "poet-blue has reached a state of COMPLETED: ..."
-    const stateMatch = content.match(/state of (\w+)/i);
+    let s = content.trim().replace(/^```[a-zA-Z]*\n?/, '').replace(/\n?```$/, '').trim();
+    // Legacy scion state messages: "… has reached a state of COMPLETED: …"
+    const stateMatch = s.match(/state of (\w+)/i);
     if (stateMatch) return stateMatch[1];
-    // Truncate long content
-    if (content.length > 30) return content.substring(0, 27) + '...';
-    return content;
+    // JSON/array payload → pull a "title" if there is one, else strip the punctuation.
+    if (s[0] === '[' || s[0] === '{') {
+      const m = s.match(/"title"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+      s = m ? m[1].replace(/\\"/g, '"') : s.replace(/[[\]{}"]/g, ' ').trim();
+    }
+    // First meaningful, de-marked line (drop leading #, >, *, - markdown).
+    for (const line of s.split('\n')) {
+      const ln = line.replace(/^[#>*\-\s]+/, '').trim();
+      if (ln) { s = ln; break; }
+    }
+    return s.length > 26 ? s.slice(0, 25) + '…' : s;
   }
 
   private hexToRgba(hex: string, alpha: number): string {

--- a/extras/agent-viz/web/src/playback.ts
+++ b/extras/agent-viz/web/src/playback.ts
@@ -39,6 +39,7 @@ export class PlaybackControls {
   // Callbacks
   private onFilterChange?: (agents: string[], eventTypes: string[]) => void;
   private onShowFileLabelsChange?: (show: boolean) => void;
+  private onAgentColor?: (id: string, name: string, color: string) => void;
 
   constructor(container: HTMLElement, ws: WSClient) {
     this.container = container;
@@ -60,10 +61,13 @@ export class PlaybackControls {
       label.className = 'filter-item';
       label.innerHTML = `
         <input type="checkbox" checked data-agent-id="${agent.id}">
-        <span class="agent-dot" style="background:${agent.color}"></span>
+        <input type="color" class="agent-color" value="${agent.color}" title="Change ${agent.name} colour">
         ${agent.name}
       `;
-      label.querySelector('input')!.addEventListener('change', () => this.emitFilter());
+      label.querySelector('input[type="checkbox"]')!.addEventListener('change', () => this.emitFilter());
+      const colorInput = label.querySelector('input[type="color"]') as HTMLInputElement;
+      colorInput.addEventListener('click', (e) => e.stopPropagation());  // don't toggle the checkbox
+      colorInput.addEventListener('change', () => this.onAgentColor?.(agent.id, agent.name, colorInput.value));
       list.appendChild(label);
     }
   }
@@ -74,6 +78,10 @@ export class PlaybackControls {
 
   setOnShowFileLabelsChange(cb: (show: boolean) => void): void {
     this.onShowFileLabelsChange = cb;
+  }
+
+  setOnAgentColorChange(cb: (id: string, name: string, color: string) => void): void {
+    this.onAgentColor = cb;
   }
 
   updateStatus(status: StatusUpdate): void {
@@ -93,9 +101,10 @@ export class PlaybackControls {
     this.container.innerHTML = `
       <div class="transport-bar">
         <div class="transport-controls">
-          <button class="transport-btn" id="rewind-btn" title="Rewind">⏮</button>
+          <button class="transport-btn" id="rewind-btn" title="Rewind to start">⏮</button>
           <button class="transport-btn" id="play-btn" title="Play/Pause">▶</button>
-          <button class="transport-btn" id="forward-btn" title="Forward">⏭</button>
+          <button class="transport-btn" id="forward-btn" title="Skip to end">⏭</button>
+          <button class="transport-btn" id="replay-btn" title="Replay from start">↻</button>
         </div>
         <div class="scrubber-container">
           <input type="range" class="scrubber" id="scrubber" min="0" max="0" value="0">
@@ -160,6 +169,12 @@ export class PlaybackControls {
     // Forward
     this.container.querySelector('#forward-btn')!.addEventListener('click', () => {
       this.ws.send({ type: 'seek', timestamp: this.timeEnd });
+    });
+
+    // Replay — jump back to the start AND play, in one click (vs. Rewind then Play).
+    this.container.querySelector('#replay-btn')!.addEventListener('click', () => {
+      this.ws.send({ type: 'seek', timestamp: this.timeStart });
+      this.ws.send({ type: 'play' });
     });
 
     // Speed

--- a/extras/agent-viz/web/src/playback.ts
+++ b/extras/agent-viz/web/src/playback.ts
@@ -59,9 +59,14 @@ export class PlaybackControls {
     for (const agent of agents) {
       const label = document.createElement('label');
       label.className = 'filter-item';
+      // <input type="color"> requires #rrggbb; expand 3-digit hex (e.g. the default #888) so the
+      // picker shows the real colour instead of silently falling back to black.
+      const swatch = /^#[0-9a-f]{3}$/i.test(agent.color)
+        ? '#' + agent.color.slice(1).replace(/./g, (c) => c + c)
+        : agent.color;
       label.innerHTML = `
         <input type="checkbox" checked data-agent-id="${agent.id}">
-        <input type="color" class="agent-color" value="${agent.color}" title="Change ${agent.name} colour">
+        <input type="color" class="agent-color" value="${swatch}" title="Change ${agent.name} colour">
         ${agent.name}
       `;
       label.querySelector('input[type="checkbox"]')!.addEventListener('change', () => this.emitFilter());


### PR DESCRIPTION
## Summary

Follow-up to #342 / #427 (the **Agent Communications** transcript panel in `extras/agent-viz`).
Adds three independent quality-of-life improvements to the visualizer, all **frontend-only**.

## What it does

- **Per-agent colour override** — the Agents filter panel now shows a colour picker (replacing
  the static dot). Picking a colour recolours that agent's ring + label live and persists the
  override **by agent name** in `localStorage`, so it survives reloads and carries across runs of
  the same team. Defaults are untouched when no override is set.
- **Replay button** — a one-click `↻` that seeks to the start and plays, instead of Rewind-then-Play.
- **Richer comms transcript** — each message card is coloured by its **sender** (left border + a
  faint same-colour tint) so the transcript is scannable by who-said-what, instead of a uniform
  broadcast-green (broadcasts keep their badge + a slightly stronger tint). The collapsed one-line
  summary now understands structured JSON payloads (pulls a `title` / item count) and otherwise
  falls back to a de-marked first line, so both JSON and plain/markdown logs collapse to something
  meaningful. The in-flight message label on the graph is anchored near the sender (28% of the way
  to the recipient) so it reads as a hand-off and stays clear of the recipient ring.

## Compatibility

This is **frontend-only**. The playback data contract (`web/src/types.ts`) and the Go
log-ingestion layer (`internal/logparser`, `internal/playback`, `internal/server`) are **unchanged**,
and all new code only reads existing manifest/event fields (`name`, `color`, `id`, `content`).
Existing logs render exactly as before; the legacy `state of <X>` message summary is preserved.

## Testing

- `npm run typecheck` ✅
- `npm run build` (tsc + vite) ✅
- Verified existing #342/#427 behaviours are unchanged: sender→recipient cards, broadcast
  highlight + dedup, agent-ring colour matching, `T+m:ss` timestamps, panel + per-message collapse,
  Markdown rendering, and snapshot/seek replay.
- Verified plain-text (non-JSON) messages still summarize and render cleanly.

## Files

- `web/src/agents.ts` — live recolour helper (`setAgentColor`)
- `web/src/main.ts` — colour-override load/save + apply to manifest
- `web/src/playback.ts` — colour picker in filter panel + Replay button
- `web/src/comms.ts` — per-sender card colour + JSON-aware collapsed summary
- `web/src/messages.ts` — sender-anchored label + JSON-title-aware summary
- `web/index.html` — supporting styles