### PR TITLE
agent: embed platform skills and inject into all agents at provisioning time

### DIFF
--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -33,6 +33,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/GoogleCloudPlatform/scion/pkg/provision"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
+	"github.com/GoogleCloudPlatform/scion/resources"
 )
 
 func DeleteAgentFiles(agentName string, projectPath string, removeBranch bool) (bool, error) {
@@ -765,12 +766,19 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 	}
 	util.Debugf("provision: home/skills copy completed in %s", time.Since(homeCopyStart))
 
-	// Step 3b: Auto-inject workspace skills from /workspace/skills/
+	// Step 3a2: Inject platform skills from embedded resources
 	hubEnabled := (settings != nil && settings.IsHubEnabled()) || api.IsBrokerModeFromContext(ctx)
 	injCtx := workspaceSkillsInjectionContext{
 		IsGit:      isGit,
 		HubEnabled: hubEnabled,
 	}
+	if skillsDir != "" {
+		if err := injectPlatformSkills(resources.PlatformSkillsFS(), agentHome, skillsDir, injCtx); err != nil {
+			return "", "", nil, fmt.Errorf("failed to inject platform skills: %w", err)
+		}
+	}
+
+	// Step 3b: Auto-inject workspace skills from /workspace/skills/
 	wsInjectedContent, err := injectWorkspaceSkills(projectDir, agentHome, skillsDir, injCtx, nil)
 	if err != nil {
 		return "", "", nil, fmt.Errorf("failed to inject workspace skills: %w", err)
@@ -1241,6 +1249,78 @@ func shouldInjectSkill(fm skillFrontmatter, injCtx workspaceSkillsInjectionConte
 		util.Debugf("provision: unknown inject_when=%q for skill %q, skipping", fm.InjectWhen, fm.Name)
 		return false
 	}
+}
+
+// injectPlatformSkills copies platform skills from the embedded filesystem
+// into the agent's skills directory. Skills with inject_when conditions are
+// evaluated against the injection context (e.g. git_workspace skills are
+// only injected when isGit is true). Template skills take precedence: if a
+// template already installed a skill with the same directory name, the
+// platform skill is skipped.
+func injectPlatformSkills(
+	skillsFS fs.FS,
+	agentHome string,
+	skillsDir string,
+	injCtx workspaceSkillsInjectionContext,
+) error {
+	entries, err := fs.ReadDir(skillsFS, ".")
+	if err != nil {
+		return fmt.Errorf("failed to read platform skills FS: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		skillName := entry.Name()
+
+		skillMDData, err := fs.ReadFile(skillsFS, skillName+"/SKILL.md")
+		if err != nil {
+			util.Debugf("provision: platform skill %q has no SKILL.md, skipping", skillName)
+			continue
+		}
+
+		fm := parseSkillFrontmatter(skillMDData)
+		if !shouldInjectSkill(fm, injCtx) {
+			util.Debugf("provision: skipping platform skill %q (inject_when=%q not satisfied)", skillName, fm.InjectWhen)
+			continue
+		}
+
+		skillDest := filepath.Join(agentHome, skillsDir, skillName)
+
+		// Template skills take precedence
+		if _, err := os.Stat(skillDest); err == nil {
+			util.Debugf("provision: platform skill %q skipped (template skill takes precedence)", skillName)
+			continue
+		}
+
+		// Walk the embedded skill directory and copy all files
+		skillRoot := skillName
+		if err := fs.WalkDir(skillsFS, skillRoot, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			rel, err := filepath.Rel(skillRoot, path)
+			if err != nil {
+				return err
+			}
+			target := filepath.Join(skillDest, rel)
+
+			if d.IsDir() {
+				return os.MkdirAll(target, 0755)
+			}
+			data, err := fs.ReadFile(skillsFS, path)
+			if err != nil {
+				return err
+			}
+			return os.WriteFile(target, data, 0644)
+		}); err != nil {
+			return fmt.Errorf("failed to copy platform skill %s: %w", skillName, err)
+		}
+		util.Debugf("provision: injected platform skill %q into %s", skillName, skillDest)
+	}
+
+	return nil
 }
 
 // injectWorkspaceSkills discovers skills in the workspace-level skills/

