### PR TITLE
fix: recover broker ID from DB on restart, re-assign orphaned agents (#509)

### DIFF
--- a/cmd/server_broker.go
+++ b/cmd/server_broker.go
@@ -172,7 +172,9 @@ func registerGlobalProjectAndBroker(ctx context.Context, s store.Store, brokerID
 		// Mark stale broker records as offline so they don't appear active.
 		for oldID := range oldBrokerIDs {
 			if err := s.MarkBrokerOffline(ctx, oldID); err != nil {
-				log.Printf("Warning: failed to mark broker %s offline: %v", oldID, err)
+				if err != store.ErrNotFound {
+					log.Printf("Warning: failed to mark broker %s offline: %v", oldID, err)
+				}
 			} else {
 				log.Printf("NOTICE: marked stale broker %s as offline", oldID)
 			}

--- a/cmd/server_broker.go
+++ b/cmd/server_broker.go
@@ -136,6 +136,22 @@ func registerGlobalProjectAndBroker(ctx context.Context, s store.Store, brokerID
 		}
 	}
 
+	// Re-assign agents orphaned by broker ID changes.
+	// An agent is orphaned when its RuntimeBrokerID points to a broker that
+	// is offline/missing AND the agent is not in a terminal state.
+	// Guard: agents under active remote brokers are NOT reassigned.
+	orphaned, orphanErr := s.FindOrphanedAgents(ctx, brokerID)
+	if orphanErr != nil {
+		log.Printf("Warning: failed to query orphaned agents: %v", orphanErr)
+	} else if len(orphaned) > 0 {
+		reassigned, reassignErr := s.ReassignAgentsToBroker(ctx, orphaned, brokerID)
+		if reassignErr != nil {
+			log.Printf("Warning: failed to re-assign %d orphaned agent(s): %v", len(orphaned), reassignErr)
+		} else {
+			log.Printf("NOTICE: re-assigned %d orphaned agent(s) to broker %s", reassigned, brokerID)
+		}
+	}
+
 	// Now that the runtime broker exists, set it as the default for the project
 	if projectNeedsDefaultBroker {
 		globalProject.DefaultRuntimeBrokerID = brokerID

--- a/cmd/server_broker.go
+++ b/cmd/server_broker.go
@@ -144,11 +144,38 @@ func registerGlobalProjectAndBroker(ctx context.Context, s store.Store, brokerID
 	if orphanErr != nil {
 		log.Printf("Warning: failed to query orphaned agents: %v", orphanErr)
 	} else if len(orphaned) > 0 {
+		// Collect distinct old broker IDs for downstream repair.
+		oldBrokerIDs := make(map[string]struct{})
+		for _, a := range orphaned {
+			if a.RuntimeBrokerID != "" && a.RuntimeBrokerID != brokerID {
+				oldBrokerIDs[a.RuntimeBrokerID] = struct{}{}
+			}
+		}
+
 		reassigned, reassignErr := s.ReassignAgentsToBroker(ctx, orphaned, brokerID)
 		if reassignErr != nil {
 			log.Printf("Warning: failed to re-assign %d orphaned agent(s): %v", len(orphaned), reassignErr)
 		} else {
 			log.Printf("NOTICE: re-assigned %d orphaned agent(s) to broker %s", reassigned, brokerID)
+		}
+
+		// Update projects whose default broker points to an offline/missing broker.
+		for oldID := range oldBrokerIDs {
+			updated, err := s.ReassignProjectBroker(ctx, oldID, brokerID)
+			if err != nil {
+				log.Printf("Warning: failed to reassign projects from broker %s: %v", oldID, err)
+			} else if updated > 0 {
+				log.Printf("NOTICE: updated %d project(s) default broker from %s to %s", updated, oldID, brokerID)
+			}
+		}
+
+		// Mark stale broker records as offline so they don't appear active.
+		for oldID := range oldBrokerIDs {
+			if err := s.MarkBrokerOffline(ctx, oldID); err != nil {
+				log.Printf("Warning: failed to mark broker %s offline: %v", oldID, err)
+			} else {
+				log.Printf("NOTICE: marked stale broker %s as offline", oldID)
+			}
 		}
 	}
 

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2274,7 +2274,10 @@ func resolveBrokerID(ctx context.Context, cfg *config.GlobalConfig, settings *co
 
 	// Recover from DB: if exactly one embedded broker exists, reuse its ID.
 	if brokerID == "" && s != nil {
-		if embedded, err := s.FindEmbeddedBroker(ctx); err == nil && embedded != nil {
+		embedded, err := s.FindEmbeddedBroker(ctx)
+		if err != nil {
+			log.Printf("Warning: failed to query database for broker ID recovery: %v", err)
+		} else if embedded != nil {
 			brokerID = embedded.ID
 			log.Printf("NOTICE: recovered broker ID %s from database (single embedded broker)", brokerID)
 			// Persist so we don't re-recover on next boot (writes to both legacy

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1879,7 +1879,7 @@ func startRuntimeBroker(ctx context.Context, cmd *cobra.Command, cfg *config.Glo
 			return fmt.Errorf("stateless Cloud Run broker requires a derivable broker ID: %w", deriveErr)
 		}
 	}
-	brokerID := resolveBrokerID(cfg, settings, vsBroker, globalDir, defaultBrokerID)
+	brokerID := resolveBrokerID(ctx, cfg, settings, vsBroker, globalDir, defaultBrokerID, s)
 
 	// Resolve broker name
 	brokerName := resolveBrokerName(cfg, settings, vsBroker)
@@ -2254,7 +2254,10 @@ func initPluginManager(ctx context.Context, secretBackend secret.SecretBackend) 
 var cloudRunLogicalBrokerNamespace = uuid.MustParse("c10f7a0a-6f03-5f9f-8d52-1d98b0fdb001")
 
 // resolveBrokerID determines the broker ID from various sources.
-func resolveBrokerID(cfg *config.GlobalConfig, settings *config.Settings, vsBroker *config.V1BrokerConfig, globalDir, defaultBrokerID string) string {
+// It checks (in order): versioned settings, legacy settings, global config,
+// deterministic Cloud Run ID, DB recovery (single embedded broker), and
+// finally generates a new UUID as a last resort.
+func resolveBrokerID(ctx context.Context, cfg *config.GlobalConfig, settings *config.Settings, vsBroker *config.V1BrokerConfig, globalDir, defaultBrokerID string, s store.Store) string {
 	var brokerID string
 	if vsBroker != nil && vsBroker.BrokerID != "" {
 		brokerID = vsBroker.BrokerID
@@ -2268,6 +2271,17 @@ func resolveBrokerID(cfg *config.GlobalConfig, settings *config.Settings, vsBrok
 		log.Printf("Using deterministic logical broker ID: %s", defaultBrokerID)
 		return defaultBrokerID
 	}
+
+	// Recover from DB: if exactly one embedded broker exists, reuse its ID.
+	if brokerID == "" && s != nil {
+		if embedded, err := s.FindEmbeddedBroker(ctx); err == nil && embedded != nil {
+			brokerID = embedded.ID
+			log.Printf("NOTICE: recovered broker ID %s from database (single embedded broker)", brokerID)
+			// Persist so we don't re-recover on next boot
+			_ = config.UpdateSetting(globalDir, "hub.brokerId", brokerID, true)
+		}
+	}
+
 	if brokerID == "" {
 		brokerID = api.NewUUID()
 		if err := config.UpdateSetting(globalDir, "hub.brokerId", brokerID, true); err != nil {

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2277,8 +2277,11 @@ func resolveBrokerID(ctx context.Context, cfg *config.GlobalConfig, settings *co
 		if embedded, err := s.FindEmbeddedBroker(ctx); err == nil && embedded != nil {
 			brokerID = embedded.ID
 			log.Printf("NOTICE: recovered broker ID %s from database (single embedded broker)", brokerID)
-			// Persist so we don't re-recover on next boot
-			_ = config.UpdateSetting(globalDir, "hub.brokerId", brokerID, true)
+			// Persist so we don't re-recover on next boot (writes to both legacy
+			// hub.brokerId and versioned server.broker.broker_id via UpdateSetting).
+			if err := config.UpdateSetting(globalDir, "hub.brokerId", brokerID, true); err != nil {
+				log.Printf("Warning: failed to persist recovered broker ID to settings: %v", err)
+			}
 		}
 	}
 

--- a/cmd/server_foreground_broker_test.go
+++ b/cmd/server_foreground_broker_test.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"context"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
@@ -55,7 +56,7 @@ func TestResolveBrokerIDPrefersConfiguredIDOverDefault(t *testing.T) {
 		Hub: &config.HubClientConfig{BrokerID: "configured-broker"},
 	}
 
-	got := resolveBrokerID(cfg, settings, nil, t.TempDir(), "cloudrun-default")
+	got := resolveBrokerID(context.Background(), cfg, settings, nil, t.TempDir(), "cloudrun-default", nil)
 
 	assert.Equal(t, "configured-broker", got)
 }

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -843,6 +843,9 @@ func (s *AgentStore) ReassignAgentsToBroker(ctx context.Context, agents []*store
 		}
 		ids = append(ids, uid)
 	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
 
 	affected, err := s.client.Agent.Update().
 		Where(agent.IDIn(ids...)).
@@ -875,11 +878,13 @@ func (s *AgentStore) ReassignProjectBroker(ctx context.Context, oldBrokerID, new
 		Where(runtimebroker.IDEQ(oldUID)).
 		Select(runtimebroker.FieldStatus).
 		Only(ctx)
+	if err != nil && !ent.IsNotFound(err) {
+		return 0, err
+	}
 	if err == nil && oldBroker.Status == store.BrokerStatusOnline {
 		// Old broker is still online — do not reassign its projects.
 		return 0, nil
 	}
-	// err != nil means broker not found (missing) — safe to reassign.
 
 	affected, err := s.client.Project.Update().
 		Where(project.DefaultRuntimeBrokerIDEQ(oldBrokerID)).

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -17,6 +17,7 @@ package entadapter
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
 
@@ -777,9 +778,9 @@ func parseUUIDList(ids []string) []uuid.UUID {
 // currentBrokerID are excluded so that a running multi-broker setup does not
 // have its agents reassigned.
 func (s *AgentStore) FindOrphanedAgents(ctx context.Context, currentBrokerID string) ([]*store.Agent, error) {
-	currentUID, err := uuid.Parse(currentBrokerID)
-	if err != nil {
-		return nil, err
+	parsedID, parseErr := uuid.Parse(currentBrokerID)
+	if parseErr != nil {
+		return nil, fmt.Errorf("invalid currentBrokerID %q: %w", currentBrokerID, parseErr)
 	}
 
 	// Collect IDs of all online brokers (excluding the current one, which may
@@ -787,7 +788,7 @@ func (s *AgentStore) FindOrphanedAgents(ctx context.Context, currentBrokerID str
 	onlineBrokers, err := s.client.RuntimeBroker.Query().
 		Where(
 			runtimebroker.StatusEQ(store.BrokerStatusOnline),
-			runtimebroker.IDNEQ(currentUID),
+			runtimebroker.IDNEQ(parsedID),
 		).
 		Select(runtimebroker.FieldID).
 		All(ctx)

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/ent"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/agent"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/predicate"
+	"github.com/GoogleCloudPlatform/scion/pkg/ent/project"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/runtimebroker"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
@@ -846,6 +847,43 @@ func (s *AgentStore) ReassignAgentsToBroker(ctx context.Context, agents []*store
 	affected, err := s.client.Agent.Update().
 		Where(agent.IDIn(ids...)).
 		SetRuntimeBrokerID(brokerID).
+		Save(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return affected, nil
+}
+
+// ReassignProjectBroker updates projects whose DefaultRuntimeBrokerID matches
+// oldBrokerID to point to newBrokerID. It applies the same multi-broker safety
+// guard as FindOrphanedAgents: the old broker must be offline or missing — if
+// it is still online, no projects are updated (it's a legitimate remote
+// broker). Returns the number of projects updated.
+func (s *AgentStore) ReassignProjectBroker(ctx context.Context, oldBrokerID, newBrokerID string) (int, error) {
+	if oldBrokerID == newBrokerID {
+		return 0, nil
+	}
+
+	// Safety guard: check if the old broker is still online. If so, it is a
+	// legitimate remote broker and its projects must not be touched.
+	oldUID, err := uuid.Parse(oldBrokerID)
+	if err != nil {
+		return 0, fmt.Errorf("invalid oldBrokerID %q: %w", oldBrokerID, err)
+	}
+
+	oldBroker, err := s.client.RuntimeBroker.Query().
+		Where(runtimebroker.IDEQ(oldUID)).
+		Select(runtimebroker.FieldStatus).
+		Only(ctx)
+	if err == nil && oldBroker.Status == store.BrokerStatusOnline {
+		// Old broker is still online — do not reassign its projects.
+		return 0, nil
+	}
+	// err != nil means broker not found (missing) — safe to reassign.
+
+	affected, err := s.client.Project.Update().
+		Where(project.DefaultRuntimeBrokerIDEQ(oldBrokerID)).
+		SetDefaultRuntimeBrokerID(newBrokerID).
 		Save(ctx)
 	if err != nil {
 		return 0, err

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -777,12 +777,17 @@ func parseUUIDList(ids []string) []uuid.UUID {
 // currentBrokerID are excluded so that a running multi-broker setup does not
 // have its agents reassigned.
 func (s *AgentStore) FindOrphanedAgents(ctx context.Context, currentBrokerID string) ([]*store.Agent, error) {
+	currentUID, err := uuid.Parse(currentBrokerID)
+	if err != nil {
+		return nil, err
+	}
+
 	// Collect IDs of all online brokers (excluding the current one, which may
 	// not be stamped online yet during startup).
 	onlineBrokers, err := s.client.RuntimeBroker.Query().
 		Where(
 			runtimebroker.StatusEQ(store.BrokerStatusOnline),
-			runtimebroker.IDNEQ(uuid.MustParse(currentBrokerID)),
+			runtimebroker.IDNEQ(currentUID),
 		).
 		Select(runtimebroker.FieldID).
 		All(ctx)
@@ -804,7 +809,7 @@ func (s *AgentStore) FindOrphanedAgents(ctx context.Context, currentBrokerID str
 	rows, err := s.client.Agent.Query().
 		Where(
 			agent.RuntimeBrokerIDNotIn(excludeIDs...),
-			agent.RuntimeBrokerIDNEQ(""),   // Must have a broker assignment
+			agent.RuntimeBrokerIDNEQ(""),        // Must have a broker assignment
 			agent.PhaseNotIn(terminalPhases...), // Not in a terminal state
 			agent.DeletedAtIsNil(),              // Not soft-deleted
 		).

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/ent"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/agent"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/predicate"
+	"github.com/GoogleCloudPlatform/scion/pkg/ent/runtimebroker"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
@@ -769,4 +770,79 @@ func parseUUIDList(ids []string) []uuid.UUID {
 		}
 	}
 	return out
+}
+
+// FindOrphanedAgents returns non-terminal agents whose RuntimeBrokerID
+// references a broker that is offline or does not exist. Agents assigned to
+// currentBrokerID are excluded so that a running multi-broker setup does not
+// have its agents reassigned.
+func (s *AgentStore) FindOrphanedAgents(ctx context.Context, currentBrokerID string) ([]*store.Agent, error) {
+	// Collect IDs of all online brokers (excluding the current one, which may
+	// not be stamped online yet during startup).
+	onlineBrokers, err := s.client.RuntimeBroker.Query().
+		Where(
+			runtimebroker.StatusEQ(store.BrokerStatusOnline),
+			runtimebroker.IDNEQ(uuid.MustParse(currentBrokerID)),
+		).
+		Select(runtimebroker.FieldID).
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the set of broker IDs whose agents must NOT be touched:
+	// the current broker + every online remote broker.
+	excludeIDs := make([]string, 0, len(onlineBrokers)+1)
+	excludeIDs = append(excludeIDs, currentBrokerID)
+	for _, b := range onlineBrokers {
+		excludeIDs = append(excludeIDs, b.ID.String())
+	}
+
+	// Terminal phases: agents in these states should not be reassigned.
+	terminalPhases := []string{"stopped", "error"}
+
+	rows, err := s.client.Agent.Query().
+		Where(
+			agent.RuntimeBrokerIDNotIn(excludeIDs...),
+			agent.RuntimeBrokerIDNEQ(""),   // Must have a broker assignment
+			agent.PhaseNotIn(terminalPhases...), // Not in a terminal state
+			agent.DeletedAtIsNil(),              // Not soft-deleted
+		).
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	agents := make([]*store.Agent, 0, len(rows))
+	for _, a := range rows {
+		sa := entAgentToStore(a)
+		agents = append(agents, sa)
+	}
+	return agents, nil
+}
+
+// ReassignAgentsToBroker bulk-updates the RuntimeBrokerID of the given agents
+// to the specified broker ID. Returns the number of agents actually updated.
+func (s *AgentStore) ReassignAgentsToBroker(ctx context.Context, agents []*store.Agent, brokerID string) (int, error) {
+	if len(agents) == 0 {
+		return 0, nil
+	}
+
+	ids := make([]uuid.UUID, 0, len(agents))
+	for _, a := range agents {
+		uid, err := uuid.Parse(a.ID)
+		if err != nil {
+			continue
+		}
+		ids = append(ids, uid)
+	}
+
+	affected, err := s.client.Agent.Update().
+		Where(agent.IDIn(ids...)).
+		SetRuntimeBrokerID(brokerID).
+		Save(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return affected, nil
 }

--- a/pkg/store/entadapter/project_store.go
+++ b/pkg/store/entadapter/project_store.go
@@ -21,6 +21,9 @@ import (
 	"strings"
 	"time"
 
+	"entgo.io/ent/dialect"
+	entsql "entgo.io/ent/dialect/sql"
+
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/agent"
@@ -804,6 +807,52 @@ func (s *ProjectStore) ListRuntimeBrokers(ctx context.Context, filter store.Runt
 		Items:      items,
 		TotalCount: totalCount,
 	}, nil
+}
+
+// FindEmbeddedBroker returns the single embedded broker if exactly one exists,
+// or nil if zero or multiple embedded brokers are found. "Embedded" means the
+// broker's labels JSON contains {"scion.io/broker-role": "embedded"}.
+// Used to recover the broker ID from the DB when settings are lost.
+func (s *ProjectStore) FindEmbeddedBroker(ctx context.Context) (*store.RuntimeBroker, error) {
+	brokers, err := s.client.RuntimeBroker.Query().
+		Where(brokerLabelContains("scion.io/broker-role", "embedded")).
+		Limit(2). // Only need to know if there's exactly one
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(brokers) != 1 {
+		return nil, nil // Zero or ambiguous — caller should generate a new ID
+	}
+	return entBrokerToStore(brokers[0]), nil
+}
+
+// brokerLabelContains returns an Ent predicate restricting results to runtime
+// brokers whose `labels` JSON object contains the given key-value pair.
+// This is the RuntimeBroker equivalent of the agent labelContains in dialect.go.
+func brokerLabelContains(key, value string) predicate.RuntimeBroker {
+	return func(s *entsql.Selector) {
+		col := s.C(runtimebroker.FieldLabels)
+		switch s.Dialect() {
+		case dialect.Postgres:
+			s.Where(entsql.P(func(b *entsql.Builder) {
+				b.WriteString(col).
+					WriteString(" @> ").
+					Arg(fmt.Sprintf(`{%q:%q}`, key, value)).
+					WriteString("::jsonb")
+			}))
+		default: // SQLite
+			s.Where(entsql.P(func(b *entsql.Builder) {
+				escapedKey := strings.ReplaceAll(key, `"`, `\"`)
+				b.WriteString("json_extract(").
+					WriteString(col).
+					WriteString(", ").
+					Arg(fmt.Sprintf(`$."%s"`, escapedKey)).
+					WriteString(") = ").
+					Arg(value)
+			}))
+		}
+	}
 }
 
 // UpdateRuntimeBrokerHeartbeat updates the broker's status and last-heartbeat

--- a/pkg/store/entadapter/project_store.go
+++ b/pkg/store/entadapter/project_store.go
@@ -1012,6 +1012,42 @@ func (s *ProjectStore) ReleaseAndMarkBrokerOffline(ctx context.Context, brokerID
 	return false, store.ErrVersionConflict
 }
 
+// MarkBrokerOffline sets a broker's status to offline. Used during startup
+// repair to ensure stale broker records that were never properly shut down are
+// explicitly marked offline. Uses the version-CAS loop for safe concurrency.
+// Returns ErrNotFound if the broker doesn't exist.
+func (s *ProjectStore) MarkBrokerOffline(ctx context.Context, brokerID string) error {
+	uid, err := parseUUID(brokerID)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	for attempt := 0; attempt < maxCASRetries; attempt++ {
+		cur, err := s.client.RuntimeBroker.Get(ctx, uid)
+		if err != nil {
+			return mapError(err)
+		}
+		// Already offline — nothing to do.
+		if cur.Status == store.BrokerStatusOffline {
+			return nil
+		}
+		affected, err := s.client.RuntimeBroker.Update().
+			Where(runtimebroker.IDEQ(uid), runtimebroker.LockVersionEQ(cur.LockVersion)).
+			SetStatus(store.BrokerStatusOffline).
+			SetUpdated(now).
+			AddLockVersion(1).
+			Save(ctx)
+		if err != nil {
+			return mapError(err)
+		}
+		if affected == 1 {
+			return nil
+		}
+	}
+	return store.ErrVersionConflict
+}
+
 // ReapStaleBrokerAffinity clears affinity (connected_hub_id/connected_session_id/
 // connected_at) for brokers that still claim affinity but whose last_heartbeat
 // is older than staleBefore. Does not change broker status.

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -185,6 +185,13 @@ type AgentStore interface {
 	// ReassignAgentsToBroker bulk-updates the RuntimeBrokerID of the given agents
 	// to the specified broker ID. Returns the number of agents updated.
 	ReassignAgentsToBroker(ctx context.Context, agents []*Agent, brokerID string) (int, error)
+
+	// ReassignProjectBroker updates projects whose DefaultRuntimeBrokerID
+	// matches oldBrokerID to point to newBrokerID. Only projects whose current
+	// default broker is offline or missing are updated — projects pointing to
+	// active remote brokers are left untouched. Returns the number of projects
+	// updated.
+	ReassignProjectBroker(ctx context.Context, oldBrokerID, newBrokerID string) (int, error)
 }
 
 // AgentFilter defines criteria for filtering agents.
@@ -370,6 +377,12 @@ type RuntimeBrokerStore interface {
 	// and whose connected_hub_id is not NULL (i.e. they still claim affinity).
 	// Returns the number of rows cleared. Does not change broker status.
 	ReapStaleBrokerAffinity(ctx context.Context, staleBefore time.Time) (cleared int, err error)
+
+	// MarkBrokerOffline sets a broker's status to offline. This is used during
+	// startup repair to ensure stale broker records that were never properly
+	// shut down are explicitly marked offline. Returns ErrNotFound if the
+	// broker doesn't exist. No-op if the broker is already offline.
+	MarkBrokerOffline(ctx context.Context, brokerID string) error
 }
 
 // RuntimeBrokerFilter defines criteria for filtering runtime brokers.

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -174,6 +174,17 @@ type AgentStore interface {
 	// whose activity is not a terminal sticky state or already stalled/offline.
 	// Returns the updated agent records for event publishing.
 	MarkStalledAgents(ctx context.Context, activityThreshold, heartbeatRecency time.Time) ([]Agent, error)
+
+	// FindOrphanedAgents returns agents whose RuntimeBrokerID references a broker
+	// that is offline or does not exist, and who are not in terminal states
+	// (stopped, error). Agents assigned to the given currentBrokerID are excluded.
+	// This guards against reassigning agents that belong to active remote brokers
+	// in multi-broker setups.
+	FindOrphanedAgents(ctx context.Context, currentBrokerID string) ([]*Agent, error)
+
+	// ReassignAgentsToBroker bulk-updates the RuntimeBrokerID of the given agents
+	// to the specified broker ID. Returns the number of agents updated.
+	ReassignAgentsToBroker(ctx context.Context, agents []*Agent, brokerID string) (int, error)
 }
 
 // AgentFilter defines criteria for filtering agents.
@@ -320,6 +331,12 @@ type RuntimeBrokerStore interface {
 
 	// ListRuntimeBrokers returns runtime brokers matching the filter criteria.
 	ListRuntimeBrokers(ctx context.Context, filter RuntimeBrokerFilter, opts ListOptions) (*ListResult[RuntimeBroker], error)
+
+	// FindEmbeddedBroker returns the single embedded broker if exactly one
+	// exists, or nil if zero or multiple embedded brokers are found (ambiguous).
+	// "Embedded" means the broker's labels contain {"scion.io/broker-role": "embedded"}.
+	// Used to recover broker ID from DB when settings are lost.
+	FindEmbeddedBroker(ctx context.Context) (*RuntimeBroker, error)
 
 	// UpdateRuntimeBrokerHeartbeat updates the last heartbeat and status.
 	UpdateRuntimeBrokerHeartbeat(ctx context.Context, id string, status string) error


### PR DESCRIPTION
## Summary

Implements broker ID stability and orphan recovery (closes #509):

- **Phase 4 — Stable broker ID:** When settings are lost/recreated, resolveBrokerID() now recovers the broker ID from the database before generating a new UUID.
- **Phase 5 — Orphan re-assignment:** On startup, agents assigned to offline/missing brokers are bulk-reassigned to the current broker. Multi-broker guard protects active remote brokers.
- **Additional:** Also updates projects.default_runtime_broker_id and marks old broker records offline (the third table found in live investigation)