### PR TITLE
hub: surface schema validation errors in harness config import UI

### DIFF
--- a/pkg/hub/handlers_resource_import.go
+++ b/pkg/hub/handlers_resource_import.go
@@ -34,10 +34,17 @@ type ImportTemplatesRequest struct {
 	Names         []string `json:"names,omitempty"`
 }
 
+// ImportFailure pairs a resource name with the reason it failed to import.
+type ImportFailure struct {
+	Name   string `json:"name"`
+	Reason string `json:"reason"`
+}
+
 // ImportTemplatesResponse is returned after a direct template import completes.
 type ImportTemplatesResponse struct {
-	Templates []string `json:"templates"`
-	Count     int      `json:"count"`
+	Templates []string        `json:"templates"`
+	Count     int             `json:"count"`
+	Failed    []ImportFailure `json:"failed,omitempty"`
 }
 
 // handleProjectImportTemplates imports templates directly from a remote URL into
@@ -116,15 +123,27 @@ func (s *Server) handleProjectImportTemplates(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	imported, err := run(nil)
+	var failures []ImportFailure
+	imported, err := run(failureCollector(&failures))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "import_failed", err.Error(), nil)
+		return
+	}
+
+	if len(imported) == 0 && len(failures) > 0 {
+		reasons := make([]string, len(failures))
+		for i, f := range failures {
+			reasons[i] = f.Name + ": " + f.Reason
+		}
+		writeError(w, http.StatusBadRequest, "import_failed",
+			"config validation failed: "+strings.Join(reasons, "; "), nil)
 		return
 	}
 
 	writeJSON(w, http.StatusOK, ImportTemplatesResponse{
 		Templates: imported,
 		Count:     len(imported),
+		Failed:    failures,
 	})
 }
 
@@ -138,8 +157,9 @@ type ImportHarnessConfigsRequest struct {
 
 // ImportHarnessConfigsResponse is returned after a direct harness-config import completes.
 type ImportHarnessConfigsResponse struct {
-	HarnessConfigs []string `json:"harnessConfigs"`
-	Count          int      `json:"count"`
+	HarnessConfigs []string        `json:"harnessConfigs"`
+	Count          int             `json:"count"`
+	Failed         []ImportFailure `json:"failed,omitempty"`
 }
 
 // handleProjectImportHarnessConfigs imports harness-configs directly from a
@@ -215,15 +235,27 @@ func (s *Server) handleProjectImportHarnessConfigs(w http.ResponseWriter, r *htt
 		return
 	}
 
-	imported, err := run(nil)
+	var failures []ImportFailure
+	imported, err := run(failureCollector(&failures))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "import_failed", err.Error(), nil)
+		return
+	}
+
+	if len(imported) == 0 && len(failures) > 0 {
+		reasons := make([]string, len(failures))
+		for i, f := range failures {
+			reasons[i] = f.Name + ": " + f.Reason
+		}
+		writeError(w, http.StatusBadRequest, "import_failed",
+			"config.yaml validation failed: "+strings.Join(reasons, "; "), nil)
 		return
 	}
 
 	writeJSON(w, http.StatusOK, ImportHarnessConfigsResponse{
 		HarnessConfigs: imported,
 		Count:          len(imported),
+		Failed:         failures,
 	})
 }
 
@@ -246,9 +278,10 @@ type ImportResourcesRequest struct {
 
 // ImportResourcesResponse reports the result of a unified import.
 type ImportResourcesResponse struct {
-	Kind     string   `json:"kind"`
-	Imported []string `json:"imported"`
-	Count    int      `json:"count"`
+	Kind     string          `json:"kind"`
+	Imported []string        `json:"imported"`
+	Count    int             `json:"count"`
+	Failed   []ImportFailure `json:"failed,omitempty"`
 }
 
 // handleResourcesImport handles POST /api/v1/resources/import: a single,
@@ -357,16 +390,41 @@ func (s *Server) handleResourcesImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	imported, err := run(nil)
+	var failures []ImportFailure
+	imported, err := run(failureCollector(&failures))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "import_failed", err.Error(), nil)
 		return
 	}
