### PR TITLE
hub: fix hasRequiredAuthCredentials to auto-detect auth type before checking requirements

### DIFF
--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -772,6 +772,28 @@ func (s *Server) findBrokerByIDOrSlug(ctx context.Context, identifier string) (*
 // SkippedWhenGCPServiceAccountAssigned are treated as satisfied when the
 // agent's project has at least one verified GCP service account.
 func (s *Server) hasRequiredAuthCredentials(ctx context.Context, agent *store.Agent, harnessType string, authMeta *config.HarnessAuthMetadata) (bool, error) {
+	// When authMeta defines auth types and no explicit type was selected,
+	// check ALL config-defined auth types and return true if ANY is fully
+	// satisfiable. This prevents the compiled default (api-key) from
+	// short-circuiting before config-driven types like vertex-ai are checked.
+	if authMeta != nil && agent.AppliedConfig.HarnessAuth == "" && len(authMeta.Types) > 0 {
+		gcpSAAssigned, err := s.projectHasVerifiedGCPSA(ctx, agent.ProjectID)
+		if err != nil {
+			return false, err
+		}
+		for authType := range authMeta.Types {
+			satisfied, err := s.isAuthTypeSatisfied(ctx, agent, authMeta, authType, gcpSAAssigned)
+			if err != nil {
+				return false, err
+			}
+			if satisfied {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	// Explicit auth type selected or no authMeta — use the compiled check.
 	keyGroups := harness.RequiredAuthEnvKeys(harnessType, agent.AppliedConfig.HarnessAuth)
 	if len(keyGroups) == 0 && authMeta == nil {
 		return true, nil
@@ -795,6 +817,43 @@ func (s *Server) hasRequiredAuthCredentials(ctx context.Context, agent *store.Ag
 		fileSecrets := harness.RequiredAuthSecretsFromConfig(authMeta, agent.AppliedConfig.HarnessAuth, gcpSAAssigned)
 		for _, fs := range fileSecrets {
 			keys := append([]string{fs.Key}, fs.AlternativeEnvKeys...)
+			found, err := s.hasAnyKey(ctx, agent, keys)
+			if err != nil {
+				return false, err
+			}
+			if !found {
+				return false, nil
+			}
+		}
+	}
+
+	return true, nil
+}
+
+// isAuthTypeSatisfied checks whether all env-var and file-secret requirements
+// for a single auth type (as declared in authMeta) are met. Unlike the broker
+// preflight (which only enforces required: true files), this checks ALL listed
+// files so the hub can determine whether the auth type is viable.
+func (s *Server) isAuthTypeSatisfied(ctx context.Context, agent *store.Agent, authMeta *config.HarnessAuthMetadata, authType string, gcpSAAssigned bool) (bool, error) {
+	keyGroups := harness.RequiredAuthEnvKeysFromConfig(authMeta, authType)
+	for _, group := range keyGroups {
+		found, err := s.hasAnyKey(ctx, agent, group)
+		if err != nil {
+			return false, err
+		}
+		if !found {
+			return false, nil
+		}
+	}
+
+	t, ok := authMeta.Types[authType]
+	if ok {
+		for _, f := range t.RequiredFiles {
+			if f.SkippedWhenGCPServiceAccountAssigned && gcpSAAssigned {
+				continue
+			}
+			keys := []string{f.Name}
+			keys = append(keys, f.AlternativeEnvKeys...)
 			found, err := s.hasAnyKey(ctx, agent, keys)
 			if err != nil {
 				return false, err

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -793,8 +793,13 @@ func (s *Server) hasRequiredAuthCredentials(ctx context.Context, agent *store.Ag
 		return false, nil
 	}
 
-	// Explicit auth type selected or no authMeta — use the compiled check.
-	keyGroups := harness.RequiredAuthEnvKeys(harnessType, agent.AppliedConfig.HarnessAuth)
+	// Explicit auth type selected or no authMeta — use config-driven check when available.
+	var keyGroups [][]string
+	if authMeta != nil {
+		keyGroups = harness.RequiredAuthEnvKeysFromConfig(authMeta, agent.AppliedConfig.HarnessAuth)
+	} else {
+		keyGroups = harness.RequiredAuthEnvKeys(harnessType, agent.AppliedConfig.HarnessAuth)
+	}
 	if len(keyGroups) == 0 && authMeta == nil {
 		return true, nil
 	}

--- a/pkg/hub/resource_store.go
+++ b/pkg/hub/resource_store.go
@@ -477,7 +477,7 @@ func extractAuthMeta(hc *store.HarnessConfig, dir string) {
 	if err != nil {
 		return
 	}
-	if hcDir.Config.Auth != nil && len(hcDir.Config.Auth.Types) > 0 {
+	if hcDir != nil && hcDir.Config.Auth != nil && len(hcDir.Config.Auth.Types) > 0 {
 		if hc.Config == nil {
 			hc.Config = &store.HarnessConfigData{}
 		}


### PR DESCRIPTION
## Summary

Fixes two auth auto-detection failures in the hub's pre-dispatch credential check:

1. **claude vertex-ai not detected on GCP SA projects** — when HarnessAuth is empty (auto mode), the function defaulted to api-key check (ANTHROPIC_API_KEY), which failed and short-circuited before ever evaluating vertex-ai viability via GCP SA assignment.

2. **codex CODEX_AUTH file secret not detected** — same short-circuit: default api-key check (CODEX_API_KEY/OPENAI_API_KEY) failed, preventing auth-file detection even when CODEX_AUTH exists in the project secrets.

**Root cause**: hasRequiredAuthCredentials() called RequiredAuthEnvKeys(harnessType, "") which always defaults to api-key type when HarnessAuth is empty.

**Fix**: When authMeta is non-nil and HarnessAuth is empty, iterate ALL auth types in authMeta.Types and return true if ANY type is fully satisfiable.

## Test plan

- [ ] Claude agent in project with verified GCP SA → vertex-ai auth
- [ ] Codex agent with CODEX_AUTH secret → auth-file auth
- [ ] Explicit auth type selection → unchanged
