### PR TITLE
gh:// private-repo skill resolution via project git credentials

### DIFF
--- a/.design/project-skills-gh-scheme.md
+++ b/.design/project-skills-gh-scheme.md
@@ -1,0 +1,350 @@
+# Design: gh:// Private-Repo Skill Resolution
+
+**Author:** ps-arch  
+**Date:** 2026-07-24  
+**Branch:** `scion/project-skills-gh-scheme`  
+**Depends on:** `.design/project-skills.md` (Injected Skills feature)  
+**Related issue:** ptone/scion#557 (`as_needed` enforcement bug — separate work)
+
+---
+
+## Problem & Goals
+
+The Injected Skills feature allows `gh://owner/repo/skill-name[@ref]` URIs in a project's injected skill list. The `gh://` scheme and `GitHubSkillResolver` are fully implemented and work for public repos. The gap: `GitHubSkillResolver` is constructed with `os.Getenv("GITHUB_TOKEN")` — the broker process environment — not with the project's configured git credentials. Private repositories return 401/403.
+
+**Goals:**
+1. `gh://` URIs in injected skill lists resolve correctly when the target is a private GitHub repository using the project's configured credentials (GitHub App installation token or PAT).
+2. A skill URI can name a specific project secret to use as the GitHub token — enabling per-URI credential selection and different credentials for different private repos.
+3. Provision-time credentials are available to core provision code (the Go resolver) but **never** forwarded to the agent container env or harness scripts.
+4. Failure is explicit: missing credentials produce a clear error; optional skills (`optional: true`) degrade gracefully.
+
+**Non-Goals:**
+- Fixing the `as_needed` enforcement bug broadly — tracked at ptone/scion#557. This design creates a new `ProvisionCredentials` channel that carries all project secrets to provision-time Go code; fixing which secrets land in the container is separate work.
+- Supporting non-GitHub private registries — out of scope.
+- Hub-side skill content fetching (hub fetches skill files, not broker).
+- New URI schemes — `gh://` already exists and is routed correctly.
+
+---
+
+## Proposed Design
+
+### Overview
+
+Two complementary mechanisms:
+
+1. **`ProvisionCredentials`** — a new field in the broker dispatch request carrying all project-scope secrets, available to core provision code only. Never forwarded to the container env.
+2. **`?token=SECRET_NAME` URI query parameter** — an optional extension to `gh://` URIs that names which secret from `ProvisionCredentials` to use as the GitHub token for that specific resolver call.
+
+These compose: a bare `gh://` URI uses the default credential; a `gh://...?token=SKILLS_TOKEN` URI uses the named secret. Either way, the credential is pulled from `ProvisionCredentials`, not from `ResolvedEnv`.
+
+---
+
+### 1. `ProvisionCredentials` in the Broker Dispatch Request
+
+**File:** `pkg/runtimebroker/types.go`
+
+```go
+// CreateAgentRequest additions
+
+// ProvisionCredentials carries project-scope secrets for use by core provision
+// logic (skill resolution, URI variable substitution, credential helpers).
+// These are NEVER forwarded to the agent container environment or harness scripts.
+// Populated by the Hub from all project-scope secrets at dispatch time.
+ProvisionCredentials map[string]string `json:"provisionCredentials,omitempty"`
+```
+
+**Hub population** (`pkg/hub/httpdispatcher.go`, `buildCreateRequest`):
+
+After the existing `resolveSecrets` call, collect all project-scope secrets (all types) into `ProvisionCredentials`. The existing loop that puts environment-type secrets into `ResolvedEnv` is unchanged — `ProvisionCredentials` is additive, parallel to `ResolvedEnv`.
+
+```pseudocode
+// Collect all project-scope secrets for provision-time credential resolution.
+// These are NOT merged into ResolvedEnv and will not appear in the container.
+if agent.ProjectID != "" && d.secretBackend != nil {
+    projectSecrets, _ := d.secretBackend.List(ctx, secret.Filter{
+        Scope:   secret.ScopeProject,
+        ScopeID: agent.ProjectID,
+    })
+    req.ProvisionCredentials = make(map[string]string, len(projectSecrets))
+    for _, sm := range projectSecrets {
+        if sm.SecretType == store.SecretTypeInternal {
+            continue
+        }
+        sv, err := d.secretBackend.Get(ctx, sm.Name, secret.ScopeProject, agent.ProjectID)
+        if err == nil && sv.Value != "" {
+            req.ProvisionCredentials[sm.Name] = sv.Value
+        }
+    }
+}
+```
+
+**Security invariant:** `ProvisionCredentials` is consumed by the broker's provision pipeline and then discarded. It is never written to disk, never placed in `req.ResolvedEnv`, and never passed to `provision.py` or harness containers.
+
+---
+
+### 2. `?token=SECRET_NAME` URI Query Parameter
+
+**File:** `pkg/agent/github_uri.go`
+
+Extend `GitHubSkillRef` with an optional `TokenSecretName` field:
+
+```go
+type GitHubSkillRef struct {
+    Owner           string
+    Repo            string
+    SkillName       string
+    Ref             string
+    SkillPath       string
+    Raw             string
+    TokenSecretName string // Secret name from ?token= param; empty = use default credential
+}
+```
+
+Extend `parseGHShorthand` to extract the `?token=SECRET_NAME` query parameter:
+
+```pseudocode
+// After splitting off @ref and before splitting on /:
+// Check for ?token=SECRET_NAME query param in the rest string.
+// The ref (@...) must be stripped first; then check if remaining path has '?'
+
+// Supported forms:
+//   gh://owner/repo/skill-name[@ref][?token=SECRET_NAME]
+// Note: ?token must come after @ref if both are present.
+```
+
+The query parameter name is `token`. The value is a bare secret name (e.g., `SKILLS_TOKEN`), not a shell variable reference. No `${}` syntax — the name IS the lookup key in `ProvisionCredentials`.
+
+Full GitHub URL form (`https://github.com/...`): The `?token=` param is also supported if present.
+
+**Validation:** `SECRET_NAME` must match `[A-Z][A-Z0-9_]*` (env-var-style name). Invalid names → parse error.
+
+---
+
+### 3. `GitHubSkillResolver` Credential Lookup
+
+**File:** `pkg/agent/github_skill_resolver.go`
+
+Add a new constructor that accepts both a default token and a credential map:
+
+```go
+// NewGitHubSkillResolverWithCredentials constructs a resolver with an
+// explicit default token and a named-credential map for per-URI lookup.
+// provisionCredentials maps secret name → secret value; may be nil.
+func NewGitHubSkillResolverWithCredentials(
+    defaultToken string,
+    provisionCredentials map[string]string,
+) *GitHubSkillResolver
+```
+
+Token resolution per-URI (in `Resolve` / `resolveOne`):
+
+```pseudocode
+func (r *GitHubSkillResolver) tokenForRef(ref *GitHubSkillRef) string {
+    if ref.TokenSecretName != "" {
+        if val, ok := r.provisionCredentials[ref.TokenSecretName]; ok && val != "" {
+            return val
+        }
+        // Named secret not found — return empty string; caller handles error
+        return ""
+    }
+    return r.token // default: GITHUB_TOKEN from ResolvedEnv or env var
+}
+```
+
+When `tokenForRef` returns `""` for a required skill → resolution fails with:
+```
+failed to resolve gh://...: secret "SKILLS_TOKEN" not found in ProvisionCredentials; 
+ensure the secret is set at project scope
+```
+
+`setAuthHeader` is updated to accept the token per-call (currently it uses `r.token` directly).
+
+**Fallback chain for default token (no `?token=` param):**
+1. `defaultToken` passed to the constructor (from `req.ResolvedEnv["GITHUB_TOKEN"]`)
+2. `os.Getenv("GITHUB_TOKEN")` if `defaultToken` is empty (existing behavior, broker process env)
+
+---
+
+### 4. Broker Wiring
+
+**File:** `pkg/runtimebroker/handlers.go`
+
+```go
+// Replace:
+ghResolver := agent.NewGitHubSkillResolver()
+
+// With:
+defaultGHToken := req.ResolvedEnv["GITHUB_TOKEN"]
+ghResolver := agent.NewGitHubSkillResolverWithCredentials(defaultGHToken, req.ProvisionCredentials)
+```
+
+`ProvisionCredentials` is passed directly to the resolver constructor. It is not stored in any context value — only the resolver itself holds it, in memory, for the duration of skill resolution.
+
+---
+
+### 5. CLI Wiring (local mode)
+
+**File:** `cmd/create.go`
+
+In local mode there is no hub-managed secrets store, so `ProvisionCredentials` is nil. The resolver falls back to `os.Getenv("GITHUB_TOKEN")` as before. Users who need private repos in local mode set `GITHUB_TOKEN` in their environment.
+
+```go
+// Replace (line ~146):
+ghResolver := agent.NewGitHubSkillResolver()
+
+// With:
+ghToken := os.Getenv("GITHUB_TOKEN")
+ghResolver := agent.NewGitHubSkillResolverWithCredentials(ghToken, nil)
+```
+
+No behavior change for CLI users.
+
+---
+
+### 6. URI Examples
+
+```
+# Public repo — no credential needed
+gh://acme-corp/public-skills/my-skill
+
+# Private repo — uses project's default GITHUB_TOKEN (App token or PAT)
+gh://acme-corp/private-skills/my-skill
+
+# Private repo — uses named project secret, not default GITHUB_TOKEN
+gh://acme-corp/partner-skills/my-skill?token=PARTNER_GITHUB_TOKEN
+
+# Private repo with pinned ref and named token
+gh://acme-corp/partner-skills/my-skill@v1.2.3?token=PARTNER_GITHUB_TOKEN
+```
+
+---
+
+### 7. Failure Handling
+
+| Scenario | Behavior |
+|---|---|
+| Private repo, no project credentials | 401/403 from GitHub; clear error with "ensure GITHUB_TOKEN is set at project scope or a GitHub App is configured" |
+| `?token=SKILLS_TOKEN` but secret not set | Error: "secret SKILLS_TOKEN not found in ProvisionCredentials" |
+| Project App token scoped only to project repo, skill in different repo | 403 from GitHub; error message; user sets a PAT as `SKILLS_TOKEN` for that URI |
+| Optional skill (`optional: true`) + any credential failure | Warning logged; skill skipped; provisioning continues |
+| `ProvisionCredentials` not populated (broker without hub, local mode) | Falls back to default token from env var |
+
+---
+
+### 8. Security Properties
+
+- `ProvisionCredentials` is a separate map, never merged into `ResolvedEnv`. It will not appear in the agent's container environment.
+- `ProvisionCredentials` is not written to any disk path during normal provision flow.
+- The resolver does not log credential values. Error messages reference secret names only, never values.
+- The `?token=` query param value is a secret name (public), never the secret value itself — the URI is safe to store and display in the skill injection settings UI.
+- Token scope: the default project GitHub App token is scoped to the project's git repo. Skills in other private repos require either a broader PAT (`GITHUB_TOKEN` set as a project secret) or a per-URI named secret (`?token=SECRET_NAME` where the secret has the appropriate repo scope). This is explicit and user-controlled.
+
+---
+
+## Alternatives Considered
+
+### A. Pass existing `req.ResolvedEnv["GITHUB_TOKEN"]` only (no `ProvisionCredentials`)
+
+**Rejected** because:
+- GITHUB_TOKEN is already in the container env; this design gives users a way to use a skill-resolution credential that never reaches the container.
+- No per-URI flexibility — all `gh://` skills share one credential.
+- Token scope issue: the App token is scoped to the project's own repo and will 403 for cross-repo skills. Users would be forced to use PATs with broader scope as the project GITHUB_TOKEN.
+
+This remains valid as a zero-extra-code first step (Phase 1), but the full design adds Phase 2.
+
+### B. Hub-side resolution (hub fetches skill content directly)
+
+Hub parses `gh://` URIs and fetches the content using its own GitHub credentials before dispatch. The broker receives pre-fetched content, not URIs to resolve.
+
+**Rejected** because:
+- Contradicts the existing architecture where the broker/provisioner owns skill resolution. Skills are installed into the agent's home directory by the provisioner, not by the hub.
+- Hub-side fetching breaks the broker's caching layer (`CachingSkillResolver`).
+- Creates a large hub-side code surface for something the agent package already handles correctly.
+
+### C. On-demand hub callback from broker
+
+Broker calls a new hub API endpoint to fetch a named secret value when resolving a `?token=` URI, rather than receiving all secrets upfront.
+
+**Rejected** because:
+- Adds latency (RPC per skill resolution)
+- Requires a new authenticated API endpoint on the hub for secret value retrieval
+- More complex error handling (network failure during provision is already handled; a new secret-fetch RPC adds another failure mode)
+- The security gain (secrets not in-memory on broker until needed) is marginal given that `ProvisionCredentials` is an in-memory-only map already isolated from the container env
+
+### D. New `provision_only` injection mode
+
+Add a third injection mode value alongside `always` and `as_needed`. Secrets marked `provision_only` go to `ProvisionCredentials` only.
+
+**Rejected** per user direction: avoid a third mode. Instead, the `ProvisionCredentials` mechanism naturally captures all project secrets at provision time; the "as needed" concept applies when a URI references a specific secret name. The `as_needed` enforcement bug (injecting secrets into containers that shouldn't be there) is tracked separately as ptone/scion#557.
+
+---
+
+## Migration / Rollout
+
+- **Backward compatible.** All existing `gh://` URIs with no `?token=` param continue to work as before (fallback to env var token).
+- **No schema changes.** `ProvisionCredentials` is a new JSON field on the wire format; brokers that don't recognize it ignore it.
+- **Graceful degradation.** If hub doesn't populate `ProvisionCredentials` (older hub version), resolver falls back to default token. `?token=SECRET_NAME` URIs would fail with a clear "secret not found" error rather than silently ignoring the param.
+- **No UI changes required.** The `?token=SECRET_NAME` syntax is a URI extension that the existing skill injection UI stores as-is in the URI field. Optionally, the UI can highlight it with a tooltip in a future iteration.
+
+---
+
+## Open Questions
+
+None blocking this design. All design decisions have been resolved with the user.
+
+**Tracked separately:**
+- ptone/scion#557 — `as_needed` injection mode enforcement: `as_needed` secrets should not appear in `ResolvedEnv`. Fix in dedicated work.
+- Token scope UX: when a user's App token is repo-scoped and a skill in another repo returns 403, the error message must be actionable. Exact wording TBD by developer.
+
+---
+
+## Implementation Phases
+
+### Phase 1: Default credential injection (~20 lines)
+**What:** Wire the existing `req.ResolvedEnv["GITHUB_TOKEN"]` into `GitHubSkillResolver` at broker construction time. No `ProvisionCredentials`, no URI query params.
+
+**Changes:**
+- `pkg/agent/github_skill_resolver.go`: add `NewGitHubSkillResolverWithToken(token string)` constructor
+- `pkg/runtimebroker/handlers.go`: replace `NewGitHubSkillResolver()` with `NewGitHubSkillResolverWithToken(req.ResolvedEnv["GITHUB_TOKEN"])`
+- `cmd/create.go`: `NewGitHubSkillResolverWithToken(os.Getenv("GITHUB_TOKEN"))` (no behavior change)
+
+**Outcome:** Private repos accessible via the project's existing GitHub App token — provided the skill repo is in scope of that token (i.e., same repo as the project's git remote, or no git remote configured).
+
+### Phase 2: `ProvisionCredentials` + URI `?token=` param (~130 lines)
+**What:** The full design. Per-URI credential selection; credentials never in container env.
+
+**Changes:**
+- `pkg/runtimebroker/types.go`: add `ProvisionCredentials map[string]string`
+- `pkg/hub/httpdispatcher.go`: populate `ProvisionCredentials` from project-scope secrets
+- `pkg/agent/github_uri.go`: parse `?token=SECRET_NAME` into `GitHubSkillRef.TokenSecretName`; validate secret name format
+- `pkg/agent/github_skill_resolver.go`: `NewGitHubSkillResolverWithCredentials(defaultToken, provisionCredentials)`, `tokenForRef(ref)`, per-call token threading through `setAuthHeader`
+- `pkg/runtimebroker/handlers.go`: pass `req.ProvisionCredentials` to resolver constructor
+- Tests: unit tests for URI parsing with `?token=`, resolver token selection, fallback behavior, missing-secret error
+
+**Outcome:** Full feature. Any named project secret can be used as a GitHub token for a specific `gh://` skill URI. Credential never in container env.
+
+---
+
+## Acceptance Criteria
+
+The QA tester should verify:
+
+1. **Public repo, no credentials configured** — `gh://owner/public-repo/skill` resolves successfully and the skill is installed.
+
+2. **Private repo, GitHub App configured** — `gh://org/same-repo-as-project/skill` resolves using the minted App token. The `GITHUB_TOKEN` value does NOT appear in any additionally-injected env var that wouldn't have been there before.
+
+3. **Private repo, cross-repo, named PAT** — `gh://org/other-private-repo/skill?token=SKILLS_TOKEN` where `SKILLS_TOKEN` is a project secret resolves successfully. Verify that `SKILLS_TOKEN` does NOT appear in the agent container's environment (check `env | grep SKILLS_TOKEN` inside a started agent container returns nothing).
+
+4. **Named secret missing** — `gh://...?token=MISSING_SECRET` with no `MISSING_SECRET` project secret → provisioning fails with an error message that names the missing secret and suggests setting it at project scope. Does NOT fail silently or use a wrong credential.
+
+5. **Optional skill with missing credential** — `{uri: "gh://...?token=MISSING_SECRET", optional: true}` → provisioning succeeds; warning in logs; skill directory not present; no error returned to caller.
+
+6. **`?token=` not in URI, no App token, no GITHUB_TOKEN env** — `gh://org/private-repo/skill` → fails with a 401-related error message pointing user to configure credentials.
+
+7. **CLI local mode** — `scion create` (no hub) with `GITHUB_TOKEN` set in process env resolves public and private repos as before. No regression.
+
+8. **Phased backward compatibility** — existing `gh://` URIs without `?token=` continue to work unchanged in all scenarios.
+
+9. **URI validation** — `gh://owner/repo/skill?token=invalid-secret-name` (lowercase, hyphens) → parse error with clear message about valid secret name format.
+
+10. **Cache correctness** — two `gh://` URIs for the same skill but different `?token=` values are treated as separate cache entries (cache key includes the token name, not the token value, to avoid leaking values into cache keys).

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -143,7 +143,7 @@ arguments are provided, an empty prompt.md is created for later editing.`,
 		if hubErr == nil && hctx != nil && hctx.Client != nil {
 			hubResolver := agent.NewHubSkillResolver(hctx.Client.Skills())
 			resolver := agent.NewRoutingSkillResolver(hubResolver)
-			ghResolver := agent.NewGitHubSkillResolver()
+			ghResolver := agent.NewGitHubSkillResolverWithToken(os.Getenv("GITHUB_TOKEN"))
 			resolver.Register("gh", ghResolver)
 
 			registrySvc := hctx.Client.SkillRegistries()

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -143,7 +143,7 @@ arguments are provided, an empty prompt.md is created for later editing.`,
 		if hubErr == nil && hctx != nil && hctx.Client != nil {
 			hubResolver := agent.NewHubSkillResolver(hctx.Client.Skills())
 			resolver := agent.NewRoutingSkillResolver(hubResolver)
-			ghResolver := agent.NewGitHubSkillResolverWithToken(os.Getenv("GITHUB_TOKEN"))
+			ghResolver := agent.NewGitHubSkillResolverWithCredentials(os.Getenv("GITHUB_TOKEN"), nil)
 			resolver.Register("gh", ghResolver)
 
 			registrySvc := hctx.Client.SkillRegistries()

--- a/pkg/agent/github_skill_resolver.go
+++ b/pkg/agent/github_skill_resolver.go
@@ -48,11 +48,12 @@ const (
 // GitHubSkillResolver resolves skills from GitHub repositories
 // using the GitHub Contents API.
 type GitHubSkillResolver struct {
-	httpClient      *http.Client
-	token           string // GITHUB_TOKEN for authenticated requests
-	apiBase         string // Default: githubAPIBase, override in tests
-	rawBase         string // Default: githubRawBase, override in tests
-	resolutionCache *GitHubResolutionCache
+	httpClient           *http.Client
+	token                string            // Default GITHUB_TOKEN for authenticated requests
+	provisionCredentials map[string]string // Per-URI named credentials from ProvisionCredentials
+	apiBase              string            // Default: githubAPIBase, override in tests
+	rawBase              string            // Default: githubRawBase, override in tests
+	resolutionCache      *GitHubResolutionCache
 }
 
 // NewGitHubSkillResolver creates a resolver for gh:// and GitHub URL skills.
@@ -82,6 +83,31 @@ func NewGitHubSkillResolverWithToken(token string) *GitHubSkillResolver {
 		r.token = token
 	}
 	return r
+}
+
+// NewGitHubSkillResolverWithCredentials constructs a resolver with an explicit
+// default token and a named-credential map for per-URI lookup.
+// provisionCredentials maps secret name → value; may be nil.
+func NewGitHubSkillResolverWithCredentials(defaultToken string, provisionCredentials map[string]string) *GitHubSkillResolver {
+	r := NewGitHubSkillResolverWithToken(defaultToken)
+	r.provisionCredentials = provisionCredentials
+	return r
+}
+
+// tokenForRef returns the appropriate GitHub token for the given ref.
+// If ref.TokenSecretName is set, it looks up the named secret in provisionCredentials.
+// If the named secret is not found, it returns an error.
+// If no TokenSecretName is set, it returns the default token.
+func (r *GitHubSkillResolver) tokenForRef(ref *GitHubSkillRef) (string, error) {
+	if ref.TokenSecretName != "" {
+		if r.provisionCredentials != nil {
+			if val, ok := r.provisionCredentials[ref.TokenSecretName]; ok && val != "" {
+				return val, nil
+			}
+		}
+		return "", fmt.Errorf("secret %q not found in ProvisionCredentials; ensure it is set at project scope", ref.TokenSecretName)
+	}
+	return r.token, nil
 }
 
 func (r *GitHubSkillResolver) ResolverName() string { return "github" }
@@ -122,12 +148,18 @@ func (r *GitHubSkillResolver) resolveOne(ctx context.Context, ghRef *GitHubSkill
 		}
 	}
 
