### PR TITLE
fix(config): handle branch names with slashes in GitHub URL parsing

### DIFF
--- a/pkg/config/remote_templates.go
+++ b/pkg/config/remote_templates.go
@@ -254,6 +254,7 @@ func resolveGitHubRef(ctx context.Context, parts *GitHubURLParts, token string) 
 	}
 
 	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--heads", repoURL)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_ASKPASS=echo")
 	output, err := cmd.Output()
 	if err != nil {
 		return
@@ -261,6 +262,7 @@ func resolveGitHubRef(ctx context.Context, parts *GitHubURLParts, token string) 
 
 	refs := make(map[string]bool)
 	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		line = strings.TrimRight(line, "\r")
 		if line == "" {
 			continue
 		}

--- a/pkg/config/remote_templates.go
+++ b/pkg/config/remote_templates.go
@@ -221,6 +221,9 @@ func fetchGitHubFolder(ctx context.Context, uri string, destPath string, token s
 		return err
 	}
 
+	// Resolve branch names that may contain slashes
+	resolveGitHubRef(ctx, parsed, token)
+
 	// Try GitHub tarball download first (works without git installed)
 	if err := fetchGitHubTarball(ctx, parsed, destPath, token); err == nil {
 		return nil
@@ -228,6 +231,70 @@ func fetchGitHubFolder(ctx context.Context, uri string, destPath string, token s
 
 	// Fall back to sparse git checkout
 	return sparseGitCheckout(ctx, parsed, destPath, token)
+}
+
+// resolveGitHubRef uses git ls-remote to disambiguate branch names that may
+// contain slashes. It updates parts.Branch and parts.Path in place.
+// Falls back silently to the naive parse if git is unavailable.
+func resolveGitHubRef(ctx context.Context, parts *GitHubURLParts, token string) {
+	afterTree := parts.Branch
+	if parts.Path != "" {
+		afterTree = parts.Branch + "/" + parts.Path
+	}
+
+	if !strings.Contains(afterTree, "/") {
+		return
+	}
+
+	var repoURL string
+	if token != "" {
+		repoURL = fmt.Sprintf("https://x-access-token:%s@github.com/%s/%s.git", token, parts.Owner, parts.Repo)
+	} else {
+		repoURL = fmt.Sprintf("https://github.com/%s/%s.git", parts.Owner, parts.Repo)
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--heads", repoURL)
+	output, err := cmd.Output()
+	if err != nil {
+		return
+	}
+
+	refs := make(map[string]bool)
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.SplitN(line, "\t", 2)
+		if len(fields) == 2 {
+			ref := strings.TrimPrefix(fields[1], "refs/heads/")
+			refs[ref] = true
+		}
+	}
+
+	if branch, path, ok := matchBranchFromRefs(afterTree, refs); ok {
+		parts.Branch = branch
+		parts.Path = path
+	}
+}
+
+// matchBranchFromRefs finds the longest branch name from refs that is a prefix
+// of afterTree (the URL path segments after "tree/").
+func matchBranchFromRefs(afterTree string, refs map[string]bool) (branch, path string, found bool) {
+	bestMatch := ""
+	for ref := range refs {
+		if ref == afterTree || strings.HasPrefix(afterTree, ref+"/") {
+			if len(ref) > len(bestMatch) {
+				bestMatch = ref
+			}
+		}
+	}
+
+	if bestMatch == "" {
+		return "", "", false
+	}
+
+	rest := strings.TrimPrefix(afterTree, bestMatch)
+	return bestMatch, strings.TrimPrefix(rest, "/"), true
 }
 
 // fetchGitHubTarball downloads the repo tarball from GitHub and extracts the

--- a/pkg/config/remote_templates_test.go
+++ b/pkg/config/remote_templates_test.go
@@ -152,6 +152,85 @@ func TestParseGitHubURL(t *testing.T) {
 	}
 }
 
+func TestMatchBranchFromRefs(t *testing.T) {
+	tests := []struct {
+		name       string
+		afterTree  string
+		refs       map[string]bool
+		wantBranch string
+		wantPath   string
+		wantFound  bool
+	}{
+		{
+			name:       "simple branch with path",
+			afterTree:  "main/pkg/config",
+			refs:       map[string]bool{"main": true, "develop": true},
+			wantBranch: "main",
+			wantPath:   "pkg/config",
+			wantFound:  true,
+		},
+		{
+			name:       "branch with slash and path",
+			afterTree:  "scion/gh-copilot-harness-lead/harnesses/copilot",
+			refs:       map[string]bool{"main": true, "scion/gh-copilot-harness-lead": true},
+			wantBranch: "scion/gh-copilot-harness-lead",
+			wantPath:   "harnesses/copilot",
+			wantFound:  true,
+		},
+		{
+			name:       "branch with slash no remaining path",
+			afterTree:  "feature/branch-name",
+			refs:       map[string]bool{"feature/branch-name": true},
+			wantBranch: "feature/branch-name",
+			wantPath:   "",
+			wantFound:  true,
+		},
+		{
+			name:       "prefers longest matching ref",
+			afterTree:  "scion/feature/test/path",
+			refs:       map[string]bool{"scion": true, "scion/feature": true, "scion/feature/test": true},
+			wantBranch: "scion/feature/test",
+			wantPath:   "path",
+			wantFound:  true,
+		},
+		{
+			name:       "no matching ref",
+			afterTree:  "nonexistent/path",
+			refs:       map[string]bool{"main": true, "develop": true},
+			wantBranch: "",
+			wantPath:   "",
+			wantFound:  false,
+		},
+		{
+			name:       "exact match no path",
+			afterTree:  "main",
+			refs:       map[string]bool{"main": true},
+			wantBranch: "main",
+			wantPath:   "",
+			wantFound:  true,
+		},
+		{
+			name:       "ambiguous prefix resolved by longest match",
+			afterTree:  "release/v1/hotfix/file.go",
+			refs:       map[string]bool{"release": true, "release/v1": true, "release/v1/hotfix": true},
+			wantBranch: "release/v1/hotfix",
+			wantPath:   "file.go",
+			wantFound:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			branch, path, found := matchBranchFromRefs(tt.afterTree, tt.refs)
+			assert.Equal(t, tt.wantFound, found)
+			if found {
+				assert.Equal(t, tt.wantBranch, branch)
+				assert.Equal(t, tt.wantPath, path)
+			}
+		})
+	}
+}
+
 func TestNormalizeTemplateSourceURL(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
parseGitHubURL naively took only the first path segment after /tree/ as the branch name, breaking imports from URLs like
github.com/owner/repo/tree/scion/feature-branch/harnesses/copilot.

Add resolveGitHubRef which uses git ls-remote to list all remote branches and find the longest matching ref, correctly splitting branch from path. Called in fetchGitHubFolder before attempting download.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
