### PR TITLE
feat(config): Cloud Run HA deployment config with fail-closed guards i

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -733,7 +733,7 @@ func validateHostedHAPreflight(cfg *config.GlobalConfig) error {
 	if cfg.Auth.Proxy.IAP == nil || strings.TrimSpace(cfg.Auth.Proxy.IAP.Audience) == "" {
 		return fmt.Errorf("hosted production HA requires server.auth.proxy.iap.audience")
 	}
-	proxyAudience := strings.TrimSpace(cfg.Auth.Proxy.IAP.Audience)
+	proxyAudience := strings.TrimRight(strings.TrimSpace(cfg.Auth.Proxy.IAP.Audience), "/")
 	if !isCloudRunIAPAudience(proxyAudience) {
 		return fmt.Errorf("hosted production HA requires a Cloud Run native IAP audience (/projects/<number>/locations/<region>/services/<service>); got %q", proxyAudience)
 	}
@@ -744,7 +744,7 @@ func validateHostedHAPreflight(cfg *config.GlobalConfig) error {
 	if cfg.Auth.Transport.Mode != "iap" {
 		return fmt.Errorf("hosted production HA requires server.auth.transport.mode=iap; got %q", cfg.Auth.Transport.Mode)
 	}
-	transportAudience := strings.TrimSpace(cfg.Auth.Transport.OIDCAudience)
+	transportAudience := strings.TrimRight(strings.TrimSpace(cfg.Auth.Transport.OIDCAudience), "/")
 	if transportAudience == "" {
 		return fmt.Errorf("hosted production HA requires server.auth.transport.oidc_audience")
 	}

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -138,6 +138,10 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no server components enabled; use --enable-hub, --enable-runtime-broker, or --enable-web")
 	}
 
+	if err := validateHostedHAPreflight(cfg); err != nil {
+		return err
+	}
+
 	// 6. Check ports
 	if err := checkServerPorts(cfg); err != nil {
 		return err
@@ -294,7 +298,10 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 
 		if !enableWeb {
 			// Hub runs its own HTTP server (standalone mode).
-			eventPub := newEventPublisher(ctx, cfg, hubDBRec)
+			eventPub, err := newEventPublisher(ctx, cfg, hubDBRec)
+			if err != nil {
+				return err
+			}
 			hubSrv.SetEventPublisher(eventPub)
 
 			log.Printf("Starting Hub API server on %s:%d", cfg.Hub.Host, cfg.Hub.Port)
@@ -322,7 +329,10 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 	// 12. Start Web
 	var webSrv *hub.WebServer
 	if enableWeb {
-		webSrv = initWebServer(ctx, cfg, hubSrv, devAuthToken, adminEmailList, adminMode, maintenanceMessage, requestLogger, hubDBRec)
+		webSrv, err = initWebServer(ctx, cfg, hubSrv, devAuthToken, adminEmailList, adminMode, maintenanceMessage, requestLogger, hubDBRec)
+		if err != nil {
+			return err
+		}
 
 		// In combined mode, start Hub background services now that the
 		// ChannelEventPublisher has been wired by initWebServer.
@@ -684,6 +694,79 @@ func loadAndReconcileConfig(cmd *cobra.Command) (*config.GlobalConfig, error) {
 	}
 
 	return cfg, nil
+}
+
+func hostedHAGuardsRequired(cfg *config.GlobalConfig) bool {
+	return hostedMode && enableHub && cfg != nil
+}
+
+func validateHostedHAPreflight(cfg *config.GlobalConfig) error {
+	if !hostedHAGuardsRequired(cfg) {
+		return nil
+	}
+
+	if !strings.EqualFold(cfg.Database.Driver, "postgres") {
+		return fmt.Errorf("hosted production HA requires server.database.driver=postgres; got %q", cfg.Database.Driver)
+	}
+	if strings.TrimSpace(cfg.Database.URL) == "" {
+		return fmt.Errorf("hosted production HA requires server.database.url for Postgres")
+	}
+
+	if !strings.EqualFold(cfg.Storage.Provider, "gcs") || strings.TrimSpace(cfg.Storage.Bucket) == "" {
+		return fmt.Errorf("hosted production HA requires server.storage.provider=gcs and server.storage.bucket; local storage is not HA-safe")
+	}
+
+	if strings.TrimSpace(resolveSessionSecret()) == "" {
+		return fmt.Errorf("hosted production HA requires a durable session/signing secret; set --session-secret or SCION_SERVER_SESSION_SECRET")
+	}
+
+	if cfg.Auth.Mode != "proxy" {
+		return fmt.Errorf("hosted production HA requires server.auth.mode=proxy for Cloud Run IAP; got %q", cfg.Auth.Mode)
+	}
+	if cfg.Auth.Proxy == nil || cfg.Auth.Proxy.Provider != "iap" {
+		provider := ""
+		if cfg.Auth.Proxy != nil {
+			provider = cfg.Auth.Proxy.Provider
+		}
+		return fmt.Errorf("hosted production HA requires server.auth.proxy.provider=iap; got %q", provider)
+	}
+	if cfg.Auth.Proxy.IAP == nil || strings.TrimSpace(cfg.Auth.Proxy.IAP.Audience) == "" {
+		return fmt.Errorf("hosted production HA requires server.auth.proxy.iap.audience")
+	}
+	proxyAudience := strings.TrimSpace(cfg.Auth.Proxy.IAP.Audience)
+	if !isCloudRunIAPAudience(proxyAudience) {
+		return fmt.Errorf("hosted production HA requires a Cloud Run native IAP audience (/projects/<number>/locations/<region>/services/<service>); got %q", proxyAudience)
+	}
+
+	if cfg.Auth.Transport == nil {
+		return fmt.Errorf("hosted production HA requires server.auth.transport; do not use server.transport")
+	}
+	if cfg.Auth.Transport.Mode != "iap" {
+		return fmt.Errorf("hosted production HA requires server.auth.transport.mode=iap; got %q", cfg.Auth.Transport.Mode)
+	}
+	transportAudience := strings.TrimSpace(cfg.Auth.Transport.OIDCAudience)
+	if transportAudience == "" {
+		return fmt.Errorf("hosted production HA requires server.auth.transport.oidc_audience")
+	}
+	if transportAudience != proxyAudience {
+		return fmt.Errorf("hosted production HA requires server.auth.transport.oidc_audience to match server.auth.proxy.iap.audience")
+	}
+	if strings.TrimSpace(cfg.Auth.Transport.PlatformAuthSA) == "" {
+		return fmt.Errorf("hosted production HA requires server.auth.transport.platform_auth_sa")
+	}
+
+	return nil
+}
+
+func isCloudRunIAPAudience(audience string) bool {
+	parts := strings.Split(strings.TrimSpace(audience), "/")
+	if len(parts) != 7 {
+		return false
+	}
+	return parts[0] == "" &&
+		parts[1] == "projects" && parts[2] != "" &&
+		parts[3] == "locations" && parts[4] != "" &&
+		parts[5] == "services" && parts[6] != ""
 }
 
 // checkServerPorts checks that required server ports are available.
@@ -1124,7 +1207,9 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 	// can create its proxy with the ChannelEventPublisher.
 
 	// Initialize storage
-	initHubStorage(ctx, hubSrv, cfg, globalDir)
+	if err := initHubStorage(ctx, hubSrv, cfg, globalDir); err != nil {
+		return nil, err
+	}
 
 	// Hub ID was already resolved and set during initHubServer via ServerConfig.HubID
 	hubID := hubSrv.HubID()
@@ -1187,7 +1272,7 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 }
 
 // initHubStorage initializes the storage backend for the Hub server.
-func initHubStorage(ctx context.Context, hubSrv *hub.Server, cfg *config.GlobalConfig, globalDir string) {
+func initHubStorage(ctx context.Context, hubSrv *hub.Server, cfg *config.GlobalConfig, globalDir string) error {
 	if storageBucket != "" {
 		log.Printf("Initializing GCS storage with bucket: %s", storageBucket)
 		storageCfg := storage.Config{
@@ -1196,8 +1281,11 @@ func initHubStorage(ctx context.Context, hubSrv *hub.Server, cfg *config.GlobalC
 		}
 		stor, err := storage.New(ctx, storageCfg)
 		if err != nil {
+			if hostedHAGuardsRequired(cfg) {
+				return fmt.Errorf("failed to initialize required GCS storage: %w", err)
+			}
 			log.Printf("Warning: failed to initialize GCS storage: %v", err)
-			return
+			return nil
 		}
 		hubSrv.SetStorage(stor)
 		log.Printf("GCS storage configured: gs://%s", storageBucket)
@@ -1210,7 +1298,7 @@ func initHubStorage(ctx context.Context, hubSrv *hub.Server, cfg *config.GlobalC
 		stor, err := storage.New(ctx, storageCfg)
 		if err != nil {
 			log.Printf("Warning: failed to initialize local storage: %v", err)
-			return
+			return nil
 		}
 		hubSrv.SetStorage(stor)
 		log.Printf("Local storage configured: %s", storageDir)
@@ -1226,32 +1314,35 @@ func initHubStorage(ctx context.Context, hubSrv *hub.Server, cfg *config.GlobalC
 		stor, err := storage.New(ctx, storageCfg)
 		if err != nil {
 			log.Printf("Warning: failed to initialize local storage fallback: %v", err)
-			return
+			return nil
 		}
 		hubSrv.SetStorage(stor)
 	}
+	return nil
 }
 
 // newEventPublisher selects the event publisher backend based on the configured
 // database driver. With Postgres it returns a PostgresEventPublisher
 // (cross-replica LISTEN/NOTIFY); otherwise it returns the in-process
-// ChannelEventPublisher. If the Postgres publisher cannot be started it falls
-// back to the in-process publisher so a single instance still functions, logging
-// a prominent warning since cross-replica SSE delivery will be unavailable.
-func newEventPublisher(ctx context.Context, cfg *config.GlobalConfig, dbRec dbmetrics.Recorder) hub.EventPublisher {
+// ChannelEventPublisher. If the Postgres publisher cannot be started in hosted
+// HA mode startup fails closed because in-process events cannot cross replicas.
+func newEventPublisher(ctx context.Context, cfg *config.GlobalConfig, dbRec dbmetrics.Recorder) (hub.EventPublisher, error) {
 	if strings.EqualFold(cfg.Database.Driver, "postgres") {
 		if dbRec == nil {
 			dbRec = dbmetrics.NewDisabled()
 		}
 		pub, err := hub.NewPostgresEventPublisher(ctx, cfg.Database.URL, dbRec, logging.Subsystem("hub.events"))
 		if err != nil {
+			if hostedHAGuardsRequired(cfg) {
+				return nil, fmt.Errorf("failed to start required Postgres event publisher: %w", err)
+			}
 			log.Printf("WARNING: failed to start Postgres event publisher (%v); falling back to in-process events. Cross-replica SSE will not work.", err)
-			return hub.NewChannelEventPublisher()
+			return hub.NewChannelEventPublisher(), nil
 		}
 		log.Printf("Using Postgres LISTEN/NOTIFY event publisher")
-		return pub
+		return pub, nil
 	}
-	return hub.NewChannelEventPublisher()
+	return hub.NewChannelEventPublisher(), nil
 }
 
 // newCommandBus selects the command bus backend. With Postgres it returns a
@@ -1280,7 +1371,7 @@ func newCommandBus(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 // initWebServer creates and configures the Web server. The provided context is
 // threaded to the event publisher so that the Postgres LISTEN/NOTIFY goroutine
 // is cancelled cleanly on shutdown, preventing connection leaks.
-func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Server, devAuthToken string, adminEmailList []string, adminMode bool, maintenanceMessage string, requestLogger *slog.Logger, dbRec dbmetrics.Recorder) *hub.WebServer {
+func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Server, devAuthToken string, adminEmailList []string, adminMode bool, maintenanceMessage string, requestLogger *slog.Logger, dbRec dbmetrics.Recorder) (*hub.WebServer, error) {
 	webHost := cfg.Hub.Host
 	if webHost == "" {
 		webHost = "0.0.0.0"
@@ -1336,7 +1427,10 @@ func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 	webSrv.SetRequestLogger(requestLogger)
 
 	// Create shared event publisher for real-time SSE
-	eventPub := newEventPublisher(ctx, cfg, dbRec)
+	eventPub, err := newEventPublisher(ctx, cfg, dbRec)
+	if err != nil {
+		return nil, err
+	}
 	webSrv.SetEventPublisher(eventPub)
 
 	// Wire Hub services into WebServer if Hub is enabled
@@ -1354,7 +1448,7 @@ func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 		})
 	}
 
-	return webSrv
+	return webSrv, nil
 }
 
 // startRuntimeBroker initializes and starts the runtime broker server.

--- a/cmd/server_ha_preflight_test.go
+++ b/cmd/server_ha_preflight_test.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/hub"
+	"github.com/stretchr/testify/require"
+)
+
+func validHostedHAConfig() *config.GlobalConfig {
+	cfg := config.DefaultGlobalConfig()
+	cfg.Mode = "hosted"
+	cfg.Database.Driver = "postgres"
+	cfg.Database.URL = "postgres://scion:secret@localhost/scionhub"
+	cfg.Storage.Provider = "gcs"
+	cfg.Storage.Bucket = "scion-prod-artifacts"
+	cfg.Auth.Mode = "proxy"
+	cfg.Auth.Proxy = &config.ProxyAuthConfig{
+		Provider: "iap",
+		IAP: &config.IAPAuthConfig{
+			Audience: "/projects/123456789/locations/us-central1/services/scion-hub",
+		},
+	}
+	cfg.Auth.Transport = &config.TransportAuthConfig{
+		Mode:           "iap",
+		OIDCAudience:   "/projects/123456789/locations/us-central1/services/scion-hub",
+		PlatformAuthSA: "scion-transport@example.iam.gserviceaccount.com",
+	}
+	return &cfg
+}
+
+func withHostedHAGuards(t *testing.T) {
+	t.Helper()
+	resetServerFlags()
+	hostedMode = true
+	enableHub = true
+	t.Setenv("SCION_SERVER_SESSION_SECRET", "durable-test-secret")
+	t.Cleanup(resetServerFlags)
+}
+
+func TestValidateHostedHAPreflightAcceptsCloudRunHAConfig(t *testing.T) {
+	withHostedHAGuards(t)
+
+	require.NoError(t, validateHostedHAPreflight(validHostedHAConfig()))
+}
+
+func TestValidateHostedHAPreflightRejectsUnsafeBackends(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*config.GlobalConfig)
+		wantErr string
+	}{
+		{
+			name: "sqlite",
+			mutate: func(cfg *config.GlobalConfig) {
+				cfg.Database.Driver = "sqlite"
+			},
+			wantErr: "requires server.database.driver=postgres",
+		},
+		{
+			name: "empty postgres dsn",
+			mutate: func(cfg *config.GlobalConfig) {
+				cfg.Database.URL = ""
+			},
+			wantErr: "requires server.database.url",
+		},
+		{
+			name: "local storage",
+			mutate: func(cfg *config.GlobalConfig) {
+				cfg.Storage.Provider = "local"
+				cfg.Storage.Bucket = ""
+			},
+			wantErr: "requires server.storage.provider=gcs",
+		},
+		{
+			name: "missing transport",
+			mutate: func(cfg *config.GlobalConfig) {
+				cfg.Auth.Transport = nil
+			},
+			wantErr: "requires server.auth.transport",
+		},
+		{
+			name: "wrong transport mode",
+			mutate: func(cfg *config.GlobalConfig) {
+				cfg.Auth.Transport.Mode = "cloudrun_invoker"
+			},
+			wantErr: "requires server.auth.transport.mode=iap",
+		},
+		{
+			name: "backend service audience",
+			mutate: func(cfg *config.GlobalConfig) {
+				cfg.Auth.Proxy.IAP.Audience = "/projects/123456789/global/backendServices/987654321"
+				cfg.Auth.Transport.OIDCAudience = cfg.Auth.Proxy.IAP.Audience
+			},
+			wantErr: "Cloud Run native IAP audience",
+		},
+		{
+			name: "transport audience mismatch",
+			mutate: func(cfg *config.GlobalConfig) {
+				cfg.Auth.Transport.OIDCAudience = "/projects/123456789/locations/us-central1/services/other"
+			},
+			wantErr: "oidc_audience to match",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withHostedHAGuards(t)
+			cfg := validHostedHAConfig()
+			tt.mutate(cfg)
+
+			err := validateHostedHAPreflight(cfg)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestValidateHostedHAPreflightRequiresSessionSecret(t *testing.T) {
+	resetServerFlags()
+	hostedMode = true
+	enableHub = true
+	webSessionSecret = ""
+	t.Setenv("SCION_SERVER_SESSION_SECRET", "")
+	t.Setenv("SESSION_SECRET", "")
+	t.Cleanup(resetServerFlags)
+
+	err := validateHostedHAPreflight(validHostedHAConfig())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "durable session/signing secret")
+}
+
+func TestValidateHostedHAPreflightSkippedOutsideHostedHub(t *testing.T) {
+	resetServerFlags()
+	t.Cleanup(resetServerFlags)
+
+	cfg := validHostedHAConfig()
+	cfg.Database.Driver = "sqlite"
+	cfg.Storage.Provider = "local"
+	cfg.Storage.Bucket = ""
+
+	require.NoError(t, validateHostedHAPreflight(cfg))
+}
+
+func TestNewEventPublisherFailsClosedForHostedHA(t *testing.T) {
+	withHostedHAGuards(t)
+	cfg := validHostedHAConfig()
+	cfg.Database.URL = "not a postgres dsn"
+
+	_, err := newEventPublisher(context.Background(), cfg, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "required Postgres event publisher")
+}
+
+func TestNewEventPublisherFallsBackOutsideHostedHA(t *testing.T) {
+	resetServerFlags()
+	t.Cleanup(resetServerFlags)
+
+	cfg := validHostedHAConfig()
+	cfg.Database.URL = "not a postgres dsn"
+
+	pub, err := newEventPublisher(context.Background(), cfg, nil)
+	require.NoError(t, err)
+	require.IsType(t, &hub.ChannelEventPublisher{}, pub)
+}
+
+func TestCloudRunIAPAudienceShape(t *testing.T) {
+	require.True(t, isCloudRunIAPAudience("/projects/123/locations/us-central1/services/scion"))
+	require.False(t, isCloudRunIAPAudience("/projects/123/global/backendServices/456"))
+	require.False(t, isCloudRunIAPAudience(strings.TrimSpace("")))
+}

--- a/cmd/server_workstation_test.go
+++ b/cmd/server_workstation_test.go
@@ -46,6 +46,7 @@ func resetServerFlags() {
 	storageDir = ""
 	serverConfigPath = ""
 	dbURL = ""
+	webSessionSecret = ""
 }
 
 func TestWorkstationModeDefaults(t *testing.T) {

--- a/scripts/cloudrun/Dockerfile
+++ b/scripts/cloudrun/Dockerfile
@@ -39,14 +39,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       git \
       openssh-client \
       curl \
-      apt-transport-https \
-      gnupg \
-    && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
-       > /etc/apt/sources.list.d/google-cloud-sdk.list \
-    && curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-       | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends google-cloud-cli-gke-gcloud-auth-plugin \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -d /home/scion -s /bin/bash -u 1000 scion \

--- a/scripts/cloudrun/README.md
+++ b/scripts/cloudrun/README.md
@@ -1,114 +1,151 @@
-# Scion Hub — Cloud Run Deployment
+# Scion Hub Cloud Run HA Deployment
 
-Deploys the Scion hub as a single Cloud Run instance with IAP authentication
-and a co-located GKE broker targeting `scion-demo-cluster`.
+This directory deploys the production Cloud Run shape described in
+`.design/hub-cloudrun-deployment.md`: a horizontally scalable Hub/Web service
+with a co-located stateless Runtime Broker, protected by Cloud Run native IAP.
+
+The production path uses Cloud SQL Postgres and GCS from the start. SQLite,
+local filesystem storage, and GKE broker targeting are demo or alternate-runtime
+material and are not configured by `deploy.sh`.
 
 ## Architecture
 
-```
-User → Cloud Run (built-in IAP) → Hub container
-┌──────────────────────────┐
-│  scion server (combo)    │
-│  ├─ Hub API   :8080      │
-│  ├─ Web UI    :8080      │
-│  └─ Broker    :9810      │──▶ GKE Autopilot (scion-demo-cluster)
-│     SQLite: /tmp/scion.db│       namespace: scion-agents
-└──────────────────────────┘
+```text
+User / agent / CLI
+  -> Cloud Run native IAP
+  -> scion server --enable-hub --enable-web --enable-runtime-broker
+  -> Cloud SQL Postgres, GCS, Cloud Run Instances, Filestore
 ```
 
-- **IAP-protected** — Cloud Run's native IAP integration secures all ingress
-  paths (including the default `*.run.app` URL). No load balancer required.
-- **Authenticated HTTPS only** (`--no-allow-unauthenticated`)
-- **SQLite (ephemeral)** — lost on instance restart, acceptable for demo
-- **GKE auth via ADC** — Cloud Run service account → Workload Identity → GKE
+Key properties:
+
+- Cloud Run native IAP is enabled directly on the service.
+- The IAP audience is `/projects/<PROJECT_NUMBER>/locations/<REGION>/services/<SERVICE_NAME>`.
+- Hub state and realtime events use Postgres, not SQLite.
+- Template/workspace artifacts use GCS, not instance-local storage.
+- One logical broker identity (`server.broker.broker_id`) is shared by all Cloud Run replicas.
+- The default runtime is Cloud Run Instances (`runtimes.cloudrun.type: cloudrun`).
 
 ## Prerequisites
 
-- `gcloud` CLI, authenticated with project `deploy-demo-test`
-- `docker` CLI, authenticated to Artifact Registry
-- `kubectl` with access to `scion-demo-cluster` (for namespace creation only)
-- `openssl` (for session secret generation)
-- IAP API enabled (`gcloud services enable iap.googleapis.com`)
+- `gcloud`, `docker`, `python3`, and `openssl`.
+- Enabled APIs: Cloud Run, IAP, Artifact Registry, Secret Manager, IAM Credentials,
+  Cloud SQL Admin, Cloud Storage, and Cloud Logging.
+- A Cloud SQL Postgres instance in the target region.
+- A GCS bucket for Hub artifacts.
+- Filestore/NFS details for Cloud Run Instances workspaces.
+- A VPC network/subnetwork usable by Cloud Run Instances.
 
-## Quick Start
+## Required Configuration
+
+Set these environment variables before running `deploy.sh`:
+
+| Variable | Description |
+| --- | --- |
+| `SCION_PROJECT` | GCP project ID. Defaults to `deploy-demo-test`. |
+| `SCION_REGION` | GCP region. Defaults to `us-central1`. |
+| `SCION_SERVICE` | Cloud Run service name. Defaults to `scion-hub`. |
+| `SCION_CLOUDSQL_INSTANCE` | Cloud SQL instance name, not the full connection name. |
+| `SCION_DATABASE_NAME` | Postgres database name. Defaults to `scionhub`. |
+| `SCION_DATABASE_USER` | Postgres user. Defaults to `scion`. |
+| `SCION_DATABASE_PASSWORD` | Postgres password, used to render the DSN. |
+| `SCION_DATABASE_PASSWORD_SECRET` | Alternative to `SCION_DATABASE_PASSWORD`; reads the latest Secret Manager version. |
+| `SCION_DATABASE_URL` | Alternative full Postgres DSN. Use this to bypass DSN assembly. |
+| `SCION_GCS_BUCKET` | GCS bucket for Hub storage. |
+| `SCION_RUNTIME_NETWORK` | VPC network for Cloud Run Instances. |
+| `SCION_RUNTIME_SUBNETWORK` | VPC subnetwork for Cloud Run Instances. |
+| `SCION_FILESTORE_IP` | Filestore/NFS server IP. |
+| `SCION_FILESTORE_EXPORT` | Filestore/NFS export path, for example `/scion-workspaces`. |
+
+Useful optional variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `SCION_MIN_INSTANCES` | `2` | Production HA minimum Cloud Run instances. |
+| `SCION_MAX_INSTANCES` | `10` | Cloud Run max instances; size this against the DB connection budget. |
+| `SCION_DB_MAX_OPEN_CONNS` | `10` | Per-replica Postgres max open connections. |
+| `SCION_DB_MAX_IDLE_CONNS` | `5` | Per-replica Postgres idle connections. |
+| `SCION_PUBLIC_URL` | discovered after first deploy | Public Hub URL injected into settings. |
+| `SCION_BROKER_ID` | `cloudrun-instances` | Stable logical broker ID shared by all replicas. |
+| `SCION_BROKER_NAME` | `Cloud Run Instances` | Display name for the logical broker. |
+| `SCION_SESSION_SECRET` | generated | Shared cookie/JWT signing secret stored in Secret Manager. |
+| `SCION_IAP_CLIENT_ID` / `SCION_IAP_CLIENT_SECRET` | unset | Optional custom OAuth client for IAP. |
+
+## Deploy
 
 ```bash
-# Full deploy (build + push + secrets + Cloud Run + IAP)
-./scripts/cloudrun/deploy.sh
+export SCION_PROJECT=deploy-demo-test
+export SCION_REGION=us-central1
+export SCION_CLOUDSQL_INSTANCE=scion-hub-postgres
+export SCION_DATABASE_NAME=scionhub
+export SCION_DATABASE_USER=scion
+export SCION_DATABASE_PASSWORD_SECRET=scion-hub-db-password
+export SCION_GCS_BUCKET=scion-hub-artifacts
+export SCION_RUNTIME_NETWORK=projects/deploy-demo-test/global/networks/scion
+export SCION_RUNTIME_SUBNETWORK=projects/deploy-demo-test/regions/us-central1/subnetworks/scion
+export SCION_FILESTORE_IP=10.0.0.2
+export SCION_FILESTORE_EXPORT=/scion-workspaces
 
-# Redeploy without rebuilding the image
+./scripts/cloudrun/deploy.sh
+```
+
+Redeploy an already-pushed image:
+
+```bash
 ./scripts/cloudrun/deploy.sh --skip-build
 ```
 
-## Configuration
+On a first deployment, the script may deploy twice. The first pass lets Cloud
+Run allocate the service URL; the second pass updates the settings secret with
+that URL unless `SCION_PUBLIC_URL` was provided.
 
-Environment variables override defaults:
+## What the Script Does
 
-| Variable               | Default              | Description                     |
-|------------------------|----------------------|---------------------------------|
-| `SCION_PROJECT`        | `deploy-demo-test`   | GCP project ID                  |
-| `SCION_REGION`         | `us-central1`        | GCP region                      |
-| `SCION_SERVICE`        | `scion-hub`          | Cloud Run service name          |
-| `SCION_GKE_CLUSTER`    | `scion-demo-cluster` | Target GKE cluster              |
-| `SCION_SA_NAME`        | `scion-hub-sa`       | Service account name            |
-| `SCION_REPO`           | `scion`              | Artifact Registry repo name     |
-| `SCION_SESSION_SECRET` | *(auto-generated)*   | JWT session secret (hex string) |
-
-## What the Deploy Script Does
-
-1. Creates a dedicated service account with `container.admin` and
-   `secretmanager.secretAccessor` roles (if it doesn't exist)
-2. Creates a transport service account for agent IAP traversal (Phase 2)
-3. Builds and pushes the container image to Artifact Registry
-4. Fetches GKE cluster endpoint + CA cert and generates a kubeconfig
-5. Computes the IAP audience (`/projects/NUM/locations/REGION/services/NAME`)
-6. Generates hub settings from the template (injects session secret, IAP audience)
-7. Stores kubeconfig and settings as Secret Manager secrets
-8. Ensures the `scion-agents` namespace exists in GKE
-9. Deploys the Cloud Run service with `--iap` flag and secrets mounted as files
-10. Grants the IAP service agent `roles/run.invoker` on the service
-11. Grants the transport SA `roles/iap.httpsResourceAccessor` for agent callbacks
+1. Creates or reuses the Hub, transport-auth, and agent runtime service accounts.
+2. Grants the Hub service account Cloud SQL, Secret Manager, GCS, Cloud Run
+   Instances, logging, IAP tunnel, and service-account attachment permissions.
+3. Grants the Hub service account token-creator access on the transport SA.
+4. Builds and pushes the Hub container image to Artifact Registry.
+5. Renders `hub-settings-template.yaml` with Postgres, GCS, IAP transport, and
+   Cloud Run runtime configuration.
+6. Stores settings and the shared session secret in Secret Manager.
+7. Deploys Cloud Run with `--iap`, `--no-allow-unauthenticated`,
+   `--no-cpu-throttling`, min instances `>= 2`, and Cloud SQL attachment.
+8. Grants the IAP service agent `roles/run.invoker`.
+9. Grants the transport SA `roles/iap.httpsResourceAccessor`.
 
 ## Verification
 
 ```bash
-# Get the service URL
 URL=$(gcloud run services describe scion-hub \
   --region us-central1 --project deploy-demo-test \
   --format="value(status.url)")
 
-# Verify IAP is enabled
 gcloud run services describe scion-hub \
   --region us-central1 --project deploy-demo-test \
-  | grep "Iap Enabled"
+  --format="value(metadata.annotations.run.googleapis.com/iap-enabled)"
 
-# Direct health check (bypasses IAP via identity token)
-curl -H "Authorization: Bearer $(gcloud auth print-identity-token)" "${URL}/health"
+curl -I "$URL"
+```
 
-# Visit the service URL in a browser — should redirect to Google sign-in
+The unauthenticated request should be blocked or redirected by IAP. Grant human
+access with:
+
+```bash
+gcloud iap web add-iam-policy-binding \
+  --project=deploy-demo-test \
+  --region=us-central1 \
+  --resource-type=cloud-run \
+  --service=scion-hub \
+  --member=user:EMAIL \
+  --role=roles/iap.httpsResourceAccessor
 ```
 
 ## Files
 
-| File                          | Purpose                                     |
-|-------------------------------|---------------------------------------------|
-| `Dockerfile`                  | Multi-stage build: web + Go → slim runtime  |
-| `deploy.sh`                   | End-to-end deploy script                    |
-| `hub-settings-template.yaml`  | Hub settings (IAP audience, transport SA)   |
-| `README.md`                   | This file                                   |
-
-## Notes
-
-- The Cloud Run instance uses `--timeout 3600` for long-lived WebSocket
-  connections from agent control channels.
-- `--min-instances 1` keeps the instance warm. SQLite state is lost on cold
-  starts, so a warm instance is critical.
-- The `gke-gcloud-auth-plugin` is installed in the image for robustness, but
-  `pkg/k8s/client.go` also has a `fallbackToGCEAuth()` path that uses ADC
-  directly if the plugin fails.
-- Session secret is stored in Secret Manager and injected into settings at
-  deploy time, so it survives instance restarts.
-- Cloud Run's native IAP protects all ingress paths without a load balancer,
-  managed cert, or static IP. The `*.run.app` URL is directly IAP-protected.
-- Agent IAP traversal (transport SA) requires Phase 2 transport token code
-  which is not yet merged. The infrastructure and IAM bindings are in place.
+| File | Purpose |
+| --- | --- |
+| `Dockerfile` | Multi-stage web plus Go build for Cloud Run. |
+| `entrypoint.sh` | Starts Hub, Web, and Runtime Broker in production mode. |
+| `deploy.sh` | End-to-end production Cloud Run deploy script. |
+| `hub-settings-template.yaml` | Versioned production settings template. |

--- a/scripts/cloudrun/deploy.sh
+++ b/scripts/cloudrun/deploy.sh
@@ -1,37 +1,51 @@
 #!/usr/bin/env bash
-# Deploy Scion hub as a Cloud Run service with IAP enabled directly.
+# Deploy the Scion hub as a production Cloud Run HA service with native IAP.
 #
 # Architecture:
-#   User → Cloud Run (with built-in IAP) → Hub container
+#   User / agent / CLI -> Cloud Run native IAP -> Hub/Web/co-located Broker
+#     -> Cloud SQL Postgres, GCS, Cloud Run Instances, Filestore
 #
-# Cloud Run's native IAP integration protects all ingress paths (including
-# the default *.run.app URL) without requiring a load balancer, NEG, or
-# managed certificate.
-#
-# Prerequisites:
-#   - gcloud CLI authenticated with sufficient permissions
-#   - docker CLI authenticated to Artifact Registry
-#   - kubectl configured for scion-demo-cluster (for namespace setup only)
-#   - IAP API enabled in the project (gcloud services enable iap.googleapis.com)
-#
-# Usage:
-#   ./scripts/cloudrun/deploy.sh                # full deploy
-#   ./scripts/cloudrun/deploy.sh --skip-build   # redeploy without rebuilding image
+# This script intentionally does not provision the older SQLite/GKE demo shape.
+# Required production inputs are supplied through SCION_* environment variables;
+# see scripts/cloudrun/README.md for the full list.
 
 set -euo pipefail
-
-# ── Configuration ────────────────────────────────────────────────────────────
 
 PROJECT="${SCION_PROJECT:-deploy-demo-test}"
 REGION="${SCION_REGION:-us-central1}"
 SERVICE_NAME="${SCION_SERVICE:-scion-hub}"
-GKE_CLUSTER="${SCION_GKE_CLUSTER:-scion-demo-cluster}"
 SA_NAME="${SCION_SA_NAME:-scion-hub-sa}"
+TRANSPORT_SA_NAME="${SCION_TRANSPORT_SA_NAME:-${SA_NAME}-transport}"
+RUNTIME_SA_NAME="${SCION_RUNTIME_SA_NAME:-scion-agent-runtime-sa}"
 REPO="${SCION_REPO:-scion}"
-IMAGE="us-central1-docker.pkg.dev/${PROJECT}/${REPO}/hub:latest"
-K8S_NAMESPACE="scion-agents"
+IMAGE_TAG="${SCION_IMAGE_TAG:-latest}"
+IMAGE_REGISTRY="${REGION}-docker.pkg.dev/${PROJECT}/${REPO}"
+IMAGE="${IMAGE_REGISTRY}/hub:${IMAGE_TAG}"
 
-# Optional: custom OAuth client for IAP (needed for external users)
+CLOUDSQL_INSTANCE="${SCION_CLOUDSQL_INSTANCE:-}"
+DATABASE_NAME="${SCION_DATABASE_NAME:-scionhub}"
+DATABASE_USER="${SCION_DATABASE_USER:-scion}"
+DATABASE_PASSWORD="${SCION_DATABASE_PASSWORD:-}"
+DATABASE_PASSWORD_SECRET="${SCION_DATABASE_PASSWORD_SECRET:-}"
+DATABASE_URL="${SCION_DATABASE_URL:-}"
+DB_MAX_OPEN_CONNS="${SCION_DB_MAX_OPEN_CONNS:-10}"
+DB_MAX_IDLE_CONNS="${SCION_DB_MAX_IDLE_CONNS:-5}"
+
+GCS_BUCKET="${SCION_GCS_BUCKET:-}"
+RUNTIME_NETWORK="${SCION_RUNTIME_NETWORK:-}"
+RUNTIME_SUBNETWORK="${SCION_RUNTIME_SUBNETWORK:-}"
+FILESTORE_IP="${SCION_FILESTORE_IP:-}"
+FILESTORE_EXPORT="${SCION_FILESTORE_EXPORT:-}"
+BROKER_ID="${SCION_BROKER_ID:-cloudrun-instances}"
+BROKER_NAME="${SCION_BROKER_NAME:-Cloud Run Instances}"
+PUBLIC_URL="${SCION_PUBLIC_URL:-}"
+
+MIN_INSTANCES="${SCION_MIN_INSTANCES:-2}"
+MAX_INSTANCES="${SCION_MAX_INSTANCES:-10}"
+CPU="${SCION_CPU:-1}"
+MEMORY="${SCION_MEMORY:-1Gi}"
+TIMEOUT="${SCION_TIMEOUT:-3600}"
+
 IAP_CLIENT_ID="${SCION_IAP_CLIENT_ID:-}"
 IAP_CLIENT_SECRET="${SCION_IAP_CLIENT_SECRET:-}"
 
@@ -42,152 +56,184 @@ SKIP_BUILD=false
 for arg in "$@"; do
   case "$arg" in
     --skip-build) SKIP_BUILD=true ;;
+    *) echo "ERROR: unknown argument: $arg" >&2; exit 1 ;;
   esac
 done
 
-# ── Helpers ──────────────────────────────────────────────────────────────────
-
 log() { echo "==> $*"; }
 die() { echo "ERROR: $*" >&2; exit 1; }
+
+require_var() {
+  local name="$1"
+  local value="$2"
+  [[ -n "$value" ]] || die "${name} is required"
+}
 
 ensure_secret() {
   local name="$1"
   local data="$2"
   if gcloud secrets describe "$name" --project="$PROJECT" &>/dev/null; then
     log "Updating secret ${name}"
-    echo "$data" | gcloud secrets versions add "$name" --data-file=- --project="$PROJECT"
+    printf '%s' "$data" | gcloud secrets versions add "$name" --data-file=- --project="$PROJECT"
   else
     log "Creating secret ${name}"
-    echo "$data" | gcloud secrets create "$name" --data-file=- --project="$PROJECT" \
+    printf '%s' "$data" | gcloud secrets create "$name" --data-file=- --project="$PROJECT" \
       --replication-policy=automatic
   fi
 }
 
-# ── 0. Validate ──────────────────────────────────────────────────────────────
+ensure_service_account() {
+  local name="$1"
+  local display_name="$2"
+  local email="${name}@${PROJECT}.iam.gserviceaccount.com"
+  if ! gcloud iam service-accounts describe "$email" --project="$PROJECT" &>/dev/null; then
+    log "Creating service account ${name}"
+    gcloud iam service-accounts create "$name" \
+      --display-name="$display_name" \
+      --project="$PROJECT"
+  fi
+}
+
+add_project_role() {
+  local member="$1"
+  local role="$2"
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member="$member" \
+    --role="$role" \
+    --condition=None \
+    --quiet >/dev/null
+}
+
+sed_escape() {
+  printf '%s' "$1" | sed -e 's/[\/&|\\]/\\&/g'
+}
+
+urlencode() {
+  python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$1"
+}
+
+render_settings() {
+  local service_url="$1"
+  sed \
+    -e "s|__IMAGE_REGISTRY__|$(sed_escape "$IMAGE_REGISTRY")|" \
+    -e "s|__SERVICE_URL__|$(sed_escape "$service_url")|" \
+    -e "s|__PROJECT_ID__|$(sed_escape "$PROJECT")|" \
+    -e "s|__REGION__|$(sed_escape "$REGION")|" \
+    -e "s|__POSTGRES_DSN__|$(sed_escape "$DATABASE_URL")|" \
+    -e "s|__DB_MAX_OPEN_CONNS__|$(sed_escape "$DB_MAX_OPEN_CONNS")|" \
+    -e "s|__DB_MAX_IDLE_CONNS__|$(sed_escape "$DB_MAX_IDLE_CONNS")|" \
+    -e "s|__GCS_BUCKET__|$(sed_escape "$GCS_BUCKET")|" \
+    -e "s|__IAP_AUDIENCE__|$(sed_escape "$IAP_AUDIENCE")|" \
+    -e "s|__TRANSPORT_SA_EMAIL__|$(sed_escape "$TRANSPORT_SA_EMAIL")|" \
+    -e "s|__BROKER_ID__|$(sed_escape "$BROKER_ID")|" \
+    -e "s|__BROKER_NAME__|$(sed_escape "$BROKER_NAME")|" \
+    -e "s|__RUNTIME_SA_EMAIL__|$(sed_escape "$RUNTIME_SA_EMAIL")|" \
+    -e "s|__RUNTIME_NETWORK__|$(sed_escape "$RUNTIME_NETWORK")|" \
+    -e "s|__RUNTIME_SUBNETWORK__|$(sed_escape "$RUNTIME_SUBNETWORK")|" \
+    -e "s|__FILESTORE_IP__|$(sed_escape "$FILESTORE_IP")|" \
+    -e "s|__FILESTORE_EXPORT__|$(sed_escape "$FILESTORE_EXPORT")|" \
+    "${SCRIPT_DIR}/hub-settings-template.yaml"
+}
+
+deploy_service() {
+  local settings_secret="$1"
+  local session_secret="$2"
+
+  gcloud run deploy "$SERVICE_NAME" \
+    --image "$IMAGE" \
+    --region "$REGION" \
+    --project "$PROJECT" \
+    --min-instances "$MIN_INSTANCES" \
+    --max-instances "$MAX_INSTANCES" \
+    --no-allow-unauthenticated \
+    --iap \
+    --no-cpu-throttling \
+    --add-cloudsql-instances "$CLOUDSQL_CONNECTION_NAME" \
+    --service-account "$SA_EMAIL" \
+    --port 8080 \
+    --memory "$MEMORY" \
+    --cpu "$CPU" \
+    --timeout "$TIMEOUT" \
+    --set-secrets "/run/secrets/settings.yaml=${settings_secret}:latest,SCION_SERVER_SESSION_SECRET=${session_secret}:latest" \
+    --set-env-vars "HOME=/home/scion,SCION_REQUIRE_STABLE_SIGNING_KEY=true"
+}
 
 command -v gcloud >/dev/null || die "gcloud CLI not found"
 command -v docker >/dev/null || die "docker CLI not found"
+command -v python3 >/dev/null || die "python3 is required to URL-encode the database password"
+command -v openssl >/dev/null || die "openssl is required to generate the session secret"
 
-# ── 1. Service account (hub) ────────────────────────────────────────────────
+require_var "SCION_CLOUDSQL_INSTANCE" "$CLOUDSQL_INSTANCE"
+require_var "SCION_GCS_BUCKET" "$GCS_BUCKET"
+require_var "SCION_RUNTIME_NETWORK" "$RUNTIME_NETWORK"
+require_var "SCION_RUNTIME_SUBNETWORK" "$RUNTIME_SUBNETWORK"
+require_var "SCION_FILESTORE_IP" "$FILESTORE_IP"
+require_var "SCION_FILESTORE_EXPORT" "$FILESTORE_EXPORT"
 
 SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
-
-if ! gcloud iam service-accounts describe "$SA_EMAIL" --project="$PROJECT" &>/dev/null; then
-  log "Creating service account ${SA_NAME}"
-  gcloud iam service-accounts create "$SA_NAME" \
-    --display-name="Scion Hub (Cloud Run)" \
-    --project="$PROJECT"
-
-  for role in roles/container.admin roles/secretmanager.secretAccessor; do
-    gcloud projects add-iam-policy-binding "$PROJECT" \
-      --member="serviceAccount:${SA_EMAIL}" \
-      --role="$role" \
-      --condition=None \
-      --quiet
-  done
-fi
-
-# ── 1b. Transport service account (for agent → hub IAP traversal) ───────────
-
-TRANSPORT_SA_NAME="${SA_NAME}-transport"
 TRANSPORT_SA_EMAIL="${TRANSPORT_SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+RUNTIME_SA_EMAIL="${RUNTIME_SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+CLOUDSQL_CONNECTION_NAME="${PROJECT}:${REGION}:${CLOUDSQL_INSTANCE}"
 
-if ! gcloud iam service-accounts describe "$TRANSPORT_SA_EMAIL" --project="$PROJECT" &>/dev/null; then
-  log "Creating transport service account ${TRANSPORT_SA_NAME}"
-  gcloud iam service-accounts create "$TRANSPORT_SA_NAME" \
-    --display-name="Scion Transport (IAP traversal)" \
-    --project="$PROJECT"
-
-  # Hub SA needs to mint tokens as the transport SA
-  gcloud iam service-accounts add-iam-policy-binding "$TRANSPORT_SA_EMAIL" \
-    --member="serviceAccount:${SA_EMAIL}" \
-    --role="roles/iam.serviceAccountTokenCreator" \
-    --project="$PROJECT" \
-    --quiet
+if [[ -z "$DATABASE_URL" ]]; then
+  if [[ -z "$DATABASE_PASSWORD" && -n "$DATABASE_PASSWORD_SECRET" ]]; then
+    log "Reading database password from Secret Manager secret ${DATABASE_PASSWORD_SECRET}"
+    DATABASE_PASSWORD=$(gcloud secrets versions access latest \
+      --secret="$DATABASE_PASSWORD_SECRET" \
+      --project="$PROJECT")
+  fi
+  require_var "SCION_DATABASE_PASSWORD or SCION_DATABASE_URL" "$DATABASE_PASSWORD"
+  ENCODED_DB_PASSWORD="$(urlencode "$DATABASE_PASSWORD")"
+  DATABASE_URL="postgres://${DATABASE_USER}:${ENCODED_DB_PASSWORD}@/${DATABASE_NAME}?host=/cloudsql/${CLOUDSQL_CONNECTION_NAME}"
 fi
-
-# ── 2. Build & push image ───────────────────────────────────────────────────
-
-if [[ "$SKIP_BUILD" == false ]]; then
-  log "Building container image"
-  docker build -f "${SCRIPT_DIR}/Dockerfile" -t "$IMAGE" "$REPO_ROOT"
-
-  log "Pushing image to Artifact Registry"
-  docker push "$IMAGE"
-else
-  log "Skipping build (--skip-build)"
-fi
-
-# ── 3. Generate kubeconfig from live cluster info ────────────────────────────
-
-log "Fetching GKE cluster details"
-read -r ENDPOINT CA_CERT < <(gcloud container clusters describe "$GKE_CLUSTER" \
-  --region "$REGION" --project "$PROJECT" \
-  --format="value(endpoint,masterAuth.clusterCaCertificate)")
-
-[[ -n "$ENDPOINT" ]] || die "Could not fetch cluster endpoint"
-[[ -n "$CA_CERT"  ]] || die "Could not fetch cluster CA certificate"
-
-KUBECONFIG_CONTENT="apiVersion: v1
-kind: Config
-clusters:
-- cluster:
-    certificate-authority-data: ${CA_CERT}
-    server: https://${ENDPOINT}
-  name: ${GKE_CLUSTER}
-contexts:
-- context:
-    cluster: ${GKE_CLUSTER}
-    user: ${GKE_CLUSTER}
-    namespace: ${K8S_NAMESPACE}
-  name: ${GKE_CLUSTER}
-current-context: ${GKE_CLUSTER}
-users:
-- name: ${GKE_CLUSTER}
-  user:
-    exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
-      command: gke-gcloud-auth-plugin
-      installHint: Install gke-gcloud-auth-plugin for use with kubectl by following https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin
-      provideClusterInfo: true"
-
-# ── 4. Derive IAP audience ──────────────────────────────────────────────────
-# For Cloud Run's direct IAP integration, the audience is:
-#   /projects/PROJECT_NUMBER/locations/REGION/services/SERVICE_NAME
-# No backend service needs to exist — the audience is deterministic.
 
 PROJECT_NUMBER=$(gcloud projects describe "$PROJECT" --format="value(projectNumber)")
 IAP_AUDIENCE="/projects/${PROJECT_NUMBER}/locations/${REGION}/services/${SERVICE_NAME}"
-log "IAP audience: ${IAP_AUDIENCE}"
+log "Cloud Run native IAP audience: ${IAP_AUDIENCE}"
 
-# ── 5. Generate hub settings ────────────────────────────────────────────────
+if [[ -z "$PUBLIC_URL" ]]; then
+  PUBLIC_URL=$(gcloud run services describe "$SERVICE_NAME" \
+    --region "$REGION" \
+    --project "$PROJECT" \
+    --format="value(status.url)" 2>/dev/null || true)
+fi
+if [[ -z "$PUBLIC_URL" ]]; then
+  PUBLIC_URL="https://pending-first-deploy.invalid"
+fi
 
-SESSION_SECRET="${SCION_SESSION_SECRET:-$(openssl rand -hex 32)}"
+ensure_service_account "$SA_NAME" "Scion Hub (Cloud Run HA)"
+ensure_service_account "$TRANSPORT_SA_NAME" "Scion transport auth (IAP)"
+ensure_service_account "$RUNTIME_SA_NAME" "Scion agent runtime (Cloud Run Instances)"
 
-SETTINGS_CONTENT=$(sed \
-  -e "s|__SESSION_SECRET__|${SESSION_SECRET}|" \
-  -e "s|__IAP_AUDIENCE__|${IAP_AUDIENCE}|" \
-  -e "s|__TRANSPORT_SA_EMAIL__|${TRANSPORT_SA_EMAIL}|" \
-  "${SCRIPT_DIR}/hub-settings-template.yaml")
+log "Granting project IAM roles"
+for role in \
+  roles/cloudsql.client \
+  roles/secretmanager.secretAccessor \
+  roles/storage.objectAdmin \
+  roles/run.admin \
+  roles/logging.viewer \
+  roles/iap.tunnelResourceAccessor; do
+  add_project_role "serviceAccount:${SA_EMAIL}" "$role"
+done
+add_project_role "serviceAccount:${SA_EMAIL}" "roles/iam.serviceAccountUser"
 
-# ── 6. Store secrets ────────────────────────────────────────────────────────
+log "Granting hub SA token minting access on ${TRANSPORT_SA_EMAIL}"
+gcloud iam service-accounts add-iam-policy-binding "$TRANSPORT_SA_EMAIL" \
+  --member="serviceAccount:${SA_EMAIL}" \
+  --role="roles/iam.serviceAccountTokenCreator" \
+  --project="$PROJECT" \
+  --quiet >/dev/null
 
-log "Storing secrets in Secret Manager"
-ensure_secret "${SERVICE_NAME}-kubeconfig" "$KUBECONFIG_CONTENT"
-ensure_secret "${SERVICE_NAME}-settings"   "$SETTINGS_CONTENT"
-
-# ── 7. Ensure K8s namespace ─────────────────────────────────────────────────
-
-log "Ensuring namespace ${K8S_NAMESPACE} exists in ${GKE_CLUSTER}"
-LOCAL_KUBECONFIG=$(mktemp)
-echo "$KUBECONFIG_CONTENT" > "$LOCAL_KUBECONFIG"
-KUBECONFIG="$LOCAL_KUBECONFIG" kubectl create namespace "$K8S_NAMESPACE" --dry-run=client -o yaml | KUBECONFIG="$LOCAL_KUBECONFIG" kubectl apply -f - || true
-rm -f "$LOCAL_KUBECONFIG"
-
-# ── 8. Create Artifact Registry repo (if needed) ────────────────────────────
+log "Granting hub SA runtime service account attachment access"
+gcloud iam service-accounts add-iam-policy-binding "$RUNTIME_SA_EMAIL" \
+  --member="serviceAccount:${SA_EMAIL}" \
+  --role="roles/iam.serviceAccountUser" \
+  --project="$PROJECT" \
+  --quiet >/dev/null
 
 if ! gcloud artifacts repositories describe "$REPO" \
-  --location="$REGION" --project="$PROJECT" &>/dev/null; then
+  --location="$REGION" \
+  --project="$PROJECT" &>/dev/null; then
   log "Creating Artifact Registry repository ${REPO}"
   gcloud artifacts repositories create "$REPO" \
     --repository-format=docker \
@@ -195,48 +241,48 @@ if ! gcloud artifacts repositories describe "$REPO" \
     --project="$PROJECT"
 fi
 
-# ── 9. Deploy Cloud Run service with IAP enabled ────────────────────────────
+if [[ "$SKIP_BUILD" == false ]]; then
+  log "Building container image ${IMAGE}"
+  docker build -f "${SCRIPT_DIR}/Dockerfile" -t "$IMAGE" "$REPO_ROOT"
 
-log "Deploying Cloud Run service ${SERVICE_NAME} with IAP"
-gcloud run deploy "$SERVICE_NAME" \
-  --image "$IMAGE" \
-  --region "$REGION" \
-  --project "$PROJECT" \
-  --min-instances 1 \
-  --max-instances 1 \
-  --no-allow-unauthenticated \
-  --iap \
-  --no-cpu-throttling \
-  --service-account "$SA_EMAIL" \
-  --port 8080 \
-  --memory 1Gi \
-  --cpu 1 \
-  --timeout 3600 \
-  --set-secrets "/home/scion/.kube/config=${SERVICE_NAME}-kubeconfig:latest,/run/secrets/settings.yaml=${SERVICE_NAME}-settings:latest" \
-  --set-env-vars "HOME=/home/scion,KUBECONFIG=/home/scion/.kube/config"
+  log "Pushing container image"
+  docker push "$IMAGE"
+else
+  log "Skipping build (--skip-build)"
+fi
+
+SETTINGS_SECRET="${SERVICE_NAME}-settings"
+SESSION_SECRET_NAME="${SERVICE_NAME}-session-secret"
+SESSION_SECRET="${SCION_SESSION_SECRET:-$(openssl rand -hex 32)}"
+
+log "Rendering production settings for ${PUBLIC_URL}"
+ensure_secret "$SETTINGS_SECRET" "$(render_settings "$PUBLIC_URL")"
+ensure_secret "$SESSION_SECRET_NAME" "$SESSION_SECRET"
+
+log "Deploying Cloud Run service ${SERVICE_NAME}"
+deploy_service "$SETTINGS_SECRET" "$SESSION_SECRET_NAME"
 
 SERVICE_URL=$(gcloud run services describe "$SERVICE_NAME" \
-  --region "$REGION" --project "$PROJECT" \
+  --region "$REGION" \
+  --project "$PROJECT" \
   --format="value(status.url)")
 
-# ── 10. Grant IAP service agent invoker permission ──────────────────────────
-# The IAP service agent needs roles/run.invoker to forward authenticated
-# requests to the Cloud Run service.
+if [[ "${SCION_PUBLIC_URL:-}" == "" && "$SERVICE_URL" != "$PUBLIC_URL" ]]; then
+  log "Updating settings with discovered Cloud Run URL ${SERVICE_URL}"
+  ensure_secret "$SETTINGS_SECRET" "$(render_settings "$SERVICE_URL")"
+  deploy_service "$SETTINGS_SECRET" "$SESSION_SECRET_NAME"
+fi
 
 log "Granting IAP service agent invoker permission"
 gcloud run services add-iam-policy-binding "$SERVICE_NAME" \
   --region "$REGION" \
   --project "$PROJECT" \
   --member "serviceAccount:service-${PROJECT_NUMBER}@gcp-sa-iap.iam.gserviceaccount.com" \
-  --role "roles/run.invoker"
-
-# ── 11. Configure custom OAuth client (if provided) ─────────────────────────
-# By default, Cloud Run IAP uses a Google-managed OAuth client. If custom
-# credentials are provided (needed for external users), configure them via
-# IAP settings.
+  --role "roles/run.invoker" \
+  --quiet >/dev/null
 
 if [[ -n "$IAP_CLIENT_ID" && -n "$IAP_CLIENT_SECRET" ]]; then
-  log "Configuring custom OAuth client for IAP"
+  log "Configuring custom OAuth client for Cloud Run IAP"
   IAP_SETTINGS_FILE=$(mktemp)
   cat > "$IAP_SETTINGS_FILE" <<YAML
 accessSettings:
@@ -251,38 +297,30 @@ YAML
     --service="$SERVICE_NAME"
   rm -f "$IAP_SETTINGS_FILE"
 else
-  log "Using Google-managed OAuth client for IAP (no custom credentials provided)"
+  log "Using Google-managed OAuth client for IAP"
 fi
 
-# ── 12. Grant transport SA access through IAP ──────────────────────────────
-# The transport SA needs roles/iap.httpsResourceAccessor so agents can call
-# back through IAP.
-
-log "Granting transport SA IAP access"
+log "Granting transport SA access through IAP"
 gcloud iap web add-iam-policy-binding \
   --project="$PROJECT" \
   --region="$REGION" \
   --resource-type=cloud-run \
   --service="$SERVICE_NAME" \
   --member="serviceAccount:${TRANSPORT_SA_EMAIL}" \
-  --role="roles/iap.httpsResourceAccessor"
-
-# ── 13. Print summary ───────────────────────────────────────────────────────
+  --role="roles/iap.httpsResourceAccessor" \
+  --quiet >/dev/null
 
 log "Deployment complete"
 echo ""
-echo "  Cloud Run URL (IAP-protected): ${SERVICE_URL}"
+echo "  Cloud Run URL: ${SERVICE_URL}"
 echo "  IAP audience: ${IAP_AUDIENCE}"
-echo "  Transport SA: ${TRANSPORT_SA_EMAIL}"
+echo "  Settings secret: ${SETTINGS_SECRET}"
+echo "  Session secret: ${SESSION_SECRET_NAME}"
+echo "  Hub service account: ${SA_EMAIL}"
+echo "  Transport service account: ${TRANSPORT_SA_EMAIL}"
+echo "  Runtime service account: ${RUNTIME_SA_EMAIL}"
 echo ""
-echo "  IAP protects all ingress — users will be redirected to Google sign-in."
-echo ""
-echo "  Direct health check (bypasses IAP):"
-echo "    curl -H \"Authorization: Bearer \$(gcloud auth print-identity-token)\" ${SERVICE_URL}/health"
-echo ""
-echo "  Grant a user IAP access:"
-echo "    gcloud iap web add-iam-policy-binding \\"
-echo "      --project=${PROJECT} --region=${REGION} \\"
-echo "      --resource-type=cloud-run --service=${SERVICE_NAME} \\"
-echo "      --member=user:EMAIL --role=roles/iap.httpsResourceAccessor"
-echo ""
+echo "Grant users access with:"
+echo "  gcloud iap web add-iam-policy-binding \\"
+echo "    --project=${PROJECT} --region=${REGION} --resource-type=cloud-run --service=${SERVICE_NAME} \\"
+echo "    --member=user:EMAIL --role=roles/iap.httpsResourceAccessor"

--- a/scripts/cloudrun/deploy.sh
+++ b/scripts/cloudrun/deploy.sh
@@ -105,7 +105,9 @@ add_project_role() {
 }
 
 sed_escape() {
-  printf '%s' "$1" | sed -e 's/[\/&|\\]/\\&/g'
+  # Escape only \, &, and | (the delimiter used in render_settings).
+  # No need to escape / since we use | as the sed delimiter.
+  printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
 }
 
 urlencode() {

--- a/scripts/cloudrun/entrypoint.sh
+++ b/scripts/cloudrun/entrypoint.sh
@@ -8,6 +8,6 @@ if [ -f /run/secrets/settings.yaml ]; then
   cat /run/secrets/settings.yaml > "$HOME/.scion/settings.yaml"
 fi
 exec scion server start \
-  --foreground --production --dev-auth \
+  --foreground --production \
   --enable-hub --enable-runtime-broker --enable-web --web-port 8080 \
   --auto-provide --global

--- a/scripts/cloudrun/hub-settings-template.yaml
+++ b/scripts/cloudrun/hub-settings-template.yaml
@@ -1,30 +1,56 @@
 schema_version: "1"
-image_registry: "us-central1-docker.pkg.dev/deploy-demo-test/public-docker"
+image_registry: "__IMAGE_REGISTRY__"
 active_profile: default
+
 server:
+  mode: hosted
+  hub:
+    port: 8080
+    host: "0.0.0.0"
+    public_url: "__SERVICE_URL__"
+    gcp_project_id: "__PROJECT_ID__"
   database:
-    driver: sqlite
-    url: /tmp/scion.db
+    driver: postgres
+    url: "__POSTGRES_DSN__"
+    max_open_conns: __DB_MAX_OPEN_CONNS__
+    max_idle_conns: __DB_MAX_IDLE_CONNS__
+    conn_max_idle_time: "5m"
+  storage:
+    provider: gcs
+    bucket: "__GCS_BUCKET__"
+  secrets:
+    backend: gcpsm
+    gcp_project_id: "__PROJECT_ID__"
   auth:
-    session_secret: "__SESSION_SECRET__"
     mode: proxy
     proxy:
       provider: iap
       iap:
         audience: "__IAP_AUDIENCE__"
-  transport:
-    mode: iap
-    oidcAudience: "__IAP_AUDIENCE__"
-    platformAuthSA: "__TRANSPORT_SA_EMAIL__"
-  runtimeBroker:
-    port: 9810
+    transport:
+      mode: iap
+      oidc_audience: "__IAP_AUDIENCE__"
+      platform_auth_sa: "__TRANSPORT_SA_EMAIL__"
+  broker:
+    enabled: true
+    port: 9800
+    host: "127.0.0.1"
+    broker_id: "__BROKER_ID__"
+    broker_name: "__BROKER_NAME__"
+    auto_provide: true
+
 profiles:
   default:
-    runtime: kubernetes
+    runtime: cloudrun
+
 runtimes:
-  kubernetes:
-    type: kubernetes
-    gke: true
-    context: scion-demo-cluster
-    namespace: scion-agents
-    list_all_namespaces: false
+  cloudrun:
+    type: cloudrun
+    cloudrun:
+      project_id: "__PROJECT_ID__"
+      location: "__REGION__"
+      service_account: "__RUNTIME_SA_EMAIL__"
+      network: "__RUNTIME_NETWORK__"
+      subnetwork: "__RUNTIME_SUBNETWORK__"
+      nfs_server: "__FILESTORE_IP__"
+      nfs_export: "__FILESTORE_EXPORT__"


### PR DESCRIPTION
Adds multiNode HA mode config for Cloud Run. Fails closed if Postgres LISTEN/NOTIFY event publisher cannot activate, preventing silent fallback to in-process channels that would break multi-replica SSE delivery