### PR TITLE
feat(agent): per-agent workspace subdir for directory projects

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -66,6 +66,7 @@ var (
 	attach                bool
 	branch                string
 	workspace             string
+	workspaceSubdir       string
 	runtimeBrokerID       string
 	harnessConfigFlag     string
 	harnessAuthFlag       string
@@ -510,20 +511,21 @@ func RunAgent(cmd *cobra.Command, args []string, resume bool) error {
 	}
 
 	opts := api.StartOptions{
-		Name:          agentName,
-		Task:          effectiveTask,
-		Template:      templateName,
-		Profile:       profile,
-		HarnessConfig: effectiveHarnessConfig,
-		HarnessAuth:   effectiveHarnessAuth,
-		Image:         resolvedImage,
-		ProjectPath:   projectPath,
-		Resume:        effectiveResume,
-		Detached:      detached,
-		NoAuth:        noAuth,
-		Branch:        effectiveBranch,
-		Workspace:     workspace,
-		InlineConfig:  inlineCfg,
+		Name:            agentName,
+		Task:            effectiveTask,
+		Template:        templateName,
+		Profile:         profile,
+		HarnessConfig:   effectiveHarnessConfig,
+		HarnessAuth:     effectiveHarnessAuth,
+		Image:           resolvedImage,
+		ProjectPath:     projectPath,
+		Resume:          effectiveResume,
+		Detached:        detached,
+		NoAuth:          noAuth,
+		Branch:          effectiveBranch,
+		Workspace:       workspace,
+		WorkspaceSubdir: workspaceSubdir,
+		InlineConfig:    inlineCfg,
 	}
 
 	// Apply telemetry override from CLI flags
@@ -720,6 +722,7 @@ func startAgentViaHub(hubCtx *HubContext, agentName, task string, resume bool, i
 		Task:            task,
 		Branch:          branch,
 		Workspace:       workspace,
+		WorkspaceSubdir: workspaceSubdir,
 		Labels:          parsedLabels,
 		Resume:          resume,
 		Attach:          attach,

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -109,16 +109,17 @@ arguments are provided, an empty prompt.md is created for later editing.`,
 		}
 
 		opts := api.StartOptions{
-			Name:          agentName,
-			Task:          effectiveTask,
-			Template:      templateName,
-			Profile:       profile,
-			HarnessConfig: effectiveHarnessConfig,
-			Image:         effectiveImage,
-			ProjectPath:   projectPath,
-			Branch:        effectiveBranch,
-			Workspace:     workspace,
-			InlineConfig:  inlineCfg,
+			Name:            agentName,
+			Task:            effectiveTask,
+			Template:        templateName,
+			Profile:         profile,
+			HarnessConfig:   effectiveHarnessConfig,
+			Image:           effectiveImage,
+			ProjectPath:     projectPath,
+			Branch:          effectiveBranch,
+			Workspace:       workspace,
+			WorkspaceSubdir: workspaceSubdir,
+			InlineConfig:    inlineCfg,
 		}
 
 		// Check if agent already exists (directory on disk or running container)
@@ -323,6 +324,7 @@ func init() {
 	createCmd.Flags().StringVarP(&agentImage, "image", "i", "", "Container image to use (overrides template)")
 	createCmd.Flags().StringVarP(&branch, "branch", "b", "", "Git branch to use for the agent workspace")
 	createCmd.Flags().StringVarP(&workspace, "workspace", "w", "", "Host path to mount as /workspace")
+	createCmd.Flags().StringVar(&workspaceSubdir, "workspace-subdir", "", "Project-relative subpath to mount at /workspace (directory/non-git projects)")
 	createCmd.Flags().StringVar(&runtimeBrokerID, "broker", "", "Preferred runtime broker ID or name")
 	createCmd.Flags().StringVar(&harnessConfigFlag, "harness-config", "", "Named harness configuration to use")
 	createCmd.Flags().StringVar(&harnessConfigFlag, "harness", "h", "Named harness configuration to use (alias for --harness-config)")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -51,6 +51,7 @@ func init() {
 	startCmd.Flags().StringVarP(&branch, "branch", "b", "", "Git branch to use for the agent workspace")
 
 	startCmd.Flags().StringVarP(&workspace, "workspace", "w", "", "Host path to mount as /workspace")
+	startCmd.Flags().StringVar(&workspaceSubdir, "workspace-subdir", "", "Project-relative subpath to mount at /workspace (directory/non-git projects)")
 
 	startCmd.Flags().StringVar(&runtimeBrokerID, "broker", "", "Preferred runtime broker ID or name")
 	startCmd.Flags().StringVar(&harnessConfigFlag, "harness-config", "", "Named harness configuration to use")

--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -637,8 +637,13 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 
 	// Requested a subdir but didn't take the Case-3 directory-project branch
 	// (git / explicit --workspace / clone / shared): surface the no-op.
+	var subdirWarning string
 	if subdir := api.WorkspaceSubdirFromContext(ctx); subdir != "" && !subdirApplied {
-		fmt.Fprintf(os.Stderr, "Warning: --workspace-subdir %q is ignored for this project type (only honored for directory/non-git projects without an explicit --workspace); mounting the default workspace instead\n", subdir)
+		subdirWarning = fmt.Sprintf("--workspace-subdir %q is ignored for this project type (only honored for directory/non-git projects without an explicit --workspace); mounting the default workspace instead", subdir)
+		// Stderr is the only surface a local (--no-hub) user sees; the copy on
+		// info.Warnings below is for hub/broker consumers, which never see this
+		// process's stderr. No path echoes both, so this never double-prints.
+		fmt.Fprintf(os.Stderr, "Warning: %s\n", subdirWarning)
 	}
 
 	// Worktree Creation (if needed)
@@ -1193,6 +1198,11 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 	}
 	if agentImage != "" {
 		info.Image = agentImage
+	}
+	// Carry the ignored-subdir warning into AgentInfo (and agent-info.json) so
+	// hub-dispatched provisioning surfaces it beyond the broker's stderr.
+	if subdirWarning != "" {
+		info.Warnings = append(info.Warnings, subdirWarning)
 	}
 
 	agentCfgData, err := json.MarshalIndent(finalScionCfg, "", "  ")

--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -340,6 +340,9 @@ func (m *AgentManager) Provision(ctx context.Context, opts api.StartOptions) (*a
 	if opts.GitClone != nil {
 		ctx = api.ContextWithGitClone(ctx, opts.GitClone)
 	}
+	if opts.WorkspaceSubdir != "" {
+		ctx = api.ContextWithWorkspaceSubdir(ctx, opts.WorkspaceSubdir)
+	}
 	if opts.SharedWorkspace {
 		ctx = api.ContextWithSharedWorkspace(ctx)
 	}
@@ -395,6 +398,54 @@ func resolveHarnessConfigDir(ctx context.Context, name, projectPath string, temp
 		return config.LoadHarnessConfigDir(hcPath)
 	}
 	return config.FindHarnessConfigDir(name, projectPath, templatePaths...)
+}
+
+// resolveWorkspaceSubdir joins a project-relative subdir onto base and returns
+// the absolute path to mount, rejecting any escape of base (absolute paths,
+// "..", or symlinks pointing outside). The subdir must already exist.
+func resolveWorkspaceSubdir(base, subdir string) (string, error) {
+	if filepath.IsAbs(subdir) {
+		return "", fmt.Errorf("workspace subdir must be a relative path within the project workspace, got absolute path: %s", subdir)
+	}
+
+	// Cheap "../" reject before any FS access.
+	cleaned := filepath.Clean(subdir)
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("workspace subdir escapes the project workspace: %s", subdir)
+	}
+
+	absBase, err := filepath.Abs(base)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve project workspace path %s: %w", base, err)
+	}
+	joined := filepath.Join(absBase, cleaned)
+
+	if _, err := os.Stat(joined); err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("workspace subdir does not exist: %s", joined)
+		}
+		return "", fmt.Errorf("failed to stat workspace subdir %s: %w", joined, err)
+	}
+
+	// EvalSymlinks both sides so an in-workspace symlink can't escape.
+	realBase, err := filepath.EvalSymlinks(absBase)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve project workspace path %s: %w", absBase, err)
+	}
+	realJoined, err := filepath.EvalSymlinks(joined)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve workspace subdir %s: %w", joined, err)
+	}
+
+	rel, err := filepath.Rel(realBase, realJoined)
+	if err != nil {
+		return "", fmt.Errorf("workspace subdir %s is not within the project workspace %s: %w", subdir, realBase, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("workspace subdir escapes the project workspace: %s", subdir)
+	}
+
+	return realJoined, nil
 }
 
 func ProvisionAgent(ctx context.Context, agentName string, templateName string, agentImage string, harnessConfig string, projectPath string, profileName string, optionalStatus string, branch string, workspace string, inlineConfig ...*api.ScionConfig) (string, string, *api.ScionConfig, error) {
@@ -477,6 +528,7 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 	var workspaceSource string
 	shouldCreateWorktree := false
 	explicitWorkspace := false
+	subdirApplied := false
 
 	// Check for git clone mode from context
 	gitClone := api.GitCloneFromContext(ctx)
@@ -568,6 +620,25 @@ func ProvisionAgent(ctx context.Context, agentName string, templateName string, 
 			workspaceSource = filepath.Dir(projectDir)
 		}
 		agentWorkspace = "" // Using external mount
+
+		// The only place a caller-supplied within-project subpath is honored —
+		// the feature's security boundary.
+		if subdir := api.WorkspaceSubdirFromContext(ctx); subdir != "" && workspaceSource != "" {
+			resolved, err := resolveWorkspaceSubdir(workspaceSource, subdir)
+			if err != nil {
+				return "", "", nil, err
+			}
+			workspaceSource = resolved
+			// Mark explicit so resume re-derives this subpath, not the project root.
+			explicitWorkspace = true
+			subdirApplied = true
+		}
+	}
+
+	// Requested a subdir but didn't take the Case-3 directory-project branch
+	// (git / explicit --workspace / clone / shared): surface the no-op.
+	if subdir := api.WorkspaceSubdirFromContext(ctx); subdir != "" && !subdirApplied {
+		fmt.Fprintf(os.Stderr, "Warning: --workspace-subdir %q is ignored for this project type (only honored for directory/non-git projects without an explicit --workspace); mounting the default workspace instead\n", subdir)
 	}
 
 	// Worktree Creation (if needed)

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -122,6 +122,9 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 	if opts.GitClone != nil {
 		ctx = api.ContextWithGitClone(ctx, opts.GitClone)
 	}
+	if opts.WorkspaceSubdir != "" {
+		ctx = api.ContextWithWorkspaceSubdir(ctx, opts.WorkspaceSubdir)
+	}
 	if opts.HarnessConfigPath != "" {
 		ctx = api.ContextWithHarnessConfigPath(ctx, opts.HarnessConfigPath)
 	}

--- a/pkg/agent/workspace_subdir_test.go
+++ b/pkg/agent/workspace_subdir_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
@@ -38,6 +39,18 @@ func workspaceMountSource(cfg *api.ScionConfig) string {
 		}
 	}
 	return ""
+}
+
+// subdirWarnings returns the ignored-subdir warnings recorded on the
+// provisioned AgentInfo.
+func subdirWarnings(warnings []string) []string {
+	var out []string
+	for _, w := range warnings {
+		if strings.Contains(w, "--workspace-subdir") {
+			out = append(out, w)
+		}
+	}
+	return out
 }
 
 // TestProvisionAgentWorkspaceSubdir: a within-project subpath survives to the
@@ -90,6 +103,40 @@ func TestProvisionAgentWorkspaceSubdir(t *testing.T) {
 		if evalSrc != wantSub {
 			t.Errorf("mount source = %q, want subdir %q", evalSrc, wantSub)
 		}
+		if cfg.Info == nil {
+			t.Fatal("expected cfg.Info to be set")
+		}
+		if got := subdirWarnings(cfg.Info.Warnings); len(got) != 0 {
+			t.Errorf("honored subdir must carry no ignored-subdir warning, got %v", got)
+		}
+	})
+
+	t.Run("ignored subdir is surfaced in AgentInfo warnings", func(t *testing.T) {
+		// Explicit --workspace wins (Case 1), so the requested subdir is a no-op.
+		ctx := api.ContextWithWorkspaceSubdir(context.Background(), subRel)
+		home, _, cfg, err := ProvisionAgent(ctx, "ignored-agent", "default", "", "", projectScionDir, "", "", "", evalProjectDir)
+		if err != nil {
+			t.Fatalf("ProvisionAgent failed: %v", err)
+		}
+		if cfg.Info == nil {
+			t.Fatal("expected cfg.Info to be set")
+		}
+		if got := subdirWarnings(cfg.Info.Warnings); len(got) != 1 {
+			t.Fatalf("want exactly 1 ignored-subdir warning in cfg.Info.Warnings, got %v", cfg.Info.Warnings)
+		}
+
+		// Persisted agent-info.json (the hub/broker-visible copy) carries it too.
+		raw, err := os.ReadFile(filepath.Join(home, "agent-info.json"))
+		if err != nil {
+			t.Fatalf("read agent-info.json: %v", err)
+		}
+		var persisted api.AgentInfo
+		if err := json.Unmarshal(raw, &persisted); err != nil {
+			t.Fatalf("unmarshal agent-info.json: %v", err)
+		}
+		if got := subdirWarnings(persisted.Warnings); len(got) != 1 {
+			t.Fatalf("want exactly 1 ignored-subdir warning in agent-info.json, got %v", persisted.Warnings)
+		}
 	})
 
 	t.Run("no subdir mounts the project root unchanged", func(t *testing.T) {
@@ -104,6 +151,11 @@ func TestProvisionAgentWorkspaceSubdir(t *testing.T) {
 		evalSrc, _ := filepath.EvalSymlinks(src)
 		if evalSrc != evalProjectDir {
 			t.Errorf("mount source = %q, want project root %q", evalSrc, evalProjectDir)
+		}
+		if cfg.Info != nil {
+			if got := subdirWarnings(cfg.Info.Warnings); len(got) != 0 {
+				t.Errorf("no-subdir provision must carry no ignored-subdir warning, got %v", got)
+			}
 		}
 	})
 

--- a/pkg/agent/workspace_subdir_test.go
+++ b/pkg/agent/workspace_subdir_test.go
@@ -1,0 +1,284 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// workspaceMountSource returns the /workspace volume mount source from a
+// provisioned config, or "" if no such mount exists.
+func workspaceMountSource(cfg *api.ScionConfig) string {
+	if cfg == nil {
+		return ""
+	}
+	for _, v := range cfg.Volumes {
+		if v.Target == "/workspace" {
+			return v.Source
+		}
+	}
+	return ""
+}
+
+// TestProvisionAgentWorkspaceSubdir: a within-project subpath survives to the
+// /workspace mount, the default still mounts the project root, traversal is rejected.
+func TestProvisionAgentWorkspaceSubdir(t *testing.T) {
+	mockRuntimeForTest(t)
+	tmpDir := t.TempDir()
+
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(tmpDir)
+	defer func() { _ = os.Chdir(oldWd) }()
+
+	originalHome := os.Getenv("HOME")
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+	_ = os.Setenv("HOME", tmpDir)
+
+	if err := config.InitMachine(getTestHarnesses()); err != nil {
+		t.Fatalf("InitMachine failed: %v", err)
+	}
+
+	projectDir := filepath.Join(tmpDir, "project")
+	projectScionDir := filepath.Join(projectDir, ".scion")
+	if err := config.InitProject(projectScionDir, getTestHarnesses()); err != nil {
+		t.Fatalf("InitProject failed: %v", err)
+	}
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatal(err)
+	}
+
+	evalProjectDir, _ := filepath.EvalSymlinks(projectDir)
+
+	// A subdirectory within the project workspace root.
+	subRel := filepath.Join("packages", "web")
+	if err := os.MkdirAll(filepath.Join(evalProjectDir, subRel), 0755); err != nil {
+		t.Fatalf("mkdir subdir: %v", err)
+	}
+	wantSub, _ := filepath.EvalSymlinks(filepath.Join(evalProjectDir, subRel))
+
+	t.Run("subdir survives to the mount", func(t *testing.T) {
+		ctx := api.ContextWithWorkspaceSubdir(context.Background(), subRel)
+		_, _, cfg, err := ProvisionAgent(ctx, "subdir-agent", "default", "", "", projectScionDir, "", "", "", "")
+		if err != nil {
+			t.Fatalf("ProvisionAgent failed: %v", err)
+		}
+		src := workspaceMountSource(cfg)
+		if src == "" {
+			t.Fatal("expected /workspace volume mount, found none")
+		}
+		evalSrc, _ := filepath.EvalSymlinks(src)
+		if evalSrc != wantSub {
+			t.Errorf("mount source = %q, want subdir %q", evalSrc, wantSub)
+		}
+	})
+
+	t.Run("no subdir mounts the project root unchanged", func(t *testing.T) {
+		_, _, cfg, err := ProvisionAgent(context.Background(), "root-agent", "default", "", "", projectScionDir, "", "", "", "")
+		if err != nil {
+			t.Fatalf("ProvisionAgent failed: %v", err)
+		}
+		src := workspaceMountSource(cfg)
+		if src == "" {
+			t.Fatal("expected /workspace volume mount, found none")
+		}
+		evalSrc, _ := filepath.EvalSymlinks(src)
+		if evalSrc != evalProjectDir {
+			t.Errorf("mount source = %q, want project root %q", evalSrc, evalProjectDir)
+		}
+	})
+
+	t.Run("traversal subdir is rejected", func(t *testing.T) {
+		ctx := api.ContextWithWorkspaceSubdir(context.Background(), filepath.Join("..", "..", "etc"))
+		_, _, _, err := ProvisionAgent(ctx, "escape-agent", "default", "", "", projectScionDir, "", "", "", "")
+		if err == nil {
+			t.Fatal("expected ProvisionAgent to reject a traversal subdir, got nil error")
+		}
+	})
+}
+
+// TestProvisionAgentWorkspaceSubdirResumePlainMount covers resume: provisioning
+// persists ExplicitWorkspace=true, which resume reads to keep the mount plain
+// (the subdir) rather than widening to the enclosing git repo. The paired
+// explicit=false call shows the widening that flag prevents.
+func TestProvisionAgentWorkspaceSubdirResumePlainMount(t *testing.T) {
+	mockRuntimeForTest(t)
+	tmpDir := t.TempDir()
+
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }()
+
+	originalHome := os.Getenv("HOME")
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+	_ = os.Setenv("HOME", tmpDir)
+
+	if err := config.InitMachine(getTestHarnesses()); err != nil {
+		t.Fatalf("InitMachine failed: %v", err)
+	}
+
+	// Git monorepo as the project's externalized workspace root; projectDir itself
+	// is NOT git, so provisioning takes the Case-3 branch where WorkspaceSubdir applies.
+	monorepo := filepath.Join(tmpDir, "monorepo")
+	if err := os.MkdirAll(monorepo, 0755); err != nil {
+		t.Fatal(err)
+	}
+	setupGitRepo(t, monorepo)
+	realMonorepo, _ := filepath.EvalSymlinks(monorepo)
+	subRel := filepath.Join("packages", "web")
+	if err := os.MkdirAll(filepath.Join(realMonorepo, subRel), 0755); err != nil {
+		t.Fatalf("mkdir subdir: %v", err)
+	}
+	wantSub, _ := filepath.EvalSymlinks(filepath.Join(realMonorepo, subRel))
+
+	projectDir := filepath.Join(tmpDir, "project")
+	projectScionDir := filepath.Join(projectDir, ".scion")
+	if err := config.InitProject(projectScionDir, getTestHarnesses()); err != nil {
+		t.Fatalf("InitProject failed: %v", err)
+	}
+	// Point the (non-git) project's externalized workspace at the git monorepo.
+	if err := config.ReconnectProject(projectScionDir, realMonorepo); err != nil {
+		t.Fatalf("ReconnectProject failed: %v", err)
+	}
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := api.ContextWithWorkspaceSubdir(context.Background(), subRel)
+	_, _, cfg, err := ProvisionAgent(ctx, "subdir-agent", "default", "", "", projectScionDir, "", "", "", "")
+	if err != nil {
+		t.Fatalf("ProvisionAgent failed: %v", err)
+	}
+
+	// The mount source is the nested subdir, not the monorepo root.
+	evalSrc, _ := filepath.EvalSymlinks(workspaceMountSource(cfg))
+	if evalSrc != wantSub {
+		t.Fatalf("mount source = %q, want subdir %q", evalSrc, wantSub)
+	}
+
+	// (1) ExplicitWorkspace is persisted in the agent's scion-agent.json.
+	resolvedProjectDir, err := config.GetResolvedProjectDir(projectScionDir)
+	if err != nil {
+		t.Fatalf("GetResolvedProjectDir: %v", err)
+	}
+	agentCfgPath := filepath.Join(config.GetAgentDir(resolvedProjectDir, "subdir-agent", false), "scion-agent.json")
+	raw, err := os.ReadFile(agentCfgPath)
+	if err != nil {
+		t.Fatalf("read persisted scion-agent.json: %v", err)
+	}
+	var persisted api.ScionConfig
+	if err := json.Unmarshal(raw, &persisted); err != nil {
+		t.Fatalf("unmarshal persisted config: %v", err)
+	}
+	if !persisted.ExplicitWorkspace {
+		t.Fatalf("persisted scion-agent.json ExplicitWorkspace = false, want true (resume would re-widen the subdir)")
+	}
+
+	// (2) Resume re-derives explicit=true from the persisted flag; with the
+	// subdir sitting inside the git monorepo, the mount stays plain (no widening).
+	if got := detectRepoRoot(persisted.ExplicitWorkspace, wantSub, projectScionDir); got != "" {
+		t.Fatalf("resume: detectRepoRoot widened the subdir to %q, want \"\" (plain mount)", got)
+	}
+	// Sanity: without the flag, the same subdir WOULD widen to the repo root,
+	// confirming the persisted flag is what prevents the leak.
+	if got := detectRepoRoot(false, wantSub, projectScionDir); got == "" {
+		t.Fatal("expected detectRepoRoot to widen the in-repo subdir when explicit=false, got \"\"")
+	}
+}
+
+// TestResolveWorkspaceSubdir: a within-project subpath is honored; an escape
+// (absolute, "..", or symlink pointing outside the root) is rejected.
+func TestResolveWorkspaceSubdir(t *testing.T) {
+	base := t.TempDir()
+	realBase, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(base): %v", err)
+	}
+
+	// Valid nested subdir within the project workspace.
+	nested := filepath.Join(realBase, "a", "b")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+
+	// A directory OUTSIDE the project workspace root, plus a symlink inside the
+	// root that points at it — the classic symlink-escape.
+	outside := t.TempDir()
+	realOutside, _ := filepath.EvalSymlinks(outside)
+	escapeLink := filepath.Join(realBase, "escape")
+	if err := os.Symlink(realOutside, escapeLink); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	t.Run("valid nested subdir is honored", func(t *testing.T) {
+		got, err := resolveWorkspaceSubdir(realBase, filepath.Join("a", "b"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want, _ := filepath.EvalSymlinks(nested)
+		if got != want {
+			t.Errorf("resolved = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("subdir equal to root is honored", func(t *testing.T) {
+		got, err := resolveWorkspaceSubdir(realBase, ".")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != realBase {
+			t.Errorf("resolved = %q, want %q", got, realBase)
+		}
+	})
+
+	t.Run("absolute subdir is rejected", func(t *testing.T) {
+		if _, err := resolveWorkspaceSubdir(realBase, realOutside); err == nil {
+			t.Fatal("expected error for absolute subdir, got nil")
+		}
+	})
+
+	t.Run("parent traversal is rejected", func(t *testing.T) {
+		if _, err := resolveWorkspaceSubdir(realBase, ".."); err == nil {
+			t.Fatal("expected error for '..' subdir, got nil")
+		}
+	})
+
+	t.Run("nested traversal escape is rejected", func(t *testing.T) {
+		if _, err := resolveWorkspaceSubdir(realBase, filepath.Join("a", "..", "..", "elsewhere")); err == nil {
+			t.Fatal("expected error for traversal escape, got nil")
+		}
+	})
+
+	t.Run("symlink escape is rejected", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink escape test not meaningful on windows")
+		}
+		if _, err := resolveWorkspaceSubdir(realBase, "escape"); err == nil {
+			t.Fatal("expected error for symlink escape, got nil")
+		}
+	})
+
+	t.Run("nonexistent subdir is rejected", func(t *testing.T) {
+		if _, err := resolveWorkspaceSubdir(realBase, "does-not-exist"); err == nil {
+			t.Fatal("expected error for missing subdir, got nil")
+		}
+	})
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -756,6 +756,20 @@ func GitCloneFromContext(ctx context.Context) *GitCloneConfig {
 	return gc
 }
 
+type workspaceSubdirContextKey struct{}
+
+// ContextWithWorkspaceSubdir carries a requested per-agent workspace subdir
+// (project-relative) for ProvisionAgent to consume.
+func ContextWithWorkspaceSubdir(ctx context.Context, subdir string) context.Context {
+	return context.WithValue(ctx, workspaceSubdirContextKey{}, subdir)
+}
+
+// WorkspaceSubdirFromContext returns the requested subdir, or "" if unset.
+func WorkspaceSubdirFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(workspaceSubdirContextKey{}).(string)
+	return v
+}
+
 type sharedWorkspaceContextKey struct{}
 
 // ContextWithSharedWorkspace returns a new context with the shared workspace flag attached.
@@ -830,6 +844,7 @@ type StartOptions struct {
 	NoAuth            bool
 	Branch            string
 	Workspace         string
+	WorkspaceSubdir   string          // Project-relative /workspace subpath (directory/non-git projects), guarded within the project root
 	GitClone          *GitCloneConfig // When set, skip workspace creation; sciontool clones inside container
 	SharedWorkspace   bool            // When true, workspace is a shared git clone (git-workspace hybrid); skip worktree, configure credential helper
 	TelemetryOverride *bool           // Explicit telemetry override from CLI flags (--enable-telemetry / --disable-telemetry)

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -79,14 +79,15 @@ func (s *Server) getHarnessConfigFromTemplate(template *store.Template, fallback
 // and the full ScionConfig is preserved as InlineConfig for threading to the broker.
 func (s *Server) buildAppliedConfig(req CreateAgentRequest, harnessConfig string, creatorName string) *store.AgentAppliedConfig {
 	ac := &store.AgentAppliedConfig{
-		Profile:       req.Profile,
-		HarnessConfig: harnessConfig,
-		HarnessAuth:   req.HarnessAuth,
-		Task:          req.Task,
-		Attach:        req.Attach,
-		Branch:        req.Branch,
-		Workspace:     req.Workspace,
-		CreatorName:   creatorName,
+		Profile:         req.Profile,
+		HarnessConfig:   harnessConfig,
+		HarnessAuth:     req.HarnessAuth,
+		Task:            req.Task,
+		Attach:          req.Attach,
+		Branch:          req.Branch,
+		Workspace:       req.Workspace,
+		WorkspaceSubdir: req.WorkspaceSubdir,
+		CreatorName:     creatorName,
 	}
 
 	ac.NoAuth = req.NoAuth

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -75,6 +75,7 @@ type CreateAgentRequest struct {
 	Task            string            `json:"task,omitempty"`
 	Branch          string            `json:"branch,omitempty"`
 	Workspace       string            `json:"workspace,omitempty"`
+	WorkspaceSubdir string            `json:"workspaceSubdir,omitempty"` // Project-relative /workspace subpath; see RemoteAgentConfig.WorkspaceSubdir
 	Labels          map[string]string `json:"labels,omitempty"`
 	Config          *api.ScionConfig  `json:"config,omitempty"`
 	Attach          bool              `json:"attach,omitempty"`        // If true, signals interactive attach mode to the broker/harness

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -431,12 +431,15 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 			}
 		}
 		req.Config = &RemoteAgentConfig{
-			Template:          agent.Template,
-			Image:             agent.AppliedConfig.Image,
-			HarnessConfig:     agent.AppliedConfig.HarnessConfig,
-			HarnessAuth:       agent.AppliedConfig.HarnessAuth,
-			Task:              agent.AppliedConfig.Task,
-			Workspace:         workspace,
+			Template:      agent.Template,
+			Image:         agent.AppliedConfig.Image,
+			HarnessConfig: agent.AppliedConfig.HarnessConfig,
+			HarnessAuth:   agent.AppliedConfig.HarnessAuth,
+			Task:          agent.AppliedConfig.Task,
+			Workspace:     workspace,
+			// Relative — survives the projectPath clear above (which only clears
+			// the absolute Workspace); the broker joins it later.
+			WorkspaceSubdir:   agent.AppliedConfig.WorkspaceSubdir,
 			Profile:           agent.AppliedConfig.Profile,
 			Branch:            agent.AppliedConfig.Branch,
 			TemplateID:        agent.AppliedConfig.TemplateID,

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -2149,6 +2149,78 @@ func TestHTTPAgentDispatcher_DispatchAgentCreate_NoProjectSlug_LocalPathProject(
 	}
 }
 
+// TestHTTPAgentDispatcher_DispatchAgentCreate_WorkspaceSubdirSurvivesClear: a
+// relative WorkspaceSubdir reaches the broker even for a local-path project,
+// where the absolute Workspace is cleared — it must not be dropped with it.
+func TestHTTPAgentDispatcher_DispatchAgentCreate_WorkspaceSubdirSurvivesClear(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	// Directory (non-git) project reached via a broker with a local path.
+	project := &store.Project{
+		ID:   tid("project-subdir"),
+		Name: "Subdir Project",
+		Slug: "subdir-project",
+	}
+	if err := memStore.CreateProject(ctx, project); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-1"),
+		Name:     "test-broker",
+		Slug:     "test-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	provider := &store.ProjectProvider{
+		ProjectID:  tid("project-subdir"),
+		BrokerID:   tid("broker-1"),
+		BrokerName: "test-broker",
+		LocalPath:  "/home/user/projects/subdir/.scion",
+		Status:     store.BrokerStatusOnline,
+	}
+	if err := memStore.AddProjectProvider(ctx, provider); err != nil {
+		t.Fatalf("failed to add project provider: %v", err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+
+	agent := &store.Agent{
+		ID:              tid("agent-1"),
+		Name:            "test-agent",
+		Slug:            "test-agent",
+		ProjectID:       tid("project-subdir"),
+		RuntimeBrokerID: tid("broker-1"),
+		AppliedConfig: &store.AgentAppliedConfig{
+			HarnessConfig:   "claude",
+			Workspace:       "/should/be/cleared",
+			WorkspaceSubdir: "packages/web",
+		},
+	}
+
+	if err := dispatcher.DispatchAgentCreate(ctx, agent); err != nil {
+		t.Fatalf("DispatchAgentCreate failed: %v", err)
+	}
+	if mockClient.lastCreateReq.Config == nil {
+		t.Fatal("expected config to be present")
+	}
+	// The absolute Workspace is cleared for a local-path project...
+	if mockClient.lastCreateReq.Config.Workspace != "" {
+		t.Errorf("expected empty Workspace, got %q", mockClient.lastCreateReq.Config.Workspace)
+	}
+	// ...but the project-relative WorkspaceSubdir must survive to the broker.
+	if mockClient.lastCreateReq.Config.WorkspaceSubdir != "packages/web" {
+		t.Errorf("expected WorkspaceSubdir 'packages/web' to survive, got %q",
+			mockClient.lastCreateReq.Config.WorkspaceSubdir)
+	}
+}
+
 // TestHTTPAgentDispatcher_DispatchAgentCreate_LinkedProjectNoGitRemote verifies
 // that a linked project without a git remote (registered via CLI link, not via
 // git URL) uses the provider's LocalPath rather than being treated as hub-managed.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -467,17 +467,21 @@ type ResolvedSecret struct {
 
 // RemoteAgentConfig contains agent configuration for remote creation.
 type RemoteAgentConfig struct {
-	Template      string   `json:"template,omitempty"`
-	Image         string   `json:"image,omitempty"`
-	HomeDir       string   `json:"homeDir,omitempty"`
-	Workspace     string   `json:"workspace,omitempty"`
-	Env           []string `json:"env,omitempty"`
-	Task          string   `json:"task,omitempty"`
-	CommandArgs   []string `json:"commandArgs,omitempty"`
-	HarnessConfig string   `json:"harnessConfig,omitempty"` // Resolved harness config name for env-gather
-	HarnessAuth   string   `json:"harnessAuth,omitempty"`   // Late-binding override for auth_selected_type
-	Profile       string   `json:"profile,omitempty"`       // Settings profile for the runtime broker
-	Branch        string   `json:"branch,omitempty"`        // Git branch name (defaults to agent slug if empty)
+	Template  string `json:"template,omitempty"`
+	Image     string `json:"image,omitempty"`
+	HomeDir   string `json:"homeDir,omitempty"`
+	Workspace string `json:"workspace,omitempty"`
+	// WorkspaceSubdir is a project-relative /workspace subpath (directory/non-git
+	// projects). Unlike the absolute Workspace, which the hub rewrites to the
+	// project root, it survives to the broker, which joins it under a guard.
+	WorkspaceSubdir string   `json:"workspaceSubdir,omitempty"`
+	Env             []string `json:"env,omitempty"`
+	Task            string   `json:"task,omitempty"`
+	CommandArgs     []string `json:"commandArgs,omitempty"`
+	HarnessConfig   string   `json:"harnessConfig,omitempty"` // Resolved harness config name for env-gather
+	HarnessAuth     string   `json:"harnessAuth,omitempty"`   // Late-binding override for auth_selected_type
+	Profile         string   `json:"profile,omitempty"`       // Settings profile for the runtime broker
+	Branch          string   `json:"branch,omitempty"`        // Git branch name (defaults to agent slug if empty)
 
 	// TemplateID is the Hub template ID for cache lookup on the Runtime Broker.
 	// When provided, the Runtime Broker can use this to fetch the template

--- a/pkg/hubclient/agents.go
+++ b/pkg/hubclient/agents.go
@@ -168,6 +168,7 @@ type CreateAgentRequest struct {
 	Task            string            `json:"task,omitempty"`
 	Branch          string            `json:"branch,omitempty"`
 	Workspace       string            `json:"workspace,omitempty"`
+	WorkspaceSubdir string            `json:"workspaceSubdir,omitempty"` // Project-relative /workspace subpath (directory/non-git projects)
 	Labels          map[string]string `json:"labels,omitempty"`
 	Annotations     map[string]string `json:"annotations,omitempty"`
 	Config          *api.ScionConfig  `json:"config,omitempty"`

--- a/pkg/runtimebroker/start_context.go
+++ b/pkg/runtimebroker/start_context.go
@@ -384,6 +384,7 @@ func (s *Server) buildStartContext(ctx context.Context, in startContextInputs) (
 		opts.HarnessAuth = in.Config.HarnessAuth
 		opts.Task = in.Config.Task
 		opts.Workspace = in.Config.Workspace
+		opts.WorkspaceSubdir = in.Config.WorkspaceSubdir
 		opts.Profile = in.Config.Profile
 		opts.Branch = in.Config.Branch
 		opts.SharedWorkspace = in.Config.SharedWorkspace

--- a/pkg/runtimebroker/types.go
+++ b/pkg/runtimebroker/types.go
@@ -374,22 +374,23 @@ func (r CreateAgentRequest) MarshalJSON() ([]byte, error) {
 
 // CreateAgentConfig contains configuration for agent creation.
 type CreateAgentConfig struct {
-	Template      string                `json:"template,omitempty"`
-	Image         string                `json:"image,omitempty"`
-	HomeDir       string                `json:"homeDir,omitempty"`
-	Workspace     string                `json:"workspace,omitempty"`
-	RepoRoot      string                `json:"repoRoot,omitempty"`
-	Env           []string              `json:"env,omitempty"`
-	Volumes       []api.VolumeMount     `json:"volumes,omitempty"`
-	Labels        map[string]string     `json:"labels,omitempty"`
-	Annotations   map[string]string     `json:"annotations,omitempty"`
-	HarnessConfig string                `json:"harnessConfig,omitempty"`
-	HarnessAuth   string                `json:"harnessAuth,omitempty"` // Late-binding override for auth_selected_type
-	Task          string                `json:"task,omitempty"`
-	CommandArgs   []string              `json:"commandArgs,omitempty"`
-	Profile       string                `json:"profile,omitempty"` // Settings profile for the runtime broker
-	Branch        string                `json:"branch,omitempty"`  // Git branch name (defaults to agent slug if empty)
-	Kubernetes    *api.KubernetesConfig `json:"kubernetes,omitempty"`
+	Template        string                `json:"template,omitempty"`
+	Image           string                `json:"image,omitempty"`
+	HomeDir         string                `json:"homeDir,omitempty"`
+	Workspace       string                `json:"workspace,omitempty"`
+	WorkspaceSubdir string                `json:"workspaceSubdir,omitempty"` // Project-relative /workspace subpath; see hub.RemoteAgentConfig.WorkspaceSubdir
+	RepoRoot        string                `json:"repoRoot,omitempty"`
+	Env             []string              `json:"env,omitempty"`
+	Volumes         []api.VolumeMount     `json:"volumes,omitempty"`
+	Labels          map[string]string     `json:"labels,omitempty"`
+	Annotations     map[string]string     `json:"annotations,omitempty"`
+	HarnessConfig   string                `json:"harnessConfig,omitempty"`
+	HarnessAuth     string                `json:"harnessAuth,omitempty"` // Late-binding override for auth_selected_type
+	Task            string                `json:"task,omitempty"`
+	CommandArgs     []string              `json:"commandArgs,omitempty"`
+	Profile         string                `json:"profile,omitempty"` // Settings profile for the runtime broker
+	Branch          string                `json:"branch,omitempty"`  // Git branch name (defaults to agent slug if empty)
+	Kubernetes      *api.KubernetesConfig `json:"kubernetes,omitempty"`
 
 	// TemplateID is the Hub template ID for cache lookup.
 	// When provided, the Runtime Broker can use this to look up or fetch

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -126,18 +126,19 @@ func (a *Agent) UnmarshalJSON(data []byte) error {
 
 // AgentAppliedConfig stores the effective configuration of an agent.
 type AgentAppliedConfig struct {
-	Image         string              `json:"image,omitempty"`
-	HarnessConfig string              `json:"harnessConfig,omitempty"`
-	HarnessAuth   string              `json:"harnessAuth,omitempty"` // Late-binding override for auth_selected_type
-	Env           map[string]string   `json:"env,omitempty"`
-	Model         string              `json:"model,omitempty"`
-	ThinkingLevel *int                `json:"thinkingLevel,omitempty"`
-	Profile       string              `json:"profile,omitempty"`   // Settings profile for the runtime broker
-	Task          string              `json:"task,omitempty"`      // Initial task/prompt for the agent
-	Attach        bool                `json:"attach,omitempty"`    // If true, signals interactive attach mode to the broker/harness
-	Branch        string              `json:"branch,omitempty"`    // Git branch name (defaults to agent slug if empty)
-	Workspace     string              `json:"workspace,omitempty"` // Host path to mount as /workspace (overrides default project root)
-	GitClone      *api.GitCloneConfig `json:"gitClone,omitempty"`
+	Image           string              `json:"image,omitempty"`
+	HarnessConfig   string              `json:"harnessConfig,omitempty"`
+	HarnessAuth     string              `json:"harnessAuth,omitempty"` // Late-binding override for auth_selected_type
+	Env             map[string]string   `json:"env,omitempty"`
+	Model           string              `json:"model,omitempty"`
+	ThinkingLevel   *int                `json:"thinkingLevel,omitempty"`
+	Profile         string              `json:"profile,omitempty"`         // Settings profile for the runtime broker
+	Task            string              `json:"task,omitempty"`            // Initial task/prompt for the agent
+	Attach          bool                `json:"attach,omitempty"`          // If true, signals interactive attach mode to the broker/harness
+	Branch          string              `json:"branch,omitempty"`          // Git branch name (defaults to agent slug if empty)
+	Workspace       string              `json:"workspace,omitempty"`       // Host path to mount as /workspace (overrides default project root)
+	WorkspaceSubdir string              `json:"workspaceSubdir,omitempty"` // Project-relative /workspace subpath; see hub.RemoteAgentConfig.WorkspaceSubdir
+	GitClone        *api.GitCloneConfig `json:"gitClone,omitempty"`
 
 	// Template info for Runtime Broker hydration
 	TemplateID   string `json:"templateId,omitempty"`   // Hub template ID for fetching


### PR DESCRIPTION
## Summary

Add an optional per-agent `--workspace-subdir`: a **project-relative** subpath
that an agent mounts at `/workspace` instead of the whole project root, with a
containment guard that rejects any subpath escaping the project workspace root.

## Motivation

For a **directory (non-git) project**, an agent cannot currently be confined to
a subdirectory of the project. An absolute per-agent `--workspace` does not
survive the Hub path for such projects — the applied-config step rewrites it to
the hub-managed project path (`pkg/hub/handlers_agent_create_helpers.go`) and the
dispatcher clears it for local-provider projects (`pkg/hub/httpdispatcher.go`) —
so every agent falls back to mounting `settings.WorkspacePath` (the whole
project root) at `/workspace`.

That makes it impossible to run multiple agents in one directory project, each
scoped to its own subtree. A project-relative subpath is the missing primitive:
unlike an absolute path it survives the rewrite and can be joined onto the
resolved project root broker-side.

## Change

- New `WorkspaceSubdir` threaded end-to-end: CreateAgentRequest → AppliedConfig
  (persisted) → dispatcher → RemoteAgentConfig → broker CreateAgentConfig →
  `ProvisionAgent` (via request context). JSON tag `workspaceSubdir`.
- New `--workspace-subdir` flag on `scion create` and `scion start`.
- Containment guard `resolveWorkspaceSubdir` (`pkg/agent/provision.go`): rejects
  absolute subpaths and `..` traversal, then resolves both base and joined paths
  with `EvalSymlinks` and checks containment with `filepath.Rel`, so an
  in-workspace symlink pointing outside the root is rejected. Applied only on the
  directory-project path (non-git, no explicit `--workspace`). The subdir must
  already exist.
- Honoring a subpath records it as an explicit workspace, so resume/restart
  re-derives the same plain-mounted subtree rather than widening to the project
  root (or an enclosing git repo).
- A requested subdir that is not honored (git project, explicit `--workspace`,
  git-clone, shared workspace) emits a non-fatal warning rather than being
  silently dropped.
- `--workspace-subdir .` resolves to the project root (deliberate no-op).

## Testing

- `pkg/agent/workspace_subdir_test.go`: the subpath survives to the `/workspace`
  mount for a directory project; the default (no subdir) still mounts the
  project root; traversal is rejected; the guard is exercised for absolute /
  `..` / symlink-escape / nonexistent cases; and a resume test proves the
  persisted explicit-workspace flag keeps the mount plain (the subdir) across
  restart rather than widening to an enclosing git repo.
- `pkg/hub/httpdispatcher_test.go`: a relative `WorkspaceSubdir` survives to the
  broker for a local-path project even though the absolute `Workspace` is cleared.

## Notes

Backward compatible — the field and flag are optional; behavior is unchanged
when unset, and there is no effect on git projects or explicit-`--workspace`
mounts.
