### PR TITLE
fix(hub): apply image_registry when dispatching agents to remote brokers

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -313,6 +313,13 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		util.Debugf("image resolution: from agent/template config image=%s", resolvedImage)
 	}
 
+	// Apply CLI/dispatch image override before registry rewrite so the
+	// rewrite applies last regardless of the image source.
+	if opts.Image != "" {
+		resolvedImage = opts.Image
+		util.Debugf("image resolution: from CLI/dispatch --image flag image=%s", resolvedImage)
+	}
+
 	// Two-phase image resolution: for short-form (bare) images, prefer a
 	// locally-built image over the registry version. If no local image
 	// exists, fall back to the registry rewrite.
@@ -336,12 +343,6 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 				resolvedImage = rewritten
 			}
 		}
-	}
-
-	// CLI Overrides
-	if opts.Image != "" {
-		resolvedImage = opts.Image
-		util.Debugf("image resolution: from CLI --image flag image=%s", resolvedImage)
 	}
 
 	if resolvedImage == "" {

--- a/pkg/agent/run_test.go
+++ b/pkg/agent/run_test.go
@@ -2596,3 +2596,72 @@ runtimes:
 		t.Errorf("GOOGLE_CLOUD_REGION = %q, want %q", got, "us-central1")
 	}
 }
+
+func TestStartImageRegistryRewriteAfterOptsImage(t *testing.T) {
+	// Verify that the image_registry rewrite is applied AFTER the opts.Image
+	// override, so a bare image from the dispatch request gets rewritten.
+	tmpDir := t.TempDir()
+
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(tmpDir)
+	defer func() { _ = os.Chdir(oldWd) }()
+
+	originalHome := os.Getenv("HOME")
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+	_ = os.Setenv("HOME", tmpDir)
+
+	globalScionDir := filepath.Join(tmpDir, ".scion")
+
+	hcDir := filepath.Join(globalScionDir, "harness-configs", "test-harness")
+	_ = os.MkdirAll(hcDir, 0755)
+	_ = os.WriteFile(filepath.Join(hcDir, "config.yaml"), []byte("harness: generic\nuser: scion\nimage: default-image:latest\n"), 0644)
+
+	tplDir := filepath.Join(globalScionDir, "templates", "default")
+	_ = os.MkdirAll(tplDir, 0755)
+	_ = os.WriteFile(filepath.Join(tplDir, "scion-agent.json"), []byte(`{"default_harness_config": "test-harness"}`), 0644)
+
+	_ = os.WriteFile(filepath.Join(globalScionDir, "settings.yaml"), []byte(`schema_version: "1"
+active_profile: local
+profiles:
+  local:
+    runtime: docker
+    image_registry: us-docker.pkg.dev/my-project/scion
+`), 0644)
+
+	projectDir := filepath.Join(tmpDir, "project")
+	projectScionDir := filepath.Join(projectDir, ".scion")
+	_ = os.MkdirAll(projectScionDir, 0755)
+
+	var capturedConfig runtime.RunConfig
+	mockRT := &runtime.MockRuntime{
+		ListFunc: func(ctx context.Context, labelFilter map[string]string) ([]api.AgentInfo, error) {
+			return []api.AgentInfo{}, nil
+		},
+		RunFunc: func(ctx context.Context, cfg runtime.RunConfig) (string, error) {
+			capturedConfig = cfg
+			return "mock-id", nil
+		},
+		ImageExistsFunc: func(ctx context.Context, image string) (bool, error) {
+			return false, nil
+		},
+	}
+
+	mgr := NewManager(mockRT)
+
+	_, err := mgr.Start(context.Background(), api.StartOptions{
+		Name:        "test-agent",
+		ProjectPath: projectScionDir,
+		Image:       "scion-custom:latest",
+		BrokerMode:  true,
+		NoAuth:      true,
+	})
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	want := "us-docker.pkg.dev/my-project/scion/scion-custom:latest"
+	if capturedConfig.Image != want {
+		t.Errorf("expected image %q after registry rewrite of opts.Image, got %q",
+			want, capturedConfig.Image)
+	}
+}

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/observability/dispatchmetrics"
 	"github.com/GoogleCloudPlatform/scion/pkg/secret"
@@ -153,6 +154,10 @@ type HTTPAgentDispatcher struct {
 	commandBus      CommandBus
 	dispatchMetrics dispatchmetrics.Recorder
 
+	// imageRegistry is the configured image registry prefix for rewriting
+	// bare image names before dispatching to brokers.
+	imageRegistry string
+
 	// Resource hash repair callbacks sync a resource's DB manifest from GCS
 	// when a hash mismatch is detected during dispatch. Nil = no repair.
 	harnessConfigRepairer func(ctx context.Context, name string) error
@@ -241,6 +246,12 @@ func (d *HTTPAgentDispatcher) SetDispatchMetrics(rec dispatchmetrics.Recorder) {
 // DB manifest from storage when a hash mismatch is detected during dispatch.
 func (d *HTTPAgentDispatcher) SetHarnessConfigRepairer(fn func(ctx context.Context, name string) error) {
 	d.harnessConfigRepairer = fn
+}
+
+// SetImageRegistry sets the image registry prefix for rewriting bare image
+// names before dispatching to brokers.
+func (d *HTTPAgentDispatcher) SetImageRegistry(registry string) {
+	d.imageRegistry = registry
 }
 
 // SetTemplateRepairer registers a callback that syncs a template's DB manifest
@@ -430,9 +441,13 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 				ProjectID:    gcpID.ProjectID,
 			}
 		}
