### PR TITLE
docs: Skill Bank, harness lifecycle, and Homebrew-first install

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ brew install homebrew-scion/scion/scion
 This installs the `scion` CLI — pre-configured to use `ghcr.io/homebrew-scion` as the default image registry — along with the `scion-plugin-telegram` broker plugin. To upgrade later:
 
 ```bash
-brew update && brew upgrade scion
+brew update && brew upgrade homebrew-scion/scion/scion
 ```
 
 Then start the Workstation server:

--- a/README.md
+++ b/README.md
@@ -22,14 +22,36 @@ The visualization above replays the actual telemetry collected from messages and
 
 ## Quick Start
 
-### Workstation Quick Start (Homebrew)
+### Install with Homebrew (recommended)
+
+The easiest way to get Scion is the community [homebrew-scion](https://github.com/homebrew-scion/homebrew-scion) tap:
 
 ```bash
-brew install scion
+brew tap homebrew-scion/scion
+brew install homebrew-scion/scion/scion
+```
+
+This installs the `scion` CLI — pre-configured to use `ghcr.io/homebrew-scion` as the default image registry — along with the `scion-plugin-telegram` broker plugin. To upgrade later:
+
+```bash
+brew update && brew upgrade scion
+```
+
+Then start the Workstation server:
+
+```bash
 scion server start
 ```
 
-Your browser will open to the onboarding wizard at `http://127.0.0.1:8080/onboarding`, which walks you through machine setup, runtime detection, harness selection, and creating your first project.
+Your browser opens to the onboarding wizard at `http://127.0.0.1:8080/onboarding`, which walks you through runtime detection (Docker, Podman, or Apple Container), identity configuration, container image setup, and creating your first workspace.
+
+After onboarding, start your first agent:
+
+```bash
+scion start my-agent "Your task here"
+```
+
+See the [homebrew-scion tap](https://github.com/homebrew-scion/homebrew-scion) for the full list of pre-built multi-arch container images and distribution details.
 
 ### Install from Source
 

--- a/docs-site/src/content/docs/getting-started/install.md
+++ b/docs-site/src/content/docs/getting-started/install.md
@@ -11,18 +11,70 @@ which you want, read [Choosing a Mode](/scion/choosing-a-mode/) first.
 
 :::tip[Prefer a guided setup?]
 For Workstation mode, the [Onboarding Wizard](/scion/getting-started/onboarding/) walks you
-through the whole setup in your browser — no config files to edit. Install Scion (with its web
-assets), then run `scion server start`.
+through the whole setup in your browser — no config files to edit. Install Scion with Homebrew
+(below), then run `scion server start`.
 :::
+
+## Install with Homebrew (recommended)
+
+The easiest way to get a ready-to-run Scion — CLI plus embedded web UI — is the community
+[homebrew-scion](https://github.com/homebrew-scion/homebrew-scion) tap:
+
+```bash
+brew tap homebrew-scion/scion
+brew install homebrew-scion/scion/scion
+```
+
+This installs:
+
+- **`scion`** — the main CLI, pre-configured to use `ghcr.io/homebrew-scion` as the default
+  image registry, so the harness images are pulled for you.
+- **`scion-plugin-telegram`** — the Telegram broker plugin, installed automatically alongside
+  the CLI.
+
+To upgrade later:
+
+```bash
+brew update && brew upgrade scion
+```
+
+### Quick start
+
+Start the Workstation combo server:
+
+```bash
+scion server start
+```
+
+Your browser opens to the [Onboarding Wizard](/scion/getting-started/onboarding/) at
+`http://127.0.0.1:8080/onboarding`, which handles the rest of setup for you — runtime detection
+(Docker, Podman, or Apple Container), identity configuration, container image setup (pulling from
+`ghcr.io/homebrew-scion`), and creating your first workspace.
+
+After onboarding, start your first agent:
+
+```bash
+scion start my-agent "Your task here"
+```
+
+:::note[Using Homebrew?]
+The onboarding wizard performs machine initialization and image setup for you, so you can skip
+the [Prerequisites](#prerequisites) and [Configuration](#configuration) sections below — they
+apply to a from-source install or a fully manual, CLI-only (Local mode) setup.
+:::
+
+---
 
 ## Prerequisites
 
-### 1. Go
-Scion is written in Go. You need Go 1.26 or later installed (see the `go` directive in the
-repository's `go.mod`).
-- [Download and install Go](https://golang.org/doc/install)
+These apply when you build [from source](#install-from-source) or configure Scion manually. The
+onboarding wizard checks the runtime and Git requirements for you.
 
-While a binary may be available from the github releases page, this is an active project and it is currently best to regularly build from source.
+### 1. Go
+Go is required only to build Scion **from source**. You need Go 1.26 or later installed (see the
+`go` directive in the repository's `go.mod`). Homebrew installs a prebuilt binary, so you can
+skip this if you installed with `brew`.
+- [Download and install Go](https://golang.org/doc/install)
 
 ### 2. Container Runtime
 Scion requires a container runtime to manage agents. You can use Docker, Podman, or the Apple Virtualization Framework (experimental).
@@ -59,9 +111,12 @@ For Debian you may need to build from source, see the [git site](https://git-scm
 
 ---
 
-## Scion Installation
+## Install from Source
 
-### From Source
+Building from source is the alternative to [Homebrew](#install-with-homebrew-recommended) — use
+it if you are contributing to Scion or prefer to build the binary yourself.
+
+### From Source (`go install`)
 You can install Scion directly using `go install`:
 
 ```bash

--- a/docs-site/src/content/docs/getting-started/install.md
+++ b/docs-site/src/content/docs/getting-started/install.md
@@ -35,7 +35,7 @@ This installs:
 To upgrade later:
 
 ```bash
-brew update && brew upgrade scion
+brew update && brew upgrade homebrew-scion/scion/scion
 ```
 
 ### Quick start
@@ -51,16 +51,12 @@ Your browser opens to the [Onboarding Wizard](/scion/getting-started/onboarding/
 (Docker, Podman, or Apple Container), identity configuration, container image setup (pulling from
 `ghcr.io/homebrew-scion`), and creating your first workspace.
 
-After onboarding, start your first agent:
-
-```bash
-scion start my-agent "Your task here"
-```
+After onboarding, start your first agent in the web UI:
 
 :::note[Using Homebrew?]
-The onboarding wizard performs machine initialization and image setup for you, so you can skip
+The onboarding wizard performs machine initialization and image setup for you, so you can skip many of
 the [Prerequisites](#prerequisites) and [Configuration](#configuration) sections below — they
-apply to a from-source install or a fully manual, CLI-only (Local mode) setup.
+apply to a from-source install or a fully manual, CLI-only (Local mode) setup. You will still need a container runtime - podman is recommended.
 :::
 
 ---

--- a/docs-site/src/content/docs/getting-started/onboarding.md
+++ b/docs-site/src/content/docs/getting-started/onboarding.md
@@ -15,7 +15,7 @@ The wizard sets up **Workstation mode** — a single-tenant Scion server (Hub + 
 
 Before you start, you need a working Scion install and a container runtime. See the [Installation guide](/scion/getting-started/install/) for details. In short:
 
-- Scion installed with its web assets. Use **Homebrew** (`brew install scion`) for a ready-to-run install; a bare `go install` does **not** embed the web UI, so the wizard would load blank.
+- Scion installed with its web assets. Use **Homebrew** (`brew tap homebrew-scion/scion && brew install homebrew-scion/scion/scion`) for a ready-to-run install; a bare `go install` does **not** embed the web UI, so the wizard would load blank. See the [Installation guide](/scion/getting-started/install/#install-with-homebrew-recommended) for details.
 - A container runtime — Docker, Podman, or Apple Container.
 - Git 2.47 or later (the wizard flags older versions).
 


### PR DESCRIPTION
## Summary

- **Skill Bank documentation**: New authoring/publishing guide and registry/federation admin page, plus CLI reference, glossary, and sidebar updates
- **Harness lifecycle docs**: Added Copilot, Hermes, and Antigravity to supported-harnesses matrix; documented container-script provisioning model, harness-config lifecycle management, and updated agent-credentials auth pipeline
- **CLI reference updates**: harness-config group, reset-auth, and doctor commands
- **Homebrew-first install**: Updated README.md and docs-site install page to lead with Homebrew as the recommended getting-started path, based on homebrew-scion tap
- **Review feedback**: Addressed PR #653 review items (typo, phrasing, footnote clarity)

## Test plan
- [ ] Verify docs-site builds cleanly (astro build + starlight-links-validator)
- [ ] Spot-check new pages render correctly (skills, skill-registry, supported-harnesses, harness-settings, agent-credentials)
- [ ] Verify README quick-start instructions match current CLI behavior
- [ ] Confirm sidebar navigation includes new pages in correct sections