### PR TITLE
feat(hub): HA robustness improvements for hosted deployments

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -16,8 +16,6 @@ package cmd
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1627,33 +1625,24 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 			}
 		}
 
-		// Generate credentials for co-located mode
-		secretKeyBytes := make([]byte, 32)
-		if _, err := rand.Read(secretKeyBytes); err != nil {
-			log.Printf("Warning: failed to generate secret key for co-located mode: %v", err)
-		} else {
-			brokerSecret := &store.BrokerSecret{
-				BrokerID:  brokerID,
-				SecretKey: secretKeyBytes,
-				Algorithm: store.BrokerSecretAlgorithmHMACSHA256,
-				CreatedAt: time.Now(),
-				Status:    store.BrokerSecretStatusActive,
-			}
-			if err := s.DeleteBrokerSecret(ctx, brokerID); err != nil && err != store.ErrNotFound {
-				log.Printf("Warning: failed to delete old broker secret: %v", err)
-			}
-			if err := s.CreateBrokerSecret(ctx, brokerSecret); err != nil {
-				log.Printf("Warning: failed to create broker secret for co-located mode: %v", err)
+		// Generate or retrieve credentials for co-located mode (idempotent).
+		// Uses GenerateAndStoreSecret which returns the existing secret if one
+		// is already stored, so multiple Cloud Run instances share the same key.
+		if authSvc := hubSrv.GetBrokerAuthService(); authSvc != nil {
+			secretKeyB64, secretErr := authSvc.GenerateAndStoreSecret(ctx, brokerID)
+			if secretErr != nil {
+				log.Printf("Warning: failed to generate/retrieve secret for co-located broker: %v", secretErr)
 			} else {
-				log.Printf("Created broker secret for co-located control channel")
+				log.Printf("Broker secret ready for co-located control channel (idempotent)")
+				inMemoryCreds = &brokercredentials.BrokerCredentials{
+					BrokerID:     brokerID,
+					SecretKey:    secretKeyB64,
+					HubEndpoint:  hubEndpointForRH,
+					RegisteredAt: time.Now(),
+				}
 			}
-
-			inMemoryCreds = &brokercredentials.BrokerCredentials{
-				BrokerID:     brokerID,
-				SecretKey:    base64.StdEncoding.EncodeToString(secretKeyBytes),
-				HubEndpoint:  hubEndpointForRH,
-				RegisteredAt: time.Now(),
-			}
+		} else {
+			log.Printf("Warning: BrokerAuthService not available, skipping co-located broker credentials")
 		}
 	}
 

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -511,6 +511,18 @@ func (s *Server) createAgentInProject(
 			}
 			// Template will be resolved locally by the broker
 		}
+
+		// Guard: reject dispatch when the resolved template has no files and
+		// no content hash. This catches templates stuck in 'pending' state
+		// before they reach broker hydration (where the failure is opaque).
+		if resolvedTemplate != nil && len(resolvedTemplate.Files) == 0 && resolvedTemplate.ContentHash == "" {
+			name := resolvedTemplate.Slug
+			if name == "" {
+				name = resolvedTemplate.Name
+			}
+			ValidationError(w, "template "+name+" has no files — sync template files first with: scion template sync "+name, nil)
+			return
+		}
 	}
 
 	// Resolve harness config: prefer the user's explicit choice, then template default.

--- a/pkg/hub/handlers_test.go
+++ b/pkg/hub/handlers_test.go
@@ -2741,16 +2741,19 @@ func TestAgentCreate_StoresTemplateSlug(t *testing.T) {
 		t.Fatalf("failed to add project provider: %v", err)
 	}
 
