### PR TITLE
feat(antigravity): remove gnome-keyring, switch to file-based OAuth auth

### DIFF
--- a/harnesses/antigravity/capture_auth.py
+++ b/harnesses/antigravity/capture_auth.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Antigravity capture-auth script.
+
+Captures the Antigravity OAuth token file and stores it as a project-scoped
+secret via `sciontool secret set`. Designed to run after the user authenticates
+interactively inside a no-auth agent container.
+
+AGY stores its OAuth token as a JSON file at:
+  ~/.gemini/antigravity-cli/antigravity-oauth-token
+
+This script reads the file, validates it contains a refresh_token, and stores
+it as the AGY_TOKEN secret.
+
+Exit codes:
+  0 = credential captured
+  1 = error
+  2 = no credentials found (not an error, but nothing was stored)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_NO_CREDS = 2
+
+HARNESS_BUNDLE = os.path.join(
+    os.environ.get("HOME") or os.path.expanduser("~"),
+    ".scion", "harness",
+)
+
+
+def _expand(path: str) -> str:
+    return os.path.expanduser(os.path.expandvars(path))
+
+
+def _load_config(bundle: str) -> list[dict[str, Any]]:
+    config_path = os.path.join(bundle, "inputs", "capture-auth-config.json")
+    if not os.path.isfile(config_path):
+        return []
+    with open(config_path, "r", encoding="utf-8") as f:
+        try:
+            data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return []
+    creds = data.get("credentials")
+    if not isinstance(creds, list):
+        return []
+    return creds
+
+
+def _validate_token_file(path: str) -> bool:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            obj = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"capture-auth: token file is not valid JSON: {exc}", file=sys.stderr)
+        return False
+    if not isinstance(obj, dict) or "refresh_token" not in obj:
+        print("capture-auth: token file missing refresh_token field", file=sys.stderr)
+        return False
+    return True
+
+
+def _capture_one(entry: dict[str, Any], force: bool) -> tuple[bool, str | None]:
+    key = entry.get("key", "") or entry.get("name", "")
+    source = _expand(entry.get("source", ""))
+    secret_type = entry.get("type", "file")
+    target = entry.get("target", "")
+
+    if not key or not source:
+        return False, "invalid entry: missing key or source"
+
+    if not os.path.isfile(source):
+        return False, None
+
+    cmd = [
+        "sciontool", "secret", "set", key, f"@{source}",
+        "--type", secret_type,
+        "--target", target,
+    ]
+    if force:
+        cmd.append("--force")
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except FileNotFoundError:
+        return False, "sciontool not found in PATH"
+    except subprocess.TimeoutExpired:
+        return False, f"sciontool timed out for key {key}"
+
+    if result.returncode != 0:
+        return False, f"sciontool failed for {key}: {result.stderr.strip()}"
+
+    return True, None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Capture Antigravity auth token and store as project secret"
+    )
+    parser.add_argument("--force", action="store_true", help="Overwrite existing secrets")
+    parser.add_argument("--bundle", default=HARNESS_BUNDLE)
+    args = parser.parse_args()
+
+    entries = _load_config(args.bundle)
+
+    if not entries:
+        home = os.environ.get("HOME") or os.path.expanduser("~")
+        token_path = os.path.join(home, ".gemini", "antigravity-cli", "antigravity-oauth-token")
+        entries = [{
+            "key": "AGY_TOKEN",
+            "source": token_path,
+            "type": "file",
+            "target": "~/.gemini/antigravity-cli/antigravity-oauth-token",
+        }]
+
+    captured = 0
+    errors = 0
+
+    for entry in entries:
+        key = entry.get("key", "") or entry.get("name", "<unknown>")
+        source = entry.get("source", "")
+        expanded = _expand(source) if source else ""
+
+        if not expanded or not os.path.isfile(expanded):
+            print(f"capture-auth: {key}: source not found ({source})")
+            continue
+
+        if not _validate_token_file(expanded):
+            errors += 1
+            continue
+
+        ok, err = _capture_one(entry, args.force)
+        if err:
+            print(f"capture-auth: {key}: {err}", file=sys.stderr)
+            errors += 1
+        elif ok:
+            print(f"capture-auth: {key}: captured from {source}")
+            captured += 1
+
+    if errors > 0 and captured == 0:
+        return EXIT_ERROR
+
+    if captured == 0:
+        print("capture-auth: no credentials found to capture")
+        print("  Make sure you have authenticated with: agy")
+        return EXIT_NO_CREDS
+
+    print(f"capture-auth: {captured} credential(s) captured successfully")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/harnesses/antigravity/config.yaml
+++ b/harnesses/antigravity/config.yaml
@@ -50,29 +50,37 @@ capabilities:
     system_prompt: { support: "partial", reason: "System prompt is downgraded to GEMINI.md preamble" }
     agent_instructions: { support: "yes" }
   auth:
