### PR TITLE
harness: two-phase image resolution with three-entity visibility and local image management

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -143,7 +143,7 @@ field is updated to reference the built image.`,
 			}
 		}
 
-		updateBuildConfigAndSync(harnessConfigName, hcDir, outputImage)
+		syncBuildToHub(harnessConfigName, hcDir)
 
 		return nil
 	},
@@ -268,7 +268,7 @@ func runCloudBuild(cmd *cobra.Command, harnessConfigName string, hcDir *config.H
 		return fmt.Errorf("cloud Build failed: %w", err)
 	}
 
-	updateBuildConfigAndSync(harnessConfigName, hcDir, outputImage)
+	syncBuildToHub(harnessConfigName, hcDir)
 
 	return nil
 }
@@ -285,48 +285,10 @@ func resolveGCPProject(settings *config.VersionedSettings) string {
 	return strings.TrimSpace(string(out))
 }
 
-// updateBuildConfigAndSync updates the harness config's config.yaml with the
-// new image reference and syncs to Hub.
-func updateBuildConfigAndSync(harnessConfigName string, hcDir *config.HarnessConfigDir, outputImage string) {
-	configPath := filepath.Join(hcDir.Path, "config.yaml")
-	configData, err := os.ReadFile(configPath)
-	if err != nil {
-		fmt.Printf("Warning: failed to read config.yaml for update: %v\n", err)
-		return
-	}
-	var doc yaml.Node
-	if err := yaml.Unmarshal(configData, &doc); err != nil {
-		fmt.Printf("Warning: failed to parse config.yaml: %v\n", err)
-		return
-	}
-	if len(doc.Content) > 0 && doc.Content[0].Kind == yaml.MappingNode {
-		mapping := doc.Content[0]
-		found := false
-		for i := 0; i < len(mapping.Content)-1; i += 2 {
-			if mapping.Content[i].Value == "image" {
-				mapping.Content[i+1].Value = outputImage
-				found = true
-				break
-			}
-		}
-		if !found {
-			mapping.Content = append(mapping.Content,
-				&yaml.Node{Kind: yaml.ScalarNode, Value: "image"},
-				&yaml.Node{Kind: yaml.ScalarNode, Value: outputImage},
-			)
-		}
-	}
-	updatedData, err := yaml.Marshal(&doc)
-	if err != nil {
-		fmt.Printf("Warning: failed to marshal updated config.yaml: %v\n", err)
-		return
-	}
-	if err := os.WriteFile(configPath, updatedData, 0644); err != nil {
-		fmt.Printf("Warning: failed to write updated config.yaml: %v\n", err)
-		return
-	}
-	fmt.Printf("Updated %s image to %s\n", configPath, outputImage)
-
+// syncBuildToHub syncs the harness config to Hub after a build without
+// modifying the image field in config.yaml. The image field is a stable
+// reference; two-phase resolution at agent start prefers local images.
+func syncBuildToHub(harnessConfigName string, hcDir *config.HarnessConfigDir) {
 	var gp string
 	if projectPath != "" {
 		if resolved, err := config.GetResolvedProjectDir(projectPath); err == nil {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/harness"
+	"github.com/GoogleCloudPlatform/scion/pkg/hub/imagecheck"
 	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
@@ -312,12 +313,23 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		util.Debugf("image resolution: from agent/template config image=%s", resolvedImage)
 	}
 
-	// Apply image_registry rewrite to whatever image was resolved above.
-	// This rewrites the registry prefix for scion-* images. An explicit
-	// --image flag below takes full precedence (no rewrite).
+	// Two-phase image resolution: for short-form (bare) images, prefer a
+	// locally-built image over the registry version. If no local image
+	// exists, fall back to the registry rewrite.
 	if settings != nil && resolvedImage != "" {
 		imageRegistry := settings.ResolveImageRegistry(opts.Profile)
-		if imageRegistry != "" {
+		if imageRegistry != "" && imagecheck.IsBareImageName(resolvedImage) {
+			localExists, localErr := m.Runtime.ImageExists(ctx, resolvedImage)
+			if localErr == nil && localExists {
+				util.Debugf("image resolution: using local short-form image %s", resolvedImage)
+			} else {
+				rewritten := config.RewriteImageRegistry(resolvedImage, imageRegistry)
+				if rewritten != resolvedImage {
+					util.Debugf("image resolution: image_registry rewrite %s -> %s", resolvedImage, rewritten)
+					resolvedImage = rewritten
+				}
+			}
+		} else if imageRegistry != "" {
 			rewritten := config.RewriteImageRegistry(resolvedImage, imageRegistry)
 			if rewritten != resolvedImage {
 				util.Debugf("image resolution: image_registry rewrite %s -> %s", resolvedImage, rewritten)

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -189,7 +189,7 @@ func RequireImageRegistry(projectPath, profileName string) error {
 }
 
 // RewriteImageRegistry replaces the registry prefix of a container image reference
-// with newRegistry. Only images whose basename starts with "scion-" are rewritten.
+// with newRegistry for any short-form (non-fully-qualified) image.
 // If newRegistry is empty, the original image is returned unchanged.
 func RewriteImageRegistry(fullImage, newRegistry string) string {
 	if newRegistry == "" || fullImage == "" {
@@ -203,11 +203,6 @@ func RewriteImageRegistry(fullImage, newRegistry string) string {
 		basename = fullImage[lastSlash+1:]
 	} else {
 		basename = fullImage
-	}
-
-	// Only rewrite images following the scion naming convention
-	if !strings.HasPrefix(basename, "scion-") {
-		return fullImage
 	}
 
 	// If the image already has an explicit registry hostname

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -3294,16 +3294,22 @@ func TestRewriteImageRegistry(t *testing.T) {
 			want:        "us-central1-docker.pkg.dev/example-project/scion-images/scion-gemini:latest",
 		},
 		{
-			name:        "do not rewrite non-scion image",
+			name:        "bare non-scion image rewritten",
 			fullImage:   "ubuntu:22.04",
 			newRegistry: "ghcr.io/myorg",
-			want:        "ubuntu:22.04",
+			want:        "ghcr.io/myorg/ubuntu:22.04",
 		},
 		{
 			name:        "do not rewrite custom registry image",
 			fullImage:   "myregistry.io/custom-agent:v1",
 			newRegistry: "ghcr.io/myorg",
 			want:        "myregistry.io/custom-agent:v1",
+		},
+		{
+			name:        "bare custom harness image rewritten",
+			fullImage:   "my-custom-harness:latest",
+			newRegistry: "ghcr.io/myorg",
+			want:        "ghcr.io/myorg/my-custom-harness:latest",
 		},
 		{
 			name:        "empty registry returns original",

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -22,13 +22,19 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/hub/imagecheck"
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
+
+type imageManager interface {
+	imagecheck.LocalImageExister
+	PullImage(ctx context.Context, image string) error
+	RemoveImage(ctx context.Context, image string) error
+}
 
 // CreateHarnessConfigRequest is the request body for creating a harness config.
 type CreateHarnessConfigRequest struct {
@@ -249,6 +255,12 @@ func (s *Server) handleHarnessConfigByID(w http.ResponseWriter, r *http.Request)
 		s.handleHarnessConfigValidate(w, r, hcID)
 	case "check-image":
 		s.handleHarnessConfigCheckImage(w, r, hcID)
+	case "image-status":
+		s.handleHarnessConfigImageStatus(w, r, hcID)
+	case "local-image":
+		s.handleHarnessConfigDeleteLocalImage(w, r, hcID)
+	case "pull-image":
+		s.handleHarnessConfigPullImage(w, r, hcID)
 	case "reimport":
 		s.handleHarnessConfigReimport(w, r, hcID)
 	case "files":
@@ -287,31 +299,12 @@ func (s *Server) getHarnessConfig(w http.ResponseWriter, r *http.Request, id str
 		return
 	}
 
-	if s.imageStatusStale(hc) {
-		if image := s.harnessConfigImage(hc); image != "" {
-			go func() {
-				if _, err, _ := s.imageStatusFlight.Do(hc.ID, func() (any, error) {
-					s.checkAndUpdateImageStatus(context.Background(), hc.ID, image)
-					return nil, nil
-				}); err != nil {
-					slog.Error("image status check failed", "harness_config_id", hc.ID, "error", err)
-				}
-			}()
-		}
-	}
-
 	resp := HarnessConfigWithCapabilities{HarnessConfig: *hc}
 	if identity := GetIdentityFromContext(ctx); identity != nil {
 		resp.Cap = s.authzService.ComputeCapabilities(ctx, identity, harnessConfigResource(hc))
 	}
 
 	writeJSON(w, http.StatusOK, resp)
-}
-
-func (s *Server) imageStatusStale(hc *store.HarnessConfig) bool {
-	return hc.ImageStatus == store.HarnessConfigImageStatusUnknown ||
-		hc.ImageStatusCheckedAt == nil ||
-		time.Since(*hc.ImageStatusCheckedAt) > 5*time.Minute
 }
 
 func (s *Server) harnessConfigImage(hc *store.HarnessConfig) string {
@@ -951,4 +944,108 @@ func (s *Server) handleHarnessConfigReimport(w http.ResponseWriter, r *http.Requ
 		HarnessConfigs: imported,
 		Count:          len(imported),
 	})
+}
+
+// handleHarnessConfigImageStatus returns three-entity image status.
+// GET /api/v1/harness-configs/{id}/image-status
+func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	ctx := r.Context()
+	hc, err := s.store.GetHarnessConfig(ctx, id)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	image := s.harnessConfigImage(hc)
+	if image == "" {
+		writeError(w, http.StatusBadRequest, "no_image", "Harness config has no image configured", nil)
+		return
+	}
+
+	registry := s.resolveImageRegistry()
+	longImage := config.RewriteImageRegistry(image, registry)
+
+	shortImage := image
+	if !imagecheck.IsBareImageName(image) {
+		shortImage = ""
+	}
+
+	result := s.imageChecker.CheckAll(ctx, shortImage, longImage)
+	writeJSON(w, http.StatusOK, result)
+}
+
+// handleHarnessConfigDeleteLocalImage removes the local short-form image.
+// DELETE /api/v1/harness-configs/{id}/local-image
+func (s *Server) handleHarnessConfigDeleteLocalImage(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodDelete {
+		MethodNotAllowed(w)
+		return
+	}
+
+	if s.imageManager == nil {
+		writeError(w, http.StatusServiceUnavailable, "no_runtime", "Container runtime not available", nil)
+		return
+	}
+
+	ctx := r.Context()
+	hc, err := s.store.GetHarnessConfig(ctx, id)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	image := s.harnessConfigImage(hc)
+	if image == "" || !imagecheck.IsBareImageName(image) {
+		writeError(w, http.StatusBadRequest, "no_local_image", "Harness config has no short-form image to delete", nil)
+		return
+	}
+
+	if err := s.imageManager.RemoveImage(ctx, image); err != nil {
+		writeError(w, http.StatusInternalServerError, "remove_failed", fmt.Sprintf("Failed to remove image: %v", err), nil)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "removed", "image": image})
+}
+
+// handleHarnessConfigPullImage pulls the latest image from the remote registry.
+// POST /api/v1/harness-configs/{id}/pull-image
+func (s *Server) handleHarnessConfigPullImage(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w)
+		return
+	}
+
+	if s.imageManager == nil {
+		writeError(w, http.StatusServiceUnavailable, "no_runtime", "Container runtime not available", nil)
+		return
+	}
+
+	ctx := r.Context()
+	hc, err := s.store.GetHarnessConfig(ctx, id)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	image := s.harnessConfigImage(hc)
+	if image == "" {
+		writeError(w, http.StatusBadRequest, "no_image", "Harness config has no image configured", nil)
+		return
+	}
+
+	registry := s.resolveImageRegistry()
+	pullImage := config.RewriteImageRegistry(image, registry)
+
+	if err := s.imageManager.PullImage(ctx, pullImage); err != nil {
+		writeError(w, http.StatusInternalServerError, "pull_failed", fmt.Sprintf("Failed to pull image: %v", err), nil)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "pulled", "image": pullImage})
 }

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -1005,6 +1005,16 @@ func (s *Server) handleHarnessConfigDeleteLocalImage(w http.ResponseWriter, r *h
 		return
 	}
 
+	exists, err := s.imageManager.ImageExists(ctx, image)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "check_failed", fmt.Sprintf("Failed to check image: %v", err), nil)
+		return
+	}
+	if !exists {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "not_found", "image": image})
+		return
+	}
+
 	if err := s.imageManager.RemoveImage(ctx, image); err != nil {
 		writeError(w, http.StatusInternalServerError, "remove_failed", fmt.Sprintf("Failed to remove image: %v", err), nil)
 		return

--- a/pkg/hub/imagecheck/checker.go
+++ b/pkg/hub/imagecheck/checker.go
@@ -63,7 +63,7 @@ func (c *Checker) Check(ctx context.Context, image string) CheckResult {
 	// Bare image names (no registry prefix) are local-only by convention.
 	// Without a local checker we cannot determine availability, so return
 	// "unknown" rather than probing a remote registry that will 401.
-	if isBareImageName(image) {
+	if IsBareImageName(image) {
 		result := CheckResult{
 			Status:    "unknown",
 			CheckedAt: now,
@@ -92,9 +92,9 @@ func (c *Checker) Check(ctx context.Context, image string) CheckResult {
 	return result
 }
 
-// isBareImageName returns true when the image reference has no explicit
+// IsBareImageName returns true when the image reference has no explicit
 // registry prefix (no '.' or ':' in the first path component before any '/').
-func isBareImageName(image string) bool {
+func IsBareImageName(image string) bool {
 	ref := image
 	if i := strings.LastIndex(ref, ":"); i > 0 {
 		possibleTag := ref[i+1:]

--- a/pkg/hub/imagecheck/checker.go
+++ b/pkg/hub/imagecheck/checker.go
@@ -12,6 +12,7 @@ import (
 type CheckResult struct {
 	Status    string
 	Source    string
+	Hash      string
 	Error     string
 	CheckedAt time.Time
 }
@@ -107,4 +108,87 @@ func IsBareImageName(image string) bool {
 		return true
 	}
 	return !strings.Contains(parts[0], ".") && !strings.Contains(parts[0], ":")
+}
+
+type ImageEntityStatus struct {
+	Exists        bool   `json:"exists"`
+	Image         string `json:"image,omitempty"`
+	Hash          string `json:"hash,omitempty"`
+	NewerThanLocal bool  `json:"newer_than_local,omitempty"`
+}
+
+type ThreeWayImageResult struct {
+	LocalShort       ImageEntityStatus `json:"local_short"`
+	LocalLong        ImageEntityStatus `json:"local_long"`
+	Remote           ImageEntityStatus `json:"remote"`
+	ResolvedImage    string            `json:"resolved_image"`
+	ResolutionSource string            `json:"resolution_source"`
+}
+
+// LocalImageIDer is an optional extension of LocalImageExister that can
+// return the image ID (hash) for a local image.
+type LocalImageIDer interface {
+	ImageID(ctx context.Context, image string) (string, error)
+}
+
+func (c *Checker) CheckAll(ctx context.Context, shortImage, longImage string) ThreeWayImageResult {
+	var result ThreeWayImageResult
+	result.LocalShort.Image = shortImage
+	result.LocalLong.Image = longImage
+	result.Remote.Image = longImage
+
+	if c.local != nil {
+		shortExists, _ := c.local.ImageExists(ctx, shortImage)
+		result.LocalShort.Exists = shortExists
+		if shortExists {
+			if ider, ok := c.local.(LocalImageIDer); ok {
+				if id, err := ider.ImageID(ctx, shortImage); err == nil {
+					result.LocalShort.Hash = id
+				}
+			}
+		}
+
+		if longImage != "" {
+			longExists, _ := c.local.ImageExists(ctx, longImage)
+			result.LocalLong.Exists = longExists
+			if longExists {
+				if ider, ok := c.local.(LocalImageIDer); ok {
+					if id, err := ider.ImageID(ctx, longImage); err == nil {
+						result.LocalLong.Hash = id
+					}
+				}
+			}
+		}
+	}
+
+	if longImage != "" {
+		ref, err := parseImageRef(longImage)
+		if err == nil {
+			remoteResult := checkRemoteImage(ctx, c.client, ref, time.Now())
+			if remoteResult.Status == "valid" {
+				result.Remote.Exists = true
+				result.Remote.Hash = remoteResult.Hash
+				if result.LocalLong.Exists && result.Remote.Hash != "" && result.LocalLong.Hash != "" {
+					result.Remote.NewerThanLocal = result.Remote.Hash != result.LocalLong.Hash
+				}
+			}
+		}
+	}
+
+	switch {
+	case result.LocalShort.Exists:
+		result.ResolvedImage = shortImage
+		result.ResolutionSource = "local_short"
+	case result.LocalLong.Exists:
+		result.ResolvedImage = longImage
+		result.ResolutionSource = "local_long"
+	case result.Remote.Exists:
+		result.ResolvedImage = longImage
+		result.ResolutionSource = "remote"
+	default:
+		result.ResolvedImage = shortImage
+		result.ResolutionSource = "none"
+	}
+
+	return result
 }

--- a/pkg/hub/imagecheck/checker.go
+++ b/pkg/hub/imagecheck/checker.go
@@ -138,12 +138,14 @@ func (c *Checker) CheckAll(ctx context.Context, shortImage, longImage string) Th
 	result.Remote.Image = longImage
 
 	if c.local != nil {
-		shortExists, _ := c.local.ImageExists(ctx, shortImage)
-		result.LocalShort.Exists = shortExists
-		if shortExists {
-			if ider, ok := c.local.(LocalImageIDer); ok {
-				if id, err := ider.ImageID(ctx, shortImage); err == nil {
-					result.LocalShort.Hash = id
+		if shortImage != "" {
+			shortExists, _ := c.local.ImageExists(ctx, shortImage)
+			result.LocalShort.Exists = shortExists
+			if shortExists {
+				if ider, ok := c.local.(LocalImageIDer); ok {
+					if id, err := ider.ImageID(ctx, shortImage); err == nil {
+						result.LocalShort.Hash = id
+					}
 				}
 			}
 		}
@@ -186,7 +188,10 @@ func (c *Checker) CheckAll(ctx context.Context, shortImage, longImage string) Th
 		result.ResolvedImage = longImage
 		result.ResolutionSource = "remote"
 	default:
-		result.ResolvedImage = shortImage
+		result.ResolvedImage = longImage
+		if shortImage != "" {
+			result.ResolvedImage = shortImage
+		}
 		result.ResolutionSource = "none"
 	}
 

--- a/pkg/hub/imagecheck/checker_test.go
+++ b/pkg/hub/imagecheck/checker_test.go
@@ -223,8 +223,8 @@ func TestIsBareImageName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.image, func(t *testing.T) {
-			if got := isBareImageName(tt.image); got != tt.bare {
-				t.Errorf("isBareImageName(%q) = %v, want %v", tt.image, got, tt.bare)
+			if got := IsBareImageName(tt.image); got != tt.bare {
+				t.Errorf("IsBareImageName(%q) = %v, want %v", tt.image, got, tt.bare)
 			}
 		})
 	}

--- a/pkg/hub/imagecheck/remote.go
+++ b/pkg/hub/imagecheck/remote.go
@@ -116,6 +116,7 @@ func doRegistryHead(ctx context.Context, client HTTPClient, url, token string, n
 		return CheckResult{
 			Status:    "valid",
 			Source:    "registry",
+			Hash:      resp.Header.Get("Docker-Content-Digest"),
 			CheckedAt: now,
 		}
 	case http.StatusNotFound:

--- a/pkg/hub/resource_bootstrap.go
+++ b/pkg/hub/resource_bootstrap.go
@@ -23,8 +23,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
@@ -201,28 +199,7 @@ func (s *Server) resolveImageRegistry() string {
 	return os.Getenv("SCION_IMAGE_REGISTRY")
 }
 
-// RecheckAllImageStatuses re-checks image availability for all active
-// harness configs concurrently. Called at server startup after bootstrap completes.
-func (s *Server) RecheckAllImageStatuses(ctx context.Context) {
-	result, err := s.store.ListHarnessConfigs(ctx, store.HarnessConfigFilter{
-		Status: store.HarnessConfigStatusActive,
-	}, store.ListOptions{Limit: 1000})
-	if err != nil {
-		slog.Error("failed to list harness configs for image recheck", "error", err)
-		return
-	}
-
-	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(5)
-	for _, hc := range result.Items {
-		if hc.Config == nil || hc.Config.Image == "" {
-			continue
-		}
-		id, image := hc.ID, hc.Config.Image
-		g.Go(func() error {
-			s.checkAndUpdateImageStatus(gctx, id, image)
-			return nil
-		})
-	}
-	_ = g.Wait()
-}
+// RecheckAllImageStatuses is a no-op. Remote registry checks are now
+// on-demand only (via the image-status endpoint). Retained as a stub
+// for callers that invoke it at startup.
+func (s *Server) RecheckAllImageStatuses(_ context.Context) {}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -673,6 +673,7 @@ type Server struct {
 	imagePullActive  atomic.Bool
 
 	imageChecker      *imagecheck.Checker
+	imageManager      imageManager
 	imageStatusFlight singleflight.Group
 
 	// Mode 3 (HA) integration support fields.
@@ -1634,6 +1635,9 @@ func (s *Server) SetGCPTokenMetrics(m GCPTokenMetricsRecorder) {
 // checker so it can verify images via the local Docker/Podman daemon.
 func (s *Server) SetLocalImageChecker(l imagecheck.LocalImageExister) {
 	s.imageChecker.SetLocal(l)
+	if mgr, ok := l.(imageManager); ok {
+		s.imageManager = mgr
+	}
 }
 
 // GetMaintenanceState returns the runtime maintenance state.

--- a/pkg/runtime/apple_container.go
+++ b/pkg/runtime/apple_container.go
@@ -290,6 +290,16 @@ func (r *AppleContainerRuntime) ImageExists(ctx context.Context, image string) (
 	return err == nil, nil
 }
 
+func (r *AppleContainerRuntime) ImageID(ctx context.Context, image string) (string, error) {
+	// Apple Container runtime does not expose image IDs in the same way.
+	return "", nil
+}
+
+func (r *AppleContainerRuntime) RemoveImage(ctx context.Context, image string) error {
+	// Apple Container runtime does not support image removal in the same way.
+	return nil
+}
+
 func (r *AppleContainerRuntime) PullImage(ctx context.Context, image string) error {
 	return runInteractiveCommand(r.Command, "image", "pull", image)
 }

--- a/pkg/runtime/cloudrun_runtime.go
+++ b/pkg/runtime/cloudrun_runtime.go
@@ -155,6 +155,14 @@ func (r *CloudRunRuntime) ImageExists(ctx context.Context, image string) (bool, 
 	return false, fmt.Errorf("cloudrun: ImageExists not yet implemented")
 }
 
+func (r *CloudRunRuntime) ImageID(ctx context.Context, image string) (string, error) {
+	return "", fmt.Errorf("cloudrun: ImageID not yet implemented")
+}
+
+func (r *CloudRunRuntime) RemoveImage(ctx context.Context, image string) error {
+	return fmt.Errorf("cloudrun: RemoveImage not yet implemented")
+}
+
 func (r *CloudRunRuntime) PullImage(ctx context.Context, image string) error {
 	return fmt.Errorf("cloudrun: PullImage not yet implemented")
 }

--- a/pkg/runtime/docker.go
+++ b/pkg/runtime/docker.go
@@ -256,6 +256,19 @@ func (r *DockerRuntime) ImageExists(ctx context.Context, image string) (bool, er
 	return err == nil, nil
 }
 
+func (r *DockerRuntime) ImageID(ctx context.Context, image string) (string, error) {
+	out, err := runSimpleCommand(ctx, r.Command, "image", "inspect", "--format", "{{.ID}}", image)
+	if err != nil {
+		return "", fmt.Errorf("image inspect failed: %w", err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func (r *DockerRuntime) RemoveImage(ctx context.Context, image string) error {
+	_, err := runSimpleCommand(ctx, r.Command, "rmi", image)
+	return err
+}
+
 func (r *DockerRuntime) PullImage(ctx context.Context, image string) error {
 	return runInteractiveCommand(r.Command, "pull", image)
 }

--- a/pkg/runtime/factory.go
+++ b/pkg/runtime/factory.go
@@ -210,6 +210,14 @@ func (e *ErrorRuntime) ImageExists(ctx context.Context, image string) (bool, err
 	return false, e.Err
 }
 
+func (e *ErrorRuntime) ImageID(ctx context.Context, image string) (string, error) {
+	return "", e.Err
+}
+
+func (e *ErrorRuntime) RemoveImage(ctx context.Context, image string) error {
+	return e.Err
+}
+
 func (e *ErrorRuntime) PullImage(ctx context.Context, image string) error {
 	return e.Err
 }

--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -112,6 +112,8 @@ type Runtime interface {
 	GetLogs(ctx context.Context, id string) (string, error)
 	Attach(ctx context.Context, id string) error
 	ImageExists(ctx context.Context, image string) (bool, error)
+	ImageID(ctx context.Context, image string) (string, error)
+	RemoveImage(ctx context.Context, image string) error
 	PullImage(ctx context.Context, image string) error
 	Sync(ctx context.Context, id string, direction SyncDirection) error
 	Exec(ctx context.Context, id string, cmd []string) (string, error)

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -2148,6 +2148,16 @@ func (r *KubernetesRuntime) ImageExists(ctx context.Context, image string) (bool
 	return true, nil
 }
 
+func (r *KubernetesRuntime) ImageID(ctx context.Context, image string) (string, error) {
+	// K8s doesn't have local images — images are pulled by the kubelet.
+	return "", nil
+}
+
+func (r *KubernetesRuntime) RemoveImage(ctx context.Context, image string) error {
+	// K8s doesn't have local images — image lifecycle is managed by the kubelet.
+	return nil
+}
+
 func (r *KubernetesRuntime) PullImage(ctx context.Context, image string) error {
 	// Not strictly needed as Pod creation handles pulling.
 	return nil

--- a/pkg/runtime/mock.go
+++ b/pkg/runtime/mock.go
@@ -29,6 +29,8 @@ type MockRuntime struct {
 	GetLogsFunc          func(ctx context.Context, id string) (string, error)
 	AttachFunc           func(ctx context.Context, id string) error
 	ImageExistsFunc      func(ctx context.Context, image string) (bool, error)
+	ImageIDFunc          func(ctx context.Context, image string) (string, error)
+	RemoveImageFunc      func(ctx context.Context, image string) error
 	SyncFunc             func(ctx context.Context, id string, direction SyncDirection) error
 	ExecFunc             func(ctx context.Context, id string, cmd []string) (string, error)
 	GetWorkspacePathFunc func(ctx context.Context, id string) (string, error)
@@ -92,6 +94,20 @@ func (m *MockRuntime) ImageExists(ctx context.Context, image string) (bool, erro
 		return m.ImageExistsFunc(ctx, image)
 	}
 	return true, nil
+}
+
+func (m *MockRuntime) ImageID(ctx context.Context, image string) (string, error) {
+	if m.ImageIDFunc != nil {
+		return m.ImageIDFunc(ctx, image)
+	}
+	return "", nil
+}
+
+func (m *MockRuntime) RemoveImage(ctx context.Context, image string) error {
+	if m.RemoveImageFunc != nil {
+		return m.RemoveImageFunc(ctx, image)
+	}
+	return nil
 }
 
 func (m *MockRuntime) PullImage(ctx context.Context, image string) error {

--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -373,6 +373,19 @@ func (r *PodmanRuntime) ImageExists(ctx context.Context, image string) (bool, er
 	return err == nil, nil
 }
 
+func (r *PodmanRuntime) ImageID(ctx context.Context, image string) (string, error) {
+	out, err := runSimpleCommand(ctx, r.Command, "image", "inspect", "--format", "{{.ID}}", image)
+	if err != nil {
+		return "", fmt.Errorf("image inspect failed: %w", err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func (r *PodmanRuntime) RemoveImage(ctx context.Context, image string) error {
+	_, err := runSimpleCommand(ctx, r.Command, "rmi", image)
+	return err
+}
+
 func (r *PodmanRuntime) PullImage(ctx context.Context, image string) error {
 	return runInteractiveCommand(r.Command, "pull", image)
 }

--- a/web/src/components/pages/harness-config-detail.ts
+++ b/web/src/components/pages/harness-config-detail.ts
@@ -655,9 +655,11 @@ export class ScionPageHarnessConfigDetail extends LitElement {
               <td class="image-ref">${st?.local_short?.image || image || '—'}</td>
               <td class="image-hash">${st?.local_short?.exists ? (st.local_short.hash || '—') : ''}</td>
               <td>
-                ${st?.local_short?.exists
-                  ? html`Available${src === 'local_short' ? html`<span class="active-badge">Active</span>` : nothing}`
-                  : html`<span class="not-found">Not found</span>`}
+                ${st
+                  ? (st.local_short?.exists
+                    ? html`Available${src === 'local_short' ? html`<span class="active-badge">Active</span>` : nothing}`
+                    : html`<span class="not-found">Not found</span>`)
+                  : html`<sl-spinner style="font-size: 0.75rem;"></sl-spinner> Checking...`}
               </td>
             </tr>
             <tr class=${src === 'local_long' ? 'active-row' : ''}>
@@ -665,9 +667,11 @@ export class ScionPageHarnessConfigDetail extends LitElement {
               <td class="image-ref">${st?.local_long?.image || '—'}</td>
               <td class="image-hash">${st?.local_long?.exists ? (st.local_long.hash || '—') : ''}</td>
               <td>
-                ${st?.local_long?.exists
-                  ? html`Available${src === 'local_long' ? html`<span class="active-badge">Active</span>` : nothing}`
-                  : html`<span class="not-found">Not found</span>`}
+                ${st
+                  ? (st.local_long?.exists
+                    ? html`Available${src === 'local_long' ? html`<span class="active-badge">Active</span>` : nothing}`
+                    : html`<span class="not-found">Not found</span>`)
+                  : html`<sl-spinner style="font-size: 0.75rem;"></sl-spinner> Checking...`}
               </td>
             </tr>
             <tr class=${src === 'remote' ? 'active-row' : ''}>
@@ -675,10 +679,12 @@ export class ScionPageHarnessConfigDetail extends LitElement {
               <td class="image-ref">${st?.remote?.image || '—'}</td>
               <td class="image-hash">${st?.remote?.exists ? (st.remote.hash || '—') : ''}</td>
               <td>
-                ${st?.remote?.exists
-                  ? html`Available${src === 'remote' ? html`<span class="active-badge">Active</span>` : nothing}
-                    ${st?.remote?.newer_than_local ? html`<span class="newer-badge">Newer version available</span>` : nothing}`
-                  : html`<span class="not-found">Not checked</span>`}
+                ${st
+                  ? (st.remote?.exists
+                    ? html`Available${src === 'remote' ? html`<span class="active-badge">Active</span>` : nothing}
+                      ${st.remote?.newer_than_local ? html`<span class="newer-badge">Newer version available</span>` : nothing}`
+                    : html`<span class="not-found">Not checked</span>`)
+                  : html`<sl-spinner style="font-size: 0.75rem;"></sl-spinner> Checking...`}
               </td>
             </tr>
           </tbody>

--- a/web/src/components/pages/harness-config-detail.ts
+++ b/web/src/components/pages/harness-config-detail.ts
@@ -121,6 +121,18 @@ export class ScionPageHarnessConfigDetail extends LitElement {
   @state()
   private resolvedImage = '';
 
+  @state()
+  private imageStatus: {
+    local_short?: { exists: boolean; image: string; hash: string };
+    local_long?: { exists: boolean; image: string; hash: string };
+    remote?: { exists: boolean; image: string; hash: string; newer_than_local: boolean };
+    resolved_image?: string;
+    resolution_source?: string;
+  } | null = null;
+
+  @state()
+  private imageActionRunning = false;
+
   private fileBrowserDataSource: FileBrowserDataSource | null = null;
   private fileEditorDataSource: FileEditorDataSource | null = null;
   private buildPollTimer: ReturnType<typeof setTimeout> | null = null;
@@ -281,69 +293,78 @@ export class ScionPageHarnessConfigDetail extends LitElement {
       font-weight: 600;
       margin: 0 0 1rem;
     }
-    .image-info {
-      display: flex;
-      align-items: center;
-      gap: 1rem;
-      padding: 0.75rem 1rem;
-      background: var(--sl-color-neutral-50);
+    .image-table {
+      width: 100%;
+      border-collapse: collapse;
       border: 1px solid var(--sl-color-neutral-200);
       border-radius: var(--sl-border-radius-medium);
-      flex-wrap: wrap;
-    }
-    .image-path {
-      font-family: var(--sl-font-mono);
+      overflow: hidden;
       font-size: 0.8125rem;
-      word-break: break-all;
-      flex: 1;
-      min-width: 0;
     }
-    .image-type-badge {
-      display: inline-block;
-      padding: 0.125rem 0.5rem;
-      border-radius: var(--sl-border-radius-pill);
-      font-size: 0.6875rem;
+    .image-table th {
+      text-align: left;
+      padding: 0.5rem 0.75rem;
+      background: var(--sl-color-neutral-100);
       font-weight: 600;
+      font-size: 0.75rem;
+      color: var(--sl-color-neutral-600);
       text-transform: uppercase;
+      letter-spacing: 0.025em;
+    }
+    .image-table td {
+      padding: 0.5rem 0.75rem;
+      border-top: 1px solid var(--sl-color-neutral-200);
+      vertical-align: middle;
+    }
+    .image-table tr.active-row {
+      background: var(--sl-color-success-50, #f0fdf4);
+    }
+    .image-entity-name {
+      font-weight: 600;
       white-space: nowrap;
     }
-    .image-type-badge.local {
-      background: var(--sl-color-neutral-100);
-      color: var(--sl-color-neutral-700);
-    }
-    .image-type-badge.remote {
-      background: var(--sl-color-primary-50);
-      color: var(--sl-color-primary-700);
-    }
-    .image-meta {
+    .image-ref {
+      font-family: var(--sl-font-mono);
       font-size: 0.75rem;
+      color: var(--sl-color-neutral-600);
+      word-break: break-all;
+    }
+    .image-hash {
+      font-family: var(--sl-font-mono);
+      font-size: 0.6875rem;
       color: var(--sl-color-neutral-500);
     }
-    .image-status-indicator {
+    .active-badge {
+      display: inline-block;
+      padding: 0.0625rem 0.375rem;
+      border-radius: var(--sl-border-radius-pill);
+      font-size: 0.625rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      background: var(--sl-color-success-100, #dcfce7);
+      color: var(--sl-color-success-700, #15803d);
+      margin-left: 0.5rem;
+    }
+    .newer-badge {
       display: inline-flex;
       align-items: center;
       gap: 0.25rem;
-      font-size: 0.75rem;
-      font-weight: 600;
-      padding: 0.125rem 0.5rem;
+      padding: 0.0625rem 0.375rem;
       border-radius: var(--sl-border-radius-pill);
-      white-space: nowrap;
-    }
-    .image-status-indicator.valid {
-      background: var(--sl-color-success-100, #dcfce7);
-      color: var(--sl-color-success-700, #15803d);
-    }
-    .image-status-indicator.invalid {
-      background: var(--sl-color-danger-100, #fee2e2);
-      color: var(--sl-color-danger-700, #b91c1c);
-    }
-    .image-status-indicator.error {
+      font-size: 0.625rem;
+      font-weight: 600;
       background: var(--sl-color-warning-100, #fef3c7);
       color: var(--sl-color-warning-700, #a16207);
     }
-    .image-status-indicator.unknown {
-      background: var(--sl-color-neutral-100, #f1f5f9);
-      color: var(--sl-color-neutral-500, #64748b);
+    .not-found {
+      color: var(--sl-color-neutral-400);
+      font-style: italic;
+    }
+    .image-actions {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 0.75rem;
+      flex-wrap: wrap;
     }
 
     .dialog-warning {
@@ -429,6 +450,10 @@ export class ScionPageHarnessConfigDetail extends LitElement {
       // Create data sources
       this.fileBrowserDataSource = new HarnessConfigFileBrowserDataSource(this.harnessConfigId);
       this.fileEditorDataSource = new HarnessConfigFileEditorDataSource(this.harnessConfigId);
+
+      if (this.harnessConfig.config?.image) {
+        void this.recheckImage();
+      }
     } catch (err) {
       console.error('Failed to load harness config:', err);
       this.error = err instanceof Error ? err.message : 'Failed to load harness config';
@@ -606,39 +631,59 @@ export class ScionPageHarnessConfigDetail extends LitElement {
   private renderImageSection() {
     const hc = this.harnessConfig!;
     const image = hc.config?.image;
-    const hasImageStatus = !!hc.imageStatus && hc.imageStatus !== 'unknown';
-    const showSection = image || this.hasDockerfile || hasImageStatus;
+    const showSection = image || this.hasDockerfile;
     if (!showSection) return nothing;
 
-    const isRemote = image ? this.isRemoteImage(image) : false;
+    const st = this.imageStatus;
+    const src = st?.resolution_source || '';
 
     return html`
       <div class="image-section">
