### PR TITLE
feat: move auto_inject_gcloud_adc to top-level settings; add profile page toggle

### DIFF
--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -251,6 +251,11 @@ type VersionedSettings struct {
 	DefaultMaxModelCalls int               `json:"default_max_model_calls,omitempty" yaml:"default_max_model_calls,omitempty" koanf:"default_max_model_calls"`
 	DefaultMaxDuration   string            `json:"default_max_duration,omitempty" yaml:"default_max_duration,omitempty" koanf:"default_max_duration"`
 	DefaultResources     *api.ResourceSpec `json:"default_resources,omitempty" yaml:"default_resources,omitempty" koanf:"default_resources"`
+
+	// AutoInjectGcloudADC controls whether the host's gcloud Application Default
+	// Credentials file is automatically injected into agent containers in
+	// co-located (workstation) mode.
+	AutoInjectGcloudADC bool `json:"auto_inject_gcloud_adc,omitempty" yaml:"auto_inject_gcloud_adc,omitempty" koanf:"auto_inject_gcloud_adc"`
 }
 
 // V1ServerConfig holds server-side configuration in the versioned settings format.
@@ -289,10 +294,6 @@ type V1ServerConfig struct {
 	// GitHubApp configures the Hub's GitHub App integration for agent git authentication.
 	GitHubApp *V1GitHubAppConfig `json:"github_app,omitempty" yaml:"github_app,omitempty" koanf:"github_app"`
 
-	// AutoInjectGcloudADC controls whether the host's gcloud Application Default
-	// Credentials file is automatically injected into agent containers in
-	// co-located (workstation) mode.
-	AutoInjectGcloudADC bool `json:"auto_inject_gcloud_adc,omitempty" yaml:"auto_inject_gcloud_adc,omitempty" koanf:"auto_inject_gcloud_adc"`
 }
 
 // V1GitHubAppConfig holds the GitHub App configuration in settings.yaml format.

