### PR TITLE
fix: don't silently mark notification dispatched when agent has no RuntimeBrokerID

### DIFF
--- a/pkg/hub/notifications.go
+++ b/pkg/hub/notifications.go
@@ -348,11 +348,12 @@ func (nd *NotificationDispatcher) dispatchToAgent(ctx context.Context, sub *stor
 	}
 
 	if subscriber.RuntimeBrokerID == "" {
-		nd.log.Warn("Subscriber agent has no runtime broker, skipping dispatch",
-			"subscriberID", sub.SubscriberID)
-		if err := nd.store.MarkNotificationDispatched(ctx, notif.ID); err != nil {
-			nd.log.Error("Failed to mark notification dispatched", "notificationID", notif.ID, "error", err)
-		}
+		nd.log.Error("Subscriber agent has no runtime broker; notification NOT dispatched",
+			"subscriberID", sub.SubscriberID, "notificationID", notif.ID)
+		// Do NOT mark as dispatched — the notification was never delivered.
+		// Leaving it undelivered preserves the record and makes the failure
+		// explicit; a future retry mechanism can sweep for undelivered
+		// notifications and redeliver them once a broker is assigned.
 		return
 	}
 

--- a/pkg/hub/notifications.go
+++ b/pkg/hub/notifications.go
@@ -338,12 +338,12 @@ func (nd *NotificationDispatcher) dispatchToAgent(ctx context.Context, sub *stor
 
 	dispatcher := nd.getDispatcher()
 	if dispatcher == nil {
-		nd.log.Warn("No dispatcher available, skipping notification dispatch",
-			"subscriberID", sub.SubscriberID)
-		// Mark dispatched anyway (best-effort)
-		if err := nd.store.MarkNotificationDispatched(ctx, notif.ID); err != nil {
-			nd.log.Error("Failed to mark notification dispatched", "notificationID", notif.ID, "error", err)
-		}
+		nd.log.Error("No dispatcher available; notification NOT dispatched",
+			"subscriberID", sub.SubscriberID, "notificationID", notif.ID)
+		// Do NOT mark as dispatched — the notification was never delivered.
+		// Leaving it undelivered preserves the record and makes the failure
+		// explicit; a future retry mechanism can sweep for undelivered
+		// notifications and redeliver them once a dispatcher is available.
 		return
 	}
 

--- a/pkg/hub/notifications_test.go
+++ b/pkg/hub/notifications_test.go
@@ -606,11 +606,12 @@ func TestNotificationDispatcher_NilDispatcher(t *testing.T) {
 	// No dispatch calls since dispatcher is nil
 	assert.Empty(t, env.dispatcher.getCalls())
 
-	// Notification should be stored and marked dispatched (best-effort)
+	// Notification should be stored but NOT marked dispatched — the notification
+	// was never delivered so falsely marking it dispatched would silently lose it.
 	notifs, err := env.store.GetNotifications(context.Background(), store.SubscriberTypeAgent, env.subscriber.Slug, false)
 	require.NoError(t, err)
 	assert.Len(t, notifs, 1)
-	assert.True(t, notifs[0].Dispatched)
+	assert.False(t, notifs[0].Dispatched, "notification must not be marked dispatched when no dispatcher is available")
 }
 
 func TestNotificationDispatcher_CaseInsensitiveStatus(t *testing.T) {

--- a/pkg/hub/notifications_test.go
+++ b/pkg/hub/notifications_test.go
@@ -407,11 +407,12 @@ func TestNotificationDispatcher_SubscriberNoBroker(t *testing.T) {
 	// No DispatchAgentMessage call
 	assert.Empty(t, env.dispatcher.getCalls())
 
-	// Notification should be stored and marked dispatched (best-effort)
+	// Notification should be stored but NOT marked dispatched — the notification
+	// was never delivered so falsely marking it dispatched would silently lose it.
 	notifs, err := env.store.GetNotifications(context.Background(), store.SubscriberTypeAgent, env.subscriber.Slug, false)
 	require.NoError(t, err)
 	assert.Len(t, notifs, 1)
-	assert.True(t, notifs[0].Dispatched)
+	assert.False(t, notifs[0].Dispatched, "notification must not be marked dispatched when agent has no RuntimeBrokerID")
 }
 
 func TestNotificationDispatcher_DispatchFailure(t *testing.T) {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -991,6 +991,9 @@ type NotificationStore interface {
 	AcknowledgeAllNotifications(ctx context.Context, subscriberType, subscriberID string) error
 
 	// MarkNotificationDispatched marks a notification as dispatched.
+	// Call this only after delivery was at least attempted (success or failure).
+	// Do NOT call it when delivery was skipped entirely (e.g. no broker, no
+	// dispatcher) — that would silently lose the notification.
 	// Returns ErrNotFound if the notification doesn't exist.
 	MarkNotificationDispatched(ctx context.Context, id string) error
 


### PR DESCRIPTION
Root cause: dispatchToAgent called MarkNotificationDispatched in two skip-without-delivery paths (RuntimeBrokerID empty AND dispatcher nil), silently losing notifications.

Fix: removed MarkNotificationDispatched from both paths so notifications are left Dispatched=false, making failure explicit and preservable for future retry. Added a doc-comment to store.MarkNotificationDispatched warning it must only be called after attempted delivery. Updated SubscriberNoBroker and NilDispatcher tests to assert Dispatched=false.

Files: pkg/hub/notifications.go, pkg/hub/notifications_test.go, pkg/store/store.go

Test plan: go test ./pkg/hub/... ./pkg/store/... - reviewer-approved (notif-190-rev), all findings addressed