### PR TITLE
feat: add Apple Container DNS support for Hub connectivity

### DIFF
--- a/cmd/server_bridge_test.go
+++ b/cmd/server_bridge_test.go
@@ -65,10 +65,10 @@ func TestContainerBridgeEndpoint(t *testing.T) {
 			want:        "",
 		},
 		{
-			name:        "apple runtime returns empty",
+			name:        "apple container with localhost",
 			hubEndpoint: "http://localhost:8080",
-			runtimeName: "apple-container",
-			want:        "",
+			runtimeName: "container",
+			want:        "http://host.containers.internal:8080",
 		},
 		{
 			name:        "empty runtime returns empty",

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1485,7 +1485,7 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 	}
 
 	if rt != nil && rt.Name() == "container" && containerHubEndpoint != "" {
-		created, dnsErr := runtime.EnsureAppleDNS(cmd.Context(), runtime.AppleDNSHostname, runtime.AppleDNSIP)
+		created, dnsErr := runtime.EnsureAppleDNS(ctx, runtime.AppleDNSHostname, runtime.AppleDNSIP)
 		if dnsErr != nil {
 			log.Printf("WARNING: Failed to configure Apple Container DNS (%s → %s): %v\n"+
 				"Agents may not reach the Hub. Run manually:\n"+

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1484,6 +1484,19 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 		}
 	}
 
+	if rt != nil && rt.Name() == "container" && containerHubEndpoint != "" {
+		created, dnsErr := runtime.EnsureAppleDNS(cmd.Context(), runtime.AppleDNSHostname, runtime.AppleDNSIP)
+		if dnsErr != nil {
+			log.Printf("WARNING: Failed to configure Apple Container DNS (%s → %s): %v\n"+
+				"Agents may not reach the Hub. Run manually:\n"+
+				"  sudo container system dns create %s --localhost %s",
+				runtime.AppleDNSHostname, runtime.AppleDNSIP, dnsErr,
+				runtime.AppleDNSHostname, runtime.AppleDNSIP)
+		} else if created {
+			log.Printf("Configured Apple Container DNS: %s → %s", runtime.AppleDNSHostname, runtime.AppleDNSIP)
+		}
+	}
+
 	// Create Runtime Broker server configuration
 	rhCfg := runtimebroker.ServerConfig{
 		Port:                          cfg.RuntimeBroker.Port,

--- a/cmd/server_helpers.go
+++ b/cmd/server_helpers.go
@@ -84,7 +84,7 @@ func isLocalhostURL(endpoint string) bool {
 func containerBridgeEndpoint(hubEndpoint, runtimeName string) string {
 	var bridgeHost string
 	switch runtimeName {
-	case "podman":
+	case "podman", "container":
 		bridgeHost = "host.containers.internal"
 	case "docker":
 		bridgeHost = "host.docker.internal"

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2650,6 +2650,7 @@ func (s *Server) registerRoutes() {
 	s.mux.Handle("/api/v1/system/init", s.requireWorkstation(http.HandlerFunc(s.handleSystemInit)))
 	s.mux.Handle("/api/v1/system/images/pull", s.requireWorkstation(http.HandlerFunc(s.handleSystemImagesPull)))
 	s.mux.Handle("/api/v1/system/images/build", s.requireWorkstation(http.HandlerFunc(s.handleSystemImagesBuild)))
+	s.mux.Handle("/api/v1/system/apple-dns", s.requireWorkstation(http.HandlerFunc(s.handleAppleDNS)))
 
 	// Workstation-only filesystem endpoints
 	s.mux.Handle("/api/v1/system/fs/list", s.requireWorkstation(http.HandlerFunc(s.handleFSList)))

--- a/pkg/hub/system_handlers.go
+++ b/pkg/hub/system_handlers.go
@@ -829,6 +829,57 @@ func (s *Server) handleFSValidatePath(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// --- Apple DNS ---
+
+type appleDNSResponse struct {
+	Configured bool   `json:"configured"`
+	Hostname   string `json:"hostname"`
+	IP         string `json:"ip"`
+	Error      string `json:"error,omitempty"`
+}
+
+func (s *Server) handleAppleDNS(w http.ResponseWriter, r *http.Request) {
+	if err := assertLoopback(r); err != nil {
+		writeError(w, http.StatusForbidden, ErrCodeForbidden, err.Error(), nil)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		s.handleAppleDNSStatus(w, r)
+	case http.MethodPost:
+		s.handleAppleDNSSetup(w, r)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+func (s *Server) handleAppleDNSStatus(w http.ResponseWriter, r *http.Request) {
+	exists, err := runtime.AppleDNSRuleExists(r.Context(), runtime.AppleDNSHostname)
+	resp := appleDNSResponse{
+		Configured: err == nil && exists,
+		Hostname:   runtime.AppleDNSHostname,
+		IP:         runtime.AppleDNSIP,
+	}
+	if err != nil {
+		resp.Error = err.Error()
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleAppleDNSSetup(w http.ResponseWriter, r *http.Request) {
+	_, err := runtime.EnsureAppleDNS(r.Context(), runtime.AppleDNSHostname, runtime.AppleDNSIP)
+	resp := appleDNSResponse{
+		Configured: err == nil,
+		Hostname:   runtime.AppleDNSHostname,
+		IP:         runtime.AppleDNSIP,
+	}
+	if err != nil {
+		resp.Error = err.Error()
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // trimOutput removes a trailing newline from command output.
 func trimOutput(s string) string {
 	if len(s) > 0 && s[len(s)-1] == '\n' {

--- a/pkg/runtime/apple_dns.go
+++ b/pkg/runtime/apple_dns.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const (
+	AppleDNSHostname = "host.containers.internal"
+	AppleDNSIP       = "203.0.113.1"
+)
+
+// AppleDNSRuleExists checks whether a DNS rule for the given hostname is
+// configured in Apple Container. Does not require sudo.
+func AppleDNSRuleExists(ctx context.Context, hostname string) (bool, error) {
+	out, err := exec.CommandContext(ctx, "container", "system", "dns", "list").Output()
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.Contains(line, hostname) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// EnsureAppleDNS creates the DNS rule if it doesn't already exist.
+// Checks without sudo first; only invokes sudo if the rule is missing.
+func EnsureAppleDNS(ctx context.Context, hostname, ip string) (bool, error) {
+	exists, err := AppleDNSRuleExists(ctx, hostname)
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		return false, nil
+	}
+	cmd := exec.CommandContext(ctx, "sudo", "container", "system", "dns", "create", hostname, "--localhost", ip)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return false, fmt.Errorf("sudo container system dns create failed: %w (output: %s)", err, string(out))
+	}
+	return true, nil
+}

--- a/pkg/runtime/apple_dns.go
+++ b/pkg/runtime/apple_dns.go
@@ -34,7 +34,8 @@ func AppleDNSRuleExists(ctx context.Context, hostname string) (bool, error) {
 		return false, err
 	}
 	for _, line := range strings.Split(string(out), "\n") {
-		if strings.Contains(line, hostname) {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && fields[0] == hostname {
 			return true, nil
 		}
 	}

--- a/pkg/runtime/apple_dns_test.go
+++ b/pkg/runtime/apple_dns_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"testing"
+)
+
+func TestAppleDNSConstants(t *testing.T) {
+	if AppleDNSHostname != "host.containers.internal" {
+		t.Errorf("AppleDNSHostname = %q, want %q", AppleDNSHostname, "host.containers.internal")
+	}
+	if AppleDNSIP != "203.0.113.1" {
+		t.Errorf("AppleDNSIP = %q, want %q", AppleDNSIP, "203.0.113.1")
+	}
+}

--- a/web/src/components/pages/onboarding.ts
+++ b/web/src/components/pages/onboarding.ts
@@ -74,6 +74,9 @@ export class ScionPageOnboarding extends LitElement {
   @state() private configuredRuntime = '';
   @state() private selectedRuntime = '';
 
+  // Step 2b: Apple DNS warning (non-blocking)
+  @state() private dnsWarning: string | null = null;
+
   // Step 3: Harnesses
   @state() private selectedHarnesses = new Set<string>();
 
@@ -183,6 +186,17 @@ export class ScionPageOnboarding extends LitElement {
       padding: 0.75rem 1rem;
       margin-bottom: 1rem;
       font-size: 0.875rem;
+    }
+
+    .warning-banner {
+      background: var(--sl-color-warning-50, #fefce8);
+      color: var(--sl-color-warning-700, #a16207);
+      border: 1px solid var(--sl-color-warning-200, #fef08a);
+      border-radius: var(--scion-radius, 0.5rem);
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      font-size: 0.875rem;
+      white-space: pre-line;
     }
 
     .check-results {
@@ -554,6 +568,7 @@ export class ScionPageOnboarding extends LitElement {
         ` : nothing}
 
         ${this.error ? html`<div class="error-banner">${this.error}</div>` : nothing}
+        ${this.dnsWarning ? html`<div class="warning-banner">${this.dnsWarning}</div>` : nothing}
 
         ${this.renderStep()}
       </div>
@@ -780,6 +795,7 @@ export class ScionPageOnboarding extends LitElement {
 
   private async handleRuntimeNext(): Promise<void> {
     this.error = null;
+    this.dnsWarning = null;
     this.stepLoading = true;
     try {
       const res = await apiFetch('/api/v1/system/runtime', {
@@ -791,6 +807,19 @@ export class ScionPageOnboarding extends LitElement {
         this.error = await extractApiError(res, 'Failed to save runtime');
         return;
       }
+
+      if (this.selectedRuntime === 'container') {
+        try {
+          const dnsRes = await apiFetch('/api/v1/system/apple-dns', { method: 'POST' });
+          const dnsData = await dnsRes.json() as { configured: boolean; hostname: string; ip: string; error?: string };
+          if (!dnsData.configured) {
+            this.dnsWarning = `Apple Container DNS setup requires sudo. If not prompted, run manually:\n  sudo container system dns create ${dnsData.hostname} --localhost ${dnsData.ip}`;
+          }
+        } catch {
+          // non-fatal — server startup will retry on next launch
+        }
+      }
+
       this.currentStep = 3;
     } finally {
       this.stepLoading = false;

--- a/web/src/components/pages/onboarding.ts
+++ b/web/src/components/pages/onboarding.ts
@@ -811,9 +811,11 @@ export class ScionPageOnboarding extends LitElement {
       if (this.selectedRuntime === 'container') {
         try {
           const dnsRes = await apiFetch('/api/v1/system/apple-dns', { method: 'POST' });
-          const dnsData = await dnsRes.json() as { configured: boolean; hostname: string; ip: string; error?: string };
-          if (!dnsData.configured) {
-            this.dnsWarning = `Apple Container DNS setup requires sudo. If not prompted, run manually:\n  sudo container system dns create ${dnsData.hostname} --localhost ${dnsData.ip}`;
+          if (dnsRes.ok) {
+            const dnsData = await dnsRes.json() as { configured: boolean; hostname: string; ip: string; error?: string };
+            if (!dnsData.configured) {
+              this.dnsWarning = `Apple Container DNS setup requires sudo. If not prompted, run manually:\n  sudo container system dns create ${dnsData.hostname} --localhost ${dnsData.ip}`;
+            }
           }
         } catch {
           // non-fatal — server startup will retry on next launch


### PR DESCRIPTION
## Summary

Enables agents running inside Apple Container (macOS) to reach the Scion Hub API by configuring a DNS rule via `container system dns`.

- **New `pkg/runtime/apple_dns.go`**: `AppleDNSRuleExists()` (sudo-free check via `container system dns list`) and `EnsureAppleDNS()` (sudo only when rule absent). Constants: hostname `host.containers.internal` (Podman-compatible, not Apple's singular form), IP `203.0.113.1` (TEST-NET-3, RFC 5737).
- **Server startup**: `containerBridgeEndpoint()` gains a `"container"` case → `host.containers.internal`. On startup with Apple Container runtime, `EnsureAppleDNS()` is called after auto-computing `ContainerHubEndpoint`. Failure logs a clear warning with the manual command; server continues.
- **Onboarding**: After selecting Apple Container runtime, `POST /api/v1/system/apple-dns` is called. Success is silent; failure shows a non-blocking warning with the manual command.
- **No Docker/Podman regression**: All existing bridge endpoint cases unchanged.

## Behavior

1. Pre-flight check (no sudo): `container system dns list` — if rule exists, done silently.
2. If absent: `sudo container system dns create host.containers.internal --localhost 203.0.113.1`.
3. DNS rule is left in place on server stop (harmless, cleared by macOS on reboot).
4. On macOS reboot, the rule is re-applied transparently at next server startup.

## Test plan

- [ ] Verify `container system dns list` shows `host.containers.internal → 203.0.113.1` after server startup with Apple Container runtime
- [ ] Verify agent container can reach `http://host.containers.internal:<port>` (Hub API)
- [ ] Verify idempotency: second startup does not re-run sudo
- [ ] Verify graceful failure: if sudo fails, server starts and logs actionable warning
- [ ] Verify Docker/Podman flows unaffected
- [ ] Verify onboarding shows warning (not error) if DNS setup fails
