### PR TITLE
fix(auth): honor SCION_HUB_TOKEN in getHubAccessToken

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -182,16 +182,29 @@ type HubContext struct {
 	IsGlobal    bool
 }
 
-// getHubAccessToken returns an access token for authenticating to the Hub.
-// It checks OAuth credentials first, then falls back to dev-auth tokens.
-// This mirrors the auth resolution order used by hubsync.createHubClient.
+// getHubAccessToken returns an access token for authenticating to the Hub over
+// WebSocket (attach, message streaming). It checks OAuth login credentials
+// first, then a SCION_HUB_TOKEN bearer token, then the dev-auth token —
+// mirroring the *bearer-token* order the REST hub client uses (getHubClient in
+// hub.go). The REST path's agent-token sources (scion-token file,
+// SCION_AUTH_TOKEN) are intentionally omitted here: an agent identity token
+// cannot authenticate a human attach.
 func getHubAccessToken(endpoint string) string {
 	// Priority 1: OAuth credentials from scion hub auth login
 	if token := credentials.GetAccessToken(endpoint); token != "" {
 		return token
 	}
 
-	// Priority 2: Dev auth token
+	// Priority 2: SCION_HUB_TOKEN env — a user access token (scion_pat_…) or
+	// bootstrap bearer token. The REST hub client already honors this; the
+	// WebSocket auth paths (attach, message streaming) must too, or a
+	// dev-auth-off hub driven purely by SCION_HUB_TOKEN answers REST calls but
+	// rejects every attach with "no access token found for Hub".
+	if token := os.Getenv("SCION_HUB_TOKEN"); token != "" {
+		return token
+	}
+
+	// Priority 3: Dev auth token
 	return apiclient.ResolveDevToken()
 }
 

--- a/cmd/common_auth_test.go
+++ b/cmd/common_auth_test.go
@@ -137,6 +137,7 @@ func TestGetHubAccessToken_NoAuth(t *testing.T) {
 	t.Setenv("SCION_DEV_TOKEN", "")
 	t.Setenv("SCION_AUTH_TOKEN", "")
 	t.Setenv("SCION_DEV_TOKEN_FILE", "")
+	t.Setenv("SCION_HUB_TOKEN", "")
 	// Override HOME to prevent finding ~/.scion/dev-token
 	t.Setenv("HOME", tmpDir)
 
@@ -145,4 +146,49 @@ func TestGetHubAccessToken_NoAuth(t *testing.T) {
 	// Should return empty string
 	token := getHubAccessToken(endpoint)
 	assert.Empty(t, token)
+}
+
+func TestGetHubAccessToken_HubTokenEnv(t *testing.T) {
+	// No OAuth credentials.
+	tmpDir := t.TempDir()
+	origPath := credentials.ExportCredentialsPath()
+	credentials.SetCredentialsPath(func() string {
+		return filepath.Join(tmpDir, "credentials.json")
+	})
+	defer credentials.SetCredentialsPath(origPath)
+
+	// A user access token (PAT) in the env, plus a dev token that must NOT win.
+	t.Setenv("SCION_HUB_TOKEN", "scion_pat_env123")
+	t.Setenv("SCION_DEV_TOKEN", "scion_dev_shouldnotuse")
+	t.Setenv("SCION_DEV_TOKEN_FILE", "")
+
+	endpoint := "https://hub.example.com"
+
+	// SCION_HUB_TOKEN is honored, and beats the dev token — matching the REST
+	// hub client. Without this, attach against a dev-auth-off hub driven by
+	// SCION_HUB_TOKEN fails with "no access token found for Hub".
+	token := getHubAccessToken(endpoint)
+	assert.Equal(t, "scion_pat_env123", token)
+}
+
+func TestGetHubAccessToken_OAuthTakesPriorityOverHubToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	origPath := credentials.ExportCredentialsPath()
+	credentials.SetCredentialsPath(func() string {
+		return filepath.Join(tmpDir, "credentials.json")
+	})
+	defer credentials.SetCredentialsPath(origPath)
+
+	endpoint := "https://hub.example.com"
+
+	err := credentials.Store(endpoint, &credentials.TokenResponse{
+		AccessToken: "oauth-wins",
+		ExpiresIn:   1 * time.Hour,
+	})
+	require.NoError(t, err)
+	t.Setenv("SCION_HUB_TOKEN", "scion_pat_shouldnotuse")
+
+	// OAuth still takes priority over the SCION_HUB_TOKEN env.
+	token := getHubAccessToken(endpoint)
+	assert.Equal(t, "oauth-wins", token)
 }

