### PR TITLE
Add Apple Container as a build-capable runtime

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -87,7 +87,7 @@ field is updated to reference the built image.`,
 
 		runtimeBin := runtime.DetectContainerRuntime()
 		if runtimeBin == "" {
-			return fmt.Errorf("no container runtime found (tried docker, podman)")
+			return fmt.Errorf("no container runtime found (tried docker, podman, container)")
 		}
 
 		imageBaseName := harnessConfigName
@@ -133,7 +133,7 @@ field is updated to reference the built image.`,
 		}
 
 		if buildPush {
-			pushExec := exec.CommandContext(cmd.Context(), runtimeBin, "push", outputImage)
+			pushExec := exec.CommandContext(cmd.Context(), runtimeBin, "image", "push", outputImage)
 			pushExec.Stdout = os.Stdout
 			pushExec.Stderr = os.Stderr
 			if err := pushExec.Run(); err != nil {

--- a/pkg/hub/maintenance_executors.go
+++ b/pkg/hub/maintenance_executors.go
@@ -180,7 +180,7 @@ func (e *PullImagesExecutor) Run(ctx context.Context, logger io.Writer, params m
 		runtimeBin = scionruntime.DetectContainerRuntime()
 	}
 	if runtimeBin == "" {
-		return fmt.Errorf("no container runtime found (tried docker, podman)")
+		return fmt.Errorf("no container runtime found (tried docker, podman, container)")
 	}
 
 	harnesses := e.harnesses
@@ -540,7 +540,7 @@ func (e *BuildHarnessConfigImageExecutor) Run(ctx context.Context, logger io.Wri
 		runtimeBin = scionruntime.DetectContainerRuntime()
 	}
 	if runtimeBin == "" {
-		return fmt.Errorf("no container runtime found (tried docker, podman)")
+		return fmt.Errorf("no container runtime found (tried docker, podman, container)")
 	}
 
 	imageName := hc.Slug
@@ -566,7 +566,7 @@ func (e *BuildHarnessConfigImageExecutor) Run(ctx context.Context, logger io.Wri
 	if params["push"] == "true" && registry != "" {
 		pushImage := registry + "/" + outputImage
 		_, _ = fmt.Fprintf(logger, "Tagging %s as %s...\n", outputImage, pushImage)
-		tagCmd := exec.CommandContext(ctx, runtimeBin, "tag", outputImage, pushImage)
+		tagCmd := exec.CommandContext(ctx, runtimeBin, "image", "tag", outputImage, pushImage)
 		tagCmd.Stdout = logger
 		tagCmd.Stderr = logger
 		if err := tagCmd.Run(); err != nil {
@@ -574,7 +574,7 @@ func (e *BuildHarnessConfigImageExecutor) Run(ctx context.Context, logger io.Wri
 		}
 
 		_, _ = fmt.Fprintf(logger, "Pushing %s...\n", pushImage)
-		pushCmd := exec.CommandContext(ctx, runtimeBin, "push", pushImage)
+		pushCmd := exec.CommandContext(ctx, runtimeBin, "image", "push", pushImage)
 		pushCmd.Stdout = logger
 		pushCmd.Stderr = logger
 		if err := pushCmd.Run(); err != nil {

--- a/pkg/runtime/container.go
+++ b/pkg/runtime/container.go
@@ -14,12 +14,19 @@
 
 package runtime
 
-import "os/exec"
+import (
+	"os/exec"
+	goruntime "runtime"
+)
 
-// DetectContainerRuntime finds an available container CLI (docker or podman).
-// Returns the binary name, or "" if neither is found.
+// DetectContainerRuntime finds an available container CLI (docker, podman,
+// or container on macOS). Returns the binary name, or "" if none is found.
 func DetectContainerRuntime() string {
-	for _, bin := range []string{"docker", "podman"} {
+	candidates := []string{"docker", "podman"}
+	if goruntime.GOOS == "darwin" {
+		candidates = append(candidates, "container")
+	}
+	for _, bin := range candidates {
 		if p, err := exec.LookPath(bin); err == nil && p != "" {
 			return bin
 		}

--- a/web/src/components/pages/onboarding.ts
+++ b/web/src/components/pages/onboarding.ts
@@ -739,7 +739,7 @@ export class ScionPageOnboarding extends LitElement {
           >
             <sl-option value="docker">Docker</sl-option>
             <sl-option value="podman">Podman</sl-option>
-            <sl-option value="container">Container (generic)</sl-option>
+            <sl-option value="container">Apple Container</sl-option>
           </sl-select>
         </div>
       `}

--- a/web/src/components/pages/onboarding.ts
+++ b/web/src/components/pages/onboarding.ts
@@ -914,7 +914,7 @@ export class ScionPageOnboarding extends LitElement {
         <div class="alert alert-warning">
           <strong>No container runtime detected.</strong>
           <p>
-            Install Docker or Podman to pull or build images. You can skip this
+            Install Docker, Podman, or Apple Container to pull or build images. You can skip this
             step and configure a runtime later.
           </p>
         </div>


### PR DESCRIPTION
Add the `container` binary (Apple Virtualization framework) to DetectContainerRuntime() on macOS, alongside docker and podman.

Switch tag/push commands to use the `image` subcommand form (`image tag`, `image push`) which is compatible with all three runtimes. Update error messages and UI text to mention Apple Container.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
