### PR TITLE
fix: add plug icon to bundle and hide bot_id from config UI

### DIFF
--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -391,6 +391,7 @@ func filterSensitiveConfig(name string, cfg map[string]string) map[string]string
 		"hub_url":     true,
 		"hmac_key":    true,
 		"broker_id":   true,
+		"bot_id":      true,
 		"config_file": true,
 	}
 

--- a/web/scripts/copy-shoelace-icons.mjs
+++ b/web/scripts/copy-shoelace-icons.mjs
@@ -112,6 +112,7 @@ const USED_ICONS = [
   'person-plus',
   'play-circle',
   'plus-circle',
+  'plug',
   'plus-lg',
   'question-circle',
   'robot',

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -367,7 +367,7 @@ export class ScionPageAdminIntegrations extends LitElement {
         return;
       }
       this.detail = (await res.json()) as IntegrationDetail;
-      this.editedSettings = { ...(this.detail.settings || {}) };
+      this.editedSettings = { ...this.detail.settings };
       this.editedSecrets = {};
     } catch {
       this.error = 'Failed to connect to server';
@@ -434,7 +434,8 @@ export class ScionPageAdminIntegrations extends LitElement {
   }
 
   private navigateTo(path: string): void {
-    this.dispatchEvent(new CustomEvent('nav-click', { detail: { path }, bubbles: true, composed: true }));
+    window.history.pushState({}, '', path);
+    window.dispatchEvent(new PopStateEvent('popstate'));
   }
 
   override render() {
@@ -518,7 +519,7 @@ export class ScionPageAdminIntegrations extends LitElement {
     }
     const d = this.detail;
     return html`
-      <a class="back-link" href="/admin/integrations">
+      <a class="back-link" @click=${(e: Event) => { e.preventDefault(); this.navigateTo('/admin/integrations'); }}>
         <sl-icon name="arrow-left"></sl-icon> Back to Integrations
       </a>
 
@@ -595,26 +596,12 @@ export class ScionPageAdminIntegrations extends LitElement {
               </div>
             `
           : nothing}
-        ${status.details && Object.keys(status.details).length > 0
-          ? html`
-              <div style="margin-top: 0.75rem; padding-top: 0.75rem; border-top: 1px solid var(--scion-border, #e2e8f0);">
-                ${Object.entries(status.details).map(
-                  ([k, v]) => html`
-                    <div class="status-row">
-                      <span class="status-label">${k}</span>
-                      <span style="font-size: 0.8125rem;">${v}</span>
-                    </div>
-                  `
-                )}
-              </div>
-            `
-          : nothing}
       </div>
     `;
   }
 
   private renderConfigSection(d: IntegrationDetail) {
-    const keys = Object.keys(d.settings || {});
+    const keys = Object.keys(d.settings);
     if (keys.length === 0) {
       return html`
         <div class="section">
@@ -634,7 +621,7 @@ export class ScionPageAdminIntegrations extends LitElement {
                 <label>${key}</label>
                 <sl-input
                   value=${this.editedSettings[key] ?? ''}
-                  @sl-change=${(e: Event) => {
+                  @sl-input=${(e: Event) => {
                     this.editedSettings = {
                       ...this.editedSettings,
                       [key]: (e.target as HTMLInputElement).value,
@@ -650,7 +637,7 @@ export class ScionPageAdminIntegrations extends LitElement {
   }
 
   private renderSecretsSection(d: IntegrationDetail) {
-    const secretKeys = Object.keys(d.has_secrets || {});
+    const secretKeys = Object.keys(d.has_secrets);
     if (secretKeys.length === 0) return nothing;
 
     return html`
@@ -670,7 +657,7 @@ export class ScionPageAdminIntegrations extends LitElement {
                 type="password"
                 placeholder=${d.has_secrets[key] ? 'Enter new value to update' : 'Enter value'}
                 value=${this.editedSecrets[key] ?? ''}
-                @sl-change=${(e: Event) => {
+                @sl-input=${(e: Event) => {
                   this.editedSecrets = {
                     ...this.editedSecrets,
                     [key]: (e.target as HTMLInputElement).value,
@@ -728,11 +715,5 @@ export class ScionPageAdminIntegrations extends LitElement {
       default:
         return platform;
     }
-  }
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'scion-page-admin-integrations': ScionPageAdminIntegrations;
   }
 }

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -367,7 +367,7 @@ export class ScionPageAdminIntegrations extends LitElement {
         return;
       }
       this.detail = (await res.json()) as IntegrationDetail;
-      this.editedSettings = { ...this.detail.settings };
+      this.editedSettings = { ...(this.detail.settings || {}) };
       this.editedSecrets = {};
     } catch {
       this.error = 'Failed to connect to server';
@@ -434,8 +434,7 @@ export class ScionPageAdminIntegrations extends LitElement {
   }
 
   private navigateTo(path: string): void {
-    window.history.pushState({}, '', path);
-    window.dispatchEvent(new PopStateEvent('popstate'));
+    this.dispatchEvent(new CustomEvent('nav-click', { detail: { path }, bubbles: true, composed: true }));
   }
 
   override render() {
@@ -519,7 +518,7 @@ export class ScionPageAdminIntegrations extends LitElement {
     }
     const d = this.detail;
     return html`
-      <a class="back-link" @click=${(e: Event) => { e.preventDefault(); this.navigateTo('/admin/integrations'); }}>
+      <a class="back-link" href="/admin/integrations">
         <sl-icon name="arrow-left"></sl-icon> Back to Integrations
       </a>
 
@@ -615,7 +614,7 @@ export class ScionPageAdminIntegrations extends LitElement {
   }
 
   private renderConfigSection(d: IntegrationDetail) {
-    const keys = Object.keys(d.settings);
+    const keys = Object.keys(d.settings || {});
     if (keys.length === 0) {
       return html`
         <div class="section">
@@ -635,7 +634,7 @@ export class ScionPageAdminIntegrations extends LitElement {
                 <label>${key}</label>
                 <sl-input
                   value=${this.editedSettings[key] ?? ''}
-                  @sl-input=${(e: Event) => {
+                  @sl-change=${(e: Event) => {
                     this.editedSettings = {
                       ...this.editedSettings,
                       [key]: (e.target as HTMLInputElement).value,
@@ -651,7 +650,7 @@ export class ScionPageAdminIntegrations extends LitElement {
   }
 
   private renderSecretsSection(d: IntegrationDetail) {
-    const secretKeys = Object.keys(d.has_secrets);
+    const secretKeys = Object.keys(d.has_secrets || {});
     if (secretKeys.length === 0) return nothing;
 
     return html`
@@ -671,7 +670,7 @@ export class ScionPageAdminIntegrations extends LitElement {
                 type="password"
                 placeholder=${d.has_secrets[key] ? 'Enter new value to update' : 'Enter value'}
                 value=${this.editedSecrets[key] ?? ''}
-                @sl-input=${(e: Event) => {
+                @sl-change=${(e: Event) => {
                   this.editedSecrets = {
                     ...this.editedSecrets,
                     [key]: (e.target as HTMLInputElement).value,

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -596,6 +596,20 @@ export class ScionPageAdminIntegrations extends LitElement {
               </div>
             `
           : nothing}
+        ${status.details && Object.keys(status.details).length > 0
+          ? html`
+              <div style="margin-top: 0.75rem; padding-top: 0.75rem; border-top: 1px solid var(--scion-border, #e2e8f0);">
+                ${Object.entries(status.details).map(
+                  ([k, v]) => html`
+                    <div class="status-row">
+                      <span class="status-label">${k}</span>
+                      <span style="font-size: 0.8125rem;">${v}</span>
+                    </div>
+                  `
+                )}
+              </div>
+            `
+          : nothing}
       </div>
     `;
   }
@@ -715,5 +729,11 @@ export class ScionPageAdminIntegrations extends LitElement {
       default:
         return platform;
     }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-page-admin-integrations': ScionPageAdminIntegrations;
   }
 }


### PR DESCRIPTION
Follow-up fixes after Phase 3 merge:
- Add 'plug' icon to USED_ICONS in copy-shoelace-icons.mjs
- Filter bot_id from integration config API response (implicit in Telegram token)

Related: #365