### PR TITLE
harness/copilot: use relative paths for config_dir, skills_dir, instructions_file

### DIFF
--- a/harnesses/authoring-guide.md
+++ b/harnesses/authoring-guide.md
@@ -141,6 +141,11 @@ etc.) — the agent runs unattended inside a sandboxed container.
 | `system_prompt_file` | Home-relative native system-prompt file, if the tool has one. |
 | `system_prompt_mode` | `native` (tool has a real system-prompt channel), `prepend_to_instructions` (downgrade into the instructions file), or `none`. |
 
+> **All paths must be relative** (e.g. `.copilot/skills`, not `~/.copilot/skills`).
+> The Go provisioner joins them with `agentHome` via `filepath.Join`; `~` is
+> **not** expanded and will produce a broken literal path like
+> `/home/scion/~/.copilot/skills`.
+
 `scion_harness.project_instructions()` honors `system_prompt_mode` and
 `skills_dir` from these fields — declare them and let the library do the
 composition (see below).

--- a/harnesses/copilot/config.yaml
+++ b/harnesses/copilot/config.yaml
@@ -27,10 +27,10 @@ provisioner:
   required_image_tools:
     - python3
 
-config_dir: ~/.copilot
-skills_dir: ~/.copilot/skills
+config_dir: .copilot
+skills_dir: .copilot/skills
 interrupt_key: C-c
-instructions_file: ~/.copilot/copilot-instructions.md
+instructions_file: .copilot/copilot-instructions.md
 system_prompt_mode: prepend_to_instructions
 
 model_aliases:

--- a/harnesses/copilot/provision.py
+++ b/harnesses/copilot/provision.py
@@ -238,8 +238,8 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     ctx.write_outputs(resolved, env=env, extra=extra)
 
     harness_cfg = ctx.harness_config
-    instructions_file = harness_cfg.get('instructions_file') or '~/.copilot/copilot-instructions.md'
-    target = os.path.expanduser(instructions_file)
+    instructions_file = harness_cfg.get('instructions_file') or '.copilot/copilot-instructions.md'
+    target = os.path.join(ctx.home, instructions_file)
     os.makedirs(os.path.dirname(target), exist_ok=True)
     try:
         scion_harness.project_instructions(ctx, target)


### PR DESCRIPTION
## Problem

The copilot harness config.yaml used ~/... prefixed paths for config_dir, skills_dir, and instructions_file. The Go provisioner uses filepath.Join(agentHome, path) which does NOT expand ~, producing broken literal paths like /home/scion/~/.copilot/skills. Similarly, provision.py was using os.path.expanduser() on instructions_file, which returns relative paths unchanged (no ~ to expand = CWD-relative, not home-relative).

## Fix

config.yaml:
- config_dir: ~/.copilot → .copilot
- skills_dir: ~/.copilot/skills → .copilot/skills
- instructions_file: ~/.copilot/copilot-instructions.md → .copilot/copilot-instructions.md

provision.py:
- instructions_file resolution: os.path.expanduser() → os.path.join(ctx.home, instructions_file), matching the pattern at lines 118, 169 in the same file

harnesses/authoring-guide.md:
- Added explicit warning that config_dir and skills_dir must be relative paths (no ~/); the Go provisioner joins them with agentHome