### PR TITLE
fix(store): honor cursor in ProjectStore.ListProjects

### DIFF
--- a/pkg/store/entadapter/project_store.go
+++ b/pkg/store/entadapter/project_store.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/agent"
+	"github.com/GoogleCloudPlatform/scion/pkg/ent/predicate"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/project"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/projectcontributor"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/projectsyncstate"
@@ -428,9 +429,17 @@ func (s *ProjectStore) ListProjects(ctx context.Context, filter store.ProjectFil
 		limit = 50
 	}
 
+	if opts.Cursor != "" {
+		pred, err := s.projectCursorPredicate(ctx, opts.Cursor)
+		if err != nil {
+			return nil, err
+		}
+		query.Where(pred)
+	}
+
 	rows, err := query.
-		Order(ent.Desc(project.FieldCreated)).
-		Limit(limit).
+		Order(ent.Desc(project.FieldCreated), ent.Desc(project.FieldID)).
+		Limit(limit + 1).
 		All(ctx)
 	if err != nil {
 		return nil, err
@@ -445,10 +454,32 @@ func (s *ProjectStore) ListProjects(ctx context.Context, filter store.ProjectFil
 		items = append(items, *sp)
 	}
 
-	return &store.ListResult[store.Project]{
+	result := &store.ListResult[store.Project]{
 		Items:      items,
 		TotalCount: totalCount,
-	}, nil
+	}
+	if len(items) > limit {
+		result.NextCursor = items[limit-1].ID
+		result.Items = items[:limit]
+	}
+	return result, nil
+}
+
+// projectCursorPredicate builds the keyset predicate for paginating after the
+// project identified by cursor (a project ID).
+func (s *ProjectStore) projectCursorPredicate(ctx context.Context, cursor string) (predicate.Project, error) {
+	cursorUID, err := parseUUID(cursor)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cursor: %w", err)
+	}
+	c, err := s.client.Project.Get(ctx, cursorUID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cursor: %w", mapError(err))
+	}
+	return project.Or(
+		project.CreatedLT(c.Created),
+		project.And(project.CreatedEQ(c.Created), project.IDLT(cursorUID)),
+	), nil
 }
 
 // populateProjectComputed fills the computed (non-persisted) fields on a project:

--- a/pkg/store/entadapter/project_store_test.go
+++ b/pkg/store/entadapter/project_store_test.go
@@ -620,3 +620,48 @@ func TestSyncState_DeleteAndNotFound(t *testing.T) {
 	require.NoError(t, ps.DeleteProjectSyncState(ctx, projectID, ""))
 	assert.ErrorIs(t, ps.DeleteProjectSyncState(ctx, projectID, ""), store.ErrNotFound)
 }
+
+// TestListProjects_CursorPagination verifies ListProjects honors ListOptions.Cursor
+// and enumerates every project across pages with no gaps or duplicates. Before the
+// keyset-pagination fix the cursor was ignored and NextCursor was never set, so a
+// caller could only ever see the first (default 50-row) page.
+func TestListProjects_CursorPagination(t *testing.T) {
+	ps := newTestProjectStore(t)
+	ctx := context.Background()
+
+	const total = 125 // more than two default pages
+	created := make(map[string]bool, total)
+	for i := 0; i < total; i++ {
+		p := newProject(i)
+		require.NoError(t, ps.CreateProject(ctx, p))
+		created[p.ID] = true
+	}
+
+	// A single default call must not exceed one page, and must advertise more.
+	first, err := ps.ListProjects(ctx, store.ProjectFilter{}, store.ListOptions{})
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(first.Items), 50, "default page must cap at 50 rows")
+	assert.NotEmpty(t, first.NextCursor, "more pages exist, so NextCursor must be set")
+
+	// Walking the cursor must enumerate every project exactly once.
+	seen := make(map[string]bool, total)
+	cursor := ""
+	for pages := 0; ; pages++ {
+		require.LessOrEqual(t, pages, total, "pagination did not terminate")
+		page, err := ps.ListProjects(ctx, store.ProjectFilter{}, store.ListOptions{Cursor: cursor})
+		require.NoError(t, err)
+		for _, p := range page.Items {
+			require.False(t, seen[p.ID], "duplicate project across pages: %s", p.ID)
+			seen[p.ID] = true
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+
+	assert.Len(t, seen, total, "cursor pagination must enumerate every project")
+	for id := range created {
+		assert.True(t, seen[id], "project missing from pagination: %s", id)
+	}
+}


### PR DESCRIPTION
## Problem
`ProjectStore.ListProjects` ignored `ListOptions.Cursor` and never populated
`ListResult.NextCursor`, capping every result at the default page size (50) with
no way to page further — even though the project-list HTTP handler already
forwards a `cursor` query parameter and returns `NextCursor` to clients. The
paginated projects API was silently limited to the first 50 rows.

## Change
Add keyset pagination ordered by `(created DESC, id DESC)`, matching the pattern
already used by `AllowListStore`, `AgentStore`, `ScheduleStore`, and
`MessageStore`. The no-cursor path is unchanged for existing callers (same rows,
same `TotalCount`); only the previously-undefined tie order becomes deterministic
and `NextCursor` is now populated.

## Testing
`TestListProjects_CursorPagination` — 125 projects; asserts a single default call
caps at 50 with a non-empty `NextCursor`, and walking the cursor enumerates every
project exactly once (no gaps, no duplicates).


- [x] Tests pass
