### PR TITLE
Warn when server binary is built without web assets

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -54,6 +54,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/store/entadapter"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
+	"github.com/GoogleCloudPlatform/scion/web"
 	"github.com/spf13/cobra"
 )
 
@@ -328,6 +329,10 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 			hubSrv.StartBackgroundServices(ctx)
 		}
 
+		if !web.AssetsEmbedded && webAssetsDir == "" {
+			log.Printf("WARNING: This binary was built without web assets. The web UI will not be available.")
+			log.Printf("Run 'make web' and rebuild to include the web frontend, or use --web-assets-dir.")
+		}
 		log.Printf("Starting Web Frontend on %s:%d", cfg.Hub.Host, webPort)
 		wg.Add(1)
 		go func() {

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -330,8 +330,7 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 		}
 
 		if !web.AssetsEmbedded && webAssetsDir == "" {
-			log.Printf("WARNING: This binary was built without web assets. The web UI will not be available.")
-			log.Printf("Run 'make web' and rebuild to include the web frontend, or use --web-assets-dir.")
+			slog.Warn("This binary was built without web assets. The web UI will not be available. Run 'make web' and rebuild to include the web frontend, or use --web-assets-dir.")
 		}
 		log.Printf("Starting Web Frontend on %s:%d", cfg.Hub.Host, webPort)
 		wg.Add(1)

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -765,7 +765,10 @@ func (ws *WebServer) staticHandler() http.Handler {
 
 func (ws *WebServer) serveStaticAsset(w http.ResponseWriter, r *http.Request) {
 	if ws.assetsDisk == "" && ws.assets == nil {
-		http.Error(w, "no assets available", http.StatusNotFound)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, noAssetsPage)
 		return
 	}
 


### PR DESCRIPTION
Add a prominent startup warning when web assets are not embedded and no --web-assets-dir is provided. Serve the self-contained noAssetsPage HTML from the static asset handler instead of a plain text 404, so direct requests to /assets/* also show a helpful message.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
