### PR TITLE
fix: migrate default OOB harness from gemini to antigravity

### DIFF
--- a/pkg/hub/maintenance_executors.go
+++ b/pkg/hub/maintenance_executors.go
@@ -160,7 +160,7 @@ type PullImagesExecutor struct {
 	runtimeBin string   // "docker", "podman", or "container"
 	registry   string   // image registry prefix
 	tag        string   // image tag (default "latest")
-	harnesses  []string // harness names (e.g., "claude", "gemini")
+	harnesses  []string // harness names (e.g., "claude", "antigravity")
 }
 
 func (e *PullImagesExecutor) Run(ctx context.Context, logger io.Writer, params map[string]string) error {
@@ -192,7 +192,7 @@ func (e *PullImagesExecutor) Run(ctx context.Context, logger io.Writer, params m
 
 	harnesses := e.harnesses
 	if len(harnesses) == 0 {
-		harnesses = []string{"claude", "gemini"}
+		harnesses = []string{"claude", "antigravity"}
 	}
 
 	log.Debug("Starting pull-images",

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -203,7 +203,7 @@ type MaintenanceConfig struct {
 	ImageRegistry string
 	// ImageTag is the default image tag to pull (default: "latest").
 	ImageTag string
-	// Harnesses is the list of harness names whose images should be pulled (e.g., ["claude", "gemini", "opencode", "codex"]).
+	// Harnesses is the list of harness names whose images should be pulled (e.g., ["claude", "antigravity", "opencode", "codex"]).
 	Harnesses []string
 	// RuntimeBin overrides auto-detection of the container runtime binary (docker, podman).
 	RuntimeBin string

--- a/pkg/runtime/imagepull.go
+++ b/pkg/runtime/imagepull.go
@@ -20,10 +20,11 @@ import (
 )
 
 var harnessImageMap = map[string]string{
-	"claude":   "scion-claude:latest",
-	"gemini":   "scion-gemini:latest",
-	"codex":    "scion-codex:latest",
-	"opencode": "scion-opencode:latest",
+	"claude":      "scion-claude:latest",
+	"gemini":      "scion-gemini:latest",
+	"codex":       "scion-codex:latest",
+	"opencode":    "scion-opencode:latest",
+	"antigravity": "scion-antigravity:latest",
 }
 
 // HarnessImages returns the fully qualified image names needed for the given harness keys.


### PR DESCRIPTION
Changes default OOB harness in MaintenanceConfig from gemini to antigravity in maintenance_executors.go and server.go