### PR TITLE
harness/claude: fix skills injection — use include_skills=False in project_instructions()

### DIFF
--- a/harnesses/claude/provision.py
+++ b/harnesses/claude/provision.py
@@ -266,6 +266,7 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
         ctx,
         instructions_file,
         system_prompt_mode="none",
+        include_skills=False,
     )
 
 


### PR DESCRIPTION
## Problem

provision.py called project_instructions() without include_skills=False. The Go-side provisioner already installs skills as individual files in .claude/skills/ (template skills, platform skills, skill bank refs). But project_instructions() was also re-reading those same files and concatenating them all into ~/.claude/CLAUDE.md — duplicating every skill as text blobs and bloating the instruction file.

## Fix

One-line change: add include_skills=False to the project_instructions() call in provision.py.

Skills remain as individual files in .claude/skills/ where Claude Code discovers them natively. CLAUDE.md gets only agent instructions without skills appended