### PR TITLE
fix(web): correct AgentWithConfig interface extension

### DIFF
--- a/web/src/components/pages/agent-configure.ts
+++ b/web/src/components/pages/agent-configure.ts
@@ -65,7 +65,7 @@ interface AppliedConfig {
   };
 }
 
-interface AgentWithConfig extends Agent {
+interface AgentWithConfig extends Omit<Agent, 'appliedConfig'> {
   appliedConfig?: AppliedConfig;
 }
 


### PR DESCRIPTION
Fixes TS2430: Interface AgentWithConfig incorrectly extends interface Agent. Uses Omit to resolve the appliedConfig field conflict introduced by the model-ux PR