### PR TITLE
fix: replay fanout subscriptions onto spokes added via AddSpoke

### DIFF
--- a/pkg/eventbus/fanout.go
+++ b/pkg/eventbus/fanout.go
@@ -210,14 +210,16 @@ func (f *FanOutEventBus) BusChannels() []BusChannel {
 // with the same name already exists.
 func (f *FanOutEventBus) AddSpoke(bus NamedEventBus) error {
 	f.mu.Lock()
-	defer f.mu.Unlock()
-
 	for _, nb := range f.buses {
 		if nb.Name == bus.Name {
+			f.mu.Unlock()
 			return fmt.Errorf("spoke %q already exists", bus.Name)
 		}
 	}
 	f.buses = append(f.buses, bus)
+	f.mu.Unlock()
+
+	f.replaySubscriptions(bus)
 	return nil
 }
 
@@ -246,21 +248,24 @@ func (f *FanOutEventBus) ReplaceSpoke(name string, newBus NamedEventBus) error {
 		f.log.Error("failed to close old spoke during replace", "bus", name, "error", err)
 	}
 
-	// Replay existing subscriptions onto the new spoke so it receives the
-	// same event patterns as the spoke it replaced.
+	f.replaySubscriptions(newBus)
+	return nil
+}
+
+// replaySubscriptions replays all existing subscriptions onto a spoke so it
+// receives the same event patterns as the other spokes.
+func (f *FanOutEventBus) replaySubscriptions(bus NamedEventBus) {
 	f.subMu.Lock()
 	subs := make([]string, len(f.subscriptions))
 	copy(subs, f.subscriptions)
 	f.subMu.Unlock()
 
 	for _, pattern := range subs {
-		if _, err := newBus.Bus.Subscribe(pattern, nil); err != nil {
-			f.log.Error("failed to replay subscription to replaced spoke",
-				"spoke", newBus.Name, "pattern", pattern, "error", err.Error())
+		if _, err := bus.Bus.Subscribe(pattern, nil); err != nil {
+			f.log.Error("failed to replay subscription to spoke",
+				"spoke", bus.Name, "pattern", pattern, "error", err.Error())
 		}
 	}
-
-	return nil
 }
 
 // RemoveSpoke removes a spoke by name and closes it.

--- a/pkg/eventbus/fanout_test.go
+++ b/pkg/eventbus/fanout_test.go
@@ -418,6 +418,42 @@ func TestFanOutEventBus_ChannelRoutingWithChannelID(t *testing.T) {
 	chatApp.mu.Unlock()
 }
 
+func TestFanOutEventBus_AddSpokeReplaysSubscriptions(t *testing.T) {
+	b1 := newStubEventBus()
+
+	fan := NewFanOutEventBus([]NamedEventBus{
+		{Name: "b1", Bus: b1},
+	}, slog.Default())
+
+	// Subscribe before adding the new spoke.
+	if _, err := fan.Subscribe("events.>", func(_ context.Context, _ string, _ *messages.StructuredMessage) {}); err != nil {
+		t.Fatalf("subscribe failed: %v", err)
+	}
+	if _, err := fan.Subscribe("commands.*", func(_ context.Context, _ string, _ *messages.StructuredMessage) {}); err != nil {
+		t.Fatalf("subscribe failed: %v", err)
+	}
+
+	// Track subscriptions replayed to the new spoke.
+	newBus := newStubEventBus()
+	var replayed []string
+	newBus.subscribeFunc = func(pattern string, _ EventHandler) (Subscription, error) {
+		replayed = append(replayed, pattern)
+		return &stubSubscription{}, nil
+	}
+
+	if err := fan.AddSpoke(NamedEventBus{Name: "new", Bus: newBus}); err != nil {
+		t.Fatalf("AddSpoke failed: %v", err)
+	}
+
+	if len(replayed) != 2 {
+		t.Fatalf("expected 2 replayed subscriptions, got %d", len(replayed))
+	}
+	if replayed[0] != "events.>" || replayed[1] != "commands.*" {
+		t.Errorf("unexpected replayed patterns: %v", replayed)
+	}
+}
+
+
 func TestFanOutEventBus_Subscribe(t *testing.T) {
 	b1 := newStubEventBus()
 	b2 := newStubEventBus()


### PR DESCRIPTION
AddSpoke was not replaying existing subscriptions onto the new spoke, causing inbound routing to stay dead for freshly activated plugins. Extracted replaySubscriptions helper used by both AddSpoke and ReplaceSpoke