### PR TITLE
fix(broker): make control channel dispatch async to prevent head-of-line blocking

### DIFF
--- a/pkg/runtimebroker/controlchannel.go
+++ b/pkg/runtimebroker/controlchannel.go
@@ -106,6 +106,8 @@ type AgentLookup interface {
 	RuntimeCommand() string
 }
 
+const defaultMaxConcurrentDispatches = 20
+
 // ControlChannelClient manages the WebSocket connection to the Hub.
 type ControlChannelClient struct {
 	config         ControlChannelConfig
@@ -116,6 +118,10 @@ type ControlChannelClient struct {
 	log            *slog.Logger
 	streams        map[string]*StreamHandler
 	streamMu       sync.RWMutex
+
+	// dispatchSem limits concurrent async request dispatches to prevent
+	// unbounded goroutine growth under load.
+	dispatchSem chan struct{}
 
 	// Connection state
 	connected   bool
@@ -153,6 +159,7 @@ func NewControlChannelClient(config ControlChannelConfig, handlers http.Handler,
 		connectionName: connectionName,
 		log:            log,
 		streams:        make(map[string]*StreamHandler),
+		dispatchSem:    make(chan struct{}, defaultMaxConcurrentDispatches),
 	}
 }
 
@@ -467,11 +474,38 @@ func (c *ControlChannelClient) handleMessage(data []byte) error {
 	}
 }
 
-// handleRequest processes a tunneled HTTP request.
-func (c *ControlChannelClient) handleRequest(data []byte) (retErr error) {
+// handleRequest parses the request envelope and dispatches it asynchronously
+// so the message loop is never blocked by slow HTTP handlers (e.g. container
+// creation that can take 60-90s). Without this, the single-threaded message
+// loop cannot call ReadMessage while a handler is running, pong frames are
+// never consumed, and the hub's PongWait expires — dropping the WebSocket.
+func (c *ControlChannelClient) handleRequest(data []byte) error {
 	var req wsprotocol.RequestEnvelope
 	if err := json.Unmarshal(data, &req); err != nil {
 		return fmt.Errorf("failed to parse request: %w", err)
+	}
+
+	if c.config.Debug {
+		c.log.Debug("Control channel request", "method", req.Method, "path", req.Path)
+	}
+
+	c.wg.Add(1)
+	go c.dispatchRequest(req)
+	return nil
+}
+
+// dispatchRequest runs the HTTP handler for a tunneled request and sends the
+// response back over the WebSocket. It acquires the dispatch semaphore to
+// bound concurrency and releases it when done.
+func (c *ControlChannelClient) dispatchRequest(req wsprotocol.RequestEnvelope) {
+	defer c.wg.Done()
+
+	// Acquire dispatch semaphore to limit concurrent goroutines.
+	select {
+	case c.dispatchSem <- struct{}{}:
+		defer func() { <-c.dispatchSem }()
+	case <-c.ctx.Done():
+		return
 	}
 
 	// Recover from panics (e.g. httptest.NewRequest on malformed URLs) to
@@ -481,14 +515,10 @@ func (c *ControlChannelClient) handleRequest(data []byte) (retErr error) {
 			c.log.Error("Panic in control channel request handler", "panic", r, "method", req.Method, "path", req.Path)
 			resp := wsprotocol.NewResponseEnvelope(req.RequestID, http.StatusBadRequest, nil, []byte(fmt.Sprintf(`{"error":"request caused panic: %v"}`, r)))
 			if writeErr := c.conn.WriteJSON(resp); writeErr != nil {
-				retErr = fmt.Errorf("failed to send panic error response: %w", writeErr)
+				c.log.Error("Failed to send panic error response", "error", writeErr)
 			}
 		}
 	}()
-
-	if c.config.Debug {
-		c.log.Debug("Control channel request", "method", req.Method, "path", req.Path)
-	}
 
 	// Build HTTP request
 	path := req.Path
@@ -527,8 +557,9 @@ func (c *ControlChannelClient) handleRequest(data []byte) (retErr error) {
 
 	resp := wsprotocol.NewResponseEnvelope(req.RequestID, result.StatusCode, headers, respBody)
 
-	// Send response
-	return c.conn.WriteJSON(resp)
+	if err := c.conn.WriteJSON(resp); err != nil {
+		c.log.Error("Failed to send response", "error", err, "requestID", req.RequestID)
+	}
 }
 
 // handleStreamOpen processes a stream open request.

--- a/pkg/runtimebroker/controlchannel.go
+++ b/pkg/runtimebroker/controlchannel.go
@@ -489,15 +489,16 @@ func (c *ControlChannelClient) handleRequest(data []byte) error {
 		c.log.Debug("Control channel request", "method", req.Method, "path", req.Path)
 	}
 
+	conn := c.conn
 	c.wg.Add(1)
-	go c.dispatchRequest(req)
+	go c.dispatchRequest(conn, req)
 	return nil
 }
 
 // dispatchRequest runs the HTTP handler for a tunneled request and sends the
 // response back over the WebSocket. It acquires the dispatch semaphore to
 // bound concurrency and releases it when done.
