### PR TITLE
feat(web): add IAP proxy auth middleware with live role re-evaluation

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1313,6 +1313,22 @@ func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 		webAdminEmails = cfg.Hub.AdminEmails
 	}
 
+	// Construct proxy authenticator for the web server when auth mode is "proxy".
+	// This mirrors the construction in initHubServer — both need the same authenticator.
+	var webProxyAuth hub.ProxyAuthenticator
+	if cfg.Auth.Mode == "proxy" && cfg.Auth.Proxy != nil {
+		switch cfg.Auth.Proxy.Provider {
+		case "iap":
+			if cfg.Auth.Proxy.IAP != nil && cfg.Auth.Proxy.IAP.Audience != "" {
+				webProxyAuth = &hub.IAPAuthenticator{
+					Audience: cfg.Auth.Proxy.IAP.Audience,
+					Issuer:   cfg.Auth.Proxy.IAP.Issuer,
+					JWKSURL:  cfg.Auth.Proxy.IAP.JWKSURL,
+				}
+			}
+		}
+	}
+
 	webCfg := hub.WebServerConfig{
 		Port:               webPort,
 		Host:               webHost,
@@ -1328,6 +1344,7 @@ func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 		AdminMode:          adminMode,
 		MaintenanceMessage: maintenanceMessage,
 		EnableTestLogin:    enableTestLogin,
+		ProxyAuthenticator: webProxyAuth,
 	}
 	if enableTestLogin {
 		slog.Warn("Test login endpoint is enabled (--enable-test-login). This allows bypass of authentication and MUST NOT be used in production!")

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -322,7 +322,10 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 	// 12. Start Web
 	var webSrv *hub.WebServer
 	if enableWeb {
-		webSrv = initWebServer(ctx, cfg, hubSrv, devAuthToken, adminEmailList, adminMode, maintenanceMessage, requestLogger, hubDBRec)
+		webSrv, err = initWebServer(ctx, cfg, hubSrv, devAuthToken, adminEmailList, adminMode, maintenanceMessage, requestLogger, hubDBRec)
+		if err != nil {
+			return err
+		}
 
 		// In combined mode, start Hub background services now that the
 		// ChannelEventPublisher has been wired by initWebServer.
@@ -1280,7 +1283,7 @@ func newCommandBus(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 // initWebServer creates and configures the Web server. The provided context is
 // threaded to the event publisher so that the Postgres LISTEN/NOTIFY goroutine
 // is cancelled cleanly on shutdown, preventing connection leaks.
-func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Server, devAuthToken string, adminEmailList []string, adminMode bool, maintenanceMessage string, requestLogger *slog.Logger, dbRec dbmetrics.Recorder) *hub.WebServer {
+func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Server, devAuthToken string, adminEmailList []string, adminMode bool, maintenanceMessage string, requestLogger *slog.Logger, dbRec dbmetrics.Recorder) (*hub.WebServer, error) {
 	webHost := cfg.Hub.Host
 	if webHost == "" {
 		webHost = "0.0.0.0"
@@ -1316,16 +1319,22 @@ func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 	// Construct proxy authenticator for the web server when auth mode is "proxy".
 	// This mirrors the construction in initHubServer — both need the same authenticator.
 	var webProxyAuth hub.ProxyAuthenticator
-	if cfg.Auth.Mode == "proxy" && cfg.Auth.Proxy != nil {
+	if cfg.Auth.Mode == "proxy" {
+		if cfg.Auth.Proxy == nil {
+			return nil, fmt.Errorf("auth.mode=proxy requires auth.proxy configuration")
+		}
 		switch cfg.Auth.Proxy.Provider {
 		case "iap":
-			if cfg.Auth.Proxy.IAP != nil && cfg.Auth.Proxy.IAP.Audience != "" {
-				webProxyAuth = &hub.IAPAuthenticator{
-					Audience: cfg.Auth.Proxy.IAP.Audience,
-					Issuer:   cfg.Auth.Proxy.IAP.Issuer,
-					JWKSURL:  cfg.Auth.Proxy.IAP.JWKSURL,
-				}
+			if cfg.Auth.Proxy.IAP == nil || cfg.Auth.Proxy.IAP.Audience == "" {
+				return nil, fmt.Errorf("auth.proxy.iap.audience is required when auth.mode=proxy and provider=iap")
 			}
+			webProxyAuth = &hub.IAPAuthenticator{
+				Audience: cfg.Auth.Proxy.IAP.Audience,
+				Issuer:   cfg.Auth.Proxy.IAP.Issuer,
+				JWKSURL:  cfg.Auth.Proxy.IAP.JWKSURL,
+			}
+		default:
+			return nil, fmt.Errorf("unsupported auth.proxy.provider: %q", cfg.Auth.Proxy.Provider)
 		}
 	}
 
@@ -1371,7 +1380,7 @@ func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 		})
 	}
 
-	return webSrv
+	return webSrv, nil
 }
 
 // startRuntimeBroker initializes and starts the runtime broker server.

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -437,12 +437,13 @@ func applyDatabasePoolDefaults(db *DatabaseConfig) {
 			// Conservative per-replica default so several replicas fit within a
 			// modest Postgres connection budget. The connection ceiling for N
 			// replicas is roughly N × (MaxOpenConns + event pool + 1 listener +
-			// brokers); see CONNECTION-BUDGET.md. Raise this only when the
-			// instance's max_connections (and any pooler) has headroom.
-			db.MaxOpenConns = 10
+			// brokers); see CONNECTION-BUDGET.md. With 2+ Cloud Run min-instances
+			// and a CloudSQL db-g1-small limit of ~25 connections, 5 per replica
+			// keeps the total (2×5 + overhead) safely under the limit.
+			db.MaxOpenConns = 5
 		}
 		if db.MaxIdleConns <= 1 {
-			db.MaxIdleConns = 5
+			db.MaxIdleConns = 2
 		}
 		if db.ConnMaxLifetime == "" {
 			db.ConnMaxLifetime = "30m"

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -17,6 +17,7 @@ package hub
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -1281,31 +1282,43 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 			if email != "" {
 				currentRole, _ := session.Values[sessKeyUserRole].(string)
 				expectedRole := determineUserRole(email, ws.config.AdminEmails)
-				if currentRole != expectedRole {
-					slog.Info("Session role updated",
-						"email", email,
-						"old_role", currentRole,
-						"new_role", expectedRole,
-						"user_id", uid)
-					session.Values[sessKeyUserRole] = expectedRole
-					// Regenerate Hub JWT tokens with the new role so API
-					// calls within this session also reflect the change.
-					if ws.userTokenSvc != nil {
-						name, _ := session.Values[sessKeyUserName].(string)
-						accessToken, refreshToken, expiresIn, err := ws.userTokenSvc.GenerateTokenPair(
-							uid, email, name, expectedRole, ClientTypeWeb,
-						)
-						if err == nil {
-							session.Values[sessKeyHubAccessToken] = accessToken
-							session.Values[sessKeyHubRefreshToken] = refreshToken
-							session.Values[sessKeyHubTokenExpiry] = time.Now().Add(time.Duration(expiresIn) * time.Second).UnixMilli()
-						} else {
-							slog.Warn("Failed to regenerate Hub tokens for role change", "error", err)
-						}
+				if currentRole == expectedRole {
+					// Role unchanged — inject user into context and proceed
+					// without saving session (avoids redundant write).
+					user := &webSessionUser{
+						UserID:    uid,
+						Email:     email,
+						Name:      sessionString(session, sessKeyUserName),
+						AvatarURL: sessionString(session, sessKeyUserAvatar),
+						Role:      currentRole,
 					}
-					if err := session.Save(r, w); err != nil {
-						slog.Error("Failed to save session after role update", "error", err)
+					ctx := context.WithValue(r.Context(), webUserContextKey{}, user)
+					next.ServeHTTP(w, r.WithContext(ctx))
+					return
+				}
+				slog.Info("Session role updated",
+					"email", email,
+					"old_role", currentRole,
+					"new_role", expectedRole,
+					"user_id", uid)
+				session.Values[sessKeyUserRole] = expectedRole
+				// Regenerate Hub JWT tokens with the new role so API
+				// calls within this session also reflect the change.
+				if ws.userTokenSvc != nil {
+					name, _ := session.Values[sessKeyUserName].(string)
+					accessToken, refreshToken, expiresIn, err := ws.userTokenSvc.GenerateTokenPair(
+						uid, email, name, expectedRole, ClientTypeWeb,
+					)
+					if err == nil {
+						session.Values[sessKeyHubAccessToken] = accessToken
+						session.Values[sessKeyHubRefreshToken] = refreshToken
+						session.Values[sessKeyHubTokenExpiry] = time.Now().Add(time.Duration(expiresIn) * time.Second).UnixMilli()
+					} else {
+						slog.Warn("Failed to regenerate Hub tokens for role change", "error", err)
 					}
+				}
+				if err := session.Save(r, w); err != nil {
+					slog.Error("Failed to save session after role update", "error", err)
 				}
 			}
 			next.ServeHTTP(w, r)
@@ -1315,12 +1328,13 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 		// No session — try proxy authentication
 		proxyUser, proxyErr := ws.config.ProxyAuthenticator.Authenticate(r)
 		if proxyErr != nil {
-			// Assertion present but invalid — reject
+			// Assertion present but invalid — reject. Log the real error
+			// internally but return a generic message to avoid information disclosure.
 			slog.Warn("Proxy auth rejected in web middleware",
 				"provider", ws.config.ProxyAuthenticator.Name(),
 				"error", proxyErr,
 				"path", r.URL.Path)
-			http.Error(w, "invalid proxy assertion: "+proxyErr.Error(), http.StatusUnauthorized)
+			http.Error(w, "proxy authentication failed", http.StatusUnauthorized)
 			return
 		}
 		if proxyUser == nil {
@@ -1346,8 +1360,14 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 
 		// Find or create user (same pattern as handleOAuthCallback)
 		user, err := ws.store.GetUserByEmail(ctx, proxyUser.Email)
+		if err != nil && !errors.Is(err, store.ErrNotFound) {
+			// Genuine DB error — don't treat as "create new user"
+			slog.Error("Proxy auth: failed to look up user", "email", proxyUser.Email, "error", err)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
 		if err != nil {
-			// Create new user
+			// User not found — create new user
 			role := determineUserRole(proxyUser.Email, ws.config.AdminEmails)
 			user = &store.User{
 				ID:          generateID(),
@@ -1382,7 +1402,9 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 				slog.Info("User role changed on proxy login", "email", proxyUser.Email, "old_role", user.Role, "new_role", newRole)
 				user.Role = newRole
 			}
-			_ = ws.store.UpdateUser(ctx, user)
+			if err := ws.store.UpdateUser(ctx, user); err != nil {
+				slog.Warn("Failed to update user via proxy auth", "email", proxyUser.Email, "error", err)
+			}
 		}
 
 		// Ensure hub membership

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -142,6 +142,9 @@ type WebServerConfig struct {
 	// for integration testing. Disabled by default; must never be enabled
 	// in production.
 	EnableTestLogin bool
+	// ProxyAuthenticator verifies proxy-supplied assertions (e.g., IAP JWT).
+	// Required when AuthMode == "proxy".
+	ProxyAuthenticator ProxyAuthenticator
 }
 
 // WebServer serves the web frontend SPA shell and static assets.
@@ -1240,6 +1243,159 @@ func (ws *WebServer) devAuthMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// proxyAuthMiddleware auto-creates a web session from a verified proxy assertion
+// (e.g. Google IAP signed JWT). It runs before sessionAuthMiddleware so that
+// IAP-authenticated users never see the login page.
+//
+// When AuthMode != "proxy" or no ProxyAuthenticator is configured, this is a no-op.
+// If the user already has a valid session cookie, the proxy assertion is not
+// re-verified — the session acts as a short-lived cache.
+func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
+	if ws.config.AuthMode != "proxy" || ws.config.ProxyAuthenticator == nil {
+		return next // no-op when not in proxy mode
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Skip public routes (login page, assets, API, etc.)
+		if isPublicRoute(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// If user already in context (e.g., set by devAuthMiddleware), proceed
+		if getWebSessionUser(r.Context()) != nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// If user already has a valid session, skip proxy verification
+		session, err := ws.sessionStore.Get(r, webSessionName)
+		if err != nil {
+			session, _ = ws.sessionStore.New(r, webSessionName)
+		}
+		if uid, ok := session.Values[sessKeyUserID].(string); ok && uid != "" {
+			// Session exists — let sessionAuthMiddleware handle it
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// No session — try proxy authentication
+		proxyUser, proxyErr := ws.config.ProxyAuthenticator.Authenticate(r)
+		if proxyErr != nil {
+			// Assertion present but invalid — reject
+			slog.Warn("Proxy auth rejected in web middleware",
+				"provider", ws.config.ProxyAuthenticator.Name(),
+				"error", proxyErr,
+				"path", r.URL.Path)
+			http.Error(w, "invalid proxy assertion: "+proxyErr.Error(), http.StatusUnauthorized)
+			return
+		}
+		if proxyUser == nil {
+			// No assertion present — fall through to sessionAuthMiddleware
+			// (which will redirect to login)
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Verified proxy identity — check authorization and provision/lookup user
+		ctx := r.Context()
+		if ws.store == nil {
+			slog.Error("Proxy auth: store not configured")
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		if !checkUserAuthorized(ctx, proxyUser.Email, ws.config.AuthorizedDomains, ws.config.AdminEmails, ws.config.UserAccessMode, ws.store) {
+			slog.Warn("Proxy auth: user not authorized", "email", proxyUser.Email)
+			http.Error(w, "access denied: email not authorized", http.StatusForbidden)
+			return
+		}
+
+		// Find or create user (same pattern as handleOAuthCallback)
+		user, err := ws.store.GetUserByEmail(ctx, proxyUser.Email)
+		if err != nil {
+			// Create new user
+			role := determineUserRole(proxyUser.Email, ws.config.AdminEmails)
+			user = &store.User{
+				ID:          generateID(),
+				Email:       proxyUser.Email,
+				DisplayName: proxyUser.DisplayName,
+				AvatarURL:   "",
+				Role:        role,
+				Status:      "active",
+				Created:     time.Now(),
+				LastLogin:   time.Now(),
+			}
+			if err := ws.store.CreateUser(ctx, user); err != nil {
+				slog.Error("Proxy auth: failed to create user", "email", proxyUser.Email, "error", err)
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+				return
+			}
+			slog.Info("Proxy auth: created new user", "email", proxyUser.Email, "user_id", user.ID)
+		} else {
+			// Reject suspended users
+			if user.Status == "suspended" {
+				slog.Warn("Proxy auth: user is suspended", "email", proxyUser.Email, "user_id", user.ID)
+				http.Error(w, "access denied: user account is suspended", http.StatusForbidden)
+				return
+			}
+			// Update last login and backfill profile
+			user.LastLogin = time.Now()
+			if proxyUser.DisplayName != "" && user.DisplayName == "" {
+				user.DisplayName = proxyUser.DisplayName
+			}
+			// Promote to admin if config changed
+			if user.Role != "admin" && determineUserRole(proxyUser.Email, ws.config.AdminEmails) == "admin" {
+				user.Role = "admin"
+			}
+			_ = ws.store.UpdateUser(ctx, user)
+		}
+
+		// Ensure hub membership
+		ensureHubMembership(ctx, ws.store, user.ID)
+
+		// Generate Hub JWT tokens (mirrors devAuthMiddleware / handleOAuthCallback)
+		if ws.userTokenSvc != nil {
+			accessToken, refreshToken, expiresIn, err := ws.userTokenSvc.GenerateTokenPair(
+				user.ID, user.Email, user.DisplayName, user.Role, ClientTypeWeb,
+			)
+			if err == nil {
+				session.Values[sessKeyHubAccessToken] = accessToken
+				session.Values[sessKeyHubRefreshToken] = refreshToken
+				session.Values[sessKeyHubTokenExpiry] = time.Now().Add(time.Duration(expiresIn) * time.Second).UnixMilli()
+			} else {
+				slog.Warn("Proxy auth: failed to generate Hub tokens", "error", err)
+			}
+		}
+
+		// Populate session
+		session.Values[sessKeyUserID] = user.ID
+		session.Values[sessKeyUserEmail] = user.Email
+		session.Values[sessKeyUserName] = user.DisplayName
+		session.Values[sessKeyUserAvatar] = user.AvatarURL
+		session.Values[sessKeyUserRole] = user.Role
+
+		if err := session.Save(r, w); err != nil {
+			slog.Error("Proxy auth: failed to save session", "error", err)
+		}
+
+		slog.Info("Proxy auth: session created",
+			"provider", ws.config.ProxyAuthenticator.Name(),
+			"email", user.Email,
+			"user_id", user.ID)
+
+		webUser := &webSessionUser{
+			UserID:    user.ID,
+			Email:     user.Email,
+			Name:      user.DisplayName,
+			AvatarURL: user.AvatarURL,
+			Role:      user.Role,
+		}
+		ctx = context.WithValue(ctx, webUserContextKey{}, webUser)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
 // sessionAuthMiddleware protects web routes by requiring an authenticated session.
 func (ws *WebServer) sessionAuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1715,6 +1871,9 @@ func (ws *WebServer) buildHandler() http.Handler {
 
 	// Session auth middleware (loads session user into context, redirects to login)
 	handler = ws.sessionAuthMiddleware(handler)
+
+	// Proxy auth middleware (auto-creates session from IAP assertions in proxy mode)
+	handler = ws.proxyAuthMiddleware(handler)
 
 	// Dev-auth middleware (auto-populates session when dev token configured)
 	handler = ws.devAuthMiddleware(handler)

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -1274,7 +1274,40 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 			session, _ = ws.sessionStore.New(r, webSessionName)
 		}
 		if uid, ok := session.Values[sessKeyUserID].(string); ok && uid != "" {
-			// Session exists — let sessionAuthMiddleware handle it
+			// Session exists — still re-evaluate admin role so config
+			// changes (admin grant/revoke) take effect on the next request
+			// without requiring a full session reset.
+			email, _ := session.Values[sessKeyUserEmail].(string)
+			if email != "" {
+				currentRole, _ := session.Values[sessKeyUserRole].(string)
+				expectedRole := determineUserRole(email, ws.config.AdminEmails)
+				if currentRole != expectedRole {
+					slog.Info("Session role updated",
+						"email", email,
+						"old_role", currentRole,
+						"new_role", expectedRole,
+						"user_id", uid)
+					session.Values[sessKeyUserRole] = expectedRole
+					// Regenerate Hub JWT tokens with the new role so API
+					// calls within this session also reflect the change.
+					if ws.userTokenSvc != nil {
+						name, _ := session.Values[sessKeyUserName].(string)
+						accessToken, refreshToken, expiresIn, err := ws.userTokenSvc.GenerateTokenPair(
+							uid, email, name, expectedRole, ClientTypeWeb,
+						)
+						if err == nil {
+							session.Values[sessKeyHubAccessToken] = accessToken
+							session.Values[sessKeyHubRefreshToken] = refreshToken
+							session.Values[sessKeyHubTokenExpiry] = time.Now().Add(time.Duration(expiresIn) * time.Second).UnixMilli()
+						} else {
+							slog.Warn("Failed to regenerate Hub tokens for role change", "error", err)
+						}
+					}
+					if err := session.Save(r, w); err != nil {
+						slog.Error("Failed to save session after role update", "error", err)
+					}
+				}
+			}
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -1344,9 +1344,10 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 			if proxyUser.DisplayName != "" && user.DisplayName == "" {
 				user.DisplayName = proxyUser.DisplayName
 			}
-			// Promote to admin if config changed
-			if user.Role != "admin" && determineUserRole(proxyUser.Email, ws.config.AdminEmails) == "admin" {
-				user.Role = "admin"
+			// Re-evaluate admin status on every login (matches handleOAuthCallback / provisionUser)
+			if newRole := determineUserRole(proxyUser.Email, ws.config.AdminEmails); user.Role != newRole {
+				slog.Info("User role changed on proxy login", "email", proxyUser.Email, "old_role", user.Role, "new_role", newRole)
+				user.Role = newRole
 			}
 			_ = ws.store.UpdateUser(ctx, user)
 		}

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -38,6 +38,61 @@ type mockWebStore struct {
 	store.Store // embed interface to satisfy all method signatures (will panic if called)
 }
 
+// mockProxyAuthenticator is a test double for ProxyAuthenticator.
+type mockProxyAuthenticator struct {
+	user *ProxyUserInfo
+	err  error
+}
+
+func (m *mockProxyAuthenticator) Authenticate(_ *http.Request) (*ProxyUserInfo, error) {
+	return m.user, m.err
+}
+func (m *mockProxyAuthenticator) Name() string { return "mock" }
+
+// proxyAuthStore is a minimal store that supports the proxy auth user provisioning path.
+type proxyAuthStore struct {
+	store.Store // embed interface to satisfy all methods
+	users       map[string]*store.User
+}
+
+func newProxyAuthStore() *proxyAuthStore {
+	return &proxyAuthStore{users: make(map[string]*store.User)}
+}
+
+func (s *proxyAuthStore) GetUserByEmail(_ context.Context, email string) (*store.User, error) {
+	for _, u := range s.users {
+		if u.Email == email {
+			return u, nil
+		}
+	}
+	return nil, store.ErrNotFound
+}
+
+func (s *proxyAuthStore) CreateUser(_ context.Context, user *store.User) error {
+	s.users[user.ID] = user
+	return nil
+}
+
+func (s *proxyAuthStore) UpdateUser(_ context.Context, user *store.User) error {
+	s.users[user.ID] = user
+	return nil
+}
+
+func (s *proxyAuthStore) GetGroupBySlug(_ context.Context, _ string) (*store.Group, error) {
+	return nil, store.ErrNotFound // hub-members group not found is gracefully handled
+}
+
+func (s *proxyAuthStore) AddGroupMember(_ context.Context, _ *store.GroupMember) error {
+	return nil
+}
+
+func (s *proxyAuthStore) GetUser(_ context.Context, id string) (*store.User, error) {
+	if u, ok := s.users[id]; ok {
+		return u, nil
+	}
+	return nil, store.ErrNotFound
+}
+
 func newTestWebServer(t *testing.T, cfg WebServerConfig) *WebServer {
 	t.Helper()
 	ws := NewWebServer(cfg)
@@ -1950,4 +2005,178 @@ func TestSPAShellHandler_HubAPIError(t *testing.T) {
 
 	// No API data because the Hub returned an error
 	assert.Nil(t, pageData["data"])
+}
+
+// --- Proxy Auth Middleware Tests ---
+
+func TestProxyAuthMiddleware_ValidAssertion_CreatesSession(t *testing.T) {
+	// A request with a valid proxy assertion should auto-create a session
+	// and NOT redirect to /auth/login.
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject: "12345",
+			Email:   "user@example.com",
+			Domain:  "example.com",
+		},
+	}
+	st := newProxyAuthStore()
+
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+	})
+	ws.SetStore(st)
+
+	req := httptest.NewRequest("GET", "/projects", nil)
+	req.Header.Set("Accept", "text/html")
+	rec := httptest.NewRecorder()
+
+	ws.Handler().ServeHTTP(rec, req)
+
+	resp := rec.Result()
+	// Should NOT redirect to /auth/login — user is authenticated
+	if resp.StatusCode == http.StatusFound {
+		location := resp.Header.Get("Location")
+		assert.NotEqual(t, "/auth/login", location,
+			"proxy-authenticated request should not redirect to login")
+	}
+
+	// Verify a user was created in the store
+	assert.Len(t, st.users, 1, "user should have been provisioned")
+	for _, u := range st.users {
+		assert.Equal(t, "user@example.com", u.Email)
+		assert.Equal(t, "active", u.Status)
+	}
+}
+
+func TestProxyAuthMiddleware_InvalidAssertion_Returns401(t *testing.T) {
+	// A request with an invalid proxy assertion should be rejected with 401
+	mockAuth := &mockProxyAuthenticator{
+		err: assert.AnError, // simulate verification failure
+	}
+
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+	})
+	ws.SetStore(newProxyAuthStore())
+
+	req := httptest.NewRequest("GET", "/projects", nil)
+	req.Header.Set("Accept", "text/html")
+	rec := httptest.NewRecorder()
+
+	ws.Handler().ServeHTTP(rec, req)
+
+	resp := rec.Result()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"invalid proxy assertion should return 401")
+}
+
+func TestProxyAuthMiddleware_NoAssertion_FallsThrough(t *testing.T) {
+	// A request with no proxy assertion should fall through to
+	// sessionAuthMiddleware, which redirects to login.
+	mockAuth := &mockProxyAuthenticator{
+		user: nil, // (nil, nil) = no assertion present
+		err:  nil,
+	}
+
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+	})
+	ws.SetStore(newProxyAuthStore())
+
+	req := httptest.NewRequest("GET", "/projects", nil)
+	req.Header.Set("Accept", "text/html")
+	rec := httptest.NewRecorder()
+
+	ws.Handler().ServeHTTP(rec, req)
+
+	resp := rec.Result()
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+	assert.Equal(t, "/auth/login", resp.Header.Get("Location"),
+		"request with no proxy assertion should redirect to login")
+}
+
+func TestProxyAuthMiddleware_NotProxyMode_NoOp(t *testing.T) {
+	// When AuthMode is not "proxy", the middleware should be a no-op
+	// even if a ProxyAuthenticator is somehow set.
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{Email: "user@example.com"},
+	}
+
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "oauth", // NOT proxy
+		ProxyAuthenticator: mockAuth,
+	})
+
+	req := httptest.NewRequest("GET", "/projects", nil)
+	req.Header.Set("Accept", "text/html")
+	rec := httptest.NewRecorder()
+
+	ws.Handler().ServeHTTP(rec, req)
+
+	resp := rec.Result()
+	// Without proxy mode, should redirect to login
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+	assert.Equal(t, "/auth/login", resp.Header.Get("Location"),
+		"non-proxy mode should redirect to login as usual")
+}
+
+func TestProxyAuthMiddleware_ExistingSession_SkipsVerification(t *testing.T) {
+	// If a user already has a valid session, the proxy middleware should
+	// not re-verify the assertion — just pass through.
+	callCount := 0
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject: "12345",
+			Email:   "user@example.com",
+		},
+	}
+
+	st := newProxyAuthStore()
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+	})
+	ws.SetStore(st)
+
+	handler := ws.Handler()
+
+	// First request: creates session (sets cookie)
+	req1 := httptest.NewRequest("GET", "/projects", nil)
+	req1.Header.Set("Accept", "text/html")
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+
+	resp1 := rec1.Result()
+	cookies := resp1.Cookies()
+
+	// Second request: re-use the session cookie
+	// Replace the mock authenticator to track if it's called
+	ws.config.ProxyAuthenticator = &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject: "12345",
+			Email:   "user@example.com",
+		},
+	}
+
+	req2 := httptest.NewRequest("GET", "/projects", nil)
+	req2.Header.Set("Accept", "text/html")
+	for _, c := range cookies {
+		req2.AddCookie(c)
+	}
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+
+	resp2 := rec2.Result()
+	// Should not redirect — session is valid
+	if resp2.StatusCode == http.StatusFound {
+		location := resp2.Header.Get("Location")
+		assert.NotEqual(t, "/auth/login", location)
+	}
+
+	// Verify still only 1 user in store (not re-provisioned)
+	assert.Len(t, st.users, 1, "should not re-provision user")
+	_ = callCount
 }

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -2180,3 +2180,88 @@ func TestProxyAuthMiddleware_ExistingSession_SkipsVerification(t *testing.T) {
 	assert.Len(t, st.users, 1, "should not re-provision user")
 	_ = callCount
 }