+
+	if len(imported) == 0 && len(failures) > 0 {
+		reasons := make([]string, len(failures))
+		for i, f := range failures {
+			reasons[i] = f.Name + ": " + f.Reason
+		}
+		writeError(w, http.StatusBadRequest, "import_failed",
+			"config validation failed: "+strings.Join(reasons, "; "), nil)
+		return
+	}
+
 	writeJSON(w, http.StatusOK, ImportResourcesResponse{
 		Kind:     req.Kind,
 		Imported: imported,
 		Count:    len(imported),
+		Failed:   failures,
 	})
+}
+
+// failureCollector returns a progress callback that records ImportEventFailed
+// events into the provided slice. The caller passes this to the import driver
+// instead of nil so that per-resource validation failures are surfaced in the
+// non-streaming JSON response.
+func failureCollector(failures *[]ImportFailure) importProgressFunc {
+	return func(ev ResourceImportEvent) {
+		if ev.Type == ImportEventFailed {
+			*failures = append(*failures, ImportFailure{Name: ev.Name, Reason: ev.Reason})
+		}
+	}
 }
 
 // importAcceptsNDJSON reports whether the client opted into a streaming

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -1071,15 +1071,27 @@ func (s *Server) handleHarnessConfigReimport(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	imported, err := run(nil)
+	var failures []ImportFailure
+	imported, err := run(failureCollector(&failures))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "reimport_failed", err.Error(), nil)
+		return
+	}
+
+	if len(imported) == 0 && len(failures) > 0 {
+		reasons := make([]string, len(failures))
+		for i, f := range failures {
+			reasons[i] = f.Name + ": " + f.Reason
+		}
+		writeError(w, http.StatusBadRequest, "reimport_failed",
+			"config.yaml validation failed: "+strings.Join(reasons, "; "), nil)
 		return
 	}
 
 	writeJSON(w, http.StatusOK, ImportHarnessConfigsResponse{
 		HarnessConfigs: imported,
 		Count:          len(imported),
+		Failed:         failures,
 	})
 }
 

--- a/web/src/components/pages/harness-config-detail.ts
+++ b/web/src/components/pages/harness-config-detail.ts
@@ -1093,7 +1093,17 @@ export class ScionPageHarnessConfigDetail extends LitElement {
 
       const result = await response.json();
       const count = result?.count ?? result?.harnessConfigs?.length ?? 0;
-      this.reimportStatus = `Refreshed successfully (${count} config${count !== 1 ? 's' : ''} updated).`;
+      const failed: Array<{name: string; reason: string}> = result?.failed ?? [];
+
+      if (failed.length > 0) {
+        const reasons = failed.map((f: {name: string; reason: string}) => `${f.name}: ${f.reason}`).join('\n');
+        this.reimportError = `${failed.length} config(s) failed validation:\n${reasons}`;
+        if (count > 0) {
+          this.reimportStatus = `${count} config(s) updated, but some failed.`;
+        }
+      } else {
+        this.reimportStatus = `Refreshed successfully (${count} config${count !== 1 ? 's' : ''} updated).`;
+      }
       await this.loadHarnessConfig();
     } catch (err) {
       this.reimportError = err instanceof Error ? err.message : 'Failed to refresh from source';


### PR DESCRIPTION
## Problem

When harness config import/reimport failed schema validation, the hub logged a WARN and returned HTTP 200 with an empty list. Users clicking "pull latest" saw no feedback — configs silently stayed stale with no indication why.

## Fix

The four non-streaming resource-import handlers (reimport, project templates, project harness-configs, unified resources) now return HTTP 400 with a structured error when schema validation fails, including the resource name and specific validation reason.

The streaming path already handles failures in-band. The admin allow-list import path is excluded as it uses a different pattern.

The web UI Refresh from Source button surfaces these errors inline via the existing extractApiError path for 400 responses and the failed array for partial-failure 200 responses