### PR TITLE
platform skills: add recovery, shell safety, and model override

### DIFF
--- a/resources/platform_skills/scion-agent-manage/SKILL.md
+++ b/resources/platform_skills/scion-agent-manage/SKILL.md
@@ -49,40 +49,4 @@ scion start <name> --non-interactive --model claude-sonnet-4-20250514
 
 **Do NOT use `--harness-config` for this** — that flag expects a named harness configuration registered in the hub, not a model name.
 
-## Troubleshooting and Recovery
-
-Most stuck agents are recoverable without recreation. Always start with `scion look <agent>` to inspect current state before acting.
-
-### Triage Table
-
-| Symptom | Cause | Recovery |
-|---|---|---|
-| Transient API error in log | LLM provider rate-limit or timeout | `scion message <agent> "continue"` — do NOT recreate |
-| `LIMITS_EXCEEDED` state | Context/rate limit hit | `scion message <agent> "continue"` |
-| `failed to verify token: error in cryptographic primitive` | Hub regenerated signing keys on restart | `scion message <agent> "continue"` (triggers token refresh) |
-| `Token refresh failed … 401` repeating every 30s | Token expired; refresh deadlocked | `scion message <agent> "continue"` — if no effect, recreate |
-| Container exit 255 / status `Exited` | Container crash | Recreate the agent |
-| Phase `created`, lastSeen zero, persists 5+ min | Broker dispatch exceeded CLI timeout | Wait a few minutes; if stuck, delete and recreate |
-| Phase `starting` + activity `completed` | Duplicate sciontool process reset phase via hub API | Kill duplicate process, recreate |
-| Context at 100% | Memory/context limit reached | Send raw clear sequence (see below) |
-| `gh` CLI returns 401 | Stale `GH_TOKEN` env var, not an agent state issue | Fall back to `curl` with known-good token |
-| Rebase fails "unrelated histories" | Shallow clone hides common ancestor | `git fetch --unshallow` then retry rebase |
-| Interactive prompt blocking agent | Harness waiting for user input | `scion message <agent> --raw "ENTER"` or appropriate dismissal |
-
-### Context Clear
-
-When an agent's context approaches 100%, clear it manually with raw terminal input:
-
-```bash
-scion message <agent> --raw "/"
-scion message <agent> --raw "clear"
-scion message <agent> --raw "ENTER"
-```
-
-Always `scion look <agent>` first to verify screen state before sending raw input.
-
-### Anti-Patterns
-
-- **Recreating on first sign of trouble.** Most stuck states recover with `scion message <agent> "continue"`. Recreation destroys uncommitted work and in-memory state.
-- **Sending raw input blind.** Always `scion look` first — raw keystrokes go to whatever is on screen.
-- **Treating all 401s the same.** Hub token 401 (agent state) and GitHub token 401 (API auth) have different recovery paths.
+For troubleshooting agents that are stalled, have hit an error, or are stuck see references/troubleshooting.md

--- a/resources/platform_skills/scion-agent-manage/SKILL.md
+++ b/resources/platform_skills/scion-agent-manage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scion-agent-manage
-description: Manage concurrent LLM-based code agents with scion - orchestrate parallel agents with isolated workspaces
+description: Manage concurrent LLM-based code agents with scion - orchestrate parallel agents with isolated workspaces, troubleshoot and recover stuck agents
 ---
 
 # Scion Agent Management Skill
