### PR TITLE
fix(message): reject --attach in local mode instead of silently dropping attachments

### DIFF
--- a/cmd/message.go
+++ b/cmd/message.go
@@ -184,6 +184,9 @@ Examples:
 		if len(msgAttach) > messages.MaxAttachments {
 			return fmt.Errorf("too many attachments: %d (max %d)", len(msgAttach), messages.MaxAttachments)
 		}
+		if len(msgAttach) > 0 && (msgIn != "" || msgAt != "") {
+			return fmt.Errorf("--attach cannot be combined with --in or --at")
+		}
 
 		// Check if Hub should be used
 		var hubCtx *HubContext
@@ -248,6 +251,13 @@ Examples:
 		// --wake requires Hub mode
 		if msgWake {
 			return fmt.Errorf("--wake requires Hub mode (use 'scion hub enable' first)")
+		}
+
+		// --attach requires Hub mode: attachments are delivered through Hub
+		// storage, while local mode writes plain text to the agent terminal
+		// and cannot transfer files.
+		if len(msgAttach) > 0 {
+			return fmt.Errorf("--attach requires Hub mode (use 'scion hub enable' first); in local mode, include the file contents in the message text")
 		}
 
 		// Local mode — structured messages are only available in Hub mode,

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -860,6 +860,39 @@ func TestWakeFlagValidation(t *testing.T) {
 	}
 }
 
+func TestAttachFlagValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func()
+		teardown func()
+		errMsg   string
+	}{
+		{
+			name:     "attach with in",
+			setup:    func() { msgAttach = []string{"notes.md"}; msgIn = "5m" },
+			teardown: func() { msgAttach = nil; msgIn = "" },
+			errMsg:   "--attach cannot be combined with --in or --at",
+		},
+		{
+			name:     "attach with at",
+			setup:    func() { msgAttach = []string{"notes.md"}; msgAt = "2026-01-01T00:00:00Z" },
+			teardown: func() { msgAttach = nil; msgAt = "" },
+			errMsg:   "--attach cannot be combined with --in or --at",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+			defer tc.teardown()
+
+			err := messageCmd.RunE(messageCmd, []string{"agent1", "hello"})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errMsg)
+		})
+	}
+}
+
 func TestSendGroupMessageViaHub(t *testing.T) {
 	orig := saveMessageTestState()
 	defer orig.restore()


### PR DESCRIPTION
## Problem

`scion message --attach` silently drops attachments outside the Hub single/group/outbound send paths:

- **Local (no-Hub) mode:** the flag is accepted and the message reports as delivered, but local delivery only sends the text to the agent terminal — `msgAttach` is never consumed. The sender has no indication the file was not transferred. (I originally hit this while driving a multi-agent demo in solo mode and lost time assuming the agent had the file.)
- **Scheduled messages (`--in`/`--at`):** `scheduleMessageViaHub` does not include attachments in the scheduled event, so Hub-mode scheduled sends drop them too.

## Change

Follow the existing Hub-only guard pattern already used for `--wake`, `--notify`, scheduled messages, and `user:`/`group[]` recipients in `cmd/message.go`:

- Local mode now errors: `--attach requires Hub mode (use 'scion hub enable' first); in local mode, include the file contents in the message text`
- `--attach` combined with `--in`/`--at` now errors: `--attach cannot be combined with --in or --at` (matching the existing combination validations). Supporting attachments on scheduled messages could be a follow-up if there's interest.

## Testing

- Added `TestAttachFlagValidation` covering `--attach` + `--in`/`--at` (same table pattern as `TestWakeFlagValidation`).
- Full `go test ./cmd/` passes; `go vet` clean.
- Verified manually with an isolated `$HOME`:
  - local mode + `--attach` → new error (previously: "Message delivered" with the file dropped)
  - `--attach --in 5m` → combination error
  - plain local message → unchanged behavior