### PR TITLE
fix(hub): graceful SSE reconnect before Cloud Run 3600s timeout

### DIFF
--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -1007,6 +1007,14 @@ func (ws *WebServer) tryServeStaticFile(w http.ResponseWriter, r *http.Request) 
 
 // handleSSE serves the Server-Sent Events endpoint. It subscribes to the
 // configured EventPublisher and streams matching events to the browser.
+// sseMaxConnectionAge is the maximum lifetime of an SSE connection before the
+// server proactively closes it. Cloud Run hard-kills connections at 3600s
+// (producing FAILED_PRECONDITION / error code 9); closing at 3500s gives the
+// client a clean EOF so it auto-reconnects per the SSE spec.
+//
+// Declared as a variable so tests can temporarily shorten it.
+var sseMaxConnectionAge = 3500 * time.Second
+
 // Route: GET /events?sub=<pattern>&sub=<pattern>...
 func (ws *WebServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 	if ws.events == nil {
@@ -1052,6 +1060,11 @@ func (ws *WebServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 	heartbeat := time.NewTicker(30 * time.Second)
 	defer heartbeat.Stop()
 
+	// Proactively close before Cloud Run's 3600s hard kill so the client
+	// gets a clean EOF and auto-reconnects per the SSE spec.
+	reconnectTimer := time.NewTimer(sseMaxConnectionAge)
+	defer reconnectTimer.Stop()
+
 	for {
 		select {
 		case evt, ok := <-ch:
@@ -1071,6 +1084,13 @@ func (ws *WebServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 		case <-heartbeat.C:
 			_, _ = fmt.Fprintf(w, ":heartbeat %d\n\n", time.Now().UnixMilli())
 			flusher.Flush()
+		case <-reconnectTimer.C:
+			// Send a reconnect hint so clients can distinguish a
+			// server-initiated close from an error, then return to
+			// close the connection cleanly.
+			_, _ = fmt.Fprintf(w, "event: reconnect\ndata: {}\n\n")
+			flusher.Flush()
+			return
 		case <-r.Context().Done():
 			return
 		}

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -146,6 +146,10 @@ type WebServerConfig struct {
 	// ProxyAuthenticator verifies proxy-supplied assertions (e.g., IAP JWT).
 	// Required when AuthMode == "proxy".
 	ProxyAuthenticator ProxyAuthenticator
+	// SSEMaxConnectionAge is the maximum lifetime of an SSE connection before
+	// the server proactively closes it so the client can reconnect cleanly.
+	// Defaults to defaultSSEMaxConnectionAge (3500s) when zero.
+	SSEMaxConnectionAge time.Duration
 }
 
 // WebServer serves the web frontend SPA shell and static assets.
@@ -1007,13 +1011,11 @@ func (ws *WebServer) tryServeStaticFile(w http.ResponseWriter, r *http.Request) 
 
 // handleSSE serves the Server-Sent Events endpoint. It subscribes to the
 // configured EventPublisher and streams matching events to the browser.
-// sseMaxConnectionAge is the maximum lifetime of an SSE connection before the
-// server proactively closes it. Cloud Run hard-kills connections at 3600s
-// (producing FAILED_PRECONDITION / error code 9); closing at 3500s gives the
-// client a clean EOF so it auto-reconnects per the SSE spec.
-//
-// Declared as a variable so tests can temporarily shorten it.
-var sseMaxConnectionAge = 3500 * time.Second
+// defaultSSEMaxConnectionAge is the default maximum lifetime of an SSE
+// connection. Cloud Run hard-kills connections at 3600s (producing
+// FAILED_PRECONDITION / error code 9); closing at 3500s gives the client a
+// clean EOF so it auto-reconnects per the SSE spec.
+const defaultSSEMaxConnectionAge = 3500 * time.Second
 
 // Route: GET /events?sub=<pattern>&sub=<pattern>...
 func (ws *WebServer) handleSSE(w http.ResponseWriter, r *http.Request) {
@@ -1062,7 +1064,11 @@ func (ws *WebServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 	// Proactively close before Cloud Run's 3600s hard kill so the client
 	// gets a clean EOF and auto-reconnects per the SSE spec.
-	reconnectTimer := time.NewTimer(sseMaxConnectionAge)
+	maxAge := ws.config.SSEMaxConnectionAge
+	if maxAge == 0 {
+		maxAge = defaultSSEMaxConnectionAge
+	}
+	reconnectTimer := time.NewTimer(maxAge)
 	defer reconnectTimer.Stop()
 
 	for {

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -1649,6 +1649,52 @@ func TestSSEHandler_RequiresAuth(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
 
+func TestSSEHandler_ReconnectOnMaxAge(t *testing.T) {
+	// Temporarily shorten the max connection age so the test finishes fast.
+	origAge := sseMaxConnectionAge
+	sseMaxConnectionAge = 200 * time.Millisecond
+	t.Cleanup(func() { sseMaxConnectionAge = origAge })
+
+	ws := newDevAuthWebServer(t)
+	pub := NewChannelEventPublisher()
+	ws.SetEventPublisher(pub)
+	t.Cleanup(pub.Close)
+
+	ts := httptest.NewServer(ws.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/events?sub=project.test.>")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Read all data until the server closes the connection. The last
+	// meaningful frame should be the reconnect event.
+	var accumulated strings.Builder
+	buf := make([]byte, 4096)
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for server to close SSE connection")
+		default:
+		}
+		n, readErr := resp.Body.Read(buf)
+		if n > 0 {
+			accumulated.Write(buf[:n])
+		}
+		if readErr != nil {
+			// Connection closed by server — expected.
+			break
+		}
+	}
+
+	body := accumulated.String()
+	assert.Contains(t, body, "event: reconnect")
+	assert.Contains(t, body, "data: {}")
+}
+
 func TestLoginPageRendersLoginComponent(t *testing.T) {
 	// /login is a public route so no dev-auth needed
 	ws := newTestWebServer(t, WebServerConfig{})

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -1650,12 +1650,11 @@ func TestSSEHandler_RequiresAuth(t *testing.T) {
 }
 
 func TestSSEHandler_ReconnectOnMaxAge(t *testing.T) {
-	// Temporarily shorten the max connection age so the test finishes fast.
-	origAge := sseMaxConnectionAge
-	sseMaxConnectionAge = 200 * time.Millisecond
-	t.Cleanup(func() { sseMaxConnectionAge = origAge })
-
-	ws := newDevAuthWebServer(t)
+	// Use a config override to shorten SSEMaxConnectionAge — no global mutation,
+	// no data races when tests run in parallel.
+	ws := newDevAuthWebServer(t, func(cfg *WebServerConfig) {
+		cfg.SSEMaxConnectionAge = 200 * time.Millisecond
+	})
 	pub := NewChannelEventPublisher()
 	ws.SetEventPublisher(pub)
 	t.Cleanup(pub.Close)
@@ -1671,28 +1670,35 @@ func TestSSEHandler_ReconnectOnMaxAge(t *testing.T) {
 
 	// Read all data until the server closes the connection. The last
 	// meaningful frame should be the reconnect event.
-	var accumulated strings.Builder
-	buf := make([]byte, 4096)
-	deadline := time.After(5 * time.Second)
-	for {
-		select {
-		case <-deadline:
-			t.Fatal("timed out waiting for server to close SSE connection")
-		default:
-		}
-		n, readErr := resp.Body.Read(buf)
-		if n > 0 {
-			accumulated.Write(buf[:n])
-		}
-		if readErr != nil {
-			// Connection closed by server — expected.
-			break
-		}
+	// Use a channel to make the blocking Read interruptible by the deadline.
+	type readResult struct {
+		data string
+		err  error
 	}
+	done := make(chan readResult, 1)
+	go func() {
+		var accumulated strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := resp.Body.Read(buf)
+			if n > 0 {
+				accumulated.Write(buf[:n])
+			}
+			if readErr != nil {
+				// Connection closed by server — expected.
+				done <- readResult{data: accumulated.String(), err: readErr}
+				return
+			}
+		}
+	}()
 
-	body := accumulated.String()
-	assert.Contains(t, body, "event: reconnect")
-	assert.Contains(t, body, "data: {}")
+	select {
+	case result := <-done:
+		assert.Contains(t, result.data, "event: reconnect")
+		assert.Contains(t, result.data, "data: {}")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for server to close SSE connection")
+	}
 }
 
 func TestLoginPageRendersLoginComponent(t *testing.T) {


### PR DESCRIPTION
Cloud Run hard-kills SSE connections at 3600s, producing FAILED_PRECONDITION (error code 9) on the client. Add a server-side connection lifetime limit of 3500s that sends a `reconnect` event hint and closes cleanly, so the client gets a normal EOF and auto-reconnects per the SSE spec.

The existing 30s heartbeat ticker was already in place to prevent intermediate proxy idle timeouts.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
