### PR TITLE
fix: guard empty array expansions under set -u (issue #655)

### DIFF
--- a/image-build/scripts/build-images.sh
+++ b/image-build/scripts/build-images.sh
@@ -277,7 +277,7 @@ else
       --dockerfile "${dockerfile}" \
       --tags "${tags}" \
       --platforms "${PLATFORMS}" \
-      "${build_arg_flags[@]}" \
+      ${build_arg_flags[@]+"${build_arg_flags[@]}"} \
       --push "${PUSH}" \
       --load "${LOAD}"
   done

--- a/image-build/scripts/builders/local-docker.sh
+++ b/image-build/scripts/builders/local-docker.sh
@@ -99,7 +99,7 @@ builder_build() {
   done
 
   local arg
-  for arg in "${build_args[@]}"; do
+  for arg in ${build_args[@]+"${build_args[@]}"}; do
     cmd+=(--build-arg "${arg}")
   done
 

--- a/image-build/scripts/builders/local-podman.sh
+++ b/image-build/scripts/builders/local-podman.sh
@@ -75,7 +75,7 @@ builder_build() {
   done
 
   local arg
-  for arg in "${build_args[@]}"; do
+  for arg in ${build_args[@]+"${build_args[@]}"}; do
     cmd+=(--build-arg "${arg}")
   done
 


### PR DESCRIPTION
bash <4.4 (including macOS system bash 3.2) treats "${empty_array[@]}" as an unbound variable when set -u is active.  Replace bare expansions with the ${arr[@]+"${arr[@]}"} guard idiom, which is safe back to bash 3.1 and expands to zero words when the array is empty.

Three sites affected:
- image-build/scripts/build-images.sh: build_arg_flags[@] at the builder_build call site (line 280)
- image-build/scripts/builders/local-docker.sh: build_args[@] in the --build-arg accumulation loop
- image-build/scripts/builders/local-podman.sh: build_args[@] in the same loop

Fixes #655.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
