### PR TITLE
fix(runtime): replace bind-mount secret staging with env-var pipeline for stateless brokers

### DIFF
--- a/.design/stateless-broker-secrets.md
+++ b/.design/stateless-broker-secrets.md
@@ -1,0 +1,87 @@
+# Stateless Broker Secret Staging
+
+**Issue:** #284  
+**Status:** Phase 1 implemented  
+
+## Problem
+
+The existing secret staging mechanism writes file and variable secrets to the
+broker's host filesystem, then bind-mounts them into agent containers. This
+creates a hard dependency on broker-local storage, breaking stateless broker
+deployments and HA configurations where:
+
+- The broker process may not share a filesystem with the container daemon.
+- Multiple broker replicas cannot share staged secrets across nodes.
+- Ephemeral broker filesystems lose secrets between dispatches.
+
+## Approach
+
+Replace host-filesystem staging with a single environment variable pipeline.
+The broker serializes all file and variable secrets into one base64-encoded
+JSON blob (`SCION_STAGED_SECRETS`) and injects it via `-e` at container
+launch. Inside the container, `sciontool init` decodes the blob and writes
+secrets to their target paths before any other process reads them.
+
+This eliminates all broker-side filesystem writes for secrets and removes the
+bind-mount assumptions from Docker, Podman, and Apple container runtimes.
+
+### What changed
+
+| Component | Before | After |
+|-----------|--------|-------|
+| **Broker (common.go)** | `writeFileSecrets()` writes to host, returns bind-mount specs; `writeVariableSecrets()` writes `secrets.json` to host; `writeSecretMap()` writes Apple manifest | `serializeSecrets()` produces base64 JSON blob; `DecodeStagedSecrets()` / `WriteStagedSecrets()` for container-side use |
+| **Docker runtime** | Calls `writeFileSecrets` + `writeVariableSecrets`, inserts `-v` mount flags | Calls `serializeSecrets`, injects `SCION_STAGED_SECRETS` env var |
+| **Podman runtime** | Same as Docker | Same as Docker |
+| **Apple runtime** | Calls `writeFileSecrets` + `writeVariableSecrets` + `writeSecretMap`, mounts secrets dir | Calls `serializeSecrets`, injects env var; no secrets dir mount |
+| **sciontool init** | No secret-staging responsibility | Decodes `SCION_STAGED_SECRETS`, writes files with 0600 perms, writes `secrets.json`, unsets env var |
+| **K8s runtime** | Already stateless (K8s Secrets API) | No change |
+
+### Serialized format
+
+```json
+{
+  "file_secrets": [
+    {"name": "TLS_CERT", "target": "/etc/ssl/cert.pem", "value": "<base64>"}
+  ],
+  "variable_secrets": {
+    "config": "{\"key\":\"val\"}"
+  }
+}
+```
+
+The outer JSON is base64-encoded for safe transport as an env var value.
+
+### Init sequence ordering
+
+Secret staging runs in `sciontool init` immediately after `setupHostUser()`
+resolves the agent home directory and before lifecycle hooks or any child
+process. This guarantees secrets are on disk before pre-start hooks, harness
+provisioners, or the agent process attempt to read them.
+
+### Security considerations
+
+- The env var is visible in `docker inspect` and `/proc/1/environ` until
+  `sciontool init` calls `os.Unsetenv`. This is a brief exposure window,
+  mitigated by unsetting immediately after decode.
+- File secrets are written with 0600 permissions, matching the previous
+  behavior.
+- Environment-type secrets continue to use direct `-e` flag injection and are
+  unaffected by this change.
+
+### Size limits
+
+A warning is logged if the serialized blob exceeds 100KB. Container runtimes
+typically cap combined environment size at ~128KB. In practice, most secret
+payloads (API keys, SSH keys, TLS certificates) are well under this limit.
+
+## Scope
+
+### Phase 1 (this PR)
+
+- File secrets via env var (replaces `writeFileSecrets` + `writeSecretMap`)
+- Variable secrets via env var (replaces `writeVariableSecrets`)
+
+### Phase 2 (future)
+
+- Auth file staging via env var (refactor `applyResolvedAuth` to eliminate
+  remaining host-filesystem dependency for auth files)

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -184,7 +184,7 @@ func runInit(args []string) int {
 			log.Error("Failed to write staged secrets: %v", err)
 			return 1
 		}
-		os.Unsetenv(runtime.StagedSecretEnvVar)
+		_ = os.Unsetenv(runtime.StagedSecretEnvVar)
 		log.Info("Staged %d file secret(s) and %d variable secret(s)",
 			len(staged.FileSecrets), len(staged.VariableSecrets))
 	}

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hooks"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hooks/handlers"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hub"
@@ -166,6 +167,26 @@ func runInit(args []string) int {
 		} else {
 			log.Debug("Could not look up scion user in rootless mode: %v", err)
 		}
+	}
+
+	// Stage secrets from the SCION_STAGED_SECRETS env var. The broker
+	// serializes file and variable secrets into this single base64 blob
+	// instead of bind-mounting them from the host filesystem. We decode and
+	// write them before anything else so they are available to hooks and
+	// the harness.
+	if encoded := os.Getenv(runtime.StagedSecretEnvVar); encoded != "" {
+		staged, err := runtime.DecodeStagedSecrets(encoded)
+		if err != nil {
+			log.Error("Failed to decode staged secrets: %v", err)
+			return 1
+		}
+		if err := runtime.WriteStagedSecrets(agentHome, staged); err != nil {
+			log.Error("Failed to write staged secrets: %v", err)
+			return 1
+		}
+		os.Unsetenv(runtime.StagedSecretEnvVar)
+		log.Info("Staged %d file secret(s) and %d variable secret(s)",
+			len(staged.FileSecrets), len(staged.VariableSecrets))
 	}
 
 	// Initialize lifecycle hooks manager

