### PR TITLE
fix(broker): suppress local docker profile in hosted/Cloud Run mode

### DIFF
--- a/cmd/server_broker.go
+++ b/cmd/server_broker.go
@@ -175,8 +175,21 @@ func registerGlobalProjectAndBroker(ctx context.Context, s store.Store, brokerID
 	return brokerID, nil
 }
 
+// isLocalOnlyRuntime returns true for runtime types that require a local daemon
+// or hardware and cannot function in a hosted cloud environment.
+func isLocalOnlyRuntime(runtimeType string) bool {
+	switch runtimeType {
+	case "docker", "podman", "container":
+		return true
+	}
+	return false
+}
+
 // buildStoreBrokerProfiles builds store.BrokerProfile objects from settings.Profiles.
 // If no profiles are defined in settings, returns a default profile with the detected runtime type.
+// When the detected default runtime is not local-only (e.g. cloudrun, kubernetes),
+// profiles referencing local-only runtimes (docker, podman, container) are
+// filtered out because no local daemon is available in those environments.
 func buildStoreBrokerProfiles(settings *config.Settings, defaultRuntimeType string) []store.BrokerProfile {
 	// If no settings or no profiles defined, return a default profile
 	if settings == nil || len(settings.Profiles) == 0 {
@@ -191,6 +204,10 @@ func buildStoreBrokerProfiles(settings *config.Settings, defaultRuntimeType stri
 		runtimeType := profileCfg.Runtime
 		if runtimeType == "" {
 			runtimeType = defaultRuntimeType
+		}
+
+		if !isLocalOnlyRuntime(defaultRuntimeType) && isLocalOnlyRuntime(runtimeType) {
+			continue
 		}
 
 		// Look up runtime config to get additional info (context, namespace for K8s)
@@ -209,6 +226,12 @@ func buildStoreBrokerProfiles(settings *config.Settings, defaultRuntimeType stri
 			Context:   context,
 			Namespace: namespace,
 		})
+	}
+
+	if len(profiles) == 0 {
+		profiles = []store.BrokerProfile{
+			{Name: "default", Type: defaultRuntimeType, Available: true},
+		}
 	}
 
 	return profiles

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/entc"
+	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/GoogleCloudPlatform/scion/pkg/store/entadapter"
 	"github.com/stretchr/testify/assert"
@@ -196,4 +197,121 @@ func TestRegisterGlobalProjectAndBroker_LabelsOnDedupByName(t *testing.T) {
 	broker, err := s.GetRuntimeBroker(ctx, tid("broker-1"))
 	require.NoError(t, err)
 	assert.Equal(t, "embedded", broker.Labels["scion.io/broker-role"])
+}
+func TestBuildStoreBrokerProfiles_CloudRunFiltersLocalRuntimes(t *testing.T) {
+	settings := &config.Settings{
+		Profiles: map[string]config.ProfileConfig{
+			"local":  {Runtime: "docker"},
+			"remote": {Runtime: "kubernetes"},
+		},
+	}
+
+	profiles := buildStoreBrokerProfiles(settings, "cloudrun")
+
+	assert.Len(t, profiles, 1, "Cloud Run should filter out docker profile")
+	assert.Equal(t, "kubernetes", profiles[0].Type)
+	assert.Equal(t, "remote", profiles[0].Name)
+}
+
+func TestBuildStoreBrokerProfiles_DockerDefaultKeepsAllProfiles(t *testing.T) {
+	settings := &config.Settings{
+		Profiles: map[string]config.ProfileConfig{
+			"local":  {Runtime: "docker"},
+			"remote": {Runtime: "kubernetes"},
+		},
+	}
+
+	profiles := buildStoreBrokerProfiles(settings, "docker")
+
+	assert.Len(t, profiles, 2, "docker default should keep all profiles")
+	types := map[string]bool{}
+	for _, p := range profiles {
+		types[p.Type] = true
+	}
+	assert.True(t, types["docker"])
+	assert.True(t, types["kubernetes"])
+}
+
+func TestBuildStoreBrokerProfiles_EmptyAfterFilterFallsBackToDefault(t *testing.T) {
+	settings := &config.Settings{
+		Profiles: map[string]config.ProfileConfig{
+			"local": {Runtime: "docker"},
+		},
+	}
+
+	profiles := buildStoreBrokerProfiles(settings, "cloudrun")
+
+	assert.Len(t, profiles, 1, "should fall back to default profile when all are filtered")
+	assert.Equal(t, "default", profiles[0].Name)
+	assert.Equal(t, "cloudrun", profiles[0].Type)
+	assert.True(t, profiles[0].Available)
+}
+
+func TestBuildStoreBrokerProfiles_StarterHubKeepsDockerProfiles(t *testing.T) {
+	settings := &config.Settings{
+		Profiles: map[string]config.ProfileConfig{
+			"local":  {Runtime: "docker"},
+			"remote": {Runtime: "kubernetes"},
+		},
+	}
+
+	profiles := buildStoreBrokerProfiles(settings, "docker")
+
+	assert.Len(t, profiles, 2, "starter hub (docker default) should keep docker profiles")
+	types := map[string]bool{}
+	for _, p := range profiles {
+		types[p.Type] = true
+	}
+	assert.True(t, types["docker"], "docker profile should be present")
+	assert.True(t, types["kubernetes"], "kubernetes profile should be present")
+}
+
+func TestRegisterGlobalGroveAndBroker_CloudRunSuppressesDockerProfile(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	settings := &config.Settings{
+		Profiles: map[string]config.ProfileConfig{
+			"local":  {Runtime: "docker"},
+			"remote": {Runtime: "kubernetes"},
+		},
+	}
+	rt := &runtime.MockRuntime{NameFunc: func() string { return "cloudrun" }}
+
+	_, err := registerGlobalProjectAndBroker(ctx, s, tid("broker-1"), "hosted-broker", "http://localhost:9800", rt, true, settings)
+	require.NoError(t, err)
+
+	broker, err := s.GetRuntimeBroker(ctx, tid("broker-1"))
+	require.NoError(t, err)
+
+	for _, p := range broker.Profiles {
+		assert.NotEqual(t, "docker", p.Type, "docker profile should not appear in Cloud Run mode")
+	}
+	assert.Len(t, broker.Profiles, 1)
+	assert.Equal(t, "kubernetes", broker.Profiles[0].Type)
+}
+
+func TestRegisterGlobalGroveAndBroker_StarterHubKeepsDockerProfile(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	settings := &config.Settings{
+		Profiles: map[string]config.ProfileConfig{
+			"local":  {Runtime: "docker"},
+			"remote": {Runtime: "kubernetes"},
+		},
+	}
+	rt := &runtime.MockRuntime{NameFunc: func() string { return "docker" }}
+
+	_, err := registerGlobalProjectAndBroker(ctx, s, tid("broker-1"), "starter-hub", "http://localhost:9800", rt, true, settings)
+	require.NoError(t, err)
+
+	broker, err := s.GetRuntimeBroker(ctx, tid("broker-1"))
+	require.NoError(t, err)
+
+	assert.Len(t, broker.Profiles, 2, "starter hub should keep all profiles including docker")
+	types := map[string]bool{}
+	for _, p := range broker.Profiles {
+		types[p.Type] = true
+	}
+	assert.True(t, types["docker"], "docker profile should be present on starter hub")
+	assert.True(t, types["kubernetes"], "kubernetes profile should be present")
 }


### PR DESCRIPTION
Fixes hosted Hub on Cloud Run registering an unusable docker (local) profile. Threads hostedMode flag through profile building to filter local-only runtimes (docker, podman, container) when they cannot function.

Issue: https://github.com/ptone/scion/issues/429