### PR TITLE
fix(web): clean dist directory before build to prevent stale chunk ac…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,9 @@ golangci-lint:
 ## web: Build the web frontend
 web:
 	@echo "Building web frontend..."
+	@rm -rf web/dist
 	@cd web && npm install && npm run build
+	@mkdir -p web/dist/client && touch web/dist/client/.gitkeep
 	@echo "Web frontend built."
 
 ## container-sciontool: Cross-compile sciontool for Linux containers
@@ -149,7 +151,8 @@ ci-full: fmt-check web web-typecheck lint compat-literals golangci-lint test-fas
 ## clean: Remove build artifacts
 clean:
 	@echo "Cleaning..."
-	@rm -rf $(BUILD_DIR) .build
+	@rm -rf $(BUILD_DIR) .build web/dist
+	@mkdir -p web/dist/client && touch web/dist/client/.gitkeep
 	@rm -f $(BINARY)
 	@echo "Done."
 


### PR DESCRIPTION
…cumulation

rm -rf web/dist before npm run build so old JS chunks don't persist across builds. Also include web/dist in the clean target. Restores the tracked .gitkeep after cleaning.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
