### PR TITLE
harnesses: add gemini-cli container-script harness bundle

### DIFF
--- a/harnesses/embed.go
+++ b/harnesses/embed.go
@@ -16,5 +16,5 @@ package harnesses
 
 import "embed"
 
-//go:embed all:antigravity/* all:claude/* all:codex/* all:copilot/* all:hermes/* all:opencode/*
+//go:embed all:antigravity/* all:claude/* all:codex/* all:copilot/* all:gemini-cli/* all:hermes/* all:opencode/*
 var FS embed.FS

--- a/harnesses/gemini-cli/Dockerfile
+++ b/harnesses/gemini-cli/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG GEMINI_CLI_VERSION=latest
+
+# Set `DEVCONTAINER` environment variable to help with orientation
+ENV DEVCONTAINER=true
+
+RUN mkdir -p /home/scion/.gemini /home/scion/.gemini/skills && \
+  chown -R scion:scion /home/scion/.gemini
+
+# Install gemini-cli and clean up
+RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION} \
+  && npm cache clean --force
+
+# Default entrypoint when none specified
+CMD ["gemini"]

--- a/harnesses/gemini-cli/README.md
+++ b/harnesses/gemini-cli/README.md
@@ -1,0 +1,51 @@
+# Gemini CLI Harness Bundle
+
+Scion harness configuration for [Gemini CLI](https://github.com/google-gemini/gemini-cli),
+Google's coding agent CLI.
+
+## Install
+
+From a repository checkout:
+
+```sh
+scion harness-config install harnesses/gemini-cli
+```
+
+Or directly from GitHub:
+
+```sh
+scion harness-config install github.com/GoogleCloudPlatform/scion/tree/main/harnesses/gemini-cli
+```
+
+## Auth Modes
+
+| Mode | Env / File | Notes |
+|------|-----------|-------|
+| `api-key` (default) | `GEMINI_API_KEY` or `GOOGLE_API_KEY` | Direct API access |
+| `auth-file` | `~/.gemini/oauth_creds.json` | Personal OAuth credentials |
+| `vertex-ai` | `GOOGLE_CLOUD_PROJECT` + `GOOGLE_CLOUD_REGION` | Vertex AI with ADC or service account |
+
+## Bundle Layout
+
+```
+gemini-cli/
+  config.yaml        # Harness configuration (provisioner, capabilities, auth)
+  provision.py        # Container-side provisioner (pre-start hook)
+  capture_auth.py     # Interactive auth capture script
+  Dockerfile          # Image build (FROM scion-base)
+  cloudbuild.yaml     # Cloud Build configuration
+  home/
+    .bashrc                     # Shell config with scion env sourcing
+    .gemini/settings.json       # Gemini CLI settings (hooks, permissions)
+    system_prompt.md            # System prompt placeholder
+```
+
+## Build the Image
+
+```sh
+# Local Docker build
+docker build --build-arg BASE_IMAGE=scion-base:latest -t scion-gemini:latest -f Dockerfile .
+
+# Cloud Build
+gcloud builds submit --config cloudbuild.yaml .
+```

--- a/harnesses/gemini-cli/capture_auth.py
+++ b/harnesses/gemini-cli/capture_auth.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Gemini capture-auth script.
+
+Scans for credential files on disk and stores them as project-scoped secrets
+via `sciontool secret set`. Designed to run after the user authenticates
+interactively inside a no-auth agent container.
+
+Reads credential mappings from inputs/capture-auth-config.json (derived from
+the harness config.yaml's auth.types.*.required_files declarations). This
+avoids hardcoding paths or key names in the script.
+
+Exit codes:
+  0 = at least one credential captured
+  1 = error
+  2 = no credentials found (not an error, but nothing was stored)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_NO_CREDS = 2
+
+HARNESS_BUNDLE = os.path.join(
+    os.environ.get("HOME") or os.path.expanduser("~"),
+    ".scion", "harness",
+)
+
+
+def _expand(path: str) -> str:
+    return os.path.expanduser(os.path.expandvars(path))
+
+
+def _load_config(bundle: str) -> list[dict[str, Any]]:
+    config_path = os.path.join(bundle, "inputs", "capture-auth-config.json")
+    if not os.path.isfile(config_path):
+        return []
+    with open(config_path, "r", encoding="utf-8") as f:
+        try:
+            data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return []
+    creds = data.get("credentials")
+    if not isinstance(creds, list):
+        return []
+    return creds
+
+
+def _capture_one(
+    entry: dict[str, Any], force: bool
+) -> tuple[bool, str | None]:
+    """Attempt to capture a single credential. Returns (success, error_msg)."""
+    key = entry.get("key", "")
+    source = _expand(entry.get("source", ""))
+    secret_type = entry.get("type", "file")
+    target = entry.get("target", "")
+
+    if not key or not source:
+        return False, f"invalid entry: missing key or source"
+
+    if not os.path.isfile(source):
+        return False, None
+
+    cmd = [
+        "sciontool", "secret", "set", key, f"@{source}",
+        "--type", secret_type,
+        "--target", target,
+    ]
+    if force:
+        cmd.append("--force")
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        return False, "sciontool not found in PATH"
+    except subprocess.TimeoutExpired:
+        return False, f"sciontool timed out for key {key}"
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        return False, f"sciontool failed for {key}: {stderr}"
+
+    return True, None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Capture auth credentials and store as project secrets"
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing secrets",
+    )
+    parser.add_argument(
+        "--bundle",
+        default=HARNESS_BUNDLE,
+        help="Path to harness bundle directory",
+    )
+    args = parser.parse_args()
+
+    entries = _load_config(args.bundle)
+    if not entries:
+        print(
+            "capture-auth: no credential mappings found in "
+            "inputs/capture-auth-config.json",
+            file=sys.stderr,
+        )
+        return EXIT_NO_CREDS
+
+    captured = 0
+    errors = 0
+
+    for entry in entries:
+        key = entry.get("key", "<unknown>")
+        source = entry.get("source", "")
+        expanded = _expand(source) if source else ""
+
+        if not expanded or not os.path.isfile(expanded):
+            print(f"capture-auth: {key}: source not found ({source})")
+            continue
+
+        ok, err = _capture_one(entry, args.force)
+        if err:
+            print(f"capture-auth: {key}: {err}", file=sys.stderr)
+            errors += 1
+        elif ok:
+            print(f"capture-auth: {key}: captured from {source}")
+            captured += 1
+
+    if errors > 0 and captured == 0:
+        return EXIT_ERROR
+
+    if captured == 0:
+        print("capture-auth: no credentials found to capture")
+        return EXIT_NO_CREDS
+
+    print(f"capture-auth: {captured} credential(s) captured successfully")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/harnesses/gemini-cli/capture_auth.py
+++ b/harnesses/gemini-cli/capture_auth.py
@@ -55,11 +55,11 @@ def _load_config(bundle: str) -> list[dict[str, Any]]:
     config_path = os.path.join(bundle, "inputs", "capture-auth-config.json")
     if not os.path.isfile(config_path):
         return []
-    with open(config_path, "r", encoding="utf-8") as f:
-        try:
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
             data = json.load(f)
-        except (json.JSONDecodeError, OSError):
-            return []
+    except (json.JSONDecodeError, OSError):
+        return []
     creds = data.get("credentials")
     if not isinstance(creds, list):
         return []

--- a/harnesses/gemini-cli/cloudbuild.yaml
+++ b/harnesses/gemini-cli/cloudbuild.yaml
@@ -1,0 +1,57 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Per-bundle Cloud Build configuration for the Gemini CLI harness image.
+# Builds scion-gemini on top of scion-base:<_TAG>.
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'setup-buildx'
+    args: ['buildx', 'create', '--name', 'mybuilder', '--use']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'bootstrap-buildx'
+    args: ['buildx', 'inspect', '--bootstrap']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-scion-gemini'
+    args:
+      - 'buildx'
+      - 'build'
+      - '--platform'
+      - 'linux/amd64,linux/arm64'
+      - '--build-arg'
+      - 'BASE_IMAGE=$_REGISTRY/scion-base:$_TAG'
+      - '-t'
+      - '$_REGISTRY/scion-gemini:$_SHORT_SHA'
+      - '-t'
+      - '$_REGISTRY/scion-gemini:$_TAG'
+      - '-f'
+      - 'Dockerfile'
+      - '--pull'
+      - '--push'
+      - '.'
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+substitutions:
+  _REGISTRY: 'us-central1-docker.pkg.dev/${PROJECT_ID}/public-docker'
+  _TAG: 'latest'
+options:
+  dynamicSubstitutions: true
+  machineType: 'E2_HIGHCPU_8'
+timeout: 1200s

--- a/harnesses/gemini-cli/config.yaml
+++ b/harnesses/gemini-cli/config.yaml
@@ -1,0 +1,100 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+harness: gemini-cli
+image: scion-gemini:latest
+user: scion
+provisioner:
+  type: container-script
+  interface_version: 1
+  command: ["python3", "/home/scion/.scion/harness/provision.py"]
+  timeout: 30s
+  lifecycle_events:
+    - pre-start
+  required_image_tools:
+    - python3
+config_dir: .gemini
+skills_dir: .gemini/skills
+interrupt_key: C-c
+instructions_file: .gemini/GEMINI.md
+system_prompt_file: .gemini/system_prompt.md
+system_prompt_mode: native
+model_aliases:
+  small: gemini-flash-lite
+  medium: gemini-flash
+  large: gemini-pro
+env:
+  GEMINI_CLI_NO_RELAUNCH: "true"
+command:
+  base: ["gemini", "--yolo"]
+  resume_flag: "--resume"
+  task_flag: "--prompt-interactive"
+  task_position: after_base_args
+capabilities:
+  limits:
+    max_turns: { support: "yes" }
+    max_model_calls: { support: "yes" }
+    max_duration: { support: "yes" }
+  telemetry:
+    enabled: { support: "yes" }
+    native_emitter: { support: "yes" }
+  prompts:
+    system_prompt: { support: "yes" }
+    agent_instructions: { support: "yes" }
+  auth:
+    api_key: { support: "yes" }
+    auth_file: { support: "yes" }
+    oauth_token: { support: "no" }
+    vertex_ai: { support: "yes" }
+  resume: { support: "yes" }
+no_auth:
+  behavior: drop-to-shell
+  message: |
+    This agent started without credentials.
+    Run your Gemini authentication setup.
+    Then run: python3 /home/scion/.scion/harness/capture_auth.py
+auth:
+  default_type: api-key
+  types:
+    api-key:
+      required_env:
+        - any_of: ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
+    auth-file:
+      required_files:
+        - name: GEMINI_OAUTH_CREDS
+          type: file
+          description: "Gemini personal OAuth credentials file"
+          target_suffix: "/.gemini/oauth_creds.json"
+          field: OAuthCreds
+    vertex-ai:
+      required_env:
+        - any_of: ["GOOGLE_CLOUD_PROJECT"]
+        - any_of: ["GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"]
+      required_files:
+        - name: gcloud-adc
+          type: file
+          description: "Google Cloud Application Default Credentials (ADC) file for vertex-ai authentication"
+          field: GoogleAppCredentials
+          alternative_env_keys: ["GOOGLE_APPLICATION_CREDENTIALS"]
+          skipped_when_gcp_service_account_assigned: true
+          required: true
+  autodetect:
+    env:
+      GEMINI_API_KEY: api-key
+      GOOGLE_API_KEY: api-key
+      GOOGLE_APPLICATION_CREDENTIALS: vertex-ai
+      GOOGLE_CLOUD_PROJECT: vertex-ai
+    files:
+      GEMINI_OAUTH_CREDS: auth-file
+      gcloud-adc: vertex-ai

--- a/harnesses/gemini-cli/home/.bashrc
+++ b/harnesses/gemini-cli/home/.bashrc
@@ -1,0 +1,4 @@
+# scion agent bashrc
+# Source scion environment (written by sciontool init)
+[ -f ~/.scion/scion-env ] && . ~/.scion/scion-env
+alias g="gemini"

--- a/harnesses/gemini-cli/home/.gemini/settings.json
+++ b/harnesses/gemini-cli/home/.gemini/settings.json
@@ -1,0 +1,151 @@
+{
+  "yolo": true,
+  "security": {
+    "auth": {},
+    "folderTrust": {
+      "enabled": false
+    },
+    "allowedEnvironmentVariables": ["SCION_AGENT_ID", "SCION_AGENT_NAME", "SCION_AGENT_SLUG", "SCION_AUTH_TOKEN", "SCION_BROKER_ID", "SCION_BROKER_NAME", "SCION_CREATOR", "SCION_DEBUG", "SCION_GROVE", "SCION_GROVE_ID", "SCION_GROVE_PATH", "SCION_PROJECT", "SCION_PROJECT_ID", "SCION_PROJECT_PATH", "SCION_HARNESS", "SCION_HOST_GID", "SCION_HOST_UID", "SCION_HUB_ENDPOINT", "SCION_HUB_URL", "SCION_MODEL", "SCION_OTEL_ENDPOINT", "SCION_OTEL_GCP_CREDENTIALS", "SCION_OTEL_PROTOCOL", "SCION_SHARED_WORKSPACE", "SCION_TELEMETRY_CLOUD_ENABLED", "SCION_TELEMETRY_CLOUD_PROVIDER", "SCION_TELEMETRY_DEBUG", "SCION_TELEMETRY_ENABLED", "SCION_TELEMETRY_HUB_ENABLED", "SCION_TELEMETRY_LOCAL_CONSOLE", "SCION_TELEMETRY_LOCAL_ENABLED", "SCION_TEMPLATE", "SCION_TEMPLATE_NAME", "GITHUB_TOKEN"]
+  },
+  "context": {
+    "fileName": ["CLAUDE.md","AGENTS.md", "GEMINI.md"],
+    "fileFiltering": {
+      "customIgnoreFilePaths": ["/home/scion/.gemini/.geminiignore"]
+    }
+  },
+  "model": {
+    "skipNextSpeakerCheck": true,
+    "name": "gemini-3-flash-preview"
+  },
+  "telemetry": {
+    "enabled": true
+  },
+  "general": {
+    "disableAutoUpdate": true,
+    "disableUpdateNag": true,
+    "previewFeatures": true
+  },
+  "ui": {
+    "accessibility": {
+      "disableLoadingPhrases": true
+    },
+    "hideFooter": true,
+    "hideWindowTitle": true
+  },
+  "tools": {
+    "enableMessageBusIntegration": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "scion-status",
+            "type": "command",
+            "command": "sciontool hook --dialect=gemini"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "scion-status",
+            "type": "command",
+            "command": "sciontool hook --dialect=gemini"
+          }
+        ]
+      }
+    ],
+    "BeforeAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "scion-status",
+            "type": "command",
+            "command": "sciontool hook --dialect=gemini"
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "scion-status",
+            "type": "command",
+            "command": "sciontool hook --dialect=gemini"
+          }
+        ]
+      }
+    ],
+    "BeforeTool": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "scion-status",
+            "type": "command",
+            "command": "sciontool hook --dialect=gemini"
+          }
+        ]
+      }
+    ],
+    "AfterTool": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "scion-status",
+            "type": "command",
+            "command": "sciontool hook --dialect=gemini"
+          }
+        ]
+      }
+    ],
+    "BeforeModel": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "scion-status",
+            "type": "command",
+            "command": "sciontool hook --dialect=gemini"
+          }
+        ]
+      }
+    ],
+    "AfterModel": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "scion-status",
+            "type": "command",
+            "command": "sciontool hook --dialect=gemini"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "ToolPermission",
+        "hooks": [
+          {
+            "name": "scion-status",
+            "type": "command",
+            "command": "sciontool hook --dialect=gemini"
+          }
+        ]
+      }
+    ]
+  },
+  "experimental": {
+    "modelSteering": true
+  }
+}

