### PR TITLE
feat: show image pull progress (X of N) in onboarding wizard

### DIFF
--- a/pkg/runtime/imagepull.go
+++ b/pkg/runtime/imagepull.go
@@ -48,6 +48,8 @@ type PullResult struct {
 	Image  string `json:"image"`
 	Status string `json:"status"` // "queued" | "exists" | "pulling" | "done" | "error"
 	Error  string `json:"error,omitempty"`
+	Index  int    `json:"index"` // 1-based position in the pull queue
+	Total  int    `json:"total"` // total number of images being pulled
 }
 
 // PullImages pulls the images for the given harnesses, streaming PullResult
@@ -58,30 +60,31 @@ func PullImages(ctx context.Context, rt Runtime, harnesses []string, registry st
 		return fmt.Errorf("no valid harness images to pull")
 	}
 
-	for _, img := range images {
-		onEvent(PullResult{Image: img, Status: "queued"})
+	total := len(images)
+	for i, img := range images {
+		onEvent(PullResult{Image: img, Status: "queued", Index: i + 1, Total: total})
 	}
 
-	for _, img := range images {
+	for i, img := range images {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		exists, err := rt.ImageExists(ctx, img)
 		if err != nil {
-			onEvent(PullResult{Image: img, Status: "error", Error: err.Error()})
+			onEvent(PullResult{Image: img, Status: "error", Error: err.Error(), Index: i + 1, Total: total})
 			continue
 		}
 		if exists {
-			onEvent(PullResult{Image: img, Status: "exists"})
+			onEvent(PullResult{Image: img, Status: "exists", Index: i + 1, Total: total})
 			continue
 		}
 
-		onEvent(PullResult{Image: img, Status: "pulling"})
+		onEvent(PullResult{Image: img, Status: "pulling", Index: i + 1, Total: total})
 		if err := rt.PullImage(ctx, img); err != nil {
-			onEvent(PullResult{Image: img, Status: "error", Error: err.Error()})
+			onEvent(PullResult{Image: img, Status: "error", Error: err.Error(), Index: i + 1, Total: total})
 			continue
 		}
-		onEvent(PullResult{Image: img, Status: "done"})
+		onEvent(PullResult{Image: img, Status: "done", Index: i + 1, Total: total})
 	}
 
 	return nil

--- a/pkg/runtime/imagepull.go
+++ b/pkg/runtime/imagepull.go
@@ -61,8 +61,8 @@ func PullImages(ctx context.Context, rt Runtime, harnesses []string, registry st
 	}
 
 	total := len(images)
-	for i, img := range images {
-		onEvent(PullResult{Image: img, Status: "queued", Index: i + 1, Total: total})
+	for _, img := range images {
+		onEvent(PullResult{Image: img, Status: "queued"})
 	}
 
 	for i, img := range images {

--- a/web/src/components/pages/onboarding.ts
+++ b/web/src/components/pages/onboarding.ts
@@ -1143,7 +1143,7 @@ export class ScionPageOnboarding extends LitElement {
           const fullImageName = d['image'] as string;
           const status = d['status'] as string;
 
-          if (typeof d['index'] === 'number' && typeof d['total'] === 'number') {
+          if (status !== 'queued' && typeof d['index'] === 'number' && typeof d['total'] === 'number') {
             this.pullIndex = d['index'] as number;
             this.pullTotal = d['total'] as number;
           }

--- a/web/src/components/pages/onboarding.ts
+++ b/web/src/components/pages/onboarding.ts
@@ -91,6 +91,8 @@ export class ScionPageOnboarding extends LitElement {
   @state() private imageCheckStatuses = new Map<string, { imageStatus: string; source?: string | undefined; checking?: boolean | undefined }>();
   @state() private imagePulling = false;
   @state() private imageRechecking = false;
+  @state() private pullIndex = 0;
+  @state() private pullTotal = 0;
   @state() private gitVersion = '';
   @state() private gitVersionOK = true;
   private imageEventSource: EventSource | null = null;
@@ -325,6 +327,18 @@ export class ScionPageOnboarding extends LitElement {
 
     .loading-state sl-spinner {
       font-size: 2rem;
+    }
+
+    .pull-summary {
+      margin-bottom: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .pull-summary-text {
+      font-size: 0.875rem;
+      color: var(--scion-text-muted, #64748b);
     }
 
     .image-list {
@@ -872,6 +886,17 @@ export class ScionPageOnboarding extends LitElement {
           <p>Loading harness configurations...</p>
         </div>
       ` : html`
+        ${this.imagePulling && this.pullTotal > 0 ? html`
+          <div class="pull-summary">
+            <div class="pull-summary-text">
+              Pulling image ${this.pullIndex} of ${this.pullTotal}...
+            </div>
+            <sl-progress-bar
+              value=${Math.round((this.pullIndex / this.pullTotal) * 100)}
+            ></sl-progress-bar>
+          </div>
+        ` : nothing}
+
         <div class="harness-list">
           ${this.harnessConfigs.map(hc => {
             const cs = this.imageCheckStatuses.get(hc.id);
@@ -1093,6 +1118,8 @@ export class ScionPageOnboarding extends LitElement {
 
     const finishPull = () => {
       this.imagePulling = false;
+      this.pullIndex = 0;
+      this.pullTotal = 0;
       this.cleanupImageEvents();
       void this.recheckAllImageStatuses();
     };
@@ -1115,6 +1142,11 @@ export class ScionPageOnboarding extends LitElement {
         if (d['image']) {
           const fullImageName = d['image'] as string;
           const status = d['status'] as string;
+
+          if (typeof d['index'] === 'number' && typeof d['total'] === 'number') {
+            this.pullIndex = d['index'] as number;
+            this.pullTotal = d['total'] as number;
+          }
 
           if (status === 'done' || status === 'exists' || status === 'error') {
             completedImages.add(fullImageName);


### PR DESCRIPTION
## Summary

The onboarding wizard image pull step previously showed per-image status badges (queued/pulling/done) but gave no indication of overall progress — no count of how many images remained or how far along the pull was.

## Changes

**`pkg/runtime/imagepull.go`**: Added `Index` (1-based) and `Total` fields to `PullResult` so callers know where each image sits in the pull queue.

**`web/src/components/pages/onboarding.ts`**: During an active pull, renders a `<sl-progress-bar>` and a "Pulling image X of N..." summary line above the per-image status list. Counters reset when the pull completes.

## Testing

- Start the onboarding wizard on a fresh install
- Proceed to the image pull step
- Observe "Pulling image 1 of 7...", "Pulling image 2 of 7...", etc. with a progress bar
