### PR TITLE
Fix import progress streaming and pass names on single-template import

### DIFF
--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -10204,13 +10204,20 @@ func (s *Server) handleProjectImportTemplates(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	var imported []string
-	if req.WorkspacePath != "" {
-		imported, err = s.importFromWorkspace(ctx, project, req.WorkspacePath, store.TemplateScopeProject, s.templateImportKind(), nil, req.Names)
-	} else {
+	run := func(progress importProgressFunc) ([]string, error) {
+		if req.WorkspacePath != "" {
+			return s.importFromWorkspace(ctx, project, req.WorkspacePath, store.TemplateScopeProject, s.templateImportKind(), progress, req.Names)
+		}
 		req.SourceURL = config.NormalizeTemplateSourceURL(req.SourceURL)
-		imported, err = s.importFromRemote(ctx, projectID, req.SourceURL, store.TemplateScopeProject, s.templateImportKind(), nil, req.Names)
+		return s.importFromRemote(ctx, projectID, req.SourceURL, store.TemplateScopeProject, s.templateImportKind(), progress, req.Names)
 	}
+
+	if importAcceptsNDJSON(r) {
+		s.streamImport(w, run)
+		return
+	}
+
+	imported, err := run(nil)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "import_failed", err.Error(), nil)
 		return
@@ -10296,13 +10303,20 @@ func (s *Server) handleProjectImportHarnessConfigs(w http.ResponseWriter, r *htt
 		return
 	}
 
-	var imported []string
-	if req.WorkspacePath != "" {
-		imported, err = s.importFromWorkspace(ctx, project, req.WorkspacePath, store.HarnessConfigScopeProject, s.harnessConfigImportKind(), nil, req.Names)
-	} else {
+	run := func(progress importProgressFunc) ([]string, error) {
+		if req.WorkspacePath != "" {
+			return s.importFromWorkspace(ctx, project, req.WorkspacePath, store.HarnessConfigScopeProject, s.harnessConfigImportKind(), progress, req.Names)
+		}
 		req.SourceURL = config.NormalizeTemplateSourceURL(req.SourceURL)
-		imported, err = s.importFromRemote(ctx, projectID, req.SourceURL, store.HarnessConfigScopeProject, s.harnessConfigImportKind(), nil, req.Names)
+		return s.importFromRemote(ctx, projectID, req.SourceURL, store.HarnessConfigScopeProject, s.harnessConfigImportKind(), progress, req.Names)
 	}
+
+	if importAcceptsNDJSON(r) {
+		s.streamImport(w, run)
+		return
+	}
+
+	imported, err := run(nil)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "import_failed", err.Error(), nil)
 		return

--- a/web/src/components/shared/resource-import.ts
+++ b/web/src/components/shared/resource-import.ts
@@ -277,7 +277,7 @@ export class ScionResourceImport extends LitElement {
       }
 
       if (discovered.count === 1) {
-        await this.executeImport();
+        await this.executeImport(discovered.resources);
         return;
       }
 


### PR DESCRIPTION
Per-project import handlers now support NDJSON streaming when the client sends Accept: application/x-ndjson, matching the unified endpoint. This fixes the progress display (per-resource events) and the post-import summary (the NDJSON done event uses the correct "imported" field name).

Also passes discovered names to executeImport even for the count===1 case, ensuring the import is scoped to the exact resource that was discovered.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
