### PR TITLE
harness/codex: implement reasoning_effort from thinking level

### DIFF
--- a/harnesses/codex/provision.py
+++ b/harnesses/codex/provision.py
@@ -232,7 +232,40 @@ def _build_otel_section(telemetry: dict[str, Any], env: dict[str, str] | None) -
     return "\n".join(lines) + "\n"
 
 
-def _reconcile_codex_toml(telemetry: dict[str, Any] | None, env: dict[str, str] | None) -> None:
+def _resolve_reasoning_effort(level: int) -> str:
+    """Map a thinking level (0-100) to OpenAI reasoning_effort (low/medium/high)."""
+    level = max(0, min(100, level))
+    if level >= 67:
+        return "high"
+    if level >= 34:
+        return "medium"
+    return "low"
+
+
+def _is_toml_key_line(line: str, key: str) -> bool:
+    """True if line is a top-level TOML assignment for exactly `key`."""
+    s = line.strip()
+    if not s.startswith(key):
+        return False
+    rest = s[len(key):]
+    return len(rest) > 0 and rest[0] in (" ", "=", "\t")
+
+
+def _strip_toml_top_level_key(content: str, key: str) -> str:
+    """Remove a top-level TOML key = value line from content."""
+    lines = content.split("\n")
+    kept = [
+        line for line in lines
+        if not _is_toml_key_line(line, key) or line.strip().startswith("[")
+    ]
+    return "\n".join(kept)
+
+
+def _reconcile_codex_toml(
+    telemetry: dict[str, Any] | None,
+    env: dict[str, str] | None,
+    reasoning_effort: str | None = None,
+) -> None:
     codex_dir = scion_harness.expand_path("~/.codex")
     os.makedirs(codex_dir, exist_ok=True)
     config_path = os.path.join(codex_dir, "config.toml")
