### PR TITLE
fix(cmd): use skill:// instead of scion:// in help text examples

### DIFF
--- a/cmd/project_skills.go
+++ b/cmd/project_skills.go
@@ -45,10 +45,10 @@ When omitted, the project is inferred from the current directory's Hub link.
 Examples:
   scion project skills list
   scion project skills list my-project
-  scion project skills add scion://my-skill
-  scion project skills add my-project scion://my-skill --as my-alias --optional
+  scion project skills add skill://my-skill
+  scion project skills add my-project skill://my-skill --as my-alias --optional
   scion project skills remove <id>
-  scion project skills remove my-project scion://my-skill`,
+  scion project skills remove my-project skill://my-skill`,
 }
 
 // projectSkillsListCmd implements `scion project skills list [project]`.
@@ -71,9 +71,9 @@ current directory's Hub link. When both arguments are present, the first
 is the project name/slug/UUID and the second is the skill URI.
 
 Examples:
-  scion project skills add scion://my-skill
-  scion project skills add my-project scion://my-skill
-  scion project skills add my-project scion://my-skill@1.2 --as alias --optional`,
+  scion project skills add skill://my-skill
+  scion project skills add my-project skill://my-skill
+  scion project skills add my-project skill://my-skill@1.2 --as alias --optional`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: runProjectSkillsAdd,
 }
@@ -91,9 +91,9 @@ is removed.
 
 Examples:
   scion project skills remove <uuid>
-  scion project skills remove scion://my-skill
+  scion project skills remove skill://my-skill
   scion project skills remove my-project <uuid>
-  scion project skills remove my-project scion://my-skill`,
+  scion project skills remove my-project skill://my-skill`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: runProjectSkillsRemove,
 }

