### PR TITLE
fix(image): force fresh @anthropic-ai/claude-code install with @latest tag

### DIFF
--- a/harnesses/claude/Dockerfile
+++ b/harnesses/claude/Dockerfile
@@ -72,5 +72,6 @@ RUN chmod +x /usr/local/bin/init-firewall.sh && \
 # RUN curl -fsSL https://claude.ai/install.sh | bash
 # ENV PATH=/home/scion/.local/bin:$PATH
 
-RUN npm install -g @anthropic-ai/claude-code \
+RUN npm cache clean --force \
+  && npm install -g @anthropic-ai/claude-code@latest \
   && npm cache clean --force


### PR DESCRIPTION
## Problem

Cloud Build `428a5ded` (Jul 24 2026) installed `@anthropic-ai/claude-code@2.1.197` (published Jun 30) instead of the then-current `2.1.218+`.

`harnesses/claude/Dockerfile` ran:
```
RUN npm install -g @anthropic-ai/claude-code   && npm cache clean --force
```

Without `@latest`, npm resolves from the packument cache in `/root/.npm`, inherited from `core-base:latest`. That image was last rebuilt on **May 5, 2026** (80 days stale). The stale packument told npm that `2.1.197` was "latest", silently installing an outdated version.

## Fix

```diff
-RUN npm install -g @anthropic-ai/claude-code +RUN npm cache clean --force +  && npm install -g @anthropic-ai/claude-code@latest    && npm cache clean --force
```

1. **`@latest` dist-tag** — forces npm to fetch the current dist-tag from the registry
2. **Pre-install cache clear** — removes stale packument inherited from `core-base`
3. **Changed instruction text** — invalidates any stale BuildKit layer cache
