### PR TITLE
fix(hub): skip notification lookup when agent_id is empty

### DIFF
--- a/pkg/hub/notifications.go
+++ b/pkg/hub/notifications.go
@@ -115,6 +115,12 @@ func (nd *NotificationDispatcher) handleEvent(evt Event) {
 		return
 	}
 
+	// Skip events with no agent ID — can happen for system events fired during
+	// project creation before any agents exist.
+	if statusEvt.AgentID == "" {
+		return
+	}
+
 	ctx := context.Background()
 
 	// Collect subscriptions from both scopes: agent-scoped first (more specific),
@@ -185,6 +191,10 @@ func (nd *NotificationDispatcher) handleDeletedEvent(evt Event) {
 	var deletedEvt AgentDeletedEvent
 	if err := json.Unmarshal(evt.Data, &deletedEvt); err != nil {
 		nd.log.Error("Failed to unmarshal agent deleted event", "error", err)
+		return
+	}
+
+	if deletedEvt.AgentID == "" {
 		return
 	}
 


### PR DESCRIPTION
When projects are created, system events fire with an empty AgentID before any agents exist. Passing an empty string to GetNotificationSubscriptions() fails with "invalid UUID" and logs spurious ERROR lines. Added early-return guards in handleEvent and handleDeletedEvent for empty AgentID