### PR TITLE
improve bash header lines and avoid picking up old bash versions

### DIFF
--- a/image-build/scripts/build-images.sh
+++ b/image-build/scripts/build-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Small fix to improve safety and resilience of bash script, this is my standard header.

On my mac, it was picking up bash v3 instead of the one homebrew installs (v5) and then failing on the `"${build_arg_flags[@]}"` when trying to docker build `core-base` which has no args.

This will also generally catch more errors earlier.