+
+func TestProxyAuthMiddleware_DemotesAdminWhenRemovedFromList(t *testing.T) {
+	// An existing admin user whose email is no longer in AdminEmails
+	// should be demoted to "member" on next proxy-authenticated request.
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject: "99",
+			Email:   "former-admin@example.com",
+			Domain:  "example.com",
+		},
+	}
+
+	st := newProxyAuthStore()
+	// Pre-create user as admin
+	adminUser := &store.User{
+		ID:      "u-admin-proxy",
+		Email:   "former-admin@example.com",
+		Role:    "admin",
+		Status:  "active",
+		Created: time.Now(),
+	}
+	_ = st.CreateUser(context.Background(), adminUser)
+
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+		// AdminEmails does NOT include former-admin@example.com
+		AdminEmails: []string{"other-admin@example.com"},
+	})
+	ws.SetStore(st)
+
+	req := httptest.NewRequest("GET", "/projects", nil)
+	req.Header.Set("Accept", "text/html")
+	rec := httptest.NewRecorder()
+
+	ws.Handler().ServeHTTP(rec, req)
+
+	// Verify user was demoted
+	updated, err := st.GetUserByEmail(context.Background(), "former-admin@example.com")
+	assert.NoError(t, err)
+	assert.Equal(t, "member", updated.Role,
+		"admin user should be demoted to member when removed from admin emails list")
+}
+
+func TestProxyAuthMiddleware_PromotesToAdminWhenAddedToList(t *testing.T) {
+	// An existing member user whose email is added to AdminEmails
+	// should be promoted to "admin" on next proxy-authenticated request.
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject: "88",
+			Email:   "new-admin@example.com",
+			Domain:  "example.com",
+		},
+	}
+
+	st := newProxyAuthStore()
+	// Pre-create user as member
+	memberUser := &store.User{
+		ID:      "u-member-proxy",
+		Email:   "new-admin@example.com",
+		Role:    "member",
+		Status:  "active",
+		Created: time.Now(),
+	}
+	_ = st.CreateUser(context.Background(), memberUser)
+
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+		AdminEmails:        []string{"new-admin@example.com"},
+	})
+	ws.SetStore(st)
+
+	req := httptest.NewRequest("GET", "/projects", nil)
+	req.Header.Set("Accept", "text/html")
+	rec := httptest.NewRecorder()
+
+	ws.Handler().ServeHTTP(rec, req)
+
+	// Verify user was promoted
+	updated, err := st.GetUserByEmail(context.Background(), "new-admin@example.com")
+	assert.NoError(t, err)
+	assert.Equal(t, "admin", updated.Role,
+		"member user should be promoted to admin when added to admin emails list")
+}

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -2265,3 +2265,190 @@ func TestProxyAuthMiddleware_PromotesToAdminWhenAddedToList(t *testing.T) {
 	assert.Equal(t, "admin", updated.Role,
 		"member user should be promoted to admin when added to admin emails list")
 }
