### PR TITLE
fix: address review feedback from #760 — mutex, error handling, boolean write, res.ok, workstation gate

### DIFF
--- a/pkg/hub/system_handlers.go
+++ b/pkg/hub/system_handlers.go
@@ -317,6 +317,7 @@ type OnboardingStatus struct {
 	GitVersionOK        bool   `json:"gitVersionOK"`
 	GCloudADCAvailable  bool   `json:"gcloudADCAvailable"`
 	AutoInjectGcloudADC bool   `json:"autoInjectGcloudADC"`
+	Workstation         bool   `json:"workstation"`
 }
 
 func (s *Server) computeOnboardingStatus(ctx context.Context) OnboardingStatus {
@@ -411,6 +412,9 @@ func (s *Server) computeOnboardingStatus(ctx context.Context) OnboardingStatus {
 	if vs, loadErr := config.LoadSingleFileVersioned(globalDir); loadErr == nil && vs != nil {
 		status.AutoInjectGcloudADC = vs.AutoInjectGcloudADC
 	}
+
+	// Workstation: whether the server is running in workstation mode
+	status.Workstation = s.workstation
 
 	return status
 }
@@ -1099,6 +1103,9 @@ func (s *Server) handleWorkstationSettings(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	globalDir, err := config.GetGlobalDir()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, ErrCodeInternalError, "Failed to resolve settings directory", nil)
@@ -1113,18 +1120,15 @@ func (s *Server) handleWorkstationSettings(w http.ResponseWriter, r *http.Reques
 			writeError(w, http.StatusInternalServerError, ErrCodeInternalError, "Failed to parse settings file", nil)
 			return
 		}
+	} else if !os.IsNotExist(readErr) {
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError, "Failed to read settings file", nil)
+		return
 	}
 	if raw == nil {
 		raw = make(map[string]interface{})
 	}
 
-	if req.AutoInjectGcloudADC != nil {
-		if *req.AutoInjectGcloudADC {
-			raw["auto_inject_gcloud_adc"] = true
-		} else {
-			delete(raw, "auto_inject_gcloud_adc")
-		}
-	}
+	raw["auto_inject_gcloud_adc"] = *req.AutoInjectGcloudADC
 
 	if _, ok := raw["schema_version"]; !ok {
 		raw["schema_version"] = "1"

--- a/web/src/components/pages/profile-settings.ts
+++ b/web/src/components/pages/profile-settings.ts
@@ -43,6 +43,9 @@ export class ScionPageProfileSettings extends LitElement {
   @state()
   private _autoInjectGcloudADC = false;
 
+  @state()
+  private _isWorkstation = false;
+
   static override styles = css`
     :host {
       display: block;
@@ -175,9 +178,11 @@ export class ScionPageProfileSettings extends LitElement {
         const data = (await res.json()) as {
           gcloudADCAvailable?: boolean;
           autoInjectGcloudADC?: boolean;
+          workstation?: boolean;
         };
         this._gcloudADCAvailable = data.gcloudADCAvailable ?? false;
         this._autoInjectGcloudADC = data.autoInjectGcloudADC ?? false;
+        this._isWorkstation = data.workstation ?? false;
       }
     } catch {
       // Non-critical — leave defaults
@@ -229,11 +234,14 @@ export class ScionPageProfileSettings extends LitElement {
     const enabled = target.checked;
     this._autoInjectGcloudADC = enabled;
     try {
-      await apiFetch('/api/v1/system/workstation-settings', {
+      const res = await apiFetch('/api/v1/system/workstation-settings', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ auto_inject_gcloud_adc: enabled }),
       });
+      if (!res.ok) {
+        throw new Error('Failed to update workstation settings');
+      }
     } catch {
       // Revert on failure
       this._autoInjectGcloudADC = !enabled;
@@ -313,7 +321,7 @@ export class ScionPageProfileSettings extends LitElement {
         ${this._renderPermissionStatus()}
       </div>
 
-      ${this._gcloudADCAvailable ? html`
+      ${this._gcloudADCAvailable && this._isWorkstation ? html`
         <div class="settings-card">
           <h2 class="section-title">
             <sl-icon name="cloud"></sl-icon>


### PR DESCRIPTION
## Addresses unresolved review feedback from #760

**Backend:** mutex lock on PATCH, ErrNotExist-only silent handling, direct boolean assignment, Workstation field in status
**Frontend:** res.ok check in toggle, GCP section gated on _gcloudADCAvailable && _isWorkstation (never shown in hosted mode)