### PR TITLE
fix(server): reload co-located broker runtime on container engine change in onboarding wizard

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1989,6 +1989,20 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 		rhSrv.SetMessageLogger(messageLogger)
 	}
 
+	// Wire runtime reload so reloadSettings can swap the broker's container
+	// engine without a full server restart (fixes onboarding wizard flow).
+	if hubSrv != nil && colocatedBrokerRegistered {
+		hubSrv.SetRuntimeReloadFunc(func() bool {
+			newRT := runtime.GetRuntime("", "")
+			if newRT.Name() == rhSrv.RuntimeName() {
+				return false
+			}
+			rhSrv.SwapRuntime(newRT)
+			hubSrv.SetLocalImageChecker(newRT)
+			return true
+		})
+	}
+
 	if webSrv != nil {
 		webSrv.SetBrokerHealthProvider(func(ctx context.Context) interface{} {
 			return rhSrv.GetHealthInfo(ctx)

--- a/pkg/hub/admin_settings.go
+++ b/pkg/hub/admin_settings.go
@@ -257,6 +257,22 @@ func (s *Server) reloadSettings() map[string]interface{} {
 		results["applied"] = applied
 	}
 
+	// Detect container runtime changes and reload the co-located broker.
+	// This covers the onboarding wizard flow where the user selects a
+	// different runtime (e.g. podman) after the server auto-detected one
+	// at startup. Without this, the broker continues using the stale
+	// runtime until a manual server restart.
+	s.mu.RLock()
+	reloadFn := s.runtimeReloadFunc
+	s.mu.RUnlock()
+	if reloadFn != nil {
+		if reloaded := reloadFn(); reloaded {
+			applied := results["applied"].([]string)
+			applied = append(applied, "broker_runtime")
+			results["applied"] = applied
+		}
+	}
+
 	return results
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -597,6 +597,7 @@ type Server struct {
 	// statelessEmbeddedBroker is true when the embedded broker identity is a
 	// replica-independent API adapter rather than a process-owned control channel.
 	statelessEmbeddedBroker bool
+	runtimeReloadFunc       func() bool        // Callback to reload the co-located broker runtime; returns true if swapped
 	workstation             bool               // True when running in workstation (non-production) mode
 	scheduler               *Scheduler         // Unified scheduler for recurring tasks
 	cleanupOnce             sync.Once          // Ensures CleanupResources runs only once
@@ -1396,6 +1397,16 @@ func (s *Server) SetStatelessEmbeddedBrokerID(id string) {
 	defer s.mu.Unlock()
 	s.embeddedBrokerID = id
 	s.statelessEmbeddedBroker = id != ""
+}
+
+// SetRuntimeReloadFunc registers a callback that reloads the co-located
+// broker's container runtime. Called during startup wiring so that
+// reloadSettings can trigger a runtime swap without a full restart.
+// The callback returns true if the runtime was actually swapped.
+func (s *Server) SetRuntimeReloadFunc(fn func() bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.runtimeReloadFunc = fn
 }
 
 // GetEmbeddedBrokerID returns the co-located broker ID, if any.

--- a/pkg/hub/system_handlers.go
+++ b/pkg/hub/system_handlers.go
@@ -218,10 +218,17 @@ func (s *Server) handlePutRuntime(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Update the image checker so it uses the newly selected runtime for
-	// local image existence checks instead of the previously configured one.
+	// Update the image checker and co-located broker runtime so they use
+	// the newly selected runtime instead of the previously configured one.
 	rt := runtime.GetRuntime("", "")
 	s.SetLocalImageChecker(rt)
+
+	s.mu.RLock()
+	reloadFn := s.runtimeReloadFunc
+	s.mu.RUnlock()
+	if reloadFn != nil {
+		reloadFn()
+	}
 
 	writeJSON(w, http.StatusOK, systemRuntimeResponse{
 		Detected:   req.Runtime,

--- a/pkg/runtimebroker/server.go
+++ b/pkg/runtimebroker/server.go
@@ -351,6 +351,29 @@ func New(cfg ServerConfig, mgr agent.Manager, rt scionrt.Runtime) *Server {
 	return srv
 }
 
+// RuntimeName returns the name of the currently active container runtime.
+func (s *Server) RuntimeName() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.runtime.Name()
+}
+
+// SwapRuntime replaces the broker's container runtime and agent manager.
+// This is called when the co-located hub detects a runtime configuration
+// change (e.g. during onboarding) so the broker picks up the new engine
+// without requiring a full server restart.
+func (s *Server) SwapRuntime(rt scionrt.Runtime) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	old := s.runtime.Name()
+	s.runtime = rt
+	s.manager = agent.NewManager(rt)
+	slog.Info("Runtime broker swapped container runtime",
+		"old", old,
+		"new", rt.Name(),
+	)
+}
+
 // initHubIntegration initializes the shared template cache and hub connections.
 func (s *Server) initHubIntegration() error {
 	// 1. Initialize shared template cache

--- a/pkg/runtimebroker/server_test.go
+++ b/pkg/runtimebroker/server_test.go
@@ -16,6 +16,8 @@ package runtimebroker
 
 import (
 	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
 )
 
 func TestIsControlChannelConnected_NoConnections_CCNotEnabled(t *testing.T) {
@@ -141,5 +143,24 @@ func TestIsControlChannelConnected_NilControlChannel_CCNotEnabled(t *testing.T) 
 
 	if !srv.IsControlChannelConnected() {
 		t.Error("expected true when connections exist without CC and CC is not enabled (Cloud Run)")
+	}
+}
+
+func TestSwapRuntime(t *testing.T) {
+	srv := newTestServer(t)
+
+	if got := srv.RuntimeName(); got != "mock" {
+		t.Fatalf("initial runtime = %q, want %q", got, "mock")
+	}
+
+	newRT := &runtime.MockRuntime{NameFunc: func() string { return "podman" }}
+	srv.SwapRuntime(newRT)
+
+	if got := srv.RuntimeName(); got != "podman" {
+		t.Errorf("after swap runtime = %q, want %q", got, "podman")
+	}
+
+	if srv.manager == nil {
+		t.Error("manager should be re-created after swap")
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/456 — onboarding wizard now calls SwapRuntime when the user changes container engine, reloading the co-located broker with the correct runtime instead of keeping stale state