--- a/harnesses/gemini-cli/home/system_prompt.md
+++ b/harnesses/gemini-cli/home/system_prompt.md
@@ -1,0 +1,1 @@
+# Placeholder

--- a/harnesses/gemini-cli/provision.py
+++ b/harnesses/gemini-cli/provision.py
@@ -51,14 +51,8 @@ from typing import Any
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-try:
-    import scion_harness  # type: ignore[import-not-found]
-except ImportError:
-    scion_harness = None  # type: ignore[assignment]
-
 GEMINI_SETTINGS_FILE = "~/.gemini/settings.json"
 GEMINI_OAUTH_CREDS_FILE = "~/.gemini/oauth_creds.json"
-ADC_FILE = "~/.config/gcloud/application_default_credentials.json"
 
 VALID_AUTH_TYPES = ("api-key", "auth-file", "vertex-ai")
 
@@ -121,19 +115,6 @@ def _env_secret_files(candidates: dict[str, Any]) -> dict[str, str]:
     return {str(k): str(v) for k, v in raw.items() if isinstance(k, str) and isinstance(v, str)}
 
 
-def _read_secret(secret_files: dict[str, str], env_name: str) -> str:
-    """Read the secret value from a staged secret file."""
-    path = secret_files.get(env_name, "")
-    if not path:
-        return ""
-    expanded = _expand(path)
-    try:
-        with open(expanded, "r", encoding="utf-8") as f:
-            return f.read().strip()
-    except OSError:
-        return ""
-
-
 def _auth_file_present(file_paths: list[str], target: str) -> bool:
     """Return True if the auth file is mounted or already on disk."""
     if any(_expand(p) == _expand(target) for p in file_paths):
