### PR TITLE
harness/opencode: add auth.json file secret capture + no-auth login command

### DIFF
--- a/harnesses/opencode/capture_auth.py
+++ b/harnesses/opencode/capture_auth.py
@@ -12,13 +12,70 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Capture-auth shim — delegates to scion_harness.capture_auth_main()."""
+"""Capture-auth for OpenCode — delegates to the standard capture flow,
+then captures ~/.local/share/opencode/auth.json as an OPENCODE_AUTH file secret."""
 
 import os
+import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import scion_harness
 
+_OPENCODE_AUTH = os.path.join(
+    os.environ.get("HOME") or os.path.expanduser("~"),
+    ".local", "share", "opencode", "auth.json",
+)
+
+
+def _capture_auth_json(force: bool = False) -> bool:
+    """Capture ~/.local/share/opencode/auth.json as an OPENCODE_AUTH file secret."""
+    if not os.path.isfile(_OPENCODE_AUTH):
+        print(
+            f"capture-auth: {_OPENCODE_AUTH} not found — "
+            "run 'opencode auth login' first, then re-run this script",
+            file=sys.stderr,
+        )
+        return False
+
+    cmd = [
+        "sciontool", "secret", "set", "OPENCODE_AUTH",
+        f"@{_OPENCODE_AUTH}",
+        "--type", "file",
+        "--target", _OPENCODE_AUTH,
+    ]
+    if force:
+        cmd.append("--force")
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except FileNotFoundError:
+        print("capture-auth: sciontool not found in PATH", file=sys.stderr)
+        return False
+    except subprocess.TimeoutExpired:
+        print("capture-auth: sciontool timed out setting OPENCODE_AUTH", file=sys.stderr)
+        return False
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        if "already exists" in stderr.lower():
+            print(
+                'capture-auth: OPENCODE_AUTH already exists (use --force to overwrite)',
+            )
+            return False
+        print(f"capture-auth: failed to set OPENCODE_AUTH: {stderr}", file=sys.stderr)
+        return False
+
+    print(f"capture-auth: OPENCODE_AUTH: captured from {_OPENCODE_AUTH}")
+    return True
+
+
 if __name__ == "__main__":
-    sys.exit(scion_harness.capture_auth_main())
+    rc = scion_harness.capture_auth_main()
+
+    force = "--force" in sys.argv
+    config_ok = _capture_auth_json(force)
+
+    if rc != 0 and config_ok:
+        sys.exit(0)
+    sys.exit(rc)

--- a/harnesses/opencode/capture_auth.py
+++ b/harnesses/opencode/capture_auth.py
@@ -76,6 +76,8 @@ if __name__ == "__main__":
     force = "--force" in sys.argv
     config_ok = _capture_auth_json(force)
 
-    if rc != 0 and config_ok:
+    if not config_ok:
+        sys.exit(rc if rc != 0 else 1)
+    if rc == 2:
         sys.exit(0)
     sys.exit(rc)

--- a/harnesses/opencode/config.yaml
+++ b/harnesses/opencode/config.yaml
@@ -71,9 +71,11 @@ capabilities:
     project_scope: { support: "no", reason: "OpenCode does not distinguish project-scoped MCP" }
 no_auth:
   behavior: drop-to-shell
+  command: opencode auth login
   message: |
     This agent started without credentials.
-    Run your OpenCode authentication setup.
+    Run: opencode auth login
+    Complete the interactive login flow.
     Then run: python3 /home/scion/.scion/harness/capture_auth.py
 auth:
   default_type: api-key

--- a/harnesses/opencode/provision.py
+++ b/harnesses/opencode/provision.py
@@ -186,9 +186,9 @@ def _translate_mcp_server(name: str, spec: dict[str, Any]) -> dict[str, Any] | N
 
 def _write_opencode_auth_file(ctx: sh.ProvisionContext) -> None:
     """Write ~/.local/share/opencode/auth.json from a staged OPENCODE_AUTH file secret."""
-    content = ctx.read_file_secret("OPENCODE_AUTH")
-    if not content:
+    if "OPENCODE_AUTH" not in ctx.file_secret_files:
         return
+    content = ctx.read_file_secret("OPENCODE_AUTH")
     if not content.strip():
         raise sh.ProvisionError("OPENCODE_AUTH secret is empty")
     try:

--- a/harnesses/opencode/provision.py
+++ b/harnesses/opencode/provision.py
@@ -184,6 +184,29 @@ def _translate_mcp_server(name: str, spec: dict[str, Any]) -> dict[str, Any] | N
     return None
 
 
+def _write_opencode_auth_file(ctx: sh.ProvisionContext) -> None:
+    """Write ~/.local/share/opencode/auth.json from a staged OPENCODE_AUTH file secret."""
+    content = ctx.read_file_secret("OPENCODE_AUTH")
+    if not content:
+        return
+    if not content.strip():
+        raise sh.ProvisionError("OPENCODE_AUTH secret is empty")
+    try:
+        json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise sh.ProvisionError(
+            f"OPENCODE_AUTH secret is not valid JSON: {exc}"
+        ) from exc
+    auth_dir = sh.expand_path("~/.local/share/opencode")
+    os.makedirs(auth_dir, exist_ok=True)
+    target = os.path.join(auth_dir, "auth.json")
+    tmp = target + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write(content)
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, target)
+
+
 def _write_mcp_config(servers: dict[str, Any]) -> None:
     """Merge translated MCP servers into ~/.config/opencode/opencode.json."""
     config_path = sh.expand_path(OPENCODE_CONFIG_FILE)
@@ -231,6 +254,10 @@ def provision(ctx: sh.ProvisionContext) -> None:
 
     extra: dict[str, Any] = {}
     env: dict[str, str] = {}
+
+    if resolved.method == "auth-file":
+        _write_opencode_auth_file(ctx)
+        extra["auth_file_written"] = True
 
     if resolved.method == "vertex-ai":
         extra["vertex_project_env"] = "VERTEXAI_PROJECT"

--- a/harnesses/opencode/provision.py
+++ b/harnesses/opencode/provision.py
@@ -197,14 +197,8 @@ def _write_opencode_auth_file(ctx: sh.ProvisionContext) -> None:
         raise sh.ProvisionError(
             f"OPENCODE_AUTH secret is not valid JSON: {exc}"
         ) from exc
-    auth_dir = sh.expand_path("~/.local/share/opencode")
-    os.makedirs(auth_dir, exist_ok=True)
-    target = os.path.join(auth_dir, "auth.json")
-    tmp = target + ".tmp"
-    with open(tmp, "w", encoding="utf-8") as f:
-        f.write(content)
-    os.chmod(tmp, 0o600)
-    os.replace(tmp, target)
+    target = sh.expand_path("~/.local/share/opencode/auth.json")
+    sh.atomic_write_text(target, content, mode=0o600)
 
 
 def _write_mcp_config(servers: dict[str, Any]) -> None:


### PR DESCRIPTION
## Changes

**capture_auth.py:**
- Captures ~/.local/share/opencode/auth.json as OPENCODE_AUTH file secret (mirrors copilot COPILOT_CONFIG pattern)
- Clear error if auth.json not found

**provision.py:**
- _write_opencode_auth_file(): reads staged OPENCODE_AUTH secret, validates JSON, writes to ~/.local/share/opencode/auth.json with 0600 perms
- Auth-file type already wired in AUTH spec

**config.yaml:**
- no_auth: added command: opencode auth login to guide users through authentication flow
- auth-file capability enabled
- OPENCODE_AUTH mapped to auth-file in autodetect.files