### PR TITLE
fix(discord,telegram): restore default agent when body-mention filter empties targets

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1196,6 +1196,11 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 				targets = filteredTargets
 			}
 		}
+
+		// If body-mention filter emptied targets, restore default agent so instruction is delivered.
+		if len(targets) == 0 && effectiveDefault != "" {
+			targets = []string{effectiveDefault}
+		}
 	}
 
 	// Strip bot and start-mention agent mentions from message text.

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1198,8 +1198,11 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 		}
 
 		// If body-mention filter emptied targets, restore default agent so instruction is delivered.
-		if len(targets) == 0 && effectiveDefault != "" {
-			targets = []string{effectiveDefault}
+		if len(targets) == 0 && len(classified.StartMentions) == 0 && effectiveDefault != "" && !hasNonBotMentions(m.Message, botUserID) {
+			text := strings.TrimSpace(m.Content)
+			if text != "" && !strings.HasPrefix(text, "/") {
+				targets = []string{effectiveDefault}
+			}
 		}
 	}
 

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -1990,6 +1990,11 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 				targets = filteredTargets
 			}
 		}
+
+		// If body-mention filter emptied targets, restore default agent so instruction is delivered.
+		if len(targets) == 0 && effectiveDefault != "" {
+			targets = []string{effectiveDefault}
+		}
 	}
 
 	cleanText := stripMentions(resolvedText, botUsername, stripSlugs)

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -1992,8 +1992,13 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 		}
 
 		// If body-mention filter emptied targets, restore default agent so instruction is delivered.
-		if len(targets) == 0 && effectiveDefault != "" {
-			targets = []string{effectiveDefault}
+		if len(targets) == 0 && len(classified.StartMentions) == 0 && effectiveDefault != "" {
+			hasAttachment := tgMsg.Photo != nil || tgMsg.Document != nil || tgMsg.Audio != nil || tgMsg.Video != nil
+			text := strings.TrimSpace(tgMsg.Text)
+			textRoutes := text != "" && !strings.HasPrefix(text, "/") && !hasNonBotUserMention(tgMsg, botUsername, agents)
+			if (textRoutes || hasAttachment) && slices.Contains(agents, effectiveDefault) {
+				targets = []string{effectiveDefault}
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/517

When a message has only body @mentions and no start mentions (e.g. "message cc @agent-b"), the body-mention filter correctly removes @agent-b from targets. But this left targets empty — the default agent fallback had already run earlier and was lost, so no instruction was delivered at all.

Fix: after the body-mention filter block, if targets is empty and an effective default agent exists, restore it so the default agent receives the instruction. The @mention target still receives a TypeMention notification separately