### PR TITLE
harness: remove legacy seeding dead code and fix logger subsystem

### DIFF
--- a/cmd/harness_config_test.go
+++ b/cmd/harness_config_test.go
@@ -38,7 +38,7 @@ func TestHarnessConfigList(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 
 	// Seed harness-configs via InitMachine
-	require.NoError(t, config.InitMachine(harness.EmbedOnlyHarnesses(), config.InitMachineOpts{HarnessesFS: harness.HarnessesFS()}))
+	require.NoError(t, config.InitMachine(harness.EmbedOnlyHarnesses()))
 
 	// List harness-configs
 	globalDir, err := config.GetGlobalDir()
@@ -72,7 +72,7 @@ func TestHarnessConfigReset(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 
 	// Seed harness-configs via InitMachine
-	require.NoError(t, config.InitMachine(harness.EmbedOnlyHarnesses(), config.InitMachineOpts{HarnessesFS: harness.HarnessesFS()}))
+	require.NoError(t, config.InitMachine(harness.EmbedOnlyHarnesses()))
 
 	globalDir, err := config.GetGlobalDir()
 	require.NoError(t, err)

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -81,7 +81,6 @@ With --global, it initializes in the user's home folder.`,
 			opts := config.InitMachineOpts{
 				ImageRegistry: registryValue,
 				Force:         machineInitForce,
-				HarnessesFS:   harness.HarnessesFS(),
 			}
 			if err := config.InitMachine(embedOnlyHarnesses, opts); err != nil {
 				return fmt.Errorf("failed to initialize global config: %w", err)

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -92,7 +92,7 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 	}
 	if _, err := os.Stat(globalDir); os.IsNotExist(err) {
 		log.Println("Initializing global scion directory...")
-		if err := config.InitGlobal(harness.EmbedOnlyHarnesses(), config.InitMachineOpts{HarnessesFS: harness.HarnessesFS()}); err != nil {
+		if err := config.InitGlobal(harness.EmbedOnlyHarnesses()); err != nil {
 			return fmt.Errorf("failed to initialize global config: %w", err)
 		}
 	} else if !hostedMode {

--- a/pkg/api/harness.go
+++ b/pkg/api/harness.go
@@ -35,10 +35,6 @@ type Harness interface {
 	// from filepath.Dir(agentHome) when split storage is active).
 	Provision(ctx context.Context, agentName, agentDir, agentHome, agentWorkspace string) error
 
-	// GetEmbedDir returns the name of the directory in pkg/config/embeds/
-	// that contains template files for this harness (e.g., "claude", "gemini").
-	GetEmbedDir() string
-
 	// GetInterruptKey returns the key sequence used to interrupt the harness process (e.g., "C-c" or "Escape").
 	GetInterruptKey() string
 

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -542,11 +542,6 @@ type InitMachineOpts struct {
 	// versions embedded in the binary. Use this to refresh after a binary upgrade.
 	Force bool
 
-	// HarnessesFS is the embedded harnesses/ filesystem used to seed
-	// directory-based harness-configs. Kept for backward compatibility with
-	// upgrade code; the primary seeding path now uses MaterializeBundledResources.
-	HarnessesFS fs.FS
-
 	// SelectedHarnessConfigs, when non-nil, restricts harness-config
 	// materialization to only the named configs. Templates are still
 	// materialized unconditionally. An empty non-nil slice skips all

--- a/pkg/config/mock_harness_test.go
+++ b/pkg/config/mock_harness_test.go
@@ -25,7 +25,6 @@ import (
 
 type MockHarness struct {
 	NameVal      string
-	EmbedDirVal  string
 	ConfigDirVal string
 }
 
@@ -48,7 +47,6 @@ func (m *MockHarness) HasSystemPrompt(agentHome string) bool { return false }
 func (m *MockHarness) Provision(ctx context.Context, agentName, agentDir, agentHome, agentWorkspace string) error {
 	return nil
 }
-func (m *MockHarness) GetEmbedDir() string                    { return m.EmbedDirVal }
 func (m *MockHarness) GetInterruptKey() string                { return "C-c" }
 func (m *MockHarness) GetHarnessEmbedsFS() (embed.FS, string) { return embed.FS{}, "" }
 func (m *MockHarness) InjectAgentInstructions(agentHome string, content []byte) error {
@@ -69,7 +67,7 @@ func (m *MockHarness) ResolveAuth(auth api.AuthConfig) (*api.ResolvedAuth, error
 
 func GetMockHarnesses() []api.Harness {
 	return []api.Harness{
-		&MockHarness{NameVal: "gemini", EmbedDirVal: "gemini", ConfigDirVal: ".gemini"},
-		&MockHarness{NameVal: "claude", EmbedDirVal: "claude", ConfigDirVal: ".claude"},
+		&MockHarness{NameVal: "gemini", ConfigDirVal: ".gemini"},
+		&MockHarness{NameVal: "claude", ConfigDirVal: ".claude"},
 	}
 }

--- a/pkg/harness/claude_code.go
+++ b/pkg/harness/claude_code.go
@@ -283,10 +283,6 @@ func (c *ClaudeCode) ApplyAuthSettings(agentHome string, resolved *api.ResolvedA
 	return os.WriteFile(claudeJSONPath, newData, 0644)
 }
 
-func (c *ClaudeCode) GetEmbedDir() string {
-	return "claude"
-}
-
 func (c *ClaudeCode) GetInterruptKey() string {
 	return "Escape"
 }

--- a/pkg/harness/container_script_harness.go
+++ b/pkg/harness/container_script_harness.go
@@ -84,10 +84,6 @@ func (c *ContainerScriptHarness) GetInterruptKey() string {
 	return c.entry.InterruptKey
 }
 
-// GetEmbedDir is unused for container-script harnesses; resolution flows
-// through the on-disk harness-config dir, not embedded fallback.
-func (c *ContainerScriptHarness) GetEmbedDir() string { return "" }
-
 // GetHarnessEmbedsFS returns an empty FS — container-script harnesses do not
 // own embedded files; their files live on disk in the harness-config dir.
 func (c *ContainerScriptHarness) GetHarnessEmbedsFS() (embed.FS, string) {

--- a/pkg/harness/declarative_generic.go
+++ b/pkg/harness/declarative_generic.go
@@ -66,8 +66,6 @@ func (d *DeclarativeGenericHarness) GetInterruptKey() string {
 	return "C-c"
 }
 
-func (d *DeclarativeGenericHarness) GetEmbedDir() string { return "" }
-
 func (d *DeclarativeGenericHarness) GetHarnessEmbedsFS() (embed.FS, string) {
 	return embed.FS{}, ""
 }

--- a/pkg/harness/gemini_cli.go
+++ b/pkg/harness/gemini_cli.go
@@ -263,10 +263,6 @@ func (g *GeminiCLI) ApplyAuthSettings(agentHome string, resolved *api.ResolvedAu
 	return g.updateSelectedAuthType(settingsPath, geminiAuthType)
 }
 
-func (g *GeminiCLI) GetEmbedDir() string {
-	return "gemini"
-}
-
 func (g *GeminiCLI) GetInterruptKey() string {
 	return "C-c"
 }

--- a/pkg/harness/generic.go
+++ b/pkg/harness/generic.go
@@ -85,10 +85,6 @@ func (g *Generic) Provision(ctx context.Context, agentName, agentDir, agentHome,
 	return nil
 }
 
-func (g *Generic) GetEmbedDir() string {
-	return ""
-}
-
 func (g *Generic) GetInterruptKey() string {
 	return "C-c"
 }

--- a/pkg/hub/admin_validate.go
+++ b/pkg/hub/admin_validate.go
@@ -57,7 +57,7 @@ func (s *Server) handleAdminValidateResources(w http.ResponseWriter, r *http.Req
 		rs := s.templateStore()
 		report, err := rs.ValidateStorage(ctx, rec)
 		if err != nil {
-			s.templateLog.Warn("admin validate: template validation error",
+			s.resourceLog.Warn("admin validate: template validation error",
 				"name", t.Name, "error", err)
 			continue
 		}
@@ -78,7 +78,7 @@ func (s *Server) handleAdminValidateResources(w http.ResponseWriter, r *http.Req
 		rs := s.harnessConfigStore(hc.Harness)
 		report, err := rs.ValidateStorage(ctx, rec)
 		if err != nil {
-			s.templateLog.Warn("admin validate: harness-config validation error",
+			s.resourceLog.Warn("admin validate: harness-config validation error",
 				"name", hc.Name, "error", err)
 			continue
 		}

--- a/pkg/hub/harness_config_bootstrap.go
+++ b/pkg/hub/harness_config_bootstrap.go
@@ -32,13 +32,13 @@ import (
 func (s *Server) BootstrapHarnessConfigsFromDir(ctx context.Context, harnessConfigsDir string) error {
 	info, err := os.Stat(harnessConfigsDir)
 	if err != nil || !info.IsDir() {
-		s.templateLog.Debug("harness config bootstrap: directory not found, skipping", "dir", harnessConfigsDir)
+		s.resourceLog.Debug("harness config bootstrap: directory not found, skipping", "dir", harnessConfigsDir)
 		return nil
 	}
 
 	stor := s.GetStorage()
 	if stor == nil {
-		s.templateLog.Warn("harness config bootstrap: no storage backend configured, skipping")
+		s.resourceLog.Warn("harness config bootstrap: no storage backend configured, skipping")
 		return nil
 	}
 
@@ -60,21 +60,21 @@ func (s *Server) BootstrapHarnessConfigsFromDir(ctx context.Context, harnessConf
 		// Load config.yaml to get harness type
 		hcDir, err := config.LoadHarnessConfigDir(dirPath)
 		if err != nil {
-			s.templateLog.Warn("harness config bootstrap: failed to load config, skipping",
+			s.resourceLog.Warn("harness config bootstrap: failed to load config, skipping",
 				"config", name, "error", err)
 			continue
 		}
 
 		existing, err := s.store.GetHarnessConfigBySlug(ctx, slug, store.HarnessConfigScopeGlobal, "")
 		if err != nil && err != store.ErrNotFound {
-			s.templateLog.Warn("harness config bootstrap: failed to look up config, skipping",
+			s.resourceLog.Warn("harness config bootstrap: failed to look up config, skipping",
 				"config", name, "error", err)
 			continue
 		}
 
 		if existing == nil {
 			if err := s.bootstrapSingleHarnessConfig(ctx, name, dirPath, hcDir, stor); err != nil {
-				s.templateLog.Warn("harness config bootstrap: failed to import config, skipping",
+				s.resourceLog.Warn("harness config bootstrap: failed to import config, skipping",
 					"config", name, "error", err)
 				continue
 			}
@@ -82,7 +82,7 @@ func (s *Server) BootstrapHarnessConfigsFromDir(ctx context.Context, harnessConf
 		} else {
 			changed, err := s.syncExistingHarnessConfig(ctx, existing, dirPath, hcDir, stor, false)
 			if err != nil {
-				s.templateLog.Warn("harness config bootstrap: failed to sync config, skipping",
+				s.resourceLog.Warn("harness config bootstrap: failed to sync config, skipping",
 					"config", name, "error", err)
 				continue
 			}
@@ -93,7 +93,7 @@ func (s *Server) BootstrapHarnessConfigsFromDir(ctx context.Context, harnessConf
 	}
 
 	if imported > 0 || updated > 0 {
-		s.templateLog.Info("harness config bootstrap: sync complete",
+		s.resourceLog.Info("harness config bootstrap: sync complete",
 			"imported", imported, "updated", updated)
 	}
 

--- a/pkg/hub/resource_bootstrap.go
+++ b/pkg/hub/resource_bootstrap.go
@@ -34,7 +34,7 @@ import (
 func (s *Server) BootstrapBundledResources(ctx context.Context, opts BootstrapOptions) error {
 	stor := s.GetStorage()
 	if stor == nil {
-		s.templateLog.Warn("bundled resource bootstrap: no storage backend configured, skipping")
+		s.resourceLog.Warn("bundled resource bootstrap: no storage backend configured, skipping")
 		return nil
 	}
 
@@ -64,7 +64,7 @@ func (s *Server) BootstrapBundledResources(ctx context.Context, opts BootstrapOp
 			continue
 		}
 
-		s.templateLog.Info("bootstrapped bundled resource",
+		s.resourceLog.Info("bootstrapped bundled resource",
 			"kind", r.Kind, "name", r.Name,
 			"created", result.Created, "updated", result.Updated,
 			"repaired", result.Repaired, "skipped", result.Skipped,

--- a/pkg/hub/resource_import.go
+++ b/pkg/hub/resource_import.go
@@ -285,9 +285,9 @@ func (s *Server) fetchRemoteForImport(ctx context.Context, projectID, sourceURL 
 			sec, secErr := sb.Get(ctx, "GITHUB_TOKEN", secret.ScopeProject, projectID)
 			if secErr == nil && sec != nil && sec.Value != "" {
 				authToken = sec.Value
-				s.templateLog.Info("using project GITHUB_TOKEN for resource import", "projectID", projectID)
+				s.resourceLog.Info("using project GITHUB_TOKEN for resource import", "projectID", projectID)
 			} else if secErr != nil && !errors.Is(secErr, store.ErrNotFound) {
-				s.templateLog.Warn("Failed to retrieve GITHUB_TOKEN from secret backend", "projectID", projectID, "error", secErr)
+				s.resourceLog.Warn("Failed to retrieve GITHUB_TOKEN from secret backend", "projectID", projectID, "error", secErr)
 			}
 		}
 	}
@@ -420,7 +420,7 @@ func (s *Server) importResourceDirs(ctx context.Context, dirs []resourceDir, ski
 			}
 			done := int(completed.Add(1))
 			if err != nil {
-				s.templateLog.Warn(kind.noun+" import: failed to import resource, skipping",
+				s.resourceLog.Warn(kind.noun+" import: failed to import resource, skipping",
 					"name", rd.name, "error", err)
 				failedSlots[i] = rd.name
 				emit(progress, ResourceImportEvent{

--- a/pkg/hub/resource_source.go
+++ b/pkg/hub/resource_source.go
@@ -246,7 +246,7 @@ func (rs *ResourceStore) BootstrapSource(ctx context.Context, src ResourceSource
 			return result, nil
 		case OverwriteBuiltinManaged:
 			if !IsBuiltinManaged(existing.SourceURL) && !opts.Force {
-				srv.templateLog.Warn(p.Label()+": skipping non-built-in conflict",
+				srv.resourceLog.Warn(p.Label()+": skipping non-built-in conflict",
 					"name", meta.Name, "existingSource", existing.SourceURL)
 				result.Skipped++
 				return result, nil
@@ -305,7 +305,7 @@ func (rs *ResourceStore) bootstrapSourceCreate(
 	}
 	if err := p.Create(ctx, rec, dir); err != nil {
 		if errors.Is(err, store.ErrAlreadyExists) {
-			srv.templateLog.Info(p.Label()+": duplicate create race, re-reading",
+			srv.resourceLog.Info(p.Label()+": duplicate create race, re-reading",
 				"name", meta.Name)
 			existing, rerr := p.GetBySlug(ctx, slug, meta.Scope, meta.ScopeID)
 			if rerr != nil || existing == nil {
@@ -331,7 +331,7 @@ func (rs *ResourceStore) bootstrapSourceCreate(
 		return *result, err
 	}
 
-	srv.templateLog.Info(p.Label()+": created resource from source",
+	srv.resourceLog.Info(p.Label()+": created resource from source",
 		"name", meta.Name, "files", len(uploaded))
 	p.PostFinalize(ctx, rec, dir)
 	result.Created++
@@ -383,7 +383,7 @@ func (rs *ResourceStore) bootstrapSourceUpdate(
 		return *result, err
 	}
 
-	reconcileResourceStorage(ctx, stor, storagePath, existing.Name, written, srv.templateLog, p.Label())
+	reconcileResourceStorage(ctx, stor, storagePath, existing.Name, written, srv.resourceLog, p.Label())
 
 	existing.Files = uploaded
 	existing.ContentHash = computeContentHash(uploaded)
@@ -394,7 +394,7 @@ func (rs *ResourceStore) bootstrapSourceUpdate(
 		return *result, err
 	}
 
-	srv.templateLog.Info(p.Label()+": updated resource from source",
+	srv.resourceLog.Info(p.Label()+": updated resource from source",
 		"name", meta.Name)
 	p.PostFinalize(ctx, existing, dir)
 	result.Updated++
@@ -427,7 +427,7 @@ func (rs *ResourceStore) repairStorageIfNeeded(
 		storagePath = storage.ResourceStoragePath(kind, rec.Scope, rec.ScopeID, rec.Slug)
 	}
 
-	srv.templateLog.Info(p.Label()+": repairing storage",
+	srv.resourceLog.Info(p.Label()+": repairing storage",
 		"name", rec.Name, "issues", len(report.Issues))
 
 	uploaded, written, err := uploadResourceFiles(ctx, stor, storagePath, files, p.Label())
@@ -435,7 +435,7 @@ func (rs *ResourceStore) repairStorageIfNeeded(
 		return false, fmt.Errorf("repair upload: %w", err)
 	}
 
-	reconcileResourceStorage(ctx, stor, storagePath, rec.Name, written, srv.templateLog, p.Label())
+	reconcileResourceStorage(ctx, stor, storagePath, rec.Name, written, srv.resourceLog, p.Label())
 
 	rec.Files = uploaded
 	rec.ContentHash = computeContentHash(uploaded)
@@ -444,7 +444,7 @@ func (rs *ResourceStore) repairStorageIfNeeded(
 		return false, fmt.Errorf("repair update: %w", err)
 	}
 
-	srv.templateLog.Info(p.Label()+": repaired storage",
+	srv.resourceLog.Info(p.Label()+": repaired storage",
 		"name", rec.Name, "files", len(uploaded))
 	return true, nil
 }

--- a/pkg/hub/resource_store.go
+++ b/pkg/hub/resource_store.go
@@ -171,7 +171,7 @@ func (rs *ResourceStore) Bootstrap(ctx context.Context, name, dir, scope, scopeI
 			return false, err
 		}
 
-		srv.templateLog.Info(p.Label()+": imported resource",
+		srv.resourceLog.Info(p.Label()+": imported resource",
 			"name", name, "files", len(uploaded), "harness", rec.Harness)
 		p.PostFinalize(ctx, rec, dir)
 		return true, nil
@@ -197,12 +197,12 @@ func (rs *ResourceStore) Bootstrap(ctx context.Context, name, dir, scope, scopeI
 	// Reconcile storage: drop objects no longer in the manifest so removed files
 	// don't linger. (Templates already did this on sync; harness-configs gain it
 	// by routing through the shared path — a removed-file cleanup fix.)
-	reconcileResourceStorage(ctx, stor, storagePath, existing.Name, written, srv.templateLog, p.Label())
+	reconcileResourceStorage(ctx, stor, storagePath, existing.Name, written, srv.resourceLog, p.Label())
 
 	newHash := computeContentHash(uploaded)
 	changed := newHash != existing.ContentHash
 	if changed {
-		srv.templateLog.Info(p.Label()+": resource re-synced",
+		srv.resourceLog.Info(p.Label()+": resource re-synced",
 			"name", existing.Name, "oldHash", existing.ContentHash, "newHash", newHash)
 	}
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -653,6 +653,7 @@ type Server struct {
 	authLog           *slog.Logger
 	envSecretLog      *slog.Logger
 	templateLog       *slog.Logger
+	resourceLog       *slog.Logger
 	workspaceLog      *slog.Logger
 	maintenanceLog    *slog.Logger
 
@@ -705,6 +706,7 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 		authLog:           logging.Subsystem("hub.auth"),
 		envSecretLog:      logging.Subsystem("hub.env-secrets"),
 		templateLog:       logging.Subsystem("hub.templates"),
+		resourceLog:       logging.Subsystem("hub.resources"),
 		workspaceLog:      logging.Subsystem("hub.workspace"),
 		maintenanceLog:    logging.Subsystem("hub.maintenance"),
 	}

--- a/pkg/runtime/k8s_parity_test.go
+++ b/pkg/runtime/k8s_parity_test.go
@@ -53,7 +53,6 @@ func (h *EnvHarness) HasSystemPrompt(agentHome string) bool { return false }
 func (h *EnvHarness) Provision(ctx context.Context, agentName, agentDir, agentHome, agentWorkspace string) error {
 	return nil
 }
-func (h *EnvHarness) GetEmbedDir() string                                            { return "test" }
 func (h *EnvHarness) GetInterruptKey() string                                        { return "C-c" }
 func (h *EnvHarness) GetHarnessEmbedsFS() (embed.FS, string)                         { return embed.FS{}, "" }
 func (h *EnvHarness) InjectAgentInstructions(agentHome string, content []byte) error { return nil }

--- a/pkg/runtime/k8s_runtime_tmux_test.go
+++ b/pkg/runtime/k8s_runtime_tmux_test.go
@@ -49,7 +49,6 @@ func (m *MockHarness) HasSystemPrompt(agentHome string) bool { return false }
 func (m *MockHarness) Provision(ctx context.Context, agentName, agentDir, agentHome, agentWorkspace string) error {
 	return nil
 }
-func (m *MockHarness) GetEmbedDir() string                                            { return "mock" }
 func (m *MockHarness) GetInterruptKey() string                                        { return "C-c" }
 func (m *MockHarness) GetHarnessEmbedsFS() (embed.FS, string)                         { return embed.FS{}, "" }
 func (m *MockHarness) InjectAgentInstructions(agentHome string, content []byte) error { return nil }

--- a/pkg/runtime/nfs_uid_test.go
+++ b/pkg/runtime/nfs_uid_test.go
@@ -207,7 +207,6 @@ func (h *nfsTestHarness) HasSystemPrompt(agentHome string) bool { return false }
 func (h *nfsTestHarness) Provision(ctx context.Context, agentName, agentDir, agentHome, agentWorkspace string) error {
 	return nil
 }
-func (h *nfsTestHarness) GetEmbedDir() string                    { return "test" }
 func (h *nfsTestHarness) GetInterruptKey() string                { return "C-c" }
 func (h *nfsTestHarness) GetHarnessEmbedsFS() (embed.FS, string) { return embed.FS{}, "" }
 func (h *nfsTestHarness) InjectAgentInstructions(agentHome string, content []byte) error {


### PR DESCRIPTION
## Summary

Final cleanup after the 7-PR bundled resource bootstrap plan. Removes dead code left behind when earlier PRs migrated seeding to the catalog-backed path. This is PR 7 of 7.

- Remove `GetEmbedDir()` from `api.Harness` interface and all implementations/mocks (zero callers remain after PRs 1-5 removed the seeding use)
- Remove dead `HarnessesFS` field from `InitMachineOpts` (seeding now uses `MaterializeBundledResources`) and dead variadic `harnessesFS` param from `UpdateDefaultTemplates`; retain `HarnessConfigUpgradeOptions.HarnessesFS` (still used by upgrade code)
- Add `resourceLog` with `hub.resources` subsystem for cross-resource Hub operations; `templateLog` was being used for harness-config bootstrap, resource import, bundled resource bootstrap, and admin validation — now correctly separated
- Fix gofmt alignment in `harness_config.go` and `resource_source.go`
- Add missing `Validate` method to `templatecache` hydrator and resolver test mocks (required by PR 6 interface addition)

Gemini builtin harness is unaffected — retained as-is pending its own migration to container-script provisioning.

Net: -24 lines (26 files changed, 50 insertions / 74 deletions).

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./...` (full suite) passes
- [ ] No remaining references to `GetEmbedDir` outside deleted code
- [ ] Gemini harness still works (builtin path unaffected)
- [ ] templatecache tests pass (Validate mock added)
