### PR TITLE
fix: update allow_container_script_harnesses default to true in schema

### DIFF
--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -769,8 +769,8 @@
         },
         "allow_container_script_harnesses": {
           "type": "boolean",
-          "default": false,
-          "description": "Allow agents whose harness-config declares provisioner.type: container-script. Container-script provisioners execute scripts inside the agent container with access to projected secrets, so brokers must opt in explicitly.",
+          "default": true,
+          "description": "Allow agents whose harness-config declares provisioner.type: container-script. Container-script provisioners execute scripts inside the agent container with access to projected secrets. Defaults to true; set false to block container-script dispatches on this broker.",
           "x-env-var": "SCION_SERVER_BROKER_ALLOWCONTAINERSCRIPTHARNESSES"
         },
         "cors": { "$ref": "#/$defs/corsConfig" }

--- a/pkg/runtimebroker/harness_policy.go
+++ b/pkg/runtimebroker/harness_policy.go
@@ -76,9 +76,9 @@ type harnessPolicyDecision struct {
 
 // evaluateHarnessConfigPolicy enforces broker-level dispatch policy on the
 // resolved harness-config. Today it gates container-script provisioners
-// behind ServerConfig.AllowContainerScriptHarnesses so brokers must opt in
-// before staging Hub-distributed scripts that execute inside agent
-// containers with access to projected secrets.
+// behind ServerConfig.AllowContainerScriptHarnesses (defaults to true).
+// Set AllowContainerScriptHarnesses=false to block container-script
+// dispatches on this broker.
 //
 // Caller passes the resolved harness-config name (for logs/error text) and
 // the parsed config entry. Returns a non-OK decision when the dispatch


### PR DESCRIPTION
## Summary

Align the JSON schema default and harness policy comments with the actual runtime default of true for allow_container_script_harnesses.

The Go runtime (settings_v1.go, hub_config.go) already defaulted to true — this PR makes the JSON schema consistent with that behavior.

Related: https://github.com/ptone/scion/issues/374