### PR TITLE
fix: propagate exec exit codes and standardize capture-auth conflict handling

### DIFF
--- a/harnesses/antigravity/capture_auth.py
+++ b/harnesses/antigravity/capture_auth.py
@@ -28,6 +28,7 @@ Exit codes:
   0 = credential captured
   1 = error
   2 = no credentials found (not an error, but nothing was stored)
+  3 = secret already exists (conflict — use --force to overwrite)
 """
 
 from __future__ import annotations
@@ -43,6 +44,7 @@ from typing import Any
 EXIT_OK = 0
 EXIT_ERROR = 1
 EXIT_NO_CREDS = 2
+EXIT_CONFLICT = 3
 
 HARNESS_BUNDLE = os.path.join(
     os.environ.get("HOME") or os.path.expanduser("~"),
@@ -115,8 +117,8 @@ def _capture_one(entry: dict[str, Any], force: bool) -> tuple[bool, str | None]:
 
     if result.returncode != 0:
         stderr = result.stderr.strip()
-        if "already exists" in stderr:
-            return True, None
+        if "already exists" in stderr.lower():
+            return False, "CONFLICT"
         return False, f"sciontool failed for {key}: {stderr}"
 
     return True, None
@@ -189,6 +191,7 @@ def main() -> int:
     entries = unique_entries
 
     captured = 0
+    conflicts = 0
     errors = 0
 
     for entry in entries:
@@ -205,7 +208,10 @@ def main() -> int:
             continue
 
         ok, err = _capture_one(entry, args.force)
-        if err:
+        if err == "CONFLICT":
+            print(f'CONFLICT: secret "{key}" already exists (use --force to overwrite)')
+            conflicts += 1
+        elif err:
             print(f"capture-auth: {key}: {err}", file=sys.stderr)
             errors += 1
         elif ok:
@@ -213,7 +219,7 @@ def main() -> int:
             captured += 1
 
     # Keyring fallback: AGY may store tokens only in gnome-keyring, not to file
-    if captured == 0 and errors == 0:
+    if captured == 0 and conflicts == 0 and errors == 0:
         print("capture-auth: file not found, trying gnome-keyring fallback...")
         token = _extract_from_keyring()
         if token:
@@ -230,6 +236,9 @@ def main() -> int:
                 if result.returncode == 0:
                     print(f"capture-auth: AGY_TOKEN: captured from gnome-keyring")
                     captured += 1
+                elif "already exists" in result.stderr.lower():
+                    print('CONFLICT: secret "AGY_TOKEN" already exists (use --force to overwrite)')
+                    conflicts += 1
                 else:
                     print(f"capture-auth: keyring fallback failed: {result.stderr.strip()}", file=sys.stderr)
                     errors += 1
@@ -238,6 +247,9 @@ def main() -> int:
                     os.unlink(tmp_path)
                 except OSError:
                     pass
+
+    if conflicts > 0:
+        return EXIT_CONFLICT
 
     if errors > 0 and captured == 0:
         return EXIT_ERROR

--- a/harnesses/claude/capture_auth.py
+++ b/harnesses/claude/capture_auth.py
@@ -26,6 +26,7 @@ Exit codes:
   0 = at least one credential captured
   1 = error
   2 = no credentials found (not an error, but nothing was stored)
+  3 = secret already exists (conflict — use --force to overwrite)
 """
 
 from __future__ import annotations
@@ -40,6 +41,7 @@ from typing import Any
 EXIT_OK = 0
 EXIT_ERROR = 1
 EXIT_NO_CREDS = 2
