### PR TITLE
Disable ADC auth for vertex-ai, require AGY_TOKEN + keyring

### DIFF
--- a/harnesses/antigravity/config.yaml
+++ b/harnesses/antigravity/config.yaml
@@ -53,7 +53,7 @@ capabilities:
     api_key: { support: "no", reason: "AGY uses OAuth, not API keys" }
     auth_file: { support: "yes", reason: "Via AGY_TOKEN file secret at ~/.gemini/antigravity-cli/antigravity-oauth-token" }
     oauth_token: { support: "no", reason: "AGY uses file-based OAuth token, not raw token injection" }
-    vertex_ai: { support: "yes", reason: "Enterprise/GCP mode via ADC (USE_ADC=1) + GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_LOCATION" }
+    vertex_ai: { support: "yes", reason: "Enterprise/GCP mode via AGY_TOKEN + GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_LOCATION" }
 
 no_auth:
   behavior: drop-to-shell
@@ -76,6 +76,11 @@ auth:
       required_env:
         - any_of: ["GOOGLE_CLOUD_PROJECT"]
         - any_of: ["GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION"]
+      required_files:
+        - name: AGY_TOKEN
+          type: file
+          description: "Antigravity OAuth token JSON file"
+          target_suffix: "/.gemini/antigravity-cli/antigravity-oauth-token"
   autodetect:
     env:
       AGY_TOKEN: oauth-token

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -29,7 +29,7 @@ try:
 except ImportError:
     scion_harness = None  # type: ignore[assignment]
 
-PROVISION_VERSION = "2026-06-25T00:00:00Z"
+PROVISION_VERSION = "2026-06-25T01:00:00Z"
 
 VALID_AUTH_TYPES = ("oauth-token", "vertex-ai", "none")
 
@@ -131,11 +131,13 @@ def _select_auth_method(
                 f"valid types are: {', '.join(VALID_AUTH_TYPES)}"
             )
         if explicit == "vertex-ai":
+            if not has_token:
+                raise ValueError("antigravity: auth type 'vertex-ai' selected but AGY_TOKEN secret not found")
             if not gcp_project:
                 raise ValueError("antigravity: auth type 'vertex-ai' selected but GOOGLE_CLOUD_PROJECT not found")
             if not gcp_location:
                 raise ValueError("antigravity: auth type 'vertex-ai' selected but GOOGLE_CLOUD_LOCATION/REGION not found")
-            return "vertex-ai", ""
+            return "vertex-ai", "AGY_TOKEN"
         if explicit == "oauth-token":
             if not has_token:
                 raise ValueError("antigravity: auth type 'oauth-token' selected but AGY_TOKEN secret not found")
@@ -143,9 +145,9 @@ def _select_auth_method(
         if explicit == "none":
             return "none", ""
 
-    if gcp_project and gcp_location:
-        return "vertex-ai", ""
     if has_token:
+        if gcp_project and gcp_location:
+            return "vertex-ai", "AGY_TOKEN"
         return "oauth-token", "AGY_TOKEN"
 
     return "none", ""
@@ -317,9 +319,6 @@ print('agy-wrapper: patched settings.json with gcp config', file=sys.stderr)
     else
         echo "agy-wrapper: WARNING: GCP mode but GOOGLE_CLOUD_PROJECT not set" >&2
     fi
-
-    export USE_ADC=1
-    echo "agy-wrapper: ADC mode enabled (USE_ADC=1)" >&2
 
     python3 -c "
 import json, sys
@@ -612,7 +611,7 @@ def _provision(manifest: dict[str, Any]) -> int:
 
     # Validate token if an auth method requiring it was selected
     has_token = False
-    if method == "oauth-token":
+    if method in ("oauth-token", "vertex-ai"):
         token_raw = _read_secret(secret_files, "AGY_TOKEN")
         if not token_raw:
             # AGY_TOKEN may be a file-type secret bind-mounted directly to its


### PR DESCRIPTION
USE_ADC is not yet functional in the AGY CLI, so vertex-ai auth falls back to requiring AGY_TOKEN with keyring injection. The os.environ fallback for GOOGLE_CLOUD_LOCATION and the 1.0.11 binary pin are preserved.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
