### PR TITLE
fix(store): retry group creation without owner when FK constraint fails on fresh Postgres

### DIFF
--- a/pkg/hub/handlers_project_test.go
+++ b/pkg/hub/handlers_project_test.go
@@ -1457,6 +1457,40 @@ func TestProjectRegister_ExistingProject_CreatesMembershipGroup(t *testing.T) {
 	assert.True(t, ownerIDs[DevUserID], "linking user should be an owner")
 }
 
+// TestCreateProjectMembersGroup_OwnerNotInStore verifies that when the project
+// owner does not yet exist in the users table (e.g. legacy proxy auth on a
+// fresh Postgres deployment), the members group is still created without an
+// OwnerID rather than failing with an FK constraint violation.
+func TestCreateProjectMembersGroup_OwnerNotInStore(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	// Create a project whose OwnerID is a valid UUID but has no corresponding
+	// user record — simulating the fresh-deployment proxy-auth scenario described
+	// in issue #434.
+	ghostOwnerID := api.NewUUID()
+	project := &store.Project{
+		ID:        api.NewUUID(),
+		Name:      "Ghost Owner Project",
+		Slug:      "ghost-owner-project",
+		CreatedBy: ghostOwnerID,
+		OwnerID:   ghostOwnerID,
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	// createProjectMembersGroupAndPolicy should not return an error even though
+	// the owner user does not exist. It should retry without OwnerID.
+	srv.createProjectMembersGroupAndPolicy(ctx, project)
+
+	// The members group must still have been created.
+	membersSlug := "project:" + project.Slug + ":members"
+	group, err := s.GetGroupBySlug(ctx, membersSlug)
+	require.NoError(t, err, "members group should have been created despite missing owner")
+	assert.Equal(t, project.ID, group.ProjectID)
+	// OwnerID should be empty because the referenced user did not exist.
+	assert.Empty(t, group.OwnerID, "group OwnerID should be empty when owner user is not in store")
+}
+
 // =============================================================================
 // Git-Workspace Hybrid (Shared Workspace Mode) Tests
 // =============================================================================

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -492,9 +492,20 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 		OwnerID:   project.OwnerID,
 		CreatedBy: project.CreatedBy,
 	}
-	if err := s.store.CreateGroup(ctx, membersGroup); err != nil {
-		if !errors.Is(err, store.ErrAlreadyExists) {
-			slog.Warn("failed to create project members group", "project_id", project.ID, "error", err.Error())
+	createErr := s.store.CreateGroup(ctx, membersGroup)
+	if createErr != nil && errors.Is(createErr, store.ErrInvalidInput) && membersGroup.OwnerID != "" {
+		// FK violation: the owner user does not exist in the store. This can occur
+		// when authentication uses proxy headers without provisioning a DB user record
+		// (e.g. legacy trusted-proxy auth on a fresh Postgres deployment). Retry
+		// without OwnerID so the group and its associated policy are still created.
+		slog.Warn("project members group owner not found, retrying without owner",
+			"project_id", project.ID, "owner_id", membersGroup.OwnerID, "error", createErr.Error())
+		membersGroup.OwnerID = ""
+		createErr = s.store.CreateGroup(ctx, membersGroup)
+	}
+	if createErr != nil {
+		if !errors.Is(createErr, store.ErrAlreadyExists) {
+			slog.Warn("failed to create project members group", "project_id", project.ID, "error", createErr.Error())
 			return
 		}
 		// Slug conflict — look up existing group


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/434 — on fresh Cloud Run + Postgres deployments, CreateGroup fails with FK constraint violation when the owner user ID is not yet committed. Fix detects the FK error and retries without the owner, preserving group creation