### PR TITLE
fix(hub): treat LoadOne failure during PATH-binary install as non-fatal

### DIFF
--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -701,10 +701,12 @@ func (s *Server) handleInstallIntegration(w http.ResponseWriter, r *http.Request
 
 		binaryPath, _ := exec.LookPath(binaryName)
 		if err := mgr.LoadOne(plugin.PluginTypeBroker, name, plugin.PluginEntry{Path: binaryPath, ConfigFile: configFilePath}, pluginsDir); err != nil {
-			slog.Error("Failed to load plugin from PATH binary", "plugin", name, "error", err)
-			writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
-				"Plugin found on PATH but failed to load — check server logs", nil)
-			return
+			// LoadOne failing due to missing required config (e.g. bot_token) is
+			// expected on first install — the plugin is installed but not yet
+			// configured. Log a warning and continue; the operator must configure
+			// the plugin via the admin UI before it becomes active.
+			slog.Warn("Plugin installed but not yet configured (LoadOne failed, likely missing required fields)",
+				"plugin", name, "error", err)
 		}
 	}
 


### PR DESCRIPTION
## Problem

PR #740 made PATH-binary plugins (e.g. Homebrew installs) skip the source build and call mgr.LoadOne() directly. However when the plugin validates its required config fields at startup (e.g. bot_token is required for telegram), LoadOne fails and the install endpoint returns 500, blocking the user entirely.

This is expected behavior for a first install — the user hasn't configured the plugin yet.

## Fix

Downgrade the LoadOne failure from fatal 500 to a warning log. The plugin is installed on disk; the user configures it via /admin/integrations, then the hub starts the plugin with valid config on next reconfigure.

## Diff

4 lines changed: replace slog.Error + writeError + return with slog.Warn.
