### PR TITLE
fix(provision): ensure PYTHONDONTWRITEBYTECODE=1 covers all Python invocation paths

### DIFF
--- a/pkg/harness/bundle_contract_test.go
+++ b/pkg/harness/bundle_contract_test.go
@@ -233,7 +233,7 @@ func runBundleContractCase(t *testing.T, python, hname, caseDir string) {
 
 	// Run provision.py.
 	cmd := exec.Command(python, filepath.Join(bundleDir, "provision.py"), "--manifest", manifestPath)
-	cmd.Env = append(os.Environ(), "HOME="+tmpHome)
+	cmd.Env = append(os.Environ(), "HOME="+tmpHome, "PYTHONDONTWRITEBYTECODE=1")
 	output, err := cmd.CombinedOutput()
 
 	gotExitCode := 0

--- a/pkg/harness/claude_provision_test.go
+++ b/pkg/harness/claude_provision_test.go
@@ -251,7 +251,7 @@ func TestClaudeProvisionScript_Integration_HappyPath(t *testing.T) {
 	}
 
 	cmd := exec.Command(pyPath, scriptPath, "--manifest", manifestPath)
-	cmd.Env = append(os.Environ(), "HOME="+home)
+	cmd.Env = append(os.Environ(), "HOME="+home, "PYTHONDONTWRITEBYTECODE=1")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("provision script failed: %v\noutput: %s", err, out)
@@ -363,7 +363,7 @@ func TestClaudeProvisionScript_Integration_NoCreds(t *testing.T) {
 	}
 
 	cmd := exec.Command(pyPath, scriptPath, "--manifest", manifestPath)
-	cmd.Env = append(os.Environ(), "HOME="+home)
+	cmd.Env = append(os.Environ(), "HOME="+home, "PYTHONDONTWRITEBYTECODE=1")
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected non-zero exit, got success. output: %s", out)
@@ -446,7 +446,7 @@ func TestClaudeProvisionScript_Integration_APIKeyApproval(t *testing.T) {
 	}
 
 	cmd := exec.Command(pyPath, scriptPath, "--manifest", manifestPath)
-	cmd.Env = append(os.Environ(), "HOME="+home)
+	cmd.Env = append(os.Environ(), "HOME="+home, "PYTHONDONTWRITEBYTECODE=1")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("provision script failed: %v\noutput: %s", err, out)
@@ -547,7 +547,7 @@ func TestClaudeProvisionScript_Integration_VertexAI(t *testing.T) {
 	}
 
 	cmd := exec.Command(pyPath, scriptPath, "--manifest", manifestPath)
-	cmd.Env = append(os.Environ(), "HOME="+home)
+	cmd.Env = append(os.Environ(), "HOME="+home, "PYTHONDONTWRITEBYTECODE=1")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("provision script failed: %v\noutput: %s", err, out)
@@ -649,7 +649,7 @@ func TestClaudeProvisionScript_Integration_VertexAI_NoADC(t *testing.T) {
 	}
 
 	cmd := exec.Command(pyPath, scriptPath, "--manifest", manifestPath)
-	cmd.Env = append(os.Environ(), "HOME="+home)
+	cmd.Env = append(os.Environ(), "HOME="+home, "PYTHONDONTWRITEBYTECODE=1")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("provision script failed (GCP SA / no ADC): %v\noutput: %s", err, out)
@@ -784,7 +784,7 @@ func TestClaudeProvisionScript_Integration_MCP(t *testing.T) {
 	}
 
 	cmd := exec.Command(pyPath, scriptPath, "--manifest", filepath.Join(bundle, "manifest.json"))
-	cmd.Env = append(os.Environ(), "HOME="+home)
+	cmd.Env = append(os.Environ(), "HOME="+home, "PYTHONDONTWRITEBYTECODE=1")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("provision script failed: %v\noutput: %s", err, out)

--- a/pkg/sciontool/hooks/lifecycle.go
+++ b/pkg/sciontool/hooks/lifecycle.go
@@ -219,9 +219,12 @@ func (m *LifecycleManager) executeScript(path string) error {
 
 // hookEnv builds the environment for hook scripts. When AgentHome is set,
 // HOME is overridden so that $HOME in hook scripts resolves to the scion
-// user's home directory rather than root's.
+// user's home directory rather than root's. PYTHONDONTWRITEBYTECODE is set
+// to prevent root-owned __pycache__ artifacts from being created during
+// pre-start hooks (which run before privilege drop).
 func (m *LifecycleManager) hookEnv() []string {
 	env := os.Environ()
+	env = append(env, "PYTHONDONTWRITEBYTECODE=1")
 	if m.AgentHome == "" {
 		return env
 	}

--- a/pkg/util/fs.go
+++ b/pkg/util/fs.go
@@ -17,6 +17,7 @@ package util
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -24,11 +25,22 @@ import (
 )
 
 // CopyDir recursively copies a directory tree, attempting to preserve permissions.
-// Source directory must exist.
+// Source directory must exist. Python bytecode artifacts (__pycache__ directories
+// and .pyc files) are skipped to avoid propagating stale, potentially root-owned
+// bytecode into agent homes.
 func CopyDir(src string, dst string) error {
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+
+		base := filepath.Base(path)
+
+		if info.IsDir() && base == "__pycache__" {
+			return filepath.SkipDir
+		}
+		if !info.IsDir() && strings.HasSuffix(base, ".pyc") {
+			return nil
 		}
 
 		rel, err := filepath.Rel(src, path)

--- a/pkg/util/fs_test.go
+++ b/pkg/util/fs_test.go
@@ -103,6 +103,66 @@ func TestCopyDir(t *testing.T) {
 	}
 }
 
+func TestCopyDirSkipsPycache(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	// Create structure with __pycache__ and .pyc files:
+	// src/
+	//   script.py
+	//   __pycache__/
+	//     script.cpython-311.pyc
+	//   subdir/
+	//     lib.py
+	//     lib.pyc
+
+	if err := os.WriteFile(filepath.Join(srcDir, "script.py"), []byte("print('hi')"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	pycacheDir := filepath.Join(srcDir, "__pycache__")
+	if err := os.Mkdir(pycacheDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pycacheDir, "script.cpython-311.pyc"), []byte("bytecode"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	subDir := filepath.Join(srcDir, "subdir")
+	if err := os.Mkdir(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "lib.py"), []byte("def f(): pass"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "lib.pyc"), []byte("bytecode"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	targetDir := filepath.Join(dstDir, "target")
+	if err := CopyDir(srcDir, targetDir); err != nil {
+		t.Fatalf("CopyDir failed: %v", err)
+	}
+
+	// .py files should be copied
+	if _, err := os.Stat(filepath.Join(targetDir, "script.py")); err != nil {
+		t.Errorf("script.py should be copied: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, "subdir", "lib.py")); err != nil {
+		t.Errorf("subdir/lib.py should be copied: %v", err)
+	}
+
+	// __pycache__ directory should NOT be copied
+	if _, err := os.Stat(filepath.Join(targetDir, "__pycache__")); !os.IsNotExist(err) {
+		t.Errorf("__pycache__ should not be copied, got err=%v", err)
+	}
+
+	// .pyc files should NOT be copied
+	if _, err := os.Stat(filepath.Join(targetDir, "subdir", "lib.pyc")); !os.IsNotExist(err) {
+		t.Errorf("lib.pyc should not be copied, got err=%v", err)
+	}
+}
+
 func TestMakeWritableRecursive(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
Regression fix for https://github.com/ptone/scion/issues/417 — root-owned __pycache__ persisted after scion delete because not all Python invocation paths in the provisioner inherited PYTHONDONTWRITEBYTECODE=1 from minimalEnv(). Extends the fix from PR #505