### PR TITLE
harnesses/hermes: fix pip install for Python 3.11 PEP 668 compatibility

### DIFF
--- a/harnesses/hermes/Dockerfile
+++ b/harnesses/hermes/Dockerfile
@@ -33,9 +33,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3-pip \
 
 # Install Hermes Agent via pip
 RUN if [ -n "${HERMES_VERSION}" ]; then \
-      pip install --no-cache-dir "hermes-agent==${HERMES_VERSION}"; \
+      pip install --no-cache-dir --break-system-packages "hermes-agent==${HERMES_VERSION}"; \
     else \
-      pip install --no-cache-dir hermes-agent; \
+      pip install --no-cache-dir --break-system-packages hermes-agent; \
     fi
 
 RUN mkdir -p /home/scion/.hermes /home/scion/.hermes/skills \


### PR DESCRIPTION
## Summary

Fixes the Hermes harness container image build failure in Cloud Build.

Python 3.11 on Debian enforces PEP 668 (externally-managed-environment), which blocks system-wide `pip install` without explicit opt-in. The Hermes Dockerfile was failing with:

```
error: externally-managed-environment
```

Fix: add `--break-system-packages` to both `pip install` invocations in `harnesses/hermes/Dockerfile`. This is the standard pattern for Docker containers installing Python packages into a system Python without a virtualenv.

## Test plan

- [ ] Cloud Build `build-scion-hermes` step succeeds
- [ ] Hermes container image builds for both linux/amd64 and linux/arm64
