### PR TITLE
fix(config): detect v1-shaped runtime fields when schema_version is missing

### DIFF
--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -55,7 +55,9 @@ func (e ValidationError) Error() string {
 // whether it uses the versioned format or the legacy format.
 //
 // Returns:
-//   - version: the schema_version value if present (e.g., "1"), or "" for legacy/empty
+//   - version: the schema_version value if present (e.g., "1"), or "1" if v1-only
+//     runtime fields are detected (type, cloudrun, gke, list_all_namespaces), or ""
+//     for legacy/empty files.
 //   - isLegacy: true if the file uses the legacy format (has "harnesses" key but no schema_version)
 //
 // An empty or missing file returns ("", false).
@@ -90,9 +92,43 @@ func DetectSettingsFormat(data []byte) (version string, isLegacy bool) {
 		return "", true
 	}
 
+	// Check for v1-only structural indicators in runtime entries.
+	// A runtimes map containing type, cloudrun, gke, or list_all_namespaces
+	// keys indicates a v1-format file that is missing the schema_version marker.
+	// Treat as versioned v1 to prevent silent data loss via the legacy loading path.
+	if hasV1RuntimeIndicators(raw) {
+		return "1", false
+	}
+
 	// No schema_version and no harnesses key — could be a minimal or empty file.
 	// Treat as neither versioned nor legacy (will use defaults).
 	return "", false
+}
+
+// hasV1RuntimeIndicators reports whether a parsed settings map contains v1-only
+// runtime fields (type, cloudrun, gke, list_all_namespaces) that are absent from
+// the legacy RuntimeConfig struct. Used to detect v1-shaped files missing schema_version.
+func hasV1RuntimeIndicators(raw map[string]interface{}) bool {
+	runtimes, ok := raw["runtimes"]
+	if !ok {
+		return false
+	}
+	rmap, ok := runtimes.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	for _, rv := range rmap {
+		entry, ok := rv.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, key := range []string{"type", "cloudrun", "gke", "list_all_namespaces"} {
+			if _, has := entry[key]; has {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // ValidateSettings validates raw settings data (YAML or JSON) against the

--- a/pkg/config/schema_test.go
+++ b/pkg/config/schema_test.go
@@ -91,6 +91,61 @@ harnesses:
 	assert.False(t, isLegacy)
 }
 
+func TestDetectSettingsFormat_V1RuntimeTypeIndicator(t *testing.T) {
+	// v1-shaped: runtimes entry with type key but no schema_version
+	data := []byte(`
+active_profile: cr
+runtimes:
+  cr:
+    type: cloudrun
+    cloudrun:
+      project: my-project
+      region: us-central1
+`)
+	version, isLegacy := DetectSettingsFormat(data)
+	assert.Equal(t, "1", version, "v1-shaped runtime with type key should be detected as versioned")
+	assert.False(t, isLegacy)
+}
+
+func TestDetectSettingsFormat_V1RuntimeGKEIndicator(t *testing.T) {
+	data := []byte(`
+active_profile: k8s
+runtimes:
+  k8s:
+    gke: true
+    context: my-cluster
+`)
+	version, isLegacy := DetectSettingsFormat(data)
+	assert.Equal(t, "1", version, "v1-shaped runtime with gke key should be detected as versioned")
+	assert.False(t, isLegacy)
+}
+
+func TestDetectSettingsFormat_V1RuntimeListAllNamespacesIndicator(t *testing.T) {
+	data := []byte(`
+active_profile: k8s
+runtimes:
+  k8s:
+    list_all_namespaces: true
+`)
+	version, isLegacy := DetectSettingsFormat(data)
+	assert.Equal(t, "1", version, "v1-shaped runtime with list_all_namespaces key should be detected as versioned")
+	assert.False(t, isLegacy)
+}
+
+func TestDetectSettingsFormat_LegacyRuntimeNoV1Indicators(t *testing.T) {
+	// Legacy runtimes without v1-only keys should not trigger v1 detection
+	data := []byte(`
+active_profile: local
+runtimes:
+  local:
+    host: docker
+    namespace: default
+`)
+	version, isLegacy := DetectSettingsFormat(data)
+	assert.Equal(t, "", version, "legacy runtime without v1 fields should not be detected as versioned")
+	assert.False(t, isLegacy)
+}
+
 // --- ValidateSettings tests ---
 
 func TestValidateSettings_ValidV1(t *testing.T) {

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -1839,15 +1839,30 @@ func convertVersionedToLegacy(vs *VersionedSettings) *Settings {
 
 // detectHierarchyFormat checks settings files in the global and project directories
 // to determine if any user file uses the versioned format.
-// Returns true if any user file is versioned (has schema_version).
-func detectHierarchyFormat(projectPath string) (hasVersioned bool) {
+// Returns:
+//   - hasVersioned: true if any user file is versioned (has schema_version or v1 structural indicators)
+//   - missingSchemaVersion: true if versioned was detected via v1 structural indicators only (schema_version absent)
+func detectHierarchyFormat(projectPath string) (hasVersioned bool, missingSchemaVersion bool) {
+	// fileIsVersionedViaSV returns true if data has an explicit schema_version key.
+	fileHasExplicitVersion := func(data []byte) bool {
+		var raw map[string]interface{}
+		if err := yamlv3.Unmarshal(data, &raw); err != nil || raw == nil {
+			return false
+		}
+		_, ok := raw["schema_version"]
+		return ok
+	}
+
 	// Check global settings
 	globalDir, _ := GetGlobalDir()
 	if globalDir != "" {
 		if path := GetSettingsPath(globalDir); path != "" {
 			if data, err := os.ReadFile(path); err == nil {
 				if version, _ := DetectSettingsFormat(data); version != "" {
-					return true
+					if !fileHasExplicitVersion(data) {
+						missingSchemaVersion = true
+					}
+					return true, missingSchemaVersion
 				}
 			}
 		}
@@ -1859,13 +1874,16 @@ func detectHierarchyFormat(projectPath string) (hasVersioned bool) {
 		if path := GetSettingsPath(effectiveProjectPath); path != "" {
 			if data, err := os.ReadFile(path); err == nil {
 				if version, _ := DetectSettingsFormat(data); version != "" {
-					return true
+					if !fileHasExplicitVersion(data) {
+						missingSchemaVersion = true
+					}
+					return true, missingSchemaVersion
 				}
 			}
 		}
 	}
 
-	return false
+	return false, false
 }
 
 // LoadEffectiveSettings is a unified entry point that detects the settings format
@@ -1874,12 +1892,17 @@ func detectHierarchyFormat(projectPath string) (hasVersioned bool) {
 // - If all user files are legacy or absent → uses LoadSettingsKoanf + AdaptLegacySettings
 // Returns (settings, deprecation_warnings, error).
 func LoadEffectiveSettings(projectPath string) (*VersionedSettings, []string, error) {
-	if detectHierarchyFormat(projectPath) {
+	hasVersioned, missingSchemaVersion := detectHierarchyFormat(projectPath)
+	if hasVersioned {
 		vs, err := LoadVersionedSettings(projectPath)
 		if err != nil {
 			return nil, nil, fmt.Errorf("loading versioned settings: %w", err)
 		}
-		return vs, nil, nil
+		var warnings []string
+		if missingSchemaVersion {
+			warnings = append(warnings, `settings.yaml contains v1 runtime fields (type, cloudrun, gke, list_all_namespaces) but is missing 'schema_version: "1"'; add it as the first line to silence this warning`)
+		}
+		return vs, warnings, nil
 	}
 
 	// Legacy path: load via existing loader, then adapt

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -850,7 +850,9 @@ active_profile: local
 `
 	require.NoError(t, os.WriteFile(filepath.Join(globalScionDir, "settings.yaml"), []byte(versionedSettings), 0644))
 
-	assert.True(t, detectHierarchyFormat(""))
+	hasVersioned, missingSchemaVersion := detectHierarchyFormat("")
+	assert.True(t, hasVersioned)
+	assert.False(t, missingSchemaVersion)
 }
 
 func TestDetectHierarchyFormat_Legacy(t *testing.T) {
@@ -874,7 +876,9 @@ harnesses:
 `
 	require.NoError(t, os.WriteFile(filepath.Join(globalScionDir, "settings.yaml"), []byte(legacySettings), 0644))
 
-	assert.False(t, detectHierarchyFormat(""))
+	hasVersioned, missingSchemaVersion := detectHierarchyFormat("")
+	assert.False(t, hasVersioned)
+	assert.False(t, missingSchemaVersion)
 }
 
 func TestDetectHierarchyFormat_NoFiles(t *testing.T) {
@@ -888,7 +892,9 @@ func TestDetectHierarchyFormat_NoFiles(t *testing.T) {
 	defer func() { _ = os.Chdir(originalWd) }()
 	_ = os.Chdir(tmpDir)
 
-	assert.False(t, detectHierarchyFormat(""))
+	hasVersioned, missingSchemaVersion := detectHierarchyFormat("")
+	assert.False(t, hasVersioned)
+	assert.False(t, missingSchemaVersion)
 }
 
 func TestDetectHierarchyFormat_GroveVersioned(t *testing.T) {
@@ -921,7 +927,39 @@ active_profile: custom
 `
 	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "settings.yaml"), []byte(versionedSettings), 0644))
 
-	assert.True(t, detectHierarchyFormat(projectDir))
+	hasVersioned, missingSchemaVersion := detectHierarchyFormat(projectDir)
+	assert.True(t, hasVersioned)
+	assert.False(t, missingSchemaVersion)
+}
+
+func TestDetectHierarchyFormat_V1StructuralIndicators(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	originalHome := os.Getenv("HOME")
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+	_ = os.Setenv("HOME", tmpDir)
+
+	originalWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(originalWd) }()
+	_ = os.Chdir(tmpDir)
+
+	globalScionDir := filepath.Join(tmpDir, ".scion")
+	require.NoError(t, os.MkdirAll(globalScionDir, 0755))
+
+	// v1-shaped but missing schema_version
+	v1ShapedSettings := `active_profile: cr
+runtimes:
+  cr:
+    type: cloudrun
+    cloudrun:
+      project: my-project
+      region: us-central1
+`
+	require.NoError(t, os.WriteFile(filepath.Join(globalScionDir, "settings.yaml"), []byte(v1ShapedSettings), 0644))
+
+	hasVersioned, missingSchemaVersion := detectHierarchyFormat("")
+	assert.True(t, hasVersioned, "v1-shaped file without schema_version should be detected as versioned")
+	assert.True(t, missingSchemaVersion, "should flag that schema_version is missing")
 }
 
 // --- ResolveHarnessConfig tests ---

--- a/pkg/harness/auth_test.go
+++ b/pkg/harness/auth_test.go
@@ -1282,6 +1282,9 @@ func TestGatherAuthWithEnv_EmptyAuthMetaNoEnvVars(t *testing.T) {
 func TestGatherAuthWithEnv_ConfigDrivenMultipleAuthTypes(t *testing.T) {
 	t.Setenv("COPILOT_GITHUB_TOKEN", "ghp_test")
 	t.Setenv("GOOGLE_CLOUD_PROJECT", "my-project")
+	t.Setenv("GOOGLE_CLOUD_REGION", "")
+	t.Setenv("GOOGLE_CLOUD_LOCATION", "")
+	t.Setenv("CLOUD_ML_REGION", "")
 
 	authMeta := &config.HarnessAuthMetadata{
 		Types: map[string]config.HarnessAuthTypeMetadata{

--- a/pkg/harness/bundle_contract_test.go
+++ b/pkg/harness/bundle_contract_test.go
@@ -231,9 +231,24 @@ func runBundleContractCase(t *testing.T, python, hname, caseDir string) {
 		t.Fatalf("write manifest.json: %v", err)
 	}
 
-	// Run provision.py.
+	// Run provision.py. Strip ambient GCP credentials so env_fallback in
+	// provision.py cannot pick up host credentials and alter auth selection.
+	gcpAmbient := map[string]bool{
+		"GOOGLE_CLOUD_PROJECT":           true,
+		"GOOGLE_CLOUD_REGION":            true,
+		"GOOGLE_CLOUD_LOCATION":          true,
+		"CLOUD_ML_REGION":                true,
+		"GOOGLE_APPLICATION_CREDENTIALS": true,
+	}
+	baseEnv := make([]string, 0, len(os.Environ()))
+	for _, e := range os.Environ() {
+		key, _, _ := strings.Cut(e, "=")
+		if !gcpAmbient[key] {
+			baseEnv = append(baseEnv, e)
+		}
+	}
 	cmd := exec.Command(python, filepath.Join(bundleDir, "provision.py"), "--manifest", manifestPath)
-	cmd.Env = append(os.Environ(), "HOME="+tmpHome, "PYTHONDONTWRITEBYTECODE=1")
+	cmd.Env = append(baseEnv, "HOME="+tmpHome, "PYTHONDONTWRITEBYTECODE=1")
 	output, err := cmd.CombinedOutput()
 
 	gotExitCode := 0


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/455 — AdaptLegacySettings was silently dropping v1-only runtime fields (type, cloudrun, gke, list_all_namespaces) when schema_version was absent. Now detects v1-shaped configs by checking for these indicator fields and surfaces an actionable warning