### PR TITLE
fix: resolve format check and golangci-lint on main

### DIFF
--- a/cmd/server_foreground_broker_test.go
+++ b/cmd/server_foreground_broker_test.go
@@ -40,8 +40,10 @@ func TestCloudRunLogicalBrokerIDIsDeterministic(t *testing.T) {
 	}
 	rt := &scionruntime.MockRuntime{NameFunc: func() string { return "cloudrun" }}
 
-	id1 := deriveCloudRunLogicalBrokerID(settings, rt)
-	id2 := deriveCloudRunLogicalBrokerID(settings, rt)
+	id1, err1 := deriveCloudRunLogicalBrokerID(settings, rt)
+	assert.NoError(t, err1)
+	id2, err2 := deriveCloudRunLogicalBrokerID(settings, rt)
+	assert.NoError(t, err2)
 
 	assert.NotEmpty(t, id1)
 	assert.Equal(t, id1, id2)

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -17,10 +17,10 @@ package hub
 import (
 	"context"
 	"crypto/rand"
-	"errors"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"io/fs"


### PR DESCRIPTION
## Summary

- Fix gofmt import ordering in pkg/hub/web.go
- Update TestCloudRunLogicalBrokerIDIsDeterministic to handle the new (string, error) return signature of deriveCloudRunLogicalBrokerID (commit d02f6c04 changed the function to return an error)

Note: TestInitProjectDataIsolation still fails on clean main due to import chain cmd/sciontool/commands -> pkg/runtime -> pkg/config. This is a pre-existing issue that requires a broader pkg/runtime refactor and is tracked separately