### PR TITLE
feat(hub): auto-detect gcloud ADC credentials in workstation mode

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -670,6 +670,17 @@ func loadAndReconcileConfig(cmd *cobra.Command) (*config.GlobalConfig, error) {
 			cfg.Storage.Provider = "local"
 		}
 		cfg.Secrets.Backend = "local"
+
+		// Auto-detect gcloud ADC credentials for GCP clients.
+		if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") == "" {
+			if home, err := os.UserHomeDir(); err == nil {
+				adcPath := filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
+				if _, err := os.Stat(adcPath); err == nil {
+					os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", adcPath)
+					log.Printf("GCP: auto-detected gcloud ADC credentials at %s", adcPath)
+				}
+			}
+		}
 	}
 
 	// Override with command-line flags


### PR DESCRIPTION
## Problem
Workstation users with gcloud ADC at ~/.config/gcloud/application_default_credentials.json must manually configure credentials.
## Fix
At workstation startup, auto-detect ADC file and set GOOGLE_APPLICATION_CREDENTIALS if not already set