--- a/cmd/project_skills_test.go
+++ b/cmd/project_skills_test.go
@@ -35,8 +35,8 @@ func TestIsSkillURI(t *testing.T) {
 		input string
 		want  bool
 	}{
-		{"scion://my-skill", true},
-		{"scion://my-skill@1.0", true},
+		{"skill://my-skill", true},
+		{"skill://my-skill@1.0", true},
 		{"gcs://bucket/path", true},
 		{"github://org/repo/skill", true},
 		{"", false},
@@ -67,9 +67,9 @@ func TestSplitProjectSkillsArgs(t *testing.T) {
 		},
 		{
 			name:           "uri only",
-			args:           []string{"scion://my-skill"},
+			args:           []string{"skill://my-skill"},
 			wantProjectArg: "",
-			wantSkillRef:   "scion://my-skill",
+			wantSkillRef:   "skill://my-skill",
 		},
 		{
 			name:           "project name only",
@@ -79,9 +79,9 @@ func TestSplitProjectSkillsArgs(t *testing.T) {
 		},
 		{
 			name:           "project then uri",
-			args:           []string{"my-project", "scion://my-skill"},
+			args:           []string{"my-project", "skill://my-skill"},
 			wantProjectArg: "my-project",
-			wantSkillRef:   "scion://my-skill",
+			wantSkillRef:   "skill://my-skill",
 		},
 		{
 			name:           "project then uuid",
@@ -185,7 +185,7 @@ func newProjectSkillsMockServer(t *testing.T) *httptest.Server {
 	entries := []map[string]interface{}{
 		{
 			"id":        testEntryID1,
-			"skillUri":  "scion://skill-one",
+			"skillUri":  "skill://skill-one",
 			"skillAs":   "skill1",
 			"optional":  false,
 			"sortOrder": 0,
@@ -193,7 +193,7 @@ func newProjectSkillsMockServer(t *testing.T) *httptest.Server {
 		},
 		{
 			"id":        testEntryID2,
-			"skillUri":  "scion://skill-two",
+			"skillUri":  "skill://skill-two",
 			"optional":  true,
 			"sortOrder": 1,
 		},
@@ -336,7 +336,7 @@ func TestRunProjectSkillsAdd_Success(t *testing.T) {
 	projectSkillsOptional = false
 
 	// Single arg: URI only (project inferred from settings)
-	err := runProjectSkillsAdd(projectSkillsAddCmd, []string{"scion://new-skill"})
+	err := runProjectSkillsAdd(projectSkillsAddCmd, []string{"skill://new-skill"})
 	assert.NoError(t, err)
 }
 
@@ -361,7 +361,7 @@ func TestRunProjectSkillsAdd_WithAlias(t *testing.T) {
 	// Simulate flag state for the command:
 	_ = projectSkillsAddCmd.Flags().Set("as", "my-alias")
 
-	err := runProjectSkillsAdd(projectSkillsAddCmd, []string{"scion://new-skill"})
+	err := runProjectSkillsAdd(projectSkillsAddCmd, []string{"skill://new-skill"})
 	assert.NoError(t, err)
 }
 
@@ -430,7 +430,7 @@ func TestRunProjectSkillsRemove_ByURI(t *testing.T) {
 	outputFormat = ""
 
 	// Remove by URI: should list first, then delete by resolved ID.
-	err := runProjectSkillsRemove(projectSkillsRemoveCmd, []string{"scion://skill-one"})
+	err := runProjectSkillsRemove(projectSkillsRemoveCmd, []string{"skill://skill-one"})
 	assert.NoError(t, err)
 }
 
@@ -448,7 +448,7 @@ func TestRunProjectSkillsRemove_URINotFound(t *testing.T) {
 	projectPath = projectDir
 	outputFormat = ""
 
-	err := runProjectSkillsRemove(projectSkillsRemoveCmd, []string{"scion://nonexistent-skill"})
+	err := runProjectSkillsRemove(projectSkillsRemoveCmd, []string{"skill://nonexistent-skill"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no injected skill with URI")
 }

--- a/cmd/user_skills.go
+++ b/cmd/user_skills.go
@@ -43,10 +43,10 @@ project-scope skills (template > project > user > hub).
 
 Examples:
   scion user skills list
-  scion user skills add scion://my-skill
-  scion user skills add scion://my-skill@1.2 --as alias --optional
+  scion user skills add skill://my-skill
+  scion user skills add skill://my-skill@1.2 --as alias --optional
   scion user skills remove <id>
-  scion user skills remove scion://my-skill`,
+  scion user skills remove skill://my-skill`,
 }
 
 // userSkillsListCmd implements `scion user skills list`.
@@ -65,8 +65,8 @@ var userSkillsAddCmd = &cobra.Command{
 	Long: `Add a skill URI to your personal injected-skills list.
 
 Examples:
-  scion user skills add scion://my-skill
-  scion user skills add scion://my-skill@1.2 --as alias --optional`,
+  scion user skills add skill://my-skill
+  scion user skills add skill://my-skill@1.2 --as alias --optional`,
 	Args: cobra.ExactArgs(1),
 	RunE: runUserSkillsAdd,
 }
@@ -82,7 +82,7 @@ The entry can be identified by its UUID or by the full skill URI.
 
 Examples:
   scion user skills remove <uuid>
-  scion user skills remove scion://my-skill`,
+  scion user skills remove skill://my-skill`,
 	Args: cobra.ExactArgs(1),
 	RunE: runUserSkillsRemove,
 }

--- a/cmd/user_skills_test.go
+++ b/cmd/user_skills_test.go
@@ -108,13 +108,13 @@ func newUserSkillsMockServer(t *testing.T) *httptest.Server {
 	entries := []map[string]interface{}{
 		{
 			"id":        testUserEntryID1,
-			"skillUri":  "scion://user-skill-one",
+			"skillUri":  "skill://user-skill-one",
 			"optional":  false,
 			"sortOrder": 0,
 		},
 		{
 			"id":        testUserEntryID2,
-			"skillUri":  "scion://user-skill-two",
+			"skillUri":  "skill://user-skill-two",
 			"skillAs":   "skill2",
 			"optional":  true,
 			"sortOrder": 1,
@@ -278,7 +278,7 @@ func TestRunUserSkillsAdd_Success(t *testing.T) {
 	userSkillsAs = ""
 	userSkillsOptional = false
 
-	err := runUserSkillsAdd(userSkillsAddCmd, []string{"scion://new-user-skill"})
+	err := runUserSkillsAdd(userSkillsAddCmd, []string{"skill://new-user-skill"})
 	assert.NoError(t, err)
 }
 
@@ -310,7 +310,7 @@ func TestRunUserSkillsAdd_WithAliasAndOptional(t *testing.T) {
 	t.Cleanup(func() { _ = userSkillsAddCmd.Flags().Set("optional", prevOptStr) })
 	_ = userSkillsAddCmd.Flags().Set("optional", "true")
 
-	err := runUserSkillsAdd(userSkillsAddCmd, []string{"scion://new-user-skill"})
+	err := runUserSkillsAdd(userSkillsAddCmd, []string{"skill://new-user-skill"})
 	assert.NoError(t, err)
 }
 
@@ -347,7 +347,7 @@ func TestRunUserSkillsRemove_ByURI(t *testing.T) {
 	outputFormat = ""
 
 	// Remove by URI — resolves via list first.
-	err := runUserSkillsRemove(userSkillsRemoveCmd, []string{"scion://user-skill-one"})
+	err := runUserSkillsRemove(userSkillsRemoveCmd, []string{"skill://user-skill-one"})
 	assert.NoError(t, err)
 }
 
@@ -365,7 +365,7 @@ func TestRunUserSkillsRemove_URINotFound(t *testing.T) {
 	projectPath = projectDir
 	outputFormat = ""
 
-	err := runUserSkillsRemove(userSkillsRemoveCmd, []string{"scion://nonexistent"})
+	err := runUserSkillsRemove(userSkillsRemoveCmd, []string{"skill://nonexistent"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no injected skill with URI")
 }


### PR DESCRIPTION
## Summary
Addresses ptone/scion#561: CLI help text in cmd/project_skills.go and cmd/user_skills.go used scion:// as an example skill URI scheme, but scion:// has no registered resolver. Correct scheme is skill://.

## Changes
- Replaced scion:// with skill:// in help text/examples in both files
- Updated corresponding test fixtures for consistency

go build and go vet both pass clean. Docs/copy-only change, no logic change.