### PR TITLE
fix(server): skip container runtime probe in hosted mode

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -94,7 +94,8 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 	}
 	if _, err := os.Stat(globalDir); os.IsNotExist(err) {
 		log.Println("Initializing global scion directory...")
-		if err := config.InitGlobal(harness.EmbedOnlyHarnesses()); err != nil {
+		initOpts := config.InitMachineOpts{SkipRuntimeCheck: hostedMode}
+		if err := config.InitGlobal(harness.EmbedOnlyHarnesses(), initOpts); err != nil {
 			return fmt.Errorf("failed to initialize global config: %w", err)
 		}
 	} else if !hostedMode {

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -534,6 +534,11 @@ func writeProjectSettings(externalPath, workspacePath, projectID string, opt Ini
 
 // InitMachineOpts controls optional behavior for InitMachine.
 type InitMachineOpts struct {
+	// SkipRuntimeCheck skips local container runtime detection.
+	// Use this when initializing on a hosted server where no local
+	// container runtime is available (e.g. Cloud Run).
+	SkipRuntimeCheck bool
+
 	// ImageRegistry is the container image registry to configure.
 	// If non-empty, it is written into settings after seeding.
 	ImageRegistry string
@@ -561,13 +566,21 @@ func InitMachine(harnesses []api.Harness, opts ...InitMachineOpts) error {
 		return fmt.Errorf("failed to create global directory: %w", err)
 	}
 
+	var opt InitMachineOpts
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
 	// Create global settings file if it doesn't exist
 	settingsPath := GetSettingsPath(globalDir)
 	if settingsPath == "" {
-		// Detect a functioning container runtime before seeding settings
-		detectedRuntime, err := DetectLocalRuntime()
-		if err != nil {
-			return err
+		var detectedRuntime string
+		if !opt.SkipRuntimeCheck {
+			var err error
+			detectedRuntime, err = DetectLocalRuntime()
+			if err != nil {
+				return err
+			}
 		}
 
 		// Seed default YAML settings with the detected runtime
@@ -583,11 +596,6 @@ func InitMachine(harnesses []api.Harness, opts ...InitMachineOpts) error {
 		if err := os.WriteFile(newSettingsPath, defaultSettings, 0644); err != nil {
 			return fmt.Errorf("failed to seed global settings.yaml: %w", err)
 		}
-	}
-
-	var opt InitMachineOpts
-	if len(opts) > 0 {
-		opt = opts[0]
 	}
 
 	agentsDir := filepath.Join(globalDir, "agents")

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -581,6 +581,8 @@ func InitMachine(harnesses []api.Harness, opts ...InitMachineOpts) error {
 			if err != nil {
 				return err
 			}
+		} else {
+			detectedRuntime = "docker"
 		}
 
 		// Seed default YAML settings with the detected runtime

--- a/pkg/config/init_test.go
+++ b/pkg/config/init_test.go
@@ -559,6 +559,19 @@ func TestInitMachine_SkipRuntimeCheck(t *testing.T) {
 	if settingsPath == "" {
 		t.Fatal("expected settings.yaml to be created")
 	}
+
+	// Verify the settings file contains a valid runtime (not empty)
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("failed to read settings: %v", err)
+	}
+	content := string(data)
+	if strings.Contains(content, "runtime: \n") || strings.Contains(content, "runtime:  ") {
+		t.Fatal("expected a valid runtime in settings.yaml when SkipRuntimeCheck is true, got empty runtime")
+	}
+	if !strings.Contains(content, "runtime: docker") {
+		t.Errorf("expected runtime to default to 'docker' when SkipRuntimeCheck is true, got:\n%s", content)
+	}
 }
 
 func TestInitProject_FailsWithNoRuntime(t *testing.T) {

--- a/pkg/config/init_test.go
+++ b/pkg/config/init_test.go
@@ -541,6 +541,26 @@ func TestInitMachine_FailsWithNoRuntime(t *testing.T) {
 	}
 }
 
+func TestInitMachine_SkipRuntimeCheck(t *testing.T) {
+	tmpDir := t.TempDir()
+	mockRuntimeDetectionNone(t)
+
+	origHome := os.Getenv("HOME")
+	_ = os.Setenv("HOME", tmpDir)
+	defer func() { _ = os.Setenv("HOME", origHome) }()
+
+	err := InitMachine(GetMockHarnesses(), InitMachineOpts{SkipRuntimeCheck: true})
+	if err != nil {
+		t.Fatalf("expected InitMachine with SkipRuntimeCheck to succeed, got: %v", err)
+	}
+
+	globalDir := filepath.Join(tmpDir, GlobalDir)
+	settingsPath := GetSettingsPath(globalDir)
+	if settingsPath == "" {
+		t.Fatal("expected settings.yaml to be created")
+	}
+}
+
 func TestInitProject_FailsWithNoRuntime(t *testing.T) {
 	tmpDir := t.TempDir()
 	mockRuntimeDetectionNone(t)


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/419 — InitGlobal was probing for Docker/Podman on Cloud Run (hosted mode) where no local container runtime is present or needed. Adds SkipRuntimeCheck option to InitMachineOpts