### PR TITLE
feat: add agent-specific key-value labels to core data model

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -73,7 +73,23 @@ var (
 	enableTelemetry       bool
 	disableTelemetry      bool
 	inlineConfigPath      string
+	labelFlags            []string
 )
+
+func parseLabels(raw []string) (map[string]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	m := make(map[string]string, len(raw))
+	for _, s := range raw {
+		k, v, ok := strings.Cut(s, "=")
+		if !ok || k == "" {
+			return nil, fmt.Errorf("invalid label %q: must be key=value", s)
+		}
+		m[k] = v
+	}
+	return m, nil
+}
 
 // loadInlineConfig loads a ScionConfig from the --config flag path.
 // If path is "-", reads from stdin. Supports YAML and JSON formats.
@@ -661,6 +677,11 @@ func startAgentViaHub(hubCtx *HubContext, agentName, task string, resume bool, i
 		}
 	}
 
+	parsedLabels, err := parseLabels(labelFlags)
+	if err != nil {
+		return err
+	}
+
 	// Build create request (Hub creates and starts in one operation)
 	req := &hubclient.CreateAgentRequest{
 		Name:            agentName,
@@ -673,6 +694,7 @@ func startAgentViaHub(hubCtx *HubContext, agentName, task string, resume bool, i
 		Task:            task,
 		Branch:          branch,
 		Workspace:       workspace,
+		Labels:          parsedLabels,
 		Resume:          resume,
 		Attach:          attach,
 		GatherEnv:       true, // Enable env-gather flow

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -37,6 +37,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/harness"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubsync"
+	"github.com/GoogleCloudPlatform/scion/pkg/labels"
 	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/transfer"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
@@ -87,6 +88,9 @@ func parseLabels(raw []string) (map[string]string, error) {
 			return nil, fmt.Errorf("invalid label %q: must be key=value", s)
 		}
 		m[k] = v
+	}
+	if err := labels.Validate(m); err != nil {
+		return nil, fmt.Errorf("invalid label: %w", err)
 	}
 	return m, nil
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -216,6 +216,11 @@ func createAgentViaHub(hubCtx *HubContext, agentName string, task string) error 
 		}
 	}
 
+	parsedLabels, err := parseLabels(labelFlags)
+	if err != nil {
+		return err
+	}
+
 	// Build create request — always provision-only (create does not start the agent)
 	req := &hubclient.CreateAgentRequest{
 		Name:            agentName,
@@ -226,6 +231,7 @@ func createAgentViaHub(hubCtx *HubContext, agentName string, task string) error 
 		RuntimeBrokerID: runtimeBrokerID,
 		Task:            task,
 		Branch:          branch,
+		Labels:          parsedLabels,
 		ProvisionOnly:   true,
 	}
 
