### PR TITLE
feat: per-broker container image state for harness-config detail

### DIFF
--- a/pkg/hub/broker_http_transport.go
+++ b/pkg/hub/broker_http_transport.go
@@ -470,6 +470,75 @@ func (t *brokerHTTPTransport) ExecAgent(ctx context.Context, brokerID, brokerEnd
 	return result.Output, result.ExitCode, nil
 }
 
+// BrokerImageStatusResponse is the response from a broker's /api/v1/images/status endpoint.
+type BrokerImageStatusResponse struct {
+	LocalShort *BrokerImageEntityState `json:"local_short,omitempty"`
+	LocalLong  *BrokerImageEntityState `json:"local_long,omitempty"`
+}
+
+// BrokerImageEntityState describes the local state of a single image entity on a broker.
+type BrokerImageEntityState struct {
+	Exists bool   `json:"exists"`
+	Hash   string `json:"hash,omitempty"`
+}
+
+func (t *brokerHTTPTransport) ImageStatus(ctx context.Context, brokerID, brokerEndpoint, shortImage, longImage string) (*BrokerImageStatusResponse, error) {
+	query := url.Values{}
+	if shortImage != "" {
+		query.Set("short", shortImage)
+	}
+	if longImage != "" {
+		query.Set("long", longImage)
+	}
+	endpoint := fmt.Sprintf("%s/api/v1/images/status?%s", strings.TrimSuffix(brokerEndpoint, "/"), query.Encode())
+
+	resp, err := t.doRequest(ctx, brokerID, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("broker returned status %d", resp.StatusCode)
+	}
+
+	var result BrokerImageStatusResponse
+	if err := t.decodeResponse(resp, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (t *brokerHTTPTransport) PullImage(ctx context.Context, brokerID, brokerEndpoint, image string) error {
+	endpoint := fmt.Sprintf("%s/api/v1/images/pull", strings.TrimSuffix(brokerEndpoint, "/"))
+	body, err := json.Marshal(map[string]string{"image": image})
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+	resp, err := t.doRequest(ctx, brokerID, http.MethodPost, endpoint, body)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		return brokerHTTPError(resp)
+	}
+	return nil
+}
+
+func (t *brokerHTTPTransport) DeleteImage(ctx context.Context, brokerID, brokerEndpoint, image string) error {
+	endpoint := fmt.Sprintf("%s/api/v1/images/%s", strings.TrimSuffix(brokerEndpoint, "/"), url.PathEscape(image))
+	resp, err := t.doRequest(ctx, brokerID, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		return brokerHTTPError(resp)
+	}
+	return nil
+}
+
 func (t *brokerHTTPTransport) CleanupProject(ctx context.Context, brokerID, brokerEndpoint, projectSlug, projectID string) error {
 	endpoint := fmt.Sprintf("%s/api/v1/projects/%s", strings.TrimSuffix(brokerEndpoint, "/"), url.PathEscape(projectSlug))
 	if projectID != "" {

--- a/pkg/hub/broker_http_transport.go
+++ b/pkg/hub/broker_http_transport.go
@@ -470,6 +470,16 @@ func (t *brokerHTTPTransport) ExecAgent(ctx context.Context, brokerID, brokerEnd
 	return result.Output, result.ExitCode, nil
 }
 
+// BrokerUnsupportedError indicates that a broker responded but does not support
+// the requested endpoint (e.g. an old broker that hasn't been upgraded yet).
+type BrokerUnsupportedError struct {
+	StatusCode int
+}
+
+func (e *BrokerUnsupportedError) Error() string {
+	return fmt.Sprintf("broker does not support this endpoint (HTTP %d)", e.StatusCode)
+}
+
 // BrokerImageStatusResponse is the response from a broker's /api/v1/images/status endpoint.
 type BrokerImageStatusResponse struct {
 	LocalShort *BrokerImageEntityState `json:"local_short,omitempty"`
@@ -498,6 +508,9 @@ func (t *brokerHTTPTransport) ImageStatus(ctx context.Context, brokerID, brokerE
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, &BrokerUnsupportedError{StatusCode: resp.StatusCode}
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("broker returned status %d", resp.StatusCode)
 	}

--- a/pkg/hub/broker_http_transport.go
+++ b/pkg/hub/broker_http_transport.go
@@ -527,8 +527,12 @@ func (t *brokerHTTPTransport) PullImage(ctx context.Context, brokerID, brokerEnd
 }
 
 func (t *brokerHTTPTransport) DeleteImage(ctx context.Context, brokerID, brokerEndpoint, image string) error {
-	endpoint := fmt.Sprintf("%s/api/v1/images/%s", strings.TrimSuffix(brokerEndpoint, "/"), url.PathEscape(image))
-	resp, err := t.doRequest(ctx, brokerID, http.MethodDelete, endpoint, nil)
+	endpoint := fmt.Sprintf("%s/api/v1/images/local", strings.TrimSuffix(brokerEndpoint, "/"))
+	body, err := json.Marshal(map[string]string{"image": image})
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+	resp, err := t.doRequest(ctx, brokerID, http.MethodDelete, endpoint, body)
 	if err != nil {
 		return fmt.Errorf("failed to send request: %w", err)
 	}

--- a/pkg/hub/brokerclient.go
+++ b/pkg/hub/brokerclient.go
@@ -102,3 +102,18 @@ func (c *AuthenticatedBrokerClient) CleanupProject(ctx context.Context, brokerID
 func (c *AuthenticatedBrokerClient) FinalizeEnv(ctx context.Context, brokerID, brokerEndpoint, agentID string, env map[string]string) (*RemoteAgentResponse, error) {
 	return c.transport.FinalizeEnv(ctx, brokerID, brokerEndpoint, agentID, env)
 }
+
+// ImageStatus queries a broker's local image state.
+func (c *AuthenticatedBrokerClient) ImageStatus(ctx context.Context, brokerID, brokerEndpoint, shortImage, longImage string) (*BrokerImageStatusResponse, error) {
+	return c.transport.ImageStatus(ctx, brokerID, brokerEndpoint, shortImage, longImage)
+}
+
+// PullImage asks a broker to pull an image from a remote registry.
+func (c *AuthenticatedBrokerClient) PullImage(ctx context.Context, brokerID, brokerEndpoint, image string) error {
+	return c.transport.PullImage(ctx, brokerID, brokerEndpoint, image)
+}
+
+// DeleteImage asks a broker to remove a local image.
+func (c *AuthenticatedBrokerClient) DeleteImage(ctx context.Context, brokerID, brokerEndpoint, image string) error {
+	return c.transport.DeleteImage(ctx, brokerID, brokerEndpoint, image)
+}

--- a/pkg/hub/controlchannel_client.go
+++ b/pkg/hub/controlchannel_client.go
@@ -396,8 +396,11 @@ func (c *ControlChannelBrokerClient) PullImage(ctx context.Context, brokerID, im
 
 // DeleteImage asks a broker to remove a local image via control channel.
 func (c *ControlChannelBrokerClient) DeleteImage(ctx context.Context, brokerID, image string) error {
-	path := fmt.Sprintf("/api/v1/images/%s", url.PathEscape(image))
-	_, err := c.doRequest(ctx, brokerID, "DELETE", path, "", nil)
+	body, err := json.Marshal(map[string]string{"image": image})
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+	_, err = c.doRequest(ctx, brokerID, "DELETE", "/api/v1/images/local", "", body)
 	return err
 }
 

--- a/pkg/hub/controlchannel_client.go
+++ b/pkg/hub/controlchannel_client.go
@@ -362,6 +362,45 @@ func (c *ControlChannelBrokerClient) CleanupProject(ctx context.Context, brokerI
 	return nil
 }
 
+// ImageStatus queries a broker's local image state via control channel.
+func (c *ControlChannelBrokerClient) ImageStatus(ctx context.Context, brokerID, shortImage, longImage string) (*BrokerImageStatusResponse, error) {
+	query := url.Values{}
+	if shortImage != "" {
+		query.Set("short", shortImage)
+	}
+	if longImage != "" {
+		query.Set("long", longImage)
+	}
+
+	resp, err := c.doRequest(ctx, brokerID, "GET", "/api/v1/images/status", query.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result BrokerImageStatusResponse
+	if err := json.Unmarshal(resp.Body, &result); err != nil {
+		return nil, fmt.Errorf("failed to decode image status response: %w", err)
+	}
+	return &result, nil
+}
+
+// PullImage asks a broker to pull an image via control channel.
+func (c *ControlChannelBrokerClient) PullImage(ctx context.Context, brokerID, image string) error {
+	body, err := json.Marshal(map[string]string{"image": image})
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+	_, err = c.doRequest(ctx, brokerID, "POST", "/api/v1/images/pull", "", body)
+	return err
+}
+
+// DeleteImage asks a broker to remove a local image via control channel.
+func (c *ControlChannelBrokerClient) DeleteImage(ctx context.Context, brokerID, image string) error {
+	path := fmt.Sprintf("/api/v1/images/%s", url.PathEscape(image))
+	_, err := c.doRequest(ctx, brokerID, "DELETE", path, "", nil)
+	return err
+}
+
 // FinalizeEnv sends gathered env vars to a broker to complete agent creation via control channel.
 func (c *ControlChannelBrokerClient) FinalizeEnv(ctx context.Context, brokerID, brokerEndpoint, agentID string, env map[string]string) (*RemoteAgentResponse, error) {
 	_ = brokerEndpoint
@@ -651,6 +690,47 @@ func (c *HybridBrokerClient) CleanupProject(ctx context.Context, brokerID, broke
 		return c.controlChannel.CleanupProject(ctx, brokerID, brokerEndpoint, projectSlug, projectID)
 	}
 	return c.httpClient.CleanupProject(ctx, brokerID, brokerEndpoint, projectSlug, projectID)
+}
+
+// brokerImageClient is an optional interface implemented by RuntimeBrokerClient
+// implementations that support image operations.
+type brokerImageClient interface {
+	ImageStatus(ctx context.Context, brokerID, brokerEndpoint, shortImage, longImage string) (*BrokerImageStatusResponse, error)
+	PullImage(ctx context.Context, brokerID, brokerEndpoint, image string) error
+	DeleteImage(ctx context.Context, brokerID, brokerEndpoint, image string) error
+}
+
+// ImageStatus queries a broker's local image state, preferring control channel.
+func (c *HybridBrokerClient) ImageStatus(ctx context.Context, brokerID, brokerEndpoint, shortImage, longImage string) (*BrokerImageStatusResponse, error) {
+	if c.useControlChannel(brokerID) {
+		return c.controlChannel.ImageStatus(ctx, brokerID, shortImage, longImage)
+	}
+	if ic, ok := c.httpClient.(brokerImageClient); ok {
+		return ic.ImageStatus(ctx, brokerID, brokerEndpoint, shortImage, longImage)
+	}
+	return nil, fmt.Errorf("HTTP client does not support image status queries")
+}
+
+// PullImage asks a broker to pull an image, preferring control channel.
+func (c *HybridBrokerClient) PullImage(ctx context.Context, brokerID, brokerEndpoint, image string) error {
+	if c.useControlChannel(brokerID) {
+		return c.controlChannel.PullImage(ctx, brokerID, image)
+	}
+	if ic, ok := c.httpClient.(brokerImageClient); ok {
+		return ic.PullImage(ctx, brokerID, brokerEndpoint, image)
+	}
+	return fmt.Errorf("HTTP client does not support image pull")
+}
+
+// DeleteImage asks a broker to remove a local image, preferring control channel.
+func (c *HybridBrokerClient) DeleteImage(ctx context.Context, brokerID, brokerEndpoint, image string) error {
+	if c.useControlChannel(brokerID) {
+		return c.controlChannel.DeleteImage(ctx, brokerID, image)
+	}
+	if ic, ok := c.httpClient.(brokerImageClient); ok {
+		return ic.DeleteImage(ctx, brokerID, brokerEndpoint, image)
+	}
+	return fmt.Errorf("HTTP client does not support image delete")
 }
 
 // FinalizeEnv sends gathered env vars to a broker, using route() to decide the

--- a/pkg/hub/controlchannel_client.go
+++ b/pkg/hub/controlchannel_client.go
@@ -276,6 +276,10 @@ func (c *ControlChannelBrokerClient) CreateAgentWithGather(ctx context.Context, 
 		return nil, nil, err
 	}
 
+	if resp.StatusCode >= 400 {
+		return nil, nil, fmt.Errorf("runtime broker returned error %d: %s", resp.StatusCode, string(resp.Body))
+	}
+
 	if resp.StatusCode == http.StatusAccepted {
 		var envReqs RemoteEnvRequirementsResponse
 		if err := json.Unmarshal(resp.Body, &envReqs); err != nil {
@@ -372,9 +376,16 @@ func (c *ControlChannelBrokerClient) ImageStatus(ctx context.Context, brokerID, 
 		query.Set("long", longImage)
 	}
 
-	resp, err := c.doRequest(ctx, brokerID, "GET", "/api/v1/images/status", query.Encode(), nil)
+	resp, err := c.doRequestRaw(ctx, brokerID, "GET", "/api/v1/images/status", query.Encode(), nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, &BrokerUnsupportedError{StatusCode: resp.StatusCode}
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("runtime broker returned error %d: %s", resp.StatusCode, string(resp.Body))
 	}
 
 	var result BrokerImageStatusResponse
@@ -385,6 +396,9 @@ func (c *ControlChannelBrokerClient) ImageStatus(ctx context.Context, brokerID, 
 }
 
 // PullImage asks a broker to pull an image via control channel.
+// Note: inherits the tunnel's RequestTimeout (default 120s). Large image pulls
+// may exceed this timeout and report an error even though the pull continues
+// broker-side. A future async-pull mechanism would address this limitation.
 func (c *ControlChannelBrokerClient) PullImage(ctx context.Context, brokerID, image string) error {
 	body, err := json.Marshal(map[string]string{"image": image})
 	if err != nil {
@@ -430,8 +444,8 @@ func (c *ControlChannelBrokerClient) FinalizeEnv(ctx context.Context, brokerID, 
 }
 
 // doRequestRaw tunnels an HTTP request through the control channel without
-// treating non-2xx status codes as errors. This is needed for env-gather
-// where 202 is a valid non-error response.
+// treating non-2xx status codes as errors. Callers are responsible for
+// inspecting resp.StatusCode themselves.
 func (c *ControlChannelBrokerClient) doRequestRaw(ctx context.Context, brokerID, method, path, query string, body []byte) (*wsprotocol.ResponseEnvelope, error) {
 	if !c.manager.IsConnected(brokerID) {
 		return nil, fmt.Errorf("broker %s not connected via control channel", brokerID)
@@ -446,10 +460,6 @@ func (c *ControlChannelBrokerClient) doRequestRaw(ctx context.Context, brokerID,
 	resp, err := c.manager.TunnelRequest(ctx, brokerID, req)
 	if err != nil {
 		return nil, fmt.Errorf("control channel request failed: %w", err)
-	}
-
-	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("runtime broker returned error %d: %s", resp.StatusCode, string(resp.Body))
 	}
 
 	return resp, nil

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -727,7 +727,7 @@ func (s *Server) handleHarnessConfigCheckImage(w http.ResponseWriter, r *http.Re
 						if err != nil {
 							return
 						}
-						if imgResp.LocalShort != nil && imgResp.LocalShort.Exists {
+						if imgResp != nil && imgResp.LocalShort != nil && imgResp.LocalShort.Exists {
 							mu.Lock()
 							found = true
 							mu.Unlock()
@@ -1179,7 +1179,7 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 				} else {
 					entry.Reachable = false
 				}
-			} else {
+			} else if imgResp != nil {
 				entry.Reachable = true
 				entry.LocalShort = imgResp.LocalShort
 				entry.LocalLong = imgResp.LocalLong

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
@@ -34,6 +36,66 @@ type imageManager interface {
 	imagecheck.LocalImageExister
 	PullImage(ctx context.Context, image string) error
 	RemoveImage(ctx context.Context, image string) error
+}
+
+var nodeBoundProfileTypes = map[string]bool{
+	"docker": true,
+	"podman": true,
+	"apple":  true,
+}
+
+func isNodeBoundBroker(broker *store.RuntimeBroker) bool {
+	for _, p := range broker.Profiles {
+		if nodeBoundProfileTypes[p.Type] {
+			return true
+		}
+	}
+	return false
+}
+
+type AggregatedImageStatusResponse struct {
+	Image        string               `json:"image"`
+	Registry     *RegistryImageStatus `json:"registry"`
+	Brokers      []BrokerImageEntry   `json:"brokers"`
+	ProxyBrokers []ProxyBrokerEntry   `json:"proxy_brokers,omitempty"`
+}
+
+type RegistryImageStatus struct {
+	Image     string    `json:"image"`
+	Exists    bool      `json:"exists"`
+	Hash      string    `json:"hash,omitempty"`
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+type BrokerImageEntry struct {
+	BrokerID         string                  `json:"broker_id"`
+	BrokerName       string                  `json:"broker_name"`
+	Reachable        bool                    `json:"reachable"`
+	LocalShort       *BrokerImageEntityState `json:"local_short,omitempty"`
+	LocalLong        *BrokerImageEntityState `json:"local_long,omitempty"`
+	NewerInRegistry  bool                    `json:"newer_in_registry,omitempty"`
+	ResolvedImage    string                  `json:"resolved_image,omitempty"`
+	ResolutionSource string                  `json:"resolution_source,omitempty"`
+}
+
+type ProxyBrokerEntry struct {
+	BrokerID   string `json:"broker_id"`
+	BrokerName string `json:"broker_name"`
+	Runtime    string `json:"runtime"`
+}
+
+func (s *Server) checkRegistryImage(ctx context.Context, longImage string) RegistryImageStatus {
+	now := time.Now()
+	if longImage == "" {
+		return RegistryImageStatus{CheckedAt: now}
+	}
+	result := s.imageChecker.CheckRemoteOnly(ctx, longImage)
+	return RegistryImageStatus{
+		Image:     longImage,
+		Exists:    result.Status == "valid",
+		Hash:      result.Hash,
+		CheckedAt: result.CheckedAt,
+	}
 }
 
 // CreateHarnessConfigRequest is the request body for creating a harness config.
@@ -626,6 +688,57 @@ func (s *Server) handleHarnessConfigCheckImage(w http.ResponseWriter, r *http.Re
 	registry := s.resolveImageRegistry()
 	resolvedImage := config.RewriteImageRegistry(image, registry)
 	slog.Info("checking image status", "id", hc.ID, "image", image, "resolved", resolvedImage, "registry", registry)
+
+	if imagecheck.IsBareImageName(image) {
+		status := "not_found"
+		source := "broker_check"
+
+		brokerResult, err := s.store.ListRuntimeBrokers(ctx, store.RuntimeBrokerFilter{}, store.ListOptions{Limit: 100})
+		if err == nil {
+			var found bool
+			var wg sync.WaitGroup
+			var mu sync.Mutex
+			for i := range brokerResult.Items {
+				b := &brokerResult.Items[i]
+				if !isNodeBoundBroker(b) {
+					continue
+				}
+				wg.Add(1)
+				go func(broker *store.RuntimeBroker) {
+					defer wg.Done()
+					brokerCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+					defer cancel()
+					imgResp, err := s.brokerClient.ImageStatus(brokerCtx, broker.ID, broker.Endpoint, image, "")
+					if err != nil {
+						return
+					}
+					if imgResp.LocalShort != nil && imgResp.LocalShort.Exists {
+						mu.Lock()
+						found = true
+						mu.Unlock()
+					}
+				}(b)
+			}
+			wg.Wait()
+			if found {
+				status = "valid"
+			}
+		}
+
+		now := time.Now()
+		if err := s.store.UpdateHarnessConfigImageStatus(ctx, hc.ID, status, now); err != nil {
+			slog.Warn("failed to persist image status", "id", hc.ID, "error", err)
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"image_status":            status,
+			"image_status_checked_at": now,
+			"source":                  source,
+			"resolved_image":          image,
+		})
+		return
+	}
+
 	result := s.imageChecker.CheckRemoteOnly(ctx, resolvedImage)
 	slog.Info("image check result", "id", hc.ID, "status", result.Status, "source", result.Source, "error", result.Error)
 
@@ -946,7 +1059,7 @@ func (s *Server) handleHarnessConfigReimport(w http.ResponseWriter, r *http.Requ
 	})
 }
 
-// handleHarnessConfigImageStatus returns three-entity image status.
+// handleHarnessConfigImageStatus returns per-broker aggregated image status.
 // GET /api/v1/harness-configs/{id}/image-status
 func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.Request, id string) {
 	if r.Method != http.MethodGet {
@@ -975,36 +1088,91 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 		shortImage = ""
 	}
 
-	result := s.imageChecker.CheckAll(ctx, shortImage, longImage)
+	registryStatus := s.checkRegistryImage(ctx, longImage)
 
-	resp := struct {
-		imagecheck.ThreeWayImageResult
-		HasLocalRuntime    bool   `json:"has_local_runtime"`
-		EmbeddedBrokerName string `json:"embedded_broker_name,omitempty"`
-	}{
-		ThreeWayImageResult: result,
-		HasLocalRuntime:     s.imageManager != nil,
+	brokerResult, err := s.store.ListRuntimeBrokers(ctx, store.RuntimeBrokerFilter{}, store.ListOptions{Limit: 100})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "broker_list_failed", fmt.Sprintf("Failed to list brokers: %v", err), nil)
+		return
 	}
 
-	if brokerID := s.GetEmbeddedBrokerID(); brokerID != "" {
-		if broker, err := s.store.GetRuntimeBroker(ctx, brokerID); err == nil {
-			resp.EmbeddedBrokerName = broker.Name
+	var nodeBound []*store.RuntimeBroker
+	var proxyEntries []ProxyBrokerEntry
+	for i := range brokerResult.Items {
+		b := &brokerResult.Items[i]
+		if isNodeBoundBroker(b) {
+			nodeBound = append(nodeBound, b)
+		} else {
+			runtime := ""
+			for _, p := range b.Profiles {
+				runtime = p.Type
+				break
+			}
+			proxyEntries = append(proxyEntries, ProxyBrokerEntry{
+				BrokerID: b.ID, BrokerName: b.Name, Runtime: runtime,
+			})
 		}
 	}
 
+	brokerEntries := make([]BrokerImageEntry, len(nodeBound))
+	var wg sync.WaitGroup
+	for i, broker := range nodeBound {
+		wg.Add(1)
+		go func(idx int, b *store.RuntimeBroker) {
+			defer wg.Done()
+			entry := BrokerImageEntry{
+				BrokerID:   b.ID,
+				BrokerName: b.Name,
+			}
+
+			brokerCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+			defer cancel()
+
+			imgResp, err := s.brokerClient.ImageStatus(brokerCtx, b.ID, b.Endpoint, shortImage, longImage)
+			if err != nil {
+				entry.Reachable = false
+			} else {
+				entry.Reachable = true
+				entry.LocalShort = imgResp.LocalShort
+				entry.LocalLong = imgResp.LocalLong
+
+				if entry.LocalLong != nil && entry.LocalLong.Exists && registryStatus.Hash != "" && entry.LocalLong.Hash != "" {
+					entry.NewerInRegistry = registryStatus.Hash != entry.LocalLong.Hash
+				}
+
+				switch {
+				case entry.LocalShort != nil && entry.LocalShort.Exists:
+					entry.ResolvedImage = shortImage
+					entry.ResolutionSource = "local_short"
+				case entry.LocalLong != nil && entry.LocalLong.Exists:
+					entry.ResolvedImage = longImage
+					entry.ResolutionSource = "local_long"
+				case registryStatus.Exists:
+					entry.ResolvedImage = longImage
+					entry.ResolutionSource = "remote"
+				default:
+					entry.ResolutionSource = "none"
+				}
+			}
+			brokerEntries[idx] = entry
+		}(i, broker)
+	}
+	wg.Wait()
+
+	resp := AggregatedImageStatusResponse{
+		Image:        image,
+		Registry:     &registryStatus,
+		Brokers:      brokerEntries,
+		ProxyBrokers: proxyEntries,
+	}
 	writeJSON(w, http.StatusOK, resp)
 }
 
 // handleHarnessConfigDeleteLocalImage removes the local short-form image.
-// DELETE /api/v1/harness-configs/{id}/local-image
+// DELETE /api/v1/harness-configs/{id}/local-image?broker_id=...
 func (s *Server) handleHarnessConfigDeleteLocalImage(w http.ResponseWriter, r *http.Request, id string) {
 	if r.Method != http.MethodDelete {
 		MethodNotAllowed(w)
-		return
-	}
-
-	if s.imageManager == nil {
-		writeError(w, http.StatusServiceUnavailable, "no_runtime", "Container runtime not available", nil)
 		return
 	}
 
@@ -1018,6 +1186,26 @@ func (s *Server) handleHarnessConfigDeleteLocalImage(w http.ResponseWriter, r *h
 	image := s.harnessConfigImage(hc)
 	if image == "" || !imagecheck.IsBareImageName(image) {
 		writeError(w, http.StatusBadRequest, "no_local_image", "Harness config has no short-form image to delete", nil)
+		return
+	}
+
+	brokerID := r.URL.Query().Get("broker_id")
+	if brokerID != "" {
+		broker, err := s.store.GetRuntimeBroker(ctx, brokerID)
+		if err != nil {
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		if err := s.brokerClient.DeleteImage(ctx, broker.ID, broker.Endpoint, image); err != nil {
+			writeError(w, http.StatusInternalServerError, "remove_failed", fmt.Sprintf("Failed to remove image on broker %s: %v", broker.Name, err), nil)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "removed", "image": image, "broker_id": broker.ID})
+		return
+	}
+
+	if s.imageManager == nil {
+		writeError(w, http.StatusServiceUnavailable, "no_runtime", "Container runtime not available", nil)
 		return
 	}
 
@@ -1040,15 +1228,10 @@ func (s *Server) handleHarnessConfigDeleteLocalImage(w http.ResponseWriter, r *h
 }
 
 // handleHarnessConfigPullImage pulls the latest image from the remote registry.
-// POST /api/v1/harness-configs/{id}/pull-image
+// POST /api/v1/harness-configs/{id}/pull-image?broker_id=...
 func (s *Server) handleHarnessConfigPullImage(w http.ResponseWriter, r *http.Request, id string) {
 	if r.Method != http.MethodPost {
 		MethodNotAllowed(w)
-		return
-	}
-
-	if s.imageManager == nil {
-		writeError(w, http.StatusServiceUnavailable, "no_runtime", "Container runtime not available", nil)
 		return
 	}
 
@@ -1067,6 +1250,26 @@ func (s *Server) handleHarnessConfigPullImage(w http.ResponseWriter, r *http.Req
 
 	registry := s.resolveImageRegistry()
 	pullImage := config.RewriteImageRegistry(image, registry)
+
+	brokerID := r.URL.Query().Get("broker_id")
+	if brokerID != "" {
+		broker, err := s.store.GetRuntimeBroker(ctx, brokerID)
+		if err != nil {
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		if err := s.brokerClient.PullImage(ctx, broker.ID, broker.Endpoint, pullImage); err != nil {
+			writeError(w, http.StatusInternalServerError, "pull_failed", fmt.Sprintf("Failed to pull image on broker %s: %v", broker.Name, err), nil)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "pulled", "image": pullImage, "broker_id": broker.ID})
+		return
+	}
+
+	if s.imageManager == nil {
+		writeError(w, http.StatusServiceUnavailable, "no_runtime", "Container runtime not available", nil)
+		return
+	}
 
 	if err := s.imageManager.PullImage(ctx, pullImage); err != nil {
 		writeError(w, http.StatusInternalServerError, "pull_failed", fmt.Sprintf("Failed to pull image: %v", err), nil)

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -16,6 +16,7 @@ package hub
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -71,6 +72,7 @@ type BrokerImageEntry struct {
 	BrokerID         string                  `json:"broker_id"`
 	BrokerName       string                  `json:"broker_name"`
 	Reachable        bool                    `json:"reachable"`
+	Unsupported      bool                    `json:"unsupported,omitempty"`
 	LocalShort       *BrokerImageEntityState `json:"local_short,omitempty"`
 	LocalLong        *BrokerImageEntityState `json:"local_long,omitempty"`
 	NewerInRegistry  bool                    `json:"newer_in_registry,omitempty"`
@@ -88,6 +90,12 @@ func (s *Server) checkRegistryImage(ctx context.Context, longImage string) Regis
 	now := time.Now()
 	if longImage == "" {
 		return RegistryImageStatus{CheckedAt: now}
+	}
+	if imagecheck.IsBareImageName(longImage) {
+		return RegistryImageStatus{
+			Image:     longImage,
+			CheckedAt: now,
+		}
 	}
 	result := s.imageChecker.CheckRemoteOnly(ctx, longImage)
 	return RegistryImageStatus{
@@ -690,7 +698,7 @@ func (s *Server) handleHarnessConfigCheckImage(w http.ResponseWriter, r *http.Re
 	slog.Info("checking image status", "id", hc.ID, "image", image, "resolved", resolvedImage, "registry", registry)
 
 	if imagecheck.IsBareImageName(image) {
-		status := "not_found"
+		status := store.HarnessConfigImageStatusUnknown
 		source := "broker_check"
 
 		if s.brokerClient != nil {
@@ -701,6 +709,12 @@ func (s *Server) handleHarnessConfigCheckImage(w http.ResponseWriter, r *http.Re
 				var mu sync.Mutex
 				for i := range brokerResult.Items {
 					b := &brokerResult.Items[i]
+					if _, isPlugin := b.Labels["scion.io/plugin"]; isPlugin {
+						continue
+					}
+					if !s.canDispatchToBroker(ctx, b) {
+						continue
+					}
 					if !isNodeBoundBroker(b) {
 						continue
 					}
@@ -722,8 +736,16 @@ func (s *Server) handleHarnessConfigCheckImage(w http.ResponseWriter, r *http.Re
 				}
 				wg.Wait()
 				if found {
-					status = "valid"
+					status = store.HarnessConfigImageStatusValid
 				}
+			}
+		}
+
+		if status != store.HarnessConfigImageStatusValid && resolvedImage != image {
+			result := s.imageChecker.CheckRemoteOnly(ctx, resolvedImage)
+			if result.Status == "valid" {
+				status = store.HarnessConfigImageStatusValid
+				source = "registry"
 			}
 		}
 
@@ -1110,6 +1132,12 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 	var proxyEntries []ProxyBrokerEntry
 	for i := range brokerResult.Items {
 		b := &brokerResult.Items[i]
+		if _, isPlugin := b.Labels["scion.io/plugin"]; isPlugin {
+			continue
+		}
+		if !s.canDispatchToBroker(ctx, b) {
+			continue
+		}
 		if isNodeBoundBroker(b) {
 			nodeBound = append(nodeBound, b)
 		} else {
@@ -1144,7 +1172,13 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 
 			imgResp, err := s.brokerClient.ImageStatus(brokerCtx, b.ID, b.Endpoint, shortImage, longImage)
 			if err != nil {
-				entry.Reachable = false
+				var unsupported *BrokerUnsupportedError
+				if errors.As(err, &unsupported) {
+					entry.Reachable = true
+					entry.Unsupported = true
+				} else {
+					entry.Reachable = false
+				}
 			} else {
 				entry.Reachable = true
 				entry.LocalShort = imgResp.LocalShort
@@ -1212,6 +1246,10 @@ func (s *Server) handleHarnessConfigDeleteLocalImage(w http.ResponseWriter, r *h
 		broker, err := s.store.GetRuntimeBroker(ctx, brokerID)
 		if err != nil {
 			writeErrorFromErr(w, err, "")
+			return
+		}
+		if !s.canDispatchToBroker(ctx, broker) {
+			writeError(w, http.StatusForbidden, "forbidden", "You do not have permission to perform image operations on this broker", nil)
 			return
 		}
 		if !isNodeBoundBroker(broker) {
@@ -1282,6 +1320,10 @@ func (s *Server) handleHarnessConfigPullImage(w http.ResponseWriter, r *http.Req
 		broker, err := s.store.GetRuntimeBroker(ctx, brokerID)
 		if err != nil {
 			writeErrorFromErr(w, err, "")
+			return
+		}
+		if !s.canDispatchToBroker(ctx, broker) {
+			writeError(w, http.StatusForbidden, "forbidden", "You do not have permission to perform image operations on this broker", nil)
 			return
 		}
 		if !isNodeBoundBroker(broker) {

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -986,8 +986,8 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 		HasLocalRuntime:     s.imageManager != nil,
 	}
 
-	if s.embeddedBrokerID != "" {
-		if broker, err := s.store.GetRuntimeBroker(ctx, s.embeddedBrokerID); err == nil {
+	if brokerID := s.GetEmbeddedBrokerID(); brokerID != "" {
+		if broker, err := s.store.GetRuntimeBroker(ctx, brokerID); err == nil {
 			resp.EmbeddedBrokerName = broker.Name
 		}
 	}

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -626,7 +626,7 @@ func (s *Server) handleHarnessConfigCheckImage(w http.ResponseWriter, r *http.Re
 	registry := s.resolveImageRegistry()
 	resolvedImage := config.RewriteImageRegistry(image, registry)
 	slog.Info("checking image status", "id", hc.ID, "image", image, "resolved", resolvedImage, "registry", registry)
-	result := s.imageChecker.Check(ctx, resolvedImage)
+	result := s.imageChecker.CheckRemoteOnly(ctx, resolvedImage)
 	slog.Info("image check result", "id", hc.ID, "status", result.Status, "source", result.Source, "error", result.Error)
 
 	if err := s.store.UpdateHarnessConfigImageStatus(ctx, hc.ID, result.Status, result.CheckedAt); err != nil {
@@ -976,7 +976,23 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 	}
 
 	result := s.imageChecker.CheckAll(ctx, shortImage, longImage)
-	writeJSON(w, http.StatusOK, result)
+
+	resp := struct {
+		imagecheck.ThreeWayImageResult
+		HasLocalRuntime    bool   `json:"has_local_runtime"`
+		EmbeddedBrokerName string `json:"embedded_broker_name,omitempty"`
+	}{
+		ThreeWayImageResult: result,
+		HasLocalRuntime:     s.imageManager != nil,
+	}
+
+	if s.embeddedBrokerID != "" {
+		if broker, err := s.store.GetRuntimeBroker(ctx, s.embeddedBrokerID); err == nil {
+			resp.EmbeddedBrokerName = broker.Name
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // handleHarnessConfigDeleteLocalImage removes the local short-form image.

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -693,35 +693,37 @@ func (s *Server) handleHarnessConfigCheckImage(w http.ResponseWriter, r *http.Re
 		status := "not_found"
 		source := "broker_check"
 
-		brokerResult, err := s.store.ListRuntimeBrokers(ctx, store.RuntimeBrokerFilter{}, store.ListOptions{Limit: 100})
-		if err == nil {
-			var found bool
-			var wg sync.WaitGroup
-			var mu sync.Mutex
-			for i := range brokerResult.Items {
-				b := &brokerResult.Items[i]
-				if !isNodeBoundBroker(b) {
-					continue
+		if s.brokerClient != nil {
+			brokerResult, err := s.store.ListRuntimeBrokers(ctx, store.RuntimeBrokerFilter{}, store.ListOptions{Limit: 100})
+			if err == nil {
+				var found bool
+				var wg sync.WaitGroup
+				var mu sync.Mutex
+				for i := range brokerResult.Items {
+					b := &brokerResult.Items[i]
+					if !isNodeBoundBroker(b) {
+						continue
+					}
+					wg.Add(1)
+					go func(broker *store.RuntimeBroker) {
+						defer wg.Done()
+						brokerCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+						defer cancel()
+						imgResp, err := s.brokerClient.ImageStatus(brokerCtx, broker.ID, broker.Endpoint, image, "")
+						if err != nil {
+							return
+						}
+						if imgResp.LocalShort != nil && imgResp.LocalShort.Exists {
+							mu.Lock()
+							found = true
+							mu.Unlock()
+						}
+					}(b)
 				}
-				wg.Add(1)
-				go func(broker *store.RuntimeBroker) {
-					defer wg.Done()
-					brokerCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-					defer cancel()
-					imgResp, err := s.brokerClient.ImageStatus(brokerCtx, broker.ID, broker.Endpoint, image, "")
-					if err != nil {
-						return
-					}
-					if imgResp.LocalShort != nil && imgResp.LocalShort.Exists {
-						mu.Lock()
-						found = true
-						mu.Unlock()
-					}
-				}(b)
-			}
-			wg.Wait()
-			if found {
-				status = "valid"
+				wg.Wait()
+				if found {
+					status = "valid"
+				}
 			}
 		}
 
@@ -1090,6 +1092,14 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 
 	registryStatus := s.checkRegistryImage(ctx, longImage)
 
+	if s.brokerClient == nil {
+		writeJSON(w, http.StatusOK, AggregatedImageStatusResponse{
+			Image:    image,
+			Registry: &registryStatus,
+		})
+		return
+	}
+
 	brokerResult, err := s.store.ListRuntimeBrokers(ctx, store.RuntimeBrokerFilter{}, store.ListOptions{Limit: 100})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "broker_list_failed", fmt.Sprintf("Failed to list brokers: %v", err), nil)
@@ -1103,11 +1113,15 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 		if isNodeBoundBroker(b) {
 			nodeBound = append(nodeBound, b)
 		} else {
-			runtime := ""
+			var runtimeTypes []string
+			seen := map[string]bool{}
 			for _, p := range b.Profiles {
-				runtime = p.Type
-				break
+				if !seen[p.Type] {
+					runtimeTypes = append(runtimeTypes, p.Type)
+					seen[p.Type] = true
+				}
 			}
+			runtime := strings.Join(runtimeTypes, ",")
 			proxyEntries = append(proxyEntries, ProxyBrokerEntry{
 				BrokerID: b.ID, BrokerName: b.Name, Runtime: runtime,
 			})
@@ -1191,9 +1205,17 @@ func (s *Server) handleHarnessConfigDeleteLocalImage(w http.ResponseWriter, r *h
 
 	brokerID := r.URL.Query().Get("broker_id")
 	if brokerID != "" {
+		if s.brokerClient == nil {
+			writeError(w, http.StatusServiceUnavailable, "no_broker_client", "Broker routing not available", nil)
+			return
+		}
 		broker, err := s.store.GetRuntimeBroker(ctx, brokerID)
 		if err != nil {
 			writeErrorFromErr(w, err, "")
+			return
+		}
+		if !isNodeBoundBroker(broker) {
+			writeError(w, http.StatusBadRequest, "invalid_broker", "Image operations are only supported on node-bound brokers", nil)
 			return
 		}
 		if err := s.brokerClient.DeleteImage(ctx, broker.ID, broker.Endpoint, image); err != nil {
@@ -1253,9 +1275,17 @@ func (s *Server) handleHarnessConfigPullImage(w http.ResponseWriter, r *http.Req
 
 	brokerID := r.URL.Query().Get("broker_id")
 	if brokerID != "" {
+		if s.brokerClient == nil {
+			writeError(w, http.StatusServiceUnavailable, "no_broker_client", "Broker routing not available", nil)
+			return
+		}
 		broker, err := s.store.GetRuntimeBroker(ctx, brokerID)
 		if err != nil {
 			writeErrorFromErr(w, err, "")
+			return
+		}
+		if !isNodeBoundBroker(broker) {
+			writeError(w, http.StatusBadRequest, "invalid_broker", "Image operations are only supported on node-bound brokers", nil)
 			return
 		}
 		if err := s.brokerClient.PullImage(ctx, broker.ID, broker.Endpoint, pullImage); err != nil {

--- a/pkg/hub/harness_config_handlers_image_test.go
+++ b/pkg/hub/harness_config_handlers_image_test.go
@@ -1,0 +1,376 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/hub/imagecheck"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/GoogleCloudPlatform/scion/pkg/wsprotocol"
+)
+
+type neverConnectedTunnel struct{}
+
+func (n *neverConnectedTunnel) IsConnected(string) bool { return false }
+func (n *neverConnectedTunnel) TunnelRequest(context.Context, string, *wsprotocol.RequestEnvelope) (*wsprotocol.ResponseEnvelope, error) {
+	return nil, fmt.Errorf("not connected")
+}
+
+func TestIsNodeBoundBroker(t *testing.T) {
+	tests := []struct {
+		name     string
+		profiles []store.BrokerProfile
+		want     bool
+	}{
+		{"docker", []store.BrokerProfile{{Type: "docker"}}, true},
+		{"podman", []store.BrokerProfile{{Type: "podman"}}, true},
+		{"apple", []store.BrokerProfile{{Type: "apple"}}, true},
+		{"kubernetes", []store.BrokerProfile{{Type: "kubernetes"}}, false},
+		{"cloudrun", []store.BrokerProfile{{Type: "cloudrun"}}, false},
+		{"mixed_with_docker", []store.BrokerProfile{{Type: "kubernetes"}, {Type: "docker"}}, true},
+		{"empty", nil, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &store.RuntimeBroker{Profiles: tc.profiles}
+			got := isNodeBoundBroker(b)
+			if got != tc.want {
+				t.Errorf("isNodeBoundBroker(%v) = %v, want %v", tc.profiles, got, tc.want)
+			}
+		})
+	}
+}
+
+// fakeBrokerServer creates an httptest server that responds to /api/v1/images/status.
+// statusCode controls the response code; body is returned for 200.
+func fakeBrokerServer(statusCode int, body *BrokerImageStatusResponse) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if statusCode == http.StatusNotFound {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if statusCode != http.StatusOK {
+			w.WriteHeader(statusCode)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+}
+
+func setupImageStatusTest(t *testing.T) (*Server, store.Store) {
+	t.Helper()
+	db, err := newTestStore(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	srv := &Server{
+		store:        db,
+		imageChecker: imagecheck.NewChecker(),
+		authzService: NewAuthzService(db, nil),
+	}
+	return srv, db
+}
+
+func createTestBroker(t *testing.T, db store.Store, id, name, endpoint string, profiles []store.BrokerProfile, labels map[string]string) {
+	t.Helper()
+	broker := &store.RuntimeBroker{
+		ID:       tid(id),
+		Name:     name,
+		Slug:     name,
+		Endpoint: endpoint,
+		Status:   store.BrokerStatusOnline,
+		Profiles: profiles,
+		Labels:   labels,
+		Created:  time.Now(),
+		Updated:  time.Now(),
+	}
+	if err := db.CreateRuntimeBroker(context.Background(), broker); err != nil {
+		t.Fatalf("failed to create broker %s: %v", name, err)
+	}
+}
+
+func createTestHarnessConfig(t *testing.T, db store.Store, id, image string) *store.HarnessConfig {
+	t.Helper()
+	hc := &store.HarnessConfig{
+		ID:      tid(id),
+		Name:    "test-config",
+		Slug:    "test-config",
+		Harness: "test",
+		Scope:   store.HarnessConfigScopeGlobal,
+		Status:  store.HarnessConfigStatusActive,
+		Config: &store.HarnessConfigData{
+			Image: image,
+		},
+	}
+	if err := db.CreateHarnessConfig(context.Background(), hc); err != nil {
+		t.Fatalf("failed to create harness config: %v", err)
+	}
+	return hc
+}
+
+func TestImageStatusHandler_SingleReachableBroker(t *testing.T) {
+	srv, db := setupImageStatusTest(t)
+
+	brokerTS := fakeBrokerServer(http.StatusOK, &BrokerImageStatusResponse{
+		LocalShort: &BrokerImageEntityState{Exists: true, Hash: "sha256:abc123"},
+	})
+	defer brokerTS.Close()
+
+	createTestBroker(t, db, "broker1", "test-broker", brokerTS.URL, []store.BrokerProfile{{Type: "docker"}}, nil)
+	hc := createTestHarnessConfig(t, db, "hc1", "my-image:latest")
+
+	transport := newBrokerHTTPTransport(false, nil)
+	srv.brokerClient = &HybridBrokerClient{
+		controlChannel: &ControlChannelBrokerClient{manager: &neverConnectedTunnel{}},
+		httpClient:     transport,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/harness-configs/"+hc.ID+"/image-status", nil)
+	rr := httptest.NewRecorder()
+	srv.handleHarnessConfigImageStatus(rr, req, hc.ID)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp AggregatedImageStatusResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	if len(resp.Brokers) != 1 {
+		t.Fatalf("expected 1 broker, got %d", len(resp.Brokers))
+	}
+	if !resp.Brokers[0].Reachable {
+		t.Error("expected broker to be reachable")
+	}
+	if resp.Brokers[0].LocalShort == nil || !resp.Brokers[0].LocalShort.Exists {
+		t.Error("expected local_short to exist")
+	}
+}
+
+func TestImageStatusHandler_UnreachableBroker(t *testing.T) {
+	srv, db := setupImageStatusTest(t)
+
+	createTestBroker(t, db, "broker1", "dead-broker", "http://127.0.0.1:1", []store.BrokerProfile{{Type: "docker"}}, nil)
+	hc := createTestHarnessConfig(t, db, "hc1", "my-image:latest")
+
+	transport := newBrokerHTTPTransport(false, nil)
+	srv.brokerClient = &HybridBrokerClient{
+		controlChannel: &ControlChannelBrokerClient{manager: &neverConnectedTunnel{}},
+		httpClient:     transport,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/harness-configs/"+hc.ID+"/image-status", nil)
+	rr := httptest.NewRecorder()
+	srv.handleHarnessConfigImageStatus(rr, req, hc.ID)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp AggregatedImageStatusResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	if len(resp.Brokers) != 1 {
+		t.Fatalf("expected 1 broker, got %d", len(resp.Brokers))
+	}
+	if resp.Brokers[0].Reachable {
+		t.Error("expected broker to be unreachable")
+	}
+}
+
+func TestImageStatusHandler_OldBroker404(t *testing.T) {
+	srv, db := setupImageStatusTest(t)
+
+	brokerTS := fakeBrokerServer(http.StatusNotFound, nil)
+	defer brokerTS.Close()
+
+	createTestBroker(t, db, "broker1", "old-broker", brokerTS.URL, []store.BrokerProfile{{Type: "docker"}}, nil)
+	hc := createTestHarnessConfig(t, db, "hc1", "my-image:latest")
+
+	transport := newBrokerHTTPTransport(false, nil)
+	srv.brokerClient = &HybridBrokerClient{
+		controlChannel: &ControlChannelBrokerClient{manager: &neverConnectedTunnel{}},
+		httpClient:     transport,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/harness-configs/"+hc.ID+"/image-status", nil)
+	rr := httptest.NewRecorder()
+	srv.handleHarnessConfigImageStatus(rr, req, hc.ID)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp AggregatedImageStatusResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	if len(resp.Brokers) != 1 {
+		t.Fatalf("expected 1 broker, got %d", len(resp.Brokers))
+	}
+	b := resp.Brokers[0]
+	if !b.Reachable {
+		t.Error("expected broker to be reachable (it responded, just doesn't support the endpoint)")
+	}
+	if !b.Unsupported {
+		t.Error("expected broker to be marked unsupported")
+	}
+}
+
+func TestImageStatusHandler_NoNodeBoundBrokers(t *testing.T) {
+	srv, db := setupImageStatusTest(t)
+
+	createTestBroker(t, db, "broker1", "k8s-broker", "", []store.BrokerProfile{{Type: "kubernetes"}}, nil)
+	hc := createTestHarnessConfig(t, db, "hc1", "my-image:latest")
+
+	transport := newBrokerHTTPTransport(false, nil)
+	srv.brokerClient = &HybridBrokerClient{
+		controlChannel: &ControlChannelBrokerClient{manager: &neverConnectedTunnel{}},
+		httpClient:     transport,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/harness-configs/"+hc.ID+"/image-status", nil)
+	rr := httptest.NewRecorder()
+	srv.handleHarnessConfigImageStatus(rr, req, hc.ID)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp AggregatedImageStatusResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	if len(resp.Brokers) != 0 {
+		t.Errorf("expected 0 node-bound brokers, got %d", len(resp.Brokers))
+	}
+	if len(resp.ProxyBrokers) != 1 {
+		t.Errorf("expected 1 proxy broker, got %d", len(resp.ProxyBrokers))
+	}
+}
+
+func TestImageStatusHandler_BareImageCheck(t *testing.T) {
+	srv, db := setupImageStatusTest(t)
+
+	brokerTS := fakeBrokerServer(http.StatusOK, &BrokerImageStatusResponse{
+		LocalShort: &BrokerImageEntityState{Exists: true, Hash: "sha256:bare123"},
+	})
+	defer brokerTS.Close()
+
+	createTestBroker(t, db, "broker1", "docker-broker", brokerTS.URL, []store.BrokerProfile{{Type: "docker"}}, nil)
+	hc := createTestHarnessConfig(t, db, "hc1", "my-custom-image")
+
+	transport := newBrokerHTTPTransport(false, nil)
+	srv.brokerClient = &HybridBrokerClient{
+		controlChannel: &ControlChannelBrokerClient{manager: &neverConnectedTunnel{}},
+		httpClient:     transport,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/harness-configs/"+hc.ID+"/check-image", nil)
+	rr := httptest.NewRecorder()
+	srv.handleHarnessConfigCheckImage(rr, req, hc.ID)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	status, ok := resp["image_status"].(string)
+	if !ok {
+		t.Fatal("image_status not found in response")
+	}
+	if status != store.HarnessConfigImageStatusValid {
+		t.Errorf("expected status %q, got %q", store.HarnessConfigImageStatusValid, status)
+	}
+}
+
+func TestImageStatusHandler_MultipleBrokersMixed(t *testing.T) {
+	srv, db := setupImageStatusTest(t)
+
+	reachableTS := fakeBrokerServer(http.StatusOK, &BrokerImageStatusResponse{
+		LocalShort: &BrokerImageEntityState{Exists: true, Hash: "sha256:abc"},
+	})
+	defer reachableTS.Close()
+
+	createTestBroker(t, db, "broker1", "good-broker", reachableTS.URL, []store.BrokerProfile{{Type: "docker"}}, nil)
+	createTestBroker(t, db, "broker2", "bad-broker", "http://127.0.0.1:1", []store.BrokerProfile{{Type: "podman"}}, nil)
+
+	hc := createTestHarnessConfig(t, db, "hc1", "my-image:latest")
+
+	transport := newBrokerHTTPTransport(false, nil)
+	srv.brokerClient = &HybridBrokerClient{
+		controlChannel: &ControlChannelBrokerClient{manager: &neverConnectedTunnel{}},
+		httpClient:     transport,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/harness-configs/"+hc.ID+"/image-status", nil)
+	rr := httptest.NewRecorder()
+	srv.handleHarnessConfigImageStatus(rr, req, hc.ID)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp AggregatedImageStatusResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	if len(resp.Brokers) != 2 {
+		t.Fatalf("expected 2 brokers, got %d", len(resp.Brokers))
+	}
+
+	var reachableCount, unreachableCount int
+	for _, b := range resp.Brokers {
+		if b.Reachable {
+			reachableCount++
+		} else {
+			unreachableCount++
+		}
+	}
+	if reachableCount != 1 || unreachableCount != 1 {
+		t.Errorf("expected 1 reachable and 1 unreachable, got %d reachable and %d unreachable", reachableCount, unreachableCount)
+	}
+}
+
+func TestBrokerUnsupportedError(t *testing.T) {
+	err := &BrokerUnsupportedError{StatusCode: 404}
+	if err.Error() != "broker does not support this endpoint (HTTP 404)" {
+		t.Errorf("unexpected error message: %s", err.Error())
+	}
+}

--- a/pkg/hub/imagecheck/checker.go
+++ b/pkg/hub/imagecheck/checker.go
@@ -93,6 +93,28 @@ func (c *Checker) Check(ctx context.Context, image string) CheckResult {
 	return result
 }
 
+// CheckRemoteOnly checks only the remote registry, ignoring local state.
+// Used for persisted ImageStatus which should reflect registry validity only.
+// Bare image names are local-only and delegate to the full Check method.
+func (c *Checker) CheckRemoteOnly(ctx context.Context, image string) CheckResult {
+	now := time.Now()
+
+	if IsBareImageName(image) {
+		return c.Check(ctx, image)
+	}
+
+	ref, err := parseImageRef(image)
+	if err != nil {
+		return CheckResult{
+			Status:    "invalid",
+			Error:     err.Error(),
+			CheckedAt: now,
+		}
+	}
+
+	return checkRemoteImage(ctx, c.client, ref, now)
+}
+
 // IsBareImageName returns true when the image reference has no explicit
 // registry prefix (no '.' or ':' in the first path component before any '/').
 func IsBareImageName(image string) bool {

--- a/pkg/hub/imagecheck/checker.go
+++ b/pkg/hub/imagecheck/checker.go
@@ -93,9 +93,10 @@ func (c *Checker) Check(ctx context.Context, image string) CheckResult {
 	return result
 }
 
-// CheckRemoteOnly checks only the remote registry, ignoring local state.
-// Used for persisted ImageStatus which should reflect registry validity only.
-// Bare image names are local-only and delegate to the full Check method.
+// CheckRemoteOnly checks the remote registry for registry-qualified images,
+// ignoring local state. Bare image names (no registry prefix) delegate to the
+// full Check method since they can only be verified locally.
+// Used for persisted ImageStatus which should reflect registry/reference validity.
 func (c *Checker) CheckRemoteOnly(ctx context.Context, image string) CheckResult {
 	now := time.Now()
 

--- a/pkg/hub/resource_bootstrap.go
+++ b/pkg/hub/resource_bootstrap.go
@@ -171,7 +171,7 @@ func (s *Server) checkAndUpdateImageStatus(ctx context.Context, hcID, image stri
 	registry := s.resolveImageRegistry()
 	resolvedImage := config.RewriteImageRegistry(image, registry)
 
-	result := s.imageChecker.Check(ctx, resolvedImage)
+	result := s.imageChecker.CheckRemoteOnly(ctx, resolvedImage)
 	if result.Error != "" {
 		slog.Warn("image status check returned error", "id", hcID, "image", image, "resolved", resolvedImage, "status", result.Status, "error", result.Error)
 	}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -686,6 +686,7 @@ type Server struct {
 	imageChecker      *imagecheck.Checker
 	imageManager      imageManager
 	imageStatusFlight singleflight.Group
+	brokerClient      *HybridBrokerClient
 
 	// Mode 3 (HA) integration support fields.
 	// dbDriver records the database backend ("sqlite" or "postgres") for
@@ -1840,6 +1841,7 @@ func (s *Server) CreateAuthenticatedDispatcher() *HTTPAgentDispatcher {
 		if statelessBrokerID := s.GetStatelessEmbeddedBrokerID(); statelessBrokerID != "" {
 			hbc.SetStatelessLocalBrokers([]string{statelessBrokerID})
 		}
+		s.brokerClient = hbc
 		client = hbc
 	} else {
 		client = httpClient

--- a/pkg/runtime/mock.go
+++ b/pkg/runtime/mock.go
@@ -31,6 +31,7 @@ type MockRuntime struct {
 	ImageExistsFunc      func(ctx context.Context, image string) (bool, error)
 	ImageIDFunc          func(ctx context.Context, image string) (string, error)
 	RemoveImageFunc      func(ctx context.Context, image string) error
+	PullImageFunc        func(ctx context.Context, image string) error
 	SyncFunc             func(ctx context.Context, id string, direction SyncDirection) error
 	ExecFunc             func(ctx context.Context, id string, cmd []string) (string, error)
 	GetWorkspacePathFunc func(ctx context.Context, id string) (string, error)
@@ -111,6 +112,9 @@ func (m *MockRuntime) RemoveImage(ctx context.Context, image string) error {
 }
 
 func (m *MockRuntime) PullImage(ctx context.Context, image string) error {
+	if m.PullImageFunc != nil {
+		return m.PullImageFunc(ctx, image)
+	}
 	return nil
 }
 

--- a/pkg/runtimebroker/image_handlers.go
+++ b/pkg/runtimebroker/image_handlers.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtimebroker
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// ImageStatusResponse is the response for GET /api/v1/images/status.
+type ImageStatusResponse struct {
+	LocalShort *ImageEntityState `json:"local_short,omitempty"`
+	LocalLong  *ImageEntityState `json:"local_long,omitempty"`
+}
+
+// ImageEntityState represents the local state of a single image reference.
+type ImageEntityState struct {
+	Exists bool   `json:"exists"`
+	Hash   string `json:"hash,omitempty"`
+}
+
+// ImagePullRequest is the request body for POST /api/v1/images/pull.
+type ImagePullRequest struct {
+	Image string `json:"image"`
+}
+
+// ImageDeleteRequest is the request body for DELETE /api/v1/images/local.
+type ImageDeleteRequest struct {
+	Image string `json:"image"`
+}
+
+func (s *Server) handleImageStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	ctx := r.Context()
+	query := r.URL.Query()
+	shortImage := query.Get("short")
+	longImage := query.Get("long")
+
+	if shortImage == "" && longImage == "" {
+		BadRequest(w, "at least one of 'short' or 'long' query parameters is required")
+		return
+	}
+
+	resp := ImageStatusResponse{}
+
+	if shortImage != "" {
+		state := &ImageEntityState{}
+		exists, err := s.runtime.ImageExists(ctx, shortImage)
+		if err != nil {
+			RuntimeError(w, fmt.Sprintf("failed to check image %q: %v", shortImage, err))
+			return
+		}
+		state.Exists = exists
+		if exists {
+			if hash, err := s.runtime.ImageID(ctx, shortImage); err == nil {
+				state.Hash = hash
+			}
+		}
+		resp.LocalShort = state
+	}
+
+	if longImage != "" {
+		state := &ImageEntityState{}
+		exists, err := s.runtime.ImageExists(ctx, longImage)
+		if err != nil {
+			RuntimeError(w, fmt.Sprintf("failed to check image %q: %v", longImage, err))
+			return
+		}
+		state.Exists = exists
+		if exists {
+			if hash, err := s.runtime.ImageID(ctx, longImage); err == nil {
+				state.Hash = hash
+			}
+		}
+		resp.LocalLong = state
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleImagePull(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w)
+		return
+	}
+
+	var req ImagePullRequest
+	if err := readJSON(r, &req); err != nil {
+		BadRequest(w, "invalid request body: "+err.Error())
+		return
+	}
+	if req.Image == "" {
+		ValidationError(w, "image is required", nil)
+		return
+	}
+
+	ctx := r.Context()
+	if err := s.runtime.PullImage(ctx, req.Image); err != nil {
+		RuntimeError(w, fmt.Sprintf("failed to pull image %q: %v", req.Image, err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "pulled", "image": req.Image})
+}
+
+func (s *Server) handleImageDeleteLocal(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		MethodNotAllowed(w)
+		return
+	}
+
+	var req ImageDeleteRequest
+	if err := readJSON(r, &req); err != nil {
+		BadRequest(w, "invalid request body: "+err.Error())
+		return
+	}
+	if req.Image == "" {
+		ValidationError(w, "image is required", nil)
+		return
+	}
+
+	ctx := r.Context()
+
+	exists, err := s.runtime.ImageExists(ctx, req.Image)
+	if err != nil {
+		RuntimeError(w, fmt.Sprintf("failed to check image %q: %v", req.Image, err))
+		return
+	}
+	if !exists {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "not_found", "image": req.Image})
+		return
+	}
+
+	if err := s.runtime.RemoveImage(ctx, req.Image); err != nil {
+		RuntimeError(w, fmt.Sprintf("failed to remove image %q: %v", req.Image, err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "removed", "image": req.Image})
+}

--- a/pkg/runtimebroker/image_handlers_test.go
+++ b/pkg/runtimebroker/image_handlers_test.go
@@ -1,0 +1,364 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtimebroker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
+)
+
+func newImageTestServer(t *testing.T, rt *runtime.MockRuntime) *Server {
+	t.Helper()
+	cfg := DefaultServerConfig()
+	cfg.BrokerID = "test-broker"
+	cfg.BrokerName = "test-host"
+	cfg.HubEnabled = false
+	mgr := &mockManager{}
+	srv := &Server{
+		config:  cfg,
+		manager: mgr,
+		runtime: rt,
+		mux:     http.NewServeMux(),
+	}
+	srv.registerRoutes()
+	return srv
+}
+
+// --- GET /api/v1/images/status ---
+
+func TestImageStatus_BothExist(t *testing.T) {
+	rt := &runtime.MockRuntime{
+		ImageExistsFunc: func(_ context.Context, image string) (bool, error) {
+			return true, nil
+		},
+		ImageIDFunc: func(_ context.Context, image string) (string, error) {
+			if image == "myimage" {
+				return "sha256:aaa", nil
+			}
+			return "sha256:bbb", nil
+		},
+	}
+	srv := newImageTestServer(t, rt)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/images/status?short=myimage&long=registry.io/myimage:latest", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp ImageStatusResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.LocalShort == nil || !resp.LocalShort.Exists || resp.LocalShort.Hash != "sha256:aaa" {
+		t.Errorf("unexpected LocalShort: %+v", resp.LocalShort)
+	}
+	if resp.LocalLong == nil || !resp.LocalLong.Exists || resp.LocalLong.Hash != "sha256:bbb" {
+		t.Errorf("unexpected LocalLong: %+v", resp.LocalLong)
+	}
+}
+
+func TestImageStatus_ShortExistsLongDoesNot(t *testing.T) {
+	rt := &runtime.MockRuntime{
+		ImageExistsFunc: func(_ context.Context, image string) (bool, error) {
+			return image == "myimage", nil
+		},
+		ImageIDFunc: func(_ context.Context, image string) (string, error) {
+			return "sha256:aaa", nil
+		},
+	}
+	srv := newImageTestServer(t, rt)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/images/status?short=myimage&long=registry.io/myimage:latest", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp ImageStatusResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.LocalShort == nil || !resp.LocalShort.Exists {
+		t.Errorf("expected LocalShort.Exists=true, got %+v", resp.LocalShort)
+	}
+	if resp.LocalLong == nil || resp.LocalLong.Exists {
+		t.Errorf("expected LocalLong.Exists=false, got %+v", resp.LocalLong)
+	}
+}
+
+func TestImageStatus_NeitherExists(t *testing.T) {
+	rt := &runtime.MockRuntime{
+		ImageExistsFunc: func(_ context.Context, image string) (bool, error) {
+			return false, nil
+		},
+	}
+	srv := newImageTestServer(t, rt)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/images/status?short=a&long=b", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp ImageStatusResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.LocalShort == nil || resp.LocalShort.Exists {
+		t.Errorf("expected LocalShort.Exists=false, got %+v", resp.LocalShort)
+	}
+	if resp.LocalLong == nil || resp.LocalLong.Exists {
+		t.Errorf("expected LocalLong.Exists=false, got %+v", resp.LocalLong)
+	}
+}
+
+func TestImageStatus_MissingParams(t *testing.T) {
+	srv := newImageTestServer(t, &runtime.MockRuntime{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/images/status", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestImageStatus_RuntimeError(t *testing.T) {
+	rt := &runtime.MockRuntime{
+		ImageExistsFunc: func(_ context.Context, image string) (bool, error) {
+			return false, fmt.Errorf("daemon unavailable")
+		},
+	}
+	srv := newImageTestServer(t, rt)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/images/status?short=myimage", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestImageStatus_WrongMethod(t *testing.T) {
+	srv := newImageTestServer(t, &runtime.MockRuntime{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/images/status?short=x", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+// --- POST /api/v1/images/pull ---
+
+func TestImagePull_Success(t *testing.T) {
+	var pulledImage string
+	rt := &runtime.MockRuntime{
+		PullImageFunc: func(_ context.Context, image string) error {
+			pulledImage = image
+			return nil
+		},
+	}
+	srv := newImageTestServer(t, rt)
+
+	body := strings.NewReader(`{"image": "registry.io/myimage:latest"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/images/pull", body)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if pulledImage != "registry.io/myimage:latest" {
+		t.Errorf("expected pull of %q, got %q", "registry.io/myimage:latest", pulledImage)
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["status"] != "pulled" {
+		t.Errorf("expected status=pulled, got %q", resp["status"])
+	}
+}
+
+func TestImagePull_EmptyImage(t *testing.T) {
+	srv := newImageTestServer(t, &runtime.MockRuntime{})
+
+	body := strings.NewReader(`{"image": ""}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/images/pull", body)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestImagePull_Failure(t *testing.T) {
+	rt := &runtime.MockRuntime{
+		PullImageFunc: func(_ context.Context, image string) error {
+			return fmt.Errorf("network timeout")
+		},
+	}
+	srv := newImageTestServer(t, rt)
+
+	body := strings.NewReader(`{"image": "registry.io/myimage:latest"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/images/pull", body)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestImagePull_WrongMethod(t *testing.T) {
+	srv := newImageTestServer(t, &runtime.MockRuntime{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/images/pull", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+// --- DELETE /api/v1/images/local ---
+
+func TestImageDeleteLocal_ExistsAndRemoved(t *testing.T) {
+	var removedImage string
+	rt := &runtime.MockRuntime{
+		ImageExistsFunc: func(_ context.Context, image string) (bool, error) {
+			return true, nil
+		},
+		RemoveImageFunc: func(_ context.Context, image string) error {
+			removedImage = image
+			return nil
+		},
+	}
+	srv := newImageTestServer(t, rt)
+
+	body := strings.NewReader(`{"image": "myimage"}`)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/images/local", body)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if removedImage != "myimage" {
+		t.Errorf("expected removal of %q, got %q", "myimage", removedImage)
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["status"] != "removed" {
+		t.Errorf("expected status=removed, got %q", resp["status"])
+	}
+}
+
+func TestImageDeleteLocal_DoesNotExist(t *testing.T) {
+	rt := &runtime.MockRuntime{
+		ImageExistsFunc: func(_ context.Context, image string) (bool, error) {
+			return false, nil
+		},
+	}
+	srv := newImageTestServer(t, rt)
+
+	body := strings.NewReader(`{"image": "myimage"}`)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/images/local", body)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["status"] != "not_found" {
+		t.Errorf("expected status=not_found, got %q", resp["status"])
+	}
+}
+
+func TestImageDeleteLocal_RemoveFailure(t *testing.T) {
+	rt := &runtime.MockRuntime{
+		ImageExistsFunc: func(_ context.Context, image string) (bool, error) {
+			return true, nil
+		},
+		RemoveImageFunc: func(_ context.Context, image string) error {
+			return fmt.Errorf("image in use")
+		},
+	}
+	srv := newImageTestServer(t, rt)
+
+	body := strings.NewReader(`{"image": "myimage"}`)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/images/local", body)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestImageDeleteLocal_EmptyImage(t *testing.T) {
+	srv := newImageTestServer(t, &runtime.MockRuntime{})
+
+	body := strings.NewReader(`{"image": ""}`)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/images/local", body)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestImageDeleteLocal_WrongMethod(t *testing.T) {
+	srv := newImageTestServer(t, &runtime.MockRuntime{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/images/local", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}

--- a/pkg/runtimebroker/server.go
+++ b/pkg/runtimebroker/server.go
@@ -1567,6 +1567,11 @@ func (s *Server) registerRoutes() {
 	// Project routes
 	s.mux.HandleFunc("/api/v1/projects/", s.handleProjectBySlug)
 
+	// Image state endpoints
+	s.mux.HandleFunc("/api/v1/images/status", s.handleImageStatus)
+	s.mux.HandleFunc("/api/v1/images/pull", s.handleImagePull)
+	s.mux.HandleFunc("/api/v1/images/local", s.handleImageDeleteLocal)
+
 	// Workspace sync routes (for Hub-initiated sync via control channel)
 	s.mux.HandleFunc("/api/v1/workspace/upload", s.handleWorkspaceUpload)
 	s.mux.HandleFunc("/api/v1/workspace/apply", s.handleWorkspaceApply)

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -613,7 +613,8 @@ const (
 	HarnessConfigStatusArchived = "archived"
 )
 
-// HarnessConfigImageStatus constants
+// HarnessConfigImageStatus constants — reflect registry/reference validity only.
+// Local image availability is runtime-dependent and not persisted here.
 const (
 	HarnessConfigImageStatusUnknown = "unknown"
 	HarnessConfigImageStatusValid   = "valid"

--- a/web/src/components/pages/harness-config-detail.ts
+++ b/web/src/components/pages/harness-config-detail.ts
@@ -120,14 +120,32 @@ export class ScionPageHarnessConfigDetail extends LitElement {
 
   @state()
   private imageStatus: {
-    local_short?: { exists: boolean; image: string; hash: string };
-    local_long?: { exists: boolean; image: string; hash: string };
-    remote?: { exists: boolean; image: string; hash: string; newer_than_local: boolean };
-    resolved_image?: string;
-    resolution_source?: string;
-    has_local_runtime?: boolean;
-    embedded_broker_name?: string;
+    image?: string;
+    registry?: {
+      image: string;
+      exists: boolean;
+      hash: string;
+      checked_at: string;
+    };
+    brokers?: Array<{
+      broker_id: string;
+      broker_name: string;
+      reachable: boolean;
+      local_short?: { exists: boolean; hash: string };
+      local_long?: { exists: boolean; hash: string };
+      newer_in_registry?: boolean;
+      resolved_image?: string;
+      resolution_source?: string;
+    }>;
+    proxy_brokers?: Array<{
+      broker_id: string;
+      broker_name: string;
+      runtime: string;
+    }>;
   } | null = null;
+
+  @state()
+  private expandedBrokers: Set<string> = new Set();
 
   @state()
   private imageActionRunning = false;
@@ -374,6 +392,79 @@ export class ScionPageHarnessConfigDetail extends LitElement {
       display: flex;
       gap: 0.5rem;
       margin-top: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .broker-row {
+      cursor: pointer;
+      user-select: none;
+    }
+    .broker-row:hover {
+      background: var(--sl-color-neutral-50);
+    }
+    .broker-row-expanded {
+      background: var(--sl-color-neutral-50);
+    }
+    .broker-detail-row td {
+      padding-left: 2rem;
+    }
+    .broker-toggle {
+      display: inline-block;
+      width: 1em;
+      text-align: center;
+      margin-right: 0.25rem;
+      font-size: 0.75rem;
+    }
+    .rollup-badge {
+      display: inline-block;
+      padding: 0.0625rem 0.375rem;
+      border-radius: var(--sl-border-radius-pill);
+      font-size: 0.625rem;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+    .rollup-badge-up-to-date {
+      background: var(--sl-color-success-100, #dcfce7);
+      color: var(--sl-color-success-700, #15803d);
+    }
+    .rollup-badge-stale {
+      background: var(--sl-color-warning-100, #fef3c7);
+      color: var(--sl-color-warning-700, #a16207);
+    }
+    .rollup-badge-local-only {
+      background: var(--sl-color-primary-100, #dbeafe);
+      color: var(--sl-color-primary-700, #1d4ed8);
+    }
+    .rollup-badge-missing {
+      background: var(--sl-color-danger-100, #fee2e2);
+      color: var(--sl-color-danger-700, #b91c1c);
+    }
+    .rollup-badge-unreachable {
+      background: var(--sl-color-neutral-200);
+      color: var(--sl-color-neutral-600);
+    }
+    .reachable-dot {
+      display: inline-block;
+      width: 0.5rem;
+      height: 0.5rem;
+      border-radius: 50%;
+      margin-right: 0.25rem;
+    }
+    .reachable-dot.online { background: var(--sl-color-success-500); }
+    .reachable-dot.offline { background: var(--sl-color-neutral-400); }
+    .proxy-info-note {
+      font-size: 0.8125rem;
+      color: var(--sl-color-neutral-500);
+      margin: 1rem 0 0;
+      padding: 0.75rem 1rem;
+      background: var(--sl-color-neutral-50);
+      border: 1px solid var(--sl-color-neutral-200);
+      border-radius: var(--sl-border-radius-medium);
+    }
+    .broker-actions {
+      display: flex;
+      gap: 0.5rem;
+      padding: 0.5rem 0.75rem;
       flex-wrap: wrap;
     }
 
@@ -641,106 +732,244 @@ export class ScionPageHarnessConfigDetail extends LitElement {
     if (!showSection) return nothing;
 
     const st = this.imageStatus;
-    const src = st?.resolution_source || '';
-    const hasRuntime = st?.has_local_runtime !== false;
-    const brokerName = st?.embedded_broker_name;
+    const brokers = st?.brokers ?? [];
+    const proxyBrokers = st?.proxy_brokers ?? [];
 
+    if (brokers.length === 1) {
+      return this.renderSingleBrokerImage(brokers[0], st);
+    } else if (brokers.length > 1) {
+      return this.renderMultiBrokerImage(brokers, proxyBrokers, st);
+    } else {
+      return this.renderProxyOnlyImage(proxyBrokers, st);
+    }
+  }
+
+  private brokerRollup(broker: NonNullable<NonNullable<typeof this.imageStatus>['brokers']>[0]): { label: string; cssClass: string } {
+    if (!broker.reachable) return { label: 'unreachable', cssClass: 'rollup-badge-unreachable' };
+    if (broker.local_short?.exists && !broker.local_long?.exists) return { label: 'local build only', cssClass: 'rollup-badge-local-only' };
+    if (broker.local_long?.exists && broker.newer_in_registry) return { label: 'stale pull', cssClass: 'rollup-badge-stale' };
+    if ((broker.local_long?.exists && !broker.newer_in_registry) || broker.local_short?.exists) return { label: 'up-to-date', cssClass: 'rollup-badge-up-to-date' };
+    return { label: 'missing', cssClass: 'rollup-badge-missing' };
+  }
+
+  private renderRegistryRow(st: typeof this.imageStatus) {
+    return html`
+      <tr>
+        <td class="image-entity-name">Registry</td>
+        <td class="image-ref">${st?.registry?.image || '—'}</td>
+        <td class="image-hash">${st?.registry?.exists ? (st.registry.hash || '—') : ''}</td>
+        <td>
+          ${st
+            ? (st.registry?.exists
+              ? html`Available`
+              : html`<span class="not-found">Not found</span>`)
+            : html`<sl-spinner style="font-size: 0.75rem;"></sl-spinner> Checking...`}
+        </td>
+      </tr>
+    `;
+  }
+
+  private renderSingleBrokerImage(
+    broker: NonNullable<NonNullable<typeof this.imageStatus>['brokers']>[0],
+    st: typeof this.imageStatus
+  ) {
+    const hc = this.harnessConfig!;
+    const image = hc.config?.image;
+    const src = broker.resolution_source || '';
     return html`
       <div class="image-section">
-        <h2>Images${brokerName ? html` <span class="image-section-subtitle">Runtime: ${brokerName}</span>` : nothing}</h2>
+        <h2>Images <span class="image-section-subtitle">Runtime: ${broker.broker_name}</span></h2>
         <table class="image-table">
           <thead>
-            <tr>
-              <th>Entity</th>
-              <th>Image</th>
-              <th>Hash</th>
-              <th>Status</th>
-            </tr>
+            <tr><th>Entity</th><th>Image</th><th>Hash</th><th>Status</th></tr>
           </thead>
           <tbody>
-            ${hasRuntime ? html`
+            ${this.renderRegistryRow(st)}
             <tr class=${src === 'local_short' ? 'active-row' : ''}>
               <td class="image-entity-name">Local Build</td>
-              <td class="image-ref">${st?.local_short?.image || image || '—'}</td>
-              <td class="image-hash">${st?.local_short?.exists ? (st.local_short.hash || '—') : ''}</td>
+              <td class="image-ref">${broker.resolved_image || image || '—'}</td>
+              <td class="image-hash">${broker.local_short?.exists ? (broker.local_short.hash || '—') : ''}</td>
               <td>
-                ${st
-                  ? (st.local_short?.exists
-                    ? html`Available${src === 'local_short' ? html`<span class="active-badge">Active</span>` : nothing}`
-                    : html`<span class="not-found">Not found</span>`)
-                  : html`<sl-spinner style="font-size: 0.75rem;"></sl-spinner> Checking...`}
+                ${broker.local_short?.exists
+                  ? html`Available${src === 'local_short' ? html`<span class="active-badge">Active</span>` : nothing}`
+                  : html`<span class="not-found">Not found</span>`}
               </td>
             </tr>
             <tr class=${src === 'local_long' ? 'active-row' : ''}>
               <td class="image-entity-name">Pulled</td>
-              <td class="image-ref">${st?.local_long?.image || '—'}</td>
-              <td class="image-hash">${st?.local_long?.exists ? (st.local_long.hash || '—') : ''}</td>
+              <td class="image-ref">${st?.registry?.image || '—'}</td>
+              <td class="image-hash">${broker.local_long?.exists ? (broker.local_long.hash || '—') : ''}</td>
               <td>
-                ${st
-                  ? (st.local_long?.exists
-                    ? html`Available${src === 'local_long' ? html`<span class="active-badge">Active</span>` : nothing}`
-                    : html`<span class="not-found">Not found</span>`)
-                  : html`<sl-spinner style="font-size: 0.75rem;"></sl-spinner> Checking...`}
-              </td>
-            </tr>
-            ` : nothing}
-            <tr class=${src === 'remote' ? 'active-row' : ''}>
-              <td class="image-entity-name">Remote</td>
-              <td class="image-ref">${st?.remote?.image || '—'}</td>
-              <td class="image-hash">${st?.remote?.exists ? (st.remote.hash || '—') : ''}</td>
-              <td>
-                ${st
-                  ? (st.remote?.exists
-                    ? html`Available${src === 'remote' ? html`<span class="active-badge">Active</span>` : nothing}
-                      ${st.remote?.newer_than_local ? html`<span class="newer-badge">Newer version available</span>` : nothing}`
-                    : html`<span class="not-found">Not checked</span>`)
-                  : html`<sl-spinner style="font-size: 0.75rem;"></sl-spinner> Checking...`}
+                ${broker.local_long?.exists
+                  ? html`Available${src === 'local_long' ? html`<span class="active-badge">Active</span>` : nothing}
+                    ${broker.newer_in_registry ? html`<span class="newer-badge">Newer in registry</span>` : nothing}`
+                  : html`<span class="not-found">Not found</span>`}
               </td>
             </tr>
           </tbody>
         </table>
-        ${!hasRuntime && st ? html`
-          <p class="image-info-note">No local runtime available. Images are pulled by the substrate at provision time.</p>
-        ` : nothing}
         <div class="image-actions">
           ${this.hasDockerfile ? html`
-            <sl-button
-              size="small"
-              variant="primary"
-              @click=${this.openBuildDialog}
-              ?disabled=${this.buildRunning}
-            >
+            <sl-button size="small" variant="primary" @click=${this.openBuildDialog} ?disabled=${this.buildRunning}>
               <sl-icon slot="prefix" name="hammer"></sl-icon>
               ${this.buildRunning ? 'Building...' : 'Build Image'}
             </sl-button>
           ` : nothing}
-          ${hasRuntime && st?.local_short?.exists ? html`
-            <sl-button
-              size="small"
-              variant="warning"
-              outline
-              @click=${this.deleteLocalImage}
-              ?disabled=${this.imageActionRunning}
-            >
+          ${broker.local_long?.exists ? html`
+            <sl-button size="small" variant="default" @click=${() => this.pullLatestImage(broker.broker_id)} ?disabled=${this.imageActionRunning}>
+              <sl-icon slot="prefix" name="cloud-download"></sl-icon>
+              Pull Latest
+            </sl-button>
+          ` : html`
+            <sl-button size="small" variant="default" @click=${() => this.pullLatestImage(broker.broker_id)} ?disabled=${this.imageActionRunning}>
+              <sl-icon slot="prefix" name="cloud-download"></sl-icon>
+              Pull Latest
+            </sl-button>
+          `}
+          ${broker.local_short?.exists ? html`
+            <sl-button size="small" variant="warning" outline @click=${() => this.deleteLocalImage(broker.broker_id)} ?disabled=${this.imageActionRunning}>
               <sl-icon slot="prefix" name="trash"></sl-icon>
               Delete Local
             </sl-button>
           ` : nothing}
-          ${hasRuntime ? html`
-          <sl-button
-            size="small"
-            variant="default"
-            @click=${this.pullLatestImage}
-            ?disabled=${this.imageActionRunning}
-          >
-            <sl-icon slot="prefix" name="cloud-download"></sl-icon>
-            Pull Latest
+          <sl-button size="small" variant="text" @click=${this.recheckImage} ?disabled=${this.imageActionRunning}>
+            <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
+            Re-check
           </sl-button>
+        </div>
+      </div>
+    `;
+  }
+
+  private toggleBroker(brokerId: string): void {
+    const next = new Set(this.expandedBrokers);
+    if (next.has(brokerId)) {
+      next.delete(brokerId);
+    } else {
+      next.add(brokerId);
+    }
+    this.expandedBrokers = next;
+  }
+
+  private renderMultiBrokerImage(
+    brokers: NonNullable<NonNullable<typeof this.imageStatus>['brokers']>,
+    _proxyBrokers: NonNullable<NonNullable<typeof this.imageStatus>['proxy_brokers']>,
+    st: typeof this.imageStatus
+  ) {
+    return html`
+      <div class="image-section">
+        <h2>Images</h2>
+        <table class="image-table">
+          <thead>
+            <tr><th>Entity</th><th>Image</th><th>Hash</th><th>Status</th></tr>
+          </thead>
+          <tbody>
+            ${this.renderRegistryRow(st)}
+            ${brokers.map(b => this.renderBrokerRow(b, st))}
+          </tbody>
+        </table>
+        <div class="image-actions">
+          ${this.hasDockerfile ? html`
+            <sl-button size="small" variant="primary" @click=${this.openBuildDialog} ?disabled=${this.buildRunning}>
+              <sl-icon slot="prefix" name="hammer"></sl-icon>
+              ${this.buildRunning ? 'Building...' : 'Build Image'}
+            </sl-button>
           ` : nothing}
           <sl-button size="small" variant="text" @click=${this.recheckImage} ?disabled=${this.imageActionRunning}>
             <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
-            Re-check Remote
+            Re-check
           </sl-button>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderBrokerRow(
+    broker: NonNullable<NonNullable<typeof this.imageStatus>['brokers']>[0],
+    st: typeof this.imageStatus
+  ) {
+    const expanded = this.expandedBrokers.has(broker.broker_id);
+    const rollup = this.brokerRollup(broker);
+    const src = broker.resolution_source || '';
+
+    return html`
+      <tr class="broker-row ${expanded ? 'broker-row-expanded' : ''}" @click=${() => this.toggleBroker(broker.broker_id)}>
+        <td class="image-entity-name">
+          <span class="broker-toggle">${expanded ? '▾' : '▸'}</span>
+          <span class="reachable-dot ${broker.reachable ? 'online' : 'offline'}"></span>
+          ${broker.broker_name}
+        </td>
+        <td><span class="rollup-badge ${rollup.cssClass}">${rollup.label}</span></td>
+        <td></td>
+        <td>${broker.resolved_image ? html`resolves: ${src === 'local_short' ? 'local build' : src === 'local_long' ? 'pulled' : src}` : ''}</td>
+      </tr>
+      ${expanded && broker.reachable ? html`
+        <tr class="broker-detail-row">
+          <td class="image-entity-name">Local Build</td>
+          <td class="image-ref">${broker.resolved_image || st?.image || '—'}</td>
+          <td class="image-hash">${broker.local_short?.exists ? (broker.local_short.hash || '—') : ''}</td>
+          <td>${broker.local_short?.exists
+            ? html`Available${src === 'local_short' ? html`<span class="active-badge">Active</span>` : nothing}`
+            : html`<span class="not-found">—</span>`}</td>
+        </tr>
+        <tr class="broker-detail-row">
+          <td class="image-entity-name">Pulled</td>
+          <td class="image-ref">${st?.registry?.image || '—'}</td>
+          <td class="image-hash">${broker.local_long?.exists ? (broker.local_long.hash || '—') : ''}</td>
+          <td>${broker.local_long?.exists
+            ? html`Available${src === 'local_long' ? html`<span class="active-badge">Active</span>` : nothing}
+              ${broker.newer_in_registry ? html`<span class="newer-badge">Newer in registry</span>` : nothing}`
+            : html`<span class="not-found">—</span>`}</td>
+        </tr>
+        <tr class="broker-detail-row">
+          <td colspan="4">
+            <div class="broker-actions">
+              <sl-button size="small" variant="default" @click=${(e: Event) => { e.stopPropagation(); void this.pullLatestImage(broker.broker_id); }} ?disabled=${this.imageActionRunning}>
+                <sl-icon slot="prefix" name="cloud-download"></sl-icon>
+                Pull Latest
+              </sl-button>
+              ${broker.local_short?.exists ? html`
+                <sl-button size="small" variant="warning" outline @click=${(e: Event) => { e.stopPropagation(); void this.deleteLocalImage(broker.broker_id); }} ?disabled=${this.imageActionRunning}>
+                  <sl-icon slot="prefix" name="trash"></sl-icon>
+                  Delete Local
+                </sl-button>
+              ` : nothing}
+              <sl-button size="small" variant="text" @click=${(e: Event) => { e.stopPropagation(); void this.recheckImage(); }} ?disabled=${this.imageActionRunning}>
+                <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
+                Re-check
+              </sl-button>
+            </div>
+          </td>
+        </tr>
+      ` : nothing}
+    `;
+  }
+
+  private renderProxyOnlyImage(
+    _proxyBrokers: NonNullable<NonNullable<typeof this.imageStatus>['proxy_brokers']>,
+    st: typeof this.imageStatus
+  ) {
+    return html`
+      <div class="image-section">
+        <h2>Images</h2>
+        <table class="image-table">
+          <thead>
+            <tr><th>Entity</th><th>Image</th><th>Hash</th><th>Status</th></tr>
+          </thead>
+          <tbody>
+            ${this.renderRegistryRow(st)}
+          </tbody>
+        </table>
+        <div class="image-actions">
+          <sl-button size="small" variant="text" @click=${this.recheckImage} ?disabled=${this.imageActionRunning}>
+            <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
+            Re-check
+          </sl-button>
+        </div>
+        <div class="proxy-info-note">
+          Agents on this hub run on proxy brokers.
+          Images are pulled by the substrate at provision time;
+          there is no node-local image state to inspect.
         </div>
       </div>
     `;
@@ -763,11 +992,11 @@ export class ScionPageHarnessConfigDetail extends LitElement {
     }
   }
 
-  private async deleteLocalImage(): Promise<void> {
+  private async deleteLocalImage(brokerId: string): Promise<void> {
     this.imageActionRunning = true;
     try {
       const resp = await apiFetch(
-        `/api/v1/harness-configs/${this.harnessConfigId}/local-image`,
+        `/api/v1/harness-configs/${this.harnessConfigId}/local-image?broker_id=${brokerId}`,
         { method: 'DELETE' }
       );
       if (resp.ok) {
@@ -781,11 +1010,11 @@ export class ScionPageHarnessConfigDetail extends LitElement {
     }
   }
 
-  private async pullLatestImage(): Promise<void> {
+  private async pullLatestImage(brokerId: string): Promise<void> {
     this.imageActionRunning = true;
     try {
       const resp = await apiFetch(
-        `/api/v1/harness-configs/${this.harnessConfigId}/pull-image`,
+        `/api/v1/harness-configs/${this.harnessConfigId}/pull-image?broker_id=${brokerId}`,
         { method: 'POST' }
       );
       if (resp.ok) {

--- a/web/src/components/pages/harness-config-detail.ts
+++ b/web/src/components/pages/harness-config-detail.ts
@@ -131,6 +131,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
       broker_id: string;
       broker_name: string;
       reachable: boolean;
+      unsupported?: boolean;
       local_short?: { exists: boolean; hash: string };
       local_long?: { exists: boolean; hash: string };
       newer_in_registry?: boolean;
@@ -732,8 +733,18 @@ export class ScionPageHarnessConfigDetail extends LitElement {
     if (!showSection) return nothing;
 
     const st = this.imageStatus;
-    const brokers = st?.brokers ?? [];
-    const proxyBrokers = st?.proxy_brokers ?? [];
+
+    if (!st) {
+      return html`
+        <div class="image-section">
+          <h2>Images</h2>
+          <sl-spinner style="font-size: 1rem;"></sl-spinner> Loading image status...
+        </div>
+      `;
+    }
+
+    const brokers = st.brokers ?? [];
+    const proxyBrokers = st.proxy_brokers ?? [];
 
     if (brokers.length === 1) {
       return this.renderSingleBrokerImage(brokers[0], st);
@@ -746,6 +757,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
 
   private brokerRollup(broker: NonNullable<NonNullable<typeof this.imageStatus>['brokers']>[0]): { label: string; cssClass: string } {
     if (!broker.reachable) return { label: 'unreachable', cssClass: 'rollup-badge-unreachable' };
+    if (broker.unsupported) return { label: 'needs upgrade', cssClass: 'rollup-badge-stale' };
     if (broker.local_short?.exists && !broker.local_long?.exists) return { label: 'local build only', cssClass: 'rollup-badge-local-only' };
     if (broker.local_long?.exists && broker.newer_in_registry) return { label: 'stale pull', cssClass: 'rollup-badge-stale' };
     if ((broker.local_long?.exists && !broker.newer_in_registry) || broker.local_short?.exists) return { label: 'up-to-date', cssClass: 'rollup-badge-up-to-date' };
@@ -775,6 +787,33 @@ export class ScionPageHarnessConfigDetail extends LitElement {
   ) {
     const hc = this.harnessConfig!;
     const image = hc.config?.image;
+
+    if (!broker.reachable) {
+      return html`
+        <div class="image-section">
+          <h2>Images <span class="image-section-subtitle">Runtime: ${broker.broker_name}</span></h2>
+          <table class="image-table">
+            <thead>
+              <tr><th>Entity</th><th>Image</th><th>Hash</th><th>Status</th></tr>
+            </thead>
+            <tbody>
+              ${this.renderRegistryRow(st)}
+            </tbody>
+          </table>
+          <div class="proxy-info-note">
+            Runtime broker "${broker.broker_name}" is currently unreachable.
+            Local image state cannot be determined.
+          </div>
+          <div class="image-actions">
+            <sl-button size="small" variant="text" @click=${this.recheckImage} ?disabled=${this.imageActionRunning}>
+              <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
+              Re-check
+            </sl-button>
+          </div>
+        </div>
+      `;
+    }
+
     const src = broker.resolution_source || '';
     return html`
       <div class="image-section">
@@ -787,7 +826,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
             ${this.renderRegistryRow(st)}
             <tr class=${src === 'local_short' ? 'active-row' : ''}>
               <td class="image-entity-name">Local Build</td>
-              <td class="image-ref">${broker.resolved_image || image || '—'}</td>
+              <td class="image-ref">${st?.image || image || '—'}</td>
               <td class="image-hash">${broker.local_short?.exists ? (broker.local_short.hash || '—') : ''}</td>
               <td>
                 ${broker.local_short?.exists
@@ -815,17 +854,10 @@ export class ScionPageHarnessConfigDetail extends LitElement {
               ${this.buildRunning ? 'Building...' : 'Build Image'}
             </sl-button>
           ` : nothing}
-          ${broker.local_long?.exists ? html`
-            <sl-button size="small" variant="default" @click=${() => this.pullLatestImage(broker.broker_id)} ?disabled=${this.imageActionRunning}>
-              <sl-icon slot="prefix" name="cloud-download"></sl-icon>
-              Pull Latest
-            </sl-button>
-          ` : html`
-            <sl-button size="small" variant="default" @click=${() => this.pullLatestImage(broker.broker_id)} ?disabled=${this.imageActionRunning}>
-              <sl-icon slot="prefix" name="cloud-download"></sl-icon>
-              Pull Latest
-            </sl-button>
-          `}
+          <sl-button size="small" variant="default" @click=${() => this.pullLatestImage(broker.broker_id)} ?disabled=${this.imageActionRunning}>
+            <sl-icon slot="prefix" name="cloud-download"></sl-icon>
+            Pull Latest
+          </sl-button>
           ${broker.local_short?.exists ? html`
             <sl-button size="small" variant="warning" outline @click=${() => this.deleteLocalImage(broker.broker_id)} ?disabled=${this.imageActionRunning}>
               <sl-icon slot="prefix" name="trash"></sl-icon>
@@ -853,7 +885,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
 
   private renderMultiBrokerImage(
     brokers: NonNullable<NonNullable<typeof this.imageStatus>['brokers']>,
-    _proxyBrokers: NonNullable<NonNullable<typeof this.imageStatus>['proxy_brokers']>,
+    proxyBrokers: NonNullable<NonNullable<typeof this.imageStatus>['proxy_brokers']>,
     st: typeof this.imageStatus
   ) {
     return html`
@@ -880,6 +912,13 @@ export class ScionPageHarnessConfigDetail extends LitElement {
             Re-check
           </sl-button>
         </div>
+        ${proxyBrokers.length > 0 ? html`
+          <div class="proxy-info-note">
+            ${proxyBrokers.length} proxy broker${proxyBrokers.length > 1 ? 's' : ''}
+            (${proxyBrokers.map(p => p.broker_name).join(', ')}) —
+            images pulled by substrate at provision time.
+          </div>
+        ` : nothing}
       </div>
     `;
   }
@@ -906,7 +945,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
       ${expanded && broker.reachable ? html`
         <tr class="broker-detail-row">
           <td class="image-entity-name">Local Build</td>
-          <td class="image-ref">${broker.resolved_image || st?.image || '—'}</td>
+          <td class="image-ref">${st?.image || '—'}</td>
           <td class="image-hash">${broker.local_short?.exists ? (broker.local_short.hash || '—') : ''}</td>
           <td>${broker.local_short?.exists
             ? html`Available${src === 'local_short' ? html`<span class="active-badge">Active</span>` : nothing}`

--- a/web/src/components/pages/harness-config-detail.ts
+++ b/web/src/components/pages/harness-config-detail.ts
@@ -125,6 +125,8 @@ export class ScionPageHarnessConfigDetail extends LitElement {
     remote?: { exists: boolean; image: string; hash: string; newer_than_local: boolean };
     resolved_image?: string;
     resolution_source?: string;
+    has_local_runtime?: boolean;
+    embedded_broker_name?: string;
   } | null = null;
 
   @state()
@@ -289,6 +291,17 @@ export class ScionPageHarnessConfigDetail extends LitElement {
       font-size: 1.1rem;
       font-weight: 600;
       margin: 0 0 1rem;
+    }
+    .image-section-subtitle {
+      font-size: 0.75rem;
+      font-weight: 400;
+      color: var(--sl-color-neutral-500);
+    }
+    .image-info-note {
+      font-size: 0.8125rem;
+      color: var(--sl-color-neutral-500);
+      margin: 0.5rem 0 0;
+      font-style: italic;
     }
     .image-table {
       width: 100%;
@@ -629,10 +642,12 @@ export class ScionPageHarnessConfigDetail extends LitElement {
 
     const st = this.imageStatus;
     const src = st?.resolution_source || '';
+    const hasRuntime = st?.has_local_runtime !== false;
+    const brokerName = st?.embedded_broker_name;
 
     return html`
       <div class="image-section">
-        <h2>Images</h2>
+        <h2>Images${brokerName ? html` <span class="image-section-subtitle">Runtime: ${brokerName}</span>` : nothing}</h2>
         <table class="image-table">
           <thead>
             <tr>
@@ -643,6 +658,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
             </tr>
           </thead>
           <tbody>
+            ${hasRuntime ? html`
             <tr class=${src === 'local_short' ? 'active-row' : ''}>
               <td class="image-entity-name">Local Build</td>
               <td class="image-ref">${st?.local_short?.image || image || '—'}</td>
@@ -667,6 +683,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
                   : html`<sl-spinner style="font-size: 0.75rem;"></sl-spinner> Checking...`}
               </td>
             </tr>
+            ` : nothing}
             <tr class=${src === 'remote' ? 'active-row' : ''}>
               <td class="image-entity-name">Remote</td>
               <td class="image-ref">${st?.remote?.image || '—'}</td>
@@ -682,6 +699,9 @@ export class ScionPageHarnessConfigDetail extends LitElement {
             </tr>
           </tbody>
         </table>
+        ${!hasRuntime && st ? html`
+          <p class="image-info-note">No local runtime available. Images are pulled by the substrate at provision time.</p>
+        ` : nothing}
         <div class="image-actions">
           ${this.hasDockerfile ? html`
             <sl-button
@@ -694,7 +714,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
               ${this.buildRunning ? 'Building...' : 'Build Image'}
             </sl-button>
           ` : nothing}
-          ${st?.local_short?.exists ? html`
+          ${hasRuntime && st?.local_short?.exists ? html`
             <sl-button
               size="small"
               variant="warning"
@@ -706,6 +726,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
               Delete Local
             </sl-button>
           ` : nothing}
+          ${hasRuntime ? html`
           <sl-button
             size="small"
             variant="default"
@@ -715,6 +736,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
             <sl-icon slot="prefix" name="cloud-download"></sl-icon>
             Pull Latest
           </sl-button>
+          ` : nothing}
           <sl-button size="small" variant="text" @click=${this.recheckImage} ?disabled=${this.imageActionRunning}>
             <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
             Re-check Remote


### PR DESCRIPTION
Replaces the single-daemon image status view in harness-config detail with a per-broker aggregated response. The hub queries all node-bound brokers concurrently and presents their image state