### PR TITLE
feat(a2a-bridge): per-user access token auth (hubUAT/hubJWT schemes)

### DIFF
--- a/.design/a2a-bridge-uat-auth.md
+++ b/.design/a2a-bridge-uat-auth.md
@@ -1,0 +1,607 @@
+# Design: Per-User Access Token Auth for the A2A Bridge
+
+**Status:** Draft  
+**Date:** 2026-07-24  
+**Author:** a2a-fed-arch  
+**Related issue:** #184 — A2A federation for Claude Desktop / Codex Desktop  
+
+---
+
+## Problem & Goals
+
+The Scion A2A bridge (`extras/scion-a2a-bridge/`) exposes Scion agents as A2A protocol endpoints. Today it authenticates all callers with a single shared static API key. From the Hub's perspective, every external A2A caller shares one admin identity — the bridge's configured `hub.user`. This makes it impossible to:
+
+1. Audit which end-user sent which message to an agent
+2. Enforce per-user scope or project restrictions at the Hub layer
+3. Allow individual Claude Desktop or Codex Desktop users to use their own Scion credentials
+
+**Goals:**
+- Add `hubUAT` auth scheme to the bridge: accept Scion user access tokens (`scion_pat_*`) from A2A callers, validate them via the Hub, and propagate the caller's identity to Hub API calls.
+- Add `hubJWT` auth scheme as a secondary option: accept Scion user JWTs (CLI or web login tokens) validated locally using the Hub's signing key.
+- Per-user task isolation at the bridge layer: callers can only read or cancel their own tasks.
+- Full identity propagation to the Hub: Hub audit logs and authz decisions reflect the real calling user, not the bridge admin.
+- Document the desktop app onboarding flow.
+- Preserve backward compatibility: existing `apiKey`, `bearer`, and `none` schemes continue to work unchanged.
+
+**Success criteria:**
+- A Claude Desktop user with a `scion_pat_*` token scoped to `agent:message` can successfully call `message/send` via the bridge, and the Hub's message delivery log shows the correct user identity.
+- A different user's task is not visible to the first user via `tasks/get`.
+- An invalid or revoked UAT is rejected at the bridge with HTTP 401.
+- A UAT without `agent:message` scope is rejected by the Hub with a 403 that the bridge maps to an A2A error.
+
+---
+
+## Non-Goals
+
+- OAuth / PKCE token exchange at the bridge. Desktop apps obtain their UAT directly from the Hub UI (or Hub CLI) before calling the bridge.
+- New token types. This design uses the existing `scion_pat_*` UAT system without modification.
+- Issuing tokens on behalf of callers. The bridge validates tokens; it does not issue them.
+- Modifying the Hub's token issuance flow.
+- Per-agent UATs (a different scoping model). This design uses project-scoped UATs.
+- Agent-principal federation (mapping external A2A identities to Scion's agent principal type — tracked separately in `agent-authz-arch`).
+
+---
+
+## Proposed Design
+
+### 3.1 Overview
+
+```
+A2A Desktop Client
+    │  Authorization: Bearer scion_pat_... (hubUAT)
+    │  or Authorization: Bearer <HS256 JWT> (hubJWT)
+    ▼
+scion-a2a-bridge — authMiddleware
+    │  1. Detect token type (UAT prefix vs JWT shape)
+    │  2a. hubUAT: call Hub GET /api/v1/auth/me with the UAT (cached 60s)
+    │  2b. hubJWT: validate JWT locally using Hub signing key
+    │  3. Populate CallerIdentity in request context
+    ▼
+bridge.SendMessage (per-request Hub client)
+    │  hubUAT: hubclient.New(endpoint, WithBearerToken(callerUAT))
+    │  hubJWT: hubclient.New(endpoint, WithAuthenticator(mintingAuth(callerIdentity)))
+    │  Sender: "user:<callerEmail>"
+    │  Broker subscription: AllUserTopic(projectID)
+    ▼
+Scion Hub — UnifiedAuthMiddleware
+    │  Validates UAT (DB lookup) or JWT (local verify)
+    │  enforceUATConstraints: project-pinned, scope-checked
+    ▼
+Scion Agent
+    │  Replies to scion.project.<projectID>.user.<callerEmail>.messages
+    ▼
+scion-a2a-bridge — AllUserTopic wildcard subscription catches reply
+    │  a2aTaskId in metadata routes to correct waiter
+    ▼
+A2A Desktop Client
+```
+
+The bridge maintains two Hub client types:
+- **Admin client** (existing, unchanged): used for read-only Hub operations (agent listing, context resolution, auto-provisioning). Created at startup with the bridge's own identity.
+- **Per-request caller client** (new): created per-request in `hubUAT` / `hubJWT` mode. Used only for Hub write operations (SendStructuredMessage, task interrupt on cancel).
+
+### 3.2 Identity-Propagation Decision
+
+The core question from the brief: does the bridge pass the caller's UAT through to the Hub, or mint a short-lived JWT after validating the UAT once?
+
+**Recommendation: UAT passthrough for `hubUAT`, JWT re-mint for `hubJWT`.**
+
+Rationale:
+
+For `hubUAT`:
+- The Hub already validates UATs natively via `UATSvc.ValidateToken` (DB lookup). Presenting the UAT on each Hub API call causes Hub-side authz (`enforceUATConstraints`) to fire on every write — which is exactly what we want. The UAT's project binding and scope constraints are enforced at the Hub layer without any bridge-side re-implementation.
+- Immediate revocation: if the UAT is revoked, the next Hub API call fails within one cache TTL (60 seconds). A re-minted JWT alternative would keep working until the short-lived JWT expires.
+- No new Hub code required.
+
+For `hubJWT`:
+- User JWTs are validated locally in the bridge using the Hub signing key (the bridge already has it). The bridge then re-mints a fresh 5-minute JWT for the same user identity using `identity.TokenMinter`. This is already how the bridge authenticates itself to the Hub — it's the same infrastructure, just for a different user identity.
+- Avoids a network round-trip for JWT validation.
+- Limitation: no immediate revocation (JWTs are not checked against the DB). Acceptable for a secondary scheme.
+
+For both schemes, **the bridge does not act as a token exchange endpoint**. It receives a credential, validates it, and uses it (or a derived credential) for Hub calls.
+
+### 3.3 UAT Introspection: Why No New Hub Endpoint Is Needed
+
+The brief asked whether the Hub needs a new UAT introspection endpoint for the bridge to call.
+
+Answer: **No.** The existing `GET /api/v1/auth/me` endpoint already serves as a UAT introspection endpoint for the bridge's purposes. When the bridge calls it with a UAT bearer token, the Hub's `UnifiedAuthMiddleware` validates the UAT via `UATSvc.ValidateToken` (DB lookup, same path as all other Hub API requests) and returns the user's ID, email, display name, and role.
+
+`/api/v1/auth/validate` was ruled out because it only validates JWTs (`UserTokenService.ValidateUserToken`), not UATs — confirmed in `pkg/hub/handlers_auth.go:handleAuthValidate`.
+
+The bridge caches `/api/v1/auth/me` responses to avoid a DB round-trip on every A2A message, with a 60-second TTL keyed by SHA-256(token). This means a revoked UAT stops working within 60 seconds of revocation.
+
+The `UserResponse` from `/api/v1/auth/me` includes `{ID, Email, DisplayName, Role}`. The bridge does not receive UAT scopes from this call — scope enforcement is left to the Hub's `enforceUATConstraints` which runs on each Hub API call the bridge makes with the caller's UAT. If the UAT lacks `agent:message` scope, the Hub returns a 403 which the bridge maps to an A2A error response.
+
+### 3.4 New Auth Schemes: `hubUAT` and `hubJWT`
+
+**`AuthConfig` struct changes** (`internal/bridge/config.go`):
+
+```go
+type AuthConfig struct {
+    // Scheme selects the auth mode.
+    // Existing: "apiKey" | "bearer" | "none"
+    // New:      "hubUAT" | "hubJWT"
+    Scheme string `yaml:"scheme"`
+
+    // APIKey is the shared static key for "apiKey" and "bearer" schemes.
+    // Not used for hubUAT or hubJWT.
+    APIKey string `yaml:"api_key"`
+
+    // UATCacheTTL is the UAT introspection cache TTL for hubUAT mode.
+    // Default: 60s. Maximum: 300s.
+    UATCacheTTL time.Duration `yaml:"uat_cache_ttl"`
+}
+```
+
+`ValidateConfig` changes:
+- Accept `"hubUAT"` and `"hubJWT"` as valid scheme values.
+- `api_key` is NOT required for `hubUAT` or `hubJWT`.
+- For `hubJWT`, the Hub signing key must be present (`cfg.Hub.SigningKey` or `cfg.Hub.SigningKeySecret`) — already validated for the existing minter path, so no new validation needed.
+- For `hubUAT`, no additional config fields are required beyond the existing `hub.endpoint`.
+
+**Sample config** (`scion-a2a-bridge.yaml.sample`) additions:
+
+```yaml
+auth:
+  # Per-user UAT auth. Callers present "Authorization: Bearer scion_pat_..."
+  # The bridge validates each token via Hub /api/v1/auth/me (60s cache).
+  scheme: "hubUAT"
+  # uat_cache_ttl: 60s   # optional: default 60s, max 300s
+
+  # --- OR: per-user JWT auth (for CLI/scripted access) ---
+  # scheme: "hubJWT"
+  # The hub.signing_key is used for local JWT validation. No api_key needed.
+
+  # --- Backward-compatible shared key (existing deployments) ---
+  # scheme: "apiKey"
+  # api_key: "${A2A_API_KEY}"
+```
+
+### 3.5 `CallerIdentity`: Context Propagation
+
+A new `CallerIdentity` struct carries the validated caller identity from `authMiddleware` through to `Bridge.SendMessage`:
+
+```go
+// internal/bridge/caller.go (new file)
+package bridge
+
+// CallerIdentity holds the per-request caller identity extracted from a
+// validated hub credential. Absent for legacy apiKey/bearer/none modes.
+type CallerIdentity struct {
+    UserID    string
+    Email     string
+    Role      string
+    RawToken  string // The original bearer token for UAT passthrough
+    TokenType string // "uat" or "jwt"
+}
+
+type callerContextKey struct{}
+
+func withCallerIdentity(ctx context.Context, id *CallerIdentity) context.Context {
+    return context.WithValue(ctx, callerContextKey{}, id)
+}
+
+func callerIdentityFromContext(ctx context.Context) *CallerIdentity {
+    v, _ := ctx.Value(callerContextKey{}).(*CallerIdentity)
+    return v
+}
+```
+
+**Context flow:**
+1. `authMiddleware` (in `server.go`) validates the token, constructs `CallerIdentity`, injects into `r.Context()`.
+2. `handleJSONRPC` already propagates `r.Context()` to the SDK handler via `r.WithContext(ctx)`.
+3. The SDK calls `executor.OnSendMessage` / `executor.OnMessageStream` which receives `ctx`.
+4. `ScionExecutor` passes `ctx` to `Bridge.SendMessage`.
+5. `Bridge.SendMessage` reads `CallerIdentity` from context to determine Hub client and Sender identity.
+
+### 3.6 `authMiddleware` Changes
+
+The revised `authMiddleware` in `server.go` adds two branches before the existing static-key comparison:
+
+```
+switch cfg.Auth.Scheme:
+
+case "hubUAT":
+    token = extractBearerOrAPIKey(r)
+    if !strings.HasPrefix(token, "scion_pat_") { → 401 }
+    callerID = s.uatValidator.Validate(ctx, token)  // cached /auth/me call
+    if err { → 401 }
+    inject CallerIdentity{UserID, Email, Role, RawToken: token, TokenType: "uat"}
+    next()
+
+case "hubJWT":
+    token = extractBearerToken(r)
+    claims = s.jwtValidator.ValidateUserToken(token) // local, no network
+    if err { → 401 }
+    inject CallerIdentity{UserID: claims.UserID, Email: claims.Email,
+                          Role: claims.Role, RawToken: token, TokenType: "jwt"}
+    next()
+
+case "apiKey", "bearer", "":
+    // Existing constant-time SHA-256 compare; no CallerIdentity injected.
+
+case "none":
+    next() // pass-through, no CallerIdentity
+```
+
+**`UATValidator`** (new, `internal/bridge/uatvalidator.go`):
+- Wraps the Hub `/api/v1/auth/me` HTTP call using the admin HTTP transport.
+- Caches results in a `sync.Map` keyed by `sha256.Sum256([]byte(rawToken))` (avoids storing plaintext tokens in cache keys).
+- Cache entries have a configurable TTL (default 60s, max 300s). A background goroutine or lazy eviction on access cleans expired entries.
+- Returns `CallerIdentity` or an error.
+
+```go
+type UATValidator struct {
+    hubEndpoint string
+    httpClient  *http.Client
+    ttl         time.Duration
+    mu          sync.Mutex
+    cache       map[[32]byte]*uatCacheEntry
+}
+
+type uatCacheEntry struct {
+    identity  *CallerIdentity
+    expiresAt time.Time
+}
+
+func (v *UATValidator) Validate(ctx context.Context, token string) (*CallerIdentity, error) {
+    key := sha256.Sum256([]byte(token))
+    // check cache; if hit and not expired, return
+    // else: GET hub.endpoint + "/api/v1/auth/me"
+    //       Header: Authorization: Bearer <token>
+    // parse UserResponse → CallerIdentity{RawToken: token, TokenType: "uat"}
+    // store in cache with expiresAt = now + ttl
+}
+```
+
+**`JWTValidator`** (thin wrapper around the existing `UserTokenService`):
+- In `hubJWT` mode, the bridge constructs a `hub.UserTokenService` from the same signing key it already uses for minting. No new key material needed.
+- `ValidateUserToken` is already implemented (`pkg/hub/usertoken.go`). The bridge imports and calls it directly.
+- The bridge's `go.mod` already imports `pkg/hub` (confirmed via import of `pkg/hubclient`). If it doesn't import `pkg/hub` directly, a thin copy of the JWT validation logic into `internal/bridge/jwtvalidator.go` avoids the import cycle (the bridge is in `extras/`, not `pkg/`, so there is no cycle — confirm before implementation).
+
+### 3.7 Hub API Call Routing
+
+**`Bridge.SendMessage` changes** (`internal/bridge/bridge.go`):
+
+```go
+func (b *Bridge) SendMessage(ctx context.Context, projectSlug, agentSlug, contextID,
+    existingTaskID string, parts []Part, blocking bool) (*TaskResult, error) {
+
+    caller := callerIdentityFromContext(ctx) // nil in legacy mode
+
+    // writeClient: used for Hub write operations (send message, cancel interrupt).
+    // In per-user mode, this is a short-lived client authenticated as the caller.
+    // In legacy mode, it's the bridge admin client.
+    writeClient := b.hubClient // legacy default
+    senderUser := b.config.Hub.User
+
+    if caller != nil {
+        senderUser = caller.Email
+        var err error
+        writeClient, err = b.callerHubClient(caller)
+        if err != nil {
+            return nil, fmt.Errorf("creating per-user hub client: %w", err)
+        }
+        // Note: writeClient is created here per-message. The hubclient.New
+        // call is cheap (no connection made until first request).
+    }
+
+    // ... existing context resolution uses b.hubClient (admin, unchanged) ...
+
+    scionMsg.Sender = fmt.Sprintf("user:%s", senderUser)
+    scionMsg.Recipient = fmt.Sprintf("agent:%s", agentCtx.AgentSlug)
+
+    // Broker subscription: in per-user mode, subscribe to wildcard
+    // AllUserTopic so replies to any user's messages are received.
+    if b.broker != nil {
+        if caller != nil {
+            b.subscribeAllUserTopics(agentCtx.ProjectID)
+        } else {
+            b.subscribeAdminUserTopics(agentCtx.ProjectID)
+        }
+    }
+
+    // ... send via writeClient.Agents().SendStructuredMessage ...
+}
+
+// callerHubClient creates a per-request Hub client authenticated as the caller.
+func (b *Bridge) callerHubClient(caller *CallerIdentity) (hubclient.Client, error) {
+    switch caller.TokenType {
+    case "uat":
+        return hubclient.New(b.config.Hub.Endpoint,
+            hubclient.WithBearerToken(caller.RawToken))
+    case "jwt":
+        // Re-mint a 5-minute JWT for the caller's identity using the bridge's signing key.
+        mintAuth := identity.NewMintingAuth(b.minter,
+            caller.UserID, caller.Email, caller.Role, 5*time.Minute)
+        return hubclient.New(b.config.Hub.Endpoint,
+            hubclient.WithAuthenticator(mintAuth))
+    default:
+        return nil, fmt.Errorf("unknown token type: %s", caller.TokenType)
+    }
+}
+```
+
+**Context resolution and agent lookup** (`resolveContext`, `lookupAgent`) continue to use `b.hubClient` (the admin client). These are read-only operations on the bridge's configured projects, and the admin client has full access. Per-user callers don't need to own the context resolution path — it's a bridge-internal concern.
+
+### 3.8 Broker Subscription: Wildcard Per-Project
+
+**Problem:** Today the bridge subscribes to `UserTopic(projectID, b.config.Hub.User)` — the bridge admin's user topic. If we change `scionMsg.Sender` to the caller's email, agents reply to the caller's user topic, which the bridge's existing subscription doesn't cover.
+
+**Solution:** In `hubUAT`/`hubJWT` mode, subscribe to `AllUserTopic(projectID)` — the wildcard `scion.project.<projectID>.user.*.messages`. This single subscription captures replies from all users, regardless of which user sent the original message. The existing `a2aTaskId` metadata in message replies ensures each reply is routed to the correct waiter.
+
+```go
+func (b *Bridge) subscribeAllUserTopics(projectID string) {
+    patterns := []string{
+        projectcompat.AllUserTopic(projectID),
+        projectcompat.LegacyAllUserTopic(projectID), // if it exists; else skip
+    }
+    for _, pattern := range patterns {
+        if err := b.broker.RequestSubscription(pattern); err != nil {
+            b.log.Warn("failed to request wildcard subscription", "pattern", pattern, "error", err)
+        }
+    }
+}
+```
+
+The wildcard subscription is idempotent (the broker deduplicates repeated subscription requests). It is requested once per project per message, but the underlying subscription persists until the broker connection resets.
+
+**Concern: wildcard subscription traffic.** In a multi-tenant environment, subscribing to `scion.project.<projectID>.user.*.messages` causes the bridge to receive ALL user messages in that project, not just A2A-bridged ones. The bridge already has `a2aTaskId`-based filtering: if a message's `a2aTaskId` is unknown or absent, `dispatchBrokerMessage` drops it with a warning. Net effect: some extra broker messages are received and discarded. This is acceptable given the bridge is a dedicated service for a specific set of configured projects.
+
+**Legacy mode** (`apiKey`/`bearer`/`none`): continues to subscribe to `UserTopic(projectID, b.config.Hub.User)` as today, no change.
+
+**Migration:** If an operator switches from `apiKey` mode to `hubUAT` mode mid-operation, in-flight tasks created under the old mode (with Sender = bridge admin user) will have their agent replies routed to the bridge admin's user topic. The bridge will no longer subscribe to that topic in per-user mode. **Recommendation:** Drain in-flight tasks before switching auth modes, or subscribe to BOTH the admin user topic and the AllUserTopic during a transition window.
+
+### 3.9 Per-User Task Isolation
+
+**State schema change** (`internal/state/state.go`):
+
+```go
+type Task struct {
+    ID          string
+    ContextID   string
+    ProjectID   string
+    AgentSlug   string
+    AgentID     string
+    State       string
+    CallerUserID string // NEW: empty for legacy-mode tasks
+    CreatedAt   time.Time
+    UpdatedAt   time.Time
+    Metadata    string
+}
+```
+
+SQLite migration (at startup, existing migration pattern):
+
+```sql
+ALTER TABLE tasks ADD COLUMN caller_user_id TEXT NOT NULL DEFAULT '';
+```
+
+This is backward-compatible (existing rows get `''`).
+
+**Isolation enforcement:**
+
+- `Bridge.GetTask`: if `CallerIdentity` is in context AND task's `CallerUserID` is non-empty, return 404 if caller's UserID ≠ task's CallerUserID.
+- `Bridge.CancelTask`: same check.
+- `Bridge.ListTasks`: filter by `CallerUserID` if caller is identified.
+- Legacy mode (no CallerIdentity, CallerUserID is `''`): no isolation enforced — behavior unchanged.
+
+Tasks created in legacy mode (`CallerUserID = ''`) are visible to all legacy-mode callers but NOT to per-user callers (the 404 guard only fires if BOTH the context has a caller identity AND the task has a non-empty CallerUserID). This means mixed-mode deployments work safely.
+
+### 3.10 Task Record at CreateTask
+
+In `Bridge.SendMessage`, when creating the task:
+
+```go
+task := &state.Task{
+    ID:           taskID,
+    ContextID:    agentCtx.ContextID,
+    ProjectID:    agentCtx.ProjectID,
+    AgentSlug:    agentCtx.AgentSlug,
+    AgentID:      agentCtx.AgentID,
+    State:        TaskStateSubmitted,
+    CallerUserID: "", // default
+    CreatedAt:    now,
+    UpdatedAt:    now,
+    Metadata:     "{}",
+}
+if caller != nil {
+    task.CallerUserID = caller.UserID
+}
+```
+
+### 3.11 ScopedTaskStore and SDK-Level Task Isolation
+
+The bridge uses a `ScopedTaskStore` wrapper around the SDK's in-memory task store (`a2asrv/taskstore`). This store already enforces project/agent routing isolation (task ownership by route key). The `CallerUserID` isolation described in §3.9 is enforced at the `Bridge` layer on `GetTask`/`CancelTask`/`ListTasks` — which wrap the SQLite state store, not the SDK task store. The two isolation layers are complementary.
+
+### 3.12 Documentation Deliverable
+
+Add a new section to `docs-site/src/content/docs/hosted/user/external-channels.md`:
+
+**"Desktop App Federation (Claude Desktop, Codex Desktop)":**
+
+1. Create a Scion UAT with `agent:message` and `agent:read` scopes for your project:
+   ```
+   scion token create --name "claude-desktop" --project <project-slug> \
+     --scope agent:message,agent:read --expires 365d
+   ```
+2. In Claude Desktop's A2A provider settings, set:
+   - Endpoint: `https://<bridge-host>/projects/<project-slug>/agents/<agent-slug>`
+   - Auth: Bearer token → paste your `scion_pat_...` token
+3. Bridge operator: configure `auth.scheme: hubUAT` (no api_key needed).
+
+The documentation should cover the agent card URL for discovery, the required scopes, and how to test the connection with `curl`.
+
+---
+
+## Alternatives Considered
+
+### Alternative A: New Hub UAT Introspection Endpoint (`POST /api/v1/auth/introspect`)
+
+Create a new endpoint on the Hub (RFC 7662-style) that accepts a token and returns `{valid, user_id, email, role, scopes, project_id}`. The bridge calls this once per request (cached) to get full token metadata including scopes, allowing bridge-level scope pre-validation.
+
+**Rejected because:**
+- Requires new Hub code, adding to the scope and creating a Hub dependency.
+- The existing `GET /api/v1/auth/me` already provides the user identity the bridge needs (ID, email, role). Scope enforcement at the Hub layer is sufficient — the bridge does not need to pre-validate scopes.
+- RFC 7662 is valuable in a multi-service architecture where many services share a token validation endpoint; here the bridge-to-Hub topology is point-to-point and `/auth/me` is simpler.
+
+This alternative is not entirely off the table for a future iteration (e.g., if the bridge needs to make scope-based routing decisions), but it is unnecessary for the current requirement.
+
+### Alternative B: Service Account Model (Bridge Admin Always, User ID in Metadata)
+
+The bridge validates the caller's UAT via `/auth/me` to get identity, but continues to make all Hub API calls as the bridge admin user (`b.hubClient`). The caller's user ID is passed as message metadata (`scionMsg.Metadata["callerUserID"] = callerUserID`).
+
+**Rejected because:**
+- Does not close the actual gap. Hub audit logs still show the bridge admin as the message sender, not the real user. Hub-side authz (`enforceUATConstraints`) doesn't run on the caller's scopes — it runs on the bridge admin's permissions. A misconfigured bridge admin could send messages beyond what the UAT's scopes allow.
+- The caller's UAT scopes (e.g., `agent:message` only, not `agent:create`) are not enforced at the Hub layer — only at the bridge layer, which is a weaker guarantee.
+- Auth-lead explicitly identified this as the gap: "All A2A callers share one undifferentiated Hub identity."
+
+This model is significantly simpler to implement (no per-request Hub clients, no broker subscription changes) and could be a valid "Phase 0" or "escape hatch" if full identity propagation proves operationally difficult. It is preserved as an option but is not the recommended path.
+
+### Alternative C: JWT-Only Auth (No UAT Support)
+
+Add only `hubJWT` mode: validate user JWTs locally using the Hub signing key, re-mint for Hub calls. No `hubUAT` support.
+
+**Rejected because:**
+- User JWTs (15 min) and CLI JWTs (30 days) require more frequent rotation than UATs (up to 1 year). Desktop apps benefit from long-lived credentials.
+- No immediate revocation for JWTs. If a user's access is revoked in the Hub, their JWT remains valid until expiry.
+- UATs are the idiomatic Scion programmatic credential (`scion_pat_*`) and the natural choice for desktop app onboarding. Supporting only JWTs would require users to manage token rotation themselves.
+- Both schemes can be supported with modest additional code.
+
+`hubJWT` is kept as a secondary scheme for scripting/CI use cases where JWT rotation is already managed by the tool (e.g., the Scion CLI).
+
+### Alternative D: UAT Validated Entirely by Hub Per-Request (No Bridge Cache)
+
+Skip the `/auth/me` introspection call and just pass the UAT directly to the Hub on every Hub API call (first call is list-agents or send-message). The Hub validates it there. The bridge gets the user identity only implicitly (it doesn't know who the caller is until the Hub rejects or accepts the call).
+
+**Rejected because:**
+- The bridge needs the caller's identity BEFORE the Hub call to: (a) set the correct `Sender` field, (b) record `CallerUserID` on the task, (c) enforce per-user task isolation. Without a dedicated introspection step, the bridge is blind to the caller's identity.
+- This model would require the bridge to parse the Hub's response to infer user identity, which is fragile.
+
+---
+
+## Migration / Rollout
+
+### Forward-Compat
+- Existing deployments using `apiKey` or `bearer` schemes continue to work with zero config changes. The new schemes are opt-in.
+- The `CallerUserID` column has a `DEFAULT ''` — existing rows are unaffected.
+- Legacy tasks (CallerUserID = '') are not subject to per-user isolation checks. Mixed-mode operation is safe.
+
+### Backward-Compat
+- The `hubUAT` scheme does not remove or change the `apiKey` or `bearer` schemes.
+- The API key validation code path is unchanged.
+- The broker subscription pattern change (`AllUserTopic` vs specific user topic) is scoped to `hubUAT`/`hubJWT` mode. Legacy mode retains the existing subscription behavior.
+
+### Migration Steps for Operators
+
+1. **Bridge operator:** Update bridge config to `auth.scheme: hubUAT`. Remove `auth.api_key`. Ensure `hub.signing_key` is still set (unchanged).
+2. **Drain in-flight tasks** before the config change to avoid subscription routing issues (see §3.8).
+3. **End users:** Create a UAT in the Scion Hub UI with `agent:message` and `agent:read` scopes, scoped to the target project.
+4. **Desktop app:** Set `Authorization: Bearer scion_pat_...` in the A2A provider config.
+5. **Verify:** Use the `/healthz` endpoint to confirm the bridge restarted cleanly. Send a test message via `curl` to verify auth succeeds.
+
+### State Database Migration
+
+The SQLite `ALTER TABLE` migration runs at startup if the `caller_user_id` column doesn't exist. No downtime is required — SQLite `ALTER TABLE ADD COLUMN` is instantaneous.
+
+---
+
+## Open Questions
+
+1. **`AllUserTopic` wildcard and legacy broker compatibility:** `projectcompat.AllUserTopic()` exists in the codebase. Does the broker support NATS-style wildcard subscriptions with `*`? Verify with the broker team before implementation. If wildcards are not supported, fall back to Alternative B (service account model) for Phase 1 and add a GitHub issue for wildcard broker support.
+
+2. **`agent-authz-arch` overlap:** Auth-lead flagged an active project designing a role-tier system for agent identities. If that project changes how external identities are represented, this design may need a revision pass. The developer should check `agent-authz-arch`'s current state before implementation and file a follow-up issue if integration work is needed.
+
+3. **Hub client creation cost at scale:** Per-request `hubclient.New()` is cheap (creates a struct, no connection until first HTTP call). At high request rates, connection pool behavior may matter. If profiling shows this is a bottleneck, the bridge can maintain a short-lived per-user client LRU cache (keyed by caller token hash, TTL matching the auth cache TTL). This is a follow-on optimization.
+
+4. **Hosted vs. self-hosted:** The documentation should call out whether the bridge is deployed by the Scion operator (self-hosted) or is a shared hosted service. For the hosted case, the bridge operator's `hub.user` admin identity has access to all projects, which may raise privilege questions. The bridge's `exposed_agents` allowlist and project config already limit which agents are reachable — this is the existing defense-in-depth.
+
+---
+
+## Implementation Phases
+
+### Phase 1: Bridge-Side Auth (No Hub Changes)
+
+**Commits/PRs expected: 3–5**
+
+1. **`config.go`**: Add `hubUAT` and `hubJWT` to `ValidateConfig`. Add `UATCacheTTL` to `AuthConfig`. Remove the `api_key` requirement for the new schemes.
+
+2. **`caller.go`** (new file): Define `CallerIdentity`, context key helpers `withCallerIdentity` / `callerIdentityFromContext`.
+
+3. **`uatvalidator.go`** (new file): Implement `UATValidator` with the `/api/v1/auth/me` introspection call and 60-second TTL cache.
+
+4. **`jwtvalidator.go`** (new file or thin wrapper): Wire up `hub.UserTokenService.ValidateUserToken` for local JWT validation in `hubJWT` mode. If `pkg/hub` cannot be imported from `extras/` (check for import cycles), inline the JWT validation logic using `go-jose` (already a dependency of the bridge via `identity.go`).
+
+5. **`server.go:authMiddleware`**: Add `hubUAT` and `hubJWT` branches. Inject `CallerIdentity` into context. Update `WarnOnOpenAuth` to not warn for the new schemes.
+
+6. **`state.go`**: Add `CallerUserID string` to `Task`. Add the `ALTER TABLE` migration in `state.New`. Add `ListTasksByCallerUser` store method.
+
+7. **`bridge.go`**: 
+   - `callerHubClient()`: per-request Hub client factory.
+   - `SendMessage`: read `CallerIdentity` from context; set `scionMsg.Sender`; use `writeClient`; record `CallerUserID` on task.
+   - `GetTask` / `CancelTask` / `ListTasks`: enforce per-user isolation when `CallerIdentity` is present.
+   - `subscribeAllUserTopics()` / `subscribeAdminUserTopics()`: broker subscription helpers.
+
+8. **`scion-a2a-bridge.yaml.sample`**: Add `hubUAT`/`hubJWT` examples.
+
+9. **`docs-site/.../external-channels.md`**: Add desktop app federation guide.
+
+10. **Tests**: 
+    - `uatvalidator_test.go`: mock Hub `/auth/me` call, test cache TTL, test revoked UAT rejection.
+    - `jwtvalidator_test.go`: test expired JWT rejection, wrong audience rejection.
+    - `server_test.go`: table-driven middleware tests for all schemes.
+    - `bridge_test.go` (integration): per-user task isolation (user A cannot access user B's tasks).
+
+### Phase 2: Full Identity Propagation (Follow-On)
+
+If Phase 1 uses the service account fallback (Alternative B) for initial safety:
+
+- Switch `SendMessage` to per-request caller Hub clients.
+- Switch broker subscription to `AllUserTopic`.
+- Update `scionMsg.Sender` to caller's email.
+
+If Phase 1 already implements full identity propagation (recommended), Phase 2 is the optimization pass:
+- Per-user Hub client LRU cache (if needed for performance).
+- Scope pre-validation at bridge layer (if Hub introspection endpoint is added later).
+
+---
+
+## Acceptance Criteria
+
+The QA tester should verify the following before considering this done:
+
+**Functional correctness**
+
+1. `hubUAT` mode: A valid `scion_pat_*` UAT with `agent:message` scope successfully authenticates a `message/send` call.
+2. `hubUAT` mode: An invalid or malformed UAT returns HTTP 401.
+3. `hubUAT` mode: A revoked UAT is rejected within 60 seconds of revocation (the cache TTL).
+4. `hubUAT` mode: A UAT without `agent:message` scope causes a Hub-side 403 that the bridge maps to an A2A error response (not a bridge crash or silent success).
+5. `hubJWT` mode: A valid Scion CLI JWT (HS256, `type: cli`) authenticates successfully.
+6. `hubJWT` mode: An expired or tampered JWT is rejected with HTTP 401.
+7. Legacy `apiKey` mode: Unaffected by this change — existing shared-key deployments continue to work.
+8. Legacy `none` mode: Unaffected.
+
+**Per-user isolation**
+
+9. User A creates a task. User B (different UAT) calls `tasks/get` with User A's task ID and receives a "task not found" response (not A's task data).
+10. User A can cancel their own task.
+11. User A cannot cancel User B's task.
+12. A legacy task (created before this change, with empty CallerUserID) is accessible by legacy callers but not by per-user callers with a populated CallerUserID.
+
+**Identity propagation**
+
+13. After a `message/send` via `hubUAT`, the Scion Hub's message delivery log (or Hub API response) shows the calling user's identity as the message sender, not the bridge admin identity.
+14. The task record in the bridge SQLite DB has `caller_user_id` set to the calling user's Hub user ID.
+
+**State migration**
+
+15. Starting the new bridge binary against an existing SQLite database (without the `caller_user_id` column) succeeds without error. Existing tasks are preserved.
+
+**Documentation**
+
+16. The desktop app federation guide in `external-channels.md` is accurate end-to-end: a user can follow the guide from UAT creation through to a successful `message/send` call.
+
+---
+
+*Design doc path: `.design/a2a-bridge-uat-auth.md`*  
+*Scratchpad: `/scion-volumes/scratchpad/projects/a2a-federation/`*

--- a/docs-site/src/content/docs/hosted/user/external-channels.md
+++ b/docs-site/src/content/docs/hosted/user/external-channels.md
@@ -67,3 +67,86 @@ The A2A (Agent-to-Agent protocol) bridge exposes Scion agents as **standard A2A 
 This is useful for integrating Scion agents into larger multi-agent systems or exposing them to third-party A2A-compatible clients.
 
 For setup and configuration, see [extras/scion-a2a-bridge/README.md](https://github.com/GoogleCloudPlatform/scion/tree/main/extras/scion-a2a-bridge).
+
+### Desktop App Federation (Claude Desktop, Codex Desktop)
+
+Desktop A2A clients (such as Claude Desktop and Codex Desktop) can interact with Scion agents using per-user authentication. Each user presents their own Scion User Access Token (UAT), and the bridge propagates their identity to the Hub for audit logging and access control.
+
+#### Prerequisites
+
+- The bridge operator has deployed the A2A bridge with `auth.scheme: hubUAT`.
+- Your Scion Hub account has access to the target project.
+
+#### Step 1: Create a UAT
+
+Create a Scion UAT scoped to your project with the required permissions:
+
+```bash
+scion token create --name "claude-desktop" --project <project-slug> \
+  --scope agent:message,agent:read --expires 365d
+```
+
+This returns a `scion_pat_...` token. Copy it securely — it will not be shown again.
+
+#### Step 2: Configure Your Desktop App
+
+In your desktop A2A client's provider settings:
+
+- **Endpoint:** `https://<bridge-host>/projects/<project-slug>/agents/<agent-slug>`
+- **Auth type:** Bearer token
+- **Token:** Paste your `scion_pat_...` token
+
+To discover available agents, query the bridge's agent card:
+
+```bash
+curl https://<bridge-host>/.well-known/agent-card.json
+```
+
+Or for a specific agent:
+
+```bash
+curl https://<bridge-host>/projects/<project-slug>/agents/<agent-slug>/.well-known/agent-card.json
+```
+
+#### Step 3: Test the Connection
+
+Verify end-to-end connectivity with a `message/send` call:
+
+```bash
+curl -X POST https://<bridge-host>/projects/<project-slug>/agents/<agent-slug>/jsonrpc \
+  -H "Authorization: Bearer scion_pat_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "message/send",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [{"type": "text", "text": "Hello from desktop!"}]
+      }
+    }
+  }'
+```
+
+#### Required Scopes
+
+| Scope | Purpose |
+|-------|---------|
+| `agent:message` | Send messages to agents |
+| `agent:read` | List agents and read task status |
+
+#### Per-User Isolation
+
+When the bridge uses `hubUAT` or `hubJWT` auth, each user's tasks are isolated:
+
+- You can only see and cancel tasks you created.
+- The Hub's audit logs reflect your identity, not the bridge admin's.
+- If your UAT is revoked, access stops within 60 seconds (the bridge's cache TTL).
+
+:::note[Bridge operator note]
+To enable per-user auth, set `auth.scheme: hubUAT` in `scion-a2a-bridge.yaml`.
+The `auth.api_key` field is not needed for this scheme. See the
+[sample config](https://github.com/GoogleCloudPlatform/scion/tree/main/extras/scion-a2a-bridge/scion-a2a-bridge.yaml.sample)
+for details.
+:::

--- a/extras/scion-a2a-bridge/internal/bridge/auth_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/auth_test.go
@@ -1,0 +1,504 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4/jwt"
+
+	"github.com/GoogleCloudPlatform/scion/extras/scion-a2a-bridge/internal/state"
+)
+
+// testHandler is a minimal handler that echoes back the CallerIdentity if present.
+func testHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		caller := callerIdentityFromContext(r.Context())
+		if caller != nil {
+			json.NewEncoder(w).Encode(map[string]string{
+				"user_id":    caller.UserID,
+				"email":      caller.Email,
+				"token_type": caller.TokenType,
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"caller":"none"}`))
+	})
+}
+
+func TestAuthMiddleware_AllSchemes(t *testing.T) {
+	// Set up a mock Hub for UAT validation.
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/auth/me" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		auth := r.Header.Get("Authorization")
+		if auth == "Bearer scion_pat_valid" {
+			json.NewEncoder(w).Encode(userResponse{
+				ID:    "uat-user-1",
+				Email: "alice@example.com",
+				Role:  "user",
+			})
+			return
+		}
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer hub.Close()
+
+	tests := []struct {
+		name       string
+		scheme     string
+		apiKey     string
+		header     string // header name
+		headerVal  string // header value
+		wantStatus int
+		wantCaller string // expected user_id from CallerIdentity, or "none"
+	}{
+		{
+			name:       "apiKey/valid",
+			scheme:     "apiKey",
+			apiKey:     "my-secret",
+			header:     "X-API-Key",
+			headerVal:  "my-secret",
+			wantStatus: http.StatusOK,
+			wantCaller: "none",
+		},
+		{
+			name:       "apiKey/invalid",
+			scheme:     "apiKey",
+			apiKey:     "my-secret",
+			header:     "X-API-Key",
+			headerVal:  "wrong-key",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "apiKey/missing",
+			scheme:     "apiKey",
+			apiKey:     "my-secret",
+			header:     "",
+			headerVal:  "",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "bearer/valid",
+			scheme:     "bearer",
+			apiKey:     "my-secret",
+			header:     "Authorization",
+			headerVal:  "Bearer my-secret",
+			wantStatus: http.StatusOK,
+			wantCaller: "none",
+		},
+		{
+			name:       "bearer/invalid",
+			scheme:     "bearer",
+			apiKey:     "my-secret",
+			header:     "Authorization",
+			headerVal:  "Bearer wrong",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "none/no-header",
+			scheme:     "none",
+			header:     "",
+			headerVal:  "",
+			wantStatus: http.StatusOK,
+			wantCaller: "none",
+		},
+		{
+			name:       "hubUAT/valid",
+			scheme:     "hubUAT",
+			header:     "Authorization",
+			headerVal:  "Bearer scion_pat_valid",
+			wantStatus: http.StatusOK,
+			wantCaller: "uat-user-1",
+		},
+		{
+			name:       "hubUAT/invalid",
+			scheme:     "hubUAT",
+			header:     "Authorization",
+			headerVal:  "Bearer scion_pat_bad",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "hubUAT/not-pat-prefix",
+			scheme:     "hubUAT",
+			header:     "Authorization",
+			headerVal:  "Bearer not-a-pat",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "hubUAT/missing",
+			scheme:     "hubUAT",
+			header:     "",
+			headerVal:  "",
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			store, err := state.New(filepath.Join(dir, "test.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+
+			cfg := &Config{
+				Bridge: BridgeConfig{ExternalURL: "https://test"},
+				Hub:    HubConfig{Endpoint: hub.URL, User: "admin@test"},
+				Auth:   AuthConfig{Scheme: tt.scheme, APIKey: tt.apiKey},
+			}
+
+			log := slog.New(slog.NewTextHandler(io.Discard, nil))
+			b := New(store, nil, nil, cfg, nil, log)
+			srv := NewServer(b, cfg, nil, log, testHandler())
+
+			mw := srv.authMiddleware(testHandler())
+			req := httptest.NewRequest(http.MethodPost, "/projects/p/agents/a/jsonrpc", nil)
+			if tt.header != "" {
+				req.Header.Set(tt.header, tt.headerVal)
+			}
+
+			w := httptest.NewRecorder()
+			mw.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+
+			if tt.wantStatus == http.StatusOK && tt.wantCaller != "" {
+				var body map[string]string
+				json.NewDecoder(w.Body).Decode(&body)
+				if tt.wantCaller == "none" {
+					if body["caller"] != "none" && body["user_id"] != "" {
+						t.Errorf("expected no caller identity, got %v", body)
+					}
+				} else {
+					if body["user_id"] != tt.wantCaller {
+						t.Errorf("caller user_id = %q, want %q", body["user_id"], tt.wantCaller)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestAuthMiddleware_HubJWT(t *testing.T) {
+	signingKey := testSigningKey(t)
+
+	dir := t.TempDir()
+	store, err := state.New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	cfg := &Config{
+		Bridge: BridgeConfig{ExternalURL: "https://test"},
+		Hub:    HubConfig{Endpoint: "http://hub", User: "admin@test"},
+		Auth:   AuthConfig{Scheme: "hubJWT"},
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := New(store, nil, nil, cfg, nil, log)
+	srv := NewServer(b, cfg, nil, log, testHandler())
+	srv.SetJWTValidator(NewJWTValidator(signingKey))
+
+	// Valid JWT
+	claims := validClaims()
+	token := mintTestJWT(t, signingKey, claims)
+
+	mw := srv.authMiddleware(testHandler())
+	req := httptest.NewRequest(http.MethodPost, "/projects/p/agents/a/jsonrpc", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("valid JWT: status = %d, want 200", w.Code)
+	}
+
+	var body map[string]string
+	json.NewDecoder(w.Body).Decode(&body)
+	if body["user_id"] != "user-1" {
+		t.Errorf("user_id = %q, want %q", body["user_id"], "user-1")
+	}
+	if body["token_type"] != "jwt" {
+		t.Errorf("token_type = %q, want %q", body["token_type"], "jwt")
+	}
+
+	// Expired JWT
+	expiredClaims := validClaims()
+	expiredClaims.Expiry = jwt.NewNumericDate(time.Now().Add(-1 * time.Hour))
+	expiredToken := mintTestJWT(t, signingKey, expiredClaims)
+
+	req2 := httptest.NewRequest(http.MethodPost, "/projects/p/agents/a/jsonrpc", nil)
+	req2.Header.Set("Authorization", "Bearer "+expiredToken)
+
+	w2 := httptest.NewRecorder()
+	mw.ServeHTTP(w2, req2)
+
+	if w2.Code != http.StatusUnauthorized {
+		t.Errorf("expired JWT: status = %d, want 401", w2.Code)
+	}
+}
+
+func TestAuthMiddleware_PublicEndpoints(t *testing.T) {
+	dir := t.TempDir()
+	store, err := state.New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	cfg := &Config{
+		Bridge: BridgeConfig{ExternalURL: "https://test"},
+		Hub:    HubConfig{Endpoint: "http://hub", User: "admin@test"},
+		Auth:   AuthConfig{Scheme: "hubUAT"},
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := New(store, nil, nil, cfg, nil, log)
+	srv := NewServer(b, cfg, nil, log, testHandler())
+
+	mw := srv.authMiddleware(testHandler())
+
+	paths := []string{
+		"/.well-known/agent-card.json",
+		"/healthz",
+		"/readyz",
+		"/projects/test/agents/agent/.well-known/agent-card.json",
+		"/groves/test/agents/agent/.well-known/agent-card.json",
+	}
+
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			// No auth headers
+			w := httptest.NewRecorder()
+			mw.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Errorf("public endpoint %s: status = %d, want 200", path, w.Code)
+			}
+		})
+	}
+}
+
+func TestPerUserTaskIsolation(t *testing.T) {
+	dir := t.TempDir()
+	store, err := state.New(filepath.Join(dir, "iso-test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	cfg := &Config{
+		Bridge: BridgeConfig{ExternalURL: "https://test"},
+		Hub:    HubConfig{Endpoint: "http://hub", User: "admin@test"},
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := New(store, nil, nil, cfg, nil, log)
+
+	now := time.Now()
+
+	// Create tasks for two different users.
+	store.CreateTask(&state.Task{
+		ID: "task-alice", ContextID: "ctx-1", ProjectID: "proj-1",
+		AgentSlug: "agent-1", State: "working", CallerUserID: "user-alice",
+		CreatedAt: now, UpdatedAt: now, Metadata: "{}",
+	})
+	store.CreateTask(&state.Task{
+		ID: "task-bob", ContextID: "ctx-1", ProjectID: "proj-1",
+		AgentSlug: "agent-1", State: "working", CallerUserID: "user-bob",
+		CreatedAt: now, UpdatedAt: now, Metadata: "{}",
+	})
+	// Create a legacy task (no caller).
+	store.CreateTask(&state.Task{
+		ID: "task-legacy", ContextID: "ctx-1", ProjectID: "proj-1",
+		AgentSlug: "agent-1", State: "working", CallerUserID: "",
+		CreatedAt: now, UpdatedAt: now, Metadata: "{}",
+	})
+
+	aliceCtx := withCallerIdentity(context.Background(), &CallerIdentity{
+		UserID: "user-alice", Email: "alice@test", TokenType: "uat",
+	})
+	bobCtx := withCallerIdentity(context.Background(), &CallerIdentity{
+		UserID: "user-bob", Email: "bob@test", TokenType: "uat",
+	})
+	legacyCtx := context.Background() // no caller identity
+
+	// Alice can get her own task.
+	result, err := b.GetTask(aliceCtx, "task-alice")
+	if err != nil {
+		t.Fatalf("Alice GetTask own: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Alice should be able to get her own task")
+	}
+
+	// Alice cannot get Bob's task.
+	result, err = b.GetTask(aliceCtx, "task-bob")
+	if err != nil {
+		t.Fatalf("Alice GetTask bob: %v", err)
+	}
+	if result != nil {
+		t.Fatal("Alice should NOT be able to get Bob's task")
+	}
+
+	// Alice cannot see legacy tasks.
+	result, err = b.GetTask(aliceCtx, "task-legacy")
+	if err != nil {
+		t.Fatalf("Alice GetTask legacy: %v", err)
+	}
+	if result != nil {
+		t.Fatal("Alice (per-user) should NOT see legacy tasks")
+	}
+
+	// Legacy caller can see legacy tasks.
+	result, err = b.GetTask(legacyCtx, "task-legacy")
+	if err != nil {
+		t.Fatalf("Legacy GetTask legacy: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Legacy caller should see legacy tasks")
+	}
+
+	// Legacy caller can see per-user tasks (no isolation without CallerIdentity).
+	result, err = b.GetTask(legacyCtx, "task-alice")
+	if err != nil {
+		t.Fatalf("Legacy GetTask alice: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Legacy caller should see all tasks")
+	}
+
+	// ListTasks: Alice only sees her tasks.
+	results, err := b.ListTasks(aliceCtx, "ctx-1")
+	if err != nil {
+		t.Fatalf("Alice ListTasks: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != "task-alice" {
+		t.Errorf("Alice ListTasks = %d tasks, want 1 (task-alice)", len(results))
+	}
+
+	// ListTasks: Bob only sees his tasks.
+	results, err = b.ListTasks(bobCtx, "ctx-1")
+	if err != nil {
+		t.Fatalf("Bob ListTasks: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != "task-bob" {
+		t.Errorf("Bob ListTasks = %d tasks, want 1 (task-bob)", len(results))
+	}
+
+	// ListTasks: Legacy sees all tasks.
+	results, err = b.ListTasks(legacyCtx, "ctx-1")
+	if err != nil {
+		t.Fatalf("Legacy ListTasks: %v", err)
+	}
+	if len(results) != 3 {
+		t.Errorf("Legacy ListTasks = %d tasks, want 3", len(results))
+	}
+
+	// CancelTask: Alice cannot cancel Bob's task.
+	cancelResult, err := b.CancelTask(aliceCtx, "task-bob")
+	if err != nil {
+		t.Fatalf("Alice CancelTask bob: %v", err)
+	}
+	if cancelResult != nil {
+		t.Fatal("Alice should NOT be able to cancel Bob's task")
+	}
+}
+
+func TestValidateConfig_NewSchemes(t *testing.T) {
+	base := Config{
+		Bridge: BridgeConfig{ExternalURL: "https://test"},
+		Hub:    HubConfig{Endpoint: "http://hub", User: "admin@test"},
+	}
+
+	tests := []struct {
+		name    string
+		auth    AuthConfig
+		wantErr bool
+	}{
+		{
+			name:    "hubUAT/valid",
+			auth:    AuthConfig{Scheme: "hubUAT"},
+			wantErr: false,
+		},
+		{
+			name:    "hubJWT/valid",
+			auth:    AuthConfig{Scheme: "hubJWT"},
+			wantErr: false,
+		},
+		{
+			name:    "hubUAT/with-ttl",
+			auth:    AuthConfig{Scheme: "hubUAT", UATCacheTTL: 120 * time.Second},
+			wantErr: false,
+		},
+		{
+			name:    "hubUAT/ttl-too-high",
+			auth:    AuthConfig{Scheme: "hubUAT", UATCacheTTL: 600 * time.Second},
+			wantErr: true,
+		},
+		{
+			name:    "hubUAT/negative-ttl",
+			auth:    AuthConfig{Scheme: "hubUAT", UATCacheTTL: -1 * time.Second},
+			wantErr: true,
+		},
+		{
+			name:    "hubUAT/no-api-key-needed",
+			auth:    AuthConfig{Scheme: "hubUAT"},
+			wantErr: false,
+		},
+		{
+			name:    "unsupported/scheme",
+			auth:    AuthConfig{Scheme: "oauth2"},
+			wantErr: true,
+		},
+		{
+			name:    "apiKey/still-works",
+			auth:    AuthConfig{Scheme: "apiKey", APIKey: "key"},
+			wantErr: false,
+		},
+		{
+			name:    "apiKey/missing-key",
+			auth:    AuthConfig{Scheme: "apiKey"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base
+			cfg.Auth = tt.auth
+			err := ValidateConfig(&cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateConfig() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/extras/scion-a2a-bridge/internal/bridge/auth_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/auth_test.go
@@ -440,9 +440,10 @@ func TestValidateConfig_NewSchemes(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		auth    AuthConfig
-		wantErr bool
+		name       string
+		auth       AuthConfig
+		hubOverride *HubConfig // if non-nil, overrides base Hub config
+		wantErr    bool
 	}{
 		{
 			name:    "hubUAT/valid",
@@ -450,9 +451,15 @@ func TestValidateConfig_NewSchemes(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "hubJWT/valid",
+			name:       "hubJWT/valid",
+			auth:       AuthConfig{Scheme: "hubJWT"},
+			hubOverride: &HubConfig{Endpoint: "http://hub", User: "admin@test", SigningKey: "test-secret-key"},
+			wantErr:    false,
+		},
+		{
+			name:    "hubJWT/missing-signing-key",
 			auth:    AuthConfig{Scheme: "hubJWT"},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name:    "hubUAT/with-ttl",
@@ -495,6 +502,9 @@ func TestValidateConfig_NewSchemes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := base
 			cfg.Auth = tt.auth
+			if tt.hubOverride != nil {
+				cfg.Hub = *tt.hubOverride
+			}
 			err := ValidateConfig(&cfg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateConfig() error = %v, wantErr = %v", err, tt.wantErr)

--- a/extras/scion-a2a-bridge/internal/bridge/bridge.go
+++ b/extras/scion-a2a-bridge/internal/bridge/bridge.go
@@ -257,18 +257,39 @@ func (b *Bridge) SendMessage(ctx context.Context, projectSlug, agentSlug, contex
 		return nil, fmt.Errorf("resolve context: %w", err)
 	}
 
+	caller := callerIdentityFromContext(ctx) // nil in legacy mode
+
+	// writeClient: used for Hub write operations (send message, cancel interrupt).
+	// In per-user mode, this is a short-lived client authenticated as the caller.
+	// In legacy mode, it's the bridge admin client.
+	writeClient := b.hubClient
+	senderUser := b.config.Hub.User
+
+	if caller != nil {
+		senderUser = caller.Email
+		var clientErr error
+		writeClient, clientErr = b.callerHubClient(caller)
+		if clientErr != nil {
+			return nil, fmt.Errorf("creating per-user hub client: %w", clientErr)
+		}
+	}
+
 	taskID := uuid.New().String()
 	now := time.Now()
 	task := &state.Task{
-		ID:        taskID,
-		ContextID: agentCtx.ContextID,
-		ProjectID: agentCtx.ProjectID,
-		AgentSlug: agentCtx.AgentSlug,
-		AgentID:   agentCtx.AgentID,
-		State:     TaskStateSubmitted,
-		CreatedAt: now,
-		UpdatedAt: now,
-		Metadata:  "{}",
+		ID:           taskID,
+		ContextID:    agentCtx.ContextID,
+		ProjectID:    agentCtx.ProjectID,
+		AgentSlug:    agentCtx.AgentSlug,
+		AgentID:      agentCtx.AgentID,
+		State:        TaskStateSubmitted,
+		CallerUserID: "", // default for legacy
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		Metadata:     "{}",
+	}
+	if caller != nil {
+		task.CallerUserID = caller.UserID
 	}
 	if err := b.store.CreateTask(task); err != nil {
 		return nil, fmt.Errorf("create task: %w", err)
@@ -278,19 +299,15 @@ func (b *Bridge) SendMessage(ctx context.Context, projectSlug, agentSlug, contex
 	}
 
 	scionMsg := TranslateA2AToScion(parts)
-	scionMsg.Sender = fmt.Sprintf("user:%s", b.config.Hub.User)
+	scionMsg.Sender = fmt.Sprintf("user:%s", senderUser)
 	scionMsg.Recipient = fmt.Sprintf("agent:%s", agentCtx.AgentSlug)
 	scionMsg.Metadata = map[string]string{"a2aTaskId": taskID}
 
 	if b.broker != nil {
-		pattern := projectcompat.UserTopic(agentCtx.ProjectID, b.config.Hub.User)
-		if err := b.broker.RequestSubscription(pattern); err != nil {
-			b.log.Warn("failed to request subscription", "pattern", pattern, "error", err)
-		}
-		// Subscribe to legacy grove topic as well during transition.
-		legacyPattern := projectcompat.LegacyUserTopic(agentCtx.ProjectID, b.config.Hub.User)
-		if err := b.broker.RequestSubscription(legacyPattern); err != nil {
-			b.log.Warn("failed to request legacy subscription", "pattern", legacyPattern, "error", err)
+		if caller != nil {
+			b.subscribeAllUserTopics(agentCtx.ProjectID)
+		} else {
+			b.subscribeAdminUserTopics(agentCtx.ProjectID)
 		}
 	}
 
@@ -302,7 +319,7 @@ func (b *Bridge) SendMessage(ctx context.Context, projectSlug, agentSlug, contex
 			defer b.wg.Done()
 			sendCtx, cancel := context.WithTimeout(b.shutdownCtx, 30*time.Second)
 			defer cancel()
-			if _, err := b.hubClient.Agents().SendStructuredMessage(sendCtx, agentCtx.AgentID, scionMsg, false, false, false); err != nil {
+			if _, err := writeClient.Agents().SendStructuredMessage(sendCtx, agentCtx.AgentID, scionMsg, false, false, false); err != nil {
 				b.log.Error("non-blocking send failed", "error", err, "task_id", taskID)
 				if err := b.store.UpdateTaskState(taskID, TaskStateFailed); err != nil {
 					b.log.Error("failed to update task state", "error", err, "task_id", taskID)
@@ -337,7 +354,7 @@ func (b *Bridge) SendMessage(ctx context.Context, projectSlug, agentSlug, contex
 	// Keep task registered in activeTasks — the agent's eventual state-change
 	// to completed/failed will close it via dispatchToActiveTask.
 
-	if _, err := b.hubClient.Agents().SendStructuredMessage(ctx, agentCtx.AgentID, scionMsg, false, false, false); err != nil {
+	if _, err := writeClient.Agents().SendStructuredMessage(ctx, agentCtx.AgentID, scionMsg, false, false, false); err != nil {
 		if err := b.store.UpdateTaskState(taskID, TaskStateFailed); err != nil {
 			b.log.Error("failed to update task state", "error", err, "task_id", taskID)
 		}
@@ -404,26 +421,42 @@ func (b *Bridge) sendFollowUp(ctx context.Context, projectSlug, agentSlug, taskI
 		return nil, fmt.Errorf("%w: state is %s", ErrTaskTerminal, task.State)
 	}
 
+	caller := callerIdentityFromContext(ctx)
+
+	// Per-user isolation: the follow-up caller must match the task's owner.
+	if caller != nil && task.CallerUserID != "" && caller.UserID != task.CallerUserID {
+		return nil, fmt.Errorf("%w: %s", ErrAgentNotFound, taskID)
+	}
+
+	// Use per-user client if caller identity is present.
+	writeClient := b.hubClient
+	senderUser := b.config.Hub.User
+	if caller != nil {
+		senderUser = caller.Email
+		var clientErr error
+		writeClient, clientErr = b.callerHubClient(caller)
+		if clientErr != nil {
+			return nil, fmt.Errorf("creating per-user hub client: %w", clientErr)
+		}
+	}
+
 	agentID := task.AgentID
 	if agent := b.lookupAgent(ctx, task.ProjectID, task.AgentSlug); agent != nil {
 		agentID = agent.ID
 	}
 
 	scionMsg := TranslateA2AToScion(parts)
-	scionMsg.Sender = fmt.Sprintf("user:%s", b.config.Hub.User)
+	scionMsg.Sender = fmt.Sprintf("user:%s", senderUser)
 	scionMsg.Recipient = fmt.Sprintf("agent:%s", task.AgentSlug)
 	scionMsg.Metadata = map[string]string{"a2aTaskId": taskID}
 
 	// Re-request broker subscriptions in case the broker reconnected since
 	// the original task was created (subscriptions may have been lost).
 	if b.broker != nil {
-		pattern := projectcompat.UserTopic(task.ProjectID, b.config.Hub.User)
-		if err := b.broker.RequestSubscription(pattern); err != nil {
-			b.log.Warn("failed to re-request subscription for follow-up", "pattern", pattern, "error", err)
-		}
-		legacyPattern := projectcompat.LegacyUserTopic(task.ProjectID, b.config.Hub.User)
-		if err := b.broker.RequestSubscription(legacyPattern); err != nil {
-			b.log.Warn("failed to re-request legacy subscription for follow-up", "pattern", legacyPattern, "error", err)
+		if caller != nil {
+			b.subscribeAllUserTopics(task.ProjectID)
+		} else {
+			b.subscribeAdminUserTopics(task.ProjectID)
 		}
 	}
 
@@ -439,7 +472,7 @@ func (b *Bridge) sendFollowUp(ctx context.Context, projectSlug, agentSlug, taskI
 		defer b.removeWaiter(taskID)
 		defer b.unregisterActiveTask(taskID, aKey)
 
-		if _, err := b.hubClient.Agents().SendStructuredMessage(ctx, agentID, scionMsg, false, false, false); err != nil {
+		if _, err := writeClient.Agents().SendStructuredMessage(ctx, agentID, scionMsg, false, false, false); err != nil {
 			b.failFollowUpTask(taskID)
 			return nil, fmt.Errorf("send follow-up to agent: %w", err)
 		}
@@ -480,7 +513,7 @@ func (b *Bridge) sendFollowUp(ctx context.Context, projectSlug, agentSlug, taskI
 		defer b.wg.Done()
 		sendCtx, cancel := context.WithTimeout(b.shutdownCtx, 30*time.Second)
 		defer cancel()
-		if _, err := b.hubClient.Agents().SendStructuredMessage(sendCtx, agentID, scionMsg, false, false, false); err != nil {
+		if _, err := writeClient.Agents().SendStructuredMessage(sendCtx, agentID, scionMsg, false, false, false); err != nil {
 			b.log.Error("non-blocking follow-up send failed", "error", err, "task_id", taskID)
 			b.failFollowUpTask(taskID)
 			b.unregisterActiveTask(taskID, aKey)
@@ -494,13 +527,27 @@ func (b *Bridge) sendFollowUp(ctx context.Context, projectSlug, agentSlug, taskI
 	}, nil
 }
 
-// GetTask retrieves a task by ID.
+// GetTask retrieves a task by ID. Per-user isolation: if CallerIdentity is
+// present and the task has a CallerUserID, only the task's owner can read it.
 func (b *Bridge) GetTask(ctx context.Context, taskID string) (*TaskResult, error) {
 	task, err := b.store.GetTask(taskID)
 	if err != nil {
 		return nil, fmt.Errorf("get task: %w", err)
 	}
 	if task == nil {
+		return nil, nil
+	}
+
+	// Per-user isolation: if the request has a caller identity AND the task
+	// was created by a per-user caller, deny access to other users.
+	// Legacy tasks (CallerUserID == "") are visible to all legacy callers
+	// but NOT to per-user callers (prevents information leakage across modes).
+	caller := callerIdentityFromContext(ctx)
+	if caller != nil && task.CallerUserID != "" && caller.UserID != task.CallerUserID {
+		return nil, nil // not found (avoids leaking existence)
+	}
+	if caller != nil && task.CallerUserID == "" {
+		// Per-user caller cannot see legacy tasks — prevents mode mixing.
 		return nil, nil
 	}
 
@@ -513,9 +560,19 @@ func (b *Bridge) GetTask(ctx context.Context, taskID string) (*TaskResult, error
 	}, nil
 }
 
-// ListTasks returns tasks for a given context.
+// ListTasks returns tasks for a given context. Per-user isolation:
+// if CallerIdentity is present, only the caller's tasks are returned.
 func (b *Bridge) ListTasks(ctx context.Context, contextID string) ([]TaskResult, error) {
-	tasks, err := b.store.ListTasksByContext(ctx, contextID)
+	caller := callerIdentityFromContext(ctx)
+
+	var tasks []state.Task
+	var err error
+	if caller != nil {
+		// Per-user mode: only list tasks created by this caller.
+		tasks, err = b.store.ListTasksByContextAndCaller(ctx, contextID, caller.UserID)
+	} else {
+		tasks, err = b.store.ListTasksByContext(ctx, contextID)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("list tasks: %w", err)
 	}
@@ -532,7 +589,9 @@ func (b *Bridge) ListTasks(ctx context.Context, contextID string) ([]TaskResult,
 }
 
 // CancelTask cancels an in-progress task, notifying stream and push subscribers,
-// and sending an interrupt to the Hub to stop the agent.
+// and sending an interrupt to the Hub to stop the agent. Per-user isolation:
+// if CallerIdentity is present and the task has a CallerUserID, only the
+// task's owner can cancel it.
 func (b *Bridge) CancelTask(ctx context.Context, taskID string) (*TaskResult, error) {
 	task, err := b.store.GetTask(taskID)
 	if err != nil {
@@ -541,6 +600,16 @@ func (b *Bridge) CancelTask(ctx context.Context, taskID string) (*TaskResult, er
 	if task == nil {
 		return nil, nil
 	}
+
+	// Per-user isolation (same logic as GetTask).
+	caller := callerIdentityFromContext(ctx)
+	if caller != nil && task.CallerUserID != "" && caller.UserID != task.CallerUserID {
+		return nil, nil // not found
+	}
+	if caller != nil && task.CallerUserID == "" {
+		return nil, nil // per-user caller cannot cancel legacy tasks
+	}
+
 	if IsTerminalState(task.State) {
 		return nil, fmt.Errorf("task %s is already in terminal state: %s", taskID, task.State)
 	}
@@ -836,6 +905,53 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return s[:n] + "..."
+}
+
+// callerHubClient creates a per-request Hub client authenticated as the caller.
+// For UAT callers, the original token is passed through to the Hub.
+// For JWT callers, a fresh 5-minute JWT is minted for the caller's identity.
+func (b *Bridge) callerHubClient(caller *CallerIdentity) (hubclient.Client, error) {
+	switch caller.TokenType {
+	case "uat":
+		return hubclient.New(b.config.Hub.Endpoint,
+			hubclient.WithBearerToken(caller.RawToken))
+	case "jwt":
+		// Re-mint a 5-minute JWT for the caller's identity using the bridge's
+		// signing key. This is the same infrastructure used for the bridge's
+		// own admin identity.
+		mintAuth := identity.NewMintingAuth(b.minter,
+			caller.UserID, caller.Email, caller.Role, 5*time.Minute)
+		return hubclient.New(b.config.Hub.Endpoint,
+			hubclient.WithAuthenticator(mintAuth))
+	default:
+		return nil, fmt.Errorf("unknown token type: %s", caller.TokenType)
+	}
+}
+
+// subscribeAllUserTopics subscribes to the wildcard user topic for per-user
+// mode. This captures replies to all users' messages in the project.
+// The broker's eventbus supports NATS-style * wildcards (confirmed by
+// TestInProcessEventBus_WildcardSubscribe).
+func (b *Bridge) subscribeAllUserTopics(projectID string) {
+	pattern := projectcompat.AllUserTopic(projectID)
+	if err := b.broker.RequestSubscription(pattern); err != nil {
+		b.log.Warn("failed to request wildcard subscription", "pattern", pattern, "error", err)
+	}
+	// Note: no LegacyAllUserTopic exists in projectcompat, so legacy wildcard
+	// subscription is not available. Legacy user topics use the scion.grove.*
+	// prefix which will be phased out.
+}
+
+// subscribeAdminUserTopics subscribes to the bridge admin's user topic (legacy mode).
+func (b *Bridge) subscribeAdminUserTopics(projectID string) {
+	pattern := projectcompat.UserTopic(projectID, b.config.Hub.User)
+	if err := b.broker.RequestSubscription(pattern); err != nil {
+		b.log.Warn("failed to request subscription", "pattern", pattern, "error", err)
+	}
+	legacyPattern := projectcompat.LegacyUserTopic(projectID, b.config.Hub.User)
+	if err := b.broker.RequestSubscription(legacyPattern); err != nil {
+		b.log.Warn("failed to request legacy subscription", "pattern", legacyPattern, "error", err)
+	}
 }
 
 // GenerateAgentCard builds an agent card for the given project and agent,

--- a/extras/scion-a2a-bridge/internal/bridge/bridge.go
+++ b/extras/scion-a2a-bridge/internal/bridge/bridge.go
@@ -620,21 +620,33 @@ func (b *Bridge) CancelTask(ctx context.Context, taskID string) (*TaskResult, er
 	b.unregisterActiveTask(taskID, aKey)
 
 	// Send interrupt to the agent via Hub, re-resolving if the stored AgentID is stale.
+	// Use per-user client when CallerIdentity is present (M1).
 	if b.hubClient != nil && task.AgentID != "" {
 		targetAgentID := task.AgentID
 		if agent := b.lookupAgent(ctx, task.ProjectID, task.AgentSlug); agent != nil {
 			targetAgentID = agent.ID
 		}
+		cancelClient := b.hubClient
+		senderUser := b.config.Hub.User
+		if caller != nil {
+			senderUser = caller.Email
+			if cc, err := b.callerHubClient(caller); err == nil {
+				cancelClient = cc
+			} else {
+				b.log.Warn("CancelTask: failed to create per-user client, falling back to admin",
+					"error", err, "task_id", taskID)
+			}
+		}
 		interruptMsg := &messages.StructuredMessage{
 			Version:   1,
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
-			Sender:    fmt.Sprintf("user:%s", b.config.Hub.User),
+			Sender:    fmt.Sprintf("user:%s", senderUser),
 			Recipient: fmt.Sprintf("agent:%s", task.AgentSlug),
 			Msg:       "Task cancelled by A2A client.",
 			Type:      messages.TypeInstruction,
 			Metadata:  map[string]string{"a2aTaskId": taskID},
 		}
-		if _, err := b.hubClient.Agents().SendStructuredMessage(ctx, targetAgentID, interruptMsg, true, false, false); err != nil {
+		if _, err := cancelClient.Agents().SendStructuredMessage(ctx, targetAgentID, interruptMsg, true, false, false); err != nil {
 			b.log.Error("failed to send cancel interrupt to agent", "error", err, "task_id", taskID, "agent_id", targetAgentID)
 		}
 	}

--- a/extras/scion-a2a-bridge/internal/bridge/caller.go
+++ b/extras/scion-a2a-bridge/internal/bridge/caller.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import "context"
+
+// CallerIdentity holds the per-request caller identity extracted from a
+// validated hub credential. Absent for legacy apiKey/bearer/none modes.
+type CallerIdentity struct {
+	UserID    string
+	Email     string
+	Role      string
+	RawToken  string // The original bearer token for UAT passthrough
+	TokenType string // "uat" or "jwt"
+}
+
+type callerContextKey struct{}
+
+// withCallerIdentity injects a CallerIdentity into the context.
+func withCallerIdentity(ctx context.Context, id *CallerIdentity) context.Context {
+	return context.WithValue(ctx, callerContextKey{}, id)
+}
+
+// callerIdentityFromContext retrieves the CallerIdentity from the context.
+// Returns nil for legacy auth modes (apiKey/bearer/none).
+func callerIdentityFromContext(ctx context.Context) *CallerIdentity {
+	v, _ := ctx.Value(callerContextKey{}).(*CallerIdentity)
+	return v
+}

--- a/extras/scion-a2a-bridge/internal/bridge/config.go
+++ b/extras/scion-a2a-bridge/internal/bridge/config.go
@@ -14,7 +14,9 @@
 
 package bridge
 
-import "time"
+import (
+	"time"
+)
 
 // Config holds the complete bridge configuration.
 type Config struct {
@@ -61,8 +63,18 @@ type PluginConfig struct {
 
 // AuthConfig holds external authentication settings for A2A clients.
 type AuthConfig struct {
+	// Scheme selects the auth mode.
+	// Existing: "apiKey" | "bearer" | "none"
+	// New:      "hubUAT" | "hubJWT"
 	Scheme string `yaml:"scheme"`
+
+	// APIKey is the shared static key for "apiKey" and "bearer" schemes.
+	// Not used for hubUAT or hubJWT.
 	APIKey string `yaml:"api_key"`
+
+	// UATCacheTTL is the UAT introspection cache TTL for hubUAT mode.
+	// Default: 60s. Maximum: 300s.
+	UATCacheTTL time.Duration `yaml:"uat_cache_ttl"`
 }
 
 // ProjectConfig configures a project exposed via the bridge.

--- a/extras/scion-a2a-bridge/internal/bridge/executor.go
+++ b/extras/scion-a2a-bridge/internal/bridge/executor.go
@@ -131,7 +131,7 @@ func (e *ScionExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorCon
 		defer e.bridge.removeWaiter(string(taskID))
 
 		// Send to Hub.
-		if err := e.bridge.hubClient.Agents().SendStructuredMessage(ctx, agentCtx.AgentID, scionMsg, false, false, false); err != nil {
+		if _, err := e.bridge.hubClient.Agents().SendStructuredMessage(ctx, agentCtx.AgentID, scionMsg, false, false, false); err != nil {
 			e.log.Error("failed to send message to agent", "error", err, "task_id", taskID, "agent_id", agentCtx.AgentID)
 			failMsg := a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("Failed to route message to agent"))
 			yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateFailed, failMsg), nil)
@@ -223,7 +223,7 @@ func (e *ScionExecutor) Cancel(ctx context.Context, execCtx *a2asrv.ExecutorCont
 					Type:      messages.TypeInstruction,
 					Metadata:  map[string]string{"a2aTaskId": string(taskID)},
 				}
-				if err := e.bridge.hubClient.Agents().SendStructuredMessage(ctx, agent.ID, interruptMsg, true, false, false); err != nil {
+				if _, err := e.bridge.hubClient.Agents().SendStructuredMessage(ctx, agent.ID, interruptMsg, true, false, false); err != nil {
 					e.log.Error("failed to send cancel interrupt", "error", err, "task_id", taskID)
 				}
 			}

--- a/extras/scion-a2a-bridge/internal/bridge/executor.go
+++ b/extras/scion-a2a-bridge/internal/bridge/executor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 )
 
@@ -98,21 +99,34 @@ func (e *ScionExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorCon
 			}
 		}
 
+		// Per-user identity propagation: use the caller's credentials for Hub
+		// writes, sender field, and broker subscriptions (mirrors Bridge.SendMessage).
+		caller := callerIdentityFromContext(ctx) // nil in legacy mode
+		var writeClient hubclient.Client = e.bridge.hubClient
+		senderUser := e.bridge.config.Hub.User
+
+		if caller != nil {
+			senderUser = caller.Email
+			var clientErr error
+			writeClient, clientErr = e.bridge.callerHubClient(caller)
+			if clientErr != nil {
+				yield(nil, fmt.Errorf("creating per-user hub client: %w", clientErr))
+				return
+			}
+		}
+
 		// Translate A2A message parts to Scion format.
 		scionMsg := TranslateA2APartsToScion(execCtx.Message.Parts)
-		scionMsg.Sender = fmt.Sprintf("user:%s", e.bridge.config.Hub.User)
+		scionMsg.Sender = fmt.Sprintf("user:%s", senderUser)
 		scionMsg.Recipient = fmt.Sprintf("agent:%s", agentCtx.AgentSlug)
 		scionMsg.Metadata = map[string]string{"a2aTaskId": string(taskID)}
 
 		// Request broker subscription for responses.
 		if e.bridge.broker != nil {
-			pattern := fmt.Sprintf("scion.project.%s.user.%s.messages", agentCtx.ProjectID, e.bridge.config.Hub.User)
-			if err := e.bridge.broker.RequestSubscription(pattern); err != nil {
-				e.log.Warn("failed to request subscription", "pattern", pattern, "error", err)
-			}
-			legacyPattern := fmt.Sprintf("scion.grove.%s.user.%s.messages", agentCtx.ProjectID, e.bridge.config.Hub.User)
-			if err := e.bridge.broker.RequestSubscription(legacyPattern); err != nil {
-				e.log.Warn("failed to request legacy subscription", "pattern", legacyPattern, "error", err)
+			if caller != nil {
+				e.bridge.subscribeAllUserTopics(agentCtx.ProjectID)
+			} else {
+				e.bridge.subscribeAdminUserTopics(agentCtx.ProjectID)
 			}
 		}
 
@@ -130,8 +144,8 @@ func (e *ScionExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorCon
 		})
 		defer e.bridge.removeWaiter(string(taskID))
 
-		// Send to Hub.
-		if _, err := e.bridge.hubClient.Agents().SendStructuredMessage(ctx, agentCtx.AgentID, scionMsg, false, false, false); err != nil {
+		// Send to Hub using the per-user or admin client.
+		if _, err := writeClient.Agents().SendStructuredMessage(ctx, agentCtx.AgentID, scionMsg, false, false, false); err != nil {
 			e.log.Error("failed to send message to agent", "error", err, "task_id", taskID, "agent_id", agentCtx.AgentID)
 			failMsg := a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("Failed to route message to agent"))
 			yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateFailed, failMsg), nil)
@@ -213,17 +227,32 @@ func (e *ScionExecutor) Cancel(ctx context.Context, execCtx *a2asrv.ExecutorCont
 				yield(a2a.NewStatusUpdateEvent(execCtx, a2a.TaskStateCanceled, nil), nil)
 				return
 			}
+
+			// Per-user identity propagation for cancel interrupts.
+			caller := callerIdentityFromContext(ctx)
+			var cancelClient hubclient.Client = e.bridge.hubClient
+			senderUser := e.bridge.config.Hub.User
+			if caller != nil {
+				senderUser = caller.Email
+				if cc, err := e.bridge.callerHubClient(caller); err == nil {
+					cancelClient = cc
+				} else {
+					e.log.Warn("cancel: failed to create per-user client, falling back to admin",
+						"error", err, "task_id", taskID)
+				}
+			}
+
 			if agent := e.bridge.lookupAgent(ctx, route.ProjectSlug, route.AgentSlug); agent != nil {
 				interruptMsg := &messages.StructuredMessage{
 					Version:   1,
 					Timestamp: time.Now().UTC().Format(time.RFC3339),
-					Sender:    fmt.Sprintf("user:%s", e.bridge.config.Hub.User),
+					Sender:    fmt.Sprintf("user:%s", senderUser),
 					Recipient: fmt.Sprintf("agent:%s", route.AgentSlug),
 					Msg:       "Task cancelled by A2A client.",
 					Type:      messages.TypeInstruction,
 					Metadata:  map[string]string{"a2aTaskId": string(taskID)},
 				}
-				if _, err := e.bridge.hubClient.Agents().SendStructuredMessage(ctx, agent.ID, interruptMsg, true, false, false); err != nil {
+				if _, err := cancelClient.Agents().SendStructuredMessage(ctx, agent.ID, interruptMsg, true, false, false); err != nil {
 					e.log.Error("failed to send cancel interrupt", "error", err, "task_id", taskID)
 				}
 			}

--- a/extras/scion-a2a-bridge/internal/bridge/followup_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/followup_test.go
@@ -33,6 +33,24 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 )
 
+// ErrCodeInvalidParams is the JSON-RPC error code for invalid params.
+// Previously defined in handler.go; kept here for test compatibility.
+const ErrCodeInvalidParams = -32602
+
+// SendMessageParams mirrors the A2A message/send params for test assertions.
+type SendMessageParams struct {
+	TaskID        string             `json:"taskId,omitempty"`
+	Message       Message            `json:"message"`
+	Configuration *SendMessageConfig `json:"configuration,omitempty"`
+}
+
+// SendMessageConfig mirrors the A2A configuration block.
+type SendMessageConfig struct {
+	Blocking *bool `json:"blocking,omitempty"`
+}
+
+func boolPtr(b bool) *bool { return &b }
+
 // --- Mock hubclient ---
 
 // mockAgentService implements hubclient.AgentService for testing.
@@ -827,7 +845,7 @@ func TestHandleSendMessage_PassesTaskIDToSendMessage(t *testing.T) {
 	hub := &mockHubClient{agents: agents}
 	bridge := New(store, hub, nil, cfg, nil, log)
 	defer bridge.Shutdown()
-	srv := NewServer(bridge, cfg, nil, log)
+	srv := NewServer(bridge, cfg, nil, log, testHandler())
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
@@ -894,7 +912,7 @@ func TestHandleSendMessage_ErrTaskTerminal_ReturnsCorrectError(t *testing.T) {
 	hub := &mockHubClient{agents: agents}
 	bridge := New(store, hub, nil, cfg, nil, log)
 	defer bridge.Shutdown()
-	srv := NewServer(bridge, cfg, nil, log)
+	srv := NewServer(bridge, cfg, nil, log, testHandler())
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
@@ -941,7 +959,7 @@ func TestHandleSendMessage_UnknownTaskID_ReturnsAgentNotFound(t *testing.T) {
 	hub := &mockHubClient{agents: agents}
 	bridge := New(store, hub, nil, cfg, nil, log)
 	defer bridge.Shutdown()
-	srv := NewServer(bridge, cfg, nil, log)
+	srv := NewServer(bridge, cfg, nil, log, testHandler())
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
@@ -1001,7 +1019,7 @@ func TestHandleSendMessage_NoTaskID_RoutesToNewTask(t *testing.T) {
 	hub := &mockHubClient{agents: agents}
 	bridge := New(store, hub, nil, cfg, nil, log)
 	defer bridge.Shutdown()
-	srv := NewServer(bridge, cfg, nil, log)
+	srv := NewServer(bridge, cfg, nil, log, testHandler())
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
@@ -1174,5 +1192,3 @@ func TestSendFollowUp_MessageContentTranslated(t *testing.T) {
 }
 
 // --- Helpers ---
-
-func boolPtr(b bool) *bool { return &b }

--- a/extras/scion-a2a-bridge/internal/bridge/jwtvalidator.go
+++ b/extras/scion-a2a-bridge/internal/bridge/jwtvalidator.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+)
+
+// JWT issuer and audience must match the Hub's UserTokenService constants
+// (pkg/hub/usertoken.go). Inlined here to avoid importing pkg/hub which
+// would pull in database and server dependencies.
+const (
+	jwtIssuer   = "scion-hub"
+	jwtAudience = "scion-hub-api"
+)
+
+// jwtUserClaims mirrors pkg/hub.UserTokenClaims.
+type jwtUserClaims struct {
+	jwt.Claims
+	UserID      string `json:"uid"`
+	Email       string `json:"email"`
+	DisplayName string `json:"name,omitempty"`
+	Role        string `json:"role"`
+	TokenType   string `json:"type"`
+	ClientType  string `json:"client"`
+}
+
+// JWTValidator validates Scion user JWTs locally using the Hub's HS256
+// signing key. No network call is required — validation is purely
+// cryptographic. This is the bridge-side equivalent of
+// pkg/hub.UserTokenService.ValidateUserToken.
+type JWTValidator struct {
+	signingKey []byte
+}
+
+// NewJWTValidator creates a validator from the Hub's raw HS256 signing key.
+func NewJWTValidator(signingKey []byte) *JWTValidator {
+	return &JWTValidator{signingKey: signingKey}
+}
+
+// Validate parses and verifies a JWT, returning the caller identity on
+// success. Rejects expired, tampered, or wrongly-issued tokens.
+func (v *JWTValidator) Validate(tokenString string) (*CallerIdentity, error) {
+	token, err := jwt.ParseSigned(tokenString, []jose.SignatureAlgorithm{jose.HS256})
+	if err != nil {
+		return nil, fmt.Errorf("parse JWT: %w", err)
+	}
+
+	var claims jwtUserClaims
+	if err := token.Claims(v.signingKey, &claims); err != nil {
+		return nil, fmt.Errorf("verify JWT signature: %w", err)
+	}
+
+	// Validate standard claims (issuer, audience, expiry, not-before).
+	expected := jwt.Expected{
+		Issuer:      jwtIssuer,
+		AnyAudience: jwt.Audience{jwtAudience},
+		Time:        time.Now(),
+	}
+	if err := claims.Validate(expected); err != nil {
+		return nil, fmt.Errorf("JWT claims validation: %w", err)
+	}
+
+	if claims.UserID == "" || claims.Email == "" {
+		return nil, fmt.Errorf("JWT missing required claims (uid=%q, email=%q)", claims.UserID, claims.Email)
+	}
+
+	return &CallerIdentity{
+		UserID:    claims.UserID,
+		Email:     claims.Email,
+		Role:      claims.Role,
+		RawToken:  tokenString,
+		TokenType: "jwt",
+	}, nil
+}

--- a/extras/scion-a2a-bridge/internal/bridge/jwtvalidator.go
+++ b/extras/scion-a2a-bridge/internal/bridge/jwtvalidator.go
@@ -77,6 +77,11 @@ func (v *JWTValidator) Validate(tokenString string) (*CallerIdentity, error) {
 		return nil, fmt.Errorf("JWT claims validation: %w", err)
 	}
 
+	// Reject refresh tokens — only access tokens are valid for API calls.
+	if claims.TokenType == "refresh" {
+		return nil, fmt.Errorf("refresh tokens are not accepted for API authentication")
+	}
+
 	if claims.UserID == "" || claims.Email == "" {
 		return nil, fmt.Errorf("JWT missing required claims (uid=%q, email=%q)", claims.UserID, claims.Email)
 	}

--- a/extras/scion-a2a-bridge/internal/bridge/jwtvalidator.go
+++ b/extras/scion-a2a-bridge/internal/bridge/jwtvalidator.go
@@ -68,6 +68,8 @@ func (v *JWTValidator) Validate(tokenString string) (*CallerIdentity, error) {
 	}
 
 	// Validate standard claims (issuer, audience, expiry, not-before).
+	// Note: jwt.Claims.Validate uses a default 1-minute leeway for time
+	// comparisons, which tolerates minor clock drift between Hub and bridge.
 	expected := jwt.Expected{
 		Issuer:      jwtIssuer,
 		AnyAudience: jwt.Audience{jwtAudience},

--- a/extras/scion-a2a-bridge/internal/bridge/jwtvalidator_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/jwtvalidator_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+)
+
+// mintTestJWT creates a signed JWT for testing.
+func mintTestJWT(t *testing.T, signingKey []byte, claims jwtUserClaims) string {
+	t.Helper()
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.HS256, Key: signingKey},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	token, err := jwt.Signed(signer).Claims(claims).Serialize()
+	if err != nil {
+		t.Fatalf("Serialize: %v", err)
+	}
+	return token
+}
+
+func testSigningKey(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	return key
+}
+
+func validClaims() jwtUserClaims {
+	now := time.Now()
+	return jwtUserClaims{
+		Claims: jwt.Claims{
+			Issuer:    jwtIssuer,
+			Subject:   "user-1",
+			Audience:  jwt.Audience{jwtAudience},
+			IssuedAt:  jwt.NewNumericDate(now.Add(-1 * time.Minute)),
+			Expiry:    jwt.NewNumericDate(now.Add(15 * time.Minute)),
+			NotBefore: jwt.NewNumericDate(now.Add(-1 * time.Minute)),
+		},
+		UserID:     "user-1",
+		Email:      "alice@example.com",
+		Role:       "user",
+		TokenType:  "access",
+		ClientType: "api",
+	}
+}
+
+func TestJWTValidator_ValidToken(t *testing.T) {
+	key := testSigningKey(t)
+	v := NewJWTValidator(key)
+
+	claims := validClaims()
+	token := mintTestJWT(t, key, claims)
+
+	id, err := v.Validate(token)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if id.UserID != "user-1" {
+		t.Errorf("UserID = %q, want %q", id.UserID, "user-1")
+	}
+	if id.Email != "alice@example.com" {
+		t.Errorf("Email = %q, want %q", id.Email, "alice@example.com")
+	}
+	if id.Role != "user" {
+		t.Errorf("Role = %q, want %q", id.Role, "user")
+	}
+	if id.TokenType != "jwt" {
+		t.Errorf("TokenType = %q, want %q", id.TokenType, "jwt")
+	}
+	if id.RawToken != token {
+		t.Error("RawToken mismatch")
+	}
+}
+
+func TestJWTValidator_ExpiredToken(t *testing.T) {
+	key := testSigningKey(t)
+	v := NewJWTValidator(key)
+
+	claims := validClaims()
+	claims.Expiry = jwt.NewNumericDate(time.Now().Add(-1 * time.Hour))
+
+	token := mintTestJWT(t, key, claims)
+	_, err := v.Validate(token)
+	if err == nil {
+		t.Fatal("expected error for expired token")
+	}
+}
+
+func TestJWTValidator_WrongSigningKey(t *testing.T) {
+	realKey := testSigningKey(t)
+	wrongKey := testSigningKey(t)
+
+	v := NewJWTValidator(realKey)
+
+	claims := validClaims()
+	token := mintTestJWT(t, wrongKey, claims)
+
+	_, err := v.Validate(token)
+	if err == nil {
+		t.Fatal("expected error for wrong signing key")
+	}
+}
+
+func TestJWTValidator_WrongIssuer(t *testing.T) {
+	key := testSigningKey(t)
+	v := NewJWTValidator(key)
+
+	claims := validClaims()
+	claims.Issuer = "wrong-issuer"
+
+	token := mintTestJWT(t, key, claims)
+	_, err := v.Validate(token)
+	if err == nil {
+		t.Fatal("expected error for wrong issuer")
+	}
+}
+
+func TestJWTValidator_WrongAudience(t *testing.T) {
+	key := testSigningKey(t)
+	v := NewJWTValidator(key)
+
+	claims := validClaims()
+	claims.Audience = jwt.Audience{"wrong-audience"}
+
+	token := mintTestJWT(t, key, claims)
+	_, err := v.Validate(token)
+	if err == nil {
+		t.Fatal("expected error for wrong audience")
+	}
+}
+
+func TestJWTValidator_MissingClaims(t *testing.T) {
+	key := testSigningKey(t)
+	v := NewJWTValidator(key)
+
+	claims := validClaims()
+	claims.UserID = "" // missing
+	claims.Email = ""  // missing
+
+	token := mintTestJWT(t, key, claims)
+	_, err := v.Validate(token)
+	if err == nil {
+		t.Fatal("expected error for missing required claims")
+	}
+}
+
+func TestJWTValidator_CLIToken(t *testing.T) {
+	key := testSigningKey(t)
+	v := NewJWTValidator(key)
+
+	claims := validClaims()
+	claims.TokenType = "access"
+	claims.ClientType = "cli"
+
+	token := mintTestJWT(t, key, claims)
+	id, err := v.Validate(token)
+	if err != nil {
+		t.Fatalf("CLI token should be valid: %v", err)
+	}
+	if id.UserID != "user-1" {
+		t.Errorf("UserID = %q, want %q", id.UserID, "user-1")
+	}
+}
+
+func TestJWTValidator_MalformedToken(t *testing.T) {
+	key := testSigningKey(t)
+	v := NewJWTValidator(key)
+
+	_, err := v.Validate("not-a-jwt")
+	if err == nil {
+		t.Fatal("expected error for malformed token")
+	}
+}

--- a/extras/scion-a2a-bridge/internal/bridge/jwtvalidator_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/jwtvalidator_test.go
@@ -16,6 +16,7 @@ package bridge
 
 import (
 	"crypto/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -183,6 +184,23 @@ func TestJWTValidator_CLIToken(t *testing.T) {
 	}
 	if id.UserID != "user-1" {
 		t.Errorf("UserID = %q, want %q", id.UserID, "user-1")
+	}
+}
+
+func TestJWTValidator_RefreshTokenRejected(t *testing.T) {
+	key := testSigningKey(t)
+	v := NewJWTValidator(key)
+
+	claims := validClaims()
+	claims.TokenType = "refresh"
+
+	token := mintTestJWT(t, key, claims)
+	_, err := v.Validate(token)
+	if err == nil {
+		t.Fatal("expected error for refresh token")
+	}
+	if !strings.Contains(err.Error(), "refresh tokens") {
+		t.Errorf("error should mention refresh tokens, got: %v", err)
 	}
 }
 

--- a/extras/scion-a2a-bridge/internal/bridge/server.go
+++ b/extras/scion-a2a-bridge/internal/bridge/server.go
@@ -103,6 +103,9 @@ func ValidateConfig(cfg *Config) error {
 	if cfg.Auth.APIKey == "" && cfg.Auth.Scheme != "none" && cfg.Auth.Scheme != "hubUAT" && cfg.Auth.Scheme != "hubJWT" {
 		return fmt.Errorf("auth.api_key is required (set auth.scheme: \"none\" to explicitly disable authentication)")
 	}
+	if cfg.Auth.Scheme == "hubJWT" && cfg.Hub.SigningKey == "" && cfg.Hub.SigningKeySecret == "" {
+		return fmt.Errorf("hub.signing_key or hub.signing_key_secret is required when auth.scheme is hubJWT")
+	}
 	if cfg.Auth.UATCacheTTL < 0 {
 		return fmt.Errorf("auth.uat_cache_ttl must not be negative")
 	}

--- a/extras/scion-a2a-bridge/internal/bridge/server.go
+++ b/extras/scion-a2a-bridge/internal/bridge/server.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
 )
@@ -71,14 +72,25 @@ func ValidateConfig(cfg *Config) error {
 	if cfg.Hub.User == "" {
 		return fmt.Errorf("hub.user is required")
 	}
-	if cfg.Auth.Scheme != "" && cfg.Auth.Scheme != "apiKey" && cfg.Auth.Scheme != "bearer" && cfg.Auth.Scheme != "none" {
-		return fmt.Errorf("unsupported auth.scheme: %q (supported: apiKey, bearer, none)", cfg.Auth.Scheme)
+	switch cfg.Auth.Scheme {
+	case "", "apiKey", "bearer", "none", "hubUAT", "hubJWT":
+		// valid
+	default:
+		return fmt.Errorf("unsupported auth.scheme: %q (supported: apiKey, bearer, none, hubUAT, hubJWT)", cfg.Auth.Scheme)
 	}
 	if (cfg.Auth.Scheme == "apiKey" || cfg.Auth.Scheme == "bearer") && cfg.Auth.APIKey == "" {
 		return fmt.Errorf("auth.api_key is required when auth.scheme is %q", cfg.Auth.Scheme)
 	}
-	if cfg.Auth.APIKey == "" && cfg.Auth.Scheme != "none" {
+	// api_key is required for legacy schemes and the default (empty) scheme.
+	// hubUAT and hubJWT do not use api_key — they validate per-user credentials instead.
+	if cfg.Auth.APIKey == "" && cfg.Auth.Scheme != "none" && cfg.Auth.Scheme != "hubUAT" && cfg.Auth.Scheme != "hubJWT" {
 		return fmt.Errorf("auth.api_key is required (set auth.scheme: \"none\" to explicitly disable authentication)")
+	}
+	if cfg.Auth.UATCacheTTL < 0 {
+		return fmt.Errorf("auth.uat_cache_ttl must not be negative")
+	}
+	if cfg.Auth.UATCacheTTL > 300*time.Second {
+		return fmt.Errorf("auth.uat_cache_ttl must not exceed 300s")
 	}
 	if cfg.Bridge.Provider.URL != "" {
 		if _, err := url.Parse(cfg.Bridge.Provider.URL); err != nil {
@@ -90,10 +102,15 @@ func ValidateConfig(cfg *Config) error {
 
 // WarnOnOpenAuth logs a warning if the auth configuration leaves the bridge open.
 func (s *Server) WarnOnOpenAuth() {
-	if s.config.Auth.Scheme == "none" {
+	switch s.config.Auth.Scheme {
+	case "none":
 		s.log.Warn("bridge auth is explicitly DISABLED (auth.scheme: none) — all requests will be accepted without authentication")
-	} else if s.config.Auth.Scheme == "" {
+	case "":
 		s.log.Warn("auth.scheme is empty: bridge will accept credentials from both X-API-Key and Authorization headers")
+	case "hubUAT":
+		s.log.Info("bridge auth: hubUAT — per-user Scion UAT authentication enabled")
+	case "hubJWT":
+		s.log.Info("bridge auth: hubJWT — per-user Scion JWT authentication enabled")
 	}
 	if s.config.RateLimit.TrustProxy {
 		s.log.Warn("rate_limit.trust_proxy is enabled — X-Forwarded-For is trusted unconditionally, which allows clients to spoof their IP and bypass per-IP rate limits; consider adding network-level proxy restrictions")

--- a/extras/scion-a2a-bridge/internal/bridge/server.go
+++ b/extras/scion-a2a-bridge/internal/bridge/server.go
@@ -33,22 +33,39 @@ var slugRE = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,62}$`)
 
 // Server is the A2A HTTP server that routes requests to the SDK handler.
 type Server struct {
-	bridge     *Bridge
-	config     *Config
-	metrics    *Metrics
-	log        *slog.Logger
-	sdkHandler http.Handler // SDK JSON-RPC handler
+	bridge       *Bridge
+	config       *Config
+	metrics      *Metrics
+	log          *slog.Logger
+	sdkHandler   http.Handler // SDK JSON-RPC handler
+	uatValidator *UATValidator
+	jwtValidator *JWTValidator
 }
 
 // NewServer creates a new A2A protocol server backed by the SDK.
 func NewServer(bridge *Bridge, cfg *Config, metrics *Metrics, log *slog.Logger, sdkHandler http.Handler) *Server {
-	return &Server{
+	s := &Server{
 		bridge:     bridge,
 		config:     cfg,
 		metrics:    metrics,
 		log:        log,
 		sdkHandler: sdkHandler,
 	}
+	// Initialize per-user auth validators based on the configured scheme.
+	switch cfg.Auth.Scheme {
+	case "hubUAT":
+		s.uatValidator = NewUATValidator(cfg.Hub.Endpoint, cfg.Auth.UATCacheTTL)
+	case "hubJWT":
+		// JWTValidator is initialized later via SetJWTValidator once the
+		// signing key is loaded (it may come from Secret Manager).
+	}
+	return s
+}
+
+// SetJWTValidator sets the JWT validator for hubJWT mode. Called after the
+// signing key is loaded (which may require Secret Manager access).
+func (s *Server) SetJWTValidator(v *JWTValidator) {
+	s.jwtValidator = v
 }
 
 // ValidateConfig checks that required configuration fields are present and consistent.
@@ -302,7 +319,7 @@ func writeJSONRPCError(w http.ResponseWriter, id interface{}, code int, message 
 	json.NewEncoder(w).Encode(resp)
 }
 
-// authMiddleware validates API key authentication on non-public endpoints.
+// authMiddleware validates authentication on non-public endpoints.
 func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Public endpoints skip auth.
@@ -318,40 +335,92 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		if s.config.Auth.Scheme == "none" {
+		switch s.config.Auth.Scheme {
+		case "none":
 			next.ServeHTTP(w, r)
 			return
-		}
 
-		var apiKey string
-		switch s.config.Auth.Scheme {
-		case "apiKey":
-			apiKey = r.Header.Get("X-API-Key")
-		case "bearer":
-			auth := r.Header.Get("Authorization")
-			if strings.HasPrefix(auth, "Bearer ") {
-				apiKey = strings.TrimPrefix(auth, "Bearer ")
+		case "hubUAT":
+			token := extractBearerOrAPIKey(r)
+			if !strings.HasPrefix(token, "scion_pat_") {
+				http.Error(w, "unauthorized: expected scion_pat_* token", http.StatusUnauthorized)
+				return
 			}
+			caller, err := s.uatValidator.Validate(r.Context(), token)
+			if err != nil {
+				s.log.Debug("UAT validation failed", "error", err)
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			ctx := withCallerIdentity(r.Context(), caller)
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
+
+		case "hubJWT":
+			token := extractBearerToken(r)
+			if token == "" {
+				http.Error(w, "unauthorized: missing bearer token", http.StatusUnauthorized)
+				return
+			}
+			if s.jwtValidator == nil {
+				s.log.Error("hubJWT scheme configured but JWT validator not initialized")
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+				return
+			}
+			caller, err := s.jwtValidator.Validate(token)
+			if err != nil {
+				s.log.Debug("JWT validation failed", "error", err)
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			ctx := withCallerIdentity(r.Context(), caller)
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
+
 		default:
-			// When auth.scheme is unset (empty), accept credentials from either
-			// X-API-Key or Authorization: Bearer headers for convenience.
-			apiKey = r.Header.Get("X-API-Key")
-			if apiKey == "" {
-				auth := r.Header.Get("Authorization")
-				if strings.HasPrefix(auth, "Bearer ") {
-					apiKey = strings.TrimPrefix(auth, "Bearer ")
+			// Legacy schemes: "apiKey", "bearer", or "" (accept either header).
+			// No CallerIdentity is injected.
+			var apiKey string
+			switch s.config.Auth.Scheme {
+			case "apiKey":
+				apiKey = r.Header.Get("X-API-Key")
+			case "bearer":
+				apiKey = extractBearerToken(r)
+			default:
+				// When auth.scheme is unset (empty), accept credentials from either
+				// X-API-Key or Authorization: Bearer headers for convenience.
+				apiKey = r.Header.Get("X-API-Key")
+				if apiKey == "" {
+					apiKey = extractBearerToken(r)
 				}
 			}
-		}
 
-		// Compare SHA-256 hashes to avoid leaking key length via timing.
-		expectedHash := sha256.Sum256([]byte(s.config.Auth.APIKey))
-		providedHash := sha256.Sum256([]byte(apiKey))
-		if subtle.ConstantTimeCompare(expectedHash[:], providedHash[:]) != 1 {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
+			// Compare SHA-256 hashes to avoid leaking key length via timing.
+			expectedHash := sha256.Sum256([]byte(s.config.Auth.APIKey))
+			providedHash := sha256.Sum256([]byte(apiKey))
+			if subtle.ConstantTimeCompare(expectedHash[:], providedHash[:]) != 1 {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
 
-		next.ServeHTTP(w, r)
+			next.ServeHTTP(w, r)
+		}
 	})
+}
+
+// extractBearerToken extracts the token from an Authorization: Bearer header.
+func extractBearerToken(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	if strings.HasPrefix(auth, "Bearer ") {
+		return strings.TrimPrefix(auth, "Bearer ")
+	}
+	return ""
+}
+
+// extractBearerOrAPIKey extracts a token from Authorization: Bearer or X-API-Key headers.
+func extractBearerOrAPIKey(r *http.Request) string {
+	if token := extractBearerToken(r); token != "" {
+		return token
+	}
+	return r.Header.Get("X-API-Key")
 }

--- a/extras/scion-a2a-bridge/internal/bridge/server_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/server_test.go
@@ -30,8 +30,6 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
 	"github.com/a2aproject/a2a-go/v2/a2asrv/taskstore"
 
-	"context"
-
 	"github.com/GoogleCloudPlatform/scion/extras/scion-a2a-bridge/internal/state"
 )
 

--- a/extras/scion-a2a-bridge/internal/bridge/uatvalidator.go
+++ b/extras/scion-a2a-bridge/internal/bridge/uatvalidator.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	defaultUATCacheTTL = 60 * time.Second
+	maxUATCacheTTL     = 300 * time.Second
+)
+
+// UATValidator validates Scion user access tokens (scion_pat_*) by calling
+// the Hub's GET /api/v1/auth/me endpoint. Results are cached by SHA-256(token)
+// with a configurable TTL to avoid a round-trip on every request.
+type UATValidator struct {
+	hubEndpoint string
+	httpClient  *http.Client
+	ttl         time.Duration
+
+	mu    sync.Mutex
+	cache map[[32]byte]*uatCacheEntry
+}
+
+type uatCacheEntry struct {
+	identity  *CallerIdentity
+	expiresAt time.Time
+}
+
+// userResponse mirrors the fields returned by GET /api/v1/auth/me.
+type userResponse struct {
+	ID          string `json:"id"`
+	Email       string `json:"email"`
+	DisplayName string `json:"display_name"`
+	Role        string `json:"role"`
+}
+
+// NewUATValidator creates a validator that introspects UATs via the Hub.
+func NewUATValidator(hubEndpoint string, ttl time.Duration) *UATValidator {
+	if ttl <= 0 {
+		ttl = defaultUATCacheTTL
+	}
+	if ttl > maxUATCacheTTL {
+		ttl = maxUATCacheTTL
+	}
+	return &UATValidator{
+		hubEndpoint: hubEndpoint,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		ttl:   ttl,
+		cache: make(map[[32]byte]*uatCacheEntry),
+	}
+}
+
+// Validate introspects a UAT by calling Hub /api/v1/auth/me. The result
+// is cached by SHA-256(token) to avoid a DB round-trip on every A2A message.
+// A revoked UAT stops working within one cache TTL of revocation.
+func (v *UATValidator) Validate(ctx context.Context, token string) (*CallerIdentity, error) {
+	key := sha256.Sum256([]byte(token))
+
+	v.mu.Lock()
+	if entry, ok := v.cache[key]; ok {
+		if time.Now().Before(entry.expiresAt) {
+			id := entry.identity
+			v.mu.Unlock()
+			return id, nil
+		}
+		// Expired — remove and re-validate.
+		delete(v.cache, key)
+	}
+	v.mu.Unlock()
+
+	// Call Hub /api/v1/auth/me with the caller's UAT as the bearer token.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, v.hubEndpoint+"/api/v1/auth/me", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create auth/me request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := v.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("call auth/me: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("UAT rejected by Hub (HTTP %d)", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected Hub response: HTTP %d", resp.StatusCode)
+	}
+
+	var user userResponse
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return nil, fmt.Errorf("decode auth/me response: %w", err)
+	}
+	if user.ID == "" || user.Email == "" {
+		return nil, fmt.Errorf("auth/me returned incomplete identity (id=%q, email=%q)", user.ID, user.Email)
+	}
+
+	identity := &CallerIdentity{
+		UserID:    user.ID,
+		Email:     user.Email,
+		Role:      user.Role,
+		RawToken:  token,
+		TokenType: "uat",
+	}
+
+	v.mu.Lock()
+	v.cache[key] = &uatCacheEntry{
+		identity:  identity,
+		expiresAt: time.Now().Add(v.ttl),
+	}
+	// Lazy eviction: remove expired entries while we hold the lock.
+	now := time.Now()
+	for k, e := range v.cache {
+		if now.After(e.expiresAt) {
+			delete(v.cache, k)
+		}
+	}
+	v.mu.Unlock()
+
+	return identity, nil
+}

--- a/extras/scion-a2a-bridge/internal/bridge/uatvalidator.go
+++ b/extras/scion-a2a-bridge/internal/bridge/uatvalidator.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -111,7 +112,7 @@ func (v *UATValidator) Validate(ctx context.Context, token string) (*CallerIdent
 	}
 
 	var user userResponse
-	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&user); err != nil {
 		return nil, fmt.Errorf("decode auth/me response: %w", err)
 	}
 	if user.ID == "" || user.Email == "" {
@@ -130,13 +131,6 @@ func (v *UATValidator) Validate(ctx context.Context, token string) (*CallerIdent
 	v.cache[key] = &uatCacheEntry{
 		identity:  identity,
 		expiresAt: time.Now().Add(v.ttl),
-	}
-	// Lazy eviction: remove expired entries while we hold the lock.
-	now := time.Now()
-	for k, e := range v.cache {
-		if now.After(e.expiresAt) {
-			delete(v.cache, k)
-		}
 	}
 	v.mu.Unlock()
 

--- a/extras/scion-a2a-bridge/internal/bridge/uatvalidator_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/uatvalidator_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestUATValidator_ValidToken(t *testing.T) {
+	callCount := int32(0)
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		if r.URL.Path != "/api/v1/auth/me" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer scion_pat_test123" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		json.NewEncoder(w).Encode(userResponse{
+			ID:    "user-1",
+			Email: "alice@example.com",
+			Role:  "user",
+		})
+	}))
+	defer hub.Close()
+
+	v := NewUATValidator(hub.URL, 60*time.Second)
+	ctx := context.Background()
+
+	id, err := v.Validate(ctx, "scion_pat_test123")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if id.UserID != "user-1" || id.Email != "alice@example.com" || id.TokenType != "uat" {
+		t.Errorf("unexpected identity: %+v", id)
+	}
+	if id.RawToken != "scion_pat_test123" {
+		t.Errorf("RawToken = %q, want %q", id.RawToken, "scion_pat_test123")
+	}
+}
+
+func TestUATValidator_InvalidToken(t *testing.T) {
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer hub.Close()
+
+	v := NewUATValidator(hub.URL, 60*time.Second)
+	ctx := context.Background()
+
+	_, err := v.Validate(ctx, "scion_pat_invalid")
+	if err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+}
+
+func TestUATValidator_CacheTTL(t *testing.T) {
+	callCount := int32(0)
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		json.NewEncoder(w).Encode(userResponse{
+			ID:    "user-1",
+			Email: "alice@example.com",
+			Role:  "user",
+		})
+	}))
+	defer hub.Close()
+
+	// Use a very short TTL so we can test expiry.
+	v := NewUATValidator(hub.URL, 50*time.Millisecond)
+	ctx := context.Background()
+
+	// First call — hits Hub.
+	_, err := v.Validate(ctx, "scion_pat_cached")
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if c := atomic.LoadInt32(&callCount); c != 1 {
+		t.Fatalf("call count after first = %d, want 1", c)
+	}
+
+	// Second call — should be cached (no Hub call).
+	_, err = v.Validate(ctx, "scion_pat_cached")
+	if err != nil {
+		t.Fatalf("cached call: %v", err)
+	}
+	if c := atomic.LoadInt32(&callCount); c != 1 {
+		t.Fatalf("call count after cached = %d, want 1 (cached)", c)
+	}
+
+	// Wait for TTL to expire.
+	time.Sleep(100 * time.Millisecond)
+
+	// Third call — cache expired, should hit Hub again.
+	_, err = v.Validate(ctx, "scion_pat_cached")
+	if err != nil {
+		t.Fatalf("expired call: %v", err)
+	}
+	if c := atomic.LoadInt32(&callCount); c != 2 {
+		t.Fatalf("call count after expiry = %d, want 2", c)
+	}
+}
+
+func TestUATValidator_RevokedToken(t *testing.T) {
+	// Simulates a token that's valid initially, then revoked.
+	revoked := int32(0)
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.LoadInt32(&revoked) == 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		json.NewEncoder(w).Encode(userResponse{
+			ID:    "user-revoke",
+			Email: "revoke@example.com",
+			Role:  "user",
+		})
+	}))
+	defer hub.Close()
+
+	v := NewUATValidator(hub.URL, 50*time.Millisecond)
+	ctx := context.Background()
+
+	// Valid initially.
+	id, err := v.Validate(ctx, "scion_pat_revokable")
+	if err != nil {
+		t.Fatalf("initial validate: %v", err)
+	}
+	if id.UserID != "user-revoke" {
+		t.Fatalf("unexpected user: %s", id.UserID)
+	}
+
+	// Revoke the token.
+	atomic.StoreInt32(&revoked, 1)
+
+	// Still cached — should succeed.
+	_, err = v.Validate(ctx, "scion_pat_revokable")
+	if err != nil {
+		t.Fatalf("cached after revoke: %v", err)
+	}
+
+	// Wait for cache expiry.
+	time.Sleep(100 * time.Millisecond)
+
+	// Now should fail.
+	_, err = v.Validate(ctx, "scion_pat_revokable")
+	if err == nil {
+		t.Fatal("expected error after revocation and cache expiry")
+	}
+}
+
+func TestUATValidator_DefaultAndMaxTTL(t *testing.T) {
+	// Default TTL
+	v1 := NewUATValidator("http://hub", 0)
+	if v1.ttl != defaultUATCacheTTL {
+		t.Errorf("default TTL = %v, want %v", v1.ttl, defaultUATCacheTTL)
+	}
+
+	// Negative TTL
+	v2 := NewUATValidator("http://hub", -1*time.Second)
+	if v2.ttl != defaultUATCacheTTL {
+		t.Errorf("negative TTL = %v, want %v", v2.ttl, defaultUATCacheTTL)
+	}
+
+	// Over max TTL
+	v3 := NewUATValidator("http://hub", 600*time.Second)
+	if v3.ttl != maxUATCacheTTL {
+		t.Errorf("over-max TTL = %v, want %v", v3.ttl, maxUATCacheTTL)
+	}
+}
+
+func TestUATValidator_IncompleteResponse(t *testing.T) {
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return a response with missing email
+		json.NewEncoder(w).Encode(userResponse{
+			ID:   "user-1",
+			Role: "user",
+		})
+	}))
+	defer hub.Close()
+
+	v := NewUATValidator(hub.URL, 60*time.Second)
+	_, err := v.Validate(context.Background(), "scion_pat_test")
+	if err == nil {
+		t.Fatal("expected error for incomplete response")
+	}
+}

