### PR TITLE
fix(telegram): propagate delivery errors (5xx) back to hub and CLI caller

### DIFF
--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -774,8 +774,8 @@ func (b *TelegramBrokerV2) Publish(ctx context.Context, topic string, msg *messa
 		}
 		if err != nil {
 			var apiErr *APIError
-			if errors.As(err, &apiErr) && apiErr.IsTransient() {
-				b.log.Warn("Transient Telegram API error, dropping message",
+			if errors.As(err, &apiErr) && apiErr.Code == http.StatusTooManyRequests {
+				b.log.Warn("Rate-limited by Telegram API, dropping message",
 					"chat_id", chatID, "topic", topic,
 					"code", apiErr.Code, "retry_after_sec", apiErr.RetryAfterSec,
 					"error", err)
@@ -941,8 +941,8 @@ func (b *TelegramBrokerV2) publishInputNeeded(ctx context.Context, api *Telegram
 		}
 		if err != nil {
 			var apiErr *APIError
-			if errors.As(err, &apiErr) && apiErr.IsTransient() {
-				b.log.Warn("Transient error sending input-needed",
+			if errors.As(err, &apiErr) && apiErr.Code == http.StatusTooManyRequests {
+				b.log.Warn("Rate-limited sending input-needed",
 					"chat_id", chatID, "error", err)
 				continue
 			}
@@ -1074,8 +1074,8 @@ func (b *TelegramBrokerV2) publishStateChangeDM(ctx context.Context, api *Telegr
 	}
 	if err != nil {
 		var apiErr *APIError
-		if errors.As(err, &apiErr) && apiErr.IsTransient() {
-			b.log.Warn("Transient error sending state-change DM",
+		if errors.As(err, &apiErr) && apiErr.Code == http.StatusTooManyRequests {
+			b.log.Warn("Rate-limited sending state-change DM",
 				"telegram_user_id", tgUserID, "error", err)
 			return nil
 		}
@@ -1155,8 +1155,8 @@ func (b *TelegramBrokerV2) publishInputNeededDM(ctx context.Context, api *Telegr
 	}
 	if err != nil {
 		var apiErr *APIError
-		if errors.As(err, &apiErr) && apiErr.IsTransient() {
-			b.log.Warn("Transient error sending input-needed DM",
+		if errors.As(err, &apiErr) && apiErr.Code == http.StatusTooManyRequests {
+			b.log.Warn("Rate-limited sending input-needed DM",
 				"telegram_user_id", tgUserID, "error", err)
 			return nil
 		}
@@ -1290,8 +1290,8 @@ func (b *TelegramBrokerV2) publishAttachment(ctx context.Context, api *TelegramA
 		_, err := api.SendDocument(ctx, chatID, filename, f, caption, "", opts...)
 		if err != nil {
 			var apiErr *APIError
-			if errors.As(err, &apiErr) && apiErr.IsTransient() {
-				b.log.Warn("Transient error sending attachment",
+			if errors.As(err, &apiErr) && apiErr.Code == http.StatusTooManyRequests {
+				b.log.Warn("Rate-limited sending attachment",
 					"chat_id", chatID, "error", err)
 				continue
 			}

--- a/extras/scion-telegram/internal/telegram/telegram.go
+++ b/extras/scion-telegram/internal/telegram/telegram.go
@@ -417,15 +417,15 @@ func (b *TelegramBroker) Publish(ctx context.Context, topic string, msg *message
 	}
 
 	// Send to each matching chat.
-	// Transient Telegram API errors (429 rate limits, 5xx) are logged and
-	// swallowed — propagating them would cause the caller to retry and
-	// amplify the problem into a message storm.
+	// 429 rate-limit responses are swallowed to avoid retry amplification.
+	// 5xx server errors are propagated so callers can surface delivery
+	// failures instead of silently dropping messages.
 	var errs []error
 	for _, chatID := range chatIDs {
 		if _, err := api.SendMessage(ctx, chatID, text, ""); err != nil {
 			var apiErr *APIError
-			if errors.As(err, &apiErr) && apiErr.IsTransient() {
-				b.log.Warn("Transient Telegram API error, dropping message",
+			if errors.As(err, &apiErr) && apiErr.Code == http.StatusTooManyRequests {
+				b.log.Warn("Rate-limited by Telegram API, dropping message",
 					"chat_id", chatID, "topic", topic,
 					"code", apiErr.Code, "retry_after_sec", apiErr.RetryAfterSec,
 					"error", err)

--- a/extras/scion-telegram/internal/telegram/telegram_test.go
+++ b/extras/scion-telegram/internal/telegram/telegram_test.go
@@ -17,6 +17,7 @@ package telegram
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -926,7 +927,7 @@ func TestPublish_Swallows429(t *testing.T) {
 	assert.NoError(t, err, "429 should be swallowed, not propagated")
 }
 
-func TestPublish_Swallows5xx(t *testing.T) {
+func TestPublish_Propagates5xx(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -959,7 +960,12 @@ func TestPublish_Swallows5xx(t *testing.T) {
 
 	msg := messages.NewInstruction("user:alice", "agent:coder", "server error")
 	err := b.Publish(context.Background(), "test.topic", msg)
-	assert.NoError(t, err, "5xx should be swallowed, not propagated")
+	require.Error(t, err, "5xx errors must be propagated to the caller")
+
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr), "error should be an APIError")
+	assert.Equal(t, 502, apiErr.Code)
+	assert.Contains(t, apiErr.Description, "Bad Gateway")
 }
 
 func TestPublish_PropagatesPermanentError(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/398

When Telegram channel delivery failed with a 5xx error, the hub silently returned success to the CLI caller. This fix propagates errors at all 6 call sites while preserving 429 rate-limit swallowing behavior.

Non-blocking: IsTransient() is now dead code in production after this change