### PR TITLE
fix: misc correctness fixes (Makefile, InitProject, GitHub URL import)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ install:
 	@echo ""
 	@echo "✔ Installed $(BINARY) to $(DESTDIR)$(INSTALL_DIR)/$(BINARY)"
 	@echo ""
-	@echo "  Run 'scion --version' to verify."
+	@echo "  Run 'scion version' to verify."
 	@echo ""
 	@case ":$$PATH:" in \
 		*":$(INSTALL_DIR):"* | *":$(INSTALL_DIR)/:"*) ;; \

--- a/pkg/config/remote_templates.go
+++ b/pkg/config/remote_templates.go
@@ -421,6 +421,10 @@ func parseGitHubURL(uri string) (*GitHubURLParts, error) {
 		result.Path = strings.Join(pathParts[2:], "/")
 	}
 
+	// Trim trailing slashes from the path to normalise URLs like
+	// .../tree/main/harnesses/ that browsers copy with a trailing slash.
+	result.Path = strings.TrimRight(result.Path, "/")
+
 	return result, nil
 }
 
@@ -672,7 +676,11 @@ func extractTarGz(tarGzPath, destPath string) error {
 	}
 	defer gzr.Close()
 
-	// First pass: detect common root
+	// First pass: detect common root. Only consider regular files and
+	// directories — pax global headers (TypeXGlobalHeader) and other
+	// metadata entries must be skipped or they break common-root detection
+	// (GitHub tarballs start with a pax_global_header entry whose name
+	// does not share the repo-root prefix).
 	tarReader := tar.NewReader(gzr)
 	var entries []string
 	for {
@@ -683,7 +691,9 @@ func extractTarGz(tarGzPath, destPath string) error {
 		if err != nil {
 			return fmt.Errorf("failed to read tar header: %w", err)
 		}
-		entries = append(entries, header.Name)
+		if header.Typeflag == tar.TypeDir || header.Typeflag == tar.TypeReg || header.Typeflag == tar.TypeRegA || header.Typeflag == tar.TypeSymlink {
+			entries = append(entries, header.Name)
+		}
 	}
 
 	commonRoot := detectCommonRoot(func(yield func(string) bool) {

--- a/pkg/config/remote_templates.go
+++ b/pkg/config/remote_templates.go
@@ -691,7 +691,7 @@ func extractTarGz(tarGzPath, destPath string) error {
 		if err != nil {
 			return fmt.Errorf("failed to read tar header: %w", err)
 		}
-		if header.Typeflag == tar.TypeDir || header.Typeflag == tar.TypeReg || header.Typeflag == tar.TypeRegA || header.Typeflag == tar.TypeSymlink {
+		if header.Typeflag == tar.TypeDir || header.Typeflag == tar.TypeReg || header.Typeflag == tar.TypeSymlink {
 			entries = append(entries, header.Name)
 		}
 	}
@@ -752,7 +752,7 @@ func extractTarGz(tarGzPath, destPath string) error {
 			if err := os.MkdirAll(fpath, os.FileMode(header.Mode)); err != nil {
 				return err
 			}
-		case tar.TypeReg, tar.TypeRegA:
+		case tar.TypeReg:
 			if err := os.MkdirAll(filepath.Dir(fpath), 0755); err != nil {
 				return err
 			}

--- a/pkg/config/remote_templates.go
+++ b/pkg/config/remote_templates.go
@@ -752,7 +752,7 @@ func extractTarGz(tarGzPath, destPath string) error {
 			if err := os.MkdirAll(fpath, os.FileMode(header.Mode)); err != nil {
 				return err
 			}
-		case tar.TypeReg:
+		case tar.TypeReg, tar.TypeRegA:
 			if err := os.MkdirAll(filepath.Dir(fpath), 0755); err != nil {
 				return err
 			}
@@ -767,6 +767,13 @@ func extractTarGz(tarGzPath, destPath string) error {
 				return err
 			}
 			outFile.Close()
+		case tar.TypeSymlink:
+			if err := os.MkdirAll(filepath.Dir(fpath), 0755); err != nil {
+				return err
+			}
+			if err := os.Symlink(header.Linkname, fpath); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/config/remote_templates.go
+++ b/pkg/config/remote_templates.go
@@ -768,10 +768,18 @@ func extractTarGz(tarGzPath, destPath string) error {
 			}
 			outFile.Close()
 		case tar.TypeSymlink:
+			linkTarget := header.Linkname
+			if !filepath.IsAbs(linkTarget) {
+				linkTarget = filepath.Join(filepath.Dir(fpath), linkTarget)
+			}
+			linkTarget = filepath.Clean(linkTarget)
+			if !strings.HasPrefix(linkTarget, filepath.Clean(destPath)+string(os.PathSeparator)) {
+				continue
+			}
 			if err := os.MkdirAll(filepath.Dir(fpath), 0755); err != nil {
 				return err
 			}
-			if err := os.Symlink(header.Linkname, fpath); err != nil {
+			if err := os.Symlink(header.Linkname, fpath); err != nil && !os.IsExist(err) {
 				return err
 			}
 		}

--- a/pkg/config/remote_templates_test.go
+++ b/pkg/config/remote_templates_test.go
@@ -125,6 +125,22 @@ func TestParseGitHubURL(t *testing.T) {
 			wantPath:   ".claude/agents",
 		},
 		{
+			name:       "trailing slash on tree URL path is stripped",
+			uri:        "https://github.com/GoogleCloudPlatform/scion/tree/main/harnesses/",
+			wantOwner:  "GoogleCloudPlatform",
+			wantRepo:   "scion",
+			wantBranch: "main",
+			wantPath:   "harnesses",
+		},
+		{
+			name:       "trailing slash on direct path is stripped",
+			uri:        "https://github.com/org/repo/some/path/",
+			wantOwner:  "org",
+			wantRepo:   "repo",
+			wantBranch: "main",
+			wantPath:   "some/path",
+		},
+		{
 			name:        "non-github URL",
 			uri:         "https://gitlab.com/user/repo",
 			expectError: true,
@@ -359,6 +375,11 @@ func TestDetectCommonRoot(t *testing.T) {
 			name:     "single entry",
 			entries:  []string{"mytemplate/file.txt"},
 			expected: "mytemplate/",
+		},
+		{
+			name:     "pax_global_header must be filtered before calling detectCommonRoot",
+			entries:  []string{"pax_global_header", "scion-main/harnesses/copilot/config.yaml"},
+			expected: "",
 		},
 	}
 

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -1629,6 +1629,27 @@ func (s *Server) addProjectProvider(w http.ResponseWriter, r *http.Request, proj
 		linkedBy = user.ID()
 	}
 
+	// Validate LocalPath before persisting — fail fast before touching the DB.
+	var cleanPath string
+	if req.LocalPath != "" {
+		cleanPath = filepath.Clean(req.LocalPath)
+		if !filepath.IsAbs(cleanPath) {
+			ValidationError(w, "localPath must be an absolute path", nil)
+			return
+		}
+		for _, prefix := range []string{"/etc", "/usr", "/bin", "/sbin", "/sys", "/proc", "/dev", "/boot", "/lib"} {
+			if cleanPath == prefix || strings.HasPrefix(cleanPath, prefix+"/") {
+				ValidationError(w, "localPath points to a restricted system directory", nil)
+				return
+			}
+		}
+		info, err := os.Stat(cleanPath)
+		if err != nil || !info.IsDir() {
+			ValidationError(w, "localPath must be an existing directory", nil)
+			return
+		}
+	}
+
 	// Create provider record
 	provider := &store.ProjectProvider{
 		ProjectID:  projectID,
@@ -1646,23 +1667,7 @@ func (s *Server) addProjectProvider(w http.ResponseWriter, r *http.Request, proj
 
 	// For linked projects (local directory), initialize the .scion directory
 	// so agents and templates directories exist before the first agent starts.
-	if req.LocalPath != "" {
-		cleanPath := filepath.Clean(req.LocalPath)
-		if !filepath.IsAbs(cleanPath) {
-			ValidationError(w, "localPath must be an absolute path", nil)
-			return
-		}
-		for _, prefix := range []string{"/etc", "/usr", "/bin", "/sbin", "/sys", "/proc", "/dev", "/boot", "/lib"} {
-			if cleanPath == prefix || strings.HasPrefix(cleanPath, prefix+"/") {
-				ValidationError(w, "localPath points to a restricted system directory", nil)
-				return
-			}
-		}
-		info, err := os.Stat(cleanPath)
-		if err != nil || !info.IsDir() {
-			ValidationError(w, "localPath must be an existing directory", nil)
-			return
-		}
+	if cleanPath != "" {
 		scionDir := filepath.Join(cleanPath, ".scion")
 		if err := config.InitProject(scionDir, nil, config.InitProjectOpts{SkipRuntimeCheck: true}); err != nil {
 			slog.Warn("failed to initialize .scion in linked project",

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -1640,6 +1640,16 @@ func (s *Server) addProjectProvider(w http.ResponseWriter, r *http.Request, proj
 		return
 	}
 
+	// For linked projects (local directory), initialize the .scion directory
+	// so agents and templates directories exist before the first agent starts.
+	if req.LocalPath != "" {
+		scionDir := filepath.Join(req.LocalPath, ".scion")
+		if err := config.InitProject(scionDir, nil, config.InitProjectOpts{SkipRuntimeCheck: true}); err != nil {
+			slog.Warn("failed to initialize .scion in linked project",
+				"project_id", projectID, "localPath", req.LocalPath, "error", err.Error())
+		}
+	}
+
 	// Get the project to check if we should set default runtime broker
 	project, err := s.store.GetProject(ctx, projectID)
 	if err == nil && project.DefaultRuntimeBrokerID == "" {

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -1646,10 +1647,26 @@ func (s *Server) addProjectProvider(w http.ResponseWriter, r *http.Request, proj
 	// For linked projects (local directory), initialize the .scion directory
 	// so agents and templates directories exist before the first agent starts.
 	if req.LocalPath != "" {
-		scionDir := filepath.Join(req.LocalPath, ".scion")
+		cleanPath := filepath.Clean(req.LocalPath)
+		if !filepath.IsAbs(cleanPath) {
+			ValidationError(w, "localPath must be an absolute path", nil)
+			return
+		}
+		for _, prefix := range []string{"/etc", "/usr", "/bin", "/sbin", "/sys", "/proc", "/dev", "/boot", "/lib"} {
+			if cleanPath == prefix || strings.HasPrefix(cleanPath, prefix+"/") {
+				ValidationError(w, "localPath points to a restricted system directory", nil)
+				return
+			}
+		}
+		info, err := os.Stat(cleanPath)
+		if err != nil || !info.IsDir() {
+			ValidationError(w, "localPath must be an existing directory", nil)
+			return
+		}
+		scionDir := filepath.Join(cleanPath, ".scion")
 		if err := config.InitProject(scionDir, nil, config.InitProjectOpts{SkipRuntimeCheck: true}); err != nil {
 			slog.Warn("failed to initialize .scion in linked project",
-				"project_id", projectID, "localPath", req.LocalPath, "error", err.Error())
+				"project_id", projectID, "localPath", cleanPath, "error", err.Error())
 		}
 	}
 

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -19,10 +19,13 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"path/filepath"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/secret"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )


### PR DESCRIPTION
## Summary
Three small correctness fixes:

- **Fix Makefile version command**: Install target printed `scion --version` but the correct command is `scion version` (subcommand, not flag).
- **Run InitProject when linking a local directory provider**: `handleAddBroker` was missing the `InitProject` call that `handleCreateProject` already had, causing `.scion/` to never be created when using the two-step create-project-then-add-provider flow.
- **Fix GitHub URL import (trailing slash + pax_global_header)**: Two bugs in `importFromURL` prevented importing harness configs from GitHub tree URLs: (1) `findCommonRoot` included `pax_global_header` metadata entries in common-root detection, corrupting the root prefix; (2) `resolveGitHubURL` did not strip trailing slashes from browser-copied URLs.

## Test plan
- [ ] `scion version` completion message shows `scion version` (not `scion --version`)
- [ ] Adding a local directory provider via API creates `.scion/` in the linked directory
- [ ] Importing from `https://github.com/.../tree/main/path/` (with trailing slash) works