### PR TITLE
feat: chat integration admin API endpoints (Phase 2)

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1249,6 +1249,7 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 		return nil, fmt.Errorf("hub server initialization failed: %w", err)
 	}
 	hubSrv.SetRequestLogger(requestLogger)
+	hubSrv.SetPluginManager(pluginMgr)
 	if messageLogger != nil {
 		hubSrv.SetMessageLogger(messageLogger)
 	}

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2039,26 +2039,6 @@ func resolveMaintenanceConfig(cfg *config.GlobalConfig) hub.MaintenanceConfig {
 	return mc
 }
 
-// pluginSecretKeyMap maps plugin names to their well-known secret keys and
-// the corresponding plugin config keys. Each entry maps a secret backend key
-// to the config key that the plugin's Configure() expects.
-var pluginSecretKeyMap = map[string][]struct {
-	secretKey string
-	configKey string
-}{
-	"telegram": {
-		{config.SecretTelegramBotToken, "bot_token"},
-		{config.SecretTelegramWebhookKey, "webhook_secret"},
-	},
-	"discord": {
-		{config.SecretDiscordBotToken, "bot_token"},
-		{config.SecretDiscordPublicKey, "public_key"},
-	},
-	"chat-app": {
-		{config.SecretGChatSigningKey, "signing_key"},
-	},
-}
-
 // injectPluginSecrets loads chat integration secrets from the secret backend
 // and injects them into the extra credentials map. Respects the fallback chain:
 // if the plugin's merged config (file + inline) already has a value for a key,
@@ -2068,21 +2048,21 @@ func injectPluginSecrets(ctx context.Context, sb secret.SecretBackend, pluginNam
 		return
 	}
 
-	mappings, ok := pluginSecretKeyMap[pluginName]
+	mappings, ok := config.PluginSecretKeyMap[pluginName]
 	if !ok {
 		return
 	}
 
 	hubID := sb.HubID()
 	for _, m := range mappings {
-		if existing, ok := pluginConfig[m.configKey]; ok && existing != "" {
+		if existing, ok := pluginConfig[m.ConfigKey]; ok && existing != "" {
 			continue
 		}
-		sv, err := sb.Get(ctx, m.secretKey, store.ScopeHub, hubID)
+		sv, err := sb.Get(ctx, m.SecretKey, store.ScopeHub, hubID)
 		if err != nil || sv == nil || sv.Value == "" {
 			continue
 		}
-		creds[m.configKey] = sv.Value
-		slog.Info("Injected secret into broker plugin", "secret", m.secretKey, "plugin", pluginName, "config_key", m.configKey)
+		creds[m.ConfigKey] = sv.Value
+		slog.Info("Injected secret into broker plugin", "secret", m.SecretKey, "plugin", pluginName, "config_key", m.ConfigKey)
 	}
 }

--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -129,6 +129,29 @@ func (p *YAMLConfigProvider) Save(config map[string]string) error {
 	return os.WriteFile(p.path, data, 0600)
 }
 
+// IntegrationSecretMapping maps a secret backend key to the config key that a
+// plugin's Configure() method expects.
+type IntegrationSecretMapping struct {
+	SecretKey string
+	ConfigKey string
+}
+
+// PluginSecretKeyMap maps plugin names to their well-known secret keys and the
+// corresponding plugin config keys.
+var PluginSecretKeyMap = map[string][]IntegrationSecretMapping{
+	"telegram": {
+		{SecretTelegramBotToken, "bot_token"},
+		{SecretTelegramWebhookKey, "webhook_secret"},
+	},
+	"discord": {
+		{SecretDiscordBotToken, "bot_token"},
+		{SecretDiscordPublicKey, "public_key"},
+	},
+	"chat-app": {
+		{SecretGChatSigningKey, "signing_key"},
+	},
+}
+
 // LoadPluginConfigFile reads a standalone YAML config file for a plugin and
 // returns its contents merged with any existing inline config. The inline
 // config takes precedence (allows overrides). Secret keys are excluded from

--- a/pkg/hub/handlers_chat_secrets.go
+++ b/pkg/hub/handlers_chat_secrets.go
@@ -74,6 +74,9 @@ func (s *Server) LoadChatIntegrationSecret(ctx context.Context, name string) (st
 		return sv.Value, nil
 	}
 
+	if s.store == nil {
+		return "", nil
+	}
 	return s.store.GetSecretValue(ctx, name, store.ScopeHub, s.hubID)
 }
 
@@ -85,6 +88,9 @@ func (s *Server) HasChatIntegrationSecret(ctx context.Context, name string) bool
 		return err == nil && meta != nil
 	}
 
