### PR TITLE
feat: add managed agent backend interface and Google API client

### DIFF
--- a/.design/managed-agents.md
+++ b/.design/managed-agents.md
@@ -1,0 +1,663 @@
+# ManagedAgent Design Document (Option B)
+
+## 1. Overview
+
+**Problem statement.** Scion currently runs AI coding agents exclusively in containers (Docker, Podman, Kubernetes, Apple Container, Cloud Run). Each container bundles a Runtime (container lifecycle) and a Harness (LLM CLI like Claude Code or Gemini CLI). A growing class of cloud services offer fully-managed agent execution where the model, tools, sandbox, and orchestration loop are handled server-side. Scion needs to support these managed backends so that `scion start`, `scion message`, `scion stop`, and other commands work seamlessly whether the agent runs in a local container or a remote cloud service.
+
+**Design decision.** Option B: introduce `ManagedAgent` as a peer concept to the existing Runtime+Harness stack, not as a replacement. The `Manager` interface (`pkg/agent/manager.go`) is the branching point. A new `ManagedAgentManager` implements the same `Manager` interface but delegates to a cloud API client instead of a Runtime+Harness pair. Container code is untouched.
+
+**First backend.** Google Managed Agents API (Gemini API) at `generativelanguage.googleapis.com`. The Antigravity agent is the base agent.
+
+**Scope.** This design covers the v1 managed agent integration: start, message, stop, delete, list, look, attach, and logs for managed agents. v1 targets repo-less use cases (research, exploration, standalone tasks). Repo-aware use cases (workspace sync, worktree branching) are deferred to v2.
+
+**Future.** Option C (unified `ExecutionBackend` abstraction collapsing Runtime+Harness+ManagedAgent into one interface) will be pursued once a second managed-agent backend validates the abstraction shape.
+
+---
+
+## 2. Architecture
+
+### 2.1 How ManagedAgent fits alongside Runtime+Harness
+
+The current dispatch chain for container agents:
+
+```
+Template (scion-agent.yaml)
+  -> AgentManager (implements Manager)
+     -> Runtime (docker/podman/k8s/apple/cloudrun)
+     -> Harness (claude/gemini/generic)
+```
+
+The new dispatch chain for managed agents:
+
+```
+Template (scion-agent.yaml with service: field)
+  -> ManagedAgentManager (implements Manager)
+     -> ManagedAgentBackend (interface)
+        -> GoogleManagedAgentBackend (first impl)
+```
+
+Both `AgentManager` and `ManagedAgentManager` implement the same `Manager` interface defined in `pkg/agent/manager.go`. CLI commands and the broker both talk to `Manager` -- they do not need to know whether the agent is containerized or managed.
+
+### 2.2 Package layout
+
+```
+pkg/
+  agent/
+    manager.go              # Manager interface (UNCHANGED)
+    run.go                  # AgentManager.Start (UNCHANGED)
+    managed_manager.go      # NEW: ManagedAgentManager struct + Manager impl
+    managed_state.go        # NEW: ManagedAgentState persistence
+    manager_factory.go      # NEW: NewManagerForConfig factory
+  managedagent/
+    backend.go              # NEW: ManagedAgentBackend interface
+    types.go                # NEW: Backend-agnostic types (InteractionStream, etc.)
+    google/
+      client.go             # NEW: Google API HTTP client
+      backend.go            # NEW: GoogleManagedAgentBackend (implements ManagedAgentBackend)
+      types.go              # NEW: Google API request/response types
+      sse.go                # NEW: SSE event stream parser
+  api/
+    types.go                # MODIFIED: add ServiceConfig to ScionConfig
+  config/
+    templates.go            # MODIFIED: add service: field to template validation
+```
+
+### 2.3 Interface definitions
+
+**ManagedAgentBackend** (new, in `pkg/managedagent/backend.go`):
+
+```go
+package managedagent
+
+import (
+    "context"
+    "io"
+)
+
+// ManagedAgentBackend is the cloud-provider abstraction for managed agent services.
+// Each backend (Google, LangChain, etc.) implements this interface.
+type ManagedAgentBackend interface {
+    // Name returns the backend identifier (e.g., "google", "langchain").
+    Name() string
+
+    // CreateAgent creates a persistent agent configuration on the cloud service.
+    // Returns the cloud-assigned agent ID.
+    CreateAgent(ctx context.Context, cfg CreateAgentConfig) (string, error)
+
+    // DeleteAgent removes the agent configuration from the cloud service.
+    DeleteAgent(ctx context.Context, cloudAgentID string) error
+
+    // CreateInteraction starts a new interaction (turn) with the agent.
+    // Returns an InteractionHandle for streaming results and tracking state.
+    CreateInteraction(ctx context.Context, req InteractionRequest) (*InteractionHandle, error)
+
+    // GetInteraction retrieves the current state of an interaction.
+    GetInteraction(ctx context.Context, interactionID string) (*InteractionState, error)
+
+    // CancelInteraction cancels a running interaction.
+    CancelInteraction(ctx context.Context, interactionID string) error
+
+    // StreamInteraction opens an SSE stream for a running or completed interaction.
+    // If lastEventID is non-empty, resumes from that point.
+    StreamInteraction(ctx context.Context, interactionID string, lastEventID string) (io.ReadCloser, error)
+}
+
+// CreateAgentConfig contains the parameters for creating a managed agent.
+type CreateAgentConfig struct {
+    ID                string            // Desired agent ID
+    BaseAgent         string            // e.g., "antigravity-preview-05-2026"
+    SystemInstruction string            // System prompt
+    Description       string            // Human-readable description
+    Tools             []ToolConfig      // Tool definitions
+    Environment       *EnvironmentConfig // Base environment configuration
+}
+
+// InteractionRequest contains the parameters for creating an interaction.
+type InteractionRequest struct {
+    CloudAgentID          string              // Cloud-side agent ID
+    Input                 string              // User message
+    PreviousInteractionID string              // For multi-turn continuation
+    EnvironmentID         string              // Reuse existing environment (empty = new)
+    Environment           *EnvironmentConfig  // Environment config (if creating new)
+    Stream                bool                // Enable SSE streaming
+    Background            bool                // Run asynchronously
+    Tools                 []ToolConfig        // Per-interaction tool overrides
+    SystemInstruction     string              // Per-interaction system prompt override
+}
+
+// InteractionHandle represents a running or completed interaction.
+type InteractionHandle struct {
+    InteractionID string
+    EnvironmentID string
+    Status        InteractionStatus
+    Steps         []Step
+    OutputText    string
+    Usage         *UsageInfo
+    EventStream   io.ReadCloser // Non-nil when streaming
+}
+
+// InteractionState is the polled state of an interaction.
+type InteractionState struct {
+    InteractionID string
+    Status        InteractionStatus
+    Steps         []Step
+    OutputText    string
+    EnvironmentID string
+    Usage         *UsageInfo
+}
+
+type InteractionStatus string
+
+const (
+    StatusInProgress     InteractionStatus = "in_progress"
+    StatusRequiresAction InteractionStatus = "requires_action"
+    StatusCompleted      InteractionStatus = "completed"
+    StatusFailed         InteractionStatus = "failed"
+    StatusCancelled      InteractionStatus = "cancelled"
+    StatusIncomplete     InteractionStatus = "incomplete"
+)
+
+type Step struct {
+    Type      string // "user_input", "model_output", "thought", "function_call", etc.
+    Text      string
+    Arguments string // For function_call steps
+    ToolName  string // For function_call steps
+}
+
+type ToolConfig struct {
+    Type       string                 // "code_execution", "google_search", "function", "mcp_server", "url_context"
+    Name       string                 // For function tools
+    Parameters map[string]interface{} // Tool-specific config
+}
+
+type EnvironmentConfig struct {
+    Type    string         // "remote"
+    Sources []SourceConfig // Git repos, GCS, inline content
+    Network *NetworkConfig // Egress rules
+}
+
+type SourceConfig struct {
+    Type   string // "repository", "gcs", "inline"
+    URI    string
+    Branch string
+    Path   string
+}
+
+type NetworkConfig struct {
+    Disabled  bool
+    Allowlist []AllowlistEntry
+}
+
+type AllowlistEntry struct {
+    Domain  string
+    Headers map[string]string
+}
+
+type UsageInfo struct {
+    TotalInputTokens  int
+    TotalOutputTokens int
+    TotalTokens       int
+}
+```
+
+**ManagedAgentManager** (new, in `pkg/agent/managed_manager.go`):
+
+```go
+package agent
+
+import (
+    "context"
+
+    "github.com/GoogleCloudPlatform/scion/pkg/api"
+    "github.com/GoogleCloudPlatform/scion/pkg/managedagent"
+)
+
+// ManagedAgentManager implements the Manager interface for cloud-managed agents.
+type ManagedAgentManager struct {
+    Backend   managedagent.ManagedAgentBackend
+    stateDir  string // Base directory for managed agent state files
+}
+
+func NewManagedAgentManager(backend managedagent.ManagedAgentBackend, stateDir string) Manager {
+    return &ManagedAgentManager{
+        Backend:  backend,
+        stateDir: stateDir,
+    }
+}
+
+// All Manager interface methods implemented by delegating to Backend.
+// See Section 4 for detailed lifecycle flows.
+
+func (m *ManagedAgentManager) Provision(ctx context.Context, opts api.StartOptions) (*api.ScionConfig, error) { ... }
+func (m *ManagedAgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.AgentInfo, error) { ... }
+func (m *ManagedAgentManager) Stop(ctx context.Context, agentID string, projectPath string) error { ... }
+func (m *ManagedAgentManager) Delete(ctx context.Context, agentID string, deleteFiles bool, projectPath string, removeBranch bool) (bool, error) { ... }
+func (m *ManagedAgentManager) List(ctx context.Context, filter map[string]string) ([]api.AgentInfo, error) { ... }
+func (m *ManagedAgentManager) Message(ctx context.Context, agentID, projectID string, message string, interrupt bool) error { ... }
+func (m *ManagedAgentManager) MessageRaw(ctx context.Context, agentID, projectID string, keys string) error { ... }
+func (m *ManagedAgentManager) Watch(ctx context.Context, agentID string) (<-chan api.StatusEvent, error) { ... }
+func (m *ManagedAgentManager) Close() { ... }
+```
+
+### 2.4 How the Manager interface branches
+
+The branching happens at construction time, not dispatch time. A factory function inspects the resolved template config:
+
+```go
+// pkg/agent/manager_factory.go
+
+package agent
+
+import (
+    "github.com/GoogleCloudPlatform/scion/pkg/api"
+    "github.com/GoogleCloudPlatform/scion/pkg/managedagent"
+    "github.com/GoogleCloudPlatform/scion/pkg/managedagent/google"
+    "github.com/GoogleCloudPlatform/scion/pkg/runtime"
+)
+
+// NewManagerForProfile returns the appropriate Manager implementation
+// based on the broker profile selected at agent creation time.
+// Managed agent config (API key, base agent) comes from Scion settings, not templates.
+func NewManagerForProfile(rt runtime.Runtime, profile string, settings *api.Settings, stateDir string) Manager {
+    switch profile {
+    case "managed-agents":
+        cfg := settings.ManagedAgents.Google
+        backend := google.NewBackend(google.BackendConfig{
+            APIKey:    cfg.APIKey,
+            BaseAgent: cfg.BaseAgent,
+        })
+        return NewManagedAgentManager(backend, stateDir)
+    default:
+        return NewManager(rt)
+    }
+}
+```
+
+---
+
+## 3. Template Schema — Execution-Agnostic
+
+### 3.1 Templates do NOT declare execution mode
+
+**Key decision (Q7):** Templates define *what* an agent does, not *where/how* it runs. There is no `service:` field in the template YAML. The managed-vs-container decision is a **broker profile** selected at agent creation time (analogous to choosing Cloud Run vs GKE).
+
+Templates remain unchanged from the existing schema. The same template can run on a container runtime or a managed agent service depending on the broker profile selected at `scion start` time.
+
+### 3.2 Managed agent configuration lives in Scion settings
+
+Managed agent backend configuration (provider, base agent model, API key) lives in Scion settings, not templates:
+
+```yaml
+# In Scion settings (not template YAML)
+managed_agents:
+  google:
+    api_key: "<key>"           # Or resolved from Hub secrets
+    base_agent: "antigravity-preview-05-2026"
+    environment:
+      sources:
+        - type: repository
+          uri: https://github.com/example/repo.git
+          branch: main
+      network:
+        allowlist:
+          - domain: api.github.com
+```
+
+### 3.3 Broker profile selection
+
+The execution mode is selected as a broker profile during agent creation. The profile determines whether the agent runs in a container or on a managed service:
+
+- `cloud-run` — container on Cloud Run
+- `gke` — container on GKE
+- `managed-agents` — Google Managed Agents API (Gemini)
+
+The template is the same regardless of profile.
+
+### 3.4 Example template YAML
+
+A template that works on any execution backend:
+
+```yaml
+# scion-agent.yaml — execution-agnostic
+agent_instructions: |
+  You are a research assistant. Focus on analyzing code quality.
+system_prompt: instructions.md
+task: "Analyze the repository structure and produce a report."
+max_duration: 30m
+```
+
+---
+
+## 4. Agent Lifecycle
+
+### 4.1 Start flow for managed agents
+
+When `ManagedAgentManager.Start()` is called:
+
+1. **Project resolution** -- same as container path: `config.GetResolvedProjectDir(opts.ProjectPath)`.
+2. **Duplicate check** -- scan local state directory for existing managed agent with same slug.
+3. **Template/config resolution** -- load template chain, merge configs (same as container path up to merge).
+4. **Detect managed agent** -- broker profile is `managed-agents` (selected at creation time, not from template).
+5. **Resolve auth** -- resolve API key from Scion settings (`managed_agents.google.api_key`), Hub secrets, or environment variable.
+6. **Create cloud agent** -- call `Backend.CreateAgent()` with system instruction, tools, and environment config. Synchronous call. Receives `cloudAgentID`.
+7. **Create first interaction** -- if `opts.Task` is non-empty, call `Backend.CreateInteraction()` with the task as input and `Stream: true`.
+8. **Persist local state** -- write `managed-agent-state.json` to state directory. Write `agent-info.json` with phase=running, activity=working.
+9. **Return AgentInfo** -- populated with runtime set to `"managed:google"`.
+
+Container path steps 5-12 (image resolution, harness resolution, container auth, image pull, env construction, container launch, verify) are all skipped.
+
+### 4.2 Message delivery flow
+
+1. **Find agent** -- look up managed agent state from local state directory by slug.
+2. **Load cloud state** -- read `managed-agent-state.json` for `cloudAgentID`, `latestEnvironmentID`, `latestInteractionID`.
+3. **Create new interaction** -- call `Backend.CreateInteraction()` with:
+   - `CloudAgentID`: from state
+   - `Input`: the message
+   - `PreviousInteractionID`: from state (chains conversation)
+   - `EnvironmentID`: from state (preserves sandbox)
+   - `Stream: true`
+4. **Update state** -- write new `interactionID` and `environmentID` to state file. Update `agent-info.json` with activity=working.
+5. **Monitor completion** -- goroutine reads SSE stream, updates `agent-info.json` on completion.
+
+`MessageRaw()` returns an error for managed agents (no tmux).
+
+### 4.3 Status monitoring and mapping
+
+| Google Interaction Status | Scion Phase | Scion Activity |
+|---|---|---|
+| (agent created, no interaction yet) | running | waiting_for_input |
+| `in_progress` | running | working |
+| `requires_action` (unexpected) | running | error (log warning) |
+| `completed` | running | completed |
+| `failed` | error | crashed |
+| `cancelled` | stopped | -- |
+| `incomplete` | running | limits_exceeded |
+
+SSE event-level mapping:
+
+| SSE Event | Scion Activity |
+|---|---|
+| `step.start` type=thought | thinking |
+| `step.start` type=model_output | working |
+| `step.start` type=function_call | executing |
+| `step.start` type=code_execution_call | executing |
+| `interaction.completed` | completed |
+| `interaction.status_update` requires_action | error (log warning, unexpected) |
+
+### 4.4 Stop/Delete flows
+
+**Stop**: Cancel active interaction if `in_progress`. Cloud agent and environment persist (resumable). Update `agent-info.json` phase=stopped.
+
+**Delete**: Stop (as above), then `Backend.DeleteAgent()`, then remove local state directory if `deleteFiles` is true. Return `(false, nil)` -- no branch to delete.
+
+### 4.5 CLI command behavior for managed agents
+
+**`scion look`**: Fetch latest interaction via `Backend.GetInteraction()`, format steps as structured text output with timestamps (decision Q6). Primary consumer is agent-to-agent observation:
+```
+[14:05:02] [thought] Analyzing the repository structure...
+[14:05:08] [code_execution] $ find . -name "*.go" | head -20
+[14:05:12] [model_output] The repository contains 45 Go source files...
+[14:05:12] [status] completed (3,200 input tokens, 1,800 output tokens)
+```
+
+**`scion attach`**: Not supported for managed agents in v1 (decision Q2). Returns error directing user to `scion message` and `scion look`.
+
+**`scion logs`**: Reads from GCP Cloud Logging (decision Q4). No local log files.
+
+---
+
+## 5. Google Backend Implementation
+
+### 5.1 API client package design
+
+`pkg/managedagent/google/client.go` -- thin HTTP client wrapping the Gemini API REST surface. Uses `net/http` with JSON marshaling directly (no official Go SDK dependency to avoid gRPC/proto transitive deps).
+
+```go
+package google
+
+const defaultBaseURL = "https://generativelanguage.googleapis.com/v1beta"
+
+type Client struct {
+    baseURL    string
+    apiKey     string
+    httpClient *http.Client
+}
+
+func NewClient(apiKey string) *Client { ... }
+
+// Agent CRUD
+func (c *Client) CreateAgent(ctx, *CreateAgentRequest) (*Agent, error) { ... }
+func (c *Client) GetAgent(ctx, agentID string) (*Agent, error) { ... }
+func (c *Client) DeleteAgent(ctx, agentID string) error { ... }
+func (c *Client) ListAgents(ctx, pageSize int, pageToken string) (*ListAgentsResponse, error) { ... }
+
+// Interaction lifecycle
+func (c *Client) CreateInteraction(ctx, *CreateInteractionRequest) (*Interaction, error) { ... }
+func (c *Client) CreateInteractionStream(ctx, *CreateInteractionRequest) (io.ReadCloser, error) { ... }
+func (c *Client) GetInteraction(ctx, interactionID string) (*Interaction, error) { ... }
+func (c *Client) CancelInteraction(ctx, interactionID string) error { ... }
+func (c *Client) DeleteInteraction(ctx, interactionID string) error { ... }
+```
+
+Auth: `apiKey` set as `x-goog-api-key` header on every request.
+
+### 5.2 Environment lifecycle
+
+Environments are NOT a separate CRUD resource. Created implicitly when an interaction uses `environment: "remote"`, reused by passing the returned `environment_id`. The `ManagedAgentManager` tracks `latestEnvironmentID` in state.
+
+Google API lifecycle: auto-snapshot after ~15min idle, retained 7 days, then deleted. Scion does not manage this.
+
+### 5.3 Auth handling
+
+- API key lives in Scion settings (`managed_agents.google.api_key`) — NOT in templates (decision Q1)
+- Resolution chain: Scion settings > Hub secret > environment variable
+- No template-level credential configuration; templates are execution-agnostic
+
+### 5.4 Multi-turn state tracking
+
+Two independent chains:
+- **Conversation**: `previous_interaction_id` links context
+- **Environment**: `environment_id` links sandbox state
+
+```json
+{
+  "cloud_agent_id": "agent_abc123",
+  "latest_interaction_id": "int_xyz789",
+  "latest_environment_id": "env_def456",
+  "interaction_chain": ["int_001", "int_002", "int_xyz789"],
+  "created_at": "2026-06-28T10:00:00Z",
+  "updated_at": "2026-06-28T10:05:00Z"
+}
+```
+
+### 5.5 Function calling — NOT APPLICABLE
+
+Managed agents are a pure server-side API (decision Q3). The cloud agent executes its own tools (code execution, search, etc.) internally within its sandbox. There is no client-side function execution. If the API ever surfaces a `requires_action` status, treat it as an unexpected state and log it.
+
+---
+
+## 6. Hub-Direct Integration
+
+### 6.1 No broker routing for managed agents (Decision Q5)
+
+Managed agent API calls go directly from the Hub to the cloud API, bypassing brokers entirely. Managed agents are a stateless API with no container lifecycle — the broker layer would be a pass-through adding latency with no value.
+
+### 6.2 Hub dispatch
+
+Flow:
+1. Hub receives `POST /agents` from CLI/API with broker profile = `managed-agents`
+2. Hub handles directly via its managed agent client interface (no broker delegation)
+3. Hub calls cloud API (CreateAgent, CreateInteraction, etc.)
+4. Hub tracks agent state and reports status to CLI
+
+Reference: the `cloudrun-ha` branch on origin implements a similar hub-direct client interface pattern. Look for reusable patterns to factor out (e.g., client interface abstraction, error handling, retry logic).
+
+### 6.3 Broker profile selection
+
+Managed agents are selected as a broker profile during agent creation — analogous to choosing Cloud Run or GKE (decision Q7). The profile is a runtime/deployment decision, not a template-level declaration.
+
+---
+
+## 7. State Storage
+
+### 7.1 Per-agent state
+
+```go
+type ManagedAgentState struct {
+    CloudAgentID        string   `json:"cloud_agent_id"`
+    CloudProvider       string   `json:"cloud_provider"`
+    LatestInteractionID string   `json:"latest_interaction_id,omitempty"`
+    LatestEnvironmentID string   `json:"latest_environment_id,omitempty"`
+    InteractionChain    []string `json:"interaction_chain,omitempty"`
+    LastStatus          string   `json:"last_status,omitempty"`
+    CreatedAt           string   `json:"created_at"`
+    UpdatedAt           string   `json:"updated_at"`
+    APIKeyRef           string   `json:"api_key_ref,omitempty"`
+}
+```
+
+### 7.2 Directory layout
+
+```
+<projectDir>/agents/<agent-name>/
+  scion-agent.json          # Template config (same as container agents)
+  managed-agent-state.json  # NEW: cloud-side state tracking
+  home/
+    agent-info.json          # Status (same format as container agents)
+    # No local agent.log — logs go to GCP Cloud Logging (decision Q4)
+```
+
+### 7.3 Integration with agent-info.json
+
+Same schema, different field values:
+
+| Field | Container Agent | Managed Agent |
+|---|---|---|
+| `ContainerID` | Docker/k8s ID | Empty |
+| `Runtime` | "docker" / "podman" / "kubernetes" | "managed:google" |
+| `Phase` | From container + sciontool hooks | From interaction status |
+| `Activity` | From `.scion-status.json` | From SSE event mapping |
+| `Image` | Container image | Empty |
+
+---
+
+## 8. CLI Behavior Matrix
+
+| Command | Container Agent | Managed Agent |
+|---|---|---|
+| `scion start <name> [task]` | Provision + container launch | Create cloud agent + first interaction |
+| `scion create <name> [task]` | Provision only (no container) | Create cloud agent (no interaction) |
+| `scion stop <name>` | Stop container | Cancel active interaction |
+| `scion delete <name>` | Delete container + files | Delete cloud agent + local state |
+| `scion list` | Merge container + on-disk state | Merge managed state from agent dirs |
+| `scion message <name> <msg>` | tmux paste-buffer + send-keys | Create new interaction with message |
+| `scion message --raw <name>` | tmux send-keys (control chars) | Error: "not supported for managed agents" |
+| `scion message --broadcast` | Fan-out tmux delivery | Fan-out interaction creation |
+| `scion look <name>` | tmux capture-pane | Fetch latest interaction, format as text |
+| `scion attach <name>` | tmux attach-session | Error: "not supported for managed agents — use scion message and scion look" (deferred, Q2) |
+| `scion logs <name>` | Read agent.log from container | Read from GCP Cloud Logging (Q4) |
+| `scion resume <name>` | Restart container with --continue | New interaction with environment reuse |
+| `scion sync <name>` | Workspace file sync | Not applicable (v1) |
+| `scion suspend <name>` | Stop container, preserve state | Cancel interaction, preserve cloud agent |
+
+---
+
+## 9. Migration Path to Option C
+
+### 9.1 Refactoring to ExecutionBackend
+
+Option C introduces a unified interface:
+
+```go
+type ExecutionBackend interface {
+    Name() string
+    Start(ctx context.Context, cfg BackendConfig) (AgentHandle, error)
+    Stop(ctx context.Context, handle AgentHandle) error
+    Delete(ctx context.Context, handle AgentHandle) error
+    SendMessage(ctx context.Context, handle AgentHandle, msg string) error
+    GetOutput(ctx context.Context, handle AgentHandle) (string, error)
+    StreamOutput(ctx context.Context, handle AgentHandle) (io.ReadCloser, error)
+    GetStatus(ctx context.Context, handle AgentHandle) (Phase, Activity, error)
+}
+```
+
+### 9.2 What stays stable
+
+- **`Manager` interface** -- the public API for CLI and broker. Internal impl switches from "Manager holds Runtime" to "Manager holds ExecutionBackend", but callers unaffected.
+- **`ScionConfig.Service` field** -- template schema is stable.
+- **`ManagedAgentState` persistence** -- state file format and directory layout are stable.
+- **`agent-info.json`** -- status format is stable.
+
+### 9.3 What changes
+
+- **`ManagedAgentBackend`** -- absorbed into `ExecutionBackend`.
+- **`ManagedAgentManager`** -- absorbed into unified `Manager` implementation.
+- **`AgentManager`** -- also absorbed; Runtime+Harness wrapped in `ContainerExecutionBackend`.
+- **Package layout** -- `pkg/managedagent/` may move to `pkg/backend/managed/`.
+
+Key insight: Option B's `ManagedAgentBackend` is a preview of `ExecutionBackend`'s shape, because managed agents naturally surface the right abstraction level (message-in, output-out, status query). The Option C refactor mostly consists of wrapping existing Runtime+Harness into the same shape.
+
+---
+
+## 10. Resolved Design Decisions
+
+### Q1: API key storage — DECIDED: Scion settings only
+
+API key lives in Scion settings (`managed_agents.google.api_key`), NOT in the template YAML. This is an infrastructure/credential concern (analogous to harness-config), not a template-level concern. Templates remain portable and credential-free.
+
+### Q2: `scion attach` — DECIDED: Deferred for v1
+
+`scion attach` is not supported for managed agents in v1. There is no SSH or tmux session to attach to. The primary UX is `scion message` + `scion look`. Both `message` and `look` currently use tmux internally for container agents — for managed agents, these are reimplemented as direct API calls (Message → create interaction, Look → fetch latest interaction). A web-based REPL-like interface is a potential future addition.
+
+### Q3: Function calling — DECIDED: Not applicable
+
+Managed agents are a pure server-side API. The cloud agent has its own sandbox and executes tools internally (code execution, search, etc.). There is no client-side function execution in this model. `requires_action` for local tool dispatch does not apply and is removed from the design. If the API ever surfaces a `requires_action` status, treat it as an unexpected state and log it.
+
+### Q4: Logging — DECIDED: GCP Cloud Logging
+
+Logging goes through GCP Cloud Logging with its own configurable retention policies. No local log files on hub or broker — avoids introducing statefulness. `scion logs` reads from Cloud Logging on demand.
+
+### Q5: Broker routing — DECIDED: Hub-direct
+
+Managed agent API calls go directly from the Hub to the cloud API, bypassing brokers entirely. Managed agents are a stateless API with no container lifecycle to manage — the broker layer would be a pass-through adding latency with no value. Managed agents are selected as a **broker profile** (like choosing Cloud Run or GKE) during agent creation. Reference: `cloudrun-ha` branch on origin has a similar hub-direct client interface pattern — look for reusable patterns to factor out.
+
+### Q6: `scion look` output format — DECIDED: Structured with timestamps
+
+Structured, readable format with timestamps on each step. Primary consumer is agent-to-agent observation (one agent understanding what another is doing). Timestamps are critical for this use case.
+
+```
+[14:05:02] [thought] Analyzing the repository structure...
+[14:05:08] [code_execution] $ find . -name "*.go" | head -20
+[14:05:12] [model_output] The repository contains 45 Go files...
+[14:05:12] [status] completed (3,200 input / 1,800 output tokens)
+```
+
+### Q7: Template execution model — DECIDED: Templates are execution-agnostic
+
+Templates do NOT declare whether the agent runs on a managed service or in a container. The `service:` field is removed from the template schema entirely. Templates define *what* the agent does (instructions, task, tools); the infrastructure layer decides *where/how* it runs. Managed-vs-container is a **broker profile** — analogous to choosing Cloud Run, GKE, or managed agents as the execution target. Hard error if any implementation leaks execution-mode concerns into the template.
+
+### Q8: API client — DECIDED: Custom HTTP client
+
+Custom `net/http` wrapper for v1. The API surface is small (~8 endpoints), auth is simple (API key header), and payloads are straightforward JSON. Avoids large Go SDK dependency tree and potential module conflicts. Migrate to official SDK later if it stabilizes and offers clear benefits.
+
+---
+
+## Appendix: Key Source Files for Implementation
+
+| File | Role | Change |
+|------|------|--------|
+| `pkg/agent/manager.go` | Manager interface | Add factory function |
+| `pkg/api/types.go` | Core types | Add ManagedAgentSettings (in settings, not ScionConfig) |
+| `pkg/agent/run.go` | AgentManager.Start | UNCHANGED |
+| `pkg/agent/managed_manager.go` | ManagedAgentManager | NEW |
+| `pkg/agent/managed_state.go` | State persistence | NEW |
+| `pkg/agent/manager_factory.go` | Manager factory | NEW |
+| `pkg/managedagent/backend.go` | Backend interface | NEW |
+| `pkg/managedagent/types.go` | Backend types | NEW |
+| `pkg/managedagent/google/client.go` | Google HTTP client | NEW |
+| `pkg/managedagent/google/backend.go` | Google backend impl | NEW |
+| `pkg/managedagent/google/types.go` | Google API types | NEW |
+| `pkg/managedagent/google/sse.go` | SSE parser | NEW |
+| `pkg/agent/list.go` | Agent listing | Add managed agent scanning |
+| `pkg/runtimebroker/handlers.go` | Broker dispatch | UNCHANGED (managed agents bypass broker, hub-direct) |
+| `pkg/config/templates.go` | Template validation | UNCHANGED (templates are execution-agnostic) |

