### PR TITLE
feat: broker OIDC transport auth for IAP-protected hubs (Phase 3)

### DIFF
--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -26,6 +26,8 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth/adcsource"
 	"github.com/GoogleCloudPlatform/scion/pkg/wsclient"
 	"github.com/spf13/cobra"
 )
@@ -167,5 +169,38 @@ func attachViaHub(hubCtx *HubContext, agentName string) error {
 		agentID = agentName // Fall back to name if ID not set
 	}
 
-	return wsclient.AttachToAgent(context.Background(), hubCtx.Endpoint, token, agentID)
+	// Resolve transport auth for IAP/Cloud Run traversal.
+	var attachOpts []wsclient.AttachOption
+	if transportSrc, transportMode, err := resolveAttachTransport(); err == nil && transportSrc != nil {
+		attachOpts = append(attachOpts, wsclient.WithTransport(transportSrc, transportMode))
+	}
+
+	return wsclient.AttachToAgent(context.Background(), hubCtx.Endpoint, token, agentID, attachOpts...)
+}
+
+// resolveAttachTransport resolves transport auth for the attach WebSocket path.
+// It checks env vars first, then settings.yaml. Returns (nil, _, nil) when
+// transport auth is not configured.
+func resolveAttachTransport() (transportauth.TokenSource, transportauth.HeaderMode, error) {
+	// Load settings for transport config.
+	resolvedPath, _, _ := config.ResolveProjectPath(projectPath)
+	settings, _ := config.LoadSettings(resolvedPath)
+
+	var ts *transportauth.TransportSettings
+	if settings != nil && settings.Hub != nil && settings.Hub.Transport != nil {
+		ts = &transportauth.TransportSettings{
+			Mode:     settings.Hub.Transport.Mode,
+			Audience: settings.Hub.Transport.Audience,
+		}
+	}
+
+	adcNew := func(audience string) (transportauth.TokenSource, error) {
+		src, err := adcsource.New(audience)
+		if err != nil {
+			return nil, err
+		}
+		return src, nil
+	}
+
+	return transportauth.FromSettings(ts, adcNew)
 }

--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -171,7 +171,11 @@ func attachViaHub(hubCtx *HubContext, agentName string) error {
 
 	// Resolve transport auth for IAP/Cloud Run traversal.
 	var attachOpts []wsclient.AttachOption
-	if transportSrc, transportMode, err := resolveAttachTransport(); err == nil && transportSrc != nil {
+	transportSrc, transportMode, err := resolveAttachTransport()
+	if err != nil {
+		return fmt.Errorf("failed to resolve transport auth: %w", err)
+	}
+	if transportSrc != nil {
 		attachOpts = append(attachOpts, wsclient.WithTransport(transportSrc, transportMode))
 	}
 

--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -194,13 +194,5 @@ func resolveAttachTransport() (transportauth.TokenSource, transportauth.HeaderMo
 		}
 	}
 
-	adcNew := func(audience string) (transportauth.TokenSource, error) {
-		src, err := adcsource.New(audience)
-		if err != nil {
-			return nil, err
-		}
-		return src, nil
-	}
-
-	return transportauth.FromSettings(ts, adcNew)
+	return transportauth.FromSettings(ts, adcsource.New)
 }

--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/daemon"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubsync"
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 	"github.com/GoogleCloudPlatform/scion/pkg/version"
 	"github.com/google/uuid"
@@ -1984,6 +1985,11 @@ func getHubClientForConnection(name string) (hubclient.Client, error) {
 		} else {
 			opts = append(opts, hubclient.WithAutoDevAuth())
 		}
+	}
+
+	// Transport auth for IAP-protected hubs
+	if src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience); err == nil && src != nil {
+		opts = append(opts, hubclient.WithTransportAuth(src, mode))
 	}
 
 	client, err := hubclient.New(creds.HubEndpoint, opts...)

--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubsync"
 	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth/adcsource"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 	"github.com/GoogleCloudPlatform/scion/pkg/version"
 	"github.com/google/uuid"
@@ -2006,7 +2007,7 @@ func getHubClientForConnection(name string) (hubclient.Client, error) {
 	}
 
 	// Transport auth for IAP-protected hubs
-	src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience)
+	src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience, adcsource.New)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve transport auth: %w", err)
 	}

--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -64,6 +64,10 @@ var (
 	brokerMakeDefault bool   // --make-default flag to set broker as project default
 	brokerHubFlag     string // --hub flag to target a specific hub connection
 
+	// broker register transport flags
+	brokerTransportMode     string
+	brokerTransportAudience string
+
 	// broker hubs flags
 	brokerHubsJSON bool
 )
