### PR TITLE
docs: rework templates page around roles and skills

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -167,11 +167,11 @@ export default defineConfig({
 				},
 				{
 					label: 'Technical Reference',
-					autogenerate: { directory: 'reference' },
+					items: [{ autogenerate: { directory: 'reference' } }],
 				},
 				{
 					label: 'Contributing',
-					autogenerate: { directory: 'contributing' },
+					items: [{ autogenerate: { directory: 'contributing' } }],
 				},
 			],
 		}),

--- a/docs-site/src/content/docs/local/skills.md
+++ b/docs-site/src/content/docs/local/skills.md
@@ -7,7 +7,7 @@ A **skill** is a reusable, harness-agnostic instruction snippet — a folder con
 
 Scion supports two ways to deliver skills to agents:
 
-- **Template-mounted skills** — skill folders committed inside a template's `skills/` directory. These travel with the template and require no Hub. See [Working with Templates & Harnesses](/scion/local/templates/#skills).
+- **Template-mounted skills** — skill folders committed inside a template's `skills/` directory. These travel with the template and require no Hub. See [Templates & Roles](/scion/local/templates/#skills).
 - **The Skill Bank** — a Hub-backed registry that lets you publish versioned skills once and reference them by URI from any template or agent, with semantic-version resolution, content-hash caching, and federation across external registries.
 
 This page covers the Skill Bank: how to author, publish, version, and consume skills with the `scion skills` command group. For Hub-side registry administration and federation, see [Skill Registry & Federation](/scion/hosted/single-node/skill-registry/).
@@ -243,5 +243,5 @@ A skill supplied by a template always takes precedence over a platform skill of 
 ## See also
 
 - [Skill Registry & Federation](/scion/hosted/single-node/skill-registry/) — Hub-side registry administration, external registries, and trust/pinning.
