### PR TITLE
fix: remove illegal backslash from harness_config_handlers.go

### DIFF
--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -1128,7 +1128,7 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 
 	if s.brokerClient == nil {
 		if s.imageManager != nil {
-\t\t\tentry := s.buildLocalImageEntry(ctx, shortImage, longImage, registryStatus)
+			entry := s.buildLocalImageEntry(ctx, shortImage, longImage, registryStatus)
 			writeJSON(w, http.StatusOK, AggregatedImageStatusResponse{
 				Image:    image,
 				Registry: &registryStatus,


### PR DESCRIPTION
Fixes pre-existing syntax error in pkg/hub/harness_config_handlers.go line 1131 that was causing Build & Test and golangci-lint failures on main and all open PRs