### PR TITLE
fix(discord): fix @mention routing, filter system messages, inherit parent channel config

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -968,6 +968,12 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 		return
 	}
 
+	// Drop system messages (thread created, channel rename, pin, etc.)
+	// while keeping normal messages and replies.
+	if m.Type != discordgo.MessageTypeDefault && m.Type != discordgo.MessageTypeReply {
+		return
+	}
+
 	b.mu.RLock()
 	store := b.store
 	botUser := b.botUser
@@ -982,20 +988,10 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	link, err := store.GetChannelLink(ctx, channelID)
+	link, err := resolveChannelLink(ctx, s, store, channelID)
 	if err != nil {
 		b.log.Error("Failed to get channel link", "channel_id", channelID, "error", err)
 		return
-	}
-	// If no direct link, check if this is a thread whose parent channel is linked.
-	if link == nil || !link.Active {
-		if parentID, isThread := b.resolveThreadParent(channelID); isThread && parentID != "" {
-			link, err = store.GetChannelLink(ctx, parentID)
-			if err != nil {
-				b.log.Error("Failed to get parent channel link", "parent_id", parentID, "error", err)
-				return
-			}
-		}
 	}
 	if link == nil || !link.Active {
 		return
@@ -1021,7 +1017,9 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 	}
 
 	// Fallback: unaddressed text → default agent (if configured).
