### PR TITLE
hub: check hub-scoped env vars and secrets in hasAnyKey credential check

### DIFF
--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -935,6 +935,22 @@ func (s *Server) hasAnyKey(ctx context.Context, agent *store.Agent, keys []strin
 				return true, nil
 			}
 		}
+		if s.hubID != "" {
+			ev, err := s.store.GetEnvVar(ctx, key, store.ScopeHub, s.hubID)
+			if err != nil && !errors.Is(err, store.ErrNotFound) {
+				return false, err
+			}
+			if ev != nil {
+				return true, nil
+			}
+			sec, err := s.store.GetSecret(ctx, key, store.ScopeHub, s.hubID)
+			if err != nil && !errors.Is(err, store.ErrNotFound) {
+				return false, err
+			}
+			if sec != nil {
+				return true, nil
+			}
+		}
 	}
 	return false, nil
 }


### PR DESCRIPTION
## Summary

Fixes credential detection for child agents created by other agents (owner_id is parent agent, not human user). hasAnyKey() now checks hub scope after user and project scope. Hub-scoped vars like GOOGLE_CLOUD_PROJECT are now found correctly.

## Test plan

- [ ] Claude agent created by another agent → vertex-ai auth detected if GOOGLE_CLOUD_PROJECT is hub-scoped
- [ ] User/project-scoped credentials → still found first (unaffected)
