### PR TITLE
hub: drop GCS-absent files from manifest in syncResourceFromStorage

### DIFF
--- a/pkg/hub/harness_config_repair.go
+++ b/pkg/hub/harness_config_repair.go
@@ -59,11 +59,11 @@ func (s *Server) syncResourceFromStorage(
 	}
 
 	label := string(kind)
-	updated := make([]store.TemplateFile, len(files))
-	copy(updated, files)
+	updated := make([]store.TemplateFile, 0, len(files))
 
-	for i, file := range updated {
+	for _, file := range files {
 		if file.Hash == "" {
+			updated = append(updated, file)
 			continue
 		}
 		objectPath := storagePath + "/" + file.Path
@@ -71,8 +71,9 @@ func (s *Server) syncResourceFromStorage(
 		obj, getErr := stor.GetObject(ctx, objectPath)
 		if getErr != nil {
 			if errors.Is(getErr, storage.ErrNotFound) {
-				s.resourceLog.Warn(label+" repair: object not found",
+				s.resourceLog.Warn(label+" repair: dropping file missing from storage",
 					"resource", name, "file", file.Path)
+				changed = true
 				continue
 			}
 			return nil, "", false, fmt.Errorf("get object %q: %w", objectPath, getErr)
@@ -87,13 +88,15 @@ func (s *Server) syncResourceFromStorage(
 			}
 		}
 
+		entry := file
 		if actualHash != file.Hash {
 			s.resourceLog.Warn(label+" repair: updating stale file hash",
 				"resource", name, "file", file.Path,
 				"dbHash", file.Hash, "storageHash", actualHash)
-			updated[i].Hash = actualHash
+			entry.Hash = actualHash
 			changed = true
 		}
+		updated = append(updated, entry)
 	}
 
 	if !changed {

--- a/pkg/hub/imagecheck/checker.go
+++ b/pkg/hub/imagecheck/checker.go
@@ -111,10 +111,10 @@ func IsBareImageName(image string) bool {
 }
 
 type ImageEntityStatus struct {
-	Exists        bool   `json:"exists"`
-	Image         string `json:"image,omitempty"`
-	Hash          string `json:"hash,omitempty"`
-	NewerThanLocal bool  `json:"newer_than_local,omitempty"`
+	Exists         bool   `json:"exists"`
+	Image          string `json:"image,omitempty"`
+	Hash           string `json:"hash,omitempty"`
+	NewerThanLocal bool   `json:"newer_than_local,omitempty"`
 }
 
 type ThreeWayImageResult struct {


### PR DESCRIPTION
## Problem

PR #643 introduced `syncResourceFromStorage()` which reconciles DB manifests against GCS. When a file is not found in GCS (`ErrNotFound`), the code logged a warning and continued — but still included the stale file entry in the output manifest. This meant harness-config manifests retained references to files that GCS no longer had, causing broker 404 errors during agent dispatch.

Affected on scion-gteam after latest update: codex, opencode, copilot, hermes — all had Dockerfile, README.md, cloudbuild.yaml (and others) in their DB manifests but not in GCS.

## Fix

Switch `syncResourceFromStorage()` from copy-then-mutate to build-as-you-go:
- Only files successfully fetched from GCS are appended to the output manifest
- `ErrNotFound` files are dropped with a warning log and trigger `changed=true` so the DB update fires
- No-change files (matching hash) are still included correctly

One file, +8/-5 lines in `pkg/hub/harness_config_repair.go`