-    api_key: { support: "no", reason: "AGY uses OAuth via gnome-keyring, not API keys" }
-    auth_file: { support: "no", reason: "AGY uses OAuth via gnome-keyring" }
-    oauth_token: { support: "yes", reason: "Via gnome-keyring population from AGY_KEYRING_TOKEN secret" }
-    vertex_ai: { support: "yes", reason: "Enterprise/GCP mode via AGY_KEYRING_TOKEN + GOOGLE_CLOUD_PROJECT" }
+    api_key: { support: "no", reason: "AGY uses OAuth, not API keys" }
+    auth_file: { support: "yes", reason: "Via AGY_TOKEN file secret at ~/.gemini/antigravity-cli/antigravity-oauth-token" }
+    oauth_token: { support: "no", reason: "AGY uses file-based OAuth token, not raw token injection" }
+    vertex_ai: { support: "yes", reason: "Enterprise/GCP mode via AGY_TOKEN + GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_LOCATION" }
 
 no_auth:
   behavior: drop-to-shell
   message: |
     This agent started without credentials.
-    Run: agy auth login
-    Then follow the prompts to authenticate.
+    Run: agy
+    Complete the interactive login flow.
+    Then run: python3 /home/scion/.scion/harness/capture_auth.py
 
 auth:
+  default_type: oauth-token
   types:
     oauth-token:
-      required_env:
-        - any_of: ["AGY_KEYRING_TOKEN"]
+      required_files:
+        - name: AGY_TOKEN
+          type: file
+          description: "Antigravity OAuth token JSON file"
+          target_suffix: "/.gemini/antigravity-cli/antigravity-oauth-token"
     vertex-ai:
-      # Enterprise/GCP mode: the keyring token is still required (provision.py
-      # validates AGY_KEYRING_TOKEN), plus the GCP project for Vertex routing.
       required_env:
-        - any_of: ["AGY_KEYRING_TOKEN"]
         - any_of: ["GOOGLE_CLOUD_PROJECT"]
+        - any_of: ["GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION"]
+      required_files:
+        - name: AGY_TOKEN
+          type: file
+          description: "Antigravity OAuth token JSON file"
+          target_suffix: "/.gemini/antigravity-cli/antigravity-oauth-token"
   autodetect:
     env:
-      AGY_KEYRING_TOKEN: oauth-token
+      AGY_TOKEN: oauth-token

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -18,7 +18,6 @@ import argparse
 import json
 import os
 import shutil
-import subprocess
 import sys
 from typing import Any
 
@@ -58,12 +57,7 @@ def _write_json(path: str, payload: Any) -> None:
 
 def _present_env_keys(candidates: dict[str, Any]) -> set[str]:
     raw = candidates.get("env_vars") or []
-    keys = {str(k) for k in raw if isinstance(k, str)}
-    # Also detect AGY_KEYRING_TOKEN from environment (may be injected
-    # as a plain env var rather than staged through the secret pipeline).
-    if os.environ.get("AGY_KEYRING_TOKEN"):
-        keys.add("AGY_KEYRING_TOKEN")
-    return keys
+    return {str(k) for k in raw if isinstance(k, str)}
 
 
 def _env_secret_files(candidates: dict[str, Any]) -> dict[str, str]:
