### PR TITLE
fix: wire installed/restarted broker plugin as FanOut spoke

### DIFF
--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -583,6 +583,9 @@ func (s *Server) handleUpdateIntegrationConfig(w http.ResponseWriter, r *http.Re
 				InternalError(w)
 				return
 			}
+			// The plugin may have been installed mid-session and never wired
+			// into the FanOut at startup. Ensure it has a spoke now.
+			s.ensureBrokerSpoke(mgr, name)
 		}
 	} else {
 		// The plugin was installed but never loaded (required fields were
@@ -615,13 +618,17 @@ func (s *Server) handleRestartIntegration(w http.ResponseWriter, r *http.Request
 	// reconfigureIntegration pushes new config to the running plugin process
 	// (via ReplaceBrokerConfig) without killing it, so the existing spoke's
 	// RPC connection remains valid — no refreshBrokerSpoke needed here.
-	// Contrast with handleUpdateIntegration which rebuilds the binary and
-	// restarts the process, requiring a spoke refresh.
+	// However the spoke may never have been added (e.g. first install before
+	// a full hub restart), so ensure it exists.
 	if err := s.reconfigureIntegration(r.Context(), mgr, name); err != nil {
 		slog.Error("Failed to restart integration", "plugin", name, "error", err)
 		InternalError(w)
 		return
 	}
+
+	// Ensure the plugin is wired as a FanOut spoke — it may have been
+	// installed mid-session and never added at startup.
+	s.ensureBrokerSpoke(mgr, name)
 
 	// Post-restart validation: check that the plugin is wired into the FanOut.
 	warnings := s.validateIntegrationWiring(name)
@@ -845,6 +852,10 @@ func (s *Server) handleInstallIntegration(w http.ResponseWriter, r *http.Request
 		// can reconfigure via the admin UI.
 		slog.Warn("Plugin installed but initial reconfigure failed", "plugin", name, "error", err)
 	}
+
+	// Wire the newly installed plugin into the FanOut so it receives
+	// Subscribe() calls (and can start its gateway).
+	s.ensureBrokerSpoke(mgr, name)
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
@@ -1239,6 +1250,58 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 	}
 
 	return nil
+}
+
+// ensureBrokerSpoke adds the plugin as a FanOut spoke if it is not already
+// registered. Unlike refreshBrokerSpoke it never calls ReplaceSpoke, so it
+// is safe to call on a running plugin — existing connections are preserved.
+// This fills the gap where handleInstallIntegration, handleRestartIntegration,
+// and handleUpdateIntegrationConfig (loaded-branch) all call
+// reconfigureIntegration but never wire the plugin into the FanOut, causing
+// Subscribe() (and therefore startGateway()) to never fire.
+func (s *Server) ensureBrokerSpoke(mgr IntegrationManager, name string) {
+	proxy := s.GetMessageBrokerProxy()
+	if proxy == nil {
+		return
+	}
+	fanout, ok := proxy.bus.(*eventbus.FanOutEventBus)
+	if !ok {
+		return
+	}
+	if fanout.HasSpoke(name) {
+		return // already wired — nothing to do
+	}
+
+	newBus, err := mgr.GetBroker(name)
+	if err != nil {
+		slog.Warn("ensureBrokerSpoke: cannot get broker, skipping spoke add",
+			"plugin", name, "error", err)
+		return
+	}
+
+	var observer bool
+	var channelID string
+	if _, cID, caps, infoErr := mgr.BrokerInfo(name); infoErr == nil {
+		channelID = cID
+		for _, cap := range caps {
+			if strings.EqualFold(cap, "observer") {
+				observer = true
+				break
+			}
+		}
+	}
+
+	spoke := eventbus.NamedEventBus{
+		Name:      name,
+		Bus:       newBus,
+		Observer:  observer,
+		ChannelID: channelID,
+	}
+	if err := fanout.AddSpoke(spoke); err != nil {
+		slog.Error("ensureBrokerSpoke: failed to add spoke", "plugin", name, "error", err)
+	} else {
+		slog.Info("Wired broker plugin as FanOut spoke after admin operation", "plugin", name)
+	}
 }
 
 // refreshBrokerSpoke replaces the stale fan-out eventbus spoke for a broker

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -1278,6 +1278,10 @@ func (s *Server) ensureBrokerSpoke(mgr IntegrationManager, name string) {
 			"plugin", name, "error", err)
 		return
 	}
