### PR TITLE
hub: honor skipped_when_gcp_service_account_assigned in pre-dispatch credential check

### DIFF
--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/harness"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
@@ -240,7 +241,7 @@ func (s *Server) populateAgentConfig(ctx context.Context, agent *store.Agent, pr
 				agent.AppliedConfig.HarnessAuth == "" &&
 				hc.Config != nil &&
 				hc.Config.NoAuthBehavior == "drop-to-shell" {
-				hasCreds, err := s.hasRequiredAuthCredentials(ctx, agent, hc.Harness)
+				hasCreds, err := s.hasRequiredAuthCredentials(ctx, agent, hc.Harness, hc.Config.AuthMeta)
 				if err != nil {
 					s.agentLifecycleLog.Error("Failed to check auth credentials for fallback", "agent_id", agent.ID, "error", err)
 				} else if !hasCreds {
@@ -763,11 +764,16 @@ func (s *Server) findBrokerByIDOrSlug(ctx context.Context, identifier string) (*
 }
 
 // hasRequiredAuthCredentials checks whether the required auth environment
-// variables for the given harness type are available in the agent's env,
-// or in the hub's env/secret stores (user and project scopes).
-func (s *Server) hasRequiredAuthCredentials(ctx context.Context, agent *store.Agent, harnessType string) (bool, error) {
+// variables and file secrets for the given harness type are available in the
+// agent's env, or in the hub's env/secret stores (user and project scopes).
+//
+// When authMeta is non-nil (config-driven harness), file requirements from
+// required_files are also evaluated. Files marked with
+// SkippedWhenGCPServiceAccountAssigned are treated as satisfied when the
+// agent's project has at least one verified GCP service account.
+func (s *Server) hasRequiredAuthCredentials(ctx context.Context, agent *store.Agent, harnessType string, authMeta *config.HarnessAuthMetadata) (bool, error) {
 	keyGroups := harness.RequiredAuthEnvKeys(harnessType, agent.AppliedConfig.HarnessAuth)
-	if len(keyGroups) == 0 {
+	if len(keyGroups) == 0 && authMeta == nil {
 		return true, nil
 	}
 	for _, group := range keyGroups {
@@ -779,7 +785,49 @@ func (s *Server) hasRequiredAuthCredentials(ctx context.Context, agent *store.Ag
 			return false, nil
 		}
 	}
+
+	// Check config-driven file requirements (e.g. gcloud-adc for vertex-ai).
+	if authMeta != nil {
+		gcpSAAssigned, err := s.projectHasVerifiedGCPSA(ctx, agent.ProjectID)
+		if err != nil {
+			return false, err
+		}
+		fileSecrets := harness.RequiredAuthSecretsFromConfig(authMeta, agent.AppliedConfig.HarnessAuth, gcpSAAssigned)
+		for _, fs := range fileSecrets {
+			keys := append([]string{fs.Key}, fs.AlternativeEnvKeys...)
+			found, err := s.hasAnyKey(ctx, agent, keys)
+			if err != nil {
+				return false, err
+			}
+			if !found {
+				return false, nil
+			}
+		}
+	}
+
 	return true, nil
+}
+
+// projectHasVerifiedGCPSA returns true if the project has at least one
+// verified GCP service account, meaning the GCE metadata server can provide
+// application default credentials at runtime.
+func (s *Server) projectHasVerifiedGCPSA(ctx context.Context, projectID string) (bool, error) {
+	if projectID == "" {
+		return false, nil
+	}
+	sas, err := s.store.ListGCPServiceAccounts(ctx, store.GCPServiceAccountFilter{
+		Scope:   "project",
+		ScopeID: projectID,
+	})
+	if err != nil {
+		return false, err
+	}
+	for _, sa := range sas {
+		if sa.Verified {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // hasAnyKey returns true if at least one of the keys is present in the

--- a/pkg/hub/resource_store.go
+++ b/pkg/hub/resource_store.go
@@ -385,6 +385,7 @@ func (p *harnessConfigPersistence) Create(ctx context.Context, rec *ResourceReco
 		Visibility:    rec.Visibility,
 	}
 	extractNoAuthBehavior(hc, dir)
+	extractAuthMeta(hc, dir)
 	rec.Harness = p.harness
 	p.model = hc
 	return p.s.store.CreateHarnessConfig(ctx, hc)
@@ -401,6 +402,7 @@ func (p *harnessConfigPersistence) Update(ctx context.Context, rec *ResourceReco
 		hc.SourceURL = rec.SourceURL
 	}
 	extractNoAuthBehavior(hc, dir)
+	extractAuthMeta(hc, dir)
 	return p.s.store.UpdateHarnessConfig(ctx, hc)
 }
 
@@ -460,6 +462,28 @@ func extractNoAuthBehavior(hc *store.HarnessConfig, dir string) {
 		hc.Config.NoAuthBehavior = hcDir.Config.NoAuthConfig.Behavior
 	} else if hc.Config != nil {
 		hc.Config.NoAuthBehavior = ""
+	}
+}
+
+// extractAuthMeta loads config.yaml from dir and stamps the declarative
+// auth metadata onto the HarnessConfig's Config data so the hub can
+// evaluate required_files (including SkippedWhenGCPServiceAccountAssigned)
+// at pre-dispatch time.
+func extractAuthMeta(hc *store.HarnessConfig, dir string) {
+	if dir == "" {
+		return
+	}
+	hcDir, err := config.LoadHarnessConfigDir(dir)
+	if err != nil {
+		return
+	}
+	if hcDir.Config.Auth != nil && len(hcDir.Config.Auth.Types) > 0 {
+		if hc.Config == nil {
+			hc.Config = &store.HarnessConfigData{}
+		}
+		hc.Config.AuthMeta = hcDir.Config.Auth
+	} else if hc.Config != nil {
+		hc.Config.AuthMeta = nil
 	}
 }
 

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
 )
 
 // Agent represents an agent record in the Hub database.
@@ -602,6 +603,7 @@ type HarnessConfigData struct {
 	ThinkingBudgetFlag      string               `json:"thinkingBudgetFlag,omitempty"`
 	ThinkingBudgetConfigKey string               `json:"thinkingBudgetConfigKey,omitempty"`
 	NoAuthBehavior          string               `json:"noAuthBehavior,omitempty"`
+	AuthMeta                *config.HarnessAuthMetadata `json:"authMeta,omitempty"`
 }
 
 // HarnessConfigStatus constants


### PR DESCRIPTION
## Summary

Fixes claude agents falling back to no-auth on deployments where the project has a verified GCP service account. The hub's pre-dispatch credential check evaluated required_files literally, seeing gcloud-adc as required=true and blocking vertex-ai auth — even though the harness config specifies skipped_when_gcp_service_account_assigned: true.

**Fix**: Added projectHasVerifiedGCPSA() helper; modified hasRequiredAuthCredentials() to skip required_files with skipped_when_gcp_service_account_assigned=true when the project has a verified GCP SA. CODEX_AUTH and other non-flagged file requirements are unaffected.

## Test plan

- [ ] Claude agent in project with verified GCP SA → vertex-ai auth
- [ ] Claude agent without GCP SA → no-auth fallback (unchanged)
- [ ] Codex with CODEX_AUTH → auth-file (unchanged)
