### PR TITLE
harness: invert include_skills default to False in project_instructions()

### DIFF
--- a/harnesses/antigravity/scion_harness.py
+++ b/harnesses/antigravity/scion_harness.py
@@ -772,7 +772,7 @@ def project_instructions(
     target: str,
     *,
     marker_label: str | None = None,
-    include_skills: bool = True,
+    include_skills: bool = False,
     system_prompt_mode: str | None = None,
     skills_dir: str | None = None,
 ) -> None:

--- a/harnesses/authoring-guide.md
+++ b/harnesses/authoring-guide.md
@@ -142,8 +142,11 @@ etc.) — the agent runs unattended inside a sandboxed container.
 | `system_prompt_mode` | `native` (tool has a real system-prompt channel), `prepend_to_instructions` (downgrade into the instructions file), or `none`. |
 
 `scion_harness.project_instructions()` honors `system_prompt_mode` and
-`skills_dir` from these fields — declare them and let the library do the
-composition (see below).
+`skills_dir` from these fields. It projects system prompt and instruction
+content by default, but `include_skills` defaults to `False` because scion's
+host-side provisioner already installs skills as individual files under
+`skills_dir`. Only pass `include_skills=True` for a harness that has no native
+skills directory and must inline `SKILL.md` content into its instruction file.
 
 ### Models
 
