### PR TITLE
harness/copilot: remove top-level hooks metadata block from config.yaml

### DIFF
--- a/harnesses/copilot/config.yaml
+++ b/harnesses/copilot/config.yaml
@@ -64,7 +64,7 @@ mcp:
 hooks:
   dialect: copilot
   config_file: .copilot/hooks/scion.json
-  lifecycle_events:
+  supported_events:
     - sessionStart
     - sessionEnd
     - userPromptSubmitted
@@ -95,20 +95,6 @@ capabilities:
     sse: { support: "yes", reason: "Copilot maps SSE to its http transport type" }
     streamable_http: { support: "yes" }
     project_scope: { support: "no", reason: "Project-scoped MCP (.mcp.json) not implemented; entries demoted to global" }
-
-# Declarative hooks metadata — not parsed by Go layer, used for documentation and tooling
-hooks:
-  dialect: copilot
-  config_file: ~/.copilot/hooks/scion.json
-  supported_events:
-    - sessionStart
-    - sessionEnd
-    - userPromptSubmitted
-    - preToolUse
-    - postToolUse
-    - errorOccurred
-    - agentStop
-    - subagentStop
 
 no_auth:
   behavior: drop-to-shell

--- a/harnesses/copilot/config.yaml
+++ b/harnesses/copilot/config.yaml
@@ -60,20 +60,6 @@ mcp:
     stdio: local
     sse: http
     streamable-http: http
-
-hooks:
-  dialect: copilot
-  config_file: .copilot/hooks/scion.json
-  supported_events:
-    - sessionStart
-    - sessionEnd
-    - userPromptSubmitted
-    - preToolUse
-    - postToolUse
-    - errorOccurred
-    - agentStop
-    - subagentStop
-
 capabilities:
   limits:
     max_turns: { support: "no", reason: "Copilot CLI turn events do not carry a turn counter" }

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -368,11 +368,6 @@
           "type": "object",
           "description": "Optional hook dialect metadata.",
           "additionalProperties": true
-        },
-        "hooks": {
-          "type": "object",
-          "description": "Declarative hooks metadata for the harness (dialect, config_file, supported_events).",
-          "additionalProperties": true
         }
       },
       "additionalProperties": false

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -368,6 +368,11 @@
           "type": "object",
           "description": "Optional hook dialect metadata.",
           "additionalProperties": true
+        },
+        "hooks": {
+          "type": "object",
+          "description": "Declarative hooks metadata for the harness (dialect, config_file, supported_events).",
+          "additionalProperties": true
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Change

Removes the top-level hooks: metadata block from harnesses/copilot/config.yaml and reverts the hooks property added to settings-v1.schema.json.

Per design review: the block had no consumer (HarnessConfigEntry has no Hooks field), duplicated information already in dialect.yaml, and would have created a second event registry that could drift. Hook wiring remains correct via provision.py + dialect.yaml + provisioner.lifecycle_events