### PR TITLE
fix(web): sort template list — project templates first then global, both alphabetically

### DIFF
--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -748,13 +748,21 @@ private selectBrokerForProject(): void {
    * for the current project plus global templates.
    */
   private get filteredTemplates(): Template[] {
-    if (!this.projectId) return this.templates;
-    return this.templates.filter(
-      (t) =>
-        t.scope === 'global' ||
-        t.scope === 'user' ||
-        (t.scope === 'project' && t.scopeId === this.projectId)
-    );
+    const visible = this.projectId
+      ? this.templates.filter(
+          (t) =>
+            t.scope === 'global' ||
+            t.scope === 'user' ||
+            (t.scope === 'project' && t.scopeId === this.projectId)
+        )
+      : this.templates;
+
+    const byName = (a: Template, b: Template) =>
+      (a.displayName || a.name).localeCompare(b.displayName || b.name);
+
+    const project = visible.filter((t) => t.scope === 'project').sort(byName);
+    const rest = visible.filter((t) => t.scope !== 'project').sort(byName);
+    return [...project, ...rest];
   }
 
   /**


### PR DESCRIPTION
In the new agent form, templates now appear in order: project-scoped templates (sorted A-Z by name), then global templates (sorted A-Z by name)