### PR TITLE
fix(discord,telegram): use RecipientID fallback in recipient resolution to fix outbound attachment routing

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -487,7 +487,7 @@ func (b *DiscordBroker) Publish(ctx context.Context, topic string, msg *messages
 		if ccSlug == "" && msg.Sender != "" && strings.HasPrefix(msg.Sender, "agent:") {
 			ccSlug = strings.TrimPrefix(msg.Sender, "agent:")
 		}
-		channelIDs = b.resolveRecipientChannels(ctx, msg.Recipient, projectID, ccSlug)
+		channelIDs = b.resolveRecipientChannels(ctx, msg.Recipient, msg.RecipientID, projectID, ccSlug)
 	}
 
 	// Priority 3: Broadcast to all ChannelLinks for the project.
@@ -1370,7 +1370,10 @@ func (b *DiscordBroker) isForumChannel(channelID string) bool {
 }
 
 // resolveRecipientChannels looks up target channels for a specific recipient.
-func (b *DiscordBroker) resolveRecipientChannels(ctx context.Context, recipient, projectID, agentSlug string) []string {
+// It first attempts email-based lookup via GetUserMappingByEmail; if that fails
+// (e.g. because the hub rewrote the recipient to a display name), it falls back
+// to looking up the scion user UUID via GetUserMappingByScionUserID.
+func (b *DiscordBroker) resolveRecipientChannels(ctx context.Context, recipient, recipientID, projectID, agentSlug string) []string {
 	email := strings.TrimPrefix(recipient, "user:")
 	if email == recipient {
 		return nil
@@ -1385,6 +1388,12 @@ func (b *DiscordBroker) resolveRecipientChannels(ctx context.Context, recipient,
 	}
 
 	mapping, err := store.GetUserMappingByEmail(ctx, email)
+
+	// Fallback: try scion user ID lookup (handles display-name recipients).
+	if (err != nil || mapping == nil) && recipientID != "" {
+		mapping, err = store.GetUserMappingByScionUserID(ctx, recipientID)
+	}
+
 	if err != nil || mapping == nil {
 		return nil
 	}

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1388,10 +1388,20 @@ func (b *DiscordBroker) resolveRecipientChannels(ctx context.Context, recipient,
 	}
 
 	mapping, err := store.GetUserMappingByEmail(ctx, email)
+	if err != nil {
+		b.log.Error("Failed to look up user mapping by email", "email", email, "error", err)
+	}
 
 	// Fallback: try scion user ID lookup (handles display-name recipients).
 	if (err != nil || mapping == nil) && recipientID != "" {
-		mapping, err = store.GetUserMappingByScionUserID(ctx, recipientID)
+		var fallbackErr error
+		mapping, fallbackErr = store.GetUserMappingByScionUserID(ctx, recipientID)
+		if fallbackErr != nil {
+			b.log.Error("Failed to look up user mapping by scion user ID", "recipientID", recipientID, "error", fallbackErr)
+			err = fallbackErr
+		} else {
+			err = nil
+		}
 	}
 
 	if err != nil || mapping == nil {

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -328,3 +328,73 @@ func TestPublish_MediaChannelWithoutThreadID_ReturnsError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forum/media channel")
 }
+
+func TestResolveRecipientChannels(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	// Seed a user mapping and conversation context.
+	require.NoError(t, store.CreateUserMapping(ctx, &DiscordUserMapping{
+		DiscordUserID:  "discord-user-1",
+		DiscordUsername: "alice_discord",
+		ScionUserID:    "scion-uuid-123",
+		ScionEmail:     "alice@example.com",
+		LinkedAt:       time.Now(),
+	}))
+	require.NoError(t, store.SetConversationContext(ctx, &ConversationContext{
+		DiscordUserID: "discord-user-1",
+		ProjectID:     "proj-1",
+		AgentSlug:     "coder",
+		LastChannelID: "channel-42",
+		LastMessageAt: time.Now(),
+	}))
+
+	b := &DiscordBroker{
+		log:   discardLogger(),
+		store: store,
+	}
+
+	t.Run("email lookup succeeds", func(t *testing.T) {
+		channels := b.resolveRecipientChannels(ctx, "user:alice@example.com", "", "proj-1", "coder")
+		assert.Equal(t, []string{"channel-42"}, channels)
+	})
+
+	t.Run("display name with recipientID fallback", func(t *testing.T) {
+		// Hub rewrites recipient to display name; email lookup fails,
+		// but recipientID-based fallback finds the correct mapping.
+		channels := b.resolveRecipientChannels(ctx, "user:Alice", "scion-uuid-123", "proj-1", "coder")
+		assert.Equal(t, []string{"channel-42"}, channels)
+	})
+
+	t.Run("display name without recipientID returns nil", func(t *testing.T) {
+		// No recipientID provided — fallback cannot execute.
+		channels := b.resolveRecipientChannels(ctx, "user:Alice", "", "proj-1", "coder")
+		assert.Nil(t, channels)
+	})
+
+	t.Run("non-user recipient returns nil", func(t *testing.T) {
+		channels := b.resolveRecipientChannels(ctx, "agent:coder", "", "proj-1", "coder")
+		assert.Nil(t, channels)
+	})
+
+	t.Run("email lookup preferred over recipientID", func(t *testing.T) {
+		// When email lookup succeeds, recipientID is not used.
+		channels := b.resolveRecipientChannels(ctx, "user:alice@example.com", "scion-uuid-123", "proj-1", "coder")
+		assert.Equal(t, []string{"channel-42"}, channels)
+	})
+
+	t.Run("fallback to latest conversation context", func(t *testing.T) {
+		// Add a second conversation context for a different agent.
+		require.NoError(t, store.SetConversationContext(ctx, &ConversationContext{
+			DiscordUserID: "discord-user-1",
+			ProjectID:     "proj-1",
+			AgentSlug:     "reviewer",
+			LastChannelID: "channel-99",
+			LastMessageAt: time.Now(),
+		}))
+		// With an unknown agent slug, should fall back to the latest context.
+		channels := b.resolveRecipientChannels(ctx, "user:Alice", "scion-uuid-123", "proj-1", "unknown-agent")
+		assert.NotNil(t, channels)
+		assert.Len(t, channels, 1)
+	})
+}

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -335,11 +335,11 @@ func TestResolveRecipientChannels(t *testing.T) {
 
 	// Seed a user mapping and conversation context.
 	require.NoError(t, store.CreateUserMapping(ctx, &DiscordUserMapping{
-		DiscordUserID:  "discord-user-1",
+		DiscordUserID:   "discord-user-1",
 		DiscordUsername: "alice_discord",
-		ScionUserID:    "scion-uuid-123",
-		ScionEmail:     "alice@example.com",
-		LinkedAt:       time.Now(),
+		ScionUserID:     "scion-uuid-123",
+		ScionEmail:      "alice@example.com",
+		LinkedAt:        time.Now(),
 	}))
 	require.NoError(t, store.SetConversationContext(ctx, &ConversationContext{
 		DiscordUserID: "discord-user-1",

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -897,10 +897,20 @@ func (b *TelegramBrokerV2) resolveRecipientChats(ctx context.Context, recipient,
 	}
 
 	mapping, err := b.store.GetUserMappingByEmail(ctx, email)
+	if err != nil {
+		b.log.Error("Failed to look up user mapping by email", "email", email, "error", err)
+	}
 
 	// Fallback: try scion user ID lookup (handles display-name recipients).
 	if (err != nil || mapping == nil) && recipientID != "" {
-		mapping, err = b.store.GetUserMappingByScionUserID(ctx, recipientID)
+		var fallbackErr error
+		mapping, fallbackErr = b.store.GetUserMappingByScionUserID(ctx, recipientID)
+		if fallbackErr != nil {
+			b.log.Error("Failed to look up user mapping by scion user ID", "recipientID", recipientID, "error", fallbackErr)
+			err = fallbackErr
+		} else {
+			err = nil
+		}
 	}
 
 	if err != nil || mapping == nil {

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -622,7 +622,7 @@ func (b *TelegramBrokerV2) Publish(ctx context.Context, topic string, msg *messa
 
 	// Priority 2: Look up via ConversationContext for the recipient.
 	if len(chatIDs) == 0 && msg != nil && msg.Recipient != "" && store != nil {
-		chatIDs = b.resolveRecipientChats(ctx, msg.Recipient, projectID, agentSlug)
+		chatIDs = b.resolveRecipientChats(ctx, msg.Recipient, msg.RecipientID, projectID, agentSlug)
 	}
 
 	// Priority 3: Broadcast to all GroupLinks for the project.
@@ -886,7 +886,10 @@ func resolveOutboundMentions(ctx context.Context, store Store, text string) stri
 }
 
 // resolveRecipientChats looks up target chats for a specific recipient.
-func (b *TelegramBrokerV2) resolveRecipientChats(ctx context.Context, recipient, projectID, agentSlug string) []int64 {
+// It first attempts email-based lookup via GetUserMappingByEmail; if that fails
+// (e.g. because the hub rewrote the recipient to a display name), it falls back
+// to looking up the scion user UUID via GetUserMappingByScionUserID.
+func (b *TelegramBrokerV2) resolveRecipientChats(ctx context.Context, recipient, recipientID, projectID, agentSlug string) []int64 {
 	// Extract email from "user:email@example.com" format.
 	email := strings.TrimPrefix(recipient, "user:")
 	if email == recipient {
@@ -894,6 +897,12 @@ func (b *TelegramBrokerV2) resolveRecipientChats(ctx context.Context, recipient,
 	}
 
 	mapping, err := b.store.GetUserMappingByEmail(ctx, email)
+
+	// Fallback: try scion user ID lookup (handles display-name recipients).
+	if (err != nil || mapping == nil) && recipientID != "" {
+		mapping, err = b.store.GetUserMappingByScionUserID(ctx, recipientID)
+	}
+
 	if err != nil || mapping == nil {
 		return nil
 	}

--- a/extras/scion-telegram/internal/telegram/broker_v2_test.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2_test.go
@@ -2606,3 +2606,58 @@ func TestV2_HandleGroupMessage_CodeSpanWithDefaultAgent(t *testing.T) {
 
 	assert.Equal(t, "check the `config` file", deliveredMsg.Msg)
 }
+
+func TestResolveRecipientChats(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	// Seed a user mapping and conversation context.
+	require.NoError(t, store.SaveUserMapping(ctx, &TelegramUserMapping{
+		TelegramUserID:   "tg-user-1",
+		TelegramUsername: "alice_tg",
+		ScionUserID:      "scion-uuid-456",
+		ScionEmail:       "alice@example.com",
+		LinkedAt:         time.Now(),
+	}))
+	require.NoError(t, store.SaveConversationContext(ctx, &ConversationContext{
+		TelegramUserID: "tg-user-1",
+		ProjectID:      "proj-1",
+		AgentSlug:      "coder",
+		LastChatID:     12345,
+		LastMessageAt:  time.Now(),
+	}))
+
+	b := &TelegramBrokerV2{
+		log:   slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		store: store,
+	}
+
+	t.Run("email lookup succeeds", func(t *testing.T) {
+		chats := b.resolveRecipientChats(ctx, "user:alice@example.com", "", "proj-1", "coder")
+		assert.Equal(t, []int64{12345}, chats)
+	})
+
+	t.Run("display name with recipientID fallback", func(t *testing.T) {
+		// Hub rewrites recipient to display name; email lookup fails,
+		// but recipientID-based fallback finds the correct mapping.
+		chats := b.resolveRecipientChats(ctx, "user:Alice", "scion-uuid-456", "proj-1", "coder")
+		assert.Equal(t, []int64{12345}, chats)
+	})
+
+	t.Run("display name without recipientID returns nil", func(t *testing.T) {
+		// No recipientID provided — fallback cannot execute.
+		chats := b.resolveRecipientChats(ctx, "user:Alice", "", "proj-1", "coder")
+		assert.Nil(t, chats)
+	})
+
+	t.Run("non-user recipient returns nil", func(t *testing.T) {
+		chats := b.resolveRecipientChats(ctx, "agent:coder", "", "proj-1", "coder")
+		assert.Nil(t, chats)
+	})
+
+	t.Run("email lookup preferred over recipientID", func(t *testing.T) {
+		// When email lookup succeeds, recipientID is not used.
+		chats := b.resolveRecipientChats(ctx, "user:alice@example.com", "scion-uuid-456", "proj-1", "coder")
+		assert.Equal(t, []int64{12345}, chats)
+	})
+}


### PR DESCRIPTION
Fixes outbound attachment delivery to named users in both Discord and Telegram integrations.

Root cause: the hub rewrites recipient from email to display name before publishing; both brokers were calling GetUserMappingByEmail with the display name, which always fails. Messages (and their attachments) were either broadcast to all project channels or silently dropped.

Fix: add GetUserMappingByScionUserID fallback using msg.RecipientID (already present in the message, just unused) when email lookup returns nil. Email lookup still runs first, preserving existing behavior. 11 new subtests added; all 75 existing tests pass