### PR TITLE
fix(web): sort harness configs alphabetically by displayName on resources pages

### DIFF
--- a/web/src/components/shared/resource-list.ts
+++ b/web/src/components/shared/resource-list.ts
@@ -331,7 +331,7 @@ export class ScionResourceList extends LitElement {
       }
       const data = (await response.json()) as Record<string, ResourceItem[]>;
       const list = this.kind === 'template' ? data.templates : data.harnessConfigs;
-      this.items = Array.isArray(list) ? list : [];
+      this.items = (Array.isArray(list) ? list : []).slice().sort((a, b) => a.name.localeCompare(b.name));
     } catch (err) {
       console.error(`Failed to load ${this.apiResource}:`, err);
       this.error = err instanceof Error ? err.message : `Failed to load ${this.apiResource}`;
@@ -458,7 +458,7 @@ export class ScionResourceList extends LitElement {
       }
       const data = (await response.json()) as Record<string, ResourceItem[]>;
       const list = this.kind === 'template' ? data.templates : data.harnessConfigs;
-      this.globalItems = Array.isArray(list) ? list : [];
+      this.globalItems = (Array.isArray(list) ? list : []).slice().sort((a, b) => a.name.localeCompare(b.name));
     } catch (err) {
       this.globalError = err instanceof Error ? err.message : 'Failed to load global resources';
     } finally {

--- a/web/src/components/shared/resource-list.ts
+++ b/web/src/components/shared/resource-list.ts
@@ -331,7 +331,7 @@ export class ScionResourceList extends LitElement {
       }
       const data = (await response.json()) as Record<string, ResourceItem[]>;
       const list = this.kind === 'template' ? data.templates : data.harnessConfigs;
-      this.items = (Array.isArray(list) ? list : []).slice().sort((a, b) => a.name.localeCompare(b.name));
+      this.items = (Array.isArray(list) ? list : []).slice().sort((a, b) => (a.displayName || a.name).localeCompare(b.displayName || b.name));
     } catch (err) {
       console.error(`Failed to load ${this.apiResource}:`, err);
       this.error = err instanceof Error ? err.message : `Failed to load ${this.apiResource}`;
@@ -458,7 +458,7 @@ export class ScionResourceList extends LitElement {
       }
       const data = (await response.json()) as Record<string, ResourceItem[]>;
       const list = this.kind === 'template' ? data.templates : data.harnessConfigs;
-      this.globalItems = (Array.isArray(list) ? list : []).slice().sort((a, b) => a.name.localeCompare(b.name));
+      this.globalItems = (Array.isArray(list) ? list : []).slice().sort((a, b) => (a.displayName || a.name).localeCompare(b.displayName || b.name));
     } catch (err) {
       this.globalError = err instanceof Error ? err.message : 'Failed to load global resources';
     } finally {


### PR DESCRIPTION
Harness config lists on hub/project resources pages now sorted alphabetically using displayName || name as the sort key, matching how items are rendered