### PR TITLE
hub: preserve updated timestamp when updating image status fields

### DIFF
--- a/pkg/store/entadapter/template_store.go
+++ b/pkg/store/entadapter/template_store.go
@@ -506,9 +506,14 @@ func (s *TemplateStore) UpdateHarnessConfigImageStatus(ctx context.Context, id, 
 	if err != nil {
 		return err
 	}
+	existing, err := s.client.HarnessConfig.Get(ctx, uid)
+	if err != nil {
+		return mapError(err)
+	}
 	_, err = s.client.HarnessConfig.UpdateOneID(uid).
 		SetImageStatus(entharnessconfig.ImageStatus(status)).
 		SetImageStatusCheckedAt(checkedAt).
+		SetUpdated(existing.Updated).
 		Save(ctx)
 	if err != nil {
 		return mapError(err)


### PR DESCRIPTION
UpdateHarnessConfigImageStatus was triggering ent's UpdateDefault(time.Now) on the 'updated' field, making all harness-configs appear re-written on every startup. Fix by fetching the existing record and explicitly setting the updated field to its current value.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
