### PR TITLE
feat(whoami): enhance with typed struct, env fields, and --full Hub enrichment (#277)

### DIFF
--- a/.design/whoami-enhance.md
+++ b/.design/whoami-enhance.md
@@ -1,0 +1,259 @@
+# Design: Enhance `scion whoami` — Issue #277
+
+**Author:** whoami-architect  
+**Date:** 2026-07-23  
+**Status:** Final  
+**Issue:** #277 — Enhance `scion whoami` to return richer agent identity information
+
+---
+
+## Problem & Goals
+
+Agents running inside scion containers currently have minimal self-awareness via `scion whoami`: only slug, name, and ID. Agents and scripts that need to know their project, harness, creator, model, or Hub URL must read env vars directly — knowledge that is scattered, undocumented, and fragile.
+
+**Goals:**
+
+1. Make `scion whoami --format json` the canonical, documented way for agents to discover their own identity and context.
+2. Add all available env-var-based fields (Tier 1) with zero latency cost.
+3. Add Hub API-sourced fields (Tier 2) behind an opt-in `--full` flag for agents that need phase, activity, labels, annotations, and ancestry.
+4. Construct a self-link Hub URL from existing env vars (Tier 1 — no API call needed).
+5. Maintain strict backward compatibility: existing 3 fields (`slug`, `name`, `id`) unchanged in position, type, and JSON key.
+6. Never expose secrets (`SCION_AUTH_TOKEN`, `SCION_DEV_TOKEN`, `SCION_TRANSPORT_TOKEN`, etc.).
+
+## Non-Goals
+
+- **Agent role/capabilities modeling.** Role is not modeled on the agent object. We expose `template` (from `SCION_TEMPLATE_NAME`) as the current best proxy. Proper role modeling is deferred to a separate issue.
+- **Tier 3 infrastructure.** No new fields on `store.Agent` or `api.AgentInfo`.
+- **Changing the plain-text default output.** `scion whoami` (no flags) continues to print just the slug, matching existing behavior. New fields appear only in `--format json` and in a richer plain-text block via `--full`.
+- **Full env var dump.** We use an explicit allowlist, never a glob over `SCION_*`.
+
+---
+
+## Proposed Design
+
+### 1. Typed `WhoamiResult` Struct
+
+Replace the inline `map[string]string` with a typed struct in `cmd/whoami.go`:
+
+```go
+// WhoamiResult is the JSON output shape for `scion whoami --format json`.
+type WhoamiResult struct {
+    // --- Tier 1: env-var fields (always populated, zero latency) ---
+    Slug        string `json:"slug"`
+    Name        string `json:"name"`
+    ID          string `json:"id"`
+    Project     string `json:"project,omitempty"`
+    ProjectID   string `json:"projectId,omitempty"`
+    Template    string `json:"template,omitempty"`
+    Harness     string `json:"harness,omitempty"`
+    Model       string `json:"model,omitempty"`
+    Creator     string `json:"creator,omitempty"`
+    BrokerName  string `json:"brokerName,omitempty"`
+    BrokerID    string `json:"brokerId,omitempty"`
+    CLIMode     string `json:"cliMode,omitempty"`
+    HubEndpoint string `json:"hubEndpoint,omitempty"`
+    HubURL      string `json:"hubUrl,omitempty"`      // constructed: {hubEndpoint}/agents/{id}
+
+    // --- Tier 2: Hub API fields (only with --full, omitted otherwise) ---
+    Phase       string            `json:"phase,omitempty"`
+    Activity    string            `json:"activity,omitempty"`
+    Labels      map[string]string `json:"labels,omitempty"`
+    Annotations map[string]string `json:"annotations,omitempty"`
+    Ancestry    []string          `json:"ancestry,omitempty"`
+    TaskSummary string            `json:"taskSummary,omitempty"`
+}
+```
+
+**Key decisions:**
+
+- Top 3 fields (`slug`, `name`, `id`) remain first and non-`omitempty` for backward compatibility. The JSON test currently unmarshals into `map[string]string` and checks these three keys — they must not move or change type.
+- All new Tier 1 fields use `omitempty` so that agents running outside a fully-provisioned environment get a clean, minimal response.
+- Tier 2 fields are structurally present on the struct but only populated when `--full` is passed. With `omitempty`, they are absent from JSON output in the default path.
+- `hubUrl` is constructed client-side: `fmt.Sprintf("%s/agents/%s", hubEndpoint, id)`. No API call needed. Only emitted when both `hubEndpoint` and `id` are non-empty.
+
+### 2. Env Var Allowlist (Tier 1)
+
+Explicit mapping from env var to struct field. This is the **security boundary** — only these vars are read:
+
+| Env Var | Struct Field | Notes |
+|---|---|---|
+| `SCION_AGENT_SLUG` | `Slug` | Already used |
+| `SCION_AGENT_NAME` | `Name` | Already used |
+| `SCION_AGENT_ID` | `ID` | Already used |
+| `SCION_PROJECT` | `Project` | |
+| `SCION_PROJECT_ID` | `ProjectID` | |
+| `SCION_TEMPLATE_NAME` | `Template` | Role proxy |
+| `SCION_HARNESS` | `Harness` | |
+| `SCION_MODEL` | `Model` | |
+| `SCION_CREATOR` | `Creator` | |
+| `SCION_BROKER_NAME` | `BrokerName` | |
+| `SCION_BROKER_ID` | `BrokerID` | |
+| `SCION_CLI_MODE` | `CLIMode` | |
+| `SCION_HUB_ENDPOINT` | `HubEndpoint` | For Hub URL construction |
+
+**Never-read list (defense in depth — these must never appear in the allowlist):**
+
+- `SCION_AUTH_TOKEN`
+- `SCION_DEV_TOKEN`
+- `SCION_TRANSPORT_TOKEN`
+- `SCION_METADATA_SA_EMAIL`
+- `SCION_METADATA_PROJECT_ID`
+- Any `*_KEY` or `*_TOKEN` env var
+
+### 3. `--full` Flag (Tier 2)
+
+A new boolean flag `--full` on the `whoami` command:
+
+```go
+whoamiCmd.Flags().BoolVar(&whoamiFull, "full", false,
+    "Include enriched fields from the Hub (phase, activity, labels, ancestry)")
+```
+
+**Behavior when `--full` is set:**
+
+1. Read all Tier 1 env vars (same as default).
+2. Attempt to create a Hub client using the `sciontool/hub` package's `NewClient()` (which reads `SCION_HUB_ENDPOINT`, `SCION_AUTH_TOKEN`, `SCION_AGENT_ID` internally).
+3. If the client is `nil` or not configured, emit a stderr warning ("Hub not available; --full fields omitted") and return Tier 1 fields only. This is **not** an error — the command succeeds with partial data.
+4. If the client is available, call the Hub's agent self-fetch: `GET /api/v1/agents/{agentID}` using the existing `Agents().Get(ctx, agentID)` method (or equivalently, via the `sciontool/hub` client's own endpoint).
+5. Populate `Phase`, `Activity`, `Labels`, `Annotations`, `Ancestry`, `TaskSummary` from the response.
+6. Apply a 5-second context timeout to the Hub call.
+
+**Why use `sciontool/hub.NewClient()` rather than `cmd.getHubClient()`:**
+
+- `whoami` runs inside the agent container. The `sciontool/hub` client is designed for exactly this context — it reads the canonical token file and container env vars.
+- `cmd.getHubClient()` is designed for the CLI-side (user workstation), with OAuth, dev tokens, and settings-file resolution. It would be the wrong abstraction here.
+- However, there is no `GetSelf()` or `GetAgent()` on `sciontool/hub.Client` today. The Tier 2 implementation will need to add a small method or make a direct HTTP GET. The developer should check whether `sciontool/hub.Client` already has a suitable method, or add a minimal `GetSelf()` that hits `GET /api/v1/agents/{c.agentID}` and returns the relevant fields. This is a small, contained addition.
+
+**Alternative considered:** Using `cmd.getHubClient()` + `hubclient.Agents().Get()`. Rejected because `getHubClient()` requires `*config.Settings` which is a CLI-side concern, and would pull in `hubsync` machinery that is unnecessary in-container. The `sciontool/hub` package is the correct layer.
+
+### 4. Plain-Text Output
+
+**Default (no `--full`):** Unchanged — prints the slug only.
+
+```
+$ scion whoami
+my-agent
+```
+
+**With `--full` (plain text, no `--format json`):** Print a human-readable summary of all available fields:
+
+```
+$ scion whoami --full
+Agent:    my-agent (My Agent)
+ID:       abc-123-def
+Project:  my-project
+Template: developer
+Harness:  claude
+Model:    sonnet
+Creator:  ptone
+Broker:   my-broker
+Phase:    running
+Activity: working
+Hub:      https://hub.example.com/agents/abc-123-def
+```
+
+Only non-empty fields are printed. Labels/annotations/ancestry are omitted from plain-text for readability (use `--format json --full` to see them).
+
+### 5. Backward Compatibility
+
+| Aspect | Guarantee |
+|---|---|
+| `scion whoami` (plain text) | Output unchanged: prints slug |
+| `scion whoami --format json` | Same 3 fields (`slug`, `name`, `id`) at same keys and types. New fields are additive with `omitempty`. |
+| System whoami fallback | Unchanged: when not in an agent container, delegates to system `whoami` |
+| Exit codes | Unchanged |
+| `--full` without Hub | Degrades gracefully — Tier 1 fields only, stderr warning, exit 0 |
+
+**Load-bearing decision:** The first 3 JSON keys (`slug`, `name`, `id`) are used by existing scripts and agents. Changing their names or types would break consumers. This is why we use a struct with explicit json tags rather than relying on Go's alphabetical marshaling of maps.
+
+**Easily reversible decision:** The names of new Tier 1 fields (`project`, `template`, `harness`, etc.) are chosen to match the `api.AgentInfo` JSON tags where possible. If we later decide to rename `template` to `role`, that's a one-field JSON tag change with a deprecation alias.
+
+---
+
+## Alternatives Considered
+
+### A. Glob all `SCION_*` env vars
+
+Read every env var with a `SCION_` prefix and dump them all. Rejected: **security risk**. This would expose `SCION_AUTH_TOKEN`, `SCION_DEV_TOKEN`, and other credentials. An explicit allowlist is the only safe approach.
+
+### B. Always call the Hub API (no `--full` flag)
+
+Make every `scion whoami --format json` call hit the Hub. Rejected: adds 100-300ms latency to every call, requires Hub reachability, and breaks the "zero-dependency introspection" use case. Many agents call `whoami` at startup for logging — latency matters.
+
+### C. Introduce a `Role` field now
+
+Add a `role` field backed by a new `Role` field on the agent model. Rejected: this is new infrastructure requiring changes to `store.Agent`, the Hub API, the create flow, and all broker implementations. Out of scope for this additive enhancement. `SCION_TEMPLATE_NAME` as `template` is an honest proxy that doesn't pretend to be something it isn't.
+
+### D. Decode the JWT for ancestry instead of Hub API
+
+The agent's JWT (`SCION_AUTH_TOKEN`) contains the ancestry chain in its claims. We could decode it locally without an API call. Rejected: reading the JWT puts `SCION_AUTH_TOKEN` in the code path of `whoami`, which is a security design smell — even if we only read claims and don't expose the token itself, it normalizes accessing the token in a user-facing command. The Hub API approach keeps the token handling contained in the `sciontool/hub` client where it belongs.
+
+---
+
+## Migration / Rollout
+
+This is a purely additive change with no migration concerns:
+
+- **No schema changes.** No database migrations, no API changes.
+- **No breaking changes.** All existing output is preserved.
+- **No new dependencies.** Tier 1 uses only `os.Getenv()`. Tier 2 uses the existing `sciontool/hub` client.
+- **Feature flag:** The `--full` flag is the opt-in mechanism for Tier 2. It can be removed or changed without breaking the default path.
+- **Forward compatibility:** The `WhoamiResult` struct can have fields added in future PRs without breaking consumers (JSON `omitempty` + additive-only policy).
+
+---
+
+## Open Questions
+
+None remaining. All 3 user-facing design questions have been answered:
+
+1. **Tier scope:** Tier 1 by default + Tier 2 via `--full` *(answered: option b)*
+2. **Role:** `SCION_TEMPLATE_NAME` as `template` field *(answered: option b)*
+3. **Ancestry:** Creator in Tier 1, full ancestry in `--full` *(answered: option b)*
+
+**One implementation question for the developer:** The `sciontool/hub.Client` does not currently have a `GetSelf()` or `GetAgent()` method. The developer should check the current client surface and either:
+- Use an existing HTTP helper on the client to `GET /api/v1/agents/{agentID}`
+- Or add a small `GetSelf()` method that returns the fields needed by `--full`
+
+The choice is left to the developer's judgment based on what's cleanest in the current codebase.
+
+---
+
+## Implementation Phases
+
+### Phase 1: Tier 1 — Typed struct + env var fields (single commit)
+
+1. Define `WhoamiResult` struct in `cmd/whoami.go`
+2. Replace `map[string]string{...}` with struct population from env vars
+3. Construct `hubUrl` from `SCION_HUB_ENDPOINT` + `SCION_AGENT_ID`
+4. Update tests: change `map[string]string` unmarshaling to `WhoamiResult` struct, add assertions for new fields
+
+### Phase 2: Tier 2 — `--full` flag + Hub API enrichment (single commit)
+
+1. Add `--full` flag to `whoamiCmd`
+2. When `--full` is set, create a `sciontool/hub` client and fetch self
+3. Populate Tier 2 fields from Hub response
+4. Handle Hub-unavailable case: stderr warning, return Tier 1 only
+5. Add `--full` plain-text output format
+6. Add tests: `--full` with mocked Hub response, `--full` without Hub (graceful degradation)
+
+### Phase 3: Design doc in repo (single commit)
+
+1. Commit `.design/whoami-enhance.md` to the repo per project standards
+
+---
+
+## Acceptance Criteria
+
+The QA tester should verify:
+
+1. **Backward compatibility (plain text):** `scion whoami` prints only the slug, identical to current behavior.
+2. **Backward compatibility (JSON):** `scion whoami --format json` returns a JSON object containing at minimum `slug`, `name`, `id` with the same values as before.
+3. **New Tier 1 fields:** `scion whoami --format json` includes `project`, `projectId`, `template`, `harness`, `model`, `creator`, `brokerName`, `brokerId`, `cliMode` when the corresponding env vars are set.
+4. **Hub URL:** `scion whoami --format json` includes `hubUrl` constructed from `SCION_HUB_ENDPOINT` and `SCION_AGENT_ID` when both are present.
+5. **`omitempty` behavior:** Fields for unset env vars are absent from JSON output (not present as empty strings).
+6. **`--full` with Hub available:** `scion whoami --full --format json` includes Tier 2 fields: `phase`, `activity`, `labels`, `annotations`, `ancestry`, `taskSummary`.
+7. **`--full` without Hub:** `scion whoami --full --format json` returns Tier 1 fields only, prints a warning to stderr, and exits 0.
+8. **`--full` plain text:** `scion whoami --full` prints a human-readable multi-line summary.
+9. **Security — no token exposure:** The output (both JSON and plain text) never contains `SCION_AUTH_TOKEN`, `SCION_DEV_TOKEN`, `SCION_TRANSPORT_TOKEN`, or any `*_KEY`/`*_TOKEN` value.
+10. **Non-agent context:** `scion whoami` outside an agent container still falls back to system `whoami`.
+11. **All existing tests pass** and new tests cover the added fields and the `--full` flag behavior.

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -15,11 +15,15 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/spf13/cobra"
+
+	sciontoolhub "github.com/GoogleCloudPlatform/scion/pkg/sciontool/hub"
 )
 
 // WhoamiResult is the JSON output shape for `scion whoami --format json`.
