### PR TITLE
fix: prefer podman > docker > apple-container in macOS runtime auto-detection

### DIFF
--- a/pkg/runtime/factory.go
+++ b/pkg/runtime/factory.go
@@ -69,12 +69,18 @@ func GetRuntime(projectPath string, profileName string) Runtime {
 	if runtimeType == "local" || runtimeType == "auto" {
 		util.Debugf("GetRuntime: auto-detecting for OS=%s", runtime.GOOS)
 		if runtime.GOOS == "darwin" {
-			if _, err := exec.LookPath("container"); err == nil {
+			if _, err := exec.LookPath("podman"); err == nil {
+				runtimeType = "podman"
+				util.Debugf("GetRuntime: detected 'podman' on macOS")
+			} else if _, err := exec.LookPath("docker"); err == nil {
+				runtimeType = "docker"
+				util.Debugf("GetRuntime: detected 'docker' on macOS")
+			} else if _, err := exec.LookPath("container"); err == nil {
 				runtimeType = "container"
-				util.Debugf("GetRuntime: detected 'container' CLI on macOS")
+				util.Debugf("GetRuntime: detected 'container' CLI on macOS (Apple Container)")
 			} else {
 				runtimeType = "docker"
-				util.Debugf("GetRuntime: 'container' CLI not found on macOS, using docker")
+				util.Debugf("GetRuntime: no runtime detected on macOS, defaulting to docker")
 			}
 		} else {
 			// On Linux, prefer podman over docker when both are available


### PR DESCRIPTION
## Problem

Apple Container requires sudo for DNS setup on macOS, causing a password prompt that crashes `scion server start` when running as a daemon (no tty for password input).

Users with Apple Container installed alongside Docker or Podman get apple-container selected silently as the runtime, causing the server to exit on startup.

## Fix

Change macOS auto-detection priority to: **podman → docker → apple-container**.

- Matches the Linux runtime preference (podman-first)
- Apple Container is only used as a last resort when neither Podman nor Docker is found
- Users who want Apple Container can still set `runtime: container` in their settings

## Testing

- Podman installed: uses podman
- Docker only: uses docker  
- Both: uses podman
- Only Apple Container: uses apple-container (unchanged)
- None found: defaults to docker with a clear error at agent-start time
