### PR TITLE
fix: detach daemon stdin from terminal to prevent credential prompt leaks

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -80,9 +80,11 @@ func StartComponent(component, executable string, args []string, globalDir strin
 	cmd := exec.Command(executable, args...)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
+	cmd.Stdin = nil          // prevent credential prompts leaking to user's terminal
 	cmd.Dir = globalDir
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,
+		Setsid:  true,       // detach from the controlling terminal entirely
 	}
 
 	if err := cmd.Start(); err != nil {


### PR DESCRIPTION
## Problem

On macOS, `scion server start` shows a spurious `Password:` prompt in the terminal.

The daemon launcher (`pkg/daemon/daemon.go`) redirects the child process stdout/stderr to the log file but leaves stdin inherited from the parent terminal. When the server process or Docker's credential helper prompts for input, it surfaces in the user's terminal.

## Fix

Set `cmd.Stdin = nil` and `Setsid: true` in both `StartComponent()` and `Start()` so the daemon is fully detached from the controlling terminal.

## Testing

- `scion server start` no longer shows a password prompt on macOS
- Server logs and behavior unchanged
- Daemon starts and operates normally