--- a/extras/scion-a2a-bridge/internal/state/state.go
+++ b/extras/scion-a2a-bridge/internal/state/state.go
@@ -25,15 +25,16 @@ import (
 
 // Task represents an A2A task mapped to a Scion agent interaction.
 type Task struct {
-	ID        string
-	ContextID string
-	ProjectID string
-	AgentSlug string
-	AgentID   string
-	State     string
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	Metadata  string
+	ID           string
+	ContextID    string
+	ProjectID    string
+	AgentSlug    string
+	AgentID      string
+	State        string
+	CallerUserID string // Per-user auth: Hub user ID of the caller. Empty for legacy-mode tasks.
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	Metadata     string
 }
 
 // Context maps an A2A contextId to a Scion agent.
@@ -142,6 +143,25 @@ func (s *Store) migrate() error {
 		}
 	}
 
+	// Incremental migrations: add columns to existing tables.
+	// Each uses IF NOT EXISTS-style guards so they are safe to re-run.
+	incrementalMigrations := []struct {
+		check string // Query that succeeds if migration already applied
+		apply string // DDL to run if check fails
+	}{
+		{
+			check: `SELECT caller_user_id FROM tasks LIMIT 0`,
+			apply: `ALTER TABLE tasks ADD COLUMN caller_user_id TEXT NOT NULL DEFAULT ''`,
+		},
+	}
+	for _, im := range incrementalMigrations {
+		if _, err := s.db.Exec(im.check); err != nil {
+			if _, err := s.db.Exec(im.apply); err != nil {
+				return fmt.Errorf("incremental migration: %w", err)
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -150,9 +170,9 @@ func (s *Store) migrate() error {
 // CreateTask inserts a new task record.
 func (s *Store) CreateTask(t *Task) error {
 	_, err := s.db.Exec(
-		`INSERT INTO tasks (id, context_id, project_id, agent_slug, agent_id, state, created_at, updated_at, metadata)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		t.ID, t.ContextID, t.ProjectID, t.AgentSlug, t.AgentID, t.State, t.CreatedAt, t.UpdatedAt, t.Metadata,
+		`INSERT INTO tasks (id, context_id, project_id, agent_slug, agent_id, state, caller_user_id, created_at, updated_at, metadata)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		t.ID, t.ContextID, t.ProjectID, t.AgentSlug, t.AgentID, t.State, t.CallerUserID, t.CreatedAt, t.UpdatedAt, t.Metadata,
 	)
 	if err != nil {
 		return fmt.Errorf("create task: %w", err)
@@ -164,9 +184,9 @@ func (s *Store) CreateTask(t *Task) error {
 func (s *Store) GetTask(id string) (*Task, error) {
 	t := &Task{}
 	err := s.db.QueryRow(
-		`SELECT id, context_id, project_id, agent_slug, agent_id, state, created_at, updated_at, metadata
+		`SELECT id, context_id, project_id, agent_slug, agent_id, state, caller_user_id, created_at, updated_at, metadata
 		 FROM tasks WHERE id = ?`, id,
-	).Scan(&t.ID, &t.ContextID, &t.ProjectID, &t.AgentSlug, &t.AgentID, &t.State, &t.CreatedAt, &t.UpdatedAt, &t.Metadata)
+	).Scan(&t.ID, &t.ContextID, &t.ProjectID, &t.AgentSlug, &t.AgentID, &t.State, &t.CallerUserID, &t.CreatedAt, &t.UpdatedAt, &t.Metadata)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -207,7 +227,7 @@ func (s *Store) UpdateTaskState(id, state string) error {
 // ListTasksByContext returns all tasks for the given context.
 func (s *Store) ListTasksByContext(ctx context.Context, contextID string) ([]Task, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, context_id, project_id, agent_slug, agent_id, state, created_at, updated_at, metadata
+		`SELECT id, context_id, project_id, agent_slug, agent_id, state, caller_user_id, created_at, updated_at, metadata
 		 FROM tasks WHERE context_id = ? ORDER BY created_at DESC`, contextID,
 	)
 	if err != nil {
@@ -218,7 +238,7 @@ func (s *Store) ListTasksByContext(ctx context.Context, contextID string) ([]Tas
 	var tasks []Task
 	for rows.Next() {
 		var t Task
-		if err := rows.Scan(&t.ID, &t.ContextID, &t.ProjectID, &t.AgentSlug, &t.AgentID, &t.State, &t.CreatedAt, &t.UpdatedAt, &t.Metadata); err != nil {
+		if err := rows.Scan(&t.ID, &t.ContextID, &t.ProjectID, &t.AgentSlug, &t.AgentID, &t.State, &t.CallerUserID, &t.CreatedAt, &t.UpdatedAt, &t.Metadata); err != nil {
 			return nil, fmt.Errorf("scan task: %w", err)
 		}
 		tasks = append(tasks, t)
@@ -229,7 +249,7 @@ func (s *Store) ListTasksByContext(ctx context.Context, contextID string) ([]Tas
 // ListTasksByAgent returns all tasks for a given project and agent.
 func (s *Store) ListTasksByAgent(projectID, agentSlug string) ([]Task, error) {
 	rows, err := s.db.Query(
-		`SELECT id, context_id, project_id, agent_slug, agent_id, state, created_at, updated_at, metadata
+		`SELECT id, context_id, project_id, agent_slug, agent_id, state, caller_user_id, created_at, updated_at, metadata
 		 FROM tasks WHERE project_id = ? AND agent_slug = ? ORDER BY created_at DESC`, projectID, agentSlug,
 	)
 	if err != nil {
@@ -240,7 +260,29 @@ func (s *Store) ListTasksByAgent(projectID, agentSlug string) ([]Task, error) {
 	var tasks []Task
 	for rows.Next() {
 		var t Task
-		if err := rows.Scan(&t.ID, &t.ContextID, &t.ProjectID, &t.AgentSlug, &t.AgentID, &t.State, &t.CreatedAt, &t.UpdatedAt, &t.Metadata); err != nil {
+		if err := rows.Scan(&t.ID, &t.ContextID, &t.ProjectID, &t.AgentSlug, &t.AgentID, &t.State, &t.CallerUserID, &t.CreatedAt, &t.UpdatedAt, &t.Metadata); err != nil {
+			return nil, fmt.Errorf("scan task: %w", err)
+		}
+		tasks = append(tasks, t)
+	}
+	return tasks, rows.Err()
+}
+
+// ListTasksByContextAndCaller returns tasks for the given context filtered by caller user ID.
+func (s *Store) ListTasksByContextAndCaller(ctx context.Context, contextID, callerUserID string) ([]Task, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, context_id, project_id, agent_slug, agent_id, state, caller_user_id, created_at, updated_at, metadata
+		 FROM tasks WHERE context_id = ? AND caller_user_id = ? ORDER BY created_at DESC`, contextID, callerUserID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list tasks by context and caller: %w", err)
+	}
+	defer rows.Close()
+
+	var tasks []Task
+	for rows.Next() {
+		var t Task
+		if err := rows.Scan(&t.ID, &t.ContextID, &t.ProjectID, &t.AgentSlug, &t.AgentID, &t.State, &t.CallerUserID, &t.CreatedAt, &t.UpdatedAt, &t.Metadata); err != nil {
 			return nil, fmt.Errorf("scan task: %w", err)
 		}
 		tasks = append(tasks, t)

--- a/extras/scion-a2a-bridge/scion-a2a-bridge.yaml.sample
+++ b/extras/scion-a2a-bridge/scion-a2a-bridge.yaml.sample
@@ -44,12 +44,35 @@ plugin:
 
 # External authentication for A2A clients calling the bridge.
 auth:
-  # Supported schemes: "apiKey" (default for MVP), "bearer".
+  # Supported schemes:
+  #   "apiKey"  — shared static key via X-API-Key header (default for MVP)
+  #   "bearer"  — shared static key via Authorization: Bearer header
+  #   "hubUAT"  — per-user Scion UAT (scion_pat_*) auth; tokens validated
+  #               via Hub /api/v1/auth/me; identity propagated to Hub calls
+  #   "hubJWT"  — per-user Scion JWT auth; tokens validated locally using
+  #               the hub.signing_key; identity propagated to Hub calls
+  #   "none"    — no authentication (not recommended for production)
   scheme: "apiKey"
 
-  # Static API key. Clients pass this in the X-API-Key header.
+  # Static API key (required for "apiKey" and "bearer" schemes only).
   # Use an env var reference for production: "${A2A_API_KEY}"
   api_key: "${A2A_API_KEY}"
+
+  # UAT introspection cache TTL for "hubUAT" scheme (optional).
+  # Default: 60s. Maximum: 300s. A revoked UAT stops working within
+  # one TTL of revocation.
+  # uat_cache_ttl: 60s
+
+  # --- Per-user UAT auth (recommended for desktop app federation) ---
+  # scheme: "hubUAT"
+  # Callers present "Authorization: Bearer scion_pat_..." tokens.
+  # No api_key needed. The bridge validates each token via Hub /api/v1/auth/me.
+  # uat_cache_ttl: 60s
+
+  # --- Per-user JWT auth (for CLI/scripted access) ---
+  # scheme: "hubJWT"
+  # Callers present Scion user JWTs. The hub.signing_key is used for
+  # local JWT validation. No api_key needed.
 
 # Groves exposed through the bridge. Each project maps to a set of
 # Scion agents that become discoverable A2A endpoints.


### PR DESCRIPTION
Adds per-user auth to the Scion A2A bridge (extras/scion-a2a-bridge/), closing the gap where every external A2A caller shared one static API key and Hub identity.

Design doc: .design/a2a-bridge-uat-auth.md

What ships:
- hubUAT scheme: validates Scion user access tokens via Hub GET /api/v1/auth/me (60s cache), no new Hub-side code required
- hubJWT scheme: validates HS256 user JWTs locally via Hub signing key
- Per-user identity propagation through ScionExecutor.Execute/Cancel and Hub client/Sender identity
- Per-user task isolation: CallerUserID column (backward-compatible SQLite migration)
- AllUserTopic wildcard broker subscription support in per-user mode
- Backward compatible: apiKey/bearer/none schemes unchanged
- 37 new tests, desktop-app federation guide added to external-channels.md

Zero Hub-side changes - confined to the bridge and its docs.

Test plan: go test ./extras/scion-a2a-bridge/... passes (37 new tests). Independent reviewer approved after 2 revision rounds