### PR TITLE
fix(discord): show observed messages under sender webhook identity, add embed styling

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -531,9 +531,13 @@ func (b *DiscordBroker) Publish(ctx context.Context, topic string, msg *messages
 		msg.Type == messages.TypeInstruction
 
 	// Extract agent slug from sender for webhook username.
-	senderSlug := agentSlug
-	if senderSlug == "" && strings.HasPrefix(msg.Sender, "agent:") {
+	// Prefer msg.Sender so observed agent-to-agent messages display under the sender's identity.
+	var senderSlug string
+	if strings.HasPrefix(msg.Sender, "agent:") {
 		senderSlug = strings.TrimPrefix(msg.Sender, "agent:")
+	}
+	if senderSlug == "" {
+		senderSlug = agentSlug // fallback to topic agent for non-agent senders
 	}
 
 	// Replace scion user emails with Discord @mentions in the message body.
@@ -597,6 +601,13 @@ func (b *DiscordBroker) Publish(ctx context.Context, topic string, msg *messages
 	isStateChange := msg != nil && msg.Type == messages.TypeStateChange
 	needsFilter := isAgentToAgent || isStateChange
 
+	// Build an embed for observed agent-to-agent messages so they are
+	// visually distinct from direct messages (gray sidebar, sender→recipient title).
+	var observeEmbeds []*discordgo.MessageEmbed
+	if isAgentToAgent {
+		observeEmbeds = []*discordgo.MessageEmbed{formatObservedEmbed(msg)}
+	}
+
 	// Send to each target channel.
 	var errs []error
 	for _, channelID := range channelIDs {
@@ -642,9 +653,9 @@ func (b *DiscordBroker) Publish(ctx context.Context, topic string, msg *messages
 			// webhook on the parent channel and execute with thread_id.
 			parentID, isThread := b.resolveThreadParent(channelID)
 			if isThread && parentID != "" {
-				_, err = webhooks.SendAsAgentInThread(parentID, channelID, senderSlug, text, nil, nil, files)
+				_, err = webhooks.SendAsAgentInThread(parentID, channelID, senderSlug, text, observeEmbeds, nil, files)
 			} else {
-				_, err = webhooks.SendAsAgent(channelID, senderSlug, text, nil, nil, files)
+				_, err = webhooks.SendAsAgent(channelID, senderSlug, text, observeEmbeds, nil, files)
 			}
 			if err != nil {
 				// Fallback to bot API if webhook send fails.

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -532,13 +532,7 @@ func (b *DiscordBroker) Publish(ctx context.Context, topic string, msg *messages
 
 	// Extract agent slug from sender for webhook username.
 	// Prefer msg.Sender so observed agent-to-agent messages display under the sender's identity.
-	var senderSlug string
-	if strings.HasPrefix(msg.Sender, "agent:") {
-		senderSlug = strings.TrimPrefix(msg.Sender, "agent:")
-	}
-	if senderSlug == "" {
-		senderSlug = agentSlug // fallback to topic agent for non-agent senders
-	}
+	senderSlug := deriveSenderSlug(msg.Sender, agentSlug)
 
 	// Replace scion user emails with Discord @mentions in the message body.
 	msg.Msg = resolveOutboundMentions(ctx, store, msg.Msg)

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -704,21 +704,8 @@ func TestResolveOutboundMentions(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// senderSlug derivation (mirrors broker.go publish logic)
+// senderSlug derivation — uses shared deriveSenderSlug from format.go
 // ---------------------------------------------------------------------------
-
-// deriveSenderSlug mirrors the senderSlug logic in publishToDiscord so we can
-// unit-test it without wiring up the full broker.
-func deriveSenderSlug(sender, agentSlug string) string {
-	var senderSlug string
-	if strings.HasPrefix(sender, "agent:") {
-		senderSlug = strings.TrimPrefix(sender, "agent:")
-	}
-	if senderSlug == "" {
-		senderSlug = agentSlug
-	}
-	return senderSlug
-}
 
 func TestDeriveSenderSlug(t *testing.T) {
 	tests := []struct {

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -702,3 +702,66 @@ func TestResolveOutboundMentions(t *testing.T) {
 		assert.Equal(t, "ptone@google.com", got)
 	})
 }
+
+// ---------------------------------------------------------------------------
+// senderSlug derivation (mirrors broker.go publish logic)
+// ---------------------------------------------------------------------------
+
+// deriveSenderSlug mirrors the senderSlug logic in publishToDiscord so we can
+// unit-test it without wiring up the full broker.
+func deriveSenderSlug(sender, agentSlug string) string {
+	var senderSlug string
+	if strings.HasPrefix(sender, "agent:") {
+		senderSlug = strings.TrimPrefix(sender, "agent:")
+	}
+	if senderSlug == "" {
+		senderSlug = agentSlug
+	}
+	return senderSlug
+}
+
+func TestDeriveSenderSlug(t *testing.T) {
+	tests := []struct {
+		name      string
+		sender    string
+		agentSlug string
+		want      string
+	}{
+		{
+			name:      "sender is agent — uses sender slug",
+			sender:    "agent:builder",
+			agentSlug: "reviewer",
+			want:      "builder",
+		},
+		{
+			name:      "sender is not agent — falls back to agentSlug",
+			sender:    "user:alice@example.com",
+			agentSlug: "coder",
+			want:      "coder",
+		},
+		{
+			name:      "sender is agent and agentSlug is empty",
+			sender:    "agent:deployer",
+			agentSlug: "",
+			want:      "deployer",
+		},
+		{
+			name:      "sender is not agent and agentSlug is empty",
+			sender:    "user:bob@example.com",
+			agentSlug: "",
+			want:      "",
+		},
+		{
+			name:      "observe mode — sender differs from topic agent",
+			sender:    "agent:agent-b",
+			agentSlug: "agent-a",
+			want:      "agent-b",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveSenderSlug(tt.sender, tt.agentSlug)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/extras/scion-discord/internal/discord/format.go
+++ b/extras/scion-discord/internal/discord/format.go
@@ -405,6 +405,9 @@ func SplitLongMessage(text string, maxLen int) []string {
 // formatObservedEmbed creates an embed for observed/relayed agent-to-agent
 // messages. The gray sidebar visually distinguishes them from direct messages.
 func formatObservedEmbed(msg *messages.StructuredMessage) *discordgo.MessageEmbed {
+	if msg == nil {
+		return nil
+	}
 	senderSlug := strings.TrimPrefix(msg.Sender, "agent:")
 	recipientSlug := strings.TrimPrefix(msg.Recipient, "agent:")
 	return &discordgo.MessageEmbed{
@@ -412,4 +415,17 @@ func formatObservedEmbed(msg *messages.StructuredMessage) *discordgo.MessageEmbe
 		Description: msg.Msg,
 		Color:       0x808080, // gray sidebar distinguishes relayed from direct messages
 	}
+}
+
+// deriveSenderSlug extracts the sender's display slug from the message sender
+// field, falling back to the topic-derived agentSlug when the sender is not an agent.
+func deriveSenderSlug(sender, agentSlug string) string {
+	var senderSlug string
+	if strings.HasPrefix(sender, "agent:") {
+		senderSlug = strings.TrimPrefix(sender, "agent:")
+	}
+	if senderSlug == "" {
+		senderSlug = agentSlug
+	}
+	return senderSlug
 }

--- a/extras/scion-discord/internal/discord/format.go
+++ b/extras/scion-discord/internal/discord/format.go
@@ -401,3 +401,15 @@ func SplitLongMessage(text string, maxLen int) []string {
 	}
 	return chunks
 }
+
+// formatObservedEmbed creates an embed for observed/relayed agent-to-agent
+// messages. The gray sidebar visually distinguishes them from direct messages.
+func formatObservedEmbed(msg *messages.StructuredMessage) *discordgo.MessageEmbed {
+	senderSlug := strings.TrimPrefix(msg.Sender, "agent:")
+	recipientSlug := strings.TrimPrefix(msg.Recipient, "agent:")
+	return &discordgo.MessageEmbed{
+		Title:       fmt.Sprintf("%s → %s", senderSlug, recipientSlug),
+		Description: msg.Msg,
+		Color:       0x808080, // gray sidebar distinguishes relayed from direct messages
+	}
+}

--- a/extras/scion-discord/internal/discord/format_test.go
+++ b/extras/scion-discord/internal/discord/format_test.go
@@ -441,3 +441,33 @@ func TestTruncateForDiscord_Truncates(t *testing.T) {
 	assert.LessOrEqual(t, len(result), 2000)
 	assert.True(t, strings.HasSuffix(result, truncationSuffix))
 }
+
+// ---------------------------------------------------------------------------
+// formatObservedEmbed
+// ---------------------------------------------------------------------------
+
+func TestFormatObservedEmbed_AgentToAgent(t *testing.T) {
+	msg := &messages.StructuredMessage{
+		Sender:    "agent:builder",
+		Recipient: "agent:reviewer",
+		Msg:       "please review this change",
+	}
+	embed := formatObservedEmbed(msg)
+	require.NotNil(t, embed)
+	assert.Equal(t, "builder → reviewer", embed.Title)
+	assert.Equal(t, "please review this change", embed.Description)
+	assert.Equal(t, 0x808080, embed.Color)
+}
+
+func TestFormatObservedEmbed_NonAgentSender(t *testing.T) {
+	// When sender is not an agent, TrimPrefix is a no-op and returns the full sender string.
+	msg := &messages.StructuredMessage{
+		Sender:    "user:alice@example.com",
+		Recipient: "agent:coder",
+		Msg:       "hello",
+	}
+	embed := formatObservedEmbed(msg)
+	require.NotNil(t, embed)
+	assert.Equal(t, "user:alice@example.com → coder", embed.Title)
+	assert.Equal(t, "hello", embed.Description)
+}


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/519

Observed agent-to-agent messages were displaying under the recipient's webhook avatar because senderSlug was derived from the topic agent slug (= recipient) instead of msg.Sender. When msg.Sender was a non-empty agent, the fallback was never reached.

Fix: prefer msg.Sender when it is an agent, fall back to agentSlug for non-agent senders. Also adds a gray-sidebar Discord embed for observed messages to visually distinguish them from direct messages (sender → recipient in embed title).

Non-blocking note: embed Description currently duplicates the text content — can be addressed as a follow-up