@@ -91,23 +85,12 @@ def _read_secret(env_secret_files: dict[str, str], name: str) -> str:
     return os.environ.get(name, "")
 
 
-def _parse_env_output(output: str, env: dict[str, str]) -> None:
-    """Parse KEY=VALUE lines from daemon output into env dict."""
-    for line in output.splitlines():
-        for var in (
-            "DBUS_SESSION_BUS_ADDRESS", "DBUS_SESSION_BUS_PID",
-            "GNOME_KEYRING_CONTROL", "SSH_AUTH_SOCK",
-            "GNOME_KEYRING_PID",
-        ):
-            if line.startswith(var + "="):
-                val = line.split("=", 1)[1].rstrip(";").strip("'\"")
-                env[var] = val
-
-
 def _select_auth_method(
-    explicit: str, env_keys: set[str]
+    explicit: str, env_keys: set[str], secret_files: dict[str, str]
 ) -> tuple[str, str]:
-    has_keyring = "AGY_KEYRING_TOKEN" in env_keys
+    has_token = "AGY_TOKEN" in secret_files or bool(_read_secret(secret_files, "AGY_TOKEN"))
+    has_gcp_project = any(k in env_keys for k in ("GOOGLE_CLOUD_PROJECT",))
+    has_gcp_location = any(k in env_keys for k in ("GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION"))
 
     if explicit:
         if explicit not in VALID_AUTH_TYPES:
@@ -116,28 +99,24 @@ def _select_auth_method(
                 f"valid types are: {', '.join(VALID_AUTH_TYPES)}"
             )
         if explicit == "vertex-ai":
-            if has_keyring:
-                return "vertex-ai", "AGY_KEYRING_TOKEN"
-            raise ValueError(
-                "antigravity: auth type 'vertex-ai' selected but "
-                "AGY_KEYRING_TOKEN secret not found"
-            )
+            if not has_token:
+                raise ValueError("antigravity: auth type 'vertex-ai' selected but AGY_TOKEN secret not found")
+            if not has_gcp_project:
+                raise ValueError("antigravity: auth type 'vertex-ai' selected but GOOGLE_CLOUD_PROJECT not found")
+            if not has_gcp_location:
+                raise ValueError("antigravity: auth type 'vertex-ai' selected but GOOGLE_CLOUD_LOCATION/REGION not found")
+            return "vertex-ai", "AGY_TOKEN"
         if explicit == "oauth-token":
-            if has_keyring:
-                return "oauth-token", "AGY_KEYRING_TOKEN"
-            raise ValueError(
-                "antigravity: auth type 'oauth-token' selected but "
-                "AGY_KEYRING_TOKEN secret not found"
-            )
+            if not has_token:
+                raise ValueError("antigravity: auth type 'oauth-token' selected but AGY_TOKEN secret not found")
+            return "oauth-token", "AGY_TOKEN"
         if explicit == "none":
             return "none", ""
 
-    if has_keyring:
-        # AGY_USE_GCP=true promotes to vertex-ai (enterprise) mode
-        use_gcp = os.environ.get("AGY_USE_GCP", "").lower() in ("true", "1", "yes")
-        if use_gcp:
-            return "vertex-ai", "AGY_KEYRING_TOKEN"
-        return "oauth-token", "AGY_KEYRING_TOKEN"
+    if has_token:
+        if has_gcp_project and has_gcp_location:
+            return "vertex-ai", "AGY_TOKEN"
+        return "oauth-token", "AGY_TOKEN"
 
     return "none", ""
 
@@ -194,26 +173,13 @@ def _generate_hooks_json(home: str) -> None:
     )
 
 
-def _generate_wrapper_script(
-    home: str, has_token: bool, is_enterprise: bool,
-) -> None:
-    """Generate agy-wrapper.sh that inits keyring and execs AGY.
+def _generate_wrapper_script(home: str, is_enterprise: bool) -> None:
+    """Generate agy-wrapper.sh that execs AGY.
 
