### PR TITLE
fix: restore missing StageCaptureAuthAssets call in provision.go

### DIFF
--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -1176,7 +1176,8 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 	// into the harness bundle so they are available at a known path in the
 	// container. Container-script harnesses stage these during their own
 	// Provision(); this path handles non-container-script fallbacks.
-if _, isContainerScript := h.(*harness.ContainerScriptHarness); !isContainerScript && hcDir != nil {
+	if _, isContainerScript := h.(*harness.ContainerScriptHarness); !isContainerScript && hcDir != nil {
+		if err := harness.StageCaptureAuthAssets(agentHome, hcDir.Path, hcDir.Config.Auth); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: capture-auth asset staging failed: %v\n", err)
 		}
 	}


### PR DESCRIPTION
## Problem

Commit `12077c5b` (harness: remove dead builtin harness system) accidentally deleted the `if err := harness.StageCaptureAuthAssets(...)` call, leaving only a bare `fmt.Fprintf` referencing an undefined `err` variable with broken indentation.

This causes a Go build failure:

```
#21 [builder 9/9] RUN BUILD_TIME="${BUILD_TIME:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}" && \
    SCION_PKG="github.com/GoogleCloudPlatform/scion/pkg/version" && \
    SCIONTOOL_PKG="github.com/GoogleCloudPlatform/scion/cmd/sciontool/commands" && \
    SCION_LDFLAGS="-s -w -X ${SCION_PKG}.BuildTime=${BUILD_TIME}" && \
    SCIONTOOL_LDFLAGS="-s -w -X ${SCIONTOOL_PKG}.BuildTime=${BUILD_TIME}" && \
    if [ -n "${GIT_COMMIT}" ]; then \
        SCION_LDFLAGS="${SCION_LDFLAGS} -X ${SCION_PKG}.Commit=${GIT_COMMIT}"; \
        SCIONTOOL_LDFLAGS="${SCIONTOOL_LDFLAGS} -X ${SCIONTOOL_PKG}.Commit=${GIT_COMMIT}"; \
    fi && \
    go build -buildvcs=false -tags no_embed_web -ldflags="${SCION_LDFLAGS}" -o /usr/local/bin/scion ./cmd/scion/ && \
    go build -buildvcs=false -tags no_embed_web -ldflags="${SCIONTOOL_LDFLAGS}" -o /usr/local/bin/sciontool ./cmd/sciontool/
21.49 # github.com/GoogleCloudPlatform/scion/pkg/agent
21.49 pkg/agent/provision.go:1185:2: syntax error: non-declaration statement outside function body
```

## Fix

Restore the missing `if err := harness.StageCaptureAuthAssets(...)` call in `pkg/agent/provision.go:1179`.
