### PR TITLE
harness/hermes: add Vertex AI auth support and refine from container learnings

### DIFF
--- a/harnesses/hermes/Dockerfile
+++ b/harnesses/hermes/Dockerfile
@@ -31,11 +31,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends ripgrep \
 RUN apt-get update && apt-get install -y --no-install-recommends python3-pip \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install Hermes Agent via pip
+# Install Hermes Agent with Vertex AI support (google-auth for ADC)
 RUN if [ -n "${HERMES_VERSION}" ]; then \
-      pip install --no-cache-dir --break-system-packages "hermes-agent==${HERMES_VERSION}"; \
+      pip install --no-cache-dir --break-system-packages "hermes-agent[vertex]==${HERMES_VERSION}"; \
     else \
-      pip install --no-cache-dir --break-system-packages hermes-agent; \
+      pip install --no-cache-dir --break-system-packages "hermes-agent[vertex]"; \
     fi
 
 RUN mkdir -p /home/scion/.hermes /home/scion/.hermes/skills \

--- a/harnesses/hermes/config.yaml
+++ b/harnesses/hermes/config.yaml
@@ -60,7 +60,7 @@ capabilities:
     api_key: { support: "yes" }
     auth_file: { support: "no" }
     oauth_token: { support: "no" }
-    vertex_ai: { support: "no", reason: "Hermes gemini provider uses Google AI Studio API keys, not Vertex AI ADC" }
+    vertex_ai: { support: "yes" }
   mcp:
     stdio: { support: "yes" }
     sse: { support: "yes" }
@@ -81,8 +81,24 @@ auth:
     api-key:
       required_env:
         - any_of: ["GOOGLE_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
+    vertex-ai:
+      required_env:
+        - any_of: ["VERTEX_PROJECT_ID", "GOOGLE_CLOUD_PROJECT"]
+      required_files:
+        - name: gcloud-adc
+          type: file
+          description: "Google Cloud Application Default Credentials (ADC) file for vertex-ai authentication"
+          field: GoogleAppCredentials
+          alternative_env_keys: ["GOOGLE_APPLICATION_CREDENTIALS"]
+          skipped_when_gcp_service_account_assigned: true
+          required: true
   autodetect:
     env:
       GOOGLE_API_KEY: api-key
       OPENAI_API_KEY: api-key
       ANTHROPIC_API_KEY: api-key
+      VERTEX_PROJECT_ID: vertex-ai
+      GOOGLE_CLOUD_PROJECT: vertex-ai
+      GOOGLE_APPLICATION_CREDENTIALS: vertex-ai
+    files:
+      gcloud-adc: vertex-ai

--- a/harnesses/hermes/provision.py
+++ b/harnesses/hermes/provision.py
@@ -205,6 +205,7 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     resolved = ctx.select_auth(AUTH)
 
     # Write auth credentials to ~/.hermes/.env so Hermes can read them.
+    vertex_env: dict[str, str] = {}
     if resolved.method == "api-key":
         api_key = ctx.read_secret(resolved.env_key)
         if not api_key:
@@ -215,7 +216,8 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
         _write_hermes_env({resolved.env_key: api_key})
 
     elif resolved.method == "vertex-ai":
-        _write_hermes_env(_build_vertex_env(ctx))
+        vertex_env = _build_vertex_env(ctx)
+        _write_hermes_env(vertex_env)
 
     # Instruction projection via the lib.
     harness_cfg = ctx.harness_config
@@ -244,7 +246,7 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     # For vertex-ai, propagate project/region into the container env so
     # Hermes's vertex adapter picks them up alongside ADC.
     if resolved.method == "vertex-ai":
-        env_payload.update(_build_vertex_env(ctx))
+        env_payload.update(vertex_env)
 
     # Write standard outputs.
     extra: dict[str, Any] | None = None

--- a/harnesses/hermes/provision.py
+++ b/harnesses/hermes/provision.py
@@ -24,10 +24,12 @@ ContainerScriptHarness has already:
 
 This script's job:
 
-  1. Determine which API key is available, with precedence:
-         ANTHROPIC_API_KEY > OPENAI_API_KEY > GOOGLE_API_KEY.
-  2. Read the secret value from the staged secrets/<NAME> file and write it
-     to ~/.hermes/.env (Hermes reads secrets from this dotenv file).
+  1. Determine which auth method is available, with precedence:
+         api-key (ANTHROPIC/OPENAI/GOOGLE_API_KEY) > vertex-ai (ADC).
+  2. For api-key: read the secret and write to ~/.hermes/.env.
+     For vertex-ai: resolve project/region and write Vertex config to
+     ~/.hermes/.env; propagate VERTEX_PROJECT_ID and VERTEX_REGION
+     into the container env overlay.
   3. Compose staged Scion prompt inputs into AGENTS.md (instruction
      projection — Hermes auto-reads AGENTS.md as context).
   4. Apply MCP server configuration to ~/.hermes/mcp.json.
@@ -64,9 +66,48 @@ AUTH = scion_harness.AuthSpec(
             any_of=["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"],
             hint="set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY",
         ),
+        scion_harness.env_method(
+            "vertex-ai",
+            any_of=["VERTEX_PROJECT_ID", "GOOGLE_CLOUD_PROJECT"],
+            hint="set VERTEX_PROJECT_ID or GOOGLE_CLOUD_PROJECT "
+                 "(with ADC or GCP service account) for Vertex AI",
+        ),
     ],
     fallback_to_none_on_error=True,
 )
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_vertex_var(
+    ctx: scion_harness.ProvisionContext, *names: str, default: str = "",
+) -> str:
+    """Return the first non-empty value from staged secrets or env vars."""
+    for name in names:
+        val = ctx.read_secret(name, env_fallback=True)
+        if val:
+            return val
+    return default
+
+
+def _build_vertex_env(ctx: scion_harness.ProvisionContext) -> dict[str, str]:
+    """Build the Vertex AI env vars dict from staged secrets and environment."""
+    env: dict[str, str] = {}
+    project_id = _resolve_vertex_var(ctx, "VERTEX_PROJECT_ID", "GOOGLE_CLOUD_PROJECT")
+    if project_id:
+        env["VERTEX_PROJECT_ID"] = project_id
+    region = _resolve_vertex_var(
+        ctx, "VERTEX_REGION", "GOOGLE_CLOUD_REGION", "GOOGLE_CLOUD_LOCATION",
+        default="us-central1",
+    )
+    env["VERTEX_REGION"] = region
+    creds_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
+    if creds_path:
+        env["GOOGLE_APPLICATION_CREDENTIALS"] = creds_path
+    return env
+
 
 # ---------------------------------------------------------------------------
 # Native: ~/.hermes/.env writer