--- a/pkg/hub/admin_settings.go
+++ b/pkg/hub/admin_settings.go
@@ -60,6 +60,9 @@ type ServerConfigResponse struct {
 	DefaultMaxDuration   string            `json:"default_max_duration,omitempty"`
 	DefaultResources     *api.ResourceSpec `json:"default_resources,omitempty"`
 
+	// AutoInjectGcloudADC controls whether gcloud ADC is injected into agent containers.
+	AutoInjectGcloudADC bool `json:"auto_inject_gcloud_adc,omitempty"`
+
 	// EnvOverrides lists koanf keys overridden by SCION_SERVER_* env vars
 	// on this node. Present in both file-mode and DB-mode responses so the
 	// admin UI can show env-pinned fields regardless of settings tier.
@@ -85,6 +88,9 @@ type ServerConfigUpdateRequest struct {
 	DefaultMaxModelCalls *int              `json:"default_max_model_calls,omitempty"`
 	DefaultMaxDuration   *string           `json:"default_max_duration,omitempty"`
 	DefaultResources     *api.ResourceSpec `json:"default_resources,omitempty"`
+
+	// AutoInjectGcloudADC controls whether gcloud ADC is injected into agent containers.
+	AutoInjectGcloudADC *bool `json:"auto_inject_gcloud_adc,omitempty"`
 }
 
 // handleAdminServerConfig handles GET/PUT /api/v1/admin/server-config.
@@ -236,6 +242,7 @@ func (s *Server) handleGetServerConfig(w http.ResponseWriter) {
 		DefaultMaxModelCalls: vs.DefaultMaxModelCalls,
 		DefaultMaxDuration:   vs.DefaultMaxDuration,
 		DefaultResources:     vs.DefaultResources,
+		AutoInjectGcloudADC:  vs.AutoInjectGcloudADC,
 	}
 
 	// Env overrides — detect SCION_SERVER_* env vars so the admin UI can
@@ -433,6 +440,13 @@ func applySettingsUpdates(raw map[string]interface{}, req *ServerConfigUpdateReq
 	}
 	if req.DefaultResources != nil {
 		raw["default_resources"] = marshalToMap(req.DefaultResources)
+	}
+	if req.AutoInjectGcloudADC != nil {
+		if *req.AutoInjectGcloudADC {
+			raw["auto_inject_gcloud_adc"] = true
+		} else {
+			delete(raw, "auto_inject_gcloud_adc")
+		}
 	}
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2824,6 +2824,7 @@ func (s *Server) registerRoutes() {
 	s.mux.Handle("/api/v1/system/images/build", s.requireWorkstation(http.HandlerFunc(s.handleSystemImagesBuild)))
 	s.mux.Handle("/api/v1/system/apple-dns", s.requireWorkstation(http.HandlerFunc(s.handleAppleDNS)))
 	s.mux.Handle("/api/v1/system/registry", s.requireWorkstation(http.HandlerFunc(s.handleSystemRegistry)))
+	s.mux.Handle("/api/v1/system/workstation-settings", s.requireWorkstation(http.HandlerFunc(s.handleWorkstationSettings)))
 
 	// Workstation-only filesystem endpoints
 	s.mux.Handle("/api/v1/system/fs/list", s.requireWorkstation(http.HandlerFunc(s.handleFSList)))

--- a/pkg/hub/system_handlers.go
+++ b/pkg/hub/system_handlers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
+	yamlv3 "gopkg.in/yaml.v3"
 )
 
 // --- 2.1: System Check (Doctor) ---
@@ -408,9 +409,7 @@ func (s *Server) computeOnboardingStatus(ctx context.Context) OnboardingStatus {
 
 	// AutoInjectGcloudADC: read current setting value
 	if vs, loadErr := config.LoadSingleFileVersioned(globalDir); loadErr == nil && vs != nil {
-		if vs.Server != nil {
-			status.AutoInjectGcloudADC = vs.Server.AutoInjectGcloudADC
-		}
+		status.AutoInjectGcloudADC = vs.AutoInjectGcloudADC
 	}
 
 	return status
@@ -1072,6 +1071,83 @@ func (s *Server) handleAppleDNSSetup(w http.ResponseWriter, r *http.Request) {
 		resp.Error = err.Error()
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// --- Workstation Settings ---
+
+// workstationSettingsRequest is the payload for PATCH /api/v1/system/workstation-settings.
+type workstationSettingsRequest struct {
+	AutoInjectGcloudADC *bool `json:"auto_inject_gcloud_adc,omitempty"`
+}
+
+// handleWorkstationSettings handles PATCH /api/v1/system/workstation-settings.
+// It allows toggling workstation-level settings without requiring admin role.
+func (s *Server) handleWorkstationSettings(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPatch {
+		MethodNotAllowed(w)
+		return
+	}
+
+	var req workstationSettingsRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "Invalid request body", nil)
+		return
+	}
+
+	if req.AutoInjectGcloudADC == nil {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "No settings provided", nil)
+		return
+	}
+
+	globalDir, err := config.GetGlobalDir()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError, "Failed to resolve settings directory", nil)
+		return
+	}
+
+	settingsPath := filepath.Join(globalDir, "settings.yaml")
+
+	var raw map[string]interface{}
+	if data, readErr := os.ReadFile(settingsPath); readErr == nil {
+		if err := yamlv3.Unmarshal(data, &raw); err != nil {
+			writeError(w, http.StatusInternalServerError, ErrCodeInternalError, "Failed to parse settings file", nil)
+			return
+		}
+	}
+	if raw == nil {
+		raw = make(map[string]interface{})
+	}
+
+	if req.AutoInjectGcloudADC != nil {
+		if *req.AutoInjectGcloudADC {
+			raw["auto_inject_gcloud_adc"] = true
+		} else {
+			delete(raw, "auto_inject_gcloud_adc")
+		}
+	}
+
+	if _, ok := raw["schema_version"]; !ok {
+		raw["schema_version"] = "1"
+	}
+
+	newData, err := yamlv3.Marshal(raw)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError, "Failed to marshal settings", nil)
+		return
+	}
+
+	if err := os.WriteFile(settingsPath, newData, 0644); err != nil {
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError, "Failed to write settings file", nil)
+		return
+	}
+
+	slog.Info("Workstation settings updated",
+		"auto_inject_gcloud_adc", *req.AutoInjectGcloudADC,
+	)
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"auto_inject_gcloud_adc": *req.AutoInjectGcloudADC,
+	})
 }
 
 // trimOutput removes a trailing newline from command output.

