### PR TITLE
feat(config): add name field to harness-config config.yaml

### DIFF
--- a/cmd/harness_config_install.go
+++ b/cmd/harness_config_install.go
@@ -80,7 +80,13 @@ func runHarnessConfigInstall(cmd *cobra.Command, args []string) error {
 
 	name := nameOverride
 	if name == "" {
-		name = deriveHarnessConfigName(source)
+		if hcDir.Config.Name != "" {
+			name = hcDir.Config.Name
+		} else if hcDir.Config.Harness != "" {
+			name = hcDir.Config.Harness
+		} else {
+			name = deriveHarnessConfigName(source)
+		}
 	}
 	if name == "" || name == "." || name == "/" {
 		return fmt.Errorf("could not derive harness-config name from source %q; use --name to specify", source)

--- a/cmd/harness_config_install.go
+++ b/cmd/harness_config_install.go
@@ -88,8 +88,8 @@ func runHarnessConfigInstall(cmd *cobra.Command, args []string) error {
 			name = deriveHarnessConfigName(source)
 		}
 	}
-	if name == "" || name == "." || name == "/" {
-		return fmt.Errorf("could not derive harness-config name from source %q; use --name to specify", source)
+	if name == "" || name == "." || name == ".." || strings.ContainsAny(name, "/\\") {
+		return fmt.Errorf("invalid harness-config name %q; name cannot contain path components or separators", name)
 	}
 
 	hubCtx, err := CheckHubAvailabilityWithOptions(gp, true)

--- a/pkg/config/harness_config.go
+++ b/pkg/config/harness_config.go
@@ -72,8 +72,13 @@ func LoadHarnessConfigDir(dirPath string) (*HarnessConfigDir, error) {
 		return nil, fmt.Errorf("failed to parse config.yaml: %w", err)
 	}
 
+	name := filepath.Base(absPath)
+	if entry.Name != "" {
+		name = entry.Name
+	}
+
 	return &HarnessConfigDir{
-		Name:   filepath.Base(absPath),
+		Name:   name,
 		Path:   absPath,
 		Config: entry,
 	}, nil

--- a/pkg/config/harness_config.go
+++ b/pkg/config/harness_config.go
@@ -74,11 +74,10 @@ func LoadHarnessConfigDir(dirPath string) (*HarnessConfigDir, error) {
 
 	name := filepath.Base(absPath)
 	if entry.Name != "" {
-		cleaned := filepath.Base(entry.Name)
-		if cleaned == "." || cleaned == ".." || cleaned != entry.Name {
-			return nil, fmt.Errorf("invalid name in config.yaml: %q contains path components", entry.Name)
+		if entry.Name == "." || entry.Name == ".." || strings.ContainsAny(entry.Name, "/\\") {
+			return nil, fmt.Errorf("invalid name in config.yaml: %q contains path components or separators", entry.Name)
 		}
-		name = cleaned
+		name = entry.Name
 	}
 
 	return &HarnessConfigDir{

--- a/pkg/config/harness_config.go
+++ b/pkg/config/harness_config.go
@@ -74,7 +74,11 @@ func LoadHarnessConfigDir(dirPath string) (*HarnessConfigDir, error) {
 
 	name := filepath.Base(absPath)
 	if entry.Name != "" {
-		name = entry.Name
+		cleaned := filepath.Base(entry.Name)
+		if cleaned == "." || cleaned == ".." || cleaned != entry.Name {
+			return nil, fmt.Errorf("invalid name in config.yaml: %q contains path components", entry.Name)
+		}
+		name = cleaned
 	}
 
 	return &HarnessConfigDir{

--- a/pkg/config/harness_config_test.go
+++ b/pkg/config/harness_config_test.go
@@ -117,6 +117,24 @@ func TestLoadHarnessConfigDir_InvalidUnknownField(t *testing.T) {
 	}
 }
 
+func TestLoadHarnessConfigDir_RejectsPathTraversalName(t *testing.T) {
+	for _, bad := range []string{"../evil", "sub/dir", "etc/passwd", "..", "."} {
+		tmpDir := t.TempDir()
+		configDir := filepath.Join(tmpDir, "legit")
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		yaml := "harness: claude\nname: " + bad + "\n"
+		if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(yaml), 0644); err != nil {
+			t.Fatal(err)
+		}
+		_, err := LoadHarnessConfigDir(configDir)
+		if err == nil {
+			t.Errorf("expected error for name %q, got nil", bad)
+		}
+	}
+}
+
 func TestLoadHarnessConfigDir_NotFound(t *testing.T) {
 	_, err := LoadHarnessConfigDir("/nonexistent/path")
 	if err == nil {

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -235,6 +235,7 @@
       "properties": {
         "name": {
           "type": "string",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]*$",
           "description": "Override name for this harness-config, used instead of the directory name during import/install."
         },
         "harness": {

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -233,6 +233,10 @@
       "type": "object",
       "required": ["harness"],
       "properties": {
+        "name": {
+          "type": "string",
+          "description": "Override name for this harness-config, used instead of the directory name during import/install."
+        },
         "harness": {
           "type": "string",
           "minLength": 1,

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -696,6 +696,7 @@ type V1RuntimeConfig struct {
 // HarnessConfigEntry defines a harness configuration entry in versioned settings.
 // The Harness field is required and specifies the harness type this config applies to.
 type HarnessConfigEntry struct {
+	Name             string               `json:"name,omitempty" yaml:"name,omitempty" koanf:"name"`
 	Harness          string               `json:"harness" yaml:"harness" koanf:"harness"`
 	Image            string               `json:"image,omitempty" yaml:"image,omitempty" koanf:"image"`
 	User             string               `json:"user,omitempty" yaml:"user,omitempty" koanf:"user"`

--- a/pkg/hub/resource_import.go
+++ b/pkg/hub/resource_import.go
@@ -340,7 +340,13 @@ func discoverResourceDirs(root, sourceURL string, kind resourceImportKind) ([]re
 		}
 		dir := filepath.Join(root, entry.Name())
 		if kind.isResourceDir(dir) {
-			dirs = append(dirs, resourceDir{entry.Name(), dir, sourceURL})
+			childName := entry.Name()
+			if kind.marker == "config.yaml" {
+				if hcDir, err := config.LoadHarnessConfigDir(dir); err == nil && hcDir.Config.Name != "" {
+					childName = hcDir.Config.Name
+				}
+			}
+			dirs = append(dirs, resourceDir{childName, dir, sourceURL})
 		} else {
 			skipped = append(skipped, skippedDir{entry.Name(), "no " + kind.marker})
 		}

--- a/pkg/hub/resource_import.go
+++ b/pkg/hub/resource_import.go
@@ -314,6 +314,11 @@ func discoverResourceDirs(root, sourceURL string, kind resourceImportKind) ([]re
 				name = derived
 			}
 		}
+		if kind.marker == "config.yaml" {
+			if hcDir, err := config.LoadHarnessConfigDir(root); err == nil && hcDir.Config.Name != "" {
+				name = hcDir.Config.Name
+			}
+		}
 		return []resourceDir{{name, root, sourceURL}}, nil, nil
 	}
 


### PR DESCRIPTION
## Summary

- Adds a `name` field to `HarnessConfigEntry` so harness-config authors can declare the intended config name in `config.yaml`, solving the problem where importing from a repo subfolder with a mismatched directory name (e.g. `scion/` when the desired name is `cogo`) uses the wrong name
- Name resolution priority: CLI `--name` flag > config.yaml `name` field > `harness` field (CLI install only) > URL/directory-derived name
- Updates JSON schema to allow the new `name` field

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/config/...` passes  
- [x] `go test ./cmd/...` passes
- [x] `go vet ./...` passes
- [x] Existing hub import tests pass (verified `TestImportHarnessConfigsFromWorkspace_SingleConfigAtRoot` and `TestHandleResourcesImport_SingleHarnessConfig`)