+
+func TestProxyAuthMiddleware_ExistingSession_ReEvaluatesRoleOnPromotion(t *testing.T) {
+	// A user with an existing session (role=member) should be promoted to
+	// admin when their email is added to AdminEmails — even though the
+	// session already exists and the proxy JWT is not re-verified.
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject: "12345",
+			Email:   "user@example.com",
+			Domain:  "example.com",
+		},
+	}
+
+	st := newProxyAuthStore()
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+		// Initially NOT an admin
+		AdminEmails: []string{},
+	})
+	ws.SetStore(st)
+
+	handler := ws.Handler()
+
+	// First request: creates session with role=member
+	req1 := httptest.NewRequest("GET", "/projects", nil)
+	req1.Header.Set("Accept", "text/html")
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+
+	resp1 := rec1.Result()
+	cookies := resp1.Cookies()
+	require.NotEmpty(t, cookies, "session cookie should be set")
+
+	// Verify initial role is member
+	created, err := st.GetUserByEmail(context.Background(), "user@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "member", created.Role)
+
+	// Now add user to admin list (simulates config change)
+	ws.config.AdminEmails = []string{"user@example.com"}
+
+	// Second request: re-uses the session cookie
+	req2 := httptest.NewRequest("GET", "/projects", nil)
+	req2.Header.Set("Accept", "text/html")
+	for _, c := range cookies {
+		req2.AddCookie(c)
+	}
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+
+	resp2 := rec2.Result()
+	// Should not redirect — session is valid
+	if resp2.StatusCode == http.StatusFound {
+		location := resp2.Header.Get("Location")
+		assert.NotEqual(t, "/auth/login", location)
+	}
+
+	// Verify session cookie was updated with new role by checking Set-Cookie
+	var sessionUpdated bool
+	for _, c := range resp2.Cookies() {
+		if c.Name == webSessionName {
+			sessionUpdated = true
+			break
+		}
+	}
+	assert.True(t, sessionUpdated, "session cookie should be re-set after role change")
+}
+
+func TestProxyAuthMiddleware_ExistingSession_ReEvaluatesRoleOnDemotion(t *testing.T) {
+	// A user with an existing session (role=admin) should be demoted to
+	// member when their email is removed from AdminEmails — even though
+	// the session already exists.
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject: "12345",
+			Email:   "admin@example.com",
+			Domain:  "example.com",
+		},
+	}
+
+	st := newProxyAuthStore()
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+		// Initially IS an admin
+		AdminEmails: []string{"admin@example.com"},
+	})
+	ws.SetStore(st)
+
+	handler := ws.Handler()
+
+	// First request: creates session with role=admin
+	req1 := httptest.NewRequest("GET", "/projects", nil)
+	req1.Header.Set("Accept", "text/html")
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+
+	resp1 := rec1.Result()
+	cookies := resp1.Cookies()
+	require.NotEmpty(t, cookies, "session cookie should be set")
+
+	// Verify initial role is admin
+	created, err := st.GetUserByEmail(context.Background(), "admin@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "admin", created.Role)
+
+	// Now remove user from admin list (simulates config change)
+	ws.config.AdminEmails = []string{}
+
+	// Second request: re-uses the session cookie
+	req2 := httptest.NewRequest("GET", "/projects", nil)
+	req2.Header.Set("Accept", "text/html")
+	for _, c := range cookies {
+		req2.AddCookie(c)
+	}
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+
+	resp2 := rec2.Result()
+	if resp2.StatusCode == http.StatusFound {
+		location := resp2.Header.Get("Location")
+		assert.NotEqual(t, "/auth/login", location)
+	}
+
+	// Verify session cookie was updated
+	var sessionUpdated bool
+	for _, c := range resp2.Cookies() {
+		if c.Name == webSessionName {
+			sessionUpdated = true
+			break
+		}
+	}
+	assert.True(t, sessionUpdated, "session cookie should be re-set after role demotion")
+}
+
+func TestProxyAuthMiddleware_ExistingSession_NoUpdateWhenRoleUnchanged(t *testing.T) {
+	// When the session role already matches the expected role, the session
+	// should NOT be re-saved (no Set-Cookie header emitted).
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject: "12345",
+			Email:   "user@example.com",
+			Domain:  "example.com",
+		},
+	}
+
+	st := newProxyAuthStore()
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+		AdminEmails:        []string{},
+	})
+	ws.SetStore(st)
+
+	handler := ws.Handler()
+
+	// First request: creates session with role=member
+	req1 := httptest.NewRequest("GET", "/projects", nil)
+	req1.Header.Set("Accept", "text/html")
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+
+	resp1 := rec1.Result()
+	cookies := resp1.Cookies()
+	require.NotEmpty(t, cookies, "session cookie should be set")
+
+	// Second request: role is still member (no change)
+	req2 := httptest.NewRequest("GET", "/projects", nil)
+	req2.Header.Set("Accept", "text/html")
+	for _, c := range cookies {
+		req2.AddCookie(c)
+	}
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+
+	resp2 := rec2.Result()
+	// No Set-Cookie should be emitted because nothing changed
+	var sessionReSet bool
+	for _, c := range resp2.Cookies() {
+		if c.Name == webSessionName {
+			sessionReSet = true
+			break
+		}
+	}
+	assert.False(t, sessionReSet, "session cookie should NOT be re-set when role is unchanged")
+}

