### PR TITLE
fix(antigravity): deduplicate capture-auth entries and treat "already…

### DIFF
--- a/harnesses/antigravity/capture_auth.py
+++ b/harnesses/antigravity/capture_auth.py
@@ -116,7 +116,7 @@ def _capture_one(entry: dict[str, Any], force: bool) -> tuple[bool, str | None]:
     if result.returncode != 0:
         stderr = result.stderr.strip()
         if "already exists" in stderr:
-            return False, None
+            return True, None
         return False, f"sciontool failed for {key}: {stderr}"
 
     return True, None


### PR DESCRIPTION
… exists" as skip

Config may list the same secret key in multiple auth types (e.g. AGY_TOKEN from both oauth-token and vertex-ai required_files). This caused confusing output: first iteration succeeds, second fails with "already exists", and the summary shows both a capture and an error.

Deduplicate entries by key after loading, and treat the "already exists" sciontool error as a silent skip rather than a reported error.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
