### PR TITLE
feat(discord): multi-guild command registration (phase 3 of https://github.com/ptone/scion/issues/405)

### DIFF
--- a/extras/scion-discord/cmd/scion-plugin-discord/main.go
+++ b/extras/scion-discord/cmd/scion-plugin-discord/main.go
@@ -60,7 +60,8 @@ func main() {
 	fmt.Println("  bot_token        (required) Discord bot token")
 	fmt.Println("  application_id   Discord application ID (for slash commands)")
 	fmt.Println("  public_key       Discord public key (for interaction verification)")
-	fmt.Println("  guild_id         Guild ID for guild-scoped commands (empty = global)")
+	fmt.Println("  guild_ids        Comma-separated guild IDs for per-guild commands (empty = global)")
+	fmt.Println("  guild_id         (deprecated) Alias for guild_ids with a single ID")
 	fmt.Println("  hub_url          Hub API URL for inbound message delivery")
 	fmt.Println("  hmac_key         Base64-encoded HMAC key for hub authentication")
 	fmt.Println("  broker_id        Broker ID for HMAC signing")
@@ -152,7 +153,7 @@ func serveStandalone() {
 		ConfigFile:  os.Getenv("CONFIG_FILE"),
 		EnvPrefix:   "DISCORD",
 		EnvKeys: []string{
-			"bot_token", "application_id", "public_key", "guild_id",
+			"bot_token", "application_id", "public_key", "guild_ids", "guild_id",
 			"hub_url", "hmac_key", "broker_id",
 			"mention_routing", "send_queue_size", "send_min_delay",
 			"agent_cache_ttl",

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -58,7 +58,7 @@ type Config struct {
 	BotToken       string
 	ApplicationID  string
 	PublicKey      string
-	GuildID        string // empty = global commands
+	GuildIDs       []string // parsed from comma-separated "guild_ids" config value; empty = global commands
 	DBPath         string
 	MentionRouting bool
 }
@@ -235,8 +235,20 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 			BotToken:       botToken,
 			ApplicationID:  config["application_id"],
 			PublicKey:      config["public_key"],
-			GuildID:        config["guild_id"],
 			MentionRouting: true, // default
+		}
+
+		// Parse guild IDs: prefer "guild_ids" (comma-separated), fall back to "guild_id" for backward compat.
+		guildIDsRaw := config["guild_ids"]
+		if guildIDsRaw == "" {
+			guildIDsRaw = config["guild_id"]
+		}
+		if guildIDsRaw != "" {
+			for _, id := range strings.Split(guildIDsRaw, ",") {
+				if trimmed := strings.TrimSpace(id); trimmed != "" {
+					cfg.GuildIDs = append(cfg.GuildIDs, trimmed)
+				}
+			}
 		}
 
 		if v, ok := config["mention_routing"]; ok && v != "" {
@@ -297,7 +309,7 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 
 		b.log.Info("Discord broker phase 1 configured",
 			"application_id", cfg.ApplicationID,
-			"guild_id", cfg.GuildID,
+			"guild_ids", cfg.GuildIDs,
 			"db_path", cfg.DBPath,
 			"mention_routing", cfg.MentionRouting,
 		)
@@ -310,12 +322,12 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 
 		// Create component handlers.
 		appID := ""
-		guildID := ""
+		var guildIDs []string
 		if b.config != nil {
 			appID = b.config.ApplicationID
-			guildID = b.config.GuildID
+			guildIDs = b.config.GuildIDs
 		}
-		b.commands = NewCommandHandler(b.store, b.session, b.hubClient, b.deliverInbound, appID, guildID, b.agentCacheTTL, b.log)
+		b.commands = NewCommandHandler(b.store, b.session, b.hubClient, b.deliverInbound, appID, guildIDs, b.agentCacheTTL, b.log)
 		b.callbacks = NewCallbackHandler(b.store, b.session, b.hubClient, b.deliverInbound, b.log)
 		b.registration = NewRegistrationHandler(b.store, b.session, b.hubURL, b.hmacKey, b.brokerID, b.log)
 

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -83,12 +83,21 @@ func (h *CommandHandler) RegisterCommands() error {
 	if len(h.guildIDs) == 0 {
 		return h.RegisterCommandsForGuild("")
 	}
+	var wg sync.WaitGroup
+	var mu sync.Mutex
 	var errs []error
 	for _, guildID := range h.guildIDs {
-		if err := h.RegisterCommandsForGuild(guildID); err != nil {
-			errs = append(errs, err)
-		}
+		wg.Add(1)
+		go func(gID string) {
+			defer wg.Done()
+			if err := h.RegisterCommandsForGuild(gID); err != nil {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
+			}
+		}(guildID)
 	}
+	wg.Wait()
 	return errors.Join(errs...)
 }
 

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -2,6 +2,7 @@ package discord
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -52,14 +53,14 @@ type CommandHandler struct {
 	hubClient      HubClient
 	log            *slog.Logger
 	appID          string
-	guildID        string // empty = global commands
+	guildIDs       []string // empty = global commands
 	agentCacheTTL  time.Duration
 	deliverInbound func(topic string, msg *messages.StructuredMessage) *hubError
 }
 
 // NewCommandHandler creates a new CommandHandler. agentCacheTTL controls how
 // long agent lists are cached before refreshing from the Hub API.
-func NewCommandHandler(store Store, session *discordgo.Session, hubClient HubClient, deliverInbound func(string, *messages.StructuredMessage) *hubError, appID, guildID string, agentCacheTTL time.Duration, log *slog.Logger) *CommandHandler {
+func NewCommandHandler(store Store, session *discordgo.Session, hubClient HubClient, deliverInbound func(string, *messages.StructuredMessage) *hubError, appID string, guildIDs []string, agentCacheTTL time.Duration, log *slog.Logger) *CommandHandler {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -70,13 +71,30 @@ func NewCommandHandler(store Store, session *discordgo.Session, hubClient HubCli
 		deliverInbound: deliverInbound,
 		log:            log,
 		appID:          appID,
-		guildID:        guildID,
+		guildIDs:       guildIDs,
 		agentCacheTTL:  agentCacheTTL,
 	}
 }
 
 // RegisterCommands registers the /scion command and its subcommands with Discord.
+// When guild IDs are configured, commands are registered per-guild for instant
+// availability. When no guild IDs are configured, commands are registered globally.
 func (h *CommandHandler) RegisterCommands() error {
+	if len(h.guildIDs) == 0 {
+		return h.RegisterCommandsForGuild("")
+	}
+	var errs []error
+	for _, guildID := range h.guildIDs {
+		if err := h.RegisterCommandsForGuild(guildID); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// RegisterCommandsForGuild registers the /scion command for a single guild.
+// Pass an empty guildID for global (non-guild-scoped) registration.
+func (h *CommandHandler) RegisterCommandsForGuild(guildID string) error {
 	cmd := &discordgo.ApplicationCommand{
 		Name:        "scion",
 		Description: "Scion agent management",
@@ -197,12 +215,16 @@ func (h *CommandHandler) RegisterCommands() error {
 		},
 	}
 
-	_, err := h.session.ApplicationCommandCreate(h.appID, h.guildID, cmd)
+	_, err := h.session.ApplicationCommandCreate(h.appID, guildID, cmd)
 	if err != nil {
-		return fmt.Errorf("registering /scion command: %w", err)
+		return fmt.Errorf("registering /scion command for guild %q: %w", guildID, err)
 	}
 
-	h.log.Info("Registered /scion slash command", "app_id", h.appID, "guild_id", h.guildID)
+	logGuildID := guildID
+	if logGuildID == "" {
+		logGuildID = "global"
+	}
+	h.log.Info("Registered /scion slash command", "app_id", h.appID, "guild_id", logGuildID)
 	return nil
 }
 


### PR DESCRIPTION
Refs https://github.com/ptone/scion/issues/405

Phase 3: Extend command registration to support multiple Discord guilds.

- Config.GuildID (string) -> Config.GuildIDs ([]string) with comma-separated guild_ids config key and backward-compat guild_id fallback
- RegisterCommands registers slash commands across all configured guilds
- RegisterCommandsForGuild exported for Phase 4 (auto-register on join)
- Updated main.go usage docs and EnvKeys