-        <h2>Image</h2>
-        <div class="image-info">
-          ${image ? html`
-            <span class="image-type-badge ${isRemote ? 'remote' : 'local'}">
-              ${isRemote ? 'Remote' : 'Local'}
-            </span>
-            <span class="image-path">${image}</span>
-            <span class="image-status-indicator ${hc.imageStatus || 'unknown'}">
-              ${hc.imageStatus === 'valid' ? 'Image Available' :
-                hc.imageStatus === 'invalid' ? 'Image Not Found' :
-                hc.imageStatus === 'error' ? 'Check Failed' : 'Not Checked'}
-            </span>
-            ${this.resolvedImage && this.resolvedImage !== image ? html`
-              <span class="image-meta">${this.resolvedImage}</span>
-            ` : nothing}
-            <sl-button size="small" variant="text" @click=${this.recheckImage}>
-              <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
-              Re-check
-            </sl-button>
-          ` : html`
-            <span class="image-meta">No image configured</span>
-          `}
-          ${hc.updated ? html`
-            <span class="image-meta">Last updated: ${new Date(hc.updated).toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' })}</span>
-          ` : nothing}
+        <h2>Images</h2>
+        <table class="image-table">
+          <thead>
+            <tr>
+              <th>Entity</th>
+              <th>Image</th>
+              <th>Hash</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class=${src === 'local_short' ? 'active-row' : ''}>
+              <td class="image-entity-name">Local Build</td>
+              <td class="image-ref">${st?.local_short?.image || image || '—'}</td>
+              <td class="image-hash">${st?.local_short?.exists ? (st.local_short.hash || '—') : ''}</td>
+              <td>
+                ${st?.local_short?.exists
+                  ? html`Available${src === 'local_short' ? html`<span class="active-badge">Active</span>` : nothing}`
+                  : html`<span class="not-found">Not found</span>`}
+              </td>
+            </tr>
+            <tr class=${src === 'local_long' ? 'active-row' : ''}>
+              <td class="image-entity-name">Pulled</td>
+              <td class="image-ref">${st?.local_long?.image || '—'}</td>
+              <td class="image-hash">${st?.local_long?.exists ? (st.local_long.hash || '—') : ''}</td>
+              <td>
+                ${st?.local_long?.exists
+                  ? html`Available${src === 'local_long' ? html`<span class="active-badge">Active</span>` : nothing}`
+                  : html`<span class="not-found">Not found</span>`}
+              </td>
+            </tr>
+            <tr class=${src === 'remote' ? 'active-row' : ''}>
+              <td class="image-entity-name">Remote</td>
+              <td class="image-ref">${st?.remote?.image || '—'}</td>
+              <td class="image-hash">${st?.remote?.exists ? (st.remote.hash || '—') : ''}</td>
+              <td>
+                ${st?.remote?.exists
+                  ? html`Available${src === 'remote' ? html`<span class="active-badge">Active</span>` : nothing}
+                    ${st?.remote?.newer_than_local ? html`<span class="newer-badge">Newer version available</span>` : nothing}`
+                  : html`<span class="not-found">Not checked</span>`}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="image-actions">
           ${this.hasDockerfile ? html`
             <sl-button
               size="small"
@@ -650,23 +695,87 @@ export class ScionPageHarnessConfigDetail extends LitElement {
               ${this.buildRunning ? 'Building...' : 'Build Image'}
             </sl-button>
           ` : nothing}
