### PR TITLE
harnesses/claude: capture setup-token OAuth token (sk-ant) as CLAUDE_CODE_OAUTH_TOKEN

### DIFF
--- a/harnesses/claude/capture_auth.py
+++ b/harnesses/claude/capture_auth.py
@@ -22,6 +22,10 @@ Reads credential mappings from inputs/capture-auth-config.json (derived from
 the harness config.yaml's auth.types.*.required_files declarations). This
 avoids hardcoding paths or key names in the script.
 
+Additionally captures OAuth tokens produced by `claude setup-token` by reading
+the terminal scrollback (via tmux capture-pane, the same mechanism behind
+`scion look`) and searching for lines beginning with ``sk-ant``.
+
 Exit codes:
   0 = at least one credential captured
   1 = error
@@ -34,6 +38,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from typing import Any
@@ -112,6 +117,44 @@ def _capture_one(
     return True, None
 
 
+def _extract_oauth_from_scrollback() -> str | None:
+    """Read terminal scrollback and return an sk-ant OAuth token if present."""
+    try:
+        result = subprocess.run(
+            ["tmux", "capture-pane", "-pS", "-200", "-t", "scion"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        print(f"capture-auth: scrollback read failed: {exc}", file=sys.stderr)
+        return None
+    if result.returncode != 0:
+        return None
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if re.match(r"^sk-ant-[A-Za-z0-9._-]+$", stripped):
+            return stripped
+    return None
+
+
+def _store_oauth_token(token: str, force: bool) -> tuple[bool, str | None]:
+    """Store an OAuth token as CLAUDE_CODE_OAUTH_TOKEN via sciontool."""
+    cmd = ["sciontool", "secret", "set", "CLAUDE_CODE_OAUTH_TOKEN", token]
+    if force:
+        cmd.append("--force")
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except FileNotFoundError:
+        return False, "sciontool not found in PATH"
+    except subprocess.TimeoutExpired:
+        return False, "sciontool timed out storing OAuth token"
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        if "already exists" in stderr.lower():
+            return False, "CONFLICT"
+        return False, f"sciontool failed: {stderr}"
+    return True, None
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Capture auth credentials and store as project secrets"
@@ -129,13 +172,6 @@ def main() -> int:
     args = parser.parse_args()
 
     entries = _load_config(args.bundle)
-    if not entries:
-        print(
-            "capture-auth: no credential mappings found in "
-            "inputs/capture-auth-config.json",
-            file=sys.stderr,
-        )
-        return EXIT_NO_CREDS
 
     captured = 0
     conflicts = 0
@@ -160,6 +196,25 @@ def main() -> int:
         elif ok:
             print(f"capture-auth: {key}: captured from {source}")
             captured += 1
+
+    # Scrollback fallback: capture OAuth token from `claude setup-token` output.
+    if captured == 0 and conflicts == 0 and errors == 0:
+        print("capture-auth: no credential files found, scanning terminal scrollback...")
+        token = _extract_oauth_from_scrollback()
+        if token:
+            ok, err = _store_oauth_token(token, args.force)
+            if err == "CONFLICT":
+                print(
+                    'CONFLICT: secret "CLAUDE_CODE_OAUTH_TOKEN" already exists '
+                    "(use --force to overwrite)"
+                )
+                conflicts += 1
+            elif err:
+                print(f"capture-auth: CLAUDE_CODE_OAUTH_TOKEN: {err}", file=sys.stderr)
+                errors += 1
+            elif ok:
+                print("capture-auth: CLAUDE_CODE_OAUTH_TOKEN: captured from terminal scrollback")
+                captured += 1
 
     if conflicts > 0:
         return EXIT_CONFLICT

--- a/harnesses/claude/capture_auth.py
+++ b/harnesses/claude/capture_auth.py
@@ -129,9 +129,9 @@ def _extract_oauth_from_scrollback() -> str | None:
         return None
     if result.returncode != 0:
         return None
-    for line in result.stdout.splitlines():
+    for line in reversed(result.stdout.splitlines()):
         stripped = line.strip()
-        if re.match(r"^sk-ant-[A-Za-z0-9._-]+$", stripped):
+        if re.match(r"^sk-ant-oat[A-Za-z0-9._-]+$", stripped):
             return stripped
     return None
 


### PR DESCRIPTION
## Summary

Updates `harnesses/claude/capture_auth.py` to capture the long-lived OAuth token produced by `claude setup-token`.

After the user runs `claude setup-token` in an agent shell, the command prints the token on a line starting with `sk-ant`. The capture auth script now:

1. Reads terminal scrollback via `tmux capture-pane` (the mechanism behind `scion look`)
2. Searches for a line matching `^sk-ant-[A-Za-z0-9._-]+$`  
3. Stores it as `CLAUDE_CODE_OAUTH_TOKEN` via `sciontool secret set`

Also removes the early-return when no file-based credential mappings are found, so the scrollback path runs even when no `capture-auth-config.json` entries exist.

## Test plan

- [ ] Run `claude setup-token` in a no-auth Claude agent
- [ ] Click Capture Auth → token starting with `sk-ant` is captured as `CLAUDE_CODE_OAUTH_TOKEN` secret
- [ ] Subsequent agent starts use the captured token for authentication
