### PR TITLE
fix(ui): filter message brokers from /brokers page, show only runtime brokers

### DIFF
--- a/pkg/hub/handlers_runtime_brokers.go
+++ b/pkg/hub/handlers_runtime_brokers.go
@@ -102,7 +102,6 @@ func (s *Server) listRuntimeBrokers(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	result.Items = filtered
-	result.TotalCount = len(filtered)
 
 	// Batch-resolve CreatedByName for all brokers
 	s.enrichBrokerCreatorNames(ctx, result.Items)

--- a/pkg/hub/handlers_runtime_brokers.go
+++ b/pkg/hub/handlers_runtime_brokers.go
@@ -93,6 +93,17 @@ func (s *Server) listRuntimeBrokers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Exclude message broker plugins (e.g. Discord, Telegram) — they carry
+	// the "scion.io/plugin" label and are not runtime brokers.
+	filtered := result.Items[:0]
+	for _, b := range result.Items {
+		if _, isPlugin := b.Labels["scion.io/plugin"]; !isPlugin {
+			filtered = append(filtered, b)
+		}
+	}
+	result.Items = filtered
+	result.TotalCount = len(filtered)
+
 	// Batch-resolve CreatedByName for all brokers
 	s.enrichBrokerCreatorNames(ctx, result.Items)
 


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/393 — the /brokers page was displaying message broker registrations (Discord) alongside runtime brokers. Now only runtime brokers (that dispatch agents to container runtimes) are shown