### PR TITLE
fix(agent): eliminate unauthenticated double-download causing 404 on private gh:// skills

### DIFF
--- a/pkg/agent/github_skill_resolver.go
+++ b/pkg/agent/github_skill_resolver.go
@@ -201,10 +201,11 @@ func (r *GitHubSkillResolver) resolveOne(ctx context.Context, ghRef *GitHubSkill
 		relPath := strings.TrimPrefix(entry.Path, ghRef.SkillPath+"/")
 
 		resolvedFiles = append(resolvedFiles, ResolvedFile{
-			Path: relPath,
-			URL:  r.rawContentURL(ghRef, commitSHA, entry.Path),
-			Hash: hash,
-			Size: int64(len(content)),
+			Path:    relPath,
+			URL:     r.rawContentURL(ghRef, commitSHA, entry.Path),
+			Hash:    hash,
+			Size:    int64(len(content)),
+			Content: content, // Carry bytes so install phase skips unauthenticated re-download.
 		})
 		fileInfos = append(fileInfos, transfer.FileInfo{Path: relPath, Hash: hash})
 	}

--- a/pkg/agent/github_skill_resolver_test.go
+++ b/pkg/agent/github_skill_resolver_test.go
@@ -21,7 +21,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -896,6 +899,138 @@ func TestGitHubSkillResolver_CrossCredentialCacheIsolation(t *testing.T) {
 	}
 	if apiCalls != callsAfterB {
 		t.Errorf("expected resolver B's second call to hit its own cache entry, got %d additional API calls", apiCalls-callsAfterB)
+	}
+}
+
+// TestGitHubPrivateRepoInstall_NoDoubleDownload is a regression test for a bug
+// where the install phase made a second, unauthenticated raw.githubusercontent.com
+// request to fetch file content that was already downloaded (with auth) during
+// resolution. Private repos return HTTP 404 to unauthenticated raw requests, so
+// the install phase would fail even though resolution succeeded.
+//
+// The fix (Option A): ResolvedFile.Content carries the bytes from resolution so
+// the install phase writes them directly and skips the network re-download.
+func TestGitHubPrivateRepoInstall_NoDoubleDownload(t *testing.T) {
+	skillContent := "# Private Skill\nSecret content."
+	readmeContent := "# README\nAlso secret."
+
+	// Track raw-content requests so we can assert auth behaviour.
+	var rawTotal atomic.Int32
+	var rawUnauthenticated atomic.Int32
+
+	server, mux := newTestGitHubServer(t)
+
+	// Commits endpoint — requires auth (private repo behaviour).
+	mux.HandleFunc("/repos/private-org/private-repo/commits/HEAD", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(testCommitSHA))
+	})
+
+	// Contents listing — requires auth.
+	mux.HandleFunc("/repos/private-org/private-repo/contents/skills/secret-skill", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]githubContentEntry{
+			{Name: "SKILL.md", Path: "skills/secret-skill/SKILL.md", Type: "file", Size: len(skillContent)},
+			{Name: "README.md", Path: "skills/secret-skill/README.md", Type: "file", Size: len(readmeContent)},
+		})
+	})
+
+	// Raw content — return 404 without auth, simulating GitHub private repo behaviour.
+	// Any request here without a Bearer token is exactly the unauthenticated
+	// re-download that the bug caused during the install phase.
+	mux.HandleFunc("/raw/private-org/private-repo/"+testCommitSHA+"/skills/secret-skill/SKILL.md",
+		func(w http.ResponseWriter, r *http.Request) {
+			rawTotal.Add(1)
+			if r.Header.Get("Authorization") == "" {
+				rawUnauthenticated.Add(1)
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = w.Write([]byte(skillContent))
+		})
+	mux.HandleFunc("/raw/private-org/private-repo/"+testCommitSHA+"/skills/secret-skill/README.md",
+		func(w http.ResponseWriter, r *http.Request) {
+			rawTotal.Add(1)
+			if r.Header.Get("Authorization") == "" {
+				rawUnauthenticated.Add(1)
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = w.Write([]byte(readmeContent))
+		})
+
+	resolver := newTestGitHubResolver(server)
+
+	// Phase 1: Resolve (authenticated — should succeed and populate f.Content).
+	result, err := resolver.Resolve(context.Background(), []api.SkillReference{
+		{URI: "gh://private-org/private-repo/secret-skill"},
+	}, ResolveOpts{})
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if len(result.Errors) != 0 {
+		t.Fatalf("unexpected resolve errors: %v", result.Errors)
+	}
+	if len(result.Resolved) != 1 {
+		t.Fatalf("expected 1 resolved skill, got %d", len(result.Resolved))
+	}
+
+	// All resolved files must carry pre-fetched content.
+	skill := result.Resolved[0]
+	for _, f := range skill.Files {
+		if f.Content == nil {
+			t.Errorf("file %q has nil Content after Resolve; install phase would make an unauthenticated re-download", f.Path)
+		}
+	}
+
+	// Record how many raw requests the resolution phase made (should be 2: one per file).
+	rawAfterResolve := rawTotal.Load()
+
+	// Phase 2: Install — must use pre-fetched content, not re-download.
+	agentHome := t.TempDir()
+	skillsDest := filepath.Join(agentHome, ".claude", "skills")
+
+	_, err = installResolvedSkills(context.Background(), result.Resolved, skillsDest, agentHome)
+	if err != nil {
+		// If the fix is absent, this fails with "download failed with status 404"
+		// because the install phase hits the mock server without a token.
+		t.Fatalf("installResolvedSkills failed (install phase may have made an unauthenticated re-download): %v", err)
+	}
+
+	// Verify files are present and correct on disk.
+	for _, tc := range []struct {
+		path string
+		want string
+	}{
+		{"SKILL.md", skillContent},
+		{"README.md", readmeContent},
+	} {
+		installed := filepath.Join(skillsDest, "secret-skill", tc.path)
+		data, err := os.ReadFile(installed)
+		if err != nil {
+			t.Fatalf("failed to read installed file %s: %v", tc.path, err)
+		}
+		if string(data) != tc.want {
+			t.Errorf("installed %s = %q, want %q", tc.path, string(data), tc.want)
+		}
+	}
+
+	// The raw endpoint must not have been hit again during install.
+	rawAfterInstall := rawTotal.Load()
+	if rawAfterInstall != rawAfterResolve {
+		t.Errorf("install phase made %d additional raw request(s); expected 0 (content should come from ResolvedFile.Content)",
+			rawAfterInstall-rawAfterResolve)
+	}
+
+	// No unauthenticated requests must have occurred at all.
+	if n := rawUnauthenticated.Load(); n > 0 {
+		t.Errorf("install phase made %d unauthenticated raw request(s); private-repo content would 404", n)
 	}
 }
 

--- a/pkg/agent/skill_resolver.go
+++ b/pkg/agent/skill_resolver.go
@@ -589,9 +589,14 @@ func writeSkillFileContent(content []byte, destPath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
 	}
-	defer func() { _ = f.Close() }()
+	defer func() { _ = f.Close() }() // safety net for panics / early returns
 	if _, err := f.Write(content); err != nil {
 		return fmt.Errorf("failed to write file: %w", err)
+	}
+	// Explicit close to catch flush errors (e.g. disk full). The deferred
+	// close above is a no-op after an explicit close, so it is safe to leave.
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to close file: %w", err)
 	}
 	util.Debugf("provision: wrote pre-fetched skill file %s (%d bytes)", filepath.Base(destPath), len(content))
 	return nil