@@ -38,3 +38,41 @@ The best and most current reference for the CLI commands is available from `scio
 5. **Interrupt carefully**: The `--interrupt` flag on messages stops current work - use only when necessary.
 
 6. **Preserve branches**: When deleting agents whose work might need review, use `--preserve-branch`.
+
+## Troubleshooting and Recovery
+
+Most stuck agents are recoverable without recreation. Always start with `scion look <agent>` to inspect current state before acting.
+
+### Triage Table
+
+| Symptom | Cause | Recovery |
+|---|---|---|
+| Transient API error in log | LLM provider rate-limit or timeout | `scion message <agent> "continue"` — do NOT recreate |
+| `LIMITS_EXCEEDED` state | Context/rate limit hit | `scion message <agent> "continue"` |
+| `failed to verify token: error in cryptographic primitive` | Hub regenerated signing keys on restart | `scion message <agent> "continue"` (triggers token refresh) |
+| `Token refresh failed … 401` repeating every 30s | Token expired; refresh deadlocked | `scion message <agent> "continue"` — if no effect, recreate |
+| Container exit 255 / status `Exited` | Container crash | Recreate the agent |
+| Phase `created`, lastSeen zero, persists 5+ min | Broker dispatch exceeded CLI timeout | Wait a few minutes; if stuck, delete and recreate |
+| Phase `starting` + activity `completed` | Duplicate sciontool process reset phase via hub API | Kill duplicate process, recreate |
+| Context at 100% | Memory/context limit reached | Send raw clear sequence (see below) |
+| `gh` CLI returns 401 | Stale `GH_TOKEN` env var, not an agent state issue | Fall back to `curl` with known-good token |
+| Rebase fails "unrelated histories" | Shallow clone hides common ancestor | `git fetch --unshallow` then retry rebase |
+| Interactive prompt blocking agent | Harness waiting for user input | `scion message <agent> --raw "ENTER"` or appropriate dismissal |
+
+### Context Clear
+
+When an agent's context approaches 100%, clear it manually with raw terminal input:
+
+```bash
+scion message <agent> --raw "/"
+scion message <agent> --raw "clear"
+scion message <agent> --raw "ENTER"
+```
+
+Always `scion look <agent>` first to verify screen state before sending raw input.
+
+### Anti-Patterns
+
+- **Recreating on first sign of trouble.** Most stuck states recover with `scion message <agent> "continue"`. Recreation destroys uncommitted work and in-memory state.
+- **Sending raw input blind.** Always `scion look` first — raw keystrokes go to whatever is on screen.
+- **Treating all 401s the same.** Hub token 401 (agent state) and GitHub token 401 (API auth) have different recovery paths.

--- a/resources/platform_skills/scion-agent-manage/SKILL.md
+++ b/resources/platform_skills/scion-agent-manage/SKILL.md
@@ -39,6 +39,17 @@ The best and most current reference for the CLI commands is available from `scio
 
 6. **Preserve branches**: When deleting agents whose work might need review, use `--preserve-branch`.
 
+## Model Override
+
+To start an agent with a specific model (overriding the harness default), use `--config` with a flat YAML file:
+
+```bash
+printf 'model: claude-sonnet-4-20250514\n' > /tmp/agent-config.yaml
+scion start <name> --non-interactive --config /tmp/agent-config.yaml
+```
+
+**Do NOT use `--harness-config` for this** — that flag expects a named harness configuration registered in the hub, not a model name or YAML file.
+
 ## Troubleshooting and Recovery
 
 Most stuck agents are recoverable without recreation. Always start with `scion look <agent>` to inspect current state before acting.

--- a/resources/platform_skills/scion-agent-manage/SKILL.md
+++ b/resources/platform_skills/scion-agent-manage/SKILL.md
@@ -41,14 +41,13 @@ The best and most current reference for the CLI commands is available from `scio
 
 ## Model Override
 
-To start an agent with a specific model (overriding the harness default), use `--config` with a flat YAML file:
+To start an agent with a specific model (overriding the harness default), use the `--model` flag:
 
 ```bash
-printf 'model: claude-sonnet-4-20250514\n' > /tmp/agent-config.yaml
-scion start <name> --non-interactive --config /tmp/agent-config.yaml
+scion start <name> --non-interactive --model claude-sonnet-4-20250514
 ```
 
-**Do NOT use `--harness-config` for this** — that flag expects a named harness configuration registered in the hub, not a model name or YAML file.
+**Do NOT use `--harness-config` for this** — that flag expects a named harness configuration registered in the hub, not a model name.
 
 ## Troubleshooting and Recovery
 

--- a/resources/platform_skills/scion-agent-manage/SKILL.md
+++ b/resources/platform_skills/scion-agent-manage/SKILL.md
@@ -39,6 +39,29 @@ The best and most current reference for the CLI commands is available from `scio
 
 6. **Preserve branches**: When deleting agents whose work might need review, use `--preserve-branch`.
 
