### PR TITLE
Sync built image reference back to Hub after scion build

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -167,6 +167,26 @@ field is updated to reference the built image.`,
 		}
 		fmt.Printf("Updated %s image to %s\n", configPath, outputImage)
 
+		// Sync updated config to Hub so agents pick up the new image.
+		var gp string
+		if projectPath != "" {
+			if resolved, err := config.GetResolvedProjectDir(projectPath); err == nil {
+				gp = resolved
+			}
+		} else if resolved, err := config.GetResolvedProjectDir(""); err == nil {
+			gp = resolved
+		}
+		hubCtx, hubErr := CheckHubAvailabilityWithOptions(gp, true)
+		if hubErr != nil {
+			fmt.Printf("Warning: could not sync to Hub: %v\n", hubErr)
+			fmt.Println("Run 'scion harness-config push " + harnessConfigName + "' to sync manually.")
+		} else if hubCtx != nil {
+			if err := syncHarnessConfigToHub(hubCtx, harnessConfigName, hcDir.Path, "global", "", hcDir.Config.Harness); err != nil {
+				fmt.Printf("Warning: failed to sync to Hub: %v\n", err)
+				fmt.Println("Run 'scion harness-config push " + harnessConfigName + "' to sync manually.")
+			}
+		}
+
 		return nil
 	},
 }

--- a/pkg/hub/maintenance_executors.go
+++ b/pkg/hub/maintenance_executors.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/secret"
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/GoogleCloudPlatform/scion/pkg/transfer"
 	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
 	"gopkg.in/yaml.v3"
 )
@@ -607,7 +608,10 @@ func (e *BuildHarnessConfigImageExecutor) syncBuiltImage(ctx context.Context, lo
 	if err := yaml.Unmarshal(configData, &doc); err != nil {
 		return fmt.Errorf("failed to parse config.yaml: %w", err)
 	}
-	if len(doc.Content) > 0 && doc.Content[0].Kind == yaml.MappingNode {
+	if len(doc.Content) == 0 || doc.Content[0].Kind != yaml.MappingNode {
+		return fmt.Errorf("config.yaml root is not a YAML mapping")
+	}
+	{
 		mapping := doc.Content[0]
 		found := false
 		for i := 0; i < len(mapping.Content)-1; i += 2 {
@@ -638,6 +642,17 @@ func (e *BuildHarnessConfigImageExecutor) syncBuiltImage(ctx context.Context, lo
 		}
 		fmt.Fprintf(logger, "Updated config.yaml in storage with image %s\n", outputImage)
 	}
+
+	// Update config.yaml entry in hc.Files manifest with new size and hash.
+	configHash := transfer.HashBytes(updatedData)
+	for i, f := range hc.Files {
+		if f.Path == "config.yaml" {
+			hc.Files[i].Size = int64(len(updatedData))
+			hc.Files[i].Hash = configHash
+			break
+		}
+	}
+	hc.ContentHash = computeContentHash(hc.Files)
 
 	// Update the DB record.
 	if hc.Config == nil {

--- a/pkg/hub/maintenance_executors.go
+++ b/pkg/hub/maintenance_executors.go
@@ -15,6 +15,7 @@
 package hub
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -30,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
+	"gopkg.in/yaml.v3"
 )
 
 // MaintenanceExecutor defines the interface for a runnable maintenance operation.
@@ -580,8 +582,73 @@ func (e *BuildHarnessConfigImageExecutor) Run(ctx context.Context, logger io.Wri
 		outputImage = pushImage
 	}
 
+	// Update the harness config's image in storage and the DB so agents
+	// pick up the newly-built image instead of the stale upstream reference.
+	if err := e.syncBuiltImage(ctx, logger, hc, tmpDir, outputImage); err != nil {
+		log.Error("Failed to sync built image back to store", "error", err)
+		fmt.Fprintf(logger, "Warning: build succeeded but failed to update harness-config image: %v\n", err)
+	}
+
 	fmt.Fprintf(logger, "\nBuild complete: %s\n", outputImage)
 	log.Info("Build complete", "image", outputImage, "harness_config", hc.Name)
+	return nil
+}
+
+// syncBuiltImage updates the harness config's config.yaml in storage and the
+// DB record to reference the newly-built image.
+func (e *BuildHarnessConfigImageExecutor) syncBuiltImage(ctx context.Context, logger io.Writer, hc *store.HarnessConfig, tmpDir, outputImage string) error {
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to read config.yaml: %w", err)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(configData, &doc); err != nil {
+		return fmt.Errorf("failed to parse config.yaml: %w", err)
+	}
+	if len(doc.Content) > 0 && doc.Content[0].Kind == yaml.MappingNode {
+		mapping := doc.Content[0]
+		found := false
+		for i := 0; i < len(mapping.Content)-1; i += 2 {
+			if mapping.Content[i].Value == "image" {
+				mapping.Content[i+1].Value = outputImage
+				found = true
+				break
+			}
+		}
+		if !found {
+			mapping.Content = append(mapping.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Value: "image"},
+				&yaml.Node{Kind: yaml.ScalarNode, Value: outputImage},
+			)
+		}
+	}
+
+	updatedData, err := yaml.Marshal(&doc)
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated config.yaml: %w", err)
+	}
+
+	// Upload updated config.yaml to storage.
+	if e.storage != nil && hc.StoragePath != "" {
+		objectPath := hc.StoragePath + "/config.yaml"
+		if _, err := e.storage.Upload(ctx, objectPath, bytes.NewReader(updatedData), storage.UploadOptions{}); err != nil {
+			return fmt.Errorf("failed to upload updated config.yaml to storage: %w", err)
+		}
+		fmt.Fprintf(logger, "Updated config.yaml in storage with image %s\n", outputImage)
+	}
+
+	// Update the DB record.
+	if hc.Config == nil {
+		hc.Config = &store.HarnessConfigData{}
+	}
+	hc.Config.Image = outputImage
+	if err := e.store.UpdateHarnessConfig(ctx, hc); err != nil {
+		return fmt.Errorf("failed to update harness-config record: %w", err)
+	}
+	fmt.Fprintf(logger, "Updated harness-config record image to %s\n", outputImage)
+
 	return nil
 }
 


### PR DESCRIPTION
After building a harness config image, the new image tag was written to the on-disk config.yaml but never synced to Hub. At agent start, Hub hydrated from its stale stored copy (still pointing at the old upstream image), so the locally-built image was never used.

Two fixes:

1. cmd/build.go: After updating on-disk config.yaml, auto-sync to Hub via syncHarnessConfigToHub(). If Hub is unavailable, print a warning suggesting the user run 'scion harness-config push'.

2. pkg/hub/maintenance_executors.go: After a successful build in BuildHarnessConfigImageExecutor, update the HarnessConfig record's Config.Image field in the DB and re-upload the modified config.yaml to Hub storage.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
