### PR TITLE
fix: exclude soft-deleted agents from slug lookup and clean stale dirs

### DIFF
--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1362,7 +1363,14 @@ func GetAgent(ctx context.Context, agentName string, templateName string, agentI
 	// but failed before writing scion-agent.json. Remove it so we re-provision.
 	if _, err := os.Stat(agentDir); err == nil {
 		if configPath := config.GetScionAgentConfigPath(agentDir); configPath == "" {
-			util.Debugf("GetAgent: agent dir exists but no config file found, removing stale directory")
+			util.Debugf("GetAgent: stale agent directory detected (no config file), removing: %s", agentDir)
+			// chmod to ensure we can remove root-owned files left by containers.
+			_ = filepath.WalkDir(agentDir, func(path string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return nil
+				}
+				return os.Chmod(path, 0755)
+			})
 			os.RemoveAll(agentDir)
 			// Prune worktrees so git forgets any worktree that pointed into the
 			// now-deleted directory, allowing ProvisionAgent to recreate it cleanly.

--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -1369,7 +1369,8 @@ func GetAgent(ctx context.Context, agentName string, templateName string, agentI
 				if err != nil {
 					return nil
 				}
-				return os.Chmod(path, 0755)
+				_ = os.Chmod(path, 0755)
+				return nil
 			})
 			os.RemoveAll(agentDir)
 			// Prune worktrees so git forgets any worktree that pointed into the

--- a/pkg/sciontool/services/manager_test.go
+++ b/pkg/sciontool/services/manager_test.go
@@ -101,16 +101,17 @@ func TestManager_RestartOnFailure(t *testing.T) {
 		t.Fatalf("Start() error: %v", err)
 	}
 
-	// Wait for the service to fail and be restarted at least once
-	time.Sleep(3 * time.Second)
-
 	mgr.mu.Lock()
 	svc := mgr.services[0]
 	mgr.mu.Unlock()
-	failures := svc.currentFailures()
 
-	if failures == 0 {
-		t.Error("expected at least one restart attempt for on-failure policy")
+	deadline := time.After(10 * time.Second)
+	for svc.currentFailures() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for at least one restart attempt for on-failure policy")
+		case <-time.After(100 * time.Millisecond):
+		}
 	}
 
 	cancel()
@@ -209,14 +210,17 @@ func TestManager_MaxRestarts(t *testing.T) {
 		t.Fatalf("Start() error: %v", err)
 	}
 
-	// Wait for all restart attempts to exhaust (1s + 2s + 4s backoff + some process time)
-	time.Sleep(10 * time.Second)
-
 	mgr.mu.Lock()
 	svc := mgr.services[0]
 	mgr.mu.Unlock()
-	if !svc.isAbandoned() {
-		t.Error("expected service to be abandoned after max restarts")
+
+	deadline := time.After(30 * time.Second)
+	for !svc.isAbandoned() {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for service to be abandoned after max restarts")
+		case <-time.After(100 * time.Millisecond):
+		}
 	}
 	if f := svc.currentFailures(); f < maxConsecutiveFailures {
 		t.Errorf("expected at least %d failures, got %d", maxConsecutiveFailures, f)

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -253,7 +253,7 @@ func (s *AgentStore) GetAgentBySlug(ctx context.Context, projectID, slug string)
 		return nil, err
 	}
 	a, err := s.client.Agent.Query().
-		Where(agent.ProjectIDEQ(projectUID), agent.SlugEQ(slug)).
+		Where(agent.ProjectIDEQ(projectUID), agent.SlugEQ(slug), agent.DeletedAtIsNil()).
 		Only(ctx)
 	if err != nil {
 		return nil, mapError(err)

--- a/pkg/store/entadapter/agent_store_test.go
+++ b/pkg/store/entadapter/agent_store_test.go
@@ -211,6 +211,24 @@ func TestAgentStore_SoftDeleteExclusion(t *testing.T) {
 	assert.ElementsMatch(t, []string{live.ID, gone.ID}, ids(incl.Items))
 }
 
+// TestAgentStore_GetAgentBySlugExcludesSoftDeleted verifies that GetAgentBySlug
+// does not return a soft-deleted agent, returning ErrNotFound instead.
+func TestAgentStore_GetAgentBySlugExcludesSoftDeleted(t *testing.T) {
+	ctx := context.Background()
+	s, projectID := newTestAgentStore(t)
+
+	a := makeAgent(projectID, "reusable-slug")
+	require.NoError(t, s.CreateAgent(ctx, a))
+
+	// Soft-delete the agent.
+	a.DeletedAt = time.Now()
+	require.NoError(t, s.UpdateAgent(ctx, a))
+
+	// Slug lookup must not return the soft-deleted record.
+	_, err := s.GetAgentBySlug(ctx, projectID, "reusable-slug")
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
 // TestAgentStore_OptimisticLockConflict verifies the state_version CAS guard:
 // a second update issued against a stale version is rejected with
 // ErrVersionConflict rather than silently overwriting the first.


### PR DESCRIPTION
## Summary

- GetAgentBySlug now filters out soft-deleted agents (agent.DeletedAtIsNil() predicate), so re-creating an agent with the same name as a previously-deleted one succeeds cleanly
- GetAgent now chmod-walks stale agent directories before RemoveAll so root-owned files left by containers do not block cleanup
- WalkDir chmod callback swallows individual errors to avoid aborting cleanup prematurely
- Added test: TestAgentStore_GetAgentBySlugExcludesSoftDeleted