### PR TITLE
harness/copilot: home-dir paths, hook support, and instructions improvements

### DIFF
--- a/harnesses/copilot/README.md
+++ b/harnesses/copilot/README.md
@@ -60,7 +60,7 @@ python3 /home/scion/.scion/harness/capture_auth.py
 - **No telemetry integration** — Copilot's OpenTelemetry configuration surface
   is undocumented.
 - **System prompt is approximate** — system prompt content is prepended to
-  `.github/copilot-instructions.md`; there is no native `--system-prompt` flag.
+  `~/.copilot/copilot-instructions.md`; there is no native `--system-prompt` flag.
 - **No project-scoped MCP** — project-scoped MCP server entries are demoted to
   global scope.
 - **Subscription required** — an active GitHub Copilot subscription is required.

--- a/harnesses/copilot/config.yaml
+++ b/harnesses/copilot/config.yaml
@@ -61,10 +61,23 @@ mcp:
     sse: http
     streamable-http: http
 
+hooks:
+  dialect: copilot
+  config_file: .copilot/hooks/scion.json
+  lifecycle_events:
+    - sessionStart
+    - sessionEnd
+    - userPromptSubmitted
+    - preToolUse
+    - postToolUse
+    - errorOccurred
+    - agentStop
+    - subagentStop
+
 capabilities:
   limits:
-    max_turns: { support: "no", reason: "Copilot CLI has no hook dialect for turn events" }
-    max_model_calls: { support: "no", reason: "Copilot CLI has no hook dialect for model events" }
+    max_turns: { support: "no", reason: "Copilot CLI turn events do not carry a turn counter" }
+    max_model_calls: { support: "no", reason: "Copilot CLI does not expose model-call start/end events" }
     max_duration: { support: "yes" }
   telemetry:
     enabled: { support: "no", reason: "Copilot telemetry config surface is undocumented" }

--- a/harnesses/copilot/config.yaml
+++ b/harnesses/copilot/config.yaml
@@ -96,6 +96,20 @@ capabilities:
     streamable_http: { support: "yes" }
     project_scope: { support: "no", reason: "Project-scoped MCP (.mcp.json) not implemented; entries demoted to global" }
 
+# Declarative hooks metadata — not parsed by Go layer, used for documentation and tooling
+hooks:
+  dialect: copilot
+  config_file: ~/.copilot/hooks/scion.json
+  supported_events:
+    - sessionStart
+    - sessionEnd
+    - userPromptSubmitted
+    - preToolUse
+    - postToolUse
+    - errorOccurred
+    - agentStop
+    - subagentStop
+
 no_auth:
   behavior: drop-to-shell
   command: copilot login

--- a/harnesses/copilot/config.yaml
+++ b/harnesses/copilot/config.yaml
@@ -27,10 +27,10 @@ provisioner:
   required_image_tools:
     - python3
 
-config_dir: .copilot
-skills_dir: .copilot/skills
+config_dir: ~/.copilot
+skills_dir: ~/.copilot/skills
 interrupt_key: C-c
-instructions_file: .github/copilot-instructions.md
+instructions_file: ~/.copilot/copilot-instructions.md
 system_prompt_mode: prepend_to_instructions
 
 model_aliases:

--- a/harnesses/copilot/dialect.yaml
+++ b/harnesses/copilot/dialect.yaml
@@ -1,0 +1,46 @@
+# Scion data-driven dialect spec for GitHub Copilot CLI hook events.
+# Staged to $HOME/.scion/harness/dialect.yaml at agent start.
+dialect: copilot
+
+event_name_field: hook_event_name
+
+mappings:
+  # Session lifecycle.
+  sessionStart:
+    event: session-start
+  sessionEnd:
+    event: session-end
+
+  # Prompt lifecycle.
+  userPromptSubmitted:
+    event: prompt-submit
+    fields:
+      prompt: prompt
+      session_id: session_id
+
+  # Tool lifecycle.
+  preToolUse:
+    event: tool-start
+    fields:
+      tool_name: tool_name
+      tool_input: tool_input
+  postToolUse:
+    event: tool-end
+    fields:
+      tool_name: tool_name
+      tool_output: tool_output
+      success: success
+      error: error
+
+  # Error events.
+  errorOccurred:
+    event: notification
+    fields:
+      error: error
+      message: message
+
+  # Agent completion.
+  agentStop:
+    event: agent-end
+  subagentStop:
+    event: subagent-end

