### PR TITLE
fix: resolve attachment paths to host-side paths for host-process brokers

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -28,6 +28,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/plugin"
 	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
@@ -1485,11 +1486,21 @@ func (b *DiscordBroker) resolveStaleChannelSlugs(ctx context.Context) {
 
 // --- Attachment helpers ---
 
-// resolveAttachmentPath translates an agent-relative /workspace path to the
-// host-side path under /home/scion/.scion/projects/<slug>/. Agent containers
-// mount /home/scion/.scion/projects/<slug> as /workspace.
+// resolveAttachmentPath translates agent-side paths to host-side paths.
+//
+// Supported container-side paths:
+//   - /workspace/<file>  → ~/.scion/projects/<slug>/<file>
+//   - /scion-volumes/<name>/<file> → ~/.scion/project-configs/<slug>__<shortUUID>/shared-dirs/<name>/<file>
+//   - /workspace/.scion-volumes/<name>/<file> → same as /scion-volumes/<name>/<file>
+//
+// Also accepts bare relative paths and "workspace/" without leading slash.
 // Returns empty string if the path is unsafe or cannot be resolved.
 func (b *DiscordBroker) resolveAttachmentPath(ctx context.Context, attachPath, projectID string) string {
+	// Handle /scion-volumes/<name>/... container-internal shared dir paths.
+	if strings.HasPrefix(attachPath, "/scion-volumes/") || attachPath == "/scion-volumes" {
+		return b.resolveSharedDirAttachmentPath(ctx, attachPath, projectID)
+	}
+
 	var relPath string
 	switch {
 	case strings.HasPrefix(attachPath, "/workspace/"):
@@ -1515,17 +1526,17 @@ func (b *DiscordBroker) resolveAttachmentPath(ctx context.Context, attachPath, p
 		return ""
 	}
 
-	// Look up project slug from channel links, falling back to the injected slug map.
-	slug := ""
-	if b.store != nil && projectID != "" {
-		links, err := b.store.GetChannelLinksForProject(ctx, projectID)
-		if err == nil && len(links) > 0 && links[0].ProjectSlug != "" {
-			slug = links[0].ProjectSlug
-		}
+	// In-workspace shared dirs are mounted at /workspace/.scion-volumes/<name>
+	// inside containers. Redirect to shared dir resolution.
+	if strings.HasPrefix(relPath, ".scion-volumes/") {
+		containerPath := "/scion-volumes/" + strings.TrimPrefix(relPath, ".scion-volumes/")
+		return b.resolveSharedDirAttachmentPath(ctx, containerPath, projectID)
 	}
-	if slug == "" && projectID != "" {
-		slug = b.projectSlugMap[projectID]
+	if relPath == ".scion-volumes" {
+		return ""
 	}
+
+	slug := b.resolveProjectSlug(ctx, projectID)
 	if slug == "" {
 		b.log.Warn("Cannot resolve attachment path: no project slug found",
 			"attach_path", attachPath, "project_id", projectID)
@@ -1547,6 +1558,76 @@ func (b *DiscordBroker) resolveAttachmentPath(ctx context.Context, attachPath, p
 
 	b.log.Debug("Resolved attachment path", "original", attachPath, "resolved", hostPath)
 	return hostPath
+}
+
+// resolveSharedDirAttachmentPath translates a container-internal shared dir
+// path (/scion-volumes/<name>/...) to the host-side path under
+// ~/.scion/project-configs/<slug>__<shortUUID>/shared-dirs/<name>/.
+// Returns empty string if the path is unsafe or cannot be resolved.
+func (b *DiscordBroker) resolveSharedDirAttachmentPath(ctx context.Context, attachPath, projectID string) string {
+	trimmed := strings.TrimPrefix(attachPath, "/scion-volumes/")
+	if trimmed == "" || trimmed == attachPath {
+		b.log.Warn("Invalid shared dir attachment path", "attach_path", attachPath)
+		return ""
+	}
+
+	parts := strings.SplitN(trimmed, "/", 2)
+	sharedDirName := parts[0]
+	relPath := ""
+	if len(parts) > 1 {
+		relPath = filepath.Clean(parts[1])
+		if strings.HasPrefix(relPath, "..") || filepath.IsAbs(relPath) {
+			b.log.Warn("Shared dir attachment path escapes directory",
+				"attach_path", attachPath, "rel_path", relPath)
+			return ""
+		}
+	}
+
+	slug := b.resolveProjectSlug(ctx, projectID)
+	if slug == "" || projectID == "" {
+		b.log.Warn("Cannot resolve shared dir path: no project slug or ID",
+			"attach_path", attachPath, "project_id", projectID)
+		return ""
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		b.log.Warn("Failed to resolve home dir for shared dir path", "error", err)
+		return ""
+	}
+
+	sharedDirBase := config.SharedDirHostPath(home, slug, projectID, sharedDirName)
+	var hostPath string
+	if relPath == "" || relPath == "." {
+		hostPath = sharedDirBase
+	} else {
+		hostPath = filepath.Join(sharedDirBase, relPath)
+		if !strings.HasPrefix(hostPath, sharedDirBase+"/") {
+			b.log.Warn("Resolved shared dir path escapes directory",
+				"host_path", hostPath, "expected_prefix", sharedDirBase+"/")
+			return ""
+		}
+	}
+
+	b.log.Debug("Resolved shared dir attachment path",
+		"original", attachPath, "resolved", hostPath)
+	return hostPath
+}
+
+// resolveProjectSlug looks up the project slug from the store (channel links)
+// or the hub-injected slug map.
+func (b *DiscordBroker) resolveProjectSlug(ctx context.Context, projectID string) string {
+	slug := ""
+	if b.store != nil && projectID != "" {
+		links, err := b.store.GetChannelLinksForProject(ctx, projectID)
+		if err == nil && len(links) > 0 && links[0].ProjectSlug != "" {
+			slug = links[0].ProjectSlug
+		}
+	}
+	if slug == "" && projectID != "" {
+		slug = b.projectSlugMap[projectID]
+	}
+	return slug
 }
 
 const maxDiscordAttachmentSize = 25 * 1024 * 1024 // 25 MB

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1573,6 +1573,11 @@ func (b *DiscordBroker) resolveSharedDirAttachmentPath(ctx context.Context, atta
 
 	parts := strings.SplitN(trimmed, "/", 2)
 	sharedDirName := parts[0]
+	if sharedDirName == "" || sharedDirName == "." || sharedDirName == ".." {
+		b.log.Warn("Invalid shared dir name in attachment path",
+			"attach_path", attachPath, "shared_dir_name", sharedDirName)
+		return ""
+	}
 	relPath := ""
 	if len(parts) > 1 {
 		relPath = filepath.Clean(parts[1])

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1607,9 +1607,9 @@ func (b *DiscordBroker) resolveSharedDirAttachmentPath(ctx context.Context, atta
 		hostPath = sharedDirBase
 	} else {
 		hostPath = filepath.Join(sharedDirBase, relPath)
-		if !strings.HasPrefix(hostPath, sharedDirBase+"/") {
+		if !strings.HasPrefix(hostPath, sharedDirBase+string(filepath.Separator)) {
 			b.log.Warn("Resolved shared dir path escapes directory",
-				"host_path", hostPath, "expected_prefix", sharedDirBase+"/")
+				"host_path", hostPath, "expected_prefix", sharedDirBase+string(filepath.Separator))
 			return ""
 		}
 	}

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -471,3 +471,129 @@ func TestHealthCheck_NoSession(t *testing.T) {
 	assert.Equal(t, "degraded", status.Status)
 	assert.Contains(t, status.Message, "not configured")
 }
+
+// --- resolveAttachmentPath tests ---
+
+func TestResolveAttachmentPath_WorkspacePaths(t *testing.T) {
+	b := &DiscordBroker{
+		log: discardLogger(),
+		projectSlugMap: map[string]string{
+			"proj-1": "my-project",
+		},
+	}
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		path      string
+		projectID string
+		want      string
+	}{
+		{
+			name:      "workspace with leading slash",
+			path:      "/workspace/file.txt",
+			projectID: "proj-1",
+			want:      "/home/scion/.scion/projects/my-project/file.txt",
+		},
+		{
+			name:      "workspace without leading slash",
+			path:      "workspace/file.txt",
+			projectID: "proj-1",
+			want:      "/home/scion/.scion/projects/my-project/file.txt",
+		},
+		{
+			name:      "bare workspace",
+			path:      "/workspace",
+			projectID: "proj-1",
+			want:      "/home/scion/.scion/projects/my-project",
+		},
+		{
+			name:      "relative path",
+			path:      "file.txt",
+			projectID: "proj-1",
+			want:      "/home/scion/.scion/projects/my-project/file.txt",
+		},
+		{
+			name:      "no project slug returns empty",
+			path:      "/workspace/file.txt",
+			projectID: "unknown-proj",
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := b.resolveAttachmentPath(ctx, tt.path, tt.projectID)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveAttachmentPath_SharedDirPaths(t *testing.T) {
+	b := &DiscordBroker{
+		log: discardLogger(),
+		projectSlugMap: map[string]string{
+			"550e8400-e29b-41d4-a716-446655440000": "my-project",
+		},
+	}
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		path      string
+		projectID string
+		wantEnd   string // suffix to match (avoids hardcoding HOME)
+		wantEmpty bool
+	}{
+		{
+			name:      "scion-volumes path with file",
+			path:      "/scion-volumes/scratchpad/projects/chat-admin/report.png",
+			projectID: "550e8400-e29b-41d4-a716-446655440000",
+			wantEnd:   "project-configs/my-project__550e8400/shared-dirs/scratchpad/projects/chat-admin/report.png",
+		},
+		{
+			name:      "scion-volumes path bare dir",
+			path:      "/scion-volumes/build-cache",
+			projectID: "550e8400-e29b-41d4-a716-446655440000",
+			wantEnd:   "project-configs/my-project__550e8400/shared-dirs/build-cache",
+		},
+		{
+			name:      "scion-volumes with trailing slash file",
+			path:      "/scion-volumes/scratchpad/file.txt",
+			projectID: "550e8400-e29b-41d4-a716-446655440000",
+			wantEnd:   "project-configs/my-project__550e8400/shared-dirs/scratchpad/file.txt",
+		},
+		{
+			name:      "in-workspace scion-volumes",
+			path:      "/workspace/.scion-volumes/cache/data.bin",
+			projectID: "550e8400-e29b-41d4-a716-446655440000",
+			wantEnd:   "project-configs/my-project__550e8400/shared-dirs/cache/data.bin",
+		},
+		{
+			name:      "no project slug returns empty",
+			path:      "/scion-volumes/scratchpad/file.txt",
+			projectID: "unknown-proj",
+			wantEmpty: true,
+		},
+		{
+			name:      "path traversal rejected",
+			path:      "/scion-volumes/scratchpad/../../etc/passwd",
+			projectID: "550e8400-e29b-41d4-a716-446655440000",
+			wantEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := b.resolveAttachmentPath(ctx, tt.path, tt.projectID)
+			if tt.wantEmpty {
+				assert.Empty(t, got, "resolveAttachmentPath(%q) should return empty", tt.path)
+			} else {
+				assert.True(t, strings.HasSuffix(got, tt.wantEnd),
+					"resolveAttachmentPath(%q) = %q, want suffix %q", tt.path, got, tt.wantEnd)
+			}
+		})
+	}
+}

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -597,7 +598,7 @@ func TestResolveAttachmentPath_SharedDirPaths(t *testing.T) {
 			if tt.wantEmpty {
 				assert.Empty(t, got, "resolveAttachmentPath(%q) should return empty", tt.path)
 			} else {
-				assert.True(t, strings.HasSuffix(got, tt.wantEnd),
+				assert.True(t, strings.HasSuffix(got, filepath.FromSlash(tt.wantEnd)),
 					"resolveAttachmentPath(%q) = %q, want suffix %q", tt.path, got, tt.wantEnd)
 			}
 		})

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -583,6 +583,12 @@ func TestResolveAttachmentPath_SharedDirPaths(t *testing.T) {
 			projectID: "550e8400-e29b-41d4-a716-446655440000",
 			wantEmpty: true,
 		},
+		{
+			name:      "path traversal in shared dir name rejected",
+			path:      "/scion-volumes/../.scion/settings.yaml",
+			projectID: "550e8400-e29b-41d4-a716-446655440000",
+			wantEmpty: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -1293,6 +1293,11 @@ func (b *TelegramBrokerV2) resolveSharedDirAttachmentPath(ctx context.Context, s
 
 	parts := strings.SplitN(trimmed, "/", 2)
 	sharedDirName := parts[0]
+	if sharedDirName == "" || sharedDirName == "." || sharedDirName == ".." {
+		b.log.Warn("Invalid shared dir name in attachment path",
+			"attach_path", attachPath, "shared_dir_name", sharedDirName)
+		return attachPath
+	}
 	relPath := ""
 	if len(parts) > 1 {
 		relPath = filepath.Clean(parts[1])

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -1327,9 +1327,9 @@ func (b *TelegramBrokerV2) resolveSharedDirAttachmentPath(ctx context.Context, s
 		hostPath = sharedDirBase
 	} else {
 		hostPath = filepath.Join(sharedDirBase, relPath)
-		if !strings.HasPrefix(hostPath, sharedDirBase+"/") {
+		if !strings.HasPrefix(hostPath, sharedDirBase+string(filepath.Separator)) {
 			b.log.Warn("Resolved shared dir path escapes directory",
-				"host_path", hostPath, "expected_prefix", sharedDirBase+"/")
+				"host_path", hostPath, "expected_prefix", sharedDirBase+string(filepath.Separator))
 			return attachPath
 		}
 	}

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/plugin"
 	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
@@ -1206,14 +1207,22 @@ func (b *TelegramBrokerV2) publishInputNeededDM(ctx context.Context, api *Telegr
 	return nil
 }
 
-// resolveAttachmentPath translates an agent-relative /workspace path to the
-// corresponding host-side path under /home/scion/.scion/projects/<slug>/.
-// Agent containers mount /home/scion/.scion/projects/<slug> as /workspace.
-// Accepts "/workspace/file", "/workspace", "workspace/file", "workspace",
-// and bare relative paths like "file.png". Falls back to the original path
-// if translation is not possible.
+// resolveAttachmentPath translates agent-side paths to host-side paths.
+//
+// Supported container-side paths:
+//   - /workspace/<file>  → ~/.scion/projects/<slug>/<file>
+//   - /scion-volumes/<name>/<file> → ~/.scion/project-configs/<slug>__<shortUUID>/shared-dirs/<name>/<file>
+//   - /workspace/.scion-volumes/<name>/<file> → same as /scion-volumes/<name>/<file>
+//
+// Also accepts bare relative paths and "workspace/" without leading slash.
+// Falls back to the original path if translation is not possible.
 func (b *TelegramBrokerV2) resolveAttachmentPath(ctx context.Context, store Store, attachPath, projectID string) string {
 	originalPath := attachPath
+
+	// Handle /scion-volumes/<name>/... container-internal shared dir paths.
+	if strings.HasPrefix(attachPath, "/scion-volumes/") || attachPath == "/scion-volumes" {
+		return b.resolveSharedDirAttachmentPath(ctx, store, attachPath, projectID)
+	}
 
 	var relPath string
 	switch {
@@ -1238,17 +1247,17 @@ func (b *TelegramBrokerV2) resolveAttachmentPath(ctx context.Context, store Stor
 		return attachPath
 	}
 
-	// Look up project slug from group links, falling back to the injected slug map.
-	slug := ""
-	if store != nil && projectID != "" {
-		links, err := store.GetGroupLinksForProject(ctx, projectID)
-		if err == nil && len(links) > 0 && links[0].ProjectSlug != "" {
-			slug = links[0].ProjectSlug
-		}
+	// In-workspace shared dirs are mounted at /workspace/.scion-volumes/<name>
+	// inside containers. Redirect to shared dir resolution.
+	if strings.HasPrefix(relPath, ".scion-volumes/") {
+		containerPath := "/scion-volumes/" + strings.TrimPrefix(relPath, ".scion-volumes/")
+		return b.resolveSharedDirAttachmentPath(ctx, store, containerPath, projectID)
 	}
-	if slug == "" && projectID != "" {
-		slug = b.projectSlugMap[projectID]
+	if relPath == ".scion-volumes" {
+		return attachPath
 	}
+
+	slug := b.resolveProjectSlug(ctx, store, projectID)
 	if slug == "" {
 		b.log.Debug("Attachment path unchanged, no project slug found",
 			"original", originalPath, "project_id", projectID)
@@ -1270,6 +1279,75 @@ func (b *TelegramBrokerV2) resolveAttachmentPath(ctx context.Context, store Stor
 
 	b.log.Debug("Resolved attachment path", "original", originalPath, "resolved", hostPath)
 	return hostPath
+}
+
+// resolveSharedDirAttachmentPath translates a container-internal shared dir
+// path (/scion-volumes/<name>/...) to the host-side path under
+// ~/.scion/project-configs/<slug>__<shortUUID>/shared-dirs/<name>/.
+func (b *TelegramBrokerV2) resolveSharedDirAttachmentPath(ctx context.Context, store Store, attachPath, projectID string) string {
+	trimmed := strings.TrimPrefix(attachPath, "/scion-volumes/")
+	if trimmed == "" || trimmed == attachPath {
+		b.log.Warn("Invalid shared dir attachment path", "attach_path", attachPath)
+		return attachPath
+	}
+
+	parts := strings.SplitN(trimmed, "/", 2)
+	sharedDirName := parts[0]
+	relPath := ""
+	if len(parts) > 1 {
+		relPath = filepath.Clean(parts[1])
+		if strings.HasPrefix(relPath, "..") || filepath.IsAbs(relPath) {
+			b.log.Warn("Shared dir attachment path escapes directory",
+				"attach_path", attachPath, "rel_path", relPath)
+			return attachPath
+		}
+	}
+
+	slug := b.resolveProjectSlug(ctx, store, projectID)
+	if slug == "" || projectID == "" {
+		b.log.Debug("Shared dir path unchanged, no project slug or ID",
+			"original", attachPath, "project_id", projectID)
+		return attachPath
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		b.log.Warn("Failed to resolve home dir for shared dir path", "error", err)
+		return attachPath
+	}
+
+	sharedDirBase := config.SharedDirHostPath(home, slug, projectID, sharedDirName)
+	var hostPath string
+	if relPath == "" || relPath == "." {
+		hostPath = sharedDirBase
+	} else {
+		hostPath = filepath.Join(sharedDirBase, relPath)
+		if !strings.HasPrefix(hostPath, sharedDirBase+"/") {
+			b.log.Warn("Resolved shared dir path escapes directory",
+				"host_path", hostPath, "expected_prefix", sharedDirBase+"/")
+			return attachPath
+		}
+	}
+
+	b.log.Debug("Resolved shared dir attachment path",
+		"original", attachPath, "resolved", hostPath)
+	return hostPath
+}
+
+// resolveProjectSlug looks up the project slug from the store (group links)
+// or the hub-injected slug map.
+func (b *TelegramBrokerV2) resolveProjectSlug(ctx context.Context, store Store, projectID string) string {
+	slug := ""
+	if store != nil && projectID != "" {
+		links, err := store.GetGroupLinksForProject(ctx, projectID)
+		if err == nil && len(links) > 0 && links[0].ProjectSlug != "" {
+			slug = links[0].ProjectSlug
+		}
+	}
+	if slug == "" && projectID != "" {
+		slug = b.projectSlugMap[projectID]
+	}
+	return slug
 }
 
 // publishAttachment reads a file from the local filesystem and sends it to

--- a/extras/scion-telegram/internal/telegram/broker_v2_test.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2_test.go
@@ -3237,7 +3237,7 @@ func TestV2_ResolveAttachmentPath_SharedDirPaths(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := b.resolveAttachmentPath(ctx, nil, tt.path, tt.projectID)
-			assert.True(t, strings.HasSuffix(got, tt.wantEnd),
+			assert.True(t, strings.HasSuffix(got, filepath.FromSlash(tt.wantEnd)),
 				"resolveAttachmentPath(%q) = %q, want suffix %q", tt.path, got, tt.wantEnd)
 		})
 	}

--- a/extras/scion-telegram/internal/telegram/broker_v2_test.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2_test.go
@@ -3114,3 +3114,125 @@ func TestResolveRecipientChats(t *testing.T) {
 		assert.Equal(t, []int64{12345}, chats)
 	})
 }
+
+// --- resolveAttachmentPath tests ---
+
+func TestV2_ResolveAttachmentPath_WorkspacePaths(t *testing.T) {
+	tgSrv := newFakeTGServerV2(t)
+	b := newTestBrokerV2(t, tgSrv)
+	b.projectSlugMap = map[string]string{
+		"proj-1": "my-project",
+	}
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		path      string
+		projectID string
+		want      string
+	}{
+		{
+			name:      "workspace with leading slash",
+			path:      "/workspace/file.txt",
+			projectID: "proj-1",
+			want:      "/home/scion/.scion/projects/my-project/file.txt",
+		},
+		{
+			name:      "workspace without leading slash",
+			path:      "workspace/file.txt",
+			projectID: "proj-1",
+			want:      "/home/scion/.scion/projects/my-project/file.txt",
+		},
+		{
+			name:      "bare workspace",
+			path:      "/workspace",
+			projectID: "proj-1",
+			want:      "/home/scion/.scion/projects/my-project",
+		},
+		{
+			name:      "relative path",
+			path:      "file.txt",
+			projectID: "proj-1",
+			want:      "/home/scion/.scion/projects/my-project/file.txt",
+		},
+		{
+			name:      "no project slug returns original",
+			path:      "/workspace/file.txt",
+			projectID: "unknown-proj",
+			want:      "/workspace/file.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := b.resolveAttachmentPath(ctx, nil, tt.path, tt.projectID)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestV2_ResolveAttachmentPath_SharedDirPaths(t *testing.T) {
+	tgSrv := newFakeTGServerV2(t)
+	b := newTestBrokerV2(t, tgSrv)
+	b.projectSlugMap = map[string]string{
+		"550e8400-e29b-41d4-a716-446655440000": "my-project",
+	}
+
+	ctx := context.Background()
+
+	// Expected: ~/.scion/project-configs/my-project__550e8400/shared-dirs/<name>/<file>
+	// shortUUID = "550e8400" (first 8 hex chars of UUID without dashes)
+
+	tests := []struct {
+		name      string
+		path      string
+		projectID string
+		wantEnd   string // suffix to match (avoids hardcoding HOME)
+	}{
+		{
+			name:      "scion-volumes path with file",
+			path:      "/scion-volumes/scratchpad/projects/chat-admin/report.png",
+			projectID: "550e8400-e29b-41d4-a716-446655440000",
+			wantEnd:   "project-configs/my-project__550e8400/shared-dirs/scratchpad/projects/chat-admin/report.png",
+		},
+		{
+			name:      "scion-volumes path bare dir",
+			path:      "/scion-volumes/build-cache",
+			projectID: "550e8400-e29b-41d4-a716-446655440000",
+			wantEnd:   "project-configs/my-project__550e8400/shared-dirs/build-cache",
+		},
+		{
+			name:      "scion-volumes with trailing slash file",
+			path:      "/scion-volumes/scratchpad/file.txt",
+			projectID: "550e8400-e29b-41d4-a716-446655440000",
+			wantEnd:   "project-configs/my-project__550e8400/shared-dirs/scratchpad/file.txt",
+		},
+		{
+			name:      "in-workspace scion-volumes",
+			path:      "/workspace/.scion-volumes/cache/data.bin",
+			projectID: "550e8400-e29b-41d4-a716-446655440000",
+			wantEnd:   "project-configs/my-project__550e8400/shared-dirs/cache/data.bin",
+		},
+		{
+			name:      "no project slug returns original",
+			path:      "/scion-volumes/scratchpad/file.txt",
+			projectID: "unknown-proj",
+			wantEnd:   "/scion-volumes/scratchpad/file.txt",
+		},
+		{
+			name:      "path traversal rejected",
+			path:      "/scion-volumes/scratchpad/../../etc/passwd",
+			projectID: "550e8400-e29b-41d4-a716-446655440000",
+			wantEnd:   "/scion-volumes/scratchpad/../../etc/passwd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := b.resolveAttachmentPath(ctx, nil, tt.path, tt.projectID)
+			assert.True(t, strings.HasSuffix(got, tt.wantEnd),
+				"resolveAttachmentPath(%q) = %q, want suffix %q", tt.path, got, tt.wantEnd)
+		})
+	}
+}

--- a/extras/scion-telegram/internal/telegram/broker_v2_test.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2_test.go
@@ -3226,6 +3226,12 @@ func TestV2_ResolveAttachmentPath_SharedDirPaths(t *testing.T) {
 			projectID: "550e8400-e29b-41d4-a716-446655440000",
 			wantEnd:   "/scion-volumes/scratchpad/../../etc/passwd",
 		},
+		{
+			name:      "path traversal in shared dir name rejected",
+			path:      "/scion-volumes/../.scion/settings.yaml",
+			projectID: "550e8400-e29b-41d4-a716-446655440000",
+			wantEnd:   "/scion-volumes/../.scion/settings.yaml",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/shared_dirs.go
+++ b/pkg/config/shared_dirs.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 )
@@ -156,4 +157,21 @@ func GetSharedDirInfos(projectDir string, dirs []api.SharedDir) ([]SharedDirInfo
 		})
 	}
 	return infos, nil
+}
+
+// SharedDirHostPath computes the host-side directory path for a shared
+// directory given the user's home directory, the project slug, project ID,
+// and shared dir name.  This is used by host-process plugins (Telegram,
+// Discord) that receive container-internal paths (/scion-volumes/<name>)
+// and need to translate them to host-side paths without requiring access to
+// the project's .scion marker file.
+//
+// The returned path is under ~/.scion/project-configs/<slug>__<shortUUID>/shared-dirs/<name>.
+func SharedDirHostPath(home, slug, projectID, sharedDirName string) string {
+	shortUUID := strings.ReplaceAll(projectID, "-", "")
+	if len(shortUUID) > 8 {
+		shortUUID = shortUUID[:8]
+	}
+	dirName := fmt.Sprintf("%s__%s", slug, shortUUID)
+	return filepath.Join(home, GlobalDir, ProjectConfigsDir, dirName, SharedDirsSubdir, sharedDirName)
 }

--- a/pkg/config/shared_dirs_test.go
+++ b/pkg/config/shared_dirs_test.go
@@ -17,6 +17,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
@@ -184,4 +185,40 @@ func TestGetSharedDirsBasePath_GitProject(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, basePath, SharedDirsSubdir)
 	assert.Contains(t, basePath, "project-configs")
+}
+
+func TestSharedDirHostPath(t *testing.T) {
+	tests := []struct {
+		name          string
+		home          string
+		slug          string
+		projectID     string
+		sharedDirName string
+		wantSuffix    string
+	}{
+		{
+			name:          "standard UUID",
+			home:          "/home/scion",
+			slug:          "my-project",
+			projectID:     "550e8400-e29b-41d4-a716-446655440000",
+			sharedDirName: "scratchpad",
+			wantSuffix:    "project-configs/my-project__550e8400/shared-dirs/scratchpad",
+		},
+		{
+			name:          "short UUID without dashes",
+			home:          "/home/scion",
+			slug:          "test",
+			projectID:     "abcdef12",
+			sharedDirName: "build-cache",
+			wantSuffix:    "project-configs/test__abcdef12/shared-dirs/build-cache",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SharedDirHostPath(tt.home, tt.slug, tt.projectID, tt.sharedDirName)
+			assert.True(t, strings.HasSuffix(got, tt.wantSuffix),
+				"SharedDirHostPath() = %q, want suffix %q", got, tt.wantSuffix)
+		})
+	}
 }

--- a/pkg/config/shared_dirs_test.go
+++ b/pkg/config/shared_dirs_test.go
@@ -217,7 +217,7 @@ func TestSharedDirHostPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := SharedDirHostPath(tt.home, tt.slug, tt.projectID, tt.sharedDirName)
-			assert.True(t, strings.HasSuffix(got, tt.wantSuffix),
+			assert.True(t, strings.HasSuffix(got, filepath.FromSlash(tt.wantSuffix)),
 				"SharedDirHostPath() = %q, want suffix %q", got, tt.wantSuffix)
 		})
 	}


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/397

resolveAttachmentPath() was translating /workspace/<file> to /scion-volumes/scratchpad/... (container-internal path). The Telegram and Discord plugins run as host processes where /scion-volumes/ does not exist, causing silent attachment delivery failures.

This fix adds a SharedDirHostPath() utility in pkg/config and updates both brokers to translate shared-dir attachment paths to host-side paths under ~/.scion/project-configs/<slug>/shared-dirs/<name>/. Includes path traversal guard for the shared-dir name component (rejects empty/dot/dotdot names). Reviewed and approved prior to rebase