### PR TITLE
style: gofmt files after PR #761

### DIFF
--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -293,7 +293,6 @@ type V1ServerConfig struct {
 
 	// GitHubApp configures the Hub's GitHub App integration for agent git authentication.
 	GitHubApp *V1GitHubAppConfig `json:"github_app,omitempty" yaml:"github_app,omitempty" koanf:"github_app"`
-
 }
 
 // V1GitHubAppConfig holds the GitHub App configuration in settings.yaml format.


### PR DESCRIPTION
Fixes gofmt formatting issues introduced by PR #761 that were causing Build & Test CI failures on main and PR #762