--- a/harnesses/copilot/provision.py
+++ b/harnesses/copilot/provision.py
@@ -121,6 +121,49 @@ def _write_mcp_config(ctx: scion_harness.ProvisionContext, servers: dict[str, An
     scion_harness.atomic_write_json(config_path, {"mcpServers": servers})
 
 
+_COPILOT_HOOK_EVENTS = [
+    "sessionStart",
+    "sessionEnd",
+    "userPromptSubmitted",
+    "preToolUse",
+    "postToolUse",
+    "errorOccurred",
+    "agentStop",
+    "subagentStop",
+]
+
+
+def _write_hooks(home: str) -> None:
+    """Write ~/.copilot/hooks/scion.json wiring Copilot events to sciontool.
+
+    Each hook fires ``sciontool hook <event> --dialect=copilot`` which creates
+    a synthetic event and processes it through the copilot mapping dialect
+    (staged as dialect.yaml alongside this script).
+    """
+    hooks: dict[str, list[dict[str, Any]]] = {}
+    for event in _COPILOT_HOOK_EVENTS:
+        hooks[event] = [
+            {
+                "type": "command",
+                "bash": f"sciontool hook {event} --dialect=copilot",
+            }
+        ]
+
+    hooks_data: dict[str, Any] = {"version": 1, "hooks": hooks}
+
+    hooks_dir = os.path.join(home, ".copilot", "hooks")
+    os.makedirs(hooks_dir, exist_ok=True)
+    hooks_path = os.path.join(hooks_dir, "scion.json")
+    try:
+        scion_harness.atomic_write_json(hooks_path, hooks_data)
+    except (OSError, PermissionError) as exc:
+        print(
+            f"copilot provision: warning: could not write hooks to "
+            f"{hooks_path}: {exc}",
+            file=sys.stderr,
+        )
+
+
 def _ensure_settings(ctx: scion_harness.ProvisionContext) -> None:
     """Ensure ~/.copilot/settings.json and config.json have sane defaults."""
     config_dir = os.path.join(ctx.home, ".copilot")
@@ -239,6 +282,8 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     scion_harness.apply_mcp_translated(
         ctx, translate_mcp, lambda servers: _write_mcp_config(ctx, servers)
     )
+
+    _write_hooks(ctx.home)
 
     try:
         _ensure_settings(ctx)

--- a/harnesses/copilot/provision.py
+++ b/harnesses/copilot/provision.py
@@ -22,7 +22,7 @@ Copilot-native concerns handled here:
   - Auth token is always exposed as COPILOT_GITHUB_TOKEN in env.json.
   - MCP servers translate to Copilot's native format in ~/.copilot/mcp-config.json
     (stdio→local, sse/streamable-http→http).
-  - Instructions project to ~/.github/copilot-instructions.md.
+  - Instructions project to ~/.copilot/copilot-instructions.md (configurable).
   - ~/.copilot/settings.json and config.json get sane defaults.
 
 Exception to §4.2 (env.json placeholder policy): copilot receives its auth
@@ -195,11 +195,11 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     ctx.write_outputs(resolved, env=env, extra=extra)
 
     harness_cfg = ctx.harness_config
-    instructions_file = str(
-        harness_cfg.get("instructions_file") or ".github/copilot-instructions.md"
-    )
+    instructions_file = harness_cfg.get('instructions_file') or '~/.copilot/copilot-instructions.md'
+    target = os.path.expanduser(instructions_file)
+    os.makedirs(os.path.dirname(target), exist_ok=True)
     try:
-        scion_harness.project_instructions(ctx, instructions_file)
+        scion_harness.project_instructions(ctx, target)
     except OSError as exc:
         ctx.warn(f"failed to project instructions: {exc}")
 

--- a/harnesses/copilot/provision.py
+++ b/harnesses/copilot/provision.py
@@ -22,7 +22,7 @@ Copilot-native concerns handled here:
   - Auth token is always exposed as COPILOT_GITHUB_TOKEN in env.json.
   - MCP servers translate to Copilot's native format in ~/.copilot/mcp-config.json
     (stdio→local, sse/streamable-http→http).
-  - Instructions project to .github/copilot-instructions.md.
+  - Instructions project to ~/.github/copilot-instructions.md.
   - ~/.copilot/settings.json and config.json get sane defaults.
 
 Exception to §4.2 (env.json placeholder policy): copilot receives its auth
@@ -194,9 +194,12 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
 
     ctx.write_outputs(resolved, env=env, extra=extra)
 
-    target = os.path.join(ctx.workspace, ".github", "copilot-instructions.md")
+    harness_cfg = ctx.harness_config
+    instructions_file = str(
+        harness_cfg.get("instructions_file") or ".github/copilot-instructions.md"
+    )
     try:
-        scion_harness.project_instructions(ctx, target)
+        scion_harness.project_instructions(ctx, instructions_file)
     except OSError as exc:
         ctx.warn(f"failed to project instructions: {exc}")
 


### PR DESCRIPTION
## Changes

**config.yaml:**
- config_dir: ~/.copilot (home-dir, not workspace)
- skills_dir: ~/.copilot/skills
- interrupt_key: C-c
- instructions_file: ~/.copilot/copilot-instructions.md
- system_prompt_mode: prepend_to_instructions
- Declarative hooks metadata section (supported_events, dialect, config_file)

**dialect.yaml (new):**
- Maps Copilot camelCase events to normalized scion events:
  sessionStart→session-start, sessionEnd→session-end, preToolUse→tool-start, postToolUse→tool-end, etc.

**provision.py:**
- Reads instructions_file from harness_cfg (expanduser for ~/... paths)
- Creates target directory before writing
- _write_hooks() writes ~/.copilot/hooks/scion.json at provision time

**README.md:**
- Updated path references to ~/.copilot/

Note: v1 hook implementation uses synthetic events (no stdin payload parsing). Rich event data (tool names, etc.) can be added in v2 with jq enrichment, like antigravity