### PR TITLE
fix: expire stuck pending messages in broker-message-sweep

### DIFF
--- a/pkg/hub/dispatch_wait_test.go
+++ b/pkg/hub/dispatch_wait_test.go
@@ -66,6 +66,9 @@ func (f *fakeDispatchStore) ReapStuckDispatch(_ context.Context, _ time.Time, _ 
 func (f *fakeDispatchStore) CountStuckPendingMessages(_ context.Context, _ time.Time) (int, error) {
 	return 0, nil
 }
+func (f *fakeDispatchStore) ExpireStuckPendingMessages(_ context.Context, _ time.Time, _ string) (int, error) {
+	return 0, nil
+}
 
 // sendStatus pushes a fake AgentStatusEvent onto the channel.
 func sendStatus(ch chan<- Event, phase, activity string, detail *AgentDetail) {

--- a/pkg/hub/sweep.go
+++ b/pkg/hub/sweep.go
@@ -21,8 +21,11 @@ import (
 
 const stuckMessageThreshold = 5 * time.Minute
 
+const stuckMessageExpireTTL = 24 * time.Hour
+
 // brokerMessageSweepHandler returns a handler that counts messages still in
 // dispatch_state='pending' beyond the stuck threshold and logs/emits metrics.
+// Messages stuck beyond stuckMessageExpireTTL are transitioned to failed.
 // After Phase 4 (no-queuing delivery), no code path creates pending rows — any
 // count > 0 indicates a bug. Registered as a RecurringSingleton guarded by
 // LockBrokerMessageSweep (B5-2).
@@ -42,6 +45,17 @@ func (s *Server) brokerMessageSweepHandler() func(ctx context.Context) {
 
 		if rec := s.dispatchMetrics; rec != nil {
 			rec.ObserveMessageStuck(ctx, int64(count))
+		}
+
+		expireCutoff := time.Now().Add(-stuckMessageExpireTTL)
+		expired, err := s.store.ExpireStuckPendingMessages(ctx, expireCutoff, "expired: stuck in pending state beyond TTL")
+		if err != nil {
+			s.agentLifecycleLog.Error("sweep: expire stuck pending messages failed", "error", err)
+			return
+		}
+		if expired > 0 {
+			s.agentLifecycleLog.Info("sweep: expired stuck pending messages",
+				"expired", expired, "ttl", stuckMessageExpireTTL.String())
 		}
 	}
 }

--- a/pkg/store/entadapter/broker_dispatch_store_test.go
+++ b/pkg/store/entadapter/broker_dispatch_store_test.go
@@ -239,6 +239,64 @@ func TestCountStuckPendingMessages(t *testing.T) {
 	assert.Equal(t, 0, count, "dispatched message is not stuck")
 }
 
+func TestExpireStuckPendingMessages(t *testing.T) {
+	client := enttest.NewClient(t)
+	cs := NewCompositeStore(client)
+	ctx := context.Background()
+
+	proj := &store.Project{
+		ID: uuid.NewString(), Name: "p", Slug: "p-" + uuid.NewString()[:8],
+		Visibility: store.VisibilityPrivate, OwnerID: uuid.NewString(),
+	}
+	require.NoError(t, cs.CreateProject(ctx, proj))
+
+	// A message created 25 hours ago (past TTL).
+	expiredMsg := &store.Message{
+		ID: uuid.NewString(), ProjectID: proj.ID,
+		Sender: "user:x", Recipient: "agent:a", Msg: "old",
+		CreatedAt: time.Now().Add(-25 * time.Hour),
+	}
+	require.NoError(t, cs.CreateMessage(ctx, expiredMsg))
+
+	// A message created 10 minutes ago (within TTL, but past stuck threshold).
+	recentMsg := &store.Message{
+		ID: uuid.NewString(), ProjectID: proj.ID,
+		Sender: "user:x", Recipient: "agent:b", Msg: "recent",
+		CreatedAt: time.Now().Add(-10 * time.Minute),
+	}
+	require.NoError(t, cs.CreateMessage(ctx, recentMsg))
+
+	// A message created just now (fresh).
+	freshMsg := &store.Message{
+		ID: uuid.NewString(), ProjectID: proj.ID,
+		Sender: "user:x", Recipient: "agent:c", Msg: "fresh",
+	}
+	require.NoError(t, cs.CreateMessage(ctx, freshMsg))
+
+	ttlCutoff := time.Now().Add(-24 * time.Hour)
+	reason := "expired: stuck in pending state beyond TTL"
+	expired, err := cs.ExpireStuckPendingMessages(ctx, ttlCutoff, reason)
+	require.NoError(t, err)
+	assert.Equal(t, 1, expired, "only the 25h-old message should be expired")
+
+	got, err := cs.GetMessage(ctx, expiredMsg.ID)
+	require.NoError(t, err)
+	assert.Equal(t, store.MessageDispatchFailed, got.DispatchState)
+
+	gotRecent, err := cs.GetMessage(ctx, recentMsg.ID)
+	require.NoError(t, err)
+	assert.Equal(t, store.MessageDispatchPending, gotRecent.DispatchState, "recent message still pending")
+
+	gotFresh, err := cs.GetMessage(ctx, freshMsg.ID)
+	require.NoError(t, err)
+	assert.Equal(t, store.MessageDispatchPending, gotFresh.DispatchState, "fresh message still pending")
+
+	// Running again should expire 0.
+	expired, err = cs.ExpireStuckPendingMessages(ctx, ttlCutoff, reason)
+	require.NoError(t, err)
+	assert.Equal(t, 0, expired, "already-expired message not counted again")
+}
+
 func mustCreateAgent(t *testing.T, client *ent.Client, projectID uuid.UUID, brokerID string) string {
 	t.Helper()
 	a, err := client.Agent.Create().

--- a/pkg/store/entadapter/brokerdispatch_store.go
+++ b/pkg/store/entadapter/brokerdispatch_store.go
@@ -280,6 +280,20 @@ func (s *BrokerDispatchStore) CountStuckPendingMessages(ctx context.Context, bef
 	return n, nil
 }
 
+// ExpireStuckPendingMessages transitions messages stuck in pending state past
+// the given cutoff to failed, recording the reason. Returns the number expired.
+func (s *BrokerDispatchStore) ExpireStuckPendingMessages(ctx context.Context, before time.Time, reason string) (int, error) {
+	affected, err := s.client.Message.Update().
+		Where(message.DispatchStateEQ(store.MessageDispatchPending), message.CreatedLT(before)).
+		SetDispatchState(store.MessageDispatchFailed).
+		SetNillableDispatchFailureReason(&reason).
+		Save(ctx)
+	if err != nil {
+		return 0, mapError(err)
+	}
+	return affected, nil
+}
+
 // ListPendingMessages returns messages still pending delivery whose target agent
 // lives on the given broker (messages have no broker_id; the association is via
 // the recipient agent's runtime_broker_id).

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -402,6 +402,11 @@ type BrokerDispatchStore interface {
 	// cutoff. Used by the stuck-message sweep (B5-2) to surface messages that
 	// have not been dispatched within the expected window.
 	CountStuckPendingMessages(ctx context.Context, before time.Time) (int, error)
+
+	// ExpireStuckPendingMessages transitions messages stuck in pending state
+	// past the given cutoff to failed, recording the reason. Returns the
+	// number of messages expired.
+	ExpireStuckPendingMessages(ctx context.Context, before time.Time, reason string) (int, error)
 }
 
 // TemplateStore defines template persistence operations.


### PR DESCRIPTION
The sweep detected stuck pending messages but never cleared them, causing indefinite log noise and accumulation. Add a 24h TTL after which stuck messages are transitioned to dispatch_state='failed' with a recorded reason.

Closes https://github.com/ptone/scion/issues/370

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
