### PR TITLE
feat(runtimebroker): stateless broker routi

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1361,6 +1361,7 @@ func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.GlobalConfig, hubSrv *hub.Server, webSrv *hub.WebServer, s store.Store, hubEndpoint, devAuthToken string, brokerSettings *config.Settings, globalDir string, requestLogger, messageLogger *slog.Logger, wg *sync.WaitGroup, errCh chan error) error {
 	rt := runtime.GetRuntime("", "")
 	log.Printf("Runtime broker using runtime: %s", rt.Name())
+	statelessCloudRunBroker := enableHub && !simulateRemoteBroker && rt != nil && rt.Name() == "cloudrun"
 
 	mgr := agent.NewManager(rt)
 	settings := brokerSettings
@@ -1373,7 +1374,11 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 	}
 
 	// Resolve broker ID
-	brokerID := resolveBrokerID(cfg, settings, vsBroker, globalDir)
+	defaultBrokerID := ""
+	if statelessCloudRunBroker {
+		defaultBrokerID = deriveCloudRunLogicalBrokerID(versionedSettings, rt)
+	}
+	brokerID := resolveBrokerID(cfg, settings, vsBroker, globalDir, defaultBrokerID)
 
 	// Resolve broker name
 	brokerName := resolveBrokerName(cfg, settings, vsBroker)
@@ -1415,7 +1420,11 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 				}
 			}
 			log.Printf("Registered global project with runtime broker %s (endpoint: %s, autoProvide: %v)", brokerName, rhEndpoint, serverAutoProvide)
-			hubSrv.SetEmbeddedBrokerID(brokerID)
+			if statelessCloudRunBroker {
+				hubSrv.SetStatelessEmbeddedBrokerID(brokerID)
+			} else {
+				hubSrv.SetEmbeddedBrokerID(brokerID)
+			}
 		}
 
 		// Generate credentials for co-located mode
@@ -1528,8 +1537,8 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 		TemplateCacheDir:     templateCacheDir,
 		TemplateCacheMaxSize: templateCacheMax,
 
-		ControlChannelEnabled: hubEndpointForRH != "",
-		HeartbeatEnabled:      hubEndpointForRH != "",
+		ControlChannelEnabled: hubEndpointForRH != "" && !statelessCloudRunBroker,
+		HeartbeatEnabled:      hubEndpointForRH != "" && !statelessCloudRunBroker,
 
 		InMemoryCredentials:  inMemoryCreds,
 		BrokerAuthEnabled:    true,
@@ -1679,16 +1688,22 @@ func initPluginManager() *scionplugin.Manager {
 	return mgr
 }
 
+var cloudRunLogicalBrokerNamespace = uuid.MustParse("c10f7a0a-6f03-5f9f-8d52-1d98b0fdb001")
+
 // resolveBrokerID determines the broker ID from various sources.
