### PR TITLE
config: MaterializeBundledResources for workstation local seeding

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -99,7 +99,7 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 		// In workstation mode, refresh the default template and harness-configs
 		// from the binary's embeds. Hosted mode bootstraps directly into the Hub
 		// via BootstrapBundledResources, bypassing local ~/.scion materialization.
-		if err := config.UpdateDefaultTemplates(true, harness.EmbedOnlyHarnesses(), harness.HarnessesFS()); err != nil {
+		if err := config.UpdateDefaultTemplates(true, harness.EmbedOnlyHarnesses()); err != nil {
 			log.Printf("Warning: failed to refresh default templates: %v", err)
 		}
 	}

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -626,7 +626,7 @@ If the default template already exists, a warning is printed and no changes
 are made. Use --force to overwrite the existing default template.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		force, _ := cmd.Flags().GetBool("force")
-		err := config.UpdateDefaultTemplates(force, harness.EmbedOnlyHarnesses(), harness.HarnessesFS())
+		err := config.UpdateDefaultTemplates(force, harness.EmbedOnlyHarnesses())
 		if err != nil {
 			return err
 		}

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -589,7 +589,6 @@ func InitMachine(harnesses []api.Harness, opts ...InitMachineOpts) error {
 		opt = opts[0]
 	}
 
-	templatesDir := filepath.Join(globalDir, "templates")
 	agentsDir := filepath.Join(globalDir, "agents")
 	harnessConfigsDir := filepath.Join(globalDir, harnessConfigsDirName)
 
@@ -597,18 +596,9 @@ func InitMachine(harnesses []api.Harness, opts ...InitMachineOpts) error {
 		return fmt.Errorf("failed to create global agents directory: %w", err)
 	}
 
