### PR TITLE
Make SCION_FORCE_HOST_NETWORK escape hatch runtime-agnostic

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -688,13 +688,13 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		delete(opts.Env, "SCION_AUTH_TOKEN")
 	}
 
-	// Resolve Docker host networking: when the hub endpoint is localhost or was
+	// Resolve host networking: when the hub endpoint is localhost or was
 	// translated to host.docker.internal, use --network=host so the container
 	// can reach the host's loopback interface directly. This also rewrites any
 	// bridge hostnames back to localhost in opts.Env.
-	dockerNetworkMode := runtime.ResolveDockerNetworking(m.Runtime.Name(), opts.Env)
-	if dockerNetworkMode != "" {
-		opts.Env["SCION_NETWORK_MODE"] = dockerNetworkMode
+	networkMode := runtime.ResolveHostNetworking(m.Runtime.Name(), opts.Env)
+	if networkMode != "" {
+		opts.Env["SCION_NETWORK_MODE"] = networkMode
 	}
 
 	// Persist harness auth override to scion-agent.json so sciontool inside the container sees it.
@@ -919,7 +919,7 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		Resume:               opts.Resume,
 		MetadataInterception: hasMetadataInterception(agentEnv),
 		ExtraHosts:           mergeExtraHosts(opts.ExtraHosts, runtime.BridgeExtraHosts(m.Runtime.Name(), agentEnv)),
-		NetworkMode:          dockerNetworkMode,
+		NetworkMode:          networkMode,
 		Labels: func() map[string]string {
 			l := map[string]string{
 				"scion.agent":          "true",

--- a/pkg/agent/run_metadata_test.go
+++ b/pkg/agent/run_metadata_test.go
@@ -24,7 +24,7 @@ import (
 // container's RunConfig.NetworkMode and ExtraHosts (run.go:672, 891-892) for a
 // colocated Docker agent. The broker supplies the public-domain host-gateway
 // mapping via opts.ExtraHosts (from colocatedExtraHosts); the agent path
-// derives NetworkMode from ResolveDockerNetworking and merges BridgeExtraHosts.
+// derives NetworkMode from ResolveHostNetworking and merges BridgeExtraHosts.
 func TestColocatedDockerNetworkComposition(t *testing.T) {
 	const domainHostGateway = "hub.example.com:host-gateway"
 
@@ -52,7 +52,7 @@ func TestColocatedDockerNetworkComposition(t *testing.T) {
 			wantExtraHosts: []string{domainHostGateway},
 		},
 		{
-			// Legacy fallback: ResolveDockerNetworking rewrites the bridge
+			// Legacy fallback: ResolveHostNetworking rewrites the bridge
 			// hostname back to localhost (reachable under host networking), so
 			// by the time agentEnv is built no host-gateway add-host is needed.
 			name:           "host.docker.internal fallback uses host networking",
@@ -69,7 +69,7 @@ func TestColocatedDockerNetworkComposition(t *testing.T) {
 				t.Setenv(runtime.ForceHostNetworkEnvVar, "1")
 			}
 			env := map[string]string{"SCION_HUB_ENDPOINT": tt.hubEndpoint}
-			gotMode := runtime.ResolveDockerNetworking("docker", env)
+			gotMode := runtime.ResolveHostNetworking("docker", env)
 			if gotMode != tt.wantNetMode {
 				t.Errorf("NetworkMode = %q, want %q", gotMode, tt.wantNetMode)
 			}

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -610,22 +610,20 @@ func forceHostNetworking() bool {
 	return os.Getenv(ForceHostNetworkEnvVar) != ""
 }
 
-// ResolveDockerNetworking checks whether Docker host networking should be used
-// to allow containers to reach services on the host's loopback interface.
-// When the hub endpoint is localhost or was translated to a Docker bridge
-// hostname (host.docker.internal), it returns "host" and rewrites any bridge
-// hostnames back to localhost in the env map. This avoids the need for the
-// server to bind to 0.0.0.0.
+// ResolveHostNetworking reports whether a container should use host networking
+// to reach services on the host's loopback interface, returning "host" (the
+// network mode) or "" (no override). When the hub endpoint is localhost or was
+// translated to a bridge hostname (host.docker.internal), it returns "host" and
+// rewrites any bridge hostnames back to localhost in the env map. This avoids
+// the need for the server to bind to 0.0.0.0.
 //
 // When the SCION_FORCE_HOST_NETWORK escape hatch is set, host networking is
-// forced regardless of the endpoint, reverting to the legacy behavior.
+// forced for any runtime whenever a hub endpoint is configured, reverting to
+// the legacy behavior.
 //
-// For non-Docker runtimes or non-localhost endpoints, returns "" (no override).
-func ResolveDockerNetworking(runtimeName string, env map[string]string) string {
-	if runtimeName != "docker" {
-		return ""
-	}
-
+// For non-Docker runtimes (absent the escape hatch) or non-localhost endpoints,
+// returns "" (no override).
+func ResolveHostNetworking(runtimeName string, env map[string]string) string {
 	ep := env["SCION_HUB_ENDPOINT"]
 	if ep == "" {
 		ep = env["SCION_HUB_URL"]
@@ -634,11 +632,17 @@ func ResolveDockerNetworking(runtimeName string, env map[string]string) string {
 		return ""
 	}
 
-	// Escape hatch: force host networking regardless of endpoint so a
-	// deployment can revert to the legacy behavior without a redeploy.
+	// Escape hatch: force host networking regardless of the endpoint value, for
+	// any runtime, so a deployment can revert to the legacy behavior without a
+	// redeploy. Runtime-agnostic, so evaluated before the Docker-only endpoint
+	// heuristics below.
 	if forceHostNetworking() {
 		rewriteBridgeHostToLocalhost(env)
 		return "host"
+	}
+
+	if runtimeName != "docker" {
+		return ""
 	}
 
 	// If endpoint uses the Docker bridge hostname (translated from localhost),
@@ -667,7 +671,10 @@ func ResolveDockerNetworking(runtimeName string, env map[string]string) string {
 func rewriteBridgeHostToLocalhost(env map[string]string) {
 	for _, key := range []string{"SCION_HUB_ENDPOINT", "SCION_HUB_URL"} {
 		if v, ok := env[key]; ok {
-			env[key] = strings.Replace(v, "host.docker.internal", "localhost", 1)
+			v = strings.Replace(v, "host.docker.internal", "localhost", 1)
+			// host.containers.internal does not resolve under --network=host.
+			v = strings.Replace(v, "host.containers.internal", "localhost", 1)
+			env[key] = v
 		}
 	}
 }

--- a/pkg/runtime/common_test.go
+++ b/pkg/runtime/common_test.go
@@ -1227,6 +1227,17 @@ func TestResolveHostNetworking(t *testing.T) {
 			wantEP:    "http://localhost:8080",
 		},
 		{
+			name:        "force-host with podman bridge hostname rewrites to localhost",
+			runtimeName: "podman",
+			env: map[string]string{
+				"SCION_HUB_ENDPOINT": "http://host.containers.internal:8080",
+				"SCION_HUB_URL":      "http://host.containers.internal:8080",
+			},
+			forceHost: true,
+			wantMode:  "host",
+			wantEP:    "http://localhost:8080",
+		},
+		{
 			name:        "force-host with no endpoint yields no override",
 			runtimeName: "docker",
 			env:         map[string]string{},

--- a/pkg/runtime/common_test.go
+++ b/pkg/runtime/common_test.go
@@ -1117,7 +1117,7 @@ func TestBridgeExtraHosts(t *testing.T) {
 	}
 }
 
-func TestResolveDockerNetworking(t *testing.T) {
+func TestResolveHostNetworking(t *testing.T) {
 	tests := []struct {
 		name        string
 		runtimeName string
@@ -1217,18 +1217,25 @@ func TestResolveDockerNetworking(t *testing.T) {
 			wantEP:    "http://localhost:8080",
 		},
 		{
-			name:        "force-host ignored for non-docker",
+			name:        "force-host applies to non-docker",
 			runtimeName: "podman",
 			env: map[string]string{
 				"SCION_HUB_ENDPOINT": "http://localhost:8080",
 			},
 			forceHost: true,
-			wantMode:  "",
+			wantMode:  "host",
 			wantEP:    "http://localhost:8080",
 		},
 		{
 			name:        "force-host with no endpoint yields no override",
 			runtimeName: "docker",
+			env:         map[string]string{},
+			forceHost:   true,
+			wantMode:    "",
+		},
+		{
+			name:        "force-host with no endpoint yields no override (non-docker)",
+			runtimeName: "podman",
 			env:         map[string]string{},
 			forceHost:   true,
 			wantMode:    "",
@@ -1246,9 +1253,9 @@ func TestResolveDockerNetworking(t *testing.T) {
 				env[k] = v
 			}
 
-			got := ResolveDockerNetworking(tt.runtimeName, env)
+			got := ResolveHostNetworking(tt.runtimeName, env)
 			if got != tt.wantMode {
-				t.Errorf("ResolveDockerNetworking(%q) = %q, want %q", tt.runtimeName, got, tt.wantMode)
+				t.Errorf("ResolveHostNetworking(%q) = %q, want %q", tt.runtimeName, got, tt.wantMode)
 			}
 			if tt.wantEP != "" {
 				if ep := env["SCION_HUB_ENDPOINT"]; ep != tt.wantEP {


### PR DESCRIPTION
Hey all,

Ive been using `podman`, and a `podman` container running with restricted egress can't reach `host.containers.internal` and needs host networking to reach a hub on the loopback.

The issue is, `ResolveDockerNetworking` returned early for non-Docker runtimes (ie podman) before the `SCION_FORCE_HOST_NETWORK` escape hatch is checked, so the override is only restpected for Docker. 

This patch changes it to evaluate it first (as a "force host networking" override is conceptually runtime-agnostic).  force-host now applies to non-Docker runtimes when a hub endpoint is configured. The no-endpoint case still yields no override for every runtime.

Extra notes from Claude Code on the implementation: 

```
It also `rewrites host.containers.internal` → `localhost` alongside the existing `host.docker.internal` rewrite, since that alias doesn't resolve under `--network=host`. (`BridgeExtraHosts` notes podman resolves it natively — true for bridge networking, but not under `--network=host`.)

No behaviour change when `SCION_FORCE_HOST_NETWORK` is unset.
```

I'm not a Go dev, so forgive me if this patch is missing something key. Thanks for Scion, its really great!

- [x] Tests pass
