### PR TITLE
fix: run go mod tidy before go build in plugin install/update

### DIFF
--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -520,6 +520,12 @@ func (m *Manager) UpdatePlugin(name string, repoPath string) error {
 	m.logger.Info("Building plugin from source",
 		"name", name, "source", sourceDir, "binary", binaryPath)
 
+	tidyCmd := exec.Command("go", "mod", "tidy")
+	tidyCmd.Dir = sourceDir
+	if output, err := tidyCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("go mod tidy failed for plugin %q: %w\n%s", name, err, string(output))
+	}
+
 	buildCmd := exec.Command("go", "build", "-o", tmpBinaryPath, "./cmd/scion-plugin-"+name)
 	buildCmd.Dir = sourceDir
 	if output, err := buildCmd.CombinedOutput(); err != nil {
@@ -569,6 +575,12 @@ func (m *Manager) InstallPlugin(name, repoPath, pluginsDir string) error {
 
 	m.logger.Info("Building plugin from source (first-time install)",
 		"name", name, "source", sourceDir, "binary", targetPath)
+
+	tidyCmd := exec.Command("go", "mod", "tidy")
+	tidyCmd.Dir = sourceDir
+	if output, err := tidyCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("go mod tidy failed for plugin %q: %w\n%s", name, err, string(output))
+	}
 
 	buildCmd := exec.Command("go", "build", "-o", targetPath, "./cmd/scion-plugin-"+name)
 	buildCmd.Dir = sourceDir


### PR DESCRIPTION
Fixes plugin install/update failing when extras module go.mod needs syncing.
Adds go mod tidy step before go build in both InstallPlugin and UpdatePlugin.

Related: #365