### PR TITLE
fix(broker): replay-based stateless env-gather finalize for HA (#376)

### DIFF
--- a/.design/envgather-ha-376.md
+++ b/.design/envgather-ha-376.md
@@ -1,0 +1,165 @@
+# Design #376: Stateless Env-Gather Finalize (pendingEnvGather HA Fix)
+
+**Architect:** bf-arch-376
+**Date:** 2026-07-14
+**Status:** FINAL — all open questions resolved with user on thread 4524
+**Issue:** https://github.com/ptone/scion/issues/376
+**Investigation:** `/scion-volumes/scratchpad/projects/broker-fixes/investigation-376.md`
+**Handoff sizing:** single developer, one PR, two commits (see §7). No EM needed.
+
+---
+
+## 1. Problem Summary
+
+The env-gather protocol is two-phase: the broker's `createAgent` returns HTTP 202 with missing env keys and stores a `pendingAgentState` in the in-memory `pendingEnvGather` map (`pkg/runtimebroker/server.go:215`); the later `finalize-env` call looks that state up (`pkg/runtimebroker/handlers.go:2361-2381`). In a Hub HA deployment (Cloud Run, min-instances ≥ 2, co-located hub+broker per instance), the finalize request routinely lands on a different instance than the create, the lookup misses, and the broker returns 404 — the agent is stuck in `provisioning` forever. The broker's file-based persistence (`state_store.go`) only covers same-instance crash recovery; Cloud Run instances have independent filesystems.
+
+Key architectural fact: the hub already models co-located brokers as **replica-independent** — `SetStatelessLocalBrokers` (`pkg/hub/broker_routing.go:114-128`) routes any lifecycle op for the embedded broker ID to whichever replica receives it, by design. `pendingEnvGather` is the one piece of state that violates this contract.
+
+## 2. Chosen Approach: F — Replay-Based Stateless Finalize
+
+> Confirmed by user on thread 4524, 2026-07-14: "Moving to F as the design seems to be sound."
+
+On env submission, the hub does **not** call the broker's `finalize-env` action. Instead it rebuilds the full create request from durable shared state (exactly what `buildCreateRequest` already does on every dispatch), merges the CLI-gathered env into `ResolvedEnv` at highest precedence, and dispatches a normal create with `GatherEnv=true`. The broker's env evaluation finds all keys satisfied and falls through to its standard `buildStartContext` + `Manager.Start` path. No pending state is ever written or read; the entire stateful finalize path is **removed in the same PR** (user decision, Q2).
+
+### Rationale
+
+1. **No side effects to duplicate.** The broker's 202 return (`handlers.go:551`) happens *before* `buildStartContext` (`handlers.go:604`) — no worktree provisioning, secret projection, or container work has occurred when pending state is stored. A replayed create performs the first (and only) provisioning pass.
+2. **Established pattern.** `CreateWithGatherDispatchArgs` is intentionally empty — "the owner rebuilds the full RemoteCreateAgentRequest from the shared store" (`pkg/hub/dispatch_args.go:58-60`). Env/secret resolution is already re-derived from the shared store + secret backend on every dispatch (`dispatch_args.go:22-26`). Replay extends this to finalize rather than introducing a new state store.
+3. **Fixes both topologies.** DB-backed pending state (Approach D) fixes only brokers that can reach the hub's Postgres. Replay is stateless for co-located *and* remote multi-instance brokers — broker-local env sources are re-evaluated on whichever homogeneous replica receives the replay.
+4. **Eliminates path drift.** Today `finalizeEnv` maintains a second, divergent start path — it already silently drops `WorkspaceMode` (`handlers.go:2396-2414` vs `handlers.go:604-623`). Replay leaves exactly one start path.
+5. **Forward compatible.** New hub + old broker: the replay is a plain create request old brokers already handle. (The reverse skew — old hub + new broker — is explicitly not supported; see §6. User decision: nearly all installations are co-located single-binary, so hub and broker upgrade in lockstep.)
+
+### Idempotency & duplicate-submit protection
+
+- `buildCreateRequest` generates a fresh `RequestID` per call (`httpdispatcher.go:356`), so the replay never collides with the phase-1 202 cached in the broker's `dispatchAttempts`.
+- `Manager.Start` dedupes by agent slug + project against the runtime (`pkg/agent/run.go:79-107`): if the container is already running it returns it. Since replicas of a stateless local broker share the runtime backend, this dedupe is cross-replica.
+- The hub's phase guard in `submitAgentEnv` (`handlers_agents_core.go:1134-1138`) rejects submits once the agent is `running`. The narrow concurrent-double-submit window is bounded by the `Manager.Start` dedupe above and is no worse than the pre-existing race for plain creates.
+
+## 3. Alternatives Considered
+
+| # | Approach | Why rejected |
+|---|----------|--------------|
+| A | Hub-side env injection (skip two-step for co-located) | The hub cannot know the broker's required-key set — it is derived broker-side from harness-config, settings, and broker-local sources (`extractRequiredEnvKeys`, `handlers.go:1914`). The 202 evaluation must stay on the broker; A alone cannot remove the second phase. Replay subsumes A's goal without moving the evaluation. |
+| B | Sticky / affinity routing | The breaking hop is CLI→hub LB *plus* hub→local co-located broker; Cloud Run cookie affinity does not apply to the in-process dispatch. Instance scale-down during the minutes-to-hours gather window re-breaks it. Couples correctness to LB behavior. |
+| C | Stateless token with embedded pending state | Round-trips a large encrypted blob (a full `CreateAgentRequest` incl. resolved env/secrets) through CLI and hub; new key-management and expiry surface; protocol changes in CLI, hub, and broker. Unnecessary — the hub can already rebuild the request from its DB, so the "token" adds nothing but risk. |
+| D | Shared/external pending-state store (issue's first suggestion) | DB-backed: couples the broker to hub Postgres (breaking the broker's HTTP-only independence) or requires a pluggable store injected only in co-located mode — and remote multi-instance brokers stay broken. Redis: new infra dependency. NFS: tmp+rename atomicity not guaranteed on network filesystems (`state_store.go:154-167`). Keeps the stateful two-step alive. |
+| E | Hub-mediated pending state | Converges to F: the durable "pending state" the hub needs is the agent row (phase=`provisioning`) it already writes, plus request rebuilding it already does. Broker-side `MergedEnv` extras are re-derived on replay. F is E taken to its logical end without a new hub-side record. |
+
+## 4. Detailed Implementation Plan
+
+### Commit 1 — Hub: replay in `DispatchFinalizeEnv` (the fix; shippable alone)
+
+**`pkg/hub/httpdispatcher.go:926-949` — rewrite `DispatchFinalizeEnv`:**
+
+```
+func (d *HTTPAgentDispatcher) DispatchFinalizeEnv(ctx, agent, env) error {
+    requireRuntimeBrokerAssigned(agent)
+    endpoint := d.getBrokerEndpoint(ctx, agent.RuntimeBrokerID)
+
+    req, err := d.buildCreateRequest(ctx, agent, "DispatchFinalizeEnv")  // fresh RequestID, full re-resolution
+    // handle err
+    req.GatherEnv = true                                                // broker re-verifies completeness pre-start
+    if req.ResolvedEnv == nil { req.ResolvedEnv = map[string]string{} } // guard nil map before merge
+    for k, v := range env {                                             // CLI-gathered values win
+        req.ResolvedEnv[k] = v
+    }
+    req.EnvSources = d.buildEnvSources(ctx, agent, req.ResolvedEnv)     // then label gathered keys as user-provided
+
+    resp, envReqs, err := d.client.CreateAgentWithGather(ctx, agent.RuntimeBrokerID, endpoint, req)
+    // hash-mismatch repair retry — same pattern as DispatchAgentCreateWithGather (httpdispatcher.go:888-892)
+    if errors.Is(err, ErrLifecycleDeferred) { return d.deferredFinalizeEnv(ctx, agent, env) }
+    if err != nil { return err }
+    if envReqs != nil && len(envReqs.Needs) > 0 {
+        return &ErrEnvStillMissing{Requirements: envReqs}               // new typed error, carries full response
+    }
+    if resp != nil { d.applyBrokerResponse(agent, resp) }
+    return nil
+}
+```
+
+Notes:
+- `GatherEnv=true` is kept deliberately: if keys are *still* missing, the broker answers 202 instead of launching a container that fails at runtime.
+- The deferred cross-node path needs **no change**: `deferredFinalizeEnv` (`httpdispatcher.go:951-954`) still serializes `FinalizeEnvDispatchArgs{Env}` into the durable dispatch row, and the owning node's `execDispatchFinalizeEnv` (`pkg/hub/reconcile.go:233-258`) calls `DispatchFinalizeEnv` — which now replays. `FinalizeEnvDispatchArgs`, `FinalizeEnvResult`, and `execDispatchFinalizeEnv` are hub-to-hub and are **kept**.
+- The `AgentDispatcher` interface signature of `DispatchFinalizeEnv` is unchanged; only the implementation changes.
+
+**`pkg/hub/handlers_agents_core.go:1148-1151` — `submitAgentEnv` error mapping:**
+- On `ErrEnvStillMissing`, respond with `MissingEnvVars(w, needs, s.buildEnvGatherResponse(ctx, agent, err.Requirements))` (`pkg/hub/errors.go:251`) instead of the generic `RuntimeError`. Agent stays in `provisioning`; the CLI can re-submit with the complete set.
+
+**Tests (commit 1):**
+- **#376 regression test:** dispatcher finalize against a broker `Server` whose `pendingEnvGather` map is empty (fresh instance, never saw the create) → agent starts.
+- Merge precedence: CLI-gathered value overrides storage-resolved value for the same key; `ResolvedEnv == nil` case doesn't panic.
+- Still-missing: replay returns 202 with remaining `Needs` → structured missing-env response, agent stays `provisioning`, second submit with complete env succeeds.
+- Deferred path: `execDispatchFinalizeEnv` round-trip with the replay implementation.
+
+### Commit 2 — Remove the stateful finalize path (hub client chain + broker)
+
+> User decision (Q2): remove immediately in this PR rather than deprecate — "nearly all installations for now are co-located and single binary installs."
+
+Broker (`pkg/runtimebroker`):
+- `handlers.go:1187-1188` — remove `AgentActionFinalizeEnv` route case.
+- `handlers.go:2349-2464` — remove `finalizeEnv` handler.
+- `handlers.go:504-518` — remove the pending-state write in `createAgent`'s 202 path; the 202 becomes fully stateless. (The `dispatchAttempts` 202-response cache at `handlers.go:546-550` stays; it serves same-request-ID retries.)
+- `server.go:215-216, 260-269` — remove `pendingEnvGather` map + mutex and `pendingAgentState`.
+- `state_store.go` — remove the pending-env portion: `pendingStateDir`, `pendingStatePath`, `loadPendingState`, `upsertPendingState`, `deletePendingState`, `cleanupExpiredPendingLocked`, `pendingStateTTL`, `pendingStatePending`/`pendingStateFinalizing` constants, and the pending-dir setup in `initStateStore`. `dispatchAttempts` persistence is untouched.
+- `types.go:454-458` — remove `FinalizeEnvRequest`.
+
+Hub client chain (`pkg/hub`):
+- `server.go:367-369` — remove `FinalizeEnv` from the `RuntimeBrokerClient` interface.
+- `httpdispatcher.go:96-97` — remove `HTTPRuntimeBrokerClient.FinalizeEnv`.
+- `brokerclient.go:101-104` — remove `AuthenticatedBrokerClient.FinalizeEnv`.
+- `controlchannel_client.go:421-…` and `:749-760` — remove `ControlChannelBrokerClient.FinalizeEnv` and `HybridBrokerClient.FinalizeEnv`.
+- `broker_http_transport.go:394-413` — remove the transport method.
+
+Shared API (`pkg/api`):
+- `agent_actions.go:39` — remove `AgentActionFinalizeEnv`; drop it from the action validation switch at `agent_actions.go:50`.
+
+Tests (commit 2):
+- `handlers_envgather_test.go`: drop finalize-handler tests; keep/extend the 202 evaluation tests; add a broker-side replay test — create returns 202, then a second create with complete env starts the agent on a *different* `Server` instance.
+- `grep -rn "pendingEnvGather\|pendingAgentState\|FinalizeEnvRequest\|AgentActionFinalizeEnv" pkg/` returns nothing.
+
+## 5. Impact on Other HA-Unsafe State
+
+- **`dispatchAttempts` (`server.go:220`)** — unchanged by this design, and replay does not depend on it: `RequestID` is a fresh UUID per dispatch call (`httpdispatcher.go:356`), so the map already provides no cross-call (let alone cross-instance) idempotency. The effective duplicate-create guard is `Manager.Start`'s runtime-level dedupe (`run.go:79-107`), which is HA-safe when replicas share a runtime backend. **Follow-up issue #A** (to be filed by broker-fixes-lead, see §8).
+- **`projectProvisionMu` (`server.go:236`)** — replay adds no provisioning passes (the 202 returns before provisioning; exactly one pass per successful start). The cross-instance provisioning race exists only for shared workspace backends (NFS) and is pre-existing and orthogonal. **Follow-up issue #B** (see §8).
+
+## 6. Migration / Rollout
+
+- **New hub + old broker:** replay is a standard `CreateAgentRequest` with complete env — old brokers evaluate, find nothing missing, and start. Works without broker changes.
+- **Old hub + new broker:** NOT supported — old hubs dispatching `finalize-env` would get 404 from a new broker. Accepted per user decision (Q2): nearly all installations are co-located single-binary, so hub and broker upgrade in lockstep. Standalone remote brokers must not be upgraded ahead of their hub across this release; **release notes must state this**.
+- **Co-located builds:** hub and broker version-lock in one binary, so the primary failing deployment (Cloud Run HA) gets both sides atomically.
+- **No schema, infra, or CLI/API surface changes.** The CLI-facing 202/submit protocol is untouched.
+- **Rollback:** revert the whole PR. Reverting only commit 2 also restores the legacy path, since the hub-side replay (commit 1) does not depend on the removal.
+- **Leftover on-disk state:** existing `pending-env/*.json` files from older brokers are never read after upgrade; they are inert. Optional cleanup in `initStateStore` is nice-to-have, not required.
+
+## 7. Implementation Phases (Developer Handoff)
+
+Sized for a **single developer** — two commits in one PR on one branch; no parallel phases, so no EM required.
+
+1. **Commit 1 — hub replay fix** (§4 commit 1): `DispatchFinalizeEnv` replay, `ErrEnvStillMissing`, `submitAgentEnv` mapping, tests including the #376 regression test. This commit alone fixes the bug.
+2. **Commit 2 — legacy path removal** (§4 commit 2): broker handler/state removal, hub client-chain removal, `pkg/api` action removal, test updates.
+3. Standard process: rebase onto upstream main at start and before compare URL; design doc committed to `.design/` as part of the PR; `go build ./... && go test ./pkg/runtimebroker/... ./pkg/hub/... ./pkg/api/...` green per commit.
+
+## 8. Follow-Up Issues (filed by broker-fixes-lead, out of scope here)
+
+- **#A — `dispatchAttempts` is HA-ineffective:** in-memory + per-instance, and request IDs are per-call UUIDs, so it provides no cross-instance (or even cross-call) create idempotency. Decide: rely on runtime-level dedupe and delete the map, or make request-level idempotency real (durable IDs from the hub).
+- **#B — `projectProvisionMu` cross-instance provisioning race:** per-instance mutex cannot serialize `ProvisionShared` across replicas on shared workspace backends (NFS). Needs NFS-safe locking or fully idempotent provisioning.
+
+## 9. Acceptance Criteria
+
+1. **HA regression test:** finalize dispatched to a broker instance whose `pendingEnvGather` is empty (never saw the create) starts the agent successfully.
+2. Single-instance env-gather E2E unchanged: create → 202 with `Needs` → submit → agent `running`.
+3. Submitting with keys still missing returns a structured missing-env-vars error listing the keys; agent remains `provisioning`; a subsequent complete submit succeeds.
+4. CLI-gathered values take precedence over storage-resolved values for the same key.
+5. Duplicate submit after success returns 409 `invalid_state` (existing phase guard).
+6. The `finalize-env` broker action and all `pendingEnvGather` state are gone: no references to `pendingEnvGather`, `pendingAgentState`, `FinalizeEnvRequest`, or `AgentActionFinalizeEnv` remain; the broker rejects the removed action.
+7. Deferred cross-node finalize (`execDispatchFinalizeEnv`) passes with the replay implementation.
+8. Manual/integration validation on Cloud Run with min-instances=2: agent requiring a secret-backed env var reaches `running` reliably (the #376 repro).
+9. No new DB tables, infra dependencies, or CLI protocol changes.
+
+## 10. Open Questions — Resolved
+
+| # | Question | Resolution (user, thread 4524, 2026-07-14) |
+|---|----------|--------------------------------------------|
+| 1 | Approach: replay (F, recommended) vs DB-backed pending state (D, issue's first suggestion)? | **F approved** — "Moving to F as the design seems to be sound." |
+| 2 | Retain legacy broker `finalize-env` path for one release, or remove immediately? | **Remove immediately (b)** — "nearly all installations for now are co-located and single binary installs." |
+| 3 | `dispatchAttempts` / `projectProvisionMu` hardening: follow-up issues or fold in? | **Follow-up issues**, filed by broker-fixes-lead; this design stays scoped to #376. |

--- a/pkg/api/agent_actions.go
+++ b/pkg/api/agent_actions.go
@@ -36,7 +36,6 @@ const (
 	AgentActionLogs              = "logs"
 	AgentActionStats             = "stats"
 	AgentActionHasPrompt         = "has-prompt"
-	AgentActionFinalizeEnv       = "finalize-env"
 	AgentActionResetAuth         = "reset-auth"
 )
 
@@ -47,7 +46,7 @@ func RuntimeBrokerAgentActionMethod(action string) (string, bool) {
 	switch action {
 	case AgentActionLogs, AgentActionStats, AgentActionHasPrompt:
 		return http.MethodGet, true
-	case AgentActionStart, AgentActionStop, AgentActionSuspend, AgentActionRestart, AgentActionMessage, AgentActionExec, AgentActionFinalizeEnv, AgentActionResetAuth:
+	case AgentActionStart, AgentActionStop, AgentActionSuspend, AgentActionRestart, AgentActionMessage, AgentActionExec, AgentActionResetAuth:
 		return http.MethodPost, true
 	default:
 		return "", false

--- a/pkg/hub/broker_http_transport.go
+++ b/pkg/hub/broker_http_transport.go
@@ -391,27 +391,6 @@ func (t *brokerHTTPTransport) CreateAgentWithGather(ctx context.Context, brokerI
 	return &result, nil, nil
 }
 
-func (t *brokerHTTPTransport) FinalizeEnv(ctx context.Context, brokerID, brokerEndpoint, agentID string, env map[string]string) (*RemoteAgentResponse, error) {
-	endpoint := fmt.Sprintf("%s/api/v1/agents/%s/finalize-env", strings.TrimSuffix(brokerEndpoint, "/"), url.PathEscape(agentID))
-	body, err := json.Marshal(map[string]interface{}{"env": env})
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-	resp, err := t.doRequest(ctx, brokerID, http.MethodPost, endpoint, body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode >= 400 {
-		return nil, brokerHTTPError(resp)
-	}
-	var result RemoteAgentResponse
-	if err := t.decodeResponse(resp, &result); err != nil {
-		return nil, err
-	}
-	return &result, nil
-}
-
 func (t *brokerHTTPTransport) GetAgentLogs(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID string, tail int) (string, error) {
 	endpoint := fmt.Sprintf("%s/api/v1/agents/%s/logs", strings.TrimSuffix(brokerEndpoint, "/"), url.PathEscape(agentID))
 	sep := "?"

--- a/pkg/hub/broker_routing_test.go
+++ b/pkg/hub/broker_routing_test.go
@@ -72,9 +72,6 @@ func (f *fakeHTTPClient) CheckAgentPrompt(context.Context, string, string, strin
 func (f *fakeHTTPClient) CreateAgentWithGather(context.Context, string, string, *RemoteCreateAgentRequest) (*RemoteAgentResponse, *RemoteEnvRequirementsResponse, error) {
 	return nil, nil, nil
 }
-func (f *fakeHTTPClient) FinalizeEnv(context.Context, string, string, string, map[string]string) (*RemoteAgentResponse, error) {
-	return nil, nil
-}
 func (f *fakeHTTPClient) GetAgentLogs(context.Context, string, string, string, string, int) (string, error) {
 	return "", nil
 }

--- a/pkg/hub/brokerclient.go
+++ b/pkg/hub/brokerclient.go
@@ -98,11 +98,6 @@ func (c *AuthenticatedBrokerClient) CleanupProject(ctx context.Context, brokerID
 	return c.transport.CleanupProject(ctx, brokerID, brokerEndpoint, projectSlug, projectID)
 }
 
-// FinalizeEnv sends gathered env vars to a broker to complete agent creation.
-func (c *AuthenticatedBrokerClient) FinalizeEnv(ctx context.Context, brokerID, brokerEndpoint, agentID string, env map[string]string) (*RemoteAgentResponse, error) {
-	return c.transport.FinalizeEnv(ctx, brokerID, brokerEndpoint, agentID, env)
-}
-
 // ImageStatus queries a broker's local image state.
 func (c *AuthenticatedBrokerClient) ImageStatus(ctx context.Context, brokerID, brokerEndpoint, shortImage, longImage string) (*BrokerImageStatusResponse, error) {
 	return c.transport.ImageStatus(ctx, brokerID, brokerEndpoint, shortImage, longImage)

--- a/pkg/hub/controlchannel_client.go
+++ b/pkg/hub/controlchannel_client.go
@@ -418,31 +418,6 @@ func (c *ControlChannelBrokerClient) DeleteImage(ctx context.Context, brokerID, 
 	return err
 }
 
-// FinalizeEnv sends gathered env vars to a broker to complete agent creation via control channel.
-func (c *ControlChannelBrokerClient) FinalizeEnv(ctx context.Context, brokerID, brokerEndpoint, agentID string, env map[string]string) (*RemoteAgentResponse, error) {
-	_ = brokerEndpoint
-	path := fmt.Sprintf("/api/v1/agents/%s/finalize-env", url.PathEscape(agentID))
-
-	body, err := json.Marshal(map[string]interface{}{
-		"env": env,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-
-	resp, err := c.doRequest(ctx, brokerID, "POST", path, "", body)
-	if err != nil {
-		return nil, err
-	}
-
-	var result RemoteAgentResponse
-	if err := json.Unmarshal(resp.Body, &result); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	return &result, nil
-}
-
 // doRequestRaw tunnels an HTTP request through the control channel without
 // treating non-2xx status codes as errors. Callers are responsible for
 // inspecting resp.StatusCode themselves.
@@ -746,17 +721,3 @@ func (c *HybridBrokerClient) DeleteImage(ctx context.Context, brokerID, brokerEn
 	return fmt.Errorf("HTTP client does not support image delete")
 }
 
-// FinalizeEnv sends gathered env vars to a broker, using route() to decide the
-// delivery path. routeLocal uses the control-channel tunnel, routeHTTP falls
-// back to HTTP, and routeForward/routeUndeliverable return ErrLifecycleDeferred
-// so the caller can write durable intent + wait.
-func (c *HybridBrokerClient) FinalizeEnv(ctx context.Context, brokerID, brokerEndpoint, agentID string, env map[string]string) (*RemoteAgentResponse, error) {
-	switch c.route(ctx, brokerID, brokerEndpoint) {
-	case routeLocal:
-		return c.controlChannel.FinalizeEnv(ctx, brokerID, brokerEndpoint, agentID, env)
-	case routeHTTP:
-		return c.httpClient.FinalizeEnv(ctx, brokerID, brokerEndpoint, agentID, env)
-	default:
-		return nil, ErrLifecycleDeferred
-	}
-}

--- a/pkg/hub/dispatch_exec_test.go
+++ b/pkg/hub/dispatch_exec_test.go
@@ -701,13 +701,6 @@ func (c *deferredDataOpTestClient) CheckAgentPrompt(_ context.Context, brokerID,
 	return false, nil
 }
 
-func (c *deferredDataOpTestClient) FinalizeEnv(_ context.Context, brokerID, _, _ string, _ map[string]string) (*RemoteAgentResponse, error) {
-	if brokerID != c.localBroker {
-		return nil, ErrLifecycleDeferred
-	}
-	return nil, nil
-}
-
 func (c *deferredDataOpTestClient) CreateAgentWithGather(_ context.Context, brokerID, _ string, _ *RemoteCreateAgentRequest) (*RemoteAgentResponse, *RemoteEnvRequirementsResponse, error) {
 	if brokerID != c.localBroker {
 		return nil, nil, ErrLifecycleDeferred

--- a/pkg/hub/dispatch_lifecycle_test.go
+++ b/pkg/hub/dispatch_lifecycle_test.go
@@ -193,25 +193,6 @@ func TestHybridBrokerClient_CreateAgentWithGather_RouteGate(t *testing.T) {
 	})
 }
 
-func TestHybridBrokerClient_FinalizeEnv_RouteGate(t *testing.T) {
-	const remoteBroker = "broker-remote"
-
-	mgr := NewControlChannelManager(DefaultControlChannelConfig(), slog.Default())
-	c := NewHybridBrokerClient(mgr, &fakeHTTPClient{}, nil, false)
-
-	t.Run("routeForward returns ErrLifecycleDeferred", func(t *testing.T) {
-		c.SetAffinityLookup(func(context.Context, string) (string, bool) { return "hubA", true })
-		_, err := c.FinalizeEnv(context.Background(), remoteBroker, "", "a1", nil)
-		assert.ErrorIs(t, err, ErrLifecycleDeferred)
-	})
-
-	t.Run("routeUndeliverable returns ErrLifecycleDeferred", func(t *testing.T) {
-		c.SetAffinityLookup(func(context.Context, string) (string, bool) { return "", false })
-		_, err := c.FinalizeEnv(context.Background(), remoteBroker, "", "a1", nil)
-		assert.ErrorIs(t, err, ErrLifecycleDeferred)
-	})
-}
-
 // =========================================================================
 // B4-3/B4-4: Dispatch args round-trip
 // =========================================================================

--- a/pkg/hub/envgather_test.go
+++ b/pkg/hub/envgather_test.go
@@ -36,10 +36,7 @@ type envGatherMockBrokerClient struct {
 
 	// Env-gather fields
 	createWithGatherCalled bool
-	finalizeCalled         bool
 	gatherReturnEnvReqs    *RemoteEnvRequirementsResponse
-	lastFinalizeAgentID    string
-	lastFinalizeEnv        map[string]string
 }
 
 func (m *envGatherMockBrokerClient) CreateAgentWithGather(ctx context.Context, brokerID, brokerEndpoint string, req *RemoteCreateAgentRequest) (*RemoteAgentResponse, *RemoteEnvRequirementsResponse, error) {
@@ -63,23 +60,6 @@ func (m *envGatherMockBrokerClient) CreateAgentWithGather(ctx context.Context, b
 		},
 		Created: true,
 	}, nil, nil
-}
-
-func (m *envGatherMockBrokerClient) FinalizeEnv(ctx context.Context, brokerID, brokerEndpoint, agentID string, env map[string]string) (*RemoteAgentResponse, error) {
-	m.finalizeCalled = true
-	m.lastFinalizeAgentID = agentID
-	m.lastFinalizeEnv = env
-	if m.returnErr != nil {
-		return nil, m.returnErr
-	}
-	return &RemoteAgentResponse{
-		Agent: &RemoteAgentInfo{
-			ID:     agentID,
-			Name:   agentID,
-			Status: "running",
-		},
-		Created: true,
-	}, nil
 }
 
 // TestEnvGather_HubDispatch_AllSatisfied tests that when env-gather is enabled
@@ -246,12 +226,9 @@ func TestEnvGather_HubDispatch_FinalizeEnv_Replay(t *testing.T) {
 		t.Fatalf("DispatchFinalizeEnv failed: %v", err)
 	}
 
-	// Replay uses CreateAgentWithGather, NOT FinalizeEnv
+	// Replay uses CreateAgentWithGather
 	if !mockClient.createWithGatherCalled {
 		t.Error("expected CreateAgentWithGather to be called (replay path)")
-	}
-	if mockClient.finalizeCalled {
-		t.Error("expected FinalizeEnv NOT to be called (legacy path)")
 	}
 
 	// Gathered env should be merged into the request

--- a/pkg/hub/envgather_test.go
+++ b/pkg/hub/envgather_test.go
@@ -19,6 +19,7 @@ package hub
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -203,9 +204,10 @@ func TestEnvGather_HubDispatch_NeedsGather(t *testing.T) {
 	}
 }
 
-// TestEnvGather_HubDispatch_FinalizeEnv tests that DispatchFinalizeEnv properly
-// sends gathered env to the broker.
-func TestEnvGather_HubDispatch_FinalizeEnv(t *testing.T) {
+// TestEnvGather_HubDispatch_FinalizeEnv_Replay tests that DispatchFinalizeEnv
+// replays a full create request with gathered env merged at highest precedence,
+// instead of calling the legacy broker finalize-env action.
+func TestEnvGather_HubDispatch_FinalizeEnv_Replay(t *testing.T) {
 	ctx := context.Background()
 	memStore := createTestStore(t)
 
@@ -229,6 +231,9 @@ func TestEnvGather_HubDispatch_FinalizeEnv(t *testing.T) {
 		Slug:            "test-agent-3",
 		ProjectID:       tid("project-1"),
 		RuntimeBrokerID: tid("broker-3"),
+		AppliedConfig: &store.AgentAppliedConfig{
+			HarnessConfig: "claude",
+		},
 	}
 
 	gatheredEnv := map[string]string{
@@ -241,11 +246,265 @@ func TestEnvGather_HubDispatch_FinalizeEnv(t *testing.T) {
 		t.Fatalf("DispatchFinalizeEnv failed: %v", err)
 	}
 
-	if !mockClient.finalizeCalled {
-		t.Error("expected FinalizeEnv to be called")
+	// Replay uses CreateAgentWithGather, NOT FinalizeEnv
+	if !mockClient.createWithGatherCalled {
+		t.Error("expected CreateAgentWithGather to be called (replay path)")
 	}
-	if mockClient.lastFinalizeEnv["SECRET"] != "gathered-secret-value" {
-		t.Errorf("expected SECRET=gathered-secret-value, got %q", mockClient.lastFinalizeEnv["SECRET"])
+	if mockClient.finalizeCalled {
+		t.Error("expected FinalizeEnv NOT to be called (legacy path)")
+	}
+
+	// Gathered env should be merged into the request
+	if mockClient.lastCreateReq == nil {
+		t.Fatal("expected CreateReq to be captured")
+	}
+	if mockClient.lastCreateReq.ResolvedEnv["SECRET"] != "gathered-secret-value" {
+		t.Errorf("expected SECRET=gathered-secret-value, got %q", mockClient.lastCreateReq.ResolvedEnv["SECRET"])
+	}
+	if mockClient.lastCreateReq.ResolvedEnv["API_KEY"] != "gathered-api-key" {
+		t.Errorf("expected API_KEY=gathered-api-key, got %q", mockClient.lastCreateReq.ResolvedEnv["API_KEY"])
+	}
+	if !mockClient.lastCreateReq.GatherEnv {
+		t.Error("expected GatherEnv=true in replay request")
+	}
+}
+
+// TestEnvGather_FinalizeReplay_EmptyPendingEnvGather is the #376 regression test:
+// finalize dispatched to a broker whose pendingEnvGather is empty (i.e. a fresh
+// instance that never saw the original create) succeeds because replay carries
+// the full request state.
+func TestEnvGather_FinalizeReplay_EmptyPendingEnvGather(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-ha"),
+		Name:     "ha-broker",
+		Slug:     "ha-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mock simulates a fresh broker instance — CreateAgentWithGather succeeds
+	// because the replay carries everything needed (no pending state lookup).
+	mockClient := &envGatherMockBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, true, slog.Default())
+
+	agent := &store.Agent{
+		ID:              tid("agent-ha"),
+		Name:            "ha-agent",
+		Slug:            "ha-agent",
+		ProjectID:       tid("project-1"),
+		RuntimeBrokerID: tid("broker-ha"),
+		Phase:           string(state.PhaseProvisioning),
+		AppliedConfig: &store.AgentAppliedConfig{
+			HarnessConfig: "claude",
+		},
+	}
+
+	gatheredEnv := map[string]string{
+		"GEMINI_API_KEY": "gathered-key",
+	}
+
+	err := dispatcher.DispatchFinalizeEnv(ctx, agent, gatheredEnv)
+	if err != nil {
+		t.Fatalf("DispatchFinalizeEnv on fresh broker instance should succeed, got: %v", err)
+	}
+
+	if !mockClient.createWithGatherCalled {
+		t.Error("expected replay via CreateAgentWithGather")
+	}
+	if mockClient.lastCreateReq.ResolvedEnv["GEMINI_API_KEY"] != "gathered-key" {
+		t.Errorf("expected gathered key in request, got %q", mockClient.lastCreateReq.ResolvedEnv["GEMINI_API_KEY"])
+	}
+}
+
+// TestEnvGather_FinalizeReplay_MergePrecedence tests that CLI-gathered values
+// override storage-resolved values for the same key, and that a nil ResolvedEnv
+// doesn't panic.
+func TestEnvGather_FinalizeReplay_MergePrecedence(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-prec"),
+		Name:     "prec-broker",
+		Slug:     "prec-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatal(err)
+	}
+
+	// Store an env var in project scope — this will be in ResolvedEnv from buildCreateRequest
+	project := &store.Project{ID: tid("project-prec"), Name: "prec-project", Slug: "prec-project"}
+	if err := memStore.CreateProject(ctx, project); err != nil {
+		t.Fatal(err)
+	}
+	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
+		ID: tid("env-prec-1"), Key: "API_KEY", Value: "storage-value",
+		Scope: "project", ScopeID: tid("project-prec"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := &envGatherMockBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, true, slog.Default())
+
+	agent := &store.Agent{
+		ID:              tid("agent-prec"),
+		Name:            "prec-agent",
+		Slug:            "prec-agent",
+		ProjectID:       tid("project-prec"),
+		RuntimeBrokerID: tid("broker-prec"),
+		AppliedConfig: &store.AgentAppliedConfig{
+			HarnessConfig: "claude",
+		},
+	}
+
+	gatheredEnv := map[string]string{
+		"API_KEY": "cli-gathered-value",
+	}
+
+	err := dispatcher.DispatchFinalizeEnv(ctx, agent, gatheredEnv)
+	if err != nil {
+		t.Fatalf("DispatchFinalizeEnv failed: %v", err)
+	}
+
+	// CLI-gathered value should win over storage-resolved value
+	if mockClient.lastCreateReq.ResolvedEnv["API_KEY"] != "cli-gathered-value" {
+		t.Errorf("expected CLI-gathered value to win, got %q", mockClient.lastCreateReq.ResolvedEnv["API_KEY"])
+	}
+}
+
+// TestEnvGather_FinalizeReplay_StillMissing tests that when the replay returns 202
+// with remaining Needs, the dispatcher returns ErrEnvStillMissing and the handler
+// responds with a structured missing-env response.
+func TestEnvGather_FinalizeReplay_StillMissing(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-still"),
+		Name:     "still-broker",
+		Slug:     "still-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mock broker returns 202 with remaining needs
+	mockClient := &envGatherMockBrokerClient{
+		gatherReturnEnvReqs: &RemoteEnvRequirementsResponse{
+			AgentID:  tid("agent-still"),
+			Required: []string{"KEY_A", "KEY_B"},
+			HubHas:   []string{"KEY_A"},
+			Needs:    []string{"KEY_B"},
+		},
+	}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, true, slog.Default())
+
+	agent := &store.Agent{
+		ID:              tid("agent-still"),
+		Name:            "still-agent",
+		Slug:            "still-agent",
+		ProjectID:       tid("project-1"),
+		RuntimeBrokerID: tid("broker-still"),
+		AppliedConfig: &store.AgentAppliedConfig{
+			HarnessConfig: "claude",
+		},
+	}
+
+	err := dispatcher.DispatchFinalizeEnv(ctx, agent, map[string]string{"KEY_A": "val"})
+	if err == nil {
+		t.Fatal("expected ErrEnvStillMissing, got nil")
+	}
+
+	var stillMissing *ErrEnvStillMissing
+	if !errors.As(err, &stillMissing) {
+		t.Fatalf("expected *ErrEnvStillMissing, got %T: %v", err, err)
+	}
+	if len(stillMissing.Requirements.Needs) != 1 || stillMissing.Requirements.Needs[0] != "KEY_B" {
+		t.Errorf("expected Needs=[KEY_B], got %v", stillMissing.Requirements.Needs)
+	}
+}
+
+// TestEnvGather_FinalizeReplay_StillMissing_Handler tests the full HTTP handler path
+// when replay returns still-missing keys: the handler returns 422 with a structured response.
+func TestEnvGather_FinalizeReplay_StillMissing_Handler(t *testing.T) {
+	srv, st := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{ID: tid("project-still-h"), Name: "still-h-project", Slug: "still-h-project"}
+	if err := st.CreateProject(ctx, project); err != nil {
+		t.Fatal(err)
+	}
+
+	broker := &store.RuntimeBroker{
+		ID: tid("broker-still-h"), Name: "still-h-broker", Slug: "still-h-broker",
+		Endpoint: "http://localhost:9800", Status: store.BrokerStatusOnline,
+	}
+	if err := st.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatal(err)
+	}
+
+	agent := &store.Agent{
+		ID:              tid("agent-still-h"),
+		Name:            "still-h-agent",
+		Slug:            "still-h-agent",
+		ProjectID:       tid("project-still-h"),
+		RuntimeBrokerID: tid("broker-still-h"),
+		Phase:           string(state.PhaseProvisioning),
+		AppliedConfig:   &store.AgentAppliedConfig{HarnessConfig: "claude"},
+	}
+	if err := st.CreateAgent(ctx, agent); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mock returns 202 with remaining needs on CreateAgentWithGather (the replay path)
+	mockClient := &envGatherMockBrokerClient{
+		gatherReturnEnvReqs: &RemoteEnvRequirementsResponse{
+			AgentID:  tid("agent-still-h"),
+			Required: []string{"KEY_A", "KEY_B"},
+			HubHas:   []string{"KEY_A"},
+			Needs:    []string{"KEY_B"},
+		},
+	}
+	dispatcher := NewHTTPAgentDispatcherWithClient(st, mockClient, true, slog.Default())
+	srv.SetDispatcher(dispatcher)
+
+	reqBody := map[string]interface{}{
+		"env": map[string]string{"KEY_A": "val-a"},
+	}
+
+	path := fmt.Sprintf("/api/v1/projects/%s/agents/still-h-agent/env", tid("project-still-h"))
+	rec := doRequest(t, srv, http.MethodPost, path, reqBody)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &errResp); err != nil {
+		t.Fatal("failed to decode error response:", err)
+	}
+	if errResp.Error.Code != ErrCodeMissingEnvVars {
+		t.Errorf("expected error code %q, got %q", ErrCodeMissingEnvVars, errResp.Error.Code)
+	}
+
+	// Agent should still be in provisioning (not promoted to running)
+	updated, err := st.GetAgent(ctx, tid("agent-still-h"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Phase != string(state.PhaseProvisioning) {
+		t.Errorf("expected agent to stay in provisioning, got %q", updated.Phase)
 	}
 }
 
@@ -462,12 +721,16 @@ func TestEnvGather_HubHandler_SubmitEnv(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	if !mockClient.finalizeCalled {
-		t.Error("expected FinalizeEnv to be called on broker")
+	// Replay path: should use CreateAgentWithGather, not FinalizeEnv
+	if !mockClient.createWithGatherCalled {
+		t.Error("expected CreateAgentWithGather to be called (replay path)")
 	}
 
-	if mockClient.lastFinalizeEnv["GEMINI_API_KEY"] != "test-api-key-value" {
-		t.Errorf("expected GEMINI_API_KEY=test-api-key-value, got %q", mockClient.lastFinalizeEnv["GEMINI_API_KEY"])
+	if mockClient.lastCreateReq == nil {
+		t.Fatal("expected CreateReq to be captured")
+	}
+	if mockClient.lastCreateReq.ResolvedEnv["GEMINI_API_KEY"] != "test-api-key-value" {
+		t.Errorf("expected GEMINI_API_KEY=test-api-key-value, got %q", mockClient.lastCreateReq.ResolvedEnv["GEMINI_API_KEY"])
 	}
 
 	// Agent should be updated to running

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -1146,6 +1146,12 @@ func (s *Server) submitAgentEnv(w http.ResponseWriter, r *http.Request, projectI
 	}
 
 	if err := dispatcher.DispatchFinalizeEnv(ctx, agent, req.Env); err != nil {
+		var stillMissing *ErrEnvStillMissing
+		if errors.As(err, &stillMissing) {
+			MissingEnvVars(w, stillMissing.Requirements.Needs,
+				s.buildEnvGatherResponse(ctx, agent, stillMissing.Requirements))
+			return
+		}
 		RuntimeError(w, "Failed to finalize env on runtime broker: "+err.Error())
 		return
 	}

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -93,10 +93,6 @@ func (c *HTTPRuntimeBrokerClient) CreateAgentWithGather(ctx context.Context, bro
 	return c.transport.CreateAgentWithGather(ctx, brokerID, brokerEndpoint, req)
 }
 
-func (c *HTTPRuntimeBrokerClient) FinalizeEnv(ctx context.Context, brokerID, brokerEndpoint, agentID string, env map[string]string) (*RemoteAgentResponse, error) {
-	return c.transport.FinalizeEnv(ctx, brokerID, brokerEndpoint, agentID, env)
-}
-
 func (c *HTTPRuntimeBrokerClient) GetAgentLogs(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID string, tail int) (string, error) {
 	return c.transport.GetAgentLogs(ctx, brokerID, brokerEndpoint, agentID, projectID, tail)
 }

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -923,7 +923,20 @@ func (d *HTTPAgentDispatcher) deferredCreateWithGather(ctx context.Context, agen
 	return cr.EnvRequirements, nil
 }
 
-// DispatchFinalizeEnv sends gathered env vars to the broker to complete agent creation.
+// ErrEnvStillMissing is returned when a replay-based finalize discovers that
+// required env keys are still unsatisfied after merging CLI-gathered values.
+type ErrEnvStillMissing struct {
+	Requirements *RemoteEnvRequirementsResponse
+}
+
+func (e *ErrEnvStillMissing) Error() string {
+	return fmt.Sprintf("env still missing after finalize: %v", e.Requirements.Needs)
+}
+
+// DispatchFinalizeEnv replays a full create request with CLI-gathered env merged
+// at highest precedence, instead of calling the broker's stateful finalize-env
+// action. This makes the finalize HA-safe: the replay can land on any broker
+// replica because it carries the complete request state.
 func (d *HTTPAgentDispatcher) DispatchFinalizeEnv(ctx context.Context, agent *store.Agent, env map[string]string) error {
 	if err := requireRuntimeBrokerAssigned(agent); err != nil {
 		return err
@@ -934,12 +947,36 @@ func (d *HTTPAgentDispatcher) DispatchFinalizeEnv(ctx context.Context, agent *st
 		return err
 	}
 
-	resp, err := d.client.FinalizeEnv(ctx, agent.RuntimeBrokerID, endpoint, agent.ID, env)
+	req, err := d.buildCreateRequest(ctx, agent, "DispatchFinalizeEnv")
+	if err != nil {
+		return err
+	}
+	req.GatherEnv = true
+
+	if req.ResolvedEnv == nil {
+		req.ResolvedEnv = map[string]string{}
+	}
+	for k, v := range env {
+		req.ResolvedEnv[k] = v
+	}
+
+	req.EnvSources = d.buildEnvSources(ctx, agent, req.ResolvedEnv)
+
+	resp, envReqs, err := d.client.CreateAgentWithGather(ctx, agent.RuntimeBrokerID, endpoint, req)
+	if isHashMismatchError(err) {
+		if repairErr := d.repairHashMismatch(ctx, agent, err); repairErr == nil {
+			resp, envReqs, err = d.client.CreateAgentWithGather(ctx, agent.RuntimeBrokerID, endpoint, req)
+		}
+	}
 	if errors.Is(err, ErrLifecycleDeferred) {
 		return d.deferredFinalizeEnv(ctx, agent, env)
 	}
 	if err != nil {
 		return err
+	}
+
+	if envReqs != nil && len(envReqs.Needs) > 0 {
+		return &ErrEnvStillMissing{Requirements: envReqs}
 	}
 
 	if resp != nil {

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -175,12 +175,6 @@ func (m *mockRuntimeBrokerClient) CheckAgentPrompt(ctx context.Context, brokerID
 	return false, m.returnErr
 }
 
-func (m *mockRuntimeBrokerClient) FinalizeEnv(ctx context.Context, brokerID, brokerEndpoint, agentID string, env map[string]string) (*RemoteAgentResponse, error) {
-	return &RemoteAgentResponse{
-		Agent: &RemoteAgentInfo{ID: agentID, Name: agentID, Phase: string(state.PhaseRunning)},
-	}, m.returnErr
-}
-
 func (m *mockRuntimeBrokerClient) GetAgentLogs(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID string, tail int) (string, error) {
 	return "", nil
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -364,10 +364,6 @@ type RuntimeBrokerClient interface {
 	// projectID scopes the lookup to a specific project (required for uniqueness).
 	CheckAgentPrompt(ctx context.Context, brokerID, brokerEndpoint, agentID, projectID string) (bool, error)
 
-	// FinalizeEnv sends gathered env vars to a broker to complete agent creation
-	// after an initial 202 env-gather response.
-	FinalizeEnv(ctx context.Context, brokerID, brokerEndpoint, agentID string, env map[string]string) (*RemoteAgentResponse, error)
-
 	// CreateAgentWithGather creates an agent and handles 202 env-gather responses.
 	// Returns (response, nil, nil) on success, (nil, envReqs, nil) on 202, or (nil, nil, err) on error.
 	CreateAgentWithGather(ctx context.Context, brokerID, brokerEndpoint string, req *RemoteCreateAgentRequest) (*RemoteAgentResponse, *RemoteEnvRequirementsResponse, error)

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -502,21 +502,6 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 			}
 
 			if len(needs) > 0 {
-				// Store pending state for finalize-env
-				s.pendingEnvGatherMu.Lock()
-				now := time.Now()
-				s.cleanupExpiredPendingLocked(now)
-				s.upsertPendingState(&pendingAgentState{
-					AgentID:   agentKey,
-					Request:   &req,
-					MergedEnv: env,
-					CreatedAt: now,
-					UpdatedAt: now,
-					State:     pendingStatePending,
-					RequestID: req.RequestID,
-				})
-				s.pendingEnvGatherMu.Unlock()
-
 				if s.config.Debug {
 					s.envSecretLog.Debug("Env-gather: returning 202 with requirements",
 						"required", required,
@@ -1184,8 +1169,6 @@ func (s *Server) handleAgentAction(w http.ResponseWriter, r *http.Request, id, p
 		s.getStats(w, r, id, projectID)
 	case api.AgentActionHasPrompt:
 		s.checkAgentPrompt(w, r, id, projectID)
-	case api.AgentActionFinalizeEnv:
-		s.finalizeEnv(w, r, id)
 	}
 }
 
@@ -2344,123 +2327,6 @@ func (s *Server) resolveHarnessConfigForEnvGather(req CreateAgentRequest, settin
 		return ""
 	}
 	return res.Name
-}
-
-// finalizeEnv handles the second phase of env-gather: receiving gathered env vars
-// from the Hub and starting the agent with the complete environment.
-func (s *Server) finalizeEnv(w http.ResponseWriter, r *http.Request, id string) {
-	ctx := r.Context()
-
-	var req FinalizeEnvRequest
-	if err := readJSON(r, &req); err != nil {
-		BadRequest(w, "Invalid request body: "+err.Error())
-		return
-	}
-
-	// Look up pending state
-	s.pendingEnvGatherMu.Lock()
-	s.cleanupExpiredPendingLocked(time.Now())
-	pending, ok := s.pendingEnvGather[id]
-	if ok && pending.State == pendingStateFinalizing {
-		s.pendingEnvGatherMu.Unlock()
-		writeError(w, http.StatusConflict, ErrCodeConflict, "agent finalize-env already in progress", map[string]interface{}{
-			"agentId": id,
-		})
-		return
-	}
-	if ok {
-		pending.State = pendingStateFinalizing
-		pending.UpdatedAt = time.Now()
-		pending.FinalizeRuns++
-		s.upsertPendingState(pending)
-	}
-	s.pendingEnvGatherMu.Unlock()
-
-	if !ok {
-		NotFound(w, "Pending agent")
-		return
-	}
-
-	// Merge gathered env into the previously merged env
-	for k, v := range req.Env {
-		pending.MergedEnv[k] = v
-	}
-
-	if s.config.Debug {
-		s.envSecretLog.Debug("Finalize-env: merging gathered env", "gatheredKeys", len(req.Env), "totalEnv", len(pending.MergedEnv))
-	}
-
-	origReq := pending.Request
-
-	// Build unified start context from the original pending request + merged env
-	sc, err := s.buildStartContext(ctx, startContextInputs{
-		Name:            origReq.Name,
-		AgentID:         origReq.ID,
-		Slug:            origReq.Slug,
-		ProjectPath:     origReq.ProjectPath,
-		ProjectSlug:     origReq.ProjectSlug,
-		ProjectID:       origReq.ProjectID,
-		Config:          origReq.Config,
-		InlineConfig:    origReq.InlineConfig,
-		SharedDirs:      origReq.SharedDirs,
-		HubEndpoint:     origReq.HubEndpoint,
-		AgentToken:      origReq.AgentToken,
-		CreatorName:     origReq.CreatorName,
-		ResolvedEnv:     pending.MergedEnv,
-		ResolvedSecrets: origReq.ResolvedSecrets,
-		NoAuth:          origReq.NoAuth,
-		Attach:          origReq.Attach,
-		HTTPRequest:     r,
-	})
-	if err != nil {
-		TemplateError(w, err.Error())
-		return
-	}
-	opts := sc.Opts
-
-	if s.config.Debug {
-		s.envSecretLog.Debug("Finalize-env: StartOptions built from pending request",
-			"name", opts.Name,
-			"projectPath", opts.ProjectPath,
-			"template", opts.Template,
-			"image", opts.Image,
-			"profile", opts.Profile,
-			"harnessConfig", opts.HarnessConfig,
-			"hasConfig", origReq.Config != nil,
-		)
-	}
-
-	// Start the agent
-	agentInfo, err := sc.Manager.Start(ctx, opts)
-	if err != nil {
-		// Keep pending state for retry on transient start failures.
-		s.pendingEnvGatherMu.Lock()
-		if cur, exists := s.pendingEnvGather[id]; exists {
-			cur.State = pendingStatePending
-			cur.UpdatedAt = time.Now()
-			s.upsertPendingState(cur)
-		}
-		s.pendingEnvGatherMu.Unlock()
-		RuntimeError(w, "Failed to create agent: "+err.Error())
-		return
-	}
-
-	s.pendingEnvGatherMu.Lock()
-	s.deletePendingState(id)
-	s.pendingEnvGatherMu.Unlock()
-
-	s.agentLifecycleLog.Info("Agent created (finalize-env)",
-		"agent_id", origReq.ID, "project_id", origReq.ProjectID,
-		"name", origReq.Name, "slug", origReq.Slug,
-		"phase", string(state.PhaseRunning),
-		"container_status", agentInfo.ContainerStatus)
-
-	resp := CreateAgentResponse{
-		Agent:   agentInfoPtr(AgentInfoToResponse(*agentInfo)),
-		Created: true,
-	}
-
-	writeJSON(w, http.StatusCreated, resp)
 }
 
 // resolveManagerForAgent returns the appropriate agent.Manager for an existing

--- a/pkg/runtimebroker/handlers_envgather_test.go
+++ b/pkg/runtimebroker/handlers_envgather_test.go
@@ -261,9 +261,10 @@ profiles:
 	}
 }
 
-// TestEnvGather_FinalizeEnv tests the finalize-env endpoint: after receiving
-// a 202, the caller submits gathered env and the agent starts.
-func TestEnvGather_FinalizeEnv(t *testing.T) {
+// TestEnvGather_BrokerReplay_DifferentInstance tests the broker-side replay
+// scenario: create returns 202, then a second create with complete env starts
+// the agent on a different Server instance (HA scenario).
+func TestEnvGather_BrokerReplay_DifferentInstance(t *testing.T) {
 	settings := `
 schema_version: "1"
 harness_configs:
@@ -275,149 +276,11 @@ profiles:
   default:
     runtime: mock
 `
-	srv, mgr, projectDir := newTestServerWithProjectPath(t, settings)
-
-	// Phase 1: Create agent with gather — should get 202
+	// Phase 1: first broker instance returns 202
+	srv1, _, projectDir := newTestServerWithProjectPath(t, settings)
 	createBody := `{
-		"name": "test-agent-finalize",
-		"id": "agent-uuid-fin",
-		"gatherEnv": true,
-		"grovePath": "` + projectDir + `",
-		"config": {"template": "claude", "profile": "default"}
-	}`
-	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(createBody))
-	createReq.Header.Set("Content-Type", "application/json")
-	createW := httptest.NewRecorder()
-
-	srv.Handler().ServeHTTP(createW, createReq)
-
-	if createW.Code != http.StatusAccepted {
-		t.Fatalf("phase 1: expected 202, got %d: %s", createW.Code, createW.Body.String())
-	}
-
-	// Phase 2: Submit gathered env via finalize-env
-	finalizeBody := `{"env": {"NEEDED_KEY": "gathered-value"}}`
-	finalizeReq := httptest.NewRequest(http.MethodPost, "/api/v1/agents/agent-uuid-fin/finalize-env", strings.NewReader(finalizeBody))
-	finalizeReq.Header.Set("Content-Type", "application/json")
-	finalizeW := httptest.NewRecorder()
-
-	srv.Handler().ServeHTTP(finalizeW, finalizeReq)
-
-	if finalizeW.Code != http.StatusCreated {
-		t.Fatalf("phase 2: expected 201, got %d: %s", finalizeW.Code, finalizeW.Body.String())
-	}
-
-	// Verify agent was started with the gathered key
-	if mgr.lastEnv == nil {
-		t.Fatal("expected env to be set after finalize")
-	}
-	if mgr.lastEnv["NEEDED_KEY"] != "gathered-value" {
-		t.Errorf("expected NEEDED_KEY='gathered-value', got %q", mgr.lastEnv["NEEDED_KEY"])
-	}
-
-	// Verify template slug was preserved through finalize-env (regression test:
-	// without this, container image resolution fails with "no container image resolved")
-	if mgr.lastTemplateName != "claude" {
-		t.Errorf("expected TemplateName='claude', got %q", mgr.lastTemplateName)
-	}
-}
-
-func TestEnvGather_FinalizeEnv_RetryOnStartFailure(t *testing.T) {
-	settings := `
-schema_version: "1"
-harness_configs:
-  claude:
-    harness: claude
-    env:
-      NEEDED_KEY: ""
-profiles:
-  default:
-    runtime: mock
-`
-	srv, mgr, projectDir := newTestServerWithProjectPath(t, settings)
-	mgr.startErr = os.ErrPermission
-
-	createBody := `{
-		"name": "test-agent-retry",
-		"id": "agent-uuid-retry",
-		"gatherEnv": true,
-		"grovePath": "` + projectDir + `",
-		"config": {"template": "claude", "profile": "default"}
-	}`
-	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(createBody))
-	createReq.Header.Set("Content-Type", "application/json")
-	createW := httptest.NewRecorder()
-	srv.Handler().ServeHTTP(createW, createReq)
-	if createW.Code != http.StatusAccepted {
-		t.Fatalf("phase 1: expected 202, got %d: %s", createW.Code, createW.Body.String())
-	}
-
-	finalizeBody := `{"env": {"NEEDED_KEY": "gathered-value"}}`
-	finalizeReq := httptest.NewRequest(http.MethodPost, "/api/v1/agents/agent-uuid-retry/finalize-env", strings.NewReader(finalizeBody))
-	finalizeReq.Header.Set("Content-Type", "application/json")
-	finalizeW := httptest.NewRecorder()
-	srv.Handler().ServeHTTP(finalizeW, finalizeReq)
-	if finalizeW.Code != http.StatusInternalServerError {
-		t.Fatalf("first finalize: expected 500, got %d: %s", finalizeW.Code, finalizeW.Body.String())
-	}
-
-	mgr.startErr = nil
-	retryReq := httptest.NewRequest(http.MethodPost, "/api/v1/agents/agent-uuid-retry/finalize-env", strings.NewReader(finalizeBody))
-	retryReq.Header.Set("Content-Type", "application/json")
-	retryW := httptest.NewRecorder()
-	srv.Handler().ServeHTTP(retryW, retryReq)
-	if retryW.Code != http.StatusCreated {
-		t.Fatalf("retry finalize: expected 201, got %d: %s", retryW.Code, retryW.Body.String())
-	}
-}
-
-func TestEnvGather_FinalizeEnv_SurvivesBrokerRestart(t *testing.T) {
-	settings := `
-schema_version: "1"
-harness_configs:
-  claude:
-    harness: claude
-    env:
-      NEEDED_KEY: ""
-profiles:
-  default:
-    runtime: mock
-`
-	projectDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(projectDir, "settings.yaml"), []byte(settings), 0644); err != nil {
-		t.Fatal(err)
-	}
-	for _, tpl := range []string{"claude", "default"} {
-		tplDir := filepath.Join(projectDir, "templates", tpl)
-		if err := os.MkdirAll(tplDir, 0755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(tplDir, "scion-agent.yaml"), []byte("harness_config: claude\n"), 0644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	hcDir := filepath.Join(projectDir, "harness-configs", "claude")
-	if err := os.MkdirAll(hcDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(hcDir, "config.yaml"), []byte("harness: claude\nimage: test-image:claude\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	stateDir := t.TempDir()
-	cfg := DefaultServerConfig()
-	cfg.BrokerID = "test-broker-id"
-	cfg.BrokerName = "test-host"
-	cfg.Debug = true
-	cfg.StateDir = stateDir
-	cfg.ForceRuntime = "mock"
-
-	createMgr := &envCapturingManager{}
-	srv1 := New(cfg, createMgr, &runtime.MockRuntime{NameFunc: func() string { return "docker" }})
-
-	createBody := `{
-		"name": "test-agent-restart",
-		"id": "agent-uuid-restart",
+		"name": "test-agent-replay",
+		"id": "agent-uuid-replay",
 		"gatherEnv": true,
 		"grovePath": "` + projectDir + `",
 		"config": {"template": "claude", "profile": "default"}
@@ -430,19 +293,31 @@ profiles:
 		t.Fatalf("phase 1: expected 202, got %d: %s", createW.Code, createW.Body.String())
 	}
 
-	finalizeMgr := &envCapturingManager{}
-	srv2 := New(cfg, finalizeMgr, &runtime.MockRuntime{NameFunc: func() string { return "docker" }})
+	// Phase 2: different broker instance receives a full create with gathered env
+	srv2, mgr2, _ := newTestServerWithProjectPath(t, settings)
+	replayBody := `{
+		"name": "test-agent-replay",
+		"id": "agent-uuid-replay",
+		"requestId": "replay-req-id",
+		"gatherEnv": true,
+		"grovePath": "` + projectDir + `",
+		"config": {"template": "claude", "profile": "default"},
+		"resolvedEnv": {"NEEDED_KEY": "gathered-value", "ANTHROPIC_API_KEY": "test-key"}
+	}`
+	replayReq := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(replayBody))
+	replayReq.Header.Set("Content-Type", "application/json")
+	replayW := httptest.NewRecorder()
+	srv2.Handler().ServeHTTP(replayW, replayReq)
 
-	finalizeBody := `{"env": {"NEEDED_KEY": "gathered-value"}}`
-	finalizeReq := httptest.NewRequest(http.MethodPost, "/api/v1/agents/agent-uuid-restart/finalize-env", strings.NewReader(finalizeBody))
-	finalizeReq.Header.Set("Content-Type", "application/json")
-	finalizeW := httptest.NewRecorder()
-	srv2.Handler().ServeHTTP(finalizeW, finalizeReq)
-	if finalizeW.Code != http.StatusCreated {
-		t.Fatalf("phase 2: expected 201, got %d: %s", finalizeW.Code, finalizeW.Body.String())
+	if replayW.Code != http.StatusCreated {
+		t.Fatalf("phase 2: expected 201, got %d: %s", replayW.Code, replayW.Body.String())
 	}
-	if finalizeMgr.lastEnv["NEEDED_KEY"] != "gathered-value" {
-		t.Fatalf("expected gathered value to survive restart, got %q", finalizeMgr.lastEnv["NEEDED_KEY"])
+
+	if mgr2.lastEnv == nil {
+		t.Fatal("expected env to be set on second instance")
+	}
+	if mgr2.lastEnv["NEEDED_KEY"] != "gathered-value" {
+		t.Errorf("expected NEEDED_KEY='gathered-value', got %q", mgr2.lastEnv["NEEDED_KEY"])
 	}
 }
 
@@ -1366,99 +1241,6 @@ profiles:
 	}
 }
 
-// TestEnvGather_FinalizeEnv_EmptyTemplate tests that finalize-env succeeds when
-// the create request has no template specified, verifying that harness-config
-// resolution falls back to settings defaults (default_harness_config) and
-// image resolution succeeds.
-func TestEnvGather_FinalizeEnv_EmptyTemplate(t *testing.T) {
-	projectDir := t.TempDir()
-
-	// Settings with default_harness_config that points to "claude"
-	settingsYAML := `
-schema_version: "1"
-default_harness_config: claude
-harness_configs:
-  claude:
-    harness: claude
-    env:
-      NEEDED_KEY: ""
-profiles:
-  default:
-    runtime: mock
-`
-	if err := os.WriteFile(filepath.Join(projectDir, "settings.yaml"), []byte(settingsYAML), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create "default" template WITHOUT harness_config so the fallback to
-	// settings.default_harness_config is exercised.
-	defaultTplDir := filepath.Join(projectDir, "templates", "default")
-	if err := os.MkdirAll(defaultTplDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(defaultTplDir, "scion-agent.yaml"), []byte("# no harness_config\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create "claude" harness-config directory with image
-	claudeHCDir := filepath.Join(projectDir, "harness-configs", "claude")
-	if err := os.MkdirAll(claudeHCDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(claudeHCDir, "config.yaml"), []byte("harness: claude\nimage: test-image:claude\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg := DefaultServerConfig()
-	cfg.BrokerID = "test-broker-id"
-	cfg.BrokerName = "test-host"
-	cfg.Debug = true
-
-	mgr := &envCapturingManager{}
-	// NameFunc returns "docker" so resolveManagerForOpts matches the settings-resolved runtime.
-	rt := &runtime.MockRuntime{NameFunc: func() string { return "docker" }}
-
-	srv := New(cfg, mgr, rt)
-
-	// Phase 1: Create agent with gatherEnv but NO template — should get 202
-	createBody := `{
-		"name": "test-agent-empty-tpl",
-		"id": "agent-uuid-empty-tpl",
-		"gatherEnv": true,
-		"grovePath": "` + projectDir + `",
-		"config": {"profile": "default"}
-	}`
-	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(createBody))
-	createReq.Header.Set("Content-Type", "application/json")
-	createW := httptest.NewRecorder()
-
-	srv.Handler().ServeHTTP(createW, createReq)
-
-	if createW.Code != http.StatusAccepted {
-		t.Fatalf("phase 1: expected 202, got %d: %s", createW.Code, createW.Body.String())
-	}
-
-	// Phase 2: Submit gathered env via finalize-env
-	finalizeBody := `{"env": {"NEEDED_KEY": "gathered-value"}}`
-	finalizeReq := httptest.NewRequest(http.MethodPost, "/api/v1/agents/agent-uuid-empty-tpl/finalize-env", strings.NewReader(finalizeBody))
-	finalizeReq.Header.Set("Content-Type", "application/json")
-	finalizeW := httptest.NewRecorder()
-
-	srv.Handler().ServeHTTP(finalizeW, finalizeReq)
-
-	if finalizeW.Code != http.StatusCreated {
-		t.Fatalf("phase 2: expected 201, got %d: %s", finalizeW.Code, finalizeW.Body.String())
-	}
-
-	// Verify agent was started with the gathered key
-	if mgr.lastEnv == nil {
-		t.Fatal("expected env to be set after finalize")
-	}
-	if mgr.lastEnv["NEEDED_KEY"] != "gathered-value" {
-		t.Errorf("expected NEEDED_KEY='gathered-value', got %q", mgr.lastEnv["NEEDED_KEY"])
-	}
-}
-
 // TestEnvGather_HarnessFromConfig tests that harness-config env declarations
 // drive env-gather even when using config.harnessConfig without an on-disk dir.
 func TestEnvGather_HarnessFromConfig(t *testing.T) {
@@ -1509,59 +1291,6 @@ profiles:
 	}
 	if !found {
 		t.Errorf("expected GEMINI_API_KEY in needs, got needs=%v required=%v", envReqs.Needs, envReqs.Required)
-	}
-}
-
-// TestEnvGather_FinalizeEnv_HarnessConfigPreserved tests that the harnessConfig
-// from the original create request is preserved through the env-gather/finalize-env
-// flow and passed to Start() in the StartOptions.
-func TestEnvGather_FinalizeEnv_HarnessConfigPreserved(t *testing.T) {
-	settings := `
-schema_version: "1"
-harness_configs:
-  claude:
-    harness: claude
-    env:
-      NEEDED_KEY: ""
-profiles:
-  default:
-    runtime: mock
-`
-	srv, mgr, projectDir := newTestServerWithProjectPath(t, settings)
-
-	// Phase 1: Create agent with gatherEnv and explicit harnessConfig — should get 202
-	createBody := `{
-		"name": "test-agent-hc-preserve",
-		"id": "agent-uuid-hcp",
-		"gatherEnv": true,
-		"grovePath": "` + projectDir + `",
-		"config": {"template": "claude", "harnessConfig": "claude", "profile": "default"}
-	}`
-	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(createBody))
-	createReq.Header.Set("Content-Type", "application/json")
-	createW := httptest.NewRecorder()
-
-	srv.Handler().ServeHTTP(createW, createReq)
-
-	if createW.Code != http.StatusAccepted {
-		t.Fatalf("phase 1: expected 202, got %d: %s", createW.Code, createW.Body.String())
-	}
-
-	// Phase 2: Submit gathered env via finalize-env
-	finalizeBody := `{"env": {"NEEDED_KEY": "gathered-value"}}`
-	finalizeReq := httptest.NewRequest(http.MethodPost, "/api/v1/agents/agent-uuid-hcp/finalize-env", strings.NewReader(finalizeBody))
-	finalizeReq.Header.Set("Content-Type", "application/json")
-	finalizeW := httptest.NewRecorder()
-
-	srv.Handler().ServeHTTP(finalizeW, finalizeReq)
-
-	if finalizeW.Code != http.StatusCreated {
-		t.Fatalf("phase 2: expected 201, got %d: %s", finalizeW.Code, finalizeW.Body.String())
-	}
-
-	// Verify harnessConfig was preserved through finalize-env
-	if mgr.lastHarnessConfig != "claude" {
-		t.Errorf("expected HarnessConfig='claude', got %q", mgr.lastHarnessConfig)
 	}
 }
 

--- a/pkg/runtimebroker/handlers_test.go
+++ b/pkg/runtimebroker/handlers_test.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
@@ -2031,59 +2030,6 @@ func TestCreateAgentWithGitCloneAndBranch(t *testing.T) {
 	}
 	if got := mgr.lastEnv["SCION_GIT_BRANCH"]; got != "main" {
 		t.Errorf("expected SCION_GIT_BRANCH='main', got %q", got)
-	}
-}
-
-func TestFinalizeEnvPassesAgentBranch(t *testing.T) {
-	srv, mgr := newTestServerWithGitCloneCapture()
-	agentID := "test-finalize-branch-id"
-
-	// Seed pending env-gather state with a branch and gitClone config
-	srv.pendingEnvGatherMu.Lock()
-	srv.pendingEnvGather[agentID] = &pendingAgentState{
-		AgentID: agentID,
-		Request: &CreateAgentRequest{
-			Name:        "finalize-branch-agent",
-			ProjectPath: "",
-			Config: &CreateAgentConfig{
-				Template: "claude",
-				Branch:   "my-feature",
-				GitClone: &api.GitCloneConfig{
-					URL:    "https://github.com/example/repo.git",
-					Branch: "main",
-					Depth:  1,
-				},
-			},
-		},
-		MergedEnv: map[string]string{},
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
-		State:     pendingStatePending,
-	}
-	srv.pendingEnvGatherMu.Unlock()
-
-	body := `{"env": {"GEMINI_API_KEY": "test-key"}}`
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+agentID+"/finalize-env", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-
-	srv.Handler().ServeHTTP(w, req)
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, w.Code, w.Body.String())
-	}
-
-	if mgr.lastEnv == nil {
-		t.Fatal("expected environment variables to be set, got nil")
-	}
-	if got := mgr.lastEnv["SCION_AGENT_BRANCH"]; got != "my-feature" {
-		t.Errorf("expected SCION_AGENT_BRANCH='my-feature', got %q", got)
-	}
-	if got := mgr.lastEnv["SCION_GIT_BRANCH"]; got != "main" {
-		t.Errorf("expected SCION_GIT_BRANCH='main', got %q", got)
-	}
-	if got := mgr.lastEnv["SCION_GIT_CLONE_URL"]; got != "https://github.com/example/repo.git" {
-		t.Errorf("expected SCION_GIT_CLONE_URL set, got %q", got)
 	}
 }
 

--- a/pkg/runtimebroker/server.go
+++ b/pkg/runtimebroker/server.go
@@ -210,11 +210,6 @@ type Server struct {
 	credLastScan    time.Time
 	credWatcherStop chan struct{}
 
-	// Pending env-gather state: agents waiting for env var submission.
-	// Keyed by immutable agent ID.
-	pendingEnvGather   map[string]*pendingAgentState
-	pendingEnvGatherMu sync.Mutex
-
 	// dispatchAttempts tracks request-id based create-attempt state for
 	// idempotency and auditability.
 	dispatchAttempts   map[string]*dispatchAttempt
@@ -256,18 +251,6 @@ type auxiliaryRuntime struct {
 	Manager agent.Manager
 }
 
-// pendingAgentState holds the partial state for an agent waiting on env-gather.
-type pendingAgentState struct {
-	AgentID      string
-	Request      *CreateAgentRequest
-	MergedEnv    map[string]string
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
-	State        string
-	RequestID    string
-	FinalizeRuns int
-}
-
 type dispatchAttempt struct {
 	RequestID  string
 	Operation  string
@@ -299,7 +282,6 @@ func New(cfg ServerConfig, mgr agent.Manager, rt scionrt.Runtime) *Server {
 		startTime:         time.Now(),
 		version:           "0.1.0", // TODO: Get from build info
 		hubConnections:    make(map[string]*HubConnection),
-		pendingEnvGather:  make(map[string]*pendingAgentState),
 		dispatchAttempts:  make(map[string]*dispatchAttempt),
 		auxiliaryRuntimes: make(map[string]auxiliaryRuntime),
 

--- a/pkg/runtimebroker/state_store.go
+++ b/pkg/runtimebroker/state_store.go
@@ -25,14 +25,10 @@ import (
 )
 
 const (
-	pendingStatePending    = "pending"
-	pendingStateFinalizing = "finalizing"
-
 	dispatchAttemptInProgress = "in_progress"
 	dispatchAttemptSucceeded  = "succeeded"
 	dispatchAttemptFailed     = "failed"
 
-	pendingStateTTL    = 24 * time.Hour
 	dispatchAttemptTTL = 24 * time.Hour
 )
 
@@ -40,14 +36,8 @@ func (s *Server) initStateStore() error {
 	if s.stateDir == "" {
 		return nil
 	}
-	if err := os.MkdirAll(s.pendingStateDir(), 0755); err != nil {
-		return fmt.Errorf("create pending state dir: %w", err)
-	}
 	if err := os.MkdirAll(s.dispatchAttemptDir(), 0755); err != nil {
 		return fmt.Errorf("create dispatch attempt dir: %w", err)
-	}
-	if err := s.loadPendingState(); err != nil {
-		return fmt.Errorf("load pending state: %w", err)
 	}
 	if err := s.loadDispatchAttempts(); err != nil {
 		return fmt.Errorf("load dispatch attempts: %w", err)
@@ -55,63 +45,12 @@ func (s *Server) initStateStore() error {
 	return nil
 }
 
-func (s *Server) pendingStateDir() string {
-	return filepath.Join(s.stateDir, "pending-env")
-}
-
 func (s *Server) dispatchAttemptDir() string {
 	return filepath.Join(s.stateDir, "dispatch-attempts")
 }
 
-func (s *Server) pendingStatePath(agentID string) string {
-	return filepath.Join(s.pendingStateDir(), agentID+".json")
-}
-
 func (s *Server) dispatchAttemptPath(requestID string) string {
 	return filepath.Join(s.dispatchAttemptDir(), requestID+".json")
-}
-
-func (s *Server) loadPendingState() error {
-	entries, err := os.ReadDir(s.pendingStateDir())
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
-		return err
-	}
-	now := time.Now()
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
-			continue
-		}
-		p := filepath.Join(s.pendingStateDir(), e.Name())
-		raw, err := os.ReadFile(p)
-		if err != nil {
-			continue
-		}
-		var st pendingAgentState
-		if err := json.Unmarshal(raw, &st); err != nil {
-			continue
-		}
-		if st.AgentID == "" {
-			st.AgentID = strings.TrimSuffix(e.Name(), ".json")
-		}
-		if st.CreatedAt.IsZero() {
-			st.CreatedAt = now
-		}
-		if st.UpdatedAt.IsZero() {
-			st.UpdatedAt = st.CreatedAt
-		}
-		if st.State == "" {
-			st.State = pendingStatePending
-		}
-		if now.Sub(st.UpdatedAt) > pendingStateTTL {
-			_ = os.Remove(p)
-			continue
-		}
-		s.pendingEnvGather[st.AgentID] = &st
-	}
-	return nil
 }
 
 func (s *Server) loadDispatchAttempts() error {
@@ -164,34 +103,6 @@ func (s *Server) writeJSONFile(path string, v interface{}) error {
 		return err
 	}
 	return os.Rename(tmp, path)
-}
-
-func (s *Server) upsertPendingState(st *pendingAgentState) {
-	if st == nil || st.AgentID == "" {
-		return
-	}
-	if st.UpdatedAt.IsZero() {
-		st.UpdatedAt = time.Now()
-	}
-	s.pendingEnvGather[st.AgentID] = st
-	if s.stateDir != "" {
-		_ = s.writeJSONFile(s.pendingStatePath(st.AgentID), st)
-	}
-}
-
-func (s *Server) deletePendingState(agentID string) {
-	delete(s.pendingEnvGather, agentID)
-	if s.stateDir != "" {
-		_ = os.Remove(s.pendingStatePath(agentID))
-	}
-}
-
-func (s *Server) cleanupExpiredPendingLocked(now time.Time) {
-	for id, st := range s.pendingEnvGather {
-		if now.Sub(st.UpdatedAt) > pendingStateTTL {
-			s.deletePendingState(id)
-		}
-	}
 }
 
 func (s *Server) beginCreateAttempt(requestID, agentID string) (*dispatchAttempt, *dispatchAttempt) {

--- a/pkg/runtimebroker/types.go
+++ b/pkg/runtimebroker/types.go
@@ -451,12 +451,6 @@ type EnvRequirementsResponse struct {
 	SecretInfo map[string]api.SecretKeyInfo `json:"secretInfo,omitempty"`
 }
 
-// FinalizeEnvRequest is sent to the broker to supply gathered env vars
-// and complete agent creation after a 202 env-gather response.
-type FinalizeEnvRequest struct {
-	Env map[string]string `json:"env"`
-}
-
 // ============================================================================
 // Interaction Types
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes the env-gather HA breakage where `finalize-env` returns 404 when routed to a broker instance that never saw the original create request (issue https://github.com/ptone/scion/issues/376).

**Approach: Replay-based stateless finalize (Design doc: `.design/envgather-ha-376.md`)**

Instead of calling the broker's stateful `finalize-env` action, the hub now rebuilds the full create request via `buildCreateRequest`, merges CLI-gathered env at highest precedence, and dispatches a normal create with `GatherEnv=true`. The broker re-evaluates env completeness and starts the agent — no pending state needed.

## Two commits

1. **`fix(hub): replay-based stateless env-gather finalize for HA`** — Rewrites `DispatchFinalizeEnv` to use the replay path. Adds `ErrEnvStillMissing` typed error. Updates `submitAgentEnv` handler to return structured 422 on still-missing keys. This commit alone fixes the bug.

2. **`refactor(broker): remove stateful finalize-env path and pendingEnvGather`** — Removes the entire legacy finalize-env protocol: broker handler, pending state map/mutex/persistence, hub client chain `FinalizeEnv` methods, `AgentActionFinalizeEnv` constant, and `FinalizeEnvRequest` type.

## Test plan

- [x] Regression test: finalize against broker with empty pendingEnvGather succeeds
- [x] Merge precedence: CLI-gathered value overrides storage-resolved value
- [x] Still-missing: replay returns structured 422 with remaining Needs
- [x] Deferred path: `execDispatchFinalizeEnv` round-trip with replay
- [x] Broker-side replay: create returns 202, second create with complete env starts agent on different instance
- [x] Grep returns nothing: `pendingEnvGather`, `pendingAgentState`, `FinalizeEnvRequest`, `AgentActionFinalizeEnv`
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/runtimebroker/... ./pkg/hub/... ./pkg/api/...` passes (3 pre-existing failures on main excluded)

Refs https://github.com/ptone/scion/issues/376