### PR TITLE
fix: PUT /config falls back to settings.yaml for installed-but-unloaded plugins

### DIFF
--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -332,23 +332,17 @@ func (s *Server) handleGetIntegration(w http.ResponseWriter, r *http.Request, na
 		// Fallback: plugin may be in settings.yaml but not loaded (e.g. bot_token
 		// was missing at startup so LoadOne failed). Return a stub detail so the
 		// UI can show the configuration form instead of an error toast.
-		if globalDir, err := config.GetGlobalDir(); err == nil {
-			if vs, err := config.LoadSingleFileVersioned(globalDir); err == nil {
-				if vs.Server != nil && vs.Server.Plugins != nil {
-					if _, ok := vs.Server.Plugins.Broker[name]; ok {
-						writeJSON(w, http.StatusOK, IntegrationDetail{
-							Name:     name,
-							Platform: resolvePlatform(name),
-							Settings: map[string]string{},
-							Status: &IntegrationStatus{
-								Connected: false,
-								Message:   "Plugin installed — configure required fields to activate",
-							},
-						})
-						return
-					}
-				}
-			}
+		if installedPluginSettingsEntry(name) != nil {
+			writeJSON(w, http.StatusOK, IntegrationDetail{
+				Name:     name,
+				Platform: resolvePlatform(name),
+				Settings: map[string]string{},
+				Status: &IntegrationStatus{
+					Connected: false,
+					Message:   "Plugin installed — configure required fields to activate",
+				},
+			})
+			return
 		}
 		NotFound(w, "integration")
 		return
@@ -421,9 +415,33 @@ func (s *Server) handleUpdateIntegrationConfig(w http.ResponseWriter, r *http.Re
 	mgr := s.pluginManager
 	s.mu.RUnlock()
 
-	if mgr == nil || !mgr.HasPlugin("broker", name) {
+	if mgr == nil {
 		NotFound(w, "integration")
 		return
+	}
+
+	loaded := mgr.HasPlugin("broker", name)
+	var settingsEntry *config.V1PluginEntry
+	if !loaded {
+		// Mirror handleGetIntegration's fallback: the plugin may be registered
+		// in settings.yaml but not loaded — on a fresh install LoadOne fails
+		// because required fields (e.g. bot_token) don't exist yet. GET already
+		// returns a stub so the UI can show the config form; PUT must accept
+		// that form's submission, otherwise the required fields can never be
+		// saved and the integration can never activate.
+		settingsEntry = installedPluginSettingsEntry(name)
+		if settingsEntry == nil {
+			NotFound(w, "integration")
+			return
+		}
+	}
+
+	isHA := false
+	if loaded {
+		isHA = s.isHAIntegration(mgr, name)
+	} else {
+		pe := plugin.PluginEntry{SelfManaged: settingsEntry.SelfManaged, Mode: settingsEntry.Mode}
+		isHA = pe.ResolvedDeploymentMode() == plugin.DeploymentModeHA
 	}
 
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
@@ -468,7 +486,7 @@ func (s *Server) handleUpdateIntegrationConfig(w http.ResponseWriter, r *http.Re
 		var provider config.IntegrationConfigProvider
 		var haConfigTx *ent.Tx
 
-		if s.isHAIntegration(mgr, name) {
+		if isHA {
 			if !s.requirePostgres(w) {
 				return
 			}
@@ -488,12 +506,17 @@ func (s *Server) handleUpdateIntegrationConfig(w http.ResponseWriter, r *http.Re
 			provider = pgProvider
 			haConfigTx = haTx
 		} else {
-			configFile := mgr.GetPluginConfigFile("broker", name)
-			if configFile == "" {
-				pluginCfg := mgr.GetPluginConfig("broker", name)
-				if pluginCfg != nil {
-					configFile = pluginCfg["config_file"]
+			configFile := ""
+			if loaded {
+				configFile = mgr.GetPluginConfigFile("broker", name)
+				if configFile == "" {
+					pluginCfg := mgr.GetPluginConfig("broker", name)
+					if pluginCfg != nil {
+						configFile = pluginCfg["config_file"]
+					}
 				}
+			} else {
+				configFile = settingsEntry.ConfigFile
 			}
 
 			if configFile == "" {
@@ -552,11 +575,26 @@ func (s *Server) handleUpdateIntegrationConfig(w http.ResponseWriter, r *http.Re
 	// Reconfigure the running integration with updated config.
 	// For HA integrations the DB write + NOTIFY is the reconfigure path —
 	// pushing a hub-side merge over gRPC would race with the DB-backed reload.
-	if !s.isHAIntegration(mgr, name) {
-		if err := s.reconfigureIntegration(r.Context(), mgr, name); err != nil {
-			slog.Error("Failed to reconfigure integration after config update", "plugin", name, "error", err)
-			InternalError(w)
-			return
+	if loaded {
+		if !isHA {
+			if err := s.reconfigureIntegration(r.Context(), mgr, name); err != nil {
+				slog.Error("Failed to reconfigure integration after config update", "plugin", name, "error", err)
+				InternalError(w)
+				return
+			}
+		}
+	} else {
+		// The plugin was installed but never loaded (required fields were
+		// missing at install/startup). Now that config and secrets are saved,
+		// try to activate it. Failure is non-fatal: the config is persisted,
+		// and the plugin will load on the next server restart once all its
+		// required fields are present.
+		if err := s.activateInstalledIntegration(ctx, mgr, name, settingsEntry); err != nil {
+			slog.Warn("Config saved but plugin activation failed (likely still missing required fields)",
+				"plugin", name, "error", err)
+		} else {
+			s.refreshBrokerSpoke(mgr, name)
+			slog.Info("Plugin activated after config update", "plugin", name)
 		}
 	}
 
@@ -838,6 +876,72 @@ func (s *Server) handleListAvailableIntegrations(w http.ResponseWriter, _ *http.
 }
 
 // --- Helpers ---
+
+// installedPluginSettingsEntry returns the settings.yaml broker entry for the
+// named plugin, or nil if the plugin is not registered there. Used as the
+// fallback identity check for plugins that are installed (present in
+// settings.yaml) but not loaded into the manager (LoadOne failed because
+// required fields were missing).
+func installedPluginSettingsEntry(name string) *config.V1PluginEntry {
+	globalDir, err := config.GetGlobalDir()
+	if err != nil {
+		return nil
+	}
+	vs, err := config.LoadSingleFileVersioned(globalDir)
+	if err != nil || vs.Server == nil || vs.Server.Plugins == nil {
+		return nil
+	}
+	entry, ok := vs.Server.Plugins.Broker[name]
+	if !ok {
+		return nil
+	}
+	return &entry
+}
+
+// activateInstalledIntegration loads a plugin that is registered in
+// settings.yaml but not yet running. It builds the same fully-resolved config
+// map that server startup builds — file settings, secret-backend secrets, and
+// hub wiring credentials — so the plugin's Configure call succeeds on load.
+func (s *Server) activateInstalledIntegration(ctx context.Context, mgr IntegrationManager, name string, entry *config.V1PluginEntry) error {
+	merged, err := config.ResolvePluginConfig(entry.ConfigFile, entry.Config)
+	if err != nil {
+		slog.Warn("Failed to resolve config file for plugin activation", "plugin", name, "error", err)
+		merged = make(map[string]string)
+	}
+
+	for _, m := range config.PluginSecretKeyMap[name] {
+		if merged[m.ConfigKey] != "" {
+			continue
+		}
+		if val, err := s.LoadChatIntegrationSecret(ctx, m.SecretKey); err == nil && val != "" {
+			merged[m.ConfigKey] = val
+		}
+	}
+
+	for k, v := range s.getPluginHubCreds(ctx, name) {
+		if v != "" {
+			merged[k] = v
+		}
+	}
+
+	pluginsDir, err := plugin.DefaultPluginsDir()
+	if err != nil {
+		return err
+	}
+
+	return mgr.LoadOne(plugin.PluginTypeBroker, name, plugin.PluginEntry{
+		Path:          entry.Path,
+		Config:        merged,
+		ConfigFile:    entry.ConfigFile,
+		SelfManaged:   entry.SelfManaged,
+		Mode:          entry.Mode,
+		Address:       entry.Address,
+		TLSCertFile:   entry.TLSCertFile,
+		TLSKeyFile:    entry.TLSKeyFile,
+		TLSCAFile:     entry.TLSCAFile,
+		TLSSkipVerify: entry.TLSSkipVerify,
+	}, pluginsDir)
+}
 
 // pluginNameFromKey extracts the plugin name from a "type:name" key,
 // returning only broker plugin names.
@@ -1140,7 +1244,14 @@ func (s *Server) refreshBrokerSpoke(mgr IntegrationManager, name string) {
 		ChannelID: channelID,
 	}
 	if err := fanout.ReplaceSpoke(name, spoke); err != nil {
-		slog.Error("Failed to replace broker spoke", "plugin", name, "error", err)
+		// No existing spoke — the plugin was activated after startup (e.g. it
+		// failed to load at boot and was configured via the admin UI). Add it.
+		if addErr := fanout.AddSpoke(spoke); addErr != nil {
+			slog.Error("Failed to replace or add broker spoke", "plugin", name,
+				"replace_error", err, "add_error", addErr)
+		} else {
+			slog.Info("Added broker spoke for newly activated plugin", "plugin", name)
+		}
 	} else {
 		slog.Info("Replaced broker spoke after plugin restart", "plugin", name)
 	}

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -52,6 +52,8 @@ type mockIntegrationManager struct {
 	reconnectCalls     []string
 	updateCalls        []string
 	installCalls       []string
+	loadOneCalls       []string
+	loadOneErr         error
 }
 
 func newMockIntegrationManager() *mockIntegrationManager {
@@ -175,6 +177,13 @@ func (m *mockIntegrationManager) InstallPlugin(name, repoPath, pluginsDir, confi
 }
 
 func (m *mockIntegrationManager) LoadOne(pluginType, name string, entry plugin.PluginEntry, pluginsDir string) error {
+	m.loadOneCalls = append(m.loadOneCalls, name)
+	if m.loadOneErr != nil {
+		return m.loadOneErr
+	}
+	if pluginType == "broker" {
+		m.plugins[name] = entry.Config
+	}
 	return nil
 }
 
@@ -686,6 +695,79 @@ func TestUpdateConfig_WithConfigFile(t *testing.T) {
 	}
 }
 
+func TestUpdateConfig_InstalledButNotLoaded(t *testing.T) {
+	// Regression test for the PUT /config 404: a freshly installed plugin whose
+	// LoadOne failed (required fields like bot_token missing) is registered in
+	// settings.yaml but absent from the plugin manager. GET falls back to a
+	// settings.yaml stub, and PUT must accept the same fallback — otherwise the
+	// required fields can never be saved and the plugin can never activate.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".scion"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddPluginToSettings("telegram", "~/.scion/scion-telegram.yaml"); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := newMockIntegrationManager() // telegram NOT loaded in the manager
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	body := `{"settings":{"webhook_listen":":9095"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/integrations/telegram/config", strings.NewReader(body))
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpHome, ".scion", "scion-telegram.yaml"))
+	if err != nil {
+		t.Fatalf("config file not written: %v", err)
+	}
+	if !strings.Contains(string(data), "webhook_listen") {
+		t.Errorf("config file missing saved setting: %s", string(data))
+	}
+
+	if len(mgr.loadOneCalls) != 1 || mgr.loadOneCalls[0] != "telegram" {
+		t.Errorf("expected activation LoadOne call for telegram, got %v", mgr.loadOneCalls)
+	}
+}
+
+func TestUpdateConfig_InstalledButNotLoaded_ActivationFailureIsNonFatal(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".scion"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddPluginToSettings("telegram", "~/.scion/scion-telegram.yaml"); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := newMockIntegrationManager()
+	mgr.loadOneErr = fmt.Errorf("bot_token is required")
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	body := `{"settings":{"webhook_listen":":9095"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/integrations/telegram/config", strings.NewReader(body))
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	// Config is persisted even if the plugin still can't load — must be 200.
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
 func TestUpdateConfig_InvalidBody(t *testing.T) {
 	mgr := newMockIntegrationManager()
 	mgr.plugins["telegram"] = map[string]string{}
@@ -724,6 +806,10 @@ func TestUpdateConfig_UnknownSecretKey(t *testing.T) {
 }
 
 func TestUpdateConfig_NotFound(t *testing.T) {
+	// Isolate from any real ~/.scion/settings.yaml so the settings.yaml
+	// fallback doesn't find plugins from the host environment.
+	t.Setenv("HOME", t.TempDir())
+
 	mgr := newMockIntegrationManager()
 	srv := &Server{}
 	srv.pluginManager = mgr


### PR DESCRIPTION
Fixes 404 on PUT /config for fresh installs (chicken-and-egg: plugin can't load without bot_token, but bot_token can't be saved until plugin loads).

PUT /config now falls back to settings.yaml broker entry (same as GET), writes config to file, then tries LoadOne non-fatally