+## Briefing
+
+Every agent you create needs a brief. Write the brief to a **shared scratchpad file and
+pass the filepath** — do not inline a long brief into the creation command.
+
+```bash
+scion start <name> --non-interactive \
+  "Read your brief at /scion-volumes/scratchpad/briefs/<name>.md and follow it."
+```
+
+A brief states:
+
+| Section | Content |
+|---|---|
+| Task | what to do, in one or two sentences |
+| Context | what has already been decided, and where to read it |
+| Boundaries | what is explicitly out of scope |
+| Deliverable | what artifact is owed, and in what shape |
+| Reporting | who to report to, and when |
+
+For shell-escaping rules when passing prompts, see the `scion-cli-operations` skill —
+do not improvise quoting.
+
 ## Model Override
 
 To start an agent with a specific model (overriding the harness default), use the `--model` flag:
@@ -50,3 +73,5 @@ scion start <name> --non-interactive --model claude-sonnet-4-20250514
 **Do NOT use `--harness-config` for this** — that flag expects a named harness configuration registered in the hub, not a model name.
 
 For troubleshooting agents that are stalled, have hit an error, or are stuck see references/troubleshooting.md
+
+For agent lifecycle rules — when to delete, when to stop, and who may authorize deletion — see references/agent-lifecycle.md

--- a/resources/platform_skills/scion-agent-manage/references/agent-lifecycle.md
+++ b/resources/platform_skills/scion-agent-manage/references/agent-lifecycle.md
@@ -24,6 +24,7 @@ accepted. Time-box it; do not leave agents stopped indefinitely.
 |---|---|---|
 | Developer, reviewer — clear start and end | The agent's creator/supervisor | Once output is accepted and verified |
 | Investigator, architect — may hold an open question | The agent's creator/supervisor | **Only after all questions to humans are answered** and the conversation is explicitly done |
+| Project initiator — the first agent on a project, whatever role it started as | **Only on explicit human instruction** | It is the project's continuity point from first research through closure; its starting role does not govern its lifespan |
 | Engineering manager, coordinator, project lead | **Only on explicit human instruction naming the workstream** | Human says "close down the X workstream" or equivalent |
 
 ### Rules

--- a/resources/platform_skills/scion-agent-manage/references/agent-lifecycle.md
+++ b/resources/platform_skills/scion-agent-manage/references/agent-lifecycle.md
@@ -51,6 +51,12 @@ accepted. Time-box it; do not leave agents stopped indefinitely.
    | "Check with leads about cleanup" | Ask leads which of **their sub-agents** are safe to delete |
    | A lead's own readiness signal | **Never** authorizes deleting that lead |
 
+5. **A notification is not proof of completion.** State-change notifications fire on
+   sub-task transitions, not only on full-task completion. Before treating an agent as
+   done, verify with `scion look <agent>` and confirm the artifact it owed — commit
+   pushed, file written, PR opened. Acting on the notification alone causes premature
+   follow-up dispatch against a state that does not yet exist.
+
 ## Anti-patterns
 
 - **Deleting an agent immediately on completion signal.** Wait for explicit confirmation

