### PR TITLE
fix(onboarding): derive image pull total from server events, not harness slug count

### DIFF
--- a/web/src/components/pages/onboarding.ts
+++ b/web/src/components/pages/onboarding.ts
@@ -1100,7 +1100,7 @@ export class ScionPageOnboarding extends LitElement {
         return;
       }
       const data = (await res.json()) as { jobId: string };
-      this.subscribeToImageJob(data.jobId, harnesses.length);
+      this.subscribeToImageJob(data.jobId, 0);
     } catch {
       this.error = 'Failed to connect to the server.';
       this.imagePulling = false;
@@ -1150,7 +1150,7 @@ export class ScionPageOnboarding extends LitElement {
 
           if (status === 'done' || status === 'exists' || status === 'error') {
             completedImages.add(fullImageName);
-            if (completedImages.size >= totalImages) {
+            if (this.pullTotal > 0 && completedImages.size >= this.pullTotal) {
               finishPull();
             }
           }


### PR DESCRIPTION
SPA passed harnesses.length as totalImages but HarnessImages() silently drops embed-only harnesses, so completedImages.size never reached totalImages and the spinner never stopped. Fix: use this.pullTotal from server events (already updated per event) for the completion check