--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
@@ -132,6 +133,10 @@ func attachViaHub(hubCtx *HubContext, agentName string) error {
 	agent, err := hubCtx.Client.ProjectAgents(projectID).Get(ctx, agentName)
 	if err != nil {
 		return wrapHubError(fmt.Errorf("failed to get agent '%s': %w", agentName, err))
+	}
+
+	if strings.HasPrefix(agent.Runtime, "managed:") {
+		return fmt.Errorf("attach is not supported for managed agents — use scion message and scion look")
 	}
 
 	// Check agent lifecycle status - the agent must be running to attach.

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
@@ -103,6 +105,24 @@ func init() {
 // getHubLogs retrieves agent logs via the hub relay (hub -> broker -> agent.log).
 func getHubLogs(ctx context.Context, hubCtx *HubContext, agentName string) error {
 	PrintUsingHub(hubCtx.Endpoint)
+
+	tctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	agent, err := hubCtx.Client.ProjectAgents(hubCtx.ProjectID).Get(tctx, agentName)
+	if err != nil {
+		return wrapHubError(fmt.Errorf("failed to get agent '%s': %w", agentName, err))
+	}
+
+	if strings.HasPrefix(agent.Runtime, "managed:") {
+		fmt.Println("Managed agent logs are available in GCP Cloud Logging.")
+		fmt.Println()
+		fmt.Println("View logs in the Google Cloud Console:")
+		fmt.Println("  https://console.cloud.google.com/logs")
+		fmt.Println()
+		fmt.Println("Use scion look to view the agent's current interaction output.")
+		return nil
+	}
 
 	client := hubCtx.Client.ProjectAgents(hubCtx.ProjectID)
 

--- a/hack/check-project-compat-literals.sh
+++ b/hack/check-project-compat-literals.sh
@@ -147,6 +147,7 @@ allowed_paths=(
 
   # Core compatibility adapters and bounded legacy protocol/storage surfaces.
   "^pkg/agent/list.go$"
+  "^pkg/agent/managed_manager.go$"
   "^pkg/agent/msgbuffer.go$"
   "^pkg/api/types.go$"
   "^pkg/brokerclient/agents.go$"

--- a/pkg/agent/list.go
+++ b/pkg/agent/list.go
@@ -254,6 +254,18 @@ func (m *AgentManager) List(ctx context.Context, filter map[string]string) ([]ap
 							Project: projectName,
 							Phase:   "unknown",
 						}
+					} else if ms, msErr := LoadManagedAgentState(agentDir); msErr == nil {
+						phase := "stopped"
+						if ms.LastStatus == "in_progress" {
+							phase = "running"
+						}
+						info = &api.AgentInfo{
+							Name:    e.Name(),
+							Project: projectName,
+							Runtime: "managed:" + ms.CloudProvider,
+							Profile: "managed-agents",
+							Phase:   phase,
+						}
 					} else {
 						continue
 					}

--- a/pkg/agent/managed_manager.go
+++ b/pkg/agent/managed_manager.go
@@ -148,27 +148,22 @@ func (m *ManagedAgentManager) Start(ctx context.Context, opts api.StartOptions) 
 		}
 	}
 
-	// Create the cloud-side agent.
-	cloudAgentID, err := m.Backend.CreateAgent(ctx, managedagent.CreateAgentConfig{
-		SystemInstruction: systemInstruction,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("creating cloud agent: %w", err)
-	}
-
 	now := time.Now().UTC().Format(time.RFC3339)
 	agentState := &ManagedAgentState{
-		CloudAgentID:  cloudAgentID,
 		CloudProvider: m.Backend.Name(),
 		CreatedAt:     now,
 	}
 
-	// If a task was provided, create the first interaction.
+	// Create the first interaction directly using the interactions API.
+	// We skip the agents CRUD endpoint (/v1beta/agents) because it may
+	// not be generally available; the interactions endpoint works with
+	// both model names and built-in agent names.
 	if opts.Task != "" {
 		handle, err := m.Backend.CreateInteraction(ctx, managedagent.InteractionRequest{
-			CloudAgentID: cloudAgentID,
-			Input:        opts.Task,
-			Background:   true,
+			Input:             opts.Task,
+			SystemInstruction: systemInstruction,
+			Environment:       &managedagent.EnvironmentConfig{Type: "remote"},
+			Background:        true,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("creating initial interaction: %w", err)
@@ -264,13 +259,6 @@ func (m *ManagedAgentManager) Delete(ctx context.Context, agentID string, delete
 			return false, err
 		}
 		return false, nil
-	}
-
-	agentState, loadErr := LoadManagedAgentState(agentDir)
-	if loadErr == nil && agentState.CloudAgentID != "" {
-		if delErr := m.Backend.DeleteAgent(ctx, agentState.CloudAgentID); delErr != nil {
-			slog.Warn("failed to delete cloud agent", "cloud_agent_id", agentState.CloudAgentID, "err", delErr)
-		}
 	}
 
 	if deleteFiles {
@@ -382,7 +370,6 @@ func (m *ManagedAgentManager) Message(ctx context.Context, agentID, projectID st
 	}
 
 	req := managedagent.InteractionRequest{
-		CloudAgentID:          agentState.CloudAgentID,
 		Input:                 message,
 		PreviousInteractionID: agentState.LatestInteractionID,
 		EnvironmentID:         agentState.LatestEnvironmentID,

--- a/pkg/agent/managed_manager.go
+++ b/pkg/agent/managed_manager.go
@@ -183,6 +183,11 @@ func (m *ManagedAgentManager) Start(ctx context.Context, opts api.StartOptions) 
 		return nil, fmt.Errorf("saving managed agent state: %w", err)
 	}
 
+	// Monitor interaction completion asynchronously.
+	if agentState.LatestInteractionID != "" {
+		go m.monitorInteraction(opts.Name, projectDir, agentDir, agentState.LatestInteractionID)
+	}
+
 	// Update agent-info.json with running phase.
 	info := &api.AgentInfo{
 		Name:        opts.Name,
@@ -204,8 +209,12 @@ func (m *ManagedAgentManager) Start(ctx context.Context, opts api.StartOptions) 
 		}
 	}
 
-	infoData, _ := json.MarshalIndent(info, "", "  ")
-	_ = os.WriteFile(infoPath, infoData, 0644)
+	infoData, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		slog.Warn("failed to marshal agent-info.json", "agent", opts.Name, "err", err)
+	} else if writeErr := os.WriteFile(infoPath, infoData, 0644); writeErr != nil {
+		slog.Warn("failed to write agent-info.json", "agent", opts.Name, "err", writeErr)
+	}
 
 	return info, nil
 }
@@ -396,6 +405,22 @@ func (m *ManagedAgentManager) Message(ctx context.Context, agentID, projectID st
 		return fmt.Errorf("saving managed agent state: %w", err)
 	}
 
+	// Update agent-info.json to reflect that the agent is working on the new message.
+	projectDir, _ := config.GetResolvedProjectDir(projectPath)
+	if projectDir != "" {
+		agentHome := config.GetAgentHomePath(projectDir, agentID)
+		infoPath := filepath.Join(agentHome, "agent-info.json")
+		if err := persistAgentInfoState(infoPath, "running", "working"); err != nil {
+			slog.Warn("failed to update agent-info after message", "agent", agentID, "err", err)
+		}
+	}
+
+	// Monitor interaction completion asynchronously and update agent-info.json
+	// when the interaction reaches a terminal state.
+	if projectDir != "" {
+		go m.monitorInteraction(agentID, projectDir, agentDir, handle.InteractionID)
+	}
+
 	return nil
 }
 
@@ -403,6 +428,8 @@ func (m *ManagedAgentManager) MessageRaw(_ context.Context, _, _ string, _ strin
 	return fmt.Errorf("MessageRaw is not supported for managed agents")
 }
 
+// Watch uses m.stateDir as the project path to resolve the agent directory.
+// Callers must ensure stateDir was set to the project path at construction time.
 func (m *ManagedAgentManager) Watch(ctx context.Context, agentID string) (<-chan api.StatusEvent, error) {
 	agentDir, err := managedAgentDir(agentID, m.stateDir)
 	if err != nil {
@@ -457,6 +484,48 @@ func (m *ManagedAgentManager) Watch(ctx context.Context, agentID string) (<-chan
 	return ch, nil
 }
 
+// monitorInteraction polls the backend for interaction status and updates
+// agent-info.json when the interaction reaches a terminal state. Runs as a
+// background goroutine launched by Start and Message.
+func (m *ManagedAgentManager) monitorInteraction(agentID, projectDir, agentDir, interactionID string) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	ctx := context.Background()
+	for range ticker.C {
+		state, err := m.Backend.GetInteraction(ctx, interactionID)
+		if err != nil {
+			slog.Warn("interaction monitor: poll failed", "agent", agentID, "interaction", interactionID, "err", err)
+			continue
+		}
+
+		if !isTerminalStatus(state.Status) {
+			continue
+		}
+
+		activity := mapInteractionStatus(state.Status)
+		phase := "running"
+		if state.Status == managedagent.StatusCancelled || state.Status == managedagent.StatusFailed {
+			phase = "stopped"
+		}
+
+		agentHome := config.GetAgentHomePath(projectDir, agentID)
+		infoPath := filepath.Join(agentHome, "agent-info.json")
+		if err := persistAgentInfoState(infoPath, phase, activity); err != nil {
+			slog.Warn("interaction monitor: failed to update agent-info", "agent", agentID, "err", err)
+		}
+
+		// Update managed-agent-state with the final status.
+		if agentState, loadErr := LoadManagedAgentState(agentDir); loadErr == nil {
+			agentState.LastStatus = string(state.Status)
+			if saveErr := SaveManagedAgentState(agentDir, agentState); saveErr != nil {
+				slog.Warn("interaction monitor: failed to save state", "agent", agentID, "err", saveErr)
+			}
+		}
+		return
+	}
+}
+
 func (m *ManagedAgentManager) Close() {}
 
 func mapInteractionStatus(s managedagent.InteractionStatus) string {
@@ -464,7 +533,10 @@ func mapInteractionStatus(s managedagent.InteractionStatus) string {
 	case managedagent.StatusInProgress:
 		return "running"
 	case managedagent.StatusRequiresAction:
-		return "waiting_for_input"
+		// requires_action is unexpected for managed agents — the cloud service
+		// should handle tool calls internally. Log a warning so operators notice.
+		slog.Warn("unexpected requires_action status from managed agent backend", "status", s)
+		return "error"
 	case managedagent.StatusCompleted:
 		return "completed"
 	case managedagent.StatusFailed:
@@ -472,7 +544,7 @@ func mapInteractionStatus(s managedagent.InteractionStatus) string {
 	case managedagent.StatusCancelled:
 		return "stopped"
 	case managedagent.StatusIncomplete:
-		return "error"
+		return "limits_exceeded"
 	default:
 		return string(s)
 	}

--- a/pkg/agent/managed_manager.go
+++ b/pkg/agent/managed_manager.go
@@ -1,0 +1,488 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/managedagent"
+)
+
+// ManagedAgentManager implements the Manager interface for cloud-managed agents.
+// It delegates agent lifecycle operations to a ManagedAgentBackend (e.g. Google)
+// instead of managing local containers.
+type ManagedAgentManager struct {
+	Backend  managedagent.ManagedAgentBackend
+	stateDir string
+}
+
+// NewManagedAgentManager creates a Manager backed by a cloud managed-agent service.
+func NewManagedAgentManager(backend managedagent.ManagedAgentBackend, stateDir string) Manager {
+	return &ManagedAgentManager{
+		Backend:  backend,
+		stateDir: stateDir,
+	}
+}
+
+func (m *ManagedAgentManager) Provision(ctx context.Context, opts api.StartOptions) (*api.ScionConfig, error) {
+	projectDir, err := config.GetResolvedProjectDir(opts.ProjectPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolving project dir: %w", err)
+	}
+
+	agentDir := filepath.Join(projectDir, "agents", opts.Name)
+	if err := os.MkdirAll(agentDir, 0755); err != nil {
+		return nil, fmt.Errorf("creating agent directory: %w", err)
+	}
+
+	// Resolve template chain and build scion config
+	templateName := opts.Template
+	if templateName == "" {
+		templateName = "default"
+	}
+
+	finalCfg := &api.ScionConfig{}
+
+	chain, err := config.GetTemplateChainInProject(templateName, opts.ProjectPath)
+	if err != nil {
+		slog.Debug("managed: template chain not found, using empty config", "template", templateName, "err", err)
+	} else {
+		for _, tpl := range chain {
+			tplCfg, loadErr := tpl.LoadConfig()
+			if loadErr != nil {
+				return nil, fmt.Errorf("loading template config %s: %w", tpl.Name, loadErr)
+			}
+			finalCfg = config.MergeScionConfig(finalCfg, tplCfg)
+		}
+	}
+
+	if opts.InlineConfig != nil {
+		finalCfg = config.MergeScionConfig(finalCfg, opts.InlineConfig)
+	}
+
+	projectName := config.GetProjectName(projectDir)
+	displayTemplateName := templateName
+	if len(chain) > 0 {
+		displayTemplateName = chain[len(chain)-1].Name
+	}
+
+	info := &api.AgentInfo{
+		Name:        opts.Name,
+		Template:    displayTemplateName,
+		Project:     projectName,
+		ProjectPath: projectDir,
+		Phase:       "created",
+		Runtime:     "managed:" + m.Backend.Name(),
+		Created:     time.Now(),
+	}
+	finalCfg.Info = info
+
+	cfgData, err := json.MarshalIndent(finalCfg, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshaling agent config: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "scion-agent.json"), cfgData, 0644); err != nil {
+		return nil, fmt.Errorf("writing agent config: %w", err)
+	}
+
+	agentHome := config.GetAgentHomePath(projectDir, opts.Name)
+	if err := os.MkdirAll(agentHome, 0755); err != nil {
+		return nil, fmt.Errorf("creating agent home: %w", err)
+	}
+
+	infoData, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshaling agent info: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentHome, "agent-info.json"), infoData, 0644); err != nil {
+		return nil, fmt.Errorf("writing agent info: %w", err)
+	}
+
+	return finalCfg, nil
+}
+
+func (m *ManagedAgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.AgentInfo, error) {
+	projectDir, err := config.GetResolvedProjectDir(opts.ProjectPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolving project dir: %w", err)
+	}
+	agentDir := filepath.Join(projectDir, "agents", opts.Name)
+
+	// Provision if the agent directory does not exist yet.
+	if _, err := os.Stat(agentDir); os.IsNotExist(err) {
+		if _, provErr := m.Provision(ctx, opts); provErr != nil {
+			return nil, fmt.Errorf("provisioning managed agent: %w", provErr)
+		}
+	}
+
+	// Resolve system instruction from template config.
+	scionJSON := filepath.Join(agentDir, "scion-agent.json")
+	var systemInstruction string
+	if data, readErr := os.ReadFile(scionJSON); readErr == nil {
+		var cfg api.ScionConfig
+		if json.Unmarshal(data, &cfg) == nil {
+			systemInstruction = cfg.SystemPrompt
+			if systemInstruction == "" {
+				systemInstruction = cfg.AgentInstructions
+			}
+		}
+	}
+
+	// Create the cloud-side agent.
+	cloudAgentID, err := m.Backend.CreateAgent(ctx, managedagent.CreateAgentConfig{
+		SystemInstruction: systemInstruction,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating cloud agent: %w", err)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	agentState := &ManagedAgentState{
+		CloudAgentID:  cloudAgentID,
+		CloudProvider: m.Backend.Name(),
+		CreatedAt:     now,
+	}
+
+	// If a task was provided, create the first interaction.
+	if opts.Task != "" {
+		handle, err := m.Backend.CreateInteraction(ctx, managedagent.InteractionRequest{
+			CloudAgentID: cloudAgentID,
+			Input:        opts.Task,
+			Background:   true,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("creating initial interaction: %w", err)
+		}
+		agentState.LatestInteractionID = handle.InteractionID
+		agentState.LatestEnvironmentID = handle.EnvironmentID
+		agentState.InteractionChain = []string{handle.InteractionID}
+		agentState.LastStatus = string(handle.Status)
+	}
+
+	if err := SaveManagedAgentState(agentDir, agentState); err != nil {
+		return nil, fmt.Errorf("saving managed agent state: %w", err)
+	}
+
+	// Update agent-info.json with running phase.
+	info := &api.AgentInfo{
+		Name:        opts.Name,
+		Project:     config.GetProjectName(projectDir),
+		ProjectPath: projectDir,
+		Phase:       "running",
+		Runtime:     "managed:" + m.Backend.Name(),
+		Created:     time.Now(),
+	}
+
+	agentHome := config.GetAgentHomePath(projectDir, opts.Name)
+	infoPath := filepath.Join(agentHome, "agent-info.json")
+	if existingData, readErr := os.ReadFile(infoPath); readErr == nil {
+		var existing api.AgentInfo
+		if json.Unmarshal(existingData, &existing) == nil {
+			existing.Phase = "running"
+			existing.Runtime = "managed:" + m.Backend.Name()
+			info = &existing
+		}
+	}
+
+	infoData, _ := json.MarshalIndent(info, "", "  ")
+	_ = os.WriteFile(infoPath, infoData, 0644)
+
+	return info, nil
+}
+
+func (m *ManagedAgentManager) Stop(ctx context.Context, agentID string, projectPath string) error {
+	agentDir, err := managedAgentDir(agentID, projectPath)
+	if err != nil {
+		return err
+	}
+
+	agentState, err := LoadManagedAgentState(agentDir)
+	if err != nil {
+		return fmt.Errorf("loading managed agent state: %w", err)
+	}
+
+	// Cancel the active interaction if one is in progress.
+	if agentState.LatestInteractionID != "" {
+		interactionState, getErr := m.Backend.GetInteraction(ctx, agentState.LatestInteractionID)
+		if getErr == nil && interactionState.Status == managedagent.StatusInProgress {
+			if cancelErr := m.Backend.CancelInteraction(ctx, agentState.LatestInteractionID); cancelErr != nil {
+				slog.Warn("failed to cancel interaction", "interaction_id", agentState.LatestInteractionID, "err", cancelErr)
+			}
+		}
+	}
+
+	agentState.LastStatus = string(managedagent.StatusCancelled)
+	if err := SaveManagedAgentState(agentDir, agentState); err != nil {
+		slog.Warn("failed to save state after stop", "err", err)
+	}
+
+	projectDir, _ := config.GetResolvedProjectDir(projectPath)
+	if projectDir != "" {
+		agentHome := config.GetAgentHomePath(projectDir, agentID)
+		_ = persistAgentInfoState(filepath.Join(agentHome, "agent-info.json"), "stopped", "")
+	}
+
+	return nil
+}
+
+func (m *ManagedAgentManager) Delete(ctx context.Context, agentID string, deleteFiles bool, projectPath string, removeBranch bool) (bool, error) {
+	// Stop first (best-effort).
+	_ = m.Stop(ctx, agentID, projectPath)
+
+	agentDir, err := managedAgentDir(agentID, projectPath)
+	if err != nil {
+		if deleteFiles {
+			return false, err
+		}
+		return false, nil
+	}
+
+	agentState, loadErr := LoadManagedAgentState(agentDir)
+	if loadErr == nil && agentState.CloudAgentID != "" {
+		if delErr := m.Backend.DeleteAgent(ctx, agentState.CloudAgentID); delErr != nil {
+			slog.Warn("failed to delete cloud agent", "cloud_agent_id", agentState.CloudAgentID, "err", delErr)
+		}
+	}
+
+	if deleteFiles {
+		if err := os.RemoveAll(agentDir); err != nil {
+			return false, fmt.Errorf("removing agent directory: %w", err)
+		}
+		projectDir, _ := config.GetResolvedProjectDir(projectPath)
+		if projectDir != "" {
+			agentHome := config.GetAgentHomePath(projectDir, agentID)
+			_ = os.RemoveAll(agentHome)
+		}
+	}
+
+	return false, nil
+}
+
+func (m *ManagedAgentManager) List(ctx context.Context, filter map[string]string) ([]api.AgentInfo, error) {
+	var projectsToScan []string
+
+	projectPath := filter["scion.project_path"]
+	if projectPath == "" {
+		projectPath = filter["scion.grove_path"]
+	}
+	if projectPath != "" {
+		projectsToScan = append(projectsToScan, projectPath)
+	} else if len(filter) == 0 || (len(filter) == 1 && filter["scion.agent"] == "true") {
+		pd, _ := config.GetResolvedProjectDir("")
+		if pd != "" {
+			projectsToScan = append(projectsToScan, pd)
+		}
+	}
+
+	var agents []api.AgentInfo
+	for _, projectDir := range projectsToScan {
+		agentsDir := filepath.Join(projectDir, "agents")
+		entries, err := os.ReadDir(agentsDir)
+		if err != nil {
+			continue
+		}
+		projectName := config.GetProjectName(projectDir)
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			agentDir := filepath.Join(agentsDir, e.Name())
+			stateFile := filepath.Join(agentDir, managedAgentStateFile)
+			if _, err := os.Stat(stateFile); err != nil {
+				continue
+			}
+
+			agentState, loadErr := LoadManagedAgentState(agentDir)
+			if loadErr != nil {
+				continue
+			}
+
+			info := api.AgentInfo{
+				Name:        e.Name(),
+				Project:     projectName,
+				ProjectPath: projectDir,
+				Runtime:     "managed:" + agentState.CloudProvider,
+				Phase:       "running",
+			}
+
+			agentHome := config.GetAgentHomePath(projectDir, e.Name())
+			infoPath := filepath.Join(agentHome, "agent-info.json")
+			if data, readErr := os.ReadFile(infoPath); readErr == nil {
+				var savedInfo api.AgentInfo
+				if json.Unmarshal(data, &savedInfo) == nil {
+					info.Phase = savedInfo.Phase
+					info.Activity = savedInfo.Activity
+					info.Template = savedInfo.Template
+					info.HarnessConfig = savedInfo.HarnessConfig
+					info.Profile = savedInfo.Profile
+					info.Detail = savedInfo.Detail
+					info.Created = savedInfo.Created
+				}
+			}
+
+			agents = append(agents, info)
+		}
+	}
+
+	return agents, nil
+}
+
+func (m *ManagedAgentManager) Message(ctx context.Context, agentID, projectID string, message string, interrupt bool) error {
+	projectPath := ""
+	if projectID != "" {
+		projectPath = projectID
+	}
+	agentDir, err := managedAgentDir(agentID, projectPath)
+	if err != nil {
+		return err
+	}
+
+	agentState, err := LoadManagedAgentState(agentDir)
+	if err != nil {
+		return fmt.Errorf("loading managed agent state: %w", err)
+	}
+
+	if interrupt && agentState.LatestInteractionID != "" {
+		if cancelErr := m.Backend.CancelInteraction(ctx, agentState.LatestInteractionID); cancelErr != nil {
+			slog.Warn("failed to cancel interaction for interrupt", "err", cancelErr)
+		}
+	}
+
+	if message == "" {
+		return nil
+	}
+
+	req := managedagent.InteractionRequest{
+		CloudAgentID:          agentState.CloudAgentID,
+		Input:                 message,
+		PreviousInteractionID: agentState.LatestInteractionID,
+		EnvironmentID:         agentState.LatestEnvironmentID,
+		Background:            true,
+	}
+
+	handle, err := m.Backend.CreateInteraction(ctx, req)
+	if err != nil {
+		return fmt.Errorf("creating interaction: %w", err)
+	}
+
+	agentState.LatestInteractionID = handle.InteractionID
+	if handle.EnvironmentID != "" {
+		agentState.LatestEnvironmentID = handle.EnvironmentID
+	}
+	agentState.InteractionChain = append(agentState.InteractionChain, handle.InteractionID)
+	agentState.LastStatus = string(handle.Status)
+
+	if err := SaveManagedAgentState(agentDir, agentState); err != nil {
+		return fmt.Errorf("saving managed agent state: %w", err)
+	}
+
+	return nil
+}
+
+func (m *ManagedAgentManager) MessageRaw(_ context.Context, _, _ string, _ string) error {
+	return fmt.Errorf("MessageRaw is not supported for managed agents")
+}
+
+func (m *ManagedAgentManager) Watch(ctx context.Context, agentID string) (<-chan api.StatusEvent, error) {
+	agentDir, err := managedAgentDir(agentID, m.stateDir)
+	if err != nil {
+		return nil, err
+	}
+
+	agentState, err := LoadManagedAgentState(agentDir)
+	if err != nil {
+		return nil, fmt.Errorf("loading managed agent state: %w", err)
+	}
+
+	if agentState.LatestInteractionID == "" {
+		return nil, fmt.Errorf("no active interaction for agent %s", agentID)
+	}
+
+	ch := make(chan api.StatusEvent, 16)
+	go func() {
+		defer close(ch)
+		ticker := time.NewTicker(3 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				interactionState, err := m.Backend.GetInteraction(ctx, agentState.LatestInteractionID)
+				if err != nil {
+					ch <- api.StatusEvent{
+						AgentID:   agentID,
+						Status:    "error",
+						Message:   err.Error(),
+						Timestamp: time.Now().UTC().Format(time.RFC3339),
+					}
+					return
+				}
+
+				status := mapInteractionStatus(interactionState.Status)
+				ch <- api.StatusEvent{
+					AgentID:   agentID,
+					Status:    status,
+					Timestamp: time.Now().UTC().Format(time.RFC3339),
+				}
+
+				if isTerminalStatus(interactionState.Status) {
+					return
+				}
+			}
+		}
+	}()
+
+	return ch, nil
+}
+
+func (m *ManagedAgentManager) Close() {}
+
+func mapInteractionStatus(s managedagent.InteractionStatus) string {
+	switch s {
+	case managedagent.StatusInProgress:
+		return "running"
+	case managedagent.StatusRequiresAction:
+		return "waiting_for_input"
+	case managedagent.StatusCompleted:
+		return "completed"
+	case managedagent.StatusFailed:
+		return "error"
+	case managedagent.StatusCancelled:
+		return "stopped"
+	case managedagent.StatusIncomplete:
+		return "error"
+	default:
+		return string(s)
+	}
+}
+
+func isTerminalStatus(s managedagent.InteractionStatus) bool {
+	switch s {
+	case managedagent.StatusCompleted, managedagent.StatusFailed,
+		managedagent.StatusCancelled, managedagent.StatusIncomplete:
+		return true
+	}
+	return false
+}

