### PR TITLE
feat(web): harness-config detail delete, image section, and agent logs fallback

### DIFF
--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -411,6 +411,21 @@ func (s *Server) deleteHarnessConfig(w http.ResponseWriter, r *http.Request, id 
 			writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required", nil)
 			return
 		}
+	} else if existing.Scope == store.HarnessConfigScopeUser {
+		userIdent := GetUserIdentityFromContext(ctx)
+		if userIdent == nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required", nil)
+			return
+		}
+		if existing.OwnerID != userIdent.ID() {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden,
+				"You do not have permission to delete another user's harness config", nil)
+			return
+		}
+	} else {
+		writeError(w, http.StatusForbidden, ErrCodeForbidden,
+			"Delete is not supported for this resource scope", nil)
+		return
 	}
 
 	if deleteFiles && existing.StoragePath != "" {

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -942,26 +942,23 @@ export class ScionPageAgentDetail extends LitElement {
 
       <sl-tab-group @sl-tab-show=${this.handleTabShow}>
         <sl-tab slot="nav" panel="status">Status</sl-tab>
-        ${this.agent.cloudLogging ? html`<sl-tab slot="nav" panel="logs">Logs</sl-tab>` : nothing}
+        <sl-tab slot="nav" panel="logs">Logs</sl-tab>
         <sl-tab slot="nav" panel="messages">Messages</sl-tab>
         <sl-tab slot="nav" panel="configuration">Configuration</sl-tab>
 
         <sl-tab-panel name="status">${this.renderStatusTab()}</sl-tab-panel>
-        ${this.agent.cloudLogging
-          ? html`
-              <sl-tab-panel name="logs">
-                <scion-agent-log-viewer
-                  agentId=${this.agentId}
-                  .brokers=${this.agent.runtimeBrokerId
-                    ? {
-                        [this.agent.runtimeBrokerId]:
-                          this.agent.runtimeBrokerName || this.agent.runtimeBrokerId,
-                      }
-                    : {}}
-                ></scion-agent-log-viewer>
-              </sl-tab-panel>
-            `
-          : nothing}
+        <sl-tab-panel name="logs">
+          <scion-agent-log-viewer
+            agentId=${this.agentId}
+            ?cloudLogging=${this.agent.cloudLogging || false}
+            .brokers=${this.agent.runtimeBrokerId
+              ? {
+                  [this.agent.runtimeBrokerId]:
+                    this.agent.runtimeBrokerName || this.agent.runtimeBrokerId,
+                }
+              : {}}
+          ></scion-agent-log-viewer>
+        </sl-tab-panel>
         <sl-tab-panel name="messages">
           <scion-agent-message-viewer
             agentId=${this.agentId}

--- a/web/src/components/pages/harness-config-detail.ts
+++ b/web/src/components/pages/harness-config-detail.ts
@@ -106,6 +106,18 @@ export class ScionPageHarnessConfigDetail extends LitElement {
   @state()
   private reimportError = '';
 
+  @state()
+  private deleteDialogOpen = false;
+
+  @state()
+  private deleteInProgress = false;
+
+  @state()
+  private deleteFiles = true;
+
+  @state()
+  private deleteError = '';
+
   private fileBrowserDataSource: FileBrowserDataSource | null = null;
   private fileEditorDataSource: FileEditorDataSource | null = null;
   private buildPollTimer: ReturnType<typeof setTimeout> | null = null;
@@ -258,6 +270,67 @@ export class ScionPageHarnessConfigDetail extends LitElement {
       margin-top: 0.5rem;
     }
 
+    .image-section {
+      margin-top: 1.5rem;
+    }
+    .image-section h2 {
+      font-size: 1.1rem;
+      font-weight: 600;
+      margin: 0 0 1rem;
+    }
+    .image-info {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 0.75rem 1rem;
+      background: var(--sl-color-neutral-50);
+      border: 1px solid var(--sl-color-neutral-200);
+      border-radius: var(--sl-border-radius-medium);
+      flex-wrap: wrap;
+    }
+    .image-path {
+      font-family: var(--sl-font-mono);
+      font-size: 0.8125rem;
+      word-break: break-all;
+      flex: 1;
+      min-width: 0;
+    }
+    .image-type-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: var(--sl-border-radius-pill);
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+    .image-type-badge.local {
+      background: var(--sl-color-neutral-100);
+      color: var(--sl-color-neutral-700);
+    }
+    .image-type-badge.remote {
+      background: var(--sl-color-primary-50);
+      color: var(--sl-color-primary-700);
+    }
+    .image-meta {
+      font-size: 0.75rem;
+      color: var(--sl-color-neutral-500);
+    }
+
+    .dialog-warning {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.8125rem;
+      color: var(--sl-color-danger-600);
+      margin-top: 0.75rem;
+    }
+    .dialog-error {
+      color: var(--sl-color-danger-600);
+      font-size: 0.8125rem;
+      margin-top: 0.5rem;
+    }
+
     .error-state,
     .loading-state {
       text-align: center;
@@ -397,7 +470,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
         )}
       </div>
 
-      ${this.renderHeader()} ${this.renderFilesSection()} ${this.renderBuildDialog()} ${this.renderBuildLog()}
+      ${this.renderHeader()} ${this.renderFilesSection()} ${this.renderImageSection()} ${this.renderBuildDialog()} ${this.renderBuildLog()} ${this.renderDeleteDialog()}
     `;
   }
 
@@ -425,15 +498,15 @@ export class ScionPageHarnessConfigDetail extends LitElement {
                 Refresh from Source
               </sl-button>
             ` : nothing}
-            ${this.hasDockerfile ? html`
+            ${can(hc._capabilities, 'delete') || can(hc._capabilities, 'manage') ? html`
               <sl-button
                 size="small"
-                variant="primary"
-                @click=${this.openBuildDialog}
-                ?disabled=${this.buildRunning}
+                variant="danger"
+                outline
+                @click=${() => { this.deleteDialogOpen = true; this.deleteError = ''; }}
               >
-                <sl-icon slot="prefix" name="hammer"></sl-icon>
-                ${this.buildRunning ? 'Building...' : 'Build Image'}
+                <sl-icon slot="prefix" name="trash"></sl-icon>
+                Delete
               </sl-button>
             ` : nothing}
           </div>
@@ -497,6 +570,49 @@ export class ScionPageHarnessConfigDetail extends LitElement {
       </div>
     `;
   }
+  private isRemoteImage(image: string): boolean {
+    return image.includes('/') && (image.includes('.') || image.includes(':'));
+  }
+
+  private renderImageSection() {
+    const hc = this.harnessConfig!;
+    const image = hc.config?.image;
+    const showSection = image || this.hasDockerfile;
+    if (!showSection) return nothing;
+
+    const isRemote = image ? this.isRemoteImage(image) : false;
+
+    return html`
+      <div class="image-section">
+        <h2>Image</h2>
+        <div class="image-info">
+          ${image ? html`
+            <span class="image-type-badge ${isRemote ? 'remote' : 'local'}">
+              ${isRemote ? 'Remote' : 'Local'}
+            </span>
+            <span class="image-path">${image}</span>
+          ` : html`
+            <span class="image-meta">No image configured</span>
+          `}
+          ${hc.updated ? html`
+            <span class="image-meta">Last updated: ${new Date(hc.updated).toLocaleString()}</span>
+          ` : nothing}
+          ${this.hasDockerfile ? html`
+            <sl-button
+              size="small"
+              variant="primary"
+              @click=${this.openBuildDialog}
+              ?disabled=${this.buildRunning}
+            >
+              <sl-icon slot="prefix" name="hammer"></sl-icon>
+              ${this.buildRunning ? 'Building...' : 'Build Image'}
+            </sl-button>
+          ` : nothing}
+        </div>
+      </div>
+    `;
+  }
+
   // ── Refresh from Source ──
 
   private async startReimport(): Promise<void> {
@@ -702,6 +818,86 @@ export class ScionPageHarnessConfigDetail extends LitElement {
         <pre class="build-log">${this.buildLog}</pre>
       </div>
     `;
+  }
+
+  // ── Delete ──
+
+  private renderDeleteDialog() {
+    if (!this.deleteDialogOpen || !this.harnessConfig) return nothing;
+    const hc = this.harnessConfig;
+    return html`
+      <sl-dialog
+        label="Delete harness config"
+        open
+        @sl-request-close=${(e: Event) => {
+          if (this.deleteInProgress) e.preventDefault();
+          else this.deleteDialogOpen = false;
+        }}
+      >
+        <p>
+          Are you sure you want to delete
+          <strong>${hc.displayName || hc.name}</strong>?
+        </p>
+        <sl-checkbox
+          ?checked=${this.deleteFiles}
+          @sl-change=${(e: Event) => {
+            this.deleteFiles = (e.target as HTMLInputElement).checked;
+          }}
+        >
+          Also delete stored files
+        </sl-checkbox>
+        <div class="dialog-warning">
+          <sl-icon name="exclamation-triangle"></sl-icon>
+          This action cannot be undone.
+        </div>
+        ${this.deleteError ? html`<div class="dialog-error">${this.deleteError}</div>` : nothing}
+        <div slot="footer">
+          <sl-button
+            variant="default"
+            size="small"
+            ?disabled=${this.deleteInProgress}
+            @click=${() => { this.deleteDialogOpen = false; }}
+          >
+            Cancel
+          </sl-button>
+          <sl-button
+            variant="danger"
+            size="small"
+            ?loading=${this.deleteInProgress}
+            ?disabled=${this.deleteInProgress}
+            @click=${() => this.confirmDelete()}
+          >
+            Delete
+          </sl-button>
+        </div>
+      </sl-dialog>
+    `;
+  }
+
+  private async confirmDelete(): Promise<void> {
+    if (!this.harnessConfig) return;
+    this.deleteInProgress = true;
+    this.deleteError = '';
+    try {
+      const params = new URLSearchParams({ deleteFiles: String(this.deleteFiles) });
+      const response = await apiFetch(
+        `/api/v1/harness-configs/${this.harnessConfig.id}?${params.toString()}`,
+        { method: 'DELETE' }
+      );
+      if (!response.ok && response.status !== 204) {
+        throw new Error(
+          await extractApiError(response, `Failed to delete: HTTP ${response.status}`)
+        );
+      }
+      this.deleteDialogOpen = false;
+      // Navigate back to the list view
+      const backLink = this.backLinks()[0];
+      window.location.href = backLink.href;
+    } catch (err) {
+      this.deleteError = err instanceof Error ? err.message : 'Delete failed';
+    } finally {
+      this.deleteInProgress = false;
+    }
   }
 
   override disconnectedCallback(): void {

--- a/web/src/components/pages/harness-config-detail.ts
+++ b/web/src/components/pages/harness-config-detail.ts
@@ -595,7 +595,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
             <span class="image-meta">No image configured</span>
           `}
           ${hc.updated ? html`
-            <span class="image-meta">Last updated: ${new Date(hc.updated).toLocaleString()}</span>
+            <span class="image-meta">Last updated: ${new Date(hc.updated).toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' })}</span>
           ` : nothing}
           ${this.hasDockerfile ? html`
             <sl-button
@@ -884,7 +884,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
         `/api/v1/harness-configs/${this.harnessConfig.id}?${params.toString()}`,
         { method: 'DELETE' }
       );
-      if (!response.ok && response.status !== 204) {
+      if (!response.ok) {
         throw new Error(
           await extractApiError(response, `Failed to delete: HTTP ${response.status}`)
         );

--- a/web/src/components/pages/harness-config-detail.ts
+++ b/web/src/components/pages/harness-config-detail.ts
@@ -113,7 +113,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
   private deleteInProgress = false;
 
   @state()
-  private deleteFiles = true;
+  private deleteFiles = false;
 
   @state()
   private deleteError = '';

--- a/web/src/components/shared/agent-log-viewer.ts
+++ b/web/src/components/shared/agent-log-viewer.ts
@@ -54,6 +54,10 @@ export class ScionAgentLogViewer extends LitElement {
   @property()
   agentId = '';
 
+  /** Whether Cloud Logging is available for this agent. */
+  @property({ type: Boolean })
+  cloudLogging = true;
+
   /** Available brokers for filtering (id -> name). */
   @property({ type: Object })
   brokers: Record<string, string> = {};
@@ -67,6 +71,9 @@ export class ScionAgentLogViewer extends LitElement {
   @state() private loaded = false;
   @state() private selectedBrokerId = '';
   @state() private selectedSeverity = '';
+
+  /** Plain-text logs from the broker (fallback when cloud logging is unavailable). */
+  @state() private brokerLogs: string | null = null;
 
   private eventSource: EventSource | null = null;
 
@@ -184,6 +191,20 @@ export class ScionAgentLogViewer extends LitElement {
       background: var(--scion-surface, #ffffff);
     }
 
+    .broker-logs {
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--sl-border-radius-medium, 0.5rem);
+      padding: 1rem;
+      font-family: var(--scion-font-mono, monospace);
+      font-size: 0.8125rem;
+      line-height: 1.6;
+      white-space: pre-wrap;
+      word-break: break-word;
+      max-height: 600px;
+      overflow-y: auto;
+    }
+
     .stream-indicator {
       display: inline-flex;
       align-items: center;
@@ -217,7 +238,11 @@ export class ScionAgentLogViewer extends LitElement {
   loadLogs(): void {
     if (this.loaded) return;
     this.loaded = true;
-    void this.fetchLogs();
+    if (this.cloudLogging) {
+      void this.fetchLogs();
+    } else {
+      void this.fetchBrokerLogs();
+    }
   }
 
   private async fetchLogs(): Promise<void> {
@@ -249,6 +274,34 @@ export class ScionAgentLogViewer extends LitElement {
 
       const data = (await res.json()) as CloudLogsResponse;
       this.mergeEntries(data.entries);
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to fetch logs';
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private async fetchBrokerLogs(): Promise<void> {
+    if (!this.agentId) return;
+    this.loading = true;
+    this.error = null;
+
+    try {
+      const res = await apiFetch(`/api/v1/agents/${this.agentId}/logs?tail=500`);
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({})) as { error?: { message?: string }; message?: string };
+        throw new Error(
+          (errData.error as { message?: string })?.message || errData.message || `HTTP ${res.status}`
+        );
+      }
+
+      const contentType = res.headers.get('Content-Type') || '';
+      if (contentType.includes('application/json')) {
+        const data = await res.json() as { logs?: string };
+        this.brokerLogs = data.logs || '';
+      } else {
+        this.brokerLogs = await res.text();
+      }
     } catch (err) {
       this.error = err instanceof Error ? err.message : 'Failed to fetch logs';
     } finally {
@@ -371,7 +424,11 @@ export class ScionAgentLogViewer extends LitElement {
   }
 
   private handleRefresh(): void {
-    void this.fetchLogs();
+    if (this.cloudLogging) {
+      void this.fetchLogs();
+    } else {
+      void this.fetchBrokerLogs();
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -379,10 +436,65 @@ export class ScionAgentLogViewer extends LitElement {
   // -------------------------------------------------------------------------
 
   override render() {
+    if (!this.cloudLogging) {
+      return html`
+        ${this.renderBrokerToolbar()}
+        ${this.renderBrokerContent()}
+      `;
+    }
     return html`
       ${this.renderToolbar()}
       ${this.renderContent()}
     `;
+  }
+
+  private renderBrokerToolbar() {
+    return html`
+      <div class="toolbar">
+        <sl-button
+          size="small"
+          variant="default"
+          ?loading=${this.loading}
+          ?disabled=${this.loading}
+          @click=${this.handleRefresh}
+        >
+          <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+          Refresh
+        </sl-button>
+      </div>
+    `;
+  }
+
+  private renderBrokerContent() {
+    if (this.loading && this.brokerLogs === null) {
+      return html`
+        <div class="state-msg">
+          <sl-spinner></sl-spinner>
+          <span>Loading logs...</span>
+        </div>
+      `;
+    }
+
+    if (this.error && this.brokerLogs === null) {
+      return html`
+        <div class="state-msg">
+          <sl-icon name="exclamation-triangle"></sl-icon>
+          <span>${this.error}</span>
+          <sl-button size="small" @click=${this.handleRefresh}>Retry</sl-button>
+        </div>
+      `;
+    }
+
+    if (!this.brokerLogs) {
+      return html`
+        <div class="state-msg">
+          <sl-icon name="file-text"></sl-icon>
+          <span>No log entries found</span>
+        </div>
+      `;
+    }
+
+    return html`<pre class="broker-logs">${this.brokerLogs}</pre>`;
   }
 
   private renderToolbar() {

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -460,6 +460,15 @@ export interface TemplateFileInfo {
   mode?: string;
 }
 
+export interface HarnessConfigData {
+  harness?: string;
+  image?: string;
+  user?: string;
+  model?: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
 export interface HarnessConfig {
   id: string;
   name: string;
@@ -467,6 +476,7 @@ export interface HarnessConfig {
   displayName?: string;
   description?: string;
   harness: string;
+  config?: HarnessConfigData;
   status: string;
   scope: string;
   scopeId?: string;


### PR DESCRIPTION
## Summary

- **Delete button**: Added a trash icon / delete action to the harness-config detail page with a confirmation dialog (including "also delete stored files" checkbox and undo warning), consistent with the existing delete UX in the list view. Navigates back to the list on success.
- **Image status section**: Added an image info section below the file list on the harness-config detail page showing the image path (with local/remote badge), last update time, and the Build Image button (moved from the header into this section).
- **Agent logs fallback**: The Logs tab on the agent detail page is now always visible regardless of the `cloudLogging` flag. When Cloud Logging is not configured, it falls back to the broker-based legacy endpoint (`/api/v1/agents/{id}/logs`) which reads from the agent's `agent.log` file or container stdout/stderr — surfacing provisioning errors that previously went unseen.

## Test plan

- [ ] Open a harness-config detail page with delete permission — verify the Delete button appears and the confirmation dialog works
- [ ] Open a harness-config with a configured image — verify the Image section shows the path with the correct local/remote badge
- [ ] Open a harness-config with a Dockerfile — verify the Build button appears in the Image section
- [ ] Open an agent detail page without Cloud Logging configured — verify the Logs tab is visible and shows broker logs
- [ ] Open an agent in error phase — verify provisioning error output is visible in the Logs tab