@@ -163,7 +204,7 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     """Hermes provisioning logic."""
     resolved = ctx.select_auth(AUTH)
 
-    # Write the API key to ~/.hermes/.env so Hermes can read it.
+    # Write auth credentials to ~/.hermes/.env so Hermes can read them.
     if resolved.method == "api-key":
         api_key = ctx.read_secret(resolved.env_key)
         if not api_key:
@@ -172,6 +213,9 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
                 "was staged at the recorded path; check ApplyAuthSettings"
             )
         _write_hermes_env({resolved.env_key: api_key})
+
+    elif resolved.method == "vertex-ai":
+        _write_hermes_env(_build_vertex_env(ctx))
 
     # Instruction projection via the lib.
     harness_cfg = ctx.harness_config
@@ -194,9 +238,19 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     resolved_model = str(ctx.model_resolution.get("resolved_model") or "").strip()
     if resolved_model:
         env_payload["HERMES_INFERENCE_MODEL"] = resolved_model
+    elif resolved.method == "vertex-ai":
+        env_payload["HERMES_INFERENCE_MODEL"] = "google/gemini-2.5-flash"
+
+    # For vertex-ai, propagate project/region into the container env so
+    # Hermes's vertex adapter picks them up alongside ADC.
+    if resolved.method == "vertex-ai":
+        env_payload.update(_build_vertex_env(ctx))
 
     # Write standard outputs.
-    ctx.write_outputs(resolved, env=env_payload)
+    extra: dict[str, Any] | None = None
+    if resolved.method == "vertex-ai":
+        extra = {"vertex_ai": True}
+    ctx.write_outputs(resolved, env=env_payload, extra=extra)
 
     # MCP server configuration.
     _apply_mcp_servers(ctx)

--- a/harnesses/hermes/provision_test.py
+++ b/harnesses/hermes/provision_test.py
@@ -114,10 +114,116 @@ class AuthResolutionTest(unittest.TestCase):
             self._select(["ANTHROPIC_API_KEY"], explicit="auth-file")
         self.assertIn("valid types are", str(ctx.exception))
 
