### PR TITLE
harness/copilot: capture config.json as COPILOT_CONFIG auth-file secret + credential file provisioning

### DIFF
--- a/harnesses/copilot/config.yaml
+++ b/harnesses/copilot/config.yaml
@@ -98,7 +98,7 @@ auth:
     api-key:
       required_env:
         - any_of: ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"]
-    config-file:
+    auth-file:
       required_files:
         - name: COPILOT_CONFIG
           type: file
@@ -110,4 +110,4 @@ auth:
       GH_TOKEN: api-key
       GITHUB_TOKEN: api-key
     files:
-      COPILOT_CONFIG: config-file
+      COPILOT_CONFIG: auth-file

--- a/harnesses/copilot/provision.py
+++ b/harnesses/copilot/provision.py
@@ -62,7 +62,7 @@ AUTH = scion_harness.AuthSpec(
             env_fallback=True,
         ),
         scion_harness.file_method(
-            "config-file",
+            "auth-file",
             path=COPILOT_CONFIG_FILE,
             hint=f"provide copilot config at {COPILOT_CONFIG_FILE}",
             secret_key="COPILOT_CONFIG",
@@ -188,7 +188,7 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
             )
         env["COPILOT_GITHUB_TOKEN"] = secret
 
-    if resolved.method == "config-file":
+    if resolved.method == "auth-file":
         _write_copilot_config_file(ctx)
         extra = {"config_file_written": True}
 


### PR DESCRIPTION
## Changes

**capture_auth.py:**
- Reads ~/.copilot/config.json and stores it as COPILOT_CONFIG file secret

**provision.py:**
- Resolves COPILOT_CONFIG as auth-file credential (matching codex CODEX_AUTH pattern)
- Writes config.json to ~/.copilot/config.json in agent container with 0600 perms
- _ensure_settings() always adds container workspace to trustedFolders

**config.yaml:**
- auth-file capability enabled (was no)
- COPILOT_CONFIG mapped to auth-file type (schema-valid, no new types introduced)