### PR TITLE
feat(slack): replace email references with Slack @mentions

### DIFF
--- a/extras/scion-slack/internal/slack/broker.go
+++ b/extras/scion-slack/internal/slack/broker.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -438,6 +439,11 @@ func (b *SlackBroker) Publish(ctx context.Context, topic string, msg *messages.S
 		return nil
 	}
 
+	// Replace scion user emails with Slack @mentions in the message body.
+	if msg != nil && store != nil {
+		msg.Msg = resolveOutboundMentions(ctx, store, msg.Msg)
+	}
+
 	senderSlug := agentSlug
 	if senderSlug == "" && strings.HasPrefix(msg.Sender, "agent:") {
 		senderSlug = strings.TrimPrefix(msg.Sender, "agent:")
@@ -845,6 +851,56 @@ func (b *SlackBroker) pruneSentIDsLocked() {
 			delete(b.sentIDs, k)
 		}
 	}
+}
+
+// --- Outbound mention resolution ---
+
+var outboundEmailRe = regexp.MustCompile(`(?:user:)?[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`)
+
+// resolveOutboundMentions scans text for scion user emails (with optional
+// "user:" prefix) and replaces them with Slack <@user_id> mentions when the
+// user is registered.
+func resolveOutboundMentions(ctx context.Context, store Store, text string) string {
+	if store == nil || text == "" {
+		return text
+	}
+
+	matches := outboundEmailRe.FindAllStringIndex(text, -1)
+	if len(matches) == 0 {
+		return text
+	}
+
+	// Process in reverse order so indices remain valid after replacement.
+	for i := len(matches) - 1; i >= 0; i-- {
+		start, end := matches[i][0], matches[i][1]
+
+		// Skip emails embedded in URLs (preceded by '/' or ':').
+		if start > 0 {
+			prev := text[start-1]
+			if prev == '/' || prev == ':' {
+				continue
+			}
+		}
+		// Skip emails followed by '/' (URL path).
+		if end < len(text) && text[end] == '/' {
+			continue
+		}
+
+		match := text[start:end]
+		email := match
+		if strings.HasPrefix(email, "user:") {
+			email = strings.TrimPrefix(email, "user:")
+		}
+
+		mapping, err := store.GetUserMappingByEmail(ctx, email)
+		if err != nil || mapping == nil || mapping.SlackUserID == "" {
+			continue
+		}
+
+		text = text[:start] + "<@" + mapping.SlackUserID + ">" + text[end:]
+	}
+
+	return text
 }
 
 // --- HMAC auth helpers ---

--- a/extras/scion-slack/internal/slack/broker.go
+++ b/extras/scion-slack/internal/slack/broker.go
@@ -440,8 +440,14 @@ func (b *SlackBroker) Publish(ctx context.Context, topic string, msg *messages.S
 	}
 
 	// Replace scion user emails with Slack @mentions in the message body.
-	if msg != nil && store != nil {
-		msg.Msg = resolveOutboundMentions(ctx, store, msg.Msg)
+	// Create a shallow copy to avoid mutating the shared msg pointer.
+	if store != nil {
+		resolvedMsg := resolveOutboundMentions(ctx, store, msg.Msg)
+		if resolvedMsg != msg.Msg {
+			msgCopy := *msg
+			msgCopy.Msg = resolvedMsg
+			msg = &msgCopy
+		}
 	}
 
 	senderSlug := agentSlug
@@ -870,6 +876,10 @@ func resolveOutboundMentions(ctx context.Context, store Store, text string) stri
 		return text
 	}
 
+	// Cache email→SlackUserID lookups within this call to avoid redundant
+	// DB queries when the same email appears multiple times.
+	emailCache := make(map[string]string)
+
 	// Process in reverse order so indices remain valid after replacement.
 	for i := len(matches) - 1; i >= 0; i-- {
 		start, end := matches[i][0], matches[i][1]
@@ -892,12 +902,22 @@ func resolveOutboundMentions(ctx context.Context, store Store, text string) stri
 			email = strings.TrimPrefix(email, "user:")
 		}
 
-		mapping, err := store.GetUserMappingByEmail(ctx, email)
-		if err != nil || mapping == nil || mapping.SlackUserID == "" {
+		var slackUserID string
+		if id, cached := emailCache[email]; cached {
+			slackUserID = id
+		} else {
+			mapping, err := store.GetUserMappingByEmail(ctx, email)
+			if err == nil && mapping != nil {
+				slackUserID = mapping.SlackUserID
+			}
+			emailCache[email] = slackUserID
+		}
+
+		if slackUserID == "" {
 			continue
 		}
 
-		text = text[:start] + "<@" + mapping.SlackUserID + ">" + text[end:]
+		text = text[:start] + "<@" + slackUserID + ">" + text[end:]
 	}
 
 	return text

