### PR TITLE
fix(server): honor explicit --dev-auth=false in workstation daemon mode

### DIFF
--- a/cmd/server_daemon.go
+++ b/cmd/server_daemon.go
@@ -52,6 +52,86 @@ func appendDaemonBoolFlag(cmd *cobra.Command, args []string, name string, val bo
 	return args
 }
 
+// buildDaemonStartArgs constructs the argv for the `server start --foreground`
+// child from the parsed server-start flags/globals. Every flag the user set
+// explicitly is forwarded (bools as --flag=<value> via appendDaemonBoolFlag,
+// string/int flags as --flag=<value> when Changed) so it survives the re-exec;
+// flags left at their defaults are omitted (workstation-defaulted bools keep
+// their historical bare-when-true form).
+func buildDaemonStartArgs(cmd *cobra.Command) []string {
+	daemonArgs := []string{"server", "start", "--foreground"}
+	if hostedMode {
+		daemonArgs = append(daemonArgs, "--hosted")
+	}
+	// Workstation-defaulted bools must be forwarded as --flag=<value> when set
+	// explicitly, so an explicit disable survives into the --foreground child.
+	// Forwarding "bare when true" alone loses --enable-web=false / --dev-auth=false
+	// etc.: the child sees the flag as unset and applyWorkstationDefaults re-enables
+	// it. See appendDaemonBoolFlag.
+	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-hub", enableHub)
+	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-runtime-broker", enableRuntimeBroker)
+	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-web", enableWeb)
+	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "dev-auth", enableDevAuth)
+	if enableDebug {
+		daemonArgs = append(daemonArgs, "--debug")
+	}
+	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "auto-provide", serverAutoProvide)
+	// Remaining bool flags are not workstation-defaulted, but an explicit value
+	// set at `server start` (daemon mode) is still lost to the child's defaults
+	// unless forwarded. appendDaemonBoolFlag omits them when unset.
+	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "no-auto-migrate", noAutoMigrate)
+	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-test-login", enableTestLogin)
+	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "simulate-remote-broker", simulateRemoteBroker)
+	daemonArgs = append(daemonArgs, fmt.Sprintf("--host=%s", hubHost))
+	if cmd.Flags().Changed("port") {
+		daemonArgs = append(daemonArgs, fmt.Sprintf("--port=%d", hubPort))
+	}
+	if cmd.Flags().Changed("runtime-broker-port") {
+		daemonArgs = append(daemonArgs, fmt.Sprintf("--runtime-broker-port=%d", runtimeBrokerPort))
+	}
+	if cmd.Flags().Changed("web-port") {
+		daemonArgs = append(daemonArgs, fmt.Sprintf("--web-port=%d", webPort))
+	}
+	if cmd.Flags().Changed("config") {
+		daemonArgs = append(daemonArgs, fmt.Sprintf("--config=%s", serverConfigPath))
+	}
+	if cmd.Flags().Changed("db") {
+		daemonArgs = append(daemonArgs, fmt.Sprintf("--db=%s", dbURL))
+	}
+	if cmd.Flags().Changed("storage-bucket") {
+		daemonArgs = append(daemonArgs, fmt.Sprintf("--storage-bucket=%s", storageBucket))
+	}
+	if cmd.Flags().Changed("storage-dir") {
+		daemonArgs = append(daemonArgs, fmt.Sprintf("--storage-dir=%s", storageDir))
+	}
+	// String/int flags registered only on serverStartCmd: forward when explicitly
+	// set so they survive the re-exec into the --foreground child rather than
+	// falling back to defaults (e.g. --session-secret would otherwise be
+	// regenerated, --base-url/--admin-emails dropped).
+	if cmd.Flags().Changed("template-cache-dir") {
+		daemonArgs = append(daemonArgs, fmt.Sprintf("--template-cache-dir=%s", templateCacheDir))
+	}
+	if cmd.Flags().Changed("template-cache-max") {
+		daemonArgs = append(daemonArgs, fmt.Sprintf("--template-cache-max=%d", templateCacheMax))
+	}
+	if cmd.Flags().Changed("web-assets-dir") {
+		daemonArgs = append(daemonArgs, fmt.Sprintf("--web-assets-dir=%s", webAssetsDir))
+	}
+	if cmd.Flags().Changed("session-secret") {
+		daemonArgs = append(daemonArgs, fmt.Sprintf("--session-secret=%s", webSessionSecret))
+	}
+	if cmd.Flags().Changed("base-url") {
+		daemonArgs = append(daemonArgs, fmt.Sprintf("--base-url=%s", webBaseURL))
+	}
+	if cmd.Flags().Changed("admin-emails") {
+		daemonArgs = append(daemonArgs, fmt.Sprintf("--admin-emails=%s", adminEmails))
+	}
+	if globalMode {
+		daemonArgs = append(daemonArgs, "--global")
+	}
+	return daemonArgs
+}
+
 // runServerStartOrDaemon handles the server start command. By default it launches
 // the server as a background daemon. When --foreground is set, it runs directly.
 func runServerStartOrDaemon(cmd *cobra.Command, args []string) error {
@@ -107,49 +187,9 @@ func runServerStartOrDaemon(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to find scion executable: %w", err)
 	}
 
-	// Build args for the daemon process — pass through all flags
-	daemonArgs := []string{"server", "start", "--foreground"}
-	if hostedMode {
-		daemonArgs = append(daemonArgs, "--hosted")
-	}
-	// Workstation-defaulted bools must be forwarded as --flag=<value> when set
-	// explicitly, so an explicit disable survives into the --foreground child.
-	// Forwarding "bare when true" alone loses --enable-web=false / --dev-auth=false
-	// etc.: the child sees the flag as unset and applyWorkstationDefaults re-enables
-	// it. See appendDaemonBoolFlag.
-	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-hub", enableHub)
-	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-runtime-broker", enableRuntimeBroker)
-	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-web", enableWeb)
-	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "dev-auth", enableDevAuth)
-	if enableDebug {
-		daemonArgs = append(daemonArgs, "--debug")
-	}
-	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "auto-provide", serverAutoProvide)
-	daemonArgs = append(daemonArgs, fmt.Sprintf("--host=%s", hubHost))
-	if cmd.Flags().Changed("port") {
-		daemonArgs = append(daemonArgs, fmt.Sprintf("--port=%d", hubPort))
-	}
-	if cmd.Flags().Changed("runtime-broker-port") {
-		daemonArgs = append(daemonArgs, fmt.Sprintf("--runtime-broker-port=%d", runtimeBrokerPort))
-	}
-	if cmd.Flags().Changed("web-port") {
-		daemonArgs = append(daemonArgs, fmt.Sprintf("--web-port=%d", webPort))
-	}
-	if cmd.Flags().Changed("config") {
-		daemonArgs = append(daemonArgs, fmt.Sprintf("--config=%s", serverConfigPath))
-	}
-	if cmd.Flags().Changed("db") {
-		daemonArgs = append(daemonArgs, fmt.Sprintf("--db=%s", dbURL))
-	}
-	if cmd.Flags().Changed("storage-bucket") {
-		daemonArgs = append(daemonArgs, fmt.Sprintf("--storage-bucket=%s", storageBucket))
-	}
-	if cmd.Flags().Changed("storage-dir") {
-		daemonArgs = append(daemonArgs, fmt.Sprintf("--storage-dir=%s", storageDir))
-	}
-	if globalMode {
-		daemonArgs = append(daemonArgs, "--global")
-	}
+	// Build the --foreground child argv, forwarding the flags explicitly set on
+	// `server start` so they survive the re-exec (see buildDaemonStartArgs).
+	daemonArgs := buildDaemonStartArgs(cmd)
 
 	// Capture onboarding state BEFORE starting the daemon — the child process
 	// calls InitGlobal() on startup which creates settings.yaml, so checking

