### PR TITLE
fix(hub): register /api/v1/message-channels route

### DIFF
--- a/pkg/hub/handlers_resource_import.go
+++ b/pkg/hub/handlers_resource_import.go
@@ -727,8 +727,6 @@ func (s *Server) handleResourcesDiscover(w http.ResponseWriter, r *http.Request)
 }
 
 // handleMessageChannels handles GET /api/v1/message-channels.
-//
-//nolint:unused // Kept for legacy message channel route compatibility.
 func (s *Server) handleMessageChannels(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed", nil)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2605,6 +2605,7 @@ func (s *Server) registerRoutes() {
 	// Message inbox endpoints (user-facing)
 	s.mux.HandleFunc("/api/v1/messages", s.handleMessages)
 	s.mux.HandleFunc("/api/v1/messages/", s.handleMessageRoutes)
+	s.mux.HandleFunc("/api/v1/message-channels", s.handleMessageChannels)
 
 	// WebSocket control channel endpoint for Runtime Brokers
 	s.mux.HandleFunc("/api/v1/runtime-brokers/connect", s.handleRuntimeBrokerConnect)


### PR DESCRIPTION
The handleMessageChannels handler existed but was never wired up in registerRoutes(), causing 404s for --channel flag in the CLI.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
