### PR TITLE
feat(broker): add deployment-type labels to broker registration

### DIFF
--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -538,6 +538,9 @@ func runBrokerRegister(cmd *cobra.Command, args []string) error {
 				"attach",
 			},
 			AutoProvide: brokerAutoProvide,
+			Labels: map[string]string{
+				"scion.io/broker-role": "remote",
+			},
 		}
 
 		createResp, err := client.RuntimeBrokers().Create(ctx, createReq)

--- a/cmd/server_broker.go
+++ b/cmd/server_broker.go
@@ -88,6 +88,10 @@ func registerGlobalProjectAndBroker(ctx context.Context, s store.Store, brokerID
 		}
 	}
 
+	brokerLabels := map[string]string{
+		"scion.io/broker-role": "embedded",
+	}
+
 	if broker == nil {
 		broker = &store.RuntimeBroker{
 			ID:              brokerID,
@@ -104,9 +108,7 @@ func registerGlobalProjectAndBroker(ctx context.Context, s store.Store, brokerID
 				Attach: true,
 			},
 			Profiles: profiles,
-			Labels: map[string]string{
-				"scion.io/broker-type": "hosted",
-			},
+			Labels:   brokerLabels,
 		}
 
 		if err := s.CreateRuntimeBroker(ctx, broker); err != nil {
@@ -121,14 +123,14 @@ func registerGlobalProjectAndBroker(ctx context.Context, s store.Store, brokerID
 		broker.LastHeartbeat = time.Now()
 		// Update profiles from settings (may have changed)
 		broker.Profiles = profiles
-		// Unconditionally set the hosted label. This is safe because
-		// registerGlobalProjectAndBroker is only called for co-located
-		// (hub-embedded) brokers; external brokers register through
-		// CreateBrokerRegistration in brokerauth.go instead.
+		// Ensure deployment-type labels are set on re-registration
 		if broker.Labels == nil {
-			broker.Labels = make(map[string]string)
+			broker.Labels = brokerLabels
+		} else {
+			for k, v := range brokerLabels {
+				broker.Labels[k] = v
+			}
 		}
-		broker.Labels["scion.io/broker-type"] = "hosted"
 		if err := s.UpdateRuntimeBroker(ctx, broker); err != nil {
 			return brokerID, fmt.Errorf("failed to update runtime broker: %w", err)
 		}

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -135,3 +135,65 @@ func TestRegisterGlobalGroveAndBroker_DedupCaseInsensitive(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, tid("broker-1"), effectiveID, "should match case-insensitively")
 }
+
+func TestRegisterGlobalProjectAndBroker_SetsEmbeddedLabel(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	settings := &config.Settings{}
+
+	// Register a new co-located broker
+	effectiveID, err := registerGlobalProjectAndBroker(ctx, s, tid("broker-1"), "test-broker", "http://localhost:9800", nil, true, settings)
+	require.NoError(t, err)
+	assert.Equal(t, tid("broker-1"), effectiveID)
+
+	// Verify the broker has the embedded label
+	broker, err := s.GetRuntimeBroker(ctx, tid("broker-1"))
+	require.NoError(t, err)
+	assert.Equal(t, "embedded", broker.Labels["scion.io/broker-role"])
+}
+
+func TestRegisterGlobalProjectAndBroker_LabelsOnReregistration(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	settings := &config.Settings{}
+
+	// First registration
+	_, err := registerGlobalProjectAndBroker(ctx, s, tid("broker-1"), "test-broker", "http://localhost:9800", nil, true, settings)
+	require.NoError(t, err)
+
+	// Manually add a user-set label to simulate prior customization
+	broker, err := s.GetRuntimeBroker(ctx, tid("broker-1"))
+	require.NoError(t, err)
+	broker.Labels["custom-label"] = "custom-value"
+	require.NoError(t, s.UpdateRuntimeBroker(ctx, broker))
+
+	// Re-register (same ID, same name)
+	_, err = registerGlobalProjectAndBroker(ctx, s, tid("broker-1"), "test-broker", "http://localhost:9800", nil, true, settings)
+	require.NoError(t, err)
+
+	// Verify the embedded label is set AND the custom label is preserved
+	broker, err = s.GetRuntimeBroker(ctx, tid("broker-1"))
+	require.NoError(t, err)
+	assert.Equal(t, "embedded", broker.Labels["scion.io/broker-role"])
+	assert.Equal(t, "custom-value", broker.Labels["custom-label"])
+}
+
+func TestRegisterGlobalProjectAndBroker_LabelsOnDedupByName(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	settings := &config.Settings{}
+
+	// First registration
+	_, err := registerGlobalProjectAndBroker(ctx, s, tid("broker-1"), "test-broker", "http://localhost:9800", nil, true, settings)
+	require.NoError(t, err)
+
+	// Second registration with different ID but same name (dedup path)
+	effectiveID, err := registerGlobalProjectAndBroker(ctx, s, tid("broker-2"), "test-broker", "http://localhost:9800", nil, true, settings)
+	require.NoError(t, err)
+	assert.Equal(t, tid("broker-1"), effectiveID)
+
+	// Verify the embedded label survives the dedup re-registration
+	broker, err := s.GetRuntimeBroker(ctx, tid("broker-1"))
+	require.NoError(t, err)
+	assert.Equal(t, "embedded", broker.Labels["scion.io/broker-role"])
+}

--- a/pkg/hub/brokerauth.go
+++ b/pkg/hub/brokerauth.go
@@ -238,7 +238,16 @@ func (s *BrokerAuthService) CreateBrokerRegistration(ctx context.Context, req Cr
 		brokerID = existingBroker.ID
 		reregistered = true
 		existingBroker.AutoProvide = req.AutoProvide
-		existingBroker.Labels = req.Labels
+		// Merge request labels into existing labels to preserve any
+		// user-set labels while updating registration-provided ones.
+		if len(req.Labels) > 0 {
+			if existingBroker.Labels == nil {
+				existingBroker.Labels = make(map[string]string, len(req.Labels))
+			}
+			for k, v := range req.Labels {
+				existingBroker.Labels[k] = v
+			}
+		}
 		existingBroker.Updated = time.Now()
 		if err := s.store.UpdateRuntimeBroker(ctx, existingBroker); err != nil {
 			return nil, fmt.Errorf("failed to update existing broker: %w", err)

--- a/pkg/hub/brokerauth_test.go
+++ b/pkg/hub/brokerauth_test.go
@@ -994,7 +994,7 @@ func TestBrokerReregistration_MergesLabels(t *testing.T) {
 		Name: "merge-host",
 		Labels: map[string]string{
 			"scion.io/broker-role": "remote",
-			"custom":              "value1",
+			"custom":               "value1",
 		},
 	}
 
@@ -1029,7 +1029,7 @@ func TestBrokerReregistration_MergesLabels(t *testing.T) {
 		Name: "merge-host",
 		Labels: map[string]string{
 			"scion.io/broker-role": "remote",
-			"custom":              "value2",
+			"custom":               "value2",
 		},
 	}
 

--- a/pkg/hub/brokerauth_test.go
+++ b/pkg/hub/brokerauth_test.go
@@ -957,3 +957,102 @@ func TestBrokerReregistrationNewSecret(t *testing.T) {
 		t.Error("Expected old secret to fail authentication after re-registration")
 	}
 }
+
+func TestBrokerRegistration_SetsLabels(t *testing.T) {
+	svc, s := setupTestBrokerAuthService(t)
+	ctx := context.Background()
+
+	// Register a broker with role label
+	req := CreateBrokerRegistrationRequest{
+		Name: "remote-host",
+		Labels: map[string]string{
+			"scion.io/broker-role": "remote",
+		},
+	}
+
+	resp, err := svc.CreateBrokerRegistration(ctx, req, "admin-user-id")
+	if err != nil {
+		t.Fatalf("CreateBrokerRegistration failed: %v", err)
+	}
+
+	// Verify labels are persisted on the broker record
+	broker, err := s.GetRuntimeBroker(ctx, resp.BrokerID)
+	if err != nil {
+		t.Fatalf("failed to get broker: %v", err)
+	}
+	if broker.Labels["scion.io/broker-role"] != "remote" {
+		t.Errorf("Expected broker-role=remote, got %q", broker.Labels["scion.io/broker-role"])
+	}
+}
+
+func TestBrokerReregistration_MergesLabels(t *testing.T) {
+	svc, s := setupTestBrokerAuthService(t)
+	ctx := context.Background()
+
+	// First registration with custom labels
+	req := CreateBrokerRegistrationRequest{
+		Name: "merge-host",
+		Labels: map[string]string{
+			"scion.io/broker-role": "remote",
+			"custom":              "value1",
+		},
+	}
+
+	resp1, err := svc.CreateBrokerRegistration(ctx, req, "admin")
+	if err != nil {
+		t.Fatalf("First CreateBrokerRegistration failed: %v", err)
+	}
+
+	// Complete the first join (consumes the join token)
+	_, err = svc.CompleteBrokerJoin(ctx, BrokerJoinRequest{
+		BrokerID:  resp1.BrokerID,
+		JoinToken: resp1.JoinToken,
+		Hostname:  "merge-host",
+		Version:   "1.0.0",
+	}, "http://localhost:9810")
+	if err != nil {
+		t.Fatalf("First CompleteBrokerJoin failed: %v", err)
+	}
+
+	// Add a user-set label directly on the broker
+	broker, err := s.GetRuntimeBroker(ctx, resp1.BrokerID)
+	if err != nil {
+		t.Fatalf("failed to get broker: %v", err)
+	}
+	broker.Labels["user-label"] = "user-value"
+	if err := s.UpdateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to update broker: %v", err)
+	}
+
+	// Re-register with same name, different labels
+	req2 := CreateBrokerRegistrationRequest{
+		Name: "merge-host",
+		Labels: map[string]string{
+			"scion.io/broker-role": "remote",
+			"custom":              "value2",
+		},
+	}
+
+	resp2, err := svc.CreateBrokerRegistration(ctx, req2, "admin")
+	if err != nil {
+		t.Fatalf("Second CreateBrokerRegistration failed: %v", err)
+	}
+	if resp2.BrokerID != resp1.BrokerID {
+		t.Fatalf("Expected same broker ID on re-registration")
+	}
+
+	// Verify labels were merged: user-label preserved, custom updated
+	broker, err = s.GetRuntimeBroker(ctx, resp2.BrokerID)
+	if err != nil {
+		t.Fatalf("failed to get broker: %v", err)
+	}
+	if broker.Labels["scion.io/broker-role"] != "remote" {
+		t.Errorf("Expected broker-role=remote, got %q", broker.Labels["scion.io/broker-role"])
+	}
+	if broker.Labels["custom"] != "value2" {
+		t.Errorf("Expected custom=value2, got %q", broker.Labels["custom"])
+	}
+	if broker.Labels["user-label"] != "user-value" {
+		t.Errorf("Expected user-label=user-value to be preserved, got %q", broker.Labels["user-label"])
+	}
+}


### PR DESCRIPTION
Makes broker deployment type explicit using the existing Labels infrastructure. Co-located brokers get scion.io/broker-role=embedded, remote brokers get scion.io/broker-role=remote. Labels merge on re-registration (preserving user-set labels)