### PR TITLE
feat(claude-harness): add deny list and disable flags to settings.json

### DIFF
--- a/harnesses/claude/home/.claude/settings.json
+++ b/harnesses/claude/home/.claude/settings.json
@@ -29,7 +29,7 @@
   "disableWorkflows": true,
   "disableRemoteControl": true,
   "disableClaudeAiConnectors": true,
-  "disableArtifact": true,
+  "disableArtifacts": true,
   "includeCoAuthoredBy": false,
   "gitAttribution": false,
   "hooks": {

--- a/harnesses/claude/home/.claude/settings.json
+++ b/harnesses/claude/home/.claude/settings.json
@@ -6,10 +6,30 @@
     "enabled": false
   },
   "permissions": {
-        "allow": [
+    "allow": [
       "*"
+    ],
+    "deny": [
+      "EnterPlanMode",
+      "ExitPlanMode",
+      "DesignSync",
+      "NotebookEdit",
+      "SendMessage",
+      "PushNotification",
+      "RemoteTrigger",
+      "ReportFindings",
+      "ScheduleWakeup",
+      "AskUserQuestion",
+      "CronCreate",
+      "CronDelete",
+      "CronList"
     ]
   },
+  "disableBundledSkills": true,
+  "disableWorkflows": true,
+  "disableRemoteControl": true,
+  "disableClaudeAiConnectors": true,
+  "disableArtifact": true,
   "includeCoAuthoredBy": false,
   "gitAttribution": false,
   "hooks": {


### PR DESCRIPTION
## Summary
- Add deny list with 13 tool entries to permissions (EnterPlanMode, ExitPlanMode, DesignSync, NotebookEdit, SendMessage, PushNotification, RemoteTrigger, ReportFindings, ScheduleWakeup, AskUserQuestion, CronCreate, CronDelete, CronList)
- Add 5 disable flags: disableBundledSkills, disableWorkflows, disableRemoteControl, disableClaudeAiConnectors, disableArtifact

## Test plan
- [ ] Verify settings.json is valid JSON
- [ ] Verify deny list contains all 13 expected entries
- [ ] Verify all 5 disable flags set to true
- [ ] Verify no existing settings were modified