### PR TITLE
fix: chat interrupt ! processing for inbound broker path and interrupt_sequence support

### DIFF
--- a/harnesses/claude/config.yaml
+++ b/harnesses/claude/config.yaml
@@ -33,6 +33,11 @@ provisioner:
 config_dir: .claude
 skills_dir: .claude/skills
 interrupt_key: Escape
+interrupt_sequence:
+  - Escape
+  - Escape
+  - Escape
+interrupt_signal: sequence
 instructions_file: .claude/CLAUDE.md
 system_prompt_file: .claude/system-prompt.md
 system_prompt_mode: native

--- a/pkg/agent/manager.go
+++ b/pkg/agent/manager.go
@@ -286,8 +286,14 @@ func (m *AgentManager) deliverImmediate(ctx context.Context, agentID, projectID 
 	var cmds [][]string
 
 	if interrupt {
-		key := h.GetInterruptKey()
-		cmds = append(cmds, []string{"tmux", "send-keys", "-t", "scion:0", key})
+		if seq := h.GetInterruptSequence(); len(seq) > 0 {
+			for _, key := range seq {
+				cmds = append(cmds, []string{"tmux", "send-keys", "-t", "scion:0", key})
+			}
+		} else {
+			key := h.GetInterruptKey()
+			cmds = append(cmds, []string{"tmux", "send-keys", "-t", "scion:0", key})
+		}
 	}
 
 	if message == "" {

--- a/pkg/api/harness.go
+++ b/pkg/api/harness.go
@@ -35,8 +35,14 @@ type Harness interface {
 	// from filepath.Dir(agentHome) when split storage is active).
 	Provision(ctx context.Context, agentName, agentDir, agentHome, agentWorkspace string) error
 
-	// GetInterruptKey returns the key sequence used to interrupt the harness process (e.g., "C-c" or "Escape").
+	// GetInterruptKey returns the single key used to interrupt the harness process (e.g., "C-c" or "Escape").
 	GetInterruptKey() string
+
+	// GetInterruptSequence returns the sequence of keys to send to interrupt the
+	// harness, each as a separate tmux send-keys call. When interrupt_signal is
+	// "sequence" (or interrupt_sequence is populated), this takes priority over
+	// GetInterruptKey. Returns nil to fall back to GetInterruptKey.
+	GetInterruptSequence() []string
 
 	// GetHarnessEmbedsFS returns the embedded filesystem containing default harness-config files
 	// and the base path within it (e.g., "embeds").

--- a/pkg/config/mock_harness_test.go
+++ b/pkg/config/mock_harness_test.go
@@ -48,6 +48,7 @@ func (m *MockHarness) Provision(ctx context.Context, agentName, agentDir, agentH
 	return nil
 }
 func (m *MockHarness) GetInterruptKey() string                { return "C-c" }
+func (m *MockHarness) GetInterruptSequence() []string         { return nil }
 func (m *MockHarness) GetHarnessEmbedsFS() (embed.FS, string) { return embed.FS{}, "" }
 func (m *MockHarness) InjectAgentInstructions(agentHome string, content []byte) error {
 	target := filepath.Join(agentHome, "agents.md")

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -301,7 +301,17 @@
         },
         "interrupt_key": {
           "type": "string",
-          "description": "Key sequence used to interrupt the harness process."
+          "description": "Single key used to interrupt the harness process (e.g. C-c or Escape)."
+        },
+        "interrupt_sequence": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Ordered list of keys to send as separate tmux send-keys calls to interrupt the harness. Used when a single key is insufficient."
+        },
+        "interrupt_signal": {
+          "type": "string",
+          "enum": ["key", "sequence"],
+          "description": "Which interrupt method to use: key (single interrupt_key) or sequence (interrupt_sequence array)."
         },
         "instructions_file": {
           "type": "string",

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -738,22 +738,22 @@ type HarnessConfigEntry struct {
 	// model field; the alias is resolved to the concrete name at provision time.
 	ModelAliases map[string]string `json:"model_aliases,omitempty" yaml:"model_aliases,omitempty" koanf:"model_aliases"`
 
-	Provisioner      *HarnessProvisionerConfig        `json:"provisioner,omitempty" yaml:"provisioner,omitempty" koanf:"provisioner"`
-	ConfigDir        string                           `json:"config_dir,omitempty" yaml:"config_dir,omitempty" koanf:"config_dir"`
-	SkillsDir        string                           `json:"skills_dir,omitempty" yaml:"skills_dir,omitempty" koanf:"skills_dir"`
+	Provisioner       *HarnessProvisionerConfig        `json:"provisioner,omitempty" yaml:"provisioner,omitempty" koanf:"provisioner"`
+	ConfigDir         string                           `json:"config_dir,omitempty" yaml:"config_dir,omitempty" koanf:"config_dir"`
+	SkillsDir         string                           `json:"skills_dir,omitempty" yaml:"skills_dir,omitempty" koanf:"skills_dir"`
 	InterruptKey      string                           `json:"interrupt_key,omitempty" yaml:"interrupt_key,omitempty" koanf:"interrupt_key"`
 	InterruptSequence []string                         `json:"interrupt_sequence,omitempty" yaml:"interrupt_sequence,omitempty" koanf:"interrupt_sequence"`
 	InterruptSignal   string                           `json:"interrupt_signal,omitempty" yaml:"interrupt_signal,omitempty" koanf:"interrupt_signal"`
-	InstructionsFile string                           `json:"instructions_file,omitempty" yaml:"instructions_file,omitempty" koanf:"instructions_file"`
-	SystemPromptFile string                           `json:"system_prompt_file,omitempty" yaml:"system_prompt_file,omitempty" koanf:"system_prompt_file"`
-	SystemPromptMode string                           `json:"system_prompt_mode,omitempty" yaml:"system_prompt_mode,omitempty" koanf:"system_prompt_mode"`
-	Command          *HarnessCommandConfig            `json:"command,omitempty" yaml:"command,omitempty" koanf:"command"`
-	EnvTemplate      map[string]string                `json:"env_template,omitempty" yaml:"env_template,omitempty" koanf:"env_template"`
-	Capabilities     *api.HarnessAdvancedCapabilities `json:"capabilities,omitempty" yaml:"capabilities,omitempty" koanf:"capabilities"`
-	Auth             *HarnessAuthMetadata             `json:"auth,omitempty" yaml:"auth,omitempty" koanf:"auth"`
-	NoAuthConfig     *HarnessNoAuthConfig             `json:"no_auth,omitempty" yaml:"no_auth,omitempty" koanf:"no_auth"`
-	MCP              *HarnessMCPConfig                `json:"mcp,omitempty" yaml:"mcp,omitempty" koanf:"mcp"`
-	Dialect          map[string]interface{}           `json:"dialect,omitempty" yaml:"dialect,omitempty" koanf:"dialect"`
+	InstructionsFile  string                           `json:"instructions_file,omitempty" yaml:"instructions_file,omitempty" koanf:"instructions_file"`
+	SystemPromptFile  string                           `json:"system_prompt_file,omitempty" yaml:"system_prompt_file,omitempty" koanf:"system_prompt_file"`
+	SystemPromptMode  string                           `json:"system_prompt_mode,omitempty" yaml:"system_prompt_mode,omitempty" koanf:"system_prompt_mode"`
+	Command           *HarnessCommandConfig            `json:"command,omitempty" yaml:"command,omitempty" koanf:"command"`
+	EnvTemplate       map[string]string                `json:"env_template,omitempty" yaml:"env_template,omitempty" koanf:"env_template"`
+	Capabilities      *api.HarnessAdvancedCapabilities `json:"capabilities,omitempty" yaml:"capabilities,omitempty" koanf:"capabilities"`
+	Auth              *HarnessAuthMetadata             `json:"auth,omitempty" yaml:"auth,omitempty" koanf:"auth"`
+	NoAuthConfig      *HarnessNoAuthConfig             `json:"no_auth,omitempty" yaml:"no_auth,omitempty" koanf:"no_auth"`
+	MCP               *HarnessMCPConfig                `json:"mcp,omitempty" yaml:"mcp,omitempty" koanf:"mcp"`
+	Dialect           map[string]interface{}           `json:"dialect,omitempty" yaml:"dialect,omitempty" koanf:"dialect"`
 }
 
 // HarnessProvisionerConfig declares how a harness-config is provisioned.

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -741,7 +741,9 @@ type HarnessConfigEntry struct {
 	Provisioner      *HarnessProvisionerConfig        `json:"provisioner,omitempty" yaml:"provisioner,omitempty" koanf:"provisioner"`
 	ConfigDir        string                           `json:"config_dir,omitempty" yaml:"config_dir,omitempty" koanf:"config_dir"`
 	SkillsDir        string                           `json:"skills_dir,omitempty" yaml:"skills_dir,omitempty" koanf:"skills_dir"`
-	InterruptKey     string                           `json:"interrupt_key,omitempty" yaml:"interrupt_key,omitempty" koanf:"interrupt_key"`
+	InterruptKey      string                           `json:"interrupt_key,omitempty" yaml:"interrupt_key,omitempty" koanf:"interrupt_key"`
+	InterruptSequence []string                         `json:"interrupt_sequence,omitempty" yaml:"interrupt_sequence,omitempty" koanf:"interrupt_sequence"`
+	InterruptSignal   string                           `json:"interrupt_signal,omitempty" yaml:"interrupt_signal,omitempty" koanf:"interrupt_signal"`
 	InstructionsFile string                           `json:"instructions_file,omitempty" yaml:"instructions_file,omitempty" koanf:"instructions_file"`
 	SystemPromptFile string                           `json:"system_prompt_file,omitempty" yaml:"system_prompt_file,omitempty" koanf:"system_prompt_file"`
 	SystemPromptMode string                           `json:"system_prompt_mode,omitempty" yaml:"system_prompt_mode,omitempty" koanf:"system_prompt_mode"`

--- a/pkg/harness/container_script_harness.go
+++ b/pkg/harness/container_script_harness.go
@@ -85,6 +85,16 @@ func (c *ContainerScriptHarness) GetInterruptKey() string {
 	return c.entry.InterruptKey
 }
 
+// GetInterruptSequence returns the configured interrupt key sequence.
+// When interrupt_signal is "sequence" or interrupt_sequence is populated,
+// each entry is sent as a separate tmux send-keys call.
+func (c *ContainerScriptHarness) GetInterruptSequence() []string {
+	if c.entry.InterruptSignal == "sequence" || len(c.entry.InterruptSequence) > 0 {
+		return c.entry.InterruptSequence
+	}
+	return nil
+}
+
 // GetHarnessEmbedsFS returns an empty FS — container-script harnesses do not
 // own embedded files; their files live on disk in the harness-config dir.
 func (c *ContainerScriptHarness) GetHarnessEmbedsFS() (embed.FS, string) {

--- a/pkg/harness/container_script_harness_test.go
+++ b/pkg/harness/container_script_harness_test.go
@@ -100,6 +100,58 @@ func TestContainerScriptHarness_BasicGetters(t *testing.T) {
 	}
 }
 
+func TestContainerScriptHarness_GetInterruptSequence(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "config.yaml"), "harness: seqtest\nimage: scion-test:latest\n")
+	writeFile(t, filepath.Join(dir, "provision.py"), "#!/usr/bin/env python3\nimport sys\nsys.exit(0)\n")
+
+	// No sequence configured — should return nil.
+	entry := config.HarnessConfigEntry{
+		Harness:      "seqtest",
+		Image:        "scion-test:latest",
+		InterruptKey: "C-c",
+		Provisioner: &config.HarnessProvisionerConfig{
+			Type:             "container-script",
+			InterfaceVersion: 1,
+			Command:          []string{"python3", "$HOME/.scion/harness/provision.py"},
+		},
+	}
+	h, err := NewContainerScriptHarness(dir, entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seq := h.GetInterruptSequence(); seq != nil {
+		t.Errorf("expected nil sequence, got %v", seq)
+	}
+
+	// With interrupt_sequence and interrupt_signal=sequence.
+	entry.InterruptSequence = []string{"Escape", "Escape", "Escape"}
+	entry.InterruptSignal = "sequence"
+	h2, err := NewContainerScriptHarness(dir, entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seq := h2.GetInterruptSequence()
+	if len(seq) != 3 {
+		t.Fatalf("expected 3-key sequence, got %v", seq)
+	}
+	for i, want := range []string{"Escape", "Escape", "Escape"} {
+		if seq[i] != want {
+			t.Errorf("seq[%d]=%q, want %q", i, seq[i], want)
+		}
+	}
+
+	// With interrupt_sequence populated but no explicit interrupt_signal — still returns sequence.
+	entry.InterruptSignal = ""
+	h3, err := NewContainerScriptHarness(dir, entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seq := h3.GetInterruptSequence(); len(seq) != 3 {
+		t.Errorf("expected sequence even without signal field, got %v", seq)
+	}
+}
+
 func TestContainerScriptHarness_GetEnvTemplating(t *testing.T) {
 	h, _ := newTestContainerScriptHarness(t)
 	env := h.GetEnv("agent42", "/home/scion", "scion")

--- a/pkg/harness/declarative_generic.go
+++ b/pkg/harness/declarative_generic.go
@@ -66,6 +66,13 @@ func (d *DeclarativeGenericHarness) GetInterruptKey() string {
 	return "C-c"
 }
 
+func (d *DeclarativeGenericHarness) GetInterruptSequence() []string {
+	if d.entry.InterruptSignal == "sequence" || len(d.entry.InterruptSequence) > 0 {
+		return d.entry.InterruptSequence
+	}
+	return nil
+}
+
 func (d *DeclarativeGenericHarness) GetHarnessEmbedsFS() (embed.FS, string) {
 	return embed.FS{}, ""
 }

--- a/pkg/harness/generic.go
+++ b/pkg/harness/generic.go
@@ -89,6 +89,10 @@ func (g *Generic) GetInterruptKey() string {
 	return "C-c"
 }
 
+func (g *Generic) GetInterruptSequence() []string {
+	return nil
+}
+
 func (g *Generic) GetHarnessEmbedsFS() (embed.FS, string) {
 	return embed.FS{}, ""
 }

--- a/pkg/hub/handlers_broker_inbound.go
+++ b/pkg/hub/handlers_broker_inbound.go
@@ -145,6 +145,18 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// A leading "!" in the message body acts as an inline interrupt signal:
+	// strip the prefix and promote to urgent so the harness is interrupted
+	// before delivery — equivalent to --interrupt on the CLI.
+	if trimmed := strings.TrimSpace(req.Message.Msg); strings.HasPrefix(trimmed, "!") {
+		content := strings.TrimSpace(trimmed[1:])
+		if content == "" {
+			content = "interrupt"
+		}
+		req.Message.Msg = content
+		req.Message.Urgent = true
+	}
+
 	// Dispatch directly to the agent, bypassing the broker to avoid circular delivery
 	dispatcher := s.GetDispatcher()
 	if dispatcher == nil {

--- a/pkg/runtime/k8s_parity_test.go
+++ b/pkg/runtime/k8s_parity_test.go
@@ -54,6 +54,7 @@ func (h *EnvHarness) Provision(ctx context.Context, agentName, agentDir, agentHo
 	return nil
 }
 func (h *EnvHarness) GetInterruptKey() string                                        { return "C-c" }
+func (h *EnvHarness) GetInterruptSequence() []string                                 { return nil }
 func (h *EnvHarness) GetHarnessEmbedsFS() (embed.FS, string)                         { return embed.FS{}, "" }
 func (h *EnvHarness) InjectAgentInstructions(agentHome string, content []byte) error { return nil }
 func (h *EnvHarness) InjectSystemPrompt(agentHome string, content []byte) error      { return nil }

--- a/pkg/runtime/k8s_runtime_tmux_test.go
+++ b/pkg/runtime/k8s_runtime_tmux_test.go
@@ -50,6 +50,7 @@ func (m *MockHarness) Provision(ctx context.Context, agentName, agentDir, agentH
 	return nil
 }
 func (m *MockHarness) GetInterruptKey() string                                        { return "C-c" }
+func (m *MockHarness) GetInterruptSequence() []string                                 { return nil }
 func (m *MockHarness) GetHarnessEmbedsFS() (embed.FS, string)                         { return embed.FS{}, "" }
 func (m *MockHarness) InjectAgentInstructions(agentHome string, content []byte) error { return nil }
 func (m *MockHarness) InjectSystemPrompt(agentHome string, content []byte) error      { return nil }

--- a/pkg/runtime/nfs_uid_test.go
+++ b/pkg/runtime/nfs_uid_test.go
@@ -208,6 +208,7 @@ func (h *nfsTestHarness) Provision(ctx context.Context, agentName, agentDir, age
 	return nil
 }
 func (h *nfsTestHarness) GetInterruptKey() string                { return "C-c" }
+func (h *nfsTestHarness) GetInterruptSequence() []string         { return nil }
 func (h *nfsTestHarness) GetHarnessEmbedsFS() (embed.FS, string) { return embed.FS{}, "" }
 func (h *nfsTestHarness) InjectAgentInstructions(agentHome string, content []byte) error {
 	return nil


### PR DESCRIPTION
Two fixes for chat integration interrupt handling

- Strip the ! prefix from inbound broker messages before forwarding to agent (mirrors existing messagebroker.go logic)
- Add interrupt_sequence support to Harness interface with fallback to GetInterruptKey, all harness implementations updated

Related: https://github.com/ptone/scion/issues/192