### PR TITLE
hub: wire BootstrapBundledResources into hosted startup path

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -95,13 +95,10 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 		if err := config.InitGlobal(harness.EmbedOnlyHarnesses(), config.InitMachineOpts{HarnessesFS: harness.HarnessesFS()}); err != nil {
 			return fmt.Errorf("failed to initialize global config: %w", err)
 		}
-	} else if hostedMode {
-		// In hosted mode, refresh the default template and harness-configs
-		// from the binary's embeds on every start. This ensures a binary upgrade
-		// automatically propagates new defaults without manual re-init.
-		// Only done in hosted mode to avoid overwriting local customizations
-		// during development; admins should use non-default names for custom
-		// templates.
+	} else if !hostedMode {
+		// In workstation mode, refresh the default template and harness-configs
+		// from the binary's embeds. Hosted mode bootstraps directly into the Hub
+		// via BootstrapBundledResources, bypassing local ~/.scion materialization.
 		if err := config.UpdateDefaultTemplates(true, harness.EmbedOnlyHarnesses(), harness.HarnessesFS()); err != nil {
 			log.Printf("Warning: failed to refresh default templates: %v", err)
 		}
@@ -1324,16 +1321,28 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 		}
 	}
 
-	// Bootstrap local templates into Hub if database is empty
-	globalTemplatesDir := filepath.Join(globalDir, "templates")
-	if err := hubSrv.BootstrapTemplatesFromDir(ctx, globalTemplatesDir); err != nil {
-		log.Printf("Warning: template bootstrap failed: %v", err)
-	}
-
-	// Bootstrap local harness configs into Hub
-	globalHarnessConfigsDir := filepath.Join(globalDir, "harness-configs")
-	if err := hubSrv.BootstrapHarnessConfigsFromDir(ctx, globalHarnessConfigsDir); err != nil {
-		log.Printf("Warning: harness config bootstrap failed: %v", err)
+	if hostedMode {
+		// Hosted mode: bootstrap bundled resources directly into the Hub from
+		// the binary's embedded catalog. This removes the dependency on local
+		// ~/.scion directories and ensures every replica converges on the same
+		// DB + storage state.
+		if err := hubSrv.BootstrapBundledResources(ctx, hub.BootstrapOptions{
+			RepairStorage:   true,
+			OverwritePolicy: hub.OverwriteBuiltinManaged,
+		}); err != nil {
+			log.Printf("Warning: bundled resource bootstrap failed: %v", err)
+		}
+	} else {
+		// Workstation mode: import from local ~/.scion directories. These were
+		// refreshed from embeds earlier in the startup sequence.
+		globalTemplatesDir := filepath.Join(globalDir, "templates")
+		if err := hubSrv.BootstrapTemplatesFromDir(ctx, globalTemplatesDir); err != nil {
+			log.Printf("Warning: template bootstrap failed: %v", err)
+		}
+		globalHarnessConfigsDir := filepath.Join(globalDir, "harness-configs")
+		if err := hubSrv.BootstrapHarnessConfigsFromDir(ctx, globalHarnessConfigsDir); err != nil {
+			log.Printf("Warning: harness config bootstrap failed: %v", err)
+		}
 	}
 
 	log.Printf("Database: %s (%s)", cfg.Database.Driver, cfg.Database.URL)

--- a/pkg/hub/resource_bootstrap.go
+++ b/pkg/hub/resource_bootstrap.go
@@ -67,7 +67,8 @@ func (s *Server) BootstrapBundledResources(ctx context.Context, opts BootstrapOp
 		s.templateLog.Info("bootstrapped bundled resource",
 			"kind", r.Kind, "name", r.Name,
 			"created", result.Created, "updated", result.Updated,
-			"skipped", result.Skipped, "failed", result.Failed)
+			"repaired", result.Repaired, "skipped", result.Skipped,
+			"failed", result.Failed)
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/hub/resource_bootstrap.go
+++ b/pkg/hub/resource_bootstrap.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/storage"
+	"github.com/GoogleCloudPlatform/scion/resources"
+)
+
+// BootstrapBundledResources iterates all built-in bundled resources and
+// bootstraps each into the Hub's database and storage backend. Templates are
+// routed to templateStore and harness-configs to harnessConfigStore. The
+// operation is idempotent: unchanged resources are skipped, and updated
+// built-in-managed resources are re-uploaded.
+func (s *Server) BootstrapBundledResources(ctx context.Context, opts BootstrapOptions) error {
+	stor := s.GetStorage()
+	if stor == nil {
+		s.templateLog.Warn("bundled resource bootstrap: no storage backend configured, skipping")
+		return nil
+	}
+
+	var errs []error
+	for _, r := range resources.BuiltinResources() {
+		src := NewFSResourceSource(r)
+
+		var rs *ResourceStore
+		switch r.Kind {
+		case storage.ResourceKindTemplate:
+			rs = s.templateStore()
+		case storage.ResourceKindHarnessConfig:
+			harness, err := resolveHarnessType(r)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("bootstrap %s %q: %w", r.Kind, r.Name, err))
+				continue
+			}
+			rs = s.harnessConfigStore(harness)
+		default:
+			errs = append(errs, fmt.Errorf("bootstrap: unsupported resource kind %q", r.Kind))
+			continue
+		}
+
+		result, err := rs.BootstrapSource(ctx, src, opts)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("bootstrap %s %q: %w", r.Kind, r.Name, err))
+			continue
+		}
+
+		s.templateLog.Info("bootstrapped bundled resource",
+			"kind", r.Kind, "name", r.Name,
+			"created", result.Created, "updated", result.Updated,
+			"skipped", result.Skipped, "failed", result.Failed)
+	}
+	return errors.Join(errs...)
+}
+
+// resolveHarnessType reads config.yaml from a bundled harness-config resource's
+// embedded FS and returns the harness type field.
+func resolveHarnessType(r resources.BundledResource) (string, error) {
+	configPath := filepath.ToSlash(filepath.Join(r.Root, "config.yaml"))
+	if r.Root == "." || r.Root == "" {
+		configPath = "config.yaml"
+	}
+
+	data, err := fs.ReadFile(r.FS, configPath)
+	if err != nil {
+		return "", fmt.Errorf("read config.yaml: %w", err)
+	}
+
+	entry, err := config.ParseHarnessConfigYAML(data)
+	if err != nil {
+		return "", fmt.Errorf("parse config.yaml: %w", err)
+	}
+
+	if entry.Harness == "" {
+		return "", fmt.Errorf("config.yaml missing harness field")
+	}
+	return entry.Harness, nil
+}

