### PR TITLE
ws: raise MaxMessageSize from 64KB to 1MB and add pre-send size guard…

### DIFF
--- a/pkg/hub/controlchannel.go
+++ b/pkg/hub/controlchannel.go
@@ -52,7 +52,7 @@ func DefaultControlChannelConfig() ControlChannelConfig {
 		PingInterval:   30 * time.Second,
 		PongWait:       60 * time.Second,
 		WriteWait:      10 * time.Second,
-		MaxMessageSize: 64 * 1024, // 64KB
+		MaxMessageSize: 1024 * 1024, // 1MB — must be large enough to carry RemoteCreateAgentRequest payloads (see issue #165)
 		RequestTimeout: 120 * time.Second,
 		Debug:          false,
 	}

--- a/pkg/hub/controlchannel_client.go
+++ b/pkg/hub/controlchannel_client.go
@@ -30,6 +30,14 @@ import (
 	"github.com/google/uuid"
 )
 
+// maxControlChannelBodySize is the maximum body size (in bytes) that can be
+// sent through the WebSocket control channel without exceeding the broker's
+// read limit. The RequestEnvelope.Body field is base64-encoded in JSON, adding
+// ~33% overhead, so the safe body threshold for a 1MB wire limit is ~768KB.
+// Requests exceeding this limit are rejected before encoding with a clear error
+// so callers (e.g. HybridBrokerClient) can fall back to direct HTTP (issue #165).
+const maxControlChannelBodySize = 768 * 1024 // 768KB → ~1MB on wire after base64
+
 // ControlChannelBrokerClient implements RuntimeBrokerClient by tunneling requests
 // through the control channel WebSocket connection.
 type ControlChannelBrokerClient struct {
@@ -418,12 +426,31 @@ func (c *ControlChannelBrokerClient) DeleteImage(ctx context.Context, brokerID, 
 	return err
 }
 
+// checkBodySize returns an error if the body is too large to tunnel safely
+// through the control channel WebSocket without exceeding the broker's read
+// limit. The Body field is base64-encoded in the RequestEnvelope JSON, so the
+// actual wire size is roughly len(body)*4/3 plus envelope metadata.
+func checkBodySize(method, path string, body []byte) error {
+	if len(body) > maxControlChannelBodySize {
+		return fmt.Errorf(
+			"control channel payload too large: %s %s body is %d bytes (limit %d); "+
+				"use direct HTTP to reach this broker instead (issue #165)",
+			method, path, len(body), maxControlChannelBodySize,
+		)
+	}
+	return nil
+}
+
 // doRequestRaw tunnels an HTTP request through the control channel without
 // treating non-2xx status codes as errors. Callers are responsible for
 // inspecting resp.StatusCode themselves.
 func (c *ControlChannelBrokerClient) doRequestRaw(ctx context.Context, brokerID, method, path, query string, body []byte) (*wsprotocol.ResponseEnvelope, error) {
 	if !c.manager.IsConnected(brokerID) {
 		return nil, fmt.Errorf("broker %s not connected via control channel", brokerID)
+	}
+
+	if err := checkBodySize(method, path, body); err != nil {
+		return nil, err
 	}
 
 	headers, err := c.buildRequestHeaders(ctx, brokerID, method, path, query, body)
@@ -444,6 +471,10 @@ func (c *ControlChannelBrokerClient) doRequestRaw(ctx context.Context, brokerID,
 func (c *ControlChannelBrokerClient) doRequest(ctx context.Context, brokerID, method, path, query string, body []byte) (*wsprotocol.ResponseEnvelope, error) {
 	if !c.manager.IsConnected(brokerID) {
 		return nil, fmt.Errorf("broker %s not connected via control channel", brokerID)
+	}
+
+	if err := checkBodySize(method, path, body); err != nil {
+		return nil, err
 	}
 
 	headers, err := c.buildRequestHeaders(ctx, brokerID, method, path, query, body)

--- a/pkg/hub/controlchannel_client.go
+++ b/pkg/hub/controlchannel_client.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -34,9 +35,29 @@ import (
 // sent through the WebSocket control channel without exceeding the broker's
 // read limit. The RequestEnvelope.Body field is base64-encoded in JSON, adding
 // ~33% overhead, so the safe body threshold for a 1MB wire limit is ~768KB.
-// Requests exceeding this limit are rejected before encoding with a clear error
-// so callers (e.g. HybridBrokerClient) can fall back to direct HTTP (issue #165).
+// Requests exceeding this limit are rejected before encoding so callers
+// (e.g. HybridBrokerClient) can detect ErrPayloadTooLarge and fall back to
+// direct HTTP (issue #165).
 const maxControlChannelBodySize = 768 * 1024 // 768KB → ~1MB on wire after base64
+
+// ErrPayloadTooLarge is returned by the control channel client when a request
+// body exceeds maxControlChannelBodySize. Callers should use errors.As to
+// detect this condition and fall back to direct HTTP rather than propagating
+// the error.
+type ErrPayloadTooLarge struct {
+	Method string
+	Path   string
+	Size   int
+	Limit  int
+}
+
+func (e *ErrPayloadTooLarge) Error() string {
+	return fmt.Sprintf(
+		"control channel payload too large: %s %s body is %d bytes (limit %d); "+
+			"use direct HTTP to reach this broker instead (issue #165)",
+		e.Method, e.Path, e.Size, e.Limit,
+	)
+}
 
 // ControlChannelBrokerClient implements RuntimeBrokerClient by tunneling requests
 // through the control channel WebSocket connection.
@@ -426,17 +447,20 @@ func (c *ControlChannelBrokerClient) DeleteImage(ctx context.Context, brokerID, 
 	return err
 }
 
-// checkBodySize returns an error if the body is too large to tunnel safely
-// through the control channel WebSocket without exceeding the broker's read
-// limit. The Body field is base64-encoded in the RequestEnvelope JSON, so the
-// actual wire size is roughly len(body)*4/3 plus envelope metadata.
+// checkBodySize returns an *ErrPayloadTooLarge if the body is too large to
+// tunnel safely through the control channel WebSocket without exceeding the
+// broker's read limit. The Body field is base64-encoded in the RequestEnvelope
+// JSON, so the actual wire size is roughly len(body)*4/3 plus envelope
+// metadata. Callers should use errors.As(err, &ErrPayloadTooLarge{}) to detect
+// this condition and fall back to direct HTTP.
 func checkBodySize(method, path string, body []byte) error {
 	if len(body) > maxControlChannelBodySize {
-		return fmt.Errorf(
-			"control channel payload too large: %s %s body is %d bytes (limit %d); "+
-				"use direct HTTP to reach this broker instead (issue #165)",
-			method, path, len(body), maxControlChannelBodySize,
-		)
+		return &ErrPayloadTooLarge{
+			Method: method,
+			Path:   path,
+			Size:   len(body),
+			Limit:  maxControlChannelBodySize,
+		}
 	}
 	return nil
 }
@@ -565,9 +589,20 @@ func (c *HybridBrokerClient) useControlChannel(brokerID string) bool {
 }
 
 // CreateAgent creates an agent, preferring control channel.
+// If the control channel rejects the payload as too large (ErrPayloadTooLarge),
+// it falls back to direct HTTP so the agent creation can still succeed.
 func (c *HybridBrokerClient) CreateAgent(ctx context.Context, brokerID, brokerEndpoint string, req *RemoteCreateAgentRequest) (*RemoteAgentResponse, error) {
 	if c.useControlChannel(brokerID) {
-		return c.controlChannel.CreateAgent(ctx, brokerID, brokerEndpoint, req)
+		resp, err := c.controlChannel.CreateAgent(ctx, brokerID, brokerEndpoint, req)
+		if err == nil {
+			return resp, nil
+		}
+		var payloadErr *ErrPayloadTooLarge
+		if errors.As(err, &payloadErr) {
+			// Payload too large for the WebSocket channel — fall back to HTTP.
+			return c.httpClient.CreateAgent(ctx, brokerID, brokerEndpoint, req)
+		}
+		return nil, err
 	}
 	return c.httpClient.CreateAgent(ctx, brokerID, brokerEndpoint, req)
 }
@@ -677,10 +712,21 @@ func (c *HybridBrokerClient) CheckAgentPrompt(ctx context.Context, brokerID, bro
 // to decide the delivery path. routeLocal uses the control-channel tunnel,
 // routeHTTP falls back to HTTP, and routeForward/routeUndeliverable return
 // ErrLifecycleDeferred so the caller can write durable intent + wait.
+// If the control channel rejects the payload as too large (ErrPayloadTooLarge),
+// it falls back to direct HTTP regardless of the routing decision.
 func (c *HybridBrokerClient) CreateAgentWithGather(ctx context.Context, brokerID, brokerEndpoint string, req *RemoteCreateAgentRequest) (*RemoteAgentResponse, *RemoteEnvRequirementsResponse, error) {
 	switch c.route(ctx, brokerID, brokerEndpoint) {
 	case routeLocal:
-		return c.controlChannel.CreateAgentWithGather(ctx, brokerID, brokerEndpoint, req)
+		resp, envReqs, err := c.controlChannel.CreateAgentWithGather(ctx, brokerID, brokerEndpoint, req)
+		if err == nil {
+			return resp, envReqs, nil
+		}
+		var payloadErr *ErrPayloadTooLarge
+		if errors.As(err, &payloadErr) {
+			// Payload too large for the WebSocket channel — fall back to HTTP.
+			return c.httpClient.CreateAgentWithGather(ctx, brokerID, brokerEndpoint, req)
+		}
+		return nil, nil, err
 	case routeHTTP:
 		return c.httpClient.CreateAgentWithGather(ctx, brokerID, brokerEndpoint, req)
 	default:

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -874,7 +874,7 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 		PingInterval:   30 * time.Second,
 		PongWait:       60 * time.Second,
 		WriteWait:      10 * time.Second,
-		MaxMessageSize: 64 * 1024,
+		MaxMessageSize: 1024 * 1024, // 1MB — see issue #165
 		RequestTimeout: 120 * time.Second,
 		Debug:          cfg.Debug,
 	}, logging.Subsystem("hub.control-channel"))

--- a/pkg/runtimebroker/controlchannel.go
+++ b/pkg/runtimebroker/controlchannel.go
@@ -246,7 +246,14 @@ func (c *ControlChannelClient) doConnect() error {
 	// for closing resp.Body in that case — otherwise the transport holds the
 	// connection open and leaks the file descriptor. Drain-and-close before
 	// returning the error.
-	conn, resp, err := wsprotocol.Dial(c.ctx, wsURL, headers)
+	//
+	// Use DialWithConfig so the broker's read limit matches the hub's write
+	// limit. The default 64KB was too small for RemoteCreateAgentRequest
+	// payloads that include InlineConfig, resolved env/secrets, and a JWT
+	// (see issue #165). 1MB aligns with the hub-side MaxMessageSize.
+	connCfg := wsprotocol.DefaultConnectionConfig()
+	connCfg.MaxMessageSize = 1024 * 1024 // 1MB
+	conn, resp, err := wsprotocol.DialWithConfig(c.ctx, wsURL, headers, connCfg)
 	if err != nil {
 		if resp != nil {
 			_, _ = io.Copy(io.Discard, resp.Body)

--- a/pkg/wsprotocol/connection.go
+++ b/pkg/wsprotocol/connection.go
@@ -32,7 +32,7 @@ const (
 	DefaultPingInterval    = 30 * time.Second
 	DefaultPongWait        = 60 * time.Second
 	DefaultWriteWait       = 10 * time.Second
-	DefaultMaxMessageSize  = 64 * 1024 // 64KB
+	DefaultMaxMessageSize  = 1024 * 1024 // 1MB — raised from 64KB to accommodate large agent creation payloads (see issue #165)
 )
 
 // ConnectionConfig holds configuration for a WebSocket connection.


### PR DESCRIPTION
… (issue #165)

RemoteCreateAgentRequest payloads can exceed the previous 64KB WebSocket read limit when they carry a large InlineConfig (AgentInstructions, SystemPrompt, MCPServers), multiple scopes of resolved env vars and secrets, and a JWT. The RequestEnvelope.Body field is base64-encoded in JSON (+33% overhead), further amplifying the wire size.

Changes:
- pkg/wsprotocol/connection.go: raise DefaultMaxMessageSize 64KB → 1MB
- pkg/hub/controlchannel.go: raise default ControlChannelConfig limit to 1MB
- pkg/hub/server.go: raise hardcoded construction-time limit to 1MB
- pkg/runtimebroker/controlchannel.go: switch from wsprotocol.Dial to DialWithConfig with explicit 1MB read limit so the broker can receive hub→broker messages that fit within the new limit
- pkg/hub/controlchannel_client.go: add checkBodySize guard in both doRequest/doRequestRaw; returns a clear error (with issue reference) when a body exceeds 768KB (the safe threshold before base64 pushes the wire size past 1MB), allowing HybridBrokerClient callers to fall back to direct HTTP

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
