### PR TITLE
fix: pass thread-id to Telegram attachment send API calls (#432)

### DIFF
--- a/extras/scion-telegram/internal/telegram/api.go
+++ b/extras/scion-telegram/internal/telegram/api.go
@@ -642,7 +642,7 @@ func (c *TelegramAPIClient) SendMessageWithForceReply(ctx context.Context, chatI
 // access to agent files — a future telegram_attachment_url metadata key
 // should fetch the file from a URL (GCS signed URL or hub download endpoint)
 // instead.
-func (c *TelegramAPIClient) SendDocument(ctx context.Context, chatID int64, filename string, document io.Reader, caption, parseMode string) (*TGMessage, error) {
+func (c *TelegramAPIClient) SendDocument(ctx context.Context, chatID int64, filename string, document io.Reader, caption, parseMode string, opts ...SendOption) (*TGMessage, error) {
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 
@@ -657,6 +657,13 @@ func (c *TelegramAPIClient) SendDocument(ctx context.Context, chatID int64, file
 	if parseMode != "" {
 		if err := writer.WriteField("parse_mode", parseMode); err != nil {
 			return nil, fmt.Errorf("write parse_mode field: %w", err)
+		}
+	}
+	for _, opt := range opts {
+		if opt.MessageThreadID != 0 {
+			if err := writer.WriteField("message_thread_id", fmt.Sprintf("%d", opt.MessageThreadID)); err != nil {
+				return nil, fmt.Errorf("write message_thread_id field: %w", err)
+			}
 		}
 	}
 

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -696,6 +696,14 @@ func (b *TelegramBrokerV2) Publish(ctx context.Context, topic string, msg *messa
 		return b.publishInputNeeded(ctx, api, sq, chatIDs, msg, agentSlug, projectID)
 	}
 
+	// Determine thread ID for Telegram forum topics.
+	var threadOpts []SendOption
+	if msg != nil && msg.ThreadID != "" {
+		if tid, err := strconv.ParseInt(msg.ThreadID, 10, 64); err == nil && tid != 0 {
+			threadOpts = append(threadOpts, SendOption{MessageThreadID: tid})
+		}
+	}
+
 	// File attachment: check msg.Attachments (scion CLI --attach flag convention)
 	// first, then fall back to telegram_attachment_path metadata key.
 	if msg != nil {
@@ -709,7 +717,7 @@ func (b *TelegramBrokerV2) Publish(ctx context.Context, topic string, msg *messa
 			// Translate /workspace/<file> → /home/scion/.scion/projects/<projectSlug>/<file>
 			// Agent containers mount the hub's project directory as /workspace.
 			attachPath = b.resolveAttachmentPath(ctx, store, attachPath, projectID)
-			return b.publishAttachment(ctx, api, chatIDs, msg, agentSlug, attachPath)
+			return b.publishAttachment(ctx, api, chatIDs, msg, agentSlug, attachPath, threadOpts...)
 		}
 	}
 
@@ -746,14 +754,6 @@ func (b *TelegramBrokerV2) Publish(ctx context.Context, topic string, msg *messa
 	if msg != nil && msg.Metadata != nil {
 		if v, ok := msg.Metadata["telegram_message_id"]; ok {
 			replyToMsgID, _ = strconv.ParseInt(v, 10, 64)
-		}
-	}
-
-	// Determine thread ID for Telegram forum topics.
-	var threadOpts []SendOption
-	if msg != nil && msg.ThreadID != "" {
-		if tid, err := strconv.ParseInt(msg.ThreadID, 10, 64); err == nil && tid != 0 {
-			threadOpts = append(threadOpts, SendOption{MessageThreadID: tid})
 		}
 	}
 
@@ -1257,7 +1257,7 @@ func (b *TelegramBrokerV2) resolveAttachmentPath(ctx context.Context, store Stor
 // NOT work when agents and the plugin run in separate GKE pods with isolated
 // volumes. A future telegram_attachment_url metadata key should support
 // fetching the file from a URL (e.g. GCS signed URL) instead.
-func (b *TelegramBrokerV2) publishAttachment(ctx context.Context, api *TelegramAPIClient, chatIDs []int64, msg *messages.StructuredMessage, agentSlug, attachPath string) error {
+func (b *TelegramBrokerV2) publishAttachment(ctx context.Context, api *TelegramAPIClient, chatIDs []int64, msg *messages.StructuredMessage, agentSlug, attachPath string, opts ...SendOption) error {
 	f, err := os.Open(attachPath)
 	if err != nil {
 		b.log.Error("Failed to open attachment file",
@@ -1287,7 +1287,7 @@ func (b *TelegramBrokerV2) publishAttachment(ctx context.Context, api *TelegramA
 			}
 		}
 
-		_, err := api.SendDocument(ctx, chatID, filename, f, caption, "")
+		_, err := api.SendDocument(ctx, chatID, filename, f, caption, "", opts...)
 		if err != nil {
 			var apiErr *APIError
 			if errors.As(err, &apiErr) && apiErr.IsTransient() {


### PR DESCRIPTION
Fixes #432: message_thread_id now threaded through publishAttachment and SendDocument via opts variadic pattern