-    The keyring daemons must run in the same process tree as AGY so they
-    stay alive for the duration of the session. A provisioner-started daemon
-    dies when the provisioner exits, so we bootstrap inline here.
-
-    Token injection always includes an env-var fallback because the
-    provisioner runs before scion-env is sourced — AGY_KEYRING_TOKEN may
-    only be available in the child process environment, not during provisioning.
-
-    GCP/enterprise settings are also patched here at runtime for the same
-    reason — GOOGLE_CLOUD_PROJECT/GOOGLE_CLOUD_LOCATION and AGY_USE_GCP
+    GCP/enterprise settings are patched at runtime because
+    GOOGLE_CLOUD_PROJECT/GOOGLE_CLOUD_LOCATION and AGY_USE_GCP
     are only available in the child environment.
     """
-    secret_path = os.path.join(
-        home, ".scion", "harness", "secrets", "AGY_KEYRING_TOKEN"
-    )
     settings_path = os.path.join(
         home, ".gemini", "antigravity-cli", "settings.json"
     )
@@ -221,8 +187,6 @@ def _generate_wrapper_script(
         home, ".gemini", "antigravity-cli", "cache", "onboarding.json"
     )
 
-    # Enterprise marker: provisioner writes this when explicit vertex-ai
-    # is selected. The wrapper checks both this file and AGY_USE_GCP env.
     enterprise_marker = os.path.join(
         home, ".scion", "harness", ".enterprise-mode"
     )
@@ -231,42 +195,11 @@ def _generate_wrapper_script(
         with open(enterprise_marker, "w") as f:
             f.write("1")
     elif os.path.exists(enterprise_marker):
-        # Idempotent reprovision: if the auth mode switched away from
-        # vertex-ai (e.g. to oauth-token), remove the stale marker so the
-        # wrapper does not keep running in enterprise/GCP mode.
         os.remove(enterprise_marker)
 
     script = f"""#!/bin/bash
 # Generated by antigravity provision.py {PROVISION_VERSION}
 set -e
-
-# Initialize DBUS session bus
-eval $(dbus-launch --sh-syntax)
-export DBUS_SESSION_BUS_ADDRESS
-
-# Unlock and start gnome-keyring
-eval $(echo "test" | gnome-keyring-daemon --unlock 2>/dev/null)
-gnome-keyring-daemon --start --components=secrets,pkcs11,ssh > /dev/null 2>&1
-
-echo "agy-wrapper: keyring initialized (DBUS=$DBUS_SESSION_BUS_ADDRESS)" >&2
-
-# Inject OAuth token into keyring (secret file first, env var fallback)
-if [ -f "{secret_path}" ]; then
-    secret-tool store \\
-        --label="Password for antigravity on gemini" \\
-        service gemini username antigravity \\
-        < "{secret_path}" 2>/dev/null \\
-        && echo "agy-wrapper: token injected into keyring (from file)" >&2 \\
-        || echo "agy-wrapper: WARNING: failed to inject token" >&2
-elif [ -n "${{AGY_KEYRING_TOKEN:-}}" ]; then
-    printf '%s' "$AGY_KEYRING_TOKEN" | secret-tool store \\
-        --label="Password for antigravity on gemini" \\
-        service gemini username antigravity 2>/dev/null \\
-        && echo "agy-wrapper: token injected into keyring (from env)" >&2 \\
-        || echo "agy-wrapper: WARNING: failed to inject token" >&2
-else
-    echo "agy-wrapper: no token available, AGY will prompt for login" >&2
-fi
 
 # GCP/enterprise mode: patch settings.json with gcp block and mark
 # enterprise onboarding complete. Triggered by explicit vertex-ai auth
@@ -280,7 +213,7 @@ fi
 
 if [ "$_use_gcp" = "true" ]; then
     _gcp_project="${{GOOGLE_CLOUD_PROJECT:-}}"
