### PR TITLE
fix(agent): honor explicit --workspace over git auto-detection

### DIFF
--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -476,6 +476,7 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 
 	var workspaceSource string
 	shouldCreateWorktree := false
+	explicitWorkspace := false
 
 	// Check for git clone mode from context
 	gitClone := api.GitCloneFromContext(ctx)
@@ -521,6 +522,7 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 
 		workspaceSource = absWorkspace
 		agentWorkspace = "" // We are not using the managed local workspace directory
+		explicitWorkspace = true
 
 	} else if isGit {
 		// Case 2: Git Repository (and no explicit workspace)
@@ -1086,6 +1088,9 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 			ReadOnly: false,
 		})
 	}
+	if explicitWorkspace {
+		finalScionCfg.ExplicitWorkspace = true
+	}
 
 	// Update agent-specific scion-agent.json
 	if finalScionCfg == nil {
@@ -1602,6 +1607,23 @@ func GetAgent(ctx context.Context, agentName string, templateName string, agentI
 			if root, rootErr := util.RepoRootDir(filepath.Dir(agentWorkspace)); rootErr == nil {
 				_ = util.PruneWorktreesIn(root)
 			}
+		}
+	}
+
+	// An explicit --workspace agent has no managed per-agent worktree: its mount
+	// is the operator's own directory, recovered on resume from the persisted
+	// /workspace volume (see effectiveWorkspace in run.go). Treat it like a
+	// shared-workspace agent by clearing agentWorkspace, so the managed-worktree
+	// recovery below is skipped. Otherwise, when projectDir is itself a git repo,
+	// that recovery would CreateWorktree a throwaway managed worktree and the
+	// agent would silently edit that phantom branch instead of the operator's
+	// explicit tree — breaking "edit the real tree in place" on resume.
+	if agentWorkspace != "" && config.ScionAgentConfigExists(agentDir) {
+		if persisted, cfgErr := (&config.Template{Path: agentDir}).LoadConfig(); cfgErr != nil {
+			util.Debugf("GetAgent: could not load persisted config to check explicit workspace: %v", cfgErr)
+		} else if persisted.ExplicitWorkspace {
+			util.Debugf("GetAgent: explicit-workspace agent %q — skipping managed-worktree recovery", agentName)
+			agentWorkspace = ""
 		}
 	}
 

--- a/pkg/agent/provision_test.go
+++ b/pkg/agent/provision_test.go
@@ -1406,6 +1406,77 @@ func TestGetAgent_RecreatesMissingWorktree(t *testing.T) {
 	}
 }
 