+    def test_vertex_project_id_selects_vertex_ai(self) -> None:
+        result = self._select(["VERTEX_PROJECT_ID"])
+        self.assertEqual(result.method, "vertex-ai")
+        self.assertEqual(result.env_key, "VERTEX_PROJECT_ID")
+
+    def test_google_cloud_project_selects_vertex_ai(self) -> None:
+        result = self._select(["GOOGLE_CLOUD_PROJECT"])
+        self.assertEqual(result.method, "vertex-ai")
+        self.assertEqual(result.env_key, "GOOGLE_CLOUD_PROJECT")
+
+    def test_api_key_takes_precedence_over_vertex(self) -> None:
+        result = self._select(["ANTHROPIC_API_KEY", "VERTEX_PROJECT_ID"])
+        self.assertEqual(result.method, "api-key")
+        self.assertEqual(result.env_key, "ANTHROPIC_API_KEY")
+
+    def test_explicit_vertex_ai_type_accepted(self) -> None:
+        result = self._select(["VERTEX_PROJECT_ID"], explicit="vertex-ai")
+        self.assertEqual(result.method, "vertex-ai")
+        self.assertEqual(result.env_key, "VERTEX_PROJECT_ID")
+
     def test_no_keys_raises(self) -> None:
         with self.assertRaises(scion_harness.ProvisionError) as ctx:
             self._select([])
         self.assertIn("no valid auth method found", str(ctx.exception))
