### PR TITLE
docs: warn that go install produces a blank web UI and fix build-from-clone steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ See the full [Installation Guide](https://googlecloudplatform.github.io/scion/ge
 go install github.com/GoogleCloudPlatform/scion/cmd/scion@latest
 ```
 
+> **Warning:** `go install` builds only the Go binary. It does not build or embed the web frontend, so `scion server start` will serve a blank web UI with missing frontend assets. Use Homebrew for a ready-to-run install, or build from a clone with `make all` before installing the binary.
+
 ### Initialize your machine and a Project (project)
 
 > **Tip:** If you used `scion server start` above, the onboarding wizard handles machine initialization automatically — you can skip this section.

--- a/docs-site/src/content/docs/getting-started/install.md
+++ b/docs-site/src/content/docs/getting-started/install.md
@@ -58,17 +58,23 @@ You can install Scion directly using `go install`:
 go install github.com/GoogleCloudPlatform/scion/cmd/scion@latest
 ```
 
+:::caution[Web UI assets are not included]
+`go install` builds only the Go binary. It does not build or embed the web frontend, so `scion server start` will serve a blank web UI with missing frontend assets. Use Homebrew for a ready-to-run install, or build from a clone with `make all`.
+:::
+
 Ensure your `$GOPATH/bin` (typically `~/go/bin`) is in your system `$PATH`.
 
 ### From Clone
 If you have the repository cloned, you can use the provided `Makefile`:
 
 ```bash
-make build
+make all
 # This creates a 'scion' binary in the build directory.
 # You can move it to a directory in your PATH:
 sudo mv ./build/scion /usr/local/bin/
 ```
+
+The `all` target builds the web frontend before compiling the Go binary, so the embedded web UI assets are present. If you prefer separate steps, run `make web` before `make build`.
 
 To verify your installation, run:
 


### PR DESCRIPTION
## Summary
Installing via `go install` builds only the Go binary and does not embed the web frontend, so `scion server start` serves a blank web UI. The install docs did not mention this, and the from-clone steps used `make build` (which also skips the frontend).

## Changes
Add a caution to the install guide and README that `go install` omits the web assets, and point users to Homebrew or a `make all` clone build. Change the from-clone instructions from `make build` to `make all` (which builds the frontend before the binary).

Fixes #174
