### PR TITLE
feat: add per-thread default agents for Discord (closes #513)

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1039,13 +1039,23 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 		}
 	}
 
+	// Resolve effective default — thread override first, then channel fallback.
+	effectiveDefault := link.DefaultAgent
+	if parentID, isThread := b.resolveThreadParent(channelID); isThread {
+		if threadDefault, err := store.GetThreadDefault(ctx, parentID, channelID); err != nil {
+			b.log.Error("Failed to get thread default", "error", err)
+		} else if threadDefault != "" {
+			effectiveDefault = threadDefault
+		}
+	}
+
 	// Fallback: unaddressed text → default agent (if configured).
 	// Skip if the message @-mentions a non-bot Discord user — those are
 	// directed at humans, not the bot's default agent.
-	if len(targets) == 0 && link.DefaultAgent != "" && !hasNonBotMentions(m.Message, botUserID) {
+	if len(targets) == 0 && effectiveDefault != "" && !hasNonBotMentions(m.Message, botUserID) {
 		text := strings.TrimSpace(m.Content)
 		if text != "" && !strings.HasPrefix(text, "/") {
-			targets = []string{link.DefaultAgent}
+			targets = []string{effectiveDefault}
 		}
 	}
 

--- a/extras/scion-discord/internal/discord/callbacks.go
+++ b/extras/scion-discord/internal/discord/callbacks.go
@@ -152,7 +152,7 @@ func (h *CallbackHandler) handleSetupDefaultAgent(s *discordgo.Session, i *disco
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	link, _ := h.store.GetChannelLink(ctx, i.ChannelID)
+	link, _ := resolveChannelLink(ctx, s, h.store, i.ChannelID)
 	if link == nil {
 		h.respondUpdate(s, i, "Setup session expired. Please use `/scion setup` again.", nil)
 		return
@@ -177,12 +177,18 @@ func (h *CallbackHandler) handleSetupDefaultAgent(s *discordgo.Session, i *disco
 }
 
 // saveChannelLink persists a channel-to-project link.
+// If the interaction is in a thread, the link is saved against the parent channel.
 func (h *CallbackHandler) saveChannelLink(ctx context.Context, i *discordgo.InteractionCreate, projectID, projectSlug, agentSlug string) {
 	linkedBy := interactionUserID(i)
 	guildID := i.GuildID
 
+	channelID := i.ChannelID
+	if parentID := threadParentID(h.session, channelID); parentID != "" {
+		channelID = parentID
+	}
+
 	link := &ChannelLink{
-		ChannelID:          i.ChannelID,
+		ChannelID:          channelID,
 		GuildID:            guildID,
 		ProjectID:          projectID,
 		ProjectSlug:        projectSlug,
@@ -499,10 +505,12 @@ func (h *CallbackHandler) handleSettingsCallback(s *discordgo.Session, i *discor
 
 // handleDefaultCallback handles default agent selection buttons.
 // custom_id formats:
-//   - default:set:<agentSlug>  — set agent as default
-//   - default:none             — clear default agent
+//   - default:set:<agentSlug>             — set channel-level default
+//   - default:set:<agentSlug>:<threadID>  — set thread-level default
+//   - default:none                        — clear channel-level default
+//   - default:none:<threadID>             — clear thread-level default
 func (h *CallbackHandler) handleDefaultCallback(s *discordgo.Session, i *discordgo.InteractionCreate, customID string) {
-	parts := strings.SplitN(customID, ":", 3)
+	parts := strings.SplitN(customID, ":", 4)
 	if len(parts) < 2 {
 		h.log.Warn("Malformed default callback custom_id", "custom_id", customID)
 		return
@@ -520,14 +528,35 @@ func (h *CallbackHandler) handleDefaultCallback(s *discordgo.Session, i *discord
 	action := parts[1]
 	switch action {
 	case "none":
-		link.DefaultAgent = ""
-		if err := h.store.UpdateChannelLink(ctx, link); err != nil {
-			h.log.Error("Failed to clear default agent", "error", err)
-			h.respondUpdate(s, i, "Failed to clear default agent. Please try again.", nil)
-			return
+		// Check for thread ID: "default:none:<threadID>"
+		threadID := ""
+		if len(parts) >= 3 {
+			threadID = parts[2]
 		}
-		h.respondUpdate(s, i, "Default agent cleared for this channel.", nil)
-		h.log.Info("Default agent cleared via button", "channel_id", i.ChannelID)
+		if threadID != "" {
+			// Thread-level: delete thread default.
+			if err := h.store.DeleteThreadDefault(ctx, link.ChannelID, threadID); err != nil {
+				h.log.Error("Failed to clear thread default", "error", err)
+				h.respondUpdate(s, i, "Failed to clear thread default. Please try again.", nil)
+				return
+			}
+			msg := "Thread default agent cleared."
+			if link.DefaultAgent != "" {
+				msg += fmt.Sprintf(" Messages will use the channel default (**%s**).", link.DefaultAgent)
+			}
+			h.respondUpdate(s, i, msg, nil)
+			h.log.Info("Thread default cleared via button", "channel_id", link.ChannelID, "thread_id", threadID)
+		} else {
+			// Channel-level: existing behavior.
+			link.DefaultAgent = ""
+			if err := h.store.UpdateChannelLink(ctx, link); err != nil {
+				h.log.Error("Failed to clear default agent", "error", err)
+				h.respondUpdate(s, i, "Failed to clear default agent. Please try again.", nil)
+				return
+			}
+			h.respondUpdate(s, i, "Default agent cleared for this channel.", nil)
+			h.log.Info("Default agent cleared via button", "channel_id", i.ChannelID)
+		}
 
 	case "set":
 		if len(parts) < 3 {
@@ -535,14 +564,30 @@ func (h *CallbackHandler) handleDefaultCallback(s *discordgo.Session, i *discord
 			return
 		}
 		agentSlug := parts[2]
-		link.DefaultAgent = agentSlug
-		if err := h.store.UpdateChannelLink(ctx, link); err != nil {
-			h.log.Error("Failed to set default agent", "error", err)
-			h.respondUpdate(s, i, "Failed to set default agent. Please try again.", nil)
-			return
+		threadID := ""
+		if len(parts) >= 4 {
+			threadID = parts[3]
 		}
-		h.respondUpdate(s, i, fmt.Sprintf("Default agent set to **%s** for this channel.", agentSlug), nil)
-		h.log.Info("Default agent set via button", "channel_id", i.ChannelID, "agent", agentSlug)
+		if threadID != "" {
+			// Thread-level: set thread default.
+			if err := h.store.SetThreadDefault(ctx, link.ChannelID, threadID, agentSlug); err != nil {
+				h.log.Error("Failed to set thread default", "error", err)
+				h.respondUpdate(s, i, "Failed to set thread default. Please try again.", nil)
+				return
+			}
+			h.respondUpdate(s, i, fmt.Sprintf("Default agent for this thread set to **%s**.", agentSlug), nil)
+			h.log.Info("Thread default set via button", "channel_id", link.ChannelID, "thread_id", threadID, "agent", agentSlug)
+		} else {
+			// Channel-level: existing behavior.
+			link.DefaultAgent = agentSlug
+			if err := h.store.UpdateChannelLink(ctx, link); err != nil {
+				h.log.Error("Failed to set default agent", "error", err)
+				h.respondUpdate(s, i, "Failed to set default agent. Please try again.", nil)
+				return
+			}
+			h.respondUpdate(s, i, fmt.Sprintf("Default agent set to **%s** for this channel.", agentSlug), nil)
+			h.log.Info("Default agent set via button", "channel_id", i.ChannelID, "agent", agentSlug)
+		}
 
 	default:
 		h.log.Debug("Unknown default action", "action", action, "custom_id", customID)

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -435,8 +435,28 @@ func (h *CommandHandler) HandleSetup(s *discordgo.Session, i *discordgo.Interact
 		return
 	}
 
+	// If running in a thread/forum topic, resolve the parent channel.
+	effectiveChannelID := i.ChannelID
+	parentID := threadParentID(s, i.ChannelID)
+	if parentID != "" {
+		parentLink, err := h.store.GetChannelLink(ctx, parentID)
+		if err != nil {
+			h.log.Error("Failed to check parent channel link", "error", err, "parent_id", parentID)
+			h.followup(s, i, "Something went wrong. Please try again.")
+			return
+		}
+		if parentLink != nil && parentLink.Active {
+			h.followup(s, i, fmt.Sprintf(
+				"This channel is already set up (project **%s**). Use `/scion default` to set a per-thread default agent.",
+				parentLink.ProjectSlug,
+			))
+			return
+		}
+		effectiveChannelID = parentID
+	}
+
 	// Check existing link.
-	link, err := h.store.GetChannelLink(ctx, i.ChannelID)
+	link, err := h.store.GetChannelLink(ctx, effectiveChannelID)
 	if err != nil {
 		h.log.Error("Failed to check channel link", "error", err, "channel_id", i.ChannelID)
 		h.followup(s, i, "Something went wrong. Please try again.")
@@ -647,6 +667,9 @@ func (h *CommandHandler) HandleStatus(s *discordgo.Session, i *discordgo.Interac
 		return
 	}
 
+	// Detect thread context for default info display.
+	statusParentID := threadParentID(s, i.ChannelID)
+
 	for _, agent := range agents {
 		if agent.Slug == agentSlug {
 			emoji := activityEmoji(agent.Activity)
@@ -654,7 +677,20 @@ func (h *CommandHandler) HandleStatus(s *discordgo.Session, i *discordgo.Interac
 			if activity == "" {
 				activity = "unknown"
 			}
-			h.followup(s, i, fmt.Sprintf("%s **%s** -- %s", emoji, agent.Slug, activity))
+			statusMsg := fmt.Sprintf("%s **%s** -- %s", emoji, agent.Slug, activity)
+			if statusParentID != "" {
+				threadDefault, _ := h.store.GetThreadDefault(ctx, link.ChannelID, i.ChannelID)
+				if threadDefault != "" {
+					statusMsg += fmt.Sprintf("\nThread default: **%s**", threadDefault)
+				}
+				channelDefault := link.DefaultAgent
+				if channelDefault != "" {
+					statusMsg += fmt.Sprintf("\nChannel default: **%s**", channelDefault)
+				} else {
+					statusMsg += "\nChannel default: none"
+				}
+			}
+			h.followup(s, i, statusMsg)
 			return
 		}
 	}
@@ -792,6 +828,8 @@ func (h *CommandHandler) HandleLogs(s *discordgo.Session, i *discordgo.Interacti
 }
 
 // HandleDefault shows agent selection buttons for setting the default agent.
+// When invoked from a thread, it manages per-thread overrides instead of
+// the channel-level default.
 func (h *CommandHandler) HandleDefault(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -819,22 +857,53 @@ func (h *CommandHandler) HandleDefault(s *discordgo.Session, i *discordgo.Intera
 		return
 	}
 
+	// Detect thread context.
+	parentID := threadParentID(s, i.ChannelID)
+	isThread := parentID != ""
+	threadID := ""
+	if isThread {
+		threadID = i.ChannelID
+	}
+
+	// Determine the current effective default for highlighting.
+	currentDefault := link.DefaultAgent
+	if isThread {
+		td, err := h.store.GetThreadDefault(ctx, link.ChannelID, threadID)
+		if err != nil {
+			h.log.Error("Failed to get thread default", "error", err)
+		} else if td != "" {
+			currentDefault = td
+		}
+	}
+
+	promptText := "Select the default agent for this channel:"
+	if isThread {
+		promptText = "Select the default agent for this thread:"
+		if link.DefaultAgent != "" {
+			promptText += fmt.Sprintf("\nChannel-wide default: **%s**", link.DefaultAgent)
+		}
+	}
+
 	var currentText string
-	if link.DefaultAgent != "" {
-		currentText = fmt.Sprintf("Current default: **%s**\n", link.DefaultAgent)
+	if currentDefault != "" {
+		currentText = fmt.Sprintf("Current default: **%s**\n", currentDefault)
 	}
 
 	var rows []discordgo.MessageComponent
 	var buttons []discordgo.MessageComponent
 	for idx, slug := range agents {
 		style := discordgo.SecondaryButton
-		if slug == link.DefaultAgent {
+		if slug == currentDefault {
 			style = discordgo.PrimaryButton
+		}
+		customID := fmt.Sprintf("default:set:%s", slug)
+		if threadID != "" {
+			customID = fmt.Sprintf("default:set:%s:%s", slug, threadID)
 		}
 		buttons = append(buttons, discordgo.Button{
 			Label:    slug,
 			Style:    style,
-			CustomID: fmt.Sprintf("default:set:%s", slug),
+			CustomID: customID,
 		})
 		if len(buttons) == 5 || idx == len(agents)-1 {
 			rows = append(rows, discordgo.ActionsRow{Components: buttons})
@@ -845,19 +914,23 @@ func (h *CommandHandler) HandleDefault(s *discordgo.Session, i *discordgo.Intera
 		}
 	}
 	if len(rows) < 5 {
+		noneCustomID := "default:none"
+		if threadID != "" {
+			noneCustomID = fmt.Sprintf("default:none:%s", threadID)
+		}
 		rows = append(rows, discordgo.ActionsRow{
 			Components: []discordgo.MessageComponent{
 				discordgo.Button{
 					Label:    "None",
 					Style:    discordgo.DangerButton,
-					CustomID: "default:none",
+					CustomID: noneCustomID,
 				},
 			},
 		})
 	}
 
 	_, _ = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
-		Content:    currentText + "Select the default agent for this channel:",
+		Content:    currentText + promptText,
 		Components: rows,
 	})
 }

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -436,38 +436,37 @@ func (h *CommandHandler) HandleSetup(s *discordgo.Session, i *discordgo.Interact
 	}
 
 	// If running in a thread/forum topic, resolve the parent channel.
-	effectiveChannelID := i.ChannelID
+	var link *ChannelLink
 	parentID := threadParentID(s, i.ChannelID)
 	if parentID != "" {
-		parentLink, err := h.store.GetChannelLink(ctx, parentID)
+		link, err = h.store.GetChannelLink(ctx, parentID)
 		if err != nil {
 			h.log.Error("Failed to check parent channel link", "error", err, "parent_id", parentID)
 			h.followup(s, i, "Something went wrong. Please try again.")
 			return
 		}
-		if parentLink != nil && parentLink.Active {
+		if link != nil && link.Active {
 			h.followup(s, i, fmt.Sprintf(
 				"This channel is already set up (project **%s**). Use `/scion default` to set a per-thread default agent.",
-				parentLink.ProjectSlug,
+				link.ProjectSlug,
 			))
 			return
 		}
-		effectiveChannelID = parentID
-	}
-
-	// Check existing link.
-	link, err := h.store.GetChannelLink(ctx, effectiveChannelID)
-	if err != nil {
-		h.log.Error("Failed to check channel link", "error", err, "channel_id", i.ChannelID)
-		h.followup(s, i, "Something went wrong. Please try again.")
-		return
-	}
-	if link != nil {
-		h.followup(s, i, fmt.Sprintf(
-			"This channel is already linked to project **%s**.\nUse `/scion unlink` first to change it.",
-			link.ProjectSlug,
-		))
-		return
+	} else {
+		// Check existing link.
+		link, err = h.store.GetChannelLink(ctx, i.ChannelID)
+		if err != nil {
+			h.log.Error("Failed to check channel link", "error", err, "channel_id", i.ChannelID)
+			h.followup(s, i, "Something went wrong. Please try again.")
+			return
+		}
+		if link != nil {
+			h.followup(s, i, fmt.Sprintf(
+				"This channel is already linked to project **%s**.\nUse `/scion unlink` first to change it.",
+				link.ProjectSlug,
+			))
+			return
+		}
 	}
 
 	// Get user's projects.
@@ -679,8 +678,10 @@ func (h *CommandHandler) HandleStatus(s *discordgo.Session, i *discordgo.Interac
 			}
 			statusMsg := fmt.Sprintf("%s **%s** -- %s", emoji, agent.Slug, activity)
 			if statusParentID != "" {
-				threadDefault, _ := h.store.GetThreadDefault(ctx, link.ChannelID, i.ChannelID)
-				if threadDefault != "" {
+				threadDefault, err := h.store.GetThreadDefault(ctx, link.ChannelID, i.ChannelID)
+				if err != nil {
+					h.log.Error("Failed to get thread default", "error", err)
+				} else if threadDefault != "" {
 					statusMsg += fmt.Sprintf("\nThread default: **%s**", threadDefault)
 				}
 				channelDefault := link.DefaultAgent

--- a/extras/scion-discord/internal/discord/store.go
+++ b/extras/scion-discord/internal/discord/store.go
@@ -31,6 +31,12 @@ type Store interface {
 	DeactivateLinksForGuild(ctx context.Context, guildID string) error
 	DeleteChannelLink(ctx context.Context, channelID string) error
 
+	// Thread defaults — per-thread agent overrides
+	GetThreadDefault(ctx context.Context, channelID, threadID string) (string, error)
+	SetThreadDefault(ctx context.Context, channelID, threadID, agentSlug string) error
+	DeleteThreadDefault(ctx context.Context, channelID, threadID string) error
+	DeleteThreadDefaultsForChannel(ctx context.Context, channelID string) error
+
 	// User mappings (Discord user <-> Scion identity)
 	CreateUserMapping(ctx context.Context, mapping *DiscordUserMapping) error
 	GetUserMapping(ctx context.Context, discordUserID string) (*DiscordUserMapping, error)
@@ -247,6 +253,13 @@ CREATE TABLE IF NOT EXISTS notification_prefs (
 	updated_at TEXT NOT NULL,
 	PRIMARY KEY (discord_user_id, project_id, agent_slug)
 );
+
+CREATE TABLE IF NOT EXISTS thread_defaults (
+	channel_id TEXT NOT NULL,
+	thread_id  TEXT NOT NULL,
+	agent_slug TEXT NOT NULL,
+	PRIMARY KEY (channel_id, thread_id)
+);
 `
 	_, err := s.db.Exec(ddl)
 	if err != nil {
@@ -344,7 +357,47 @@ func (s *sqliteStore) DeactivateLinksForGuild(ctx context.Context, guildID strin
 }
 
 func (s *sqliteStore) DeleteChannelLink(ctx context.Context, channelID string) error {
-	_, err := s.db.ExecContext(ctx, `DELETE FROM channel_links WHERE channel_id = ?`, channelID)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM thread_defaults WHERE channel_id = ?`, channelID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM channel_links WHERE channel_id = ?`, channelID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// --- Thread defaults ---
+
+func (s *sqliteStore) GetThreadDefault(ctx context.Context, channelID, threadID string) (string, error) {
+	const q = `SELECT agent_slug FROM thread_defaults WHERE channel_id = ? AND thread_id = ?`
+	var slug string
+	err := s.db.QueryRowContext(ctx, q, channelID, threadID).Scan(&slug)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return slug, err
+}
+
+func (s *sqliteStore) SetThreadDefault(ctx context.Context, channelID, threadID, agentSlug string) error {
+	const q = `INSERT INTO thread_defaults (channel_id, thread_id, agent_slug)
+               VALUES (?, ?, ?)
+               ON CONFLICT(channel_id, thread_id) DO UPDATE SET agent_slug=excluded.agent_slug`
+	_, err := s.db.ExecContext(ctx, q, channelID, threadID, agentSlug)
+	return err
+}
+
+func (s *sqliteStore) DeleteThreadDefault(ctx context.Context, channelID, threadID string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM thread_defaults WHERE channel_id = ? AND thread_id = ?`, channelID, threadID)
+	return err
+}
+
+func (s *sqliteStore) DeleteThreadDefaultsForChannel(ctx context.Context, channelID string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM thread_defaults WHERE channel_id = ?`, channelID)
 	return err
 }
 

--- a/extras/scion-discord/internal/discord/store_postgres.go
+++ b/extras/scion-discord/internal/discord/store_postgres.go
@@ -105,6 +105,13 @@ CREATE TABLE IF NOT EXISTS discord_notification_prefs (
 	updated_at TIMESTAMPTZ NOT NULL,
 	PRIMARY KEY (discord_user_id, project_id, agent_slug)
 );
+
+CREATE TABLE IF NOT EXISTS discord_thread_defaults (
+	channel_id TEXT NOT NULL,
+	thread_id  TEXT NOT NULL,
+	agent_slug TEXT NOT NULL,
+	PRIMARY KEY (channel_id, thread_id)
+);
 `
 	_, err := s.db.Exec(ddl)
 	return err
@@ -184,7 +191,47 @@ func (s *postgresStore) DeactivateLinksForGuild(ctx context.Context, guildID str
 }
 
 func (s *postgresStore) DeleteChannelLink(ctx context.Context, channelID string) error {
-	_, err := s.db.ExecContext(ctx, `DELETE FROM discord_channel_links WHERE channel_id = $1`, channelID)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM discord_thread_defaults WHERE channel_id = $1`, channelID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM discord_channel_links WHERE channel_id = $1`, channelID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// --- Thread defaults ---
+
+func (s *postgresStore) GetThreadDefault(ctx context.Context, channelID, threadID string) (string, error) {
+	const q = `SELECT agent_slug FROM discord_thread_defaults WHERE channel_id = $1 AND thread_id = $2`
+	var slug string
+	err := s.db.QueryRowContext(ctx, q, channelID, threadID).Scan(&slug)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return slug, err
+}
+
+func (s *postgresStore) SetThreadDefault(ctx context.Context, channelID, threadID, agentSlug string) error {
+	const q = `INSERT INTO discord_thread_defaults (channel_id, thread_id, agent_slug)
+               VALUES ($1, $2, $3)
+               ON CONFLICT(channel_id, thread_id) DO UPDATE SET agent_slug=EXCLUDED.agent_slug`
+	_, err := s.db.ExecContext(ctx, q, channelID, threadID, agentSlug)
+	return err
+}
+
+func (s *postgresStore) DeleteThreadDefault(ctx context.Context, channelID, threadID string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM discord_thread_defaults WHERE channel_id = $1 AND thread_id = $2`, channelID, threadID)
+	return err
+}
+
+func (s *postgresStore) DeleteThreadDefaultsForChannel(ctx context.Context, channelID string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM discord_thread_defaults WHERE channel_id = $1`, channelID)
 	return err
 }
 

--- a/extras/scion-discord/internal/discord/store_test.go
+++ b/extras/scion-discord/internal/discord/store_test.go
@@ -664,6 +664,137 @@ func TestPendingAskUser(t *testing.T) {
 	})
 }
 
+// --- Thread defaults ---
+
+func TestThreadDefaultCRUD(t *testing.T) {
+	t.Run("GetReturnsEmptyWhenNoneSet", func(t *testing.T) {
+		store := newTestStore(t)
+		ctx := context.Background()
+
+		slug, err := store.GetThreadDefault(ctx, "chan-1", "thread-1")
+		require.NoError(t, err)
+		assert.Equal(t, "", slug)
+	})
+
+	t.Run("SetAndGetRoundTrip", func(t *testing.T) {
+		store := newTestStore(t)
+		ctx := context.Background()
+
+		require.NoError(t, store.SetThreadDefault(ctx, "chan-1", "thread-1", "coder"))
+
+		slug, err := store.GetThreadDefault(ctx, "chan-1", "thread-1")
+		require.NoError(t, err)
+		assert.Equal(t, "coder", slug)
+	})
+
+	t.Run("Upsert", func(t *testing.T) {
+		store := newTestStore(t)
+		ctx := context.Background()
+
+		require.NoError(t, store.SetThreadDefault(ctx, "chan-1", "thread-1", "coder"))
+		require.NoError(t, store.SetThreadDefault(ctx, "chan-1", "thread-1", "reviewer"))
+
+		slug, err := store.GetThreadDefault(ctx, "chan-1", "thread-1")
+		require.NoError(t, err)
+		assert.Equal(t, "reviewer", slug)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		store := newTestStore(t)
+		ctx := context.Background()
+
+		require.NoError(t, store.SetThreadDefault(ctx, "chan-1", "thread-1", "coder"))
+		require.NoError(t, store.DeleteThreadDefault(ctx, "chan-1", "thread-1"))
+
+		slug, err := store.GetThreadDefault(ctx, "chan-1", "thread-1")
+		require.NoError(t, err)
+		assert.Equal(t, "", slug)
+	})
+
+	t.Run("DeleteForChannel", func(t *testing.T) {
+		store := newTestStore(t)
+		ctx := context.Background()
+
+		require.NoError(t, store.SetThreadDefault(ctx, "chan-1", "thread-1", "coder"))
+		require.NoError(t, store.SetThreadDefault(ctx, "chan-1", "thread-2", "reviewer"))
+		require.NoError(t, store.SetThreadDefault(ctx, "chan-2", "thread-3", "tester"))
+
+		require.NoError(t, store.DeleteThreadDefaultsForChannel(ctx, "chan-1"))
+
+		slug, err := store.GetThreadDefault(ctx, "chan-1", "thread-1")
+		require.NoError(t, err)
+		assert.Equal(t, "", slug)
+
+		slug, err = store.GetThreadDefault(ctx, "chan-1", "thread-2")
+		require.NoError(t, err)
+		assert.Equal(t, "", slug)
+
+		// Different channel should be unaffected.
+		slug, err = store.GetThreadDefault(ctx, "chan-2", "thread-3")
+		require.NoError(t, err)
+		assert.Equal(t, "tester", slug)
+	})
+
+	t.Run("Isolation", func(t *testing.T) {
+		store := newTestStore(t)
+		ctx := context.Background()
+
+		require.NoError(t, store.SetThreadDefault(ctx, "chan-1", "thread-1", "coder"))
+		require.NoError(t, store.SetThreadDefault(ctx, "chan-2", "thread-1", "reviewer"))
+
+		slug1, err := store.GetThreadDefault(ctx, "chan-1", "thread-1")
+		require.NoError(t, err)
+		assert.Equal(t, "coder", slug1)
+
+		slug2, err := store.GetThreadDefault(ctx, "chan-2", "thread-1")
+		require.NoError(t, err)
+		assert.Equal(t, "reviewer", slug2)
+	})
+}
+
+func TestDeleteChannelLinkCascade(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Create a channel link.
+	require.NoError(t, store.CreateChannelLink(ctx, &ChannelLink{
+		ChannelID: "chan-1",
+		GuildID:   "guild-1",
+		ProjectID: "proj-1",
+		LinkedAt:  time.Now().UTC(),
+		Active:    true,
+	}))
+
+	// Set thread defaults for that channel.
+	require.NoError(t, store.SetThreadDefault(ctx, "chan-1", "thread-1", "coder"))
+	require.NoError(t, store.SetThreadDefault(ctx, "chan-1", "thread-2", "reviewer"))
+
+	// Also set a thread default for a different channel (should not be affected).
+	require.NoError(t, store.SetThreadDefault(ctx, "chan-2", "thread-3", "tester"))
+
+	// Delete the channel link.
+	require.NoError(t, store.DeleteChannelLink(ctx, "chan-1"))
+
+	// Verify channel link is deleted.
+	got, err := store.GetChannelLink(ctx, "chan-1")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	// Verify thread defaults for chan-1 are also deleted.
+	slug, err := store.GetThreadDefault(ctx, "chan-1", "thread-1")
+	require.NoError(t, err)
+	assert.Equal(t, "", slug)
+
+	slug, err = store.GetThreadDefault(ctx, "chan-1", "thread-2")
+	require.NoError(t, err)
+	assert.Equal(t, "", slug)
+
+	// Verify thread defaults for chan-2 are unaffected.
+	slug, err = store.GetThreadDefault(ctx, "chan-2", "thread-3")
+	require.NoError(t, err)
+	assert.Equal(t, "tester", slug)
+}
+
 // --- Store lifecycle ---
 
 func TestStore_OpenInvalidPath(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/513

- Adds thread_defaults table (SQLite + Postgres) for per-thread agent default overrides
- Makes /setup forum/thread-aware: links forum container, not individual topics
- Makes /default thread-aware: embeds thread ID in callback data, routes to thread-level storage
- Adds two-tier default resolution in broker: thread override first, channel fallback
- Enhances /status to show both thread and channel defaults when in a thread
- Includes tests for thread default CRUD and CASCADE delete behavior