+EXIT_CONFLICT = 3
 
 HARNESS_BUNDLE = os.path.join(
     os.environ.get("HOME") or os.path.expanduser("~"),
@@ -103,6 +105,8 @@ def _capture_one(
 
     if result.returncode != 0:
         stderr = result.stderr.strip()
+        if "already exists" in stderr.lower():
+            return False, "CONFLICT"
         return False, f"sciontool failed for {key}: {stderr}"
 
     return True, None
@@ -134,6 +138,7 @@ def main() -> int:
         return EXIT_NO_CREDS
 
     captured = 0
+    conflicts = 0
     errors = 0
 
     for entry in entries:
@@ -146,12 +151,18 @@ def main() -> int:
             continue
 
         ok, err = _capture_one(entry, args.force)
-        if err:
+        if err == "CONFLICT":
+            print(f'CONFLICT: secret "{key}" already exists (use --force to overwrite)')
+            conflicts += 1
+        elif err:
             print(f"capture-auth: {key}: {err}", file=sys.stderr)
             errors += 1
         elif ok:
             print(f"capture-auth: {key}: captured from {source}")
             captured += 1
+
+    if conflicts > 0:
+        return EXIT_CONFLICT
 
     if errors > 0 and captured == 0:
         return EXIT_ERROR

--- a/harnesses/codex/capture_auth.py
+++ b/harnesses/codex/capture_auth.py
@@ -26,6 +26,7 @@ Exit codes:
   0 = at least one credential captured
   1 = error
   2 = no credentials found (not an error, but nothing was stored)
+  3 = secret already exists (conflict — use --force to overwrite)
 """
 
 from __future__ import annotations
@@ -40,6 +41,7 @@ from typing import Any
 EXIT_OK = 0
 EXIT_ERROR = 1
 EXIT_NO_CREDS = 2
+EXIT_CONFLICT = 3
 
 HARNESS_BUNDLE = os.path.join(
     os.environ.get("HOME") or os.path.expanduser("~"),
@@ -103,6 +105,8 @@ def _capture_one(
 
     if result.returncode != 0:
         stderr = result.stderr.strip()
+        if "already exists" in stderr.lower():
+            return False, "CONFLICT"
         return False, f"sciontool failed for {key}: {stderr}"
 
     return True, None
@@ -134,6 +138,7 @@ def main() -> int:
         return EXIT_NO_CREDS
 
     captured = 0
+    conflicts = 0
     errors = 0
 
     for entry in entries:
@@ -146,12 +151,18 @@ def main() -> int:
             continue
 
         ok, err = _capture_one(entry, args.force)
-        if err:
+        if err == "CONFLICT":
+            print(f'CONFLICT: secret "{key}" already exists (use --force to overwrite)')
+            conflicts += 1
+        elif err:
             print(f"capture-auth: {key}: {err}", file=sys.stderr)
             errors += 1
         elif ok:
             print(f"capture-auth: {key}: captured from {source}")
             captured += 1
+
+    if conflicts > 0:
+        return EXIT_CONFLICT
 
     if errors > 0 and captured == 0:
         return EXIT_ERROR

--- a/harnesses/copilot/capture_auth.py
+++ b/harnesses/copilot/capture_auth.py
@@ -26,6 +26,7 @@ Exit codes:
   0 = at least one credential captured
   1 = error
   2 = no credentials found (not an error, but nothing was stored)
+  3 = secret already exists (conflict — use --force to overwrite)
 """
 
 from __future__ import annotations
@@ -40,6 +41,7 @@ from typing import Any
 EXIT_OK = 0
 EXIT_ERROR = 1
 EXIT_NO_CREDS = 2
+EXIT_CONFLICT = 3
 
 HARNESS_BUNDLE = os.path.join(
     os.environ.get("HOME") or os.path.expanduser("~"),
@@ -106,7 +108,7 @@ def _capture_one(
     if result.returncode != 0:
         stderr = result.stderr.strip()
         if "already exists" in stderr.lower():
-            return True, None
+            return False, "CONFLICT"
         return False, f"sciontool failed for {key}: {stderr}"
 
     return True, None
@@ -138,6 +140,7 @@ def main() -> int:
         return EXIT_NO_CREDS
 
     captured = 0
+    conflicts = 0
     errors = 0
 
     for entry in entries:
@@ -150,12 +153,18 @@ def main() -> int:
             continue
 
         ok, err = _capture_one(entry, args.force)
-        if err:
+        if err == "CONFLICT":
+            print(f'CONFLICT: secret "{key}" already exists (use --force to overwrite)')
+            conflicts += 1
+        elif err:
             print(f"capture-auth: {key}: {err}", file=sys.stderr)
             errors += 1
         elif ok:
             print(f"capture-auth: {key}: captured from {source}")
             captured += 1
+
+    if conflicts > 0:
+        return EXIT_CONFLICT
 
     if errors > 0 and captured == 0:
         return EXIT_ERROR

--- a/harnesses/gemini-cli/capture_auth.py
+++ b/harnesses/gemini-cli/capture_auth.py
@@ -26,6 +26,7 @@ Exit codes:
   0 = at least one credential captured
   1 = error
   2 = no credentials found (not an error, but nothing was stored)
+  3 = secret already exists (conflict — use --force to overwrite)
 """
 
 from __future__ import annotations
@@ -40,6 +41,7 @@ from typing import Any
 EXIT_OK = 0
 EXIT_ERROR = 1
 EXIT_NO_CREDS = 2
+EXIT_CONFLICT = 3
 
 HARNESS_BUNDLE = os.path.join(
     os.environ.get("HOME") or os.path.expanduser("~"),
@@ -103,6 +105,8 @@ def _capture_one(
 
     if result.returncode != 0:
         stderr = result.stderr.strip()
+        if "already exists" in stderr.lower():
+            return False, "CONFLICT"
         return False, f"sciontool failed for {key}: {stderr}"
 
     return True, None
@@ -134,6 +138,7 @@ def main() -> int:
         return EXIT_NO_CREDS
 
     captured = 0
+    conflicts = 0
     errors = 0
 
     for entry in entries:
@@ -146,12 +151,18 @@ def main() -> int:
             continue
 
         ok, err = _capture_one(entry, args.force)
-        if err:
+        if err == "CONFLICT":
+            print(f'CONFLICT: secret "{key}" already exists (use --force to overwrite)')
+            conflicts += 1
+        elif err:
             print(f"capture-auth: {key}: {err}", file=sys.stderr)
             errors += 1
         elif ok:
             print(f"capture-auth: {key}: captured from {source}")
             captured += 1
+
+    if conflicts > 0:
+        return EXIT_CONFLICT
 
     if errors > 0 and captured == 0:
         return EXIT_ERROR

--- a/harnesses/hermes/capture_auth.py
+++ b/harnesses/hermes/capture_auth.py
@@ -26,6 +26,7 @@ Exit codes:
   0 = at least one credential captured
   1 = error
   2 = no credentials found (not an error, but nothing was stored)
+  3 = secret already exists (conflict — use --force to overwrite)
 """
 
 from __future__ import annotations
@@ -40,6 +41,7 @@ from typing import Any
 EXIT_OK = 0
 EXIT_ERROR = 1
 EXIT_NO_CREDS = 2
+EXIT_CONFLICT = 3
 
 HARNESS_BUNDLE = os.path.join(
     os.environ.get("HOME") or os.path.expanduser("~"),
@@ -103,6 +105,8 @@ def _capture_one(
 
     if result.returncode != 0:
         stderr = result.stderr.strip()
+        if "already exists" in stderr.lower():
+            return False, "CONFLICT"
         return False, f"sciontool failed for {key}: {stderr}"
 
     return True, None
@@ -134,6 +138,7 @@ def main() -> int:
         return EXIT_NO_CREDS
 
     captured = 0
+    conflicts = 0
     errors = 0
 
     for entry in entries:
@@ -146,12 +151,18 @@ def main() -> int:
             continue
 
         ok, err = _capture_one(entry, args.force)
-        if err:
+        if err == "CONFLICT":
+            print(f'CONFLICT: secret "{key}" already exists (use --force to overwrite)')
+            conflicts += 1
+        elif err:
             print(f"capture-auth: {key}: {err}", file=sys.stderr)
             errors += 1
         elif ok:
             print(f"capture-auth: {key}: captured from {source}")
             captured += 1
+
+    if conflicts > 0:
+        return EXIT_CONFLICT
 
     if errors > 0 and captured == 0:
         return EXIT_ERROR

--- a/harnesses/opencode/capture_auth.py
+++ b/harnesses/opencode/capture_auth.py
@@ -26,6 +26,7 @@ Exit codes:
   0 = at least one credential captured
   1 = error
   2 = no credentials found (not an error, but nothing was stored)
+  3 = secret already exists (conflict — use --force to overwrite)
 """
 
 from __future__ import annotations
@@ -40,6 +41,7 @@ from typing import Any
 EXIT_OK = 0
 EXIT_ERROR = 1
 EXIT_NO_CREDS = 2
+EXIT_CONFLICT = 3
 
 HARNESS_BUNDLE = os.path.join(
     os.environ.get("HOME") or os.path.expanduser("~"),
@@ -103,6 +105,8 @@ def _capture_one(
 
     if result.returncode != 0:
         stderr = result.stderr.strip()
+        if "already exists" in stderr.lower():
+            return False, "CONFLICT"
         return False, f"sciontool failed for {key}: {stderr}"
 
     return True, None
@@ -134,6 +138,7 @@ def main() -> int:
         return EXIT_NO_CREDS
 
     captured = 0
+    conflicts = 0
     errors = 0
 
     for entry in entries:
@@ -146,12 +151,18 @@ def main() -> int:
             continue
 
         ok, err = _capture_one(entry, args.force)
-        if err:
+        if err == "CONFLICT":
+            print(f'CONFLICT: secret "{key}" already exists (use --force to overwrite)')
+            conflicts += 1
+        elif err:
             print(f"capture-auth: {key}: {err}", file=sys.stderr)
             errors += 1
         elif ok:
             print(f"capture-auth: {key}: captured from {source}")
             captured += 1
+
+    if conflicts > 0:
+        return EXIT_CONFLICT
 
     if errors > 0 and captured == 0:
         return EXIT_ERROR

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -17,10 +17,12 @@ package runtimebroker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -1672,13 +1674,21 @@ func (s *Server) execCommand(w http.ResponseWriter, r *http.Request, id, project
 			NotFound(w, "Agent")
 			return
 		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			writeJSON(w, http.StatusOK, ExecResponse{
+				Output:   output,
+				ExitCode: exitErr.ExitCode(),
+			})
+			return
+		}
 		RuntimeError(w, "Failed to execute command: "+err.Error())
 		return
 	}
 
 	writeJSON(w, http.StatusOK, ExecResponse{
 		Output:   output,
-		ExitCode: 0, // TODO: Get actual exit code from runtime
+		ExitCode: 0,
 	})
 }
 

--- a/web/src/components/pages/terminal.ts
+++ b/web/src/components/pages/terminal.ts
@@ -21,7 +21,7 @@
  * via WebSocket proxy through Koa to the Hub PTY endpoint.
  */
 
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import type { PageData, Agent, AgentPhase, AgentActivity } from '../../shared/types.js';
@@ -96,6 +96,9 @@ export class ScionPageTerminal extends LitElement {
 
   @state()
   private captureAuthLoading = false;
+
+  @state()
+  private captureAuthConflicts: string[] | null = null;
 
   private terminal: Terminal | null = null;
   private fitAddon: FitAddon | null = null;
@@ -780,17 +783,20 @@ export class ScionPageTerminal extends LitElement {
     return isNoAuth && !!agent.resolvedHarness;
   }
 
-  private async handleCaptureAuth(): Promise<void> {
+  private static readonly SECRET_CONFLICT_RE = /secret "([^"]+)" already exists/g;
+
+  private async handleCaptureAuth(force = false): Promise<void> {
     if (!this.agent) return;
     this.captureAuthLoading = true;
+    this.captureAuthConflicts = null;
     try {
+      const command = ['python3', '/home/scion/.scion/harness/capture_auth.py'];
+      if (force) command.push('--force');
+
       const response = await apiFetch(`/api/v1/agents/${this.agent.id}/exec`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          command: ['python3', '/home/scion/.scion/harness/capture_auth.py'],
-          timeout: 60,
-        }),
+        body: JSON.stringify({ command, timeout: 60 }),
       });
 
       if (!response.ok) {
@@ -807,7 +813,15 @@ export class ScionPageTerminal extends LitElement {
       } else if (result.exitCode === 2) {
         alert(`No credentials found yet.\n\nAuthenticate first (e.g., run 'agy' inside the container), then try again.\n\n${result.output}`);
       } else {
-        alert(`Capture failed (exit ${result.exitCode}).\n\n${result.output}`);
+        const conflicts: string[] = [];
+        for (const m of result.output.matchAll(ScionPageTerminal.SECRET_CONFLICT_RE)) {
+          conflicts.push(m[1]);
+        }
+        if (conflicts.length > 0) {
+          this.captureAuthConflicts = conflicts;
+        } else {
+          alert(`Capture failed (exit ${result.exitCode}).\n\n${result.output}`);
+        }
       }
     } catch (err) {
       console.error('Failed to capture auth:', err);
@@ -815,6 +829,37 @@ export class ScionPageTerminal extends LitElement {
     } finally {
       this.captureAuthLoading = false;
     }
+  }
+
+  private renderCaptureAuthConflictDialog() {
+    if (!this.captureAuthConflicts) return nothing;
+    const secrets = this.captureAuthConflicts;
+    const label = secrets.length === 1
+      ? `Secret "${secrets[0]}" already exists`
+      : `${secrets.length} secrets already exist`;
+    return html`
+      <sl-dialog
+        label=${label}
+        open
+        @sl-request-close=${() => { if (!this.captureAuthLoading) this.captureAuthConflicts = null; }}
+      >
+        <p>The following secret${secrets.length > 1 ? 's' : ''} already exist${secrets.length === 1 ? 's' : ''}:</p>
+        <ul>${secrets.map(s => html`<li><code>${s}</code></li>`)}</ul>
+        <p>Do you want to force-update ${secrets.length > 1 ? 'them' : 'it'}?</p>
+        <sl-button
+          slot="footer"
+          variant="default"
+          ?disabled=${this.captureAuthLoading}
+          @click=${() => { this.captureAuthConflicts = null; }}
+        >Cancel</sl-button>
+        <sl-button
+          slot="footer"
+          variant="warning"
+          ?loading=${this.captureAuthLoading}
+          @click=${() => void this.handleCaptureAuth(true)}
+        >Force Update</sl-button>
+      </sl-dialog>
+    `;
   }
 
   private async refreshAgentData(): Promise<void> {
@@ -954,6 +999,7 @@ export class ScionPageTerminal extends LitElement {
             </div>`
           : ''}
       </div>
+      ${this.renderCaptureAuthConflictDialog()}
     `;
   }
 }


### PR DESCRIPTION
## Summary

- Broker (runtimebroker/handlers.go): propagate actual exit codes from exec processes instead of hardcoding 0; fix a long-standing TODO
- All 7 capture_auth.py scripts: exit 3 with CONFLICT marker when secret already exists without --force
- UI: shows conflict dialog with Force Update / Cancel buttons when exit 3 + CONFLICT output detected
- Generic — works for any secret name, not just CODEX_AUTH
- --force path correctly overwrites existing secrets