### PR TITLE
harness/gemini-cli: update model aliases and fix auth.selectedType in settings.json

### DIFF
--- a/harnesses/gemini-cli/config.yaml
+++ b/harnesses/gemini-cli/config.yaml
@@ -33,8 +33,8 @@ system_prompt_file: .gemini/system_prompt.md
 system_prompt_mode: native
 model_aliases:
   small: gemini-flash-lite
-  medium: gemini-flash
-  large: gemini-pro
+  medium: gemini-3.5-flash
+  large: gemini-3.1-pro-preview
   extra-large: gemini-pro
 env:
   GEMINI_CLI_NO_RELAUNCH: "true"

--- a/harnesses/gemini-cli/provision.py
+++ b/harnesses/gemini-cli/provision.py
@@ -108,10 +108,15 @@ def _update_gemini_settings(settings_path: str, gemini_auth_type: str) -> None:
         auth = {}
         security["auth"] = auth
 
-    if auth.get("selectedType") == gemini_auth_type:
-        return
+    if gemini_auth_type:
+        if auth.get("selectedType") == gemini_auth_type:
+            return
+        auth["selectedType"] = gemini_auth_type
+    else:
+        auth.pop("selectedType", None)
+        if not auth:
+            security.pop("auth", None)
 
-    auth["selectedType"] = gemini_auth_type
     scion_harness.atomic_write_json(expanded, settings)
 
 
@@ -137,8 +142,7 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     resolved = ctx.select_auth(AUTH)
 
     gemini_auth_type = _GEMINI_AUTH_TYPE_MAP.get(resolved.method, "")
-    if gemini_auth_type:
-        _update_gemini_settings(GEMINI_SETTINGS_FILE, gemini_auth_type)
+    _update_gemini_settings(GEMINI_SETTINGS_FILE, gemini_auth_type)
 
     env = _build_env_overlay(resolved.method, resolved.env_key)
     extra: dict[str, Any] | None = None


### PR DESCRIPTION
## Changes

**Model aliases** (config.yaml):
- medium: gemini-flash → gemini-3.5-flash
- large: gemini-pro → gemini-3.1-pro-preview

**auth.selectedType fix** (provision.py):
Previously, when auth resolved to "none" (no credentials staged), _GEMINI_AUTH_TYPE_MAP returned empty string and an "if gemini_auth_type:" guard silently skipped _update_gemini_settings() entirely — leaving the seed's bare "auth: {}" untouched in settings.json.

Fix:
- Removed the if-guard so _update_gemini_settings() always runs
- No-auth path explicitly cleans up: removes selectedType via pop(), and removes the empty auth dict from security if nothing else is in it
- Happy-path (api-key, auth-file, vertex-ai) behavior unchanged