### PR TITLE
feat(web): add graph/tree view toggle to project detail page

### DIFF
--- a/web/src/components/pages/agent-graph.ts
+++ b/web/src/components/pages/agent-graph.ts
@@ -599,8 +599,13 @@ export class AgentGraphPage extends LitElement {
   private onViewChange(e: CustomEvent<{ view: ViewMode }>): void {
     const mode = e.detail.view;
     if (mode === 'graph') return;
-    localStorage.setItem('scion-view-agents', mode);
-    window.history.pushState({}, '', '/agents');
+    if (this.initiallyProjectScoped && this.projectFilter) {
+      localStorage.setItem('scion-view-project-agents', mode);
+      window.history.pushState({}, '', `/projects/${this.projectFilter}`);
+    } else {
+      localStorage.setItem('scion-view-agents', mode);
+      window.history.pushState({}, '', '/agents');
+    }
     window.dispatchEvent(new PopStateEvent('popstate'));
   }
 

--- a/web/src/components/pages/agent-graph.ts
+++ b/web/src/components/pages/agent-graph.ts
@@ -68,6 +68,8 @@ export class AgentGraphPage extends LitElement {
   @state() private error: string | null = null;
   @state() private projectFilter = '';
   @state() private showUsers = false;
+  /** True when the page was entered with a ?project= param already set in the URL. */
+  private initiallyProjectScoped = false;
   @state() private hoverId: string | null = null;
   @state() private collapsedIds: ReadonlySet<string> = new Set();
   @state() private scale = 1;
@@ -326,6 +328,7 @@ export class AgentGraphPage extends LitElement {
 
     const params = new URLSearchParams(window.location.search);
     this.projectFilter = params.get('project') || '';
+    this.initiallyProjectScoped = !!params.get('project');
     this.focusId = params.get('focus') || '';
     this.showUsers = localStorage.getItem('scion-graph-show-users') === 'true';
 
@@ -606,6 +609,7 @@ export class AgentGraphPage extends LitElement {
       <div class="header">
         <h1>Agents</h1>
         <div class="header-actions">
+          ${this.initiallyProjectScoped ? nothing : html`
           <sl-select
             size="small"
             placeholder="All projects"
@@ -615,7 +619,7 @@ export class AgentGraphPage extends LitElement {
             style="min-width: 180px"
           >
             ${this.projects.map(p => html`<sl-option value=${p.id}>${p.name}</sl-option>`)}
-          </sl-select>
+          </sl-select>`}
           <sl-switch
             size="small"
             ?checked=${this.showUsers}

--- a/web/src/components/pages/project-detail.ts
+++ b/web/src/components/pages/project-detail.ts
@@ -1086,6 +1086,8 @@ export class ScionPageProjectDetail extends LitElement {
   }
 
   private onViewChange(e: CustomEvent<{ view: ViewMode }>): void {
+    // 'graph' is a link segment handled by the router, never an event here.
+    if (e.detail.view === 'graph') return;
     this.viewMode = e.detail.view;
   }
 
@@ -1434,6 +1436,7 @@ export class ScionPageProjectDetail extends LitElement {
           <scion-view-toggle
             .view=${this.viewMode}
             storageKey="scion-view-project-agents"
+            graphHref="/agents/graph?project=${this.projectId}"
             @view-change=${this.onViewChange}
           ></scion-view-toggle>
           ${can(this.agentScopeCapabilities, 'stop_all') && this.hasRunningAgents() ? html`


### PR DESCRIPTION
- Wire up graphHref on project-detail's <scion-view-toggle> so users can navigate to /agents/graph?project=<id> from the project detail page
- Handle 'graph' view in onViewChange (early return, router handles it)
- Hide the project filter dropdown on the graph page when entered with a ?project= URL param (user already scoped via navigation, selector is redundant)

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
