### PR TITLE
fix: scion version shows both tag and commit

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -80,11 +80,11 @@ func StartComponent(component, executable string, args []string, globalDir strin
 	cmd := exec.Command(executable, args...)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
-	cmd.Stdin = nil          // prevent credential prompts leaking to user's terminal
+	cmd.Stdin = nil // prevent credential prompts leaking to user's terminal
 	cmd.Dir = globalDir
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,
-		Setsid:  true,       // detach from the controlling terminal entirely
+		Setsid:  true, // detach from the controlling terminal entirely
 	}
 
 	if err := cmd.Start(); err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -42,7 +42,9 @@ func Get() string {
 	}
 
 	commit := GetCommit()
-	if len(commit) > 8 {
+	if commit == "" {
+		commit = "unknown"
+	} else if len(commit) > 8 {
 		commit = commit[:8]
 	}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -34,52 +34,19 @@ var (
 	BuildTime string
 )
 
-// Get returns the version string based on the current build information.
+// Get returns the version string showing both version tag and commit hash.
 func Get() string {
-	// If Version is set, we assume it's a semantic version tag injected at build time.
-	if Version != "" {
-		return Version
+	ver := Version
+	if ver == "" {
+		ver = "dev"
 	}
 
-	// Fallback to commit and build time.
-	commit := Commit
-	buildTime := BuildTime
-
-	// If variables are empty (e.g. go run or simple go build), try to read from debug info.
-	if commit == "" {
-		if info, ok := debug.ReadBuildInfo(); ok {
-			for _, setting := range info.Settings {
-				if setting.Key == "vcs.revision" {
-					commit = setting.Value
-				}
-				// Note: vcs.time is commit time, not build time.
-			}
-		}
-	}
-
-	// Shorten commit hash if it's long
+	commit := GetCommit()
 	if len(commit) > 8 {
 		commit = commit[:8]
 	}
 
-	if commit == "" {
-		commit = "unknown"
-	}
-
-	// If buildTime is not set via ldflags, try to get the binary's modification time.
-	if buildTime == "" {
-		if exe, err := os.Executable(); err == nil {
-			if info, err := os.Stat(exe); err == nil {
-				buildTime = info.ModTime().Format("2006-01-02 15:04:05")
-			}
-		}
-	}
-
-	if buildTime == "" {
-		buildTime = "unknown"
-	}
-
-	return fmt.Sprintf("Commit: %s\nBuild Time: %s", commit, buildTime)
+	return fmt.Sprintf("scion %s (commit %s)", ver, commit)
 }
 
 // GetBuildTime returns the build time, applying fallbacks if the ldflags


### PR DESCRIPTION
Always show both the version tag and git commit hash in scion version output