### PR TITLE
agent: add --thinking-level flag and SCION_THINKING_LEVEL env injection

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -76,6 +76,7 @@ var (
 	inlineConfigPath      string
 	labelFlags            []string
 	modelFlag             string
+	thinkingLevelFlag     int
 )
 
 func parseLabels(raw []string) (map[string]string, error) {
@@ -427,6 +428,12 @@ func RunAgent(cmd *cobra.Command, args []string, resume bool) error {
 			inlineCfg = &api.ScionConfig{}
 		}
 		inlineCfg.Model = normalizedModel
+	}
+	if thinkingLevelFlag >= 0 && thinkingLevelFlag <= 100 {
+		if inlineCfg == nil {
+			inlineCfg = &api.ScionConfig{}
+		}
+		inlineCfg.ThinkingLevel = &thinkingLevelFlag
 	}
 
 	// This allows starting/resuming an agent even if it exists on Hub but not locally

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -76,7 +76,7 @@ var (
 	inlineConfigPath      string
 	labelFlags            []string
 	modelFlag             string
-	thinkingLevelFlag     int
+	thinkingLevelFlag     int = -1
 )
 
 func parseLabels(raw []string) (map[string]string, error) {

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -429,11 +429,15 @@ func RunAgent(cmd *cobra.Command, args []string, resume bool) error {
 		}
 		inlineCfg.Model = normalizedModel
 	}
-	if thinkingLevelFlag >= 0 && thinkingLevelFlag <= 100 {
+	if thinkingLevelFlag != -1 {
+		if thinkingLevelFlag < 0 || thinkingLevelFlag > 100 {
+			return fmt.Errorf("invalid --thinking-level value %d: must be between 0 and 100", thinkingLevelFlag)
+		}
 		if inlineCfg == nil {
 			inlineCfg = &api.ScionConfig{}
 		}
-		inlineCfg.ThinkingLevel = &thinkingLevelFlag
+		val := thinkingLevelFlag
+		inlineCfg.ThinkingLevel = &val
 	}
 
 	// This allows starting/resuming an agent even if it exists on Hub but not locally

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -80,6 +80,9 @@ func init() {
 	// Model flag
 	startCmd.Flags().StringVar(&modelFlag, "model", "", "Model to use: alias (small, medium, large, extra-large/xl) or explicit model ID")
 
+	// Thinking level flag
+	startCmd.Flags().IntVar(&thinkingLevelFlag, "thinking-level", -1, "Thinking level (0-100) to inject into agent config")
+
 	// Label flags
 	startCmd.Flags().StringArrayVar(&labelFlags, "label", nil, "Label in key=value format (repeatable)")
 

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -636,6 +636,9 @@ authDone:
 	if _, ok := opts.Env["SCION_MODEL"]; !ok && finalScionCfg != nil && finalScionCfg.Model != "" {
 		opts.Env["SCION_MODEL"] = finalScionCfg.Model
 	}
+	if _, ok := opts.Env["SCION_THINKING_LEVEL"]; !ok && finalScionCfg != nil && finalScionCfg.ThinkingLevel != nil {
+		opts.Env["SCION_THINKING_LEVEL"] = strconv.Itoa(*finalScionCfg.ThinkingLevel)
+	}
 	if _, ok := opts.Env["SCION_CREATOR"]; !ok {
 		if u, err := user.Current(); err == nil {
 			opts.Env["SCION_CREATOR"] = u.Username


### PR DESCRIPTION
## Change

Adds --thinking-level int flag to scion start (consistent with --model which is also start-only). The value (0-100) flows into ScionConfig.ThinkingLevel and is injected as SCION_THINKING_LEVEL into the agent container environment, following the exact SCION_MODEL pattern in pkg/agent/run.go.

Three files: pkg/agent/run.go (injection after SCION_MODEL), cmd/common.go (flag variable + ThinkingLevel flow), cmd/start.go (flag registration).

Harness provision.py scripts read SCION_THINKING_LEVEL to apply harness-specific thinking/reasoning effort