--- a/pkg/agent/managed_state.go
+++ b/pkg/agent/managed_state.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+const managedAgentStateFile = "managed-agent-state.json"
+
+// ManagedAgentState persists the cloud-side identifiers and interaction chain
+// for a managed agent so that the local CLI can reconnect across restarts.
+type ManagedAgentState struct {
+	CloudAgentID        string   `json:"cloud_agent_id"`
+	CloudProvider       string   `json:"cloud_provider"`
+	LatestInteractionID string   `json:"latest_interaction_id,omitempty"`
+	LatestEnvironmentID string   `json:"latest_environment_id,omitempty"`
+	InteractionChain    []string `json:"interaction_chain,omitempty"`
+	LastStatus          string   `json:"last_status,omitempty"`
+	CreatedAt           string   `json:"created_at"`
+	UpdatedAt           string   `json:"updated_at"`
+}
+
+// LoadManagedAgentState reads the managed agent state from the given agent directory.
+func LoadManagedAgentState(agentDir string) (*ManagedAgentState, error) {
+	data, err := os.ReadFile(filepath.Join(agentDir, managedAgentStateFile))
+	if err != nil {
+		return nil, fmt.Errorf("loading managed agent state: %w", err)
+	}
+	var s ManagedAgentState
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parsing managed agent state: %w", err)
+	}
+	return &s, nil
+}
+
+// SaveManagedAgentState writes the managed agent state atomically to the given agent directory.
+func SaveManagedAgentState(agentDir string, s *ManagedAgentState) error {
+	s.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling managed agent state: %w", err)
+	}
+	target := filepath.Join(agentDir, managedAgentStateFile)
+	tmp := target + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return fmt.Errorf("writing managed agent state: %w", err)
+	}
+	if err := os.Rename(tmp, target); err != nil {
+		return fmt.Errorf("renaming managed agent state: %w", err)
+	}
+	return nil
+}
+
+// managedAgentDir resolves the local agent directory from agent name and project path.
+func managedAgentDir(agentName, projectPath string) (string, error) {
+	projectDir, err := config.GetResolvedProjectDir(projectPath)
+	if err != nil {
+		return "", fmt.Errorf("resolving project dir: %w", err)
+	}
+	return filepath.Join(projectDir, "agents", agentName), nil
+}

