### PR TITLE
fix(message): close remaining silent-drop gaps for --plain/--notify/--channel flag combinations

### DIFF
--- a/cmd/message.go
+++ b/cmd/message.go
@@ -108,6 +108,14 @@ Examples:
 		if (msgIn != "" || msgAt != "") && (msgBroadcast || msgAll) {
 			return fmt.Errorf("--in/--at cannot be combined with --broadcast or --all")
 		}
+		// Scheduled events only carry interrupt/plain; reject flags that
+		// would otherwise be silently dropped when the event fires.
+		if msgNotify && (msgIn != "" || msgAt != "") {
+			return fmt.Errorf("--notify cannot be combined with --in or --at")
+		}
+		if msgChannel != "" && (msgIn != "" || msgAt != "") {
+			return fmt.Errorf("--channel cannot be combined with --in or --at")
+		}
 
 		// Validate --thread-id requires --channel
 		if msgThreadID != "" && msgChannel == "" {
@@ -187,6 +195,11 @@ Examples:
 		if len(msgAttach) > 0 && (msgIn != "" || msgAt != "") {
 			return fmt.Errorf("--attach cannot be combined with --in or --at")
 		}
+		// Plain delivery strips the structured envelope that carries
+		// attachment references, so the combination would silently drop them.
+		if len(msgAttach) > 0 && msgPlain {
+			return fmt.Errorf("--attach cannot be combined with --plain (attachments are delivered in the structured message envelope)")
+		}
 
 		// Check if Hub should be used
 		var hubCtx *HubContext
@@ -258,6 +271,12 @@ Examples:
 		// and cannot transfer files.
 		if len(msgAttach) > 0 {
 			return fmt.Errorf("--attach requires Hub mode (use 'scion hub enable' first); in local mode, include the file contents in the message text")
+		}
+
+		// --channel/--thread-id require Hub mode: channel routing is resolved
+		// by the Hub's channel registry and never reaches local delivery.
+		if msgChannel != "" {
+			return fmt.Errorf("--channel requires Hub mode (use 'scion hub enable' first)")
 		}
 
 		// Local mode — structured messages are only available in Hub mode,

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -929,6 +929,58 @@ func TestAttachFlagValidation(t *testing.T) {
 	}
 }
 