+		image := agent.AppliedConfig.Image
+		if image != "" && d.imageRegistry != "" {
+			image = config.RewriteImageRegistry(image, d.imageRegistry)
+		}
 		req.Config = &RemoteAgentConfig{
 			Template:          agent.Template,
-			Image:             agent.AppliedConfig.Image,
+			Image:             image,
 			HarnessConfig:     agent.AppliedConfig.HarnessConfig,
 			HarnessAuth:       agent.AppliedConfig.HarnessAuth,
 			Task:              agent.AppliedConfig.Task,

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -3371,3 +3371,143 @@ func TestBuildCreateRequest_NoAuth_SkipsSecrets(t *testing.T) {
 		}
 	})
 }
+
+func TestHTTPAgentDispatcher_DispatchAgentCreate_AppliesImageRegistry(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("host-1"),
+		Name:     "test-host",
+		Slug:     "test-host",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	dispatcher.SetImageRegistry("us-docker.pkg.dev/my-project/scion")
+
+	agent := &store.Agent{
+		ID:              tid("agent-1"),
+		Name:            "test-agent",
+		Slug:            "test-agent",
+		ProjectID:       tid("project-1"),
+		RuntimeBrokerID: tid("host-1"),
+		AppliedConfig: &store.AgentAppliedConfig{
+			HarnessConfig: "claude",
+			Task:          "do something",
+			Image:         "scion-claude:latest",
+		},
+	}
+
+	err := dispatcher.DispatchAgentCreate(ctx, agent)
+	if err != nil {
+		t.Fatalf("DispatchAgentCreate failed: %v", err)
+	}
+
+	if !mockClient.createCalled {
+		t.Fatal("expected CreateAgent to be called")
+	}
+	if mockClient.lastCreateReq.Config == nil {
+		t.Fatal("expected config to be present")
+	}
+	want := "us-docker.pkg.dev/my-project/scion/scion-claude:latest"
+	if mockClient.lastCreateReq.Config.Image != want {
+		t.Errorf("expected image %q after registry rewrite, got %q",
+			want, mockClient.lastCreateReq.Config.Image)
+	}
+}
+
+func TestHTTPAgentDispatcher_DispatchAgentCreate_NoRegistryNoRewrite(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("host-1"),
+		Name:     "test-host",
+		Slug:     "test-host",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	// No SetImageRegistry call — registry is empty
+
+	agent := &store.Agent{
+		ID:              tid("agent-1"),
+		Name:            "test-agent",
+		Slug:            "test-agent",
+		ProjectID:       tid("project-1"),
+		RuntimeBrokerID: tid("host-1"),
+		AppliedConfig: &store.AgentAppliedConfig{
+			HarnessConfig: "claude",
+			Image:         "scion-claude:latest",
+		},
+	}
+
+	err := dispatcher.DispatchAgentCreate(ctx, agent)
+	if err != nil {
+		t.Fatalf("DispatchAgentCreate failed: %v", err)
+	}
+
+	if mockClient.lastCreateReq.Config == nil {
+		t.Fatal("expected config to be present")
+	}
+	if mockClient.lastCreateReq.Config.Image != "scion-claude:latest" {
+		t.Errorf("expected bare image when no registry set, got %q",
+			mockClient.lastCreateReq.Config.Image)
+	}
+}
+
+func TestHTTPAgentDispatcher_DispatchAgentCreate_FullyQualifiedImageNotRewritten(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("host-1"),
+		Name:     "test-host",
+		Slug:     "test-host",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	dispatcher.SetImageRegistry("us-docker.pkg.dev/my-project/scion")
+
+	agent := &store.Agent{
+		ID:              tid("agent-1"),
+		Name:            "test-agent",
+		Slug:            "test-agent",
+		ProjectID:       tid("project-1"),
+		RuntimeBrokerID: tid("host-1"),
+		AppliedConfig: &store.AgentAppliedConfig{
+			HarnessConfig: "claude",
+			Image:         "ghcr.io/custom/image:v2",
+		},
+	}
+
+	err := dispatcher.DispatchAgentCreate(ctx, agent)
+	if err != nil {
+		t.Fatalf("DispatchAgentCreate failed: %v", err)
+	}
+
+	if mockClient.lastCreateReq.Config == nil {
+		t.Fatal("expected config to be present")
+	}
+	if mockClient.lastCreateReq.Config.Image != "ghcr.io/custom/image:v2" {
+		t.Errorf("expected fully-qualified image to be unchanged, got %q",
+			mockClient.lastCreateReq.Config.Image)
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1904,6 +1904,9 @@ func (s *Server) CreateAuthenticatedDispatcher() *HTTPAgentDispatcher {
 	dispatcher.SetHarnessConfigRepairer(s.syncHarnessConfigFromStorage)
 	dispatcher.SetTemplateRepairer(s.syncTemplateFromStorage)
 
+	// Set image registry so bare image names are rewritten before dispatch
+	dispatcher.SetImageRegistry(s.resolveImageRegistry())
+
 	return dispatcher
 }
 


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/443 — image_registry was not applied when dispatching to hosted/remote brokers. Adds RewriteImageRegistry call in HTTPAgentDispatcher.buildCreateRequest, wires registry config via SetImageRegistry, and reorders opts.Image before rewrite so all image sources are covered. Idempotent for fully-qualified images. 4 new tests