### PR TITLE
hub/web: show full image state in harness detail for workstation/podman mode

### DIFF
--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -1127,6 +1127,15 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 	registryStatus := s.checkRegistryImage(ctx, longImage)
 
 	if s.brokerClient == nil {
+		if s.imageManager != nil {
+			entry := s.buildLocalImageEntry(ctx, shortImage, longImage, &registryStatus)
+			writeJSON(w, http.StatusOK, AggregatedImageStatusResponse{
+				Image:    image,
+				Registry: &registryStatus,
+				Brokers:  []BrokerImageEntry{entry},
+			})
+			return
+		}
 		writeJSON(w, http.StatusOK, AggregatedImageStatusResponse{
 			Image:    image,
 			Registry: &registryStatus,
@@ -1226,6 +1235,52 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 		ProxyBrokers: proxyEntries,
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// buildLocalImageEntry constructs a BrokerImageEntry using the hub's
+// co-located container runtime (Docker/Podman) when no broker client is
+// available. This ensures workstation-mode users see pulled image state
+// and the Build Image option.
+func (s *Server) buildLocalImageEntry(ctx context.Context, shortImage, longImage string, registryStatus *RegistryImageStatus) BrokerImageEntry {
+	result := s.imageChecker.CheckAll(ctx, shortImage, longImage)
+
+	brokerName := "Local Runtime"
+	if namer, ok := s.imageManager.(interface{ Name() string }); ok {
+		if n := namer.Name(); n != "" {
+			brokerName = n
+		}
+	}
+
+	entry := BrokerImageEntry{
+		BrokerName: brokerName,
+		Reachable:  true,
+	}
+	if shortImage != "" {
+		entry.LocalShort = &BrokerImageEntityState{Exists: result.LocalShort.Exists, Hash: result.LocalShort.Hash}
+	}
+	if longImage != "" {
+		entry.LocalLong = &BrokerImageEntityState{Exists: result.LocalLong.Exists, Hash: result.LocalLong.Hash}
+	}
+
+	if entry.LocalLong != nil && entry.LocalLong.Exists && registryStatus.Hash != "" && entry.LocalLong.Hash != "" {
+		entry.NewerInRegistry = registryStatus.Hash != entry.LocalLong.Hash
+	}
+
+	switch {
+	case entry.LocalShort != nil && entry.LocalShort.Exists:
+		entry.ResolvedImage = shortImage
+		entry.ResolutionSource = "local_short"
+	case entry.LocalLong != nil && entry.LocalLong.Exists:
+		entry.ResolvedImage = longImage
+		entry.ResolutionSource = "local_long"
+	case registryStatus.Exists:
+		entry.ResolvedImage = longImage
+		entry.ResolutionSource = "remote"
+	default:
+		entry.ResolutionSource = "none"
+	}
+
+	return entry
 }
 
 // handleHarnessConfigDeleteLocalImage removes the local short-form image.

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -1128,7 +1128,7 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 
 	if s.brokerClient == nil {
 		if s.imageManager != nil {
-			entry := s.buildLocalImageEntry(ctx, shortImage, longImage, &registryStatus)
+\t\t\tentry := s.buildLocalImageEntry(ctx, shortImage, longImage, registryStatus)
 			writeJSON(w, http.StatusOK, AggregatedImageStatusResponse{
 				Image:    image,
 				Registry: &registryStatus,

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -1241,7 +1241,7 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 // co-located container runtime (Docker/Podman) when no broker client is
 // available. This ensures workstation-mode users see pulled image state
 // and the Build Image option.
-func (s *Server) buildLocalImageEntry(ctx context.Context, shortImage, longImage string, registryStatus *RegistryImageStatus) BrokerImageEntry {
+func (s *Server) buildLocalImageEntry(ctx context.Context, shortImage, longImage string, registryStatus RegistryImageStatus) BrokerImageEntry {
 	result := s.imageChecker.CheckAll(ctx, shortImage, longImage)
 
 	brokerName := "Local Runtime"


### PR DESCRIPTION
## Problem

In workstation mode (no control channel broker), handleHarnessConfigImageStatus returned early when brokerClient==nil, sending only registry status. The UI then fell into renderProxyOnlyImage() — hiding the pulled image state, Build Image button, Pull Latest, and Delete Local actions.

## Fix

When brokerClient is nil but imageManager is available (local Docker/Podman runtime detected), the handler uses imageChecker.CheckAll() to probe local images and returns a synthetic BrokerImageEntry with empty broker_id.

The existing single-broker UI rendering path picks this up without any frontend changes. Pull/delete actions work because the empty broker_id falls through to the direct imageManager path.

Hosted mode is unaffected — new code is inside the brokerClient==nil guard