@@ -240,7 +273,13 @@ def _reconcile_codex_toml(telemetry: dict[str, Any] | None, env: dict[str, str] 
     if os.path.isfile(config_path):
         with open(config_path, "r", encoding="utf-8") as f:
             content = f.read()
+    content = _strip_toml_top_level_key(content, "reasoning_effort")
     content = scion_harness.strip_toml_sections(content, lambda h: h == "[otel]")
+
+    if reasoning_effort:
+        re_line = f'reasoning_effort = "{scion_harness.toml_escape(reasoning_effort)}"'
+        content = content.rstrip("\n\t ") + "\n" + re_line + "\n"
+
     if _telemetry_enabled(telemetry):
         section = _build_otel_section(telemetry or {}, env)
         content = content.rstrip("\n\t ") + "\n\n" + section
@@ -351,6 +390,13 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     instructions_file = str(harness_cfg.get("instructions_file") or ".codex/AGENTS.md")
     scion_harness.project_instructions(ctx, instructions_file)
 
+    thinking_raw = os.environ.get("AGY_THINKING_LEVEL", "")
+    reasoning_effort: str | None = None
+    if thinking_raw.strip().isdigit():
+        thinking_level = int(thinking_raw)
+        reasoning_effort = _resolve_reasoning_effort(thinking_level)
+        ctx.info(f"thinking_level={thinking_level} reasoning_effort={reasoning_effort}")
+
     telemetry_payload = ctx.telemetry
     telemetry = telemetry_payload.get("telemetry") if isinstance(telemetry_payload, dict) else None
     env_overlay = telemetry_payload.get("env") if isinstance(telemetry_payload, dict) else None
@@ -359,6 +405,7 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     _reconcile_codex_toml(
         telemetry if isinstance(telemetry, dict) else None,
         env_overlay,
+        reasoning_effort=reasoning_effort,
     )
 
     extra: dict[str, Any] | None = None

--- a/harnesses/codex/provision.py
+++ b/harnesses/codex/provision.py
@@ -390,7 +390,7 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     instructions_file = str(harness_cfg.get("instructions_file") or ".codex/AGENTS.md")
     scion_harness.project_instructions(ctx, instructions_file)
 
-    thinking_raw = os.environ.get("AGY_THINKING_LEVEL", "")
+    thinking_raw = os.environ.get("SCION_THINKING_LEVEL", "")
     reasoning_effort: str | None = None
     if thinking_raw.strip().isdigit():
         thinking_level = int(thinking_raw)

--- a/harnesses/codex/provision.py
+++ b/harnesses/codex/provision.py
@@ -254,10 +254,15 @@ def _is_toml_key_line(line: str, key: str) -> bool:
 def _strip_toml_top_level_key(content: str, key: str) -> str:
     """Remove a top-level TOML key = value line from content."""
     lines = content.split("\n")
-    kept = [
-        line for line in lines
-        if not _is_toml_key_line(line, key) or line.strip().startswith("[")
-    ]
+    kept = []
+    in_section = False
+    for line in lines:
+        s = line.strip()
+        if s.startswith("["):
+            in_section = True
+        if not in_section and _is_toml_key_line(line, key):
+            continue
+        kept.append(line)
     return "\n".join(kept)
 
 
@@ -390,12 +395,15 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     instructions_file = str(harness_cfg.get("instructions_file") or ".codex/AGENTS.md")
     scion_harness.project_instructions(ctx, instructions_file)
 
-    thinking_raw = os.environ.get("SCION_THINKING_LEVEL", "")
+    thinking_raw = os.environ.get("SCION_THINKING_LEVEL", "").strip()
     reasoning_effort: str | None = None
-    if thinking_raw.strip().isdigit():
-        thinking_level = int(thinking_raw)
-        reasoning_effort = _resolve_reasoning_effort(thinking_level)
-        ctx.info(f"thinking_level={thinking_level} reasoning_effort={reasoning_effort}")
+    if thinking_raw:
+        try:
+            thinking_level = int(thinking_raw)
+            reasoning_effort = _resolve_reasoning_effort(thinking_level)
+            ctx.info(f"thinking_level={thinking_level} reasoning_effort={reasoning_effort}")
+        except ValueError:
+            pass
 
     telemetry_payload = ctx.telemetry
     telemetry = telemetry_payload.get("telemetry") if isinstance(telemetry_payload, dict) else None

--- a/harnesses/codex/provision_test.py
+++ b/harnesses/codex/provision_test.py
@@ -274,6 +274,11 @@ class CodexProvisionTest(unittest.TestCase):
                 self.assertNotIn('"low"', content)
                 self.assertIn('other_key = "value"', content)
 
+    def test_strip_toml_top_level_key_section_safety(self) -> None:
+        content = '[otel]\nreasoning_effort = "low"\n[other]\nkey = "val"\n'
+        result = provision._strip_toml_top_level_key(content, "reasoning_effort")
+        self.assertIn('reasoning_effort = "low"', result)
+
     def test_strip_toml_top_level_key_does_not_match_prefixed_keys(self) -> None:
         content = 'reasoning_effort = "low"\nreasoning_effort_extended = "yes"\n'
         result = provision._strip_toml_top_level_key(content, "reasoning_effort")

--- a/harnesses/codex/provision_test.py
+++ b/harnesses/codex/provision_test.py
@@ -228,5 +228,58 @@ class CodexProvisionTest(unittest.TestCase):
         self.assertIn('environment = "production"', defaulted)
 
 
+    def test_resolve_reasoning_effort_maps_thinking_levels(self) -> None:
+        self.assertEqual(provision._resolve_reasoning_effort(0), "low")
+        self.assertEqual(provision._resolve_reasoning_effort(33), "low")
+        self.assertEqual(provision._resolve_reasoning_effort(34), "medium")
+        self.assertEqual(provision._resolve_reasoning_effort(50), "medium")
+        self.assertEqual(provision._resolve_reasoning_effort(66), "medium")
+        self.assertEqual(provision._resolve_reasoning_effort(67), "high")
+        self.assertEqual(provision._resolve_reasoning_effort(100), "high")
+
+    def test_resolve_reasoning_effort_clamps_out_of_range(self) -> None:
+        self.assertEqual(provision._resolve_reasoning_effort(-10), "low")
+        self.assertEqual(provision._resolve_reasoning_effort(150), "high")
+
+    def test_reconcile_codex_toml_writes_reasoning_effort(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with temporary_home(tmp):
+                provision._reconcile_codex_toml(None, None, reasoning_effort="medium")
+                config_path = os.path.join(tmp, ".codex", "config.toml")
+                with open(config_path, "r", encoding="utf-8") as f:
+                    content = f.read()
+                self.assertIn('reasoning_effort = "medium"', content)
+
+    def test_reconcile_codex_toml_omits_reasoning_effort_when_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with temporary_home(tmp):
+                provision._reconcile_codex_toml(None, None, reasoning_effort=None)
+                config_path = os.path.join(tmp, ".codex", "config.toml")
+                with open(config_path, "r", encoding="utf-8") as f:
+                    content = f.read()
+                self.assertNotIn("reasoning_effort", content)
+
+    def test_reconcile_codex_toml_replaces_existing_reasoning_effort(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with temporary_home(tmp):
+                codex_dir = os.path.join(tmp, ".codex")
+                os.makedirs(codex_dir)
+                config_path = os.path.join(codex_dir, "config.toml")
+                with open(config_path, "w", encoding="utf-8") as f:
+                    f.write('reasoning_effort = "low"\nother_key = "value"\n')
+                provision._reconcile_codex_toml(None, None, reasoning_effort="high")
+                with open(config_path, "r", encoding="utf-8") as f:
+                    content = f.read()
+                self.assertIn('reasoning_effort = "high"', content)
+                self.assertNotIn('"low"', content)
+                self.assertIn('other_key = "value"', content)
+
+    def test_strip_toml_top_level_key_does_not_match_prefixed_keys(self) -> None:
+        content = 'reasoning_effort = "low"\nreasoning_effort_extended = "yes"\n'
+        result = provision._strip_toml_top_level_key(content, "reasoning_effort")
+        self.assertNotIn('reasoning_effort = "low"', result)
+        self.assertIn('reasoning_effort_extended = "yes"', result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -81,6 +81,7 @@ type BucketConfig struct {
 //   - SCION_HUB_TOKEN: Bearer token for Hub authentication
 //   - SCION_HUB_API_KEY: API key for Hub authentication (alternative to token)
 //   - SCION_HUB_ENABLED: Set to "true" to enable Hub integration
+//
 // HubTransportConfig defines transport-layer auth settings for traversing
 // platform guards (IAP, Cloud Run invoker IAM) in front of the Hub.
 type HubTransportConfig struct {


### PR DESCRIPTION
## Change

Reads AGY_THINKING_LEVEL from container env and maps 0-100 → low/medium/high (0-33/34-66/67-100), writing reasoning_effort to ~/.codex/config.toml. Unset = omit (codex uses default).

Note: The env var will be updated to SCION_THINKING_LEVEL once the auto-injection PR lands (that PR adds SCION_THINKING_LEVEL injection from AgentAppliedConfig.ThinkingLevel, analogous to SCION_MODEL). Antigravity has the same pending update.

6 new tests (28 total) cover: bucket boundaries, clamping, write, omit, replace, prefix protection. Matches antigravity bucket mapping exactly