### PR TITLE
fix(web): detect incomplete embedded assets and serve helpful error page

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"log/slog"
 	"os"
@@ -330,7 +331,13 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 		}
 
 		if !web.AssetsEmbedded && webAssetsDir == "" {
-			slog.Warn("This binary was built without web assets. The web UI will not be available. Run 'make web' and rebuild to include the web frontend, or use --web-assets-dir.")
+			slog.Warn("This binary was built without web assets. The web UI will not be available. Run 'make all' (or 'make web && make build') to rebuild with web assets included, or use --web-assets-dir.")
+		} else if web.AssetsEmbedded && webAssetsDir == "" {
+			if sub, err := fs.Sub(web.ClientAssets, "dist/client"); err == nil {
+				if _, err := fs.Stat(sub, "assets/main.js"); err != nil {
+					slog.Warn("Embedded web assets are incomplete (main.js missing). The web UI will not be available. Run 'make all' (or 'make web && make build') to rebuild with web assets included, or use --web-assets-dir.")
+				}
+			}
 		}
 		log.Printf("Starting Web Frontend on %s:%d", cfg.Hub.Host, webPort)
 		wg.Add(1)

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -333,10 +333,11 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 		if !web.AssetsEmbedded && webAssetsDir == "" {
 			slog.Warn("This binary was built without web assets. The web UI will not be available. Run 'make all' (or 'make web && make build') to rebuild with web assets included, or use --web-assets-dir.")
 		} else if web.AssetsEmbedded && webAssetsDir == "" {
-			if sub, err := fs.Sub(web.ClientAssets, "dist/client"); err == nil {
-				if _, err := fs.Stat(sub, "assets/main.js"); err != nil {
-					slog.Warn("Embedded web assets are incomplete (main.js missing). The web UI will not be available. Run 'make all' (or 'make web && make build') to rebuild with web assets included, or use --web-assets-dir.")
-				}
+			sub, err := fs.Sub(web.ClientAssets, "dist/client")
+			if err != nil {
+				slog.Error("Failed to create sub-filesystem from embedded assets. The web UI will not be available. Run 'make web && make build' to rebuild with web assets included, or use --web-assets-dir.", "error", err)
+			} else if _, err := fs.Stat(sub, "assets/main.js"); err != nil {
+				slog.Warn("Embedded web assets are incomplete (main.js missing). The web UI will not be available. Run 'make all' (or 'make web && make build') to rebuild with web assets included, or use --web-assets-dir.")
 			}
 		}
 		log.Printf("Starting Web Frontend on %s:%d", cfg.Hub.Host, webPort)

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -381,11 +381,11 @@ var noAssetsPage = `<!DOCTYPE html>
 <body>
     <div class="container">
         <h1>Web UI Not Available</h1>
-        <p>This Scion binary was not built from source with web assets included.
+        <p>This hub binary was built without embedded web assets.
            The Hub API is still fully operational.</p>
         <div class="hint">
             <p>To use the web UI, either:</p>
-            <p>1. Build from source: <code>make build</code></p>
+            <p>1. Rebuild with assets: <code>make all</code> (or <code>make web &amp;&amp; make build</code>)</p>
             <p>2. Point to pre-built assets: <code>--web-assets-dir /path/to/dist/client</code></p>
         </div>
     </div>
@@ -476,10 +476,14 @@ func NewWebServer(cfg WebServerConfig) *WebServer {
 		sub, err := fs.Sub(web.ClientAssets, "dist/client")
 		if err != nil {
 			slog.Error("Failed to create sub-filesystem from embedded assets", "error", err)
+		} else if _, err := fs.Stat(sub, "assets/main.js"); err != nil {
+			slog.Warn("Embedded web assets directory exists but main.js is missing. Run 'make all' (or 'make web && make build') to rebuild with web assets included, or use --web-assets-dir.")
 		} else {
 			ws.assets = sub
 		}
-		slog.Info("Web server using embedded assets")
+		if ws.assets != nil {
+			slog.Info("Web server using embedded assets")
+		}
 	} else {
 		slog.Warn("No web assets available: build with embedded assets or use --web-assets-dir")
 	}

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -475,7 +475,7 @@ func NewWebServer(cfg WebServerConfig) *WebServer {
 	} else if web.AssetsEmbedded {
 		sub, err := fs.Sub(web.ClientAssets, "dist/client")
 		if err != nil {
-			slog.Error("Failed to create sub-filesystem from embedded assets", "error", err)
+			slog.Error("Failed to create sub-filesystem from embedded assets. Run 'make web && make build' to rebuild with web assets included, or use --web-assets-dir.", "error", err)
 		} else if _, err := fs.Stat(sub, "assets/main.js"); err != nil {
 			slog.Warn("Embedded web assets directory exists but main.js is missing. Run 'make all' (or 'make web && make build') to rebuild with web assets included, or use --web-assets-dir.")
 		} else {

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
@@ -39,7 +40,13 @@ type mockWebStore struct {
 
 func newTestWebServer(t *testing.T, cfg WebServerConfig) *WebServer {
 	t.Helper()
-	return NewWebServer(cfg)
+	ws := NewWebServer(cfg)
+	if ws.assets == nil && ws.assetsDisk == "" && cfg.AssetsDir == "" {
+		ws.assets = fstest.MapFS{
+			"assets/main.js": &fstest.MapFile{Data: []byte("// test stub")},
+		}
+	}
+	return ws
 }
 
 // newDevAuthWebServer creates a web server with dev-auth enabled for testing
@@ -52,7 +59,13 @@ func newDevAuthWebServer(t *testing.T, overrides ...func(*WebServerConfig)) *Web
 	for _, fn := range overrides {
 		fn(&cfg)
 	}
-	return NewWebServer(cfg)
+	ws := NewWebServer(cfg)
+	if ws.assets == nil && ws.assetsDisk == "" {
+		ws.assets = fstest.MapFS{
+			"assets/main.js": &fstest.MapFile{Data: []byte("// test stub")},
+		}
+	}
+	return ws
 }
 
 func TestSPAShellHandler(t *testing.T) {
@@ -231,7 +244,7 @@ func TestSPAHandler_NoAssets_ServesErrorPage(t *testing.T) {
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			assert.Contains(t, resp.Header.Get("Content-Type"), "text/html")
 			assert.Contains(t, html, "Web UI Not Available")
-			assert.Contains(t, html, "not built from source")
+			assert.Contains(t, html, "built without embedded web assets")
 			assert.Contains(t, html, "Hub API")
 			assert.NotContains(t, html, "scion-app",
 				"should not render SPA shell when no assets are available")


### PR DESCRIPTION
## Summary

When the hub binary is built without first running `make web`, the embedded web filesystem is empty and the server silently serves a blank page. This PR detects the missing assets condition and serves a clear static error page instead.

## What changed
- Added detection for missing/empty embedded web assets at server startup
- When assets are missing, serves a static HTML page explaining the issue and the build steps needed (`make all` or `make web && make build`)  
- API endpoints continue to function normally
- Supports future architectures where hub API and web-server run on separate machines

Fixes the confusing blank page / 404 for main.js developer experience.