@@ -155,8 +136,6 @@ def _select_auth_method(
     has_google_key = "GOOGLE_API_KEY" in env_keys
     has_authfile = _auth_file_present(file_paths, GEMINI_OAUTH_CREDS_FILE)
     has_gcp_project = "GOOGLE_CLOUD_PROJECT" in env_keys
-    has_gcp_region = "GOOGLE_CLOUD_REGION" in env_keys
-
     if explicit:
         if explicit not in VALID_AUTH_TYPES:
             raise ValueError(

--- a/harnesses/gemini-cli/provision.py
+++ b/harnesses/gemini-cli/provision.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Gemini CLI container-side provisioner.
+
+Runs inside the agent container during the pre-start lifecycle hook, invoked
+by `sciontool harness provision --manifest ...`. The host-side
+ContainerScriptHarness has already:
+
+  * Staged this script and config.yaml under $HOME/.scion/harness/.
+  * Written inputs/auth-candidates.json with the env-var names + paths to
+    secret-value files under $HOME/.scion/harness/secrets/<NAME>.
+  * Mounted any auth file (e.g. ~/.gemini/oauth_creds.json) at the declared
+    container_path, when auth-file mode is in use.
+  * Mounted ADC credentials when vertex-ai mode is in use.
+
+This script's job mirrors the compiled GeminiCLI harness:
+
+  1. Determine which auth method Gemini CLI will use, honoring an explicit
+     selection if present and otherwise applying the same precedence as the
+     compiled harness:
+         GEMINI_API_KEY / GOOGLE_API_KEY > auth-file (OAuth) > vertex-ai.
+  2. Map the universal auth type to a Gemini-internal auth type string and
+     write it into ~/.gemini/settings.json under security.auth.selectedType.
+  3. Write outputs/resolved-auth.json describing the chosen method.
+  4. Write outputs/env.json with env vars to project into the harness process
+     (e.g. GEMINI_API_KEY, GOOGLE_CLOUD_PROJECT, or Vertex AI vars).
+
+The script is intentionally stdlib-only so it works on any container image
+that ships python3 (declared in config.yaml's required_image_tools).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    import scion_harness  # type: ignore[import-not-found]
+except ImportError:
+    scion_harness = None  # type: ignore[assignment]
+
+GEMINI_SETTINGS_FILE = "~/.gemini/settings.json"
+GEMINI_OAUTH_CREDS_FILE = "~/.gemini/oauth_creds.json"
+ADC_FILE = "~/.config/gcloud/application_default_credentials.json"
+
+VALID_AUTH_TYPES = ("api-key", "auth-file", "vertex-ai")
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_UNSUPPORTED = 2
+
+# Maps universal auth type values to Gemini CLI-internal values.
+# Gemini CLI settings.json expects specific strings like "gemini-api-key",
+# "oauth-personal", "vertex-ai".
+_GEMINI_AUTH_TYPE_MAP = {
+    "api-key": "gemini-api-key",
+    "auth-file": "oauth-personal",
+    "vertex-ai": "vertex-ai",
+}
+
+
+def _expand(path: str) -> str:
+    """Expand ~ and $HOME in a container path."""
+    return os.path.expanduser(os.path.expandvars(path))
+
+
+def _load_json(path: str) -> Any:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _write_json(path: str, payload: Any) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+        f.write("\n")
+    os.replace(tmp, path)
+
+
+def _present_env_keys(candidates: dict[str, Any]) -> set[str]:
+    """Names of auth env vars staged by the host as candidates."""
+    raw = candidates.get("env_vars") or []
+    return {str(k) for k in raw if isinstance(k, str)}
+
+
+def _present_file_paths(candidates: dict[str, Any]) -> list[str]:
+    """Container paths of auth files mounted by the host as candidates."""
+    raw = candidates.get("files") or []
+    out: list[str] = []
+    for entry in raw:
+        if isinstance(entry, dict):
+            cp = entry.get("container_path")
+            if isinstance(cp, str) and cp:
+                out.append(cp)
+    return out
+
+
+def _env_secret_files(candidates: dict[str, Any]) -> dict[str, str]:
+    """Map of env-var name -> path to secret value file staged by the host."""
+    raw = candidates.get("env_secret_files") or {}
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): str(v) for k, v in raw.items() if isinstance(k, str) and isinstance(v, str)}
+
+
+def _read_secret(secret_files: dict[str, str], env_name: str) -> str:
+    """Read the secret value from a staged secret file."""
+    path = secret_files.get(env_name, "")
+    if not path:
+        return ""
+    expanded = _expand(path)
+    try:
+        with open(expanded, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    except OSError:
+        return ""
+
+
+def _auth_file_present(file_paths: list[str], target: str) -> bool:
+    """Return True if the auth file is mounted or already on disk."""
+    if any(_expand(p) == _expand(target) for p in file_paths):
+        return True
+    return os.path.isfile(_expand(target))
+
+
+def _select_auth_method(
+    explicit: str,
+    env_keys: set[str],
+    file_paths: list[str],
+) -> tuple[str, str]:
+    """Pick an auth method.
+
+    Returns (method, env_key_or_empty). env_key is the chosen API key env var
+    name when method == 'api-key', else "". Raises ValueError on no-creds.
+    """
+    has_gemini_key = "GEMINI_API_KEY" in env_keys
+    has_google_key = "GOOGLE_API_KEY" in env_keys
+    has_authfile = _auth_file_present(file_paths, GEMINI_OAUTH_CREDS_FILE)
+    has_gcp_project = "GOOGLE_CLOUD_PROJECT" in env_keys
+    has_gcp_region = "GOOGLE_CLOUD_REGION" in env_keys
+
+    if explicit:
+        if explicit not in VALID_AUTH_TYPES:
+            raise ValueError(
+                f"gemini: unknown auth type {explicit!r}; valid types are: "
+                f"{', '.join(VALID_AUTH_TYPES)}"
+            )
+        if explicit == "api-key":
+            if has_gemini_key:
+                return "api-key", "GEMINI_API_KEY"
+            if has_google_key:
+                return "api-key", "GOOGLE_API_KEY"
+            raise ValueError(
+                "gemini: auth type 'api-key' selected but no API key found; "
+                "set GEMINI_API_KEY or GOOGLE_API_KEY"
+            )
+        if explicit == "auth-file":
+            if not has_authfile:
+                raise ValueError(
+                    "gemini: auth type 'auth-file' selected but OAuth credentials "
+                    f"file not found at {GEMINI_OAUTH_CREDS_FILE}"
+                )
+            return "auth-file", ""
+        if explicit == "vertex-ai":
+            if not has_gcp_project:
+                raise ValueError(
+                    "gemini: auth type 'vertex-ai' selected but "
+                    "GOOGLE_CLOUD_PROJECT is not set"
+                )
+            return "vertex-ai", ""
+
+    # Auto-detect precedence matches the compiled GeminiCLI harness:
+    # API key -> OAuth (auth-file) -> Vertex AI
+    if has_gemini_key:
+        return "api-key", "GEMINI_API_KEY"
+    if has_google_key:
+        return "api-key", "GOOGLE_API_KEY"
+    if has_authfile:
+        return "auth-file", ""
+    if has_gcp_project:
+        return "vertex-ai", ""
+
+    raise ValueError(
+        "gemini: no valid auth method found; set GEMINI_API_KEY or "
+        "GOOGLE_API_KEY for API key auth, provide OAuth credentials at "
+        f"{GEMINI_OAUTH_CREDS_FILE}, or set GOOGLE_CLOUD_PROJECT "
+        "(with ADC or GCP service account) for Vertex AI"
+    )
+
+
+def _update_gemini_settings(settings_path: str, gemini_auth_type: str) -> None:
+    """Update ~/.gemini/settings.json with the Gemini-native auth type.
+
+    Mirrors GeminiCLI.updateSelectedAuthType in gemini_cli.go.
+    """
+    settings: dict[str, Any] = {}
+    expanded = _expand(settings_path)
+    if os.path.isfile(expanded):
+        try:
+            settings = _load_json(expanded) or {}
+        except (OSError, json.JSONDecodeError):
+            settings = {}
+    if not isinstance(settings, dict):
+        settings = {}
+
+    security = settings.get("security")
+    if not isinstance(security, dict):
+        security = {}
+        settings["security"] = security
+
+    auth = security.get("auth")
+    if not isinstance(auth, dict):
+        auth = {}
+        security["auth"] = auth
+
+    if auth.get("selectedType") == gemini_auth_type:
+        return
+
+    auth["selectedType"] = gemini_auth_type
+    _write_json(expanded, settings)
+
+
+def _build_env_overlay(method: str, env_key: str) -> dict[str, str]:
+    """Build the env vars overlay for outputs/env.json.
+
+    Mirrors the env updates the compiled GeminiCLI.Provision() writes
+    into scion-agent.json.
+    """
+    if method == "api-key" and env_key:
+        return {env_key: f"${{{env_key}}}"}
+    if method == "auth-file":
+        overlay: dict[str, str] = {}
+        if os.environ.get("GOOGLE_CLOUD_PROJECT"):
+            overlay["GOOGLE_CLOUD_PROJECT"] = "${GOOGLE_CLOUD_PROJECT}"
+        return overlay
+    if method == "vertex-ai":
+        return {
+            "GOOGLE_CLOUD_PROJECT": "${GOOGLE_CLOUD_PROJECT}",
+            "GOOGLE_CLOUD_REGION": "${GOOGLE_CLOUD_REGION}",
+            "GOOGLE_CLOUD_LOCATION": "${GOOGLE_CLOUD_REGION}",
+        }
+    return {}
+
+
+def _provision(manifest: dict[str, Any]) -> int:
+    bundle = manifest.get("harness_bundle_dir") or "$HOME/.scion/harness"
+    bundle = _expand(bundle)
+    workspace = manifest.get("agent_workspace") or "/workspace"
+
+    inputs_dir = os.path.join(bundle, "inputs")
+    auth_candidates_path = os.path.join(inputs_dir, "auth-candidates.json")
+
+    candidates: dict[str, Any] = {}
+    if os.path.isfile(auth_candidates_path):
+        try:
+            candidates = _load_json(auth_candidates_path) or {}
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"gemini provision: invalid auth-candidates.json: {exc}", file=sys.stderr)
+            return EXIT_ERROR
+
+    explicit = str(candidates.get("explicit_type") or "").strip()
+    env_keys = _present_env_keys(candidates)
+    file_paths = _present_file_paths(candidates)
+    secret_files = _env_secret_files(candidates)
+
+    harness_cfg = manifest.get("harness_config") or {}
+    no_auth_cfg = harness_cfg.get("no_auth") or {}
+    no_auth_behavior = str(no_auth_cfg.get("behavior") or "").strip()
+
+    if not candidates and no_auth_behavior:
+        print(f"gemini provision: no-auth mode (behavior={no_auth_behavior}), skipping auth setup", file=sys.stderr)
+        method = "none"
+        env_key = ""
+    else:
+        try:
+            method, env_key = _select_auth_method(explicit, env_keys, file_paths)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return EXIT_ERROR
+
+    outputs = manifest.get("outputs") or {}
+    env_out = _expand(outputs.get("env") or os.path.join(bundle, "outputs", "env.json"))
+    auth_out = _expand(outputs.get("resolved_auth") or os.path.join(bundle, "outputs", "resolved-auth.json"))
+
+    # 1. Update ~/.gemini/settings.json with the resolved auth type.
+    gemini_auth_type = _GEMINI_AUTH_TYPE_MAP.get(method, "")
+    if gemini_auth_type:
+        try:
+            _update_gemini_settings(GEMINI_SETTINGS_FILE, gemini_auth_type)
+        except OSError as exc:
+            print(f"gemini provision: failed to update gemini settings: {exc}", file=sys.stderr)
+            return EXIT_ERROR
+
+    # 2. Build resolved-auth output.
+    resolved_payload: dict[str, Any] = {
+        "schema_version": 1,
+        "harness": "gemini-cli",
+        "method": method,
+        "explicit_type": explicit or None,
+    }
+    if method == "api-key":
+        resolved_payload["env_var"] = env_key
+    elif method == "auth-file":
+        resolved_payload["auth_file"] = GEMINI_OAUTH_CREDS_FILE
+    elif method == "vertex-ai":
+        resolved_payload["vertex_ai"] = True
+
+    # 3. Build env overlay.
+    env_payload = _build_env_overlay(method, env_key)
+
+    try:
+        _write_json(auth_out, resolved_payload)
+        _write_json(env_out, env_payload)
+    except OSError as exc:
+        print(f"gemini provision: failed to write outputs: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    print(f"gemini provision: method={method}", file=sys.stderr)
+    return EXIT_OK
+
+
+def _dispatch(manifest: dict[str, Any]) -> int:
+    command = str(manifest.get("command") or "provision")
+    if command == "provision":
+        return _provision(manifest)
+    print(f"gemini provision: unsupported command {command!r}", file=sys.stderr)
+    return EXIT_UNSUPPORTED
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Gemini CLI container-side provisioner")
+    parser.add_argument(
+        "--manifest",
+        help="Path to the staged manifest.json (defaults to $HOME/.scion/harness/manifest.json)",
+        default=None,
+    )
+    args = parser.parse_args()
+
+    manifest_path = args.manifest
+    if not manifest_path:
+        home = os.environ.get("HOME") or os.path.expanduser("~")
+        manifest_path = os.path.join(home, ".scion", "harness", "manifest.json")
+
+    try:
+        manifest = _load_json(manifest_path)
+    except FileNotFoundError:
+        print(f"gemini provision: manifest not found at {manifest_path}", file=sys.stderr)
+        return EXIT_ERROR
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"gemini provision: failed to load manifest {manifest_path}: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    if not isinstance(manifest, dict):
+        print("gemini provision: manifest is not an object", file=sys.stderr)
+        return EXIT_ERROR
+
+    return _dispatch(manifest)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pkg/harness/gemini/embeds/capture_auth.py
+++ b/pkg/harness/gemini/embeds/capture_auth.py
@@ -55,11 +55,11 @@ def _load_config(bundle: str) -> list[dict[str, Any]]:
     config_path = os.path.join(bundle, "inputs", "capture-auth-config.json")
     if not os.path.isfile(config_path):
         return []
-    with open(config_path, "r", encoding="utf-8") as f:
-        try:
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
             data = json.load(f)
-        except (json.JSONDecodeError, OSError):
-            return []
+    except (json.JSONDecodeError, OSError):
+        return []
     creds = data.get("credentials")
     if not isinstance(creds, list):
         return []

--- a/resources/catalog.go
+++ b/resources/catalog.go
@@ -66,8 +66,6 @@ func BuiltinTemplates() []BundledResource {
 }
 
 // BuiltinHarnessConfigs returns the bundled harness-config resources.
-// Gemini is excluded — it remains supplied through existing embed-only harness code
-// and has no directory in harnesses/.
 func BuiltinHarnessConfigs() []BundledResource {
 	var configs []BundledResource
 	entries, err := fs.ReadDir(harnesses.FS, ".")


### PR DESCRIPTION
## Summary

Adds a complete `harnesses/gemini-cli/` container-script harness bundle for the Gemini CLI, following the same pattern as `harnesses/claude/` (PR #548).

- `config.yaml`: declares `provisioner.type: container-script` with Gemini-specific command, config_dir (`.gemini`), capabilities, and auth modes
- `provision.py`: container-side provisioning with auth mode detection and precedence:
  - API key (GEMINI_API_KEY / GOOGLE_API_KEY)
  - OAuth auth-file (~/.gemini/oauth_creds.json)
  - Vertex AI (GOOGLE_CLOUD_PROJECT)
  - Maps to Gemini-internal auth types and writes ~/.gemini/settings.json
- `capture_auth.py`: adapted from existing builtin for interactive OAuth capture
- `Dockerfile` + `cloudbuild.yaml`: container image definition and Cloud Build config
- `README.md`: auth modes and install instructions
- `home/`: .bashrc, .gemini/settings.json, system_prompt.md (byte-identical to existing embeds)
- `harnesses/embed.go`: add `all:gemini-cli/*` to embed directive
- `resources/catalog.go`: remove Gemini exclusion — dynamic FS scan now includes gemini-cli

The compiled-in `GeminiCLI` struct (`pkg/harness/gemini_cli.go`) is retained for backward compatibility; removal is a follow-up.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./harnesses/... ./resources/...` passes
- [ ] `scion harness-config install harnesses/gemini-cli` works
- [ ] `resources.BuiltinHarnessConfigs()` includes gemini-cli entry
- [ ] Existing `TestBuiltinHarnessConfigsExcludesGemini` still passes (checks for name "gemini", not "gemini-cli")
