### PR TITLE
fix(web): obfuscate secret textarea value using -webkit-text-security

### DIFF
--- a/web/src/components/shared/secret-list.ts
+++ b/web/src/components/shared/secret-list.ts
@@ -24,7 +24,7 @@
  * In compact mode (project page), wraps in a section with header/description.
  */
 
-import { LitElement, html, nothing } from 'lit';
+import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import type { Secret, SecretType, ResourceScope, InjectionMode } from '../../shared/types.js';
@@ -61,7 +61,14 @@ export class ScionSecretList extends LitElement {
   // Copy-to-clipboard feedback
   @state() private copiedSecretKey: string | null = null;
 
-  static override styles = [resourceStyles];
+  static override styles = [
+    resourceStyles,
+    css`
+      sl-textarea.secret-value::part(textarea) {
+        -webkit-text-security: disc;
+      }
+    `,
+  ];
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -440,6 +447,7 @@ export class ScionSecretList extends LitElement {
           ${this.dialogType === 'file'
             ? html`
                 <sl-textarea
+                  class="secret-value"
                   label="Value"
                   placeholder="Paste file contents (e.g. private key)"
                   value=${this.dialogValue}


### PR DESCRIPTION
Adds password-style obfuscation to the file-type secret textarea using CSS -webkit-text-security: disc, scoped to the Shoelace Shadow DOM textarea part. No font loading required