### PR TITLE
hub: use SCION_IMAGE_REGISTRY env var fallback for registry resolution

### DIFF
--- a/pkg/hub/system_handlers.go
+++ b/pkg/hub/system_handlers.go
@@ -291,6 +291,10 @@ func (s *Server) computeOnboardingStatus(ctx context.Context) OnboardingStatus {
 	if vs, loadErr := config.LoadSingleFileVersioned(globalDir); loadErr == nil && vs != nil {
 		status.ImageRegistry = vs.ResolveImageRegistry("")
 	}
+	// TODO: use an internal settings API when available (needed for HA/DB-backed settings)
+	if status.ImageRegistry == "" {
+		status.ImageRegistry = os.Getenv("SCION_IMAGE_REGISTRY")
+	}
 
 	// BuildAvailable: true only if the build script can be resolved
 	status.BuildAvailable = resolveBuildScript() != ""
@@ -466,6 +470,10 @@ func (s *Server) handleSystemImagesPull(w http.ResponseWriter, r *http.Request) 
 		if vs, loadErr := config.LoadSingleFileVersioned(globalDir); loadErr == nil && vs != nil {
 			registry = vs.ResolveImageRegistry("")
 		}
+	}
+	// TODO: use an internal settings API when available (needed for HA/DB-backed settings)
+	if registry == "" {
+		registry = os.Getenv("SCION_IMAGE_REGISTRY")
 	}
 	if registry == "" {
 		s.imagePullActive.Store(false)

--- a/pkg/hub/system_handlers.go
+++ b/pkg/hub/system_handlers.go
@@ -292,8 +292,8 @@ func (s *Server) computeOnboardingStatus(ctx context.Context) OnboardingStatus {
 		status.ImageRegistry = vs.ResolveImageRegistry("")
 	}
 	// TODO: use an internal settings API when available (needed for HA/DB-backed settings)
-	if status.ImageRegistry == "" {
-		status.ImageRegistry = os.Getenv("SCION_IMAGE_REGISTRY")
+	if envRegistry := os.Getenv("SCION_IMAGE_REGISTRY"); envRegistry != "" {
+		status.ImageRegistry = envRegistry
 	}
 
 	// BuildAvailable: true only if the build script can be resolved
@@ -472,8 +472,8 @@ func (s *Server) handleSystemImagesPull(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	// TODO: use an internal settings API when available (needed for HA/DB-backed settings)
-	if registry == "" {
-		registry = os.Getenv("SCION_IMAGE_REGISTRY")
+	if envRegistry := os.Getenv("SCION_IMAGE_REGISTRY"); envRegistry != "" {
+		registry = envRegistry
 	}
 	if registry == "" {
 		s.imagePullActive.Store(false)


### PR DESCRIPTION
## Summary

Fixes registry resolution in two hub handlers that were reading only from settings.yaml (via LoadSingleFileVersioned), bypassing environment variables. When SCION_IMAGE_REGISTRY is set in hub.env, these handlers did not pick it up.

- computeOnboardingStatus (system_handlers.go): used for the onboarding status API
- handleSystemImagesPull (system_handlers.go): used for the image pull/build admin operations

Both now fall back to os.Getenv("SCION_IMAGE_REGISTRY") when file-based resolution returns empty.

TODO comments added for migrating to an internal settings API when available (needed for HA/DB-backed settings).

## Test plan

- [ ] go build ./... passes
- [ ] Onboarding status API returns correct image registry when only hub.env has it
- [ ] Image pull/build operations use correct registry when only hub.env has it
