### PR TITLE
fix(discord): gofmt cleanup for extras/scion-discord (unblocks main CI)

### DIFF
--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -707,7 +707,6 @@ func TestResolveOutboundMentions(t *testing.T) {
 // senderSlug derivation — uses shared deriveSenderSlug from format.go
 // ---------------------------------------------------------------------------
 
-
 func TestDeriveSenderSlug(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -753,7 +752,6 @@ func TestDeriveSenderSlug(t *testing.T) {
 		})
 	}
 }
-
 
 func TestHandleGuildDelete(t *testing.T) {
 	t.Run("bot removed — deactivates links", func(t *testing.T) {

--- a/extras/scion-discord/internal/discord/format.go
+++ b/extras/scion-discord/internal/discord/format.go
@@ -421,7 +421,6 @@ func formatObservedEmbed(msg *messages.StructuredMessage) *discordgo.MessageEmbe
 	}
 }
 
-
 // deriveSenderSlug extracts the sender's display slug from the message sender
 // field, falling back to the topic-derived agentSlug when the sender is not an agent.
 func deriveSenderSlug(sender, agentSlug string) string {


### PR DESCRIPTION
Remove double blank lines in format.go and broker_test.go that were introduced by PRs #816 and #818 and are failing the Format Check step on upstream main CI.