+	if newBus == nil {
+		slog.Warn("ensureBrokerSpoke: broker is nil, skipping spoke add", "plugin", name)
+		return
+	}
 
 	var observer bool
 	var channelID string

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -55,6 +55,7 @@ type mockIntegrationManager struct {
 	installCalls       []string
 	loadOneCalls       []string
 	loadOneErr         error
+	brokers            map[string]eventbus.EventBus // name → bus (for GetBroker)
 }
 
 func newMockIntegrationManager() *mockIntegrationManager {
@@ -189,6 +190,11 @@ func (m *mockIntegrationManager) LoadOne(pluginType, name string, entry plugin.P
 }
 
 func (m *mockIntegrationManager) GetBroker(name string) (eventbus.EventBus, error) {
+	if m.brokers != nil {
+		if b, ok := m.brokers[name]; ok {
+			return b, nil
+		}
+	}
 	return nil, fmt.Errorf("mock: GetBroker not wired")
 }
 
@@ -586,6 +592,75 @@ func TestValidateIntegrationWiring_NoProxy(t *testing.T) {
 	if !strings.Contains(warnings[0], "message broker not initialized") {
 		t.Errorf("unexpected warning: %s", warnings[0])
 	}
+}
+
+// --- ensureBrokerSpoke tests ---
+
+func TestEnsureBrokerSpoke_AddsWhenMissing(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["discord"] = map[string]string{}
+
+	discordBus := eventbus.NewInProcessEventBus(slog.Default())
+	mgr.brokers = map[string]eventbus.EventBus{"discord": discordBus}
+
+	// FanOut has only the inprocess spoke — discord is missing.
+	inproc := eventbus.NewInProcessEventBus(slog.Default())
+	fanout := eventbus.NewFanOutEventBus([]eventbus.NamedEventBus{
+		{Name: "inprocess", Bus: inproc},
+	}, slog.Default())
+
+	proxy := NewMessageBrokerProxy(fanout, nil, nil, nil, slog.Default())
+	srv := &Server{}
+	srv.pluginManager = mgr
+	srv.SetMessageBrokerProxy(proxy)
+
+	if fanout.HasSpoke("discord") {
+		t.Fatal("precondition failed: discord spoke should not exist yet")
+	}
+
+	srv.ensureBrokerSpoke(mgr, "discord")
+
+	if !fanout.HasSpoke("discord") {
+		t.Fatal("ensureBrokerSpoke should have added the discord spoke")
+	}
+}
+
+func TestEnsureBrokerSpoke_NoopWhenAlreadyPresent(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["discord"] = map[string]string{}
+
+	discordBus := eventbus.NewInProcessEventBus(slog.Default())
+	mgr.brokers = map[string]eventbus.EventBus{"discord": discordBus}
+
+	// FanOut already has a discord spoke.
+	inproc := eventbus.NewInProcessEventBus(slog.Default())
+	existingDiscordBus := eventbus.NewInProcessEventBus(slog.Default())
+	fanout := eventbus.NewFanOutEventBus([]eventbus.NamedEventBus{
+		{Name: "inprocess", Bus: inproc},
+		{Name: "discord", Bus: existingDiscordBus},
+	}, slog.Default())
+
+	proxy := NewMessageBrokerProxy(fanout, nil, nil, nil, slog.Default())
+	srv := &Server{}
+	srv.pluginManager = mgr
+	srv.SetMessageBrokerProxy(proxy)
+
+	// Should be a no-op — HasSpoke returns true, AddSpoke is never called.
+	srv.ensureBrokerSpoke(mgr, "discord")
+
+	if !fanout.HasSpoke("discord") {
+		t.Fatal("discord spoke should still exist")
+	}
+}
+
+func TestEnsureBrokerSpoke_NoProxyIsNoop(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["discord"] = map[string]string{}
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+	// No proxy set — should not panic.
+	srv.ensureBrokerSpoke(mgr, "discord")
 }
 
 func TestRestartIntegration_NotFound(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/545

After installing or restarting a broker plugin via the admin UI, the plugin was never added as a FanOut event bus spoke. Without being a spoke, Discord (and other plugins) never received Subscribe() callbacks, so the Discord gateway never opened. A full hub restart was required to recover.

Adds ensureBrokerSpoke() helper that safely checks HasSpoke() before adding (never replaces existing spokes). Called after reconfigureIntegration() in handleInstallIntegration, handleRestartIntegration, and handleUpdateIntegrationConfig