### PR TITLE
harness/opencode+hermes: fix model write from SCION_MODEL env var

### DIFF
--- a/harnesses/hermes/provision.py
+++ b/harnesses/hermes/provision.py
@@ -238,6 +238,8 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
 
     # Model resolution passthrough.
     resolved_model = str(ctx.model_resolution.get("resolved_model") or "").strip()
+    if not resolved_model:
+        resolved_model = os.environ.get("SCION_MODEL", "").strip()
     if resolved_model:
         env_payload["HERMES_INFERENCE_MODEL"] = resolved_model
     elif resolved.method == "vertex-ai":

--- a/harnesses/opencode/provision.py
+++ b/harnesses/opencode/provision.py
@@ -282,6 +282,8 @@ def provision(ctx: sh.ProvisionContext) -> None:
     sh.apply_mcp_translated(ctx, _translate_mcp_server, _write_mcp_config)
 
     resolved_model = str(ctx.model_resolution.get("resolved_model") or "").strip()
+    if not resolved_model:
+        resolved_model = os.environ.get("SCION_MODEL", "").strip()
     _write_model_config(resolved_model)
 
     ctx.info(f"method={resolved.method}" + (f" model={resolved_model}" if resolved_model else ""))


### PR DESCRIPTION
## Problem

Both opencode and hermes provision.py read model from ctx.model_resolution.get("resolved_model"), but ProvisionManifest has no model_resolution field — this always returned empty. Model was never written even when set at agent or project level.

## Fix

Added os.environ.get("SCION_MODEL") fallback when ctx.model_resolution is empty.
SCION_MODEL is injected by run.go:636 from AgentAppliedConfig.Model (includes project defaults).

Priority chain for hermes: manifest resolved_model → SCION_MODEL env var → vertex-ai default (gemini-2.5-flash).
Priority chain for opencode: manifest resolved_model → SCION_MODEL env var → omit (opencode uses its own default)