--- a/resources/platform_skills/scion-agent-manage/references/agent-lifecycle.md
+++ b/resources/platform_skills/scion-agent-manage/references/agent-lifecycle.md
@@ -1,0 +1,62 @@
+# Agent Lifecycle
+
+When to delete an agent, when to stop one, and who may authorize it.
+
+## Default: delete when done
+
+`scion delete <name> --non-interactive` frees the broker slot. `scion list` silently
+truncates at 50 agents — stopped agents count against that ceiling. **Delete is the
+default disposition for a completed agent.** Use `--preserve-branch` when the agent's
+branch may still need review.
+
+`scion stop` is justified only when you need the agent's terminal state within the
+current work phase — for example, to inspect logs before deciding whether output was
+accepted. Time-box it; do not leave agents stopped indefinitely.
+
+> **Deleting an agent is safe because its deliverable is an artifact** — files committed
+> to the repo, designs written to the scratchpad, findings in a shared document. These
+> survive deletion. Terminal logs do not, and should not need to — they are not the
+> audit trail.
+
+## Who may authorize deletion
+
+| Agent role | Deleted by | When |
+|---|---|---|
+| Developer, reviewer — clear start and end | The agent's creator/supervisor | Once output is accepted and verified |
+| Investigator, architect — may hold an open question | The agent's creator/supervisor | **Only after all questions to humans are answered** and the conversation is explicitly done |
+| Engineering manager, coordinator, project lead | **Only on explicit human instruction naming the workstream** | Human says "close down the X workstream" or equivalent |
+
+### Rules
+
+1. **Completion of a task is not completion of an agent.** A completion signal means the
+   task is done, not that the agent should be deleted. The user may want follow-up work.
+
+2. **An agent with an unanswered question to a human is not complete.** "Design complete"
+   does not mean "conversation complete." Before deleting any agent, ask: *has this agent
+   raised open questions to the user?* If yes, do not delete.
+
+3. **An agent's own readiness signal is not permission.** An agent saying it is ready for
+   cleanup does not constitute user permission to delete it. Only a human can authorize
+   deletion of leads and initiators.
+
+4. **"Clean up the agents" means workers.** When a human says "clean up agents" or "check
+   with leads about cleanup," they mean completed **worker** agents (developers, reviewers,
+   investigators). They do **not** mean delete the leads themselves.
+
+   | Human phrase | Means |
+   |---|---|
+   | "Clean up agents" | Delete completed **workers** only |
+   | "Close down the X workstream" | Delete the lead for **that named** project |
+   | "Check with leads about cleanup" | Ask leads which of **their sub-agents** are safe to delete |
+   | A lead's own readiness signal | **Never** authorizes deleting that lead |
+
+## Anti-patterns
+
+- **Deleting an agent immediately on completion signal.** Wait for explicit confirmation
+  or apply the role-based rules above.
+- **Interpreting "clean up" as permission to delete leads.** It never is, unless the
+  human names the specific workstream being closed.
+- **Leaving agents stopped for audit trail.** Commit findings to files instead. Stopped
+  agents consume broker slots and count against the 50-agent list ceiling.
+- **Deleting an agent with uncommitted work.** Always verify work is committed or
+  preserved before deletion.

--- a/resources/platform_skills/scion-agent-manage/references/troubleshooting.md
+++ b/resources/platform_skills/scion-agent-manage/references/troubleshooting.md
@@ -15,7 +15,7 @@ Most stuck agents are recoverable without recreation. Always start with `scion l
 | Phase `starting` + activity `completed` | Duplicate sciontool process reset phase via hub API | Kill duplicate process, recreate |
 | Context at 100% | Memory/context limit reached | Send raw clear sequence (see below) |
 | `gh` CLI returns 401 | Stale `GH_TOKEN` env var, not an agent state issue | Fall back to `curl` with known-good token |
-| Rebase fails "unrelated histories" | Shallow clone hides common ancestor | `git fetch --unshallow` then retry rebase |
+| Rebase fails "unrelated histories" | Shallow clone hides common ancestor | `git fetch --unshallow` then retry `git rebase origin/main` — **not** force-push or branch recreation |
 | Interactive prompt blocking agent | Harness waiting for user input | `scion message <agent> --raw "ENTER"` or appropriate dismissal |
 
 ## Context Clear

--- a/resources/platform_skills/scion-agent-manage/references/troubleshooting.md
+++ b/resources/platform_skills/scion-agent-manage/references/troubleshooting.md
@@ -1,0 +1,37 @@
+# Troubleshooting and Recovery
+
+Most stuck agents are recoverable without recreation. Always start with `scion look <agent>` to inspect current state before acting.
+
+## Triage Table
+
+| Symptom | Cause | Recovery |
+|---|---|---|
+| Transient API error in log | LLM provider rate-limit or timeout | `scion message <agent> "continue"` — do NOT recreate |
+| `LIMITS_EXCEEDED` state | Context/rate limit hit | `scion message <agent> "continue"` |
+| `failed to verify token: error in cryptographic primitive` | Hub regenerated signing keys on restart | `scion message <agent> "continue"` (triggers token refresh) |
+| `Token refresh failed … 401` repeating every 30s | Token expired; refresh deadlocked | `scion message <agent> "continue"` — if no effect, recreate |
+| Container exit 255 / status `Exited` | Container crash | Recreate the agent |
+| Phase `created`, lastSeen zero, persists 5+ min | Broker dispatch exceeded CLI timeout | Wait a few minutes; if stuck, delete and recreate |
+| Phase `starting` + activity `completed` | Duplicate sciontool process reset phase via hub API | Kill duplicate process, recreate |
+| Context at 100% | Memory/context limit reached | Send raw clear sequence (see below) |
+| `gh` CLI returns 401 | Stale `GH_TOKEN` env var, not an agent state issue | Fall back to `curl` with known-good token |
+| Rebase fails "unrelated histories" | Shallow clone hides common ancestor | `git fetch --unshallow` then retry rebase |
+| Interactive prompt blocking agent | Harness waiting for user input | `scion message <agent> --raw "ENTER"` or appropriate dismissal |
+
+## Context Clear
+
+When an agent's context approaches 100%, clear it manually with raw terminal input:
+
+```bash
+scion message <agent> --raw "/"
+scion message <agent> --raw "clear"
+scion message <agent> --raw "ENTER"
+```
+
+Always `scion look <agent>` first to verify screen state before sending raw input.
+
+## Anti-Patterns
+
+- **Recreating on first sign of trouble.** Most stuck states recover with `scion message <agent> "continue"`. Recreation destroys uncommitted work and in-memory state.
+- **Sending raw input blind.** Always `scion look` first — raw keystrokes go to whatever is on screen.
+- **Treating all 401s the same.** Hub token 401 (agent state) and GitHub token 401 (API auth) have different recovery paths.

--- a/resources/platform_skills/scion-cli-operations/SKILL.md
+++ b/resources/platform_skills/scion-cli-operations/SKILL.md
@@ -30,6 +30,8 @@ scion start <name> --non-interactive \
   "Read your brief at /path/to/brief.md and follow it."
 ```
 