+func TestHubOnlyFlagLocalModeValidation(t *testing.T) {
+	// noHub forces EnsureHubReady to return a nil Hub context, so the
+	// local-mode guards are exercised regardless of the environment's
+	// hub configuration.
+	origNoHub := noHub
+	noHub = true
+	defer func() { noHub = origNoHub }()
+
+	tests := []struct {
+		name     string
+		setup    func()
+		teardown func()
+		errMsg   string
+	}{
+		{
+			name:     "channel requires hub mode",
+			setup:    func() { msgChannel = "telegram" },
+			teardown: func() { msgChannel = "" },
+			errMsg:   "--channel requires Hub mode",
+		},
+		{
+			name:     "attach requires hub mode",
+			setup:    func() { msgAttach = []string{"notes.md"} },
+			teardown: func() { msgAttach = nil },
+			errMsg:   "--attach requires Hub mode",
+		},
+		{
+			name:     "wake requires hub mode",
+			setup:    func() { msgWake = true },
+			teardown: func() { msgWake = false },
+			errMsg:   "--wake requires Hub mode",
+		},
+		{
+			name:     "notify requires hub mode",
+			setup:    func() { msgNotify = true },
+			teardown: func() { msgNotify = false },
+			errMsg:   "--notify requires Hub mode",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+			defer tc.teardown()
+
+			err := messageCmd.RunE(messageCmd, []string{"agent1", "hello"})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errMsg)
+		})
+	}
+}
+
 func TestSendGroupMessageViaHub(t *testing.T) {
 	orig := saveMessageTestState()
 	defer orig.restore()

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -356,6 +356,8 @@ func TestScheduleMessageFlagValidation(t *testing.T) {
 		at        string
 		broadcast bool
 		all       bool
+		notify    bool
+		channel   string
 		wantErr   string
 	}{
 		{
@@ -376,6 +378,30 @@ func TestScheduleMessageFlagValidation(t *testing.T) {
 			all:     true,
 			wantErr: "--in/--at cannot be combined with --broadcast or --all",
 		},
+		{
+			name:    "notify with in not allowed",
+			in:      "30m",
+			notify:  true,
+			wantErr: "--notify cannot be combined with --in or --at",
+		},
+		{
+			name:    "notify with at not allowed",
+			at:      "2030-01-01T00:00:00Z",
+			notify:  true,
+			wantErr: "--notify cannot be combined with --in or --at",
+		},
+		{
+			name:    "channel with in not allowed",
+			in:      "30m",
+			channel: "telegram",
+			wantErr: "--channel cannot be combined with --in or --at",
+		},
+		{
+			name:    "channel with at not allowed",
+			at:      "2030-01-01T00:00:00Z",
+			channel: "telegram",
+			wantErr: "--channel cannot be combined with --in or --at",
+		},
 	}
 
 	for _, tc := range tests {
@@ -383,15 +409,19 @@ func TestScheduleMessageFlagValidation(t *testing.T) {
 			// Save and restore global state
 			origIn, origAt := msgIn, msgAt
 			origBroadcast, origAll := msgBroadcast, msgAll
+			origNotify, origChannel := msgNotify, msgChannel
 			defer func() {
 				msgIn, msgAt = origIn, origAt
 				msgBroadcast, msgAll = origBroadcast, origAll
+				msgNotify, msgChannel = origNotify, origChannel
 			}()
 
 			msgIn = tc.in
 			msgAt = tc.at
 			msgBroadcast = tc.broadcast
 			msgAll = tc.all
+			msgNotify = tc.notify
+			msgChannel = tc.channel
 
 			// Build args appropriate for the flag combination
 			var args []string
@@ -878,6 +908,12 @@ func TestAttachFlagValidation(t *testing.T) {
 			setup:    func() { msgAttach = []string{"notes.md"}; msgAt = "2026-01-01T00:00:00Z" },
 			teardown: func() { msgAttach = nil; msgAt = "" },
 			errMsg:   "--attach cannot be combined with --in or --at",
+		},
+		{
+			name:     "attach with plain",
+			setup:    func() { msgAttach = []string{"notes.md"}; msgPlain = true },
+			teardown: func() { msgAttach = nil; msgPlain = false },
+			errMsg:   "--attach cannot be combined with --plain",
 		},
 	}
 


### PR DESCRIPTION
## Problem

Follow-up to #568. Auditing the remaining `scion message` flag routes turned up four more combinations that are accepted, reported as delivered/scheduled, and silently dropped:

- **`--attach` + `--plain` (Hub mode):** plain delivery returns the bare message text (`pkg/messages/format.go` `FormatForDelivery`), stripping the structured envelope that carries the attachment references — the agent never sees them.
- **`--notify` + `--in`/`--at`:** `scheduleMessageViaHub` only forwards interrupt/plain; the notify subscription is never created when the event fires (`MessageEventPayload` has no notify field).
- **`--channel`/`--thread-id` + `--in`/`--at`:** same scheduled path — the event payload carries no channel/thread routing, so the metadata is gone at fire time.
- **`--channel`/`--thread-id` in local (no-Hub) mode:** channel routing is resolved by the Hub's channel registry; local delivery sends plain text and never references the flags.

## Change

Reject each combination up front, matching the existing guard style:

- `--attach cannot be combined with --plain (attachments are delivered in the structured message envelope)`
- `--notify cannot be combined with --in or --at`
- `--channel cannot be combined with --in or --at`
- `--channel requires Hub mode (use 'scion hub enable' first)` (covers `--thread-id` transitively via the existing `--thread-id requires --channel` check)

If scheduled messages should eventually carry notify/channel/attachments, these guards make that visible as explicit follow-up work instead of silent loss.

## Testing

- Extended `TestScheduleMessageFlagValidation` (notify/channel × in/at) and `TestAttachFlagValidation` (attach+plain).
- Full `go test ./cmd/` passes; `go vet` clean. Rebased on current main.
- Verified manually with an isolated `$HOME`: all four combinations now error; a plain single-agent local message is unchanged.