### PR TITLE
feat: mention message type — position-aware @mention routing with TypeMention notifications

### DIFF
--- a/.design/project-log/2026-07-19-phase1-type-mention.md
+++ b/.design/project-log/2026-07-19-phase1-type-mention.md
@@ -1,0 +1,27 @@
+# Phase 1: Add TypeMention message type
+
+**Date:** 2026-07-19
+**Branch:** scion/ca-mgr-mention
+**Phase:** 1 of 4
+
+## Summary
+
+Added the `TypeMention` message type to the Scion messaging system in `pkg/messages/`. This is the foundation for Phases 2-4, which will integrate mention detection and delivery into the Telegram and Discord broker plugins.
+
+## Changes
+
+### `pkg/messages/types.go`
+- Added `TypeMention = "mention"` constant to the message type enum
+- Added `TypeMention: true` to the `validTypes` map
+- Updated the `ValidateType()` error message to include "mention" in the list of valid types
+- Added `NewMention(sender, recipient, msg, mentionSource string)` constructor that creates a `StructuredMessage` with `Type: TypeMention` and metadata keys `mention_source` and `mention_position`
+
+### `pkg/messages/types_test.go`
+- Added `TypeMention` to the `TestValidateType` table-driven test (validates `ValidateType("mention")` returns nil)
+- Added `TestStructuredMessage_ValidateMention` to verify a fully-populated mention message passes `Validate()`
+- Added `TestNewMention` to verify the constructor sets all fields correctly including Type, Metadata keys, Sender, Recipient, Msg, Version, and Timestamp
+
+## Verification
+
+- `go test ./pkg/messages/...` passes (all existing + new tests)
+- `go build ./...` succeeds with no compilation errors

