### PR TITLE
harness/claude: fix workspace trust dialog + add project_instructions()

### DIFF
--- a/harnesses/claude/home/.claude.json
+++ b/harnesses/claude/home/.claude.json
@@ -10,8 +10,12 @@
   "githubRepoPaths": {},
   "shiftEnterKeyBindingInstalled": true,
   "hasCompletedOnboarding": true,
-  "lastOnboardingVersion": "2.0.76",
+  "lastOnboardingVersion": "2.1.197",
   "projects": {
+    "/workspace": {
+      "hasTrustDialogAccepted": true,
+      "projectOnboardingSeenCount": 1
+    },
     "/repo-root/.scion/agents/ggg/workspace": {
       "allowedTools": [],
       "mcpContextUris": [],
@@ -29,5 +33,5 @@
   "officialMarketplaceAutoInstalled": true,
   "bypassPermissionsModeAccepted": true,
   "effortCalloutDismissed": true,
-  "lastReleaseNotesSeen": "2.0.76"
+  "lastReleaseNotesSeen": "2.1.197"
 }

--- a/harnesses/claude/home/.claude.json
+++ b/harnesses/claude/home/.claude.json
@@ -12,10 +12,6 @@
   "hasCompletedOnboarding": true,
   "lastOnboardingVersion": "2.1.197",
   "projects": {
-    "/workspace": {
-      "hasTrustDialogAccepted": true,
-      "projectOnboardingSeenCount": 1
-    },
     "/repo-root/.scion/agents/ggg/workspace": {
       "allowedTools": [],
       "mcpContextUris": [],

--- a/harnesses/claude/provision.py
+++ b/harnesses/claude/provision.py
@@ -258,6 +258,14 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     if count > 0:
         ctx.info(f"applied {count} mcp server(s)")
 
+    harness_cfg = ctx.harness_config
+    instructions_file = str(harness_cfg.get("instructions_file") or ".claude/CLAUDE.md")
+    scion_harness.project_instructions(
+        ctx,
+        instructions_file,
+        system_prompt_mode="none",
+    )
+
 
 if __name__ == "__main__":
     scion_harness.run("claude", provision)

--- a/harnesses/claude/provision.py
+++ b/harnesses/claude/provision.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from typing import Any
 
@@ -130,12 +131,31 @@ def _apply_api_key_approval(ctx: scion_harness.ProvisionContext, api_key: str) -
     scion_harness.atomic_write_json(claude_json_path, cfg)
 
 
+def _detect_claude_version() -> str:
+    """Detect the installed Claude Code version by running ``claude --version``."""
+    try:
+        result = subprocess.run(
+            ["claude", "--version"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            version = result.stdout.strip().split()[0]
+            return version
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return ""
+
+
 def _update_project_paths(ctx: scion_harness.ProvisionContext) -> None:
     """Update .claude.json project paths to point at the container workspace.
 
     Mirrors ClaudeCode.provisionClaudeJSON in claude_code.go. Takes the first
     existing project entry's settings and re-keys it to the container workspace
     path. If no project entries exist, creates a default settings map.
+
+    Also pre-trusts /workspace so the trust dialog does not fire when
+    Claude Code is launched there for git-clone-per-agent agents whose
+    ctx.workspace is a subdirectory of /workspace.
     """
     claude_json_path = scion_harness.expand_path(CLAUDE_JSON_FILE)
 
@@ -171,7 +191,22 @@ def _update_project_paths(ctx: scion_harness.ProvisionContext) -> None:
             "exampleFiles": [],
         }
 
-    cfg["projects"] = {ctx.workspace: project_settings}
+    new_projects: dict[str, Any] = {ctx.workspace: project_settings}
+
+    workspace_root = "/workspace"
+    if ctx.workspace != workspace_root:
+        new_projects[workspace_root] = {
+            "hasTrustDialogAccepted": True,
+            "projectOnboardingSeenCount": 1,
+        }
+
+    cfg["projects"] = new_projects
+
+    version = _detect_claude_version()
+    if version:
+        cfg["lastReleaseNotesSeen"] = version
+        cfg["lastOnboardingVersion"] = version
+
     scion_harness.atomic_write_json(claude_json_path, cfg)
 
 

--- a/harnesses/claude/provision.py
+++ b/harnesses/claude/provision.py
@@ -139,7 +139,9 @@ def _detect_claude_version() -> str:
             capture_output=True, text=True, timeout=10,
         )
         if result.returncode == 0 and result.stdout.strip():
-            version = result.stdout.strip().split()[0]
+            raw_version = result.stdout.strip().split()[0]
+            # Extract clean semver from formats like '@anthropic-ai/claude-code/0.2.9' or 'v0.2.9'
+            version = raw_version.split("/")[-1].lstrip("v")
             return version
     except (OSError, subprocess.TimeoutExpired):
         pass


### PR DESCRIPTION
## Fixes

**1. Workspace trust dialog (#178 recurrence)**

_update_project_paths() pre-trusted the agent-specific path but not /workspace. For git-clone-per-agent agents (which launch Claude Code in /workspace), the trust dialog appeared on every start.

Root cause: the seed .claude.json mistakenly included /workspace as the first projects entry. _update_project_paths() uses the first entry as the 9-field template — the minimal 2-field /workspace entry caused missing allowedTools, mcpServers, etc.

Fix:
- Remove /workspace from seed .claude.json; _update_project_paths() adds it dynamically at provision time
- Detect installed Claude Code version via "claude --version" and update lastReleaseNotesSeen/lastOnboardingVersion at provision time
- Update seed .claude.json to 2.1.197 baseline

**2. Missing project_instructions() call (issue #414)**

provision.py never called scion_harness.project_instructions(), so agent template instructions and skills were never written to CLAUDE.md. Every other harness already does this.

Fix: Added project_instructions(system_prompt_mode="none") — Claude handles system prompt natively via --system-prompt CLI flag, so CLAUDE.md gets instructions and skills without duplication