### PR TITLE
feat: skill URI input validation and auto-transform

### DIFF
--- a/.design/project-skills-uri-transform.md
+++ b/.design/project-skills-uri-transform.md
@@ -1,0 +1,361 @@
+# Design: Skill URI Input Validation & Auto-Transform
+
+**Author:** ps-arch  
+**Date:** 2026-07-24  
+**Branch:** `scion/project-skills-uri-transform`  
+**Depends on:** PR #859 (`gh://` private-repo skill resolution, merged to main)  
+**Related findings:** `findings-uri-transform.md`
+
+---
+
+## Problem & Goals
+
+Users adding skills via `scion project skills add`, `scion user skills add`, or the web UI must type (or paste) a URI. The only current validation is `strings.Contains(s, "://")` in the CLI and an empty-string check in the hub — both trivially loose. The result:
+
+1. **Pasting a GitHub URL fails silently or with a cryptic 404.** A user who copies `https://github.com/org/repo/tree/main/skills/my-skill` from their browser will get a confusing 404 at provision time rather than having the URI auto-transformed to `gh://org/repo/my-skill@main`.
+2. **Unsupported schemes are stored and silently fail.** `scion://my-skill` appears in CLI docs but has no registered resolver; it fails at provision time with no useful guidance.
+3. **No deduplication.** Two different URL forms for the same skill are stored as separate entries.
+4. **No user feedback on what formats are accepted.**
+
+**Goals:**
+1. Accept full GitHub tree (and blob) URLs as input and transform them to the canonical `gh://` form.
+2. Reject unrecognized or ambiguous inputs with specific, actionable error messages.
+3. Fix the `scion://` latent bug by normalizing to `skill://` at input time.
+4. Enforce one canonical stored form so deduplication works correctly.
+5. Provide input-time feedback in the CLI (transform notice) and web UI (live preview).
+
+**Success criteria:** A user pasting `https://github.com/scion-frontiers/scion-repo-contrib/tree/main/skills/harness-qa` into any add flow sees the URI transformed to `gh://scion-frontiers/scion-repo-contrib/harness-qa@main` and stored in that form — without any additional steps.
+
+---
+
+## Non-Goals
+
+- Fixing the 404 on private repos (`scion-frontiers/scion-repo-contrib`). That is a credential configuration issue, not a URI format issue. See `findings-uri-transform.md §9`. The resolver correctly handles both URI forms; the 404 means the project lacks credentials for that org.
+- Supporting non-GitHub hosting (GitLab, Bitbucket, etc.). Scope creep; add a GCP resolver if needed separately.
+- Validating that the referenced skill actually exists at resolution time (that happens at provision time).
+- Supporting `https://raw.githubusercontent.com/` direct raw content URLs.
+
+---
+
+## Proposed Design
+
+### 1. `NormalizeSkillURI` in `pkg/api`
+
+Add a `NormalizeSkillURI(input string) (string, error)` function to `pkg/api/skill_uri.go`. This is the authoritative normalization function used by the hub (enforcement) and CLI (early feedback). The web UI implements a TypeScript equivalent.
+
+**Why `pkg/api`?** It already contains `ParseSkillURI` (for `skill://` URIs) and `SkillURIScheme`. Both `pkg/hub` and `pkg/agent` import `pkg/api`. The function does not need to import `pkg/agent` — the GitHub URL parsing is reimplemented inline (simpler than `ParseGitHubSkillURI`, which returns a full struct). The two implementations share the same URL grammar rules, documented with a cross-reference comment.
+
+**Function contract:**
+
+```go
+// NormalizeSkillURI accepts a user-supplied skill URI in any supported input form
+// and returns the canonical stored form.
+//
+// Supported input → output:
+//
+//  gh://owner/repo/skill[@ref][?token=SECRET_NAME]
+//    → gh://owner/repo/skill[@ref][?token=SECRET_NAME]   (validated, returned as-is)
+//
+//  https://github.com/owner/repo/tree/ref/skills/skill-name[?token=SECRET_NAME]
+//    → gh://owner/repo/skill-name@ref[?token=SECRET_NAME]   (shorthand)
+//
+//  https://github.com/owner/repo/tree/ref/other/path[?token=SECRET_NAME]
+//    → https://github.com/owner/repo/tree/ref/other/path[?token=SECRET_NAME]  (kept; resolver handles it)
+//
+//  https://github.com/owner/repo/blob/ref/skills/skill-name/SKILL.md[?token=SECRET_NAME]
+//    → gh://owner/repo/skill-name@ref[?token=SECRET_NAME]   (blob: strip filename, then apply tree rules)
+//
+//  scion://skill-name
+//    → skill://skill-name   (alias fix; see §4 below)
+//
+//  skill://... or bare name
+//    → validated via ParseSkillURI, returned as-is
+//
+// Returns a non-nil error for unsupported or ambiguous inputs, with an actionable
+// message that includes a valid-format example.
+func NormalizeSkillURI(input string) (string, error)
+```
+
+**Transform rules in detail:**
+
+| Input form | Output | Notes |
+|---|---|---|
+| `gh://owner/repo/skill[@ref][?token=X]` | same (validated) | Must have exactly 3 path segments |
+| `https://github.com/owner/repo/tree/ref/skills/skill-name` | `gh://owner/repo/skill-name@ref` | Skills-convention shorthand |
+| `https://github.com/owner/repo/tree/ref/other/deep/path` | `https://github.com/owner/repo/tree/ref/other/deep/path` | Non-standard path; kept as full URL |
+| `https://github.com/owner/repo/blob/ref/.../filename.ext` | parent dir → apply tree rule | Strip last segment if it contains `.` |
+| `scion://skill-name` | `skill://skill-name` | Alias fix; logged as transformation |
+| `skill://...` or bare name | same (validated) | Via existing `ParseSkillURI` |
+| `https://github.com/owner/repo` (bare repo) | error | No skill path |
+| `https://github.com/owner/repo/tree/main` (no path) | error | No skill path after ref |
+| `gcp-skill://...` | error | Not supported via add command; scheme reserved |
+| Any unknown `foo://` | error | Message: "unsupported scheme; supported: gh://, skill://, or a GitHub URL" |
+
+**`?token=SECRET_NAME` passthrough:** Present in input → preserved in output unchanged. The normalizer validates the secret name format (`[A-Z][A-Z0-9_]*`) but does not look up the value.
+
+**`blob` URL handling:** If the last path segment contains a `.` (looks like a filename), strip it and use the parent directory as the skill path. Apply the same rule as a `tree` URL. This covers the dominant pattern (`skills/skill-name/SKILL.md`, `skills/skill-name/README.md`). If the parent directory is empty after stripping, return an error.
+
+**`scion://` alias:** See §4.
+
+---
+
+### 2. Hub Enforcement (Authoritative)
+
+**File:** `pkg/hub/handlers_skills_injection.go`
+
+In `addProjectInjectedSkill` and `addUserInjectedSkill`, after trimming whitespace, call `api.NormalizeSkillURI`:
+
+```pseudocode
+entry.SkillURI = strings.TrimSpace(entry.SkillURI)
+if entry.SkillURI == "" {
+    ValidationError(w, "skillUri is required", nil)
+    return
+}
+normalized, err := api.NormalizeSkillURI(entry.SkillURI)
+if err != nil {
+    ValidationError(w, err.Error(), nil)  // HTTP 422
+    return
+}
+entry.SkillURI = normalized
+// (rest of handler unchanged)
+```
+
+Also apply in the **bulk PUT** endpoints (`setProjectInjectedSkills`, `setUserInjectedSkills`) where the per-entry URI is trimmed and dedup-checked. Each entry's URI is normalized before the dedup set and before storage.
+
+**HTTP response on invalid URI:** `422 Unprocessable Entity` with the error message from `NormalizeSkillURI`. Not 400 — the input was structurally valid JSON but semantically invalid. This is consistent with how `ValidationError` is used elsewhere in the handler.
+
+---
+
+### 3. CLI Normalization (Early Feedback)
+
+**Files:** `cmd/project_skills.go`, `cmd/user_skills.go`
+
+In `runProjectSkillsAdd` and `runUserSkillsAdd`, after the existing `isSkillURI` check:
+
+```pseudocode
+skillURI := args[0]
+normalized, err := api.NormalizeSkillURI(skillURI)
+if err != nil {
+    return fmt.Errorf("invalid skill URI: %w", err)
+}
+if normalized != skillURI {
+    fmt.Fprintf(cmd.ErrOrStderr(), "Note: URI transformed → %s\n", normalized)
+}
+skillURI = normalized
+// ... send skillURI to hub API
+```
+
+The `isSkillURI` check (`strings.Contains(s, "://")`) can be removed or replaced with the normalization call — `NormalizeSkillURI` accepts both URIs and bare skill names.
+
+**Behavior change:** Currently a bare skill name (`my-skill`) passes `isSkillURI` as false and is rejected. After this change, `NormalizeSkillURI` accepts it as a hub-skill bare name, normalizing to the same bare name. This is a net improvement (consistent with the API accepting bare names).
+
+---
+
+### 4. `scion://` Alias Fix
+
+`scion://` is documented in CLI help text and examples for `scion project skills add` and `scion user skills add`. However, `detectScheme()` in `routing_skill_resolver.go` routes it to scheme `"scion"`, which has no registered resolver → silent provision-time failure.
+
+**Fix in `NormalizeSkillURI`:** Replace `scion://` with `skill://` in the normalizer. The replacement is transparent to users — `scion://my-skill` is accepted and stored as `skill://my-skill`.
+
+Additionally, update the CLI help text examples to use `skill://` directly, so new users learn the correct scheme. The normalization remains for backward compatibility with existing stored entries (though any existing `scion://` entries in the DB would still fail until re-added — see §Migration).
+
+**Open question #1 (product decision, my recommendation):** Should `scion://` be normalized to `skill://` silently (recommendation: yes — it's a docs bug, not user error) or rejected with a message ("use skill:// instead")? I recommend silent normalization with a transformation notice in the CLI, because users who followed the documented examples shouldn't need to re-enter their skills.
+
+---
+
+### 5. Web UI Normalization
+
+**File:** `web/src/components/shared/injected-skills-panel.ts`
+
+In `handleAddSkill`, before submitting, apply a TypeScript normalization function. This is a client-side TypeScript re-implementation of the same rules (not a shared WASM or API call, to keep the latency-free UX).
+
+```typescript
+// Returns { canonical: string, transformed: boolean } or throws Error
+function normalizeSkillURI(input: string): { canonical: string; transformed: boolean }
+```
+
+Supported transforms in TypeScript:
+1. `https://github.com/owner/repo/tree/ref/skills/skill-name` → `gh://owner/repo/skill-name@ref`
+2. `https://github.com/owner/repo/blob/ref/.../file.ext` → strip filename → apply #1
+3. `scion://skill` → `skill://skill`
+4. `gh://...` → validate 3-segment form, pass through
+5. `skill://...` → pass through
+6. Other `://` schemes → throw with error message
+
+If `transformed === true`, show a brief "Transformed to: `gh://...`" message below the input before the user clicks Add.
+
+**Fallback:** If the TypeScript normalizer misses a case, the hub's Go implementation is authoritative and returns a 422 with a clear message that the UI can display.
+
+---
+
+### 6. Error Message Standards
+
+All error messages from `NormalizeSkillURI` must:
+1. State what was wrong with the input
+2. Give a correct-format example
+
+Example messages:
+- `"unsupported GitHub URL form \"%s\": expected a /tree/ URL with a skill path after the ref; example: https://github.com/owner/repo/tree/main/skills/my-skill"`
+- `"unsupported scheme \"gcp-skill\": skills using gcp-skill:// cannot be added via this command"`
+- `"invalid gh:// URI: expected gh://owner/repo/skill-name[@ref][?token=SECRET_NAME]"`
+- `"bare repo URL \"%s\" has no skill path; specify the skill directory, e.g. https://github.com/owner/repo/tree/main/skills/my-skill"`
+
+---
+
+## Alternatives Considered
+
+### A. Hub-only, no CLI/web normalization
+
+Only the hub normalizes. CLI and web UI send raw input; the hub returns 422 on invalid.
+
+**Rejected:** CLI users see a round-trip error with no pre-flight feedback. Acceptable security baseline, but poor UX. We implement both (hub authoritative + clients normalize for immediate feedback) at low additional cost since the Go function is shared between hub and CLI via `pkg/api`.
+
+### B. Normalization in `pkg/agent`
+
+Put `NormalizeSkillURI` in `pkg/agent/github_uri.go` alongside `ParseGitHubSkillURI`, and have `pkg/hub` import `pkg/agent`.
+
+**Rejected:** Currently `pkg/hub` does not import `pkg/agent` (only `pkg/agent/state`). Adding this import inverts the intended layering — `pkg/agent` is broker-side code. The normalization function is a user-facing API concern, not a broker concern. `pkg/api` is the correct home.
+
+### C. Move `GitHubSkillRef` to `pkg/api`, share parsing
+
+Refactor `pkg/agent/github_uri.go` to import `pkg/api` for the struct, and put `ParseGitHubSkillURI` in `pkg/api`. Eliminates code duplication between normalizer and resolver.
+
+**Rejected for this iteration:** Too large a refactor for the scope of this feature. The normalizer produces a canonical *string*; it doesn't need a `GitHubSkillRef` struct. The duplication is ~30 lines of URL parsing logic with a comment noting they must be kept in sync. Tracked as a future cleanup.
+
+### D. Reject all GitHub full URLs; require `gh://` input only
+
+Don't implement normalization. Document `gh://` as the only accepted form and tell users to convert manually.
+
+**Rejected:** The user's explicit requirement is that pasting a GitHub URL should work. The conversion is unambiguous for the common case. Requiring manual conversion is a UX failure.
+
+### E. Extend `gh://` to support multi-segment paths (`gh://owner/repo/path/to/skill`)
+
+Allow `gh://owner/repo/path/to/skill` as a 4+-segment path form, eliminating the implicit `skills/` prefix assumption and enabling canonical storage of all skill paths.
+
+**Rejected for this iteration:** Breaking change risk (current 3-part shorthand prepends `skills/`; a 4-part form would need a different semantic). The common case (skills at `skills/skill-name`) is handled by the 3-part shorthand. Non-standard paths can be stored as full GitHub URLs, which the resolver already handles. Tracked as potential future extension.
+
+---
+
+## Migration / Rollout
+
+- **No schema change.** URIs are stored as `text` columns; the canonical form is valid for existing DB values.
+- **Existing stored URIs are not migrated.** Entries already in the DB retain their current form. If a user previously stored `https://github.com/org/repo/tree/main/skills/my-skill` as a full URL, it continues to work (resolver handles both forms). The deduplication improvement only applies to new entries added after this change.
+- **`scion://` in existing DB entries.** Any existing `scion://` entries remain broken (no registered resolver) until the user removes and re-adds them. The normalization prevents new `scion://` entries from being stored. A one-time DB migration to replace `scion://` → `skill://` is recommended post-deploy but is not part of this design.
+- **Backward compat for API callers.** Programmatic callers (hub API clients) that POST a valid normalized URI see no change. Callers that POST `scion://` or a full GitHub URL will now receive the canonical form silently.
+- **CLI behavior change.** `isSkillURI()` currently rejects bare names (no `://`). After this change, bare names are accepted (normalized to hub-skill bare name form). This is strictly more permissive.
+
+---
+
+## Open Questions
+
+### OQ1: `scion://` — silent normalize vs. reject-with-guidance?
+
+**Recommendation:** Normalize silently to `skill://` with a CLI transformation notice. Rationale: documented in CLI examples, so users who followed docs are not at fault. Silent fix with a note is friendlier than telling them they did something wrong.
+
+**Alternative:** Return an error: `"scion:// is not a registered scheme; use skill:// instead"`. Simpler code (no alias), but breaks users who followed the docs.
+
+**Needs user sign-off.**
+
+### OQ2: `blob` URL handling — support or reject?
+
+**Recommendation:** Support `blob` URLs with the filename-stripping heuristic. The pattern (`skills/my-skill/SKILL.md` or `skills/my-skill/README.md`) is universal for well-formed skills. The heuristic is: "strip the last path segment if it contains a `.`".
+
+**Risk:** If a user pastes `https://github.com/org/repo/blob/main/skills/my-skill/some.dir.with.dots` (a directory with dots, unlikely but possible), the heuristic would incorrectly strip it. The error would be caught at provision time (skill directory not found).
+
+**Alternative:** Reject `blob` URLs with: `"Paste the directory URL instead of the file URL: replace /blob/ with /tree/ and omit the filename"`. Explicit and safe, but adds friction.
+
+**Needs user sign-off.**
+
+---
+
+## Implementation Phases
+
+### Phase 1: `NormalizeSkillURI` in `pkg/api` + tests (~150 lines)
+
+Add `NormalizeSkillURI(string) (string, error)` to `pkg/api/skill_uri.go` (or a new `pkg/api/skill_uri_normalize.go`).
+
+Unit test coverage:
+- All transform cases in the table above
+- `?token=SECRET_NAME` passthrough
+- Error cases with message content assertions
+- Round-trip: output of `NormalizeSkillURI` is a fixed point (calling it again returns the same string)
+
+This phase has no external dependencies and can be reviewed in isolation.
+
+### Phase 2: Hub enforcement (~40 lines)
+
+Add `NormalizeSkillURI` calls in `pkg/hub/handlers_skills_injection.go`:
+- `addProjectInjectedSkill` (line ~141 region)
+- `addUserInjectedSkill` (line ~431 region)
+- `setProjectInjectedSkills` bulk PUT (inner loop)
+- `setUserInjectedSkills` bulk PUT (inner loop)
+
+Return `ValidationError` (422) on normalization error.
+
+Integration test: POST a full GitHub URL → verify stored URI is the canonical `gh://` form.
+
+### Phase 3: CLI normalization (~30 lines)
+
+Update `cmd/project_skills.go` and `cmd/user_skills.go`:
+- Replace `isSkillURI` check with `api.NormalizeSkillURI` call
+- Print transformation notice to stderr when normalized form differs from input
+
+Update CLI help text and examples: replace `scion://` with `skill://`.
+
+### Phase 4: Web UI TypeScript normalization (~70 lines TS)
+
+Add `normalizeSkillURI` in `injected-skills-panel.ts` (or a shared utility module).
+Show transformation preview below the input field when a GitHub URL is entered.
+Handle 422 responses from hub by displaying the error message inline.
+
+---
+
+## Acceptance Criteria
+
+The QA tester should verify:
+
+**Transform coverage:**
+
+1. **Full GitHub tree URL → `gh://`** — `scion project skills add https://github.com/org/repo/tree/main/skills/my-skill` succeeds. Stored URI is `gh://org/repo/my-skill@main` (not the full URL). No error.
+
+2. **Full GitHub tree URL with non-standard path** — `https://github.com/org/repo/tree/main/contrib/my-skill` is accepted and stored as the full URL (resolver handles it). No error.
+
+3. **GitHub blob URL → `gh://`** — Pasting `https://github.com/org/repo/blob/main/skills/my-skill/SKILL.md` is transformed to `gh://org/repo/my-skill@main`. No error.
+
+4. **`gh://` shorthand passthrough** — `gh://org/repo/my-skill@main` is accepted unchanged. `gh://org/repo/my-skill` (no ref) is accepted unchanged.
+
+5. **`skill://` passthrough** — `skill://my-skill` is accepted unchanged.
+
+6. **Bare name** — `my-skill` is accepted as a bare hub-skill name.
+
+7. **`scion://` → `skill://`** — `scion://my-skill` is accepted and stored as `skill://my-skill`. CLI prints a transformation notice.
+
+**Validation (error cases):**
+
+8. **Bare repo URL** — `https://github.com/org/repo` produces a 422 error with message referencing the expected `/tree/ref/path` format.
+
+9. **Unsupported scheme** — `gcp-skill://something` produces a 422 with a message explaining the scheme is not accepted via this command.
+
+10. **Unknown scheme** — `ftp://anything` produces a 422 with the actionable error message.
+
+11. **Invalid `gh://` format** — `gh://owner-only` (too few segments) produces a 422.
+
+**Canonical storage (deduplication):**
+
+12. **Dedup** — Adding `https://github.com/org/repo/tree/main/skills/my-skill` when `gh://org/repo/my-skill@main` already exists produces a 409 Conflict (they normalize to the same URI).
+
+**Web UI:**
+
+13. **Live transform preview** — Pasting a full GitHub URL into the web UI skill add input shows the transformed `gh://` form before the user clicks Add.
+
+14. **Error display** — Pasting an unsupported URL displays the error message inline (not a console error or silent failure).
+
+**CLI:**
+
+15. **Transformation notice** — `scion project skills add https://github.com/org/repo/tree/main/skills/my-skill` prints `Note: URI transformed → gh://org/repo/my-skill@main` to stderr before confirming success.
+
+**Backward compatibility:**
+
+16. **Existing stored full-URL entries** — Skills stored as full GitHub URLs before this change continue to resolve at provision time (resolver handles both forms).
+
+17. **No regression on `skill://` and bare names** — Existing skill injection entries using `skill://` or bare names are unaffected.

