### PR TITLE
fix(antigravity): patch gcp settings block for oauth-token agents wit…

### DIFF
--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -270,6 +270,8 @@ if [ -f "{enterprise_marker}" ]; then
     _use_gcp=true
 elif [ "${{AGY_USE_GCP:-}}" = "true" ] || [ "${{AGY_USE_GCP:-}}" = "1" ] || [ "${{AGY_USE_GCP:-}}" = "yes" ]; then
     _use_gcp=true
+elif [ -n "${{GOOGLE_CLOUD_PROJECT:-}}" ]; then
+    _use_gcp=true
 fi
 
 if [ "$_use_gcp" = "true" ]; then


### PR DESCRIPTION
…h GCP env

The wrapper script's GCP gate only triggers on the enterprise marker file or AGY_USE_GCP env var. For oauth-token auth with GOOGLE_CLOUD_PROJECT injected into the container, neither condition is met so the gcp block is never written to settings.json.

Add an elif to also set _use_gcp=true when GOOGLE_CLOUD_PROJECT is present. The inner block already guards against empty project values.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