+// TestGetAgent_ExplicitWorkspaceSkipsWorktreeRecovery is the resume counterpart
+// to the widening guard: an explicit --workspace agent must NOT get a managed
+// worktree recreated on resume, even when the project dir is itself a git repo.
+// Its mount is the operator's own tree, recovered downstream from the /workspace
+// volume, so GetAgent returns an empty managed workspace path (mirroring a
+// shared-workspace agent) rather than silently editing a phantom worktree branch.
+func TestGetAgent_ExplicitWorkspaceSkipsWorktreeRecovery(t *testing.T) {
+	t.Setenv("SCION_HOST_UID", "") // Clear container context for worktree ops
+	tmpDir := t.TempDir()
+
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(tmpDir)
+	defer func() { _ = os.Chdir(oldWd) }()
+
+	originalHome := os.Getenv("HOME")
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+	_ = os.Setenv("HOME", tmpDir)
+
+	// The trap: the project root is itself a git repo.
+	projectDir := filepath.Join(tmpDir, "project")
+	_ = os.MkdirAll(projectDir, 0755)
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+		{"commit", "--allow-empty", "-m", "initial"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = projectDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	// Set up .scion structure + global default template harness config.
+	scionDir := filepath.Join(projectDir, ".scion")
+	_ = os.MkdirAll(filepath.Join(scionDir, "templates"), 0755)
+	globalScionDir := filepath.Join(tmpDir, ".scion")
+	_ = os.MkdirAll(filepath.Join(globalScionDir, "templates"), 0755)
+	seedTestHarnessConfig(t, globalScionDir, "generic", "generic")
+	tplDir := filepath.Join(globalScionDir, "templates", "default")
+	_ = os.MkdirAll(tplDir, 0755)
+	_ = os.WriteFile(filepath.Join(tplDir, "scion-agent.json"), []byte(`{"default_harness_config":"generic"}`), 0644)
+
+	agentName := "explicit-ws-agent"
+	agentDir := filepath.Join(scionDir, "agents", agentName)
+	agentWorkspace := filepath.Join(agentDir, "workspace")
+	agentHome := config.GetAgentHomePath(scionDir, agentName)
+	_ = os.MkdirAll(agentDir, 0755)
+	_ = os.MkdirAll(agentHome, 0755)
+
+	// Persist an EXISTING explicit-workspace agent: config carries the flag, and
+	// (as for a real explicit agent) there is no managed worktree on disk.
+	_ = os.WriteFile(filepath.Join(agentDir, "scion-agent.json"),
+		[]byte(`{"harness":"generic","default_harness_config":"generic","explicit_workspace":true}`), 0644)
+	_ = os.WriteFile(filepath.Join(agentHome, "agent-info.json"),
+		[]byte(`{"name":"explicit-ws-agent","template":"default"}`), 0644)
+
+	// Resume: GetAgent must NOT recreate a managed worktree for an explicit agent.
+	_, _, wsPath, _, err := GetAgent(context.Background(), agentName, "", "", "", scionDir, "", "", "", "")
+	if err != nil {
+		t.Fatalf("GetAgent failed: %v", err)
+	}
+	if wsPath != "" {
+		t.Fatalf("explicit-workspace agent: expected empty managed workspace path on resume, got %q", wsPath)
+	}
+	if _, statErr := os.Stat(agentWorkspace); !os.IsNotExist(statErr) {
+		t.Fatalf("explicit-workspace agent: expected NO phantom worktree at %s, but one was created", agentWorkspace)
+	}
+}
+
 // TestGetAgent_StaleDirectoryCreatesWorkspace verifies that when an agent
 // directory exists without a config file (stale/incomplete provisioning),
 // GetAgent removes it and re-provisions with a valid workspace worktree.

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -807,7 +807,10 @@ authDone:
 		}
 	}
 
-	repoRoot := detectRepoRoot(opts.Workspace, effectiveWorkspace, projectDir)
+	// On resume/restart opts.Workspace is empty, so re-derive the explicit intent
+	// from the persisted config to keep the explicit workspace plain-mounted.
+	explicitWorkspace := opts.Workspace != "" || (finalScionCfg != nil && finalScionCfg.ExplicitWorkspace)
+	repoRoot := detectRepoRoot(explicitWorkspace, effectiveWorkspace, projectDir)
 
 	// Telemetry defaults to enabled when not explicitly set to false.
 	telemetryEnabled := finalScionCfg != nil && finalScionCfg.Telemetry != nil &&
@@ -1016,9 +1019,11 @@ authDone:
 // for a plain in-place workspace mount. An explicit --workspace skips git
 // detection: a workspace that merely sits inside a repo must not be widened to
 // the whole repo, matching ProvisionAgent, which mounts it directly "even if
