### PR TITLE
harness: no-auth auto-fallback and auto-run suggested command

### DIFF
--- a/harnesses/antigravity/config.yaml
+++ b/harnesses/antigravity/config.yaml
@@ -57,6 +57,7 @@ capabilities:
 
 no_auth:
   behavior: drop-to-shell
+  command: agy
   message: |
     This agent started without credentials.
     Run: agy

--- a/harnesses/claude/config.yaml
+++ b/harnesses/claude/config.yaml
@@ -70,6 +70,7 @@ capabilities:
   resume: { support: "yes" }
 no_auth:
   behavior: drop-to-shell
+  command: claude login
   message: |
     This agent started without credentials.
     Run: claude login

--- a/harnesses/codex/config.yaml
+++ b/harnesses/codex/config.yaml
@@ -72,6 +72,7 @@ capabilities:
     project_scope: { support: "no", reason: "Project-scoped MCP (.codex/mcp_servers.json) is not implemented yet; project entries are demoted to global" }
 no_auth:
   behavior: drop-to-shell
+  command: codex login --device-auth
   message: |
     This agent started without credentials.
     Run: codex login --device-auth

--- a/harnesses/copilot/config.yaml
+++ b/harnesses/copilot/config.yaml
@@ -83,6 +83,7 @@ capabilities:
 
 no_auth:
   behavior: drop-to-shell
+  command: copilot login
   message: |
     This agent started without credentials.
     Run: copilot login

--- a/harnesses/hermes/config.yaml
+++ b/harnesses/hermes/config.yaml
@@ -67,6 +67,7 @@ capabilities:
 
 no_auth:
   behavior: drop-to-shell
+  command: hermes setup
   message: |
     This agent started without credentials.
     Run: hermes setup

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -477,7 +477,7 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 			if canFallbackToNoAuth() {
 				util.Debugf("auth: resolution failed, falling back to no-auth mode: %v", err)
 				opts.NoAuth = true
-				warnings = append(warnings, fmt.Sprintf("Auth: no credentials found, starting in no-auth mode"))
+				warnings = append(warnings, "Auth: no credentials found, starting in no-auth mode")
 				goto authDone
 			}
 			return nil, fmt.Errorf("auth resolution failed: %w", err)
@@ -494,7 +494,7 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 			if canFallbackToNoAuth() {
 				util.Debugf("auth: validation failed, falling back to no-auth mode: %v", err)
 				opts.NoAuth = true
-				warnings = append(warnings, fmt.Sprintf("Auth: credential validation failed, starting in no-auth mode"))
+				warnings = append(warnings, "Auth: credential validation failed, starting in no-auth mode")
 				goto authDone
 			}
 			return nil, fmt.Errorf("auth validation failed: %w", err)

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -441,6 +441,10 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 	// later projected into the container environment).
 	authEnvOverlay := buildAuthEnvOverlay(opts.Env, opts.ResolvedSecrets)
 
+	canFallbackToNoAuth := func() bool {
+		return opts.HarnessAuth == "" && noAuthConfig != nil && noAuthConfig.Behavior == "drop-to-shell"
+	}
+
 	var auth api.AuthConfig
 	var resolvedAuth *api.ResolvedAuth
 	if !opts.NoAuth {
@@ -470,6 +474,12 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		util.Debugf("auth: after overlay — selectedType=%q", auth.SelectedType)
 		resolved, err := h.ResolveAuth(auth)
 		if err != nil {
+			if canFallbackToNoAuth() {
+				util.Debugf("auth: resolution failed, falling back to no-auth mode: %v", err)
+				opts.NoAuth = true
+				warnings = append(warnings, fmt.Sprintf("Auth: no credentials found, starting in no-auth mode"))
+				goto authDone
+			}
 			return nil, fmt.Errorf("auth resolution failed: %w", err)
 		}
 		// Keep a copy of the full resolved auth material for secret filtering.
@@ -481,6 +491,12 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		}
 		util.Debugf("auth: resolved — method=%q, envVars=%v, files=%d", resolved.Method, resolved.EnvVars, len(resolved.Files))
 		if err := harness.ValidateAuth(resolved); err != nil {
+			if canFallbackToNoAuth() {
+				util.Debugf("auth: validation failed, falling back to no-auth mode: %v", err)
+				opts.NoAuth = true
+				warnings = append(warnings, fmt.Sprintf("Auth: credential validation failed, starting in no-auth mode"))
+				goto authDone
+			}
 			return nil, fmt.Errorf("auth validation failed: %w", err)
 		}
 		// Allow harnesses to update their native settings files (e.g. Gemini settings.json)
