### PR TITLE
feat(web): add QR code to Telegram setup step in workstation onboarding

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -33,11 +33,13 @@
         "dompurify": "^3.4.11",
         "js-yaml": "^4.1.0",
         "lit": "^3.1.2",
-        "marked": "^17.0.5"
+        "marked": "^17.0.5",
+        "qrcode": "^1.5.4"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.11.0",
+        "@types/qrcode": "^1.5.6",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "bootstrap-icons": "^1.11.0",
@@ -1554,6 +1556,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
@@ -2031,7 +2043,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2041,7 +2052,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2149,6 +2159,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2188,11 +2207,21 @@
         "pnpm": ">=8"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2205,7 +2234,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/composed-offset-position": {
@@ -2277,11 +2305,26 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
     },
     "node_modules/dir-glob": {
@@ -2318,6 +2361,12 @@
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "7.0.1",
@@ -2788,6 +2837,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -2984,6 +3042,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -3334,6 +3401,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3351,7 +3427,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3562,6 +3637,32 @@
       "integrity": "sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ==",
       "license": "MIT"
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -3582,6 +3683,21 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3703,6 +3819,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3784,11 +3906,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4747,6 +4882,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4772,6 +4913,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {
@@ -4801,6 +4956,99 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/web/package.json
+++ b/web/package.json
@@ -47,11 +47,13 @@
     "dompurify": "^3.4.11",
     "js-yaml": "^4.1.0",
     "lit": "^3.1.2",
-    "marked": "^17.0.5"
+    "marked": "^17.0.5",
+    "qrcode": "^1.5.4"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.11.0",
+    "@types/qrcode": "^1.5.6",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "bootstrap-icons": "^1.11.0",

--- a/web/src/components/pages/profile-telegram.ts
+++ b/web/src/components/pages/profile-telegram.ts
@@ -24,6 +24,7 @@
 
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
+import QRCode from 'qrcode';
 import { apiFetch } from '../../client/api.js';
 
 @customElement('scion-page-profile-telegram')
@@ -40,16 +41,48 @@ export class ScionPageProfileTelegram extends LitElement {
   @state()
   private _autoLinked = false;
 
+  @state()
+  private _qrDataUrl = '';
+
   override connectedCallback(): void {
     super.connectedCallback();
     const params = new URLSearchParams(window.location.search);
     const code = params.get('code');
     if (code) {
-      this._code = code.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 6);
+      this._code = code
+        .toUpperCase()
+        .replace(/[^A-Z0-9]/g, '')
+        .slice(0, 6);
       if (this._code.length === 6) {
         this._autoLinked = true;
         this._autoSubmit();
       }
+    }
+    void this._generateQrCode();
+  }
+
+  private _buildRegistrationUrl(): string {
+    const base = `${window.location.origin}/profile/telegram`;
+    if (this._code.length === 6) {
+      return `${base}?code=${this._code}`;
+    }
+    return base;
+  }
+
+  private async _generateQrCode(): Promise<void> {
+    try {
+      const url = this._buildRegistrationUrl();
+      this._qrDataUrl = await QRCode.toDataURL(url, {
+        width: 200,
+        margin: 2,
+        errorCorrectionLevel: 'M',
+        color: {
+          dark: '#1e293b',
+          light: '#ffffff',
+        },
+      });
+    } catch {
+      this._qrDataUrl = '';
     }
   }
 
@@ -67,14 +100,17 @@ export class ScionPageProfileTelegram extends LitElement {
       if (resp.ok) {
         await resp.json();
         this._status = 'success';
-        this._message = 'Telegram account linked successfully! You can close this page and return to Telegram.';
+        this._message =
+          'Telegram account linked successfully! You can close this page and return to Telegram.';
         this._code = '';
       } else {
         const errData = (await resp.json().catch(() => null)) as {
           message?: string;
         } | null;
         this._status = 'error';
-        this._message = errData?.message || 'Code not found or expired. Please try again with a new code from the bot.';
+        this._message =
+          errData?.message ||
+          'Code not found or expired. Please try again with a new code from the bot.';
       }
     } catch {
       this._status = 'error';
@@ -200,12 +236,84 @@ export class ScionPageProfileTelegram extends LitElement {
       color: var(--scion-text-muted, #64748b);
       padding: 0.5rem 0;
     }
+
+    .qr-section {
+      display: flex;
+      align-items: flex-start;
+      gap: 1.5rem;
+      margin-bottom: 1.25rem;
+    }
+
+    .qr-code {
+      flex-shrink: 0;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.5rem;
+      padding: 0.5rem;
+      background: #ffffff;
+    }
+
+    .qr-code img {
+      display: block;
+      width: 160px;
+      height: 160px;
+    }
+
+    .qr-info {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .qr-info p {
+      font-size: 0.8125rem;
+      color: var(--scion-text-muted, #64748b);
+      margin: 0 0 0.75rem 0;
+      line-height: 1.5;
+    }
+
+    .registration-link {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      background: var(--scion-surface-alt, #f8fafc);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.375rem;
+      padding: 0.5rem 0.75rem;
+      font-size: 0.75rem;
+      font-family: monospace;
+      word-break: break-all;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .registration-link a {
+      color: var(--sl-color-primary-600, #2563eb);
+      text-decoration: none;
+      word-break: break-all;
+    }
+
+    .registration-link a:hover {
+      text-decoration: underline;
+    }
+
+    @media (max-width: 480px) {
+      .qr-section {
+        flex-direction: column;
+        align-items: center;
+      }
+
+      .qr-info {
+        text-align: center;
+      }
+    }
   `;
 
   private _handleInput(e: Event): void {
     const input = e.target as HTMLInputElement & { value: string };
-    this._code = input.value.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 6);
+    this._code = input.value
+      .toUpperCase()
+      .replace(/[^A-Z0-9]/g, '')
+      .slice(0, 6);
     input.value = this._code;
+    void this._generateQrCode();
   }
 
   private async _handleSubmit(e: Event): Promise<void> {
@@ -230,14 +338,17 @@ export class ScionPageProfileTelegram extends LitElement {
       if (resp.ok) {
         await resp.json();
         this._status = 'success';
-        this._message = 'Telegram account linked successfully! You can close this page and return to Telegram.';
+        this._message =
+          'Telegram account linked successfully! You can close this page and return to Telegram.';
         this._code = '';
       } else {
         const errData = (await resp.json().catch(() => null)) as {
           message?: string;
         } | null;
         this._status = 'error';
-        this._message = errData?.message || 'Code not found or expired. Please try again with a new code from the bot.';
+        this._message =
+          errData?.message ||
+          'Code not found or expired. Please try again with a new code from the bot.';
       }
     } catch {
       this._status = 'error';
@@ -253,6 +364,7 @@ export class ScionPageProfileTelegram extends LitElement {
           Link Telegram Account
         </h2>
 
+        ${this._status === 'submitting' ? nothing : this._renderQrCode()}
         ${this._status === 'submitting'
           ? html`
               <div class="auto-link-status">
@@ -281,6 +393,27 @@ export class ScionPageProfileTelegram extends LitElement {
     `;
   }
 
+  private _renderQrCode() {
+    if (!this._qrDataUrl) return nothing;
+
+    const url = this._buildRegistrationUrl();
+
+    return html`
+      <div class="qr-section">
+        <div class="qr-code">
+          <img src=${this._qrDataUrl} alt="QR code for Telegram registration" />
+        </div>
+        <div class="qr-info">
+          <p>Scan this QR code with your phone to open the registration link directly.</p>
+          <div class="registration-link">
+            <sl-icon name="link-45deg" style="flex-shrink:0;font-size:0.875rem;"></sl-icon>
+            <a href=${url}>${url}</a>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
   private _renderForm() {
     return html`
       <div class="settings-card">
@@ -289,11 +422,16 @@ export class ScionPageProfileTelegram extends LitElement {
           Link Telegram Account
         </h2>
 
+        ${this._renderQrCode()}
+
         <div class="instructions">
           <ol>
             <li>Open a direct message with the Scion Telegram bot</li>
             <li>Send <strong>/register</strong> to the bot</li>
-            <li>Enter the 6-character code below</li>
+            <li>
+              Enter the 6-character code below, or scan the QR code above on the device where you
+              received the link
+            </li>
           </ol>
         </div>
 

--- a/web/src/components/pages/profile-telegram.ts
+++ b/web/src/components/pages/profile-telegram.ts
@@ -58,7 +58,12 @@ export class ScionPageProfileTelegram extends LitElement {
         this._autoSubmit();
       }
     }
-    void this._generateQrCode();
+  }
+
+  override willUpdate(changedProperties: Map<PropertyKey, unknown>): void {
+    if (changedProperties.has('_code')) {
+      void this._generateQrCode();
+    }
   }
 
   private _buildRegistrationUrl(): string {
@@ -70,9 +75,9 @@ export class ScionPageProfileTelegram extends LitElement {
   }
 
   private async _generateQrCode(): Promise<void> {
+    const url = this._buildRegistrationUrl();
     try {
-      const url = this._buildRegistrationUrl();
-      this._qrDataUrl = await QRCode.toDataURL(url, {
+      const qrDataUrl = await QRCode.toDataURL(url, {
         width: 200,
         margin: 2,
         errorCorrectionLevel: 'M',
@@ -81,8 +86,13 @@ export class ScionPageProfileTelegram extends LitElement {
           light: '#ffffff',
         },
       });
+      if (url === this._buildRegistrationUrl()) {
+        this._qrDataUrl = qrDataUrl;
+      }
     } catch {
-      this._qrDataUrl = '';
+      if (url === this._buildRegistrationUrl()) {
+        this._qrDataUrl = '';
+      }
     }
   }
 
@@ -313,7 +323,6 @@ export class ScionPageProfileTelegram extends LitElement {
       .replace(/[^A-Z0-9]/g, '')
       .slice(0, 6);
     input.value = this._code;
-    void this._generateQrCode();
   }
 
   private async _handleSubmit(e: Event): Promise<void> {


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/267

Adds a QR code to the Telegram integration setup step in the workstation onboarding wizard. Users can scan with their phone to open the Telegram bot directly, eliminating manual link copy-paste. QR encodes the same verification URL as the existing link (with code embedded). Falls back gracefully if JS is unavailable; accessible alt text included