--- a/.design/project-log/2026-07-19-phase23-telegram-mentions.md
+++ b/.design/project-log/2026-07-19-phase23-telegram-mentions.md
@@ -1,0 +1,68 @@
+# Phase 2+3: Position-Aware Mention Classification for Telegram Broker
+
+**Date**: 2026-07-19
+**Branch**: `scion/ca-mgr-mention`
+**Author**: Developer Agent
+
+## Summary
+
+Implemented position-aware mention classification (`classifyMentions()`) and integrated it into the Telegram broker's `handleGroupMessage()` pipeline. This enables distinguishing between "start mentions" (primary recipients at the beginning of a message) and "body mentions" (inline references to agents within the message body).
+
+## Changes
+
+### pkg/messages/types.go
+- Added `TypeMention = "mention"` to the message type enum
+- Added `NewMention(sender, recipient, msg, mentionSource string)` constructor
+- Updated `validTypes` map and `ValidateType` error message
+
+### extras/scion-telegram/internal/telegram/mentions.go
+- Added `Mention` struct with Name, Kind ("agent"/"user"/"unknown"), and Identity fields
+- Added `ClassifiedMentions` struct with StartMentions, BodyMentions, and StrippedBody
+- Implemented `classifyMentions()` function with:
+  - Whitespace tokenization and consecutive leading @-mention scanning
+  - Case-insensitive agent matching preserving original case from knownAgents
+  - User resolution via pluggable `userResolver` callback
+  - @all detection (returns empty result to let broadcast logic handle it)
+  - Bot username skipping
+  - Body mention cap at 5
+  - Start-to-body deduplication (agent in start won't appear in body)
+  - Original spacing preservation for StrippedBody using byte positions
+
+### extras/scion-telegram/internal/telegram/mentions_test.go
+- Added 16 test cases covering:
+  - Start-only mentions, body-only mentions, mixed start+body
+  - User mention resolution (resolved and unresolvable)
+  - Self-dedup (same agent in start and body)
+  - No mentions, empty text
+  - @all broadcast bypass
+  - Bot name skipping
+  - Body mention cap (7 mentions, only 5 returned)
+  - Case-insensitive matching
+  - Original spacing preservation
+  - Unknown body mentions skipped
+  - Trailing punctuation handling
+
+### extras/scion-telegram/internal/telegram/broker_v2.go
+- Integrated `classifyMentions()` call after target resolution in `handleGroupMessage()`
+- Changed `stripMentions()` to only strip start-mention agent slugs (body mentions remain in text)
+- Added body mention delivery loop after main delivery loop:
+  - Creates `TypeMention` messages via `messages.NewMention()`
+  - Sets mention_source metadata to primary recipient identity
+  - Deduplicates against primary targets
+  - Copies channel/thread metadata from original message
+  - Delivers via `deliverInboundWithFeedback()`
+- Skips mention classification for @all broadcasts
+
+## Design Decisions
+
+1. **Body mentions use StrippedBody**: Body mention recipients see the message with start mentions removed but body mentions preserved, giving them context about who else was mentioned.
+2. **User resolver stub**: The user resolver currently returns not-found for all users. Per the design doc, unresolvable @chatUser mentions are dropped, not delivered as messages.
+3. **Dedup at two levels**: classifyMentions() deduplicates body vs start mentions, and the broker integration also checks against the resolved targets set (which may differ from classified start mentions due to fallback routing).
+4. **Existing behavior preserved**: @all broadcasts, reply-to-bot fallback, conversation context fallback, and default agent routing are all unchanged.
+
+## Verification
+
+- `go build ./...` passes (root module)
+- `go build ./...` passes (scion-telegram module)
+- `go test ./pkg/messages/...` passes
+- `go test ./...` passes (scion-telegram module, all 16 new + existing tests)

--- a/.design/project-log/2026-07-19-phase4-discord-mentions.md
+++ b/.design/project-log/2026-07-19-phase4-discord-mentions.md
@@ -1,0 +1,45 @@
+# Phase 4: Discord Broker Position-Aware Mention Classification
+
+**Date:** 2026-07-19
+**Author:** developer agent
+**Branch:** scion/ca-mgr-mention
+
+## Summary
+
+Implemented position-aware mention classification for the Discord broker, mirroring the architecture planned for the Telegram broker. This allows body mentions (e.g., "cc @agent-b") to generate `TypeMention` notification messages, distinct from start mentions which continue to route as primary `TypeInstruction` (or `TypeGroupSet`) messages.
+
+## Changes
+
+### `extras/scion-discord/internal/discord/mentions.go`
+- Added `Mention` struct (Name, Kind, Identity) and `ClassifiedMentions` struct (StartMentions, BodyMentions, StrippedBody)
+- Added `classifyMentions()` function that:
+  - Tokenizes text by whitespace and scans leading `@` tokens as start mentions
+  - Skips Discord bot mentions (`<@ID>` format) — they are handled separately
+  - Returns empty result for `@all` (delegates to existing broadcast logic)
+  - Classifies mentions as "agent", "user" (via userResolver callback), or "unknown"
+  - Caps body mentions at 5 to prevent spam
+  - Deduplicates: skips body mentions for agents already in StartMentions
+
+### `extras/scion-discord/internal/discord/mentions_test.go`
+- Added 11 test cases covering:
+  - Start mentions only, body mentions only, mixed start+body
+  - Self-dedup (same agent at start and in body)
+  - No mentions, `@all` handling
+  - Body mention cap (7 mentions, only first 5 captured)
+  - Discord bot mention skipping (`<@BOT_ID>`)
+  - Empty text, user resolver, unknown body mentions skipped
+
+### `extras/scion-discord/internal/discord/broker.go`
+- Integrated `classifyMentions()` into `handleIncomingMessage()`:
+  - Called before `stripMentions()` to determine start vs body mentions
+  - `stripMentions()` now only strips start-mention agents (body mentions stay in text)
+  - Added `TypeGroupSet` support: multi-agent routing (len(targets) > 1, not `@all`) sets type to `TypeGroupSet` with `Recipients` populated via `FormatGroupRecipients()`
+  - After the primary delivery loop, iterates body mentions of kind "agent", skips agents already in targets, and delivers `TypeMention` messages via `messages.NewMention()`
+  - Mention messages carry full channel/thread metadata (discord_channel_id, discord_message_id, discord_guild_id, project_id)
+  - `mentionSource` is set to the primary recipient identity (single agent) or group format (multiple agents)
+
+## Verification
+
+- `go test ./extras/scion-discord/...` passes (all existing + 11 new tests)
+- `go build ./...` succeeds
+- Existing behavior preserved: single agent routing, reply-to-webhook fallback, default agent fallback, `@all` broadcast

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1148,16 +1148,20 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 
 	// Determine which agent slugs are start-mentions (to strip from text).
 	// Only strip start-mention agents; body mentions stay in text.
-	var startMentionSlugs []string
-	for _, sm := range classified.StartMentions {
-		if sm.Kind == "agent" {
-			startMentionSlugs = append(startMentionSlugs, sm.Name)
+	// For @all or fallback routing, fall back to stripping all targets.
+	stripSlugs := targets
+	if !isAll && len(classified.StartMentions) > 0 {
+		stripSlugs = make([]string, 0, len(classified.StartMentions))
+		for _, sm := range classified.StartMentions {
+			if sm.Kind == "agent" {
+				stripSlugs = append(stripSlugs, sm.Name)
+			}
 		}
 	}
 
 	// Strip bot and start-mention agent mentions from message text.
 	// Body-mention agents remain visible in the delivered text.
-	cleanText := stripMentions(m.Content, botUserID, startMentionSlugs)
+	cleanText := stripMentions(m.Content, botUserID, stripSlugs)
 	cleanText = strings.TrimSpace(cleanText)
 
 	// Download Discord attachments and build metadata.
@@ -1251,7 +1255,7 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 	if !isAll && len(classified.BodyMentions) > 0 {
 		targetSet := make(map[string]bool, len(targets))
 		for _, slug := range targets {
-			targetSet[slug] = true
+			targetSet[strings.ToLower(slug)] = true
 		}
 
 		// Build the mention source: who the primary message was addressed to.
@@ -1267,7 +1271,7 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 				continue
 			}
 			// Skip agents already receiving the primary message.
-			if targetSet[bm.Name] {
+			if targetSet[strings.ToLower(bm.Name)] {
 				continue
 			}
 
@@ -1279,6 +1283,9 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 			mentionMsg.Metadata["discord_message_id"] = m.ID
 			mentionMsg.Metadata["discord_guild_id"] = m.GuildID
 			mentionMsg.Metadata["project_id"] = link.ProjectID
+			if len(attachmentPaths) > 0 {
+				mentionMsg.Attachments = attachmentPaths
+			}
 
 			mentionTopic := projectcompat.AgentTopic(link.ProjectID, bm.Name)
 

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1082,7 +1082,7 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 	agents := b.getProjectAgents(ctx, link.ProjectID)
 
 	// Three-tier @-mention routing.
-	targets, _ := resolveTargetAgents(m, botUserID, link.DefaultAgent, agents)
+	targets, isAll := resolveTargetAgents(m, botUserID, link.DefaultAgent, agents)
 
 	// Fallback: reply-to-bot message — extract agent from webhook username.
 	if len(targets) == 0 && m.ReferencedMessage != nil {
@@ -1137,8 +1137,24 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 		return
 	}
 
-	// Strip bot and agent mentions from message text.
-	cleanText := stripMentions(m.Content, botUserID, targets)
+	// Classify mentions by position before stripping.
+	classified := classifyMentions(m.Content, botUserID, agents, func(username string) (string, bool) {
+		// User resolution via store mapping is not yet wired up.
+		return "", false
+	})
+
+	// Determine which agent slugs are start-mentions (to strip from text).
+	// Only strip start-mention agents; body mentions stay in text.
+	var startMentionSlugs []string
+	for _, sm := range classified.StartMentions {
+		if sm.Kind == "agent" {
+			startMentionSlugs = append(startMentionSlugs, sm.Name)
+		}
+	}
+
+	// Strip bot and start-mention agent mentions from message text.
+	// Body-mention agents remain visible in the delivered text.
+	cleanText := stripMentions(m.Content, botUserID, startMentionSlugs)
 	cleanText = strings.TrimSpace(cleanText)
 
 	// Download Discord attachments and build metadata.
@@ -1167,6 +1183,18 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 		return
 	}
 
+	// Determine message type and recipients for multi-agent routing.
+	msgType := messages.TypeInstruction
+	var groupRecipients string
+	if len(targets) > 1 && !isAll {
+		msgType = messages.TypeGroupSet
+		recipientIDs := make([]string, len(targets))
+		for i, slug := range targets {
+			recipientIDs[i] = "agent:" + slug
+		}
+		groupRecipients = messages.FormatGroupRecipients(sender, recipientIDs)
+	}
+
 	// Deliver to each target agent.
 	for _, agentSlug := range targets {
 		cc := &ConversationContext{
@@ -1191,8 +1219,9 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 			Sender:      sender,
 			SenderID:    senderID,
 			Recipient:   recipient,
+			Recipients:  groupRecipients,
 			Msg:         cleanText,
-			Type:        messages.TypeInstruction,
+			Type:        msgType,
 			Attachments: attachmentPaths,
 			Metadata: map[string]string{
 				"discord_channel_id": channelID,
@@ -1212,6 +1241,53 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 
 		if he := b.deliverInbound(topic, msg); he != nil {
 			s.ChannelMessageSend(channelID, he.userFacingMessage())
+		}
+	}
+
+	// Deliver TypeMention notifications for body mentions.
+	targetSet := make(map[string]bool, len(targets))
+	for _, slug := range targets {
+		targetSet[slug] = true
+	}
+
+	// Build the mention source: who the primary message was addressed to.
+	var mentionSource string
+	if len(targets) == 1 {
+		mentionSource = "agent:" + targets[0]
+	} else if len(targets) > 1 {
+		recipientIDs := make([]string, len(targets))
+		for i, slug := range targets {
+			recipientIDs[i] = "agent:" + slug
+		}
+		mentionSource = messages.FormatGroupRecipients(sender, recipientIDs)
+	}
+
+	for _, bm := range classified.BodyMentions {
+		if bm.Kind != "agent" {
+			continue
+		}
+		// Skip agents already receiving the primary message.
+		if targetSet[bm.Name] {
+			continue
+		}
+
+		mentionMsg := messages.NewMention(sender, "agent:"+bm.Name, cleanText, mentionSource)
+		mentionMsg.SenderID = senderID
+		mentionMsg.Channel = "discord"
+		mentionMsg.ThreadID = channelID
+		mentionMsg.Metadata["discord_channel_id"] = channelID
+		mentionMsg.Metadata["discord_message_id"] = m.ID
+		mentionMsg.Metadata["discord_guild_id"] = m.GuildID
+		mentionMsg.Metadata["project_id"] = link.ProjectID
+
+		mentionTopic := projectcompat.AgentTopic(link.ProjectID, bm.Name)
+
+		b.log.Debug("Delivering body mention notification",
+			"topic", mentionTopic, "sender", sender, "mentioned_agent", bm.Name)
+
+		if he := b.deliverInbound(mentionTopic, mentionMsg); he != nil {
+			b.log.Warn("Failed to deliver mention notification",
+				"agent", bm.Name, "error", he.userFacingMessage())
 		}
 	}
 }

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1138,10 +1138,13 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 	}
 
 	// Classify mentions by position before stripping.
-	classified := classifyMentions(m.Content, botUserID, agents, func(username string) (string, bool) {
-		// User resolution via store mapping is not yet wired up.
-		return "", false
-	})
+	var classified ClassifiedMentions
+	if !isAll {
+		classified = classifyMentions(m.Content, botUserID, agents, func(username string) (string, bool) {
+			// User resolution via store mapping is not yet wired up.
+			return "", false
+		})
+	}
 
 	// Determine which agent slugs are start-mentions (to strip from text).
 	// Only strip start-mention agents; body mentions stay in text.
@@ -1245,49 +1248,47 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 	}
 
 	// Deliver TypeMention notifications for body mentions.
-	targetSet := make(map[string]bool, len(targets))
-	for _, slug := range targets {
-		targetSet[slug] = true
-	}
-
-	// Build the mention source: who the primary message was addressed to.
-	var mentionSource string
-	if len(targets) == 1 {
-		mentionSource = "agent:" + targets[0]
-	} else if len(targets) > 1 {
-		recipientIDs := make([]string, len(targets))
-		for i, slug := range targets {
-			recipientIDs[i] = "agent:" + slug
-		}
-		mentionSource = messages.FormatGroupRecipients(sender, recipientIDs)
-	}
-
-	for _, bm := range classified.BodyMentions {
-		if bm.Kind != "agent" {
-			continue
-		}
-		// Skip agents already receiving the primary message.
-		if targetSet[bm.Name] {
-			continue
+	if !isAll && len(classified.BodyMentions) > 0 {
+		targetSet := make(map[string]bool, len(targets))
+		for _, slug := range targets {
+			targetSet[slug] = true
 		}
 
-		mentionMsg := messages.NewMention(sender, "agent:"+bm.Name, cleanText, mentionSource)
-		mentionMsg.SenderID = senderID
-		mentionMsg.Channel = "discord"
-		mentionMsg.ThreadID = channelID
-		mentionMsg.Metadata["discord_channel_id"] = channelID
-		mentionMsg.Metadata["discord_message_id"] = m.ID
-		mentionMsg.Metadata["discord_guild_id"] = m.GuildID
-		mentionMsg.Metadata["project_id"] = link.ProjectID
+		// Build the mention source: who the primary message was addressed to.
+		var mentionSource string
+		if groupRecipients != "" {
+			mentionSource = groupRecipients
+		} else if len(targets) == 1 {
+			mentionSource = "agent:" + targets[0]
+		}
 
-		mentionTopic := projectcompat.AgentTopic(link.ProjectID, bm.Name)
+		for _, bm := range classified.BodyMentions {
+			if bm.Kind != "agent" {
+				continue
+			}
+			// Skip agents already receiving the primary message.
+			if targetSet[bm.Name] {
+				continue
+			}
 
-		b.log.Debug("Delivering body mention notification",
-			"topic", mentionTopic, "sender", sender, "mentioned_agent", bm.Name)
+			mentionMsg := messages.NewMention(sender, "agent:"+bm.Name, cleanText, mentionSource)
+			mentionMsg.SenderID = senderID
+			mentionMsg.Channel = "discord"
+			mentionMsg.ThreadID = channelID
+			mentionMsg.Metadata["discord_channel_id"] = channelID
+			mentionMsg.Metadata["discord_message_id"] = m.ID
+			mentionMsg.Metadata["discord_guild_id"] = m.GuildID
+			mentionMsg.Metadata["project_id"] = link.ProjectID
 
-		if he := b.deliverInbound(mentionTopic, mentionMsg); he != nil {
-			b.log.Warn("Failed to deliver mention notification",
-				"agent", bm.Name, "error", he.userFacingMessage())
+			mentionTopic := projectcompat.AgentTopic(link.ProjectID, bm.Name)
+
+			b.log.Debug("Delivering body mention notification",
+				"topic", mentionTopic, "sender", sender, "mentioned_agent", bm.Name)
+
+			if he := b.deliverInbound(mentionTopic, mentionMsg); he != nil {
+				b.log.Warn("Failed to deliver mention notification",
+					"agent", bm.Name, "error", he.userFacingMessage())
+			}
 		}
 	}
 }

--- a/extras/scion-discord/internal/discord/mentions.go
+++ b/extras/scion-discord/internal/discord/mentions.go
@@ -282,9 +282,9 @@ func classifyMentions(text string, botUserID string, knownAgents []string, userR
 	strippedBody := strings.Join(bodyTokens, " ")
 
 	// Phase 2: scan body tokens for @mentions.
-	startSeen := make(map[string]bool, len(startMentions))
+	seen := make(map[string]bool, len(startMentions))
 	for _, sm := range startMentions {
-		startSeen[strings.ToLower(sm.Name)] = true
+		seen[strings.ToLower(sm.Name)] = true
 	}
 
 	var bodyMentions []Mention
@@ -296,10 +296,12 @@ func classifyMentions(text string, botUserID string, knownAgents []string, userR
 		if !ok || m.Kind == "unknown" {
 			continue
 		}
-		// Deduplicate: skip if already a start mention.
-		if startSeen[strings.ToLower(m.Name)] {
+		// Deduplicate: skip if already seen (start mention or earlier body mention).
+		lower := strings.ToLower(m.Name)
+		if seen[lower] {
 			continue
 		}
+		seen[lower] = true
 		bodyMentions = append(bodyMentions, m)
 	}
 

--- a/extras/scion-discord/internal/discord/mentions.go
+++ b/extras/scion-discord/internal/discord/mentions.go
@@ -278,8 +278,35 @@ func classifyMentions(text string, botUserID string, knownAgents []string, userR
 	}
 
 	// Build StrippedBody by dropping the leading mention tokens.
+	// Use byte-offset preservation to avoid destroying formatting.
+	var strippedBody string
+	if startTokenCount < len(tokens) {
+		idx := 0
+		tokenCount := 0
+		runes := []rune(text)
+		for idx < len(runes) {
+			// Skip whitespace.
+			for idx < len(runes) && unicode.IsSpace(runes[idx]) {
+				idx++
+			}
+			if idx >= len(runes) {
+				break
+			}
+			if tokenCount == startTokenCount {
+				break
+			}
+			// Skip non-whitespace.
+			for idx < len(runes) && !unicode.IsSpace(runes[idx]) {
+				idx++
+			}
+			tokenCount++
+		}
+		if idx < len(runes) {
+			byteOffset := len(string(runes[:idx]))
+			strippedBody = text[byteOffset:]
+		}
+	}
 	bodyTokens := tokens[startTokenCount:]
-	strippedBody := strings.Join(bodyTokens, " ")
 
 	// Phase 2: scan body tokens for @mentions.
 	seen := make(map[string]bool, len(startMentions))

--- a/extras/scion-discord/internal/discord/mentions.go
+++ b/extras/scion-discord/internal/discord/mentions.go
@@ -176,6 +176,140 @@ func extractUnresolvedMentions(text string, botUserID string, knownAgents []stri
 	return unresolved
 }
 
+// Mention represents a classified @mention in a message.
+type Mention struct {
+	Name     string // agent slug or username (without @)
+	Kind     string // "agent", "user", "unknown"
+	Identity string // resolved: "agent:agent-a", "user:email@example.com", "unknown"
+}
+
+// ClassifiedMentions holds the result of position-aware mention parsing.
+type ClassifiedMentions struct {
+	StartMentions []Mention // @mentions at the beginning of the message (primary recipients)
+	BodyMentions  []Mention // @mentions in the body of the message (mention notifications)
+	StrippedBody  string    // message text with start mentions removed, body mentions left in
+}
+
+// maxBodyMentions caps the number of body mentions to avoid spam.
+const maxBodyMentions = 5
+
+// classifyMentions performs position-aware classification of @mentions in text.
+//
+// It separates leading @mentions (start mentions used for routing) from
+// @mentions embedded in the body (used for mention notifications).
+// Discord bot mentions (<@ID> format) are skipped — they are handled separately.
+// If @all is found at the start, returns empty ClassifiedMentions.
+func classifyMentions(text string, botUserID string, knownAgents []string, userResolver func(username string) (email string, found bool)) ClassifiedMentions {
+	tokens := strings.Fields(text)
+	if len(tokens) == 0 {
+		return ClassifiedMentions{}
+	}
+
+	known := make(map[string]string, len(knownAgents))
+	for _, a := range knownAgents {
+		known[strings.ToLower(a)] = a
+	}
+
+	// classifyToken resolves a single @token into a Mention.
+	// Returns the Mention and true if resolved, or zero Mention and false if
+	// the token should be skipped (bot mention, empty name, unknown non-agent).
+	classifyToken := func(token string) (Mention, bool) {
+		// Skip Discord bot mentions: <@ID> or <@!ID>
+		if strings.HasPrefix(token, "<@") && strings.HasSuffix(token, ">") {
+			return Mention{}, false
+		}
+		if !strings.HasPrefix(token, "@") {
+			return Mention{}, false
+		}
+
+		name := strings.TrimPrefix(token, "@")
+		name = strings.TrimRightFunc(name, func(r rune) bool {
+			return unicode.IsPunct(r) && r != '_' && r != '-'
+		})
+		if name == "" {
+			return Mention{}, false
+		}
+
+		lower := strings.ToLower(name)
+		if slug, ok := known[lower]; ok {
+			return Mention{Name: slug, Kind: "agent", Identity: "agent:" + slug}, true
+		}
+		if userResolver != nil {
+			if email, found := userResolver(name); found {
+				return Mention{Name: name, Kind: "user", Identity: "user:" + email}, true
+			}
+		}
+		return Mention{Name: name, Kind: "unknown", Identity: "unknown"}, true
+	}
+
+	// Phase 1: scan leading tokens for start mentions.
+	var startMentions []Mention
+	var startTokenCount int
+
+	for _, token := range tokens {
+		// Skip Discord bot mentions at the start — they don't count as
+		// @agent mentions and shouldn't break the leading-mention scan.
+		if strings.HasPrefix(token, "<@") && strings.HasSuffix(token, ">") {
+			startTokenCount++
+			continue
+		}
+		if !strings.HasPrefix(token, "@") {
+			break // first non-mention token ends the start region
+		}
+
+		name := strings.TrimPrefix(token, "@")
+		name = strings.TrimRightFunc(name, func(r rune) bool {
+			return unicode.IsPunct(r) && r != '_' && r != '-'
+		})
+		if name == "" {
+			break
+		}
+
+		// @all at start → return empty, let broadcast logic handle it.
+		if strings.ToLower(name) == "all" {
+			return ClassifiedMentions{}
+		}
+
+		m, ok := classifyToken(token)
+		if ok {
+			startMentions = append(startMentions, m)
+		}
+		startTokenCount++
+	}
+
+	// Build StrippedBody by dropping the leading mention tokens.
+	bodyTokens := tokens[startTokenCount:]
+	strippedBody := strings.Join(bodyTokens, " ")
+
+	// Phase 2: scan body tokens for @mentions.
+	startSeen := make(map[string]bool, len(startMentions))
+	for _, sm := range startMentions {
+		startSeen[strings.ToLower(sm.Name)] = true
+	}
+
+	var bodyMentions []Mention
+	for _, token := range bodyTokens {
+		if len(bodyMentions) >= maxBodyMentions {
+			break
+		}
+		m, ok := classifyToken(token)
+		if !ok || m.Kind == "unknown" {
+			continue
+		}
+		// Deduplicate: skip if already a start mention.
+		if startSeen[strings.ToLower(m.Name)] {
+			continue
+		}
+		bodyMentions = append(bodyMentions, m)
+	}
+
+	return ClassifiedMentions{
+		StartMentions: startMentions,
+		BodyMentions:  bodyMentions,
+		StrippedBody:  strippedBody,
+	}
+}
+
 // agentFromReply extracts the agent slug from a referenced message.
 // When a user replies to a webhook message, the webhook username IS the agent
 // slug (since the Discord plugin uses per-agent webhooks with the agent slug

--- a/extras/scion-discord/internal/discord/mentions_test.go
+++ b/extras/scion-discord/internal/discord/mentions_test.go
@@ -334,3 +334,133 @@ func TestAgentFromReply_WebhookWithHyphenatedSlug(t *testing.T) {
 	}
 	assert.Equal(t, "my-agent", agentFromReply(ref, "BOT123"))
 }
+
+// --- classifyMentions tests ---
+
+// noopResolver is a userResolver that never finds a match.
+func noopResolver(_ string) (string, bool) { return "", false }
+
+func TestClassifyMentions_StartMentionsOnly(t *testing.T) {
+	result := classifyMentions("@agent-a @agent-b do this", "BOT123",
+		[]string{"agent-a", "agent-b"}, noopResolver)
+
+	assert.Equal(t, []Mention{
+		{Name: "agent-a", Kind: "agent", Identity: "agent:agent-a"},
+		{Name: "agent-b", Kind: "agent", Identity: "agent:agent-b"},
+	}, result.StartMentions)
+	assert.Empty(t, result.BodyMentions)
+	assert.Equal(t, "do this", result.StrippedBody)
+}
+
+func TestClassifyMentions_StartAndBodyMentions(t *testing.T) {
+	result := classifyMentions("@agent-a do this cc @agent-b", "BOT123",
+		[]string{"agent-a", "agent-b"}, noopResolver)
+
+	assert.Equal(t, []Mention{
+		{Name: "agent-a", Kind: "agent", Identity: "agent:agent-a"},
+	}, result.StartMentions)
+	assert.Equal(t, []Mention{
+		{Name: "agent-b", Kind: "agent", Identity: "agent:agent-b"},
+	}, result.BodyMentions)
+	assert.Equal(t, "do this cc @agent-b", result.StrippedBody)
+}
+
+func TestClassifyMentions_BodyMentionsOnly(t *testing.T) {
+	result := classifyMentions("do this @agent-a and @agent-b", "BOT123",
+		[]string{"agent-a", "agent-b"}, noopResolver)
+
+	assert.Empty(t, result.StartMentions)
+	assert.Equal(t, []Mention{
+		{Name: "agent-a", Kind: "agent", Identity: "agent:agent-a"},
+		{Name: "agent-b", Kind: "agent", Identity: "agent:agent-b"},
+	}, result.BodyMentions)
+	assert.Equal(t, "do this @agent-a and @agent-b", result.StrippedBody)
+}
+
+func TestClassifyMentions_SelfDedup(t *testing.T) {
+	// @agent-a at start, then @agent-a in body → body should be empty (deduped).
+	result := classifyMentions("@agent-a do this and ask @agent-a again", "BOT123",
+		[]string{"agent-a"}, noopResolver)
+
+	assert.Equal(t, []Mention{
+		{Name: "agent-a", Kind: "agent", Identity: "agent:agent-a"},
+	}, result.StartMentions)
+	assert.Empty(t, result.BodyMentions)
+}
+
+func TestClassifyMentions_NoMentions(t *testing.T) {
+	result := classifyMentions("fix the tests", "BOT123",
+		[]string{"agent-a", "agent-b"}, noopResolver)
+
+	assert.Empty(t, result.StartMentions)
+	assert.Empty(t, result.BodyMentions)
+	assert.Equal(t, "fix the tests", result.StrippedBody)
+}
+
+func TestClassifyMentions_AllAtStart(t *testing.T) {
+	// @all → return empty ClassifiedMentions (broadcast).
+	result := classifyMentions("@all deploy", "BOT123",
+		[]string{"agent-a", "agent-b"}, noopResolver)
+
+	assert.Empty(t, result.StartMentions)
+	assert.Empty(t, result.BodyMentions)
+	assert.Equal(t, "", result.StrippedBody)
+}
+
+func TestClassifyMentions_BodyMentionCap(t *testing.T) {
+	// 7 body mentions → only first 5 should be captured.
+	text := "do this @a1 @a2 @a3 @a4 @a5 @a6 @a7"
+	agents := []string{"a1", "a2", "a3", "a4", "a5", "a6", "a7"}
+	result := classifyMentions(text, "BOT123", agents, noopResolver)
+
+	assert.Empty(t, result.StartMentions)
+	assert.Len(t, result.BodyMentions, 5)
+	assert.Equal(t, "a1", result.BodyMentions[0].Name)
+	assert.Equal(t, "a5", result.BodyMentions[4].Name)
+}
+
+func TestClassifyMentions_DiscordBotMentionSkipped(t *testing.T) {
+	// <@BOT_ID> should be skipped, @agent-a should be a start mention.
+	result := classifyMentions("<@BOT123> @agent-a do this", "BOT123",
+		[]string{"agent-a"}, noopResolver)
+
+	assert.Equal(t, []Mention{
+		{Name: "agent-a", Kind: "agent", Identity: "agent:agent-a"},
+	}, result.StartMentions)
+	assert.Empty(t, result.BodyMentions)
+	assert.Equal(t, "do this", result.StrippedBody)
+}
+
+func TestClassifyMentions_EmptyText(t *testing.T) {
+	result := classifyMentions("", "BOT123", []string{"agent-a"}, noopResolver)
+	assert.Empty(t, result.StartMentions)
+	assert.Empty(t, result.BodyMentions)
+	assert.Equal(t, "", result.StrippedBody)
+}
+
+func TestClassifyMentions_UserResolver(t *testing.T) {
+	resolver := func(username string) (string, bool) {
+		if username == "alice" {
+			return "alice@example.com", true
+		}
+		return "", false
+	}
+	result := classifyMentions("@agent-a do this cc @alice", "BOT123",
+		[]string{"agent-a"}, resolver)
+
+	assert.Equal(t, []Mention{
+		{Name: "agent-a", Kind: "agent", Identity: "agent:agent-a"},
+	}, result.StartMentions)
+	assert.Equal(t, []Mention{
+		{Name: "alice", Kind: "user", Identity: "user:alice@example.com"},
+	}, result.BodyMentions)
+}
+
+func TestClassifyMentions_UnknownBodyMentionsSkipped(t *testing.T) {
+	// Unknown mentions in the body should be skipped.
+	result := classifyMentions("do this @stranger", "BOT123",
+		[]string{"agent-a"}, noopResolver)
+
+	assert.Empty(t, result.StartMentions)
+	assert.Empty(t, result.BodyMentions)
+}

--- a/extras/scion-discord/internal/discord/mentions_test.go
+++ b/extras/scion-discord/internal/discord/mentions_test.go
@@ -464,3 +464,16 @@ func TestClassifyMentions_UnknownBodyMentionsSkipped(t *testing.T) {
 	assert.Empty(t, result.StartMentions)
 	assert.Empty(t, result.BodyMentions)
 }
+
+func TestClassifyMentions_BodyMentionDedup(t *testing.T) {
+	// Duplicate @agent-b in body should be deduplicated.
+	result := classifyMentions("@agent-a hey @agent-b check @agent-b", "BOT123",
+		[]string{"agent-a", "agent-b"}, noopResolver)
+
+	assert.Equal(t, []Mention{
+		{Name: "agent-a", Kind: "agent", Identity: "agent:agent-a"},
+	}, result.StartMentions)
+	assert.Equal(t, []Mention{
+		{Name: "agent-b", Kind: "agent", Identity: "agent:agent-b"},
+	}, result.BodyMentions)
+}

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -1925,12 +1925,34 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 		}
 	}
 
+	// Classify mentions by position (start vs. body) for mention notifications.
+	// Skip classification for @all broadcasts — those are handled by existing logic.
+	var classified ClassifiedMentions
+	if !isAll {
+		classified = classifyMentions(tgMsg.Text, botUsername, agents, func(username string) (string, bool) {
+			// User resolver: for now return not-found. Unresolvable @chatUser
+			// mentions are dropped per the design doc.
+			return "", false
+		})
+	}
+
 	// Resolve @username mentions to scion user identities and replace
 	// text_mention display names with "user:email" in the message text.
 	resolvedText, resolvedMentionsJSON := b.resolveUserMentions(ctx, tgMsg)
 
-	// Strip bot/agent mentions to get clean message text.
-	cleanText := stripMentions(resolvedText, botUsername, targets)
+	// Strip only start-mention agent slugs (not body mentions) so body mentions
+	// remain in the delivered text. For @all or fallback routing (no classifyMentions
+	// result), fall back to stripping all targets.
+	stripSlugs := targets
+	if !isAll && len(classified.StartMentions) > 0 {
+		stripSlugs = make([]string, 0, len(classified.StartMentions))
+		for _, m := range classified.StartMentions {
+			if m.Kind == "agent" {
+				stripSlugs = append(stripSlugs, m.Name)
+			}
+		}
+	}
+	cleanText := stripMentions(resolvedText, botUsername, stripSlugs)
 	cleanText = strings.TrimSpace(cleanText)
 
 	// Download file attachments (photos/documents/audio/video).
@@ -2048,6 +2070,76 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 				}
 				b.api.SendMessage(ctx, chatID, "Message delivery failed: "+deliveryErr, replyTo) //nolint:errcheck
 			}
+		}
+	}
+
+	// Deliver TypeMention messages for body mentions (agents referenced
+	// inline in the message body, not as primary recipients).
+	if !isAll && len(classified.BodyMentions) > 0 {
+		// Build the mention source: the primary recipient identity.
+		var mentionSource string
+		if recipientsSet != "" {
+			mentionSource = recipientsSet
+		} else if len(targets) == 1 {
+			mentionSource = "agent:" + targets[0]
+		}
+
+		// Use StrippedBody (start mentions removed, body mentions preserved)
+		// as the message text for mention recipients.
+		mentionText := classified.StrippedBody
+		if placeholder != "" {
+			if mentionText != "" {
+				mentionText = mentionText + "\n" + placeholder
+			} else {
+				mentionText = placeholder
+			}
+		}
+
+		// Build a set of primary targets for dedup.
+		targetSet := make(map[string]bool, len(targets))
+		for _, slug := range targets {
+			targetSet[strings.ToLower(slug)] = true
+		}
+
+		for _, mention := range classified.BodyMentions {
+			if mention.Kind != "agent" {
+				continue
+			}
+			// Skip if the agent is already a primary target (dedup).
+			if targetSet[strings.ToLower(mention.Name)] {
+				continue
+			}
+			if mentionText == "" {
+				continue
+			}
+
+			mentionRecipient := "agent:" + mention.Name
+			mentionTopic := projectcompat.AgentTopic(link.ProjectID, mention.Name)
+
+			mentionMsg := messages.NewMention(sender, mentionRecipient, mentionText, mentionSource)
+			mentionMsg.SenderID = senderID
+			mentionMsg.Channel = "telegram"
+			mentionMsg.Metadata["telegram_chat_id"] = strconv.FormatInt(chatID, 10)
+			mentionMsg.Metadata["telegram_message_id"] = strconv.FormatInt(tgMsg.MessageID, 10)
+			mentionMsg.Metadata["project_id"] = link.ProjectID
+
+			if tgMsg.MessageThreadID != 0 {
+				mentionMsg.ThreadID = strconv.FormatInt(tgMsg.MessageThreadID, 10)
+			}
+
+			if attachmentPath != "" {
+				mentionMsg.Attachments = []string{attachmentPath}
+			}
+
+			if resolvedMentionsJSON != "" {
+				mentionMsg.Metadata["resolved_mentions"] = resolvedMentionsJSON
+			}
+
+			b.log.Debug("Delivering mention notification",
+				"topic", mentionTopic, "sender", sender, "mentioned_agent", mention.Name,
+				"mention_source", mentionSource)
+
+			b.deliverInboundWithFeedback(ctx, mentionTopic, mentionMsg) //nolint:errcheck
 		}
 	}
 }

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -1925,20 +1925,21 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 		}
 	}
 
