### PR TITLE
fix: store config_file path immutably so PUT /config can always find it

### DIFF
--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -1083,6 +1083,13 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 		}
 	}
 
+	// Preserve the config_file path in the merged map so that
+	// ReplaceBrokerConfig doesn't overwrite dp.Config with a map that
+	// lacks the key, which would cause subsequent reloads to lose it.
+	if configFile != "" {
+		merged["config_file"] = configFile
+	}
+
 	if err := mgr.ReplaceBrokerConfig(name, merged); err != nil {
 		if mgr.IsSelfManaged("broker", name) {
 			slog.Warn("ReplaceBrokerConfig failed for self-managed plugin, trying Reconnect",

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -72,6 +72,7 @@ type IntegrationManager interface {
 	ListPlugins() []string
 	HasPlugin(pluginType, name string) bool
 	GetPluginConfig(pluginType, name string) map[string]string
+	GetPluginConfigFile(pluginType, name string) string
 	IsSelfManaged(pluginType, name string) bool
 	GetDeploymentMode(pluginType, name string) plugin.DeploymentMode
 	ConfigureBroker(name string, extra map[string]string) error
@@ -396,7 +397,10 @@ func (s *Server) resolveIntegrationSettings(ctx context.Context, mgr Integration
 		return runtimeCfg
 	}
 
-	configFile := runtimeCfg["config_file"]
+	configFile := mgr.GetPluginConfigFile("broker", name)
+	if configFile == "" {
+		configFile = runtimeCfg["config_file"]
+	}
 	if configFile != "" {
 		if settings, err := config.ResolvePluginConfig(configFile, nil); err == nil {
 			for k, v := range runtimeCfg {
@@ -484,10 +488,12 @@ func (s *Server) handleUpdateIntegrationConfig(w http.ResponseWriter, r *http.Re
 			provider = pgProvider
 			haConfigTx = haTx
 		} else {
-			pluginCfg := mgr.GetPluginConfig("broker", name)
-			configFile := ""
-			if pluginCfg != nil {
-				configFile = pluginCfg["config_file"]
+			configFile := mgr.GetPluginConfigFile("broker", name)
+			if configFile == "" {
+				pluginCfg := mgr.GetPluginConfig("broker", name)
+				if pluginCfg != nil {
+					configFile = pluginCfg["config_file"]
+				}
 			}
 
 			if configFile == "" {
@@ -1021,9 +1027,10 @@ func (s *Server) getPluginHubCreds(ctx context.Context, name string) map[string]
 func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationManager, name string) error {
 	pluginCfg := mgr.GetPluginConfig("broker", name)
 
-	// Re-read config file if one is configured.
-	configFile := ""
-	if pluginCfg != nil {
+	// Re-read config file if one is configured. Prefer the immutable
+	// configFiles store over the mutable runtime config map.
+	configFile := mgr.GetPluginConfigFile("broker", name)
+	if configFile == "" && pluginCfg != nil {
 		configFile = pluginCfg["config_file"]
 	}
 

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -93,6 +93,17 @@ func (m *mockIntegrationManager) GetPluginConfig(pluginType, name string) map[st
 	return out
 }
 
+func (m *mockIntegrationManager) GetPluginConfigFile(pluginType, name string) string {
+	if pluginType != "broker" {
+		return ""
+	}
+	cfg, ok := m.plugins[name]
+	if !ok {
+		return ""
+	}
+	return cfg["config_file"]
+}
+
 func (m *mockIntegrationManager) IsSelfManaged(pluginType, name string) bool {
 	if pluginType != "broker" {
 		return false

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -210,6 +210,8 @@ func (m *Manager) loadGRPCPlugin(pluginType, name string, entry PluginEntry) err
 	m.pluginEntries[key] = entry
 	if entry.ConfigFile != "" {
 		m.configFiles[key] = entry.ConfigFile
+	} else {
+		delete(m.configFiles, key)
 	}
 	m.mu.Unlock()
 
@@ -306,6 +308,8 @@ func (m *Manager) loadPlugin(dp DiscoveredPlugin) error {
 	m.configs[key] = dp
 	if cf := dp.Config["config_file"]; cf != "" {
 		m.configFiles[key] = cf
+	} else {
+		delete(m.configFiles, key)
 	}
 	// Cache the dispensed interface so subsequent Get() calls don't
 	// trigger a second Dispense (which would start another AcceptAndServe

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -37,6 +37,7 @@ type Manager struct {
 	selfManaged     map[string]bool             // "type:name" -> true if self-managed
 	grpcAdapters    map[string]GRPCBrokerClient // "type:name" -> gRPC adapter
 	configs         map[string]DiscoveredPlugin // "type:name" -> original config (for reconnection)
+	configFiles     map[string]string           // "type:name" -> config file path (immutable after load)
 	pluginEntries   map[string]PluginEntry      // "type:name" -> original PluginEntry (for mode resolution)
 	mu              sync.RWMutex
 	logger          *slog.Logger
@@ -58,6 +59,7 @@ func NewManager(logger *slog.Logger) *Manager {
 		selfManaged:     make(map[string]bool),
 		grpcAdapters:    make(map[string]GRPCBrokerClient),
 		configs:         make(map[string]DiscoveredPlugin),
+		configFiles:     make(map[string]string),
 		pluginEntries:   make(map[string]PluginEntry),
 		logger:          logger,
 		brokerCallbacks: &HostCallbacksForwarder{},
@@ -206,6 +208,9 @@ func (m *Manager) loadGRPCPlugin(pluginType, name string, entry PluginEntry) err
 	}
 	m.grpcAdapters[key] = adapter
 	m.pluginEntries[key] = entry
+	if entry.ConfigFile != "" {
+		m.configFiles[key] = entry.ConfigFile
+	}
 	m.mu.Unlock()
 
 	m.logger.Info("Loaded gRPC plugin",
@@ -299,6 +304,9 @@ func (m *Manager) loadPlugin(dp DiscoveredPlugin) error {
 	m.clients[key] = client
 	m.selfManaged[key] = dp.SelfManaged
 	m.configs[key] = dp
+	if cf := dp.Config["config_file"]; cf != "" {
+		m.configFiles[key] = cf
+	}
 	// Cache the dispensed interface so subsequent Get() calls don't
 	// trigger a second Dispense (which would start another AcceptAndServe
 	// on the same MuxBroker stream ID, causing a timeout).
@@ -559,6 +567,16 @@ func (m *Manager) GetPluginConfig(pluginType, name string) map[string]string {
 		return out
 	}
 	return nil
+}
+
+// GetPluginConfigFile returns the config file path for the named plugin.
+// Unlike GetPluginConfig, this value is set once at load time and is not
+// affected by ReplaceBrokerConfig overwrites.
+func (m *Manager) GetPluginConfigFile(pluginType, name string) string {
+	key := pluginType + ":" + name
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.configFiles[key]
 }
 
 // HasPlugin returns true if a plugin with the given type and name is loaded
@@ -852,6 +870,7 @@ func (m *Manager) Shutdown() {
 	m.selfManaged = make(map[string]bool)
 	m.grpcAdapters = make(map[string]GRPCBrokerClient)
 	m.configs = make(map[string]DiscoveredPlugin)
+	m.configFiles = make(map[string]string)
 	m.pluginEntries = make(map[string]PluginEntry)
 
 	goplugin.CleanupClients()


### PR DESCRIPTION
ReplaceBrokerConfig was overwriting dp.Config entirely, losing config_file key on every reconfigure. Fix: adds immutable configFiles map set once at load time. All PUT /config handlers now read config_file via GetPluginConfigFile first