--- a/cmd/common_auth_test.go
+++ b/cmd/common_auth_test.go
@@ -61,9 +61,10 @@ func TestGetHubAccessToken_DevTokenFallback(t *testing.T) {
 	})
 	defer credentials.SetCredentialsPath(origPath)
 
-	// Set a dev token via env var
+	// Set a dev token via env var; clear SCION_HUB_TOKEN, which outranks it
 	t.Setenv("SCION_DEV_TOKEN", "scion_dev_test123")
 	t.Setenv("SCION_DEV_TOKEN_FILE", "")
+	t.Setenv("SCION_HUB_TOKEN", "")
 
 	endpoint := "https://hub.example.com"
 
@@ -81,9 +82,11 @@ func TestGetHubAccessToken_DevTokenFileFallback(t *testing.T) {
 	})
 	defer credentials.SetCredentialsPath(origPath)
 
-	// Clear env-based dev token (including v1 settings env var)
+	// Clear env-based dev token (including v1 settings env var) and
+	// SCION_HUB_TOKEN, which outranks the dev-token file
 	t.Setenv("SCION_DEV_TOKEN", "")
 	t.Setenv("SCION_AUTH_TOKEN", "")
+	t.Setenv("SCION_HUB_TOKEN", "")
 
 	// Set up a dev token file
 	tokenFile := filepath.Join(tmpDir, "dev-token")


### PR DESCRIPTION
## Summary

`scion attach` — and the other paths that resolve a Hub token through
`getHubAccessToken` (`cmd/common.go`): interactive start-and-attach and project
sync — checked only OAuth login credentials and the dev-auth token. They
ignored `SCION_HUB_TOKEN`, even though the REST Hub client (`getHubClient`)
honors it and the docs advertise `export SCION_HUB_TOKEN=scion_pat_...`
(`cmd/hub_token.go`).

## Problem

Against a Hub running `--dev-auth=false` and driven by a user access token (PAT)
in `SCION_HUB_TOKEN`:

- every REST call authenticates correctly (`list`, `start`, …), but
- every `scion attach` fails with
  `no access token found for Hub / Please login first: scion hub auth login`.

So an operator/automation that authenticates purely via `SCION_HUB_TOKEN` can
drive the Hub over REST but can never attach.

## Change

Add `SCION_HUB_TOKEN` as a bearer-token source in `getHubAccessToken`, between
OAuth credentials and the dev-auth token — mirroring the REST client's
resolution order (OAuth > … > `SCION_HUB_TOKEN` > auto dev-auth). Purely
additive: it only applies when no OAuth credential is present, so it cannot
override a more explicit credential.

The REST client's *agent-token* sources (scion-token file, `SCION_AUTH_TOKEN`)
are intentionally not added here — those are in-container agent identities that
cannot authenticate a human attach.

## Testing

`cmd/common_auth_test.go`:
- `SCION_HUB_TOKEN` is honored and beats the dev token.
- OAuth still takes priority over `SCION_HUB_TOKEN`.
- The existing no-auth test now also clears `SCION_HUB_TOKEN` to stay hermetic.

`go test ./cmd/ -run GetHubAccessToken` passes; `go vet ./cmd/` clean.
