### PR TITLE
fix(antigravity): accept nested AGY token format with auth_method env…

### DIFF
--- a/harnesses/antigravity/capture_auth.py
+++ b/harnesses/antigravity/capture_auth.py
@@ -75,7 +75,11 @@ def _validate_token_file(path: str) -> bool:
     except (json.JSONDecodeError, OSError) as exc:
         print(f"capture-auth: token file is not valid JSON: {exc}", file=sys.stderr)
         return False
-    if not isinstance(obj, dict) or "refresh_token" not in obj:
+    has_refresh = (
+        "refresh_token" in obj
+        or (isinstance(obj.get("token"), dict) and "refresh_token" in obj["token"])
+    )
+    if not isinstance(obj, dict) or not has_refresh:
         print("capture-auth: token file missing refresh_token field", file=sys.stderr)
         return False
     return True

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -627,7 +627,11 @@ def _provision(manifest: dict[str, Any]) -> int:
         except json.JSONDecodeError as exc:
             print(f"antigravity provision: AGY_TOKEN is not valid JSON: {exc}", file=sys.stderr)
             return EXIT_ERROR
-        if not isinstance(token_obj, dict) or "refresh_token" not in token_obj:
+        has_refresh = (
+            "refresh_token" in token_obj
+            or (isinstance(token_obj.get("token"), dict) and "refresh_token" in token_obj["token"])
+        )
+        if not isinstance(token_obj, dict) or not has_refresh:
             print("antigravity provision: AGY_TOKEN must contain refresh_token", file=sys.stderr)
             return EXIT_ERROR
         has_token = True


### PR DESCRIPTION
…elope

AGY stores refresh_token nested under a "token" key with an "auth_method" envelope, but the validation only checked the top level. Accept both layouts in provision.py and capture_auth.py.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
