### PR TITLE
feat(runtimebroker): gate gcloud ADC auto-injection behind user opt-in setting and onboarding wizard

### DIFF
--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -288,6 +288,11 @@ type V1ServerConfig struct {
 
 	// GitHubApp configures the Hub's GitHub App integration for agent git authentication.
 	GitHubApp *V1GitHubAppConfig `json:"github_app,omitempty" yaml:"github_app,omitempty" koanf:"github_app"`
+
+	// AutoInjectGcloudADC controls whether the host's gcloud Application Default
+	// Credentials file is automatically injected into agent containers in
+	// co-located (workstation) mode.
+	AutoInjectGcloudADC bool `json:"auto_inject_gcloud_adc,omitempty" yaml:"auto_inject_gcloud_adc,omitempty" koanf:"auto_inject_gcloud_adc"`
 }
 
 // V1GitHubAppConfig holds the GitHub App configuration in settings.yaml format.

--- a/pkg/hub/system_handlers.go
+++ b/pkg/hub/system_handlers.go
@@ -314,6 +314,8 @@ type OnboardingStatus struct {
 	GCPProjectID        string `json:"gcpProjectId,omitempty"`
 	GitVersion          string `json:"gitVersion,omitempty"`
 	GitVersionOK        bool   `json:"gitVersionOK"`
+	GCloudADCAvailable  bool   `json:"gcloudADCAvailable"`
+	AutoInjectGcloudADC bool   `json:"autoInjectGcloudADC"`
 }
 
 func (s *Server) computeOnboardingStatus(ctx context.Context) OnboardingStatus {
@@ -394,6 +396,21 @@ func (s *Server) computeOnboardingStatus(ctx context.Context) OnboardingStatus {
 	} else {
 		status.GitVersion = "not found"
 		status.GitVersionOK = false
+	}
+
+	// GCloudADCAvailable: check if host has gcloud ADC file
+	if home, hErr := os.UserHomeDir(); hErr == nil {
+		adcPath := filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
+		if _, err := os.Stat(adcPath); err == nil {
+			status.GCloudADCAvailable = true
+		}
+	}
+
+	// AutoInjectGcloudADC: read current setting value
+	if vs, loadErr := config.LoadSingleFileVersioned(globalDir); loadErr == nil && vs != nil {
+		if vs.Server != nil {
+			status.AutoInjectGcloudADC = vs.Server.AutoInjectGcloudADC
+		}
 	}
 
 	return status

--- a/pkg/runtimebroker/start_context.go
+++ b/pkg/runtimebroker/start_context.go
@@ -515,25 +515,31 @@ func (s *Server) buildStartContext(ctx context.Context, in startContextInputs) (
 	// In co-located (workstation) hub mode, auto-inject the host ADC file as a
 	// gcloud-adc file secret so agents can authenticate with GCP without requiring
 	// the user to manually upload the credential file.
+	// Only inject if the user has explicitly opted in via settings.
 	if isColocated {
-		home, _ := os.UserHomeDir()
-		adcPath := filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
-		if data, err := os.ReadFile(adcPath); err == nil {
-			alreadyHave := false
-			for _, s := range opts.ResolvedSecrets {
-				if s.Name == "gcloud-adc" {
-					alreadyHave = true
-					break
+		if adcGlobalDir, gErr := config.GetGlobalDir(); gErr == nil {
+			if vs, loadErr := config.LoadSingleFileVersioned(adcGlobalDir); loadErr == nil &&
+				vs != nil && vs.Server != nil && vs.Server.AutoInjectGcloudADC {
+				home, _ := os.UserHomeDir()
+				adcPath := filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
+				if data, err := os.ReadFile(adcPath); err == nil {
+					alreadyHave := false
+					for _, s := range opts.ResolvedSecrets {
+						if s.Name == "gcloud-adc" {
+							alreadyHave = true
+							break
+						}
+					}
+					if !alreadyHave {
+						opts.ResolvedSecrets = append(opts.ResolvedSecrets, api.ResolvedSecret{
+							Name:   "gcloud-adc",
+							Type:   "file",
+							Target: "/home/scion/.config/gcloud/application_default_credentials.json",
+							Value:  string(data),
+							Source: "runtime_broker",
+						})
+					}
 				}
-			}
-			if !alreadyHave {
-				opts.ResolvedSecrets = append(opts.ResolvedSecrets, api.ResolvedSecret{
-					Name:   "gcloud-adc",
-					Type:   "file",
-					Target: "/home/scion/.config/gcloud/application_default_credentials.json",
-					Value:  string(data),
-					Source: "runtime_broker",
-				})
 			}
 		}
 	}

--- a/pkg/runtimebroker/start_context.go
+++ b/pkg/runtimebroker/start_context.go
@@ -512,6 +512,32 @@ func (s *Server) buildStartContext(ctx context.Context, in startContextInputs) (
 		}
 	}
 
+	// In co-located (workstation) hub mode, auto-inject the host ADC file as a
+	// gcloud-adc file secret so agents can authenticate with GCP without requiring
+	// the user to manually upload the credential file.
+	if isColocated {
+		home, _ := os.UserHomeDir()
+		adcPath := filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
+		if data, err := os.ReadFile(adcPath); err == nil {
+			alreadyHave := false
+			for _, s := range opts.ResolvedSecrets {
+				if s.Name == "gcloud-adc" {
+					alreadyHave = true
+					break
+				}
+			}
+			if !alreadyHave {
+				opts.ResolvedSecrets = append(opts.ResolvedSecrets, api.ResolvedSecret{
+					Name:   "gcloud-adc",
+					Type:   "file",
+					Target: "/home/scion/.config/gcloud/application_default_credentials.json",
+					Value:  string(data),
+					Source: "runtime_broker",
+				})
+			}
+		}
+	}
+
 	// --- Manager resolution ---
 	mgr := s.resolveManagerForOpts(opts)
 

--- a/web/src/components/pages/onboarding.ts
+++ b/web/src/components/pages/onboarding.ts
@@ -36,6 +36,8 @@ interface OnboardingStatus {
   imageRegistry?: string;
   gitVersion?: string;
   gitVersionOK?: boolean;
+  gcloudADCAvailable?: boolean;
+  autoInjectGcloudADC?: boolean;
 }
 
 interface DiagnosticResult {
@@ -95,6 +97,8 @@ export class ScionPageOnboarding extends LitElement {
   @state() private pullTotal = 0;
   @state() private gitVersion = '';
   @state() private gitVersionOK = true;
+  @state() private gcloudADCAvailable = false;
+  @state() private autoInjectGcloudADC = false;
   private imageEventSource: EventSource | null = null;
   private imageJobTimeoutId: number | null = null;
 
@@ -514,6 +518,8 @@ export class ScionPageOnboarding extends LitElement {
       }
       if (status?.gitVersion !== undefined) this.gitVersion = status.gitVersion;
       if (status?.gitVersionOK !== undefined) this.gitVersionOK = status.gitVersionOK;
+      if (status?.gcloudADCAvailable) this.gcloudADCAvailable = true;
+      if (status?.autoInjectGcloudADC) this.autoInjectGcloudADC = true;
 
       // Resume: advance past completed steps only if user has previously started
       const previouslyStarted = sessionStorage.getItem('onboardingStarted') === 'true';
@@ -965,6 +971,22 @@ export class ScionPageOnboarding extends LitElement {
         </p>
       `}
 
+      ${this.gcloudADCAvailable ? html`
+        <div style="margin-top:1rem;padding:0.75rem 1rem;border:1px solid var(--sl-color-neutral-200);border-radius:var(--sl-border-radius-medium);background:var(--sl-color-neutral-50);">
+          <sl-checkbox
+            ?checked=${this.autoInjectGcloudADC}
+            @sl-change=${(e: Event) => {
+              this.autoInjectGcloudADC = (e.target as HTMLInputElement).checked;
+            }}
+          >
+            Automatically inject gcloud credentials into agent containers
+          </sl-checkbox>
+          <p style="font-size:0.75rem;color:var(--scion-text-muted,#64748b);margin:0.25rem 0 0 1.75rem;">
+            Detected: ~/.config/gcloud/application_default_credentials.json
+          </p>
+        </div>
+      ` : nothing}
+
       <div class="footer">
         <sl-button variant="text" @click=${() => { this.currentStep = 3; }}>Back</sl-button>
         <div class="footer-right">
@@ -1062,6 +1084,16 @@ export class ScionPageOnboarding extends LitElement {
       if (!res.ok) {
         this.error = await extractApiError(res, 'Failed to initialize harnesses');
         return;
+      }
+      // Save gcloud ADC injection preference if the option was shown
+      if (this.gcloudADCAvailable) {
+        await apiFetch('/api/v1/admin/server-config', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            server: { auto_inject_gcloud_adc: this.autoInjectGcloudADC },
+          }),
+        });
       }
       this.cleanupImageEvents();
       this.currentStep = 5;


### PR DESCRIPTION
## Design

User opt-in at two points:
1. Onboarding wizard Step 4 — if ADC file detected, checkbox appears: "Automatically inject gcloud credentials into agent containers?" (default: unchecked)
2. Settings field — auto_inject_gcloud_adc in settings.yaml

Changes: settings_v1.go (new field) + start_context.go (gate on setting) + system_handlers.go (ADC detection in status) + onboarding.ts (checkbox)