### PR TITLE
fix: graceful raw/base64 fallback in all four secret-write handlers

### DIFF
--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -499,7 +499,7 @@ type ListSecretsResponse struct {
 
 type SetSecretRequest struct {
 	Value         string `json:"value"`
-	Encoding      string `json:"encoding,omitempty"`      // "base64" (default, value is base64-encoded) or "raw" (value is literal text)
+	Encoding      string `json:"encoding,omitempty"` // "base64" (default, value is base64-encoded) or "raw" (value is literal text)
 	Scope         string `json:"scope,omitempty"`
 	ScopeID       string `json:"scopeId,omitempty"`
 	Description   string `json:"description,omitempty"`

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -732,8 +732,10 @@ func (s *Server) setSecret(w http.ResponseWriter, r *http.Request, key string) {
 
 	decoded, err := base64.StdEncoding.DecodeString(req.Value)
 	if err != nil {
-		BadRequest(w, "value must be base64-encoded")
-		return
+		// Value is not base64-encoded — treat as raw text.
+		// This makes the endpoint work for both the CLI (which sends base64)
+		// and the web UI or any other caller that sends raw text.
+		decoded = []byte(req.Value)
 	}
 
 	// Validate and default secret type
@@ -946,8 +948,10 @@ func (s *Server) handleAgentSecrets(w http.ResponseWriter, r *http.Request, agen
 
 	decoded, err := base64.StdEncoding.DecodeString(req.Value)
 	if err != nil {
-		BadRequest(w, "value must be base64-encoded")
-		return
+		// Value is not base64-encoded — treat as raw text.
+		// This makes the endpoint work for both the CLI (which sends base64)
+		// and the web UI or any other caller that sends raw text.
+		decoded = []byte(req.Value)
 	}
 
 	// Validate and default secret type.
@@ -1438,8 +1442,10 @@ func (s *Server) handleProjectSecretByKey(w http.ResponseWriter, r *http.Request
 		}
 		decoded, err := base64.StdEncoding.DecodeString(req.Value)
 		if err != nil {
-			BadRequest(w, "value must be base64-encoded")
-			return
+			// Value is not base64-encoded — treat as raw text.
+			// This makes the endpoint work for both the CLI (which sends base64)
+			// and the web UI or any other caller that sends raw text.
+			decoded = []byte(req.Value)
 		}
 		secretType := req.Type
 		if secretType == "" {
@@ -2096,8 +2102,10 @@ func (s *Server) handleBrokerSecretByKey(w http.ResponseWriter, r *http.Request,
 		}
 		decoded, err := base64.StdEncoding.DecodeString(req.Value)
 		if err != nil {
-			BadRequest(w, "value must be base64-encoded")
-			return
+			// Value is not base64-encoded — treat as raw text.
+			// This makes the endpoint work for both the CLI (which sends base64)
+			// and the web UI or any other caller that sends raw text.
+			decoded = []byte(req.Value)
 		}
 		secretType := req.Type
 		if secretType == "" {

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -499,6 +499,7 @@ type ListSecretsResponse struct {
 
 type SetSecretRequest struct {
 	Value         string `json:"value"`
+	Encoding      string `json:"encoding,omitempty"`      // "base64" (default, value is base64-encoded) or "raw" (value is literal text)
 	Scope         string `json:"scope,omitempty"`
 	ScopeID       string `json:"scopeId,omitempty"`
 	Description   string `json:"description,omitempty"`
@@ -730,12 +731,18 @@ func (s *Server) setSecret(w http.ResponseWriter, r *http.Request, key string) {
 		return
 	}
 
-	decoded, err := base64.StdEncoding.DecodeString(req.Value)
-	if err != nil {
-		// Value is not base64-encoded — treat as raw text.
-		// This makes the endpoint work for both the CLI (which sends base64)
-		// and the web UI or any other caller that sends raw text.
+	var decoded []byte
+	if req.Encoding == "raw" {
+		// Caller explicitly opted in to raw text — store the value as-is.
 		decoded = []byte(req.Value)
+	} else {
+		// Default: value must be base64-encoded (matches CLI behaviour).
+		var decErr error
+		decoded, decErr = base64.StdEncoding.DecodeString(req.Value)
+		if decErr != nil {
+			BadRequest(w, "value must be base64-encoded")
+			return
+		}
 	}
 
 	// Validate and default secret type
@@ -866,10 +873,11 @@ func (s *Server) deleteSecret(w http.ResponseWriter, r *http.Request, key string
 
 // AgentSetSecretRequest is the request body for agent-initiated secret creation.
 type AgentSetSecretRequest struct {
-	Value  string `json:"value"`            // Base64-encoded secret value
-	Type   string `json:"type,omitempty"`   // environment (default), variable, file
-	Target string `json:"target,omitempty"` // Injection target path
-	Force  bool   `json:"force,omitempty"`  // Overwrite existing secret
+	Value    string `json:"value"`              // Secret value (base64-encoded by default; use Encoding:"raw" for literal text)
+	Encoding string `json:"encoding,omitempty"` // "base64" (default) or "raw" (value is literal text, no decoding)
+	Type     string `json:"type,omitempty"`     // environment (default), variable, file
+	Target   string `json:"target,omitempty"`   // Injection target path
+	Force    bool   `json:"force,omitempty"`    // Overwrite existing secret
 }
 
 // AgentSetSecretResponse is returned on successful agent secret creation.
@@ -946,12 +954,18 @@ func (s *Server) handleAgentSecrets(w http.ResponseWriter, r *http.Request, agen
 		return
 	}
 
-	decoded, err := base64.StdEncoding.DecodeString(req.Value)
-	if err != nil {
-		// Value is not base64-encoded — treat as raw text.
-		// This makes the endpoint work for both the CLI (which sends base64)
-		// and the web UI or any other caller that sends raw text.
+	var decoded []byte
+	if req.Encoding == "raw" {
+		// Caller explicitly opted in to raw text — store the value as-is.
 		decoded = []byte(req.Value)
+	} else {
+		// Default: value must be base64-encoded (matches CLI behaviour).
+		var decErr error
+		decoded, decErr = base64.StdEncoding.DecodeString(req.Value)
+		if decErr != nil {
+			BadRequest(w, "value must be base64-encoded")
+			return
+		}
 	}
 
 	// Validate and default secret type.
@@ -1440,12 +1454,18 @@ func (s *Server) handleProjectSecretByKey(w http.ResponseWriter, r *http.Request
 			ValidationError(w, "value is required", nil)
 			return
 		}
-		decoded, err := base64.StdEncoding.DecodeString(req.Value)
-		if err != nil {
-			// Value is not base64-encoded — treat as raw text.
-			// This makes the endpoint work for both the CLI (which sends base64)
-			// and the web UI or any other caller that sends raw text.
+		var decoded []byte
+		if req.Encoding == "raw" {
+			// Caller explicitly opted in to raw text — store the value as-is.
 			decoded = []byte(req.Value)
+		} else {
+			// Default: value must be base64-encoded (matches CLI behaviour).
+			var decErr error
+			decoded, decErr = base64.StdEncoding.DecodeString(req.Value)
+			if decErr != nil {
+				BadRequest(w, "value must be base64-encoded")
+				return
+			}
 		}
 		secretType := req.Type
 		if secretType == "" {
@@ -2100,12 +2120,18 @@ func (s *Server) handleBrokerSecretByKey(w http.ResponseWriter, r *http.Request,
 			ValidationError(w, "value is required", nil)
 			return
 		}
-		decoded, err := base64.StdEncoding.DecodeString(req.Value)
-		if err != nil {
-			// Value is not base64-encoded — treat as raw text.
-			// This makes the endpoint work for both the CLI (which sends base64)
-			// and the web UI or any other caller that sends raw text.
+		var decoded []byte
+		if req.Encoding == "raw" {
+			// Caller explicitly opted in to raw text — store the value as-is.
 			decoded = []byte(req.Value)
+		} else {
+			// Default: value must be base64-encoded (matches CLI behaviour).
+			var decErr error
+			decoded, decErr = base64.StdEncoding.DecodeString(req.Value)
+			if decErr != nil {
+				BadRequest(w, "value must be base64-encoded")
+				return
+			}
 		}
 		secretType := req.Type
 		if secretType == "" {

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -731,6 +731,15 @@ func (s *Server) setSecret(w http.ResponseWriter, r *http.Request, key string) {
 		return
 	}
 
+	if req.Encoding != "" && req.Encoding != "base64" && req.Encoding != "raw" {
+		ValidationError(w, "encoding must be \"base64\" or \"raw\"", map[string]interface{}{
+			"field":   "encoding",
+			"value":   req.Encoding,
+			"allowed": []string{"base64", "raw"},
+		})
+		return
+	}
+
 	var decoded []byte
 	if req.Encoding == "raw" {
 		// Caller explicitly opted in to raw text — store the value as-is.
@@ -951,6 +960,15 @@ func (s *Server) handleAgentSecrets(w http.ResponseWriter, r *http.Request, agen
 
 	if req.Value == "" {
 		ValidationError(w, "value is required", nil)
+		return
+	}
+
+	if req.Encoding != "" && req.Encoding != "base64" && req.Encoding != "raw" {
+		ValidationError(w, "encoding must be \"base64\" or \"raw\"", map[string]interface{}{
+			"field":   "encoding",
+			"value":   req.Encoding,
+			"allowed": []string{"base64", "raw"},
+		})
 		return
 	}
 
@@ -1452,6 +1470,14 @@ func (s *Server) handleProjectSecretByKey(w http.ResponseWriter, r *http.Request
 		}
 		if req.Value == "" {
 			ValidationError(w, "value is required", nil)
+			return
+		}
+		if req.Encoding != "" && req.Encoding != "base64" && req.Encoding != "raw" {
+			ValidationError(w, "encoding must be \"base64\" or \"raw\"", map[string]interface{}{
+				"field":   "encoding",
+				"value":   req.Encoding,
+				"allowed": []string{"base64", "raw"},
+			})
 			return
 		}
 		var decoded []byte
@@ -2118,6 +2144,14 @@ func (s *Server) handleBrokerSecretByKey(w http.ResponseWriter, r *http.Request,
 		}
 		if req.Value == "" {
 			ValidationError(w, "value is required", nil)
+			return
+		}
+		if req.Encoding != "" && req.Encoding != "base64" && req.Encoding != "raw" {
+			ValidationError(w, "encoding must be \"base64\" or \"raw\"", map[string]interface{}{
+				"field":   "encoding",
+				"value":   req.Encoding,
+				"allowed": []string{"base64", "raw"},
+			})
 			return
 		}
 		var decoded []byte

--- a/pkg/hub/handlers_secret_base64_test.go
+++ b/pkg/hub/handlers_secret_base64_test.go
@@ -572,6 +572,33 @@ func TestBrokerSecretByKey_SizeLimit_ReturnsJSONError(t *testing.T) {
 	checkJSONError(t, rec.Body.String())
 }
 
+// ============================================================================
+// Unrecognized encoding value (all handlers share the same guard)
+// ============================================================================
+
+// TestSetSecret_UnrecognizedEncoding_Returns400 confirms that an encoding value
+// other than "" / "base64" / "raw" is rejected with a structured JSON 400, so
+// typos like "bas64" or "Base64" are caught rather than silently treated as
+// strict base64.
+func TestSetSecret_UnrecognizedEncoding_Returns400(t *testing.T) {
+	srv, s := testServer(t)
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+
+	body := SetSecretRequest{
+		Value:    base64.StdEncoding.EncodeToString([]byte("value")),
+		Encoding: "bas64", // typo — not a valid encoding value
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/UNK_ENC_KEY", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("unrecognized encoding: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	checkJSONError(t, rec.Body.String())
+	// Confirm the error body mentions the invalid value so callers can self-diagnose.
+	if !strings.Contains(rec.Body.String(), "bas64") {
+		t.Errorf("expected error body to contain the invalid encoding value, got: %s", rec.Body.String())
+	}
+}
+
 // Ensure the agent fixture is usable from this file (it uses a local import
 // via setupAgentSecretTest which references state.PhaseRunning).
 var _ = state.PhaseRunning

--- a/pkg/hub/handlers_secret_base64_test.go
+++ b/pkg/hub/handlers_secret_base64_test.go
@@ -1,0 +1,422 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+// Package hub – tests for the base64/raw-value fallback and structured error
+// responses in all four secret-write handlers:
+//
+//   - setSecret             (PUT /api/v1/secrets/{key})
+//   - handleAgentSecrets    (PUT /api/v1/agents/{id}/secrets/{key})
+//   - handleProjectSecretByKey (PUT /api/v1/projects/{id}/secrets/{key})
+//   - handleBrokerSecretByKey  (PUT /api/v1/runtime-brokers/{id}/secrets/{key})
+//
+// The tests cover three scenarios per handler:
+//  1. Valid base64-encoded value → 200/201 (backward compat, CLI behaviour)
+//  2. Raw/non-base64 value       → 200/201 (new fallback, fixes web-UI regression)
+//  3. Remaining 400 validations  → body is parseable JSON with {"error":…}
+//     (path traversal and file size limit)
+
+package hub
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// checkJSONError asserts that the response body is a valid JSON ErrorResponse.
+func checkJSONError(t *testing.T, body string) {
+	t.Helper()
+	var errResp ErrorResponse
+	if err := json.Unmarshal([]byte(body), &errResp); err != nil {
+		t.Errorf("expected JSON error body, got non-JSON: %s", body)
+		return
+	}
+	if errResp.Error.Code == "" {
+		t.Errorf("expected non-empty error.code in JSON response, got: %s", body)
+	}
+	if errResp.Error.Message == "" {
+		t.Errorf("expected non-empty error.message in JSON response, got: %s", body)
+	}
+}
+
+// ============================================================================
+// setSecret (PUT /api/v1/secrets/{key})
+// ============================================================================
+
+func TestSetSecret_Base64Value_Works(t *testing.T) {
+	srv, s := testServer(t)
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+
+	body := SetSecretRequest{
+		Value: base64.StdEncoding.EncodeToString([]byte("my-plain-value")),
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/BASE64_KEY", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("base64 value: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSetSecret_RawValue_FallsBack(t *testing.T) {
+	srv, s := testServer(t)
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+
+	// Send raw text that is NOT valid base64 (contains punctuation that base64 rejects).
+	body := SetSecretRequest{
+		Value: "raw!value$that=is*not-base64",
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/RAW_KEY", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("raw value fallback: expected 200 (not 400), got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSetSecret_PathTraversal_ReturnsJSONError(t *testing.T) {
+	srv, s := testServer(t)
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+
+	body := SetSecretRequest{
+		Value:  base64.StdEncoding.EncodeToString([]byte("data")),
+		Type:   "file",
+		Target: "/tmp/../etc/passwd",
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/PATH_KEY", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("path traversal: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	checkJSONError(t, rec.Body.String())
+}
+
+func TestSetSecret_SizeLimit_ReturnsJSONError(t *testing.T) {
+	srv, s := testServer(t)
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+
+	// Send a raw value that exceeds 64 KiB as a file type.
+	// The fallback decodes to []byte(req.Value), so len(decoded) == len(rawValue).
+	bigValue := strings.Repeat("x", 64*1024+1)
+	body := SetSecretRequest{
+		Value:  bigValue,
+		Type:   "file",
+		Target: "/tmp/big-file.txt",
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/BIG_KEY", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("size limit: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	checkJSONError(t, rec.Body.String())
+}
+
+// ============================================================================
+// handleAgentSecrets (PUT /api/v1/agents/{id}/secrets/{key})
+// ============================================================================
+
+func TestAgentSecrets_Base64Value_Works_Compat(t *testing.T) {
+	srv, _, agentID, _, agentToken := setupAgentSecretTest(t)
+
+	body := AgentSetSecretRequest{
+		Value: base64.StdEncoding.EncodeToString([]byte("agent-secret")),
+	}
+	rec := doRequestWithAgentToken(t, srv, http.MethodPut,
+		"/api/v1/agents/"+agentID+"/secrets/COMPAT_KEY", body, agentToken)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("base64 compat: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentSecrets_RawValue_FallsBack(t *testing.T) {
+	srv, _, agentID, _, agentToken := setupAgentSecretTest(t)
+
+	body := AgentSetSecretRequest{
+		Value: "raw!value$that=is*not-base64",
+	}
+	rec := doRequestWithAgentToken(t, srv, http.MethodPut,
+		"/api/v1/agents/"+agentID+"/secrets/RAW_AGENT_KEY", body, agentToken)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("raw fallback: expected 201 (not 400), got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentSecrets_PathTraversal_ReturnsJSONError(t *testing.T) {
+	srv, _, agentID, _, agentToken := setupAgentSecretTest(t)
+
+	body := AgentSetSecretRequest{
+		Value:  base64.StdEncoding.EncodeToString([]byte("data")),
+		Type:   "file",
+		Target: "/tmp/../etc/shadow",
+	}
+	rec := doRequestWithAgentToken(t, srv, http.MethodPut,
+		"/api/v1/agents/"+agentID+"/secrets/TRAV_KEY", body, agentToken)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("path traversal: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	checkJSONError(t, rec.Body.String())
+}
+
+func TestAgentSecrets_SizeLimit_ReturnsJSONError(t *testing.T) {
+	srv, _, agentID, _, agentToken := setupAgentSecretTest(t)
+
+	bigValue := strings.Repeat("a", 64*1024+1)
+	body := AgentSetSecretRequest{
+		Value:  bigValue,
+		Type:   "file",
+		Target: "/tmp/bigfile.dat",
+	}
+	rec := doRequestWithAgentToken(t, srv, http.MethodPut,
+		"/api/v1/agents/"+agentID+"/secrets/BIG_AGENT_KEY", body, agentToken)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("size limit: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	checkJSONError(t, rec.Body.String())
+}
+
+// ============================================================================
+// handleProjectSecretByKey (PUT /api/v1/projects/{id}/secrets/{key})
+// ============================================================================
+
+func setupProjectSecretTest(t *testing.T) (*Server, string) {
+	t.Helper()
+	srv, s := testServer(t)
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	ctx := context.Background()
+
+	projectID := tid("proj-secret-b64")
+	project := &store.Project{
+		ID:      projectID,
+		Name:    "Base64 Fallback Project",
+		Slug:    "base64-fallback-project",
+		OwnerID: DevUserID, // makes the test-user (admin) the owner
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+	return srv, projectID
+}
+
+func TestProjectSecretByKey_Base64Value_Works(t *testing.T) {
+	srv, projectID := setupProjectSecretTest(t)
+
+	body := SetSecretRequest{
+		Value: base64.StdEncoding.EncodeToString([]byte("project-value")),
+	}
+	rec := doRequest(t, srv, http.MethodPut,
+		"/api/v1/projects/"+projectID+"/secrets/PROJ_B64_KEY", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("base64 value: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProjectSecretByKey_RawValue_FallsBack(t *testing.T) {
+	srv, projectID := setupProjectSecretTest(t)
+
+	body := SetSecretRequest{
+		Value: "raw!value$that=is*not-base64",
+	}
+	rec := doRequest(t, srv, http.MethodPut,
+		"/api/v1/projects/"+projectID+"/secrets/PROJ_RAW_KEY", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("raw fallback: expected 200 (not 400), got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProjectSecretByKey_PathTraversal_ReturnsJSONError(t *testing.T) {
+	srv, projectID := setupProjectSecretTest(t)
+
+	body := SetSecretRequest{
+		Value:  base64.StdEncoding.EncodeToString([]byte("data")),
+		Type:   "file",
+		Target: "/home/../etc/passwd",
+	}
+	rec := doRequest(t, srv, http.MethodPut,
+		"/api/v1/projects/"+projectID+"/secrets/PROJ_TRAV_KEY", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("path traversal: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	checkJSONError(t, rec.Body.String())
+}
+
+func TestProjectSecretByKey_SizeLimit_ReturnsJSONError(t *testing.T) {
+	srv, projectID := setupProjectSecretTest(t)
+
+	bigValue := strings.Repeat("z", 64*1024+1)
+	body := SetSecretRequest{
+		Value:  bigValue,
+		Type:   "file",
+		Target: "/tmp/bigfile.txt",
+	}
+	rec := doRequest(t, srv, http.MethodPut,
+		"/api/v1/projects/"+projectID+"/secrets/PROJ_BIG_KEY", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("size limit: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	checkJSONError(t, rec.Body.String())
+}
+
+// ============================================================================
+// handleBrokerSecretByKey (PUT /api/v1/runtime-brokers/{id}/secrets/{key})
+// ============================================================================
+
+func setupBrokerSecretTest(t *testing.T) (*Server, string) {
+	t.Helper()
+	srv, s := testServer(t)
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	ctx := context.Background()
+
+	brokerID := tid("broker-secret-b64")
+	broker := &store.RuntimeBroker{
+		ID:      brokerID,
+		Name:    "Base64 Fallback Broker",
+		Slug:    "base64-fallback-broker",
+		Status:  store.BrokerStatusOnline,
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	if err := s.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create broker: %v", err)
+	}
+	return srv, brokerID
+}
+
+func TestBrokerSecretByKey_Base64Value_Works(t *testing.T) {
+	srv, brokerID := setupBrokerSecretTest(t)
+
+	body := SetSecretRequest{
+		Value: base64.StdEncoding.EncodeToString([]byte("broker-value")),
+	}
+	rec := doRequest(t, srv, http.MethodPut,
+		"/api/v1/runtime-brokers/"+brokerID+"/secrets/BROKER_B64_KEY", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("base64 value: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestBrokerSecretByKey_RawValue_FallsBack(t *testing.T) {
+	srv, brokerID := setupBrokerSecretTest(t)
+
+	body := SetSecretRequest{
+		Value: "raw!value$that=is*not-base64",
+	}
+	rec := doRequest(t, srv, http.MethodPut,
+		"/api/v1/runtime-brokers/"+brokerID+"/secrets/BROKER_RAW_KEY", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("raw fallback: expected 200 (not 400), got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestBrokerSecretByKey_PathTraversal_ReturnsJSONError(t *testing.T) {
+	srv, brokerID := setupBrokerSecretTest(t)
+
+	body := SetSecretRequest{
+		Value:  base64.StdEncoding.EncodeToString([]byte("data")),
+		Type:   "file",
+		Target: "/opt/../etc/cron.d/badfile",
+	}
+	rec := doRequest(t, srv, http.MethodPut,
+		"/api/v1/runtime-brokers/"+brokerID+"/secrets/BROKER_TRAV_KEY", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("path traversal: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	checkJSONError(t, rec.Body.String())
+}
+
+func TestBrokerSecretByKey_SizeLimit_ReturnsJSONError(t *testing.T) {
+	srv, brokerID := setupBrokerSecretTest(t)
+
+	bigValue := strings.Repeat("b", 64*1024+1)
+	body := SetSecretRequest{
+		Value:  bigValue,
+		Type:   "file",
+		Target: "/tmp/brokerfile.dat",
+	}
+	rec := doRequest(t, srv, http.MethodPut,
+		"/api/v1/runtime-brokers/"+brokerID+"/secrets/BROKER_BIG_KEY", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("size limit: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	checkJSONError(t, rec.Body.String())
+}
+
+// ============================================================================
+// Cross-cutting: verify raw-value roundtrip stores the correct bytes
+// ============================================================================
+
+// TestSetSecret_RawValueRoundtrip verifies that when a raw (non-base64) value
+// is accepted via the fallback, the stored bytes equal the original raw string —
+// not some corrupted decoding of it.
+func TestSetSecret_RawValueRoundtrip(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	rawValue := "pa$$w0rd!with&special<chars>"
+	body := SetSecretRequest{
+		Value: rawValue,
+		Scope: "user",
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/ROUNDTRIP_KEY", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Retrieve the stored secret via the backend and verify the stored value matches.
+	stored, err := localBackend.Get(ctx, "ROUNDTRIP_KEY", store.ScopeUser, DevUserID)
+	if err != nil {
+		t.Fatalf("failed to retrieve stored secret: %v", err)
+	}
+	if stored.Value != rawValue {
+		t.Errorf("roundtrip: stored value %q != original %q", stored.Value, rawValue)
+	}
+}
+
+// TestAgentSecrets_RawValueRoundtrip performs the same roundtrip check for the
+// agent secret endpoint.
+func TestAgentSecrets_RawValueRoundtrip(t *testing.T) {
+	srv, s, agentID, projectID, agentToken := setupAgentSecretTest(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	rawValue := "agent_raw!value@host"
+	body := AgentSetSecretRequest{
+		Value: rawValue,
+	}
+	rec := doRequestWithAgentToken(t, srv, http.MethodPut,
+		"/api/v1/agents/"+agentID+"/secrets/AGENT_ROUND_KEY", body, agentToken)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	stored, err := localBackend.Get(ctx, "AGENT_ROUND_KEY", store.ScopeProject, projectID)
+	if err != nil {
+		t.Fatalf("failed to retrieve stored secret: %v", err)
+	}
+	if stored.Value != rawValue {
+		t.Errorf("roundtrip: stored value %q != original %q", stored.Value, rawValue)
+	}
+}
+
+// Ensure the agent fixture is usable from this file (it uses a local import
+// via setupAgentSecretTest which references state.PhaseRunning).
+var _ = state.PhaseRunning

--- a/pkg/hub/handlers_secret_base64_test.go
+++ b/pkg/hub/handlers_secret_base64_test.go
@@ -14,19 +14,20 @@
 
 //go:build !no_sqlite
 
-// Package hub – tests for the base64/raw-value fallback and structured error
-// responses in all four secret-write handlers:
+// Package hub – tests for the Encoding field and base64/raw-value handling in
+// all four secret-write handlers:
 //
 //   - setSecret             (PUT /api/v1/secrets/{key})
 //   - handleAgentSecrets    (PUT /api/v1/agents/{id}/secrets/{key})
 //   - handleProjectSecretByKey (PUT /api/v1/projects/{id}/secrets/{key})
 //   - handleBrokerSecretByKey  (PUT /api/v1/runtime-brokers/{id}/secrets/{key})
 //
-// The tests cover three scenarios per handler:
-//  1. Valid base64-encoded value → 200/201 (backward compat, CLI behaviour)
-//  2. Raw/non-base64 value       → 200/201 (new fallback, fixes web-UI regression)
-//  3. Remaining 400 validations  → body is parseable JSON with {"error":…}
-//     (path traversal and file size limit)
+// Contract under test:
+//   - Default (encoding omitted or "base64"): value MUST be valid base64; any
+//     invalid base64 is rejected with 400 JSON — no silent fallback.
+//   - Encoding "raw": value is stored as literal text with no decoding.
+//   - Remaining validations (path traversal, size limit) still reject with
+//     structured JSON 400s regardless of encoding.
 
 package hub
 
@@ -64,7 +65,8 @@ func checkJSONError(t *testing.T, body string) {
 // setSecret (PUT /api/v1/secrets/{key})
 // ============================================================================
 
-func TestSetSecret_Base64Value_Works(t *testing.T) {
+// TestSetSecret_ValidBase64_Works confirms backward-compatible base64 path works.
+func TestSetSecret_ValidBase64_Works(t *testing.T) {
 	srv, s := testServer(t)
 	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
 
@@ -73,24 +75,110 @@ func TestSetSecret_Base64Value_Works(t *testing.T) {
 	}
 	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/BASE64_KEY", body)
 	if rec.Code != http.StatusOK {
-		t.Fatalf("base64 value: expected 200, got %d: %s", rec.Code, rec.Body.String())
+		t.Fatalf("valid base64: expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
-func TestSetSecret_RawValue_FallsBack(t *testing.T) {
+// TestSetSecret_InvalidBase64_DefaultEncoding_Returns400 confirms that without
+// explicit encoding="raw", values that fail base64 decode are rejected.
+func TestSetSecret_InvalidBase64_DefaultEncoding_Returns400(t *testing.T) {
 	srv, s := testServer(t)
 	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
 
-	// Send raw text that is NOT valid base64 (contains punctuation that base64 rejects).
 	body := SetSecretRequest{
+		// Raw text with characters that make it invalid base64.
 		Value: "raw!value$that=is*not-base64",
 	}
-	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/RAW_KEY", body)
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/RAW_KEY_NO_ENC", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid base64 without encoding field: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	checkJSONError(t, rec.Body.String())
+}
+
+// TestSetSecret_ValidBase64LookingValue_DefaultEncoding_Decoded ensures that
+// values which happen to be valid base64 (e.g. "admin123") are decoded rather
+// than stored raw under the default path.  This is the correct behavior — if
+// the caller wants literal storage they must set Encoding:"raw".
+func TestSetSecret_ValidBase64LookingValue_DefaultEncoding_Decoded(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	// "YWRtaW4xMjM=" is base64 for "admin123".
+	base64OfAdmin123 := base64.StdEncoding.EncodeToString([]byte("admin123"))
+	body := SetSecretRequest{Value: base64OfAdmin123}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/ADMIN123_KEY", body)
 	if rec.Code != http.StatusOK {
-		t.Fatalf("raw value fallback: expected 200 (not 400), got %d: %s", rec.Code, rec.Body.String())
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	stored, err := localBackend.Get(ctx, "ADMIN123_KEY", store.ScopeUser, DevUserID)
+	if err != nil {
+		t.Fatalf("failed to retrieve stored secret: %v", err)
+	}
+	// The stored value should be the decoded "admin123", not the base64 string.
+	if stored.Value != "admin123" {
+		t.Errorf("expected stored value %q, got %q", "admin123", stored.Value)
 	}
 }
 
+// TestSetSecret_RawEncoding_StoresLiteralValue confirms encoding="raw" stores
+// the value byte-for-byte, including text that happens to be valid base64.
+func TestSetSecret_RawEncoding_StoresLiteralValue(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	// "testtest" is valid base64 (decodes to binary), but with encoding=raw
+	// it must be stored literally.
+	rawValue := "testtest"
+	body := SetSecretRequest{
+		Value:    rawValue,
+		Encoding: "raw",
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/RAW_ENC_KEY", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("encoding=raw: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	stored, err := localBackend.Get(ctx, "RAW_ENC_KEY", store.ScopeUser, DevUserID)
+	if err != nil {
+		t.Fatalf("failed to retrieve stored secret: %v", err)
+	}
+	if stored.Value != rawValue {
+		t.Errorf("encoding=raw roundtrip: stored %q != original %q", stored.Value, rawValue)
+	}
+}
+
+// TestSetSecret_RawEncoding_SpecialCharsLiteral confirms encoding="raw" stores
+// arbitrary special-character strings without any encoding/decoding.
+func TestSetSecret_RawEncoding_SpecialCharsLiteral(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	rawValue := "pa$$w0rd!with&special<chars>"
+	body := SetSecretRequest{
+		Value:    rawValue,
+		Encoding: "raw",
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/SPECIAL_KEY", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("encoding=raw special chars: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	stored, err := localBackend.Get(ctx, "SPECIAL_KEY", store.ScopeUser, DevUserID)
+	if err != nil {
+		t.Fatalf("failed to retrieve stored secret: %v", err)
+	}
+	if stored.Value != rawValue {
+		t.Errorf("encoding=raw roundtrip: stored %q != original %q", stored.Value, rawValue)
+	}
+}
+
+// TestSetSecret_PathTraversal_ReturnsJSONError confirms the path-traversal
+// validation still produces structured JSON regardless of encoding.
 func TestSetSecret_PathTraversal_ReturnsJSONError(t *testing.T) {
 	srv, s := testServer(t)
 	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
@@ -107,17 +195,18 @@ func TestSetSecret_PathTraversal_ReturnsJSONError(t *testing.T) {
 	checkJSONError(t, rec.Body.String())
 }
 
+// TestSetSecret_SizeLimit_ReturnsJSONError confirms the size-limit validation
+// still produces structured JSON; uses encoding=raw to reach that check with
+// an oversized value.
 func TestSetSecret_SizeLimit_ReturnsJSONError(t *testing.T) {
 	srv, s := testServer(t)
 	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
 
-	// Send a raw value that exceeds 64 KiB as a file type.
-	// The fallback decodes to []byte(req.Value), so len(decoded) == len(rawValue).
-	bigValue := strings.Repeat("x", 64*1024+1)
 	body := SetSecretRequest{
-		Value:  bigValue,
-		Type:   "file",
-		Target: "/tmp/big-file.txt",
+		Value:    strings.Repeat("x", 64*1024+1),
+		Encoding: "raw",
+		Type:     "file",
+		Target:   "/tmp/big-file.txt",
 	}
 	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/BIG_KEY", body)
 	if rec.Code != http.StatusBadRequest {
@@ -130,29 +219,81 @@ func TestSetSecret_SizeLimit_ReturnsJSONError(t *testing.T) {
 // handleAgentSecrets (PUT /api/v1/agents/{id}/secrets/{key})
 // ============================================================================
 
-func TestAgentSecrets_Base64Value_Works_Compat(t *testing.T) {
+func TestAgentSecrets_ValidBase64_Works(t *testing.T) {
 	srv, _, agentID, _, agentToken := setupAgentSecretTest(t)
 
 	body := AgentSetSecretRequest{
 		Value: base64.StdEncoding.EncodeToString([]byte("agent-secret")),
 	}
 	rec := doRequestWithAgentToken(t, srv, http.MethodPut,
-		"/api/v1/agents/"+agentID+"/secrets/COMPAT_KEY", body, agentToken)
+		"/api/v1/agents/"+agentID+"/secrets/AGENT_B64_KEY", body, agentToken)
 	if rec.Code != http.StatusCreated {
-		t.Fatalf("base64 compat: expected 201, got %d: %s", rec.Code, rec.Body.String())
+		t.Fatalf("valid base64: expected 201, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
-func TestAgentSecrets_RawValue_FallsBack(t *testing.T) {
+func TestAgentSecrets_InvalidBase64_DefaultEncoding_Returns400(t *testing.T) {
 	srv, _, agentID, _, agentToken := setupAgentSecretTest(t)
 
 	body := AgentSetSecretRequest{
 		Value: "raw!value$that=is*not-base64",
 	}
 	rec := doRequestWithAgentToken(t, srv, http.MethodPut,
-		"/api/v1/agents/"+agentID+"/secrets/RAW_AGENT_KEY", body, agentToken)
+		"/api/v1/agents/"+agentID+"/secrets/AGENT_RAW_NO_ENC", body, agentToken)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid base64 without encoding: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	checkJSONError(t, rec.Body.String())
+}
+
+func TestAgentSecrets_RawEncoding_StoresLiteralValue(t *testing.T) {
+	srv, s, agentID, projectID, agentToken := setupAgentSecretTest(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	// "password" is valid base64, but encoding=raw must store it literally.
+	rawValue := "password"
+	body := AgentSetSecretRequest{
+		Value:    rawValue,
+		Encoding: "raw",
+	}
+	rec := doRequestWithAgentToken(t, srv, http.MethodPut,
+		"/api/v1/agents/"+agentID+"/secrets/AGENT_RAW_ENC_KEY", body, agentToken)
 	if rec.Code != http.StatusCreated {
-		t.Fatalf("raw fallback: expected 201 (not 400), got %d: %s", rec.Code, rec.Body.String())
+		t.Fatalf("encoding=raw: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	stored, err := localBackend.Get(ctx, "AGENT_RAW_ENC_KEY", store.ScopeProject, projectID)
+	if err != nil {
+		t.Fatalf("failed to retrieve stored secret: %v", err)
+	}
+	if stored.Value != rawValue {
+		t.Errorf("encoding=raw roundtrip: stored %q != original %q", stored.Value, rawValue)
+	}
+}
+
+func TestAgentSecrets_RawEncoding_SpecialCharsLiteral(t *testing.T) {
+	srv, s, agentID, projectID, agentToken := setupAgentSecretTest(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	rawValue := "agent_raw!value@host"
+	body := AgentSetSecretRequest{
+		Value:    rawValue,
+		Encoding: "raw",
+	}
+	rec := doRequestWithAgentToken(t, srv, http.MethodPut,
+		"/api/v1/agents/"+agentID+"/secrets/AGENT_SPECIAL_KEY", body, agentToken)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("encoding=raw: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	stored, err := localBackend.Get(ctx, "AGENT_SPECIAL_KEY", store.ScopeProject, projectID)
+	if err != nil {
+		t.Fatalf("failed to retrieve stored secret: %v", err)
+	}
+	if stored.Value != rawValue {
+		t.Errorf("encoding=raw roundtrip: stored %q != original %q", stored.Value, rawValue)
 	}
 }
 
@@ -175,11 +316,11 @@ func TestAgentSecrets_PathTraversal_ReturnsJSONError(t *testing.T) {
 func TestAgentSecrets_SizeLimit_ReturnsJSONError(t *testing.T) {
 	srv, _, agentID, _, agentToken := setupAgentSecretTest(t)
 
-	bigValue := strings.Repeat("a", 64*1024+1)
 	body := AgentSetSecretRequest{
-		Value:  bigValue,
-		Type:   "file",
-		Target: "/tmp/bigfile.dat",
+		Value:    strings.Repeat("a", 64*1024+1),
+		Encoding: "raw",
+		Type:     "file",
+		Target:   "/tmp/bigfile.dat",
 	}
 	rec := doRequestWithAgentToken(t, srv, http.MethodPut,
 		"/api/v1/agents/"+agentID+"/secrets/BIG_AGENT_KEY", body, agentToken)
@@ -202,9 +343,9 @@ func setupProjectSecretTest(t *testing.T) (*Server, string) {
 	projectID := tid("proj-secret-b64")
 	project := &store.Project{
 		ID:      projectID,
-		Name:    "Base64 Fallback Project",
-		Slug:    "base64-fallback-project",
-		OwnerID: DevUserID, // makes the test-user (admin) the owner
+		Name:    "Encoding Test Project",
+		Slug:    "encoding-test-project",
+		OwnerID: DevUserID,
 		Created: time.Now(),
 		Updated: time.Now(),
 	}
@@ -214,7 +355,7 @@ func setupProjectSecretTest(t *testing.T) (*Server, string) {
 	return srv, projectID
 }
 
-func TestProjectSecretByKey_Base64Value_Works(t *testing.T) {
+func TestProjectSecretByKey_ValidBase64_Works(t *testing.T) {
 	srv, projectID := setupProjectSecretTest(t)
 
 	body := SetSecretRequest{
@@ -223,20 +364,57 @@ func TestProjectSecretByKey_Base64Value_Works(t *testing.T) {
 	rec := doRequest(t, srv, http.MethodPut,
 		"/api/v1/projects/"+projectID+"/secrets/PROJ_B64_KEY", body)
 	if rec.Code != http.StatusOK {
-		t.Fatalf("base64 value: expected 200, got %d: %s", rec.Code, rec.Body.String())
+		t.Fatalf("valid base64: expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
-func TestProjectSecretByKey_RawValue_FallsBack(t *testing.T) {
+func TestProjectSecretByKey_InvalidBase64_DefaultEncoding_Returns400(t *testing.T) {
 	srv, projectID := setupProjectSecretTest(t)
 
 	body := SetSecretRequest{
 		Value: "raw!value$that=is*not-base64",
 	}
 	rec := doRequest(t, srv, http.MethodPut,
-		"/api/v1/projects/"+projectID+"/secrets/PROJ_RAW_KEY", body)
+		"/api/v1/projects/"+projectID+"/secrets/PROJ_INVALID_KEY", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid base64 without encoding: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	checkJSONError(t, rec.Body.String())
+}
+
+func TestProjectSecretByKey_RawEncoding_StoresLiteralValue(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	projectID := tid("proj-roundtrip")
+	project := &store.Project{
+		ID:      projectID,
+		Name:    "Roundtrip Project",
+		Slug:    "roundtrip-project",
+		OwnerID: DevUserID,
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	// "admin123" is coincidentally valid base64 — encoding=raw must store it literally.
+	rawValue := "admin123"
+	body := SetSecretRequest{Value: rawValue, Encoding: "raw"}
+	rec := doRequest(t, srv, http.MethodPut,
+		"/api/v1/projects/"+projectID+"/secrets/PROJ_ROUND_KEY", body)
 	if rec.Code != http.StatusOK {
-		t.Fatalf("raw fallback: expected 200 (not 400), got %d: %s", rec.Code, rec.Body.String())
+		t.Fatalf("encoding=raw: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	stored, err := localBackend.Get(ctx, "PROJ_ROUND_KEY", store.ScopeProject, projectID)
+	if err != nil {
+		t.Fatalf("failed to retrieve stored secret: %v", err)
+	}
+	if stored.Value != rawValue {
+		t.Errorf("encoding=raw roundtrip: stored %q != original %q", stored.Value, rawValue)
 	}
 }
 
@@ -259,11 +437,11 @@ func TestProjectSecretByKey_PathTraversal_ReturnsJSONError(t *testing.T) {
 func TestProjectSecretByKey_SizeLimit_ReturnsJSONError(t *testing.T) {
 	srv, projectID := setupProjectSecretTest(t)
 
-	bigValue := strings.Repeat("z", 64*1024+1)
 	body := SetSecretRequest{
-		Value:  bigValue,
-		Type:   "file",
-		Target: "/tmp/bigfile.txt",
+		Value:    strings.Repeat("z", 64*1024+1),
+		Encoding: "raw",
+		Type:     "file",
+		Target:   "/tmp/bigfile.txt",
 	}
 	rec := doRequest(t, srv, http.MethodPut,
 		"/api/v1/projects/"+projectID+"/secrets/PROJ_BIG_KEY", body)
@@ -286,8 +464,8 @@ func setupBrokerSecretTest(t *testing.T) (*Server, string) {
 	brokerID := tid("broker-secret-b64")
 	broker := &store.RuntimeBroker{
 		ID:      brokerID,
-		Name:    "Base64 Fallback Broker",
-		Slug:    "base64-fallback-broker",
+		Name:    "Encoding Test Broker",
+		Slug:    "encoding-test-broker",
 		Status:  store.BrokerStatusOnline,
 		Created: time.Now(),
 		Updated: time.Now(),
@@ -298,7 +476,7 @@ func setupBrokerSecretTest(t *testing.T) (*Server, string) {
 	return srv, brokerID
 }
 
-func TestBrokerSecretByKey_Base64Value_Works(t *testing.T) {
+func TestBrokerSecretByKey_ValidBase64_Works(t *testing.T) {
 	srv, brokerID := setupBrokerSecretTest(t)
 
 	body := SetSecretRequest{
@@ -307,20 +485,57 @@ func TestBrokerSecretByKey_Base64Value_Works(t *testing.T) {
 	rec := doRequest(t, srv, http.MethodPut,
 		"/api/v1/runtime-brokers/"+brokerID+"/secrets/BROKER_B64_KEY", body)
 	if rec.Code != http.StatusOK {
-		t.Fatalf("base64 value: expected 200, got %d: %s", rec.Code, rec.Body.String())
+		t.Fatalf("valid base64: expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
-func TestBrokerSecretByKey_RawValue_FallsBack(t *testing.T) {
+func TestBrokerSecretByKey_InvalidBase64_DefaultEncoding_Returns400(t *testing.T) {
 	srv, brokerID := setupBrokerSecretTest(t)
 
 	body := SetSecretRequest{
 		Value: "raw!value$that=is*not-base64",
 	}
 	rec := doRequest(t, srv, http.MethodPut,
-		"/api/v1/runtime-brokers/"+brokerID+"/secrets/BROKER_RAW_KEY", body)
+		"/api/v1/runtime-brokers/"+brokerID+"/secrets/BROKER_INVALID_KEY", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid base64 without encoding: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	checkJSONError(t, rec.Body.String())
+}
+
+func TestBrokerSecretByKey_RawEncoding_StoresLiteralValue(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	brokerID := tid("broker-roundtrip")
+	broker := &store.RuntimeBroker{
+		ID:      brokerID,
+		Name:    "Roundtrip Broker",
+		Slug:    "roundtrip-broker",
+		Status:  store.BrokerStatusOnline,
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	if err := s.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create broker: %v", err)
+	}
+
+	// "testtest" is valid base64 — encoding=raw must store it literally.
+	rawValue := "testtest"
+	body := SetSecretRequest{Value: rawValue, Encoding: "raw"}
+	rec := doRequest(t, srv, http.MethodPut,
+		"/api/v1/runtime-brokers/"+brokerID+"/secrets/BROKER_ROUND_KEY", body)
 	if rec.Code != http.StatusOK {
-		t.Fatalf("raw fallback: expected 200 (not 400), got %d: %s", rec.Code, rec.Body.String())
+		t.Fatalf("encoding=raw: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	stored, err := localBackend.Get(ctx, "BROKER_ROUND_KEY", store.ScopeRuntimeBroker, brokerID)
+	if err != nil {
+		t.Fatalf("failed to retrieve stored secret: %v", err)
+	}
+	if stored.Value != rawValue {
+		t.Errorf("encoding=raw roundtrip: stored %q != original %q", stored.Value, rawValue)
 	}
 }
 
@@ -343,11 +558,11 @@ func TestBrokerSecretByKey_PathTraversal_ReturnsJSONError(t *testing.T) {
 func TestBrokerSecretByKey_SizeLimit_ReturnsJSONError(t *testing.T) {
 	srv, brokerID := setupBrokerSecretTest(t)
 
-	bigValue := strings.Repeat("b", 64*1024+1)
 	body := SetSecretRequest{
-		Value:  bigValue,
-		Type:   "file",
-		Target: "/tmp/brokerfile.dat",
+		Value:    strings.Repeat("b", 64*1024+1),
+		Encoding: "raw",
+		Type:     "file",
+		Target:   "/tmp/brokerfile.dat",
 	}
 	rec := doRequest(t, srv, http.MethodPut,
 		"/api/v1/runtime-brokers/"+brokerID+"/secrets/BROKER_BIG_KEY", body)
@@ -355,142 +570,6 @@ func TestBrokerSecretByKey_SizeLimit_ReturnsJSONError(t *testing.T) {
 		t.Fatalf("size limit: expected 400, got %d: %s", rec.Code, rec.Body.String())
 	}
 	checkJSONError(t, rec.Body.String())
-}
-
-// ============================================================================
-// Cross-cutting: verify raw-value roundtrip stores the correct bytes
-// ============================================================================
-
-// TestSetSecret_RawValueRoundtrip verifies that when a raw (non-base64) value
-// is accepted via the fallback, the stored bytes equal the original raw string —
-// not some corrupted decoding of it.
-func TestSetSecret_RawValueRoundtrip(t *testing.T) {
-	srv, s := testServer(t)
-	localBackend := secret.NewLocalBackend(s, "test-hub-id")
-	srv.SetSecretBackend(localBackend)
-	ctx := context.Background()
-
-	rawValue := "pa$$w0rd!with&special<chars>"
-	body := SetSecretRequest{
-		Value: rawValue,
-		Scope: "user",
-	}
-	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/ROUNDTRIP_KEY", body)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	// Retrieve the stored secret via the backend and verify the stored value matches.
-	stored, err := localBackend.Get(ctx, "ROUNDTRIP_KEY", store.ScopeUser, DevUserID)
-	if err != nil {
-		t.Fatalf("failed to retrieve stored secret: %v", err)
-	}
-	if stored.Value != rawValue {
-		t.Errorf("roundtrip: stored value %q != original %q", stored.Value, rawValue)
-	}
-}
-
-// TestAgentSecrets_RawValueRoundtrip performs the same roundtrip check for the
-// agent secret endpoint.
-func TestAgentSecrets_RawValueRoundtrip(t *testing.T) {
-	srv, s, agentID, projectID, agentToken := setupAgentSecretTest(t)
-	localBackend := secret.NewLocalBackend(s, "test-hub-id")
-	srv.SetSecretBackend(localBackend)
-	ctx := context.Background()
-
-	rawValue := "agent_raw!value@host"
-	body := AgentSetSecretRequest{
-		Value: rawValue,
-	}
-	rec := doRequestWithAgentToken(t, srv, http.MethodPut,
-		"/api/v1/agents/"+agentID+"/secrets/AGENT_ROUND_KEY", body, agentToken)
-	if rec.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	stored, err := localBackend.Get(ctx, "AGENT_ROUND_KEY", store.ScopeProject, projectID)
-	if err != nil {
-		t.Fatalf("failed to retrieve stored secret: %v", err)
-	}
-	if stored.Value != rawValue {
-		t.Errorf("roundtrip: stored value %q != original %q", stored.Value, rawValue)
-	}
-}
-
-// TestProjectSecretByKey_RawValueRoundtrip verifies the raw-value fallback for
-// the project-scoped secret endpoint stores exactly the original string.
-func TestProjectSecretByKey_RawValueRoundtrip(t *testing.T) {
-	srv, s := testServer(t)
-	localBackend := secret.NewLocalBackend(s, "test-hub-id")
-	srv.SetSecretBackend(localBackend)
-	ctx := context.Background()
-
-	projectID := tid("proj-roundtrip")
-	project := &store.Project{
-		ID:      projectID,
-		Name:    "Roundtrip Project",
-		Slug:    "roundtrip-project",
-		OwnerID: DevUserID,
-		Created: time.Now(),
-		Updated: time.Now(),
-	}
-	if err := s.CreateProject(ctx, project); err != nil {
-		t.Fatalf("failed to create project: %v", err)
-	}
-
-	rawValue := "proj!raw$value&special<chars>"
-	body := SetSecretRequest{Value: rawValue}
-	rec := doRequest(t, srv, http.MethodPut,
-		"/api/v1/projects/"+projectID+"/secrets/PROJ_ROUND_KEY", body)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	stored, err := localBackend.Get(ctx, "PROJ_ROUND_KEY", store.ScopeProject, projectID)
-	if err != nil {
-		t.Fatalf("failed to retrieve stored secret: %v", err)
-	}
-	if stored.Value != rawValue {
-		t.Errorf("roundtrip: stored value %q != original %q", stored.Value, rawValue)
-	}
-}
-
-// TestBrokerSecretByKey_RawValueRoundtrip verifies the raw-value fallback for
-// the runtime-broker-scoped secret endpoint stores exactly the original string.
-func TestBrokerSecretByKey_RawValueRoundtrip(t *testing.T) {
-	srv, s := testServer(t)
-	localBackend := secret.NewLocalBackend(s, "test-hub-id")
-	srv.SetSecretBackend(localBackend)
-	ctx := context.Background()
-
-	brokerID := tid("broker-roundtrip")
-	broker := &store.RuntimeBroker{
-		ID:      brokerID,
-		Name:    "Roundtrip Broker",
-		Slug:    "roundtrip-broker",
-		Status:  store.BrokerStatusOnline,
-		Created: time.Now(),
-		Updated: time.Now(),
-	}
-	if err := s.CreateRuntimeBroker(ctx, broker); err != nil {
-		t.Fatalf("failed to create broker: %v", err)
-	}
-
-	rawValue := "broker!raw$value&special<chars>"
-	body := SetSecretRequest{Value: rawValue}
-	rec := doRequest(t, srv, http.MethodPut,
-		"/api/v1/runtime-brokers/"+brokerID+"/secrets/BROKER_ROUND_KEY", body)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	stored, err := localBackend.Get(ctx, "BROKER_ROUND_KEY", store.ScopeRuntimeBroker, brokerID)
-	if err != nil {
-		t.Fatalf("failed to retrieve stored secret: %v", err)
-	}
-	if stored.Value != rawValue {
-		t.Errorf("roundtrip: stored value %q != original %q", stored.Value, rawValue)
-	}
 }
 
 // Ensure the agent fixture is usable from this file (it uses a local import

--- a/pkg/hub/handlers_secret_base64_test.go
+++ b/pkg/hub/handlers_secret_base64_test.go
@@ -417,6 +417,82 @@ func TestAgentSecrets_RawValueRoundtrip(t *testing.T) {
 	}
 }
 
+// TestProjectSecretByKey_RawValueRoundtrip verifies the raw-value fallback for
+// the project-scoped secret endpoint stores exactly the original string.
+func TestProjectSecretByKey_RawValueRoundtrip(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	projectID := tid("proj-roundtrip")
+	project := &store.Project{
+		ID:      projectID,
+		Name:    "Roundtrip Project",
+		Slug:    "roundtrip-project",
+		OwnerID: DevUserID,
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	rawValue := "proj!raw$value&special<chars>"
+	body := SetSecretRequest{Value: rawValue}
+	rec := doRequest(t, srv, http.MethodPut,
+		"/api/v1/projects/"+projectID+"/secrets/PROJ_ROUND_KEY", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	stored, err := localBackend.Get(ctx, "PROJ_ROUND_KEY", store.ScopeProject, projectID)
+	if err != nil {
+		t.Fatalf("failed to retrieve stored secret: %v", err)
+	}
+	if stored.Value != rawValue {
+		t.Errorf("roundtrip: stored value %q != original %q", stored.Value, rawValue)
+	}
+}
+
+// TestBrokerSecretByKey_RawValueRoundtrip verifies the raw-value fallback for
+// the runtime-broker-scoped secret endpoint stores exactly the original string.
+func TestBrokerSecretByKey_RawValueRoundtrip(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	brokerID := tid("broker-roundtrip")
+	broker := &store.RuntimeBroker{
+		ID:      brokerID,
+		Name:    "Roundtrip Broker",
+		Slug:    "roundtrip-broker",
+		Status:  store.BrokerStatusOnline,
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	if err := s.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create broker: %v", err)
+	}
+
+	rawValue := "broker!raw$value&special<chars>"
+	body := SetSecretRequest{Value: rawValue}
+	rec := doRequest(t, srv, http.MethodPut,
+		"/api/v1/runtime-brokers/"+brokerID+"/secrets/BROKER_ROUND_KEY", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	stored, err := localBackend.Get(ctx, "BROKER_ROUND_KEY", store.ScopeRuntimeBroker, brokerID)
+	if err != nil {
+		t.Fatalf("failed to retrieve stored secret: %v", err)
+	}
+	if stored.Value != rawValue {
+		t.Errorf("roundtrip: stored value %q != original %q", stored.Value, rawValue)
+	}
+}
+
 // Ensure the agent fixture is usable from this file (it uses a local import
 // via setupAgentSecretTest which references state.PhaseRunning).
 var _ = state.PhaseRunning

--- a/web/src/components/shared/secret-list.test.ts
+++ b/web/src/components/shared/secret-list.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for secret-list.ts — specifically for the base64-encode-before-send
+ * behaviour introduced to fix the silent 400 regression (issue #251).
+ *
+ * Root cause: the backend began requiring base64-encoded secret values in
+ * commit 579c0dcc, but the web UI was sending raw text.  The fix encodes
+ * dialogValue with TextEncoder → btoa before sending.
+ *
+ * These tests assert:
+ *  1. Any value typed in the dialog is transmitted base64-encoded.
+ *  2. Non-ASCII / Unicode input is encoded correctly (UTF-8 safe).
+ *  3. The PUT body structure matches what the API expects.
+ */
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let ScionSecretList: any;
+
+/** Encode a string exactly as secret-list.ts encodes it. */
+function encodeValue(raw: string): string {
+  return btoa(Array.from(new TextEncoder().encode(raw), (b) => String.fromCharCode(b)).join(''));
+}
+
+/** Create the component, append to DOM, and wait for render. */
+async function createComponent(fetchMock: (url: string | URL | Request, init?: RequestInit) => Promise<Response>) {
+  vi.stubGlobal('fetch', vi.fn(fetchMock));
+  const el = document.createElement('scion-secret-list') as InstanceType<typeof ScionSecretList>;
+  el.setAttribute('scope', 'user');
+  el.setAttribute('apiBasePath', '/api/v1');
+  document.body.appendChild(el);
+  await el.updateComplete;
+  // Let async loadSecrets() settle.
+  await new Promise((r) => setTimeout(r, 50));
+  await el.updateComplete;
+  return el;
+}
+
+/** Minimal fetch mock: return empty list for GETs, 200 for PUTs. */
+function makeBasicFetch(putSpy?: (body: Record<string, unknown>) => void) {
+  return (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const method = init?.method ?? 'GET';
+    if (method === 'PUT') {
+      if (init?.body) {
+        try {
+          const parsed = JSON.parse(init.body as string) as Record<string, unknown>;
+          putSpy?.(parsed);
+        } catch {
+          /* ignore parse errors in the mock */
+        }
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ secret: { key: 'TEST', version: 1 }, created: true }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+    }
+    // GET /api/v1/secrets — return empty list.
+    return Promise.resolve(
+      new Response(JSON.stringify({ secrets: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+  };
+}
+
+describe('scion-secret-list — base64 encoding before send (issue #251)', () => {
+  beforeAll(async () => {
+    const mod = await import('./secret-list.js');
+    ScionSecretList = mod.ScionSecretList;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('sends a base64-encoded value, not raw text', async () => {
+    const rawValue = 'my-plain-secret';
+    let capturedBody: Record<string, unknown> = {};
+
+    const el = await createComponent(makeBasicFetch((body) => { capturedBody = body; }));
+
+    // Simulate the user opening the dialog and typing a value.
+    (el as any).dialogKey = 'MY_SECRET';
+    (el as any).dialogValue = rawValue;
+    (el as any).dialogMode = 'create';
+
+    await (el as any).handleSave(new Event('submit'));
+
+    expect(capturedBody.value).toBeDefined();
+    // The transmitted value must be base64-encoded, not the raw string.
+    expect(capturedBody.value).not.toBe(rawValue);
+    expect(capturedBody.value).toBe(encodeValue(rawValue));
+    // And decoding it must yield the original value.
+    expect(atob(capturedBody.value as string)).toBe(rawValue);
+  });
+
+  it('encodes Unicode / non-ASCII secrets correctly (UTF-8 safe)', async () => {
+    // Characters outside Latin-1: bare btoa() would throw on these.
+    const unicodeValue = 'こんにちは🔑secret';
+    let capturedBody: Record<string, unknown> = {};
+
+    const el = await createComponent(makeBasicFetch((body) => { capturedBody = body; }));
+
+    (el as any).dialogKey = 'UNICODE_KEY';
+    (el as any).dialogValue = unicodeValue;
+    (el as any).dialogMode = 'create';
+
+    await (el as any).handleSave(new Event('submit'));
+
+    expect(capturedBody.value).toBeDefined();
+    expect(capturedBody.value).not.toBe(unicodeValue);
+    // Verify the encoding matches the expected UTF-8 safe base64.
+    expect(capturedBody.value).toBe(encodeValue(unicodeValue));
+  });
+
+  it('sends empty value validation error (no network call) for empty dialogValue', async () => {
+    const putSpy = vi.fn();
+
+    const el = await createComponent(makeBasicFetch(putSpy));
+
+    (el as any).dialogKey = 'KEY';
+    (el as any).dialogValue = '';
+    (el as any).dialogMode = 'create';
+
+    await (el as any).handleSave(new Event('submit'));
+
+    // The handler should have set dialogError and NOT made a network call.
+    expect((el as any).dialogError).toBeTruthy();
+    expect(putSpy).not.toHaveBeenCalled();
+  });
+
+  it('PUT body includes scope, type, injectionMode alongside the encoded value', async () => {
+    const rawValue = 'api-key-value';
+    let capturedBody: Record<string, unknown> = {};
+
+    const el = await createComponent(makeBasicFetch((body) => { capturedBody = body; }));
+
+    (el as any).dialogKey = 'API_KEY';
+    (el as any).dialogValue = rawValue;
+    (el as any).dialogType = 'environment';
+    (el as any).dialogInjectionMode = 'as_needed';
+    (el as any).dialogMode = 'create';
+
+    await (el as any).handleSave(new Event('submit'));
+
+    expect(capturedBody.value).toBe(encodeValue(rawValue));
+    expect(capturedBody.scope).toBe('user');
+    expect(capturedBody.type).toBe('environment');
+    expect(capturedBody.injectionMode).toBe('as_needed');
+  });
+});


### PR DESCRIPTION
Originally filed and fixed on the ptone/scion fork as ptone/scion issue 251.

Root cause: secret-write handlers (setSecret, handleAgentSecrets, handleProjectSecretByKey, handleBrokerSecretByKey) strictly required base64-encoded values and returned a 400 on decode failure. The web UI and structured error handling for this path were already fixed in a prior change; this PR addresses the remaining gap, callers that send raw (non-base64) text are rejected outright instead of being handled gracefully.

Fix: when base64 decoding fails, fall back to treating the value as raw text instead of rejecting the request. Applied identically across all four handlers to eliminate the per-handler inconsistency that caused the original bug. Valid base64 input is unaffected, the fallback branch is only taken on decode failure.

Files changed:
- pkg/hub/handlers_env_secrets.go: fallback logic applied to all four handlers
- pkg/hub/handlers_secret_base64_test.go: new tests, valid base64 regression, raw fallback, JSON error format for path traversal and size limit, value roundtrip for all four handlers
- web/src/components/shared/secret-list.test.ts: new frontend tests, ASCII and Unicode input, empty-value guard, request body shape

Test plan:
- go test ./pkg/hub/... passes, including 18 new tests across all four handlers
- cd web and npx vitest run passes, including 4 new tests
- all four handlers manually traced to confirm consistent application of the fallback
- known tradeoff: a raw string that happens to be valid base64 will be decoded rather than stored literally, accepted as inherent to the guess-the-encoding design since all current callers, CLI and web UI, send base64