### PR TITLE
fix(broker): enumerate configured profiles in broker info endpoint

### DIFF
--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -155,12 +155,54 @@ func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
 			Attach: true,
 			Exec:   true,
 		},
-		Profiles: []BrokerProfile{
-			{Name: "default", Type: runtimeType, Available: true},
-		},
+		Profiles: s.buildInfoProfiles(runtimeType),
 	}
 
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// buildInfoProfiles enumerates configured profiles from effective settings.
+// Falls back to a single "default" profile when no profiles are configured.
+func (s *Server) buildInfoProfiles(defaultRuntimeType string) []BrokerProfile {
+	vs, _, err := config.LoadEffectiveSettings("")
+	if err != nil || len(vs.Profiles) == 0 {
+		return []BrokerProfile{
+			{Name: "default", Type: defaultRuntimeType, Available: true},
+		}
+	}
+
+	var profiles []BrokerProfile
+	for name, profileCfg := range vs.Profiles {
+		rtType := profileCfg.Runtime
+		if rtType == "" {
+			rtType = defaultRuntimeType
+		}
+
+		var ctx, ns string
+		if rtCfg, ok := vs.Runtimes[profileCfg.Runtime]; ok {
+			if rtCfg.Type != "" {
+				rtType = rtCfg.Type
+			}
+			ctx = rtCfg.Context
+			ns = rtCfg.Namespace
+		}
+
+		profiles = append(profiles, BrokerProfile{
+			Name:      name,
+			Type:      rtType,
+			Available: true,
+			Context:   ctx,
+			Namespace: ns,
+		})
+	}
+
+	if len(profiles) == 0 {
+		return []BrokerProfile{
+			{Name: "default", Type: defaultRuntimeType, Available: true},
+		}
+	}
+
+	return profiles
 }
 
 // handleHubConnections returns live status of all hub connections.

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -161,6 +161,16 @@ func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// isLocalOnlyRuntime returns true for runtime types that require a local daemon
+// or hardware and cannot function in a hosted cloud environment.
+func isLocalOnlyRuntime(runtimeType string) bool {
+	switch runtimeType {
+	case "docker", "podman", "container":
+		return true
+	}
+	return false
+}
+
 // buildInfoProfiles enumerates configured profiles from effective settings.
 // Falls back to a single "default" profile when no profiles are configured.
 func (s *Server) buildInfoProfiles(defaultRuntimeType string) []BrokerProfile {
@@ -178,13 +188,16 @@ func (s *Server) buildInfoProfiles(defaultRuntimeType string) []BrokerProfile {
 			rtType = defaultRuntimeType
 		}
 
+		if !isLocalOnlyRuntime(defaultRuntimeType) && isLocalOnlyRuntime(rtType) {
+			continue
+		}
+
 		var ctx, ns string
-		if rtCfg, ok := vs.Runtimes[profileCfg.Runtime]; ok {
-			if rtCfg.Type != "" {
-				rtType = rtCfg.Type
+		if vs.Runtimes != nil {
+			if rtCfg, ok := vs.Runtimes[profileCfg.Runtime]; ok {
+				ctx = rtCfg.Context
+				ns = rtCfg.Namespace
 			}
-			ctx = rtCfg.Context
-			ns = rtCfg.Namespace
 		}
 
 		profiles = append(profiles, BrokerProfile{

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -181,8 +182,15 @@ func (s *Server) buildInfoProfiles(defaultRuntimeType string) []BrokerProfile {
 		}
 	}
 
+	names := make([]string, 0, len(vs.Profiles))
+	for name := range vs.Profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
 	var profiles []BrokerProfile
-	for name, profileCfg := range vs.Profiles {
+	for _, name := range names {
+		profileCfg := vs.Profiles[name]
 		rtType := profileCfg.Runtime
 		if rtType == "" {
 			rtType = defaultRuntimeType
@@ -194,7 +202,7 @@ func (s *Server) buildInfoProfiles(defaultRuntimeType string) []BrokerProfile {
 
 		var ctx, ns string
 		if vs.Runtimes != nil {
-			if rtCfg, ok := vs.Runtimes[profileCfg.Runtime]; ok {
+			if rtCfg, ok := vs.Runtimes[rtType]; ok {
 				ctx = rtCfg.Context
 				ns = rtCfg.Namespace
 			}


### PR DESCRIPTION
## Summary

- The broker /api/v1/info endpoint hardcoded a single default profile, preventing multi-cluster GKE deployments from discovering which profiles/clusters a broker supports
- Now enumerates profiles from effective settings via config.LoadEffectiveSettings, resolving runtime type, context, and namespace for each profile
- Falls back to a single "default" profile when no profiles are configured (backward compatible)

Fixes https://github.com/ptone/scion/issues/477