### PR TITLE
fix: skill bank URI display and public skill permissions

### DIFF
--- a/pkg/hub/skill_handlers.go
+++ b/pkg/hub/skill_handlers.go
@@ -259,7 +259,9 @@ func (s *Server) listSkills(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		for i := range result.Items {
-			skills = append(skills, SkillWithCapabilities{Skill: result.Items[i]})
+			if result.Items[i].Visibility == store.VisibilityPublic {
+				skills = append(skills, SkillWithCapabilities{Skill: result.Items[i]})
+			}
 		}
 	}
 
@@ -1327,15 +1329,20 @@ func (s *Server) handleSkillsResolve(w http.ResponseWriter, r *http.Request) {
 
 		if skill.Visibility != store.VisibilityPublic {
 			identity := GetIdentityFromContext(ctx)
-			if identity != nil {
-				decision := s.authzService.CheckAccess(ctx, identity, skillResource(skill), ActionRead)
-				if !decision.Allowed {
-					resolveErrors = append(resolveErrors, ResolveSkillError{
-						URI: skillRef.URI, Code: "forbidden",
-						Message: "you do not have permission to access this skill",
-					})
-					continue
-				}
+			if identity == nil {
+				resolveErrors = append(resolveErrors, ResolveSkillError{
+					URI: skillRef.URI, Code: "forbidden",
+					Message: "you do not have permission to access this skill",
+				})
+				continue
+			}
+			decision := s.authzService.CheckAccess(ctx, identity, skillResource(skill), ActionRead)
+			if !decision.Allowed {
+				resolveErrors = append(resolveErrors, ResolveSkillError{
+					URI: skillRef.URI, Code: "forbidden",
+					Message: "you do not have permission to access this skill",
+				})
+				continue
 			}
 		}
 

--- a/pkg/hub/skill_handlers.go
+++ b/pkg/hub/skill_handlers.go
@@ -252,7 +252,7 @@ func (s *Server) listSkills(w http.ResponseWriter, r *http.Request) {
 		}
 		caps := s.authzService.ComputeCapabilitiesBatch(ctx, identity, resources, "skill")
 		for i := range result.Items {
-			if !capabilityAllows(caps[i], ActionRead) {
+			if !capabilityAllows(caps[i], ActionRead) && result.Items[i].Visibility != store.VisibilityPublic {
 				continue
 			}
 			skills = append(skills, SkillWithCapabilities{Skill: result.Items[i], Cap: caps[i]})
@@ -413,7 +413,7 @@ func (s *Server) getSkill(w http.ResponseWriter, r *http.Request, id string) {
 	}
 
 	identity := GetIdentityFromContext(ctx)
-	if identity != nil {
+	if identity != nil && skill.Visibility != store.VisibilityPublic {
 		decision := s.authzService.CheckAccess(ctx, identity, skillResource(skill), ActionRead)
 		if !decision.Allowed {
 			NotFound(w, "Skill")
@@ -550,7 +550,7 @@ func (s *Server) listSkillVersions(w http.ResponseWriter, r *http.Request, skill
 	}
 
 	identity := GetIdentityFromContext(ctx)
-	if identity != nil {
+	if identity != nil && skill.Visibility != store.VisibilityPublic {
 		decision := s.authzService.CheckAccess(ctx, identity, skillResource(skill), ActionRead)
 		if !decision.Allowed {
 			NotFound(w, "Skill")
@@ -580,7 +580,7 @@ func (s *Server) getSkillVersion(w http.ResponseWriter, r *http.Request, skillID
 	}
 
 	identity := GetIdentityFromContext(ctx)
-	if identity != nil {
+	if identity != nil && skill.Visibility != store.VisibilityPublic {
 		decision := s.authzService.CheckAccess(ctx, identity, skillResource(skill), ActionRead)
 		if !decision.Allowed {
 			NotFound(w, "Skill")
@@ -1180,7 +1180,7 @@ func (s *Server) handleSkillDownload(w http.ResponseWriter, r *http.Request, ski
 	}
 
 	identity := GetIdentityFromContext(ctx)
-	if identity != nil {
+	if identity != nil && skill.Visibility != store.VisibilityPublic {
 		decision := s.authzService.CheckAccess(ctx, identity, skillResource(skill), ActionRead)
 		if !decision.Allowed {
 			NotFound(w, "Skill")
@@ -1241,7 +1241,7 @@ func (s *Server) handleSkillResolveSingle(w http.ResponseWriter, r *http.Request
 	}
 
 	identity := GetIdentityFromContext(ctx)
-	if identity != nil {
+	if identity != nil && skill.Visibility != store.VisibilityPublic {
 		decision := s.authzService.CheckAccess(ctx, identity, skillResource(skill), ActionRead)
 		if !decision.Allowed {
 			NotFound(w, "Skill")
@@ -1325,15 +1325,17 @@ func (s *Server) handleSkillsResolve(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		identity := GetIdentityFromContext(ctx)
-		if identity != nil {
-			decision := s.authzService.CheckAccess(ctx, identity, skillResource(skill), ActionRead)
-			if !decision.Allowed {
-				resolveErrors = append(resolveErrors, ResolveSkillError{
-					URI: skillRef.URI, Code: "forbidden",
-					Message: "you do not have permission to access this skill",
-				})
-				continue
+		if skill.Visibility != store.VisibilityPublic {
+			identity := GetIdentityFromContext(ctx)
+			if identity != nil {
+				decision := s.authzService.CheckAccess(ctx, identity, skillResource(skill), ActionRead)
+				if !decision.Allowed {
+					resolveErrors = append(resolveErrors, ResolveSkillError{
+						URI: skillRef.URI, Code: "forbidden",
+						Message: "you do not have permission to access this skill",
+					})
+					continue
+				}
 			}
 		}
 

--- a/pkg/hub/skill_handlers_authz_test.go
+++ b/pkg/hub/skill_handlers_authz_test.go
@@ -220,6 +220,36 @@ func TestSkillAuthz_Resolve_ForbiddenSkill(t *testing.T) {
 	assert.Equal(t, "forbidden", resp.Errors[0].Code)
 }
 
+func TestSkillAuthz_Resolve_PublicSkillAllowed(t *testing.T) {
+	srv, s, alice, bob, _ := setupSkillAuthzTest(t)
+	skill := createTestSkill(t, s, "public-skill", store.SkillScopeGlobal, "", alice.ID)
+
+	// Mark the skill as public.
+	skill.Visibility = store.VisibilityPublic
+	require.NoError(t, s.UpdateSkill(context.Background(), skill))
+
+	sv := &store.SkillVersion{
+		ID:      api.NewUUID(),
+		SkillID: skill.ID,
+		Version: "1.0.0",
+		Status:  store.SkillVersionStatusPublished,
+		Created: time.Now(),
+	}
+	require.NoError(t, s.CreateSkillVersion(context.Background(), sv))
+
+	rec := doRequestAsUser(t, srv, bob, http.MethodPost, "/api/v1/skills/resolve", ResolveSkillsRequest{
+		Skills: []ResolveSkillRef{{URI: "skill://scion/global/public-skill"}},
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ResolveSkillsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	assert.Empty(t, resp.Errors, "public skill should not produce authorization errors")
+	require.NotEmpty(t, resp.Resolved, "public skill should be resolved for any authenticated user")
+	assert.Equal(t, "public-skill", resp.Resolved[0].Name)
+}
+
 // ============================================================================
 // H2: createSkill user scope tests
 // ============================================================================

--- a/pkg/hub/skill_handlers_authz_test.go
+++ b/pkg/hub/skill_handlers_authz_test.go
@@ -17,10 +17,12 @@
 package hub
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -280,6 +282,69 @@ func TestSkillAuthz_CreateSkill_UserScope_UnauthenticatedRejected(t *testing.T) 
 	})
 	assert.Equal(t, http.StatusUnauthorized, rec.Code,
 		"unauthenticated user-scope create should be rejected; got: %s", rec.Body.String())
+}
+
+// ============================================================================
+// Unauthenticated access to private skills
+// ============================================================================
+
+func TestSkillAuthz_ListSkills_NilIdentitySeesOnlyPublic(t *testing.T) {
+	srv, s, alice, _, project := setupSkillAuthzTest(t)
+
+	createTestSkill(t, s, "private-skill", store.SkillScopeProject, project.ID, alice.ID)
+
+	publicSkill := createTestSkill(t, s, "public-list-skill", store.SkillScopeProject, project.ID, alice.ID)
+	publicSkill.Visibility = store.VisibilityPublic
+	require.NoError(t, s.UpdateSkill(context.Background(), publicSkill))
+
+	// Bypass auth middleware to reach the handler with nil identity (defense-in-depth).
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/skills?scope=project&scopeId="+project.ID, nil)
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ListSkillsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	for _, sk := range resp.Skills {
+		assert.Equal(t, store.VisibilityPublic, sk.Skill.Visibility,
+			"nil-identity list should only contain public skills, got %q with visibility %q", sk.Skill.Name, sk.Skill.Visibility)
+	}
+	assert.Equal(t, 1, len(resp.Skills), "should see exactly the one public skill")
+}
+
+func TestSkillAuthz_Resolve_NilIdentityPrivateDenied(t *testing.T) {
+	srv, s, alice, _, project := setupSkillAuthzTest(t)
+	skill := createTestSkill(t, s, "private-resolve-skill", store.SkillScopeProject, project.ID, alice.ID)
+
+	sv := &store.SkillVersion{
+		ID:      api.NewUUID(),
+		SkillID: skill.ID,
+		Version: "1.0.0",
+		Status:  store.SkillVersionStatusPublished,
+		Created: time.Now(),
+	}
+	require.NoError(t, s.CreateSkillVersion(context.Background(), sv))
+
+	body, err := json.Marshal(ResolveSkillsRequest{
+		Skills:    []ResolveSkillRef{{URI: "skill://project/" + project.ID + "/private-resolve-skill"}},
+		ProjectID: project.ID,
+	})
+	require.NoError(t, err)
+
+	// Bypass auth middleware to reach the handler with nil identity (defense-in-depth).
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/skills/resolve", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ResolveSkillsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	assert.Empty(t, resp.Resolved, "private skill should not be resolved with nil identity")
+	require.NotEmpty(t, resp.Errors, "private skill should produce a forbidden error")
+	assert.Equal(t, "forbidden", resp.Errors[0].Code)
 }
 
 // ============================================================================

--- a/web/src/components/pages/skill-detail.ts
+++ b/web/src/components/pages/skill-detail.ts
@@ -418,7 +418,10 @@ export class ScionPageSkillDetail extends LitElement {
 
   private getSkillUri(): string {
     if (!this.skill) return '';
-    return `${this.skill.scope}:${this.skill.slug}@latest`;
+    const scopePath = this.skill.scopeId
+      ? `${this.skill.scope}/${this.skill.scopeId}`
+      : this.skill.scope;
+    return `skill://scion/${scopePath}/${this.skill.slug}@latest`;
   }
 
   private async copyUri(): Promise<void> {


### PR DESCRIPTION
## Summary

- **Bug 1 — Wrong URI format in skill detail page**: The web UI displayed skill URIs as `scope:slug@latest` instead of the canonical `skill://scion/scope/slug@latest` format. Users copying this into template `skills:` fields got validation errors. Fixed `getSkillUri()` in `web/src/components/pages/skill-detail.ts`.

- **Bug 2 — Public skill permissions denied during resolution**: Skills marked `visibility: public` were rejected with "you do not have permission to access this skill" during provisioning. Fixed by bypassing authz for public skills on all read paths.

## Test plan
- Added `TestSkillAuthz_Resolve_PublicSkillAllowed` — verifies non-owner can resolve a public skill
- Existing `TestSkillAuthz_Resolve_ForbiddenSkill` still passes
- All 11 `TestSkillAuthz_*` tests pass