+          ${st?.local_short?.exists ? html`
+            <sl-button
+              size="small"
+              variant="warning"
+              outline
+              @click=${this.deleteLocalImage}
+              ?disabled=${this.imageActionRunning}
+            >
+              <sl-icon slot="prefix" name="trash"></sl-icon>
+              Delete Local
+            </sl-button>
+          ` : nothing}
+          <sl-button
+            size="small"
+            variant="default"
+            @click=${this.pullLatestImage}
+            ?disabled=${this.imageActionRunning}
+          >
+            <sl-icon slot="prefix" name="cloud-download"></sl-icon>
+            Pull Latest
+          </sl-button>
+          <sl-button size="small" variant="text" @click=${this.recheckImage} ?disabled=${this.imageActionRunning}>
+            <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
+            Re-check Remote
+          </sl-button>
         </div>
       </div>
     `;
   }
 
   private async recheckImage(): Promise<void> {
-    const resp = await apiFetch(
-      `/api/v1/harness-configs/${this.harnessConfigId}/check-image`,
-      { method: 'POST' }
-    );
-    if (resp.ok) {
-      const data = await resp.json();
-      this.resolvedImage = data.resolved_image || '';
-      await this.loadHarnessConfig();
-    } else {
-      const msg = await extractApiError(resp, `HTTP ${resp.status}`);
-      alert(msg);
+    this.imageActionRunning = true;
+    try {
+      const resp = await apiFetch(
+        `/api/v1/harness-configs/${this.harnessConfigId}/image-status`
+      );
+      if (resp.ok) {
+        this.imageStatus = await resp.json();
+        this.resolvedImage = this.imageStatus?.resolved_image || '';
+      } else {
+        const msg = await extractApiError(resp, `HTTP ${resp.status}`);
+        alert(msg);
+      }
+    } finally {
+      this.imageActionRunning = false;
+    }
+  }
+
+  private async deleteLocalImage(): Promise<void> {
+    this.imageActionRunning = true;
+    try {
+      const resp = await apiFetch(
+        `/api/v1/harness-configs/${this.harnessConfigId}/local-image`,
+        { method: 'DELETE' }
+      );
+      if (resp.ok) {
+        await this.recheckImage();
+      } else {
+        const msg = await extractApiError(resp, `HTTP ${resp.status}`);
+        alert(msg);
+      }
+    } finally {
+      this.imageActionRunning = false;
+    }
+  }
+
+  private async pullLatestImage(): Promise<void> {
+    this.imageActionRunning = true;
+    try {
+      const resp = await apiFetch(
+        `/api/v1/harness-configs/${this.harnessConfigId}/pull-image`,
+        { method: 'POST' }
+      );
+      if (resp.ok) {
+        await this.recheckImage();
+      } else {
+        const msg = await extractApiError(resp, `HTTP ${resp.status}`);
+        alert(msg);
+      }
+    } finally {
+      this.imageActionRunning = false;
     }
   }
 


### PR DESCRIPTION
## Problem

When a locally-built harness image exists alongside a registry image, the system silently bypassed the local image (`RewriteImageRegistry` always preferred the registry). Users had no visibility into which image would be used, what its digest was, or whether a newer remote version was available.

## Changes

**Two-phase resolution** (`pkg/agent/run.go`): For short-form image names, check local Docker first. If found locally, use it. Otherwise rewrite to registry path. Long-form (fully-qualified) refs are used as-is.

**Generalized rewrite** (`pkg/config/settings_v1.go`): Removed `scion-*` prefix restriction — all short-form harness images get registry rewrite when configured.

**Stable image field** (`cmd/build.go`): Build no longer overwrites the `image` field in config.yaml. The field stays as a stable reference to the default/remote image.

**Three-entity image checker** (`pkg/hub/imagecheck`): New `CheckAll()` returning status for local short-form, local long-form (pulled), and remote registry — each with digest hash and a `newer_than_local` indicator.

**New API endpoints** (`pkg/hub/harness_config_handlers.go`):
- `GET /api/v1/harness-configs/{id}/image-status` (enhanced) — returns all three entities plus `resolved_image` and `resolution_source`
- `DELETE /api/v1/harness-configs/{id}/local-image` — removes local short-form image
- `POST /api/v1/harness-configs/{id}/pull-image` — pulls latest from regis