### PR TITLE
fix: remove Setsid from daemon SysProcAttr — causes EPERM on macOS

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -83,8 +83,7 @@ func StartComponent(component, executable string, args []string, globalDir strin
 	cmd.Stdin = nil // prevent credential prompts leaking to user's terminal
 	cmd.Dir = globalDir
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true,
-		Setsid:  true, // detach from the controlling terminal entirely
+		Setpgid: true, // new process group; Setsid omitted — fails with EPERM on macOS for Homebrew binaries
 	}
 
 	if err := cmd.Start(); err != nil {


### PR DESCRIPTION
## Problem

PR #629 added `Setsid: true` to the daemon's `SysProcAttr` to fully detach from the controlling terminal. On macOS, `setsid()` fails with `EPERM` for Homebrew-installed binaries that lack the required entitlements, causing:

```
Error: failed to start daemon: fork/exec /opt/homebrew/bin/scion: operation not permitted
```

## Fix

Remove `Setsid: true`. The existing `Setpgid: true` is sufficient to detach the daemon from the parent's process group, and `cmd.Stdin = nil` (also from #629) already prevents credential prompts from leaking to the terminal.

## Testing

- `scion server start` works on macOS with Homebrew-installed binary
- No password prompt in terminal (stdin still nil)
- Daemon detaches correctly from parent process