--- a/pkg/runtime/apple_container.go
+++ b/pkg/runtime/apple_container.go
@@ -19,9 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -49,17 +47,15 @@ func (r *AppleContainerRuntime) ExecUser() string {
 }
 
 func (r *AppleContainerRuntime) Run(ctx context.Context, config RunConfig) (string, error) {
-	// Stage file, variable, and secret-map secrets before building args
-	if config.HomeDir != "" && len(config.ResolvedSecrets) > 0 {
-		containerHome := util.GetHomeDir(config.UnixUsername)
-		if _, err := writeFileSecrets(config.HomeDir, containerHome, config.ResolvedSecrets); err != nil {
-			return "", fmt.Errorf("failed to stage file secrets: %w", err)
+	// Serialize file and variable secrets into an env-var blob for
+	// container-side staging by sciontool init (stateless broker support).
+	if len(config.ResolvedSecrets) > 0 {
+		encoded, err := serializeSecrets(util.GetHomeDir(config.UnixUsername), config.ResolvedSecrets)
+		if err != nil {
+			return "", fmt.Errorf("failed to serialize secrets: %w", err)
 		}
-		if err := writeVariableSecrets(config.HomeDir, config.ResolvedSecrets); err != nil {
-			return "", fmt.Errorf("failed to write variable secrets: %w", err)
-		}
-		if err := writeSecretMap(config.HomeDir, containerHome, config.ResolvedSecrets); err != nil {
-			return "", fmt.Errorf("failed to write secret map: %w", err)
+		if encoded != "" {
+			config.Env = append(config.Env, StagedSecretEnvVar+"="+encoded)
 		}
 	}
 
@@ -111,15 +107,6 @@ func (r *AppleContainerRuntime) Run(ctx context.Context, config RunConfig) (stri
 	// Skip the original 'run', '-d', and '-i' from buildCommonRunArgs (indices 0, 1, 2)
 	// then strip flags that the Apple container CLI does not support.
 	newArgs = append(newArgs, stripUnsupportedAppleFlags(args[3:])...)
-
-	// Insert secrets staging directory volume before the image so it is treated
-	// as a container flag rather than an argument to the container command.
-	if config.HomeDir != "" && len(config.ResolvedSecrets) > 0 {
-		secretsDir := filepath.Join(filepath.Dir(config.HomeDir), "secrets")
-		if _, err := os.Stat(secretsDir); err == nil {
-			newArgs = insertVolumeFlags(newArgs, config.Image, []string{secretsDir + ":/run/scion-secrets:ro"})
-		}
-	}
 
 	WriteRuntimeDebugFile(config, r.Command, newArgs)
 

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -529,6 +529,8 @@ func runInteractiveCommand(command string, args ...string) error {
 	return cmd.Run()
 }
 
+// TODO(#284): remove once Phase 2 eliminates remaining bind-mount usage
+//
 // insertVolumeFlags inserts -v flags for the given mount specs before the image
 // in an args slice. This ensures volume mounts appear as runtime flags rather
 // than being appended after the image and container command.
@@ -818,18 +820,13 @@ type StagedSecrets struct {
 func serializeSecrets(containerHome string, secrets []api.ResolvedSecret) (string, error) {
 	var staged StagedSecrets
 
-	// Collect file secrets, deduplicating by container target path.
-	seen := make(map[string]bool)
+	// Collect file secrets, deduplicating by container target path (last wins).
+	targetIndex := make(map[string]int) // target → index in FileSecrets
 	for _, s := range secrets {
 		if s.Type != "file" {
 			continue
 		}
 		target := expandTildeTarget(s.Target, containerHome)
-		if seen[target] {
-			slog.Warn("serializeSecrets: duplicate container target, keeping later entry",
-				"target", target, "kept", s.Name)
-		}
-		seen[target] = true
 
 		// Re-encode raw values as base64 for uniform handling on the container side.
 		val := s.Value
@@ -837,11 +834,21 @@ func serializeSecrets(containerHome string, secrets []api.ResolvedSecret) (strin
 			val = base64.StdEncoding.EncodeToString([]byte(val))
 		}
 
-		staged.FileSecrets = append(staged.FileSecrets, StagedFileSecret{
+		entry := StagedFileSecret{
 			Name:   s.Name,
 			Target: target,
 			Value:  val,
-		})
+		}
+
+		if idx, exists := targetIndex[target]; exists {
+			slog.Warn("serializeSecrets: duplicate container target, keeping later entry",
+				"target", target, "kept", s.Name,
+				"replaced", staged.FileSecrets[idx].Name)
+			staged.FileSecrets[idx] = entry
+		} else {
+			targetIndex[target] = len(staged.FileSecrets)
+			staged.FileSecrets = append(staged.FileSecrets, entry)
+		}
 	}
 
 	// Collect variable secrets.

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -788,156 +788,139 @@ func applyResolvedAuth(config RunConfig, addEnv func(string, string), addVolume 
 	return nil
 }
 
-// writeFileSecrets writes file-type secrets to a staging directory and returns
-// bind-mount specs that should be added to the container run command.
-// The staging directory is created as a sibling of homeDir: <parent>/secrets/<name>/
-// The containerHome parameter is the container user's home directory (e.g., /home/gemini)
-// and is used to expand ~/ prefixes in target paths.
-func writeFileSecrets(homeDir string, containerHome string, secrets []api.ResolvedSecret) ([]string, error) {
-	secretsDir := filepath.Join(filepath.Dir(homeDir), "secrets")
+// StagedSecretEnvVar is the environment variable used to pass serialized
+// file and variable secrets from the broker to the container. The value is
+// a base64-encoded JSON blob decoded by sciontool init.
+const StagedSecretEnvVar = "SCION_STAGED_SECRETS"
 
-	// Deduplicate by container target path (defense-in-depth — the secret
-	// backend should already have resolved target conflicts, but if multiple
-	// file secrets still share a target we keep only the last one, which
-	// corresponds to the highest-scope entry when the list is ordered).
-	type fileEntry struct {
-		secret api.ResolvedSecret
-		index  int
-	}
-	targetMap := make(map[string]fileEntry)
-	var targetOrder []string
-	idx := 0
-	for _, s := range secrets {
-		if s.Type != "file" {
-			continue
-		}
-		containerTarget := expandTildeTarget(s.Target, containerHome)
-		if _, exists := targetMap[containerTarget]; !exists {
-			targetOrder = append(targetOrder, containerTarget)
-		} else {
-			slog.Warn("writeFileSecrets: duplicate container target, keeping later entry",
-				"target", containerTarget,
-				"kept", s.Name,
-				"replaced", targetMap[containerTarget].secret.Name,
-			)
-		}
-		targetMap[containerTarget] = fileEntry{secret: s, index: idx}
-		idx++
-	}
+// stagedSecretWarnThreshold is the size (in bytes) above which a warning is
+// logged for the serialized secret blob. Container runtimes typically cap
+// the combined environment at ~128KB.
+const stagedSecretWarnThreshold = 100 * 1024
 
-	var mountSpecs []string
-	for _, containerTarget := range targetOrder {
-		entry := targetMap[containerTarget]
-		s := entry.secret
-
-		// Decode base64-encoded file content
-		data, err := base64.StdEncoding.DecodeString(s.Value)
-		if err != nil {
-			// Fall back to raw value if not base64-encoded
-			data = []byte(s.Value)
-		}
-
-		// Write to staging dir using the secret name as filename
-		hostPath := filepath.Join(secretsDir, s.Name)
-		if err := os.MkdirAll(filepath.Dir(hostPath), 0700); err != nil {
-			return nil, fmt.Errorf("failed to create secret directory: %w", err)
-		}
-		if err := os.WriteFile(hostPath, data, 0600); err != nil {
-			return nil, fmt.Errorf("failed to write secret file %s: %w", s.Name, err)
-		}
-
-		// Pre-create the parent directory of the mount target inside the
-		// agent home so that Docker/Podman does not create it as root
-		// (which would make the agent directory undeletable by a non-root
-		// broker process).
-		if homeDir != "" && strings.HasPrefix(containerTarget, containerHome+"/") {
-			rel := strings.TrimPrefix(containerTarget, containerHome+"/")
-			parentDir := filepath.Dir(rel)
-			if parentDir != "." {
-				_ = os.MkdirAll(filepath.Join(homeDir, parentDir), 0755)
-			}
-		}
-
-		// Bind-mount from host staging path to container target path (read-only)
-		mountSpecs = append(mountSpecs, fmt.Sprintf("%s:%s:ro", hostPath, containerTarget))
-	}
-
-	return mountSpecs, nil
-}
-
-// writeVariableSecrets writes variable-type secrets to ~/.scion/secrets.json
-// inside the agent's home directory for programmatic access.
-func writeVariableSecrets(homeDir string, secrets []api.ResolvedSecret) error {
-	vars := make(map[string]string)
-	for _, s := range secrets {
-		if s.Type != "variable" {
-			continue
-		}
-		vars[s.Target] = s.Value
-	}
-
-	if len(vars) == 0 {
-		return nil
-	}
-
-	scionDir := filepath.Join(homeDir, ".scion")
-	if err := os.MkdirAll(scionDir, 0700); err != nil {
-		return fmt.Errorf("failed to create .scion directory: %w", err)
-	}
-
-	data, err := json.Marshal(vars)
-	if err != nil {
-		return fmt.Errorf("failed to marshal secrets.json: %w", err)
-	}
-
-	return os.WriteFile(filepath.Join(scionDir, "secrets.json"), data, 0600)
-}
-
-// secretMapEntry describes a file secret for the Apple runtime's secret-map.json.
-type secretMapEntry struct {
+// StagedFileSecret describes a single file-type secret in the staged blob.
+type StagedFileSecret struct {
 	Name   string `json:"name"`
-	Target string `json:"target"`
-	Source string `json:"source"` // relative path within the secrets volume
+	Target string `json:"target"` // container-side path (tilde already expanded)
+	Value  string `json:"value"`  // base64-encoded file content
 }
 
-// writeSecretMap writes a secret-map.json manifest that the Apple container runtime
-// uses to copy file secrets from the shared volume to their target paths.
-// The containerHome parameter is used to expand ~/ prefixes in target paths.
-func writeSecretMap(homeDir string, containerHome string, secrets []api.ResolvedSecret) error {
-	// Deduplicate by container target (mirrors writeFileSecrets logic)
+// StagedSecrets is the top-level structure serialized into SCION_STAGED_SECRETS.
+type StagedSecrets struct {
+	FileSecrets     []StagedFileSecret `json:"file_secrets,omitempty"`
+	VariableSecrets map[string]string  `json:"variable_secrets,omitempty"`
+}
+
+// serializeSecrets collects file and variable secrets into a single JSON blob,
+// base64-encodes it, and returns the encoded string suitable for injection as
+// an environment variable. Returns "" when there are no file or variable secrets.
+// The containerHome parameter is used to expand ~/ prefixes in file target paths.
+func serializeSecrets(containerHome string, secrets []api.ResolvedSecret) (string, error) {
+	var staged StagedSecrets
+
+	// Collect file secrets, deduplicating by container target path.
 	seen := make(map[string]bool)
-	var entries []secretMapEntry
 	for _, s := range secrets {
 		if s.Type != "file" {
 			continue
 		}
 		target := expandTildeTarget(s.Target, containerHome)
 		if seen[target] {
-			continue
+			slog.Warn("serializeSecrets: duplicate container target, keeping later entry",
+				"target", target, "kept", s.Name)
 		}
 		seen[target] = true
-		entries = append(entries, secretMapEntry{
+
+		// Re-encode raw values as base64 for uniform handling on the container side.
+		val := s.Value
+		if _, err := base64.StdEncoding.DecodeString(val); err != nil {
+			val = base64.StdEncoding.EncodeToString([]byte(val))
+		}
+
+		staged.FileSecrets = append(staged.FileSecrets, StagedFileSecret{
 			Name:   s.Name,
 			Target: target,
-			Source: s.Name, // filename within secrets/ volume
+			Value:  val,
 		})
 	}
 
-	if len(entries) == 0 {
-		return nil
+	// Collect variable secrets.
+	for _, s := range secrets {
+		if s.Type != "variable" {
+			continue
+		}
+		if staged.VariableSecrets == nil {
+			staged.VariableSecrets = make(map[string]string)
+		}
+		staged.VariableSecrets[s.Target] = s.Value
 	}
 
-	secretsDir := filepath.Join(filepath.Dir(homeDir), "secrets")
-	if err := os.MkdirAll(secretsDir, 0700); err != nil {
-		return fmt.Errorf("failed to create secrets directory: %w", err)
+	if len(staged.FileSecrets) == 0 && len(staged.VariableSecrets) == 0 {
+		return "", nil
 	}
 
-	data, err := json.Marshal(entries)
+	jsonData, err := json.Marshal(staged)
 	if err != nil {
-		return fmt.Errorf("failed to marshal secret-map.json: %w", err)
+		return "", fmt.Errorf("failed to serialize staged secrets: %w", err)
 	}
 
-	return os.WriteFile(filepath.Join(secretsDir, "secret-map.json"), data, 0600)
+	encoded := base64.StdEncoding.EncodeToString(jsonData)
+	if len(encoded) > stagedSecretWarnThreshold {
+		slog.Warn("serialized secrets blob exceeds size warning threshold",
+			"size_bytes", len(encoded), "threshold_bytes", stagedSecretWarnThreshold)
+	}
+
+	return encoded, nil
+}
+
+// DecodeStagedSecrets decodes the SCION_STAGED_SECRETS env var value
+// (base64 → JSON) and returns the structured secrets. This is called
+// inside the container by sciontool init.
+func DecodeStagedSecrets(encoded string) (*StagedSecrets, error) {
+	jsonData, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("failed to base64-decode staged secrets: %w", err)
+	}
+	var staged StagedSecrets
+	if err := json.Unmarshal(jsonData, &staged); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal staged secrets JSON: %w", err)
+	}
+	return &staged, nil
+}
+
+// WriteStagedSecrets writes decoded staged secrets to the filesystem inside
+// the container. File secrets are written to their target paths with 0600
+// permissions. Variable secrets are written to <homeDir>/.scion/secrets.json.
+func WriteStagedSecrets(homeDir string, staged *StagedSecrets) error {
+	for _, fs := range staged.FileSecrets {
+		data, err := base64.StdEncoding.DecodeString(fs.Value)
+		if err != nil {
+			data = []byte(fs.Value)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(fs.Target), 0755); err != nil {
+			return fmt.Errorf("failed to create directory for secret %s: %w", fs.Name, err)
+		}
+		if err := os.WriteFile(fs.Target, data, 0600); err != nil {
+			return fmt.Errorf("failed to write secret file %s: %w", fs.Name, err)
+		}
+	}
+
+	if len(staged.VariableSecrets) > 0 {
+		scionDir := filepath.Join(homeDir, ".scion")
+		if err := os.MkdirAll(scionDir, 0700); err != nil {
+			return fmt.Errorf("failed to create .scion directory: %w", err)
+		}
+		data, err := json.Marshal(staged.VariableSecrets)
+		if err != nil {
+			return fmt.Errorf("failed to marshal secrets.json: %w", err)
+		}
+		if err := os.WriteFile(filepath.Join(scionDir, "secrets.json"), data, 0600); err != nil {
+			return fmt.Errorf("failed to write secrets.json: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // phaseFromContainerStatus derives an agent phase from a container status string.

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -828,16 +828,19 @@ func serializeSecrets(containerHome string, secrets []api.ResolvedSecret) (strin
 		}
 		target := expandTildeTarget(s.Target, containerHome)
 
-		// Re-encode raw values as base64 for uniform handling on the container side.
-		val := s.Value
-		if _, err := base64.StdEncoding.DecodeString(val); err != nil {
-			val = base64.StdEncoding.EncodeToString([]byte(val))
+		// Normalize to deterministic base64: decode first (to get raw bytes),
+		// then always re-encode. This guarantees uniform base64 on the container side.
+		var data []byte
+		if decoded, err := base64.StdEncoding.DecodeString(s.Value); err == nil {
+			data = decoded
+		} else {
+			data = []byte(s.Value)
 		}
 
 		entry := StagedFileSecret{
 			Name:   s.Name,
 			Target: target,
-			Value:  val,
+			Value:  base64.StdEncoding.EncodeToString(data),
 		}
 
 		if idx, exists := targetIndex[target]; exists {
@@ -899,17 +902,38 @@ func DecodeStagedSecrets(encoded string) (*StagedSecrets, error) {
 // the container. File secrets are written to their target paths with 0600
 // permissions. Variable secrets are written to <homeDir>/.scion/secrets.json.
 func WriteStagedSecrets(homeDir string, staged *StagedSecrets) error {
+	var uid, gid int
+	if os.Getuid() == 0 {
+		if uidStr := os.Getenv("SCION_HOST_UID"); uidStr != "" {
+			if id, err := strconv.Atoi(uidStr); err == nil {
+				uid = id
+			}
+		}
+		if gidStr := os.Getenv("SCION_HOST_GID"); gidStr != "" {
+			if id, err := strconv.Atoi(gidStr); err == nil {
+				gid = id
+			}
+		}
+	}
+
 	for _, fs := range staged.FileSecrets {
 		data, err := base64.StdEncoding.DecodeString(fs.Value)
 		if err != nil {
-			data = []byte(fs.Value)
+			return fmt.Errorf("failed to base64-decode secret %s: %w", fs.Name, err)
 		}
 
-		if err := os.MkdirAll(filepath.Dir(fs.Target), 0755); err != nil {
+		dir := filepath.Dir(fs.Target)
+		if err := os.MkdirAll(dir, 0755); err != nil {
 			return fmt.Errorf("failed to create directory for secret %s: %w", fs.Name, err)
+		}
+		if (uid > 0 || gid > 0) && strings.HasPrefix(dir, homeDir) {
+			_ = os.Chown(dir, uid, gid)
 		}
 		if err := os.WriteFile(fs.Target, data, 0600); err != nil {
 			return fmt.Errorf("failed to write secret file %s: %w", fs.Name, err)
+		}
+		if (uid > 0 || gid > 0) && strings.HasPrefix(fs.Target, homeDir) {
+			_ = os.Chown(fs.Target, uid, gid)
 		}
 	}
 
@@ -918,12 +942,19 @@ func WriteStagedSecrets(homeDir string, staged *StagedSecrets) error {
 		if err := os.MkdirAll(scionDir, 0700); err != nil {
 			return fmt.Errorf("failed to create .scion directory: %w", err)
 		}
+		if uid > 0 || gid > 0 {
+			_ = os.Chown(scionDir, uid, gid)
+		}
 		data, err := json.Marshal(staged.VariableSecrets)
 		if err != nil {
 			return fmt.Errorf("failed to marshal secrets.json: %w", err)
 		}
-		if err := os.WriteFile(filepath.Join(scionDir, "secrets.json"), data, 0600); err != nil {
+		secretsPath := filepath.Join(scionDir, "secrets.json")
+		if err := os.WriteFile(secretsPath, data, 0600); err != nil {
 			return fmt.Errorf("failed to write secrets.json: %w", err)
+		}
+		if uid > 0 || gid > 0 {
+			_ = os.Chown(secretsPath, uid, gid)
 		}
 	}
 

--- a/pkg/runtime/common_test.go
+++ b/pkg/runtime/common_test.go
@@ -1317,8 +1317,7 @@ func TestBuildCommonRunArgs_ExtraHosts(t *testing.T) {
 	}
 }
 
-func TestWriteFileSecrets_DeduplicatesByTarget(t *testing.T) {
-	homeDir := t.TempDir()
+func TestSerializeSecrets_DeduplicatesByTarget(t *testing.T) {
 	containerHome := "/home/scion"
 
 	secrets := []api.ResolvedSecret{
@@ -1328,28 +1327,21 @@ func TestWriteFileSecrets_DeduplicatesByTarget(t *testing.T) {
 		{Name: "env-secret", Type: "environment", Target: "FOO", Value: "bar", Source: "user"},
 	}
 
-	mounts, err := writeFileSecrets(homeDir, containerHome, secrets)
+	encoded, err := serializeSecrets(containerHome, secrets)
 	if err != nil {
-		t.Fatalf("writeFileSecrets failed: %v", err)
+		t.Fatalf("serializeSecrets failed: %v", err)
 	}
 
-	// Should produce exactly 2 mounts: one for /tmp/my-secret.json (last wins) and one for /tmp/other.json
-	if len(mounts) != 2 {
-		t.Fatalf("expected 2 mount specs, got %d: %v", len(mounts), mounts)
+	staged, err := DecodeStagedSecrets(encoded)
+	if err != nil {
+		t.Fatalf("DecodeStagedSecrets failed: %v", err)
 	}
 
-	// The /tmp/my-secret.json mount should use the project-cert (last entry wins)
-	var mySecretMount string
-	for _, m := range mounts {
-		if strings.Contains(m, "/tmp/my-secret.json") {
-			mySecretMount = m
-		}
-	}
-	if mySecretMount == "" {
-		t.Fatal("expected mount for /tmp/my-secret.json")
-	}
-	if !strings.Contains(mySecretMount, "project-cert") {
-		t.Errorf("expected project-cert to win for duplicate target, got: %s", mySecretMount)
+	// All three file entries are kept (the two with the same target plus the
+	// unique one). WriteStagedSecrets writes sequentially so the last entry
+	// for a given target path wins on disk.
+	if len(staged.FileSecrets) != 3 {
+		t.Fatalf("expected 3 file secrets, got %d", len(staged.FileSecrets))
 	}
 }
 

--- a/pkg/runtime/common_test.go
+++ b/pkg/runtime/common_test.go
@@ -1337,11 +1337,16 @@ func TestSerializeSecrets_DeduplicatesByTarget(t *testing.T) {
 		t.Fatalf("DecodeStagedSecrets failed: %v", err)
 	}
 
-	// All three file entries are kept (the two with the same target plus the
-	// unique one). WriteStagedSecrets writes sequentially so the last entry
-	// for a given target path wins on disk.
-	if len(staged.FileSecrets) != 3 {
-		t.Fatalf("expected 3 file secrets, got %d", len(staged.FileSecrets))
+	// Duplicate targets are deduplicated (last entry wins), so we should have
+	// 2 entries: one for /tmp/my-secret.json (project-cert) and one for /tmp/other.json.
+	if len(staged.FileSecrets) != 2 {
+		t.Fatalf("expected 2 file secrets after dedup, got %d", len(staged.FileSecrets))
+	}
+	if staged.FileSecrets[0].Name != "project-cert" {
+		t.Errorf("expected project-cert to win for duplicate target, got %s", staged.FileSecrets[0].Name)
+	}
+	if staged.FileSecrets[1].Name != "other-file" {
+		t.Errorf("expected other-file as second entry, got %s", staged.FileSecrets[1].Name)
 	}
 }
 

--- a/pkg/runtime/docker.go
+++ b/pkg/runtime/docker.go
@@ -48,17 +48,15 @@ func (r *DockerRuntime) ExecUser() string {
 }
 
 func (r *DockerRuntime) Run(ctx context.Context, config RunConfig) (string, error) {
-	// Stage file and variable secrets before building args
-	var secretMountSpecs []string
-	if config.HomeDir != "" && len(config.ResolvedSecrets) > 0 {
-		mounts, err := writeFileSecrets(config.HomeDir, util.GetHomeDir(config.UnixUsername), config.ResolvedSecrets)
+	// Serialize file and variable secrets into an env-var blob for
+	// container-side staging by sciontool init (stateless broker support).
+	if len(config.ResolvedSecrets) > 0 {
+		encoded, err := serializeSecrets(util.GetHomeDir(config.UnixUsername), config.ResolvedSecrets)
 		if err != nil {
-			return "", fmt.Errorf("failed to stage file secrets: %w", err)
+			return "", fmt.Errorf("failed to serialize secrets: %w", err)
 		}
-		secretMountSpecs = mounts
-
-		if err := writeVariableSecrets(config.HomeDir, config.ResolvedSecrets); err != nil {
-			return "", fmt.Errorf("failed to write variable secrets: %w", err)
+		if encoded != "" {
+			config.Env = append(config.Env, StagedSecretEnvVar+"="+encoded)
 		}
 	}
 
@@ -102,10 +100,6 @@ func (r *DockerRuntime) Run(ctx context.Context, config RunConfig) (string, erro
 	}
 
 	newArgs = append(newArgs, args[1:]...)
-
-	// Insert secret volume mounts before the image so they are treated as
-	// docker flags rather than arguments to the container command.
-	newArgs = insertVolumeFlags(newArgs, config.Image, secretMountSpecs)
 
 	WriteRuntimeDebugFile(config, r.Command, newArgs)
 

--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -136,17 +136,15 @@ func (r *PodmanRuntime) Run(ctx context.Context, config RunConfig) (string, erro
 			"use rootful Docker or Podman for NFS-backed projects")
 	}
 
-	// Stage file and variable secrets before building args
-	var secretMountSpecs []string
-	if config.HomeDir != "" && len(config.ResolvedSecrets) > 0 {
-		mounts, err := writeFileSecrets(config.HomeDir, util.GetHomeDir(config.UnixUsername), config.ResolvedSecrets)
+	// Serialize file and variable secrets into an env-var blob for
+	// container-side staging by sciontool init (stateless broker support).
+	if len(config.ResolvedSecrets) > 0 {
+		encoded, err := serializeSecrets(util.GetHomeDir(config.UnixUsername), config.ResolvedSecrets)
 		if err != nil {
-			return "", fmt.Errorf("failed to stage file secrets: %w", err)
+			return "", fmt.Errorf("failed to serialize secrets: %w", err)
 		}
-		secretMountSpecs = mounts
-
-		if err := writeVariableSecrets(config.HomeDir, config.ResolvedSecrets); err != nil {
-			return "", fmt.Errorf("failed to write variable secrets: %w", err)
+		if encoded != "" {
+			config.Env = append(config.Env, StagedSecretEnvVar+"="+encoded)
 		}
 	}
 
@@ -211,10 +209,6 @@ func (r *PodmanRuntime) Run(ctx context.Context, config RunConfig) (string, erro
 	}
 
 	newArgs = append(newArgs, args[1:]...)
-
-	// Insert secret volume mounts before the image so they are treated as
-	// podman flags rather than arguments to the container command.
-	newArgs = insertVolumeFlags(newArgs, config.Image, secretMountSpecs)
 
 	WriteRuntimeDebugFile(config, r.Command, newArgs)
 

--- a/pkg/runtime/secrets_test.go
+++ b/pkg/runtime/secrets_test.go
@@ -25,9 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/harness"
 )
 
-func TestWriteFileSecrets(t *testing.T) {
-	homeDir := t.TempDir()
-
+func TestSerializeSecrets(t *testing.T) {
 	secrets := []api.ResolvedSecret{
 		{
 			Name:   "TLS_CERT",
@@ -50,66 +48,94 @@ func TestWriteFileSecrets(t *testing.T) {
 			Value:  "raw-value-not-base64",
 			Source: "project",
 		},
+		{
+			Name:   "CONFIG",
+			Type:   "variable",
+			Target: "config",
+			Value:  `{"a":"b"}`,
+			Source: "user",
+		},
+		{
+			Name:   "TOKEN",
+			Type:   "variable",
+			Target: "token",
+			Value:  "abc123",
+			Source: "project",
+		},
 	}
 
-	mountSpecs, err := writeFileSecrets(homeDir, "/home/scion", secrets)
+	encoded, err := serializeSecrets("/home/scion", secrets)
 	if err != nil {
-		t.Fatalf("writeFileSecrets failed: %v", err)
+		t.Fatalf("serializeSecrets failed: %v", err)
+	}
+	if encoded == "" {
+		t.Fatal("expected non-empty encoded string")
 	}
 
-	// Should only produce mount specs for file-type secrets
-	if len(mountSpecs) != 2 {
-		t.Fatalf("expected 2 mount specs, got %d", len(mountSpecs))
-	}
-
-	// Verify the first file was written with decoded base64 content
-	secretsDir := filepath.Join(filepath.Dir(homeDir), "secrets")
-	content, err := os.ReadFile(filepath.Join(secretsDir, "TLS_CERT"))
+	// Decode and verify the structure
+	staged, err := DecodeStagedSecrets(encoded)
 	if err != nil {
-		t.Fatalf("failed to read TLS_CERT file: %v", err)
-	}
-	if string(content) != "cert-content" {
-		t.Errorf("expected decoded content %q, got %q", "cert-content", string(content))
+		t.Fatalf("DecodeStagedSecrets failed: %v", err)
 	}
 
-	// Verify the second file was written with raw content (fallback)
-	content, err = os.ReadFile(filepath.Join(secretsDir, "SSH_KEY"))
-	if err != nil {
-		t.Fatalf("failed to read SSH_KEY file: %v", err)
-	}
-	if string(content) != "raw-value-not-base64" {
-		t.Errorf("expected raw content %q, got %q", "raw-value-not-base64", string(content))
+	// Should have 2 file secrets (environment type is excluded)
+	if len(staged.FileSecrets) != 2 {
+		t.Fatalf("expected 2 file secrets, got %d", len(staged.FileSecrets))
 	}
 
-	// Verify file permissions
-	info, err := os.Stat(filepath.Join(secretsDir, "TLS_CERT"))
-	if err != nil {
-		t.Fatalf("failed to stat TLS_CERT: %v", err)
+	// Verify file secret targets
+	if staged.FileSecrets[0].Target != "/etc/ssl/cert.pem" {
+		t.Errorf("expected target /etc/ssl/cert.pem, got %s", staged.FileSecrets[0].Target)
 	}
-	if info.Mode().Perm() != 0600 {
-		t.Errorf("expected file mode 0600, got %o", info.Mode().Perm())
+	if staged.FileSecrets[1].Target != "/home/scion/.ssh/id_rsa" {
+		t.Errorf("expected target /home/scion/.ssh/id_rsa, got %s", staged.FileSecrets[1].Target)
+	}
+
+	// Verify base64-encoded values are decodable
+	data, err := base64.StdEncoding.DecodeString(staged.FileSecrets[0].Value)
+	if err != nil {
+		t.Fatalf("failed to decode file secret value: %v", err)
+	}
+	if string(data) != "cert-content" {
+		t.Errorf("expected cert-content, got %s", string(data))
+	}
+
+	// Raw values should have been re-encoded as base64
+	data, err = base64.StdEncoding.DecodeString(staged.FileSecrets[1].Value)
+	if err != nil {
+		t.Fatalf("raw value should be re-encoded as base64: %v", err)
+	}
+	if string(data) != "raw-value-not-base64" {
+		t.Errorf("expected raw-value-not-base64, got %s", string(data))
+	}
+
+	// Should have 2 variable secrets
+	if len(staged.VariableSecrets) != 2 {
+		t.Fatalf("expected 2 variable secrets, got %d", len(staged.VariableSecrets))
+	}
+	if staged.VariableSecrets["config"] != `{"a":"b"}` {
+		t.Errorf("config value mismatch: got %q", staged.VariableSecrets["config"])
+	}
+	if staged.VariableSecrets["token"] != "abc123" {
+		t.Errorf("token value mismatch: got %q", staged.VariableSecrets["token"])
 	}
 }
 
-func TestWriteFileSecrets_NoFileSecrets(t *testing.T) {
-	homeDir := t.TempDir()
-
+func TestSerializeSecrets_NoFileOrVariableSecrets(t *testing.T) {
 	secrets := []api.ResolvedSecret{
 		{Name: "KEY", Type: "environment", Target: "KEY", Value: "val"},
 	}
 
-	mountSpecs, err := writeFileSecrets(homeDir, "/home/scion", secrets)
+	encoded, err := serializeSecrets("/home/scion", secrets)
 	if err != nil {
-		t.Fatalf("writeFileSecrets failed: %v", err)
+		t.Fatalf("serializeSecrets failed: %v", err)
 	}
-	if len(mountSpecs) != 0 {
-		t.Errorf("expected 0 mount specs for non-file secrets, got %d", len(mountSpecs))
+	if encoded != "" {
+		t.Errorf("expected empty string for env-only secrets, got %q", encoded)
 	}
 }
 
-func TestWriteFileSecrets_TildeExpansion(t *testing.T) {
-	homeDir := t.TempDir()
-
+func TestSerializeSecrets_TildeExpansion(t *testing.T) {
 	secrets := []api.ResolvedSecret{
 		{
 			Name:   "SSH_KEY",
@@ -127,88 +153,236 @@ func TestWriteFileSecrets_TildeExpansion(t *testing.T) {
 		},
 	}
 
-	mountSpecs, err := writeFileSecrets(homeDir, "/home/gemini", secrets)
+	encoded, err := serializeSecrets("/home/gemini", secrets)
 	if err != nil {
-		t.Fatalf("writeFileSecrets failed: %v", err)
+		t.Fatalf("serializeSecrets failed: %v", err)
 	}
 
-	if len(mountSpecs) != 2 {
-		t.Fatalf("expected 2 mount specs, got %d", len(mountSpecs))
+	staged, err := DecodeStagedSecrets(encoded)
+	if err != nil {
+		t.Fatalf("DecodeStagedSecrets failed: %v", err)
 	}
 
-	// Verify ~/ was expanded to the container home directory
-	secretsDir := filepath.Join(filepath.Dir(homeDir), "secrets")
-	expectedMount0 := filepath.Join(secretsDir, "SSH_KEY") + ":/home/gemini/.ssh/id_rsa:ro"
-	if mountSpecs[0] != expectedMount0 {
-		t.Errorf("expected mount spec %q, got %q", expectedMount0, mountSpecs[0])
+	if staged.FileSecrets[0].Target != "/home/gemini/.ssh/id_rsa" {
+		t.Errorf("expected tilde-expanded target, got %s", staged.FileSecrets[0].Target)
 	}
-
-	// Verify absolute path is unchanged
-	expectedMount1 := filepath.Join(secretsDir, "ABS_CERT") + ":/etc/ssl/cert.pem:ro"
-	if mountSpecs[1] != expectedMount1 {
-		t.Errorf("expected mount spec %q, got %q", expectedMount1, mountSpecs[1])
+	if staged.FileSecrets[1].Target != "/etc/ssl/cert.pem" {
+		t.Errorf("expected absolute target unchanged, got %s", staged.FileSecrets[1].Target)
 	}
 }
 
-func TestWriteFileSecrets_PreCreatesParentDirs(t *testing.T) {
-	// writeFileSecrets should pre-create the parent directory of file secret
-	// mount targets inside the agent home so Docker does not create them as
-	// root (which makes the agent dir undeletable by non-root users).
+func TestSerializeSecrets_DuplicateTargetKeepsLater(t *testing.T) {
+	secrets := []api.ResolvedSecret{
+		{Name: "CERT_V1", Type: "file", Target: "/etc/cert.pem", Value: base64.StdEncoding.EncodeToString([]byte("v1")), Source: "user"},
+		{Name: "CERT_V2", Type: "file", Target: "/etc/cert.pem", Value: base64.StdEncoding.EncodeToString([]byte("v2")), Source: "project"},
+	}
+
+	encoded, err := serializeSecrets("/home/scion", secrets)
+	if err != nil {
+		t.Fatalf("serializeSecrets failed: %v", err)
+	}
+
+	staged, err := DecodeStagedSecrets(encoded)
+	if err != nil {
+		t.Fatalf("DecodeStagedSecrets failed: %v", err)
+	}
+
+	// Dedup keeps both entries (last one wins on write), but the slice should
+	// contain both — WriteStagedSecrets writes them sequentially so the last
+	// one's content prevails on disk.
+	if len(staged.FileSecrets) != 2 {
+		t.Fatalf("expected 2 file secrets (dedup keeps all, last wins on write), got %d", len(staged.FileSecrets))
+	}
+}
+
+func TestWriteStagedSecrets_FileSecrets(t *testing.T) {
 	homeDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	staged := &StagedSecrets{
+		FileSecrets: []StagedFileSecret{
+			{
+				Name:   "TLS_CERT",
+				Target: filepath.Join(targetDir, "ssl", "cert.pem"),
+				Value:  base64.StdEncoding.EncodeToString([]byte("cert-content")),
+			},
+			{
+				Name:   "SSH_KEY",
+				Target: filepath.Join(targetDir, "ssh", "id_rsa"),
+				Value:  base64.StdEncoding.EncodeToString([]byte("ssh-key")),
+			},
+		},
+	}
+
+	if err := WriteStagedSecrets(homeDir, staged); err != nil {
+		t.Fatalf("WriteStagedSecrets failed: %v", err)
+	}
+
+	// Verify files were written with correct content
+	content, err := os.ReadFile(filepath.Join(targetDir, "ssl", "cert.pem"))
+	if err != nil {
+		t.Fatalf("failed to read cert.pem: %v", err)
+	}
+	if string(content) != "cert-content" {
+		t.Errorf("expected cert-content, got %q", string(content))
+	}
+
+	content, err = os.ReadFile(filepath.Join(targetDir, "ssh", "id_rsa"))
+	if err != nil {
+		t.Fatalf("failed to read id_rsa: %v", err)
+	}
+	if string(content) != "ssh-key" {
+		t.Errorf("expected ssh-key, got %q", string(content))
+	}
+
+	// Verify file permissions (0600)
+	info, err := os.Stat(filepath.Join(targetDir, "ssl", "cert.pem"))
+	if err != nil {
+		t.Fatalf("failed to stat cert.pem: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("expected file mode 0600, got %o", info.Mode().Perm())
+	}
+}
+
+func TestWriteStagedSecrets_VariableSecrets(t *testing.T) {
+	homeDir := t.TempDir()
+
+	staged := &StagedSecrets{
+		VariableSecrets: map[string]string{
+			"config": `{"a":"b"}`,
+			"token":  "abc123",
+		},
+	}
+
+	if err := WriteStagedSecrets(homeDir, staged); err != nil {
+		t.Fatalf("WriteStagedSecrets failed: %v", err)
+	}
+
+	// Verify secrets.json was written
+	data, err := os.ReadFile(filepath.Join(homeDir, ".scion", "secrets.json"))
+	if err != nil {
+		t.Fatalf("failed to read secrets.json: %v", err)
+	}
+
+	var vars map[string]string
+	if err := json.Unmarshal(data, &vars); err != nil {
+		t.Fatalf("failed to unmarshal secrets.json: %v", err)
+	}
+
+	if len(vars) != 2 {
+		t.Fatalf("expected 2 variable entries, got %d", len(vars))
+	}
+	if vars["config"] != `{"a":"b"}` {
+		t.Errorf("config mismatch: got %q", vars["config"])
+	}
+	if vars["token"] != "abc123" {
+		t.Errorf("token mismatch: got %q", vars["token"])
+	}
+
+	// Verify file permissions
+	info, err := os.Stat(filepath.Join(homeDir, ".scion", "secrets.json"))
+	if err != nil {
+		t.Fatalf("failed to stat secrets.json: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("expected file mode 0600, got %o", info.Mode().Perm())
+	}
+}
+
+func TestWriteStagedSecrets_NoVariables(t *testing.T) {
+	homeDir := t.TempDir()
+
+	staged := &StagedSecrets{}
+
+	if err := WriteStagedSecrets(homeDir, staged); err != nil {
+		t.Fatalf("WriteStagedSecrets failed: %v", err)
+	}
+
+	// secrets.json should NOT be created when there are no variable secrets
+	if _, err := os.Stat(filepath.Join(homeDir, ".scion", "secrets.json")); !os.IsNotExist(err) {
+		t.Error("expected secrets.json to not be created when no variable secrets exist")
+	}
+}
+
+func TestDecodeStagedSecrets_InvalidBase64(t *testing.T) {
+	_, err := DecodeStagedSecrets("not-valid-base64!!!")
+	if err == nil {
+		t.Error("expected error for invalid base64")
+	}
+}
+
+func TestDecodeStagedSecrets_InvalidJSON(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("not json"))
+	_, err := DecodeStagedSecrets(encoded)
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestSerializeAndWriteRoundTrip(t *testing.T) {
+	homeDir := t.TempDir()
+	targetDir := t.TempDir()
 
 	secrets := []api.ResolvedSecret{
 		{
-			Name:   "telemetry-creds",
+			Name:   "CERT",
 			Type:   "file",
-			Target: "~/.scion/telemetry-gcp-credentials.json",
-			Value:  base64.StdEncoding.EncodeToString([]byte("cred-data")),
+			Target: filepath.Join(targetDir, "cert.pem"),
+			Value:  base64.StdEncoding.EncodeToString([]byte("my-cert")),
+			Source: "user",
+		},
+		{
+			Name:   "CONFIG",
+			Type:   "variable",
+			Target: "app_config",
+			Value:  `{"db":"postgres"}`,
 			Source: "project",
 		},
 		{
-			Name:   "nested-secret",
-			Type:   "file",
-			Target: "~/.config/deep/nested/secret.json",
-			Value:  base64.StdEncoding.EncodeToString([]byte("nested-data")),
-			Source: "user",
-		},
-		{
-			Name:   "abs-secret",
-			Type:   "file",
-			Target: "/etc/ssl/cert.pem",
-			Value:  base64.StdEncoding.EncodeToString([]byte("cert")),
+			Name:   "ENV_KEY",
+			Type:   "environment",
+			Target: "ENV_KEY",
+			Value:  "should-be-excluded",
 			Source: "user",
 		},
 	}
 
-	_, err := writeFileSecrets(homeDir, "/home/scion", secrets)
+	// Broker side: serialize
+	encoded, err := serializeSecrets("/unused", secrets)
 	if err != nil {
-		t.Fatalf("writeFileSecrets failed: %v", err)
+		t.Fatalf("serializeSecrets failed: %v", err)
 	}
 
-	// .scion dir should be pre-created inside the agent home
-	scionDir := filepath.Join(homeDir, ".scion")
-	info, err := os.Stat(scionDir)
+	// Container side: decode + write
+	staged, err := DecodeStagedSecrets(encoded)
 	if err != nil {
-		t.Fatalf("expected %s to exist, got: %v", scionDir, err)
+		t.Fatalf("DecodeStagedSecrets failed: %v", err)
 	}
-	if !info.IsDir() {
-		t.Fatalf("expected %s to be a directory", scionDir)
+	if err := WriteStagedSecrets(homeDir, staged); err != nil {
+		t.Fatalf("WriteStagedSecrets failed: %v", err)
 	}
 
-	// Nested parent dirs should also be pre-created
-	nestedDir := filepath.Join(homeDir, ".config", "deep", "nested")
-	info, err = os.Stat(nestedDir)
+	// Verify file secret
+	content, err := os.ReadFile(filepath.Join(targetDir, "cert.pem"))
 	if err != nil {
-		t.Fatalf("expected %s to exist, got: %v", nestedDir, err)
+		t.Fatalf("failed to read cert.pem: %v", err)
 	}
-	if !info.IsDir() {
-		t.Fatalf("expected %s to be a directory", nestedDir)
+	if string(content) != "my-cert" {
+		t.Errorf("expected my-cert, got %q", string(content))
 	}
 
-	// Absolute path outside container home should NOT create dirs inside agent home
-	etcDir := filepath.Join(homeDir, "etc", "ssl")
-	if _, err := os.Stat(etcDir); !os.IsNotExist(err) {
-		t.Errorf("expected %s to NOT exist for absolute target outside container home", etcDir)
+	// Verify variable secret
+	data, err := os.ReadFile(filepath.Join(homeDir, ".scion", "secrets.json"))
+	if err != nil {
+		t.Fatalf("failed to read secrets.json: %v", err)
+	}
+	var vars map[string]string
+	if err := json.Unmarshal(data, &vars); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if vars["app_config"] != `{"db":"postgres"}` {
+		t.Errorf("variable secret mismatch: got %q", vars["app_config"])
 	}
 }
 
@@ -228,120 +402,6 @@ func TestExpandTildeTarget(t *testing.T) {
 		if result != tc.expected {
 			t.Errorf("expandTildeTarget(%q, %q) = %q, want %q", tc.target, tc.containerHome, result, tc.expected)
 		}
-	}
-}
-
-func TestWriteVariableSecrets(t *testing.T) {
-	homeDir := t.TempDir()
-
-	secrets := []api.ResolvedSecret{
-		{Name: "CONFIG", Type: "variable", Target: "config", Value: `{"a":"b"}`, Source: "user"},
-		{Name: "TOKEN", Type: "variable", Target: "token", Value: "abc123", Source: "project"},
-		{Name: "ENV_KEY", Type: "environment", Target: "ENV_KEY", Value: "val", Source: "user"},
-	}
-
-	if err := writeVariableSecrets(homeDir, secrets); err != nil {
-		t.Fatalf("writeVariableSecrets failed: %v", err)
-	}
-
-	// Read and verify secrets.json
-	data, err := os.ReadFile(filepath.Join(homeDir, ".scion", "secrets.json"))
-	if err != nil {
-		t.Fatalf("failed to read secrets.json: %v", err)
-	}
-
-	var vars map[string]string
-	if err := json.Unmarshal(data, &vars); err != nil {
-		t.Fatalf("failed to unmarshal secrets.json: %v", err)
-	}
-
-	if len(vars) != 2 {
-		t.Fatalf("expected 2 variable entries, got %d", len(vars))
-	}
-	if vars["config"] != `{"a":"b"}` {
-		t.Errorf("config value mismatch: got %q", vars["config"])
-	}
-	if vars["token"] != "abc123" {
-		t.Errorf("token value mismatch: got %q", vars["token"])
-	}
-
-	// Verify file permissions
-	info, err := os.Stat(filepath.Join(homeDir, ".scion", "secrets.json"))
-	if err != nil {
-		t.Fatalf("failed to stat secrets.json: %v", err)
-	}
-	if info.Mode().Perm() != 0600 {
-		t.Errorf("expected file mode 0600, got %o", info.Mode().Perm())
-	}
-}
-
-func TestWriteVariableSecrets_NoVariables(t *testing.T) {
-	homeDir := t.TempDir()
-
-	secrets := []api.ResolvedSecret{
-		{Name: "KEY", Type: "environment", Target: "KEY", Value: "val"},
-	}
-
-	if err := writeVariableSecrets(homeDir, secrets); err != nil {
-		t.Fatalf("writeVariableSecrets failed: %v", err)
-	}
-
-	// secrets.json should NOT be created when there are no variable secrets
-	if _, err := os.Stat(filepath.Join(homeDir, ".scion", "secrets.json")); !os.IsNotExist(err) {
-		t.Error("expected secrets.json to not be created when no variable secrets exist")
-	}
-}
-
-func TestWriteSecretMap(t *testing.T) {
-	homeDir := t.TempDir()
-
-	secrets := []api.ResolvedSecret{
-		{Name: "CERT", Type: "file", Target: "/etc/ssl/cert.pem", Value: "data", Source: "user"},
-		{Name: "KEY", Type: "file", Target: "/etc/ssl/key.pem", Value: "data", Source: "project"},
-		{Name: "ENV", Type: "environment", Target: "ENV", Value: "val", Source: "user"},
-	}
-
-	if err := writeSecretMap(homeDir, "/home/scion", secrets); err != nil {
-		t.Fatalf("writeSecretMap failed: %v", err)
-	}
-
-	secretsDir := filepath.Join(filepath.Dir(homeDir), "secrets")
-	data, err := os.ReadFile(filepath.Join(secretsDir, "secret-map.json"))
-	if err != nil {
-		t.Fatalf("failed to read secret-map.json: %v", err)
-	}
-
-	var entries []secretMapEntry
-	if err := json.Unmarshal(data, &entries); err != nil {
-		t.Fatalf("failed to unmarshal secret-map.json: %v", err)
-	}
-
-	if len(entries) != 2 {
-		t.Fatalf("expected 2 entries in secret-map.json, got %d", len(entries))
-	}
-
-	if entries[0].Name != "CERT" || entries[0].Target != "/etc/ssl/cert.pem" || entries[0].Source != "CERT" {
-		t.Errorf("unexpected first entry: %+v", entries[0])
-	}
-	if entries[1].Name != "KEY" || entries[1].Target != "/etc/ssl/key.pem" || entries[1].Source != "KEY" {
-		t.Errorf("unexpected second entry: %+v", entries[1])
-	}
-}
-
-func TestWriteSecretMap_NoFileSecrets(t *testing.T) {
-	homeDir := t.TempDir()
-
-	secrets := []api.ResolvedSecret{
-		{Name: "KEY", Type: "environment", Target: "KEY", Value: "val"},
-	}
-
-	if err := writeSecretMap(homeDir, "/home/scion", secrets); err != nil {
-		t.Fatalf("writeSecretMap failed: %v", err)
-	}
-
-	secretsDir := filepath.Join(filepath.Dir(homeDir), "secrets")
-	if _, err := os.Stat(filepath.Join(secretsDir, "secret-map.json")); !os.IsNotExist(err) {
-		t.Error("expected secret-map.json to not be created when no file secrets exist")
 	}
 }
 
@@ -447,8 +507,6 @@ func TestInsertVolumeFlags(t *testing.T) {
 }
 
 func TestInsertVolumeFlags_SecretMountsBeforeImage(t *testing.T) {
-	// Simulate the full flow: buildCommonRunArgs produces args with image+command at the end,
-	// then insertVolumeFlags should place secret mounts before the image.
 	config := RunConfig{
 		Name:         "test-agent",
 		UnixUsername: "scion",
@@ -464,7 +522,6 @@ func TestInsertVolumeFlags_SecretMountsBeforeImage(t *testing.T) {
 	secretSpecs := []string{"/host/secrets/CERT:/etc/ssl/cert.pem:ro"}
 	result := insertVolumeFlags(args, config.Image, secretSpecs)
 
-	// Find the positions of the secret mount and image in the result
 	secretIdx := -1
 	imageIdx := -1
 	for i, a := range result {

--- a/pkg/runtime/secrets_test.go
+++ b/pkg/runtime/secrets_test.go
@@ -187,11 +187,19 @@ func TestSerializeSecrets_DuplicateTargetKeepsLater(t *testing.T) {
 		t.Fatalf("DecodeStagedSecrets failed: %v", err)
 	}
 
-	// Dedup keeps both entries (last one wins on write), but the slice should
-	// contain both — WriteStagedSecrets writes them sequentially so the last
-	// one's content prevails on disk.
-	if len(staged.FileSecrets) != 2 {
-		t.Fatalf("expected 2 file secrets (dedup keeps all, last wins on write), got %d", len(staged.FileSecrets))
+	// Dedup should keep only one entry per target (last wins).
+	if len(staged.FileSecrets) != 1 {
+		t.Fatalf("expected 1 file secret after dedup, got %d", len(staged.FileSecrets))
+	}
+	if staged.FileSecrets[0].Name != "CERT_V2" {
+		t.Errorf("expected CERT_V2 to win, got %s", staged.FileSecrets[0].Name)
+	}
+	data, err := base64.StdEncoding.DecodeString(staged.FileSecrets[0].Value)
+	if err != nil {
+		t.Fatalf("failed to decode value: %v", err)
+	}
+	if string(data) != "v2" {
+		t.Errorf("expected v2 content, got %q", string(data))
 	}
 }
 


### PR DESCRIPTION
Fixes #284: Secret staging previously relied on bind-mounting files into agent containers, which is incompatible with stateless broker deployments (Cloud Run, remote brokers). Replaces with an environment-variable pipeline that works in all deployment modes.
