### PR TITLE
fix(discord): default state notifications to off for new channel links

### DIFF
--- a/extras/scion-discord/internal/discord/callbacks.go
+++ b/extras/scion-discord/internal/discord/callbacks.go
@@ -206,7 +206,7 @@ func (h *CallbackHandler) saveChannelLink(ctx context.Context, i *discordgo.Inte
 		LinkedAt:           time.Now(),
 		Active:             true,
 		ShowAssistantReply: false,
-		ShowStateChanges:   true,
+		ShowStateChanges:   false,
 		NotifyInGroup:      true,
 	}
 

--- a/extras/scion-discord/internal/discord/store.go
+++ b/extras/scion-discord/internal/discord/store.go
@@ -196,7 +196,7 @@ CREATE TABLE IF NOT EXISTS channel_links (
 	active INTEGER NOT NULL DEFAULT 1,
 	show_agent_to_agent INTEGER NOT NULL DEFAULT 0,
 	show_assistant_reply INTEGER NOT NULL DEFAULT 1,
-	show_state_changes INTEGER NOT NULL DEFAULT 1,
+	show_state_changes INTEGER NOT NULL DEFAULT 0,
 	notify_in_group INTEGER NOT NULL DEFAULT 1,
 	chat_only INTEGER NOT NULL DEFAULT 0
 );
@@ -273,7 +273,7 @@ CREATE TABLE IF NOT EXISTS thread_defaults (
 
 func (s *sqliteStore) migrateSchema() {
 	migrations := []string{
-		`ALTER TABLE channel_links ADD COLUMN show_state_changes INTEGER NOT NULL DEFAULT 1`,
+		`ALTER TABLE channel_links ADD COLUMN show_state_changes INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE channel_links ADD COLUMN guild_name TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, m := range migrations {

--- a/extras/scion-discord/internal/discord/store_postgres.go
+++ b/extras/scion-discord/internal/discord/store_postgres.go
@@ -47,7 +47,7 @@ CREATE TABLE IF NOT EXISTS discord_channel_links (
 	active BOOLEAN NOT NULL DEFAULT TRUE,
 	show_agent_to_agent BOOLEAN NOT NULL DEFAULT FALSE,
 	show_assistant_reply BOOLEAN NOT NULL DEFAULT TRUE,
-	show_state_changes BOOLEAN NOT NULL DEFAULT TRUE,
+	show_state_changes BOOLEAN NOT NULL DEFAULT FALSE,
 	notify_in_group BOOLEAN NOT NULL DEFAULT TRUE,
 	chat_only BOOLEAN NOT NULL DEFAULT FALSE
 );


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/541

State change notifications (WAITING_FOR_INPUT, WORKING, etc.) now default to OFF when a channel or thread is set up via /setup. Users can enable per-channel via the /scion status toggle. Existing channels are unaffected. 3 changes: ShowStateChanges default in callbacks.go, SQLite schema DEFAULT 0, migration DEFAULT 0