### PR TITLE
fix: slim down Cloud Build source upload for harness builds

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,97 @@
+# Cloud Build source upload filter.
+#
+# All cloudbuild-*.yaml configs share this ignore file. The union of
+# files they need is:
+#   image-build/   — Dockerfiles, scripts
+#   harnesses/     — harness Dockerfiles and assets
+#   cmd/, pkg/     — Go source (compiled in scion-base)
+#   resources/     — embedded resources
+#   web/*.go       — Go embed stubs only
+#   go.mod, go.sum
+#
+# Everything else is excluded to keep the upload small and fast.
+
+#!include:.gitignore
+
+# ---------------------------------------------------------------------------
+# Directories not needed by any Cloud Build config
+# ---------------------------------------------------------------------------
+changelog/
+docs/
+docs-repo/
+docs-site/
+examples/
+extras/
+hack/
+internal/
+reviews/
+scratch/
+scripts/
+shared-dirs/
+skills/
+
+# ---------------------------------------------------------------------------
+# Web frontend — only web/embed.go and web/embed_stub.go are needed
+# (for the no_embed_web Go build tag). Exclude everything else.
+# ---------------------------------------------------------------------------
+web/dist/
+web/node_modules/
+web/public/
+web/scripts/
+web/src/
+web/test-scripts/
+web/*.md
+web/*.json
+web/*.ts
+web/*.html
+web/.env*
+web/.eslintrc*
+web/.prettierrc*
+web/.screenshots/
+web/coverage/
+
+# ---------------------------------------------------------------------------
+# Test files — Cloud Build compiles Go but never runs tests
+# ---------------------------------------------------------------------------
+*_test.go
+
+# ---------------------------------------------------------------------------
+# Build artifacts and tool state
+# ---------------------------------------------------------------------------
+.git/
+.claude/
+.design/
+.scratch/
+.tasks/
+.scion/
+build/
+.build/
+testdata/
+downloads/
+
+# ---------------------------------------------------------------------------
+# CI / IDE / config files not needed for image builds
+# ---------------------------------------------------------------------------
+.gemini/
+.geminiignore
+.github/
+.gitignore
+
+# ---------------------------------------------------------------------------
+# Root files not needed for image builds
+# ---------------------------------------------------------------------------
+claude.md
+gemini.md
+.claudeignore
+.dockerignore
+.coordinator-state.md
+.eng-manager-state.md
+agents.md
+CHANGELOG.md
+GLOSSARY.md
+LICENSE
+Makefile
+README.md
+Dockerfile
+Dockerfile.hub
+pr-*-review*.md

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -26,9 +26,9 @@ hack/
 internal/
 reviews/
 scratch/
-scripts/
+/scripts/
 shared-dirs/
-skills/
+/skills/
 
 # ---------------------------------------------------------------------------
 # Web frontend — only web/embed.go and web/embed_stub.go are needed


### PR DESCRIPTION
Add .gcloudignore to exclude unnecessary files from Cloud Build source archive. Reduces upload from 2344 files / 38.5MiB