### PR TITLE
fix(discord): fail-closed observe mode filter using resolveChannelLink

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -658,13 +658,13 @@ func (b *DiscordBroker) Publish(ctx context.Context, topic string, msg *messages
 					"channel_id", channelID, "error", linkErr)
 				link = nil
 			}
-			// Fail closed: a missing link (or a failed lookup) is treated the
-			// same as a link with observe settings disabled. Channels with no
-			// link row at all should not receive observe traffic; defaulting to
-			// "deliver everything" leaked agent-to-agent traffic and state
-			// changes into channels with observe mode off.
-			showAgentToAgent := link != nil && link.ShowAgentToAgent
-			showStateChanges := link != nil && link.ShowStateChanges
+			// Fail closed: a missing link, an inactive link, or a failed lookup
+			// is treated the same as a link with observe settings disabled.
+			// Channels with no link row at all should not receive observe
+			// traffic; defaulting to "deliver everything" leaked agent-to-agent
+			// traffic and state changes into channels with observe mode off.
+			showAgentToAgent := link != nil && link.Active && link.ShowAgentToAgent
+			showStateChanges := link != nil && link.Active && link.ShowStateChanges
 
 			if isAgentToAgent && !showAgentToAgent {
 				b.log.Debug("Filtering agent-to-agent message",

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -648,15 +648,27 @@ func (b *DiscordBroker) Publish(ctx context.Context, topic string, msg *messages
 
 		if needsFilter && store != nil {
 			link, linkErr := store.GetChannelLink(ctx, channelID)
-			if linkErr == nil && link != nil {
-				if isAgentToAgent && !link.ShowAgentToAgent {
-					b.log.Debug("Filtering agent-to-agent message", "channel_id", channelID)
-					continue
-				}
-				if isStateChange && !link.ShowStateChanges {
-					b.log.Debug("Filtering state change notification", "channel_id", channelID)
-					continue
-				}
+			if linkErr != nil {
+				b.log.Warn("Failed to look up channel link; applying fail-closed filter",
+					"channel_id", channelID, "error", linkErr)
+			}
+			// Fail closed: a missing link (or a failed lookup) is treated the
+			// same as a link with observe settings disabled. Threads reached by
+			// direct ThreadID routing often have no channel_link row, and
+			// defaulting to "deliver everything" leaked agent-to-agent traffic
+			// and state changes into channels with observe mode off.
+			showAgentToAgent := link != nil && link.ShowAgentToAgent
+			showStateChanges := link != nil && link.ShowStateChanges
+
+			if isAgentToAgent && !showAgentToAgent {
+				b.log.Debug("Filtering agent-to-agent message",
+					"channel_id", channelID, "linked", link != nil)
+				continue
+			}
+			if isStateChange && !showStateChanges {
+				b.log.Debug("Filtering state change notification",
+					"channel_id", channelID, "linked", link != nil)
+				continue
 			}
 		}
 

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -647,16 +647,22 @@ func (b *DiscordBroker) Publish(ctx context.Context, topic string, msg *messages
 		}
 
 		if needsFilter && store != nil {
-			link, linkErr := store.GetChannelLink(ctx, channelID)
+			// Use resolveChannelLink so threads fall back to their parent
+			// channel's link. Links are only ever stored on parent channels
+			// (saveChannelLink rewrites thread IDs to the parent), so a direct
+			// GetChannelLink on a thread snowflake always returns nil and would
+			// filter out every message in every thread.
+			link, linkErr := resolveChannelLink(ctx, session, store, channelID)
 			if linkErr != nil {
 				b.log.Warn("Failed to look up channel link; applying fail-closed filter",
 					"channel_id", channelID, "error", linkErr)
+				link = nil
 			}
 			// Fail closed: a missing link (or a failed lookup) is treated the
-			// same as a link with observe settings disabled. Threads reached by
-			// direct ThreadID routing often have no channel_link row, and
-			// defaulting to "deliver everything" leaked agent-to-agent traffic
-			// and state changes into channels with observe mode off.
+			// same as a link with observe settings disabled. Channels with no
+			// link row at all should not receive observe traffic; defaulting to
+			// "deliver everything" leaked agent-to-agent traffic and state
+			// changes into channels with observe mode off.
 			showAgentToAgent := link != nil && link.ShowAgentToAgent
 			showStateChanges := link != nil && link.ShowStateChanges
 

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -3,6 +3,7 @@ package discord
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -864,4 +865,200 @@ func newTestBrokerStore(t *testing.T) Store {
 	require.NoError(t, err)
 	t.Cleanup(func() { store.Close() })
 	return store
+}
+
+// recordingTransport captures outbound Discord REST calls so Publish can be
+// exercised without touching the network.
+type recordingTransport struct {
+	paths []string
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.paths = append(rt.paths, req.URL.Path)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{}`)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+// newRecordingSession returns a Session whose REST calls are intercepted, with
+// the given channels seeded into its state cache.
+func newRecordingSession(t *testing.T, channels []*discordgo.Channel) (*discordgo.Session, *recordingTransport) {
+	t.Helper()
+	s, err := discordgo.New("Bot test-token")
+	require.NoError(t, err)
+
+	rt := &recordingTransport{}
+	s.Client = &http.Client{Transport: rt}
+	s.MaxRestRetries = 0
+	s.ShouldRetryOnRateLimit = false
+
+	_ = s.State.GuildAdd(&discordgo.Guild{ID: testGuildID})
+	for _, ch := range channels {
+		if ch.GuildID == "" {
+			ch.GuildID = testGuildID
+		}
+		_ = s.State.ChannelAdd(ch)
+	}
+	return s, rt
+}
+
+// TestPublish_ObserveFilter_ThreadResolvesParentLink covers the fail-closed
+// observe filter for messages routed directly at a thread snowflake.
+//
+// Channel links are only ever persisted against parent channels
+// (saveChannelLink rewrites thread IDs to the parent), so the filter must use
+// resolveChannelLink rather than a bare store.GetChannelLink — otherwise every
+// thread looks unlinked and agent-to-agent traffic is blocked even when observe
+// mode is explicitly enabled on the parent.
+func TestPublish_ObserveFilter_ThreadResolvesParentLink(t *testing.T) {
+	tests := []struct {
+		name string
+		// parentLink is nil when the parent channel has no link row at all.
+		parentLink       *ChannelLink
+		wantDelivered    bool
+		wantDeliveredMsg string
+	}{
+		{
+			name:             "thread with no parent link is filtered out",
+			parentLink:       nil,
+			wantDelivered:    false,
+			wantDeliveredMsg: "unlinked thread must fail closed",
+		},
+		{
+			name: "thread whose parent enables observe is delivered",
+			parentLink: &ChannelLink{
+				ShowAgentToAgent: true,
+			},
+			wantDelivered:    true,
+			wantDeliveredMsg: "observe mode on the parent must allow agent-to-agent through",
+		},
+		{
+			name: "thread whose parent disables observe is filtered out",
+			parentLink: &ChannelLink{
+				ShowAgentToAgent: false,
+			},
+			wantDelivered:    false,
+			wantDeliveredMsg: "observe mode off on the parent must filter agent-to-agent",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Unique IDs per case: resolveChannelLink memoises thread parents
+			// in a package-level cache that outlives individual tests.
+			parentID := fmt.Sprintf("parent-%d", i)
+			threadID := fmt.Sprintf("thread-%d", i)
+			t.Cleanup(func() {
+				threadParentsMu.Lock()
+				delete(threadParents, threadID)
+				threadParentsMu.Unlock()
+			})
+
+			session, rt := newRecordingSession(t, []*discordgo.Channel{
+				{ID: parentID, Type: discordgo.ChannelTypeGuildText},
+				{
+					ID:       threadID,
+					Type:     discordgo.ChannelTypeGuildPublicThread,
+					ParentID: parentID,
+				},
+			})
+
+			store := newTestBrokerStore(t)
+			if tt.parentLink != nil {
+				link := *tt.parentLink
+				link.ChannelID = parentID
+				link.GuildID = testGuildID
+				link.ProjectID = "proj-1"
+				link.ProjectSlug = "proj"
+				link.Active = true
+				link.LinkedAt = time.Now()
+				require.NoError(t, store.CreateChannelLink(ctx, &link))
+			}
+
+			b := testBroker(session)
+			b.log = discardLogger()
+			b.store = store
+
+			// Agent-to-agent message routed straight at the thread snowflake.
+			msg := &messages.StructuredMessage{
+				Version:   messages.Version,
+				Channel:   "discord",
+				Sender:    "agent:alice",
+				Recipient: "agent:bob",
+				Msg:       fmt.Sprintf("observe payload %d", i),
+				Type:      messages.TypeInstruction,
+				ThreadID:  threadID,
+			}
+
+			require.NoError(t, b.Publish(ctx, "proj-1.agent.alice", msg))
+
+			delivered := len(rt.paths) > 0
+			assert.Equal(t, tt.wantDelivered, delivered, tt.wantDeliveredMsg)
+			if tt.wantDelivered {
+				assert.Contains(t, strings.Join(rt.paths, ","), threadID,
+					"message should be delivered to the thread, not the parent")
+			}
+		})
+	}
+}
+
+// TestPublish_ObserveFilter_StateChangeThreadResolvesParentLink is the
+// state-change counterpart: ShowStateChanges lives on the parent link too.
+func TestPublish_ObserveFilter_StateChangeThreadResolvesParentLink(t *testing.T) {
+	for i, showStateChanges := range []bool{false, true} {
+		t.Run(fmt.Sprintf("show_state_changes=%v", showStateChanges), func(t *testing.T) {
+			ctx := context.Background()
+
+			parentID := fmt.Sprintf("sc-parent-%d", i)
+			threadID := fmt.Sprintf("sc-thread-%d", i)
+			t.Cleanup(func() {
+				threadParentsMu.Lock()
+				delete(threadParents, threadID)
+				threadParentsMu.Unlock()
+			})
+
+			session, rt := newRecordingSession(t, []*discordgo.Channel{
+				{ID: parentID, Type: discordgo.ChannelTypeGuildText},
+				{
+					ID:       threadID,
+					Type:     discordgo.ChannelTypeGuildPublicThread,
+					ParentID: parentID,
+				},
+			})
+
+			store := newTestBrokerStore(t)
+			require.NoError(t, store.CreateChannelLink(ctx, &ChannelLink{
+				ChannelID:        parentID,
+				GuildID:          testGuildID,
+				ProjectID:        "proj-1",
+				ProjectSlug:      "proj",
+				Active:           true,
+				LinkedAt:         time.Now(),
+				ShowStateChanges: showStateChanges,
+			}))
+
+			b := testBroker(session)
+			b.log = discardLogger()
+			b.store = store
+
+			msg := &messages.StructuredMessage{
+				Version:  messages.Version,
+				Channel:  "discord",
+				Sender:   "agent:alice",
+				Msg:      fmt.Sprintf("state change %d", i),
+				Type:     messages.TypeStateChange,
+				ThreadID: threadID,
+			}
+
+			require.NoError(t, b.Publish(ctx, "proj-1.agent.alice", msg))
+
+			assert.Equal(t, showStateChanges, len(rt.paths) > 0,
+				"state change delivery must follow the parent link's ShowStateChanges flag")
+		})
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/573

The observe mode filter (ShowAgentToAgent, ShowStateChanges) was fail-open: when a thread had no channel link entry, GetChannelLink returned nil and all messages passed through unfiltered.

Fix: use resolveChannelLink() (which already does the thread->parent fallback) instead of GetChannelLink(threadID). When no parent link exists (truly unlinked), filter agent-to-agent and state-change messages by default. link is explicitly set to nil on the error path for true fail-closed semantics.

3 regression tests added (nil parent, show=true pass-through, show=false filter)