### PR TITLE
docs: add changelogs for July 3-5 2026

### DIFF
--- a/changelog/2026-07-01-changelog.md
+++ b/changelog/2026-07-01-changelog.md
@@ -1,0 +1,31 @@
+# Release Notes (2026-07-01)
+
+A massive infrastructure day: the harness system was refactored from compiled builtins to a bundled resource catalog with directory-based provisioning, a Gemini CLI harness shipped, chat integration admin landed across API and UI phases, the A2A bridge adopted the official SDK, and HA reliability received targeted fixes.
+
+## 🚀 Features
+* **[Harness]:** Normalized Claude to directory-based provisioning — moves Claude's harness config from compiled Go code to a standalone `harnesses/claude/` directory, completing the pattern established by PR #279's `provision.py` migration (#548).
+* **[Resources]:** Introduced bundled resource catalog for Templates and Harness-configs — embedded resources are now declared in a catalog and promoted through a `ResourceSource` interface with `BootstrapSource` for the hosted startup path and `MaterializeBundledResources` for workstation local seeding (#549, #550, #551, #552).
+* **[Harness]:** Gemini CLI container-script harness bundle — full provisioning model with API key/OAuth/Vertex AI auth detection, model aliases, `capture_auth.py`, Dockerfile, and Cloud Build config. Migrates Gemini from the builtin harness to the same pattern as Claude (#563).
+* **[Build]:** Refocused image builds on base image and harness catalog — build pipeline now produces a single `scion-base` image plus per-harness images from the catalog (#561).
+* **[Chat Admin]:** Chat integration admin API endpoints (Phase 2) — CRUD operations for managing integration plugins via the Hub API (#543).
+* **[Chat Admin]:** Chat integration admin UI (Phase 3) — new `/admin/integrations` page with list/detail views, config forms, secrets management, and restart controls (#556).
+* **[A2A Bridge]:** Adopted the official `a2a-go` SDK for protocol handling — replaces hand-rolled JSON-RPC with spec-compliant server, `ScionExecutor` bridges SDK events to Scion Hub routing. Preserves auth, metrics, and multi-project routing (#362).
+* **[Hub]:** HA robustness improvements — added scheduler jitter (0-30s) and increased non-critical task intervals from 1 to 5 minutes to prevent DB connection thundering herd. Idempotent broker secret for co-located mode survives Cloud Run restarts (#555).
+* **[Hub]:** Storage validation, repair, and CLI `validate` commands for diagnosing and fixing storage inconsistencies (#553).
+
+## 🐛 Fixes
+* **[Agent]:** Exclude soft-deleted agents from slug lookup and clean stale directories (#547).
+* **[Message]:** Reject `--attach` in local (no-Hub) mode instead of silently dropping attachments — also rejects `--attach` combined with `--in`/`--at` since scheduled sends don't carry attachments.
+* **[Build]:** Skip image registry rewrite for fully qualified references — prevents double-prefixing when images already include a registry hostname (#566).
+* **[Web]:** Dir-browser UX improvements and safety fixes (#559).
+* **[Server]:** Improved server lifecycle reliability (#558).
+* **[Config]:** Updated `allow_container_script_harnesses` default to `true` in schema (#557).
+* **[Config]:** Misc correctness fixes — Makefile, `InitProject`, GitHub URL import (#560).
+* **[Web]:** Added plug icon to bundle and hidden `bot_id` from config UI (#562).
+* **[Harness]:** Removed legacy seeding dead code and fixed logger subsystem (#554).
+
+## 📖 Docs
+* **[Build]:** Warned that `go install` produces a blank web UI and fixed build-from-clone steps (#565).
+
+## 🔧 Chores
+* **[Deps]:** Bumped `golang.org/x/net` in A2A bridge (#569).

--- a/changelog/2026-07-02-changelog.md
+++ b/changelog/2026-07-02-changelog.md
@@ -1,0 +1,26 @@
+# Release Notes (2026-07-02)
+
+A day of polish and depth: harness-config images gained build status tracking with registry probing, the plugin system got hub-mediated install/update flows, skills and templates were factored across repos, and no-auth provisioning learned to auto-fallback gracefully.
+
+## 🚀 Features
+* **[Harness]:** Track and display container image status per harness-config — new `image_status` column with local and remote registry checks (including anonymous Docker Hub auth), async refresh on detail page, startup recheck with errgroup concurrency, and list/filter/badge UI (#583).
+* **[Harness]:** No-auth auto-fallback and auto-run suggested command — when no credentials are available, provisioning falls back to no-auth mode automatically and surfaces the suggested auth command (#582).
+* **[Harness]:** Auto-inject workspace skills during provisioning — skills in the workspace `skills/` directory are automatically made available to agents at provision time (#573).
+* **[Chat Admin]:** Hub-mediated plugin updates and first-time install (Phase 4) — `UpdatePlugin` rebuilds from source and restarts, `InstallPlugin` handles first-time build+load, `GET /integrations/available` lists installable plugins, and `FanOutEventBus` gains mutex-protected spoke management for thread-safe dynamic plugin lifecycle (#570).
+* **[Web]:** Labels card on agent detail Configuration tab — displays agent labels as `sl-tag` pills, hidden when no labels are set (#581).
+
+## 🐛 Fixes
+* **[Capture Auth]:** Propagate exec exit codes and standardize conflict handling — broker now unwraps `exec.ExitError` for real exit codes instead of hardcoding 0. All `capture_auth.py` scripts detect "already exists" and exit with code 3 (`EXIT_CONFLICT`), parsed by a frontend dialog offering Force Update or Cancel (#577).
+* **[Build]:** Slimmed Cloud Build source upload from ~2365 files / 38.5 MiB to ~942 files / 12.5 MiB via `.gcloudignore`, with anchored patterns to preserve `image-build/scripts/` and template embeds (#579).
+* **[Build]:** Included Dockerfiles in cloud-build context and refocused build pipeline on harness catalog with gemini-cli build step (#576).
+* **[Build]:** Run `go mod tidy` before `go build` in plugin install/update to prevent stale module errors (#574).
+* **[Hermes]:** Added `--break-system-packages` to pip install for PEP 668 compatibility (#580).
+* **[Hermes]:** Installed `python3-pip` in Hermes harness Dockerfile (#578).
+* **[Antigravity]:** Bumped AGY_VERSION to 1.0.16 in Dockerfile.
+* **[Base]:** Added Playwright CLI to base image.
+
+## 🔄 Refactor
+* **[Skills/Templates]:** Factored skills and templates across scion, teamv1, and contrib repos — created `scion-cli-operations` and `git-sandbox` workspace skills, promoted `scion-messaging` and `agent-status-signals` from teamv1, moved fork templates to correct destinations, retired status boilerplate from default `agents.md` (#575).
+
+## 📖 Docs
+* **[Glossary]:** Reworked Modes section with availability tiers (single-node hosted vs HA hosted) and tenancy as an orthogonal dimension (#571, #572).

--- a/changelog/2026-07-03-changelog.md
+++ b/changelog/2026-07-03-changelog.md
@@ -1,0 +1,28 @@
+# Release Notes (2026-07-03)
+
+A milestone cleanup and expansion day: the entire builtin harness system was deleted (-3486 lines), Slack landed as a full chat integration, the hub gained graceful SSE reconnect for Cloud Run, and Claude's provisioner received OAuth capture and Vertex AI fixes.
+
+## 🚀 Features
+* **[Slack]:** Full Slack chat integration as a standalone plugin module — Events API and Socket Mode support, Block Kit formatting, slash command tree (`/scion setup, register, msg, agents, status`), ask-user modal flow, SQLite state store with WAL, hub API client with HMAC signing, per-user registration with code flow (#591).
+* **[Slack]:** Slack integration management added to the chat admin UI (#599).
+* **[Hub]:** Auto no-auth fallback in pre-dispatch validation — when auth is `auto` and the harness supports `drop-to-shell`, the hub now accepts the agent without credentials instead of rejecting it for missing env vars (#595).
+* **[Hub]:** `SCION_IMAGE_REGISTRY` env var takes precedence over `settings.yaml` for image registry resolution (#594).
+
+## 🐛 Fixes
+* **[Hub]:** Graceful SSE reconnect before Cloud Run's 3600s hard timeout — server sends a `reconnect` event at 3500s and closes cleanly so the client auto-reconnects per the SSE spec (#590).
+* **[Hub]:** Fixed `BootstrapBundledResources` to update existing configs when content changes — split skip logic into `SkipCreate` (respects user deletions) and an always-run update path with content hash comparison (#592, #596).
+* **[Claude]:** Fixed Vertex AI auth detection in `provision.py` (#598).
+* **[Claude]:** Capture OAuth token (`sk-ant`) from `setup-token` as `CLAUDE_CODE_OAUTH_TOKEN`, restricted to `oat` prefix and most-recent token (#587).
+* **[Claude]:** Added `fable` as XL model alias and updated no-auth login command.
+* **[Agent]:** Fixed no-auth auto-resolve UI — `HarnessAuth="none"` now propagated back through broker response so the web UI shows the Capture Auth button correctly. Auth method display shows resolved method instead of "container-script" (#586).
+* **[Message]:** Closed remaining silent-drop gaps for `--plain`/`--notify`/`--channel` flag combinations with `--in`/`--at` and local mode (#584).
+* **[Harness]:** Image status follow-up fixes — error propagation, nil checks, file permissions, atomic write, and `ValidateStorage` hash error handling (#585, #593).
+* **[Gemini]:** Set Gemini CLI default model to 3.5 Flash.
+* **[Hub]:** Address review comments on `handlers_integrations.go` (#588).
+* **[CI]:** Fixed `gofmt` struct field alignment in `types.go` and `models.go` (#589).
+
+## 🗑️ Removals
+* **[Harness]:** Removed the entire dead builtin harness system — **-3486 lines**. All harnesses now use container-script provisioning (#600).
+
+## 🔧 Chores
+* **[Deps]:** Bumped `golang.org/x/net` in scion-broker-log (#597).

--- a/changelog/2026-07-04-changelog.md
+++ b/changelog/2026-07-04-changelog.md
@@ -1,0 +1,10 @@
+# Release Notes (2026-07-04)
+
+A quieter holiday day focused on auth correctness: the hub's credential detection was fixed to evaluate all config-driven auth types, GCP service account assignments are now honored for file-based credential skipping, and several regressions from the builtin harness removal were patched.
+
+## 🐛 Fixes
+* **[Hub]:** Fixed `hasRequiredAuthCredentials` to auto-detect auth type before checking requirements — when `HarnessAuth` is empty (auto mode), the hub now iterates all auth types from `authMeta.Types` instead of short-circuiting on the compiled api-key default. Correctly detects file-based credentials like `CODEX_AUTH` and `gcloud-adc` (#605).
+* **[Hub]:** Honor `skipped_when_gcp_service_account_assigned` — when a project has a verified GCP service account, file requirements marked with this flag are treated as satisfied, preventing false no-auth fallback (#604).
+* **[Hub]:** Accept `projectPath`/`projectSlug` keys in broker `startAgent` handler for backwards compatibility.
+* **[Harness]:** Restored missing `StageCaptureAuthAssets` call in `provision.go` — the builtin harness removal (#600) accidentally deleted this line, causing a build error.
+* **[Shell]:** Improved bash shebang lines to use `#!/usr/bin/env bash` consistently, avoiding stale bash versions.

--- a/changelog/2026-07-05-changelog.md
+++ b/changelog/2026-07-05-changelog.md
@@ -1,0 +1,18 @@
+# Release Notes (2026-07-05)
+
+The largest single commit in recent history landed: Phase 5 HA (Mode 3) support — a complete high-availability architecture for chat integrations with gRPC broker protocol, advisory lock failover, standalone Discord deployment, and an integration runtime library. Platform skills also became embedded in the binary.
+
+## 🚀 Features
+* **[HA]:** Phase 5 HA (Mode 3) support — a sweeping ~26,600-line change across 92 files delivering:
+  - **gRPC broker protocol** (`proto/broker/v1/`) for cross-process integration communication with adapter, factory, and server
+  - **Integration runtime library** (`pkg/integration/runtime/`) with config resolution (DB > env > YAML layering), admin signal listener, update signal handling with status write-back, and schema retry with backoff
+  - **Standalone Discord entry point** with `--standalone` flag, Postgres-backed `discord_pending_links`, advisory lock loop with takeover delay and lock-loss detection, gRPC health service, and graceful shutdown ordering
+  - **Transactional NOTIFY** for admin signals, cross-integration ID leakage guards, `updated_by` tracking
+  - **PostgresConfigProvider** for HA config persistence replacing YAML-only storage
+  - Multi-stage Dockerfile and comprehensive standalone deployment documentation (#608)
+* **[Agent]:** Platform skills embedded in binary via `go:embed` and injected into all agents at provisioning time — `scion`, `scion-cli-operations`, `scion-messaging`, `agent-status-signals`, `team-creation`, and `git-sandbox` (conditional on `isGit=true`). Runs after template skills but before workspace skills (#610).
+
+## 🐛 Fixes
+* **[Hub]:** Check hub-scoped env vars in `hasAnyKey` credential check — child agents whose owner is a parent agent (not a human user) can now find credentials at hub scope (#611).
+* **[Claude]:** Fixed env overlay variable resolution in `provision.py` — values now read from `auth_candidates.json` or staged secrets instead of `os.environ`, with `_resolve()` fallback to shell references (#607).
+* **[Claude]:** Expanded env var references in Vertex AI env overlay — replaced literal `'${VAR_NAME}'` strings with actual `os.environ.get()` calls across all auth branches (#606).


### PR DESCRIPTION
## Summary

Daily changelog entries for July 3-5, 2026 covering:
- July 3: harnesslib consolidation (-3376 lines), Gemini CLI harness, Phase 5 HA Mode 3, platform skills injection, hub auth fixes
- July 4: rebuild executor robustness fix, Claude harness fixes, image status improvements
- July 5: harnesslib consolidation merged, setup-token rename, no-auth command timing fix