### PR TITLE
feat(discord): add autocomplete agent parameter to /default for large projects

### DIFF
--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -915,15 +915,15 @@ func (h *CommandHandler) HandleDefault(s *discordgo.Session, i *discordgo.Intera
 	// If the "agent" parameter was provided, set the default directly.
 	agentParam := getSubcommandOption(i, "agent")
 	if agentParam != "" {
-		// Validate that the agent exists in the project.
-		found := false
+		// Validate that the agent exists in the project (case-insensitive).
+		matchedSlug := ""
 		for _, slug := range agents {
-			if slug == agentParam {
-				found = true
+			if strings.EqualFold(slug, agentParam) {
+				matchedSlug = slug
 				break
 			}
 		}
-		if !found {
+		if matchedSlug == "" {
 			h.followup(s, i, fmt.Sprintf(
 				"Agent **%s** not found in this project. Use `/scion agents` to see available agents.",
 				agentParam,
@@ -931,26 +931,26 @@ func (h *CommandHandler) HandleDefault(s *discordgo.Session, i *discordgo.Intera
 			return
 		}
 
-		// Set the default at the appropriate level.
+		// Set the default at the appropriate level using the correctly-cased slug.
 		if isThread {
-			if err := h.store.SetThreadDefault(ctx, link.ChannelID, threadID, agentParam); err != nil {
+			if err := h.store.SetThreadDefault(ctx, link.ChannelID, threadID, matchedSlug); err != nil {
 				h.log.Error("Failed to set thread default", "error", err)
 				h.followup(s, i, "Failed to set thread default. Please try again.")
 				return
 			}
-			h.followup(s, i, fmt.Sprintf("Default agent for this thread set to **%s**.", agentParam))
+			h.followup(s, i, fmt.Sprintf("Default agent for this thread set to **%s**.", matchedSlug))
 			h.log.Info("Thread default set via autocomplete",
-				"channel_id", link.ChannelID, "thread_id", threadID, "agent", agentParam)
+				"channel_id", link.ChannelID, "thread_id", threadID, "agent", matchedSlug)
 		} else {
-			link.DefaultAgent = agentParam
+			link.DefaultAgent = matchedSlug
 			if err := h.store.UpdateChannelLink(ctx, link); err != nil {
 				h.log.Error("Failed to set default agent", "error", err)
 				h.followup(s, i, "Failed to set default agent. Please try again.")
 				return
 			}
-			h.followup(s, i, fmt.Sprintf("Default agent set to **%s** for this channel.", agentParam))
+			h.followup(s, i, fmt.Sprintf("Default agent set to **%s** for this channel.", matchedSlug))
 			h.log.Info("Default agent set via autocomplete",
-				"channel_id", i.ChannelID, "agent", agentParam)
+				"channel_id", i.ChannelID, "agent", matchedSlug)
 		}
 		return
 	}

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -195,6 +195,13 @@ func (h *CommandHandler) RegisterCommandsForGuild(guildID string) error {
 				Type:        discordgo.ApplicationCommandOptionSubCommand,
 				Name:        "default",
 				Description: "Set or show the default agent for this channel",
+				Options: []*discordgo.ApplicationCommandOption{{
+					Type:         discordgo.ApplicationCommandOptionString,
+					Name:         "agent",
+					Description:  "Agent name (leave empty to show/clear current default)",
+					Required:     false,
+					Autocomplete: true,
+				}},
 			},
 			{
 				Type:        discordgo.ApplicationCommandOptionSubCommand,
@@ -397,7 +404,7 @@ func helpText() string {
 		"`/scion stop <agent>` — Stop an agent\n" +
 		"`/scion msg <agent> <text>` — Send a message to an agent\n" +
 		"`/scion logs <agent>` — View agent logs\n" +
-		"`/scion default` — Set or clear the default agent\n" +
+		"`/scion default [agent]` — Set or clear the default agent\n" +
 		"`/scion register` — Link your Discord account to Scion Hub\n" +
 		"`/scion unregister` — Unlink your Discord account\n" +
 		"`/scion settings` — Configure channel notification settings\n" +
@@ -865,6 +872,11 @@ func (h *CommandHandler) HandleLogs(s *discordgo.Session, i *discordgo.Interacti
 // HandleDefault shows agent selection buttons for setting the default agent.
 // When invoked from a thread, it manages per-thread overrides instead of
 // the channel-level default.
+//
+// Hybrid routing:
+//   - If the "agent" parameter is provided: validate and set the default directly.
+//   - If no parameter + ≤20 agents: show the existing button grid.
+//   - If no parameter + >20 agents: show info + prompt to use autocomplete.
 func (h *CommandHandler) HandleDefault(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -900,6 +912,51 @@ func (h *CommandHandler) HandleDefault(s *discordgo.Session, i *discordgo.Intera
 		threadID = i.ChannelID
 	}
 
+	// If the "agent" parameter was provided, set the default directly.
+	agentParam := getSubcommandOption(i, "agent")
+	if agentParam != "" {
+		// Validate that the agent exists in the project.
+		found := false
+		for _, slug := range agents {
+			if slug == agentParam {
+				found = true
+				break
+			}
+		}
+		if !found {
+			h.followup(s, i, fmt.Sprintf(
+				"Agent **%s** not found in this project. Use `/scion agents` to see available agents.",
+				agentParam,
+			))
+			return
+		}
+
+		// Set the default at the appropriate level.
+		if isThread {
+			if err := h.store.SetThreadDefault(ctx, link.ChannelID, threadID, agentParam); err != nil {
+				h.log.Error("Failed to set thread default", "error", err)
+				h.followup(s, i, "Failed to set thread default. Please try again.")
+				return
+			}
+			h.followup(s, i, fmt.Sprintf("Default agent for this thread set to **%s**.", agentParam))
+			h.log.Info("Thread default set via autocomplete",
+				"channel_id", link.ChannelID, "thread_id", threadID, "agent", agentParam)
+		} else {
+			link.DefaultAgent = agentParam
+			if err := h.store.UpdateChannelLink(ctx, link); err != nil {
+				h.log.Error("Failed to set default agent", "error", err)
+				h.followup(s, i, "Failed to set default agent. Please try again.")
+				return
+			}
+			h.followup(s, i, fmt.Sprintf("Default agent set to **%s** for this channel.", agentParam))
+			h.log.Info("Default agent set via autocomplete",
+				"channel_id", i.ChannelID, "agent", agentParam)
+		}
+		return
+	}
+
+	// No agent parameter — show UI based on agent count.
+
 	// Determine the current effective default for highlighting.
 	currentDefault := link.DefaultAgent
 	if isThread {
@@ -911,17 +968,57 @@ func (h *CommandHandler) HandleDefault(s *discordgo.Session, i *discordgo.Intera
 		}
 	}
 
+	var currentText string
+	if currentDefault != "" {
+		currentText = fmt.Sprintf("Current default: **%s**\n", currentDefault)
+	}
+
+	// Large project path (>20 agents): info message + clear button only.
+	if len(agents) > 20 {
+		promptText := fmt.Sprintf(
+			"This project has %d agents. Use `/scion default agent:<name>` with autocomplete to select.",
+			len(agents),
+		)
+		if isThread {
+			promptText = fmt.Sprintf(
+				"This project has %d agents. Use `/scion default agent:<name>` with autocomplete to select a thread default.",
+				len(agents),
+			)
+			if link.DefaultAgent != "" {
+				promptText += fmt.Sprintf("\nChannel-wide default: **%s**", link.DefaultAgent)
+			}
+		}
+
+		noneCustomID := "default:none"
+		if threadID != "" {
+			noneCustomID = fmt.Sprintf("default:none:%s", threadID)
+		}
+		rows := []discordgo.MessageComponent{
+			discordgo.ActionsRow{
+				Components: []discordgo.MessageComponent{
+					discordgo.Button{
+						Label:    "Clear Default",
+						Style:    discordgo.DangerButton,
+						CustomID: noneCustomID,
+					},
+				},
+			},
+		}
+
+		_, _ = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+			Content:    currentText + promptText,
+			Components: rows,
+		})
+		return
+	}
+
+	// Small project path (≤20 agents): existing button grid.
 	promptText := "Select the default agent for this channel:"
 	if isThread {
 		promptText = "Select the default agent for this thread:"
 		if link.DefaultAgent != "" {
 			promptText += fmt.Sprintf("\nChannel-wide default: **%s**", link.DefaultAgent)
 		}
-	}
-
-	var currentText string
-	if currentDefault != "" {
-		currentText = fmt.Sprintf("Current default: **%s**\n", currentDefault)
 	}
 
 	var rows []discordgo.MessageComponent


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/546

The /scion default command could not display all agents when a project has many agents (Discord button limit). Adds a hybrid approach: optional autocomplete agent parameter. Projects with 20 or fewer agents keep the existing button grid; projects with more show a clear message prompting to use the parameter with autocomplete. When the parameter is provided directly, the agent is validated and set immediately without a button step