### PR TITLE
fix(codex): update no-auth hint to suggest `codex login --device-auth`

### DIFF
--- a/harnesses/codex/config.yaml
+++ b/harnesses/codex/config.yaml
@@ -74,7 +74,7 @@ no_auth:
   behavior: drop-to-shell
   message: |
     This agent started without credentials.
-    Run your Codex authentication setup.
+    Run: codex login --device-auth
     Then run: python3 /home/scion/.scion/harness/capture_auth.py
 auth:
   default_type: api-key


### PR DESCRIPTION
The generic "Run your Codex authentication setup" message didn't tell users which command to run. Replace it with the specific device-auth login command.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