--- a/pkg/agent/managed_state.go
+++ b/pkg/agent/managed_state.go
@@ -29,11 +29,11 @@ const managedAgentStateFile = "managed-agent-state.json"
 // ManagedAgentState persists the cloud-side identifiers and interaction chain
 // for a managed agent so that the local CLI can reconnect across restarts.
 type ManagedAgentState struct {
-	CloudAgentID        string   `json:"cloud_agent_id"`
-	CloudProvider       string   `json:"cloud_provider"`
-	APIKeyRef           string   `json:"api_key_ref,omitempty"`
-	LatestInteractionID string   `json:"latest_interaction_id,omitempty"`
-	LatestEnvironmentID string   `json:"latest_environment_id,omitempty"`
+	CloudAgentID        string `json:"cloud_agent_id"`
+	CloudProvider       string `json:"cloud_provider"`
+	APIKeyRef           string `json:"api_key_ref,omitempty"`
+	LatestInteractionID string `json:"latest_interaction_id,omitempty"`
+	LatestEnvironmentID string `json:"latest_environment_id,omitempty"`
 	// InteractionChain grows unbounded in v1; a future version should cap or
 	// rotate old entries for long-lived agents.
 	InteractionChain []string `json:"interaction_chain,omitempty"`

--- a/pkg/agent/managed_state.go
+++ b/pkg/agent/managed_state.go
@@ -31,12 +31,15 @@ const managedAgentStateFile = "managed-agent-state.json"
 type ManagedAgentState struct {
 	CloudAgentID        string   `json:"cloud_agent_id"`
 	CloudProvider       string   `json:"cloud_provider"`
+	APIKeyRef           string   `json:"api_key_ref,omitempty"`
 	LatestInteractionID string   `json:"latest_interaction_id,omitempty"`
 	LatestEnvironmentID string   `json:"latest_environment_id,omitempty"`
-	InteractionChain    []string `json:"interaction_chain,omitempty"`
-	LastStatus          string   `json:"last_status,omitempty"`
-	CreatedAt           string   `json:"created_at"`
-	UpdatedAt           string   `json:"updated_at"`
+	// InteractionChain grows unbounded in v1; a future version should cap or
+	// rotate old entries for long-lived agents.
+	InteractionChain []string `json:"interaction_chain,omitempty"`
+	LastStatus       string   `json:"last_status,omitempty"`
+	CreatedAt        string   `json:"created_at"`
+	UpdatedAt        string   `json:"updated_at"`
 }
 
 // LoadManagedAgentState reads the managed agent state from the given agent directory.

--- a/pkg/agent/manager_factory.go
+++ b/pkg/agent/manager_factory.go
@@ -39,6 +39,7 @@ func NewManagerForProfile(rt runtime.Runtime, profile string, settings *config.V
 	backend, err := google.NewBackend(google.BackendConfig{
 		APIKey:    cfg.APIKey,
 		BaseAgent: cfg.BaseAgent,
+		Model:     cfg.Model,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating managed agent backend: %w", err)

--- a/pkg/agent/manager_factory.go
+++ b/pkg/agent/manager_factory.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/managedagent/google"
+	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
+)
+
+// NewManagerForProfile returns a Manager appropriate for the given profile.
+// The "managed-agents" profile returns a ManagedAgentManager backed by the
+// configured cloud provider; all other profiles return the standard
+// container-based AgentManager.
+func NewManagerForProfile(rt runtime.Runtime, profile string, settings *config.VersionedSettings, stateDir string) (Manager, error) {
+	if profile != "managed-agents" {
+		return NewManager(rt), nil
+	}
+
+	if settings == nil || settings.ManagedAgents == nil || settings.ManagedAgents.Google == nil {
+		return nil, fmt.Errorf("managed-agents profile requires managed_agents.google configuration in settings")
+	}
+
+	cfg := settings.ManagedAgents.Google
+	backend, err := google.NewBackend(google.BackendConfig{
+		APIKey:    cfg.APIKey,
+		BaseAgent: cfg.BaseAgent,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating managed agent backend: %w", err)
+	}
+
+	return NewManagedAgentManager(backend, stateDir), nil
+}

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -2361,6 +2361,7 @@ type V1ManagedAgentsConfig struct {
 type V1GoogleManagedAgentConfig struct {
 	APIKey    string `json:"api_key,omitempty" yaml:"api_key,omitempty" koanf:"api_key"`
 	BaseAgent string `json:"base_agent,omitempty" yaml:"base_agent,omitempty" koanf:"base_agent"`
+	Model     string `json:"model,omitempty" yaml:"model,omitempty" koanf:"model"`
 }
 
 // getBackupPath returns a backup file path that does not already exist.

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -238,6 +238,7 @@ type VersionedSettings struct {
 	HarnessConfigs       map[string]HarnessConfigEntry `json:"harness_configs,omitempty" yaml:"harness_configs,omitempty" koanf:"harness_configs"`
 	Profiles             map[string]V1ProfileConfig    `json:"profiles,omitempty" yaml:"profiles,omitempty" koanf:"profiles"`
 	SharedDirs           []api.SharedDir               `json:"shared_dirs,omitempty" yaml:"shared_dirs,omitempty" koanf:"shared_dirs"`
+	ManagedAgents        *V1ManagedAgentsConfig        `json:"managed_agents,omitempty" yaml:"managed_agents,omitempty" koanf:"managed_agents"`
 
 	// Default agent limits (applied when no explicit value is set)
 	DefaultMaxTurns      int               `json:"default_max_turns,omitempty" yaml:"default_max_turns,omitempty" koanf:"default_max_turns"`
@@ -2349,6 +2350,17 @@ func loadServerConfigOnly(path string) (*GlobalConfig, error) {
 		return nil, fmt.Errorf("failed to unmarshal server config: %w", err)
 	}
 	return &gc, nil
+}
+
+// V1ManagedAgentsConfig holds configuration for cloud-managed agent backends.
+type V1ManagedAgentsConfig struct {
+	Google *V1GoogleManagedAgentConfig `json:"google,omitempty" yaml:"google,omitempty" koanf:"google"`
+}
+
+// V1GoogleManagedAgentConfig holds Google-specific managed agent settings.
+type V1GoogleManagedAgentConfig struct {
+	APIKey    string `json:"api_key,omitempty" yaml:"api_key,omitempty" koanf:"api_key"`
+	BaseAgent string `json:"base_agent,omitempty" yaml:"base_agent,omitempty" koanf:"base_agent"`
 }
 
 // getBackupPath returns a backup file path that does not already exist.

--- a/pkg/hub/handlers_agent_lifecycle.go
+++ b/pkg/hub/handlers_agent_lifecycle.go
@@ -200,6 +200,12 @@ func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id
 		return
 	}
 
+	// Managed agent lifecycle: handle directly without broker dispatch.
+	if isManagedAgentRuntime(agent.Runtime) {
+		s.handleManagedAgentLifecycle(w, r, agent, action)
+		return
+	}
+
 	if !s.checkBrokerAvailability(w, r, agent) {
 		return
 	}

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -608,6 +608,37 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		s.events.PublishUserMessage(ctx, storeMsg)
 	}
 
+	// Managed agent path: deliver message directly via backend, bypass broker.
+	if isManagedAgentRuntime(agent.Runtime) {
+		if err := s.managedAgentMessage(ctx, agent, plainMessage, req.Interrupt); err != nil {
+			if persistedMsgID != "" {
+				if markErr := s.store.MarkMessageFailed(ctx, persistedMsgID, err.Error()); markErr != nil {
+					s.messageLog.Error("Failed to mark message as failed", "id", persistedMsgID, "error", markErr)
+				}
+			}
+			RuntimeError(w, "Failed to send message to managed agent: "+err.Error())
+			return
+		}
+
+		agent.Phase = string(state.PhaseRunning)
+		agent.Activity = "working"
+		_ = s.store.UpdateAgentStatus(ctx, agent.ID, store.AgentStatusUpdate{
+			Phase:    agent.Phase,
+			Activity: agent.Activity,
+		})
+		s.events.PublishAgentStatus(ctx, agent)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(MessageDeliveryResponse{
+			MessageID:  persistedMsgID,
+			Status:     "delivered",
+			Agent:      agent.Slug,
+			AgentPhase: agent.Phase,
+		})
+		return
+	}
+
 	// If a dispatcher is available, dispatch the message to the runtime broker
 	dispatcher := s.GetDispatcher()
 	if dispatcher == nil {

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -719,6 +719,40 @@ func (s *Server) createAgentInProject(
 		}
 	}
 
+	// Managed agent path: bypass broker dispatch entirely and handle directly.
+	if req.Profile == ManagedAgentsProfile {
+		s.agentLifecycleLog.Info("Hub: managed agent create (hub-direct)",
+			"agent_id", agent.ID, "agent", agent.Name, "elapsed", time.Since(hubCreateStart).String())
+
+		task := ""
+		if agent.AppliedConfig != nil {
+			task = agent.AppliedConfig.Task
+		}
+		if err := s.managedAgentCreate(ctx, agent, task); err != nil {
+			_ = s.store.DeleteAgent(ctx, agent.ID)
+			RuntimeError(w, "Failed to create managed agent: "+err.Error())
+			return
+		}
+
+		agent.Phase = string(state.PhaseRunning)
+		if task == "" {
+			agent.Activity = "waiting_for_input"
+		} else {
+			agent.Activity = "working"
+		}
+		if err := s.store.UpdateAgent(ctx, agent); err != nil {
+			s.agentLifecycleLog.Warn("Failed to update managed agent after create", "agent_id", agent.ID, "error", err)
+		}
+
+		s.events.PublishAgentCreated(ctx, agent)
+		s.enrichAgent(ctx, agent, project, nil)
+
+		writeJSON(w, http.StatusCreated, CreateAgentResponse{
+			Agent: agent,
+		})
+		return
+	}
+
 	// Dispatch to runtime broker if available.
 	// Unless provision-only is requested, do a full create+start via DispatchAgentCreate.
 	// Otherwise provision only — set up dirs, worktree, templates without launching the container.
@@ -1606,9 +1640,17 @@ func (s *Server) performAgentDelete(w http.ResponseWriter, r *http.Request, agen
 		deleteFiles = false
 	}
 
+	// Managed agent delete: clean up cloud resources directly, skip broker.
+	if isManagedAgentRuntime(agent.Runtime) {
+		if err := s.managedAgentDelete(ctx, agent); err != nil {
+			s.agentLifecycleLog.Warn("Failed to delete managed agent cloud resources",
+				"agent_id", agent.ID, "error", err)
+		}
+	}
+
 	// Verify broker is reachable before deleting to avoid orphaned containers.
 	// Force mode bypasses this check so stuck agents can always be cleaned up.
-	if !force && !s.checkBrokerAvailability(w, r, agent) {
+	if !isManagedAgentRuntime(agent.Runtime) && !force && !s.checkBrokerAvailability(w, r, agent) {
 		return
 	}
 
@@ -1817,17 +1859,35 @@ func (s *Server) handleAgentExec(w http.ResponseWriter, r *http.Request, id stri
 		return
 	}
 
+	agent, err := s.store.GetAgent(ctx, id)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Managed agents: return formatted interaction state instead of exec.
+	if isManagedAgentRuntime(agent.Runtime) {
+		output, err := formatManagedAgentLook(ctx, agent)
+		if err != nil {
+			RuntimeError(w, "Failed to get managed agent state: "+err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, struct {
+			Output   string `json:"output"`
+			ExitCode int    `json:"exitCode"`
+		}{
+			Output:   output,
+			ExitCode: 0,
+		})
+		return
+	}
+
 	dispatcher := s.GetDispatcher()
 	if dispatcher == nil {
 		ServiceNotReady(w, "Exec dispatch is not available yet — the server may still be starting up")
 		return
 	}
 
-	agent, err := s.store.GetAgent(ctx, id)
-	if err != nil {
-		writeErrorFromErr(w, err, "")
-		return
-	}
 	if err := requireRuntimeBrokerAssigned(agent); err != nil {
 		ServiceNotReady(w, "Agent has no runtime broker assigned — the server may still be starting up")
 		return

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -729,6 +729,7 @@ func (s *Server) createAgentInProject(
 			task = agent.AppliedConfig.Task
 		}
 		if err := s.managedAgentCreate(ctx, agent, task); err != nil {
+			_ = s.managedAgentDelete(ctx, agent)
 			_ = s.store.DeleteAgent(ctx, agent.ID)
 			RuntimeError(w, "Failed to create managed agent: "+err.Error())
 			return

--- a/pkg/hub/handlers_managed_agents.go
+++ b/pkg/hub/handlers_managed_agents.go
@@ -32,7 +32,6 @@ const (
 	ManagedAgentsProfile = "managed-agents"
 	ManagedRuntimePrefix = "managed:"
 
-	annotationCloudAgentID  = "scion.dev/cloud-agent-id"
 	annotationCloudProvider = "scion.dev/cloud-provider"
 	annotationInteractionID = "scion.dev/interaction-id"
 	annotationEnvironmentID = "scion.dev/environment-id"
@@ -97,22 +96,27 @@ func (s *Server) managedAgentCreate(ctx context.Context, agent *store.Agent, tas
 
 	agent.Runtime = ManagedRuntimePrefix + backend.Name()
 
-	cloudAgentID, err := backend.CreateAgent(ctx, managedagent.CreateAgentConfig{})
-	if err != nil {
-		return fmt.Errorf("creating cloud agent: %w", err)
-	}
-
 	if agent.Annotations == nil {
 		agent.Annotations = make(map[string]string)
 	}
-	agent.Annotations[annotationCloudAgentID] = cloudAgentID
 	agent.Annotations[annotationCloudProvider] = backend.Name()
 
+	// Skip the /v1beta/agents CRUD endpoint — it may not be generally
+	// available. Go directly to creating an interaction via
+	// /v1beta/interactions, which works with built-in agent names.
 	if task != "" {
+		var systemInstruction string
+		if agent.AppliedConfig != nil && agent.AppliedConfig.InlineConfig != nil {
+			systemInstruction = agent.AppliedConfig.InlineConfig.SystemPrompt
+			if systemInstruction == "" {
+				systemInstruction = agent.AppliedConfig.InlineConfig.AgentInstructions
+			}
+		}
 		handle, err := backend.CreateInteraction(ctx, managedagent.InteractionRequest{
-			CloudAgentID: cloudAgentID,
-			Input:        task,
-			Background:   true,
+			Input:             task,
+			SystemInstruction: systemInstruction,
+			Environment:       &managedagent.EnvironmentConfig{Type: "remote"},
+			Background:        true,
 		})
 		if err != nil {
 			return fmt.Errorf("creating initial interaction: %w", err)
@@ -133,11 +137,6 @@ func (s *Server) managedAgentMessage(ctx context.Context, agent *store.Agent, me
 		return fmt.Errorf("managed agent backend: %w", err)
 	}
 
-	cloudAgentID := agent.Annotations[annotationCloudAgentID]
-	if cloudAgentID == "" {
-		return fmt.Errorf("managed agent has no cloud agent ID")
-	}
-
 	if interrupt {
 		if interactionID := agent.Annotations[annotationInteractionID]; interactionID != "" {
 			if cancelErr := backend.CancelInteraction(ctx, interactionID); cancelErr != nil {
@@ -151,7 +150,6 @@ func (s *Server) managedAgentMessage(ctx context.Context, agent *store.Agent, me
 	}
 
 	req := managedagent.InteractionRequest{
-		CloudAgentID:          cloudAgentID,
 		Input:                 message,
 		PreviousInteractionID: agent.Annotations[annotationInteractionID],
 		EnvironmentID:         agent.Annotations[annotationEnvironmentID],
@@ -199,20 +197,8 @@ func (s *Server) managedAgentStop(ctx context.Context, agent *store.Agent) error
 
 // managedAgentDelete deletes a managed agent's cloud resources.
 func (s *Server) managedAgentDelete(ctx context.Context, agent *store.Agent) error {
-	backend, err := getManagedBackend()
-	if err != nil {
-		return fmt.Errorf("managed agent backend: %w", err)
-	}
-
-	// Stop first (best-effort).
+	// Stop first (best-effort) — cancels the active interaction.
 	_ = s.managedAgentStop(ctx, agent)
-
-	if cloudAgentID := agent.Annotations[annotationCloudAgentID]; cloudAgentID != "" {
-		if delErr := backend.DeleteAgent(ctx, cloudAgentID); delErr != nil {
-			slog.Warn("failed to delete cloud agent", "agent_id", agent.ID, "cloud_agent_id", cloudAgentID, "err", delErr)
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/hub/handlers_managed_agents.go
+++ b/pkg/hub/handlers_managed_agents.go
@@ -32,10 +32,10 @@ const (
 	ManagedAgentsProfile = "managed-agents"
 	ManagedRuntimePrefix = "managed:"
 
-	annotationCloudAgentID       = "scion.dev/cloud-agent-id"
-	annotationCloudProvider      = "scion.dev/cloud-provider"
-	annotationInteractionID      = "scion.dev/interaction-id"
-	annotationEnvironmentID      = "scion.dev/environment-id"
+	annotationCloudAgentID  = "scion.dev/cloud-agent-id"
+	annotationCloudProvider = "scion.dev/cloud-provider"
+	annotationInteractionID = "scion.dev/interaction-id"
+	annotationEnvironmentID = "scion.dev/environment-id"
 )
 
 var (

--- a/pkg/hub/handlers_managed_agents.go
+++ b/pkg/hub/handlers_managed_agents.go
@@ -1,0 +1,317 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/managedagent"
+	"github.com/GoogleCloudPlatform/scion/pkg/managedagent/google"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+const (
+	ManagedAgentsProfile = "managed-agents"
+	ManagedRuntimePrefix = "managed:"
+
+	annotationCloudAgentID       = "scion.dev/cloud-agent-id"
+	annotationCloudProvider      = "scion.dev/cloud-provider"
+	annotationInteractionID      = "scion.dev/interaction-id"
+	annotationEnvironmentID      = "scion.dev/environment-id"
+)
+
+var (
+	managedBackendMu   sync.Mutex
+	managedBackendOnce sync.Once
+	managedBackendInst managedagent.ManagedAgentBackend
+	managedBackendErr  error
+)
+
+// getManagedBackend returns the lazily-initialized managed agent backend.
+// It reads settings from the global settings file on first call.
+func getManagedBackend() (managedagent.ManagedAgentBackend, error) {
+	managedBackendMu.Lock()
+	defer managedBackendMu.Unlock()
+
+	if managedBackendInst != nil {
+		return managedBackendInst, nil
+	}
+	if managedBackendErr != nil {
+		return nil, managedBackendErr
+	}
+
+	globalDir, err := config.GetGlobalDir()
+	if err != nil {
+		managedBackendErr = fmt.Errorf("resolving global dir: %w", err)
+		return nil, managedBackendErr
+	}
+
+	vs, err := config.LoadSingleFileVersioned(globalDir)
+	if err != nil {
+		managedBackendErr = fmt.Errorf("loading settings: %w", err)
+		return nil, managedBackendErr
+	}
+
+	if vs.ManagedAgents == nil || vs.ManagedAgents.Google == nil {
+		managedBackendErr = fmt.Errorf("managed_agents.google configuration not found in settings")
+		return nil, managedBackendErr
+	}
+
+	cfg := vs.ManagedAgents.Google
+	backend, err := google.NewBackend(google.BackendConfig{
+		APIKey:    cfg.APIKey,
+		BaseAgent: cfg.BaseAgent,
+	})
+	if err != nil {
+		managedBackendErr = fmt.Errorf("creating managed agent backend: %w", err)
+		return nil, managedBackendErr
+	}
+
+	managedBackendInst = backend
+	return managedBackendInst, nil
+}
+
+// isManagedAgentRuntime returns true if the runtime string indicates a managed agent.
+func isManagedAgentRuntime(runtime string) bool {
+	return len(runtime) > len(ManagedRuntimePrefix) && runtime[:len(ManagedRuntimePrefix)] == ManagedRuntimePrefix
+}
+
+// managedAgentCreate handles agent creation for the managed-agents profile.
+// It creates the cloud agent via the backend and stores the cloud agent ID
+// in the agent's annotations.
+func (s *Server) managedAgentCreate(ctx context.Context, agent *store.Agent, task string) error {
+	backend, err := getManagedBackend()
+	if err != nil {
+		return fmt.Errorf("managed agent backend: %w", err)
+	}
+
+	agent.Runtime = ManagedRuntimePrefix + backend.Name()
+
+	cloudAgentID, err := backend.CreateAgent(ctx, managedagent.CreateAgentConfig{})
+	if err != nil {
+		return fmt.Errorf("creating cloud agent: %w", err)
+	}
+
+	if agent.Annotations == nil {
+		agent.Annotations = make(map[string]string)
+	}
+	agent.Annotations[annotationCloudAgentID] = cloudAgentID
+	agent.Annotations[annotationCloudProvider] = backend.Name()
+
+	if task != "" {
+		handle, err := backend.CreateInteraction(ctx, managedagent.InteractionRequest{
+			CloudAgentID: cloudAgentID,
+			Input:        task,
+			Background:   true,
+		})
+		if err != nil {
+			return fmt.Errorf("creating initial interaction: %w", err)
+		}
+		agent.Annotations[annotationInteractionID] = handle.InteractionID
+		if handle.EnvironmentID != "" {
+			agent.Annotations[annotationEnvironmentID] = handle.EnvironmentID
+		}
+	}
+
+	return nil
+}
+
+// managedAgentMessage sends a message to a managed agent by creating a new interaction.
+func (s *Server) managedAgentMessage(ctx context.Context, agent *store.Agent, message string, interrupt bool) error {
+	backend, err := getManagedBackend()
+	if err != nil {
+		return fmt.Errorf("managed agent backend: %w", err)
+	}
+
+	cloudAgentID := agent.Annotations[annotationCloudAgentID]
+	if cloudAgentID == "" {
+		return fmt.Errorf("managed agent has no cloud agent ID")
+	}
+
+	if interrupt {
+		if interactionID := agent.Annotations[annotationInteractionID]; interactionID != "" {
+			if cancelErr := backend.CancelInteraction(ctx, interactionID); cancelErr != nil {
+				slog.Warn("failed to cancel interaction for interrupt", "agent_id", agent.ID, "err", cancelErr)
+			}
+		}
+	}
+
+	if message == "" {
+		return nil
+	}
+
+	req := managedagent.InteractionRequest{
+		CloudAgentID:          cloudAgentID,
+		Input:                 message,
+		PreviousInteractionID: agent.Annotations[annotationInteractionID],
+		EnvironmentID:         agent.Annotations[annotationEnvironmentID],
+		Background:            true,
+	}
+
+	handle, err := backend.CreateInteraction(ctx, req)
+	if err != nil {
+		return fmt.Errorf("creating interaction: %w", err)
+	}
+
+	if agent.Annotations == nil {
+		agent.Annotations = make(map[string]string)
+	}
+	agent.Annotations[annotationInteractionID] = handle.InteractionID
+	if handle.EnvironmentID != "" {
+		agent.Annotations[annotationEnvironmentID] = handle.EnvironmentID
+	}
+
+	if err := s.store.UpdateAgent(ctx, agent); err != nil {
+		slog.Warn("failed to persist interaction annotations", "agent_id", agent.ID, "err", err)
+	}
+
+	return nil
+}
+
+// managedAgentStop stops a managed agent by cancelling the active interaction.
+func (s *Server) managedAgentStop(ctx context.Context, agent *store.Agent) error {
+	backend, err := getManagedBackend()
+	if err != nil {
+		return fmt.Errorf("managed agent backend: %w", err)
+	}
+
+	if interactionID := agent.Annotations[annotationInteractionID]; interactionID != "" {
+		interactionState, getErr := backend.GetInteraction(ctx, interactionID)
+		if getErr == nil && interactionState.Status == managedagent.StatusInProgress {
+			if cancelErr := backend.CancelInteraction(ctx, interactionID); cancelErr != nil {
+				slog.Warn("failed to cancel interaction on stop", "agent_id", agent.ID, "err", cancelErr)
+			}
+		}
+	}
+
+	return nil
+}
+
+// managedAgentDelete deletes a managed agent's cloud resources.
+func (s *Server) managedAgentDelete(ctx context.Context, agent *store.Agent) error {
+	backend, err := getManagedBackend()
+	if err != nil {
+		return fmt.Errorf("managed agent backend: %w", err)
+	}
+
+	// Stop first (best-effort).
+	_ = s.managedAgentStop(ctx, agent)
+
+	if cloudAgentID := agent.Annotations[annotationCloudAgentID]; cloudAgentID != "" {
+		if delErr := backend.DeleteAgent(ctx, cloudAgentID); delErr != nil {
+			slog.Warn("failed to delete cloud agent", "agent_id", agent.ID, "cloud_agent_id", cloudAgentID, "err", delErr)
+		}
+	}
+
+	return nil
+}
+
+// handleManagedAgentLifecycle handles lifecycle actions (start, stop, restart) for managed agents.
+func (s *Server) handleManagedAgentLifecycle(w http.ResponseWriter, r *http.Request, agent *store.Agent, action string) {
+	ctx := r.Context()
+
+	var newPhase string
+	var actionErr error
+
+	switch action {
+	case "start":
+		newPhase = string("running")
+	case "stop":
+		newPhase = string("stopped")
+		actionErr = s.managedAgentStop(ctx, agent)
+	case "restart":
+		_ = s.managedAgentStop(ctx, agent)
+		newPhase = string("running")
+	case "suspend":
+		writeError(w, http.StatusBadRequest, ErrCodeValidationError,
+			"Suspend is not supported for managed agents — use stop instead.", nil)
+		return
+	default:
+		writeError(w, http.StatusBadRequest, ErrCodeValidationError,
+			fmt.Sprintf("Unknown lifecycle action %q for managed agent", action), nil)
+		return
+	}
+
+	if actionErr != nil {
+		RuntimeError(w, "Failed managed agent lifecycle action: "+actionErr.Error())
+		return
+	}
+
+	statusUpdate := store.AgentStatusUpdate{
+		Phase: newPhase,
+	}
+	if action == "stop" {
+		statusUpdate.Activity = ""
+	}
+	if err := s.store.UpdateAgentStatus(ctx, agent.ID, statusUpdate); err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	agent.Phase = newPhase
+	s.events.PublishAgentStatus(ctx, agent)
+	writeJSON(w, http.StatusOK, agent)
+}
+
+// formatManagedAgentLook returns the latest interaction formatted as structured text.
+func formatManagedAgentLook(ctx context.Context, agent *store.Agent) (string, error) {
+	state, err := managedAgentGetInteraction(ctx, agent)
+	if err != nil {
+		return fmt.Sprintf("[status] %s (no active interaction)\n", agent.Phase), nil
+	}
+
+	var b strings.Builder
+	for _, step := range state.Steps {
+		stepType := step.Type
+		if stepType == "" {
+			stepType = "output"
+		}
+		text := step.Text
+		if text == "" && step.Arguments != "" {
+			text = step.ToolName + "(" + step.Arguments + ")"
+		}
+		fmt.Fprintf(&b, "[%s] %s\n", stepType, text)
+	}
+
+	statusLine := string(state.Status)
+	if state.Usage != nil {
+		statusLine += fmt.Sprintf(" (%d input / %d output tokens)",
+			state.Usage.TotalInputTokens, state.Usage.TotalOutputTokens)
+	}
+	fmt.Fprintf(&b, "[status] %s\n", statusLine)
+
+	return b.String(), nil
+}
+
+// managedAgentGetInteraction retrieves the latest interaction state for a managed agent.
+func managedAgentGetInteraction(ctx context.Context, agent *store.Agent) (*managedagent.InteractionState, error) {
+	backend, err := getManagedBackend()
+	if err != nil {
+		return nil, fmt.Errorf("managed agent backend: %w", err)
+	}
+
+	interactionID := agent.Annotations[annotationInteractionID]
+	if interactionID == "" {
+		return nil, fmt.Errorf("no active interaction for agent %s", agent.Slug)
+	}
+
+	return backend.GetInteraction(ctx, interactionID)
+}

--- a/pkg/hub/handlers_managed_agents.go
+++ b/pkg/hub/handlers_managed_agents.go
@@ -40,13 +40,12 @@ const (
 
 var (
 	managedBackendMu   sync.Mutex
-	managedBackendOnce sync.Once
 	managedBackendInst managedagent.ManagedAgentBackend
-	managedBackendErr  error
 )
 
 // getManagedBackend returns the lazily-initialized managed agent backend.
 // It reads settings from the global settings file on first call.
+// Transient init failures are not cached so subsequent calls can retry.
 func getManagedBackend() (managedagent.ManagedAgentBackend, error) {
 	managedBackendMu.Lock()
 	defer managedBackendMu.Unlock()
@@ -54,25 +53,19 @@ func getManagedBackend() (managedagent.ManagedAgentBackend, error) {
 	if managedBackendInst != nil {
 		return managedBackendInst, nil
 	}
-	if managedBackendErr != nil {
-		return nil, managedBackendErr
-	}
 
 	globalDir, err := config.GetGlobalDir()
 	if err != nil {
-		managedBackendErr = fmt.Errorf("resolving global dir: %w", err)
-		return nil, managedBackendErr
+		return nil, fmt.Errorf("resolving global dir: %w", err)
 	}
 
 	vs, err := config.LoadSingleFileVersioned(globalDir)
 	if err != nil {
-		managedBackendErr = fmt.Errorf("loading settings: %w", err)
-		return nil, managedBackendErr
+		return nil, fmt.Errorf("loading settings: %w", err)
 	}
 
 	if vs.ManagedAgents == nil || vs.ManagedAgents.Google == nil {
-		managedBackendErr = fmt.Errorf("managed_agents.google configuration not found in settings")
-		return nil, managedBackendErr
+		return nil, fmt.Errorf("managed_agents.google configuration not found in settings")
 	}
 
 	cfg := vs.ManagedAgents.Google
@@ -81,8 +74,7 @@ func getManagedBackend() (managedagent.ManagedAgentBackend, error) {
 		BaseAgent: cfg.BaseAgent,
 	})
 	if err != nil {
-		managedBackendErr = fmt.Errorf("creating managed agent backend: %w", err)
-		return nil, managedBackendErr
+		return nil, fmt.Errorf("creating managed agent backend: %w", err)
 	}
 
 	managedBackendInst = backend
@@ -91,7 +83,7 @@ func getManagedBackend() (managedagent.ManagedAgentBackend, error) {
 
 // isManagedAgentRuntime returns true if the runtime string indicates a managed agent.
 func isManagedAgentRuntime(runtime string) bool {
-	return len(runtime) > len(ManagedRuntimePrefix) && runtime[:len(ManagedRuntimePrefix)] == ManagedRuntimePrefix
+	return strings.HasPrefix(runtime, ManagedRuntimePrefix)
 }
 
 // managedAgentCreate handles agent creation for the managed-agents profile.
@@ -278,6 +270,8 @@ func formatManagedAgentLook(ctx context.Context, agent *store.Agent) (string, er
 		return fmt.Sprintf("[status] %s (no active interaction)\n", agent.Phase), nil
 	}
 
+	// TODO: add per-step timestamps ([HH:MM:SS] prefix) once the backend
+	// API exposes them on managedagent.Step — see design doc section 4.5.
 	var b strings.Builder
 	for _, step := range state.Steps {
 		stepType := step.Type

--- a/pkg/hub/handlers_managed_agents.go
+++ b/pkg/hub/handlers_managed_agents.go
@@ -71,6 +71,7 @@ func getManagedBackend() (managedagent.ManagedAgentBackend, error) {
 	backend, err := google.NewBackend(google.BackendConfig{
 		APIKey:    cfg.APIKey,
 		BaseAgent: cfg.BaseAgent,
+		Model:     cfg.Model,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating managed agent backend: %w", err)

--- a/pkg/hub/harness_capabilities_test.go
+++ b/pkg/hub/harness_capabilities_test.go
@@ -67,7 +67,7 @@ func TestGetAgent_ExposesHarnessCapabilities(t *testing.T) {
 
 func TestUpdateAgent_RejectsUnsupportedMaxModelCallsForGeneric(t *testing.T) {
 	srv, s := testServer(t)
-	agent := seedCreatedAgentForHarnessTest(t, s, "generic-update", "generic")
+	agent := seedCreatedAgentForHarnessTest(t, s, "claude-update", "generic")
 
 	rec := doRequest(t, srv, http.MethodPatch, "/api/v1/agents/"+agent.ID, map[string]interface{}{
 		"config": map[string]interface{}{

--- a/pkg/hub/harness_config_handlers_test.go
+++ b/pkg/hub/harness_config_handlers_test.go
@@ -153,9 +153,9 @@ func TestHarnessConfigListByScopeAndProject(t *testing.T) {
 	for _, hc := range []*store.HarnessConfig{
 		{ID: tid("hc_g"), Slug: "g", Name: "G", Harness: "claude", Scope: "global",
 			Visibility: store.VisibilityPublic, Status: store.HarnessConfigStatusActive, Created: now, Updated: now},
-		{ID: tid("hc_a"), Slug: "a", Name: "A", Harness: "claude", Scope: "project", ScopeID: "project_abc",
+		{ID: tid("hc_a"), Slug: "a", Name: "A", Harness: "claude", Scope: "project", ScopeID: tid("project_abc"),
 			Visibility: store.VisibilityPublic, Status: store.HarnessConfigStatusActive, Created: now, Updated: now},
-		{ID: tid("hc_b"), Slug: "b", Name: "B", Harness: "claude", Scope: "project", ScopeID: "project_xyz",
+		{ID: tid("hc_b"), Slug: "b", Name: "B", Harness: "claude", Scope: "project", ScopeID: tid("project_xyz"),
 			Visibility: store.VisibilityPublic, Status: store.HarnessConfigStatusActive, Created: now, Updated: now},
 	} {
 		if err := s.CreateHarnessConfig(ctx, hc); err != nil {
@@ -164,7 +164,7 @@ func TestHarnessConfigListByScopeAndProject(t *testing.T) {
 	}
 
 	// scope=project + projectId should return only that project's configs.
-	rec := doRequest(t, srv, http.MethodGet, "/api/v1/harness-configs?scope=project&projectId=project_abc", nil)
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/harness-configs?scope=project&projectId="+tid("project_abc"), nil)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
 	}
@@ -177,7 +177,7 @@ func TestHarnessConfigListByScopeAndProject(t *testing.T) {
 		for i, hc := range resp.HarnessConfigs {
 			ids[i] = hc.ID
 		}
-		t.Errorf("expected only [hc_a], got %v", ids)
+		t.Errorf("expected only [%s], got %v", tid("hc_a"), ids)
 	}
 }
 

--- a/pkg/managedagent/backend.go
+++ b/pkg/managedagent/backend.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedagent
+
+import (
+	"context"
+	"io"
+)
+
+// ManagedAgentBackend is the cloud-provider abstraction for managed agent services.
+// Each backend (Google, etc.) implements this interface.
+type ManagedAgentBackend interface {
+	// Name returns the backend identifier (e.g., "google").
+	Name() string
+
+	// CreateAgent creates a persistent agent configuration on the cloud service.
+	// Returns the cloud-assigned agent ID.
+	CreateAgent(ctx context.Context, cfg CreateAgentConfig) (string, error)
+
+	// DeleteAgent removes the agent configuration from the cloud service.
+	DeleteAgent(ctx context.Context, cloudAgentID string) error
+
+	// CreateInteraction starts a new interaction (turn) with the agent.
+	CreateInteraction(ctx context.Context, req InteractionRequest) (*InteractionHandle, error)
+
+	// GetInteraction retrieves the current state of an interaction.
+	GetInteraction(ctx context.Context, interactionID string) (*InteractionState, error)
+
+	// CancelInteraction cancels a running interaction.
+	CancelInteraction(ctx context.Context, interactionID string) error
+
+	// StreamInteraction opens an SSE stream for a running or completed interaction.
+	// If lastEventID is non-empty, resumes from that point.
+	StreamInteraction(ctx context.Context, interactionID string, lastEventID string) (io.ReadCloser, error)
+}

--- a/pkg/managedagent/google/backend.go
+++ b/pkg/managedagent/google/backend.go
@@ -81,8 +81,16 @@ func (b *Backend) DeleteAgent(ctx context.Context, cloudAgentID string) error {
 }
 
 func (b *Backend) CreateInteraction(ctx context.Context, req managedagent.InteractionRequest) (*managedagent.InteractionHandle, error) {
+	agentName := req.CloudAgentID
+	if agentName == "" {
+		agentName = req.AgentName
+	}
+	if agentName == "" {
+		agentName = b.baseAgent
+	}
+
 	apiReq := &CreateInteractionRequest{
-		Agent:                 req.CloudAgentID,
+		Agent:                 agentName,
 		Input:                 req.Input,
 		PreviousInteractionID: req.PreviousInteractionID,
 		Stream:                req.Stream,

--- a/pkg/managedagent/google/backend.go
+++ b/pkg/managedagent/google/backend.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/managedagent"
 )
@@ -35,11 +36,15 @@ type Backend struct {
 }
 
 // NewBackend creates a new Google managed agent backend.
-func NewBackend(cfg BackendConfig) *Backend {
+// Returns an error if APIKey is empty.
+func NewBackend(cfg BackendConfig) (*Backend, error) {
+	if cfg.APIKey == "" {
+		return nil, fmt.Errorf("google backend: API key is required")
+	}
 	return &Backend{
 		client:    NewClient(cfg.APIKey),
 		baseAgent: cfg.BaseAgent,
-	}
+	}, nil
 }
 
 func (b *Backend) Name() string {
@@ -85,7 +90,7 @@ func (b *Backend) CreateInteraction(ctx context.Context, req managedagent.Intera
 	}
 
 	if req.EnvironmentID != "" {
-		apiReq.Environment = &Environment{Type: req.EnvironmentID}
+		apiReq.Environment = req.EnvironmentID
 	} else if req.Environment != nil {
 		apiReq.Environment = convertEnvironmentConfig(req.Environment)
 	}
@@ -95,10 +100,26 @@ func (b *Backend) CreateInteraction(ctx context.Context, req managedagent.Intera
 		if err != nil {
 			return nil, fmt.Errorf("google backend: %w", err)
 		}
-		return &managedagent.InteractionHandle{
+		handle := &managedagent.InteractionHandle{
 			Status:      managedagent.StatusInProgress,
 			EventStream: stream,
-		}, nil
+		}
+		// Parse the first event (interaction.created) to populate IDs.
+		reader := NewSSEReader(stream)
+		evt, err := reader.Next()
+		if err == nil && evt.Type == EventInteractionCreated {
+			if interaction, parseErr := ParseInteraction(evt.Data); parseErr == nil {
+				handle.InteractionID = interaction.ID
+				handle.EnvironmentID = interaction.EnvironmentID
+				handle.Status = managedagent.InteractionStatus(interaction.Status)
+			}
+		}
+		// Wrap the stream so subsequent reads continue from where we left off.
+		handle.EventStream = &prefixedSSEStream{
+			reader:     reader,
+			underlying: stream,
+		}
+		return handle, nil
 	}
 
 	interaction, err := b.client.CreateInteraction(ctx, apiReq)
@@ -117,7 +138,7 @@ func (b *Backend) GetInteraction(ctx context.Context, interactionID string) (*ma
 
 	return &managedagent.InteractionState{
 		InteractionID: interaction.ID,
-		Status:        managedagent.InteractionStatus(interaction.Status),
+		Status:        toInteractionStatus(interaction.Status),
 		Steps:         convertSteps(interaction.Steps),
 		OutputText:    interaction.OutputText,
 		EnvironmentID: interaction.EnvironmentID,
@@ -140,15 +161,48 @@ func (b *Backend) StreamInteraction(ctx context.Context, interactionID string, l
 	return stream, nil
 }
 
+// prefixedSSEStream wraps an SSEReader so that callers who want to continue
+// reading raw bytes from the underlying stream get the remaining data after
+// the first event was already consumed.
+type prefixedSSEStream struct {
+	reader     *SSEReader
+	underlying io.ReadCloser
+}
+
+func (s *prefixedSSEStream) Read(p []byte) (int, error) {
+	return s.underlying.Read(p)
+}
+
+func (s *prefixedSSEStream) Close() error {
+	return s.underlying.Close()
+}
+
 func convertInteractionToHandle(i *Interaction) *managedagent.InteractionHandle {
 	return &managedagent.InteractionHandle{
 		InteractionID: i.ID,
 		EnvironmentID: i.EnvironmentID,
-		Status:        managedagent.InteractionStatus(i.Status),
+		Status:        toInteractionStatus(i.Status),
 		Steps:         convertSteps(i.Steps),
 		OutputText:    i.OutputText,
 		Usage:         convertUsage(i.Usage),
 	}
+}
+
+var knownStatuses = map[managedagent.InteractionStatus]bool{
+	managedagent.StatusInProgress:     true,
+	managedagent.StatusRequiresAction: true,
+	managedagent.StatusCompleted:      true,
+	managedagent.StatusFailed:         true,
+	managedagent.StatusCancelled:      true,
+	managedagent.StatusIncomplete:     true,
+}
+
+func toInteractionStatus(s string) managedagent.InteractionStatus {
+	status := managedagent.InteractionStatus(s)
+	if !knownStatuses[status] {
+		log.Printf("google backend: unknown interaction status %q", s)
+	}
+	return status
 }
 
 func convertSteps(steps []InteractionStep) []managedagent.Step {
@@ -157,10 +211,14 @@ func convertSteps(steps []InteractionStep) []managedagent.Step {
 	}
 	result := make([]managedagent.Step, len(steps))
 	for i, s := range steps {
+		args := s.Arguments
+		if args == "" {
+			args = s.ArgumentsDelta
+		}
 		result[i] = managedagent.Step{
 			Type:      s.Type,
 			Text:      s.Text,
-			Arguments: s.ArgumentsDelta,
+			Arguments: args,
 			ToolName:  s.ToolName,
 		}
 	}

--- a/pkg/managedagent/google/backend.go
+++ b/pkg/managedagent/google/backend.go
@@ -27,12 +27,14 @@ import (
 type BackendConfig struct {
 	APIKey    string
 	BaseAgent string
+	Model     string
 }
 
 // Backend implements managedagent.ManagedAgentBackend using the Google API.
 type Backend struct {
 	client    *Client
 	baseAgent string
+	model     string
 }
 
 // NewBackend creates a new Google managed agent backend.
@@ -44,6 +46,7 @@ func NewBackend(cfg BackendConfig) (*Backend, error) {
 	return &Backend{
 		client:    NewClient(cfg.APIKey),
 		baseAgent: cfg.BaseAgent,
+		model:     cfg.Model,
 	}, nil
 }
 
@@ -90,13 +93,22 @@ func (b *Backend) CreateInteraction(ctx context.Context, req managedagent.Intera
 	}
 
 	apiReq := &CreateInteractionRequest{
-		Agent:                 agentName,
 		Input:                 req.Input,
 		PreviousInteractionID: req.PreviousInteractionID,
 		Stream:                req.Stream,
 		Background:            req.Background,
 		SystemInstruction:     req.SystemInstruction,
 		Tools:                 convertToolConfigs(req.Tools),
+	}
+
+	if agentName != "" {
+		apiReq.Agent = agentName
+	} else {
+		model := req.Model
+		if model == "" {
+			model = b.model
+		}
+		apiReq.Model = model
 	}
 
 	if req.EnvironmentID != "" {

--- a/pkg/managedagent/google/backend.go
+++ b/pkg/managedagent/google/backend.go
@@ -1,0 +1,229 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/managedagent"
+)
+
+// BackendConfig holds configuration for the Google managed agent backend.
+type BackendConfig struct {
+	APIKey    string
+	BaseAgent string
+}
+
+// Backend implements managedagent.ManagedAgentBackend using the Google API.
+type Backend struct {
+	client    *Client
+	baseAgent string
+}
+
+// NewBackend creates a new Google managed agent backend.
+func NewBackend(cfg BackendConfig) *Backend {
+	return &Backend{
+		client:    NewClient(cfg.APIKey),
+		baseAgent: cfg.BaseAgent,
+	}
+}
+
+func (b *Backend) Name() string {
+	return "google"
+}
+
+func (b *Backend) CreateAgent(ctx context.Context, cfg managedagent.CreateAgentConfig) (string, error) {
+	req := &CreateAgentRequest{
+		ID:                cfg.ID,
+		BaseAgent:         cfg.BaseAgent,
+		SystemInstruction: cfg.SystemInstruction,
+		Description:       cfg.Description,
+		Tools:             convertToolConfigs(cfg.Tools),
+		BaseEnvironment:   convertEnvironmentConfig(cfg.Environment),
+	}
+	if req.BaseAgent == "" {
+		req.BaseAgent = b.baseAgent
+	}
+
+	agent, err := b.client.CreateAgent(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("google backend: %w", err)
+	}
+	return agent.ID, nil
+}
+
+func (b *Backend) DeleteAgent(ctx context.Context, cloudAgentID string) error {
+	if err := b.client.DeleteAgent(ctx, cloudAgentID); err != nil {
+		return fmt.Errorf("google backend: %w", err)
+	}
+	return nil
+}
+
+func (b *Backend) CreateInteraction(ctx context.Context, req managedagent.InteractionRequest) (*managedagent.InteractionHandle, error) {
+	apiReq := &CreateInteractionRequest{
+		Agent:                 req.CloudAgentID,
+		Input:                 req.Input,
+		PreviousInteractionID: req.PreviousInteractionID,
+		Stream:                req.Stream,
+		Background:            req.Background,
+		SystemInstruction:     req.SystemInstruction,
+		Tools:                 convertToolConfigs(req.Tools),
+	}
+
+	if req.EnvironmentID != "" {
+		apiReq.Environment = &Environment{Type: req.EnvironmentID}
+	} else if req.Environment != nil {
+		apiReq.Environment = convertEnvironmentConfig(req.Environment)
+	}
+
+	if req.Stream {
+		stream, err := b.client.CreateInteractionStream(ctx, apiReq)
+		if err != nil {
+			return nil, fmt.Errorf("google backend: %w", err)
+		}
+		return &managedagent.InteractionHandle{
+			Status:      managedagent.StatusInProgress,
+			EventStream: stream,
+		}, nil
+	}
+
+	interaction, err := b.client.CreateInteraction(ctx, apiReq)
+	if err != nil {
+		return nil, fmt.Errorf("google backend: %w", err)
+	}
+
+	return convertInteractionToHandle(interaction), nil
+}
+
+func (b *Backend) GetInteraction(ctx context.Context, interactionID string) (*managedagent.InteractionState, error) {
+	interaction, err := b.client.GetInteraction(ctx, interactionID)
+	if err != nil {
+		return nil, fmt.Errorf("google backend: %w", err)
+	}
+
+	return &managedagent.InteractionState{
+		InteractionID: interaction.ID,
+		Status:        managedagent.InteractionStatus(interaction.Status),
+		Steps:         convertSteps(interaction.Steps),
+		OutputText:    interaction.OutputText,
+		EnvironmentID: interaction.EnvironmentID,
+		Usage:         convertUsage(interaction.Usage),
+	}, nil
+}
+
+func (b *Backend) CancelInteraction(ctx context.Context, interactionID string) error {
+	if err := b.client.CancelInteraction(ctx, interactionID); err != nil {
+		return fmt.Errorf("google backend: %w", err)
+	}
+	return nil
+}
+
+func (b *Backend) StreamInteraction(ctx context.Context, interactionID string, lastEventID string) (io.ReadCloser, error) {
+	stream, err := b.client.GetInteractionStream(ctx, interactionID, lastEventID)
+	if err != nil {
+		return nil, fmt.Errorf("google backend: %w", err)
+	}
+	return stream, nil
+}
+
+func convertInteractionToHandle(i *Interaction) *managedagent.InteractionHandle {
+	return &managedagent.InteractionHandle{
+		InteractionID: i.ID,
+		EnvironmentID: i.EnvironmentID,
+		Status:        managedagent.InteractionStatus(i.Status),
+		Steps:         convertSteps(i.Steps),
+		OutputText:    i.OutputText,
+		Usage:         convertUsage(i.Usage),
+	}
+}
+
+func convertSteps(steps []InteractionStep) []managedagent.Step {
+	if len(steps) == 0 {
+		return nil
+	}
+	result := make([]managedagent.Step, len(steps))
+	for i, s := range steps {
+		result[i] = managedagent.Step{
+			Type:      s.Type,
+			Text:      s.Text,
+			Arguments: s.ArgumentsDelta,
+			ToolName:  s.ToolName,
+		}
+	}
+	return result
+}
+
+func convertUsage(u *InteractionUsage) *managedagent.UsageInfo {
+	if u == nil {
+		return nil
+	}
+	return &managedagent.UsageInfo{
+		TotalInputTokens:  u.TotalInputTokens,
+		TotalOutputTokens: u.TotalOutputTokens,
+		TotalTokens:       u.TotalTokens,
+	}
+}
+
+func convertToolConfigs(tools []managedagent.ToolConfig) []AgentTool {
+	if len(tools) == 0 {
+		return nil
+	}
+	result := make([]AgentTool, len(tools))
+	for i, t := range tools {
+		result[i] = AgentTool{
+			Type:       t.Type,
+			Name:       t.Name,
+			Parameters: t.Parameters,
+		}
+	}
+	return result
+}
+
+func convertEnvironmentConfig(env *managedagent.EnvironmentConfig) *Environment {
+	if env == nil {
+		return nil
+	}
+	e := &Environment{
+		Type: env.Type,
+	}
+	if len(env.Sources) > 0 {
+		e.Sources = make([]SourceConfig, len(env.Sources))
+		for i, s := range env.Sources {
+			e.Sources[i] = SourceConfig{
+				Type:   s.Type,
+				URI:    s.URI,
+				Branch: s.Branch,
+				Path:   s.Path,
+			}
+		}
+	}
+	if env.Network != nil {
+		e.Network = &NetworkConfig{
+			Disabled: env.Network.Disabled,
+		}
+		if len(env.Network.Allowlist) > 0 {
+			e.Network.Allowlist = make([]AllowlistEntry, len(env.Network.Allowlist))
+			for i, a := range env.Network.Allowlist {
+				e.Network.Allowlist[i] = AllowlistEntry{
+					Domain:  a.Domain,
+					Headers: a.Headers,
+				}
+			}
+		}
+	}
+	return e
+}

--- a/pkg/managedagent/google/backend.go
+++ b/pkg/managedagent/google/backend.go
@@ -58,7 +58,9 @@ func (b *Backend) CreateAgent(ctx context.Context, cfg managedagent.CreateAgentC
 		SystemInstruction: cfg.SystemInstruction,
 		Description:       cfg.Description,
 		Tools:             convertToolConfigs(cfg.Tools),
-		BaseEnvironment:   convertEnvironmentConfig(cfg.Environment),
+	}
+	if cfg.Environment != nil {
+		req.BaseEnvironment = convertEnvironmentConfig(cfg.Environment)
 	}
 	if req.BaseAgent == "" {
 		req.BaseAgent = b.baseAgent
@@ -114,10 +116,12 @@ func (b *Backend) CreateInteraction(ctx context.Context, req managedagent.Intera
 				handle.Status = managedagent.InteractionStatus(interaction.Status)
 			}
 		}
-		// Wrap the stream so subsequent reads continue from where we left off.
-		handle.EventStream = &prefixedSSEStream{
-			reader:     reader,
-			underlying: stream,
+		// The SSEReader's bufio.Reader may have read ahead beyond the first
+		// event. Compose the buffered remainder with the raw stream so
+		// callers reading from EventStream don't miss any data.
+		handle.EventStream = &sseStreamContinuation{
+			Reader: io.MultiReader(reader.BufferedReader(), stream),
+			closer: stream,
 		}
 		return handle, nil
 	}
@@ -161,20 +165,16 @@ func (b *Backend) StreamInteraction(ctx context.Context, interactionID string, l
 	return stream, nil
 }
 
-// prefixedSSEStream wraps an SSEReader so that callers who want to continue
-// reading raw bytes from the underlying stream get the remaining data after
-// the first event was already consumed.
-type prefixedSSEStream struct {
-	reader     *SSEReader
-	underlying io.ReadCloser
+// sseStreamContinuation combines the bufio.Reader's buffered remainder
+// with the raw HTTP body so that no data is lost after consuming the
+// first SSE event.
+type sseStreamContinuation struct {
+	io.Reader
+	closer io.Closer
 }
 
-func (s *prefixedSSEStream) Read(p []byte) (int, error) {
-	return s.underlying.Read(p)
-}
-
-func (s *prefixedSSEStream) Close() error {
-	return s.underlying.Close()
+func (s *sseStreamContinuation) Close() error {
+	return s.closer.Close()
 }
 
 func convertInteractionToHandle(i *Interaction) *managedagent.InteractionHandle {

--- a/pkg/managedagent/google/client.go
+++ b/pkg/managedagent/google/client.go
@@ -31,9 +31,10 @@ const maxErrorBodySize = 64 * 1024
 
 // Client is a thin HTTP client for the Google Managed Agents API.
 type Client struct {
-	baseURL    string
-	apiKey     string
-	httpClient *http.Client
+	baseURL          string
+	apiKey           string
+	httpClient       *http.Client
+	streamHTTPClient *http.Client
 }
 
 // NewClient creates a new Google API client with the given API key.
@@ -44,6 +45,7 @@ func NewClient(apiKey string) *Client {
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
+		streamHTTPClient: &http.Client{},
 	}
 }
 
@@ -125,7 +127,7 @@ func (c *Client) CreateInteractionStream(ctx context.Context, req *CreateInterac
 	c.setHeaders(httpReq, true)
 	httpReq.Header.Set("Accept", "text/event-stream")
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.streamHTTPClient.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("executing streaming request: %w", err)
 	}
@@ -163,7 +165,7 @@ func (c *Client) GetInteractionStream(ctx context.Context, interactionID string,
 	c.setHeaders(httpReq, false)
 	httpReq.Header.Set("Accept", "text/event-stream")
 
-	resp, err := c.httpClient.Do(httpReq)
+	resp, err := c.streamHTTPClient.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("opening interaction stream: %w", err)
 	}

--- a/pkg/managedagent/google/client.go
+++ b/pkg/managedagent/google/client.go
@@ -133,7 +133,7 @@ func (c *Client) CreateInteractionStream(ctx context.Context, req *CreateInterac
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		return nil, c.parseError(resp)
 	}
 
@@ -171,7 +171,7 @@ func (c *Client) GetInteractionStream(ctx context.Context, interactionID string,
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		return nil, c.parseError(resp)
 	}
 
@@ -216,7 +216,7 @@ func (c *Client) do(ctx context.Context, method, path string, reqBody interface{
 	if err != nil {
 		return fmt.Errorf("executing request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return c.parseError(resp)

--- a/pkg/managedagent/google/client.go
+++ b/pkg/managedagent/google/client.go
@@ -22,9 +22,12 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 const defaultBaseURL = "https://generativelanguage.googleapis.com/v1beta"
+
+const maxErrorBodySize = 64 * 1024
 
 // Client is a thin HTTP client for the Google Managed Agents API.
 type Client struct {
@@ -36,10 +39,17 @@ type Client struct {
 // NewClient creates a new Google API client with the given API key.
 func NewClient(apiKey string) *Client {
 	return &Client{
-		baseURL:    defaultBaseURL,
-		apiKey:     apiKey,
-		httpClient: http.DefaultClient,
+		baseURL: defaultBaseURL,
+		apiKey:  apiKey,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
 	}
+}
+
+// SetBaseURL overrides the API base URL (useful for testing).
+func (c *Client) SetBaseURL(url string) {
+	c.baseURL = url
 }
 
 // CreateAgent creates a new managed agent configuration.
@@ -112,7 +122,7 @@ func (c *Client) CreateInteractionStream(ctx context.Context, req *CreateInterac
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
-	c.setHeaders(httpReq)
+	c.setHeaders(httpReq, true)
 	httpReq.Header.Set("Accept", "text/event-stream")
 
 	resp, err := c.httpClient.Do(httpReq)
@@ -150,7 +160,7 @@ func (c *Client) GetInteractionStream(ctx context.Context, interactionID string,
 	if err != nil {
 		return nil, fmt.Errorf("creating stream request: %w", err)
 	}
-	c.setHeaders(httpReq)
+	c.setHeaders(httpReq, false)
 	httpReq.Header.Set("Accept", "text/event-stream")
 
 	resp, err := c.httpClient.Do(httpReq)
@@ -185,7 +195,8 @@ func (c *Client) DeleteInteraction(ctx context.Context, interactionID string) er
 
 func (c *Client) do(ctx context.Context, method, path string, reqBody interface{}, respBody interface{}) error {
 	var bodyReader io.Reader
-	if reqBody != nil {
+	hasBody := reqBody != nil
+	if hasBody {
 		data, err := json.Marshal(reqBody)
 		if err != nil {
 			return fmt.Errorf("marshaling request: %w", err)
@@ -197,7 +208,7 @@ func (c *Client) do(ctx context.Context, method, path string, reqBody interface{
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
 	}
-	c.setHeaders(httpReq)
+	c.setHeaders(httpReq, hasBody)
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
@@ -218,13 +229,15 @@ func (c *Client) do(ctx context.Context, method, path string, reqBody interface{
 	return nil
 }
 
-func (c *Client) setHeaders(req *http.Request) {
+func (c *Client) setHeaders(req *http.Request, hasBody bool) {
 	req.Header.Set("x-goog-api-key", c.apiKey)
-	req.Header.Set("Content-Type", "application/json")
+	if hasBody {
+		req.Header.Set("Content-Type", "application/json")
+	}
 }
 
 func (c *Client) parseError(resp *http.Response) error {
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
 	if err != nil {
 		return fmt.Errorf("API error (status %d, failed to read body: %w)", resp.StatusCode, err)
 	}

--- a/pkg/managedagent/google/client.go
+++ b/pkg/managedagent/google/client.go
@@ -1,0 +1,238 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+const defaultBaseURL = "https://generativelanguage.googleapis.com/v1beta"
+
+// Client is a thin HTTP client for the Google Managed Agents API.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+// NewClient creates a new Google API client with the given API key.
+func NewClient(apiKey string) *Client {
+	return &Client{
+		baseURL:    defaultBaseURL,
+		apiKey:     apiKey,
+		httpClient: http.DefaultClient,
+	}
+}
+
+// CreateAgent creates a new managed agent configuration.
+func (c *Client) CreateAgent(ctx context.Context, req *CreateAgentRequest) (*Agent, error) {
+	var agent Agent
+	if err := c.do(ctx, http.MethodPost, "/agents", req, &agent); err != nil {
+		return nil, fmt.Errorf("creating agent: %w", err)
+	}
+	return &agent, nil
+}
+
+// GetAgent retrieves an agent by ID.
+func (c *Client) GetAgent(ctx context.Context, agentID string) (*Agent, error) {
+	var agent Agent
+	if err := c.do(ctx, http.MethodGet, "/agents/"+url.PathEscape(agentID), nil, &agent); err != nil {
+		return nil, fmt.Errorf("getting agent %q: %w", agentID, err)
+	}
+	return &agent, nil
+}
+
+// DeleteAgent deletes an agent by ID.
+func (c *Client) DeleteAgent(ctx context.Context, agentID string) error {
+	if err := c.do(ctx, http.MethodDelete, "/agents/"+url.PathEscape(agentID), nil, nil); err != nil {
+		return fmt.Errorf("deleting agent %q: %w", agentID, err)
+	}
+	return nil
+}
+
+// ListAgents lists agents with optional pagination.
+func (c *Client) ListAgents(ctx context.Context, pageSize int, pageToken string) (*ListAgentsResponse, error) {
+	path := "/agents"
+	params := url.Values{}
+	if pageSize > 0 {
+		params.Set("page_size", fmt.Sprintf("%d", pageSize))
+	}
+	if pageToken != "" {
+		params.Set("page_token", pageToken)
+	}
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	var resp ListAgentsResponse
+	if err := c.do(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, fmt.Errorf("listing agents: %w", err)
+	}
+	return &resp, nil
+}
+
+// CreateInteraction creates a new interaction (synchronous or background).
+func (c *Client) CreateInteraction(ctx context.Context, req *CreateInteractionRequest) (*Interaction, error) {
+	var interaction Interaction
+	if err := c.do(ctx, http.MethodPost, "/interactions", req, &interaction); err != nil {
+		return nil, fmt.Errorf("creating interaction: %w", err)
+	}
+	return &interaction, nil
+}
+
+// CreateInteractionStream creates a new streaming interaction and returns the
+// raw SSE response body. The caller is responsible for closing the returned reader.
+func (c *Client) CreateInteractionStream(ctx context.Context, req *CreateInteractionRequest) (io.ReadCloser, error) {
+	req.Stream = true
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/interactions", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	c.setHeaders(httpReq)
+	httpReq.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("executing streaming request: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
+		return nil, c.parseError(resp)
+	}
+
+	return resp.Body, nil
+}
+
+// GetInteraction retrieves an interaction by ID.
+func (c *Client) GetInteraction(ctx context.Context, interactionID string) (*Interaction, error) {
+	var interaction Interaction
+	if err := c.do(ctx, http.MethodGet, "/interactions/"+url.PathEscape(interactionID), nil, &interaction); err != nil {
+		return nil, fmt.Errorf("getting interaction %q: %w", interactionID, err)
+	}
+	return &interaction, nil
+}
+
+// GetInteractionStream opens an SSE stream for a running or completed interaction.
+// If lastEventID is non-empty, the stream resumes from that point.
+func (c *Client) GetInteractionStream(ctx context.Context, interactionID string, lastEventID string) (io.ReadCloser, error) {
+	params := url.Values{"stream": {"true"}}
+	if lastEventID != "" {
+		params.Set("last_event_id", lastEventID)
+	}
+	path := "/interactions/" + url.PathEscape(interactionID) + "?" + params.Encode()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating stream request: %w", err)
+	}
+	c.setHeaders(httpReq)
+	httpReq.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("opening interaction stream: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
+		return nil, c.parseError(resp)
+	}
+
+	return resp.Body, nil
+}
+
+// CancelInteraction cancels a running interaction.
+func (c *Client) CancelInteraction(ctx context.Context, interactionID string) error {
+	path := "/interactions/" + url.PathEscape(interactionID) + "/cancel"
+	if err := c.do(ctx, http.MethodPost, path, nil, nil); err != nil {
+		return fmt.Errorf("cancelling interaction %q: %w", interactionID, err)
+	}
+	return nil
+}
+
+// DeleteInteraction deletes a stored interaction.
+func (c *Client) DeleteInteraction(ctx context.Context, interactionID string) error {
+	if err := c.do(ctx, http.MethodDelete, "/interactions/"+url.PathEscape(interactionID), nil, nil); err != nil {
+		return fmt.Errorf("deleting interaction %q: %w", interactionID, err)
+	}
+	return nil
+}
+
+func (c *Client) do(ctx context.Context, method, path string, reqBody interface{}, respBody interface{}) error {
+	var bodyReader io.Reader
+	if reqBody != nil {
+		data, err := json.Marshal(reqBody)
+		if err != nil {
+			return fmt.Errorf("marshaling request: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	c.setHeaders(httpReq)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return c.parseError(resp)
+	}
+
+	if respBody != nil {
+		if err := json.NewDecoder(resp.Body).Decode(respBody); err != nil {
+			return fmt.Errorf("decoding response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) setHeaders(req *http.Request) {
+	req.Header.Set("x-goog-api-key", c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+}
+
+func (c *Client) parseError(resp *http.Response) error {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("API error (status %d, failed to read body: %w)", resp.StatusCode, err)
+	}
+
+	var apiErr APIError
+	if err := json.Unmarshal(body, &apiErr); err == nil && apiErr.Error.Message != "" {
+		return fmt.Errorf("API error %d (%s): %s", apiErr.Error.Code, apiErr.Error.Status, apiErr.Error.Message)
+	}
+
+	return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+}

--- a/pkg/managedagent/google/sse.go
+++ b/pkg/managedagent/google/sse.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// SSE event type constants from the Google Managed Agents API.
+const (
+	EventInteractionCreated    = "interaction.created"
+	EventInteractionCompleted  = "interaction.completed"
+	EventInteractionStatusUpdate = "interaction.status_update"
+	EventStepStart             = "step.start"
+	EventStepDelta             = "step.delta"
+	EventStepStop              = "step.stop"
+	EventError                 = "error"
+	EventDone                  = "done"
+)
+
+// SSEEvent represents a parsed Server-Sent Event.
+type SSEEvent struct {
+	Type string
+	ID   string
+	Data json.RawMessage
+}
+
+// SSEReader reads and parses Server-Sent Events from an io.Reader.
+type SSEReader struct {
+	scanner *bufio.Scanner
+}
+
+// NewSSEReader creates a new SSE parser that reads from r.
+func NewSSEReader(r io.Reader) *SSEReader {
+	return &SSEReader{
+		scanner: bufio.NewScanner(r),
+	}
+}
+
+// Next reads the next SSE event from the stream. Returns io.EOF when
+// the stream ends or a "done" event is received.
+func (r *SSEReader) Next() (*SSEEvent, error) {
+	var event SSEEvent
+	var dataLines []string
+	hasFields := false
+
+	for r.scanner.Scan() {
+		line := r.scanner.Text()
+
+		if line == "" {
+			if !hasFields {
+				continue
+			}
+			if len(dataLines) > 0 {
+				event.Data = json.RawMessage(strings.Join(dataLines, "\n"))
+			}
+			if event.Type == EventDone {
+				return nil, io.EOF
+			}
+			return &event, nil
+		}
+
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+
+		field, value, _ := strings.Cut(line, ":")
+		value = strings.TrimPrefix(value, " ")
+		hasFields = true
+
+		switch field {
+		case "event":
+			event.Type = value
+		case "data":
+			dataLines = append(dataLines, value)
+		case "id":
+			event.ID = value
+		}
+	}
+
+	if err := r.scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading SSE stream: %w", err)
+	}
+
+	if hasFields {
+		if len(dataLines) > 0 {
+			event.Data = json.RawMessage(strings.Join(dataLines, "\n"))
+		}
+		return &event, nil
+	}
+
+	return nil, io.EOF
+}
+
+// ParseStepStart parses the data payload of a step.start event.
+func ParseStepStart(data json.RawMessage) (*StepStartEvent, error) {
+	var e StepStartEvent
+	if err := json.Unmarshal(data, &e); err != nil {
+		return nil, fmt.Errorf("parsing step.start: %w", err)
+	}
+	return &e, nil
+}
+
+// ParseStepDelta parses the data payload of a step.delta event.
+func ParseStepDelta(data json.RawMessage) (*StepDeltaEvent, error) {
+	var e StepDeltaEvent
+	if err := json.Unmarshal(data, &e); err != nil {
+		return nil, fmt.Errorf("parsing step.delta: %w", err)
+	}
+	return &e, nil
+}
+
+// ParseInteraction parses the data payload of interaction.created or
+// interaction.completed events.
+func ParseInteraction(data json.RawMessage) (*Interaction, error) {
+	var i Interaction
+	if err := json.Unmarshal(data, &i); err != nil {
+		return nil, fmt.Errorf("parsing interaction: %w", err)
+	}
+	return &i, nil
+}

--- a/pkg/managedagent/google/sse.go
+++ b/pkg/managedagent/google/sse.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"strings"
 )
 
@@ -91,6 +92,8 @@ func (r *SSEReader) Next() (*SSEEvent, error) {
 			dataLines = append(dataLines, value)
 		case "id":
 			event.ID = value
+		case "retry":
+			log.Printf("SSE: server sent retry: %s (ignored)", value)
 		}
 	}
 

--- a/pkg/managedagent/google/sse.go
+++ b/pkg/managedagent/google/sse.go
@@ -25,14 +25,14 @@ import (
 
 // SSE event type constants from the Google Managed Agents API.
 const (
-	EventInteractionCreated    = "interaction.created"
-	EventInteractionCompleted  = "interaction.completed"
+	EventInteractionCreated      = "interaction.created"
+	EventInteractionCompleted    = "interaction.completed"
 	EventInteractionStatusUpdate = "interaction.status_update"
-	EventStepStart             = "step.start"
-	EventStepDelta             = "step.delta"
-	EventStepStop              = "step.stop"
-	EventError                 = "error"
-	EventDone                  = "done"
+	EventStepStart               = "step.start"
+	EventStepDelta               = "step.delta"
+	EventStepStop                = "step.stop"
+	EventError                   = "error"
+	EventDone                    = "done"
 )
 
 // SSEEvent represents a parsed Server-Sent Event.

--- a/pkg/managedagent/google/sse.go
+++ b/pkg/managedagent/google/sse.go
@@ -43,15 +43,34 @@ type SSEEvent struct {
 }
 
 // SSEReader reads and parses Server-Sent Events from an io.Reader.
+// It uses bufio.Reader internally so that Buffered() can be called to
+// retrieve any data read-ahead from the underlying stream.
 type SSEReader struct {
-	scanner *bufio.Scanner
+	br *bufio.Reader
 }
 
 // NewSSEReader creates a new SSE parser that reads from r.
 func NewSSEReader(r io.Reader) *SSEReader {
 	return &SSEReader{
-		scanner: bufio.NewScanner(r),
+		br: bufio.NewReader(r),
 	}
+}
+
+// Buffered returns the number of bytes buffered but not yet consumed.
+func (r *SSEReader) Buffered() int {
+	return r.br.Buffered()
+}
+
+// BufferedReader returns the underlying bufio.Reader. Use this to
+// recover any read-ahead data after consuming specific events.
+func (r *SSEReader) BufferedReader() *bufio.Reader {
+	return r.br
+}
+
+func (r *SSEReader) readLine() (string, error) {
+	line, err := r.br.ReadString('\n')
+	line = strings.TrimRight(line, "\r\n")
+	return line, err
 }
 
 // Next reads the next SSE event from the stream. Returns io.EOF when
@@ -61,8 +80,21 @@ func (r *SSEReader) Next() (*SSEEvent, error) {
 	var dataLines []string
 	hasFields := false
 
-	for r.scanner.Scan() {
-		line := r.scanner.Text()
+	for {
+		line, err := r.readLine()
+
+		if line == "" && err != nil {
+			if hasFields {
+				if len(dataLines) > 0 {
+					event.Data = json.RawMessage(strings.Join(dataLines, "\n"))
+				}
+				return &event, nil
+			}
+			if err == io.EOF {
+				return nil, io.EOF
+			}
+			return nil, fmt.Errorf("reading SSE stream: %w", err)
+		}
 
 		if line == "" {
 			if !hasFields {
@@ -95,20 +127,14 @@ func (r *SSEReader) Next() (*SSEEvent, error) {
 		case "retry":
 			log.Printf("SSE: server sent retry: %s (ignored)", value)
 		}
-	}
 
-	if err := r.scanner.Err(); err != nil {
-		return nil, fmt.Errorf("reading SSE stream: %w", err)
-	}
-
-	if hasFields {
-		if len(dataLines) > 0 {
-			event.Data = json.RawMessage(strings.Join(dataLines, "\n"))
+		if err != nil {
+			if len(dataLines) > 0 {
+				event.Data = json.RawMessage(strings.Join(dataLines, "\n"))
+			}
+			return &event, nil
 		}
-		return &event, nil
 	}
-
-	return nil, io.EOF
 }
 
 // ParseStepStart parses the data payload of a step.start event.

--- a/pkg/managedagent/google/types.go
+++ b/pkg/managedagent/google/types.go
@@ -89,19 +89,19 @@ type InteractionStep struct {
 
 // InteractionUsage contains token usage statistics.
 type InteractionUsage struct {
-	TotalInputTokens  int `json:"total_input_tokens"`
-	TotalOutputTokens int `json:"total_output_tokens"`
-	TotalCachedTokens int `json:"total_cached_tokens,omitempty"`
+	TotalInputTokens   int `json:"total_input_tokens"`
+	TotalOutputTokens  int `json:"total_output_tokens"`
+	TotalCachedTokens  int `json:"total_cached_tokens,omitempty"`
 	TotalThoughtTokens int `json:"total_thought_tokens,omitempty"`
 	TotalToolUseTokens int `json:"total_tool_use_tokens,omitempty"`
-	TotalTokens       int `json:"total_tokens"`
+	TotalTokens        int `json:"total_tokens"`
 }
 
 // Environment describes the execution environment configuration.
 type Environment struct {
-	Type    string          `json:"type,omitempty"`
-	Sources []SourceConfig  `json:"sources,omitempty"`
-	Network *NetworkConfig  `json:"network,omitempty"`
+	Type    string         `json:"type,omitempty"`
+	Sources []SourceConfig `json:"sources,omitempty"`
+	Network *NetworkConfig `json:"network,omitempty"`
 }
 
 // SourceConfig describes a source to mount into the environment.

--- a/pkg/managedagent/google/types.go
+++ b/pkg/managedagent/google/types.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+// CreateAgentRequest is the request body for POST /v1beta/agents.
+type CreateAgentRequest struct {
+	ID                string       `json:"id"`
+	BaseAgent         string       `json:"base_agent"`
+	SystemInstruction string       `json:"system_instruction,omitempty"`
+	Description       string       `json:"description,omitempty"`
+	Tools             []AgentTool  `json:"tools,omitempty"`
+	BaseEnvironment   *Environment `json:"base_environment,omitempty"`
+}
+
+// Agent is the response resource from the Agents API.
+type Agent struct {
+	ID                string       `json:"id"`
+	BaseAgent         string       `json:"base_agent"`
+	SystemInstruction string       `json:"system_instruction,omitempty"`
+	Description       string       `json:"description,omitempty"`
+	Tools             []AgentTool  `json:"tools,omitempty"`
+	BaseEnvironment   *Environment `json:"base_environment,omitempty"`
+}
+
+// AgentTool describes a tool available to the agent.
+type AgentTool struct {
+	Type       string                 `json:"type"`
+	Name       string                 `json:"name,omitempty"`
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+}
+
+// ListAgentsResponse is the response body for GET /v1beta/agents.
+type ListAgentsResponse struct {
+	Agents        []Agent `json:"agents"`
+	NextPageToken string  `json:"next_page_token,omitempty"`
+}
+
+// CreateInteractionRequest is the request body for POST /v1beta/interactions.
+type CreateInteractionRequest struct {
+	Agent                 string       `json:"agent,omitempty"`
+	Model                 string       `json:"model,omitempty"`
+	Input                 string       `json:"input"`
+	SystemInstruction     string       `json:"system_instruction,omitempty"`
+	Tools                 []AgentTool  `json:"tools,omitempty"`
+	Environment           *Environment `json:"environment,omitempty"`
+	PreviousInteractionID string       `json:"previous_interaction_id,omitempty"`
+	Stream                bool         `json:"stream,omitempty"`
+	Background            bool         `json:"background,omitempty"`
+	Store                 *bool        `json:"store,omitempty"`
+}
+
+// Interaction is the response resource from the Interactions API.
+type Interaction struct {
+	ID            string            `json:"id"`
+	Agent         string            `json:"agent,omitempty"`
+	Model         string            `json:"model,omitempty"`
+	Status        string            `json:"status"`
+	Steps         []InteractionStep `json:"steps,omitempty"`
+	OutputText    string            `json:"output_text,omitempty"`
+	EnvironmentID string            `json:"environment_id,omitempty"`
+	Usage         *InteractionUsage `json:"usage,omitempty"`
+}
+
+// InteractionStep is a single step in an interaction's execution.
+type InteractionStep struct {
+	Type           string `json:"type"`
+	Text           string `json:"text,omitempty"`
+	ArgumentsDelta string `json:"arguments_delta,omitempty"`
+	ToolName       string `json:"tool_name,omitempty"`
+}
+
+// InteractionUsage contains token usage statistics.
+type InteractionUsage struct {
+	TotalInputTokens  int `json:"total_input_tokens"`
+	TotalOutputTokens int `json:"total_output_tokens"`
+	TotalCachedTokens int `json:"total_cached_tokens,omitempty"`
+	TotalThoughtTokens int `json:"total_thought_tokens,omitempty"`
+	TotalToolUseTokens int `json:"total_tool_use_tokens,omitempty"`
+	TotalTokens       int `json:"total_tokens"`
+}
+
+// Environment describes the execution environment configuration.
+type Environment struct {
+	Type    string          `json:"type,omitempty"`
+	Sources []SourceConfig  `json:"sources,omitempty"`
+	Network *NetworkConfig  `json:"network,omitempty"`
+}
+
+// SourceConfig describes a source to mount into the environment.
+type SourceConfig struct {
+	Type   string `json:"type"`
+	URI    string `json:"uri,omitempty"`
+	Branch string `json:"branch,omitempty"`
+	Path   string `json:"path,omitempty"`
+}
+
+// NetworkConfig describes network access rules.
+type NetworkConfig struct {
+	Disabled  bool             `json:"disabled,omitempty"`
+	Allowlist []AllowlistEntry `json:"allowlist,omitempty"`
+}
+
+// AllowlistEntry is a domain and optional header injection for egress.
+type AllowlistEntry struct {
+	Domain  string            `json:"domain"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+// InteractionEvent is the envelope for an SSE event from the streaming API.
+type InteractionEvent struct {
+	Type string      `json:"type"`
+	Data interface{} `json:"data,omitempty"`
+}
+
+// StepDeltaEvent is the data payload for step.delta SSE events.
+type StepDeltaEvent struct {
+	Type           string `json:"type,omitempty"`
+	Text           string `json:"text,omitempty"`
+	ArgumentsDelta string `json:"arguments_delta,omitempty"`
+}
+
+// StepStartEvent is the data payload for step.start SSE events.
+type StepStartEvent struct {
+	Type     string `json:"type"`
+	ToolName string `json:"tool_name,omitempty"`
+}
+
+// APIError is an error response from the Google API.
+type APIError struct {
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Status  string `json:"status"`
+	} `json:"error"`
+}

--- a/pkg/managedagent/google/types.go
+++ b/pkg/managedagent/google/types.go
@@ -124,12 +124,6 @@ type AllowlistEntry struct {
 	Headers map[string]string `json:"headers,omitempty"`
 }
 
-// InteractionEvent is the envelope for an SSE event from the streaming API.
-type InteractionEvent struct {
-	Type string      `json:"type"`
-	Data interface{} `json:"data,omitempty"`
-}
-
 // StepDeltaEvent is the data payload for step.delta SSE events.
 type StepDeltaEvent struct {
 	Type           string `json:"type,omitempty"`

--- a/pkg/managedagent/google/types.go
+++ b/pkg/managedagent/google/types.go
@@ -15,13 +15,15 @@
 package google
 
 // CreateAgentRequest is the request body for POST /v1beta/agents.
+// BaseEnvironment is polymorphic: a string ("remote" or an environment ID)
+// or an *Environment config object.
 type CreateAgentRequest struct {
-	ID                string       `json:"id"`
-	BaseAgent         string       `json:"base_agent"`
-	SystemInstruction string       `json:"system_instruction,omitempty"`
-	Description       string       `json:"description,omitempty"`
-	Tools             []AgentTool  `json:"tools,omitempty"`
-	BaseEnvironment   *Environment `json:"base_environment,omitempty"`
+	ID                string      `json:"id"`
+	BaseAgent         string      `json:"base_agent"`
+	SystemInstruction string      `json:"system_instruction,omitempty"`
+	Description       string      `json:"description,omitempty"`
+	Tools             []AgentTool `json:"tools,omitempty"`
+	BaseEnvironment   interface{} `json:"base_environment,omitempty"`
 }
 
 // Agent is the response resource from the Agents API.
@@ -48,17 +50,19 @@ type ListAgentsResponse struct {
 }
 
 // CreateInteractionRequest is the request body for POST /v1beta/interactions.
+// Environment is polymorphic: a string ("remote" or an environment ID)
+// or an *Environment config object.
 type CreateInteractionRequest struct {
-	Agent                 string       `json:"agent,omitempty"`
-	Model                 string       `json:"model,omitempty"`
-	Input                 string       `json:"input"`
-	SystemInstruction     string       `json:"system_instruction,omitempty"`
-	Tools                 []AgentTool  `json:"tools,omitempty"`
-	Environment           *Environment `json:"environment,omitempty"`
-	PreviousInteractionID string       `json:"previous_interaction_id,omitempty"`
-	Stream                bool         `json:"stream,omitempty"`
-	Background            bool         `json:"background,omitempty"`
-	Store                 *bool        `json:"store,omitempty"`
+	Agent                 string      `json:"agent,omitempty"`
+	Model                 string      `json:"model,omitempty"`
+	Input                 string      `json:"input"`
+	SystemInstruction     string      `json:"system_instruction,omitempty"`
+	Tools                 []AgentTool `json:"tools,omitempty"`
+	Environment           interface{} `json:"environment,omitempty"`
+	PreviousInteractionID string      `json:"previous_interaction_id,omitempty"`
+	Stream                bool        `json:"stream,omitempty"`
+	Background            bool        `json:"background,omitempty"`
+	Store                 *bool       `json:"store,omitempty"`
 }
 
 // Interaction is the response resource from the Interactions API.
@@ -74,9 +78,11 @@ type Interaction struct {
 }
 
 // InteractionStep is a single step in an interaction's execution.
+// Arguments appears in polled responses; ArgumentsDelta in streaming deltas.
 type InteractionStep struct {
 	Type           string `json:"type"`
 	Text           string `json:"text,omitempty"`
+	Arguments      string `json:"arguments,omitempty"`
 	ArgumentsDelta string `json:"arguments_delta,omitempty"`
 	ToolName       string `json:"tool_name,omitempty"`
 }

--- a/pkg/managedagent/types.go
+++ b/pkg/managedagent/types.go
@@ -27,8 +27,11 @@ type CreateAgentConfig struct {
 }
 
 // InteractionRequest contains the parameters for creating an interaction.
+// Either CloudAgentID or AgentName should be set; AgentName is the base
+// agent identifier used when no cloud-side agent config exists.
 type InteractionRequest struct {
 	CloudAgentID          string
+	AgentName             string
 	Input                 string
 	PreviousInteractionID string
 	EnvironmentID         string

--- a/pkg/managedagent/types.go
+++ b/pkg/managedagent/types.go
@@ -32,6 +32,7 @@ type CreateAgentConfig struct {
 type InteractionRequest struct {
 	CloudAgentID          string
 	AgentName             string
+	Model                 string
 	Input                 string
 	PreviousInteractionID string
 	EnvironmentID         string

--- a/pkg/managedagent/types.go
+++ b/pkg/managedagent/types.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedagent
+
+import "io"
+
+// CreateAgentConfig contains the parameters for creating a managed agent.
+type CreateAgentConfig struct {
+	ID                string
+	BaseAgent         string
+	SystemInstruction string
+	Description       string
+	Tools             []ToolConfig
+	Environment       *EnvironmentConfig
+}
+
+// InteractionRequest contains the parameters for creating an interaction.
+type InteractionRequest struct {
+	CloudAgentID          string
+	Input                 string
+	PreviousInteractionID string
+	EnvironmentID         string
+	Environment           *EnvironmentConfig
+	Stream                bool
+	Background            bool
+	Tools                 []ToolConfig
+	SystemInstruction     string
+}
+
+// InteractionHandle represents a running or completed interaction.
+type InteractionHandle struct {
+	InteractionID string
+	EnvironmentID string
+	Status        InteractionStatus
+	Steps         []Step
+	OutputText    string
+	Usage         *UsageInfo
+	EventStream   io.ReadCloser
+}
+
+// InteractionState is the polled state of an interaction.
+type InteractionState struct {
+	InteractionID string
+	Status        InteractionStatus
+	Steps         []Step
+	OutputText    string
+	EnvironmentID string
+	Usage         *UsageInfo
+}
+
+// InteractionStatus represents the status of an interaction.
+type InteractionStatus string
+
+const (
+	StatusInProgress     InteractionStatus = "in_progress"
+	StatusRequiresAction InteractionStatus = "requires_action"
+	StatusCompleted      InteractionStatus = "completed"
+	StatusFailed         InteractionStatus = "failed"
+	StatusCancelled      InteractionStatus = "cancelled"
+	StatusIncomplete     InteractionStatus = "incomplete"
+)
+
+// Step represents a single step in an interaction.
+type Step struct {
+	Type      string
+	Text      string
+	Arguments string
+	ToolName  string
+}
+
+// ToolConfig defines a tool available to the agent.
+type ToolConfig struct {
+	Type       string
+	Name       string
+	Parameters map[string]interface{}
+}
+
+// EnvironmentConfig describes the execution environment for a managed agent.
+type EnvironmentConfig struct {
+	Type    string
+	Sources []SourceConfig
+	Network *NetworkConfig
+}
+
+// SourceConfig describes a source to mount into the agent environment.
+type SourceConfig struct {
+	Type   string
+	URI    string
+	Branch string
+	Path   string
+}
+
+// NetworkConfig describes network access rules for the agent environment.
+type NetworkConfig struct {
+	Disabled  bool
+	Allowlist []AllowlistEntry
+}
+
+// AllowlistEntry is a domain and optional header injection for egress rules.
+type AllowlistEntry struct {
+	Domain  string
+	Headers map[string]string
+}
+
+// UsageInfo contains token usage statistics for an interaction.
+type UsageInfo struct {
+	TotalInputTokens  int
+	TotalOutputTokens int
+	TotalTokens       int
+}


### PR DESCRIPTION
## Summary
- Introduces ManagedAgent as a peer concept to Runtime+Harness (Option B) for cloud-hosted agent backends
- Adds Google Managed Agents API (Gemini API) as first backend implementation
- Custom HTTP client for Agents API + Interactions API with SSE streaming
- ManagedAgentManager implementing the Manager interface for hub-direct integration
- Design doc committed to .design/managed-agents.md

## Details
- 8 commits, 18 files, ~2,840 lines
- pkg/managedagent/ — backend interface, Google API client, SSE parser
- pkg/agent/managed_manager, managed_state, manager_factory + settings types
- Hub-direct integration, CLI changes, agent listing for managed agents