--- a/pkg/agent/skill_resolver.go
+++ b/pkg/agent/skill_resolver.go
@@ -102,7 +102,16 @@ type ResolvedFile struct {
 	// GitHub resolver, which downloads each file during resolution for hashing).
 	// If non-nil, installOneSkill writes this directly and skips the network
 	// re-download, preventing unauthenticated requests that would 404 on
-	// private repos. The json:"-" tag keeps this out of the resolution cache.
+	// private repos.
+	//
+	// The json:"-" tag intentionally excludes Content from the on-disk
+	// GitHubResolutionCache. Entries loaded from disk (e.g. after a broker
+	// restart within the TTL window) will have Content == nil and fall back
+	// to downloadSkillFile, which makes an unauthenticated request. For private
+	// repos this means the restart-within-TTL path has the same limitation as
+	// before this fix. A follow-up is needed to address that narrower window
+	// (e.g. by not caching private-repo entries to disk, or by re-fetching
+	// content when the disk-cache entry is used for install).
 	Content []byte `json:"-"`
 }
 
@@ -310,6 +319,12 @@ func installOneSkill(ctx context.Context, skill ResolvedSkill, dest, skillsDest 
 		// resolution-phase download; using them here avoids a second,
 		// unauthenticated raw.githubusercontent.com request that would 404 on
 		// private repos.
+		//
+		// Note: entries loaded from the on-disk resolution cache have
+		// Content == nil (json:"-" strips it), so they fall through to
+		// downloadSkillFile. This means the post-restart, within-TTL path
+		// retains the pre-fix limitation for private repos. See the Content
+		// field doc on ResolvedFile for details.
 		if f.Content != nil {
 			if err := writeSkillFileContent(f.Content, destPath); err != nil {
 				return nil, fmt.Errorf("failed to write %s: %w", f.Path, err)
@@ -562,7 +577,14 @@ func downloadSkillFile(ctx context.Context, fileURL, destPath string, maxSize in
 // bypassing the network download. This is used when the resolver already holds
 // the file bytes in memory (e.g. GitHubSkillResolver downloads each file during
 // resolution for hashing) so that no second unauthenticated request is needed.
+//
+// Callers are responsible for pre-bounding content to a safe size. The GitHub
+// resolver enforces githubMaxFileSize (10 MB) before populating ResolvedFile.Content;
+// the check here is a defensive backstop for any future resolver that sets Content.
 func writeSkillFileContent(content []byte, destPath string) error {
+	if int64(len(content)) > defaultMaxFileSize {
+		return fmt.Errorf("pre-fetched content exceeds maximum size of %d bytes", defaultMaxFileSize)
+	}
 	f, err := os.Create(destPath)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)

--- a/pkg/agent/skill_resolver.go
+++ b/pkg/agent/skill_resolver.go
@@ -98,6 +98,12 @@ type ResolvedFile struct {
 	URL  string
 	Hash string
 	Size int64
+	// Content holds the pre-fetched file bytes when available (e.g. from the
+	// GitHub resolver, which downloads each file during resolution for hashing).
+	// If non-nil, installOneSkill writes this directly and skips the network
+	// re-download, preventing unauthenticated requests that would 404 on
+	// private repos. The json:"-" tag keeps this out of the resolution cache.
+	Content []byte `json:"-"`
 }
 
 // --- Context injection ---
@@ -299,8 +305,16 @@ func installOneSkill(ctx context.Context, skill ResolvedSkill, dest, skillsDest 
 			}
 		}
 
-		// S5: Download with transport constraints
-		if err := downloadSkillFile(ctx, f.URL, destPath, defaultMaxFileSize); err != nil {
+		// S5: Write pre-fetched content or download with transport constraints.
+		// GitHubSkillResolver carries content bytes from the authenticated
+		// resolution-phase download; using them here avoids a second,
+		// unauthenticated raw.githubusercontent.com request that would 404 on
+		// private repos.
+		if f.Content != nil {
+			if err := writeSkillFileContent(f.Content, destPath); err != nil {
+				return nil, fmt.Errorf("failed to write %s: %w", f.Path, err)
+			}
+		} else if err := downloadSkillFile(ctx, f.URL, destPath, defaultMaxFileSize); err != nil {
 			return nil, fmt.Errorf("failed to download %s: %w", f.Path, err)
 		}
 
@@ -541,6 +555,23 @@ func downloadSkillFile(ctx context.Context, fileURL, destPath string, maxSize in
 	// S5: Do not log the URL (may contain signed tokens)
 	util.Debugf("provision: downloaded skill file %s (%d bytes)", filepath.Base(destPath), n)
 
+	return nil
+}
+
+// writeSkillFileContent writes pre-fetched content bytes directly to destPath,
+// bypassing the network download. This is used when the resolver already holds
+// the file bytes in memory (e.g. GitHubSkillResolver downloads each file during
+// resolution for hashing) so that no second unauthenticated request is needed.
+func writeSkillFileContent(content []byte, destPath string) error {
+	f, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.Write(content); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+	util.Debugf("provision: wrote pre-fetched skill file %s (%d bytes)", filepath.Base(destPath), len(content))
 	return nil
 }
 


### PR DESCRIPTION
## Summary
GitHubSkillResolver downloaded each skill file twice: once authenticated (resolveOne, for hashing, bytes discarded) and once unauthenticated (installOneSkill via downloadSkillFile, no token access). Private repos 404 on the unauthenticated second fetch.

## Fix
Added Content []byte (json:"-") to ResolvedFile. resolveOne stores the already-fetched bytes; installOneSkill writes Content directly when present, skipping the redundant download. Other resolvers unaffected (Content stays nil, existing path unchanged).

## Scope note
A pre-existing, unrelated gap remains: disk-cache entries loaded after a broker restart still hit the unauthenticated path (Content isn't persisted to disk by design). Tracked separately: ptone/scion#565.

Regression test: TestGitHubPrivateRepoInstall_NoDoubleDownload. Reviewed and rechecked; all findings addressed.