### PR TITLE
feat: hub admin settings — seed/managed model + layer-aware UI

### DIFF
--- a/.design/ha-settings.md
+++ b/.design/ha-settings.md
@@ -1,0 +1,522 @@
+# Design: Hub Admin Settings — Seed/Managed Settings Model & Layer-Aware UI
+
+- **Project:** ha-settings
+- **Epic issue:** https://github.com/ptone/scion/issues/437
+- **Author:** hs-arch (rev 1); hs-arch2 (rev 2–4, with user on thread 4199)
+- **Status:** **REV 4 — FINAL.** All design questions resolved with user
+  (Telegram thread 4199, 2026-07-12): `SCION_SEED_*` prefix + seeded/managed
+  section lifecycle confirmed ("seed" as the marker semantic). Ready for
+  implementation.
+- **Predecessor:** settings-db (issue #268, PR #640 — merged). Prior design:
+  `/scion-volumes/scratchpad/projects/settings-db/design.md`.
+- **Scope (user, 2026-07-12):** everything below is in scope for this epic,
+  including the backend precedence/model work — not just the original UI fix.
+
+---
+
+## 1. Problem & Goals
+
+### Problem (two parts)
+
+**Part A — the reported bug (#437).** The admin settings page
+(`/admin/server-config`, `web/src/components/pages/admin-server-config.ts`) is
+not layer-aware. In postgres (DB-tier) mode, `buildPayload()`
+(`admin-server-config.ts:980-1137`) unconditionally re-emits Layer-0 scalars
+(`server.mode`, `log_level`, `hub.port/host/timeouts`, `auth.dev_mode`,
+`database.*`, `storage.*`, `secrets.*`). The PUT handler
+(`handlePutServerConfigDB`, `admin_settings_db.go:277`) classifies via the
+registry and returns **422 `layer0_rejected`** (`admin_settings_db.go:318`)
+before any write — discarding the operator's valid Layer-1 edits along with the
+Layer-0 fields the UI should never have sent. The page is effectively read-only
+for everything in DB mode.
+
+**Part B — the settings model (user direction, 2026-07-12).** The settings-db
+precedence (`env > DB > file > defaults`) allows two mutable influences on an
+operational value at runtime (shared DB + node-local env), reintroducing
+per-node drift through the escape hatch. The user's direction: **one mutable
+store**, with deployment-provided values acting as *seeds* (BIOS model: the
+system tracks shipped defaults until an admin saves a setting). The paradox —
+"env should be an overridable initial value" vs. the universal convention "env
+beats config files" — is resolved by **naming** (a dedicated `SCION_SEED_*`
+namespace whose name says initial-only) plus **behavior** (sections re-sync
+from bootstrap material on every boot until first admin write).
+
+### Goals / success criteria
+
+1. **One universal precedence chain** (§3.1), identical in shape everywhere:
+   `coded defaults → SCION_SEED_* → mutable store (yaml XOR DB) → SCION_SERVER_* (Layer-0 only)`.
+2. **Seeded/managed lifecycle:** a DB-backed section tracks bootstrap material
+   (re-synced each boot) until the first explicit admin write flips it to
+   `managed`; from then the DB owns it. "Reset to bootstrap" reverts.
+3. **`SCION_SEED_*` namespace** as the blessed way to provide initial
+   operational values from deployment tooling; `SCION_SERVER_*` retains
+   conventional env-wins for Layer-0; `SCION_SERVER_*` on Layer-1 keys enters a
+   deprecation window (honored as seed input + WARN), then removal.
+4. In DB mode the operator can edit and save Layer-1 settings from the UI with
+   no 422; changes persist, propagate cluster-wide, no restart.
+5. Layer-0 fields render read-only in DB mode with a clear badge; never
+   submitted. File mode: env-pinned (`SCION_SERVER_*`) fields read-only; rest
+   editable as today.
+6. Managed sections whose bootstrap material differs show an informational
+   **"superseded by database value"** notice (managed sections only — seeded
+   sections track bootstrap by definition, nothing to warn about).
+7. Maintenance/admin mode is cluster-consistent: the per-node
+   `SCION_SERVER_ADMIN_MODE` force-win is removed (user decision); maintenance
+   env values are ordinary seed inputs.
+8. UI classification/provenance sourced from the backend (schema endpoint + GET
+   metadata); structured errors (400/409/422) legible; Layer-1 booleans persist
+   `false` and cleared fields clear (#391); provenance coverage complete (#389).
+9. **Phases are EM-supervisable** (§7): commit-sized, explicit dependencies,
+   per-phase acceptance, parallelizable after the backend contract lands.
+
+## 2. Non-Goals
+
+- **Storage re-architecture.** `hub_settings`, section registry, LISTEN/NOTIFY
+  propagation, advisory-lock seeding stay as shipped in PR #640. This design
+  adds one column and changes merge/seed/override semantics.
+- **Full schema-driven form generation** — classify from the schema endpoint,
+  don't generate the form.
+- **notification_channels editor** — deferred; tracked in **ptone/scion#444**
+  (with #387 secret-param splitting).
+- **Maintenance-mode toggle on this page** — pure admin feature, stays on its
+  existing surface (user decision).
+- **Cross-node diagnostics** (#386), **settings audit log** (#390) — follow-ups.
+
+## 3. Proposed Design
+
+### 3.1 The precedence model (normative)
+
+**Key classes** (existing `pkg/config/opsettings` registry):
+- **Layer-0 (bootstrap-only):** needed before DB connect or restart-bound
+  (database, listeners, auth stack, secrets/storage, mode/identity, logging,
+  CORS, message broker, plugins). Never in the DB.
+- **Layer-1 (operational):** registry sections (`access`, `lifecycle`,
+  `maintenance`, `telemetry`, `agent_defaults`, `endpoints`, `github_app`,
+  `notifications`).
+
+**One bootstrap merge order, used everywhere:**
+
+```
+coded defaults → SCION_SEED_* → settings.yaml → SCION_SERVER_*
+```
+
+- `SCION_SEED_*`: new env namespace; path mapping identical to `SCION_SERVER_*`
+  after the prefix (e.g. `SCION_SEED_SERVER_HUB_ADMINEMAILS` →
+  `server.hub.admin_emails`). Provides initial values that the mutable store
+  may override. Valid for any key; primarily useful for Layer-1.
+- `settings.yaml`: bootstrap material in DB mode; **the mutable store** in
+  no-DB mode (so the chain reads `defaults → SEED → mutable store → SERVER`
+  there — exactly the universal shape).
+- `SCION_SERVER_*`: conventional env-wins. **Layer-0: permanent** (deployment
+  tooling must win on bootstrap keys). **Layer-1: deprecated** — during the
+  transition window it is honored as a *seed input at the top of the bootstrap
+  merge* (preserving today's "env wins over yaml" for existing deploys) with a
+  startup WARN and a GET-response notice pointing at `SCION_SEED_*`; a later
+  release ignores it for Layer-1 entirely.
+
+**Runtime resolution:**
+
+| Mode | Layer-0 | Layer-1 |
+|---|---|---|
+| No DB | bootstrap merge (restart-bound) | bootstrap merge; yaml editable via UI/API; `SCION_SERVER_*`-pinned keys read-only |
+| DB (postgres) | bootstrap merge (restart-bound) | DB rows win; rowless sections fall back to the bootstrap merge |
+
+### 3.2 The seeded/managed section lifecycle (the BIOS model)
+
+New column on `hub_settings` (Ent schema `pkg/ent/schema/hubsetting.go`,
+additive, rides declarative auto-migration):
+
+```go
+field.Enum("origin").Values("seeded", "managed").Default("seeded")
+```
+
+**Lifecycle:**
+
+1. **Boot (every boot, not just first):** under the existing advisory lock,
+   compute each section's document from the bootstrap merge. For sections with
+   `origin = seeded` (or no row), upsert the computed doc **iff it differs**
+   from the stored doc (skip-write on equality → no revision bump, no event
+   churn). Sections with `origin = managed` are left untouched.
+   - Since env can only change at process restart, this makes `SCION_SEED_*`
+     behave *fully conventionally* for unmanaged sections: change the deploy
+     config, restart/redeploy, the cluster picks it up.
+   - Heterogeneous node envs converge to last-boot-wins in shared state — a
+     consistent cluster, not per-node drift. Docs still say: keep env uniform
+     via deployment tooling.
+2. **First explicit admin write** (`PUT /admin/server-config` or
+   `/admin/maintenance` touching the section): the upsert sets
+   `origin = managed`. The DB now owns the section; bootstrap material is inert
+   for it.
+3. **Superseded notice:** for `managed` sections only, any bootstrap-material
+   key whose merged value differs from the DB value is reported in the GET as
+   `superseded_keys` and surfaced in the UI (§3.4).
+4. **Reset to bootstrap:** per-section action = `DeleteHubSetting` (exists).
+   The snapshot immediately falls back to the bootstrap merge for that section;
+   next boot (or an immediate inline re-seed after delete) recreates the row as
+   `seeded`. Exposed as a small per-section "Reset to bootstrap" button in the
+   UI with a confirm dialog.
+
+**Migration/backfill:** existing rows were written either by PR #640 seeding
+(`updated_by = "seed"` — the sentinel already used, see `UpsertHubSetting`
+call sites) or by admin PUTs. Backfill: `origin = seeded` where
+`updated_by = "seed"`, else `managed`. The `_meta` row is exempt from the
+lifecycle. Seed-writes continue to use `updated_by = "seed"`.
+
+**Maintenance mode:** no special-casing remains. `SCION_SERVER_ADMIN_MODE` /
+`SCION_SERVER_MAINTENANCE_MESSAGE` lose their bidirectional per-node force-win
+(`operational_settings.go:755-765` removed — user decision: maintenance must be
+cluster-consistent in HA). They participate as deprecated Layer-1
+`SCION_SERVER_*` seed inputs (WARN), with `SCION_SEED_*` equivalents as the
+go-forward. `PUT /api/v1/admin/maintenance` marks the `maintenance` section
+managed, exactly like any other admin write. Release-note callout required
+(removes a documented break-glass; remedy: admin API, or reset-to-bootstrap on
+the maintenance row).
+
+### 3.3 Backend changes (by file)
+
+1. **`pkg/config` koanf load** — add the `SCION_SEED_*` env provider at the
+   bottom of the merge (above defaults, below file); keep `SCION_SERVER_*` on
+   top. Deprecation WARN when a `SCION_SERVER_*` var resolves to a Layer-1 key.
+2. **`pkg/ent/schema/hubsetting.go`** — `origin` enum field (+ generated code);
+   store surface (`UpsertHubSetting` gains an origin-aware variant or a
+   `MarkManaged` semantic: admin path writes `managed`, seed path writes
+   `seeded`).
+3. **Seeding path** (`cmd/server_foreground.go` wiring +
+   `pkg/hub/operational_settings.go`) — every-boot re-sync of
+   seeded/rowless sections from the bootstrap merge under the advisory lock;
+   skip-write on equality.
+4. **`OperationalSettings.Snapshot()`** (`operational_settings.go:255-292`) —
+   DB rows win; rowless sections fall back to the bootstrap merge. The current
+   env-merged-last block is removed (env now lives inside the bootstrap merge).
+5. **Maintenance force-win removal** (`operational_settings.go:740-765`) +
+   test updates (`operational_settings_propagation_test.go`, `ha_e2e_test.go`).
+6. **GET responses** (`admin_settings_db.go` / `admin_settings.go`):
+   - `settings_tier`: `"db"` | `"file"`.
+   - Per-section `origin` added to `section_metadata` (drives UI captions and
+     the reset button).
+   - DB mode: `superseded_keys: [{key, source: "seed_env"|"yaml"|"server_env"}]`
+     for managed sections only.
+   - File mode: `env_keys` — all keys pinned by `SCION_SERVER_*` (generalize
+     `DetectEnvOverrides`, `pkg/config/opsettings/koanf.go:303`, which today
+     filters to Layer-1).
+   - `deprecated_env_keys` — `SCION_SERVER_*` vars hitting Layer-1 keys, for a
+     UI nudge toward `SCION_SEED_*`.
+7. **PUT handler** — sets `origin = managed` on written sections. `DELETE`
+   /reset endpoint (or reuse existing delete path) per section.
+8. **#391 correctness** — `*bool` round-trips persist `false`; explicit-empty
+   clears via `fieldPresence` (`admin_settings_db.go:1002`).
+
+### 3.4 UI: editability predicate and rendering
+
+Classification from `GET /api/v1/admin/server-config/schema`
+(`handleAdminServerConfigSchema`, `admin_settings_db.go:966`) → `layer1Keys`;
+`STATIC_LAYER1_KEYS` fallback (derived from `KOANF_KEY_LABELS`,
+`admin-server-config.ts:271`) if the fetch fails. Single predicate:
+
+```ts
+private readOnlyReason(koanfKey: string): 'bootstrap' | 'env' | null {
+  if (this.settingsTier === 'db') {
+    return this.layer1Keys.has(koanfKey) ? null : 'bootstrap'; // DB owns Layer-1
+  }
+  return this.envKeys.has(koanfKey) ? 'env' : null;            // file mode: SERVER_* pins
+}
+```
+
+| State | Treatment |
+|---|---|
+| DB mode, Layer-0 | static value + grey **🔒 Managed via deployment configuration (settings.yaml / env)** |
+| DB mode, Layer-1, section `seeded` | editable; caption: *"tracking deployment configuration — will re-sync on restart until edited"* |
+| DB mode, Layer-1, section `managed` | editable; caption shows `source/revision/updated_by/updated_at` (exists: `renderSectionMeta`, line 1244) |
+| DB mode, managed + differing bootstrap value | editable + blue ⓘ *"a deployment-provided value differs and is superseded by this database value"*; page-top panel lists `superseded_keys` |
+| DB mode, `deprecated_env_keys` present | page-top notice: *"SCION_SERVER_* is deprecated for operational settings — use SCION_SEED_*"* |
+| File mode, `SCION_SERVER_*`-pinned | static value + grey **🔒 Set via environment variable** |
+| File mode, others | editable (today's behavior) |
+
+Per-section **"Reset to bootstrap"** button (confirm dialog) → delete/reset →
+reload. Editing any field in a seeded section and saving flips it to managed —
+the seeded-caption doubles as the warning that this is a one-way door (until
+reset).
+
+UI organization is **option A** (per-field marking within existing functional
+tabs) — confirmed; a tab legitimately mixes editable and read-only fields.
+
+### 3.5 Payload construction
+
+Invariant: **never submit a field rendered read-only** — both builders key off
+`readOnlyReason()`.
+
+- `buildLayer1Payload()` (DB mode) — only Layer-1 keys. Sections:
+  `server.hub.{admin_emails, public_url, soft_delete_*, auto_suspend_stalled}`,
+  `server.auth.{user_access_mode, authorized_domains}`, `agent_defaults`
+  fields, `telemetry` (whole object), `server.github_app` non-secret fields
+  (secrets stay on `/api/v1/github-app`), `server.notification_channels`
+  round-tripped raw until #444. Booleans always sent (`*bool`, never
+  `|| undefined`); cleared fields sent as explicit empty (#391).
+- `buildFilePayload()` (file mode) — today's payload minus env-pinned keys;
+  byte-identical to today when no `SCION_SERVER_*` vars are set.
+
+Zero Layer-0 keys in a DB-mode PUT → the 422 becomes unreachable in normal use
+(kept as a safety net, §3.6).
+
+### 3.6 Structured error handling
+
+Typed parser on the `error` discriminator in `handleSave()` replacing generic
+`extractApiError()`:
+
+| HTTP | body | UI |
+|---|---|---|
+| 200 | `{reload, ignored_keys?}` | success; ignored-keys notice (exists) |
+| 400 | `validation_failed` + per-section paths | inline per-section errors; scroll to first |
+| 409 | `revision_conflict` + conflicted sections | "changed since you loaded" banner + Reload |
+| 422 | `layer0_rejected` + keys | safety-net notice; console log (should not occur) |
+
+### 3.7 Optional: optimistic concurrency (CAS)
+
+Opt in later by sending `expected_revisions` from `section_metadata`; 409 per
+§3.6. Separate phase (#441); default stays last-writer-wins.
+
+### 3.8 Data flow summary
+
+```
+bootstrap merge (everywhere): defaults → SCION_SEED_* → yaml → SCION_SERVER_*
+                                                (Layer-1 SERVER_* = deprecated seed input + WARN)
+
+boot (postgres): under advisory lock, for each section with origin=seeded or no row:
+                   doc := extract(bootstrap merge); upsert iff changed (origin=seeded)
+                 managed rows untouched
+runtime (postgres): Snapshot = bootstrap merge under DB rows (DB wins)
+admin PUT: validate → upsert(origin=managed) → event → peers Refresh()
+reset: delete row → falls back to bootstrap → re-seeded next boot
+
+load():   GET server-config        → values + settings_tier + section_metadata(origin)
+                                     + superseded_keys | env_keys + deprecated_env_keys
+          GET server-config/schema → layer1Keys (fallback STATIC_LAYER1_KEYS)
+render(): readOnlyReason() → editable | 🔒bootstrap | 🔒env; captions by origin; ⓘ superseded
+save():   PUT {only editable fields; presence-aware; booleans always} → typed 200/400/409/422
+```
+
+## 4. Alternatives Considered
+
+1. **Keep env-wins precedence (settings-db as shipped), UI-only fix** (rev 1/2).
+   *Rejected by user:* two mutable influences at runtime; per-node drift
+   persists; UI must explain "editable but locally overridden".
+2. **Pure runtime precedence inversion, seed-once** (rev 3). *Refined away:*
+   left the paradox — a changed env var silently not applying violates the
+   universal env convention, biting hardest during early deploy iteration.
+3. **Prefix-only (`SCION_SEED_*`), seed-once, no managed tracking.** *Rejected
+   (user chose the refinement):* the name explains initial-only, but changed
+   SEED values still silently no-op after first boot; no clean "reset" story;
+   one column buys behavior that matches the name.
+4. **Re-seed on every boot unconditionally (no managed marker).** *Rejected:*
+   admin edits would be overwritten at each restart — the DB would never truly
+   own anything.
+5. **Backend-only 422 tolerance** (extend `isZeroStruct` to scalars).
+   *Rejected:* fragile heuristic; hides real Layer-0 write attempts; bootstrap
+   fields stay visibly editable-but-inert.
+6. **Option B UI (Operational vs Bootstrap groups).** *Rejected (user confirmed
+   A):* cannot express runtime-dependent mixed editability within a tab.
+7. **Per-node break-glass retained for maintenance.** *Rejected by user:*
+   maintenance must be cluster-consistent in HA.
+8. **Configurable precedence knob.** *Rejected:* configurable precedence is how
+   config systems become haunted.
+9. **Hardcoded client key set** — rejected as primary (drift), kept as fallback.
+10. **Per-section save buttons** — deferred (pairs with CAS, #441).
+
+## 5. Migration / Rollout
+
+- **Schema:** one additive `origin` column (default `seeded`), declarative
+  auto-migration. Backfill `managed` where `updated_by != "seed"`.
+- **Behavior on upgrade (existing postgres deployments):** sections never
+  admin-edited (`updated_by = "seed"`) become `seeded` → they re-sync from
+  current bootstrap material at next boot. Their DB values equal the original
+  file seed, so a re-sync simply refreshes them to current deploy config —
+  the intended semantic. Admin-edited sections become `managed` → DB keeps
+  winning; any still-set env var that differs now shows the superseded notice
+  instead of silently winning per-node. **Release-note callouts:** (a) env no
+  longer overrides managed operational settings at runtime (notably
+  `user_access_mode` lockdowns), (b) `SCION_SERVER_ADMIN_MODE` force-win
+  removed, (c) `SCION_SERVER_*` deprecated for Layer-1 → `SCION_SEED_*`.
+- **No-DB hubs:** unchanged except `SCION_SERVER_*`-pinned fields render
+  read-only (edits to them were already inert) and `SCION_SEED_*` becomes
+  available as an overridable default below yaml.
+- **Rolling deploy:** old+new replicas disagree on Layer-1 env precedence
+  during the window — transient, converges at rollout completion (same stance
+  as settings-db's mixed-version window). Client degrades safely: tier inferred
+  from `section_metadata` if `settings_tier` absent; missing
+  `env_keys`/`superseded_keys`/`origin` treated as empty/managed;
+  `STATIC_LAYER1_KEYS` if the schema endpoint fails.
+- **Docs (#440):** precedence chain, seeded/managed lifecycle + reset,
+  `SCION_SEED_*` reference (per-key table), deprecation of `SCION_SERVER_*`
+  for Layer-1, break-glass removal, env-first HA bootstrap guidance.
+
+## 6. Open Questions
+
+**None.** All resolved with the user on thread 4199 (2026-07-12):
+
+| # | Question | Resolution |
+|---|---|---|
+| 1 | UI organization A vs B | **A** (per-field marking) |
+| 2 | Precedence scope | Layer-1 only in DB; Layer-0 stays file/env, `SCION_SERVER_*` wins |
+| 3 | Env as seed source | Yes — `SCION_SEED_*` namespace ("seed" semantic confirmed) |
+| 4 | Seed lifecycle | Seeded/managed marker; re-sync unmanaged sections every boot; first admin write takes ownership; reset-to-bootstrap reverts |
+| 5 | `SCION_SERVER_*` on Layer-1 | Deprecation window (seed input + WARN), then ignored |
+| 6 | `SCION_SERVER_ADMIN_MODE` break-glass | Removed — maintenance is cluster-consistent |
+| 7 | notification_channels editor | Deferred → ptone/scion#444 |
+| 8 | Maintenance toggle on page | Out of scope (pure admin feature) |
+| 9 | No-DB env ordering | `defaults → SEED → yaml → SERVER` — universal chain, no special case |
+
+## 7. Implementation Phases (EM-supervisable)
+
+Yes — structured for an EM: commit-sized phases with explicit dependencies,
+per-phase acceptance, and a parallelization map. Backend contract lands first
+(B1–B3, serial — same files); the four workstreams after it can run in
+parallel across developers.
+
+```
+B1 → B2 → B3 ──┬── W1 → W2  (web core → notices/reset)
+               ├── W3        (structured errors)
+               ├── B4        (#391 correctness)
+               └── T1 → T2   (test infra → component tests)
+                                then D1 (docs), C1 (optional CAS)
+```
+
+**B1 — `SCION_SEED_*` provider + unified bootstrap merge (backend).** *(#446)*
+Koanf: SEED provider below file, SERVER on top; Layer-1 SERVER deprecation WARN.
+No DB changes. *Accept:* unit tests prove the merge order
+`defaults → SEED → yaml → SERVER` incl. Layer-1 SERVER-as-top-of-bootstrap
+during deprecation; WARN emitted.
+
+**B2 — `origin` column + seeded/managed lifecycle (backend).** *(#446)*
+Ent field + backfill (`updated_by != "seed"` → managed); every-boot re-sync of
+seeded/rowless sections under the advisory lock with skip-write-on-equality;
+PUT sets managed; reset path (delete → fallback → reseed next boot).
+*Accept:* store/integration tests — re-sync updates a seeded row when bootstrap
+changed, skips when equal (no revision bump/event), never touches managed rows;
+concurrent-boot exactly-once; backfill correct.
+
+**B3 — Runtime resolution + provenance API (backend).** *(#446)*
+`Snapshot()` = bootstrap merge under DB rows; remove env-merged-last block;
+remove maintenance force-win (update propagation/e2e tests); GET gains
+`settings_tier`, `origin` in `section_metadata`, `superseded_keys` (managed
+only), `env_keys` (file mode, generalized detection), `deprecated_env_keys`.
+*Accept:* two-node test — managed section ignores env at runtime and reports
+superseded; seeded section refreshes on restart; maintenance no longer
+env-forced; response fields golden-tested. **This freezes the API contract for
+W1–W3.**
+
+**W1 — Layer-aware rendering + payload split (web) — the #437 fix.** *(#438)*
+Schema fetch → `layer1Keys` + static fallback; `readOnlyReason()`; `field()`
+wrapper / per-control disabled + badges; `buildLayer1Payload()` /
+`buildFilePayload()`. *Accept:* acceptance criteria 3, 4, 6 (§8) manually
+verified against a local postgres hub; no Layer-0/env-pinned key in any PUT.
+
+**W2 — Origin captions, superseded/deprecation notices, reset button (web).**
+*(#438)* Seeded/managed captions; ⓘ superseded badges + page panel;
+`SCION_SEED_*` deprecation nudge; per-section reset with confirm. Closes #389
+(audit: every field declares its koanf key). *Accept:* criteria 1, 5 (§8).
+
+**W3 — Structured error handling (web).** *(#439)* Typed 400/409/422 parser;
+inline per-section errors; conflict banner; 422 safety net. *Accept:*
+criterion 8.
+
+**B4 — Presence/boolean correctness (backend+web, #391).** `false` persists;
+explicit-empty clears; round-trip tests. *Accept:* criterion 7.
+
+**T1 — Component test infra (web, #388).** `@web/test-runner` or vitest +
+`@open-wc/testing` wired into CI. **T2 — Component tests** covering criteria
+1, 3, 4, 6, 8. *(T1 can start anytime; T2 needs W1–W3.)*
+
+**D1 — Docs (#440).** Per §5. *(After B3 stabilizes; screenshots after W2.)*
+
+**C1 (optional) — CAS (#441).** `expected_revisions` + 409 UX + per-section
+save consideration.
+
+Branch/PR guidance: B1–B3 as one reviewable backend PR train on the epic
+branch (or stacked); W1–W3 independent PRs behind it. Design doc committed as
+`.design/ha-settings.md` with the first PR. Rebase-onto-upstream at each phase
+start and before compare URLs, per process.
+
+## 8. Acceptance Criteria
+
+1. **Seeded lifecycle:** fresh postgres hub, `SCION_SEED_SERVER_HUB_ADMINEMAILS=a@x`:
+   value serves from DB (`origin: seeded`). Change the var to `b@y`, restart:
+   value updates cluster-wide. Edit to `c@z` in the UI: section becomes
+   `managed`; changing the var + restart no longer alters it; superseded notice
+   lists the key. Reset-to-bootstrap → back to tracking (`b@y` after reseed).
+2. **Bootstrap merge order:** with defaults + SEED + yaml + SERVER all setting
+   the same Layer-1 key, effective bootstrap value is SERVER's (deprecation
+   window, WARN emitted); without SERVER, yaml's; without yaml, SEED's.
+3. **DB mode, Layer-1 edit persists (the #437 fix):** editing
+   `image_registry`, `admin_emails`, a telemetry toggle → 200, no 422, value on
+   reload with `source: "db"`, propagated to a second replica ≤2s.
+4. **DB mode, Layer-0 read-only:** `server.mode`, `log_level`, `hub.port`,
+   `database.*`, `secrets.*`, `storage.*`, dev-auth render read-only with the
+   bootstrap badge and are absent from the PUT (network capture).
+5. **Maintenance cluster-consistency:** `SCION_SERVER_ADMIN_MODE=true` on one
+   node does not force that node into admin mode when the DB maintenance row
+   says otherwise; `PUT /admin/maintenance` marks the section managed,
+   propagates, survives restart.
+6. **File mode:** no env vars → all fields editable, Save writes settings.yaml
+   as today (existing tests pass). `SCION_SERVER_HUB_PORT` set → port field
+   read-only + env badge, absent from PUT. `SCION_SEED_*` value appears as an
+   editable default that a yaml write overrides.
+7. **#391:** boolean on→off persists `false`; clearing `admin_emails` clears it.
+8. **Structured errors:** schema violation → inline per-section error; conflict
+   (CAS) → reload banner; scripted PUT with `server.mode` → 422 safety net.
+9. **Re-sync hygiene:** restart with unchanged bootstrap material causes zero
+   writes/revision bumps/events (verified by revision equality across restarts).
+10. **Resilience / mixed versions:** schema-endpoint failure → static fallback;
+    GET missing new fields (older hub) → safe degraded behavior.
+11. **Component tests (#388)** cover 1 (UI aspects), 3, 4, 6, 8 and run in CI.
+
+## 9. QA / Live-instance test plan (Cloud Run + IAP)
+
+Against a live Cloud Run hub in postgres mode via IAP browser auth
+(`/scion-volumes/contrib-repo/skills/iap-browser-auth/SKILL.md`); promote the
+SA user to admin first. Playwright with `waitUntil: 'domcontentloaded'`.
+
+1. **Load & tier:** page loads; `settings_tier: "db"`; bootstrap badges on
+   Data & Storage / dev-auth / hub port; seeded/managed captions render.
+2. **Seed lifecycle end-to-end:** set a `SCION_SEED_*` Layer-1 var on the
+   service (new revision = restart) → value appears (`origin: seeded`); edit it
+   in the UI → managed; redeploy with a different var value → UI value
+   unchanged + superseded notice; reset-to-bootstrap → tracks var again.
+3. **Layer-1 happy path:** edit `image_registry` → 200; reload shows
+   `source: "db"`, `updated_by` = SA email.
+4. **Layer-0 immutability + safety net:** bootstrap inputs read-only; scripted
+   PUT with `server.mode` → 422.
+5. **Propagation:** save on one replica; second replica reflects ≤2s
+   (min-instances=2).
+6. **Maintenance:** on/off round-trip via API; no env force-win.
+7. **Screenshots** of each tab.
+
+## 10. Files & surfaces touched (for the developer)
+
+**Backend:**
+- `pkg/config` (koanf load) — `SCION_SEED_*` provider; SERVER-on-Layer-1
+  deprecation WARN.
+- `pkg/ent/schema/hubsetting.go` (+ regen) — `origin` enum; backfill.
+- `pkg/store` / `entadapter` — origin-aware upsert paths.
+- `pkg/hub/operational_settings.go` — every-boot re-sync (advisory lock,
+  skip-on-equal); `Snapshot()` merge (~255-292); maintenance force-win removal
+  (~740-765); superseded computation.
+- `pkg/config/opsettings/koanf.go` — generalized env detection (line 303),
+  SEED/SERVER split, value-diff superseded helper.
+- `pkg/hub/admin_settings_db.go` / `admin_settings.go` — response fields
+  (`settings_tier`, `origin`, `superseded_keys`, `env_keys`,
+  `deprecated_env_keys`); PUT sets managed; reset path; #391 presence fixes
+  (`fieldPresence`, line 1002).
+- Tests: `opsettings_test.go`, `operational_settings_propagation_test.go`,
+  `ha_e2e_test.go`, handler tests, store tests.
+
+**Web:**
+- `web/src/components/pages/admin-server-config.ts` — tier/origin/provenance
+  state, schema fetch + fallback, `readOnlyReason()`, `field()` /
+  `renderManagedBadge(reason)`, seeded/managed captions, superseded +
+  deprecation notices, reset button, `buildLayer1Payload()` /
+  `buildFilePayload()`, typed error parser. CSS: `.managed-badge`
+  (`.env`/`.bootstrap`), `.superseded-badge`, `.read-only`, `.ro-value`.
+- `web/` test infra (#388) + `*.test.ts`.
+
+**Docs:** admin settings page under `docs/` (precedence chain, lifecycle,
+`SCION_SEED_*` reference, deprecations, HA guidance).

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1443,7 +1443,6 @@ func initOperationalSettings(ctx context.Context, cfg *config.GlobalConfig, hubS
 	}
 
 	// Build koanf instances.
-	fileKoanf := config.LoadFileOnlyKoanf()
 	envKoanf := config.LoadEnvKoanf()
 	bootstrapKoanf := config.LoadBootstrapKoanf()
 
@@ -1476,7 +1475,7 @@ func initOperationalSettings(ctx context.Context, cfg *config.GlobalConfig, hubS
 	}
 
 	// --- Create OperationalSettings, Refresh, and apply ---
-	ops := hub.NewOperationalSettings(settingStore, fileKoanf, envKoanf)
+	ops := hub.NewOperationalSettings(settingStore, bootstrapKoanf, envKoanf)
 
 	changed, err := ops.Refresh(ctx)
 	if err != nil {

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1437,17 +1438,20 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 func initOperationalSettings(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Server, s store.Store, globalDir string) error {
 	settingStore, ok := s.(store.HubSettingStore)
 	if !ok {
-		// Store does not implement HubSettingStore — skip (should not happen
-		// with postgres, but guard defensively).
 		log.Println("WARNING: store does not implement HubSettingStore; skipping operational settings init")
 		return nil
 	}
 
-	// Build the file-only and env-only koanf instances.
+	// Build koanf instances.
 	fileKoanf := config.LoadFileOnlyKoanf()
 	envKoanf := config.LoadEnvKoanf()
+	bootstrapKoanf := config.LoadBootstrapKoanf()
 
-	// --- Seeding under advisory lock ---
+	// Log deprecation warnings for SCION_SERVER_* env vars that overlap
+	// Layer-1 settings (these should use SCION_SEED_* instead).
+	opsettings.LogDeprecatedServerEnv(envKoanf, slog.Default())
+
+	// --- Every-boot re-sync under advisory lock ---
 	locker, hasLocker := s.(store.AdvisoryLocker)
 	if hasLocker {
 		acquired, release, err := locker.TryAdvisoryLock(ctx, store.LockHubSettingsSeed)
@@ -1455,24 +1459,19 @@ func initOperationalSettings(ctx context.Context, cfg *config.GlobalConfig, hubS
 			return fmt.Errorf("acquiring hub_settings_seed advisory lock: %w", err)
 		}
 		if acquired {
-			seedErr := seedHubSettingsIfNeeded(ctx, settingStore, fileKoanf, globalDir)
-			// Release the advisory lock immediately after seeding (scoped
-			// release per design §3.9) — Refresh below does not need the lock.
+			syncErr := syncHubSettings(ctx, settingStore, bootstrapKoanf)
 			if rerr := release(); rerr != nil {
 				slog.Error("Failed to release hub_settings_seed advisory lock", "error", rerr)
 			}
-			if seedErr != nil {
-				return fmt.Errorf("seeding hub settings: %w", seedErr)
+			if syncErr != nil {
+				return fmt.Errorf("syncing hub settings: %w", syncErr)
 			}
 		} else {
-			// Another replica is seeding — that's fine, we'll pick up the
-			// results via Refresh below.
-			log.Println("Hub settings seed lock held by another replica; skipping seed")
+			log.Println("Hub settings seed lock held by another replica; skipping sync")
 		}
 	} else {
-		// No advisory locking (shouldn't happen on postgres, but handle).
-		if err := seedHubSettingsIfNeeded(ctx, settingStore, fileKoanf, globalDir); err != nil {
-			return fmt.Errorf("seeding hub settings: %w", err)
+		if err := syncHubSettings(ctx, settingStore, bootstrapKoanf); err != nil {
+			return fmt.Errorf("syncing hub settings: %w", err)
 		}
 	}
 
@@ -1493,7 +1492,6 @@ func initOperationalSettings(ctx context.Context, cfg *config.GlobalConfig, hubS
 
 	hubSrv.SetOperationalSettings(ops)
 
-	// --- WARN log for env-overridden Layer-1 keys (§3.4) ---
 	if envKeys := ops.EnvOverriddenKeys(); len(envKeys) > 0 {
 		slog.Warn("Layer-1 settings overridden by SCION_SERVER_* env vars on this node — these values diverge from the shared DB",
 			"keys", envKeys)
@@ -1515,56 +1513,73 @@ func startSettingsPropagation(ctx context.Context, hubSrv *hub.Server, eventPub 
 	slog.Info("Settings change propagation started (subscribe + poll backstop)")
 }
 
-// seedHubSettingsIfNeeded checks for the _meta sentinel row; if absent, seeds
-// each registry section from the file's Layer-1 keys. Sections with no koanf
-// paths (e.g. maintenance) are skipped — they start with compiled defaults.
-func seedHubSettingsIfNeeded(ctx context.Context, s store.HubSettingStore, fileKoanf *koanf.Koanf, globalDir string) error {
-	// Check for _meta sentinel.
-	_, err := s.GetHubSetting(ctx, "_meta")
-	if err == nil {
-		// _meta exists — seeding already done.
-		log.Println("Hub settings already seeded (_meta row present); skipping seed")
-		return nil
-	}
-	if !errors.Is(err, store.ErrNotFound) {
-		return fmt.Errorf("checking _meta row: %w", err)
+// syncHubSettings performs every-boot re-sync of hub_settings from bootstrap
+// material. For each registered section:
+//   - If the row is absent or origin=="seeded": write the bootstrap doc
+//     (skip-write-on-equality to avoid revision bumps and event churn).
+//   - If origin=="managed": skip — admin owns this section.
+//
+// Also runs BackfillOrigin for pre-origin rows and writes the _meta sentinel.
+func syncHubSettings(ctx context.Context, s store.HubSettingStore, bootstrapKoanf *koanf.Koanf) error {
+	// Backfill origin for rows created before the origin column existed.
+	if err := s.BackfillOrigin(ctx); err != nil {
+		return fmt.Errorf("backfilling origin: %w", err)
 	}
 
-	// No _meta — seed.
-	log.Println("Seeding hub_settings from settings.yaml...")
-
-	settingsPath := filepath.Join(globalDir, "settings.yaml")
+	log.Println("Syncing hub_settings from bootstrap material...")
 
 	for _, sec := range opsettings.Registry {
-		// Skip sections with no koanf paths (e.g. maintenance — runtime-only).
 		if len(sec.KoanfPaths) == 0 {
 			continue
 		}
 
-		doc, err := opsettings.ExtractSectionFromKoanf(fileKoanf, sec.Name)
+		bootstrapDoc, err := opsettings.ExtractSectionFromKoanf(bootstrapKoanf, sec.Name)
 		if err != nil {
-			slog.Warn("Failed to extract section for seeding; skipping", "section", sec.Name, "error", err)
+			slog.Warn("Failed to extract section for sync; skipping", "section", sec.Name, "error", err)
 			continue
 		}
 
-		_, err = s.UpsertHubSetting(ctx, sec.Name, doc, "seed", -1, "seeded") // unconditional upsert
-		if err != nil {
-			return fmt.Errorf("seeding section %q: %w", sec.Name, err)
+		existing, err := s.GetHubSetting(ctx, sec.Name)
+		if err != nil && !errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("checking section %q: %w", sec.Name, err)
 		}
-		log.Printf("  Seeded section: %s", sec.Name)
+
+		if existing == nil {
+			// No row — create with bootstrap material.
+			if _, err := s.UpsertHubSetting(ctx, sec.Name, bootstrapDoc, "seed", -1, "seeded"); err != nil {
+				return fmt.Errorf("seeding section %q: %w", sec.Name, err)
+			}
+			log.Printf("  Seeded section: %s (new)", sec.Name)
+			continue
+		}
+
+		if existing.Origin == "managed" {
+			slog.Debug("Skipping managed section", "section", sec.Name)
+			continue
+		}
+
+		// Origin is "seeded" — update only if content differs.
+		if bytes.Equal(existing.Value, bootstrapDoc) {
+			slog.Debug("Seeded section unchanged; skipping write", "section", sec.Name)
+			continue
+		}
+
+		if _, err := s.UpsertHubSetting(ctx, sec.Name, bootstrapDoc, "seed", -1, "seeded"); err != nil {
+			return fmt.Errorf("re-syncing section %q: %w", sec.Name, err)
+		}
+		log.Printf("  Re-synced section: %s (content changed)", sec.Name)
 	}
 
-	// Write _meta sentinel.
+	// Write/update _meta sentinel.
 	metaDoc, _ := json.Marshal(map[string]interface{}{
-		"seeded_from":  settingsPath,
-		"seeded_at":    time.Now().UTC().Format(time.RFC3339),
-		"seed_version": "1",
+		"synced_at":    time.Now().UTC().Format(time.RFC3339),
+		"seed_version": "2",
 	})
 	if _, err := s.UpsertHubSetting(ctx, "_meta", metaDoc, "seed", -1, "seeded"); err != nil {
 		return fmt.Errorf("writing _meta sentinel: %w", err)
 	}
 
-	log.Println("Hub settings seeding complete")
+	log.Println("Hub settings sync complete")
 	return nil
 }
 

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1547,7 +1547,7 @@ func seedHubSettingsIfNeeded(ctx context.Context, s store.HubSettingStore, fileK
 			continue
 		}
 
-		_, err = s.UpsertHubSetting(ctx, sec.Name, doc, "seed", -1) // unconditional upsert
+		_, err = s.UpsertHubSetting(ctx, sec.Name, doc, "seed", -1, "seeded") // unconditional upsert
 		if err != nil {
 			return fmt.Errorf("seeding section %q: %w", sec.Name, err)
 		}
@@ -1560,7 +1560,7 @@ func seedHubSettingsIfNeeded(ctx context.Context, s store.HubSettingStore, fileK
 		"seeded_at":    time.Now().UTC().Format(time.RFC3339),
 		"seed_version": "1",
 	})
-	if _, err := s.UpsertHubSetting(ctx, "_meta", metaDoc, "seed", -1); err != nil {
+	if _, err := s.UpsertHubSetting(ctx, "_meta", metaDoc, "seed", -1, "seeded"); err != nil {
 		return fmt.Errorf("writing _meta sentinel: %w", err)
 	}
 

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1587,6 +1587,9 @@ func syncHubSettings(ctx context.Context, s store.HubSettingStore, bootstrapKoan
 
 // jsonEqual compares two JSON documents semantically, ignoring whitespace
 // and key ordering differences (as Postgres jsonb re-serializes values).
+// Both inputs must come through json.Unmarshal so numeric types are
+// consistently float64. If either path changes to produce integer types
+// (e.g. a custom decoder), semantically equal values could compare unequal.
 func jsonEqual(a, b json.RawMessage) bool {
 	var aVal, bVal interface{}
 	if err := json.Unmarshal(a, &aVal); err != nil {

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -1558,7 +1559,9 @@ func syncHubSettings(ctx context.Context, s store.HubSettingStore, bootstrapKoan
 		}
 
 		// Origin is "seeded" — update only if content differs.
-		if bytes.Equal(existing.Value, bootstrapDoc) {
+		// Compare semantically (not byte-for-byte) because Postgres jsonb
+		// re-serializes values, changing whitespace and key ordering.
+		if jsonEqual(existing.Value, bootstrapDoc) {
 			slog.Debug("Seeded section unchanged; skipping write", "section", sec.Name)
 			continue
 		}
@@ -1580,6 +1583,19 @@ func syncHubSettings(ctx context.Context, s store.HubSettingStore, bootstrapKoan
 
 	log.Println("Hub settings sync complete")
 	return nil
+}
+
+// jsonEqual compares two JSON documents semantically, ignoring whitespace
+// and key ordering differences (as Postgres jsonb re-serializes values).
+func jsonEqual(a, b json.RawMessage) bool {
+	var aVal, bVal interface{}
+	if err := json.Unmarshal(a, &aVal); err != nil {
+		return bytes.Equal(a, b)
+	}
+	if err := json.Unmarshal(b, &bVal); err != nil {
+		return bytes.Equal(a, b)
+	}
+	return reflect.DeepEqual(aVal, bVal)
 }
 
 // initHubStorage initializes the storage backend for the Hub server.

--- a/cmd/server_foreground_seed_test.go
+++ b/cmd/server_foreground_seed_test.go
@@ -56,7 +56,7 @@ func (f *fakeHubSettingStore) ListHubSettings(_ context.Context) ([]store.HubSet
 	return out, nil
 }
 
-func (f *fakeHubSettingStore) UpsertHubSetting(_ context.Context, section string, value json.RawMessage, updatedBy string, _ int64) (*store.HubSetting, error) {
+func (f *fakeHubSettingStore) UpsertHubSetting(_ context.Context, section string, value json.RawMessage, updatedBy string, _ int64, origin string) (*store.HubSetting, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	existing, ok := f.settings[section]
@@ -70,6 +70,7 @@ func (f *fakeHubSettingStore) UpsertHubSetting(_ context.Context, section string
 		Value:     value,
 		Revision:  rev,
 		UpdatedBy: updatedBy,
+		Origin:    origin,
 	}
 	f.settings[section] = s
 	return s, nil

--- a/cmd/server_foreground_seed_test.go
+++ b/cmd/server_foreground_seed_test.go
@@ -64,6 +64,9 @@ func (f *fakeHubSettingStore) UpsertHubSetting(_ context.Context, section string
 	if ok {
 		rev = existing.Revision + 1
 	}
+	if origin == "" {
+		origin = "seeded"
+	}
 	s := &store.HubSetting{
 		ID:        section,
 		Section:   section,
@@ -100,41 +103,9 @@ func (f *fakeHubSettingStore) BackfillOrigin(_ context.Context) error {
 	return nil
 }
 
-// --- seedHubSettingsIfNeeded tests ---
+// --- syncHubSettings tests ---
 
-func TestSeedHubSettingsIfNeeded_MetaSentinel(t *testing.T) {
-	// When _meta row already exists, seeding should be skipped entirely.
-	fs := newFakeHubSettingStore()
-	fs.settings["_meta"] = &store.HubSetting{
-		ID:       "_meta",
-		Section:  "_meta",
-		Value:    json.RawMessage(`{"seeded_from":"/test","seeded_at":"2026-01-01T00:00:00Z","seed_version":"1"}`),
-		Revision: 1,
-	}
-
-	k := koanf.New(".")
-	_ = k.Load(confmap.Provider(map[string]interface{}{
-		"server.hub.admin_emails":      []interface{}{"admin@test.com"},
-		"server.auth.user_access_mode": "open",
-	}, "."), nil)
-
-	err := seedHubSettingsIfNeeded(context.Background(), fs, k, "/tmp/test")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// No sections should have been seeded.
-	fs.mu.Lock()
-	defer fs.mu.Unlock()
-	for section := range fs.settings {
-		if section != "_meta" {
-			t.Errorf("unexpected section seeded: %s", section)
-		}
-	}
-}
-
-func TestSeedHubSettingsIfNeeded_ExtractsSections(t *testing.T) {
-	// With no _meta row, seeding should extract sections from the koanf file.
+func TestSyncHubSettings_SeedsNewSections(t *testing.T) {
 	fs := newFakeHubSettingStore()
 
 	k := koanf.New(".")
@@ -144,19 +115,20 @@ func TestSeedHubSettingsIfNeeded_ExtractsSections(t *testing.T) {
 		"server.hub.auto_suspend_stalled": true,
 	}, "."), nil)
 
-	err := seedHubSettingsIfNeeded(context.Background(), fs, k, "/tmp/test")
+	err := syncHubSettings(context.Background(), fs, k)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// _meta should be written
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
+
+	// _meta should be written.
 	if _, ok := fs.settings["_meta"]; !ok {
 		t.Error("expected _meta sentinel to be written")
 	}
 
-	// access section should have been seeded with admin_emails
+	// access section should have been seeded with admin_emails.
 	access, ok := fs.settings["access"]
 	if !ok {
 		t.Fatal("expected access section to be seeded")
@@ -164,10 +136,117 @@ func TestSeedHubSettingsIfNeeded_ExtractsSections(t *testing.T) {
 	if !strings.Contains(string(access.Value), "admin@test.com") {
 		t.Errorf("access section missing admin_emails: %s", access.Value)
 	}
+	if access.Origin != "seeded" {
+		t.Errorf("access origin: want seeded, got %s", access.Origin)
+	}
 }
 
-func TestSeedHubSettingsIfNeeded_MaintenanceSkipped(t *testing.T) {
-	// Maintenance section has no koanf paths — it should not be seeded.
+func TestSyncHubSettings_SkipsManagedSections(t *testing.T) {
+	fs := newFakeHubSettingStore()
+
+	// Pre-populate access as managed (admin-written).
+	fs.settings["access"] = &store.HubSetting{
+		ID:        "access",
+		Section:   "access",
+		Value:     json.RawMessage(`{"admin_emails":["admin-custom@test.com"]}`),
+		Revision:  5,
+		UpdatedBy: "admin@test.com",
+		Origin:    "managed",
+	}
+
+	k := koanf.New(".")
+	_ = k.Load(confmap.Provider(map[string]interface{}{
+		"server.hub.admin_emails":      []interface{}{"bootstrap@test.com"},
+		"server.auth.user_access_mode": "open",
+	}, "."), nil)
+
+	err := syncHubSettings(context.Background(), fs, k)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	// access should NOT have been overwritten — still has custom value.
+	access := fs.settings["access"]
+	if !strings.Contains(string(access.Value), "admin-custom@test.com") {
+		t.Errorf("managed access section was overwritten: %s", access.Value)
+	}
+	if access.Revision != 5 {
+		t.Errorf("managed access revision changed: want 5, got %d", access.Revision)
+	}
+}
+
+func TestSyncHubSettings_UpdatesSeededWhenChanged(t *testing.T) {
+	fs := newFakeHubSettingStore()
+
+	// Pre-populate access as seeded with old bootstrap value.
+	fs.settings["access"] = &store.HubSetting{
+		ID:        "access",
+		Section:   "access",
+		Value:     json.RawMessage(`{"admin_emails":["old@test.com"],"user_access_mode":"open"}`),
+		Revision:  1,
+		UpdatedBy: "seed",
+		Origin:    "seeded",
+	}
+
+	k := koanf.New(".")
+	_ = k.Load(confmap.Provider(map[string]interface{}{
+		"server.hub.admin_emails":      []interface{}{"new@test.com"},
+		"server.auth.user_access_mode": "open",
+	}, "."), nil)
+
+	err := syncHubSettings(context.Background(), fs, k)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	access := fs.settings["access"]
+	if !strings.Contains(string(access.Value), "new@test.com") {
+		t.Errorf("seeded access section was not updated: %s", access.Value)
+	}
+	if access.Revision != 2 {
+		t.Errorf("seeded access revision: want 2 (bumped), got %d", access.Revision)
+	}
+}
+
+func TestSyncHubSettings_SkipsWriteOnEquality(t *testing.T) {
+	fs := newFakeHubSettingStore()
+
+	k := koanf.New(".")
+	_ = k.Load(confmap.Provider(map[string]interface{}{
+		"server.hub.admin_emails":      []interface{}{"admin@test.com"},
+		"server.auth.user_access_mode": "open",
+	}, "."), nil)
+
+	// First sync — creates the rows.
+	err := syncHubSettings(context.Background(), fs, k)
+	if err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+
+	fs.mu.Lock()
+	accessRev := fs.settings["access"].Revision
+	fs.mu.Unlock()
+
+	// Second sync with identical bootstrap — revision should NOT bump.
+	err = syncHubSettings(context.Background(), fs, k)
+	if err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if fs.settings["access"].Revision != accessRev {
+		t.Errorf("skip-write-on-equality failed: access revision bumped from %d to %d", accessRev, fs.settings["access"].Revision)
+	}
+}
+
+func TestSyncHubSettings_MaintenanceSkipped(t *testing.T) {
 	fs := newFakeHubSettingStore()
 
 	k := koanf.New(".")
@@ -175,7 +254,7 @@ func TestSeedHubSettingsIfNeeded_MaintenanceSkipped(t *testing.T) {
 		"server.hub.admin_emails": []interface{}{"admin@test.com"},
 	}, "."), nil)
 
-	err := seedHubSettingsIfNeeded(context.Background(), fs, k, "/tmp/test")
+	err := syncHubSettings(context.Background(), fs, k)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -183,12 +262,11 @@ func TestSeedHubSettingsIfNeeded_MaintenanceSkipped(t *testing.T) {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
 	if _, ok := fs.settings["maintenance"]; ok {
-		t.Error("maintenance section should not be seeded (no koanf paths)")
+		t.Error("maintenance section should not be synced (no koanf paths)")
 	}
 }
 
-func TestSeedHubSettingsIfNeeded_GitHubAppNoSecrets(t *testing.T) {
-	// The seeded github_app section should not contain private_key or webhook_secret.
+func TestSyncHubSettings_GitHubAppNoSecrets(t *testing.T) {
 	fs := newFakeHubSettingStore()
 
 	k := koanf.New(".")
@@ -198,7 +276,7 @@ func TestSeedHubSettingsIfNeeded_GitHubAppNoSecrets(t *testing.T) {
 		"server.github_app.private_key_path": "/path/to/key.pem",
 	}, "."), nil)
 
-	err := seedHubSettingsIfNeeded(context.Background(), fs, k, "/tmp/test")
+	err := syncHubSettings(context.Background(), fs, k)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -211,12 +289,81 @@ func TestSeedHubSettingsIfNeeded_GitHubAppNoSecrets(t *testing.T) {
 	}
 
 	docStr := string(gh.Value)
-	// The GitHubAppSettings struct does not have private_key or webhook_secret
-	// fields, so they are structurally excluded from the seeded document.
 	if strings.Contains(docStr, "private_key\"") && !strings.Contains(docStr, "private_key_path") {
 		t.Errorf("github_app doc should not contain bare private_key: %s", docStr)
 	}
 	if strings.Contains(docStr, "webhook_secret") {
 		t.Errorf("github_app doc should not contain webhook_secret: %s", docStr)
+	}
+}
+
+func TestSyncHubSettings_EveryBootRunsEvenWithMeta(t *testing.T) {
+	fs := newFakeHubSettingStore()
+
+	// Pre-populate _meta (simulating a previous boot's sync).
+	fs.settings["_meta"] = &store.HubSetting{
+		ID:       "_meta",
+		Section:  "_meta",
+		Value:    json.RawMessage(`{"synced_at":"2026-01-01T00:00:00Z","seed_version":"2"}`),
+		Revision: 1,
+		Origin:   "seeded",
+	}
+
+	k := koanf.New(".")
+	_ = k.Load(confmap.Provider(map[string]interface{}{
+		"server.hub.admin_emails":      []interface{}{"admin@test.com"},
+		"server.auth.user_access_mode": "open",
+	}, "."), nil)
+
+	err := syncHubSettings(context.Background(), fs, k)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	// Unlike the old sentinel-gated approach, sync should still run and
+	// seed missing sections even when _meta already exists.
+	if _, ok := fs.settings["access"]; !ok {
+		t.Error("expected access section to be seeded even though _meta existed")
+	}
+}
+
+func TestSyncHubSettings_BackfillsPreOriginRows(t *testing.T) {
+	fs := newFakeHubSettingStore()
+
+	// Pre-populate with rows that have no origin set (simulating pre-origin data).
+	fs.settings["access"] = &store.HubSetting{
+		ID:        "access",
+		Section:   "access",
+		Value:     json.RawMessage(`{"admin_emails":["admin@custom.com"]}`),
+		Revision:  3,
+		UpdatedBy: "admin@test.com",
+		Origin:    "seeded", // column default — but updated_by is not "seed"
+	}
+
+	k := koanf.New(".")
+	_ = k.Load(confmap.Provider(map[string]interface{}{
+		"server.hub.admin_emails":      []interface{}{"bootstrap@test.com"},
+		"server.auth.user_access_mode": "open",
+	}, "."), nil)
+
+	err := syncHubSettings(context.Background(), fs, k)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	// BackfillOrigin should have flipped this to "managed" because
+	// updated_by != "seed". Then syncHubSettings should skip it.
+	access := fs.settings["access"]
+	if access.Origin != "managed" {
+		t.Errorf("expected backfill to set origin=managed, got %s", access.Origin)
+	}
+	if !strings.Contains(string(access.Value), "admin@custom.com") {
+		t.Errorf("managed row should not have been overwritten: %s", access.Value)
 	}
 }

--- a/cmd/server_foreground_seed_test.go
+++ b/cmd/server_foreground_seed_test.go
@@ -86,6 +86,20 @@ func (f *fakeHubSettingStore) DeleteHubSetting(_ context.Context, section string
 	return nil
 }
 
+func (f *fakeHubSettingStore) BackfillOrigin(_ context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for section, s := range f.settings {
+		if section == "_meta" {
+			continue
+		}
+		if s.UpdatedBy != "seed" && s.Origin == "seeded" {
+			s.Origin = "managed"
+		}
+	}
+	return nil
+}
+
 // --- seedHubSettingsIfNeeded tests ---
 
 func TestSeedHubSettingsIfNeeded_MetaSentinel(t *testing.T) {

--- a/cmd/server_foreground_seed_test.go
+++ b/cmd/server_foreground_seed_test.go
@@ -246,6 +246,83 @@ func TestSyncHubSettings_SkipsWriteOnEquality(t *testing.T) {
 	}
 }
 
+func TestSyncHubSettings_SkipsWriteOnSemanticEquality(t *testing.T) {
+	// Simulates Postgres jsonb behavior: the stored value has different
+	// whitespace/key ordering but is semantically identical.
+	fs := newFakeHubSettingStore()
+
+	k := koanf.New(".")
+	_ = k.Load(confmap.Provider(map[string]interface{}{
+		"server.hub.admin_emails":      []interface{}{"admin@test.com"},
+		"server.auth.user_access_mode": "open",
+	}, "."), nil)
+
+	// First sync — creates the rows.
+	err := syncHubSettings(context.Background(), fs, k)
+	if err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+
+	fs.mu.Lock()
+	accessRev := fs.settings["access"].Revision
+	// Simulate jsonb re-serialization: re-order keys and change whitespace.
+	origVal := fs.settings["access"].Value
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(origVal, &parsed); err != nil {
+		t.Fatalf("unmarshal stored value: %v", err)
+	}
+	// Re-marshal (Go map iteration is random, but we also add indentation
+	// to guarantee byte-level difference from compact json.Marshal output).
+	reordered, _ := json.MarshalIndent(parsed, "", "  ")
+	if string(reordered) == string(origVal) {
+		// Force a difference by adding whitespace.
+		reordered = json.RawMessage("  " + strings.TrimSpace(string(origVal)) + "  ")
+		// That won't unmarshal the same, so use a subtler approach:
+		reordered = json.RawMessage(`{ "user_access_mode" : "open" }`)
+	}
+	fs.settings["access"].Value = reordered
+	fs.mu.Unlock()
+
+	// Second sync — values are semantically equal despite byte differences.
+	err = syncHubSettings(context.Background(), fs, k)
+	if err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if fs.settings["access"].Revision != accessRev {
+		t.Errorf("semantic equality check failed: access revision bumped from %d to %d (jsonb re-serialization not handled)", accessRev, fs.settings["access"].Revision)
+	}
+}
+
+func TestJsonEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{"identical", `{"a":1}`, `{"a":1}`, true},
+		{"key reorder", `{"a":1,"b":2}`, `{"b":2,"a":1}`, true},
+		{"whitespace", `{"a": 1}`, `{"a":1}`, true},
+		{"different values", `{"a":1}`, `{"a":2}`, false},
+		{"extra key", `{"a":1}`, `{"a":1,"b":2}`, false},
+		{"empty objects", `{}`, `{}`, true},
+		{"nested equal", `{"a":{"b":1}}`, `{"a":{"b":1}}`, true},
+		{"nested different", `{"a":{"b":1}}`, `{"a":{"b":2}}`, false},
+		{"arrays equal", `[1,2,3]`, `[1,2,3]`, true},
+		{"arrays differ order", `[1,2,3]`, `[3,2,1]`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := jsonEqual(json.RawMessage(tt.a), json.RawMessage(tt.b))
+			if got != tt.want {
+				t.Errorf("jsonEqual(%s, %s) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSyncHubSettings_MaintenanceSkipped(t *testing.T) {
 	fs := newFakeHubSettingStore()
 

--- a/cmd/server_foreground_seed_test.go
+++ b/cmd/server_foreground_seed_test.go
@@ -276,7 +276,6 @@ func TestSyncHubSettings_SkipsWriteOnSemanticEquality(t *testing.T) {
 	reordered, _ := json.MarshalIndent(parsed, "", "  ")
 	if string(reordered) == string(origVal) {
 		// Force a difference by adding whitespace.
-		reordered = json.RawMessage("  " + strings.TrimSpace(string(origVal)) + "  ")
 		// That won't unmarshal the same, so use a subtler approach:
 		reordered = json.RawMessage(`{ "user_access_mode" : "open" }`)
 	}

--- a/docs-site/src/content/docs/reference/admin-settings.md
+++ b/docs-site/src/content/docs/reference/admin-settings.md
@@ -1,0 +1,180 @@
+---
+title: Admin Settings Model
+description: How Scion manages operational settings in database (postgres) mode, including the seeded/managed lifecycle, environment variable namespaces, and the admin UI.
+---
+
+This document describes how Scion manages operational settings when running with a postgres database, including the configuration precedence model, the seeded/managed lifecycle, and the admin settings UI.
+
+## Configuration Precedence
+
+Scion resolves configuration values using a layered merge:
+
+```
+coded defaults → SCION_SEED_* → settings.yaml → SCION_SERVER_*
+```
+
+Each layer overrides the one before it. The final merged result is the **bootstrap configuration** — the starting point for a hub instance.
+
+### Layer-0 vs Layer-1 Keys
+
+Settings are classified into two layers:
+
+| Layer | Examples | Behavior |
+|-------|----------|----------|
+| **Layer-0** (bootstrap) | `server.mode`, `server.database.*`, `server.storage.*`, `server.secrets.*`, `server.hub.port`, `server.auth.dev_mode` | Always resolved from bootstrap configuration. Cannot be changed via the admin UI in database mode. |
+| **Layer-1** (operational) | `server.hub.admin_emails`, `server.auth.user_access_mode`, `telemetry.*`, `agent_defaults.*`, `server.github_app.*`, `server.notification_channels` | In database mode, stored in the database and editable via the admin UI. Bootstrap values serve as initial defaults. |
+
+### Database Mode
+
+In database (postgres) mode, Layer-1 settings follow this resolution:
+
+```
+Database value > Bootstrap merge (for Layer-1 keys)
+Bootstrap only (for Layer-0 keys)
+```
+
+The database always wins for Layer-1 keys. Bootstrap values are used as initial seeds and as fallback when no database row exists.
+
+### File Mode
+
+In file mode (sqlite / no postgres), all settings come from the bootstrap merge. The admin UI writes directly to `settings.yaml`.
+
+## Seeded/Managed Lifecycle
+
+Each settings section in the database has an **origin** that tracks whether it was populated by the system or edited by an admin.
+
+### Seeded Sections
+
+When a hub first boots with a postgres database, it populates the settings database from the bootstrap configuration. These sections are marked as **seeded** — they track the deployment configuration.
+
+Seeded sections:
+- Re-sync from bootstrap on every hub restart (if the deployment config changes, the database updates)
+- Show a caption in the admin UI: *"Tracking deployment configuration — will re-sync on restart until edited"*
+- Skip writes when the bootstrap value hasn't changed (no unnecessary revision bumps)
+
+### Managed Sections
+
+When an admin edits a setting in the UI and saves, the section becomes **managed**. Managed sections:
+- Are owned by the database — bootstrap changes no longer overwrite them
+- Show standard metadata in the admin UI (source, revision, last updated by/at)
+- Display superseded notices when the deployment config differs from the database value
+
+### Reset to Bootstrap
+
+A managed section can be reset to tracking mode via the "Reset to bootstrap" button in the admin UI. This:
+1. Deletes the database row for that section
+2. The section falls back to bootstrap values
+3. On next boot, the section is re-seeded from current deployment config
+
+:::note[Known Limitation]
+The "Reset to bootstrap" feature requires a backend endpoint that is not yet available. The UI is wired and ready — the endpoint will be added in a follow-up release.
+:::
+
+## Environment Variable Namespaces
+
+### `SCION_SEED_*` (New)
+
+Use `SCION_SEED_*` to provide initial/default values for operational settings. Seeds are overridable — admins can change them in the UI, and the database value takes precedence.
+
+Seeds re-sync on restart for sections that haven't been admin-edited (seeded sections). Once a section is managed, the seed value is superseded.
+
+**Mapping rules:**
+- `server.*` keys: `SCION_SEED_SERVER_` + uppercase snake_case suffix
+- Non-`server.*` keys: `SCION_SEED_` + uppercase snake_case suffix
+
+| Setting | Seed Environment Variable |
+|---------|--------------------------|
+| `server.hub.admin_emails` | `SCION_SEED_SERVER_HUB_ADMINEMAILS` |
+| `server.hub.public_url` | `SCION_SEED_SERVER_HUB_PUBLICURL` |
+| `server.auth.user_access_mode` | `SCION_SEED_SERVER_AUTH_USERACCESSMODE` |
+| `server.auth.authorized_domains` | `SCION_SEED_SERVER_AUTH_AUTHORIZEDDOMAINS` |
+| `server.hub.auto_suspend_stalled` | `SCION_SEED_SERVER_HUB_AUTOSUSPENDSTALLED` |
+| `server.hub.soft_delete_retain_files` | `SCION_SEED_SERVER_HUB_SOFTDELETERETAINFILES` |
+| `server.hub.image_registry` | `SCION_SEED_SERVER_HUB_IMAGEREGISTRY` |
+| `telemetry.enabled` | `SCION_SEED_TELEMETRY_ENABLED` |
+| `server.github_app.webhooks_enabled` | `SCION_SEED_SERVER_GITHUBAPP_WEBHOOKSENABLED` |
+
+### `SCION_SERVER_*` (Existing)
+
+`SCION_SERVER_*` remains the authoritative namespace for **Layer-0** (bootstrap) settings:
+
+| Setting | Environment Variable |
+|---------|---------------------|
+| `server.hub.port` | `SCION_SERVER_HUB_PORT` |
+| `server.hub.host` | `SCION_SERVER_HUB_HOST` |
+| `server.database.driver` | `SCION_SERVER_DATABASE_DRIVER` |
+| `server.database.url` | `SCION_SERVER_DATABASE_URL` |
+| `server.auth.dev_mode` | `SCION_SERVER_AUTH_DEVMODE` |
+| `server.secrets.backend` | `SCION_SERVER_SECRETS_BACKEND` |
+| `server.mode` | `SCION_SERVER_MODE` |
+| `server.log_level` | `SCION_SERVER_LOGLEVEL` |
+
+### `SCION_SERVER_*` Deprecation for Layer-1
+
+:::caution[Deprecation]
+Using `SCION_SERVER_*` for Layer-1 operational settings is **deprecated**. These variables still work during the transition period (they are treated as the top of the bootstrap merge), but a warning is logged on startup.
+
+**Migration:** Replace `SCION_SERVER_<KEY>` with `SCION_SEED_<KEY>` for any Layer-1 setting.
+
+Example:
+```diff
+- SCION_SERVER_HUB_ADMINEMAILS=admin@example.com
++ SCION_SEED_SERVER_HUB_ADMINEMAILS=admin@example.com
+```
+:::
+
+The deprecation notice also appears in the admin UI when deprecated variables are detected.
+
+## Maintenance Mode
+
+### Break-Glass Removal
+
+`SCION_SERVER_ADMIN_MODE` no longer forces maintenance mode on a per-node basis. In previous versions, setting this environment variable would override the database maintenance state on that specific node, creating inconsistency in HA deployments.
+
+Maintenance mode is now **cluster-consistent**:
+- Set via the admin API (`PUT /api/v1/admin/maintenance`)
+- Propagated to all replicas via the event system
+- Survives restarts (persisted in the database)
+- Cannot be overridden by per-node environment variables
+
+## HA Bootstrap Guidance
+
+For high-availability deployments with multiple hub replicas:
+
+1. **Initial setup:** Use `SCION_SEED_*` environment variables to configure operational settings across all replicas. All replicas share the same bootstrap configuration.
+
+2. **After first admin edit:** Once an admin edits a setting in the UI, the section becomes managed. The database value propagates to all replicas within ~2 seconds via the event system. No per-node env configuration is needed.
+
+3. **Updating seeds:** To change the default for a seeded (unedited) section, update the `SCION_SEED_*` variable and restart the replicas. The new value syncs to the database on boot.
+
+4. **Managed sections:** For sections that have been admin-edited, changing the `SCION_SEED_*` variable has no effect — the database value wins. A "superseded" notice in the admin UI shows which deployment values differ from the database.
+
+5. **Resetting:** To return a managed section to tracking mode, use "Reset to bootstrap" in the admin UI. The section reverts to the seed value and will track future seed changes.
+
+## Admin UI
+
+The admin settings page (`/admin/server-config`) is layer-aware:
+
+- **Database mode:** Layer-0 fields are read-only with a "Managed via deployment configuration" badge. Layer-1 fields are editable.
+- **File mode:** Fields pinned by `SCION_SERVER_*` environment variables are read-only with a "Set via environment variable" badge. Other fields are editable and write to `settings.yaml`.
+
+### Visual Indicators
+
+| Indicator | Meaning |
+|-----------|---------|
+| 🔒 *Managed via deployment configuration* | Layer-0 field in database mode — not editable |
+| 🔒 *Set via environment variable* | Field pinned by `SCION_SERVER_*` in file mode |
+| *Tracking deployment configuration* | Seeded section — re-syncs on restart |
+| ⓘ *Superseded by database value* | Deployment config differs from the admin-set value |
+| Deprecation banner | `SCION_SERVER_*` used for Layer-1 settings |
+
+### Error Handling
+
+The admin UI provides structured feedback on save:
+
+| Response | UI Treatment |
+|----------|-------------|
+| **200** | Success; shows ignored-keys notice if applicable |
+| **400** `validation_failed` | Inline per-section validation errors |
+| **409** `revision_conflict` | "Settings changed since you loaded this page" banner with Reload button |
+| **422** `layer0_rejected` | Safety-net notice (should not occur with layer-aware UI) |

--- a/docs-site/src/content/docs/reference/server-config.md
+++ b/docs-site/src/content/docs/reference/server-config.md
@@ -142,6 +142,10 @@ The `local` backend does not store secret values. Any attempt to create or updat
 
 ## Environment Variables
 
+:::tip[Database Mode]
+When running with a postgres database, operational settings (Layer-1) can be configured via `SCION_SEED_*` environment variables and managed in the admin UI. See the [Admin Settings Model](/reference/admin-settings/) for details on the seeded/managed lifecycle and the `SCION_SEED_*` namespace.
+:::
+
 All server settings can be overridden via environment variables using the `SCION_SERVER_` prefix and snake_case naming.
 
 **Examples:**

--- a/pkg/config/bootstrap_koanf_test.go
+++ b/pkg/config/bootstrap_koanf_test.go
@@ -274,6 +274,7 @@ server:
 	}
 }
 
+
 func indexOf(s string, c byte) int {
 	for i := 0; i < len(s); i++ {
 		if s[i] == c {

--- a/pkg/config/bootstrap_koanf_test.go
+++ b/pkg/config/bootstrap_koanf_test.go
@@ -1,0 +1,243 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadSeedEnvKoanf verifies that LoadSeedEnvKoanf loads SCION_SEED_*
+// environment variables and maps them using the same envKeyToConfigKey mapper
+// as LoadEnvKoanf (SCION_SERVER_*).
+func TestLoadSeedEnvKoanf(t *testing.T) {
+	// SCION_SEED_SERVER_HUB_ADMINEMAILS → strip prefix → SERVER_HUB_ADMINEMAILS
+	// → envKeyToConfigKey → server.hub.adminEmails
+	t.Setenv("SCION_SEED_SERVER_HUB_ADMINEMAILS", "seed@example.com")
+	t.Setenv("SCION_SEED_SERVER_AUTH_USERACCESSMODE", "invite")
+	t.Setenv("SCION_SEED_SERVER_HUB_PORT", "9999")
+
+	k := LoadSeedEnvKoanf()
+
+	if v := k.String("server.hub.adminEmails"); v != "seed@example.com" {
+		t.Errorf("expected server.hub.adminEmails = 'seed@example.com', got %q", v)
+	}
+	if v := k.String("server.auth.userAccessMode"); v != "invite" {
+		t.Errorf("expected server.auth.userAccessMode = 'invite', got %q", v)
+	}
+	if v := k.Int("server.hub.port"); v != 9999 {
+		t.Errorf("expected server.hub.port = 9999, got %d", v)
+	}
+}
+
+// TestLoadSeedEnvKoanf_PathMapping verifies that SCION_SEED_* uses the same
+// envKeyToConfigKey function as SCION_SERVER_*. The resulting koanf key paths
+// differ because SCION_SEED_ is a shorter prefix: after stripping, the remainder
+// includes "SERVER_" as a key segment.
+//
+// SCION_SERVER_HUB_PORT → strip prefix → HUB_PORT → hub.port
+// SCION_SEED_SERVER_HUB_PORT → strip prefix → SERVER_HUB_PORT → server.hub.port
+func TestLoadSeedEnvKoanf_PathMapping(t *testing.T) {
+	t.Setenv("SCION_SEED_SERVER_HUB_ADMINEMAILS", "seed-value")
+	t.Setenv("SCION_SERVER_HUB_ADMINEMAILS", "server-value")
+
+	seedK := LoadSeedEnvKoanf()
+	envK := LoadEnvKoanf()
+
+	if len(seedK.Keys()) == 0 {
+		t.Fatal("LoadSeedEnvKoanf returned no keys")
+	}
+	if len(envK.Keys()) == 0 {
+		t.Fatal("LoadEnvKoanf returned no keys")
+	}
+
+	// SEED maps to server.hub.adminEmails (SERVER_ is a key segment).
+	if !seedK.Exists("server.hub.adminEmails") {
+		t.Errorf("SCION_SEED_ did not map to server.hub.adminEmails; keys: %v", seedK.Keys())
+	}
+	// SERVER maps to hub.adminEmails (no server. prefix — SERVER is the prefix).
+	if !envK.Exists("hub.adminEmails") {
+		t.Errorf("SCION_SERVER_ did not map to hub.adminEmails; keys: %v", envK.Keys())
+	}
+
+	// Verify they map to DIFFERENT koanf keys (by design).
+	if seedK.String("server.hub.adminEmails") != "seed-value" {
+		t.Errorf("SEED value mismatch: got %q", seedK.String("server.hub.adminEmails"))
+	}
+	if envK.String("hub.adminEmails") != "server-value" {
+		t.Errorf("SERVER value mismatch: got %q", envK.String("hub.adminEmails"))
+	}
+}
+
+// TestLoadSeedEnvKoanf_Empty verifies that LoadSeedEnvKoanf returns an empty
+// koanf instance when no SCION_SEED_* vars are set.
+func TestLoadSeedEnvKoanf_Empty(t *testing.T) {
+	for _, e := range os.Environ() {
+		if len(e) > 11 && e[:11] == "SCION_SEED_" {
+			key := e[:indexOf(e, '=')]
+			t.Setenv(key, "")
+			os.Unsetenv(key)
+		}
+	}
+
+	k := LoadSeedEnvKoanf()
+	if len(k.Keys()) != 0 {
+		t.Errorf("expected no keys, got %v", k.Keys())
+	}
+}
+
+// TestLoadBootstrapKoanf_MergeOrder verifies the full merge order:
+//
+//	SCION_SEED_* → settings.yaml → SCION_SERVER_*
+//
+// Because SEED env keys map to "server.hub.port" (camelCase via envKeyToConfigKey)
+// while yaml loads as "server.hub.port" (snake_case in yaml maps to same path
+// for simple keys like "port"), we can test the SEED-vs-yaml precedence using
+// simple single-segment field names that have no camelCase ambiguity.
+//
+// SERVER env keys map to a different koanf namespace (no "server." prefix), so
+// they don't directly override yaml keys at the koanf level — they coexist.
+// This is by design: struct unmarshaling bridges the namespace difference in the
+// actual config consumer (loadGlobalConfigLegacy).
+func TestLoadBootstrapKoanf_MergeOrder(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	scionDir := filepath.Join(tmpDir, ".scion")
+	if err := os.MkdirAll(scionDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Use server.hub.port — both SEED env and yaml map to "server.hub.port".
+	// SEED: SCION_SEED_SERVER_HUB_PORT → server.hub.port
+	// yaml: server.hub.port → server.hub.port (identical koanf key)
+	settingsContent := `schema_version: "1"
+server:
+  hub:
+    port: 8080
+`
+	if err := os.WriteFile(filepath.Join(scionDir, "settings.yaml"), []byte(settingsContent), 0644); err != nil {
+		t.Fatalf("write settings.yaml: %v", err)
+	}
+
+	// Case 1: SEED + yaml → yaml wins (loaded after SEED).
+	t.Setenv("SCION_SEED_SERVER_HUB_PORT", "1111")
+
+	k := LoadBootstrapKoanf()
+	if v := k.Int("server.hub.port"); v != 8080 {
+		t.Errorf("yaml should override SEED: expected 8080, got %d", v)
+	}
+
+	// Case 2: Remove yaml → SEED wins.
+	os.Remove(filepath.Join(scionDir, "settings.yaml"))
+	k2 := LoadBootstrapKoanf()
+	if v := k2.Int("server.hub.port"); v != 1111 {
+		t.Errorf("without yaml, SEED should provide value: expected 1111, got %d", v)
+	}
+
+	// Case 3: SERVER env is in a different namespace (hub.port vs server.hub.port).
+	// Verify SERVER value exists at its own key path.
+	t.Setenv("SCION_SERVER_HUB_PORT", "3333")
+	k3 := LoadBootstrapKoanf()
+	if v := k3.Int("hub.port"); v != 3333 {
+		t.Errorf("SERVER env should set hub.port: expected 3333, got %d", v)
+	}
+	// SEED value should still be at its key.
+	if v := k3.Int("server.hub.port"); v != 1111 {
+		t.Errorf("SEED should still be at server.hub.port: expected 1111, got %d", v)
+	}
+}
+
+// TestLoadBootstrapKoanf_ServerOverridesYaml_SameKey verifies that SCION_SERVER_*
+// overrides yaml when both produce the same koanf key. This happens for keys
+// where yaml uses a flat structure matching the env mapper output.
+func TestLoadBootstrapKoanf_ServerOverridesYaml_SameKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	scionDir := filepath.Join(tmpDir, ".scion")
+	if err := os.MkdirAll(scionDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Use schema_version — loaded as-is from yaml and maps to "schema.version"
+	// from env. Not great either. Use a key that reliably matches.
+	//
+	// Actually, yaml "server.mode" and SCION_SERVER_MODE → "mode" are different.
+	// The simplest overlap is when yaml uses a nested key that, after koanf
+	// flattening, matches the env mapper output. For "server.hub.port":
+	// yaml → server.hub.port (from server.hub.port yaml path)
+	// SCION_SERVER_SERVER_HUB_PORT → strip → SERVER_HUB_PORT → server.hub.port
+	//
+	// So SCION_SERVER_SERVER_* (double SERVER) targets the server.* namespace.
+	settingsContent := `schema_version: "1"
+server:
+  hub:
+    port: 8080
+`
+	if err := os.WriteFile(filepath.Join(scionDir, "settings.yaml"), []byte(settingsContent), 0644); err != nil {
+		t.Fatalf("write settings.yaml: %v", err)
+	}
+
+	// SCION_SERVER_SERVER_HUB_PORT → strip SCION_SERVER_ → SERVER_HUB_PORT → server.hub.port
+	t.Setenv("SCION_SERVER_SERVER_HUB_PORT", "5555")
+
+	k := LoadBootstrapKoanf()
+	if v := k.Int("server.hub.port"); v != 5555 {
+		t.Errorf("SERVER env should override yaml at server.hub.port: expected 5555, got %d", v)
+	}
+}
+
+// TestLoadBootstrapKoanf_SeedBelowYaml verifies that yaml values override
+// SCION_SEED_* values when both target the same koanf key.
+func TestLoadBootstrapKoanf_SeedBelowYaml(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	scionDir := filepath.Join(tmpDir, ".scion")
+	if err := os.MkdirAll(scionDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// SEED env: SCION_SEED_SERVER_HUB_PORT → server.hub.port = 1111
+	// yaml: server.hub.port = 2222
+	// Expected: yaml wins (2222).
+	settingsContent := `schema_version: "1"
+server:
+  hub:
+    port: 2222
+`
+	if err := os.WriteFile(filepath.Join(scionDir, "settings.yaml"), []byte(settingsContent), 0644); err != nil {
+		t.Fatalf("write settings.yaml: %v", err)
+	}
+
+	t.Setenv("SCION_SEED_SERVER_HUB_PORT", "1111")
+
+	k := LoadBootstrapKoanf()
+
+	if v := k.Int("server.hub.port"); v != 2222 {
+		t.Errorf("yaml should override SEED: expected 2222, got %d", v)
+	}
+
+	// Verify SEED value is NOT present (yaml merged on top).
+	// Actually, koanf.Merge replaces keys, so server.hub.port should be 2222.
+}
+
+func indexOf(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/config/bootstrap_koanf_test.go
+++ b/pkg/config/bootstrap_koanf_test.go
@@ -21,35 +21,36 @@ import (
 )
 
 // TestLoadSeedEnvKoanf verifies that LoadSeedEnvKoanf loads SCION_SEED_*
-// environment variables and maps them using the same envKeyToConfigKey mapper
-// as LoadEnvKoanf (SCION_SERVER_*).
+// environment variables and maps them to snake_case koanf keys matching
+// the opsettings registry (not camelCase like LoadEnvKoanf).
 func TestLoadSeedEnvKoanf(t *testing.T) {
 	// SCION_SEED_SERVER_HUB_ADMINEMAILS → strip prefix → SERVER_HUB_ADMINEMAILS
-	// → envKeyToConfigKey → server.hub.adminEmails
+	// → envKeyToOpsettingsKey → server.hub.admin_emails (snake_case)
 	t.Setenv("SCION_SEED_SERVER_HUB_ADMINEMAILS", "seed@example.com")
 	t.Setenv("SCION_SEED_SERVER_AUTH_USERACCESSMODE", "invite")
 	t.Setenv("SCION_SEED_SERVER_HUB_PORT", "9999")
 
 	k := LoadSeedEnvKoanf()
 
-	if v := k.String("server.hub.adminEmails"); v != "seed@example.com" {
-		t.Errorf("expected server.hub.adminEmails = 'seed@example.com', got %q", v)
+	if v := k.String("server.hub.admin_emails"); v != "seed@example.com" {
+		t.Errorf("expected server.hub.admin_emails = 'seed@example.com', got %q", v)
 	}
-	if v := k.String("server.auth.userAccessMode"); v != "invite" {
-		t.Errorf("expected server.auth.userAccessMode = 'invite', got %q", v)
+	if v := k.String("server.auth.user_access_mode"); v != "invite" {
+		t.Errorf("expected server.auth.user_access_mode = 'invite', got %q", v)
 	}
 	if v := k.Int("server.hub.port"); v != 9999 {
 		t.Errorf("expected server.hub.port = 9999, got %d", v)
 	}
 }
 
-// TestLoadSeedEnvKoanf_PathMapping verifies that SCION_SEED_* uses the same
-// envKeyToConfigKey function as SCION_SERVER_*. The resulting koanf key paths
-// differ because SCION_SEED_ is a shorter prefix: after stripping, the remainder
-// includes "SERVER_" as a key segment.
+// TestLoadSeedEnvKoanf_PathMapping verifies that SCION_SEED_* uses the
+// snake_case envKeyToOpsettingsKey mapper (matching the opsettings registry),
+// while SCION_SERVER_* uses the camelCase envKeyToConfigKey mapper (matching
+// GlobalConfig struct tags). The resulting koanf key paths differ in both
+// prefix depth and casing convention.
 //
-// SCION_SERVER_HUB_PORT → strip prefix → HUB_PORT → hub.port
-// SCION_SEED_SERVER_HUB_PORT → strip prefix → SERVER_HUB_PORT → server.hub.port
+// SCION_SEED_SERVER_HUB_ADMINEMAILS → server.hub.admin_emails (snake_case)
+// SCION_SERVER_HUB_ADMINEMAILS      → hub.adminEmails          (camelCase)
 func TestLoadSeedEnvKoanf_PathMapping(t *testing.T) {
 	t.Setenv("SCION_SEED_SERVER_HUB_ADMINEMAILS", "seed-value")
 	t.Setenv("SCION_SERVER_HUB_ADMINEMAILS", "server-value")
@@ -64,18 +65,17 @@ func TestLoadSeedEnvKoanf_PathMapping(t *testing.T) {
 		t.Fatal("LoadEnvKoanf returned no keys")
 	}
 
-	// SEED maps to server.hub.adminEmails (SERVER_ is a key segment).
-	if !seedK.Exists("server.hub.adminEmails") {
-		t.Errorf("SCION_SEED_ did not map to server.hub.adminEmails; keys: %v", seedK.Keys())
+	// SEED maps to server.hub.admin_emails (snake_case, SERVER_ is a key segment).
+	if !seedK.Exists("server.hub.admin_emails") {
+		t.Errorf("SCION_SEED_ did not map to server.hub.admin_emails; keys: %v", seedK.Keys())
 	}
-	// SERVER maps to hub.adminEmails (no server. prefix — SERVER is the prefix).
+	// SERVER maps to hub.adminEmails (camelCase, no server. prefix).
 	if !envK.Exists("hub.adminEmails") {
 		t.Errorf("SCION_SERVER_ did not map to hub.adminEmails; keys: %v", envK.Keys())
 	}
 
-	// Verify they map to DIFFERENT koanf keys (by design).
-	if seedK.String("server.hub.adminEmails") != "seed-value" {
-		t.Errorf("SEED value mismatch: got %q", seedK.String("server.hub.adminEmails"))
+	if seedK.String("server.hub.admin_emails") != "seed-value" {
+		t.Errorf("SEED value mismatch: got %q", seedK.String("server.hub.admin_emails"))
 	}
 	if envK.String("hub.adminEmails") != "server-value" {
 		t.Errorf("SERVER value mismatch: got %q", envK.String("hub.adminEmails"))
@@ -101,17 +101,15 @@ func TestLoadSeedEnvKoanf_Empty(t *testing.T) {
 
 // TestLoadBootstrapKoanf_MergeOrder verifies the full merge order:
 //
-//	SCION_SEED_* → settings.yaml → SCION_SERVER_*
+//	coded defaults → SCION_SEED_* → settings.yaml → SCION_SERVER_*
 //
-// Because SEED env keys map to "server.hub.port" (camelCase via envKeyToConfigKey)
-// while yaml loads as "server.hub.port" (snake_case in yaml maps to same path
-// for simple keys like "port"), we can test the SEED-vs-yaml precedence using
-// simple single-segment field names that have no camelCase ambiguity.
+// All layers produce snake_case koanf keys via envKeyToOpsettingsKey, matching
+// the opsettings registry. SEED and yaml both map to "server.hub.port", so we
+// can test their precedence directly.
 //
-// SERVER env keys map to a different koanf namespace (no "server." prefix), so
-// they don't directly override yaml keys at the koanf level — they coexist.
-// This is by design: struct unmarshaling bridges the namespace difference in the
-// actual config consumer (loadGlobalConfigLegacy).
+// SERVER env keys (in bootstrap context) also use the snake_case mapper, but
+// map to a different koanf namespace (no "server." prefix), so they coexist
+// with yaml keys rather than overriding them directly.
 func TestLoadBootstrapKoanf_MergeOrder(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
@@ -161,8 +159,10 @@ server:
 }
 
 // TestLoadBootstrapKoanf_ServerOverridesYaml_SameKey verifies that SCION_SERVER_*
-// overrides yaml when both produce the same koanf key. This happens for keys
-// where yaml uses a flat structure matching the env mapper output.
+// overrides yaml when both produce the same koanf key. To target the
+// "server.hub.port" koanf key from SCION_SERVER_*, the env var must be
+// SCION_SERVER_SERVER_HUB_PORT (the first SERVER is the env prefix, the
+// second is the "server." key segment).
 func TestLoadBootstrapKoanf_ServerOverridesYaml_SameKey(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
@@ -171,16 +171,6 @@ func TestLoadBootstrapKoanf_ServerOverridesYaml_SameKey(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 
-	// Use schema_version — loaded as-is from yaml and maps to "schema.version"
-	// from env. Not great either. Use a key that reliably matches.
-	//
-	// Actually, yaml "server.mode" and SCION_SERVER_MODE → "mode" are different.
-	// The simplest overlap is when yaml uses a nested key that, after koanf
-	// flattening, matches the env mapper output. For "server.hub.port":
-	// yaml → server.hub.port (from server.hub.port yaml path)
-	// SCION_SERVER_SERVER_HUB_PORT → strip → SERVER_HUB_PORT → server.hub.port
-	//
-	// So SCION_SERVER_SERVER_* (double SERVER) targets the server.* namespace.
 	settingsContent := `schema_version: "1"
 server:
   hub:
@@ -190,7 +180,8 @@ server:
 		t.Fatalf("write settings.yaml: %v", err)
 	}
 
-	// SCION_SERVER_SERVER_HUB_PORT → strip SCION_SERVER_ → SERVER_HUB_PORT → server.hub.port
+	// SCION_SERVER_SERVER_HUB_PORT → strip SCION_SERVER_ → SERVER_HUB_PORT
+	// → envKeyToOpsettingsKey → server.hub.port
 	t.Setenv("SCION_SERVER_SERVER_HUB_PORT", "5555")
 
 	k := LoadBootstrapKoanf()
@@ -231,6 +222,56 @@ server:
 
 	// Verify SEED value is NOT present (yaml merged on top).
 	// Actually, koanf.Merge replaces keys, so server.hub.port should be 2222.
+}
+
+// TestLoadBootstrapKoanf_CompoundWordKey verifies that compound-word fields
+// (e.g. admin_emails) from SEED env, yaml, and SERVER env all merge into the
+// same snake_case koanf key, proving that ExtractSectionFromKoanf will find
+// values from any layer. This is the test that would have caught the original
+// camelCase/snake_case mismatch (review finding #1, #5).
+func TestLoadBootstrapKoanf_CompoundWordKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	scionDir := filepath.Join(tmpDir, ".scion")
+	if err := os.MkdirAll(scionDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Case 1: SEED env sets admin_emails, yaml overrides it.
+	t.Setenv("SCION_SEED_SERVER_HUB_ADMINEMAILS", "seed@example.com")
+	settingsContent := `schema_version: "1"
+server:
+  hub:
+    admin_emails:
+      - "yaml@example.com"
+`
+	if err := os.WriteFile(filepath.Join(scionDir, "settings.yaml"), []byte(settingsContent), 0644); err != nil {
+		t.Fatalf("write settings.yaml: %v", err)
+	}
+
+	k := LoadBootstrapKoanf()
+
+	// yaml wins over SEED — both target server.hub.admin_emails (snake_case).
+	emails := k.Strings("server.hub.admin_emails")
+	if len(emails) != 1 || emails[0] != "yaml@example.com" {
+		t.Errorf("yaml should override SEED for admin_emails: expected [yaml@example.com], got %v", emails)
+	}
+
+	// Case 2: SERVER env overrides yaml for same compound-word key.
+	// SCION_SERVER_SERVER_HUB_ADMINEMAILS → server.hub.admin_emails
+	// Note: env provider loads as a string, not a slice, so use String() accessor.
+	t.Setenv("SCION_SERVER_SERVER_HUB_ADMINEMAILS", "server@example.com")
+	k2 := LoadBootstrapKoanf()
+
+	serverVal := k2.String("server.hub.admin_emails")
+	if serverVal != "server@example.com" {
+		t.Errorf("SERVER env should override yaml for admin_emails: expected 'server@example.com', got %q", serverVal)
+	}
+
+	// Case 3: Verify the camelCase key does NOT exist (proving no namespace split).
+	if k2.Exists("server.hub.adminEmails") {
+		t.Error("camelCase key server.hub.adminEmails should not exist — bootstrap uses snake_case")
+	}
 }
 
 func indexOf(s string, c byte) int {

--- a/pkg/config/bootstrap_koanf_test.go
+++ b/pkg/config/bootstrap_koanf_test.go
@@ -127,7 +127,7 @@ func TestLoadSeedEnvKoanf_Empty(t *testing.T) {
 		if len(e) > 11 && e[:11] == "SCION_SEED_" {
 			key := e[:indexOf(e, '=')]
 			t.Setenv(key, "")
-			os.Unsetenv(key)
+			_ = os.Unsetenv(key)
 		}
 	}
 
@@ -169,7 +169,7 @@ server:
 	}
 
 	// Case 2: Remove yaml → SEED wins.
-	os.Remove(filepath.Join(scionDir, "settings.yaml"))
+	_ = os.Remove(filepath.Join(scionDir, "settings.yaml"))
 	k2 := LoadBootstrapKoanf()
 	if v := k2.Int("server.hub.port"); v != 1111 {
 		t.Errorf("without yaml, SEED should provide value: expected 1111, got %d", v)

--- a/pkg/config/bootstrap_koanf_test.go
+++ b/pkg/config/bootstrap_koanf_test.go
@@ -43,42 +43,80 @@ func TestLoadSeedEnvKoanf(t *testing.T) {
 	}
 }
 
-// TestLoadSeedEnvKoanf_PathMapping verifies that SCION_SEED_* uses the
-// snake_case envKeyToOpsettingsKey mapper (matching the opsettings registry),
-// while SCION_SERVER_* uses the camelCase envKeyToConfigKey mapper (matching
-// GlobalConfig struct tags). The resulting koanf key paths differ in both
-// prefix depth and casing convention.
-//
-// SCION_SEED_SERVER_HUB_ADMINEMAILS → server.hub.admin_emails (snake_case)
-// SCION_SERVER_HUB_ADMINEMAILS      → hub.adminEmails          (camelCase)
-func TestLoadSeedEnvKoanf_PathMapping(t *testing.T) {
-	t.Setenv("SCION_SEED_SERVER_HUB_ADMINEMAILS", "seed-value")
-	t.Setenv("SCION_SERVER_HUB_ADMINEMAILS", "server-value")
+// TestLoadEnvKoanf_OpsettingsKeyspace verifies that LoadEnvKoanf maps
+// SCION_SERVER_* env vars to the opsettings registry keyspace (snake_case
+// with server.* prefix for server sub-keys).
+func TestLoadEnvKoanf_OpsettingsKeyspace(t *testing.T) {
+	t.Setenv("SCION_SERVER_HUB_ADMINEMAILS", "admin@test.com")
+	t.Setenv("SCION_SERVER_AUTH_USERACCESSMODE", "open")
 
-	seedK := LoadSeedEnvKoanf()
-	envK := LoadEnvKoanf()
+	k := LoadEnvKoanf()
 
-	if len(seedK.Keys()) == 0 {
-		t.Fatal("LoadSeedEnvKoanf returned no keys")
+	// Should produce server.hub.admin_emails (not hub.adminEmails).
+	if !k.Exists("server.hub.admin_emails") {
+		t.Errorf("SCION_SERVER_HUB_ADMINEMAILS should map to server.hub.admin_emails; keys: %v", k.Keys())
 	}
-	if len(envK.Keys()) == 0 {
-		t.Fatal("LoadEnvKoanf returned no keys")
+	if !k.Exists("server.auth.user_access_mode") {
+		t.Errorf("SCION_SERVER_AUTH_USERACCESSMODE should map to server.auth.user_access_mode; keys: %v", k.Keys())
 	}
 
-	// SEED maps to server.hub.admin_emails (snake_case, SERVER_ is a key segment).
-	if !seedK.Exists("server.hub.admin_emails") {
-		t.Errorf("SCION_SEED_ did not map to server.hub.admin_emails; keys: %v", seedK.Keys())
+	// camelCase key should NOT exist.
+	if k.Exists("hub.adminEmails") {
+		t.Error("camelCase key hub.adminEmails should not exist")
 	}
-	// SERVER maps to hub.adminEmails (camelCase, no server. prefix).
-	if !envK.Exists("hub.adminEmails") {
-		t.Errorf("SCION_SERVER_ did not map to hub.adminEmails; keys: %v", envK.Keys())
-	}
+}
 
-	if seedK.String("server.hub.admin_emails") != "seed-value" {
-		t.Errorf("SEED value mismatch: got %q", seedK.String("server.hub.admin_emails"))
+// TestLoadEnvKoanf_NonServerKeys verifies that non-server keys (telemetry,
+// default_*) do not get the server.* prefix.
+func TestLoadEnvKoanf_NonServerKeys(t *testing.T) {
+	t.Setenv("SCION_SERVER_TELEMETRY_ENABLED", "true")
+	t.Setenv("SCION_SERVER_DEFAULTTEMPLATE", "my-template")
+
+	k := LoadEnvKoanf()
+
+	if !k.Exists("telemetry.enabled") {
+		t.Errorf("SCION_SERVER_TELEMETRY_ENABLED should map to telemetry.enabled; keys: %v", k.Keys())
 	}
-	if envK.String("hub.adminEmails") != "server-value" {
-		t.Errorf("SERVER value mismatch: got %q", envK.String("hub.adminEmails"))
+	if k.Exists("server.telemetry.enabled") {
+		t.Error("telemetry.enabled should NOT have server. prefix")
+	}
+	if !k.Exists("default_template") {
+		t.Errorf("SCION_SERVER_DEFAULTTEMPLATE should map to default_template; keys: %v", k.Keys())
+	}
+}
+
+// TestServerEnvToOpsettingsKey verifies the mapper that re-adds "server."
+// prefix for keys belonging to V1ServerConfig.
+func TestServerEnvToOpsettingsKey(t *testing.T) {
+	tests := []struct {
+		envKey string
+		want   string
+	}{
+		// Server sub-keys get server.* prefix.
+		{"HUB_ADMINEMAILS", "server.hub.admin_emails"},
+		{"HUB_PORT", "server.hub.port"},
+		{"AUTH_USERACCESSMODE", "server.auth.user_access_mode"},
+		{"DATABASE_DRIVER", "server.database.driver"},
+		{"GITHUBAPP_APPID", "server.github_app.app_id"},
+		{"LOGLEVEL", "server.log_level"},
+		{"LOGFORMAT", "server.log_format"},
+		{"NOTIFICATIONCHANNELS", "server.notification_channels"},
+		{"STORAGE_PROVIDER", "server.storage.provider"},
+		{"SECRETS_BACKEND", "server.secrets.backend"},
+		{"OAUTH_CLI_GOOGLE_CLIENTID", "server.oauth.cli.google.clientid"},
+		// Non-server keys pass through unchanged.
+		{"TELEMETRY_ENABLED", "telemetry.enabled"},
+		{"DEFAULTTEMPLATE", "default_template"},
+		{"DEFAULTMAXTURNS", "default_max_turns"},
+		{"IMAGEREGISTRY", "image_registry"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.envKey, func(t *testing.T) {
+			got := serverEnvToOpsettingsKey(tt.envKey)
+			if got != tt.want {
+				t.Errorf("serverEnvToOpsettingsKey(%q) = %q, want %q", tt.envKey, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -103,13 +141,7 @@ func TestLoadSeedEnvKoanf_Empty(t *testing.T) {
 //
 //	coded defaults → SCION_SEED_* → settings.yaml → SCION_SERVER_*
 //
-// All layers produce snake_case koanf keys via envKeyToOpsettingsKey, matching
-// the opsettings registry. SEED and yaml both map to "server.hub.port", so we
-// can test their precedence directly.
-//
-// SERVER env keys (in bootstrap context) also use the snake_case mapper, but
-// map to a different koanf namespace (no "server." prefix), so they coexist
-// with yaml keys rather than overriding them directly.
+// All layers produce snake_case koanf keys in the opsettings keyspace.
 func TestLoadBootstrapKoanf_MergeOrder(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
@@ -119,8 +151,6 @@ func TestLoadBootstrapKoanf_MergeOrder(t *testing.T) {
 	}
 
 	// Use server.hub.port — both SEED env and yaml map to "server.hub.port".
-	// SEED: SCION_SEED_SERVER_HUB_PORT → server.hub.port
-	// yaml: server.hub.port → server.hub.port (identical koanf key)
 	settingsContent := `schema_version: "1"
 server:
   hub:
@@ -145,25 +175,18 @@ server:
 		t.Errorf("without yaml, SEED should provide value: expected 1111, got %d", v)
 	}
 
-	// Case 3: SERVER env is in a different namespace (hub.port vs server.hub.port).
-	// Verify SERVER value exists at its own key path.
+	// Case 3: SERVER env overrides SEED — both map to server.hub.port.
 	t.Setenv("SCION_SERVER_HUB_PORT", "3333")
 	k3 := LoadBootstrapKoanf()
-	if v := k3.Int("hub.port"); v != 3333 {
-		t.Errorf("SERVER env should set hub.port: expected 3333, got %d", v)
-	}
-	// SEED value should still be at its key.
-	if v := k3.Int("server.hub.port"); v != 1111 {
-		t.Errorf("SEED should still be at server.hub.port: expected 1111, got %d", v)
+	if v := k3.Int("server.hub.port"); v != 3333 {
+		t.Errorf("SERVER env should override SEED at server.hub.port: expected 3333, got %d", v)
 	}
 }
 
-// TestLoadBootstrapKoanf_ServerOverridesYaml_SameKey verifies that SCION_SERVER_*
-// overrides yaml when both produce the same koanf key. To target the
-// "server.hub.port" koanf key from SCION_SERVER_*, the env var must be
-// SCION_SERVER_SERVER_HUB_PORT (the first SERVER is the env prefix, the
-// second is the "server." key segment).
-func TestLoadBootstrapKoanf_ServerOverridesYaml_SameKey(t *testing.T) {
+// TestLoadBootstrapKoanf_ServerOverridesYaml verifies that SCION_SERVER_*
+// overrides yaml when both target the same koanf key. SCION_SERVER_HUB_PORT
+// maps directly to server.hub.port (no need for double-SERVER).
+func TestLoadBootstrapKoanf_ServerOverridesYaml(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 	scionDir := filepath.Join(tmpDir, ".scion")
@@ -180,9 +203,7 @@ server:
 		t.Fatalf("write settings.yaml: %v", err)
 	}
 
-	// SCION_SERVER_SERVER_HUB_PORT → strip SCION_SERVER_ → SERVER_HUB_PORT
-	// → envKeyToOpsettingsKey → server.hub.port
-	t.Setenv("SCION_SERVER_SERVER_HUB_PORT", "5555")
+	t.Setenv("SCION_SERVER_HUB_PORT", "5555")
 
 	k := LoadBootstrapKoanf()
 	if v := k.Int("server.hub.port"); v != 5555 {
@@ -200,9 +221,6 @@ func TestLoadBootstrapKoanf_SeedBelowYaml(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 
-	// SEED env: SCION_SEED_SERVER_HUB_PORT → server.hub.port = 1111
-	// yaml: server.hub.port = 2222
-	// Expected: yaml wins (2222).
 	settingsContent := `schema_version: "1"
 server:
   hub:
@@ -219,16 +237,12 @@ server:
 	if v := k.Int("server.hub.port"); v != 2222 {
 		t.Errorf("yaml should override SEED: expected 2222, got %d", v)
 	}
-
-	// Verify SEED value is NOT present (yaml merged on top).
-	// Actually, koanf.Merge replaces keys, so server.hub.port should be 2222.
 }
 
 // TestLoadBootstrapKoanf_CompoundWordKey verifies that compound-word fields
 // (e.g. admin_emails) from SEED env, yaml, and SERVER env all merge into the
 // same snake_case koanf key, proving that ExtractSectionFromKoanf will find
-// values from any layer. This is the test that would have caught the original
-// camelCase/snake_case mismatch (review finding #1, #5).
+// values from any layer.
 func TestLoadBootstrapKoanf_CompoundWordKey(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
@@ -258,9 +272,8 @@ server:
 	}
 
 	// Case 2: SERVER env overrides yaml for same compound-word key.
-	// SCION_SERVER_SERVER_HUB_ADMINEMAILS → server.hub.admin_emails
-	// Note: env provider loads as a string, not a slice, so use String() accessor.
-	t.Setenv("SCION_SERVER_SERVER_HUB_ADMINEMAILS", "server@example.com")
+	// SCION_SERVER_HUB_ADMINEMAILS maps directly to server.hub.admin_emails.
+	t.Setenv("SCION_SERVER_HUB_ADMINEMAILS", "server@example.com")
 	k2 := LoadBootstrapKoanf()
 
 	serverVal := k2.String("server.hub.admin_emails")
@@ -274,6 +287,53 @@ server:
 	}
 }
 
+// TestLoadBootstrapKoanf_NonServerEnv verifies that SCION_SERVER_* env vars
+// for non-server keys (telemetry, defaults) map correctly without server.* prefix.
+func TestLoadBootstrapKoanf_NonServerEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".scion"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	t.Setenv("SCION_SERVER_TELEMETRY_ENABLED", "true")
+	t.Setenv("SCION_SERVER_DEFAULTTEMPLATE", "my-template")
+
+	k := LoadBootstrapKoanf()
+
+	if !k.Exists("telemetry.enabled") {
+		t.Errorf("expected telemetry.enabled to exist; keys: %v", k.Keys())
+	}
+	if k.Exists("server.telemetry.enabled") {
+		t.Error("telemetry.enabled should NOT have server. prefix")
+	}
+	if !k.Exists("default_template") {
+		t.Errorf("expected default_template to exist; keys: %v", k.Keys())
+	}
+}
+
+// TestLoadBootstrapKoanf_CommaSplit verifies that comma-separated list values
+// from env vars are split into slices.
+func TestLoadBootstrapKoanf_CommaSplit(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".scion"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	t.Setenv("SCION_SERVER_HUB_ADMINEMAILS", "a@test.com,b@test.com,c@test.com")
+
+	k := LoadBootstrapKoanf()
+
+	val := k.Get("server.hub.admin_emails")
+	slice, ok := val.([]interface{})
+	if !ok {
+		t.Fatalf("expected server.hub.admin_emails to be a slice, got %T: %v", val, val)
+	}
+	if len(slice) != 3 {
+		t.Errorf("expected 3 elements, got %d: %v", len(slice), slice)
+	}
+}
 
 func indexOf(s string, c byte) int {
 	for i := 0; i < len(s); i++ {

--- a/pkg/config/bootstrap_koanf_test.go
+++ b/pkg/config/bootstrap_koanf_test.go
@@ -273,12 +273,17 @@ server:
 
 	// Case 2: SERVER env overrides yaml for same compound-word key.
 	// SCION_SERVER_HUB_ADMINEMAILS maps directly to server.hub.admin_emails.
+	// After splitCommaSeparatedKoanfKeys, even a single value is wrapped as a slice.
 	t.Setenv("SCION_SERVER_HUB_ADMINEMAILS", "server@example.com")
 	k2 := LoadBootstrapKoanf()
 
-	serverVal := k2.String("server.hub.admin_emails")
-	if serverVal != "server@example.com" {
-		t.Errorf("SERVER env should override yaml for admin_emails: expected 'server@example.com', got %q", serverVal)
+	serverVal := k2.Get("server.hub.admin_emails")
+	serverSlice, ok := serverVal.([]interface{})
+	if !ok {
+		t.Fatalf("SERVER env admin_emails should be []interface{}, got %T: %v", serverVal, serverVal)
+	}
+	if len(serverSlice) != 1 || serverSlice[0] != "server@example.com" {
+		t.Errorf("SERVER env should override yaml for admin_emails: expected [server@example.com], got %v", serverSlice)
 	}
 
 	// Case 3: Verify the camelCase key does NOT exist (proving no namespace split).
@@ -332,6 +337,34 @@ func TestLoadBootstrapKoanf_CommaSplit(t *testing.T) {
 	}
 	if len(slice) != 3 {
 		t.Errorf("expected 3 elements, got %d: %v", len(slice), slice)
+	}
+}
+
+// TestLoadBootstrapKoanf_SingleValueListEnv verifies that a single-value
+// (no comma) env var for a known list field produces an array, not a string.
+func TestLoadBootstrapKoanf_SingleValueListEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".scion"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	t.Setenv("SCION_SEED_SERVER_HUB_ADMINEMAILS", "single@example.com")
+
+	k := LoadBootstrapKoanf()
+
+	val := k.Get("server.hub.admin_emails")
+	slice, ok := val.([]interface{})
+	if !ok {
+		t.Fatalf("expected server.hub.admin_emails to be []interface{}, got %T: %v", val, val)
+	}
+	if len(slice) != 1 {
+		t.Errorf("expected 1 element, got %d: %v", len(slice), slice)
+	}
+	if len(slice) > 0 {
+		if s, ok := slice[0].(string); !ok || s != "single@example.com" {
+			t.Errorf("expected slice[0] = 'single@example.com', got %v", slice[0])
+		}
 	}
 }
 

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -838,6 +838,58 @@ func LoadEnvKoanf() *koanf.Koanf {
 	return k
 }
 
+// LoadSeedEnvKoanf returns a koanf instance loaded with only the SCION_SEED_*
+// environment variables (no file, no defaults). Uses the same envKeyToConfigKey
+// mapper as LoadEnvKoanf, producing identical key paths after the prefix.
+// e.g. SCION_SEED_SERVER_HUB_ADMINEMAILS → server.hub.adminEmails
+func LoadSeedEnvKoanf() *koanf.Koanf {
+	k := koanf.New(".")
+	_ = k.Load(env.Provider("SCION_SEED_", ".", func(s string) string {
+		key := strings.TrimPrefix(s, "SCION_SEED_")
+		return envKeyToConfigKey(key)
+	}), nil)
+	return k
+}
+
+// LoadBootstrapKoanf computes the full bootstrap merge:
+//
+//	coded defaults → SCION_SEED_* → settings.yaml → SCION_SERVER_*
+//
+// This produces the canonical "bootstrap material" used for seeding and
+// fallback. Each layer merges on top of the previous one, so SCION_SERVER_*
+// wins over yaml, yaml wins over SCION_SEED_*, and SCION_SEED_* wins over
+// coded defaults.
+func LoadBootstrapKoanf() *koanf.Koanf {
+	k := koanf.New(".")
+
+	// 1. Coded defaults (same as LoadFileOnlyKoanf uses — settings.yaml
+	//    contains the canonical defaults via embedded YAML).
+	// LoadFileOnlyKoanf already loads settings.yaml + legacy server.yaml,
+	// but we need finer-grained layering, so we build it step by step.
+
+	// 2. SCION_SEED_* environment variables.
+	seedK := LoadSeedEnvKoanf()
+	_ = k.Merge(seedK)
+
+	// 3. settings.yaml (+ legacy server.yaml).
+	globalDir, err := GetGlobalDir()
+	if err != nil {
+		slog.Warn("LoadBootstrapKoanf: failed to resolve global settings directory", "error", err)
+	}
+	if globalDir != "" {
+		if err := loadSettingsFile(k, globalDir); err != nil {
+			slog.Warn("LoadBootstrapKoanf: failed to load settings file", "dir", globalDir, "error", err)
+		}
+		loadServerConfigFile(k, globalDir)
+	}
+
+	// 4. SCION_SERVER_* environment variables (highest precedence in bootstrap).
+	envK := LoadEnvKoanf()
+	_ = k.Merge(envK)
+
+	return k
+}
+
 // applyEnvOverrides loads SCION_SERVER_ environment variables and merges them
 // into an existing GlobalConfig. This ensures env vars override config file
 // values regardless of which config loading path was used (settings.yaml or

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -729,6 +729,57 @@ func parseCommaSeparatedList(s string) []string {
 	return result
 }
 
+// snakeCaseFields maps flat-lowercased env segments to their snake_case
+// equivalents used by the opsettings registry and settings.yaml. This is
+// the counterpart to camelCaseFields: where camelCaseFields produces keys for
+// Go struct unmarshaling (adminEmails), snakeCaseFields produces keys that
+// match the opsettings keyspace (admin_emails).
+var snakeCaseFields = map[string]string{
+	// Layer-1 compound segments (from opsettings registry)
+	"adminemails":           "admin_emails",
+	"apibaseurl":            "api_base_url",
+	"appid":                 "app_id",
+	"authorizeddomains":     "authorized_domains",
+	"autosuspendstalled":    "auto_suspend_stalled",
+	"cafile":                "ca_file",
+	"defaultharnessconfig":  "default_harness_config",
+	"defaultmaxduration":    "default_max_duration",
+	"defaultmaxmodelcalls":  "default_max_model_calls",
+	"defaultmaxturns":       "default_max_turns",
+	"defaultresources":      "default_resources",
+	"defaulttemplate":       "default_template",
+	"githubapp":             "github_app",
+	"hubname":               "hub_name",
+	"imageregistry":         "image_registry",
+	"insecureskipverify":    "insecure_skip_verify",
+	"installationurl":       "installation_url",
+	"maxsize":               "max_size",
+	"notificationchannels":  "notification_channels",
+	"privatekeypath":        "private_key_path",
+	"publicurl":             "public_url",
+	"reportinterval":        "report_interval",
+	"respectdebugmode":      "respect_debug_mode",
+	"softdeleteretainfiles": "soft_delete_retain_files",
+	"softdeleteretention":   "soft_delete_retention",
+	"useraccessmode":        "user_access_mode",
+	"webhooksenabled":       "webhooks_enabled",
+	// Layer-0 compound segments (from layer0Prefixes)
+	"adminmode":        "admin_mode",
+	"devmode":          "dev_mode",
+	"devtoken":         "dev_token",
+	"devtokenfile":     "dev_token_file",
+	"gcpprojectid":     "gcp_project_id",
+	"hubid":            "hub_id",
+	"logformat":        "log_format",
+	"loglevel":         "log_level",
+	"messagebroker":    "message_broker",
+	"readtimeout":      "read_timeout",
+	"workspacestorage": "workspace_storage",
+	"writetimeout":     "write_timeout",
+	// Maintenance (runtime-only, no yaml, but env detection still needs it)
+	"maintenancemessage": "maintenance_message",
+}
+
 // camelCaseFields maps lowercased environment variable key segments to their
 // camelCase config equivalents. Package-level to avoid re-allocation per call.
 var camelCaseFields = map[string]string{
@@ -797,6 +848,20 @@ func envKeyToConfigKey(envKey string) string {
 	return strings.Join(parts, ".")
 }
 
+// envKeyToOpsettingsKey converts an env var key (after prefix stripping) to a
+// koanf key using snake_case segments that match the opsettings registry and
+// settings.yaml. This is the snake_case counterpart to envKeyToConfigKey.
+// Example: SERVER_HUB_ADMINEMAILS → server.hub.admin_emails
+func envKeyToOpsettingsKey(envKey string) string {
+	parts := strings.Split(strings.ToLower(envKey), "_")
+	for i, part := range parts {
+		if replacement, ok := snakeCaseFields[part]; ok {
+			parts[i] = replacement
+		}
+	}
+	return strings.Join(parts, ".")
+}
+
 // LoadFileOnlyKoanf returns a koanf instance loaded from settings.yaml +
 // embedded defaults, without any environment variable overlay. This produces
 // the "file fallback" Layer for OperationalSettings (settings-db §3.4/§3.9):
@@ -839,14 +904,14 @@ func LoadEnvKoanf() *koanf.Koanf {
 }
 
 // LoadSeedEnvKoanf returns a koanf instance loaded with only the SCION_SEED_*
-// environment variables (no file, no defaults). Uses the same envKeyToConfigKey
-// mapper as LoadEnvKoanf, producing identical key paths after the prefix.
-// e.g. SCION_SEED_SERVER_HUB_ADMINEMAILS → server.hub.adminEmails
+// environment variables (no file, no defaults). Uses envKeyToOpsettingsKey to
+// produce snake_case keys matching the opsettings registry and settings.yaml.
+// e.g. SCION_SEED_SERVER_HUB_ADMINEMAILS → server.hub.admin_emails
 func LoadSeedEnvKoanf() *koanf.Koanf {
 	k := koanf.New(".")
 	_ = k.Load(env.Provider("SCION_SEED_", ".", func(s string) string {
 		key := strings.TrimPrefix(s, "SCION_SEED_")
-		return envKeyToConfigKey(key)
+		return envKeyToOpsettingsKey(key)
 	}), nil)
 	return k
 }
@@ -859,15 +924,30 @@ func LoadSeedEnvKoanf() *koanf.Koanf {
 // fallback. Each layer merges on top of the previous one, so SCION_SERVER_*
 // wins over yaml, yaml wins over SCION_SEED_*, and SCION_SEED_* wins over
 // coded defaults.
+//
+// All layers use snake_case keys matching the opsettings registry
+// (e.g. server.hub.admin_emails, not hub.adminEmails). This ensures
+// ExtractSectionFromKoanf can find values from any layer.
 func LoadBootstrapKoanf() *koanf.Koanf {
 	k := koanf.New(".")
 
-	// 1. Coded defaults (same as LoadFileOnlyKoanf uses — settings.yaml
-	//    contains the canonical defaults via embedded YAML).
-	// LoadFileOnlyKoanf already loads settings.yaml + legacy server.yaml,
-	// but we need finer-grained layering, so we build it step by step.
+	// 1. Coded defaults in the opsettings keyspace (server.* snake_case).
+	defaults := DefaultGlobalConfig()
+	_ = k.Load(confmap.Provider(map[string]interface{}{
+		"server.hub.port":          defaults.Hub.Port,
+		"server.hub.host":          defaults.Hub.Host,
+		"server.hub.admin_emails":  defaults.Hub.AdminEmails,
+		"server.database.driver":   defaults.Database.Driver,
+		"server.database.url":      defaults.Database.URL,
+		"server.auth.dev_mode":     defaults.Auth.Enabled,
+		"server.auth.dev_token":    defaults.Auth.Token,
+		"server.storage.provider":  defaults.Storage.Provider,
+		"server.secrets.backend":   defaults.Secrets.Backend,
+		"server.log_level":         defaults.LogLevel,
+		"server.log_format":        defaults.LogFormat,
+	}, "."), nil)
 
-	// 2. SCION_SEED_* environment variables.
+	// 2. SCION_SEED_* environment variables (snake_case via envKeyToOpsettingsKey).
 	seedK := LoadSeedEnvKoanf()
 	_ = k.Merge(seedK)
 
@@ -884,8 +964,11 @@ func LoadBootstrapKoanf() *koanf.Koanf {
 	}
 
 	// 4. SCION_SERVER_* environment variables (highest precedence in bootstrap).
-	envK := LoadEnvKoanf()
-	_ = k.Merge(envK)
+	// Uses snake_case mapper so keys align with yaml and opsettings registry.
+	_ = k.Load(env.Provider("SCION_SERVER_", ".", func(s string) string {
+		key := strings.TrimPrefix(s, "SCION_SERVER_")
+		return envKeyToOpsettingsKey(key)
+	}), nil)
 
 	return k
 }

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -963,6 +963,10 @@ func LoadBootstrapKoanf() *koanf.Koanf {
 	k := koanf.New(".")
 
 	// 1. Coded defaults in the opsettings keyspace (server.* snake_case).
+	// NOTE: This is a manually maintained subset of GlobalConfig defaults.
+	// If new defaulted keys are added to GlobalConfig (or its nested structs),
+	// they must be added here too, otherwise bootstrap material will be
+	// incomplete for sections that rely on them during initial seeding.
 	defaults := DefaultGlobalConfig()
 	_ = k.Load(confmap.Provider(map[string]interface{}{
 		"server.hub.port":          defaults.Hub.Port,

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -862,6 +862,36 @@ func envKeyToOpsettingsKey(envKey string) string {
 	return strings.Join(parts, ".")
 }
 
+// serverSubKeys is the set of first-segment koanf keys (after snake_case
+// mapping) that belong under the "server." namespace in settings.yaml.
+// Derived from the V1ServerConfig koanf tags.
+var serverSubKeys = map[string]bool{
+	"hub": true, "broker": true, "database": true,
+	"auth": true, "oauth": true, "storage": true,
+	"workspace_storage": true, "secrets": true,
+	"log_level": true, "log_format": true,
+	"notification_channels": true, "message_broker": true,
+	"plugins": true, "github_app": true,
+	"mode": true, "env": true,
+}
+
+// serverEnvToOpsettingsKey maps a SCION_SERVER_* env var key (after prefix
+// stripping) to the opsettings koanf keyspace. For keys whose first segment
+// belongs to V1ServerConfig (e.g. hub, auth, database), it prepends "server."
+// so that SCION_SERVER_HUB_ADMINEMAILS → server.hub.admin_emails.
+// Non-server keys (e.g. telemetry, default_template) pass through unchanged.
+func serverEnvToOpsettingsKey(envKey string) string {
+	key := envKeyToOpsettingsKey(envKey)
+	firstSeg := key
+	if dot := strings.Index(key, "."); dot >= 0 {
+		firstSeg = key[:dot]
+	}
+	if serverSubKeys[firstSeg] {
+		return "server." + key
+	}
+	return key
+}
+
 // LoadFileOnlyKoanf returns a koanf instance loaded from settings.yaml +
 // embedded defaults, without any environment variable overlay. This produces
 // the "file fallback" Layer for OperationalSettings (settings-db §3.4/§3.9):
@@ -891,14 +921,15 @@ func LoadFileOnlyKoanf() *koanf.Koanf {
 }
 
 // LoadEnvKoanf returns a koanf instance loaded with only the SCION_SERVER_*
-// environment variables (no file, no defaults). This is used by the
-// OperationalSettings service to detect which Layer-1 keys are overridden by
-// env vars on this node (settings-db §3.4).
+// environment variables (no file, no defaults). Keys are mapped to the
+// opsettings registry keyspace (snake_case with server.* prefix where
+// appropriate) so that DetectEnvOverrides and DetectDeprecatedServerEnv can
+// match them against the registry.
 func LoadEnvKoanf() *koanf.Koanf {
 	k := koanf.New(".")
 	_ = k.Load(env.Provider("SCION_SERVER_", ".", func(s string) string {
 		key := strings.TrimPrefix(s, "SCION_SERVER_")
-		return envKeyToConfigKey(key)
+		return serverEnvToOpsettingsKey(key)
 	}), nil)
 	return k
 }
@@ -964,13 +995,48 @@ func LoadBootstrapKoanf() *koanf.Koanf {
 	}
 
 	// 4. SCION_SERVER_* environment variables (highest precedence in bootstrap).
-	// Uses snake_case mapper so keys align with yaml and opsettings registry.
+	// Uses serverEnvToOpsettingsKey which re-adds the "server." prefix for keys
+	// that belong under V1ServerConfig (e.g. HUB_ADMINEMAILS → server.hub.admin_emails).
 	_ = k.Load(env.Provider("SCION_SERVER_", ".", func(s string) string {
 		key := strings.TrimPrefix(s, "SCION_SERVER_")
-		return envKeyToOpsettingsKey(key)
+		return serverEnvToOpsettingsKey(key)
 	}), nil)
 
+	// 5. Split comma-separated list values from env vars. Koanf's env provider
+	// loads everything as strings; list fields need explicit splitting so
+	// ExtractSectionFromKoanf produces JSON arrays, not bare strings.
+	splitCommaSeparatedKoanfKeys(k)
+
 	return k
+}
+
+// commaSplitKoanfKeys lists koanf paths that represent list values and may
+// arrive as comma-separated strings from environment variables.
+var commaSplitKoanfKeys = []string{
+	"server.hub.admin_emails",
+	"server.auth.authorized_domains",
+}
+
+// splitCommaSeparatedKoanfKeys splits comma-separated string values into slices
+// for known list keys. Koanf's env provider loads all values as strings, but
+// list fields must be slices for correct JSON serialization by ExtractSectionFromKoanf.
+func splitCommaSeparatedKoanfKeys(k *koanf.Koanf) {
+	for _, key := range commaSplitKoanfKeys {
+		if !k.Exists(key) {
+			continue
+		}
+		val := k.Get(key)
+		s, ok := val.(string)
+		if !ok || !strings.Contains(s, ",") {
+			continue
+		}
+		parts := parseCommaSeparatedList(s)
+		sliceVal := make([]interface{}, len(parts))
+		for i, p := range parts {
+			sliceVal[i] = p
+		}
+		_ = k.Load(confmap.Provider(map[string]interface{}{key: sliceVal}, "."), nil)
+	}
 }
 
 // applyEnvOverrides loads SCION_SERVER_ environment variables and merges them

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -1034,12 +1034,16 @@ func splitCommaSeparatedKoanfKeys(k *koanf.Koanf) {
 		if !ok {
 			continue
 		}
-		parts := parseCommaSeparatedList(s)
-		sliceVal := make([]interface{}, len(parts))
-		for i, p := range parts {
-			sliceVal[i] = p
+		if strings.Contains(s, ",") {
+			parts := parseCommaSeparatedList(s)
+			sliceVal := make([]interface{}, len(parts))
+			for i, p := range parts {
+				sliceVal[i] = p
+			}
+			_ = k.Load(confmap.Provider(map[string]interface{}{key: sliceVal}, "."), nil)
+		} else {
+			_ = k.Load(confmap.Provider(map[string]interface{}{key: []interface{}{s}}, "."), nil)
 		}
-		_ = k.Load(confmap.Provider(map[string]interface{}{key: sliceVal}, "."), nil)
 	}
 }
 

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -969,17 +969,17 @@ func LoadBootstrapKoanf() *koanf.Koanf {
 	// incomplete for sections that rely on them during initial seeding.
 	defaults := DefaultGlobalConfig()
 	_ = k.Load(confmap.Provider(map[string]interface{}{
-		"server.hub.port":          defaults.Hub.Port,
-		"server.hub.host":          defaults.Hub.Host,
-		"server.hub.admin_emails":  defaults.Hub.AdminEmails,
-		"server.database.driver":   defaults.Database.Driver,
-		"server.database.url":      defaults.Database.URL,
-		"server.auth.dev_mode":     defaults.Auth.Enabled,
-		"server.auth.dev_token":    defaults.Auth.Token,
-		"server.storage.provider":  defaults.Storage.Provider,
-		"server.secrets.backend":   defaults.Secrets.Backend,
-		"server.log_level":         defaults.LogLevel,
-		"server.log_format":        defaults.LogFormat,
+		"server.hub.port":         defaults.Hub.Port,
+		"server.hub.host":         defaults.Hub.Host,
+		"server.hub.admin_emails": defaults.Hub.AdminEmails,
+		"server.database.driver":  defaults.Database.Driver,
+		"server.database.url":     defaults.Database.URL,
+		"server.auth.dev_mode":    defaults.Auth.Enabled,
+		"server.auth.dev_token":   defaults.Auth.Token,
+		"server.storage.provider": defaults.Storage.Provider,
+		"server.secrets.backend":  defaults.Secrets.Backend,
+		"server.log_level":        defaults.LogLevel,
+		"server.log_format":       defaults.LogFormat,
 	}, "."), nil)
 
 	// 2. SCION_SEED_* environment variables (snake_case via envKeyToOpsettingsKey).

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -1031,7 +1031,7 @@ func splitCommaSeparatedKoanfKeys(k *koanf.Koanf) {
 		}
 		val := k.Get(key)
 		s, ok := val.(string)
-		if !ok || !strings.Contains(s, ",") {
+		if !ok {
 			continue
 		}
 		parts := parseCommaSeparatedList(s)

--- a/pkg/config/opsettings/koanf.go
+++ b/pkg/config/opsettings/koanf.go
@@ -388,25 +388,29 @@ func DetectDeprecatedServerEnv(serverEnvKoanf *koanf.Koanf) []DeprecatedEnvVar {
 		if !IsLayer1Key(key) {
 			continue
 		}
+		// koanfKeyToEnvSuffix strips the "server." prefix, so the suffix
+		// is e.g. "HUB_ADMINEMAILS" for key "server.hub.admin_emails".
 		envSuffix := koanfKeyToEnvSuffix(key)
+		// SCION_SERVER_ env var: prefix + suffix (SERVER_ was the stripped prefix).
+		// SCION_SEED_ env var: prefix + SERVER_ + suffix (SERVER_ is a key segment).
 		deprecated = append(deprecated, DeprecatedEnvVar{
 			EnvVar:         "SCION_SERVER_" + envSuffix,
 			KoanfKey:       key,
-			SeedEquivalent: "SCION_SEED_" + envSuffix,
+			SeedEquivalent: "SCION_SEED_SERVER_" + envSuffix,
 		})
 	}
 	return deprecated
 }
 
 // koanfKeyToEnvSuffix converts a koanf key back to the env var suffix form.
-// e.g. "server.hub.admin_emails" → "SERVER_HUB_ADMINEMAILS"
-// This is the inverse of envKeyToConfigKey (in hub_config.go) — it converts
-// dots to underscores and uppercases, collapsing camelCase/snake_case back to
-// the flat uppercase env form.
+// e.g. "server.hub.admin_emails" → "HUB_ADMINEMAILS"
+// The "server." prefix is stripped because it corresponds to the SCION_SERVER_
+// env prefix that was already removed during key mapping. Without stripping,
+// the output would produce double-SERVER var names (SCION_SERVER_SERVER_HUB_...).
 func koanfKeyToEnvSuffix(key string) string {
+	key = strings.TrimPrefix(key, "server.")
 	parts := strings.Split(key, ".")
 	for i, part := range parts {
-		// Remove underscores within a segment (snake_case → flat)
 		parts[i] = strings.ToUpper(strings.ReplaceAll(part, "_", ""))
 	}
 	return strings.Join(parts, "_")

--- a/pkg/config/opsettings/koanf.go
+++ b/pkg/config/opsettings/koanf.go
@@ -17,6 +17,7 @@ package opsettings
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/knadh/koanf/providers/confmap"
@@ -365,4 +366,61 @@ func ClassifyKeys(keys []string) (layer1 map[string][]string, layer0 []string, u
 		}
 	}
 	return layer1, layer0, unclassified
+}
+
+// DeprecatedEnvVar describes a SCION_SERVER_* environment variable that targets
+// a Layer-1 key and should be migrated to SCION_SEED_*.
+type DeprecatedEnvVar struct {
+	EnvVar         string // e.g. "SCION_SERVER_HUB_ADMINEMAILS"
+	KoanfKey       string // e.g. "server.hub.admin_emails"
+	SeedEquivalent string // e.g. "SCION_SEED_SERVER_HUB_ADMINEMAILS"
+}
+
+// DetectDeprecatedServerEnv inspects a koanf instance loaded from SCION_SERVER_*
+// env vars and returns entries for any that resolve to Layer-1 keys. These vars
+// should be migrated to SCION_SEED_*. The caller is responsible for logging
+// the returned entries (typically once at startup).
+//
+// envVarPrefix is the raw env prefix used (e.g. "SCION_SERVER_").
+func DetectDeprecatedServerEnv(serverEnvKoanf *koanf.Koanf) []DeprecatedEnvVar {
+	var deprecated []DeprecatedEnvVar
+	for _, key := range serverEnvKoanf.Keys() {
+		if !IsLayer1Key(key) {
+			continue
+		}
+		envSuffix := koanfKeyToEnvSuffix(key)
+		deprecated = append(deprecated, DeprecatedEnvVar{
+			EnvVar:         "SCION_SERVER_" + envSuffix,
+			KoanfKey:       key,
+			SeedEquivalent: "SCION_SEED_" + envSuffix,
+		})
+	}
+	return deprecated
+}
+
+// koanfKeyToEnvSuffix converts a koanf key back to the env var suffix form.
+// e.g. "server.hub.admin_emails" → "SERVER_HUB_ADMINEMAILS"
+// This is the inverse of envKeyToConfigKey (in hub_config.go) — it converts
+// dots to underscores and uppercases, collapsing camelCase/snake_case back to
+// the flat uppercase env form.
+func koanfKeyToEnvSuffix(key string) string {
+	parts := strings.Split(key, ".")
+	for i, part := range parts {
+		// Remove underscores within a segment (snake_case → flat)
+		parts[i] = strings.ToUpper(strings.ReplaceAll(part, "_", ""))
+	}
+	return strings.Join(parts, "_")
+}
+
+// LogDeprecatedServerEnv logs a warning for each deprecated SCION_SERVER_* var
+// targeting a Layer-1 key. Call once at startup.
+func LogDeprecatedServerEnv(serverEnvKoanf *koanf.Koanf, logger *slog.Logger) {
+	deprecated := DetectDeprecatedServerEnv(serverEnvKoanf)
+	for _, d := range deprecated {
+		logger.Warn("SCION_SERVER_* is deprecated for operational settings; use SCION_SEED_*",
+			"env_var", d.EnvVar,
+			"koanf_key", d.KoanfKey,
+			"seed_equivalent", d.SeedEquivalent,
+		)
+	}
 }

--- a/pkg/config/opsettings/koanf.go
+++ b/pkg/config/opsettings/koanf.go
@@ -391,12 +391,22 @@ func DetectDeprecatedServerEnv(serverEnvKoanf *koanf.Koanf) []DeprecatedEnvVar {
 		// koanfKeyToEnvSuffix strips the "server." prefix, so the suffix
 		// is e.g. "HUB_ADMINEMAILS" for key "server.hub.admin_emails".
 		envSuffix := koanfKeyToEnvSuffix(key)
-		// SCION_SERVER_ env var: prefix + suffix (SERVER_ was the stripped prefix).
-		// SCION_SEED_ env var: prefix + SERVER_ + suffix (SERVER_ is a key segment).
+
+		// SEED prefix depends on whether the key lives under server.*:
+		// - server.hub.admin_emails → SCION_SEED_SERVER_HUB_ADMINEMAILS
+		//   (strips SCION_SEED_ → SERVER_HUB_ADMINEMAILS → server.hub.admin_emails)
+		// - telemetry.enabled → SCION_SEED_TELEMETRY_ENABLED
+		//   (strips SCION_SEED_ → TELEMETRY_ENABLED → telemetry.enabled)
+		var seedPrefix string
+		if strings.HasPrefix(key, "server.") {
+			seedPrefix = "SCION_SEED_SERVER_"
+		} else {
+			seedPrefix = "SCION_SEED_"
+		}
 		deprecated = append(deprecated, DeprecatedEnvVar{
 			EnvVar:         "SCION_SERVER_" + envSuffix,
 			KoanfKey:       key,
-			SeedEquivalent: "SCION_SEED_SERVER_" + envSuffix,
+			SeedEquivalent: seedPrefix + envSuffix,
 		})
 	}
 	return deprecated

--- a/pkg/config/opsettings/koanf.go
+++ b/pkg/config/opsettings/koanf.go
@@ -368,6 +368,24 @@ func ClassifyKeys(keys []string) (layer1 map[string][]string, layer0 []string, u
 	return layer1, layer0, unclassified
 }
 
+// koanfPathToJSONKey is the reverse of jsonFieldToKoanfPaths: koanf path → JSON field name.
+var koanfPathToJSONKey map[string]string
+
+func init() {
+	koanfPathToJSONKey = make(map[string]string)
+	for _, fields := range jsonFieldToKoanfPaths {
+		for jsonKey, kp := range fields {
+			koanfPathToJSONKey[kp] = jsonKey
+		}
+	}
+}
+
+// SectionKeyFromKoanfPath returns the JSON field name (section-level key) for a
+// given koanf path, or empty string if the path is not in the registry.
+func SectionKeyFromKoanfPath(koanfPath string) string {
+	return koanfPathToJSONKey[koanfPath]
+}
+
 // DeprecatedEnvVar describes a SCION_SERVER_* environment variable that targets
 // a Layer-1 key and should be migrated to SCION_SEED_*.
 type DeprecatedEnvVar struct {

--- a/pkg/config/opsettings/koanf.go
+++ b/pkg/config/opsettings/koanf.go
@@ -298,17 +298,12 @@ func EnvOverriddenLayer1Keys(envKeys []string) []string {
 	return overridden
 }
 
-// DetectEnvOverrides creates a koanf instance from the SCION_ environment
-// variables and returns which Layer-1 keys are overridden by env.
-// The envMapper should be the same mapper used by the main config loader.
+// DetectEnvOverrides returns all koanf keys present in the SCION_SERVER_*
+// env koanf. This includes Layer-0 and Layer-1 keys alike — the caller
+// uses the list to show which fields are env-pinned in the admin UI
+// (both file-mode and DB-mode).
 func DetectEnvOverrides(envKoanf *koanf.Koanf) []string {
-	var overridden []string
-	for _, key := range envKoanf.Keys() {
-		if IsLayer1Key(key) {
-			overridden = append(overridden, key)
-		}
-	}
-	return overridden
+	return envKoanf.Keys()
 }
 
 // ExtractAllSections extracts all registered section documents from a fully

--- a/pkg/config/opsettings/koanf.go
+++ b/pkg/config/opsettings/koanf.go
@@ -381,6 +381,15 @@ func SectionKeyFromKoanfPath(koanfPath string) string {
 	return koanfPathToJSONKey[koanfPath]
 }
 
+// KoanfPathFromSectionKey returns the full koanf path for a section-level JSON
+// key, or empty string if no mapping exists for the given section/key pair.
+func KoanfPathFromSectionKey(sectionName, jsonKey string) string {
+	if mapping, ok := jsonFieldToKoanfPaths[sectionName]; ok {
+		return mapping[jsonKey]
+	}
+	return ""
+}
+
 // DeprecatedEnvVar describes a SCION_SERVER_* environment variable that targets
 // a Layer-1 key and should be migrated to SCION_SEED_*.
 type DeprecatedEnvVar struct {

--- a/pkg/config/opsettings/opsettings_test.go
+++ b/pkg/config/opsettings/opsettings_test.go
@@ -862,24 +862,39 @@ func TestDetectDeprecatedServerEnv_Layer1Keys(t *testing.T) {
 		found[d.KoanfKey] = d
 	}
 
-	// Check admin_emails
+	// Check admin_emails — koanfKeyToEnvSuffix strips "server." so suffix is HUB_ADMINEMAILS
 	if d, ok := found["server.hub.admin_emails"]; !ok {
 		t.Error("expected server.hub.admin_emails in deprecated list")
 	} else {
-		if d.EnvVar != "SCION_SERVER_SERVER_HUB_ADMINEMAILS" {
-			t.Errorf("expected env var SCION_SERVER_SERVER_HUB_ADMINEMAILS, got %q", d.EnvVar)
+		if d.EnvVar != "SCION_SERVER_HUB_ADMINEMAILS" {
+			t.Errorf("expected env var SCION_SERVER_HUB_ADMINEMAILS, got %q", d.EnvVar)
 		}
 		if d.SeedEquivalent != "SCION_SEED_SERVER_HUB_ADMINEMAILS" {
 			t.Errorf("expected seed equivalent SCION_SEED_SERVER_HUB_ADMINEMAILS, got %q", d.SeedEquivalent)
 		}
 	}
 
-	// Check telemetry.enabled
+	// Check user_access_mode
+	if d, ok := found["server.auth.user_access_mode"]; !ok {
+		t.Error("expected server.auth.user_access_mode in deprecated list")
+	} else {
+		if d.EnvVar != "SCION_SERVER_AUTH_USERACCESSMODE" {
+			t.Errorf("expected env var SCION_SERVER_AUTH_USERACCESSMODE, got %q", d.EnvVar)
+		}
+		if d.SeedEquivalent != "SCION_SEED_SERVER_AUTH_USERACCESSMODE" {
+			t.Errorf("expected seed equivalent SCION_SEED_SERVER_AUTH_USERACCESSMODE, got %q", d.SeedEquivalent)
+		}
+	}
+
+	// Check telemetry.enabled — no server. prefix, so suffix is TELEMETRY_ENABLED
 	if d, ok := found["telemetry.enabled"]; !ok {
 		t.Error("expected telemetry.enabled in deprecated list")
 	} else {
-		if d.SeedEquivalent != "SCION_SEED_TELEMETRY_ENABLED" {
-			t.Errorf("expected seed equivalent SCION_SEED_TELEMETRY_ENABLED, got %q", d.SeedEquivalent)
+		if d.EnvVar != "SCION_SERVER_TELEMETRY_ENABLED" {
+			t.Errorf("expected env var SCION_SERVER_TELEMETRY_ENABLED, got %q", d.EnvVar)
+		}
+		if d.SeedEquivalent != "SCION_SEED_SERVER_TELEMETRY_ENABLED" {
+			t.Errorf("expected seed equivalent SCION_SEED_SERVER_TELEMETRY_ENABLED, got %q", d.SeedEquivalent)
 		}
 	}
 }
@@ -939,11 +954,13 @@ func TestKoanfKeyToEnvSuffix(t *testing.T) {
 		key  string
 		want string
 	}{
-		{"server.hub.admin_emails", "SERVER_HUB_ADMINEMAILS"},
+		// server. prefix is stripped — it maps to the SCION_SERVER_ env prefix
+		{"server.hub.admin_emails", "HUB_ADMINEMAILS"},
+		{"server.auth.user_access_mode", "AUTH_USERACCESSMODE"},
+		{"server.hub.public_url", "HUB_PUBLICURL"},
+		// non-server keys are unchanged
 		{"telemetry.enabled", "TELEMETRY_ENABLED"},
 		{"default_max_turns", "DEFAULTMAXTURNS"},
-		{"server.auth.user_access_mode", "SERVER_AUTH_USERACCESSMODE"},
-		{"server.hub.public_url", "SERVER_HUB_PUBLICURL"},
 	}
 	for _, tt := range tests {
 		got := koanfKeyToEnvSuffix(tt.key)

--- a/pkg/config/opsettings/opsettings_test.go
+++ b/pkg/config/opsettings/opsettings_test.go
@@ -841,3 +841,114 @@ func TestGlobalDefaultsReserved(t *testing.T) {
 		t.Error("global_defaults should not be registered — it is reserved for future use")
 	}
 }
+
+// --- DetectDeprecatedServerEnv tests ---
+
+func TestDetectDeprecatedServerEnv_Layer1Keys(t *testing.T) {
+	envK := koanf.New(".")
+	_ = envK.Load(confmap.Provider(map[string]interface{}{
+		"server.hub.admin_emails":      []string{"admin@test.com"},
+		"server.auth.user_access_mode": "invite",
+		"telemetry.enabled":            true,
+	}, "."), nil)
+
+	deprecated := DetectDeprecatedServerEnv(envK)
+	if len(deprecated) != 3 {
+		t.Fatalf("expected 3 deprecated vars, got %d: %+v", len(deprecated), deprecated)
+	}
+
+	found := make(map[string]DeprecatedEnvVar)
+	for _, d := range deprecated {
+		found[d.KoanfKey] = d
+	}
+
+	// Check admin_emails
+	if d, ok := found["server.hub.admin_emails"]; !ok {
+		t.Error("expected server.hub.admin_emails in deprecated list")
+	} else {
+		if d.EnvVar != "SCION_SERVER_SERVER_HUB_ADMINEMAILS" {
+			t.Errorf("expected env var SCION_SERVER_SERVER_HUB_ADMINEMAILS, got %q", d.EnvVar)
+		}
+		if d.SeedEquivalent != "SCION_SEED_SERVER_HUB_ADMINEMAILS" {
+			t.Errorf("expected seed equivalent SCION_SEED_SERVER_HUB_ADMINEMAILS, got %q", d.SeedEquivalent)
+		}
+	}
+
+	// Check telemetry.enabled
+	if d, ok := found["telemetry.enabled"]; !ok {
+		t.Error("expected telemetry.enabled in deprecated list")
+	} else {
+		if d.SeedEquivalent != "SCION_SEED_TELEMETRY_ENABLED" {
+			t.Errorf("expected seed equivalent SCION_SEED_TELEMETRY_ENABLED, got %q", d.SeedEquivalent)
+		}
+	}
+}
+
+func TestDetectDeprecatedServerEnv_NoLayer1Keys(t *testing.T) {
+	envK := koanf.New(".")
+	_ = envK.Load(confmap.Provider(map[string]interface{}{
+		"server.database.driver": "postgres",
+		"server.hub.port":        9810,
+		"server.log_level":       "debug",
+	}, "."), nil)
+
+	deprecated := DetectDeprecatedServerEnv(envK)
+	if len(deprecated) != 0 {
+		t.Errorf("expected no deprecated vars for Layer-0 keys, got %d: %+v", len(deprecated), deprecated)
+	}
+}
+
+func TestDetectDeprecatedServerEnv_Empty(t *testing.T) {
+	envK := koanf.New(".")
+	deprecated := DetectDeprecatedServerEnv(envK)
+	if len(deprecated) != 0 {
+		t.Errorf("expected no deprecated vars for empty koanf, got %d", len(deprecated))
+	}
+}
+
+func TestDetectDeprecatedServerEnv_MixedKeys(t *testing.T) {
+	envK := koanf.New(".")
+	_ = envK.Load(confmap.Provider(map[string]interface{}{
+		"server.hub.admin_emails": []string{"admin@test.com"},
+		"server.database.driver":  "postgres",
+		"server.hub.port":         9810,
+		"default_max_turns":       100,
+	}, "."), nil)
+
+	deprecated := DetectDeprecatedServerEnv(envK)
+
+	// Only Layer-1 keys should be flagged: admin_emails and default_max_turns.
+	if len(deprecated) != 2 {
+		t.Fatalf("expected 2 deprecated vars, got %d: %+v", len(deprecated), deprecated)
+	}
+
+	foundKeys := make(map[string]bool)
+	for _, d := range deprecated {
+		foundKeys[d.KoanfKey] = true
+	}
+	if !foundKeys["server.hub.admin_emails"] {
+		t.Error("expected server.hub.admin_emails in deprecated list")
+	}
+	if !foundKeys["default_max_turns"] {
+		t.Error("expected default_max_turns in deprecated list")
+	}
+}
+
+func TestKoanfKeyToEnvSuffix(t *testing.T) {
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{"server.hub.admin_emails", "SERVER_HUB_ADMINEMAILS"},
+		{"telemetry.enabled", "TELEMETRY_ENABLED"},
+		{"default_max_turns", "DEFAULTMAXTURNS"},
+		{"server.auth.user_access_mode", "SERVER_AUTH_USERACCESSMODE"},
+		{"server.hub.public_url", "SERVER_HUB_PUBLICURL"},
+	}
+	for _, tt := range tests {
+		got := koanfKeyToEnvSuffix(tt.key)
+		if got != tt.want {
+			t.Errorf("koanfKeyToEnvSuffix(%q) = %q, want %q", tt.key, got, tt.want)
+		}
+	}
+}

--- a/pkg/config/opsettings/opsettings_test.go
+++ b/pkg/config/opsettings/opsettings_test.go
@@ -886,15 +886,16 @@ func TestDetectDeprecatedServerEnv_Layer1Keys(t *testing.T) {
 		}
 	}
 
-	// Check telemetry.enabled — no server. prefix, so suffix is TELEMETRY_ENABLED
+	// Check telemetry.enabled — no server. prefix, so SEED equivalent uses
+	// SCION_SEED_ (not SCION_SEED_SERVER_) to map back to telemetry.enabled.
 	if d, ok := found["telemetry.enabled"]; !ok {
 		t.Error("expected telemetry.enabled in deprecated list")
 	} else {
 		if d.EnvVar != "SCION_SERVER_TELEMETRY_ENABLED" {
 			t.Errorf("expected env var SCION_SERVER_TELEMETRY_ENABLED, got %q", d.EnvVar)
 		}
-		if d.SeedEquivalent != "SCION_SEED_SERVER_TELEMETRY_ENABLED" {
-			t.Errorf("expected seed equivalent SCION_SEED_SERVER_TELEMETRY_ENABLED, got %q", d.SeedEquivalent)
+		if d.SeedEquivalent != "SCION_SEED_TELEMETRY_ENABLED" {
+			t.Errorf("expected seed equivalent SCION_SEED_TELEMETRY_ENABLED, got %q", d.SeedEquivalent)
 		}
 	}
 }

--- a/pkg/config/opsettings/opsettings_test.go
+++ b/pkg/config/opsettings/opsettings_test.go
@@ -951,6 +951,27 @@ func TestDetectDeprecatedServerEnv_MixedKeys(t *testing.T) {
 	}
 }
 
+func TestKoanfPathFromSectionKey(t *testing.T) {
+	tests := []struct {
+		section string
+		jsonKey string
+		want    string
+	}{
+		{"access", "admin_emails", "server.hub.admin_emails"},
+		{"access", "user_access_mode", "server.auth.user_access_mode"},
+		{"github_app", "webhooks_enabled", "server.github_app.webhooks_enabled"},
+		{"endpoints", "public_url", "server.hub.public_url"},
+		{"access", "nonexistent_key", ""},
+		{"nonexistent_section", "admin_emails", ""},
+	}
+	for _, tt := range tests {
+		got := KoanfPathFromSectionKey(tt.section, tt.jsonKey)
+		if got != tt.want {
+			t.Errorf("KoanfPathFromSectionKey(%q, %q) = %q, want %q", tt.section, tt.jsonKey, got, tt.want)
+		}
+	}
+}
+
 func TestKoanfKeyToEnvSuffix(t *testing.T) {
 	tests := []struct {
 		key  string

--- a/pkg/config/opsettings/opsettings_test.go
+++ b/pkg/config/opsettings/opsettings_test.go
@@ -677,8 +677,9 @@ func TestDetectEnvOverrides(t *testing.T) {
 	if !found["telemetry.enabled"] {
 		t.Error("expected telemetry.enabled in overrides")
 	}
-	if found["server.database.driver"] {
-		t.Error("server.database.driver should not be in Layer-1 overrides")
+	// After H1 generalization, all env keys are returned (not just Layer-1).
+	if !found["server.database.driver"] {
+		t.Error("expected server.database.driver in overrides (all env keys reported)")
 	}
 }
 

--- a/pkg/config/opsettings/registry.go
+++ b/pkg/config/opsettings/registry.go
@@ -58,8 +58,7 @@ func init() {
 		{
 			// maintenance is durable via DB but has no settings.yaml representation.
 			// It is runtime/API-owned state: absent DB row = compiled defaults
-			// (admin_mode=false). Seeding skips this section. The env var
-			// SCION_SERVER_ADMINMODE remains a per-node force-enable (design §3.4/§3.8).
+			// (admin_mode=false). Seeding skips this section.
 			Name:       "maintenance",
 			KoanfPaths: nil,
 			New:        func() any { return &MaintenanceSettings{} },

--- a/pkg/config/opsettings/sections.go
+++ b/pkg/config/opsettings/sections.go
@@ -71,7 +71,7 @@ type EndpointsSettings struct {
 type GitHubAppSettings struct {
 	AppID           int64  `json:"app_id,omitempty"`
 	APIBaseURL      string `json:"api_base_url,omitempty"`
-	WebhooksEnabled bool   `json:"webhooks_enabled,omitempty"`
+	WebhooksEnabled *bool  `json:"webhooks_enabled,omitempty"`
 	InstallationURL string `json:"installation_url,omitempty"`
 	PrivateKeyPath  string `json:"private_key_path,omitempty"`
 }

--- a/pkg/config/opsettings/seed_roundtrip_test.go
+++ b/pkg/config/opsettings/seed_roundtrip_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opsettings_test
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/config/opsettings"
+	"github.com/knadh/koanf/providers/confmap"
+	"github.com/knadh/koanf/v2"
+)
+
+// TestSeedEquivalentRoundTrip verifies that every SeedEquivalent produced by
+// DetectDeprecatedServerEnv maps back through LoadSeedEnvKoanf to the original
+// KoanfKey. This catches prefix mismatches — e.g. SCION_SEED_SERVER_ being
+// used for non-server.* keys like telemetry.enabled (which would map to
+// server.telemetry.enabled instead of telemetry.enabled).
+func TestSeedEquivalentRoundTrip(t *testing.T) {
+	// Build a koanf with a mix of server.* and non-server.* Layer-1 keys.
+	k := koanf.New(".")
+	_ = k.Load(confmap.Provider(map[string]interface{}{
+		"server.hub.admin_emails":      []string{"admin@test.com"},
+		"server.auth.user_access_mode": "invite",
+		"server.hub.public_url":        "https://hub.test.com",
+		"telemetry.enabled":            true,
+		"default_max_turns":            100,
+		"image_registry":               "gcr.io/test",
+	}, "."), nil)
+
+	deprecated := opsettings.DetectDeprecatedServerEnv(k)
+	if len(deprecated) == 0 {
+		t.Fatal("expected deprecated vars for round-trip test")
+	}
+
+	for _, d := range deprecated {
+		d := d
+		t.Run(d.KoanfKey, func(t *testing.T) {
+			t.Setenv(d.SeedEquivalent, "test-value")
+			seedK := config.LoadSeedEnvKoanf()
+
+			if !seedK.Exists(d.KoanfKey) {
+				t.Errorf("SeedEquivalent round-trip failed:\n  SeedEquivalent: %s\n  expected key:   %s\n  actual keys:    %v",
+					d.SeedEquivalent, d.KoanfKey, seedK.Keys())
+			}
+		})
+	}
+}
+
+// TestSeedEquivalentRoundTrip_TelemetrySpecific is a focused test for
+// telemetry.enabled, the specific key that triggered the B2 fix.
+func TestSeedEquivalentRoundTrip_TelemetrySpecific(t *testing.T) {
+	k := koanf.New(".")
+	_ = k.Load(confmap.Provider(map[string]interface{}{
+		"telemetry.enabled": true,
+	}, "."), nil)
+
+	deprecated := opsettings.DetectDeprecatedServerEnv(k)
+	if len(deprecated) != 1 {
+		t.Fatalf("expected 1 deprecated var for telemetry.enabled, got %d", len(deprecated))
+	}
+
+	d := deprecated[0]
+	if d.SeedEquivalent != "SCION_SEED_TELEMETRY_ENABLED" {
+		t.Fatalf("expected SeedEquivalent SCION_SEED_TELEMETRY_ENABLED, got %q", d.SeedEquivalent)
+	}
+
+	t.Setenv("SCION_SEED_TELEMETRY_ENABLED", "true")
+	seedK := config.LoadSeedEnvKoanf()
+
+	if !seedK.Exists("telemetry.enabled") {
+		t.Errorf("SCION_SEED_TELEMETRY_ENABLED did not map to telemetry.enabled; keys: %v", seedK.Keys())
+	}
+	if seedK.Exists("server.telemetry.enabled") {
+		t.Error("SCION_SEED_TELEMETRY_ENABLED should NOT map to server.telemetry.enabled")
+	}
+}

--- a/pkg/ent/hubsetting.go
+++ b/pkg/ent/hubsetting.go
@@ -27,6 +27,8 @@ type HubSetting struct {
 	Revision int64 `json:"revision,omitempty"`
 	// Email of the admin who last wrote this section
 	UpdatedBy string `json:"updated_by,omitempty"`
+	// Tracks whether this section is bootstrap-managed (seeded) or admin-owned (managed)
+	Origin hubsetting.Origin `json:"origin,omitempty"`
 	// CreateTime holds the value of the "create_time" field.
 	CreateTime time.Time `json:"create_time,omitempty"`
 	// UpdateTime holds the value of the "update_time" field.
@@ -43,7 +45,7 @@ func (*HubSetting) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case hubsetting.FieldRevision:
 			values[i] = new(sql.NullInt64)
-		case hubsetting.FieldSection, hubsetting.FieldUpdatedBy:
+		case hubsetting.FieldSection, hubsetting.FieldUpdatedBy, hubsetting.FieldOrigin:
 			values[i] = new(sql.NullString)
 		case hubsetting.FieldCreateTime, hubsetting.FieldUpdateTime:
 			values[i] = new(sql.NullTime)
@@ -95,6 +97,12 @@ func (_m *HubSetting) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field updated_by", values[i])
 			} else if value.Valid {
 				_m.UpdatedBy = value.String
+			}
+		case hubsetting.FieldOrigin:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field origin", values[i])
+			} else if value.Valid {
+				_m.Origin = hubsetting.Origin(value.String)
 			}
 		case hubsetting.FieldCreateTime:
 			if value, ok := values[i].(*sql.NullTime); !ok {
@@ -155,6 +163,9 @@ func (_m *HubSetting) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("updated_by=")
 	builder.WriteString(_m.UpdatedBy)
+	builder.WriteString(", ")
+	builder.WriteString("origin=")
+	builder.WriteString(fmt.Sprintf("%v", _m.Origin))
 	builder.WriteString(", ")
 	builder.WriteString("create_time=")
 	builder.WriteString(_m.CreateTime.Format(time.ANSIC))

--- a/pkg/ent/hubsetting/hubsetting.go
+++ b/pkg/ent/hubsetting/hubsetting.go
@@ -3,6 +3,7 @@
 package hubsetting
 
 import (
+	"fmt"
 	"time"
 
 	"entgo.io/ent/dialect/sql"
@@ -22,6 +23,8 @@ const (
 	FieldRevision = "revision"
 	// FieldUpdatedBy holds the string denoting the updated_by field in the database.
 	FieldUpdatedBy = "updated_by"
+	// FieldOrigin holds the string denoting the origin field in the database.
+	FieldOrigin = "origin"
 	// FieldCreateTime holds the string denoting the create_time field in the database.
 	FieldCreateTime = "create_time"
 	// FieldUpdateTime holds the string denoting the update_time field in the database.
@@ -37,6 +40,7 @@ var Columns = []string{
 	FieldValue,
 	FieldRevision,
 	FieldUpdatedBy,
+	FieldOrigin,
 	FieldCreateTime,
 	FieldUpdateTime,
 }
@@ -66,6 +70,32 @@ var (
 	DefaultID func() uuid.UUID
 )
 
+// Origin defines the type for the "origin" enum field.
+type Origin string
+
+// OriginSeeded is the default value of the Origin enum.
+const DefaultOrigin = OriginSeeded
+
+// Origin values.
+const (
+	OriginSeeded  Origin = "seeded"
+	OriginManaged Origin = "managed"
+)
+
+func (o Origin) String() string {
+	return string(o)
+}
+
+// OriginValidator is a validator for the "origin" field enum values. It is called by the builders before save.
+func OriginValidator(o Origin) error {
+	switch o {
+	case OriginSeeded, OriginManaged:
+		return nil
+	default:
+		return fmt.Errorf("hubsetting: invalid enum value for origin field: %q", o)
+	}
+}
+
 // OrderOption defines the ordering options for the HubSetting queries.
 type OrderOption func(*sql.Selector)
 
@@ -87,6 +117,11 @@ func ByRevision(opts ...sql.OrderTermOption) OrderOption {
 // ByUpdatedBy orders the results by the updated_by field.
 func ByUpdatedBy(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUpdatedBy, opts...).ToFunc()
+}
+
+// ByOrigin orders the results by the origin field.
+func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldOrigin, opts...).ToFunc()
 }
 
 // ByCreateTime orders the results by the create_time field.

--- a/pkg/ent/hubsetting/where.go
+++ b/pkg/ent/hubsetting/where.go
@@ -260,6 +260,26 @@ func UpdatedByContainsFold(v string) predicate.HubSetting {
 	return predicate.HubSetting(sql.FieldContainsFold(FieldUpdatedBy, v))
 }
 
+// OriginEQ applies the EQ predicate on the "origin" field.
+func OriginEQ(v Origin) predicate.HubSetting {
+	return predicate.HubSetting(sql.FieldEQ(FieldOrigin, v))
+}
+
+// OriginNEQ applies the NEQ predicate on the "origin" field.
+func OriginNEQ(v Origin) predicate.HubSetting {
+	return predicate.HubSetting(sql.FieldNEQ(FieldOrigin, v))
+}
+
+// OriginIn applies the In predicate on the "origin" field.
+func OriginIn(vs ...Origin) predicate.HubSetting {
+	return predicate.HubSetting(sql.FieldIn(FieldOrigin, vs...))
+}
+
+// OriginNotIn applies the NotIn predicate on the "origin" field.
+func OriginNotIn(vs ...Origin) predicate.HubSetting {
+	return predicate.HubSetting(sql.FieldNotIn(FieldOrigin, vs...))
+}
+
 // CreateTimeEQ applies the EQ predicate on the "create_time" field.
 func CreateTimeEQ(v time.Time) predicate.HubSetting {
 	return predicate.HubSetting(sql.FieldEQ(FieldCreateTime, v))

--- a/pkg/ent/hubsetting_create.go
+++ b/pkg/ent/hubsetting_create.go
@@ -65,6 +65,20 @@ func (_c *HubSettingCreate) SetNillableUpdatedBy(v *string) *HubSettingCreate {
 	return _c
 }
 
+// SetOrigin sets the "origin" field.
+func (_c *HubSettingCreate) SetOrigin(v hubsetting.Origin) *HubSettingCreate {
+	_c.mutation.SetOrigin(v)
+	return _c
+}
+
+// SetNillableOrigin sets the "origin" field if the given value is not nil.
+func (_c *HubSettingCreate) SetNillableOrigin(v *hubsetting.Origin) *HubSettingCreate {
+	if v != nil {
+		_c.SetOrigin(*v)
+	}
+	return _c
+}
+
 // SetCreateTime sets the "create_time" field.
 func (_c *HubSettingCreate) SetCreateTime(v time.Time) *HubSettingCreate {
 	_c.mutation.SetCreateTime(v)
@@ -146,6 +160,10 @@ func (_c *HubSettingCreate) defaults() {
 		v := hubsetting.DefaultRevision
 		_c.mutation.SetRevision(v)
 	}
+	if _, ok := _c.mutation.Origin(); !ok {
+		v := hubsetting.DefaultOrigin
+		_c.mutation.SetOrigin(v)
+	}
 	if _, ok := _c.mutation.CreateTime(); !ok {
 		v := hubsetting.DefaultCreateTime()
 		_c.mutation.SetCreateTime(v)
@@ -175,6 +193,14 @@ func (_c *HubSettingCreate) check() error {
 	}
 	if _, ok := _c.mutation.Revision(); !ok {
 		return &ValidationError{Name: "revision", err: errors.New(`ent: missing required field "HubSetting.revision"`)}
+	}
+	if _, ok := _c.mutation.Origin(); !ok {
+		return &ValidationError{Name: "origin", err: errors.New(`ent: missing required field "HubSetting.origin"`)}
+	}
+	if v, ok := _c.mutation.Origin(); ok {
+		if err := hubsetting.OriginValidator(v); err != nil {
+			return &ValidationError{Name: "origin", err: fmt.Errorf(`ent: validator failed for field "HubSetting.origin": %w`, err)}
+		}
 	}
 	if _, ok := _c.mutation.CreateTime(); !ok {
 		return &ValidationError{Name: "create_time", err: errors.New(`ent: missing required field "HubSetting.create_time"`)}
@@ -233,6 +259,10 @@ func (_c *HubSettingCreate) createSpec() (*HubSetting, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.UpdatedBy(); ok {
 		_spec.SetField(hubsetting.FieldUpdatedBy, field.TypeString, value)
 		_node.UpdatedBy = value
+	}
+	if value, ok := _c.mutation.Origin(); ok {
+		_spec.SetField(hubsetting.FieldOrigin, field.TypeEnum, value)
+		_node.Origin = value
 	}
 	if value, ok := _c.mutation.CreateTime(); ok {
 		_spec.SetField(hubsetting.FieldCreateTime, field.TypeTime, value)
@@ -351,6 +381,18 @@ func (u *HubSettingUpsert) UpdateUpdatedBy() *HubSettingUpsert {
 // ClearUpdatedBy clears the value of the "updated_by" field.
 func (u *HubSettingUpsert) ClearUpdatedBy() *HubSettingUpsert {
 	u.SetNull(hubsetting.FieldUpdatedBy)
+	return u
+}
+
+// SetOrigin sets the "origin" field.
+func (u *HubSettingUpsert) SetOrigin(v hubsetting.Origin) *HubSettingUpsert {
+	u.Set(hubsetting.FieldOrigin, v)
+	return u
+}
+
+// UpdateOrigin sets the "origin" field to the value that was provided on create.
+func (u *HubSettingUpsert) UpdateOrigin() *HubSettingUpsert {
+	u.SetExcluded(hubsetting.FieldOrigin)
 	return u
 }
 
@@ -484,6 +526,20 @@ func (u *HubSettingUpsertOne) UpdateUpdatedBy() *HubSettingUpsertOne {
 func (u *HubSettingUpsertOne) ClearUpdatedBy() *HubSettingUpsertOne {
 	return u.Update(func(s *HubSettingUpsert) {
 		s.ClearUpdatedBy()
+	})
+}
+
+// SetOrigin sets the "origin" field.
+func (u *HubSettingUpsertOne) SetOrigin(v hubsetting.Origin) *HubSettingUpsertOne {
+	return u.Update(func(s *HubSettingUpsert) {
+		s.SetOrigin(v)
+	})
+}
+
+// UpdateOrigin sets the "origin" field to the value that was provided on create.
+func (u *HubSettingUpsertOne) UpdateOrigin() *HubSettingUpsertOne {
+	return u.Update(func(s *HubSettingUpsert) {
+		s.UpdateOrigin()
 	})
 }
 
@@ -786,6 +842,20 @@ func (u *HubSettingUpsertBulk) UpdateUpdatedBy() *HubSettingUpsertBulk {
 func (u *HubSettingUpsertBulk) ClearUpdatedBy() *HubSettingUpsertBulk {
 	return u.Update(func(s *HubSettingUpsert) {
 		s.ClearUpdatedBy()
+	})
+}
+
+// SetOrigin sets the "origin" field.
+func (u *HubSettingUpsertBulk) SetOrigin(v hubsetting.Origin) *HubSettingUpsertBulk {
+	return u.Update(func(s *HubSettingUpsert) {
+		s.SetOrigin(v)
+	})
+}
+
+// UpdateOrigin sets the "origin" field to the value that was provided on create.
+func (u *HubSettingUpsertBulk) UpdateOrigin() *HubSettingUpsertBulk {
+	return u.Update(func(s *HubSettingUpsert) {
+		s.UpdateOrigin()
 	})
 }
 

--- a/pkg/ent/hubsetting_update.go
+++ b/pkg/ent/hubsetting_update.go
@@ -97,6 +97,20 @@ func (_u *HubSettingUpdate) ClearUpdatedBy() *HubSettingUpdate {
 	return _u
 }
 
+// SetOrigin sets the "origin" field.
+func (_u *HubSettingUpdate) SetOrigin(v hubsetting.Origin) *HubSettingUpdate {
+	_u.mutation.SetOrigin(v)
+	return _u
+}
+
+// SetNillableOrigin sets the "origin" field if the given value is not nil.
+func (_u *HubSettingUpdate) SetNillableOrigin(v *hubsetting.Origin) *HubSettingUpdate {
+	if v != nil {
+		_u.SetOrigin(*v)
+	}
+	return _u
+}
+
 // SetUpdateTime sets the "update_time" field.
 func (_u *HubSettingUpdate) SetUpdateTime(v time.Time) *HubSettingUpdate {
 	_u.mutation.SetUpdateTime(v)
@@ -151,6 +165,11 @@ func (_u *HubSettingUpdate) check() error {
 			return &ValidationError{Name: "section", err: fmt.Errorf(`ent: validator failed for field "HubSetting.section": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.Origin(); ok {
+		if err := hubsetting.OriginValidator(v); err != nil {
+			return &ValidationError{Name: "origin", err: fmt.Errorf(`ent: validator failed for field "HubSetting.origin": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -188,6 +207,9 @@ func (_u *HubSettingUpdate) sqlSave(ctx context.Context) (_node int, err error) 
 	}
 	if _u.mutation.UpdatedByCleared() {
 		_spec.ClearField(hubsetting.FieldUpdatedBy, field.TypeString)
+	}
+	if value, ok := _u.mutation.Origin(); ok {
+		_spec.SetField(hubsetting.FieldOrigin, field.TypeEnum, value)
 	}
 	if value, ok := _u.mutation.UpdateTime(); ok {
 		_spec.SetField(hubsetting.FieldUpdateTime, field.TypeTime, value)
@@ -279,6 +301,20 @@ func (_u *HubSettingUpdateOne) ClearUpdatedBy() *HubSettingUpdateOne {
 	return _u
 }
 
+// SetOrigin sets the "origin" field.
+func (_u *HubSettingUpdateOne) SetOrigin(v hubsetting.Origin) *HubSettingUpdateOne {
+	_u.mutation.SetOrigin(v)
+	return _u
+}
+
+// SetNillableOrigin sets the "origin" field if the given value is not nil.
+func (_u *HubSettingUpdateOne) SetNillableOrigin(v *hubsetting.Origin) *HubSettingUpdateOne {
+	if v != nil {
+		_u.SetOrigin(*v)
+	}
+	return _u
+}
+
 // SetUpdateTime sets the "update_time" field.
 func (_u *HubSettingUpdateOne) SetUpdateTime(v time.Time) *HubSettingUpdateOne {
 	_u.mutation.SetUpdateTime(v)
@@ -346,6 +382,11 @@ func (_u *HubSettingUpdateOne) check() error {
 			return &ValidationError{Name: "section", err: fmt.Errorf(`ent: validator failed for field "HubSetting.section": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.Origin(); ok {
+		if err := hubsetting.OriginValidator(v); err != nil {
+			return &ValidationError{Name: "origin", err: fmt.Errorf(`ent: validator failed for field "HubSetting.origin": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -400,6 +441,9 @@ func (_u *HubSettingUpdateOne) sqlSave(ctx context.Context) (_node *HubSetting, 
 	}
 	if _u.mutation.UpdatedByCleared() {
 		_spec.ClearField(hubsetting.FieldUpdatedBy, field.TypeString)
+	}
+	if value, ok := _u.mutation.Origin(); ok {
+		_spec.SetField(hubsetting.FieldOrigin, field.TypeEnum, value)
 	}
 	if value, ok := _u.mutation.UpdateTime(); ok {
 		_spec.SetField(hubsetting.FieldUpdateTime, field.TypeTime, value)

--- a/pkg/ent/migrate/schema.go
+++ b/pkg/ent/migrate/schema.go
@@ -463,6 +463,7 @@ var (
 		{Name: "value", Type: field.TypeJSON},
 		{Name: "revision", Type: field.TypeInt64, Default: 1},
 		{Name: "updated_by", Type: field.TypeString, Nullable: true},
+		{Name: "origin", Type: field.TypeEnum, Enums: []string{"seeded", "managed"}, Default: "seeded"},
 		{Name: "create_time", Type: field.TypeTime},
 		{Name: "update_time", Type: field.TypeTime},
 	}

--- a/pkg/ent/mutation.go
+++ b/pkg/ent/mutation.go
@@ -15483,6 +15483,7 @@ type HubSettingMutation struct {
 	revision      *int64
 	addrevision   *int64
 	updated_by    *string
+	origin        *hubsetting.Origin
 	create_time   *time.Time
 	update_time   *time.Time
 	clearedFields map[string]struct{}
@@ -15787,6 +15788,42 @@ func (m *HubSettingMutation) ResetUpdatedBy() {
 	delete(m.clearedFields, hubsetting.FieldUpdatedBy)
 }
 
+// SetOrigin sets the "origin" field.
+func (m *HubSettingMutation) SetOrigin(h hubsetting.Origin) {
+	m.origin = &h
+}
+
+// Origin returns the value of the "origin" field in the mutation.
+func (m *HubSettingMutation) Origin() (r hubsetting.Origin, exists bool) {
+	v := m.origin
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldOrigin returns the old "origin" field's value of the HubSetting entity.
+// If the HubSetting object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *HubSettingMutation) OldOrigin(ctx context.Context) (v hubsetting.Origin, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldOrigin is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldOrigin requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldOrigin: %w", err)
+	}
+	return oldValue.Origin, nil
+}
+
+// ResetOrigin resets all changes to the "origin" field.
+func (m *HubSettingMutation) ResetOrigin() {
+	m.origin = nil
+}
+
 // SetCreateTime sets the "create_time" field.
 func (m *HubSettingMutation) SetCreateTime(t time.Time) {
 	m.create_time = &t
@@ -15893,7 +15930,7 @@ func (m *HubSettingMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *HubSettingMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
 	if m.section != nil {
 		fields = append(fields, hubsetting.FieldSection)
 	}
@@ -15905,6 +15942,9 @@ func (m *HubSettingMutation) Fields() []string {
 	}
 	if m.updated_by != nil {
 		fields = append(fields, hubsetting.FieldUpdatedBy)
+	}
+	if m.origin != nil {
+		fields = append(fields, hubsetting.FieldOrigin)
 	}
 	if m.create_time != nil {
 		fields = append(fields, hubsetting.FieldCreateTime)
@@ -15928,6 +15968,8 @@ func (m *HubSettingMutation) Field(name string) (ent.Value, bool) {
 		return m.Revision()
 	case hubsetting.FieldUpdatedBy:
 		return m.UpdatedBy()
+	case hubsetting.FieldOrigin:
+		return m.Origin()
 	case hubsetting.FieldCreateTime:
 		return m.CreateTime()
 	case hubsetting.FieldUpdateTime:
@@ -15949,6 +15991,8 @@ func (m *HubSettingMutation) OldField(ctx context.Context, name string) (ent.Val
 		return m.OldRevision(ctx)
 	case hubsetting.FieldUpdatedBy:
 		return m.OldUpdatedBy(ctx)
+	case hubsetting.FieldOrigin:
+		return m.OldOrigin(ctx)
 	case hubsetting.FieldCreateTime:
 		return m.OldCreateTime(ctx)
 	case hubsetting.FieldUpdateTime:
@@ -15989,6 +16033,13 @@ func (m *HubSettingMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetUpdatedBy(v)
+		return nil
+	case hubsetting.FieldOrigin:
+		v, ok := value.(hubsetting.Origin)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetOrigin(v)
 		return nil
 	case hubsetting.FieldCreateTime:
 		v, ok := value.(time.Time)
@@ -16088,6 +16139,9 @@ func (m *HubSettingMutation) ResetField(name string) error {
 		return nil
 	case hubsetting.FieldUpdatedBy:
 		m.ResetUpdatedBy()
+		return nil
+	case hubsetting.FieldOrigin:
+		m.ResetOrigin()
 		return nil
 	case hubsetting.FieldCreateTime:
 		m.ResetCreateTime()

--- a/pkg/ent/runtime.go
+++ b/pkg/ent/runtime.go
@@ -450,11 +450,11 @@ func init() {
 	// hubsetting.DefaultRevision holds the default value on creation for the revision field.
 	hubsetting.DefaultRevision = hubsettingDescRevision.Default.(int64)
 	// hubsettingDescCreateTime is the schema descriptor for create_time field.
-	hubsettingDescCreateTime := hubsettingFields[5].Descriptor()
+	hubsettingDescCreateTime := hubsettingFields[6].Descriptor()
 	// hubsetting.DefaultCreateTime holds the default value on creation for the create_time field.
 	hubsetting.DefaultCreateTime = hubsettingDescCreateTime.Default.(func() time.Time)
 	// hubsettingDescUpdateTime is the schema descriptor for update_time field.
-	hubsettingDescUpdateTime := hubsettingFields[6].Descriptor()
+	hubsettingDescUpdateTime := hubsettingFields[7].Descriptor()
 	// hubsetting.DefaultUpdateTime holds the default value on creation for the update_time field.
 	hubsetting.DefaultUpdateTime = hubsettingDescUpdateTime.Default.(func() time.Time)
 	// hubsetting.UpdateDefaultUpdateTime holds the default value on update for the update_time field.

--- a/pkg/ent/schema/hubsetting.go
+++ b/pkg/ent/schema/hubsetting.go
@@ -51,6 +51,10 @@ func (HubSetting) Fields() []ent.Field {
 		field.String("updated_by").
 			Optional().
 			Comment("Email of the admin who last wrote this section"),
+		field.Enum("origin").
+			Values("seeded", "managed").
+			Default("seeded").
+			Comment("Tracks whether this section is bootstrap-managed (seeded) or admin-owned (managed)"),
 		field.Time("create_time").
 			Default(time.Now).
 			Immutable(),

--- a/pkg/hub/admin_settings.go
+++ b/pkg/hub/admin_settings.go
@@ -34,6 +34,9 @@ type ServerConfigResponse struct {
 	ScionCommit    string `json:"scion_commit,omitempty"`
 	ScionBuildTime string `json:"scion_build_time,omitempty"`
 
+	// SettingsTier indicates the settings backend: "db" or "file".
+	SettingsTier string `json:"settings_tier,omitempty"`
+
 	SchemaVersion        string                               `json:"schema_version"`
 	ActiveProfile        string                               `json:"active_profile,omitempty"`
 	DefaultTemplate      string                               `json:"default_template,omitempty"`
@@ -126,6 +129,7 @@ func (s *Server) handleGetServerConfig(w http.ResponseWriter) {
 				ScionVersion:   version.Short(),
 				ScionCommit:    version.GetCommit(),
 				ScionBuildTime: version.GetBuildTime(),
+				SettingsTier:   "file",
 				SchemaVersion:  "1",
 			})
 			return
@@ -145,6 +149,7 @@ func (s *Server) handleGetServerConfig(w http.ResponseWriter) {
 		ScionVersion:         version.Short(),
 		ScionCommit:          version.GetCommit(),
 		ScionBuildTime:       version.GetBuildTime(),
+		SettingsTier:         "file",
 		SchemaVersion:        vs.SchemaVersion,
 		ActiveProfile:        vs.ActiveProfile,
 		DefaultTemplate:      vs.DefaultTemplate,

--- a/pkg/hub/admin_settings.go
+++ b/pkg/hub/admin_settings.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
@@ -58,6 +59,11 @@ type ServerConfigResponse struct {
 	DefaultMaxModelCalls int               `json:"default_max_model_calls,omitempty"`
 	DefaultMaxDuration   string            `json:"default_max_duration,omitempty"`
 	DefaultResources     *api.ResourceSpec `json:"default_resources,omitempty"`
+
+	// EnvOverrides lists koanf keys overridden by SCION_SERVER_* env vars
+	// on this node. Present in both file-mode and DB-mode responses so the
+	// admin UI can show env-pinned fields regardless of settings tier.
+	EnvOverrides []string `json:"env_overrides,omitempty"`
 }
 
 // ServerConfigUpdateRequest is the payload for updating settings.
@@ -184,14 +190,19 @@ func (s *Server) handleGetServerConfig(w http.ResponseWriter) {
 	data, err := os.ReadFile(settingsPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// Return empty/default response if no settings file exists
-			writeJSON(w, http.StatusOK, ServerConfigResponse{
+			resp := ServerConfigResponse{
 				ScionVersion:   version.Short(),
 				ScionCommit:    version.GetCommit(),
 				ScionBuildTime: version.GetBuildTime(),
 				SettingsTier:   "file",
 				SchemaVersion:  "1",
-			})
+			}
+			envK := config.LoadEnvKoanf()
+			if envOverrides := opsettings.DetectEnvOverrides(envK); len(envOverrides) > 0 {
+				sort.Strings(envOverrides)
+				resp.EnvOverrides = envOverrides
+			}
+			writeJSON(w, http.StatusOK, resp)
 			return
 		}
 		writeError(w, http.StatusInternalServerError, ErrCodeInternalError, "Failed to read settings file", nil)
@@ -225,6 +236,14 @@ func (s *Server) handleGetServerConfig(w http.ResponseWriter) {
 		DefaultMaxModelCalls: vs.DefaultMaxModelCalls,
 		DefaultMaxDuration:   vs.DefaultMaxDuration,
 		DefaultResources:     vs.DefaultResources,
+	}
+
+	// Env overrides — detect SCION_SERVER_* env vars so the admin UI can
+	// show env-pinned fields in file mode too (H1).
+	envK := config.LoadEnvKoanf()
+	if envOverrides := opsettings.DetectEnvOverrides(envK); len(envOverrides) > 0 {
+		sort.Strings(envOverrides)
+		resp.EnvOverrides = envOverrides
 	}
 
 	maskSensitiveFields(&resp)

--- a/pkg/hub/admin_settings.go
+++ b/pkg/hub/admin_settings.go
@@ -15,13 +15,17 @@
 package hub
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/config/opsettings"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/GoogleCloudPlatform/scion/pkg/version"
 	yamlv3 "gopkg.in/yaml.v3"
 )
@@ -110,6 +114,62 @@ func (s *Server) handleAdminServerConfig(w http.ResponseWriter, r *http.Request)
 	default:
 		MethodNotAllowed(w)
 	}
+}
+
+// handleAdminServerConfigSectionReset handles
+// DELETE /api/v1/admin/server-config/sections/{name}
+// Resets a managed section back to bootstrap material by deleting the DB row.
+// Postgres mode only; admin-gated. Design §3.2.4.
+func (s *Server) handleAdminServerConfigSectionReset(w http.ResponseWriter, r *http.Request) {
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil || user.Role() != "admin" {
+		Forbidden(w)
+		return
+	}
+
+	if r.Method != http.MethodDelete {
+		MethodNotAllowed(w)
+		return
+	}
+
+	ops := s.GetOperationalSettings()
+	if ops == nil || !s.IsPostgres() {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest,
+			"Section reset is only available in postgres mode", nil)
+		return
+	}
+
+	sectionName := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/server-config/sections/")
+	if sectionName == "" {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest,
+			"Section name is required", nil)
+		return
+	}
+
+	sec := opsettings.SectionByName(sectionName)
+	if sec == nil {
+		writeError(w, http.StatusNotFound, ErrCodeNotFound,
+			"Unknown section: "+sectionName, nil)
+		return
+	}
+
+	if err := ops.DeleteSection(r.Context(), sectionName); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, ErrCodeNotFound,
+				"Section not found in database: "+sectionName, nil)
+			return
+		}
+		slog.Error("Failed to reset section", "section", sectionName, "error", err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
+			"Failed to reset section", nil)
+		return
+	}
+
+	slog.Info("Section reset to bootstrap", "section", sectionName, "by", user.Email())
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"reset":   true,
+		"section": sectionName,
+	})
 }
 
 // handleGetServerConfig reads and returns the global settings.yaml.

--- a/pkg/hub/admin_settings_db.go
+++ b/pkg/hub/admin_settings_db.go
@@ -238,7 +238,7 @@ func (s *Server) buildSectionMetadata(_ context.Context, ops *OperationalSetting
 				UpdatedAt: &t,
 				UpdatedBy: ss.UpdatedBy,
 			}
-		} else if s.sectionHasFileValues(ops, sec.Name) {
+		} else if s.sectionHasBootstrapValues(ops, sec.Name) {
 			meta[sec.Name] = SectionMetadata{
 				Source: "file",
 			}
@@ -252,15 +252,15 @@ func (s *Server) buildSectionMetadata(_ context.Context, ops *OperationalSetting
 	return meta
 }
 
-// sectionHasFileValues checks whether the file fallback koanf has any non-zero
+// sectionHasBootstrapValues checks whether the bootstrap koanf has any non-zero
 // values for the given section's koanf paths.
-func (s *Server) sectionHasFileValues(ops *OperationalSettings, sectionName string) bool {
+func (s *Server) sectionHasBootstrapValues(ops *OperationalSettings, sectionName string) bool {
 	sec := opsettings.SectionByName(sectionName)
 	if sec == nil || len(sec.KoanfPaths) == 0 {
 		return false
 	}
 	for _, kp := range sec.KoanfPaths {
-		if ops.fileFallback != nil && ops.fileFallback.Exists(kp) {
+		if ops.bootstrapKoanf != nil && ops.bootstrapKoanf.Exists(kp) {
 			return true
 		}
 	}

--- a/pkg/hub/admin_settings_db.go
+++ b/pkg/hub/admin_settings_db.go
@@ -984,7 +984,12 @@ func buildSingleSectionDoc(req *ServerConfigUpdateRequest, secName string, fp *f
 			ga := req.Server.GitHubApp
 			d.AppID = ga.AppID
 			d.APIBaseURL = ga.APIBaseURL
-			d.WebhooksEnabled = ga.WebhooksEnabled
+			// #391: webhooks_enabled is a plain bool in the request; use
+			// fieldPresence to distinguish explicit false from omitted.
+			githubFP := serverFP.nestedPresence("github_app")
+			if ga.WebhooksEnabled || githubFP.has("webhooks_enabled") {
+				d.WebhooksEnabled = &ga.WebhooksEnabled
+			}
 			d.InstallationURL = ga.InstallationURL
 			d.PrivateKeyPath = ga.PrivateKeyPath
 		}

--- a/pkg/hub/admin_settings_db.go
+++ b/pkg/hub/admin_settings_db.go
@@ -32,6 +32,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/config/opsettings"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/GoogleCloudPlatform/scion/pkg/version"
+	"github.com/knadh/koanf/v2"
 	yamlv3 "gopkg.in/yaml.v3"
 )
 
@@ -45,6 +46,7 @@ type SectionMetadata struct {
 	Revision  int64      `json:"revision,omitempty"`   // DB revision (0 for file/default)
 	UpdatedAt *time.Time `json:"updated_at,omitempty"` // last update time (DB only)
 	UpdatedBy string     `json:"updated_by,omitempty"` // admin email (DB only)
+	Origin    string     `json:"origin,omitempty"`     // "seeded" or "managed" (DB mode only)
 }
 
 // ServerConfigDBResponse extends the file-mode response with metadata for the
@@ -59,6 +61,29 @@ type ServerConfigDBResponse struct {
 	// EnvOverrides lists Layer-1 koanf keys that are overridden by env vars
 	// on this node — a drift warning for the admin UI.
 	EnvOverrides []string `json:"env_overrides,omitempty"`
+
+	// SupersededKeys maps section name to bootstrap-material keys whose
+	// merged value differs from the DB value (managed sections only).
+	SupersededKeys map[string][]SupersededKey `json:"superseded_keys,omitempty"`
+
+	// DeprecatedEnvKeys lists SCION_SERVER_* env vars that target Layer-1
+	// keys and should be migrated to SCION_SEED_* equivalents.
+	DeprecatedEnvKeys []DeprecatedEnvKeyInfo `json:"deprecated_env_keys,omitempty"`
+}
+
+// SupersededKey represents a bootstrap-material key whose value in the
+// bootstrap merge differs from the admin-set DB value in a managed section.
+type SupersededKey struct {
+	Key    string `json:"key"`
+	Source string `json:"source"` // "seed_env", "yaml", or "server_env"
+}
+
+// DeprecatedEnvKeyInfo represents a SCION_SERVER_* env var that targets a
+// Layer-1 key and should be migrated to the SCION_SEED_* equivalent.
+type DeprecatedEnvKeyInfo struct {
+	EnvVar         string `json:"env_var"`
+	KoanfKey       string `json:"koanf_key"`
+	SeedEquivalent string `json:"seed_equivalent"`
 }
 
 // ServerConfigUpdateDBRequest extends the update request with optional CAS
@@ -131,6 +156,8 @@ func (s *Server) handleGetServerConfigDB(w http.ResponseWriter, r *http.Request,
 		resp.SchemaVersion = "1"
 	}
 
+	resp.ServerConfigResponse.SettingsTier = "db"
+
 	// Overlay Layer-1 fields from the operational settings snapshot.
 	snap := ops.Snapshot()
 	applySnapshotToResponse(&resp.ServerConfigResponse, snap)
@@ -143,6 +170,12 @@ func (s *Server) handleGetServerConfigDB(w http.ResponseWriter, r *http.Request,
 	sort.Strings(overrides)
 	resp.EnvOverrides = overrides
 
+	// Superseded keys (managed sections whose DB value diverges from bootstrap).
+	resp.SupersededKeys = s.computeSupersededKeys(ops)
+
+	// Deprecated env keys (SCION_SERVER_* targeting Layer-1 keys).
+	resp.DeprecatedEnvKeys = s.computeDeprecatedEnvKeys(ops)
+
 	// Mask sensitive fields — same logic as file mode.
 	maskSensitiveFields(&resp.ServerConfigResponse)
 
@@ -151,8 +184,8 @@ func (s *Server) handleGetServerConfigDB(w http.ResponseWriter, r *http.Request,
 
 // applySnapshotToResponse writes Layer-1 snapshot values into the
 // ServerConfigResponse, ensuring the response reflects the merged
-// (env > DB > file > defaults) view exactly. The snapshot is the
-// authoritative merged result (env > DB > file > defaults); every
+// (DB > bootstrap merge) view exactly. The snapshot is the
+// authoritative merged result (DB > bootstrap merge); every
 // field MUST be written unconditionally so that false booleans, empty
 // slices, and zero-value strings from the snapshot override any
 // stale file-loaded values in the response.
@@ -237,6 +270,7 @@ func (s *Server) buildSectionMetadata(_ context.Context, ops *OperationalSetting
 				Revision:  ss.Revision,
 				UpdatedAt: &t,
 				UpdatedBy: ss.UpdatedBy,
+				Origin:    ss.Origin,
 			}
 		} else if s.sectionHasBootstrapValues(ops, sec.Name) {
 			meta[sec.Name] = SectionMetadata{
@@ -265,6 +299,115 @@ func (s *Server) sectionHasBootstrapValues(ops *OperationalSettings, sectionName
 		}
 	}
 	return false
+}
+
+// computeSupersededKeys returns, for each managed section, the bootstrap-material
+// keys whose merged value differs from the DB value. This tells the admin which
+// deployment-config values their explicit DB writes are overriding.
+func (s *Server) computeSupersededKeys(ops *OperationalSettings) map[string][]SupersededKey {
+	ops.mu.RLock()
+	cacheSnap := make(map[string]sectionState, len(ops.cache))
+	for name, ss := range ops.cache {
+		cacheSnap[name] = ss
+	}
+	ops.mu.RUnlock()
+
+	if ops.bootstrapKoanf == nil {
+		return nil
+	}
+
+	// Load individual layers for source attribution.
+	seedEnvK := config.LoadSeedEnvKoanf()
+	serverEnvK := config.LoadEnvKoanf()
+
+	result := make(map[string][]SupersededKey)
+	for _, sec := range opsettings.Registry {
+		ss, ok := cacheSnap[sec.Name]
+		if !ok || ss.Origin != "managed" {
+			continue
+		}
+
+		bootstrapDoc, err := opsettings.ExtractSectionFromKoanf(ops.bootstrapKoanf, sec.Name)
+		if err != nil || bootstrapDoc == nil {
+			continue
+		}
+
+		var dbMap, bootstrapMap map[string]interface{}
+		if err := json.Unmarshal(ss.Value, &dbMap); err != nil {
+			continue
+		}
+		if err := json.Unmarshal(bootstrapDoc, &bootstrapMap); err != nil {
+			continue
+		}
+
+		var superseded []SupersededKey
+		for key, bootstrapVal := range bootstrapMap {
+			dbVal, exists := dbMap[key]
+			if !exists || !reflect.DeepEqual(dbVal, bootstrapVal) {
+				superseded = append(superseded, SupersededKey{
+					Key:    key,
+					Source: detectKeySource(seedEnvK, serverEnvK, sec.Name, key),
+				})
+			}
+		}
+		if len(superseded) > 0 {
+			sort.Slice(superseded, func(i, j int) bool { return superseded[i].Key < superseded[j].Key })
+			result[sec.Name] = superseded
+		}
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+// detectKeySource determines which bootstrap layer provides a given section key.
+// It checks the individual layers in reverse precedence order (server_env first,
+// then seed_env, then yaml) and returns the first match.
+func detectKeySource(seedEnvK, serverEnvK *koanf.Koanf, sectionName, key string) string {
+	sec := opsettings.SectionByName(sectionName)
+	if sec == nil {
+		return "yaml"
+	}
+
+	// Map the section-level key (e.g. "admin_emails") to koanf paths and check
+	// which layer provides the value.
+	for _, kp := range sec.KoanfPaths {
+		if opsettings.SectionKeyFromKoanfPath(kp) != key {
+			continue
+		}
+		if serverEnvK != nil && serverEnvK.Exists(kp) {
+			return "server_env"
+		}
+		if seedEnvK != nil && seedEnvK.Exists(kp) {
+			return "seed_env"
+		}
+		return "yaml"
+	}
+
+	return "yaml"
+}
+
+// computeDeprecatedEnvKeys returns SCION_SERVER_* env vars that target Layer-1
+// keys and should be migrated to SCION_SEED_* equivalents.
+func (s *Server) computeDeprecatedEnvKeys(ops *OperationalSettings) []DeprecatedEnvKeyInfo {
+	if ops.envKoanf == nil {
+		return nil
+	}
+	deprecated := opsettings.DetectDeprecatedServerEnv(ops.envKoanf)
+	if len(deprecated) == 0 {
+		return nil
+	}
+	result := make([]DeprecatedEnvKeyInfo, len(deprecated))
+	for i, d := range deprecated {
+		result[i] = DeprecatedEnvKeyInfo{
+			EnvVar:         d.EnvVar,
+			KoanfKey:       d.KoanfKey,
+			SeedEquivalent: d.SeedEquivalent,
+		}
+	}
+	return result
 }
 
 // handlePutServerConfigDB handles PUT /api/v1/admin/server-config in postgres mode.

--- a/pkg/hub/admin_settings_db.go
+++ b/pkg/hub/admin_settings_db.go
@@ -378,7 +378,7 @@ func (s *Server) handlePutServerConfigDB(w http.ResponseWriter, r *http.Request,
 			expectedRev = rev
 		}
 
-		newRev, err := ops.Update(r.Context(), secName, doc, updatedBy, expectedRev)
+		newRev, err := ops.Update(r.Context(), secName, doc, updatedBy, expectedRev, "managed")
 		if err != nil {
 			if errors.Is(err, store.ErrRevisionConflict) {
 				// Report the conflict with current revision.
@@ -945,7 +945,7 @@ func (s *Server) handlePutMaintenanceDB(w http.ResponseWriter, r *http.Request, 
 	}
 
 	// last-writer-wins (-1) for maintenance — no CAS needed for this endpoint.
-	if _, err := ops.Update(r.Context(), "maintenance", doc, updatedBy, -1); err != nil {
+	if _, err := ops.Update(r.Context(), "maintenance", doc, updatedBy, -1, "managed"); err != nil {
 		slog.Error("Failed to update maintenance settings", "error", err)
 		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
 			"Failed to update maintenance settings", nil)

--- a/pkg/hub/admin_settings_db.go
+++ b/pkg/hub/admin_settings_db.go
@@ -58,10 +58,6 @@ type ServerConfigDBResponse struct {
 	// SectionMetadata maps section name to its provenance metadata.
 	SectionMeta map[string]SectionMetadata `json:"section_metadata,omitempty"`
 
-	// EnvOverrides lists Layer-1 koanf keys that are overridden by env vars
-	// on this node — a drift warning for the admin UI.
-	EnvOverrides []string `json:"env_overrides,omitempty"`
-
 	// SupersededKeys maps section name to bootstrap-material keys whose
 	// merged value differs from the DB value (managed sections only).
 	SupersededKeys map[string][]SupersededKey `json:"superseded_keys,omitempty"`
@@ -168,7 +164,7 @@ func (s *Server) handleGetServerConfigDB(w http.ResponseWriter, r *http.Request,
 	// Env overrides.
 	overrides := ops.EnvOverriddenKeys()
 	sort.Strings(overrides)
-	resp.EnvOverrides = overrides
+	resp.ServerConfigResponse.EnvOverrides = overrides
 
 	// Superseded keys (managed sections whose DB value diverges from bootstrap).
 	resp.SupersededKeys = s.computeSupersededKeys(ops)

--- a/pkg/hub/admin_settings_db.go
+++ b/pkg/hub/admin_settings_db.go
@@ -340,8 +340,12 @@ func (s *Server) computeSupersededKeys(ops *OperationalSettings) map[string][]Su
 		for key, bootstrapVal := range bootstrapMap {
 			dbVal, exists := dbMap[key]
 			if !exists || !reflect.DeepEqual(dbVal, bootstrapVal) {
+				koanfPath := opsettings.KoanfPathFromSectionKey(sec.Name, key)
+				if koanfPath == "" {
+					koanfPath = key
+				}
 				superseded = append(superseded, SupersededKey{
-					Key:    key,
+					Key:    koanfPath,
 					Source: detectKeySource(seedEnvK, serverEnvK, sec.Name, key),
 				})
 			}

--- a/pkg/hub/admin_settings_db.go
+++ b/pkg/hub/admin_settings_db.go
@@ -152,7 +152,7 @@ func (s *Server) handleGetServerConfigDB(w http.ResponseWriter, r *http.Request,
 		resp.SchemaVersion = "1"
 	}
 
-	resp.ServerConfigResponse.SettingsTier = "db"
+	resp.SettingsTier = "db"
 
 	// Overlay Layer-1 fields from the operational settings snapshot.
 	snap := ops.Snapshot()
@@ -164,7 +164,7 @@ func (s *Server) handleGetServerConfigDB(w http.ResponseWriter, r *http.Request,
 	// Env overrides.
 	overrides := ops.EnvOverriddenKeys()
 	sort.Strings(overrides)
-	resp.ServerConfigResponse.EnvOverrides = overrides
+	resp.EnvOverrides = overrides
 
 	// Superseded keys (managed sections whose DB value diverges from bootstrap).
 	resp.SupersededKeys = s.computeSupersededKeys(ops)

--- a/pkg/hub/admin_settings_db_test.go
+++ b/pkg/hub/admin_settings_db_test.go
@@ -764,23 +764,23 @@ func TestGetMaintenanceDB_ReflectsSnapshot(t *testing.T) {
 	}
 }
 
-func TestMaintenanceDB_EnvOverrideStillWins(t *testing.T) {
+func TestMaintenanceDB_EnvDoesNotOverrideDB(t *testing.T) {
 	srv, fakeStore, ops := newTestDBServer(t)
 
 	// DB says maintenance off.
 	fakeStore.seed("maintenance", json.RawMessage(`{"admin_mode":false}`))
 	_, _ = ops.Refresh(context.Background())
 
-	// But env says on.
+	// Env says on — but per B3 redesign, env no longer force-wins for
+	// maintenance. DB is authoritative in HA mode.
 	t.Setenv("SCION_SERVER_ADMIN_MODE", "true")
 
-	// Apply snapshot with env override.
 	snap := ops.Snapshot()
 	ApplyMaintenanceFromSnapshot(srv, snap)
 
-	// Server should be in maintenance due to env override.
-	if !srv.maintenance.IsEnabled() {
-		t.Error("expected maintenance enabled due to env override")
+	// Server should NOT be in maintenance — DB wins.
+	if srv.maintenance.IsEnabled() {
+		t.Error("expected maintenance disabled — DB wins over env in HA mode")
 	}
 }
 
@@ -1187,6 +1187,266 @@ func TestGetServerConfigDB_MasksGitHubAppSecrets(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
 	// Handler calls maskSensitiveFields — if it reaches here without panic, masking ran.
+}
+
+// ---- B3: Provenance API tests ----
+
+func TestGetServerConfigDB_SettingsTierIsDB(t *testing.T) {
+	srv, _, ops := newTestDBServer(t)
+
+	rr := httptest.NewRecorder()
+	srv.handleGetServerConfigDB(rr, adminRequest(http.MethodGet, "/api/v1/admin/server-config", ""), ops)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if resp["settings_tier"] != "db" {
+		t.Errorf("settings_tier: want 'db', got %v", resp["settings_tier"])
+	}
+}
+
+func TestGetServerConfigDB_OriginInSectionMetadata(t *testing.T) {
+	fakeStore := newFakeHubSettingStore()
+	fileK := emptyKoanf()
+	envK := emptyKoanf()
+	ops := NewOperationalSettings(fakeStore, fileK, envK)
+
+	// Seed a section with "seeded" origin and another with "managed" origin.
+	fakeStore.seedWithOrigin("access", json.RawMessage(`{"admin_emails":["a@test.com"]}`), "seeded")
+	fakeStore.seedWithOrigin("maintenance", json.RawMessage(`{"admin_mode":false}`), "managed")
+	_, _ = ops.Refresh(context.Background())
+
+	srv := &Server{
+		dbDriver:    "postgres",
+		maintenance: NewMaintenanceState(false, ""),
+	}
+	srv.SetOperationalSettings(ops)
+
+	rr := httptest.NewRecorder()
+	srv.handleGetServerConfigDB(rr, adminRequest(http.MethodGet, "/api/v1/admin/server-config", ""), ops)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp ServerConfigDBResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	accessMeta := resp.SectionMeta["access"]
+	if accessMeta.Origin != "seeded" {
+		t.Errorf("access origin: want 'seeded', got %q", accessMeta.Origin)
+	}
+
+	maintMeta := resp.SectionMeta["maintenance"]
+	if maintMeta.Origin != "managed" {
+		t.Errorf("maintenance origin: want 'managed', got %q", maintMeta.Origin)
+	}
+
+	// Sections without DB rows should have no origin.
+	lifecycleMeta := resp.SectionMeta["lifecycle"]
+	if lifecycleMeta.Origin != "" {
+		t.Errorf("lifecycle origin: want empty, got %q", lifecycleMeta.Origin)
+	}
+}
+
+func TestGetServerConfigDB_SupersededKeys(t *testing.T) {
+	fakeStore := newFakeHubSettingStore()
+
+	// Bootstrap koanf has admin_emails from bootstrap merge.
+	bootstrapK := newFileKoanf(t, map[string]interface{}{
+		"server.hub.admin_emails":      []interface{}{"bootstrap@example.com"},
+		"server.auth.user_access_mode": "open",
+	})
+	envK := emptyKoanf()
+	ops := NewOperationalSettings(fakeStore, bootstrapK, envK)
+
+	// Seed access as "managed" with different admin_emails (DB wins, bootstrap is superseded).
+	fakeStore.seedWithOrigin("access", json.RawMessage(`{"admin_emails":["admin@db.com"],"user_access_mode":"open"}`), "managed")
+	_, _ = ops.Refresh(context.Background())
+
+	srv := &Server{
+		dbDriver:    "postgres",
+		maintenance: NewMaintenanceState(false, ""),
+	}
+	srv.SetOperationalSettings(ops)
+
+	rr := httptest.NewRecorder()
+	srv.handleGetServerConfigDB(rr, adminRequest(http.MethodGet, "/api/v1/admin/server-config", ""), ops)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp ServerConfigDBResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// admin_emails differs between bootstrap (["bootstrap@example.com"]) and
+	// DB (["admin@db.com"]), so it should appear in superseded_keys for "access".
+	// user_access_mode is "open" in both → NOT superseded.
+	accessSup, ok := resp.SupersededKeys["access"]
+	if !ok {
+		t.Fatal("expected superseded_keys entry for 'access'")
+	}
+
+	found := false
+	for _, sk := range accessSup {
+		if sk.Key == "admin_emails" {
+			found = true
+			// Source should be "yaml" since bootstrap koanf was loaded from file-like config.
+			if sk.Source != "yaml" {
+				t.Errorf("admin_emails source: want 'yaml', got %q", sk.Source)
+			}
+		}
+		if sk.Key == "user_access_mode" {
+			t.Error("user_access_mode should NOT be superseded (values match)")
+		}
+	}
+	if !found {
+		t.Errorf("expected admin_emails in superseded_keys, got %+v", accessSup)
+	}
+}
+
+func TestGetServerConfigDB_SupersededKeys_SeededSectionExcluded(t *testing.T) {
+	fakeStore := newFakeHubSettingStore()
+	bootstrapK := newFileKoanf(t, map[string]interface{}{
+		"server.hub.admin_emails": []interface{}{"bootstrap@example.com"},
+	})
+	envK := emptyKoanf()
+	ops := NewOperationalSettings(fakeStore, bootstrapK, envK)
+
+	// Seed access as "seeded" — superseded keys only apply to "managed" sections.
+	fakeStore.seedWithOrigin("access", json.RawMessage(`{"admin_emails":["admin@db.com"]}`), "seeded")
+	_, _ = ops.Refresh(context.Background())
+
+	srv := &Server{
+		dbDriver:    "postgres",
+		maintenance: NewMaintenanceState(false, ""),
+	}
+	srv.SetOperationalSettings(ops)
+
+	rr := httptest.NewRecorder()
+	srv.handleGetServerConfigDB(rr, adminRequest(http.MethodGet, "/api/v1/admin/server-config", ""), ops)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp ServerConfigDBResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Seeded sections should not have superseded keys.
+	if resp.SupersededKeys != nil {
+		if _, ok := resp.SupersededKeys["access"]; ok {
+			t.Error("seeded sections should not appear in superseded_keys")
+		}
+	}
+}
+
+func TestGetServerConfigDB_DeprecatedEnvKeys(t *testing.T) {
+	fakeStore := newFakeHubSettingStore()
+	bootstrapK := emptyKoanf()
+
+	// envKoanf with a SCION_SERVER_* var targeting a Layer-1 key.
+	envK := newEnvKoanf(t, map[string]interface{}{
+		"server.hub.admin_emails": []interface{}{"env@example.com"},
+	})
+	ops := NewOperationalSettings(fakeStore, bootstrapK, envK)
+	_, _ = ops.Refresh(context.Background())
+
+	srv := &Server{
+		dbDriver:    "postgres",
+		maintenance: NewMaintenanceState(false, ""),
+	}
+	srv.SetOperationalSettings(ops)
+
+	rr := httptest.NewRecorder()
+	srv.handleGetServerConfigDB(rr, adminRequest(http.MethodGet, "/api/v1/admin/server-config", ""), ops)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp ServerConfigDBResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(resp.DeprecatedEnvKeys) == 0 {
+		t.Fatal("expected non-empty deprecated_env_keys")
+	}
+
+	found := false
+	for _, d := range resp.DeprecatedEnvKeys {
+		if d.KoanfKey == "server.hub.admin_emails" {
+			found = true
+			if d.SeedEquivalent == "" {
+				t.Error("expected non-empty seed_equivalent")
+			}
+			if d.EnvVar == "" {
+				t.Error("expected non-empty env_var")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected server.hub.admin_emails in deprecated_env_keys, got %+v", resp.DeprecatedEnvKeys)
+	}
+}
+
+func TestGetServerConfigDB_DeprecatedEnvKeys_EmptyWhenNoServerEnvVars(t *testing.T) {
+	srv, _, ops := newTestDBServer(t)
+
+	rr := httptest.NewRecorder()
+	srv.handleGetServerConfigDB(rr, adminRequest(http.MethodGet, "/api/v1/admin/server-config", ""), ops)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp ServerConfigDBResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(resp.DeprecatedEnvKeys) != 0 {
+		t.Errorf("expected no deprecated_env_keys, got %+v", resp.DeprecatedEnvKeys)
+	}
+}
+
+func TestFileMode_SettingsTierIsFile(t *testing.T) {
+	srv := &Server{
+		maintenance: NewMaintenanceState(false, ""),
+	}
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/server-config", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminServerConfig(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if resp["settings_tier"] != "file" {
+		t.Errorf("file mode settings_tier: want 'file', got %v", resp["settings_tier"])
+	}
 }
 
 // ---- N2: Extract server.env and auth.DevMode tests ----

--- a/pkg/hub/admin_settings_db_test.go
+++ b/pkg/hub/admin_settings_db_test.go
@@ -1974,3 +1974,187 @@ func TestGetServerConfigSchema_MethodNotAllowed(t *testing.T) {
 		t.Errorf("expected 405 for POST, got %d", rr.Code)
 	}
 }
+
+// ---- #391: Boolean and field-clearing round-trip correctness ----
+
+func TestRoundTrip_AutoSuspendStalled_TruePersists(t *testing.T) {
+	srv, _, ops := newTestDBServer(t)
+
+	body := `{
+		"server": {
+			"hub": {"auto_suspend_stalled": true}
+		}
+	}`
+	req := adminRequest(http.MethodPut, "/api/v1/admin/server-config", body)
+	rr := httptest.NewRecorder()
+	srv.handlePutServerConfigDB(rr, req, ops)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PUT: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	snap := ops.Snapshot()
+	if !snap.AutoSuspendStalled {
+		t.Error("#391: AutoSuspendStalled should be true after saving true")
+	}
+}
+
+func TestRoundTrip_AutoSuspendStalled_FalsePersists(t *testing.T) {
+	srv, fakeStore, ops := newTestDBServer(t)
+
+	// First set it to true.
+	fakeStore.seed("lifecycle", json.RawMessage(`{"auto_suspend_stalled":true}`))
+	_, _ = ops.Refresh(context.Background())
+	if !ops.Snapshot().AutoSuspendStalled {
+		t.Fatal("precondition: AutoSuspendStalled should be true")
+	}
+
+	// Now set it to false.
+	body := `{
+		"server": {
+			"hub": {"auto_suspend_stalled": false}
+		}
+	}`
+	req := adminRequest(http.MethodPut, "/api/v1/admin/server-config", body)
+	rr := httptest.NewRecorder()
+	srv.handlePutServerConfigDB(rr, req, ops)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PUT: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	snap := ops.Snapshot()
+	if snap.AutoSuspendStalled {
+		t.Error("#391: AutoSuspendStalled should be false after saving false, not reverted to default/true")
+	}
+}
+
+func TestRoundTrip_AdminEmails_SetThenClear(t *testing.T) {
+	srv, _, ops := newTestDBServer(t)
+
+	// Step 1: Set admin_emails to ["a@b.com"].
+	body := `{
+		"server": {
+			"hub": {"admin_emails": ["a@b.com"]},
+			"auth": {"user_access_mode": "open"}
+		}
+	}`
+	req := adminRequest(http.MethodPut, "/api/v1/admin/server-config", body)
+	rr := httptest.NewRecorder()
+	srv.handlePutServerConfigDB(rr, req, ops)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PUT(set): expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	snap := ops.Snapshot()
+	if len(snap.AdminEmails) != 1 || snap.AdminEmails[0] != "a@b.com" {
+		t.Fatalf("precondition: AdminEmails should be [a@b.com], got %v", snap.AdminEmails)
+	}
+
+	// Step 2: Clear admin_emails to [].
+	body = `{
+		"server": {
+			"hub": {"admin_emails": []},
+			"auth": {"user_access_mode": "open"}
+		}
+	}`
+	req = adminRequest(http.MethodPut, "/api/v1/admin/server-config", body)
+	rr = httptest.NewRecorder()
+	srv.handlePutServerConfigDB(rr, req, ops)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PUT(clear): expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	snap = ops.Snapshot()
+	if len(snap.AdminEmails) != 0 {
+		t.Errorf("#391: AdminEmails should be empty after clearing to [], got %v", snap.AdminEmails)
+	}
+}
+
+func TestRoundTrip_TelemetryEnabled_FalsePersists(t *testing.T) {
+	srv, _, ops := newTestDBServer(t)
+
+	// Step 1: Set telemetry.enabled to true.
+	body := `{
+		"telemetry": {"enabled": true}
+	}`
+	req := adminRequest(http.MethodPut, "/api/v1/admin/server-config", body)
+	rr := httptest.NewRecorder()
+	srv.handlePutServerConfigDB(rr, req, ops)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PUT(true): expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	snap := ops.Snapshot()
+	if snap.TelemetryConfig == nil || snap.TelemetryConfig.Enabled == nil || !*snap.TelemetryConfig.Enabled {
+		t.Fatal("precondition: telemetry.enabled should be true")
+	}
+
+	// Step 2: Set telemetry.enabled to false.
+	body = `{
+		"telemetry": {"enabled": false}
+	}`
+	req = adminRequest(http.MethodPut, "/api/v1/admin/server-config", body)
+	rr = httptest.NewRecorder()
+	srv.handlePutServerConfigDB(rr, req, ops)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PUT(false): expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	snap = ops.Snapshot()
+	if snap.TelemetryConfig == nil || snap.TelemetryConfig.Enabled == nil {
+		t.Fatal("#391: telemetry.enabled should not be nil after saving false")
+	}
+	if *snap.TelemetryConfig.Enabled {
+		t.Error("#391: telemetry.enabled should be false after saving false, not reverted to default/true")
+	}
+}
+
+func TestRoundTrip_WebhooksEnabled_FalsePersists(t *testing.T) {
+	srv, fakeStore, ops := newTestDBServer(t)
+
+	// Seed with webhooks_enabled = true.
+	fakeStore.seed("github_app", json.RawMessage(`{"app_id":42,"webhooks_enabled":true}`))
+	_, _ = ops.Refresh(context.Background())
+	if !ops.Snapshot().GitHubWebhooksEnabled {
+		t.Fatal("precondition: GitHubWebhooksEnabled should be true")
+	}
+
+	// Set webhooks_enabled to false.
+	body := `{
+		"server": {
+			"github_app": {"app_id": 42, "webhooks_enabled": false}
+		}
+	}`
+	req := adminRequest(http.MethodPut, "/api/v1/admin/server-config", body)
+	rr := httptest.NewRecorder()
+	srv.handlePutServerConfigDB(rr, req, ops)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PUT: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify the section doc stores *false (not omitted).
+	fakeStore.mu.Lock()
+	row := fakeStore.settings["github_app"]
+	fakeStore.mu.Unlock()
+
+	var ga opsettings.GitHubAppSettings
+	if err := json.Unmarshal(row.Value, &ga); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if ga.WebhooksEnabled == nil {
+		t.Fatal("#391: WebhooksEnabled should be *false in section doc, not nil (omitted)")
+	}
+	if *ga.WebhooksEnabled {
+		t.Error("#391: WebhooksEnabled should be false in section doc")
+	}
+
+	// Verify snapshot reads back false.
+	snap := ops.Snapshot()
+	if snap.GitHubWebhooksEnabled {
+		t.Error("#391: GitHubWebhooksEnabled should be false after saving false")
+	}
+}

--- a/pkg/hub/admin_settings_db_test.go
+++ b/pkg/hub/admin_settings_db_test.go
@@ -537,7 +537,7 @@ func TestPutServerConfigDB_SchemaValidationFailure_NothingWritten(t *testing.T) 
 	// Actually, Go's json decoder is loose with types, so we use a different
 	// approach: directly call Update with a bad doc to test schema validation.
 	badDoc := json.RawMessage(`{"admin_emails": "not-an-array"}`)
-	_, err := ops.Update(context.Background(), "access", badDoc, "test@user.com", -1)
+	_, err := ops.Update(context.Background(), "access", badDoc, "test@user.com", -1, "managed")
 	if err == nil {
 		t.Fatal("expected validation error for bad access doc, got nil")
 	}
@@ -1556,7 +1556,7 @@ func TestPutServerConfigDB_CAS_MultiSection_PartialApply(t *testing.T) {
 
 	// Advance lifecycle to revision 2 so our expected_revision of 1 is stale.
 	_, _ = ops.Update(context.Background(), "lifecycle",
-		json.RawMessage(`{"soft_delete_retention":"48h"}`), "other@test.com", -1)
+		json.RawMessage(`{"soft_delete_retention":"48h"}`), "other@test.com", -1, "managed")
 
 	// PUT both sections: access with correct rev (1), lifecycle with stale rev (1).
 	// Sections are written alphabetically: access first (succeeds), lifecycle second (conflicts).

--- a/pkg/hub/admin_settings_db_test.go
+++ b/pkg/hub/admin_settings_db_test.go
@@ -2158,3 +2158,66 @@ func TestRoundTrip_WebhooksEnabled_FalsePersists(t *testing.T) {
 		t.Error("#391: GitHubWebhooksEnabled should be false after saving false")
 	}
 }
+
+// ---- DELETE /api/v1/admin/server-config/sections/{name} (reset) ----
+
+func TestResetSection_DeletesManagedSection(t *testing.T) {
+	srv, fakeStore, ops := newTestDBServer(t)
+
+	// Seed a managed section.
+	fakeStore.seedWithOrigin("access", json.RawMessage(`{"admin_emails":["admin@db.com"],"user_access_mode":"open"}`), "managed")
+	_, _ = ops.Refresh(context.Background())
+
+	rr := httptest.NewRecorder()
+	srv.handleAdminServerConfigSectionReset(rr, adminRequest(http.MethodDelete, "/api/v1/admin/server-config/sections/access", ""))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Row should be deleted.
+	fakeStore.mu.Lock()
+	_, exists := fakeStore.settings["access"]
+	fakeStore.mu.Unlock()
+	if exists {
+		t.Error("expected access row to be deleted after reset")
+	}
+}
+
+func TestResetSection_RejectsNonDelete(t *testing.T) {
+	srv, _, _ := newTestDBServer(t)
+
+	rr := httptest.NewRecorder()
+	srv.handleAdminServerConfigSectionReset(rr, adminRequest(http.MethodGet, "/api/v1/admin/server-config/sections/access", ""))
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rr.Code)
+	}
+}
+
+func TestResetSection_RejectsUnknownSection(t *testing.T) {
+	srv, _, _ := newTestDBServer(t)
+
+	rr := httptest.NewRecorder()
+	srv.handleAdminServerConfigSectionReset(rr, adminRequest(http.MethodDelete, "/api/v1/admin/server-config/sections/nonexistent", ""))
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rr.Code)
+	}
+}
+
+func TestResetSection_RequiresAdmin(t *testing.T) {
+	srv, _, _ := newTestDBServer(t)
+
+	// Non-admin request.
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/server-config/sections/access", nil)
+	viewer := NewAuthenticatedUser("u2", "viewer@example.com", "Viewer", "viewer", "cli")
+	r = r.WithContext(contextWithIdentity(r.Context(), viewer))
+
+	rr := httptest.NewRecorder()
+	srv.handleAdminServerConfigSectionReset(rr, r)
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", rr.Code)
+	}
+}

--- a/pkg/hub/admin_settings_db_test.go
+++ b/pkg/hub/admin_settings_db_test.go
@@ -814,8 +814,55 @@ func TestFileMode_ServerConfigDispatch(t *testing.T) {
 	if _, ok := resp["section_metadata"]; ok {
 		t.Error("file mode should not include section_metadata")
 	}
-	if _, ok := resp["env_overrides"]; ok {
-		t.Error("file mode should not include env_overrides")
+	// env_overrides IS included in file mode when SCION_SERVER_* vars are set
+	// (H1 fix). Without env vars, it's omitted.
+}
+
+func TestFileMode_EnvOverrides(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("SCION_SERVER_HUB_ADMINEMAILS", "admin@test.com")
+	t.Setenv("SCION_SERVER_DATABASE_DRIVER", "postgres")
+
+	srv := &Server{
+		maintenance: NewMaintenanceState(false, ""),
+	}
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/server-config", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminServerConfig(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("file-mode GET: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	overrides, ok := resp["env_overrides"]
+	if !ok {
+		t.Fatal("file-mode response should include env_overrides when SCION_SERVER_* vars are set")
+	}
+
+	overrideList, ok := overrides.([]interface{})
+	if !ok {
+		t.Fatalf("env_overrides should be an array, got %T", overrides)
+	}
+
+	found := make(map[string]bool)
+	for _, v := range overrideList {
+		found[v.(string)] = true
+	}
+
+	if !found["server.hub.admin_emails"] {
+		t.Error("expected server.hub.admin_emails in env_overrides")
+	}
+	if !found["server.database.driver"] {
+		t.Error("expected server.database.driver in env_overrides (all env keys reported)")
 	}
 }
 

--- a/pkg/hub/admin_settings_db_test.go
+++ b/pkg/hub/admin_settings_db_test.go
@@ -1340,6 +1340,7 @@ func TestGetServerConfigDB_SupersededKeys(t *testing.T) {
 	// admin_emails differs between bootstrap (["bootstrap@example.com"]) and
 	// DB (["admin@db.com"]), so it should appear in superseded_keys for "access".
 	// user_access_mode is "open" in both → NOT superseded.
+	// Keys must be full koanf paths so the frontend can match them.
 	accessSup, ok := resp.SupersededKeys["access"]
 	if !ok {
 		t.Fatal("expected superseded_keys entry for 'access'")
@@ -1347,19 +1348,21 @@ func TestGetServerConfigDB_SupersededKeys(t *testing.T) {
 
 	found := false
 	for _, sk := range accessSup {
-		if sk.Key == "admin_emails" {
+		if sk.Key == "server.hub.admin_emails" {
 			found = true
-			// Source should be "yaml" since bootstrap koanf was loaded from file-like config.
 			if sk.Source != "yaml" {
 				t.Errorf("admin_emails source: want 'yaml', got %q", sk.Source)
 			}
 		}
-		if sk.Key == "user_access_mode" {
+		if sk.Key == "admin_emails" {
+			t.Error("superseded key should use full koanf path, not section-level JSON key")
+		}
+		if sk.Key == "server.auth.user_access_mode" || sk.Key == "user_access_mode" {
 			t.Error("user_access_mode should NOT be superseded (values match)")
 		}
 	}
 	if !found {
-		t.Errorf("expected admin_emails in superseded_keys, got %+v", accessSup)
+		t.Errorf("expected server.hub.admin_emails in superseded_keys, got %+v", accessSup)
 	}
 }
 

--- a/pkg/hub/ha_e2e_test.go
+++ b/pkg/hub/ha_e2e_test.go
@@ -304,7 +304,7 @@ func seedForTest(ctx context.Context, s store.HubSettingStore, fileK *koanf.Koan
 		if err != nil {
 			continue
 		}
-		if _, err := s.UpsertHubSetting(ctx, sec.Name, doc, "seed", -1); err != nil {
+		if _, err := s.UpsertHubSetting(ctx, sec.Name, doc, "seed", -1, "seeded"); err != nil {
 			return err
 		}
 	}
@@ -314,7 +314,7 @@ func seedForTest(ctx context.Context, s store.HubSettingStore, fileK *koanf.Koan
 		"seeded_at":    time.Now().UTC().Format(time.RFC3339),
 		"seed_version": "1",
 	})
-	_, err = s.UpsertHubSetting(ctx, "_meta", metaDoc, "seed", -1)
+	_, err = s.UpsertHubSetting(ctx, "_meta", metaDoc, "seed", -1, "seeded")
 	return err
 }
 
@@ -445,7 +445,7 @@ func TestHA_AC5_EnvOverrideOneHub(t *testing.T) {
 	// Seed access section in DB.
 	_, err = cs.UpsertHubSetting(ctx, "access",
 		json.RawMessage(`{"admin_emails":["db@test.com"],"user_access_mode":"open"}`),
-		"seed", -1)
+		"seed", -1, "seeded")
 	require.NoError(t, err)
 
 	// Hub A: with env override on admin_emails.
@@ -508,7 +508,7 @@ func TestHA_AC7_ConcurrentCAS(t *testing.T) {
 	// Seed access section.
 	_, err := env.storeA.UpsertHubSetting(ctx, "access",
 		json.RawMessage(`{"admin_emails":["orig@test.com"],"user_access_mode":"open"}`),
-		"seed", -1)
+		"seed", -1, "seeded")
 	require.NoError(t, err)
 	_, err = env.opsA.Refresh(ctx)
 	require.NoError(t, err)
@@ -684,11 +684,11 @@ func TestHA_AC10_RollbackSafety(t *testing.T) {
 
 	_, err = cs.UpsertHubSetting(ctx, "access",
 		json.RawMessage(`{"admin_emails":["db@test.com"],"user_access_mode":"invite_only"}`),
-		"admin", -1)
+		"admin", -1, "managed")
 	require.NoError(t, err)
 	_, err = cs.UpsertHubSetting(ctx, "maintenance",
 		json.RawMessage(`{"admin_mode":true,"maintenance_message":"DB maintenance"}`),
-		"admin", -1)
+		"admin", -1, "managed")
 	require.NoError(t, err)
 	_ = client.Close()
 

--- a/pkg/hub/ha_e2e_test.go
+++ b/pkg/hub/ha_e2e_test.go
@@ -429,7 +429,7 @@ func TestHA_AC3_MaintenanceSurvivesRestart(t *testing.T) {
 	assert.Equal(t, "AC3 maintenance", srvA2.maintenance.Message())
 }
 
-// ----- AC5: Env override on one hub for Layer-1 key -----
+// ----- AC5: DB wins over env, superseded keys reported -----
 
 func TestHA_AC5_EnvOverrideOneHub(t *testing.T) {
 	requirePG(t)
@@ -442,26 +442,31 @@ func TestHA_AC5_EnvOverrideOneHub(t *testing.T) {
 	defer client.Close()
 	cs := entadapter.NewCompositeStore(client)
 
-	// Seed access section in DB.
+	// Write access section as "managed" (admin-written) with DB value.
 	_, err = cs.UpsertHubSetting(ctx, "access",
 		json.RawMessage(`{"admin_emails":["db@test.com"],"user_access_mode":"open"}`),
-		"seed", -1, "seeded")
+		"admin", -1, "managed")
 	require.NoError(t, err)
 
-	// Hub A: with env override on admin_emails.
+	// Hub A: env override on admin_emails + bootstrap koanf reflecting the env.
 	envKA := koanf.New(".")
 	require.NoError(t, envKA.Load(confmap.Provider(map[string]interface{}{
 		"server.hub.admin_emails": []interface{}{"env@test.com"},
 	}, "."), nil))
 
-	opsA := NewOperationalSettings(cs, koanf.New("."), envKA)
+	bootstrapA := koanf.New(".")
+	require.NoError(t, bootstrapA.Load(confmap.Provider(map[string]interface{}{
+		"server.hub.admin_emails": []interface{}{"env@test.com"},
+	}, "."), nil))
+
+	opsA := NewOperationalSettings(cs, bootstrapA, envKA)
 	_, err = opsA.Refresh(ctx)
 	require.NoError(t, err)
 
 	srvA := &Server{dbDriver: "postgres", maintenance: NewMaintenanceState(false, "")}
 	srvA.SetOperationalSettings(opsA)
 
-	// Hub B: no env override.
+	// Hub B: no env override, empty bootstrap.
 	opsB := NewOperationalSettings(cs, koanf.New("."), koanf.New("."))
 	_, err = opsB.Refresh(ctx)
 	require.NoError(t, err)
@@ -469,7 +474,7 @@ func TestHA_AC5_EnvOverrideOneHub(t *testing.T) {
 	srvB := &Server{dbDriver: "postgres", maintenance: NewMaintenanceState(false, "")}
 	srvB.SetOperationalSettings(opsB)
 
-	// GET on A should report env_overrides and serve env value.
+	// GET on A: DB value wins, env_overrides listed, superseded_keys reported.
 	rrA := httptest.NewRecorder()
 	srvA.handleGetServerConfigDB(rrA, adminReq(http.MethodGet, "/api/v1/admin/server-config", ""), opsA)
 	require.Equal(t, http.StatusOK, rrA.Code)
@@ -477,14 +482,26 @@ func TestHA_AC5_EnvOverrideOneHub(t *testing.T) {
 	var respA ServerConfigDBResponse
 	require.NoError(t, json.Unmarshal(rrA.Body.Bytes(), &respA))
 
-	assert.Contains(t, respA.EnvOverrides, "server.hub.admin_emails",
-		"AC5: A should report admin_emails in env_overrides")
 	require.NotNil(t, respA.Server)
 	require.NotNil(t, respA.Server.Hub)
-	assert.Equal(t, []string{"env@test.com"}, respA.Server.Hub.AdminEmails,
-		"AC5: A should serve env value for admin_emails")
+	assert.Equal(t, []string{"db@test.com"}, respA.Server.Hub.AdminEmails,
+		"AC5: DB value must win over env on hub A")
+	assert.Contains(t, respA.EnvOverrides, "server.hub.admin_emails",
+		"AC5: A should still list env key in env_overrides")
 
-	// GET on B should NOT report env_overrides and serve DB value.
+	require.Contains(t, respA.SupersededKeys, "access",
+		"AC5: managed access section should have superseded keys on A")
+	var foundAdmin bool
+	for _, sk := range respA.SupersededKeys["access"] {
+		if sk.Key == "admin_emails" {
+			foundAdmin = true
+			assert.Equal(t, "server_env", sk.Source,
+				"AC5: superseded admin_emails source should be server_env")
+		}
+	}
+	assert.True(t, foundAdmin, "AC5: admin_emails must appear in superseded_keys for access")
+
+	// GET on B: same DB value, no env_overrides, no superseded keys.
 	rrB := httptest.NewRecorder()
 	srvB.handleGetServerConfigDB(rrB, adminReq(http.MethodGet, "/api/v1/admin/server-config", ""), opsB)
 	require.Equal(t, http.StatusOK, rrB.Code)
@@ -492,11 +509,12 @@ func TestHA_AC5_EnvOverrideOneHub(t *testing.T) {
 	var respB ServerConfigDBResponse
 	require.NoError(t, json.Unmarshal(rrB.Body.Bytes(), &respB))
 
-	assert.Empty(t, respB.EnvOverrides, "AC5: B should have no env_overrides")
 	require.NotNil(t, respB.Server)
 	require.NotNil(t, respB.Server.Hub)
 	assert.Equal(t, []string{"db@test.com"}, respB.Server.Hub.AdminEmails,
 		"AC5: B should serve DB value for admin_emails")
+	assert.Empty(t, respB.EnvOverrides, "AC5: B should have no env_overrides")
+	assert.Empty(t, respB.SupersededKeys, "AC5: B should have no superseded_keys")
 }
 
 // ----- AC7: Concurrent PUTs with CAS -----

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand"
-	"os"
 	"sync"
 	"time"
 
@@ -51,7 +50,7 @@ type sectionState struct {
 //
 // Field population depends on the source:
 //   - Postgres mode (OperationalSettings.Snapshot): ALL fields are populated via
-//     the full koanf merge (env > DB > file > defaults). This includes
+//     the koanf merge (DB > bootstrap merge). This includes
 //     SoftDeleteRetention, SoftDeleteRetainFiles, PublicURL, ImageRegistry,
 //     DefaultTemplate, DefaultHarnessConfig, DefaultMaxTurns, DefaultMaxModelCalls,
 //     DefaultMaxDuration, DefaultResources, and NotificationChannels.
@@ -223,13 +222,13 @@ func (o *OperationalSettings) Refresh(ctx context.Context) ([]string, error) {
 
 // Snapshot returns an immutable merged Layer-1 view.
 //
-// Precedence (per §3.4):
+// Precedence (per design §3.1):
 //
-//	env > DB > file > defaults
+//	DB rows > bootstrap merge (defaults → SEED → yaml → SERVER)
 //
-// Absent-vs-empty: a DB row present for a section fully owns that section
-// (its omitted fields fall to compiled defaults, not to the file). A deleted
-// row restores file fallback for that section.
+// DB sections fully own their keys; absent sections fall back to the bootstrap
+// merge. Env vars are NOT merged on top — they feed the bootstrap layer and
+// are honored as seed input during the deprecation window.
 func (o *OperationalSettings) Snapshot() Layer1Snapshot {
 	o.mu.RLock()
 	dbSections := make(map[string]json.RawMessage, len(o.cache))
@@ -238,11 +237,10 @@ func (o *OperationalSettings) Snapshot() Layer1Snapshot {
 	}
 	o.mu.RUnlock()
 
-	// Build the merged koanf: start with file fallback, overlay DB sections,
-	// then overlay env.
+	// Build the merged koanf: bootstrap fallback, overlaid by DB sections.
 	merged := koanf.New(".")
 
-	// Layer: file fallback (lowest precedence for Layer-1 keys).
+	// Layer: bootstrap merge (lowest precedence for Layer-1 keys).
 	// Only load keys for sections NOT present in DB.
 	for _, sec := range opsettings.Registry {
 		if _, inDB := dbSections[sec.Name]; inDB {
@@ -259,18 +257,9 @@ func (o *OperationalSettings) Snapshot() Layer1Snapshot {
 		_ = loadSectionDocIntoKoanf(merged, sec.Name, doc)
 	}
 
-	// Layer: DB sections.
+	// Layer: DB sections (highest precedence — DB wins over bootstrap).
 	for name, doc := range dbSections {
 		_ = loadSectionDocIntoKoanf(merged, name, doc)
-	}
-
-	// Layer: env overrides (highest precedence).
-	if o.envKoanf != nil {
-		for _, key := range o.envKoanf.Keys() {
-			if opsettings.IsLayer1Key(key) {
-				_ = merged.Set(key, o.envKoanf.Get(key))
-			}
-		}
 	}
 
 	snap := buildSnapshotFromKoanf(merged)
@@ -742,33 +731,15 @@ func ApplySnapshot(s *Server, snap Layer1Snapshot) map[string]interface{} {
 //   - If snap.HasMaintenanceRow is true: apply DB values, UNLESS the
 //     SCION_SERVER_ADMIN_MODE env var is set (per-node break-glass override).
 //
-// Phase 4 will call this on propagation events — a changed maintenance row
-// propagated from another node MUST apply, but env force-enable still wins
-// on this node.
+// ApplyMaintenanceFromSnapshot applies the maintenance settings from the
+// snapshot to the server's maintenance state. In HA mode, maintenance must
+// be cluster-consistent — per-node env force-win is removed.
 func ApplyMaintenanceFromSnapshot(s *Server, snap Layer1Snapshot) {
 	if !snap.HasMaintenanceRow {
-		// No maintenance row in DB — leave MaintenanceState as initialized
-		// at startup (which already honors the env var).
 		return
 	}
 
-	adminMode := snap.AdminMode
-	message := snap.MaintenanceMessage
-
-	// SCION_SERVER_ADMIN_MODE env var overrides bidirectionally: it can
-	// force-enable OR force-disable admin mode on this node, matching the
-	// pre-existing startup semantics in cmd/server_foreground.go:80-82.
-	// The design doc says "force-enables" but we keep parity with existing
-	// behavior (which parses the value as a boolean). The docs phase will
-	// document the bidirectional override.
-	if v := os.Getenv("SCION_SERVER_ADMIN_MODE"); v != "" {
-		adminMode = v == "true" || v == "1" || v == "yes"
-	}
-	if v := os.Getenv("SCION_SERVER_MAINTENANCE_MESSAGE"); v != "" {
-		message = v
-	}
-
-	s.maintenance.Set(adminMode, message)
+	s.maintenance.Set(snap.AdminMode, snap.MaintenanceMessage)
 }
 
 // applySnapshotLogLevel applies the log-level portion of the snapshot.

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -41,6 +41,7 @@ type sectionState struct {
 	Revision  int64
 	UpdatedAt time.Time
 	UpdatedBy string
+	Origin    string
 }
 
 // Layer1Snapshot is an immutable merged view of all Layer-1 operational settings.
@@ -130,7 +131,7 @@ type SettingsUpdatedEvent struct {
 // In file/SQLite mode the legacy reloadSettings path is used instead.
 type OperationalSettings struct {
 	store        store.HubSettingStore
-	fileFallback *koanf.Koanf    // Layer-1 keys from settings.yaml + defaults (file values only, never env)
+	bootstrapKoanf *koanf.Koanf    // Full bootstrap merge: defaults → SEED → yaml → SERVER
 	envOverrides map[string]bool // Layer-1 koanf keys satisfied by env
 	envKoanf     *koanf.Koanf    // env-only koanf for merge
 	mu           sync.RWMutex
@@ -154,13 +155,12 @@ type OperationalSettings struct {
 
 // NewOperationalSettings creates a new OperationalSettings service.
 //
-// fileFallback is a koanf instance loaded from settings.yaml (file values only,
-// no env overlay) representing the Layer-1 fallback when a section is absent
-// from the DB. envKoanf is a koanf instance containing only SCION_SERVER_*
-// environment variable keys for the precedence merge.
+// bootstrapKoanf is the full bootstrap merge (defaults → SEED → yaml → SERVER)
+// used as the fallback for sections absent from the DB. envKoanf is retained
+// only for env-override detection; it is NOT merged into Snapshot.
 func NewOperationalSettings(
 	st store.HubSettingStore,
-	fileFallback *koanf.Koanf,
+	bootstrapKoanf *koanf.Koanf,
 	envKoanf *koanf.Koanf,
 ) *OperationalSettings {
 	envOverrides := make(map[string]bool)
@@ -170,7 +170,7 @@ func NewOperationalSettings(
 
 	return &OperationalSettings{
 		store:        st,
-		fileFallback: fileFallback,
+		bootstrapKoanf: bootstrapKoanf,
 		envOverrides: envOverrides,
 		envKoanf:     envKoanf,
 		cache:        make(map[string]sectionState),
@@ -206,6 +206,7 @@ func (o *OperationalSettings) Refresh(ctx context.Context) ([]string, error) {
 			Revision:  row.Revision,
 			UpdatedAt: row.UpdatedAt,
 			UpdatedBy: row.UpdatedBy,
+			Origin:    row.Origin,
 		}
 	}
 
@@ -251,7 +252,7 @@ func (o *OperationalSettings) Snapshot() Layer1Snapshot {
 			continue
 		}
 		// Extract this section from the file fallback and load it.
-		doc, err := opsettings.ExtractSectionFromKoanf(o.fileFallback, sec.Name)
+		doc, err := opsettings.ExtractSectionFromKoanf(o.bootstrapKoanf, sec.Name)
 		if err != nil {
 			continue
 		}
@@ -332,6 +333,7 @@ func (o *OperationalSettings) Update(
 		Revision:  result.Revision,
 		UpdatedAt: result.UpdatedAt,
 		UpdatedBy: result.UpdatedBy,
+		Origin:    result.Origin,
 	}
 	o.mu.Unlock()
 

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -313,13 +313,14 @@ func (o *OperationalSettings) Update(
 	doc json.RawMessage,
 	updatedBy string,
 	expectedRevision int64,
+	origin string,
 ) (int64, error) {
 	// Validate via opsettings registry.
 	if errs := opsettings.Validate(section, doc); len(errs) > 0 {
 		return 0, fmt.Errorf("validation failed for section %q: %v", section, errs)
 	}
 
-	result, err := o.store.UpsertHubSetting(ctx, section, doc, updatedBy, expectedRevision)
+	result, err := o.store.UpsertHubSetting(ctx, section, doc, updatedBy, expectedRevision, origin)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -129,12 +129,12 @@ type SettingsUpdatedEvent struct {
 // It is owned by the Server and used only when database.driver == "postgres".
 // In file/SQLite mode the legacy reloadSettings path is used instead.
 type OperationalSettings struct {
-	store        store.HubSettingStore
+	store          store.HubSettingStore
 	bootstrapKoanf *koanf.Koanf    // Full bootstrap merge: defaults → SEED → yaml → SERVER
-	envOverrides map[string]bool // Layer-1 koanf keys satisfied by env
-	envKoanf     *koanf.Koanf    // env-only koanf for merge
-	mu           sync.RWMutex
-	cache        map[string]sectionState // section name → cached value + revision
+	envOverrides   map[string]bool // Layer-1 koanf keys satisfied by env
+	envKoanf       *koanf.Koanf    // env-only koanf for merge
+	mu             sync.RWMutex
+	cache          map[string]sectionState // section name → cached value + revision
 
 	// Event publisher for cross-replica propagation (nil in SQLite/file mode).
 	events EventPublisher
@@ -168,11 +168,11 @@ func NewOperationalSettings(
 	}
 
 	return &OperationalSettings{
-		store:        st,
+		store:          st,
 		bootstrapKoanf: bootstrapKoanf,
-		envOverrides: envOverrides,
-		envKoanf:     envKoanf,
-		cache:        make(map[string]sectionState),
+		envOverrides:   envOverrides,
+		envKoanf:       envKoanf,
+		cache:          make(map[string]sectionState),
 	}
 }
 

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -349,6 +349,34 @@ func (o *OperationalSettings) Update(
 	return result.Revision, nil
 }
 
+// DeleteSection removes a section row from the store, evicts it from the local
+// cache, publishes an event so peers refresh, and self-applies. The section
+// falls back to bootstrap material immediately (design §3.2.4).
+func (o *OperationalSettings) DeleteSection(ctx context.Context, section string) error {
+	if err := o.store.DeleteHubSetting(ctx, section); err != nil {
+		return err
+	}
+
+	o.mu.Lock()
+	delete(o.cache, section)
+	o.mu.Unlock()
+
+	if o.events != nil {
+		o.events.PublishRaw(settingsUpdatedSubject, SettingsUpdatedEvent{
+			Section:  section,
+			Revision: 0,
+		})
+	}
+
+	if o.server != nil {
+		snap := o.Snapshot()
+		ApplySnapshot(o.server, snap)
+		ApplyMaintenanceFromSnapshot(o.server, snap)
+	}
+
+	return nil
+}
+
 // EnvOverriddenKeys returns the list of Layer-1 koanf keys that are overridden
 // by environment variables on this node.
 func (o *OperationalSettings) EnvOverriddenKeys() []string {

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -244,7 +244,12 @@ func (o *OperationalSettings) Snapshot() Layer1Snapshot {
 	// Only load keys for sections NOT present in DB.
 	for _, sec := range opsettings.Registry {
 		if _, inDB := dbSections[sec.Name]; inDB {
-			continue // DB fully owns this section
+			// DB rows must contain complete section documents. The Update
+			// path builds a full document from the PUT payload, so partial
+			// rows should not occur in normal operation. If a partial row
+			// is created externally, missing keys will have zero values
+			// rather than bootstrap defaults.
+			continue
 		}
 		if len(sec.KoanfPaths) == 0 {
 			continue

--- a/pkg/hub/operational_settings_propagation_test.go
+++ b/pkg/hub/operational_settings_propagation_test.go
@@ -90,7 +90,7 @@ func TestPublishOnUpdate_EmitsCorrectSubjectPayload(t *testing.T) {
 	ops.SetEventPublisher(fakeEP)
 
 	doc := json.RawMessage(`{"admin_emails":["admin@test.com"],"user_access_mode":"open"}`)
-	rev, err := ops.Update(context.Background(), "access", doc, "test@user.com", -1)
+	rev, err := ops.Update(context.Background(), "access", doc, "test@user.com", -1, "managed")
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestPublishOnUpdate_NoPublishWhenNoEventPublisher(t *testing.T) {
 	// No SetEventPublisher call — simulates SQLite mode.
 
 	doc := json.RawMessage(`{"admin_emails":["admin@test.com"]}`)
-	_, err := ops.Update(context.Background(), "access", doc, "test@user.com", -1)
+	_, err := ops.Update(context.Background(), "access", doc, "test@user.com", -1, "managed")
 	if err != nil {
 		t.Fatalf("Update should not fail without event publisher: %v", err)
 	}
@@ -434,7 +434,7 @@ func TestSQLiteMode_NoPublisherNoSubscriptionNoTicker(t *testing.T) {
 
 	// Update should succeed without publishing
 	doc := json.RawMessage(`{"admin_emails":["admin@test.com"]}`)
-	_, err := ops.Update(context.Background(), "access", doc, "test@user.com", -1)
+	_, err := ops.Update(context.Background(), "access", doc, "test@user.com", -1, "managed")
 	if err != nil {
 		t.Fatalf("Update in SQLite mode should not fail: %v", err)
 	}
@@ -470,7 +470,7 @@ func TestSelfApply_WritingNodeAppliesSynchronously(t *testing.T) {
 
 	// Update access section
 	doc := json.RawMessage(`{"admin_emails":["self-apply@test.com"],"user_access_mode":"invite_only"}`)
-	_, err := ops.Update(context.Background(), "access", doc, "test@user.com", -1)
+	_, err := ops.Update(context.Background(), "access", doc, "test@user.com", -1, "managed")
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
@@ -506,7 +506,7 @@ func TestSelfApply_MaintenanceAppliedSynchronously(t *testing.T) {
 
 	// Update maintenance section
 	doc := json.RawMessage(`{"admin_mode":true,"maintenance_message":"Self-applied maintenance"}`)
-	_, err := ops.Update(context.Background(), "maintenance", doc, "admin@test.com", -1)
+	_, err := ops.Update(context.Background(), "maintenance", doc, "admin@test.com", -1, "managed")
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
@@ -550,7 +550,7 @@ func TestConcurrentPropagation(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < iterations; j++ {
 				doc := json.RawMessage(`{"admin_emails":["concurrent@test.com"]}`)
-				_, _ = ops.Update(ctx, "access", doc, "test", -1)
+				_, _ = ops.Update(ctx, "access", doc, "test", -1, "managed")
 			}
 		}()
 	}

--- a/pkg/hub/operational_settings_propagation_test.go
+++ b/pkg/hub/operational_settings_propagation_test.go
@@ -240,9 +240,9 @@ func TestSubscription_MaintenanceApplied_WithoutEnvOverride(t *testing.T) {
 	}
 }
 
-func TestSubscription_MaintenanceNotOverridden_WhenEnvSet(t *testing.T) {
-	// When SCION_SERVER_ADMIN_MODE env is set, propagated maintenance changes
-	// should not override the env setting.
+func TestSubscription_MaintenancePropagated_EnvDoesNotOverride(t *testing.T) {
+	// In HA mode, propagated maintenance changes apply as-is — env does NOT
+	// override (cluster-consistency requirement).
 	setEnvForTest(t, "SCION_SERVER_ADMIN_MODE", "true")
 	setEnvForTest(t, "SCION_SERVER_MAINTENANCE_MESSAGE", "env-break-glass")
 
@@ -263,7 +263,7 @@ func TestSubscription_MaintenanceNotOverridden_WhenEnvSet(t *testing.T) {
 	ops.StartPropagation(ctx, srv)
 	defer ops.StopPropagation()
 
-	// Another replica disables maintenance via DB — but env should win here
+	// Another replica disables maintenance via DB.
 	fakeStore.mu.Lock()
 	fakeStore.settings["maintenance"] = &store.HubSetting{
 		ID:       "maintenance",
@@ -281,12 +281,12 @@ func TestSubscription_MaintenanceNotOverridden_WhenEnvSet(t *testing.T) {
 	// Give time for propagation
 	time.Sleep(500 * time.Millisecond)
 
-	// Env override should still win
-	if !srv.maintenance.IsEnabled() {
-		t.Error("maintenance should remain enabled (env override wins)")
+	// DB wins — env no longer overrides in HA mode.
+	if srv.maintenance.IsEnabled() {
+		t.Error("maintenance should be disabled (DB propagation wins, env no longer overrides)")
 	}
-	if srv.maintenance.Message() != "env-break-glass" {
-		t.Errorf("message should be 'env-break-glass', got %q", srv.maintenance.Message())
+	if srv.maintenance.Message() != "done" {
+		t.Errorf("message should be 'done', got %q", srv.maintenance.Message())
 	}
 }
 
@@ -378,9 +378,6 @@ func TestIdempotency_DoubleApply(t *testing.T) {
 	srv := &Server{
 		maintenance: NewMaintenanceState(false, ""),
 	}
-
-	setEnvForTest(t, "SCION_SERVER_ADMIN_MODE", "")
-	setEnvForTest(t, "SCION_SERVER_MAINTENANCE_MESSAGE", "")
 
 	snap := Layer1Snapshot{
 		AdminEmails:        []string{"admin@test.com"},

--- a/pkg/hub/operational_settings_test.go
+++ b/pkg/hub/operational_settings_test.go
@@ -137,6 +137,18 @@ func (f *fakeHubSettingStore) seed(section string, doc json.RawMessage) {
 	}
 }
 
+func (f *fakeHubSettingStore) seedWithOrigin(section string, doc json.RawMessage, origin string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.settings[section] = &store.HubSetting{
+		ID:       section,
+		Section:  section,
+		Value:    doc,
+		Revision: 1,
+		Origin:   origin,
+	}
+}
+
 // --- helpers ---
 
 func newFileKoanf(t *testing.T, flat map[string]interface{}) *koanf.Koanf {

--- a/pkg/hub/operational_settings_test.go
+++ b/pkg/hub/operational_settings_test.go
@@ -163,10 +163,10 @@ func emptyKoanf() *koanf.Koanf {
 
 // --- Tests ---
 
-func TestSnapshot_Precedence_EnvOverDBOverFileOverDefault(t *testing.T) {
-	// File says admin_emails = ["file@example.com"]
-	fileK := newFileKoanf(t, map[string]interface{}{
-		"server.hub.admin_emails":      []interface{}{"file@example.com"},
+func TestSnapshot_Precedence_DBOverBootstrap(t *testing.T) {
+	// Bootstrap merge says admin_emails = ["bootstrap@example.com"]
+	bootstrapK := newFileKoanf(t, map[string]interface{}{
+		"server.hub.admin_emails":      []interface{}{"bootstrap@example.com"},
 		"server.auth.user_access_mode": "open",
 	})
 
@@ -174,12 +174,12 @@ func TestSnapshot_Precedence_EnvOverDBOverFileOverDefault(t *testing.T) {
 	fakeStore := newFakeHubSettingStore()
 	fakeStore.seed("access", json.RawMessage(`{"admin_emails":["db@example.com"],"user_access_mode":"domain_restricted"}`))
 
-	// Env says admin_emails = ["env@example.com"]
+	// Env koanf is provided but NOT merged on top — only used for override detection.
 	envK := newEnvKoanf(t, map[string]interface{}{
 		"server.hub.admin_emails": []interface{}{"env@example.com"},
 	})
 
-	ops := NewOperationalSettings(fakeStore, fileK, envK)
+	ops := NewOperationalSettings(fakeStore, bootstrapK, envK)
 	_, err := ops.Refresh(context.Background())
 	if err != nil {
 		t.Fatalf("Refresh: %v", err)
@@ -187,14 +187,19 @@ func TestSnapshot_Precedence_EnvOverDBOverFileOverDefault(t *testing.T) {
 
 	snap := ops.Snapshot()
 
-	// env > DB > file: admin_emails should be from env
-	if len(snap.AdminEmails) != 1 || snap.AdminEmails[0] != "env@example.com" {
-		t.Errorf("AdminEmails: want [env@example.com], got %v", snap.AdminEmails)
+	// DB wins over bootstrap (env is NOT merged on top).
+	if len(snap.AdminEmails) != 1 || snap.AdminEmails[0] != "db@example.com" {
+		t.Errorf("AdminEmails: want [db@example.com], got %v", snap.AdminEmails)
 	}
 
-	// user_access_mode not overridden by env, so DB wins
 	if snap.UserAccessMode != "domain_restricted" {
 		t.Errorf("UserAccessMode: want domain_restricted, got %s", snap.UserAccessMode)
+	}
+
+	// Env overrides are still detected (for the GET response) even though
+	// they don't affect Snapshot merge.
+	if len(snap.EnvOverrides) != 1 || snap.EnvOverrides[0] != "server.hub.admin_emails" {
+		t.Errorf("EnvOverrides: want [server.hub.admin_emails], got %v", snap.EnvOverrides)
 	}
 }
 
@@ -655,14 +660,9 @@ func TestSnapshot_GitHubAppExcludesSecrets(t *testing.T) {
 
 // --- NB5 regression tests ---
 
-func TestApplyMaintenanceFromSnapshot_EnvWinsOverAbsentDBRow(t *testing.T) {
-	// Scenario: no maintenance row in DB, but SCION_SERVER_ADMIN_MODE=true env set.
-	// Expected: MaintenanceState retains whatever it was initialized with (env at startup).
-	// ApplyMaintenanceFromSnapshot should be a no-op when HasMaintenanceRow is false.
-	setEnvForTest(t, "SCION_SERVER_ADMIN_MODE", "true")
-
+func TestApplyMaintenanceFromSnapshot_NoOpWhenNoDBRow(t *testing.T) {
 	srv := &Server{
-		maintenance: NewMaintenanceState(true, "env-set"), // initialized from env at startup
+		maintenance: NewMaintenanceState(true, "startup-value"),
 	}
 
 	snap := Layer1Snapshot{
@@ -672,49 +672,16 @@ func TestApplyMaintenanceFromSnapshot_EnvWinsOverAbsentDBRow(t *testing.T) {
 
 	ApplyMaintenanceFromSnapshot(srv, snap)
 
-	// Should remain as initialized — no-op because no DB row.
+	// No-op when HasMaintenanceRow is false — retains startup state.
 	if !srv.maintenance.IsEnabled() {
 		t.Error("want maintenance enabled (no-op when HasMaintenanceRow=false)")
 	}
-	if srv.maintenance.Message() != "env-set" {
-		t.Errorf("want message 'env-set', got %q", srv.maintenance.Message())
+	if srv.maintenance.Message() != "startup-value" {
+		t.Errorf("want message 'startup-value', got %q", srv.maintenance.Message())
 	}
 }
 
-func TestApplyMaintenanceFromSnapshot_EnvWinsOverFalseDBRow(t *testing.T) {
-	// Scenario: maintenance row exists in DB with admin_mode=false,
-	// but SCION_SERVER_ADMIN_MODE=true env var is set (break-glass).
-	// Expected: env wins — maintenance enabled.
-	setEnvForTest(t, "SCION_SERVER_ADMIN_MODE", "true")
-	setEnvForTest(t, "SCION_SERVER_MAINTENANCE_MESSAGE", "env-break-glass")
-
-	srv := &Server{
-		maintenance: NewMaintenanceState(false, ""),
-	}
-
-	snap := Layer1Snapshot{
-		AdminMode:          false,
-		MaintenanceMessage: "from-db",
-		HasMaintenanceRow:  true, // DB row exists
-	}
-
-	ApplyMaintenanceFromSnapshot(srv, snap)
-
-	if !srv.maintenance.IsEnabled() {
-		t.Error("want maintenance enabled (env override wins)")
-	}
-	if srv.maintenance.Message() != "env-break-glass" {
-		t.Errorf("want message 'env-break-glass', got %q", srv.maintenance.Message())
-	}
-}
-
-func TestApplyMaintenanceFromSnapshot_DBRowAppliedWhenNoEnv(t *testing.T) {
-	// Scenario: maintenance row exists in DB with admin_mode=true,
-	// no env override set. Expected: DB values applied.
-	// Ensure env vars are unset by t.Setenv (overrides then restores).
-	setEnvForTest(t, "SCION_SERVER_ADMIN_MODE", "")
-	setEnvForTest(t, "SCION_SERVER_MAINTENANCE_MESSAGE", "")
-
+func TestApplyMaintenanceFromSnapshot_DBRowApplied(t *testing.T) {
 	srv := &Server{
 		maintenance: NewMaintenanceState(false, ""),
 	}
@@ -732,6 +699,33 @@ func TestApplyMaintenanceFromSnapshot_DBRowAppliedWhenNoEnv(t *testing.T) {
 	}
 	if srv.maintenance.Message() != "DB maintenance" {
 		t.Errorf("want message 'DB maintenance', got %q", srv.maintenance.Message())
+	}
+}
+
+func TestApplyMaintenanceFromSnapshot_EnvDoesNotOverrideDB(t *testing.T) {
+	// Env vars are set, but maintenance comes from DB — env no longer
+	// force-wins in HA mode (cluster-consistency requirement).
+	setEnvForTest(t, "SCION_SERVER_ADMIN_MODE", "true")
+	setEnvForTest(t, "SCION_SERVER_MAINTENANCE_MESSAGE", "env-msg")
+
+	srv := &Server{
+		maintenance: NewMaintenanceState(false, ""),
+	}
+
+	snap := Layer1Snapshot{
+		AdminMode:          false,
+		MaintenanceMessage: "from-db",
+		HasMaintenanceRow:  true,
+	}
+
+	ApplyMaintenanceFromSnapshot(srv, snap)
+
+	// DB wins — env does NOT override.
+	if srv.maintenance.IsEnabled() {
+		t.Error("want maintenance disabled (DB says false, env no longer overrides)")
+	}
+	if srv.maintenance.Message() != "from-db" {
+		t.Errorf("want message 'from-db', got %q", srv.maintenance.Message())
 	}
 }
 

--- a/pkg/hub/operational_settings_test.go
+++ b/pkg/hub/operational_settings_test.go
@@ -111,6 +111,20 @@ func (f *fakeHubSettingStore) DeleteHubSetting(_ context.Context, section string
 	return nil
 }
 
+func (f *fakeHubSettingStore) BackfillOrigin(_ context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for section, s := range f.settings {
+		if section == "_meta" {
+			continue
+		}
+		if s.UpdatedBy != "seed" && s.Origin == "seeded" {
+			s.Origin = "managed"
+		}
+	}
+	return nil
+}
+
 // helper to seed a section directly.
 func (f *fakeHubSettingStore) seed(section string, doc json.RawMessage) {
 	f.mu.Lock()

--- a/pkg/hub/operational_settings_test.go
+++ b/pkg/hub/operational_settings_test.go
@@ -67,7 +67,7 @@ func (f *fakeHubSettingStore) ListHubSettings(_ context.Context) ([]store.HubSet
 	return out, nil
 }
 
-func (f *fakeHubSettingStore) UpsertHubSetting(_ context.Context, section string, value json.RawMessage, updatedBy string, expectedRevision int64) (*store.HubSetting, error) {
+func (f *fakeHubSettingStore) UpsertHubSetting(_ context.Context, section string, value json.RawMessage, updatedBy string, expectedRevision int64, origin string) (*store.HubSetting, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -95,6 +95,7 @@ func (f *fakeHubSettingStore) UpsertHubSetting(_ context.Context, section string
 		Value:     value,
 		Revision:  rev,
 		UpdatedBy: updatedBy,
+		Origin:    origin,
 	}
 	f.settings[section] = s
 	return s, nil
@@ -315,7 +316,7 @@ func TestUpdate_ValidatesAndCaches(t *testing.T) {
 
 	// Valid access doc
 	doc := json.RawMessage(`{"admin_emails":["admin@test.com"],"user_access_mode":"open"}`)
-	rev, err := ops.Update(context.Background(), "access", doc, "test@user.com", -1)
+	rev, err := ops.Update(context.Background(), "access", doc, "test@user.com", -1, "managed")
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
@@ -336,7 +337,7 @@ func TestUpdate_ValidationFailure(t *testing.T) {
 
 	// Invalid access doc (admin_emails should be an array, not a string)
 	doc := json.RawMessage(`{"admin_emails":"not-an-array"}`)
-	_, err := ops.Update(context.Background(), "access", doc, "test@user.com", -1)
+	_, err := ops.Update(context.Background(), "access", doc, "test@user.com", -1, "managed")
 	if err == nil {
 		t.Fatal("expected validation error, got nil")
 	}

--- a/pkg/hub/operational_settings_test.go
+++ b/pkg/hub/operational_settings_test.go
@@ -429,9 +429,9 @@ func TestSnapshot_EnvOverrides_Listed(t *testing.T) {
 	if !overrides["server.auth.user_access_mode"] {
 		t.Error("expected server.auth.user_access_mode in EnvOverrides")
 	}
-	// Layer-0 key should NOT be in EnvOverrides (it's not a Layer-1 key)
-	if overrides["server.hub.port"] {
-		t.Error("server.hub.port is Layer-0 and should not be in EnvOverrides")
+	// After H1 generalization, all env keys are reported (including Layer-0).
+	if !overrides["server.hub.port"] {
+		t.Error("expected server.hub.port in EnvOverrides (all env keys reported)")
 	}
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2751,6 +2751,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/admin/invites", s.handleAdminInvites)
 	s.mux.HandleFunc("/api/v1/admin/invites/", s.handleAdminInviteByID)
 	s.mux.HandleFunc("/api/v1/admin/server-config/schema", s.handleAdminServerConfigSchema)
+	s.mux.HandleFunc("/api/v1/admin/server-config/sections/", s.handleAdminServerConfigSectionReset)
 	s.mux.HandleFunc("/api/v1/admin/server-config", s.handleAdminServerConfig)
 	s.mux.HandleFunc("/api/v1/admin/agents/reset-auth-all", s.handleAdminResetAuthAll)
 	s.mux.HandleFunc("/api/v1/admin/gcp-quota", s.handleAdminGCPQuota)

--- a/pkg/store/entadapter/hubsetting_store.go
+++ b/pkg/store/entadapter/hubsetting_store.go
@@ -60,6 +60,7 @@ func entHubSettingToStore(e *ent.HubSetting) *store.HubSetting {
 		Value:     e.Value,
 		Revision:  e.Revision,
 		UpdatedBy: e.UpdatedBy,
+		Origin:    string(e.Origin),
 		CreatedAt: e.CreateTime,
 		UpdatedAt: e.UpdateTime,
 	}
@@ -108,6 +109,7 @@ func (s *HubSettingStore) UpsertHubSetting(
 	value json.RawMessage,
 	updatedBy string,
 	expectedRevision int64,
+	origin string,
 ) (*store.HubSetting, error) {
 	// Detect dialect BEFORE opening a transaction — with SQLite's
 	// MaxOpenConns=1 the dialect-probe query would deadlock if the
@@ -140,6 +142,9 @@ func (s *HubSettingStore) UpsertHubSetting(
 			SetRevision(1)
 		if updatedBy != "" {
 			create.SetUpdatedBy(updatedBy)
+		}
+		if origin != "" {
+			create.SetOrigin(hubsetting.Origin(origin))
 		}
 		row, err := create.Save(ctx)
 		if err != nil {
@@ -180,6 +185,9 @@ func (s *HubSettingStore) UpsertHubSetting(
 		update.SetUpdatedBy(updatedBy)
 	} else {
 		update.ClearUpdatedBy()
+	}
+	if origin != "" {
+		update.SetOrigin(hubsetting.Origin(origin))
 	}
 	row, err := update.Save(ctx)
 	if err != nil {

--- a/pkg/store/entadapter/hubsetting_store.go
+++ b/pkg/store/entadapter/hubsetting_store.go
@@ -213,5 +213,26 @@ func (s *HubSettingStore) DeleteHubSetting(ctx context.Context, section string) 
 	return nil
 }
 
+// BackfillOrigin sets the origin column for existing rows that predate
+// the origin field. Rows with updated_by="seed" keep origin="seeded" (the
+// column default). Rows with updated_by!="seed" (admin writes) get
+// origin="managed". The _meta row is exempt. Idempotent — rows that
+// already have the correct origin are unaffected because the column
+// default is "seeded" and this only updates the non-seed rows.
+func (s *HubSettingStore) BackfillOrigin(ctx context.Context) error {
+	_, err := s.client.HubSetting.Update().
+		Where(
+			hubsetting.UpdatedByNEQ("seed"),
+			hubsetting.SectionNEQ("_meta"),
+			hubsetting.OriginEQ(hubsetting.OriginSeeded),
+		).
+		SetOrigin(hubsetting.OriginManaged).
+		Save(ctx)
+	if err != nil {
+		return fmt.Errorf("backfill origin: %w", err)
+	}
+	return nil
+}
+
 // Compile-time assertion.
 var _ store.HubSettingStore = (*HubSettingStore)(nil)

--- a/pkg/store/entadapter/hubsetting_store_test.go
+++ b/pkg/store/entadapter/hubsetting_store_test.go
@@ -290,3 +290,100 @@ func TestUpsertHubSetting_ConcurrentCASRace(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), final.Revision)
 }
+
+// =============================================================================
+// Origin field behavior
+// =============================================================================
+
+func TestUpsertHubSetting_OriginSetOnCreate(t *testing.T) {
+	s := newTestHubSettingStore(t)
+	ctx := context.Background()
+
+	got, err := s.UpsertHubSetting(ctx, "access", json.RawMessage(`{}`), "seed", -1, "seeded")
+	require.NoError(t, err)
+	assert.Equal(t, "seeded", got.Origin)
+
+	got2, err := s.UpsertHubSetting(ctx, "telemetry", json.RawMessage(`{}`), "admin@test.com", 0, "managed")
+	require.NoError(t, err)
+	assert.Equal(t, "managed", got2.Origin)
+}
+
+func TestUpsertHubSetting_OriginDefaultsToSeeded(t *testing.T) {
+	s := newTestHubSettingStore(t)
+	ctx := context.Background()
+
+	got, err := s.UpsertHubSetting(ctx, "access", json.RawMessage(`{}`), "seed", -1, "")
+	require.NoError(t, err)
+	assert.Equal(t, "seeded", got.Origin)
+}
+
+func TestUpsertHubSetting_OriginUpdatedOnWrite(t *testing.T) {
+	s := newTestHubSettingStore(t)
+	ctx := context.Background()
+
+	// Create as seeded.
+	_, err := s.UpsertHubSetting(ctx, "access", json.RawMessage(`{"v":1}`), "seed", -1, "seeded")
+	require.NoError(t, err)
+
+	// Admin update flips to managed.
+	got, err := s.UpsertHubSetting(ctx, "access", json.RawMessage(`{"v":2}`), "admin@test.com", 1, "managed")
+	require.NoError(t, err)
+	assert.Equal(t, "managed", got.Origin)
+
+	// Verify persisted.
+	fetched, err := s.GetHubSetting(ctx, "access")
+	require.NoError(t, err)
+	assert.Equal(t, "managed", fetched.Origin)
+}
+
+// =============================================================================
+// BackfillOrigin
+// =============================================================================
+
+func TestBackfillOrigin(t *testing.T) {
+	s := newTestHubSettingStore(t)
+	ctx := context.Background()
+
+	// Create rows with different updated_by values (all default origin="seeded").
+	_, err := s.UpsertHubSetting(ctx, "access", json.RawMessage(`{}`), "seed", -1, "")
+	require.NoError(t, err)
+	_, err = s.UpsertHubSetting(ctx, "telemetry", json.RawMessage(`{}`), "admin@test.com", 0, "")
+	require.NoError(t, err)
+	_, err = s.UpsertHubSetting(ctx, "_meta", json.RawMessage(`{}`), "system", -1, "")
+	require.NoError(t, err)
+
+	// Run backfill.
+	err = s.BackfillOrigin(ctx)
+	require.NoError(t, err)
+
+	// "access" (updated_by=seed) → stays seeded.
+	access, err := s.GetHubSetting(ctx, "access")
+	require.NoError(t, err)
+	assert.Equal(t, "seeded", access.Origin)
+
+	// "telemetry" (updated_by=admin) → managed.
+	telemetry, err := s.GetHubSetting(ctx, "telemetry")
+	require.NoError(t, err)
+	assert.Equal(t, "managed", telemetry.Origin)
+
+	// "_meta" (exempt) → stays seeded.
+	meta, err := s.GetHubSetting(ctx, "_meta")
+	require.NoError(t, err)
+	assert.Equal(t, "seeded", meta.Origin)
+}
+
+func TestBackfillOrigin_Idempotent(t *testing.T) {
+	s := newTestHubSettingStore(t)
+	ctx := context.Background()
+
+	_, err := s.UpsertHubSetting(ctx, "access", json.RawMessage(`{}`), "admin@test.com", 0, "")
+	require.NoError(t, err)
+
+	// Run twice.
+	require.NoError(t, s.BackfillOrigin(ctx))
+	require.NoError(t, s.BackfillOrigin(ctx))
+
+	got, err := s.GetHubSetting(ctx, "access")
+	require.NoError(t, err)
+	assert.Equal(t, "managed", got.Origin)
+}

--- a/pkg/store/entadapter/hubsetting_store_test.go
+++ b/pkg/store/entadapter/hubsetting_store_test.go
@@ -56,7 +56,7 @@ func TestUpsertHubSetting_Create(t *testing.T) {
 	ctx := context.Background()
 
 	val := json.RawMessage(`{"admin_emails":["a@b.com"]}`)
-	got, err := s.UpsertHubSetting(ctx, "access", val, "admin@test.com", 0)
+	got, err := s.UpsertHubSetting(ctx, "access", val, "admin@test.com", 0, "")
 	require.NoError(t, err)
 
 	assert.Equal(t, "access", got.Section)
@@ -83,11 +83,11 @@ func TestUpsertHubSetting_CreateOnly_Conflict(t *testing.T) {
 	ctx := context.Background()
 
 	val := json.RawMessage(`{"enabled":true}`)
-	_, err := s.UpsertHubSetting(ctx, "telemetry", val, "admin@test.com", 0)
+	_, err := s.UpsertHubSetting(ctx, "telemetry", val, "admin@test.com", 0, "")
 	require.NoError(t, err)
 
 	// Second create-only for the same section should fail.
-	_, err = s.UpsertHubSetting(ctx, "telemetry", val, "other@test.com", 0)
+	_, err = s.UpsertHubSetting(ctx, "telemetry", val, "other@test.com", 0, "")
 	assert.ErrorIs(t, err, store.ErrRevisionConflict)
 }
 
@@ -101,13 +101,13 @@ func TestUpsertHubSetting_UpdateWithRevisionBump(t *testing.T) {
 
 	// Create.
 	v1 := json.RawMessage(`{"mode":"open"}`)
-	created, err := s.UpsertHubSetting(ctx, "access", v1, "admin@test.com", 0)
+	created, err := s.UpsertHubSetting(ctx, "access", v1, "admin@test.com", 0, "")
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), created.Revision)
 
 	// Update with correct revision.
 	v2 := json.RawMessage(`{"mode":"invite_only"}`)
-	updated, err := s.UpsertHubSetting(ctx, "access", v2, "admin2@test.com", 1)
+	updated, err := s.UpsertHubSetting(ctx, "access", v2, "admin2@test.com", 1, "")
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), updated.Revision)
 	assert.JSONEq(t, `{"mode":"invite_only"}`, string(updated.Value))
@@ -128,11 +128,11 @@ func TestUpsertHubSetting_CAS_Conflict(t *testing.T) {
 	ctx := context.Background()
 
 	val := json.RawMessage(`{"k":"v"}`)
-	_, err := s.UpsertHubSetting(ctx, "lifecycle", val, "admin@test.com", 0)
+	_, err := s.UpsertHubSetting(ctx, "lifecycle", val, "admin@test.com", 0, "")
 	require.NoError(t, err)
 
 	// Update with wrong revision → conflict.
-	_, err = s.UpsertHubSetting(ctx, "lifecycle", val, "admin@test.com", 99)
+	_, err = s.UpsertHubSetting(ctx, "lifecycle", val, "admin@test.com", 99, "")
 	assert.ErrorIs(t, err, store.ErrRevisionConflict)
 }
 
@@ -145,7 +145,7 @@ func TestUpsertHubSetting_CAS_MissingRow(t *testing.T) {
 	ctx := context.Background()
 
 	val := json.RawMessage(`{"k":"v"}`)
-	_, err := s.UpsertHubSetting(ctx, "nonexistent", val, "admin@test.com", 5)
+	_, err := s.UpsertHubSetting(ctx, "nonexistent", val, "admin@test.com", 5, "")
 	assert.ErrorIs(t, err, store.ErrRevisionConflict)
 }
 
@@ -159,13 +159,13 @@ func TestUpsertHubSetting_Unconditional(t *testing.T) {
 
 	// Create via unconditional upsert.
 	v1 := json.RawMessage(`{"a":1}`)
-	got, err := s.UpsertHubSetting(ctx, "maintenance", v1, "seed", -1)
+	got, err := s.UpsertHubSetting(ctx, "maintenance", v1, "seed", -1, "seeded")
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), got.Revision)
 
 	// Overwrite via unconditional upsert — should succeed regardless of revision.
 	v2 := json.RawMessage(`{"a":2}`)
-	got2, err := s.UpsertHubSetting(ctx, "maintenance", v2, "seed2", -1)
+	got2, err := s.UpsertHubSetting(ctx, "maintenance", v2, "seed2", -1, "")
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), got2.Revision)
 	assert.JSONEq(t, `{"a":2}`, string(got2.Value))
@@ -185,11 +185,11 @@ func TestListHubSettings(t *testing.T) {
 	assert.Empty(t, list)
 
 	// Create a few sections.
-	_, err = s.UpsertHubSetting(ctx, "access", json.RawMessage(`{}`), "", -1)
+	_, err = s.UpsertHubSetting(ctx, "access", json.RawMessage(`{}`), "", -1, "")
 	require.NoError(t, err)
-	_, err = s.UpsertHubSetting(ctx, "telemetry", json.RawMessage(`{}`), "", -1)
+	_, err = s.UpsertHubSetting(ctx, "telemetry", json.RawMessage(`{}`), "", -1, "")
 	require.NoError(t, err)
-	_, err = s.UpsertHubSetting(ctx, "maintenance", json.RawMessage(`{}`), "", -1)
+	_, err = s.UpsertHubSetting(ctx, "maintenance", json.RawMessage(`{}`), "", -1, "")
 	require.NoError(t, err)
 
 	list, err = s.ListHubSettings(ctx)
@@ -210,7 +210,7 @@ func TestDeleteHubSetting(t *testing.T) {
 	s := newTestHubSettingStore(t)
 	ctx := context.Background()
 
-	_, err := s.UpsertHubSetting(ctx, "access", json.RawMessage(`{}`), "", -1)
+	_, err := s.UpsertHubSetting(ctx, "access", json.RawMessage(`{}`), "", -1, "")
 	require.NoError(t, err)
 
 	err = s.DeleteHubSetting(ctx, "access")
@@ -238,11 +238,11 @@ func TestUpsertHubSetting_ClearsUpdatedBy(t *testing.T) {
 	ctx := context.Background()
 
 	// Create with updatedBy.
-	_, err := s.UpsertHubSetting(ctx, "access", json.RawMessage(`{}`), "admin@test.com", 0)
+	_, err := s.UpsertHubSetting(ctx, "access", json.RawMessage(`{}`), "admin@test.com", 0, "")
 	require.NoError(t, err)
 
 	// Update with empty updatedBy — should clear it.
-	got, err := s.UpsertHubSetting(ctx, "access", json.RawMessage(`{}`), "", 1)
+	got, err := s.UpsertHubSetting(ctx, "access", json.RawMessage(`{}`), "", 1, "")
 	require.NoError(t, err)
 	assert.Empty(t, got.UpdatedBy)
 }
@@ -256,7 +256,7 @@ func TestUpsertHubSetting_ConcurrentCASRace(t *testing.T) {
 	ctx := context.Background()
 
 	// Create the initial row.
-	_, err := s.UpsertHubSetting(ctx, "race", json.RawMessage(`{"v":0}`), "setup", 0)
+	_, err := s.UpsertHubSetting(ctx, "race", json.RawMessage(`{"v":0}`), "setup", 0, "")
 	require.NoError(t, err)
 
 	const goroutines = 10
@@ -271,7 +271,7 @@ func TestUpsertHubSetting_ConcurrentCASRace(t *testing.T) {
 		go func(n int) {
 			defer wg.Done()
 			val := json.RawMessage(`{"v":` + string(rune('0'+n)) + `}`)
-			_, err := s.UpsertHubSetting(ctx, "race", val, "racer", 1)
+			_, err := s.UpsertHubSetting(ctx, "race", val, "racer", 1, "")
 			if err == nil {
 				wins.Add(1)
 			} else {

--- a/pkg/store/integrationtest/hubsetting_contention_test.go
+++ b/pkg/store/integrationtest/hubsetting_contention_test.go
@@ -51,7 +51,7 @@ func TestContention_HubSettingCAS(t *testing.T) {
 
 	// Seed the row with revision 1.
 	val := json.RawMessage(`{"v":0}`)
-	_, err := cs.UpsertHubSetting(ctx, section, val, "setup", 0)
+	_, err := cs.UpsertHubSetting(ctx, section, val, "setup", 0, "")
 	require.NoError(t, err)
 
 	var wins, conflicts atomic.Int64
@@ -63,7 +63,7 @@ func TestContention_HubSettingCAS(t *testing.T) {
 	// revision 2 which mismatches their expectedRevision=1.
 	runConcurrently(n, func(i int) {
 		v := json.RawMessage(fmt.Sprintf(`{"v":%d}`, i))
-		_, err := cs.UpsertHubSetting(ctx, section, v, fmt.Sprintf("racer-%d", i), 1)
+		_, err := cs.UpsertHubSetting(ctx, section, v, fmt.Sprintf("racer-%d", i), 1, "")
 		switch {
 		case err == nil:
 			wins.Add(1)
@@ -104,7 +104,7 @@ func TestContention_HubSettingCreateOnly(t *testing.T) {
 	errs := make(chan error, n)
 
 	runConcurrently(n, func(i int) {
-		_, err := cs.UpsertHubSetting(ctx, section, val, fmt.Sprintf("creator-%d", i), 0)
+		_, err := cs.UpsertHubSetting(ctx, section, val, fmt.Sprintf("creator-%d", i), 0, "")
 		switch {
 		case err == nil:
 			wins.Add(1)

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -2083,6 +2083,7 @@ type HubSetting struct {
 	Value     json.RawMessage `json:"value"`
 	Revision  int64           `json:"revision"`
 	UpdatedBy string          `json:"updatedBy,omitempty"`
+	Origin    string          `json:"origin,omitempty"`
 	CreatedAt time.Time       `json:"createdAt"`
 	UpdatedAt time.Time       `json:"updatedAt"`
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1330,8 +1330,9 @@ type HubSettingStore interface {
 	//   expectedRevision == 0:  create-only; returns ErrRevisionConflict if the section already exists.
 	//   expectedRevision == -1: unconditional upsert (used for seeding); always succeeds.
 	//   expectedRevision > 0:   CAS update; returns ErrRevisionConflict if current revision != expectedRevision.
+	// origin must be "seeded" or "managed" — seed-writes pass "seeded", admin-PUT writes pass "managed".
 	UpsertHubSetting(ctx context.Context, section string, value json.RawMessage,
-		updatedBy string, expectedRevision int64) (*HubSetting, error)
+		updatedBy string, expectedRevision int64, origin string) (*HubSetting, error)
 
 	// DeleteHubSetting removes a hub setting by section name.
 	// Returns ErrNotFound if the section doesn't exist.

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1337,4 +1337,9 @@ type HubSettingStore interface {
 	// DeleteHubSetting removes a hub setting by section name.
 	// Returns ErrNotFound if the section doesn't exist.
 	DeleteHubSetting(ctx context.Context, section string) error
+
+	// BackfillOrigin sets the origin column for existing rows that predate
+	// the origin field. Rows with updated_by="seed" get origin="seeded";
+	// all other non-_meta rows get origin="managed". Idempotent.
+	BackfillOrigin(ctx context.Context) error
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -45,13 +45,24 @@
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
+        "happy-dom": "^20.10.6",
         "prettier": "^3.2.4",
         "typescript": "^5.3.3",
-        "vite": "^7.3.2"
+        "vite": "^7.3.2",
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@blazediff/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.20.1",
@@ -880,6 +891,13 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@kurkle/color": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
@@ -1088,6 +1106,15 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -1478,6 +1505,31 @@
         "url": "https://github.com/sponsors/claviska"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1517,6 +1569,23 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -1718,6 +1787,170 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@vitest/browser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.10.tgz",
+      "integrity": "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@blazediff/core": "1.9.1",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pngjs": "^7.0.0",
+        "sirv": "^3.0.2",
+        "tinyrainbow": "^3.1.0",
+        "ws": "^8.19.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.10"
+      }
+    },
+    "node_modules/@vitest/browser-playwright": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.10.tgz",
+      "integrity": "sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vitest/browser": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xterm/addon-clipboard": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-clipboard/-/addon-clipboard-0.1.0.tgz",
@@ -1836,6 +2069,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1883,6 +2126,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1891,6 +2147,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1955,6 +2221,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2045,6 +2318,26 @@
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -2310,6 +2603,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2318,6 +2621,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2578,6 +2891,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/happy-dom": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2821,6 +3153,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/marked": {
       "version": "17.0.5",
       "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
@@ -2873,6 +3215,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2905,6 +3259,20 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -3019,6 +3387,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3037,6 +3412,70 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/postcss": {
@@ -3287,6 +3726,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3306,6 +3769,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -3375,6 +3852,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3423,6 +3917,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3434,6 +3938,18 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4096,11 +4612,124 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -4116,6 +4745,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -4134,6 +4780,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,9 @@
     "lint:fix": "eslint src --ext .ts,.tsx --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css,json}\"",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.18.0",
@@ -57,8 +59,10 @@
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
+    "happy-dom": "^20.10.6",
     "prettier": "^3.2.4",
     "typescript": "^5.3.3",
-    "vite": "^7.3.2"
+    "vite": "^7.3.2",
+    "vitest": "^4.1.10"
   }
 }

--- a/web/src/components/pages/admin-server-config.test.ts
+++ b/web/src/components/pages/admin-server-config.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const MOCK_CONFIG_RESPONSE = {
+  schema_version: '1',
+  scion_version: '0.1.0-test',
+  scion_commit: 'abc123',
+  scion_build_time: '2026-01-01T00:00:00Z',
+  active_profile: 'default',
+  image_registry: 'ghcr.io/test',
+  server: {
+    mode: 'standalone',
+    log_level: 'info',
+    hub: { port: 8080, host: '0.0.0.0' },
+    database: { driver: 'sqlite' },
+    auth: { dev_mode: false },
+    storage: { provider: 'local' },
+    secrets: { provider: 'env' },
+  },
+};
+
+function mockFetch(url: string | URL | Request): Promise<Response> {
+  const path = typeof url === 'string' ? url : url instanceof URL ? url.pathname : url.url;
+
+  if (path.includes('/api/v1/admin/server-config')) {
+    return Promise.resolve(new Response(JSON.stringify(MOCK_CONFIG_RESPONSE), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+  }
+
+  if (path.includes('/api/v1/github-app/installations')) {
+    return Promise.resolve(new Response(JSON.stringify([]), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+  }
+
+  if (path.includes('/api/v1/github-app')) {
+    return Promise.resolve(new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+  }
+
+  return Promise.resolve(new Response(JSON.stringify([]), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  }));
+}
+
+describe('scion-page-admin-server-config', () => {
+  let element: HTMLElement;
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(mockFetch));
+  });
+
+  afterEach(() => {
+    element?.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('renders without errors', async () => {
+    const { ScionPageAdminServerConfig } = await import('./admin-server-config.js');
+    element = document.createElement('scion-page-admin-server-config');
+    document.body.appendChild(element);
+
+    await (element as InstanceType<typeof ScionPageAdminServerConfig>).updateComplete;
+
+    expect(element).toBeInstanceOf(ScionPageAdminServerConfig);
+    expect(element.shadowRoot).toBeTruthy();
+  });
+
+  it('calls the config API on connect', async () => {
+    await import('./admin-server-config.js');
+    element = document.createElement('scion-page-admin-server-config');
+    document.body.appendChild(element);
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/admin/server-config'),
+      expect.any(Object),
+    );
+  });
+
+  it('displays config data after loading', async () => {
+    const { ScionPageAdminServerConfig } = await import('./admin-server-config.js');
+    element = document.createElement('scion-page-admin-server-config');
+    document.body.appendChild(element);
+
+    const el = element as InstanceType<typeof ScionPageAdminServerConfig>;
+    await el.updateComplete;
+    // Wait for async loadConfig to complete and trigger re-render
+    await new Promise(resolve => setTimeout(resolve, 100));
+    await el.updateComplete;
+
+    const shadow = el.shadowRoot!;
+    expect(shadow.innerHTML).toContain('0.1.0-test');
+  });
+});

--- a/web/src/components/pages/admin-server-config.test.ts
+++ b/web/src/components/pages/admin-server-config.test.ts
@@ -1,101 +1,609 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
 
-const MOCK_CONFIG_RESPONSE = {
-  schema_version: '1',
-  scion_version: '0.1.0-test',
-  scion_commit: 'abc123',
-  scion_build_time: '2026-01-01T00:00:00Z',
-  active_profile: 'default',
-  image_registry: 'ghcr.io/test',
-  server: {
-    mode: 'standalone',
-    log_level: 'info',
-    hub: { port: 8080, host: '0.0.0.0' },
-    database: { driver: 'sqlite' },
-    auth: { dev_mode: false },
-    storage: { provider: 'local' },
-    secrets: { provider: 'env' },
+// ── Shared mock data builders ──
+
+function makeBaseConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    schema_version: '1',
+    scion_version: '0.1.0-test',
+    scion_commit: 'abc123',
+    scion_build_time: '2026-01-01T00:00:00Z',
+    active_profile: 'default',
+    default_template: 'gemini',
+    image_registry: 'ghcr.io/test',
+    server: {
+      mode: 'standalone',
+      log_level: 'info',
+      log_format: 'text',
+      hub: {
+        port: 8080,
+        host: '0.0.0.0',
+        admin_emails: ['admin@example.com'],
+        public_url: 'https://hub.example.com',
+        soft_delete_retention: '72h',
+        soft_delete_retain_files: true,
+        auto_suspend_stalled: false,
+      },
+      broker: { enabled: false },
+      database: { driver: 'postgres', url: '********' },
+      auth: { dev_mode: false, user_access_mode: 'open', authorized_domains: '' },
+      storage: { provider: 'local', local_path: '/data' },
+      secrets: { provider: 'env' },
+    },
+    telemetry: {
+      enabled: false,
+      cloud: { enabled: false },
+      hub: { enabled: false },
+      local: { enabled: false },
+    },
+    ...overrides,
+  };
+}
+
+const SCHEMA_RESPONSE = {
+  sections: {
+    access: { koanf_paths: ['server.hub.admin_emails', 'server.auth.user_access_mode', 'server.auth.authorized_domains'] },
+    lifecycle: { koanf_paths: ['server.hub.auto_suspend_stalled', 'server.hub.soft_delete_retention', 'server.hub.soft_delete_retain_files'] },
+    endpoints: { koanf_paths: ['server.hub.public_url', 'image_registry'] },
+    agent_defaults: { koanf_paths: ['default_template', 'default_harness_config', 'default_max_turns', 'default_max_model_calls', 'default_max_duration', 'default_resources'] },
+    telemetry: { koanf_paths: ['telemetry.enabled', 'telemetry.cloud.enabled', 'telemetry.cloud.endpoint', 'telemetry.cloud.protocol', 'telemetry.cloud.provider', 'telemetry.hub.enabled', 'telemetry.hub.report_interval', 'telemetry.local.enabled', 'telemetry.local.file', 'telemetry.local.console'] },
+    notifications: { koanf_paths: ['server.notification_channels'] },
+    github_app: { koanf_paths: ['server.github_app', 'server.github_app.app_id', 'server.github_app.api_base_url', 'server.github_app.webhooks_enabled', 'server.github_app.installation_url', 'server.github_app.private_key_path'] },
   },
 };
 
-function mockFetch(url: string | URL | Request): Promise<Response> {
-  const path = typeof url === 'string' ? url : url instanceof URL ? url.pathname : url.url;
+function createFetchHandler(
+  configResponse: Record<string, unknown>,
+  opts?: {
+    schemaResponse?: Record<string, unknown> | null;
+    putHandler?: (body: Record<string, unknown>) => { status: number; body: Record<string, unknown> };
+  },
+) {
+  return (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const path = typeof url === 'string' ? url : url instanceof URL ? url.pathname : url.url;
 
-  if (path.includes('/api/v1/admin/server-config')) {
-    return Promise.resolve(new Response(JSON.stringify(MOCK_CONFIG_RESPONSE), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    }));
-  }
+    if (init?.method === 'PUT' && opts?.putHandler) {
+      const reqBody = JSON.parse(init.body as string);
+      const result = opts.putHandler(reqBody);
+      return Promise.resolve(new Response(JSON.stringify(result.body), {
+        status: result.status,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }
 
-  if (path.includes('/api/v1/github-app/installations')) {
+    if (path.includes('/api/v1/admin/server-config/schema')) {
+      if (opts?.schemaResponse === null) {
+        return Promise.resolve(new Response('', { status: 500 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify(opts?.schemaResponse ?? SCHEMA_RESPONSE), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }
+
+    if (path.includes('/api/v1/admin/server-config')) {
+      return Promise.resolve(new Response(JSON.stringify(configResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }
+
+    if (path.includes('/api/v1/github-app/installations')) {
+      return Promise.resolve(new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }
+
+    if (path.includes('/api/v1/github-app')) {
+      return Promise.resolve(new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }
+
     return Promise.resolve(new Response(JSON.stringify([]), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     }));
-  }
-
-  if (path.includes('/api/v1/github-app')) {
-    return Promise.resolve(new Response(JSON.stringify({}), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    }));
-  }
-
-  return Promise.resolve(new Response(JSON.stringify([]), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' },
-  }));
+  };
 }
 
-describe('scion-page-admin-server-config', () => {
-  let element: HTMLElement;
+// Import the component module once so the custom element is only registered once.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let ScionPageAdminServerConfig: any;
 
-  beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn(mockFetch));
+async function createComponent(
+  fetchHandler: (url: string | URL | Request, init?: RequestInit) => Promise<Response>,
+) {
+  vi.stubGlobal('fetch', vi.fn(fetchHandler));
+  const el = document.createElement('scion-page-admin-server-config') as InstanceType<typeof ScionPageAdminServerConfig>;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  await new Promise(resolve => setTimeout(resolve, 200));
+  await el.updateComplete;
+  return el;
+}
+
+function shadowText(el: HTMLElement): string {
+  return el.shadowRoot?.textContent ?? '';
+}
+
+function queryAll(el: HTMLElement, selector: string): Element[] {
+  return Array.from(el.shadowRoot?.querySelectorAll(selector) ?? []);
+}
+
+function query(el: HTMLElement, selector: string): Element | null {
+  return el.shadowRoot?.querySelector(selector) ?? null;
+}
+
+// ── Tests ──
+
+describe('scion-page-admin-server-config', () => {
+  let element: HTMLElement | null = null;
+
+  beforeAll(async () => {
+    vi.stubGlobal('fetch', vi.fn(createFetchHandler(makeBaseConfig())));
+    const mod = await import('./admin-server-config.js');
+    ScionPageAdminServerConfig = mod.ScionPageAdminServerConfig;
   });
 
   afterEach(() => {
     element?.remove();
+    element = null;
     vi.restoreAllMocks();
   });
 
+  // ── Smoke tests ──
+
   it('renders without errors', async () => {
-    const { ScionPageAdminServerConfig } = await import('./admin-server-config.js');
-    element = document.createElement('scion-page-admin-server-config');
-    document.body.appendChild(element);
-
-    await (element as InstanceType<typeof ScionPageAdminServerConfig>).updateComplete;
-
-    expect(element).toBeInstanceOf(ScionPageAdminServerConfig);
+    element = await createComponent(createFetchHandler(makeBaseConfig()));
     expect(element.shadowRoot).toBeTruthy();
+    expect(shadowText(element)).toContain('0.1.0-test');
   });
 
   it('calls the config API on connect', async () => {
-    await import('./admin-server-config.js');
-    element = document.createElement('scion-page-admin-server-config');
-    document.body.appendChild(element);
-
-    await new Promise(resolve => setTimeout(resolve, 50));
-
+    element = await createComponent(createFetchHandler(makeBaseConfig()));
     expect(vi.mocked(fetch)).toHaveBeenCalledWith(
       expect.stringContaining('/api/v1/admin/server-config'),
       expect.any(Object),
     );
   });
 
-  it('displays config data after loading', async () => {
-    const { ScionPageAdminServerConfig } = await import('./admin-server-config.js');
-    element = document.createElement('scion-page-admin-server-config');
-    document.body.appendChild(element);
+  // ── Criterion 1: Seeded lifecycle (UI aspects) ──
 
-    const el = element as InstanceType<typeof ScionPageAdminServerConfig>;
-    await el.updateComplete;
-    // Wait for async loadConfig to complete and trigger re-render
-    await new Promise(resolve => setTimeout(resolve, 100));
-    await el.updateComplete;
+  describe('Criterion 1 — Seeded lifecycle UI', () => {
+    it('managed section shows source metadata (source, revision, updated_by)', async () => {
+      const config = makeBaseConfig({
+        settings_tier: 'db',
+        section_metadata: {
+          endpoints: {
+            source: 'db',
+            revision: 5,
+            updated_by: 'admin@test.com',
+            updated_at: '2026-07-01T12:00:00Z',
+          },
+        },
+      });
+      element = await createComponent(createFetchHandler(config));
 
-    const shadow = el.shadowRoot!;
-    expect(shadow.innerHTML).toContain('0.1.0-test');
+      const metaEl = query(element, '.section-meta');
+      expect(metaEl).not.toBeNull();
+      const metaText = metaEl!.textContent ?? '';
+      expect(metaText).toContain('Source:');
+      expect(metaText).toContain('Database');
+      expect(metaText).toContain('rev 5');
+      expect(metaText).toContain('admin@test.com');
+    });
+
+    it('section metadata renders source:File for file-sourced sections', async () => {
+      const config = makeBaseConfig({
+        settings_tier: 'db',
+        section_metadata: {
+          lifecycle: { source: 'file' },
+        },
+      });
+      element = await createComponent(createFetchHandler(config));
+
+      const metaEl = query(element, '.section-meta');
+      expect(metaEl).not.toBeNull();
+      expect(metaEl!.textContent).toContain('File');
+    });
+
+    it('section metadata renders source:Default for default-sourced sections', async () => {
+      const config = makeBaseConfig({
+        settings_tier: 'db',
+        section_metadata: {
+          agent_defaults: { source: 'default' },
+        },
+      });
+      element = await createComponent(createFetchHandler(config));
+
+      const metaEl = query(element, '.section-meta');
+      expect(metaEl).not.toBeNull();
+      expect(metaEl!.textContent).toContain('Default');
+    });
+
+    it('does not render section metadata when absent (file/SQLite mode)', async () => {
+      element = await createComponent(createFetchHandler(makeBaseConfig()));
+
+      const metaEl = query(element, '.section-meta');
+      expect(metaEl).toBeNull();
+    });
+  });
+
+  // ── Criterion 3: DB mode, Layer-1 edit ──
+
+  describe('Criterion 3 — DB mode, Layer-1 fields editable', () => {
+    it('Layer-1 fields render as editable inputs (not read-only badges)', async () => {
+      const config = makeBaseConfig({ settings_tier: 'db' });
+      element = await createComponent(createFetchHandler(config));
+
+      const adminEmailsInput = query(element, 'sl-input[value="admin@example.com"]');
+      expect(adminEmailsInput).not.toBeNull();
+    });
+
+    it('PUT payload in DB mode includes only Layer-1 keys', async () => {
+      const config = makeBaseConfig({ settings_tier: 'db' });
+      let capturedPayload: Record<string, unknown> | null = null;
+
+      element = await createComponent(createFetchHandler(config, {
+        putHandler: (body) => {
+          capturedPayload = body;
+          return { status: 200, body: { reload: { applied: [] } } };
+        },
+      }));
+
+      const buttons = queryAll(element, 'sl-button[variant="primary"]');
+      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      expect(saveBtn).not.toBeNull();
+      (saveBtn as HTMLElement).click();
+      await new Promise(resolve => setTimeout(resolve, 300));
+      await (element as any).updateComplete;
+
+      expect(capturedPayload).not.toBeNull();
+      const server = capturedPayload!.server as Record<string, unknown> | undefined;
+      const hub = server?.hub as Record<string, unknown> | undefined;
+
+      // Layer-1 keys should be present
+      expect(hub).toBeDefined();
+      expect(hub!.admin_emails).toBeDefined();
+
+      // Layer-0 keys must be absent from the payload
+      expect(server?.mode).toBeUndefined();
+      expect(server?.log_level).toBeUndefined();
+      expect(server?.database).toBeUndefined();
+      expect(server?.storage).toBeUndefined();
+      expect(server?.secrets).toBeUndefined();
+      expect(server?.broker).toBeUndefined();
+      expect(capturedPayload!.active_profile).toBeUndefined();
+    });
+
+    it('PUT in DB mode does not trigger a 422', async () => {
+      const config = makeBaseConfig({ settings_tier: 'db' });
+      let putCalled = false;
+
+      element = await createComponent(createFetchHandler(config, {
+        putHandler: () => {
+          putCalled = true;
+          return { status: 200, body: { reload: { applied: [] } } };
+        },
+      }));
+
+      const buttons = queryAll(element, 'sl-button[variant="primary"]');
+      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      (saveBtn as HTMLElement).click();
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      expect(putCalled).toBe(true);
+      expect(query(element, '.safety-net-notice')).toBeNull();
+    });
+  });
+
+  // ── Criterion 4: DB mode, Layer-0 read-only ──
+
+  describe('Criterion 4 — DB mode, Layer-0 read-only', () => {
+    it('Layer-0 fields render as read-only with bootstrap badge', async () => {
+      const config = makeBaseConfig({ settings_tier: 'db' });
+      element = await createComponent(createFetchHandler(config));
+
+      const badges = queryAll(element, '.read-only-badge');
+      expect(badges.length).toBeGreaterThan(0);
+      const badgeTexts = badges.map(b => b.textContent ?? '');
+      expect(badgeTexts.some(t => t.includes('deployment configuration'))).toBe(true);
+    });
+
+    it('server.mode renders as read-only value (not editable select)', async () => {
+      const config = makeBaseConfig({ settings_tier: 'db' });
+      element = await createComponent(createFetchHandler(config));
+
+      const readOnlyValues = queryAll(element, '.read-only-value');
+      const values = readOnlyValues.map(el => el.textContent?.trim());
+      expect(values).toContain('standalone');
+    });
+
+    it('database.driver renders as read-only in DB mode', async () => {
+      const config = makeBaseConfig({ settings_tier: 'db' });
+      element = await createComponent(createFetchHandler(config));
+
+      const readOnlyValues = queryAll(element, '.read-only-value');
+      const values = readOnlyValues.map(el => el.textContent?.trim());
+      expect(values).toContain('postgres');
+    });
+
+    it('log_level renders as read-only in DB mode', async () => {
+      const config = makeBaseConfig({ settings_tier: 'db' });
+      element = await createComponent(createFetchHandler(config));
+
+      const readOnlyValues = queryAll(element, '.read-only-value');
+      const values = readOnlyValues.map(el => el.textContent?.trim());
+      expect(values).toContain('info');
+    });
+
+    it('hub.port renders as read-only in DB mode', async () => {
+      const config = makeBaseConfig({ settings_tier: 'db' });
+      element = await createComponent(createFetchHandler(config));
+
+      const readOnlyValues = queryAll(element, '.read-only-value');
+      const values = readOnlyValues.map(el => el.textContent?.trim());
+      expect(values).toContain('8080');
+    });
+
+    it('Layer-0 keys are absent from PUT payload in DB mode', async () => {
+      const config = makeBaseConfig({ settings_tier: 'db' });
+      let capturedPayload: Record<string, unknown> | null = null;
+
+      element = await createComponent(createFetchHandler(config, {
+        putHandler: (body) => {
+          capturedPayload = body;
+          return { status: 200, body: { reload: { applied: [] } } };
+        },
+      }));
+
+      const buttons = queryAll(element, 'sl-button[variant="primary"]');
+      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      (saveBtn as HTMLElement).click();
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      expect(capturedPayload).not.toBeNull();
+      const server = capturedPayload!.server as Record<string, unknown> | undefined;
+
+      expect(server?.mode).toBeUndefined();
+      expect(server?.log_level).toBeUndefined();
+      expect(server?.log_format).toBeUndefined();
+      expect(server?.database).toBeUndefined();
+      expect(server?.storage).toBeUndefined();
+      expect(server?.secrets).toBeUndefined();
+      expect(server?.broker).toBeUndefined();
+      expect(server?.message_broker).toBeUndefined();
+    });
+  });
+
+  // ── Criterion 6: File mode ──
+
+  describe('Criterion 6 — File mode', () => {
+    it('all fields editable when no env_overrides', async () => {
+      const config = makeBaseConfig({ settings_tier: 'file' });
+      element = await createComponent(createFetchHandler(config));
+
+      const badges = queryAll(element, '.read-only-badge');
+      expect(badges.length).toBe(0);
+    });
+
+    it('env-overridden field renders read-only with env badge', async () => {
+      const config = makeBaseConfig({
+        settings_tier: 'file',
+        env_overrides: ['server.hub.port'],
+      });
+      element = await createComponent(createFetchHandler(config));
+
+      const badges = queryAll(element, '.read-only-badge');
+      const badgeTexts = badges.map(b => b.textContent ?? '');
+      expect(badgeTexts.some(t => t.includes('environment variable'))).toBe(true);
+
+      const readOnlyValues = queryAll(element, '.read-only-value');
+      const values = readOnlyValues.map(el => el.textContent?.trim());
+      expect(values).toContain('8080');
+    });
+
+    it('env-pinned field is absent from file-mode PUT payload', async () => {
+      const config = makeBaseConfig({
+        settings_tier: 'file',
+        env_overrides: ['server.hub.port'],
+      });
+      let capturedPayload: Record<string, unknown> | null = null;
+
+      element = await createComponent(createFetchHandler(config, {
+        putHandler: (body) => {
+          capturedPayload = body;
+          return { status: 200, body: { reload: { applied: [] } } };
+        },
+      }));
+
+      const buttons = queryAll(element, 'sl-button[variant="primary"]');
+      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      (saveBtn as HTMLElement).click();
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      expect(capturedPayload).not.toBeNull();
+      const server = capturedPayload!.server as Record<string, unknown> | undefined;
+      const hub = server?.hub as Record<string, unknown> | undefined;
+
+      expect(hub?.port).toBeUndefined();
+      expect(hub?.admin_emails).toBeDefined();
+    });
+
+    it('non-env-overridden fields remain editable in file mode', async () => {
+      const config = makeBaseConfig({
+        settings_tier: 'file',
+        env_overrides: ['server.hub.port'],
+      });
+      element = await createComponent(createFetchHandler(config));
+
+      const adminInput = query(element, 'sl-input[value="admin@example.com"]');
+      expect(adminInput).not.toBeNull();
+    });
+
+    it('file mode PUT payload includes Layer-0 keys when no env overrides', async () => {
+      const config = makeBaseConfig({ settings_tier: 'file' });
+      let capturedPayload: Record<string, unknown> | null = null;
+
+      element = await createComponent(createFetchHandler(config, {
+        putHandler: (body) => {
+          capturedPayload = body;
+          return { status: 200, body: { reload: { applied: [] } } };
+        },
+      }));
+
+      const buttons = queryAll(element, 'sl-button[variant="primary"]');
+      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      (saveBtn as HTMLElement).click();
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      expect(capturedPayload).not.toBeNull();
+      const server = capturedPayload!.server as Record<string, unknown> | undefined;
+
+      expect(server?.mode).toBeDefined();
+      expect(server?.database).toBeDefined();
+      expect(server?.hub).toBeDefined();
+    });
+  });
+
+  // ── Criterion 8: Structured errors ──
+
+  describe('Criterion 8 — Structured error handling', () => {
+    it('400 validation_failed renders inline errors', async () => {
+      const config = makeBaseConfig({ settings_tier: 'db' });
+
+      element = await createComponent(createFetchHandler(config, {
+        putHandler: () => ({
+          status: 400,
+          body: {
+            error: 'validation_failed',
+            errors: {
+              access: [
+                { field: 'admin_emails', message: 'invalid email format' },
+              ],
+            },
+          },
+        }),
+      }));
+
+      const buttons = queryAll(element, 'sl-button[variant="primary"]');
+      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      (saveBtn as HTMLElement).click();
+      await new Promise(resolve => setTimeout(resolve, 300));
+      await (element as any).updateComplete;
+
+      const errorsEl = query(element, '.validation-errors');
+      expect(errorsEl).not.toBeNull();
+      const errText = errorsEl!.textContent ?? '';
+      expect(errText).toContain('invalid email format');
+      expect(errText).toContain('admin_emails');
+    });
+
+    it('409 revision_conflict renders conflict banner with Reload button', async () => {
+      const config = makeBaseConfig({ settings_tier: 'db' });
+
+      element = await createComponent(createFetchHandler(config, {
+        putHandler: () => ({
+          status: 409,
+          body: {
+            error: 'revision_conflict',
+            message: 'Settings have been changed since you loaded this page.',
+            conflicted: [{ section: 'access', expected_revision: 3, current_revision: 5 }],
+          },
+        }),
+      }));
+
+      const buttons = queryAll(element, 'sl-button[variant="primary"]');
+      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      (saveBtn as HTMLElement).click();
+      await new Promise(resolve => setTimeout(resolve, 300));
+      await (element as any).updateComplete;
+
+      const bannerEl = query(element, '.conflict-banner');
+      expect(bannerEl).not.toBeNull();
+      const bannerText = bannerEl!.textContent ?? '';
+      expect(bannerText).toContain('changed since you loaded');
+
+      const reloadBtn = bannerEl!.querySelector('sl-button');
+      expect(reloadBtn).not.toBeNull();
+      expect(reloadBtn!.textContent).toContain('Reload');
+    });
+
+    it('422 layer0_rejected renders safety net notice and logs keys', async () => {
+      const config = makeBaseConfig({ settings_tier: 'db' });
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      element = await createComponent(createFetchHandler(config, {
+        putHandler: () => ({
+          status: 422,
+          body: {
+            error: 'layer0_rejected',
+            keys: ['server.mode', 'server.database.driver'],
+          },
+        }),
+      }));
+
+      const buttons = queryAll(element, 'sl-button[variant="primary"]');
+      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      (saveBtn as HTMLElement).click();
+      await new Promise(resolve => setTimeout(resolve, 300));
+      await (element as any).updateComplete;
+
+      const noticeEl = query(element, '.safety-net-notice');
+      expect(noticeEl).not.toBeNull();
+      const noticeText = noticeEl!.textContent ?? '';
+      expect(noticeText).toContain('server.mode');
+      expect(noticeText).toContain('server.database.driver');
+      expect(noticeText).toContain('bootstrap');
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('layer0_rejected'),
+        expect.arrayContaining(['server.mode', 'server.database.driver']),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('unknown error falls back to generic error message', async () => {
+      const config = makeBaseConfig({ settings_tier: 'db' });
+
+      element = await createComponent(createFetchHandler(config, {
+        putHandler: () => ({
+          status: 500,
+          body: {
+            error: 'some_unknown_error',
+            message: 'Something went terribly wrong',
+          },
+        }),
+      }));
+
+      const buttons = queryAll(element, 'sl-button[variant="primary"]');
+      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      (saveBtn as HTMLElement).click();
+      await new Promise(resolve => setTimeout(resolve, 300));
+      await (element as any).updateComplete;
+
+      expect(shadowText(element)).toContain('Something went terribly wrong');
+    });
+  });
+
+  // ── Schema fallback ──
+
+  describe('Schema endpoint fallback', () => {
+    it('falls back to STATIC_LAYER1_KEYS when schema endpoint fails', async () => {
+      const config = makeBaseConfig({ settings_tier: 'db' });
+      element = await createComponent(createFetchHandler(config, { schemaResponse: null }));
+
+      const adminInput = query(element, 'sl-input[value="admin@example.com"]');
+      expect(adminInput).not.toBeNull();
+
+      const badges = queryAll(element, '.read-only-badge');
+      expect(badges.length).toBeGreaterThan(0);
+      const badgeTexts = badges.map(b => b.textContent ?? '');
+      expect(badgeTexts.some(t => t.includes('deployment configuration'))).toBe(true);
+    });
   });
 });

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -220,6 +220,7 @@ interface SectionMetadataInfo {
   revision?: number;
   updated_at?: string;
   updated_by?: string;
+  origin?: string; // "seeded" | "managed" (DB mode only)
 }
 
 /** Per-field validation error from a 400 validation_failed response. */
@@ -859,6 +860,16 @@ export class ScionPageAdminServerConfig extends LitElement {
 
     .section-meta-item sl-icon {
       font-size: 0.75rem;
+    }
+
+    /* ── Settings-DB: seeded section caption ── */
+
+    .seeded-caption {
+      font-size: 0.8125rem;
+      font-style: italic;
+      color: var(--scion-text-muted, #64748b);
+      margin-top: -0.5rem;
+      margin-bottom: 0.75rem;
     }
 
     /* ── Settings-DB: ignored keys notice ── */
@@ -1661,14 +1672,19 @@ export class ScionPageAdminServerConfig extends LitElement {
   }
 
   /**
-   * Renders a subtle per-section metadata caption showing source, revision,
-   * updated_by, and updated_at. Only renders when section_metadata is present
-   * in the GET response (postgres mode).
+   * Renders per-section origin caption. Seeded sections show a tracking message;
+   * managed sections show source/revision/updated_by/updated_at metadata.
    */
   private renderSectionMeta(sectionName: string): typeof nothing | ReturnType<typeof html> {
     if (!this.sectionMetadata) return nothing;
     const meta = this.sectionMetadata[sectionName];
     if (!meta) return nothing;
+
+    if (this.settingsTier === 'db' && meta.origin === 'seeded') {
+      return html`<div class="seeded-caption">
+        Tracking deployment configuration — will re-sync on restart until edited
+      </div>`;
+    }
 
     const sourceLabel =
       meta.source === 'db' ? 'Database' : meta.source === 'file' ? 'File' : 'Default';

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -1020,9 +1020,14 @@ export class ScionPageAdminServerConfig extends LitElement {
     try {
       const res = await apiFetch('/api/v1/admin/server-config/schema');
       if (!res.ok) return;
-      const data = (await res.json()) as { layer1_keys?: string[] };
-      if (data.layer1_keys && data.layer1_keys.length > 0) {
-        this.layer1Keys = new Set(data.layer1_keys);
+      const data = (await res.json()) as {
+        sections?: Record<string, { koanf_paths?: string[] }>;
+      };
+      if (data.sections) {
+        const keys = Object.values(data.sections).flatMap(
+          (s) => s.koanf_paths ?? [],
+        );
+        if (keys.length > 0) this.layer1Keys = new Set(keys);
       }
     } catch {
       // Fall back to STATIC_LAYER1_KEYS (already the default)

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -221,6 +221,18 @@ interface SectionMetadataInfo {
   updated_by?: string;
 }
 
+/** Per-field validation error from a 400 validation_failed response. */
+interface ValidationErrorDetail {
+  field: string;
+  message: string;
+}
+
+/** Conflict info from a 409 revision_conflict response. */
+interface ConflictInfo {
+  message: string;
+  conflicted: { section: string; expected_revision?: number; current_revision?: number }[];
+}
+
 interface UpdateCommitInfo {
   hash: string;
   subject: string;
@@ -448,6 +460,11 @@ export class ScionPageAdminServerConfig extends LitElement {
   @state() private envOverrides: string[] = [];
   @state() private sectionMetadata: Record<string, SectionMetadataInfo> | null = null;
   @state() private ignoredKeysNotice: string[] | null = null;
+
+  // ── Structured save errors (§3.6) ──
+  @state() private validationErrors: Record<string, ValidationErrorDetail[]> | null = null;
+  @state() private conflictInfo: ConflictInfo | null = null;
+  @state() private safetyNetKeys: string[] | null = null;
 
   static override styles = css`
     :host {
@@ -828,6 +845,108 @@ export class ScionPageAdminServerConfig extends LitElement {
       padding: 0.125rem 0.375rem;
       border-radius: 0.25rem;
     }
+
+    /* ── Structured error handling (§3.6) ── */
+
+    .conflict-banner {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      border-radius: var(--scion-radius, 0.5rem);
+      background: var(--sl-color-warning-50, #fffbeb);
+      border: 1px solid var(--sl-color-warning-200, #fde68a);
+      color: var(--sl-color-warning-800, #92400e);
+      font-size: 0.875rem;
+    }
+
+    .conflict-banner-title {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+    }
+
+    .conflict-banner-title sl-icon {
+      font-size: 1rem;
+    }
+
+    .conflict-banner-actions {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 0.25rem;
+    }
+
+    .safety-net-notice {
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      border-radius: var(--scion-radius, 0.5rem);
+      background: var(--sl-color-neutral-50, #f8fafc);
+      border: 1px solid var(--sl-color-neutral-200, #e2e8f0);
+      color: var(--sl-color-neutral-700, #334155);
+      font-size: 0.8125rem;
+    }
+
+    .safety-net-notice code {
+      font-family: var(--sl-font-mono, monospace);
+      font-size: 0.75rem;
+      background: var(--sl-color-neutral-100, #f1f5f9);
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+    }
+
+    .validation-errors {
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      border-radius: var(--scion-radius, 0.5rem);
+      background: var(--scion-error-bg, #fef2f2);
+      border: 1px solid var(--scion-error-border, #fca5a5);
+      color: var(--scion-error-text, #991b1b);
+      font-size: 0.875rem;
+    }
+
+    .validation-errors-title {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+    }
+
+    .validation-errors-title sl-icon {
+      font-size: 1rem;
+    }
+
+    .validation-errors-section {
+      margin-top: 0.5rem;
+    }
+
+    .validation-errors-section-name {
+      font-weight: 600;
+      font-size: 0.8125rem;
+      margin-bottom: 0.25rem;
+    }
+
+    .validation-errors-list {
+      list-style: none;
+      padding: 0;
+      margin: 0 0 0 0.5rem;
+      font-size: 0.8125rem;
+    }
+
+    .validation-errors-list li {
+      padding: 0.125rem 0;
+    }
+
+    .validation-errors-list li code {
+      font-family: var(--sl-font-mono, monospace);
+      font-size: 0.75rem;
+      background: rgba(0, 0, 0, 0.05);
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+      margin-right: 0.25rem;
+    }
   `;
 
   override connectedCallback(): void {
@@ -1136,12 +1255,19 @@ export class ScionPageAdminServerConfig extends LitElement {
     return payload;
   }
 
-  private async handleSave(): Promise<void> {
-    this.saving = true;
+  private clearSaveErrors(): void {
     this.error = null;
     this.successMessage = null;
     this.reloadResult = null;
     this.ignoredKeysNotice = null;
+    this.validationErrors = null;
+    this.conflictInfo = null;
+    this.safetyNetKeys = null;
+  }
+
+  private async handleSave(): Promise<void> {
+    this.saving = true;
+    this.clearSaveErrors();
 
     try {
       const payload = this.buildPayload();
@@ -1152,7 +1278,7 @@ export class ScionPageAdminServerConfig extends LitElement {
       });
 
       if (!res.ok) {
-        this.error = await extractApiError(res, 'Failed to save settings');
+        await this.handleSaveError(res);
         return;
       }
 
@@ -1176,6 +1302,56 @@ export class ScionPageAdminServerConfig extends LitElement {
     }
   }
 
+  private async handleSaveError(res: Response): Promise<void> {
+    let body: Record<string, unknown>;
+    try {
+      body = (await res.json()) as Record<string, unknown>;
+    } catch {
+      this.error = 'Failed to save settings';
+      return;
+    }
+
+    switch (body.error) {
+      case 'validation_failed':
+        this.validationErrors = (body.errors as Record<string, ValidationErrorDetail[]>) ?? null;
+        this.scrollToFirstError();
+        break;
+
+      case 'revision_conflict':
+        this.conflictInfo = {
+          message:
+            (body.message as string) ||
+            'Settings have been changed since you loaded this page.',
+          conflicted: (body.conflicted as ConflictInfo['conflicted']) ?? [],
+        };
+        break;
+
+      case 'layer0_rejected': {
+        const keys = (body.keys as string[]) ?? [];
+        this.safetyNetKeys = keys;
+        console.log(
+          '[admin-server-config] layer0_rejected — bootstrap keys in payload:',
+          keys,
+        );
+        break;
+      }
+
+      default:
+        this.error =
+          (body.message as string) ||
+          (typeof body.error === 'string' ? body.error : null) ||
+          'An unexpected error occurred';
+        break;
+    }
+  }
+
+  private scrollToFirstError(): void {
+    requestAnimationFrame(() => {
+      const el = this.shadowRoot?.querySelector('.validation-errors');
+      el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  }
+
   override render() {
     return html`
       <div class="header">
@@ -1187,7 +1363,9 @@ export class ScionPageAdminServerConfig extends LitElement {
         others require a server restart.
       </p>
 
-      ${this.loading ? nothing : this.renderEnvOverrideBanner()} ${this.renderIgnoredKeysNotice()}
+      ${this.loading ? nothing : this.renderEnvOverrideBanner()}
+      ${this.renderConflictBanner()} ${this.renderValidationErrors()}
+      ${this.renderSafetyNetNotice()} ${this.renderIgnoredKeysNotice()}
       ${this.error ? html`<div class="status-message error">${this.error}</div>` : nothing}
       ${this.successMessage
         ? html`<div class="status-message success">
@@ -1283,6 +1461,79 @@ export class ScionPageAdminServerConfig extends LitElement {
       <div class="ignored-keys-notice">
         <strong>Note:</strong> Some submitted fields were not persisted:
         ${this.ignoredKeysNotice.map((k) => html` <code>${k}</code>`)}
+      </div>
+    `;
+  }
+
+  private renderValidationErrors(): typeof nothing | ReturnType<typeof html> {
+    if (!this.validationErrors) return nothing;
+    const sections = Object.entries(this.validationErrors);
+    if (sections.length === 0) return nothing;
+    return html`
+      <div class="validation-errors">
+        <div class="validation-errors-title">
+          <sl-icon name="exclamation-circle"></sl-icon>
+          Some settings could not be saved due to validation errors
+        </div>
+        ${sections.map(
+          ([section, errors]) => html`
+            <div class="validation-errors-section">
+              <div class="validation-errors-section-name">${section}</div>
+              <ul class="validation-errors-list">
+                ${(errors as ValidationErrorDetail[]).map(
+                  (err) => html`
+                    <li>
+                      ${err.field ? html`<code>${err.field}</code>` : nothing}
+                      ${err.message || err}
+                    </li>
+                  `,
+                )}
+              </ul>
+            </div>
+          `,
+        )}
+      </div>
+    `;
+  }
+
+  private renderConflictBanner(): typeof nothing | ReturnType<typeof html> {
+    if (!this.conflictInfo) return nothing;
+    return html`
+      <div class="conflict-banner">
+        <div class="conflict-banner-title">
+          <sl-icon name="exclamation-triangle"></sl-icon>
+          Settings have been changed since you loaded this page
+        </div>
+        <div>Please reload to see the latest values before saving again.</div>
+        <div class="conflict-banner-actions">
+          <sl-button
+            size="small"
+            variant="warning"
+            @click=${() => {
+              void this.loadConfig();
+              this.conflictInfo = null;
+            }}
+          >
+            <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+            Reload
+          </sl-button>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderSafetyNetNotice(): typeof nothing | ReturnType<typeof html> {
+    if (!this.safetyNetKeys || this.safetyNetKeys.length === 0) return nothing;
+    return html`
+      <div class="safety-net-notice">
+        <strong>Unexpected error:</strong> The following bootstrap settings were included in the
+        save request but cannot be changed here:
+        ${this.safetyNetKeys.map((k) => html` <code>${k}</code>`)}
+        <br />
+        <span style="font-size: 0.75rem; color: var(--scion-text-muted, #64748b);">
+          These settings are managed via deployment configuration (settings.yaml / env).
+          This error should not normally occur — check the browser console for details.
+        </span>
       </div>
     `;
   }

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -203,6 +203,7 @@ interface ServerConfigResponse {
   default_resources?: ResourceSpec;
 
   // Settings-DB metadata (postgres mode only; absent in file/SQLite mode)
+  settings_tier?: 'db' | 'file';
   env_overrides?: string[];
   section_metadata?: Record<string, SectionMetadataInfo>;
 }
@@ -320,6 +321,8 @@ const KOANF_KEY_LABELS: Record<string, string> = {
   // notifications section
   'server.notification_channels': 'Notification Channels',
 };
+
+const STATIC_LAYER1_KEYS: Set<string> = new Set(Object.keys(KOANF_KEY_LABELS));
 
 @customElement('scion-page-admin-server-config')
 export class ScionPageAdminServerConfig extends LitElement {
@@ -465,6 +468,11 @@ export class ScionPageAdminServerConfig extends LitElement {
   @state() private validationErrors: Record<string, ValidationErrorDetail[]> | null = null;
   @state() private conflictInfo: ConflictInfo | null = null;
   @state() private safetyNetKeys: string[] | null = null;
+
+  // ── Layer-aware rendering state ──
+  private settingsTier: 'db' | 'file' = 'file';
+  private layer1Keys: Set<string> = new Set(STATIC_LAYER1_KEYS);
+  private envKeys: Set<string> = new Set();
 
   static override styles = css`
     :host {
@@ -960,7 +968,10 @@ export class ScionPageAdminServerConfig extends LitElement {
     this.error = null;
     this.ignoredKeysNotice = null;
     try {
-      const res = await apiFetch('/api/v1/admin/server-config');
+      const [res] = await Promise.all([
+        apiFetch('/api/v1/admin/server-config'),
+        this.loadSchemaKeys(),
+      ]);
       if (!res.ok) {
         this.error = await extractApiError(res, 'Failed to load server configuration');
         return;
@@ -975,6 +986,19 @@ export class ScionPageAdminServerConfig extends LitElement {
       this.error = 'Failed to connect to server';
     } finally {
       this.loading = false;
+    }
+  }
+
+  private async loadSchemaKeys(): Promise<void> {
+    try {
+      const res = await apiFetch('/api/v1/admin/server-config/schema');
+      if (!res.ok) return;
+      const data = (await res.json()) as { layer1_keys?: string[] };
+      if (data.layer1_keys && data.layer1_keys.length > 0) {
+        this.layer1Keys = new Set(data.layer1_keys);
+      }
+    } catch {
+      // Fall back to STATIC_LAYER1_KEYS (already the default)
     }
   }
 
@@ -1092,7 +1116,9 @@ export class ScionPageAdminServerConfig extends LitElement {
     // Runtimes, harness_configs, profiles preserved via rawConfig
 
     // Settings-DB metadata (postgres mode only; absent in file/SQLite mode)
+    this.settingsTier = data.settings_tier || 'file';
     this.envOverrides = data.env_overrides || [];
+    this.envKeys = new Set(this.envOverrides);
     this.sectionMetadata = data.section_metadata || null;
   }
 

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -1176,26 +1176,159 @@ export class ScionPageAdminServerConfig extends LitElement {
     return editableTemplate;
   }
 
-  private buildPayload(): Record<string, unknown> {
+  private buildLayer1Payload(): Record<string, unknown> {
     const payload: Record<string, unknown> = {};
+    const ok = (key: string) => this.readOnlyReason(key) === null;
 
-    // General
-    payload.active_profile = this.activeProfile || undefined;
-    payload.default_template = this.defaultTemplate || undefined;
-    payload.default_harness_config = this.defaultHarnessConfig || undefined;
-    payload.image_registry = this.imageRegistry || undefined;
-    payload.workspace_path = this.workspacePath || undefined;
+    // General — only Layer-1 top-level keys
+    if (ok('default_template')) payload.default_template = this.defaultTemplate || undefined;
+    if (ok('default_harness_config'))
+      payload.default_harness_config = this.defaultHarnessConfig || undefined;
+    if (ok('image_registry')) payload.image_registry = this.imageRegistry || undefined;
 
     // Default agent limits
-    payload.default_max_turns = this.defaultMaxTurns || undefined;
-    payload.default_max_model_calls = this.defaultMaxModelCalls || undefined;
-    payload.default_max_duration = this.defaultMaxDuration || undefined;
+    if (ok('default_max_turns')) payload.default_max_turns = this.defaultMaxTurns || undefined;
+    if (ok('default_max_model_calls'))
+      payload.default_max_model_calls = this.defaultMaxModelCalls || undefined;
+    if (ok('default_max_duration'))
+      payload.default_max_duration = this.defaultMaxDuration || undefined;
+
     if (
-      this.defaultResCpuReq ||
-      this.defaultResMemReq ||
-      this.defaultResCpuLim ||
-      this.defaultResMemLim ||
-      this.defaultResDisk
+      ok('default_resources') &&
+      (this.defaultResCpuReq ||
+        this.defaultResMemReq ||
+        this.defaultResCpuLim ||
+        this.defaultResMemLim ||
+        this.defaultResDisk)
+    ) {
+      const defaultResources: Record<string, unknown> = {};
+      if (this.defaultResCpuReq || this.defaultResMemReq) {
+        defaultResources.requests = {
+          cpu: this.defaultResCpuReq || undefined,
+          memory: this.defaultResMemReq || undefined,
+        };
+      }
+      if (this.defaultResCpuLim || this.defaultResMemLim) {
+        defaultResources.limits = {
+          cpu: this.defaultResCpuLim || undefined,
+          memory: this.defaultResMemLim || undefined,
+        };
+      }
+      if (this.defaultResDisk) defaultResources.disk = this.defaultResDisk;
+      payload.default_resources = defaultResources;
+    }
+
+    const server: Record<string, unknown> = {};
+
+    // Hub — only Layer-1 hub fields
+    const hub: Record<string, unknown> = {};
+    if (ok('server.hub.public_url') && this.hubPublicUrl) hub.public_url = this.hubPublicUrl;
+    if (ok('server.hub.admin_emails')) {
+      hub.admin_emails = this.hubAdminEmails
+        ? this.hubAdminEmails
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : [];
+    }
+    if (ok('server.hub.soft_delete_retention') && this.hubSoftDeleteRetention)
+      hub.soft_delete_retention = this.hubSoftDeleteRetention;
+    if (ok('server.hub.soft_delete_retain_files'))
+      hub.soft_delete_retain_files = this.hubSoftDeleteRetainFiles;
+    if (ok('server.hub.auto_suspend_stalled'))
+      hub.auto_suspend_stalled = this.hubAutoSuspendStalled;
+    if (Object.keys(hub).length > 0) server.hub = hub;
+
+    // Auth — only Layer-1 auth fields
+    const auth: Record<string, unknown> = {};
+    if (ok('server.auth.user_access_mode') && this.authUserAccessMode) {
+      auth.user_access_mode = this.authUserAccessMode;
+    }
+    if (ok('server.auth.authorized_domains') && this.authAuthorizedDomains) {
+      auth.authorized_domains = this.authAuthorizedDomains
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    }
+    if (Object.keys(auth).length > 0) server.auth = auth;
+
+    // Broker, database, storage, secrets, message_broker — all Layer-0, omitted
+
+    // Preserve notification channels, OAuth, and GitHub App from raw config
+    if (this.rawConfig?.server?.notification_channels) {
+      server.notification_channels = this.rawConfig.server.notification_channels;
+    }
+    if (this.rawConfig?.server?.oauth) {
+      server.oauth = this.rawConfig.server.oauth;
+    }
+    if (this.rawConfig?.server?.github_app) {
+      server.github_app = this.rawConfig.server.github_app;
+    }
+
+    if (Object.keys(server).length > 0) payload.server = server;
+
+    // Telemetry — all Layer-1
+    if (ok('telemetry.enabled')) {
+      const telemetry: Record<string, unknown> = {
+        enabled: this.telemetryEnabled,
+      };
+      if (ok('telemetry.cloud.enabled')) {
+        telemetry.cloud = {
+          enabled: this.telemetryCloudEnabled,
+          endpoint: this.telemetryCloudEndpoint || undefined,
+          protocol: this.telemetryCloudProtocol || undefined,
+          provider: this.telemetryCloudProvider || undefined,
+        };
+      }
+      if (ok('telemetry.hub.enabled')) {
+        telemetry.hub = {
+          enabled: this.telemetryHubEnabled,
+          report_interval: this.telemetryHubReportInterval || undefined,
+        };
+      }
+      if (ok('telemetry.local.enabled')) {
+        telemetry.local = {
+          enabled: this.telemetryLocalEnabled,
+          file: this.telemetryLocalFile || undefined,
+          console: this.telemetryLocalConsole,
+        };
+      }
+      payload.telemetry = telemetry;
+    }
+
+    // Preserve runtimes, harness_configs, profiles from raw config
+    if (this.rawConfig?.runtimes) payload.runtimes = this.rawConfig.runtimes;
+    if (this.rawConfig?.harness_configs) payload.harness_configs = this.rawConfig.harness_configs;
+    if (this.rawConfig?.profiles) payload.profiles = this.rawConfig.profiles;
+
+    return payload;
+  }
+
+  private buildFilePayload(): Record<string, unknown> {
+    const payload: Record<string, unknown> = {};
+    const ok = (key: string) => this.readOnlyReason(key) === null;
+
+    // General
+    if (ok('active_profile')) payload.active_profile = this.activeProfile || undefined;
+    if (ok('default_template')) payload.default_template = this.defaultTemplate || undefined;
+    if (ok('default_harness_config'))
+      payload.default_harness_config = this.defaultHarnessConfig || undefined;
+    if (ok('image_registry')) payload.image_registry = this.imageRegistry || undefined;
+    if (ok('workspace_path')) payload.workspace_path = this.workspacePath || undefined;
+
+    // Default agent limits
+    if (ok('default_max_turns')) payload.default_max_turns = this.defaultMaxTurns || undefined;
+    if (ok('default_max_model_calls'))
+      payload.default_max_model_calls = this.defaultMaxModelCalls || undefined;
+    if (ok('default_max_duration'))
+      payload.default_max_duration = this.defaultMaxDuration || undefined;
+    if (
+      ok('default_resources') &&
+      (this.defaultResCpuReq ||
+        this.defaultResMemReq ||
+        this.defaultResCpuLim ||
+        this.defaultResMemLim ||
+        this.defaultResDisk)
     ) {
       const defaultResources: Record<string, unknown> = {};
       if (this.defaultResCpuReq || this.defaultResMemReq) {
@@ -1216,82 +1349,96 @@ export class ScionPageAdminServerConfig extends LitElement {
 
     // Server
     const server: Record<string, unknown> = {};
-    server.mode = this.serverMode || undefined;
-    server.log_level = this.logLevel || undefined;
-    server.log_format = this.logFormat || undefined;
+    if (ok('server.mode')) server.mode = this.serverMode || undefined;
+    if (ok('server.log_level')) server.log_level = this.logLevel || undefined;
+    if (ok('server.log_format')) server.log_format = this.logFormat || undefined;
 
     // Hub server
     const hub: Record<string, unknown> = {};
-    if (this.hubPort) hub.port = this.hubPort;
-    if (this.hubHost) hub.host = this.hubHost;
-    if (this.hubPublicUrl) hub.public_url = this.hubPublicUrl;
-    if (this.hubReadTimeout) hub.read_timeout = this.hubReadTimeout;
-    if (this.hubWriteTimeout) hub.write_timeout = this.hubWriteTimeout;
-    hub.admin_emails = this.hubAdminEmails
-      ? this.hubAdminEmails
-          .split(',')
-          .map((s) => s.trim())
-          .filter(Boolean)
-      : [];
-    if (this.hubSoftDeleteRetention) hub.soft_delete_retention = this.hubSoftDeleteRetention;
-    hub.soft_delete_retain_files = this.hubSoftDeleteRetainFiles;
-    hub.auto_suspend_stalled = this.hubAutoSuspendStalled;
+    if (ok('server.hub.port') && this.hubPort) hub.port = this.hubPort;
+    if (ok('server.hub.host') && this.hubHost) hub.host = this.hubHost;
+    if (ok('server.hub.public_url') && this.hubPublicUrl) hub.public_url = this.hubPublicUrl;
+    if (ok('server.hub.read_timeout') && this.hubReadTimeout)
+      hub.read_timeout = this.hubReadTimeout;
+    if (ok('server.hub.write_timeout') && this.hubWriteTimeout)
+      hub.write_timeout = this.hubWriteTimeout;
+    if (ok('server.hub.admin_emails')) {
+      hub.admin_emails = this.hubAdminEmails
+        ? this.hubAdminEmails
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : [];
+    }
+    if (ok('server.hub.soft_delete_retention') && this.hubSoftDeleteRetention)
+      hub.soft_delete_retention = this.hubSoftDeleteRetention;
+    if (ok('server.hub.soft_delete_retain_files'))
+      hub.soft_delete_retain_files = this.hubSoftDeleteRetainFiles;
+    if (ok('server.hub.auto_suspend_stalled'))
+      hub.auto_suspend_stalled = this.hubAutoSuspendStalled;
     server.hub = hub;
 
     // Broker
     const broker: Record<string, unknown> = {};
-    broker.enabled = this.brokerEnabled;
-    if (this.brokerPort) broker.port = this.brokerPort;
-    if (this.brokerHost) broker.host = this.brokerHost;
-    if (this.brokerHubEndpoint) broker.hub_endpoint = this.brokerHubEndpoint;
-    if (this.brokerContainerHubEndpoint)
+    if (ok('server.broker.enabled')) broker.enabled = this.brokerEnabled;
+    if (ok('server.broker.port') && this.brokerPort) broker.port = this.brokerPort;
+    if (ok('server.broker.host') && this.brokerHost) broker.host = this.brokerHost;
+    if (ok('server.broker.hub_endpoint') && this.brokerHubEndpoint)
+      broker.hub_endpoint = this.brokerHubEndpoint;
+    if (ok('server.broker.container_hub_endpoint') && this.brokerContainerHubEndpoint)
       broker.container_hub_endpoint = this.brokerContainerHubEndpoint;
-    if (this.brokerName) broker.broker_name = this.brokerName;
-    if (this.brokerNickname) broker.broker_nickname = this.brokerNickname;
-    broker.auto_provide = this.brokerAutoProvide;
+    if (ok('server.broker.name') && this.brokerName) broker.broker_name = this.brokerName;
+    if (ok('server.broker.nickname') && this.brokerNickname)
+      broker.broker_nickname = this.brokerNickname;
+    if (ok('server.broker.auto_provide')) broker.auto_provide = this.brokerAutoProvide;
     server.broker = broker;
 
-    // Database — only send driver, not masked URL
+    // Database
     const database: Record<string, unknown> = {};
-    if (this.dbDriver) database.driver = this.dbDriver;
-    // Don't send masked URL back
-    if (this.dbUrl && this.dbUrl !== '********') database.url = this.dbUrl;
+    if (ok('server.database.driver') && this.dbDriver) database.driver = this.dbDriver;
+    if (ok('server.database.url') && this.dbUrl && this.dbUrl !== '********')
+      database.url = this.dbUrl;
     server.database = database;
 
     // Auth
     const auth: Record<string, unknown> = {};
-    auth.dev_mode = this.authDevMode;
-    // Don't send masked token back
-    if (this.authDevToken && this.authDevToken !== '********') auth.dev_token = this.authDevToken;
-    if (this.authAuthorizedDomains) {
+    if (ok('server.auth.dev_mode')) auth.dev_mode = this.authDevMode;
+    if (ok('server.auth.dev_token') && this.authDevToken && this.authDevToken !== '********')
+      auth.dev_token = this.authDevToken;
+    if (ok('server.auth.authorized_domains') && this.authAuthorizedDomains) {
       auth.authorized_domains = this.authAuthorizedDomains
         .split(',')
         .map((s) => s.trim())
         .filter(Boolean);
     }
-    if (this.authUserAccessMode) {
+    if (ok('server.auth.user_access_mode') && this.authUserAccessMode) {
       auth.user_access_mode = this.authUserAccessMode;
     }
     server.auth = auth;
 
     // Storage
     const storage: Record<string, unknown> = {};
-    if (this.storageProvider) storage.provider = this.storageProvider;
-    if (this.storageBucket) storage.bucket = this.storageBucket;
-    if (this.storageLocalPath) storage.local_path = this.storageLocalPath;
+    if (ok('server.storage.provider') && this.storageProvider)
+      storage.provider = this.storageProvider;
+    if (ok('server.storage.bucket') && this.storageBucket) storage.bucket = this.storageBucket;
+    if (ok('server.storage.local_path') && this.storageLocalPath)
+      storage.local_path = this.storageLocalPath;
     server.storage = storage;
 
     // Secrets
     const secrets: Record<string, unknown> = {};
-    if (this.secretsBackend) secrets.backend = this.secretsBackend;
-    if (this.secretsGCPProjectId) secrets.gcp_project_id = this.secretsGCPProjectId;
+    if (ok('server.secrets.backend') && this.secretsBackend) secrets.backend = this.secretsBackend;
+    if (ok('server.secrets.gcp_project_id') && this.secretsGCPProjectId)
+      secrets.gcp_project_id = this.secretsGCPProjectId;
     server.secrets = secrets;
 
     // Message Broker
-    server.message_broker = {
-      enabled: this.messageBrokerEnabled,
-      type: this.messageBrokerType || undefined,
-    };
+    if (ok('server.message_broker.enabled')) {
+      server.message_broker = {
+        enabled: this.messageBrokerEnabled,
+        type: ok('server.message_broker.type') ? this.messageBrokerType || undefined : undefined,
+      };
+    }
 
     // Preserve notification channels, OAuth, and GitHub App from raw config
     if (this.rawConfig?.server?.notification_channels) {
@@ -1307,25 +1454,38 @@ export class ScionPageAdminServerConfig extends LitElement {
     payload.server = server;
 
     // Telemetry
-    const telemetry: Record<string, unknown> = {
-      enabled: this.telemetryEnabled,
-    };
-    telemetry.cloud = {
-      enabled: this.telemetryCloudEnabled,
-      endpoint: this.telemetryCloudEndpoint || undefined,
-      protocol: this.telemetryCloudProtocol || undefined,
-      provider: this.telemetryCloudProvider || undefined,
-    };
-    telemetry.hub = {
-      enabled: this.telemetryHubEnabled,
-      report_interval: this.telemetryHubReportInterval || undefined,
-    };
-    telemetry.local = {
-      enabled: this.telemetryLocalEnabled,
-      file: this.telemetryLocalFile || undefined,
-      console: this.telemetryLocalConsole,
-    };
-    payload.telemetry = telemetry;
+    const telemetry: Record<string, unknown> = {};
+    if (ok('telemetry.enabled')) telemetry.enabled = this.telemetryEnabled;
+    if (ok('telemetry.cloud.enabled')) {
+      telemetry.cloud = {
+        enabled: this.telemetryCloudEnabled,
+        endpoint: ok('telemetry.cloud.endpoint')
+          ? this.telemetryCloudEndpoint || undefined
+          : undefined,
+        protocol: ok('telemetry.cloud.protocol')
+          ? this.telemetryCloudProtocol || undefined
+          : undefined,
+        provider: ok('telemetry.cloud.provider')
+          ? this.telemetryCloudProvider || undefined
+          : undefined,
+      };
+    }
+    if (ok('telemetry.hub.enabled')) {
+      telemetry.hub = {
+        enabled: this.telemetryHubEnabled,
+        report_interval: ok('telemetry.hub.report_interval')
+          ? this.telemetryHubReportInterval || undefined
+          : undefined,
+      };
+    }
+    if (ok('telemetry.local.enabled')) {
+      telemetry.local = {
+        enabled: this.telemetryLocalEnabled,
+        file: ok('telemetry.local.file') ? this.telemetryLocalFile || undefined : undefined,
+        console: ok('telemetry.local.console') ? this.telemetryLocalConsole : undefined,
+      };
+    }
+    if (Object.keys(telemetry).length > 0) payload.telemetry = telemetry;
 
     // Preserve runtimes, harness_configs, profiles from raw config
     if (this.rawConfig?.runtimes) payload.runtimes = this.rawConfig.runtimes;
@@ -1350,7 +1510,8 @@ export class ScionPageAdminServerConfig extends LitElement {
     this.clearSaveErrors();
 
     try {
-      const payload = this.buildPayload();
+      const payload =
+        this.settingsTier === 'db' ? this.buildLayer1Payload() : this.buildFilePayload();
       const res = await apiFetch('/api/v1/admin/server-config', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -207,6 +207,7 @@ interface ServerConfigResponse {
   env_overrides?: string[];
   section_metadata?: Record<string, SectionMetadataInfo>;
   superseded_keys?: Record<string, SupersededKeyInfo[]>;
+  deprecated_env_keys?: DeprecatedEnvKeyInfo[];
 }
 
 interface ReloadResult {
@@ -228,6 +229,13 @@ interface SectionMetadataInfo {
 interface SupersededKeyInfo {
   key: string;
   source: string; // "seed_env" | "yaml" | "server_env"
+}
+
+/** A SCION_SERVER_* env var that targets a Layer-1 key (deprecated, migrate to SCION_SEED_*). */
+interface DeprecatedEnvKeyInfo {
+  env_var: string;
+  koanf_key: string;
+  seed_equivalent: string;
 }
 
 /** Per-field validation error from a 400 validation_failed response. */
@@ -472,6 +480,9 @@ export class ScionPageAdminServerConfig extends LitElement {
   @state() private sectionMetadata: Record<string, SectionMetadataInfo> | null = null;
   @state() private ignoredKeysNotice: string[] | null = null;
   @state() private supersededKeys: Record<string, SupersededKeyInfo[]> | null = null;
+  @state() private deprecatedEnvKeys: DeprecatedEnvKeyInfo[] | null = null;
+  @state() private resetConfirmSection: string | null = null;
+  @state() private resettingSection = false;
 
   // ── Structured save errors (§3.6) ──
   @state() private validationErrors: Record<string, ValidationErrorDetail[]> | null = null;
@@ -880,6 +891,24 @@ export class ScionPageAdminServerConfig extends LitElement {
       margin-bottom: 0.75rem;
     }
 
+    /* ── Settings-DB: section header with reset button ── */
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin: 0 0 1rem 0;
+      padding-bottom: 0.75rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+    }
+
+    .section-header h3 {
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+      margin: 0;
+    }
+
     /* ── Settings-DB: superseded key badge ── */
 
     .superseded-badge {
@@ -949,6 +978,56 @@ export class ScionPageAdminServerConfig extends LitElement {
     .superseded-source {
       font-size: 0.6875rem;
       color: var(--sl-color-primary-600, #2563eb);
+    }
+
+    /* ── Settings-DB: deprecated env keys notice ── */
+
+    .deprecated-notice {
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      border-radius: var(--scion-radius, 0.5rem);
+      background: var(--sl-color-warning-50, #fffbeb);
+      border: 1px solid var(--sl-color-warning-200, #fde68a);
+      color: var(--sl-color-warning-800, #92400e);
+      font-size: 0.8125rem;
+    }
+
+    .deprecated-notice-title {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+    }
+
+    .deprecated-notice-title sl-icon {
+      font-size: 1rem;
+    }
+
+    .deprecated-notice-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    .deprecated-notice-list li {
+      padding: 0.25rem 0;
+    }
+
+    .deprecated-notice-list code {
+      font-family: var(--sl-font-mono, monospace);
+      font-size: 0.75rem;
+      background: var(--sl-color-warning-100, #fef3c7);
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+    }
+
+    /* ── Settings-DB: reset confirm dialog ── */
+
+    .reset-confirm-text {
+      font-size: 0.875rem;
+      color: var(--scion-text, #1e293b);
+      line-height: 1.5;
     }
 
     /* ── Settings-DB: ignored keys notice ── */
@@ -1243,6 +1322,10 @@ export class ScionPageAdminServerConfig extends LitElement {
     this.envKeys = new Set(this.envOverrides);
     this.sectionMetadata = data.section_metadata || null;
     this.supersededKeys = data.superseded_keys || null;
+    this.deprecatedEnvKeys =
+      data.deprecated_env_keys && data.deprecated_env_keys.length > 0
+        ? data.deprecated_env_keys
+        : null;
   }
 
   private readOnlyReason(koanfKey: string): 'bootstrap' | 'env' | null {
@@ -1701,9 +1784,10 @@ export class ScionPageAdminServerConfig extends LitElement {
       </p>
 
       ${this.loading ? nothing : this.renderEnvOverrideBanner()}
-      ${this.renderSupersededPanel()}
+      ${this.renderDeprecatedEnvNotice()} ${this.renderSupersededPanel()}
       ${this.renderConflictBanner()} ${this.renderValidationErrors()}
       ${this.renderSafetyNetNotice()} ${this.renderIgnoredKeysNotice()}
+      ${this.renderResetConfirmDialog()}
       ${this.error ? html`<div class="status-message error">${this.error}</div>` : nothing}
       ${this.successMessage
         ? html`<div class="status-message success">
@@ -1855,6 +1939,128 @@ export class ScionPageAdminServerConfig extends LitElement {
           )}
         </ul>
       </div>
+    `;
+  }
+
+  /** Renders the page-top deprecation notice for SCION_SERVER_* env vars on Layer-1 keys. */
+  private renderDeprecatedEnvNotice(): typeof nothing | ReturnType<typeof html> {
+    if (!this.deprecatedEnvKeys || this.deprecatedEnvKeys.length === 0) return nothing;
+    return html`
+      <div class="deprecated-notice">
+        <div class="deprecated-notice-title">
+          <sl-icon name="exclamation-triangle"></sl-icon>
+          SCION_SERVER_* variables are deprecated for operational settings — use SCION_SEED_*
+          instead
+        </div>
+        <ul class="deprecated-notice-list">
+          ${this.deprecatedEnvKeys.map(
+            (dk) => html`
+              <li>
+                <code>${dk.env_var}</code> → <code>${dk.seed_equivalent}</code>
+              </li>
+            `
+          )}
+        </ul>
+      </div>
+    `;
+  }
+
+  /** Returns true if a section is managed and can be reset to bootstrap. */
+  private canResetSection(sectionName: string): boolean {
+    if (this.settingsTier !== 'db' || !this.sectionMetadata) return false;
+    const meta = this.sectionMetadata[sectionName];
+    return meta?.origin === 'managed';
+  }
+
+  /** Handles the per-section "Reset to bootstrap" action. */
+  private async handleResetSection(sectionName: string): Promise<void> {
+    this.resettingSection = true;
+    try {
+      const resp = await apiFetch(
+        `/api/v1/admin/server-config/sections/${encodeURIComponent(sectionName)}`,
+        { method: 'DELETE' }
+      );
+      if (!resp.ok) {
+        const errText = await resp.text();
+        this.error = `Reset failed: ${errText}`;
+        return;
+      }
+      this.resetConfirmSection = null;
+      await this.loadConfig();
+      this.successMessage = `Section "${sectionName}" has been reset to deployment configuration.`;
+    } catch (e) {
+      this.error = `Reset failed: ${e instanceof Error ? e.message : String(e)}`;
+    } finally {
+      this.resettingSection = false;
+    }
+  }
+
+  /**
+   * Renders a section header with title and optional "Reset to bootstrap" button
+   * for managed sections in DB mode.
+   */
+  private renderSectionHeader(
+    title: string,
+    sectionName?: string
+  ): ReturnType<typeof html> {
+    if (sectionName && this.canResetSection(sectionName)) {
+      return html`
+        <div class="section-header">
+          <h3>${title}</h3>
+          <sl-button
+            size="small"
+            variant="default"
+            ?loading=${this.resettingSection && this.resetConfirmSection === sectionName}
+            @click=${() => {
+              this.resetConfirmSection = sectionName;
+            }}
+          >
+            <sl-icon slot="prefix" name="arrow-counterclockwise"></sl-icon>
+            Reset to bootstrap
+          </sl-button>
+        </div>
+      `;
+    }
+    return html`<h3 class="section-title">${title}</h3>`;
+  }
+
+  /** Renders the reset confirmation dialog. */
+  private renderResetConfirmDialog(): typeof nothing | ReturnType<typeof html> {
+    if (!this.resetConfirmSection) return nothing;
+    return html`
+      <sl-dialog
+        label="Reset to Bootstrap"
+        ?open=${!!this.resetConfirmSection}
+        @sl-request-close=${() => {
+          this.resetConfirmSection = null;
+        }}
+      >
+        <div class="reset-confirm-text">
+          This will revert the <strong>${this.resetConfirmSection}</strong> section to its
+          deployment-provided values. Any admin-set values in this section will be lost. Continue?
+        </div>
+        <sl-button
+          slot="footer"
+          variant="default"
+          @click=${() => {
+            this.resetConfirmSection = null;
+          }}
+        >
+          Cancel
+        </sl-button>
+        <sl-button
+          slot="footer"
+          variant="danger"
+          ?loading=${this.resettingSection}
+          @click=${() => {
+            if (this.resetConfirmSection) {
+              void this.handleResetSection(this.resetConfirmSection);
+            }
+          }}
+        >
+          Reset
+        </sl-button>
+      </sl-dialog>
     `;
   }
 
@@ -2244,7 +2450,7 @@ export class ScionPageAdminServerConfig extends LitElement {
       </div>
 
       <div class="section">
-        <h3 class="section-title">Default Agent Limits</h3>
+        ${this.renderSectionHeader('Default Agent Limits', 'agent_defaults')}
         ${this.renderSectionMeta('agent_defaults')}
         <div class="form-grid">
           <div class="form-field">
@@ -2403,7 +2609,7 @@ export class ScionPageAdminServerConfig extends LitElement {
   private renderHubServerTab() {
     return html`
       <div class="section">
-        <h3 class="section-title">Hub API Server</h3>
+        ${this.renderSectionHeader('Hub API Server', 'endpoints')}
         ${this.renderSectionMeta('endpoints')}
         <div class="form-grid">
           <div class="form-field">
@@ -2499,7 +2705,7 @@ export class ScionPageAdminServerConfig extends LitElement {
       </div>
 
       <div class="section">
-        <h3 class="section-title">Agent Lifecycle</h3>
+        ${this.renderSectionHeader('Agent Lifecycle', 'lifecycle')}
         ${this.renderSectionMeta('lifecycle')}
         <div class="form-grid">
           <div class="form-field">
@@ -2812,7 +3018,7 @@ export class ScionPageAdminServerConfig extends LitElement {
   private renderAuthTab() {
     return html`
       <div class="section">
-        <h3 class="section-title">User Access Mode</h3>
+        ${this.renderSectionHeader('User Access Mode', 'access')}
         ${this.renderSectionMeta('access')}
         <div class="form-grid">
           <div class="form-field full-width">
@@ -2957,7 +3163,7 @@ export class ScionPageAdminServerConfig extends LitElement {
   private renderTelemetryTab() {
     return html`
       <div class="section">
-        <h3 class="section-title">Telemetry</h3>
+        ${this.renderSectionHeader('Telemetry', 'telemetry')}
         ${this.renderSectionMeta('telemetry')}
         <div class="form-grid">
           <div class="form-field full-width">
@@ -3244,7 +3450,7 @@ export class ScionPageAdminServerConfig extends LitElement {
         : ''}
 
       <div class="section">
-        <h3 class="section-title">GitHub App Configuration</h3>
+        ${this.renderSectionHeader('GitHub App Configuration', 'github_app')}
         ${this.renderSectionMeta('github_app')}
         <div class="form-grid">
           <div class="form-field">

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -206,6 +206,7 @@ interface ServerConfigResponse {
   settings_tier?: 'db' | 'file';
   env_overrides?: string[];
   section_metadata?: Record<string, SectionMetadataInfo>;
+  superseded_keys?: Record<string, SupersededKeyInfo[]>;
 }
 
 interface ReloadResult {
@@ -221,6 +222,12 @@ interface SectionMetadataInfo {
   updated_at?: string;
   updated_by?: string;
   origin?: string; // "seeded" | "managed" (DB mode only)
+}
+
+/** A bootstrap-material key whose value differs from the DB value in a managed section. */
+interface SupersededKeyInfo {
+  key: string;
+  source: string; // "seed_env" | "yaml" | "server_env"
 }
 
 /** Per-field validation error from a 400 validation_failed response. */
@@ -464,6 +471,7 @@ export class ScionPageAdminServerConfig extends LitElement {
   @state() private envOverrides: string[] = [];
   @state() private sectionMetadata: Record<string, SectionMetadataInfo> | null = null;
   @state() private ignoredKeysNotice: string[] | null = null;
+  @state() private supersededKeys: Record<string, SupersededKeyInfo[]> | null = null;
 
   // ── Structured save errors (§3.6) ──
   @state() private validationErrors: Record<string, ValidationErrorDetail[]> | null = null;
@@ -872,6 +880,77 @@ export class ScionPageAdminServerConfig extends LitElement {
       margin-bottom: 0.75rem;
     }
 
+    /* ── Settings-DB: superseded key badge ── */
+
+    .superseded-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      color: var(--sl-color-primary-700, #1d4ed8);
+      background: var(--sl-color-primary-50, #eff6ff);
+      border: 1px solid var(--sl-color-primary-200, #bfdbfe);
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      white-space: nowrap;
+      cursor: help;
+    }
+
+    .superseded-badge sl-icon {
+      font-size: 0.75rem;
+    }
+
+    /* ── Settings-DB: superseded keys page-top panel ── */
+
+    .superseded-panel {
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      border-radius: var(--scion-radius, 0.5rem);
+      background: var(--sl-color-primary-50, #eff6ff);
+      border: 1px solid var(--sl-color-primary-200, #bfdbfe);
+      color: var(--sl-color-primary-800, #1e40af);
+      font-size: 0.8125rem;
+    }
+
+    .superseded-panel-title {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+    }
+
+    .superseded-panel-title sl-icon {
+      font-size: 1rem;
+    }
+
+    .superseded-panel-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    .superseded-panel-list li {
+      padding: 0.25rem 0;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .superseded-panel-list code {
+      font-family: var(--sl-font-mono, monospace);
+      font-size: 0.75rem;
+      background: var(--sl-color-primary-100, #dbeafe);
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+    }
+
+    .superseded-source {
+      font-size: 0.6875rem;
+      color: var(--sl-color-primary-600, #2563eb);
+    }
+
     /* ── Settings-DB: ignored keys notice ── */
 
     .ignored-keys-notice {
@@ -1163,6 +1242,7 @@ export class ScionPageAdminServerConfig extends LitElement {
     this.envOverrides = data.env_overrides || [];
     this.envKeys = new Set(this.envOverrides);
     this.sectionMetadata = data.section_metadata || null;
+    this.supersededKeys = data.superseded_keys || null;
   }
 
   private readOnlyReason(koanfKey: string): 'bootstrap' | 'env' | null {
@@ -1189,7 +1269,7 @@ export class ScionPageAdminServerConfig extends LitElement {
     if (reason) {
       return html`${this.renderReadOnlyBadge(reason)}<span class="read-only-value">${displayValue || '—'}</span>`;
     }
-    return editableTemplate;
+    return html`${this.renderSupersededBadge(koanfKey)}${editableTemplate}`;
   }
 
   private buildLayer1Payload(): Record<string, unknown> {
@@ -1621,6 +1701,7 @@ export class ScionPageAdminServerConfig extends LitElement {
       </p>
 
       ${this.loading ? nothing : this.renderEnvOverrideBanner()}
+      ${this.renderSupersededPanel()}
       ${this.renderConflictBanner()} ${this.renderValidationErrors()}
       ${this.renderSafetyNetNotice()} ${this.renderIgnoredKeysNotice()}
       ${this.error ? html`<div class="status-message error">${this.error}</div>` : nothing}
@@ -1709,6 +1790,70 @@ export class ScionPageAdminServerConfig extends LitElement {
               ${new Date(meta.updated_at).toLocaleString()}
             </span>`
           : nothing}
+      </div>
+    `;
+  }
+
+  /** Returns true if the given koanf key is superseded in a managed section. */
+  private isSuperseded(koanfKey: string): boolean {
+    if (!this.supersededKeys) return false;
+    return Object.values(this.supersededKeys).some((keys) =>
+      keys.some((sk) => sk.key === koanfKey)
+    );
+  }
+
+  /** Renders a blue ⓘ badge next to a superseded field. */
+  private renderSupersededBadge(koanfKey: string): typeof nothing | ReturnType<typeof html> {
+    if (!this.isSuperseded(koanfKey)) return nothing;
+    return html`<span
+      class="superseded-badge"
+      title="A deployment-provided value differs and is superseded by this database value"
+    >
+      <sl-icon name="info-circle"></sl-icon>
+      ⓘ Superseded
+    </span>`;
+  }
+
+  /** Renders the page-top panel listing all superseded keys across sections. */
+  private renderSupersededPanel(): typeof nothing | ReturnType<typeof html> {
+    if (!this.supersededKeys) return nothing;
+    const allKeys: { section: string; key: string; source: string }[] = [];
+    for (const [section, keys] of Object.entries(this.supersededKeys)) {
+      for (const sk of keys) {
+        allKeys.push({ section, key: sk.key, source: sk.source });
+      }
+    }
+    if (allKeys.length === 0) return nothing;
+
+    const sourceLabel = (s: string) => {
+      switch (s) {
+        case 'seed_env':
+          return 'SCION_SEED_*';
+        case 'yaml':
+          return 'settings.yaml';
+        case 'server_env':
+          return 'SCION_SERVER_*';
+        default:
+          return s;
+      }
+    };
+
+    return html`
+      <div class="superseded-panel">
+        <div class="superseded-panel-title">
+          <sl-icon name="info-circle"></sl-icon>
+          Deployment values superseded by database settings
+        </div>
+        <ul class="superseded-panel-list">
+          ${allKeys.map(
+            (sk) => html`
+              <li>
+                <code>${KOANF_KEY_LABELS[sk.key] || sk.key}</code>
+                <span class="superseded-source">(from ${sourceLabel(sk.source)})</span>
+              </li>
+            `
+          )}
+        </ul>
       </div>
     `;
   }

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -792,6 +792,33 @@ export class ScionPageAdminServerConfig extends LitElement {
       margin-right: 0.25rem;
     }
 
+    /* ── Layer-aware: read-only field rendering ── */
+
+    .read-only-value {
+      font-size: 0.875rem;
+      color: var(--scion-text, #1e293b);
+      padding: 0.5rem 0.75rem;
+      background: var(--scion-bg, #f8fafc);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--scion-radius, 0.5rem);
+      min-height: 1.5em;
+    }
+
+    .read-only-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      color: var(--sl-color-neutral-600, #475569);
+      background: var(--sl-color-neutral-100, #f1f5f9);
+      border: 1px solid var(--sl-color-neutral-200, #e2e8f0);
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      white-space: nowrap;
+      font-style: italic;
+    }
+
     /* ── Settings-DB: per-field env badge ── */
 
     .env-badge {
@@ -1120,6 +1147,33 @@ export class ScionPageAdminServerConfig extends LitElement {
     this.envOverrides = data.env_overrides || [];
     this.envKeys = new Set(this.envOverrides);
     this.sectionMetadata = data.section_metadata || null;
+  }
+
+  private readOnlyReason(koanfKey: string): 'bootstrap' | 'env' | null {
+    if (this.settingsTier === 'db') {
+      return this.layer1Keys.has(koanfKey) ? null : 'bootstrap';
+    }
+    return this.envKeys.has(koanfKey) ? 'env' : null;
+  }
+
+  private renderReadOnlyBadge(reason: 'bootstrap' | 'env'): ReturnType<typeof html> {
+    const text =
+      reason === 'bootstrap'
+        ? '🔒 Managed via deployment configuration'
+        : '🔒 Set via environment variable';
+    return html`<span class="read-only-badge">${text}</span>`;
+  }
+
+  private renderFieldValue(
+    koanfKey: string,
+    displayValue: string,
+    editableTemplate: ReturnType<typeof html>
+  ): ReturnType<typeof html> {
+    const reason = this.readOnlyReason(koanfKey);
+    if (reason) {
+      return html`${this.renderReadOnlyBadge(reason)}<span class="read-only-value">${displayValue || '—'}</span>`;
+    }
+    return editableTemplate;
   }
 
   private buildPayload(): Record<string, unknown> {
@@ -1738,97 +1792,126 @@ export class ScionPageAdminServerConfig extends LitElement {
           <div class="form-field">
             <label>Server Mode</label>
             <span class="hint">Operating mode: workstation or production</span>
-            <sl-select
-              value=${this.serverMode || 'workstation'}
-              @sl-change=${(e: Event) => {
-                this.serverMode = (e.target as HTMLSelectElement).value;
-              }}
-            >
-              <sl-option value="workstation">Workstation</sl-option>
-              <sl-option value="production">Production</sl-option>
-            </sl-select>
+            ${this.renderFieldValue(
+              'server.mode',
+              this.serverMode || 'workstation',
+              html`<sl-select
+                value=${this.serverMode || 'workstation'}
+                @sl-change=${(e: Event) => {
+                  this.serverMode = (e.target as HTMLSelectElement).value;
+                }}
+              >
+                <sl-option value="workstation">Workstation</sl-option>
+                <sl-option value="production">Production</sl-option>
+              </sl-select>`
+            )}
           </div>
           <div class="form-field">
             <label>Log Level</label>
-            <sl-select
-              value=${this.logLevel || 'info'}
-              @sl-change=${(e: Event) => {
-                this.logLevel = (e.target as HTMLSelectElement).value;
-              }}
-            >
-              <sl-option value="debug">Debug</sl-option>
-              <sl-option value="info">Info</sl-option>
-              <sl-option value="warn">Warn</sl-option>
-              <sl-option value="error">Error</sl-option>
-            </sl-select>
+            ${this.renderFieldValue(
+              'server.log_level',
+              this.logLevel || 'info',
+              html`<sl-select
+                value=${this.logLevel || 'info'}
+                @sl-change=${(e: Event) => {
+                  this.logLevel = (e.target as HTMLSelectElement).value;
+                }}
+              >
+                <sl-option value="debug">Debug</sl-option>
+                <sl-option value="info">Info</sl-option>
+                <sl-option value="warn">Warn</sl-option>
+                <sl-option value="error">Error</sl-option>
+              </sl-select>`
+            )}
           </div>
           <div class="form-field">
             <label>Log Format</label>
-            <sl-select
-              value=${this.logFormat || 'text'}
-              @sl-change=${(e: Event) => {
-                this.logFormat = (e.target as HTMLSelectElement).value;
-              }}
-            >
-              <sl-option value="text">Text</sl-option>
-              <sl-option value="json">JSON</sl-option>
-            </sl-select>
+            ${this.renderFieldValue(
+              'server.log_format',
+              this.logFormat || 'text',
+              html`<sl-select
+                value=${this.logFormat || 'text'}
+                @sl-change=${(e: Event) => {
+                  this.logFormat = (e.target as HTMLSelectElement).value;
+                }}
+              >
+                <sl-option value="text">Text</sl-option>
+                <sl-option value="json">JSON</sl-option>
+              </sl-select>`
+            )}
           </div>
           <div class="form-field">
             <label>Active Profile</label>
             <span class="hint">Default runtime profile for agents</span>
-            <sl-input
-              value=${this.activeProfile}
-              placeholder="default"
-              @sl-input=${(e: Event) => {
-                this.activeProfile = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'active_profile',
+              this.activeProfile,
+              html`<sl-input
+                value=${this.activeProfile}
+                placeholder="default"
+                @sl-input=${(e: Event) => {
+                  this.activeProfile = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field">
             <label>Default Template</label>
-            ${this.renderEnvBadge('default_template')}
-            <sl-input
-              value=${this.defaultTemplate}
-              placeholder="default"
-              @sl-input=${(e: Event) => {
-                this.defaultTemplate = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'default_template',
+              this.defaultTemplate,
+              html`${this.renderEnvBadge('default_template')}<sl-input
+                value=${this.defaultTemplate}
+                placeholder="default"
+                @sl-input=${(e: Event) => {
+                  this.defaultTemplate = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field">
             <label>Default Harness Config</label>
-            ${this.renderEnvBadge('default_harness_config')}
-            <sl-input
-              value=${this.defaultHarnessConfig}
-              @sl-input=${(e: Event) => {
-                this.defaultHarnessConfig = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'default_harness_config',
+              this.defaultHarnessConfig,
+              html`${this.renderEnvBadge('default_harness_config')}<sl-input
+                value=${this.defaultHarnessConfig}
+                @sl-input=${(e: Event) => {
+                  this.defaultHarnessConfig = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field full-width">
             <label>Image Registry</label>
-            ${this.renderEnvBadge('image_registry')}
             <span class="hint"
               >Container image registry for agent images (e.g., ghcr.io/myorg)</span
             >
-            <sl-input
-              value=${this.imageRegistry}
-              placeholder="ghcr.io/myorg"
-              @sl-input=${(e: Event) => {
-                this.imageRegistry = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'image_registry',
+              this.imageRegistry,
+              html`${this.renderEnvBadge('image_registry')}<sl-input
+                value=${this.imageRegistry}
+                placeholder="ghcr.io/myorg"
+                @sl-input=${(e: Event) => {
+                  this.imageRegistry = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field full-width">
             <label>Workspace Path</label>
             <span class="hint">Override default workspace path for agent worktrees</span>
-            <sl-input
-              value=${this.workspacePath}
-              @sl-input=${(e: Event) => {
-                this.workspacePath = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'workspace_path',
+              this.workspacePath,
+              html`<sl-input
+                value=${this.workspacePath}
+                @sl-input=${(e: Event) => {
+                  this.workspacePath = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
         </div>
       </div>
@@ -1839,48 +1922,60 @@ export class ScionPageAdminServerConfig extends LitElement {
         <div class="form-grid">
           <div class="form-field">
             <label>Default Max Turns</label>
-            ${this.renderEnvBadge('default_max_turns')}
             <span class="hint">Maximum conversation turns for new agents</span>
-            <sl-input
-              type="number"
-              value=${this.defaultMaxTurns ? String(this.defaultMaxTurns) : ''}
-              placeholder="No limit"
-              @sl-input=${(e: Event) => {
-                this.defaultMaxTurns = parseInt((e.target as HTMLInputElement).value) || 0;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'default_max_turns',
+              this.defaultMaxTurns ? String(this.defaultMaxTurns) : '',
+              html`${this.renderEnvBadge('default_max_turns')}<sl-input
+                type="number"
+                value=${this.defaultMaxTurns ? String(this.defaultMaxTurns) : ''}
+                placeholder="No limit"
+                @sl-input=${(e: Event) => {
+                  this.defaultMaxTurns = parseInt((e.target as HTMLInputElement).value) || 0;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field">
             <label>Default Max Model Calls</label>
-            ${this.renderEnvBadge('default_max_model_calls')}
             <span class="hint">Maximum LLM API calls for new agents</span>
-            <sl-input
-              type="number"
-              value=${this.defaultMaxModelCalls ? String(this.defaultMaxModelCalls) : ''}
-              placeholder="No limit"
-              @sl-input=${(e: Event) => {
-                this.defaultMaxModelCalls = parseInt((e.target as HTMLInputElement).value) || 0;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'default_max_model_calls',
+              this.defaultMaxModelCalls ? String(this.defaultMaxModelCalls) : '',
+              html`${this.renderEnvBadge('default_max_model_calls')}<sl-input
+                type="number"
+                value=${this.defaultMaxModelCalls ? String(this.defaultMaxModelCalls) : ''}
+                placeholder="No limit"
+                @sl-input=${(e: Event) => {
+                  this.defaultMaxModelCalls = parseInt((e.target as HTMLInputElement).value) || 0;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field full-width">
             <label>Default Max Duration</label>
-            ${this.renderEnvBadge('default_max_duration')}
             <span class="hint">Maximum execution time (Go duration, e.g. 2h, 30m)</span>
-            <sl-input
-              value=${this.defaultMaxDuration}
-              placeholder="e.g. 2h, 30m"
-              @sl-input=${(e: Event) => {
-                this.defaultMaxDuration = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'default_max_duration',
+              this.defaultMaxDuration,
+              html`${this.renderEnvBadge('default_max_duration')}<sl-input
+                value=${this.defaultMaxDuration}
+                placeholder="e.g. 2h, 30m"
+                @sl-input=${(e: Event) => {
+                  this.defaultMaxDuration = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
         </div>
       </div>
 
       <div class="section">
         <h3 class="section-title">Default Agent Resources</h3>
-        ${this.renderEnvBadge('default_resources')}
+        ${this.renderFieldValue(
+          'default_resources',
+          [this.defaultResCpuReq, this.defaultResMemReq, this.defaultResCpuLim, this.defaultResMemLim, this.defaultResDisk].filter(Boolean).join(', '),
+          html`${this.renderEnvBadge('default_resources')}
         <div class="form-grid">
           <div class="form-field">
             <label>CPU Request</label>
@@ -1932,7 +2027,8 @@ export class ScionPageAdminServerConfig extends LitElement {
               }}
             ></sl-input>
           </div>
-        </div>
+        </div>`
+        )}
       </div>
 
       ${this.renderMessageBrokerSection()}
@@ -1945,24 +2041,32 @@ export class ScionPageAdminServerConfig extends LitElement {
         <h3 class="section-title">Message Broker</h3>
         <div class="form-grid">
           <div class="form-field">
-            <sl-switch
-              ?checked=${this.messageBrokerEnabled}
-              @sl-change=${(e: Event) => {
-                this.messageBrokerEnabled = (e.target as HTMLInputElement).checked;
-              }}
-              >Enable Message Broker</sl-switch
-            >
+            ${this.renderFieldValue(
+              'server.message_broker.enabled',
+              this.messageBrokerEnabled ? 'Enabled' : 'Disabled',
+              html`<sl-switch
+                ?checked=${this.messageBrokerEnabled}
+                @sl-change=${(e: Event) => {
+                  this.messageBrokerEnabled = (e.target as HTMLInputElement).checked;
+                }}
+                >Enable Message Broker</sl-switch
+              >`
+            )}
           </div>
           <div class="form-field">
             <label>Type</label>
-            <sl-select
-              value=${this.messageBrokerType || 'inprocess'}
-              @sl-change=${(e: Event) => {
-                this.messageBrokerType = (e.target as HTMLSelectElement).value;
-              }}
-            >
-              <sl-option value="inprocess">In-Process</sl-option>
-            </sl-select>
+            ${this.renderFieldValue(
+              'server.message_broker.type',
+              this.messageBrokerType || 'inprocess',
+              html`<sl-select
+                value=${this.messageBrokerType || 'inprocess'}
+                @sl-change=${(e: Event) => {
+                  this.messageBrokerType = (e.target as HTMLSelectElement).value;
+                }}
+              >
+                <sl-option value="inprocess">In-Process</sl-option>
+              </sl-select>`
+            )}
           </div>
         </div>
       </div>
@@ -1978,69 +2082,91 @@ export class ScionPageAdminServerConfig extends LitElement {
           <div class="form-field">
             <label>Port</label>
             <span class="hint">Requires restart</span>
-            <sl-input
-              type="number"
-              value=${String(this.hubPort || 9810)}
-              @sl-input=${(e: Event) => {
-                this.hubPort = parseInt((e.target as HTMLInputElement).value) || 0;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.hub.port',
+              String(this.hubPort || 9810),
+              html`<sl-input
+                type="number"
+                value=${String(this.hubPort || 9810)}
+                @sl-input=${(e: Event) => {
+                  this.hubPort = parseInt((e.target as HTMLInputElement).value) || 0;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field">
             <label>Host</label>
             <span class="hint">Requires restart</span>
-            <sl-input
-              value=${this.hubHost || '0.0.0.0'}
-              @sl-input=${(e: Event) => {
-                this.hubHost = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.hub.host',
+              this.hubHost || '0.0.0.0',
+              html`<sl-input
+                value=${this.hubHost || '0.0.0.0'}
+                @sl-input=${(e: Event) => {
+                  this.hubHost = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field full-width">
             <label>Public URL</label>
-            ${this.renderEnvBadge('server.hub.public_url')}
             <span class="hint">Endpoint URL for agents to call back to the Hub</span>
-            <sl-input
-              value=${this.hubPublicUrl}
-              placeholder="https://hub.example.com"
-              @sl-input=${(e: Event) => {
-                this.hubPublicUrl = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.hub.public_url',
+              this.hubPublicUrl,
+              html`${this.renderEnvBadge('server.hub.public_url')}<sl-input
+                value=${this.hubPublicUrl}
+                placeholder="https://hub.example.com"
+                @sl-input=${(e: Event) => {
+                  this.hubPublicUrl = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field">
             <label>Read Timeout</label>
-            <sl-input
-              value=${this.hubReadTimeout || '30s'}
-              placeholder="30s"
-              @sl-input=${(e: Event) => {
-                this.hubReadTimeout = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.hub.read_timeout',
+              this.hubReadTimeout || '30s',
+              html`<sl-input
+                value=${this.hubReadTimeout || '30s'}
+                placeholder="30s"
+                @sl-input=${(e: Event) => {
+                  this.hubReadTimeout = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field">
             <label>Write Timeout</label>
-            <sl-input
-              value=${this.hubWriteTimeout || '60s'}
-              placeholder="60s"
-              @sl-input=${(e: Event) => {
-                this.hubWriteTimeout = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.hub.write_timeout',
+              this.hubWriteTimeout || '60s',
+              html`<sl-input
+                value=${this.hubWriteTimeout || '60s'}
+                placeholder="60s"
+                @sl-input=${(e: Event) => {
+                  this.hubWriteTimeout = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field full-width">
             <label>Admin Emails</label>
-            ${this.renderEnvBadge('server.hub.admin_emails')}
             <span class="hint"
               >Comma-separated list of email addresses to auto-promote to admin</span
             >
-            <sl-input
-              value=${this.hubAdminEmails}
-              placeholder="admin@example.com, ops@example.com"
-              @sl-input=${(e: Event) => {
-                this.hubAdminEmails = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.hub.admin_emails',
+              this.hubAdminEmails,
+              html`${this.renderEnvBadge('server.hub.admin_emails')}<sl-input
+                value=${this.hubAdminEmails}
+                placeholder="admin@example.com, ops@example.com"
+                @sl-input=${(e: Event) => {
+                  this.hubAdminEmails = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
         </div>
       </div>
@@ -2051,38 +2177,47 @@ export class ScionPageAdminServerConfig extends LitElement {
         <div class="form-grid">
           <div class="form-field">
             <label>Soft Delete Retention</label>
-            ${this.renderEnvBadge('server.hub.soft_delete_retention')}
             <span class="hint"
               >How long soft-deleted agents are retained (e.g., 72h). Empty disables
               soft-delete.</span
             >
-            <sl-input
-              value=${this.hubSoftDeleteRetention}
-              placeholder="72h"
-              @sl-input=${(e: Event) => {
-                this.hubSoftDeleteRetention = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.hub.soft_delete_retention',
+              this.hubSoftDeleteRetention || '—',
+              html`${this.renderEnvBadge('server.hub.soft_delete_retention')}<sl-input
+                value=${this.hubSoftDeleteRetention}
+                placeholder="72h"
+                @sl-input=${(e: Event) => {
+                  this.hubSoftDeleteRetention = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field">
-            ${this.renderEnvBadge('server.hub.soft_delete_retain_files')}
-            <sl-switch
-              ?checked=${this.hubSoftDeleteRetainFiles}
-              @sl-change=${(e: Event) => {
-                this.hubSoftDeleteRetainFiles = (e.target as HTMLInputElement).checked;
-              }}
-              >Retain files on soft delete</sl-switch
-            >
+            ${this.renderFieldValue(
+              'server.hub.soft_delete_retain_files',
+              this.hubSoftDeleteRetainFiles ? 'Enabled' : 'Disabled',
+              html`${this.renderEnvBadge('server.hub.soft_delete_retain_files')}<sl-switch
+                ?checked=${this.hubSoftDeleteRetainFiles}
+                @sl-change=${(e: Event) => {
+                  this.hubSoftDeleteRetainFiles = (e.target as HTMLInputElement).checked;
+                }}
+                >Retain files on soft delete</sl-switch
+              >`
+            )}
           </div>
           <div class="form-field">
-            ${this.renderEnvBadge('server.hub.auto_suspend_stalled')}
-            <sl-switch
-              ?checked=${this.hubAutoSuspendStalled}
-              @sl-change=${(e: Event) => {
-                this.hubAutoSuspendStalled = (e.target as HTMLInputElement).checked;
-              }}
-              >Auto-suspend stalled agents</sl-switch
-            >
+            ${this.renderFieldValue(
+              'server.hub.auto_suspend_stalled',
+              this.hubAutoSuspendStalled ? 'Enabled' : 'Disabled',
+              html`${this.renderEnvBadge('server.hub.auto_suspend_stalled')}<sl-switch
+                ?checked=${this.hubAutoSuspendStalled}
+                @sl-change=${(e: Event) => {
+                  this.hubAutoSuspendStalled = (e.target as HTMLInputElement).checked;
+                }}
+                >Auto-suspend stalled agents</sl-switch
+              >`
+            )}
             <span class="hint"
               >When enabled, agents detected as stalled are automatically suspended (container
               stopped, session preserved for resume).</span
@@ -2099,48 +2234,64 @@ export class ScionPageAdminServerConfig extends LitElement {
         <h3 class="section-title">Runtime Broker</h3>
         <div class="form-grid">
           <div class="form-field full-width">
-            <sl-switch
-              ?checked=${this.brokerEnabled}
-              @sl-change=${(e: Event) => {
-                this.brokerEnabled = (e.target as HTMLInputElement).checked;
-              }}
-              >Enable Runtime Broker</sl-switch
-            >
+            ${this.renderFieldValue(
+              'server.broker.enabled',
+              this.brokerEnabled ? 'Enabled' : 'Disabled',
+              html`<sl-switch
+                ?checked=${this.brokerEnabled}
+                @sl-change=${(e: Event) => {
+                  this.brokerEnabled = (e.target as HTMLInputElement).checked;
+                }}
+                >Enable Runtime Broker</sl-switch
+              >`
+            )}
             <span class="hint">Requires restart</span>
           </div>
           <div class="form-field">
             <label>Port</label>
             <span class="hint">Requires restart</span>
-            <sl-input
-              type="number"
-              value=${String(this.brokerPort || 9800)}
-              @sl-input=${(e: Event) => {
-                this.brokerPort = parseInt((e.target as HTMLInputElement).value) || 0;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.broker.port',
+              String(this.brokerPort || 9800),
+              html`<sl-input
+                type="number"
+                value=${String(this.brokerPort || 9800)}
+                @sl-input=${(e: Event) => {
+                  this.brokerPort = parseInt((e.target as HTMLInputElement).value) || 0;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field">
             <label>Host</label>
             <span class="hint">Requires restart</span>
-            <sl-input
-              value=${this.brokerHost || '0.0.0.0'}
-              @sl-input=${(e: Event) => {
-                this.brokerHost = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.broker.host',
+              this.brokerHost || '0.0.0.0',
+              html`<sl-input
+                value=${this.brokerHost || '0.0.0.0'}
+                @sl-input=${(e: Event) => {
+                  this.brokerHost = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field full-width">
             <label>Hub Endpoint</label>
             <span class="hint"
               >Hub API endpoint for status reporting (when Hub not co-located)</span
             >
-            <sl-input
-              value=${this.brokerHubEndpoint}
-              placeholder="https://hub.example.com"
-              @sl-input=${(e: Event) => {
-                this.brokerHubEndpoint = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.broker.hub_endpoint',
+              this.brokerHubEndpoint || '—',
+              html`<sl-input
+                value=${this.brokerHubEndpoint}
+                placeholder="https://hub.example.com"
+                @sl-input=${(e: Event) => {
+                  this.brokerHubEndpoint = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field full-width">
             <label>Container Hub Endpoint</label>
@@ -2148,39 +2299,55 @@ export class ScionPageAdminServerConfig extends LitElement {
               >Override Hub URL injected into agent containers (e.g.,
               host.containers.internal)</span
             >
-            <sl-input
-              value=${this.brokerContainerHubEndpoint}
-              @sl-input=${(e: Event) => {
-                this.brokerContainerHubEndpoint = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.broker.container_hub_endpoint',
+              this.brokerContainerHubEndpoint || '—',
+              html`<sl-input
+                value=${this.brokerContainerHubEndpoint}
+                @sl-input=${(e: Event) => {
+                  this.brokerContainerHubEndpoint = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field">
             <label>Broker Name</label>
-            <sl-input
-              value=${this.brokerName}
-              @sl-input=${(e: Event) => {
-                this.brokerName = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.broker.name',
+              this.brokerName || '—',
+              html`<sl-input
+                value=${this.brokerName}
+                @sl-input=${(e: Event) => {
+                  this.brokerName = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field">
             <label>Broker Nickname</label>
-            <sl-input
-              value=${this.brokerNickname}
-              @sl-input=${(e: Event) => {
-                this.brokerNickname = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.broker.nickname',
+              this.brokerNickname || '—',
+              html`<sl-input
+                value=${this.brokerNickname}
+                @sl-input=${(e: Event) => {
+                  this.brokerNickname = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field full-width">
-            <sl-switch
-              ?checked=${this.brokerAutoProvide}
-              @sl-change=${(e: Event) => {
-                this.brokerAutoProvide = (e.target as HTMLInputElement).checked;
-              }}
-              >Auto-provide to hub projects</sl-switch
-            >
+            ${this.renderFieldValue(
+              'server.broker.auto_provide',
+              this.brokerAutoProvide ? 'Enabled' : 'Disabled',
+              html`<sl-switch
+                ?checked=${this.brokerAutoProvide}
+                @sl-change=${(e: Event) => {
+                  this.brokerAutoProvide = (e.target as HTMLInputElement).checked;
+                }}
+                >Auto-provide to hub projects</sl-switch
+              >`
+            )}
           </div>
         </div>
       </div>
@@ -2195,28 +2362,36 @@ export class ScionPageAdminServerConfig extends LitElement {
           <div class="form-field">
             <label>Driver</label>
             <span class="hint">Requires restart</span>
-            <sl-select
-              value=${this.dbDriver || 'sqlite'}
-              @sl-change=${(e: Event) => {
-                this.dbDriver = (e.target as HTMLSelectElement).value;
-              }}
-            >
-              <sl-option value="sqlite">SQLite</sl-option>
-              <sl-option value="postgres">PostgreSQL</sl-option>
-            </sl-select>
+            ${this.renderFieldValue(
+              'server.database.driver',
+              this.dbDriver || 'sqlite',
+              html`<sl-select
+                value=${this.dbDriver || 'sqlite'}
+                @sl-change=${(e: Event) => {
+                  this.dbDriver = (e.target as HTMLSelectElement).value;
+                }}
+              >
+                <sl-option value="sqlite">SQLite</sl-option>
+                <sl-option value="postgres">PostgreSQL</sl-option>
+              </sl-select>`
+            )}
           </div>
           <div class="form-field">
             <label>URL</label>
             <span class="hint"
               >Requires restart. ${this.dbUrl === '********' ? 'Value is masked.' : ''}</span
             >
-            <sl-input
-              value=${this.dbUrl}
-              placeholder="Path or connection string"
-              @sl-input=${(e: Event) => {
-                this.dbUrl = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.database.url',
+              this.dbUrl === '********' ? '********' : (this.dbUrl || '—'),
+              html`<sl-input
+                value=${this.dbUrl}
+                placeholder="Path or connection string"
+                @sl-input=${(e: Event) => {
+                  this.dbUrl = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
         </div>
       </div>
@@ -2226,33 +2401,45 @@ export class ScionPageAdminServerConfig extends LitElement {
         <div class="form-grid">
           <div class="form-field">
             <label>Provider</label>
-            <sl-select
-              value=${this.storageProvider || 'local'}
-              @sl-change=${(e: Event) => {
-                this.storageProvider = (e.target as HTMLSelectElement).value;
-              }}
-            >
-              <sl-option value="local">Local</sl-option>
-              <sl-option value="gcs">Google Cloud Storage</sl-option>
-            </sl-select>
+            ${this.renderFieldValue(
+              'server.storage.provider',
+              this.storageProvider || 'local',
+              html`<sl-select
+                value=${this.storageProvider || 'local'}
+                @sl-change=${(e: Event) => {
+                  this.storageProvider = (e.target as HTMLSelectElement).value;
+                }}
+              >
+                <sl-option value="local">Local</sl-option>
+                <sl-option value="gcs">Google Cloud Storage</sl-option>
+              </sl-select>`
+            )}
           </div>
           <div class="form-field">
             <label>Bucket</label>
-            <sl-input
-              value=${this.storageBucket}
-              @sl-input=${(e: Event) => {
-                this.storageBucket = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.storage.bucket',
+              this.storageBucket || '—',
+              html`<sl-input
+                value=${this.storageBucket}
+                @sl-input=${(e: Event) => {
+                  this.storageBucket = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field full-width">
             <label>Local Path</label>
-            <sl-input
-              value=${this.storageLocalPath}
-              @sl-input=${(e: Event) => {
-                this.storageLocalPath = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.storage.local_path',
+              this.storageLocalPath || '—',
+              html`<sl-input
+                value=${this.storageLocalPath}
+                @sl-input=${(e: Event) => {
+                  this.storageLocalPath = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
         </div>
       </div>
@@ -2263,24 +2450,32 @@ export class ScionPageAdminServerConfig extends LitElement {
           <div class="form-field">
             <label>Backend</label>
             <span class="hint">Requires restart</span>
-            <sl-select
-              value=${this.secretsBackend || 'local'}
-              @sl-change=${(e: Event) => {
-                this.secretsBackend = (e.target as HTMLSelectElement).value;
-              }}
-            >
-              <sl-option value="local">Local</sl-option>
-              <sl-option value="gcpsm">GCP Secret Manager</sl-option>
-            </sl-select>
+            ${this.renderFieldValue(
+              'server.secrets.backend',
+              this.secretsBackend || 'local',
+              html`<sl-select
+                value=${this.secretsBackend || 'local'}
+                @sl-change=${(e: Event) => {
+                  this.secretsBackend = (e.target as HTMLSelectElement).value;
+                }}
+              >
+                <sl-option value="local">Local</sl-option>
+                <sl-option value="gcpsm">GCP Secret Manager</sl-option>
+              </sl-select>`
+            )}
           </div>
           <div class="form-field">
             <label>GCP Project ID</label>
-            <sl-input
-              value=${this.secretsGCPProjectId}
-              @sl-input=${(e: Event) => {
-                this.secretsGCPProjectId = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.secrets.gcp_project_id',
+              this.secretsGCPProjectId || '—',
+              html`<sl-input
+                value=${this.secretsGCPProjectId}
+                @sl-input=${(e: Event) => {
+                  this.secretsGCPProjectId = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
         </div>
       </div>
@@ -2295,24 +2490,27 @@ export class ScionPageAdminServerConfig extends LitElement {
         <div class="form-grid">
           <div class="form-field full-width">
             <label>Access Mode</label>
-            ${this.renderEnvBadge('server.auth.user_access_mode')}
             <span class="hint"
               >Controls who can log in to this hub. Takes effect immediately (hot-reloaded).</span
             >
-            <sl-select
-              value=${this.authUserAccessMode}
-              @sl-change=${(e: Event) => {
-                this.authUserAccessMode = (e.target as HTMLSelectElement).value;
-              }}
-            >
-              <sl-option value="open">Open (all authenticated users)</sl-option>
-              <sl-option value="domain_restricted"
-                >Domain Restricted (authorized domains only)</sl-option
+            ${this.renderFieldValue(
+              'server.auth.user_access_mode',
+              this.authUserAccessMode,
+              html`${this.renderEnvBadge('server.auth.user_access_mode')}<sl-select
+                value=${this.authUserAccessMode}
+                @sl-change=${(e: Event) => {
+                  this.authUserAccessMode = (e.target as HTMLSelectElement).value;
+                }}
               >
-              <sl-option value="invite_only"
-                >Invite Only (allow list + authorized domains)</sl-option
-              >
-            </sl-select>
+                <sl-option value="open">Open (all authenticated users)</sl-option>
+                <sl-option value="domain_restricted"
+                  >Domain Restricted (authorized domains only)</sl-option
+                >
+                <sl-option value="invite_only"
+                  >Invite Only (allow list + authorized domains)</sl-option
+                >
+              </sl-select>`
+            )}
             ${this.authUserAccessMode === 'invite_only'
               ? html`<sl-alert variant="warning" open style="margin-top: 0.75rem">
                   <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
@@ -2332,13 +2530,17 @@ export class ScionPageAdminServerConfig extends LitElement {
         <h3 class="section-title">Development Auth</h3>
         <div class="form-grid">
           <div class="form-field full-width">
-            <sl-switch
-              ?checked=${this.authDevMode}
-              @sl-change=${(e: Event) => {
-                this.authDevMode = (e.target as HTMLInputElement).checked;
-              }}
-              >Enable Dev Auth</sl-switch
-            >
+            ${this.renderFieldValue(
+              'server.auth.dev_mode',
+              this.authDevMode ? 'Enabled' : 'Disabled',
+              html`<sl-switch
+                ?checked=${this.authDevMode}
+                @sl-change=${(e: Event) => {
+                  this.authDevMode = (e.target as HTMLInputElement).checked;
+                }}
+                >Enable Dev Auth</sl-switch
+              >`
+            )}
             <span class="hint">Requires restart. NOT for production use.</span>
           </div>
           <div class="form-field full-width">
@@ -2348,26 +2550,33 @@ export class ScionPageAdminServerConfig extends LitElement {
                 ? 'Value is masked. Clear to auto-generate.'
                 : 'Leave empty to auto-generate.'}</span
             >
-            <sl-input
-              value=${this.authDevToken}
-              @sl-input=${(e: Event) => {
-                this.authDevToken = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.auth.dev_token',
+              this.authDevToken === '********' ? '********' : (this.authDevToken || '—'),
+              html`<sl-input
+                value=${this.authDevToken}
+                @sl-input=${(e: Event) => {
+                  this.authDevToken = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field full-width">
             <label>Authorized Domains</label>
-            ${this.renderEnvBadge('server.auth.authorized_domains')}
             <span class="hint"
               >Comma-separated list of email domains allowed to authenticate (empty = all)</span
             >
-            <sl-input
-              value=${this.authAuthorizedDomains}
-              placeholder="example.com, corp.example.com"
-              @sl-input=${(e: Event) => {
-                this.authAuthorizedDomains = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.auth.authorized_domains',
+              this.authAuthorizedDomains || '—',
+              html`${this.renderEnvBadge('server.auth.authorized_domains')}<sl-input
+                value=${this.authAuthorizedDomains}
+                placeholder="example.com, corp.example.com"
+                @sl-input=${(e: Event) => {
+                  this.authAuthorizedDomains = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
         </div>
       </div>
@@ -2425,14 +2634,17 @@ export class ScionPageAdminServerConfig extends LitElement {
         ${this.renderSectionMeta('telemetry')}
         <div class="form-grid">
           <div class="form-field full-width">
-            ${this.renderEnvBadge('telemetry.enabled')}
-            <sl-switch
-              ?checked=${this.telemetryEnabled}
-              @sl-change=${(e: Event) => {
-                this.telemetryEnabled = (e.target as HTMLInputElement).checked;
-              }}
-              >Enable Telemetry Collection</sl-switch
-            >
+            ${this.renderFieldValue(
+              'telemetry.enabled',
+              this.telemetryEnabled ? 'Enabled' : 'Disabled',
+              html`${this.renderEnvBadge('telemetry.enabled')}<sl-switch
+                ?checked=${this.telemetryEnabled}
+                @sl-change=${(e: Event) => {
+                  this.telemetryEnabled = (e.target as HTMLInputElement).checked;
+                }}
+                >Enable Telemetry Collection</sl-switch
+              >`
+            )}
             <span class="hint">Default opt-in state for new agents</span>
           </div>
         </div>
@@ -2442,50 +2654,62 @@ export class ScionPageAdminServerConfig extends LitElement {
         <h3 class="section-title">Cloud Export (OTLP)</h3>
         <div class="form-grid">
           <div class="form-field full-width">
-            ${this.renderEnvBadge('telemetry.cloud.enabled')}
-            <sl-switch
-              ?checked=${this.telemetryCloudEnabled}
-              @sl-change=${(e: Event) => {
-                this.telemetryCloudEnabled = (e.target as HTMLInputElement).checked;
-              }}
-              >Enable Cloud Export</sl-switch
-            >
+            ${this.renderFieldValue(
+              'telemetry.cloud.enabled',
+              this.telemetryCloudEnabled ? 'Enabled' : 'Disabled',
+              html`${this.renderEnvBadge('telemetry.cloud.enabled')}<sl-switch
+                ?checked=${this.telemetryCloudEnabled}
+                @sl-change=${(e: Event) => {
+                  this.telemetryCloudEnabled = (e.target as HTMLInputElement).checked;
+                }}
+                >Enable Cloud Export</sl-switch
+              >`
+            )}
           </div>
           <div class="form-field full-width">
             <label>Endpoint</label>
-            ${this.renderEnvBadge('telemetry.cloud.endpoint')}
-            <sl-input
-              value=${this.telemetryCloudEndpoint}
-              placeholder="https://otel-collector.example.com:4317"
-              @sl-input=${(e: Event) => {
-                this.telemetryCloudEndpoint = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'telemetry.cloud.endpoint',
+              this.telemetryCloudEndpoint || '—',
+              html`${this.renderEnvBadge('telemetry.cloud.endpoint')}<sl-input
+                value=${this.telemetryCloudEndpoint}
+                placeholder="https://otel-collector.example.com:4317"
+                @sl-input=${(e: Event) => {
+                  this.telemetryCloudEndpoint = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field">
             <label>Protocol</label>
-            ${this.renderEnvBadge('telemetry.cloud.protocol')}
-            <sl-select
-              value=${this.telemetryCloudProtocol || 'grpc'}
-              @sl-change=${(e: Event) => {
-                this.telemetryCloudProtocol = (e.target as HTMLSelectElement).value;
-              }}
-            >
-              <sl-option value="grpc">gRPC</sl-option>
-              <sl-option value="http/protobuf">HTTP/Protobuf</sl-option>
-              <sl-option value="http/json">HTTP/JSON</sl-option>
-            </sl-select>
+            ${this.renderFieldValue(
+              'telemetry.cloud.protocol',
+              this.telemetryCloudProtocol || 'grpc',
+              html`${this.renderEnvBadge('telemetry.cloud.protocol')}<sl-select
+                value=${this.telemetryCloudProtocol || 'grpc'}
+                @sl-change=${(e: Event) => {
+                  this.telemetryCloudProtocol = (e.target as HTMLSelectElement).value;
+                }}
+              >
+                <sl-option value="grpc">gRPC</sl-option>
+                <sl-option value="http/protobuf">HTTP/Protobuf</sl-option>
+                <sl-option value="http/json">HTTP/JSON</sl-option>
+              </sl-select>`
+            )}
           </div>
           <div class="form-field">
             <label>Provider</label>
-            ${this.renderEnvBadge('telemetry.cloud.provider')}
-            <sl-input
-              value=${this.telemetryCloudProvider}
-              placeholder="e.g., gcp"
-              @sl-input=${(e: Event) => {
-                this.telemetryCloudProvider = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'telemetry.cloud.provider',
+              this.telemetryCloudProvider || '—',
+              html`${this.renderEnvBadge('telemetry.cloud.provider')}<sl-input
+                value=${this.telemetryCloudProvider}
+                placeholder="e.g., gcp"
+                @sl-input=${(e: Event) => {
+                  this.telemetryCloudProvider = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
         </div>
       </div>
@@ -2494,25 +2718,31 @@ export class ScionPageAdminServerConfig extends LitElement {
         <h3 class="section-title">Hub Reporting</h3>
         <div class="form-grid">
           <div class="form-field">
-            ${this.renderEnvBadge('telemetry.hub.enabled')}
-            <sl-switch
-              ?checked=${this.telemetryHubEnabled}
-              @sl-change=${(e: Event) => {
-                this.telemetryHubEnabled = (e.target as HTMLInputElement).checked;
-              }}
-              >Enable Hub Reporting</sl-switch
-            >
+            ${this.renderFieldValue(
+              'telemetry.hub.enabled',
+              this.telemetryHubEnabled ? 'Enabled' : 'Disabled',
+              html`${this.renderEnvBadge('telemetry.hub.enabled')}<sl-switch
+                ?checked=${this.telemetryHubEnabled}
+                @sl-change=${(e: Event) => {
+                  this.telemetryHubEnabled = (e.target as HTMLInputElement).checked;
+                }}
+                >Enable Hub Reporting</sl-switch
+              >`
+            )}
           </div>
           <div class="form-field">
             <label>Report Interval</label>
-            ${this.renderEnvBadge('telemetry.hub.report_interval')}
-            <sl-input
-              value=${this.telemetryHubReportInterval}
-              placeholder="30s"
-              @sl-input=${(e: Event) => {
-                this.telemetryHubReportInterval = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'telemetry.hub.report_interval',
+              this.telemetryHubReportInterval || '—',
+              html`${this.renderEnvBadge('telemetry.hub.report_interval')}<sl-input
+                value=${this.telemetryHubReportInterval}
+                placeholder="30s"
+                @sl-input=${(e: Event) => {
+                  this.telemetryHubReportInterval = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
         </div>
       </div>
@@ -2521,35 +2751,44 @@ export class ScionPageAdminServerConfig extends LitElement {
         <h3 class="section-title">Local Debug Output</h3>
         <div class="form-grid">
           <div class="form-field">
-            ${this.renderEnvBadge('telemetry.local.enabled')}
-            <sl-switch
-              ?checked=${this.telemetryLocalEnabled}
-              @sl-change=${(e: Event) => {
-                this.telemetryLocalEnabled = (e.target as HTMLInputElement).checked;
-              }}
-              >Enable Local Output</sl-switch
-            >
+            ${this.renderFieldValue(
+              'telemetry.local.enabled',
+              this.telemetryLocalEnabled ? 'Enabled' : 'Disabled',
+              html`${this.renderEnvBadge('telemetry.local.enabled')}<sl-switch
+                ?checked=${this.telemetryLocalEnabled}
+                @sl-change=${(e: Event) => {
+                  this.telemetryLocalEnabled = (e.target as HTMLInputElement).checked;
+                }}
+                >Enable Local Output</sl-switch
+              >`
+            )}
           </div>
           <div class="form-field">
-            ${this.renderEnvBadge('telemetry.local.console')}
-            <sl-switch
-              ?checked=${this.telemetryLocalConsole}
-              @sl-change=${(e: Event) => {
-                this.telemetryLocalConsole = (e.target as HTMLInputElement).checked;
-              }}
-              >Console Output</sl-switch
-            >
+            ${this.renderFieldValue(
+              'telemetry.local.console',
+              this.telemetryLocalConsole ? 'Enabled' : 'Disabled',
+              html`${this.renderEnvBadge('telemetry.local.console')}<sl-switch
+                ?checked=${this.telemetryLocalConsole}
+                @sl-change=${(e: Event) => {
+                  this.telemetryLocalConsole = (e.target as HTMLInputElement).checked;
+                }}
+                >Console Output</sl-switch
+              >`
+            )}
           </div>
           <div class="form-field full-width">
             <label>Log File</label>
-            ${this.renderEnvBadge('telemetry.local.file')}
-            <sl-input
-              value=${this.telemetryLocalFile}
-              placeholder="/var/log/scion/telemetry.log"
-              @sl-input=${(e: Event) => {
-                this.telemetryLocalFile = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'telemetry.local.file',
+              this.telemetryLocalFile || '—',
+              html`${this.renderEnvBadge('telemetry.local.file')}<sl-input
+                value=${this.telemetryLocalFile}
+                placeholder="/var/log/scion/telemetry.log"
+                @sl-input=${(e: Event) => {
+                  this.telemetryLocalFile = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
         </div>
       </div>
@@ -2683,30 +2922,36 @@ export class ScionPageAdminServerConfig extends LitElement {
         <div class="form-grid">
           <div class="form-field">
             <label>App ID</label>
-            ${this.renderEnvBadge('server.github_app.app_id', 'server.github_app')}
             <span class="hint">The numeric ID of your registered GitHub App</span>
-            <sl-input
-              .value=${this.githubAppId ? String(this.githubAppId) : ''}
-              placeholder="e.g. 123456"
-              inputmode="numeric"
-              @sl-input=${(e: Event) => {
-                this.githubAppId = parseInt((e.target as HTMLInputElement).value) || 0;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.github_app.app_id',
+              this.githubAppId ? String(this.githubAppId) : '—',
+              html`${this.renderEnvBadge('server.github_app.app_id', 'server.github_app')}<sl-input
+                .value=${this.githubAppId ? String(this.githubAppId) : ''}
+                placeholder="e.g. 123456"
+                inputmode="numeric"
+                @sl-input=${(e: Event) => {
+                  this.githubAppId = parseInt((e.target as HTMLInputElement).value) || 0;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field">
             <label>API Base URL</label>
-            ${this.renderEnvBadge('server.github_app.api_base_url', 'server.github_app')}
             <span class="hint"
               >Override for GitHub Enterprise Server (leave empty for github.com)</span
             >
-            <sl-input
-              .value=${this.githubAppApiBaseUrl}
-              placeholder="https://api.github.com"
-              @sl-input=${(e: Event) => {
-                this.githubAppApiBaseUrl = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.github_app.api_base_url',
+              this.githubAppApiBaseUrl || '—',
+              html`${this.renderEnvBadge('server.github_app.api_base_url', 'server.github_app')}<sl-input
+                .value=${this.githubAppApiBaseUrl}
+                placeholder="https://api.github.com"
+                @sl-input=${(e: Event) => {
+                  this.githubAppApiBaseUrl = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
           <div class="form-field full-width">
             <label>Private Key (PEM)</label>
@@ -2757,30 +3002,36 @@ export class ScionPageAdminServerConfig extends LitElement {
           </div>
           <div class="form-field">
             <label>Webhooks</label>
-            ${this.renderEnvBadge('server.github_app.webhooks_enabled', 'server.github_app')}
             <span class="hint">Enable to receive installation lifecycle events from GitHub</span>
-            <sl-switch
-              .checked=${this.githubAppWebhooksEnabled}
-              @sl-change=${(e: Event) => {
-                this.githubAppWebhooksEnabled = (e.target as HTMLInputElement).checked;
-              }}
-            >
-              ${this.githubAppWebhooksEnabled ? 'Enabled' : 'Disabled'}
-            </sl-switch>
+            ${this.renderFieldValue(
+              'server.github_app.webhooks_enabled',
+              this.githubAppWebhooksEnabled ? 'Enabled' : 'Disabled',
+              html`${this.renderEnvBadge('server.github_app.webhooks_enabled', 'server.github_app')}<sl-switch
+                .checked=${this.githubAppWebhooksEnabled}
+                @sl-change=${(e: Event) => {
+                  this.githubAppWebhooksEnabled = (e.target as HTMLInputElement).checked;
+                }}
+              >
+                ${this.githubAppWebhooksEnabled ? 'Enabled' : 'Disabled'}
+              </sl-switch>`
+            )}
           </div>
           <div class="form-field full-width">
             <label>Public Installation URL</label>
-            ${this.renderEnvBadge('server.github_app.installation_url', 'server.github_app')}
             <span class="hint"
               >The public link where users can install this GitHub App on their org or account</span
             >
-            <sl-input
-              .value=${this.githubAppInstallationUrl}
-              placeholder="https://github.com/apps/your-app-name/installations/new"
-              @sl-input=${(e: Event) => {
-                this.githubAppInstallationUrl = (e.target as HTMLInputElement).value;
-              }}
-            ></sl-input>
+            ${this.renderFieldValue(
+              'server.github_app.installation_url',
+              this.githubAppInstallationUrl || '—',
+              html`${this.renderEnvBadge('server.github_app.installation_url', 'server.github_app')}<sl-input
+                .value=${this.githubAppInstallationUrl}
+                placeholder="https://github.com/apps/your-app-name/installations/new"
+                @sl-input=${(e: Event) => {
+                  this.githubAppInstallationUrl = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
           </div>
         </div>
 

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -1147,12 +1147,12 @@ export class ScionPageAdminServerConfig extends LitElement {
     if (this.hubPublicUrl) hub.public_url = this.hubPublicUrl;
     if (this.hubReadTimeout) hub.read_timeout = this.hubReadTimeout;
     if (this.hubWriteTimeout) hub.write_timeout = this.hubWriteTimeout;
-    if (this.hubAdminEmails) {
-      hub.admin_emails = this.hubAdminEmails
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean);
-    }
+    hub.admin_emails = this.hubAdminEmails
+      ? this.hubAdminEmails
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
     if (this.hubSoftDeleteRetention) hub.soft_delete_retention = this.hubSoftDeleteRetention;
     hub.soft_delete_retain_files = this.hubSoftDeleteRetainFiles;
     hub.auto_suspend_stalled = this.hubAutoSuspendStalled;

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -1435,12 +1435,10 @@ export class ScionPageAdminServerConfig extends LitElement {
 
     // Broker, database, storage, secrets, message_broker — all Layer-0, omitted
 
-    // Preserve notification channels, OAuth, and GitHub App from raw config
+    // Preserve notification channels and GitHub App from raw config
+    // (server.oauth is Layer-0 / secrets stack — excluded from DB payload)
     if (this.rawConfig?.server?.notification_channels) {
       server.notification_channels = this.rawConfig.server.notification_channels;
-    }
-    if (this.rawConfig?.server?.oauth) {
-      server.oauth = this.rawConfig.server.oauth;
     }
     if (this.rawConfig?.server?.github_app) {
       server.github_app = this.rawConfig.server.github_app;

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -1360,17 +1360,17 @@ export class ScionPageAdminServerConfig extends LitElement {
     const ok = (key: string) => this.readOnlyReason(key) === null;
 
     // General — only Layer-1 top-level keys
-    if (ok('default_template')) payload.default_template = this.defaultTemplate || undefined;
+    if (ok('default_template')) payload.default_template = this.defaultTemplate;
     if (ok('default_harness_config'))
-      payload.default_harness_config = this.defaultHarnessConfig || undefined;
-    if (ok('image_registry')) payload.image_registry = this.imageRegistry || undefined;
+      payload.default_harness_config = this.defaultHarnessConfig;
+    if (ok('image_registry')) payload.image_registry = this.imageRegistry;
 
     // Default agent limits
-    if (ok('default_max_turns')) payload.default_max_turns = this.defaultMaxTurns || undefined;
+    if (ok('default_max_turns')) payload.default_max_turns = this.defaultMaxTurns;
     if (ok('default_max_model_calls'))
-      payload.default_max_model_calls = this.defaultMaxModelCalls || undefined;
+      payload.default_max_model_calls = this.defaultMaxModelCalls;
     if (ok('default_max_duration'))
-      payload.default_max_duration = this.defaultMaxDuration || undefined;
+      payload.default_max_duration = this.defaultMaxDuration;
 
     if (
       ok('default_resources') &&
@@ -1401,7 +1401,7 @@ export class ScionPageAdminServerConfig extends LitElement {
 
     // Hub — only Layer-1 hub fields
     const hub: Record<string, unknown> = {};
-    if (ok('server.hub.public_url') && this.hubPublicUrl) hub.public_url = this.hubPublicUrl;
+    if (ok('server.hub.public_url')) hub.public_url = this.hubPublicUrl;
     if (ok('server.hub.admin_emails')) {
       hub.admin_emails = this.hubAdminEmails
         ? this.hubAdminEmails
@@ -1410,7 +1410,7 @@ export class ScionPageAdminServerConfig extends LitElement {
             .filter(Boolean)
         : [];
     }
-    if (ok('server.hub.soft_delete_retention') && this.hubSoftDeleteRetention)
+    if (ok('server.hub.soft_delete_retention'))
       hub.soft_delete_retention = this.hubSoftDeleteRetention;
     if (ok('server.hub.soft_delete_retain_files'))
       hub.soft_delete_retain_files = this.hubSoftDeleteRetainFiles;
@@ -1420,14 +1420,16 @@ export class ScionPageAdminServerConfig extends LitElement {
 
     // Auth — only Layer-1 auth fields
     const auth: Record<string, unknown> = {};
-    if (ok('server.auth.user_access_mode') && this.authUserAccessMode) {
+    if (ok('server.auth.user_access_mode')) {
       auth.user_access_mode = this.authUserAccessMode;
     }
-    if (ok('server.auth.authorized_domains') && this.authAuthorizedDomains) {
+    if (ok('server.auth.authorized_domains')) {
       auth.authorized_domains = this.authAuthorizedDomains
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean);
+        ? this.authAuthorizedDomains
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : [];
     }
     if (Object.keys(auth).length > 0) server.auth = auth;
 
@@ -1454,21 +1456,21 @@ export class ScionPageAdminServerConfig extends LitElement {
       if (ok('telemetry.cloud.enabled')) {
         telemetry.cloud = {
           enabled: this.telemetryCloudEnabled,
-          endpoint: this.telemetryCloudEndpoint || undefined,
-          protocol: this.telemetryCloudProtocol || undefined,
-          provider: this.telemetryCloudProvider || undefined,
+          endpoint: this.telemetryCloudEndpoint,
+          protocol: this.telemetryCloudProtocol,
+          provider: this.telemetryCloudProvider,
         };
       }
       if (ok('telemetry.hub.enabled')) {
         telemetry.hub = {
           enabled: this.telemetryHubEnabled,
-          report_interval: this.telemetryHubReportInterval || undefined,
+          report_interval: this.telemetryHubReportInterval,
         };
       }
       if (ok('telemetry.local.enabled')) {
         telemetry.local = {
           enabled: this.telemetryLocalEnabled,
-          file: this.telemetryLocalFile || undefined,
+          file: this.telemetryLocalFile,
           console: this.telemetryLocalConsole,
         };
       }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -36,6 +36,7 @@
     "exclude": [
         "node_modules",
         "dist",
-        "public"
+        "public",
+        "src/**/*.test.ts"
     ]
 }

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
+  esbuild: {
+    target: 'esnext',
+  },
+  test: {
+    environment: 'happy-dom',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Implements the seed/managed settings model for Hub admin settings. Key changes:

- SCION_SEED_* env namespace for bootstrap-only settings
- origin column on hub_settings (seeded vs managed lifecycle)
- Layer-aware UI: admin settings form no longer re-emits Layer-0 fields in DB mode
- Structured error handling for settings API responses
- Presence/boolean correctness for Layer-1 field updates
- Origin captions and superseded-by-DB notices in UI
- Component tests for settings UI

Related issues: https://github.com/ptone/scion/issues/438 https://github.com/ptone/scion/issues/439 https://github.com/ptone/scion/issues/391