### PR TITLE
config: add thinking_budget fields to harness config schema

### DIFF
--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -351,6 +351,19 @@
           "$ref": "#/$defs/harnessNoAuthConfig",
           "description": "Behavior when an agent starts without credentials (NoAuth mode)."
         },
+        "thinking_budget_map": {
+          "type": "object",
+          "additionalProperties": { "type": "integer" },
+          "description": "Maps model identifiers to their thinking-budget token limits."
+        },
+        "thinking_budget_flag": {
+          "type": "string",
+          "description": "CLI flag name used to pass the thinking budget to the harness (e.g., '--thinking-budget')."
+        },
+        "thinking_budget_config_key": {
+          "type": "string",
+          "description": "Harness-native config key used to set the thinking budget in a config file."
+        },
         "dialect": {
           "type": "object",
           "description": "Optional hook dialect metadata.",


### PR DESCRIPTION
## Problem

Codex (and potentially other harnesses) config.yaml files include thinking_budget_map, thinking_budget_flag, and thinking_budget_config_key fields. The settings-v1.schema.json uses additionalProperties: false, so any harness config.yaml with unrecognized fields fails validation on hub startup, preventing agent dispatch.

## Fix

Add the three missing property definitions to the harnessConfig section of settings-v1.schema.json:
- thinking_budget_map: object (map of model name → budget values)  
- thinking_budget_flag: string
- thinking_budget_config_key: string