+**Use absolute paths** in task prompts and briefs. A sub-agent's working directory may differ from yours — relative paths resolve against the sub-agent's `/workspace`, not yours.
+
 ## Recommended Commands
 
 - **Inspect an Agent**: `scion look <agent-id>` — inspect the recent output and current terminal-UI state of any running agent.

--- a/resources/platform_skills/scion-cli-operations/SKILL.md
+++ b/resources/platform_skills/scion-cli-operations/SKILL.md
@@ -21,6 +21,15 @@ You are an autonomous Scion agent running inside a containerized sandbox. Your w
 - **Do Not Use Global**: Never use the `--global` option; you are operating in a grove workspace and it is set implicitly by default.
 - **Do Not Interact with Settings or Login Commands**.
 
+## Shell Safety for Task Prompts
+
+The `scion start` task prompt is embedded in a shell command. **Do not use backticks, `$variables`, or other shell metacharacters** in the inlined prompt — they cause the shell to exit before the agent starts, with no visible error. For long or formatted briefs, write the content to a file and pass a filepath reference instead:
+
+```bash
+scion start <name> --non-interactive --notify \
+  "Read your brief at /path/to/brief.md and follow it."
+```
+
 ## Recommended Commands
 
 - **Inspect an Agent**: `scion look <agent-id>` — inspect the recent output and current terminal-UI state of any running agent.

--- a/resources/platform_skills/scion-cli-operations/SKILL.md
+++ b/resources/platform_skills/scion-cli-operations/SKILL.md
@@ -26,7 +26,7 @@ You are an autonomous Scion agent running inside a containerized sandbox. Your w
 The `scion start` task prompt is embedded in a shell command. **Do not use backticks, `$variables`, or other shell metacharacters** in the inlined prompt — they cause the shell to exit before the agent starts, with no visible error. For long or formatted briefs, write the content to a file and pass a filepath reference instead:
 
 ```bash
-scion start <name> --non-interactive --notify \
+scion start <name> --non-interactive \
   "Read your brief at /path/to/brief.md and follow it."
 ```
 


### PR DESCRIPTION
## Summary

Three additions to built-in platform skills, merging generic operational content from contrib-repo into upstream:

### scion-agent-manage
- **Troubleshooting and Recovery** — triage table (11 symptoms x cause x recovery), context clear recipe, anti-patterns
- **Model Override** — --config with flat YAML for model selection, --harness-config warning

### scion-cli-operations
- **Shell Safety for Task Prompts** — metacharacters in scion start args cause silent failure; use filepath references for long briefs