### PR TITLE
fix(runtime): return user-friendly 409 error when agent name already in use

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -57,8 +57,9 @@ func isContainerNameInUseError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "already in use")
+	msg := strings.ToLower(err.Error())
+	return (strings.Contains(msg, "container name") && strings.Contains(msg, "already in use")) ||
+		strings.Contains(msg, "is already in use by container")
 }
 
 func isTmuxShellNotFoundError(err error) bool {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -38,6 +38,7 @@ import (
 )
 
 var ErrTmuxBinaryNotFound = errors.New("tmux binary not found")
+var ErrContainerNameInUse = errors.New("agent name is already in use by a stopped container; please delete the existing agent or choose a different name")
 
 func classifyLaunchRuntimeError(err error, resolvedImage string) error {
 	if err == nil {
@@ -46,7 +47,18 @@ func classifyLaunchRuntimeError(err error, resolvedImage string) error {
 	if errors.Is(err, exec.ErrNotFound) || isTmuxShellNotFoundError(err) {
 		return fmt.Errorf("failed to launch container in image %q: %w: %w", resolvedImage, ErrTmuxBinaryNotFound, err)
 	}
+	if isContainerNameInUseError(err) {
+		return ErrContainerNameInUse
+	}
 	return fmt.Errorf("failed to launch container: %w", err)
+}
+
+func isContainerNameInUseError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "already in use")
 }
 
 func isTmuxShellNotFoundError(err error) bool {

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -389,7 +389,11 @@ func (s *Server) handleExistingAgent(
 		// session (Claude --continue) rather than starting fresh.
 		resume := existingAgent.Phase == string(state.PhaseSuspended)
 		if err := dispatcher.DispatchAgentStart(ctx, existingAgent, req.Task, resume); err != nil {
-			RuntimeError(w, "Failed to resume suspended agent: "+err.Error())
+			if isContainerNameConflict(err) {
+				Conflict(w, "Agent name is already in use by a stopped container. Please delete the existing agent or choose a different name.")
+			} else {
+				RuntimeError(w, "Failed to resume suspended agent: "+err.Error())
+			}
 			return existingAgentErrored
 		}
 
@@ -442,7 +446,11 @@ func (s *Server) handleExistingAgent(
 			// A stopped agent restarts with a fresh harness session even when
 			// resume was requested (mirrors the local CLI's effectiveResume).
 			if err := dispatcher.DispatchAgentStart(ctx, existingAgent, req.Task, false); err != nil {
-				RuntimeError(w, "Failed to resume stopped agent: "+err.Error())
+				if isContainerNameConflict(err) {
+					Conflict(w, "Agent name is already in use by a stopped container. Please delete the existing agent or choose a different name.")
+				} else {
+					RuntimeError(w, "Failed to resume stopped agent: "+err.Error())
+				}
 				return existingAgentErrored
 			}
 
@@ -515,7 +523,11 @@ func (s *Server) handleExistingAgent(
 		// response (status, container info) onto existingAgent in-place.
 		// A created/provisioning agent has no prior session to resume.
 		if err := dispatcher.DispatchAgentStart(ctx, existingAgent, req.Task, false); err != nil {
-			RuntimeError(w, "Failed to start agent: "+err.Error())
+			if isContainerNameConflict(err) {
+				Conflict(w, "Agent name is already in use by a stopped container. Please delete the existing agent or choose a different name.")
+			} else {
+				RuntimeError(w, "Failed to start agent: "+err.Error())
+			}
 			return existingAgentErrored
 		}
 

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -793,7 +793,11 @@ func (s *Server) createAgentInProject(
 					// trigger spurious sync-registration attempts.
 					_ = dispatcher.DispatchAgentDelete(ctx, agent, true, true, false, time.Time{})
 					_ = s.store.DeleteAgent(ctx, agent.ID)
-					RuntimeError(w, "Failed to dispatch to runtime broker: "+err.Error())
+					if isContainerNameConflict(err) {
+						Conflict(w, "Agent name is already in use by a stopped container. Please delete the existing agent or choose a different name.")
+					} else {
+						RuntimeError(w, "Failed to dispatch to runtime broker: "+err.Error())
+					}
 					return
 				} else if envReqs != nil {
 					// Broker returned 202: needs env gather
@@ -830,7 +834,11 @@ func (s *Server) createAgentInProject(
 					// trigger spurious sync-registration attempts.
 					_ = dispatcher.DispatchAgentDelete(ctx, agent, true, true, false, time.Time{})
 					_ = s.store.DeleteAgent(ctx, agent.ID)
-					RuntimeError(w, "Failed to dispatch to runtime broker: "+err.Error())
+					if isContainerNameConflict(err) {
+						Conflict(w, "Agent name is already in use by a stopped container. Please delete the existing agent or choose a different name.")
+					} else {
+						RuntimeError(w, "Failed to dispatch to runtime broker: "+err.Error())
+					}
 					return
 				} else if envReqs != nil && len(envReqs.Needs) > 0 {
 					// Broker reported missing required env vars — fail the dispatch.
@@ -2053,4 +2061,8 @@ func (s *Server) handleAgentResetAuth(w http.ResponseWriter, r *http.Request, id
 	writeJSON(w, http.StatusOK, map[string]string{
 		"message": "Auth reset dispatched successfully",
 	})
+}
+
+func isContainerNameConflict(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "already in use")
 }

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -2064,5 +2064,10 @@ func (s *Server) handleAgentResetAuth(w http.ResponseWriter, r *http.Request, id
 }
 
 func isContainerNameConflict(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "already in use")
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return (strings.Contains(msg, "container name") && strings.Contains(msg, "already in use")) ||
+		strings.Contains(msg, "is already in use by container")
 }

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -807,7 +807,11 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 					"agent_id", req.ID, "project_id", req.ProjectID, "agent", opts.Name)
 			}
 		}
-		RuntimeError(w, "Failed to create agent: "+err.Error())
+		if errors.Is(err, agent.ErrContainerNameInUse) {
+			Conflict(w, err.Error())
+		} else {
+			RuntimeError(w, "Failed to create agent: "+err.Error())
+		}
 		return
 	}
 
@@ -1309,7 +1313,11 @@ func (s *Server) startAgent(w http.ResponseWriter, r *http.Request, id, projectI
 	if err != nil {
 		s.agentLifecycleLog.Error("Agent start failed",
 			"agent_id", id, "error", err)
-		RuntimeError(w, "Failed to start agent: "+err.Error())
+		if errors.Is(err, agent.ErrContainerNameInUse) {
+			Conflict(w, err.Error())
+		} else {
+			RuntimeError(w, "Failed to start agent: "+err.Error())
+		}
 		return
 	}
 


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/457 — detects container-name-already-in-use errors across all runtimes (Docker, Podman, etc) and returns a clean 409 Conflict: Agent name is already in use by a stopped container