### PR TITLE
hub: show local image state when all brokers are proxy-typed in workstation mode

### DIFF
--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -1128,7 +1128,7 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 
 	if s.brokerClient == nil {
 		if s.imageManager != nil {
-\t\t\tentry := s.buildLocalImageEntry(ctx, shortImage, longImage, registryStatus)
+			entry := s.buildLocalImageEntry(ctx, shortImage, longImage, registryStatus)
 			writeJSON(w, http.StatusOK, AggregatedImageStatusResponse{
 				Image:    image,
 				Registry: &registryStatus,
@@ -1227,6 +1227,11 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 		}(i, broker)
 	}
 	wg.Wait()
+
+	if len(nodeBound) == 0 && s.imageManager != nil {
+		entry := s.buildLocalImageEntry(ctx, shortImage, longImage, registryStatus)
+		brokerEntries = append(brokerEntries, entry)
+	}
 
 	resp := AggregatedImageStatusResponse{
 		Image:        image,

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -1127,6 +1127,15 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 	registryStatus := s.checkRegistryImage(ctx, longImage)
 
 	if s.brokerClient == nil {
+		if s.imageManager != nil {
+			entry := s.buildLocalImageEntry(ctx, shortImage, longImage, &registryStatus)
+			writeJSON(w, http.StatusOK, AggregatedImageStatusResponse{
+				Image:    image,
+				Registry: &registryStatus,
+				Brokers:  []BrokerImageEntry{entry},
+			})
+			return
+		}
 		writeJSON(w, http.StatusOK, AggregatedImageStatusResponse{
 			Image:    image,
 			Registry: &registryStatus,
@@ -1226,6 +1235,52 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 		ProxyBrokers: proxyEntries,
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// buildLocalImageEntry constructs a BrokerImageEntry using the hub's
+// co-located container runtime (Docker/Podman) when no broker client is
+// available. This ensures workstation-mode users see pulled image state
+// and the Build Image option.
+func (s *Server) buildLocalImageEntry(ctx context.Context, shortImage, longImage string, registryStatus *RegistryImageStatus) BrokerImageEntry {
+	result := s.imageChecker.CheckAll(ctx, shortImage, longImage)
+
+	brokerName := "Local Runtime"
+	if namer, ok := s.imageManager.(interface{ Name() string }); ok {
+		if n := namer.Name(); n != "" {
+			brokerName = n
+		}
+	}
+
+	entry := BrokerImageEntry{
+		BrokerName: brokerName,
+		Reachable:  true,
+	}
+	if shortImage != "" {
+		entry.LocalShort = &BrokerImageEntityState{Exists: result.LocalShort.Exists, Hash: result.LocalShort.Hash}
+	}
+	if longImage != "" {
+		entry.LocalLong = &BrokerImageEntityState{Exists: result.LocalLong.Exists, Hash: result.LocalLong.Hash}
+	}
+
+	if entry.LocalLong != nil && entry.LocalLong.Exists && registryStatus.Hash != "" && entry.LocalLong.Hash != "" {
+		entry.NewerInRegistry = registryStatus.Hash != entry.LocalLong.Hash
+	}
+
+	switch {
+	case entry.LocalShort != nil && entry.LocalShort.Exists:
+		entry.ResolvedImage = shortImage
+		entry.ResolutionSource = "local_short"
+	case entry.LocalLong != nil && entry.LocalLong.Exists:
+		entry.ResolvedImage = longImage
+		entry.ResolutionSource = "local_long"
+	case registryStatus.Exists:
+		entry.ResolvedImage = longImage
+		entry.ResolutionSource = "remote"
+	default:
+		entry.ResolutionSource = "none"
+	}
+
+	return entry
 }
 
 // handleHarnessConfigDeleteLocalImage removes the local short-form image.

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -1128,7 +1128,7 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 
 	if s.brokerClient == nil {
 		if s.imageManager != nil {
-			entry := s.buildLocalImageEntry(ctx, shortImage, longImage, &registryStatus)
+\t\t\tentry := s.buildLocalImageEntry(ctx, shortImage, longImage, registryStatus)
 			writeJSON(w, http.StatusOK, AggregatedImageStatusResponse{
 				Image:    image,
 				Registry: &registryStatus,

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -1241,7 +1241,7 @@ func (s *Server) handleHarnessConfigImageStatus(w http.ResponseWriter, r *http.R
 // co-located container runtime (Docker/Podman) when no broker client is
 // available. This ensures workstation-mode users see pulled image state
 // and the Build Image option.
-func (s *Server) buildLocalImageEntry(ctx context.Context, shortImage, longImage string, registryStatus *RegistryImageStatus) BrokerImageEntry {
+func (s *Server) buildLocalImageEntry(ctx context.Context, shortImage, longImage string, registryStatus RegistryImageStatus) BrokerImageEntry {
 	result := s.imageChecker.CheckAll(ctx, shortImage, longImage)
 
 	brokerName := "Local Runtime"

--- a/pkg/hub/harness_config_handlers_image_test.go
+++ b/pkg/hub/harness_config_handlers_image_test.go
@@ -280,6 +280,60 @@ func TestImageStatusHandler_NoNodeBoundBrokers(t *testing.T) {
 	}
 }
 
+type fakeImageManager struct {
+	exists map[string]bool
+}
+
+func (f *fakeImageManager) ImageExists(_ context.Context, image string) (bool, error) {
+	return f.exists[image], nil
+}
+func (f *fakeImageManager) PullImage(context.Context, string) error   { return nil }
+func (f *fakeImageManager) RemoveImage(context.Context, string) error { return nil }
+func (f *fakeImageManager) Name() string                              { return "Podman" }
+
+func TestImageStatusHandler_ProxyBrokersWithLocalImageManager(t *testing.T) {
+	srv, db := setupImageStatusTest(t)
+
+	createTestBroker(t, db, "broker1", "k8s-broker", "", []store.BrokerProfile{{Type: "kubernetes"}}, nil)
+	hc := createTestHarnessConfig(t, db, "hc1", "my-image:latest")
+
+	transport := newBrokerHTTPTransport(false, nil)
+	srv.brokerClient = &HybridBrokerClient{
+		controlChannel: &ControlChannelBrokerClient{manager: &neverConnectedTunnel{}},
+		httpClient:     transport,
+	}
+
+	mgr := &fakeImageManager{exists: map[string]bool{"my-image:latest": true}}
+	srv.imageManager = mgr
+	srv.imageChecker.SetLocal(mgr)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/harness-configs/"+hc.ID+"/image-status", nil)
+	rr := httptest.NewRecorder()
+	srv.handleHarnessConfigImageStatus(rr, req, hc.ID)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp AggregatedImageStatusResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	if len(resp.Brokers) != 1 {
+		t.Fatalf("expected 1 broker entry (local), got %d", len(resp.Brokers))
+	}
+	if !resp.Brokers[0].Reachable {
+		t.Error("expected local entry to be reachable")
+	}
+	if resp.Brokers[0].BrokerName != "Podman" {
+		t.Errorf("expected broker name %q, got %q", "Podman", resp.Brokers[0].BrokerName)
+	}
+	if len(resp.ProxyBrokers) != 1 {
+		t.Errorf("expected 1 proxy broker, got %d", len(resp.ProxyBrokers))
+	}
+}
+
 func TestImageStatusHandler_BareImageCheck(t *testing.T) {
 	srv, db := setupImageStatusTest(t)
 


### PR DESCRIPTION
## Problem

On workstations with podman, the harness-config detail page showed only a Registry row with the message "Agents on this hub run on proxy brokers. Images are pulled by the substrate at provision time, there is no node-local image state to inspect."

PR #738 fixed the case where brokerClient==nil. But this is different: the broker IS connected, however all broker profiles are proxy-typed (no docker/podman/apple node-bound profiles). The handler returned empty Brokers[], causing the frontend to hit the proxy-only rendering path.

## Fix

After the broker classification loop, when no node-bound brokers are found but imageManager is available (only set in workstation mode via SetLocalImageChecker), fall back to buildLocalImageEntry() to populate the Brokers array with local image state.

Test added: TestImageStatusHandler_ProxyBrokersWithLocalImageManager.

imageManager is only present in workstation mode — no false-positive risk for hosted hubs