--- a/pkg/agent/provision_test.go
+++ b/pkg/agent/provision_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
@@ -2384,6 +2385,158 @@ func TestInjectWorkspaceSkills_FallbackComposition(t *testing.T) {
 
 		if !strings.Contains(string(result), "# Hub content") {
 			t.Errorf("expected hub skill content when hubEnabled=true")
+		}
+	})
+}
+
+func TestInjectPlatformSkills(t *testing.T) {
+	t.Run("unconditional skills are injected", func(t *testing.T) {
+		agentHome := t.TempDir()
+		skillsDir := ".claude/commands"
+
+		skillsFS := fstest.MapFS{
+			"my-skill/SKILL.md": &fstest.MapFile{
+				Data: []byte("---\nname: my-skill\ndescription: A test skill\n---\n\n# My Skill\n"),
+			},
+		}
+
+		injCtx := workspaceSkillsInjectionContext{IsGit: false, HubEnabled: false}
+		if err := injectPlatformSkills(skillsFS, agentHome, skillsDir, injCtx); err != nil {
+			t.Fatalf("injectPlatformSkills failed: %v", err)
+		}
+
+		dest := filepath.Join(agentHome, skillsDir, "my-skill", "SKILL.md")
+		if _, err := os.Stat(dest); os.IsNotExist(err) {
+			t.Errorf("expected platform skill to be copied to %s", dest)
+		}
+	})
+
+	t.Run("git_workspace skill injected when isGit=true", func(t *testing.T) {
+		agentHome := t.TempDir()
+		skillsDir := ".claude/commands"
+
+		skillsFS := fstest.MapFS{
+			"git-skill/SKILL.md": &fstest.MapFile{
+				Data: []byte("---\nname: git-skill\ninject_when: git_workspace\n---\n\n# Git\n"),
+			},
+		}
+
+		injCtx := workspaceSkillsInjectionContext{IsGit: true}
+		if err := injectPlatformSkills(skillsFS, agentHome, skillsDir, injCtx); err != nil {
+			t.Fatalf("injectPlatformSkills failed: %v", err)
+		}
+
+		dest := filepath.Join(agentHome, skillsDir, "git-skill", "SKILL.md")
+		if _, err := os.Stat(dest); os.IsNotExist(err) {
+			t.Errorf("expected git-skill to be injected when isGit=true")
+		}
+	})
+
+	t.Run("git_workspace skill skipped when isGit=false", func(t *testing.T) {
+		agentHome := t.TempDir()
+		skillsDir := ".claude/commands"
+
+		skillsFS := fstest.MapFS{
+			"git-skill/SKILL.md": &fstest.MapFile{
+				Data: []byte("---\nname: git-skill\ninject_when: git_workspace\n---\n\n# Git\n"),
+			},
+		}
+
+		injCtx := workspaceSkillsInjectionContext{IsGit: false}
+		if err := injectPlatformSkills(skillsFS, agentHome, skillsDir, injCtx); err != nil {
+			t.Fatalf("injectPlatformSkills failed: %v", err)
+		}
+
+		dest := filepath.Join(agentHome, skillsDir, "git-skill")
+		if _, err := os.Stat(dest); !os.IsNotExist(err) {
+			t.Errorf("expected git-skill to NOT be injected when isGit=false")
+		}
+	})
+
+	t.Run("template skill takes precedence over platform skill", func(t *testing.T) {
+		agentHome := t.TempDir()
+		skillsDir := ".claude/commands"
+
+		tplContent := "template version"
+		tplSkillDir := filepath.Join(agentHome, skillsDir, "conflict-skill")
+		if err := os.MkdirAll(tplSkillDir, 0755); err != nil {
+			t.Fatalf("failed to create template skill dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tplSkillDir, "SKILL.md"), []byte(tplContent), 0644); err != nil {
+			t.Fatalf("failed to write template skill: %v", err)
+		}
+
+		skillsFS := fstest.MapFS{
+			"conflict-skill/SKILL.md": &fstest.MapFile{
+				Data: []byte("---\nname: conflict-skill\n---\n\nplatform version"),
+			},
+		}
+
+		injCtx := workspaceSkillsInjectionContext{}
+		if err := injectPlatformSkills(skillsFS, agentHome, skillsDir, injCtx); err != nil {
+			t.Fatalf("injectPlatformSkills failed: %v", err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(tplSkillDir, "SKILL.md"))
+		if err != nil {
+			t.Fatalf("failed to read skill: %v", err)
+		}
+		if string(data) != tplContent {
+			t.Errorf("template skill was overwritten: got %q, want %q", string(data), tplContent)
+		}
+	})
+
+	t.Run("skill with scripts subdirectory is fully copied", func(t *testing.T) {
+		agentHome := t.TempDir()
+		skillsDir := ".claude/commands"
+
+		skillsFS := fstest.MapFS{
+			"scion/SKILL.md": &fstest.MapFile{
+				Data: []byte("---\nname: scion\n---\n\n# Scion\n"),
+			},
+			"scion/scripts/start-agent.sh": &fstest.MapFile{
+				Data: []byte("#!/bin/bash\necho start"),
+			},
+		}
+
+		injCtx := workspaceSkillsInjectionContext{}
+		if err := injectPlatformSkills(skillsFS, agentHome, skillsDir, injCtx); err != nil {
+			t.Fatalf("injectPlatformSkills failed: %v", err)
+		}
+
+		dest := filepath.Join(agentHome, skillsDir, "scion", "scripts", "start-agent.sh")
+		data, err := os.ReadFile(dest)
+		if err != nil {
+			t.Fatalf("expected script to be copied, got error: %v", err)
+		}
+		if !strings.Contains(string(data), "echo start") {
+			t.Errorf("script content mismatch: %q", string(data))
+		}
+	})
+
+	t.Run("multiple skills with mixed conditions", func(t *testing.T) {
+		agentHome := t.TempDir()
+		skillsDir := ".claude/commands"
+
+		skillsFS := fstest.MapFS{
+			"always-skill/SKILL.md": &fstest.MapFile{
+				Data: []byte("---\nname: always-skill\n---\n\n# Always\n"),
+			},
+			"git-only/SKILL.md": &fstest.MapFile{
+				Data: []byte("---\nname: git-only\ninject_when: git_workspace\n---\n\n# Git Only\n"),
+			},
+		}
+
+		injCtx := workspaceSkillsInjectionContext{IsGit: false}
+		if err := injectPlatformSkills(skillsFS, agentHome, skillsDir, injCtx); err != nil {
+			t.Fatalf("injectPlatformSkills failed: %v", err)
+		}
+
+		if _, err := os.Stat(filepath.Join(agentHome, skillsDir, "always-skill", "SKILL.md")); os.IsNotExist(err) {
+			t.Errorf("expected unconditional skill to be injected")
+		}
+		if _, err := os.Stat(filepath.Join(agentHome, skillsDir, "git-only")); !os.IsNotExist(err) {
+			t.Errorf("expected git-only skill to be skipped when isGit=false")
 		}
 	})
 }

--- a/resources/catalog.go
+++ b/resources/catalog.go
@@ -102,3 +102,14 @@ func BuiltinHarnessConfigs() []BundledResource {
 func BuiltinResources() []BundledResource {
 	return append(BuiltinTemplates(), BuiltinHarnessConfigs()...)
 }
+
+// PlatformSkillsFS returns the embedded filesystem containing platform skills.
+// Each top-level directory under platform_skills/ is a skill directory
+// containing at minimum a SKILL.md file.
+func PlatformSkillsFS() fs.FS {
+	sub, err := fs.Sub(platformSkillsFS, "platform_skills")
+	if err != nil {
+		panic(fmt.Sprintf("resources: sub platform_skills FS: %v", err))
+	}
+	return sub
+}

--- a/resources/embed.go
+++ b/resources/embed.go
@@ -18,3 +18,6 @@ import "embed"
 
 //go:embed all:templates/*
 var templatesFS embed.FS
+
+//go:embed all:platform_skills/*
+var platformSkillsFS embed.FS

--- a/resources/platform_skills/agent-status-signals/SKILL.md
+++ b/resources/platform_skills/agent-status-signals/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: agent-status-signals
+description: >-
+  Status signaling protocol for all Scion agents. Covers the three mandatory signals
+  (ask_user, blocked, task_completed) that keep the orchestration system informed of
+  agent state. Every agent template should reference this skill.
+---
+
+# Agent Status Signals
+
+Every Scion agent must signal its state to the orchestration system using `sciontool status`. These signals prevent false stall detection, enable notification routing, and keep users informed.
+
+## Waiting for Input
+
+Before asking a user or coordinator a question, signal that you are waiting:
+
+```bash
+sciontool status ask_user "<question>"
+```
+
+Then proceed to ask the question via `scion message`.
+
+## Blocked (Intentionally Waiting)
+
+When you are intentionally waiting for something — such as a child agent to complete, a scheduled event, or a user reply — signal that you are blocked:
+
+```bash
+sciontool status blocked "<reason>"
+```
+
+Example: `sciontool status blocked "Waiting for agent deploy-frontend to complete"`
+
+This prevents the system from falsely marking you as stalled. The status clears automatically when you resume work (e.g. when you receive a message or start a new task).
+
+**Important:** An agent that has completed its current work and is waiting for the next assignment must call `sciontool status blocked` — not go idle. Idle triggers stall detection; blocked tells the system it is intentionally waiting.
+
+## Completing Your Task
+
+Once you have completed your task, summarize and report back as you normally would, then signal completion:
+
+```bash
+sciontool status task_completed "<task title>"
+```
+
+Do not follow this with "What would you like to do now?" or similar — just stop.

--- a/resources/platform_skills/git-sandbox/SKILL.md
+++ b/resources/platform_skills/git-sandbox/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: git-sandbox
+description: >-
+  Git workflow protocol for agents in sandbox/worktree environments. Covers
+  local-only operations, worktree-aware branch management, and non-interactive
+  conflict resolution. Injected only for git-associated workspaces.
+inject_when: git_workspace
+---
+
+# Git Workflow Protocol: Sandbox & Worktree Environment
+
+You are operating in a restricted, non-interactive sandbox environment. Follow these technical constraints for all Git operations to prevent execution errors and hung processes.
+
+## 1. Local-Only Operations (No Network Access)
+
+- **Restriction:** The environment is air-gapped from `origin`. Commands like `git fetch`, `git pull`, or `git push` will fail.
+- **Directive:** Always assume the local `main` branch is the source of truth.
+- **Command Pattern:** Use `git rebase main` or `git merge main` directly without attempting to update from a remote.
+
+## 2. Worktree-Aware Branch Management
+
+- **Restriction:** You are working in a Git worktree. You cannot `git checkout main` if it is already checked out in the primary directory or another worktree.
+- **Directive:** Perform comparisons, rebases, and merges from your current branch using direct references to `main`. Do not attempt to switch branches to inspect code.
+- **Reference Patterns:**
+  - **Comparison:** `git diff main...HEAD` (to see changes in your branch).
+  - **File Inspection:** `git show main:path/to/file.ext` (to view content on main without switching).
+  - **Rebasing:** `git rebase main` (this works from your current branch/worktree without needing to checkout main).
+
+## 3. Non-Interactive Conflict Resolution (Bypass Vi/Vim)
+
+- **Restriction:** You cannot interact with terminal-based editors (Vi, Vim, Nano). Any command that triggers an editor will cause the process to hang.
+- **Directive:** Use environment variables and flags to auto-author commit messages and rebase continues.
+- **Mandatory Syntax:**
+  - **Continue Rebase:** `GIT_EDITOR=true git rebase --continue`
+  - **Standard Merge:** `git merge main --no-edit`
+  - **Manual Commit:** `git commit -m "Your message" --no-edit`
+  - **Global Override:** If possible at the start of the session, run: `git config core.editor true`
+
+## 4. Conflict Resolution Loop
+
+If a rebase or merge results in conflicts:
+
+1. Identify conflicted files via `git status`.
+2. Resolve conflicts in the source files.
+3. Stage changes: `git add <resolved-files>`.
+4. Finalize: `GIT_EDITOR=true git rebase --continue`.

--- a/resources/platform_skills/scion-cli-operations/SKILL.md
+++ b/resources/platform_skills/scion-cli-operations/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: scion-cli-operations
+description: >-
+  Operational constraints for Scion agents running in containerized sandboxes.
+  Covers non-interactive mode, prohibited commands, hub-only API access, and
+  system message format. Complements the scion CLI reference and messaging skills.
+---
+
+# Scion CLI Operating Constraints
+
+You are an autonomous Scion agent running inside a containerized sandbox. Your workspace is managed by the Scion orchestration system.
+
+## Core Rules (DO NOT VIOLATE)
+
+- **Non-Interactive Mode**: You MUST use the `--non-interactive` flag with the Scion CLI, ALWAYS. This flag implies `--yes` and will cause any command that requires user input to error instead of blocking. Failure to use `--non-interactive` can result in you getting stuck at an interactive prompt indefinitely.
+- **Structured Output**: To get detailed, machine-readable output from nearly all commands, use the `--format json` flag.
+- **Prohibited Commands**: DO NOT use the `sync` or `cdw` commands.
+- **Agent State**: Do not attempt to resume an agent unless you were the one who stopped it. An 'idle' agent may still be working.
+- **Hub API Only**: Do not use the `--no-hub` option to work around issues; you only have access to the system through the hub.
+- **Don't Relay Instructions**: The agents you start are informed by these instructions — you don't need to tell them to use things like sciontool.
+- **Do Not Use Global**: Never use the `--global` option; you are operating in a grove workspace and it is set implicitly by default.
+- **Do Not Interact with Settings or Login Commands**.
+
+## Recommended Commands
+
+- **Inspect an Agent**: `scion look <agent-id>` — inspect the recent output and current terminal-UI state of any running agent.
+- **Full CLI Details**: `scion --help` — for specific details on all hierarchical commands.
+- **Focused Usage**: Use the scion CLI as needed for your task. Do not pre-emptively explore `.scion` folders, read agent-template files, etc. — focus only on what you need.
+
+## System Message Format
+
+You may be sent messages via the system. These will include markers:
+
+```
+---BEGIN SCION MESSAGE---
+---END SCION MESSAGE---
+```
+
+They will contain information about the sender and may be instructions, or a notification about an agent you are interacting with (for example, it completed its task or needs input).

--- a/resources/platform_skills/scion-messaging/SKILL.md
+++ b/resources/platform_skills/scion-messaging/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: scion-messaging
+description: Teaches agents how to use the scion message command effectively. Use this for ANY agent type that needs to communicate with other agents or users. Covers recipient types, message timing, content best practices, and special message flags.
+---
+
+# Scion Messaging
+
+## Overview
+
+In a multi-agent orchestration environment, communication is the primary failure mode. Agent terminal output is invisible to everyone outside the container. The **only** way to communicate is via the `scion message` command. This skill codifies the patterns required for reliable, high-signal communication within the Scion ecosystem.
+
+## When to Use
+
+- When starting a task that requires coordination with other agents.
+- When you need to provide a status update or ask a question to a user.
+- When forwarding feedback or unblocking another agent.
+- When you need to send literal keystrokes to an agent's terminal.
+- When scheduling messages for the future.
+
+**When NOT to use:** For internal cognitive work or logging that doesn't need to be seen by others. Never use messaging for banter or repetitive, low-signal status updates.
+
+## Recipient Types
+
+Choosing the right recipient is critical to avoid spam and ensure the message reaches the intended target.
+
+- **`agent:<name>`**: Use this to message a specific agent by its name (e.g., `agent:tech-lead`).
+- **`user:<email>`**: Use this to message a human user directly (e.g., `user:preston@example.com`).
+- **`set[a,b,...]`**: Use this for group messaging to a specific list of agents/users (e.g., `set[tech-lead, editor]`).
+- **`coordinator`**: (Convention) Usually refers to the agent managing the project.
+
+**Anti-Pattern:** NEVER use `--broadcast`. It spams every agent in the project, wastes context windows, and is often ignored or causes confusion.
+
+## Message Timing and Cadence
+
+Effective communication requires balancing responsiveness with focus.
+
+1.  **Immediate Acknowledgment**: When assigned a significant task, reply immediately to acknowledge receipt (e.g., "Got it, starting on the tech spec for X").
+2.  **Milestone Reporting**: Report at significant milestones, not continuously. Don't spam "Still working..." messages.
+3.  **No Silence**: If a task takes longer than expected, send a brief update before diving back in.
+4.  **Simple Questions**: Gather all necessary info first, then ask clearly. Don't send a stream of consciousness.
+5.  **Status Blocked**: When waiting for a reply or a scheduled event, use `sciontool status blocked "<reason>"` to signal you are intentionally waiting.
+
+## Message Content Best Practices
+
+Every message should move work forward. High-signal messages are functional and concrete.
+
+- **Be Functional**: No banter, cheerleading, or "Ready to help!" filler.
+- **Include Concrete Details**: Reference file paths, branch names, URLs, and specific error messages.
+- **Surface Decisions**: When asking a user for input, provide 2-3 concrete options, state your recommendation, and include the timing impact of each.
+- **Keep it Concise**: Focus on key findings and links rather than lengthy narratives.
+
+## Channel and Thread Targeting
+
+- **`--channel <name>`**: Use this to target a specific delivery channel (e.g., `telegram`, `gchat`, `web`).
+- **`--thread-id <id>`**: Use this to reply within a specific project thread, ensuring continuity for the user.
+
+## Special Message Flags
+
+The `scion message` command provides powerful flags for advanced orchestration:
+
+- **`--raw`**: Sends literal keystrokes to an agent's tmux terminal (e.g., `scion message agent:editor --raw "ENTER"`). Useful for unblocking interactive prompts.
+- **`--wake`**: Resumes a suspended agent and delivers the message.
+- **`--interrupt`**: Interrupts the target agent's current process before delivering the message (use with caution).
+- **`--notify`**: Subscribes you to state-change notifications (e.g., completion, stall) for the target agent.
+- **`--attach <file>`**: Attaches one or more files to the message.
+- **`--in <delay>`**: Schedules a message for a relative delay (e.g., `--in 5m`).
+- **`--at <time>`**: Schedules a message for an absolute time (e.g., `--at "2026-06-10 14:00"`).
+
+## Agent-to-Agent Coordination Patterns
+
+- **Coordinator Relay**: Workers generally communicate through the coordinator rather than directly with each other.
+- **Context Sharding**: For long-running tasks, split the work into batches of ≤10 items. Have the agent message the coordinator after each batch to avoid context exhaustion.
+- **Self-Callback Heartbeat**: For very long tasks, use `scion message --in` to send yourself a reminder to check in or provide a status update.
+
+## Multi-User Communication
+
+In projects with multiple users:
+- Reply to each user independently.
+- Do NOT notify other users when replying to a specific individual.
+- Handle each user's requests within their own context.
+
+## Anti-Patterns and Red Flags
+
+- **Red Flag**: Using `--broadcast`.
+- **Red Flag**: An agent goes silent for >30 minutes without a milestone update or "blocked" status.
+- **Anti-Pattern**: Sending "I'm still here" or other low-signal filler messages.
+- **Anti-Pattern**: Using `sleep` to wait for something; use `sciontool status blocked` instead.
+- **Anti-Pattern**: Repeating the entire original brief in a follow-up message (exhausts context).
+
+## Verification Checklist
+
+- [ ] Does the message have a clear recipient (`agent:`, `user:`, or `set[]`)?
+- [ ] Is the message functional and free of filler/banter?
+- [ ] Does it include concrete references (paths, IDs, errors)?
+- [ ] If a decision is needed, are concrete options and a recommendation provided?
+- [ ] Is the message targeted to the correct channel or thread if applicable?
+- [ ] For long tasks, has a milestone reporting cadence been established?

--- a/resources/platform_skills/scion/SKILL.md
+++ b/resources/platform_skills/scion/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: scion
+description: Manage concurrent LLM-based code agents with scion - orchestrate parallel agents with isolated workspaces
+---
+
+# Scion Agent Management Skill
+
+Scion is a container-based orchestration tool for managing concurrent LLM-based code agents. It enables parallel execution of specialized sub-agents with isolated identities, credentials, and workspaces.
+
+## Core Concepts
+
+### Projects
+A **project** is the grouping construct for agents, represented by the `.scion` directory. Each project can have its own project, and there's also a global project in `~/.scion/`.
+
+### Agents
+An **agent** is an isolated LLM instance running in a container with its own workspace (git worktree), credentials, and configuration.
+
+### Templates
+**Templates** are blueprints for creating agents. Common templates include:
+- `gemini` - Gemini CLI-based agents
+- `claude` - Claude Code-based agents
+- `opencode` - OpenCode-based agents
+- `codex` - Codex-based agents
+
+### Harnesses
+A **harness** is the LLM interface (Gemini CLI, Claude Code, etc.) that the agent uses.
+
+## Command Reference
+
+### Initialization
+
+```bash
+# Initialize a project in the current project (creates .scion directory)
+scion init
+
+# Initialize the global project
+scion init --global
+```
+
+### Starting Agents
+
+```bash
+# Start an agent with a task
+scion start <agent-name> <task description>
+
+# Start with a specific template
+scion start <agent-name> "task" --type claude
+
+# Start and immediately attach to the session
+scion start <agent-name> "task" --attach
+
+# Start with a custom branch
+scion start <agent-name> "task" --branch feature-branch
+
+# Start with a custom workspace path
+scion start <agent-name> "task" --workspace /path/to/workspace
+```
+
+### Listing Agents
+
+```bash
+# List agents in the current project
+scion list
+
+# List all agents across all projects
+scion list --all
+
+# Output as JSON
+scion list --format json
+```
+
+Output columns:
+- NAME: Agent name
+- TEMPLATE: Template used (gemini, claude, etc.)
+- RUNTIME: Execution runtime (docker, container, k8s)
+- PROJECT: Project name
+- AGENT STATUS: Agent state
+- SESSION: Session status
+- CONTAINER: Container status
+
+### Interacting with Agents
+
+```bash
+# Attach to an agent's interactive session
+scion attach <agent-name>
+
+# Send a message to an agent
+scion message <agent-name> "Your message here"
+
+# Send message with interrupt (stops current work first)
+scion message <agent-name> "Urgent task" --interrupt
+
+# Broadcast message to all agents in current project
+scion message --broadcast "Stop and report status"
+
+# Broadcast to all agents across all projects
+scion message --all "Global announcement"
+```
+
+### Viewing Logs
+
+```bash
+# View agent logs
+scion logs <agent-name>
+```
+
+### Stopping and Resuming
+
+```bash
+# Stop an agent
+scion stop <agent-name>
+
+# Stop and remove the agent
+scion stop <agent-name> --rm
+
+# Resume a stopped agent
+scion resume <agent-name>
+
+# Resume with attach
+scion resume <agent-name> --attach
+```
+
+### Deleting Agents
+
+```bash
+# Delete an agent (stops container, removes directory and worktree)
+scion delete <agent-name>
+
+# Delete but preserve the git branch
+scion delete <agent-name> --preserve-branch
+
+# Delete all stopped agents
+scion delete --stopped
+```
+
+### Workspace Synchronization
+
+```bash
+# Sync workspace (direction depends on sync mode)
+scion sync <agent-name>
+
+# Sync to the agent container
+scion sync to <agent-name>
+
+# Sync from the agent container
+scion sync from <agent-name>
+```
+
+### Template Management
+
+```bash
+# List available templates
+scion templates list
+
+# Show template configuration
+scion templates show <template-name>
+
+# Create a new template
+scion templates create <name> --harness gemini
+
+# Clone an existing template
+scion templates clone <source> <destination>
+
+# Delete a template
+scion templates delete <name>
+
+# Update default templates from binary
+scion templates update-default
+```
+
+### Configuration
+
+```bash
+# List all effective settings
+scion config list
+
+# Get a specific setting
+scion config get <key>
+
+# Set a local setting (in current project)
+scion config set <key> <value>
+
+# Set a global setting
+scion config set <key> <value> --global
+```
+
+## Common Workflows
+
+### Parallel Task Execution
+
+To run multiple agents in parallel on different tasks:
+
+```bash
+# Start multiple agents for parallel work
+scion start coder "Implement the new API endpoint"
+scion start tester "Write tests for the auth module"
+scion start auditor "Review security of user input handling" --type claude
+
+# Check status of all agents
+scion list
+
+# Attach to any agent to monitor or interact
+scion attach coder
+```
+
+### Agent Collaboration Pattern
+
+When coordinating work across agents:
+
+1. Start agents for different subtasks
+2. Use `scion list` to monitor progress
+3. Use `scion message` to communicate new information
+4. Use `scion attach` when human intervention is needed
+5. Use `scion logs` to review work history
+
+### Cleanup
+
+```bash
+# Delete all stopped agents at once
+scion delete --stopped
+
+# Delete specific agent, keeping its branch for review
+scion delete my-agent --preserve-branch
+```
+
+## Global Flags
+
+These flags work with most commands:
+
+- `--project, -g <path>`: Specify a project directory
+- `--global`: Use the global project (~/.scion/)
+- `--profile, -p <name>`: Use a specific configuration profile
+- `--format <type>`: Output format (json, plain) - currently for list only
+
+## Tips for Agents
+
+1. **Check existing agents first**: Before starting a new agent, use `scion list` to see what's already running.
+
+2. **Use descriptive names**: Agent names should reflect their purpose (e.g., `refactor-auth`, `test-api`, `audit-security`).
+
+3. **Choose appropriate templates**: Use `--type claude` for Claude Code, default is Gemini CLI.
+
+4. **Monitor with logs**: Use `scion logs <agent>` to check progress without interrupting.
+
+5. **Interrupt carefully**: The `--interrupt` flag on messages stops current work - use only when necessary.
+
+6. **Preserve branches**: When deleting agents whose work might need review, use `--preserve-branch`.
+
+7. **Use attach for complex interactions**: When an agent needs guidance, `scion attach` provides full interactive access.

--- a/resources/platform_skills/scion/scripts/agent-status.sh
+++ b/resources/platform_skills/scion/scripts/agent-status.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Get status of a specific agent or all agents
+# Usage: agent-status.sh [agent-name]
+# Returns JSON with agent information
+
+if [ -n "$1" ]; then
+    # Get specific agent status
+    scion list --format json | jq --arg name "$1" '.[] | select(.name == $name or .Name == $name)'
+else
+    # Get all agents as JSON
+    scion list --format json
+fi

--- a/resources/platform_skills/scion/scripts/list-agents.sh
+++ b/resources/platform_skills/scion/scripts/list-agents.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# List scion agents with optional JSON output
+# Usage: list-agents.sh [--json] [--all]
+
+JSON_OUTPUT=""
+ALL_FLAG=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --json)
+            JSON_OUTPUT="--format json"
+            shift
+            ;;
+        --all|-a)
+            ALL_FLAG="--all"
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+scion list $ALL_FLAG $JSON_OUTPUT

--- a/resources/platform_skills/scion/scripts/send-message.sh
+++ b/resources/platform_skills/scion/scripts/send-message.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Send a message to an agent
+# Usage: send-message.sh <agent-name> <message> [--interrupt]
+
+if [ $# -lt 2 ]; then
+    echo "Usage: send-message.sh <agent-name> <message> [--interrupt]"
+    exit 1
+fi
+
+AGENT="$1"
+shift
+MESSAGE="$1"
+shift
+
+scion message "$AGENT" "$MESSAGE" "$@"

--- a/resources/platform_skills/scion/scripts/start-agent.sh
+++ b/resources/platform_skills/scion/scripts/start-agent.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Start a scion agent with a task
+# Usage: start-agent.sh <name> <task> [--type template] [--attach]
+
+if [ $# -lt 2 ]; then
+    echo "Usage: start-agent.sh <name> <task> [--type template] [--attach]"
+    exit 1
+fi
+
+NAME="$1"
+shift
+TASK="$1"
+shift
+
+# Pass remaining args to scion
+scion start "$NAME" "$TASK" "$@"

--- a/resources/platform_skills/team-creation/SKILL.md
+++ b/resources/platform_skills/team-creation/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: team-creation
+description: >-
+  Create or extend scion agent team templates from a high-level description of roles and workflow.
+  Use when the user describes a multi-agent team, panel, crew, pipeline, or any scenario
+  requiring coordinated LLM agents with distinct roles. Also use when adding new roles to an
+  existing team, modifying workflows, or restructuring agent coordination. Produces ready-to-use
+  template directories in .scion/templates/ by default, or in a custom path if specified.
+---
+
+# Scion Team Creation & Extension Skill
+
+You create and extend **scion agent templates** — the blueprints that define specialized agent roles. Given a description of a team (roles, responsibilities, workflow), you produce template directories that can be used to start agents with `scion start <name> --type <template>`.
+
+When extending an existing team, review the current templates to understand the established patterns, naming, and workflow before making changes.
+
+## Template Directory Structure
+
+Each template lives in `.scion/templates/<template-name>/` and contains:
+
+```
+.scion/templates/<template-name>/
+├── scion-agent.yaml       # REQUIRED: template metadata and config
+├── agents.md              # REQUIRED: agent behavioral instructions
+├── system-prompt.md       # REQUIRED: role persona and expertise framing
+└── skills/                # OPTIONAL: harness skills (agentskills.io standard)
+    └── <skill-name>/
+        └── SKILL.md
+```
+
+Custom templates automatically **inherit** from the built-in `default` template, which provides shell configs, git setup, and base scion infrastructure. You do NOT need to create a `home/` directory or duplicate any infrastructure files.
+
+### Template Naming
+
+- Directory names use **kebab-case**: `panel-judge`, `code-reviewer`, `team-lead`
+- Names should be descriptive of the role, not the project
+
+## Required File Formats
+
+### scion-agent.yaml
+
+Every template MUST have this file. Minimal valid config:
+
+```yaml
+schema_version: "1"
+description: "Short description of this agent role"
+agent_instructions: agents.md
+system_prompt: system-prompt.md
+```
+
+Optional fields you may include when the role requires them:
+
+```yaml
+max_turns: 50              # Maximum conversation turns
+max_duration: "30m"        # Maximum wall-clock time (e.g. "1h", "30m")
+
+env:
+  ROLE: "reviewer"
+
+services:
+  - name: chromium
+    command: ["chromium", "--headless", "--no-sandbox", "--remote-debugging-port=9222"]
+    restart: always
+    ready_check:
+      type: tcp
+      target: "localhost:9222"
+      timeout: "10s"
+```
+
+### agents.md (Agent Instructions)
+
+This file contains the behavioral instructions injected into the agent's context. 
+
+The primary contents should focus on task and job work describing what the agent should do, how it should behave, and any constraints on its work.
+
+Do **not** include instructions on how to use the scion CLI (starting agents, messaging, `scion look`, etc.) — every agent automatically receives base CLI operating instructions from the platform.
+
+### system-prompt.md (Optional)
+
+Frames the agent's persona, expertise, and perspective — *who* the agent is, while `agents.md` shapes *what* it does. Example:
+
+```markdown
+# Expert Code Reviewer
+
+You are a senior software engineer with deep expertise in code quality,
+security, and maintainability. You approach code review methodically,
+prioritizing correctness and clarity over style preferences.
+```
+
+If the role doesn't need a distinct persona, omit this file and remove the `system_prompt` line from `scion-agent.yaml`.
+
+This file can contain broad direction around skillsets.
+
+## Harness Skills
+
+Templates can include a `skills/` directory containing reusable skill definitions that follow the [agentskills.io](https://agentskills.io/) standard. Each skill is a subdirectory with a `SKILL.md` file:
+
+```
+skills/
+└── my-skill/
+    └── SKILL.md
+```
+
+A `SKILL.md` file has YAML frontmatter with `name` and `description`, followed by markdown content:
+
+```markdown
+---
+name: my-skill
+description: >-
+  Short description of what this skill does and when the agent should use it.
+---
+
+Skill instructions and reference material here.
+```
+
+During agent provisioning, Scion automatically merges skills from the template into the correct harness-specific location (e.g. `.claude/skills/` for Claude, `.gemini/skills/` for Gemini). The agent's LLM harness discovers and loads these skills at runtime.
+
+Use skills to package domain knowledge, tool-usage patterns, or specialized workflows that a role needs. Skills are portable across harnesses and reusable across templates.
+
+## The Orchestrator Pattern
+
+Every team MUST have exactly one **orchestrator** (also called lead, supervisor, or coordinator). This is the agent the user starts directly — it then creates and manages the other agents.
+
+The orchestrator's `agents.md` should focus on:
+
+- **What templates are available** and what each role does
+- **The workflow**: when to start which agents, what tasks to give them, how to handle their results
+- **Communication patterns**: what information flows between roles and when
+- **Completion criteria**: how the orchestrator knows the overall task is done
+
+Workers don't communicate directly with each other — the orchestrator reads output from one and relays relevant information to others.
+
+### Orchestrator agents.md Structure
+
+```markdown
+[status reporting boilerplate]
+
+## Role: Team Orchestrator
+
+You are the orchestrator for [team description]. Your job is to:
+1. [high-level workflow step 1]
+2. [high-level workflow step 2]
+
+## Available Agent Roles
+
+- `<template-1>`: [what this role does, expected input, what it produces]
+- `<template-2>`: [what this role does, expected input, what it produces]
+
+## Workflow
+
+[Step-by-step instructions: when to create agents, what to tell them,
+how to handle results, when the overall task is complete.]
+```
+
+## Creating a New Team
+
+### 1. Analyze the Description
+
+Identify from the user's description:
+- **Roles**: What distinct agent types are needed?
+- **Workflow**: How do the agents interact? Sequential pipeline, parallel work, debate, review cycle?
+- **Orchestration**: Who starts whom? Who collects results?
+
+### 2. Design the Team Structure
+
+- Identify one role as the **orchestrator** — the entry point the user will start
+- All other roles are **workers** — started and managed by the orchestrator
+- Map out the communication flow
+
+### 3. Create Templates
+
+For each role, create the template directory with its files. Write worker templates first, then the orchestrator (since it references worker template names).
+
+### 4. Add Skills When Appropriate
+
+If a role needs specialized domain knowledge or tool-usage patterns that would benefit from being a discrete, reusable skill file rather than inline in `agents.md`, add it to the template's `skills/` directory.
+
+### 5. Validate
+
+- [ ] Every template has `scion-agent.yaml` with `schema_version: "1"`
+- [ ] Every `agents.md` starts with the status reporting boilerplate
+- [ ] The orchestrator references the correct template names
+- [ ] Template directory names are kebab-case
+- [ ] The workflow matches the user's intent
+- [ ] No CLI usage instructions are duplicated in templates
+
+## Extending an Existing Team
+
+When adding to or modifying an existing team:
+
+### 1. Review Current State
+
+Read the existing templates in `.scion/templates/` to understand:
+- The current roles and their responsibilities
+- The orchestrator's workflow and how it references workers
+- Naming conventions and patterns already established
+- Any existing skills in template `skills/` directories
+- Skill may be hard copied between templates if they are relevant to more than one type.
+
+### 2. Determine the Change
+
+- **Adding a role**: Create a new worker template, then update the orchestrator's `agents.md` to reference it — add the new template to the "Available Agent Roles" section and integrate it into the workflow.
+- **Modifying a role**: Update the existing template's `agents.md` and/or `system-prompt.md`. Check if the orchestrator's workflow needs adjustment.
+- **Changing workflow**: Update the orchestrator's `agents.md` workflow section. May require changes to worker instructions if handoff patterns change.
+- **Adding capabilities**: Consider whether the new capability belongs as inline instructions in `agents.md` or as a discrete skill in the template's `skills/` directory.
+
+### 3. Maintain Consistency
+
+- Follow the naming conventions already in use
+- Keep the communication patterns consistent (workers report to orchestrator)
+- Update the orchestrator whenever worker templates change
+
+## Gotchas
+
+- **Don't duplicate CLI usage instructions**. Every agent already receives base scion CLI instructions from the platform.
+- **Don't create `home/` directories** in custom templates. The default template provides all infrastructure.
+- **Template names = directory names**. The `description` in `scion-agent.yaml` is cosmetic; the `--type` value is the directory name.
+- **Skills are harness-portable**. Write `SKILL.md` content without assuming a specific harness — scion mounts skills into the correct location automatically.


### PR DESCRIPTION
## Summary

Embeds 6 platform skills in the binary and injects them into every agent during provisioning regardless of template. Precedence: template > platform > workspace. git-sandbox gated on IsGitRepoDir(). 6 new tests pass.

## Test plan

- [ ] Any template → 5 unconditional skills injected
- [ ] Git project → git-sandbox also injected
- [ ] Template skill wins on name conflict
