### PR TITLE
fix: add plugin to message_broker.types on web UI install

### DIFF
--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -325,6 +325,86 @@ func AddPluginToSettings(pluginName, configFilePath string) error {
 	return os.WriteFile(settingsPath, out, 0644)
 }
 
+// AddPluginToMessageBrokerTypes appends pluginName to
+// server.message_broker.types in the global settings.yaml if it is not already
+// present. It also ensures that message_broker.enabled is true. The caller is
+// responsible for serialising concurrent writes (settingsWriteMu).
+func AddPluginToMessageBrokerTypes(pluginName string) error {
+	globalDir, err := GetGlobalDir()
+	if err != nil {
+		return fmt.Errorf("resolve global dir: %w", err)
+	}
+
+	settingsPath := filepath.Join(globalDir, "settings.yaml")
+
+	var raw map[string]interface{}
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("read settings file: %w", err)
+		}
+		raw = make(map[string]interface{})
+	} else {
+		if err := yamlv3.Unmarshal(data, &raw); err != nil {
+			return fmt.Errorf("parse settings file: %w", err)
+		}
+		if raw == nil {
+			raw = make(map[string]interface{})
+		}
+	}
+
+	server, _ := raw["server"].(map[string]interface{})
+	if server == nil {
+		server = make(map[string]interface{})
+		raw["server"] = server
+	}
+
+	mb, _ := server["message_broker"].(map[string]interface{})
+	if mb == nil {
+		mb = make(map[string]interface{})
+		server["message_broker"] = mb
+	}
+
+	// Ensure enabled.
+	mb["enabled"] = true
+
+	// Read existing types list.
+	var types []string
+	if existing, ok := mb["types"]; ok {
+		if arr, ok := existing.([]interface{}); ok {
+			for _, v := range arr {
+				if s, ok := v.(string); ok {
+					types = append(types, s)
+				}
+			}
+		}
+	}
+
+	// Check for duplicates.
+	for _, t := range types {
+		if t == pluginName {
+			// Already present — nothing to do.
+			return nil
+		}
+	}
+
+	types = append(types, pluginName)
+
+	// Convert back to []interface{} for YAML marshalling.
+	iface := make([]interface{}, len(types))
+	for i, t := range types {
+		iface[i] = t
+	}
+	mb["types"] = iface
+
+	out, err := yamlv3.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("marshal settings: %w", err)
+	}
+
+	return os.WriteFile(settingsPath, out, 0644)
+}
+
 // CreatePluginConfigFile creates a default config file for a newly installed plugin.
 func CreatePluginConfigFile(pluginName, configFilePath string) error {
 	resolved := configFilePath

--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -365,8 +365,8 @@ func AddPluginToMessageBrokerTypes(pluginName string) error {
 		server["message_broker"] = mb
 	}
 
-	// Ensure enabled.
-	mb["enabled"] = true
+	// Read existing enabled state.
+	enabled, _ := mb["enabled"].(bool)
 
 	// Read existing types list.
 	var types []string
@@ -380,15 +380,24 @@ func AddPluginToMessageBrokerTypes(pluginName string) error {
 		}
 	}
 
-	// Check for duplicates.
+	// Check if the plugin is already present.
+	hasPlugin := false
 	for _, t := range types {
 		if t == pluginName {
-			// Already present — nothing to do.
-			return nil
+			hasPlugin = true
+			break
 		}
 	}
 
-	types = append(types, pluginName)
+	// If already enabled and the plugin is present, nothing to do.
+	if enabled && hasPlugin {
+		return nil
+	}
+
+	mb["enabled"] = true
+	if !hasPlugin {
+		types = append(types, pluginName)
+	}
 
 	// Convert back to []interface{} for YAML marshalling.
 	iface := make([]interface{}, len(types))

--- a/pkg/config/integration_config_test.go
+++ b/pkg/config/integration_config_test.go
@@ -395,6 +395,41 @@ func TestAddPluginToMessageBrokerTypes_Idempotent(t *testing.T) {
 	}
 }
 
