### PR TITLE
fix: detect podman at non-standard macOS paths (/opt/podman/bin)

### DIFF
--- a/pkg/runtime/factory.go
+++ b/pkg/runtime/factory.go
@@ -72,6 +72,9 @@ func GetRuntime(projectPath string, profileName string) Runtime {
 			if _, err := exec.LookPath("podman"); err == nil {
 				runtimeType = "podman"
 				util.Debugf("GetRuntime: detected 'podman' on macOS")
+			} else if p := findPodmanNonStandardPath(); p != "" {
+				runtimeType = "podman"
+				util.Debugf("GetRuntime: found podman at non-standard path %s on macOS", p)
 			} else if _, err := exec.LookPath("docker"); err == nil {
 				runtimeType = "docker"
 				util.Debugf("GetRuntime: detected 'docker' on macOS")
@@ -110,7 +113,13 @@ func GetRuntime(projectPath string, profileName string) Runtime {
 		}
 		return dr
 	case "podman":
-		pr := NewPodmanRuntime()
+		podmanCmd := ""
+		if runtime.GOOS == "darwin" {
+			if _, err := exec.LookPath("podman"); err != nil {
+				podmanCmd = findPodmanNonStandardPath()
+			}
+		}
+		pr := NewPodmanRuntime(podmanCmd)
 		if rtConfig.Host != "" {
 			if p, ok := pr.(*PodmanRuntime); ok {
 				p.Host = rtConfig.Host
@@ -146,6 +155,19 @@ func GetRuntime(projectPath string, profileName string) Runtime {
 
 	// Fallback should not be reached if logic is correct, but default to Docker
 	return NewDockerRuntime()
+}
+
+func findPodmanNonStandardPath() string {
+	for _, p := range []string{
+		"/opt/podman/bin/podman",
+		"/usr/local/bin/podman",
+		"/usr/bin/podman",
+	} {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
 }
 
 type ErrorRuntime struct {

--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -37,16 +37,19 @@ type PodmanRuntime struct {
 
 // NewPodmanRuntime creates a new PodmanRuntime after verifying that the podman
 // binary exists and meets the minimum version requirement (4.x+).
-// Returns an ErrorRuntime if validation fails.
-func NewPodmanRuntime() Runtime {
+// If cmdOverride is non-empty, it is used as the podman binary path instead of
+// looking up "podman" on $PATH. Returns an ErrorRuntime if validation fails.
+func NewPodmanRuntime(cmdOverride string) Runtime {
 	command := "podman"
-
-	// Verify podman is on PATH
-	path, err := exec.LookPath(command)
-	if err != nil {
-		return &ErrorRuntime{Err: fmt.Errorf("podman not found on PATH: %w", err)}
+	if cmdOverride != "" {
+		command = cmdOverride
 	}
-	_ = path
+
+	if cmdOverride == "" {
+		if _, err := exec.LookPath(command); err != nil {
+			return &ErrorRuntime{Err: fmt.Errorf("podman not found on PATH: %w", err)}
+		}
+	}
 
 	// Check version: minimum 4.x
 	out, err := exec.Command(command, "--version").Output()


### PR DESCRIPTION
## Problem
`exec.LookPath("podman")` only searches $PATH. Podman Desktop installs to /opt/podman/bin/ which is absent from the daemon PATH.
## Fix
Check /opt/podman/bin/podman and other common macOS paths as fallback after LookPath fails