### PR TITLE
fix(hermes): remove nodesource apt repo after nodejs install to fix arm64 build

### DIFF
--- a/harnesses/hermes/Dockerfile
+++ b/harnesses/hermes/Dockerfile
@@ -18,9 +18,16 @@ FROM ${BASE_IMAGE}
 
 ARG HERMES_VERSION=
 
-# Install Node.js 22 LTS (required by Hermes for tool execution)
+# Install Node.js 22 LTS (required by Hermes for tool execution).
+# After installing, remove the nodesource apt-source entries so that
+# subsequent RUN layers' apt-get update does not re-fetch the nodesource
+# InRelease file, which causes a QEMU arm64 "Cannot allocate memory" crash.
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
   && apt-get install -y --no-install-recommends nodejs \
+  && rm -f /etc/apt/sources.list.d/nodesource.sources \
+           /etc/apt/preferences.d/nodejs \
+           /etc/apt/preferences.d/nsolid \
+           /usr/share/keyrings/nodesource.gpg \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install ripgrep (required by Hermes for code search)

--- a/harnesses/hermes/Dockerfile
+++ b/harnesses/hermes/Dockerfile
@@ -25,6 +25,7 @@ ARG HERMES_VERSION=
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
   && apt-get install -y --no-install-recommends nodejs \
   && rm -f /etc/apt/sources.list.d/nodesource.sources \
+           /etc/apt/sources.list.d/nodesource.list \
            /etc/apt/preferences.d/nodejs \
            /etc/apt/preferences.d/nsolid \
            /usr/share/keyrings/nodesource.gpg \


### PR DESCRIPTION
Root cause: The nodesource setup_22.x script adds apt repository entries that persist across Docker RUN layers. Subsequent apt-get update calls in later layers re-fetch the nodesource InRelease file. In the QEMU-emulated arm64 build environment used by docker buildx --platform linux/amd64,linux/arm64, reading this file triggers a getline (12: Cannot allocate memory) error (exit 100), causing the docker step to exit 1.

Fix: Remove all nodesource apt configuration files immediately after installing nodejs in the same RUN layer, preventing subsequent apt-get update calls from contacting nodesource.

Files removed:
- /etc/apt/sources.list.d/nodesource.sources  (primary apt source)
- /etc/apt/sources.list.d/nodesource.list      (legacy format, defense-in-depth)
- /etc/apt/preferences.d/nodejs
- /etc/apt/preferences.d/nsolid
- /usr/share/keyrings/nodesource.gpg

Verified: Cloud Build 591bdf8a-f9c4-402f-9d7a-62e0f6c979f9 passed for linux/amd64+arm64 after applying this fix