+func TestAddPluginToMessageBrokerTypes_PluginPresentButDisabled(t *testing.T) {
+	_, settingsPath := setupTestHome(t)
+
+	// Plugin is already in types but enabled is false.
+	if err := os.WriteFile(settingsPath, []byte("server:\n  message_broker:\n    enabled: false\n    types:\n      - telegram\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AddPluginToMessageBrokerTypes("telegram"); err != nil {
+		t.Fatalf("AddPluginToMessageBrokerTypes() error: %v", err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+
+	server := raw["server"].(map[string]interface{})
+	mb := server["message_broker"].(map[string]interface{})
+
+	if enabled, ok := mb["enabled"].(bool); !ok || !enabled {
+		t.Error("expected message_broker.enabled = true after re-enabling")
+	}
+
+	typesRaw := mb["types"].([]interface{})
+	if len(typesRaw) != 1 || typesRaw[0] != "telegram" {
+		t.Errorf("expected types=[telegram] (no duplicate), got %v", typesRaw)
+	}
+}
+
 func TestAddPluginToMessageBrokerTypes_AppendsSecondPlugin(t *testing.T) {
 	_, settingsPath := setupTestHome(t)
 

--- a/pkg/config/integration_config_test.go
+++ b/pkg/config/integration_config_test.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestYAMLConfigProvider_LoadNonExistent(t *testing.T) {
@@ -307,6 +309,152 @@ func TestResolvePluginConfig_BackendKeyNamesStrippedFromBothSources(t *testing.T
 	}
 	if result["inbound_mode"] != "poll" {
 		t.Errorf("non-secret file key should survive: got %q", result["inbound_mode"])
+	}
+}
+
+// setupTestHome sets HOME to a temp dir and creates the .scion subdirectory
+// so that GetGlobalDir() returns a predictable path. Returns the .scion dir
+// and the settings.yaml path within it.
+func setupTestHome(t *testing.T) (globalDir, settingsPath string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	globalDir = filepath.Join(home, ".scion")
+	if err := os.MkdirAll(globalDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath = filepath.Join(globalDir, "settings.yaml")
+	return globalDir, settingsPath
+}
+
+func TestAddPluginToMessageBrokerTypes_NewPlugin(t *testing.T) {
+	_, settingsPath := setupTestHome(t)
+
+	// Seed a minimal settings.yaml.
+	if err := os.WriteFile(settingsPath, []byte("server:\n  plugins: {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AddPluginToMessageBrokerTypes("telegram"); err != nil {
+		t.Fatalf("AddPluginToMessageBrokerTypes() error: %v", err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Parse back and verify.
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+
+	server := raw["server"].(map[string]interface{})
+	mb := server["message_broker"].(map[string]interface{})
+
+	if enabled, ok := mb["enabled"].(bool); !ok || !enabled {
+		t.Error("expected message_broker.enabled = true")
+	}
+
+	typesRaw, ok := mb["types"].([]interface{})
+	if !ok {
+		t.Fatal("expected message_broker.types to be a list")
+	}
+	if len(typesRaw) != 1 || typesRaw[0] != "telegram" {
+		t.Errorf("expected types=[telegram], got %v", typesRaw)
+	}
+}
+
+func TestAddPluginToMessageBrokerTypes_Idempotent(t *testing.T) {
+	_, settingsPath := setupTestHome(t)
+
+	if err := os.WriteFile(settingsPath, []byte("server:\n  message_broker:\n    enabled: true\n    types:\n      - telegram\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AddPluginToMessageBrokerTypes("telegram"); err != nil {
+		t.Fatalf("AddPluginToMessageBrokerTypes() error: %v", err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+
+	server := raw["server"].(map[string]interface{})
+	mb := server["message_broker"].(map[string]interface{})
+	typesRaw := mb["types"].([]interface{})
+	if len(typesRaw) != 1 {
+		t.Errorf("expected types list to remain length 1 (idempotent), got %v", typesRaw)
+	}
+}
+
+func TestAddPluginToMessageBrokerTypes_AppendsSecondPlugin(t *testing.T) {
+	_, settingsPath := setupTestHome(t)
+
+	if err := os.WriteFile(settingsPath, []byte("server:\n  message_broker:\n    enabled: true\n    types:\n      - telegram\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := AddPluginToMessageBrokerTypes("discord"); err != nil {
+		t.Fatalf("AddPluginToMessageBrokerTypes() error: %v", err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+
+	server := raw["server"].(map[string]interface{})
+	mb := server["message_broker"].(map[string]interface{})
+	typesRaw := mb["types"].([]interface{})
+	if len(typesRaw) != 2 {
+		t.Fatalf("expected 2 types, got %v", typesRaw)
+	}
+	if typesRaw[0] != "telegram" || typesRaw[1] != "discord" {
+		t.Errorf("expected [telegram discord], got %v", typesRaw)
+	}
+}
+
+func TestAddPluginToMessageBrokerTypes_NoSettingsFile(t *testing.T) {
+	_, settingsPath := setupTestHome(t)
+
+	// No settings.yaml exists yet — the function should create one.
+	if err := AddPluginToMessageBrokerTypes("slack"); err != nil {
+		t.Fatalf("AddPluginToMessageBrokerTypes() error: %v", err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+
+	server := raw["server"].(map[string]interface{})
+	mb := server["message_broker"].(map[string]interface{})
+
+	if enabled, ok := mb["enabled"].(bool); !ok || !enabled {
+		t.Error("expected message_broker.enabled = true")
+	}
+
+	typesRaw := mb["types"].([]interface{})
+	if len(typesRaw) != 1 || typesRaw[0] != "slack" {
+		t.Errorf("expected types=[slack], got %v", typesRaw)
 	}
 }
 

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -803,6 +803,9 @@ func (s *Server) handleInstallIntegration(w http.ResponseWriter, r *http.Request
 
 	settingsWriteMu.Lock()
 	err = config.AddPluginToSettings(name, configFilePath)
+	if err == nil {
+		err = config.AddPluginToMessageBrokerTypes(name)
+	}
 	settingsWriteMu.Unlock()
 	if err != nil {
 		slog.Error("Failed to add plugin to settings.yaml", "plugin", name, "error", err)


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/537

Installing a broker plugin via the web UI did not add it to server.message_broker.types, causing the plugin to load but be excluded from message routing (slash commands, inbound messages, and outbound delivery all silently failing).

Adds AddPluginToMessageBrokerTypes() helper that appends the plugin name to the types list with a duplicate guard, using the same read-modify-write pattern as AddPluginToSettings(). Called from handleInstallIntegration() under the existing settingsWriteMu lock. 4 unit tests