### PR TITLE
fix: snapshot runtime wiring keys before plugin restart in reconfigureIntegration (#430)

### DIFF
--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -820,6 +820,16 @@ func releasePluginBuildLock(name string) {
 func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationManager, name string) error {
 	pluginCfg := mgr.GetPluginConfig("broker", name)
 
+	// Snapshot runtime/wiring keys before any operation that may kill
+	// the plugin process. These keys are not in config files and must
+	// survive the restart cycle.
+	runtimeSnapshot := make(map[string]string, len(reconfigureRuntimeKeys))
+	for k, v := range pluginCfg {
+		if reconfigureRuntimeKeys[k] && v != "" {
+			runtimeSnapshot[k] = v
+		}
+	}
+
 	// Re-read config file if one is configured.
 	configFile := ""
 	if pluginCfg != nil {
@@ -841,15 +851,6 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 		merged = make(map[string]string)
 	}
 
-	// Carry over runtime/wiring keys from the manager map.
-	// Wiring keys must be included because ReplaceBrokerConfig uses replace
-	// semantics (no underlay from boot-time config).
-	for k, v := range pluginCfg {
-		if reconfigureRuntimeKeys[k] && merged[k] == "" {
-			merged[k] = v
-		}
-	}
-
 	// Inject secrets from the secret backend.
 	mappings := config.PluginSecretKeyMap[name]
 	for _, m := range mappings {
@@ -861,6 +862,16 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 			continue
 		}
 		merged[m.ConfigKey] = val
+	}
+
+	// Re-inject runtime/wiring keys from the snapshot captured before the
+	// process restart. These are authoritative values set by the hub at
+	// startup (hub_url, broker_id, hmac_key, etc.) and are not present in
+	// config files. Apply as underlay so file/secret values are not clobbered.
+	for k, v := range runtimeSnapshot {
+		if merged[k] == "" {
+			merged[k] = v
+		}
 	}
 
 	if err := mgr.ReplaceBrokerConfig(name, merged); err != nil {

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -47,6 +47,7 @@ type mockIntegrationManager struct {
 	installErr         error
 	configureCalls     []string
 	replaceConfigCalls []string
+	lastReplacedConfig map[string]string
 	reconnectCalls     []string
 	updateCalls        []string
 	installCalls       []string
@@ -118,6 +119,10 @@ func (m *mockIntegrationManager) ConfigureBroker(name string, extra map[string]s
 
 func (m *mockIntegrationManager) ReplaceBrokerConfig(name string, cfg map[string]string) error {
 	m.replaceConfigCalls = append(m.replaceConfigCalls, name)
+	m.lastReplacedConfig = make(map[string]string, len(cfg))
+	for k, v := range cfg {
+		m.lastReplacedConfig[k] = v
+	}
 	return m.replaceConfigErr
 }
 
@@ -487,6 +492,89 @@ func TestRestartIntegration_MethodNotAllowed(t *testing.T) {
 
 	if rr.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("expected 405, got %d", rr.Code)
+	}
+}
+
+func TestReconfigureIntegration_PreservesRuntimeKeys(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["telegram"] = map[string]string{
+		"hub_url":          "http://hub:8080",
+		"broker_id":        "br-123",
+		"hmac_key":         "s3cret",
+		"plugin_name":      "telegram",
+		"project_slug_map": "proj1:slug1",
+		"database_url":     "postgres://localhost/scion",
+		"database_driver":  "postgres",
+		"webhook_listen":   ":9095",
+	}
+
+	srv := &Server{}
+
+	if err := srv.reconfigureIntegration(context.Background(), mgr, "telegram"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(mgr.replaceConfigCalls) != 1 {
+		t.Fatalf("expected 1 ReplaceBrokerConfig call, got %d", len(mgr.replaceConfigCalls))
+	}
+
+	wantKeys := map[string]string{
+		"hub_url":          "http://hub:8080",
+		"broker_id":        "br-123",
+		"hmac_key":         "s3cret",
+		"plugin_name":      "telegram",
+		"project_slug_map": "proj1:slug1",
+		"database_url":     "postgres://localhost/scion",
+		"database_driver":  "postgres",
+	}
+	for k, want := range wantKeys {
+		got := mgr.lastReplacedConfig[k]
+		if got != want {
+			t.Errorf("runtime key %q: got %q, want %q", k, got, want)
+		}
+	}
+
+	if got := mgr.lastReplacedConfig["webhook_listen"]; got != ":9095" {
+		t.Errorf("non-runtime key webhook_listen: got %q, want %q", got, ":9095")
+	}
+}
+
+func TestReconfigureIntegration_RuntimeKeysWithConfigFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgFile := filepath.Join(tmpDir, "telegram.yaml")
+	if err := os.WriteFile(cfgFile, []byte("webhook_listen: \":9095\"\nwebhook_path: /hook\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := newMockIntegrationManager()
+	mgr.plugins["telegram"] = map[string]string{
+		"config_file":      cfgFile,
+		"hub_url":          "http://hub:8080",
+		"broker_id":        "br-456",
+		"hmac_key":         "key123",
+		"plugin_name":      "telegram",
+		"project_slug_map": "p:s",
+	}
+
+	srv := &Server{}
+
+	if err := srv.reconfigureIntegration(context.Background(), mgr, "telegram"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := mgr.lastReplacedConfig
+
+	if cfg["hub_url"] != "http://hub:8080" {
+		t.Errorf("hub_url lost after reconfigure with config file: got %q", cfg["hub_url"])
+	}
+	if cfg["broker_id"] != "br-456" {
+		t.Errorf("broker_id lost after reconfigure with config file: got %q", cfg["broker_id"])
+	}
+	if cfg["hmac_key"] != "key123" {
+		t.Errorf("hmac_key lost after reconfigure with config file: got %q", cfg["hmac_key"])
+	}
+	if cfg["webhook_listen"] != ":9095" {
+		t.Errorf("config file key webhook_listen should be present: got %q", cfg["webhook_listen"])
 	}
 }
 


### PR DESCRIPTION
Fixes #430: hub_url, broker_id, hmac_key etc. are now snapshotted before plugin process kill and re-injected after YAML reload + secret injection