### PR TITLE
fix(hub): re-evaluate admin role on every login and token refresh

### DIFF
--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -441,10 +441,30 @@ func (s *Server) handleAuthRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	accessToken, refreshToken, expiresIn, err := s.userTokenService.RefreshTokens(req.RefreshToken)
+	claims, err := s.userTokenService.ValidateRefreshToken(req.RefreshToken)
 	if err != nil {
 		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized,
 			"invalid refresh token", nil)
+		return
+	}
+
+	// Re-evaluate admin status on token refresh
+	role := claims.Role
+	if newRole := s.getUserRole(claims.Email); role != newRole {
+		slog.Info("User role changed on token refresh", "email", claims.Email, "old_role", role, "new_role", newRole)
+		role = newRole
+		// Persist the role change
+		if user, err := s.store.GetUserByEmail(r.Context(), claims.Email); err == nil && user.Role != role {
+			user.Role = role
+			_ = s.store.UpdateUser(r.Context(), user)
+		}
+	}
+
+	accessToken, refreshToken, expiresIn, err := s.userTokenService.GenerateTokenPair(
+		claims.UserID, claims.Email, claims.DisplayName, role, claims.ClientType,
+	)
+	if err != nil {
+		InternalError(w)
 		return
 	}
 
@@ -1212,9 +1232,10 @@ func (s *Server) provisionUser(ctx context.Context, info *ExternalUserInfo) (*st
 		if info.DisplayName != "" && user.DisplayName == "" {
 			user.DisplayName = info.DisplayName
 		}
-		// Promote to admin if config changed
-		if user.Role != "admin" && s.getUserRole(info.Email) == "admin" {
-			user.Role = "admin"
+		// Re-evaluate admin status on every login
+		if newRole := s.getUserRole(info.Email); user.Role != newRole {
+			slog.Info("User role changed on login", "email", info.Email, "old_role", user.Role, "new_role", newRole)
+			user.Role = newRole
 		}
 		_ = s.store.UpdateUser(ctx, user)
 	}

--- a/pkg/hub/handlers_auth_test.go
+++ b/pkg/hub/handlers_auth_test.go
@@ -640,6 +640,44 @@ func TestProvisionUser(t *testing.T) {
 		}
 	})
 
+	t.Run("demotes admin to member when removed from admin emails", func(t *testing.T) {
+		srv, s := testServer(t)
+
+		// Pre-create user as admin
+		original := &store.User{
+			ID:      generateID(),
+			Email:   "former-admin@example.com",
+			Role:    "admin",
+			Status:  "active",
+			Created: time.Now(),
+		}
+		if err := s.CreateUser(ctx, original); err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+
+		// Admin emails list does NOT include this user
+		srv.config.AdminEmails = []string{"other-admin@example.com"}
+
+		info := &ExternalUserInfo{Email: "former-admin@example.com"}
+		user, err := srv.provisionUser(ctx, info)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if user.Role != "member" {
+			t.Errorf("expected role 'member' after demotion, got %q", user.Role)
+		}
+
+		// Verify persisted in store
+		stored, err := s.GetUserByEmail(ctx, "former-admin@example.com")
+		if err != nil {
+			t.Fatalf("user not found in store: %v", err)
+		}
+		if stored.Role != "member" {
+			t.Errorf("expected stored role 'member', got %q", stored.Role)
+		}
+	})
+
 	t.Run("returns ErrAccessDenied for unauthorized domain", func(t *testing.T) {
 		srv, _ := testServer(t)
 

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -1464,6 +1464,12 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 		if userInfo.DisplayName != "" && user.DisplayName == "" {
 			user.DisplayName = userInfo.DisplayName
 		}
+		// Re-evaluate admin status on every login
+		newRole := determineUserRole(userInfo.Email, ws.config.AdminEmails)
+		if user.Role != newRole {
+			slog.Info("User role changed on login", "email", userInfo.Email, "old_role", user.Role, "new_role", newRole)
+			user.Role = newRole
+		}
 		if err := ws.store.UpdateUser(ctx, user); err != nil {
 			slog.Warn("Failed to update user on login", "email", userInfo.Email, "error", err)
 		}


### PR DESCRIPTION
Admin status was only checked when a user record was first created. If the ADMIN_USERS env var was updated to add a user, that user would not gain admin privileges until their record was deleted and recreated. This fix re-evaluates admin status on every login and token refresh, so env var changes take effect at next login