### PR TITLE
Fix TypeScript errors in metrics-dashboard causing CI failure

### DIFF
--- a/web/src/components/pages/metrics-dashboard.ts
+++ b/web/src/components/pages/metrics-dashboard.ts
@@ -431,7 +431,7 @@ export class ScionPageMetrics extends LitElement {
 
       const existing = this.charts.get(canvasId);
       if (existing) {
-        if (existing.config.type === type) {
+        if ((existing.config as { type?: string }).type === type) {
           existing.data.labels = labels;
           existing.data.datasets = datasets;
           existing.update();
@@ -548,8 +548,6 @@ export class ScionPageMetrics extends LitElement {
     if (this.loading) return html`<sl-spinner></sl-spinner>`;
     if (!this.sessions) return this.renderEmptyState();
 
-    const s = this.sessions;
-
     return html`
       <div class="chart-row">
         <div class="section">
@@ -572,8 +570,6 @@ export class ScionPageMetrics extends LitElement {
     if (this.loading) return html`<sl-spinner></sl-spinner>`;
     if (!this.modelCalls) return this.renderEmptyState();
 
-    const mc = this.modelCalls;
-
     return html`
       <div class="chart-row">
         <div class="section">
@@ -595,8 +591,6 @@ export class ScionPageMetrics extends LitElement {
   private renderTokensTab() {
     if (this.loading) return html`<sl-spinner></sl-spinner>`;
     if (!this.tokens) return this.renderEmptyState();
-
-    const t = this.tokens;
 
     return html`
       <div class="chart-row">


### PR DESCRIPTION
- Cast config to access `type` property, fixing TS2339 on union type
- Remove unused variables (s, mc, t) in render methods, fixing TS6133

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
