### PR TITLE
fix: auto-populate message_broker.types, add gateway health, restart wiring validation (#508)

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -418,6 +418,31 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 					log.Printf("Auto-enabled message broker for configured broker plugin(s): %v", vs.Server.MessageBroker.Types)
 				}
 			}
+
+			// Auto-populate: if message_broker.enabled but types is empty while
+			// broker plugins exist, populate types from the plugin list.
+			if vs.Server.Plugins != nil && vs.Server.MessageBroker != nil &&
+				vs.Server.MessageBroker.Enabled && len(vs.Server.MessageBroker.Types) == 0 && len(vs.Server.Plugins.Broker) > 0 {
+				for name := range vs.Server.Plugins.Broker {
+					vs.Server.MessageBroker.Types = append(vs.Server.MessageBroker.Types, name)
+				}
+				log.Printf("NOTICE: message_broker.types was empty — auto-populated from plugins: %v", vs.Server.MessageBroker.Types)
+			}
+
+			// Warn on plugin-not-in-types
+			if vs.Server.Plugins != nil && vs.Server.MessageBroker != nil &&
+				vs.Server.MessageBroker.Enabled && len(vs.Server.MessageBroker.Types) > 0 {
+				typesSet := make(map[string]bool, len(vs.Server.MessageBroker.Types))
+				for _, t := range vs.Server.MessageBroker.Types {
+					typesSet[t] = true
+				}
+				for name := range vs.Server.Plugins.Broker {
+					if !typesSet[name] {
+						log.Printf("WARNING: Broker plugin %q is loaded but not listed in message_broker.types — it will NOT participate in message routing", name)
+					}
+				}
+			}
+
 			if vs.Server.MessageBroker != nil && vs.Server.MessageBroker.Enabled {
 				var namedBuses []eventbus.NamedEventBus
 

--- a/cmd/server_foreground_autoheal_test.go
+++ b/cmd/server_foreground_autoheal_test.go
@@ -1,0 +1,227 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// autoPopulateBrokerTypes replicates the auto-populate logic from
+// server_foreground.go so it can be tested in isolation.
+func autoPopulateBrokerTypes(vs *config.VersionedSettings) {
+	if vs.Server == nil || vs.Server.Plugins == nil || vs.Server.MessageBroker == nil {
+		return
+	}
+	if vs.Server.MessageBroker.Enabled && len(vs.Server.MessageBroker.Types) == 0 && len(vs.Server.Plugins.Broker) > 0 {
+		for name := range vs.Server.Plugins.Broker {
+			vs.Server.MessageBroker.Types = append(vs.Server.MessageBroker.Types, name)
+		}
+	}
+}
+
+// pluginsNotInTypes returns the names of broker plugins that are loaded
+// but not listed in message_broker.types.
+func pluginsNotInTypes(vs *config.VersionedSettings) []string {
+	if vs.Server == nil || vs.Server.Plugins == nil || vs.Server.MessageBroker == nil {
+		return nil
+	}
+	if !vs.Server.MessageBroker.Enabled || len(vs.Server.MessageBroker.Types) == 0 {
+		return nil
+	}
+	typesSet := make(map[string]bool, len(vs.Server.MessageBroker.Types))
+	for _, t := range vs.Server.MessageBroker.Types {
+		typesSet[t] = true
+	}
+	var missing []string
+	for name := range vs.Server.Plugins.Broker {
+		if !typesSet[name] {
+			missing = append(missing, name)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+func TestAutoPopulateBrokerTypes_EmptyTypesWithPlugins(t *testing.T) {
+	vs := &config.VersionedSettings{
+		Server: &config.V1ServerConfig{
+			MessageBroker: &config.V1MessageBrokerConfig{
+				Enabled: true,
+				Types:   nil, // empty
+			},
+			Plugins: &config.V1PluginsConfig{
+				Broker: map[string]config.V1PluginEntry{
+					"discord": {Path: "/usr/bin/scion-plugin-discord"},
+				},
+			},
+		},
+	}
+
+	autoPopulateBrokerTypes(vs)
+
+	if len(vs.Server.MessageBroker.Types) != 1 {
+		t.Fatalf("expected 1 type, got %d", len(vs.Server.MessageBroker.Types))
+	}
+	if vs.Server.MessageBroker.Types[0] != "discord" {
+		t.Errorf("expected type 'discord', got %q", vs.Server.MessageBroker.Types[0])
+	}
+}
+
+func TestAutoPopulateBrokerTypes_MultiplePlugins(t *testing.T) {
+	vs := &config.VersionedSettings{
+		Server: &config.V1ServerConfig{
+			MessageBroker: &config.V1MessageBrokerConfig{
+				Enabled: true,
+				Types:   []string{}, // explicitly empty
+			},
+			Plugins: &config.V1PluginsConfig{
+				Broker: map[string]config.V1PluginEntry{
+					"discord":  {Path: "/usr/bin/scion-plugin-discord"},
+					"telegram": {Path: "/usr/bin/scion-plugin-telegram"},
+				},
+			},
+		},
+	}
+
+	autoPopulateBrokerTypes(vs)
+
+	if len(vs.Server.MessageBroker.Types) != 2 {
+		t.Fatalf("expected 2 types, got %d", len(vs.Server.MessageBroker.Types))
+	}
+
+	sort.Strings(vs.Server.MessageBroker.Types)
+	if vs.Server.MessageBroker.Types[0] != "discord" || vs.Server.MessageBroker.Types[1] != "telegram" {
+		t.Errorf("unexpected types: %v", vs.Server.MessageBroker.Types)
+	}
+}
+
+func TestAutoPopulateBrokerTypes_NoOpWhenTypesAlreadySet(t *testing.T) {
+	vs := &config.VersionedSettings{
+		Server: &config.V1ServerConfig{
+			MessageBroker: &config.V1MessageBrokerConfig{
+				Enabled: true,
+				Types:   []string{"discord"},
+			},
+			Plugins: &config.V1PluginsConfig{
+				Broker: map[string]config.V1PluginEntry{
+					"discord":  {Path: "/usr/bin/scion-plugin-discord"},
+					"telegram": {Path: "/usr/bin/scion-plugin-telegram"},
+				},
+			},
+		},
+	}
+
+	autoPopulateBrokerTypes(vs)
+
+	// Should not modify — types was already populated.
+	if len(vs.Server.MessageBroker.Types) != 1 {
+		t.Fatalf("expected 1 type (unchanged), got %d", len(vs.Server.MessageBroker.Types))
+	}
+	if vs.Server.MessageBroker.Types[0] != "discord" {
+		t.Errorf("expected type 'discord', got %q", vs.Server.MessageBroker.Types[0])
+	}
+}
+
+func TestAutoPopulateBrokerTypes_NoOpWhenNotEnabled(t *testing.T) {
+	vs := &config.VersionedSettings{
+		Server: &config.V1ServerConfig{
+			MessageBroker: &config.V1MessageBrokerConfig{
+				Enabled: false,
+				Types:   nil,
+			},
+			Plugins: &config.V1PluginsConfig{
+				Broker: map[string]config.V1PluginEntry{
+					"discord": {Path: "/usr/bin/scion-plugin-discord"},
+				},
+			},
+		},
+	}
+
+	autoPopulateBrokerTypes(vs)
+
+	if len(vs.Server.MessageBroker.Types) != 0 {
+		t.Fatalf("expected 0 types when broker not enabled, got %d", len(vs.Server.MessageBroker.Types))
+	}
+}
+
+func TestAutoPopulateBrokerTypes_NoOpWhenNoPlugins(t *testing.T) {
+	vs := &config.VersionedSettings{
+		Server: &config.V1ServerConfig{
+			MessageBroker: &config.V1MessageBrokerConfig{
+				Enabled: true,
+				Types:   nil,
+			},
+			Plugins: &config.V1PluginsConfig{
+				Broker: map[string]config.V1PluginEntry{},
+			},
+		},
+	}
+
+	autoPopulateBrokerTypes(vs)
+
+	if len(vs.Server.MessageBroker.Types) != 0 {
+		t.Fatalf("expected 0 types when no plugins, got %d", len(vs.Server.MessageBroker.Types))
+	}
+}
+
+func TestPluginsNotInTypes_WarnsOnMissingPlugin(t *testing.T) {
+	vs := &config.VersionedSettings{
+		Server: &config.V1ServerConfig{
+			MessageBroker: &config.V1MessageBrokerConfig{
+				Enabled: true,
+				Types:   []string{"discord"},
+			},
+			Plugins: &config.V1PluginsConfig{
+				Broker: map[string]config.V1PluginEntry{
+					"discord":  {Path: "/usr/bin/scion-plugin-discord"},
+					"telegram": {Path: "/usr/bin/scion-plugin-telegram"},
+				},
+			},
+		},
+	}
+
+	missing := pluginsNotInTypes(vs)
+	if len(missing) != 1 {
+		t.Fatalf("expected 1 missing plugin, got %d: %v", len(missing), missing)
+	}
+	if missing[0] != "telegram" {
+		t.Errorf("expected 'telegram', got %q", missing[0])
+	}
+}
+
+func TestPluginsNotInTypes_AllPresent(t *testing.T) {
+	vs := &config.VersionedSettings{
+		Server: &config.V1ServerConfig{
+			MessageBroker: &config.V1MessageBrokerConfig{
+				Enabled: true,
+				Types:   []string{"discord", "telegram"},
+			},
+			Plugins: &config.V1PluginsConfig{
+				Broker: map[string]config.V1PluginEntry{
+					"discord":  {},
+					"telegram": {},
+				},
+			},
+		},
+	}
+
+	missing := pluginsNotInTypes(vs)
+	if len(missing) != 0 {
+		t.Errorf("expected no missing plugins, got %v", missing)
+	}
+}

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -146,6 +146,8 @@ type DiscordBroker struct {
 	sendQueue *SendQueue
 	webhooks  *WebhookManager
 
+	gatewayConnected bool // set true in handleReady, false on disconnect
+
 	threadParents map[string]string // channelID -> parentID (cached thread lookups)
 
 	agentCacheTTL  time.Duration
@@ -757,7 +759,8 @@ func (b *DiscordBroker) HealthCheck() (*plugin.HealthStatus, error) {
 	}
 
 	details := map[string]string{
-		"subscriptions": fmt.Sprintf("%d", len(b.subs)),
+		"subscriptions":     fmt.Sprintf("%d", len(b.subs)),
+		"gateway_connected": fmt.Sprintf("%v", b.gatewayConnected),
 	}
 
 	if b.botUser != nil {
@@ -766,6 +769,15 @@ func (b *DiscordBroker) HealthCheck() (*plugin.HealthStatus, error) {
 	}
 	if b.hubURL != "" {
 		details["hub_url"] = b.hubURL
+	}
+
+	// Report degraded when gateway is disconnected but subscriptions are active.
+	if !b.gatewayConnected && len(b.subs) > 0 {
+		return &plugin.HealthStatus{
+			Status:  "degraded",
+			Message: "gateway not connected (subscriptions active but no gateway session)",
+			Details: details,
+		}, nil
 	}
 
 	return &plugin.HealthStatus{
@@ -787,6 +799,7 @@ func (b *DiscordBroker) startGateway() error {
 
 	// Register gateway event handlers.
 	session.AddHandler(b.handleReady)
+	session.AddHandler(b.handleDisconnect)
 	session.AddHandler(b.handleGuildCreate)
 	session.AddHandler(b.handleGuildDelete)
 	session.AddHandler(b.handleMessageCreate)
@@ -807,6 +820,7 @@ func (b *DiscordBroker) startGateway() error {
 func (b *DiscordBroker) handleReady(_ *discordgo.Session, r *discordgo.Ready) {
 	b.mu.Lock()
 	b.botUser = r.User
+	b.gatewayConnected = true
 	commands := b.commands
 	b.mu.Unlock()
 
@@ -823,6 +837,15 @@ func (b *DiscordBroker) handleReady(_ *discordgo.Session, r *discordgo.Ready) {
 			b.log.Error("Failed to register slash commands", "error", err)
 		}
 	}
+}
+
+// handleDisconnect is called when the bot disconnects from the Discord gateway.
+func (b *DiscordBroker) handleDisconnect(_ *discordgo.Session, _ *discordgo.Disconnect) {
+	b.mu.Lock()
+	b.gatewayConnected = false
+	b.mu.Unlock()
+
+	b.log.Warn("Discord gateway disconnected")
 }
 
 // handleGuildCreate is called when the bot joins a guild or when guild

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -398,3 +398,76 @@ func TestResolveRecipientChannels(t *testing.T) {
 		assert.Len(t, channels, 1)
 	})
 }
+
+// --- HealthCheck gateway_connected tests ---
+
+func TestHealthCheck_GatewayConnected(t *testing.T) {
+	b := &DiscordBroker{
+		log:              discardLogger(),
+		session:          &discordgo.Session{},
+		subs:             map[string]bool{"test.>": true},
+		sentIDs:          make(map[string]time.Time),
+		gatewayConnected: true,
+	}
+
+	status, err := b.HealthCheck()
+	require.NoError(t, err)
+	assert.Equal(t, "healthy", status.Status)
+	assert.Equal(t, "discord bot operational", status.Message)
+	assert.Equal(t, "true", status.Details["gateway_connected"])
+}
+
+func TestHealthCheck_GatewayDisconnectedWithSubs(t *testing.T) {
+	b := &DiscordBroker{
+		log:              discardLogger(),
+		session:          &discordgo.Session{},
+		subs:             map[string]bool{"test.>": true},
+		sentIDs:          make(map[string]time.Time),
+		gatewayConnected: false,
+	}
+
+	status, err := b.HealthCheck()
+	require.NoError(t, err)
+	assert.Equal(t, "degraded", status.Status)
+	assert.Contains(t, status.Message, "gateway not connected")
+	assert.Equal(t, "false", status.Details["gateway_connected"])
+}
+
+func TestHealthCheck_GatewayDisconnectedNoSubs(t *testing.T) {
+	b := &DiscordBroker{
+		log:              discardLogger(),
+		session:          &discordgo.Session{},
+		subs:             map[string]bool{},
+		sentIDs:          make(map[string]time.Time),
+		gatewayConnected: false,
+	}
+
+	status, err := b.HealthCheck()
+	require.NoError(t, err)
+	// No subscriptions → no degraded status even if gateway disconnected.
+	assert.Equal(t, "healthy", status.Status)
+	assert.Equal(t, "false", status.Details["gateway_connected"])
+}
+
+func TestHealthCheck_Closed(t *testing.T) {
+	b := &DiscordBroker{
+		log:    discardLogger(),
+		closed: true,
+	}
+
+	status, err := b.HealthCheck()
+	require.NoError(t, err)
+	assert.Equal(t, "unhealthy", status.Status)
+}
+
+func TestHealthCheck_NoSession(t *testing.T) {
+	b := &DiscordBroker{
+		log:     discardLogger(),
+		session: nil,
+	}
+
+	status, err := b.HealthCheck()
+	require.NoError(t, err)
+	assert.Equal(t, "degraded", status.Status)
+	assert.Contains(t, status.Message, "not configured")
+}

--- a/pkg/eventbus/fanout.go
+++ b/pkg/eventbus/fanout.go
@@ -268,6 +268,18 @@ func (f *FanOutEventBus) replaySubscriptions(bus NamedEventBus) {
 	}
 }
 
+// HasSpoke reports whether a spoke with the given name exists.
+func (f *FanOutEventBus) HasSpoke(name string) bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	for _, nb := range f.buses {
+		if nb.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 // RemoveSpoke removes a spoke by name and closes it.
 func (f *FanOutEventBus) RemoveSpoke(name string) error {
 	if name == InProcessBusName {

--- a/pkg/eventbus/fanout_test.go
+++ b/pkg/eventbus/fanout_test.go
@@ -470,3 +470,55 @@ func TestFanOutEventBus_Subscribe(t *testing.T) {
 		t.Fatalf("unexpected unsubscribe error: %v", err)
 	}
 }
+
+func TestFanOutEventBus_HasSpoke(t *testing.T) {
+	b1 := newStubEventBus()
+	b2 := newStubEventBus()
+
+	fan := NewFanOutEventBus([]NamedEventBus{
+		{Name: "discord", Bus: b1},
+		{Name: "inprocess", Bus: b2},
+	}, slog.Default())
+
+	if !fan.HasSpoke("discord") {
+		t.Error("expected HasSpoke('discord') = true")
+	}
+	if !fan.HasSpoke("inprocess") {
+		t.Error("expected HasSpoke('inprocess') = true")
+	}
+	if fan.HasSpoke("telegram") {
+		t.Error("expected HasSpoke('telegram') = false")
+	}
+	if fan.HasSpoke("") {
+		t.Error("expected HasSpoke('') = false")
+	}
+}
+
+func TestFanOutEventBus_HasSpokeAfterAddRemove(t *testing.T) {
+	b1 := newStubEventBus()
+	fan := NewFanOutEventBus([]NamedEventBus{
+		{Name: "inprocess", Bus: b1},
+	}, slog.Default())
+
+	// Initially no discord spoke.
+	if fan.HasSpoke("discord") {
+		t.Fatal("expected HasSpoke('discord') = false before add")
+	}
+
+	// Add a spoke.
+	b2 := newStubEventBus()
+	if err := fan.AddSpoke(NamedEventBus{Name: "discord", Bus: b2}); err != nil {
+		t.Fatalf("AddSpoke failed: %v", err)
+	}
+	if !fan.HasSpoke("discord") {
+		t.Fatal("expected HasSpoke('discord') = true after add")
+	}
+
+	// Remove the spoke.
+	if err := fan.RemoveSpoke("discord"); err != nil {
+		t.Fatalf("RemoveSpoke failed: %v", err)
+	}
+	if fan.HasSpoke("discord") {
+		t.Fatal("expected HasSpoke('discord') = false after remove")
+	}
+}

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -17,6 +17,7 @@ package hub
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -622,7 +623,38 @@ func (s *Server) handleRestartIntegration(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	// Post-restart validation: check that the plugin is wired into the FanOut.
+	warnings := s.validateIntegrationWiring(name)
+
+	response := map[string]interface{}{
+		"status": "ok",
+	}
+	if len(warnings) > 0 {
+		response["warnings"] = warnings
+	}
+
+	writeJSON(w, http.StatusOK, response)
+}
+
+// validateIntegrationWiring checks that the named plugin is wired into the
+// FanOut event bus as a spoke. Returns warnings for any issues found.
+func (s *Server) validateIntegrationWiring(name string) []string {
+	var warnings []string
+
+	proxy := s.GetMessageBrokerProxy()
+	if proxy == nil {
+		warnings = append(warnings, "message broker not initialized")
+		return warnings
+	}
+	fanout, ok := proxy.bus.(*eventbus.FanOutEventBus)
+	if !ok {
+		return warnings
+	}
+	if !fanout.HasSpoke(name) {
+		warnings = append(warnings, fmt.Sprintf("plugin %q is not wired into the FanOut event bus — messages will not be routed", name))
+	}
+
+	return warnings
 }
 
 func (s *Server) handleIntegrationHealth(w http.ResponseWriter, r *http.Request, name string) {

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -488,6 +489,102 @@ func TestRestartIntegration_OK(t *testing.T) {
 
 	if len(mgr.replaceConfigCalls) != 1 || mgr.replaceConfigCalls[0] != "telegram" {
 		t.Errorf("expected ReplaceBrokerConfig call for telegram, got %v", mgr.replaceConfigCalls)
+	}
+}
+
+func TestRestartIntegration_WithSpokeWired(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["discord"] = map[string]string{}
+
+	// Create a FanOutEventBus with a discord spoke.
+	inproc := eventbus.NewInProcessEventBus(slog.Default())
+	discordBus := eventbus.NewInProcessEventBus(slog.Default())
+	fanout := eventbus.NewFanOutEventBus([]eventbus.NamedEventBus{
+		{Name: "inprocess", Bus: inproc},
+		{Name: "discord", Bus: discordBus},
+	}, slog.Default())
+
+	proxy := NewMessageBrokerProxy(fanout, nil, nil, nil, slog.Default())
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+	srv.SetMessageBrokerProxy(proxy)
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations/discord/restart", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp["status"] != "ok" {
+		t.Errorf("expected status 'ok', got %v", resp["status"])
+	}
+	// No warnings expected when spoke is wired.
+	if _, hasWarnings := resp["warnings"]; hasWarnings {
+		t.Errorf("expected no warnings when spoke is wired, got %v", resp["warnings"])
+	}
+}
+
+func TestRestartIntegration_WithoutSpokeWired(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["discord"] = map[string]string{}
+
+	// Create a FanOutEventBus WITHOUT a discord spoke.
+	inproc := eventbus.NewInProcessEventBus(slog.Default())
+	fanout := eventbus.NewFanOutEventBus([]eventbus.NamedEventBus{
+		{Name: "inprocess", Bus: inproc},
+	}, slog.Default())
+
+	proxy := NewMessageBrokerProxy(fanout, nil, nil, nil, slog.Default())
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+	srv.SetMessageBrokerProxy(proxy)
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations/discord/restart", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp["status"] != "ok" {
+		t.Errorf("expected status 'ok', got %v", resp["status"])
+	}
+	// Warnings expected when spoke is NOT wired.
+	warnings, ok := resp["warnings"].([]interface{})
+	if !ok || len(warnings) == 0 {
+		t.Fatalf("expected warnings when spoke is not wired, got %v", resp["warnings"])
+	}
+	warning := fmt.Sprintf("%v", warnings[0])
+	if !strings.Contains(warning, "not wired") {
+		t.Errorf("expected warning about spoke not being wired, got %q", warning)
+	}
+}
+
+func TestValidateIntegrationWiring_NoProxy(t *testing.T) {
+	srv := &Server{}
+	warnings := srv.validateIntegrationWiring("discord")
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d", len(warnings))
+	}
+	if !strings.Contains(warnings[0], "message broker not initialized") {
+		t.Errorf("unexpected warning: %s", warnings[0])
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements Phases 1-3 of the settings auto-heal design (closes #508):

- **Phase 1:** Auto-populate `message_broker.types` from plugin list when broker is enabled but types is empty. Logs NOTICE on auto-populate and WARNING for plugins loaded but not in types.
- **Phase 2:** Add `gatewayConnected` field to Discord broker HealthCheck. Reports `degraded` status when gateway is disconnected but subscriptions are active. Adds disconnect handler.
- **Phase 3:** Add `HasSpoke(name)` to FanOutEventBus. `handleRestartIntegration` now validates spoke wiring post-restart and returns warnings when issues are detected.

## Test plan

- [x] Phase 1: 7 unit tests for auto-populate with empty/non-empty types, enabled/disabled broker, with/without plugins
- [x] Phase 2: 5 unit tests for HealthCheck with gateway connected/disconnected, with/without subscriptions
- [x] Phase 3: 3 tests for HasSpoke and restart wiring validation
- [x] All pre-existing tests pass