+
+
+_VERTEX_ENV_KEYS = [
+    "VERTEX_PROJECT_ID", "VERTEX_REGION", "VERTEX_CREDENTIALS_PATH",
+    "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_REGION", "GOOGLE_CLOUD_LOCATION",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+]
+
+
+@contextmanager
+def clean_vertex_env():
+    """Temporarily unset Vertex/GCP env vars so tests aren't affected by the host."""
+    saved = {k: os.environ.pop(k) for k in _VERTEX_ENV_KEYS if k in os.environ}
+    try:
+        yield
+    finally:
+        os.environ.update(saved)
+
+
+class VertexAIProvisionTest(unittest.TestCase):
+    def test_vertex_ai_sets_default_model_and_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, clean_vertex_env():
+            home = os.path.join(tmp, "home")
+            bundle = os.path.join(tmp, "bundle")
+            os.makedirs(os.path.join(bundle, "outputs"))
+            os.makedirs(home)
+
+            ctx = _make_ctx(
+                bundle,
+                env_vars=["VERTEX_PROJECT_ID"],
+                env_secret_files={"VERTEX_PROJECT_ID": ""},
+                harness_config={
+                    "instructions_file": "AGENTS.md",
+                    "skills_dir": ".hermes/skills",
+                    "system_prompt_mode": "none",
+                },
+            )
+
+            stderr = io.StringIO()
+            with temporary_home(home), redirect_stderr(stderr):
+                provision.provision(ctx)
+
+            with open(os.path.join(bundle, "outputs", "resolved-auth.json"), "r") as f:
+                resolved = json.load(f)
+            self.assertEqual(resolved["method"], "vertex-ai")
+            self.assertTrue(resolved.get("vertex_ai"))
+
+            with open(os.path.join(bundle, "outputs", "env.json"), "r") as f:
+                env = json.load(f)
+            self.assertEqual(env["HERMES_INFERENCE_MODEL"], "google/gemini-2.5-flash")
+            self.assertEqual(env["VERTEX_REGION"], "us-central1")
+
+    def test_vertex_ai_respects_explicit_model(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, clean_vertex_env():
+            home = os.path.join(tmp, "home")
+            bundle = os.path.join(tmp, "bundle")
+            os.makedirs(os.path.join(bundle, "outputs"))
+            os.makedirs(home)
+
+            manifest = {
+                "harness_bundle_dir": bundle,
+                "harness_config": {
+                    "instructions_file": "AGENTS.md",
+                    "skills_dir": ".hermes/skills",
+                    "system_prompt_mode": "none",
+                },
+                "model_resolution": {"resolved_model": "google/gemini-2.5-pro"},
+            }
+
+            os.makedirs(os.path.join(bundle, "inputs"), exist_ok=True)
+            candidates = {
+                "env_vars": ["VERTEX_PROJECT_ID"],
+                "env_secret_files": {"VERTEX_PROJECT_ID": ""},
+            }
+            with open(os.path.join(bundle, "inputs", "auth-candidates.json"), "w") as f:
+                json.dump(candidates, f)
+
+            ctx = scion_harness.ProvisionContext("hermes", manifest)
+
+            stderr = io.StringIO()
+            with temporary_home(home), redirect_stderr(stderr):
+                provision.provision(ctx)
+
+            with open(os.path.join(bundle, "outputs", "env.json"), "r") as f:
+                env = json.load(f)
+            self.assertEqual(env["HERMES_INFERENCE_MODEL"], "google/gemini-2.5-pro")
 
 
 class NoAuthModeTest(unittest.TestCase):

--- a/harnesses/hermes/provision_test.py
+++ b/harnesses/hermes/provision_test.py
@@ -226,6 +226,43 @@ class VertexAIProvisionTest(unittest.TestCase):
             self.assertEqual(env["HERMES_INFERENCE_MODEL"], "google/gemini-2.5-pro")
 
 
+class VertexRegionFallbackTest(unittest.TestCase):
+    """Test VERTEX_REGION → GOOGLE_CLOUD_REGION → GOOGLE_CLOUD_LOCATION → us-central1."""
+
+    def _region(self, env_overrides: dict[str, str]) -> str:
+        with tempfile.TemporaryDirectory() as tmp, clean_vertex_env():
+            bundle = os.path.join(tmp, "bundle")
+            os.makedirs(os.path.join(bundle, "inputs"))
+            os.makedirs(os.path.join(bundle, "outputs"))
+
+            secrets_dir = os.path.join(bundle, "secrets")
+            os.makedirs(secrets_dir, exist_ok=True)
+            env_secret_files: dict[str, str] = {}
+            for k, v in env_overrides.items():
+                path = os.path.join(secrets_dir, k)
+                with open(path, "w") as f:
+                    f.write(v)
+                env_secret_files[k] = path
+
+            ctx = _make_ctx(bundle, env_vars=list(env_overrides), env_secret_files=env_secret_files)
+            return provision._build_vertex_env(ctx).get("VERTEX_REGION", "")
+
+    def test_vertex_region_preferred(self) -> None:
+        self.assertEqual(
+            self._region({"VERTEX_REGION": "europe-west1", "GOOGLE_CLOUD_REGION": "asia-east1"}),
+            "europe-west1",
+        )
+
+    def test_google_cloud_region_second(self) -> None:
+        self.assertEqual(self._region({"GOOGLE_CLOUD_REGION": "asia-east1"}), "asia-east1")
+
+    def test_google_cloud_location_third(self) -> None:
+        self.assertEqual(self._region({"GOOGLE_CLOUD_LOCATION": "us-west1"}), "us-west1")
+
+    def test_default_us_central1(self) -> None:
+        self.assertEqual(self._region({}), "us-central1")
+
+
 class NoAuthModeTest(unittest.TestCase):
     def test_no_auth_activates_when_env_keys_empty_but_candidates_has_metadata(self) -> None:
         """auth-candidates.json always has metadata (schema_version etc.) even


### PR DESCRIPTION
## Changes

**Vertex AI auth** (main):
- config.yaml: vertex_ai capability enabled, vertex-ai auth type with VERTEX_PROJECT_ID / GOOGLE_CLOUD_PROJECT env resolution, gcloud-adc required_files with skipped_when_gcp_service_account_assigned
- provision.py: _build_vertex_env() resolves project/region (VERTEX_REGION → GOOGLE_CLOUD_REGION → GOOGLE_CLOUD_LOCATION → us-central1 default), writes ~/.hermes/.env and env overlay
- Default model for vertex-ai: google/gemini-2.5-flash (google/ prefix required for hermes vertex provider)

**Dockerfile**: hermes-agent → hermes-agent[vertex] (valid PyPI extra — installs google-auth for ADC)

**Tests**: 28 tests including vertex-ai auth selection, project ID fallback, API key precedence, region fallback chain (4 cases), and provision integration.

Skipped learnings: pin image digest (we build our own image), boot time tuning (container orchestration), dashboard auth (headless mode), ADC metadata server probe (handled declaratively via skipped_when_gcp_service_account_assigned)