### PR TITLE
antigravity: add missing field extractions and fix max_model_calls ca…

### DIFF
--- a/harnesses/antigravity/config.yaml
+++ b/harnesses/antigravity/config.yaml
@@ -41,7 +41,7 @@ mcp:
 capabilities:
   limits:
     max_turns: { support: "yes" }
-    max_model_calls: { support: "no", reason: "AGY events do not distinguish model calls from invocations" }
+    max_model_calls: { support: "yes" }
     max_duration: { support: "yes" }
   telemetry:
     enabled: { support: "no", reason: "AGY has no native OTEL integration" }

--- a/harnesses/antigravity/dialect.yaml
+++ b/harnesses/antigravity/dialect.yaml
@@ -3,16 +3,22 @@ event_name_field: hook_event_name
 mappings:
   PreInvocation:
     event: model-start
+    fields:
+      session_id: .conversationId
   PostInvocation:
     event: model-end
+    fields:
+      session_id: .conversationId
   PreToolUse:
     event: tool-start
     fields:
       tool_name: .toolCall.name
+      tool_input: .toolCall.args
   PostToolUse:
     event: tool-end
     fields:
-      tool_name: .toolCall.name
+      # AGY PostToolUse payload only includes stepIdx and error.
+      # toolCall is NOT present — do not map tool_name here.
       error: .error
   Stop:
     event: agent-end

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -29,7 +29,7 @@ try:
 except ImportError:
     scion_harness = None  # type: ignore[assignment]
 
-PROVISION_VERSION = "2026-06-25T00:00:00Z"
+PROVISION_VERSION = "2026-06-25T01:00:00Z"
 
 VALID_AUTH_TYPES = ("oauth-token", "vertex-ai", "none")
 


### PR DESCRIPTION
…pability

- Extract session_id from .conversationId on PreInvocation/PostInvocation
- Extract tool_input from .toolCall.args on PreToolUse
- Remove false tool_name extraction from PostToolUse (field not in payload)
- Declare max_model_calls as supported (model-start/model-end are wired)
- Bump PROVISION_VERSION

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
