### PR TITLE
fix(discord): reduce agent cache TTL to 30s to minimize /default lag

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	defaultAgentCacheTTL = 5 * time.Minute
+	defaultAgentCacheTTL = 30 * time.Second
 	defaultDBPath        = "discord.db"
 
 	// dedupTTL is how long a message ID is remembered for deduplication.


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/539

New agents were taking 0-5 minutes to appear in the /default command agent list and mention resolution because defaultAgentCacheTTL was 5 minutes with no event-driven invalidation. Reduces TTL to 30s so agents appear within 30 seconds of creation.

See https://github.com/ptone/scion/issues/539 for the follow-on issue tracking proper event-driven cache invalidation