### PR TITLE
Tighten web channel default to actual web clients only

### DIFF
--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -2575,8 +2575,14 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 	structuredMsg.RecipientID = agent.ID
 
 	// Default the channel to "web" for messages sent through the web UI.
-	if structuredMsg.Channel == "" && GetUserIdentityFromContext(ctx) != nil {
-		structuredMsg.Channel = "web"
+	// Only tag as "web" when the authenticated user's client type is
+	// actually "web" — CLI and API callers should not be tagged.
+	if structuredMsg.Channel == "" {
+		if user := GetUserIdentityFromContext(ctx); user != nil {
+			if au, ok := user.(*AuthenticatedUser); ok && au.ClientType() == "web" {
+				structuredMsg.Channel = "web"
+			}
+		}
 	}
 
 	if !s.checkBrokerAvailability(w, r, agent) {

--- a/pkg/hub/handlers_messages.go
+++ b/pkg/hub/handlers_messages.go
@@ -210,8 +210,8 @@ func (s *Server) handleAgentMessages(w http.ResponseWriter, r *http.Request, age
 }
 
 // handleAgentMessagesStream handles GET /api/v1/agents/{id}/messages/stream.
-// Streams new messages involving a specific agent in real time, scoped to
-// the conversation between the current authenticated user and the agent.
+// Streams new messages involving a specific agent in real time. Users who
+// can manage the agent see all messages; others see only their own.
 // Unlike /message-logs/stream this does not depend on Cloud Logging: it
 // subscribes to the in-process event bus that handleAgentOutboundMessage
 // and handleAgentMessage already publish to, so it works on any hub


### PR DESCRIPTION
Only set channel="web" when the authenticated user's ClientType is "web", not for CLI or API callers hitting the same endpoint. Also update stale doc-comment on the stream handler.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
