### PR TITLE
feat: chat integration config refactor + secrets migration (Phase 1)

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -460,7 +460,10 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 								hubCreds["database_url"] = cfg.Database.URL
 							}
 							// Inject chat integration secrets from the secret backend.
-							injectPluginSecrets(ctx, secretBackend, bt, hubCreds)
+							// Pass the plugin's merged config so secrets are only injected
+							// when not already set by file or inline config.
+							brokerCfg := pluginMgr.GetPluginConfig(scionplugin.PluginTypeBroker, bt)
+							injectPluginSecrets(ctx, secretBackend, bt, brokerCfg, hubCreds)
 							if cfgErr := pluginMgr.ConfigureBroker(bt, hubCreds); cfgErr != nil {
 								log.Printf("Warning: failed to inject hub credentials into broker plugin %q: %v", bt, cfgErr)
 							} else {
@@ -2021,9 +2024,10 @@ var pluginSecretKeyMap = map[string][]struct {
 }
 
 // injectPluginSecrets loads chat integration secrets from the secret backend
-// and injects them into the plugin's credential map. Only injects if the key
-// is not already set (fallback chain: in-memory config → secret backend).
-func injectPluginSecrets(ctx context.Context, sb secret.SecretBackend, pluginName string, creds map[string]string) {
+// and injects them into the extra credentials map. Respects the fallback chain:
+// if the plugin's merged config (file + inline) already has a value for a key,
+// the secret backend is not consulted for that key.
+func injectPluginSecrets(ctx context.Context, sb secret.SecretBackend, pluginName string, pluginConfig, creds map[string]string) {
 	if sb == nil {
 		return
 	}
@@ -2035,7 +2039,7 @@ func injectPluginSecrets(ctx context.Context, sb secret.SecretBackend, pluginNam
 
 	hubID := sb.HubID()
 	for _, m := range mappings {
-		if existing, ok := creds[m.configKey]; ok && existing != "" {
+		if existing, ok := pluginConfig[m.configKey]; ok && existing != "" {
 			continue
 		}
 		sv, err := sb.Get(ctx, m.secretKey, store.ScopeHub, hubID)
@@ -2043,6 +2047,6 @@ func injectPluginSecrets(ctx context.Context, sb secret.SecretBackend, pluginNam
 			continue
 		}
 		creds[m.configKey] = sv.Value
-		log.Printf("Injected secret %q into broker plugin %q as %q", m.secretKey, pluginName, m.configKey)
+		slog.Info("Injected secret into broker plugin", "secret", m.secretKey, "plugin", pluginName, "config_key", m.configKey)
 	}
 }

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -459,6 +459,8 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 								hubCreds["database_driver"] = cfg.Database.Driver
 								hubCreds["database_url"] = cfg.Database.URL
 							}
+							// Inject chat integration secrets from the secret backend.
+							injectPluginSecrets(ctx, secretBackend, bt, hubCreds)
 							if cfgErr := pluginMgr.ConfigureBroker(bt, hubCreds); cfgErr != nil {
 								log.Printf("Warning: failed to inject hub credentials into broker plugin %q: %v", bt, cfgErr)
 							} else {
@@ -1827,9 +1829,15 @@ func initPluginManager() *scionplugin.Manager {
 		Broker: make(map[string]scionplugin.PluginEntry),
 	}
 	for name, entry := range vs.Server.Plugins.Broker {
+		// Merge config_file contents with inline config (inline overrides file).
+		mergedConfig, mergeErr := config.LoadPluginConfigFile(entry.ConfigFile, entry.Config)
+		if mergeErr != nil {
+			log.Printf("Warning: failed to load config file for plugin %q: %v", name, mergeErr)
+			mergedConfig = entry.Config
+		}
 		pluginsCfg.Broker[name] = scionplugin.PluginEntry{
 			Path:        entry.Path,
-			Config:      entry.Config,
+			Config:      mergedConfig,
 			ConfigFile:  entry.ConfigFile,
 			SelfManaged: entry.SelfManaged,
 			Address:     entry.Address,
@@ -1990,4 +1998,51 @@ func resolveMaintenanceConfig(cfg *config.GlobalConfig) hub.MaintenanceConfig {
 	}
 
 	return mc
+}
+
+// pluginSecretKeyMap maps plugin names to their well-known secret keys and
+// the corresponding plugin config keys. Each entry maps a secret backend key
+// to the config key that the plugin's Configure() expects.
+var pluginSecretKeyMap = map[string][]struct {
+	secretKey string
+	configKey string
+}{
+	"telegram": {
+		{config.SecretTelegramBotToken, "bot_token"},
+		{config.SecretTelegramWebhookKey, "webhook_secret"},
+	},
+	"discord": {
+		{config.SecretDiscordBotToken, "bot_token"},
+		{config.SecretDiscordPublicKey, "public_key"},
+	},
+	"chat-app": {
+		{config.SecretGChatSigningKey, "signing_key"},
+	},
+}
+
+// injectPluginSecrets loads chat integration secrets from the secret backend
+// and injects them into the plugin's credential map. Only injects if the key
+// is not already set (fallback chain: in-memory config → secret backend).
+func injectPluginSecrets(ctx context.Context, sb secret.SecretBackend, pluginName string, creds map[string]string) {
+	if sb == nil {
+		return
+	}
+
+	mappings, ok := pluginSecretKeyMap[pluginName]
+	if !ok {
+		return
+	}
+
+	hubID := sb.HubID()
+	for _, m := range mappings {
+		if existing, ok := creds[m.configKey]; ok && existing != "" {
+			continue
+		}
+		sv, err := sb.Get(ctx, m.secretKey, store.ScopeHub, hubID)
+		if err != nil || sv == nil || sv.Value == "" {
+			continue
+		}
+		creds[m.configKey] = sv.Value
+		log.Printf("Injected secret %q into broker plugin %q as %q", m.secretKey, pluginName, m.configKey)
+	}
 }

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1830,6 +1830,7 @@ func initPluginManager() *scionplugin.Manager {
 		pluginsCfg.Broker[name] = scionplugin.PluginEntry{
 			Path:        entry.Path,
 			Config:      entry.Config,
+			ConfigFile:  entry.ConfigFile,
 			SelfManaged: entry.SelfManaged,
 			Address:     entry.Address,
 		}

--- a/cmd/server_foreground_broker_test.go
+++ b/cmd/server_foreground_broker_test.go
@@ -40,8 +40,10 @@ func TestCloudRunLogicalBrokerIDIsDeterministic(t *testing.T) {
 	}
 	rt := &scionruntime.MockRuntime{NameFunc: func() string { return "cloudrun" }}
 
-	id1 := deriveCloudRunLogicalBrokerID(settings, rt)
-	id2 := deriveCloudRunLogicalBrokerID(settings, rt)
+	id1, err1 := deriveCloudRunLogicalBrokerID(settings, rt)
+	assert.NoError(t, err1)
+	id2, err2 := deriveCloudRunLogicalBrokerID(settings, rt)
+	assert.NoError(t, err2)
 
 	assert.NotEmpty(t, id1)
 	assert.Equal(t, id1, id2)

--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -40,6 +40,10 @@ const (
 // IntegrationConfigProvider defines the interface for reading and writing
 // per-integration configuration. Implementations handle only non-sensitive
 // settings; secrets are managed separately via SecretBackend.
+//
+// Phase 1 exposes file-based Load/Save only. Phase 2 will extend this to the
+// full admin API surface (context-aware, per-integration routing, list, status)
+// per design doc §3.3.
 type IntegrationConfigProvider interface {
 	// Load reads the integration config file and returns its contents as a
 	// flat key-value map suitable for merging into a plugin's Config map.
@@ -63,21 +67,19 @@ func NewYAMLConfigProvider(path string) (*YAMLConfigProvider, error) {
 	}
 
 	resolved := path
-	if !filepath.IsAbs(path) {
-		globalDir, err := GetGlobalDir()
-		if err != nil {
-			return nil, fmt.Errorf("resolve config dir: %w", err)
-		}
-		resolved = filepath.Join(globalDir, path)
-	}
-
-	// Expand ~ prefix
 	if strings.HasPrefix(resolved, "~/") {
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return nil, fmt.Errorf("resolve home dir: %w", err)
 		}
 		resolved = filepath.Join(home, resolved[2:])
+	}
+	if !filepath.IsAbs(resolved) {
+		globalDir, err := GetGlobalDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolve config dir: %w", err)
+		}
+		resolved = filepath.Join(globalDir, resolved)
 	}
 
 	return &YAMLConfigProvider{path: resolved}, nil

--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+// Well-known secret keys for chat integration credentials stored via the secrets system.
+const (
+	// Telegram
+	SecretTelegramBotToken    = "TELEGRAM_BOT_TOKEN"
+	SecretTelegramWebhookKey  = "TELEGRAM_WEBHOOK_SECRET"
+
+	// Discord
+	SecretDiscordBotToken  = "DISCORD_BOT_TOKEN"
+	SecretDiscordPublicKey = "DISCORD_PUBLIC_KEY"
+
+	// Google Chat
+	SecretGChatSigningKey = "GCHAT_SIGNING_KEY"
+)
+
+// IntegrationConfigProvider defines the interface for reading and writing
+// per-integration configuration. Implementations handle only non-sensitive
+// settings; secrets are managed separately via SecretBackend.
+type IntegrationConfigProvider interface {
+	// Load reads the integration config file and returns its contents as a
+	// flat key-value map suitable for merging into a plugin's Config map.
+	Load() (map[string]string, error)
+
+	// Save writes the given key-value map to the integration config file.
+	Save(config map[string]string) error
+}
+
+// YAMLConfigProvider reads and writes per-integration YAML config files.
+// The YAML file is a flat map[string]string at the top level.
+type YAMLConfigProvider struct {
+	path string
+}
+
+// NewYAMLConfigProvider creates a new YAMLConfigProvider for the given file path.
+// If path is relative, it is resolved relative to the global scion config dir (~/.scion/).
+func NewYAMLConfigProvider(path string) (*YAMLConfigProvider, error) {
+	if path == "" {
+		return nil, fmt.Errorf("config file path is required")
+	}
+
+	resolved := path
+	if !filepath.IsAbs(path) {
+		globalDir, err := GetGlobalDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolve config dir: %w", err)
+		}
+		resolved = filepath.Join(globalDir, path)
+	}
+
+	// Expand ~ prefix
+	if strings.HasPrefix(resolved, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolve home dir: %w", err)
+		}
+		resolved = filepath.Join(home, resolved[2:])
+	}
+
+	return &YAMLConfigProvider{path: resolved}, nil
+}
+
+// Path returns the resolved absolute path to the config file.
+func (p *YAMLConfigProvider) Path() string {
+	return p.path
+}
+
+// Load reads the YAML config file and returns its contents as a flat key-value map.
+// Returns an empty map (not an error) if the file does not exist.
+func (p *YAMLConfigProvider) Load() (map[string]string, error) {
+	data, err := os.ReadFile(p.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]string), nil
+		}
+		return nil, fmt.Errorf("read config file %s: %w", p.path, err)
+	}
+
+	var raw map[string]interface{}
+	if err := yamlv3.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse config file %s: %w", p.path, err)
+	}
+
+	result := make(map[string]string, len(raw))
+	for k, v := range raw {
+		result[k] = fmt.Sprintf("%v", v)
+	}
+	return result, nil
+}
+
+// Save writes the given key-value map to the YAML config file.
+// The parent directory is created if it does not exist.
+func (p *YAMLConfigProvider) Save(config map[string]string) error {
+	dir := filepath.Dir(p.path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("create config dir %s: %w", dir, err)
+	}
+
+	data, err := yamlv3.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+
+	return os.WriteFile(p.path, data, 0600)
+}
+
+// LoadPluginConfigFile reads a standalone YAML config file for a plugin and
+// returns its contents merged with any existing inline config. The inline
+// config takes precedence (allows overrides). Secret keys are excluded from
+// the file-based config to prevent accidental leakage.
+func LoadPluginConfigFile(configFile string, inlineConfig map[string]string) (map[string]string, error) {
+	if configFile == "" {
+		return inlineConfig, nil
+	}
+
+	provider, err := NewYAMLConfigProvider(configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	fileConfig, err := provider.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter out secret keys from file-based config
+	for _, secretKey := range []string{
+		SecretTelegramBotToken, SecretTelegramWebhookKey,
+		SecretDiscordBotToken, SecretDiscordPublicKey,
+		SecretGChatSigningKey,
+	} {
+		delete(fileConfig, strings.ToLower(secretKey))
+		delete(fileConfig, secretKey)
+	}
+
+	// Merge: file config is the base, inline config overrides
+	merged := make(map[string]string, len(fileConfig)+len(inlineConfig))
+	for k, v := range fileConfig {
+		merged[k] = v
+	}
+	for k, v := range inlineConfig {
+		merged[k] = v
+	}
+
+	return merged, nil
+}

--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -26,8 +26,8 @@ import (
 // Well-known secret keys for chat integration credentials stored via the secrets system.
 const (
 	// Telegram
-	SecretTelegramBotToken    = "TELEGRAM_BOT_TOKEN"
-	SecretTelegramWebhookKey  = "TELEGRAM_WEBHOOK_SECRET"
+	SecretTelegramBotToken   = "TELEGRAM_BOT_TOKEN"
+	SecretTelegramWebhookKey = "TELEGRAM_WEBHOOK_SECRET"
 
 	// Discord
 	SecretDiscordBotToken  = "DISCORD_BOT_TOKEN"

--- a/pkg/config/integration_config_test.go
+++ b/pkg/config/integration_config_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestYAMLConfigProvider_LoadNonExistent(t *testing.T) {
+	p, err := NewYAMLConfigProvider(filepath.Join(t.TempDir(), "nonexistent.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := p.Load()
+	if err != nil {
+		t.Fatalf("Load() should not error for missing file: %v", err)
+	}
+	if len(config) != 0 {
+		t.Fatalf("expected empty map, got %v", config)
+	}
+}
+
+func TestYAMLConfigProvider_SaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test-config.yaml")
+	p, err := NewYAMLConfigProvider(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := map[string]string{
+		"bot_token":     "secret-token",
+		"inbound_mode":  "webhook",
+		"webhook_url":   "https://example.com/webhook",
+	}
+
+	if err := p.Save(input); err != nil {
+		t.Fatalf("Save() failed: %v", err)
+	}
+
+	// Verify file was created with restricted permissions
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("config file not created: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("expected 0600 permissions, got %o", info.Mode().Perm())
+	}
+
+	loaded, err := p.Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	for k, want := range input {
+		if got := loaded[k]; got != want {
+			t.Errorf("key %q: got %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestYAMLConfigProvider_EmptyPath(t *testing.T) {
+	_, err := NewYAMLConfigProvider("")
+	if err == nil {
+		t.Fatal("expected error for empty path")
+	}
+}
+
+func TestLoadPluginConfigFile_Empty(t *testing.T) {
+	inline := map[string]string{"key": "value"}
+	result, err := LoadPluginConfigFile("", inline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result["key"] != "value" {
+		t.Errorf("expected inline config passthrough, got %v", result)
+	}
+}
+
+func TestLoadPluginConfigFile_MergeWithInlineOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plugin.yaml")
+	p, _ := NewYAMLConfigProvider(path)
+	p.Save(map[string]string{
+		"inbound_mode": "poll",
+		"db_path":      "/tmp/test.db",
+	})
+
+	inline := map[string]string{
+		"inbound_mode": "webhook",
+	}
+
+	result, err := LoadPluginConfigFile(path, inline)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result["inbound_mode"] != "webhook" {
+		t.Errorf("inline should override file: got %q", result["inbound_mode"])
+	}
+	if result["db_path"] != "/tmp/test.db" {
+		t.Errorf("file config should be included: got %q", result["db_path"])
+	}
+}
+
+func TestLoadPluginConfigFile_FiltersSecretKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plugin.yaml")
+	p, _ := NewYAMLConfigProvider(path)
+	p.Save(map[string]string{
+		"bot_token":              "should-stay",
+		"TELEGRAM_BOT_TOKEN":    "should-be-filtered",
+		"telegram_bot_token":    "should-be-filtered",
+		"DISCORD_BOT_TOKEN":     "should-be-filtered",
+		"GCHAT_SIGNING_KEY":     "should-be-filtered",
+	})
+
+	result, err := LoadPluginConfigFile(path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// bot_token is a plugin-level config key, not a well-known secret constant
+	if result["bot_token"] != "should-stay" {
+		t.Errorf("bot_token should be preserved: got %q", result["bot_token"])
+	}
+
+	for _, key := range []string{
+		"TELEGRAM_BOT_TOKEN", "telegram_bot_token",
+		"DISCORD_BOT_TOKEN", "GCHAT_SIGNING_KEY",
+	} {
+		if _, ok := result[key]; ok {
+			t.Errorf("secret key %q should have been filtered", key)
+		}
+	}
+}

--- a/pkg/config/integration_config_test.go
+++ b/pkg/config/integration_config_test.go
@@ -44,9 +44,9 @@ func TestYAMLConfigProvider_SaveAndLoad(t *testing.T) {
 	}
 
 	input := map[string]string{
-		"bot_token":     "secret-token",
-		"inbound_mode":  "webhook",
-		"webhook_url":   "https://example.com/webhook",
+		"bot_token":    "secret-token",
+		"inbound_mode": "webhook",
+		"webhook_url":  "https://example.com/webhook",
 	}
 
 	if err := p.Save(input); err != nil {
@@ -113,10 +113,12 @@ func TestLoadPluginConfigFile_MergeWithInlineOverride(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "plugin.yaml")
 	p, _ := NewYAMLConfigProvider(path)
-	p.Save(map[string]string{
+	if err := p.Save(map[string]string{
 		"inbound_mode": "poll",
 		"db_path":      "/tmp/test.db",
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	inline := map[string]string{
 		"inbound_mode": "webhook",
@@ -139,13 +141,15 @@ func TestLoadPluginConfigFile_FiltersSecretKeys(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "plugin.yaml")
 	p, _ := NewYAMLConfigProvider(path)
-	p.Save(map[string]string{
-		"bot_token":              "should-stay",
-		"TELEGRAM_BOT_TOKEN":    "should-be-filtered",
-		"telegram_bot_token":    "should-be-filtered",
-		"DISCORD_BOT_TOKEN":     "should-be-filtered",
-		"GCHAT_SIGNING_KEY":     "should-be-filtered",
-	})
+	if err := p.Save(map[string]string{
+		"bot_token":          "should-stay",
+		"TELEGRAM_BOT_TOKEN": "should-be-filtered",
+		"telegram_bot_token": "should-be-filtered",
+		"DISCORD_BOT_TOKEN":  "should-be-filtered",
+		"GCHAT_SIGNING_KEY":  "should-be-filtered",
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	result, err := LoadPluginConfigFile(path, nil)
 	if err != nil {

--- a/pkg/config/integration_config_test.go
+++ b/pkg/config/integration_config_test.go
@@ -81,6 +81,23 @@ func TestYAMLConfigProvider_EmptyPath(t *testing.T) {
 	}
 }
 
+func TestYAMLConfigProvider_TildePath(t *testing.T) {
+	p, err := NewYAMLConfigProvider("~/configs/telegram.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := filepath.Join(home, "configs", "telegram.yaml")
+	if p.Path() != expected {
+		t.Errorf("expected path %q, got %q", expected, p.Path())
+	}
+}
+
 func TestLoadPluginConfigFile_Empty(t *testing.T) {
 	inline := map[string]string{"key": "value"}
 	result, err := LoadPluginConfigFile("", inline)

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -328,6 +328,11 @@ type V1PluginEntry struct {
 	Path string `json:"path,omitempty" yaml:"path,omitempty" koanf:"path"`
 	// Config is an opaque key-value map passed to the plugin via Configure().
 	Config map[string]string `json:"config,omitempty" yaml:"config,omitempty" koanf:"config"`
+	// ConfigFile is the path to a standalone YAML config file for this plugin.
+	// When set, the hub reads non-sensitive settings from this file and merges
+	// them into the Config map. Secrets are loaded separately via SecretBackend.
+	// If empty, the inline Config map is used as-is (backward compatible).
+	ConfigFile string `json:"config_file,omitempty" yaml:"config_file,omitempty" koanf:"config_file"`
 	// SelfManaged indicates the plugin manages its own process lifecycle.
 	// The Hub connects to the plugin's RPC server rather than starting it.
 	SelfManaged bool `json:"self_managed,omitempty" yaml:"self_managed,omitempty" koanf:"self_managed"`

--- a/pkg/hub/handlers_chat_secrets.go
+++ b/pkg/hub/handlers_chat_secrets.go
@@ -68,6 +68,9 @@ func (s *Server) LoadChatIntegrationSecret(ctx context.Context, name string) (st
 		if err != nil {
 			return "", err
 		}
+		if sv == nil {
+			return "", nil
+		}
 		return sv.Value, nil
 	}
 

--- a/pkg/hub/handlers_chat_secrets.go
+++ b/pkg/hub/handlers_chat_secrets.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// SetChatIntegrationSecret stores a chat integration secret (Telegram bot token,
+// Discord bot token, etc.) via the secrets backend, following the GitHub App
+// pattern from handlers_github_app.go.
+func (s *Server) SetChatIntegrationSecret(ctx context.Context, name, value, description, userID string) error {
+	if s.secretBackend != nil {
+		_, _, err := s.secretBackend.Set(ctx, &secret.SetSecretInput{
+			Name:          name,
+			Value:         value,
+			SecretType:    secret.TypeVariable,
+			Scope:         store.ScopeHub,
+			ScopeID:       s.hubID,
+			Description:   description,
+			InjectionMode: "as_needed",
+			CreatedBy:     userID,
+			UpdatedBy:     userID,
+		})
+		return err
+	}
+
+	sec := &store.Secret{
+		ID:             fmt.Sprintf("hub-chat-%s", strings.ToLower(strings.ReplaceAll(name, "_", "-"))),
+		Key:            name,
+		EncryptedValue: value,
+		Scope:          store.ScopeHub,
+		ScopeID:        s.hubID,
+		SecretType:     store.SecretTypeVariable,
+		Description:    description,
+		Version:        1,
+		CreatedBy:      userID,
+		UpdatedBy:      userID,
+	}
+	_, err := s.store.UpsertSecret(ctx, sec)
+	return err
+}
+
+// LoadChatIntegrationSecret loads a chat integration secret from the secrets
+// backend, with fallback to the database.
+func (s *Server) LoadChatIntegrationSecret(ctx context.Context, name string) (string, error) {
+	if s.secretBackend != nil {
+		sv, err := s.secretBackend.Get(ctx, name, store.ScopeHub, s.hubID)
+		if err != nil {
+			return "", err
+		}
+		return sv.Value, nil
+	}
+
+	return s.store.GetSecretValue(ctx, name, store.ScopeHub, s.hubID)
+}
+
+// HasChatIntegrationSecret checks whether a chat integration secret exists
+// in either the secrets backend or the database.
+func (s *Server) HasChatIntegrationSecret(ctx context.Context, name string) bool {
+	if s.secretBackend != nil {
+		meta, err := s.secretBackend.GetMeta(ctx, name, store.ScopeHub, s.hubID)
+		return err == nil && meta != nil
+	}
+
+	val, err := s.store.GetSecretValue(ctx, name, store.ScopeHub, s.hubID)
+	return err == nil && val != ""
+}
+
+// chatSecretDescription returns a human-readable description for a chat secret key.
+func chatSecretDescription(secretKey string) string {
+	switch secretKey {
+	case config.SecretTelegramBotToken:
+		return "Telegram bot token"
+	case config.SecretTelegramWebhookKey:
+		return "Telegram webhook secret"
+	case config.SecretDiscordBotToken:
+		return "Discord bot token"
+	case config.SecretDiscordPublicKey:
+		return "Discord application public key"
+	case config.SecretGChatSigningKey:
+		return "Google Chat signing key"
+	default:
+		slog.Warn("Unknown chat secret key", "key", secretKey)
+		return "Chat integration secret"
+	}
+}

--- a/pkg/hub/handlers_chat_secrets.go
+++ b/pkg/hub/handlers_chat_secrets.go
@@ -89,8 +89,8 @@ func (s *Server) HasChatIntegrationSecret(ctx context.Context, name string) bool
 	return err == nil && val != ""
 }
 
-// chatSecretDescription returns a human-readable description for a chat secret key.
-func chatSecretDescription(secretKey string) string {
+// ChatSecretDescription returns a human-readable description for a chat secret key.
+func ChatSecretDescription(secretKey string) string {
 	switch secretKey {
 	case config.SecretTelegramBotToken:
 		return "Telegram bot token"

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -17,10 +17,10 @@ package hub
 import (
 	"context"
 	"crypto/rand"
-	"errors"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"io/fs"

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -52,6 +52,13 @@ type PluginEntry struct {
 	// The plugin validates its own config and returns clear errors for invalid values.
 	Config map[string]string `json:"config,omitempty" yaml:"config,omitempty" koanf:"config"`
 
+	// ConfigFile is the path to a standalone YAML config file for this plugin.
+	// When set, the hub reads non-sensitive settings from this file and merges
+	// them into the Config map before calling Configure(). Secrets are loaded
+	// separately via SecretBackend. If empty, the inline Config map is used
+	// as-is (backward compatible).
+	ConfigFile string `json:"config_file,omitempty" yaml:"config_file,omitempty" koanf:"config_file"`
+
 	// SelfManaged indicates the plugin manages its own process lifecycle.
 	// The Hub connects to the plugin's RPC server rather than starting it.
 	// The plugin is responsible for its own startup and shutdown.

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -402,6 +402,24 @@ func (m *Manager) ConfigureBroker(name string, extra map[string]string) error {
 	return rpcClient.Configure(merged)
 }
 
+// GetPluginConfig returns a copy of the stored config map for the named plugin,
+// or nil if the plugin is not loaded. The returned map is safe to read without
+// affecting the manager's internal state.
+func (m *Manager) GetPluginConfig(pluginType, name string) map[string]string {
+	key := pluginType + ":" + name
+	m.mu.RLock()
+	dp, ok := m.configs[key]
+	m.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, len(dp.Config))
+	for k, v := range dp.Config {
+		out[k] = v
+	}
+	return out
+}
+
 // HasPlugin returns true if a plugin with the given type and name is loaded.
 func (m *Manager) HasPlugin(pluginType, name string) bool {
 	key := pluginType + ":" + name

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -25,6 +25,7 @@ package plugin
 type V1PluginEntryLike struct {
 	Path        string
 	Config      map[string]string
+	ConfigFile  string
 	SelfManaged bool
 	Address     string
 }


### PR DESCRIPTION
Phase 1 of Chat Admin UI (issue #365).

- Add ConfigFile field to V1PluginEntry for standalone integration YAML configs
- Implement YAMLConfigProvider for per-integration config files in ~/.scion/
- Add secret key constants + hub secret backend helpers (GitHub App pattern)
- Wire plugin startup: LoadPluginConfigFile() + injectPluginSecrets()
- Backward compatible: inline config map still works when config_file is unset