### PR TITLE
cmd/harness-config: auto-include hub results in agent context

### DIFF
--- a/cmd/harness_config.go
+++ b/cmd/harness_config.go
@@ -57,6 +57,7 @@ var harnessConfigListCmd = &cobra.Command{
 
 		// Check for --hub flag
 		showHub, _ := cmd.Flags().GetBool("hub")
+		includeHub := showHub || config.IsHubContext()
 
 		type hcEntry struct {
 			Name    string `json:"name"`
@@ -79,8 +80,8 @@ var harnessConfigListCmd = &cobra.Command{
 			})
 		}
 
-		// Include Hub results if requested
-		if showHub {
+		// Include Hub results if requested or when running in hub context (agent containers)
+		if includeHub {
 			hubCtx, err := CheckHubAvailabilityWithOptions(gp, true)
 			if err == nil && hubCtx != nil {
 				hubResp, err := hubCtx.Client.HarnessConfigs().List(context.Background(), &hubclient.ListHarnessConfigsOptions{
@@ -117,7 +118,7 @@ var harnessConfigListCmd = &cobra.Command{
 			return outputJSON(entries)
 		}
 
-		if showHub {
+		if includeHub {
 			fmt.Printf("%-20s %-12s %-8s %s\n", "NAME", "HARNESS", "SOURCE", "IMAGE")
 			for _, e := range entries {
 				image := e.Image


### PR DESCRIPTION
## Problem

scion harness-config list returned "No harness configurations found" inside agent containers. The command only queried the Hub API when --hub was explicitly passed. Agent containers have no local harness-config dirs, so the result was always empty.

## Fix

Added includeHub := showHub || config.IsHubContext() so Hub results are automatically included when running in a hub-connected container (detected via SCION_HUB_ENDPOINT/SCION_HUB_URL/SCION_GROVE_ID/SCION_PROJECT_ID env vars). SOURCE column shown to distinguish local vs hub entries.

Zero behavior change on workstations without those env vars set. --no-hub flag still respected