### PR TITLE
feat(server): auto-configure hub endpoint in workstation mode

### DIFF
--- a/cmd/server_daemon.go
+++ b/cmd/server_daemon.go
@@ -597,6 +597,19 @@ func printWorkstationQuickstart(needsOnboarding bool, globalDir string, host str
 			displayHost = "127.0.0.1"
 		}
 
+		// Auto-configure hub.endpoint so that `scion hub` commands work
+		// immediately after workstation-mode start.
+		hubEndpoint := fmt.Sprintf("http://%s:%d", displayHost, wPort)
+		if vs, err := config.LoadSingleFileVersioned(globalDir); err == nil {
+			if vs.GetHubEndpoint() == "" {
+				if err := config.UpdateVersionedSetting(globalDir, "hub.endpoint", hubEndpoint); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to auto-configure hub endpoint: %v\n", err)
+				} else {
+					fmt.Printf("Configured hub endpoint: %s (run 'scion hub status' to verify)\n", hubEndpoint)
+				}
+			}
+		}
+
 		// Point to /onboarding when the machine hadn't been set up before daemon start.
 		// This state is captured before the daemon launches (which auto-creates settings.yaml).
 		path := ""


### PR DESCRIPTION
## Problem

After scion server start in workstation mode, users get:

  scion hub projects
  Error: hub endpoint not configured; set SCION_HUB_ENDPOINT or use --hub flag

The hub is running at http://127.0.0.1:8080 but the CLI has no way to discover this.

## Fix

In printWorkstationQuickstart (cmd/server_daemon.go), after confirming the server is ready, auto-write hub.endpoint to ~/.scion/settings.yaml if not already configured. This is idempotent — only writes when the field is empty. Uses the same host/port that the web UI URL uses.

After this change, scion hub projects works immediately after scion server start with no extra configuration steps.

## Testing

- Fresh workstation start: hub.endpoint written to settings, scion hub projects works
- Existing settings with hub.endpoint set: no overwrite
- --hub flag still works and takes precedence
