### PR TITLE
fix(sciontool): prevent __pycache__ creation during harness provision

### DIFF
--- a/cmd/sciontool/commands/harness.go
+++ b/cmd/sciontool/commands/harness.go
@@ -310,6 +310,7 @@ func minimalEnv(home string, m *containerProvisionManifest) []string {
 		"SCION_AGENT_WORKSPACE=" + m.AgentWorkspace,
 		"SCION_HARNESS_BUNDLE=" + m.HarnessBundleDir,
 		"SCION_HARNESS=" + m.HarnessConfig.Harness,
+		"PYTHONDONTWRITEBYTECODE=1",
 	}
 	for _, e := range os.Environ() {
 		if strings.HasPrefix(e, "SCION_") {


### PR DESCRIPTION
## Summary

- Adds `PYTHONDONTWRITEBYTECODE=1` to the `minimalEnv()` environment in `cmd/sciontool/commands/harness.go`, preventing Python from writing `.pyc` bytecache files during container provisioning.
- Fixes a permission-denied bug where `scion delete` fails because root-owned `__pycache__` files on bind-mounted agent homes cannot be removed by the host-user broker.
- The provisioner runs once per agent start, so bytecache provides zero performance benefit.

## Root Cause

On Docker (non-rootless), `sciontool init` runs pre-start hooks as root. When `provision.py` imports `scion_harness.py`, Python creates `__pycache__/*.pyc` files owned by root on the bind-mounted agent home directory. The broker process runs as the host user and cannot delete these root-owned files, causing agent deletion to fail.

## Test plan

- [x] `go build ./cmd/sciontool/` compiles successfully
- [x] `go test ./cmd/sciontool/...` passes
- [ ] Manual: create and delete an agent on Docker (non-rootless) — verify no `__pycache__` is created and deletion succeeds