-- [Working with Templates & Harnesses](/scion/local/templates/#skills) — template-mounted skills.
+- [Templates & Roles](/scion/local/templates/#skills) — template-mounted skills.
 - [Scion CLI Reference](/scion/reference/cli/#scion-skills) — the full `scion skills` command reference.

--- a/docs-site/src/content/docs/local/templates.md
+++ b/docs-site/src/content/docs/local/templates.md
@@ -1,92 +1,55 @@
 ---
-title: Working with Templates & Harnesses
+title: Templates & Roles
+description: Define reusable, harness-agnostic agent roles with Scion templates, compose them with skills, and manage them locally or through a Hub.
 ---
 
-Scion separates the **role** of an agent (what it does) from its **execution mechanics** (how it runs). This is achieved through two complementary concepts: **Templates** and **Harness-Configs**.
+A **template** defines an agent's *role* — its purpose, instructions, and persona — as a small directory of files you can version, share, and reuse. Templates are **harness-agnostic**: the same `code-reviewer` role can run on Claude, Gemini, or any other supported harness. The harness-specific mechanics (container image, concrete model, auth) live separately in a **harness-config**, so a template stays portable across backends.
 
-## Core Concepts
+Templates work hand-in-hand with **skills** — reusable instruction snippets a template can bundle or pull from the [Skill Bank](/scion/local/skills/). A role is the "who"; skills are the "how-to" capabilities you graft onto it.
 
-### 1. Templates (The "Role")
-A template defines the agent's purpose, personality, and instructions. It is **harness-agnostic**, meaning a "Code Reviewer" template can theoretically run on Claude, Gemini, or any other LLM.
+:::note
+Looking for a real-world set of roles? The [scion-frontiers/agent-team](https://github.com/scion-frontiers/agent-team) repository is a ready-to-use library of templates (`coordinator`, `developer`, `architect`, `code-reviewer`, `doc-writer`, …) and shared skills. It is referenced throughout this page as a practical example.
+:::
 
-A template typically contains:
-- `scion-agent.yaml`: The agent definition (resources, env vars).
-- `agents.md`: Operational instructions for the agent.
-- `system-prompt.md`: The core persona and role definition.
-- `home/`: Optional portable configuration files (e.g., linter configs).
+## What a template is
 
-### 2. Harness-Configs (The "Mechanics")
-A harness-config defines the runtime environment and tool-specific settings. It includes the base files required by the underlying tool (e.g., `.claude.json` for Claude, `.gemini/settings.json` for Gemini).
-
-Harness-configs live in `~/.scion/harness-configs/` and contain:
-- `config.yaml`: Runtime parameters (container image, model, model aliases, auth).
-- `home/`: Base files that are copied to the agent's home directory.
-
-> **Important**: Harness-specific settings — container image, concrete model names, and authentication type — belong in the harness-config, not in the template. Templates should remain harness-agnostic so they can work across different LLM backends.
-
-### 3. Composition
-When you create an agent, Scion composes the final environment by layering:
-1.  **Harness-Config Base Layer**: The foundation (e.g., Gemini CLI settings).
-2.  **Template Overlay**: The role definition (prompts, instructions).
-3.  **Profile/Runtime Overrides**: User-specific tweaks.
-
-## Creating an Agent
-
-To create an agent, you specify both a template and a harness-config.
-
-```bash
-# Explicitly specify both
-scion create my-agent --template code-reviewer --harness-config gemini
-
-# Use the template's default harness-config (if defined)
-scion create my-agent --template code-reviewer
-
-# Use the system default harness-config (from settings.yaml)
-scion create my-agent --template code-reviewer
-```
-
-### Resolution Order
-Scion determines which harness-config to use in this order:
-1.  CLI flag: `--harness-config`
-2.  Template default: `default_harness_config` in `scion-agent.yaml`
-3.  System default: `default_harness_config` in global `settings.yaml`
-
-## Managing Templates
-
-### Template Bootstrapping
-
-Local agent templates are automatically bootstrapped into the Hub database during server startup. This ensures that all defined templates are consistently available across the system, allowing for seamless deployment without manual importing steps.
-
-### Template Traceability
-
-To provide clear visibility into the exact configuration version associated with each agent, Scion captures and displays template IDs and hashes. When you view an agent's details in the CLI (`scion list`, `scion info`) or the Web UI, you can see the precise template version that was used to provision it.
-
-### Structure of a Template
-A typical template directory looks like this:
+A template is a directory. Its **name is the directory name** — there is no `name` field to keep in sync. A typical template looks like this:
 
 ```text
-my-template/
-├── scion-agent.yaml      # Configuration
-├── agents.md             # Instructions
-├── system-prompt.md      # Persona
-└── home/                 # Portable files (optional)
-    └── .config/
-        └── my-tool.conf
+code-reviewer/
+├── scion-agent.yaml     # role configuration (the only file Scion parses)
+├── agents.md            # operational instructions for the agent
+├── system-prompt.md     # the core persona / role definition
+├── home/                # optional: portable dotfiles copied into the agent's home
+│   └── .config/
+│       └── my-tool.conf
+└── skills/              # optional: template-mounted skills (see Skills, below)
+    └── review-checklist/
+        └── SKILL.md
 ```
 
-**`scion-agent.yaml` Example:**
+Only `scion-agent.yaml` is required for Scion to recognize the directory as a template. Everything else is referenced *from* that file.
+
+### `scion-agent.yaml`
+
+The config file drives the role. Fields that point at content — `agent_instructions`, `system_prompt` — accept **either a filename** (resolved relative to the template directory) **or inline text**. The convention is to keep prose in separate `.md` files:
 
 ```yaml
 schema_version: "1"
-name: code-reviewer
-description: "Thorough code review agent"
+description: "Senior code reviewer — correctness, readability, security, performance"
 
-agent_instructions: agents.md
+agent_instructions: agents.md      # file reference (or inline text)
 system_prompt: system-prompt.md
-default_harness_config: gemini
+
+default_harness_config: claude     # harness-config to use when none is given
 
 env:
   REVIEW_STRICTNESS: high
+
+model: large                       # portable size alias — see Model size aliases
+
+skills:
+  - uri: "gh://scion-frontiers/agent-team/pr-code-review"
 
 resources:
   requests:
@@ -94,32 +57,247 @@ resources:
     memory: "512Mi"
 ```
 
-### Template Commands
+Common fields:
+
+| Field | Purpose |
+| :--- | :--- |
+| `schema_version` | Schema marker; use `"1"`. |
+| `description` | Human-readable summary of the role. |
+| `agent_instructions` | Path to (or inline) operational instructions, mounted as the harness's agent instructions file. |
+| `system_prompt` | Path to (or inline) the system prompt / persona. |
+| `default_harness_config` | The harness-config to use when the user does not pass one. |
+| `model` | Model **size alias** (`small`, `medium`, `large`, `extra-large`) — see [Model size aliases](#model-size-aliases). |
+| `skills` | Skill references to resolve at provision time — see [Skills](#skills). |
+| `env` | Environment variables for the agent. |
+| `resources` | CPU/memory requests and limits. |
+| `mcp_servers` | MCP server definitions, translated per harness. |
+| `secrets` | Secrets the agent requires. |
+| `volumes`, `services`, `max_turns`, `max_duration`, `telemetry`, `kubernetes` | Further runtime knobs. |
+
+:::tip
+Top-level keys accept **either hyphens or underscores** — `default-harness-config` and `default_harness_config` are equivalent. Underscored form is canonical.
+:::
+
+:::caution
+Keep harness-specific settings **out** of the template. `image`, `auth_selectedType`, and concrete `model` names (e.g. `opus`, `gemini-pro`) are still accepted for backward compatibility but emit a deprecation warning — they belong in a [harness-config](#harness-configs) so the template stays portable. The legacy `harness` field is rejected outright; use `default_harness_config` or the `--harness-config` flag instead.
+:::
+
+## Creating an agent from a template
+
+You reference a template by name (or by path/URI) with the `--type` / `-t` flag:
 
 ```bash
-# List available templates
-scion templates list
+# Provision and launch an agent from the code-reviewer template
+scion start my-review my task... --type code-reviewer
 
-# Create a new template
-scion templates create my-new-role
+# Explicitly choose the harness-config as well
+scion start my-review --type code-reviewer --harness-config gemini
 
-# Clone an existing template
-scion templates clone code-reviewer my-custom-reviewer
-
-# Import definitions from Claude or Gemini sub-agents
-scion templates import .claude/agents/code-reviewer.md
-
-# Delete a template
-scion templates delete my-old-template
+# Provision without starting (writes the agent dir + prompt.md for later)
+scion create my-review my task... --type code-reviewer
 ```
 
-## Managing Harness-Configs
+`--type` also accepts an **absolute path** or a **remote URI**, so you can run a template straight from a repository without importing it first:
 
-Harness-configs are directories stored in `~/.scion/harness-configs/` (global) or `.scion/harness-configs/` (project-level).
+```bash
+# Run a role directly from GitHub (deep path into the agent-team repo)
+scion start coord --type gh://scion-frontiers/agent-team/templates/coordinator
 
-### Model Size Aliases
+# Run from a locally cloned checkout
+scion start coord --type ./templates/coordinator
+```
 
-Templates can use abstract **model size aliases** (`small`, `medium`, `large`) in their `model` field instead of concrete, provider-specific model names. Each harness-config defines how these aliases map to real models via the `model_aliases` field:
+### Which harness-config is used
+
+When you do not pass `--harness-config`, Scion resolves it in this order:
+
+1. **CLI flag** — `--harness-config` (alias `--harness`).
+2. **Template default** — `default_harness_config` in the template's `scion-agent.yaml`.
+3. **System default** — `default_harness_config` in the global `settings.yaml`.
+
+## Template composition & inheritance
+
+Every non-`default` template automatically **inherits the `default` template as a base layer**. When an agent is provisioned, Scion builds a chain — `default` first, then your template — and layers them:
+
+- **Config** is merged field-by-field (`MergeScionConfig`): your template's values override the base, maps like `env` and `mcp_servers` are unioned, and `skills` are **appended** (so base skills are kept and yours are added).
+- **Content references** (`agents.md`, `system-prompt.md`) are resolved by walking the chain from most-specific to least-specific, so a file inherited from the base is still found even if your template doesn't redefine it.
+- **`home/` files** from the base are copied first, then overlaid by your template's `home/`.
+
+This is why a minimal template only needs a `scion-agent.yaml` plus the files it wants to override — common dotfiles and defaults come from `default` for free.
+
+The final composition layers on top of the chosen harness-config:
+
+1. **Harness-config base layer** — runtime mechanics (image, model aliases, auth, base tool files).
+2. **Template overlay** — the role (config, prompts, instructions, skills).
+3. **Runtime overrides** — CLI flags and per-agent tweaks.
+
+## Skills
+
+Templates and skills are complementary: a template gives an agent its role, and skills give it reusable, harness-agnostic capabilities that are mounted into the harness's skills directory at provision time. There are **two ways** a template delivers skills.
+
+### 1. Template-mounted skills
+
+Commit skill folders directly inside the template's `skills/` directory. They travel with the template and need no Hub:
+
+```text
+web-builder/
+├── scion-agent.yaml
+├── agents.md
+└── skills/
+    ├── gcs-static-site/
+    │   └── SKILL.md
+    └── gcs-auth-proxy/
+        ├── SKILL.md
+        └── scripts/
+            └── main.go
+```
+
+When the template chain is provisioned, Scion collects the skills from each template and mounts them into the harness-specific location:
+
+| Harness | Skills directory |
+| :--- | :--- |
+| Claude | `.claude/skills/` |
+| Gemini | `.gemini/skills/` |
+
+When multiple templates are chained, skills from later templates overlay earlier ones.
+
+### 2. Skill Bank references
+
+Instead of bundling files, declare skills by **URI** in the `skills:` list. These are resolved at provision time from the [Skill Bank](/scion/local/skills/) (a Hub-backed registry) or a federated source such as GitHub:
+
+```yaml
+# templates/coordinator/scion-agent.yaml
+schema_version: "1"
+description: "Project coordinator — delegates implementation, drives progress"
+agent_instructions: agents.md
+system_prompt: system-prompt.md
+
+skills:
+  - uri: "gh://scion-frontiers/agent-team/agent-recovery"
+  - uri: deploy-checklist                       # bare name → latest, default search order
+  - uri: "skill://scion/global/notes@^1.2"      # semver range
+  - uri: "gh://my-org/skills/linting"           # federated GitHub source
+    as: lint-rules                              # mount under a different name
+  - uri: "skill://scion/user/alice/scratch"
+    optional: true                              # don't fail provisioning if unresolved
+```
+
+Each entry supports `uri` (required), `as` (mount under a different name), and `optional` (continue provisioning if it can't be resolved). For the full URI grammar, scopes, versioning, and the `scion skills` publishing workflow, see [Skills — Authoring & Publishing](/scion/local/skills/) and [Skill Registry & Federation](/scion/hosted/single-node/skill-registry/).
+
+:::tip
+A skill supplied by a template always takes precedence over a **platform skill** (one embedded in the Scion binary and injected automatically) of the same name.
+:::
+
+### The `team-creation` skill
+
+Scion ships a built-in **`team-creation`** skill for generating coordinated multi-agent template sets. It scaffolds orchestrator-worker patterns with best-practice guidance for agent-to-agent communication and template structure — a fast way to bootstrap a whole team of roles rather than hand-writing each template.
+
+## Built-in vs custom templates
+
+- **`default`** — the built-in template shipped inside the Scion binary. It seeds common `home/` dotfiles and the baseline `agents.md` status-signaling instructions, and it is the base layer every other template inherits. It is **protected** — it cannot be deleted. Use `scion templates update-default` to refresh it from the binary (`--force` to overwrite an existing copy).
+- **Custom templates** — anything you create, clone, or import. They live in one of two scopes.
+
+### Template locations & resolution order
+
+| Scope | Location |
+| :--- | :--- |
+| **Project** | `.scion/templates/<name>/` (in the current project) |
+| **Global** | `~/.scion/templates/<name>/` (your machine) |
+
+When you reference a template by bare name, Scion searches in this order and uses the first match:
+
+1. **Remote URI** (GitHub URL / deep path, archive, or rclone) — fetched and cached.
+2. **Absolute path** to a template directory.
+3. **Project** templates (`.scion/templates/`).
+4. **Global** templates (`~/.scion/templates/`).
+
+When connected to a Hub, templates can also resolve from the Hub (project scope, then global scope). If a name matches in several locations, the CLI prompts you to choose; the `--local`, `--hub`, and `--global` flags narrow the search.
+
+## The `scion templates` CLI
+
+The command group is `scion templates` (singular `scion template` is an accepted alias).
+
+### Local management
+
+```bash
+# List available templates (local, and Hub when connected), grouped by scope
+scion templates list
+
+# Show a template's resolved configuration
+scion templates show code-reviewer
+
+# Create a new template (seeded from the default template)
+scion templates create my-new-role
+
+# Create in global scope instead of the project
+scion --global templates create my-new-role
+
+# Clone an existing template (local or Hub source) to a new local one
+scion templates clone code-reviewer my-custom-reviewer
+
+# Delete a template (alias: rm)
+scion templates delete my-old-role
+
+# Refresh the built-in default template from the binary
+scion templates update-default --force
+```
+
+### Importing existing agents
+
+`scion templates import` converts agent definitions into Scion templates and writes them into your project (or global) templates directory. It understands Claude Code sub-agents (`.claude/agents/*.md`), Gemini CLI agents (`.gemini/agents/*.md`), and existing Scion templates (copied directly, no conversion):
+
+```bash
+# Import a single Claude sub-agent
+scion templates import .claude/agents/code-reviewer.md
+
+# Auto-discover and import everything under a project root
+scion templates import --all .
+
+# Import Scion templates from another repo (deep GitHub path)
+scion templates import --all https://github.com/scion-frontiers/agent-team/tree/main/templates
+
+# Preview without writing
+scion templates import --dry-run .claude/agents/code-reviewer.md
+```
+
+Useful flags: `--all` (import every discovered agent), `--harness`/`-H` (force `claude`/`gemini` detection), `--name` (rename a single import), `--force` (overwrite), `--dry-run` (preview).
+
+### Hub commands
+
+When a Hub is enabled, these commands move templates between the local filesystem and the Hub:
+
+```bash
+# Upload a local template to the Hub (creates or updates; only changed files upload)
+scion templates sync code-reviewer          # alias: scion templates push
+
+# Sync every local project template at once
+scion templates sync --all
+
+# Sync to global scope, or under a different Hub name
+scion --global templates sync code-reviewer
+scion templates sync code-reviewer --name team-reviewer
+
+# Download a Hub template to the local filesystem
+scion templates pull code-reviewer --to .scion/templates/code-reviewer
+
+# Compare local vs Hub (synced / out of date / local-only / hub-only)
+scion templates status
+```
+
+`sync` is content-aware: it hashes files and uploads only what changed, and templates carry a content hash for traceability (visible in `scion templates list`, `scion templates show`, and the Web UI). Beyond the CLI, a connected Hub can import a whole repository of templates server-side via the **Load Templates** action in the Web UI, and imported templates can be browsed and edited directly in the dashboard.
+
+For the condensed command list, see the [CLI reference](/scion/reference/cli/#template-management).
+
+## Harness-configs
+
+A **harness-config** is the counterpart to a template: it holds the runtime *mechanics* a template deliberately omits, so roles stay harness-agnostic. Harness-configs live in `~/.scion/harness-configs/` (global) or `.scion/harness-configs/` (project) and contain:
+
+- `config.yaml` — runtime parameters (container image, model aliases, auth type).
+- `home/` — base files copied into the agent's home directory (e.g. `.claude.json`, `.gemini/settings.json`).
+
+### Model size aliases
+
+Templates should express model choice with abstract **size aliases** — `small`, `medium`, `large`, `extra-large` (`xl`) — rather than provider model names. Each harness-config maps those aliases to real models:
 
 ```yaml
 # ~/.scion/harness-configs/claude/config.yaml
@@ -141,121 +319,34 @@ model_aliases:
   large: gemini-pro
 ```
 
-A template can then use the alias:
+A template that sets `model: large` then resolves to `opus` under Claude and `gemini-pro` under Gemini — the same role, portable across harnesses. Concrete model names still pass through unchanged (for backward compatibility) but tie the template to one harness.
 
-```yaml
-# .scion/templates/docs-writer/scion-agent.yaml
-schema_version: "1"
-description: "Documentation writer"
-model: large    # resolved to "opus" with Claude, "gemini-pro" with Gemini
-```
+### Customizing and creating variants
 
-This keeps templates portable across harnesses. Concrete model names still work and are passed through unchanged for backward compatibility, but they tie the template to a specific harness.
-
-### Customizing a Harness-Config
-To change the default model or customize model aliases for a specific harness, edit the files directly in the harness-config directory.
-
-**Example: Changing the Gemini model alias mapping**
-Edit `~/.scion/harness-configs/gemini/config.yaml`:
-
-```yaml
-harness: gemini
-model_aliases:
-  small: gemini-flash-lite
-  medium: gemini-flash
-  large: gemini-2-pro    # upgraded from gemini-pro
-# ...
-```
-
-**Example: Adding a persistent CLI flag**
-Edit `~/.scion/harness-configs/gemini/home/.gemini/settings.json`.
-
-### Creating Variants
-You can create custom variants of harness-configs by copying the directory.
+Edit the files in a harness-config directory to change defaults (for example, remap `large` to a newer model, or add a persistent CLI flag in `home/.gemini/settings.json`). Copy the directory to make a variant:
 
 ```bash
 cp -r ~/.scion/harness-configs/gemini ~/.scion/harness-configs/gemini-experimental
+scion start test-agent --type default --harness-config gemini-experimental
 ```
 
-Now you can use this variant:
-```bash
-scion create test-agent --harness-config gemini-experimental
-```
-
-### Resetting Defaults
-If you mess up a harness-config, you can restore the factory defaults:
+If you break a stock harness-config, restore the factory defaults:
 
 ```bash
 scion harness-config reset gemini
 ```
 
-## Skills
+## Sharing templates
 
-Templates can define **skills** — reusable, harness-agnostic instruction snippets that are automatically mounted into the appropriate harness-specific directory during agent provisioning.
+A template is just a directory, so sharing is straightforward:
 
-:::note
-This section covers **template-mounted** skills that ship inside a template. To publish versioned skills to a Hub-backed registry and reference them by URI from any template, see [Skills — Authoring & Publishing](/scion/local/skills/) and [Skill Registry & Federation](/scion/hosted/single-node/skill-registry/).
-:::
+- **Version it in a repo.** Commit templates under `.scion/templates/` (or a dedicated repo like [scion-frontiers/agent-team](https://github.com/scion-frontiers/agent-team)) and reference them by `gh://` URI or import them with `scion templates import`.
+- **Publish to a Hub.** `scion templates sync` uploads a template so teammates on the same Hub can create agents from it by name.
+- **Bundle capabilities as skills.** Pull shared behavior out into skills — either template-mounted or published to the [Skill Bank](/scion/local/skills/) — so multiple roles can reuse them.
 
-When an agent is created, Scion collects skills from each template in the chain and mounts them into the correct location for the harness:
+## See also
 
-| Harness | Skills Directory |
-| :--- | :--- |
-| Claude | `.claude/skills/` |
-| Gemini | `.gemini/skills/` |
-
-This allows you to package domain-specific expertise (e.g., coding standards, review checklists) as portable skill files that any template can reference.
-
-### Defining Skills in a Template
-
-Place skill files in the template's `skills/` directory:
-
-```text
-my-template/
-├── scion-agent.yaml
-├── agents.md
-└── skills/
-    └── my-skill/
-        └── SKILL.md
-```
-
-When multiple templates are chained, skills from later templates overlay earlier ones.
-
-### The `team-creation` Skill
-
-Scion includes a specialized built-in skill called `team-creation`. This skill is designed for generating coordinated multi-agent template sets. It simplifies the creation of orchestrator-worker patterns by providing best-practice guidance for agent-to-agent communication and template structure, allowing an agent to quickly scaffold a team of specialized sub-agents.
-
-## Template Importing (Hub Integration)
-
-When connected to a Hub, you can import templates into your projects. This process is now a direct, high-performance server-side operation that provides immediate feedback, replacing the older container-based sync mechanism.
-
-### Direct Server-Side Import
-
-You can initiate a template import directly from the Web UI using the **Load Templates** button on the project details page, or programmatically via the Hub API:
-
-```
-POST /api/v1/projects/{projectId}/import-templates
-```
-
-*(Note: The legacy `sync-templates` endpoint has been removed.)*
-
-### Supported Sources and Deep Paths
-
-The import system supports a wide variety of sources, allowing you to pull templates from specific locations:
-
-- **Git Repositories:** Standard HTTPS clones are supported.
-- **Deep GitHub Paths:** You can import from specific subdirectories within a repository (e.g., `https://github.com/my-org/templates/tree/main/path/to/templates`). This relies on GitHub's tarball API via HTTPS for high reliability in restricted environments without requiring `svn` or `git` binaries.
-- **Archives:** Direct import from `.zip` or `.tar.gz` archive URLs.
-- **Rclone URIs:** Support for importing from cloud storage via rclone URIs (e.g., `:gcs:my-bucket/templates`).
-
-### Native Scion Templates
-
-The import process automatically detects and performs direct "copy" imports of native Scion templates (those containing a `scion-agent.yaml`), bypassing any conversion steps needed for generic templates.
-
-### Automatic Sync on Hub Startup
-
-Local templates are automatically bootstrapped into the Hub during server startup. This ensures all defined templates are consistently available across distributed brokers without manual intervention.
-
-### Web UI Management
-
-Once imported, templates can be directly managed via the Scion Web UI. The dashboard provides comprehensive **template file browsing, inline editing (with Markdown preview), and upload capabilities**, allowing you to refine agent roles and instructions without leaving the browser.
+- [Skills — Authoring & Publishing](/scion/local/skills/) — author, version, and publish reusable skills.
+- [Skill Registry & Federation](/scion/hosted/single-node/skill-registry/) — Hub-side registry administration and external sources.
+- [Scion CLI Reference](/scion/reference/cli/#template-management) — the full `scion templates` command list.
+- [scion-frontiers/agent-team](https://github.com/scion-frontiers/agent-team) — a real-world library of roles and skills.

--- a/docs-site/src/content/docs/reference/cli.md
+++ b/docs-site/src/content/docs/reference/cli.md
@@ -240,19 +240,29 @@ Manages shared directories for agents within a project.
 
 ### `scion templates`
 
-Manages agent templates.
+Manages agent templates. `scion template` (singular) is an accepted alias. Scope defaults to the project; add the root `--global` flag to target global templates.
 
-- `list`: List available templates.
-- `show <name>`: Show configuration of a template.
-- `create <name> [--harness <type>]`: Create a new template.
-- `clone <src> <dest>`: Clone a template.
+- `list`: List available templates (local, and Hub when connected), grouped by scope.
+- `show <name>`: Show a template's resolved configuration.
+    - Flags: `--local` (search local only), `--hub` (search Hub only).
+- `create <name>`: Create a new template (seeded from the `default` template).
+- `clone <src> <dest>`: Clone an existing template (local or Hub source) to a new local one.
+    - Flags: `--local`, `--hub` (restrict where the source is searched).
 - `delete <name>` (alias `rm`): Delete a template.
-- `import <source>`: Import agent definitions (from Claude/Gemini) as templates.
+    - Flags: `--local`, `--hub`.
+- `import <source>`: Import agent definitions (Claude/Gemini sub-agents or Scion templates) into your templates directory.
+    - Flags: `--all` (import every discovered agent), `-H, --harness <type>` (force `claude`/`gemini`), `--name <name>` (rename a single import), `--force` (overwrite), `--dry-run` (preview).
 - `update-default`: Update the global default template with the latest from the binary.
     - Flags:
         - `--force`: Overwrite the existing default template if it already exists.
-- `sync [--all]`: Sync project-level templates with the Hub. Use `--all` to sync all templates at once.
+
+Hub-only commands (require an enabled Hub):
+
+- `sync [template]` (alias `push`): Create or update a template in the Hub; only changed files are uploaded. Use `--all` to sync every local template, or `--name <name>` to sync under a different Hub name.
+- `pull <name>`: Download a template from the Hub to the local filesystem. Use `--to <path>` for a custom destination.
 - `status`: Show the sync status of templates relative to the Hub.
+
+See [Templates & Roles](/scion/local/templates/) for the full guide.
 
 ## Skill Bank
 


### PR DESCRIPTION
Rewrite local/templates.md from scratch based on current code:
- template = harness-agnostic role dir; name derived from folder
- scion-agent.yaml recognized fields, file-or-inline content resolution, hyphen/underscore key normalization, deprecated harness-specific fields
- template composition/inheritance (default base layer, MergeScionConfig, content-chain resolution, home overlay)
- two skill delivery paths (template-mounted skills/ dir vs Skill Bank URI refs) with cross-links to skills.md and skill-registry.md
- built-in default vs custom templates, project/global locations, and the full local/remote/Hub resolution order
- complete `scion templates` CLI incl. import, sync/push, pull, status
- harness-configs and model size aliases
- reference scion-frontiers/agent-team as the real-world example

Also update reference/cli.md template section (add show/clone/delete/import flags, pull, push alias, singular alias) and fix skills.md link text.

Divergence flagged: agent creation uses `--type`/`-t`, not `--template`. The previous templates page documented `--template`, which the CLI does not accept (cmd/start.go, cmd/create.go). Corrected here.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