@@ -339,6 +343,8 @@ func init() {
 	brokerRegisterCmd.Flags().BoolVar(&brokerForceRegister, "force", false, "Force re-registration even if already registered")
 	brokerRegisterCmd.Flags().BoolVar(&brokerAutoProvide, "auto-provide", false, "Automatically add as provider for new projects")
 	brokerRegisterCmd.Flags().StringVar(&brokerHubName, "name", "", "Name for this hub connection (derived from endpoint if not specified)")
+	brokerRegisterCmd.Flags().StringVar(&brokerTransportMode, "transport-mode", "", "Transport auth mode: 'iap' or 'cloudrun_invoker' (overrides SCION_TRANSPORT_MODE)")
+	brokerRegisterCmd.Flags().StringVar(&brokerTransportAudience, "transport-audience", "", "Transport auth OIDC audience (overrides SCION_TRANSPORT_AUDIENCE)")
 
 	// Deregister flags
 	brokerDeregisterCmd.Flags().BoolVar(&brokerDeregisterBrokerOnly, "broker-only", false, "Only remove broker record, not project providers")
@@ -578,14 +584,26 @@ func runBrokerRegister(cmd *cobra.Command, args []string) error {
 
 		brokerID = joinResp.BrokerID
 
+		// Resolve transport config from flags, then env
+		transportMode := brokerTransportMode
+		if transportMode == "" {
+			transportMode = os.Getenv(transportauth.EnvTransportMode)
+		}
+		transportAudience := brokerTransportAudience
+		if transportAudience == "" {
+			transportAudience = os.Getenv(transportauth.EnvTransportAudience)
+		}
+
 		// Save credentials to MultiStore
 		newCreds := &brokercredentials.BrokerCredentials{
-			Name:         hubName,
-			BrokerID:     brokerID,
-			SecretKey:    joinResp.SecretKey,
-			HubEndpoint:  endpoint,
-			AuthMode:     brokercredentials.AuthModeHMAC,
-			RegisteredAt: time.Now(),
+			Name:              hubName,
+			BrokerID:          brokerID,
+			SecretKey:         joinResp.SecretKey,
+			HubEndpoint:       endpoint,
+			AuthMode:          brokercredentials.AuthModeHMAC,
+			RegisteredAt:      time.Now(),
+			TransportMode:     transportMode,
+			TransportAudience: transportAudience,
 		}
 		if err := multiStore.Save(newCreds); err != nil {
 			fmt.Printf("Warning: failed to save broker credentials: %v\n", err)

--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -2006,7 +2006,11 @@ func getHubClientForConnection(name string) (hubclient.Client, error) {
 	}
 
 	// Transport auth for IAP-protected hubs
-	if src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience); err == nil && src != nil {
+	src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve transport auth: %w", err)
+	}
+	if src != nil {
 		opts = append(opts, hubclient.WithTransportAuth(src, mode))
 	}
 

--- a/cmd/hub.go
+++ b/cmd/hub.go
@@ -509,9 +509,11 @@ func getAuthInfo(settings *config.Settings, endpoint string) authInfo {
 		return info
 	}
 
-	// Check for proxy-auth mode: transport auth is active but no PAT/token.
-	// This is acceptable when the hub is behind IAP in proxy-auth mode —
-	// the broker's identity comes from the IAP assertion, not from a PAT.
+	// Proxy-auth mode: transport auth is active but no PAT/token configured.
+	// This checks only transport auth presence, not hub proxy mode, because:
+	// (a) getAuthInfo is informational — it doesn't enforce access control,
+	// (b) the client cannot know the hub's proxy-auth mode at this point,
+	// (c) the hub validates the IAP assertion server-side, which is the real guard.
 	if src, err := transportauth.FromEnv(); src != nil && err == nil {
 		info.Method = "Proxy-auth (transport)"
 		info.MethodType = "proxy-auth"

--- a/cmd/hub.go
+++ b/cmd/hub.go
@@ -34,6 +34,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/credentials"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubsync"
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 	"github.com/GoogleCloudPlatform/scion/pkg/version"
 	"github.com/spf13/cobra"
@@ -505,6 +506,16 @@ func getAuthInfo(settings *config.Settings, endpoint string) authInfo {
 		info.MethodType = "devauth"
 		info.Source = source
 		info.IsDevAuth = true
+		return info
+	}
+
+	// Check for proxy-auth mode: transport auth is active but no PAT/token.
+	// This is acceptable when the hub is behind IAP in proxy-auth mode —
+	// the broker's identity comes from the IAP assertion, not from a PAT.
+	if src, err := transportauth.FromEnv(); src != nil && err == nil {
+		info.Method = "Proxy-auth (transport)"
+		info.MethodType = "proxy-auth"
+		info.Source = "transport auth"
 		return info
 	}
 

--- a/cmd/sciontool/commands/doctor_transport_test.go
+++ b/cmd/sciontool/commands/doctor_transport_test.go
@@ -42,7 +42,7 @@ func doctorIAPMiddleware(expectedToken string, next http.Handler) http.Handler {
 		if auth != "Bearer "+expectedToken {
 			w.Header().Set("Content-Type", "text/html")
 			w.WriteHeader(http.StatusFound)
-			fmt.Fprint(w, "<html><body>Sign in with Google</body></html>")
+			_, _ = fmt.Fprint(w, "<html><body>Sign in with Google</body></html>")
 			return
 		}
 		next.ServeHTTP(w, r)
@@ -141,11 +141,11 @@ func TestCheckAuthentication_WithTransportAuth(t *testing.T) {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"status":"ok"}`)
+		_, _ = fmt.Fprint(w, `{"status":"ok"}`)
 	})
 	handler.HandleFunc("/api/v1/agents/test-agent/token/refresh", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"token":"new-token"}`)
+		_, _ = fmt.Fprint(w, `{"token":"new-token"}`)
 	})
 
 	server := httptest.NewServer(doctorIAPMiddleware(transportToken, handler))

--- a/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
+++ b/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
@@ -341,3 +341,174 @@ server:
 ### Reference scripts
 
 The `scripts/cloudrun/` directory on the `pr/cloudrun-hub` branch contains reference deployment scripts (deploy.sh, entrypoint.sh, hub-settings-template.yaml) for a Cloud Run + IAP topology that can serve as a starting point.
+
+## Brokers behind IAP
+
+When the Hub is behind IAP, **Runtime Brokers** must also carry a transport-layer OIDC token on every request — just like agents do. However, brokers are long-lived *originators*: nothing injects a transport token into them, so they must mint their own OIDC tokens from their runtime identity (GKE Workload Identity or ambient GCE service account).
+
+This section covers the deployment and configuration steps to connect brokers to an IAP-protected Hub.
+
+### Custom OAuth 2.0 Client ID requirement
+
+The Google-managed OAuth client that Cloud Run auto-provisions when IAP is enabled **does not support programmatic (service-account) authentication**. This means brokers (and any other machine client) cannot use it to mint OIDC tokens.
+
+You must:
+
+1. **Create a custom OAuth 2.0 Client ID** in the Google Cloud Console under **APIs & Services → Credentials → Create Credentials → OAuth client ID** (application type: Web application).
+2. **Bind the custom client ID to the IAP settings** for your Hub's backend service (Console → Security → IAP → select backend → Edit OAuth Client → Use custom client).
+
+The custom client ID (e.g., `1234567890-abc.apps.googleusercontent.com`) becomes the **OIDC audience** for all machine clients — both agents and brokers.
+
+:::note
+This is the same audience value used in `auth.transport.oidc_audience` in the Hub's `settings.yaml`. See [Transport configuration](#transport-configuration) above.
+:::
+
+### Broker Workload Identity setup
+
+Brokers running in GKE use [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) to mint OIDC tokens from the GCE metadata server.
+
+1. **Create a Google Service Account (GSA)** for brokers:
+   ```bash
+   gcloud iam service-accounts create scion-broker \
+     --display-name="Scion Broker"
+   ```
+
+2. **Grant the GSA access to traverse the platform guard.** The required role depends on the transport mode:
+
+   | Transport mode | Role | Target |
+   |---|---|---|
+   | `iap` | `roles/iap.httpsResourceAccessor` | Hub backend service |
+   | `cloudrun_invoker` | `roles/run.invoker` | Hub Cloud Run service |
+
+   For IAP:
+   ```bash
+   gcloud iap web add-iam-policy-binding \
+     --resource-type=backend-services \
+     --service=YOUR_BACKEND_SERVICE_NAME \
+     --member="serviceAccount:scion-broker@PROJECT_ID.iam.gserviceaccount.com" \
+     --role="roles/iap.httpsResourceAccessor"
+   ```
+
+3. **Bind the broker's Kubernetes Service Account (KSA) to the GSA** via the Workload Identity annotation:
+   ```bash
+   # Allow the KSA to impersonate the GSA
+   gcloud iam service-accounts add-iam-policy-binding \
+     scion-broker@PROJECT_ID.iam.gserviceaccount.com \
+     --member="serviceAccount:PROJECT_ID.svc.id.goog[NAMESPACE/BROKER_KSA_NAME]" \
+     --role="roles/iam.workloadIdentityUser"
+
+   # Annotate the KSA
+   kubectl annotate serviceaccount BROKER_KSA_NAME \
+     --namespace NAMESPACE \
+     iam.gke.io/gcp-service-account=scion-broker@PROJECT_ID.iam.gserviceaccount.com
+   ```
+
+The broker can now mint OIDC ID tokens for the configured audience via the metadata server, which the transport layer uses automatically.
+
+### Broker transport configuration
+
+Broker transport auth has two configuration layers: **environment variables** (for containerized brokers in Kubernetes) and **credentials-file fields** (for per-connection config).
+
+#### Environment variables
+
+Set these on the broker's Kubernetes Deployment:
+
+| Variable | Description |
+|---|---|
+| `SCION_TRANSPORT_MODE` | Transport mode: `iap` or `cloudrun_invoker` |
+| `SCION_TRANSPORT_AUDIENCE` | OIDC audience — the custom OAuth 2.0 Client ID (for `iap` mode) or the Hub URL (for `cloudrun_invoker` mode) |
+
+```yaml
+env:
+  - name: SCION_TRANSPORT_MODE
+    value: "iap"
+  - name: SCION_TRANSPORT_AUDIENCE
+    value: "1234567890-abc.apps.googleusercontent.com"
+```
+
+#### Credentials-file fields
+
+The broker credentials file (written by `scion hub brokers register`) can also store transport settings per hub connection:
+
+```json
+{
+  "brokerId": "...",
+  "secretKey": "...",
+  "hubEndpoint": "https://hub.example.com",
+  "transportMode": "iap",
+  "transportAudience": "1234567890-abc.apps.googleusercontent.com"
+}
+```
+
+**Environment variables override credentials-file values.** This allows Kubernetes Deployment manifests to set transport config declaratively while the credentials file retains the values persisted at registration time.
+
+:::tip[Multi-hub brokers]
+Per-connection placement in the credentials file exists for the **multi-hub scenario**: each hub connection can have its own `transportMode` and `transportAudience` (different IAP OAuth client IDs). A single broker can serve both IAP-protected and plain hubs simultaneously. See [Multi-Broker Setup](/scion/hosted/ha/multi-broker/) for details.
+:::
+
+### Broker registration without PAT (proxy-auth mode)
+
+With transport auth configured, `scion hub brokers register` works through IAP natively — no Personal Access Token (PAT) or hub token is needed. The broker authenticates via the IAP assertion of its service account identity.
+
+When the Hub is in `proxy` auth mode and the broker has a valid transport token source (Workload Identity), the registration command:
+
+1. Sends the OIDC transport token in the `Authorization` header to traverse IAP.
+2. IAP verifies the token and passes the request through to the Hub.
+3. The Hub identifies the caller via the IAP assertion (`X-Goog-IAP-JWT-Assertion`) and completes the registration.
+
+This retires the manual `install-broker.sh` curl-from-a-pod workaround.
+
+The `register` command also persists `transportMode` and `transportAudience` into the credentials file automatically, so the broker daemon inherits them on startup.
+
+### Registration Job manifest
+
+Instead of manual shell scripts, use a Kubernetes Job to register the broker. The Job runs with the broker's KSA (which has Workload Identity configured) and the transport environment variables:
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: register-broker
+  namespace: scion
+spec:
+  template:
+    metadata:
+      labels:
+        app: scion-broker-register
+    spec:
+      serviceAccountName: scion-broker  # KSA with Workload Identity annotation
+      restartPolicy: Never
+      containers:
+        - name: register
+          image: YOUR_SCION_IMAGE
+          env:
+            - name: SCION_TRANSPORT_MODE
+              value: "iap"
+            - name: SCION_TRANSPORT_AUDIENCE
+              value: "1234567890-abc.apps.googleusercontent.com"
+          command:
+            - scion
+            - hub
+            - brokers
+            - register
+            - --name
+            - my-broker
+            - --transport-mode
+            - iap
+            - --transport-audience
+            - "1234567890-abc.apps.googleusercontent.com"
+            - https://hub.example.com
+  backoffLimit: 2
+```
+
+After the Job completes, the credentials file is written to the broker's storage. The broker Deployment (using the same KSA and transport env vars) picks up the credentials on startup.
+
+### GKE deployment summary
+
+| Step | What |
+|---|---|
+| 1 | Create a custom OAuth 2.0 Client ID; bind it to the Hub service's IAP settings |
+| 2 | Create a broker GSA; grant `roles/iap.httpsResourceAccessor` on the Hub backend service |
+| 3 | Bind KSA ↔ GSA via Workload Identity annotation on the broker's Kubernetes service account |
+| 4 | Broker Deployment env: `SCION_TRANSPORT_MODE=iap`, `SCION_TRANSPORT_AUDIENCE=<custom client id>` |
+| 5 | One-time registration Job (same KSA) runs `scion hub brokers register` — no curl scripts |

--- a/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
+++ b/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
@@ -482,10 +482,15 @@ spec:
         - name: register
           image: YOUR_SCION_IMAGE
           env:
+            # Env vars enable the scion binary to traverse IAP for the
+            # registration HTTP request itself.
             - name: SCION_TRANSPORT_MODE
               value: "iap"
             - name: SCION_TRANSPORT_AUDIENCE
               value: "1234567890-abc.apps.googleusercontent.com"
+          volumeMounts:
+            - name: broker-credentials
+              mountPath: /home/scion/.scion
           command:
             - scion
             - hub
@@ -493,15 +498,24 @@ spec:
             - register
             - --name
             - my-broker
+            # CLI flags ensure transport values are persisted to the
+            # credentials file for the broker daemon to inherit.
             - --transport-mode
             - iap
             - --transport-audience
             - "1234567890-abc.apps.googleusercontent.com"
             - https://hub.example.com
+      volumes:
+        # The credentials file must persist beyond the Job pod so the
+        # broker Deployment can read it. Use a PVC, a Secret, or any
+        # shared volume accessible to the broker Deployment.
+        - name: broker-credentials
+          persistentVolumeClaim:
+            claimName: broker-credentials  # replace with your PVC
   backoffLimit: 2
 ```
 
-After the Job completes, the credentials file is written to the broker's storage. The broker Deployment (using the same KSA and transport env vars) picks up the credentials on startup.
+After the Job completes, the credentials file is written to the shared volume. The broker Deployment (mounting the same volume, with the same KSA and transport env vars) picks up the credentials on startup.
 
 ### GKE deployment summary
 

--- a/docs-site/src/content/docs/hosted/ha/kubernetes.md
+++ b/docs-site/src/content/docs/hosted/ha/kubernetes.md
@@ -89,6 +89,10 @@ When running in Google Kubernetes Engine (GKE), Scion natively supports Workload
 
 This provides the agent container with an ambient identity, which the underlying harness (e.g., Gemini or Claude via Vertex) can automatically resolve using Application Default Credentials (ADC).
 
+:::note[Broker Workload Identity]
+Runtime Brokers use the same Workload Identity mechanism for OIDC transport tokens when connecting to an IAP-protected Hub. The broker's GSA needs `roles/iap.httpsResourceAccessor` on the Hub backend service (or `roles/run.invoker` for Cloud Run invoker mode) — this is separate from the agent dispatch transport SA. See [Brokers behind IAP](/scion/hosted/ha/auth-proxy-iap/#brokers-behind-iap) for the full setup.
+:::
+
 ## Architecture & Security
 
 ### Native Client & In-Cluster Authentication

--- a/docs-site/src/content/docs/hosted/ha/multi-broker.md
+++ b/docs-site/src/content/docs/hosted/ha/multi-broker.md
@@ -51,6 +51,18 @@ When starting an agent, the Hub selects an available broker automatically. You c
   scion broker status
   ```
 
+## IAP-Protected Hubs
+
+When the Hub is behind [Google IAP](/scion/hosted/ha/auth-proxy-iap/), **all** brokers connecting to it need transport auth configured. Each broker must carry an OIDC token to traverse the platform guard.
+
+In a multi-hub setup using the broker's multistore, each hub connection can have its own transport settings:
+
+- **`transportMode`** and **`transportAudience`** are per-connection fields in the credentials file. Different hubs may use different IAP OAuth client IDs.
+- A single broker can serve both IAP-protected and plain (non-IAP) hubs simultaneously — connections without transport fields behave as before.
+- Environment variables (`SCION_TRANSPORT_MODE`, `SCION_TRANSPORT_AUDIENCE`) apply globally and override all credential-file values. Use per-connection fields when serving hubs with different audiences.
+
+See [Brokers behind IAP](/scion/hosted/ha/auth-proxy-iap/#brokers-behind-iap) for the full deployment guide.
+
 ## Considerations
 
 - Each broker manages its own **port pools, container images, and local storage**. Images must be available on each broker independently.

--- a/docs-site/src/content/docs/hosted/ha/runtime-broker.md
+++ b/docs-site/src/content/docs/hosted/ha/runtime-broker.md
@@ -63,6 +63,35 @@ To verify which projects your broker is currently serving:
 scion broker status
 ```
 
+## Transport Auth for IAP-Protected Hubs
+
+When the Hub is behind [Google IAP](/scion/hosted/ha/auth-proxy-iap/), the broker must carry a transport-layer OIDC token on every request. Transport auth is configured either during registration or via environment variables.
+
+### Configuration at registration time
+
+The `scion hub brokers register` command accepts transport flags that are persisted to the credentials file:
+
+```bash
+scion hub brokers register \
+  --name my-broker \
+  --transport-mode iap \
+  --transport-audience "1234567890-abc.apps.googleusercontent.com" \
+  https://hub.example.com
+```
+
+| Flag | Description |
+|---|---|
+| `--transport-mode` | Transport mode: `iap` or `cloudrun_invoker` |
+| `--transport-audience` | OIDC audience — the custom OAuth 2.0 Client ID (for `iap`) or Hub URL (for `cloudrun_invoker`) |
+
+These values are written to the credentials file as `transportMode` and `transportAudience`, so the broker daemon automatically uses them on startup.
+
+### Environment variable overrides
+
+For containerized brokers, set `SCION_TRANSPORT_MODE` and `SCION_TRANSPORT_AUDIENCE` as environment variables in the Deployment manifest. Environment variables override credentials-file values.
+
+See [Brokers behind IAP](/scion/hosted/ha/auth-proxy-iap/#brokers-behind-iap) for the full deployment guide, including Workload Identity setup and the registration Job manifest.
+
 ## Security & Isolation
 
 When you register your machine as a broker:

--- a/docs-site/src/content/docs/reference/server-config.md
+++ b/docs-site/src/content/docs/reference/server-config.md
@@ -102,6 +102,47 @@ Persistence settings for the Hub.
 | `dev_token` | string | | Static token for dev mode. |
 | `authorized_domains` | list | `[]` | Limit access to specific email domains. |
 
+### Transport Auth (`server.auth.transport`)
+
+Transport auth configuration for the platform guard (IAP or Cloud Run invoker). See [Proxy Auth (Google IAP)](/scion/hosted/ha/auth-proxy-iap/) for the full deployment guide.
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `mode` | string | `"none"` | Transport auth mode: `none`, `iap`, or `cloudrun_invoker`. |
+| `oidc_audience` | string | | OIDC audience for transport tokens. For `iap`: the IAP OAuth client ID. For `cloudrun_invoker`: the Hub URL (auto-derived from `hub.public_url` if empty). |
+| `platform_auth_sa` | string | | Dedicated service account the Hub impersonates to mint OIDC ID tokens for agents. |
+
+#### Agent transport environment variables
+
+When transport auth is configured, the Hub injects these environment variables into agent containers at dispatch time:
+
+| Variable | Description |
+| :--- | :--- |
+| `SCION_TRANSPORT_TOKEN` | Initial Google OIDC ID token for the transport layer. |
+| `SCION_TRANSPORT_AUDIENCE` | Audience the transport token was minted for. |
+| `SCION_TRANSPORT_TOKEN_EXPIRY` | Token expiry in RFC 3339 format. |
+| `SCION_TRANSPORT_MODE` | Transport mode (`iap` or `cloudrun_invoker`). Injected alongside the other three transport vars so that in-agent clients can select the correct header placement. |
+
+#### Broker transport configuration
+
+Brokers are long-lived originators that mint their own OIDC tokens (via GKE Workload Identity or ambient GCE SA). Transport settings are configured via environment variables or per-connection credentials-file fields.
+
+**Environment variables** (for containerized brokers):
+
+| Variable | Description |
+| :--- | :--- |
+| `SCION_TRANSPORT_MODE` | Transport mode: `iap` or `cloudrun_invoker`. |
+| `SCION_TRANSPORT_AUDIENCE` | OIDC audience — the custom OAuth 2.0 Client ID (for `iap`) or Hub URL (for `cloudrun_invoker`). |
+
+**Credentials-file fields** (per hub connection, persisted by `scion hub brokers register`):
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `transportMode` | string | Transport mode: `iap` or `cloudrun_invoker`. |
+| `transportAudience` | string | OIDC audience for the transport token. |
+
+Environment variables override credentials-file values. Per-connection credentials-file fields support the multi-hub scenario where each hub has a different IAP OAuth client ID.
+
 ### OAuth (`server.oauth`)
 
 OAuth provider credentials.

--- a/pkg/brokercredentials/multistore_test.go
+++ b/pkg/brokercredentials/multistore_test.go
@@ -524,6 +524,115 @@ func TestMultiStore_SaveValidation(t *testing.T) {
 	}
 }
 
+func TestMultiStore_TransportFieldsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store := NewMultiStore(dir)
+
+	creds := &BrokerCredentials{
+		Name:              "iap-hub",
+		BrokerID:          "broker-iap",
+		SecretKey:         base64.StdEncoding.EncodeToString([]byte("secret")),
+		HubEndpoint:       "https://iap-hub.example.com",
+		AuthMode:          AuthModeHMAC,
+		TransportMode:     "iap",
+		TransportAudience: "12345.apps.googleusercontent.com",
+	}
+
+	if err := store.Save(creds); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	loaded, err := store.Load("iap-hub")
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if loaded.TransportMode != "iap" {
+		t.Errorf("TransportMode: expected %q, got %q", "iap", loaded.TransportMode)
+	}
+	if loaded.TransportAudience != "12345.apps.googleusercontent.com" {
+		t.Errorf("TransportAudience: expected %q, got %q", "12345.apps.googleusercontent.com", loaded.TransportAudience)
+	}
+}
+
+func TestMultiStore_TransportFieldsBackwardCompatibility(t *testing.T) {
+	dir := t.TempDir()
+	store := NewMultiStore(dir)
+
+	// Write old-format JSON without transport fields
+	oldJSON := `{"name": "old-hub", "brokerId": "old-broker", "secretKey": "c2VjcmV0"}`
+	if err := os.MkdirAll(dir, DirMode); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "old-hub.json"), []byte(oldJSON), FileMode); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := store.Load("old-hub")
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if loaded.TransportMode != "" {
+		t.Errorf("Expected empty TransportMode, got %q", loaded.TransportMode)
+	}
+	if loaded.TransportAudience != "" {
+		t.Errorf("Expected empty TransportAudience, got %q", loaded.TransportAudience)
+	}
+}
+
+func TestMultiStore_MixedTransportConfigs(t *testing.T) {
+	dir := t.TempDir()
+	store := NewMultiStore(dir)
+
+	// IAP hub
+	iapCreds := &BrokerCredentials{
+		Name:              "iap-hub",
+		BrokerID:          "broker-iap",
+		SecretKey:         base64.StdEncoding.EncodeToString([]byte("secret1")),
+		HubEndpoint:       "https://iap-hub.example.com",
+		AuthMode:          AuthModeHMAC,
+		TransportMode:     "iap",
+		TransportAudience: "12345.apps.googleusercontent.com",
+	}
+	// Plain hub (no transport auth)
+	plainCreds := &BrokerCredentials{
+		Name:        "plain-hub",
+		BrokerID:    "broker-plain",
+		SecretKey:   base64.StdEncoding.EncodeToString([]byte("secret2")),
+		HubEndpoint: "https://plain-hub.example.com",
+		AuthMode:    AuthModeHMAC,
+	}
+
+	if err := store.Save(iapCreds); err != nil {
+		t.Fatalf("Save IAP failed: %v", err)
+	}
+	if err := store.Save(plainCreds); err != nil {
+		t.Fatalf("Save plain failed: %v", err)
+	}
+
+	// Verify IAP hub has transport config
+	iap, err := store.Load("iap-hub")
+	if err != nil {
+		t.Fatalf("Load IAP failed: %v", err)
+	}
+	if iap.TransportMode != "iap" {
+		t.Errorf("IAP TransportMode: expected %q, got %q", "iap", iap.TransportMode)
+	}
+
+	// Verify plain hub has no transport config
+	plain, err := store.Load("plain-hub")
+	if err != nil {
+		t.Fatalf("Load plain failed: %v", err)
+	}
+	if plain.TransportMode != "" {
+		t.Errorf("Plain TransportMode: expected empty, got %q", plain.TransportMode)
+	}
+	if plain.TransportAudience != "" {
+		t.Errorf("Plain TransportAudience: expected empty, got %q", plain.TransportAudience)
+	}
+}
+
 func TestMultiStore_LoadPopulatesName(t *testing.T) {
 	dir := t.TempDir()
 	store := NewMultiStore(dir)

--- a/pkg/brokercredentials/store.go
+++ b/pkg/brokercredentials/store.go
@@ -69,6 +69,10 @@ type BrokerCredentials struct {
 	AuthMode AuthMode `json:"authMode,omitempty"`
 	// RegisteredAt is when this broker was registered with the Hub.
 	RegisteredAt time.Time `json:"registeredAt"`
+	// TransportMode is the transport-layer auth mode ("iap" or "cloudrun_invoker").
+	TransportMode string `json:"transportMode,omitempty"`
+	// TransportAudience is the OIDC audience for transport-layer auth.
+	TransportAudience string `json:"transportAudience,omitempty"`
 }
 
 // Store manages broker credentials on the local filesystem.

--- a/pkg/brokercredentials/store_test.go
+++ b/pkg/brokercredentials/store_test.go
@@ -356,6 +356,63 @@ func TestStore_JSONFormat(t *testing.T) {
 	}
 }
 
