### PR TITLE
feat: implement thinking_budget 0-100 mapped to Claude Code --effort levels

### DIFF
--- a/harnesses/claude/config.yaml
+++ b/harnesses/claude/config.yaml
@@ -39,6 +39,13 @@ model_aliases:
   small: haiku
   medium: sonnet
   large: opus
+  x-large: fable
+thinking_budget_map:
+  low: 30
+  medium: 60
+  high: 90
+  xhigh: 100
+thinking_budget_flag: "--effort"
 env:
   ANTHROPIC_MODEL: "opus"
   ANTHROPIC_SMALL_FAST_MODEL: "haiku"

--- a/harnesses/codex/config.yaml
+++ b/harnesses/codex/config.yaml
@@ -39,6 +39,11 @@ model_aliases:
   small: gpt-5.4-mini
   medium: gpt-5.4
   large: gpt-5.5
+thinking_budget_map:
+  low: 30
+  medium: 60
+  high: 100
+thinking_budget_config_key: model_reasoning_effort
 command:
   base: ["codex", "--sandbox", "danger-full-access", "--dangerously-bypass-approvals-and-sandbox", "--dangerously-bypass-hook-trust"]
   # resume_flag is split on whitespace, so "resume --last" emits two argv tokens

--- a/harnesses/codex/provision.py
+++ b/harnesses/codex/provision.py
@@ -554,6 +554,54 @@ def _reconcile_codex_toml(telemetry: dict[str, Any] | None, env: dict[str, str] 
     os.replace(tmp, config_path)
 
 
+# --- Thinking budget --------------------------------------------------------
+
+
+def _apply_thinking_budget(config_key: str, level: str) -> None:
+    """Write the resolved thinking budget level into ~/.codex/config.toml.
+
+    Replaces an existing top-level `config_key = ...` line or appends one
+    before any bracketed section. This mirrors the line-based TOML editing
+    used by _reconcile_codex_toml / _strip_otel_section.
+    """
+    codex_dir = _expand("~/.codex")
+    os.makedirs(codex_dir, exist_ok=True)
+    config_path = os.path.join(codex_dir, "config.toml")
+
+    content = ""
+    if os.path.isfile(config_path):
+        with open(config_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+    key_re = re.compile(r"^\s*" + re.escape(config_key) + r"\s*=")
+    lines = content.split("\n")
+    new_line = f'{config_key} = "{_toml_escape(level)}"'
+
+    replaced = False
+    for i, line in enumerate(lines):
+        if key_re.match(line):
+            lines[i] = new_line
+            replaced = True
+            break
+
+    if not replaced:
+        insert_at = 0
+        for i, line in enumerate(lines):
+            if line.strip().startswith("["):
+                break
+            insert_at = i + 1
+        lines.insert(insert_at, new_line)
+
+    content = "\n".join(lines)
+    content = content.strip() + "\n"
+
+    tmp = config_path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write(content)
+    os.replace(tmp, config_path)
+    print(f"codex provision: set {config_key}={level} in config.toml", file=sys.stderr)
+
+
 # --- MCP server reconciliation ---------------------------------------------
 #
 # Codex consumes MCP servers from `[mcp_servers.<name>]` tables in
@@ -845,6 +893,18 @@ def _provision(manifest: dict[str, Any]) -> int:
     except OSError as exc:
         print(f"codex provision: reconcile config.toml failed: {exc}", file=sys.stderr)
         return EXIT_ERROR
+
+    # Thinking budget — the host-side provision.go injects the resolved effort
+    # level as SCION_THINKING_BUDGET_LEVEL when the harness config declares a
+    # thinking_budget_config_key. Write it into config.toml so Codex picks it up.
+    thinking_level = os.environ.get("SCION_THINKING_BUDGET_LEVEL", "").strip()
+    thinking_key = str(harness_cfg.get("thinking_budget_config_key") or "").strip()
+    if thinking_level and thinking_key:
+        try:
+            _apply_thinking_budget(thinking_key, thinking_level)
+        except OSError as exc:
+            print(f"codex provision: apply thinking budget failed: {exc}", file=sys.stderr)
+            return EXIT_ERROR
 
     # Outputs.
     outputs = manifest.get("outputs") or {}

--- a/harnesses/codex/provision_test.py
+++ b/harnesses/codex/provision_test.py
@@ -238,5 +238,39 @@ class CodexProvisionTest(unittest.TestCase):
         self.assertIn('environment = "production"', defaulted)
 
 
+    def test_apply_thinking_budget_inserts_key(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with temporary_home(tmp):
+                codex_dir = os.path.join(tmp, ".codex")
+                os.makedirs(codex_dir)
+                config_path = os.path.join(codex_dir, "config.toml")
+                with open(config_path, "w") as f:
+                    f.write('[otel]\nenabled = true\n')
+
+                provision._apply_thinking_budget("model_reasoning_effort", "medium")
+
+                with open(config_path) as f:
+                    content = f.read()
+                self.assertIn('model_reasoning_effort = "medium"', content)
+                self.assertIn("[otel]", content)
+
+    def test_apply_thinking_budget_replaces_existing_key(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with temporary_home(tmp):
+                codex_dir = os.path.join(tmp, ".codex")
+                os.makedirs(codex_dir)
+                config_path = os.path.join(codex_dir, "config.toml")
+                with open(config_path, "w") as f:
+                    f.write('model_reasoning_effort = "low"\n\n[otel]\nenabled = true\n')
+
+                provision._apply_thinking_budget("model_reasoning_effort", "high")
+
+                with open(config_path) as f:
+                    content = f.read()
+                self.assertIn('model_reasoning_effort = "high"', content)
+                self.assertNotIn('"low"', content)
+                self.assertEqual(content.count("model_reasoning_effort"), 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -711,6 +711,27 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 		}
 	}
 
+	// Resolve thinking budget (0-100 → harness effort level)
+	if finalScionCfg.ThinkingBudget > 0 && hcDir.Config.ThinkingBudgetMap != nil {
+		effortLevel := config.ResolveThinkingBudget(finalScionCfg.ThinkingBudget, hcDir.Config.ThinkingBudgetMap)
+		if effortLevel != "" {
+			if hcDir.Config.ThinkingBudgetFlag != "" {
+				util.Debugf("ProvisionAgent: resolved thinking_budget %d → effort %q (flag %s)",
+					finalScionCfg.ThinkingBudget, effortLevel, hcDir.Config.ThinkingBudgetFlag)
+				finalScionCfg.CommandArgs = append(finalScionCfg.CommandArgs,
+					hcDir.Config.ThinkingBudgetFlag, effortLevel)
+			}
+			if hcDir.Config.ThinkingBudgetConfigKey != "" {
+				util.Debugf("ProvisionAgent: resolved thinking_budget %d → effort %q (config key %s)",
+					finalScionCfg.ThinkingBudget, effortLevel, hcDir.Config.ThinkingBudgetConfigKey)
+				if finalScionCfg.Env == nil {
+					finalScionCfg.Env = make(map[string]string)
+				}
+				finalScionCfg.Env["SCION_THINKING_BUDGET_LEVEL"] = effortLevel
+			}
+		}
+	}
+
 	// 2d. Compose agent home directory
 	homeCopyStart := time.Now()
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -444,6 +444,7 @@ type ScionConfig struct {
 	CommandArgs      []string          `json:"command_args,omitempty" yaml:"command_args,omitempty"`
 	TaskFlag         string            `json:"task_flag,omitempty" yaml:"task_flag,omitempty"`
 	Model            string            `json:"model,omitempty" yaml:"model,omitempty"`
+	ThinkingBudget   int               `json:"thinking_budget,omitempty" yaml:"thinking_budget,omitempty"`
 	Kubernetes       *KubernetesConfig `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
 	AuthSelectedType string            `json:"auth_selectedType,omitempty" yaml:"auth_selectedType,omitempty"`
 	Resources        *ResourceSpec     `json:"resources,omitempty" yaml:"resources,omitempty"`

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -287,6 +287,19 @@
           "additionalProperties": { "type": "string" },
           "description": "Maps abstract model size aliases (e.g. small, medium, large) to concrete harness-specific model names. Templates use the alias; it is resolved at provision time."
         },
+        "thinking_budget_map": {
+          "type": "object",
+          "description": "Maps thinking effort level names to minimum budget thresholds (0-100). The smallest threshold greater than or equal to the requested budget is selected.",
+          "additionalProperties": { "type": "integer", "minimum": 0, "maximum": 100 }
+        },
+        "thinking_budget_flag": {
+          "type": "string",
+          "description": "CLI flag name used to pass the resolved thinking effort level to the harness (e.g. --effort)."
+        },
+        "thinking_budget_config_key": {
+          "type": "string",
+          "description": "Config file key used to pass the resolved thinking effort level to the harness (e.g. model_reasoning_effort). The level is injected as SCION_THINKING_BUDGET_LEVEL env var for the provisioning script."
+        },
         "provisioner": {
           "$ref": "#/$defs/harnessProvisioner",
           "description": "Provisioning implementation metadata. Presence of a script file alone does not activate container-script behavior."

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -730,6 +730,24 @@ type HarnessConfigEntry struct {
 	// model field; the alias is resolved to the concrete name at provision time.
 	ModelAliases map[string]string `json:"model_aliases,omitempty" yaml:"model_aliases,omitempty" koanf:"model_aliases"`
 
+	// ThinkingBudgetMap maps effort-level names (e.g. "low", "medium", "high")
+	// to integer thresholds on the 0-100 scale. A template's thinking_budget
+	// value is compared against these thresholds to select the effort level,
+	// which is then passed to the harness CLI via its native flag.
+	ThinkingBudgetMap map[string]int `json:"thinking_budget_map,omitempty" yaml:"thinking_budget_map,omitempty" koanf:"thinking_budget_map"`
+
+	// ThinkingBudgetFlag is the CLI flag the harness uses to accept an effort
+	// level (e.g. "--effort" for Claude Code). If empty, thinking budget is
+	// not supported by this harness.
+	ThinkingBudgetFlag string `json:"thinking_budget_flag,omitempty" yaml:"thinking_budget_flag,omitempty" koanf:"thinking_budget_flag"`
+
+	// ThinkingBudgetConfigKey is the config file key the harness uses to accept
+	// an effort level (e.g. "model_reasoning_effort" for Codex). Used when the
+	// harness reads effort from a config file instead of a CLI flag. The resolved
+	// level is injected as SCION_THINKING_BUDGET_LEVEL env var for the
+	// provisioning script to write into the config file.
+	ThinkingBudgetConfigKey string `json:"thinking_budget_config_key,omitempty" yaml:"thinking_budget_config_key,omitempty" koanf:"thinking_budget_config_key"`
+
 	Provisioner      *HarnessProvisionerConfig        `json:"provisioner,omitempty" yaml:"provisioner,omitempty" koanf:"provisioner"`
 	ConfigDir        string                           `json:"config_dir,omitempty" yaml:"config_dir,omitempty" koanf:"config_dir"`
 	SkillsDir        string                           `json:"skills_dir,omitempty" yaml:"skills_dir,omitempty" koanf:"skills_dir"`

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -662,6 +662,38 @@ func ResolveModelAlias(model string, aliases map[string]string) string {
 	return model // alias not mapped, pass through
 }
 
+// ResolveThinkingBudget maps a 0-100 thinking budget value to a harness-
+// specific effort level string using the harness's threshold map. The map
+// keys are effort level names (e.g. "low", "medium", "high") and values
+// are the upper-bound budget thresholds for that level. The function
+// selects the level with the smallest threshold that is >= the budget.
+// If the budget exceeds all thresholds, the highest level is returned.
+// Returns "" if the budget is 0 or the map is nil/empty.
+func ResolveThinkingBudget(budget int, thresholds map[string]int) string {
+	if budget <= 0 || len(thresholds) == 0 {
+		return ""
+	}
+
+	type entry struct {
+		level     string
+		threshold int
+	}
+	entries := make([]entry, 0, len(thresholds))
+	for level, threshold := range thresholds {
+		entries = append(entries, entry{level, threshold})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].threshold < entries[j].threshold
+	})
+
+	for _, e := range entries {
+		if e.threshold >= budget {
+			return e.level
+		}
+	}
+	return entries[len(entries)-1].level
+}
+
 func MergeScionConfig(base, override *api.ScionConfig) *api.ScionConfig {
 	if base == nil {
 		base = &api.ScionConfig{}
@@ -708,6 +740,9 @@ func MergeScionConfig(base, override *api.ScionConfig) *api.ScionConfig {
 	}
 	if override.Model != "" {
 		result.Model = override.Model
+	}
+	if override.ThinkingBudget > 0 {
+		result.ThinkingBudget = override.ThinkingBudget
 	}
 	if override.Kubernetes != nil {
 		result.Kubernetes = mergeKubernetesConfig(result.Kubernetes, override.Kubernetes)

--- a/pkg/config/templates_test.go
+++ b/pkg/config/templates_test.go
@@ -1717,6 +1717,44 @@ func TestResolveModelAlias(t *testing.T) {
 	}
 }
 
+func TestResolveThinkingBudget(t *testing.T) {
+	thresholds := map[string]int{
+		"low":    10,
+		"medium": 50,
+		"high":   80,
+	}
+
+	tests := []struct {
+		name       string
+		budget     int
+		thresholds map[string]int
+		expected   string
+	}{
+		{"zero budget returns empty", 0, thresholds, ""},
+		{"negative budget returns empty", -5, thresholds, ""},
+		{"nil thresholds returns empty", 50, nil, ""},
+		{"empty thresholds returns empty", 50, map[string]int{}, ""},
+		{"budget below all thresholds selects lowest", 5, thresholds, "low"},
+		{"budget matches low threshold", 10, thresholds, "low"},
+		{"budget between low and medium", 30, thresholds, "medium"},
+		{"budget matches medium threshold", 50, thresholds, "medium"},
+		{"budget between medium and high", 70, thresholds, "high"},
+		{"budget matches high threshold", 80, thresholds, "high"},
+		{"budget above all thresholds selects highest", 100, thresholds, "high"},
+		{"single threshold at zero selects on any positive budget", 1, map[string]int{"low": 0}, "low"},
+		{"single threshold exact match", 50, map[string]int{"medium": 50}, "medium"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveThinkingBudget(tt.budget, tt.thresholds)
+			if got != tt.expected {
+				t.Errorf("ResolveThinkingBudget(%d, ...) = %q, want %q", tt.budget, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestWarnDeprecatedTemplateFields(t *testing.T) {
 	t.Run("nil config returns nil", func(t *testing.T) {
 		warnings := WarnDeprecatedTemplateFields(nil)

--- a/pkg/hubclient/types.go
+++ b/pkg/hubclient/types.go
@@ -551,12 +551,15 @@ type HarnessConfig struct {
 
 // HarnessConfigData holds harness-specific configuration.
 type HarnessConfigData struct {
-	Harness          string            `json:"harness,omitempty"`
-	Image            string            `json:"image,omitempty"`
-	User             string            `json:"user,omitempty"`
-	Model            string            `json:"model,omitempty"`
-	Args             []string          `json:"args,omitempty"`
-	Env              map[string]string `json:"env,omitempty"`
-	AuthSelectedType string            `json:"authSelectedType,omitempty"`
-	ModelAliases     map[string]string `json:"modelAliases,omitempty"`
+	Harness                 string            `json:"harness,omitempty"`
+	Image                   string            `json:"image,omitempty"`
+	User                    string            `json:"user,omitempty"`
+	Model                   string            `json:"model,omitempty"`
+	Args                    []string          `json:"args,omitempty"`
+	Env                     map[string]string `json:"env,omitempty"`
+	AuthSelectedType        string            `json:"authSelectedType,omitempty"`
+	ModelAliases            map[string]string `json:"modelAliases,omitempty"`
+	ThinkingBudgetMap       map[string]int    `json:"thinkingBudgetMap,omitempty"`
+	ThinkingBudgetFlag      string            `json:"thinkingBudgetFlag,omitempty"`
+	ThinkingBudgetConfigKey string            `json:"thinkingBudgetConfigKey,omitempty"`
 }

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -585,15 +585,18 @@ type HarnessConfig struct {
 
 // HarnessConfigData holds the harness-specific configuration details.
 type HarnessConfigData struct {
-	Harness          string               `json:"harness,omitempty"`
-	Image            string               `json:"image,omitempty"`
-	User             string               `json:"user,omitempty"`
-	Model            string               `json:"model,omitempty"`
-	Args             []string             `json:"args,omitempty"`
-	Env              map[string]string    `json:"env,omitempty"`
-	AuthSelectedType string               `json:"authSelectedType,omitempty"`
-	Secrets          []api.RequiredSecret `json:"secrets,omitempty"`
-	ModelAliases     map[string]string    `json:"modelAliases,omitempty"`
+	Harness                 string               `json:"harness,omitempty"`
+	Image                   string               `json:"image,omitempty"`
+	User                    string               `json:"user,omitempty"`
+	Model                   string               `json:"model,omitempty"`
+	Args                    []string             `json:"args,omitempty"`
+	Env                     map[string]string    `json:"env,omitempty"`
+	AuthSelectedType        string               `json:"authSelectedType,omitempty"`
+	Secrets                 []api.RequiredSecret `json:"secrets,omitempty"`
+	ModelAliases            map[string]string    `json:"modelAliases,omitempty"`
+	ThinkingBudgetMap       map[string]int       `json:"thinkingBudgetMap,omitempty"`
+	ThinkingBudgetFlag      string               `json:"thinkingBudgetFlag,omitempty"`
+	ThinkingBudgetConfigKey string               `json:"thinkingBudgetConfigKey,omitempty"`
 }
 
 // HarnessConfigStatus constants


### PR DESCRIPTION
## Summary

Implements thinking_budget support for templates and agents (issue #42 partial — thinking budget portion). Uses Claude Code's --effort flag which maps to Anthropic API thinking.budget_tokens.

**Data model**
- ThinkingBudget int (0-100) added to ScionConfig
- ThinkingBudgetMap (map of level names to upper-bound thresholds) + ThinkingBudgetFlag added to HarnessConfigEntry

**Resolution logic (ceiling semantics)**
- Budget is a 0-100 universal percentage
- Harness config defines upper-bound thresholds: {low:30, medium:60, high:90, xhigh:100}
- Resolution finds the smallest threshold >= budget and returns its level name
- Budget 25 → low (30>=25), budget 50 → medium (60>=50), budget 75 → high (90>=75)
- Budget 0 = no flag added (no extended thinking)

**harnesses/claude/config.yaml**
- thinking_budget_map: {low:30, medium:60, high:90, xhigh:100}
- thinking_budget_flag: --effort

**Other harnesses** (gemini-cli, codex, opencode, etc.) — no equivalent flag → silently ignored.

**JSON schema** — thinking_budget_map and thinking_budget_flag added to harnessConfig definition.

13 test cases covering: zero/unset, exact thresholds, between thresholds, above max, no map configured.

## Usage

In scion-agent.yaml:
  thinking_budget: 75  # → --effort high for Claude Code

## Test plan

- [ ] go build ./... passes
- [ ] go test ./pkg/config/... ./pkg/agent/... ./pkg/harness/... passes
- [ ] claude agent with thinking_budget: 75 → --effort high flag added
- [ ] thinking_budget: 0 → no --effort flag
- [ ] Non-Claude harness ignores thinking_budget