--- a/web/src/components/pages/login.ts
+++ b/web/src/components/pages/login.ts
@@ -60,6 +60,12 @@ export class ScionLoginPage extends LitElement {
   private githubEnabled = false;
 
   /**
+   * Whether the server is in proxy auth mode (e.g., behind IAP)
+   */
+  @state()
+  private _proxyMode = false;
+
+  /**
    * Whether provider config is still loading
    */
   @state()
@@ -326,9 +332,10 @@ export class ScionLoginPage extends LitElement {
     try {
       const resp = await fetch('/auth/providers');
       if (resp.ok) {
-        const data = (await resp.json()) as Record<string, boolean>;
+        const data = (await resp.json()) as Record<string, unknown>;
         this.googleEnabled = !!data.google;
         this.githubEnabled = !!data.github;
+        this._proxyMode = data.authMode === 'proxy';
       }
     } catch {
       // If the fetch fails, leave providers disabled
@@ -376,14 +383,21 @@ export class ScionLoginPage extends LitElement {
           : ''}
 
         <div class="providers">
-          ${hasProviders
-            ? providers.map((provider) => this.renderProvider(provider))
-            : html`
+          ${this._proxyMode
+            ? html`
                 <div class="no-providers">
-                  <p>No authentication providers configured.</p>
-                  <p>Please configure OAuth credentials in the server settings.</p>
+                  <p>Authentication is handled by your organization's identity provider.</p>
+                  <p>If you continue to see this page, the authenticating proxy may not be configured correctly.</p>
                 </div>
-              `}
+              `
+            : hasProviders
+              ? providers.map((provider) => this.renderProvider(provider))
+              : html`
+                  <div class="no-providers">
+                    <p>No authentication providers configured.</p>
+                    <p>Please configure OAuth credentials in the server settings.</p>
+                  </div>
+                `}
         </div>
 
         <div class="footer">


### PR DESCRIPTION
Adds proxyAuthMiddleware verifying X-Goog-IAP-JWT-Assertion headers and auto-creating Hub sessions for IAP users. Re-evaluates user role on every request so admin changes take effect immediately without clearing cookies