### PR TITLE
fix(hub): GKE dispatch — derive Hub endpoint from IAP audience, decouple transport oidc_audience

### DIFF
--- a/cmd/server_bridge_test.go
+++ b/cmd/server_bridge_test.go
@@ -278,3 +278,58 @@ func TestIsLocalhostURL(t *testing.T) {
 		})
 	}
 }
+
+func TestIAPAudienceToCloudRunURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		audience string
+		want     string
+	}{
+		{
+			name:     "valid audience",
+			audience: "/projects/721899303052/locations/us-central1/services/scion-hub",
+			want:     "https://scion-hub-721899303052.us-central1.run.app",
+		},
+		{
+			name:     "valid audience with trailing slash",
+			audience: "/projects/721899303052/locations/us-central1/services/scion-hub/",
+			want:     "https://scion-hub-721899303052.us-central1.run.app",
+		},
+		{
+			name:     "valid audience with whitespace",
+			audience: "  /projects/123456/locations/europe-west1/services/my-svc  ",
+			want:     "https://my-svc-123456.europe-west1.run.app",
+		},
+		{
+			name:     "missing leading slash",
+			audience: "projects/123456/locations/us-central1/services/scion-hub",
+			want:     "",
+		},
+		{
+			name:     "wrong structure",
+			audience: "/projects/123456/regions/us-central1/services/scion-hub",
+			want:     "",
+		},
+		{
+			name:     "empty string",
+			audience: "",
+			want:     "",
+		},
+		{
+			name:     "too few parts",
+			audience: "/projects/123456/locations/us-central1",
+			want:     "",
+		},
+		{
+			name:     "empty service name",
+			audience: "/projects/123456/locations/us-central1/services/",
+			want:     "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := iapAudienceToCloudRunURL(tt.audience)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1170,10 +1170,15 @@ func resolveHubEndpoint(cfg *config.GlobalConfig, brokerSettings *config.Setting
 // iapAudienceToCloudRunURL converts a Cloud Run native IAP audience path
 // (/projects/<number>/locations/<region>/services/<service>) to the
 // corresponding Cloud Run service URL (https://<service>-<number>.<region>.run.app).
+//
+// NOTE: This produces legacy-format Cloud Run URLs (<service>-<number>.<region>.run.app).
+// Newer Cloud Run services use the format <service>-<hash>-<region>.a.run.app where
+// the hash cannot be derived from the project number. For those services, set
+// SCION_SERVER_BASE_URL explicitly instead of relying on this derivation.
 func iapAudienceToCloudRunURL(audience string) string {
 	// Expected format: /projects/<project-number>/locations/<region>/services/<service>
-	parts := strings.Split(strings.TrimSpace(audience), "/")
-	if len(parts) != 7 || parts[1] != "projects" || parts[3] != "locations" || parts[5] != "services" {
+	parts := strings.Split(strings.TrimRight(strings.TrimSpace(audience), "/"), "/")
+	if len(parts) != 7 || parts[0] != "" || parts[1] != "projects" || parts[3] != "locations" || parts[5] != "services" {
 		return ""
 	}
 	projectNumber := parts[2]

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -866,9 +866,12 @@ func validateHostedHAPreflight(cfg *config.GlobalConfig) error {
 	if transportAudience == "" {
 		return fmt.Errorf("hosted HA deployment requires server.auth.transport.oidc_audience")
 	}
-	if transportAudience != proxyAudience {
-		return fmt.Errorf("hosted HA deployment requires server.auth.transport.oidc_audience to match server.auth.proxy.iap.audience")
-	}
+	// Note: transport.oidc_audience and proxy.iap.audience are intentionally
+	// allowed to differ. proxy.iap.audience is the Cloud Run native IAP
+	// audience path used for validating incoming IAP-signed JWTs, while
+	// transport.oidc_audience is the audience minted into OIDC tokens for
+	// dispatched agents (typically the IAP OAuth client ID). IAP requires
+	// the OAuth client ID format for token validation, not the Cloud Run path.
 	if strings.TrimSpace(cfg.Auth.Transport.PlatformAuthSA) == "" {
 		return fmt.Errorf("hosted HA deployment requires server.auth.transport.platform_auth_sa")
 	}
@@ -1143,6 +1146,16 @@ func resolveHubEndpoint(cfg *config.GlobalConfig, brokerSettings *config.Setting
 		return hubEndpoint
 	}
 
+	// In hosted mode with IAP authentication, derive the Cloud Run URL from
+	// the IAP audience. This prevents the localhost:8080 fallback which is
+	// unreachable from GKE-dispatched agents.
+	if hostedMode && cfg.Auth.Proxy != nil && cfg.Auth.Proxy.IAP != nil && cfg.Auth.Proxy.IAP.Audience != "" {
+		if cloudRunURL := iapAudienceToCloudRunURL(cfg.Auth.Proxy.IAP.Audience); cloudRunURL != "" {
+			log.Printf("Hub endpoint derived from IAP audience: %s", cloudRunURL)
+			return cloudRunURL
+		}
+	}
+
 	port := cfg.Hub.Port
 	if enableWeb {
 		port = webPort
@@ -1152,6 +1165,24 @@ func resolveHubEndpoint(cfg *config.GlobalConfig, brokerSettings *config.Setting
 		log.Printf("Auto-computed hub endpoint for combo mode: %s", hubEndpoint)
 	}
 	return hubEndpoint
+}
+
+// iapAudienceToCloudRunURL converts a Cloud Run native IAP audience path
+// (/projects/<number>/locations/<region>/services/<service>) to the
+// corresponding Cloud Run service URL (https://<service>-<number>.<region>.run.app).
+func iapAudienceToCloudRunURL(audience string) string {
+	// Expected format: /projects/<project-number>/locations/<region>/services/<service>
+	parts := strings.Split(strings.TrimSpace(audience), "/")
+	if len(parts) != 7 || parts[1] != "projects" || parts[3] != "locations" || parts[5] != "services" {
+		return ""
+	}
+	projectNumber := parts[2]
+	region := parts[4]
+	service := parts[6]
+	if projectNumber == "" || region == "" || service == "" {
+		return ""
+	}
+	return fmt.Sprintf("https://%s-%s.%s.run.app", service, projectNumber, region)
 }
 
 // parseAdminEmails parses admin emails from the flag or config.

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -671,6 +671,11 @@ func (c *Client) StartTokenRefresh(ctx context.Context, config *TokenRefreshConf
 		}
 
 		refreshAt := config.RefreshAt
+		// Adjust the initial schedule for transport tokens. Without this,
+		// the first refresh fires based on the app token's ~10h expiry
+		// (at T+8h), but the transport (OIDC/IAP) token expires at ~T+1h.
+		// adjustRefreshForTransportTokens picks the earlier deadline.
+		refreshAt = c.adjustRefreshForTransportTokens(refreshAt)
 		consecutiveFailures := 0
 		authLostNotified := false
 

--- a/pkg/sciontool/hub/client_test.go
+++ b/pkg/sciontool/hub/client_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	state "github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -801,6 +802,69 @@ func TestClient_StartTokenRefresh(t *testing.T) {
 
 		assert.Equal(t, int32(1), atomic.LoadInt32(&authLostCount), "OnAuthLost should fire exactly once")
 		assert.True(t, sawUnauthorized.Load(), "401 refresh error should wrap ErrTokenRefreshUnauthorized")
+	})
+
+	t.Run("initial schedule adjusted for transport token TTL", func(t *testing.T) {
+		// Regression test: the initial refreshAt must account for transport
+		// tokens that expire sooner than the app token. Without the fix,
+		// the first refresh fires at T+8h (2h before the 10h app token
+		// expiry), but the transport token dies at T+1h.
+		cleanup := SetTokenHome(t.TempDir())
+		defer cleanup()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			futureExpiry := time.Now().Add(10 * time.Hour).UTC().Format(time.RFC3339)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"token":"refreshed-token","expires_at":"` + futureExpiry + `"}`))
+		}))
+		defer server.Close()
+
+		// Set up an InjectedSource with a transport token that already needs
+		// refreshing: it expires in 2 minutes, and the refresh margin is 5m,
+		// so adjustRefreshForTransportTokens returns a time in the past →
+		// the timer fires immediately (delay clamped to 0).
+		source := transportauth.NewInjectedSource()
+		transportExpiry := time.Now().Add(2 * time.Minute)
+		source.SetToken("transport-tok", transportExpiry)
+
+		client := NewClientWithConfig(server.URL, "old-token", "agent-123")
+		client.oidcSource = source
+
+		// App token refresh at T+8h — without the fix, this is what would be
+		// used and the refresh would never fire in the test timeout.
+		appRefreshAt := time.Now().Add(8 * time.Hour)
+
+		refreshFired := make(chan time.Time, 1)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		start := time.Now()
+		done := client.StartTokenRefresh(ctx, &TokenRefreshConfig{
+			RefreshAt: appRefreshAt,
+			Timeout:   5 * time.Second,
+			OnRefreshed: func(newExpiry time.Time) {
+				select {
+				case refreshFired <- time.Now():
+				default:
+				}
+			},
+		})
+
+		// With the fix, the adjusted schedule is now - 3min (in the past),
+		// so the refresh fires immediately. Without the fix, the 8h app
+		// schedule means this blocks until the 2s context timeout.
+		select {
+		case fired := <-refreshFired:
+			elapsed := fired.Sub(start)
+			assert.Less(t, elapsed, 500*time.Millisecond,
+				"refresh should fire almost immediately when transport token needs refreshing")
+		case <-time.After(2 * time.Second):
+			t.Fatal("refresh did not fire within 2s — initial schedule was NOT adjusted for transport token TTL")
+		}
+
+		cancel()
+		<-done
 	})
 }
 


### PR DESCRIPTION
## Summary

Two fixes for GKE-hosted broker dispatch, validated end-to-end on Cloud Run + GKE Autopilot:

### fix(hub): derive Hub endpoint from IAP audience for GKE dispatch
resolveHubEndpoint() fell through to localhost:8080 for GKE pods. Container bridge translates localhost for Docker agents but not K8s pods. Adds cloudRunURLFromAudience() to derive the public Cloud Run URL from the IAP transport audience config, used as a fallback before the localhost d