@@ -330,4 +336,7 @@ func init() {
 
 	// Inline config flag
 	createCmd.Flags().StringVar(&inlineConfigPath, "config", "", "Path to inline agent config file (YAML/JSON), or '-' for stdin")
+
+	// Label flags
+	createCmd.Flags().StringArrayVar(&labelFlags, "label", nil, "Label in key=value format (repeatable)")
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -45,6 +45,7 @@ var (
 	filterTemplate string
 	sortField      string
 	sortReverse    bool
+	filterLabels   []string
 )
 
 var validSortFields = map[string]bool{
@@ -120,9 +121,15 @@ func listAgentsViaHub(hubCtx *HubContext) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	parsedLabels, err := parseLabels(filterLabels)
+	if err != nil {
+		return err
+	}
+
 	opts := &hubclient.ListAgentsOptions{
 		IncludeDeleted: listDeleted,
 		Phase:          filterPhase,
+		Labels:         parsedLabels,
 	}
 	agentSvc := hubCtx.Client.Agents()
 
@@ -686,4 +693,5 @@ func init() {
 	listCmd.Flags().StringVar(&filterTemplate, "template", "", "Filter by template name")
 	listCmd.Flags().StringVar(&sortField, "sort", "", "Sort by field (name, phase, created, updated, last-seen)")
 	listCmd.Flags().BoolVar(&sortReverse, "reverse", false, "Reverse sort order")
+	listCmd.Flags().StringArrayVar(&filterLabels, "label", nil, "Filter by label in key=value format (repeatable)")
 }

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
-	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hooks"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hooks/handlers"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hub"
@@ -34,6 +33,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/services"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/supervisor"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/telemetry"
+	"github.com/GoogleCloudPlatform/scion/pkg/stagedsecrets"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 	otellog "go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/metric"
@@ -174,17 +174,17 @@ func runInit(args []string) int {
 	// instead of bind-mounting them from the host filesystem. We decode and
 	// write them before anything else so they are available to hooks and
 	// the harness.
-	if encoded := os.Getenv(runtime.StagedSecretEnvVar); encoded != "" {
-		staged, err := runtime.DecodeStagedSecrets(encoded)
+	if encoded := os.Getenv(stagedsecrets.EnvVar); encoded != "" {
+		staged, err := stagedsecrets.Decode(encoded)
 		if err != nil {
 			log.Error("Failed to decode staged secrets: %v", err)
 			return 1
 		}
-		if err := runtime.WriteStagedSecrets(agentHome, staged); err != nil {
+		if err := stagedsecrets.Write(agentHome, staged); err != nil {
 			log.Error("Failed to write staged secrets: %v", err)
 			return 1
 		}
-		_ = os.Unsetenv(runtime.StagedSecretEnvVar)
+		_ = os.Unsetenv(stagedsecrets.EnvVar)
 		log.Info("Staged %d file secret(s) and %d variable secret(s)",
 			len(staged.FileSecrets), len(staged.VariableSecrets))
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -77,4 +77,7 @@ func init() {
 	// Inline config flag
 	startCmd.Flags().StringVar(&inlineConfigPath, "config", "", "Path to inline agent config file (YAML/JSON), or '-' for stdin")
 
+	// Label flags
+	startCmd.Flags().StringArrayVar(&labelFlags, "label", nil, "Label in key=value format (repeatable)")
+
 }

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -36,6 +36,26 @@ import (
 	gouuid "github.com/google/uuid"
 )
 
+// parseLabelFilters parses label=key=value query parameters into a map and
+// validates the resulting labels against constraint rules.
+func parseLabelFilters(params []string) (map[string]string, error) {
+	if len(params) == 0 {
+		return nil, nil
+	}
+	m := make(map[string]string, len(params))
+	for _, lp := range params {
+		k, v, ok := strings.Cut(lp, "=")
+		if !ok || k == "" {
+			return nil, fmt.Errorf("invalid label filter %q: must be key=value", lp)
+		}
+		m[k] = v
+	}
+	if err := labels.Validate(m); err != nil {
+		return nil, fmt.Errorf("invalid label filter: %w", err)
+	}
+	return m, nil
+}
+
 type ListAgentsResponse struct {
 	Agents       []AgentWithCapabilities `json:"agents"`
 	NextCursor   string                  `json:"nextCursor,omitempty"`
@@ -153,15 +173,12 @@ func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if labelParams := query["label"]; len(labelParams) > 0 {
-		filter.Labels = make(map[string]string, len(labelParams))
-		for _, lp := range labelParams {
-			k, v, ok := strings.Cut(lp, "=")
-			if !ok || k == "" {
-				BadRequest(w, fmt.Sprintf("Invalid label filter %q: must be key=value", lp))
-				return
-			}
-			filter.Labels[k] = v
+		parsed, err := parseLabelFilters(labelParams)
+		if err != nil {
+			BadRequest(w, err.Error())
+			return
 		}
+		filter.Labels = parsed
 	}
 
 	// scope=mine: agents the current user created

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/gcp"
+	"github.com/GoogleCloudPlatform/scion/pkg/labels"
 	"github.com/GoogleCloudPlatform/scion/pkg/secret"
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
@@ -149,6 +150,18 @@ func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 		RuntimeBrokerID: query.Get("runtimeBrokerId"),
 		Phase:           query.Get("phase"),
 		IncludeDeleted:  query.Get("includeDeleted") == "true",
+	}
+
+	if labelParams := query["label"]; len(labelParams) > 0 {
+		filter.Labels = make(map[string]string, len(labelParams))
+		for _, lp := range labelParams {
+			k, v, ok := strings.Cut(lp, "=")
+			if !ok || k == "" {
+				BadRequest(w, fmt.Sprintf("Invalid label filter %q: must be key=value", lp))
+				return
+			}
+			filter.Labels[k] = v
+		}
 	}
 
 	// scope=mine: agents the current user created
@@ -278,6 +291,11 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 			ValidationError(w, "metadata_mode must be 'block', 'passthrough', or 'assign'", nil)
 			return
 		}
+	}
+
+	if err := labels.Validate(req.Labels); err != nil {
+		ValidationError(w, "Invalid labels: "+err.Error(), nil)
+		return
 	}
 
 	// Check if the caller is an agent (sub-agent creation)
@@ -1397,6 +1415,10 @@ func (s *Server) updateAgent(w http.ResponseWriter, r *http.Request, id string) 
 		agent.Name = updates.Name
 	}
 	if updates.Labels != nil {
+		if err := labels.Validate(updates.Labels); err != nil {
+			ValidationError(w, "Invalid labels: "+err.Error(), nil)
+			return
+		}
 		agent.Labels = updates.Labels
 	}
 	if updates.Annotations != nil {

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -1610,15 +1610,12 @@ func (s *Server) listProjectAgents(w http.ResponseWriter, r *http.Request, proje
 	}
 
 	if labelParams := query["label"]; len(labelParams) > 0 {
-		filter.Labels = make(map[string]string, len(labelParams))
-		for _, lp := range labelParams {
-			k, v, ok := strings.Cut(lp, "=")
-			if !ok || k == "" {
-				BadRequest(w, fmt.Sprintf("Invalid label filter %q: must be key=value", lp))
-				return
-			}
-			filter.Labels[k] = v
+		parsed, err := parseLabelFilters(labelParams)
+		if err != nil {
+			BadRequest(w, err.Error())
+			return
 		}
+		filter.Labels = parsed
 	}
 
 	limit := 50

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/gcp"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
+	"github.com/GoogleCloudPlatform/scion/pkg/labels"
 	"github.com/GoogleCloudPlatform/scion/pkg/secret"
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
@@ -1608,6 +1609,18 @@ func (s *Server) listProjectAgents(w http.ResponseWriter, r *http.Request, proje
 		IncludeDeleted:  query.Get("includeDeleted") == "true",
 	}
 
+	if labelParams := query["label"]; len(labelParams) > 0 {
+		filter.Labels = make(map[string]string, len(labelParams))
+		for _, lp := range labelParams {
+			k, v, ok := strings.Cut(lp, "=")
+			if !ok || k == "" {
+				BadRequest(w, fmt.Sprintf("Invalid label filter %q: must be key=value", lp))
+				return
+			}
+			filter.Labels[k] = v
+		}
+	}
+
 	limit := 50
 	if l := query.Get("limit"); l != "" {
 		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
@@ -1676,6 +1689,10 @@ func (s *Server) createProjectAgent(w http.ResponseWriter, r *http.Request, proj
 	}
 	if req.CleanupMode != "" && req.CleanupMode != "strict" && req.CleanupMode != "force" {
 		ValidationError(w, "cleanupMode must be 'strict' or 'force'", nil)
+		return
+	}
+	if err := labels.Validate(req.Labels); err != nil {
+		ValidationError(w, "Invalid labels: "+err.Error(), nil)
 		return
 	}
 
@@ -1784,6 +1801,10 @@ func (s *Server) updateProjectAgent(w http.ResponseWriter, r *http.Request, proj
 		agent.Name = updates.Name
 	}
 	if updates.Labels != nil {
+		if err := labels.Validate(updates.Labels); err != nil {
+			ValidationError(w, "Invalid labels: "+err.Error(), nil)
+			return
+		}
 		agent.Labels = updates.Labels
 	}
 	if updates.Annotations != nil {

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package labels
+
+import "fmt"
+
+const (
+	MaxLabels   = 16
+	MaxKeyLen   = 63
+	MaxValueLen = 63
+)
+
+// Validate checks that labels satisfy all constraints:
+//   - At most 16 labels
+//   - Keys must not be empty
+//   - Keys and values must be printable ASCII (0x20–0x7E)
+//   - Keys max 63 characters, values max 63 characters
+func Validate(labels map[string]string) error {
+	if len(labels) > MaxLabels {
+		return fmt.Errorf("too many labels: %d exceeds maximum of %d", len(labels), MaxLabels)
+	}
+	for k, v := range labels {
+		if k == "" {
+			return fmt.Errorf("label key must not be empty")
+		}
+		if len(k) > MaxKeyLen {
+			return fmt.Errorf("label key %q exceeds maximum length of %d characters", k, MaxKeyLen)
+		}
+		if len(v) > MaxValueLen {
+			return fmt.Errorf("label value for key %q exceeds maximum length of %d characters", k, MaxValueLen)
+		}
+		if err := checkPrintableASCII(k); err != nil {
+			return fmt.Errorf("label key %q: %w", k, err)
+		}
+		if err := checkPrintableASCII(v); err != nil {
+			return fmt.Errorf("label value for key %q: %w", k, err)
+		}
+	}
+	return nil
+}
+
+func checkPrintableASCII(s string) error {
+	for i, c := range s {
+		if c < 0x20 || c > 0x7E {
+			return fmt.Errorf("contains non-printable ASCII character at position %d", i)
+		}
+	}
+	return nil
+}

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package labels
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		labels  map[string]string
+		wantErr string
+	}{
+		{
+			name:   "nil labels",
+			labels: nil,
+		},
+		{
+			name:   "empty labels",
+			labels: map[string]string{},
+		},
+		{
+			name:   "valid single label",
+			labels: map[string]string{"env": "prod"},
+		},
+		{
+			name:   "valid multiple labels",
+			labels: map[string]string{"env": "prod", "team": "platform", "role": "worker"},
+		},
+		{
+			name:   "value can be empty",
+			labels: map[string]string{"marker": ""},
+		},
+		{
+			name:    "empty key",
+			labels:  map[string]string{"": "value"},
+			wantErr: "label key must not be empty",
+		},
+		{
+			name:    "key too long",
+			labels:  map[string]string{strings.Repeat("a", 64): "value"},
+			wantErr: "exceeds maximum length of 63 characters",
+		},
+		{
+			name:   "key at max length",
+			labels: map[string]string{strings.Repeat("a", 63): "value"},
+		},
+		{
+			name:    "value too long",
+			labels:  map[string]string{"key": strings.Repeat("b", 64)},
+			wantErr: "exceeds maximum length of 63 characters",
+		},
+		{
+			name:   "value at max length",
+			labels: map[string]string{"key": strings.Repeat("b", 63)},
+		},
+		{
+			name:    "non-printable ASCII in key",
+			labels:  map[string]string{"key\x00": "value"},
+			wantErr: "non-printable ASCII character",
+		},
+		{
+			name:    "non-printable ASCII in value",
+			labels:  map[string]string{"key": "val\x01ue"},
+			wantErr: "non-printable ASCII character",
+		},
+		{
+			name:    "non-ASCII unicode in key",
+			labels:  map[string]string{"ké y": "value"},
+			wantErr: "non-printable ASCII character",
+		},
+		{
+			name:    "tab in value",
+			labels:  map[string]string{"key": "val\tue"},
+			wantErr: "non-printable ASCII character",
+		},
+		{
+			name:   "printable special characters",
+			labels: map[string]string{"key-1.0/test": "value_with spaces & symbols!"},
+		},
+		{
+			name: "too many labels",
+			labels: func() map[string]string {
+				m := make(map[string]string)
+				for i := 0; i < 17; i++ {
+					m[string(rune('a'+i))] = "v"
+				}
+				return m
+			}(),
+			wantErr: "too many labels: 17 exceeds maximum of 16",
+		},
+		{
+			name: "exactly 16 labels",
+			labels: func() map[string]string {
+				m := make(map[string]string)
+				for i := 0; i < 16; i++ {
+					m[string(rune('a'+i))] = "v"
+				}
+				return m
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(tt.labels)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("Validate() expected error containing %q, got nil", tt.wantErr)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Validate() error = %q, want substring %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -32,6 +32,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
+	stagedsecrets "github.com/GoogleCloudPlatform/scion/pkg/stagedsecrets"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 )
 
@@ -791,27 +792,19 @@ func applyResolvedAuth(config RunConfig, addEnv func(string, string), addVolume 
 }
 
 // StagedSecretEnvVar is the environment variable used to pass serialized
-// file and variable secrets from the broker to the container. The value is
-// a base64-encoded JSON blob decoded by sciontool init.
-const StagedSecretEnvVar = "SCION_STAGED_SECRETS"
+// file and variable secrets from the broker to the container.
+const StagedSecretEnvVar = stagedsecrets.EnvVar
 
 // stagedSecretWarnThreshold is the size (in bytes) above which a warning is
 // logged for the serialized secret blob. Container runtimes typically cap
 // the combined environment at ~128KB.
 const stagedSecretWarnThreshold = 100 * 1024
 
-// StagedFileSecret describes a single file-type secret in the staged blob.
-type StagedFileSecret struct {
-	Name   string `json:"name"`
-	Target string `json:"target"` // container-side path (tilde already expanded)
-	Value  string `json:"value"`  // base64-encoded file content
-}
+// StagedFileSecret is an alias for the type in pkg/stagedsecrets.
+type StagedFileSecret = stagedsecrets.FileSecret
 
-// StagedSecrets is the top-level structure serialized into SCION_STAGED_SECRETS.
-type StagedSecrets struct {
-	FileSecrets     []StagedFileSecret `json:"file_secrets,omitempty"`
-	VariableSecrets map[string]string  `json:"variable_secrets,omitempty"`
-}
+// StagedSecrets is an alias for the type in pkg/stagedsecrets.
+type StagedSecrets = stagedsecrets.Staged
 
 // serializeSecrets collects file and variable secrets into a single JSON blob,
 // base64-encodes it, and returns the encoded string suitable for injection as
@@ -883,82 +876,16 @@ func serializeSecrets(containerHome string, secrets []api.ResolvedSecret) (strin
 	return encoded, nil
 }
 
-// DecodeStagedSecrets decodes the SCION_STAGED_SECRETS env var value
-// (base64 → JSON) and returns the structured secrets. This is called
-// inside the container by sciontool init.
+// DecodeStagedSecrets decodes the SCION_STAGED_SECRETS env var value.
+// Deprecated: Use stagedsecrets.Decode directly.
 func DecodeStagedSecrets(encoded string) (*StagedSecrets, error) {
-	jsonData, err := base64.StdEncoding.DecodeString(encoded)
-	if err != nil {
-		return nil, fmt.Errorf("failed to base64-decode staged secrets: %w", err)
-	}
-	var staged StagedSecrets
-	if err := json.Unmarshal(jsonData, &staged); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal staged secrets JSON: %w", err)
-	}
-	return &staged, nil
+	return stagedsecrets.Decode(encoded)
 }
 
-// WriteStagedSecrets writes decoded staged secrets to the filesystem inside
-// the container. File secrets are written to their target paths with 0600
-// permissions. Variable secrets are written to <homeDir>/.scion/secrets.json.
+// WriteStagedSecrets writes decoded staged secrets to the filesystem.
+// Deprecated: Use stagedsecrets.Write directly.
 func WriteStagedSecrets(homeDir string, staged *StagedSecrets) error {
-	var uid, gid int
-	if os.Getuid() == 0 {
-		if uidStr := os.Getenv("SCION_HOST_UID"); uidStr != "" {
-			if id, err := strconv.Atoi(uidStr); err == nil {
-				uid = id
-			}
-		}
-		if gidStr := os.Getenv("SCION_HOST_GID"); gidStr != "" {
-			if id, err := strconv.Atoi(gidStr); err == nil {
-				gid = id
-			}
-		}
-	}
-
-	for _, fs := range staged.FileSecrets {
-		data, err := base64.StdEncoding.DecodeString(fs.Value)
-		if err != nil {
-			return fmt.Errorf("failed to base64-decode secret %s: %w", fs.Name, err)
-		}
-
-		dir := filepath.Dir(fs.Target)
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return fmt.Errorf("failed to create directory for secret %s: %w", fs.Name, err)
-		}
-		if (uid > 0 || gid > 0) && strings.HasPrefix(dir, homeDir) {
-			_ = os.Chown(dir, uid, gid)
-		}
-		if err := os.WriteFile(fs.Target, data, 0600); err != nil {
-			return fmt.Errorf("failed to write secret file %s: %w", fs.Name, err)
-		}
-		if (uid > 0 || gid > 0) && strings.HasPrefix(fs.Target, homeDir) {
-			_ = os.Chown(fs.Target, uid, gid)
-		}
-	}
-
-	if len(staged.VariableSecrets) > 0 {
-		scionDir := filepath.Join(homeDir, ".scion")
-		if err := os.MkdirAll(scionDir, 0700); err != nil {
-			return fmt.Errorf("failed to create .scion directory: %w", err)
-		}
-		if uid > 0 || gid > 0 {
-			_ = os.Chown(scionDir, uid, gid)
-		}
-		data, err := json.Marshal(staged.VariableSecrets)
-		if err != nil {
-			return fmt.Errorf("failed to marshal secrets.json: %w", err)
-		}
-		secretsPath := filepath.Join(scionDir, "secrets.json")
-		if err := os.WriteFile(secretsPath, data, 0600); err != nil {
-			return fmt.Errorf("failed to write secrets.json: %w", err)
-		}
-		if uid > 0 || gid > 0 {
-			_ = os.Chown(secretsPath, uid, gid)
-		}
-	}
-
-	return nil
+	return stagedsecrets.Write(homeDir, staged)
 }
 
 // phaseFromContainerStatus derives an agent phase from a container status string.

--- a/pkg/stagedsecrets/stagedsecrets.go
+++ b/pkg/stagedsecrets/stagedsecrets.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stagedsecrets
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// EnvVar is the environment variable used to pass serialized
+// file and variable secrets from the broker to the container. The value is
+// a base64-encoded JSON blob decoded by sciontool init.
+const EnvVar = "SCION_STAGED_SECRETS"
+
+// FileSecret describes a single file-type secret in the staged blob.
+type FileSecret struct {
+	Name   string `json:"name"`
+	Target string `json:"target"` // container-side path (tilde already expanded)
+	Value  string `json:"value"`  // base64-encoded file content
+}
+
+// Staged is the top-level structure serialized into SCION_STAGED_SECRETS.
+type Staged struct {
+	FileSecrets     []FileSecret      `json:"file_secrets,omitempty"`
+	VariableSecrets map[string]string `json:"variable_secrets,omitempty"`
+}
+
+// Decode decodes the SCION_STAGED_SECRETS env var value
+// (base64 → JSON) and returns the structured secrets. This is called
+// inside the container by sciontool init.
+func Decode(encoded string) (*Staged, error) {
+	jsonData, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("failed to base64-decode staged secrets: %w", err)
+	}
+	var staged Staged
+	if err := json.Unmarshal(jsonData, &staged); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal staged secrets JSON: %w", err)
+	}
+	return &staged, nil
+}
+
+// Write writes decoded staged secrets to the filesystem inside
+// the container. File secrets are written to their target paths with 0600
+// permissions. Variable secrets are written to <homeDir>/.scion/secrets.json.
+func Write(homeDir string, staged *Staged) error {
+	var uid, gid int
+	if os.Getuid() == 0 {
+		if uidStr := os.Getenv("SCION_HOST_UID"); uidStr != "" {
+			if id, err := strconv.Atoi(uidStr); err == nil {
+				uid = id
+			}
+		}
+		if gidStr := os.Getenv("SCION_HOST_GID"); gidStr != "" {
+			if id, err := strconv.Atoi(gidStr); err == nil {
+				gid = id
+			}
+		}
+	}
+
+	for _, fs := range staged.FileSecrets {
+		data, err := base64.StdEncoding.DecodeString(fs.Value)
+		if err != nil {
+			return fmt.Errorf("failed to base64-decode secret %s: %w", fs.Name, err)
+		}
+
+		dir := filepath.Dir(fs.Target)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory for secret %s: %w", fs.Name, err)
+		}
+		if (uid > 0 || gid > 0) && strings.HasPrefix(dir, homeDir) {
+			_ = os.Chown(dir, uid, gid)
+		}
+		if err := os.WriteFile(fs.Target, data, 0600); err != nil {
+			return fmt.Errorf("failed to write secret file %s: %w", fs.Name, err)
+		}
+		if (uid > 0 || gid > 0) && strings.HasPrefix(fs.Target, homeDir) {
+			_ = os.Chown(fs.Target, uid, gid)
+		}
+	}
+
+	if len(staged.VariableSecrets) > 0 {
+		scionDir := filepath.Join(homeDir, ".scion")
+		if err := os.MkdirAll(scionDir, 0700); err != nil {
+			return fmt.Errorf("failed to create .scion directory: %w", err)
+		}
+		if uid > 0 || gid > 0 {
+			_ = os.Chown(scionDir, uid, gid)
+		}
+		data, err := json.Marshal(staged.VariableSecrets)
+		if err != nil {
+			return fmt.Errorf("failed to marshal secrets.json: %w", err)
+		}
+		secretsPath := filepath.Join(scionDir, "secrets.json")
+		if err := os.WriteFile(secretsPath, data, 0600); err != nil {
+			return fmt.Errorf("failed to write secrets.json: %w", err)
+		}
+		if uid > 0 || gid > 0 {
+			_ = os.Chown(secretsPath, uid, gid)
+		}
+	}
+
+	return nil
+}

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -481,6 +481,9 @@ func agentFilterPredicates(filter store.AgentFilter) ([]predicate.Agent, error) 
 	if filter.AncestorID != "" {
 		preds = append(preds, ancestryContains(filter.AncestorID))
 	}
+	for k, v := range filter.Labels {
+		preds = append(preds, labelContains(k, v))
+	}
 
 	// Exclude soft-deleted agents unless explicitly requested.
 	if !filter.IncludeDeleted {

--- a/pkg/store/entadapter/agent_store_test.go
+++ b/pkg/store/entadapter/agent_store_test.go
@@ -514,9 +514,9 @@ func TestAgentStore_LabelFiltering(t *testing.T) {
 	require.NoError(t, s.CreateAgent(ctx, a5))
 
 	tests := []struct {
-		name     string
-		labels   map[string]string
-		wantIDs  []string
+		name    string
+		labels  map[string]string
+		wantIDs []string
 	}{
 		{
 			name:    "single label match",

--- a/pkg/store/entadapter/agent_store_test.go
+++ b/pkg/store/entadapter/agent_store_test.go
@@ -489,6 +489,66 @@ func TestAgentStore_PurgeDeletedAgents(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestAgentStore_LabelFiltering(t *testing.T) {
+	ctx := context.Background()
+	s, projectID := newTestAgentStore(t)
+
+	a1 := makeAgent(projectID, "label-1")
+	a1.Labels = map[string]string{"env": "prod", "team": "platform"}
+	require.NoError(t, s.CreateAgent(ctx, a1))
+
+	a2 := makeAgent(projectID, "label-2")
+	a2.Labels = map[string]string{"env": "staging", "team": "platform"}
+	require.NoError(t, s.CreateAgent(ctx, a2))
+
+	a3 := makeAgent(projectID, "label-3")
+	a3.Labels = map[string]string{"env": "prod", "team": "data"}
+	require.NoError(t, s.CreateAgent(ctx, a3))
+
+	a4 := makeAgent(projectID, "label-4")
+	a4.Labels = nil
+	require.NoError(t, s.CreateAgent(ctx, a4))
+
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		wantIDs  []string
+	}{
+		{
+			name:    "single label match",
+			labels:  map[string]string{"env": "prod"},
+			wantIDs: []string{a1.ID, a3.ID},
+		},
+		{
+			name:    "multi-label AND",
+			labels:  map[string]string{"env": "prod", "team": "platform"},
+			wantIDs: []string{a1.ID},
+		},
+		{
+			name:    "no match",
+			labels:  map[string]string{"env": "dev"},
+			wantIDs: nil,
+		},
+		{
+			name:    "empty filter returns all",
+			labels:  map[string]string{},
+			wantIDs: []string{a1.ID, a2.ID, a3.ID, a4.ID},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := s.ListAgents(ctx, store.AgentFilter{
+				ProjectID: projectID,
+				Labels:    tt.labels,
+			}, store.ListOptions{})
+			require.NoError(t, err)
+			gotIDs := ids(result.Items)
+			assert.ElementsMatch(t, tt.wantIDs, gotIDs)
+		})
+	}
+}
+
 // ids extracts the agent IDs from a slice for order-independent comparison.
 func ids(agents []store.Agent) []string {
 	out := make([]string, len(agents))

--- a/pkg/store/entadapter/agent_store_test.go
+++ b/pkg/store/entadapter/agent_store_test.go
@@ -509,6 +509,10 @@ func TestAgentStore_LabelFiltering(t *testing.T) {
 	a4.Labels = nil
 	require.NoError(t, s.CreateAgent(ctx, a4))
 
+	a5 := makeAgent(projectID, "label-5")
+	a5.Labels = map[string]string{"scion.dev/role": "worker"}
+	require.NoError(t, s.CreateAgent(ctx, a5))
+
 	tests := []struct {
 		name     string
 		labels   map[string]string
@@ -532,7 +536,12 @@ func TestAgentStore_LabelFiltering(t *testing.T) {
 		{
 			name:    "empty filter returns all",
 			labels:  map[string]string{},
-			wantIDs: []string{a1.ID, a2.ID, a3.ID, a4.ID},
+			wantIDs: []string{a1.ID, a2.ID, a3.ID, a4.ID, a5.ID},
+		},
+		{
+			name:    "dotted key",
+			labels:  map[string]string{"scion.dev/role": "worker"},
+			wantIDs: []string{a5.ID},
 		},
 	}
 

--- a/pkg/store/entadapter/dialect.go
+++ b/pkg/store/entadapter/dialect.go
@@ -15,12 +15,47 @@
 package entadapter
 
 import (
+	"fmt"
+
 	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/agent"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/predicate"
 )
+
+// labelContains returns an Ent predicate restricting results to agents whose
+// `labels` JSON object contains the given key-value pair.
+//
+//	SQLite:   json_extract(labels, '$.key') = ?
+//	Postgres: labels @> '{"key":"value"}'::jsonb
+//
+// The Postgres path embeds both key and value into the @> operand literal
+// (after quoting) to use the GIN-indexable containment operator. The SQLite
+// path uses json_extract with a parameterised value to avoid SQL injection.
+func labelContains(key, value string) predicate.Agent {
+	return func(s *entsql.Selector) {
+		col := s.C(agent.FieldLabels)
+		switch s.Dialect() {
+		case dialect.Postgres:
+			s.Where(entsql.P(func(b *entsql.Builder) {
+				b.WriteString(col).
+					WriteString(" @> ").
+					Arg(fmt.Sprintf(`{%q:%q}`, key, value)).
+					WriteString("::jsonb")
+			}))
+		default: // SQLite
+			s.Where(entsql.P(func(b *entsql.Builder) {
+				b.WriteString("json_extract(").
+					WriteString(col).
+					WriteString(", ").
+					Arg("$." + key).
+					WriteString(") = ").
+					Arg(value)
+			}))
+		}
+	}
+}
 
 // ancestryContains returns an Ent predicate restricting results to agents whose
 // `ancestry` JSON array contains principalID.

--- a/pkg/store/entadapter/dialect.go
+++ b/pkg/store/entadapter/dialect.go
@@ -16,6 +16,7 @@ package entadapter
 
 import (
 	"fmt"
+	"strings"
 
 	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
@@ -27,12 +28,16 @@ import (
 // labelContains returns an Ent predicate restricting results to agents whose
 // `labels` JSON object contains the given key-value pair.
 //
-//	SQLite:   json_extract(labels, '$.key') = ?
+//	SQLite:   json_extract(labels, '$."key"') = ?
 //	Postgres: labels @> '{"key":"value"}'::jsonb
 //
 // The Postgres path embeds both key and value into the @> operand literal
 // (after quoting) to use the GIN-indexable containment operator. The SQLite
 // path uses json_extract with a parameterised value to avoid SQL injection.
+//
+// The SQLite json_path uses quoted-member syntax ($."key") so that keys
+// containing dots (e.g. "scion.dev/role") are treated as a single top-level
+// key rather than nested object traversal.
 func labelContains(key, value string) predicate.Agent {
 	return func(s *entsql.Selector) {
 		col := s.C(agent.FieldLabels)
@@ -46,10 +51,11 @@ func labelContains(key, value string) predicate.Agent {
 			}))
 		default: // SQLite
 			s.Where(entsql.P(func(b *entsql.Builder) {
+				escapedKey := strings.ReplaceAll(key, `"`, `\"`)
 				b.WriteString("json_extract(").
 					WriteString(col).
 					WriteString(", ").
-					Arg("$." + key).
+					Arg(fmt.Sprintf(`$."%s"`, escapedKey)).
 					WriteString(") = ").
 					Arg(value)
 			}))

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -197,6 +197,10 @@ type AgentFilter struct {
 	// AncestorID, when non-empty, restricts results to agents whose ancestry
 	// chain contains the given principal ID (transitive access via creation lineage).
 	AncestorID string
+
+	// Labels, when non-empty, restricts results to agents whose labels
+	// contain all specified key-value pairs (AND semantics).
+	Labels map[string]string
 }
 
 // AgentStatusUpdate contains fields for status-only updates.

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -104,6 +104,9 @@ export class ScionPageAgentCreate extends LitElement {
   private notify = true;
 
   @state()
+  private labelEntries: Array<{ key: string; value: string }> = [];
+
+  @state()
   private telemetryEnabled = false;
 
   @state()
@@ -501,6 +504,15 @@ export class ScionPageAgentCreate extends LitElement {
         body.task = this.task.trim();
       }
 
+      const validLabels = this.labelEntries.filter(l => l.key.trim());
+      if (validLabels.length > 0) {
+        const labels: Record<string, string> = {};
+        for (const l of validLabels) {
+          labels[l.key.trim()] = l.value.trim();
+        }
+        body.labels = labels;
+      }
+
       // GCP identity assignment
       if (this.gcpMetadataMode === 'assign' && this.gcpServiceAccountId) {
         body.gcp_identity = {
@@ -631,6 +643,15 @@ export class ScionPageAgentCreate extends LitElement {
       }
       if (this.task.trim()) {
         body.task = this.task.trim();
+      }
+
+      const validLabels = this.labelEntries.filter(l => l.key.trim());
+      if (validLabels.length > 0) {
+        const labels: Record<string, string> = {};
+        for (const l of validLabels) {
+          labels[l.key.trim()] = l.value.trim();
+        }
+        body.labels = labels;
       }
 
       // GCP identity assignment
@@ -1304,6 +1325,58 @@ private selectBrokerForProject(): void {
               resize="auto"
             ></sl-textarea>
             <div class="hint">The task or prompt to start the agent with.</div>
+          </div>
+
+          <div class="form-field">
+            <label>Labels</label>
+            ${this.labelEntries.map(
+              (entry, i) => html`
+                <div style="display: flex; gap: 0.5em; margin-bottom: 0.5em; align-items: center;">
+                  <sl-input
+                    size="small"
+                    placeholder="key"
+                    .value=${entry.key}
+                    @sl-input=${(e: Event) => {
+                      const updated = [...this.labelEntries];
+                      updated[i] = { ...updated[i], key: (e.target as HTMLElement & { value: string }).value };
+                      this.labelEntries = updated;
+                    }}
+                    style="flex: 1;"
+                  ></sl-input>
+                  <sl-input
+                    size="small"
+                    placeholder="value"
+                    .value=${entry.value}
+                    @sl-input=${(e: Event) => {
+                      const updated = [...this.labelEntries];
+                      updated[i] = { ...updated[i], value: (e.target as HTMLElement & { value: string }).value };
+                      this.labelEntries = updated;
+                    }}
+                    style="flex: 1;"
+                  ></sl-input>
+                  <sl-icon-button
+                    name="x-lg"
+                    label="Remove"
+                    @click=${() => {
+                      this.labelEntries = this.labelEntries.filter((_, idx) => idx !== i);
+                    }}
+                  ></sl-icon-button>
+                </div>
+              `
+            )}
+            ${this.labelEntries.length < 16
+              ? html`<sl-button
+                  size="small"
+                  variant="text"
+                  @click=${() => {
+                    this.labelEntries = [...this.labelEntries, { key: '', value: '' }];
+                  }}
+                >
+                  <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+                  Add label
+                </sl-button>`
+              : ''}
+            <div class="hint">Optional key-value labels to organize agents (max 16).</div>
           </div>
 
           <div class="notify-field">

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -456,6 +456,16 @@ export class ScionPageAgentCreate extends LitElement {
     }
   }
 
+  private buildLabels(): Record<string, string> | undefined {
+    const valid = this.labelEntries.filter(l => l.key.trim());
+    if (valid.length === 0) return undefined;
+    const labels: Record<string, string> = {};
+    for (const l of valid) {
+      labels[l.key.trim()] = l.value.trim();
+    }
+    return labels;
+  }
+
   private async handleSubmit(_e: Event): Promise<void> {
     // Validate required fields
     if (!this.name.trim()) {
@@ -504,13 +514,9 @@ export class ScionPageAgentCreate extends LitElement {
         body.task = this.task.trim();
       }
 
-      const validLabels = this.labelEntries.filter(l => l.key.trim());
-      if (validLabels.length > 0) {
-        const labels: Record<string, string> = {};
-        for (const l of validLabels) {
-          labels[l.key.trim()] = l.value.trim();
-        }
-        body.labels = labels;
+      const builtLabels = this.buildLabels();
+      if (builtLabels) {
+        body.labels = builtLabels;
       }
 
       // GCP identity assignment
@@ -645,13 +651,9 @@ export class ScionPageAgentCreate extends LitElement {
         body.task = this.task.trim();
       }
 
-      const validLabels = this.labelEntries.filter(l => l.key.trim());
-      if (validLabels.length > 0) {
-        const labels: Record<string, string> = {};
-        for (const l of validLabels) {
-          labels[l.key.trim()] = l.value.trim();
-        }
-        body.labels = labels;
+      const builtLabels = this.buildLabels();
+      if (builtLabels) {
+        body.labels = builtLabels;
       }
 
       // GCP identity assignment

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -1211,6 +1211,18 @@ export class ScionPageAgentDetail extends LitElement {
                 </div>
               `
             : ''}
+          ${agent.labels && Object.keys(agent.labels).length > 0
+            ? html`
+                <div class="info-item">
+                  <span class="info-label">Labels</span>
+                  <span class="info-value">
+                    ${Object.entries(agent.labels).map(
+                      ([k, v]) => html`<sl-tag size="small" variant="neutral" style="margin: 0.15em;">${k}: ${v}</sl-tag>`
+                    )}
+                  </span>
+                </div>
+              `
+            : ''}
         </div>
       </div>
     `;

--- a/web/src/components/pages/agents.ts
+++ b/web/src/components/pages/agents.ts
@@ -427,9 +427,15 @@ export class ScionPageAgents extends LitElement {
   }
 
   private async fetchAndMergeAgents(): Promise<void> {
-    const url = this.agentScope !== 'all'
-      ? `/api/v1/agents?scope=${this.agentScope}`
-      : '/api/v1/agents';
+    const params = new URLSearchParams();
+    if (this.agentScope !== 'all') {
+      params.set('scope', this.agentScope);
+    }
+    if (this.labelFilter.trim() && this.labelFilter.includes('=')) {
+      params.append('label', this.labelFilter.trim());
+    }
+    const qs = params.toString();
+    const url = qs ? `/api/v1/agents?${qs}` : '/api/v1/agents';
     const response = await apiFetch(url);
 
     if (!response.ok) {
@@ -777,6 +783,8 @@ export class ScionPageAgents extends LitElement {
           @sl-input=${(e: Event) => {
             this.labelFilter = (e.target as HTMLElement & { value: string }).value;
           }}
+          @sl-change=${() => void this.loadAgents()}
+          @sl-clear=${() => { this.labelFilter = ''; void this.loadAgents(); }}
           style="max-width: 220px;"
         >
           <sl-icon slot="prefix" name="tag"></sl-icon>

--- a/web/src/components/pages/agents.ts
+++ b/web/src/components/pages/agents.ts
@@ -96,6 +96,9 @@ export class ScionPageAgents extends LitElement {
   private phaseFilter: AgentPhase | '' = '';
 
   @state()
+  private labelFilter = '';
+
+  @state()
   private sortField: AgentSortField = 'updated';
 
   @state()
@@ -567,6 +570,16 @@ export class ScionPageAgents extends LitElement {
     if (this.phaseFilter) {
       list = list.filter(a => a.phase === this.phaseFilter);
     }
+    if (this.labelFilter.trim()) {
+      const parts = this.labelFilter.trim().split('=');
+      const filterKey = parts[0];
+      const filterValue = parts.slice(1).join('=');
+      list = list.filter(a => {
+        if (!a.labels) return false;
+        if (filterValue) return a.labels[filterKey] === filterValue;
+        return filterKey in a.labels;
+      });
+    }
     const sorted = [...list];
     sorted.sort((a, b) => {
       let cmp = 0;
@@ -756,6 +769,18 @@ export class ScionPageAgents extends LitElement {
             @click=${() => this.setPhaseFilter('error')}
           >Error</button>
         </div>
+        <sl-input
+          size="small"
+          placeholder="Filter by label (key=value)"
+          clearable
+          .value=${this.labelFilter}
+          @sl-input=${(e: Event) => {
+            this.labelFilter = (e.target as HTMLElement & { value: string }).value;
+          }}
+          style="max-width: 220px;"
+        >
+          <sl-icon slot="prefix" name="tag"></sl-icon>
+        </sl-input>
         ${this.viewMode === 'grid' ? html`
           <sl-dropdown>
             <sl-button slot="trigger" size="small" outline>
@@ -975,6 +1000,12 @@ export class ScionPageAgents extends LitElement {
         </div>
 
         ${agent.taskSummary ? html` <div class="agent-task">${agent.taskSummary}</div> ` : ''}
+
+        ${agent.labels && Object.keys(agent.labels).length > 0
+          ? html`<div class="agent-labels" style="margin-top: 0.5em;">${Object.entries(agent.labels).map(
+              ([k, v]) => html`<sl-tag size="small" variant="neutral" style="margin: 0.15em;">${k}: ${v}</sl-tag>`
+            )}</div>`
+          : ''}
 
         <div class="agent-actions">
           ${this.renderActionButtons(agent)}

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -415,6 +415,10 @@ export interface Agent {
   runtimeBrokerName?: string;
   _capabilities?: Capabilities;
 
+  // Labels and annotations
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+
   // Configuration tab fields
   slug?: string;
   image?: string;


### PR DESCRIPTION
## Summary

Implements agent-specific key-value labels (issue https://github.com/ptone/scion/issues/309):

- **Validation package** (`pkg/labels/`): printable ASCII, max 63 chars per key/value, max 16 labels per agent
- **Store-layer filtering**: dialect-aware label predicates (JSONB containment for Postgres, json_extract for SQLite)
- **API**: label validation on create/update (400 on invalid), server-side `?label=key=value` query param filtering on list (global + project-scoped)
- **CLI**: repeatable `--label key=value` flag on `start`, `create`, and `list` commands with client-side validation
- **Web UI**: label chips on agent detail page, label filter on agent list page (server-side query), label input rows on agent create page

Runtime propagation to Docker/Podman labels, Kubernetes pod labels, and Cloud Run service labels was already in place — no changes needed.

## Test plan

- Unit tests for label validation (boundary conditions, constraint violations, edge cases)
- Unit tests for store-layer label filtering (single/multi-label match, no-match, dotted keys)
- `go vet ./...` and `go build ./...` pass
- `go test ./pkg/labels/... ./pkg/store/...` pass
- Web UI builds cleanly (`npm run build`)

## Key files changed

- `pkg/labels/labels.go` / `labels_test.go` — validation package
- `pkg/store/store.go` — AgentFilter.Labels field
- `pkg/store/entadapter/dialect.go` — dialect-aware label predicates
- `pkg/store/entadapter/agent_store.go` / `agent_store_test.go` — store filtering + tests
- `pkg/hub/handlers_agents_core.go` / `handlers_projects_core.go` — API validation + list filtering
- `cmd/start.go` / `create.go` / `list.go` / `common.go` — CLI --label flags
- `web/src/components/pages/agent-detail.ts` / `agents.ts` / `agent-create.ts` — UI display + filtering