@@ -356,7 +359,9 @@ helpers), never from `os.environ`.
 1. Select an auth method (`ctx.select_auth(AUTH)`) and write the tool's
    native credential file(s) or env overlay.
 2. Project instructions: `scion_harness.project_instructions(ctx,
-   instructions_file)`.
+   instructions_file)`. Leave `include_skills` at its default `False` when
+   your config declares `skills_dir`; pass `include_skills=True` only for
+   harnesses that cannot load skills from files.
 3. Translate MCP servers (`apply_mcp_servers_simple` or
    `apply_mcp_translated`).
 4. Reconcile telemetry into native client settings if the tool supports it
@@ -433,9 +438,12 @@ Key API surface:
   is configured and no candidates were staged.
 - **`project_instructions(ctx, target, ...)`** — composes
   `inputs/system-prompt.md` (per `system_prompt_mode`),
-  `inputs/instructions.md`, and installed `SKILL.md` files from `skills_dir`
-  into the target file inside `<!-- BEGIN/END SCION MANAGED -->` markers,
-  preserving user content outside the block.
+  `inputs/instructions.md`, and, only when `include_skills=True`, installed
+  `SKILL.md` files from `skills_dir` into the target file inside
+  `<!-- BEGIN/END SCION MANAGED -->` markers, preserving user content outside
+  the block. `include_skills` defaults to `False`; keep it that way for
+  harnesses that declare `skills_dir`, because those skills are installed as
+  native files by the host-side provisioner.
 - **MCP** — `apply_mcp_servers_simple(bundle_path, mcp_mapping, workspace)`
   for JSON-native tools (driven by the `mcp:` block);
   `apply_mcp_translated(ctx, translate_fn, write_fn)` for custom formats

--- a/harnesses/claude/provision.py
+++ b/harnesses/claude/provision.py
@@ -266,7 +266,6 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
         ctx,
         instructions_file,
         system_prompt_mode="none",
-        include_skills=False,
     )
 
 

--- a/harnesses/claude/scion_harness.py
+++ b/harnesses/claude/scion_harness.py
@@ -772,7 +772,7 @@ def project_instructions(
     target: str,
     *,
     marker_label: str | None = None,
-    include_skills: bool = True,
+    include_skills: bool = False,
     system_prompt_mode: str | None = None,
     skills_dir: str | None = None,
 ) -> None:

--- a/harnesses/codex/provision_test.py
+++ b/harnesses/codex/provision_test.py
@@ -51,7 +51,7 @@ def temporary_home(path: str):
 
 
 class CodexProvisionTest(unittest.TestCase):
-    def test_instruction_projection_composes_prompts_and_skills(self) -> None:
+    def test_instruction_projection_composes_prompts_without_skills_by_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             home = os.path.join(tmp, "home")
             bundle = os.path.join(tmp, "bundle")
@@ -96,12 +96,11 @@ class CodexProvisionTest(unittest.TestCase):
             self.assertEqual(content.count(MANAGED_BEGIN), 1)
             self.assertIn("# System Instruction\n\nSystem rules", content)
             self.assertIn("# Agent Instructions\n\nAgent rules", content)
-            self.assertIn("# Skills\n\n## example\n\n# Example Skill", content)
-            self.assertIn("# Skills\n\n## example\n\n# Example Skill\n\nUse this skill.\n\n## second", content)
+            self.assertNotIn("# Skills", content)
+            self.assertNotIn("# Example Skill", content)
             self.assertIn(
                 "# System Instruction\n\nSystem rules\n\n"
-                "# Agent Instructions\n\nAgent rules\n\n"
-                "# Skills\n\n## example",
+                "# Agent Instructions\n\nAgent rules",
                 content,
             )
 

--- a/harnesses/codex/scion_harness.py
+++ b/harnesses/codex/scion_harness.py
@@ -772,7 +772,7 @@ def project_instructions(
     target: str,
     *,
     marker_label: str | None = None,
-    include_skills: bool = True,
+    include_skills: bool = False,
     system_prompt_mode: str | None = None,
     skills_dir: str | None = None,
 ) -> None:

--- a/harnesses/copilot/scion_harness.py
+++ b/harnesses/copilot/scion_harness.py
@@ -772,7 +772,7 @@ def project_instructions(
     target: str,
     *,
     marker_label: str | None = None,
-    include_skills: bool = True,
+    include_skills: bool = False,
     system_prompt_mode: str | None = None,
     skills_dir: str | None = None,
 ) -> None:

--- a/harnesses/gemini-cli/scion_harness.py
+++ b/harnesses/gemini-cli/scion_harness.py
@@ -772,7 +772,7 @@ def project_instructions(
     target: str,
     *,
     marker_label: str | None = None,
-    include_skills: bool = True,
+    include_skills: bool = False,
     system_prompt_mode: str | None = None,
     skills_dir: str | None = None,
 ) -> None:

--- a/harnesses/hermes/provision_test.py
+++ b/harnesses/hermes/provision_test.py
@@ -155,7 +155,7 @@ class NoAuthModeTest(unittest.TestCase):
 
 
 class InstructionProjectionTest(unittest.TestCase):
-    def test_composes_prompts_and_skills(self) -> None:
+    def test_composes_prompts_without_skills_by_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             home = os.path.join(tmp, "home")
             bundle = os.path.join(tmp, "bundle")
@@ -200,8 +200,8 @@ class InstructionProjectionTest(unittest.TestCase):
             self.assertEqual(content.count(MANAGED_BEGIN), 1)
             self.assertIn("# System Instruction\n\nSystem rules", content)
             self.assertIn("# Agent Instructions\n\nAgent rules", content)
-            self.assertIn("## example\n\n# Example Skill\n\nUse this skill.", content)
-            self.assertIn("## second\n\n# Second Skill\n\nUse this other skill.", content)
+            self.assertNotIn("# Skills", content)
+            self.assertNotIn("# Example Skill", content)
 
     def test_cleans_stale_managed_block_when_inputs_empty(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/harnesses/hermes/scion_harness.py
+++ b/harnesses/hermes/scion_harness.py
@@ -772,7 +772,7 @@ def project_instructions(
     target: str,
     *,
     marker_label: str | None = None,
-    include_skills: bool = True,
+    include_skills: bool = False,
     system_prompt_mode: str | None = None,
     skills_dir: str | None = None,
 ) -> None:

--- a/harnesses/opencode/scion_harness.py
+++ b/harnesses/opencode/scion_harness.py
@@ -772,7 +772,7 @@ def project_instructions(
     target: str,
     *,
     marker_label: str | None = None,
-    include_skills: bool = True,
+    include_skills: bool = False,
     system_prompt_mode: str | None = None,
     skills_dir: str | None = None,
 ) -> None:

--- a/harnesses/scion_harness.py
+++ b/harnesses/scion_harness.py
@@ -771,7 +771,7 @@ def project_instructions(
     target: str,
     *,
     marker_label: str | None = None,
-    include_skills: bool = True,
+    include_skills: bool = False,
     system_prompt_mode: str | None = None,
     skills_dir: str | None = None,
 ) -> None:

--- a/harnesses/scion_harness_test.py
+++ b/harnesses/scion_harness_test.py
@@ -387,6 +387,40 @@ class TestProjectInstructions(unittest.TestCase):
         self.assertIn("Agent Instructions", content)
         self.assertIn("Do the thing.", content)
 
+    def test_skills_excluded_by_default_and_included_explicitly(self):
+        with tempfile.TemporaryDirectory() as home:
+            skill_dir = os.path.join(home, ".test", "skills", "example")
+            os.makedirs(skill_dir)
+            with open(os.path.join(skill_dir, "SKILL.md"), "w") as f:
+                f.write("# Example Skill\n\nUse this skill.")
+
+            old_home = os.environ.get("HOME")
+            os.environ["HOME"] = home
+            try:
+                ctx = _make_ctx(harness_config={"skills_dir": ".test/skills"})
+                inputs = ctx.inputs_dir
+                with open(os.path.join(inputs, "instructions.md"), "w") as f:
+                    f.write("Do the thing.")
+
+                default_target = os.path.join(home, "default.md")
+                sh.project_instructions(ctx, default_target)
+                with open(default_target) as f:
+                    default_content = f.read()
+                self.assertNotIn("# Skills", default_content)
+                self.assertNotIn("# Example Skill", default_content)
+
+                explicit_target = os.path.join(home, "explicit.md")
+                sh.project_instructions(ctx, explicit_target, include_skills=True)
+                with open(explicit_target) as f:
+                    explicit_content = f.read()
+                self.assertIn("# Skills", explicit_content)
+                self.assertIn("# Example Skill", explicit_content)
+            finally:
+                if old_home is None:
+                    os.environ.pop("HOME", None)
+                else:
+                    os.environ["HOME"] = old_home
+
     def test_strips_existing_managed_block(self):
         ctx = _make_ctx()
         inputs = ctx.inputs_dir


### PR DESCRIPTION
## Problem

project_instructions() defaulted include_skills=True, causing skills to be injected as text blobs into agent instruction files (CLAUDE.md, AGENTS.md, etc.) even when the Go provisioner already installs them as individual skill files. PR #705 fixed claude with an explicit include_skills=False; this PR fixes the root cause.

## Fix

Inverts the default to include_skills=False in the canonical scion_harness.py and all 7 harness-bundled copies. All harnesses that call project_instructions() have a skills_dir configured — the Go provisioner handles skill file installation. No harness needs include_skills=True.

Also:
- Removes the now-redundant explicit include_skills=False from claude provision.py
- Updates harnesses/authoring-guide.md to document the pattern (3 locations)
- Adds a canonical test covering both the default and explicit True paths