### PR TITLE
feat(ha): introduce hub_name as Layer-1 operational setting, replace hostname-based hub identity

### DIFF
--- a/.design/hub-scope.md
+++ b/.design/hub-scope.md
@@ -1,0 +1,422 @@
+# Design: Hub Scope — Hub Name for HA Multi-Node Deployments
+
+**Issue:** [#392](https://github.com/ptone/scion/issues/392)
+**Status:** Draft
+**Author:** hs-arch agent
+**Date:** 2026-07-10
+
+## Summary
+
+Replace hostname-based hub identification with a configurable `hub_name` — a stable, human-readable identifier for a logical hub instance, independent of node hostnames. In HA deployments, all nodes share the same `hub_name`. Hostname is retained for node-level diagnostics only.
+
+---
+
+## 1. Current State
+
+### 1.1 Hub Identity Model
+
+The hub currently has two identity mechanisms:
+
+| Identifier | Source | Use |
+|---|---|---|
+| **HubID** | `SHA256(hostname)[:12]` or explicit config | Secret namespacing, telemetry resource attribute |
+| **InstanceID** | UUID (or POD_NAME + UUID) | Broker connection affinity, per-process tracking |
+
+Both are set at startup and immutable for the process lifetime.
+
+### 1.2 Hostname Used as Hub Identity
+
+`os.Hostname()` is called directly in 6 locations where it serves as a **hub-level** identifier:
+
+1. **Cloud Logging handler** (`pkg/util/logging/cloud_handler.go:118,189`) — `labels["hub"] = hostname`
+2. **GCP log handler** (`pkg/util/logging/gcp_handler.go:60,111-113`) — `labels["hub"] = hostname` and `labels["hostname"] = hostname`
+3. **Message log handler** (`pkg/util/logging/message_log.go:118-119`) — `labels["hub"] = hostname`
+4. **GCP Secret Manager** (`pkg/secret/gcpbackend.go:173,466-473`) — `scion-hub-hostname` label on secrets
+5. **Chat app** (`extras/scion-chat-app/cmd/scion-chat-app/main.go:453-462`) — key discovery by hostname label
+6. **Telemetry** (`pkg/observability/hubmetrics/hubmetrics.go:89-93`) — `scion.hub.id` defaults from HubID which defaults from hostname
+
+### 1.3 The HA Problem
+
+In a multi-node deployment behind a load balancer:
+- Each node has a different `os.Hostname()` (e.g., `hub-7f8b4-abc`, `hub-7f8b4-def`)
+- Log labels diverge: filtering by `hub=hub-7f8b4-abc` misses logs from `hub-7f8b4-def`
+- GCP secrets get different `scion-hub-hostname` labels depending on which node created them
+- HubID diverges unless explicitly configured the same on all nodes
+- Telemetry metrics scatter across different `scion.hub.id` resource attribute values
+
+### 1.4 Hostname Used Correctly (Node-Level)
+
+These uses are **node-level** and should remain unchanged:
+- Broker join request hostname (`pkg/hubclient/runtime_brokers.go:221`)
+- Broker status display (`cmd/broker.go:1418`)
+- Broker name default (`cmd/project.go:389`, `pkg/hubsync/sync.go:1236`)
+- Apple DNS configuration (`pkg/hub/system_handlers.go:1006`)
+
+---
+
+## 2. Hub Name Mechanism
+
+### 2.1 Definition
+
+Introduce `hub_name` — a stable, human-readable identifier for a logical hub.
+
+```yaml
+# settings.yaml
+server:
+  hub:
+    hub_name: "production"
+```
+
+### 2.2 Properties
+
+| Property | Value |
+|---|---|
+| **Type** | string |
+| **Constraints** | Lowercase alphanumeric + hyphens, 1-63 chars, must start with a letter, must not end with a hyphen (DNS-label-safe) |
+| **Default** | `os.Hostname()` (backward compatible with current behavior) |
+| **Uniqueness** | Not enforced — operator responsibility (like `hub_id`) |
+| **Immutability** | Mutable via admin API (Layer-1), but changes should be rare |
+
+### 2.3 Naming Constraints Rationale
+
+DNS-label rules (RFC 1123) are chosen because the hub name may appear in:
+- GCP resource labels (max 63 chars, lowercase alphanumeric + hyphens)
+- Cloud Monitoring metric labels (same constraints)
+- Log filter queries (special characters complicate filtering)
+- URLs in future federation scenarios
+
+### 2.4 Resolution Order
+
+```
+env var (SCION_SERVER_HUB_HUB_NAME) > DB (hub_settings.endpoints) > settings.yaml > os.Hostname()
+```
+
+This follows the standard Layer-1 precedence from the settings-db design (§3.4).
+
+---
+
+## 3. Settings Integration
+
+### 3.1 Layer Classification
+
+| Setting | Layer | Rationale |
+|---|---|---|
+| `hub_id` | **Layer-0** (unchanged) | Needed for secret backend init before DB. Machine-readable. |
+| `hub_name` | **Layer-1** (new) | Human-readable display identifier. Not needed at bootstrap. Can be synced across replicas via DB. |
+
+### 3.2 Why Layer-1 for hub_name
+
+The `hub_name` is used in:
+- Log labels (set after handlers are created, can be hot-reloaded)
+- Telemetry attributes (set after OTel provider init — could be plumbed)
+- GCP Secret Manager labels (only on write, not on read/key derivation)
+- Admin UI (runtime display)
+- API responses (runtime)
+
+None of these are in the bootstrap path. The one concern — log handler initialization — can be addressed by:
+1. Initializing log handlers with `os.Hostname()` as default
+2. Overwriting the hub label once DB-sourced `hub_name` is resolved
+3. This means a brief window at startup where logs carry hostname instead of hub_name — acceptable since the hub is already starting up
+
+### 3.3 Operational Settings Registration
+
+Add `hub_name` to the existing `endpoints` section:
+
+```go
+// pkg/config/opsettings/registry.go
+{
+    Name:       "endpoints",
+    KoanfPaths: []string{"server.hub.public_url", "server.hub.hub_name", "image_registry"},
+    New:        func() any { return &EndpointsSettings{} },
+},
+```
+
+```go
+// pkg/config/opsettings/sections.go
+type EndpointsSettings struct {
+    PublicURL     string `json:"public_url,omitempty"`
+    HubName       string `json:"hub_name,omitempty"`
+    ImageRegistry string `json:"image_registry,omitempty"`
+}
+```
+
+### 3.4 Config Structs
+
+```go
+// pkg/config/settings_v1.go — V1ServerHubConfig
+type V1ServerHubConfig struct {
+    // ... existing fields ...
+    HubName  string `json:"hub_name,omitempty" yaml:"hub_name,omitempty" koanf:"hub_name"`
+}
+```
+
+```go
+// pkg/config/hub_config.go — HubServerConfig
+type HubServerConfig struct {
+    // ... existing fields ...
+    HubName string `json:"hubName" yaml:"hubName" koanf:"hubName"`
+}
+```
+
+### 3.5 Environment Variable
+
+```
+SCION_SERVER_HUB_HUBNAME → server.hub.hubName
+```
+
+Added to `envKeyToConfigKey` in `hub_config.go`.
+
+### 3.6 Layer1Snapshot Extension
+
+```go
+// pkg/hub/operational_settings.go — Layer1Snapshot
+type Layer1Snapshot struct {
+    // ... existing fields ...
+
+    // Endpoints
+    PublicURL     string
+    HubName       string  // NEW
+    ImageRegistry string
+}
+```
+
+### 3.7 Schema Extension
+
+Add to `settings-v1.schema.json` under `server.hub`:
+
+```json
+"hub_name": {
+    "type": "string",
+    "pattern": "^[a-z][a-z0-9-]{0,61}[a-z0-9]$",
+    "description": "Human-readable hub identifier for HA deployments. All nodes in a cluster should share the same hub_name.",
+    "x-env-var": "SCION_SERVER_HUB_HUBNAME",
+    "x-scope": "global"
+}
+```
+
+---
+
+## 4. Migration Strategy
+
+### 4.1 Backward Compatibility (Single-Node)
+
+When `hub_name` is not explicitly set:
+- Default to `os.Hostname()` (matching current behavior)
+- Existing single-node deployments see no change in log labels or metrics
+- No migration action required
+
+### 4.2 HA Deployments
+
+Operators setting up HA should:
+1. Choose a hub name (e.g., `"production"`, `"staging"`, `"dev-hub"`)
+2. Set it via one of:
+   - Admin API: `PUT /api/v1/admin/server-config` with `{"hub_name": "production"}` in the endpoints section
+   - Environment variable: `SCION_SERVER_HUB_HUBNAME=production` (on all nodes)
+   - Settings file: `server.hub.hub_name: production` in `settings.yaml`
+
+In Postgres mode, the DB value propagates automatically to all replicas. In file mode, operators must configure each node.
+
+### 4.3 hub_id Alignment
+
+Operators deploying HA should also set `hub_id` explicitly to the same value on all nodes (it's Layer-0, so must be in config/env). This is already the case today — the new `hub_name` doesn't change this requirement.
+
+Recommendation: document that `hub_id` should be set explicitly in HA deployments. A future enhancement could auto-derive `hub_id` from `hub_name` when `hub_name` is set and `hub_id` is not.
+
+### 4.4 GCP Secret Label Migration
+
+Existing secrets in GCP Secret Manager have `scion-hub-hostname` labels with per-node hostnames. After adopting `hub_name`:
+- New secrets get `scion-hub-name` (the hub_name) instead of `scion-hub-hostname`
+- Existing secrets retain their old labels (immutable after creation in GCP SM)
+- No automated migration needed — labels are informational, not used for lookup (secret names use HubID for scoping)
+- Operators can re-label via GCP console/API if desired
+
+---
+
+## 5. Surface Areas — Detailed Change Plan
+
+### 5.1 Logging Labels
+
+**Files:**
+- `pkg/util/logging/cloud_handler.go`
+- `pkg/util/logging/gcp_handler.go`
+- `pkg/util/logging/message_log.go`
+
+**Change:** Replace `hostname` field with `hubName` field. The `"hub"` label emits `hub_name` instead of hostname. Add a separate `"node"` label with hostname for node-level identification.
+
+```go
+// Before:
+labels["hub"] = h.hostname
+
+// After:
+labels["hub"] = h.hubName
+labels["node"] = h.hostname  // new: node-level identity
+```
+
+**Plumbing:** The log handlers are initialized in `cmd/server_foreground.go`. Add a `hubName` parameter. At startup, use `os.Hostname()` as default; once `Layer1Snapshot` is available (after DB init), update the hub name.
+
+Since log handlers are immutable once created (slog.Handler is an interface without setters), the hub name must be resolved before handler creation. In Postgres mode, the startup sequence is:
+1. Load config → resolve `hub_name` from file/env
+2. Connect to DB → load Layer-1 settings → may override `hub_name`
+3. Create log handlers with resolved `hub_name`
+
+This works because log handlers are created AFTER DB init in `cmd/server_foreground.go`. For the brief early logging before handlers are created, Go's default logger uses stderr with no hub label — acceptable.
+
+### 5.2 Telemetry — OTel Resource Attributes
+
+**File:** `pkg/observability/hubmetrics/hubmetrics.go`
+
+**Change:** Add `scion.hub.name` resource attribute alongside existing `scion.hub.id`.
+
+```go
+if o.hubName != "" {
+    resAttrs = append(resAttrs, attribute.String("scion.hub.name", o.hubName))
+}
+```
+
+Add `WithHubName(name string) Option` function.
+
+### 5.3 GCP Secret Manager Labels
+
+**File:** `pkg/secret/gcpbackend.go`
+
+**Change:** Replace `scion-hub-hostname` label with `scion-hub-name`. Pass hub_name into the backend instead of calling `os.Hostname()`.
+
+```go
+// Before:
+"scion-hub-hostname": sanitizeLabel(hubHostname),
+
+// After:
+"scion-hub-name": sanitizeLabel(hubName),
+"scion-hub-node": sanitizeLabel(hostname),  // optional: keep node identity
+```
+
+Plumb `hubName` into `GCPBackend` via constructor or setter.
+
+### 5.4 Admin UI
+
+The admin settings UI already displays hub configuration. `hub_name` should appear in:
+- Server info panel (alongside hub_id)
+- Admin settings "endpoints" section (editable)
+
+The web frontend already renders Layer-1 sections from the admin settings API response. No custom UI work needed — the field will appear automatically when added to the endpoints schema.
+
+### 5.5 API Responses
+
+**Hub info endpoint:** Add `hub_name` to the response of any system info or health endpoints. The existing `hub_id` stays.
+
+**Agent metadata:** When agents receive hub info (via dispatch or status endpoints), include `hub_name` for display purposes.
+
+### 5.6 ServerConfig Propagation
+
+**File:** `pkg/hub/server.go`
+
+Add `HubName string` to `ServerConfig`. Wire it through `ApplySnapshot()` in `operational_settings.go`:
+
+```go
+// In ApplySnapshot:
+if snap.HubName != "" {
+    s.config.HubName = snap.HubName
+    applied = append(applied, "hub_name")
+}
+```
+
+### 5.7 Chat App (Extras)
+
+**File:** `extras/scion-chat-app/cmd/scion-chat-app/main.go`
+
+Replace `scion-hub-hostname` label matching with `scion-hub-name`. This is a follow-up item — the chat app is in `extras/` and may lag behind core changes.
+
+---
+
+## 6. Phased Implementation Plan
+
+### Phase 1: Config Foundation (Small, No Behavior Change)
+
+**Goal:** Add `hub_name` to config structs, schema, and settings architecture without changing any runtime behavior.
+
+**Changes:**
+1. Add `HubName` field to `V1ServerHubConfig` (`settings_v1.go`)
+2. Add `HubName` field to `HubServerConfig` (`hub_config.go`)
+3. Add `ResolveHubName()` method that returns HubName or falls back to `os.Hostname()`
+4. Add `hub_name` to settings-v1 JSON schema
+5. Add `hubname` to `envKeyToConfigKey` mapping
+6. Add `hub_name` to the `endpoints` opsettings section
+7. Add `HubName` to `Layer1Snapshot`
+8. Add `hub_name` to `ConvertV1ServerToGlobalConfig` and `ConvertGlobalConfigToV1Server`
+9. Wire `hub_name` through `buildSnapshotFromKoanf`
+
+**Tests:** Config loading, V1 conversion, schema validation, opsettings section registration.
+
+### Phase 2: Server Plumbing
+
+**Goal:** Make hub_name available throughout the hub server.
+
+**Changes:**
+1. Add `HubName string` to `hub.ServerConfig`
+2. Set `HubName` in `cmd/server_foreground.go` from resolved config
+3. Add `HubName()` accessor to `hub.Server`
+4. Wire through `ApplySnapshot()` for runtime updates
+5. Add `WithHubName()` option to `hubmetrics`
+6. Pass `hubName` to secret backend constructor
+
+**Tests:** Server initialization, snapshot application.
+
+### Phase 3: Surface Area Migration
+
+**Goal:** Replace hostname with hub_name in all hub-level identity sites.
+
+**Changes:**
+1. **Logging handlers** — replace `hostname` field with `hubName`, add `hostname` as `"node"` label
+2. **Telemetry** — add `scion.hub.name` resource attribute
+3. **GCP Secret Manager** — replace `scion-hub-hostname` with `scion-hub-name` label
+4. **Admin API** — include `hub_name` in server info responses
+
+**Tests:** Log label verification, telemetry attribute verification, GCP label verification.
+
+### Phase 4: Documentation and Chat App
+
+**Goal:** Document the migration path and update extras.
+
+**Changes:**
+1. Update HA deployment documentation
+2. Add `hub_name` to workstation onboarding wizard defaults
+3. Update chat app to use `scion-hub-name` label (extras)
+4. Add migration guide for existing HA deployments
+
+---
+
+## 7. Open Questions
+
+### 7.1 Layer-0 vs Layer-1 for hub_name (RAISED WITH USER)
+
+**Recommendation:** Layer-1 (operational). The hub_name is not needed in the bootstrap path. It's used for display/correlation contexts that are all initialized after DB is available. See §3.2 for analysis.
+
+**Risk:** If a future feature needs hub_name before DB init, it would need to fall back to config/env — which the Layer-1 precedence chain already supports.
+
+### 7.2 Naming: hub_name vs hub_slug (RAISED WITH USER)
+
+**Recommendation:** `hub_name` — more natural in YAML config, familiar pattern from `broker_nickname`. Apply slug-like constraints (DNS-label-safe) to the value.
+
+### 7.3 Should hub_id Auto-Derive from hub_name?
+
+Currently `hub_id` defaults to `SHA256(hostname)[:12]`. If `hub_name` is set, should `hub_id` default to `SHA256(hub_name)[:12]` instead?
+
+**Recommendation:** Not in the initial implementation. This creates a coupling where changing `hub_name` (Layer-1, easy to change) silently changes `hub_id` (Layer-0, hard to change), which would orphan secrets. Keep them independent. Document that operators should set `hub_id` explicitly in HA.
+
+### 7.4 Log Handler Hot-Reload
+
+slog.Handler instances are immutable. If `hub_name` changes via admin API (Layer-1), existing log handlers continue emitting the old name until the process restarts.
+
+**Recommendation:** Accept this limitation. `hub_name` changes are rare. Document that log label updates require a rolling restart. A future enhancement could use an atomic string pointer for the hub label, but this adds complexity for a rare operation.
+
+### 7.5 Relationship to Node Registry (#386)
+
+Issue #386 proposes a node-level diagnostics endpoint with a node registry and heartbeat. The `"node"` label added in Phase 3 complements this — each node's hostname provides node-level identity while `hub_name` provides hub-level identity.
+
+**Recommendation:** Implement #392 (this design) first. The `"node"` label in logs provides immediate value. #386's node registry can build on this later.
+
+### 7.6 Endpoint Section vs New Section
+
+Should `hub_name` go in the existing `endpoints` section or get its own `identity` section?
+
+**Recommendation:** Use `endpoints`. The field is small, related to hub surface area, and adding a new section for one field adds unnecessary complexity. If hub identity grows (e.g., hub description, hub icon), a dedicated section can be created later.

--- a/.design/hub-scope.md
+++ b/.design/hub-scope.md
@@ -256,8 +256,10 @@ Operators deploying HA should set `hub_id` explicitly to the same value on all n
 Existing secrets in GCP Secret Manager have `scion-hub-hostname` labels with per-node hostnames. After adopting `hub_name`:
 - New secrets get `scion-hub-name` (the hub_name) instead of `scion-hub-hostname`
 - Existing secrets retain their old labels (immutable after creation in GCP SM)
-- No automated migration needed — labels are informational, not used for lookup (secret names use HubID for scoping)
+- No automated migration needed for the hub itself — labels are informational, not used for lookup (secret names use HubID for scoping)
 - Operators can re-label via GCP console/API if desired
+
+**Exception: Chat App.** The chat app (`extras/scion-chat-app`) uses label-based discovery via `ListSecrets` with a filter to auto-discover the hub signing key. Unlike the hub, which looks up secrets by computed name, the chat app queries `labels.scion-hub-name=X`. To maintain backward compatibility with secrets created under the old `scion-hub-hostname` label, the chat app uses an OR filter: `(labels.scion-hub-name=X OR labels.scion-hub-hostname=X)`. This ensures discovery works for both pre-upgrade and post-upgrade secrets without requiring manual relabeling.
 
 ---
 

--- a/.design/hub-scope.md
+++ b/.design/hub-scope.md
@@ -1,13 +1,19 @@
-# Design: Hub Scope — Hub Name for HA Multi-Node Deployments
+# Design: Hub Scope — Two-Identifier Hub Identity for HA Multi-Node Deployments
 
 **Issue:** [#392](https://github.com/ptone/scion/issues/392)
-**Status:** Draft
-**Author:** hs-arch agent
+**Status:** Approved
+**Author:** hs-arch agent (refined by hs-em per user direction)
 **Date:** 2026-07-10
 
 ## Summary
 
-Replace hostname-based hub identification with a configurable `hub_name` — a stable, human-readable identifier for a logical hub instance, independent of node hostnames. In HA deployments, all nodes share the same `hub_name`. Hostname is retained for node-level diagnostics only.
+Introduce a two-identifier hub identity model:
+
+1. **hub_id (Layer-0, immutable):** Machine-readable identity for secret namespacing, telemetry, and infrastructure. Currently defaults to `SHA256(hostname)[:12]` (hex). **Refined:** accept any unique string slug as hub_id (not just hex), keeping hex as the suggested default. Changing hub_id effectively creates a new hub (orphans secrets, etc.).
+
+2. **hub_name (Layer-1, mutable):** A new human-readable display name for the hub. Mutable via admin API, synced across replicas. Used in user-facing UI, log labels, and display contexts. Defaults to `os.Hostname()` for backward compatibility.
+
+Hostname is retained for node-level diagnostics only.
 
 ---
 
@@ -19,7 +25,7 @@ The hub currently has two identity mechanisms:
 
 | Identifier | Source | Use |
 |---|---|---|
-| **HubID** | `SHA256(hostname)[:12]` or explicit config | Secret namespacing, telemetry resource attribute |
+| **HubID** | `SHA256(hostname)[:12]` or any explicit string slug | Secret namespacing, telemetry resource attribute |
 | **InstanceID** | UUID (or POD_NAME + UUID) | Broker connection affinity, per-process tracking |
 
 Both are set at startup and immutable for the process lifetime.
@@ -95,13 +101,36 @@ This follows the standard Layer-1 precedence from the settings-db design (§3.4)
 
 ---
 
+## 2b. Hub ID Flexibility (User Refinement)
+
+### 2b.1 Current State
+
+`hub_id` currently defaults to `SHA256(hostname)[:12]` — a 12-character hex string. The `DefaultHubID()` function in `hub_config.go` enforces this format.
+
+### 2b.2 Refinement
+
+Allow `hub_id` to be set as **any unique string slug**, not just hex. The hex value remains the **suggested default** when no explicit value is provided, but operators can set descriptive slugs like `"prod-hub-west"` or `"staging"`.
+
+### 2b.3 Changes Required
+
+1. **Remove hex-only assumption:** `DefaultHubID()` continues to return hex, but explicit values are no longer validated as hex
+2. **Validation:** Apply the same DNS-label-safe constraints as `hub_name` (lowercase alphanumeric + hyphens, 1-63 chars) to ensure compatibility with GCP labels and secret namespacing
+3. **Schema:** Update the `hub_id` schema entry to reflect the relaxed format constraint
+4. **Documentation:** Note that changing `hub_id` orphans existing secrets and effectively creates a new hub
+
+### 2b.4 Immutability Note
+
+`hub_id` remains Layer-0 (bootstrap). It cannot be changed via admin API. Changing it in config/env and restarting effectively creates a new logical hub — existing GCP secrets namespaced under the old hub_id become orphaned.
+
+---
+
 ## 3. Settings Integration
 
 ### 3.1 Layer Classification
 
 | Setting | Layer | Rationale |
 |---|---|---|
-| `hub_id` | **Layer-0** (unchanged) | Needed for secret backend init before DB. Machine-readable. |
+| `hub_id` | **Layer-0** (unchanged) | Needed for secret backend init before DB. Machine-readable. Now accepts any string slug (not just hex). |
 | `hub_name` | **Layer-1** (new) | Human-readable display identifier. Not needed at bootstrap. Can be synced across replicas via DB. |
 
 ### 3.2 Why Layer-1 for hub_name
@@ -218,9 +247,9 @@ In Postgres mode, the DB value propagates automatically to all replicas. In file
 
 ### 4.3 hub_id Alignment
 
-Operators deploying HA should also set `hub_id` explicitly to the same value on all nodes (it's Layer-0, so must be in config/env). This is already the case today — the new `hub_name` doesn't change this requirement.
+Operators deploying HA should set `hub_id` explicitly to the same value on all nodes (it's Layer-0, so must be in config/env). With the relaxed format, operators can now use descriptive slugs like `"prod-hub"` instead of opaque hex strings. If not set, the default remains `SHA256(hostname)[:12]`.
 
-Recommendation: document that `hub_id` should be set explicitly in HA deployments. A future enhancement could auto-derive `hub_id` from `hub_name` when `hub_name` is set and `hub_id` is not.
+**Important:** Changing `hub_id` orphans existing secrets. In HA deployments, all nodes must share the same `hub_id`.
 
 ### 4.4 GCP Secret Label Migration
 
@@ -330,9 +359,9 @@ Replace `scion-hub-hostname` label matching with `scion-hub-name`. This is a fol
 
 ## 6. Phased Implementation Plan
 
-### Phase 1: Config Foundation (Small, No Behavior Change)
+### Phase 1: Config Foundation (No Behavior Change)
 
-**Goal:** Add `hub_name` to config structs, schema, and settings architecture without changing any runtime behavior.
+**Goal:** Add `hub_name` to config structs, schema, and settings. Update `hub_id` to accept any unique string slug. No runtime behavior changes.
 
 **Changes:**
 1. Add `HubName` field to `V1ServerHubConfig` (`settings_v1.go`)
@@ -344,6 +373,8 @@ Replace `scion-hub-hostname` label matching with `scion-hub-name`. This is a fol
 7. Add `HubName` to `Layer1Snapshot`
 8. Add `hub_name` to `ConvertV1ServerToGlobalConfig` and `ConvertGlobalConfigToV1Server`
 9. Wire `hub_name` through `buildSnapshotFromKoanf`
+10. Update `hub_id` schema to accept any string slug (relax hex-only constraint)
+11. Update `hub_id` documentation/comments to reflect slug flexibility
 
 **Tests:** Config loading, V1 conversion, schema validation, opsettings section registration.
 
@@ -401,7 +432,7 @@ Replace `scion-hub-hostname` label matching with `scion-hub-name`. This is a fol
 
 Currently `hub_id` defaults to `SHA256(hostname)[:12]`. If `hub_name` is set, should `hub_id` default to `SHA256(hub_name)[:12]` instead?
 
-**Recommendation:** Not in the initial implementation. This creates a coupling where changing `hub_name` (Layer-1, easy to change) silently changes `hub_id` (Layer-0, hard to change), which would orphan secrets. Keep them independent. Document that operators should set `hub_id` explicitly in HA.
+**Decision:** No. Keep them independent. hub_id is now flexible (accepts any slug), so operators can choose a descriptive value directly. Auto-deriving would create dangerous coupling where changing `hub_name` (Layer-1, easy) silently changes `hub_id` (Layer-0, hard), orphaning secrets.
 
 ### 7.4 Log Handler Hot-Reload
 

--- a/.design/hub-scope.md
+++ b/.design/hub-scope.md
@@ -216,7 +216,7 @@ Add to `settings-v1.schema.json` under `server.hub`:
 ```json
 "hub_name": {
     "type": "string",
-    "pattern": "^[a-z][a-z0-9-]{0,61}[a-z0-9]$",
+    "pattern": "^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$",
     "description": "Human-readable hub identifier for HA deployments. All nodes in a cluster should share the same hub_name.",
     "x-env-var": "SCION_SERVER_HUB_HUBNAME",
     "x-scope": "global"

--- a/.design/hub-scope.md
+++ b/.design/hub-scope.md
@@ -316,8 +316,9 @@ Add `WithHubName(name string) Option` function.
 
 // After:
 "scion-hub-name": sanitizeLabel(hubName),
-"scion-hub-node": sanitizeLabel(hostname),  // optional: keep node identity
 ```
+
+The optional `scion-hub-node` label for node-level identity on secrets was deferred — secret labels are informational and node identity is not needed for secret filtering.
 
 Plumb `hubName` into `GCPBackend` via constructor or setter.
 

--- a/.design/hub-scope.md
+++ b/.design/hub-scope.md
@@ -1,7 +1,7 @@
 # Design: Hub Scope — Two-Identifier Hub Identity for HA Multi-Node Deployments
 
 **Issue:** [#392](https://github.com/ptone/scion/issues/392)
-**Status:** Approved
+**Status:** Implemented
 **Author:** hs-arch agent (refined by hs-em per user direction)
 **Date:** 2026-07-10
 

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -250,6 +250,7 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 		if cfg.Hub.GCPProjectID != "" {
 			mp, mpErr := hubmetrics.NewMeterProvider(ctx, cfg.Hub.GCPProjectID,
 				hubmetrics.WithHubID(hubSrv.HubID()),
+				hubmetrics.WithHubName(cfg.Hub.ResolveHubName()),
 			)
 			if mpErr != nil {
 				log.Printf("WARNING: hub metrics export disabled: %v", mpErr)
@@ -549,6 +550,8 @@ func initServerLogging(cmd *cobra.Command) (cleanups []func(), requestLogger *sl
 		component = "scion-broker"
 	}
 
+	hubName := resolveHubNameFromEnv()
+
 	// Initialize OTel logging
 	ctx := context.Background()
 	logProvider, logCleanup, otelErr := logging.InitOTelLogging(ctx, logging.OTelConfig{})
@@ -568,6 +571,7 @@ func initServerLogging(cmd *cobra.Command) (cleanups []func(), requestLogger *sl
 		logLevel := logging.ResolveLogLevel(enableDebug)
 		cfg := logging.CloudLoggingConfig{
 			Component: component,
+			HubName:   hubName,
 		}
 		ch, cloudLogCleanup, cloudErr := logging.NewCloudHandler(ctx, cfg, logLevel)
 		if cloudErr != nil {
@@ -584,12 +588,13 @@ func initServerLogging(cmd *cobra.Command) (cleanups []func(), requestLogger *sl
 		}
 	}
 
-	logging.SetupWithOTel(component, enableDebug, useGCP, logProvider, cloudHandler)
+	logging.SetupWithOTel(component, hubName, enableDebug, useGCP, logProvider, cloudHandler)
 
 	// Initialize request logger
 	reqLogCfg := logging.RequestLoggerConfig{
 		FilePath:   os.Getenv(logging.EnvRequestLogPath),
 		Component:  component,
+		HubName:    hubName,
 		UseGCP:     useGCP,
 		Foreground: serverStartForeground,
 		Level:      logging.ResolveLogLevel(enableDebug),
@@ -611,6 +616,7 @@ func initServerLogging(cmd *cobra.Command) (cleanups []func(), requestLogger *sl
 	// Initialize message logger
 	msgLogCfg := logging.MessageLoggerConfig{
 		Component: component,
+		HubName:   hubName,
 		UseGCP:    useGCP,
 		Level:     logging.ResolveLogLevel(enableDebug),
 	}
@@ -1096,6 +1102,20 @@ func parseAdminEmails(cfg *config.GlobalConfig) []string {
 		log.Printf("Admin emails configured: %v", adminEmailList)
 	}
 	return adminEmailList
+}
+
+// resolveHubNameFromEnv resolves the hub display name from the SCION_HUB_NAME
+// environment variable, falling back to os.Hostname(). This is used during
+// early logging init before the full config is loaded.
+func resolveHubNameFromEnv() string {
+	if v := os.Getenv("SCION_HUB_NAME"); v != "" {
+		return v
+	}
+	h, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+	return h
 }
 
 // resolveSessionSecret resolves the deployment-wide session secret from the

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -229,6 +229,9 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 		if sbErr != nil {
 			log.Printf("Warning: failed to initialize secret backend: %v", sbErr)
 		}
+		if gcpBackend, ok := secretBackend.(*secret.GCPBackend); ok {
+			gcpBackend.SetHubName(cfg.Hub.ResolveHubName())
+		}
 	}
 
 	// 10b. Initialize plugin manager

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1109,14 +1109,14 @@ func parseAdminEmails(cfg *config.GlobalConfig) []string {
 
 // resolveHubNameFromEnv resolves the hub display name from environment variables,
 // falling back to os.Hostname(). This is used during early logging init before
-// the full config is loaded. Both SCION_HUB_NAME and the koanf-style
-// SCION_SERVER_HUB_HUBNAME are accepted so that operators setting either one
-// get consistent behavior across early logging and config-driven code paths.
+// the full config is loaded. SCION_SERVER_HUB_HUBNAME (the standard koanf-derived
+// name) takes precedence; SCION_HUB_NAME is accepted as a shorter fallback for
+// simple setups.
 func resolveHubNameFromEnv() string {
-	if v := os.Getenv("SCION_HUB_NAME"); v != "" {
+	if v := os.Getenv("SCION_SERVER_HUB_HUBNAME"); v != "" {
 		return v
 	}
-	if v := os.Getenv("SCION_SERVER_HUB_HUBNAME"); v != "" {
+	if v := os.Getenv("SCION_HUB_NAME"); v != "" {
 		return v
 	}
 	h, err := os.Hostname()

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1107,11 +1107,16 @@ func parseAdminEmails(cfg *config.GlobalConfig) []string {
 	return adminEmailList
 }
 
-// resolveHubNameFromEnv resolves the hub display name from the SCION_HUB_NAME
-// environment variable, falling back to os.Hostname(). This is used during
-// early logging init before the full config is loaded.
+// resolveHubNameFromEnv resolves the hub display name from environment variables,
+// falling back to os.Hostname(). This is used during early logging init before
+// the full config is loaded. Both SCION_HUB_NAME and the koanf-style
+// SCION_SERVER_HUB_HUBNAME are accepted so that operators setting either one
+// get consistent behavior across early logging and config-driven code paths.
 func resolveHubNameFromEnv() string {
 	if v := os.Getenv("SCION_HUB_NAME"); v != "" {
+		return v
+	}
+	if v := os.Getenv("SCION_SERVER_HUB_HUBNAME"); v != "" {
 		return v
 	}
 	h, err := os.Hostname()

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1121,6 +1121,7 @@ func resolveSessionSecret() string {
 func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store, entClient *ent.Client, hubEndpoint, devAuthToken string, adminEmailList []string, adminMode bool, maintenanceMessage string, requestLogger, messageLogger *slog.Logger, globalDir string, pluginMgr *scionplugin.Manager, secretBackend secret.SecretBackend) (*hub.Server, error) {
 	hubCfg := hub.ServerConfig{
 		HubID:                 cfg.Hub.ResolveHubID(),
+		HubName:               cfg.Hub.ResolveHubName(),
 		Port:                  cfg.Hub.Port,
 		Host:                  cfg.Hub.Host,
 		ReadTimeout:           cfg.Hub.ReadTimeout,

--- a/extras/scion-chat-app/cmd/scion-chat-app/main.go
+++ b/extras/scion-chat-app/cmd/scion-chat-app/main.go
@@ -465,8 +465,8 @@ func discoverSigningKey(ctx context.Context, projectID string) (value, resourceN
 	hubNameLabel := strings.ToLower(hubName)
 
 	filter := fmt.Sprintf(
-		"labels.scion-name=user_signing_key AND labels.scion-hub-name=%s",
-		hubNameLabel,
+		"labels.scion-name=user_signing_key AND (labels.scion-hub-name=%s OR labels.scion-hub-hostname=%s)",
+		hubNameLabel, hubNameLabel,
 	)
 
 	slog.Debug("searching Secret Manager for signing key",
@@ -494,7 +494,7 @@ func discoverSigningKey(ctx context.Context, projectID string) (value, resourceN
 	}
 
 	if len(candidates) == 0 {
-		return "", "", fmt.Errorf("no secret with labels scion-name=user_signing_key, scion-hub-name=%s found in project %s", hubNameLabel, projectID)
+		return "", "", fmt.Errorf("no secret with labels scion-name=user_signing_key, scion-hub-name=%s or scion-hub-hostname=%s found in project %s", hubNameLabel, hubNameLabel, projectID)
 	}
 
 	// Pick the best candidate using a scoring heuristic. The hub's current

--- a/extras/scion-chat-app/cmd/scion-chat-app/main.go
+++ b/extras/scion-chat-app/cmd/scion-chat-app/main.go
@@ -439,8 +439,8 @@ func loadConfig(path string) (*chatapp.Config, error) {
 // scion-hub-name matching the hub name, which uniquely identifies
 // the hub in a multi-hub project.
 //
-// The hub name is resolved from the SCION_HUB_NAME environment variable,
-// falling back to os.Hostname().
+// The hub name is resolved from SCION_SERVER_HUB_HUBNAME (the standard
+// koanf-derived name), then SCION_HUB_NAME, falling back to os.Hostname().
 //
 // When multiple secrets match (e.g. after a hub migration that left a stale
 // secret behind), the function prefers a secret with scion-type=internal
@@ -453,7 +453,12 @@ func discoverSigningKey(ctx context.Context, projectID string) (value, resourceN
 	}
 	defer client.Close()
 
-	hubName := os.Getenv("SCION_HUB_NAME")
+	// SCION_SERVER_HUB_HUBNAME (koanf-derived) takes precedence;
+	// SCION_HUB_NAME is a shorter fallback for simple setups.
+	hubName := os.Getenv("SCION_SERVER_HUB_HUBNAME")
+	if hubName == "" {
+		hubName = os.Getenv("SCION_HUB_NAME")
+	}
 	if hubName == "" {
 		h, err := os.Hostname()
 		if err != nil {

--- a/extras/scion-chat-app/cmd/scion-chat-app/main.go
+++ b/extras/scion-chat-app/cmd/scion-chat-app/main.go
@@ -436,8 +436,11 @@ func loadConfig(path string) (*chatapp.Config, error) {
 
 // discoverSigningKey searches GCP Secret Manager for a secret matching the
 // local hub instance. It filters by scion-name=user_signing_key and
-// scion-hub-hostname matching the local hostname, which uniquely identifies
+// scion-hub-name matching the hub name, which uniquely identifies
 // the hub in a multi-hub project.
+//
+// The hub name is resolved from the SCION_HUB_NAME environment variable,
+// falling back to os.Hostname().
 //
 // When multiple secrets match (e.g. after a hub migration that left a stale
 // secret behind), the function prefers a secret with scion-type=internal
@@ -450,16 +453,20 @@ func discoverSigningKey(ctx context.Context, projectID string) (value, resourceN
 	}
 	defer client.Close()
 
-	hostname, err := os.Hostname()
-	if err != nil {
-		return "", "", fmt.Errorf("getting hostname for label match: %w", err)
+	hubName := os.Getenv("SCION_HUB_NAME")
+	if hubName == "" {
+		h, err := os.Hostname()
+		if err != nil {
+			return "", "", fmt.Errorf("getting hostname for label match: %w", err)
+		}
+		hubName = h
 	}
 	// Labels are stored lowercase (sanitizeLabel in the hub).
-	hostnameLabel := strings.ToLower(hostname)
+	hubNameLabel := strings.ToLower(hubName)
 
 	filter := fmt.Sprintf(
-		"labels.scion-name=user_signing_key AND labels.scion-hub-hostname=%s",
-		hostnameLabel,
+		"labels.scion-name=user_signing_key AND labels.scion-hub-name=%s",
+		hubNameLabel,
 	)
 
 	slog.Debug("searching Secret Manager for signing key",
@@ -487,7 +494,7 @@ func discoverSigningKey(ctx context.Context, projectID string) (value, resourceN
 	}
 
 	if len(candidates) == 0 {
-		return "", "", fmt.Errorf("no secret with labels scion-name=user_signing_key, scion-hub-hostname=%s found in project %s", hostnameLabel, projectID)
+		return "", "", fmt.Errorf("no secret with labels scion-name=user_signing_key, scion-hub-name=%s found in project %s", hubNameLabel, projectID)
 	}
 
 	// Pick the best candidate using a scoring heuristic. The hub's current

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -67,6 +67,11 @@ type HubServerConfig struct {
 	// Defaults to sha256(hostname)[:12] if not set.
 	HubID string `json:"hubId" yaml:"hubId" koanf:"hubId"`
 
+	// HubName is a human-readable display name for this hub in HA deployments.
+	// All nodes in a cluster should share the same hub_name.
+	// Defaults to os.Hostname() if not set.
+	HubName string `json:"hubName,omitempty" yaml:"hubName,omitempty" koanf:"hubName"`
+
 	// GCPProjectID is the GCP project ID used for minting service accounts.
 	// If empty, auto-detected from the metadata server when running on GCE/Cloud Run.
 	GCPProjectID string `json:"gcpProjectId,omitempty" yaml:"gcpProjectId,omitempty" koanf:"gcpProjectId"`
@@ -93,6 +98,18 @@ func (c *HubServerConfig) ResolveHubID() string {
 		return c.HubID
 	}
 	return DefaultHubID()
+}
+
+// ResolveHubName returns the configured HubName if set, otherwise falls back to os.Hostname().
+func (c *HubServerConfig) ResolveHubName() string {
+	if c.HubName != "" {
+		return c.HubName
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+	return hostname
 }
 
 // RuntimeBrokerConfig holds configuration for the Runtime Broker API server.
@@ -726,6 +743,7 @@ func envKeyToConfigKey(envKey string) string {
 		"gcpprojectid":         "gcpProjectId",
 		"gcpcredentials":       "gcpCredentials",
 		"hubid":                "hubId",
+		"hubname":              "hubName",
 		"adminmode":            "adminMode",
 		"maintenancemessage":   "maintenanceMessage",
 	}

--- a/pkg/config/opsettings/registry.go
+++ b/pkg/config/opsettings/registry.go
@@ -93,7 +93,7 @@ func init() {
 		},
 		{
 			Name:       "endpoints",
-			KoanfPaths: []string{"server.hub.public_url", "image_registry"},
+			KoanfPaths: []string{"server.hub.public_url", "server.hub.hub_name", "image_registry"},
 			New:        func() any { return &EndpointsSettings{} },
 		},
 		{

--- a/pkg/config/opsettings/sections.go
+++ b/pkg/config/opsettings/sections.go
@@ -62,6 +62,7 @@ type AgentDefaultsSettings struct {
 // EndpointsSettings holds Layer-1 endpoint configuration.
 type EndpointsSettings struct {
 	PublicURL     string `json:"public_url,omitempty"`
+	HubName       string `json:"hub_name,omitempty"`
 	ImageRegistry string `json:"image_registry,omitempty"`
 }
 

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -720,6 +720,13 @@
           "description": "Stable hub instance identifier used for hub-scoped secret namespacing.",
           "x-env-var": "SCION_SERVER_HUB_HUBID"
         },
+        "hub_name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]{0,61}[a-z0-9]$",
+          "description": "Human-readable hub display name for HA deployments. All nodes in a cluster should share the same hub_name. Defaults to os.Hostname() if not set.",
+          "x-env-var": "SCION_SERVER_HUB_HUBNAME",
+          "x-scope": "global"
+        },
         "public_url": {
           "type": "string",
           "format": "uri",

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -722,7 +722,7 @@
         },
         "hub_name": {
           "type": "string",
-          "pattern": "^[a-z][a-z0-9-]{0,61}[a-z0-9]$",
+          "pattern": "^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$",
           "description": "Human-readable hub display name for HA deployments. All nodes in a cluster should share the same hub_name. Defaults to os.Hostname() if not set.",
           "x-env-var": "SCION_SERVER_HUB_HUBNAME",
           "x-scope": "global"

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -366,6 +366,7 @@ type V1ServerHubConfig struct {
 	Port         int           `json:"port,omitempty" yaml:"port,omitempty" koanf:"port"`
 	Host         string        `json:"host,omitempty" yaml:"host,omitempty" koanf:"host"`
 	HubID        string        `json:"hub_id,omitempty" yaml:"hub_id,omitempty" koanf:"hub_id"`
+	HubName      string        `json:"hub_name,omitempty" yaml:"hub_name,omitempty" koanf:"hub_name"`
 	PublicURL    string        `json:"public_url,omitempty" yaml:"public_url,omitempty" koanf:"public_url"`
 	ReadTimeout  string        `json:"read_timeout,omitempty" yaml:"read_timeout,omitempty" koanf:"read_timeout"`
 	WriteTimeout string        `json:"write_timeout,omitempty" yaml:"write_timeout,omitempty" koanf:"write_timeout"`
@@ -1205,6 +1206,9 @@ func ConvertV1ServerToGlobalConfig(v1 *V1ServerConfig) *GlobalConfig {
 		if v1.Hub.HubID != "" {
 			gc.Hub.HubID = v1.Hub.HubID
 		}
+		if v1.Hub.HubName != "" {
+			gc.Hub.HubName = v1.Hub.HubName
+		}
 		if v1.Hub.PublicURL != "" {
 			gc.Hub.Endpoint = v1.Hub.PublicURL
 		}
@@ -1469,6 +1473,7 @@ func ConvertGlobalToV1ServerConfig(gc *GlobalConfig) *V1ServerConfig {
 		Port:         gc.Hub.Port,
 		Host:         gc.Hub.Host,
 		HubID:        gc.Hub.HubID,
+		HubName:      gc.Hub.HubName,
 		PublicURL:    gc.Hub.Endpoint,
 		ReadTimeout:  gc.Hub.ReadTimeout.String(),
 		WriteTimeout: gc.Hub.WriteTimeout.String(),

--- a/pkg/hub/handlers_health.go
+++ b/pkg/hub/handlers_health.go
@@ -28,6 +28,8 @@ type HealthResponse struct {
 	Status       string            `json:"status"`
 	Version      string            `json:"version"`
 	ScionVersion string            `json:"scionVersion"`
+	HubID        string            `json:"hub_id,omitempty"`
+	HubName      string            `json:"hub_name,omitempty"`
 	Uptime       string            `json:"uptime"`
 	Checks       map[string]string `json:"checks,omitempty"`
 	Stats        *HealthStats      `json:"stats,omitempty"`
@@ -76,6 +78,8 @@ func (s *Server) GetHealthInfo(ctx context.Context) *HealthResponse {
 		Status:       status,
 		Version:      "0.1.0", // TODO: Get from build info
 		ScionVersion: version.Short(),
+		HubID:        s.HubID(),
+		HubName:      s.HubName(),
 		Uptime:       time.Since(s.startTime).Round(time.Second).String(),
 		Checks:       checks,
 		Stats:        stats,

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -94,6 +94,7 @@ type Layer1Snapshot struct {
 
 	// Endpoints
 	PublicURL     string
+	HubName       string
 	ImageRegistry string
 
 	// GitHub App (non-secret fields only)
@@ -567,6 +568,7 @@ func buildSnapshotFromKoanf(k *koanf.Koanf) Layer1Snapshot {
 
 	// Endpoints
 	snap.PublicURL = k.String("server.hub.public_url")
+	snap.HubName = k.String("server.hub.hub_name")
 	snap.ImageRegistry = k.String("image_registry")
 
 	// GitHub App

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/config/opsettings"
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/knadh/koanf/v2"
 )
@@ -695,6 +696,14 @@ func ApplySnapshot(s *Server, snap Layer1Snapshot) map[string]interface{} {
 	}
 
 	s.mu.Unlock()
+
+	// Propagate hub_name to the GCP secret backend so new secrets get the
+	// correct label value. Log handlers have a similar limitation (§7.4).
+	if snap.HubName != "" {
+		if gcpBackend, ok := s.secretBackend.(*secret.GCPBackend); ok {
+			gcpBackend.SetHubName(snap.HubName)
+		}
+	}
 
 	// NOTE: Maintenance state is deliberately NOT applied here.
 	// Maintenance is runtime/API-owned state. In file mode, reloadSettings

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -688,6 +688,12 @@ func ApplySnapshot(s *Server, snap Layer1Snapshot) map[string]interface{} {
 		applied = append(applied, "github_app")
 	}
 
+	// Hub name
+	if snap.HubName != "" {
+		s.config.HubName = snap.HubName
+		applied = append(applied, "hub_name")
+	}
+
 	s.mu.Unlock()
 
 	// NOTE: Maintenance state is deliberately NOT applied here.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -157,6 +157,8 @@ type ServerConfig struct {
 	// HubID is the unique hub instance ID used for secret namespacing.
 	// If empty, secrets are looked up/stored with an empty scope ID.
 	HubID string
+	// HubName is the human-readable hub display name for HA deployments.
+	HubName string
 	// SecretBackend is the optional secret backend for signing key storage.
 	// When set before New(), ensureSigningKey can load/persist keys through the
 	// production secret backend (e.g., GCP Secret Manager) instead of relying
@@ -1540,6 +1542,13 @@ func (s *Server) HubID() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.hubID
+}
+
+// HubName returns the human-readable hub display name. Thread-safe.
+func (s *Server) HubName() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.config.HubName
 }
 
 // SetSecretBackend sets the secret backend for pluggable secret storage.

--- a/pkg/observability/hubmetrics/hubmetrics.go
+++ b/pkg/observability/hubmetrics/hubmetrics.go
@@ -98,6 +98,9 @@ func NewMeterProvider(ctx context.Context, gcpProjectID string, opts ...Option) 
 	if envHubID := os.Getenv("SCION_HUB_ID"); envHubID != "" && o.hubID == "" {
 		resAttrs = append(resAttrs, attribute.String("scion.hub.id", envHubID))
 	}
+	if o.hubName != "" {
+		resAttrs = append(resAttrs, attribute.String("scion.hub.name", o.hubName))
+	}
 
 	res, err := resource.New(ctx,
 		resource.WithAttributes(resAttrs...),

--- a/pkg/observability/hubmetrics/hubmetrics.go
+++ b/pkg/observability/hubmetrics/hubmetrics.go
@@ -50,6 +50,7 @@ type Option func(*options)
 type options struct {
 	exportInterval time.Duration
 	hubID          string
+	hubName        string
 }
 
 // WithExportInterval sets the periodic reader interval. Defaults to 60s.
@@ -60,6 +61,11 @@ func WithExportInterval(d time.Duration) Option {
 // WithHubID sets the scion.hub.id resource attribute.
 func WithHubID(id string) Option {
 	return func(o *options) { o.hubID = id }
+}
+
+// WithHubName sets the scion.hub.name resource attribute.
+func WithHubName(name string) Option {
+	return func(o *options) { o.hubName = name }
 }
 
 // NewMeterProvider creates an OTel SDK MeterProvider that exports to GCP Cloud

--- a/pkg/secret/gcpbackend.go
+++ b/pkg/secret/gcpbackend.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 
 	smpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"google.golang.org/grpc/codes"
@@ -38,6 +39,7 @@ type GCPBackend struct {
 	smClient  SMClient
 	projectID string
 	hubID     string
+	mu        sync.RWMutex
 	hubName   string
 }
 
@@ -75,7 +77,9 @@ func (b *GCPBackend) HubID() string {
 
 // SetHubName sets the human-readable hub display name.
 func (b *GCPBackend) SetHubName(name string) {
+	b.mu.Lock()
 	b.hubName = name
+	b.mu.Unlock()
 }
 
 func (b *GCPBackend) Get(ctx context.Context, name, scope, scopeID string) (*SecretWithValue, error) {
@@ -486,8 +490,11 @@ func buildLabels(input *SetSecretInput, target, hubName string) map[string]strin
 
 // resolveHubName returns the hub display name if set, falling back to the machine hostname.
 func (b *GCPBackend) resolveHubName() string {
-	if b.hubName != "" {
-		return b.hubName
+	b.mu.RLock()
+	name := b.hubName
+	b.mu.RUnlock()
+	if name != "" {
+		return name
 	}
 	h, err := os.Hostname()
 	if err != nil {

--- a/pkg/secret/gcpbackend.go
+++ b/pkg/secret/gcpbackend.go
@@ -38,6 +38,7 @@ type GCPBackend struct {
 	smClient  SMClient
 	projectID string
 	hubID     string
+	hubName   string
 }
 
 // NewGCPBackend creates a GCPBackend with a real GCP Secret Manager client.
@@ -70,6 +71,11 @@ func NewGCPBackendWithClient(s store.SecretStore, client SMClient, projectID, hu
 // HubID returns the hub instance ID used for hub-scoped secret namespacing.
 func (b *GCPBackend) HubID() string {
 	return b.hubID
+}
+
+// SetHubName sets the human-readable hub display name.
+func (b *GCPBackend) SetHubName(name string) {
+	b.hubName = name
 }
 
 func (b *GCPBackend) Get(ctx context.Context, name, scope, scopeID string) (*SecretWithValue, error) {

--- a/pkg/secret/gcpbackend.go
+++ b/pkg/secret/gcpbackend.go
@@ -176,7 +176,7 @@ func (b *GCPBackend) Set(ctx context.Context, input *SetSecretInput) (bool, *Sec
 							Automatic: &smpb.Replication_Automatic{},
 						},
 					},
-					Labels: buildLabels(input, target, hostname()),
+					Labels: buildLabels(input, target, b.resolveHubName()),
 				},
 			})
 			if err != nil {
@@ -468,15 +468,15 @@ func sanitizeLabel(s string) string {
 
 // buildLabels constructs the GCP SM labels map for a secret.
 // For user-scoped secrets with a known email, a scion-userid label is added.
-// The hubHostname label allows filtering secrets by hub in the GCP console.
-func buildLabels(input *SetSecretInput, target, hubHostname string) map[string]string {
+// The scion-hub-name label allows filtering secrets by hub in the GCP console.
+func buildLabels(input *SetSecretInput, target, hubName string) map[string]string {
 	labels := map[string]string{
-		"scion-scope":        sanitizeLabel(input.Scope),
-		"scion-scope-id":     sanitizeLabel(input.ScopeID),
-		"scion-type":         sanitizeLabel(input.SecretType),
-		"scion-name":         sanitizeLabel(input.Name),
-		"scion-target":       sanitizeLabel(target),
-		"scion-hub-hostname": sanitizeLabel(hubHostname),
+		"scion-scope":    sanitizeLabel(input.Scope),
+		"scion-scope-id": sanitizeLabel(input.ScopeID),
+		"scion-type":     sanitizeLabel(input.SecretType),
+		"scion-name":     sanitizeLabel(input.Name),
+		"scion-target":   sanitizeLabel(target),
+		"scion-hub-name": sanitizeLabel(hubName),
 	}
 	if input.Scope == ScopeUser && input.UserEmail != "" {
 		labels["scion-userid"] = sanitizeLabel(input.UserEmail)
@@ -484,8 +484,11 @@ func buildLabels(input *SetSecretInput, target, hubHostname string) map[string]s
 	return labels
 }
 
-// hostname returns the machine hostname for labeling, or "unknown" if unavailable.
-func hostname() string {
+// resolveHubName returns the hub display name if set, falling back to the machine hostname.
+func (b *GCPBackend) resolveHubName() string {
+	if b.hubName != "" {
+		return b.hubName
+	}
 	h, err := os.Hostname()
 	if err != nil {
 		return "unknown"

--- a/pkg/secret/gcpbackend_test.go
+++ b/pkg/secret/gcpbackend_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -30,6 +31,14 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+func testResolveHostname() string {
+	h, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+	return h
+}
 
 // mockSMClient implements SMClient for testing.
 type mockSMClient struct {
@@ -552,7 +561,7 @@ func TestGCPBackend_Labels(t *testing.T) {
 			"scion-name":         "api_key",
 			"scion-target":       "anthropic_api_key",
 			"scion-userid":       "alice-example-com",
-			"scion-hub-hostname": sanitizeLabel(hostname()),
+			"scion-hub-name": sanitizeLabel(testResolveHostname()),
 		}
 		for k, expected := range expectedLabels {
 			got, ok := labels[k]

--- a/pkg/secret/gcpbackend_test.go
+++ b/pkg/secret/gcpbackend_test.go
@@ -555,12 +555,12 @@ func TestGCPBackend_Labels(t *testing.T) {
 	for _, sec := range mock.secrets {
 		labels := sec.Labels
 		expectedLabels := map[string]string{
-			"scion-scope":        "user",
-			"scion-scope-id":     "user-1",
-			"scion-type":         "environment",
-			"scion-name":         "api_key",
-			"scion-target":       "anthropic_api_key",
-			"scion-userid":       "alice-example-com",
+			"scion-scope":    "user",
+			"scion-scope-id": "user-1",
+			"scion-type":     "environment",
+			"scion-name":     "api_key",
+			"scion-target":   "anthropic_api_key",
+			"scion-userid":   "alice-example-com",
 			"scion-hub-name": sanitizeLabel(testResolveHostname()),
 		}
 		for k, expected := range expectedLabels {
@@ -573,6 +573,43 @@ func TestGCPBackend_Labels(t *testing.T) {
 		}
 		if len(labels) != len(expectedLabels) {
 			t.Errorf("expected %d labels, got %d: %v", len(expectedLabels), len(labels), labels)
+		}
+	}
+}
+
+func TestGCPBackend_Labels_ExplicitHubName(t *testing.T) {
+	backend, mock := createTestGCPBackend(t)
+	backend.SetHubName("prod-hub")
+	ctx := context.Background()
+
+	input := &SetSecretInput{
+		Name:       "API_KEY",
+		Value:      "sk-test-456",
+		SecretType: TypeEnvironment,
+		Target:     "ANTHROPIC_API_KEY",
+		Scope:      ScopeUser,
+		ScopeID:    "user-2",
+		UserEmail:  "bob@example.com",
+	}
+
+	_, _, err := backend.Set(ctx, input)
+	if err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	if len(mock.secrets) != 1 {
+		t.Fatalf("expected 1 secret in mock, got %d", len(mock.secrets))
+	}
+
+	for _, sec := range mock.secrets {
+		got, ok := sec.Labels["scion-hub-name"]
+		if !ok {
+			t.Error("missing scion-hub-name label")
+		} else if got != "prod-hub" {
+			t.Errorf("scion-hub-name: expected %q, got %q", "prod-hub", got)
 		}
 	}
 }

--- a/pkg/util/logging/cloud_handler.go
+++ b/pkg/util/logging/cloud_handler.go
@@ -55,6 +55,8 @@ type CloudLoggingConfig struct {
 	LogID string
 	// Component is the server component name (e.g., "scion-hub").
 	Component string
+	// HubName is the logical hub identity used in the "hub" log label.
+	HubName string
 	// BufferedByteLimit is the maximum bytes the Cloud Logging client
 	// will buffer. Prevents unbounded memory growth when Cloud Logging
 	// is temporarily unavailable. Default: 8 MiB.
@@ -71,6 +73,7 @@ type CloudHandler struct {
 	client    *gcplog.Client
 	level     slog.Level
 	component string
+	hubName   string
 	hostname  string
 	projectID string
 	attrs     []slog.Attr
@@ -122,6 +125,7 @@ func NewCloudHandler(ctx context.Context, config CloudLoggingConfig, level slog.
 		client:    client,
 		level:     level,
 		component: config.Component,
+		hubName:   config.HubName,
 		hostname:  hostname,
 		projectID: projectID,
 	}
@@ -186,8 +190,11 @@ func (h *CloudHandler) Handle(_ context.Context, r slog.Record) error {
 	labels := map[string]string{
 		"component": h.component,
 	}
+	if h.hubName != "" {
+		labels["hub"] = h.hubName
+	}
 	if h.hostname != "" {
-		labels["hub"] = h.hostname
+		labels["node"] = h.hostname
 	}
 	for _, a := range h.attrs {
 		promoteAttrToLabels(labels, a)
@@ -233,6 +240,7 @@ func (h *CloudHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 		client:    h.client,
 		level:     h.level,
 		component: h.component,
+		hubName:   h.hubName,
 		hostname:  h.hostname,
 		projectID: h.projectID,
 		attrs:     newAttrs,
@@ -250,6 +258,7 @@ func (h *CloudHandler) WithGroup(name string) slog.Handler {
 		client:    h.client,
 		level:     h.level,
 		component: h.component,
+		hubName:   h.hubName,
 		hostname:  h.hostname,
 		projectID: h.projectID,
 		attrs:     h.attrs,
@@ -265,7 +274,7 @@ func (h *CloudHandler) Client() *gcplog.Client {
 
 // NewCloudHandlerFromClient creates a CloudHandler from an existing client.
 // This avoids opening a second connection for the request log stream.
-func NewCloudHandlerFromClient(client *gcplog.Client, logID, component string, level slog.Level) *CloudHandler {
+func NewCloudHandlerFromClient(client *gcplog.Client, logID, component, hubName string, level slog.Level) *CloudHandler {
 	logger := client.Logger(logID)
 	hostname, _ := os.Hostname()
 	return &CloudHandler{
@@ -273,6 +282,7 @@ func NewCloudHandlerFromClient(client *gcplog.Client, logID, component string, l
 		client:    client,
 		level:     level,
 		component: component,
+		hubName:   hubName,
 		hostname:  hostname,
 		projectID: resolveProjectID(),
 	}

--- a/pkg/util/logging/gcp_handler.go
+++ b/pkg/util/logging/gcp_handler.go
@@ -45,13 +45,14 @@ var levelToSeverity = map[slog.Level]string{
 type GCPHandler struct {
 	handler   slog.Handler
 	component string
+	hubName   string
 	hostname  string
 	projectID string
 	preAttrs  []slog.Attr // tracked for label promotion
 }
 
 // NewGCPHandler creates a new GCPHandler.
-func NewGCPHandler(w io.Writer, opts *slog.HandlerOptions, component string) *GCPHandler {
+func NewGCPHandler(w io.Writer, opts *slog.HandlerOptions, component, hubName string) *GCPHandler {
 	if opts == nil {
 		opts = &slog.HandlerOptions{}
 	}
@@ -94,6 +95,7 @@ func NewGCPHandler(w io.Writer, opts *slog.HandlerOptions, component string) *GC
 	return &GCPHandler{
 		handler:   jsonHandler,
 		component: component,
+		hubName:   hubName,
 		hostname:  hostname,
 		projectID: projectID,
 	}
@@ -108,9 +110,12 @@ func (h *GCPHandler) Handle(ctx context.Context, r slog.Record) error {
 	labels := map[string]string{
 		"component": h.component,
 	}
+	if h.hubName != "" {
+		labels["hub"] = h.hubName
+	}
 	if h.hostname != "" {
 		labels["hostname"] = h.hostname
-		labels["hub"] = h.hostname
+		labels["node"] = h.hostname
 	}
 	for _, a := range h.preAttrs {
 		promoteAttrToLabels(labels, a)
@@ -145,6 +150,7 @@ func (h *GCPHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &GCPHandler{
 		handler:   h.handler.WithAttrs(attrs),
 		component: h.component,
+		hubName:   h.hubName,
 		hostname:  h.hostname,
 		projectID: h.projectID,
 		preAttrs:  newPreAttrs,
@@ -155,6 +161,7 @@ func (h *GCPHandler) WithGroup(name string) slog.Handler {
 	return &GCPHandler{
 		handler:   h.handler.WithGroup(name),
 		component: h.component,
+		hubName:   h.hubName,
 		hostname:  h.hostname,
 		projectID: h.projectID,
 		preAttrs:  h.preAttrs,

--- a/pkg/util/logging/gcp_handler.go
+++ b/pkg/util/logging/gcp_handler.go
@@ -114,7 +114,6 @@ func (h *GCPHandler) Handle(ctx context.Context, r slog.Record) error {
 		labels["hub"] = h.hubName
 	}
 	if h.hostname != "" {
-		labels["hostname"] = h.hostname
 		labels["node"] = h.hostname
 	}
 	for _, a := range h.preAttrs {

--- a/pkg/util/logging/logging.go
+++ b/pkg/util/logging/logging.go
@@ -38,13 +38,13 @@ const (
 // debug enables DEBUG level logging.
 // useGCP formats logs for Google Cloud Logging.
 func Setup(component string, debug bool, useGCP bool) {
-	handler := createBaseHandler(component, debug, useGCP)
+	handler := createBaseHandler(component, debug, useGCP, "")
 	logger := slog.New(handler)
 	slog.SetDefault(logger)
 }
 
 // createBaseHandler creates the base slog handler for local logging.
-func createBaseHandler(component string, debug bool, useGCP bool) slog.Handler {
+func createBaseHandler(component string, debug bool, useGCP bool, hubName string) slog.Handler {
 	level := slog.LevelInfo
 	if debug || os.Getenv("SCION_LOG_LEVEL") == "debug" {
 		level = slog.LevelDebug
@@ -55,7 +55,7 @@ func createBaseHandler(component string, debug bool, useGCP bool) slog.Handler {
 	}
 
 	if useGCP {
-		return NewGCPHandler(os.Stdout, opts, component)
+		return NewGCPHandler(os.Stdout, opts, component, hubName)
 	}
 
 	// Default to JSON handler for structured logging

--- a/pkg/util/logging/logging_test.go
+++ b/pkg/util/logging/logging_test.go
@@ -28,7 +28,7 @@ import (
 func TestGCPHandler(t *testing.T) {
 	var buf bytes.Buffer
 	opts := &slog.HandlerOptions{Level: slog.LevelInfo}
-	handler := NewGCPHandler(&buf, opts, "test-component")
+	handler := NewGCPHandler(&buf, opts, "test-component", "")
 	logger := slog.New(handler)
 
 	logger.Info("test message", "key", "value")
@@ -48,14 +48,14 @@ func TestGCPHandler(t *testing.T) {
 	hostname, _ := os.Hostname()
 	if hostname != "" {
 		assert.Equal(t, hostname, labels["hostname"])
-		assert.Equal(t, hostname, labels["hub"])
+		assert.Equal(t, hostname, labels["node"])
 	}
 }
 
 func TestGCPHandler_EmptyMessageSuppressed(t *testing.T) {
 	var buf bytes.Buffer
 	opts := &slog.HandlerOptions{Level: slog.LevelInfo}
-	handler := NewGCPHandler(&buf, opts, "test-component")
+	handler := NewGCPHandler(&buf, opts, "test-component", "")
 	logger := slog.New(handler)
 
 	// Log with empty message (as HTTP request logs do)
@@ -82,7 +82,7 @@ func TestGCPHandler_EmptyMessageSuppressed(t *testing.T) {
 
 func TestGCPHandler_LabelsPromoteAgentProject(t *testing.T) {
 	var buf bytes.Buffer
-	handler := NewGCPHandler(&buf, nil, "test-component")
+	handler := NewGCPHandler(&buf, nil, "test-component", "")
 	logger := slog.New(handler)
 
 	logger.Info("test message",
@@ -106,7 +106,7 @@ func TestGCPHandler_LabelsPromoteAgentProject(t *testing.T) {
 
 func TestGCPHandler_LabelsFromWithAttrs(t *testing.T) {
 	var buf bytes.Buffer
-	handler := NewGCPHandler(&buf, nil, "test-component")
+	handler := NewGCPHandler(&buf, nil, "test-component", "")
 
 	// Simulate Logger(ctx) which uses slog.With()
 	childHandler := handler.WithAttrs([]slog.Attr{
@@ -130,7 +130,7 @@ func TestGCPHandler_TraceCorrelationFields(t *testing.T) {
 	t.Setenv(EnvGCPProjectID, "deploy-demo-test")
 
 	var buf bytes.Buffer
-	handler := NewGCPHandler(&buf, nil, "test-component")
+	handler := NewGCPHandler(&buf, nil, "test-component", "")
 	logger := slog.New(handler)
 
 	logger.Info("trace log",
@@ -172,7 +172,7 @@ func TestSubsystemLogger(t *testing.T) {
 func TestGCPHandlerSourceLocation(t *testing.T) {
 	var buf bytes.Buffer
 	opts := &slog.HandlerOptions{Level: slog.LevelInfo, AddSource: true}
-	handler := NewGCPHandler(&buf, opts, "test-component")
+	handler := NewGCPHandler(&buf, opts, "test-component", "")
 	logger := slog.New(handler)
 
 	logger.Info("test message")

--- a/pkg/util/logging/logging_test.go
+++ b/pkg/util/logging/logging_test.go
@@ -47,9 +47,25 @@ func TestGCPHandler(t *testing.T) {
 
 	hostname, _ := os.Hostname()
 	if hostname != "" {
-		assert.Equal(t, hostname, labels["hostname"])
+		assert.Nil(t, labels["hostname"], "hostname label should not be set; use node instead")
 		assert.Equal(t, hostname, labels["node"])
 	}
+}
+
+func TestGCPHandler_HubNameLabel(t *testing.T) {
+	var buf bytes.Buffer
+	opts := &slog.HandlerOptions{Level: slog.LevelInfo}
+	handler := NewGCPHandler(&buf, opts, "test-component", "prod-hub")
+	logger := slog.New(handler)
+
+	logger.Info("test message")
+
+	var data map[string]interface{}
+	err := json.Unmarshal(buf.Bytes(), &data)
+	assert.NoError(t, err)
+
+	labels := data[GCPKeyLabels].(map[string]interface{})
+	assert.Equal(t, "prod-hub", labels["hub"])
 }
 
 func TestGCPHandler_EmptyMessageSuppressed(t *testing.T) {

--- a/pkg/util/logging/message_log.go
+++ b/pkg/util/logging/message_log.go
@@ -40,6 +40,7 @@ type MessageLoggerConfig struct {
 	CloudClient *gcplog.Client // Shared GCP client (nil if not enabled)
 	CircuitOpen func() bool    // Returns true when circuit breaker is open (nil = never open)
 	Component   string         // "scion-server", "scion-hub", "scion-broker"
+	HubName     string         // Logical hub identity for log labels
 	UseGCP      bool           // Format output as GCP-compatible JSON
 	Level       slog.Level
 }
@@ -56,7 +57,7 @@ func NewMessageLogger(cfg MessageLoggerConfig) (*slog.Logger, func(), error) {
 
 	// Cloud handler with dedicated log ID and message-aware label promotion
 	if cfg.CloudClient != nil {
-		ch := newMessageCloudHandler(cfg.CloudClient, MessageLogID, cfg.Component, cfg.Level)
+		ch := newMessageCloudHandler(cfg.CloudClient, MessageLogID, cfg.Component, cfg.HubName, cfg.Level)
 		var cloudHandler slog.Handler = ch
 		if cfg.CircuitOpen != nil {
 			cloudHandler = &circuitGatedHandler{inner: ch, circuitOpen: cfg.CircuitOpen}
@@ -69,7 +70,7 @@ func NewMessageLogger(cfg MessageLoggerConfig) (*slog.Logger, func(), error) {
 
 	// Stdout handler for local visibility (always enabled for message log)
 	if cfg.UseGCP {
-		handlers = append(handlers, NewGCPHandler(os.Stdout, opts, cfg.Component))
+		handlers = append(handlers, NewGCPHandler(os.Stdout, opts, cfg.Component, cfg.HubName))
 	} else {
 		handlers = append(handlers, slog.NewJSONHandler(os.Stdout, opts).WithAttrs([]slog.Attr{
 			slog.String(AttrComponent, cfg.Component),
@@ -104,8 +105,8 @@ type messageCloudHandler struct {
 
 // newMessageCloudHandler creates a CloudHandler for the message log that
 // promotes sender, recipient, and msg_type to GCP labels.
-func newMessageCloudHandler(client *gcplog.Client, logID, component string, level slog.Level) *messageCloudHandler {
-	base := NewCloudHandlerFromClient(client, logID, component, level)
+func newMessageCloudHandler(client *gcplog.Client, logID, component, hubName string, level slog.Level) *messageCloudHandler {
+	base := NewCloudHandlerFromClient(client, logID, component, hubName, level)
 	return &messageCloudHandler{CloudHandler: *base}
 }
 
@@ -115,8 +116,11 @@ func (h *messageCloudHandler) Handle(ctx context.Context, r slog.Record) error {
 	labels := map[string]string{
 		"component": h.component,
 	}
+	if h.hubName != "" {
+		labels["hub"] = h.hubName
+	}
 	if h.hostname != "" {
-		labels["hub"] = h.hostname
+		labels["node"] = h.hostname
 	}
 	for _, a := range h.attrs {
 		promoteAttrToLabels(labels, a)
@@ -177,6 +181,7 @@ func (h *messageCloudHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 			client:    h.client,
 			level:     h.level,
 			component: h.component,
+			hubName:   h.hubName,
 			hostname:  h.hostname,
 			attrs:     newAttrs,
 			groups:    h.groups,
@@ -195,6 +200,7 @@ func (h *messageCloudHandler) WithGroup(name string) slog.Handler {
 			client:    h.client,
 			level:     h.level,
 			component: h.component,
+			hubName:   h.hubName,
 			hostname:  h.hostname,
 			attrs:     h.attrs,
 			groups:    newGroups,

--- a/pkg/util/logging/otel.go
+++ b/pkg/util/logging/otel.go
@@ -94,9 +94,9 @@ func NewOTelHandler(component string, lp log.LoggerProvider) slog.Handler {
 // SetupWithOTel initializes the global logger with optional OTel bridge.
 // If lp is nil, falls back to standard Setup behavior.
 // Extra handlers (e.g., CloudHandler) are appended to the handler chain.
-func SetupWithOTel(component string, debug bool, useGCP bool, lp log.LoggerProvider, extraHandlers ...slog.Handler) {
+func SetupWithOTel(component, hubName string, debug bool, useGCP bool, lp log.LoggerProvider, extraHandlers ...slog.Handler) {
 	// Create the base handler (same logic as Setup)
-	baseHandler := createBaseHandler(component, debug, useGCP)
+	baseHandler := createBaseHandler(component, debug, useGCP, hubName)
 
 	// Collect all handlers
 	handlers := []slog.Handler{baseHandler}

--- a/pkg/util/logging/otel_test.go
+++ b/pkg/util/logging/otel_test.go
@@ -91,7 +91,7 @@ func TestNewOTelHandler_NilProvider(t *testing.T) {
 
 func TestSetupWithOTel_NilProvider(t *testing.T) {
 	// Should fall back to base handler behavior
-	SetupWithOTel("test-component", false, false, nil)
+	SetupWithOTel("test-component", "", false, false, nil)
 
 	// Verify logging still works
 	logger := slog.Default()
@@ -102,13 +102,13 @@ func TestSetupWithOTel_NilProvider(t *testing.T) {
 
 func TestCreateBaseHandler(t *testing.T) {
 	// Test JSON handler (default)
-	h := createBaseHandler("test", false, false)
+	h := createBaseHandler("test", false, false, "")
 	if h == nil {
 		t.Error("createBaseHandler should return a handler")
 	}
 
 	// Test GCP handler
-	h = createBaseHandler("test", false, true)
+	h = createBaseHandler("test", false, true, "")
 	if h == nil {
 		t.Error("createBaseHandler should return GCP handler")
 	}

--- a/pkg/util/logging/request_log.go
+++ b/pkg/util/logging/request_log.go
@@ -164,6 +164,7 @@ type RequestLoggerConfig struct {
 	CircuitOpen func() bool    // Returns true when circuit breaker is open (nil = never open)
 	ProjectID   string         // For trace URL formatting
 	Component   string         // "scion-server", "scion-hub", "scion-broker"
+	HubName     string         // Logical hub identity for log labels
 	UseGCP      bool           // Format output as GCP-compatible JSON
 	Foreground  bool           // If true, suppress stdout output
 	Level       slog.Level
@@ -192,7 +193,7 @@ func NewRequestLogger(cfg RequestLoggerConfig) (*slog.Logger, func(), error) {
 
 	// Cloud handler
 	if cfg.CloudClient != nil {
-		ch := NewCloudHandlerFromClient(cfg.CloudClient, RequestLogID, cfg.Component, cfg.Level)
+		ch := NewCloudHandlerFromClient(cfg.CloudClient, RequestLogID, cfg.Component, cfg.HubName, cfg.Level)
 		var cloudHandler slog.Handler = ch
 		if cfg.CircuitOpen != nil {
 			cloudHandler = &circuitGatedHandler{inner: ch, circuitOpen: cfg.CircuitOpen}
@@ -206,7 +207,7 @@ func NewRequestLogger(cfg RequestLoggerConfig) (*slog.Logger, func(), error) {
 	// Stdout fallback: only if NOT foreground AND no other targets configured
 	if !cfg.Foreground && len(handlers) == 0 {
 		if cfg.UseGCP {
-			handlers = append(handlers, NewGCPHandler(os.Stdout, opts, cfg.Component))
+			handlers = append(handlers, NewGCPHandler(os.Stdout, opts, cfg.Component, cfg.HubName))
 		} else {
 			handlers = append(handlers, slog.NewJSONHandler(os.Stdout, opts))
 		}


### PR DESCRIPTION
Implements https://github.com/ptone/scion/issues/392 — introduces hub_name as a configurable Layer-1 operational setting for HA multi-node deployments.

- Phase 1: hub_name config foundation
- Phase 2: server plumbing (ServerConfig, ApplySnapshot, hubmetrics, secret backend)
- Phase 3: surface area migration (logs, telemetry, GCP secrets, health API)
- Phase 4: chat app secret discovery (scion-hub-name label + SCION_HUB_NAME env var)

Design: .design/hub-scope.md