### PR TITLE
feat(telegram): download and deliver file attachments to agents

### DIFF
--- a/extras/scion-telegram/internal/telegram/api.go
+++ b/extras/scion-telegram/internal/telegram/api.go
@@ -77,6 +77,47 @@ type TGDocument struct {
 	FileSize     int64  `json:"file_size"`
 }
 
+// TGAudio represents an audio file sent in a Telegram message.
+type TGAudio struct {
+	FileID       string `json:"file_id"`
+	FileUniqueID string `json:"file_unique_id"`
+	Duration     int    `json:"duration"`
+	Performer    string `json:"performer,omitempty"`
+	Title        string `json:"title,omitempty"`
+	FileName     string `json:"file_name,omitempty"`
+	MimeType     string `json:"mime_type,omitempty"`
+	FileSize     int64  `json:"file_size"`
+}
+
+// TGVideo represents a video file sent in a Telegram message.
+type TGVideo struct {
+	FileID       string `json:"file_id"`
+	FileUniqueID string `json:"file_unique_id"`
+	Width        int    `json:"width"`
+	Height       int    `json:"height"`
+	Duration     int    `json:"duration"`
+	FileName     string `json:"file_name,omitempty"`
+	MimeType     string `json:"mime_type,omitempty"`
+	FileSize     int64  `json:"file_size"`
+}
+
+// TGSticker represents a sticker sent in a Telegram message.
+type TGSticker struct {
+	FileID       string `json:"file_id"`
+	FileUniqueID string `json:"file_unique_id"`
+	Type         string `json:"type"`
+	FileSize     int64  `json:"file_size"`
+}
+
+// TGAnimation represents an animation (GIF) sent in a Telegram message.
+type TGAnimation struct {
+	FileID       string `json:"file_id"`
+	FileUniqueID string `json:"file_unique_id"`
+	FileName     string `json:"file_name,omitempty"`
+	MimeType     string `json:"mime_type,omitempty"`
+	FileSize     int64  `json:"file_size"`
+}
+
 // TGFile represents a file ready for download, returned by the getFile API.
 type TGFile struct {
 	FileID   string `json:"file_id"`
@@ -98,6 +139,10 @@ type TGMessage struct {
 	MigrateToChatID int64           `json:"migrate_to_chat_id,omitempty"`
 	Photo           []PhotoSize     `json:"photo,omitempty"`
 	Document        *TGDocument     `json:"document,omitempty"`
+	Audio           *TGAudio        `json:"audio,omitempty"`
+	Video           *TGVideo        `json:"video,omitempty"`
+	Sticker         *TGSticker      `json:"sticker,omitempty"`
+	Animation       *TGAnimation    `json:"animation,omitempty"`
 }
 
 // MessageEntity represents a special entity in a Telegram message (e.g. @mentions, commands).

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -1272,7 +1272,7 @@ func (b *TelegramBrokerV2) publishAttachment(ctx context.Context, api *TelegramA
 	}
 	defer f.Close()
 
-	filename := filepath.Base(attachPath)
+	filename := filepath.Base(strings.ReplaceAll(attachPath, "\\", "/"))
 	if name, ok := msg.Metadata["telegram_attachment_name"]; ok && name != "" {
 		filename = name
 	}
@@ -1568,6 +1568,9 @@ func (b *TelegramBrokerV2) getUpdatesV2(ctx context.Context, offset int64, timeo
 // --- Inbound message handling ---
 
 func (b *TelegramBrokerV2) handleIncomingMessageV2(tgMsg *TGMessage) {
+	if tgMsg == nil {
+		return
+	}
 	hasAttachment := tgMsg.Photo != nil || tgMsg.Document != nil || tgMsg.Audio != nil || tgMsg.Video != nil
 	hasSkippedAttachment := tgMsg.Sticker != nil || tgMsg.Animation != nil
 
@@ -1997,9 +2000,10 @@ func (b *TelegramBrokerV2) downloadTelegramFile(ctx context.Context, tgMsg *TGMe
 	}
 
 	// Sanitize the filename to prevent path traversal via user-controlled
-	// fields (e.g. Document.FileName, Audio.Title). filepath.Base strips
-	// any directory components so the file stays in the downloads dir.
-	fileName = filepath.Base(fileName)
+	// fields (e.g. Document.FileName, Audio.Title). Replacing backslashes
+	// with forward slashes first ensures that both Windows and Unix path
+	// separators are stripped regardless of the host OS.
+	fileName = filepath.Base(strings.ReplaceAll(fileName, "\\", "/"))
 	if fileName == "." || fileName == "" {
 		fileName = fmt.Sprintf("file_%s", fileID)
 	}
@@ -2053,6 +2057,7 @@ func (b *TelegramBrokerV2) downloadTelegramFile(ctx context.Context, tgMsg *TGMe
 	} else {
 		agentPath = filepath.Join("/workspace/downloads", destName)
 	}
+	agentPath = filepath.ToSlash(agentPath)
 	placeholder = fmt.Sprintf("📎 [%s attached: %s]", fileType, fileName)
 
 	b.log.Info("Downloaded telegram file",

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -1739,7 +1739,7 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 	// later (offset>0) do not block default routing; resolveUserMentions
 	// injects the resolved scion identity for those.
 	if len(targets) == 0 && effectiveDefault != "" {
-		hasAttachment := tgMsg.Photo != nil || tgMsg.Document != nil
+		hasAttachment := tgMsg.Photo != nil || tgMsg.Document != nil || tgMsg.Audio != nil || tgMsg.Video != nil
 		text := strings.TrimSpace(tgMsg.Text)
 		textRoutes := text != "" && !strings.HasPrefix(text, "/") && !strings.HasPrefix(text, "@") && !hasNonBotUserMention(tgMsg, botUsername, agents)
 		if textRoutes || hasAttachment {
@@ -1996,6 +1996,14 @@ func (b *TelegramBrokerV2) downloadTelegramFile(ctx context.Context, tgMsg *TGMe
 		return "", "", fmt.Errorf("message has no downloadable attachment")
 	}
 
+	// Sanitize the filename to prevent path traversal via user-controlled
+	// fields (e.g. Document.FileName, Audio.Title). filepath.Base strips
+	// any directory components so the file stays in the downloads dir.
+	fileName = filepath.Base(fileName)
+	if fileName == "." || fileName == "" {
+		fileName = fmt.Sprintf("file_%s", fileID)
+	}
+
 	if fileSize > maxTelegramFileSize {
 		return "", "", fmt.Errorf("file too large (%d bytes, max %d)", fileSize, maxTelegramFileSize)
 	}
@@ -2037,7 +2045,14 @@ func (b *TelegramBrokerV2) downloadTelegramFile(ctx context.Context, tgMsg *TGMe
 		return "", "", fmt.Errorf("write file: %w", err)
 	}
 
-	agentPath = filepath.Join("/workspace/downloads", destName)
+	// Derive the agent-visible path from the same base used to save the file.
+	// When a custom downloads_path is configured, the agent sees that path
+	// directly; otherwise it sees the conventional /workspace/downloads mount.
+	if b.downloadsPath != "" {
+		agentPath = filepath.Join(b.downloadsPath, destName)
+	} else {
+		agentPath = filepath.Join("/workspace/downloads", destName)
+	}
 	placeholder = fmt.Sprintf("📎 [%s attached: %s]", fileType, fileName)
 
 	b.log.Info("Downloaded telegram file",

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -84,6 +84,7 @@ type TelegramBrokerV2 struct {
 
 	agentCacheTTL  time.Duration
 	projectSlugMap map[string]string // injected by hub: projectID → slug
+	downloadsPath  string            // override for file download directory; empty = default
 
 	// Webhook mode fields.
 	inboundMode   string // "poll" (default) or "webhook"
@@ -170,6 +171,11 @@ func (b *TelegramBrokerV2) Configure(config map[string]string) error {
 			return fmt.Errorf("invalid agent_cache_ttl: %w", err)
 		}
 		b.agentCacheTTL = d
+	}
+
+	// Parse optional downloads directory override.
+	if v, ok := config["downloads_path"]; ok && v != "" {
+		b.downloadsPath = v
 	}
 
 	// Initialize store: Postgres if database_url is set, otherwise SQLite.
@@ -1562,11 +1568,20 @@ func (b *TelegramBrokerV2) getUpdatesV2(ctx context.Context, offset int64, timeo
 // --- Inbound message handling ---
 
 func (b *TelegramBrokerV2) handleIncomingMessageV2(tgMsg *TGMessage) {
-	if tgMsg.Text == "" && tgMsg.Caption == "" && tgMsg.Photo == nil && tgMsg.Document == nil {
+	hasAttachment := tgMsg.Photo != nil || tgMsg.Document != nil || tgMsg.Audio != nil || tgMsg.Video != nil
+	hasSkippedAttachment := tgMsg.Sticker != nil || tgMsg.Animation != nil
+
+	if tgMsg.Text == "" && tgMsg.Caption == "" && !hasAttachment {
+		if hasSkippedAttachment {
+			b.log.Debug("Skipping unsupported attachment type (sticker/animation)",
+				"message_id", tgMsg.MessageID,
+				"has_sticker", tgMsg.Sticker != nil,
+				"has_animation", tgMsg.Animation != nil)
+		}
 		return
 	}
 
-	// Use caption as text fallback for photo/document messages.
+	// Use caption as text fallback for photo/document/audio/video messages.
 	if tgMsg.Text == "" && tgMsg.Caption != "" {
 		tgMsg.Text = tgMsg.Caption
 	}
@@ -1813,9 +1828,9 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 	cleanText := stripMentions(resolvedText, botUsername, targets)
 	cleanText = strings.TrimSpace(cleanText)
 
-	// Download file attachments (photos/documents).
+	// Download file attachments (photos/documents/audio/video).
 	var attachmentPath, placeholder string
-	if tgMsg.Photo != nil || tgMsg.Document != nil {
+	if tgMsg.Photo != nil || tgMsg.Document != nil || tgMsg.Audio != nil || tgMsg.Video != nil {
 		var err error
 		attachmentPath, placeholder, err = b.downloadTelegramFile(ctx, tgMsg, link.ProjectSlug)
 		if err != nil {
@@ -1934,9 +1949,9 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 
 const maxTelegramFileSize = 20 * 1024 * 1024 // 20 MB
 
-// downloadTelegramFile downloads a photo or document from a Telegram message
-// and saves it to the agent's workspace downloads directory. Returns the
-// agent-relative path and a placeholder string for the message body.
+// downloadTelegramFile downloads a photo, document, audio, or video from a
+// Telegram message and saves it to the configured downloads directory.
+// Returns the agent-relative path and a placeholder string for the message body.
 func (b *TelegramBrokerV2) downloadTelegramFile(ctx context.Context, tgMsg *TGMessage, projectSlug string) (agentPath, placeholder string, err error) {
 	var fileID, fileName, fileType string
 	var fileSize int64
@@ -1956,8 +1971,29 @@ func (b *TelegramBrokerV2) downloadTelegramFile(ctx context.Context, tgMsg *TGMe
 		fileSize = largest.FileSize
 		fileName = fmt.Sprintf("photo_%s.jpg", largest.FileUniqueID)
 		fileType = "Photo"
+	case tgMsg.Audio != nil:
+		fileID = tgMsg.Audio.FileID
+		fileSize = tgMsg.Audio.FileSize
+		fileName = tgMsg.Audio.FileName
+		if fileName == "" {
+			// Build a descriptive name from title/performer if available.
+			if tgMsg.Audio.Title != "" {
+				fileName = tgMsg.Audio.Title + ".ogg"
+			} else {
+				fileName = fmt.Sprintf("audio_%s.ogg", tgMsg.Audio.FileUniqueID)
+			}
+		}
+		fileType = "Audio"
+	case tgMsg.Video != nil:
+		fileID = tgMsg.Video.FileID
+		fileSize = tgMsg.Video.FileSize
+		fileName = tgMsg.Video.FileName
+		if fileName == "" {
+			fileName = fmt.Sprintf("video_%s.mp4", tgMsg.Video.FileUniqueID)
+		}
+		fileType = "Video"
 	default:
-		return "", "", fmt.Errorf("message has no photo or document")
+		return "", "", fmt.Errorf("message has no downloadable attachment")
 	}
 
 	if fileSize > maxTelegramFileSize {
@@ -1978,7 +2014,13 @@ func (b *TelegramBrokerV2) downloadTelegramFile(ctx context.Context, tgMsg *TGMe
 	timestamp := time.Now().Unix()
 	destName := fmt.Sprintf("tg_%d_%s", timestamp, fileName)
 
-	hostDir := filepath.Join("/home/scion/.scion/projects", projectSlug, "downloads")
+	// Use configured downloads_path if set; otherwise default to project dir.
+	var hostDir string
+	if b.downloadsPath != "" {
+		hostDir = b.downloadsPath
+	} else {
+		hostDir = filepath.Join("/home/scion/.scion/projects", projectSlug, "downloads")
+	}
 	if err := os.MkdirAll(hostDir, 0o755); err != nil {
 		return "", "", fmt.Errorf("create downloads dir: %w", err)
 	}

--- a/extras/scion-telegram/internal/telegram/broker_v2_test.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2_test.go
@@ -2179,7 +2179,7 @@ func TestV2_HandleIncoming_EmptyMessageDropped(t *testing.T) {
 		atomic.AddInt32(&received, 1)
 	}
 
-	// No text, no caption, no photo, no document.
+	// No text, no caption, no photo, no document, no audio, no video.
 	b.handleIncomingMessageV2(&TGMessage{
 		MessageID: 1,
 		From:      &TGUser{ID: 456, Username: "alice"},
@@ -2274,7 +2274,7 @@ func TestV2_DownloadTelegramFile_NoAttachment(t *testing.T) {
 
 	_, _, err := b.downloadTelegramFile(ctx, tgMsg, "test-slug")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no photo or document")
+	assert.Contains(t, err.Error(), "no downloadable attachment")
 }
 
 func TestV2_DownloadTelegramFile_DownloadFailure(t *testing.T) {
@@ -2313,6 +2313,266 @@ func TestV2_DownloadTelegramFile_DownloadFailure(t *testing.T) {
 	_, _, err := b.downloadTelegramFile(ctx, tgMsg, "test-slug")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "download file")
+}
+
+func TestV2_DownloadTelegramFile_AudioWithFilename(t *testing.T) {
+	tgSrv := newFakeTGServerV2(t)
+	b := newTestBrokerV2(t, tgSrv)
+
+	ctx := context.Background()
+	slug := filepath.Base(t.TempDir())
+
+	tgMsg := &TGMessage{
+		Audio: &TGAudio{
+			FileID:       "audio-xyz",
+			FileUniqueID: "audiouniq1",
+			FileName:     "song.mp3",
+			MimeType:     "audio/mpeg",
+			FileSize:     10000,
+			Duration:     180,
+		},
+	}
+
+	agentPath, placeholder, err := b.downloadTelegramFile(ctx, tgMsg, slug)
+	require.NoError(t, err)
+	assert.Contains(t, agentPath, "song.mp3")
+	assert.Contains(t, placeholder, "Audio attached")
+	assert.Contains(t, placeholder, "song.mp3")
+}
+
+func TestV2_DownloadTelegramFile_AudioFallbackName(t *testing.T) {
+	tgSrv := newFakeTGServerV2(t)
+	b := newTestBrokerV2(t, tgSrv)
+
+	ctx := context.Background()
+	slug := filepath.Base(t.TempDir())
+
+	// Audio with title but no filename — should use title.
+	tgMsg := &TGMessage{
+		Audio: &TGAudio{
+			FileID:       "audio-abc",
+			FileUniqueID: "audiouniq2",
+			Title:        "My Song",
+			FileSize:     5000,
+			Duration:     120,
+		},
+	}
+
+	agentPath, placeholder, err := b.downloadTelegramFile(ctx, tgMsg, slug)
+	require.NoError(t, err)
+	assert.Contains(t, agentPath, "My Song.ogg")
+	assert.Contains(t, placeholder, "Audio attached")
+
+	// Audio with no filename and no title — should use unique ID fallback.
+	tgMsg2 := &TGMessage{
+		Audio: &TGAudio{
+			FileID:       "audio-def",
+			FileUniqueID: "audiouniq3",
+			FileSize:     3000,
+			Duration:     60,
+		},
+	}
+
+	agentPath2, _, err := b.downloadTelegramFile(ctx, tgMsg2, slug)
+	require.NoError(t, err)
+	assert.Contains(t, agentPath2, "audio_audiouniq3.ogg")
+}
+
+func TestV2_DownloadTelegramFile_Video(t *testing.T) {
+	tgSrv := newFakeTGServerV2(t)
+	b := newTestBrokerV2(t, tgSrv)
+
+	ctx := context.Background()
+	slug := filepath.Base(t.TempDir())
+
+	tgMsg := &TGMessage{
+		Video: &TGVideo{
+			FileID:       "video-xyz",
+			FileUniqueID: "viduniq1",
+			FileName:     "clip.mp4",
+			MimeType:     "video/mp4",
+			FileSize:     50000,
+			Width:        1920,
+			Height:       1080,
+			Duration:     30,
+		},
+	}
+
+	agentPath, placeholder, err := b.downloadTelegramFile(ctx, tgMsg, slug)
+	require.NoError(t, err)
+	assert.Contains(t, agentPath, "clip.mp4")
+	assert.Contains(t, placeholder, "Video attached")
+	assert.Contains(t, placeholder, "clip.mp4")
+}
+
+func TestV2_DownloadTelegramFile_VideoFallbackName(t *testing.T) {
+	tgSrv := newFakeTGServerV2(t)
+	b := newTestBrokerV2(t, tgSrv)
+
+	ctx := context.Background()
+	slug := filepath.Base(t.TempDir())
+
+	tgMsg := &TGMessage{
+		Video: &TGVideo{
+			FileID:       "video-abc",
+			FileUniqueID: "viduniq2",
+			FileSize:     25000,
+			Width:        640,
+			Height:       480,
+			Duration:     10,
+		},
+	}
+
+	agentPath, _, err := b.downloadTelegramFile(ctx, tgMsg, slug)
+	require.NoError(t, err)
+	assert.Contains(t, agentPath, "video_viduniq2.mp4")
+}
+
+func TestV2_HandleIncoming_StickerSkipped(t *testing.T) {
+	tgSrv := newFakeTGServerV2(t)
+	b := newTestBrokerV2(t, tgSrv)
+
+	var received int32
+	b.InboundHandler = func(_ string, _ *messages.StructuredMessage) {
+		atomic.AddInt32(&received, 1)
+	}
+
+	// Sticker-only message — should be silently dropped (debug log).
+	b.handleIncomingMessageV2(&TGMessage{
+		MessageID: 10,
+		From:      &TGUser{ID: 456, Username: "alice"},
+		Chat:      TGChat{ID: -200, Type: "group"},
+		Sticker: &TGSticker{
+			FileID:       "sticker-abc",
+			FileUniqueID: "stickeruniq1",
+			Type:         "regular",
+			FileSize:     8000,
+		},
+	})
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&received))
+}
+
+func TestV2_HandleIncoming_AnimationSkipped(t *testing.T) {
+	tgSrv := newFakeTGServerV2(t)
+	b := newTestBrokerV2(t, tgSrv)
+
+	var received int32
+	b.InboundHandler = func(_ string, _ *messages.StructuredMessage) {
+		atomic.AddInt32(&received, 1)
+	}
+
+	// Animation-only message — should be silently dropped (debug log).
+	b.handleIncomingMessageV2(&TGMessage{
+		MessageID: 11,
+		From:      &TGUser{ID: 456, Username: "alice"},
+		Chat:      TGChat{ID: -200, Type: "group"},
+		Animation: &TGAnimation{
+			FileID:       "anim-abc",
+			FileUniqueID: "animuniq1",
+			FileName:     "funny.gif",
+			MimeType:     "video/mp4",
+			FileSize:     12000,
+		},
+	})
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&received))
+}
+
+func TestV2_HandleIncoming_AudioMessageDelivered(t *testing.T) {
+	tgSrv := newFakeTGServerV2(t)
+	hub := newFakeHubClient()
+	hub.agents["proj-1"] = []AgentInfo{{Slug: "coder"}}
+	b := newTestBrokerV2WithHub(t, tgSrv, hub)
+
+	ctx := context.Background()
+	require.NoError(t, b.store.SaveUserMapping(ctx, &TelegramUserMapping{
+		TelegramUserID: "456",
+		ScionEmail:     "alice@example.com",
+		LinkedAt:       time.Now().UTC(),
+	}))
+
+	tmpDir := t.TempDir()
+	require.NoError(t, b.store.SaveGroupLink(ctx, &GroupLink{
+		ChatID:       -200,
+		ProjectID:    "proj-1",
+		ProjectSlug:  filepath.Base(tmpDir),
+		DefaultAgent: "coder",
+		LinkedAt:     time.Now().UTC(),
+		Active:       true,
+	}))
+	require.NoError(t, b.store.SaveProjectAgents(ctx, &ProjectAgents{
+		ProjectID:   "proj-1",
+		Agents:      []AgentInfo{{Slug: "coder"}},
+		RefreshedAt: time.Now(),
+	}))
+
+	var deliveredMsg *messages.StructuredMessage
+	done := make(chan struct{}, 1)
+	b.InboundHandler = func(_ string, msg *messages.StructuredMessage) {
+		deliveredMsg = msg
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}
+
+	b.handleIncomingMessageV2(&TGMessage{
+		MessageID: 50,
+		From:      &TGUser{ID: 456, Username: "alice"},
+		Chat:      TGChat{ID: -200, Type: "group"},
+		Date:      time.Now().Unix(),
+		Caption:   "listen to this",
+		Audio: &TGAudio{
+			FileID:       "audio-msg",
+			FileUniqueID: "auduniq",
+			FileName:     "voice.mp3",
+			FileSize:     4096,
+			Duration:     15,
+		},
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for delivery")
+	}
+
+	require.NotNil(t, deliveredMsg)
+	assert.Contains(t, deliveredMsg.Msg, "listen to this")
+	assert.Contains(t, deliveredMsg.Msg, "Audio attached")
+	assert.Len(t, deliveredMsg.Attachments, 1)
+	assert.Contains(t, deliveredMsg.Attachments[0], "voice.mp3")
+}
+
+func TestV2_DownloadTelegramFile_ConfiguredDownloadsPath(t *testing.T) {
+	tgSrv := newFakeTGServerV2(t)
+	b := newTestBrokerV2(t, tgSrv)
+
+	// Set a custom downloads path.
+	customDir := filepath.Join(t.TempDir(), "custom-downloads")
+	b.downloadsPath = customDir
+
+	ctx := context.Background()
+
+	tgMsg := &TGMessage{
+		Document: &TGDocument{
+			FileID:       "doc-custom",
+			FileUniqueID: "docuniqcustom",
+			FileName:     "custom.pdf",
+			MimeType:     "application/pdf",
+			FileSize:     1024,
+		},
+	}
+
+	_, _, err := b.downloadTelegramFile(ctx, tgMsg, "any-slug")
+	require.NoError(t, err)
+
+	// Verify the file was saved in the custom directory.
+	entries, err := os.ReadDir(customDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Contains(t, entries[0].Name(), "custom.pdf")
 }
 
 // --- Code span restoration tests ---

--- a/extras/scion-telegram/internal/telegram/broker_v2_test.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2_test.go
@@ -2810,6 +2810,199 @@ func TestV2_HandleGroupMessage_PreBlockWithLanguage(t *testing.T) {
 	assert.Equal(t, "```go\nfmt.Println(\"hello\")\n```", deliveredMsg.Msg)
 }
 
+// --- Fix H1: captionless audio/video routes to default agent ---
+
+func TestV2_HandleIncoming_CaptionlessAudioRoutesToDefaultAgent(t *testing.T) {
+	tgSrv := newFakeTGServerV2(t)
+	hub := newFakeHubClient()
+	hub.agents["proj-1"] = []AgentInfo{{Slug: "coder"}}
+	b := newTestBrokerV2WithHub(t, tgSrv, hub)
+
+	ctx := context.Background()
+	require.NoError(t, b.store.SaveUserMapping(ctx, &TelegramUserMapping{
+		TelegramUserID: "456",
+		ScionEmail:     "alice@example.com",
+		LinkedAt:       time.Now().UTC(),
+	}))
+
+	tmpDir := t.TempDir()
+	require.NoError(t, b.store.SaveGroupLink(ctx, &GroupLink{
+		ChatID:       -200,
+		ProjectID:    "proj-1",
+		ProjectSlug:  filepath.Base(tmpDir),
+		DefaultAgent: "coder",
+		LinkedAt:     time.Now().UTC(),
+		Active:       true,
+	}))
+	require.NoError(t, b.store.SaveProjectAgents(ctx, &ProjectAgents{
+		ProjectID:   "proj-1",
+		Agents:      []AgentInfo{{Slug: "coder"}},
+		RefreshedAt: time.Now(),
+	}))
+
+	var deliveredMsg *messages.StructuredMessage
+	done := make(chan struct{}, 1)
+	b.InboundHandler = func(_ string, msg *messages.StructuredMessage) {
+		deliveredMsg = msg
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}
+
+	// Audio with NO caption and NO @mention — must route via Fallback 3.
+	b.handleIncomingMessageV2(&TGMessage{
+		MessageID: 60,
+		From:      &TGUser{ID: 456, Username: "alice"},
+		Chat:      TGChat{ID: -200, Type: "group"},
+		Date:      time.Now().Unix(),
+		Audio: &TGAudio{
+			FileID:       "audio-nocap",
+			FileUniqueID: "auduniqnocap",
+			FileName:     "song.mp3",
+			FileSize:     4096,
+			Duration:     30,
+		},
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for delivery — captionless audio was dropped")
+	}
+
+	require.NotNil(t, deliveredMsg)
+	assert.Contains(t, deliveredMsg.Msg, "Audio attached")
+	assert.Len(t, deliveredMsg.Attachments, 1)
+	assert.Contains(t, deliveredMsg.Attachments[0], "song.mp3")
+}
+
+func TestV2_HandleIncoming_CaptionlessVideoRoutesToDefaultAgent(t *testing.T) {
+	tgSrv := newFakeTGServerV2(t)
+	hub := newFakeHubClient()
+	hub.agents["proj-1"] = []AgentInfo{{Slug: "coder"}}
+	b := newTestBrokerV2WithHub(t, tgSrv, hub)
+
+	ctx := context.Background()
+	require.NoError(t, b.store.SaveUserMapping(ctx, &TelegramUserMapping{
+		TelegramUserID: "456",
+		ScionEmail:     "alice@example.com",
+		LinkedAt:       time.Now().UTC(),
+	}))
+
+	tmpDir := t.TempDir()
+	require.NoError(t, b.store.SaveGroupLink(ctx, &GroupLink{
+		ChatID:       -200,
+		ProjectID:    "proj-1",
+		ProjectSlug:  filepath.Base(tmpDir),
+		DefaultAgent: "coder",
+		LinkedAt:     time.Now().UTC(),
+		Active:       true,
+	}))
+	require.NoError(t, b.store.SaveProjectAgents(ctx, &ProjectAgents{
+		ProjectID:   "proj-1",
+		Agents:      []AgentInfo{{Slug: "coder"}},
+		RefreshedAt: time.Now(),
+	}))
+
+	var deliveredMsg *messages.StructuredMessage
+	done := make(chan struct{}, 1)
+	b.InboundHandler = func(_ string, msg *messages.StructuredMessage) {
+		deliveredMsg = msg
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}
+
+	// Video with NO caption and NO @mention — must route via Fallback 3.
+	b.handleIncomingMessageV2(&TGMessage{
+		MessageID: 61,
+		From:      &TGUser{ID: 456, Username: "alice"},
+		Chat:      TGChat{ID: -200, Type: "group"},
+		Date:      time.Now().Unix(),
+		Video: &TGVideo{
+			FileID:       "video-nocap",
+			FileUniqueID: "viduniqnocap",
+			FileSize:     10000,
+			Width:        640,
+			Height:       480,
+			Duration:     5,
+		},
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for delivery — captionless video was dropped")
+	}
+
+	require.NotNil(t, deliveredMsg)
+	assert.Contains(t, deliveredMsg.Msg, "Video attached")
+	assert.Len(t, deliveredMsg.Attachments, 1)
+	assert.Contains(t, deliveredMsg.Attachments[0], "video_viduniqnocap.mp4")
+}
+
+// --- Fix M1: path traversal in Audio.Title ---
+
+func TestV2_DownloadTelegramFile_AudioTitlePathTraversal(t *testing.T) {
+	tgSrv := newFakeTGServerV2(t)
+	b := newTestBrokerV2(t, tgSrv)
+
+	ctx := context.Background()
+	slug := filepath.Base(t.TempDir())
+
+	tgMsg := &TGMessage{
+		Audio: &TGAudio{
+			FileID:       "audio-evil",
+			FileUniqueID: "audevil",
+			FileSize:     1024,
+			Duration:     5,
+			Title:        "../../etc/passwd",
+		},
+	}
+
+	agentPath, _, err := b.downloadTelegramFile(ctx, tgMsg, slug)
+	require.NoError(t, err)
+	// The path-traversal components must be stripped — the file should be
+	// named "passwd.ogg" (filepath.Base of "../../etc/passwd.ogg"), not
+	// contain any ".." segments.
+	assert.NotContains(t, agentPath, "..")
+	assert.Contains(t, agentPath, "passwd.ogg")
+}
+
+// --- Fix M2: agentPath reflects custom downloads_path ---
+
+func TestV2_DownloadTelegramFile_ConfiguredDownloadsPathAgentPath(t *testing.T) {
+	tgSrv := newFakeTGServerV2(t)
+	b := newTestBrokerV2(t, tgSrv)
+
+	// Set a custom downloads path.
+	customDir := filepath.Join(t.TempDir(), "shared-attachments")
+	b.downloadsPath = customDir
+
+	ctx := context.Background()
+
+	tgMsg := &TGMessage{
+		Document: &TGDocument{
+			FileID:       "doc-agent-path",
+			FileUniqueID: "docuniqap",
+			FileName:     "report.pdf",
+			MimeType:     "application/pdf",
+			FileSize:     2048,
+		},
+	}
+
+	agentPath, _, err := b.downloadTelegramFile(ctx, tgMsg, "any-slug")
+	require.NoError(t, err)
+
+	// agentPath must start with the custom downloads path, NOT /workspace/downloads.
+	assert.True(t, strings.HasPrefix(agentPath, customDir),
+		"agentPath %q should start with custom downloads dir %q", agentPath, customDir)
+	assert.NotContains(t, agentPath, "/workspace/downloads")
+	assert.Contains(t, agentPath, "report.pdf")
+}
+
 func TestV2_HandleGroupMessage_CodeSpanWithDefaultAgent(t *testing.T) {
 	tgSrv := newFakeTGServerV2(t)
 	hub := newFakeHubClient()


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/78

When a user sends a photo, document, audio, or video via Telegram, the integration now downloads it (respecting the 20MB bot limit) to a configurable downloads_path directory and includes attachment: <path> in the structured message delivered to agents. Filenames are sanitized against path traversal. All four attachment types routed correctly including captionless audio/video in group channels