### PR TITLE
agent: thinking level field + model choice UX refactor

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -444,6 +444,7 @@ type ScionConfig struct {
 	CommandArgs      []string          `json:"command_args,omitempty" yaml:"command_args,omitempty"`
 	TaskFlag         string            `json:"task_flag,omitempty" yaml:"task_flag,omitempty"`
 	Model            string            `json:"model,omitempty" yaml:"model,omitempty"`
+	ThinkingLevel    *int              `json:"thinking_level,omitempty" yaml:"thinking_level,omitempty"`
 	Kubernetes       *KubernetesConfig `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
 	AuthSelectedType string            `json:"auth_selectedType,omitempty" yaml:"auth_selectedType,omitempty"`
 	Resources        *ResourceSpec     `json:"resources,omitempty" yaml:"resources,omitempty"`

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -95,6 +95,7 @@ func (s *Server) buildAppliedConfig(req CreateAgentRequest, harnessConfig string
 		ac.Image = req.Config.Image
 		ac.Env = req.Config.Env
 		ac.Model = req.Config.Model
+		ac.ThinkingLevel = req.Config.ThinkingLevel
 
 		// Extract ScionConfig-specific fields
 		if req.Config.HarnessConfig != "" {

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -1516,6 +1516,9 @@ func (s *Server) updateAgent(w http.ResponseWriter, r *http.Request, id string) 
 		if cfg.Model != "" {
 			agent.AppliedConfig.Model = cfg.Model
 		}
+		if cfg.ThinkingLevel != nil {
+			agent.AppliedConfig.ThinkingLevel = cfg.ThinkingLevel
+		}
 		if cfg.Task != "" {
 			agent.AppliedConfig.Task = cfg.Task
 		}

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -552,6 +552,13 @@ func (s *Server) createAgentInProject(
 		agent.Template = resolvedTemplate.Slug
 	}
 
+	if req.Config != nil && req.Config.ThinkingLevel != nil {
+		if tl := *req.Config.ThinkingLevel; tl < 0 || tl > 100 {
+			BadRequest(w, "thinking_level must be between 0 and 100")
+			return
+		}
+	}
+
 	agent.AppliedConfig = s.buildAppliedConfig(req, harnessConfig, creatorName)
 
 	// Populate GCP identity in applied config.
@@ -1517,8 +1524,13 @@ func (s *Server) updateAgent(w http.ResponseWriter, r *http.Request, id string) 
 			agent.AppliedConfig.Model = cfg.Model
 		}
 		if cfg.ThinkingLevel != nil {
-			agent.AppliedConfig.ThinkingLevel = cfg.ThinkingLevel
+			if tl := *cfg.ThinkingLevel; tl < 0 || tl > 100 {
+				BadRequest(w, "thinking_level must be between 0 and 100")
+				return
+			}
 		}
+		// Always apply thinking level from config (nil = explicit unset)
+		agent.AppliedConfig.ThinkingLevel = cfg.ThinkingLevel
 		if cfg.Task != "" {
 			agent.AppliedConfig.Task = cfg.Task
 		}

--- a/pkg/hub/project_settings_handlers.go
+++ b/pkg/hub/project_settings_handlers.go
@@ -28,6 +28,7 @@ const (
 	projectSettingDefaultTemplate      = "scion.io/default-template"
 	projectSettingDefaultHarnessConfig = "scion.io/default-harness-config"
 	projectSettingDefaultModel         = "scion.io/default-model"
+	projectSettingDefaultThinkingLevel = "scion.io/default-thinking-level"
 	projectSettingTelemetryEnabled     = "scion.io/telemetry-enabled"
 	projectSettingActiveProfile        = "scion.io/active-profile"
 
@@ -131,6 +132,11 @@ func projectSettingsFromAnnotations(project *store.Project) *hubclient.ProjectSe
 	settings.DefaultTemplate = project.Annotations[projectSettingDefaultTemplate]
 	settings.DefaultHarnessConfig = project.Annotations[projectSettingDefaultHarnessConfig]
 	settings.DefaultModel = project.Annotations[projectSettingDefaultModel]
+	if val, ok := project.Annotations[projectSettingDefaultThinkingLevel]; ok {
+		if n, err := strconv.Atoi(val); err == nil {
+			settings.DefaultThinkingLevel = &n
+		}
+	}
 	settings.ActiveProfile = project.Annotations[projectSettingActiveProfile]
 
 	if val, ok := project.Annotations[projectSettingTelemetryEnabled]; ok {
@@ -197,6 +203,11 @@ func applyProjectSettingsToAnnotations(project *store.Project, settings *hubclie
 	setOrDelete(project.Annotations, projectSettingDefaultTemplate, settings.DefaultTemplate)
 	setOrDelete(project.Annotations, projectSettingDefaultHarnessConfig, settings.DefaultHarnessConfig)
 	setOrDelete(project.Annotations, projectSettingDefaultModel, settings.DefaultModel)
+	if settings.DefaultThinkingLevel != nil {
+		project.Annotations[projectSettingDefaultThinkingLevel] = strconv.Itoa(*settings.DefaultThinkingLevel)
+	} else {
+		delete(project.Annotations, projectSettingDefaultThinkingLevel)
+	}
 	setOrDelete(project.Annotations, projectSettingActiveProfile, settings.ActiveProfile)
 
 	if settings.TelemetryEnabled != nil {
@@ -277,6 +288,11 @@ func applyProjectDefaults(ac *store.AgentAppliedConfig, project *store.Project) 
 	// Apply default model (only if not already set by agent/template/CLI)
 	if ac.Model == "" && settings.DefaultModel != "" {
 		ac.Model = settings.DefaultModel
+	}
+
+	// Apply default thinking level (only if not already set)
+	if ac.ThinkingLevel == nil && settings.DefaultThinkingLevel != nil {
+		ac.ThinkingLevel = settings.DefaultThinkingLevel
 	}
 
 	// Check if there are any project limit/resource defaults to apply

--- a/pkg/hub/project_settings_handlers.go
+++ b/pkg/hub/project_settings_handlers.go
@@ -107,6 +107,13 @@ func (s *Server) handleProjectSettings(w http.ResponseWriter, r *http.Request, p
 			return
 		}
 
+		if req.DefaultThinkingLevel != nil {
+			if tl := *req.DefaultThinkingLevel; tl < 0 || tl > 100 {
+				BadRequest(w, "thinking_level must be between 0 and 100")
+				return
+			}
+		}
+
 		applyProjectSettingsToAnnotations(project, &req)
 
 		if err := s.store.UpdateProject(ctx, project); err != nil {

--- a/pkg/hubclient/types.go
+++ b/pkg/hubclient/types.go
@@ -203,6 +203,7 @@ type ProjectSettings struct {
 	DefaultTemplate      string                 `json:"defaultTemplate,omitempty"`
 	DefaultHarnessConfig string                 `json:"defaultHarnessConfig,omitempty"`
 	DefaultModel         string                 `json:"defaultModel,omitempty"`
+	DefaultThinkingLevel *int                   `json:"defaultThinkingLevel,omitempty"`
 	TelemetryEnabled     *bool                  `json:"telemetryEnabled,omitempty"`
 	Bucket               *BucketConfig          `json:"bucket,omitempty"`
 	Runtimes             map[string]interface{} `json:"runtimes,omitempty"`

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -131,6 +131,7 @@ type AgentAppliedConfig struct {
 	HarnessAuth   string              `json:"harnessAuth,omitempty"` // Late-binding override for auth_selected_type
 	Env           map[string]string   `json:"env,omitempty"`
 	Model         string              `json:"model,omitempty"`
+	ThinkingLevel *int                `json:"thinkingLevel,omitempty"`
 	Profile       string              `json:"profile,omitempty"`   // Settings profile for the runtime broker
 	Task          string              `json:"task,omitempty"`      // Initial task/prompt for the agent
 	Attach        bool                `json:"attach,omitempty"`    // If true, signals interactive attach mode to the broker/harness

--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -68,6 +68,7 @@ import '@shoelace-style/shoelace/dist/components/menu-item/menu-item.js';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '@shoelace-style/shoelace/dist/components/radio-group/radio-group.js';
 import '@shoelace-style/shoelace/dist/components/radio-button/radio-button.js';
+import '@shoelace-style/shoelace/dist/components/range/range.js';
 import '@shoelace-style/shoelace/dist/components/switch/switch.js';
 import '@shoelace-style/shoelace/dist/components/tab-group/tab-group.js';
 import '@shoelace-style/shoelace/dist/components/tab/tab.js';

--- a/web/src/components/pages/agent-configure.ts
+++ b/web/src/components/pages/agent-configure.ts
@@ -487,7 +487,7 @@ export class ScionPageAgentConfigure extends LitElement {
       ? this.customModelId
       : this.modelSelection;
     if (model) config.model = model;
-    if (this.thinkingLevel !== null) config.thinking_level = this.thinkingLevel;
+    config.thinking_level = this.thinkingLevel;
     if (this.image) config.image = this.image;
     if (this.branch) config.branch = this.branch;
     if (this.containerUser) config.user = this.containerUser;

--- a/web/src/components/pages/agent-configure.ts
+++ b/web/src/components/pages/agent-configure.ts
@@ -48,6 +48,7 @@ interface ScionConfigPayload {
     limits?: { cpu?: string; memory?: string };
     disk?: string;
   };
+  thinking_level?: number | null;
   env?: Record<string, string>;
   telemetry?: { enabled?: boolean };
 }
@@ -55,6 +56,7 @@ interface ScionConfigPayload {
 interface AppliedConfig {
   image?: string;
   model?: string;
+  thinkingLevel?: number | null;
   harnessConfig?: string;
   harnessAuth?: string;
   task?: string;
@@ -83,6 +85,7 @@ export class ScionPageAgentConfigure extends LitElement {
   @state() private model = '';
   @state() private modelSelection: '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other' = '';
   @state() private customModelId = '';
+  @state() private thinkingLevel: number | null = null;
   @state() private image = '';
   @state() private branch = '';
   @state() private containerUser = '';
@@ -438,6 +441,7 @@ export class ScionPageAgentConfigure extends LitElement {
     const derived = this.deriveModelSelection(this.model);
     this.modelSelection = derived.selection;
     this.customModelId = derived.customId;
+    this.thinkingLevel = ac?.thinkingLevel ?? ic?.thinking_level ?? null;
     this.image = ac?.image || ic?.image || '';
     this.branch = ic?.branch || '';
     this.containerUser = ic?.user || '';
@@ -483,6 +487,7 @@ export class ScionPageAgentConfigure extends LitElement {
       ? this.customModelId
       : this.modelSelection;
     if (model) config.model = model;
+    if (this.thinkingLevel !== null) config.thinking_level = this.thinkingLevel;
     if (this.image) config.image = this.image;
     if (this.branch) config.branch = this.branch;
     if (this.containerUser) config.user = this.containerUser;
@@ -807,7 +812,7 @@ export class ScionPageAgentConfigure extends LitElement {
 
     return html`
       <div class="form-field">
-        <sl-select label="Model" .value=${this.modelSelection} clearable
+        <sl-select label="Model" placeholder="use harness default" .value=${this.modelSelection} clearable
             @sl-change=${(e: any) => { this.modelSelection = e.target.value; if (e.target.value !== 'other') this.customModelId = ''; }}>
           <sl-option value="small">Small</sl-option>
           <sl-option value="medium">Medium</sl-option>
@@ -823,6 +828,28 @@ export class ScionPageAgentConfigure extends LitElement {
             style="margin-top: 0.75rem">
           </sl-input>
         ` : ''}
+      </div>
+
+      <div class="form-field">
+        <label>Thinking Level${this.thinkingLevel !== null ? html` <span style="font-weight:normal;color:var(--sl-color-neutral-500)">(${this.thinkingLevel})</span>` : ''}</label>
+        <div style="display:flex;align-items:center;gap:0.75rem">
+          <sl-range
+            min="0" max="100" step="1"
+            .value=${this.thinkingLevel ?? 50}
+            ?disabled=${this.thinkingLevel === null}
+            style="flex:1"
+            @sl-input=${(e: any) => { this.thinkingLevel = e.target.value; }}
+          ></sl-range>
+          <sl-checkbox
+            ?checked=${this.thinkingLevel !== null}
+            @sl-change=${(e: any) => { this.thinkingLevel = e.target.checked ? 50 : null; }}
+          >Set</sl-checkbox>
+        </div>
+        <div class="hint" style="display:flex;justify-content:space-between;margin-top:0.25rem">
+          <span>0 = minimal reasoning</span>
+          <span>${this.thinkingLevel === null ? 'Using harness default' : ''}</span>
+          <span>100 = maximum reasoning</span>
+        </div>
       </div>
 
       <div class="form-field">

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -30,7 +30,6 @@ import type {
   Template,
   GCPServiceAccount,
 } from '../../shared/types.js';
-import { normalizeModelAlias } from '../../shared/model-utils.js';
 
 interface HarnessConfigEntry {
   id: string;
@@ -122,12 +121,6 @@ export class ScionPageAgentCreate extends LitElement {
   @state()
   private harnessConfigs: HarnessConfigEntry[] = [];
 
-  @state()
-  private modelSelection: '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other' = '';
-
-  @state()
-  private customModelId = '';
-
   /** ID of an existing agent we're editing (came back from configure page) */
   private editingAgentId: string | null = null;
 
@@ -145,7 +138,6 @@ export class ScionPageAgentCreate extends LitElement {
       defaultMaxDuration?: string;
       defaultGCPIdentityMode?: string;
       defaultGCPIdentityServiceAccountID?: string;
-      defaultModel?: string;
     }
   > = new Map();
 
@@ -550,13 +542,6 @@ export class ScionPageAgentCreate extends LitElement {
         },
       };
 
-      const model = this.modelSelection === 'other'
-        ? this.customModelId
-        : this.modelSelection;
-      if (model) {
-        config.model = model;
-      }
-
       body.config = config;
 
       // Validate GCP assign mode
@@ -670,14 +655,6 @@ export class ScionPageAgentCreate extends LitElement {
       const builtLabels = this.buildLabels();
       if (builtLabels) {
         body.labels = builtLabels;
-      }
-
-      // Model selection
-      const model = this.modelSelection === 'other'
-        ? this.customModelId
-        : this.modelSelection;
-      if (model) {
-        body.config = { ...(body.config as Record<string, unknown> || {}), model };
       }
 
       // GCP identity assignment
@@ -823,16 +800,6 @@ private selectBrokerForProject(): void {
       }
     }
 
-    // Pre-populate model from project defaults if user hasn't selected one
-    if (!this.modelSelection && settings?.defaultModel) {
-      const dm = normalizeModelAlias(settings.defaultModel);
-      if (['small', 'medium', 'large', 'extra-large'].includes(dm)) {
-        this.modelSelection = dm as 'small' | 'medium' | 'large' | 'extra-large';
-      } else if (dm) {
-        this.modelSelection = 'other';
-        this.customModelId = settings.defaultModel;
-      }
-    }
   }
 
   /**
@@ -1170,43 +1137,6 @@ private selectBrokerForProject(): void {
             </sl-select>
             <div class="hint">Agent configuration template.</div>
           </div>
-
-          <div class="form-field">
-            <label for="model">Model</label>
-            <sl-select
-              id="model"
-              placeholder="Select a model size..."
-              .value=${this.modelSelection}
-              clearable
-              @sl-change=${(e: Event) => {
-                this.modelSelection = (e.target as HTMLElement & { value: string }).value as
-                  | '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other';
-                if (this.modelSelection !== 'other') this.customModelId = '';
-              }}
-            >
-              <sl-option value="small">Small</sl-option>
-              <sl-option value="medium">Medium</sl-option>
-              <sl-option value="large">Large</sl-option>
-              <sl-option value="extra-large">Extra Large</sl-option>
-              <sl-option value="other">Other (specify)</sl-option>
-            </sl-select>
-            <div class="hint">Model size or specific model for this agent.</div>
-          </div>
-          ${this.modelSelection === 'other'
-            ? html`
-                <div class="form-field">
-                  <label for="model-id">Model ID</label>
-                  <sl-input
-                    id="model-id"
-                    placeholder="e.g. claude-opus-4-8"
-                    .value=${this.customModelId}
-                    @sl-input=${(e: Event) => {
-                      this.customModelId = (e.target as HTMLElement & { value: string }).value;
-                    }}
-                  ></sl-input>
-                </div>
-              `
-            : ''}
 
           <div class="form-field">
             <label for="harness">Harness Config</label>

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -58,6 +58,7 @@ interface ProjectSettings {
   defaultGCPIdentityMode?: string | undefined;
   defaultGCPIdentityServiceAccountID?: string | undefined;
   defaultModel?: string | undefined;
+  defaultThinkingLevel?: number | null | undefined;
 }
 
 interface HarnessConfigEntry {
@@ -176,6 +177,9 @@ export class ScionPageProjectSettings extends LitElement {
 
   @state()
   private defaultCustomModelId = '';
+
+  @state()
+  private defaultThinkingLevel: number | null = null;
 
   @state()
   private gcpServiceAccounts: GCPServiceAccount[] = [];
@@ -893,6 +897,7 @@ export class ScionPageProjectSettings extends LitElement {
         } else {
           this.defaultModelSelection = '';
         }
+        this.defaultThinkingLevel = this.settings.defaultThinkingLevel ?? null;
       }
     } catch (err) {
       console.error('Failed to load project settings:', err);
@@ -987,6 +992,7 @@ export class ScionPageProjectSettings extends LitElement {
         defaultMaxModelCalls: this.configDefaultMaxModelCalls || undefined,
         defaultMaxDuration: this.configDefaultMaxDuration || undefined,
         defaultResources,
+        defaultThinkingLevel: this.defaultThinkingLevel,
         defaultGCPIdentityMode: this.configDefaultGCPIdentityMode || undefined,
         defaultGCPIdentityServiceAccountID:
           this.configDefaultGCPIdentityMode === 'assign'
@@ -1478,7 +1484,7 @@ export class ScionPageProjectSettings extends LitElement {
               <div class="config-field">
                 <label>Default Model</label>
                 <sl-select
-                  placeholder="None (use server default)"
+                  placeholder="use harness default"
                   clearable
                   value=${this.defaultModelSelection}
                   ?disabled=${!canEdit}
@@ -1514,6 +1520,29 @@ export class ScionPageProjectSettings extends LitElement {
                     </div>
                   `
                 : ''}
+
+              <div class="config-field">
+                <label>Default Thinking Level${this.defaultThinkingLevel !== null ? html` <span style="font-weight:normal;color:var(--sl-color-neutral-500)">(${this.defaultThinkingLevel})</span>` : ''}</label>
+                <div style="display:flex;align-items:center;gap:0.75rem">
+                  <sl-range
+                    min="0" max="100" step="1"
+                    .value=${this.defaultThinkingLevel ?? 50}
+                    ?disabled=${this.defaultThinkingLevel === null || !canEdit}
+                    style="flex:1"
+                    @sl-input=${(e: Event) => { this.defaultThinkingLevel = (e.target as HTMLInputElement & { value: number }).value; }}
+                  ></sl-range>
+                  <sl-checkbox
+                    ?checked=${this.defaultThinkingLevel !== null}
+                    ?disabled=${!canEdit}
+                    @sl-change=${(e: Event) => { this.defaultThinkingLevel = (e.target as HTMLInputElement & { checked: boolean }).checked ? 50 : null; }}
+                  >Set</sl-checkbox>
+                </div>
+                <span class="field-help" style="display:flex;justify-content:space-between;margin-top:0.25rem">
+                  <span>0 = minimal reasoning</span>
+                  <span>${this.defaultThinkingLevel === null ? 'Using harness default' : ''}</span>
+                  <span>100 = maximum reasoning</span>
+                </span>
+              </div>
 
               <div class="config-field">
                 <label>Telemetry</label>

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -329,6 +329,7 @@ export interface AgentInlineConfig {
   max_model_calls?: number;
   max_duration?: string;
   model?: string;
+  thinking_level?: number;
   branch?: string;
   task?: string;
   image?: string;
@@ -375,6 +376,7 @@ export interface AgentAppliedConfig {
   harnessAuth?: string;
   noAuth?: boolean;
   model?: string;
+  thinkingLevel?: number;
   profile?: string;
   task?: string;
   attach?: boolean;


### PR DESCRIPTION
## Changes

**Frontend:**
- Removed model choice dropdown from agent-create form
- Updated model dropdown placeholder to "use harness default" (agent-configure, project-settings)
- Added 0-100 thinking level slider with checkbox toggle (agent-configure, project-settings)
- Slider shows no value when unset — UI does not default to 50, harness decides

**Backend:**
- ThinkingLevel *int added to ScionConfig, AgentAppliedConfig, ProjectSettings
- scion.io/default-thinking-level project annotation
- Wired through agent create, agent update, and project settings paths
- Server-side validation: 0-100 range enforced, returns 400 on out-of-range
- Unset semantics: explicit null from frontend clears stored value