### PR TITLE
harness/opencode: auth.json file secret + no-auth login command + capture_auth fix

### DIFF
--- a/harnesses/opencode/capture_auth.py
+++ b/harnesses/opencode/capture_auth.py
@@ -76,8 +76,6 @@ if __name__ == "__main__":
     force = "--force" in sys.argv
     config_ok = _capture_auth_json(force)
 
-    if not config_ok:
-        sys.exit(rc if rc != 0 else 1)
-    if rc == 2:
+    if rc != 0 and config_ok:
         sys.exit(0)
     sys.exit(rc)

--- a/harnesses/opencode/provision.py
+++ b/harnesses/opencode/provision.py
@@ -197,7 +197,7 @@ def _write_opencode_auth_file(ctx: sh.ProvisionContext) -> None:
         raise sh.ProvisionError(
             f"OPENCODE_AUTH secret is not valid JSON: {exc}"
         ) from exc
-    target = sh.expand_path("~/.local/share/opencode/auth.json")
+    target = sh.expand_path(OPENCODE_AUTH_FILE)
     sh.atomic_write_text(target, content, mode=0o600)
 
 


### PR DESCRIPTION
## Changes

**capture_auth.py:**
- Captures ~/.local/share/opencode/auth.json as OPENCODE_AUTH file secret
- Fixed double-detection bug: inverted exit logic caused 'already exists' error when capture_auth_main() had already set the secret. Aligned with copilot pattern — success stands.

**provision.py:**
- Resolves OPENCODE_AUTH as auth-file credential, writes to container path with 0600 perms

**config.yaml:**
- auth-file capability enabled, OPENCODE_AUTH autodetect
- no_auth: command set to opencode auth login