### PR TITLE
hub: self-healing DB←GCS sync for harness-config and template hash mismatches

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1354,6 +1354,11 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 		}
 	}
 
+	// Reconcile harness-config DB manifest hashes against actual GCS content.
+	// In multi-hub mode a peer hub may have uploaded newer files; this ensures
+	// the local DB reflects reality before any dispatch is attempted.
+	go hubSrv.SyncAllHarnessConfigsFromStorage(ctx)
+
 	log.Printf("Database: %s (%s)", cfg.Database.Driver, cfg.Database.URL)
 
 	return hubSrv, nil

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1354,10 +1354,11 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 		}
 	}
 
-	// Reconcile harness-config DB manifest hashes against actual GCS content.
+	// Reconcile resource DB manifest hashes against actual GCS content.
 	// In multi-hub mode a peer hub may have uploaded newer files; this ensures
 	// the local DB reflects reality before any dispatch is attempted.
 	go hubSrv.SyncAllHarnessConfigsFromStorage(ctx)
+	go hubSrv.SyncAllTemplatesFromStorage(ctx)
 
 	log.Printf("Database: %s (%s)", cfg.Database.Driver, cfg.Database.URL)
 

--- a/pkg/hub/harness_config_repair.go
+++ b/pkg/hub/harness_config_repair.go
@@ -24,13 +24,79 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
-// syncHarnessConfigFromStorage synchronises a single harness-config's DB
-// manifest hashes with the actual GCS content. In a multi-hub topology the
-// GCS bucket is shared while each hub keeps its own DB; when another hub
-// uploads newer content, the local DB manifest becomes stale and causes
-// hash-mismatch errors on broker hydration. This method downloads each file
-// from storage, recomputes the SHA-256 hash, and updates the DB record when
-// any file hash has drifted.
+// syncResourceFromStorage synchronises a resource's DB manifest hashes with
+// actual GCS content. In a multi-hub topology the GCS bucket is shared while
+// each hub keeps its own DB; when another hub uploads newer content, the local
+// DB manifest becomes stale and causes hash-mismatch errors on broker
+// hydration. This helper downloads each file from storage, recomputes the
+// SHA-256 hash, and returns the updated files + content hash when any file
+// hash has drifted. Returns changed=false when no update is needed.
+func (s *Server) syncResourceFromStorage(
+	ctx context.Context,
+	kind storage.ResourceKind,
+	name string,
+	storagePath string,
+	scope string,
+	scopeID string,
+	slug string,
+	files []store.TemplateFile,
+) (updatedFiles []store.TemplateFile, contentHash string, changed bool, err error) {
+	stor := s.GetStorage()
+	if stor == nil {
+		return nil, "", false, fmt.Errorf("storage backend not configured")
+	}
+
+	if storagePath == "" {
+		storagePath = storage.ResourceStoragePath(kind, scope, scopeID, slug)
+	}
+
+	label := string(kind)
+	updated := make([]store.TemplateFile, len(files))
+	copy(updated, files)
+
+	for i, file := range updated {
+		if file.Hash == "" {
+			continue
+		}
+		objectPath := storagePath + "/" + file.Path
+
+		obj, getErr := stor.GetObject(ctx, objectPath)
+		if getErr != nil {
+			s.resourceLog.Warn(label+" repair: cannot stat object",
+				"resource", name, "file", file.Path, "error", getErr)
+			continue
+		}
+
+		actualHash := objectMetadataHash(obj)
+		if actualHash == "" {
+			var hashErr error
+			actualHash, hashErr = computeStoredHash(ctx, stor, objectPath)
+			if hashErr != nil {
+				s.resourceLog.Warn(label+" repair: cannot hash object",
+					"resource", name, "file", file.Path, "error", hashErr)
+				continue
+			}
+		}
+
+		if actualHash != file.Hash {
+			s.resourceLog.Warn(label+" repair: updating stale file hash",
+				"resource", name, "file", file.Path,
+				"dbHash", file.Hash, "storageHash", actualHash)
+			updated[i].Hash = actualHash
+			changed = true
+		}
+	}
+
+	if !changed {
+		return nil, "", false, nil
+	}
+
+	contentHash = computeContentHash(updated)
+	return updated, contentHash, true, nil
+}
+
+// syncHarnessConfigFromStorage syncs a single harness-config's DB manifest
+// from actual GCS content.
 func (s *Server) syncHarnessConfigFromStorage(ctx context.Context, hcName string) error {
 	hc, err := s.findHarnessConfigByName(ctx, hcName)
 	if err != nil {
@@ -40,62 +106,54 @@ func (s *Server) syncHarnessConfigFromStorage(ctx context.Context, hcName string
 		return fmt.Errorf("harness-config %q not found", hcName)
 	}
 
-	stor := s.GetStorage()
-	if stor == nil {
-		return fmt.Errorf("storage backend not configured")
+	updated, contentHash, changed, err := s.syncResourceFromStorage(
+		ctx, storage.ResourceKindHarnessConfig, hc.Name,
+		hc.StoragePath, hc.Scope, hc.ScopeID, hc.Slug, hc.Files)
+	if err != nil {
+		return err
 	}
-
-	storagePath := hc.StoragePath
-	if storagePath == "" {
-		storagePath = storage.ResourceStoragePath(
-			storage.ResourceKindHarnessConfig, hc.Scope, hc.ScopeID, hc.Slug)
-	}
-
-	changed := false
-	for i, file := range hc.Files {
-		if file.Hash == "" {
-			continue
-		}
-		objectPath := storagePath + "/" + file.Path
-
-		obj, getErr := stor.GetObject(ctx, objectPath)
-		if getErr != nil {
-			s.resourceLog.Warn("harness-config repair: cannot stat object",
-				"config", hcName, "file", file.Path, "error", getErr)
-			continue
-		}
-
-		actualHash := objectMetadataHash(obj)
-		if actualHash == "" {
-			var hashErr error
-			actualHash, hashErr = computeStoredHash(ctx, stor, objectPath)
-			if hashErr != nil {
-				s.resourceLog.Warn("harness-config repair: cannot hash object",
-					"config", hcName, "file", file.Path, "error", hashErr)
-				continue
-			}
-		}
-
-		if actualHash != file.Hash {
-			s.resourceLog.Warn("harness-config repair: updating stale file hash",
-				"config", hcName, "file", file.Path,
-				"dbHash", file.Hash, "storageHash", actualHash)
-			hc.Files[i].Hash = actualHash
-			changed = true
-		}
-	}
-
 	if !changed {
 		return nil
 	}
 
-	hc.ContentHash = computeContentHash(hc.Files)
+	hc.Files = updated
+	hc.ContentHash = contentHash
 	if err := s.store.UpdateHarnessConfig(ctx, hc); err != nil {
 		return fmt.Errorf("harness-config repair: update DB: %w", err)
 	}
-
 	s.resourceLog.Info("harness-config repair: synced DB manifest from storage",
-		"config", hcName, "contentHash", hc.ContentHash)
+		"config", hc.Name, "contentHash", contentHash)
+	return nil
+}
+
+// syncTemplateFromStorage syncs a single template's DB manifest from actual
+// GCS content.
+func (s *Server) syncTemplateFromStorage(ctx context.Context, templateRef string) error {
+	tmpl, err := s.findTemplateByRef(ctx, templateRef)
+	if err != nil {
+		return err
+	}
+	if tmpl == nil {
+		return fmt.Errorf("template %q not found", templateRef)
+	}
+
+	updated, contentHash, changed, err := s.syncResourceFromStorage(
+		ctx, storage.ResourceKindTemplate, tmpl.Name,
+		tmpl.StoragePath, tmpl.Scope, tmpl.ScopeID, tmpl.Slug, tmpl.Files)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+
+	tmpl.Files = updated
+	tmpl.ContentHash = contentHash
+	if err := s.store.UpdateTemplate(ctx, tmpl); err != nil {
+		return fmt.Errorf("template repair: update DB: %w", err)
+	}
+	s.resourceLog.Info("template repair: synced DB manifest from storage",
+		"template", tmpl.Name, "contentHash", contentHash)
 	return nil
 }
 
@@ -103,40 +161,100 @@ func (s *Server) syncHarnessConfigFromStorage(ctx context.Context, hcName string
 // actual GCS content for all active harness-configs. Call at startup to catch
 // stale manifests left by peer hubs that updated the shared GCS bucket.
 func (s *Server) SyncAllHarnessConfigsFromStorage(ctx context.Context) {
+	s.syncAllResourcesFromStorage(ctx, storage.ResourceKindHarnessConfig)
+}
+
+// SyncAllTemplatesFromStorage reconciles DB manifest hashes against actual
+// GCS content for all active templates.
+func (s *Server) SyncAllTemplatesFromStorage(ctx context.Context) {
+	s.syncAllResourcesFromStorage(ctx, storage.ResourceKindTemplate)
+}
+
+func (s *Server) syncAllResourcesFromStorage(ctx context.Context, kind storage.ResourceKind) {
 	stor := s.GetStorage()
 	if stor == nil {
 		return
 	}
 
-	result, err := s.store.ListHarnessConfigs(ctx, store.HarnessConfigFilter{
-		Status: store.HarnessConfigStatusActive,
-	}, store.ListOptions{Limit: 1000})
-	if err != nil {
-		s.resourceLog.Error("harness-config sync: failed to list configs", "error", err)
-		return
+	label := string(kind)
+
+	type resourceEntry struct {
+		name    string
+		harness string
+		rec     *ResourceRecord
+	}
+
+	var entries []resourceEntry
+
+	switch kind {
+	case storage.ResourceKindHarnessConfig:
+		result, err := s.store.ListHarnessConfigs(ctx, store.HarnessConfigFilter{
+			Status: store.HarnessConfigStatusActive,
+		}, store.ListOptions{Limit: 1000})
+		if err != nil {
+			s.resourceLog.Error(label+" sync: failed to list", "error", err)
+			return
+		}
+		for _, hc := range result.Items {
+			if len(hc.Files) == 0 {
+				continue
+			}
+			entries = append(entries, resourceEntry{
+				name:    hc.Name,
+				harness: hc.Harness,
+				rec:     harnessConfigToRecord(&hc),
+			})
+		}
+	case storage.ResourceKindTemplate:
+		result, err := s.store.ListTemplates(ctx, store.TemplateFilter{
+			Status: store.TemplateStatusActive,
+		}, store.ListOptions{Limit: 1000})
+		if err != nil {
+			s.resourceLog.Error(label+" sync: failed to list", "error", err)
+			return
+		}
+		for _, t := range result.Items {
+			if len(t.Files) == 0 {
+				continue
+			}
+			entries = append(entries, resourceEntry{
+				name:    t.Name,
+				harness: t.Harness,
+				rec:     templateToRecord(&t),
+			})
+		}
 	}
 
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(5)
-	for _, hc := range result.Items {
-		if len(hc.Files) == 0 {
-			continue
-		}
-		name := hc.Name
+	for _, e := range entries {
+		e := e
 		g.Go(func() error {
-			rs := s.harnessConfigStore(hc.Harness)
-			rec := harnessConfigToRecord(&hc)
-			report, vErr := rs.ValidateStorage(gctx, rec)
+			var rs *ResourceStore
+			switch kind {
+			case storage.ResourceKindHarnessConfig:
+				rs = s.harnessConfigStore(e.harness)
+			case storage.ResourceKindTemplate:
+				rs = s.templateStore()
+			}
+			report, vErr := rs.ValidateStorage(gctx, e.rec)
 			if vErr != nil {
-				s.resourceLog.Warn("harness-config sync: validation error",
-					"config", name, "error", vErr)
+				s.resourceLog.Warn(label+" sync: validation error",
+					"resource", e.name, "error", vErr)
 				return nil
 			}
 			for _, issue := range report.Issues {
 				if issue.Kind == ValidationIssueContentHashMismatch {
-					if syncErr := s.syncHarnessConfigFromStorage(gctx, name); syncErr != nil {
-						s.resourceLog.Warn("harness-config sync: repair failed",
-							"config", name, "error", syncErr)
+					var syncErr error
+					switch kind {
+					case storage.ResourceKindHarnessConfig:
+						syncErr = s.syncHarnessConfigFromStorage(gctx, e.name)
+					case storage.ResourceKindTemplate:
+						syncErr = s.syncTemplateFromStorage(gctx, e.name)
+					}
+					if syncErr != nil {
+						s.resourceLog.Warn(label+" sync: repair failed",
+							"resource", e.name, "error", syncErr)
 					}
 					return nil
 				}
@@ -155,6 +273,27 @@ func (s *Server) findHarnessConfigByName(ctx context.Context, name string) (*sto
 	}, store.ListOptions{Limit: 1})
 	if err != nil {
 		return nil, fmt.Errorf("lookup harness-config %q: %w", name, err)
+	}
+	if len(result.Items) == 0 {
+		return nil, nil
+	}
+	return &result.Items[0], nil
+}
+
+// findTemplateByRef looks up an active template by ID or name.
+func (s *Server) findTemplateByRef(ctx context.Context, ref string) (*store.Template, error) {
+	// Try by ID first (UUIDs are passed from the dispatch path).
+	tmpl, err := s.store.GetTemplate(ctx, ref)
+	if err == nil && tmpl != nil {
+		return tmpl, nil
+	}
+	// Fall back to name search.
+	result, err := s.store.ListTemplates(ctx, store.TemplateFilter{
+		Name:   ref,
+		Status: store.TemplateStatusActive,
+	}, store.ListOptions{Limit: 1})
+	if err != nil {
+		return nil, fmt.Errorf("lookup template %q: %w", ref, err)
 	}
 	if len(result.Items) == 0 {
 		return nil, nil

--- a/pkg/hub/harness_config_repair.go
+++ b/pkg/hub/harness_config_repair.go
@@ -16,13 +16,21 @@ package hub
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
+
+// repairFlight deduplicates concurrent repair attempts for the same resource.
+// When multiple dispatches hit a hash mismatch simultaneously, only one
+// actually downloads from GCS and updates the DB; the others wait and share
+// the result.
+var repairFlight singleflight.Group
 
 // syncResourceFromStorage synchronises a resource's DB manifest hashes with
 // actual GCS content. In a multi-hub topology the GCS bucket is shared while
@@ -62,9 +70,12 @@ func (s *Server) syncResourceFromStorage(
 
 		obj, getErr := stor.GetObject(ctx, objectPath)
 		if getErr != nil {
-			s.resourceLog.Warn(label+" repair: cannot stat object",
-				"resource", name, "file", file.Path, "error", getErr)
-			continue
+			if errors.Is(getErr, storage.ErrNotFound) {
+				s.resourceLog.Warn(label+" repair: object not found",
+					"resource", name, "file", file.Path)
+				continue
+			}
+			return nil, "", false, fmt.Errorf("get object %q: %w", objectPath, getErr)
 		}
 
 		actualHash := objectMetadataHash(obj)
@@ -72,9 +83,7 @@ func (s *Server) syncResourceFromStorage(
 			var hashErr error
 			actualHash, hashErr = computeStoredHash(ctx, stor, objectPath)
 			if hashErr != nil {
-				s.resourceLog.Warn(label+" repair: cannot hash object",
-					"resource", name, "file", file.Path, "error", hashErr)
-				continue
+				return nil, "", false, fmt.Errorf("compute hash for %q: %w", objectPath, hashErr)
 			}
 		}
 
@@ -96,8 +105,16 @@ func (s *Server) syncResourceFromStorage(
 }
 
 // syncHarnessConfigFromStorage syncs a single harness-config's DB manifest
-// from actual GCS content.
+// from actual GCS content. Concurrent calls for the same config are
+// deduplicated via singleflight.
 func (s *Server) syncHarnessConfigFromStorage(ctx context.Context, hcName string) error {
+	_, err, _ := repairFlight.Do("hc:"+hcName, func() (interface{}, error) {
+		return nil, s.syncHarnessConfigFromStorageInner(context.WithoutCancel(ctx), hcName)
+	})
+	return err
+}
+
+func (s *Server) syncHarnessConfigFromStorageInner(ctx context.Context, hcName string) error {
 	hc, err := s.findHarnessConfigByName(ctx, hcName)
 	if err != nil {
 		return err
@@ -127,8 +144,16 @@ func (s *Server) syncHarnessConfigFromStorage(ctx context.Context, hcName string
 }
 
 // syncTemplateFromStorage syncs a single template's DB manifest from actual
-// GCS content.
+// GCS content. Concurrent calls for the same template are deduplicated via
+// singleflight.
 func (s *Server) syncTemplateFromStorage(ctx context.Context, templateRef string) error {
+	_, err, _ := repairFlight.Do("tmpl:"+templateRef, func() (interface{}, error) {
+		return nil, s.syncTemplateFromStorageInner(context.WithoutCancel(ctx), templateRef)
+	})
+	return err
+}
+
+func (s *Server) syncTemplateFromStorageInner(ctx context.Context, templateRef string) error {
 	tmpl, err := s.findTemplateByRef(ctx, templateRef)
 	if err != nil {
 		return err
@@ -195,6 +220,9 @@ func (s *Server) syncAllResourcesFromStorage(ctx context.Context, kind storage.R
 			s.resourceLog.Error(label+" sync: failed to list", "error", err)
 			return
 		}
+		if result == nil {
+			return
+		}
 		for _, hc := range result.Items {
 			if len(hc.Files) == 0 {
 				continue
@@ -211,6 +239,9 @@ func (s *Server) syncAllResourcesFromStorage(ctx context.Context, kind storage.R
 		}, store.ListOptions{Limit: 1000})
 		if err != nil {
 			s.resourceLog.Error(label+" sync: failed to list", "error", err)
+			return
+		}
+		if result == nil {
 			return
 		}
 		for _, t := range result.Items {
@@ -237,10 +268,18 @@ func (s *Server) syncAllResourcesFromStorage(ctx context.Context, kind storage.R
 			case storage.ResourceKindTemplate:
 				rs = s.templateStore()
 			}
+			if rs == nil {
+				s.resourceLog.Warn(label+" sync: no resource store",
+					"resource", e.name)
+				return nil
+			}
 			report, vErr := rs.ValidateStorage(gctx, e.rec)
 			if vErr != nil {
 				s.resourceLog.Warn(label+" sync: validation error",
 					"resource", e.name, "error", vErr)
+				return nil
+			}
+			if report == nil {
 				return nil
 			}
 			for _, issue := range report.Issues {
@@ -274,7 +313,7 @@ func (s *Server) findHarnessConfigByName(ctx context.Context, name string) (*sto
 	if err != nil {
 		return nil, fmt.Errorf("lookup harness-config %q: %w", name, err)
 	}
-	if len(result.Items) == 0 {
+	if result == nil || len(result.Items) == 0 {
 		return nil, nil
 	}
 	return &result.Items[0], nil
@@ -282,12 +321,10 @@ func (s *Server) findHarnessConfigByName(ctx context.Context, name string) (*sto
 
 // findTemplateByRef looks up an active template by ID or name.
 func (s *Server) findTemplateByRef(ctx context.Context, ref string) (*store.Template, error) {
-	// Try by ID first (UUIDs are passed from the dispatch path).
 	tmpl, err := s.store.GetTemplate(ctx, ref)
 	if err == nil && tmpl != nil {
 		return tmpl, nil
 	}
-	// Fall back to name search.
 	result, err := s.store.ListTemplates(ctx, store.TemplateFilter{
 		Name:   ref,
 		Status: store.TemplateStatusActive,
@@ -295,7 +332,7 @@ func (s *Server) findTemplateByRef(ctx context.Context, ref string) (*store.Temp
 	if err != nil {
 		return nil, fmt.Errorf("lookup template %q: %w", ref, err)
 	}
-	if len(result.Items) == 0 {
+	if result == nil || len(result.Items) == 0 {
 		return nil, nil
 	}
 	return &result.Items[0], nil

--- a/pkg/hub/harness_config_repair.go
+++ b/pkg/hub/harness_config_repair.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/storage"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// syncHarnessConfigFromStorage synchronises a single harness-config's DB
+// manifest hashes with the actual GCS content. In a multi-hub topology the
+// GCS bucket is shared while each hub keeps its own DB; when another hub
+// uploads newer content, the local DB manifest becomes stale and causes
+// hash-mismatch errors on broker hydration. This method downloads each file
+// from storage, recomputes the SHA-256 hash, and updates the DB record when
+// any file hash has drifted.
+func (s *Server) syncHarnessConfigFromStorage(ctx context.Context, hcName string) error {
+	hc, err := s.findHarnessConfigByName(ctx, hcName)
+	if err != nil {
+		return err
+	}
+	if hc == nil {
+		return fmt.Errorf("harness-config %q not found", hcName)
+	}
+
+	stor := s.GetStorage()
+	if stor == nil {
+		return fmt.Errorf("storage backend not configured")
+	}
+
+	storagePath := hc.StoragePath
+	if storagePath == "" {
+		storagePath = storage.ResourceStoragePath(
+			storage.ResourceKindHarnessConfig, hc.Scope, hc.ScopeID, hc.Slug)
+	}
+
+	changed := false
+	for i, file := range hc.Files {
+		if file.Hash == "" {
+			continue
+		}
+		objectPath := storagePath + "/" + file.Path
+
+		obj, getErr := stor.GetObject(ctx, objectPath)
+		if getErr != nil {
+			s.resourceLog.Warn("harness-config repair: cannot stat object",
+				"config", hcName, "file", file.Path, "error", getErr)
+			continue
+		}
+
+		actualHash := objectMetadataHash(obj)
+		if actualHash == "" {
+			var hashErr error
+			actualHash, hashErr = computeStoredHash(ctx, stor, objectPath)
+			if hashErr != nil {
+				s.resourceLog.Warn("harness-config repair: cannot hash object",
+					"config", hcName, "file", file.Path, "error", hashErr)
+				continue
+			}
+		}
+
+		if actualHash != file.Hash {
+			s.resourceLog.Warn("harness-config repair: updating stale file hash",
+				"config", hcName, "file", file.Path,
+				"dbHash", file.Hash, "storageHash", actualHash)
+			hc.Files[i].Hash = actualHash
+			changed = true
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	hc.ContentHash = computeContentHash(hc.Files)
+	if err := s.store.UpdateHarnessConfig(ctx, hc); err != nil {
+		return fmt.Errorf("harness-config repair: update DB: %w", err)
+	}
+
+	s.resourceLog.Info("harness-config repair: synced DB manifest from storage",
+		"config", hcName, "contentHash", hc.ContentHash)
+	return nil
+}
+
+// SyncAllHarnessConfigsFromStorage reconciles DB manifest hashes against
+// actual GCS content for all active harness-configs. Call at startup to catch
+// stale manifests left by peer hubs that updated the shared GCS bucket.
+func (s *Server) SyncAllHarnessConfigsFromStorage(ctx context.Context) {
+	stor := s.GetStorage()
+	if stor == nil {
+		return
+	}
+
+	result, err := s.store.ListHarnessConfigs(ctx, store.HarnessConfigFilter{
+		Status: store.HarnessConfigStatusActive,
+	}, store.ListOptions{Limit: 1000})
+	if err != nil {
+		s.resourceLog.Error("harness-config sync: failed to list configs", "error", err)
+		return
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(5)
+	for _, hc := range result.Items {
+		if len(hc.Files) == 0 {
+			continue
+		}
+		name := hc.Name
+		g.Go(func() error {
+			rs := s.harnessConfigStore(hc.Harness)
+			rec := harnessConfigToRecord(&hc)
+			report, vErr := rs.ValidateStorage(gctx, rec)
+			if vErr != nil {
+				s.resourceLog.Warn("harness-config sync: validation error",
+					"config", name, "error", vErr)
+				return nil
+			}
+			for _, issue := range report.Issues {
+				if issue.Kind == ValidationIssueContentHashMismatch {
+					if syncErr := s.syncHarnessConfigFromStorage(gctx, name); syncErr != nil {
+						s.resourceLog.Warn("harness-config sync: repair failed",
+							"config", name, "error", syncErr)
+					}
+					return nil
+				}
+			}
+			return nil
+		})
+	}
+	_ = g.Wait()
+}
+
+// findHarnessConfigByName looks up an active harness-config by its display name.
+func (s *Server) findHarnessConfigByName(ctx context.Context, name string) (*store.HarnessConfig, error) {
+	result, err := s.store.ListHarnessConfigs(ctx, store.HarnessConfigFilter{
+		Name:   name,
+		Status: store.HarnessConfigStatusActive,
+	}, store.ListOptions{Limit: 1})
+	if err != nil {
+		return nil, fmt.Errorf("lookup harness-config %q: %w", name, err)
+	}
+	if len(result.Items) == 0 {
+		return nil, nil
+	}
+	return &result.Items[0], nil
+}

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -281,7 +281,7 @@ func (d *HTTPAgentDispatcher) repairHashMismatch(ctx context.Context, agent *sto
 }
 
 func (d *HTTPAgentDispatcher) repairHarnessConfig(ctx context.Context, agent *store.Agent) error {
-	if d.harnessConfigRepairer == nil || agent.AppliedConfig.HarnessConfig == "" {
+	if d.harnessConfigRepairer == nil || agent.AppliedConfig == nil || agent.AppliedConfig.HarnessConfig == "" {
 		return fmt.Errorf("no repairer or harness config")
 	}
 	name := agent.AppliedConfig.HarnessConfig
@@ -300,7 +300,10 @@ func (d *HTTPAgentDispatcher) repairTemplate(ctx context.Context, agent *store.A
 	if d.templateRepairer == nil {
 		return fmt.Errorf("no template repairer")
 	}
-	ref := agent.AppliedConfig.TemplateID
+	var ref string
+	if agent.AppliedConfig != nil {
+		ref = agent.AppliedConfig.TemplateID
+	}
 	if ref == "" {
 		ref = agent.Template
 	}

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -153,9 +153,10 @@ type HTTPAgentDispatcher struct {
 	commandBus      CommandBus
 	dispatchMetrics dispatchmetrics.Recorder
 
-	// harnessConfigRepairer syncs a harness-config's DB manifest from GCS
+	// Resource hash repair callbacks sync a resource's DB manifest from GCS
 	// when a hash mismatch is detected during dispatch. Nil = no repair.
 	harnessConfigRepairer func(ctx context.Context, name string) error
+	templateRepairer      func(ctx context.Context, ref string) error
 }
 
 // NewHTTPAgentDispatcher creates a new HTTP-based agent dispatcher.
@@ -242,20 +243,49 @@ func (d *HTTPAgentDispatcher) SetHarnessConfigRepairer(fn func(ctx context.Conte
 	d.harnessConfigRepairer = fn
 }
 
+// SetTemplateRepairer registers a callback that syncs a template's DB manifest
+// from storage when a hash mismatch is detected during dispatch.
+func (d *HTTPAgentDispatcher) SetTemplateRepairer(fn func(ctx context.Context, ref string) error) {
+	d.templateRepairer = fn
+}
+
 // isHashMismatchError reports whether err is a broker hash-mismatch error
-// from harness-config hydration.
+// from resource hydration (template or harness-config).
 func isHashMismatchError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "hash mismatch for file")
 }
 
-// repairHarnessConfig attempts to sync the agent's harness-config DB manifest
-// from storage. Returns nil on success so the caller can retry the dispatch.
+// repairHashMismatch attempts to sync the affected resource's DB manifest from
+// storage. It inspects the error prefix to determine whether a template or
+// harness-config needs repair. Returns nil on success so the caller can retry.
+func (d *HTTPAgentDispatcher) repairHashMismatch(ctx context.Context, agent *store.Agent, dispatchErr error) error {
+	if agent.AppliedConfig == nil {
+		return fmt.Errorf("no applied config")
+	}
+
+	msg := dispatchErr.Error()
+
+	// Route to the correct repairer based on the hydration error prefix.
+	if strings.Contains(msg, "Failed to hydrate template:") {
+		return d.repairTemplate(ctx, agent)
+	}
+	if strings.Contains(msg, "Failed to hydrate harness-config:") {
+		return d.repairHarnessConfig(ctx, agent)
+	}
+
+	// Prefix not recognized — try both (harness-config first, then template).
+	if err := d.repairHarnessConfig(ctx, agent); err == nil {
+		return nil
+	}
+	return d.repairTemplate(ctx, agent)
+}
+
 func (d *HTTPAgentDispatcher) repairHarnessConfig(ctx context.Context, agent *store.Agent) error {
-	if d.harnessConfigRepairer == nil || agent.AppliedConfig == nil || agent.AppliedConfig.HarnessConfig == "" {
+	if d.harnessConfigRepairer == nil || agent.AppliedConfig.HarnessConfig == "" {
 		return fmt.Errorf("no repairer or harness config")
 	}
 	name := agent.AppliedConfig.HarnessConfig
-	d.log.Warn("hash mismatch detected, attempting DB→storage repair",
+	d.log.Warn("hash mismatch detected, attempting harness-config DB→storage repair",
 		"agent", agent.Slug, "harnessConfig", name)
 	if err := d.harnessConfigRepairer(ctx, name); err != nil {
 		d.log.Warn("harness-config repair failed", "harnessConfig", name, "error", err)
@@ -263,6 +293,28 @@ func (d *HTTPAgentDispatcher) repairHarnessConfig(ctx context.Context, agent *st
 	}
 	d.log.Info("harness-config repair succeeded, retrying dispatch",
 		"agent", agent.Slug, "harnessConfig", name)
+	return nil
+}
+
+func (d *HTTPAgentDispatcher) repairTemplate(ctx context.Context, agent *store.Agent) error {
+	if d.templateRepairer == nil {
+		return fmt.Errorf("no template repairer")
+	}
+	ref := agent.AppliedConfig.TemplateID
+	if ref == "" {
+		ref = agent.Template
+	}
+	if ref == "" {
+		return fmt.Errorf("no template reference")
+	}
+	d.log.Warn("hash mismatch detected, attempting template DB→storage repair",
+		"agent", agent.Slug, "template", ref)
+	if err := d.templateRepairer(ctx, ref); err != nil {
+		d.log.Warn("template repair failed", "template", ref, "error", err)
+		return err
+	}
+	d.log.Info("template repair succeeded, retrying dispatch",
+		"agent", agent.Slug, "template", ref)
 	return nil
 }
 
@@ -723,7 +775,7 @@ func (d *HTTPAgentDispatcher) DispatchAgentCreate(ctx context.Context, agent *st
 
 	resp, err := d.client.CreateAgent(ctx, agent.RuntimeBrokerID, endpoint, req)
 	if isHashMismatchError(err) {
-		if repairErr := d.repairHarnessConfig(ctx, agent); repairErr == nil {
+		if repairErr := d.repairHashMismatch(ctx, agent, err); repairErr == nil {
 			resp, err = d.client.CreateAgent(ctx, agent.RuntimeBrokerID, endpoint, req)
 		}
 	}
@@ -771,7 +823,7 @@ func (d *HTTPAgentDispatcher) DispatchAgentProvision(ctx context.Context, agent 
 
 	resp, err := d.client.CreateAgent(ctx, agent.RuntimeBrokerID, endpoint, req)
 	if isHashMismatchError(err) {
-		if repairErr := d.repairHarnessConfig(ctx, agent); repairErr == nil {
+		if repairErr := d.repairHashMismatch(ctx, agent, err); repairErr == nil {
 			resp, err = d.client.CreateAgent(ctx, agent.RuntimeBrokerID, endpoint, req)
 		}
 	}
@@ -816,7 +868,7 @@ func (d *HTTPAgentDispatcher) DispatchAgentCreateWithGather(ctx context.Context,
 		"brokerElapsed", time.Since(brokerCallStart).String(),
 		"totalElapsed", time.Since(dispatchStart).String())
 	if isHashMismatchError(err) {
-		if repairErr := d.repairHarnessConfig(ctx, agent); repairErr == nil {
+		if repairErr := d.repairHashMismatch(ctx, agent, err); repairErr == nil {
 			resp, envReqs, err = d.client.CreateAgentWithGather(ctx, agent.RuntimeBrokerID, endpoint, req)
 		}
 	}
@@ -1238,7 +1290,7 @@ func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *sto
 
 	resp, err := d.client.StartAgent(ctx, agent.RuntimeBrokerID, endpoint, agent.Slug, agent.ProjectID, task, projectPath, projectSlug, harnessConfig, resolvedEnv, resolvedSecrets, inlineConfig, projectInfo.sharedDirs, projectInfo.sharedWorkspace, resume)
 	if isHashMismatchError(err) {
-		if repairErr := d.repairHarnessConfig(ctx, agent); repairErr == nil {
+		if repairErr := d.repairHashMismatch(ctx, agent, err); repairErr == nil {
 			resp, err = d.client.StartAgent(ctx, agent.RuntimeBrokerID, endpoint, agent.Slug, agent.ProjectID, task, projectPath, projectSlug, harnessConfig, resolvedEnv, resolvedSecrets, inlineConfig, projectInfo.sharedDirs, projectInfo.sharedWorkspace, resume)
 		}
 	}

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -152,6 +152,10 @@ type HTTPAgentDispatcher struct {
 	events          EventPublisher
 	commandBus      CommandBus
 	dispatchMetrics dispatchmetrics.Recorder
+
+	// harnessConfigRepairer syncs a harness-config's DB manifest from GCS
+	// when a hash mismatch is detected during dispatch. Nil = no repair.
+	harnessConfigRepairer func(ctx context.Context, name string) error
 }
 
 // NewHTTPAgentDispatcher creates a new HTTP-based agent dispatcher.
@@ -230,6 +234,36 @@ func (d *HTTPAgentDispatcher) SetCrossNodeDeps(events EventPublisher, bus Comman
 // SetDispatchMetrics wires the dispatch metrics recorder (B5-2).
 func (d *HTTPAgentDispatcher) SetDispatchMetrics(rec dispatchmetrics.Recorder) {
 	d.dispatchMetrics = rec
+}
+
+// SetHarnessConfigRepairer registers a callback that syncs a harness-config's
+// DB manifest from storage when a hash mismatch is detected during dispatch.
+func (d *HTTPAgentDispatcher) SetHarnessConfigRepairer(fn func(ctx context.Context, name string) error) {
+	d.harnessConfigRepairer = fn
+}
+
+// isHashMismatchError reports whether err is a broker hash-mismatch error
+// from harness-config hydration.
+func isHashMismatchError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "hash mismatch for file")
+}
+
+// repairHarnessConfig attempts to sync the agent's harness-config DB manifest
+// from storage. Returns nil on success so the caller can retry the dispatch.
+func (d *HTTPAgentDispatcher) repairHarnessConfig(ctx context.Context, agent *store.Agent) error {
+	if d.harnessConfigRepairer == nil || agent.AppliedConfig == nil || agent.AppliedConfig.HarnessConfig == "" {
+		return fmt.Errorf("no repairer or harness config")
+	}
+	name := agent.AppliedConfig.HarnessConfig
+	d.log.Warn("hash mismatch detected, attempting DB→storage repair",
+		"agent", agent.Slug, "harnessConfig", name)
+	if err := d.harnessConfigRepairer(ctx, name); err != nil {
+		d.log.Warn("harness-config repair failed", "harnessConfig", name, "error", err)
+		return err
+	}
+	d.log.Info("harness-config repair succeeded, retrying dispatch",
+		"agent", agent.Slug, "harnessConfig", name)
+	return nil
 }
 
 // getBrokerEndpoint retrieves the endpoint URL for a runtime broker.
@@ -688,6 +722,11 @@ func (d *HTTPAgentDispatcher) DispatchAgentCreate(ctx context.Context, agent *st
 	}
 
 	resp, err := d.client.CreateAgent(ctx, agent.RuntimeBrokerID, endpoint, req)
+	if isHashMismatchError(err) {
+		if repairErr := d.repairHarnessConfig(ctx, agent); repairErr == nil {
+			resp, err = d.client.CreateAgent(ctx, agent.RuntimeBrokerID, endpoint, req)
+		}
+	}
 	if err != nil {
 		return err
 	}
@@ -771,6 +810,11 @@ func (d *HTTPAgentDispatcher) DispatchAgentCreateWithGather(ctx context.Context,
 		"agent_id", agent.ID, "agent", agent.Name,
 		"brokerElapsed", time.Since(brokerCallStart).String(),
 		"totalElapsed", time.Since(dispatchStart).String())
+	if isHashMismatchError(err) {
+		if repairErr := d.repairHarnessConfig(ctx, agent); repairErr == nil {
+			resp, envReqs, err = d.client.CreateAgentWithGather(ctx, agent.RuntimeBrokerID, endpoint, req)
+		}
+	}
 	if errors.Is(err, ErrLifecycleDeferred) {
 		return d.deferredCreateWithGather(ctx, agent)
 	}
@@ -1188,6 +1232,11 @@ func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *sto
 	}
 
 	resp, err := d.client.StartAgent(ctx, agent.RuntimeBrokerID, endpoint, agent.Slug, agent.ProjectID, task, projectPath, projectSlug, harnessConfig, resolvedEnv, resolvedSecrets, inlineConfig, projectInfo.sharedDirs, projectInfo.sharedWorkspace, resume)
+	if isHashMismatchError(err) {
+		if repairErr := d.repairHarnessConfig(ctx, agent); repairErr == nil {
+			resp, err = d.client.StartAgent(ctx, agent.RuntimeBrokerID, endpoint, agent.Slug, agent.ProjectID, task, projectPath, projectSlug, harnessConfig, resolvedEnv, resolvedSecrets, inlineConfig, projectInfo.sharedDirs, projectInfo.sharedWorkspace, resume)
+		}
+	}
 	if errors.Is(err, ErrLifecycleDeferred) {
 		return d.deferredStart(ctx, agent, &StartDispatchArgs{
 			Task:   task,

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -770,6 +770,11 @@ func (d *HTTPAgentDispatcher) DispatchAgentProvision(ctx context.Context, agent 
 	}
 
 	resp, err := d.client.CreateAgent(ctx, agent.RuntimeBrokerID, endpoint, req)
+	if isHashMismatchError(err) {
+		if repairErr := d.repairHarnessConfig(ctx, agent); repairErr == nil {
+			resp, err = d.client.CreateAgent(ctx, agent.RuntimeBrokerID, endpoint, req)
+		}
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1857,9 +1857,10 @@ func (s *Server) CreateAuthenticatedDispatcher() *HTTPAgentDispatcher {
 		dispatcher.SetTransportMinter(s.transportMinter, s.transportAudience)
 	}
 
-	// Wire harness-config hash repair so the dispatcher can auto-fix stale
-	// DB manifests when the shared GCS bucket was updated by another hub.
+	// Wire resource hash repair so the dispatcher can auto-fix stale DB
+	// manifests when the shared GCS bucket was updated by another hub.
 	dispatcher.SetHarnessConfigRepairer(s.syncHarnessConfigFromStorage)
+	dispatcher.SetTemplateRepairer(s.syncTemplateFromStorage)
 
 	return dispatcher
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1857,6 +1857,10 @@ func (s *Server) CreateAuthenticatedDispatcher() *HTTPAgentDispatcher {
 		dispatcher.SetTransportMinter(s.transportMinter, s.transportAudience)
 	}
 
+	// Wire harness-config hash repair so the dispatcher can auto-fix stale
+	// DB manifests when the shared GCS bucket was updated by another hub.
+	dispatcher.SetHarnessConfigRepairer(s.syncHarnessConfigFromStorage)
+
 	return dispatcher
 }
 


### PR DESCRIPTION
## Problem

When multiple hubs share a GCS bucket, one hub updating harness-config or template files causes other hubs' SQLite DB manifests to fall out of sync. This produces hash mismatch errors at agent dispatch time (`Failed to hydrate harness-config: hash mismatch for file ...`), completely blocking agent starts.

## Solution

Two complementary mechanisms:

**Startup reconciliation:** `SyncAllHarnessConfigsFromStorage()` and `SyncAllTemplatesFromStorage()` run concurrently on hub boot, downloading actual GCS content to recompute hashes and update stale DB manifests.

**Runtime self-healing:** All four dispatch paths (`DispatchAgentCreate`, `DispatchAgentCreateWithGather`, `DispatchAgentProvision`, `DispatchAgentStart`) detect hash mismatch errors, repair the affected resource by syncing DB from GCS, and retry dispatch once — transparent to the caller.

GCS is the source of truth. Repair syncs DB←GCS, not re-upload from embedded source. Covers both harness-configs and templates via a shared `syncResourceFromStorage()` helper