### PR TITLE
fix: three GKE hosted broker dispatch fixes (#474, #483, #485)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,3 +34,4 @@ node_modules/
 vendor/
 tmp/
 .cache/
+!resources/**

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -28,6 +28,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -2285,7 +2286,14 @@ func deriveCloudRunLogicalBrokerID(settings *config.VersionedSettings, rt runtim
 	// Scan all profiles to find one backed by a cloudrun runtime with project+region.
 	// This avoids requiring active_profile to point to the cloudrun profile, which
 	// would make cloudrun the default dispatch profile — conflicting with k8s dispatch.
+	// Sort profile names for deterministic iteration: if multiple cloudrun profiles
+	// exist, the first alphabetically wins, producing a stable broker ID across restarts.
+	profileNames := make([]string, 0, len(settings.Profiles))
 	for profileName := range settings.Profiles {
+		profileNames = append(profileNames, profileName)
+	}
+	sort.Strings(profileNames)
+	for _, profileName := range profileNames {
 		rtConfig, runtimeType, err := settings.ResolveRuntime(profileName)
 		if err != nil || runtimeType != "cloudrun" || rtConfig.CloudRun == nil {
 			continue

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2282,12 +2282,29 @@ func deriveCloudRunLogicalBrokerID(settings *config.VersionedSettings, rt runtim
 	if settings == nil || rt == nil || rt.Name() != "cloudrun" {
 		return "", fmt.Errorf("deriveCloudRunLogicalBrokerID requires cloudrun runtime (got settings=%v, rt=%v)", settings != nil, rt)
 	}
+	// Scan all profiles to find one backed by a cloudrun runtime with project+region.
+	// This avoids requiring active_profile to point to the cloudrun profile, which
+	// would make cloudrun the default dispatch profile — conflicting with k8s dispatch.
+	for profileName := range settings.Profiles {
+		rtConfig, runtimeType, err := settings.ResolveRuntime(profileName)
+		if err != nil || runtimeType != "cloudrun" || rtConfig.CloudRun == nil {
+			continue
+		}
+		projectID := strings.TrimSpace(rtConfig.CloudRun.Project)
+		location := strings.TrimSpace(rtConfig.CloudRun.Region)
+		if projectID == "" || location == "" {
+			continue
+		}
+		seed := fmt.Sprintf("cloudrun:%s:%s", projectID, location)
+		return uuid.NewSHA1(cloudRunLogicalBrokerNamespace, []byte(seed)).String(), nil
+	}
+	// Fall back to resolving via active_profile for backward compatibility.
 	rtConfig, runtimeType, err := settings.ResolveRuntime("")
 	if err != nil {
 		return "", fmt.Errorf("deriveCloudRunLogicalBrokerID: failed to resolve runtime: %w", err)
 	}
 	if runtimeType != "cloudrun" || rtConfig.CloudRun == nil {
-		return "", fmt.Errorf("deriveCloudRunLogicalBrokerID: expected cloudrun runtime, got %q", runtimeType)
+		return "", fmt.Errorf("deriveCloudRunLogicalBrokerID: no cloudrun profile with project+region found in settings (active profile runtime: %q)", runtimeType)
 	}
 	projectID := strings.TrimSpace(rtConfig.CloudRun.Project)
 	location := strings.TrimSpace(rtConfig.CloudRun.Region)

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -336,11 +336,28 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 	// Two-phase image resolution: for short-form (bare) images, prefer a
 	// locally-built image over the registry version. If no local image
 	// exists, fall back to the registry rewrite.
+	// NOTE: The local-exists check only applies to runtimes with local image
+	// storage (docker, podman, container). Runtimes like kubernetes and cloudrun
+	// always return true from ImageExists (images are pulled on demand by the
+	// node), so we must skip the local check to ensure registry rewrite applies.
 	if settings != nil && resolvedImage != "" {
 		imageRegistry := settings.ResolveImageRegistry(opts.Profile)
 		if imageRegistry != "" && imagecheck.IsBareImageName(resolvedImage) {
-			localExists, localErr := m.Runtime.ImageExists(ctx, resolvedImage)
-			if localErr == nil && localExists {
+			runtimeName := ""
+			if m.Runtime != nil {
+				runtimeName = m.Runtime.Name()
+			}
+			hasLocalImages := runtimeName == "docker" || runtimeName == "podman" ||
+				runtimeName == "container" || runtimeName == "apple-container"
+			localExists := false
+			if hasLocalImages {
+				var localErr error
+				localExists, localErr = m.Runtime.ImageExists(ctx, resolvedImage)
+				if localErr != nil {
+					localExists = false
+				}
+			}
+			if localExists {
 				util.Debugf("image resolution: using local short-form image %s", resolvedImage)
 			} else {
 				rewritten := config.RewriteImageRegistry(resolvedImage, imageRegistry)

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -344,6 +344,9 @@ func GetTemplateChain(name string) ([]*Template, error) {
 
 	tpl, err := FindTemplate(name)
 	if err != nil {
+		if name == "default" {
+			return chain, nil
+		}
 		return nil, err
 	}
 	chain = append(chain, tpl)
@@ -407,6 +410,11 @@ func GetTemplateChainInProject(name, projectPath string) ([]*Template, error) {
 
 	tpl, err := FindTemplateInProjectPath(name, projectPath)
 	if err != nil {
+		if name == "default" {
+			// When the default template is not found, proceed without it
+			// (e.g. hub-dispatched agents on brokers with no local templates)
+			return chain, nil
+		}
 		return nil, err
 	}
 	chain = append(chain, tpl)


### PR DESCRIPTION
## Summary

Three fixes for GKE-dispatched agents via the Cloud Run hosted broker, discovered during end-to-end QA of the Cloud Run Hub + GKE Autopilot setup.

### pkg/agent/run.go — closes ptone:474
Skip ImageExists check for non-local runtimes (kubernetes, cloudrun). KubernetesRuntime.ImageExists always returns true, causing the two-phase resolver to skip RewriteImageRegistry. Bare images like scion-gemini-cli:latest were sent to GKE unqualified, resulting in docker.io/library/... not found errors.

### pkg/config/templates.go — closes ptone:485
Return empty chain instead of error when the default template is not found. The hosted broker has no local template dirs; agent creation without explicit template crashed with 'failed to load template: template default not found'.

### cmd/server_foreground.go — closes ptone:483
deriveCloudRunLogicalBrokerID now scans all profiles for type=cloudrun instead of using active_profile. Allows active_profile: remote (kubernetes) for dispatch while a separate cr profile handles broker ID.

## Testing

All three fixes validated on Cloud Run Hub scion-hub-00025-2sv (ptone-experiments) against GKE Autopilot cluster scion-agents (us-west2)