### PR TITLE
fix(harness): stage required_files as secrets instead of bind-mounting

### DIFF
--- a/pkg/harness/container_script_harness.go
+++ b/pkg/harness/container_script_harness.go
@@ -422,6 +422,13 @@ func (c *ContainerScriptHarness) Provision(ctx context.Context, agentName, agent
 // value (e.g. Codex writes its API key into .codex/auth.json) read the file
 // because sciontool harness provision strips secret env vars from the script's
 // process environment for containment.
+//
+// For file-based credentials declared in required_files (e.g. auth-file mode),
+// the file content is read from the host SourcePath and staged as a secret file
+// under agent_home/.scion/harness/secrets/<NAME> (mode 0600). The path is
+// recorded in file_secret_files in auth-candidates.json so the container-side
+// script can write a fresh writable copy. The FileMapping is removed from
+// resolved.Files so the runtime does not bind-mount the file read-only.
 func (c *ContainerScriptHarness) ApplyAuthSettings(agentHome string, resolved *api.ResolvedAuth) error {
 	if resolved == nil {
 		return nil
@@ -432,19 +439,131 @@ func (c *ContainerScriptHarness) ApplyAuthSettings(agentHome string, resolved *a
 		return err
 	}
 
+	fileSecretFiles, remainingFiles, err := c.stageFileSecretFiles(agentHome, resolved.Files)
+	if err != nil {
+		return err
+	}
+	// Remove staged-as-secret FileMappings from resolved so the runtime does
+	// not also bind-mount them (which would create a read-only overlay that
+	// prevents the container-side script from writing the file).
+	resolved.Files = remainingFiles
+
 	payload := map[string]interface{}{
-		"schema_version":   1,
-		"explicit_type":    c.entry.AuthSelectedType,
-		"resolved_method":  resolved.Method,
-		"env_vars":         sortedKeys(resolved.EnvVars),
-		"env_secret_files": envSecretFiles,
-		"files":            fileMappingsToJSON(resolved.Files),
+		"schema_version":    1,
+		"explicit_type":     c.entry.AuthSelectedType,
+		"resolved_method":   resolved.Method,
+		"env_vars":          sortedKeys(resolved.EnvVars),
+		"env_secret_files":  envSecretFiles,
+		"file_secret_files": fileSecretFiles,
+		"files":             fileMappingsToJSON(resolved.Files),
 	}
 	data, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal auth candidates: %w", err)
 	}
 	return c.stageInputFile(agentHome, "auth-candidates.json", data)
+}
+
+// stageFileSecretFiles reads the content of each FileMapping whose ContainerPath
+// matches a required_files declaration in the harness config, writes it to
+// agent_home/.scion/harness/secrets/<NAME> (mode 0600), and returns:
+//   - fileSecretFiles: map of name -> "$HOME/.scion/harness/secrets/<NAME>" for
+//     the staged secrets (to be written into file_secret_files in auth-candidates.json)
+//   - remainingFiles: the FileMappings that were NOT staged as secrets and should
+//     still be passed to the runtime for bind-mounting
+//
+// This prevents read-only bind-mounts for credential files that the container-side
+// provisioner script needs to write (e.g. Codex auth.json).
+func (c *ContainerScriptHarness) stageFileSecretFiles(agentHome string, files []api.FileMapping) (map[string]string, []api.FileMapping, error) {
+	fileSecretFiles := map[string]string{}
+	if len(files) == 0 || c.entry.Auth == nil {
+		return fileSecretFiles, files, nil
+	}
+
+	// Build a lookup from container path suffix → credential name using the
+	// harness config's required_files declarations.
+	type fileReq struct {
+		name         string
+		targetSuffix string
+	}
+	var reqs []fileReq
+	for _, authType := range c.entry.Auth.Types {
+		for _, rf := range authType.RequiredFiles {
+			if rf.Name == "" || rf.TargetSuffix == "" {
+				continue
+			}
+			reqs = append(reqs, fileReq{name: rf.Name, targetSuffix: rf.TargetSuffix})
+		}
+	}
+	if len(reqs) == 0 {
+		return fileSecretFiles, files, nil
+	}
+
+	// Normalize a container path by expanding ~ to $HOME and stripping trailing
+	// slashes so comparison is consistent.
+	normalize := func(p string) string {
+		p = strings.TrimRight(p, "/")
+		if strings.HasPrefix(p, "~/") {
+			p = "$HOME/" + p[2:]
+		}
+		return p
+	}
+
+	dir := filepath.Join(agentHome, ".scion", "harness", "secrets")
+	dirCreated := false
+
+	var remaining []api.FileMapping
+	for _, f := range files {
+		normCP := normalize(f.ContainerPath)
+
+		// Find a matching required_file entry by container path suffix.
+		var matchedName string
+		for _, req := range reqs {
+			suffix := req.targetSuffix
+			if !strings.HasPrefix(suffix, "/") {
+				suffix = "/" + suffix
+			}
+			normSuffix := normalize("~" + suffix)
+			if normCP == normSuffix {
+				matchedName = req.name
+				break
+			}
+		}
+
+		if matchedName == "" || !isSafeEnvName(matchedName) {
+			// Not a declared file credential or unsafe name — keep as bind-mount.
+			remaining = append(remaining, f)
+			continue
+		}
+
+		if f.SourcePath == "" {
+			// No host path to read; keep as bind-mount fallback.
+			remaining = append(remaining, f)
+			continue
+		}
+
+		content, err := os.ReadFile(f.SourcePath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read credential file %s (%s): %w", matchedName, f.SourcePath, err)
+		}
+
+		if !dirCreated {
+			if err := os.MkdirAll(dir, 0700); err != nil {
+				return nil, nil, fmt.Errorf("create secrets dir: %w", err)
+			}
+			dirCreated = true
+		}
+
+		target := filepath.Join(dir, matchedName)
+		if err := os.WriteFile(target, content, 0600); err != nil {
+			return nil, nil, fmt.Errorf("write file secret %s: %w", matchedName, err)
+		}
+		fileSecretFiles[matchedName] = "$HOME/.scion/harness/secrets/" + matchedName
+		// Do NOT add to remaining — this file is now staged as a secret and
+		// must not be bind-mounted.
+	}
+
+	return fileSecretFiles, remaining, nil
 }
 
 // stageEnvSecretFiles writes each non-empty env value to

--- a/pkg/harness/container_script_harness.go
+++ b/pkg/harness/container_script_harness.go
@@ -500,7 +500,9 @@ func (c *ContainerScriptHarness) stageFileSecretFiles(agentHome string, files []
 	}
 
 	// Normalize a container path by expanding ~ to $HOME and stripping trailing
-	// slashes so comparison is consistent.
+	// slashes so comparison is consistent. Absolute paths (e.g.
+	// /home/scion/.codex/auth.json) are returned unchanged; tilde paths are
+	// expanded to $HOME/... form.
 	normalize := func(p string) string {
 		p = strings.TrimRight(p, "/")
 		if strings.HasPrefix(p, "~/") {
@@ -517,14 +519,16 @@ func (c *ContainerScriptHarness) stageFileSecretFiles(agentHome string, files []
 		normCP := normalize(f.ContainerPath)
 
 		// Find a matching required_file entry by container path suffix.
+		// Use HasSuffix so that both tilde paths (~/.codex/auth.json →
+		// $HOME/.codex/auth.json) and absolute paths
+		// (/home/scion/.codex/auth.json) match the same suffix declaration.
 		var matchedName string
 		for _, req := range reqs {
-			suffix := req.targetSuffix
+			suffix := strings.TrimRight(req.targetSuffix, "/")
 			if !strings.HasPrefix(suffix, "/") {
 				suffix = "/" + suffix
 			}
-			normSuffix := normalize("~" + suffix)
-			if normCP == normSuffix {
+			if strings.HasSuffix(normCP, suffix) {
 				matchedName = req.name
 				break
 			}

--- a/pkg/harness/container_script_harness_test.go
+++ b/pkg/harness/container_script_harness_test.go
@@ -344,6 +344,92 @@ func TestContainerScriptHarness_ApplyAuthSettings_StagesFileSecrets(t *testing.T
 	}
 }
 
+func TestContainerScriptHarness_ApplyAuthSettings_StagesFileSecrets_AbsolutePath(t *testing.T) {
+	// Identical harness setup to StagesFileSecrets, but the FileMapping uses an
+	// absolute container path (/home/scion/.codex/auth.json) instead of the
+	// tilde form (~/.codex/auth.json). HasSuffix matching must handle both.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "config.yaml"), "harness: codex\nimage: scion-codex:latest\n")
+	writeFile(t, filepath.Join(dir, "provision.py"), "#!/usr/bin/env python3\nimport sys\nsys.exit(0)\n")
+
+	entry := config.HarnessConfigEntry{
+		Harness: "codex",
+		Image:   "scion-codex:latest",
+		Provisioner: &config.HarnessProvisionerConfig{
+			Type:             "container-script",
+			InterfaceVersion: 1,
+			Command:          []string{"python3", "$HOME/.scion/harness/provision.py"},
+		},
+		Auth: &config.HarnessAuthMetadata{
+			Types: map[string]config.HarnessAuthTypeMetadata{
+				"auth-file": {
+					RequiredFiles: []config.HarnessAuthFileRequirement{
+						{
+							Name:         "CODEX_AUTH",
+							Type:         "file",
+							TargetSuffix: "/.codex/auth.json",
+							Field:        "CodexAuthFile",
+						},
+					},
+				},
+			},
+		},
+	}
+	h, err := NewContainerScriptHarness(dir, entry)
+	if err != nil {
+		t.Fatalf("NewContainerScriptHarness: %v", err)
+	}
+
+	agentHome := t.TempDir()
+	hostAuthFile := filepath.Join(t.TempDir(), "auth.json")
+	writeFile(t, hostAuthFile, `{"auth_mode":"oauth","token":"tok-abs"}`)
+
+	// Provide an absolute container path — the suffix matcher must still match.
+	resolved := &api.ResolvedAuth{
+		Method:  "container-script",
+		EnvVars: map[string]string{},
+		Files: []api.FileMapping{
+			{SourcePath: hostAuthFile, ContainerPath: "/home/scion/.codex/auth.json"},
+		},
+	}
+
+	if err := h.ApplyAuthSettings(agentHome, resolved); err != nil {
+		t.Fatalf("ApplyAuthSettings (absolute path): %v", err)
+	}
+
+	// The FileMapping must have been consumed (not left as a bind-mount).
+	if len(resolved.Files) != 0 {
+		t.Errorf("expected resolved.Files to be empty after staging; got %+v", resolved.Files)
+	}
+
+	// Secret file should be written.
+	secretPath := filepath.Join(agentHome, ".scion", "harness", "secrets", "CODEX_AUTH")
+	content, err := os.ReadFile(secretPath)
+	if err != nil {
+		t.Fatalf("staged secret not found at %s: %v", secretPath, err)
+	}
+	if string(content) != `{"auth_mode":"oauth","token":"tok-abs"}` {
+		t.Errorf("secret content=%q", content)
+	}
+
+	// auth-candidates.json must carry file_secret_files.CODEX_AUTH.
+	data, err := os.ReadFile(filepath.Join(agentHome, ".scion", "harness", "inputs", "auth-candidates.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	fsf, ok := payload["file_secret_files"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("file_secret_files missing or wrong type: %T", payload["file_secret_files"])
+	}
+	if _, ok := fsf["CODEX_AUTH"]; !ok {
+		t.Errorf("file_secret_files.CODEX_AUTH missing; got %v", fsf)
+	}
+}
+
 func TestContainerScriptHarness_ApplyAuthSettings_NonFileCredentialKeptAsBindMount(t *testing.T) {
 	// FileMappings for credentials without a required_files declaration should
 	// remain as bind-mounts (not staged as secrets).

--- a/pkg/harness/container_script_harness_test.go
+++ b/pkg/harness/container_script_harness_test.go
@@ -245,6 +245,139 @@ func TestContainerScriptHarness_ApplyAuthSettings_WritesCandidates(t *testing.T)
 	}
 }
 
+func TestContainerScriptHarness_ApplyAuthSettings_StagesFileSecrets(t *testing.T) {
+	// Harness entry with a required_files declaration matching Codex auth-file.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "config.yaml"), "harness: codex\nimage: scion-codex:latest\n")
+	writeFile(t, filepath.Join(dir, "provision.py"), "#!/usr/bin/env python3\nimport sys\nsys.exit(0)\n")
+
+	entry := config.HarnessConfigEntry{
+		Harness: "codex",
+		Image:   "scion-codex:latest",
+		Provisioner: &config.HarnessProvisionerConfig{
+			Type:             "container-script",
+			InterfaceVersion: 1,
+			Command:          []string{"python3", "$HOME/.scion/harness/provision.py"},
+		},
+		Auth: &config.HarnessAuthMetadata{
+			Types: map[string]config.HarnessAuthTypeMetadata{
+				"auth-file": {
+					RequiredFiles: []config.HarnessAuthFileRequirement{
+						{
+							Name:         "CODEX_AUTH",
+							Type:         "file",
+							TargetSuffix: "/.codex/auth.json",
+							Field:        "CodexAuthFile",
+						},
+					},
+				},
+			},
+		},
+	}
+	h, err := NewContainerScriptHarness(dir, entry)
+	if err != nil {
+		t.Fatalf("NewContainerScriptHarness: %v", err)
+	}
+
+	agentHome := t.TempDir()
+
+	// Write a fake auth.json on the host.
+	hostAuthFile := filepath.Join(t.TempDir(), "auth.json")
+	writeFile(t, hostAuthFile, `{"auth_mode":"oauth","token":"tok-xxx"}`)
+
+	resolved := &api.ResolvedAuth{
+		Method:  "container-script",
+		EnvVars: map[string]string{},
+		Files: []api.FileMapping{
+			{SourcePath: hostAuthFile, ContainerPath: "~/.codex/auth.json"},
+		},
+	}
+
+	if err := h.ApplyAuthSettings(agentHome, resolved); err != nil {
+		t.Fatalf("ApplyAuthSettings: %v", err)
+	}
+
+	// The FileMapping should have been removed from resolved.Files.
+	if len(resolved.Files) != 0 {
+		t.Errorf("expected resolved.Files to be empty after staging; got %+v", resolved.Files)
+	}
+
+	// The secret file should be written at secrets/CODEX_AUTH with mode 0600.
+	secretPath := filepath.Join(agentHome, ".scion", "harness", "secrets", "CODEX_AUTH")
+	info, err := os.Stat(secretPath)
+	if err != nil {
+		t.Fatalf("staged secret not found at %s: %v", secretPath, err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("secret mode=%o, want 0600", info.Mode().Perm())
+	}
+	content, _ := os.ReadFile(secretPath)
+	if string(content) != `{"auth_mode":"oauth","token":"tok-xxx"}` {
+		t.Errorf("secret content=%q", content)
+	}
+
+	// auth-candidates.json should have file_secret_files.CODEX_AUTH set.
+	data, err := os.ReadFile(filepath.Join(agentHome, ".scion", "harness", "inputs", "auth-candidates.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	fsf, ok := payload["file_secret_files"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("file_secret_files missing or wrong type: %T", payload["file_secret_files"])
+	}
+	codexAuthPath, ok := fsf["CODEX_AUTH"].(string)
+	if !ok || codexAuthPath == "" {
+		t.Errorf("file_secret_files.CODEX_AUTH missing or empty: %v", fsf)
+	}
+	if !strings.HasPrefix(codexAuthPath, "$HOME/.scion/harness/secrets/") {
+		t.Errorf("file_secret_files.CODEX_AUTH=%q does not have expected prefix", codexAuthPath)
+	}
+
+	// The files array should be empty (bind-mount removed).
+	filesRaw, _ := payload["files"].([]interface{})
+	if len(filesRaw) != 0 {
+		t.Errorf("files array should be empty; got %v", filesRaw)
+	}
+}
+
+func TestContainerScriptHarness_ApplyAuthSettings_NonFileCredentialKeptAsBindMount(t *testing.T) {
+	// FileMappings for credentials without a required_files declaration should
+	// remain as bind-mounts (not staged as secrets).
+	h, _ := newTestContainerScriptHarness(t) // no Auth metadata
+	agentHome := t.TempDir()
+
+	hostFile := filepath.Join(t.TempDir(), "gcloud.json")
+	writeFile(t, hostFile, `{"type":"service_account"}`)
+
+	resolved := &api.ResolvedAuth{
+		Method:  "container-script",
+		EnvVars: map[string]string{},
+		Files: []api.FileMapping{
+			{SourcePath: hostFile, ContainerPath: "~/.config/gcloud/application_default_credentials.json"},
+		},
+	}
+
+	if err := h.ApplyAuthSettings(agentHome, resolved); err != nil {
+		t.Fatalf("ApplyAuthSettings: %v", err)
+	}
+
+	// No Auth metadata → no required_files → file should remain in resolved.Files.
+	if len(resolved.Files) != 1 {
+		t.Errorf("expected 1 file to remain as bind-mount; got %+v", resolved.Files)
+	}
+
+	// No secret should be staged.
+	secretDir := filepath.Join(agentHome, ".scion", "harness", "secrets")
+	entries, _ := os.ReadDir(secretDir)
+	for _, e := range entries {
+		t.Errorf("unexpected secret staged: %s", e.Name())
+	}
+}
+
 func TestContainerScriptHarness_ApplyMCPSettings_WritesInput(t *testing.T) {
 	h, _ := newTestContainerScriptHarness(t)
 	agentHome := t.TempDir()


### PR DESCRIPTION
For auth-file credentials declared in required_files (e.g. Codex auth.json), ApplyAuthSettings now reads the file content on the host and stages it as a 0600 secret file under agent_home/.scion/harness/secrets/<NAME>, recording the container-side path in a new file_secret_files field in auth-candidates.json.

The FileMapping is removed from resolved.Files so the runtime does not bind-mount the credential file read-only — Codex crashes on startup when auth.json is a read-only bind-mount because it tries to chown/write the file.

Non-declared file credentials (e.g. gcloud ADC) are unaffected and continue to pass through as bind-mounts.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