@@ -49,6 +53,14 @@ type WhoamiResult struct {
 	TaskSummary string            `json:"taskSummary,omitempty"`
 }
 
+// whoamiFull controls whether the --full flag was set.
+var whoamiFull bool
+
+// newHubClient is the default Hub client factory. Overridden in tests.
+var newHubClient = func() *sciontoolhub.Client {
+	return sciontoolhub.NewClient()
+}
+
 var whoamiCmd = &cobra.Command{
 	Use:   "whoami",
 	Short: "Print the current agent's identity",
@@ -68,9 +80,20 @@ When run outside an agent container, falls back to the system whoami command.`,
 			slug = name
 		}
 
+		result := buildWhoamiResult(slug, name)
+
+		// Enrich with Hub data when --full is requested.
+		if whoamiFull {
+			enrichFromHub(cmd, &result)
+		}
+
 		if isJSONOutput() {
-			result := buildWhoamiResult(slug, name)
 			return outputJSON(result)
+		}
+
+		if whoamiFull {
+			printFullPlainText(result)
+			return nil
 		}
 
 		fmt.Println(slug)
@@ -107,6 +130,75 @@ func buildWhoamiResult(slug, name string) WhoamiResult {
 	return result
 }
 
+// enrichFromHub attempts to populate Tier 2 fields from the Hub API.
+// On failure, it emits a stderr warning and returns Tier 1 fields only.
+func enrichFromHub(cmd *cobra.Command, result *WhoamiResult) {
+	client := newHubClient()
+	if client == nil || !client.IsConfigured() {
+		fmt.Fprintln(os.Stderr, "Warning: Hub not available; --full fields omitted")
+		return
+	}
+
+	parentCtx := cmd.Context()
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parentCtx, 5*time.Second)
+	defer cancel()
+
+	self, err := client.GetSelf(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Hub query failed: %v; --full fields omitted\n", err)
+		return
+	}
+
+	result.Phase = self.Phase
+	result.Activity = self.Activity
+	result.Labels = self.Labels
+	result.Annotations = self.Annotations
+	result.Ancestry = self.Ancestry
+	result.TaskSummary = self.TaskSummary
+}
+
+// printFullPlainText prints a human-readable multi-line summary of all available fields.
+func printFullPlainText(r WhoamiResult) {
+	if r.Name != "" {
+		fmt.Printf("Agent:    %s (%s)\n", r.Slug, r.Name)
+	} else {
+		fmt.Printf("Agent:    %s\n", r.Slug)
+	}
+	if r.ID != "" {
+		fmt.Printf("ID:       %s\n", r.ID)
+	}
+	if r.Project != "" {
+		fmt.Printf("Project:  %s\n", r.Project)
+	}
+	if r.Template != "" {
+		fmt.Printf("Template: %s\n", r.Template)
+	}
+	if r.Harness != "" {
+		fmt.Printf("Harness:  %s\n", r.Harness)
+	}
+	if r.Model != "" {
+		fmt.Printf("Model:    %s\n", r.Model)
+	}
+	if r.Creator != "" {
+		fmt.Printf("Creator:  %s\n", r.Creator)
+	}
+	if r.BrokerName != "" {
+		fmt.Printf("Broker:   %s\n", r.BrokerName)
+	}
+	if r.Phase != "" {
+		fmt.Printf("Phase:    %s\n", r.Phase)
+	}
+	if r.Activity != "" {
+		fmt.Printf("Activity: %s\n", r.Activity)
+	}
+	if r.HubURL != "" {
+		fmt.Printf("Hub:      %s\n", r.HubURL)
+	}
+}
+
 func runSystemWhoami() error {
 	path, err := exec.LookPath("whoami")
 	if err != nil {
@@ -120,4 +212,6 @@ func runSystemWhoami() error {
 
 func init() {
 	rootCmd.AddCommand(whoamiCmd)
+	whoamiCmd.Flags().BoolVar(&whoamiFull, "full", false,
+		"Include enriched fields from the Hub (phase, activity, labels, ancestry)")
 }

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -22,6 +22,33 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// WhoamiResult is the JSON output shape for `scion whoami --format json`.
+type WhoamiResult struct {
+	// --- Tier 1: env-var fields (always populated, zero latency) ---
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	ID          string `json:"id"`
+	Project     string `json:"project,omitempty"`
+	ProjectID   string `json:"projectId,omitempty"`
+	Template    string `json:"template,omitempty"`
+	Harness     string `json:"harness,omitempty"`
+	Model       string `json:"model,omitempty"`
+	Creator     string `json:"creator,omitempty"`
+	BrokerName  string `json:"brokerName,omitempty"`
+	BrokerID    string `json:"brokerId,omitempty"`
+	CLIMode     string `json:"cliMode,omitempty"`
+	HubEndpoint string `json:"hubEndpoint,omitempty"`
+	HubURL      string `json:"hubUrl,omitempty"` // constructed: {hubEndpoint}/agents/{id}
+
+	// --- Tier 2: Hub API fields (only with --full, omitted otherwise) ---
+	Phase       string            `json:"phase,omitempty"`
+	Activity    string            `json:"activity,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Ancestry    []string          `json:"ancestry,omitempty"`
+	TaskSummary string            `json:"taskSummary,omitempty"`
+}
+
 var whoamiCmd = &cobra.Command{
 	Use:   "whoami",
 	Short: "Print the current agent's identity",
@@ -42,16 +69,42 @@ When run outside an agent container, falls back to the system whoami command.`,
 		}
 
 		if isJSONOutput() {
-			return outputJSON(map[string]string{
-				"slug": slug,
-				"name": name,
-				"id":   os.Getenv("SCION_AGENT_ID"),
-			})
+			result := buildWhoamiResult(slug, name)
+			return outputJSON(result)
 		}
 
 		fmt.Println(slug)
 		return nil
 	},
+}
+
+// buildWhoamiResult populates a WhoamiResult from the env var allowlist.
+func buildWhoamiResult(slug, name string) WhoamiResult {
+	id := os.Getenv("SCION_AGENT_ID")
+	hubEndpoint := os.Getenv("SCION_HUB_ENDPOINT")
+
+	result := WhoamiResult{
+		Slug:        slug,
+		Name:        name,
+		ID:          id,
+		Project:     os.Getenv("SCION_PROJECT"),
+		ProjectID:   os.Getenv("SCION_PROJECT_ID"),
+		Template:    os.Getenv("SCION_TEMPLATE_NAME"),
+		Harness:     os.Getenv("SCION_HARNESS"),
+		Model:       os.Getenv("SCION_MODEL"),
+		Creator:     os.Getenv("SCION_CREATOR"),
+		BrokerName:  os.Getenv("SCION_BROKER_NAME"),
+		BrokerID:    os.Getenv("SCION_BROKER_ID"),
+		CLIMode:     os.Getenv("SCION_CLI_MODE"),
+		HubEndpoint: hubEndpoint,
+	}
+
+	// Construct hubUrl from hubEndpoint + id (no API call needed).
+	if hubEndpoint != "" && id != "" {
+		result.HubURL = fmt.Sprintf("%s/agents/%s", hubEndpoint, id)
+	}
+
+	return result
 }
 
 func runSystemWhoami() error {

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -124,7 +124,7 @@ func buildWhoamiResult(slug, name string) WhoamiResult {
 
 	// Construct hubUrl from hubEndpoint + id (no API call needed).
 	if hubEndpoint != "" && id != "" {
-		result.HubURL = fmt.Sprintf("%s/agents/%s", hubEndpoint, id)
+		result.HubURL = fmt.Sprintf("%s/agents/%s", strings.TrimSuffix(hubEndpoint, "/"), id)
 	}
 
 	return result

--- a/cmd/whoami_test.go
+++ b/cmd/whoami_test.go
@@ -17,12 +17,18 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	sciontoolhub "github.com/GoogleCloudPlatform/scion/pkg/sciontool/hub"
 )
 
 func captureStdout(t *testing.T, fn func()) string {
@@ -34,6 +40,20 @@ func captureStdout(t *testing.T, fn func()) string {
 	fn()
 	_ = w.Close()
 	os.Stdout = old
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	old := os.Stderr
+	os.Stderr = w
+	fn()
+	_ = w.Close()
+	os.Stderr = old
 	var buf bytes.Buffer
 	_, _ = io.Copy(&buf, r)
 	return buf.String()
@@ -225,6 +245,178 @@ func TestWhoamiHubURL(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(out), &raw))
 		assert.NotContains(t, raw, "hubUrl")
 	})
+}
+
+func TestWhoamiFull(t *testing.T) {
+	// Set up a mock Hub server.
+	agentResp := map[string]interface{}{
+		"id":          "agent-full-id",
+		"slug":        "full-agent",
+		"name":        "Full Agent",
+		"phase":       "running",
+		"activity":    "working",
+		"labels":      map[string]string{"env": "prod", "team": "infra"},
+		"annotations": map[string]string{"note": "test annotation"},
+		"ancestry":    []string{"user-root", "parent-agent"},
+		"taskSummary": "Implementing feature X",
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/api/v1/agents/agent-full-id")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(agentResp)
+	}))
+	defer srv.Close()
+
+	// Set env vars.
+	t.Setenv("SCION_AGENT_SLUG", "full-agent")
+	t.Setenv("SCION_AGENT_NAME", "Full Agent")
+	t.Setenv("SCION_AGENT_ID", "agent-full-id")
+	t.Setenv("SCION_HUB_ENDPOINT", srv.URL)
+
+	// Override the Hub client factory with one pointing at our test server.
+	cleanup := sciontoolhub.SetHubTestSandboxed()
+	defer cleanup()
+	origFactory := newHubClient
+	newHubClient = func() *sciontoolhub.Client {
+		return sciontoolhub.NewClientWithConfig(srv.URL, "test-token", "agent-full-id")
+	}
+	defer func() { newHubClient = origFactory }()
+
+	// Save and restore the --full flag.
+	oldFull := whoamiFull
+	whoamiFull = true
+	defer func() { whoamiFull = oldFull }()
+
+	oldFormat := outputFormat
+	outputFormat = "json"
+	defer func() { outputFormat = oldFormat }()
+
+	cmd := whoamiCmd
+	out := captureStdout(t, func() {
+		err := cmd.RunE(cmd, nil)
+		require.NoError(t, err)
+	})
+
+	var result WhoamiResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+
+	// Tier 1 fields.
+	assert.Equal(t, "full-agent", result.Slug)
+	assert.Equal(t, "Full Agent", result.Name)
+	assert.Equal(t, "agent-full-id", result.ID)
+	assert.Equal(t, fmt.Sprintf("%s/agents/agent-full-id", srv.URL), result.HubURL)
+
+	// Tier 2 fields from Hub API.
+	assert.Equal(t, "running", result.Phase)
+	assert.Equal(t, "working", result.Activity)
+	assert.Equal(t, map[string]string{"env": "prod", "team": "infra"}, result.Labels)
+	assert.Equal(t, map[string]string{"note": "test annotation"}, result.Annotations)
+	assert.Equal(t, []string{"user-root", "parent-agent"}, result.Ancestry)
+	assert.Equal(t, "Implementing feature X", result.TaskSummary)
+}
+
+func TestWhoamiFullNoHub(t *testing.T) {
+	t.Setenv("SCION_AGENT_SLUG", "nohub-agent")
+	t.Setenv("SCION_AGENT_NAME", "NoHub Agent")
+	t.Setenv("SCION_AGENT_ID", "agent-nohub-id")
+	// No Hub endpoint set — client will be nil.
+	t.Setenv("SCION_HUB_ENDPOINT", "")
+
+	// Override the Hub client factory to return nil (no Hub).
+	origFactory := newHubClient
+	newHubClient = func() *sciontoolhub.Client {
+		return nil
+	}
+	defer func() { newHubClient = origFactory }()
+
+	oldFull := whoamiFull
+	whoamiFull = true
+	defer func() { whoamiFull = oldFull }()
+
+	oldFormat := outputFormat
+	outputFormat = "json"
+	defer func() { outputFormat = oldFormat }()
+
+	cmd := whoamiCmd
+
+	var stderr string
+	out := captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			err := cmd.RunE(cmd, nil)
+			require.NoError(t, err) // Must exit 0 even without Hub.
+		})
+	})
+
+	// Verify stderr warning.
+	assert.Contains(t, stderr, "Hub not available")
+
+	// Verify Tier 1 fields are still present.
+	var result WhoamiResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Equal(t, "nohub-agent", result.Slug)
+	assert.Equal(t, "NoHub Agent", result.Name)
+	assert.Equal(t, "agent-nohub-id", result.ID)
+
+	// Verify Tier 2 fields are absent.
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(out), &raw))
+	assert.NotContains(t, raw, "phase")
+	assert.NotContains(t, raw, "activity")
+	assert.NotContains(t, raw, "labels")
+	assert.NotContains(t, raw, "annotations")
+	assert.NotContains(t, raw, "ancestry")
+	assert.NotContains(t, raw, "taskSummary")
+}
+
+func TestWhoamiFullPlainText(t *testing.T) {
+	t.Setenv("SCION_AGENT_SLUG", "text-agent")
+	t.Setenv("SCION_AGENT_NAME", "Text Agent")
+	t.Setenv("SCION_AGENT_ID", "agent-text-id")
+	t.Setenv("SCION_PROJECT", "my-project")
+	t.Setenv("SCION_TEMPLATE_NAME", "developer")
+	t.Setenv("SCION_HARNESS", "claude")
+	t.Setenv("SCION_MODEL", "sonnet")
+	t.Setenv("SCION_CREATOR", "ptone")
+	t.Setenv("SCION_BROKER_NAME", "my-broker")
+	t.Setenv("SCION_HUB_ENDPOINT", "https://hub.example.com")
+
+	// Override the Hub client factory to return nil (skip Hub enrichment for this test).
+	origFactory := newHubClient
+	newHubClient = func() *sciontoolhub.Client {
+		return nil
+	}
+	defer func() { newHubClient = origFactory }()
+
+	oldFull := whoamiFull
+	whoamiFull = true
+	defer func() { whoamiFull = oldFull }()
+
+	// Plain text (not JSON).
+	oldFormat := outputFormat
+	outputFormat = ""
+	defer func() { outputFormat = oldFormat }()
+
+	cmd := whoamiCmd
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			err := cmd.RunE(cmd, nil)
+			require.NoError(t, err)
+		})
+	})
+
+	assert.Contains(t, out, "Agent:    text-agent (Text Agent)")
+	assert.Contains(t, out, "ID:       agent-text-id")
+	assert.Contains(t, out, "Project:  my-project")
+	assert.Contains(t, out, "Template: developer")
+	assert.Contains(t, out, "Harness:  claude")
+	assert.Contains(t, out, "Model:    sonnet")
+	assert.Contains(t, out, "Creator:  ptone")
+	assert.Contains(t, out, "Broker:   my-broker")
+	assert.Contains(t, out, "Hub:      https://hub.example.com/agents/agent-text-id")
+
+	// Verify plain-text does not contain JSON braces.
+	assert.False(t, strings.HasPrefix(strings.TrimSpace(out), "{"))
 }
 
 func TestWhoamiNameOnly(t *testing.T) {

--- a/cmd/whoami_test.go
+++ b/cmd/whoami_test.go
@@ -67,11 +67,164 @@ func TestWhoamiAgentContextJSON(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	var result map[string]string
+	var result WhoamiResult
 	require.NoError(t, json.Unmarshal([]byte(out), &result))
-	assert.Equal(t, "my-agent", result["slug"])
-	assert.Equal(t, "My Agent", result["name"])
-	assert.Equal(t, "uuid-123", result["id"])
+	assert.Equal(t, "my-agent", result.Slug)
+	assert.Equal(t, "My Agent", result.Name)
+	assert.Equal(t, "uuid-123", result.ID)
+}
+
+func TestWhoamiTier1FieldsJSON(t *testing.T) {
+	// Set all Tier 1 env vars.
+	t.Setenv("SCION_AGENT_SLUG", "dev-agent")
+	t.Setenv("SCION_AGENT_NAME", "Dev Agent")
+	t.Setenv("SCION_AGENT_ID", "agent-456")
+	t.Setenv("SCION_PROJECT", "my-project")
+	t.Setenv("SCION_PROJECT_ID", "proj-789")
+	t.Setenv("SCION_TEMPLATE_NAME", "developer")
+	t.Setenv("SCION_HARNESS", "claude")
+	t.Setenv("SCION_MODEL", "sonnet")
+	t.Setenv("SCION_CREATOR", "ptone")
+	t.Setenv("SCION_BROKER_NAME", "my-broker")
+	t.Setenv("SCION_BROKER_ID", "broker-001")
+	t.Setenv("SCION_CLI_MODE", "non-interactive")
+	t.Setenv("SCION_HUB_ENDPOINT", "https://hub.example.com")
+
+	oldFormat := outputFormat
+	outputFormat = "json"
+	defer func() { outputFormat = oldFormat }()
+
+	cmd := whoamiCmd
+	out := captureStdout(t, func() {
+		err := cmd.RunE(cmd, nil)
+		require.NoError(t, err)
+	})
+
+	var result WhoamiResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+
+	assert.Equal(t, "dev-agent", result.Slug)
+	assert.Equal(t, "Dev Agent", result.Name)
+	assert.Equal(t, "agent-456", result.ID)
+	assert.Equal(t, "my-project", result.Project)
+	assert.Equal(t, "proj-789", result.ProjectID)
+	assert.Equal(t, "developer", result.Template)
+	assert.Equal(t, "claude", result.Harness)
+	assert.Equal(t, "sonnet", result.Model)
+	assert.Equal(t, "ptone", result.Creator)
+	assert.Equal(t, "my-broker", result.BrokerName)
+	assert.Equal(t, "broker-001", result.BrokerID)
+	assert.Equal(t, "non-interactive", result.CLIMode)
+	assert.Equal(t, "https://hub.example.com", result.HubEndpoint)
+	assert.Equal(t, "https://hub.example.com/agents/agent-456", result.HubURL)
+}
+
+func TestWhoamiOmitEmpty(t *testing.T) {
+	// Set only slug and name — all other env vars absent.
+	t.Setenv("SCION_AGENT_SLUG", "minimal-agent")
+	t.Setenv("SCION_AGENT_NAME", "Minimal Agent")
+	t.Setenv("SCION_AGENT_ID", "")
+
+	// Clear all optional env vars explicitly.
+	t.Setenv("SCION_PROJECT", "")
+	t.Setenv("SCION_PROJECT_ID", "")
+	t.Setenv("SCION_TEMPLATE_NAME", "")
+	t.Setenv("SCION_HARNESS", "")
+	t.Setenv("SCION_MODEL", "")
+	t.Setenv("SCION_CREATOR", "")
+	t.Setenv("SCION_BROKER_NAME", "")
+	t.Setenv("SCION_BROKER_ID", "")
+	t.Setenv("SCION_CLI_MODE", "")
+	t.Setenv("SCION_HUB_ENDPOINT", "")
+
+	oldFormat := outputFormat
+	outputFormat = "json"
+	defer func() { outputFormat = oldFormat }()
+
+	cmd := whoamiCmd
+	out := captureStdout(t, func() {
+		err := cmd.RunE(cmd, nil)
+		require.NoError(t, err)
+	})
+
+	// Parse raw JSON to check key absence (omitempty).
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(out), &raw))
+
+	// Required fields are always present.
+	assert.Contains(t, raw, "slug")
+	assert.Contains(t, raw, "name")
+	assert.Contains(t, raw, "id")
+
+	// Optional fields must be absent when env vars are empty.
+	assert.NotContains(t, raw, "project")
+	assert.NotContains(t, raw, "projectId")
+	assert.NotContains(t, raw, "template")
+	assert.NotContains(t, raw, "harness")
+	assert.NotContains(t, raw, "model")
+	assert.NotContains(t, raw, "creator")
+	assert.NotContains(t, raw, "brokerName")
+	assert.NotContains(t, raw, "brokerId")
+	assert.NotContains(t, raw, "cliMode")
+	assert.NotContains(t, raw, "hubEndpoint")
+	assert.NotContains(t, raw, "hubUrl")
+}
+
+func TestWhoamiHubURL(t *testing.T) {
+	oldFormat := outputFormat
+	outputFormat = "json"
+	defer func() { outputFormat = oldFormat }()
+
+	t.Run("present when both endpoint and ID set", func(t *testing.T) {
+		t.Setenv("SCION_AGENT_SLUG", "agent-a")
+		t.Setenv("SCION_AGENT_NAME", "Agent A")
+		t.Setenv("SCION_AGENT_ID", "id-abc")
+		t.Setenv("SCION_HUB_ENDPOINT", "https://hub.example.com")
+
+		cmd := whoamiCmd
+		out := captureStdout(t, func() {
+			err := cmd.RunE(cmd, nil)
+			require.NoError(t, err)
+		})
+
+		var result WhoamiResult
+		require.NoError(t, json.Unmarshal([]byte(out), &result))
+		assert.Equal(t, "https://hub.example.com/agents/id-abc", result.HubURL)
+	})
+
+	t.Run("absent when endpoint missing", func(t *testing.T) {
+		t.Setenv("SCION_AGENT_SLUG", "agent-b")
+		t.Setenv("SCION_AGENT_NAME", "Agent B")
+		t.Setenv("SCION_AGENT_ID", "id-def")
+		t.Setenv("SCION_HUB_ENDPOINT", "")
+
+		cmd := whoamiCmd
+		out := captureStdout(t, func() {
+			err := cmd.RunE(cmd, nil)
+			require.NoError(t, err)
+		})
+
+		var raw map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(out), &raw))
+		assert.NotContains(t, raw, "hubUrl")
+	})
+
+	t.Run("absent when ID missing", func(t *testing.T) {
+		t.Setenv("SCION_AGENT_SLUG", "agent-c")
+		t.Setenv("SCION_AGENT_NAME", "Agent C")
+		t.Setenv("SCION_AGENT_ID", "")
+		t.Setenv("SCION_HUB_ENDPOINT", "https://hub.example.com")
+
+		cmd := whoamiCmd
+		out := captureStdout(t, func() {
+			err := cmd.RunE(cmd, nil)
+			require.NoError(t, err)
+		})
+
+		var raw map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(out), &raw))
+		assert.NotContains(t, raw, "hubUrl")
+	})
 }
 
 func TestWhoamiNameOnly(t *testing.T) {

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -1406,3 +1406,57 @@ func (c *Client) FetchGCPIdentityToken(ctx context.Context, audience string) (st
 
 	return result.Token, nil
 }
+
+// AgentSelf is the subset of Hub agent fields returned by GetSelf.
+// It covers the Tier 2 fields needed by `scion whoami --full`.
+type AgentSelf struct {
+	Phase       string            `json:"phase,omitempty"`
+	Activity    string            `json:"activity,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Ancestry    []string          `json:"ancestry,omitempty"`
+	TaskSummary string            `json:"taskSummary,omitempty"`
+}
+
+// GetSelf fetches the current agent's metadata from the Hub API.
+// It calls GET /api/v1/agents/{agentID} and decodes only the fields
+// needed for `scion whoami --full`. Returns an error if the Hub is
+// unreachable or returns a non-2xx status.
+func (c *Client) GetSelf(ctx context.Context) (*AgentSelf, error) {
+	if !c.IsConfigured() {
+		return nil, fmt.Errorf("hub client not configured")
+	}
+
+	endpoint := fmt.Sprintf("%s/api/v1/agents/%s",
+		strings.TrimSuffix(c.hubURL, "/"), c.agentID)
+
+	c.tokenMu.RLock()
+	currentToken := c.token
+	c.tokenMu.RUnlock()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("X-Scion-Agent-Token", currentToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("hub returned error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result AgentSelf
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}


### PR DESCRIPTION
## Summary

Closes ptone/scion#277 — Enhance `scion whoami` to return richer agent identity information.

- **Commit 1:** Replace inline `map[string]string` with typed `WhoamiResult` struct. Populate all Tier 1 fields from explicit env var allowlist (project, template, harness, model, creator, broker, CLI mode, hub endpoint, hub URL). All new fields use `omitempty`. Backward compatible: `slug`, `name`, `id` JSON keys unchanged.
- **Commit 2:** Add `--full` flag for Hub API enrichment. Adds `GetSelf()` method to `sciontool/hub.Client`. Populates Tier 2 fields (phase, activity, labels, annotations, ancestry, taskSummary). Graceful degradation when Hub unavailable (stderr warning, Tier 1 only, exit 0). 5-second timeout.
- **Commit 3:** Add design doc to `.design/whoami-enhance.md`