### PR TITLE
fix(ui): fetch current harness_configs from Hub DB in Create Agent form

### DIFF
--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -388,7 +388,7 @@ export class ScionPageAgentCreate extends LitElement {
           fetch('/api/v1/runtime-brokers?limit=200', { credentials: 'include' }),
           fetch('/api/v1/templates?status=active&limit=200', { credentials: 'include' }),
           fetch('/api/v1/settings/public', { credentials: 'include' }),
-          fetch('/api/v1/harness-configs?status=active&limit=100', { credentials: 'include' }),
+          apiFetch('/api/v1/harness-configs?status=active&limit=100'),
         ]);
 
       if (projectsRes.ok) {


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/428