### PR TITLE
fix(config): add cloudrun to V1 settings schema runtime type validation

### DIFF
--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -210,7 +210,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["docker", "podman", "container", "kubernetes"],
+          "enum": ["docker", "podman", "container", "kubernetes", "cloudrun"],
           "description": "Runtime type. Defaults to the runtime entry name if omitted."
         },
         "host": { "type": "string" },


### PR DESCRIPTION
## Summary

- Add "cloudrun" to the runtimeConfig.type enum in settings-v1.schema.json
- The schema was missing this value, causing a validation warning whenever the Hub hosted runtime broker (Cloud Run) persisted its broker ID to settings.yaml
- Non-fatal but logged a misleading warning on every startup

Fixes https://github.com/ptone/scion/issues/476