+	if s.store == nil {
+		return false
+	}
 	val, err := s.store.GetSecretValue(ctx, name, store.ScopeHub, s.hubID)
 	return err == nil && val != ""
 }

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -1,0 +1,504 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// IntegrationManager is the narrow interface satisfied by *plugin.Manager.
+// It lets the hub query and control broker plugins without importing the
+// plugin package directly.
+type IntegrationManager interface {
+	ListPlugins() []string
+	HasPlugin(pluginType, name string) bool
+	GetPluginConfig(pluginType, name string) map[string]string
+	IsSelfManaged(pluginType, name string) bool
+	ConfigureBroker(name string, extra map[string]string) error
+	Reconnect(pluginType, name string) error
+	BrokerHealthCheck(name string) (status, message string, details map[string]string, err error)
+	BrokerInfo(name string) (version, channelID string, capabilities []string, err error)
+}
+
+// --- Response types ---
+
+// IntegrationSummary is the response element for the list endpoint.
+type IntegrationSummary struct {
+	Name        string            `json:"name"`
+	Platform    string            `json:"platform"`
+	SelfManaged bool              `json:"self_managed"`
+	HasSecrets  map[string]bool   `json:"has_secrets"`
+	Status      *IntegrationStatus `json:"status,omitempty"`
+}
+
+// IntegrationDetail is the response for the single-integration GET endpoint.
+type IntegrationDetail struct {
+	Name        string             `json:"name"`
+	Platform    string             `json:"platform"`
+	SelfManaged bool               `json:"self_managed"`
+	Settings    map[string]string  `json:"settings"`
+	HasSecrets  map[string]bool    `json:"has_secrets"`
+	Status      *IntegrationStatus `json:"status,omitempty"`
+}
+
+// IntegrationStatus holds runtime status information from a broker plugin.
+type IntegrationStatus struct {
+	Connected    bool              `json:"connected"`
+	Version      string            `json:"version,omitempty"`
+	ChannelID    string            `json:"channel_id,omitempty"`
+	Capabilities []string          `json:"capabilities,omitempty"`
+	Health       string            `json:"health,omitempty"`
+	Message      string            `json:"message,omitempty"`
+	Details      map[string]string `json:"details,omitempty"`
+}
+
+// IntegrationConfigUpdateRequest is the request body for the PUT config endpoint.
+type IntegrationConfigUpdateRequest struct {
+	Settings map[string]string `json:"settings"`
+	Secrets  map[string]string `json:"secrets"`
+}
+
+// --- Route dispatchers ---
+
+// handleAdminIntegrations dispatches GET /api/v1/admin/integrations.
+func (s *Server) handleAdminIntegrations(w http.ResponseWriter, r *http.Request) {
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil || user.Role() != "admin" {
+		Forbidden(w)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		s.handleListIntegrations(w, r)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// handleAdminIntegrationByName dispatches requests under
+// /api/v1/admin/integrations/{name}[/config|/restart|/health].
+func (s *Server) handleAdminIntegrationByName(w http.ResponseWriter, r *http.Request) {
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil || user.Role() != "admin" {
+		Forbidden(w)
+		return
+	}
+
+	// Parse: /api/v1/admin/integrations/{name}[/{action}]
+	path := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/integrations/")
+	parts := strings.SplitN(path, "/", 2)
+	name := parts[0]
+	if name == "" {
+		NotFound(w, "integration")
+		return
+	}
+
+	action := ""
+	if len(parts) == 2 {
+		action = parts[1]
+	}
+
+	switch action {
+	case "":
+		if r.Method != http.MethodGet {
+			MethodNotAllowed(w)
+			return
+		}
+		s.handleGetIntegration(w, r, name)
+	case "config":
+		if r.Method != http.MethodPut {
+			MethodNotAllowed(w)
+			return
+		}
+		s.handleUpdateIntegrationConfig(w, r, name)
+	case "restart":
+		if r.Method != http.MethodPost {
+			MethodNotAllowed(w)
+			return
+		}
+		s.handleRestartIntegration(w, r, name)
+	case "health":
+		if r.Method != http.MethodGet {
+			MethodNotAllowed(w)
+			return
+		}
+		s.handleIntegrationHealth(w, r, name)
+	default:
+		NotFound(w, "integration endpoint")
+	}
+}
+
+// --- Handlers ---
+
+func (s *Server) handleListIntegrations(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	mgr := s.pluginManager
+	s.mu.RUnlock()
+
+	if mgr == nil {
+		writeJSON(w, http.StatusOK, []IntegrationSummary{})
+		return
+	}
+
+	plugins := mgr.ListPlugins()
+	summaries := make([]IntegrationSummary, 0, len(plugins))
+	for _, key := range plugins {
+		name := pluginNameFromKey(key)
+		if name == "" {
+			continue
+		}
+
+		summary := IntegrationSummary{
+			Name:        name,
+			Platform:    resolvePlatform(name),
+			SelfManaged: mgr.IsSelfManaged("broker", name),
+			HasSecrets:  s.checkIntegrationSecrets(r.Context(), name),
+			Status:      getIntegrationStatus(mgr, name),
+		}
+		summaries = append(summaries, summary)
+	}
+
+	writeJSON(w, http.StatusOK, summaries)
+}
+
+func (s *Server) handleGetIntegration(w http.ResponseWriter, r *http.Request, name string) {
+	s.mu.RLock()
+	mgr := s.pluginManager
+	s.mu.RUnlock()
+
+	if mgr == nil || !mgr.HasPlugin("broker", name) {
+		NotFound(w, "integration")
+		return
+	}
+
+	cfg := mgr.GetPluginConfig("broker", name)
+	if cfg == nil {
+		cfg = make(map[string]string)
+	}
+
+	detail := IntegrationDetail{
+		Name:        name,
+		Platform:    resolvePlatform(name),
+		SelfManaged: mgr.IsSelfManaged("broker", name),
+		Settings:    filterSensitiveConfig(name, cfg),
+		HasSecrets:  s.checkIntegrationSecrets(r.Context(), name),
+		Status:      getIntegrationStatus(mgr, name),
+	}
+
+	writeJSON(w, http.StatusOK, detail)
+}
+
+func (s *Server) handleUpdateIntegrationConfig(w http.ResponseWriter, r *http.Request, name string) {
+	s.mu.RLock()
+	mgr := s.pluginManager
+	s.mu.RUnlock()
+
+	if mgr == nil || !mgr.HasPlugin("broker", name) {
+		NotFound(w, "integration")
+		return
+	}
+
+	var req IntegrationConfigUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		BadRequest(w, "invalid request body")
+		return
+	}
+
+	ctx := r.Context()
+	user := GetUserIdentityFromContext(ctx)
+	userID := ""
+	if user != nil {
+		userID = user.ID()
+	}
+
+	// Store secrets via secret backend (never written to YAML).
+	if len(req.Secrets) > 0 {
+		mappings := config.PluginSecretKeyMap[name]
+		allowedSecrets := make(map[string]string, len(mappings))
+		for _, m := range mappings {
+			allowedSecrets[m.ConfigKey] = m.SecretKey
+		}
+
+		for configKey, value := range req.Secrets {
+			secretKey, ok := allowedSecrets[configKey]
+			if !ok {
+				BadRequest(w, "unknown secret key: "+configKey)
+				return
+			}
+			if err := s.SetChatIntegrationSecret(ctx, secretKey, value, ChatSecretDescription(secretKey), userID); err != nil {
+				slog.Error("Failed to store integration secret", "plugin", name, "key", configKey, "error", err)
+				InternalError(w)
+				return
+			}
+		}
+	}
+
+	// Write non-sensitive settings to YAML config file.
+	if len(req.Settings) > 0 {
+		pluginCfg := mgr.GetPluginConfig("broker", name)
+		configFile := ""
+		if pluginCfg != nil {
+			configFile = pluginCfg["config_file"]
+		}
+
+		if configFile == "" {
+			BadRequest(w, "integration has no config file configured")
+			return
+		}
+
+		provider, err := config.NewYAMLConfigProvider(configFile)
+		if err != nil {
+			slog.Error("Failed to create config provider", "plugin", name, "error", err)
+			InternalError(w)
+			return
+		}
+
+		existing, err := provider.Load()
+		if err != nil {
+			slog.Error("Failed to load existing config", "plugin", name, "error", err)
+			InternalError(w)
+			return
+		}
+
+		// Merge new settings into existing, filtering out any secret keys.
+		secretKeys := allSecretConfigKeys(name)
+		for k, v := range req.Settings {
+			if secretKeys[k] {
+				continue
+			}
+			existing[k] = v
+		}
+
+		if err := provider.Save(existing); err != nil {
+			slog.Error("Failed to save config", "plugin", name, "error", err)
+			InternalError(w)
+			return
+		}
+	}
+
+	// Reconfigure the running integration with updated config.
+	if err := s.reconfigureIntegration(r.Context(), mgr, name); err != nil {
+		slog.Error("Failed to reconfigure integration after config update", "plugin", name, "error", err)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleRestartIntegration(w http.ResponseWriter, r *http.Request, name string) {
+	s.mu.RLock()
+	mgr := s.pluginManager
+	s.mu.RUnlock()
+
+	if mgr == nil || !mgr.HasPlugin("broker", name) {
+		NotFound(w, "integration")
+		return
+	}
+
+	if err := s.reconfigureIntegration(r.Context(), mgr, name); err != nil {
+		slog.Error("Failed to restart integration", "plugin", name, "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+			"status": "error",
+			"error":  err.Error(),
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleIntegrationHealth(w http.ResponseWriter, r *http.Request, name string) {
+	s.mu.RLock()
+	mgr := s.pluginManager
+	s.mu.RUnlock()
+
+	if mgr == nil || !mgr.HasPlugin("broker", name) {
+		NotFound(w, "integration")
+		return
+	}
+
+	status := getIntegrationStatus(mgr, name)
+	if status == nil {
+		status = &IntegrationStatus{Health: "unknown", Message: "unable to query plugin status"}
+	}
+
+	writeJSON(w, http.StatusOK, status)
+}
+
+// --- Helpers ---
+
+// pluginNameFromKey extracts the plugin name from a "type:name" key,
+// returning only broker plugin names.
+func pluginNameFromKey(key string) string {
+	parts := strings.SplitN(key, ":", 2)
+	if len(parts) != 2 || parts[0] != "broker" {
+		return ""
+	}
+	return parts[1]
+}
+
+// resolvePlatform maps a plugin name to its user-facing platform name.
+func resolvePlatform(name string) string {
+	switch name {
+	case "telegram":
+		return "telegram"
+	case "discord":
+		return "discord"
+	case "chat-app":
+		return "gchat"
+	default:
+		return name
+	}
+}
+
+// checkIntegrationSecrets returns a map of config_key → bool indicating
+// whether each expected secret for the integration is present.
+func (s *Server) checkIntegrationSecrets(ctx context.Context, name string) map[string]bool {
+	mappings := config.PluginSecretKeyMap[name]
+	result := make(map[string]bool, len(mappings))
+	for _, m := range mappings {
+		result[m.ConfigKey] = s.HasChatIntegrationSecret(ctx, m.SecretKey)
+	}
+	return result
+}
+
+// filterSensitiveConfig returns a copy of the config map with secret values
+// and internal runtime keys removed.
+func filterSensitiveConfig(name string, cfg map[string]string) map[string]string {
+	filtered := make(map[string]string, len(cfg))
+
+	secretKeys := allSecretConfigKeys(name)
+	internalKeys := map[string]bool{
+		"hub_url":     true,
+		"hmac_key":    true,
+		"broker_id":   true,
+		"config_file": true,
+	}
+
+	for k, v := range cfg {
+		if secretKeys[k] || internalKeys[k] {
+			continue
+		}
+		filtered[k] = v
+	}
+	return filtered
+}
+
+// allSecretConfigKeys returns the set of config keys that correspond to
+// secrets for the named plugin.
+func allSecretConfigKeys(name string) map[string]bool {
+	mappings := config.PluginSecretKeyMap[name]
+	keys := make(map[string]bool, len(mappings))
+	for _, m := range mappings {
+		keys[m.ConfigKey] = true
+	}
+	return keys
+}
+
+// getIntegrationStatus queries health and info from the plugin manager.
+func getIntegrationStatus(mgr IntegrationManager, name string) *IntegrationStatus {
+	status := &IntegrationStatus{}
+
+	version, channelID, capabilities, err := mgr.BrokerInfo(name)
+	if err != nil {
+		status.Health = "unknown"
+		status.Message = "failed to query plugin info"
+		return status
+	}
+	status.Version = version
+	status.ChannelID = channelID
+	status.Capabilities = capabilities
+	status.Connected = true
+
+	health, message, details, err := mgr.BrokerHealthCheck(name)
+	if err != nil {
+		status.Health = "unknown"
+		status.Message = "failed to query health"
+		return status
+	}
+	status.Health = health
+	status.Message = message
+	status.Details = details
+
+	if health == "unhealthy" {
+		status.Connected = false
+	}
+
+	return status
+}
+
+// reconfigureIntegration reloads config for a plugin and calls ConfigureBroker.
+// For self-managed plugins, it falls back to Reconnect on ConfigureBroker failure.
+func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationManager, name string) error {
+	pluginCfg := mgr.GetPluginConfig("broker", name)
+
+	// Re-read config file if one is configured.
+	configFile := ""
+	if pluginCfg != nil {
+		configFile = pluginCfg["config_file"]
+	}
+
+	merged := make(map[string]string)
+	if configFile != "" {
+		var inlineCfg map[string]string
+		if pluginCfg != nil {
+			inlineCfg = pluginCfg
+		}
+		fileMerged, err := config.LoadPluginConfigFile(configFile, inlineCfg)
+		if err != nil {
+			slog.Error("Failed to reload config file for reconfigure", "plugin", name, "error", err)
+			// Fall through with what we have.
+			for k, v := range pluginCfg {
+				merged[k] = v
+			}
+		} else {
+			merged = fileMerged
+		}
+	} else if pluginCfg != nil {
+		for k, v := range pluginCfg {
+			merged[k] = v
+		}
+	}
+
+	// Inject secrets from the secret backend.
+	mappings := config.PluginSecretKeyMap[name]
+	for _, m := range mappings {
+		if existing := merged[m.ConfigKey]; existing != "" {
+			continue
+		}
+		val, err := s.LoadChatIntegrationSecret(ctx, m.SecretKey)
+		if err != nil || val == "" {
+			continue
+		}
+		merged[m.ConfigKey] = val
+	}
+
+	if err := mgr.ConfigureBroker(name, merged); err != nil {
+		if mgr.IsSelfManaged("broker", name) {
+			slog.Warn("ConfigureBroker failed for self-managed plugin, trying Reconnect",
+				"plugin", name, "error", err)
+			return mgr.Reconnect("broker", name)
+		}
+		return err
+	}
+
+	return nil
+}

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -217,6 +217,7 @@ func (s *Server) handleUpdateIntegrationConfig(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	var req IntegrationConfigUpdateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		BadRequest(w, "invalid request body")
@@ -315,10 +316,7 @@ func (s *Server) handleRestartIntegration(w http.ResponseWriter, r *http.Request
 
 	if err := s.reconfigureIntegration(r.Context(), mgr, name); err != nil {
 		slog.Error("Failed to restart integration", "plugin", name, "error", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
-			"status": "error",
-			"error":  err.Error(),
-		})
+		InternalError(w)
 		return
 	}
 

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -105,6 +105,7 @@ func (s *Server) handleAdminIntegrationByName(w http.ResponseWriter, r *http.Req
 
 	// Parse: /api/v1/admin/integrations/{name}[/{action}]
 	path := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/integrations/")
+	path = strings.TrimSuffix(path, "/")
 	parts := strings.SplitN(path, "/", 2)
 	name := parts[0]
 	if name == "" {
@@ -299,6 +300,8 @@ func (s *Server) handleUpdateIntegrationConfig(w http.ResponseWriter, r *http.Re
 	// Reconfigure the running integration with updated config.
 	if err := s.reconfigureIntegration(r.Context(), mgr, name); err != nil {
 		slog.Error("Failed to reconfigure integration after config update", "plugin", name, "error", err)
+		InternalError(w)
+		return
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
@@ -456,19 +459,21 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 
 	merged := make(map[string]string)
 	if configFile != "" {
-		var inlineCfg map[string]string
-		if pluginCfg != nil {
-			inlineCfg = pluginCfg
-		}
-		fileMerged, err := config.LoadPluginConfigFile(configFile, inlineCfg)
+		fileMerged, err := config.LoadPluginConfigFile(configFile, nil)
 		if err != nil {
 			slog.Error("Failed to reload config file for reconfigure", "plugin", name, "error", err)
-			// Fall through with what we have.
 			for k, v := range pluginCfg {
 				merged[k] = v
 			}
 		} else {
 			merged = fileMerged
+			// Carry over runtime/internal keys from the old config that
+			// are not present in the file (e.g. hub_url, hmac_key).
+			for k, v := range pluginCfg {
+				if _, ok := merged[k]; !ok {
+					merged[k] = v
+				}
+			}
 		}
 	} else {
 		for k, v := range pluginCfg {

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -42,10 +42,10 @@ type IntegrationManager interface {
 
 // IntegrationSummary is the response element for the list endpoint.
 type IntegrationSummary struct {
-	Name        string            `json:"name"`
-	Platform    string            `json:"platform"`
-	SelfManaged bool              `json:"self_managed"`
-	HasSecrets  map[string]bool   `json:"has_secrets"`
+	Name        string             `json:"name"`
+	Platform    string             `json:"platform"`
+	SelfManaged bool               `json:"self_managed"`
+	HasSecrets  map[string]bool    `json:"has_secrets"`
 	Status      *IntegrationStatus `json:"status,omitempty"`
 }
 
@@ -472,7 +472,7 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 		} else {
 			merged = fileMerged
 		}
-	} else if pluginCfg != nil {
+	} else {
 		for k, v := range pluginCfg {
 			merged[k] = v
 		}

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -25,12 +25,12 @@ import (
 // --- mock IntegrationManager ---
 
 type mockIntegrationManager struct {
-	plugins     map[string]map[string]string // name → config
-	selfManaged map[string]bool
-	healthErr   error
-	infoErr     error
-	configureErr error
-	reconnectErr error
+	plugins        map[string]map[string]string // name → config
+	selfManaged    map[string]bool
+	healthErr      error
+	infoErr        error
+	configureErr   error
+	reconnectErr   error
 	configureCalls []string
 	reconnectCalls []string
 }

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -1,0 +1,629 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// --- mock IntegrationManager ---
+
+type mockIntegrationManager struct {
+	plugins     map[string]map[string]string // name → config
+	selfManaged map[string]bool
+	healthErr   error
+	infoErr     error
+	configureErr error
+	reconnectErr error
+	configureCalls []string
+	reconnectCalls []string
+}
+
+func newMockIntegrationManager() *mockIntegrationManager {
+	return &mockIntegrationManager{
+		plugins:     make(map[string]map[string]string),
+		selfManaged: make(map[string]bool),
+	}
+}
+
+func (m *mockIntegrationManager) ListPlugins() []string {
+	keys := make([]string, 0, len(m.plugins))
+	for name := range m.plugins {
+		keys = append(keys, "broker:"+name)
+	}
+	return keys
+}
+
+func (m *mockIntegrationManager) HasPlugin(pluginType, name string) bool {
+	if pluginType != "broker" {
+		return false
+	}
+	_, ok := m.plugins[name]
+	return ok
+}
+
+func (m *mockIntegrationManager) GetPluginConfig(pluginType, name string) map[string]string {
+	if pluginType != "broker" {
+		return nil
+	}
+	cfg, ok := m.plugins[name]
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, len(cfg))
+	for k, v := range cfg {
+		out[k] = v
+	}
+	return out
+}
+
+func (m *mockIntegrationManager) IsSelfManaged(pluginType, name string) bool {
+	if pluginType != "broker" {
+		return false
+	}
+	return m.selfManaged[name]
+}
+
+func (m *mockIntegrationManager) ConfigureBroker(name string, extra map[string]string) error {
+	m.configureCalls = append(m.configureCalls, name)
+	return m.configureErr
+}
+
+func (m *mockIntegrationManager) Reconnect(pluginType, name string) error {
+	m.reconnectCalls = append(m.reconnectCalls, name)
+	return m.reconnectErr
+}
+
+func (m *mockIntegrationManager) BrokerHealthCheck(name string) (string, string, map[string]string, error) {
+	if m.healthErr != nil {
+		return "", "", nil, m.healthErr
+	}
+	return "healthy", "all good", map[string]string{"connections": "5"}, nil
+}
+
+func (m *mockIntegrationManager) BrokerInfo(name string) (string, string, []string, error) {
+	if m.infoErr != nil {
+		return "", "", nil, m.infoErr
+	}
+	return "v0.8.2", "telegram", []string{"send", "receive"}, nil
+}
+
+// --- Auth tests ---
+
+func TestIntegrations_Unauthenticated(t *testing.T) {
+	srv := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations", nil)
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrations(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rr.Code)
+	}
+}
+
+func TestIntegrations_NonAdmin(t *testing.T) {
+	srv := &Server{}
+	member := NewAuthenticatedUser("u1", "member@example.com", "Member", "member", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), member))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrations(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rr.Code)
+	}
+}
+
+func TestIntegrationByName_Unauthenticated(t *testing.T) {
+	srv := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/telegram", nil)
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rr.Code)
+	}
+}
+
+func TestIntegrationByName_NonAdmin(t *testing.T) {
+	srv := &Server{}
+	member := NewAuthenticatedUser("u1", "member@example.com", "Member", "member", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/telegram", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), member))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rr.Code)
+	}
+}
+
+// --- List endpoint ---
+
+func TestListIntegrations_Empty(t *testing.T) {
+	srv := &Server{}
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrations(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var result []IntegrationSummary
+	if err := json.NewDecoder(rr.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Fatalf("expected empty list, got %d", len(result))
+	}
+}
+
+func TestListIntegrations_WithPlugins(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["telegram"] = map[string]string{"webhook_listen": ":9094"}
+	mgr.plugins["discord"] = map[string]string{"guild_id": "12345"}
+	mgr.selfManaged["discord"] = true
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrations(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var result []IntegrationSummary
+	if err := json.NewDecoder(rr.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 integrations, got %d", len(result))
+	}
+
+	byName := make(map[string]IntegrationSummary)
+	for _, s := range result {
+		byName[s.Name] = s
+	}
+
+	tg, ok := byName["telegram"]
+	if !ok {
+		t.Fatal("telegram not in list")
+	}
+	if tg.Platform != "telegram" {
+		t.Errorf("expected platform telegram, got %s", tg.Platform)
+	}
+	if tg.SelfManaged {
+		t.Error("telegram should not be self-managed")
+	}
+	if tg.Status == nil || tg.Status.Version != "v0.8.2" {
+		t.Error("expected status with version v0.8.2")
+	}
+
+	dc, ok := byName["discord"]
+	if !ok {
+		t.Fatal("discord not in list")
+	}
+	if !dc.SelfManaged {
+		t.Error("discord should be self-managed")
+	}
+}
+
+func TestListIntegrations_MethodNotAllowed(t *testing.T) {
+	srv := &Server{}
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrations(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rr.Code)
+	}
+}
+
+// --- Detail endpoint ---
+
+func TestGetIntegration_NotFound(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/nonexistent", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rr.Code)
+	}
+}
+
+func TestGetIntegration_OK(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["telegram"] = map[string]string{
+		"webhook_listen": ":9094",
+		"hub_url":        "https://hub.example.com",
+		"bot_token":      "should-be-filtered",
+	}
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/telegram", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var detail IntegrationDetail
+	if err := json.NewDecoder(rr.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if detail.Name != "telegram" {
+		t.Errorf("expected name telegram, got %s", detail.Name)
+	}
+	if detail.Platform != "telegram" {
+		t.Errorf("expected platform telegram, got %s", detail.Platform)
+	}
+	if _, ok := detail.Settings["bot_token"]; ok {
+		t.Error("bot_token should be filtered from settings")
+	}
+	if _, ok := detail.Settings["hub_url"]; ok {
+		t.Error("hub_url should be filtered from settings")
+	}
+	if detail.Settings["webhook_listen"] != ":9094" {
+		t.Errorf("expected webhook_listen :9094, got %s", detail.Settings["webhook_listen"])
+	}
+	if detail.Status == nil || !detail.Status.Connected {
+		t.Error("expected connected status")
+	}
+}
+
+func TestGetIntegration_MethodNotAllowed(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["telegram"] = map[string]string{}
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/integrations/telegram", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rr.Code)
+	}
+}
+
+// --- Health endpoint ---
+
+func TestIntegrationHealth_OK(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["telegram"] = map[string]string{}
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/telegram/health", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var status IntegrationStatus
+	if err := json.NewDecoder(rr.Body).Decode(&status); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if status.Health != "healthy" {
+		t.Errorf("expected healthy, got %s", status.Health)
+	}
+	if !status.Connected {
+		t.Error("expected connected")
+	}
+	if status.Version != "v0.8.2" {
+		t.Errorf("expected version v0.8.2, got %s", status.Version)
+	}
+}
+
+func TestIntegrationHealth_NotFound(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/nonexistent/health", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rr.Code)
+	}
+}
+
+// --- Restart endpoint ---
+
+func TestRestartIntegration_OK(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["telegram"] = map[string]string{}
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations/telegram/restart", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	if len(mgr.configureCalls) != 1 || mgr.configureCalls[0] != "telegram" {
+		t.Errorf("expected ConfigureBroker call for telegram, got %v", mgr.configureCalls)
+	}
+}
+
+func TestRestartIntegration_NotFound(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations/nonexistent/restart", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rr.Code)
+	}
+}
+
+func TestRestartIntegration_MethodNotAllowed(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["telegram"] = map[string]string{}
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/telegram/restart", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rr.Code)
+	}
+}
+
+// --- Config PUT endpoint ---
+
+func TestUpdateConfig_NoConfigFile(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["telegram"] = map[string]string{}
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	body := `{"settings":{"webhook_listen":":9095"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/integrations/telegram/config", strings.NewReader(body))
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 (no config file), got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestUpdateConfig_WithConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	configFile := dir + "/telegram.yaml"
+
+	mgr := newMockIntegrationManager()
+	mgr.plugins["telegram"] = map[string]string{
+		"config_file":    configFile,
+		"webhook_listen": ":9094",
+	}
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	body := `{"settings":{"webhook_listen":":9095","db_path":"/tmp/tg.db"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/integrations/telegram/config", strings.NewReader(body))
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	if len(mgr.configureCalls) != 1 {
+		t.Errorf("expected 1 ConfigureBroker call, got %d", len(mgr.configureCalls))
+	}
+}
+
+func TestUpdateConfig_InvalidBody(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["telegram"] = map[string]string{}
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/integrations/telegram/config", strings.NewReader("not json"))
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestUpdateConfig_UnknownSecretKey(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["telegram"] = map[string]string{}
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	body := `{"secrets":{"unknown_key":"value"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/integrations/telegram/config", strings.NewReader(body))
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestUpdateConfig_NotFound(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	body := `{"settings":{}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/integrations/nonexistent/config", strings.NewReader(body))
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rr.Code)
+	}
+}
+
+// --- Helper unit tests ---
+
+func TestResolvePlatform(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"telegram", "telegram"},
+		{"discord", "discord"},
+		{"chat-app", "gchat"},
+		{"custom", "custom"},
+	}
+	for _, tt := range tests {
+		if got := resolvePlatform(tt.name); got != tt.expected {
+			t.Errorf("resolvePlatform(%q) = %q, want %q", tt.name, got, tt.expected)
+		}
+	}
+}
+
+func TestFilterSensitiveConfig(t *testing.T) {
+	cfg := map[string]string{
+		"webhook_listen": ":9094",
+		"bot_token":      "secret-token",
+		"hub_url":        "https://hub.example.com",
+		"hmac_key":       "secret-hmac",
+		"broker_id":      "br-123",
+		"config_file":    "/etc/telegram.yaml",
+		"db_path":        "/var/lib/tg.db",
+	}
+
+	filtered := filterSensitiveConfig("telegram", cfg)
+
+	if _, ok := filtered["bot_token"]; ok {
+		t.Error("bot_token should be filtered")
+	}
+	if _, ok := filtered["hub_url"]; ok {
+		t.Error("hub_url should be filtered")
+	}
+	if _, ok := filtered["hmac_key"]; ok {
+		t.Error("hmac_key should be filtered")
+	}
+	if _, ok := filtered["broker_id"]; ok {
+		t.Error("broker_id should be filtered")
+	}
+	if _, ok := filtered["config_file"]; ok {
+		t.Error("config_file should be filtered")
+	}
+	if filtered["webhook_listen"] != ":9094" {
+		t.Errorf("expected webhook_listen :9094, got %s", filtered["webhook_listen"])
+	}
+	if filtered["db_path"] != "/var/lib/tg.db" {
+		t.Errorf("expected db_path preserved, got %s", filtered["db_path"])
+	}
+}
+
+func TestPluginNameFromKey(t *testing.T) {
+	tests := []struct {
+		key      string
+		expected string
+	}{
+		{"broker:telegram", "telegram"},
+		{"broker:discord", "discord"},
+		{"other:telegram", ""},
+		{"invalid", ""},
+	}
+	for _, tt := range tests {
+		if got := pluginNameFromKey(tt.key); got != tt.expected {
+			t.Errorf("pluginNameFromKey(%q) = %q, want %q", tt.key, got, tt.expected)
+		}
+	}
+}
+
+// --- Unknown endpoint ---
+
+func TestIntegrationByName_UnknownAction(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["telegram"] = map[string]string{}
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/telegram/unknown", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rr.Code)
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -604,6 +604,9 @@ type Server struct {
 	// Discord link service for code-based account linking (nil = disabled)
 	discordLinkService *DiscordLinkService
 
+	// Plugin manager for broker integration admin API (nil = no integrations)
+	pluginManager IntegrationManager
+
 	// Channel registry for external notification delivery (nil = disabled)
 	channelRegistry *ChannelRegistry
 
@@ -1425,6 +1428,13 @@ func (s *Server) GetMessageBrokerProxy() *MessageBrokerProxy {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.messageBrokerProxy
+}
+
+// SetPluginManager sets the plugin manager for broker integration admin API.
+func (s *Server) SetPluginManager(m IntegrationManager) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pluginManager = m
 }
 
 // logMessage logs a message dispatch event to the dedicated message logger
@@ -2623,6 +2633,8 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/admin/lifecycle-hooks", s.handleAdminLifecycleHooks)
 	s.mux.HandleFunc("/api/v1/admin/lifecycle-hooks/", s.handleAdminLifecycleHookByID)
 	s.mux.HandleFunc("/api/v1/admin/validate-resources", s.handleAdminValidateResources)
+	s.mux.HandleFunc("/api/v1/admin/integrations", s.handleAdminIntegrations)
+	s.mux.HandleFunc("/api/v1/admin/integrations/", s.handleAdminIntegrationByName)
 	s.mux.HandleFunc("/api/v1/metrics/", s.handleMetricsDashboard)
 	s.mux.HandleFunc("/api/v1/admin/metrics-dashboard", s.handleAdminMetricsDashboard) // legacy backward-compat
 

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -449,6 +449,48 @@ func (m *Manager) ListPlugins() []string {
 	return keys
 }
 
+// BrokerHealthCheck returns the health status of a named broker plugin as
+// primitive types so callers need not import plugin-package structs.
+func (m *Manager) BrokerHealthCheck(name string) (status, message string, details map[string]string, err error) {
+	raw, err := m.Get(PluginTypeBroker, name)
+	if err != nil {
+		return "", "", nil, err
+	}
+	rpcClient, ok := raw.(*BrokerRPCClient)
+	if !ok {
+		return "", "", nil, fmt.Errorf("plugin %s is not a broker RPC client", name)
+	}
+	hs, err := rpcClient.HealthCheck()
+	if err != nil {
+		return "", "", nil, err
+	}
+	if hs == nil {
+		return "unknown", "", nil, nil
+	}
+	return hs.Status, hs.Message, hs.Details, nil
+}
+
+// BrokerInfo returns plugin metadata for a named broker plugin as primitive
+// types so callers need not import plugin-package structs.
+func (m *Manager) BrokerInfo(name string) (version, channelID string, capabilities []string, err error) {
+	raw, err := m.Get(PluginTypeBroker, name)
+	if err != nil {
+		return "", "", nil, err
+	}
+	rpcClient, ok := raw.(*BrokerRPCClient)
+	if !ok {
+		return "", "", nil, fmt.Errorf("plugin %s is not a broker RPC client", name)
+	}
+	info, err := rpcClient.GetInfo()
+	if err != nil {
+		return "", "", nil, err
+	}
+	if info == nil {
+		return "", "", nil, nil
+	}
+	return info.Version, info.ChannelID, info.Capabilities, nil
+}
+
 // Shutdown kills all plugin processes gracefully.
 // Self-managed plugins are disconnected but their processes are not terminated.
 func (m *Manager) Shutdown() {


### PR DESCRIPTION
Phase 2 of Chat Admin UI (issue #365).

- IntegrationManager interface + 5 admin API endpoints
- BrokerHealthCheck/BrokerInfo convenience methods on plugin Manager
- Secret filtering (has_* booleans only, never values)
- Config PUT separates secrets to backend, settings to YAML
- 24 tests covering auth, CRUD, restart, health