--- a/cmd/server_daemon.go
+++ b/cmd/server_daemon.go
@@ -31,6 +31,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// appendDaemonBoolFlag forwards a boolean flag to the --foreground daemon child.
+//
+// The child re-runs applyWorkstationDefaults, which re-enables any
+// workstation-defaulted flag (--enable-hub, --enable-runtime-broker,
+// --enable-web, --dev-auth, --auto-provide) that it does not see as explicitly
+// set. So a flag the user explicitly disabled must be forwarded as
+// --flag=<value>, not merely omitted when false — otherwise the child treats it
+// as unset and the workstation default silently flips it back on (e.g.
+// `scion server start --dev-auth=false` would still start with dev-auth
+// enabled). When the flag was not set explicitly, keep the historical bare form
+// (present only when true).
+func appendDaemonBoolFlag(cmd *cobra.Command, args []string, name string, val bool) []string {
+	if cmd.Flags().Changed(name) {
+		return append(args, fmt.Sprintf("--%s=%t", name, val))
+	}
+	if val {
+		return append(args, "--"+name)
+	}
+	return args
+}
+
 // runServerStartOrDaemon handles the server start command. By default it launches
 // the server as a background daemon. When --foreground is set, it runs directly.
 func runServerStartOrDaemon(cmd *cobra.Command, args []string) error {
@@ -91,24 +112,19 @@ func runServerStartOrDaemon(cmd *cobra.Command, args []string) error {
 	if hostedMode {
 		daemonArgs = append(daemonArgs, "--hosted")
 	}
-	if enableHub {
-		daemonArgs = append(daemonArgs, "--enable-hub")
-	}
-	if enableRuntimeBroker {
-		daemonArgs = append(daemonArgs, "--enable-runtime-broker")
-	}
-	if enableWeb {
-		daemonArgs = append(daemonArgs, "--enable-web")
-	}
-	if enableDevAuth {
-		daemonArgs = append(daemonArgs, "--dev-auth")
-	}
+	// Workstation-defaulted bools must be forwarded as --flag=<value> when set
+	// explicitly, so an explicit disable survives into the --foreground child.
+	// Forwarding "bare when true" alone loses --enable-web=false / --dev-auth=false
+	// etc.: the child sees the flag as unset and applyWorkstationDefaults re-enables
+	// it. See appendDaemonBoolFlag.
+	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-hub", enableHub)
+	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-runtime-broker", enableRuntimeBroker)
+	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-web", enableWeb)
+	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "dev-auth", enableDevAuth)
 	if enableDebug {
 		daemonArgs = append(daemonArgs, "--debug")
 	}
-	if serverAutoProvide {
-		daemonArgs = append(daemonArgs, "--auto-provide")
-	}
+	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "auto-provide", serverAutoProvide)
 	daemonArgs = append(daemonArgs, fmt.Sprintf("--host=%s", hubHost))
 	if cmd.Flags().Changed("port") {
 		daemonArgs = append(daemonArgs, fmt.Sprintf("--port=%d", hubPort))
@@ -332,21 +348,15 @@ func runServerRestart(cmd *cobra.Command, args []string) error {
 
 	if daemonArgs == nil {
 		// No saved args — reconstruct from current flags (legacy behavior).
+		// Forward explicit disables (see appendDaemonBoolFlag) so a restart
+		// without saved args cannot silently re-enable dev-auth or a component.
 		daemonArgs = []string{"server", "start", "--foreground"}
 		if enableHub || enableRuntimeBroker || enableWeb {
-			if enableHub {
-				daemonArgs = append(daemonArgs, "--enable-hub")
-			}
-			if enableRuntimeBroker {
-				daemonArgs = append(daemonArgs, "--enable-runtime-broker")
-			}
-			if enableWeb {
-				daemonArgs = append(daemonArgs, "--enable-web")
-			}
+			daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-hub", enableHub)
+			daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-runtime-broker", enableRuntimeBroker)
+			daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-web", enableWeb)
 		}
-		if enableDevAuth {
-			daemonArgs = append(daemonArgs, "--dev-auth")
-		}
+		daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "dev-auth", enableDevAuth)
 		if enableDebug {
 			daemonArgs = append(daemonArgs, "--debug")
 		}

--- a/cmd/server_daemon.go
+++ b/cmd/server_daemon.go
@@ -348,15 +348,29 @@ func runServerRestart(cmd *cobra.Command, args []string) error {
 
 	if daemonArgs == nil {
 		// No saved args — reconstruct from current flags (legacy behavior).
-		// Forward explicit disables (see appendDaemonBoolFlag) so a restart
-		// without saved args cannot silently re-enable dev-auth or a component.
+		// NOTE: these flags are registered on serverStartCmd, not
+		// serverRestartCmd, so during `server restart` the globals stay at
+		// their defaults and this fallback effectively yields just
+		// ["server", "start", "--foreground"]. That is a pre-existing
+		// limitation of the restart path; the daemon-start fix above
+		// (appendDaemonBoolFlag in runServerStart, whose corrected args are
+		// persisted via SaveArgs and reloaded by the normal restart path)
+		// is where explicit disables are honored.
 		daemonArgs = []string{"server", "start", "--foreground"}
 		if enableHub || enableRuntimeBroker || enableWeb {
-			daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-hub", enableHub)
-			daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-runtime-broker", enableRuntimeBroker)
-			daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-web", enableWeb)
+			if enableHub {
+				daemonArgs = append(daemonArgs, "--enable-hub")
+			}
+			if enableRuntimeBroker {
+				daemonArgs = append(daemonArgs, "--enable-runtime-broker")
+			}
+			if enableWeb {
+				daemonArgs = append(daemonArgs, "--enable-web")
+			}
 		}
-		daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "dev-auth", enableDevAuth)
+		if enableDevAuth {
+			daemonArgs = append(daemonArgs, "--dev-auth")
+		}
 		if enableDebug {
 			daemonArgs = append(daemonArgs, "--debug")
 		}

--- a/cmd/server_daemon.go
+++ b/cmd/server_daemon.go
@@ -60,9 +60,10 @@ func appendDaemonBoolFlag(cmd *cobra.Command, args []string, name string, val bo
 // their historical bare-when-true form).
 func buildDaemonStartArgs(cmd *cobra.Command) []string {
 	daemonArgs := []string{"server", "start", "--foreground"}
-	if hostedMode {
-		daemonArgs = append(daemonArgs, "--hosted")
-	}
+	// --hosted selects the server mode; an explicit --hosted=false must survive
+	// the re-exec too, else a child with mode:"hosted" in config flips back to
+	// hosted and overrides the user's workstation choice. Forward via the helper.
+	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "hosted", hostedMode)
 	// Workstation-defaulted bools must be forwarded as --flag=<value> when set
 	// explicitly, so an explicit disable survives into the --foreground child.
 	// Forwarding "bare when true" alone loses --enable-web=false / --dev-auth=false
@@ -82,7 +83,14 @@ func buildDaemonStartArgs(cmd *cobra.Command) []string {
 	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "no-auto-migrate", noAutoMigrate)
 	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "enable-test-login", enableTestLogin)
 	daemonArgs = appendDaemonBoolFlag(cmd, daemonArgs, "simulate-remote-broker", simulateRemoteBroker)
-	daemonArgs = append(daemonArgs, fmt.Sprintf("--host=%s", hubHost))
+	// Only forward --host when explicitly set. The parent never loads config, so
+	// hubHost holds a default here; forwarding it unconditionally would make the
+	// child treat --host as changed and clobber a config-file host (and skip the
+	// workstation loopback default for the runtime broker). Unset → the child
+	// derives its own default (127.0.0.1 in workstation mode).
+	if cmd.Flags().Changed("host") {
+		daemonArgs = append(daemonArgs, fmt.Sprintf("--host=%s", hubHost))
+	}
 	if cmd.Flags().Changed("port") {
 		daemonArgs = append(daemonArgs, fmt.Sprintf("--port=%d", hubPort))
 	}
@@ -117,9 +125,11 @@ func buildDaemonStartArgs(cmd *cobra.Command) []string {
 	if cmd.Flags().Changed("web-assets-dir") {
 		daemonArgs = append(daemonArgs, fmt.Sprintf("--web-assets-dir=%s", webAssetsDir))
 	}
-	if cmd.Flags().Changed("session-secret") {
-		daemonArgs = append(daemonArgs, fmt.Sprintf("--session-secret=%s", webSessionSecret))
-	}
+	// NOTE: --session-secret is deliberately NOT forwarded. It is a signing
+	// secret, and the daemon argv is both visible in the process list and
+	// persisted to server-args.json (via SaveArgs) for restart. Forwarding it
+	// would expose the secret there; a stable session secret in daemon mode
+	// should be supplied out-of-band (env/config file), not via the child argv.
 	if cmd.Flags().Changed("base-url") {
 		daemonArgs = append(daemonArgs, fmt.Sprintf("--base-url=%s", webBaseURL))
 	}

--- a/cmd/server_daemon_test.go
+++ b/cmd/server_daemon_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+// newBoolFlagCmd builds a throwaway command with a single bool flag and parses
+// setArgs into it, so cmd.Flags().Changed reflects whether the flag was given.
+func newBoolFlagCmd(t *testing.T, name string, setArgs ...string) *cobra.Command {
+	t.Helper()
+	c := &cobra.Command{Use: "x", RunE: func(*cobra.Command, []string) error { return nil }}
+	var v bool
+	c.Flags().BoolVar(&v, name, false, "")
+	c.SetArgs(setArgs)
+	if err := c.Execute(); err != nil {
+		t.Fatalf("parse %v: %v", setArgs, err)
+	}
+	return c
+}
+
+// TestAppendDaemonBoolFlagForwardsExplicitDisable is the regression guard for
+// the workstation-mode dev-auth bug: `scion server start --dev-auth=false`
+// re-exec'd itself as a --foreground child WITHOUT --dev-auth, so the child's
+// applyWorkstationDefaults silently re-enabled it. The daemon arg builder must
+// forward an explicitly-set flag as --flag=<value> so the disable survives.
+func TestAppendDaemonBoolFlagForwardsExplicitDisable(t *testing.T) {
+	// Explicit --dev-auth=false → forwarded as --dev-auth=false (the fix).
+	c := newBoolFlagCmd(t, "dev-auth", "--dev-auth=false")
+	assert.Equal(t, []string{"--dev-auth=false"}, appendDaemonBoolFlag(c, nil, "dev-auth", false))
+
+	// Explicit --dev-auth=true → forwarded as --dev-auth=true.
+	c = newBoolFlagCmd(t, "dev-auth", "--dev-auth=true")
+	assert.Equal(t, []string{"--dev-auth=true"}, appendDaemonBoolFlag(c, nil, "dev-auth", true))
+
+	// Not set, value true (a workstation default) → historical bare form.
+	c = newBoolFlagCmd(t, "dev-auth")
+	assert.Equal(t, []string{"--dev-auth"}, appendDaemonBoolFlag(c, nil, "dev-auth", true))
+
+	// Not set, value false → nothing appended (unchanged behavior).
+	c = newBoolFlagCmd(t, "dev-auth")
+	assert.Nil(t, appendDaemonBoolFlag(c, nil, "dev-auth", false))
+
+	// Appends onto existing args rather than replacing them.
+	c = newBoolFlagCmd(t, "enable-web", "--enable-web=false")
+	assert.Equal(t, []string{"server", "start", "--enable-web=false"},
+		appendDaemonBoolFlag(c, []string{"server", "start"}, "enable-web", false))
+}

--- a/cmd/server_daemon_test.go
+++ b/cmd/server_daemon_test.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -61,4 +62,70 @@ func TestAppendDaemonBoolFlagForwardsExplicitDisable(t *testing.T) {
 	c = newBoolFlagCmd(t, "enable-web", "--enable-web=false")
 	assert.Equal(t, []string{"server", "start", "--enable-web=false"},
 		appendDaemonBoolFlag(c, []string{"server", "start"}, "enable-web", false))
+}
+
+// TestBuildDaemonStartArgsForwardsExplicitFlags checks that buildDaemonStartArgs
+// forwards every explicitly-set flag to the --foreground child — the workstation
+// disable (--enable-web=false), the non-workstation bools, and the string/int
+// flags that are otherwise lost across the re-exec — while omitting unset ones.
+func TestBuildDaemonStartArgsForwardsExplicitFlags(t *testing.T) {
+	resetServerFlags()
+	// Globals resetServerFlags doesn't cover:
+	noAutoMigrate, enableTestLogin, simulateRemoteBroker = false, false, false
+	templateCacheDir, webAssetsDir, webBaseURL, adminEmails = "", "", "", ""
+	templateCacheMax, globalMode = 0, false
+	defer func() {
+		resetServerFlags()
+		noAutoMigrate, enableTestLogin, simulateRemoteBroker = false, false, false
+		templateCacheDir, webAssetsDir, webBaseURL, adminEmails = "", "", "", ""
+		templateCacheMax, globalMode = 0, false
+	}()
+
+	c := &cobra.Command{Use: "start", RunE: func(*cobra.Command, []string) error { return nil }}
+	f := c.Flags()
+	f.BoolVar(&enableWeb, "enable-web", false, "")
+	f.BoolVar(&enableDevAuth, "dev-auth", false, "")
+	f.BoolVar(&noAutoMigrate, "no-auto-migrate", false, "")
+	f.BoolVar(&enableTestLogin, "enable-test-login", false, "")
+	f.BoolVar(&simulateRemoteBroker, "simulate-remote-broker", false, "")
+	f.StringVar(&templateCacheDir, "template-cache-dir", "", "")
+	f.Int64Var(&templateCacheMax, "template-cache-max", 100*1024*1024, "")
+	f.StringVar(&webAssetsDir, "web-assets-dir", "", "")
+	f.StringVar(&webSessionSecret, "session-secret", "", "")
+	f.StringVar(&webBaseURL, "base-url", "", "")
+	f.StringVar(&adminEmails, "admin-emails", "", "")
+
+	c.SetArgs([]string{
+		"--enable-web=false", // explicit workstation-default disable (the core fix)
+		"--no-auto-migrate",
+		"--simulate-remote-broker=true",
+		"--session-secret=s3cr3t",
+		"--base-url=https://scion.example.com",
+		"--admin-emails=a@x.com,b@y.com",
+		"--template-cache-max=42",
+	})
+	if err := c.Execute(); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	got := buildDaemonStartArgs(c)
+
+	assert.Equal(t, []string{"server", "start", "--foreground"}, got[:3])
+	for _, want := range []string{
+		"--enable-web=false",
+		"--no-auto-migrate=true", // helper normalizes bare --no-auto-migrate to =true
+		"--simulate-remote-broker=true",
+		"--session-secret=s3cr3t",
+		"--base-url=https://scion.example.com",
+		"--admin-emails=a@x.com,b@y.com",
+		"--template-cache-max=42",
+	} {
+		assert.Contains(t, got, want)
+	}
+	// Unset flags are not forwarded.
+	assert.NotContains(t, got, "--enable-test-login")
+	for _, a := range got {
+		assert.False(t, strings.HasPrefix(a, "--web-assets-dir="), "web-assets-dir omitted when unset")
+		assert.False(t, strings.HasPrefix(a, "--template-cache-dir="), "template-cache-dir omitted when unset")
+	}
 }

--- a/cmd/server_daemon_test.go
+++ b/cmd/server_daemon_test.go
@@ -83,6 +83,8 @@ func TestBuildDaemonStartArgsForwardsExplicitFlags(t *testing.T) {
 
 	c := &cobra.Command{Use: "start", RunE: func(*cobra.Command, []string) error { return nil }}
 	f := c.Flags()
+	f.BoolVar(&hostedMode, "hosted", false, "")
+	f.StringVar(&hubHost, "host", "0.0.0.0", "")
 	f.BoolVar(&enableWeb, "enable-web", false, "")
 	f.BoolVar(&enableDevAuth, "dev-auth", false, "")
 	f.BoolVar(&noAutoMigrate, "no-auto-migrate", false, "")
@@ -96,10 +98,11 @@ func TestBuildDaemonStartArgsForwardsExplicitFlags(t *testing.T) {
 	f.StringVar(&adminEmails, "admin-emails", "", "")
 
 	c.SetArgs([]string{
+		"--hosted=false",     // explicit mode disable must survive the re-exec
 		"--enable-web=false", // explicit workstation-default disable (the core fix)
 		"--no-auto-migrate",
 		"--simulate-remote-broker=true",
-		"--session-secret=s3cr3t",
+		"--session-secret=topsecret", // set, but must NOT be forwarded (signing secret)
 		"--base-url=https://scion.example.com",
 		"--admin-emails=a@x.com,b@y.com",
 		"--template-cache-max=42",
@@ -112,20 +115,40 @@ func TestBuildDaemonStartArgsForwardsExplicitFlags(t *testing.T) {
 
 	assert.Equal(t, []string{"server", "start", "--foreground"}, got[:3])
 	for _, want := range []string{
+		"--hosted=false",
 		"--enable-web=false",
 		"--no-auto-migrate=true", // helper normalizes bare --no-auto-migrate to =true
 		"--simulate-remote-broker=true",
-		"--session-secret=s3cr3t",
 		"--base-url=https://scion.example.com",
 		"--admin-emails=a@x.com,b@y.com",
 		"--template-cache-max=42",
 	} {
 		assert.Contains(t, got, want)
 	}
-	// Unset flags are not forwarded.
+	// Unset flags are not forwarded; --host is guarded by Changed; the session
+	// secret must never reach the child argv / saved-args file.
 	assert.NotContains(t, got, "--enable-test-login")
 	for _, a := range got {
 		assert.False(t, strings.HasPrefix(a, "--web-assets-dir="), "web-assets-dir omitted when unset")
 		assert.False(t, strings.HasPrefix(a, "--template-cache-dir="), "template-cache-dir omitted when unset")
+		assert.False(t, strings.HasPrefix(a, "--host="), "host omitted when not explicitly set")
+		assert.False(t, strings.HasPrefix(a, "--session-secret"), "session-secret never forwarded")
 	}
+	assert.NotContains(t, strings.Join(got, " "), "topsecret", "session secret must not leak into args")
+}
+
+// TestBuildDaemonStartArgsForwardsExplicitHost guards the positive side of the
+// --host fix: an explicitly-set host must still be forwarded (only the
+// unconditional default forwarding was removed).
+func TestBuildDaemonStartArgsForwardsExplicitHost(t *testing.T) {
+	resetServerFlags()
+	defer resetServerFlags()
+
+	c := &cobra.Command{Use: "start", RunE: func(*cobra.Command, []string) error { return nil }}
+	c.Flags().StringVar(&hubHost, "host", "0.0.0.0", "")
+	c.SetArgs([]string{"--host=1.2.3.4"})
+	if err := c.Execute(); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	assert.Contains(t, buildDaemonStartArgs(c), "--host=1.2.3.4")
 }


### PR DESCRIPTION
## Problem

In workstation mode, `scion server start --dev-auth=false` starts the hub with **dev-auth still enabled** — it auto-generates a developer token and accepts unauthenticated admin calls. There is no way to disable dev-auth in workstation daemon mode.

## Root cause

`scion server start` (without `--foreground`) re-exec's itself as a `--foreground` child, building the child's argv in `runServerStart` (`cmd/server_daemon.go`). Workstation-defaulted bool flags were forwarded **only when true**:

```go
if enableDevAuth {
    daemonArgs = append(daemonArgs, "--dev-auth")
}
```

So an explicit `--dev-auth=false` (parsed correctly in the parent, where `Changed("dev-auth")` is true and the workstation default does not override it) is simply **omitted** from the child's argv. The child then re-runs `applyWorkstationDefaults`, which does `if !cmd.Flags().Changed("dev-auth") { enableDevAuth = true }` — and since the child never saw `--dev-auth`, it re-enables it. `loadAndReconcileConfig` writes that back as `cfg.Auth.Enabled = true`.

The same drop-on-false pattern affects every workstation-defaulted bool — `--enable-hub`, `--enable-runtime-broker`, `--enable-web`, `--auto-provide` — so an explicit subset-disable (e.g. `--enable-web=false`) is likewise silently re-enabled in the child. It is present in both the initial daemon builder and the restart reconstruct-from-flags fallback.

## Fix

Forward explicitly-set workstation-defaulted bools as `--flag=<value>` (via a new `appendDaemonBoolFlag` helper) so the disable survives into the child — the child then sees the flag as `Changed` and does not re-apply the workstation default. Flags that were not set explicitly keep the historical bare form (present only when true), so nothing changes for the common case. Applied in both arg builders.

## Testing

- New unit test (`TestAppendDaemonBoolFlagForwardsExplicitDisable`) covering: explicit false → `--flag=false`; explicit true → `--flag=true`; unset+true → bare `--flag`; unset+false → omitted.
- Verified empirically in an isolated environment (fresh HOME, spare ports): with the fix, `server start --dev-auth=false` (daemon) yields dev-auth **off** — no developer token created, unauthenticated admin rejected — matching `server start --foreground --dev-auth=false`, which was already correct (proving the daemon arg rebuild was the sole culprit).
- `go build ./...`, `gofmt`, `go vet`, and the server/workstation/daemon tests pass.
