### PR TITLE
fix: remove apple-container DNS sudo from server startup and onboarding

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1714,15 +1714,16 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 	}
 
 	if rt != nil && rt.Name() == "container" && containerHubEndpoint != "" {
-		_, dnsErr := runtime.EnsureAppleDNS(ctx, runtime.AppleDNSHostname, runtime.AppleDNSIP)
-		if dnsErr != nil {
-			log.Printf("WARNING: Failed to configure Apple Container DNS (%s → %s): %v\n"+
-				"Agents may not reach the Hub. Run manually:\n"+
-				"  sudo container system dns create %s --localhost %s",
-				runtime.AppleDNSHostname, runtime.AppleDNSIP, dnsErr,
-				runtime.AppleDNSHostname, runtime.AppleDNSIP)
+		exists, checkErr := runtime.AppleDNSRuleExists(ctx, runtime.AppleDNSHostname)
+		if checkErr != nil {
+			log.Printf("WARNING: could not check Apple Container DNS status: %v", checkErr)
+		} else if exists {
+			log.Printf("Apple Container DNS rule already configured: %s → %s", runtime.AppleDNSHostname, runtime.AppleDNSIP)
 		} else {
-			log.Printf("Refreshed Apple Container DNS rule: %s → %s (PF rule restored)", runtime.AppleDNSHostname, runtime.AppleDNSIP)
+			log.Printf("Apple Container runtime detected. To enable agent connectivity, run once:\n"+
+				"  sudo container system dns create %s --localhost %s\n"+
+				"  See: https://googlecloudplatform.github.io/scion/",
+				runtime.AppleDNSHostname, runtime.AppleDNSIP)
 		}
 	}
 

--- a/pkg/runtime/apple_dns.go
+++ b/pkg/runtime/apple_dns.go
@@ -42,20 +42,22 @@ func AppleDNSRuleExists(ctx context.Context, hostname string) (bool, error) {
 	return false, nil
 }
 
-// EnsureAppleDNS always attempts to create (or recreate) the DNS rule.
-// This is necessary because PF rules do not persist across macOS reboots
-// even though DNS entries do, so we must re-run the create command on
-// every server startup to restore the packet filter rule.
+// EnsureAppleDNS attempts to create (or recreate) the DNS rule using
+// non-interactive sudo (sudo -n). This prevents password prompts from
+// leaking to the user's terminal when the server runs as a daemon.
+// PF rules do not persist across macOS reboots even though DNS entries
+// do, so the create command must be re-run to restore the packet filter
+// rule.
 func EnsureAppleDNS(ctx context.Context, hostname, ip string) (bool, error) {
-	cmd := exec.CommandContext(ctx, "sudo", "container", "system", "dns", "create", hostname, "--localhost", ip)
+	cmd := exec.CommandContext(ctx, "sudo", "-n", "container", "system", "dns", "create", hostname, "--localhost", ip)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		// Create failed — likely the entry already exists (possibly with a
 		// different IP). Delete it and retry.
-		delCmd := exec.CommandContext(ctx, "sudo", "container", "system", "dns", "delete", hostname)
+		delCmd := exec.CommandContext(ctx, "sudo", "-n", "container", "system", "dns", "delete", hostname)
 		if delOut, delErr := delCmd.CombinedOutput(); delErr != nil {
 			return false, fmt.Errorf("sudo container system dns delete failed: %w (output: %s); original create error: %v (output: %s)", delErr, string(delOut), err, string(out))
 		}
-		retryCmd := exec.CommandContext(ctx, "sudo", "container", "system", "dns", "create", hostname, "--localhost", ip)
+		retryCmd := exec.CommandContext(ctx, "sudo", "-n", "container", "system", "dns", "create", hostname, "--localhost", ip)
 		if retryOut, retryErr := retryCmd.CombinedOutput(); retryErr != nil {
 			return false, fmt.Errorf("sudo container system dns create (retry after delete) failed: %w (output: %s)", retryErr, string(retryOut))
 		}

--- a/web/src/components/pages/onboarding.ts
+++ b/web/src/components/pages/onboarding.ts
@@ -799,17 +799,10 @@ export class ScionPageOnboarding extends LitElement {
       }
 
       if (this.selectedRuntime === 'container') {
-        try {
-          const dnsRes = await apiFetch('/api/v1/system/apple-dns', { method: 'POST' });
-          if (dnsRes.ok) {
-            const dnsData = await dnsRes.json() as { configured: boolean; hostname: string; ip: string; error?: string };
-            if (!dnsData.configured) {
-              this.dnsWarning = `Apple Container DNS setup requires sudo. If not prompted, run manually:\n  sudo container system dns create ${dnsData.hostname} --localhost ${dnsData.ip}`;
-            }
-          }
-        } catch {
-          // non-fatal — server startup will retry on next launch
-        }
+        this.dnsWarning =
+          'Apple Container requires a DNS rule for agent connectivity. Run once (and after each reboot):\n' +
+          '  sudo container system dns create host.containers.internal --localhost 203.0.113.1\n' +
+          'See: https://googlecloudplatform.github.io/scion/local/apple-container/';
       }
 
       this.currentStep = 3;


### PR DESCRIPTION
## Problem
Two sudo calls causing Password prompts: one in startRuntimeBroker() at startup, one in onboarding.ts POST to /api/v1/system/apple-dns.
## Fix
Replace startup call with log message to docs; remove SPA POST, show info banner with manual command and docs link; use sudo -n in EnsureAppleDNS