### PR TITLE
fix: resolve model aliases before storing in AppliedConfig and SCION_MODEL

### DIFF
--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -1777,7 +1777,7 @@ func GetAgent(ctx context.Context, agentName string, templateName string, agentI
 		}
 		if hcName != "" {
 			hcDir, err := resolveHarnessConfigDir(ctx, hcName, projectPath)
-			if err == nil && hcDir.Config.ModelAliases != nil {
+			if err == nil && hcDir != nil && hcDir.Config.ModelAliases != nil {
 				resolved := config.ResolveModelAlias(finalCfg.Model, hcDir.Config.ModelAliases)
 				if resolved != finalCfg.Model {
 					util.Debugf("GetAgent: resolved model alias %q → %q", finalCfg.Model, resolved)

--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -1765,6 +1765,28 @@ func GetAgent(ctx context.Context, agentName string, templateName string, agentI
 
 	finalCfg := config.MergeScionConfig(mergedCfg, agentCfg)
 
+	// Resolve model size aliases for existing agents.
+	// Mirrors the alias resolution in ProvisionAgent (line 778-785).
+	// This covers the case where scion-agent.json was written with a raw alias
+	// (e.g. by applyInlineConfigUpdate before the hub-side fix) or where the
+	// agent was created before the hub resolved aliases at storage time.
+	if finalCfg.Model != "" {
+		hcName := finalCfg.HarnessConfig
+		if hcName == "" {
+			hcName = finalCfg.DefaultHarnessConfig
+		}
+		if hcName != "" {
+			hcDir, err := resolveHarnessConfigDir(ctx, hcName, projectPath)
+			if err == nil && hcDir.Config.ModelAliases != nil {
+				resolved := config.ResolveModelAlias(finalCfg.Model, hcDir.Config.ModelAliases)
+				if resolved != finalCfg.Model {
+					util.Debugf("GetAgent: resolved model alias %q → %q", finalCfg.Model, resolved)
+					finalCfg.Model = resolved
+				}
+			}
+		}
+	}
+
 	// Ensure Info is populated from agent-info.json if available
 	if agentInfo != nil {
 		finalCfg.Info = agentInfo

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -262,6 +262,20 @@ func (s *Server) populateAgentConfig(ctx context.Context, agent *store.Agent, pr
 		}
 	}
 
+	// Resolve model size aliases (e.g. "extra-large" → "fable") so that
+	// AppliedConfig.Model and InlineConfig.Model carry the concrete model
+	// name. This prevents raw aliases from leaking into SCION_MODEL env var
+	// (set by httpdispatcher) and --model CLI flag (set by run.go).
+	if agent.AppliedConfig.Model != "" {
+		resolved := s.resolveModelAliasForAgent(ctx, agent, agent.AppliedConfig.Model)
+		if resolved != agent.AppliedConfig.Model {
+			agent.AppliedConfig.Model = resolved
+			if agent.AppliedConfig.InlineConfig != nil && agent.AppliedConfig.InlineConfig.Model != "" {
+				agent.AppliedConfig.InlineConfig.Model = resolved
+			}
+		}
+	}
+
 	// Merge hub-level telemetry config as lowest-priority default.
 	// Only applies when no per-agent or template telemetry config is set.
 	s.mu.RLock()

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -1535,7 +1535,9 @@ func (s *Server) updateAgent(w http.ResponseWriter, r *http.Request, id string) 
 			agent.AppliedConfig.Image = cfg.Image
 		}
 		if cfg.Model != "" {
-			agent.AppliedConfig.Model = cfg.Model
+			resolved := s.resolveModelAliasForAgent(ctx, agent, cfg.Model)
+			agent.AppliedConfig.Model = resolved
+			cfg.Model = resolved // ensures InlineConfig (set later) also carries resolved value
 		}
 		if cfg.ThinkingLevel != nil {
 			if tl := *cfg.ThinkingLevel; tl < 0 || tl > 100 {

--- a/pkg/hub/harness_capabilities.go
+++ b/pkg/hub/harness_capabilities.go
@@ -126,14 +126,14 @@ func (s *Server) resolveAgentHarnessCapabilities(ctx context.Context, agent *sto
 // model_aliases map. Returns the input unchanged if no alias mapping exists
 // or any lookup fails.
 func (s *Server) resolveModelAliasForAgent(ctx context.Context, agent *store.Agent, model string) string {
-	if agent.AppliedConfig == nil || model == "" {
+	if agent == nil || agent.AppliedConfig == nil || model == "" {
 		return model
 	}
 
 	// Try by ID first (fast path — stamped during create)
 	if hcID := agent.AppliedConfig.HarnessConfigID; hcID != "" {
 		hc, err := s.store.GetHarnessConfig(ctx, hcID)
-		if err == nil && hc.Config != nil && len(hc.Config.ModelAliases) > 0 {
+		if err == nil && hc != nil && hc.Config != nil && len(hc.Config.ModelAliases) > 0 {
 			return config.ResolveModelAlias(model, hc.Config.ModelAliases)
 		}
 	}

--- a/pkg/hub/harness_capabilities.go
+++ b/pkg/hub/harness_capabilities.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/harness"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
@@ -118,6 +119,41 @@ func (s *Server) resolveAgentHarnessType(ctx context.Context, agent *store.Agent
 func (s *Server) resolveAgentHarnessCapabilities(ctx context.Context, agent *store.Agent) (string, api.HarnessAdvancedCapabilities) {
 	resolvedHarness := s.resolveAgentHarnessType(ctx, agent)
 	return resolvedHarness, harness.New(resolvedHarness).AdvancedCapabilities()
+}
+
+// resolveModelAliasForAgent resolves a model size alias (e.g. "extra-large")
+// to a concrete model name (e.g. "fable") using the agent's harness config's
+// model_aliases map. Returns the input unchanged if no alias mapping exists
+// or any lookup fails.
+func (s *Server) resolveModelAliasForAgent(ctx context.Context, agent *store.Agent, model string) string {
+	if agent.AppliedConfig == nil || model == "" {
+		return model
+	}
+
+	// Try by ID first (fast path — stamped during create)
+	if hcID := agent.AppliedConfig.HarnessConfigID; hcID != "" {
+		hc, err := s.store.GetHarnessConfig(ctx, hcID)
+		if err == nil && hc.Config != nil && len(hc.Config.ModelAliases) > 0 {
+			return config.ResolveModelAlias(model, hc.Config.ModelAliases)
+		}
+	}
+
+	// Fallback: by slug (project scope, then global)
+	hcSlug := agent.AppliedConfig.HarnessConfig
+	if hcSlug == "" {
+		return model
+	}
+	var hc *store.HarnessConfig
+	if agent.ProjectID != "" {
+		hc, _ = s.store.GetHarnessConfigBySlug(ctx, hcSlug, store.HarnessConfigScopeProject, agent.ProjectID)
+	}
+	if hc == nil {
+		hc, _ = s.store.GetHarnessConfigBySlug(ctx, hcSlug, store.HarnessConfigScopeGlobal, "")
+	}
+	if hc != nil && hc.Config != nil && len(hc.Config.ModelAliases) > 0 {
+		return config.ResolveModelAlias(model, hc.Config.ModelAliases)
+	}
+	return model
 }
 
 func supportReason(field api.CapabilityField) string {


### PR DESCRIPTION
## Problem
Model aliases (e.g. `extra-large`) leaked through unresolved to both the `--model` CLI flag and `SCION_MODEL` env var in hub-dispatched agent workflows, causing the claude CLI (and other harnesses) to receive an alias string it cannot recognize.

## Root cause
Two independent defects:
1. Hub stored raw alias in `AppliedConfig.Model` / `InlineConfig.Model`
2. `GetAgent` existing-agent path never called `ResolveModelAlias`

## Changes (4 files, +75/-1)
- `pkg/hub/harness_capabilities.go`: new `resolveModelAliasForAgent` helper
- `pkg/hub/handlers_agent_create_helpers.go`: resolve in `populateAgentConfig`
- `pkg/hub/handlers_agents_core.go`: resolve in `updateAgent`
- `pkg/agent/provision.go`: resolve in `GetAgent` existing-agent path

## Scenarios fixed
Hub full create, two-step, start/restart, config update. Local scion run was already correct. Existing agents self-heal on next restart