--- a/.design/project-skills-uri-transform.md
+++ b/.design/project-skills-uri-transform.md
@@ -20,7 +20,7 @@ Users adding skills via `scion project skills add`, `scion user skills add`, or 
 **Goals:**
 1. Accept full GitHub tree (and blob) URLs as input and transform them to the canonical `gh://` form.
 2. Reject unrecognized or ambiguous inputs with specific, actionable error messages.
-3. Fix the `scion://` latent bug by normalizing to `skill://` at input time.
+3. Reject `scion://` input with a clear error pointing to `skill://` (the docs/example bug is tracked at #561).
 4. Enforce one canonical stored form so deduplication works correctly.
 5. Provide input-time feedback in the CLI (transform notice) and web UI (live preview).
 
@@ -66,7 +66,7 @@ Add a `NormalizeSkillURI(input string) (string, error)` function to `pkg/api/ski
 //    → gh://owner/repo/skill-name@ref[?token=SECRET_NAME]   (blob: strip filename, then apply tree rules)
 //
 //  scion://skill-name
-//    → skill://skill-name   (alias fix; see §4 below)
+//    → Error: "scion:// is not a supported scheme; use skill:// for hub-bank skills"
 //
 //  skill://... or bare name
 //    → validated via ParseSkillURI, returned as-is
@@ -93,7 +93,7 @@ func NormalizeSkillURI(input string) (string, error)
 
 **`?token=SECRET_NAME` passthrough:** Present in input → preserved in output unchanged. The normalizer validates the secret name format (`[A-Z][A-Z0-9_]*`) but does not look up the value.
 
-**`blob` URL handling:** If the last path segment contains a `.` (looks like a filename), strip it and use the parent directory as the skill path. Apply the same rule as a `tree` URL. This covers the dominant pattern (`skills/skill-name/SKILL.md`, `skills/skill-name/README.md`). If the parent directory is empty after stripping, return an error.
+**`blob` URL handling:** Strip the last path segment unconditionally (GitHub blob URLs always end in a filename — this is cleaner than a dot-check which would miss files without extensions like `Makefile`). Apply the same rule as a `tree` URL after stripping. If the parent directory is empty after stripping, return an error.
 
 **`scion://` alias:** See §4.
 
@@ -113,7 +113,7 @@ if entry.SkillURI == "" {
 }
 normalized, err := api.NormalizeSkillURI(entry.SkillURI)
 if err != nil {
-    ValidationError(w, err.Error(), nil)  // HTTP 422
+    ValidationError(w, err.Error(), nil)  // HTTP 400
     return
 }
 entry.SkillURI = normalized
@@ -122,7 +122,7 @@ entry.SkillURI = normalized
 
 Also apply in the **bulk PUT** endpoints (`setProjectInjectedSkills`, `setUserInjectedSkills`) where the per-entry URI is trimmed and dedup-checked. Each entry's URI is normalized before the dedup set and before storage.
 
-**HTTP response on invalid URI:** `422 Unprocessable Entity` with the error message from `NormalizeSkillURI`. Not 400 — the input was structurally valid JSON but semantically invalid. This is consistent with how `ValidationError` is used elsewhere in the handler.
+**HTTP response on invalid URI:** `400 Bad Request` (via `ValidationError`, which uses `http.StatusBadRequest`). Tests assert 400.
 
 ---
 
@@ -175,14 +175,14 @@ function normalizeSkillURI(input: string): { canonical: string; transformed: boo
 Supported transforms in TypeScript:
 1. `https://github.com/owner/repo/tree/ref/skills/skill-name` → `gh://owner/repo/skill-name@ref`
 2. `https://github.com/owner/repo/blob/ref/.../file.ext` → strip filename → apply #1
-3. `scion://skill` → `skill://skill`
+3. `scion://skill` → error: "scion:// is not a supported scheme; use skill:// for hub-bank skills"
 4. `gh://...` → validate 3-segment form, pass through
 5. `skill://...` → pass through
 6. Other `://` schemes → throw with error message
 
 If `transformed === true`, show a brief "Transformed to: `gh://...`" message below the input before the user clicks Add.
 
-**Fallback:** If the TypeScript normalizer misses a case, the hub's Go implementation is authoritative and returns a 422 with a clear message that the UI can display.
+**Fallback:** If the TypeScript normalizer misses a case, the hub's Go implementation is authoritative and returns a 400 with a clear message that the UI can display.
 
 ---
 
@@ -204,7 +204,7 @@ Example messages:
 
 ### A. Hub-only, no CLI/web normalization
 
-Only the hub normalizes. CLI and web UI send raw input; the hub returns 422 on invalid.
+Only the hub normalizes. CLI and web UI send raw input; the hub returns 400 on invalid.
 
 **Rejected:** CLI users see a round-trip error with no pre-flight feedback. Acceptable security baseline, but poor UX. We implement both (hub authoritative + clients normalize for immediate feedback) at low additional cost since the Go function is shared between hub and CLI via `pkg/api`.
 
@@ -278,7 +278,7 @@ Add `NormalizeSkillURI` calls in `pkg/hub/handlers_skills_injection.go`:
 - `setProjectInjectedSkills` bulk PUT (inner loop)
 - `setUserInjectedSkills` bulk PUT (inner loop)
 
-Return `ValidationError` (422) on normalization error.
+Return `ValidationError` (400) on normalization error.
 
 Integration test: POST a full GitHub URL → verify stored URI is the canonical `gh://` form.
 
@@ -294,7 +294,7 @@ Update CLI help text and examples: replace `scion://` with `skill://`.
 
 Add `normalizeSkillURI` in `injected-skills-panel.ts` (or a shared utility module).
 Show transformation preview below the input field when a GitHub URL is entered.
-Handle 422 responses from hub by displaying the error message inline.
+Handle 400 responses from hub by displaying the error message inline.
 
 ---
 
@@ -316,17 +316,17 @@ The QA tester should verify:
 
 6. **Bare name** — `my-skill` is accepted as a bare hub-skill name.
 
-7. **`scion://` rejected** — `scion://my-skill` produces a 422 error with a message pointing to `skill://`. No entry is stored.
+7. **`scion://` rejected** — `scion://my-skill` produces a 400 error with a message pointing to `skill://`. No entry is stored.
 
 **Validation (error cases):**
 
-8. **Bare repo URL** — `https://github.com/org/repo` produces a 422 error with message referencing the expected `/tree/ref/path` format.
+8. **Bare repo URL** — `https://github.com/org/repo` produces a 400 error with message referencing the expected `/tree/ref/path` format.
 
-9. **Unsupported scheme** — `gcp-skill://something` produces a 422 with a message explaining the scheme is not accepted via this command.
+9. **Unsupported scheme** — `gcp-skill://something` produces a 400 with a message explaining the scheme is not accepted via this command.
 
-10. **Unknown scheme** — `ftp://anything` produces a 422 with the actionable error message.
+10. **Unknown scheme** — `ftp://anything` produces a 400 with the actionable error message.
 
-11. **Invalid `gh://` format** — `gh://owner-only` (too few segments) produces a 422.
+11. **Invalid `gh://` format** — `gh://owner-only` (too few segments) produces a 400.
 
 **Canonical storage (deduplication):**
 

--- a/.design/project-skills-uri-transform.md
+++ b/.design/project-skills-uri-transform.md
@@ -84,7 +84,7 @@ func NormalizeSkillURI(input string) (string, error)
 | `https://github.com/owner/repo/tree/ref/skills/skill-name` | `gh://owner/repo/skill-name@ref` | Skills-convention shorthand |
 | `https://github.com/owner/repo/tree/ref/other/deep/path` | `https://github.com/owner/repo/tree/ref/other/deep/path` | Non-standard path; kept as full URL |
 | `https://github.com/owner/repo/blob/ref/.../filename.ext` | parent dir → apply tree rule | Strip last segment if it contains `.` |
-| `scion://skill-name` | `skill://skill-name` | Alias fix; logged as transformation |
+| `scion://skill-name` | error | Not supported; use `skill://`; docs bug tracked at #561 |
 | `skill://...` or bare name | same (validated) | Via existing `ParseSkillURI` |
 | `https://github.com/owner/repo` (bare repo) | error | No skill path |
 | `https://github.com/owner/repo/tree/main` (no path) | error | No skill path after ref |
@@ -151,15 +151,13 @@ The `isSkillURI` check (`strings.Contains(s, "://")`) can be removed or replaced
 
 ---
 
-### 4. `scion://` Alias Fix
+### 4. `scion://` Handling
 
-`scion://` is documented in CLI help text and examples for `scion project skills add` and `scion user skills add`. However, `detectScheme()` in `routing_skill_resolver.go` routes it to scheme `"scion"`, which has no registered resolver → silent provision-time failure.
+`scion://` appears in CLI help text and examples but has no registered resolver — it fails silently at provision time. The correct scheme is `skill://`.
 
-**Fix in `NormalizeSkillURI`:** Replace `scion://` with `skill://` in the normalizer. The replacement is transparent to users — `scion://my-skill` is accepted and stored as `skill://my-skill`.
+**Decision (2026-07-24, user sign-off):** `scion://` is rejected by `NormalizeSkillURI` with a clear error: `"scion:// is not a supported scheme; use skill:// for hub-bank skills"`. No alias or silent normalization.
 
-Additionally, update the CLI help text examples to use `skill://` directly, so new users learn the correct scheme. The normalization remains for backward compatibility with existing stored entries (though any existing `scion://` entries in the DB would still fail until re-added — see §Migration).
-
-**Open question #1 (product decision, my recommendation):** Should `scion://` be normalized to `skill://` silently (recommendation: yes — it's a docs bug, not user error) or rejected with a message ("use skill:// instead")? I recommend silent normalization with a transformation notice in the CLI, because users who followed the documented examples shouldn't need to re-enter their skills.
+The underlying docs bug is tracked at ptone/scion#561 and will be addressed by a separate cleanup agent (CLI help text updated to use `skill://`). The design doc update entry in the transform table changes from "normalized to skill://" to "rejected with error".
 
 ---
 
@@ -240,8 +238,8 @@ Allow `gh://owner/repo/path/to/skill` as a 4+-segment path form, eliminating the
 
 - **No schema change.** URIs are stored as `text` columns; the canonical form is valid for existing DB values.
 - **Existing stored URIs are not migrated.** Entries already in the DB retain their current form. If a user previously stored `https://github.com/org/repo/tree/main/skills/my-skill` as a full URL, it continues to work (resolver handles both forms). The deduplication improvement only applies to new entries added after this change.
-- **`scion://` in existing DB entries.** Any existing `scion://` entries remain broken (no registered resolver) until the user removes and re-adds them. The normalization prevents new `scion://` entries from being stored. A one-time DB migration to replace `scion://` → `skill://` is recommended post-deploy but is not part of this design.
-- **Backward compat for API callers.** Programmatic callers (hub API clients) that POST a valid normalized URI see no change. Callers that POST `scion://` or a full GitHub URL will now receive the canonical form silently.
+- **`scion://` in existing DB entries.** Any existing `scion://` entries remain broken (no registered resolver). The normalizer rejects new `scion://` input with a clear error. Existing stored entries are unaffected by this feature; cleanup tracked at ptone/scion#561.
+- **Backward compat for API callers.** Programmatic callers (hub API clients) that POST a valid normalized URI see no change. Callers that POST a full GitHub URL will receive the canonical `gh://` form.
 - **CLI behavior change.** `isSkillURI()` currently rejects bare names (no `://`). After this change, bare names are accepted (normalized to hub-skill bare name form). This is strictly more permissive.
 
 ---
@@ -250,11 +248,7 @@ Allow `gh://owner/repo/path/to/skill` as a 4+-segment path form, eliminating the
 
 ### OQ1: `scion://` — silent normalize vs. reject-with-guidance?
 
-**Recommendation:** Normalize silently to `skill://` with a CLI transformation notice. Rationale: documented in CLI examples, so users who followed docs are not at fault. Silent fix with a note is friendlier than telling them they did something wrong.
-
-**Alternative:** Return an error: `"scion:// is not a registered scheme; use skill:// instead"`. Simpler code (no alias), but breaks users who followed the docs.
-
-**Needs user sign-off.**
+**Resolved (2026-07-24):** Reject `scion://` with a clear error. Do not add a normalization alias. The docs/examples bug is tracked at ptone/scion#561 and will be cleaned up separately by a dedicated agent. Error message: `"scion:// is not a supported scheme; use skill:// for hub-bank skills"`.
 
 ### OQ2: `blob` URL handling — support or reject?
 
@@ -328,7 +322,7 @@ The QA tester should verify:
 
 6. **Bare name** — `my-skill` is accepted as a bare hub-skill name.
 
-7. **`scion://` → `skill://`** — `scion://my-skill` is accepted and stored as `skill://my-skill`. CLI prints a transformation notice.
+7. **`scion://` rejected** — `scion://my-skill` produces a 422 error with a message pointing to `skill://`. No entry is stored.
 
 **Validation (error cases):**
 

--- a/.design/project-skills-uri-transform.md
+++ b/.design/project-skills-uri-transform.md
@@ -252,13 +252,7 @@ Allow `gh://owner/repo/path/to/skill` as a 4+-segment path form, eliminating the
 
 ### OQ2: `blob` URL handling — support or reject?
 
-**Recommendation:** Support `blob` URLs with the filename-stripping heuristic. The pattern (`skills/my-skill/SKILL.md` or `skills/my-skill/README.md`) is universal for well-formed skills. The heuristic is: "strip the last path segment if it contains a `.`".
-
-**Risk:** If a user pastes `https://github.com/org/repo/blob/main/skills/my-skill/some.dir.with.dots` (a directory with dots, unlikely but possible), the heuristic would incorrectly strip it. The error would be caught at provision time (skill directory not found).
-
-**Alternative:** Reject `blob` URLs with: `"Paste the directory URL instead of the file URL: replace /blob/ with /tree/ and omit the filename"`. Explicit and safe, but adds friction.
-
-**Needs user sign-off.**
+**Resolved (2026-07-24):** Support `blob` URLs. Heuristic: strip the last path segment unconditionally (GitHub blob URLs always end in a filename). If the remaining path is empty after stripping, return an error. This is cleaner than the dot-check heuristic (no false positives for files without extensions, e.g., `Makefile`).
 
 ---
 

--- a/cmd/project_skills.go
+++ b/cmd/project_skills.go
@@ -219,9 +219,15 @@ func runProjectSkillsAdd(cmd *cobra.Command, args []string) error {
 	if skillURI == "" {
 		return fmt.Errorf("skill URI is required (expected format containing ://), got %q", args[0])
 	}
-	if !isSkillURI(skillURI) {
-		return fmt.Errorf("expected a skill URI (containing ://), got %q", skillURI)
+
+	normalized, err := api.NormalizeSkillURI(skillURI)
+	if err != nil {
+		return fmt.Errorf("invalid skill URI: %w", err)
 	}
+	if normalized != skillURI {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Note: URI transformed → %s\n", normalized)
+	}
+	skillURI = normalized
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/cmd/user_skills.go
+++ b/cmd/user_skills.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	"github.com/spf13/cobra"
@@ -146,9 +147,14 @@ func runUserSkillsList(cmd *cobra.Command, args []string) error {
 func runUserSkillsAdd(cmd *cobra.Command, args []string) error {
 	skillURI := args[0]
 
-	if !isSkillURI(skillURI) {
-		return fmt.Errorf("skill URI is required (expected format containing ://), got %q", skillURI)
+	normalized, err := api.NormalizeSkillURI(skillURI)
+	if err != nil {
+		return fmt.Errorf("invalid skill URI: %w", err)
 	}
+	if normalized != skillURI {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Note: URI transformed → %s\n", normalized)
+	}
+	skillURI = normalized
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/pkg/agent/github_uri.go
+++ b/pkg/agent/github_uri.go
@@ -108,10 +108,10 @@ func parseGHShorthand(uri string) (*GitHubSkillRef, error) {
 			return nil, fmt.Errorf("invalid gh:// URI %q: empty path component", uri)
 		}
 	}
-	if !validGitHubComponent.MatchString(parts[0]) {
+	if !validGitHubComponent.MatchString(parts[0]) || parts[0] == "." || parts[0] == ".." {
 		return nil, fmt.Errorf("invalid gh:// URI %q: invalid owner %q", uri, parts[0])
 	}
-	if !validGitHubComponent.MatchString(parts[1]) {
+	if !validGitHubComponent.MatchString(parts[1]) || parts[1] == "." || parts[1] == ".." {
 		return nil, fmt.Errorf("invalid gh:// URI %q: invalid repo %q", uri, parts[1])
 	}
 	if strings.Contains(parts[2], "..") {
@@ -173,10 +173,10 @@ func parseGitHubFullURL(uri string) (*GitHubSkillRef, error) {
 
 	owner := parts[0]
 	repo := parts[1]
-	if !validGitHubComponent.MatchString(owner) {
+	if !validGitHubComponent.MatchString(owner) || owner == "." || owner == ".." {
 		return nil, fmt.Errorf("invalid GitHub URL %q: invalid owner %q", uri, owner)
 	}
-	if !validGitHubComponent.MatchString(repo) {
+	if !validGitHubComponent.MatchString(repo) || repo == "." || repo == ".." {
 		return nil, fmt.Errorf("invalid GitHub URL %q: invalid repo %q", uri, repo)
 	}
 	refAndPath := parts[3] + "/" + parts[4]

--- a/pkg/agent/github_uri.go
+++ b/pkg/agent/github_uri.go
@@ -94,8 +94,8 @@ func parseGHShorthand(uri string) (*GitHubSkillRef, error) {
 	if idx := strings.LastIndex(rest, "@"); idx >= 0 {
 		ref = rest[idx+1:]
 		rest = rest[:idx]
-		if ref == "" {
-			return nil, fmt.Errorf("invalid gh:// URI %q: empty ref after @", uri)
+		if ref == "" || ref == "." || ref == ".." {
+			return nil, fmt.Errorf("invalid gh:// URI %q: invalid ref %q", uri, ref)
 		}
 	}
 
@@ -114,8 +114,8 @@ func parseGHShorthand(uri string) (*GitHubSkillRef, error) {
 	if !validGitHubComponent.MatchString(parts[1]) || parts[1] == "." || parts[1] == ".." {
 		return nil, fmt.Errorf("invalid gh:// URI %q: invalid repo %q", uri, parts[1])
 	}
-	if strings.Contains(parts[2], "..") {
-		return nil, fmt.Errorf("invalid gh:// URI %q: skill name must not contain '..'", uri)
+	if parts[2] == "." || strings.Contains(parts[2], "..") {
+		return nil, fmt.Errorf("invalid gh:// URI %q: skill name must not contain '.' or '..'", uri)
 	}
 	if strings.ContainsAny(parts[2], "?#&=") {
 		return nil, fmt.Errorf("invalid gh:// URI %q: skill name contains invalid characters", uri)
@@ -188,6 +188,9 @@ func parseGitHubFullURL(uri string) (*GitHubSkillRef, error) {
 		return nil, fmt.Errorf("invalid GitHub URL %q: missing skill path after ref", uri)
 	}
 	ref := refParts[0]
+	if ref == "." || ref == ".." {
+		return nil, fmt.Errorf("invalid GitHub URL %q: invalid ref %q", uri, ref)
+	}
 	skillFullPath := refParts[1]
 
 	pathParts := strings.Split(skillFullPath, "/")

--- a/pkg/api/skill_uri_normalize.go
+++ b/pkg/api/skill_uri_normalize.go
@@ -131,10 +131,10 @@ func normalizeGHShorthand(uri string) (string, error) {
 			return "", fmt.Errorf("invalid gh:// URI %q: empty path component", uri)
 		}
 	}
-	if !validGHComponent.MatchString(parts[0]) {
+	if !validGHComponent.MatchString(parts[0]) || parts[0] == "." || parts[0] == ".." {
 		return "", fmt.Errorf("invalid gh:// URI %q: invalid owner %q (must match [a-zA-Z0-9._-]+)", uri, parts[0])
 	}
-	if !validGHComponent.MatchString(parts[1]) {
+	if !validGHComponent.MatchString(parts[1]) || parts[1] == "." || parts[1] == ".." {
 		return "", fmt.Errorf("invalid gh:// URI %q: invalid repo %q (must match [a-zA-Z0-9._-]+)", uri, parts[1])
 	}
 	if strings.Contains(parts[2], "..") || strings.ContainsAny(parts[2], "?#&=") {
@@ -190,14 +190,14 @@ func normalizeGitHubURL(uri string) (string, error) {
 	keyword := strings.ToLower(parts[2])
 	ref := parts[3]
 
-	if !validGHComponent.MatchString(owner) {
+	if !validGHComponent.MatchString(owner) || owner == "." || owner == ".." {
 		return "", fmt.Errorf("invalid GitHub URL %q: invalid owner %q", uri, owner)
 	}
-	if !validGHComponent.MatchString(repo) {
+	if !validGHComponent.MatchString(repo) || repo == "." || repo == ".." {
 		return "", fmt.Errorf("invalid GitHub URL %q: invalid repo %q", uri, repo)
 	}
-	if ref == "" {
-		return "", fmt.Errorf("invalid GitHub URL %q: empty ref", uri)
+	if ref == "" || ref == "." || ref == ".." {
+		return "", fmt.Errorf("invalid GitHub URL %q: empty or invalid ref %q", uri, ref)
 	}
 
 	var skillFullPath string

--- a/pkg/api/skill_uri_normalize.go
+++ b/pkg/api/skill_uri_normalize.go
@@ -1,0 +1,249 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// validGHComponent matches valid GitHub owner and repo name characters.
+// NOTE: this must be kept in sync with validGitHubComponent in
+// pkg/agent/github_uri.go.
+var validGHComponent = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+// validGHSecretName matches token secret names: [A-Z][A-Z0-9_]*.
+// NOTE: this must be kept in sync with validTokenSecretName in
+// pkg/agent/github_uri.go.
+var validGHSecretName = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+// NormalizeSkillURI accepts a user-supplied skill URI in any supported input
+// form and returns the canonical stored form.
+//
+// Supported input → canonical output:
+//
+//	gh://owner/repo/skill[@ref][?token=SECRET_NAME]
+//	  → gh://owner/repo/skill[@ref][?token=SECRET_NAME]   (validated, returned as-is)
+//
+//	https://github.com/owner/repo/tree/ref/skills/skill-name[?token=SECRET_NAME]
+//	  → gh://owner/repo/skill-name@ref[?token=SECRET_NAME]   (shorthand)
+//
+//	https://github.com/owner/repo/tree/ref/other/path[?token=SECRET_NAME]
+//	  → https://github.com/owner/repo/tree/ref/other/path[?token=SECRET_NAME]   (kept)
+//
+//	https://github.com/owner/repo/blob/ref/skills/skill-name/SKILL.md[?token=SECRET_NAME]
+//	  → gh://owner/repo/skill-name@ref[?token=SECRET_NAME]   (blob: last segment stripped)
+//
+//	skill://[registry/][scope/]name[@version]  or  bare-name
+//	  → validated via ParseSkillURI, returned as-is
+//
+// Returns a non-nil error with an actionable message for unsupported or
+// ambiguous inputs (bare repo URL, unknown scheme, invalid component, etc.).
+func NormalizeSkillURI(input string) (string, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", fmt.Errorf("skill URI must not be empty")
+	}
+
+	lower := strings.ToLower(input)
+
+	switch {
+	case strings.HasPrefix(lower, "gh://"):
+		return normalizeGHShorthand(input)
+	case strings.HasPrefix(lower, "https://github.com/"),
+		strings.HasPrefix(lower, "http://github.com/"):
+		return normalizeGitHubURL(input)
+	case strings.HasPrefix(lower, "scion://"):
+		return "", fmt.Errorf("scion:// is not a supported scheme; use skill:// for hub-bank skills")
+	case strings.HasPrefix(lower, "skill://"):
+		if _, err := ParseSkillURI(input); err != nil {
+			return "", err
+		}
+		return input, nil
+	case strings.Contains(input, "://"):
+		// Unknown scheme
+		scheme := input[:strings.Index(input, "://")]
+		return "", fmt.Errorf("unsupported scheme %q; supported inputs: gh://owner/repo/skill, skill://name, or a GitHub URL (https://github.com/...)", scheme)
+	default:
+		// Bare skill name
+		if _, err := ParseSkillURI(input); err != nil {
+			return "", err
+		}
+		return input, nil
+	}
+}
+
+// normalizeGHShorthand validates a gh:// URI and returns it unchanged if valid.
+// The grammar is: gh://owner/repo/skill-name[@ref][?token=SECRET_NAME]
+// This mirrors parseGHShorthand in pkg/agent/github_uri.go.
+func normalizeGHShorthand(uri string) (string, error) {
+	rest := uri[len("gh://"):]
+
+	// Extract ?token=SECRET_NAME query param, which must be the last component.
+	var tokenSuffix string
+	if qIdx := strings.Index(rest, "?"); qIdx >= 0 {
+		query := rest[qIdx+1:]
+		rest = rest[:qIdx]
+		if !strings.HasPrefix(query, "token=") {
+			return "", fmt.Errorf("invalid gh:// URI %q: unsupported query parameter; only ?token=SECRET_NAME is supported", uri)
+		}
+		tokenName := query[len("token="):]
+		if tokenName == "" {
+			return "", fmt.Errorf("invalid gh:// URI %q: empty ?token= value", uri)
+		}
+		if !validGHSecretName.MatchString(tokenName) {
+			return "", fmt.Errorf("invalid gh:// URI %q: ?token= value %q must match [A-Z][A-Z0-9_]* (uppercase env-var style)", uri, tokenName)
+		}
+		tokenSuffix = "?" + query
+	}
+
+	// Extract @ref (split at last @, which must be after the skill-name segment).
+	var refSuffix string
+	if idx := strings.LastIndex(rest, "@"); idx >= 0 {
+		ref := rest[idx+1:]
+		rest = rest[:idx]
+		if ref == "" {
+			return "", fmt.Errorf("invalid gh:// URI %q: empty ref after @", uri)
+		}
+		refSuffix = "@" + ref
+	}
+
+	// Expect exactly owner/repo/skill-name (3 slash-separated segments).
+	parts := strings.Split(rest, "/")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid gh:// URI %q: expected gh://owner/repo/skill-name[@ref][?token=SECRET_NAME]", uri)
+	}
+	for _, p := range parts {
+		if p == "" {
+			return "", fmt.Errorf("invalid gh:// URI %q: empty path component", uri)
+		}
+	}
+	if !validGHComponent.MatchString(parts[0]) {
+		return "", fmt.Errorf("invalid gh:// URI %q: invalid owner %q (must match [a-zA-Z0-9._-]+)", uri, parts[0])
+	}
+	if !validGHComponent.MatchString(parts[1]) {
+		return "", fmt.Errorf("invalid gh:// URI %q: invalid repo %q (must match [a-zA-Z0-9._-]+)", uri, parts[1])
+	}
+	if strings.Contains(parts[2], "..") || strings.ContainsAny(parts[2], "?#&=") {
+		return "", fmt.Errorf("invalid gh:// URI %q: invalid skill name %q", uri, parts[2])
+	}
+
+	return "gh://" + rest + refSuffix + tokenSuffix, nil
+}
+
+// normalizeGitHubURL transforms a full GitHub URL (tree or blob form) into
+// the canonical stored form.
+//
+// tree URLs with a skills/skill-name path → gh://owner/repo/skill-name@ref
+// tree URLs with any other path            → full URL (kept, with https://)
+// blob URLs                               → last segment stripped, then same rules as tree
+func normalizeGitHubURL(uri string) (string, error) {
+	// Determine the path part after the scheme+host, preserving original case.
+	var rest string
+	for _, prefix := range []string{"https://github.com/", "http://github.com/"} {
+		if strings.HasPrefix(strings.ToLower(uri), prefix) {
+			rest = uri[len(prefix):]
+			break
+		}
+	}
+
+	// Extract ?token=SECRET_NAME before path parsing.
+	var tokenSuffix string
+	if qIdx := strings.Index(rest, "?"); qIdx >= 0 {
+		query := rest[qIdx+1:]
+		rest = rest[:qIdx]
+		if !strings.HasPrefix(query, "token=") {
+			return "", fmt.Errorf("invalid GitHub URL %q: unsupported query parameter; only ?token=SECRET_NAME is supported", uri)
+		}
+		tokenName := query[len("token="):]
+		if tokenName == "" {
+			return "", fmt.Errorf("invalid GitHub URL %q: empty ?token= value", uri)
+		}
+		if !validGHSecretName.MatchString(tokenName) {
+			return "", fmt.Errorf("invalid GitHub URL %q: ?token= value %q must match [A-Z][A-Z0-9_]* (uppercase env-var style)", uri, tokenName)
+		}
+		tokenSuffix = "?" + query
+	}
+
+	// Split: owner / repo / keyword / ref / path...
+	// Use SplitN 5 so the path portion is kept whole.
+	parts := strings.SplitN(rest, "/", 5)
+	if len(parts) < 4 {
+		return "", fmt.Errorf("invalid GitHub URL %q: expected https://github.com/owner/repo/tree/ref/path/to/skill", uri)
+	}
+
+	owner := parts[0]
+	repo := parts[1]
+	keyword := strings.ToLower(parts[2])
+	ref := parts[3]
+
+	if !validGHComponent.MatchString(owner) {
+		return "", fmt.Errorf("invalid GitHub URL %q: invalid owner %q", uri, owner)
+	}
+	if !validGHComponent.MatchString(repo) {
+		return "", fmt.Errorf("invalid GitHub URL %q: invalid repo %q", uri, repo)
+	}
+	if ref == "" {
+		return "", fmt.Errorf("invalid GitHub URL %q: empty ref", uri)
+	}
+
+	var skillFullPath string
+	switch keyword {
+	case "tree":
+		if len(parts) < 5 || parts[4] == "" {
+			return "", fmt.Errorf("invalid GitHub URL %q: missing skill path after ref; example: https://github.com/owner/repo/tree/main/skills/my-skill", uri)
+		}
+		skillFullPath = parts[4]
+	case "blob":
+		if len(parts) < 5 || parts[4] == "" {
+			return "", fmt.Errorf("invalid GitHub URL %q: missing file path after ref", uri)
+		}
+		filePath := parts[4]
+		// Blob URLs always end in a filename; strip the last segment to get
+		// the skill directory.
+		if idx := strings.LastIndex(filePath, "/"); idx >= 0 {
+			filePath = filePath[:idx]
+		} else {
+			// No slash means the file is at the repo root — no skill directory.
+			return "", fmt.Errorf("invalid GitHub URL %q: cannot determine skill directory from blob URL (no parent directory)", uri)
+		}
+		if filePath == "" {
+			return "", fmt.Errorf("invalid GitHub URL %q: cannot determine skill directory from blob URL", uri)
+		}
+		skillFullPath = filePath
+	default:
+		return "", fmt.Errorf("invalid GitHub URL %q: expected /tree/ or /blob/ after owner/repo, got /%s/", uri, parts[2])
+	}
+
+	if strings.Contains(skillFullPath, "..") {
+		return "", fmt.Errorf("invalid GitHub URL %q: path must not contain '..'", uri)
+	}
+
+	// Try to produce the compact gh:// shorthand.
+	// The shorthand maps gh://owner/repo/skill-name → skills/skill-name in the
+	// repo (implicit "skills/" prefix). Only use it for paths of exactly that form.
+	pathParts := strings.Split(skillFullPath, "/")
+	if len(pathParts) == 2 && strings.ToLower(pathParts[0]) == "skills" && pathParts[1] != "" {
+		skillName := pathParts[1]
+		if strings.Contains(skillName, "..") || strings.ContainsAny(skillName, "?#&=") {
+			return "", fmt.Errorf("invalid GitHub URL %q: invalid skill name %q", uri, skillName)
+		}
+		return "gh://" + owner + "/" + repo + "/" + skillName + "@" + ref + tokenSuffix, nil
+	}
+
+	// Non-standard path: keep as full canonical tree URL (resolver handles it).
+	return "https://github.com/" + owner + "/" + repo + "/tree/" + ref + "/" + skillFullPath + tokenSuffix, nil
+}

--- a/pkg/api/skill_uri_normalize.go
+++ b/pkg/api/skill_uri_normalize.go
@@ -115,8 +115,8 @@ func normalizeGHShorthand(uri string) (string, error) {
 	if idx := strings.LastIndex(rest, "@"); idx >= 0 {
 		ref := rest[idx+1:]
 		rest = rest[:idx]
-		if ref == "" {
-			return "", fmt.Errorf("invalid gh:// URI %q: empty ref after @", uri)
+		if ref == "" || ref == "." || ref == ".." {
+			return "", fmt.Errorf("invalid gh:// URI %q: invalid ref %q", uri, ref)
 		}
 		refSuffix = "@" + ref
 	}
@@ -137,7 +137,7 @@ func normalizeGHShorthand(uri string) (string, error) {
 	if !validGHComponent.MatchString(parts[1]) || parts[1] == "." || parts[1] == ".." {
 		return "", fmt.Errorf("invalid gh:// URI %q: invalid repo %q (must match [a-zA-Z0-9._-]+)", uri, parts[1])
 	}
-	if strings.Contains(parts[2], "..") || strings.ContainsAny(parts[2], "?#&=") {
+	if parts[2] == "." || strings.Contains(parts[2], "..") || strings.ContainsAny(parts[2], "?#&=") {
 		return "", fmt.Errorf("invalid gh:// URI %q: invalid skill name %q", uri, parts[2])
 	}
 

--- a/pkg/api/skill_uri_normalize_test.go
+++ b/pkg/api/skill_uri_normalize_test.go
@@ -73,6 +73,26 @@ func TestNormalizeSkillURI(t *testing.T) {
 			wantErr: "invalid owner",
 		},
 		{
+			name:    "gh shorthand dot as owner rejected",
+			input:   "gh://./repo/skill",
+			wantErr: "invalid owner",
+		},
+		{
+			name:    "gh shorthand dotdot as owner rejected",
+			input:   "gh://../repo/skill",
+			wantErr: "invalid owner",
+		},
+		{
+			name:    "gh shorthand dot as repo rejected",
+			input:   "gh://org/./skill",
+			wantErr: "invalid repo",
+		},
+		{
+			name:    "gh shorthand dotdot as repo rejected",
+			input:   "gh://org/../skill",
+			wantErr: "invalid repo",
+		},
+		{
 			name:    "gh shorthand dotdot in skill",
 			input:   "gh://org/repo/..evil",
 			wantErr: "invalid skill name",
@@ -184,6 +204,36 @@ func TestNormalizeSkillURI(t *testing.T) {
 			name:    "github dotdot path traversal",
 			input:   "https://github.com/org/repo/tree/main/skills/../secret",
 			wantErr: "must not contain '..'",
+		},
+		{
+			name:    "github dot as owner rejected",
+			input:   "https://github.com/./repo/tree/main/skills/my-skill",
+			wantErr: "invalid owner",
+		},
+		{
+			name:    "github dotdot as owner rejected",
+			input:   "https://github.com/../repo/tree/main/skills/my-skill",
+			wantErr: "invalid owner",
+		},
+		{
+			name:    "github dot as repo rejected",
+			input:   "https://github.com/org/./tree/main/skills/my-skill",
+			wantErr: "invalid repo",
+		},
+		{
+			name:    "github dotdot as repo rejected",
+			input:   "https://github.com/org/../tree/main/skills/my-skill",
+			wantErr: "invalid repo",
+		},
+		{
+			name:    "github dot as ref rejected",
+			input:   "https://github.com/org/repo/tree/./skills/my-skill",
+			wantErr: "invalid ref",
+		},
+		{
+			name:    "github dotdot as ref rejected",
+			input:   "https://github.com/org/repo/tree/../skills/my-skill",
+			wantErr: "invalid ref",
 		},
 
 		// ── scion:// rejected ────────────────────────────────────────────────

--- a/pkg/api/skill_uri_normalize_test.go
+++ b/pkg/api/skill_uri_normalize_test.go
@@ -115,7 +115,22 @@ func TestNormalizeSkillURI(t *testing.T) {
 		{
 			name:    "gh shorthand empty ref after @",
 			input:   "gh://org/repo/skill@",
-			wantErr: "empty ref after @",
+			wantErr: "invalid ref",
+		},
+		{
+			name:    "gh shorthand dot as ref rejected",
+			input:   "gh://org/repo/skill@.",
+			wantErr: "invalid ref",
+		},
+		{
+			name:    "gh shorthand dotdot as ref rejected",
+			input:   "gh://org/repo/skill@..",
+			wantErr: "invalid ref",
+		},
+		{
+			name:    "gh shorthand single-dot skill name rejected",
+			input:   "gh://org/repo/.",
+			wantErr: "invalid skill name",
 		},
 
 		// ── GitHub tree URL → gh:// shorthand ───────────────────────────────

--- a/pkg/api/skill_uri_normalize_test.go
+++ b/pkg/api/skill_uri_normalize_test.go
@@ -1,0 +1,305 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeSkillURI(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string // empty means error expected
+		wantErr string // substring that must appear in the error
+	}{
+		// ── gh:// passthrough / validation ──────────────────────────────────
+		{
+			name:  "gh shorthand no ref",
+			input: "gh://org/repo/my-skill",
+			want:  "gh://org/repo/my-skill",
+		},
+		{
+			name:  "gh shorthand with ref",
+			input: "gh://org/repo/my-skill@main",
+			want:  "gh://org/repo/my-skill@main",
+		},
+		{
+			name:  "gh shorthand with sha ref",
+			input: "gh://org/repo/my-skill@a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+			want:  "gh://org/repo/my-skill@a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+		},
+		{
+			name:  "gh shorthand with token",
+			input: "gh://org/repo/my-skill?token=SKILLS_TOKEN",
+			want:  "gh://org/repo/my-skill?token=SKILLS_TOKEN",
+		},
+		{
+			name:  "gh shorthand with ref and token",
+			input: "gh://org/repo/my-skill@v1.2.3?token=PARTNER_TOKEN",
+			want:  "gh://org/repo/my-skill@v1.2.3?token=PARTNER_TOKEN",
+		},
+		{
+			name:    "gh shorthand too few segments",
+			input:   "gh://org/repo",
+			wantErr: "expected gh://owner/repo/skill-name",
+		},
+		{
+			name:    "gh shorthand too many segments",
+			input:   "gh://org/repo/skills/my-skill",
+			wantErr: "expected gh://owner/repo/skill-name",
+		},
+		{
+			name:    "gh shorthand empty skill name",
+			input:   "gh://org/repo/@main",
+			wantErr: "empty path component",
+		},
+		{
+			name:    "gh shorthand invalid owner chars",
+			input:   "gh://org name/repo/skill",
+			wantErr: "invalid owner",
+		},
+		{
+			name:    "gh shorthand dotdot in skill",
+			input:   "gh://org/repo/..evil",
+			wantErr: "invalid skill name",
+		},
+		{
+			name:    "gh shorthand bad token name",
+			input:   "gh://org/repo/skill?token=lowercase",
+			wantErr: "must match [A-Z][A-Z0-9_]*",
+		},
+		{
+			name:    "gh shorthand empty token value",
+			input:   "gh://org/repo/skill?token=",
+			wantErr: "empty ?token= value",
+		},
+		{
+			name:    "gh shorthand unsupported query param",
+			input:   "gh://org/repo/skill?foo=bar",
+			wantErr: "unsupported query parameter",
+		},
+		{
+			name:    "gh shorthand empty ref after @",
+			input:   "gh://org/repo/skill@",
+			wantErr: "empty ref after @",
+		},
+
+		// ── GitHub tree URL → gh:// shorthand ───────────────────────────────
+		{
+			name:  "github tree skills/skill-name",
+			input: "https://github.com/scion-frontiers/scion-repo-contrib/tree/main/skills/harness-qa",
+			want:  "gh://scion-frontiers/scion-repo-contrib/harness-qa@main",
+		},
+		{
+			name:  "github tree with sha ref",
+			input: "https://github.com/org/repo/tree/a1b2c3d/skills/my-skill",
+			want:  "gh://org/repo/my-skill@a1b2c3d",
+		},
+		{
+			name:  "github tree with token param",
+			input: "https://github.com/org/repo/tree/main/skills/my-skill?token=SKILLS_TOKEN",
+			want:  "gh://org/repo/my-skill@main?token=SKILLS_TOKEN",
+		},
+		{
+			name:  "github tree http scheme normalized to https",
+			input: "http://github.com/org/repo/tree/main/skills/my-skill",
+			want:  "gh://org/repo/my-skill@main",
+		},
+
+		// ── GitHub tree URL, non-standard path → full URL kept ───────────────
+		{
+			name:  "github tree non-skills prefix kept as full url",
+			input: "https://github.com/org/repo/tree/main/contrib/deep/my-skill",
+			want:  "https://github.com/org/repo/tree/main/contrib/deep/my-skill",
+		},
+		{
+			name:  "github tree single-segment non-skills path kept",
+			input: "https://github.com/org/repo/tree/main/my-skill",
+			want:  "https://github.com/org/repo/tree/main/my-skill",
+		},
+
+		// ── GitHub blob URL → strip filename → apply tree rules ─────────────
+		{
+			name:  "github blob skills SKILL.md",
+			input: "https://github.com/org/repo/blob/main/skills/my-skill/SKILL.md",
+			want:  "gh://org/repo/my-skill@main",
+		},
+		{
+			name:  "github blob skills README.md",
+			input: "https://github.com/org/repo/blob/main/skills/my-skill/README.md",
+			want:  "gh://org/repo/my-skill@main",
+		},
+		{
+			name:  "github blob skills Makefile (no extension — still strips)",
+			input: "https://github.com/org/repo/blob/main/skills/my-skill/Makefile",
+			want:  "gh://org/repo/my-skill@main",
+		},
+		{
+			name:  "github blob non-standard path kept as tree url",
+			input: "https://github.com/org/repo/blob/main/contrib/my-skill/SKILL.md",
+			want:  "https://github.com/org/repo/tree/main/contrib/my-skill",
+		},
+		{
+			name:    "github blob root-level file (no parent dir)",
+			input:   "https://github.com/org/repo/blob/main/SKILL.md",
+			wantErr: "cannot determine skill directory",
+		},
+
+		// ── GitHub URL error cases ───────────────────────────────────────────
+		{
+			name:    "github bare repo URL",
+			input:   "https://github.com/org/repo",
+			wantErr: "expected https://github.com/owner/repo/tree/ref/path",
+		},
+		{
+			name:    "github repo with ref but no skill path",
+			input:   "https://github.com/org/repo/tree/main",
+			wantErr: "missing skill path",
+		},
+		{
+			name:    "github unsupported path segment",
+			input:   "https://github.com/org/repo/issues/123",
+			wantErr: "expected /tree/ or /blob/",
+		},
+		{
+			name:    "github pull request URL",
+			input:   "https://github.com/org/repo/pull/42",
+			wantErr: "expected /tree/ or /blob/",
+		},
+		{
+			name:    "github dotdot path traversal",
+			input:   "https://github.com/org/repo/tree/main/skills/../secret",
+			wantErr: "must not contain '..'",
+		},
+
+		// ── scion:// rejected ────────────────────────────────────────────────
+		{
+			name:    "scion scheme rejected",
+			input:   "scion://my-skill",
+			wantErr: "scion:// is not a supported scheme",
+		},
+		{
+			name:    "scion scheme with path rejected",
+			input:   "scion://core/my-skill",
+			wantErr: "scion:// is not a supported scheme",
+		},
+
+		// ── skill:// passthrough ─────────────────────────────────────────────
+		{
+			name:  "skill with registry and scope",
+			input: "skill://scion/core/my-skill",
+			want:  "skill://scion/core/my-skill",
+		},
+		{
+			name:  "skill alias form",
+			input: "skill://project/my-skill",
+			want:  "skill://project/my-skill",
+		},
+		{
+			name:    "skill:// with only one segment treated as registry missing name",
+			input:   "skill://my-skill",
+			wantErr: "missing skill name",
+		},
+
+		// ── bare name passthrough ────────────────────────────────────────────
+		{
+			name:  "bare skill name",
+			input: "my-skill",
+			want:  "my-skill",
+		},
+		{
+			name:  "bare skill name with digits",
+			input: "security-audit-v2",
+			want:  "security-audit-v2",
+		},
+		{
+			name:    "bare name with uppercase rejected",
+			input:   "MySkill",
+			wantErr: "kebab-case",
+		},
+
+		// ── unknown schemes ──────────────────────────────────────────────────
+		{
+			name:    "gcp-skill scheme rejected",
+			input:   "gcp-skill://something",
+			wantErr: "unsupported scheme",
+		},
+		{
+			name:    "ftp scheme rejected",
+			input:   "ftp://example.com/something",
+			wantErr: "unsupported scheme",
+		},
+
+		// ── whitespace trimming ──────────────────────────────────────────────
+		{
+			name:  "leading/trailing whitespace trimmed",
+			input: "  gh://org/repo/skill@main  ",
+			want:  "gh://org/repo/skill@main",
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: "must not be empty",
+		},
+		{
+			name:    "whitespace only",
+			input:   "   ",
+			wantErr: "must not be empty",
+		},
+
+		// ── idempotency ──────────────────────────────────────────────────────
+		{
+			name:  "canonical gh:// is idempotent",
+			input: "gh://org/repo/skill@main",
+			want:  "gh://org/repo/skill@main",
+		},
+		{
+			name:  "canonical skill:// is idempotent",
+			input: "skill://scion/core/my-skill",
+			want:  "skill://scion/core/my-skill",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeSkillURI(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("NormalizeSkillURI(%q) = %q, want error containing %q", tt.input, got, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("NormalizeSkillURI(%q) error = %q, want it to contain %q", tt.input, err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeSkillURI(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("NormalizeSkillURI(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+
+			// Idempotency check: normalizing the output again must produce the same result.
+			got2, err2 := NormalizeSkillURI(got)
+			if err2 != nil {
+				t.Errorf("NormalizeSkillURI(output=%q) round-trip error: %v", got, err2)
+			} else if got2 != got {
+				t.Errorf("NormalizeSkillURI is not idempotent: NormalizeSkillURI(%q) = %q, then NormalizeSkillURI(%q) = %q", tt.input, got, got, got2)
+			}
+		})
+	}
+}

--- a/pkg/hub/handlers_skills_injection.go
+++ b/pkg/hub/handlers_skills_injection.go
@@ -143,6 +143,12 @@ func (s *Server) addProjectInjectedSkill(w http.ResponseWriter, r *http.Request,
 		ValidationError(w, "skillUri is required", nil)
 		return
 	}
+	normalizedURI, err := api.NormalizeSkillURI(entry.SkillURI)
+	if err != nil {
+		ValidationError(w, err.Error(), nil)
+		return
+	}
+	entry.SkillURI = normalizedURI
 
 	var createdBy string
 	if userIdent, ok := identity.(UserIdentity); ok {
@@ -237,7 +243,7 @@ func (s *Server) setProjectInjectedSkills(w http.ResponseWriter, r *http.Request
 		createdBy = userIdent.ID()
 	}
 
-	// Validate all entries before committing any changes (N-2).
+	// Validate and normalize all entries before committing any changes (N-2).
 	seenURIs := make(map[string]bool)
 	for i, entry := range req.Entries {
 		uri := strings.TrimSpace(entry.SkillURI)
@@ -245,12 +251,18 @@ func (s *Server) setProjectInjectedSkills(w http.ResponseWriter, r *http.Request
 			BadRequest(w, fmt.Sprintf("entry %d: skillUri is required", i))
 			return
 		}
-		if seenURIs[uri] {
-			writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest,
-				fmt.Sprintf("duplicate skillUri in request: %s", uri), nil)
+		normalized, normErr := api.NormalizeSkillURI(uri)
+		if normErr != nil {
+			ValidationError(w, fmt.Sprintf("entry %d: %s", i, normErr.Error()), nil)
 			return
 		}
-		seenURIs[uri] = true
+		req.Entries[i].SkillURI = normalized
+		if seenURIs[normalized] {
+			writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest,
+				fmt.Sprintf("duplicate skillUri in request: %s", normalized), nil)
+			return
+		}
+		seenURIs[normalized] = true
 	}
 
 	// Build set of explicitly-assigned sort orders (C4: collision-free defaults).
@@ -275,7 +287,7 @@ func (s *Server) setProjectInjectedSkills(w http.ResponseWriter, r *http.Request
 		injections = append(injections, store.SkillInjection{
 			Scope:     store.SkillInjectionScopeProject,
 			ScopeID:   projectID,
-			SkillURI:  strings.TrimSpace(e.SkillURI),
+			SkillURI:  e.SkillURI,
 			SkillAs:   e.SkillAs,
 			Optional:  e.Optional,
 			SortOrder: so,
@@ -433,6 +445,12 @@ func (s *Server) addUserInjectedSkill(w http.ResponseWriter, r *http.Request) {
 		ValidationError(w, "skillUri is required", nil)
 		return
 	}
+	normalizedURI, err := api.NormalizeSkillURI(entry.SkillURI)
+	if err != nil {
+		ValidationError(w, err.Error(), nil)
+		return
+	}
+	entry.SkillURI = normalizedURI
 
 	// Determine sort order: use the client-supplied value if non-zero, otherwise
 	// append at the end (max existing sortOrder + 1).
@@ -494,7 +512,7 @@ func (s *Server) setUserInjectedSkills(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate all entries before committing any changes (N-2).
+	// Validate and normalize all entries before committing any changes (N-2).
 	seenURIs := make(map[string]bool)
 	for i, entry := range req.Entries {
 		uri := strings.TrimSpace(entry.SkillURI)
@@ -502,12 +520,18 @@ func (s *Server) setUserInjectedSkills(w http.ResponseWriter, r *http.Request) {
 			BadRequest(w, fmt.Sprintf("entry %d: skillUri is required", i))
 			return
 		}
-		if seenURIs[uri] {
-			writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest,
-				fmt.Sprintf("duplicate skillUri in request: %s", uri), nil)
+		normalized, normErr := api.NormalizeSkillURI(uri)
+		if normErr != nil {
+			ValidationError(w, fmt.Sprintf("entry %d: %s", i, normErr.Error()), nil)
 			return
 		}
-		seenURIs[uri] = true
+		req.Entries[i].SkillURI = normalized
+		if seenURIs[normalized] {
+			writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest,
+				fmt.Sprintf("duplicate skillUri in request: %s", normalized), nil)
+			return
+		}
+		seenURIs[normalized] = true
 	}
 
 	// Build set of explicitly-assigned sort orders (C4: collision-free defaults).
@@ -532,7 +556,7 @@ func (s *Server) setUserInjectedSkills(w http.ResponseWriter, r *http.Request) {
 		injections = append(injections, store.SkillInjection{
 			Scope:     store.SkillInjectionScopeUser,
 			ScopeID:   userIdent.ID(),
-			SkillURI:  strings.TrimSpace(e.SkillURI),
+			SkillURI:  e.SkillURI,
 			SkillAs:   e.SkillAs,
 			Optional:  e.Optional,
 			SortOrder: so,

--- a/pkg/hub/handlers_skills_injection_test.go
+++ b/pkg/hub/handlers_skills_injection_test.go
@@ -109,7 +109,7 @@ func TestListProjectInjectedSkills_ReturnsEntries(t *testing.T) {
 	si := &store.SkillInjection{
 		Scope:    store.SkillInjectionScopeProject,
 		ScopeID:  project.ID,
-		SkillURI: "scion://test-skill@1.0",
+		SkillURI: "skill://scion/test-skill@1.0",
 	}
 	require.NoError(t, s.AddSkillInjection(ctx, si))
 
@@ -120,7 +120,7 @@ func TestListProjectInjectedSkills_ReturnsEntries(t *testing.T) {
 	var resp api.SkillInjectionList
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.Len(t, resp.Entries, 1)
-	assert.Equal(t, "scion://test-skill@1.0", resp.Entries[0].SkillURI)
+	assert.Equal(t, "skill://scion/test-skill@1.0", resp.Entries[0].SkillURI)
 	assert.NotEmpty(t, resp.Entries[0].ID)
 }
 
@@ -143,7 +143,7 @@ func TestListProjectInjectedSkills_IsolatedBetweenProjects(t *testing.T) {
 	si2 := &store.SkillInjection{
 		Scope:    store.SkillInjectionScopeProject,
 		ScopeID:  project2.ID,
-		SkillURI: "scion://beta-skill@1.0",
+		SkillURI: "skill://scion/beta-skill@1.0",
 	}
 	require.NoError(t, s.AddSkillInjection(ctx, si2))
 
@@ -165,7 +165,7 @@ func TestAddProjectInjectedSkill_Success(t *testing.T) {
 	srv, s, project, alice, _ := setupInjectedSkillsTest(t)
 	ctx := context.Background()
 
-	body := api.SkillInjectionEntry{SkillURI: "scion://my-skill@2.0", Optional: true}
+	body := api.SkillInjectionEntry{SkillURI: "skill://scion/my-skill@2.0", Optional: true}
 	rec := doRequestAsUser(t, srv, alice, http.MethodPost,
 		"/api/v1/projects/"+project.ID+"/injected-skills", body)
 	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
@@ -173,14 +173,14 @@ func TestAddProjectInjectedSkill_Success(t *testing.T) {
 	var entry api.SkillInjectionEntry
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&entry))
 	assert.NotEmpty(t, entry.ID)
-	assert.Equal(t, "scion://my-skill@2.0", entry.SkillURI)
+	assert.Equal(t, "skill://scion/my-skill@2.0", entry.SkillURI)
 	assert.True(t, entry.Optional)
 
 	// Verify in store.
 	sis, err := s.ListSkillInjections(ctx, store.SkillInjectionScopeProject, project.ID)
 	require.NoError(t, err)
 	assert.Len(t, sis, 1)
-	assert.Equal(t, "scion://my-skill@2.0", sis[0].SkillURI)
+	assert.Equal(t, "skill://scion/my-skill@2.0", sis[0].SkillURI)
 }
 
 func TestAddProjectInjectedSkill_MissingSkillURI(t *testing.T) {
@@ -212,7 +212,7 @@ func TestAddProjectInjectedSkill_WhitespaceSkillURIRejected(t *testing.T) {
 func TestAddProjectInjectedSkill_DuplicateReturnsConflict(t *testing.T) {
 	srv, _, project, alice, _ := setupInjectedSkillsTest(t)
 
-	body := api.SkillInjectionEntry{SkillURI: "scion://dup-skill@1.0"}
+	body := api.SkillInjectionEntry{SkillURI: "skill://scion/dup-skill@1.0"}
 	rec := doRequestAsUser(t, srv, alice, http.MethodPost,
 		"/api/v1/projects/"+project.ID+"/injected-skills", body)
 	require.Equal(t, http.StatusCreated, rec.Code)
@@ -234,15 +234,15 @@ func TestSetProjectInjectedSkills_ReplacesListAtomically(t *testing.T) {
 	si := &store.SkillInjection{
 		Scope:    store.SkillInjectionScopeProject,
 		ScopeID:  project.ID,
-		SkillURI: "scion://old-skill@1.0",
+		SkillURI: "skill://scion/old-skill@1.0",
 	}
 	require.NoError(t, s.AddSkillInjection(ctx, si))
 
 	// Replace with two new entries.
 	newList := api.SkillInjectionList{
 		Entries: []api.SkillInjectionEntry{
-			{SkillURI: "scion://new-skill-a@1.0"},
-			{SkillURI: "scion://new-skill-b@2.0", Optional: true},
+			{SkillURI: "skill://scion/new-skill-a@1.0"},
+			{SkillURI: "skill://scion/new-skill-b@2.0", Optional: true},
 		},
 	}
 	rec := doRequestAsUser(t, srv, alice, http.MethodPut,
@@ -258,8 +258,8 @@ func TestSetProjectInjectedSkills_ReplacesListAtomically(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, sis, 2)
 	uris := []string{sis[0].SkillURI, sis[1].SkillURI}
-	assert.Contains(t, uris, "scion://new-skill-a@1.0")
-	assert.Contains(t, uris, "scion://new-skill-b@2.0")
+	assert.Contains(t, uris, "skill://scion/new-skill-a@1.0")
+	assert.Contains(t, uris, "skill://scion/new-skill-b@2.0")
 }
 
 // TestSetProjectInjectedSkills_SortOrderPreserved verifies M-2:
@@ -270,9 +270,9 @@ func TestSetProjectInjectedSkills_SortOrderPreserved(t *testing.T) {
 
 	newList := api.SkillInjectionList{
 		Entries: []api.SkillInjectionEntry{
-			{SkillURI: "scion://skill-c@1.0", SortOrder: 30},
-			{SkillURI: "scion://skill-a@1.0", SortOrder: 10},
-			{SkillURI: "scion://skill-b@1.0", SortOrder: 20},
+			{SkillURI: "skill://scion/skill-c@1.0", SortOrder: 30},
+			{SkillURI: "skill://scion/skill-a@1.0", SortOrder: 10},
+			{SkillURI: "skill://scion/skill-b@1.0", SortOrder: 20},
 		},
 	}
 	rec := doRequestAsUser(t, srv, alice, http.MethodPut,
@@ -285,11 +285,11 @@ func TestSetProjectInjectedSkills_SortOrderPreserved(t *testing.T) {
 	require.Len(t, sis, 3)
 	// Store returns them sorted by sort_order, so expect 10, 20, 30.
 	assert.Equal(t, 10, sis[0].SortOrder)
-	assert.Equal(t, "scion://skill-a@1.0", sis[0].SkillURI)
+	assert.Equal(t, "skill://scion/skill-a@1.0", sis[0].SkillURI)
 	assert.Equal(t, 20, sis[1].SortOrder)
-	assert.Equal(t, "scion://skill-b@1.0", sis[1].SkillURI)
+	assert.Equal(t, "skill://scion/skill-b@1.0", sis[1].SkillURI)
 	assert.Equal(t, 30, sis[2].SortOrder)
-	assert.Equal(t, "scion://skill-c@1.0", sis[2].SkillURI)
+	assert.Equal(t, "skill://scion/skill-c@1.0", sis[2].SkillURI)
 }
 
 // TestSetProjectInjectedSkills_MixedSortOrder verifies N-1:
@@ -304,9 +304,9 @@ func TestSetProjectInjectedSkills_MixedSortOrder(t *testing.T) {
 	// Entry 2: no explicit SortOrder → gets default i+1 = 3
 	newList := api.SkillInjectionList{
 		Entries: []api.SkillInjectionEntry{
-			{SkillURI: "scion://skill-auto-0@1.0"},                    // default → 1
-			{SkillURI: "scion://skill-explicit-1@1.0", SortOrder: 10}, // explicit 10
-			{SkillURI: "scion://skill-auto-2@1.0"},                    // default → 3
+			{SkillURI: "skill://scion/skill-auto-0@1.0"},                    // default → 1
+			{SkillURI: "skill://scion/skill-explicit-1@1.0", SortOrder: 10}, // explicit 10
+			{SkillURI: "skill://scion/skill-auto-2@1.0"},                    // default → 3
 		},
 	}
 	rec := doRequestAsUser(t, srv, alice, http.MethodPut,
@@ -328,7 +328,7 @@ func TestSetProjectInjectedSkills_MixedSortOrder(t *testing.T) {
 
 	// The explicit entry must preserve its value.
 	for _, si := range sis {
-		if si.SkillURI == "scion://skill-explicit-1@1.0" {
+		if si.SkillURI == "skill://scion/skill-explicit-1@1.0" {
 			assert.Equal(t, 10, si.SortOrder, "explicit SortOrder must be stored as-is")
 		}
 	}
@@ -345,8 +345,8 @@ func TestSetProjectInjectedSkills_ExplicitSortOrder1CollisionFree(t *testing.T) 
 	// Entry 1: explicit sortOrder = 1.
 	newList := api.SkillInjectionList{
 		Entries: []api.SkillInjectionEntry{
-			{SkillURI: "scion://proj-auto@1.0"},                     // default, must NOT get 1
-			{SkillURI: "scion://proj-explicit-1@1.0", SortOrder: 1}, // explicit 1
+			{SkillURI: "skill://scion/proj-auto@1.0"},                     // default, must NOT get 1
+			{SkillURI: "skill://scion/proj-explicit-1@1.0", SortOrder: 1}, // explicit 1
 		},
 	}
 	rec := doRequestAsUser(t, srv, alice, http.MethodPut,
@@ -368,7 +368,7 @@ func TestSetProjectInjectedSkills_ExplicitSortOrder1CollisionFree(t *testing.T) 
 
 	// The explicit entry must preserve its value.
 	for _, si := range sis {
-		if si.SkillURI == "scion://proj-explicit-1@1.0" {
+		if si.SkillURI == "skill://scion/proj-explicit-1@1.0" {
 			assert.Equal(t, 1, si.SortOrder, "explicit sortOrder=1 must be preserved")
 		}
 	}
@@ -382,7 +382,7 @@ func TestSetProjectInjectedSkills_EmptySkillURIRejected(t *testing.T) {
 
 	badList := api.SkillInjectionList{
 		Entries: []api.SkillInjectionEntry{
-			{SkillURI: "scion://valid-skill@1.0"},
+			{SkillURI: "skill://scion/valid-skill@1.0"},
 			{SkillURI: ""},
 		},
 	}
@@ -403,7 +403,7 @@ func TestSetProjectInjectedSkills_EmptyListClearsAll(t *testing.T) {
 	si := &store.SkillInjection{
 		Scope:    store.SkillInjectionScopeProject,
 		ScopeID:  project.ID,
-		SkillURI: "scion://to-be-cleared@1.0",
+		SkillURI: "skill://scion/to-be-cleared@1.0",
 	}
 	require.NoError(t, s.AddSkillInjection(ctx, si))
 
@@ -425,7 +425,7 @@ func TestSetProjectInjectedSkills_NormalizesSkillURI(t *testing.T) {
 
 	newList := api.SkillInjectionList{
 		Entries: []api.SkillInjectionEntry{
-			{SkillURI: "  scion://proj-trimmed-skill@1.0  "},
+			{SkillURI: "  skill://scion/proj-trimmed-skill@1.0  "},
 		},
 	}
 	rec := doRequestAsUser(t, srv, alice, http.MethodPut,
@@ -436,15 +436,64 @@ func TestSetProjectInjectedSkills_NormalizesSkillURI(t *testing.T) {
 	var resp api.SkillInjectionList
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	require.Len(t, resp.Entries, 1)
-	assert.Equal(t, "scion://proj-trimmed-skill@1.0", resp.Entries[0].SkillURI,
+	assert.Equal(t, "skill://scion/proj-trimmed-skill@1.0", resp.Entries[0].SkillURI,
 		"response URI must be trimmed")
 
 	// The stored value must also be trimmed.
 	sis, err := s.ListSkillInjections(ctx, store.SkillInjectionScopeProject, project.ID)
 	require.NoError(t, err)
 	require.Len(t, sis, 1)
-	assert.Equal(t, "scion://proj-trimmed-skill@1.0", sis[0].SkillURI,
+	assert.Equal(t, "skill://scion/proj-trimmed-skill@1.0", sis[0].SkillURI,
 		"stored URI must not have surrounding whitespace")
+}
+
+// TestAddProjectInjectedSkill_NormalizesGitHubURL verifies that posting a full
+// GitHub tree URL auto-transforms it to the canonical gh:// form.
+func TestAddProjectInjectedSkill_NormalizesGitHubURL(t *testing.T) {
+	srv, s, project, alice, _ := setupInjectedSkillsTest(t)
+	ctx := context.Background()
+
+	body := api.SkillInjectionEntry{
+		SkillURI: "https://github.com/org/repo/tree/main/skills/my-skill",
+	}
+	rec := doRequestAsUser(t, srv, alice, http.MethodPost,
+		"/api/v1/projects/"+project.ID+"/injected-skills", body)
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var entry api.SkillInjectionEntry
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&entry))
+	assert.Equal(t, "gh://org/repo/my-skill@main", entry.SkillURI,
+		"GitHub tree URL should be transformed to canonical gh:// form")
+
+	sis, err := s.ListSkillInjections(ctx, store.SkillInjectionScopeProject, project.ID)
+	require.NoError(t, err)
+	require.Len(t, sis, 1)
+	assert.Equal(t, "gh://org/repo/my-skill@main", sis[0].SkillURI,
+		"stored URI must be the canonical gh:// form")
+}
+
+// TestAddProjectInjectedSkill_RejectsInvalidScheme verifies that unsupported
+// schemes return a 400 with a specific error.
+func TestAddProjectInjectedSkill_RejectsInvalidScheme(t *testing.T) {
+	srv, _, project, alice, _ := setupInjectedSkillsTest(t)
+
+	tests := []struct {
+		name string
+		uri  string
+	}{
+		{"scion scheme", "scion://my-skill"},
+		{"ftp scheme", "ftp://example.com/skill"},
+		{"bare repo github URL", "https://github.com/org/repo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := api.SkillInjectionEntry{SkillURI: tt.uri}
+			rec := doRequestAsUser(t, srv, alice, http.MethodPost,
+				"/api/v1/projects/"+project.ID+"/injected-skills", body)
+			assert.Equal(t, http.StatusBadRequest, rec.Code,
+				"invalid URI %q should return 400, body: %s", tt.uri, rec.Body.String())
+		})
+	}
 }
 
 // =============================================================================
@@ -458,7 +507,7 @@ func TestRemoveProjectInjectedSkill_Success(t *testing.T) {
 	si := &store.SkillInjection{
 		Scope:    store.SkillInjectionScopeProject,
 		ScopeID:  project.ID,
-		SkillURI: "scion://removable-skill@1.0",
+		SkillURI: "skill://scion/removable-skill@1.0",
 	}
 	require.NoError(t, s.AddSkillInjection(ctx, si))
 
@@ -500,7 +549,7 @@ func TestRemoveProjectInjectedSkill_CrossProjectIDORRejected(t *testing.T) {
 	siB := &store.SkillInjection{
 		Scope:    store.SkillInjectionScopeProject,
 		ScopeID:  projectB.ID,
-		SkillURI: "scion://project-b-skill@1.0",
+		SkillURI: "skill://scion/project-b-skill@1.0",
 	}
 	require.NoError(t, s.AddSkillInjection(ctx, siB))
 
@@ -526,7 +575,7 @@ func TestRemoveProjectInjectedSkill_TrailingSlash(t *testing.T) {
 	si := &store.SkillInjection{
 		Scope:    store.SkillInjectionScopeProject,
 		ScopeID:  project.ID,
-		SkillURI: "scion://trailing-slash-skill@1.0",
+		SkillURI: "skill://scion/trailing-slash-skill@1.0",
 	}
 	require.NoError(t, s.AddSkillInjection(ctx, si))
 
@@ -558,7 +607,7 @@ func TestProjectInjectedSkills_ForbiddenForNonMember(t *testing.T) {
 	srv, _, project, _, bob := setupInjectedSkillsTest(t)
 
 	// Bob is not a member of the project, so POST should be forbidden.
-	body := api.SkillInjectionEntry{SkillURI: "scion://forbidden@1.0"}
+	body := api.SkillInjectionEntry{SkillURI: "skill://scion/forbidden@1.0"}
 	rec := doRequestAsUser(t, srv, bob, http.MethodPost,
 		"/api/v1/projects/"+project.ID+"/injected-skills", body)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
@@ -629,7 +678,7 @@ func TestListUserInjectedSkills_ReturnsOwnEntries(t *testing.T) {
 	si := &store.SkillInjection{
 		Scope:    store.SkillInjectionScopeUser,
 		ScopeID:  alice.ID,
-		SkillURI: "scion://alice-skill@1.0",
+		SkillURI: "skill://scion/alice-skill@1.0",
 	}
 	require.NoError(t, s.AddSkillInjection(ctx, si))
 
@@ -640,7 +689,7 @@ func TestListUserInjectedSkills_ReturnsOwnEntries(t *testing.T) {
 	var resp api.SkillInjectionList
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.Len(t, resp.Entries, 1)
-	assert.Equal(t, "scion://alice-skill@1.0", resp.Entries[0].SkillURI)
+	assert.Equal(t, "skill://scion/alice-skill@1.0", resp.Entries[0].SkillURI)
 }
 
 func TestListUserInjectedSkills_IsolatedBetweenUsers(t *testing.T) {
@@ -651,7 +700,7 @@ func TestListUserInjectedSkills_IsolatedBetweenUsers(t *testing.T) {
 	siBob := &store.SkillInjection{
 		Scope:    store.SkillInjectionScopeUser,
 		ScopeID:  bob.ID,
-		SkillURI: "scion://bob-skill@1.0",
+		SkillURI: "skill://scion/bob-skill@1.0",
 	}
 	require.NoError(t, s.AddSkillInjection(ctx, siBob))
 
@@ -673,7 +722,7 @@ func TestAddUserInjectedSkill_Success(t *testing.T) {
 	srv, s, _, alice, _ := setupInjectedSkillsTest(t)
 	ctx := context.Background()
 
-	body := api.SkillInjectionEntry{SkillURI: "scion://my-user-skill@1.0", SkillAs: "alias"}
+	body := api.SkillInjectionEntry{SkillURI: "skill://scion/my-user-skill@1.0", SkillAs: "alias"}
 	rec := doRequestAsUser(t, srv, alice, http.MethodPost,
 		"/api/v1/users/me/injected-skills", body)
 	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
@@ -681,7 +730,7 @@ func TestAddUserInjectedSkill_Success(t *testing.T) {
 	var entry api.SkillInjectionEntry
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&entry))
 	assert.NotEmpty(t, entry.ID)
-	assert.Equal(t, "scion://my-user-skill@1.0", entry.SkillURI)
+	assert.Equal(t, "skill://scion/my-user-skill@1.0", entry.SkillURI)
 	assert.Equal(t, "alias", entry.SkillAs)
 
 	// Verify in store.
@@ -719,7 +768,7 @@ func TestAddUserInjectedSkill_WhitespaceSkillURIRejected(t *testing.T) {
 func TestAddUserInjectedSkill_DuplicateReturnsConflict(t *testing.T) {
 	srv, _, _, alice, _ := setupInjectedSkillsTest(t)
 
-	body := api.SkillInjectionEntry{SkillURI: "scion://dup-user-skill@1.0"}
+	body := api.SkillInjectionEntry{SkillURI: "skill://scion/dup-user-skill@1.0"}
 	rec := doRequestAsUser(t, srv, alice, http.MethodPost,
 		"/api/v1/users/me/injected-skills", body)
 	require.Equal(t, http.StatusCreated, rec.Code)
@@ -741,14 +790,14 @@ func TestSetUserInjectedSkills_ReplacesListAtomically(t *testing.T) {
 	si := &store.SkillInjection{
 		Scope:    store.SkillInjectionScopeUser,
 		ScopeID:  alice.ID,
-		SkillURI: "scion://old-user-skill@1.0",
+		SkillURI: "skill://scion/old-user-skill@1.0",
 	}
 	require.NoError(t, s.AddSkillInjection(ctx, si))
 
 	newList := api.SkillInjectionList{
 		Entries: []api.SkillInjectionEntry{
-			{SkillURI: "scion://new-user-skill-a@1.0"},
-			{SkillURI: "scion://new-user-skill-b@2.0"},
+			{SkillURI: "skill://scion/new-user-skill-a@1.0"},
+			{SkillURI: "skill://scion/new-user-skill-b@2.0"},
 		},
 	}
 	rec := doRequestAsUser(t, srv, alice, http.MethodPut,
@@ -773,9 +822,9 @@ func TestSetUserInjectedSkills_SortOrderPreserved(t *testing.T) {
 
 	newList := api.SkillInjectionList{
 		Entries: []api.SkillInjectionEntry{
-			{SkillURI: "scion://user-skill-c@1.0", SortOrder: 30},
-			{SkillURI: "scion://user-skill-a@1.0", SortOrder: 10},
-			{SkillURI: "scion://user-skill-b@1.0", SortOrder: 20},
+			{SkillURI: "skill://scion/user-skill-c@1.0", SortOrder: 30},
+			{SkillURI: "skill://scion/user-skill-a@1.0", SortOrder: 10},
+			{SkillURI: "skill://scion/user-skill-b@1.0", SortOrder: 20},
 		},
 	}
 	rec := doRequestAsUser(t, srv, alice, http.MethodPut,
@@ -788,11 +837,11 @@ func TestSetUserInjectedSkills_SortOrderPreserved(t *testing.T) {
 	require.Len(t, sis, 3)
 	// Store returns them sorted by sort_order, so expect 10, 20, 30.
 	assert.Equal(t, 10, sis[0].SortOrder)
-	assert.Equal(t, "scion://user-skill-a@1.0", sis[0].SkillURI)
+	assert.Equal(t, "skill://scion/user-skill-a@1.0", sis[0].SkillURI)
 	assert.Equal(t, 20, sis[1].SortOrder)
-	assert.Equal(t, "scion://user-skill-b@1.0", sis[1].SkillURI)
+	assert.Equal(t, "skill://scion/user-skill-b@1.0", sis[1].SkillURI)
 	assert.Equal(t, 30, sis[2].SortOrder)
-	assert.Equal(t, "scion://user-skill-c@1.0", sis[2].SkillURI)
+	assert.Equal(t, "skill://scion/user-skill-c@1.0", sis[2].SkillURI)
 }
 
 // TestSetUserInjectedSkills_MixedSortOrder verifies N-1 for user scope:
@@ -803,9 +852,9 @@ func TestSetUserInjectedSkills_MixedSortOrder(t *testing.T) {
 
 	newList := api.SkillInjectionList{
 		Entries: []api.SkillInjectionEntry{
-			{SkillURI: "scion://user-auto-0@1.0"},                     // default → 1
-			{SkillURI: "scion://user-explicit-10@1.0", SortOrder: 10}, // explicit 10
-			{SkillURI: "scion://user-auto-2@1.0"},                     // default → 3
+			{SkillURI: "skill://scion/user-auto-0@1.0"},                     // default → 1
+			{SkillURI: "skill://scion/user-explicit-10@1.0", SortOrder: 10}, // explicit 10
+			{SkillURI: "skill://scion/user-auto-2@1.0"},                     // default → 3
 		},
 	}
 	rec := doRequestAsUser(t, srv, alice, http.MethodPut,
@@ -827,7 +876,7 @@ func TestSetUserInjectedSkills_MixedSortOrder(t *testing.T) {
 
 	// Explicit entry must keep its value.
 	for _, si := range sis {
-		if si.SkillURI == "scion://user-explicit-10@1.0" {
+		if si.SkillURI == "skill://scion/user-explicit-10@1.0" {
 			assert.Equal(t, 10, si.SortOrder)
 		}
 	}
@@ -844,8 +893,8 @@ func TestSetUserInjectedSkills_ExplicitSortOrder1CollisionFree(t *testing.T) {
 	// Entry 1: explicit sortOrder = 1.
 	newList := api.SkillInjectionList{
 		Entries: []api.SkillInjectionEntry{
-			{SkillURI: "scion://user-auto@1.0"},                     // default, must NOT get 1
-			{SkillURI: "scion://user-explicit-1@1.0", SortOrder: 1}, // explicit 1
+			{SkillURI: "skill://scion/user-auto@1.0"},                     // default, must NOT get 1
+			{SkillURI: "skill://scion/user-explicit-1@1.0", SortOrder: 1}, // explicit 1
 		},
 	}
 	rec := doRequestAsUser(t, srv, alice, http.MethodPut,
@@ -867,7 +916,7 @@ func TestSetUserInjectedSkills_ExplicitSortOrder1CollisionFree(t *testing.T) {
 
 	// The explicit entry must preserve its value.
 	for _, si := range sis {
-		if si.SkillURI == "scion://user-explicit-1@1.0" {
+		if si.SkillURI == "skill://scion/user-explicit-1@1.0" {
 			assert.Equal(t, 1, si.SortOrder, "explicit sortOrder=1 must be preserved")
 		}
 	}
@@ -881,7 +930,7 @@ func TestSetUserInjectedSkills_EmptySkillURIRejected(t *testing.T) {
 
 	badList := api.SkillInjectionList{
 		Entries: []api.SkillInjectionEntry{
-			{SkillURI: "scion://valid-user-skill@1.0"},
+			{SkillURI: "skill://scion/valid-user-skill@1.0"},
 			{SkillURI: ""},
 		},
 	}
@@ -903,7 +952,7 @@ func TestSetUserInjectedSkills_NormalizesSkillURI(t *testing.T) {
 
 	newList := api.SkillInjectionList{
 		Entries: []api.SkillInjectionEntry{
-			{SkillURI: "  scion://user-trimmed-skill@1.0  "},
+			{SkillURI: "  skill://scion/user-trimmed-skill@1.0  "},
 		},
 	}
 	rec := doRequestAsUser(t, srv, alice, http.MethodPut,
@@ -914,14 +963,14 @@ func TestSetUserInjectedSkills_NormalizesSkillURI(t *testing.T) {
 	var resp api.SkillInjectionList
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	require.Len(t, resp.Entries, 1)
-	assert.Equal(t, "scion://user-trimmed-skill@1.0", resp.Entries[0].SkillURI,
+	assert.Equal(t, "skill://scion/user-trimmed-skill@1.0", resp.Entries[0].SkillURI,
 		"response URI must be trimmed")
 
 	// The stored value must also be trimmed.
 	sis, err := s.ListSkillInjections(ctx, store.SkillInjectionScopeUser, alice.ID)
 	require.NoError(t, err)
 	require.Len(t, sis, 1)
-	assert.Equal(t, "scion://user-trimmed-skill@1.0", sis[0].SkillURI,
+	assert.Equal(t, "skill://scion/user-trimmed-skill@1.0", sis[0].SkillURI,
 		"stored URI must not have surrounding whitespace")
 }
 
@@ -936,7 +985,7 @@ func TestRemoveUserInjectedSkill_Success(t *testing.T) {
 	si := &store.SkillInjection{
 		Scope:    store.SkillInjectionScopeUser,
 		ScopeID:  alice.ID,
-		SkillURI: "scion://removable-user-skill@1.0",
+		SkillURI: "skill://scion/removable-user-skill@1.0",
 	}
 	require.NoError(t, s.AddSkillInjection(ctx, si))
 
@@ -967,7 +1016,7 @@ func TestRemoveUserInjectedSkill_CrossUserIDORRejected(t *testing.T) {
 	siBob := &store.SkillInjection{
 		Scope:    store.SkillInjectionScopeUser,
 		ScopeID:  bob.ID,
-		SkillURI: "scion://bob-private-skill@1.0",
+		SkillURI: "skill://scion/bob-private-skill@1.0",
 	}
 	require.NoError(t, s.AddSkillInjection(ctx, siBob))
 
@@ -1044,8 +1093,8 @@ func TestGetHubInjectedSkills_ReturnsStoredSetting(t *testing.T) {
 
 	// Pre-seed via store.
 	setting := api.HubSkillInjectionSetting{
-		System:      []api.SkillReference{{URI: "scion://platform-skill@1.0"}},
-		UserDefined: []api.SkillReference{{URI: "scion://admin-skill@1.0"}},
+		System:      []api.SkillReference{{URI: "skill://scion/platform-skill@1.0"}},
+		UserDefined: []api.SkillReference{{URI: "skill://scion/admin-skill@1.0"}},
 	}
 	raw, err := json.Marshal(setting)
 	require.NoError(t, err)
@@ -1059,9 +1108,9 @@ func TestGetHubInjectedSkills_ReturnsStoredSetting(t *testing.T) {
 	var resp api.HubSkillInjectionSetting
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.Len(t, resp.System, 1)
-	assert.Equal(t, "scion://platform-skill@1.0", resp.System[0].URI)
+	assert.Equal(t, "skill://scion/platform-skill@1.0", resp.System[0].URI)
 	assert.Len(t, resp.UserDefined, 1)
-	assert.Equal(t, "scion://admin-skill@1.0", resp.UserDefined[0].URI)
+	assert.Equal(t, "skill://scion/admin-skill@1.0", resp.UserDefined[0].URI)
 }
 
 // =============================================================================
@@ -1075,7 +1124,7 @@ func TestSetHubInjectedSkills_AdminCanUpdate(t *testing.T) {
 	// Dev user is admin. Use doRequest which uses the dev token.
 	body := map[string]interface{}{
 		"user_defined": []map[string]interface{}{
-			{"uri": "scion://hub-custom-skill@1.0"},
+			{"uri": "skill://scion/hub-custom-skill@1.0"},
 		},
 	}
 	rec := doRequest(t, srv, http.MethodPut,
@@ -1085,7 +1134,7 @@ func TestSetHubInjectedSkills_AdminCanUpdate(t *testing.T) {
 	var resp api.HubSkillInjectionSetting
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.Len(t, resp.UserDefined, 1)
-	assert.Equal(t, "scion://hub-custom-skill@1.0", resp.UserDefined[0].URI)
+	assert.Equal(t, "skill://scion/hub-custom-skill@1.0", resp.UserDefined[0].URI)
 
 	// Verify in store.
 	hs, err := s.GetHubSetting(ctx, "injected_skills")
@@ -1101,7 +1150,7 @@ func TestSetHubInjectedSkills_PreservesSystemEntries(t *testing.T) {
 
 	// Pre-seed a system entry (simulating seeded platform skills).
 	initial := api.HubSkillInjectionSetting{
-		System:      []api.SkillReference{{URI: "scion://system-skill@1.0"}},
+		System:      []api.SkillReference{{URI: "skill://scion/system-skill@1.0"}},
 		UserDefined: []api.SkillReference{},
 	}
 	raw, err := json.Marshal(initial)
@@ -1112,7 +1161,7 @@ func TestSetHubInjectedSkills_PreservesSystemEntries(t *testing.T) {
 	// Admin updates user_defined only.
 	body := map[string]interface{}{
 		"user_defined": []map[string]interface{}{
-			{"uri": "scion://admin-added-skill@1.0"},
+			{"uri": "skill://scion/admin-added-skill@1.0"},
 		},
 	}
 	rec := doRequest(t, srv, http.MethodPut,
@@ -1123,9 +1172,9 @@ func TestSetHubInjectedSkills_PreservesSystemEntries(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	// System entry must still be present.
 	assert.Len(t, resp.System, 1)
-	assert.Equal(t, "scion://system-skill@1.0", resp.System[0].URI)
+	assert.Equal(t, "skill://scion/system-skill@1.0", resp.System[0].URI)
 	assert.Len(t, resp.UserDefined, 1)
-	assert.Equal(t, "scion://admin-added-skill@1.0", resp.UserDefined[0].URI)
+	assert.Equal(t, "skill://scion/admin-added-skill@1.0", resp.UserDefined[0].URI)
 }
 
 func TestSetHubInjectedSkills_ForbiddenForNonAdmin(t *testing.T) {
@@ -1133,7 +1182,7 @@ func TestSetHubInjectedSkills_ForbiddenForNonAdmin(t *testing.T) {
 
 	body := map[string]interface{}{
 		"user_defined": []map[string]interface{}{
-			{"uri": "scion://unauthorized-skill@1.0"},
+			{"uri": "skill://scion/unauthorized-skill@1.0"},
 		},
 	}
 	rec := doRequestAsUser(t, srv, bob, http.MethodPut,
@@ -1210,7 +1259,7 @@ func TestSetHubInjectedSkills_CorruptBlobReturns500(t *testing.T) {
 
 	// First seed a valid row so the table row exists.
 	initial := api.HubSkillInjectionSetting{
-		System:      []api.SkillReference{{URI: "scion://system-skill@1.0"}},
+		System:      []api.SkillReference{{URI: "skill://scion/system-skill@1.0"}},
 		UserDefined: []api.SkillReference{},
 	}
 	validBlob, err := json.Marshal(initial)
@@ -1229,7 +1278,7 @@ func TestSetHubInjectedSkills_CorruptBlobReturns500(t *testing.T) {
 	// Admin (dev user) attempts a PUT — handler must detect the corrupt blob and return 500.
 	body := map[string]interface{}{
 		"user_defined": []map[string]interface{}{
-			{"uri": "scion://should-not-persist@1.0"},
+			{"uri": "skill://scion/should-not-persist@1.0"},
 		},
 	}
 	rec := doRequest(t, srv, http.MethodPut,

--- a/web/src/components/shared/injected-skills-panel.ts
+++ b/web/src/components/shared/injected-skills-panel.ts
@@ -89,7 +89,7 @@ function validateGHShorthand(uri: string): string {
   const atIdx = main.lastIndexOf('@');
   if (atIdx >= 0) {
     const ref = main.slice(atIdx + 1);
-    if (!ref) throw new Error('Invalid gh:// URI: empty ref after @');
+    if (!ref || ref === '.' || ref === '..') throw new Error('Invalid gh:// URI: invalid ref (must not be empty, ".", or "..")');
     main = main.slice(0, atIdx);
     refSuffix = '@' + ref;
   }

--- a/web/src/components/shared/injected-skills-panel.ts
+++ b/web/src/components/shared/injected-skills-panel.ts
@@ -37,6 +37,113 @@ import { resourceStyles } from './resource-styles.js';
 
 export type InjectedSkillsScope = 'project' | 'user' | 'hub';
 
+// ── Skill URI client-side normalization ──────────────────────────────────────
+// Mirrors NormalizeSkillURI in pkg/api/skill_uri_normalize.go.
+// The hub's Go implementation is authoritative; these functions provide
+// immediate client-side feedback for the most common cases.
+
+/** Result of client-side URI normalization. */
+interface NormalizeResult {
+  canonical: string;
+  /** True when canonical differs from the original input. */
+  transformed: boolean;
+}
+
+/**
+ * Normalizes a user-supplied skill URI to its canonical stored form.
+ * Throws an Error with an actionable message for unsupported inputs.
+ */
+function normalizeSkillURIClient(input: string): NormalizeResult {
+  const trimmed = input.trim();
+  if (!trimmed) throw new Error('Skill URI is required');
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith('gh://')) {
+    return { canonical: validateGHShorthand(trimmed), transformed: false };
+  }
+  if (lower.startsWith('https://github.com/') || lower.startsWith('http://github.com/')) {
+    const canonical = normalizeGitHubURL(trimmed);
+    return { canonical, transformed: canonical !== trimmed };
+  }
+  if (lower.startsWith('scion://')) {
+    throw new Error('scion:// is not a supported scheme; use skill:// for hub-bank skills');
+  }
+  // skill://, bare names, other schemes — pass through to the hub for validation.
+  return { canonical: trimmed, transformed: false };
+}
+
+function validateGHShorthand(uri: string): string {
+  let main = uri.slice('gh://'.length);
+  let tokenSuffix = '';
+  const qIdx = main.indexOf('?');
+  if (qIdx >= 0) {
+    const query = main.slice(qIdx + 1);
+    main = main.slice(0, qIdx);
+    if (!query.startsWith('token=')) throw new Error('Invalid gh:// URI: only ?token=SECRET_NAME is supported');
+    const tokenName = query.slice('token='.length);
+    if (!tokenName || !/^[A-Z][A-Z0-9_]*$/.test(tokenName)) {
+      throw new Error('Invalid gh:// URI: ?token= value must be an uppercase env-var name (e.g. SKILLS_TOKEN)');
+    }
+    tokenSuffix = '?' + query;
+  }
+  let refSuffix = '';
+  const atIdx = main.lastIndexOf('@');
+  if (atIdx >= 0) {
+    const ref = main.slice(atIdx + 1);
+    if (!ref) throw new Error('Invalid gh:// URI: empty ref after @');
+    main = main.slice(0, atIdx);
+    refSuffix = '@' + ref;
+  }
+  const parts = main.split('/');
+  if (parts.length !== 3 || parts.some((p) => !p)) {
+    throw new Error('Invalid gh:// URI: expected gh://owner/repo/skill-name[@ref][?token=SECRET_NAME]');
+  }
+  return 'gh://' + main + refSuffix + tokenSuffix;
+}
+
+function normalizeGitHubURL(uri: string): string {
+  let rest = uri;
+  for (const prefix of ['https://github.com/', 'http://github.com/']) {
+    if (rest.toLowerCase().startsWith(prefix)) {
+      rest = rest.slice(prefix.length);
+      break;
+    }
+  }
+  let tokenSuffix = '';
+  const qIdx = rest.indexOf('?');
+  if (qIdx >= 0) {
+    const query = rest.slice(qIdx + 1);
+    rest = rest.slice(0, qIdx);
+    if (!query.startsWith('token=')) throw new Error('Invalid GitHub URL: only ?token=SECRET_NAME is supported');
+    tokenSuffix = '?' + query;
+  }
+  const segments = rest.split('/');
+  const [owner, repo, keyword, ref, ...pathParts] = segments;
+  if (!owner || !repo || !keyword || !ref) {
+    throw new Error('Invalid GitHub URL: expected https://github.com/owner/repo/tree/ref/path/to/skill');
+  }
+  const kw = keyword.toLowerCase();
+  let fullPath: string;
+  if (kw === 'tree') {
+    fullPath = pathParts.join('/');
+    if (!fullPath) throw new Error('Invalid GitHub URL: missing skill path after ref; example: .../tree/main/skills/my-skill');
+  } else if (kw === 'blob') {
+    const filePath = pathParts.join('/');
+    if (!filePath) throw new Error('Invalid GitHub URL: missing file path after ref');
+    const lastSlash = filePath.lastIndexOf('/');
+    if (lastSlash < 0) throw new Error('Invalid GitHub URL: cannot determine skill directory from blob URL (no parent directory)');
+    fullPath = filePath.slice(0, lastSlash);
+    if (!fullPath) throw new Error('Invalid GitHub URL: cannot determine skill directory from blob URL');
+  } else {
+    throw new Error(`Invalid GitHub URL: expected /tree/ or /blob/ after owner/repo, got /${keyword}/`);
+  }
+  // Use gh:// shorthand for skills/skill-name paths (standard layout).
+  const pathSegs = fullPath.split('/');
+  if (pathSegs.length === 2 && pathSegs[0].toLowerCase() === 'skills' && pathSegs[1]) {
+    return `gh://${owner}/${repo}/${pathSegs[1]}@${ref}${tokenSuffix}`;
+  }
+  return `https://github.com/${owner}/${repo}/tree/${ref}/${fullPath}${tokenSuffix}`;
+}
+
 /** Normalized internal row — covers both SkillInjectionEntry and SkillReference shapes. */
 interface SkillRow {
   /** Entry ID — present for project/user scopes (from SkillInjectionEntry); empty for hub. */
@@ -84,6 +191,8 @@ export class ScionInjectedSkillsPanel extends LitElement {
   @state() private dialogOptional = false;
   @state() private dialogLoading = false;
   @state() private dialogError: string | null = null;
+  /** When a URI input is transformed to canonical form, holds the preview string. */
+  @state() private dialogTransformed: string | null = null;
 
   // Delete — tracked by index to avoid key collisions on hub rows (all have id='')
   @state() private _deletingIndex: number | null = null;
@@ -477,6 +586,7 @@ export class ScionInjectedSkillsPanel extends LitElement {
     this.dialogOptional = false;
     this.dialogLoading = false;
     this.dialogError = null;
+    this.dialogTransformed = null;
     this.dialogOpen = true;
   }
 
@@ -541,9 +651,17 @@ export class ScionInjectedSkillsPanel extends LitElement {
       // Build a skill bank URI from the skill's slug
       uri = `skill://${this.dialogSelectedSkill.slug}`;
     } else {
-      uri = this.dialogUri.trim();
-      if (!uri) {
+      const raw = this.dialogUri.trim();
+      if (!raw) {
         this.dialogError = 'Skill URI is required';
+        return;
+      }
+      // Normalize client-side before sending; the hub is authoritative for edge cases.
+      try {
+        const result = normalizeSkillURIClient(raw);
+        uri = result.canonical;
+      } catch (normErr) {
+        this.dialogError = normErr instanceof Error ? normErr.message : 'Invalid skill URI';
         return;
       }
     }
@@ -907,13 +1025,27 @@ export class ScionInjectedSkillsPanel extends LitElement {
             : html`
                 <sl-input
                   label="Skill URI"
-                  placeholder="e.g. skill://my-skill or gs://bucket/path/skill.yaml"
-                  help-text="Skill bank URI (skill://slug), GCS path, or GitHub URL."
+                  placeholder="e.g. skill://scion/core/my-skill or https://github.com/org/repo/tree/main/skills/my-skill"
+                  help-text="Hub-skill URI (skill://…), GitHub tree or blob URL (auto-transformed), or gh:// shorthand."
                   .value=${this.dialogUri}
                   @sl-input=${(e: Event) => {
-                    this.dialogUri = (e.target as HTMLInputElement).value;
+                    const val = (e.target as HTMLInputElement).value;
+                    this.dialogUri = val;
+                    // Live transform preview: attempt normalization on each keystroke.
+                    try {
+                      const result = normalizeSkillURIClient(val);
+                      this.dialogTransformed = result.transformed ? result.canonical : null;
+                    } catch {
+                      this.dialogTransformed = null;
+                    }
                   }}
                 ></sl-input>
+                ${this.dialogTransformed
+                  ? html`<div class="dialog-hint">
+                      <sl-icon name="arrow-right-circle"></sl-icon>
+                      Will be stored as: <strong>${this.dialogTransformed}</strong>
+                    </div>`
+                  : nothing}
               `}
 
           <sl-input

--- a/web/src/components/shared/injected-skills-panel.ts
+++ b/web/src/components/shared/injected-skills-panel.ts
@@ -94,7 +94,7 @@ function validateGHShorthand(uri: string): string {
     refSuffix = '@' + ref;
   }
   const parts = main.split('/');
-  if (parts.length !== 3 || parts.some((p) => !p)) {
+  if (parts.length !== 3 || parts.some((p) => !p || p === '.' || p === '..')) {
     throw new Error('Invalid gh:// URI: expected gh://owner/repo/skill-name[@ref][?token=SECRET_NAME]');
   }
   return 'gh://' + main + refSuffix + tokenSuffix;
@@ -114,11 +114,15 @@ function normalizeGitHubURL(uri: string): string {
     const query = rest.slice(qIdx + 1);
     rest = rest.slice(0, qIdx);
     if (!query.startsWith('token=')) throw new Error('Invalid GitHub URL: only ?token=SECRET_NAME is supported');
+    const tokenName = query.slice('token='.length);
+    if (!tokenName || !/^[A-Z][A-Z0-9_]*$/.test(tokenName)) {
+      throw new Error('Invalid GitHub URL: ?token= value must be an uppercase env-var name (e.g. SKILLS_TOKEN)');
+    }
     tokenSuffix = '?' + query;
   }
   const segments = rest.split('/');
   const [owner, repo, keyword, ref, ...pathParts] = segments;
-  if (!owner || !repo || !keyword || !ref) {
+  if (!owner || !repo || !keyword || !ref || owner === '.' || owner === '..' || repo === '.' || repo === '..' || ref === '.' || ref === '..') {
     throw new Error('Invalid GitHub URL: expected https://github.com/owner/repo/tree/ref/path/to/skill');
   }
   const kw = keyword.toLowerCase();


### PR DESCRIPTION
## Summary
Validates skill URI input and auto-transforms common pasted formats (e.g. GitHub tree/blob web URLs) into the internal gh:// scheme, with a rejection error for unsupported schemes like scion:// (correct scheme: skill://, fixed separately upstream in #863).

## Changes
- pkg/api/skill_uri_normalize.go: NormalizeSkillURI, 45 unit tests
- Enforced in all 4 project/user skill-injection POST/PUT hub endpoints (single + bulk)
- CLI (scion project/user skills add) normalizes before API call, prints transformation notice
- Web UI: TypeScript normalizer with live transform preview

Design doc: .design/project-skills-uri-transform.md. Reviewed and approved, all findings addressed.