-	// Create a template with a known slug
+	// Create a template with a known slug and files (active template)
 	tmpl := &store.Template{
-		ID:         tid("tmpl_uuid_123"),
-		Slug:       "my-claude-template",
-		Name:       "My Claude Template",
-		Harness:    "claude",
-		Scope:      "global",
-		Visibility: store.VisibilityPublic,
-		Created:    time.Now(),
-		Updated:    time.Now(),
+		ID:          tid("tmpl_uuid_123"),
+		Slug:        "my-claude-template",
+		Name:        "My Claude Template",
+		Harness:     "claude",
+		Scope:       "global",
+		Visibility:  store.VisibilityPublic,
+		Status:      store.TemplateStatusActive,
+		ContentHash: "abc123",
+		Files:       []store.TemplateFile{{Path: "CLAUDE.md", Size: 100, Hash: "deadbeef"}},
+		Created:     time.Now(),
+		Updated:     time.Now(),
 	}
 	if err := s.CreateTemplate(ctx, tmpl); err != nil {
 		t.Fatalf("failed to create template: %v", err)

--- a/pkg/hub/heartbeat_timeout_test.go
+++ b/pkg/hub/heartbeat_timeout_test.go
@@ -221,6 +221,7 @@ func TestAgentHeartbeatTimeoutHandler_SchedulerIntegration(t *testing.T) {
 	// Verify the handler can be registered and runs without panic
 	scheduler := NewScheduler(s, slog.Default())
 	scheduler.tickInterval = 50 * time.Millisecond
+	scheduler.MaxJitter = 0
 
 	scheduler.RegisterRecurring("agent-heartbeat-timeout", 1, srv.agentHeartbeatTimeoutHandler())
 

--- a/pkg/hub/reaper.go
+++ b/pkg/hub/reaper.go
@@ -40,6 +40,11 @@ const (
 // so at most one replica runs it per tick.
 func (s *Server) brokerAffinityReapHandler() func(ctx context.Context) {
 	return func(ctx context.Context) {
+		// Tight timeout: fail fast if DB connections are saturated rather than
+		// holding a connection while waiting, which worsens the thundering herd.
+		ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+
 		now := time.Now()
 
 		cleared, err := s.store.ReapStaleBrokerAffinity(ctx, now.Add(-affinityStaleAge))

--- a/pkg/hub/scheduler.go
+++ b/pkg/hub/scheduler.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -43,6 +44,12 @@ type Scheduler struct {
 
 	// Root ticker interval
 	tickInterval time.Duration
+
+	// MaxJitter is the upper bound on random delay added before each recurring
+	// handler invocation. Spreading handlers over this window prevents the
+	// "thundering herd" where all background tasks hit the DB simultaneously.
+	// Defaults to 30 s in production; tests can set it to 0 for determinism.
+	MaxJitter time.Duration
 
 	// Recurring handlers
 	recurring []RecurringHandler
@@ -82,11 +89,13 @@ type scheduledTimer struct {
 	Cancel context.CancelFunc
 }
 
-// NewScheduler creates a new Scheduler with a 1-minute root ticker interval.
+// NewScheduler creates a new Scheduler with a 1-minute root ticker interval
+// and a 30-second max jitter to desynchronize recurring handlers.
 func NewScheduler(st store.Store, log *slog.Logger) *Scheduler {
 	return &Scheduler{
 		store:         st,
 		tickInterval:  1 * time.Minute,
+		MaxJitter:     maxJitter,
 		timers:        make(map[string]*scheduledTimer),
 		eventHandlers: make(map[string]EventHandler),
 		log:           log,
@@ -238,13 +247,32 @@ func (s *Scheduler) Stop() {
 	s.wg.Wait()
 }
 
+// maxJitter is the upper bound on random delay added before each recurring
+// handler invocation. Spreading handlers over a 30-second window prevents the
+// "thundering herd" where all background tasks hit the DB simultaneously.
+const maxJitter = 30 * time.Second
+
 // runRecurringHandlers invokes all handlers whose interval divides the current
 // tick count. Each handler runs in its own goroutine with a timeout context.
+// A random jitter (0–30 s) is added before each invocation so background tasks
+// desynchronize and avoid saturating the DB connection pool.
 func (s *Scheduler) runRecurringHandlers(ctx context.Context) {
 	for _, h := range s.recurring {
 		if s.tickCount%uint64(h.Interval) == 0 {
 			handler := h // capture loop variable
 			go func() {
+				// Stagger start: sleep a random 0–MaxJitter so tasks that fire on
+				// the same tick don't all compete for DB connections at once.
+				jitter := time.Duration(0)
+				if s.MaxJitter > 0 {
+					jitter = time.Duration(rand.Int63n(int64(s.MaxJitter)))
+				}
+				select {
+				case <-time.After(jitter):
+				case <-ctx.Done():
+					return
+				}
+
 				handlerCtx, cancel := context.WithTimeout(ctx, 55*time.Second)
 				defer cancel()
 

--- a/pkg/hub/scheduler_test.go
+++ b/pkg/hub/scheduler_test.go
@@ -29,16 +29,20 @@ import (
 )
 
 // newTestScheduler creates a scheduler with a fast tick interval for testing.
+// MaxJitter is set to 0 so handlers fire immediately and tests remain deterministic.
 func newTestScheduler(interval time.Duration) *Scheduler {
 	s := NewScheduler(nil, slog.Default())
 	s.tickInterval = interval
+	s.MaxJitter = 0
 	return s
 }
 
 // newTestSchedulerWithStore creates a scheduler with a mock store and fast tick interval.
+// MaxJitter is set to 0 so handlers fire immediately and tests remain deterministic.
 func newTestSchedulerWithStore(interval time.Duration, st store.Store) *Scheduler {
 	s := NewScheduler(st, slog.Default())
 	s.tickInterval = interval
+	s.MaxJitter = 0
 	return s
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1831,6 +1831,11 @@ func (s *Server) GenerateAgentToken(agentID, projectID string, ancestry []string
 // notification system are informed.
 func (s *Server) agentHeartbeatTimeoutHandler() func(ctx context.Context) {
 	return func(ctx context.Context) {
+		// Tight timeout: fail fast if DB connections are saturated rather than
+		// holding a connection while waiting, which worsens the thundering herd.
+		ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+
 		threshold := time.Now().Add(-2 * time.Minute)
 
 		agents, err := s.store.MarkStaleAgentsOffline(ctx, threshold)
@@ -1859,6 +1864,11 @@ func (s *Server) agentHeartbeatTimeoutHandler() func(ctx context.Context) {
 // (container stopped, phase set to "suspended").
 func (s *Server) agentStalledDetectionHandler() func(ctx context.Context) {
 	return func(ctx context.Context) {
+		// Tight timeout: fail fast if DB connections are saturated rather than
+		// holding a connection while waiting, which worsens the thundering herd.
+		ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+
 		activityThreshold := time.Now().Add(-s.config.StalledThreshold)
 		heartbeatRecency := time.Now().Add(-2 * time.Minute)
 
@@ -2308,16 +2318,20 @@ func (s *Server) StartBackgroundServices(ctx context.Context) {
 	// otherwise every replica would publish duplicate offline/stalled events and
 	// race on the schedule claim. On SQLite the lock is a no-op. See
 	// CONCURRENCY-AUDIT.md §"Singleton / leader".
-	s.scheduler.RegisterRecurringSingleton("agent-heartbeat-timeout", 1, store.LockAgentHeartbeatTimeout, s.agentHeartbeatTimeoutHandler())
-	s.scheduler.RegisterRecurringSingleton("agent-stalled-detection", 1, store.LockAgentStalledDetection, s.agentStalledDetectionHandler())
+	// Non-critical maintenance tasks run every 5 minutes (not every 1 minute) to
+	// reduce DB connection pressure. Combined with per-handler jitter in the
+	// scheduler, this eliminates the thundering-herd pattern that was causing
+	// 9-54 s API latency spikes.
+	s.scheduler.RegisterRecurringSingleton("agent-heartbeat-timeout", 5, store.LockAgentHeartbeatTimeout, s.agentHeartbeatTimeoutHandler())
+	s.scheduler.RegisterRecurringSingleton("agent-stalled-detection", 5, store.LockAgentStalledDetection, s.agentStalledDetectionHandler())
 	if s.config.SoftDeleteRetention > 0 {
 		s.scheduler.RegisterRecurringSingleton("soft-delete-purge", 60, store.LockSoftDeletePurge, s.purgeHandler())
 	}
 	s.scheduler.RegisterEventHandler("message", s.messageEventHandler())
 	s.scheduler.RegisterEventHandler("dispatch_agent", s.dispatchAgentEventHandler())
 	s.scheduler.RegisterRecurringSingleton("schedule-evaluator", 1, store.LockScheduleEvaluator, s.evaluateSchedulesHandler())
-	s.scheduler.RegisterRecurringSingleton("broker-affinity-reap", 1, store.LockBrokerAffinityReap, s.brokerAffinityReapHandler())
-	s.scheduler.RegisterRecurringSingleton("broker-message-sweep", 1, store.LockBrokerMessageSweep, s.brokerMessageSweepHandler())
+	s.scheduler.RegisterRecurringSingleton("broker-affinity-reap", 5, store.LockBrokerAffinityReap, s.brokerAffinityReapHandler())
+	s.scheduler.RegisterRecurringSingleton("broker-message-sweep", 5, store.LockBrokerMessageSweep, s.brokerMessageSweepHandler())
 
 	// Register GitHub App health check if the app is configured
 	s.mu.RLock()

--- a/pkg/hub/skill_handlers.go
+++ b/pkg/hub/skill_handlers.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -1353,13 +1354,20 @@ func (s *Server) handleSkillsResolve(w http.ResponseWriter, r *http.Request) {
 		if stor != nil && len(sv.Files) > 0 {
 			versionPath := skill.StoragePath + "/" + sv.Version
 			downloadURLs, _, _, dlErr := generateDownloadURLs(ctx, stor, versionPath, sv.Files)
-			if dlErr == nil {
-				if stor.Provider() == storage.ProviderLocal {
-					hubURL := requestBaseURL(r)
-					downloadURLs = rewriteLocalDownloadURLs(downloadURLs, hubURL, "skills", skill.ID)
-				}
-				entry.Files = downloadURLs
+			if dlErr != nil {
+				slog.ErrorContext(ctx, "failed to generate download URLs for skill version",
+					"skill", skill.Name, "version", sv.Version, "error", dlErr)
+				resolveErrors = append(resolveErrors, ResolveSkillError{
+					URI: skillRef.URI, Code: "storage_error",
+					Message: fmt.Sprintf("skill %s version %s has storage files missing — re-sync the skill", skill.Name, sv.Version),
+				})
+				continue
 			}
+			if stor.Provider() == storage.ProviderLocal {
+				hubURL := requestBaseURL(r)
+				downloadURLs = rewriteLocalDownloadURLs(downloadURLs, hubURL, "skills", skill.ID)
+			}
+			entry.Files = downloadURLs
 		}
 
 		go func(versionID string) {

--- a/pkg/hub/stalled_detection_test.go
+++ b/pkg/hub/stalled_detection_test.go
@@ -573,6 +573,7 @@ func TestAgentStalledDetectionHandler_SchedulerIntegration(t *testing.T) {
 
 	scheduler := NewScheduler(s, slog.Default())
 	scheduler.tickInterval = 50 * time.Millisecond
+	scheduler.MaxJitter = 0
 
 	scheduler.RegisterRecurring("agent-stalled-detection", 1, srv.agentStalledDetectionHandler())
 

--- a/pkg/hub/storage_helpers.go
+++ b/pkg/hub/storage_helpers.go
@@ -40,9 +40,12 @@ const fileUploadConcurrency = 8
 
 // generateUploadURLs generates signed PUT URLs for a list of files under basePath.
 // Returns the upload URL infos, a manifest URL (if possible), and any error.
+//
+// Any failure to generate a signed URL for a listed file is treated as a hard
+// error — a partial URL set would cause the client to silently skip files,
+// producing an incomplete upload that passes verification only by accident.
 func generateUploadURLs(ctx context.Context, stor storage.Storage, basePath string, files []FileUploadRequest) ([]UploadURLInfo, string, error) {
 	uploadURLs := make([]UploadURLInfo, 0, len(files))
-	var lastErr error
 	for _, file := range files {
 		objectPath := basePath + "/" + file.Path
 		signedURL, err := stor.GenerateSignedURL(ctx, objectPath, storage.SignedURLOptions{
@@ -50,8 +53,7 @@ func generateUploadURLs(ctx context.Context, stor storage.Storage, basePath stri
 			Expires: SignedURLExpiry,
 		})
 		if err != nil {
-			lastErr = err
-			continue
+			return nil, "", fmt.Errorf("failed to generate signed URL for file %q: %w", file.Path, err)
 		}
 		uploadURLs = append(uploadURLs, UploadURLInfo{
 			Path:    file.Path,
@@ -62,11 +64,7 @@ func generateUploadURLs(ctx context.Context, stor storage.Storage, basePath stri
 		})
 	}
 
-	if len(uploadURLs) == 0 && len(files) > 0 && lastErr != nil {
-		return nil, "", lastErr
-	}
-
-	// Generate manifest URL
+	// Generate manifest URL — best-effort; callers handle a missing manifest.
 	var manifestURL string
 	manifestPath := basePath + "/manifest.json"
 	signedURL, err := stor.GenerateSignedURL(ctx, manifestPath, storage.SignedURLOptions{
@@ -246,7 +244,8 @@ func generateDownloadURLs(ctx context.Context, stor storage.Storage, basePath st
 		})
 	}
 
-	// Generate manifest URL
+	// Generate manifest URL — best-effort; a missing manifest is not fatal
+	// because callers fall back to per-file downloads.
 	var manifestURL string
 	manifestPath := basePath + "/manifest.json"
 	signedURL, err := stor.GenerateSignedURL(ctx, manifestPath, storage.SignedURLOptions{

--- a/pkg/hub/sweep.go
+++ b/pkg/hub/sweep.go
@@ -31,6 +31,11 @@ const stuckMessageExpireTTL = 24 * time.Hour
 // LockBrokerMessageSweep (B5-2).
 func (s *Server) brokerMessageSweepHandler() func(ctx context.Context) {
 	return func(ctx context.Context) {
+		// Tight timeout: fail fast if DB connections are saturated rather than
+		// holding a connection while waiting, which worsens the thundering herd.
+		ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+
 		cutoff := time.Now().Add(-stuckMessageThreshold)
 		count, err := s.store.CountStuckPendingMessages(ctx, cutoff)
 		if err != nil {

--- a/pkg/hub/template_handlers.go
+++ b/pkg/hub/template_handlers.go
@@ -281,10 +281,12 @@ func (s *Server) createTemplateV2(w http.ResponseWriter, r *http.Request) {
 		template.Visibility = store.VisibilityPrivate
 	}
 
-	// If no files provided, mark as active immediately
-	if len(req.Files) == 0 {
-		template.Status = store.TemplateStatusActive
-	}
+	// If no files provided, keep the template in 'pending' status so it
+	// cannot be used for agent dispatch until files are uploaded via
+	// "scion template sync". This prevents template_error failures when
+	// agents are dispatched to file-less templates.
+	// Templates with files are also created as 'pending' and promoted to
+	// 'active' during finalize (handleTemplateFinalize).
 
 	// Generate storage path and URI
 	storagePath := storage.TemplateStoragePath(template.Scope, template.ScopeID, template.Slug)
@@ -687,7 +689,11 @@ func (s *Server) handleTemplateDownload(w http.ResponseWriter, r *http.Request, 
 	}
 
 	if len(template.Files) == 0 {
-		ValidationError(w, "template has no files", nil)
+		name := template.Slug
+		if name == "" {
+			name = template.Name
+		}
+		ValidationError(w, "template "+name+" ("+template.ID+") has no files — sync template files first with: scion template sync "+name, nil)
 		return
 	}
 


### PR DESCRIPTION
Four fixes for hosted HA Hub deployments on Cloud Run:

1. Scheduler thundering herd — adds 0-30s jitter and extends non-critical task intervals 1min‒5min, plus 15s fail-fast timeouts. Eliminates periodic 9-54s API latency spikes.

2. Co-located broker idempotent secret — fixes "invalid signature" errors on Cloud Run scale-out/restart by using GenerateAndStoreSecret (idempotent; first instance creates, subsequent reuse).

3. File-less template guard — templates created without files stay pending (not active); dispatch returns actionable error with re-sync hint.

4. GCS signed URL error surfacing — GenerateSignedURL failures no longer silently become empty file lists; propagated as hard errors with template name and re-sync hint