### PR TITLE
feat(web): add copy-to-clipboard for service account emails on project settings

### DIFF
--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -1612,13 +1612,13 @@ export class ScionPageProjectSettings extends LitElement {
                                     const sa = this.gcpServiceAccounts.find(
                                       (s) => s.id === this.configDefaultGCPIdentitySAID
                                     );
-                                    if (sa) {
+                                    if (sa && navigator.clipboard) {
                                       void navigator.clipboard.writeText(sa.email).then(() => {
                                         this.copiedDefaultSAEmail = true;
                                         setTimeout(() => {
                                           this.copiedDefaultSAEmail = false;
                                         }, 1500);
-                                      });
+                                      }).catch(() => {});
                                     }
                                   }}
                                 ></sl-icon-button>

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -182,6 +182,9 @@ export class ScionPageProjectSettings extends LitElement {
   private defaultThinkingLevel: number | null = null;
 
   @state()
+  private copiedDefaultSAEmail = false;
+
+  @state()
   private gcpServiceAccounts: GCPServiceAccount[] = [];
 
   // GitHub App integration
@@ -1597,28 +1600,56 @@ export class ScionPageProjectSettings extends LitElement {
                 ? html`
                     <div class="config-field">
                       <label>Service Account</label>
-                      <sl-select
-                        placeholder="Select a verified service account"
-                        clearable
-                        value=${this.configDefaultGCPIdentitySAID}
-                        ?disabled=${!canEdit}
-                        @sl-change=${(e: Event) => {
-                          this.configDefaultGCPIdentitySAID = (e.target as HTMLSelectElement).value;
-                        }}
-                      >
-                        ${this.gcpServiceAccounts.length > 0
-                          ? this.gcpServiceAccounts.map(
-                              (sa) => html`
-                                <sl-option value=${sa.id}>
-                                  ${sa.displayName || sa.email}
-                                  <small>(${sa.email})</small>
-                                </sl-option>
-                              `
-                            )
-                          : html`<sl-option value="" disabled
-                              >No verified service accounts available</sl-option
-                            >`}
-                      </sl-select>
+                      <div style="display: flex; align-items: center; gap: 0.25rem;">
+                        ${this.configDefaultGCPIdentitySAID
+                          ? html`
+                              <sl-tooltip content=${this.copiedDefaultSAEmail ? 'Copied!' : 'Copy email'}>
+                                <sl-icon-button
+                                  name=${this.copiedDefaultSAEmail ? 'clipboard-check' : 'clipboard'}
+                                  label="Copy service account email"
+                                  style="font-size: 1rem;"
+                                  @click=${() => {
+                                    const sa = this.gcpServiceAccounts.find(
+                                      (s) => s.id === this.configDefaultGCPIdentitySAID
+                                    );
+                                    if (sa) {
+                                      void navigator.clipboard.writeText(sa.email).then(() => {
+                                        this.copiedDefaultSAEmail = true;
+                                        setTimeout(() => {
+                                          this.copiedDefaultSAEmail = false;
+                                        }, 1500);
+                                      });
+                                    }
+                                  }}
+                                ></sl-icon-button>
+                              </sl-tooltip>
+                            `
+                          : ''}
+                        <sl-select
+                          style="flex: 1;"
+                          placeholder="Select a verified service account"
+                          clearable
+                          value=${this.configDefaultGCPIdentitySAID}
+                          ?disabled=${!canEdit}
+                          @sl-change=${(e: Event) => {
+                            this.configDefaultGCPIdentitySAID = (e.target as HTMLSelectElement).value;
+                            this.copiedDefaultSAEmail = false;
+                          }}
+                        >
+                          ${this.gcpServiceAccounts.length > 0
+                            ? this.gcpServiceAccounts.map(
+                                (sa) => html`
+                                  <sl-option value=${sa.id}>
+                                    ${sa.displayName || sa.email}
+                                    <small>(${sa.email})</small>
+                                  </sl-option>
+                                `
+                              )
+                            : html`<sl-option value="" disabled
+                                >No verified service accounts available</sl-option
+                              >`}
+                        </sl-select>
+                      </div>
                       <span class="field-help"
                         >The GCP service account to assign to new agents by default. Only verified accounts are shown.</span
                       >

--- a/web/src/components/shared/gcp-service-account-list.ts
+++ b/web/src/components/shared/gcp-service-account-list.ts
@@ -62,6 +62,9 @@ export class ScionGCPServiceAccountList extends LitElement {
   // Quota info
   @state() private mintQuota: GCPMintQuotaInfo | null = null;
 
+  // Copy-to-clipboard state
+  @state() private copiedEmail: string | null = null;
+
   // Verify-failed dialog state
   @state() private verifyFailedOpen = false;
   @state() private verifyFailedHubEmail = '';
@@ -550,6 +553,18 @@ export class ScionGCPServiceAccountList extends LitElement {
     `;
   }
 
+  private async copyEmail(email: string): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(email);
+      this.copiedEmail = email;
+      setTimeout(() => {
+        this.copiedEmail = null;
+      }, 1500);
+    } catch {
+      // Clipboard unavailable
+    }
+  }
+
   private renderRow(account: GCPServiceAccount) {
     const isDeleting = this.deletingId === account.id;
     const isVerifying = this.verifyingId === account.id;
@@ -566,6 +581,14 @@ export class ScionGCPServiceAccountList extends LitElement {
             </div>
             ${account.email}
             ${account.managed ? html`<span class="managed-badge">Hub-minted</span>` : ''}
+            <sl-tooltip content=${this.copiedEmail === account.email ? 'Copied!' : 'Copy email'}>
+              <sl-icon-button
+                name=${this.copiedEmail === account.email ? 'clipboard-check' : 'clipboard'}
+                label="Copy email"
+                style="font-size: 0.875rem;"
+                @click=${() => this.copyEmail(account.email)}
+              ></sl-icon-button>
+            </sl-tooltip>
           </div>
         </td>
         <td class="hide-mobile">


### PR DESCRIPTION
Adds clipboard copy buttons in two locations on the project settings page: left of the default SA field in project defaults, and right of each SA email in the resources card SA list tab