### PR TITLE
fix: skip image registry rewrite for fully qualified references

### DIFF
--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -210,6 +210,17 @@ func RewriteImageRegistry(fullImage, newRegistry string) string {
 		return fullImage
 	}
 
+	// If the image already has an explicit registry hostname
+	// (first path component contains "." or ":"), don't rewrite it.
+	// A fully qualified reference like ghcr.io/org/scion-foo:v1
+	// means the author chose that registry deliberately.
+	if firstSlash := strings.Index(fullImage, "/"); firstSlash >= 0 {
+		firstComponent := fullImage[:firstSlash]
+		if strings.ContainsAny(firstComponent, ".:") {
+			return fullImage
+		}
+	}
+
 	// Strip trailing slash from registry
 	registry := strings.TrimRight(newRegistry, "/")
 	return registry + "/" + basename

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -3239,16 +3239,16 @@ func TestRewriteImageRegistry(t *testing.T) {
 		want        string
 	}{
 		{
-			name:        "rewrite scion image",
+			name:        "fully qualified scion image preserved",
 			fullImage:   "us-central1-docker.pkg.dev/example-project/scion-images/scion-claude:latest",
 			newRegistry: "ghcr.io/myorg",
-			want:        "ghcr.io/myorg/scion-claude:latest",
+			want:        "us-central1-docker.pkg.dev/example-project/scion-images/scion-claude:latest",
 		},
 		{
-			name:        "rewrite with trailing slash",
+			name:        "fully qualified scion image preserved with trailing slash",
 			fullImage:   "us-central1-docker.pkg.dev/example-project/scion-images/scion-gemini:latest",
 			newRegistry: "ghcr.io/myorg/",
-			want:        "ghcr.io/myorg/scion-gemini:latest",
+			want:        "us-central1-docker.pkg.dev/example-project/scion-images/scion-gemini:latest",
 		},
 		{
 			name:        "do not rewrite non-scion image",
@@ -3275,16 +3275,16 @@ func TestRewriteImageRegistry(t *testing.T) {
 			want:        "",
 		},
 		{
-			name:        "scion-base image is rewritten",
+			name:        "fully qualified scion-base image preserved",
 			fullImage:   "us-central1-docker.pkg.dev/example-project/scion-images/scion-base:v2",
 			newRegistry: "docker.io/myuser",
-			want:        "docker.io/myuser/scion-base:v2",
+			want:        "us-central1-docker.pkg.dev/example-project/scion-images/scion-base:v2",
 		},
 		{
-			name:        "preserves tag",
+			name:        "fully qualified preserves tag",
 			fullImage:   "us-central1-docker.pkg.dev/example-project/scion-images/scion-opencode:sha-abc123",
 			newRegistry: "ghcr.io/myorg",
-			want:        "ghcr.io/myorg/scion-opencode:sha-abc123",
+			want:        "us-central1-docker.pkg.dev/example-project/scion-images/scion-opencode:sha-abc123",
 		},
 		{
 			name:        "bare image name (no registry prefix)",
@@ -3297,6 +3297,24 @@ func TestRewriteImageRegistry(t *testing.T) {
 			fullImage:   "scion-gemini:latest",
 			newRegistry: "",
 			want:        "scion-gemini:latest",
+		},
+		{
+			name:        "explicit registry preserved",
+			fullImage:   "ghcr.io/myorg/scion-elixir:latest",
+			newRegistry: "docker.io/other",
+			want:        "ghcr.io/myorg/scion-elixir:latest",
+		},
+		{
+			name:        "port-based registry preserved",
+			fullImage:   "localhost:5000/scion-test:latest",
+			newRegistry: "ghcr.io/myorg",
+			want:        "localhost:5000/scion-test:latest",
+		},
+		{
+			name:        "docker hub path rewritten",
+			fullImage:   "myuser/scion-custom:latest",
+			newRegistry: "ghcr.io/myorg",
+			want:        "ghcr.io/myorg/scion-custom:latest",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- **RewriteImageRegistry()** now detects when an image reference already has an explicit registry hostname (first path component contains "." or ":") and skips rewriting it.
- This aligns with OCI/Docker reference semantics: a fully qualified reference like `ghcr.io/org/scion-foo:v1` means the author chose that registry deliberately.
- Makes the `image_pinned` approach from PR #425 unnecessary — the rewrite function itself now correctly detects when to skip.

## Changes

- `pkg/config/settings_v1.go`: Added explicit-registry guard in `RewriteImageRegistry()`
- `pkg/config/settings_v1_test.go`: Updated existing tests + added 3 new edge-case tests (13 total, all passing)

## Test plan

- [x] All 13 `TestRewriteImageRegistry` subtests pass
- [x] Full `pkg/config` test suite passes
- [x] Code reviewed and approved by independent reviewer