### PR TITLE
feat(web): agent lineage graph view (/agents/graph)

### DIFF
--- a/pkg/hub/events.go
+++ b/pkg/hub/events.go
@@ -115,22 +115,23 @@ type AgentStatusEvent struct {
 // Unlike status deltas this carries the full agent snapshot so that
 // subscribers can render a complete row without an extra REST fetch.
 type AgentCreatedEvent struct {
-	AgentID         string `json:"agentId"`
-	ProjectID       string `json:"projectId"`
-	GroveID         string `json:"groveId"`
-	Name            string `json:"name"`
-	Slug            string `json:"slug"`
-	Template        string `json:"template,omitempty"`
-	Phase           string `json:"phase,omitempty"`
-	Activity        string `json:"activity,omitempty"`
-	ContainerStatus string `json:"containerStatus,omitempty"`
-	Image           string `json:"image,omitempty"`
-	Runtime         string `json:"runtime,omitempty"`
-	RuntimeBrokerID string `json:"runtimeBrokerId,omitempty"`
-	CreatedBy       string `json:"createdBy,omitempty"`
-	Visibility      string `json:"visibility,omitempty"`
-	TaskSummary     string `json:"taskSummary,omitempty"`
-	Created         string `json:"created,omitempty"`
+	AgentID         string   `json:"agentId"`
+	ProjectID       string   `json:"projectId"`
+	GroveID         string   `json:"groveId"`
+	Name            string   `json:"name"`
+	Slug            string   `json:"slug"`
+	Template        string   `json:"template,omitempty"`
+	Phase           string   `json:"phase,omitempty"`
+	Activity        string   `json:"activity,omitempty"`
+	ContainerStatus string   `json:"containerStatus,omitempty"`
+	Image           string   `json:"image,omitempty"`
+	Runtime         string   `json:"runtime,omitempty"`
+	RuntimeBrokerID string   `json:"runtimeBrokerId,omitempty"`
+	CreatedBy       string   `json:"createdBy,omitempty"`
+	Visibility      string   `json:"visibility,omitempty"`
+	TaskSummary     string   `json:"taskSummary,omitempty"`
+	Created         string   `json:"created,omitempty"`
+	Ancestry        []string `json:"ancestry,omitempty"`
 }
 
 // AgentDeletedEvent is published when an agent is deleted.
@@ -393,6 +394,7 @@ func (p *eventBuilder) PublishAgentCreated(_ context.Context, agent *store.Agent
 		CreatedBy:       agent.CreatedBy,
 		Visibility:      agent.Visibility,
 		TaskSummary:     agent.TaskSummary,
+		Ancestry:        agent.Ancestry,
 	}
 	if !agent.Created.IsZero() {
 		evt.Created = agent.Created.Format("2006-01-02T15:04:05Z07:00")

--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -170,6 +170,7 @@ const ROUTES: RouteConfig[] = [
   { pattern: /^\/projects\/[^/]+\/metrics$/, tag: 'scion-page-metrics', load: () => import('../components/pages/metrics-dashboard.js') },
   { pattern: /^\/projects\/[^/]+$/, tag: 'scion-page-project-detail', load: () => import('../components/pages/project-detail.js') },
   { pattern: /^\/agents\/new$/, tag: 'scion-page-agent-create', load: () => import('../components/pages/agent-create.js') },
+  { pattern: /^\/agents\/graph$/, tag: 'scion-page-agent-graph', load: () => import('../components/pages/agent-graph.js') },
   { pattern: /^\/agents\/[^/]+\/configure$/, tag: 'scion-page-agent-configure', load: () => import('../components/pages/agent-configure.js') },
   { pattern: /^\/agents\/[^/]+\/terminal$/, tag: 'scion-page-terminal', load: () => import('../components/pages/terminal.js') },
   { pattern: /^\/agents\/[^/]+$/, tag: 'scion-page-agent-detail', load: () => import('../components/pages/agent-detail.js') },

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -1116,6 +1116,13 @@ export class ScionPageAgentDetail extends LitElement {
                 </sl-tooltip>
               `
             : nothing}
+          <sl-tooltip content="See this agent in graph">
+            <a href="/agents/graph?focus=${this.agentId}" style="text-decoration: none;">
+              <sl-button variant="default" size="small">
+                <sl-icon slot="prefix" name="diagram-3"></sl-icon>
+              </sl-button>
+            </a>
+          </sl-tooltip>
           ${can(agent._capabilities, 'delete')
             ? html`
                 <sl-button

--- a/web/src/components/pages/agent-graph.ts
+++ b/web/src/components/pages/agent-graph.ts
@@ -564,16 +564,26 @@ export class AgentGraphPage extends LitElement {
       related.add(parent.id);
       cur = parent;
     }
-    // Walk down: repeated sweeps until closure (forests are small).
-    let grew = true;
-    while (grew) {
-      grew = false;
-      for (const a of agents) {
-        if (related.has(a.id)) continue;
-        const pid = parentIdOf(a);
-        if (pid && related.has(pid)) {
-          related.add(a.id);
-          grew = true;
+    // Walk down with BFS over a child adjacency map. Seeded from the
+    // hovered agent only, so ancestors' other branches (the hovered
+    // agent's siblings and cousins) stay dim.
+    const childrenOf = new Map<string, string[]>();
+    for (const a of agents) {
+      const pid = parentIdOf(a);
+      if (!pid) continue;
+      const siblings = childrenOf.get(pid);
+      if (siblings) {
+        siblings.push(a.id);
+      } else {
+        childrenOf.set(pid, [a.id]);
+      }
+    }
+    const queue = [hovered.id];
+    for (let head = 0; head < queue.length; head++) {
+      for (const childId of childrenOf.get(queue[head]) ?? []) {
+        if (!related.has(childId)) {
+          related.add(childId);
+          queue.push(childId);
         }
       }
     }

--- a/web/src/components/pages/agent-graph.ts
+++ b/web/src/components/pages/agent-graph.ts
@@ -1,0 +1,819 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LitElement, html, css, svg, nothing } from 'lit';
+import { customElement, property, state, query } from 'lit/decorators.js';
+import type { PageData, Agent } from '../../shared/types.js';
+import { getAgentDisplayStatus } from '../../shared/types.js';
+import { getStateDisplay, type StatusVariant } from '../../shared/agent-state-display.js';
+import {
+  buildLineageForest,
+  descendantCounts,
+  layoutForest,
+  layoutForestWithUsers,
+  parentIdOf,
+  pruneCollapsed,
+  rootUserOf,
+  userKey,
+  NODE_W,
+  NODE_H,
+  type PositionedNode,
+  type PositionedEdge,
+  type PositionedUser,
+} from '../../shared/lineage.js';
+import { apiFetch, extractApiError } from '../../client/api.js';
+import { stateManager } from '../../client/state.js';
+import type { StatusType } from '../shared/status-badge.js';
+import type { ViewMode } from '../shared/view-toggle.js';
+import '../shared/status-badge.js';
+import '../shared/view-toggle.js';
+
+const VARIANT_COLOR: Record<StatusVariant, string> = {
+  success: 'var(--sl-color-success-600)',
+  warning: 'var(--sl-color-warning-600)',
+  danger: 'var(--sl-color-danger-600)',
+  primary: 'var(--sl-color-primary-600)',
+  neutral: 'var(--sl-color-neutral-400)',
+};
+
+const MIN_SCALE = 0.25;
+const MAX_SCALE = 2.5;
+
+/**
+ * Agent lineage graph page: renders project agents as a parent/child forest
+ * based on each agent's ancestry chain. Nodes are HTML cards (real anchors,
+ * so client-side routing works); edges are drawn in an SVG underlay.
+ * Supports pan (drag), zoom (wheel / buttons), and hover highlighting of the
+ * hovered agent's lineage.
+ */
+@customElement('scion-page-agent-graph')
+export class AgentGraphPage extends LitElement {
+  @property({ type: Object }) pageData?: PageData;
+
+  @state() private agents: Agent[] = [];
+  @state() private loading = true;
+  @state() private error: string | null = null;
+  @state() private projectFilter = '';
+  @state() private showUsers = false;
+  @state() private hoverId: string | null = null;
+  @state() private collapsedIds: ReadonlySet<string> = new Set();
+  @state() private scale = 1;
+  @state() private panX = 0;
+  @state() private panY = 0;
+
+  @query('.canvas') private canvasEl?: HTMLDivElement;
+
+  private boundOnAgentsUpdated = () => this.onAgentsUpdated();
+  private boundOnWheel = (e: WheelEvent) => this.onWheel(e);
+  /** Agent to center and ring on load (?focus=<agent-id> deep link) */
+  private focusId = '';
+  private dragging = false;
+  private dragStartX = 0;
+  private dragStartY = 0;
+  private dragPanX = 0;
+  private dragPanY = 0;
+  private didAutoFit = false;
+
+  static override styles = css`
+    :host {
+      display: block;
+      padding: var(--sl-spacing-large, 1.25rem);
+    }
+
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-bottom: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .header h1 {
+      margin: 0;
+      font-size: 1.5rem;
+    }
+
+    .header-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .canvas {
+      position: relative;
+      overflow: hidden;
+      border: 1px solid var(--sl-color-neutral-200);
+      border-radius: var(--sl-border-radius-medium, 6px);
+      background-color: var(--sl-color-neutral-0);
+      background-image: radial-gradient(var(--sl-color-neutral-200) 1px, transparent 1px);
+      background-size: 22px 22px;
+      height: 70vh;
+      min-height: 340px;
+      cursor: grab;
+      touch-action: none;
+    }
+
+    .canvas.dragging {
+      cursor: grabbing;
+    }
+
+    .stage {
+      position: absolute;
+      top: 0;
+      left: 0;
+      transform-origin: 0 0;
+    }
+
+    .stage svg {
+      position: absolute;
+      top: 0;
+      left: 0;
+      overflow: visible;
+      pointer-events: none;
+    }
+
+    .edge {
+      stroke: var(--sl-color-neutral-400);
+      stroke-width: 1.6;
+      fill: none;
+      transition: opacity 0.2s ease, stroke 0.2s ease;
+      marker-end: url(#arrow-neutral);
+    }
+
+    .edge.dim {
+      opacity: 0.15;
+    }
+
+    .edge.lit {
+      stroke: var(--sl-color-primary-600);
+      stroke-width: 2.2;
+      marker-end: url(#arrow-lit);
+    }
+
+    .node {
+      position: absolute;
+      box-sizing: border-box;
+      width: 180px;
+      height: 76px;
+      padding: 8px 10px;
+      border: 1px solid var(--sl-color-neutral-300);
+      border-left-width: 4px;
+      border-radius: var(--sl-border-radius-medium, 6px);
+      background: var(--sl-color-neutral-0);
+      text-decoration: none;
+      color: inherit;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      gap: 2px;
+      transition:
+        opacity 0.2s ease,
+        box-shadow 0.15s ease,
+        transform 0.15s ease;
+      animation: node-in 0.35s ease both;
+    }
+
+    @keyframes node-in {
+      from {
+        opacity: 0;
+        transform: translateY(-8px) scale(0.96);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+
+    .node:hover {
+      box-shadow: var(--sl-shadow-medium, 0 3px 10px rgba(0, 0, 0, 0.18));
+      transform: translateY(-1px) scale(1.02);
+      z-index: 2;
+    }
+
+    .node.dim {
+      opacity: 0.3;
+    }
+
+    /* Deep-linked node (?focus=<agent-id>): persistent ring so the agent the
+       user jumped here for stands out. The status color keeps the left edge
+       (set inline), so only the remaining sides pick up the ring border. */
+    .node.focus {
+      border-color: var(--sl-color-primary-500);
+      box-shadow: 0 0 0 3px var(--sl-color-primary-200);
+    }
+
+    .node .name {
+      font-weight: 600;
+      font-size: 0.95rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    /* The whole card is a link to the agent detail page; underline the name
+       on hover (same affordance as the list view) to make that visible. */
+    .node:hover .name {
+      text-decoration: underline;
+    }
+
+    .node .meta {
+      font-size: 0.72rem;
+      color: var(--sl-color-neutral-600);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .node scion-status-badge {
+      align-self: flex-start;
+      max-width: 100%;
+    }
+
+    /* Collapse/expand toggle: small chip on the parent's bottom edge */
+    .collapse-chip {
+      position: absolute;
+      bottom: -9px;
+      left: 50%;
+      transform: translateX(-50%);
+      min-width: 18px;
+      height: 18px;
+      padding: 0 4px;
+      box-sizing: border-box;
+      border: 1px solid var(--sl-color-neutral-300);
+      border-radius: 999px;
+      background: var(--sl-color-neutral-0);
+      color: var(--sl-color-neutral-600);
+      font-size: 10px;
+      line-height: 1;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      z-index: 1;
+    }
+
+    .collapse-chip:hover {
+      border-color: var(--sl-color-primary-500);
+      color: var(--sl-color-primary-600);
+    }
+
+    /* User (human) nodes: same footprint as agent nodes, distinct styling */
+    .node.user {
+      border-style: dashed;
+      border-left-style: solid;
+      border-left-color: var(--sl-color-neutral-400);
+      background: var(--sl-color-neutral-50);
+      cursor: default;
+      justify-content: center;
+    }
+
+    .node.user .name {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .node.user .name sl-icon {
+      font-size: 1rem;
+      flex: none;
+      color: var(--sl-color-neutral-600);
+    }
+
+    .zoom-controls {
+      position: absolute;
+      right: 10px;
+      bottom: 10px;
+      display: flex;
+      gap: 4px;
+      z-index: 3;
+    }
+
+    .empty-state,
+    .loading-state,
+    .error-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 3rem 1rem;
+      color: var(--sl-color-neutral-600);
+      text-align: center;
+    }
+
+    .error-state {
+      color: var(--sl-color-danger-600);
+    }
+  `;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    stateManager.setScope({ type: 'dashboard' });
+
+    const params = new URLSearchParams(window.location.search);
+    this.projectFilter = params.get('project') || '';
+    this.focusId = params.get('focus') || '';
+    this.showUsers = localStorage.getItem('scion-graph-show-users') === 'true';
+
+    const hydrated = stateManager.getAgents();
+    if (hydrated.length > 0) {
+      this.agents = hydrated;
+      this.loading = false;
+    } else {
+      void this.loadAgents();
+    }
+
+    stateManager.addEventListener('agents-updated', this.boundOnAgentsUpdated as EventListener);
+    // Wheel needs passive:false to preventDefault (browser page zoom/scroll).
+    this.addEventListener('wheel', this.boundOnWheel, { passive: false });
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    stateManager.removeEventListener('agents-updated', this.boundOnAgentsUpdated as EventListener);
+    this.removeEventListener('wheel', this.boundOnWheel);
+    if (this.refetchTimer !== undefined) {
+      window.clearTimeout(this.refetchTimer);
+      this.refetchTimer = undefined;
+    }
+  }
+
+  private refetchTimer: number | undefined;
+
+  private onAgentsUpdated(): void {
+    const updated = stateManager.getAgents();
+    const prev = new Map(this.agents.map(a => [a.id, a]));
+    let ancestryGap = false;
+    // Every persisted agent has a non-empty ancestry (at minimum [userID]).
+    // An empty chain means the update arrived via an event payload that
+    // omitted it — keep the previously known chain, or quietly re-fetch.
+    this.agents = updated.map(a => {
+      if (a.ancestry && a.ancestry.length > 0) return a;
+      const old = prev.get(a.id);
+      if (old?.ancestry?.length) return { ...a, ancestry: old.ancestry };
+      ancestryGap = true;
+      return a;
+    });
+    if (ancestryGap && this.refetchTimer === undefined) {
+      this.refetchTimer = window.setTimeout(() => {
+        this.refetchTimer = undefined;
+        void this.fetchAgents(true);
+      }, 800);
+    }
+  }
+
+  private async loadAgents(): Promise<void> {
+    this.loading = true;
+    this.error = null;
+    try {
+      await this.fetchAgents(false);
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  /** Fetches the agent list; quiet mode skips error state (background refresh). */
+  private async fetchAgents(quiet: boolean): Promise<void> {
+    try {
+      const response = await apiFetch('/api/v1/agents');
+      if (!response.ok) {
+        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+      }
+      const data = (await response.json()) as { agents?: Agent[] } | Agent[];
+      this.agents = Array.isArray(data) ? data : data.agents || [];
+      stateManager.seedAgents(this.agents);
+    } catch (err) {
+      console.error('Failed to load agents:', err);
+      if (!quiet) {
+        this.error = err instanceof Error ? err.message : 'Failed to load agents';
+      }
+    }
+  }
+
+  /** Agents after the project filter is applied */
+  private get visibleAgents(): Agent[] {
+    if (!this.projectFilter) return this.agents;
+    return this.agents.filter(a => a.projectId === this.projectFilter);
+  }
+
+  private get projects(): Array<{ id: string; name: string }> {
+    const seen = new Map<string, string>();
+    for (const agent of this.agents) {
+      if (agent.projectId && !seen.has(agent.projectId)) {
+        seen.set(agent.projectId, agent.project || agent.projectId);
+      }
+    }
+    return Array.from(seen, ([id, name]) => ({ id, name })).sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  private onProjectFilterChange(e: Event): void {
+    const value = (e.target as HTMLSelectElement & { value: string }).value;
+    this.projectFilter = value;
+    this.didAutoFit = false;
+    const url = new URL(window.location.href);
+    if (value) {
+      url.searchParams.set('project', value);
+    } else {
+      url.searchParams.delete('project');
+    }
+    window.history.replaceState({}, '', url);
+  }
+
+  // --- Pan & zoom -----------------------------------------------------------
+
+  private onWheel(e: WheelEvent): void {
+    const canvas = this.canvasEl;
+    if (!canvas) return;
+    const path = e.composedPath();
+    if (!path.includes(canvas)) return;
+    e.preventDefault();
+    const factor = e.deltaY < 0 ? 1.12 : 1 / 1.12;
+    this.zoomAround(e.clientX, e.clientY, factor);
+  }
+
+  private zoomAround(clientX: number, clientY: number, factor: number): void {
+    const canvas = this.canvasEl;
+    if (!canvas) return;
+    const next = Math.min(MAX_SCALE, Math.max(MIN_SCALE, this.scale * factor));
+    const applied = next / this.scale;
+    if (applied === 1) return;
+    const rect = canvas.getBoundingClientRect();
+    const cx = clientX - rect.left;
+    const cy = clientY - rect.top;
+    this.panX = cx - applied * (cx - this.panX);
+    this.panY = cy - applied * (cy - this.panY);
+    this.scale = next;
+  }
+
+  private zoomButtons(factor: number): void {
+    const canvas = this.canvasEl;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    this.zoomAround(rect.left + rect.width / 2, rect.top + rect.height / 2, factor);
+  }
+
+  private fitToView(contentW: number, contentH: number): void {
+    const canvas = this.canvasEl;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return;
+    const scale = Math.min(rect.width / contentW, rect.height / contentH, 1);
+    this.scale = Math.max(MIN_SCALE, scale);
+    this.panX = (rect.width - contentW * this.scale) / 2;
+    this.panY = Math.max((rect.height - contentH * this.scale) / 2, 8);
+  }
+
+  /** Centers the viewport on one node at 1:1 scale (?focus= deep link). */
+  private centerOn(n: PositionedNode): void {
+    const canvas = this.canvasEl;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return;
+    this.scale = 1;
+    this.panX = rect.width / 2 - (n.px + NODE_W / 2);
+    this.panY = rect.height / 2 - (n.py + NODE_H / 2);
+  }
+
+  private onPointerDown(e: PointerEvent): void {
+    // Only start panning from the background — keep node and control clicks
+    // working. Walk the whole composed path instead of target.closest():
+    // a click on sl-button lands inside its shadow root, where closest()
+    // cannot see the host, and the pointer capture below would swallow the
+    // button's click.
+    for (const el of e.composedPath()) {
+      if (el === this.canvasEl) break;
+      const tag = (el as HTMLElement).tagName;
+      if (tag === 'A' || tag === 'SL-BUTTON') return;
+    }
+    this.dragging = true;
+    this.dragStartX = e.clientX;
+    this.dragStartY = e.clientY;
+    this.dragPanX = this.panX;
+    this.dragPanY = this.panY;
+    this.canvasEl?.setPointerCapture(e.pointerId);
+    this.canvasEl?.classList.add('dragging');
+  }
+
+  private onPointerMove(e: PointerEvent): void {
+    if (!this.dragging) return;
+    this.panX = this.dragPanX + (e.clientX - this.dragStartX);
+    this.panY = this.dragPanY + (e.clientY - this.dragStartY);
+  }
+
+  private onPointerUp(e: PointerEvent): void {
+    this.dragging = false;
+    this.canvasEl?.releasePointerCapture(e.pointerId);
+    this.canvasEl?.classList.remove('dragging');
+  }
+
+  private onShowUsersChange(e: Event): void {
+    this.showUsers = (e.target as HTMLInputElement & { checked: boolean }).checked;
+    localStorage.setItem('scion-graph-show-users', String(this.showUsers));
+    this.didAutoFit = false;
+  }
+
+  // --- Hover lineage highlight ---------------------------------------------
+
+  /**
+   * Keys related to the hovered node, or null when nothing is hovered.
+   * Hovering an agent lights itself, its agent ancestors, its descendants,
+   * and its originating user. Hovering a user lights every agent whose
+   * lineage starts with that user. Everything else is dimmed.
+   */
+  private relatedIds(agents: Agent[]): Set<string> | null {
+    if (!this.hoverId) return null;
+
+    if (this.hoverId.startsWith('user:')) {
+      const uid = this.hoverId.slice('user:'.length);
+      const related = new Set<string>([this.hoverId]);
+      // Every descendant inherits the chain's first entry, so a flat filter
+      // is the full closure.
+      for (const a of agents) {
+        if (rootUserOf(a) === uid) related.add(a.id);
+      }
+      return related;
+    }
+
+    const byId = new Map(agents.map(a => [a.id, a]));
+    const hovered = byId.get(this.hoverId);
+    if (!hovered) return null;
+
+    const related = new Set<string>([this.hoverId]);
+    const rootUser = rootUserOf(hovered);
+    if (rootUser) related.add(userKey(rootUser));
+    // Walk up the ancestor chain.
+    let cur: Agent | undefined = hovered;
+    while (cur) {
+      const pid = parentIdOf(cur);
+      const parent = pid ? byId.get(pid) : undefined;
+      if (!parent || related.has(parent.id)) break;
+      related.add(parent.id);
+      cur = parent;
+    }
+    // Walk down: repeated sweeps until closure (forests are small).
+    let grew = true;
+    while (grew) {
+      grew = false;
+      for (const a of agents) {
+        if (related.has(a.id)) continue;
+        const pid = parentIdOf(a);
+        if (pid && related.has(pid)) {
+          related.add(a.id);
+          grew = true;
+        }
+      }
+    }
+    return related;
+  }
+
+  // --- Rendering ------------------------------------------------------------
+
+  /** Grid/list picks from the toggle navigate back to the agents list. */
+  private onViewChange(e: CustomEvent<{ view: ViewMode }>): void {
+    const mode = e.detail.view;
+    if (mode === 'graph') return;
+    localStorage.setItem('scion-view-agents', mode);
+    window.history.pushState({}, '', '/agents');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }
+
+  override render() {
+    return html`
+      <div class="header">
+        <h1>Agents</h1>
+        <div class="header-actions">
+          <sl-select
+            size="small"
+            placeholder="All projects"
+            clearable
+            value=${this.projectFilter}
+            @sl-change=${this.onProjectFilterChange}
+            style="min-width: 180px"
+          >
+            ${this.projects.map(p => html`<sl-option value=${p.id}>${p.name}</sl-option>`)}
+          </sl-select>
+          <sl-switch
+            size="small"
+            ?checked=${this.showUsers}
+            @sl-change=${this.onShowUsersChange}
+          >Show users</sl-switch>
+          <scion-view-toggle
+            view="graph"
+            @view-change=${this.onViewChange}
+          ></scion-view-toggle>
+        </div>
+      </div>
+      ${this.loading ? this.renderLoading() : this.error ? this.renderError() : this.renderGraph()}
+    `;
+  }
+
+  private renderLoading() {
+    return html`
+      <div class="loading-state">
+        <sl-spinner></sl-spinner>
+        <p>Loading agents...</p>
+      </div>
+    `;
+  }
+
+  private renderError() {
+    return html`
+      <div class="error-state">
+        <sl-icon name="exclamation-triangle"></sl-icon>
+        <p>${this.error}</p>
+        <sl-button size="small" @click=${() => this.loadAgents()}>Retry</sl-button>
+      </div>
+    `;
+  }
+
+  private renderGraph() {
+    const agents = this.visibleAgents;
+    if (agents.length === 0) {
+      return html`
+        <div class="empty-state">
+          <sl-icon name="diagram-3"></sl-icon>
+          <p>No agents to display${this.projectFilter ? ' in this project' : ''}.</p>
+        </div>
+      `;
+    }
+
+    const forest = buildLineageForest(agents);
+    const hiddenCounts = descendantCounts(forest);
+    pruneCollapsed(forest, this.collapsedIds);
+    const { nodes, edges, users, width, height } = this.showUsers
+      ? layoutForestWithUsers(forest)
+      : layoutForest(forest);
+    const related = this.relatedIds(agents);
+
+    // First render with content: center on the deep-linked agent if there is
+    // one (and it survived filtering), otherwise fit the forest.
+    if (!this.didAutoFit) {
+      this.didAutoFit = true;
+      const focus = this.focusId ? nodes.find(n => n.agent.id === this.focusId) : undefined;
+      requestAnimationFrame(() => (focus ? this.centerOn(focus) : this.fitToView(width, height)));
+    }
+
+    return html`
+      <div
+        class="canvas"
+        @pointerdown=${this.onPointerDown}
+        @pointermove=${this.onPointerMove}
+        @pointerup=${this.onPointerUp}
+        @pointercancel=${this.onPointerUp}
+        @pointerleave=${() => (this.hoverId = null)}
+      >
+        <div class="stage" style="transform: translate(${this.panX}px, ${this.panY}px) scale(${this.scale})">
+          <svg width=${width} height=${height} aria-hidden="true">
+            ${this.renderEdgeMarkers()}
+            ${edges.map(e => this.renderEdge(e, related))}
+          </svg>
+          ${users.map(u => this.renderUserNode(u, agents, edges, related))}
+          ${nodes.map(n => this.renderNode(n, related, hiddenCounts))}
+        </div>
+        <div class="zoom-controls">
+          <sl-button size="small" @click=${() => this.zoomButtons(1.25)} title="Zoom in">+</sl-button>
+          <sl-button size="small" @click=${() => this.zoomButtons(1 / 1.25)} title="Zoom out">−</sl-button>
+          <sl-button size="small" @click=${() => this.fitToView(width, height)} title="Fit to view">Fit</sl-button>
+        </div>
+      </div>
+    `;
+  }
+
+  /**
+   * Arrowhead markers for the spawn direction (parent → child). One marker
+   * per edge style since marker fills don't inherit the path's stroke.
+   * Rendered with svg`` — see the namespace note on renderEdge.
+   */
+  private renderEdgeMarkers() {
+    const marker = (id: string, color: string) => svg`
+      <marker
+        id=${id}
+        viewBox="0 0 8 8"
+        markerWidth="7"
+        markerHeight="7"
+        refX="6.5"
+        refY="4"
+        orient="auto"
+        markerUnits="userSpaceOnUse"
+      >
+        <path d="M 0 0.5 L 7 4 L 0 7.5 Z" fill=${color} />
+      </marker>
+    `;
+    return svg`<defs>
+      ${marker('arrow-neutral', 'var(--sl-color-neutral-400)')}
+      ${marker('arrow-lit', 'var(--sl-color-primary-600)')}
+    </defs>`;
+  }
+
+  private renderEdge(e: PositionedEdge, related: Set<string> | null) {
+    const lit = related !== null && related.has(e.parentId) && related.has(e.childId);
+    const dim = related !== null && !lit;
+    const midY = (e.y1 + e.y2) / 2;
+    const yEnd = e.y2 - 2; // leave room so the arrowhead tip meets the node edge
+    // NOTE: svg`` (not html``) — nested fragments inside <svg> must be
+    // created in the SVG namespace or the browser renders nothing.
+    return svg`<path
+      class="edge ${lit ? 'lit' : ''} ${dim ? 'dim' : ''}"
+      d="M ${e.x1} ${e.y1} C ${e.x1} ${midY}, ${e.x2} ${midY}, ${e.x2} ${yEnd}"
+    />`;
+  }
+
+  private toggleCollapse(agentId: string, e: Event): void {
+    // The chip lives inside the node's <a>: keep the click from navigating.
+    e.preventDefault();
+    e.stopPropagation();
+    const next = new Set(this.collapsedIds);
+    if (!next.delete(agentId)) next.add(agentId);
+    this.collapsedIds = next;
+  }
+
+  private renderNode(n: PositionedNode, related: Set<string> | null, hiddenCounts: Map<string, number>) {
+    const agent = n.agent;
+    const status = getAgentDisplayStatus(agent);
+    const color = VARIANT_COLOR[getStateDisplay(status).variant];
+    const creator = agent.appliedConfig?.creatorName || agent.createdBy || '';
+    const parentId = parentIdOf(agent);
+    const isRoot = !parentId || !this.visibleAgents.some(a => a.id === parentId);
+    const dim = related !== null && !related.has(agent.id);
+    const descendants = hiddenCounts.get(agent.id) ?? 0;
+    const collapsed = this.collapsedIds.has(agent.id);
+    return html`
+      <a
+        class="node ${dim ? 'dim' : ''} ${agent.id === this.focusId ? 'focus' : ''}"
+        href="/agents/${agent.id}"
+        style="left: ${n.px}px; top: ${n.py}px; border-left-color: ${color}"
+        title=${`${agent.name}${agent.template ? ` — ${agent.template}` : ''}${isRoot && creator ? `\ncreated by ${creator}` : ''}`}
+        @pointerenter=${() => (this.hoverId = agent.id)}
+        @pointerleave=${() => (this.hoverId = null)}
+      >
+        <span class="name">${agent.name}</span>
+        <scion-status-badge
+          status=${status as StatusType}
+          label=${status}
+          size="small"
+        ></scion-status-badge>
+        ${agent.template ? html`<span class="meta">${agent.template}</span>` : nothing}
+        ${descendants > 0 ? html`
+          <button
+            class="collapse-chip"
+            title=${collapsed ? `Expand ${descendants} hidden agent${descendants === 1 ? '' : 's'}` : 'Collapse subtree'}
+            @click=${(e: Event) => this.toggleCollapse(agent.id, e)}
+          >${collapsed ? `+${descendants}` : '−'}</button>
+        ` : nothing}
+      </a>
+    `;
+  }
+
+  private renderUserNode(
+    u: PositionedUser,
+    agents: Agent[],
+    edges: PositionedEdge[],
+    related: Set<string> | null
+  ) {
+    const key = userKey(u.id);
+    // Display name: only agents the user created DIRECTLY (ancestry is just
+    // [userID]) carry the human's name — on spawned descendants creatorName
+    // is the spawning agent instead.
+    let label = '';
+    for (const a of agents) {
+      if (a.ancestry?.length !== 1 || a.ancestry[0] !== u.id) continue;
+      label = a.appliedConfig?.creatorName || a.createdBy || '';
+      if (label) break;
+    }
+    if (!label) label = u.id.slice(0, 8);
+    const started = edges.filter(e => e.parentId === key).length;
+    const dim = related !== null && !related.has(key);
+    return html`
+      <div
+        class="node user ${dim ? 'dim' : ''}"
+        style="left: ${u.px}px; top: ${u.py}px"
+        title=${`${label}\nstarted ${started} agent${started === 1 ? '' : 's'}`}
+        @pointerenter=${() => (this.hoverId = key)}
+        @pointerleave=${() => (this.hoverId = null)}
+      >
+        <span class="name"><sl-icon name="person-circle"></sl-icon> ${label}</span>
+        <span class="meta">user</span>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-page-agent-graph': AgentGraphPage;
+  }
+}

--- a/web/src/components/pages/agents.ts
+++ b/web/src/components/pages/agents.ts
@@ -569,6 +569,8 @@ export class ScionPageAgents extends LitElement {
   }
 
   private onViewChange(e: CustomEvent<{ view: ViewMode }>): void {
+    // 'graph' is a link segment handled by the router, never an event here.
+    if (e.detail.view === 'graph') return;
     this.viewMode = e.detail.view;
   }
 
@@ -693,6 +695,7 @@ export class ScionPageAgents extends LitElement {
           <scion-view-toggle
             .view=${this.viewMode}
             storageKey="scion-view-agents"
+            graphHref="/agents/graph"
             @view-change=${this.onViewChange}
           ></scion-view-toggle>
           ${can(this.scopeCapabilities, 'stop_all') && this.hasRunningAgents() ? html`

--- a/web/src/components/shared/view-toggle.ts
+++ b/web/src/components/shared/view-toggle.ts
@@ -17,14 +17,15 @@
 /**
  * View Toggle Component
  *
- * A compact two-button toggle for switching between grid (card) and list (table) views.
- * Persists the selected view in localStorage and dispatches a `view-change` CustomEvent.
+ * A compact toggle for switching between grid (card) and list (table) views,
+ * with an optional third segment linking to a graph view. Persists the
+ * selected view in localStorage and dispatches a `view-change` CustomEvent.
  */
 
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-export type ViewMode = 'grid' | 'list';
+export type ViewMode = 'grid' | 'list' | 'graph';
 
 @customElement('scion-view-toggle')
 export class ScionViewToggle extends LitElement {
@@ -40,6 +41,14 @@ export class ScionViewToggle extends LitElement {
   @property({ type: String })
   storageKey = '';
 
+  /**
+   * When set, shows a third "graph" segment rendered as a link to this URL
+   * (the SPA router intercepts it). The graph segment also appears, as a
+   * plain active button, when the current view is 'graph'.
+   */
+  @property({ type: String })
+  graphHref = '';
+
   static override styles = css`
     :host {
       display: inline-flex;
@@ -52,7 +61,8 @@ export class ScionViewToggle extends LitElement {
       overflow: hidden;
     }
 
-    button {
+    button,
+    a {
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -63,23 +73,28 @@ export class ScionViewToggle extends LitElement {
       color: var(--scion-text-muted, #64748b);
       cursor: pointer;
       padding: 0;
+      text-decoration: none;
       transition: all 150ms ease;
     }
 
-    button:first-child {
+    button:not(:last-child),
+    a:not(:last-child) {
       border-right: 1px solid var(--scion-border, #e2e8f0);
     }
 
-    button:hover:not(.active) {
+    button:hover:not(.active),
+    a:hover:not(.active) {
       background: var(--scion-bg-subtle, #f1f5f9);
     }
 
-    button.active {
+    button.active,
+    a.active {
       background: var(--scion-primary, #3b82f6);
       color: white;
     }
 
-    button sl-icon {
+    button sl-icon,
+    a sl-icon {
       font-size: 0.875rem;
     }
   `;
@@ -97,7 +112,8 @@ export class ScionViewToggle extends LitElement {
   private setView(mode: ViewMode): void {
     if (this.view === mode) return;
     this.view = mode;
-    if (this.storageKey) {
+    // 'graph' is a navigation target, not a persisted list rendering mode.
+    if (this.storageKey && mode !== 'graph') {
       localStorage.setItem(this.storageKey, mode);
     }
     this.dispatchEvent(
@@ -107,6 +123,28 @@ export class ScionViewToggle extends LitElement {
         composed: true,
       })
     );
+  }
+
+  private renderGraphSegment() {
+    if (this.graphHref) {
+      return html`
+        <a
+          class=${this.view === 'graph' ? 'active' : ''}
+          href=${this.graphHref}
+          title="Graph view"
+        >
+          <sl-icon name="diagram-3"></sl-icon>
+        </a>
+      `;
+    }
+    if (this.view === 'graph') {
+      return html`
+        <button class="active" title="Graph view">
+          <sl-icon name="diagram-3"></sl-icon>
+        </button>
+      `;
+    }
+    return nothing;
   }
 
   override render() {
@@ -126,6 +164,7 @@ export class ScionViewToggle extends LitElement {
         >
           <sl-icon name="list-ul"></sl-icon>
         </button>
+        ${this.renderGraphSegment()}
       </div>
     `;
   }

--- a/web/src/shared/lineage.test.ts
+++ b/web/src/shared/lineage.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildLineageForest,
+  descendantCounts,
+  layoutForest,
+  layoutForestWithUsers,
+  parentIdOf,
+  pruneCollapsed,
+  rootUserOf,
+  userKey,
+  NODE_W,
+  NODE_H,
+  GAP_X,
+  GAP_Y,
+  PAD,
+} from './lineage.js';
+import type { Agent } from './types.js';
+
+/** Minimal agent factory for lineage tests */
+function agent(id: string, name: string, ancestry?: string[]): Agent {
+  return { id, name, ancestry, projectId: 'p1', template: 't', phase: 'running' } as Agent;
+}
+
+describe('parentIdOf', () => {
+  it('returns the last ancestry entry', () => {
+    expect(parentIdOf(agent('a', 'a', ['user-1', 'root-agent']))).toBe('root-agent');
+  });
+
+  it('returns undefined for empty or missing ancestry', () => {
+    expect(parentIdOf(agent('a', 'a', []))).toBeUndefined();
+    expect(parentIdOf(agent('a', 'a'))).toBeUndefined();
+  });
+});
+
+describe('buildLineageForest', () => {
+  it('builds a parent/child tree from ancestry chains', () => {
+    const coordinator = agent('c1', 'coordinator', ['user-1']);
+    const editor = agent('e1', 'editor', ['user-1', 'c1']);
+    const techlead = agent('t1', 'techlead', ['user-1', 'c1']);
+    const helper = agent('h1', 'helper', ['user-1', 'c1', 't1']);
+
+    const roots = buildLineageForest([coordinator, editor, techlead, helper]);
+
+    expect(roots).toHaveLength(1);
+    expect(roots[0].agent.id).toBe('c1');
+    expect(roots[0].children.map(c => c.agent.id).sort()).toEqual(['e1', 't1']);
+    const tl = roots[0].children.find(c => c.agent.id === 't1')!;
+    expect(tl.children.map(c => c.agent.id)).toEqual(['h1']);
+    expect(tl.children[0].depth).toBe(2);
+  });
+
+  it('treats user-created agents as roots', () => {
+    const a = agent('a1', 'alpha', ['user-1']);
+    const b = agent('b1', 'beta', ['user-2']);
+    const roots = buildLineageForest([a, b]);
+    expect(roots.map(r => r.agent.id).sort()).toEqual(['a1', 'b1']);
+    expect(roots.every(r => r.depth === 0)).toBe(true);
+  });
+
+  it('promotes agents whose parent is outside the set to roots', () => {
+    const orphan = agent('o1', 'orphan', ['user-1', 'deleted-agent']);
+    const roots = buildLineageForest([orphan]);
+    expect(roots).toHaveLength(1);
+    expect(roots[0].agent.id).toBe('o1');
+  });
+
+  it('handles cyclic ancestry without hanging', () => {
+    // a claims parent b; b claims parent a — malformed but must not loop.
+    const a = agent('a1', 'alpha', ['user-1', 'b1']);
+    const b = agent('b1', 'beta', ['user-1', 'a1']);
+    const roots = buildLineageForest([a, b]);
+    const layout = layoutForest(roots);
+    expect(layout.nodes).toHaveLength(2);
+    const ids = layout.nodes.map(n => n.agent.id).sort();
+    expect(ids).toEqual(['a1', 'b1']);
+  });
+
+  it('ignores self-referential ancestry', () => {
+    const selfRef = agent('s1', 'self', ['user-1', 's1']);
+    const roots = buildLineageForest([selfRef]);
+    expect(roots).toHaveLength(1);
+    expect(roots[0].children).toHaveLength(0);
+  });
+});
+
+describe('layoutForest', () => {
+  it('positions leaves in consecutive slots and centers parents', () => {
+    const parent = agent('p1', 'parent', ['user-1']);
+    const left = agent('l1', 'a-left', ['user-1', 'p1']);
+    const right = agent('r1', 'b-right', ['user-1', 'p1']);
+
+    const { nodes, edges } = layoutForest(buildLineageForest([parent, left, right]));
+
+    const byId = new Map(nodes.map(n => [n.agent.id, n]));
+    const leftX = byId.get('l1')!.px;
+    const rightX = byId.get('r1')!.px;
+    const parentX = byId.get('p1')!.px;
+
+    expect(leftX).toBe(PAD);
+    expect(rightX).toBe(PAD + NODE_W + GAP_X);
+    expect(parentX).toBe((leftX + rightX) / 2);
+    expect(edges).toHaveLength(2);
+    // Edges run from the parent's bottom-center to each child's top-center.
+    for (const e of edges) {
+      expect(e.x1).toBe(parentX + NODE_W / 2);
+      expect(e.y2).toBeGreaterThan(e.y1);
+    }
+  });
+
+  it('reports canvas size that bounds all nodes', () => {
+    const a = agent('a1', 'alpha', ['user-1']);
+    const b = agent('b1', 'beta', ['user-1']);
+    const { nodes, width, height } = layoutForest(buildLineageForest([a, b]));
+    for (const n of nodes) {
+      expect(n.px + NODE_W).toBeLessThanOrEqual(width);
+      expect(n.py).toBeLessThan(height);
+    }
+  });
+});
+
+describe('descendantCounts', () => {
+  it('counts transitive descendants per node', () => {
+    const root = agent('r1', 'root', ['user-1']);
+    const mid = agent('m1', 'mid', ['user-1', 'r1']);
+    const leafA = agent('la', 'leaf-a', ['user-1', 'r1', 'm1']);
+    const leafB = agent('lb', 'leaf-b', ['user-1', 'r1', 'm1']);
+    const counts = descendantCounts(buildLineageForest([root, mid, leafA, leafB]));
+    expect(counts.get('r1')).toBe(3);
+    expect(counts.get('m1')).toBe(2);
+    expect(counts.get('la')).toBe(0);
+  });
+});
+
+describe('pruneCollapsed', () => {
+  it('hides the subtree of a collapsed node but keeps siblings', () => {
+    const root = agent('r1', 'root', ['user-1']);
+    const left = agent('l1', 'a-left', ['user-1', 'r1']);
+    const leftKid = agent('lk', 'left-kid', ['user-1', 'r1', 'l1']);
+    const right = agent('r2', 'b-right', ['user-1', 'r1']);
+    const forest = pruneCollapsed(
+      buildLineageForest([root, left, leftKid, right]),
+      new Set(['l1'])
+    );
+    const { nodes, edges } = layoutForest(forest);
+    const ids = nodes.map(n => n.agent.id).sort();
+    expect(ids).toEqual(['l1', 'r1', 'r2']);
+    expect(edges.some(e => e.childId === 'lk')).toBe(false);
+    expect(edges.some(e => e.childId === 'r2')).toBe(true);
+  });
+
+  it('collapsing the root leaves only the root visible', () => {
+    const root = agent('r1', 'root', ['user-1']);
+    const kid = agent('k1', 'kid', ['user-1', 'r1']);
+    const forest = pruneCollapsed(buildLineageForest([root, kid]), new Set(['r1']));
+    const { nodes, edges } = layoutForest(forest);
+    expect(nodes.map(n => n.agent.id)).toEqual(['r1']);
+    expect(edges).toHaveLength(0);
+  });
+});
+
+describe('rootUserOf', () => {
+  it('returns the first ancestry entry for any depth', () => {
+    expect(rootUserOf(agent('a', 'a', ['user-1']))).toBe('user-1');
+    expect(rootUserOf(agent('b', 'b', ['user-1', 'c1', 'p1']))).toBe('user-1');
+    expect(rootUserOf(agent('c', 'c'))).toBeUndefined();
+  });
+});
+
+describe('layoutForestWithUsers', () => {
+  it('adds a user row above the trees and shifts agents down', () => {
+    const a = agent('a1', 'alpha', ['user-1']);
+    const child = agent('c1', 'child', ['user-1', 'a1']);
+    const { nodes, users } = layoutForestWithUsers(buildLineageForest([a, child]));
+
+    expect(users).toHaveLength(1);
+    expect(users[0].id).toBe('user-1');
+    expect(users[0].py).toBe(PAD);
+    const byId = new Map(nodes.map(n => [n.agent.id, n]));
+    expect(byId.get('a1')!.py).toBe(PAD + NODE_H + GAP_Y);
+    expect(byId.get('c1')!.py).toBe(PAD + 2 * (NODE_H + GAP_Y));
+  });
+
+  it('groups roots from the same user under one centered user node', () => {
+    const a = agent('a1', 'alpha', ['user-1']);
+    const b = agent('b1', 'beta', ['user-1']);
+    const c = agent('c1', 'gamma', ['user-2']);
+    const { nodes, users, edges } = layoutForestWithUsers(buildLineageForest([a, b, c]));
+
+    expect(users.map(u => u.id).sort()).toEqual(['user-1', 'user-2']);
+    const u1 = users.find(u => u.id === 'user-1')!;
+    const byId = new Map(nodes.map(n => [n.agent.id, n]));
+    expect(u1.px).toBe((byId.get('a1')!.px + byId.get('b1')!.px) / 2);
+
+    const u1Edges = edges.filter(e => e.parentId === userKey('user-1'));
+    expect(u1Edges.map(e => e.childId).sort()).toEqual(['a1', 'b1']);
+    const u2Edges = edges.filter(e => e.parentId === userKey('user-2'));
+    expect(u2Edges.map(e => e.childId)).toEqual(['c1']);
+  });
+
+  it('keeps agent-to-agent edges alongside user edges', () => {
+    const root = agent('r1', 'root', ['user-1']);
+    const child = agent('k1', 'kid', ['user-1', 'r1']);
+    const { edges } = layoutForestWithUsers(buildLineageForest([root, child]));
+    expect(edges.some(e => e.parentId === 'r1' && e.childId === 'k1')).toBe(true);
+    expect(edges.some(e => e.parentId === userKey('user-1') && e.childId === 'r1')).toBe(true);
+  });
+
+  it('leaves roots without ancestry parentless but positioned', () => {
+    const known = agent('a1', 'alpha', ['user-1']);
+    const unknown = agent('u1', 'mystery');
+    const { nodes, users, edges } = layoutForestWithUsers(buildLineageForest([known, unknown]));
+    expect(users.map(u => u.id)).toEqual(['user-1']);
+    expect(nodes.map(n => n.agent.id).sort()).toEqual(['a1', 'u1']);
+    expect(edges.filter(e => e.childId === 'u1')).toHaveLength(0);
+  });
+});

--- a/web/src/shared/lineage.ts
+++ b/web/src/shared/lineage.ts
@@ -1,0 +1,297 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Pure lineage-forest construction and layout for the agent graph view.
+ * Kept free of Lit/DOM dependencies so it can be unit-tested directly.
+ */
+
+import type { Agent } from './types.js';
+
+/** A node in the lineage forest (each agent has at most one parent). */
+export interface LineageNode {
+  agent: Agent;
+  children: LineageNode[];
+  /** Horizontal position in leaf units (assigned by layout) */
+  x: number;
+  /** Tree depth: 0 for roots */
+  depth: number;
+}
+
+export interface PositionedNode {
+  agent: Agent;
+  /** Pixel coordinates of the node's top-left corner */
+  px: number;
+  py: number;
+}
+
+export interface PositionedEdge {
+  /** Pixel coordinates: parent bottom-center -> child top-center */
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  parentId: string;
+  childId: string;
+}
+
+/** A user (human) node shown above the trees they originated. */
+export interface PositionedUser {
+  /** User ID: the first ancestry entry shared by every agent in the tree */
+  id: string;
+  px: number;
+  py: number;
+}
+
+export interface ForestLayout {
+  nodes: PositionedNode[];
+  edges: PositionedEdge[];
+  /** Present only in layouts produced by layoutForestWithUsers */
+  users: PositionedUser[];
+  width: number;
+  height: number;
+}
+
+export const NODE_W = 180;
+export const NODE_H = 76;
+export const GAP_X = 24;
+export const GAP_Y = 48;
+export const PAD = 24;
+
+/** Edge/hover key for a user node, distinct from any agent ID. */
+export function userKey(userId: string): string {
+  return `user:${userId}`;
+}
+
+/**
+ * Direct parent ID from the agent's ancestry chain ([root, ..., parent]).
+ * The parent may be another agent or a user; callers decide by lookup.
+ */
+export function parentIdOf(agent: Agent): string | undefined {
+  const chain = agent.ancestry;
+  return chain && chain.length > 0 ? chain[chain.length - 1] : undefined;
+}
+
+/**
+ * The user (human) at the origin of the agent's lineage chain. Ancestry
+ * always starts with the user who created the root agent, so this is stable
+ * across the whole tree.
+ */
+export function rootUserOf(agent: Agent): string | undefined {
+  const chain = agent.ancestry;
+  return chain && chain.length > 0 ? chain[0] : undefined;
+}
+
+/**
+ * Builds the lineage forest. An agent is attached under its parent only when
+ * the parent is another agent in the given set; otherwise it becomes a root
+ * (its parent is a user, filtered out, or deleted). A visited guard keeps
+ * malformed cyclic ancestry from hanging the layout: any agent not reachable
+ * from a root is promoted to a root.
+ */
+export function buildLineageForest(agents: Agent[]): LineageNode[] {
+  const byId = new Map<string, LineageNode>();
+  for (const agent of agents) {
+    byId.set(agent.id, { agent, children: [], x: 0, depth: 0 });
+  }
+
+  const roots: LineageNode[] = [];
+  for (const node of byId.values()) {
+    const parentId = parentIdOf(node.agent);
+    const parent = parentId ? byId.get(parentId) : undefined;
+    if (parent && parent !== node) {
+      parent.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  const byName = (a: LineageNode, b: LineageNode) => a.agent.name.localeCompare(b.agent.name);
+  for (const node of byId.values()) {
+    node.children.sort(byName);
+  }
+  roots.sort(byName);
+
+  // Walk the forest, assigning depths. Dropping already-visited children as
+  // we go turns any malformed cyclic ancestry into plain tree edges instead
+  // of infinite recursion; nodes unreachable from a root (cycle members) are
+  // then promoted to roots.
+  const visited = new Set<string>();
+  const visit = (node: LineageNode, depth: number) => {
+    if (visited.has(node.agent.id)) return;
+    visited.add(node.agent.id);
+    node.depth = depth;
+    node.children = node.children.filter(c => !visited.has(c.agent.id));
+    for (const child of node.children) visit(child, depth + 1);
+  };
+  for (const root of roots) visit(root, 0);
+  for (const node of byId.values()) {
+    if (!visited.has(node.agent.id)) {
+      roots.push(node);
+      visit(node, 0);
+    }
+  }
+
+  return roots;
+}
+
+/**
+ * Number of transitive descendants for every node in the forest, keyed by
+ * agent ID. Compute this BEFORE pruneCollapsed — pruning removes the very
+ * subtrees being counted.
+ */
+export function descendantCounts(roots: LineageNode[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  const count = (node: LineageNode): number => {
+    let total = 0;
+    for (const child of node.children) {
+      total += 1 + count(child);
+    }
+    counts.set(node.agent.id, total);
+    return total;
+  };
+  for (const root of roots) count(root);
+  return counts;
+}
+
+/**
+ * Drops the children of every collapsed node so the layout skips their
+ * subtrees. Mutates the given forest (buildLineageForest returns a fresh
+ * one per call) and returns it for chaining.
+ */
+export function pruneCollapsed(roots: LineageNode[], collapsed: ReadonlySet<string>): LineageNode[] {
+  const walk = (node: LineageNode): void => {
+    if (collapsed.has(node.agent.id)) {
+      node.children = [];
+      return;
+    }
+    for (const child of node.children) walk(child);
+  };
+  for (const root of roots) walk(root);
+  return roots;
+}
+
+/**
+ * Tidy-ish tree layout: leaves take consecutive horizontal slots, parents
+ * center over their children. Returns positioned nodes/edges plus the canvas
+ * size in pixels.
+ */
+export function layoutForest(roots: LineageNode[]): ForestLayout {
+  let nextLeaf = 0;
+  let maxDepth = 0;
+
+  const assign = (node: LineageNode) => {
+    maxDepth = Math.max(maxDepth, node.depth);
+    if (node.children.length === 0) {
+      node.x = nextLeaf++;
+      return;
+    }
+    for (const child of node.children) assign(child);
+    const first = node.children[0].x;
+    const last = node.children[node.children.length - 1].x;
+    node.x = (first + last) / 2;
+  };
+  for (const root of roots) assign(root);
+
+  const px = (n: LineageNode) => PAD + n.x * (NODE_W + GAP_X);
+  const py = (n: LineageNode) => PAD + n.depth * (NODE_H + GAP_Y);
+
+  const nodes: PositionedNode[] = [];
+  const edges: PositionedEdge[] = [];
+  const walk = (node: LineageNode) => {
+    nodes.push({ agent: node.agent, px: px(node), py: py(node) });
+    for (const child of node.children) {
+      edges.push({
+        x1: px(node) + NODE_W / 2,
+        y1: py(node) + NODE_H,
+        x2: px(child) + NODE_W / 2,
+        y2: py(child),
+        parentId: node.agent.id,
+        childId: child.agent.id,
+      });
+      walk(child);
+    }
+  };
+  for (const root of roots) walk(root);
+
+  return {
+    nodes,
+    edges,
+    users: [],
+    width: PAD * 2 + Math.max(nextLeaf, 1) * (NODE_W + GAP_X) - GAP_X,
+    height: PAD * 2 + (maxDepth + 1) * (NODE_H + GAP_Y) - GAP_Y,
+  };
+}
+
+/**
+ * Like layoutForest, but inserts a row of user (human) nodes above the trees,
+ * grouping each root agent under the user at the origin of its lineage chain
+ * (ancestry[0]). Roots sharing a user are laid out adjacently under a single
+ * user node with an edge to each. Roots with no recorded ancestry keep their
+ * position but get no user parent.
+ */
+export function layoutForestWithUsers(roots: LineageNode[]): ForestLayout {
+  // Group roots by originating user, preserving the sorted root order.
+  const groups = new Map<string, LineageNode[]>();
+  const ungrouped: LineageNode[] = [];
+  for (const root of roots) {
+    const uid = rootUserOf(root.agent);
+    if (!uid) {
+      ungrouped.push(root);
+      continue;
+    }
+    const group = groups.get(uid);
+    if (group) {
+      group.push(root);
+    } else {
+      groups.set(uid, [root]);
+    }
+  }
+  const ordered = [...groups.values()].flat().concat(ungrouped);
+
+  // Shift every agent down one row to make room for the user row. Children
+  // were already de-cycled by buildLineageForest, so plain recursion is safe.
+  const bump = (node: LineageNode, depth: number): void => {
+    node.depth = depth;
+    for (const child of node.children) bump(child, depth + 1);
+  };
+  for (const root of ordered) bump(root, 1);
+
+  const base = layoutForest(ordered);
+  const nodeById = new Map(base.nodes.map(n => [n.agent.id, n]));
+
+  const users: PositionedUser[] = [];
+  const edges = [...base.edges];
+  for (const [uid, groupRoots] of groups) {
+    const xs = groupRoots.map(r => nodeById.get(r.agent.id)!.px);
+    const px = (Math.min(...xs) + Math.max(...xs)) / 2;
+    const py = PAD;
+    users.push({ id: uid, px, py });
+    for (const root of groupRoots) {
+      const target = nodeById.get(root.agent.id)!;
+      edges.push({
+        x1: px + NODE_W / 2,
+        y1: py + NODE_H,
+        x2: target.px + NODE_W / 2,
+        y2: target.py,
+        parentId: userKey(uid),
+        childId: root.agent.id,
+      });
+    }
+  }
+
+  return { ...base, edges, users };
+}

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -429,6 +429,10 @@ export interface Agent {
   createdBy?: string;
   appliedConfig?: AgentAppliedConfig;
 
+  // Ordered ancestor chain [root, ..., parent]; last entry is the direct
+  // parent (user or spawning agent). Drives the lineage graph view.
+  ancestry?: string[];
+
   // Status tab fields (limits tracking)
   currentTurns?: number;
   currentModelCalls?: number;


### PR DESCRIPTION
Implements ptone/scion#465 — a built-in graph view of agent lineage in the web UI.

## What

- New `/agents/graph` page rendering all agents as parent/child trees derived from each agent's persisted `ancestry` chain (`[root user, ..., parent]`). Agents whose parent is a user (or is filtered out / deleted) become roots.
- The graph is the **third segment of the existing grid/list view toggle** on the Agents page — not a separate button.
- Node cards reuse the shared `scion-status-badge`; edges are static SVG curves with **spawn-direction arrowheads** (no animation).
- **Hover** highlights the hovered agent's full lineage (ancestors + descendants + originating user) and dims the rest.
- **Pan / zoom / fit-to-view**; auto-fits on load.
- **Collapse/expand subtrees** via a chip on the parent node's bottom edge (`−` / `+N`).
- Optional **"Show users" toggle** adds a row of human nodes above the trees, grouped by `ancestry[0]` (off by default, persisted in localStorage).
- **Project filter** synced to `?project=`.
- **`?focus=<agent-id>` deep link** centers the viewport on one agent and rings it; the agent detail page gets a **"See this agent in graph"** button that links there.
- **Live updates** over the existing `agents-updated` SSE stream — new agents attach to their parent as they spawn. Hub change: `AgentCreatedEvent` now carries `ancestry` so a freshly spawned agent doesn't render as a root until the next full fetch.

## Design notes

- **Zero new dependencies.** Forest building + tidy-tree layout live in a pure, DOM-free module (`web/src/shared/lineage.ts`) with 17 unit tests. Nodes are plain HTML anchors (SPA routing and browser a11y work as-is); only edges are SVG.
- Clicking anywhere on a node card opens the agent detail page; the agent name underlines on hover to make that visible (same affordance as the list view).
- Malformed cyclic ancestry is de-cycled during traversal instead of hanging the layout; unreachable cycle members are promoted to roots.
- No new Shoelace icons beyond ones already in `USED_ICONS`.

## Testing

- `npm test`: 49/49 (17 lineage-specific), `npm run typecheck` + production build clean.
- `go build ./...`, `go vet ./pkg/hub/...` clean. (`go test ./pkg/hub` has pre-existing failures reproducible on `main` — unrelated to this change.)
- Exercised live against a workstation hub with a 13-agent, 3-generation fleet (coordinator → 3 coaches → 3 workers each), spawned via the in-container `scion` CLI so ancestry chains are real.

## Demo

Demo video attached in the first comment below.


https://github.com/user-attachments/assets/097ed033-a987-4e90-9267-7b52344f226f