-// inside a repo" (provision.go).
-func detectRepoRoot(explicitWorkspace, effectiveWorkspace, projectDir string) string {
-	if explicitWorkspace != "" {
+// inside a repo" (provision.go). explicit is set on first start (opts.Workspace)
+// and re-derived on resume from the persisted ExplicitWorkspace flag, so the
+// guarantee holds on every entry path.
+func detectRepoRoot(explicit bool, effectiveWorkspace, projectDir string) string {
+	if explicit {
 		return ""
 	}
 	if effectiveWorkspace != "" && util.IsGitRepoDir(effectiveWorkspace) {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -807,15 +807,7 @@ authDone:
 		}
 	}
 
-	repoRoot := ""
-	if effectiveWorkspace != "" && util.IsGitRepoDir(effectiveWorkspace) {
-		commonDir, err := util.GetCommonGitDir(effectiveWorkspace)
-		if err == nil {
-			repoRoot = filepath.Dir(commonDir)
-		}
-	} else if util.IsGitRepoDir(projectDir) {
-		repoRoot, _ = util.RepoRootDir(projectDir)
-	}
+	repoRoot := detectRepoRoot(opts.Workspace, effectiveWorkspace, projectDir)
 
 	// Telemetry defaults to enabled when not explicitly set to false.
 	telemetryEnabled := finalScionCfg != nil && finalScionCfg.Telemetry != nil &&
@@ -1018,6 +1010,29 @@ authDone:
 		HarnessAuth:           opts.HarnessAuth,
 		Profile:               profileName,
 	}, nil
+}
+
+// detectRepoRoot resolves the git repo root to bind-mount for an agent, or ""
+// for a plain in-place workspace mount. An explicit --workspace skips git
+// detection: a workspace that merely sits inside a repo must not be widened to
+// the whole repo, matching ProvisionAgent, which mounts it directly "even if
+// inside a repo" (provision.go).
+func detectRepoRoot(explicitWorkspace, effectiveWorkspace, projectDir string) string {
+	if explicitWorkspace != "" {
+		return ""
+	}
+	if effectiveWorkspace != "" && util.IsGitRepoDir(effectiveWorkspace) {
+		commonDir, err := util.GetCommonGitDir(effectiveWorkspace)
+		if err == nil {
+			return filepath.Dir(commonDir)
+		}
+		return ""
+	}
+	if util.IsGitRepoDir(projectDir) {
+		root, _ := util.RepoRootDir(projectDir)
+		return root
+	}
+	return ""
 }
 
 // extractWorkspaceFromVolumes finds a volume mounted to /workspace and returns its source path.

--- a/pkg/agent/run_reporoot_test.go
+++ b/pkg/agent/run_reporoot_test.go
@@ -46,13 +46,36 @@ func TestDetectRepoRoot_ExplicitWorkspaceSkipsGitDetection(t *testing.T) {
 	}
 
 	// Explicit workspace = a subdir inside the repo -> no repo-root detection.
