### PR TITLE
fix(build): use config.yaml image field to determine output image name

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -90,7 +90,16 @@ field is updated to reference the built image.`,
 			return fmt.Errorf("no container runtime found (tried docker, podman)")
 		}
 
-		outputImage := harnessConfigName + ":" + tag
+		imageBaseName := harnessConfigName
+		if hcDir.Config.Image != "" {
+			name := hcDir.Config.Image
+			if colonIdx := strings.LastIndex(name, ":"); colonIdx >= 0 {
+				name = name[:colonIdx]
+			}
+			imageBaseName = name
+		}
+
+		outputImage := imageBaseName + ":" + tag
 		if buildPush {
 			imageRegistry := ""
 			if settings != nil {
@@ -99,7 +108,7 @@ field is updated to reference the built image.`,
 			if imageRegistry == "" {
 				return fmt.Errorf("--push requires image_registry to be configured")
 			}
-			outputImage = imageRegistry + "/" + harnessConfigName + ":" + tag
+			outputImage = imageRegistry + "/" + imageBaseName + ":" + tag
 		}
 
 		buildArgs := []string{"build",


### PR DESCRIPTION
When config.yaml specifies an image field (e.g. "scion-cogo:latest"), use its name portion as the output image base name instead of always using the harness-config CLI argument. This ensures the built image matches the intended name from the config rather than the directory name.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
