### PR TITLE
agent: fix no-auth auto-resolve UI and auth method display

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -477,6 +477,7 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 			if canFallbackToNoAuth() {
 				util.Debugf("auth: resolution failed, falling back to no-auth mode: %v", err)
 				opts.NoAuth = true
+				opts.HarnessAuth = "none"
 				warnings = append(warnings, "Auth: no credentials found, starting in no-auth mode")
 				goto authDone
 			}
@@ -494,6 +495,7 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 			if canFallbackToNoAuth() {
 				util.Debugf("auth: validation failed, falling back to no-auth mode: %v", err)
 				opts.NoAuth = true
+				opts.HarnessAuth = "none"
 				warnings = append(warnings, "Auth: credential validation failed, starting in no-auth mode")
 				goto authDone
 			}

--- a/pkg/harness/claude_provision_test.go
+++ b/pkg/harness/claude_provision_test.go
@@ -858,8 +858,8 @@ func TestClaudeContainerScriptResolveAuthShape(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveAuth: %v", err)
 	}
-	if resolved.Method != "container-script" {
-		t.Errorf("Method=%q want container-script (final selection deferred to script)", resolved.Method)
+	if resolved.Method != "api-key" {
+		t.Errorf("Method=%q want api-key (detected from ANTHROPIC_API_KEY via auth metadata)", resolved.Method)
 	}
 	if resolved.EnvVars["ANTHROPIC_API_KEY"] != "sk-ant-xx" {
 		t.Errorf("expected ANTHROPIC_API_KEY to flow through, got %v", resolved.EnvVars)

--- a/pkg/harness/container_script_harness.go
+++ b/pkg/harness/container_script_harness.go
@@ -206,6 +206,7 @@ func (c *ContainerScriptHarness) ResolveAuth(auth api.AuthConfig) (*api.Resolved
 	// use them. SCION_HARNESS_AUTH_CANDIDATES is a manifest-style hint.
 	if auth.SelectedType != "" {
 		resolved.EnvVars["SCION_HARNESS_SELECTED_AUTH"] = auth.SelectedType
+		resolved.Method = auth.SelectedType
 	}
 
 	// Forward any explicit auth env vars to the container. The script may
@@ -267,10 +268,51 @@ func (c *ContainerScriptHarness) ResolveAuth(auth api.AuthConfig) (*api.Resolved
 		})
 	}
 
+	// When no explicit auth type was selected, detect from the staged
+	// credentials using harness-config auth metadata. This sets a
+	// user-facing Method (e.g. "api-key") instead of the provisioner type.
+	if auth.SelectedType == "" && c.entry.Auth != nil {
+		envKeys := make(map[string]struct{}, len(resolved.EnvVars))
+		for k := range resolved.EnvVars {
+			envKeys[k] = struct{}{}
+		}
+		if detected := DetectAuthTypeFromEnvVarsFromConfig(c.entry.Auth, envKeys); detected != "" {
+			resolved.Method = detected
+		} else if c.entry.Auth.DefaultType != "" {
+			// Check if the default auth type's required env keys are satisfied.
+			if meta, ok := c.entry.Auth.Types[c.entry.Auth.DefaultType]; ok {
+				if authTypeEnvSatisfied(meta, envKeys) {
+					resolved.Method = c.entry.Auth.DefaultType
+				}
+			}
+		}
+	}
+
 	// The auth_candidates manifest written during Provision() captures the full
 	// candidate set for the script. ResolveAuth provides the env/file material
 	// the runtime needs to project secrets into the container.
 	return resolved, nil
+}
+
+// authTypeEnvSatisfied checks if at least one required_env group for an auth
+// type has all its any_of keys satisfied by the presentKeys set.
+func authTypeEnvSatisfied(meta config.HarnessAuthTypeMetadata, presentKeys map[string]struct{}) bool {
+	if len(meta.RequiredEnv) == 0 {
+		return false
+	}
+	for _, req := range meta.RequiredEnv {
+		satisfied := false
+		for _, key := range req.AnyOf {
+			if _, ok := presentKeys[key]; ok {
+				satisfied = true
+				break
+			}
+		}
+		if !satisfied {
+			return false
+		}
+	}
+	return true
 }
 
 // ProvisionManifest is the JSON payload written to

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -653,6 +653,9 @@ func (d *HTTPAgentDispatcher) applyBrokerResponse(agent *store.Agent, resp *Remo
 			}
 			if resp.Agent.HarnessAuth != "" {
 				agent.AppliedConfig.HarnessAuth = resp.Agent.HarnessAuth
+				if resp.Agent.HarnessAuth == "none" {
+					agent.AppliedConfig.NoAuth = true
+				}
 			}
 			if resp.Agent.Image != "" {
 				agent.AppliedConfig.Image = resp.Agent.Image


### PR DESCRIPTION
## Summary

Two fixes for the agent detail page UI related to no-auth mode and auth method display.

**Fix 1: Auto-resolved no-auth agents now show Capture Auth button**

When auth auto-resolution fell back to no-auth (no credentials found + harness has no_auth config), the agent was started in no-auth mode but the Capture Auth button was not shown because the no-auth state was not propagated to the UI.

- In `pkg/agent/run.go`: set `opts.HarnessAuth = "none"` alongside `opts.NoAuth = true` in both auto-fallback paths
- In `pkg/hub/httpdispatcher.go`: set `NoAuth = true` when `HarnessAuth == "none"` comes back from the broker response

**Fix 2: Agent config page shows resolved auth method instead of provisioner type**

`ContainerScriptHarness.ResolveAuth()` was returning `Method = "container-script"` (the provisioner type) instead of the actual resolved auth type. This caused the agent configuration page to display "container-script" as the auth method.

- When `SelectedType` is explicitly set, use it directly as `Method`  
- When auto-detecting (SelectedType empty), inspect staged credentials against harness-config auth metadata to resolve the actual type (e.g. ANTHROPIC_API_KEY → "api-key", CLAUDE_CODE_OAUTH_TOKEN → "oauth-token")

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./pkg/agent/... ./pkg/harness/... ./pkg/hub/...` passes
- [ ] Agent started with auto no-auth fallback shows Capture Auth button
- [ ] Agent config page shows "api-key" / "oauth-token" / "vertex-ai" not "container-script"
- [ ] Explicitly selected auth type still displays correctly