--- a/pkg/hub/resource_bootstrap_test.go
+++ b/pkg/hub/resource_bootstrap_test.go
@@ -1,0 +1,283 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/storage"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/GoogleCloudPlatform/scion/resources"
+)
+
+func TestBootstrapBundledResources_EmptyDB(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	err := srv.BootstrapBundledResources(ctx, BootstrapOptions{
+		RepairStorage:   true,
+		OverwritePolicy: OverwriteBuiltinManaged,
+	})
+	if err != nil {
+		t.Fatalf("BootstrapBundledResources failed: %v", err)
+	}
+
+	// Verify templates were created
+	templates, err := s.ListTemplates(ctx, store.TemplateFilter{}, store.ListOptions{Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedTemplates := len(resources.BuiltinTemplates())
+	if templates.TotalCount != expectedTemplates {
+		t.Errorf("expected %d templates, got %d", expectedTemplates, templates.TotalCount)
+	}
+	for _, tmpl := range templates.Items {
+		if tmpl.Status != store.TemplateStatusActive {
+			t.Errorf("template %q: expected active status, got %q", tmpl.Name, tmpl.Status)
+		}
+		if !IsBuiltinManaged(tmpl.SourceURL) {
+			t.Errorf("template %q: expected built-in source URL, got %q", tmpl.Name, tmpl.SourceURL)
+		}
+		if tmpl.ContentHash == "" {
+			t.Errorf("template %q: expected non-empty content hash", tmpl.Name)
+		}
+		if len(tmpl.Files) == 0 {
+			t.Errorf("template %q: expected files, got none", tmpl.Name)
+		}
+	}
+
+	// Verify harness-configs were created
+	configs, err := s.ListHarnessConfigs(ctx, store.HarnessConfigFilter{}, store.ListOptions{Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedConfigs := len(resources.BuiltinHarnessConfigs())
+	if configs.TotalCount != expectedConfigs {
+		t.Errorf("expected %d harness configs, got %d", expectedConfigs, configs.TotalCount)
+	}
+	for _, hc := range configs.Items {
+		if hc.Status != store.HarnessConfigStatusActive {
+			t.Errorf("harness-config %q: expected active status, got %q", hc.Name, hc.Status)
+		}
+		if !IsBuiltinManaged(hc.SourceURL) {
+			t.Errorf("harness-config %q: expected built-in source URL, got %q", hc.Name, hc.SourceURL)
+		}
+		if hc.ContentHash == "" {
+			t.Errorf("harness-config %q: expected non-empty content hash", hc.Name)
+		}
+		if hc.Harness == "" {
+			t.Errorf("harness-config %q: expected non-empty harness type", hc.Name)
+		}
+	}
+}
+
+func TestBootstrapBundledResources_Idempotent(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	opts := BootstrapOptions{
+		RepairStorage:   true,
+		OverwritePolicy: OverwriteBuiltinManaged,
+	}
+
+	// First run: creates everything
+	if err := srv.BootstrapBundledResources(ctx, opts); err != nil {
+		t.Fatalf("first BootstrapBundledResources failed: %v", err)
+	}
+
+	// Capture state after first run
+	templates1, _ := s.ListTemplates(ctx, store.TemplateFilter{}, store.ListOptions{Limit: 100})
+	configs1, _ := s.ListHarnessConfigs(ctx, store.HarnessConfigFilter{}, store.ListOptions{Limit: 100})
+
+	templateHashes := make(map[string]string)
+	for _, tmpl := range templates1.Items {
+		templateHashes[tmpl.Slug] = tmpl.ContentHash
+	}
+	configHashes := make(map[string]string)
+	for _, hc := range configs1.Items {
+		configHashes[hc.Slug] = hc.ContentHash
+	}
+
+	// Second run: should be no-op
+	if err := srv.BootstrapBundledResources(ctx, opts); err != nil {
+		t.Fatalf("second BootstrapBundledResources failed: %v", err)
+	}
+
+	// Verify counts are unchanged
+	templates2, _ := s.ListTemplates(ctx, store.TemplateFilter{}, store.ListOptions{Limit: 100})
+	configs2, _ := s.ListHarnessConfigs(ctx, store.HarnessConfigFilter{}, store.ListOptions{Limit: 100})
+
+	if templates2.TotalCount != templates1.TotalCount {
+		t.Errorf("template count changed: %d -> %d", templates1.TotalCount, templates2.TotalCount)
+	}
+	if configs2.TotalCount != configs1.TotalCount {
+		t.Errorf("harness-config count changed: %d -> %d", configs1.TotalCount, configs2.TotalCount)
+	}
+
+	// Verify content hashes are unchanged
+	for _, tmpl := range templates2.Items {
+		if tmpl.ContentHash != templateHashes[tmpl.Slug] {
+			t.Errorf("template %q content hash changed on idempotent re-run", tmpl.Name)
+		}
+	}
+	for _, hc := range configs2.Items {
+		if hc.ContentHash != configHashes[hc.Slug] {
+			t.Errorf("harness-config %q content hash changed on idempotent re-run", hc.Name)
+		}
+	}
+}
+
+func TestBootstrapBundledResources_ParallelConverges(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	opts := BootstrapOptions{
+		RepairStorage:   true,
+		OverwritePolicy: OverwriteBuiltinManaged,
+	}
+
+	// Run two bootstraps in parallel to simulate HA replicas
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := range 2 {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = srv.BootstrapBundledResources(ctx, opts)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("parallel bootstrap %d failed: %v", i, err)
+		}
+	}
+
+	// Verify exactly one copy of each resource exists
+	templates, _ := s.ListTemplates(ctx, store.TemplateFilter{}, store.ListOptions{Limit: 100})
+	expectedTemplates := len(resources.BuiltinTemplates())
+	if templates.TotalCount != expectedTemplates {
+		t.Errorf("expected %d templates after parallel bootstrap, got %d", expectedTemplates, templates.TotalCount)
+	}
+
+	configs, _ := s.ListHarnessConfigs(ctx, store.HarnessConfigFilter{}, store.ListOptions{Limit: 100})
+	expectedConfigs := len(resources.BuiltinHarnessConfigs())
+	if configs.TotalCount != expectedConfigs {
+		t.Errorf("expected %d harness-configs after parallel bootstrap, got %d", expectedConfigs, configs.TotalCount)
+	}
+
+	// All resources should be active
+	for _, tmpl := range templates.Items {
+		if tmpl.Status != store.TemplateStatusActive {
+			t.Errorf("template %q: expected active after parallel bootstrap, got %q", tmpl.Name, tmpl.Status)
+		}
+	}
+	for _, hc := range configs.Items {
+		if hc.Status != store.HarnessConfigStatusActive {
+			t.Errorf("harness-config %q: expected active after parallel bootstrap, got %q", hc.Name, hc.Status)
+		}
+	}
+}
+
+func TestBootstrapBundledResources_NoLocalDirRequired(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	// BootstrapBundledResources reads from the embedded FS, not from
+	// ~/.scion/templates/default. This test verifies it succeeds even
+	// when no local template directory exists (which is always the case
+	// in the test environment).
+	err := srv.BootstrapBundledResources(ctx, BootstrapOptions{
+		RepairStorage:   true,
+		OverwritePolicy: OverwriteBuiltinManaged,
+	})
+	if err != nil {
+		t.Fatalf("BootstrapBundledResources failed (no local dir): %v", err)
+	}
+
+	templates, _ := s.ListTemplates(ctx, store.TemplateFilter{}, store.ListOptions{Limit: 100})
+	if templates.TotalCount == 0 {
+		t.Error("expected at least one template from bundled resources, got 0")
+	}
+}
+
+func TestBootstrapBundledResources_NoStorage(t *testing.T) {
+	srv, _, _ := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	// Remove the storage backend to verify graceful handling
+	srv.SetStorage(nil)
+
+	err := srv.BootstrapBundledResources(ctx, BootstrapOptions{
+		OverwritePolicy: OverwriteBuiltinManaged,
+	})
+	if err != nil {
+		t.Fatalf("expected nil error without storage, got: %v", err)
+	}
+}
+
+func TestResolveHarnessType(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   map[string]string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "valid config",
+			files: map[string]string{"config.yaml": "harness: claude\nimage: test:latest\n"},
+			want:  "claude",
+		},
+		{
+			name:    "missing config.yaml",
+			files:   map[string]string{"other.txt": "data"},
+			wantErr: true,
+		},
+		{
+			name:    "missing harness field",
+			files:   map[string]string{"config.yaml": "image: test:latest\n"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := resources.BundledResource{
+				Kind: storage.ResourceKindHarnessConfig,
+				Name: "test",
+				FS:   testFS(tt.files),
+				Root: ".",
+			}
+			got, err := resolveHarnessType(r)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/hub/resource_source_test.go
+++ b/pkg/hub/resource_source_test.go
@@ -369,6 +369,10 @@ func TestBootstrapSource_SkipNonBuiltinConflict(t *testing.T) {
 	}
 }
 
+// TODO: This test exercises the normal update path (GetBySlug finds pre-existing record).
+// A proper race test requires a mock persistence where GetBySlug returns nil on first call
+// but Create returns ErrAlreadyExists, simulating the HA window between read and write.
+// Add this test before or alongside the HA integration tests.
 func TestBootstrapSource_DuplicateCreateRace(t *testing.T) {
 	srv, s, _ := testTemplateBootstrapServer(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Introduces direct bundled resource promotion for hosted Hub startup, removing the dependency on local `~/.scion` seed directories. This is PR 4 of a 7-PR bundled resource bootstrap plan.

- Add `Server.BootstrapBundledResources(ctx, opts)` in new `pkg/hub/resource_bootstrap.go`
  - Iterates `resources.BuiltinResources()` (Templates + Harness-configs from PR 2 catalog)
  - Routes each resource to the correct store (templateStore / harnessConfigStore)
  - Resolves harness type dynamically from the bundled `config.yaml` (not hardcoded)
  - Accumulates errors — one failing resource does not abort the rest
  - Graceful no-op when no storage backend is configured
- Update `cmd/server_foreground.go`:
  - Hosted mode: calls `BootstrapBundledResources(RepairStorage: true)` — no local filesystem dependency
  - Workstation mode: retains existing `BootstrapTemplatesFromDir` / `BootstrapHarnessConfigsFromDir` path
  - `UpdateDefaultTemplates` gated to workstation-only (removed from hosted startup)
- 6 integration tests: empty DB creation, idempotent re-run, parallel convergence (HA-safe), no `~/.scion` dependency, no-storage graceful skip, harness type resolver
- Add TODO comment on race recovery test from PR 3

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./pkg/hub/...` passes (includes 6 new integration tests)
- [ ] `go test ./cmd/...` passes
- [ ] Hosted startup with empty DB creates all bundled resources
- [ ] Hosted startup is idempotent on re-run
- [ ] Two parallel hosted startups converge without duplicates
- [ ] Hosted startup does not require `~/.scion/templates/default` to exist
