### PR TITLE
feat: Model UX improvements - alias tiers, CLI flag, project defaults, and web UI dropdowns

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -75,6 +75,7 @@ var (
 	disableTelemetry      bool
 	inlineConfigPath      string
 	labelFlags            []string
+	modelFlag             string
 )
 
 func parseLabels(raw []string) (map[string]string, error) {
@@ -405,6 +406,14 @@ func RunAgent(cmd *cobra.Command, args []string, resume bool) error {
 		if err := resolveInlineConfigContent(inlineCfg, inlineConfigDir); err != nil {
 			return err
 		}
+	}
+
+	if modelFlag != "" {
+		normalizedModel := config.NormalizeModelAlias(modelFlag)
+		if inlineCfg == nil {
+			inlineCfg = &api.ScionConfig{}
+		}
+		inlineCfg.Model = normalizedModel
 	}
 
 	// This allows starting/resuming an agent even if it exists on Hub but not locally

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -77,6 +77,9 @@ func init() {
 	// Inline config flag
 	startCmd.Flags().StringVar(&inlineConfigPath, "config", "", "Path to inline agent config file (YAML/JSON), or '-' for stdin")
 
+	// Model flag
+	startCmd.Flags().StringVar(&modelFlag, "model", "", "Model to use: alias (small, medium, large, extra-large/xl) or explicit model ID")
+
 	// Label flags
 	startCmd.Flags().StringArrayVar(&labelFlags, "label", nil, "Label in key=value format (repeatable)")
 

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -17,6 +17,8 @@ package cmd
 import (
 	"testing"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,4 +41,40 @@ func TestModelFlagRegistered(t *testing.T) {
 	f := startCmd.Flags().Lookup("model")
 	require.NotNil(t, f, "--model flag should be registered on start command")
 	assert.Equal(t, "", f.DefValue, "--model default should be empty")
+}
+
+func TestModelFlagOverridesConfigModel(t *testing.T) {
+	inlineCfg := &api.ScionConfig{Model: "small"}
+
+	flagModel := "large"
+	normalizedModel := config.NormalizeModelAlias(flagModel)
+
+	if normalizedModel != "" {
+		inlineCfg.Model = normalizedModel
+	}
+
+	if inlineCfg.Model != "large" {
+		t.Errorf("expected model 'large', got %q", inlineCfg.Model)
+	}
+}
+
+func TestModelFlagCreatesConfig(t *testing.T) {
+	var inlineCfg *api.ScionConfig
+
+	flagModel := "xl"
+	normalizedModel := config.NormalizeModelAlias(flagModel)
+
+	if normalizedModel != "" {
+		if inlineCfg == nil {
+			inlineCfg = &api.ScionConfig{}
+		}
+		inlineCfg.Model = normalizedModel
+	}
+
+	if inlineCfg == nil {
+		t.Fatal("expected inlineCfg to be created")
+	}
+	if inlineCfg.Model != "extra-large" {
+		t.Errorf("expected model 'extra-large', got %q", inlineCfg.Model)
+	}
 }

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -34,3 +34,9 @@ func TestNoNotifyFlagRegistered(t *testing.T) {
 	assert.Empty(t, f.Deprecated, "--no-notify should not be deprecated")
 	assert.Equal(t, "false", f.DefValue)
 }
+
+func TestModelFlagRegistered(t *testing.T) {
+	f := startCmd.Flags().Lookup("model")
+	require.NotNil(t, f, "--model flag should be registered on start command")
+	assert.Equal(t, "", f.DefValue, "--model default should be empty")
+}

--- a/harnesses/claude/config.yaml
+++ b/harnesses/claude/config.yaml
@@ -40,6 +40,7 @@ model_aliases:
   small: haiku
   medium: sonnet
   large: opus
+  extra-large: opus
 env:
   ANTHROPIC_MODEL: "opus"
   ANTHROPIC_SMALL_FAST_MODEL: "haiku"

--- a/harnesses/codex/config.yaml
+++ b/harnesses/codex/config.yaml
@@ -40,6 +40,7 @@ model_aliases:
   small: gpt-5.4-mini
   medium: gpt-5.4
   large: gpt-5.5
+  extra-large: gpt-5.5
 command:
   base: ["codex", "--sandbox", "danger-full-access", "--dangerously-bypass-approvals-and-sandbox", "--dangerously-bypass-hook-trust"]
   # resume_flag is split on whitespace, so "resume --last" emits two argv tokens

--- a/harnesses/copilot/config.yaml
+++ b/harnesses/copilot/config.yaml
@@ -37,6 +37,7 @@ model_aliases:
   small: claude-haiku-4.5
   medium: claude-sonnet-4.5
   large: claude-opus-4.8
+  extra-large: claude-opus-4.8
 
 command:
   base: ["copilot", "--no-auto-update", "--no-remote", "--no-color",

--- a/harnesses/gemini-cli/config.yaml
+++ b/harnesses/gemini-cli/config.yaml
@@ -35,6 +35,7 @@ model_aliases:
   small: gemini-flash-lite
   medium: gemini-flash
   large: gemini-pro
+  extra-large: gemini-pro
 env:
   GEMINI_CLI_NO_RELAUNCH: "true"
 command:

--- a/harnesses/hermes/config.yaml
+++ b/harnesses/hermes/config.yaml
@@ -37,6 +37,7 @@ model_aliases:
   small: google/gemini-3.5-flash
   medium: anthropic/claude-sonnet-4
   large: anthropic/claude-opus-4
+  extra-large: anthropic/claude-opus-4
 
 command:
   base: ["hermes", "chat", "--yolo"]

--- a/harnesses/opencode/config.yaml
+++ b/harnesses/opencode/config.yaml
@@ -39,6 +39,7 @@ model_aliases:
   small: claude-sonnet
   medium: claude-sonnet
   large: claude-opus
+  extra-large: claude-opus
 command:
   # task_position is before_base_args because the compiled OpenCode harness
   # emits `opencode --prompt <task> <base_args...>` — flipping this to

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -621,9 +621,10 @@ func ValidateAgnosticTemplate(cfg *api.ScionConfig) error {
 
 // KnownModelAliases is the canonical set of recognized model size aliases.
 var KnownModelAliases = map[string]bool{
-	"small":  true,
-	"medium": true,
-	"large":  true,
+	"small":       true,
+	"medium":      true,
+	"large":       true,
+	"extra-large": true,
 }
 
 // WarnDeprecatedTemplateFields returns deprecation warnings for harness-specific
@@ -641,9 +642,18 @@ func WarnDeprecatedTemplateFields(cfg *api.ScionConfig) []string {
 		warnings = append(warnings, "template sets 'auth_selectedType' which is harness-specific; move it to your harness-config's config.yaml instead")
 	}
 	if cfg.Model != "" && !KnownModelAliases[cfg.Model] {
-		warnings = append(warnings, fmt.Sprintf("template sets 'model' to a concrete model name %q; consider using a size alias (small, medium, large) for portability across harnesses", cfg.Model))
+		warnings = append(warnings, fmt.Sprintf("template sets 'model' to a concrete model name %q; consider using a size alias (small, medium, large, extra-large) for portability across harnesses", cfg.Model))
 	}
 	return warnings
+}
+
+// NormalizeModelAlias normalizes shorthand model alias names to their canonical form.
+// Currently maps "xl" to "extra-large".
+func NormalizeModelAlias(model string) string {
+	if model == "xl" {
+		return "extra-large"
+	}
+	return model
 }
 
 // ResolveModelAlias resolves a model size alias to a concrete model name
@@ -653,6 +663,7 @@ func ResolveModelAlias(model string, aliases map[string]string) string {
 	if model == "" || aliases == nil {
 		return model
 	}
+	model = NormalizeModelAlias(model)
 	if !KnownModelAliases[model] {
 		return model // concrete model name, pass through
 	}

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -641,15 +641,15 @@ func WarnDeprecatedTemplateFields(cfg *api.ScionConfig) []string {
 	if cfg.AuthSelectedType != "" {
 		warnings = append(warnings, "template sets 'auth_selectedType' which is harness-specific; move it to your harness-config's config.yaml instead")
 	}
-	if cfg.Model != "" && !KnownModelAliases[cfg.Model] {
+	if cfg.Model != "" && !KnownModelAliases[NormalizeModelAlias(cfg.Model)] {
 		warnings = append(warnings, fmt.Sprintf("template sets 'model' to a concrete model name %q; consider using a size alias (small, medium, large, extra-large) for portability across harnesses", cfg.Model))
 	}
 	return warnings
 }
 
 // NormalizeModelAlias normalizes shorthand model alias names to their canonical form.
-// Currently maps "xl" to "extra-large".
 func NormalizeModelAlias(model string) string {
+	model = strings.ToLower(model)
 	if model == "xl" {
 		return "extra-large"
 	}

--- a/pkg/config/templates_test.go
+++ b/pkg/config/templates_test.go
@@ -1726,10 +1726,17 @@ func TestNormalizeModelAlias(t *testing.T) {
 		expected string
 	}{
 		{"xl", "extra-large"},
+		{"XL", "extra-large"},
+		{"Xl", "extra-large"},
 		{"small", "small"},
+		{"Small", "small"},
 		{"medium", "medium"},
+		{"MEDIUM", "medium"},
 		{"large", "large"},
+		{"LARGE", "large"},
 		{"extra-large", "extra-large"},
+		{"Extra-Large", "extra-large"},
+		{"EXTRA-LARGE", "extra-large"},
 		{"claude-opus-4-8", "claude-opus-4-8"},
 		{"", ""},
 	}
@@ -1768,6 +1775,22 @@ func TestWarnDeprecatedTemplateFields(t *testing.T) {
 		warnings := WarnDeprecatedTemplateFields(cfg)
 		if len(warnings) != 0 {
 			t.Errorf("expected no warnings for model alias 'large', got %v", warnings)
+		}
+	})
+
+	t.Run("no warning for xl shorthand", func(t *testing.T) {
+		cfg := &api.ScionConfig{Model: "xl"}
+		warnings := WarnDeprecatedTemplateFields(cfg)
+		if len(warnings) != 0 {
+			t.Errorf("expected no warnings for model alias 'xl', got %v", warnings)
+		}
+	})
+
+	t.Run("no warning for uppercase alias", func(t *testing.T) {
+		cfg := &api.ScionConfig{Model: "LARGE"}
+		warnings := WarnDeprecatedTemplateFields(cfg)
+		if len(warnings) != 0 {
+			t.Errorf("expected no warnings for model alias 'LARGE', got %v", warnings)
 		}
 	})
 

--- a/pkg/config/templates_test.go
+++ b/pkg/config/templates_test.go
@@ -1686,9 +1686,10 @@ func TestFriendlyTemplateName(t *testing.T) {
 
 func TestResolveModelAlias(t *testing.T) {
 	aliases := map[string]string{
-		"small":  "haiku",
-		"medium": "sonnet",
-		"large":  "opus",
+		"small":       "haiku",
+		"medium":      "sonnet",
+		"large":       "opus",
+		"extra-large": "opus-xl",
 	}
 
 	tests := []struct {
@@ -1700,6 +1701,8 @@ func TestResolveModelAlias(t *testing.T) {
 		{"alias resolves to concrete name", "large", aliases, "opus"},
 		{"small alias", "small", aliases, "haiku"},
 		{"medium alias", "medium", aliases, "sonnet"},
+		{"extra-large alias resolves", "extra-large", aliases, "opus-xl"},
+		{"xl shorthand resolves via normalization", "xl", aliases, "opus-xl"},
 		{"concrete model passes through", "gemini-pro", aliases, "gemini-pro"},
 		{"empty model passes through", "", aliases, ""},
 		{"nil aliases passes through", "large", nil, "large"},
@@ -1712,6 +1715,29 @@ func TestResolveModelAlias(t *testing.T) {
 			got := ResolveModelAlias(tt.model, tt.aliases)
 			if got != tt.expected {
 				t.Errorf("ResolveModelAlias(%q, ...) = %q, want %q", tt.model, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeModelAlias(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"xl", "extra-large"},
+		{"small", "small"},
+		{"medium", "medium"},
+		{"large", "large"},
+		{"extra-large", "extra-large"},
+		{"claude-opus-4-8", "claude-opus-4-8"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := NormalizeModelAlias(tt.input)
+			if got != tt.expected {
+				t.Errorf("NormalizeModelAlias(%q) = %q, want %q", tt.input, got, tt.expected)
 			}
 		})
 	}
@@ -1792,7 +1818,7 @@ func TestWarnDeprecatedTemplateFields(t *testing.T) {
 }
 
 func TestKnownModelAliases(t *testing.T) {
-	expected := []string{"small", "medium", "large"}
+	expected := []string{"small", "medium", "large", "extra-large"}
 	for _, alias := range expected {
 		if !KnownModelAliases[alias] {
 			t.Errorf("expected %q to be a known model alias", alias)

--- a/pkg/config/templates_test.go
+++ b/pkg/config/templates_test.go
@@ -1825,7 +1825,7 @@ func TestKnownModelAliases(t *testing.T) {
 		}
 	}
 
-	notAliases := []string{"tiny", "xl", "gemini-pro", "opus", ""}
+	notAliases := []string{"tiny", "gemini-pro", "opus", ""}
 	for _, name := range notAliases {
 		if KnownModelAliases[name] {
 			t.Errorf("expected %q to NOT be a known model alias", name)

--- a/pkg/hub/project_settings_handlers.go
+++ b/pkg/hub/project_settings_handlers.go
@@ -27,6 +27,7 @@ import (
 const (
 	projectSettingDefaultTemplate      = "scion.io/default-template"
 	projectSettingDefaultHarnessConfig = "scion.io/default-harness-config"
+	projectSettingDefaultModel         = "scion.io/default-model"
 	projectSettingTelemetryEnabled     = "scion.io/telemetry-enabled"
 	projectSettingActiveProfile        = "scion.io/active-profile"
 
@@ -129,6 +130,7 @@ func projectSettingsFromAnnotations(project *store.Project) *hubclient.ProjectSe
 
 	settings.DefaultTemplate = project.Annotations[projectSettingDefaultTemplate]
 	settings.DefaultHarnessConfig = project.Annotations[projectSettingDefaultHarnessConfig]
+	settings.DefaultModel = project.Annotations[projectSettingDefaultModel]
 	settings.ActiveProfile = project.Annotations[projectSettingActiveProfile]
 
 	if val, ok := project.Annotations[projectSettingTelemetryEnabled]; ok {
@@ -194,6 +196,7 @@ func applyProjectSettingsToAnnotations(project *store.Project, settings *hubclie
 
 	setOrDelete(project.Annotations, projectSettingDefaultTemplate, settings.DefaultTemplate)
 	setOrDelete(project.Annotations, projectSettingDefaultHarnessConfig, settings.DefaultHarnessConfig)
+	setOrDelete(project.Annotations, projectSettingDefaultModel, settings.DefaultModel)
 	setOrDelete(project.Annotations, projectSettingActiveProfile, settings.ActiveProfile)
 
 	if settings.TelemetryEnabled != nil {
@@ -269,6 +272,11 @@ func applyProjectDefaults(ac *store.AgentAppliedConfig, project *store.Project) 
 	// Apply default harness config (only if not already set)
 	if ac.HarnessConfig == "" && settings.DefaultHarnessConfig != "" {
 		ac.HarnessConfig = settings.DefaultHarnessConfig
+	}
+
+	// Apply default model (only if not already set by agent/template/CLI)
+	if ac.Model == "" && settings.DefaultModel != "" {
+		ac.Model = settings.DefaultModel
 	}
 
 	// Check if there are any project limit/resource defaults to apply

--- a/pkg/hub/project_settings_handlers_test.go
+++ b/pkg/hub/project_settings_handlers_test.go
@@ -208,6 +208,63 @@ func TestApplyProjectDefaults_HarnessConfig(t *testing.T) {
 	})
 }
 
+func TestProjectSettings_DefaultModel(t *testing.T) {
+	srv, s := testServer(t)
+	project := createTestProjectForSettings(t, s)
+
+	putBody := hubclient.ProjectSettings{
+		DefaultModel: "claude-sonnet-5",
+	}
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/projects/"+project.ID+"/settings", putBody)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var putResp hubclient.ProjectSettings
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&putResp))
+	assert.Equal(t, "claude-sonnet-5", putResp.DefaultModel)
+
+	// GET should return persisted value
+	rec = doRequest(t, srv, http.MethodGet, "/api/v1/projects/"+project.ID+"/settings", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var getResp hubclient.ProjectSettings
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&getResp))
+	assert.Equal(t, "claude-sonnet-5", getResp.DefaultModel)
+
+	// Clear by sending empty value
+	clearBody := hubclient.ProjectSettings{}
+	rec = doRequest(t, srv, http.MethodPut, "/api/v1/projects/"+project.ID+"/settings", clearBody)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var clearResp hubclient.ProjectSettings
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&clearResp))
+	assert.Empty(t, clearResp.DefaultModel)
+}
+
+func TestApplyProjectDefaults_Model(t *testing.T) {
+	t.Run("applies default model when empty", func(t *testing.T) {
+		project := &store.Project{
+			Annotations: map[string]string{
+				"scion.io/default-model": "claude-sonnet-5",
+			},
+		}
+		ac := &store.AgentAppliedConfig{}
+		applyProjectDefaults(ac, project)
+		assert.Equal(t, "claude-sonnet-5", ac.Model)
+	})
+
+	t.Run("does not override explicit model", func(t *testing.T) {
+		project := &store.Project{
+			Annotations: map[string]string{
+				"scion.io/default-model": "claude-sonnet-5",
+			},
+		}
+		ac := &store.AgentAppliedConfig{Model: "claude-opus-4"}
+		applyProjectDefaults(ac, project)
+		assert.Equal(t, "claude-opus-4", ac.Model)
+	})
+}
+
 func TestProjectSettings_DefaultGCPIdentity(t *testing.T) {
 	srv, s := testServer(t)
 	project := createTestProjectForSettings(t, s)

--- a/pkg/hubclient/types.go
+++ b/pkg/hubclient/types.go
@@ -202,6 +202,7 @@ type ProjectSettings struct {
 	ActiveProfile        string                 `json:"activeProfile,omitempty"`
 	DefaultTemplate      string                 `json:"defaultTemplate,omitempty"`
 	DefaultHarnessConfig string                 `json:"defaultHarnessConfig,omitempty"`
+	DefaultModel         string                 `json:"defaultModel,omitempty"`
 	TelemetryEnabled     *bool                  `json:"telemetryEnabled,omitempty"`
 	Bucket               *BucketConfig          `json:"bucket,omitempty"`
 	Runtimes             map[string]interface{} `json:"runtimes,omitempty"`

--- a/web/src/components/pages/agent-configure.ts
+++ b/web/src/components/pages/agent-configure.ts
@@ -27,6 +27,7 @@ import { customElement, state } from 'lit/decorators.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { dispatchPageTitle } from '../../client/page-title.js';
 import type { Agent, CapabilityField, GCPIdentityConfig, GCPServiceAccount, HarnessAdvancedCapabilities } from '../../shared/types.js';
+import { normalizeModelAlias } from '../../shared/model-utils.js';
 import type { EnvEntry } from '../shared/env-editor.js';
 import '../shared/env-editor.js';
 
@@ -420,8 +421,9 @@ export class ScionPageAgentConfigure extends LitElement {
 
   private deriveModelSelection(model: string): { selection: '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other'; customId: string } {
     if (!model) return { selection: '', customId: '' };
-    if (['small', 'medium', 'large', 'extra-large'].includes(model)) {
-      return { selection: model as 'small' | 'medium' | 'large' | 'extra-large', customId: '' };
+    const normalized = normalizeModelAlias(model);
+    if (['small', 'medium', 'large', 'extra-large'].includes(normalized)) {
+      return { selection: normalized as 'small' | 'medium' | 'large' | 'extra-large', customId: '' };
     }
     return { selection: 'other', customId: model };
   }
@@ -805,7 +807,7 @@ export class ScionPageAgentConfigure extends LitElement {
 
     return html`
       <div class="form-field">
-        <sl-select label="Model" value=${this.modelSelection} clearable
+        <sl-select label="Model" .value=${this.modelSelection} clearable
             @sl-change=${(e: any) => { this.modelSelection = e.target.value; if (e.target.value !== 'other') this.customModelId = ''; }}>
           <sl-option value="small">Small</sl-option>
           <sl-option value="medium">Medium</sl-option>

--- a/web/src/components/pages/agent-configure.ts
+++ b/web/src/components/pages/agent-configure.ts
@@ -80,6 +80,8 @@ export class ScionPageAgentConfigure extends LitElement {
 
   // Form fields — General
   @state() private model = '';
+  @state() private modelSelection: '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other' = '';
+  @state() private customModelId = '';
   @state() private image = '';
   @state() private branch = '';
   @state() private containerUser = '';
@@ -416,6 +418,14 @@ export class ScionPageAgentConfigure extends LitElement {
     }
   }
 
+  private deriveModelSelection(model: string): { selection: '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other'; customId: string } {
+    if (!model) return { selection: '', customId: '' };
+    if (['small', 'medium', 'large', 'extra-large'].includes(model)) {
+      return { selection: model as 'small' | 'medium' | 'large' | 'extra-large', customId: '' };
+    }
+    return { selection: 'other', customId: model };
+  }
+
   private populateForm(): void {
     if (!this.agent) return;
     const ac = this.agent.appliedConfig;
@@ -423,6 +433,9 @@ export class ScionPageAgentConfigure extends LitElement {
 
     // General
     this.model = ac?.model || ic?.model || '';
+    const derived = this.deriveModelSelection(this.model);
+    this.modelSelection = derived.selection;
+    this.customModelId = derived.customId;
     this.image = ac?.image || ic?.image || '';
     this.branch = ic?.branch || '';
     this.containerUser = ic?.user || '';
@@ -464,7 +477,10 @@ export class ScionPageAgentConfigure extends LitElement {
     const config: ScionConfigPayload = {};
     const caps = this.harnessCapabilities;
 
-    if (this.model) config.model = this.model;
+    const model = this.modelSelection === 'other'
+      ? this.customModelId
+      : this.modelSelection;
+    if (model) config.model = model;
     if (this.image) config.image = this.image;
     if (this.branch) config.branch = this.branch;
     if (this.containerUser) config.user = this.containerUser;
@@ -789,12 +805,22 @@ export class ScionPageAgentConfigure extends LitElement {
 
     return html`
       <div class="form-field">
-        <label>Model</label>
-        <sl-input
-          placeholder="e.g. claude-opus-4-6, gemini-2.5-pro"
-          .value=${this.model}
-          @sl-input=${(e: Event) => { this.model = (e.target as HTMLElement & { value: string }).value; }}
-        ></sl-input>
+        <sl-select label="Model" value=${this.modelSelection} clearable
+            @sl-change=${(e: any) => { this.modelSelection = e.target.value; if (e.target.value !== 'other') this.customModelId = ''; }}>
+          <sl-option value="small">Small</sl-option>
+          <sl-option value="medium">Medium</sl-option>
+          <sl-option value="large">Large</sl-option>
+          <sl-option value="extra-large">Extra Large</sl-option>
+          <sl-option value="other">Other (specify)</sl-option>
+        </sl-select>
+
+        ${this.modelSelection === 'other' ? html`
+          <sl-input label="Model ID" placeholder="e.g. claude-opus-4-8"
+            .value=${this.customModelId}
+            @sl-input=${(e: any) => { this.customModelId = e.target.value; }}
+            style="margin-top: 0.75rem">
+          </sl-input>
+        ` : ''}
       </div>
 
       <div class="form-field">

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -30,6 +30,7 @@ import type {
   Template,
   GCPServiceAccount,
 } from '../../shared/types.js';
+import { normalizeModelAlias } from '../../shared/model-utils.js';
 
 interface HarnessConfigEntry {
   id: string;
@@ -824,7 +825,7 @@ private selectBrokerForProject(): void {
 
     // Pre-populate model from project defaults if user hasn't selected one
     if (!this.modelSelection && settings?.defaultModel) {
-      const dm = settings.defaultModel;
+      const dm = normalizeModelAlias(settings.defaultModel);
       if (['small', 'medium', 'large', 'extra-large'].includes(dm)) {
         this.modelSelection = dm as 'small' | 'medium' | 'large' | 'extra-large';
       } else if (dm) {

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -121,6 +121,12 @@ export class ScionPageAgentCreate extends LitElement {
   @state()
   private harnessConfigs: HarnessConfigEntry[] = [];
 
+  @state()
+  private modelSelection: '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other' = '';
+
+  @state()
+  private customModelId = '';
+
   /** ID of an existing agent we're editing (came back from configure page) */
   private editingAgentId: string | null = null;
 
@@ -138,6 +144,7 @@ export class ScionPageAgentCreate extends LitElement {
       defaultMaxDuration?: string;
       defaultGCPIdentityMode?: string;
       defaultGCPIdentityServiceAccountID?: string;
+      defaultModel?: string;
     }
   > = new Map();
 
@@ -541,6 +548,14 @@ export class ScionPageAgentCreate extends LitElement {
           SCION_TELEMETRY_ENABLED: this.telemetryEnabled ? 'true' : 'false',
         },
       };
+
+      const model = this.modelSelection === 'other'
+        ? this.customModelId
+        : this.modelSelection;
+      if (model) {
+        config.model = model;
+      }
+
       body.config = config;
 
       // Validate GCP assign mode
@@ -654,6 +669,14 @@ export class ScionPageAgentCreate extends LitElement {
       const builtLabels = this.buildLabels();
       if (builtLabels) {
         body.labels = builtLabels;
+      }
+
+      // Model selection
+      const model = this.modelSelection === 'other'
+        ? this.customModelId
+        : this.modelSelection;
+      if (model) {
+        body.config = { ...(body.config as Record<string, unknown> || {}), model };
       }
 
       // GCP identity assignment
@@ -772,6 +795,7 @@ private selectBrokerForProject(): void {
       t.defaultHarnessConfig || t.harness || harnessDefault;
 
     // Try project settings default template first
+    let templateResolved = false;
     if (settings?.defaultTemplate) {
       const match = visible.find(
         (t) => t.name === settings.defaultTemplate || t.slug === settings.defaultTemplate
@@ -779,21 +803,34 @@ private selectBrokerForProject(): void {
       if (match) {
         this.templateId = match.id;
         this.setHarnessFromValue(harnessFor(match));
-        return;
+        templateResolved = true;
       }
     }
 
-    // Fallback: template named "default"
-    const fallback = visible.find((t) => t.slug === 'default' || t.name === 'default');
-    if (fallback) {
-      this.templateId = fallback.id;
-      this.setHarnessFromValue(harnessFor(fallback));
-    } else if (visible.length > 0) {
-      this.templateId = visible[0].id;
-      this.setHarnessFromValue(harnessFor(visible[0]));
-    } else {
-      this.templateId = '';
-      this.setHarnessFromValue(harnessDefault);
+    if (!templateResolved) {
+      // Fallback: template named "default"
+      const fallback = visible.find((t) => t.slug === 'default' || t.name === 'default');
+      if (fallback) {
+        this.templateId = fallback.id;
+        this.setHarnessFromValue(harnessFor(fallback));
+      } else if (visible.length > 0) {
+        this.templateId = visible[0].id;
+        this.setHarnessFromValue(harnessFor(visible[0]));
+      } else {
+        this.templateId = '';
+        this.setHarnessFromValue(harnessDefault);
+      }
+    }
+
+    // Pre-populate model from project defaults if user hasn't selected one
+    if (!this.modelSelection && settings?.defaultModel) {
+      const dm = settings.defaultModel;
+      if (['small', 'medium', 'large', 'extra-large'].includes(dm)) {
+        this.modelSelection = dm as 'small' | 'medium' | 'large' | 'extra-large';
+      } else if (dm) {
+        this.modelSelection = 'other';
+        this.customModelId = dm;
+      }
     }
   }
 
@@ -930,6 +967,7 @@ private selectBrokerForProject(): void {
     defaultMaxDuration?: string;
     defaultGCPIdentityMode?: string;
     defaultGCPIdentityServiceAccountID?: string;
+    defaultModel?: string;
   } | null> {
     if (!projectId) return null;
 
@@ -947,6 +985,7 @@ private selectBrokerForProject(): void {
           defaultMaxDuration?: string;
           defaultGCPIdentityMode?: string;
           defaultGCPIdentityServiceAccountID?: string;
+          defaultModel?: string;
         };
         this.projectSettingsCache.set(projectId, data);
         return data;
@@ -1130,6 +1169,42 @@ private selectBrokerForProject(): void {
             </sl-select>
             <div class="hint">Agent configuration template.</div>
           </div>
+
+          <div class="form-field">
+            <label for="model">Model</label>
+            <sl-select
+              id="model"
+              placeholder="Select a model size..."
+              .value=${this.modelSelection}
+              clearable
+              @sl-change=${(e: Event) => {
+                this.modelSelection = (e.target as HTMLElement & { value: string }).value as
+                  | '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other';
+              }}
+            >
+              <sl-option value="small">Small</sl-option>
+              <sl-option value="medium">Medium</sl-option>
+              <sl-option value="large">Large</sl-option>
+              <sl-option value="extra-large">Extra Large</sl-option>
+              <sl-option value="other">Other (specify)</sl-option>
+            </sl-select>
+            <div class="hint">Model size or specific model for this agent.</div>
+          </div>
+          ${this.modelSelection === 'other'
+            ? html`
+                <div class="form-field">
+                  <label for="model-id">Model ID</label>
+                  <sl-input
+                    id="model-id"
+                    placeholder="e.g. claude-opus-4-8"
+                    .value=${this.customModelId}
+                    @sl-input=${(e: Event) => {
+                      this.customModelId = (e.target as HTMLElement & { value: string }).value;
+                    }}
+                  ></sl-input>
+                </div>
+              `
+            : ''}
 
           <div class="form-field">
             <label for="harness">Harness Config</label>

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -1180,6 +1180,7 @@ private selectBrokerForProject(): void {
               @sl-change=${(e: Event) => {
                 this.modelSelection = (e.target as HTMLElement & { value: string }).value as
                   | '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other';
+                if (this.modelSelection !== 'other') this.customModelId = '';
               }}
             >
               <sl-option value="small">Small</sl-option>

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -830,7 +830,7 @@ private selectBrokerForProject(): void {
         this.modelSelection = dm as 'small' | 'medium' | 'large' | 'extra-large';
       } else if (dm) {
         this.modelSelection = 'other';
-        this.customModelId = dm;
+        this.customModelId = settings.defaultModel;
       }
     }
   }

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -25,6 +25,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 import type { PageData, Project, Template, AdminGroup, GitHubAppProjectStatus, GitHubTokenPermissions, RuntimeBroker, BrokerProfile, GCPServiceAccount } from '../../shared/types.js';
 import { can, canAny } from '../../shared/types.js';
+import { normalizeModelAlias } from '../../shared/model-utils.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { dispatchPageTitle } from '../../client/page-title.js';
 import '../shared/env-var-list.js';
@@ -882,8 +883,9 @@ export class ScionPageProjectSettings extends LitElement {
         this.configDefaultGCPIdentityMode = this.settings.defaultGCPIdentityMode || '';
         this.configDefaultGCPIdentitySAID = this.settings.defaultGCPIdentityServiceAccountID || '';
         if (this.settings.defaultModel) {
-          if (['small', 'medium', 'large', 'extra-large'].includes(this.settings.defaultModel)) {
-            this.defaultModelSelection = this.settings.defaultModel as 'small' | 'medium' | 'large' | 'extra-large';
+          const dm = normalizeModelAlias(this.settings.defaultModel);
+          if (['small', 'medium', 'large', 'extra-large'].includes(dm)) {
+            this.defaultModelSelection = dm as 'small' | 'medium' | 'large' | 'extra-large';
           } else {
             this.defaultModelSelection = 'other';
             this.defaultCustomModelId = this.settings.defaultModel;

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -56,6 +56,7 @@ interface ProjectSettings {
   defaultResources?: ProjectResourceSpec | undefined;
   defaultGCPIdentityMode?: string | undefined;
   defaultGCPIdentityServiceAccountID?: string | undefined;
+  defaultModel?: string | undefined;
 }
 
 interface HarnessConfigEntry {
@@ -168,6 +169,12 @@ export class ScionPageProjectSettings extends LitElement {
 
   @state()
   private configDefaultGCPIdentitySAID = '';
+
+  @state()
+  private defaultModelSelection: '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other' = '';
+
+  @state()
+  private defaultCustomModelId = '';
 
   @state()
   private gcpServiceAccounts: GCPServiceAccount[] = [];
@@ -874,6 +881,16 @@ export class ScionPageProjectSettings extends LitElement {
         this.configDefaultResDisk = res?.disk || '';
         this.configDefaultGCPIdentityMode = this.settings.defaultGCPIdentityMode || '';
         this.configDefaultGCPIdentitySAID = this.settings.defaultGCPIdentityServiceAccountID || '';
+        if (this.settings.defaultModel) {
+          if (['small', 'medium', 'large', 'extra-large'].includes(this.settings.defaultModel)) {
+            this.defaultModelSelection = this.settings.defaultModel as 'small' | 'medium' | 'large' | 'extra-large';
+          } else {
+            this.defaultModelSelection = 'other';
+            this.defaultCustomModelId = this.settings.defaultModel;
+          }
+        } else {
+          this.defaultModelSelection = '';
+        }
       }
     } catch (err) {
       console.error('Failed to load project settings:', err);
@@ -955,9 +972,14 @@ export class ScionPageProjectSettings extends LitElement {
         }
       }
 
+      const defaultModel = this.defaultModelSelection === 'other'
+        ? this.defaultCustomModelId
+        : this.defaultModelSelection;
+
       const body: ProjectSettings = {
         defaultTemplate: this.configDefaultTemplate || undefined,
         defaultHarnessConfig: this.configDefaultHarnessConfig || undefined,
+        defaultModel: defaultModel || undefined,
         telemetryEnabled: this.configTelemetryEnabled,
         defaultMaxTurns: this.configDefaultMaxTurns || undefined,
         defaultMaxModelCalls: this.configDefaultMaxModelCalls || undefined,
@@ -1450,6 +1472,46 @@ export class ScionPageProjectSettings extends LitElement {
                   >Harness configuration used by default for new agents.</span
                 >
               </div>
+
+              <div class="config-field">
+                <label>Default Model</label>
+                <sl-select
+                  placeholder="None (use server default)"
+                  clearable
+                  value=${this.defaultModelSelection}
+                  ?disabled=${!canEdit}
+                  @sl-change=${(e: Event) => {
+                    const val = (e.target as HTMLSelectElement).value as '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other';
+                    this.defaultModelSelection = val;
+                    if (val !== 'other') this.defaultCustomModelId = '';
+                  }}
+                >
+                  <sl-option value="small">Small</sl-option>
+                  <sl-option value="medium">Medium</sl-option>
+                  <sl-option value="large">Large</sl-option>
+                  <sl-option value="extra-large">Extra Large</sl-option>
+                  <sl-option value="other">Other (specify)</sl-option>
+                </sl-select>
+                <span class="field-help"
+                  >Default model alias or ID used for new agents.</span
+                >
+              </div>
+
+              ${this.defaultModelSelection === 'other'
+                ? html`
+                    <div class="config-field">
+                      <label>Model ID</label>
+                      <sl-input
+                        placeholder="e.g. claude-opus-4-8"
+                        .value=${this.defaultCustomModelId}
+                        ?disabled=${!canEdit}
+                        @sl-input=${(e: Event) => {
+                          this.defaultCustomModelId = (e.target as HTMLInputElement).value;
+                        }}
+                      ></sl-input>
+                    </div>
+                  `
+                : ''}
 
               <div class="config-field">
                 <label>Telemetry</label>

--- a/web/src/shared/model-utils.ts
+++ b/web/src/shared/model-utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const shortcuts: Record<string, string> = { xl: 'extra-large' };
+
+export function normalizeModelAlias(alias: string): string {
+  const lower = alias.toLowerCase();
+  return shortcuts[lower] ?? lower;
+}


### PR DESCRIPTION
## Summary
- **Phase 0:** Add extra-large model alias tier with xl shorthand (all 6 harness configs + NormalizeModelAlias)
- **Phase 1:** Add --model flag to scion start command (flag overrides config file model, xl normalized)
- **Phase 2:** Add DefaultModel to ProjectSettings for project-level model default (annotation-backed, applied at provision time)
- **Phase 3:** Add model selection dropdown to agent create form (Small/Medium/Large/Extra Large/Other + project default pre-population)
- **Phase 4:** Replace free-text model input with dropdown in agent configure form (deriveModelSelection for existing values)
- **Phase 5:** Add Default Model dropdown to project settings (Agent Defaults section)
- **Fix:** Clear custom model ID when switching away from Other in create form (consistency across all 3 forms)

## Test plan
- [x] go test ./pkg/config/... (NormalizeModelAlias, ResolveModelAlias, KnownModelAliases)
- [x] go test ./cmd/... (flag registration, flag-config merge precedence, xl normalization)
- [x] go test ./pkg/hub/... (DefaultModel round-trip, applyProjectDefaults)
- [x] Web build succeeds (npm run build)
- [x] All 3 web UI forms use consistent dropdown pattern with clear behavior