### PR TITLE
fix: pass Hub-hydrated harness-config path to harness.Resolve

### DIFF
--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -738,6 +738,7 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 		TemplatePaths: templatePaths,
 		ProfileName:   profileName,
 		Settings:      settings,
+		ConfigDirPath: api.HarnessConfigPathFromContext(ctx),
 	})
 	if err != nil {
 		return "", "", nil, fmt.Errorf("failed to resolve harness for %q: %w", harnessConfigName, err)

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -361,6 +361,7 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 			TemplatePaths: resolveTemplatePaths,
 			ProfileName:   profileName,
 			Settings:      settings,
+			ConfigDirPath: opts.HarnessConfigPath,
 		})
 		if err != nil {
 			util.Debugf("harness.Resolve fell back to New(%q): %v", harnessName, err)

--- a/pkg/harness/resolve.go
+++ b/pkg/harness/resolve.go
@@ -40,6 +40,7 @@ type ResolveOptions struct {
 	TemplatePaths []string                  // optional template dirs (highest priority)
 	ProfileName   string                    // active profile (for settings overlay)
 	Settings      *config.VersionedSettings // optional settings overlay
+	ConfigDirPath string                    // explicit harness-config dir (Hub-hydrated path); takes priority over name-based lookup
 }
 
 // ResolvedHarness is the result of harness.Resolve. The selected
@@ -67,7 +68,13 @@ func Resolve(_ context.Context, opts ResolveOptions) (*ResolvedHarness, error) {
 		return nil, fmt.Errorf("harness.Resolve requires a name")
 	}
 
-	hcDir, hcErr := config.FindHarnessConfigDir(opts.Name, opts.ProjectPath, opts.TemplatePaths...)
+	var hcDir *config.HarnessConfigDir
+	var hcErr error
+	if opts.ConfigDirPath != "" {
+		hcDir, hcErr = config.LoadHarnessConfigDir(opts.ConfigDirPath)
+	} else {
+		hcDir, hcErr = config.FindHarnessConfigDir(opts.Name, opts.ProjectPath, opts.TemplatePaths...)
+	}
 
 	entry := config.HarnessConfigEntry{Harness: opts.Name}
 	if hcDir != nil {


### PR DESCRIPTION
## Summary

- In broker mode, `harness.Resolve()` used `FindHarnessConfigDir` which only searches local disk (template, project, global dirs). Hub-managed harness configs hydrated into temp directories were invisible to the resolver.
- This caused Resolve to fall back to `Generic{}` with no command config, producing an empty shell command (`sh -c ""`) — the agent exited immediately with code 0.
- The bug affected all Hub-managed harness configs in broker mode, but was most visible with no-auth/drop-to-shell because the NoAuth config was also nil (preventing the drop-to-shell path from activating).
- Fix: add `ConfigDirPath` to `ResolveOptions` so the broker can pass the Hub-hydrated path directly. `run.go` now passes `opts.HarnessConfigPath` through to the resolver.

## Test plan

- [ ] Start an agent with a Hub-managed harness config (e.g. antigravity) — verify the agent command runs (not empty)
- [ ] Start an agent with no-auth selected on a harness config with `no_auth.behavior: drop-to-shell` — verify drop to bash shell with guidance message
- [ ] Start an agent with a local (on-disk) harness config — verify no regression (ConfigDirPath is empty, falls through to FindHarnessConfigDir)
- [ ] `go test ./pkg/harness/...` passes
