### PR TITLE
skill-bank M5: address Gemini code review findings

### DIFF
--- a/cmd/skill_registries.go
+++ b/cmd/skill_registries.go
@@ -44,7 +44,7 @@ func runRegistriesList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Hub connection required: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 	defer cancel()
 
 	resp, err := hubCtx.Client.SkillRegistries().List(ctx)
@@ -83,7 +83,7 @@ func runRegistriesAdd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Hub connection required: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 	defer cancel()
 
 	endpoint, _ := cmd.Flags().GetString("endpoint")
@@ -133,7 +133,7 @@ func runRegistriesShow(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Hub connection required: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 	defer cancel()
 
 	registry, err := hubCtx.Client.SkillRegistries().Get(ctx, args[0])
@@ -175,7 +175,7 @@ func runRegistriesUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Hub connection required: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 	defer cancel()
 
 	endpoint, _ := cmd.Flags().GetString("endpoint")
@@ -220,7 +220,7 @@ func runRegistriesRemove(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Hub connection required: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 	defer cancel()
 
 	if err := hubCtx.Client.SkillRegistries().Delete(ctx, args[0]); err != nil {
@@ -248,7 +248,7 @@ func runRegistriesPin(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Hub connection required: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 	defer cancel()
 
 	hash, _ := cmd.Flags().GetString("hash")

--- a/cmd/skill_registries.go
+++ b/cmd/skill_registries.go
@@ -185,13 +185,24 @@ func runRegistriesUpdate(cmd *cobra.Command, args []string) error {
 	authToken, _ := cmd.Flags().GetString("auth-token")
 	resolvePath, _ := cmd.Flags().GetString("resolve-path")
 
-	req := &hubclient.UpdateSkillRegistryRequest{
-		Endpoint:    endpoint,
-		TrustLevel:  trust,
-		Status:      status,
-		Description: description,
-		AuthToken:   authToken,
-		ResolvePath: resolvePath,
+	req := &hubclient.UpdateSkillRegistryRequest{}
+	if cmd.Flags().Changed("endpoint") {
+		req.Endpoint = &endpoint
+	}
+	if cmd.Flags().Changed("trust") {
+		req.TrustLevel = &trust
+	}
+	if cmd.Flags().Changed("status") {
+		req.Status = &status
+	}
+	if cmd.Flags().Changed("description") {
+		req.Description = &description
+	}
+	if cmd.Flags().Changed("auth-token") {
+		req.AuthToken = &authToken
+	}
+	if cmd.Flags().Changed("resolve-path") {
+		req.ResolvePath = &resolvePath
 	}
 
 	registry, err := hubCtx.Client.SkillRegistries().Update(ctx, args[0], req)

--- a/pkg/agent/github_uri.go
+++ b/pkg/agent/github_uri.go
@@ -35,10 +35,11 @@ type GitHubSkillRef struct {
 // ParseGitHubSkillURI parses a gh:// shorthand or full GitHub URL
 // into a GitHubSkillRef.
 func ParseGitHubSkillURI(uri string) (*GitHubSkillRef, error) {
-	if strings.HasPrefix(uri, "gh://") {
+	lower := strings.ToLower(uri)
+	if strings.HasPrefix(lower, "gh://") {
 		return parseGHShorthand(uri)
 	}
-	if strings.HasPrefix(uri, "https://github.com/") || strings.HasPrefix(uri, "http://github.com/") {
+	if strings.HasPrefix(lower, "https://github.com/") || strings.HasPrefix(lower, "http://github.com/") {
 		return parseGitHubFullURL(uri)
 	}
 	return nil, fmt.Errorf("not a GitHub skill URI: %q", uri)

--- a/pkg/agent/github_uri.go
+++ b/pkg/agent/github_uri.go
@@ -36,13 +36,30 @@ type GitHubSkillRef struct {
 // into a GitHubSkillRef.
 func ParseGitHubSkillURI(uri string) (*GitHubSkillRef, error) {
 	lower := strings.ToLower(uri)
-	if strings.HasPrefix(lower, "gh://") {
-		return parseGHShorthand(uri)
+
+	var normalized string
+	switch {
+	case strings.HasPrefix(lower, "gh://"):
+		normalized = "gh://" + uri[len("gh://"):]
+	case strings.HasPrefix(lower, "https://github.com/"):
+		normalized = "https://github.com/" + uri[len("https://github.com/"):]
+	case strings.HasPrefix(lower, "http://github.com/"):
+		normalized = "http://github.com/" + uri[len("http://github.com/"):]
+	default:
+		return nil, fmt.Errorf("not a GitHub skill URI: %q", uri)
 	}
-	if strings.HasPrefix(lower, "https://github.com/") || strings.HasPrefix(lower, "http://github.com/") {
-		return parseGitHubFullURL(uri)
+
+	var ref *GitHubSkillRef
+	var err error
+	if strings.HasPrefix(normalized, "gh://") {
+		ref, err = parseGHShorthand(normalized)
+	} else {
+		ref, err = parseGitHubFullURL(normalized)
 	}
-	return nil, fmt.Errorf("not a GitHub skill URI: %q", uri)
+	if ref != nil {
+		ref.Raw = uri
+	}
+	return ref, err
 }
 
 func parseGHShorthand(uri string) (*GitHubSkillRef, error) {

--- a/pkg/agent/github_uri_test.go
+++ b/pkg/agent/github_uri_test.go
@@ -94,6 +94,28 @@ func TestParseGHShorthand(t *testing.T) {
 			uri:       "skill://my-skill",
 			wantError: true,
 		},
+		{
+			name: "uppercase scheme GH://",
+			uri:  "GH://owner/repo/skill",
+			want: &GitHubSkillRef{
+				Owner:     "owner",
+				Repo:      "repo",
+				SkillName: "skill",
+				Ref:       "",
+				SkillPath: "skills/skill",
+			},
+		},
+		{
+			name: "mixed-case scheme Gh:// with ref",
+			uri:  "Gh://owner/repo/skill@main",
+			want: &GitHubSkillRef{
+				Owner:     "owner",
+				Repo:      "repo",
+				SkillName: "skill",
+				Ref:       "main",
+				SkillPath: "skills/skill",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -179,6 +201,28 @@ func TestParseGitHubFullURL(t *testing.T) {
 			name:      "blob instead of tree",
 			uri:       "https://github.com/owner/repo/blob/main/file.go",
 			wantError: true,
+		},
+		{
+			name: "uppercase HTTPS scheme and host",
+			uri:  "HTTPS://GITHUB.COM/owner/repo/tree/main/skills/skill",
+			want: &GitHubSkillRef{
+				Owner:     "owner",
+				Repo:      "repo",
+				SkillName: "skill",
+				Ref:       "main",
+				SkillPath: "skills/skill",
+			},
+		},
+		{
+			name: "mixed-case Http scheme and host",
+			uri:  "Http://GitHub.Com/owner/repo/tree/main/skills/skill",
+			want: &GitHubSkillRef{
+				Owner:     "owner",
+				Repo:      "repo",
+				SkillName: "skill",
+				Ref:       "main",
+				SkillPath: "skills/skill",
+			},
 		},
 	}
 

--- a/pkg/agent/routing_skill_resolver.go
+++ b/pkg/agent/routing_skill_resolver.go
@@ -103,20 +103,21 @@ func (r *RoutingSkillResolver) Resolve(ctx context.Context, refs []api.SkillRefe
 
 // detectScheme extracts the routing scheme from a skill URI.
 func detectScheme(uri string) string {
-	if strings.HasPrefix(uri, "gh://") {
+	lower := strings.ToLower(uri)
+	if strings.HasPrefix(lower, "gh://") {
 		return "gh"
 	}
-	if strings.HasPrefix(uri, "gcp-skill://") {
+	if strings.HasPrefix(lower, "gcp-skill://") {
 		return "gcp-skill"
 	}
-	if strings.HasPrefix(uri, "https://github.com/") || strings.HasPrefix(uri, "http://github.com/") {
+	if strings.HasPrefix(lower, "https://github.com/") || strings.HasPrefix(lower, "http://github.com/") {
 		return "gh"
 	}
-	if strings.HasPrefix(uri, "skill://") || !strings.Contains(uri, "://") {
+	if strings.HasPrefix(lower, "skill://") || !strings.Contains(lower, "://") {
 		return "skill"
 	}
-	if idx := strings.Index(uri, "://"); idx > 0 {
-		return uri[:idx]
+	if idx := strings.Index(lower, "://"); idx > 0 {
+		return lower[:idx]
 	}
 	return ""
 }

--- a/pkg/api/skill_uri.go
+++ b/pkg/api/skill_uri.go
@@ -229,7 +229,7 @@ func parseScopedPath(raw string, uri *SkillURI, segments []string, version strin
 // This function is a lightweight utility for non-routing scheme checks.
 func SkillURIScheme(uri string) string {
 	if idx := strings.Index(uri, "://"); idx > 0 {
-		return uri[:idx]
+		return strings.ToLower(uri[:idx])
 	}
 	return "skill"
 }

--- a/pkg/hub/handlers.go
+++ b/pkg/hub/handlers.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
-	gouuid "github.com/google/uuid"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/gcp"
@@ -45,6 +44,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/transfer"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 	"github.com/GoogleCloudPlatform/scion/pkg/version"
+	gouuid "github.com/google/uuid"
 )
 
 // ============================================================================

--- a/pkg/hub/skill_federation.go
+++ b/pkg/hub/skill_federation.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
 const (
@@ -39,13 +41,13 @@ func (s *Server) federateResolve(ctx context.Context, registryName string, skill
 			Message: fmt.Sprintf("registry %q is not configured", registryName),
 		}
 	}
-	if registry.Status != "active" {
+	if registry.Status != store.SkillRegistryStatusActive {
 		return nil, &ResolveSkillError{
 			URI: skillRef.URI, Code: "registry_disabled",
 			Message: fmt.Sprintf("registry %q is disabled", registryName),
 		}
 	}
-	if registry.Type != "hub" {
+	if registry.Type != store.SkillRegistryTypeHub {
 		return nil, &ResolveSkillError{
 			URI: skillRef.URI, Code: "wrong_registry_type",
 			Message: fmt.Sprintf("registry %q is type %q, not hub", registryName, registry.Type),
@@ -124,7 +126,7 @@ func (s *Server) federateResolve(ctx context.Context, registryName string, skill
 	resolved := &resolveResp.Resolved[0]
 
 	// Trust enforcement
-	if registry.TrustLevel == "pinned" {
+	if registry.TrustLevel == store.SkillRegistryTrustPinned {
 		pinnedHash, err := s.store.GetPinnedHash(ctx, registry.ID, skillRef.URI)
 		if err != nil {
 			return nil, &ResolveSkillError{

--- a/pkg/hub/skill_registry_handlers.go
+++ b/pkg/hub/skill_registry_handlers.go
@@ -36,12 +36,12 @@ type CreateSkillRegistryRequest struct {
 
 // UpdateSkillRegistryRequest is the request body for updating a skill registry.
 type UpdateSkillRegistryRequest struct {
-	Endpoint    string `json:"endpoint,omitempty"`
-	Description string `json:"description,omitempty"`
-	TrustLevel  string `json:"trustLevel,omitempty"`
-	AuthToken   string `json:"authToken,omitempty"`
-	ResolvePath string `json:"resolvePath,omitempty"`
-	Status      string `json:"status,omitempty"`
+	Endpoint    *string `json:"endpoint,omitempty"`
+	Description *string `json:"description,omitempty"`
+	TrustLevel  *string `json:"trustLevel,omitempty"`
+	AuthToken   *string `json:"authToken,omitempty"`
+	ResolvePath *string `json:"resolvePath,omitempty"`
+	Status      *string `json:"status,omitempty"`
 }
 
 // PinSkillHashRequest is the request body for pinning a skill hash.
@@ -238,36 +238,36 @@ func (s *Server) updateSkillRegistry(w http.ResponseWriter, r *http.Request, id 
 		return
 	}
 
-	if req.Endpoint != "" {
-		u, err := url.Parse(req.Endpoint)
+	if req.Endpoint != nil {
+		u, err := url.Parse(*req.Endpoint)
 		if err != nil || u.Scheme != "https" || u.Host == "" {
 			ValidationError(w, "endpoint must be a valid HTTPS URL", nil)
 			return
 		}
-		registry.Endpoint = req.Endpoint
+		registry.Endpoint = *req.Endpoint
 	}
-	if req.Description != "" {
-		registry.Description = req.Description
+	if req.Description != nil {
+		registry.Description = *req.Description
 	}
-	if req.TrustLevel != "" {
-		if req.TrustLevel != store.SkillRegistryTrustTrusted && req.TrustLevel != store.SkillRegistryTrustPinned {
+	if req.TrustLevel != nil {
+		if *req.TrustLevel != store.SkillRegistryTrustTrusted && *req.TrustLevel != store.SkillRegistryTrustPinned {
 			ValidationError(w, "trustLevel must be 'trusted' or 'pinned'", nil)
 			return
 		}
-		registry.TrustLevel = req.TrustLevel
+		registry.TrustLevel = *req.TrustLevel
 	}
-	if req.AuthToken != "" {
-		registry.AuthToken = req.AuthToken
+	if req.AuthToken != nil {
+		registry.AuthToken = *req.AuthToken
 	}
-	if req.ResolvePath != "" {
-		registry.ResolvePath = req.ResolvePath
+	if req.ResolvePath != nil {
+		registry.ResolvePath = *req.ResolvePath
 	}
-	if req.Status != "" {
-		if req.Status != store.SkillRegistryStatusActive && req.Status != store.SkillRegistryStatusDisabled {
+	if req.Status != nil {
+		if *req.Status != store.SkillRegistryStatusActive && *req.Status != store.SkillRegistryStatusDisabled {
 			ValidationError(w, "status must be 'active' or 'disabled'", nil)
 			return
 		}
-		registry.Status = req.Status
+		registry.Status = *req.Status
 	}
 
 	if err := s.store.UpdateSkillRegistry(ctx, registry); err != nil {

--- a/pkg/hub/skill_registry_handlers_test.go
+++ b/pkg/hub/skill_registry_handlers_test.go
@@ -261,6 +261,73 @@ func TestSkillRegistryCRUD_AuthTokenNotInResponse(t *testing.T) {
 	}
 }
 
+func TestSkillRegistryCRUD_ClearAuthTokenAndResolvePath(t *testing.T) {
+	srv, st := newRegistryTestServer(t)
+	admin := NewAuthenticatedUser("admin-1", "admin@test.com", "Admin", "admin", "cli")
+
+	// Create registry with non-empty AuthToken and ResolvePath
+	body := `{"name":"clear-reg","endpoint":"https://registry.example.com","authToken":"my-token","resolvePath":"/custom/resolve"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/skill-registries", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleSkillRegistries(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var created store.SkillRegistry
+	if err := json.Unmarshal(rr.Body.Bytes(), &created); err != nil {
+		t.Fatalf("create: invalid JSON: %v", err)
+	}
+
+	// Verify initial values via store (AuthToken is json:"-")
+	got, err := st.GetSkillRegistry(req.Context(), created.ID)
+	if err != nil {
+		t.Fatalf("get after create: %v", err)
+	}
+	if got.AuthToken != "my-token" {
+		t.Fatalf("expected authToken 'my-token', got %q", got.AuthToken)
+	}
+	if got.ResolvePath != "/custom/resolve" {
+		t.Fatalf("expected resolvePath '/custom/resolve', got %q", got.ResolvePath)
+	}
+
+	// Update with explicit empty strings to clear both fields
+	updateBody := `{"authToken":"","resolvePath":""}`
+	req = httptest.NewRequest(http.MethodPut, "/api/v1/skill-registries/"+created.ID, strings.NewReader(updateBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr = httptest.NewRecorder()
+	srv.handleSkillRegistryByID(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify resolvePath is cleared in response (omitempty means absent when empty)
+	var updatedResp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &updatedResp); err != nil {
+		t.Fatalf("update response: invalid JSON: %v", err)
+	}
+	if _, ok := updatedResp["resolvePath"]; ok {
+		t.Errorf("expected resolvePath absent from response (omitempty), got %v", updatedResp["resolvePath"])
+	}
+
+	// Verify fields are cleared via store (authoritative check)
+	got, err = st.GetSkillRegistry(req.Context(), created.ID)
+	if err != nil {
+		t.Fatalf("get after update: %v", err)
+	}
+	if got.AuthToken != "" {
+		t.Errorf("expected authToken cleared, got %q", got.AuthToken)
+	}
+	if got.ResolvePath != "" {
+		t.Errorf("expected resolvePath cleared, got %q", got.ResolvePath)
+	}
+}
+
 func TestSkillRegistryPin(t *testing.T) {
 	srv, _ := newRegistryTestServer(t)
 	admin := NewAuthenticatedUser("admin-1", "admin@test.com", "Admin", "admin", "cli")

--- a/pkg/hubclient/skill_registries.go
+++ b/pkg/hubclient/skill_registries.go
@@ -69,12 +69,12 @@ type CreateSkillRegistryRequest struct {
 
 // UpdateSkillRegistryRequest is the request body for updating a skill registry.
 type UpdateSkillRegistryRequest struct {
-	Endpoint    string `json:"endpoint,omitempty"`
-	Description string `json:"description,omitempty"`
-	TrustLevel  string `json:"trustLevel,omitempty"`
-	AuthToken   string `json:"authToken,omitempty"`
-	ResolvePath string `json:"resolvePath,omitempty"`
-	Status      string `json:"status,omitempty"`
+	Endpoint    *string `json:"endpoint,omitempty"`
+	Description *string `json:"description,omitempty"`
+	TrustLevel  *string `json:"trustLevel,omitempty"`
+	AuthToken   *string `json:"authToken,omitempty"`
+	ResolvePath *string `json:"resolvePath,omitempty"`
+	Status      *string `json:"status,omitempty"`
 }
 
 // PinSkillHashRequest is the request body for pinning a skill hash.

--- a/pkg/store/entadapter/skill_registry_store.go
+++ b/pkg/store/entadapter/skill_registry_store.go
@@ -135,12 +135,8 @@ func (s *SkillRegistryStore) UpdateSkillRegistry(ctx context.Context, registry *
 	if registry.TrustLevel != "" {
 		update.SetTrustLevel(entskillregistry.TrustLevel(registry.TrustLevel))
 	}
-	if registry.AuthToken != "" {
-		update.SetAuthToken(registry.AuthToken)
-	}
-	if registry.ResolvePath != "" {
-		update.SetResolvePath(registry.ResolvePath)
-	}
+	update.SetAuthToken(registry.AuthToken)
+	update.SetResolvePath(registry.ResolvePath)
 	if registry.Status != "" {
 		update.SetStatus(entskillregistry.Status(registry.Status))
 	}

--- a/pkg/store/entadapter/skill_registry_store.go
+++ b/pkg/store/entadapter/skill_registry_store.go
@@ -58,7 +58,7 @@ func entSkillRegistryToStore(e *ent.SkillRegistry) *store.SkillRegistry {
 
 func (s *SkillRegistryStore) CreateSkillRegistry(ctx context.Context, registry *store.SkillRegistry) error {
 	pinnedHashesJSON := ""
-	if len(registry.PinnedHashes) > 0 {
+	if registry.PinnedHashes != nil {
 		b, _ := json.Marshal(registry.PinnedHashes)
 		pinnedHashesJSON = string(b)
 	}
@@ -144,7 +144,7 @@ func (s *SkillRegistryStore) UpdateSkillRegistry(ctx context.Context, registry *
 	if registry.Status != "" {
 		update.SetStatus(entskillregistry.Status(registry.Status))
 	}
-	if len(registry.PinnedHashes) > 0 {
+	if registry.PinnedHashes != nil {
 		b, _ := json.Marshal(registry.PinnedHashes)
 		update.SetPinnedHashes(string(b))
 	}


### PR DESCRIPTION
- Replace context.Background() with cmd.Context() in CLI commands (Ctrl+C support)
- Use pointer fields in UpdateSkillRegistryRequest for proper partial updates
- Make URI scheme detection case-insensitive (RFC 3986 compliance)
- Make GitHub URI parsing case-insensitive
- Use store constants instead of hardcoded strings in skill federation
- Return lowercase scheme from SkillURIScheme
- Fix PinnedHashes nil check to allow clearing pinned hashes

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
