### PR TITLE
fix: show integrations as Available when plugin binary is on $PATH

### DIFF
--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -699,14 +700,25 @@ func (s *Server) handleListAvailableIntegrations(w http.ResponseWriter, _ *http.
 		if mgr != nil && mgr.HasPlugin("broker", name) {
 			continue
 		}
+
+		binaryName := "scion-plugin-" + name
+
+		// Check 1: binary is on $PATH (covers Homebrew / package-manager installs).
+		_, onPathErr := exec.LookPath(binaryName)
+
+		// Check 2: source checkout exists (covers development installs).
+		inSourceCheckout := false
 		if repoPath != "" {
 			sourceDir := filepath.Join(repoPath, "extras", "scion-"+name)
-			if _, err := os.Stat(sourceDir); err != nil {
-				continue
+			if _, err := os.Stat(sourceDir); err == nil {
+				inSourceCheckout = true
 			}
-		} else {
-			continue
 		}
+
+		if onPathErr != nil && !inSourceCheckout {
+			continue // neither binary on PATH nor source checkout found
+		}
+
 		available = append(available, AvailableIntegration{
 			Name:     name,
 			Platform: resolvePlatform(name),


### PR DESCRIPTION
## Problem

The /admin/integrations Available list only showed plugins when SCION_MAINTENANCE_REPO_PATH was set to a directory containing extras/scion-\<name>/. Homebrew and other package-manager installs have no source checkout, so the Available list was always empty — even when scion-plugin-telegram was installed and on $PATH.

## Fix

Added exec.LookPath("scion-plugin-\<name>") as a fallback check in handleListAvailableIntegrations. A plugin now appears as Available if either:
1. Its binary is found on $PATH (covers Homebrew/package-manager installs)
2. Its source directory exists in the maintenance repo checkout (covers dev installs)

## Testing

- Install scion-plugin-telegram via brew (places binary on PATH)
- Navigate to /admin/integrations
- Telegram should appear in the Available list without needing SCION_MAINTENANCE_REPO_PATH
