### PR TITLE
fix: accept registered-but-not-active plugins in HasPlugin and ListPlugins

### DIFF
--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -561,13 +561,21 @@ func (m *Manager) GetPluginConfig(pluginType, name string) map[string]string {
 	return nil
 }
 
-// HasPlugin returns true if a plugin with the given type and name is loaded.
+// HasPlugin returns true if a plugin with the given type and name is loaded
+// or registered (has config). A plugin may be registered via settings.yaml
+// but not yet active if its binary failed to load or the connection dropped.
 func (m *Manager) HasPlugin(pluginType, name string) bool {
 	key := pluginType + ":" + name
 	m.mu.RLock()
 	_, ok := m.clients[key]
 	if !ok {
 		_, ok = m.grpcAdapters[key]
+	}
+	if !ok {
+		_, ok = m.configs[key]
+	}
+	if !ok {
+		_, ok = m.pluginEntries[key]
 	}
 	m.mu.RUnlock()
 	return ok
@@ -581,12 +589,14 @@ func (m *Manager) IsSelfManaged(pluginType, name string) bool {
 	return m.selfManaged[key]
 }
 
-// ListPlugins returns a list of all loaded plugin keys ("type:name").
+// ListPlugins returns a list of all loaded or registered plugin keys ("type:name").
+// This includes plugins whose config was registered but whose process is not
+// currently active (e.g. binary failed to load).
 func (m *Manager) ListPlugins() []string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	seen := make(map[string]bool, len(m.clients)+len(m.grpcAdapters))
+	seen := make(map[string]bool, len(m.clients)+len(m.grpcAdapters)+len(m.configs)+len(m.pluginEntries))
 	keys := make([]string, 0, len(m.clients)+len(m.grpcAdapters))
 	for k := range m.clients {
 		if !seen[k] {
@@ -595,6 +605,18 @@ func (m *Manager) ListPlugins() []string {
 		}
 	}
 	for k := range m.grpcAdapters {
+		if !seen[k] {
+			keys = append(keys, k)
+			seen[k] = true
+		}
+	}
+	for k := range m.configs {
+		if !seen[k] {
+			keys = append(keys, k)
+			seen[k] = true
+		}
+	}
+	for k := range m.pluginEntries {
 		if !seen[k] {
 			keys = append(keys, k)
 			seen[k] = true

--- a/pkg/plugin/manager_test.go
+++ b/pkg/plugin/manager_test.go
@@ -41,6 +41,40 @@ func TestManagerHasPlugin_NotLoaded(t *testing.T) {
 	assert.False(t, mgr.HasPlugin(PluginTypeBroker, "nats"))
 }
 
+func TestManagerHasPlugin_RegisteredButNotActive(t *testing.T) {
+	mgr := NewManager(nil)
+
+	mgr.mu.Lock()
+	mgr.configs["broker:telegram"] = DiscoveredPlugin{
+		Name: "telegram",
+		Type: PluginTypeBroker,
+		Config: map[string]string{
+			"config_file": "/etc/scion/telegram.yaml",
+		},
+	}
+	mgr.mu.Unlock()
+
+	assert.True(t, mgr.HasPlugin(PluginTypeBroker, "telegram"),
+		"HasPlugin should return true for a registered-but-not-active plugin")
+	assert.False(t, mgr.HasPlugin(PluginTypeBroker, "discord"),
+		"HasPlugin should return false for a completely unknown plugin")
+}
+
+func TestManagerListPlugins_IncludesRegistered(t *testing.T) {
+	mgr := NewManager(nil)
+
+	mgr.mu.Lock()
+	mgr.configs["broker:telegram"] = DiscoveredPlugin{
+		Name: "telegram",
+		Type: PluginTypeBroker,
+	}
+	mgr.mu.Unlock()
+
+	plugins := mgr.ListPlugins()
+	assert.Contains(t, plugins, "broker:telegram",
+		"ListPlugins should include registered-but-not-active plugins")
+}
+
 func TestManagerGet_NotLoaded(t *testing.T) {
 	mgr := NewManager(nil)
 


### PR DESCRIPTION
Fixes 404 'integration not found' when saving config for a registered but not yet started plugin. HasPlugin and ListPlugins now check m.clients, m.grpcAdapters, m.configs, and m.pluginEntries