### PR TITLE
fix(discord,telegram): route body @mentions as TypeMention, not group recipients

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1159,6 +1159,27 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 		}
 	}
 
+	// Filter targets to only start-mention agents.
+	// Body-mention agents will be handled by the TypeMention delivery loop.
+	startMentionSet := make(map[string]bool)
+	for _, sm := range classified.StartMentions {
+		if sm.Kind == "agent" {
+			startMentionSet[strings.ToLower(sm.Name)] = true
+		}
+	}
+
+	// Replace targets with only the start-mention agents.
+	// (Keep isAll path unchanged — @all means all agents are start targets)
+	if !isAll && len(classified.StartMentions) > 0 {
+		filteredTargets := make([]string, 0, len(classified.StartMentions))
+		for _, t := range targets {
+			if startMentionSet[strings.ToLower(t)] {
+				filteredTargets = append(filteredTargets, t)
+			}
+		}
+		targets = filteredTargets
+	}
+
 	// Strip bot and start-mention agent mentions from message text.
 	// Body-mention agents remain visible in the delivered text.
 	cleanText := stripMentions(m.Content, botUserID, stripSlugs)

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1159,25 +1159,43 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 		}
 	}
 
-	// Filter targets to only start-mention agents.
+	// Filter targets to only start-mention agents, or exclude body-mention agents if no start-mentions exist.
 	// Body-mention agents will be handled by the TypeMention delivery loop.
-	startMentionSet := make(map[string]bool)
-	for _, sm := range classified.StartMentions {
-		if sm.Kind == "agent" {
-			startMentionSet[strings.ToLower(sm.Name)] = true
-		}
-	}
+	if !isAll {
+		if len(classified.StartMentions) > 0 {
+			startMentionSet := make(map[string]bool, len(classified.StartMentions))
+			for _, sm := range classified.StartMentions {
+				if sm.Kind == "agent" {
+					startMentionSet[strings.ToLower(sm.Name)] = true
+				}
+			}
+			filteredTargets := make([]string, 0, len(targets))
+			for _, t := range targets {
+				if startMentionSet[strings.ToLower(t)] {
+					filteredTargets = append(filteredTargets, t)
+				}
+			}
+			targets = filteredTargets
+		} else {
+			// No start mentions: don't strip any agents from text (body mentions stay visible).
+			stripSlugs = nil
 
-	// Replace targets with only the start-mention agents.
-	// (Keep isAll path unchanged — @all means all agents are start targets)
-	if !isAll && len(classified.StartMentions) > 0 {
-		filteredTargets := make([]string, 0, len(classified.StartMentions))
-		for _, t := range targets {
-			if startMentionSet[strings.ToLower(t)] {
-				filteredTargets = append(filteredTargets, t)
+			if len(classified.BodyMentions) > 0 {
+				bodyMentionSet := make(map[string]bool, len(classified.BodyMentions))
+				for _, bm := range classified.BodyMentions {
+					if bm.Kind == "agent" {
+						bodyMentionSet[strings.ToLower(bm.Name)] = true
+					}
+				}
+				filteredTargets := make([]string, 0, len(targets))
+				for _, t := range targets {
+					if !bodyMentionSet[strings.ToLower(t)] {
+						filteredTargets = append(filteredTargets, t)
+					}
+				}
+				targets = filteredTargets
 			}
 		}
-		targets = filteredTargets
 	}
 
 	// Strip bot and start-mention agent mentions from message text.

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -1953,6 +1953,27 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 			}
 		}
 	}
+	// Filter targets to only start-mention agents.
+	// Body-mention agents will be handled by the TypeMention delivery loop.
+	startMentionSet := make(map[string]bool)
+	for _, sm := range classified.StartMentions {
+		if sm.Kind == "agent" {
+			startMentionSet[strings.ToLower(sm.Name)] = true
+		}
+	}
+
+	// Replace targets with only the start-mention agents.
+	// (Keep isAll path unchanged — @all means all agents are start targets)
+	if !isAll && len(classified.StartMentions) > 0 {
+		filteredTargets := make([]string, 0, len(classified.StartMentions))
+		for _, t := range targets {
+			if startMentionSet[strings.ToLower(t)] {
+				filteredTargets = append(filteredTargets, t)
+			}
+		}
+		targets = filteredTargets
+	}
+
 	cleanText := stripMentions(resolvedText, botUsername, stripSlugs)
 	cleanText = strings.TrimSpace(cleanText)
 

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -1953,25 +1953,43 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 			}
 		}
 	}
-	// Filter targets to only start-mention agents.
+	// Filter targets to only start-mention agents, or exclude body-mention agents if no start-mentions exist.
 	// Body-mention agents will be handled by the TypeMention delivery loop.
-	startMentionSet := make(map[string]bool)
-	for _, sm := range classified.StartMentions {
-		if sm.Kind == "agent" {
-			startMentionSet[strings.ToLower(sm.Name)] = true
-		}
-	}
+	if !isAll {
+		if len(classified.StartMentions) > 0 {
+			startMentionSet := make(map[string]bool, len(classified.StartMentions))
+			for _, sm := range classified.StartMentions {
+				if sm.Kind == "agent" {
+					startMentionSet[strings.ToLower(sm.Name)] = true
+				}
+			}
+			filteredTargets := make([]string, 0, len(targets))
+			for _, t := range targets {
+				if startMentionSet[strings.ToLower(t)] {
+					filteredTargets = append(filteredTargets, t)
+				}
+			}
+			targets = filteredTargets
+		} else {
+			// No start mentions: don't strip any agents from text (body mentions stay visible).
+			stripSlugs = nil
 
-	// Replace targets with only the start-mention agents.
-	// (Keep isAll path unchanged — @all means all agents are start targets)
-	if !isAll && len(classified.StartMentions) > 0 {
-		filteredTargets := make([]string, 0, len(classified.StartMentions))
-		for _, t := range targets {
-			if startMentionSet[strings.ToLower(t)] {
-				filteredTargets = append(filteredTargets, t)
+			if len(classified.BodyMentions) > 0 {
+				bodyMentionSet := make(map[string]bool, len(classified.BodyMentions))
+				for _, bm := range classified.BodyMentions {
+					if bm.Kind == "agent" {
+						bodyMentionSet[strings.ToLower(bm.Name)] = true
+					}
+				}
+				filteredTargets := make([]string, 0, len(targets))
+				for _, t := range targets {
+					if !bodyMentionSet[strings.ToLower(t)] {
+						filteredTargets = append(filteredTargets, t)
+					}
+				}
+				targets = filteredTargets
 			}
 		}
-		targets = filteredTargets
 	}
 
 	cleanText := stripMentions(resolvedText, botUsername, stripSlugs)


### PR DESCRIPTION
Fixes body @mention routing bug in the mention message type feature.

Root cause: resolveTargetAgents() collected ALL @mentioned agents into targets before classifyMentions() ran. Since len(targets)>1, TypeGroupSet was triggered for all agents, and body-mention agents were skipped by the dedup check — never receiving TypeMention notifications.

Fix: after classifyMentions(), narrow targets to only start-mention agents. Body-mention agents then correctly fall through to the TypeMention delivery loop.

Confirmed with live logs on scion-es: both agents were receiving group-set; after fix, start-mention agent receives instruction and body-mention agent receives TypeMention