### PR TITLE
fix(ci): add handlers_projects_core and handlers_runtime_brokers to compat-literals allowlist

### DIFF
--- a/hack/check-project-compat-literals.sh
+++ b/hack/check-project-compat-literals.sh
@@ -166,6 +166,8 @@ allowed_paths=(
   "^pkg/hub/handlers_auth.go$"
   "^pkg/hub/handlers_broker_inbound.go$"
   "^pkg/hub/handlers_notifications.go$"
+  "^pkg/hub/handlers_projects_core.go$"
+  "^pkg/hub/handlers_runtime_brokers.go$"
   "^pkg/hub/project_cache.go$"
   "^pkg/hub/project_compat.go$"
   "^pkg/hub/project_webdav.go$"


### PR DESCRIPTION
PR #480 (handlers split) moved grove compatibility code from handlers.go to new files without updating the compat-literals script allowlist, causing Build and Test failures on all subsequent PRs.

Adds the two new files to the allowed_paths array in hack/check-project-compat-literals.sh.