@@ -528,6 +544,7 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		}
 		warnings = append(warnings, fmt.Sprintf("Auth: resolved as %s", authDetail))
 	}
+authDone:
 
 	// 4. Launch container
 	detached := true

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -932,6 +932,12 @@ authDone:
 			}
 			return ""
 		}(),
+		NoAuthCommand: func() string {
+			if opts.NoAuth && noAuthConfig != nil && noAuthConfig.Behavior == "drop-to-shell" {
+				return noAuthConfig.Command
+			}
+			return ""
+		}(),
 		Debug:                util.DebugEnabled(),
 		Resume:               opts.Resume,
 		MetadataInterception: hasMetadataInterception(agentEnv),

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -823,6 +823,7 @@ type HarnessAuthAutodetect struct {
 type HarnessNoAuthConfig struct {
 	Behavior string `json:"behavior,omitempty" yaml:"behavior,omitempty" koanf:"behavior"`
 	Message  string `json:"message,omitempty" yaml:"message,omitempty" koanf:"message"`
+	Command  string `json:"command,omitempty" yaml:"command,omitempty" koanf:"command"`
 }
 
 // HarnessMCPConfig is the declarative mapping that lets a harness's

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -430,7 +430,13 @@ func buildCommonRunArgs(config RunConfig) ([]string, error) {
 	// Get command from harness
 	var harnessArgs []string
 	if config.NoAuth {
-		if config.NoAuthMessage != "" {
+		if config.NoAuthCommand != "" {
+			msgPart := ""
+			if config.NoAuthMessage != "" {
+				msgPart = fmt.Sprintf("printf '%%s\\n' %s; ", shellQuote(config.NoAuthMessage))
+			}
+			harnessArgs = []string{"sh", "-c", fmt.Sprintf("%s%s; exec bash", msgPart, config.NoAuthCommand)}
+		} else if config.NoAuthMessage != "" {
 			harnessArgs = []string{"sh", "-c", fmt.Sprintf("printf '%%s\\n' %s; exec bash", shellQuote(config.NoAuthMessage))}
 		} else {
 			harnessArgs = []string{"bash"}

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -80,6 +80,20 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
+func buildNoAuthArgs(noAuthMsg, noAuthCmd string) []string {
+	if noAuthCmd != "" {
+		msgPart := ""
+		if noAuthMsg != "" {
+			msgPart = fmt.Sprintf("printf '%%s\\n' %s; ", shellQuote(noAuthMsg))
+		}
+		return []string{"sh", "-c", fmt.Sprintf("%s%s; exec bash", msgPart, noAuthCmd)}
+	}
+	if noAuthMsg != "" {
+		return []string{"sh", "-c", fmt.Sprintf("printf '%%s\\n' %s; exec bash", shellQuote(noAuthMsg))}
+	}
+	return []string{"bash"}
+}
+
 // buildCommonRunArgs constructs the common arguments for 'run' command across different runtimes.
 func buildCommonRunArgs(config RunConfig) ([]string, error) {
 	args := []string{"run", "-d", "-i"}
@@ -430,17 +444,7 @@ func buildCommonRunArgs(config RunConfig) ([]string, error) {
 	// Get command from harness
 	var harnessArgs []string
 	if config.NoAuth {
-		if config.NoAuthCommand != "" {
-			msgPart := ""
-			if config.NoAuthMessage != "" {
-				msgPart = fmt.Sprintf("printf '%%s\\n' %s; ", shellQuote(config.NoAuthMessage))
-			}
-			harnessArgs = []string{"sh", "-c", fmt.Sprintf("%s%s; exec bash", msgPart, config.NoAuthCommand)}
-		} else if config.NoAuthMessage != "" {
-			harnessArgs = []string{"sh", "-c", fmt.Sprintf("printf '%%s\\n' %s; exec bash", shellQuote(config.NoAuthMessage))}
-		} else {
-			harnessArgs = []string{"bash"}
-		}
+		harnessArgs = buildNoAuthArgs(config.NoAuthMessage, config.NoAuthCommand)
 	} else if config.Harness != nil {
 		harnessArgs = config.Harness.GetCommand(config.Task, config.Resume, config.CommandArgs)
 	} else {

--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -48,6 +48,7 @@ type RunConfig struct {
 	BrokerMode           bool
 	NoAuth               bool
 	NoAuthMessage        string
+	NoAuthCommand        string
 	Debug                bool
 	MetadataInterception bool     // Add NET_ADMIN cap for iptables-based metadata server interception
 	ExtraHosts           []string // Extra /etc/hosts entries (e.g. "host.docker.internal:host-gateway")

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -882,17 +882,7 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 	var cmd []string
 	var harnessArgs []string
 	if config.NoAuth {
-		if config.NoAuthCommand != "" {
-			msgPart := ""
-			if config.NoAuthMessage != "" {
-				msgPart = fmt.Sprintf("printf '%%s\\n' %s; ", shellQuote(config.NoAuthMessage))
-			}
-			harnessArgs = []string{"sh", "-c", fmt.Sprintf("%s%s; exec bash", msgPart, config.NoAuthCommand)}
-		} else if config.NoAuthMessage != "" {
-			harnessArgs = []string{"sh", "-c", fmt.Sprintf("printf '%%s\\n' %s; exec bash", shellQuote(config.NoAuthMessage))}
-		} else {
-			harnessArgs = []string{"bash"}
-		}
+		harnessArgs = buildNoAuthArgs(config.NoAuthMessage, config.NoAuthCommand)
 	} else if config.Harness != nil {
 		harnessArgs = config.Harness.GetCommand(config.Task, config.Resume, config.CommandArgs)
 	} else {

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -882,7 +882,13 @@ func (r *KubernetesRuntime) buildPod(namespace string, config RunConfig) (*corev
 	var cmd []string
 	var harnessArgs []string
 	if config.NoAuth {
-		if config.NoAuthMessage != "" {
+		if config.NoAuthCommand != "" {
+			msgPart := ""
+			if config.NoAuthMessage != "" {
+				msgPart = fmt.Sprintf("printf '%%s\\n' %s; ", shellQuote(config.NoAuthMessage))
+			}
+			harnessArgs = []string{"sh", "-c", fmt.Sprintf("%s%s; exec bash", msgPart, config.NoAuthCommand)}
+		} else if config.NoAuthMessage != "" {
 			harnessArgs = []string{"sh", "-c", fmt.Sprintf("printf '%%s\\n' %s; exec bash", shellQuote(config.NoAuthMessage))}
 		} else {
 			harnessArgs = []string{"bash"}


### PR DESCRIPTION
## Summary

Two improvements to the no-auth harness flow:

**1. Auto-fallback to no-auth when auto-auth finds no credentials**
In `pkg/agent/run.go`: when auth type is "auto" and no valid credentials are found, and the harness config has a `no_auth` section with `behavior: drop-to-shell`, the agent automatically falls back to no-auth mode instead of failing. Only applies when the user did not explicitly choose an auth type.

**2. Auto-run suggested command on agent shell open**
Added a `command` field to `HarnessNoAuthConfig` (e.g., `claude auth login`). When set, this command is automatically run in the agent shell when it opens in no-auth mode, before dropping to a bash prompt. Updated `pkg/runtime/common.go` (Docker) and `pkg/runtime/k8s_runtime.go` (K8s).

**Harness configs updated:** claude, codex, copilot, hermes, antigravity — each now has a `command` field in the `no_auth` block.

## Test plan

- [ ] Agent with auto auth and no credentials → falls back to no-auth (not an error)
- [ ] Agent opened in no-auth mode with command configured → command runs automatically on shell open
- [ ] Agent with explicit auth type set → no fallback behavior (existing behavior preserved)
- [ ] Harnesses without no_auth section → no change in behavior
