### PR TITLE
harness/copilot: capture config.json as COPILOT_CONFIG file secret + provision as credential file

### DIFF
--- a/harnesses/copilot/capture_auth.py
+++ b/harnesses/copilot/capture_auth.py
@@ -12,13 +12,70 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Capture-auth shim — delegates to scion_harness.capture_auth_main()."""
+"""Capture-auth for Copilot — delegates to the standard capture flow,
+then captures ~/.copilot/config.json as a COPILOT_CONFIG file secret."""
 
 import os
+import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import scion_harness
 
+_COPILOT_CONFIG = os.path.join(
+    os.environ.get("HOME") or os.path.expanduser("~"),
+    ".copilot", "config.json",
+)
+
+
+def _capture_config_json(force: bool = False) -> bool:
+    """Capture ~/.copilot/config.json as a COPILOT_CONFIG file secret."""
+    if not os.path.isfile(_COPILOT_CONFIG):
+        print(
+            f"capture-auth: {_COPILOT_CONFIG} not found — "
+            "run 'copilot login' first, then re-run this script",
+            file=sys.stderr,
+        )
+        return False
+
+    cmd = [
+        "sciontool", "secret", "set", "COPILOT_CONFIG",
+        f"@{_COPILOT_CONFIG}",
+        "--type", "file",
+        "--target", _COPILOT_CONFIG,
+    ]
+    if force:
+        cmd.append("--force")
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except FileNotFoundError:
+        print("capture-auth: sciontool not found in PATH", file=sys.stderr)
+        return False
+    except subprocess.TimeoutExpired:
+        print("capture-auth: sciontool timed out setting COPILOT_CONFIG", file=sys.stderr)
+        return False
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        if "already exists" in stderr.lower():
+            print(
+                'capture-auth: COPILOT_CONFIG already exists (use --force to overwrite)',
+            )
+            return False
+        print(f"capture-auth: failed to set COPILOT_CONFIG: {stderr}", file=sys.stderr)
+        return False
+
+    print(f"capture-auth: COPILOT_CONFIG: captured from {_COPILOT_CONFIG}")
+    return True
+
+
 if __name__ == "__main__":
-    sys.exit(scion_harness.capture_auth_main())
+    rc = scion_harness.capture_auth_main()
+
+    force = "--force" in sys.argv
+    config_ok = _capture_config_json(force)
+
+    if rc != 0 and config_ok:
+        sys.exit(0)
+    sys.exit(rc)

--- a/harnesses/copilot/config.yaml
+++ b/harnesses/copilot/config.yaml
@@ -74,7 +74,7 @@ capabilities:
     agent_instructions: { support: "yes" }
   auth:
     api_key: { support: "yes" }
-    auth_file: { support: "no", reason: "OAuth capture not implemented in initial version" }
+    auth_file: { support: "yes" }
     oauth_token: { support: "no" }
     vertex_ai: { support: "no", reason: "Copilot uses GitHub auth, not GCP" }
   mcp:
@@ -98,8 +98,16 @@ auth:
     api-key:
       required_env:
         - any_of: ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"]
+    config-file:
+      required_files:
+        - name: COPILOT_CONFIG
+          type: file
+          target_suffix: "/.copilot/config.json"
+          field: CopilotConfigFile
   autodetect:
     env:
       COPILOT_GITHUB_TOKEN: api-key
       GH_TOKEN: api-key
       GITHUB_TOKEN: api-key
+    files:
+      COPILOT_CONFIG: config-file

--- a/harnesses/copilot/provision.py
+++ b/harnesses/copilot/provision.py
@@ -97,7 +97,8 @@ def _write_copilot_config_file(ctx: scion_harness.ProvisionContext) -> None:
     if not content.strip():
         raise scion_harness.ProvisionError("COPILOT_CONFIG secret is empty")
     try:
-        json.loads(content)
+        lines = [ln for ln in content.splitlines() if not ln.strip().startswith("//")]
+        json.loads("\n".join(lines))
     except json.JSONDecodeError as exc:
         raise scion_harness.ProvisionError(
             f"COPILOT_CONFIG secret is not valid JSON: {exc}"
@@ -154,8 +155,12 @@ def _ensure_settings(ctx: scion_harness.ProvisionContext) -> None:
         except (OSError, json.JSONDecodeError):
             pass
 
-    if "trustedFolders" not in config:
+    folders = config.get("trustedFolders")
+    if not isinstance(folders, list):
         config["trustedFolders"] = [ctx.workspace]
+        scion_harness.atomic_write_json(config_path, config)
+    elif ctx.workspace not in folders:
+        folders.append(ctx.workspace)
         scion_harness.atomic_write_json(config_path, config)
 
 

--- a/harnesses/copilot/provision.py
+++ b/harnesses/copilot/provision.py
@@ -47,6 +47,8 @@ assert scion_harness.INTERFACE_VERSION >= 2, (
     f"got {scion_harness.INTERFACE_VERSION}"
 )
 
+COPILOT_CONFIG_FILE = "~/.copilot/config.json"
+
 AUTH = scion_harness.AuthSpec(
     "copilot",
     [
@@ -58,6 +60,12 @@ AUTH = scion_harness.AuthSpec(
                 'with a fine-grained PAT that has "Copilot Requests" permission'
             ),
             env_fallback=True,
+        ),
+        scion_harness.file_method(
+            "config-file",
+            path=COPILOT_CONFIG_FILE,
+            hint=f"provide copilot config at {COPILOT_CONFIG_FILE}",
+            secret_key="COPILOT_CONFIG",
         ),
     ],
     fallback_to_none_on_error=True,
@@ -79,6 +87,29 @@ def _read_token(ctx: scion_harness.ProvisionContext, env_key: str) -> str:
         except OSError:
             pass
     return os.environ.get(env_key, "")
+
+
+def _write_copilot_config_file(ctx: scion_harness.ProvisionContext) -> None:
+    """Write ~/.copilot/config.json from a staged COPILOT_CONFIG file secret."""
+    content = ctx.read_file_secret("COPILOT_CONFIG")
+    if not content:
+        return
+    if not content.strip():
+        raise scion_harness.ProvisionError("COPILOT_CONFIG secret is empty")
+    try:
+        json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise scion_harness.ProvisionError(
+            f"COPILOT_CONFIG secret is not valid JSON: {exc}"
+        ) from exc
+    config_dir = scion_harness.expand_path("~/.copilot")
+    os.makedirs(config_dir, exist_ok=True)
+    target = os.path.join(config_dir, "config.json")
+    tmp = target + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write(content)
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, target)
 
 
 def _write_mcp_config(ctx: scion_harness.ProvisionContext, servers: dict[str, Any]) -> None:
@@ -142,6 +173,7 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
         resolved = scion_harness.ResolvedAuth(method="none")
 
     env: dict[str, str] = {}
+    extra: dict[str, Any] | None = None
     if resolved.method == "api-key" and resolved.env_key:
         secret = _read_token(ctx, resolved.env_key)
         if not secret:
@@ -151,7 +183,11 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
             )
         env["COPILOT_GITHUB_TOKEN"] = secret
 
-    ctx.write_outputs(resolved, env=env)
+    if resolved.method == "config-file":
+        _write_copilot_config_file(ctx)
+        extra = {"config_file_written": True}
+
+    ctx.write_outputs(resolved, env=env, extra=extra)
 
     target = os.path.join(ctx.workspace, ".github", "copilot-instructions.md")
     try:


### PR DESCRIPTION
## Changes

**capture_auth.py:**
- Reads ~/.copilot/config.json and stores it as COPILOT_CONFIG file secret via sciontool
- Still runs capture_auth_main() for API key flow
- Clear error if config.json not found

**provision.py:**
- Added file_method("config-file", secret_key="COPILOT_CONFIG") to AUTH spec
- _write_copilot_config_file(): reads staged COPILOT_CONFIG secret, validates JSON (stripping // comments to match copilot CLI format), writes to ~/.copilot/config.json with 0600 perms
- _ensure_settings(): trustedFolders guard checks ctx.workspace is IN the list (not just key existence) — captured config host paths preserved, container workspace always added
- write_outputs(extra={"config_file_written": True}) for observability

**config.yaml:**
- auth_file capability: no → yes
- Added config-file auth type with COPILOT_CONFIG required file and autodetect entry