### PR TITLE
harness: image status post-merge fixes and improvements

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1628,6 +1628,7 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 			} else {
 				hubSrv.SetEmbeddedBrokerID(brokerID)
 			}
+			hubSrv.SetLocalImageChecker(rt)
 		}
 
 		// Generate or retrieve credentials for co-located mode (idempotent).

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -363,6 +363,12 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// 13b. Re-check image status for all active harness configs now that
+	// the local image checker has been registered by startRuntimeBroker.
+	if enableHub && hubSrv != nil {
+		go hubSrv.RecheckAllImageStatuses(ctx)
+	}
+
 	// 14. Set up dispatcher, message broker, and notification dispatcher.
 	// This must happen after the ChannelEventPublisher is set (step 11/12)
 	// so that StartMessageBroker and StartNotificationDispatcher can
@@ -1344,9 +1350,6 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 			log.Printf("Warning: harness config bootstrap failed: %v", err)
 		}
 	}
-
-	// Re-check image status for all active harness configs after bootstrap
-	go hubSrv.RecheckAllImageStatuses(ctx)
 
 	log.Printf("Database: %s (%s)", cfg.Database.Driver, cfg.Database.URL)
 

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -48,7 +48,7 @@ type mockStorage struct {
 	// race-clean under `go test -race`).
 	mu      sync.Mutex
 	objects map[string]*storage.Object // objectPath -> Object
-	content map[string][]byte         // objectPath -> file data
+	content map[string][]byte          // objectPath -> file data
 }
 
 func newMockStorage(bucket string) *mockStorage {

--- a/pkg/hub/bootstrap_test.go
+++ b/pkg/hub/bootstrap_test.go
@@ -42,12 +42,13 @@ const testBootstrapDevToken = "scion_dev_bootstrap_test_token_1234567890"
 // mockStorage implements storage.Storage for testing.
 type mockStorage struct {
 	bucket string
-	// mu guards objects: the Phase-4 import path uploads files and resources
-	// concurrently, so real backends (GCS / local FS) are exercised concurrently
-	// and the mock must be safe for concurrent access too (and race-clean under
-	// `go test -race`).
+	// mu guards objects and content: the Phase-4 import path uploads files and
+	// resources concurrently, so real backends (GCS / local FS) are exercised
+	// concurrently and the mock must be safe for concurrent access too (and
+	// race-clean under `go test -race`).
 	mu      sync.Mutex
 	objects map[string]*storage.Object // objectPath -> Object
+	content map[string][]byte         // objectPath -> file data
 }
 
 func newMockStorage(bucket string) *mockStorage {
@@ -74,7 +75,7 @@ func (m *mockStorage) GetObject(_ context.Context, objectPath string) (*storage.
 	defer m.mu.Unlock()
 	obj, ok := m.objects[objectPath]
 	if !ok {
-		return nil, fmt.Errorf("object not found: %s", objectPath)
+		return nil, storage.ErrNotFound
 	}
 	return obj, nil
 }
@@ -86,19 +87,41 @@ func (m *mockStorage) Exists(_ context.Context, objectPath string) (bool, error)
 	return ok, nil
 }
 
-func (m *mockStorage) Upload(_ context.Context, objectPath string, _ io.Reader, opts storage.UploadOptions) (*storage.Object, error) {
+func (m *mockStorage) Upload(_ context.Context, objectPath string, r io.Reader, opts storage.UploadOptions) (*storage.Object, error) {
+	var data []byte
+	if r != nil {
+		var err error
+		data, err = io.ReadAll(r)
+		if err != nil {
+			return nil, err
+		}
+	}
 	obj := &storage.Object{
 		Name:     objectPath,
+		Size:     int64(len(data)),
 		Metadata: opts.Metadata,
 	}
 	m.mu.Lock()
 	m.objects[objectPath] = obj
+	if data != nil {
+		if m.content == nil {
+			m.content = make(map[string][]byte)
+		}
+		m.content[objectPath] = data
+	}
 	m.mu.Unlock()
 	return obj, nil
 }
 
-func (m *mockStorage) Download(_ context.Context, _ string) (io.ReadCloser, *storage.Object, error) {
-	return nil, nil, fmt.Errorf("not implemented")
+func (m *mockStorage) Download(_ context.Context, objectPath string) (io.ReadCloser, *storage.Object, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	obj, ok := m.objects[objectPath]
+	if !ok {
+		return nil, nil, storage.ErrNotFound
+	}
+	data := m.content[objectPath]
+	return io.NopCloser(bytes.NewReader(data)), obj, nil
 }
 
 func (m *mockStorage) Delete(_ context.Context, objectPath string) error {

--- a/pkg/hub/harness_config_bootstrap_test.go
+++ b/pkg/hub/harness_config_bootstrap_test.go
@@ -91,6 +91,47 @@ func TestBootstrapHarnessConfigsFromDir_ImportsConfigs(t *testing.T) {
 	}
 }
 
+func TestBootstrapHarnessConfigsFromDir_PersistsConfigImage(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	dir := makeHarnessConfigDir(t, "claude", map[string]string{
+		"config.yaml": "harness: claude\nimage: scion-claude:latest\nuser: scion\n",
+	})
+
+	if err := srv.BootstrapHarnessConfigsFromDir(ctx, dir); err != nil {
+		t.Fatalf("bootstrap failed: %v", err)
+	}
+
+	hc, err := s.GetHarnessConfigBySlug(ctx, "claude", store.HarnessConfigScopeGlobal, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hc.Config == nil {
+		t.Fatal("expected Config to be populated after bootstrap, got nil")
+	}
+	if hc.Config.Image != "scion-claude:latest" {
+		t.Errorf("expected Config.Image = %q, got %q", "scion-claude:latest", hc.Config.Image)
+	}
+
+	// Re-bootstrap with a different image and verify it updates.
+	if err := os.WriteFile(filepath.Join(dir, "claude", "config.yaml"),
+		[]byte("harness: claude\nimage: scion-claude:v2\nuser: scion\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.BootstrapHarnessConfigsFromDir(ctx, dir); err != nil {
+		t.Fatalf("second bootstrap failed: %v", err)
+	}
+
+	hc, err = s.GetHarnessConfigBySlug(ctx, "claude", store.HarnessConfigScopeGlobal, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hc.Config == nil || hc.Config.Image != "scion-claude:v2" {
+		t.Errorf("expected Config.Image = %q after re-sync, got %+v", "scion-claude:v2", hc.Config)
+	}
+}
+
 func TestBootstrapHarnessConfigsFromDir_MultipleConfigs(t *testing.T) {
 	srv, s, _ := testTemplateBootstrapServer(t)
 	ctx := context.Background()

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -606,17 +606,23 @@ func (s *Server) handleHarnessConfigCheckImage(w http.ResponseWriter, r *http.Re
 
 	registry := s.resolveImageRegistry()
 	resolvedImage := config.RewriteImageRegistry(image, registry)
+	slog.Info("checking image status", "id", hc.ID, "image", image, "resolved", resolvedImage, "registry", registry)
 	result := s.imageChecker.Check(ctx, resolvedImage)
+	slog.Info("image check result", "id", hc.ID, "status", result.Status, "source", result.Source, "error", result.Error)
 
 	if err := s.store.UpdateHarnessConfigImageStatus(ctx, hc.ID, result.Status, result.CheckedAt); err != nil {
 		slog.Warn("failed to persist image status", "id", hc.ID, "error", err)
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{
+	resp := map[string]any{
 		"image_status":            result.Status,
 		"image_status_checked_at": result.CheckedAt,
 		"source":                  result.Source,
-	})
+	}
+	if result.Error != "" {
+		resp["error"] = result.Error
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // handleHarnessConfigDownload returns signed URLs for downloading harness config files.

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -288,7 +288,10 @@ func (s *Server) getHarnessConfig(w http.ResponseWriter, r *http.Request, id str
 
 	if s.imageStatusStale(hc) {
 		if image := s.harnessConfigImage(hc); image != "" {
-			go s.checkAndUpdateImageStatus(context.Background(), hc.ID, image)
+			go s.imageStatusFlight.Do(hc.ID, func() (any, error) {
+				s.checkAndUpdateImageStatus(context.Background(), hc.ID, image)
+				return nil, nil
+			})
 		}
 	}
 

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -324,7 +324,7 @@ func (s *Server) harnessConfigImage(hc *store.HarnessConfig) string {
 func extractImageFromStorage(ctx context.Context, stor storage.Storage, storagePath string) string {
 	objectPath := storagePath + "/config.yaml"
 	reader, _, err := stor.Download(ctx, objectPath)
-	if err != nil {
+	if err != nil || reader == nil {
 		return ""
 	}
 	defer func() { _ = reader.Close() }()

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -288,10 +288,14 @@ func (s *Server) getHarnessConfig(w http.ResponseWriter, r *http.Request, id str
 
 	if s.imageStatusStale(hc) {
 		if image := s.harnessConfigImage(hc); image != "" {
-			go s.imageStatusFlight.Do(hc.ID, func() (any, error) {
-				s.checkAndUpdateImageStatus(context.Background(), hc.ID, image)
-				return nil, nil
-			})
+			go func() {
+				if _, err, _ := s.imageStatusFlight.Do(hc.ID, func() (any, error) {
+					s.checkAndUpdateImageStatus(context.Background(), hc.ID, image)
+					return nil, nil
+				}); err != nil {
+					slog.Error("image status check failed", "harness_config_id", hc.ID, "error", err)
+				}
+			}()
 		}
 	}
 

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -288,14 +288,7 @@ func (s *Server) getHarnessConfig(w http.ResponseWriter, r *http.Request, id str
 
 	if s.imageStatusStale(hc) {
 		if image := s.harnessConfigImage(hc); image != "" {
-			go func() {
-				if _, err, _ := s.imageStatusFlight.Do(hc.ID, func() (any, error) {
-					s.checkAndUpdateImageStatus(context.Background(), hc.ID, image)
-					return nil, nil
-				}); err != nil {
-					slog.Error("image status check failed", "harness_config_id", hc.ID, "error", err)
-				}
-			}()
+			go s.checkAndUpdateImageStatus(context.Background(), hc.ID, image)
 		}
 	}
 

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -327,7 +327,7 @@ func extractImageFromStorage(ctx context.Context, stor storage.Storage, storageP
 	if err != nil {
 		return ""
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	data, err := io.ReadAll(reader)
 	if err != nil {
 		return ""

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -644,6 +644,7 @@ func (s *Server) handleHarnessConfigCheckImage(w http.ResponseWriter, r *http.Re
 		"image_status":            result.Status,
 		"image_status_checked_at": result.CheckedAt,
 		"source":                  result.Source,
+		"resolved_image":          resolvedImage,
 	}
 	if result.Error != "" {
 		resp["error"] = result.Error

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -17,6 +17,7 @@ package hub
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -320,6 +321,24 @@ func (s *Server) harnessConfigImage(hc *store.HarnessConfig) string {
 	return ""
 }
 
+func extractImageFromStorage(ctx context.Context, stor storage.Storage, storagePath string) string {
+	objectPath := storagePath + "/config.yaml"
+	reader, _, err := stor.Download(ctx, objectPath)
+	if err != nil {
+		return ""
+	}
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return ""
+	}
+	entry, err := config.ParseHarnessConfigYAML(data)
+	if err != nil {
+		return ""
+	}
+	return entry.Image
+}
+
 func (s *Server) updateHarnessConfig(w http.ResponseWriter, r *http.Request, id string) {
 	ctx := r.Context()
 
@@ -574,6 +593,13 @@ func (s *Server) handleHarnessConfigFinalize(w http.ResponseWriter, r *http.Requ
 	hc.Files = req.Manifest.Files
 	hc.ContentHash = contentHash
 	hc.Status = store.HarnessConfigStatusActive
+
+	if image := extractImageFromStorage(ctx, stor, hc.StoragePath); image != "" {
+		if hc.Config == nil {
+			hc.Config = &store.HarnessConfigData{}
+		}
+		hc.Config.Image = image
+	}
 
 	if err := s.store.UpdateHarnessConfig(ctx, hc); err != nil {
 		writeErrorFromErr(w, err, "")

--- a/pkg/hub/imagecheck/checker.go
+++ b/pkg/hub/imagecheck/checker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -55,6 +56,16 @@ func (c *Checker) Check(ctx context.Context, image string) CheckResult {
 		}
 	}
 
+	// Bare image names (no registry prefix) are local-only by convention.
+	// Without a local checker we cannot determine availability, so return
+	// "unknown" rather than probing a remote registry that will 401.
+	if isBareImageName(image) {
+		return CheckResult{
+			Status:    "unknown",
+			CheckedAt: now,
+		}
+	}
+
 	ref, err := parseImageRef(image)
 	if err != nil {
 		slog.Warn("image check: invalid image reference", "image", image, "error", err)
@@ -70,4 +81,21 @@ func (c *Checker) Check(ctx context.Context, image string) CheckResult {
 		slog.Warn("image check: remote check failed", "image", image, "registry", ref.Registry, "repo", ref.Repository, "tag", ref.Tag, "status", result.Status, "error", result.Error)
 	}
 	return result
+}
+
+// isBareImageName returns true when the image reference has no explicit
+// registry prefix (no '.' or ':' in the first path component before any '/').
+func isBareImageName(image string) bool {
+	ref := image
+	if i := strings.LastIndex(ref, ":"); i > 0 {
+		possibleTag := ref[i+1:]
+		if !strings.Contains(possibleTag, "/") {
+			ref = ref[:i]
+		}
+	}
+	parts := strings.SplitN(ref, "/", 2)
+	if len(parts) < 2 {
+		return true
+	}
+	return !strings.Contains(parts[0], ".") && !strings.Contains(parts[0], ":")
 }

--- a/pkg/hub/imagecheck/checker.go
+++ b/pkg/hub/imagecheck/checker.go
@@ -2,6 +2,7 @@ package imagecheck
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"time"
 )
@@ -56,11 +57,17 @@ func (c *Checker) Check(ctx context.Context, image string) CheckResult {
 
 	ref, err := parseImageRef(image)
 	if err != nil {
+		slog.Warn("image check: invalid image reference", "image", image, "error", err)
 		return CheckResult{
 			Status:    "invalid",
+			Error:     err.Error(),
 			CheckedAt: now,
 		}
 	}
 
-	return checkRemoteImage(ctx, c.client, ref, now)
+	result := checkRemoteImage(ctx, c.client, ref, now)
+	if result.Error != "" {
+		slog.Warn("image check: remote check failed", "image", image, "registry", ref.Registry, "repo", ref.Repository, "tag", ref.Tag, "status", result.Status, "error", result.Error)
+	}
+	return result
 }

--- a/pkg/hub/imagecheck/checker_test.go
+++ b/pkg/hub/imagecheck/checker_test.go
@@ -102,8 +102,8 @@ func TestChecker_ErrorUnauthorized(t *testing.T) {
 	if result.Status != "error" {
 		t.Errorf("expected status error, got %s", result.Status)
 	}
-	if result.Error != "registry requires authentication" {
-		t.Errorf("expected auth error message, got %s", result.Error)
+	if !strings.Contains(result.Error, "auth") {
+		t.Errorf("expected auth-related error message, got %s", result.Error)
 	}
 }
 

--- a/pkg/hub/imagecheck/checker_test.go
+++ b/pkg/hub/imagecheck/checker_test.go
@@ -144,6 +144,79 @@ func TestChecker_NoLocalFallsToRemote(t *testing.T) {
 	}
 }
 
+func TestChecker_BareImageNoLocal(t *testing.T) {
+	remoteChecked := false
+	client := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			remoteChecked = true
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+		}),
+	}
+	c := NewChecker(WithHTTPClient(client))
+	result := c.Check(context.Background(), "cogo:latest")
+	if result.Status != "unknown" {
+		t.Errorf("expected status unknown for bare image without local checker, got %s", result.Status)
+	}
+	if remoteChecked {
+		t.Error("remote check should not be called for bare image names")
+	}
+}
+
+func TestChecker_BareImageLocalNotFound(t *testing.T) {
+	remoteChecked := false
+	client := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			remoteChecked = true
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+		}),
+	}
+	c := NewChecker(
+		WithLocalChecker(&mockLocalChecker{exists: false}),
+		WithHTTPClient(client),
+	)
+	result := c.Check(context.Background(), "cogo:latest")
+	if result.Status != "unknown" {
+		t.Errorf("expected status unknown for bare image not found locally, got %s", result.Status)
+	}
+	if remoteChecked {
+		t.Error("remote check should not be called for bare image names")
+	}
+}
+
+func TestChecker_BareImageLocalFound(t *testing.T) {
+	c := NewChecker(
+		WithLocalChecker(&mockLocalChecker{exists: true}),
+	)
+	result := c.Check(context.Background(), "cogo:latest")
+	if result.Status != "valid" {
+		t.Errorf("expected status valid, got %s", result.Status)
+	}
+	if result.Source != "local" {
+		t.Errorf("expected source local, got %s", result.Source)
+	}
+}
+
+func TestIsBareImageName(t *testing.T) {
+	tests := []struct {
+		image string
+		bare  bool
+	}{
+		{"cogo:latest", true},
+		{"cogo", true},
+		{"myorg/myimage:v2", true},
+		{"ghcr.io/myorg/scion-claude:latest", false},
+		{"us-docker.pkg.dev/proj/repo/img:v1", false},
+		{"localhost:5000/myimage:latest", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.image, func(t *testing.T) {
+			if got := isBareImageName(tt.image); got != tt.bare {
+				t.Errorf("isBareImageName(%q) = %v, want %v", tt.image, got, tt.bare)
+			}
+		})
+	}
+}
+
 func TestParseImageRef(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/pkg/hub/imagecheck/local.go
+++ b/pkg/hub/imagecheck/local.go
@@ -2,6 +2,7 @@ package imagecheck
 
 import (
 	"context"
+	"log/slog"
 	"time"
 )
 
@@ -19,12 +20,17 @@ func WithLocalChecker(l LocalImageExister) Option {
 
 func checkLocalImage(ctx context.Context, local LocalImageExister, image string, now time.Time) (CheckResult, bool) {
 	found, err := local.ImageExists(ctx, image)
-	if err == nil && found {
+	if err != nil {
+		slog.Warn("local image check failed", "image", image, "error", err)
+		return CheckResult{}, false
+	}
+	if found {
 		return CheckResult{
 			Status:    "valid",
 			Source:    "local",
 			CheckedAt: now,
 		}, true
 	}
+	slog.Debug("local image not found", "image", image)
 	return CheckResult{}, false
 }

--- a/pkg/hub/imagecheck/remote.go
+++ b/pkg/hub/imagecheck/remote.go
@@ -158,7 +158,7 @@ func fetchAnonymousToken(ctx context.Context, client HTTPClient, wwwAuth string)
 	tokenURL := realm
 	sep := "?"
 	for k, v := range params {
-		tokenURL += sep + url.QueryEscape(k) + "=" + url.QueryEscape(v)
+		tokenURL += sep + k + "=" + v
 		sep = "&"
 	}
 

--- a/pkg/hub/imagecheck/remote.go
+++ b/pkg/hub/imagecheck/remote.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -65,9 +66,11 @@ func registryHost(registry string) string {
 
 func checkRemoteImage(ctx context.Context, client HTTPClient, ref imageRef, now time.Time) CheckResult {
 	host := registryHost(ref.Registry)
-	url := fmt.Sprintf("https://%s/v2/%s/manifests/%s", host, ref.Repository, ref.Tag)
+	manifestURL := fmt.Sprintf("https://%s/v2/%s/manifests/%s", host, ref.Repository, ref.Tag)
 
-	result := doRegistryHead(ctx, client, url, "", now)
+	slog.Debug("image check: probing remote registry", "url", manifestURL, "registry", ref.Registry, "repo", ref.Repository, "tag", ref.Tag)
+
+	result := doRegistryHead(ctx, client, manifestURL, "", now)
 	if result.Status != "" {
 		return result
 	}
@@ -121,17 +124,19 @@ func doRegistryHead(ctx context.Context, client HTTPClient, url, token string, n
 		}
 	case http.StatusUnauthorized:
 		if token != "" {
+			slog.Warn("image check: registry auth failed after token exchange", "url", url)
 			return CheckResult{
 				Status:    "error",
-				Error:     "registry requires authentication",
+				Error:     "registry requires authentication (token rejected)",
 				CheckedAt: now,
 			}
 		}
 		anonToken, err := fetchAnonymousToken(ctx, client, resp.Header.Get("Www-Authenticate"))
 		if err != nil {
+			slog.Warn("image check: anonymous token fetch failed", "url", url, "error", err)
 			return CheckResult{
 				Status:    "error",
-				Error:     "registry requires authentication",
+				Error:     fmt.Sprintf("registry auth: %v", err),
 				CheckedAt: now,
 			}
 		}

--- a/pkg/hub/imagecheck/remote.go
+++ b/pkg/hub/imagecheck/remote.go
@@ -92,6 +92,7 @@ func doRegistryHead(ctx context.Context, client HTTPClient, url, token string, n
 		}
 	}
 	req.Header.Set("Accept", strings.Join([]string{
+		"application/vnd.oci.image.index.v1+json",
 		"application/vnd.oci.image.manifest.v1+json",
 		"application/vnd.docker.distribution.manifest.v2+json",
 		"application/vnd.docker.distribution.manifest.list.v2+json",

--- a/pkg/hub/imagecheck/remote.go
+++ b/pkg/hub/imagecheck/remote.go
@@ -158,7 +158,7 @@ func fetchAnonymousToken(ctx context.Context, client HTTPClient, wwwAuth string)
 	tokenURL := realm
 	sep := "?"
 	for k, v := range params {
-		tokenURL += sep + k + "=" + v
+		tokenURL += sep + url.QueryEscape(k) + "=" + url.QueryEscape(v)
 		sep = "&"
 	}
 

--- a/pkg/hub/resource_bootstrap.go
+++ b/pkg/hub/resource_bootstrap.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"os"
 	"path/filepath"
 
 	"golang.org/x/sync/errgroup"
@@ -132,18 +133,19 @@ func (s *Server) checkAndUpdateImageStatus(ctx context.Context, hcID, image stri
 	}
 }
 
-// resolveImageRegistry returns the configured image registry, falling back
-// to an empty string (no rewrite) if unavailable.
+// resolveImageRegistry returns the configured image registry from the
+// server's in-memory config, which includes environment variable overrides
+// applied at startup. Falls back to SCION_IMAGE_REGISTRY env var if the
+// maintenance config value is empty.
+//
+// TODO: use an internal settings API that returns fully-resolved settings
+// (env var overrides + DB values) once available — needed for HA mode where
+// settings will live in the database.
 func (s *Server) resolveImageRegistry() string {
-	globalDir, err := config.GetGlobalDir()
-	if err != nil {
-		return ""
+	if r := s.config.MaintenanceConfig.ImageRegistry; r != "" {
+		return r
 	}
-	vs, err := config.LoadSingleFileVersioned(globalDir)
-	if err != nil || vs == nil {
-		return ""
-	}
-	return vs.ResolveImageRegistry("")
+	return os.Getenv("SCION_IMAGE_REGISTRY")
 }
 
 // RecheckAllImageStatuses re-checks image availability for all active

--- a/pkg/hub/resource_bootstrap.go
+++ b/pkg/hub/resource_bootstrap.go
@@ -123,6 +123,9 @@ func (s *Server) checkAndUpdateImageStatus(ctx context.Context, hcID, image stri
 	resolvedImage := config.RewriteImageRegistry(image, registry)
 
 	result := s.imageChecker.Check(ctx, resolvedImage)
+	if result.Error != "" {
+		slog.Warn("image status check returned error", "id", hcID, "image", image, "resolved", resolvedImage, "status", result.Status, "error", result.Error)
+	}
 
 	if err := s.store.UpdateHarnessConfigImageStatus(ctx, hcID, result.Status, result.CheckedAt); err != nil {
 		slog.Error("failed to update image status", "id", hcID, "error", err)

--- a/pkg/hub/resource_import.go
+++ b/pkg/hub/resource_import.go
@@ -346,7 +346,11 @@ func discoverResourceDirs(root, sourceURL string, kind resourceImportKind) ([]re
 					childName = hcDir.Config.Name
 				}
 			}
-			dirs = append(dirs, resourceDir{childName, dir, sourceURL})
+			childSourceURL := sourceURL
+			if sourceURL != "" {
+				childSourceURL = strings.TrimRight(sourceURL, "/") + "/" + entry.Name()
+			}
+			dirs = append(dirs, resourceDir{childName, dir, childSourceURL})
 		} else {
 			skipped = append(skipped, skippedDir{entry.Name(), "no " + kind.marker})
 		}

--- a/pkg/hub/resource_source.go
+++ b/pkg/hub/resource_source.go
@@ -133,6 +133,7 @@ func (s *FSResourceSource) Files(ctx context.Context) ([]transfer.FileInfo, erro
 		if readErr != nil {
 			return readErr
 		}
+		data = transfer.NormalizeFileContent(data)
 
 		hash := sha256.Sum256(data)
 		files = append(files, transfer.FileInfo{
@@ -264,6 +265,11 @@ func (rs *ResourceStore) BootstrapSource(ctx context.Context, src ResourceSource
 		return result, fmt.Errorf("%s: stage source: %w", p.Label(), err)
 	}
 	defer cleanup()
+
+	if err := transfer.NormalizeDir(dir); err != nil {
+		result.Failed++
+		return result, fmt.Errorf("%s: normalize staged dir: %w", p.Label(), err)
+	}
 
 	files, err := transfer.CollectFiles(dir, nil)
 	if err != nil {

--- a/pkg/hub/resource_store.go
+++ b/pkg/hub/resource_store.go
@@ -17,6 +17,7 @@ package hub
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -407,23 +408,33 @@ func (p *harnessConfigPersistence) PostFinalize(ctx context.Context, rec *Resour
 	if image == "" {
 		return
 	}
+
+	if p.model != nil && (p.model.Config == nil || p.model.Config.Image != image) {
+		if p.model.Config == nil {
+			p.model.Config = &store.HarnessConfigData{}
+		}
+		p.model.Config.Image = image
+		if err := p.s.store.UpdateHarnessConfig(ctx, p.model); err != nil {
+			slog.Error("failed to persist image in harness config", "id", rec.ID, "error", err)
+		}
+	}
+
 	go p.s.checkAndUpdateImageStatus(context.WithoutCancel(ctx), rec.ID, image)
 }
 
 func (p *harnessConfigPersistence) extractImage(dir string) string {
-	if p.model != nil && p.model.Config != nil && p.model.Config.Image != "" {
-		return p.model.Config.Image
-	}
 	configPath := filepath.Join(dir, "config.yaml")
 	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return ""
+	if err == nil {
+		entry, err := config.ParseHarnessConfigYAML(data)
+		if err == nil && entry.Image != "" {
+			return entry.Image
+		}
 	}
-	entry, err := config.ParseHarnessConfigYAML(data)
-	if err != nil {
-		return ""
+	if p.model != nil && p.model.Config != nil {
+		return p.model.Config.Image
 	}
-	return entry.Image
+	return ""
 }
 
 func harnessConfigToRecord(hc *store.HarnessConfig) *ResourceRecord {

--- a/pkg/hub/resource_store.go
+++ b/pkg/hub/resource_store.go
@@ -132,6 +132,9 @@ func (rs *ResourceStore) Bootstrap(ctx context.Context, name, dir, scope, scopeI
 		return false, fmt.Errorf("storage backend is not configured")
 	}
 
+	if err := transfer.NormalizeDir(dir); err != nil {
+		return false, fmt.Errorf("normalize dir: %w", err)
+	}
 	files, err := transfer.CollectFiles(dir, nil)
 	if err != nil {
 		return false, err

--- a/pkg/hub/resource_validate.go
+++ b/pkg/hub/resource_validate.go
@@ -99,7 +99,16 @@ func (rs *ResourceStore) ValidateStorage(ctx context.Context, rec *ResourceRecor
 
 		storedHash := objectMetadataHash(obj)
 		if storedHash == "" {
-			storedHash = computeStoredHash(ctx, stor, objectPath)
+			var hashErr error
+			storedHash, hashErr = computeStoredHash(ctx, stor, objectPath)
+			if hashErr != nil {
+				report.Issues = append(report.Issues, ValidationIssue{
+					Kind:    ValidationIssueContentHashMismatch,
+					File:    file.Path,
+					Message: fmt.Sprintf("failed to compute hash: %v", hashErr),
+				})
+				continue
+			}
 		}
 		if storedHash != "" && storedHash != file.Hash {
 			report.Issues = append(report.Issues, ValidationIssue{
@@ -134,18 +143,19 @@ func objectMetadataHash(obj *storage.Object) string {
 	return obj.Metadata["sha256"]
 }
 
-// computeStoredHash downloads an object's content and computes its SHA256 hash.
-// Returns "" if the download fails or the hash cannot be computed.
-func computeStoredHash(ctx context.Context, stor storage.Storage, objectPath string) string {
+func computeStoredHash(ctx context.Context, stor storage.Storage, objectPath string) (string, error) {
 	reader, _, err := stor.Download(ctx, objectPath)
 	if err != nil {
-		return ""
+		return "", err
+	}
+	if reader == nil {
+		return "", fmt.Errorf("storage returned nil reader for %s", objectPath)
 	}
 	defer func() { _ = reader.Close() }()
 
 	hasher := sha256.New()
 	if _, err := io.Copy(hasher, reader); err != nil {
-		return ""
+		return "", err
 	}
-	return "sha256:" + hex.EncodeToString(hasher.Sum(nil))
+	return "sha256:" + hex.EncodeToString(hasher.Sum(nil)), nil
 }

--- a/pkg/hub/resource_validate.go
+++ b/pkg/hub/resource_validate.go
@@ -141,7 +141,7 @@ func computeStoredHash(ctx context.Context, stor storage.Storage, objectPath str
 	if err != nil {
 		return ""
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	hasher := sha256.New()
 	if _, err := io.Copy(hasher, reader); err != nil {

--- a/pkg/hub/resource_validate.go
+++ b/pkg/hub/resource_validate.go
@@ -16,7 +16,11 @@ package hub
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 )
@@ -39,9 +43,10 @@ type ValidationIssue struct {
 
 // Validation issue kinds.
 const (
-	ValidationIssueMissingObject   = "missing_object"
-	ValidationIssueMissingManifest = "missing_manifest"
-	ValidationIssueZeroFilesActive = "zero_files_active"
+	ValidationIssueMissingObject       = "missing_object"
+	ValidationIssueMissingManifest     = "missing_manifest"
+	ValidationIssueZeroFilesActive     = "zero_files_active"
+	ValidationIssueContentHashMismatch = "content_hash_mismatch"
 )
 
 // ValidateStorage checks a resource record's storage consistency. It verifies:
@@ -75,15 +80,32 @@ func (rs *ResourceStore) ValidateStorage(ctx context.Context, rec *ResourceRecor
 
 	for _, file := range rec.Files {
 		objectPath := storagePath + "/" + file.Path
-		exists, err := stor.Exists(ctx, objectPath)
+		obj, err := stor.GetObject(ctx, objectPath)
 		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				report.Issues = append(report.Issues, ValidationIssue{
+					Kind:    ValidationIssueMissingObject,
+					File:    file.Path,
+					Message: fmt.Sprintf("storage object missing for file %q", file.Path),
+				})
+				continue
+			}
 			return report, fmt.Errorf("checking object %q: %w", objectPath, err)
 		}
-		if !exists {
+
+		if file.Hash == "" {
+			continue
+		}
+
+		storedHash := objectMetadataHash(obj)
+		if storedHash == "" {
+			storedHash = computeStoredHash(ctx, stor, objectPath)
+		}
+		if storedHash != "" && storedHash != file.Hash {
 			report.Issues = append(report.Issues, ValidationIssue{
-				Kind:    ValidationIssueMissingObject,
+				Kind:    ValidationIssueContentHashMismatch,
 				File:    file.Path,
-				Message: fmt.Sprintf("storage object missing for file %q", file.Path),
+				Message: fmt.Sprintf("expected %s, got %s", file.Hash, storedHash),
 			})
 		}
 	}
@@ -101,4 +123,29 @@ func (rs *ResourceStore) ValidateStorage(ctx context.Context, rec *ResourceRecor
 	}
 
 	return report, nil
+}
+
+// objectMetadataHash extracts the SHA256 hash stored in object metadata during
+// upload. Returns "" if the metadata doesn't contain a hash.
+func objectMetadataHash(obj *storage.Object) string {
+	if obj == nil || obj.Metadata == nil {
+		return ""
+	}
+	return obj.Metadata["sha256"]
+}
+
+// computeStoredHash downloads an object's content and computes its SHA256 hash.
+// Returns "" if the download fails or the hash cannot be computed.
+func computeStoredHash(ctx context.Context, stor storage.Storage, objectPath string) string {
+	reader, _, err := stor.Download(ctx, objectPath)
+	if err != nil {
+		return ""
+	}
+	defer reader.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, reader); err != nil {
+		return ""
+	}
+	return "sha256:" + hex.EncodeToString(hasher.Sum(nil))
 }

--- a/pkg/hub/resource_validate_test.go
+++ b/pkg/hub/resource_validate_test.go
@@ -17,6 +17,7 @@
 package hub
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -196,6 +197,118 @@ func TestValidateStorage_ZeroFilesActive(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected zero_files_active issue, got: %v", report.Issues)
+	}
+}
+
+func TestValidateStorage_ContentHashMismatch(t *testing.T) {
+	srv, s, stor := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	br := testBundledResource(storage.ResourceKindTemplate, "hash-mismatch", map[string]string{
+		"scion-agent.yaml": "harness: claude\n",
+		"home/.bashrc":     "# original content",
+	})
+	src := NewFSResourceSource(br)
+	rs := srv.templateStore()
+
+	_, err := rs.BootstrapSource(ctx, src, BootstrapOptions{
+		OverwritePolicy: OverwriteBuiltinManaged,
+	})
+	if err != nil {
+		t.Fatalf("bootstrap failed: %v", err)
+	}
+
+	tmpl, err := s.GetTemplateBySlug(ctx, "hash-mismatch", "global", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Overwrite one file with different content while keeping the DB manifest
+	// unchanged, simulating GCS/DB divergence.
+	objectPath := tmpl.StoragePath + "/home/.bashrc"
+	stor.Upload(ctx, objectPath, //nolint:errcheck
+		bytes.NewReader([]byte("# WRONG content")),
+		storage.UploadOptions{Metadata: map[string]string{"sha256": "sha256:0000000000000000000000000000000000000000000000000000000000000000"}},
+	)
+
+	// Add manifest so we don't get a missing_manifest issue
+	manifestPath := tmpl.StoragePath + "/manifest.json"
+	stor.Upload(ctx, manifestPath, nil, storage.UploadOptions{}) //nolint:errcheck
+
+	rec := templateToRecord(tmpl)
+	report, err := rs.ValidateStorage(ctx, rec)
+	if err != nil {
+		t.Fatalf("ValidateStorage failed: %v", err)
+	}
+
+	found := false
+	for _, issue := range report.Issues {
+		if issue.Kind == ValidationIssueContentHashMismatch && issue.File == "home/.bashrc" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected content_hash_mismatch issue for home/.bashrc, got: %v", report.Issues)
+	}
+}
+
+func TestRepairStorage_FixesHashMismatch(t *testing.T) {
+	srv, s, stor := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	br := testBundledResource(storage.ResourceKindTemplate, "repair-hash", map[string]string{
+		"scion-agent.yaml": "harness: claude\n",
+		"home/.bashrc":     "# correct content",
+	})
+	src := NewFSResourceSource(br)
+	rs := srv.templateStore()
+
+	_, err := rs.BootstrapSource(ctx, src, BootstrapOptions{
+		OverwritePolicy: OverwriteBuiltinManaged,
+	})
+	if err != nil {
+		t.Fatalf("bootstrap failed: %v", err)
+	}
+
+	tmpl, err := s.GetTemplateBySlug(ctx, "repair-hash", "global", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Corrupt one file in storage
+	objectPath := tmpl.StoragePath + "/home/.bashrc"
+	stor.Upload(ctx, objectPath, //nolint:errcheck
+		bytes.NewReader([]byte("# CORRUPTED")),
+		storage.UploadOptions{Metadata: map[string]string{"sha256": "sha256:badhash"}},
+	)
+
+	// Verify it's detected as broken
+	rec := templateToRecord(tmpl)
+	report, err := rs.ValidateStorage(ctx, rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hashMismatchFound := false
+	for _, issue := range report.Issues {
+		if issue.Kind == ValidationIssueContentHashMismatch {
+			hashMismatchFound = true
+		}
+	}
+	if !hashMismatchFound {
+		t.Fatal("expected content_hash_mismatch before repair")
+	}
+
+	// Run repair
+	result, err := rs.BootstrapSource(ctx, src, BootstrapOptions{
+		RepairStorage:   true,
+		OverwritePolicy: OverwriteBuiltinManaged,
+	})
+	if err != nil {
+		t.Fatalf("repair bootstrap failed: %v", err)
+	}
+	if result.Repaired != 1 {
+		t.Errorf("expected Repaired=1, got %d", result.Repaired)
 	}
 }
 

--- a/pkg/hub/storage_helpers.go
+++ b/pkg/hub/storage_helpers.go
@@ -165,7 +165,11 @@ func uploadResourceFiles(ctx context.Context, stor storage.Storage, storagePath 
 				return fmt.Errorf("%s: failed to open file %s: %w", label, fi.Path, err)
 			}
 
-			_, err = stor.Upload(ctx, objectPath, f, storage.UploadOptions{})
+			uploadOpts := storage.UploadOptions{}
+			if fi.Hash != "" {
+				uploadOpts.Metadata = map[string]string{"sha256": fi.Hash}
+			}
+			_, err = stor.Upload(ctx, objectPath, f, uploadOpts)
 			_ = f.Close()
 			if err != nil {
 				return fmt.Errorf("%s: failed to upload file %s: %w", label, fi.Path, err)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -485,10 +485,10 @@ type HarnessConfigStore interface {
 
 // HarnessConfigFilter defines criteria for filtering harness configs.
 type HarnessConfigFilter struct {
-	Name        string // Exact match on name
-	Scope       string
-	ScopeID     string
-	ProjectID   string // When set without Scope, returns global + project-scoped configs for this project
+	Name      string // Exact match on name
+	Scope     string
+	ScopeID   string
+	ProjectID string // When set without Scope, returns global + project-scoped configs for this project
 	Harness     string
 	OwnerID     string
 	Status      string

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -485,10 +485,10 @@ type HarnessConfigStore interface {
 
 // HarnessConfigFilter defines criteria for filtering harness configs.
 type HarnessConfigFilter struct {
-	Name      string // Exact match on name
-	Scope     string
-	ScopeID   string
-	ProjectID string // When set without Scope, returns global + project-scoped configs for this project
+	Name        string // Exact match on name
+	Scope       string
+	ScopeID     string
+	ProjectID   string // When set without Scope, returns global + project-scoped configs for this project
 	Harness     string
 	OwnerID     string
 	Status      string

--- a/pkg/transfer/normalize.go
+++ b/pkg/transfer/normalize.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transfer
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+)
+
+// NormalizeFileContent normalizes line endings from CRLF to LF for text files.
+// Binary content (detected by the presence of null bytes or invalid UTF-8 in
+// the first 8KB) is returned unchanged.
+func NormalizeFileContent(data []byte) []byte {
+	if !isTextContent(data) {
+		return data
+	}
+	if !bytes.Contains(data, []byte("\r\n")) {
+		return data
+	}
+	return bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+}
+
+// isTextContent returns true if data appears to be text (UTF-8, no null bytes).
+// It inspects at most the first 8KB.
+func isTextContent(data []byte) bool {
+	sample := data
+	if len(sample) > 8192 {
+		sample = sample[:8192]
+	}
+	if bytes.ContainsRune(sample, 0) {
+		return false
+	}
+	return utf8.Valid(sample)
+}
+
+// binaryExtensions are file extensions that should never be normalized.
+var binaryExtensions = map[string]bool{
+	".png": true, ".jpg": true, ".jpeg": true, ".gif": true,
+	".ico": true, ".bmp": true, ".webp": true, ".svg": true,
+	".woff": true, ".woff2": true, ".ttf": true, ".otf": true, ".eot": true,
+	".zip": true, ".tar": true, ".gz": true, ".bz2": true, ".xz": true,
+	".pdf": true, ".exe": true, ".dll": true, ".so": true, ".dylib": true,
+	".bin": true, ".dat": true, ".db": true, ".sqlite": true,
+}
+
+// NormalizeDir walks dir and normalizes line endings (CRLF → LF) for all text
+// files in place. Binary files are left unchanged.
+func NormalizeDir(dir string) error {
+	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if binaryExtensions[ext] {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		normalized := NormalizeFileContent(data)
+		if len(normalized) == len(data) && bytes.Equal(normalized, data) {
+			return nil
+		}
+		return os.WriteFile(path, normalized, 0644)
+	})
+}

--- a/pkg/transfer/normalize.go
+++ b/pkg/transfer/normalize.go
@@ -85,6 +85,10 @@ func NormalizeDir(dir string) error {
 		if len(normalized) == len(data) && bytes.Equal(normalized, data) {
 			return nil
 		}
-		return os.WriteFile(path, normalized, 0644)
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(path, normalized, info.Mode())
 	})
 }

--- a/pkg/transfer/normalize_test.go
+++ b/pkg/transfer/normalize_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transfer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeFileContent_CRLF(t *testing.T) {
+	input := []byte("line1\r\nline2\r\nline3\r\n")
+	want := []byte("line1\nline2\nline3\n")
+	got := NormalizeFileContent(input)
+	if string(got) != string(want) {
+		t.Errorf("NormalizeFileContent CRLF:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestNormalizeFileContent_LF(t *testing.T) {
+	input := []byte("line1\nline2\nline3\n")
+	got := NormalizeFileContent(input)
+	if string(got) != string(input) {
+		t.Errorf("NormalizeFileContent should not modify LF-only content:\n got %q\nwant %q", got, input)
+	}
+}
+
+func TestNormalizeFileContent_Binary(t *testing.T) {
+	input := []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0x00}
+	got := NormalizeFileContent(input)
+	if string(got) != string(input) {
+		t.Errorf("NormalizeFileContent should not modify binary content")
+	}
+}
+
+func TestNormalizeFileContent_Empty(t *testing.T) {
+	got := NormalizeFileContent(nil)
+	if len(got) != 0 {
+		t.Errorf("NormalizeFileContent(nil) should return empty, got %q", got)
+	}
+}
+
+func TestNormalizeFileContent_MixedLineEndings(t *testing.T) {
+	input := []byte("line1\r\nline2\nline3\r\n")
+	want := []byte("line1\nline2\nline3\n")
+	got := NormalizeFileContent(input)
+	if string(got) != string(want) {
+		t.Errorf("NormalizeFileContent mixed:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestNormalizeDir(t *testing.T) {
+	dir := t.TempDir()
+
+	crlfContent := []byte("hello\r\nworld\r\n")
+	lfContent := []byte("already\nnormalized\n")
+	binContent := []byte{0x00, 0x01, '\r', '\n', 0x02}
+
+	if err := os.WriteFile(filepath.Join(dir, "crlf.txt"), crlfContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "lf.txt"), lfContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "binary.bin"), binContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NormalizeDir(dir); err != nil {
+		t.Fatalf("NormalizeDir failed: %v", err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(dir, "crlf.txt"))
+	if string(got) != "hello\nworld\n" {
+		t.Errorf("crlf.txt not normalized: %q", got)
+	}
+
+	got, _ = os.ReadFile(filepath.Join(dir, "lf.txt"))
+	if string(got) != string(lfContent) {
+		t.Errorf("lf.txt was modified unexpectedly: %q", got)
+	}
+
+	got, _ = os.ReadFile(filepath.Join(dir, "binary.bin"))
+	if string(got) != string(binContent) {
+		t.Errorf("binary.bin was modified: %q", got)
+	}
+}
+
+func TestNormalizeDir_SameHashAcrossPaths(t *testing.T) {
+	content := "harness: claude\r\nimage: test:latest\r\n"
+
+	// Simulate the embedded path: normalize content, then hash
+	normalizedData := NormalizeFileContent([]byte(content))
+	embeddedHash := HashBytes(normalizedData)
+
+	// Simulate the import path: write CRLF to disk, normalize dir, then hash
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := NormalizeDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	importHash, err := HashFile(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if embeddedHash != importHash {
+		t.Errorf("hash mismatch between paths:\n  embedded: %s\n  import:   %s", embeddedHash, importHash)
+	}
+}

--- a/web/src/components/pages/harness-config-detail.ts
+++ b/web/src/components/pages/harness-config-detail.ts
@@ -118,6 +118,9 @@ export class ScionPageHarnessConfigDetail extends LitElement {
   @state()
   private deleteError = '';
 
+  @state()
+  private resolvedImage = '';
+
   private fileBrowserDataSource: FileBrowserDataSource | null = null;
   private fileEditorDataSource: FileEditorDataSource | null = null;
   private buildPollTimer: ReturnType<typeof setTimeout> | null = null;
@@ -623,6 +626,9 @@ export class ScionPageHarnessConfigDetail extends LitElement {
                 hc.imageStatus === 'invalid' ? 'Image Not Found' :
                 hc.imageStatus === 'error' ? 'Check Failed' : 'Not Checked'}
             </span>
+            ${this.resolvedImage && this.resolvedImage !== image ? html`
+              <span class="image-meta">${this.resolvedImage}</span>
+            ` : nothing}
             <sl-button size="small" variant="text" @click=${this.recheckImage}>
               <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
               Re-check
@@ -655,6 +661,8 @@ export class ScionPageHarnessConfigDetail extends LitElement {
       { method: 'POST' }
     );
     if (resp.ok) {
+      const data = await resp.json();
+      this.resolvedImage = data.resolved_image || '';
       await this.loadHarnessConfig();
     } else {
       const msg = await extractApiError(resp, `HTTP ${resp.status}`);

--- a/web/src/components/pages/harness-config-detail.ts
+++ b/web/src/components/pages/harness-config-detail.ts
@@ -603,7 +603,8 @@ export class ScionPageHarnessConfigDetail extends LitElement {
   private renderImageSection() {
     const hc = this.harnessConfig!;
     const image = hc.config?.image;
-    const showSection = image || this.hasDockerfile;
+    const hasImageStatus = !!hc.imageStatus && hc.imageStatus !== 'unknown';
+    const showSection = image || this.hasDockerfile || hasImageStatus;
     if (!showSection) return nothing;
 
     const isRemote = image ? this.isRemoteImage(image) : false;


### PR DESCRIPTION
## Summary

Follow-up fixes to the harness image status feature (PR #583). Addresses reviewer feedback, production-found bugs, and prevents hash mismatches between DB file manifests and GCS storage.

**Reviewer feedback (commits 1-3)**
- Fix docker.io → registry-1.docker.io endpoint normalization
- Add structured logging to image check failure paths
- Fix gofmt and errcheck lint issues

**Production bug fixes (commits 4-9)**
- Fix SourceURL for imported harnesses (parent dir vs specific subdir)
- Fix detail page image status display when config.image is empty
- Wire SetLocalImageChecker before RecheckAllImageStatuses (fixes 6ms startup race)
- Add application/vnd.oci.image.index.v1+json to Accept header (GCP Artifact Registry multi-arch support)
- Persist Config.Image to DB for reliable startup rechecks
- Bare image names return unknown instead of falling through to Docker Hub
- Use SCION_IMAGE_REGISTRY env var for registry rewrite (not just settings.yaml)
- Include resolved_image in check-image API response; show on detail page

**Hash mismatch prevention (commits 9-10)**
- Content normalization: CRLF→LF for text files across all import and bootstrap paths, so GitHub tarballs and embedded files produce identical SHA256 hashes
- ValidateStorage content hash verification: compares stored GCS content hash against DB manifest (via sha256 metadata or content download fallback); triggers auto-repair on mismatch
- New ValidationIssueContentHashMismatch kind — any detected mismatch automatically triggers repairStorageIfNeeded

## Verified in production

All 9 harness configs (8 bundled + 1 custom local) verified imageStatus=valid on scion-gteam. Registry resolution works from SCION_IMAGE_REGISTRY env var without settings.yaml entry required.

## Test plan

- [ ] go build ./... passes
- [ ] go test ./pkg/hub/... ./pkg/transfer/... passes
- [ ] Same file imported via GitHub API and embedded bootstrap produces identical SHA256
- [ ] ValidateStorage detects content_hash_mismatch when GCS content differs from DB manifest
- [ ] repairStorageIfNeeded triggers on content_hash_mismatch (not just missing_object)
- [ ] SCION_IMAGE_REGISTRY env var used for registry rewrite
- [ ] Local Docker image resolves valid without remote check
- [ ] Startup recheck works after clean restart (Config.Image persisted)
