### PR TITLE
fix(hub): restore wiring keys and eventbus spoke after plugin restart

### DIFF
--- a/pkg/eventbus/fanout.go
+++ b/pkg/eventbus/fanout.go
@@ -47,6 +47,9 @@ type FanOutEventBus struct {
 	mu    sync.RWMutex
 	buses []NamedEventBus
 	log   *slog.Logger
+
+	subMu         sync.Mutex
+	subscriptions []string
 }
 
 // NewFanOutEventBus creates a FanOutEventBus that delegates to the given children.
@@ -152,6 +155,11 @@ func (f *FanOutEventBus) Subscribe(pattern string, handler EventHandler) (Subscr
 		}
 		subs = append(subs, sub)
 	}
+
+	f.subMu.Lock()
+	f.subscriptions = append(f.subscriptions, pattern)
+	f.subMu.Unlock()
+
 	return &fanOutSubscription{subs: subs}, nil
 }
 
@@ -237,6 +245,21 @@ func (f *FanOutEventBus) ReplaceSpoke(name string, newBus NamedEventBus) error {
 	if err := oldBus.Close(); err != nil {
 		f.log.Error("failed to close old spoke during replace", "bus", name, "error", err)
 	}
+
+	// Replay existing subscriptions onto the new spoke so it receives the
+	// same event patterns as the spoke it replaced.
+	f.subMu.Lock()
+	subs := make([]string, len(f.subscriptions))
+	copy(subs, f.subscriptions)
+	f.subMu.Unlock()
+
+	for _, pattern := range subs {
+		if _, err := newBus.Bus.Subscribe(pattern, nil); err != nil {
+			f.log.Error("failed to replay subscription to replaced spoke",
+				"spoke", newBus.Name, "pattern", pattern, "error", err.Error())
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -516,6 +516,11 @@ func (s *Server) handleRestartIntegration(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// reconfigureIntegration pushes new config to the running plugin process
+	// (via ReplaceBrokerConfig) without killing it, so the existing spoke's
+	// RPC connection remains valid — no refreshBrokerSpoke needed here.
+	// Contrast with handleUpdateIntegration which rebuilds the binary and
+	// restarts the process, requiring a spoke refresh.
 	if err := s.reconfigureIntegration(r.Context(), mgr, name); err != nil {
 		slog.Error("Failed to restart integration", "plugin", name, "error", err)
 		InternalError(w)

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -36,6 +36,14 @@ import (
 
 // reconfigureRuntimeKeys lists keys that are injected at runtime/wiring time
 // and must be carried over during reconfigure (they are not in config files).
+var pluginBrokerNS = uuid.MustParse("5c104390-a1d0-5e9a-9b1e-5c104390a1d0")
+
+var hubKeys = map[string]bool{
+	"hub_url": true, "broker_id": true, "hmac_key": true,
+	"plugin_name": true, "project_slug_map": true,
+	"database_driver": true, "database_url": true,
+}
+
 var reconfigureRuntimeKeys = map[string]bool{
 	"config_file":      true,
 	"hub_url":          true,
@@ -830,14 +838,15 @@ func (s *Server) getPluginHubCreds(ctx context.Context, name string) map[string]
 	}
 
 	// broker_id: deterministic UUIDv5 — same namespace and seed as startup.
-	pluginBrokerNS := uuid.MustParse("5c104390-a1d0-5e9a-9b1e-5c104390a1d0")
 	legacyID := "plugin-broker-" + name
 	brokerID := uuid.NewSHA1(pluginBrokerNS, []byte(legacyID)).String()
 	creds["broker_id"] = brokerID
 
 	// hmac_key: from BrokerAuthService (idempotent — returns existing key).
 	if authSvc := s.GetBrokerAuthService(); authSvc != nil {
-		if secretKey, err := authSvc.GenerateAndStoreSecret(ctx, brokerID); err == nil {
+		if secretKey, err := authSvc.GenerateAndStoreSecret(ctx, brokerID); err != nil {
+			slog.Error("Failed to generate or retrieve HMAC key", "plugin", name, "error", err)
+		} else {
 			creds["hmac_key"] = secretKey
 		}
 	}
@@ -847,7 +856,9 @@ func (s *Server) getPluginHubCreds(ctx context.Context, name string) map[string]
 
 	// project_slug_map: from the store.
 	if s.store != nil {
-		if projects, err := s.store.ListProjects(ctx, store.ProjectFilter{}, store.ListOptions{Limit: 500}); err == nil {
+		if projects, err := s.store.ListProjects(ctx, store.ProjectFilter{}, store.ListOptions{Limit: 500}); err != nil {
+			slog.Warn("Failed to list projects for plugin slug map", "plugin", name, "error", err)
+		} else {
 			slugMap := make(map[string]string, len(projects.Items))
 			for _, p := range projects.Items {
 				if p.Slug != "" {
@@ -912,11 +923,6 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 
 	// Carry over non-hub runtime keys (config_file, mode, path, address,
 	// TLS) from the manager's cached config as underlay.
-	hubKeys := map[string]bool{
-		"hub_url": true, "broker_id": true, "hmac_key": true,
-		"plugin_name": true, "project_slug_map": true,
-		"database_driver": true, "database_url": true,
-	}
 	for k, v := range pluginCfg {
 		if reconfigureRuntimeKeys[k] && !hubKeys[k] && v != "" {
 			if merged[k] == "" {

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/ent"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/integrationupdate"
 	"github.com/GoogleCloudPlatform/scion/pkg/plugin"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
 // reconfigureRuntimeKeys lists keys that are injected at runtime/wiring time
@@ -815,20 +816,65 @@ func releasePluginBuildLock(name string) {
 	}
 }
 
+// getPluginHubCreds reconstructs the hub wiring credentials for a broker
+// plugin from live, authoritative sources — the same values that
+// server_foreground.go injects via ConfigureBroker at startup. This avoids
+// relying on the plugin manager's config map, which may be stale or empty
+// after a process restart.
+func (s *Server) getPluginHubCreds(ctx context.Context, name string) map[string]string {
+	creds := make(map[string]string)
+
+	// hub_url: from the server config (same value that startup resolves).
+	if s.config.HubEndpoint != "" {
+		creds["hub_url"] = s.config.HubEndpoint
+	}
+
+	// broker_id: deterministic UUIDv5 — same namespace and seed as startup.
+	pluginBrokerNS := uuid.MustParse("5c104390-a1d0-5e9a-9b1e-5c104390a1d0")
+	legacyID := "plugin-broker-" + name
+	brokerID := uuid.NewSHA1(pluginBrokerNS, []byte(legacyID)).String()
+	creds["broker_id"] = brokerID
+
+	// hmac_key: from BrokerAuthService (idempotent — returns existing key).
+	if authSvc := s.GetBrokerAuthService(); authSvc != nil {
+		if secretKey, err := authSvc.GenerateAndStoreSecret(ctx, brokerID); err == nil {
+			creds["hmac_key"] = secretKey
+		}
+	}
+
+	// plugin_name: the plugin's own name.
+	creds["plugin_name"] = name
+
+	// project_slug_map: from the store.
+	if s.store != nil {
+		if projects, err := s.store.ListProjects(ctx, store.ProjectFilter{}, store.ListOptions{Limit: 500}); err == nil {
+			slugMap := make(map[string]string, len(projects.Items))
+			for _, p := range projects.Items {
+				if p.Slug != "" {
+					slugMap[p.ID] = p.Slug
+				} else {
+					slugMap[p.ID] = p.Name
+				}
+			}
+			if jsonBytes, err := json.Marshal(slugMap); err == nil {
+				creds["project_slug_map"] = string(jsonBytes)
+			}
+		}
+	}
+
+	// database_driver + database_url: only for Postgres backends.
+	if s.dbDriver != "" && s.dbDriver != "sqlite" {
+		creds["database_driver"] = s.dbDriver
+		creds["database_url"] = s.databaseDSN
+	}
+
+	return creds
+}
+
 // reconfigureIntegration reloads config for a plugin and calls ConfigureBroker.
 // For self-managed plugins, it falls back to Reconnect on ConfigureBroker failure.
 func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationManager, name string) error {
 	pluginCfg := mgr.GetPluginConfig("broker", name)
-
-	// Snapshot runtime/wiring keys before any operation that may kill
-	// the plugin process. These keys are not in config files and must
-	// survive the restart cycle.
-	runtimeSnapshot := make(map[string]string, len(reconfigureRuntimeKeys))
-	for k, v := range pluginCfg {
-		if reconfigureRuntimeKeys[k] && v != "" {
-			runtimeSnapshot[k] = v
-		}
-	}
 
 	// Re-read config file if one is configured.
 	configFile := ""
@@ -864,12 +910,28 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 		merged[m.ConfigKey] = val
 	}
 
-	// Re-inject runtime/wiring keys from the snapshot captured before the
-	// process restart. These are authoritative values set by the hub at
-	// startup (hub_url, broker_id, hmac_key, etc.) and are not present in
-	// config files. Apply as underlay so file/secret values are not clobbered.
-	for k, v := range runtimeSnapshot {
-		if merged[k] == "" {
+	// Carry over non-hub runtime keys (config_file, mode, path, address,
+	// TLS) from the manager's cached config as underlay.
+	hubKeys := map[string]bool{
+		"hub_url": true, "broker_id": true, "hmac_key": true,
+		"plugin_name": true, "project_slug_map": true,
+		"database_driver": true, "database_url": true,
+	}
+	for k, v := range pluginCfg {
+		if reconfigureRuntimeKeys[k] && !hubKeys[k] && v != "" {
+			if merged[k] == "" {
+				merged[k] = v
+			}
+		}
+	}
+
+	// Reconstruct hub wiring credentials from authoritative live sources
+	// and apply as OVERRIDE. The manager's cached config may be stale or
+	// empty (e.g. after process restart), so we recompute these values the
+	// same way server_foreground.go does at startup.
+	hubCreds := s.getPluginHubCreds(ctx, name)
+	for k, v := range hubCreds {
+		if v != "" {
 			merged[k] = v
 		}
 	}

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/integrationupdate"
+	"github.com/GoogleCloudPlatform/scion/pkg/eventbus"
 	"github.com/GoogleCloudPlatform/scion/pkg/plugin"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
@@ -79,6 +80,7 @@ type IntegrationManager interface {
 	BrokerInfo(name string) (version, channelID string, capabilities []string, err error)
 	UpdatePlugin(name string, repoPath string) error
 	InstallPlugin(name, repoPath, pluginsDir, configFile string) error
+	GetBroker(name string) (eventbus.EventBus, error)
 	GetGRPCBrokerAdapter(name string) plugin.GRPCBrokerClient
 }
 
@@ -583,6 +585,8 @@ func (s *Server) handleUpdateIntegration(w http.ResponseWriter, r *http.Request,
 		slog.Warn("Plugin rebuilt but reconfigure failed", "plugin", name, "error", err)
 	}
 
+	s.refreshBrokerSpoke(mgr, name)
+
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
@@ -952,6 +956,50 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 	}
 
 	return nil
+}
+
+// refreshBrokerSpoke replaces the stale fan-out eventbus spoke for a broker
+// plugin after its process has been restarted (e.g. UpdatePlugin). The old
+// spoke wraps a dead RPC connection; this swaps in a fresh one.
+func (s *Server) refreshBrokerSpoke(mgr IntegrationManager, name string) {
+	proxy := s.GetMessageBrokerProxy()
+	if proxy == nil {
+		return
+	}
+	fanout, ok := proxy.bus.(*eventbus.FanOutEventBus)
+	if !ok {
+		return
+	}
+
+	newBus, err := mgr.GetBroker(name)
+	if err != nil {
+		slog.Error("Failed to get broker for spoke refresh", "plugin", name, "error", err)
+		return
+	}
+
+	var observer bool
+	var channelID string
+	if _, cID, caps, infoErr := mgr.BrokerInfo(name); infoErr == nil {
+		channelID = cID
+		for _, cap := range caps {
+			if strings.EqualFold(cap, "observer") {
+				observer = true
+				break
+			}
+		}
+	}
+
+	spoke := eventbus.NamedEventBus{
+		Name:      name,
+		Bus:       newBus,
+		Observer:  observer,
+		ChannelID: channelID,
+	}
+	if err := fanout.ReplaceSpoke(name, spoke); err != nil {
+		slog.Error("Failed to replace broker spoke", "plugin", name, "error", err)
+	} else {
+		slog.Info("Replaced broker spoke after plugin restart", "plugin", name)
+	}
 }
 
 // requirePostgres is a feature gate for Mode 3 (HA) endpoints that require

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/integrationupdate"
+	"github.com/GoogleCloudPlatform/scion/pkg/eventbus"
 	"github.com/GoogleCloudPlatform/scion/pkg/plugin"
 	"github.com/GoogleCloudPlatform/scion/pkg/store/enttest"
 	"github.com/google/uuid"
@@ -160,6 +161,10 @@ func (m *mockIntegrationManager) InstallPlugin(name, repoPath, pluginsDir, confi
 		m.plugins[name]["config_file"] = configFile
 	}
 	return nil
+}
+
+func (m *mockIntegrationManager) GetBroker(name string) (eventbus.EventBus, error) {
+	return nil, fmt.Errorf("mock: GetBroker not wired")
 }
 
 func (m *mockIntegrationManager) GetGRPCBrokerAdapter(name string) plugin.GRPCBrokerClient {

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -496,9 +496,13 @@ func TestRestartIntegration_MethodNotAllowed(t *testing.T) {
 }
 
 func TestReconfigureIntegration_PreservesRuntimeKeys(t *testing.T) {
+	// Compute the deterministic broker_id that getPluginHubCreds produces.
+	pluginBrokerNS := uuid.MustParse("5c104390-a1d0-5e9a-9b1e-5c104390a1d0")
+	wantBrokerID := uuid.NewSHA1(pluginBrokerNS, []byte("plugin-broker-telegram")).String()
+
 	mgr := newMockIntegrationManager()
 	mgr.plugins["telegram"] = map[string]string{
-		"hub_url":          "http://hub:8080",
+		"hub_url":          "http://stale:9999",
 		"broker_id":        "br-123",
 		"hmac_key":         "s3cret",
 		"plugin_name":      "telegram",
@@ -508,7 +512,9 @@ func TestReconfigureIntegration_PreservesRuntimeKeys(t *testing.T) {
 		"webhook_listen":   ":9095",
 	}
 
-	srv := &Server{}
+	srv := &Server{
+		config: ServerConfig{HubEndpoint: "http://hub:8080"},
+	}
 
 	if err := srv.reconfigureIntegration(context.Background(), mgr, "telegram"); err != nil {
 		t.Fatal(err)
@@ -519,13 +525,9 @@ func TestReconfigureIntegration_PreservesRuntimeKeys(t *testing.T) {
 	}
 
 	wantKeys := map[string]string{
-		"hub_url":          "http://hub:8080",
-		"broker_id":        "br-123",
-		"hmac_key":         "s3cret",
-		"plugin_name":      "telegram",
-		"project_slug_map": "proj1:slug1",
-		"database_url":     "postgres://localhost/scion",
-		"database_driver":  "postgres",
+		"hub_url":     "http://hub:8080",
+		"broker_id":   wantBrokerID,
+		"plugin_name": "telegram",
 	}
 	for k, want := range wantKeys {
 		got := mgr.lastReplacedConfig[k]
@@ -540,6 +542,9 @@ func TestReconfigureIntegration_PreservesRuntimeKeys(t *testing.T) {
 }
 
 func TestReconfigureIntegration_RuntimeKeysWithConfigFile(t *testing.T) {
+	pluginBrokerNS := uuid.MustParse("5c104390-a1d0-5e9a-9b1e-5c104390a1d0")
+	wantBrokerID := uuid.NewSHA1(pluginBrokerNS, []byte("plugin-broker-telegram")).String()
+
 	tmpDir := t.TempDir()
 	cfgFile := filepath.Join(tmpDir, "telegram.yaml")
 	if err := os.WriteFile(cfgFile, []byte("webhook_listen: \":9095\"\nwebhook_path: /hook\n"), 0644); err != nil {
@@ -549,14 +554,16 @@ func TestReconfigureIntegration_RuntimeKeysWithConfigFile(t *testing.T) {
 	mgr := newMockIntegrationManager()
 	mgr.plugins["telegram"] = map[string]string{
 		"config_file":      cfgFile,
-		"hub_url":          "http://hub:8080",
+		"hub_url":          "http://stale:9999",
 		"broker_id":        "br-456",
 		"hmac_key":         "key123",
 		"plugin_name":      "telegram",
 		"project_slug_map": "p:s",
 	}
 
-	srv := &Server{}
+	srv := &Server{
+		config: ServerConfig{HubEndpoint: "http://hub:8080"},
+	}
 
 	if err := srv.reconfigureIntegration(context.Background(), mgr, "telegram"); err != nil {
 		t.Fatal(err)
@@ -565,16 +572,47 @@ func TestReconfigureIntegration_RuntimeKeysWithConfigFile(t *testing.T) {
 	cfg := mgr.lastReplacedConfig
 
 	if cfg["hub_url"] != "http://hub:8080" {
-		t.Errorf("hub_url lost after reconfigure with config file: got %q", cfg["hub_url"])
+		t.Errorf("hub_url should come from server config: got %q, want %q", cfg["hub_url"], "http://hub:8080")
 	}
-	if cfg["broker_id"] != "br-456" {
-		t.Errorf("broker_id lost after reconfigure with config file: got %q", cfg["broker_id"])
-	}
-	if cfg["hmac_key"] != "key123" {
-		t.Errorf("hmac_key lost after reconfigure with config file: got %q", cfg["hmac_key"])
+	if cfg["broker_id"] != wantBrokerID {
+		t.Errorf("broker_id should be deterministic UUIDv5: got %q, want %q", cfg["broker_id"], wantBrokerID)
 	}
 	if cfg["webhook_listen"] != ":9095" {
 		t.Errorf("config file key webhook_listen should be present: got %q", cfg["webhook_listen"])
+	}
+	if cfg["config_file"] != cfgFile {
+		t.Errorf("config_file should be carried over: got %q, want %q", cfg["config_file"], cfgFile)
+	}
+}
+
+// TestReconfigureIntegration_EmptyManagerConfig verifies that hub wiring keys
+// are reconstructed from live sources even when the plugin manager's config
+// map is empty (the scenario described in issue #430).
+func TestReconfigureIntegration_EmptyManagerConfig(t *testing.T) {
+	pluginBrokerNS := uuid.MustParse("5c104390-a1d0-5e9a-9b1e-5c104390a1d0")
+	wantBrokerID := uuid.NewSHA1(pluginBrokerNS, []byte("plugin-broker-telegram")).String()
+
+	mgr := newMockIntegrationManager()
+	mgr.plugins["telegram"] = map[string]string{}
+
+	srv := &Server{
+		config: ServerConfig{HubEndpoint: "http://hub:8080"},
+	}
+
+	if err := srv.reconfigureIntegration(context.Background(), mgr, "telegram"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := mgr.lastReplacedConfig
+
+	if cfg["hub_url"] != "http://hub:8080" {
+		t.Errorf("hub_url should come from server config even with empty manager map: got %q", cfg["hub_url"])
+	}
+	if cfg["broker_id"] != wantBrokerID {
+		t.Errorf("broker_id should be deterministic UUIDv5 even with empty manager map: got %q", cfg["broker_id"])
+	}
+	if cfg["plugin_name"] != "telegram" {
+		t.Errorf("plugin_name should be set even with empty manager map: got %q", cfg["plugin_name"])
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/430

After UpdatePlugin kills and replaces the plugin process:
1. Inbound: getPluginHubCreds() reconstructs hub_url, broker_id, hmac_key from live server state - avoids relying on stale manager cache
2. Outbound: refreshBrokerSpoke() replaces the stale RPC connection in the fan-out eventbus
3. Subscriptions replayed on new spoke (ReplaceSpoke now mirrors AddSpoke)
Restart endpoint clarified as reconfigure-only (no process kill)