### PR TITLE
changelog: add June 25-27 entries

### DIFF
--- a/changelog/2026-06-25-changelog.md
+++ b/changelog/2026-06-25-changelog.md
@@ -1,0 +1,22 @@
+# Release Notes (2026-06-25)
+
+A major push on harness development — the Codex harness gained notification hooks, dialect YAML configuration, OTEL telemetry support, and template instructions. Antigravity was pinned to a specific release, briefly switched to ADC auth, then reverted. The Hub handlers were split by resource for maintainability.
+
+## 🚀 Features
+* **[Codex Harness]:** Notification hooks enabled — harness now fires lifecycle events and OTEL-escaped telemetry configuration for agent observability (#482, #488).
+* **[Codex Harness]:** Dialect YAML configuration — maps model aliases and API conventions for the Codex harness (#484, #486).
+* **[Codex Harness]:** Project template instructions — added instruction projection with hardened output and dropped unused system prompt file (#483).
+* **[Codex Harness]:** Extended OTEL config support for richer telemetry integration (#494).
+* **[Codex Harness]:** Updated model aliases (#481).
+* **[Antigravity]:** Pinned CLI binary to v1.0.11 from GitHub Releases for build reproducibility, with `TARGETARCH` mapping for multi-platform support (#487).
+* **[Sciontool]:** Hook support for bundled dialect overrides, allowing harness-specific model mapping to be shipped with the harness config (#485, #489).
+
+## 🐛 Fixes
+* **[Antigravity]:** Added missing field extractions (`session_id` from `.conversationId`, `tool_input` from `.toolCall.args`) and removed false `tool_name` extraction from `PostToolUse`. Declared `max_model_calls` as supported capability (#490).
+* **[Antigravity]:** Disabled ADC auth for vertex-ai (USE_ADC not yet functional in AGY CLI) and reverted to requiring `AGY_TOKEN` with keyring injection. GCP location fallback and v1.0.11 pin preserved (#497).
+* **[Codex Harness]:** Write instructions under container home directory (#491).
+* **[Codex Harness]:** Make notify hook executable (#492).
+
+## 🔧 Chores
+* **[Hub]:** Split monolithic handlers.go by resource type for maintainability (#480).
+* **[Docs]:** Changelog updates merged (#changelog).

--- a/changelog/2026-06-26-changelog.md
+++ b/changelog/2026-06-26-changelog.md
@@ -1,0 +1,20 @@
+# Release Notes (2026-06-26)
+
+A harness-heavy day: the Codex harness received critical auth fixes for file-based credentials, a new GitHub Copilot CLI harness shipped end-to-end tested, OpenCode gained Vertex AI auth support, and several provisioning issues were resolved.
+
+## 🚀 Features
+* **[Harness]:** GitHub Copilot CLI harness bundle — complete harness with build integration, provisioner with resilient auth fallback to no-auth mode when hub-registered configs haven't staged auth keys yet, and env var fallback for tokens in container environment (#506).
+* **[OpenCode]:** Vertex AI auth support — autodetects GCP project + location env vars and writes `VERTEXAI_PROJECT`/`VERTEX_LOCATION` to `outputs/env.json`. Lowest priority fallback after api-key and auth-file.
+* **[Harness]:** Stage `required_files` as secrets instead of bind-mounting — reads file content on host and stages as 0600 secret files under `agent_home/.scion/harness/secrets/`, fixing read-only filesystem crashes when harnesses try to write to credential files (#498).
+
+## 🐛 Fixes
+* **[Codex]:** Write fresh writable `auth.json` from staged secret in auth-file mode, fixing `lchown: read-only file system` crash at Codex startup (#501).
+* **[Codex]:** Validate `CODEX_AUTH` secret is valid JSON before writing to `~/.codex/auth.json`, surfacing clear errors at provisioning time instead of opaque startup failures (#499).
+* **[Codex]:** Updated no-auth hint to suggest `codex login --device-auth` instead of generic message (#504).
+* **[Hub]:** Registered missing `/api/v1/message-channels` route that was causing 404s for `--channel` flag in the CLI (#502).
+* **[Sciontool]:** Prevent `__pycache__` creation during harness provision by setting `PYTHONDONTWRITEBYTECODE=1`, fixing `scion delete` permission errors from root-owned bytecache on bind-mounted agent home (#505).
+* **[Web]:** Move Name field above Workspace Type in new project form (#507).
+* **[Web]:** Clean `dist` directory before build to prevent stale chunk accumulation (#508).
+
+## 🔧 Chores
+* **[CI]:** Fixed TypeScript errors in metrics-dashboard causing CI failure (#500).

--- a/changelog/2026-06-27-changelog.md
+++ b/changelog/2026-06-27-changelog.md
@@ -1,0 +1,6 @@
+# Release Notes (2026-06-27)
+
+A single targeted fix: GitHub URL parsing now correctly handles branch names containing slashes when resolving remote template references.
+
+## 🐛 Fixes
+* **[Config]:** Handle branch names with slashes in GitHub URL parsing — `resolveGitHubRef` now uses `git ls-remote --heads` to disambiguate branch vs path segments, picking the longest matching ref. Previously, branches like `feature/foo` were incorrectly split at the first slash, misidentifying part of the branch name as a file path (#503).


### PR DESCRIPTION
Adds 3 daily changelog entries covering June 25-27 work:
- June 25: Codex harness hooks/dialect/OTEL/templates/model aliases, Antigravity auth fixes
- June 26: Copilot CLI harness (e2e tested), Codex auth staging, OpenCode Vertex AI auth, pycache prevention, message-channels route fix, web build cleanup
- June 27: GitHub URL parsing fix (branch names with slashes), web build dist cleanup