-func resolveBrokerID(cfg *config.GlobalConfig, settings *config.Settings, vsBroker *config.V1BrokerConfig, globalDir string) string {
+func resolveBrokerID(cfg *config.GlobalConfig, settings *config.Settings, vsBroker *config.V1BrokerConfig, globalDir, defaultBrokerID string) string {
 	var brokerID string
 	if vsBroker != nil && vsBroker.BrokerID != "" {
 		brokerID = vsBroker.BrokerID
-	} else {
+	} else if settings != nil && settings.Hub != nil {
 		brokerID = settings.Hub.BrokerID
 	}
 	if brokerID == "" {
 		brokerID = cfg.RuntimeBroker.BrokerID
+	}
+	if brokerID == "" && defaultBrokerID != "" {
+		log.Printf("Using deterministic logical broker ID: %s", defaultBrokerID)
+		return defaultBrokerID
 	}
 	if brokerID == "" {
 		brokerID = api.NewUUID()
@@ -1699,6 +1714,23 @@ func resolveBrokerID(cfg *config.GlobalConfig, settings *config.Settings, vsBrok
 		}
 	}
 	return brokerID
+}
+
+func deriveCloudRunLogicalBrokerID(settings *config.VersionedSettings, rt runtime.Runtime) string {
+	if settings == nil || rt == nil || rt.Name() != "cloudrun" {
+		return ""
+	}
+	rtConfig, runtimeType, err := settings.ResolveRuntime("")
+	if err != nil || runtimeType != "cloudrun" || rtConfig.CloudRun == nil {
+		return ""
+	}
+	projectID := strings.TrimSpace(rtConfig.CloudRun.Project)
+	location := strings.TrimSpace(rtConfig.CloudRun.Region)
+	if projectID == "" || location == "" {
+		return ""
+	}
+	seed := fmt.Sprintf("cloudrun:%s:%s", projectID, location)
+	return uuid.NewSHA1(cloudRunLogicalBrokerNamespace, []byte(seed)).String()
 }
 
 // resolveBrokerName determines the broker name from various sources.

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1376,7 +1376,11 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 	// Resolve broker ID
 	defaultBrokerID := ""
 	if statelessCloudRunBroker {
-		defaultBrokerID = deriveCloudRunLogicalBrokerID(versionedSettings, rt)
+		var deriveErr error
+		defaultBrokerID, deriveErr = deriveCloudRunLogicalBrokerID(versionedSettings, rt)
+		if deriveErr != nil {
+			return fmt.Errorf("stateless Cloud Run broker requires a derivable broker ID: %w", deriveErr)
+		}
 	}
 	brokerID := resolveBrokerID(cfg, settings, vsBroker, globalDir, defaultBrokerID)
 
@@ -1716,21 +1720,24 @@ func resolveBrokerID(cfg *config.GlobalConfig, settings *config.Settings, vsBrok
 	return brokerID
 }
 
-func deriveCloudRunLogicalBrokerID(settings *config.VersionedSettings, rt runtime.Runtime) string {
+func deriveCloudRunLogicalBrokerID(settings *config.VersionedSettings, rt runtime.Runtime) (string, error) {
 	if settings == nil || rt == nil || rt.Name() != "cloudrun" {
-		return ""
+		return "", fmt.Errorf("deriveCloudRunLogicalBrokerID requires cloudrun runtime (got settings=%v, rt=%v)", settings != nil, rt)
 	}
 	rtConfig, runtimeType, err := settings.ResolveRuntime("")
-	if err != nil || runtimeType != "cloudrun" || rtConfig.CloudRun == nil {
-		return ""
+	if err != nil {
+		return "", fmt.Errorf("deriveCloudRunLogicalBrokerID: failed to resolve runtime: %w", err)
+	}
+	if runtimeType != "cloudrun" || rtConfig.CloudRun == nil {
+		return "", fmt.Errorf("deriveCloudRunLogicalBrokerID: expected cloudrun runtime, got %q", runtimeType)
 	}
 	projectID := strings.TrimSpace(rtConfig.CloudRun.Project)
 	location := strings.TrimSpace(rtConfig.CloudRun.Region)
 	if projectID == "" || location == "" {
-		return ""
+		return "", fmt.Errorf("deriveCloudRunLogicalBrokerID: project (%q) and region (%q) must both be set in cloudrun runtime config", projectID, location)
 	}
 	seed := fmt.Sprintf("cloudrun:%s:%s", projectID, location)
-	return uuid.NewSHA1(cloudRunLogicalBrokerNamespace, []byte(seed)).String()
+	return uuid.NewSHA1(cloudRunLogicalBrokerNamespace, []byte(seed)).String(), nil
 }
 
 // resolveBrokerName determines the broker name from various sources.

--- a/cmd/server_foreground_broker_test.go
+++ b/cmd/server_foreground_broker_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	scionruntime "github.com/GoogleCloudPlatform/scion/pkg/runtime"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloudRunLogicalBrokerIDIsDeterministic(t *testing.T) {
+	settings := &config.VersionedSettings{
+		ActiveProfile: "default",
+		Profiles: map[string]config.V1ProfileConfig{
+			"default": {Runtime: "cloudrun"},
+		},
+		Runtimes: map[string]config.V1RuntimeConfig{
+			"cloudrun": {
+				Type: "cloudrun",
+				CloudRun: &config.V1CloudRunConfig{
+					Project: "test-project",
+					Region:  "us-central1",
+				},
+			},
+		},
+	}
+	rt := &scionruntime.MockRuntime{NameFunc: func() string { return "cloudrun" }}
+
+	id1 := deriveCloudRunLogicalBrokerID(settings, rt)
+	id2 := deriveCloudRunLogicalBrokerID(settings, rt)
+
+	assert.NotEmpty(t, id1)
+	assert.Equal(t, id1, id2)
+}
+
+func TestResolveBrokerIDPrefersConfiguredIDOverDefault(t *testing.T) {
+	cfg := &config.GlobalConfig{}
+	settings := &config.Settings{
+		Hub: &config.HubClientConfig{BrokerID: "configured-broker"},
+	}
+
+	got := resolveBrokerID(cfg, settings, nil, t.TempDir(), "cloudrun-default")
+
+	assert.Equal(t, "configured-broker", got)
+}

--- a/pkg/hub/broker_routing.go
+++ b/pkg/hub/broker_routing.go
@@ -76,12 +76,17 @@ func (d routeDecision) String() string {
 // reaper (B5-1) clears dead owners.
 const defaultAffinityFreshness = 90 * time.Second
 
-// route decides how to deliver a dispatch for brokerID. The local fast path is
-// checked first and unchanged; affinity is consulted only to choose between
-// forwarding (durable intent + signal) and fast-failing (design §5.3). The
-// affinity lookup is a hint — a wrong "alive" costs one timeout (intent stays
-// durable and reconciles later); a wrong "dead" is reaped by §7.1.
+// route decides how to deliver a dispatch for brokerID. Stateless local broker
+// identities represent a shared, replica-independent runtime capability and are
+// always routed through this replica's local broker HTTP endpoint when present.
+// Stateful brokers keep the existing control-channel and affinity behavior.
 func (c *HybridBrokerClient) route(ctx context.Context, brokerID, brokerEndpoint string) routeDecision {
+	if c.isStatelessLocalBroker(brokerID) {
+		if brokerEndpoint != "" {
+			return routeHTTP
+		}
+		return routeUndeliverable
+	}
 	if c.controlChannel.manager.IsConnected(brokerID) {
 		return routeLocal
 	}
@@ -104,6 +109,30 @@ func (c *HybridBrokerClient) route(ctx context.Context, brokerID, brokerEndpoint
 // server to a store-backed lookup (StoreAffinityLookup).
 func (c *HybridBrokerClient) SetAffinityLookup(fn func(ctx context.Context, brokerID string) (owner string, alive bool)) {
 	c.affinity = fn
+}
+
+// SetStatelessLocalBrokers marks co-located broker IDs whose runtime operations
+// are replica-independent. Remote/stateful brokers must not be listed here.
+func (c *HybridBrokerClient) SetStatelessLocalBrokers(ids []string) {
+	if len(ids) == 0 {
+		c.statelessLocalBrokers = nil
+		return
+	}
+	c.statelessLocalBrokers = make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		c.statelessLocalBrokers[id] = struct{}{}
+	}
+}
+
+func (c *HybridBrokerClient) isStatelessLocalBroker(brokerID string) bool {
+	if c == nil || brokerID == "" || len(c.statelessLocalBrokers) == 0 {
+		return false
+	}
+	_, ok := c.statelessLocalBrokers[brokerID]
+	return ok
 }
 
 const (

--- a/pkg/hub/broker_routing_test.go
+++ b/pkg/hub/broker_routing_test.go
@@ -34,6 +34,9 @@ import (
 // fallback path. Other methods are stubs.
 type fakeHTTPClient struct {
 	messageAgentCalled bool
+	startAgentCalled   bool
+	stopAgentCalled    bool
+	deleteAgentCalled  bool
 }
 
 func (f *fakeHTTPClient) MessageAgent(context.Context, string, string, string, string, string, bool, *messages.StructuredMessage) error {
@@ -46,9 +49,11 @@ func (f *fakeHTTPClient) CreateAgent(context.Context, string, string, *RemoteCre
 	return nil, nil
 }
 func (f *fakeHTTPClient) StartAgent(context.Context, string, string, string, string, string, string, string, string, map[string]string, []ResolvedSecret, *api.ScionConfig, []api.SharedDir, bool, bool) (*RemoteAgentResponse, error) {
+	f.startAgentCalled = true
 	return nil, nil
 }
 func (f *fakeHTTPClient) StopAgent(context.Context, string, string, string, string) error {
+	f.stopAgentCalled = true
 	return nil
 }
 func (f *fakeHTTPClient) RestartAgent(context.Context, string, string, string, string, map[string]string) error {
@@ -58,6 +63,7 @@ func (f *fakeHTTPClient) ResetAuthAgent(context.Context, string, string, string,
 	return nil
 }
 func (f *fakeHTTPClient) DeleteAgent(context.Context, string, string, string, string, bool, bool, bool, time.Time) error {
+	f.deleteAgentCalled = true
 	return nil
 }
 func (f *fakeHTTPClient) CheckAgentPrompt(context.Context, string, string, string, string) (bool, error) {
@@ -124,6 +130,46 @@ func TestHybridBrokerClient_Route_NilAffinityIsSafe(t *testing.T) {
 	// No affinity lookup set: a non-local broker with no endpoint is undeliverable.
 	assert.Equal(t, routeUndeliverable, c.route(context.Background(), "b-none", ""))
 	assert.Equal(t, routeHTTP, c.route(context.Background(), "b-ep", "http://x"))
+}
+
+func TestHybridBrokerClient_Route_StatelessBrokerIgnoresAffinity(t *testing.T) {
+	ctx := context.Background()
+	const brokerID = "cloudrun-logical-broker"
+
+	mgr := NewControlChannelManager(DefaultControlChannelConfig(), slog.Default())
+	mgr.mu.Lock()
+	mgr.connections[brokerID] = &BrokerConnection{brokerID: brokerID, sessionID: "s1"}
+	mgr.mu.Unlock()
+
+	c := NewHybridBrokerClient(mgr, nil, nil, false)
+	c.SetStatelessLocalBrokers([]string{brokerID})
+	c.SetAffinityLookup(func(context.Context, string) (string, bool) { return "other-replica", true })
+
+	assert.Equal(t, routeHTTP, c.route(ctx, brokerID, "http://localhost:9800"))
+	assert.Equal(t, routeUndeliverable, c.route(ctx, brokerID, ""))
+}
+
+func TestHybridBrokerClient_StatelessBrokerLifecycleUsesHTTP(t *testing.T) {
+	ctx := context.Background()
+	const brokerID = "cloudrun-logical-broker"
+
+	mgr := NewControlChannelManager(DefaultControlChannelConfig(), slog.Default())
+	httpClient := &fakeHTTPClient{}
+	c := NewHybridBrokerClient(mgr, httpClient, nil, false)
+	c.SetStatelessLocalBrokers([]string{brokerID})
+	c.SetAffinityLookup(func(context.Context, string) (string, bool) { return "other-replica", true })
+
+	_, err := c.StartAgent(ctx, brokerID, "http://localhost:9800", "agent-1", "project-1", "", "", "", "", nil, nil, nil, nil, false, false)
+	assert.NoError(t, err)
+	assert.True(t, httpClient.startAgentCalled)
+
+	err = c.StopAgent(ctx, brokerID, "http://localhost:9800", "agent-1", "project-1")
+	assert.NoError(t, err)
+	assert.True(t, httpClient.stopAgentCalled)
+
+	err = c.DeleteAgent(ctx, brokerID, "http://localhost:9800", "agent-1", "project-1", false, false, false, time.Time{})
+	assert.NoError(t, err)
+	assert.True(t, httpClient.deleteAgentCalled)
 }
 
 func TestHybridBrokerClient_MessageAgent_RouteGate(t *testing.T) {

--- a/pkg/hub/controlchannel_client.go
+++ b/pkg/hub/controlchannel_client.go
@@ -478,6 +478,10 @@ type HybridBrokerClient struct {
 	controlChannel *ControlChannelBrokerClient
 	httpClient     RuntimeBrokerClient
 	debug          bool
+	// statelessLocalBrokers identifies co-located broker identities that are
+	// safe to serve from any replica through the local broker HTTP endpoint.
+	// Store affinity for these IDs is replica health, not lifecycle ownership.
+	statelessLocalBrokers map[string]struct{}
 	// affinity returns the believed owning hub instanceID for a broker and
 	// whether that owner is alive (last_heartbeat fresh). It is a routing HINT
 	// only (correctness comes from durable intent + drain); injected so route()
@@ -496,6 +500,9 @@ func NewHybridBrokerClient(manager *ControlChannelManager, httpClient RuntimeBro
 
 // useControlChannel returns true if we should use control channel for this broker.
 func (c *HybridBrokerClient) useControlChannel(brokerID string) bool {
+	if c.isStatelessLocalBroker(brokerID) {
+		return false
+	}
 	return c.controlChannel.manager.IsConnected(brokerID)
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -582,15 +582,18 @@ type Server struct {
 	// Phase 3/4 supply the real local-tunnel ops; tests override for exactly-once.
 	execDispatch     func(ctx context.Context, d store.BrokerDispatch) (string, error)
 	deliverMsg       func(ctx context.Context, m *store.Message) error
-	maintenance      *MaintenanceState  // Runtime maintenance mode state
-	hubID            string             // Unique hub instance ID for secret namespacing
-	instanceID       string             // Unique per-process ID (uuid); affinity key for broker dispatch
-	embeddedBrokerID string             // Broker ID when running in hub+broker combo mode
-	workstation      bool               // True when running in workstation (non-production) mode
-	scheduler        *Scheduler         // Unified scheduler for recurring tasks
-	cleanupOnce      sync.Once          // Ensures CleanupResources runs only once
-	ctx              context.Context    // Server-lifetime context; cancelled on Shutdown
-	ctxCancel        context.CancelFunc // Cancels ctx
+	maintenance      *MaintenanceState // Runtime maintenance mode state
+	hubID            string            // Unique hub instance ID for secret namespacing
+	instanceID       string            // Unique per-process ID (uuid); affinity key for broker dispatch
+	embeddedBrokerID string            // Broker ID when running in hub+broker combo mode
+	// statelessEmbeddedBroker is true when the embedded broker identity is a
+	// replica-independent API adapter rather than a process-owned control channel.
+	statelessEmbeddedBroker bool
+	workstation             bool               // True when running in workstation (non-production) mode
+	scheduler               *Scheduler         // Unified scheduler for recurring tasks
+	cleanupOnce             sync.Once          // Ensures CleanupResources runs only once
+	ctx                     context.Context    // Server-lifetime context; cancelled on Shutdown
+	ctxCancel               context.CancelFunc // Cancels ctx
 
 	logQueryService  *LogQueryService         // Cloud Logging query service (nil = disabled)
 	metricsDashboard *MetricsDashboardService // Cloud Monitoring metrics dashboard (nil = disabled)
@@ -1340,10 +1343,29 @@ func (s *Server) SetEmbeddedBrokerID(id string) {
 	s.embeddedBrokerID = id
 }
 
+// SetStatelessEmbeddedBrokerID records a co-located broker whose runtime
+// lifecycle operations are safe from any hub replica.
+func (s *Server) SetStatelessEmbeddedBrokerID(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.embeddedBrokerID = id
+	s.statelessEmbeddedBroker = id != ""
+}
+
 // GetEmbeddedBrokerID returns the co-located broker ID, if any.
 func (s *Server) GetEmbeddedBrokerID() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	return s.embeddedBrokerID
+}
+
+// GetStatelessEmbeddedBrokerID returns the embedded stateless broker ID, if any.
+func (s *Server) GetStatelessEmbeddedBrokerID() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if !s.statelessEmbeddedBroker {
+		return ""
+	}
 	return s.embeddedBrokerID
 }
 
@@ -1701,6 +1723,9 @@ func (s *Server) CreateAuthenticatedDispatcher() *HTTPAgentDispatcher {
 	if s.controlChannel != nil {
 		hbc := NewHybridBrokerClient(s.controlChannel, httpClient, &hmacBrokerSigner{store: s.store}, s.config.Debug)
 		hbc.SetAffinityLookup(StoreAffinityLookup(s.store, 0))
+		if statelessBrokerID := s.GetStatelessEmbeddedBrokerID(); statelessBrokerID != "" {
+			hbc.SetStatelessLocalBrokers([]string{statelessBrokerID})
+		}
 		client = hbc
 	} else {
 		client = httpClient


### PR DESCRIPTION
When the Hub runs as multiple Cloud Run replicas, broker lifecycle calls (register, heartbeat, delete) must be routed to any instance without requiring sticky sessions. Replace instance-local broker state with hub-mediated API calls for lifecycle operations.

Add deterministic broker ID derivation from Cloud Run project/region config so all replicas converge on the same logical broker identity.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