-	commitSHA, err := r.resolveCommitSHA(ctx, ghRef)
+	// Resolve the per-URI token once; all API calls for this ref use it.
+	token, err := r.tokenForRef(ghRef)
+	if err != nil {
+		return nil, err
+	}
+
+	commitSHA, err := r.resolveCommitSHA(ctx, ghRef, token)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve ref for %s: %w", ghRef.Raw, err)
 	}
 
-	contents, err := r.listContents(ctx, ghRef, commitSHA)
+	contents, err := r.listContents(ctx, ghRef, commitSHA, token)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +181,7 @@ func (r *GitHubSkillResolver) resolveOne(ctx context.Context, ghRef *GitHubSkill
 			continue
 		}
 
-		content, err := r.downloadRawFile(ctx, ghRef, commitSHA, entry.Path)
+		content, err := r.downloadRawFile(ctx, ghRef, commitSHA, entry.Path, token)
 		if err != nil {
 			return nil, fmt.Errorf("failed to download %s: %w", entry.Path, err)
 		}
@@ -199,7 +231,7 @@ type githubContentEntry struct {
 	DownloadURL string `json:"download_url"`
 }
 
-func (r *GitHubSkillResolver) resolveCommitSHA(ctx context.Context, ghRef *GitHubSkillRef) (string, error) {
+func (r *GitHubSkillResolver) resolveCommitSHA(ctx context.Context, ghRef *GitHubSkillRef, token string) (string, error) {
 	ref := ghRef.Ref
 	if ref == "" {
 		ref = "HEAD"
@@ -212,7 +244,7 @@ func (r *GitHubSkillResolver) resolveCommitSHA(ctx context.Context, ghRef *GitHu
 		return "", err
 	}
 	req.Header.Set("Accept", "application/vnd.github.v3.sha")
-	r.setAuthHeader(req)
+	r.setAuthHeader(req, token)
 
 	resp, err := r.doWithRetry(ctx, req)
 	if err != nil {
@@ -238,7 +270,7 @@ func (r *GitHubSkillResolver) resolveCommitSHA(ctx context.Context, ghRef *GitHu
 	return sha, nil
 }
 
-func (r *GitHubSkillResolver) listContents(ctx context.Context, ghRef *GitHubSkillRef, commitSHA string) ([]githubContentEntry, error) {
+func (r *GitHubSkillResolver) listContents(ctx context.Context, ghRef *GitHubSkillRef, commitSHA string, token string) ([]githubContentEntry, error) {
 	escapedPath := escapePathSegments(ghRef.SkillPath)
 	reqURL := fmt.Sprintf("%s/repos/%s/%s/contents/%s?ref=%s",
 		r.apiBase, url.PathEscape(ghRef.Owner), url.PathEscape(ghRef.Repo), escapedPath, url.QueryEscape(commitSHA))
@@ -248,7 +280,7 @@ func (r *GitHubSkillResolver) listContents(ctx context.Context, ghRef *GitHubSki
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
-	r.setAuthHeader(req)
+	r.setAuthHeader(req, token)
 
 	resp, err := r.doWithRetry(ctx, req)
 	if err != nil {
@@ -272,14 +304,14 @@ func (r *GitHubSkillResolver) listContents(ctx context.Context, ghRef *GitHubSki
 	return entries, nil
 }
 
-func (r *GitHubSkillResolver) downloadRawFile(ctx context.Context, ghRef *GitHubSkillRef, commitSHA, filePath string) ([]byte, error) {
+func (r *GitHubSkillResolver) downloadRawFile(ctx context.Context, ghRef *GitHubSkillRef, commitSHA, filePath string, token string) ([]byte, error) {
 	reqURL := r.rawContentURL(ghRef, commitSHA, filePath)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	r.setAuthHeader(req)
+	r.setAuthHeader(req, token)
 
 	resp, err := r.doWithRetry(ctx, req)
 	if err != nil {
@@ -314,9 +346,9 @@ func escapePathSegments(p string) string {
 	return strings.Join(segments, "/")
 }
 
-func (r *GitHubSkillResolver) setAuthHeader(req *http.Request) {
-	if r.token != "" {
-		req.Header.Set("Authorization", "Bearer "+r.token)
+func (r *GitHubSkillResolver) setAuthHeader(req *http.Request, token string) {
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 }
 

--- a/pkg/agent/github_skill_resolver.go
+++ b/pkg/agent/github_skill_resolver.go
@@ -73,6 +73,17 @@ func NewGitHubSkillResolver() *GitHubSkillResolver {
 	}
 }
 
+// NewGitHubSkillResolverWithToken constructs a GitHubSkillResolver with an
+// explicit default token. If token is empty, falls back to the GITHUB_TOKEN
+// environment variable (same as NewGitHubSkillResolver).
+func NewGitHubSkillResolverWithToken(token string) *GitHubSkillResolver {
+	r := NewGitHubSkillResolver()
+	if token != "" {
+		r.token = token
+	}
+	return r
+}
+
 func (r *GitHubSkillResolver) ResolverName() string { return "github" }
 
 func (r *GitHubSkillResolver) Resolve(ctx context.Context, refs []api.SkillReference, opts ResolveOpts) (*ResolveResult, error) {

--- a/pkg/agent/github_skill_resolver.go
+++ b/pkg/agent/github_skill_resolver.go
@@ -17,6 +17,7 @@ package agent
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -130,36 +131,38 @@ func (r *GitHubSkillResolver) Resolve(ctx context.Context, refs []api.SkillRefer
 	return result, nil
 }
 
-// resolutionCacheKey returns a canonical cache key for a skill ref that
-// excludes the ?token= credential selector. Two refs that point to the same
-// content but use different token names share one cache entry; the fetched
-// file content is identical regardless of which credential was used.
-func resolutionCacheKey(ghRef *GitHubSkillRef) string {
-	return fmt.Sprintf("gh://%s/%s/%s@%s", ghRef.Owner, ghRef.Repo, ghRef.SkillPath, ghRef.Ref)
+// resolutionCacheKey returns a canonical cache key for a skill ref.
+// A SHA-256 hash of the token is included so that different credentials
+// produce separate cache entries, preventing cross-credential cache sharing
+// of private content. The raw token is never used as a key value.
+func resolutionCacheKey(ghRef *GitHubSkillRef, token string) string {
+	var tokenSuffix string
+	if token != "" {
+		h := sha256.Sum256([]byte(token))
+		tokenSuffix = "#" + hex.EncodeToString(h[:8]) // 16-char hex prefix of hash
+	}
+	return fmt.Sprintf("gh://%s/%s/%s@%s%s",
+		ghRef.Owner, ghRef.Repo, ghRef.SkillPath, ghRef.Ref, tokenSuffix)
 }
 
 func (r *GitHubSkillResolver) resolveOne(ctx context.Context, ghRef *GitHubSkillRef, ref api.SkillReference) (*ResolvedSkill, error) {
-	// Check resolution cache first using a key that excludes the ?token= param
-	// so that multiple token names for the same skill share one cache entry.
-	cacheKey := resolutionCacheKey(ghRef)
+	// Resolve credential first — before cache check.
+	// This ensures: (1) missing credentials fail immediately, (2) the token
+	// hash is available for the cache key, isolating cache entries per credential.
+	token, err := r.tokenForRef(ghRef)
+	if err != nil {
+		return nil, err
+	}
+
+	cacheKey := resolutionCacheKey(ghRef, token)
 	if r.resolutionCache != nil {
 		if cached, ok := r.resolutionCache.Get(cacheKey); ok {
-			// Validate credential even on cache hit — callers without the
-			// named secret must not receive cached private skill content.
-			if _, err := r.tokenForRef(ghRef); err != nil {
-				return nil, err
-			}
+			// No separate tokenForRef needed here — token already validated above.
 			util.Debugf("github: resolution cache hit for %s", ref.URI)
 			result := cached
 			result.As = ref.As
 			return &result, nil
 		}
-	}
-
-	// Resolve the per-URI token once; all API calls for this ref use it.
-	token, err := r.tokenForRef(ghRef)
-	if err != nil {
-		return nil, err
 	}
 
 	commitSHA, err := r.resolveCommitSHA(ctx, ghRef, token)
@@ -222,7 +225,7 @@ func (r *GitHubSkillResolver) resolveOne(ctx context.Context, ghRef *GitHubSkill
 		Files:   resolvedFiles,
 	}
 
-	// Store in resolution cache under the token-agnostic key.
+	// Store in resolution cache under the token-hashed key.
 	if r.resolutionCache != nil {
 		r.resolutionCache.Put(cacheKey, *resolved)
 	}

--- a/pkg/agent/github_skill_resolver.go
+++ b/pkg/agent/github_skill_resolver.go
@@ -74,22 +74,15 @@ func NewGitHubSkillResolver() *GitHubSkillResolver {
 	}
 }
 
-// NewGitHubSkillResolverWithToken constructs a GitHubSkillResolver with an
-// explicit default token. If token is empty, falls back to the GITHUB_TOKEN
-// environment variable (same as NewGitHubSkillResolver).
-func NewGitHubSkillResolverWithToken(token string) *GitHubSkillResolver {
-	r := NewGitHubSkillResolver()
-	if token != "" {
-		r.token = token
-	}
-	return r
-}
-
 // NewGitHubSkillResolverWithCredentials constructs a resolver with an explicit
 // default token and a named-credential map for per-URI lookup.
+// If defaultToken is empty, falls back to the GITHUB_TOKEN environment variable.
 // provisionCredentials maps secret name → value; may be nil.
 func NewGitHubSkillResolverWithCredentials(defaultToken string, provisionCredentials map[string]string) *GitHubSkillResolver {
-	r := NewGitHubSkillResolverWithToken(defaultToken)
+	r := NewGitHubSkillResolver()
+	if defaultToken != "" {
+		r.token = defaultToken
+	}
 	r.provisionCredentials = provisionCredentials
 	return r
 }
@@ -99,15 +92,15 @@ func NewGitHubSkillResolverWithCredentials(defaultToken string, provisionCredent
 // If the named secret is not found, it returns an error.
 // If no TokenSecretName is set, it returns the default token.
 func (r *GitHubSkillResolver) tokenForRef(ref *GitHubSkillRef) (string, error) {
-	if ref.TokenSecretName != "" {
-		if r.provisionCredentials != nil {
-			if val, ok := r.provisionCredentials[ref.TokenSecretName]; ok && val != "" {
-				return val, nil
-			}
-		}
-		return "", fmt.Errorf("secret %q not found in ProvisionCredentials; ensure it is set at project scope", ref.TokenSecretName)
+	if ref.TokenSecretName == "" {
+		return r.token, nil
 	}
-	return r.token, nil
+	// In Go, reading from a nil map is safe and returns "". Both nil map and
+	// missing/empty key produce the same error: the secret is unavailable.
+	if val := r.provisionCredentials[ref.TokenSecretName]; val != "" {
+		return val, nil
+	}
+	return "", fmt.Errorf("secret %q not found in ProvisionCredentials; ensure it is set at project scope", ref.TokenSecretName)
 }
 
 func (r *GitHubSkillResolver) ResolverName() string { return "github" }
@@ -137,10 +130,25 @@ func (r *GitHubSkillResolver) Resolve(ctx context.Context, refs []api.SkillRefer
 	return result, nil
 }
 
+// resolutionCacheKey returns a canonical cache key for a skill ref that
+// excludes the ?token= credential selector. Two refs that point to the same
+// content but use different token names share one cache entry; the fetched
+// file content is identical regardless of which credential was used.
+func resolutionCacheKey(ghRef *GitHubSkillRef) string {
+	return fmt.Sprintf("gh://%s/%s/%s@%s", ghRef.Owner, ghRef.Repo, ghRef.SkillPath, ghRef.Ref)
+}
+
 func (r *GitHubSkillResolver) resolveOne(ctx context.Context, ghRef *GitHubSkillRef, ref api.SkillReference) (*ResolvedSkill, error) {
-	// Check resolution cache first
+	// Check resolution cache first using a key that excludes the ?token= param
+	// so that multiple token names for the same skill share one cache entry.
+	cacheKey := resolutionCacheKey(ghRef)
 	if r.resolutionCache != nil {
-		if cached, ok := r.resolutionCache.Get(ref.URI); ok {
+		if cached, ok := r.resolutionCache.Get(cacheKey); ok {
+			// Validate credential even on cache hit — callers without the
+			// named secret must not receive cached private skill content.
+			if _, err := r.tokenForRef(ghRef); err != nil {
+				return nil, err
+			}
 			util.Debugf("github: resolution cache hit for %s", ref.URI)
 			result := cached
 			result.As = ref.As
@@ -214,9 +222,9 @@ func (r *GitHubSkillResolver) resolveOne(ctx context.Context, ghRef *GitHubSkill
 		Files:   resolvedFiles,
 	}
 
-	// Store in resolution cache
+	// Store in resolution cache under the token-agnostic key.
 	if r.resolutionCache != nil {
-		r.resolutionCache.Put(ref.URI, *resolved)
+		r.resolutionCache.Put(cacheKey, *resolved)
 	}
 
 	return resolved, nil

--- a/pkg/agent/github_skill_resolver_test.go
+++ b/pkg/agent/github_skill_resolver_test.go
@@ -813,6 +813,92 @@ func TestGitHubSkillResolver_CacheHitCredentialCheck(t *testing.T) {
 	})
 }
 
+func TestGitHubSkillResolver_CrossCredentialCacheIsolation(t *testing.T) {
+	// Verify that two resolvers with different credentials for the same URI
+	// do NOT share a cache entry. This prevents cross-credential information
+	// disclosure where a lower-privilege token would receive cached content
+	// fetched by a higher-privilege token.
+	server, mux := newTestGitHubServer(t)
+	apiCalls := 0
+
+	mux.HandleFunc("/repos/owner/repo/commits/HEAD", func(w http.ResponseWriter, _ *http.Request) {
+		apiCalls++
+		_, _ = w.Write([]byte(testCommitSHA))
+	})
+	mux.HandleFunc("/repos/owner/repo/contents/skills/my-skill", func(w http.ResponseWriter, _ *http.Request) {
+		apiCalls++
+		_ = json.NewEncoder(w).Encode([]githubContentEntry{
+			{Name: "SKILL.md", Path: "skills/my-skill/SKILL.md", Type: "file", Size: 5},
+		})
+	})
+	mux.HandleFunc("/raw/owner/repo/"+testCommitSHA+"/skills/my-skill/SKILL.md", func(w http.ResponseWriter, _ *http.Request) {
+		apiCalls++
+		_, _ = w.Write([]byte("hello"))
+	})
+
+	// Use a shared cache to demonstrate isolation.
+	cache, err := NewGitHubResolutionCache(t.TempDir(), 5*time.Minute)
+	if err != nil {
+		t.Fatalf("cache creation failed: %v", err)
+	}
+
+	// Resolver A uses token "token-alpha".
+	resolverA := &GitHubSkillResolver{
+		httpClient:      server.Client(),
+		token:           "token-alpha",
+		apiBase:         server.URL,
+		rawBase:         server.URL + "/raw",
+		resolutionCache: cache,
+	}
+
+	// Resolver B uses a different token "token-beta" but requests the same URI.
+	resolverB := &GitHubSkillResolver{
+		httpClient:      server.Client(),
+		token:           "token-beta",
+		apiBase:         server.URL,
+		rawBase:         server.URL + "/raw",
+		resolutionCache: cache,
+	}
+
+	uri := []api.SkillReference{{URI: "gh://owner/repo/my-skill"}}
+
+	// First call via resolver A — populates cache under alpha's key.
+	resultA, err := resolverA.Resolve(context.Background(), uri, ResolveOpts{})
+	if err != nil {
+		t.Fatalf("resolverA Resolve failed: %v", err)
+	}
+	if len(resultA.Errors) != 0 {
+		t.Fatalf("resolverA: unexpected errors: %v", resultA.Errors)
+	}
+	callsAfterA := apiCalls
+
+	// Second call via resolver B — must NOT hit resolver A's cache entry.
+	// Because tokens differ, the cache keys differ, so a fresh API call is required.
+	resultB, err := resolverB.Resolve(context.Background(), uri, ResolveOpts{})
+	if err != nil {
+		t.Fatalf("resolverB Resolve failed: %v", err)
+	}
+	if len(resultB.Errors) != 0 {
+		t.Fatalf("resolverB: unexpected errors: %v", resultB.Errors)
+	}
+	if apiCalls == callsAfterA {
+		t.Errorf("expected resolver B to make new API calls (different token = different cache key), but no additional calls were made — cross-credential cache sharing detected")
+	}
+
+	// Third call via resolver B — now should hit resolver B's own cache entry.
+	callsAfterB := apiCalls
+	resultB2, err := resolverB.Resolve(context.Background(), uri, ResolveOpts{})
+	if err != nil {
+		t.Fatalf("resolverB second Resolve failed: %v", err)
+	}
+	if len(resultB2.Errors) != 0 {
+		t.Fatalf("resolverB second call: unexpected errors: %v", resultB2.Errors)
+	}
+	if apiCalls != callsAfterB {
+		t.Errorf("expected resolver B's second call to hit its own cache entry, got %d additional API calls", apiCalls-callsAfterB)
+	}
+}
+
 type stubSkillResolver struct {
 	result *ResolveResult
 }

--- a/pkg/agent/github_skill_resolver_test.go
+++ b/pkg/agent/github_skill_resolver_test.go
@@ -575,6 +575,141 @@ func TestRetryDelay(t *testing.T) {
 	})
 }
 
+func TestGitHubSkillResolver_TokenForRef(t *testing.T) {
+	t.Run("named secret present returns correct value", func(t *testing.T) {
+		r := &GitHubSkillResolver{
+			token: "default-token",
+			provisionCredentials: map[string]string{
+				"MY_SECRET": "secret-value",
+			},
+		}
+		ref := &GitHubSkillRef{TokenSecretName: "MY_SECRET"}
+		got, err := r.tokenForRef(ref)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "secret-value" {
+			t.Errorf("expected secret-value, got %q", got)
+		}
+	})
+
+	t.Run("named secret missing returns error", func(t *testing.T) {
+		r := &GitHubSkillResolver{
+			token:                "default-token",
+			provisionCredentials: map[string]string{},
+		}
+		ref := &GitHubSkillRef{TokenSecretName: "MISSING_SECRET"}
+		_, err := r.tokenForRef(ref)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "MISSING_SECRET") {
+			t.Errorf("error should mention secret name, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "ProvisionCredentials") {
+			t.Errorf("error should mention ProvisionCredentials, got: %v", err)
+		}
+	})
+
+	t.Run("named secret with nil provisionCredentials returns error", func(t *testing.T) {
+		r := &GitHubSkillResolver{
+			token:                "default-token",
+			provisionCredentials: nil,
+		}
+		ref := &GitHubSkillRef{TokenSecretName: "MY_SECRET"}
+		_, err := r.tokenForRef(ref)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("empty TokenSecretName returns default token", func(t *testing.T) {
+		r := &GitHubSkillResolver{
+			token: "default-token",
+			provisionCredentials: map[string]string{
+				"OTHER_SECRET": "other-value",
+			},
+		}
+		ref := &GitHubSkillRef{TokenSecretName: ""}
+		got, err := r.tokenForRef(ref)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "default-token" {
+			t.Errorf("expected default-token, got %q", got)
+		}
+	})
+}
+
+func TestGitHubSkillResolver_PerURIToken(t *testing.T) {
+	server, mux := newTestGitHubServer(t)
+
+	var gotAuth string
+	mux.HandleFunc("/repos/owner/repo/commits/HEAD", func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(testCommitSHA))
+	})
+	mux.HandleFunc("/repos/owner/repo/contents/skills/my-skill", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]githubContentEntry{
+			{Name: "SKILL.md", Path: "skills/my-skill/SKILL.md", Type: "file", Size: 5},
+		})
+	})
+	mux.HandleFunc("/raw/owner/repo/"+testCommitSHA+"/skills/my-skill/SKILL.md", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("hello"))
+	})
+
+	resolver := &GitHubSkillResolver{
+		httpClient: server.Client(),
+		token:      "default-token",
+		apiBase:    server.URL,
+		rawBase:    server.URL + "/raw",
+		provisionCredentials: map[string]string{
+			"SKILLS_TOKEN": "per-uri-token",
+		},
+	}
+
+	result, err := resolver.Resolve(context.Background(), []api.SkillReference{
+		{URI: "gh://owner/repo/my-skill?token=SKILLS_TOKEN"},
+	}, ResolveOpts{})
+
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if len(result.Errors) != 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	if gotAuth != "Bearer per-uri-token" {
+		t.Errorf("expected per-uri-token to be used, got Authorization: %q", gotAuth)
+	}
+}
+
+func TestGitHubSkillResolver_MissingNamedSecret(t *testing.T) {
+	resolver := &GitHubSkillResolver{
+		httpClient:           http.DefaultClient,
+		token:                "default-token",
+		apiBase:              "http://unused",
+		rawBase:              "http://unused",
+		provisionCredentials: map[string]string{},
+	}
+
+	result, err := resolver.Resolve(context.Background(), []api.SkillReference{
+		{URI: "gh://owner/repo/my-skill?token=MISSING_SECRET"},
+	}, ResolveOpts{})
+
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if len(result.Errors) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(result.Errors), result.Errors)
+	}
+	if result.Errors[0].Code != "resolve_failed" {
+		t.Errorf("expected code resolve_failed, got %s", result.Errors[0].Code)
+	}
+	if !strings.Contains(result.Errors[0].Message, "MISSING_SECRET") {
+		t.Errorf("error should mention secret name, got: %s", result.Errors[0].Message)
+	}
+}
+
 type stubSkillResolver struct {
 	result *ResolveResult
 }

--- a/pkg/agent/github_skill_resolver_test.go
+++ b/pkg/agent/github_skill_resolver_test.go
@@ -710,6 +710,109 @@ func TestGitHubSkillResolver_MissingNamedSecret(t *testing.T) {
 	}
 }
 
+func TestGitHubSkillResolver_CacheHitCredentialCheck(t *testing.T) {
+	server, mux := newTestGitHubServer(t)
+	apiCalls := 0
+
+	mux.HandleFunc("/repos/owner/repo/commits/HEAD", func(w http.ResponseWriter, _ *http.Request) {
+		apiCalls++
+		_, _ = w.Write([]byte(testCommitSHA))
+	})
+	mux.HandleFunc("/repos/owner/repo/contents/skills/my-skill", func(w http.ResponseWriter, _ *http.Request) {
+		apiCalls++
+		_ = json.NewEncoder(w).Encode([]githubContentEntry{
+			{Name: "SKILL.md", Path: "skills/my-skill/SKILL.md", Type: "file", Size: 5},
+		})
+	})
+	mux.HandleFunc("/raw/owner/repo/"+testCommitSHA+"/skills/my-skill/SKILL.md", func(w http.ResponseWriter, _ *http.Request) {
+		apiCalls++
+		_, _ = w.Write([]byte("hello"))
+	})
+
+	cache, err := NewGitHubResolutionCache(t.TempDir(), 5*time.Minute)
+	if err != nil {
+		t.Fatalf("cache creation failed: %v", err)
+	}
+
+	t.Run("cache hit with valid credential succeeds without API call", func(t *testing.T) {
+		apiCalls = 0
+		resolver := &GitHubSkillResolver{
+			httpClient: server.Client(),
+			token:      "default-token",
+			apiBase:    server.URL,
+			rawBase:    server.URL + "/raw",
+			provisionCredentials: map[string]string{
+				"SKILLS_TOKEN": "valid-secret-value",
+			},
+			resolutionCache: cache,
+		}
+
+		// First call — populates cache
+		result1, err := resolver.Resolve(context.Background(), []api.SkillReference{
+			{URI: "gh://owner/repo/my-skill?token=SKILLS_TOKEN"},
+		}, ResolveOpts{})
+		if err != nil {
+			t.Fatalf("first Resolve failed: %v", err)
+		}
+		if len(result1.Errors) != 0 {
+			t.Fatalf("unexpected errors on first call: %v", result1.Errors)
+		}
+		callsAfterFirst := apiCalls
+
+		// Second call with same valid credential — should hit cache, no new API calls
+		result2, err := resolver.Resolve(context.Background(), []api.SkillReference{
+			{URI: "gh://owner/repo/my-skill?token=SKILLS_TOKEN"},
+		}, ResolveOpts{})
+		if err != nil {
+			t.Fatalf("second Resolve failed: %v", err)
+		}
+		if len(result2.Errors) != 0 {
+			t.Fatalf("unexpected errors on cache hit: %v", result2.Errors)
+		}
+		if len(result2.Resolved) != 1 {
+			t.Fatalf("expected 1 resolved skill on cache hit, got %d", len(result2.Resolved))
+		}
+		if apiCalls != callsAfterFirst {
+			t.Errorf("expected no new API calls on cache hit, got %d additional calls", apiCalls-callsAfterFirst)
+		}
+	})
+
+	t.Run("cache hit with missing credential returns error", func(t *testing.T) {
+		apiCallsBefore := apiCalls
+
+		// A resolver that has a populated cache but lacks the named secret
+		resolverNoSecret := &GitHubSkillResolver{
+			httpClient:           server.Client(),
+			token:                "default-token",
+			apiBase:              server.URL,
+			rawBase:              server.URL + "/raw",
+			provisionCredentials: map[string]string{}, // SKILLS_TOKEN not present
+			resolutionCache:      cache,
+		}
+
+		result, err := resolverNoSecret.Resolve(context.Background(), []api.SkillReference{
+			{URI: "gh://owner/repo/my-skill?token=SKILLS_TOKEN"},
+		}, ResolveOpts{})
+		if err != nil {
+			t.Fatalf("Resolve returned unexpected Go error: %v", err)
+		}
+		// Should get a resolve error, not a cache hit success
+		if len(result.Errors) != 1 {
+			t.Fatalf("expected 1 error (credential check on cache hit), got %d errors and %d resolved", len(result.Errors), len(result.Resolved))
+		}
+		if result.Errors[0].Code != "resolve_failed" {
+			t.Errorf("expected code resolve_failed, got %s", result.Errors[0].Code)
+		}
+		if !strings.Contains(result.Errors[0].Message, "SKILLS_TOKEN") {
+			t.Errorf("error should mention secret name, got: %s", result.Errors[0].Message)
+		}
+		// No new API calls should have been made (cache hit path, rejected before fetch)
+		if apiCalls != apiCallsBefore {
+			t.Errorf("expected no new API calls when credential check fails on cache hit, got %d", apiCalls-apiCallsBefore)
+		}
+	})
+}
+
 type stubSkillResolver struct {
 	result *ResolveResult
 }

--- a/pkg/agent/github_uri.go
+++ b/pkg/agent/github_uri.go
@@ -146,6 +146,25 @@ func parseGitHubFullURL(uri string) (*GitHubSkillRef, error) {
 		}
 	}
 
+	// Strip ?token=SECRET_NAME query parameter before path parsing.
+	// If present, validate it and carry it through to the result.
+	// Any other query string (or a malformed ?token=) is an error.
+	var tokenSecretName string
+	if qIdx := strings.Index(rest, "?"); qIdx >= 0 {
+		query := rest[qIdx+1:]
+		rest = rest[:qIdx]
+		if !strings.HasPrefix(query, "token=") {
+			return nil, fmt.Errorf("invalid GitHub URL %q: unsupported query parameter %q; only ?token=SECRET_NAME is supported", uri, query)
+		}
+		tokenSecretName = query[len("token="):]
+		if tokenSecretName == "" {
+			return nil, fmt.Errorf("invalid GitHub URL %q: empty ?token= value", uri)
+		}
+		if !validTokenSecretName.MatchString(tokenSecretName) {
+			return nil, fmt.Errorf("invalid GitHub URL %q: ?token= value %q must match [A-Z][A-Z0-9_]* (uppercase env-var style)", uri, tokenSecretName)
+		}
+	}
+
 	// Expected: owner/repo/tree/ref/path/to/skill-name
 	parts := strings.SplitN(rest, "/", 5)
 	if len(parts) < 5 || parts[2] != "tree" {
@@ -181,11 +200,12 @@ func parseGitHubFullURL(uri string) (*GitHubSkillRef, error) {
 	}
 
 	return &GitHubSkillRef{
-		Owner:     owner,
-		Repo:      repo,
-		SkillName: skillName,
-		Ref:       ref,
-		SkillPath: skillFullPath,
-		Raw:       uri,
+		Owner:           owner,
+		Repo:            repo,
+		SkillName:       skillName,
+		Ref:             ref,
+		SkillPath:       skillFullPath,
+		Raw:             uri,
+		TokenSecretName: tokenSecretName,
 	}, nil
 }

--- a/pkg/agent/github_uri.go
+++ b/pkg/agent/github_uri.go
@@ -22,14 +22,18 @@ import (
 
 var validGitHubComponent = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
+// validTokenSecretName matches uppercase env-var style names: [A-Z][A-Z0-9_]*
+var validTokenSecretName = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
 // GitHubSkillRef is the parsed representation of a GitHub skill URI.
 type GitHubSkillRef struct {
-	Owner     string // GitHub user or organization
-	Repo      string // Repository name
-	SkillName string // Directory name under skills/
-	Ref       string // Branch, tag, or commit SHA; empty = default branch
-	SkillPath string // Full path within repo (default: "skills/{SkillName}")
-	Raw       string // Original URI for error messages
+	Owner           string // GitHub user or organization
+	Repo            string // Repository name
+	SkillName       string // Directory name under skills/
+	Ref             string // Branch, tag, or commit SHA; empty = default branch
+	SkillPath       string // Full path within repo (default: "skills/{SkillName}")
+	Raw             string // Original URI for error messages
+	TokenSecretName string // Secret name from ?token= param; empty = use default credential
 }
 
 // ParseGitHubSkillURI parses a gh:// shorthand or full GitHub URL
@@ -65,6 +69,26 @@ func ParseGitHubSkillURI(uri string) (*GitHubSkillRef, error) {
 func parseGHShorthand(uri string) (*GitHubSkillRef, error) {
 	rest := strings.TrimPrefix(uri, "gh://")
 
+	// Extract ?token=SECRET_NAME query param if present.
+	// The ?token= must come after the @ref (if any) and after the path.
+	// Supported: gh://owner/repo/skill[@ref][?token=SECRET_NAME]
+	var tokenSecretName string
+	if qIdx := strings.Index(rest, "?"); qIdx >= 0 {
+		query := rest[qIdx+1:]
+		rest = rest[:qIdx]
+		// Only support a single ?token= param; anything else is invalid.
+		if !strings.HasPrefix(query, "token=") {
+			return nil, fmt.Errorf("invalid gh:// URI %q: unsupported query parameter %q; only ?token=SECRET_NAME is supported", uri, query)
+		}
+		tokenSecretName = query[len("token="):]
+		if tokenSecretName == "" {
+			return nil, fmt.Errorf("invalid gh:// URI %q: empty ?token= value", uri)
+		}
+		if !validTokenSecretName.MatchString(tokenSecretName) {
+			return nil, fmt.Errorf("invalid gh:// URI %q: ?token= value %q must match [A-Z][A-Z0-9_]* (uppercase env-var style)", uri, tokenSecretName)
+		}
+	}
+
 	// Split off @ref
 	var ref string
 	if idx := strings.LastIndex(rest, "@"); idx >= 0 {
@@ -77,7 +101,7 @@ func parseGHShorthand(uri string) (*GitHubSkillRef, error) {
 
 	parts := strings.Split(rest, "/")
 	if len(parts) != 3 {
-		return nil, fmt.Errorf("invalid gh:// URI %q: expected gh://owner/repo/skill-name[@ref]", uri)
+		return nil, fmt.Errorf("invalid gh:// URI %q: expected gh://owner/repo/skill-name[@ref][?token=SECRET_NAME]", uri)
 	}
 	for _, p := range parts {
 		if p == "" {
@@ -98,12 +122,13 @@ func parseGHShorthand(uri string) (*GitHubSkillRef, error) {
 	}
 
 	return &GitHubSkillRef{
-		Owner:     parts[0],
-		Repo:      parts[1],
-		SkillName: parts[2],
-		Ref:       ref,
-		SkillPath: "skills/" + parts[2],
-		Raw:       uri,
+		Owner:           parts[0],
+		Repo:            parts[1],
+		SkillName:       parts[2],
+		Ref:             ref,
+		SkillPath:       "skills/" + parts[2],
+		Raw:             uri,
+		TokenSecretName: tokenSecretName,
 	}, nil
 }
 

--- a/pkg/agent/github_uri_test.go
+++ b/pkg/agent/github_uri_test.go
@@ -116,6 +116,57 @@ func TestParseGHShorthand(t *testing.T) {
 				SkillPath: "skills/skill",
 			},
 		},
+		{
+			name: "with ?token= param",
+			uri:  "gh://owner/repo/skill?token=MY_TOKEN",
+			want: &GitHubSkillRef{
+				Owner:           "owner",
+				Repo:            "repo",
+				SkillName:       "skill",
+				Ref:             "",
+				SkillPath:       "skills/skill",
+				TokenSecretName: "MY_TOKEN",
+			},
+		},
+		{
+			name: "with @ref and ?token= param",
+			uri:  "gh://owner/repo/skill@main?token=MY_TOKEN",
+			want: &GitHubSkillRef{
+				Owner:           "owner",
+				Repo:            "repo",
+				SkillName:       "skill",
+				Ref:             "main",
+				SkillPath:       "skills/skill",
+				TokenSecretName: "MY_TOKEN",
+			},
+		},
+		{
+			name: "no ?token= param — TokenSecretName empty",
+			uri:  "gh://owner/repo/skill",
+			want: &GitHubSkillRef{
+				Owner:           "owner",
+				Repo:            "repo",
+				SkillName:       "skill",
+				Ref:             "",
+				SkillPath:       "skills/skill",
+				TokenSecretName: "",
+			},
+		},
+		{
+			name:      "?token= with invalid lowercase name",
+			uri:       "gh://owner/repo/skill?token=invalid-name",
+			wantError: true,
+		},
+		{
+			name:      "?token= with empty value",
+			uri:       "gh://owner/repo/skill?token=",
+			wantError: true,
+		},
+		{
+			name:      "unsupported query parameter",
+			uri:       "gh://owner/repo/skill?foo=bar",
+			wantError: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -144,6 +195,9 @@ func TestParseGHShorthand(t *testing.T) {
 			}
 			if got.SkillPath != tt.want.SkillPath {
 				t.Errorf("SkillPath = %q, want %q", got.SkillPath, tt.want.SkillPath)
+			}
+			if got.TokenSecretName != tt.want.TokenSecretName {
+				t.Errorf("TokenSecretName = %q, want %q", got.TokenSecretName, tt.want.TokenSecretName)
 			}
 			if got.Raw != tt.uri {
 				t.Errorf("Raw = %q, want %q", got.Raw, tt.uri)

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -409,13 +409,23 @@ func mergeSkillRefs(scopes ...[]api.SkillReference) []api.SkillReference {
 				"base_uri", base, "winner", winner.URI, "original", orig.URI)
 		}
 	}
-	result := make([]api.SkillReference, 0, len(seen))
-	for _, ref := range seen {
-		result = append(result, ref)
+	// Build result slice using the already-computed keys from `seen` for the sort
+	// to avoid re-calling skillBaseURI O(n log n) times.
+	type entry struct {
+		base string
+		ref  api.SkillReference
 	}
-	sort.Slice(result, func(i, j int) bool {
-		return skillBaseURI(result[i].URI) < skillBaseURI(result[j].URI)
+	entries := make([]entry, 0, len(seen))
+	for base, ref := range seen {
+		entries = append(entries, entry{base, ref})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].base < entries[j].base
 	})
+	result := make([]api.SkillReference, len(entries))
+	for i, e := range entries {
+		result[i] = e.ref
+	}
 	return result
 }
 

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -35,6 +35,7 @@ import (
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/sync/errgroup"
 )
 
 // HTTPRuntimeBrokerClient is an HTTP-based implementation of RuntimeBrokerClient.
@@ -649,23 +650,40 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 					"agent_id", agent.ID, "error", listErr)
 			}
 		} else if len(projectSecrets) > 0 {
-			req.ProvisionCredentials = make(map[string]string, len(projectSecrets))
-			for _, sm := range projectSecrets {
+			type namedValue struct{ name, value string }
+			fetched := make([]namedValue, len(projectSecrets))
+
+			g, gctx := errgroup.WithContext(ctx)
+			for i, sm := range projectSecrets {
 				if sm.SecretType == store.SecretTypeInternal {
 					continue
 				}
-				sv, getErr := d.secretBackend.Get(ctx, sm.Name, secret.ScopeProject, agent.ProjectID)
-				if getErr != nil {
-					if d.debug {
-						d.log.Warn("buildCreateRequest: failed to get project secret for ProvisionCredentials",
-							"agent_id", agent.ID, "secret_name", sm.Name, "error", getErr)
+				i, sm := i, sm // capture loop vars
+				g.Go(func() error {
+					sv, getErr := d.secretBackend.Get(gctx, sm.Name, secret.ScopeProject, agent.ProjectID)
+					if getErr != nil {
+						if d.debug {
+							d.log.Warn("buildCreateRequest: failed to get project secret for ProvisionCredentials",
+								"agent_id", agent.ID, "secret", sm.Name, "error", getErr)
+						}
+						return nil // don't fail the group for individual secrets
 					}
-				} else if sv != nil && sv.Value != "" {
-					req.ProvisionCredentials[sm.Name] = sv.Value
+					if sv != nil && sv.Value != "" {
+						fetched[i] = namedValue{sm.Name, sv.Value}
+					}
+					return nil
+				})
+			}
+			_ = g.Wait()
+
+			creds := make(map[string]string)
+			for _, nv := range fetched {
+				if nv.name != "" {
+					creds[nv.name] = nv.value
 				}
 			}
-			if len(req.ProvisionCredentials) == 0 {
-				req.ProvisionCredentials = nil
+			if len(creds) > 0 {
+				req.ProvisionCredentials = creds
 			}
 		}
 	}

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"path/filepath"
 	"strings"
 	"time"
@@ -485,20 +486,12 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 	// Clone req.ResolvedEnv to avoid mutating the shared agent.AppliedConfig.Env
 	// map, which is a direct reference and may be read concurrently.
 	if req.ResolvedEnv != nil {
-		clonedEnv := make(map[string]string, len(req.ResolvedEnv))
-		for k, v := range req.ResolvedEnv {
-			clonedEnv[k] = v
-		}
-		req.ResolvedEnv = clonedEnv
+		req.ResolvedEnv = maps.Clone(req.ResolvedEnv)
 	}
-	if agent.AppliedConfig != nil && agent.AppliedConfig.Model != "" {
-		if req.ResolvedEnv == nil {
-			req.ResolvedEnv = make(map[string]string)
-		}
-		if _, ok := req.ResolvedEnv["SCION_MODEL"]; !ok {
-			req.ResolvedEnv["SCION_MODEL"] = agent.AppliedConfig.Model
-		}
+	if req.ResolvedEnv == nil {
+		req.ResolvedEnv = make(map[string]string)
 	}
+	injectModelEnv(req.ResolvedEnv, agent.AppliedConfig)
 
 	// Resolve env vars from Hub storage (user/project/broker scopes) and merge.
 	// Storage env vars fill in keys not already set (with a non-empty value)
@@ -644,19 +637,30 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 
 	// Collect project-scope secrets for provision-time credential resolution.
 	// These are NOT merged into ResolvedEnv and will not appear in the container env.
-	if agent.ProjectID != "" && d.secretBackend != nil {
+	// Skipped for NoAuth agents just as ResolvedSecrets are skipped.
+	if !noAuth && agent.ProjectID != "" && d.secretBackend != nil {
 		projectSecrets, listErr := d.secretBackend.List(ctx, secret.Filter{
 			Scope:   secret.ScopeProject,
 			ScopeID: agent.ProjectID,
 		})
-		if listErr == nil && len(projectSecrets) > 0 {
+		if listErr != nil {
+			if d.debug {
+				d.log.Warn("buildCreateRequest: failed to list project secrets for ProvisionCredentials",
+					"agent_id", agent.ID, "error", listErr)
+			}
+		} else if len(projectSecrets) > 0 {
 			req.ProvisionCredentials = make(map[string]string, len(projectSecrets))
 			for _, sm := range projectSecrets {
 				if sm.SecretType == store.SecretTypeInternal {
 					continue
 				}
 				sv, getErr := d.secretBackend.Get(ctx, sm.Name, secret.ScopeProject, agent.ProjectID)
-				if getErr == nil && sv != nil && sv.Value != "" {
+				if getErr != nil {
+					if d.debug {
+						d.log.Warn("buildCreateRequest: failed to get project secret for ProvisionCredentials",
+							"agent_id", agent.ID, "secret_name", sm.Name, "error", getErr)
+					}
+				} else if sv != nil && sv.Value != "" {
 					req.ProvisionCredentials[sm.Name] = sv.Value
 				}
 			}
@@ -677,6 +681,7 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 			"storageEnvCount", len(envFromStorage),
 			"resolvedSecretsCount", len(req.ResolvedSecrets),
 			"totalResolvedEnvCount", len(req.ResolvedEnv),
+			"provisionCredentialsCount", len(req.ProvisionCredentials),
 		)
 	}
 
@@ -1221,12 +1226,7 @@ func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *sto
 		}
 	}
 
-	// Inject SCION_MODEL from applied config model override
-	if agent.AppliedConfig != nil && agent.AppliedConfig.Model != "" {
-		if _, ok := resolvedEnv["SCION_MODEL"]; !ok {
-			resolvedEnv["SCION_MODEL"] = agent.AppliedConfig.Model
-		}
-	}
+	injectModelEnv(resolvedEnv, agent.AppliedConfig)
 
 	// Merge env vars from Hub storage; storage vars fill in keys not already
 	// set (with a non-empty value) by explicit config env vars.
@@ -1471,12 +1471,7 @@ func (d *HTTPAgentDispatcher) DispatchAgentRestart(ctx context.Context, agent *s
 		resolvedEnv["SCION_HUB_ENDPOINT"] = d.hubEndpoint
 	}
 
-	// Inject SCION_MODEL from applied config model override
-	if agent.AppliedConfig != nil && agent.AppliedConfig.Model != "" {
-		if _, ok := resolvedEnv["SCION_MODEL"]; !ok {
-			resolvedEnv["SCION_MODEL"] = agent.AppliedConfig.Model
-		}
-	}
+	injectModelEnv(resolvedEnv, agent.AppliedConfig)
 
 	if d.tokenGenerator != nil {
 		var additionalScopes []AgentTokenScope
@@ -1652,6 +1647,18 @@ func (d *HTTPAgentDispatcher) deferredCheckPrompt(ctx context.Context, agent *st
 }
 
 // =============================================================================
+// injectModelEnv sets SCION_MODEL in env from the agent's applied config model,
+// if a model is configured and the key is not already present in env.
+// env must be non-nil.
+func injectModelEnv(env map[string]string, cfg *store.AgentAppliedConfig) {
+	if cfg == nil || cfg.Model == "" {
+		return
+	}
+	if _, ok := env["SCION_MODEL"]; !ok {
+		env["SCION_MODEL"] = cfg.Model
+	}
+}
+
 // Cross-node lifecycle dispatch (B4-2)
 // =============================================================================
 

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -642,6 +642,30 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 		}
 	}
 
+	// Collect project-scope secrets for provision-time credential resolution.
+	// These are NOT merged into ResolvedEnv and will not appear in the container env.
+	if agent.ProjectID != "" && d.secretBackend != nil {
+		projectSecrets, listErr := d.secretBackend.List(ctx, secret.Filter{
+			Scope:   secret.ScopeProject,
+			ScopeID: agent.ProjectID,
+		})
+		if listErr == nil && len(projectSecrets) > 0 {
+			req.ProvisionCredentials = make(map[string]string, len(projectSecrets))
+			for _, sm := range projectSecrets {
+				if sm.SecretType == store.SecretTypeInternal {
+					continue
+				}
+				sv, getErr := d.secretBackend.Get(ctx, sm.Name, secret.ScopeProject, agent.ProjectID)
+				if getErr == nil && sv != nil && sv.Value != "" {
+					req.ProvisionCredentials[sm.Name] = sv.Value
+				}
+			}
+			if len(req.ProvisionCredentials) == 0 {
+				req.ProvisionCredentials = nil
+			}
+		}
+	}
+
 	// Log a summary of env resolution sources
 	if d.debug {
 		configEnvCount := 0

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -448,6 +448,12 @@ type RemoteCreateAgentRequest struct {
 	// (e.g. "shared", "per-agent", "worktree-per-agent"). Threaded from the
 	// Hub so the broker can branch dispatch without re-deriving from labels.
 	WorkspaceMode string `json:"workspaceMode,omitempty"`
+
+	// ProvisionCredentials carries project-scope secrets for use by core provision
+	// logic (skill resolution, URI variable substitution, credential helpers).
+	// These are NEVER forwarded to the agent container environment or harness scripts.
+	// Populated by the Hub from project-scope secrets at dispatch time.
+	ProvisionCredentials map[string]string `json:"provisionCredentials,omitempty"`
 }
 
 // ResolvedSecret represents a secret resolved by the Hub for projection into an agent container.

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -755,7 +755,8 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 	if conn := s.resolveHubConnection(r); conn != nil && conn.HubClient != nil {
 		hubResolver := agent.NewHubSkillResolver(conn.HubClient.Skills())
 		router := agent.NewRoutingSkillResolver(hubResolver)
-		ghResolver := agent.NewGitHubSkillResolverWithToken(req.ResolvedEnv["GITHUB_TOKEN"])
+		defaultGHToken := req.ResolvedEnv["GITHUB_TOKEN"]
+		ghResolver := agent.NewGitHubSkillResolverWithCredentials(defaultGHToken, req.ProvisionCredentials)
 		router.Register("gh", ghResolver)
 
 		// GCP resolver uses Hub API for registry alias lookup.

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -755,7 +755,7 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 	if conn := s.resolveHubConnection(r); conn != nil && conn.HubClient != nil {
 		hubResolver := agent.NewHubSkillResolver(conn.HubClient.Skills())
 		router := agent.NewRoutingSkillResolver(hubResolver)
-		ghResolver := agent.NewGitHubSkillResolver()
+		ghResolver := agent.NewGitHubSkillResolverWithToken(req.ResolvedEnv["GITHUB_TOKEN"])
 		router.Register("gh", ghResolver)
 
 		// GCP resolver uses Hub API for registry alias lookup.

--- a/pkg/runtimebroker/types.go
+++ b/pkg/runtimebroker/types.go
@@ -328,6 +328,12 @@ type CreateAgentRequest struct {
 	// (e.g. "shared", "per-agent", "worktree-per-agent"). Threaded from the
 	// Hub so the broker can branch dispatch without re-deriving from labels.
 	WorkspaceMode string `json:"workspaceMode,omitempty"`
+
+	// ProvisionCredentials carries project-scope secrets for use by core provision
+	// logic (skill resolution, URI variable substitution, credential helpers).
+	// These are NEVER forwarded to the agent container environment or harness scripts.
+	// Populated by the Hub from project-scope secrets at dispatch time.
+	ProvisionCredentials map[string]string `json:"provisionCredentials,omitempty"`
 }
 
 // UnmarshalJSON implements custom unmarshaling to support legacy grove fields.


### PR DESCRIPTION
## Summary
Extends Injected Skills to fetch skill content from private GitHub repos via a gh:// URI scheme, using the project's configured GitHub App token or a named project secret.

## Changes
- Phase 1: default credential injection (project GITHUB_TOKEN wired into resolver)
- Phase 2: ProvisionCredentials channel + gh://...?token=SECRET_NAME for per-URI credential selection; credentials never reach container env or cache keys by value

Design doc: `.design/project-skills-gh-scheme.md`