-	// Seed default agnostic template
-	if err := SeedAgnosticTemplate(filepath.Join(templatesDir, "default"), opt.Force); err != nil {
-		return fmt.Errorf("failed to seed global default agnostic template: %w", err)
-	}
-
-	// Seed all directory-based harnesses unconditionally from the embedded
-	// harnesses/ FS. The directories are inert until activated, so seeding
-	// them all is safe. Selective materialization will be addressed in PR 5.
-	if opt.HarnessesFS != nil {
-		if err := SeedAllHarnessConfigsFromEmbed(harnessConfigsDir, opt.HarnessesFS, opt.Force); err != nil {
-			return fmt.Errorf("failed to seed harness-configs from embed: %w", err)
-		}
+	// Materialize all bundled Templates and Harness-configs from the catalog.
+	if err := MaterializeBundledResources(globalDir, MaterializeOptions{Force: opt.Force}); err != nil {
+		return fmt.Errorf("failed to materialize bundled resources: %w", err)
 	}
 
 	// Seed embed-only harnesses (those still using compiled-in embeds, e.g. Gemini).

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -543,9 +543,15 @@ type InitMachineOpts struct {
 	Force bool
 
 	// HarnessesFS is the embedded harnesses/ filesystem used to seed
-	// directory-based harness-configs. When non-nil, SeedAllHarnessConfigsFromEmbed
-	// is called to seed all harnesses found in the FS.
+	// directory-based harness-configs. Kept for backward compatibility with
+	// upgrade code; the primary seeding path now uses MaterializeBundledResources.
 	HarnessesFS fs.FS
+
+	// SelectedHarnessConfigs, when non-nil, restricts harness-config
+	// materialization to only the named configs. Templates are still
+	// materialized unconditionally. An empty non-nil slice skips all
+	// harness-config materialization.
+	SelectedHarnessConfigs []string
 }
 
 // InitMachine performs full global/machine-level setup: creates ~/.scion/,
@@ -596,9 +602,19 @@ func InitMachine(harnesses []api.Harness, opts ...InitMachineOpts) error {
 		return fmt.Errorf("failed to create global agents directory: %w", err)
 	}
 
-	// Materialize all bundled Templates and Harness-configs from the catalog.
-	if err := MaterializeBundledResources(globalDir, MaterializeOptions{Force: opt.Force}); err != nil {
-		return fmt.Errorf("failed to materialize bundled resources: %w", err)
+	matOpts := MaterializeOptions{Force: opt.Force}
+	if opt.SelectedHarnessConfigs != nil {
+		// Selective mode: materialize only templates + named harness-configs.
+		if err := MaterializeBundledTemplates(globalDir, matOpts); err != nil {
+			return fmt.Errorf("failed to materialize bundled templates: %w", err)
+		}
+		if err := MaterializeSelectedHarnessConfigs(globalDir, opt.SelectedHarnessConfigs, matOpts); err != nil {
+			return fmt.Errorf("failed to materialize selected harness-configs: %w", err)
+		}
+	} else {
+		if err := MaterializeBundledResources(globalDir, matOpts); err != nil {
+			return fmt.Errorf("failed to materialize bundled resources: %w", err)
+		}
 	}
 
 	// Seed embed-only harnesses (those still using compiled-in embeds, e.g. Gemini).

--- a/pkg/config/materialize.go
+++ b/pkg/config/materialize.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/storage"
+	"github.com/GoogleCloudPlatform/scion/resources"
+)
+
+// MaterializeOptions controls the behavior of MaterializeBundledResources.
+type MaterializeOptions struct {
+	Force bool
+}
+
+// MaterializeBundledResources writes bundled Templates and Harness-configs to
+// the local filesystem for workstation compatibility. It uses the same
+// resources.BuiltinResources() catalog as the hosted bootstrap path.
+func MaterializeBundledResources(globalDir string, opts MaterializeOptions) error {
+	for _, res := range resources.BuiltinResources() {
+		switch res.Kind {
+		case storage.ResourceKindTemplate:
+			targetDir := filepath.Join(globalDir, "templates", res.Name)
+			if err := materializeTemplateFromFS(targetDir, res.FS, res.Root, opts.Force); err != nil {
+				return fmt.Errorf("failed to materialize template %q: %w", res.Name, err)
+			}
+		case storage.ResourceKindHarnessConfig:
+			targetDir := filepath.Join(globalDir, harnessConfigsDirName, res.Name)
+			if err := SeedHarnessConfigFromDir(targetDir, res.FS, res.Root, opts.Force); err != nil {
+				return fmt.Errorf("failed to materialize harness-config %q: %w", res.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+// MaterializeSelectedHarnessConfigs materializes only the named harness-configs
+// from the bundled catalog. Returns an error if a requested name is not found
+// in the catalog.
+func MaterializeSelectedHarnessConfigs(globalDir string, names []string, opts MaterializeOptions) error {
+	catalog := make(map[string]resources.BundledResource)
+	for _, res := range resources.BuiltinHarnessConfigs() {
+		catalog[res.Name] = res
+	}
+
+	for _, name := range names {
+		res, ok := catalog[name]
+		if !ok {
+			return fmt.Errorf("harness-config %q is not in the bundled catalog", name)
+		}
+		targetDir := filepath.Join(globalDir, harnessConfigsDirName, res.Name)
+		if err := SeedHarnessConfigFromDir(targetDir, res.FS, res.Root, opts.Force); err != nil {
+			return fmt.Errorf("failed to materialize harness-config %q: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// materializeTemplateFromFS writes a template from an fs.FS to the target
+// directory. It walks all files and directories, preserving existing files
+// unless force is true.
+func materializeTemplateFromFS(targetDir string, srcFS fs.FS, root string, force bool) error {
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return fmt.Errorf("failed to create template directory %s: %w", targetDir, err)
+	}
+
+	return fs.WalkDir(srcFS, root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(root, filepath.ToSlash(path))
+		if err != nil {
+			return fmt.Errorf("failed to compute relative path for %s: %w", path, err)
+		}
+
+		if relPath == "." {
+			return nil
+		}
+
+		targetPath := filepath.Join(targetDir, relPath)
+
+		if d.IsDir() {
+			if err := os.MkdirAll(targetPath, 0755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", targetPath, err)
+			}
+			return nil
+		}
+
+		data, err := fs.ReadFile(srcFS, path)
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %w", path, err)
+		}
+
+		if !force {
+			if _, err := os.Stat(targetPath); err == nil {
+				return nil
+			}
+		}
+
+		if err := os.WriteFile(targetPath, data, 0644); err != nil {
+			return fmt.Errorf("failed to write file %s: %w", targetPath, err)
+		}
+
+		return nil
+	})
+}

--- a/pkg/config/materialize.go
+++ b/pkg/config/materialize.go
@@ -29,6 +29,19 @@ type MaterializeOptions struct {
 	Force bool
 }
 
+// MaterializeBundledTemplates writes only the bundled Templates to the local
+// filesystem. Use this when harness-config materialization is handled
+// separately (e.g. selective materialization in handleSystemInit).
+func MaterializeBundledTemplates(globalDir string, opts MaterializeOptions) error {
+	for _, res := range resources.BuiltinTemplates() {
+		targetDir := filepath.Join(globalDir, "templates", res.Name)
+		if err := materializeTemplateFromFS(targetDir, res.FS, res.Root, opts.Force); err != nil {
+			return fmt.Errorf("failed to materialize template %q: %w", res.Name, err)
+		}
+	}
+	return nil
+}
+
 // MaterializeBundledResources writes bundled Templates and Harness-configs to
 // the local filesystem for workstation compatibility. It uses the same
 // resources.BuiltinResources() catalog as the hosted bootstrap path.

--- a/pkg/config/materialize_test.go
+++ b/pkg/config/materialize_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/resources"
+)
+
+func TestMaterializeBundledResources_SeedsAllResources(t *testing.T) {
+	globalDir := t.TempDir()
+
+	if err := MaterializeBundledResources(globalDir, MaterializeOptions{}); err != nil {
+		t.Fatalf("MaterializeBundledResources failed: %v", err)
+	}
+
+	// Verify the default template was seeded.
+	templateDir := filepath.Join(globalDir, "templates", "default")
+	if _, err := os.Stat(filepath.Join(templateDir, "scion-agent.yaml")); err != nil {
+		t.Errorf("expected scion-agent.yaml in default template: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(templateDir, "system-prompt.md")); err != nil {
+		t.Errorf("expected system-prompt.md in default template: %v", err)
+	}
+
+	// Verify all bundled harness-configs were seeded.
+	for _, res := range resources.BuiltinHarnessConfigs() {
+		configPath := filepath.Join(globalDir, "harness-configs", res.Name, "config.yaml")
+		if _, err := os.Stat(configPath); err != nil {
+			t.Errorf("expected config.yaml for harness-config %q: %v", res.Name, err)
+		}
+	}
+}
+
+func TestMaterializeBundledResources_PreservesExistingWithoutForce(t *testing.T) {
+	globalDir := t.TempDir()
+
+	if err := MaterializeBundledResources(globalDir, MaterializeOptions{}); err != nil {
+		t.Fatalf("initial MaterializeBundledResources failed: %v", err)
+	}
+
+	// Modify a template file.
+	customContent := []byte("# custom user content")
+	customFile := filepath.Join(globalDir, "templates", "default", "system-prompt.md")
+	if err := os.WriteFile(customFile, customContent, 0644); err != nil {
+		t.Fatalf("failed to write custom file: %v", err)
+	}
+
+	// Re-materialize without force.
+	if err := MaterializeBundledResources(globalDir, MaterializeOptions{}); err != nil {
+		t.Fatalf("second MaterializeBundledResources failed: %v", err)
+	}
+
+	// Verify the custom content was preserved.
+	data, err := os.ReadFile(customFile)
+	if err != nil {
+		t.Fatalf("failed to read custom file: %v", err)
+	}
+	if string(data) != string(customContent) {
+		t.Errorf("expected custom content to be preserved, got %q", string(data))
+	}
+}
+
+func TestMaterializeBundledResources_ForceOverwrites(t *testing.T) {
+	globalDir := t.TempDir()
+
+	if err := MaterializeBundledResources(globalDir, MaterializeOptions{}); err != nil {
+		t.Fatalf("initial MaterializeBundledResources failed: %v", err)
+	}
+
+	// Modify a template file.
+	customContent := []byte("# custom user content")
+	customFile := filepath.Join(globalDir, "templates", "default", "system-prompt.md")
+	if err := os.WriteFile(customFile, customContent, 0644); err != nil {
+		t.Fatalf("failed to write custom file: %v", err)
+	}
+
+	// Re-materialize with force.
+	if err := MaterializeBundledResources(globalDir, MaterializeOptions{Force: true}); err != nil {
+		t.Fatalf("force MaterializeBundledResources failed: %v", err)
+	}
+
+	// Verify the custom content was overwritten.
+	data, err := os.ReadFile(customFile)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	if string(data) == string(customContent) {
+		t.Error("expected custom content to be overwritten with force=true")
+	}
+}
+
+func TestMaterializeBundledResources_RestoresDeletedFiles(t *testing.T) {
+	globalDir := t.TempDir()
+
+	if err := MaterializeBundledResources(globalDir, MaterializeOptions{}); err != nil {
+		t.Fatalf("initial MaterializeBundledResources failed: %v", err)
+	}
+
+	// Delete a built-in file.
+	targetFile := filepath.Join(globalDir, "templates", "default", "system-prompt.md")
+	if err := os.Remove(targetFile); err != nil {
+		t.Fatalf("failed to remove file: %v", err)
+	}
+
+	// Re-materialize (without force — deleted files should still be restored).
+	if err := MaterializeBundledResources(globalDir, MaterializeOptions{}); err != nil {
+		t.Fatalf("second MaterializeBundledResources failed: %v", err)
+	}
+
+	if _, err := os.Stat(targetFile); err != nil {
+		t.Errorf("expected deleted file to be restored: %v", err)
+	}
+}
+
+func TestMaterializeSelectedHarnessConfigs_SeedsOnlyNamed(t *testing.T) {
+	globalDir := t.TempDir()
+
+	if err := MaterializeSelectedHarnessConfigs(globalDir, []string{"claude"}, MaterializeOptions{}); err != nil {
+		t.Fatalf("MaterializeSelectedHarnessConfigs failed: %v", err)
+	}
+
+	// Claude should be seeded.
+	claudeConfig := filepath.Join(globalDir, "harness-configs", "claude", "config.yaml")
+	if _, err := os.Stat(claudeConfig); err != nil {
+		t.Errorf("expected claude config.yaml: %v", err)
+	}
+
+	// Other harness-configs should NOT be seeded.
+	allConfigs := resources.BuiltinHarnessConfigs()
+	for _, res := range allConfigs {
+		if res.Name == "claude" {
+			continue
+		}
+		otherConfig := filepath.Join(globalDir, "harness-configs", res.Name, "config.yaml")
+		if _, err := os.Stat(otherConfig); err == nil {
+			t.Errorf("harness-config %q should not have been seeded in selective mode", res.Name)
+		}
+	}
+}
+
+func TestMaterializeSelectedHarnessConfigs_UnknownReturnsError(t *testing.T) {
+	globalDir := t.TempDir()
+
+	err := MaterializeSelectedHarnessConfigs(globalDir, []string{"nonexistent-harness"}, MaterializeOptions{})
+	if err == nil {
+		t.Fatal("expected error for unknown harness-config name")
+	}
+}
+
+func TestMaterializeBundledTemplates_SeedsTemplatesOnly(t *testing.T) {
+	globalDir := t.TempDir()
+
+	if err := MaterializeBundledTemplates(globalDir, MaterializeOptions{}); err != nil {
+		t.Fatalf("MaterializeBundledTemplates failed: %v", err)
+	}
+
+	// Template should be seeded.
+	templateDir := filepath.Join(globalDir, "templates", "default")
+	if _, err := os.Stat(filepath.Join(templateDir, "scion-agent.yaml")); err != nil {
+		t.Errorf("expected scion-agent.yaml in default template: %v", err)
+	}
+
+	// No harness-configs should be seeded.
+	harnessConfigsDir := filepath.Join(globalDir, "harness-configs")
+	if _, err := os.Stat(harnessConfigsDir); err == nil {
+		entries, _ := os.ReadDir(harnessConfigsDir)
+		if len(entries) > 0 {
+			t.Errorf("expected no harness-configs, got %d entries", len(entries))
+		}
+	}
+}

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -465,7 +464,7 @@ func CloneTemplate(srcName, destName string, global bool) error {
 	return nil
 }
 
-func UpdateDefaultTemplates(force bool, harnesses []api.Harness, harnessesFS ...fs.FS) error {
+func UpdateDefaultTemplates(force bool, harnesses []api.Harness) error {
 	globalDir, err := GetGlobalDir()
 	if err != nil {
 		return err

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -471,34 +471,24 @@ func UpdateDefaultTemplates(force bool, harnesses []api.Harness, harnessesFS ...
 		return err
 	}
 
-	templatesDir, err := GetGlobalTemplatesDir()
-	if err != nil {
-		return err
-	}
 	harnessConfigsDir := filepath.Join(globalDir, harnessConfigsDirName)
 
-	defaultDir := filepath.Join(templatesDir, "default")
-
-	// Check if the default template already exists
 	if !force {
+		templatesDir, err := GetGlobalTemplatesDir()
+		if err != nil {
+			return err
+		}
+		defaultDir := filepath.Join(templatesDir, "default")
 		if _, err := os.Stat(defaultDir); err == nil {
 			return fmt.Errorf("default template already exists at %s; use --force to overwrite", defaultDir)
 		}
 	}
 
-	// Update default agnostic template
-	if err := SeedAgnosticTemplate(defaultDir, true); err != nil {
+	if err := MaterializeBundledResources(globalDir, MaterializeOptions{Force: true}); err != nil {
 		return err
 	}
 
-	// Seed directory-based harnesses from the embedded harnesses/ FS.
-	if len(harnessesFS) > 0 && harnessesFS[0] != nil {
-		if err := SeedAllHarnessConfigsFromEmbed(harnessConfigsDir, harnessesFS[0], true); err != nil {
-			return err
-		}
-	}
-
-	// Update embed-only harness-configs
+	// Seed embed-only harness-configs (e.g. Gemini).
 	for _, h := range harnesses {
 		if err := SeedHarnessConfig(filepath.Join(harnessConfigsDir, h.Name()), h, true); err != nil {
 			return err

--- a/pkg/hub/system_handlers.go
+++ b/pkg/hub/system_handlers.go
@@ -356,30 +356,28 @@ func (s *Server) handleSystemInit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(req.Harnesses) == 0 {
+		ValidationError(w, "at least one harness must be specified", nil)
+		return
+	}
+
 	allNames := harness.AllHarnessNames()
 	allowed := make(map[string]bool, len(allNames))
 	for _, n := range allNames {
 		allowed[n] = true
 	}
 
-	var selected []string
 	for _, name := range req.Harnesses {
 		if !allowed[name] {
 			ValidationError(w, fmt.Sprintf("unknown harness %q", name), nil)
 			return
 		}
-		selected = append(selected, name)
 	}
 
-	if len(selected) == 0 {
-		ValidationError(w, "at least one harness must be specified", nil)
-		return
-	}
-
-	// Build embed-only harness instances for selected names
+	// Build embed-only harness instances for selected names only.
 	var embedOnlyInstances []api.Harness
 	for _, h := range harness.EmbedOnlyHarnesses() {
-		for _, name := range selected {
+		for _, name := range req.Harnesses {
 			if h.Name() == name {
 				embedOnlyInstances = append(embedOnlyInstances, h)
 				break
@@ -387,10 +385,9 @@ func (s *Server) handleSystemInit(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Directory-based harnesses are seeded unconditionally via HarnessesFS;
-	// the directories are inert until activated. Selective materialization
-	// based on the user's selection will be addressed in PR 5.
-	opts := config.InitMachineOpts{HarnessesFS: harness.HarnessesFS()}
+	opts := config.InitMachineOpts{
+		SelectedHarnessConfigs: req.Harnesses,
+	}
 	if err := config.InitMachine(embedOnlyInstances, opts); err != nil {
 		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
 			fmt.Sprintf("initialization failed: %s", err.Error()), nil)

--- a/pkg/hub/system_handlers.go
+++ b/pkg/hub/system_handlers.go
@@ -390,7 +390,7 @@ func (s *Server) handleSystemInit(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	var catalogNames []string
+	catalogNames := []string{}
 	for _, name := range req.Harnesses {
 		if !embedOnlyNames[name] {
 			catalogNames = append(catalogNames, name)

--- a/pkg/hub/system_handlers.go
+++ b/pkg/hub/system_handlers.go
@@ -374,9 +374,14 @@ func (s *Server) handleSystemInit(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Build embed-only harness instances for selected names only.
+	// Partition requested harnesses into catalog-based and embed-only.
+	// Embed-only harnesses (e.g. Gemini) are handled by the SeedHarnessConfig
+	// loop in InitMachine and must not appear in SelectedHarnessConfigs, which
+	// only searches the bundled catalog.
+	embedOnlyNames := make(map[string]bool)
 	var embedOnlyInstances []api.Harness
 	for _, h := range harness.EmbedOnlyHarnesses() {
+		embedOnlyNames[h.Name()] = true
 		for _, name := range req.Harnesses {
 			if h.Name() == name {
 				embedOnlyInstances = append(embedOnlyInstances, h)
@@ -385,8 +390,15 @@ func (s *Server) handleSystemInit(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	var catalogNames []string
+	for _, name := range req.Harnesses {
+		if !embedOnlyNames[name] {
+			catalogNames = append(catalogNames, name)
+		}
+	}
+
 	opts := config.InitMachineOpts{
-		SelectedHarnessConfigs: req.Harnesses,
+		SelectedHarnessConfigs: catalogNames,
 	}
 	if err := config.InitMachine(embedOnlyInstances, opts); err != nil {
 		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,

--- a/pkg/hub/system_handlers_test.go
+++ b/pkg/hub/system_handlers_test.go
@@ -193,6 +193,43 @@ func TestSystemInit_EmptyHarnesses(t *testing.T) {
 	}
 }
 
+func TestSystemInit_SelectiveHarnessConfig(t *testing.T) {
+	srv, _ := testWorkstationServer(t)
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	restore := config.OverrideRuntimeDetection(
+		func(string) (string, error) { return "/usr/bin/docker", nil },
+		func(string, []string) error { return nil },
+	)
+	defer restore()
+
+	rec := doWorkstationRequest(t, srv, http.MethodPost, "/api/v1/system/init", map[string]interface{}{
+		"harnesses": []string{"codex"},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Codex harness-config should be seeded.
+	codexConfig := filepath.Join(tmpHome, ".scion", "harness-configs", "codex", "config.yaml")
+	if _, err := os.Stat(codexConfig); err != nil {
+		t.Errorf("expected codex config.yaml to be created: %v", err)
+	}
+
+	// Claude should NOT be seeded (selective materialization).
+	claudeConfig := filepath.Join(tmpHome, ".scion", "harness-configs", "claude", "config.yaml")
+	if _, err := os.Stat(claudeConfig); err == nil {
+		t.Error("expected claude config.yaml to NOT be created in selective mode")
+	}
+
+	// Default template should always be seeded.
+	templateFile := filepath.Join(tmpHome, ".scion", "templates", "default", "scion-agent.yaml")
+	if _, err := os.Stat(templateFile); err != nil {
+		t.Errorf("expected default template scion-agent.yaml to be created: %v", err)
+	}
+}
+
 // ============================================================================
 // PUT /system/identity
 // ============================================================================

--- a/pkg/hub/system_handlers_test.go
+++ b/pkg/hub/system_handlers_test.go
@@ -230,6 +230,32 @@ func TestSystemInit_SelectiveHarnessConfig(t *testing.T) {
 	}
 }
 
+func TestSystemInit_EmbedOnlyHarness(t *testing.T) {
+	srv, _ := testWorkstationServer(t)
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	restore := config.OverrideRuntimeDetection(
+		func(string) (string, error) { return "/usr/bin/docker", nil },
+		func(string, []string) error { return nil },
+	)
+	defer restore()
+
+	// Gemini is embed-only (not in the bundled catalog). This must not 500.
+	rec := doWorkstationRequest(t, srv, http.MethodPost, "/api/v1/system/init", map[string]interface{}{
+		"harnesses": []string{"gemini"},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Gemini harness-config should be seeded via the embed-only path.
+	geminiConfig := filepath.Join(tmpHome, ".scion", "harness-configs", "gemini", "config.yaml")
+	if _, err := os.Stat(geminiConfig); err != nil {
+		t.Errorf("expected gemini config.yaml to be created: %v", err)
+	}
+}
+
 // ============================================================================
 // PUT /system/identity
 // ============================================================================


### PR DESCRIPTION
## Summary

Refactors workstation local seeding to use the same bundled resource catalog as the hosted bootstrap path, and fixes `handleSystemInit` selective materialization. This is PR 5 of a 7-PR bundled resource bootstrap plan.

- Add `pkg/config/materialize.go`: `MaterializeBundledResources`, `MaterializeBundledTemplates`, `MaterializeSelectedHarnessConfigs`
  - Backed by `resources.BuiltinResources()` — same catalog as hosted bootstrap (PR 4)
  - Preserves existing files without `Force`; restores deleted files; overwrites with `Force`
- Update `scion init --machine` (`InitMachine`) to call `MaterializeBundledResources` instead of `SeedAgnosticTemplate` + `SeedAllHarnessConfigsFromEmbed` separately
- Update `UpdateDefaultTemplates` to use catalog-backed materialization
- Fix `handleSystemInit` selective materialization:
  - Only materializes the specific harnesses requested, not all directory-based harnesses
  - Correctly partitions catalog-based vs embed-only harnesses (Gemini → embed-only path)
  - Unknown harness names return a validation error (not a silent no-op)
  - Removes the temporary "seeded unconditionally" comment from PR 1
- 7 unit tests + 2 integration tests (selective init, embed-only harness routing)

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./pkg/config/...` passes (7 unit tests)
- [ ] `go test ./pkg/hub/...` passes (integration tests)
- [ ] `scion init --machine` seeds all bundled Templates and Harness-configs
- [ ] Existing files preserved without `--force`
- [ ] `POST /system/init {harnesses: [codex]}` seeds only codex harness-config
- [ ] `POST /system/init {harnesses: [gemini]}` succeeds (embed-only path)
- [ ] `POST /system/init {harnesses: [unknown]}` returns validation error