-    _gcp_location="${{GOOGLE_CLOUD_LOCATION:-global}}"
+    _gcp_location="${{GOOGLE_CLOUD_LOCATION:-${{GOOGLE_CLOUD_REGION:-global}}}}"
 
     if [ -n "$_gcp_project" ]; then
         python3 -c "
@@ -562,7 +495,7 @@ def _provision(manifest: dict[str, Any]) -> int:
         env_key = ""
     else:
         try:
-            method, env_key = _select_auth_method(explicit, env_keys)
+            method, env_key = _select_auth_method(explicit, env_keys, secret_files)
         except ValueError as exc:
             print(str(exc), file=sys.stderr)
             return EXIT_ERROR
@@ -585,38 +518,32 @@ def _provision(manifest: dict[str, Any]) -> int:
 
     env_payload: dict[str, Any] = {}
 
-    # Validate token if an auth method requiring it was selected
+    # Place the token file for AGY to read directly
     has_token = False
     if method in ("oauth-token", "vertex-ai"):
-        token_raw = _read_secret(secret_files, "AGY_KEYRING_TOKEN")
+        token_raw = _read_secret(secret_files, "AGY_TOKEN")
         if not token_raw:
-            print(
-                "antigravity provision: AGY_KEYRING_TOKEN secret is empty",
-                file=sys.stderr,
-            )
+            print("antigravity provision: AGY_TOKEN secret is empty", file=sys.stderr)
             return EXIT_ERROR
         try:
             token_obj = json.loads(token_raw)
         except json.JSONDecodeError as exc:
-            print(
-                f"antigravity provision: AGY_KEYRING_TOKEN is not valid JSON: {exc}",
-                file=sys.stderr,
-            )
+            print(f"antigravity provision: AGY_TOKEN is not valid JSON: {exc}", file=sys.stderr)
             return EXIT_ERROR
         if not isinstance(token_obj, dict) or "refresh_token" not in token_obj:
-            print(
-                "antigravity provision: AGY_KEYRING_TOKEN must contain refresh_token",
-                file=sys.stderr,
-            )
+            print("antigravity provision: AGY_TOKEN must contain refresh_token", file=sys.stderr)
             return EXIT_ERROR
+
+        token_dest = os.path.join(home, ".gemini", "antigravity-cli", "antigravity-oauth-token")
+        os.makedirs(os.path.dirname(token_dest), exist_ok=True)
+        _write_json(token_dest, token_obj)
+        os.chmod(token_dest, 0o600)
         has_token = True
+        print(f"antigravity provision: placed OAuth token at {token_dest}", file=sys.stderr)
 
     is_enterprise = method == "vertex-ai"
 
-    # Generate wrapper script that inits keyring and execs AGY.
-    # Keyring daemons must run in AGY's process tree (not the
-    # provisioner's) so they stay alive for the session.
-    _generate_wrapper_script(home, has_token, is_enterprise)
+    _generate_wrapper_script(home, is_enterprise)
 
     try:
         _write_json(auth_out, resolved_payload)

--- a/image-build/core-base/Dockerfile
+++ b/image-build/core-base/Dockerfile
@@ -119,10 +119,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-venv \
     lsb-release \
     chromium \
-    dbus-x11 \
-    gnome-keyring \
-    libsecret-1-0 \
-    libsecret-tools \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Replace gnome-keyring/DBUS token injection with direct file-based OAuth token placement. The token is now written to
~/.gemini/antigravity-cli/antigravity-oauth-token by provision.py, which AGY reads directly — no keyring daemons needed.

Changes:
- Dockerfile: remove dbus-x11, gnome-keyring, libsecret-1-0, libsecret-tools
- config.yaml: rename AGY_KEYRING_TOKEN→AGY_TOKEN (file secret), require GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_LOCATION for vertex-ai, update capabilities to reflect file-based auth
- provision.py: remove _parse_env_output, keyring/DBUS wrapper logic; write token file directly; update _select_auth_method signature to accept secret_files
- capture_auth.py: new file-based capture script (standard pattern) replacing keyring extraction

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
