### PR TITLE
hub: add auto no-auth fallback to pre-dispatch validation

### DIFF
--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -240,7 +240,10 @@ func (s *Server) populateAgentConfig(ctx context.Context, agent *store.Agent, pr
 				agent.AppliedConfig.HarnessAuth == "" &&
 				hc.Config != nil &&
 				hc.Config.NoAuthBehavior == "drop-to-shell" {
-				if !s.hasRequiredAuthCredentials(ctx, agent, hc.Harness) {
+				hasCreds, err := s.hasRequiredAuthCredentials(ctx, agent, hc.Harness)
+				if err != nil {
+					s.agentLifecycleLog.Error("Failed to check auth credentials for fallback", "agent_id", agent.ID, "error", err)
+				} else if !hasCreds {
 					agent.AppliedConfig.NoAuth = true
 					agent.AppliedConfig.HarnessAuth = "none"
 					s.agentLifecycleLog.Info("Auto no-auth fallback: harness supports drop-to-shell and no credentials found",
@@ -762,46 +765,64 @@ func (s *Server) findBrokerByIDOrSlug(ctx context.Context, identifier string) (*
 // hasRequiredAuthCredentials checks whether the required auth environment
 // variables for the given harness type are available in the agent's env,
 // or in the hub's env/secret stores (user and project scopes).
-func (s *Server) hasRequiredAuthCredentials(ctx context.Context, agent *store.Agent, harnessType string) bool {
+func (s *Server) hasRequiredAuthCredentials(ctx context.Context, agent *store.Agent, harnessType string) (bool, error) {
 	keyGroups := harness.RequiredAuthEnvKeys(harnessType, agent.AppliedConfig.HarnessAuth)
 	if len(keyGroups) == 0 {
-		return true
+		return true, nil
 	}
-	// Every key group is a set of alternatives (any one satisfies the group).
-	// All groups must be satisfied for credentials to be considered present.
 	for _, group := range keyGroups {
-		if !s.hasAnyKey(ctx, agent, group) {
-			return false
+		found, err := s.hasAnyKey(ctx, agent, group)
+		if err != nil {
+			return false, err
+		}
+		if !found {
+			return false, nil
 		}
 	}
-	return true
+	return true, nil
 }
 
 // hasAnyKey returns true if at least one of the keys is present in the
 // agent's env, or in the hub's env/secret stores at user or project scope.
-func (s *Server) hasAnyKey(ctx context.Context, agent *store.Agent, keys []string) bool {
+func (s *Server) hasAnyKey(ctx context.Context, agent *store.Agent, keys []string) (bool, error) {
 	for _, key := range keys {
 		if agent.AppliedConfig != nil && agent.AppliedConfig.Env != nil {
 			if _, ok := agent.AppliedConfig.Env[key]; ok {
-				return true
+				return true, nil
 			}
 		}
 		if agent.OwnerID != "" {
-			if ev, err := s.store.GetEnvVar(ctx, key, "user", agent.OwnerID); err == nil && ev != nil {
-				return true
+			ev, err := s.store.GetEnvVar(ctx, key, "user", agent.OwnerID)
+			if err != nil && !errors.Is(err, store.ErrNotFound) {
+				return false, err
 			}
-			if sec, err := s.store.GetSecret(ctx, key, "user", agent.OwnerID); err == nil && sec != nil {
-				return true
+			if ev != nil {
+				return true, nil
+			}
+			sec, err := s.store.GetSecret(ctx, key, "user", agent.OwnerID)
+			if err != nil && !errors.Is(err, store.ErrNotFound) {
+				return false, err
+			}
+			if sec != nil {
+				return true, nil
 			}
 		}
 		if agent.ProjectID != "" {
-			if ev, err := s.store.GetEnvVar(ctx, key, "project", agent.ProjectID); err == nil && ev != nil {
-				return true
+			ev, err := s.store.GetEnvVar(ctx, key, "project", agent.ProjectID)
+			if err != nil && !errors.Is(err, store.ErrNotFound) {
+				return false, err
 			}
-			if sec, err := s.store.GetSecret(ctx, key, "project", agent.ProjectID); err == nil && sec != nil {
-				return true
+			if ev != nil {
+				return true, nil
+			}
+			sec, err := s.store.GetSecret(ctx, key, "project", agent.ProjectID)
+			if err != nil && !errors.Is(err, store.ErrNotFound) {
+				return false, err
+			}
+			if sec != nil {
+				return true, nil
 			}
 		}
 	}
-	return false
+	return false, nil
 }

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/harness"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
@@ -230,6 +231,22 @@ func (s *Server) populateAgentConfig(ctx context.Context, agent *store.Agent, pr
 		if hc != nil {
 			agent.AppliedConfig.HarnessConfigID = hc.ID
 			agent.AppliedConfig.HarnessConfigHash = hc.ContentHash
+
+			// Auto no-auth fallback: when auth is "auto" (empty) and the harness
+			// config declares no_auth.behavior=drop-to-shell, check whether the
+			// required auth credentials are available. If not, enable NoAuth so
+			// the broker doesn't reject the agent for missing env vars.
+			if !agent.AppliedConfig.NoAuth &&
+				agent.AppliedConfig.HarnessAuth == "" &&
+				hc.Config != nil &&
+				hc.Config.NoAuthBehavior == "drop-to-shell" {
+				if !s.hasRequiredAuthCredentials(ctx, agent, hc.Harness) {
+					agent.AppliedConfig.NoAuth = true
+					agent.AppliedConfig.HarnessAuth = "none"
+					s.agentLifecycleLog.Info("Auto no-auth fallback: harness supports drop-to-shell and no credentials found",
+						"agent_id", agent.ID, "harness", hc.Harness)
+				}
+			}
 		}
 	}
 
@@ -740,4 +757,51 @@ func (s *Server) findBrokerByIDOrSlug(ctx context.Context, identifier string) (*
 	}
 
 	return nil, store.ErrNotFound
+}
+
+// hasRequiredAuthCredentials checks whether the required auth environment
+// variables for the given harness type are available in the agent's env,
+// or in the hub's env/secret stores (user and project scopes).
+func (s *Server) hasRequiredAuthCredentials(ctx context.Context, agent *store.Agent, harnessType string) bool {
+	keyGroups := harness.RequiredAuthEnvKeys(harnessType, agent.AppliedConfig.HarnessAuth)
+	if len(keyGroups) == 0 {
+		return true
+	}
+	// Every key group is a set of alternatives (any one satisfies the group).
+	// All groups must be satisfied for credentials to be considered present.
+	for _, group := range keyGroups {
+		if !s.hasAnyKey(ctx, agent, group) {
+			return false
+		}
+	}
+	return true
+}
+
+// hasAnyKey returns true if at least one of the keys is present in the
+// agent's env, or in the hub's env/secret stores at user or project scope.
+func (s *Server) hasAnyKey(ctx context.Context, agent *store.Agent, keys []string) bool {
+	for _, key := range keys {
+		if agent.AppliedConfig != nil && agent.AppliedConfig.Env != nil {
+			if _, ok := agent.AppliedConfig.Env[key]; ok {
+				return true
+			}
+		}
+		if agent.OwnerID != "" {
+			if ev, err := s.store.GetEnvVar(ctx, key, "user", agent.OwnerID); err == nil && ev != nil {
+				return true
+			}
+			if sec, err := s.store.GetSecret(ctx, key, "user", agent.OwnerID); err == nil && sec != nil {
+				return true
+			}
+		}
+		if agent.ProjectID != "" {
+			if ev, err := s.store.GetEnvVar(ctx, key, "project", agent.ProjectID); err == nil && ev != nil {
+				return true
+			}
+			if sec, err := s.store.GetSecret(ctx, key, "project", agent.ProjectID); err == nil && sec != nil {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/hub/resource_store.go
+++ b/pkg/hub/resource_store.go
@@ -458,6 +458,8 @@ func extractNoAuthBehavior(hc *store.HarnessConfig, dir string) {
 			hc.Config = &store.HarnessConfigData{}
 		}
 		hc.Config.NoAuthBehavior = hcDir.Config.NoAuthConfig.Behavior
+	} else if hc.Config != nil {
+		hc.Config.NoAuthBehavior = ""
 	}
 }
 

--- a/pkg/hub/resource_store.go
+++ b/pkg/hub/resource_store.go
@@ -384,6 +384,7 @@ func (p *harnessConfigPersistence) Create(ctx context.Context, rec *ResourceReco
 		SourceURL:     rec.SourceURL,
 		Visibility:    rec.Visibility,
 	}
+	extractNoAuthBehavior(hc, dir)
 	rec.Harness = p.harness
 	p.model = hc
 	return p.s.store.CreateHarnessConfig(ctx, hc)
@@ -399,6 +400,7 @@ func (p *harnessConfigPersistence) Update(ctx context.Context, rec *ResourceReco
 	if rec.SourceURL != "" {
 		hc.SourceURL = rec.SourceURL
 	}
+	extractNoAuthBehavior(hc, dir)
 	return p.s.store.UpdateHarnessConfig(ctx, hc)
 }
 
@@ -438,6 +440,25 @@ func (p *harnessConfigPersistence) extractImage(dir string) string {
 		return p.model.Config.Image
 	}
 	return ""
+}
+
+// extractNoAuthBehavior loads config.yaml from dir and stamps the
+// no_auth.behavior value onto the HarnessConfig's Config data so the
+// hub can use it for auto no-auth fallback decisions.
+func extractNoAuthBehavior(hc *store.HarnessConfig, dir string) {
+	if dir == "" {
+		return
+	}
+	hcDir, err := config.LoadHarnessConfigDir(dir)
+	if err != nil {
+		return
+	}
+	if hcDir.Config.NoAuthConfig != nil && hcDir.Config.NoAuthConfig.Behavior != "" {
+		if hc.Config == nil {
+			hc.Config = &store.HarnessConfigData{}
+		}
+		hc.Config.NoAuthBehavior = hcDir.Config.NoAuthConfig.Behavior
+	}
 }
 
 func harnessConfigToRecord(hc *store.HarnessConfig) *ResourceRecord {

--- a/pkg/hubclient/types.go
+++ b/pkg/hubclient/types.go
@@ -551,12 +551,16 @@ type HarnessConfig struct {
 
 // HarnessConfigData holds harness-specific configuration.
 type HarnessConfigData struct {
-	Harness          string            `json:"harness,omitempty"`
-	Image            string            `json:"image,omitempty"`
-	User             string            `json:"user,omitempty"`
-	Model            string            `json:"model,omitempty"`
-	Args             []string          `json:"args,omitempty"`
-	Env              map[string]string `json:"env,omitempty"`
-	AuthSelectedType string            `json:"authSelectedType,omitempty"`
-	ModelAliases     map[string]string `json:"modelAliases,omitempty"`
+	Harness                 string            `json:"harness,omitempty"`
+	Image                   string            `json:"image,omitempty"`
+	User                    string            `json:"user,omitempty"`
+	Model                   string            `json:"model,omitempty"`
+	Args                    []string          `json:"args,omitempty"`
+	Env                     map[string]string `json:"env,omitempty"`
+	AuthSelectedType        string            `json:"authSelectedType,omitempty"`
+	ModelAliases            map[string]string `json:"modelAliases,omitempty"`
+	ThinkingBudgetMap       map[string]int    `json:"thinkingBudgetMap,omitempty"`
+	ThinkingBudgetFlag      string            `json:"thinkingBudgetFlag,omitempty"`
+	ThinkingBudgetConfigKey string            `json:"thinkingBudgetConfigKey,omitempty"`
+	NoAuthBehavior          string            `json:"noAuthBehavior,omitempty"`
 }

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -589,15 +589,19 @@ type HarnessConfig struct {
 
 // HarnessConfigData holds the harness-specific configuration details.
 type HarnessConfigData struct {
-	Harness          string               `json:"harness,omitempty"`
-	Image            string               `json:"image,omitempty"`
-	User             string               `json:"user,omitempty"`
-	Model            string               `json:"model,omitempty"`
-	Args             []string             `json:"args,omitempty"`
-	Env              map[string]string    `json:"env,omitempty"`
-	AuthSelectedType string               `json:"authSelectedType,omitempty"`
-	Secrets          []api.RequiredSecret `json:"secrets,omitempty"`
-	ModelAliases     map[string]string    `json:"modelAliases,omitempty"`
+	Harness                 string               `json:"harness,omitempty"`
+	Image                   string               `json:"image,omitempty"`
+	User                    string               `json:"user,omitempty"`
+	Model                   string               `json:"model,omitempty"`
+	Args                    []string             `json:"args,omitempty"`
+	Env                     map[string]string    `json:"env,omitempty"`
+	AuthSelectedType        string               `json:"authSelectedType,omitempty"`
+	Secrets                 []api.RequiredSecret `json:"secrets,omitempty"`
+	ModelAliases            map[string]string    `json:"modelAliases,omitempty"`
+	ThinkingBudgetMap       map[string]int       `json:"thinkingBudgetMap,omitempty"`
+	ThinkingBudgetFlag      string               `json:"thinkingBudgetFlag,omitempty"`
+	ThinkingBudgetConfigKey string               `json:"thinkingBudgetConfigKey,omitempty"`
+	NoAuthBehavior          string               `json:"noAuthBehavior,omitempty"`
 }
 
 // HarnessConfigStatus constants


### PR DESCRIPTION
## Summary

Fixes the no-auth auto-fallback flow so it works correctly when the hub validates agent creation before dispatch. Previously, the fallback logic in pkg/agent/run.go (local runner) never had a chance to execute because the hub's pre-dispatch validation would reject the agent with "required env vars missing" (e.g. CODEX_API_KEY).

**Root cause**: pkg/hub/handlers_agent_create_helpers.go (populateAgentConfig) only set NoAuth=true when req.NoAuth was explicitly true or HarnessAuth=="none". It had no logic to detect: auth=auto + no credentials found + harness has no_auth.behavior=drop-to-shell.

**Fix**: Before dispatch, when auth mode is auto and required credentials are absent, check if the harness config has no_auth.behavior=drop-to-shell. If so, set NoAuth=true and HarnessAuth="none" in the AppliedConfig, allowing the broker to start the agent in no-auth mode.

## Test plan

- [ ] go build ./... passes
- [ ] Codex agent with no CODEX_API_KEY → starts in no-auth mode (not rejected with 422)
- [ ] Agent with explicit HarnessAuth set → fallback does not fire
- [ ] Harness without no_auth → still returns 422 when credentials missing
