### PR TITLE
fix(broker): skip docker heartbeat when docker binary is unavailable

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2090,8 +2090,10 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 		}
 	}()
 
-	// Start internal heartbeat loop for co-located operation
-	if colocatedBrokerRegistered {
+	// Start internal heartbeat loop for co-located operation.
+	// Skip for stateless Cloud Run brokers — the Hub manages the
+	// logical broker status directly and no container daemon is present.
+	if colocatedBrokerRegistered && !statelessCloudRunBroker {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/pkg/runtime/factory.go
+++ b/pkg/runtime/factory.go
@@ -86,17 +86,18 @@ func GetRuntime(projectPath string, profileName string) Runtime {
 				util.Debugf("GetRuntime: no runtime detected on macOS, defaulting to docker")
 			}
 		} else {
-			// On Linux, prefer podman over docker when both are available.
-			// If neither is found, check for Cloud Run environment.
-			if _, err := exec.LookPath("podman"); err == nil {
+			// On Linux, check for Cloud Run environment first. On Cloud Run
+			// the docker daemon is never available even when the CLI binary
+			// is present in the image, so cloudrun must take precedence.
+			if os.Getenv("K_SERVICE") != "" {
+				runtimeType = "cloudrun"
+				util.Debugf("GetRuntime: Cloud Run environment detected (K_SERVICE set), using cloudrun runtime")
+			} else if _, err := exec.LookPath("podman"); err == nil {
 				runtimeType = "podman"
 				util.Debugf("GetRuntime: detected 'podman' on Linux")
 			} else if _, err := exec.LookPath("docker"); err == nil {
 				runtimeType = "docker"
 				util.Debugf("GetRuntime: detected 'docker' on Linux")
-			} else if os.Getenv("K_SERVICE") != "" {
-				runtimeType = "cloudrun"
-				util.Debugf("GetRuntime: no container runtime binary found, detected Cloud Run environment (K_SERVICE set)")
 			} else {
 				runtimeType = "docker"
 				util.Debugf("GetRuntime: no container runtime found on Linux, defaulting to docker")
@@ -114,13 +115,18 @@ func GetRuntime(projectPath string, profileName string) Runtime {
 	case "container":
 		return NewAppleContainerRuntime()
 	case "docker":
-		if _, err := exec.LookPath("docker"); err != nil && os.Getenv("K_SERVICE") != "" {
-			util.Debugf("GetRuntime: docker binary not found and Cloud Run environment detected (K_SERVICE set), using cloudrun runtime")
+		// On Cloud Run the docker daemon is unavailable regardless of
+		// whether the CLI binary exists in the container image.
+		if os.Getenv("K_SERVICE") != "" {
+			util.Debugf("GetRuntime: Cloud Run environment detected (K_SERVICE set), docker daemon unavailable — using cloudrun runtime")
 			rt := NewCloudRunRuntime(rtConfig.CloudRun)
 			if vs != nil && vs.Server != nil {
 				rt.WorkspaceStorage = vs.Server.WorkspaceStorage
 			}
 			return rt
+		}
+		if _, err := exec.LookPath("docker"); err != nil {
+			util.Debugf("GetRuntime: docker binary not found, returning DockerRuntime (will fail on use)")
 		}
 		dr := NewDockerRuntime()
 		if rtConfig.Host != "" {

--- a/pkg/runtime/factory_test.go
+++ b/pkg/runtime/factory_test.go
@@ -293,9 +293,10 @@ func TestGetRuntime_AutoDetect_Docker_When_Binary_Available(t *testing.T) {
 	}
 	defer func() { _ = os.Chdir(oldWd) }()
 
-	// Even with K_SERVICE set, docker binary in PATH should take priority
+	// K_SERVICE takes precedence over docker binary presence: on Cloud Run
+	// the docker daemon is unavailable even when the CLI binary exists.
 	r := GetRuntime("", "")
-	if _, ok := r.(*DockerRuntime); !ok {
-		t.Errorf("expected *DockerRuntime when docker binary is available (even with K_SERVICE set), got %T", r)
+	if _, ok := r.(*CloudRunRuntime); !ok {
+		t.Errorf("expected *CloudRunRuntime when K_SERVICE is set (even with docker binary available), got %T", r)
 	}
 }

--- a/pkg/runtime/factory_test.go
+++ b/pkg/runtime/factory_test.go
@@ -273,7 +273,7 @@ active_profile: apple
 	})
 }
 
-func TestGetRuntime_AutoDetect_Docker_When_Binary_Available(t *testing.T) {
+func TestGetRuntime_CloudRun_Precedence_Over_Docker(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("Linux auto-detection path only applies on Linux")
 	}


### PR DESCRIPTION
## Summary

- On Cloud Run, the docker daemon is never available even when the docker CLI binary is present in the container image. The runtime auto-detection and explicit "docker" runtime paths now check K_SERVICE before falling back to docker, ensuring the cloudrun runtime is always selected on Cloud Run.
- The co-located DB heartbeat loop is skipped for stateless Cloud Run brokers since the Hub manages broker status directly and no container daemon is present.

Fixes https://github.com/ptone/scion/issues/475