### PR TITLE
feat(discord): guild-removal cleanup and guild_name in channel links

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -914,14 +914,29 @@ func (b *DiscordBroker) handleGuildCreate(_ *discordgo.Session, g *discordgo.Gui
 		"guild_name", g.Name,
 		"member_count", g.MemberCount,
 	)
+
+	// Update guild name for all existing channel links in this guild.
+	// This handles guild renames and populates the name for pre-migration links.
+	ctx := context.Background()
+	if err := b.store.UpdateGuildName(ctx, g.ID, g.Name); err != nil {
+		b.log.Error("Failed to update guild name for channel links", "guild_id", g.ID, "error", err)
+	}
 }
 
 // handleGuildDelete is called when the bot is removed from a guild or
 // when a guild becomes unavailable.
 func (b *DiscordBroker) handleGuildDelete(_ *discordgo.Session, g *discordgo.GuildDelete) {
-	b.log.Info("Discord guild unavailable",
-		"guild_id", g.ID,
-	)
+	if g.Unavailable {
+		// Discord outage — guild temporarily unavailable, do not deactivate.
+		b.log.Debug("Guild temporarily unavailable", "guild_id", g.ID)
+		return
+	}
+	// Bot was removed from guild — deactivate all channel links.
+	b.log.Info("Bot removed from guild, deactivating channel links", "guild_id", g.ID)
+	ctx := context.Background()
+	if err := b.store.DeactivateLinksForGuild(ctx, g.ID); err != nil {
+		b.log.Error("Failed to deactivate channel links for removed guild", "guild_id", g.ID, "error", err)
+	}
 }
 
 // handleMessageCreate is called for every new message in channels the bot

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -917,7 +917,8 @@ func (b *DiscordBroker) handleGuildCreate(_ *discordgo.Session, g *discordgo.Gui
 
 	// Update guild name for all existing channel links in this guild.
 	// This handles guild renames and populates the name for pre-migration links.
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	if err := b.store.UpdateGuildName(ctx, g.ID, g.Name); err != nil {
 		b.log.Error("Failed to update guild name for channel links", "guild_id", g.ID, "error", err)
 	}
@@ -933,7 +934,8 @@ func (b *DiscordBroker) handleGuildDelete(_ *discordgo.Session, g *discordgo.Gui
 	}
 	// Bot was removed from guild — deactivate all channel links.
 	b.log.Info("Bot removed from guild, deactivating channel links", "guild_id", g.ID)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	if err := b.store.DeactivateLinksForGuild(ctx, g.ID); err != nil {
 		b.log.Error("Failed to deactivate channel links for removed guild", "guild_id", g.ID, "error", err)
 	}

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -752,3 +752,116 @@ func TestDeriveSenderSlug(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleGuildDelete(t *testing.T) {
+	t.Run("bot removed — deactivates links", func(t *testing.T) {
+		store := newTestBrokerStore(t)
+		ctx := context.Background()
+
+		// Create two links in the target guild.
+		for _, chID := range []string{"100", "200"} {
+			require.NoError(t, store.CreateChannelLink(ctx, &ChannelLink{
+				ChannelID: chID,
+				GuildID:   "guild-1",
+				ProjectID: "proj-1",
+				LinkedAt:  time.Now().UTC(),
+				Active:    true,
+			}))
+		}
+
+		b := &DiscordBroker{
+			log:   discardLogger(),
+			store: store,
+		}
+
+		// Simulate bot removal (Unavailable = false).
+		b.handleGuildDelete(nil, &discordgo.GuildDelete{
+			Guild: &discordgo.Guild{ID: "guild-1"},
+		})
+
+		got1, err := store.GetChannelLink(ctx, "100")
+		require.NoError(t, err)
+		require.NotNil(t, got1)
+		assert.False(t, got1.Active, "link should be deactivated after guild removal")
+
+		got2, err := store.GetChannelLink(ctx, "200")
+		require.NoError(t, err)
+		require.NotNil(t, got2)
+		assert.False(t, got2.Active, "link should be deactivated after guild removal")
+	})
+
+	t.Run("guild unavailable — does not deactivate links", func(t *testing.T) {
+		store := newTestBrokerStore(t)
+		ctx := context.Background()
+
+		require.NoError(t, store.CreateChannelLink(ctx, &ChannelLink{
+			ChannelID: "100",
+			GuildID:   "guild-1",
+			ProjectID: "proj-1",
+			LinkedAt:  time.Now().UTC(),
+			Active:    true,
+		}))
+
+		b := &DiscordBroker{
+			log:   discardLogger(),
+			store: store,
+		}
+
+		// Simulate temporary outage (Unavailable = true).
+		b.handleGuildDelete(nil, &discordgo.GuildDelete{
+			Guild: &discordgo.Guild{ID: "guild-1", Unavailable: true},
+		})
+
+		got, err := store.GetChannelLink(ctx, "100")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.True(t, got.Active, "link should remain active during outage")
+	})
+}
+
+func TestHandleGuildCreate_UpdatesGuildName(t *testing.T) {
+	store := newTestBrokerStore(t)
+	ctx := context.Background()
+
+	// Create links with an old guild name.
+	for _, chID := range []string{"100", "200"} {
+		require.NoError(t, store.CreateChannelLink(ctx, &ChannelLink{
+			ChannelID: chID,
+			GuildID:   "guild-1",
+			GuildName: "Old Name",
+			ProjectID: "proj-1",
+			LinkedAt:  time.Now().UTC(),
+			Active:    true,
+		}))
+	}
+
+	b := &DiscordBroker{
+		log:   discardLogger(),
+		store: store,
+	}
+
+	// Simulate GuildCreate with a new name.
+	b.handleGuildCreate(nil, &discordgo.GuildCreate{
+		Guild: &discordgo.Guild{
+			ID:   "guild-1",
+			Name: "Renamed Server",
+		},
+	})
+
+	got1, err := store.GetChannelLink(ctx, "100")
+	require.NoError(t, err)
+	assert.Equal(t, "Renamed Server", got1.GuildName)
+
+	got2, err := store.GetChannelLink(ctx, "200")
+	require.NoError(t, err)
+	assert.Equal(t, "Renamed Server", got2.GuildName)
+}
+
+func newTestBrokerStore(t *testing.T) Store {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "broker_test.db")
+	store, err := NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+	return store
+}

--- a/extras/scion-discord/internal/discord/callbacks.go
+++ b/extras/scion-discord/internal/discord/callbacks.go
@@ -189,8 +189,10 @@ func (h *CallbackHandler) saveChannelLink(ctx context.Context, i *discordgo.Inte
 
 	// Resolve guild name from the session's guild cache.
 	var guildName string
-	if guild, err := h.session.State.Guild(guildID); err == nil {
-		guildName = guild.Name
+	if h.session.State != nil {
+		if guild, err := h.session.State.Guild(guildID); err == nil {
+			guildName = guild.Name
+		}
 	}
 
 	link := &ChannelLink{

--- a/extras/scion-discord/internal/discord/callbacks.go
+++ b/extras/scion-discord/internal/discord/callbacks.go
@@ -187,9 +187,16 @@ func (h *CallbackHandler) saveChannelLink(ctx context.Context, i *discordgo.Inte
 		channelID = parentID
 	}
 
+	// Resolve guild name from the session's guild cache.
+	var guildName string
+	if guild, err := h.session.State.Guild(guildID); err == nil {
+		guildName = guild.Name
+	}
+
 	link := &ChannelLink{
 		ChannelID:          channelID,
 		GuildID:            guildID,
+		GuildName:          guildName,
 		ProjectID:          projectID,
 		ProjectSlug:        projectSlug,
 		DefaultAgent:       agentSlug,
@@ -207,6 +214,7 @@ func (h *CallbackHandler) saveChannelLink(ctx context.Context, i *discordgo.Inte
 		h.log.Info("Channel link saved",
 			"channel_id", i.ChannelID,
 			"guild_id", guildID,
+			"guild_name", guildName,
 			"project_id", projectID,
 		)
 	}

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -633,6 +633,9 @@ func (h *CommandHandler) HandleInfo(s *discordgo.Session, i *discordgo.Interacti
 	if i.ChannelID != "" {
 		link, linkErr := resolveChannelLink(ctx, s, h.store, i.ChannelID)
 		if linkErr == nil && link != nil {
+			if link.GuildName != "" {
+				sb.WriteString(fmt.Sprintf("\n**Server:** %s", link.GuildName))
+			}
 			sb.WriteString(fmt.Sprintf("\n**Channel project:** %s", link.ProjectSlug))
 			if link.DefaultAgent != "" {
 				sb.WriteString(fmt.Sprintf("\n**Default agent:** %s", link.DefaultAgent))

--- a/extras/scion-discord/internal/discord/store.go
+++ b/extras/scion-discord/internal/discord/store.go
@@ -29,6 +29,7 @@ type Store interface {
 	GetAllChannelLinks(ctx context.Context) ([]*ChannelLink, error)
 	UpdateChannelLink(ctx context.Context, link *ChannelLink) error
 	DeactivateLinksForGuild(ctx context.Context, guildID string) error
+	UpdateGuildName(ctx context.Context, guildID, name string) error
 	DeleteChannelLink(ctx context.Context, channelID string) error
 
 	// Thread defaults — per-thread agent overrides
@@ -81,6 +82,7 @@ type Store interface {
 type ChannelLink struct {
 	ChannelID          string
 	GuildID            string
+	GuildName          string // populated at link time, refreshed on GuildCreate
 	ProjectID          string
 	ProjectSlug        string
 	DefaultAgent       string
@@ -272,6 +274,7 @@ CREATE TABLE IF NOT EXISTS thread_defaults (
 func (s *sqliteStore) migrateSchema() {
 	migrations := []string{
 		`ALTER TABLE channel_links ADD COLUMN show_state_changes INTEGER NOT NULL DEFAULT 1`,
+		`ALTER TABLE channel_links ADD COLUMN guild_name TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, m := range migrations {
 		if _, err := s.db.Exec(m); err != nil {
@@ -291,16 +294,17 @@ func (s *sqliteStore) Close() error {
 
 func (s *sqliteStore) CreateChannelLink(ctx context.Context, link *ChannelLink) error {
 	const q = `
-INSERT INTO channel_links (channel_id, guild_id, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, show_assistant_reply, show_state_changes, notify_in_group, chat_only)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO channel_links (channel_id, guild_id, guild_name, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, show_assistant_reply, show_state_changes, notify_in_group, chat_only)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(channel_id) DO UPDATE SET
-	guild_id=excluded.guild_id, project_id=excluded.project_id, project_slug=excluded.project_slug,
+	guild_id=excluded.guild_id, guild_name=excluded.guild_name,
+	project_id=excluded.project_id, project_slug=excluded.project_slug,
 	default_agent=excluded.default_agent, linked_by=excluded.linked_by, linked_at=excluded.linked_at,
 	active=excluded.active, show_agent_to_agent=excluded.show_agent_to_agent,
 	show_assistant_reply=excluded.show_assistant_reply, show_state_changes=excluded.show_state_changes,
 	notify_in_group=excluded.notify_in_group, chat_only=excluded.chat_only`
 	_, err := s.db.ExecContext(ctx, q,
-		link.ChannelID, link.GuildID, link.ProjectID, link.ProjectSlug,
+		link.ChannelID, link.GuildID, link.GuildName, link.ProjectID, link.ProjectSlug,
 		link.DefaultAgent, link.LinkedBy, link.LinkedAt.UTC().Format(time.RFC3339),
 		boolToInt(link.Active), boolToInt(link.ShowAgentToAgent),
 		boolToInt(link.ShowAssistantReply), boolToInt(link.ShowStateChanges),
@@ -309,13 +313,13 @@ ON CONFLICT(channel_id) DO UPDATE SET
 }
 
 func (s *sqliteStore) GetChannelLink(ctx context.Context, channelID string) (*ChannelLink, error) {
-	const q = `SELECT channel_id, guild_id, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, show_assistant_reply, show_state_changes, notify_in_group, chat_only FROM channel_links WHERE channel_id = ?`
+	const q = `SELECT channel_id, guild_id, guild_name, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, show_assistant_reply, show_state_changes, notify_in_group, chat_only FROM channel_links WHERE channel_id = ?`
 	row := s.db.QueryRowContext(ctx, q, channelID)
 	return scanChannelLink(row)
 }
 
 func (s *sqliteStore) GetChannelLinksForProject(ctx context.Context, projectID string) ([]*ChannelLink, error) {
-	const q = `SELECT channel_id, guild_id, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, show_assistant_reply, show_state_changes, notify_in_group, chat_only FROM channel_links WHERE project_id = ?`
+	const q = `SELECT channel_id, guild_id, guild_name, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, show_assistant_reply, show_state_changes, notify_in_group, chat_only FROM channel_links WHERE project_id = ?`
 	rows, err := s.db.QueryContext(ctx, q, projectID)
 	if err != nil {
 		return nil, err
@@ -325,7 +329,7 @@ func (s *sqliteStore) GetChannelLinksForProject(ctx context.Context, projectID s
 }
 
 func (s *sqliteStore) GetAllChannelLinks(ctx context.Context) ([]*ChannelLink, error) {
-	const q = `SELECT channel_id, guild_id, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, show_assistant_reply, show_state_changes, notify_in_group, chat_only FROM channel_links`
+	const q = `SELECT channel_id, guild_id, guild_name, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, show_assistant_reply, show_state_changes, notify_in_group, chat_only FROM channel_links`
 	rows, err := s.db.QueryContext(ctx, q)
 	if err != nil {
 		return nil, err
@@ -337,12 +341,12 @@ func (s *sqliteStore) GetAllChannelLinks(ctx context.Context) ([]*ChannelLink, e
 func (s *sqliteStore) UpdateChannelLink(ctx context.Context, link *ChannelLink) error {
 	const q = `
 UPDATE channel_links SET
-	guild_id=?, project_id=?, project_slug=?, default_agent=?, linked_by=?, linked_at=?,
+	guild_id=?, guild_name=?, project_id=?, project_slug=?, default_agent=?, linked_by=?, linked_at=?,
 	active=?, show_agent_to_agent=?, show_assistant_reply=?, show_state_changes=?,
 	notify_in_group=?, chat_only=?
 WHERE channel_id=?`
 	_, err := s.db.ExecContext(ctx, q,
-		link.GuildID, link.ProjectID, link.ProjectSlug,
+		link.GuildID, link.GuildName, link.ProjectID, link.ProjectSlug,
 		link.DefaultAgent, link.LinkedBy, link.LinkedAt.UTC().Format(time.RFC3339),
 		boolToInt(link.Active), boolToInt(link.ShowAgentToAgent),
 		boolToInt(link.ShowAssistantReply), boolToInt(link.ShowStateChanges),
@@ -353,6 +357,11 @@ WHERE channel_id=?`
 
 func (s *sqliteStore) DeactivateLinksForGuild(ctx context.Context, guildID string) error {
 	_, err := s.db.ExecContext(ctx, `UPDATE channel_links SET active = 0 WHERE guild_id = ?`, guildID)
+	return err
+}
+
+func (s *sqliteStore) UpdateGuildName(ctx context.Context, guildID, name string) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE channel_links SET guild_name = ? WHERE guild_id = ?`, name, guildID)
 	return err
 }
 
@@ -685,7 +694,7 @@ func scanChannelLink(row *sql.Row) (*ChannelLink, error) {
 	var link ChannelLink
 	var linkedAt string
 	var active, showA2A, showAssistantReply, showStateChanges, notifyInGroup, chatOnly int
-	err := row.Scan(&link.ChannelID, &link.GuildID, &link.ProjectID, &link.ProjectSlug,
+	err := row.Scan(&link.ChannelID, &link.GuildID, &link.GuildName, &link.ProjectID, &link.ProjectSlug,
 		&link.DefaultAgent, &link.LinkedBy, &linkedAt, &active, &showA2A,
 		&showAssistantReply, &showStateChanges, &notifyInGroup, &chatOnly)
 	if err == sql.ErrNoRows {
@@ -713,7 +722,7 @@ func scanChannelLinks(rows *sql.Rows) ([]*ChannelLink, error) {
 		var link ChannelLink
 		var linkedAt string
 		var active, showA2A, showAssistantReply, showStateChanges, notifyInGroup, chatOnly int
-		err := rows.Scan(&link.ChannelID, &link.GuildID, &link.ProjectID, &link.ProjectSlug,
+		err := rows.Scan(&link.ChannelID, &link.GuildID, &link.GuildName, &link.ProjectID, &link.ProjectSlug,
 			&link.DefaultAgent, &link.LinkedBy, &linkedAt, &active, &showA2A,
 			&showAssistantReply, &showStateChanges, &notifyInGroup, &chatOnly)
 		if err != nil {

--- a/extras/scion-discord/internal/discord/store_postgres.go
+++ b/extras/scion-discord/internal/discord/store_postgres.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -114,7 +115,22 @@ CREATE TABLE IF NOT EXISTS discord_thread_defaults (
 );
 `
 	_, err := s.db.Exec(ddl)
-	return err
+	if err != nil {
+		return err
+	}
+	s.migrateSchema()
+	return nil
+}
+
+func (s *postgresStore) migrateSchema() {
+	migrations := []string{
+		`ALTER TABLE discord_channel_links ADD COLUMN IF NOT EXISTS guild_name TEXT NOT NULL DEFAULT ''`,
+	}
+	for _, m := range migrations {
+		if _, err := s.db.Exec(m); err != nil {
+			slog.Warn("Failed to run Postgres migration", "migration", m, "error", err)
+		}
+	}
 }
 
 func (s *postgresStore) Close() error {
@@ -125,16 +141,17 @@ func (s *postgresStore) Close() error {
 
 func (s *postgresStore) CreateChannelLink(ctx context.Context, link *ChannelLink) error {
 	const q = `
-INSERT INTO discord_channel_links (channel_id, guild_id, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, show_assistant_reply, show_state_changes, notify_in_group, chat_only)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+INSERT INTO discord_channel_links (channel_id, guild_id, guild_name, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, show_assistant_reply, show_state_changes, notify_in_group, chat_only)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 ON CONFLICT(channel_id) DO UPDATE SET
-	guild_id=EXCLUDED.guild_id, project_id=EXCLUDED.project_id, project_slug=EXCLUDED.project_slug,
+	guild_id=EXCLUDED.guild_id, guild_name=EXCLUDED.guild_name,
+	project_id=EXCLUDED.project_id, project_slug=EXCLUDED.project_slug,
 	default_agent=EXCLUDED.default_agent, linked_by=EXCLUDED.linked_by, linked_at=EXCLUDED.linked_at,
 	active=EXCLUDED.active, show_agent_to_agent=EXCLUDED.show_agent_to_agent,
 	show_assistant_reply=EXCLUDED.show_assistant_reply, show_state_changes=EXCLUDED.show_state_changes,
 	notify_in_group=EXCLUDED.notify_in_group, chat_only=EXCLUDED.chat_only`
 	_, err := s.db.ExecContext(ctx, q,
-		link.ChannelID, link.GuildID, link.ProjectID, link.ProjectSlug,
+		link.ChannelID, link.GuildID, link.GuildName, link.ProjectID, link.ProjectSlug,
 		link.DefaultAgent, link.LinkedBy, link.LinkedAt.UTC(),
 		link.Active, link.ShowAgentToAgent,
 		link.ShowAssistantReply, link.ShowStateChanges,
@@ -143,13 +160,13 @@ ON CONFLICT(channel_id) DO UPDATE SET
 }
 
 func (s *postgresStore) GetChannelLink(ctx context.Context, channelID string) (*ChannelLink, error) {
-	const q = `SELECT channel_id, guild_id, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, show_assistant_reply, show_state_changes, notify_in_group, chat_only FROM discord_channel_links WHERE channel_id = $1`
+	const q = `SELECT channel_id, guild_id, guild_name, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, show_assistant_reply, show_state_changes, notify_in_group, chat_only FROM discord_channel_links WHERE channel_id = $1`
 	row := s.db.QueryRowContext(ctx, q, channelID)
 	return pgScanChannelLink(row)
 }
 
 func (s *postgresStore) GetChannelLinksForProject(ctx context.Context, projectID string) ([]*ChannelLink, error) {
-	const q = `SELECT channel_id, guild_id, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, show_assistant_reply, show_state_changes, notify_in_group, chat_only FROM discord_channel_links WHERE project_id = $1`
+	const q = `SELECT channel_id, guild_id, guild_name, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, show_assistant_reply, show_state_changes, notify_in_group, chat_only FROM discord_channel_links WHERE project_id = $1`
 	rows, err := s.db.QueryContext(ctx, q, projectID)
 	if err != nil {
 		return nil, err
@@ -159,7 +176,7 @@ func (s *postgresStore) GetChannelLinksForProject(ctx context.Context, projectID
 }
 
 func (s *postgresStore) GetAllChannelLinks(ctx context.Context) ([]*ChannelLink, error) {
-	const q = `SELECT channel_id, guild_id, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, show_assistant_reply, show_state_changes, notify_in_group, chat_only FROM discord_channel_links`
+	const q = `SELECT channel_id, guild_id, guild_name, project_id, project_slug, default_agent, linked_by, linked_at, active, show_agent_to_agent, show_assistant_reply, show_state_changes, notify_in_group, chat_only FROM discord_channel_links`
 	rows, err := s.db.QueryContext(ctx, q)
 	if err != nil {
 		return nil, err
@@ -171,12 +188,12 @@ func (s *postgresStore) GetAllChannelLinks(ctx context.Context) ([]*ChannelLink,
 func (s *postgresStore) UpdateChannelLink(ctx context.Context, link *ChannelLink) error {
 	const q = `
 UPDATE discord_channel_links SET
-	guild_id=$1, project_id=$2, project_slug=$3, default_agent=$4, linked_by=$5, linked_at=$6,
-	active=$7, show_agent_to_agent=$8, show_assistant_reply=$9, show_state_changes=$10,
-	notify_in_group=$11, chat_only=$12
-WHERE channel_id=$13`
+	guild_id=$1, guild_name=$2, project_id=$3, project_slug=$4, default_agent=$5, linked_by=$6, linked_at=$7,
+	active=$8, show_agent_to_agent=$9, show_assistant_reply=$10, show_state_changes=$11,
+	notify_in_group=$12, chat_only=$13
+WHERE channel_id=$14`
 	_, err := s.db.ExecContext(ctx, q,
-		link.GuildID, link.ProjectID, link.ProjectSlug,
+		link.GuildID, link.GuildName, link.ProjectID, link.ProjectSlug,
 		link.DefaultAgent, link.LinkedBy, link.LinkedAt.UTC(),
 		link.Active, link.ShowAgentToAgent,
 		link.ShowAssistantReply, link.ShowStateChanges,
@@ -187,6 +204,11 @@ WHERE channel_id=$13`
 
 func (s *postgresStore) DeactivateLinksForGuild(ctx context.Context, guildID string) error {
 	_, err := s.db.ExecContext(ctx, `UPDATE discord_channel_links SET active = FALSE WHERE guild_id = $1`, guildID)
+	return err
+}
+
+func (s *postgresStore) UpdateGuildName(ctx context.Context, guildID, name string) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE discord_channel_links SET guild_name = $1 WHERE guild_id = $2`, name, guildID)
 	return err
 }
 
@@ -485,7 +507,7 @@ func (s *postgresStore) GetNotificationPrefs(ctx context.Context, discordUserID,
 
 func pgScanChannelLink(row *sql.Row) (*ChannelLink, error) {
 	var link ChannelLink
-	err := row.Scan(&link.ChannelID, &link.GuildID, &link.ProjectID, &link.ProjectSlug,
+	err := row.Scan(&link.ChannelID, &link.GuildID, &link.GuildName, &link.ProjectID, &link.ProjectSlug,
 		&link.DefaultAgent, &link.LinkedBy, &link.LinkedAt, &link.Active, &link.ShowAgentToAgent,
 		&link.ShowAssistantReply, &link.ShowStateChanges, &link.NotifyInGroup, &link.ChatOnly)
 	if err == sql.ErrNoRows {
@@ -501,7 +523,7 @@ func pgScanChannelLinks(rows *sql.Rows) ([]*ChannelLink, error) {
 	var links []*ChannelLink
 	for rows.Next() {
 		var link ChannelLink
-		err := rows.Scan(&link.ChannelID, &link.GuildID, &link.ProjectID, &link.ProjectSlug,
+		err := rows.Scan(&link.ChannelID, &link.GuildID, &link.GuildName, &link.ProjectID, &link.ProjectSlug,
 			&link.DefaultAgent, &link.LinkedBy, &link.LinkedAt, &link.Active, &link.ShowAgentToAgent,
 			&link.ShowAssistantReply, &link.ShowStateChanges, &link.NotifyInGroup, &link.ChatOnly)
 		if err != nil {

--- a/extras/scion-discord/internal/discord/store_test.go
+++ b/extras/scion-discord/internal/discord/store_test.go
@@ -221,6 +221,86 @@ func TestChannelLinkCRUD(t *testing.T) {
 		assert.True(t, got3.Active)
 	})
 
+	t.Run("GuildNamePersistedOnCreate", func(t *testing.T) {
+		store := newTestStore(t)
+		ctx := context.Background()
+
+		require.NoError(t, store.CreateChannelLink(ctx, &ChannelLink{
+			ChannelID: "100",
+			GuildID:   "guild-1",
+			GuildName: "Test Server",
+			ProjectID: "proj-1",
+			LinkedAt:  time.Now().UTC(),
+			Active:    true,
+		}))
+
+		got, err := store.GetChannelLink(ctx, "100")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "Test Server", got.GuildName)
+	})
+
+	t.Run("UpdateGuildName", func(t *testing.T) {
+		store := newTestStore(t)
+		ctx := context.Background()
+
+		// Create two links in the same guild.
+		for _, chID := range []string{"100", "200"} {
+			require.NoError(t, store.CreateChannelLink(ctx, &ChannelLink{
+				ChannelID: chID,
+				GuildID:   "guild-1",
+				GuildName: "Old Name",
+				ProjectID: "proj-1",
+				LinkedAt:  time.Now().UTC(),
+				Active:    true,
+			}))
+		}
+		// Create a link in a different guild.
+		require.NoError(t, store.CreateChannelLink(ctx, &ChannelLink{
+			ChannelID: "300",
+			GuildID:   "guild-2",
+			GuildName: "Other Server",
+			ProjectID: "proj-2",
+			LinkedAt:  time.Now().UTC(),
+			Active:    true,
+		}))
+
+		// Update guild name for guild-1.
+		require.NoError(t, store.UpdateGuildName(ctx, "guild-1", "New Name"))
+
+		got1, err := store.GetChannelLink(ctx, "100")
+		require.NoError(t, err)
+		assert.Equal(t, "New Name", got1.GuildName)
+
+		got2, err := store.GetChannelLink(ctx, "200")
+		require.NoError(t, err)
+		assert.Equal(t, "New Name", got2.GuildName)
+
+		// Different guild should be unchanged.
+		got3, err := store.GetChannelLink(ctx, "300")
+		require.NoError(t, err)
+		assert.Equal(t, "Other Server", got3.GuildName)
+	})
+
+	t.Run("GuildNameDefaultsToEmpty", func(t *testing.T) {
+		store := newTestStore(t)
+		ctx := context.Background()
+
+		// Create without setting GuildName — should default to "".
+		require.NoError(t, store.CreateChannelLink(ctx, &ChannelLink{
+			ChannelID: "100",
+			GuildID:   "guild-1",
+			ProjectID: "proj-1",
+			LinkedAt:  time.Now().UTC(),
+			Active:    true,
+		}))
+
+		got, err := store.GetChannelLink(ctx, "100")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "", got.GuildName)
+	})
+
 	t.Run("Delete", func(t *testing.T) {
 		store := newTestStore(t)
 		ctx := context.Background()


### PR DESCRIPTION
Refs https://github.com/ptone/scion/issues/405

Phase 1 - Guild-removal cleanup: handleGuildDelete now calls DeactivateLinksForGuild(g.ID) when the bot is removed from a server, guarding on g.Unavailable to avoid deactivating links during Discord outages.

Phase 2 - Guild name in UX: Adds guild_name TEXT DEFAULT empty column to both SQLite and Postgres via additive migrations. Populates guild name at link time, refreshes on GuildCreate events, and shows in /scion info output so operators can distinguish channels from different servers.

7 tests covering removal/unavailability distinction, guild name CRUD, and backward compatibility