### PR TITLE
harness/opencode: fix model write to opencode.json from SCION_MODEL env var

### DIFF
--- a/harnesses/hermes/provision.py
+++ b/harnesses/hermes/provision.py
@@ -238,6 +238,8 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
 
     # Model resolution passthrough.
     resolved_model = str(ctx.model_resolution.get("resolved_model") or "").strip()
+    if not resolved_model:
+        resolved_model = os.environ.get("SCION_MODEL", "").strip()
     if resolved_model:
         env_payload["HERMES_INFERENCE_MODEL"] = resolved_model
     elif resolved.method == "vertex-ai":

--- a/harnesses/opencode/provision.py
+++ b/harnesses/opencode/provision.py
@@ -282,6 +282,8 @@ def provision(ctx: sh.ProvisionContext) -> None:
     sh.apply_mcp_translated(ctx, _translate_mcp_server, _write_mcp_config)
 
     resolved_model = str(ctx.model_resolution.get("resolved_model") or "").strip()
+    if not resolved_model:
+        resolved_model = os.environ.get("SCION_MODEL", "").strip()
     _write_model_config(resolved_model)
 
     ctx.info(f"method={resolved.method}" + (f" model={resolved_model}" if resolved_model else ""))


### PR DESCRIPTION
## Problem

provision.py read model from ctx.model_resolution.get("resolved_model"), but ProvisionManifest has no model_resolution field so this always returned empty. The model was never written to ~/.config/opencode/opencode.json even when set at agent or project level.

## Fix

Fall back to os.environ.get("SCION_MODEL") when ctx.model_resolution is empty. SCION_MODEL is injected by run.go:636 from AgentAppliedConfig.Model (which includes project default model).

If both are unset, _write_model_config("") removes the model key rather than writing empty string