-	if got := detectRepoRoot(subA, subA, root); got != "" {
+	if got := detectRepoRoot(true, subA, root); got != "" {
 		t.Fatalf("explicit workspace inside repo: got repoRoot %q, want \"\"", got)
 	}
 
 	// Explicit workspace = the repo root itself -> still plain-mounted, "".
-	if got := detectRepoRoot(root, root, root); got != "" {
+	if got := detectRepoRoot(true, root, root); got != "" {
 		t.Fatalf("explicit workspace at repo root: got repoRoot %q, want \"\"", got)
+	}
+}
+
+// TestDetectRepoRoot_ExplicitWorkspaceResume covers resume/restart: opts.Workspace
+// is empty but the persisted ExplicitWorkspace flag re-derives explicit=true, so
+// the recovered explicit path must stay plain-mounted rather than widening to the
+// enclosing repo — for both a subdir and the repo root itself.
+func TestDetectRepoRoot_ExplicitWorkspaceResume(t *testing.T) {
+	root := t.TempDir()
+	setupGitRepo(t, root)
+	subA := filepath.Join(root, "subA")
+	if err := os.MkdirAll(subA, 0755); err != nil {
+		t.Fatalf("mkdir subA: %v", err)
+	}
+
+	// Explicit subdir recovered as effectiveWorkspace on resume -> "".
+	if got := detectRepoRoot(true, subA, root); got != "" {
+		t.Fatalf("resume explicit subdir workspace: got repoRoot %q, want \"\"", got)
+	}
+
+	// Explicit repo root recovered as effectiveWorkspace on resume -> "".
+	if got := detectRepoRoot(true, root, root); got != "" {
+		t.Fatalf("resume explicit repo-root workspace: got repoRoot %q, want \"\"", got)
 	}
 }
 
@@ -60,7 +83,7 @@ func TestDetectRepoRoot_ExplicitWorkspaceSkipsGitDetection(t *testing.T) {
 // workspace is unaffected (unchanged behavior).
 func TestDetectRepoRoot_ExplicitPlainWorkspace(t *testing.T) {
 	dir := t.TempDir() // plain dir, no git
-	if got := detectRepoRoot(dir, dir, dir); got != "" {
+	if got := detectRepoRoot(true, dir, dir); got != "" {
 		t.Fatalf("explicit plain workspace: got repoRoot %q, want \"\"", got)
 	}
 }
@@ -76,9 +99,9 @@ func TestDetectRepoRoot_AutoDetectFromWorkspace(t *testing.T) {
 		t.Fatalf("mkdir subA: %v", err)
 	}
 
-	// explicitWorkspace == "" -> detection runs; effective workspace is subA,
+	// explicit == false -> detection runs; effective workspace is subA,
 	// which is inside the repo, so repoRoot is the repository root.
-	got := eval(t, detectRepoRoot("", subA, root))
+	got := eval(t, detectRepoRoot(false, subA, root))
 	if want := eval(t, root); got != want {
 		t.Fatalf("auto-detect from workspace: got repoRoot %q, want %q", got, want)
 	}
@@ -92,7 +115,7 @@ func TestDetectRepoRoot_AutoDetectFromProjectDir(t *testing.T) {
 	setupGitRepo(t, root)
 	plain := t.TempDir() // effective workspace, not a git repo
 
-	got := eval(t, detectRepoRoot("", plain, root))
+	got := eval(t, detectRepoRoot(false, plain, root))
 	if want := eval(t, root); got != want {
 		t.Fatalf("auto-detect from project dir: got repoRoot %q, want %q", got, want)
 	}
@@ -102,7 +125,7 @@ func TestDetectRepoRoot_AutoDetectFromProjectDir(t *testing.T) {
 func TestDetectRepoRoot_NoGitAnywhere(t *testing.T) {
 	ws := t.TempDir()
 	proj := t.TempDir()
-	if got := detectRepoRoot("", ws, proj); got != "" {
+	if got := detectRepoRoot(false, ws, proj); got != "" {
 		t.Fatalf("no git anywhere: got repoRoot %q, want \"\"", got)
 	}
 }

--- a/pkg/agent/run_reporoot_test.go
+++ b/pkg/agent/run_reporoot_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// eval resolves symlinks so comparisons hold on platforms (e.g. macOS) where
+// t.TempDir() lives under a symlinked prefix while git reports the real path.
+func eval(t *testing.T, p string) string {
+	t.Helper()
+	if p == "" {
+		return ""
+	}
+	r, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", p, err)
+	}
+	return r
+}
+
+// TestDetectRepoRoot_ExplicitWorkspaceSkipsGitDetection is the regression guard:
+// an explicit --workspace inside a git repo must return "" (plain mount), not the
+// repo root — otherwise the whole repo, including sibling dirs, leaks in.
+func TestDetectRepoRoot_ExplicitWorkspaceSkipsGitDetection(t *testing.T) {
+	root := t.TempDir()
+	setupGitRepo(t, root)
+	subA := filepath.Join(root, "subA")
+	if err := os.MkdirAll(subA, 0755); err != nil {
+		t.Fatalf("mkdir subA: %v", err)
+	}
+
+	// Explicit workspace = a subdir inside the repo -> no repo-root detection.
+	if got := detectRepoRoot(subA, subA, root); got != "" {
+		t.Fatalf("explicit workspace inside repo: got repoRoot %q, want \"\"", got)
+	}
+
+	// Explicit workspace = the repo root itself -> still plain-mounted, "".
+	if got := detectRepoRoot(root, root, root); got != "" {
+		t.Fatalf("explicit workspace at repo root: got repoRoot %q, want \"\"", got)
+	}
+}
+
+// TestDetectRepoRoot_ExplicitPlainWorkspace confirms a non-git explicit
+// workspace is unaffected (unchanged behavior).
+func TestDetectRepoRoot_ExplicitPlainWorkspace(t *testing.T) {
+	dir := t.TempDir() // plain dir, no git
+	if got := detectRepoRoot(dir, dir, dir); got != "" {
+		t.Fatalf("explicit plain workspace: got repoRoot %q, want \"\"", got)
+	}
+}
+
+// TestDetectRepoRoot_AutoDetectFromWorkspace is the counterpart regression
+// guard: with NO explicit workspace, git auto-detection still runs and resolves
+// the repository root from the effective workspace.
+func TestDetectRepoRoot_AutoDetectFromWorkspace(t *testing.T) {
+	root := t.TempDir()
+	setupGitRepo(t, root)
+	subA := filepath.Join(root, "subA")
+	if err := os.MkdirAll(subA, 0755); err != nil {
+		t.Fatalf("mkdir subA: %v", err)
+	}
+
+	// explicitWorkspace == "" -> detection runs; effective workspace is subA,
+	// which is inside the repo, so repoRoot is the repository root.
+	got := eval(t, detectRepoRoot("", subA, root))
+	if want := eval(t, root); got != want {
+		t.Fatalf("auto-detect from workspace: got repoRoot %q, want %q", got, want)
+	}
+}
+
+// TestDetectRepoRoot_AutoDetectFromProjectDir confirms the fallback branch: no
+// explicit workspace, a non-git effective workspace, but a git project dir ->
+// repoRoot resolves from the project dir.
+func TestDetectRepoRoot_AutoDetectFromProjectDir(t *testing.T) {
+	root := t.TempDir()
+	setupGitRepo(t, root)
+	plain := t.TempDir() // effective workspace, not a git repo
+
+	got := eval(t, detectRepoRoot("", plain, root))
+	if want := eval(t, root); got != want {
+		t.Fatalf("auto-detect from project dir: got repoRoot %q, want %q", got, want)
+	}
+}
+
+// TestDetectRepoRoot_NoGitAnywhere confirms the fully non-git case returns "".
+func TestDetectRepoRoot_NoGitAnywhere(t *testing.T) {
+	ws := t.TempDir()
+	proj := t.TempDir()
+	if got := detectRepoRoot("", ws, proj); got != "" {
+		t.Fatalf("no git anywhere: got repoRoot %q, want \"\"", got)
+	}
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -476,6 +476,11 @@ type ScionConfig struct {
 	Task   string `json:"task,omitempty" yaml:"task,omitempty"`
 	Branch string `json:"branch,omitempty" yaml:"branch,omitempty"`
 
+	// ExplicitWorkspace records that /workspace is a user-provided --workspace
+	// path, bind-mounted directly with no git worktree/branch, even when inside a
+	// repo. Persisted so resume/restart honors the same contract as first start.
+	ExplicitWorkspace bool `json:"explicit_workspace,omitempty" yaml:"explicit_workspace,omitempty"`
+
 	// Info contains persisted metadata about the agent
 	Info *AgentInfo `json:"-" yaml:"-"`
 }

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -766,6 +766,9 @@ func MergeScionConfig(base, override *api.ScionConfig) *api.ScionConfig {
 	if override.Task != "" {
 		result.Task = override.Task
 	}
+	if override.ExplicitWorkspace {
+		result.ExplicitWorkspace = true
+	}
 	if override.Branch != "" {
 		result.Branch = override.Branch
 	}


### PR DESCRIPTION
## Problem
`ProvisionAgent` documents and honors "an explicit `--workspace` overrides everything else… mount this path directly, no worktree or branch, even if inside a repo" (`pkg/agent/provision.go`; docs `.../local/workspace.md`). 

But the mount builder disagreed: `Start` independently recomputed the git repo root with **no guard on `opts.Workspace`** (`pkg/agent/run.go`). So when an explicit workspace happened to sit inside a git repo, scion switched to the worktree branch and bind-mounted the **entire `.git`** into the container and relocated the workdir to `/repo-root/<rel>`.

Consequence: a caller that explicitly asked for a plain subdirectory mount instead got the whole repository's committed history mounted (every sibling directory readable via `git --git-dir=/repo-root/.git show HEAD:<sibling>`), and the workdir silently moved.

## Change
Extract the repo-root detection into `detectRepoRoot` and short-circuit it when an explicit workspace is set, so that path is always plain-mounted in place. With an explicit `--workspace`, `RepoRoot` stays `""` and the plain-mount branch fires: exactly the directory the caller named, in place, nothing else. This makes the mount builder agree with `ProvisionAgent`'s contract and the documented behavior. The no-explicit-workspace path (git auto-detection) is unchanged.

## Testing
`detectRepoRoot` unit tests covering: explicit workspace inside a git repo → no repo-root (regression guard for the leak); explicit plain workspace → unchanged; no explicit workspace with a git workspace → detection still resolves the repo root; fallback to the project dir; and the fully non-git case.