-func (c *ControlChannelClient) dispatchRequest(req wsprotocol.RequestEnvelope) {
+func (c *ControlChannelClient) dispatchRequest(conn *wsprotocol.Connection, req wsprotocol.RequestEnvelope) {
 	defer c.wg.Done()
 
 	// Acquire dispatch semaphore to limit concurrent goroutines.
@@ -514,7 +515,7 @@ func (c *ControlChannelClient) dispatchRequest(req wsprotocol.RequestEnvelope) {
 		if r := recover(); r != nil {
 			c.log.Error("Panic in control channel request handler", "panic", r, "method", req.Method, "path", req.Path)
 			resp := wsprotocol.NewResponseEnvelope(req.RequestID, http.StatusBadRequest, nil, []byte(fmt.Sprintf(`{"error":"request caused panic: %v"}`, r)))
-			if writeErr := c.conn.WriteJSON(resp); writeErr != nil {
+			if writeErr := conn.WriteJSON(resp); writeErr != nil {
 				c.log.Error("Failed to send panic error response", "error", writeErr)
 			}
 		}
@@ -557,7 +558,7 @@ func (c *ControlChannelClient) dispatchRequest(req wsprotocol.RequestEnvelope) {
 
 	resp := wsprotocol.NewResponseEnvelope(req.RequestID, result.StatusCode, headers, respBody)
 
-	if err := c.conn.WriteJSON(resp); err != nil {
+	if err := conn.WriteJSON(resp); err != nil {
 		c.log.Error("Failed to send response", "error", err, "requestID", req.RequestID)
 	}
 }

--- a/pkg/runtimebroker/controlchannel_test.go
+++ b/pkg/runtimebroker/controlchannel_test.go
@@ -252,7 +252,7 @@ func TestDispatchRequest_SendsResponse(t *testing.T) {
 	}
 
 	client.wg.Add(1)
-	go client.dispatchRequest(req)
+	go client.dispatchRequest(brokerConn, req)
 	client.wg.Wait()
 
 	// Read the response from the hub side
@@ -303,7 +303,7 @@ func TestDispatchRequest_PanicRecovery(t *testing.T) {
 	}
 
 	client.wg.Add(1)
-	go client.dispatchRequest(req)
+	go client.dispatchRequest(brokerConn, req)
 	client.wg.Wait()
 
 	// Should receive a 400 error response, not crash
@@ -365,7 +365,7 @@ func TestDispatchRequest_SemaphoreLimitsConcurrency(t *testing.T) {
 			Path:      "/test",
 		}
 		client.wg.Add(1)
-		go client.dispatchRequest(req)
+		go client.dispatchRequest(brokerConn, req)
 	}
 
 	// Give goroutines time to all reach the semaphore
@@ -416,7 +416,7 @@ func TestDispatchRequest_ContextCancelledBeforeSemaphore(t *testing.T) {
 	}
 
 	client.wg.Add(1)
-	go client.dispatchRequest(req)
+	go client.dispatchRequest(brokerConn, req)
 
 	// Give the goroutine time to reach the select
 	time.Sleep(50 * time.Millisecond)

--- a/pkg/runtimebroker/controlchannel_test.go
+++ b/pkg/runtimebroker/controlchannel_test.go
@@ -15,9 +15,20 @@
 package runtimebroker
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/wsprotocol"
+	"github.com/gorilla/websocket"
 )
 
 func TestControlChannelClient_BuildAuthHeaders_Normalization(t *testing.T) {
@@ -103,6 +114,316 @@ func TestControlChannelClient_MarkDisconnected_NilCallback(t *testing.T) {
 	if client.IsConnected() {
 		t.Error("expected disconnected after markDisconnected")
 	}
+}
+
+// newWSPair creates a connected pair of wsprotocol.Connection for testing.
+// It starts an httptest server with a WebSocket endpoint, dials it, and
+// returns (brokerConn, hubConn, cleanup).
+func newWSPair(t *testing.T) (brokerConn, hubConn *wsprotocol.Connection, cleanup func()) {
+	t.Helper()
+	hubReady := make(chan *wsprotocol.Connection, 1)
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade: %v", err)
+		}
+		cfg := wsprotocol.ConnectionConfig{WriteWait: 5 * time.Second}
+		hubReady <- wsprotocol.NewConnection(ws, cfg)
+	}))
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	rawConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	bCfg := wsprotocol.ConnectionConfig{WriteWait: 5 * time.Second}
+	bc := wsprotocol.NewConnection(rawConn, bCfg)
+	hc := <-hubReady
+
+	return bc, hc, func() {
+		_ = bc.Close()
+		_ = hc.Close()
+		srv.Close()
+	}
+}
+
+func makeRequestData(requestID, method, path string) []byte {
+	req := wsprotocol.RequestEnvelope{
+		Type:      "request",
+		RequestID: requestID,
+		Method:    method,
+		Path:      path,
+	}
+	data, _ := json.Marshal(req)
+	return data
+}
+
+func TestHandleRequest_AsyncDoesNotBlockCaller(t *testing.T) {
+	// A handler that blocks for longer than PongWait. Before the fix,
+	// handleRequest would block the message loop for this duration.
+	// With the fix, handleRequest returns immediately.
+	handlerStarted := make(chan struct{})
+	handlerRelease := make(chan struct{})
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(handlerStarted)
+		<-handlerRelease
+		w.WriteHeader(http.StatusOK)
+	})
+
+	brokerConn, _, cleanup := newWSPair(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := &ControlChannelClient{
+		config:      ControlChannelConfig{Debug: true},
+		conn:        brokerConn,
+		handlers:    handler,
+		log:         slog.Default(),
+		streams:     make(map[string]*StreamHandler),
+		dispatchSem: make(chan struct{}, defaultMaxConcurrentDispatches),
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+
+	data := makeRequestData("req-1", "GET", "/api/v1/agents")
+
+	// handleRequest should return almost immediately
+	done := make(chan error, 1)
+	go func() {
+		done <- client.handleRequest(data)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("handleRequest returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleRequest blocked — async dispatch is not working")
+	}
+
+	// The handler goroutine should be running
+	select {
+	case <-handlerStarted:
+		// Good — handler is running asynchronously
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler goroutine was never started")
+	}
+
+	// Release the handler and wait for the dispatch goroutine to finish
+	close(handlerRelease)
+	client.wg.Wait()
+}
+
+func TestDispatchRequest_SendsResponse(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Test", "yes")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	brokerConn, hubConn, cleanup := newWSPair(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := &ControlChannelClient{
+		config:      ControlChannelConfig{Debug: true},
+		conn:        brokerConn,
+		handlers:    handler,
+		log:         slog.Default(),
+		streams:     make(map[string]*StreamHandler),
+		dispatchSem: make(chan struct{}, defaultMaxConcurrentDispatches),
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+
+	req := wsprotocol.RequestEnvelope{
+		Type:      "request",
+		RequestID: "test-req-1",
+		Method:    "GET",
+		Path:      "/api/v1/agents",
+	}
+
+	client.wg.Add(1)
+	go client.dispatchRequest(req)
+	client.wg.Wait()
+
+	// Read the response from the hub side
+	var resp wsprotocol.ResponseEnvelope
+	if err := hubConn.ReadJSON(&resp); err != nil {
+		t.Fatalf("failed to read response from hub side: %v", err)
+	}
+
+	if resp.RequestID != "test-req-1" {
+		t.Errorf("expected requestID 'test-req-1', got %q", resp.RequestID)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+	if string(resp.Body) != `{"ok":true}` {
+		t.Errorf("unexpected body: %s", string(resp.Body))
+	}
+}
+
+func TestDispatchRequest_PanicRecovery(t *testing.T) {
+	// Handler that panics should not crash the process
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("test panic in handler")
+	})
+
+	brokerConn, hubConn, cleanup := newWSPair(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := &ControlChannelClient{
+		config:      ControlChannelConfig{Debug: true},
+		conn:        brokerConn,
+		handlers:    handler,
+		log:         slog.Default(),
+		streams:     make(map[string]*StreamHandler),
+		dispatchSem: make(chan struct{}, defaultMaxConcurrentDispatches),
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+
+	req := wsprotocol.RequestEnvelope{
+		Type:      "request",
+		RequestID: "panic-req",
+		Method:    "GET",
+		Path:      "/panic",
+	}
+
+	client.wg.Add(1)
+	go client.dispatchRequest(req)
+	client.wg.Wait()
+
+	// Should receive a 400 error response, not crash
+	var resp wsprotocol.ResponseEnvelope
+	if err := hubConn.ReadJSON(&resp); err != nil {
+		t.Fatalf("failed to read panic error response: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400 for panic, got %d", resp.StatusCode)
+	}
+	if resp.RequestID != "panic-req" {
+		t.Errorf("expected requestID 'panic-req', got %q", resp.RequestID)
+	}
+}
+
+func TestDispatchRequest_SemaphoreLimitsConcurrency(t *testing.T) {
+	const maxConcurrent = 3
+	var inflight atomic.Int32
+	var maxSeen atomic.Int32
+
+	handlerRelease := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cur := inflight.Add(1)
+		for {
+			old := maxSeen.Load()
+			if cur <= old || maxSeen.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+		<-handlerRelease
+		inflight.Add(-1)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	brokerConn, _, cleanup := newWSPair(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := &ControlChannelClient{
+		config:      ControlChannelConfig{},
+		conn:        brokerConn,
+		handlers:    handler,
+		log:         slog.Default(),
+		streams:     make(map[string]*StreamHandler),
+		dispatchSem: make(chan struct{}, maxConcurrent),
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+
+	// Launch more goroutines than the semaphore allows
+	total := maxConcurrent + 5
+	for i := 0; i < total; i++ {
+		req := wsprotocol.RequestEnvelope{
+			Type:      "request",
+			RequestID: fmt.Sprintf("req-%d", i),
+			Method:    "GET",
+			Path:      "/test",
+		}
+		client.wg.Add(1)
+		go client.dispatchRequest(req)
+	}
+
+	// Give goroutines time to all reach the semaphore
+	time.Sleep(100 * time.Millisecond)
+
+	// Only maxConcurrent should be running inside the handler
+	if cur := inflight.Load(); cur != int32(maxConcurrent) {
+		t.Errorf("expected %d concurrent handlers, got %d", maxConcurrent, cur)
+	}
+
+	close(handlerRelease)
+	client.wg.Wait()
+
+	if max := maxSeen.Load(); max > int32(maxConcurrent) {
+		t.Errorf("max concurrent dispatches exceeded semaphore limit: got %d, limit %d", max, maxConcurrent)
+	}
+}
+
+func TestDispatchRequest_ContextCancelledBeforeSemaphore(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called when context is cancelled")
+	})
+
+	brokerConn, _, cleanup := newWSPair(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	client := &ControlChannelClient{
+		config:      ControlChannelConfig{},
+		conn:        brokerConn,
+		handlers:    handler,
+		log:         slog.Default(),
+		streams:     make(map[string]*StreamHandler),
+		dispatchSem: make(chan struct{}, 1),
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+
+	// Fill the semaphore so the next dispatch blocks on it
+	client.dispatchSem <- struct{}{}
+
+	req := wsprotocol.RequestEnvelope{
+		Type:      "request",
+		RequestID: "cancel-req",
+		Method:    "GET",
+		Path:      "/test",
+	}
+
+	client.wg.Add(1)
+	go client.dispatchRequest(req)
+
+	// Give the goroutine time to reach the select
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel context — the goroutine should exit without calling the handler
+	cancel()
+	client.wg.Wait()
 }
 
 func TestBuildWebSocketURL_Normalization(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/442 — synchronous dispatch blocked ping/pong keepalive causing WebSocket drop after 60s PongWait. Makes dispatch async with semaphore (max 20 concurrent), separate goroutine per dispatch, write mutex covering all write sites