+	// Resolve @username mentions to scion user identities and replace
+	// text_mention display names with "user:email" in the message text.
+	resolvedText, resolvedMentionsJSON := b.resolveUserMentions(ctx, tgMsg)
+
 	// Classify mentions by position (start vs. body) for mention notifications.
 	// Skip classification for @all broadcasts — those are handled by existing logic.
+	// Run on resolvedText so body-mention recipients get resolved user identities.
 	var classified ClassifiedMentions
 	if !isAll {
-		classified = classifyMentions(tgMsg.Text, botUsername, agents, func(username string) (string, bool) {
+		classified = classifyMentions(resolvedText, botUsername, agents, func(username string) (string, bool) {
 			// User resolver: for now return not-found. Unresolvable @chatUser
 			// mentions are dropped per the design doc.
 			return "", false
 		})
 	}
-
-	// Resolve @username mentions to scion user identities and replace
-	// text_mention display names with "user:email" in the message text.
-	resolvedText, resolvedMentionsJSON := b.resolveUserMentions(ctx, tgMsg)
 
 	// Strip only start-mention agent slugs (not body mentions) so body mentions
 	// remain in the delivered text. For @all or fallback routing (no classifyMentions

--- a/extras/scion-telegram/internal/telegram/mentions.go
+++ b/extras/scion-telegram/internal/telegram/mentions.go
@@ -21,6 +21,214 @@ import (
 	"unicode/utf8"
 )
 
+// maxBodyMentions is the maximum number of body mentions to include.
+const maxBodyMentions = 5
+
+// Mention represents a classified @mention in a message.
+type Mention struct {
+	Name     string // agent slug or username (without @)
+	Kind     string // "agent", "user", "unknown"
+	Identity string // resolved: "agent:agent-a", "user:email@example.com", "unknown"
+}
+
+// ClassifiedMentions holds the result of position-aware mention parsing.
+type ClassifiedMentions struct {
+	StartMentions []Mention // @mentions at the beginning of the message (primary recipients)
+	BodyMentions  []Mention // @mentions in the body of the message (mention notifications)
+	StrippedBody  string    // message text with start mentions removed, body mentions left in
+}
+
+// classifyMentions performs position-aware classification of @mentions in a message.
+// It separates leading @mentions (primary recipients) from inline body @mentions
+// (mention notifications). The bot username is skipped. If @all appears at the
+// start, an empty ClassifiedMentions is returned (let existing broadcast logic handle it).
+func classifyMentions(text string, botUsername string, knownAgents []string, userResolver func(username string) (email string, found bool)) ClassifiedMentions {
+	if text == "" {
+		return ClassifiedMentions{}
+	}
+
+	// Build case-insensitive agent lookup, mapping lowercase → original case.
+	agentMap := make(map[string]string, len(knownAgents))
+	for _, a := range knownAgents {
+		agentMap[strings.ToLower(a)] = a
+	}
+
+	lowerBot := strings.ToLower(botUsername)
+
+	// cleanMentionName strips @ prefix and trailing punctuation from a token,
+	// using the same logic as extractAgentMentions.
+	cleanName := func(token string) string {
+		name := strings.TrimPrefix(token, "@")
+		name = strings.TrimRightFunc(name, func(r rune) bool {
+			return unicode.IsPunct(r) && r != '_' && r != '-'
+		})
+		return name
+	}
+
+	// classifyName classifies a cleaned mention name into a Mention.
+	classifyName := func(name string) (Mention, bool) {
+		lower := strings.ToLower(name)
+		// Check for @all — signals broadcast.
+		if lower == "all" {
+			return Mention{}, false
+		}
+		// Skip bot username.
+		if lowerBot != "" && lower == lowerBot {
+			return Mention{}, false
+		}
+		// Check known agents.
+		if originalCase, ok := agentMap[lower]; ok {
+			return Mention{
+				Name:     originalCase,
+				Kind:     "agent",
+				Identity: "agent:" + originalCase,
+			}, true
+		}
+		// Try user resolver.
+		if userResolver != nil {
+			if email, found := userResolver(name); found {
+				return Mention{
+					Name:     name,
+					Kind:     "user",
+					Identity: "user:" + email,
+				}, true
+			}
+		}
+		// Unknown mention.
+		return Mention{
+			Name:     name,
+			Kind:     "unknown",
+			Identity: "unknown",
+		}, true
+	}
+
+	tokens := strings.Fields(text)
+	if len(tokens) == 0 {
+		return ClassifiedMentions{}
+	}
+
+	// Phase 1: Scan consecutive leading @mentions.
+	startEnd := 0 // index of first non-@ token
+	for startEnd < len(tokens) {
+		if !strings.HasPrefix(tokens[startEnd], "@") {
+			break
+		}
+		startEnd++
+	}
+
+	var startMentions []Mention
+	startSeen := make(map[string]bool)
+
+	for i := 0; i < startEnd; i++ {
+		name := cleanName(tokens[i])
+		if name == "" {
+			continue
+		}
+		lower := strings.ToLower(name)
+
+		// @all at start → return empty, let broadcast logic handle it.
+		if lower == "all" {
+			return ClassifiedMentions{}
+		}
+
+		// Skip bot username.
+		if lowerBot != "" && lower == lowerBot {
+			continue
+		}
+
+		m, ok := classifyName(name)
+		if !ok {
+			continue
+		}
+
+		if !startSeen[lower] {
+			startSeen[lower] = true
+			startMentions = append(startMentions, m)
+		}
+	}
+
+	// Compute stripped body: everything from the first non-@ token onward,
+	// preserving original spacing by using byte positions from the original text.
+	var strippedBody string
+	if startEnd < len(tokens) {
+		// Find the byte offset of the first non-@ token in the original text.
+		// We need to find the N-th whitespace-separated token's start position.
+		idx := 0
+		tokenCount := 0
+		for idx < len(text) {
+			// Skip whitespace.
+			for idx < len(text) && (text[idx] == ' ' || text[idx] == '\t' || text[idx] == '\n' || text[idx] == '\r') {
+				idx++
+			}
+			if idx >= len(text) {
+				break
+			}
+			if tokenCount == startEnd {
+				break
+			}
+			// Skip non-whitespace.
+			for idx < len(text) && text[idx] != ' ' && text[idx] != '\t' && text[idx] != '\n' && text[idx] != '\r' {
+				idx++
+			}
+			tokenCount++
+		}
+		if idx < len(text) {
+			strippedBody = text[idx:]
+		}
+	}
+
+	// Phase 2: Scan body tokens for @mentions.
+	var bodyMentions []Mention
+	bodySeen := make(map[string]bool)
+	// Merge start mentions into bodySeen for dedup.
+	for _, m := range startMentions {
+		bodySeen[strings.ToLower(m.Name)] = true
+	}
+
+	for i := startEnd; i < len(tokens) && len(bodyMentions) < maxBodyMentions; i++ {
+		if !strings.HasPrefix(tokens[i], "@") {
+			continue
+		}
+		name := cleanName(tokens[i])
+		if name == "" {
+			continue
+		}
+		lower := strings.ToLower(name)
+
+		// Skip @all in body.
+		if lower == "all" {
+			continue
+		}
+		// Skip bot.
+		if lowerBot != "" && lower == lowerBot {
+			continue
+		}
+		// Skip duplicates (including dedup with start mentions).
+		if bodySeen[lower] {
+			continue
+		}
+
+		m, ok := classifyName(name)
+		if !ok {
+			continue
+		}
+
+		// Skip unknown/unresolvable mentions in body (per spec).
+		if m.Kind == "unknown" {
+			continue
+		}
+
+		bodySeen[lower] = true
+		bodyMentions = append(bodyMentions, m)
+	}
+
+	return ClassifiedMentions{
+		StartMentions: startMentions,
+		BodyMentions:  bodyMentions,
+		StrippedBody:  strippedBody,
+	}
+}
+
 // resolveTargetAgents determines which agents a message should be routed to.
 // Returns a deduplicated list of agent slugs and whether @all was used.
 //

--- a/extras/scion-telegram/internal/telegram/mentions.go
+++ b/extras/scion-telegram/internal/telegram/mentions.go
@@ -151,29 +151,33 @@ func classifyMentions(text string, botUsername string, knownAgents []string, use
 	// preserving original spacing by using byte positions from the original text.
 	var strippedBody string
 	if startEnd < len(tokens) {
-		// Find the byte offset of the first non-@ token in the original text.
-		// We need to find the N-th whitespace-separated token's start position.
+		// Find the byte offset of the first body token (the startEnd-th
+		// whitespace-separated token) in the original text, using
+		// unicode.IsSpace to match strings.Fields' splitting behavior.
 		idx := 0
 		tokenCount := 0
-		for idx < len(text) {
+		runes := []rune(text)
+		for idx < len(runes) {
 			// Skip whitespace.
-			for idx < len(text) && (text[idx] == ' ' || text[idx] == '\t' || text[idx] == '\n' || text[idx] == '\r') {
+			for idx < len(runes) && unicode.IsSpace(runes[idx]) {
 				idx++
 			}
-			if idx >= len(text) {
+			if idx >= len(runes) {
 				break
 			}
 			if tokenCount == startEnd {
 				break
 			}
 			// Skip non-whitespace.
-			for idx < len(text) && text[idx] != ' ' && text[idx] != '\t' && text[idx] != '\n' && text[idx] != '\r' {
+			for idx < len(runes) && !unicode.IsSpace(runes[idx]) {
 				idx++
 			}
 			tokenCount++
 		}
-		if idx < len(text) {
-			strippedBody = text[idx:]
+		if idx < len(runes) {
+			// Convert rune offset back to byte offset.
+			byteOffset := len(string(runes[:idx]))
+			strippedBody = text[byteOffset:]
 		}
 	}
 

--- a/extras/scion-telegram/internal/telegram/mentions_test.go
+++ b/extras/scion-telegram/internal/telegram/mentions_test.go
@@ -169,6 +169,16 @@ func TestClassifyMentions_PreservesOriginalSpacing(t *testing.T) {
 	assert.Equal(t, "do   this   task", result.StrippedBody)
 }
 
+func TestClassifyMentions_UnicodeWhitespace(t *testing.T) {
+	// Non-breaking space (U+00A0) between mention and body text.
+	text := "@agent-a do this"
+	result := classifyMentions(text, "BotName", []string{"agent-a"}, noUserResolver)
+
+	assert.Len(t, result.StartMentions, 1)
+	assert.Equal(t, "agent-a", result.StartMentions[0].Name)
+	assert.Equal(t, "do this", result.StrippedBody)
+}
+
 func TestClassifyMentions_UnknownBodyMentionsSkipped(t *testing.T) {
 	// Body mentions that are "unknown" should be skipped per spec
 	result := classifyMentions("@agent-a do this and cc @unknownPerson", "BotName", []string{"agent-a"}, noUserResolver)

--- a/extras/scion-telegram/internal/telegram/mentions_test.go
+++ b/extras/scion-telegram/internal/telegram/mentions_test.go
@@ -21,6 +21,177 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// --- classifyMentions tests ---
+
+// noUserResolver is a stub that always returns not found.
+func noUserResolver(username string) (string, bool) { return "", false }
+
+// testUserResolver resolves "chatUser" → "chat@example.com".
+func testUserResolver(username string) (string, bool) {
+	if strings.ToLower(username) == "chatuser" {
+		return "chat@example.com", true
+	}
+	return "", false
+}
+
+func TestClassifyMentions_StartMentionsOnly(t *testing.T) {
+	// "@agent-a @agent-b do this task"
+	result := classifyMentions("@agent-a @agent-b do this task", "BotName", []string{"agent-a", "agent-b"}, noUserResolver)
+
+	assert.Len(t, result.StartMentions, 2)
+	assert.Equal(t, "agent-a", result.StartMentions[0].Name)
+	assert.Equal(t, "agent", result.StartMentions[0].Kind)
+	assert.Equal(t, "agent:agent-a", result.StartMentions[0].Identity)
+	assert.Equal(t, "agent-b", result.StartMentions[1].Name)
+	assert.Len(t, result.BodyMentions, 0)
+	assert.Equal(t, "do this task", result.StrippedBody)
+}
+
+func TestClassifyMentions_StartAndBodyMentions(t *testing.T) {
+	// "@agent-a do this and cc @agent-b"
+	result := classifyMentions("@agent-a do this and cc @agent-b", "BotName", []string{"agent-a", "agent-b"}, noUserResolver)
+
+	assert.Len(t, result.StartMentions, 1)
+	assert.Equal(t, "agent-a", result.StartMentions[0].Name)
+	assert.Len(t, result.BodyMentions, 1)
+	assert.Equal(t, "agent-b", result.BodyMentions[0].Name)
+	assert.Equal(t, "agent:agent-b", result.BodyMentions[0].Identity)
+	assert.Equal(t, "do this and cc @agent-b", result.StrippedBody)
+}
+
+func TestClassifyMentions_MultipleStartOneBody(t *testing.T) {
+	// "@agent-a @agent-b do this cc @agent-c"
+	result := classifyMentions("@agent-a @agent-b do this cc @agent-c", "BotName", []string{"agent-a", "agent-b", "agent-c"}, noUserResolver)
+
+	assert.Len(t, result.StartMentions, 2)
+	assert.Equal(t, "agent-a", result.StartMentions[0].Name)
+	assert.Equal(t, "agent-b", result.StartMentions[1].Name)
+	assert.Len(t, result.BodyMentions, 1)
+	assert.Equal(t, "agent-c", result.BodyMentions[0].Name)
+}
+
+func TestClassifyMentions_NoStartMentions(t *testing.T) {
+	// "do this @agent-a and @agent-b"
+	result := classifyMentions("do this @agent-a and @agent-b", "BotName", []string{"agent-a", "agent-b"}, noUserResolver)
+
+	assert.Len(t, result.StartMentions, 0)
+	assert.Len(t, result.BodyMentions, 2)
+	assert.Equal(t, "agent-a", result.BodyMentions[0].Name)
+	assert.Equal(t, "agent-b", result.BodyMentions[1].Name)
+	assert.Equal(t, "do this @agent-a and @agent-b", result.StrippedBody)
+}
+
+func TestClassifyMentions_UserMentionResolved(t *testing.T) {
+	// "@chatUser do this for @agent-a"
+	result := classifyMentions("@chatUser do this for @agent-a", "BotName", []string{"agent-a"}, testUserResolver)
+
+	assert.Len(t, result.StartMentions, 1)
+	assert.Equal(t, "chatUser", result.StartMentions[0].Name)
+	assert.Equal(t, "user", result.StartMentions[0].Kind)
+	assert.Equal(t, "user:chat@example.com", result.StartMentions[0].Identity)
+	assert.Len(t, result.BodyMentions, 1)
+	assert.Equal(t, "agent-a", result.BodyMentions[0].Name)
+}
+
+func TestClassifyMentions_UnresolvableUser(t *testing.T) {
+	// "@chatUser do this" with noUserResolver
+	result := classifyMentions("@chatUser do this", "BotName", []string{"agent-a"}, noUserResolver)
+
+	assert.Len(t, result.StartMentions, 1)
+	assert.Equal(t, "unknown", result.StartMentions[0].Kind)
+	assert.Equal(t, "unknown", result.StartMentions[0].Identity)
+	assert.Len(t, result.BodyMentions, 0)
+}
+
+func TestClassifyMentions_SelfDedup(t *testing.T) {
+	// "@agent-a do this and ask @agent-a again"
+	result := classifyMentions("@agent-a do this and ask @agent-a again", "BotName", []string{"agent-a"}, noUserResolver)
+
+	assert.Len(t, result.StartMentions, 1)
+	assert.Equal(t, "agent-a", result.StartMentions[0].Name)
+	assert.Len(t, result.BodyMentions, 0) // agent-a already in start, so skipped in body
+}
+
+func TestClassifyMentions_NoMentions(t *testing.T) {
+	// "fix the tests" — no mentions at all; stripped body is the full text
+	// (nothing was removed since there are no start mentions)
+	result := classifyMentions("fix the tests", "BotName", []string{"agent-a"}, noUserResolver)
+
+	assert.Len(t, result.StartMentions, 0)
+	assert.Len(t, result.BodyMentions, 0)
+	assert.Equal(t, "fix the tests", result.StrippedBody)
+}
+
+func TestClassifyMentions_AllBroadcast(t *testing.T) {
+	// "@all deploy" → empty ClassifiedMentions
+	result := classifyMentions("@all deploy", "BotName", []string{"agent-a", "agent-b"}, noUserResolver)
+
+	assert.Len(t, result.StartMentions, 0)
+	assert.Len(t, result.BodyMentions, 0)
+	assert.Equal(t, "", result.StrippedBody)
+}
+
+func TestClassifyMentions_BotNameSkipped(t *testing.T) {
+	// "@BotName @agent-a do this"
+	result := classifyMentions("@BotName @agent-a do this", "BotName", []string{"agent-a"}, noUserResolver)
+
+	assert.Len(t, result.StartMentions, 1)
+	assert.Equal(t, "agent-a", result.StartMentions[0].Name)
+	assert.Len(t, result.BodyMentions, 0)
+	assert.Equal(t, "do this", result.StrippedBody)
+}
+
+func TestClassifyMentions_BodyMentionCap(t *testing.T) {
+	// Message with 7 body mentions → only first 5
+	text := "do this @a1 @a2 @a3 @a4 @a5 @a6 @a7"
+	agents := []string{"a1", "a2", "a3", "a4", "a5", "a6", "a7"}
+	result := classifyMentions(text, "BotName", agents, noUserResolver)
+
+	assert.Len(t, result.StartMentions, 0)
+	assert.Len(t, result.BodyMentions, 5)
+	assert.Equal(t, "a1", result.BodyMentions[0].Name)
+	assert.Equal(t, "a5", result.BodyMentions[4].Name)
+}
+
+func TestClassifyMentions_CaseInsensitiveAgentMatch(t *testing.T) {
+	// "@AGENT-A do this" should match "agent-a" (case-insensitive)
+	result := classifyMentions("@AGENT-A do this", "BotName", []string{"agent-a"}, noUserResolver)
+
+	assert.Len(t, result.StartMentions, 1)
+	assert.Equal(t, "agent-a", result.StartMentions[0].Name) // uses original case from knownAgents
+	assert.Equal(t, "agent:agent-a", result.StartMentions[0].Identity)
+}
+
+func TestClassifyMentions_PreservesOriginalSpacing(t *testing.T) {
+	// "@agent-a   do   this   task" — stripped body preserves original spacing
+	result := classifyMentions("@agent-a   do   this   task", "BotName", []string{"agent-a"}, noUserResolver)
+
+	assert.Equal(t, "do   this   task", result.StrippedBody)
+}
+
+func TestClassifyMentions_UnknownBodyMentionsSkipped(t *testing.T) {
+	// Body mentions that are "unknown" should be skipped per spec
+	result := classifyMentions("@agent-a do this and cc @unknownPerson", "BotName", []string{"agent-a"}, noUserResolver)
+
+	assert.Len(t, result.StartMentions, 1)
+	assert.Len(t, result.BodyMentions, 0) // @unknownPerson is unknown, skipped in body
+}
+
+func TestClassifyMentions_EmptyText(t *testing.T) {
+	result := classifyMentions("", "BotName", []string{"agent-a"}, noUserResolver)
+	assert.Len(t, result.StartMentions, 0)
+	assert.Len(t, result.BodyMentions, 0)
+	assert.Equal(t, "", result.StrippedBody)
+}
+
+func TestClassifyMentions_TrailingPunctuation(t *testing.T) {
+	// "@agent-a, do this" — trailing comma stripped from agent name
+	result := classifyMentions("@agent-a, do this", "BotName", []string{"agent-a"}, noUserResolver)
+
+	assert.Len(t, result.StartMentions, 1)
+	assert.Equal(t, "agent-a", result.StartMentions[0].Name)
+}
+
 func TestResolveTargetAgents_BotMentionOnly(t *testing.T) {
 	msg := &TGMessage{
 		Text: "@ScionHubBot please help",

--- a/pkg/messages/types.go
+++ b/pkg/messages/types.go
@@ -55,6 +55,7 @@ const (
 	TypeStateChange    = "state-change"
 	TypeAssistantReply = "assistant-reply"
 	TypeGroupSet       = "group-set"
+	TypeMention        = "mention"
 )
 
 // Visibility constants control which consumers see a message.
@@ -84,6 +85,7 @@ var validTypes = map[string]bool{
 	TypeStateChange:    true,
 	TypeAssistantReply: true,
 	TypeGroupSet:       true,
+	TypeMention:        true,
 }
 
 // StructuredMessage represents a formatted Scion message.
@@ -117,7 +119,7 @@ type StructuredMessage struct {
 // ValidateType returns an error if the message type is not in the closed enum.
 func ValidateType(t string) error {
 	if !validTypes[t] {
-		return fmt.Errorf("invalid message type %q: must be one of: instruction, input-needed, state-change, assistant-reply, group-set", t)
+		return fmt.Errorf("invalid message type %q: must be one of: instruction, input-needed, state-change, assistant-reply, group-set, mention", t)
 	}
 	return nil
 }
@@ -194,6 +196,24 @@ func NewNotification(sender, recipient, msg, msgType string) *StructuredMessage 
 		Recipient: recipient,
 		Msg:       msg,
 		Type:      msgType,
+	}
+}
+
+// NewMention creates a mention notification message.
+// mentionSource identifies who the primary recipient of the original message was
+// (e.g., "agent:agent-a" or "group[sender,agent:a,agent:b]").
+func NewMention(sender, recipient, msg, mentionSource string) *StructuredMessage {
+	return &StructuredMessage{
+		Version:   Version,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Sender:    sender,
+		Recipient: recipient,
+		Msg:       msg,
+		Type:      TypeMention,
+		Metadata: map[string]string{
+			"mention_source":   mentionSource,
+			"mention_position": "body",
+		},
 	}
 }
 

--- a/pkg/messages/types.go
+++ b/pkg/messages/types.go
@@ -247,6 +247,25 @@ func (m *StructuredMessage) LogAttrs() []any {
 	return attrs
 }
 
+// NewMention creates a new mention notification message.
+// mentionSource identifies the primary recipient(s) whose conversation triggered the mention
+// (e.g., "agent:coder" or "group[user:alice agent:coder agent:reviewer]").
+func NewMention(sender, recipient, msg, mentionSource string) *StructuredMessage {
+	m := &StructuredMessage{
+		Version:   Version,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Sender:    sender,
+		Recipient: recipient,
+		Msg:       msg,
+		Type:      TypeMention,
+		Metadata:  map[string]string{},
+	}
+	if mentionSource != "" {
+		m.Metadata["mention_source"] = mentionSource
+	}
+	return m
+}
+
 // SenderPrefix returns the type prefix for a sender identity string.
 // For example, "user:alice" returns "user", "agent:code-reviewer" returns "agent".
 func SenderPrefix(identity string) string {

--- a/pkg/messages/types.go
+++ b/pkg/messages/types.go
@@ -247,25 +247,6 @@ func (m *StructuredMessage) LogAttrs() []any {
 	return attrs
 }
 
-// NewMention creates a new mention notification message.
-// mentionSource identifies the primary recipient(s) whose conversation triggered the mention
-// (e.g., "agent:coder" or "group[user:alice agent:coder agent:reviewer]").
-func NewMention(sender, recipient, msg, mentionSource string) *StructuredMessage {
-	m := &StructuredMessage{
-		Version:   Version,
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-		Sender:    sender,
-		Recipient: recipient,
-		Msg:       msg,
-		Type:      TypeMention,
-		Metadata:  map[string]string{},
-	}
-	if mentionSource != "" {
-		m.Metadata["mention_source"] = mentionSource
-	}
-	return m
-}
-
 // SenderPrefix returns the type prefix for a sender identity string.
 // For example, "user:alice" returns "user", "agent:code-reviewer" returns "agent".
 func SenderPrefix(identity string) string {

--- a/pkg/messages/types_test.go
+++ b/pkg/messages/types_test.go
@@ -29,6 +29,7 @@ func TestValidateType(t *testing.T) {
 		{TypeStateChange, false},
 		{TypeAssistantReply, false},
 		{TypeGroupSet, false},
+		{TypeMention, false},
 		{"unknown", true},
 		{"", true},
 	}
@@ -388,6 +389,55 @@ func TestLogAttrsWithRecipients(t *testing.T) {
 	}
 	if !found {
 		t.Error("LogAttrs() should include recipients when set")
+	}
+}
+
+func TestStructuredMessage_ValidateMention(t *testing.T) {
+	m := &StructuredMessage{
+		Version:   Version,
+		Timestamp: "2026-07-19T10:00:00Z",
+		Sender:    "agent:relay",
+		Recipient: "agent:worker",
+		Msg:       "you were mentioned in a message",
+		Type:      TypeMention,
+		Metadata: map[string]string{
+			"mention_source":   "agent:agent-a",
+			"mention_position": "body",
+		},
+	}
+	if err := m.Validate(); err != nil {
+		t.Errorf("unexpected error for valid mention message: %v", err)
+	}
+}
+
+func TestNewMention(t *testing.T) {
+	m := NewMention("agent:relay", "agent:worker", "you were mentioned", "group[sender,agent:a,agent:b]")
+	if m.Version != Version {
+		t.Errorf("version = %d, want %d", m.Version, Version)
+	}
+	if m.Type != TypeMention {
+		t.Errorf("type = %q, want %q", m.Type, TypeMention)
+	}
+	if m.Sender != "agent:relay" {
+		t.Errorf("sender = %q, want %q", m.Sender, "agent:relay")
+	}
+	if m.Recipient != "agent:worker" {
+		t.Errorf("recipient = %q, want %q", m.Recipient, "agent:worker")
+	}
+	if m.Msg != "you were mentioned" {
+		t.Errorf("msg = %q, want %q", m.Msg, "you were mentioned")
+	}
+	if m.Timestamp == "" {
+		t.Error("timestamp should be set")
+	}
+	if m.Metadata == nil {
+		t.Fatal("metadata should not be nil")
+	}
+	if got := m.Metadata["mention_source"]; got != "group[sender,agent:a,agent:b]" {
+		t.Errorf("metadata[mention_source] = %q, want %q", got, "group[sender,agent:a,agent:b]")
+	}
+	if got := m.Metadata["mention_position"]; got != "body" {
+		t.Errorf("metadata[mention_position] = %q, want %q", got, "body")
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/ptone/scion/issues/517

Implements position-aware @mention classification and TypeMention message delivery across the Scion messaging system.

Changes:
- pkg/messages/types.go: Add TypeMention constant, NewMention() constructor with mention_source/mention_position metadata
- Telegram broker: classifyMentions() with 16 unit tests, integrated into handleGroupMessage() for TypeMention delivery
- Discord broker: mirrored classifyMentions() with 12 unit tests, TypeGroupSet support, integrated into handleIncomingMessage()

Key behaviors:
- Start mentions (@agent at message beginning) route as TypeInstruction/TypeGroupSet (existing behavior)
- Body mentions (@agent inline in text) generate TypeMention notifications
- Self-mention dedup: agent receiving instruction does not also get mention
- Body mention cap: 5 per message
- @all handling unchanged

3 bugs found and fixed during code review