### PR TITLE
feat: add Slack integration management to chat admin UI

### DIFF
--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -33,6 +33,11 @@ const (
 	SecretDiscordBotToken  = "DISCORD_BOT_TOKEN"
 	SecretDiscordPublicKey = "DISCORD_PUBLIC_KEY"
 
+	// Slack
+	SecretSlackBotToken      = "SLACK_BOT_TOKEN"
+	SecretSlackAppToken      = "SLACK_APP_TOKEN"
+	SecretSlackSigningSecret = "SLACK_SIGNING_SECRET"
+
 	// Google Chat
 	SecretGChatSigningKey = "GCHAT_SIGNING_KEY"
 )
@@ -147,6 +152,11 @@ var PluginSecretKeyMap = map[string][]IntegrationSecretMapping{
 		{SecretDiscordBotToken, "bot_token"},
 		{SecretDiscordPublicKey, "public_key"},
 	},
+	"slack": {
+		{SecretSlackBotToken, "bot_token"},
+		{SecretSlackAppToken, "app_token"},
+		{SecretSlackSigningSecret, "signing_secret"},
+	},
 	"chat-app": {
 		{SecretGChatSigningKey, "signing_key"},
 	},
@@ -230,6 +240,11 @@ func CreatePluginConfigFile(pluginName, configFilePath string) error {
 	switch pluginName {
 	case "discord":
 		content += "application_id: \"\"\n"
+	case "slack":
+		content += "socket_mode: \"false\"\n"
+		content += "listen_address: \":3000\"\n"
+		content += "db_path: \"~/.scion/scion-slack.db\"\n"
+		content += "agent_cache_ttl: \"5m\"\n"
 	}
 
 	return os.WriteFile(resolved, []byte(content), 0600)
@@ -258,6 +273,7 @@ func LoadPluginConfigFile(configFile string, inlineConfig map[string]string) (ma
 	for _, secretKey := range []string{
 		SecretTelegramBotToken, SecretTelegramWebhookKey,
 		SecretDiscordBotToken, SecretDiscordPublicKey,
+		SecretSlackBotToken, SecretSlackAppToken, SecretSlackSigningSecret,
 		SecretGChatSigningKey,
 	} {
 		delete(fileConfig, strings.ToLower(secretKey))

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -89,7 +89,7 @@ type AvailableIntegration struct {
 }
 
 // knownPlugins is the list of plugins that can be discovered for installation.
-var knownPlugins = []string{"telegram", "discord"}
+var knownPlugins = []string{"telegram", "discord", "slack"}
 
 var knownPluginSet = func() map[string]bool {
 	s := make(map[string]bool, len(knownPlugins))
@@ -565,6 +565,8 @@ func resolvePlatform(name string) string {
 		return "telegram"
 	case "discord":
 		return "discord"
+	case "slack":
+		return "slack"
 	case "chat-app":
 		return "gchat"
 	default:

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -567,6 +567,7 @@ func TestResolvePlatform(t *testing.T) {
 	}{
 		{"telegram", "telegram"},
 		{"discord", "discord"},
+		{"slack", "slack"},
 		{"chat-app", "gchat"},
 		{"custom", "custom"},
 	}
@@ -610,6 +611,50 @@ func TestFilterSensitiveConfig(t *testing.T) {
 	}
 	if filtered["db_path"] != "/var/lib/tg.db" {
 		t.Errorf("expected db_path preserved, got %s", filtered["db_path"])
+	}
+}
+
+func TestFilterSensitiveConfig_Slack(t *testing.T) {
+	cfg := map[string]string{
+		"socket_mode":     "true",
+		"listen_address":  ":3000",
+		"db_path":         "~/.scion/scion-slack.db",
+		"agent_cache_ttl": "5m",
+		"bot_token":       "xoxb-secret",
+		"app_token":       "xapp-secret",
+		"signing_secret":  "secret-signing",
+		"hub_url":         "https://hub.example.com",
+		"config_file":     "/etc/slack.yaml",
+	}
+
+	filtered := filterSensitiveConfig("slack", cfg)
+
+	if _, ok := filtered["bot_token"]; ok {
+		t.Error("bot_token should be filtered")
+	}
+	if _, ok := filtered["app_token"]; ok {
+		t.Error("app_token should be filtered")
+	}
+	if _, ok := filtered["signing_secret"]; ok {
+		t.Error("signing_secret should be filtered")
+	}
+	if _, ok := filtered["hub_url"]; ok {
+		t.Error("hub_url should be filtered")
+	}
+	if _, ok := filtered["config_file"]; ok {
+		t.Error("config_file should be filtered")
+	}
+	if filtered["socket_mode"] != "true" {
+		t.Errorf("expected socket_mode true, got %s", filtered["socket_mode"])
+	}
+	if filtered["listen_address"] != ":3000" {
+		t.Errorf("expected listen_address :3000, got %s", filtered["listen_address"])
+	}
+	if filtered["db_path"] != "~/.scion/scion-slack.db" {
+		t.Errorf("expected db_path preserved, got %s", filtered["db_path"])
+	}
+	if filtered["agent_cache_ttl"] != "5m" {
+		t.Errorf("expected agent_cache_ttl 5m, got %s", filtered["agent_cache_ttl"])
 	}
 }
 
@@ -837,6 +882,45 @@ func TestListAvailableIntegrations_WithSource(t *testing.T) {
 	}
 	if result[0].Name != "telegram" {
 		t.Errorf("expected telegram, got %s", result[0].Name)
+	}
+}
+
+func TestListAvailableIntegrations_IncludesSlack(t *testing.T) {
+	repoDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoDir, "extras", "scion-slack"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := newMockIntegrationManager()
+
+	srv := &Server{}
+	srv.config.MaintenanceConfig.RepoPath = repoDir
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/available", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var result []AvailableIntegration
+	if err := json.NewDecoder(rr.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	found := false
+	for _, a := range result {
+		if a.Name == "slack" && a.Platform == "slack" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected slack in available integrations, got %v", result)
 	}
 }
 

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -53,6 +53,40 @@ interface AvailableIntegration {
   platform: string;
 }
 
+interface PlatformFieldDef {
+  key: string;
+  label: string;
+  description: string;
+  defaultValue: string;
+}
+
+function resolvePlatform(name: string): string {
+  switch (name) {
+    case 'telegram': return 'telegram';
+    case 'discord': return 'discord';
+    case 'slack': return 'slack';
+    case 'chat-app': return 'gchat';
+    default: return name;
+  }
+}
+
+const PLATFORM_FIELDS: Record<string, PlatformFieldDef[]> = {
+  telegram: [
+    { key: 'inbound_mode', label: 'Inbound Mode', description: 'How Telegram delivers updates (poll or webhook)', defaultValue: 'poll' },
+    { key: 'webhook_listen', label: 'Webhook Listen', description: 'HTTP listen address for webhook mode', defaultValue: ':9094' },
+    { key: 'db_path', label: 'Database Path', description: 'Path to SQLite database', defaultValue: '~/.scion/scion-telegram.db' },
+  ],
+  discord: [
+    { key: 'application_id', label: 'Application ID', description: 'Discord application ID for slash commands', defaultValue: '' },
+  ],
+  slack: [
+    { key: 'socket_mode', label: 'Socket Mode', description: 'Use Slack Socket Mode instead of HTTP webhooks (no public URL needed)', defaultValue: 'false' },
+    { key: 'listen_address', label: 'Listen Address', description: 'HTTP listen address (HTTP mode only)', defaultValue: ':3000' },
+    { key: 'db_path', label: 'Database Path', description: 'Path to SQLite database', defaultValue: '~/.scion/scion-slack.db' },
+    { key: 'agent_cache_ttl', label: 'Agent Cache TTL', description: 'How long to cache agent info', defaultValue: '5m' },
+  ],
+};
+
 @customElement('scion-page-admin-integrations')
 export class ScionPageAdminIntegrations extends LitElement {
   @state() private loading = true;
@@ -720,8 +754,13 @@ export class ScionPageAdminIntegrations extends LitElement {
   }
 
   private renderConfigSection(d: IntegrationDetail) {
-    const keys = Object.keys(d.settings || {});
-    if (keys.length === 0) {
+    const platform = resolvePlatform(d.name);
+    const fieldDefs = PLATFORM_FIELDS[platform] || [];
+    const definedKeys = new Set(fieldDefs.map((f) => f.key));
+    const extraKeys = Object.keys(d.settings || {}).filter((k) => !definedKeys.has(k));
+    const hasFields = fieldDefs.length > 0 || extraKeys.length > 0;
+
+    if (!hasFields && Object.keys(d.settings || {}).length === 0) {
       return html`
         <div class="section">
           <h3 class="section-title">Configuration</h3>
@@ -734,7 +773,25 @@ export class ScionPageAdminIntegrations extends LitElement {
       <div class="section">
         <h3 class="section-title">Configuration</h3>
         <div class="form-grid">
-          ${keys.map(
+          ${fieldDefs.map(
+            (field) => html`
+              <div class="form-field">
+                <label>${field.label}</label>
+                <sl-input
+                  value=${this.editedSettings[field.key] ?? field.defaultValue}
+                  placeholder=${field.defaultValue}
+                  @sl-change=${(e: Event) => {
+                    this.editedSettings = {
+                      ...this.editedSettings,
+                      [field.key]: (e.target as HTMLInputElement).value,
+                    };
+                  }}
+                ></sl-input>
+                <span class="hint">${field.description}</span>
+              </div>
+            `
+          )}
+          ${extraKeys.map(
             (key) => html`
               <div class="form-field">
                 <label>${key}</label>
@@ -842,6 +899,8 @@ export class ScionPageAdminIntegrations extends LitElement {
         return 'Telegram';
       case 'discord':
         return 'Discord';
+      case 'slack':
+        return 'Slack';
       case 'gchat':
         return 'Google Chat';
       default:

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -417,7 +417,11 @@ export class ScionPageAdminIntegrations extends LitElement {
         return;
       }
       this.detail = (await res.json()) as IntegrationDetail;
-      this.editedSettings = { ...(this.detail.settings || {}) };
+      const knownFields = PLATFORM_FIELDS[this.detail.platform] ?? [];
+      this.editedSettings = {
+        ...Object.fromEntries(knownFields.map((f) => [f.key, f.defaultValue])),
+        ...(this.detail.settings || {}),
+      };
       this.editedSecrets = {};
     } catch {
       this.error = 'Failed to connect to server';
@@ -778,7 +782,7 @@ export class ScionPageAdminIntegrations extends LitElement {
               <div class="form-field">
                 <label>${field.label}</label>
                 <sl-input
-                  value=${this.editedSettings[field.key] ?? field.defaultValue}
+                  .value=${this.editedSettings[field.key] ?? field.defaultValue}
                   placeholder=${field.defaultValue}
                   @sl-change=${(e: Event) => {
                     this.editedSettings = {
@@ -796,7 +800,7 @@ export class ScionPageAdminIntegrations extends LitElement {
               <div class="form-field">
                 <label>${key}</label>
                 <sl-input
-                  value=${this.editedSettings[key] ?? ''}
+                  .value=${this.editedSettings[key] ?? ''}
                   @sl-change=${(e: Event) => {
                     this.editedSettings = {
                       ...this.editedSettings,
@@ -832,7 +836,7 @@ export class ScionPageAdminIntegrations extends LitElement {
                 class="secret-input"
                 type="password"
                 placeholder=${d.has_secrets[key] ? 'Enter new value to update' : 'Enter value'}
-                value=${this.editedSecrets[key] ?? ''}
+                .value=${this.editedSecrets[key] ?? ''}
                 @sl-change=${(e: Event) => {
                   this.editedSecrets = {
                     ...this.editedSecrets,

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -557,7 +557,7 @@ export class ScionPageAdminIntegrations extends LitElement {
         <h1>Integrations</h1>
       </div>
       <p class="header-description">
-        Manage chat integrations — Telegram, Discord, and Google Chat plugins connected to this
+        Manage chat integrations — Telegram, Discord, Google Chat, and Slack plugins connected to this
         hub.
       </p>
 


### PR DESCRIPTION
Adds Slack to the chat integration admin system (issue #365).

- SLACK_BOT_TOKEN, SLACK_APP_TOKEN, SLACK_SIGNING_SECRET in secret backend
- Platform fields: socket_mode, listen_address, db_path, agent_cache_ttl
- Install allowlist and source path (extras/scion-slack/)
- Secret filtering wired to existing mechanism
- 3 new tests