--- a/pkg/runtimebroker/start_context.go
+++ b/pkg/runtimebroker/start_context.go
@@ -519,7 +519,7 @@ func (s *Server) buildStartContext(ctx context.Context, in startContextInputs) (
 	if isColocated {
 		if adcGlobalDir, gErr := config.GetGlobalDir(); gErr == nil {
 			if vs, loadErr := config.LoadSingleFileVersioned(adcGlobalDir); loadErr == nil &&
-				vs != nil && vs.Server != nil && vs.Server.AutoInjectGcloudADC {
+				vs != nil && vs.AutoInjectGcloudADC {
 				home, _ := os.UserHomeDir()
 				adcPath := filepath.Join(home, ".config", "gcloud", "application_default_credentials.json")
 				if data, err := os.ReadFile(adcPath); err == nil {

--- a/web/src/components/pages/onboarding.ts
+++ b/web/src/components/pages/onboarding.ts
@@ -1091,7 +1091,7 @@ export class ScionPageOnboarding extends LitElement {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            server: { auto_inject_gcloud_adc: this.autoInjectGcloudADC },
+            auto_inject_gcloud_adc: this.autoInjectGcloudADC,
           }),
         });
       }

--- a/web/src/components/pages/profile-settings.ts
+++ b/web/src/components/pages/profile-settings.ts
@@ -24,6 +24,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
+import { apiFetch } from '../../client/api.js';
 import '../shared/subscription-manager.js';
 
 const STORAGE_KEY = 'scion-push-notifications';
@@ -35,6 +36,12 @@ export class ScionPageProfileSettings extends LitElement {
 
   @state()
   private _permissionState: NotificationPermission | 'unsupported' = 'default';
+
+  @state()
+  private _gcloudADCAvailable = false;
+
+  @state()
+  private _autoInjectGcloudADC = false;
 
   static override styles = css`
     :host {
@@ -158,6 +165,23 @@ export class ScionPageProfileSettings extends LitElement {
   override connectedCallback(): void {
     super.connectedCallback();
     this._initNotificationState();
+    void this._loadSystemStatus();
+  }
+
+  private async _loadSystemStatus(): Promise<void> {
+    try {
+      const res = await apiFetch('/api/v1/system/status');
+      if (res.ok) {
+        const data = (await res.json()) as {
+          gcloudADCAvailable?: boolean;
+          autoInjectGcloudADC?: boolean;
+        };
+        this._gcloudADCAvailable = data.gcloudADCAvailable ?? false;
+        this._autoInjectGcloudADC = data.autoInjectGcloudADC ?? false;
+      }
+    } catch {
+      // Non-critical — leave defaults
+    }
   }
 
   private _initNotificationState(): void {
@@ -197,6 +221,23 @@ export class ScionPageProfileSettings extends LitElement {
     } else {
       target.checked = false;
       this._pushEnabled = false;
+    }
+  }
+
+  private async _handleADCToggle(e: Event): Promise<void> {
+    const target = e.target as HTMLInputElement & { checked: boolean };
+    const enabled = target.checked;
+    this._autoInjectGcloudADC = enabled;
+    try {
+      await apiFetch('/api/v1/system/workstation-settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ auto_inject_gcloud_adc: enabled }),
+      });
+    } catch {
+      // Revert on failure
+      this._autoInjectGcloudADC = !enabled;
+      target.checked = !enabled;
     }
   }
 
@@ -271,6 +312,31 @@ export class ScionPageProfileSettings extends LitElement {
 
         ${this._renderPermissionStatus()}
       </div>
+
+      ${this._gcloudADCAvailable ? html`
+        <div class="settings-card">
+          <h2 class="section-title">
+            <sl-icon name="cloud"></sl-icon>
+            GCP Credentials
+          </h2>
+
+          <div class="setting-row">
+            <div class="setting-info">
+              <p class="setting-label">Automatically inject gcloud credentials into agent containers</p>
+              <p class="setting-description">
+                When enabled, agents launched in workstation mode will have access to
+                your local gcloud Application Default Credentials.
+              </p>
+            </div>
+            <div class="setting-control">
+              <sl-switch
+                ?checked=${this._autoInjectGcloudADC}
+                @sl-change=${this._handleADCToggle}
+              ></sl-switch>
+            </div>
+          </div>
+        </div>
+      ` : nothing}
 
       <scion-subscription-manager compact></scion-subscription-manager>
     `;


### PR DESCRIPTION
## Changes

- auto_inject_gcloud_adc moved from server.auto_inject_gcloud_adc to top-level in settings.yaml
- New PATCH /api/v1/system/workstation-settings endpoint for updating the setting
- profile-settings.ts: "GCP Credentials" section with sl-switch toggle (only shown when ADC file detected)
- system_handlers.go: updated to read top-level field; PATCH handler added
- start_context.go: reads top-level vs.AutoInjectGcloudADC
- onboarding.ts: updated PUT body to use top-level key
- go build ./... passes, no stale nested references remain
