### PR TITLE
fix(web): add syntax highlighting for JSON and YAML in workspace file viewer

### DIFF
--- a/web/src/components/shared/file-browser.ts
+++ b/web/src/components/shared/file-browser.ts
@@ -415,6 +415,11 @@ function isMarkdownFile(filePath: string): boolean {
   return filePath.toLowerCase().endsWith('.md');
 }
 
+function isStructuredDataFile(filePath: string): boolean {
+  const ext = filePath.includes('.') ? '.' + filePath.split('.').pop()!.toLowerCase() : '';
+  return ['.json', '.yaml', '.yml'].includes(ext);
+}
+
 function isPreviewable(filePath: string): boolean {
   const ext = filePath.includes('.') ? '.' + filePath.split('.').pop()!.toLowerCase() : '';
   return PREVIEWABLE_EXTENSIONS.has(ext);
@@ -930,8 +935,8 @@ export class ScionFileBrowser extends LitElement {
 
   private handlePreview(filePath: string): void {
     if (!this.dataSource) return;
-    // Markdown files get inline preview via the editor component
-    if (isMarkdownFile(filePath)) {
+    // Markdown, JSON, and YAML files get inline preview via the editor component
+    if (isMarkdownFile(filePath) || isStructuredDataFile(filePath)) {
       this.dispatchEvent(
         new CustomEvent('file-preview-requested', {
           detail: { path: filePath },

--- a/web/src/components/shared/file-editor.ts
+++ b/web/src/components/shared/file-editor.ts
@@ -232,6 +232,13 @@ export class ScionFileEditor extends LitElement {
     return path.toLowerCase().endsWith('.md');
   }
 
+  /** Whether the current file is a structured data file (JSON/YAML). */
+  private get isStructuredData(): boolean {
+    const path = this.isNewFile ? this.newFileName : this.filePath;
+    const ext = path.includes('.') ? '.' + path.split('.').pop()!.toLowerCase() : '';
+    return ['.json', '.yaml', '.yml'].includes(ext);
+  }
+
   static override styles = css`
     :host {
       display: block;
@@ -487,7 +494,7 @@ export class ScionFileEditor extends LitElement {
               <scion-code-editor
                 .content=${this.currentContent}
                 .language=${getLanguageFromPath(this.isNewFile ? this.newFileName : this.filePath)}
-                ?readonly=${this.readonly}
+                ?readonly=${this.readonly || (this.showPreview && this.isStructuredData)}
                 @content-changed=${this.handleContentChanged}
               ></scion-code-editor>
             `}
@@ -543,7 +550,7 @@ export class ScionFileEditor extends LitElement {
                 </sl-button>
               `
             : nothing}
-          ${this.isMarkdown
+          ${this.isMarkdown || this.isStructuredData
             ? html`
                 <sl-button
                   size="small"


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/201 — JSON and YAML files now render with syntax highlighting in the workspace file viewer view-only mode, matching the existing Markdown rendering quality