### PR TITLE
fix(discord): require thread ID for forum channels to prevent broadcast

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1338,7 +1338,7 @@ func (b *DiscordBroker) isForumChannel(channelID string) bool {
 			return false
 		}
 		ch, err = session.Channel(channelID)
-		if err != nil {
+		if err != nil || ch == nil {
 			return false
 		}
 	}

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -590,6 +590,17 @@ func (b *DiscordBroker) Publish(ctx context.Context, topic string, msg *messages
 	// Send to each target channel.
 	var errs []error
 	for _, channelID := range channelIDs {
+		// Forum and media channels (types 15, 16) are thread-only containers.
+		// Sending without a thread ID would broadcast to an invalid target;
+		// return an error so callers know a thread ID is required.
+		if msg.ThreadID == "" && b.isForumChannel(channelID) {
+			errs = append(errs, fmt.Errorf(
+				"discord channel %s is a forum/media channel — a thread ID is required to send messages; omit the channel or specify a thread ID",
+				channelID,
+			))
+			continue
+		}
+
 		if needsFilter && store != nil {
 			link, linkErr := store.GetChannelLink(ctx, channelID)
 			if linkErr == nil && link != nil {
@@ -1282,7 +1293,7 @@ func (b *DiscordBroker) resolveThreadParent(channelID string) (parentID string, 
 		}
 	}
 
-	// Thread types: GuildPublicThread (11), GuildPrivateThread (12), GuildNewsThread (15)
+	// Thread types: GuildPublicThread (11), GuildPrivateThread (12), GuildNewsThread (10)
 	if ch.Type == discordgo.ChannelTypeGuildPublicThread ||
 		ch.Type == discordgo.ChannelTypeGuildPrivateThread ||
 		ch.Type == discordgo.ChannelTypeGuildNewsThread {
@@ -1303,6 +1314,37 @@ func (b *DiscordBroker) resolveThreadParent(channelID string) (parentID string, 
 	b.threadParents[channelID] = ""
 	b.mu.Unlock()
 	return "", false
+}
+
+// isForumChannel checks whether a Discord channel ID refers to a forum or media
+// channel (types 15 and 16). These channel types are thread-only containers and
+// cannot receive messages directly — a thread ID is required.
+func (b *DiscordBroker) isForumChannel(channelID string) bool {
+	session := b.session
+	if session == nil {
+		return false
+	}
+
+	var ch *discordgo.Channel
+	var err error
+	if session.State != nil {
+		ch, err = session.State.Channel(channelID)
+	}
+	if ch == nil || err != nil {
+		// Fall back to REST API only if the session has a Ratelimiter
+		// (i.e. is fully initialized). Avoids panics in tests and during
+		// early startup.
+		if session.Ratelimiter == nil {
+			return false
+		}
+		ch, err = session.Channel(channelID)
+		if err != nil {
+			return false
+		}
+	}
+
+	return ch.Type == discordgo.ChannelTypeGuildForum ||
+		ch.Type == discordgo.ChannelTypeGuildMedia
 }
 
 // resolveRecipientChannels looks up target channels for a specific recipient.

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -1,6 +1,7 @@
 package discord
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -10,9 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/bwmarrin/discordgo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 )
 
 func discardLogger() *slog.Logger {
@@ -192,4 +195,136 @@ func TestDeliverInbound_ReturnsHubError(t *testing.T) {
 		he := b.deliverInbound("test.topic", newTestStructuredMessage())
 		assert.Nil(t, he)
 	})
+}
+
+const testGuildID = "guild1"
+
+func stubSession(channels []*discordgo.Channel) *discordgo.Session {
+	s := &discordgo.Session{
+		State: discordgo.NewState(),
+	}
+	_ = s.State.GuildAdd(&discordgo.Guild{ID: testGuildID})
+	for _, ch := range channels {
+		if ch.GuildID == "" {
+			ch.GuildID = testGuildID
+		}
+		_ = s.State.ChannelAdd(ch)
+	}
+	return s
+}
+
+func testBroker(session *discordgo.Session) *DiscordBroker {
+	return &DiscordBroker{
+		session:       session,
+		log:           slog.Default(),
+		sentIDs:       make(map[string]time.Time),
+		threadParents: make(map[string]string),
+	}
+}
+
+func TestIsForumChannel(t *testing.T) {
+	tests := []struct {
+		name      string
+		chType    discordgo.ChannelType
+		wantForum bool
+	}{
+		{"text channel", discordgo.ChannelTypeGuildText, false},
+		{"DM channel", discordgo.ChannelTypeDM, false},
+		{"voice channel", discordgo.ChannelTypeGuildVoice, false},
+		{"category", discordgo.ChannelTypeGuildCategory, false},
+		{"news channel", discordgo.ChannelTypeGuildNews, false},
+		{"public thread", discordgo.ChannelTypeGuildPublicThread, false},
+		{"private thread", discordgo.ChannelTypeGuildPrivateThread, false},
+		{"news thread", discordgo.ChannelTypeGuildNewsThread, false},
+		{"stage voice", discordgo.ChannelTypeGuildStageVoice, false},
+		{"forum channel", discordgo.ChannelTypeGuildForum, true},
+		{"media channel", discordgo.ChannelTypeGuildMedia, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := stubSession([]*discordgo.Channel{
+				{ID: "ch1", Type: tt.chType},
+			})
+			b := &DiscordBroker{session: session}
+			assert.Equal(t, tt.wantForum, b.isForumChannel("ch1"))
+		})
+	}
+}
+
+func TestIsForumChannel_NilSession(t *testing.T) {
+	b := &DiscordBroker{}
+	assert.False(t, b.isForumChannel("ch1"))
+}
+
+func TestForumGuardCondition(t *testing.T) {
+	session := stubSession([]*discordgo.Channel{
+		{ID: "forum1", Type: discordgo.ChannelTypeGuildForum},
+		{ID: "media1", Type: discordgo.ChannelTypeGuildMedia},
+		{ID: "text1", Type: discordgo.ChannelTypeGuildText},
+	})
+	b := &DiscordBroker{session: session}
+
+	tests := []struct {
+		name      string
+		channelID string
+		threadID  string
+		wantBlock bool
+	}{
+		{"forum without threadID", "forum1", "", true},
+		{"forum with threadID", "forum1", "thread123", false},
+		{"media without threadID", "media1", "", true},
+		{"media with threadID", "media1", "thread456", false},
+		{"text without threadID", "text1", "", false},
+		{"text with threadID", "text1", "thread789", false},
+		{"unknown channel without threadID", "unknown", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blocked := tt.threadID == "" && b.isForumChannel(tt.channelID)
+			assert.Equal(t, tt.wantBlock, blocked)
+		})
+	}
+}
+
+func TestPublish_ForumChannelWithoutThreadID_ReturnsError(t *testing.T) {
+	session := stubSession([]*discordgo.Channel{
+		{ID: "forum123", Type: discordgo.ChannelTypeGuildForum},
+	})
+	b := testBroker(session)
+
+	msg := &messages.StructuredMessage{
+		Version:  messages.Version,
+		Channel:  "discord",
+		Sender:   "agent:test",
+		Msg:      "hello",
+		Type:     messages.TypeInstruction,
+		Metadata: map[string]string{"discord_channel_id": "forum123"},
+	}
+
+	err := b.Publish(context.Background(), "test-topic", msg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forum/media channel")
+	assert.Contains(t, err.Error(), "thread ID is required")
+}
+
+func TestPublish_MediaChannelWithoutThreadID_ReturnsError(t *testing.T) {
+	session := stubSession([]*discordgo.Channel{
+		{ID: "media123", Type: discordgo.ChannelTypeGuildMedia},
+	})
+	b := testBroker(session)
+
+	msg := &messages.StructuredMessage{
+		Version:  messages.Version,
+		Channel:  "discord",
+		Sender:   "agent:test",
+		Msg:      "hello",
+		Type:     messages.TypeInstruction,
+		Metadata: map[string]string{"discord_channel_id": "media123"},
+	}
+
+	err := b.Publish(context.Background(), "test-topic", msg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forum/media channel")
 }


### PR DESCRIPTION
Fixes : Discord forum channels were broadcasting messages to all threads when thread ID was omitted. Now validates channel type and requires thread ID for forum channels.
