### PR TITLE
fix(ui): strip git+ prefix from harness config source URL link so it opens in browser

### DIFF
--- a/web/src/components/pages/harness-config-detail.ts
+++ b/web/src/components/pages/harness-config-detail.ts
@@ -679,7 +679,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
             : ''}
           ${hc.sourceUrl
             ? html`<span class="source-url">Source:
-                <a href=${hc.sourceUrl} target="_blank" rel="noopener">${hc.sourceUrl}</a>
+                <a href=${hc.sourceUrl.replace(/^git\+/, '')} target="_blank" rel="noopener">${hc.sourceUrl}</a>
               </span>`
             : ''}
         </div>


### PR DESCRIPTION
Harness config source URLs are stored as git+https://github.com/... . The <a href> used this verbatim but browsers do not handle the git+ scheme. The Refresh from Source button already works correctly. Fix: strip the git+ prefix on the href attribute only, keeping the display text unchanged