### PR TITLE
fix: integration config architecture fixes (R0-R3)

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2255,11 +2255,15 @@ func migrateInlineSecrets(ctx context.Context, sb secret.SecretBackend, pluginNa
 		if !has || val == "" {
 			continue
 		}
-		existing, _ := sb.Get(ctx, m.SecretKey, store.ScopeHub, hubID)
+		existing, err := sb.Get(ctx, m.SecretKey, store.ScopeHub, hubID)
+		if err != nil {
+			log.Printf("Warning: failed to check secret backend for %s (plugin %q), skipping migration: %v", m.ConfigKey, pluginName, err)
+			continue
+		}
 		if existing != nil && existing.Value != "" {
 			continue
 		}
-		_, _, err := sb.Set(ctx, &secret.SetSecretInput{
+		_, _, err = sb.Set(ctx, &secret.SetSecretInput{
 			Name:          m.SecretKey,
 			Value:         val,
 			SecretType:    secret.TypeVariable,

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2260,12 +2260,13 @@ func migrateInlineSecrets(ctx context.Context, sb secret.SecretBackend, pluginNa
 			continue
 		}
 		_, _, err := sb.Set(ctx, &secret.SetSecretInput{
-			Name:        m.SecretKey,
-			Value:       val,
-			SecretType:  "environment",
-			Scope:       store.ScopeHub,
-			ScopeID:     hubID,
-			Description: fmt.Sprintf("Auto-migrated from inline config for plugin %s", pluginName),
+			Name:          m.SecretKey,
+			Value:         val,
+			SecretType:    secret.TypeVariable,
+			InjectionMode: "as_needed",
+			Scope:         store.ScopeHub,
+			ScopeID:       hubID,
+			Description:   fmt.Sprintf("Auto-migrated from inline config for plugin %s", pluginName),
 		})
 		if err != nil {
 			log.Printf("Warning: failed to migrate inline secret %s for plugin %q: %v", m.ConfigKey, pluginName, err)

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2049,6 +2049,12 @@ func initPluginManager() *scionplugin.Manager {
 			log.Printf("Warning: failed to load config file for plugin %q: %v", name, mergeErr)
 			mergedConfig = entry.Config
 		}
+		if entry.ConfigFile != "" {
+			if mergedConfig == nil {
+				mergedConfig = make(map[string]string)
+			}
+			mergedConfig["config_file"] = entry.ConfigFile
+		}
 		pluginsCfg.Broker[name] = scionplugin.PluginEntry{
 			Path:          entry.Path,
 			Config:        mergedConfig,

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -215,19 +215,11 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 	// Parse admin emails
 	adminEmailList := parseAdminEmails(cfg)
 
-	// 10b. Initialize plugin manager
-	pluginMgr := initPluginManager()
-	defer pluginMgr.Shutdown()
-
-	// 11. Start Hub
-	var hubSrv *hub.Server
+	// Initialize secret backend before plugin manager so that boot-time
+	// inline-secret migration can write to the backend before
+	// ResolvePluginConfig strips inline secrets.
 	var secretBackend secret.SecretBackend
-	var hubDBRec dbmetrics.Recorder
-	if enableHub {
-		// Initialize secret backend early so signing keys can be loaded from it
-		// during hub server creation. This prevents the previous bug where
-		// ensureSigningKey always fell through to SQLite because the secret
-		// backend was set too late (after hub.New()).
+	if enableHub && s != nil {
 		hubID := cfg.Hub.ResolveHubID()
 		var sbErr error
 		secretBackend, sbErr = secret.NewBackend(ctx, cfg.Secrets.Backend, s, secret.GCPBackendConfig{
@@ -237,6 +229,16 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 		if sbErr != nil {
 			log.Printf("Warning: failed to initialize secret backend: %v", sbErr)
 		}
+	}
+
+	// 10b. Initialize plugin manager
+	pluginMgr := initPluginManager(ctx, secretBackend)
+	defer pluginMgr.Shutdown()
+
+	// 11. Start Hub
+	var hubSrv *hub.Server
+	var hubDBRec dbmetrics.Recorder
+	if enableHub {
 
 		var hubInitErr error
 		hubSrv, hubInitErr = initHubServer(ctx, cfg, s, entClient, hubEndpoint, devAuthToken, adminEmailList, adminMode, maintenanceMessage, requestLogger, messageLogger, globalDir, pluginMgr, secretBackend)
@@ -2024,7 +2026,9 @@ func isObserverBroker(pluginMgr *scionplugin.Manager, name string) bool {
 }
 
 // initPluginManager creates and loads a plugin manager from versioned settings.
-func initPluginManager() *scionplugin.Manager {
+// The secretBackend parameter (may be nil) enables one-shot migration of inline
+// secrets to the backend before ResolvePluginConfig strips them.
+func initPluginManager(ctx context.Context, secretBackend secret.SecretBackend) *scionplugin.Manager {
 	logger := logging.Subsystem("plugin")
 	mgr := scionplugin.NewManager(logger)
 	mgr.NewGRPCBrokerAdapter = grpcbroker.NewAdapterFromEntry
@@ -2045,10 +2049,18 @@ func initPluginManager() *scionplugin.Manager {
 		Broker: make(map[string]scionplugin.PluginEntry),
 	}
 	for name, entry := range vs.Server.Plugins.Broker {
+		// B1: Auto-migrate inline secrets to the secret backend before
+		// ResolvePluginConfig strips them. This ensures existing users
+		// with bot_token in settings.yaml don't lose their credentials
+		// on upgrade.
+		if secretBackend != nil && entry.Config != nil {
+			migrateInlineSecrets(ctx, secretBackend, name, entry.Config)
+		}
+
 		mergedConfig, mergeErr := config.ResolvePluginConfig(entry.ConfigFile, entry.Config)
 		if mergeErr != nil {
 			log.Printf("Warning: failed to load config file for plugin %q: %v", name, mergeErr)
-			mergedConfig = entry.Config
+			mergedConfig = stripSecretKeys(entry.Config)
 		}
 		if entry.ConfigFile != "" {
 			if mergedConfig == nil {
@@ -2224,6 +2236,54 @@ func resolveMaintenanceConfig(cfg *config.GlobalConfig) hub.MaintenanceConfig {
 	}
 
 	return mc
+}
+
+// migrateInlineSecrets performs a one-shot migration of secret config keys found
+// in the raw inline settings.yaml config into the secret backend. This prevents
+// existing users who followed the Telegram/Discord READMEs (which have
+// bot_token directly in settings.yaml) from losing their credentials when
+// ResolvePluginConfig strips inline secrets.
+func migrateInlineSecrets(ctx context.Context, sb secret.SecretBackend, pluginName string, inlineConfig map[string]string) {
+	mappings, ok := config.PluginSecretKeyMap[pluginName]
+	if !ok {
+		return
+	}
+
+	hubID := sb.HubID()
+	for _, m := range mappings {
+		val, has := inlineConfig[m.ConfigKey]
+		if !has || val == "" {
+			continue
+		}
+		existing, _ := sb.Get(ctx, m.SecretKey, store.ScopeHub, hubID)
+		if existing != nil && existing.Value != "" {
+			continue
+		}
+		_, _, err := sb.Set(ctx, &secret.SetSecretInput{
+			Name:        m.SecretKey,
+			Value:       val,
+			SecretType:  "environment",
+			Scope:       store.ScopeHub,
+			ScopeID:     hubID,
+			Description: fmt.Sprintf("Auto-migrated from inline config for plugin %s", pluginName),
+		})
+		if err != nil {
+			log.Printf("Warning: failed to migrate inline secret %s for plugin %q: %v", m.ConfigKey, pluginName, err)
+			continue
+		}
+		log.Printf("Migrated inline %s to secret backend for plugin %q — remove it from settings.yaml", m.ConfigKey, pluginName)
+	}
+}
+
+// stripSecretKeys returns a copy of the config map with all secret config keys removed.
+func stripSecretKeys(cfg map[string]string) map[string]string {
+	out := make(map[string]string, len(cfg))
+	for k, v := range cfg {
+		if !config.IsSecretConfigKey(k) {
+			out[k] = v
+		}
+	}
+	return out
 }
 
 // injectPluginSecrets loads chat integration secrets from the secret backend

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2045,8 +2045,7 @@ func initPluginManager() *scionplugin.Manager {
 		Broker: make(map[string]scionplugin.PluginEntry),
 	}
 	for name, entry := range vs.Server.Plugins.Broker {
-		// Merge config_file contents with inline config (inline overrides file).
-		mergedConfig, mergeErr := config.LoadPluginConfigFile(entry.ConfigFile, entry.Config)
+		mergedConfig, mergeErr := config.ResolvePluginConfig(entry.ConfigFile, entry.Config)
 		if mergeErr != nil {
 			log.Printf("Warning: failed to load config file for plugin %q: %v", name, mergeErr)
 			mergedConfig = entry.Config

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -410,10 +410,12 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 					continue
 				}
 
-				// Inject hub credentials into hub-managed broker plugins so they
-				// can authenticate back to the Hub API. Self-managed plugins
-				// handle their own credential lifecycle.
-				if !pluginMgr.IsSelfManaged(scionplugin.PluginTypeBroker, bt) && hubSrv != nil && s != nil {
+				// Inject hub credentials into hub-managed, non-HA broker plugins.
+				// Self-managed plugins handle their own credential lifecycle;
+				// HA integrations pull credentials from env/Secret Manager.
+				if !pluginMgr.IsSelfManaged(scionplugin.PluginTypeBroker, bt) &&
+					pluginMgr.GetDeploymentMode(scionplugin.PluginTypeBroker, bt) != scionplugin.DeploymentModeHA &&
+					hubSrv != nil && s != nil {
 					// Use the same deterministic UUIDv5 as the α migration so the
 					// broker entity created here matches the migrated ID.
 					pluginBrokerNS := uuid.MustParse("5c104390-a1d0-5e9a-9b1e-5c104390a1d0")

--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -17,6 +17,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -161,6 +162,112 @@ var PluginSecretKeyMap = map[string][]IntegrationSecretMapping{
 	"chat-app": {
 		{SecretGChatSigningKey, "signing_key"},
 	},
+}
+
+// wiringKeys are config keys that always come from settings.yaml inline config,
+// never from the per-plugin YAML file.
+var wiringKeys = map[string]bool{
+	"mode":            true,
+	"path":            true,
+	"address":         true,
+	"tls_cert_file":   true,
+	"tls_key_file":    true,
+	"tls_ca_file":     true,
+	"tls_skip_verify": true,
+	"config_file":     true,
+}
+
+// secretConfigKeys collects all config-level key names that map to secret
+// backend entries (e.g. "bot_token", "signing_key"). Built once from
+// PluginSecretKeyMap.
+var secretConfigKeys map[string]bool
+
+func init() {
+	secretConfigKeys = make(map[string]bool)
+	for _, mappings := range PluginSecretKeyMap {
+		for _, m := range mappings {
+			secretConfigKeys[m.ConfigKey] = true
+		}
+	}
+}
+
+// IsSecretConfigKey reports whether key is a plugin config key that maps to a
+// secret backend entry (e.g. "bot_token", "signing_secret").
+func IsSecretConfigKey(key string) bool {
+	return secretConfigKeys[key]
+}
+
+// backendSecretKeys lists the well-known secret backend key names
+// (TELEGRAM_BOT_TOKEN, etc.) for stripping from config maps.
+var backendSecretKeys = []string{
+	SecretTelegramBotToken, SecretTelegramWebhookKey,
+	SecretDiscordBotToken, SecretDiscordPublicKey,
+	SecretSlackBotToken, SecretSlackAppToken, SecretSlackSigningSecret,
+	SecretGChatSigningKey,
+}
+
+// ResolvePluginConfig builds the config map for a plugin with consistent precedence.
+// If configFile is set, the file is the source of truth for non-wiring keys.
+// Inline config is only used for wiring keys or as fallback when no config_file exists.
+// Secret config keys (bot_token, signing_key, etc.) are always stripped from inline
+// config so that the secret backend takes precedence.
+func ResolvePluginConfig(configFile string, inlineConfig map[string]string) (map[string]string, error) {
+	// Build a clean copy of inline config with secret keys stripped.
+	cleanedInline := make(map[string]string, len(inlineConfig))
+	for k, v := range inlineConfig {
+		if secretConfigKeys[k] {
+			continue
+		}
+		cleanedInline[k] = v
+	}
+	// Also strip backend key names (same filtering applied to file config).
+	for _, sk := range backendSecretKeys {
+		delete(cleanedInline, sk)
+		delete(cleanedInline, strings.ToLower(sk))
+	}
+
+	if configFile == "" {
+		return cleanedInline, nil
+	}
+
+	provider, err := NewYAMLConfigProvider(configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	fileConfig, err := provider.Load(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter backend secret key names from file config.
+	for _, sk := range backendSecretKeys {
+		delete(fileConfig, sk)
+		delete(fileConfig, strings.ToLower(sk))
+	}
+
+	// File is the base for non-wiring keys.
+	merged := make(map[string]string, len(fileConfig)+len(cleanedInline))
+	for k, v := range fileConfig {
+		merged[k] = v
+	}
+
+	// Add only wiring keys from inline; log a deprecation warning for
+	// any non-wiring keys that would be silently ignored.
+	var deprecated []string
+	for k, v := range cleanedInline {
+		if wiringKeys[k] {
+			merged[k] = v
+		} else if v != "" {
+			deprecated = append(deprecated, k)
+		}
+	}
+	if len(deprecated) > 0 {
+		slog.Warn("inline config keys ignored because config_file is set — move them to the config file",
+			"keys", deprecated, "config_file", configFile)
+	}
+
+	return merged, nil
 }
 
 // AddPluginToSettings adds a broker plugin entry to the global settings.yaml.

--- a/pkg/config/integration_config_test.go
+++ b/pkg/config/integration_config_test.go
@@ -138,6 +138,191 @@ func TestLoadPluginConfigFile_MergeWithInlineOverride(t *testing.T) {
 	}
 }
 
+func TestResolvePluginConfig_NoConfigFile_FallbackToInline(t *testing.T) {
+	inline := map[string]string{
+		"inbound_mode": "webhook",
+		"db_path":      "/tmp/test.db",
+		"mode":         "plugin",
+	}
+	result, err := ResolvePluginConfig("", inline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result["inbound_mode"] != "webhook" {
+		t.Errorf("expected inline fallback, got %q", result["inbound_mode"])
+	}
+	if result["mode"] != "plugin" {
+		t.Errorf("expected wiring key preserved, got %q", result["mode"])
+	}
+}
+
+func TestResolvePluginConfig_FileWinsForNonWiringKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plugin.yaml")
+	p, _ := NewYAMLConfigProvider(path)
+	if err := p.Save(context.Background(), map[string]string{
+		"inbound_mode": "poll",
+		"db_path":      "/tmp/file.db",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	inline := map[string]string{
+		"inbound_mode": "webhook",
+		"db_path":      "/tmp/inline.db",
+		"mode":         "plugin",
+		"address":      "localhost:9090",
+	}
+
+	result, err := ResolvePluginConfig(path, inline)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result["inbound_mode"] != "poll" {
+		t.Errorf("file should win for non-wiring key: got %q, want %q", result["inbound_mode"], "poll")
+	}
+	if result["db_path"] != "/tmp/file.db" {
+		t.Errorf("file should win for non-wiring key: got %q, want %q", result["db_path"], "/tmp/file.db")
+	}
+	if result["mode"] != "plugin" {
+		t.Errorf("wiring key should come from inline: got %q, want %q", result["mode"], "plugin")
+	}
+	if result["address"] != "localhost:9090" {
+		t.Errorf("wiring key should come from inline: got %q, want %q", result["address"], "localhost:9090")
+	}
+}
+
+func TestResolvePluginConfig_InlineNonWiringIgnoredWithConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plugin.yaml")
+	p, _ := NewYAMLConfigProvider(path)
+	if err := p.Save(context.Background(), map[string]string{
+		"db_path": "/tmp/file.db",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	inline := map[string]string{
+		"custom_setting": "should-be-ignored",
+		"mode":           "plugin",
+	}
+
+	result, err := ResolvePluginConfig(path, inline)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := result["custom_setting"]; ok {
+		t.Error("non-wiring inline key should be ignored when config_file is set")
+	}
+	if result["mode"] != "plugin" {
+		t.Errorf("wiring key should be preserved: got %q", result["mode"])
+	}
+	if result["db_path"] != "/tmp/file.db" {
+		t.Errorf("file key should be present: got %q", result["db_path"])
+	}
+}
+
+func TestResolvePluginConfig_SecretKeysStrippedFromInline(t *testing.T) {
+	inline := map[string]string{
+		"bot_token":      "stale-token",
+		"signing_secret": "old-secret",
+		"inbound_mode":   "webhook",
+		"mode":           "plugin",
+	}
+
+	result, err := ResolvePluginConfig("", inline)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := result["bot_token"]; ok {
+		t.Error("secret config key bot_token should be stripped from inline")
+	}
+	if _, ok := result["signing_secret"]; ok {
+		t.Error("secret config key signing_secret should be stripped from inline")
+	}
+	if result["inbound_mode"] != "webhook" {
+		t.Errorf("non-secret key should be preserved: got %q", result["inbound_mode"])
+	}
+	if result["mode"] != "plugin" {
+		t.Errorf("wiring key should be preserved: got %q", result["mode"])
+	}
+}
+
+func TestResolvePluginConfig_SecretKeysStrippedWithConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plugin.yaml")
+	p, _ := NewYAMLConfigProvider(path)
+	if err := p.Save(context.Background(), map[string]string{
+		"inbound_mode": "poll",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	inline := map[string]string{
+		"bot_token": "stale-inline-token",
+		"mode":      "plugin",
+	}
+
+	result, err := ResolvePluginConfig(path, inline)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := result["bot_token"]; ok {
+		t.Error("secret config key bot_token should be stripped from inline even with config_file")
+	}
+	if result["inbound_mode"] != "poll" {
+		t.Errorf("file non-wiring key should be present: got %q", result["inbound_mode"])
+	}
+}
+
+func TestResolvePluginConfig_BackendKeyNamesStrippedFromBothSources(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plugin.yaml")
+	p, _ := NewYAMLConfigProvider(path)
+	if err := p.Save(context.Background(), map[string]string{
+		"TELEGRAM_BOT_TOKEN": "should-not-survive",
+		"inbound_mode":       "poll",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	inline := map[string]string{
+		"DISCORD_BOT_TOKEN": "should-not-survive",
+		"mode":              "plugin",
+	}
+
+	result, err := ResolvePluginConfig(path, inline)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, key := range []string{"TELEGRAM_BOT_TOKEN", "telegram_bot_token", "DISCORD_BOT_TOKEN", "discord_bot_token"} {
+		if _, ok := result[key]; ok {
+			t.Errorf("backend secret key %q should have been filtered", key)
+		}
+	}
+	if result["inbound_mode"] != "poll" {
+		t.Errorf("non-secret file key should survive: got %q", result["inbound_mode"])
+	}
+}
+
+func TestIsSecretConfigKey(t *testing.T) {
+	for _, key := range []string{"bot_token", "webhook_secret", "public_key", "app_token", "signing_secret", "signing_key"} {
+		if !IsSecretConfigKey(key) {
+			t.Errorf("expected %q to be a secret config key", key)
+		}
+	}
+	for _, key := range []string{"inbound_mode", "db_path", "mode", "address"} {
+		if IsSecretConfigKey(key) {
+			t.Errorf("expected %q to NOT be a secret config key", key)
+		}
+	}
+}
+
 func TestLoadPluginConfigFile_FiltersSecretKeys(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "plugin.yaml")

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -33,6 +33,27 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/plugin"
 )
 
+// reconfigureRuntimeKeys lists keys that are injected at runtime/wiring time
+// and must be carried over during reconfigure (they are not in config files).
+var reconfigureRuntimeKeys = map[string]bool{
+	"config_file":      true,
+	"hub_url":          true,
+	"hmac_key":         true,
+	"broker_id":        true,
+	"plugin_name":      true,
+	"project_slug_map": true,
+	"database_url":     true,
+	"database_driver":  true,
+	"bot_id":           true,
+	"mode":             true,
+	"path":             true,
+	"address":          true,
+	"tls_cert_file":    true,
+	"tls_key_file":     true,
+	"tls_ca_file":      true,
+	"tls_skip_verify":  true,
+}
+
 // IntegrationManager is the narrow interface satisfied by *plugin.Manager.
 // It lets the hub query and control broker plugins without importing the
 // plugin package directly.
@@ -315,7 +336,7 @@ func (s *Server) resolveIntegrationSettings(ctx context.Context, mgr Integration
 
 	configFile := runtimeCfg["config_file"]
 	if configFile != "" {
-		if settings, err := config.LoadPluginConfigFile(configFile, nil); err == nil {
+		if settings, err := config.ResolvePluginConfig(configFile, nil); err == nil {
 			for k, v := range runtimeCfg {
 				if _, ok := settings[k]; !ok {
 					settings[k] = v
@@ -805,12 +826,16 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 		configFile = pluginCfg["config_file"]
 	}
 
-	// Resolve from file only — do NOT pass the manager's boot-resolved map
-	// as "inline" config, because it contains the file's own keys and would
-	// trigger spurious "inline config keys ignored" deprecation warnings (B2).
-	// Only runtime/wiring keys are carried over via an explicit allowlist,
-	// which also ensures that keys deleted from the config file stay deleted (B3).
-	merged, err := config.ResolvePluginConfig(configFile, nil)
+	// When a config file is set, resolve from file only — do NOT pass the
+	// manager's boot-resolved map as "inline" config, because it contains
+	// the file's own keys and would trigger spurious deprecation warnings (B2).
+	// When no config file exists, pass the manager map as inline config so
+	// that inline-only deployments retain their configuration keys.
+	var inlineToPass map[string]string
+	if configFile == "" {
+		inlineToPass = pluginCfg
+	}
+	merged, err := config.ResolvePluginConfig(configFile, inlineToPass)
 	if err != nil {
 		slog.Error("Failed to resolve config for reconfigure", "plugin", name, "error", err)
 		merged = make(map[string]string)
@@ -819,26 +844,8 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 	// Carry over runtime/wiring keys from the manager map.
 	// Wiring keys must be included because ReplaceBrokerConfig uses replace
 	// semantics (no underlay from boot-time config).
-	runtimeKeys := map[string]bool{
-		"config_file":      true,
-		"hub_url":          true,
-		"hmac_key":         true,
-		"broker_id":        true,
-		"plugin_name":      true,
-		"project_slug_map": true,
-		"database_url":     true,
-		"database_driver":  true,
-		"bot_id":           true,
-		"mode":             true,
-		"path":             true,
-		"address":          true,
-		"tls_cert_file":    true,
-		"tls_key_file":     true,
-		"tls_ca_file":      true,
-		"tls_skip_verify":  true,
-	}
 	for k, v := range pluginCfg {
-		if runtimeKeys[k] && merged[k] == "" {
+		if reconfigureRuntimeKeys[k] && merged[k] == "" {
 			merged[k] = v
 		}
 	}

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -804,27 +804,20 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 		configFile = pluginCfg["config_file"]
 	}
 
-	merged := make(map[string]string)
-	if configFile != "" {
-		fileMerged, err := config.LoadPluginConfigFile(configFile, nil)
-		if err != nil {
-			slog.Error("Failed to reload config file for reconfigure", "plugin", name, "error", err)
-			for k, v := range pluginCfg {
-				merged[k] = v
-			}
-		} else {
-			merged = fileMerged
-			// Carry over runtime/internal keys from the old config that
-			// are not present in the file (e.g. hub_url, hmac_key).
-			for k, v := range pluginCfg {
-				if _, ok := merged[k]; !ok {
-					merged[k] = v
-				}
-			}
-		}
-	} else {
+	merged, err := config.ResolvePluginConfig(configFile, pluginCfg)
+	if err != nil {
+		slog.Error("Failed to resolve config for reconfigure", "plugin", name, "error", err)
+		merged = make(map[string]string)
 		for k, v := range pluginCfg {
 			merged[k] = v
+		}
+	} else {
+		// Carry over runtime/internal keys from the old config that
+		// are not present in the resolved result (e.g. hub_url, hmac_key).
+		for k, v := range pluginCfg {
+			if _, ok := merged[k]; !ok && !config.IsSecretConfigKey(k) {
+				merged[k] = v
+			}
 		}
 	}
 

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -269,10 +269,14 @@ func (s *Server) handleGetIntegration(w http.ResponseWriter, r *http.Request, na
 		return
 	}
 
-	cfg := mgr.GetPluginConfig("broker", name)
-	if cfg == nil {
-		cfg = make(map[string]string)
+	runtimeCfg := mgr.GetPluginConfig("broker", name)
+	if runtimeCfg == nil {
+		runtimeCfg = make(map[string]string)
 	}
+
+	// Resolve settings from the same provider that PUT writes to, so
+	// GET reflects the latest saved state rather than the boot-time map.
+	cfg := s.resolveIntegrationSettings(r.Context(), mgr, name, runtimeCfg)
 
 	detail := IntegrationDetail{
 		Name:           name,
@@ -285,6 +289,43 @@ func (s *Server) handleGetIntegration(w http.ResponseWriter, r *http.Request, na
 	}
 
 	writeJSON(w, http.StatusOK, detail)
+}
+
+// resolveIntegrationSettings returns the current settings for a plugin by
+// reading from the appropriate config provider (Postgres for HA, YAML file for
+// non-HA). Runtime/wiring keys from the manager map are merged as an underlay.
+func (s *Server) resolveIntegrationSettings(ctx context.Context, mgr IntegrationManager, name string, runtimeCfg map[string]string) map[string]string {
+	if s.isHAIntegration(mgr, name) {
+		if s.entClient != nil {
+			provider := config.NewPostgresConfigProvider(s.entClient, name)
+			if settings, err := provider.Load(ctx); err == nil {
+				// Merge runtime keys as underlay — provider values win.
+				for k, v := range runtimeCfg {
+					if _, ok := settings[k]; !ok {
+						settings[k] = v
+					}
+				}
+				return settings
+			}
+			slog.Warn("Failed to load HA config for GET, falling back to manager map", "plugin", name)
+		}
+		return runtimeCfg
+	}
+
+	configFile := runtimeCfg["config_file"]
+	if configFile != "" {
+		if settings, err := config.LoadPluginConfigFile(configFile, nil); err == nil {
+			for k, v := range runtimeCfg {
+				if _, ok := settings[k]; !ok {
+					settings[k] = v
+				}
+			}
+			return settings
+		}
+		slog.Warn("Failed to reload config file for GET, falling back to manager map", "plugin", name)
+	}
+
+	return runtimeCfg
 }
 
 func (s *Server) handleUpdateIntegrationConfig(w http.ResponseWriter, r *http.Request, name string) {
@@ -419,10 +460,14 @@ func (s *Server) handleUpdateIntegrationConfig(w http.ResponseWriter, r *http.Re
 	}
 
 	// Reconfigure the running integration with updated config.
-	if err := s.reconfigureIntegration(r.Context(), mgr, name); err != nil {
-		slog.Error("Failed to reconfigure integration after config update", "plugin", name, "error", err)
-		InternalError(w)
-		return
+	// For HA integrations the DB write + NOTIFY is the reconfigure path —
+	// pushing a hub-side merge over gRPC would race with the DB-backed reload.
+	if !s.isHAIntegration(mgr, name) {
+		if err := s.reconfigureIntegration(r.Context(), mgr, name); err != nil {
+			slog.Error("Failed to reconfigure integration after config update", "plugin", name, "error", err)
+			InternalError(w)
+			return
+		}
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -47,7 +47,7 @@ type IntegrationManager interface {
 	BrokerHealthCheck(name string) (status, message string, details map[string]string, err error)
 	BrokerInfo(name string) (version, channelID string, capabilities []string, err error)
 	UpdatePlugin(name string, repoPath string) error
-	InstallPlugin(name, repoPath, pluginsDir string) error
+	InstallPlugin(name, repoPath, pluginsDir, configFile string) error
 	GetGRPCBrokerAdapter(name string) plugin.GRPCBrokerClient
 }
 
@@ -605,12 +605,6 @@ func (s *Server) handleInstallIntegration(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if err := mgr.InstallPlugin(name, repoPath, pluginsDir); err != nil {
-		slog.Error("Failed to install integration", "plugin", name, "error", err)
-		InternalError(w)
-		return
-	}
-
 	configFilePath := "~/.scion/scion-" + name + ".yaml"
 	if err := config.CreatePluginConfigFile(name, configFilePath); err != nil {
 		slog.Error("Failed to create plugin config file", "plugin", name, "error", err)
@@ -623,6 +617,12 @@ func (s *Server) handleInstallIntegration(w http.ResponseWriter, r *http.Request
 	settingsWriteMu.Unlock()
 	if err != nil {
 		slog.Error("Failed to add plugin to settings.yaml", "plugin", name, "error", err)
+		InternalError(w)
+		return
+	}
+
+	if err := mgr.InstallPlugin(name, repoPath, pluginsDir, configFilePath); err != nil {
+		slog.Error("Failed to install integration", "plugin", name, "error", err)
 		InternalError(w)
 		return
 	}

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -43,6 +43,7 @@ type IntegrationManager interface {
 	IsSelfManaged(pluginType, name string) bool
 	GetDeploymentMode(pluginType, name string) plugin.DeploymentMode
 	ConfigureBroker(name string, extra map[string]string) error
+	ReplaceBrokerConfig(name string, cfg map[string]string) error
 	Reconnect(pluginType, name string) error
 	BrokerHealthCheck(name string) (status, message string, details map[string]string, err error)
 	BrokerInfo(name string) (version, channelID string, capabilities []string, err error)
@@ -815,17 +816,26 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 		merged = make(map[string]string)
 	}
 
-	// Carry over only runtime/wiring keys from the manager map.
+	// Carry over runtime/wiring keys from the manager map.
+	// Wiring keys must be included because ReplaceBrokerConfig uses replace
+	// semantics (no underlay from boot-time config).
 	runtimeKeys := map[string]bool{
-		"config_file":     true,
-		"hub_url":         true,
-		"hmac_key":        true,
-		"broker_id":       true,
-		"plugin_name":     true,
+		"config_file":      true,
+		"hub_url":          true,
+		"hmac_key":         true,
+		"broker_id":        true,
+		"plugin_name":      true,
 		"project_slug_map": true,
-		"database_url":    true,
-		"database_driver": true,
-		"bot_id":          true,
+		"database_url":     true,
+		"database_driver":  true,
+		"bot_id":           true,
+		"mode":             true,
+		"path":             true,
+		"address":          true,
+		"tls_cert_file":    true,
+		"tls_key_file":     true,
+		"tls_ca_file":      true,
+		"tls_skip_verify":  true,
 	}
 	for k, v := range pluginCfg {
 		if runtimeKeys[k] && merged[k] == "" {
@@ -846,9 +856,9 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 		merged[m.ConfigKey] = val
 	}
 
-	if err := mgr.ConfigureBroker(name, merged); err != nil {
+	if err := mgr.ReplaceBrokerConfig(name, merged); err != nil {
 		if mgr.IsSelfManaged("broker", name) {
-			slog.Warn("ConfigureBroker failed for self-managed plugin, trying Reconnect",
+			slog.Warn("ReplaceBrokerConfig failed for self-managed plugin, trying Reconnect",
 				"plugin", name, "error", err)
 			return mgr.Reconnect("broker", name)
 		}

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -804,20 +804,32 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 		configFile = pluginCfg["config_file"]
 	}
 
-	merged, err := config.ResolvePluginConfig(configFile, pluginCfg)
+	// Resolve from file only — do NOT pass the manager's boot-resolved map
+	// as "inline" config, because it contains the file's own keys and would
+	// trigger spurious "inline config keys ignored" deprecation warnings (B2).
+	// Only runtime/wiring keys are carried over via an explicit allowlist,
+	// which also ensures that keys deleted from the config file stay deleted (B3).
+	merged, err := config.ResolvePluginConfig(configFile, nil)
 	if err != nil {
 		slog.Error("Failed to resolve config for reconfigure", "plugin", name, "error", err)
 		merged = make(map[string]string)
-		for k, v := range pluginCfg {
+	}
+
+	// Carry over only runtime/wiring keys from the manager map.
+	runtimeKeys := map[string]bool{
+		"config_file":     true,
+		"hub_url":         true,
+		"hmac_key":        true,
+		"broker_id":       true,
+		"plugin_name":     true,
+		"project_slug_map": true,
+		"database_url":    true,
+		"database_driver": true,
+		"bot_id":          true,
+	}
+	for k, v := range pluginCfg {
+		if runtimeKeys[k] && merged[k] == "" {
 			merged[k] = v
-		}
-	} else {
-		// Carry over runtime/internal keys from the old config that
-		// are not present in the resolved result (e.g. hub_url, hmac_key).
-		for k, v := range pluginCfg {
-			if _, ok := merged[k]; !ok && !config.IsSecretConfigKey(k) {
-				merged[k] = v
-			}
 		}
 	}
 

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -138,12 +138,15 @@ func (m *mockIntegrationManager) UpdatePlugin(name string, repoPath string) erro
 	return m.updateErr
 }
 
-func (m *mockIntegrationManager) InstallPlugin(name, repoPath, pluginsDir string) error {
+func (m *mockIntegrationManager) InstallPlugin(name, repoPath, pluginsDir, configFile string) error {
 	m.installCalls = append(m.installCalls, name)
 	if m.installErr != nil {
 		return m.installErr
 	}
 	m.plugins[name] = map[string]string{}
+	if configFile != "" {
+		m.plugins[name]["config_file"] = configFile
+	}
 	return nil
 }
 
@@ -1581,6 +1584,25 @@ func TestGetIntegration_HA_ReadsFromPostgres(t *testing.T) {
 	// Internal keys should be filtered out.
 	if _, ok := detail.Settings["hub_url"]; ok {
 		t.Error("hub_url should be filtered from settings")
+	}
+}
+
+func TestInstallPlugin_PassesConfigFile(t *testing.T) {
+	mgr := newMockIntegrationManager()
+
+	if err := mgr.InstallPlugin("telegram", "/repo", "/plugins", "~/.scion/scion-telegram.yaml"); err != nil {
+		t.Fatalf("InstallPlugin: %v", err)
+	}
+
+	cfg := mgr.GetPluginConfig("broker", "telegram")
+	if cfg == nil {
+		t.Fatal("expected non-nil config after install")
+	}
+	if cfg["config_file"] == "" {
+		t.Error("expected config_file to be set after InstallPlugin with configFile parameter")
+	}
+	if cfg["config_file"] != "~/.scion/scion-telegram.yaml" {
+		t.Errorf("expected config_file=~/.scion/scion-telegram.yaml, got %q", cfg["config_file"])
 	}
 }
 

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/integrationupdate"
 	"github.com/GoogleCloudPlatform/scion/pkg/plugin"
 	"github.com/GoogleCloudPlatform/scion/pkg/store/enttest"
@@ -1496,5 +1497,133 @@ func TestIsHAIntegration_Modes(t *testing.T) {
 	mgr2.selfManaged["slack"] = true
 	if srv.isHAIntegration(mgr2, "slack") {
 		t.Error("self-managed without HA mode should not be HA")
+	}
+}
+
+func TestUpdateConfig_HA_SkipsReconfigure(t *testing.T) {
+	if !enttest.Active() {
+		t.Skip("requires Postgres backend; set SCION_TEST_POSTGRES_URL and build with -tags integration")
+	}
+	client := enttest.NewClient(t)
+
+	mgr := newMockIntegrationManager()
+	mgr.plugins["discord"] = map[string]string{}
+	mgr.deploymentModes["discord"] = plugin.DeploymentModeHA
+
+	srv := &Server{dbDriver: "postgres"}
+	srv.pluginManager = mgr
+	srv.entClient = client
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	body := `{"settings":{"guild_id":"12345"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/integrations/discord/config", strings.NewReader(body))
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	if len(mgr.configureCalls) != 0 {
+		t.Errorf("expected no ConfigureBroker calls for HA integration, got %v", mgr.configureCalls)
+	}
+}
+
+func TestGetIntegration_HA_ReadsFromPostgres(t *testing.T) {
+	if !enttest.Active() {
+		t.Skip("requires Postgres backend; set SCION_TEST_POSTGRES_URL and build with -tags integration")
+	}
+	client := enttest.NewClient(t)
+
+	mgr := newMockIntegrationManager()
+	mgr.plugins["discord"] = map[string]string{
+		"guild_id": "boot-value",
+		"hub_url":  "https://hub.example.com",
+	}
+	mgr.deploymentModes["discord"] = plugin.DeploymentModeHA
+
+	// Write config to Postgres — this is what PUT would have done.
+	provider := config.NewPostgresConfigProvider(client, "discord")
+	if err := provider.Save(context.Background(), map[string]string{
+		"guild_id":       "db-value",
+		"application_id": "app-from-db",
+	}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	srv := &Server{dbDriver: "postgres"}
+	srv.pluginManager = mgr
+	srv.entClient = client
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/discord", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var detail IntegrationDetail
+	if err := json.NewDecoder(rr.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Settings should reflect Postgres values, not boot-time map.
+	if detail.Settings["guild_id"] != "db-value" {
+		t.Errorf("guild_id: expected db-value, got %q", detail.Settings["guild_id"])
+	}
+	if detail.Settings["application_id"] != "app-from-db" {
+		t.Errorf("application_id: expected app-from-db, got %q", detail.Settings["application_id"])
+	}
+	// Internal keys should be filtered out.
+	if _, ok := detail.Settings["hub_url"]; ok {
+		t.Error("hub_url should be filtered from settings")
+	}
+}
+
+func TestGetIntegration_ReadsFromConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "telegram.yaml")
+	if err := os.WriteFile(configFile, []byte("webhook_listen: \":9095\"\ndb_path: /tmp/tg.db\n"), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	mgr := newMockIntegrationManager()
+	mgr.plugins["telegram"] = map[string]string{
+		"config_file":    configFile,
+		"webhook_listen": ":9094",
+		"hub_url":        "https://hub.example.com",
+	}
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/telegram", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var detail IntegrationDetail
+	if err := json.NewDecoder(rr.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Settings should reflect the YAML file values, not the boot-time map.
+	if detail.Settings["webhook_listen"] != ":9095" {
+		t.Errorf("webhook_listen: expected :9095 (from file), got %q", detail.Settings["webhook_listen"])
+	}
+	if detail.Settings["db_path"] != "/tmp/tg.db" {
+		t.Errorf("db_path: expected /tmp/tg.db, got %q", detail.Settings["db_path"])
+	}
+	if _, ok := detail.Settings["hub_url"]; ok {
+		t.Error("hub_url should be filtered from settings")
 	}
 }

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -35,19 +35,21 @@ import (
 // --- mock IntegrationManager ---
 
 type mockIntegrationManager struct {
-	plugins         map[string]map[string]string // name → config
-	selfManaged     map[string]bool
-	deploymentModes map[string]plugin.DeploymentMode
-	healthErr       error
-	infoErr         error
-	configureErr    error
-	reconnectErr    error
-	updateErr       error
-	installErr      error
-	configureCalls  []string
-	reconnectCalls  []string
-	updateCalls     []string
-	installCalls    []string
+	plugins            map[string]map[string]string // name → config
+	selfManaged        map[string]bool
+	deploymentModes    map[string]plugin.DeploymentMode
+	healthErr          error
+	infoErr            error
+	configureErr       error
+	replaceConfigErr   error
+	reconnectErr       error
+	updateErr          error
+	installErr         error
+	configureCalls     []string
+	replaceConfigCalls []string
+	reconnectCalls     []string
+	updateCalls        []string
+	installCalls       []string
 }
 
 func newMockIntegrationManager() *mockIntegrationManager {
@@ -112,6 +114,11 @@ func (m *mockIntegrationManager) GetDeploymentMode(pluginType, name string) plug
 func (m *mockIntegrationManager) ConfigureBroker(name string, extra map[string]string) error {
 	m.configureCalls = append(m.configureCalls, name)
 	return m.configureErr
+}
+
+func (m *mockIntegrationManager) ReplaceBrokerConfig(name string, cfg map[string]string) error {
+	m.replaceConfigCalls = append(m.replaceConfigCalls, name)
+	return m.replaceConfigErr
 }
 
 func (m *mockIntegrationManager) Reconnect(pluginType, name string) error {
@@ -445,8 +452,8 @@ func TestRestartIntegration_OK(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
 	}
 
-	if len(mgr.configureCalls) != 1 || mgr.configureCalls[0] != "telegram" {
-		t.Errorf("expected ConfigureBroker call for telegram, got %v", mgr.configureCalls)
+	if len(mgr.replaceConfigCalls) != 1 || mgr.replaceConfigCalls[0] != "telegram" {
+		t.Errorf("expected ReplaceBrokerConfig call for telegram, got %v", mgr.replaceConfigCalls)
 	}
 }
 
@@ -528,8 +535,8 @@ func TestUpdateConfig_WithConfigFile(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
 	}
 
-	if len(mgr.configureCalls) != 1 {
-		t.Errorf("expected 1 ConfigureBroker call, got %d", len(mgr.configureCalls))
+	if len(mgr.replaceConfigCalls) != 1 {
+		t.Errorf("expected 1 ReplaceBrokerConfig call, got %d", len(mgr.replaceConfigCalls))
 	}
 }
 
@@ -1528,8 +1535,8 @@ func TestUpdateConfig_HA_SkipsReconfigure(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
 	}
 
-	if len(mgr.configureCalls) != 0 {
-		t.Errorf("expected no ConfigureBroker calls for HA integration, got %v", mgr.configureCalls)
+	if len(mgr.replaceConfigCalls) != 0 {
+		t.Errorf("expected no ReplaceBrokerConfig calls for HA integration, got %v", mgr.replaceConfigCalls)
 	}
 }
 

--- a/pkg/plugin/discovery.go
+++ b/pkg/plugin/discovery.go
@@ -44,6 +44,12 @@ func DiscoverPlugins(cfg PluginsConfig, pluginsDir string, logger *slog.Logger) 
 
 	// 1. From settings configuration
 	for name, entry := range cfg.Broker {
+		if entry.ConfigFile != "" {
+			if entry.Config == nil {
+				entry.Config = make(map[string]string)
+			}
+			entry.Config["config_file"] = entry.ConfigFile
+		}
 		if entry.SelfManaged {
 			discovered = append(discovered, DiscoveredPlugin{
 				Name:        name,

--- a/pkg/plugin/discovery_test.go
+++ b/pkg/plugin/discovery_test.go
@@ -262,6 +262,73 @@ func TestDiscoverPlugins_MixedModes(t *testing.T) {
 	assert.Equal(t, "localhost:9090", chat.Address)
 }
 
+func TestDiscoverPlugins_ConfigFilePropagated(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.Default()
+
+	brokerDir := filepath.Join(dir, "broker")
+	require.NoError(t, os.MkdirAll(brokerDir, 0755))
+	pluginPath := filepath.Join(brokerDir, "scion-plugin-telegram")
+	require.NoError(t, os.WriteFile(pluginPath, []byte("#!/bin/sh\n"), 0755))
+
+	cfg := PluginsConfig{
+		Broker: map[string]PluginEntry{
+			"telegram": {
+				ConfigFile: "/etc/scion/telegram.yaml",
+				Config:     map[string]string{"webhook_listen": ":9094"},
+			},
+		},
+	}
+
+	discovered := DiscoverPlugins(cfg, dir, logger)
+	require.Len(t, discovered, 1)
+	assert.Equal(t, "/etc/scion/telegram.yaml", discovered[0].Config["config_file"])
+	assert.Equal(t, ":9094", discovered[0].Config["webhook_listen"])
+}
+
+func TestDiscoverPlugins_ConfigFilePropagated_SelfManaged(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.Default()
+
+	cfg := PluginsConfig{
+		Broker: map[string]PluginEntry{
+			"googlechat": {
+				SelfManaged: true,
+				Address:     "localhost:9090",
+				ConfigFile:  "/etc/scion/googlechat.yaml",
+				Config:      map[string]string{"project_id": "my-project"},
+			},
+		},
+	}
+
+	discovered := DiscoverPlugins(cfg, dir, logger)
+	require.Len(t, discovered, 1)
+	assert.Equal(t, "/etc/scion/googlechat.yaml", discovered[0].Config["config_file"])
+	assert.Equal(t, "my-project", discovered[0].Config["project_id"])
+}
+
+func TestDiscoverPlugins_NoConfigFile_NoKey(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.Default()
+
+	brokerDir := filepath.Join(dir, "broker")
+	require.NoError(t, os.MkdirAll(brokerDir, 0755))
+	pluginPath := filepath.Join(brokerDir, "scion-plugin-nats")
+	require.NoError(t, os.WriteFile(pluginPath, []byte("#!/bin/sh\n"), 0755))
+
+	cfg := PluginsConfig{
+		Broker: map[string]PluginEntry{
+			"nats": {
+				Config: map[string]string{"url": "nats://localhost:4222"},
+			},
+		},
+	}
+
+	discovered := DiscoverPlugins(cfg, dir, logger)
+	require.Len(t, discovered, 1)
+	assert.Empty(t, discovered[0].Config["config_file"])
+}
+
 func TestDefaultPluginsDir(t *testing.T) {
 	dir, err := DefaultPluginsDir()
 	require.NoError(t, err)

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -153,6 +153,12 @@ func (m *Manager) LoadAll(cfg PluginsConfig, pluginsDir string) error {
 
 // LoadOne loads a single plugin by type and name from the given configuration.
 func (m *Manager) LoadOne(pluginType, name string, entry PluginEntry, pluginsDir string) error {
+	if entry.ConfigFile != "" {
+		if entry.Config == nil {
+			entry.Config = make(map[string]string)
+		}
+		entry.Config["config_file"] = entry.ConfigFile
+	}
 	if entry.ResolvedDeploymentMode() == DeploymentModeHA {
 		return m.loadGRPCPlugin(pluginType, name, entry)
 	}

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -492,6 +492,48 @@ func (m *Manager) ConfigureBroker(name string, extra map[string]string) error {
 	return rpcClient.Configure(merged)
 }
 
+// ReplaceBrokerConfig updates the stored config for a broker plugin and pushes
+// the exact cfg to the running plugin, with no underlay from boot-time config.
+func (m *Manager) ReplaceBrokerConfig(name string, cfg map[string]string) error {
+	key := PluginTypeBroker + ":" + name
+	m.mu.Lock()
+	if dp, ok := m.configs[key]; ok {
+		dp.Config = cfg
+		m.configs[key] = dp
+	}
+	m.mu.Unlock()
+
+	m.mu.RLock()
+	adapter, isGRPC := m.grpcAdapters[key]
+	m.mu.RUnlock()
+
+	if isGRPC {
+		return adapter.Configure(cfg)
+	}
+
+	m.mu.RLock()
+	raw, ok := m.dispensed[key]
+	m.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("broker plugin not loaded: %s", name)
+	}
+
+	rpcClient, ok := raw.(*BrokerRPCClient)
+	if !ok {
+		return fmt.Errorf("plugin %s is not a broker RPC client", name)
+	}
+
+	merged := make(map[string]string, len(cfg)+1)
+	for k, v := range cfg {
+		merged[k] = v
+	}
+	if rpcClient.hostCallbacksAvailable {
+		merged[hostCallbacksConfigKey] = "true"
+	}
+
+	return rpcClient.Configure(merged)
+}
+
 // GetPluginConfig returns a copy of the stored config map for the named plugin,
 // or nil if the plugin is not loaded. The returned map is safe to read without
 // affecting the manager's internal state.

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -720,7 +720,7 @@ func (m *Manager) UpdatePlugin(name string, repoPath string) error {
 
 // InstallPlugin builds a plugin binary from source and loads it into the manager.
 // Used for first-time installation of plugins not yet present on the system.
-func (m *Manager) InstallPlugin(name, repoPath, pluginsDir string) error {
+func (m *Manager) InstallPlugin(name, repoPath, pluginsDir, configFile string) error {
 	key := PluginTypeBroker + ":" + name
 	m.mu.RLock()
 	_, alreadyLoaded := m.clients[key]
@@ -757,7 +757,7 @@ func (m *Manager) InstallPlugin(name, repoPath, pluginsDir string) error {
 		return fmt.Errorf("go build failed for plugin %q: %w\n%s", name, err, string(output))
 	}
 
-	return m.LoadOne(PluginTypeBroker, name, PluginEntry{Path: targetPath}, pluginsDir)
+	return m.LoadOne(PluginTypeBroker, name, PluginEntry{Path: targetPath, ConfigFile: configFile}, pluginsDir)
 }
 
 // Shutdown kills all plugin processes gracefully.

--- a/pkg/plugin/manager_test.go
+++ b/pkg/plugin/manager_test.go
@@ -16,6 +16,8 @@ package plugin
 
 import (
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -184,6 +186,74 @@ func (m *mockHostCallbacks) CancelSubscription(pattern string) error {
 		return m.onCancel(pattern)
 	}
 	return nil
+}
+
+func TestGetPluginConfig_ConfigFilePropagated(t *testing.T) {
+	mgr := NewManager(nil)
+
+	mgr.mu.Lock()
+	mgr.configs["broker:telegram"] = DiscoveredPlugin{
+		Name: "telegram",
+		Type: PluginTypeBroker,
+		Config: map[string]string{
+			"config_file":    "/etc/scion/telegram.yaml",
+			"webhook_listen": ":9094",
+		},
+	}
+	mgr.mu.Unlock()
+
+	cfg := mgr.GetPluginConfig(PluginTypeBroker, "telegram")
+	require.NotNil(t, cfg)
+	assert.Equal(t, "/etc/scion/telegram.yaml", cfg["config_file"])
+	assert.Equal(t, ":9094", cfg["webhook_listen"])
+}
+
+func TestGetPluginConfig_NoConfigFile(t *testing.T) {
+	mgr := NewManager(nil)
+
+	mgr.mu.Lock()
+	mgr.configs["broker:nats"] = DiscoveredPlugin{
+		Name:   "nats",
+		Type:   PluginTypeBroker,
+		Config: map[string]string{"url": "nats://localhost:4222"},
+	}
+	mgr.mu.Unlock()
+
+	cfg := mgr.GetPluginConfig(PluginTypeBroker, "nats")
+	require.NotNil(t, cfg)
+	assert.Empty(t, cfg["config_file"])
+}
+
+func TestConfigFilePropagation_EndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.Default()
+
+	brokerDir := filepath.Join(dir, "broker")
+	require.NoError(t, os.MkdirAll(brokerDir, 0755))
+	pluginPath := filepath.Join(brokerDir, "scion-plugin-telegram")
+	require.NoError(t, os.WriteFile(pluginPath, []byte("#!/bin/sh\n"), 0755))
+
+	cfg := PluginsConfig{
+		Broker: map[string]PluginEntry{
+			"telegram": {
+				ConfigFile: "/etc/scion/telegram.yaml",
+				Config:     map[string]string{"webhook_listen": ":9094"},
+			},
+		},
+	}
+
+	discovered := DiscoverPlugins(cfg, dir, logger)
+	require.Len(t, discovered, 1)
+
+	mgr := NewManager(logger)
+	mgr.mu.Lock()
+	mgr.configs["broker:telegram"] = discovered[0]
+	mgr.mu.Unlock()
+
+	pluginCfg := mgr.GetPluginConfig(PluginTypeBroker, "telegram")
+	require.NotNil(t, pluginCfg)
+	assert.Equal(t, "/etc/scion/telegram.yaml", pluginCfg["config_file"],
+		"config_file must be propagated from PluginEntry through DiscoverPlugins to GetPluginConfig")
 }
 
 func TestManagerShutdown_SelfManagedTracking(t *testing.T) {


### PR DESCRIPTION
Config architecture fixes from audit of upstream main.

R0: config_file propagation into plugin manager (settings UI unblocked)
R1: Hub stops pushing config to HA integrations
R2: GET reads from correct provider
R3: Unified config precedence + inline secret migration

Related: issue #365