--- a/extras/scion-slack/internal/slack/broker_test.go
+++ b/extras/scion-slack/internal/slack/broker_test.go
@@ -283,6 +283,11 @@ func TestResolveOutboundMentions(t *testing.T) {
 			want: "<@U12345ABC> and nousername@example.com",
 		},
 		{
+			name: "same email appears twice",
+			text: "ptone@google.com and then ptone@google.com again",
+			want: "<@U12345ABC> and then <@U12345ABC> again",
+		},
+		{
 			name: "email at start of text",
 			text: "ptone@google.com said hello",
 			want: "<@U12345ABC> said hello",

--- a/extras/scion-slack/internal/slack/broker_test.go
+++ b/extras/scion-slack/internal/slack/broker_test.go
@@ -1,7 +1,10 @@
 package slack
 
 import (
+	"context"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -9,6 +12,15 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/plugin"
 )
+
+func newTestStore(t *testing.T) Store {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	store, err := NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+	return store
+}
 
 func TestNewBroker(t *testing.T) {
 	b := NewBroker(nil)
@@ -209,4 +221,103 @@ func TestHubErrorUserFacingMessage(t *testing.T) {
 			assert.Contains(t, he.userFacingMessage(), tt.expected)
 		})
 	}
+}
+
+func TestResolveOutboundMentions(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Seed a registered user with a Slack user ID.
+	require.NoError(t, store.CreateUserMapping(ctx, &SlackUserMapping{
+		SlackUserID:  "U12345ABC",
+		SlackUsername: "ptone805",
+		ScionEmail:   "ptone@google.com",
+		LinkedAt:     time.Now().UTC(),
+	}))
+	// Seed a user without a Slack user ID (empty — should not replace).
+	require.NoError(t, store.CreateUserMapping(ctx, &SlackUserMapping{
+		SlackUserID:  "",
+		SlackUsername: "nousername",
+		ScionEmail:   "nousername@example.com",
+		LinkedAt:     time.Now().UTC(),
+	}))
+
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{
+			name: "user:email replaced",
+			text: "Hey user:ptone@google.com check this",
+			want: "Hey <@U12345ABC> check this",
+		},
+		{
+			name: "standalone email replaced",
+			text: "Hey ptone@google.com check this",
+			want: "Hey <@U12345ABC> check this",
+		},
+		{
+			name: "no slack user ID leaves as-is",
+			text: "Contact nousername@example.com please",
+			want: "Contact nousername@example.com please",
+		},
+		{
+			name: "unknown email leaves as-is",
+			text: "Contact unknown@example.com please",
+			want: "Contact unknown@example.com please",
+		},
+		{
+			name: "email in URL skipped",
+			text: "See https://ptone@google.com/path",
+			want: "See https://ptone@google.com/path",
+		},
+		{
+			name: "mailto skipped",
+			text: "Send to mailto:ptone@google.com",
+			want: "Send to mailto:ptone@google.com",
+		},
+		{
+			name: "multiple emails",
+			text: "user:ptone@google.com and nousername@example.com",
+			want: "<@U12345ABC> and nousername@example.com",
+		},
+		{
+			name: "email at start of text",
+			text: "ptone@google.com said hello",
+			want: "<@U12345ABC> said hello",
+		},
+		{
+			name: "email at end of text",
+			text: "message from ptone@google.com",
+			want: "message from <@U12345ABC>",
+		},
+		{
+			name: "empty text",
+			text: "",
+			want: "",
+		},
+		{
+			name: "no emails",
+			text: "just a regular message",
+			want: "just a regular message",
+		},
+		{
+			name: "email followed by slash skipped",
+			text: "http://ptone@google.com/foo",
+			want: "http://ptone@google.com/foo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveOutboundMentions(ctx, store, tt.text)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("nil store returns text unchanged", func(t *testing.T) {
+		got := resolveOutboundMentions(ctx, nil, "ptone@google.com")
+		assert.Equal(t, "ptone@google.com", got)
+	})
 }

--- a/extras/scion-slack/internal/slack/broker_test.go
+++ b/extras/scion-slack/internal/slack/broker_test.go
@@ -229,17 +229,17 @@ func TestResolveOutboundMentions(t *testing.T) {
 
 	// Seed a registered user with a Slack user ID.
 	require.NoError(t, store.CreateUserMapping(ctx, &SlackUserMapping{
-		SlackUserID:  "U12345ABC",
+		SlackUserID:   "U12345ABC",
 		SlackUsername: "ptone805",
-		ScionEmail:   "ptone@google.com",
-		LinkedAt:     time.Now().UTC(),
+		ScionEmail:    "ptone@google.com",
+		LinkedAt:      time.Now().UTC(),
 	}))
 	// Seed a user without a Slack user ID (empty — should not replace).
 	require.NoError(t, store.CreateUserMapping(ctx, &SlackUserMapping{
-		SlackUserID:  "",
+		SlackUserID:   "",
 		SlackUsername: "nousername",
-		ScionEmail:   "nousername@example.com",
-		LinkedAt:     time.Now().UTC(),
+		ScionEmail:    "nousername@example.com",
+		LinkedAt:      time.Now().UTC(),
 	}))
 
 	tests := []struct {


### PR DESCRIPTION
Addresses the Slack portion of https://github.com/ptone/scion/issues/514

Port of resolveOutboundMentions() from Telegram to the Slack broker. Replaces scion user emails (with optional user: prefix) with native Slack <@user_id> mentions in outbound messages. Same URL/mailto guards and reverse-order processing as the Telegram and Discord implementations. 14 test cases