### PR TITLE
fix(image-build): copy proto/ into scion-base builder stage

### DIFF
--- a/image-build/scion-base/Dockerfile
+++ b/image-build/scion-base/Dockerfile
@@ -36,6 +36,7 @@ RUN go mod download
 COPY cmd/ ./cmd/
 COPY harnesses/ ./harnesses/
 COPY pkg/ ./pkg/
+COPY proto/ ./proto/
 COPY resources/ ./resources/
 COPY web/*.go ./web/
 


### PR DESCRIPTION
## Summary
The builder stage in `image-build/scion-base/Dockerfile` copies `cmd/`, `harnesses/`, `pkg/`, `resources/`, and `web/*.go` but not `proto/`. `pkg/plugin/grpcbroker/adapter.go` imports `github.com/GoogleCloudPlatform/scion/proto/broker/v1`, so the in-image `go build` fails on every build backend (Cloud Build, the Actions workflow, local docker).

One-line fix: copy `proto/` alongside the other source directories.

Fixes #679

## Test Plan
- We have been carrying this exact patch on top of `ddb900fb75e6` in production use: with it, the full `cloudbuild.yaml` image set builds clean on Cloud Build (verified 2026-07-11); without it, the scion-base build fails at `go build` with a missing package error.