+func TestStore_TransportFieldsRoundTrip(t *testing.T) {
+	tempDir := t.TempDir()
+	credPath := filepath.Join(tempDir, "broker-credentials.json")
+	store := NewStore(credPath)
+
+	creds := &BrokerCredentials{
+		BrokerID:          "broker-iap",
+		SecretKey:         base64.StdEncoding.EncodeToString([]byte("secret")),
+		HubEndpoint:       "https://hub.example.com",
+		TransportMode:     "iap",
+		TransportAudience: "12345.apps.googleusercontent.com",
+	}
+
+	if err := store.Save(creds); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if loaded.TransportMode != "iap" {
+		t.Errorf("TransportMode: expected %q, got %q", "iap", loaded.TransportMode)
+	}
+	if loaded.TransportAudience != "12345.apps.googleusercontent.com" {
+		t.Errorf("TransportAudience: expected %q, got %q", "12345.apps.googleusercontent.com", loaded.TransportAudience)
+	}
+}
+
+func TestStore_TransportFieldsBackwardCompatibility(t *testing.T) {
+	tempDir := t.TempDir()
+	credPath := filepath.Join(tempDir, "broker-credentials.json")
+
+	// Write old-format JSON without transport fields
+	oldJSON := `{"brokerId": "old-broker", "secretKey": "c2VjcmV0", "hubEndpoint": "https://hub.example.com"}`
+	if err := os.WriteFile(credPath, []byte(oldJSON), 0600); err != nil {
+		t.Fatalf("Failed to write: %v", err)
+	}
+
+	store := NewStore(credPath)
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if loaded.TransportMode != "" {
+		t.Errorf("Expected empty TransportMode for old creds, got %q", loaded.TransportMode)
+	}
+	if loaded.TransportAudience != "" {
+		t.Errorf("Expected empty TransportAudience for old creds, got %q", loaded.TransportAudience)
+	}
+	if loaded.BrokerID != "old-broker" {
+		t.Errorf("BrokerID: expected %q, got %q", "old-broker", loaded.BrokerID)
+	}
+}
+
 func TestStore_ModTime(t *testing.T) {
 	tempDir := t.TempDir()
 	credPath := filepath.Join(tempDir, "broker-credentials.json")

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -81,6 +81,15 @@ type BucketConfig struct {
 //   - SCION_HUB_TOKEN: Bearer token for Hub authentication
 //   - SCION_HUB_API_KEY: API key for Hub authentication (alternative to token)
 //   - SCION_HUB_ENABLED: Set to "true" to enable Hub integration
+// HubTransportConfig defines transport-layer auth settings for traversing
+// platform guards (IAP, Cloud Run invoker IAM) in front of the Hub.
+type HubTransportConfig struct {
+	// Mode is the transport auth mode: "iap" or "cloudrun_invoker".
+	Mode string `json:"mode,omitempty" yaml:"mode,omitempty" koanf:"mode"`
+	// Audience is the OIDC audience (typically the IAP OAuth client ID).
+	Audience string `json:"audience,omitempty" yaml:"audience,omitempty" koanf:"audience"`
+}
+
 type HubClientConfig struct {
 	// Enabled indicates whether Hub integration is enabled.
 	// When enabled and configured, agent operations are routed through the Hub.
@@ -115,6 +124,9 @@ type HubClientConfig struct {
 	// Used to determine whether hub-only agents were created by other brokers
 	// (after this timestamp) or were locally deleted (before this timestamp).
 	LastSyncedAt string `json:"lastSyncedAt,omitempty" yaml:"lastSyncedAt,omitempty" koanf:"lastSyncedAt"`
+	// Transport defines transport-layer auth settings for traversing platform
+	// guards (IAP, Cloud Run invoker IAM) in front of the Hub.
+	Transport *HubTransportConfig `json:"transport,omitempty" yaml:"transport,omitempty" koanf:"transport"`
 }
 
 type CLIConfig struct {
@@ -681,6 +693,16 @@ func GetSettingValue(s *Settings, key string) (string, error) {
 			return s.CLI.Mode, nil
 		}
 		return "", nil
+	case "hub.transport.mode":
+		if s.Hub != nil && s.Hub.Transport != nil {
+			return s.Hub.Transport.Mode, nil
+		}
+		return "", nil
+	case "hub.transport.audience":
+		if s.Hub != nil && s.Hub.Transport != nil {
+			return s.Hub.Transport.Audience, nil
+		}
+		return "", nil
 	}
 
 	// Handle hub_connections.<name>.endpoint keys
@@ -746,6 +768,10 @@ func GetSettingsMap(s *Settings) map[string]string {
 			m["hub.brokerToken"] = "********" // Mask broker token
 		}
 		m["hub.lastSyncedAt"] = s.Hub.LastSyncedAt
+		if s.Hub.Transport != nil {
+			m["hub.transport.mode"] = s.Hub.Transport.Mode
+			m["hub.transport.audience"] = s.Hub.Transport.Audience
+		}
 	}
 	if s.CLI != nil {
 		if s.CLI.AutoHelp != nil {

--- a/pkg/runtimebroker/controlchannel.go
+++ b/pkg/runtimebroker/controlchannel.go
@@ -318,7 +318,7 @@ func (c *ControlChannelClient) buildAuthHeaders() (http.Header, error) {
 		// Still apply transport auth even without HMAC (proxy-auth mode)
 		if c.config.TransportSource != nil {
 			if err := transportauth.ApplyHeaders(headers, c.config.TransportSource, c.config.TransportMode); err != nil {
-				slog.Warn("failed to apply transport auth headers", "error", err)
+				return nil, fmt.Errorf("failed to apply transport auth headers: %w", err)
 			}
 		}
 		return headers, nil
@@ -353,7 +353,7 @@ func (c *ControlChannelClient) buildAuthHeaders() (http.Header, error) {
 	// Transport-layer OIDC for IAP-protected hubs
 	if c.config.TransportSource != nil {
 		if err := transportauth.ApplyHeaders(headers, c.config.TransportSource, c.config.TransportMode); err != nil {
-			slog.Warn("failed to apply transport auth headers", "error", err)
+			return nil, fmt.Errorf("failed to apply transport auth headers: %w", err)
 		}
 	}
 

--- a/pkg/runtimebroker/controlchannel.go
+++ b/pkg/runtimebroker/controlchannel.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
 	"github.com/GoogleCloudPlatform/scion/pkg/wsprotocol"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -58,6 +59,11 @@ type ControlChannelConfig struct {
 
 	// Debug enables verbose logging.
 	Debug bool
+
+	// TransportSource provides OIDC tokens for transport-layer auth (IAP).
+	TransportSource transportauth.TokenSource
+	// TransportMode controls which HTTP header carries the transport token.
+	TransportMode transportauth.HeaderMode
 
 	// OnConnectionStateChange is called when the control channel connects
 	// or disconnects. connected=true after a successful handshake,
@@ -308,8 +314,13 @@ func (c *ControlChannelClient) buildAuthHeaders() (http.Header, error) {
 	headers := http.Header{}
 
 	if len(c.config.SecretKey) == 0 {
-		// No auth configured
 		headers.Set("X-Scion-Broker-ID", c.config.BrokerID)
+		// Still apply transport auth even without HMAC (proxy-auth mode)
+		if c.config.TransportSource != nil {
+			if err := transportauth.ApplyHeaders(headers, c.config.TransportSource, c.config.TransportMode); err != nil {
+				slog.Warn("failed to apply transport auth headers", "error", err)
+			}
+		}
 		return headers, nil
 	}
 
@@ -337,6 +348,13 @@ func (c *ControlChannelClient) buildAuthHeaders() (http.Header, error) {
 	// Copy the signed headers
 	for key := range req.Header {
 		headers.Set(key, req.Header.Get(key))
+	}
+
+	// Transport-layer OIDC for IAP-protected hubs
+	if c.config.TransportSource != nil {
+		if err := transportauth.ApplyHeaders(headers, c.config.TransportSource, c.config.TransportMode); err != nil {
+			slog.Warn("failed to apply transport auth headers", "error", err)
+		}
 	}
 
 	return headers, nil

--- a/pkg/runtimebroker/controlchannel_transport_test.go
+++ b/pkg/runtimebroker/controlchannel_transport_test.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtimebroker
+
+import (
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
+)
+
+// fakeTokenSource returns a configurable sequence of tokens for testing.
+type fakeTokenSource struct {
+	tokens  []string
+	expiry  time.Time
+	callIdx atomic.Int64
+}
+
+func newFakeTokenSource(tokens ...string) *fakeTokenSource {
+	return &fakeTokenSource{
+		tokens: tokens,
+		expiry: time.Now().Add(time.Hour),
+	}
+}
+
+func (f *fakeTokenSource) Token() (string, error) {
+	idx := f.callIdx.Add(1) - 1
+	if int(idx) < len(f.tokens) {
+		return f.tokens[idx], nil
+	}
+	return f.tokens[len(f.tokens)-1], nil
+}
+
+func (f *fakeTokenSource) SetToken(token string, expiry time.Time) {
+	f.expiry = expiry
+}
+
+func (f *fakeTokenSource) Expiry() time.Time {
+	return f.expiry
+}
+
+func (f *fakeTokenSource) CallCount() int64 {
+	return f.callIdx.Load()
+}
+
+func TestBuildAuthHeaders_WithTransportAuth(t *testing.T) {
+	cc := &ControlChannelClient{
+		config: ControlChannelConfig{
+			HubEndpoint:     "https://hub.example.com",
+			BrokerID:        "broker-1",
+			SecretKey:       []byte("test-secret-key-for-hmac-signing"),
+			TransportSource: newFakeTokenSource("oidc-token-1"),
+			TransportMode:   transportauth.HeaderProxyAuthorization,
+		},
+	}
+
+	headers, err := cc.buildAuthHeaders()
+	if err != nil {
+		t.Fatalf("buildAuthHeaders failed: %v", err)
+	}
+
+	// HMAC headers should be present (X-Scion-* headers, not Authorization)
+	if bid := headers.Get("X-Scion-Broker-ID"); bid != "broker-1" {
+		t.Errorf("expected X-Scion-Broker-ID=%q, got %q", "broker-1", bid)
+	}
+	if sig := headers.Get("X-Scion-Signature"); sig == "" {
+		t.Error("expected X-Scion-Signature header")
+	}
+
+	// Transport OIDC token should be in Proxy-Authorization
+	if pa := headers.Get("Proxy-Authorization"); pa != "Bearer oidc-token-1" {
+		t.Errorf("Proxy-Authorization: expected %q, got %q", "Bearer oidc-token-1", pa)
+	}
+}
+
+func TestBuildAuthHeaders_WithoutTransportAuth(t *testing.T) {
+	cc := &ControlChannelClient{
+		config: ControlChannelConfig{
+			HubEndpoint: "https://hub.example.com",
+			BrokerID:    "broker-1",
+			SecretKey:   []byte("test-secret-key-for-hmac-signing"),
+		},
+	}
+
+	headers, err := cc.buildAuthHeaders()
+	if err != nil {
+		t.Fatalf("buildAuthHeaders failed: %v", err)
+	}
+
+	// HMAC headers should be present
+	if bid := headers.Get("X-Scion-Broker-ID"); bid != "broker-1" {
+		t.Errorf("expected X-Scion-Broker-ID=%q, got %q", "broker-1", bid)
+	}
+
+	// No Proxy-Authorization when transport auth is nil
+	if pa := headers.Get("Proxy-Authorization"); pa != "" {
+		t.Errorf("expected no Proxy-Authorization, got %q", pa)
+	}
+}
+
+func TestBuildAuthHeaders_ReconnectFreshToken(t *testing.T) {
+	src := newFakeTokenSource("token-attempt-1", "token-attempt-2", "token-attempt-3")
+	cc := &ControlChannelClient{
+		config: ControlChannelConfig{
+			HubEndpoint:     "https://hub.example.com",
+			BrokerID:        "broker-1",
+			SecretKey:       []byte("test-secret-key-for-hmac-signing"),
+			TransportSource: src,
+			TransportMode:   transportauth.HeaderProxyAuthorization,
+		},
+	}
+
+	// First dial attempt
+	headers1, err := cc.buildAuthHeaders()
+	if err != nil {
+		t.Fatalf("first buildAuthHeaders failed: %v", err)
+	}
+	if pa := headers1.Get("Proxy-Authorization"); pa != "Bearer token-attempt-1" {
+		t.Errorf("first attempt: expected token-attempt-1, got %q", pa)
+	}
+
+	// Simulate reconnect — second dial attempt
+	headers2, err := cc.buildAuthHeaders()
+	if err != nil {
+		t.Fatalf("second buildAuthHeaders failed: %v", err)
+	}
+	if pa := headers2.Get("Proxy-Authorization"); pa != "Bearer token-attempt-2" {
+		t.Errorf("second attempt: expected token-attempt-2, got %q", pa)
+	}
+
+	// Third reconnect
+	headers3, err := cc.buildAuthHeaders()
+	if err != nil {
+		t.Fatalf("third buildAuthHeaders failed: %v", err)
+	}
+	if pa := headers3.Get("Proxy-Authorization"); pa != "Bearer token-attempt-3" {
+		t.Errorf("third attempt: expected token-attempt-3, got %q", pa)
+	}
+
+	// Verify Token() was called once per buildAuthHeaders call
+	if src.CallCount() != 3 {
+		t.Errorf("expected 3 Token() calls, got %d", src.CallCount())
+	}
+}
+
+func TestBuildAuthHeaders_ServerlessMode(t *testing.T) {
+	cc := &ControlChannelClient{
+		config: ControlChannelConfig{
+			HubEndpoint:     "https://hub.example.com",
+			BrokerID:        "broker-1",
+			SecretKey:       []byte("test-secret-key-for-hmac-signing"),
+			TransportSource: newFakeTokenSource("serverless-token"),
+			TransportMode:   transportauth.HeaderServerlessAuthorization,
+		},
+	}
+
+	headers, err := cc.buildAuthHeaders()
+	if err != nil {
+		t.Fatalf("buildAuthHeaders failed: %v", err)
+	}
+
+	if sa := headers.Get("X-Serverless-Authorization"); sa != "Bearer serverless-token" {
+		t.Errorf("X-Serverless-Authorization: expected %q, got %q", "Bearer serverless-token", sa)
+	}
+}
+
+func TestBuildAuthHeaders_NoSecretKey_WithTransport(t *testing.T) {
+	cc := &ControlChannelClient{
+		config: ControlChannelConfig{
+			HubEndpoint:     "https://hub.example.com",
+			BrokerID:        "broker-1",
+			TransportSource: newFakeTokenSource("no-hmac-token"),
+			TransportMode:   transportauth.HeaderProxyAuthorization,
+		},
+	}
+
+	headers, err := cc.buildAuthHeaders()
+	if err != nil {
+		t.Fatalf("buildAuthHeaders failed: %v", err)
+	}
+
+	// Should have X-Scion-Broker-ID (dev-auth path)
+	if bid := headers.Get("X-Scion-Broker-ID"); bid != "broker-1" {
+		t.Errorf("expected X-Scion-Broker-ID, got %q", bid)
+	}
+
+	// Should still have transport auth
+	if pa := headers.Get("Proxy-Authorization"); pa != "Bearer no-hmac-token" {
+		t.Errorf("Proxy-Authorization: expected %q, got %q", "Bearer no-hmac-token", pa)
+	}
+}
+
+// fakeIAPMiddleware simulates IAP by rejecting requests without the expected token.
+func fakeIAPMiddleware(expectedToken string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := ""
+		if auth := r.Header.Get("Proxy-Authorization"); auth != "" {
+			token = auth
+		} else if auth := r.Header.Get("Authorization"); auth != "" {
+			token = auth
+		}
+
+		expected := "Bearer " + expectedToken
+		if token != expected {
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte("<html><body>Sign in with Google</body></html>"))
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/runtimebroker/controlchannel_transport_test.go
+++ b/pkg/runtimebroker/controlchannel_transport_test.go
@@ -15,7 +15,6 @@
 package runtimebroker
 
 import (
-	"net/http"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -202,25 +201,4 @@ func TestBuildAuthHeaders_NoSecretKey_WithTransport(t *testing.T) {
 	if pa := headers.Get("Proxy-Authorization"); pa != "Bearer no-hmac-token" {
 		t.Errorf("Proxy-Authorization: expected %q, got %q", "Bearer no-hmac-token", pa)
 	}
-}
-
-// fakeIAPMiddleware simulates IAP by rejecting requests without the expected token.
-func fakeIAPMiddleware(expectedToken string, next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		token := ""
-		if auth := r.Header.Get("Proxy-Authorization"); auth != "" {
-			token = auth
-		} else if auth := r.Header.Get("Authorization"); auth != "" {
-			token = auth
-		}
-
-		expected := "Bearer " + expectedToken
-		if token != expected {
-			w.Header().Set("Content-Type", "text/html")
-			w.WriteHeader(http.StatusForbidden)
-			w.Write([]byte("<html><body>Sign in with Google</body></html>"))
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
 }

--- a/pkg/runtimebroker/hub_connection.go
+++ b/pkg/runtimebroker/hub_connection.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/templatecache"
 	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth/adcsource"
 	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
 )
 
@@ -238,7 +239,7 @@ func (hc *HubConnection) Reinitialize(ctx context.Context, server *Server, creds
 
 	// Create new Hub client, resolving transport auth once for both REST and WebSocket
 	opts := buildHubClientOpts(creds, secretKey)
-	src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience, nil)
+	src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience, adcsource.New)
 	if err != nil {
 		hc.setStatus(ConnectionStatusError)
 		return fmt.Errorf("failed to resolve transport auth: %w", err)

--- a/pkg/runtimebroker/hub_connection.go
+++ b/pkg/runtimebroker/hub_connection.go
@@ -238,7 +238,7 @@ func (hc *HubConnection) Reinitialize(ctx context.Context, server *Server, creds
 
 	// Create new Hub client, resolving transport auth once for both REST and WebSocket
 	opts := buildHubClientOpts(creds, secretKey)
-	src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience)
+	src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience, nil)
 	if err != nil {
 		hc.setStatus(ConnectionStatusError)
 		return fmt.Errorf("failed to resolve transport auth: %w", err)

--- a/pkg/runtimebroker/hub_connection.go
+++ b/pkg/runtimebroker/hub_connection.go
@@ -238,7 +238,12 @@ func (hc *HubConnection) Reinitialize(ctx context.Context, server *Server, creds
 
 	// Create new Hub client, resolving transport auth once for both REST and WebSocket
 	opts := buildHubClientOpts(creds, secretKey)
-	if src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience); err == nil && src != nil {
+	src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience)
+	if err != nil {
+		hc.setStatus(ConnectionStatusError)
+		return fmt.Errorf("failed to resolve transport auth: %w", err)
+	}
+	if src != nil {
 		hc.TransportSource = src
 		hc.TransportMode = mode
 		opts = append(opts, hubclient.WithTransportAuth(src, mode))

--- a/pkg/runtimebroker/hub_connection.go
+++ b/pkg/runtimebroker/hub_connection.go
@@ -236,8 +236,17 @@ func (hc *HubConnection) Reinitialize(ctx context.Context, server *Server, creds
 	}
 	hc.SecretKey = secretKey
 
-	// Create new Hub client
+	// Create new Hub client, resolving transport auth once for both REST and WebSocket
 	opts := buildHubClientOpts(creds, secretKey)
+	if src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience); err == nil && src != nil {
+		hc.TransportSource = src
+		hc.TransportMode = mode
+		opts = append(opts, hubclient.WithTransportAuth(src, mode))
+	} else {
+		hc.TransportSource = nil
+		hc.TransportMode = 0
+	}
+
 	client, err := hubclient.New(creds.HubEndpoint, opts...)
 	if err != nil {
 		hc.setStatus(ConnectionStatusError)
@@ -251,15 +260,6 @@ func (hc *HubConnection) Reinitialize(ctx context.Context, server *Server, creds
 	}
 	if server.hcCache != nil {
 		hc.HCResolver = templatecache.NewHarnessConfigResolver(server.hcCache, client)
-	}
-
-	// Re-resolve transport auth for the control channel
-	if src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience); err == nil && src != nil {
-		hc.TransportSource = src
-		hc.TransportMode = mode
-	} else {
-		hc.TransportSource = nil
-		hc.TransportMode = 0
 	}
 
 	slog.Info("Hub connection reinitialized", "name", hc.Name, "brokerID", creds.BrokerID)
@@ -290,12 +290,6 @@ func buildHubClientOpts(creds *brokercredentials.BrokerCredentials, secretKey []
 			opts = append(opts, hubclient.WithAutoDevAuth())
 			slog.Info("Hub client using auto dev authentication (no secret key)", "name", creds.Name)
 		}
-	}
-
-	// Transport auth for IAP-protected hubs
-	if src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience); err == nil && src != nil {
-		opts = append(opts, hubclient.WithTransportAuth(src, mode))
-		slog.Info("Hub client using transport auth", "name", creds.Name, "mode", creds.TransportMode)
 	}
 
 	return opts

--- a/pkg/runtimebroker/hub_connection.go
+++ b/pkg/runtimebroker/hub_connection.go
@@ -54,6 +54,13 @@ type HubConnection struct {
 	Credentials *brokercredentials.BrokerCredentials
 	SecretKey   []byte // decoded from Credentials.SecretKey
 
+	// TransportSource and TransportMode are resolved per-connection for
+	// the control channel WebSocket. The REST hubclient handles its own
+	// transport auth via WithTransportAuth(), but the control channel
+	// dials directly and needs these to build auth headers.
+	TransportSource transportauth.TokenSource
+	TransportMode   transportauth.HeaderMode
+
 	HubClient      hubclient.Client
 	Hydrator       *templatecache.Hydrator
 	HCResolver     *templatecache.Resolver // harness-config hydrator
@@ -147,6 +154,8 @@ func (hc *HubConnection) Start(ctx context.Context, server *Server) error {
 				PongWait:            60 * time.Second,
 				WriteWait:           10 * time.Second,
 				Debug:               server.config.Debug,
+				TransportSource:     hc.TransportSource,
+				TransportMode:       hc.TransportMode,
 				OnConnectionStateChange: func(connected bool) {
 					if connected {
 						hc.setStatus(ConnectionStatusConnected)
@@ -242,6 +251,15 @@ func (hc *HubConnection) Reinitialize(ctx context.Context, server *Server, creds
 	}
 	if server.hcCache != nil {
 		hc.HCResolver = templatecache.NewHarnessConfigResolver(server.hcCache, client)
+	}
+
+	// Re-resolve transport auth for the control channel
+	if src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience); err == nil && src != nil {
+		hc.TransportSource = src
+		hc.TransportMode = mode
+	} else {
+		hc.TransportSource = nil
+		hc.TransportMode = 0
 	}
 
 	slog.Info("Hub connection reinitialized", "name", hc.Name, "brokerID", creds.BrokerID)

--- a/pkg/runtimebroker/hub_connection.go
+++ b/pkg/runtimebroker/hub_connection.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/templatecache"
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
 	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
 )
 
@@ -271,6 +272,12 @@ func buildHubClientOpts(creds *brokercredentials.BrokerCredentials, secretKey []
 			opts = append(opts, hubclient.WithAutoDevAuth())
 			slog.Info("Hub client using auto dev authentication (no secret key)", "name", creds.Name)
 		}
+	}
+
+	// Transport auth for IAP-protected hubs
+	if src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience); err == nil && src != nil {
+		opts = append(opts, hubclient.WithTransportAuth(src, mode))
+		slog.Info("Hub client using transport auth", "name", creds.Name, "mode", creds.TransportMode)
 	}
 
 	return opts

--- a/pkg/runtimebroker/server.go
+++ b/pkg/runtimebroker/server.go
@@ -526,7 +526,7 @@ func (s *Server) createHubConnection(name string, creds *brokercredentials.Broke
 	// Resolve transport auth once and share between REST client and control channel
 	var transportSrc transportauth.TokenSource
 	var transportMode transportauth.HeaderMode
-	src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience)
+	src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve transport auth: %w", err)
 	}

--- a/pkg/runtimebroker/server.go
+++ b/pkg/runtimebroker/server.go
@@ -522,6 +522,17 @@ func (s *Server) createHubConnection(name string, creds *brokercredentials.Broke
 
 	// Build hub client options
 	opts := buildHubClientOpts(creds, secretKey)
+
+	// Resolve transport auth once and share between REST client and control channel
+	var transportSrc transportauth.TokenSource
+	var transportMode transportauth.HeaderMode
+	if src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience); err == nil && src != nil {
+		transportSrc = src
+		transportMode = mode
+		opts = append(opts, hubclient.WithTransportAuth(src, mode))
+		slog.Info("Hub connection using transport auth", "name", name, "mode", creds.TransportMode)
+	}
+
 	client, err := hubclient.New(hubEndpoint, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Hub client: %w", err)
@@ -538,22 +549,18 @@ func (s *Server) createHubConnection(name string, creds *brokercredentials.Broke
 	}
 
 	conn := &HubConnection{
-		Name:        name,
-		HubEndpoint: hubEndpoint,
-		BrokerID:    creds.BrokerID,
-		AuthMode:    creds.AuthMode,
-		Credentials: creds,
-		SecretKey:   secretKey,
-		HubClient:   client,
-		Hydrator:    hydrator,
-		HCResolver:  hcResolver,
-		Status:      ConnectionStatusDisconnected,
-	}
-
-	// Resolve transport auth for the control channel WebSocket
-	if src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience); err == nil && src != nil {
-		conn.TransportSource = src
-		conn.TransportMode = mode
+		Name:            name,
+		HubEndpoint:     hubEndpoint,
+		BrokerID:        creds.BrokerID,
+		AuthMode:        creds.AuthMode,
+		Credentials:     creds,
+		SecretKey:       secretKey,
+		TransportSource: transportSrc,
+		TransportMode:   transportMode,
+		HubClient:       client,
+		Hydrator:        hydrator,
+		HCResolver:      hcResolver,
+		Status:          ConnectionStatusDisconnected,
 	}
 
 	return conn, nil
@@ -572,10 +579,13 @@ func (s *Server) createHubConnectionFromConfig() (*HubConnection, error) {
 		slog.Info("Hub client using auto dev authentication")
 	}
 
-	// Transport auth from env vars (no credentials file for config-based connections)
+	// Resolve transport auth once from env and share between REST client and control channel
+	var transportSrc transportauth.TokenSource
+	var transportMode transportauth.HeaderMode
 	if src, err := transportauth.FromEnv(); src != nil && err == nil {
-		mode := transportauth.ModeFromEnv()
-		opts = append(opts, hubclient.WithTransportAuth(src, mode))
+		transportSrc = src
+		transportMode = transportauth.ModeFromEnv()
+		opts = append(opts, hubclient.WithTransportAuth(src, transportMode))
 	}
 
 	client, err := hubclient.New(s.config.HubEndpoint, opts...)
@@ -593,19 +603,15 @@ func (s *Server) createHubConnectionFromConfig() (*HubConnection, error) {
 	}
 
 	conn := &HubConnection{
-		Name:        "default",
-		HubEndpoint: s.config.HubEndpoint,
-		BrokerID:    s.config.BrokerID,
-		HubClient:   client,
-		Hydrator:    hydrator,
-		HCResolver:  hcResolver,
-		Status:      ConnectionStatusDisconnected,
-	}
-
-	// Resolve transport auth for control channel WebSocket
-	if src, err := transportauth.FromEnv(); src != nil && err == nil {
-		conn.TransportSource = src
-		conn.TransportMode = transportauth.ModeFromEnv()
+		Name:            "default",
+		HubEndpoint:     s.config.HubEndpoint,
+		BrokerID:        s.config.BrokerID,
+		TransportSource: transportSrc,
+		TransportMode:   transportMode,
+		HubClient:       client,
+		Hydrator:        hydrator,
+		HCResolver:      hcResolver,
+		Status:          ConnectionStatusDisconnected,
 	}
 
 	return conn, nil

--- a/pkg/runtimebroker/server.go
+++ b/pkg/runtimebroker/server.go
@@ -41,6 +41,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/templatecache"
 	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth/adcsource"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
 )
@@ -526,7 +527,7 @@ func (s *Server) createHubConnection(name string, creds *brokercredentials.Broke
 	// Resolve transport auth once and share between REST client and control channel
 	var transportSrc transportauth.TokenSource
 	var transportMode transportauth.HeaderMode
-	src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience, nil)
+	src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience, adcsource.New)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve transport auth: %w", err)
 	}

--- a/pkg/runtimebroker/server.go
+++ b/pkg/runtimebroker/server.go
@@ -40,6 +40,7 @@ import (
 	scionrt "github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/templatecache"
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
 )
@@ -563,6 +564,12 @@ func (s *Server) createHubConnectionFromConfig() (*HubConnection, error) {
 	} else {
 		opts = append(opts, hubclient.WithAutoDevAuth())
 		slog.Info("Hub client using auto dev authentication")
+	}
+
+	// Transport auth from env vars (no credentials file for config-based connections)
+	if src, err := transportauth.FromEnv(); src != nil && err == nil {
+		mode := transportauth.ModeFromEnv()
+		opts = append(opts, hubclient.WithTransportAuth(src, mode))
 	}
 
 	client, err := hubclient.New(s.config.HubEndpoint, opts...)

--- a/pkg/runtimebroker/server.go
+++ b/pkg/runtimebroker/server.go
@@ -550,6 +550,12 @@ func (s *Server) createHubConnection(name string, creds *brokercredentials.Broke
 		Status:      ConnectionStatusDisconnected,
 	}
 
+	// Resolve transport auth for the control channel WebSocket
+	if src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience); err == nil && src != nil {
+		conn.TransportSource = src
+		conn.TransportMode = mode
+	}
+
 	return conn, nil
 }
 
@@ -594,6 +600,12 @@ func (s *Server) createHubConnectionFromConfig() (*HubConnection, error) {
 		Hydrator:    hydrator,
 		HCResolver:  hcResolver,
 		Status:      ConnectionStatusDisconnected,
+	}
+
+	// Resolve transport auth for control channel WebSocket
+	if src, err := transportauth.FromEnv(); src != nil && err == nil {
+		conn.TransportSource = src
+		conn.TransportMode = transportauth.ModeFromEnv()
 	}
 
 	return conn, nil

--- a/pkg/runtimebroker/server.go
+++ b/pkg/runtimebroker/server.go
@@ -526,7 +526,11 @@ func (s *Server) createHubConnection(name string, creds *brokercredentials.Broke
 	// Resolve transport auth once and share between REST client and control channel
 	var transportSrc transportauth.TokenSource
 	var transportMode transportauth.HeaderMode
-	if src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience); err == nil && src != nil {
+	src, mode, err := transportauth.ResolveBrokerTransport(creds.TransportMode, creds.TransportAudience)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve transport auth: %w", err)
+	}
+	if src != nil {
 		transportSrc = src
 		transportMode = mode
 		opts = append(opts, hubclient.WithTransportAuth(src, mode))

--- a/pkg/transportauth/adcsource/adcsource.go
+++ b/pkg/transportauth/adcsource/adcsource.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package adcsource provides a transportauth.TokenSource backed by Application
+// Default Credentials via google.golang.org/api/idtoken. It lives in a
+// subpackage so the lean sciontool binary never links the Google API client
+// libraries.
+package adcsource
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/idtoken"
+)
+
+// ADCSource implements transportauth.TokenSource using Application Default
+// Credentials via google.golang.org/api/idtoken. It supports gcloud ADC login,
+// SA impersonation, and JSON SA key files.
+type ADCSource struct {
+	audience string
+
+	mu     sync.RWMutex
+	token  string
+	expiry time.Time
+}
+
+// New creates an ADCSource that mints OIDC ID tokens for the given audience.
+// It validates that ADC is available by creating a test token source.
+func New(audience string) (*ADCSource, error) {
+	_, err := idtoken.NewTokenSource(context.Background(), audience)
+	if err != nil {
+		return nil, fmt.Errorf("ADC not available: %w", err)
+	}
+	return &ADCSource{audience: audience}, nil
+}
+
+// newTokenSourceFunc is overridable for testing.
+var newTokenSourceFunc func(ctx context.Context, audience string, opts ...idtoken.ClientOption) (oauth2.TokenSource, error) = idtoken.NewTokenSource
+
+func (s *ADCSource) Token() (string, error) {
+	s.mu.RLock()
+	if s.token != "" && time.Now().Before(s.expiry.Add(-transportauth.RefreshMargin)) {
+		tok := s.token
+		s.mu.RUnlock()
+		return tok, nil
+	}
+	s.mu.RUnlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Double-check after acquiring write lock.
+	if s.token != "" && time.Now().Before(s.expiry.Add(-transportauth.RefreshMargin)) {
+		return s.token, nil
+	}
+
+	ts, err := newTokenSourceFunc(context.Background(), s.audience)
+	if err != nil {
+		return "", fmt.Errorf("oidc: ADC token source: %w", err)
+	}
+
+	tok, err := ts.Token()
+	if err != nil {
+		return "", fmt.Errorf("oidc: ADC token fetch: %w", err)
+	}
+
+	idToken, ok := tok.Extra("id_token").(string)
+	if !ok || idToken == "" {
+		return "", fmt.Errorf("oidc: ADC token source returned no id_token")
+	}
+
+	expiry, err := transportauth.ParseTokenExpiry(idToken)
+	if err != nil {
+		expiry = time.Now().Add(transportauth.DefaultTTL)
+	}
+
+	s.token = idToken
+	s.expiry = expiry
+	return idToken, nil
+}
+
+func (s *ADCSource) SetToken(token string, expiry time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.token = token
+	s.expiry = expiry
+}
+
+func (s *ADCSource) Expiry() time.Time {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.expiry
+}
+
+// Audience returns the OIDC audience this source requests tokens for.
+func (s *ADCSource) Audience() string {
+	return s.audience
+}

--- a/pkg/transportauth/adcsource/adcsource.go
+++ b/pkg/transportauth/adcsource/adcsource.go
@@ -38,16 +38,17 @@ type ADCSource struct {
 	mu     sync.RWMutex
 	token  string
 	expiry time.Time
+	ts     oauth2.TokenSource
 }
 
 // New creates an ADCSource that mints OIDC ID tokens for the given audience.
-// It validates that ADC is available by creating a test token source.
+// It validates that ADC is available by creating a token source upfront.
 func New(audience string) (transportauth.TokenSource, error) {
-	_, err := idtoken.NewTokenSource(context.Background(), audience)
+	ts, err := idtoken.NewTokenSource(context.Background(), audience)
 	if err != nil {
 		return nil, fmt.Errorf("ADC not available: %w", err)
 	}
-	return &ADCSource{audience: audience}, nil
+	return &ADCSource{audience: audience, ts: ts}, nil
 }
 
 // newTokenSourceFunc is overridable for testing.
@@ -70,12 +71,15 @@ func (s *ADCSource) Token() (string, error) {
 		return s.token, nil
 	}
 
-	ts, err := newTokenSourceFunc(context.Background(), s.audience)
-	if err != nil {
-		return "", fmt.Errorf("oidc: ADC token source: %w", err)
+	if s.ts == nil {
+		ts, err := newTokenSourceFunc(context.Background(), s.audience)
+		if err != nil {
+			return "", fmt.Errorf("oidc: ADC token source: %w", err)
+		}
+		s.ts = ts
 	}
 
-	tok, err := ts.Token()
+	tok, err := s.ts.Token()
 	if err != nil {
 		return "", fmt.Errorf("oidc: ADC token fetch: %w", err)
 	}

--- a/pkg/transportauth/adcsource/adcsource.go
+++ b/pkg/transportauth/adcsource/adcsource.go
@@ -42,7 +42,7 @@ type ADCSource struct {
 
 // New creates an ADCSource that mints OIDC ID tokens for the given audience.
 // It validates that ADC is available by creating a test token source.
-func New(audience string) (*ADCSource, error) {
+func New(audience string) (transportauth.TokenSource, error) {
 	_, err := idtoken.NewTokenSource(context.Background(), audience)
 	if err != nil {
 		return nil, fmt.Errorf("ADC not available: %w", err)

--- a/pkg/transportauth/adcsource/adcsource_test.go
+++ b/pkg/transportauth/adcsource/adcsource_test.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adcsource
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/idtoken"
+)
+
+func makeTestJWT(exp time.Time) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload, _ := json.Marshal(map[string]interface{}{"exp": exp.Unix(), "iss": "test"})
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payload)
+	sig := base64.RawURLEncoding.EncodeToString([]byte("fakesig"))
+	return fmt.Sprintf("%s.%s.%s", header, payloadB64, sig)
+}
+
+// mockTokenSource implements oauth2.TokenSource for testing.
+type mockTokenSource struct {
+	idToken   string
+	err       error
+	callCount atomic.Int32
+}
+
+func (m *mockTokenSource) Token() (*oauth2.Token, error) {
+	m.callCount.Add(1)
+	if m.err != nil {
+		return nil, m.err
+	}
+	tok := &oauth2.Token{
+		AccessToken: "access-token",
+		TokenType:   "Bearer",
+	}
+	// Set id_token as extra field, matching what idtoken.NewTokenSource returns.
+	return tok.WithExtra(map[string]interface{}{"id_token": m.idToken}), nil
+}
+
+func overrideNewTokenSource(ts oauth2.TokenSource, err error) func() {
+	orig := newTokenSourceFunc
+	newTokenSourceFunc = func(_ context.Context, _ string, _ ...idtoken.ClientOption) (oauth2.TokenSource, error) {
+		if err != nil {
+			return nil, err
+		}
+		return ts, nil
+	}
+	return func() { newTokenSourceFunc = orig }
+}
+
+func TestADCSource_SetAndGet(t *testing.T) {
+	src := &ADCSource{audience: "https://hub.example.com"}
+	token := makeTestJWT(time.Now().Add(1 * time.Hour))
+	expiry := time.Now().Add(1 * time.Hour)
+
+	src.SetToken(token, expiry)
+
+	got, err := src.Token()
+	require.NoError(t, err)
+	assert.Equal(t, token, got)
+}
+
+func TestADCSource_FetchViaMock(t *testing.T) {
+	token := makeTestJWT(time.Now().Add(1 * time.Hour))
+	mock := &mockTokenSource{idToken: token}
+	cleanup := overrideNewTokenSource(mock, nil)
+	defer cleanup()
+
+	src := &ADCSource{audience: "https://hub.example.com"}
+	got, err := src.Token()
+	require.NoError(t, err)
+	assert.Equal(t, token, got)
+	assert.Equal(t, int32(1), mock.callCount.Load())
+
+	// Second call should use cache.
+	got2, err := src.Token()
+	require.NoError(t, err)
+	assert.Equal(t, token, got2)
+	assert.Equal(t, int32(1), mock.callCount.Load(), "should use cached token")
+}
+
+func TestADCSource_FetchError(t *testing.T) {
+	cleanup := overrideNewTokenSource(nil, fmt.Errorf("ADC not configured"))
+	defer cleanup()
+
+	src := &ADCSource{audience: "https://hub.example.com"}
+	_, err := src.Token()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ADC token source")
+}
+
+func TestADCSource_TokenError(t *testing.T) {
+	mock := &mockTokenSource{err: fmt.Errorf("token fetch failed")}
+	cleanup := overrideNewTokenSource(mock, nil)
+	defer cleanup()
+
+	src := &ADCSource{audience: "https://hub.example.com"}
+	_, err := src.Token()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ADC token fetch")
+}
+
+func TestADCSource_UpdateToken(t *testing.T) {
+	src := &ADCSource{audience: "https://hub.example.com"}
+	token1 := makeTestJWT(time.Now().Add(1 * time.Hour))
+	token2 := makeTestJWT(time.Now().Add(2 * time.Hour))
+
+	src.SetToken(token1, time.Now().Add(1*time.Hour))
+	got1, _ := src.Token()
+	assert.Equal(t, token1, got1)
+
+	src.SetToken(token2, time.Now().Add(2*time.Hour))
+	got2, _ := src.Token()
+	assert.Equal(t, token2, got2)
+}
+
+func TestADCSource_Expiry(t *testing.T) {
+	src := &ADCSource{audience: "https://hub.example.com"}
+	assert.True(t, src.Expiry().IsZero())
+
+	expiry := time.Now().Add(1 * time.Hour)
+	src.SetToken("tok", expiry)
+	assert.WithinDuration(t, expiry, src.Expiry(), time.Second)
+}
+
+func TestADCSource_Audience(t *testing.T) {
+	src := &ADCSource{audience: "https://hub.example.com"}
+	assert.Equal(t, "https://hub.example.com", src.Audience())
+}
+
+func TestADCSource_CachedTokenReturned(t *testing.T) {
+	src := &ADCSource{audience: "https://hub.example.com"}
+	token := makeTestJWT(time.Now().Add(1 * time.Hour))
+	src.SetToken(token, time.Now().Add(1*time.Hour))
+
+	// Multiple calls should return the cached token without error.
+	for i := 0; i < 5; i++ {
+		got, err := src.Token()
+		require.NoError(t, err)
+		assert.Equal(t, token, got)
+	}
+}
+
+func TestADCSource_RefreshWithinMargin(t *testing.T) {
+	src := &ADCSource{audience: "https://hub.example.com"}
+	token := makeTestJWT(time.Now().Add(1 * time.Hour))
+	src.SetToken(token, time.Now().Add(3*time.Minute)) // within 5-min refresh margin
+
+	// Token is within the refresh margin, so Token() should try to refresh.
+	// Without a working idtoken source, this will error.
+	_, err := src.Token()
+	assert.Error(t, err, "should attempt refresh when within margin")
+}
+
+func TestADCSource_ImplementsTokenSource(t *testing.T) {
+	var _ transportauth.TokenSource = (*ADCSource)(nil)
+}

--- a/pkg/transportauth/broker.go
+++ b/pkg/transportauth/broker.go
@@ -19,14 +19,20 @@ import (
 	"os"
 )
 
+// ADCSourceConstructor is a function that creates a TokenSource from ADC.
+// It is injected by the caller (e.g. from the adcsource subpackage) to avoid
+// linking the Google API client libraries into the lean sciontool binary.
+type ADCSourceConstructor func(audience string) (TokenSource, error)
+
 // ResolveBrokerTransport resolves transport auth config for a broker connection
 // using a two-level precedence: env vars override credentials-file values.
 // Returns (nil, 0, nil) when no transport config is present.
 //
 // Unlike FromEnv(), this function never checks SCION_TRANSPORT_TOKEN (injected
 // mode) — brokers always use MetadataSource to mint their own tokens from the
-// runtime identity (GKE Workload Identity / ambient SA).
-func ResolveBrokerTransport(transportMode, transportAudience string) (TokenSource, HeaderMode, error) {
+// runtime identity (GKE Workload Identity / ambient SA), falling back to ADC
+// when not on GCE (off-GCP brokers with SA keys).
+func ResolveBrokerTransport(transportMode, transportAudience string, adcNew ADCSourceConstructor) (TokenSource, HeaderMode, error) {
 	mode := os.Getenv(EnvTransportMode)
 	audience := os.Getenv(EnvTransportAudience)
 
@@ -45,7 +51,23 @@ func ResolveBrokerTransport(transportMode, transportAudience string) (TokenSourc
 		return nil, 0, fmt.Errorf("transport audience is required when transport auth is enabled")
 	}
 
-	src := NewMetadataSource(audience)
 	headerMode := ModeFromString(mode)
-	return src, headerMode, nil
+
+	// Prefer the metadata server when on GCE.
+	if IsOnGCEFunc() {
+		if metaMode := os.Getenv(EnvMetadataMode); metaMode == "" {
+			return NewMetadataSource(audience), headerMode, nil
+		}
+	}
+
+	// Fall back to ADC for off-GCP brokers with SA keys.
+	if adcNew != nil {
+		src, err := adcNew(audience)
+		if err != nil {
+			return nil, 0, fmt.Errorf("broker transport: %w", err)
+		}
+		return src, headerMode, nil
+	}
+
+	return nil, 0, nil
 }

--- a/pkg/transportauth/broker.go
+++ b/pkg/transportauth/broker.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transportauth
+
+import "os"
+
+// ResolveBrokerTransport resolves transport auth config for a broker connection
+// using a two-level precedence: env vars override credentials-file values.
+// Returns (nil, 0, nil) when no transport config is present.
+//
+// Unlike FromEnv(), this function never checks SCION_TRANSPORT_TOKEN (injected
+// mode) — brokers always use MetadataSource to mint their own tokens from the
+// runtime identity (GKE Workload Identity / ambient SA).
+func ResolveBrokerTransport(transportMode, transportAudience string) (TokenSource, HeaderMode, error) {
+	mode := os.Getenv(EnvTransportMode)
+	audience := os.Getenv(EnvTransportAudience)
+
+	if mode == "" {
+		mode = transportMode
+	}
+	if audience == "" {
+		audience = transportAudience
+	}
+
+	if mode == "" && audience == "" {
+		return nil, 0, nil
+	}
+
+	src := NewMetadataSource(audience)
+	headerMode := ModeFromString(mode)
+	return src, headerMode, nil
+}

--- a/pkg/transportauth/broker.go
+++ b/pkg/transportauth/broker.go
@@ -14,7 +14,10 @@
 
 package transportauth
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 // ResolveBrokerTransport resolves transport auth config for a broker connection
 // using a two-level precedence: env vars override credentials-file values.
@@ -36,6 +39,10 @@ func ResolveBrokerTransport(transportMode, transportAudience string) (TokenSourc
 
 	if mode == "" && audience == "" {
 		return nil, 0, nil
+	}
+
+	if audience == "" {
+		return nil, 0, fmt.Errorf("transport audience is required when transport auth is enabled")
 	}
 
 	src := NewMetadataSource(audience)

--- a/pkg/transportauth/broker_test.go
+++ b/pkg/transportauth/broker_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transportauth
+
+import (
+	"os"
+	"testing"
+)
+
+func TestResolveBrokerTransport_NoConfig(t *testing.T) {
+	os.Unsetenv(EnvTransportMode)
+	os.Unsetenv(EnvTransportAudience)
+
+	src, mode, err := ResolveBrokerTransport("", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src != nil {
+		t.Error("expected nil source when no config present")
+	}
+	if mode != HeaderAuthorization {
+		t.Errorf("expected HeaderAuthorization, got %v", mode)
+	}
+}
+
+func TestResolveBrokerTransport_FromCredentials(t *testing.T) {
+	os.Unsetenv(EnvTransportMode)
+	os.Unsetenv(EnvTransportAudience)
+
+	src, mode, err := ResolveBrokerTransport("iap", "test-audience.apps.googleusercontent.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src == nil {
+		t.Fatal("expected non-nil source")
+	}
+	if mode != HeaderProxyAuthorization {
+		t.Errorf("expected HeaderProxyAuthorization, got %v", mode)
+	}
+
+	ms, ok := src.(*MetadataSource)
+	if !ok {
+		t.Fatalf("expected *MetadataSource, got %T", src)
+	}
+	if ms.Audience() != "test-audience.apps.googleusercontent.com" {
+		t.Errorf("audience: expected %q, got %q", "test-audience.apps.googleusercontent.com", ms.Audience())
+	}
+}
+
+func TestResolveBrokerTransport_EnvOverridesCreds(t *testing.T) {
+	t.Setenv(EnvTransportMode, "cloudrun_invoker")
+	t.Setenv(EnvTransportAudience, "env-audience")
+
+	src, mode, err := ResolveBrokerTransport("iap", "creds-audience")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src == nil {
+		t.Fatal("expected non-nil source")
+	}
+	if mode != HeaderServerlessAuthorization {
+		t.Errorf("expected HeaderServerlessAuthorization, got %v", mode)
+	}
+
+	ms := src.(*MetadataSource)
+	if ms.Audience() != "env-audience" {
+		t.Errorf("audience: expected %q, got %q", "env-audience", ms.Audience())
+	}
+}
+
+func TestResolveBrokerTransport_PartialEnvOverride(t *testing.T) {
+	t.Setenv(EnvTransportMode, "iap")
+	os.Unsetenv(EnvTransportAudience)
+
+	src, mode, err := ResolveBrokerTransport("cloudrun_invoker", "creds-audience")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src == nil {
+		t.Fatal("expected non-nil source")
+	}
+	// Mode from env overrides creds
+	if mode != HeaderProxyAuthorization {
+		t.Errorf("expected HeaderProxyAuthorization, got %v", mode)
+	}
+	// Audience falls back to creds
+	ms := src.(*MetadataSource)
+	if ms.Audience() != "creds-audience" {
+		t.Errorf("audience: expected %q, got %q", "creds-audience", ms.Audience())
+	}
+}
+
+func TestResolveBrokerTransport_AudienceOnlyCreatesSource(t *testing.T) {
+	os.Unsetenv(EnvTransportMode)
+	os.Unsetenv(EnvTransportAudience)
+
+	src, mode, err := ResolveBrokerTransport("", "audience-only")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src == nil {
+		t.Fatal("expected non-nil source when audience is set")
+	}
+	if mode != HeaderAuthorization {
+		t.Errorf("expected HeaderAuthorization (default), got %v", mode)
+	}
+}
+
+func TestModeFromString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected HeaderMode
+	}{
+		{"iap", HeaderProxyAuthorization},
+		{"cloudrun_invoker", HeaderServerlessAuthorization},
+		{"", HeaderAuthorization},
+		{"unknown", HeaderAuthorization},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			result := ModeFromString(tc.input)
+			if result != tc.expected {
+				t.Errorf("ModeFromString(%q) = %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/transportauth/broker_test.go
+++ b/pkg/transportauth/broker_test.go
@@ -16,6 +16,7 @@ package transportauth
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -115,6 +116,22 @@ func TestResolveBrokerTransport_AudienceOnlyCreatesSource(t *testing.T) {
 	}
 	if mode != HeaderAuthorization {
 		t.Errorf("expected HeaderAuthorization (default), got %v", mode)
+	}
+}
+
+func TestResolveBrokerTransport_ModeWithoutAudience(t *testing.T) {
+	os.Unsetenv(EnvTransportMode)
+	os.Unsetenv(EnvTransportAudience)
+
+	src, _, err := ResolveBrokerTransport("iap", "")
+	if err == nil {
+		t.Fatal("expected error when mode is set but audience is empty")
+	}
+	if src != nil {
+		t.Error("expected nil source on error")
+	}
+	if !strings.Contains(err.Error(), "audience is required") {
+		t.Errorf("expected error to contain 'audience is required', got: %v", err)
 	}
 }
 

--- a/pkg/transportauth/broker_test.go
+++ b/pkg/transportauth/broker_test.go
@@ -15,16 +15,52 @@
 package transportauth
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// mockADCSource implements TokenSource for testing.
+type mockADCSource struct {
+	audience string
+	token    string
+	expiry   time.Time
+}
+
+func (m *mockADCSource) Token() (string, error) {
+	if m.token == "" {
+		return "", fmt.Errorf("no token")
+	}
+	return m.token, nil
+}
+
+func (m *mockADCSource) SetToken(token string, expiry time.Time) {
+	m.token = token
+	m.expiry = expiry
+}
+
+func (m *mockADCSource) Expiry() time.Time {
+	return m.expiry
+}
+
+func mockADCNew(audience string) (TokenSource, error) {
+	return &mockADCSource{audience: audience, token: makeTestJWT(time.Now().Add(1 * time.Hour))}, nil
+}
+
+func mockADCNewFailing(audience string) (TokenSource, error) {
+	return nil, fmt.Errorf("ADC not available")
+}
 
 func TestResolveBrokerTransport_NoConfig(t *testing.T) {
 	os.Unsetenv(EnvTransportMode)
 	os.Unsetenv(EnvTransportAudience)
 
-	src, mode, err := ResolveBrokerTransport("", "")
+	src, mode, err := ResolveBrokerTransport("", "", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -37,10 +73,14 @@ func TestResolveBrokerTransport_NoConfig(t *testing.T) {
 }
 
 func TestResolveBrokerTransport_FromCredentials(t *testing.T) {
+	cleanup := overrideGCPDetection(true)
+	defer cleanup()
+
 	os.Unsetenv(EnvTransportMode)
 	os.Unsetenv(EnvTransportAudience)
+	os.Unsetenv(EnvMetadataMode)
 
-	src, mode, err := ResolveBrokerTransport("iap", "test-audience.apps.googleusercontent.com")
+	src, mode, err := ResolveBrokerTransport("iap", "test-audience.apps.googleusercontent.com", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -61,10 +101,14 @@ func TestResolveBrokerTransport_FromCredentials(t *testing.T) {
 }
 
 func TestResolveBrokerTransport_EnvOverridesCreds(t *testing.T) {
+	cleanup := overrideGCPDetection(true)
+	defer cleanup()
+
 	t.Setenv(EnvTransportMode, "cloudrun_invoker")
 	t.Setenv(EnvTransportAudience, "env-audience")
+	os.Unsetenv(EnvMetadataMode)
 
-	src, mode, err := ResolveBrokerTransport("iap", "creds-audience")
+	src, mode, err := ResolveBrokerTransport("iap", "creds-audience", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -82,10 +126,14 @@ func TestResolveBrokerTransport_EnvOverridesCreds(t *testing.T) {
 }
 
 func TestResolveBrokerTransport_PartialEnvOverride(t *testing.T) {
+	cleanup := overrideGCPDetection(true)
+	defer cleanup()
+
 	t.Setenv(EnvTransportMode, "iap")
 	os.Unsetenv(EnvTransportAudience)
+	os.Unsetenv(EnvMetadataMode)
 
-	src, mode, err := ResolveBrokerTransport("cloudrun_invoker", "creds-audience")
+	src, mode, err := ResolveBrokerTransport("cloudrun_invoker", "creds-audience", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -104,10 +152,14 @@ func TestResolveBrokerTransport_PartialEnvOverride(t *testing.T) {
 }
 
 func TestResolveBrokerTransport_AudienceOnlyCreatesSource(t *testing.T) {
+	cleanup := overrideGCPDetection(true)
+	defer cleanup()
+
 	os.Unsetenv(EnvTransportMode)
 	os.Unsetenv(EnvTransportAudience)
+	os.Unsetenv(EnvMetadataMode)
 
-	src, mode, err := ResolveBrokerTransport("", "audience-only")
+	src, mode, err := ResolveBrokerTransport("", "audience-only", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -123,7 +175,7 @@ func TestResolveBrokerTransport_ModeWithoutAudience(t *testing.T) {
 	os.Unsetenv(EnvTransportMode)
 	os.Unsetenv(EnvTransportAudience)
 
-	src, _, err := ResolveBrokerTransport("iap", "")
+	src, _, err := ResolveBrokerTransport("iap", "", nil)
 	if err == nil {
 		t.Fatal("expected error when mode is set but audience is empty")
 	}
@@ -133,6 +185,74 @@ func TestResolveBrokerTransport_ModeWithoutAudience(t *testing.T) {
 	if !strings.Contains(err.Error(), "audience is required") {
 		t.Errorf("expected error to contain 'audience is required', got: %v", err)
 	}
+}
+
+func TestResolveBrokerTransport_MetadataPrecedence(t *testing.T) {
+	cleanup := overrideGCPDetection(true)
+	defer cleanup()
+
+	os.Unsetenv(EnvMetadataMode)
+	t.Setenv(EnvTransportAudience, "https://audience.example.com")
+	os.Unsetenv(EnvTransportMode)
+
+	src, _, err := ResolveBrokerTransport("", "", mockADCNew)
+	require.NoError(t, err)
+	require.NotNil(t, src)
+	_, ok := src.(*MetadataSource)
+	assert.True(t, ok, "should return MetadataSource when on GCE")
+}
+
+func TestResolveBrokerTransport_ADCFallback(t *testing.T) {
+	cleanup := overrideGCPDetection(false)
+	defer cleanup()
+
+	t.Setenv(EnvTransportAudience, "https://audience.example.com")
+	os.Unsetenv(EnvTransportMode)
+
+	src, _, err := ResolveBrokerTransport("", "", mockADCNew)
+	require.NoError(t, err)
+	require.NotNil(t, src)
+	_, ok := src.(*mockADCSource)
+	assert.True(t, ok, "should fall back to ADC when not on GCE")
+}
+
+func TestResolveBrokerTransport_ADCFallbackWhenMetadataBlocked(t *testing.T) {
+	cleanup := overrideGCPDetection(true)
+	defer cleanup()
+
+	t.Setenv(EnvMetadataMode, "assign")
+	t.Setenv(EnvTransportAudience, "https://audience.example.com")
+	os.Unsetenv(EnvTransportMode)
+
+	src, _, err := ResolveBrokerTransport("", "", mockADCNew)
+	require.NoError(t, err)
+	require.NotNil(t, src)
+	_, ok := src.(*mockADCSource)
+	assert.True(t, ok, "should fall back to ADC when SCION_METADATA_MODE is set")
+}
+
+func TestResolveBrokerTransport_NilADCConstructor(t *testing.T) {
+	cleanup := overrideGCPDetection(false)
+	defer cleanup()
+
+	t.Setenv(EnvTransportAudience, "https://audience.example.com")
+	os.Unsetenv(EnvTransportMode)
+
+	src, _, err := ResolveBrokerTransport("", "", nil)
+	require.NoError(t, err)
+	assert.Nil(t, src, "should return nil when ADC constructor is nil and not on GCE")
+}
+
+func TestResolveBrokerTransport_ADCError(t *testing.T) {
+	cleanup := overrideGCPDetection(false)
+	defer cleanup()
+
+	t.Setenv(EnvTransportAudience, "https://audience.example.com")
+	os.Unsetenv(EnvTransportMode)
+
+	_, _, err := ResolveBrokerTransport("", "", mockADCNewFailing)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ADC not available")
 }
 
 func TestModeFromString(t *testing.T) {

--- a/pkg/transportauth/broker_test.go
+++ b/pkg/transportauth/broker_test.go
@@ -16,7 +16,6 @@ package transportauth
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -57,8 +56,8 @@ func mockADCNewFailing(audience string) (TokenSource, error) {
 }
 
 func TestResolveBrokerTransport_NoConfig(t *testing.T) {
-	os.Unsetenv(EnvTransportMode)
-	os.Unsetenv(EnvTransportAudience)
+	t.Setenv(EnvTransportMode, "")
+	t.Setenv(EnvTransportAudience, "")
 
 	src, mode, err := ResolveBrokerTransport("", "", nil)
 	if err != nil {
@@ -76,9 +75,9 @@ func TestResolveBrokerTransport_FromCredentials(t *testing.T) {
 	cleanup := overrideGCPDetection(true)
 	defer cleanup()
 
-	os.Unsetenv(EnvTransportMode)
-	os.Unsetenv(EnvTransportAudience)
-	os.Unsetenv(EnvMetadataMode)
+	t.Setenv(EnvTransportMode, "")
+	t.Setenv(EnvTransportAudience, "")
+	t.Setenv(EnvMetadataMode, "")
 
 	src, mode, err := ResolveBrokerTransport("iap", "test-audience.apps.googleusercontent.com", nil)
 	if err != nil {
@@ -106,7 +105,7 @@ func TestResolveBrokerTransport_EnvOverridesCreds(t *testing.T) {
 
 	t.Setenv(EnvTransportMode, "cloudrun_invoker")
 	t.Setenv(EnvTransportAudience, "env-audience")
-	os.Unsetenv(EnvMetadataMode)
+	t.Setenv(EnvMetadataMode, "")
 
 	src, mode, err := ResolveBrokerTransport("iap", "creds-audience", nil)
 	if err != nil {
@@ -130,8 +129,8 @@ func TestResolveBrokerTransport_PartialEnvOverride(t *testing.T) {
 	defer cleanup()
 
 	t.Setenv(EnvTransportMode, "iap")
-	os.Unsetenv(EnvTransportAudience)
-	os.Unsetenv(EnvMetadataMode)
+	t.Setenv(EnvTransportAudience, "")
+	t.Setenv(EnvMetadataMode, "")
 
 	src, mode, err := ResolveBrokerTransport("cloudrun_invoker", "creds-audience", nil)
 	if err != nil {
@@ -155,9 +154,9 @@ func TestResolveBrokerTransport_AudienceOnlyCreatesSource(t *testing.T) {
 	cleanup := overrideGCPDetection(true)
 	defer cleanup()
 
-	os.Unsetenv(EnvTransportMode)
-	os.Unsetenv(EnvTransportAudience)
-	os.Unsetenv(EnvMetadataMode)
+	t.Setenv(EnvTransportMode, "")
+	t.Setenv(EnvTransportAudience, "")
+	t.Setenv(EnvMetadataMode, "")
 
 	src, mode, err := ResolveBrokerTransport("", "audience-only", nil)
 	if err != nil {
@@ -172,8 +171,8 @@ func TestResolveBrokerTransport_AudienceOnlyCreatesSource(t *testing.T) {
 }
 
 func TestResolveBrokerTransport_ModeWithoutAudience(t *testing.T) {
-	os.Unsetenv(EnvTransportMode)
-	os.Unsetenv(EnvTransportAudience)
+	t.Setenv(EnvTransportMode, "")
+	t.Setenv(EnvTransportAudience, "")
 
 	src, _, err := ResolveBrokerTransport("iap", "", nil)
 	if err == nil {
@@ -191,9 +190,9 @@ func TestResolveBrokerTransport_MetadataPrecedence(t *testing.T) {
 	cleanup := overrideGCPDetection(true)
 	defer cleanup()
 
-	os.Unsetenv(EnvMetadataMode)
+	t.Setenv(EnvMetadataMode, "")
 	t.Setenv(EnvTransportAudience, "https://audience.example.com")
-	os.Unsetenv(EnvTransportMode)
+	t.Setenv(EnvTransportMode, "")
 
 	src, _, err := ResolveBrokerTransport("", "", mockADCNew)
 	require.NoError(t, err)
@@ -207,7 +206,7 @@ func TestResolveBrokerTransport_ADCFallback(t *testing.T) {
 	defer cleanup()
 
 	t.Setenv(EnvTransportAudience, "https://audience.example.com")
-	os.Unsetenv(EnvTransportMode)
+	t.Setenv(EnvTransportMode, "")
 
 	src, _, err := ResolveBrokerTransport("", "", mockADCNew)
 	require.NoError(t, err)
@@ -222,7 +221,7 @@ func TestResolveBrokerTransport_ADCFallbackWhenMetadataBlocked(t *testing.T) {
 
 	t.Setenv(EnvMetadataMode, "assign")
 	t.Setenv(EnvTransportAudience, "https://audience.example.com")
-	os.Unsetenv(EnvTransportMode)
+	t.Setenv(EnvTransportMode, "")
 
 	src, _, err := ResolveBrokerTransport("", "", mockADCNew)
 	require.NoError(t, err)
@@ -236,7 +235,7 @@ func TestResolveBrokerTransport_NilADCConstructor(t *testing.T) {
 	defer cleanup()
 
 	t.Setenv(EnvTransportAudience, "https://audience.example.com")
-	os.Unsetenv(EnvTransportMode)
+	t.Setenv(EnvTransportMode, "")
 
 	src, _, err := ResolveBrokerTransport("", "", nil)
 	require.NoError(t, err)
@@ -248,7 +247,7 @@ func TestResolveBrokerTransport_ADCError(t *testing.T) {
 	defer cleanup()
 
 	t.Setenv(EnvTransportAudience, "https://audience.example.com")
-	os.Unsetenv(EnvTransportMode)
+	t.Setenv(EnvTransportMode, "")
 
 	_, _, err := ResolveBrokerTransport("", "", mockADCNewFailing)
 	assert.Error(t, err)

--- a/pkg/transportauth/iap_test.go
+++ b/pkg/transportauth/iap_test.go
@@ -37,7 +37,7 @@ func fakeIAPMiddleware(expectedToken string, next http.Handler) http.Handler {
 		if token != expected {
 			w.Header().Set("Content-Type", "text/html")
 			w.WriteHeader(http.StatusForbidden)
-			w.Write([]byte("<html><body>Sign in with Google</body></html>"))
+			_, _ = w.Write([]byte("<html><body>Sign in with Google</body></html>"))
 			return
 		}
 		next.ServeHTTP(w, r)
@@ -47,7 +47,7 @@ func fakeIAPMiddleware(expectedToken string, next http.Handler) http.Handler {
 func TestFakeIAP_RejectsWithoutToken(t *testing.T) {
 	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"ok"}`))
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
 	srv := httptest.NewServer(fakeIAPMiddleware("valid-token", backend))
@@ -57,7 +57,7 @@ func TestFakeIAP_RejectsWithoutToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusForbidden {
 		t.Errorf("expected 403, got %d", resp.StatusCode)
@@ -67,7 +67,7 @@ func TestFakeIAP_RejectsWithoutToken(t *testing.T) {
 func TestFakeIAP_AcceptsWithToken(t *testing.T) {
 	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"ok"}`))
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
 	srv := httptest.NewServer(fakeIAPMiddleware("valid-token", backend))
@@ -80,7 +80,7 @@ func TestFakeIAP_AcceptsWithToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
@@ -92,7 +92,7 @@ func TestWrap_ThroughFakeIAP(t *testing.T) {
 
 	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"ok"}`))
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
 	srv := httptest.NewServer(fakeIAPMiddleware(testToken, backend))
@@ -111,7 +111,7 @@ func TestWrap_ThroughFakeIAP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
@@ -137,7 +137,7 @@ func TestWrap_FailsThroughFakeIAP_WrongToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusForbidden {
 		t.Errorf("expected 403, got %d", resp.StatusCode)
@@ -149,7 +149,7 @@ func TestApplyHeaders_ThroughFakeIAP(t *testing.T) {
 
 	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("connected"))
+		_, _ = w.Write([]byte("connected"))
 	})
 
 	srv := httptest.NewServer(fakeIAPMiddleware(testToken, backend))
@@ -172,7 +172,7 @@ func TestApplyHeaders_ThroughFakeIAP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)

--- a/pkg/transportauth/iap_test.go
+++ b/pkg/transportauth/iap_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transportauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// fakeIAPMiddleware simulates Google IAP by rejecting requests that lack a
+// valid transport OIDC token. It checks both Authorization and
+// Proxy-Authorization headers (IAP accepts either).
+func fakeIAPMiddleware(expectedToken string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := ""
+		if auth := r.Header.Get("Proxy-Authorization"); auth != "" {
+			token = auth
+		} else if auth := r.Header.Get("Authorization"); auth != "" {
+			token = auth
+		}
+
+		expected := "Bearer " + expectedToken
+		if token != expected {
+			w.Header().Set("Content-Type", "text/html")
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte("<html><body>Sign in with Google</body></html>"))
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func TestFakeIAP_RejectsWithoutToken(t *testing.T) {
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	srv := httptest.NewServer(fakeIAPMiddleware("valid-token", backend))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/health")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestFakeIAP_AcceptsWithToken(t *testing.T) {
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	srv := httptest.NewServer(fakeIAPMiddleware("valid-token", backend))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/health", nil)
+	req.Header.Set("Proxy-Authorization", "Bearer valid-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestWrap_ThroughFakeIAP(t *testing.T) {
+	const testToken = "test-oidc-token"
+
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	srv := httptest.NewServer(fakeIAPMiddleware(testToken, backend))
+	defer srv.Close()
+
+	// Create a token source that returns our test token
+	src := NewInjectedSource()
+	src.SetToken(testToken, time.Now().Add(time.Hour))
+
+	// Wrap transport with IAP mode (Proxy-Authorization)
+	client := &http.Client{
+		Transport: Wrap(http.DefaultTransport, src, HeaderProxyAuthorization),
+	}
+
+	resp, err := client.Get(srv.URL + "/api/v1/runtime-brokers/heartbeat")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestWrap_FailsThroughFakeIAP_WrongToken(t *testing.T) {
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(fakeIAPMiddleware("correct-token", backend))
+	defer srv.Close()
+
+	src := NewInjectedSource()
+	src.SetToken("wrong-token", time.Now().Add(time.Hour))
+
+	client := &http.Client{
+		Transport: Wrap(http.DefaultTransport, src, HeaderProxyAuthorization),
+	}
+
+	resp, err := client.Get(srv.URL + "/api/v1/runtime-brokers/heartbeat")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestApplyHeaders_ThroughFakeIAP(t *testing.T) {
+	const testToken = "ws-oidc-token"
+
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("connected"))
+	})
+
+	srv := httptest.NewServer(fakeIAPMiddleware(testToken, backend))
+	defer srv.Close()
+
+	src := NewInjectedSource()
+	src.SetToken(testToken, time.Now().Add(time.Hour))
+
+	headers := http.Header{}
+	if err := ApplyHeaders(headers, src, HeaderProxyAuthorization); err != nil {
+		t.Fatalf("ApplyHeaders failed: %v", err)
+	}
+
+	req, _ := http.NewRequest("GET", srv.URL+"/connect", nil)
+	for k, v := range headers {
+		req.Header[k] = v
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestApplyHeaders_WithExistingHMACHeaders(t *testing.T) {
+	const testToken = "hmac-plus-oidc"
+
+	src := NewInjectedSource()
+	src.SetToken(testToken, time.Now().Add(time.Hour))
+
+	headers := http.Header{}
+	// Simulate HMAC headers already present
+	headers.Set("Authorization", "HMAC broker-id:signature")
+	headers.Set("X-Scion-Broker-ID", "broker-id")
+
+	// Apply transport auth with IAP mode (Proxy-Authorization)
+	if err := ApplyHeaders(headers, src, HeaderProxyAuthorization); err != nil {
+		t.Fatalf("ApplyHeaders failed: %v", err)
+	}
+
+	// HMAC Authorization header should be preserved
+	if got := headers.Get("Authorization"); got != "HMAC broker-id:signature" {
+		t.Errorf("Authorization header modified: %q", got)
+	}
+
+	// Proxy-Authorization should have the OIDC token
+	if got := headers.Get("Proxy-Authorization"); got != "Bearer "+testToken {
+		t.Errorf("Proxy-Authorization: expected %q, got %q", "Bearer "+testToken, got)
+	}
+}

--- a/pkg/transportauth/metadata.go
+++ b/pkg/transportauth/metadata.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -72,10 +73,10 @@ func (s *MetadataSource) Token() (string, error) {
 		return s.token, nil
 	}
 
-	url := fmt.Sprintf("%s/computeMetadata/v1/instance/service-accounts/default/identity?audience=%s&format=full",
+	fetchURL := fmt.Sprintf("%s/computeMetadata/v1/instance/service-accounts/default/identity?audience=%s&format=full",
 		s.metadataBaseURL, url.QueryEscape(s.audience))
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", fetchURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("oidc: build request: %w", err)
 	}

--- a/pkg/transportauth/proxy_auth_test.go
+++ b/pkg/transportauth/proxy_auth_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transportauth
+
+import (
+	"os"
+	"testing"
+)
+
+func TestFromEnv_ProxyAuthState_WithTransportToken(t *testing.T) {
+	t.Setenv(EnvTransportToken, "injected-token")
+
+	src, err := FromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src == nil {
+		t.Fatal("expected non-nil source when SCION_TRANSPORT_TOKEN is set")
+	}
+
+	tok, err := src.Token()
+	if err != nil {
+		t.Fatalf("Token() failed: %v", err)
+	}
+	if tok != "injected-token" {
+		t.Errorf("expected %q, got %q", "injected-token", tok)
+	}
+}
+
+func TestFromEnv_NoTransportAuth(t *testing.T) {
+	os.Unsetenv(EnvTransportToken)
+	os.Unsetenv(EnvTransportAudience)
+	os.Unsetenv(EnvHubOIDCAudience)
+
+	origOnGCE := IsOnGCEFunc
+	defer func() { IsOnGCEFunc = origOnGCE }()
+	IsOnGCEFunc = func() bool { return false }
+
+	src, err := FromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src != nil {
+		t.Error("expected nil source when no transport auth configured")
+	}
+}
+
+func TestFromEnv_MetadataOnGCE(t *testing.T) {
+	os.Unsetenv(EnvTransportToken)
+	os.Unsetenv(EnvMetadataMode)
+	t.Setenv(EnvTransportAudience, "test-audience-for-gce")
+
+	origOnGCE := IsOnGCEFunc
+	defer func() { IsOnGCEFunc = origOnGCE }()
+	IsOnGCEFunc = func() bool { return true }
+
+	src, err := FromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src == nil {
+		t.Fatal("expected MetadataSource on GCE with audience set")
+	}
+	ms, ok := src.(*MetadataSource)
+	if !ok {
+		t.Fatalf("expected *MetadataSource, got %T", src)
+	}
+	if ms.Audience() != "test-audience-for-gce" {
+		t.Errorf("audience: expected %q, got %q", "test-audience-for-gce", ms.Audience())
+	}
+}
+
+func TestRegistrationPersistence_TransportFields(t *testing.T) {
+	os.Unsetenv(EnvTransportMode)
+	os.Unsetenv(EnvTransportAudience)
+
+	// Simulate what runBrokerRegister does: resolve from flags then env
+	flagMode := "iap"
+	flagAudience := "12345.apps.googleusercontent.com"
+
+	transportMode := flagMode
+	if transportMode == "" {
+		transportMode = os.Getenv(EnvTransportMode)
+	}
+	transportAudience := flagAudience
+	if transportAudience == "" {
+		transportAudience = os.Getenv(EnvTransportAudience)
+	}
+
+	if transportMode != "iap" {
+		t.Errorf("expected mode %q, got %q", "iap", transportMode)
+	}
+	if transportAudience != "12345.apps.googleusercontent.com" {
+		t.Errorf("expected audience %q, got %q", "12345.apps.googleusercontent.com", transportAudience)
+	}
+}
+
+func TestRegistrationPersistence_FallsBackToEnv(t *testing.T) {
+	t.Setenv(EnvTransportMode, "cloudrun_invoker")
+	t.Setenv(EnvTransportAudience, "env-audience")
+
+	// Simulate empty flags
+	flagMode := ""
+	flagAudience := ""
+
+	transportMode := flagMode
+	if transportMode == "" {
+		transportMode = os.Getenv(EnvTransportMode)
+	}
+	transportAudience := flagAudience
+	if transportAudience == "" {
+		transportAudience = os.Getenv(EnvTransportAudience)
+	}
+
+	if transportMode != "cloudrun_invoker" {
+		t.Errorf("expected mode %q, got %q", "cloudrun_invoker", transportMode)
+	}
+	if transportAudience != "env-audience" {
+		t.Errorf("expected audience %q, got %q", "env-audience", transportAudience)
+	}
+}

--- a/pkg/transportauth/proxy_auth_test.go
+++ b/pkg/transportauth/proxy_auth_test.go
@@ -40,9 +40,9 @@ func TestFromEnv_ProxyAuthState_WithTransportToken(t *testing.T) {
 }
 
 func TestFromEnv_NoTransportAuth(t *testing.T) {
-	os.Unsetenv(EnvTransportToken)
-	os.Unsetenv(EnvTransportAudience)
-	os.Unsetenv(EnvHubOIDCAudience)
+	t.Setenv(EnvTransportToken, "")
+	t.Setenv(EnvTransportAudience, "")
+	t.Setenv(EnvHubOIDCAudience, "")
 
 	origOnGCE := IsOnGCEFunc
 	defer func() { IsOnGCEFunc = origOnGCE }()
@@ -58,8 +58,8 @@ func TestFromEnv_NoTransportAuth(t *testing.T) {
 }
 
 func TestFromEnv_MetadataOnGCE(t *testing.T) {
-	os.Unsetenv(EnvTransportToken)
-	os.Unsetenv(EnvMetadataMode)
+	t.Setenv(EnvTransportToken, "")
+	t.Setenv(EnvMetadataMode, "")
 	t.Setenv(EnvTransportAudience, "test-audience-for-gce")
 
 	origOnGCE := IsOnGCEFunc
@@ -83,8 +83,8 @@ func TestFromEnv_MetadataOnGCE(t *testing.T) {
 }
 
 func TestRegistrationPersistence_TransportFields(t *testing.T) {
-	os.Unsetenv(EnvTransportMode)
-	os.Unsetenv(EnvTransportAudience)
+	t.Setenv(EnvTransportMode, "")
+	t.Setenv(EnvTransportAudience, "")
 
 	// Simulate what runBrokerRegister does: resolve from flags then env
 	flagMode := "iap"

--- a/pkg/transportauth/transportauth.go
+++ b/pkg/transportauth/transportauth.go
@@ -22,6 +22,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -119,10 +120,10 @@ func ParseTokenExpiry(tokenString string) (time.Time, error) {
 	return time.Unix(claims.Exp, 0), nil
 }
 
-// ModeFromEnv reads SCION_TRANSPORT_MODE and returns the corresponding
-// HeaderMode. Returns HeaderAuthorization when unset or unrecognised.
-func ModeFromEnv() HeaderMode {
-	switch os.Getenv(EnvTransportMode) {
+// ModeFromString converts a transport mode string to a HeaderMode constant.
+// Returns HeaderAuthorization for empty or unrecognised values.
+func ModeFromString(mode string) HeaderMode {
+	switch mode {
 	case "iap":
 		return HeaderProxyAuthorization
 	case "cloudrun_invoker":
@@ -130,6 +131,12 @@ func ModeFromEnv() HeaderMode {
 	default:
 		return HeaderAuthorization
 	}
+}
+
+// ModeFromEnv reads SCION_TRANSPORT_MODE and returns the corresponding
+// HeaderMode. Returns HeaderAuthorization when unset or unrecognised.
+func ModeFromEnv() HeaderMode {
+	return ModeFromString(os.Getenv(EnvTransportMode))
 }
 
 // FromEnv resolves a TokenSource from environment variables. Returns

--- a/pkg/transportauth/transportauth.go
+++ b/pkg/transportauth/transportauth.go
@@ -177,6 +177,61 @@ func FromEnv() (TokenSource, error) {
 	return NewMetadataSource(audience), nil
 }
 
+// TransportSettings holds transport auth settings read from settings.yaml.
+type TransportSettings struct {
+	Mode     string
+	Audience string
+}
+
+// FromSettings resolves a TokenSource from settings when env vars are absent.
+// The adcNew constructor is optional — when nil, ADC-backed sources are not
+// available (keeping the sciontool binary lean).
+//
+// Resolution order:
+//  1. SCION_TRANSPORT_TOKEN set → InjectedSource (env always wins)
+//  2. On GCE && SCION_METADATA_MODE unset && audience available → MetadataSource
+//  3. Settings audience + adcNew → ADCSource
+//  4. Otherwise → nil
+func FromSettings(settings *TransportSettings, adcNew ADCSourceConstructor) (TokenSource, HeaderMode, error) {
+	// Env vars always take precedence.
+	src, err := FromEnv()
+	if err != nil {
+		return nil, HeaderAuthorization, err
+	}
+	if src != nil {
+		return src, ModeFromEnv(), nil
+	}
+
+	// Check settings when env vars produced nothing.
+	if settings == nil || settings.Audience == "" {
+		return nil, HeaderAuthorization, nil
+	}
+
+	// Env-var mode takes precedence over settings mode.
+	mode := ModeFromEnv()
+	if envMode := os.Getenv(EnvTransportMode); envMode == "" && settings.Mode != "" {
+		mode = ModeFromString(settings.Mode)
+	}
+
+	// Try metadata server first when on GCE.
+	if IsOnGCEFunc() {
+		if metaMode := os.Getenv(EnvMetadataMode); metaMode == "" {
+			return NewMetadataSource(settings.Audience), mode, nil
+		}
+	}
+
+	// Fall back to ADC.
+	if adcNew != nil {
+		adcSrc, err := adcNew(settings.Audience)
+		if err != nil {
+			return nil, HeaderAuthorization, err
+		}
+		return adcSrc, mode, nil
+	}
+
+	return nil, HeaderAuthorization, nil
+}
+
 // Wrap returns rt wrapped so that each outgoing request carries the
 // transport OIDC token in the header specified by mode.
 func Wrap(rt http.RoundTripper, src TokenSource, mode HeaderMode) http.RoundTripper {

--- a/pkg/transportauth/transportauth_test.go
+++ b/pkg/transportauth/transportauth_test.go
@@ -585,3 +585,129 @@ func TestFromEnv_NothingConfigured(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, src)
 }
+
+// --- ModeFromString tests ---
+
+func TestModeFromString_IAP(t *testing.T) {
+	assert.Equal(t, HeaderProxyAuthorization, ModeFromString("iap"))
+}
+
+func TestModeFromString_CloudRunInvoker(t *testing.T) {
+	assert.Equal(t, HeaderServerlessAuthorization, ModeFromString("cloudrun_invoker"))
+}
+
+func TestModeFromString_Unknown(t *testing.T) {
+	assert.Equal(t, HeaderAuthorization, ModeFromString("unknown"))
+}
+
+// --- FromSettings tests ---
+
+type fakeADCSource struct {
+	audience string
+	token    string
+	expiry   time.Time
+}
+
+func (f *fakeADCSource) Token() (string, error) {
+	if f.token == "" {
+		return "", fmt.Errorf("no token")
+	}
+	return f.token, nil
+}
+func (f *fakeADCSource) SetToken(token string, expiry time.Time) {
+	f.token = token
+	f.expiry = expiry
+}
+func (f *fakeADCSource) Expiry() time.Time { return f.expiry }
+
+func fakeADCNew(audience string) (TokenSource, error) {
+	tok := makeTestJWT(time.Now().Add(1 * time.Hour))
+	return &fakeADCSource{audience: audience, token: tok}, nil
+}
+
+func TestFromSettings_EnvOverridesSettings(t *testing.T) {
+	token := makeTestJWT(time.Now().Add(1 * time.Hour))
+	t.Setenv(EnvTransportToken, token)
+
+	settings := &TransportSettings{Mode: "iap", Audience: "from-settings"}
+	src, mode, err := FromSettings(settings, fakeADCNew)
+	require.NoError(t, err)
+	require.NotNil(t, src)
+	_, ok := src.(*InjectedSource)
+	assert.True(t, ok, "env var should take precedence over settings")
+	// When env has the token, ModeFromEnv() is used.
+	_ = mode
+}
+
+func TestFromSettings_SettingsAudience(t *testing.T) {
+	cleanup := overrideGCPDetection(false)
+	defer cleanup()
+
+	_ = os.Unsetenv(EnvTransportToken)
+	_ = os.Unsetenv(EnvTransportAudience)
+	_ = os.Unsetenv(EnvHubOIDCAudience)
+	_ = os.Unsetenv(EnvTransportMode)
+
+	settings := &TransportSettings{Mode: "iap", Audience: "https://settings-audience.example.com"}
+	src, mode, err := FromSettings(settings, fakeADCNew)
+	require.NoError(t, err)
+	require.NotNil(t, src)
+	_, ok := src.(*fakeADCSource)
+	assert.True(t, ok, "should use ADC when not on GCE")
+	assert.Equal(t, HeaderProxyAuthorization, mode, "should use IAP mode from settings")
+}
+
+func TestFromSettings_NilSettings(t *testing.T) {
+	cleanup := overrideGCPDetection(false)
+	defer cleanup()
+
+	_ = os.Unsetenv(EnvTransportToken)
+
+	src, _, err := FromSettings(nil, fakeADCNew)
+	require.NoError(t, err)
+	assert.Nil(t, src, "nil settings should return nil")
+}
+
+func TestFromSettings_EmptyAudience(t *testing.T) {
+	cleanup := overrideGCPDetection(false)
+	defer cleanup()
+
+	_ = os.Unsetenv(EnvTransportToken)
+
+	settings := &TransportSettings{Mode: "iap", Audience: ""}
+	src, _, err := FromSettings(settings, fakeADCNew)
+	require.NoError(t, err)
+	assert.Nil(t, src, "empty audience should return nil")
+}
+
+func TestFromSettings_EnvModeOverridesSettingsMode(t *testing.T) {
+	cleanup := overrideGCPDetection(false)
+	defer cleanup()
+
+	_ = os.Unsetenv(EnvTransportToken)
+	_ = os.Unsetenv(EnvTransportAudience)
+	_ = os.Unsetenv(EnvHubOIDCAudience)
+	t.Setenv(EnvTransportMode, "cloudrun_invoker")
+
+	settings := &TransportSettings{Mode: "iap", Audience: "https://audience.example.com"}
+	_, mode, err := FromSettings(settings, fakeADCNew)
+	require.NoError(t, err)
+	assert.Equal(t, HeaderServerlessAuthorization, mode, "env mode should override settings mode")
+}
+
+func TestFromSettings_MetadataOnGCE(t *testing.T) {
+	cleanup := overrideGCPDetection(true)
+	defer cleanup()
+
+	_ = os.Unsetenv(EnvTransportToken)
+	_ = os.Unsetenv(EnvTransportAudience)
+	_ = os.Unsetenv(EnvHubOIDCAudience)
+	_ = os.Unsetenv(EnvMetadataMode)
+
+	settings := &TransportSettings{Mode: "iap", Audience: "https://audience.example.com"}
+	src, _, err := FromSettings(settings, fakeADCNew)
+	require.NoError(t, err)
+	require.NotNil(t, src)
+	_, ok := src.(*MetadataSource)
+	assert.True(t, ok, "should prefer metadata on GCE")
+}

--- a/pkg/wsclient/pty.go
+++ b/pkg/wsclient/pty.go
@@ -30,6 +30,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
 	"github.com/GoogleCloudPlatform/scion/pkg/wsprotocol"
 	"github.com/gorilla/websocket"
 	"golang.org/x/term"
@@ -55,6 +56,10 @@ type PTYClientConfig struct {
 	Cols int
 	// Rows is the initial terminal height.
 	Rows int
+	// TransportSource provides OIDC transport tokens for IAP traversal.
+	TransportSource transportauth.TokenSource
+	// TransportMode controls header placement for the transport token.
+	TransportMode transportauth.HeaderMode
 }
 
 // PTYClient manages a WebSocket PTY connection.
@@ -91,6 +96,13 @@ func (c *PTYClient) Connect(ctx context.Context) error {
 	headers := http.Header{}
 	if c.config.Token != "" {
 		headers.Set("Authorization", "Bearer "+c.config.Token)
+	}
+
+	// Apply transport auth headers for IAP/Cloud Run traversal.
+	if c.config.TransportSource != nil {
+		if err := transportauth.ApplyHeaders(headers, c.config.TransportSource, c.config.TransportMode); err != nil {
+			slog.Debug("Transport auth header failed, proceeding without", "error", err)
+		}
 	}
 
 	// Connect with timeout
@@ -450,7 +462,7 @@ func (c *PTYClient) Close() error {
 }
 
 // AttachToAgent is a convenience function that connects and runs a PTY session.
-func AttachToAgent(ctx context.Context, endpoint, token, slug string) error {
+func AttachToAgent(ctx context.Context, endpoint, token, slug string, opts ...AttachOption) error {
 	// Get terminal size
 	cols, rows := 80, 24
 	if fd := int(os.Stdin.Fd()); term.IsTerminal(fd) {
@@ -460,13 +472,19 @@ func AttachToAgent(ctx context.Context, endpoint, token, slug string) error {
 		}
 	}
 
-	client := NewPTYClient(PTYClientConfig{
+	cfg := PTYClientConfig{
 		Endpoint: endpoint,
 		Token:    token,
 		Slug:     slug,
 		Cols:     cols,
 		Rows:     rows,
-	})
+	}
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	client := NewPTYClient(cfg)
 
 	if err := client.Connect(ctx); err != nil {
 		return err
@@ -474,6 +492,17 @@ func AttachToAgent(ctx context.Context, endpoint, token, slug string) error {
 	defer func() { _ = client.Close() }()
 
 	return client.Run()
+}
+
+// AttachOption configures optional parameters for AttachToAgent.
+type AttachOption func(*PTYClientConfig)
+
+// WithTransport sets the transport auth source and header mode for IAP traversal.
+func WithTransport(src transportauth.TokenSource, mode transportauth.HeaderMode) AttachOption {
+	return func(c *PTYClientConfig) {
+		c.TransportSource = src
+		c.TransportMode = mode
+	}
 }
 
 // BuildDirectAttachURL builds a URL for direct attachment to a runtime broker.

--- a/pkg/wsclient/pty_transport_test.go
+++ b/pkg/wsclient/pty_transport_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wsclient
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTokenSource implements transportauth.TokenSource for testing.
+type fakeTokenSource struct {
+	token  string
+	expiry time.Time
+}
+
+func (f *fakeTokenSource) Token() (string, error) {
+	if f.token == "" {
+		return "", fmt.Errorf("no token")
+	}
+	return f.token, nil
+}
+func (f *fakeTokenSource) SetToken(token string, expiry time.Time) {
+	f.token = token
+	f.expiry = expiry
+}
+func (f *fakeTokenSource) Expiry() time.Time { return f.expiry }
+
+func TestConnect_WithTransportAuth_IAP(t *testing.T) {
+	var receivedAuth, receivedProxy string
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		receivedProxy = r.Header.Get("Proxy-Authorization")
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}))
+	defer srv.Close()
+
+	src := &fakeTokenSource{token: "oidc-transport-token"}
+	client := NewPTYClient(PTYClientConfig{
+		Endpoint:        srv.URL,
+		Token:           "scion-user-token",
+		Slug:            "test-agent",
+		TransportSource: src,
+		TransportMode:   transportauth.HeaderProxyAuthorization,
+	})
+
+	err := client.Connect(context.Background())
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	assert.Equal(t, "Bearer scion-user-token", receivedAuth, "scion token should be in Authorization")
+	assert.Equal(t, "Bearer oidc-transport-token", receivedProxy, "OIDC token should be in Proxy-Authorization")
+}
+
+func TestConnect_WithTransportAuth_CloudRunInvoker(t *testing.T) {
+	var receivedAuth, receivedServerless string
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		receivedServerless = r.Header.Get("X-Serverless-Authorization")
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}))
+	defer srv.Close()
+
+	src := &fakeTokenSource{token: "oidc-transport-token"}
+	client := NewPTYClient(PTYClientConfig{
+		Endpoint:        srv.URL,
+		Token:           "scion-user-token",
+		Slug:            "test-agent",
+		TransportSource: src,
+		TransportMode:   transportauth.HeaderServerlessAuthorization,
+	})
+
+	err := client.Connect(context.Background())
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	assert.Equal(t, "Bearer scion-user-token", receivedAuth, "scion token in Authorization")
+	assert.Equal(t, "Bearer oidc-transport-token", receivedServerless, "OIDC in X-Serverless-Authorization")
+}
+
+func TestConnect_WithoutTransportAuth(t *testing.T) {
+	var receivedAuth, receivedProxy string
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		receivedProxy = r.Header.Get("Proxy-Authorization")
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}))
+	defer srv.Close()
+
+	client := NewPTYClient(PTYClientConfig{
+		Endpoint: srv.URL,
+		Token:    "scion-user-token",
+		Slug:     "test-agent",
+	})
+
+	err := client.Connect(context.Background())
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	assert.Equal(t, "Bearer scion-user-token", receivedAuth, "scion token should be in Authorization")
+	assert.Empty(t, receivedProxy, "no Proxy-Authorization without transport auth")
+}
+
+func TestWithTransport_AttachOption(t *testing.T) {
+	src := &fakeTokenSource{token: "test"}
+	cfg := PTYClientConfig{}
+	opt := WithTransport(src, transportauth.HeaderProxyAuthorization)
+	opt(&cfg)
+
+	assert.Equal(t, src, cfg.TransportSource)
+	assert.Equal(t, transportauth.HeaderProxyAuthorization, cfg.TransportMode)
+}


### PR DESCRIPTION
Adds OIDC transport auth support to all broker Hub communication paths, enabling GKE-hosted brokers to connect through an IAP-protected Hub without manual workarounds.

## Changes
- New `BrokerCredentials` transport auth fields + `ModeFromString` resolution helper
- REST sites wired (`hub_connection.go`, `server.go` x2, `cmd/broker.go`) with per-request OIDC token
- Control channel WebSocket (`controlchannel.buildAuthHeaders()`) mints fresh token per dial/reconnect
- Broker register/join persists transport fields; no-PAT enforcement relaxed under proxy-auth mode
- Review fixes: deduplication of token source, removed dead code

## Test Plan
See PR description for live IAP environment validation steps.

Closes the gist workaround (manual install-broker.sh curl-from-a-pod). Part of ha-run workstream.
Related: ptone/scion#490, ptone/scion#488