-	if len(targets) == 0 && link.DefaultAgent != "" {
+	// Skip if the message @-mentions a non-bot Discord user — those are
+	// directed at humans, not the bot's default agent.
+	if len(targets) == 0 && link.DefaultAgent != "" && !hasNonBotMentions(m.Message, botUserID) {
 		text := strings.TrimSpace(m.Content)
 		if text != "" && !strings.HasPrefix(text, "/") {
 			targets = []string{link.DefaultAgent}
@@ -1660,6 +1658,17 @@ func generateRequestID() string {
 	b := make([]byte, 12)
 	rand.Read(b)
 	return hex.EncodeToString(b)
+}
+
+// hasNonBotMentions returns true if the message @-mentions any Discord user
+// other than the bot itself.
+func hasNonBotMentions(m *discordgo.Message, botUserID string) bool {
+	for _, u := range m.Mentions {
+		if u.ID != botUserID {
+			return true
+		}
+	}
+	return false
 }
 
 // agentSlugs extracts slug strings from a slice of AgentInfo.

--- a/extras/scion-discord/internal/discord/callbacks.go
+++ b/extras/scion-discord/internal/discord/callbacks.go
@@ -511,7 +511,7 @@ func (h *CallbackHandler) handleDefaultCallback(s *discordgo.Session, i *discord
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	link, err := h.store.GetChannelLink(ctx, i.ChannelID)
+	link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
 	if err != nil || link == nil {
 		h.respondUpdate(s, i, "This channel is not linked to a project.", nil)
 		return
@@ -572,7 +572,7 @@ func (h *CallbackHandler) handleNotifCallback(s *discordgo.Session, i *discordgo
 	discordUserID := interactionUserID(i)
 
 	// Look up the channel link to determine the project.
-	link, err := h.store.GetChannelLink(ctx, i.ChannelID)
+	link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
 	if err != nil || link == nil {
 		h.respondUpdate(s, i, "This channel is not linked to a project.", nil)
 		return

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -311,7 +311,7 @@ func (h *CommandHandler) HandleAutocomplete(s *discordgo.Session, i *discordgo.I
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		link, err := h.store.GetChannelLink(ctx, i.ChannelID)
+		link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
 		if err != nil || link == nil {
 			// No link — return empty choices.
 			_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
@@ -537,7 +537,7 @@ func (h *CommandHandler) HandleAgents(s *discordgo.Session, i *discordgo.Interac
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	link, err := h.store.GetChannelLink(ctx, i.ChannelID)
+	link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
 	if err != nil {
 		h.log.Error("Failed to get channel link", "error", err, "channel_id", i.ChannelID)
 		h.followup(s, i, "Something went wrong. Please try again.")
@@ -611,7 +611,7 @@ func (h *CommandHandler) HandleInfo(s *discordgo.Session, i *discordgo.Interacti
 
 	// Show channel link if in a guild channel.
 	if i.ChannelID != "" {
-		link, linkErr := h.store.GetChannelLink(ctx, i.ChannelID)
+		link, linkErr := resolveChannelLink(ctx, s, h.store, i.ChannelID)
 		if linkErr == nil && link != nil {
 			sb.WriteString(fmt.Sprintf("\n**Channel project:** %s", link.ProjectSlug))
 			if link.DefaultAgent != "" {
@@ -634,7 +634,7 @@ func (h *CommandHandler) HandleStatus(s *discordgo.Session, i *discordgo.Interac
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	link, err := h.store.GetChannelLink(ctx, i.ChannelID)
+	link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
 	if err != nil || link == nil {
 		h.followup(s, i, "This channel is not linked to a project. Use `/scion setup` first.")
 		return
@@ -693,12 +693,7 @@ func (h *CommandHandler) HandleMessage(s *discordgo.Session, i *discordgo.Intera
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	link, err := h.store.GetChannelLink(ctx, i.ChannelID)
-	if err != nil || link == nil {
-		if parentID := threadParentID(s, i.ChannelID); parentID != "" {
-			link, err = h.store.GetChannelLink(ctx, parentID)
-		}
-	}
+	link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
 	if err != nil || link == nil {
 		h.followup(s, i, "This channel is not linked to a project. Use `/scion setup` first.")
 		return
@@ -800,7 +795,7 @@ func (h *CommandHandler) HandleDefault(s *discordgo.Session, i *discordgo.Intera
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	link, err := h.store.GetChannelLink(ctx, i.ChannelID)
+	link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
 	if err != nil {
 		h.log.Error("Failed to get channel link", "error", err, "channel_id", i.ChannelID)
 		h.followup(s, i, "Something went wrong. Please try again.")
@@ -871,7 +866,7 @@ func (h *CommandHandler) HandleSettings(s *discordgo.Session, i *discordgo.Inter
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	link, err := h.store.GetChannelLink(ctx, i.ChannelID)
+	link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
 	if err != nil {
 		h.log.Error("Failed to get channel link", "error", err, "channel_id", i.ChannelID)
 		h.followup(s, i, "Something went wrong. Please try again.")
@@ -1034,6 +1029,21 @@ func threadParentID(s *discordgo.Session, channelID string) string {
 		return ch.ParentID
 	}
 	return ""
+}
+
+// resolveChannelLink looks up a ChannelLink for channelID. If no active link
+// is found and the channel is a thread, it falls back to the parent channel.
+func resolveChannelLink(ctx context.Context, s *discordgo.Session, store Store, channelID string) (*ChannelLink, error) {
+	link, err := store.GetChannelLink(ctx, channelID)
+	if err != nil {
+		return nil, err
+	}
+	if link == nil || !link.Active {
+		if parentID := threadParentID(s, channelID); parentID != "" {
+			return store.GetChannelLink(ctx, parentID)
+		}
+	}
+	return link, nil
 }
 
 // activityEmoji returns an emoji for an agent activity state.

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
@@ -1009,6 +1010,11 @@ func interactionUserID(i *discordgo.InteractionCreate) string {
 	return ""
 }
 
+var (
+	threadParentsMu sync.Mutex
+	threadParents   = make(map[string]string)
+)
+
 // threadParentID returns the parent channel ID if channelID is a thread,
 // or empty string if it is not a thread or the lookup fails.
 func threadParentID(s *discordgo.Session, channelID string) string {
@@ -1039,7 +1045,18 @@ func resolveChannelLink(ctx context.Context, s *discordgo.Session, store Store, 
 		return nil, err
 	}
 	if link == nil || !link.Active {
-		if parentID := threadParentID(s, channelID); parentID != "" {
+		threadParentsMu.Lock()
+		parentID, cached := threadParents[channelID]
+		threadParentsMu.Unlock()
+
+		if !cached {
+			parentID = threadParentID(s, channelID)
+			threadParentsMu.Lock()
+			threadParents[channelID] = parentID
+			threadParentsMu.Unlock()
+		}
+
+		if parentID != "" {
 			return store.GetChannelLink(ctx, parentID)
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/400 https://github.com/ptone/scion/issues/401 https://github.com/ptone/scion/issues/402

- #400: hasNonBotMentions guard prevents user @mentions falling through to default agent
- #401: Message type allowlist drops Discord system messages (ThreadCreated, pin, etc.)
- #402: resolveChannelLink helper applies thread→parent fallback to 8 handlers