### PR TITLE
fix(discord): observe mode sender identity, embed styling, remove duplicate text

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -657,11 +657,19 @@ func (b *DiscordBroker) Publish(ctx context.Context, topic string, msg *messages
 			// Send via webhook with per-agent identity.
 			// For threads (forum channels, text channel threads), create the
 			// webhook on the parent channel and execute with thread_id.
+			//
+			// When observe embeds are present (agent-to-agent messages), send
+			// only the embed — passing text content alongside embeds causes
+			// Discord to display the message body twice.
+			webhookText := text
+			if len(observeEmbeds) > 0 {
+				webhookText = ""
+			}
 			parentID, isThread := b.resolveThreadParent(channelID)
 			if isThread && parentID != "" {
-				_, err = webhooks.SendAsAgentInThread(parentID, channelID, senderSlug, text, observeEmbeds, nil, files)
+				_, err = webhooks.SendAsAgentInThread(parentID, channelID, senderSlug, webhookText, observeEmbeds, nil, files)
 			} else {
-				_, err = webhooks.SendAsAgent(channelID, senderSlug, text, observeEmbeds, nil, files)
+				_, err = webhooks.SendAsAgent(channelID, senderSlug, webhookText, observeEmbeds, nil, files)
 			}
 			if err != nil {
 				// Fallback to bot API if webhook send fails.

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -707,6 +707,7 @@ func TestResolveOutboundMentions(t *testing.T) {
 // senderSlug derivation — uses shared deriveSenderSlug from format.go
 // ---------------------------------------------------------------------------
 
+
 func TestDeriveSenderSlug(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -752,6 +753,7 @@ func TestDeriveSenderSlug(t *testing.T) {
 		})
 	}
 }
+
 
 func TestHandleGuildDelete(t *testing.T) {
 	t.Run("bot removed — deactivates links", func(t *testing.T) {

--- a/extras/scion-discord/internal/discord/format.go
+++ b/extras/scion-discord/internal/discord/format.go
@@ -410,9 +410,13 @@ func formatObservedEmbed(msg *messages.StructuredMessage) *discordgo.MessageEmbe
 	}
 	senderSlug := strings.TrimPrefix(msg.Sender, "agent:")
 	recipientSlug := strings.TrimPrefix(msg.Recipient, "agent:")
+	description := msg.Msg
+	if len(description) > maxEmbedDescriptionLength {
+		description = truncateForDiscord(description, maxEmbedDescriptionLength)
+	}
 	return &discordgo.MessageEmbed{
 		Title:       fmt.Sprintf("%s → %s", senderSlug, recipientSlug),
-		Description: msg.Msg,
+		Description: description,
 		Color:       0x808080, // gray sidebar distinguishes relayed from direct messages
 	}
 }

--- a/extras/scion-discord/internal/discord/format.go
+++ b/extras/scion-discord/internal/discord/format.go
@@ -417,6 +417,7 @@ func formatObservedEmbed(msg *messages.StructuredMessage) *discordgo.MessageEmbe
 	}
 }
 
+
 // deriveSenderSlug extracts the sender's display slug from the message sender
 // field, falling back to the topic-derived agentSlug when the sender is not an agent.
 func deriveSenderSlug(sender, agentSlug string) string {

--- a/extras/scion-discord/internal/discord/format_test.go
+++ b/extras/scion-discord/internal/discord/format_test.go
@@ -459,6 +459,26 @@ func TestFormatObservedEmbed_AgentToAgent(t *testing.T) {
 	assert.Equal(t, 0x808080, embed.Color)
 }
 
+func TestFormatObservedEmbed_NilMessage(t *testing.T) {
+	embed := formatObservedEmbed(nil)
+	assert.Nil(t, embed)
+}
+
+func TestFormatObservedEmbed_TruncatesLongDescription(t *testing.T) {
+	longMsg := strings.Repeat("x", maxEmbedDescriptionLength+500)
+	msg := &messages.StructuredMessage{
+		Sender:    "agent:builder",
+		Recipient: "agent:reviewer",
+		Msg:       longMsg,
+	}
+	embed := formatObservedEmbed(msg)
+	require.NotNil(t, embed)
+	assert.LessOrEqual(t, len(embed.Description), maxEmbedDescriptionLength)
+	assert.True(t, strings.HasSuffix(embed.Description, truncationSuffix))
+	assert.Equal(t, "builder → reviewer", embed.Title)
+	assert.Equal(t, 0x808080, embed.Color)
+}
+
 func TestFormatObservedEmbed_NonAgentSender(t *testing.T) {
 	// When sender is not an agent, TrimPrefix is a no-op and returns the full sender string.
 	msg := &messages.StructuredMessage{


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/519

3 commits:

1. Show observed messages under the sender webhook identity (not recipient). senderSlug now derived from msg.Sender, with fallback to topic agentSlug for non-agent senders.

2. Extract deriveSenderSlug and formatObservedEmbed as shared helpers in format.go (with nil guard).

3. Remove duplicate plain-text content from observed message relay — embed block alone carries the message. Observers now see a single clean embed (sender arrow recipient in title, message in description) without the redundant text prefix