### PR TITLE
feat: surface workspace sharing mode to agents via SCION_WORKSPACE_MODE + SCION_WORKSPACE_GIT

### DIFF
--- a/.design/workspace-mode-env.md
+++ b/.design/workspace-mode-env.md
@@ -343,10 +343,10 @@ still read `SCION_SHARED_WORKSPACE`. This PR therefore:
    compatibility with older broker versions).
 3. Adds a `// Deprecated:` comment on the `SCION_SHARED_WORKSPACE` emission site.
 
-Phase 2 (eventual removal of `SCION_SHARED_WORKSPACE`) is tracked in a separate
-issue filed by the coordinator — see **ptone/scion#TBD** (issue number to be
-added once filed). The implementation phases below include a sciontool update
-task for the compatibility shim.
+Phase 2 (eventual removal of `SCION_SHARED_WORKSPACE`) is tracked in
+[ptone/scion#575](https://github.com/ptone/scion/issues/575). The
+implementation phases below include a sciontool update task for the
+compatibility shim.
 
 ---
 
@@ -409,7 +409,7 @@ task for the compatibility shim.
 1. Add "Runtime Environment Variables" section to `workspace.md` or
    `workspaces-and-sharing.md` documenting `SCION_WORKSPACE_MODE` (values,
    defaults) and `SCION_WORKSPACE_GIT` (boolean-presence contract). Note
-   `SCION_SHARED_WORKSPACE` as deprecated with the tracking issue reference.
+   `SCION_SHARED_WORKSPACE` as deprecated, referencing #575 for removal.
 2. Fix the shared-directories "both locations" doc bug in `workspace.md:190-191`
    (either/or per `SharedDir.InWorkspace`, not always-both).
 3. Update `skills.md:233-240` inject_when table if needed.

--- a/.design/workspace-mode-env.md
+++ b/.design/workspace-mode-env.md
@@ -2,7 +2,7 @@
 
 **Issue:** [ptone/scion#572](https://github.com/ptone/scion/issues/572)  
 **Project slug:** `workspace-mode-env`  
-**Status:** Draft — 3 open questions pending user input (see §Open Questions)
+**Status:** Finalized — all open questions resolved (see §Open Questions for decisions)
 
 ---
 
@@ -319,50 +319,40 @@ approach requires zero new storage.
 
 ## Open Questions
 
-Three decisions require user input before the design can be finalized.
-Raised serially below; do not continue past each until the user replies.
+All three questions resolved (2026-07-25). Decisions recorded below.
 
 **OQ1 — Canonical vs. wire labels in `SCION_WORKSPACE_MODE`:**  
-The design above emits canonical values (`shared-plain`, `clone-per-agent`,
-`worktree-per-agent`). This aligns with the glossary and the issue's
-recommendation. Confirm this is correct, or specify if wire labels (`shared`,
-`per-agent`, `worktree-per-agent`) are preferred. This decision is
-**load-bearing** — the string values baked into the env var become an agent API
-contract.
+✅ **Decision: canonical values.** `SCION_WORKSPACE_MODE` emits `shared-plain`,
+`clone-per-agent`, `worktree-per-agent` — aligned with the glossary. Wire labels
+(`shared`, `per-agent`, `worktree-per-agent`) are not exposed to agents.
+This is a stable agent API contract; new modes require a new canonical constant
+in `store.WorkspaceSharingMode` and a doc update, not a rename.
 
 **OQ2 — Ship Change 3 (WorkspaceMode propagation fix) with this PR or separately:**  
-Change 3 is a correctness bug on its own merits — restarted/resumed agents
-currently fall back to `shared-plain` regardless of their actual isolation
-level. Two options:
-- **Option A (together):** Ship Change 3 in the same PR. The fix is a
-  prerequisite for Changes 1 and 2 to be correct on restart paths.
-  Slightly larger PR, but logically cohesive.
-- **Option B (split):** File a separate issue for Change 3 (broker
-  WorkspaceMode propagation bug), fix it first, then ship Changes 1 and 2
-  in a follow-up. Cleaner history, but requires coordination between two PRs
-  and a narrow window where agents on restart still get wrong mode.
-
-The design doc is written to support either. This decision affects the phased
-plan below.
+✅ **Decision: Option A — ship all three changes together.** The propagation fix
+is a correctness prerequisite for Changes 1 and 2 to be accurate on restart
+paths. Single cohesive PR.
 
 **OQ3 — Deprecate `SCION_SHARED_WORKSPACE` once `SCION_WORKSPACE_MODE` lands:**  
-`SCION_SHARED_WORKSPACE=true` is currently consumed only by
-`sciontool init` (`cmd/sciontool/commands/init.go:330`) to detect shared-plain
-git workspaces. With `SCION_WORKSPACE_MODE=shared-plain` and
-`SCION_WORKSPACE_GIT=true` available, sciontool could read those instead.
-Two options:
-- **Option A (deprecate):** Keep emitting `SCION_SHARED_WORKSPACE` in this PR
-  for backward compat, update sciontool to read the new vars, then remove the
-  old var in a follow-up.
-- **Option B (retain independently):** Keep `SCION_SHARED_WORKSPACE` as-is
-  indefinitely; it serves a narrow sciontool bootstrap purpose and the
-  consolidation cost may not be worth it.
+✅ **Decision: Option A — deprecate, with a compatibility period.** Sciontool
+and the broker/hub do not always ship together; older `sciontool` builds may
+still read `SCION_SHARED_WORKSPACE`. This PR therefore:
+1. Continues emitting `SCION_SHARED_WORKSPACE` unchanged.
+2. Updates `sciontool init` to prefer `SCION_WORKSPACE_MODE` + `SCION_WORKSPACE_GIT`
+   (falling back to `SCION_SHARED_WORKSPACE` when the new vars are absent, for
+   compatibility with older broker versions).
+3. Adds a `// Deprecated:` comment on the `SCION_SHARED_WORKSPACE` emission site.
+
+Phase 2 (eventual removal of `SCION_SHARED_WORKSPACE`) is tracked in a separate
+issue filed by the coordinator — see **ptone/scion#TBD** (issue number to be
+added once filed). The implementation phases below include a sciontool update
+task for the compatibility shim.
 
 ---
 
 ## Implementation Phases
 
-*(Adjusts based on answer to OQ2. Shown here as Option A — all together.)*
+*(All three changes ship together per OQ2 decision. sciontool compat shim added per OQ3.)*
 
 ### Phase 0 — Bug fix: WorkspaceMode propagation (Change 3)
 
@@ -401,13 +391,25 @@ Two options:
      var present.
    - Non-git shared workspace → var absent.
 
-### Phase 3 — Documentation
+### Phase 3 — sciontool compatibility shim (OQ3)
+
+**Commit scope:** `cmd/sciontool/commands/init.go`.
+
+1. Update `sciontool init` to prefer `SCION_WORKSPACE_MODE` + `SCION_WORKSPACE_GIT`
+   when both are present, with fallback to `SCION_SHARED_WORKSPACE` for
+   older broker versions that don't yet emit the new vars.
+2. Add a `// Deprecated: use SCION_WORKSPACE_MODE+SCION_WORKSPACE_GIT` comment
+   on the `SCION_SHARED_WORKSPACE` emission site in `start_context.go`.
+3. Add tests for both code paths in the fallback logic.
+
+### Phase 4 — Documentation
 
 **Commit scope:** `docs-site/`.
 
 1. Add "Runtime Environment Variables" section to `workspace.md` or
    `workspaces-and-sharing.md` documenting `SCION_WORKSPACE_MODE` (values,
-   defaults) and `SCION_WORKSPACE_GIT` (boolean-presence contract).
+   defaults) and `SCION_WORKSPACE_GIT` (boolean-presence contract). Note
+   `SCION_SHARED_WORKSPACE` as deprecated with the tracking issue reference.
 2. Fix the shared-directories "both locations" doc bug in `workspace.md:190-191`
    (either/or per `SharedDir.InWorkspace`, not always-both).
 3. Update `skills.md:233-240` inject_when table if needed.
@@ -442,8 +444,11 @@ The QA tester should verify:
    - Agent in a project with no `scion.dev/workspace-mode` label.
    - `SCION_WORKSPACE_MODE` → `shared-plain`.
 
-6. **`SCION_SHARED_WORKSPACE` still emitted** (if OQ3 → retain):
-   - Existing shared-plain git agents still receive `SCION_SHARED_WORKSPACE=true`.
+6. **`SCION_SHARED_WORKSPACE` backward compatibility (OQ3 deprecation):**
+   - Existing shared-plain git agents still receive `SCION_SHARED_WORKSPACE=true`
+     (emitted unchanged; deprecation period is in effect).
+   - `sciontool init` works correctly when only `SCION_SHARED_WORKSPACE` is
+     present (older broker, no new vars) AND when only the new vars are present.
 
 7. **Documentation:**
    - `workspace.md` or `workspaces-and-sharing.md` documents both new vars.

--- a/.design/workspace-mode-env.md
+++ b/.design/workspace-mode-env.md
@@ -1,0 +1,454 @@
+# Design: Surface Workspace Sharing Mode to Agents via Provisioning Env Vars
+
+**Issue:** [ptone/scion#572](https://github.com/ptone/scion/issues/572)  
+**Project slug:** `workspace-mode-env`  
+**Status:** Draft — 3 open questions pending user input (see §Open Questions)
+
+---
+
+## Problem & Goals
+
+Agents cannot discover how their workspace is provisioned. The workspace sharing
+mode taxonomy (`shared-plain` / `clone-per-agent` / `worktree-per-agent`) is
+fully implemented in the store and threaded through the broker, but is never
+surfaced into the agent container. An agent cannot answer "can another agent see
+or overwrite my edits?" at runtime without knowing its mode.
+
+This has two concrete downstream consequences today:
+
+1. The `git-sandbox` platform skill (`inject_when: git_workspace`) assumes
+   worktree semantics ("air-gapped from origin," "cannot `git checkout main`")
+   — both assertions are false for `clone-per-agent`, where the agent owns a
+   full clone with a live remote. Agents in that mode receive confidently-worded,
+   incorrect git instructions.
+
+2. Any future mode-aware content (mandatory boilerplate, skills, agent
+   instructions) has no env var to branch on, so it would have to be gated at
+   provisioning time via `inject_when` — a mechanism the design doc
+   `.design/builtin-skills.md` notes "may go away soon."
+
+**Goals:**
+
+- Emit `SCION_WORKSPACE_MODE` (canonical string) and `SCION_WORKSPACE_GIT`
+  (boolean) into every agent container env.
+- Fix the `WorkspaceMode` propagation gap on `startAgent` and `restartAgent`
+  paths so restarted/resumed agents receive the correct mode rather than
+  silently falling back to `shared-plain`.
+- Leave scope for follow-on work: updating mandatory boilerplate and
+  consolidating the `git-sandbox` skill.
+
+**Non-Goals:**
+
+- Updating `mandatory_boilerplate/agent-instructions-preamble.md` — that is
+  explicitly listed as follow-on work in the issue.
+- Consolidating or rewriting the `git-sandbox` platform skill — follow-on.
+- Adding derived vars like `SCION_WORKSPACE_ISOLATION` — a second source of
+  truth for what mode already encodes invites drift; excluded by design.
+- Changing the `inject_when` mechanism or adding new `inject_when` conditions.
+
+---
+
+## Proposed Design
+
+Three changes ship together (dependency ordering: Change 3 → Change 1 → Change 2).
+
+### Change 1 — Emit `SCION_WORKSPACE_MODE`
+
+**File:** `pkg/runtimebroker/start_context.go`  
+**Location:** Step 5 "Agent identity env" block (~line 298), alongside
+`SCION_AGENT_ID` and peers.
+
+```go
+// Emit canonical workspace sharing mode.
+// On the create path, in.WorkspaceMode carries the wire label (e.g. "per-agent").
+// On start/restart paths, in.WorkspaceMode is empty but the hub pre-resolves
+// the canonical value into resolvedEnv["SCION_WORKSPACE_MODE"] (Change 3).
+// Either way, one code path produces a consistent env var.
+if in.WorkspaceMode != "" {
+    env["SCION_WORKSPACE_MODE"] = string(store.ResolveWorkspaceSharingMode(in.WorkspaceMode))
+}
+// If in.WorkspaceMode is empty, the hub-injected value (if any) already
+// arrived via resolvedEnv and was merged into env before this block.
+// Add a guaranteed fallback so the var is always present:
+if env["SCION_WORKSPACE_MODE"] == "" {
+    env["SCION_WORKSPACE_MODE"] = string(store.SharingModeSharedPlain)
+}
+```
+
+**Value contract** (pending user confirmation — Open Question 1):
+
+| Wire label (stored in project labels) | `SCION_WORKSPACE_MODE` value |
+|---|---|
+| `shared` or `""` | `shared-plain` |
+| `per-agent` | `clone-per-agent` |
+| `worktree-per-agent` | `worktree-per-agent` |
+
+`store.ResolveWorkspaceSharingMode()` (`pkg/store/models.go:225`) already
+implements this mapping and defaults empty/unknown to `shared-plain`.
+
+**Why always emit** (not conditional like `SCION_SHARED_WORKSPACE`):  
+Agents should always be able to read their mode. A missing var forces agents to
+assume `shared-plain` anyway — making the default explicit is clearer.
+
+---
+
+### Change 2 — Emit `SCION_WORKSPACE_GIT`
+
+**File:** `pkg/runtimebroker/start_context.go`  
+**Location:** After the git-clone/worktree provisioning block (~line 497), once
+`worktreeProvisioned` and `opts.GitClone` are settled.
+
+```go
+// Emit SCION_WORKSPACE_GIT when the workspace is a git repository.
+// Mode alone is insufficient: shared-plain may be git-backed or not.
+isGitWorkspace := worktreeProvisioned || opts.GitClone != nil
+if !isGitWorkspace {
+    // Covers shared-plain git workspaces on create path (opts.Workspace is
+    // the mounted directory, already populated on disk).
+    if opts.Workspace != "" {
+        isGitWorkspace = util.IsGitRepoDir(opts.Workspace)
+    }
+}
+if !isGitWorkspace {
+    // Final fallback for start/restart paths where neither opts.GitClone nor
+    // an on-disk git dir is present (e.g. clone-per-agent before the
+    // in-container clone executes). Hub injects this via resolvedEnv (Change 3).
+    isGitWorkspace = in.ResolvedEnv["SCION_WORKSPACE_GIT"] == "true"
+}
+if isGitWorkspace {
+    env["SCION_WORKSPACE_GIT"] = "true"
+}
+// Absent when false — avoids encoding a "false" string agents must parse.
+```
+
+**Why a separate var from mode:**  
+`shared-plain` may be git-backed — `pkg/hub/handlers_projects_core.go:309`
+permits `WorkspaceModeShared` for git projects, and the glossary states Linked
+projects "may be plain or git-backed." Mode alone cannot disambiguate.
+
+**Why absent rather than `"false"`:**  
+Following the `SCION_SHARED_WORKSPACE` and other boolean-presence idiom in the
+codebase. Agents test for presence/truth; absence equals false.
+
+---
+
+### Change 3 — Fix `WorkspaceMode` Propagation on Start and Restart
+
+This is a correctness bug independent of Changes 1 and 2, but it is the
+**prerequisite** for Changes 1 and 2 to work correctly on start/restart paths.
+
+#### Root cause
+
+`WorkspaceMode` is only populated on the create path
+(`pkg/runtimebroker/handlers.go:669`). The `startAgent` (~:1299) and
+`restartAgent` (~:1558) handlers pass `startContextInputs` with
+`WorkspaceMode: ""`, causing `ResolveWorkspaceSharingMode("")` to return
+`shared-plain` — the most permissive mode, and wrong for isolated workspaces.
+
+The same gap exists on the hub dispatch side: neither
+`DispatchAgentStart` nor `DispatchAgentRestart` in
+`pkg/hub/httpdispatcher.go` send `WorkspaceMode` to the broker, even though
+`projectInfo.workspaceMode` is already populated at `httpdispatcher.go:771`.
+
+#### Chosen approach: hub-side resolvedEnv injection
+
+Inject `SCION_WORKSPACE_MODE` (canonical value) and `SCION_WORKSPACE_GIT`
+into the `resolvedEnv` map that the hub already builds for both start and
+restart dispatch calls. This follows the existing pattern used for
+`SCION_AGENT_ID`, `SCION_GROVE_ID`, `SCION_HUB_ENDPOINT`, and
+`SCION_METADATA_MODE` — the hub surfaces values the broker's request body
+doesn't carry by pre-populating them in `resolvedEnv`.
+
+**Hub-side changes (both `DispatchAgentStart` ~:1287 and
+`DispatchAgentRestart` ~:1479 in `pkg/hub/httpdispatcher.go`):**
+
+```go
+// Inject workspace mode alongside existing identity vars
+// (alongside the SCION_AGENT_ID/SCION_GROVE_ID/SCION_AGENT_SLUG block)
+if projectInfo.workspaceMode != "" {
+    resolvedEnv["SCION_WORKSPACE_MODE"] = string(
+        store.ResolveWorkspaceSharingMode(projectInfo.workspaceMode))
+}
+// Inject git-ness: per-agent and worktree-per-agent are always git-backed.
+// For shared mode, check the agent's applied config for a git clone URL.
+switch projectInfo.workspaceMode {
+case store.WorkspaceModePerAgent, store.WorkspaceModeWorktreePerAgent:
+    resolvedEnv["SCION_WORKSPACE_GIT"] = "true"
+case store.WorkspaceModeShared, "":
+    if agent.AppliedConfig != nil && agent.AppliedConfig.GitClone != nil {
+        resolvedEnv["SCION_WORKSPACE_GIT"] = "true"
+    }
+}
+```
+
+**Broker-side change (none beyond Changes 1 and 2):**  
+Because `resolvedEnv` is merged into `env` early in `buildStartContext`, and
+Change 1 only overwrites `env["SCION_WORKSPACE_MODE"]` when
+`in.WorkspaceMode != ""` (create path only), the hub-injected canonical value
+passes through unchanged on start/restart paths. Change 2's fallback
+`in.ResolvedEnv["SCION_WORKSPACE_GIT"] == "true"` reads the same injection.
+
+#### Why not add `WorkspaceMode` to `StartAgent`/`RestartAgent` signatures
+
+The alternative (Approach A) is to add `workspaceMode string` to every
+`StartAgent` and `RestartAgent` function signature. That interface has
+**8 implementations** (HTTPRuntimeBrokerClient, AuthenticatedBrokerClient,
+ControlChannelBrokerClient, HybridBrokerClient, and their test doubles), plus
+every call site in the hub transport layer and broker HTTP handler.
+
+The resolvedEnv pattern is already the established mechanism for exactly this
+class of problem (hub → broker info that the request body doesn't carry). It
+requires changes in two hub dispatch functions and two broker functions — far
+narrower blast radius.
+
+**Trade-off:** The resolvedEnv approach adds an implicit coupling rather than a
+type-checked parameter. Mitigation: the injection sites are co-located with
+the existing identity-var injection block, and missing injection is caught at
+test time by verifying the env var in start/restart integration tests.
+
+---
+
+### Documentation Changes
+
+1. **`docs-site/src/content/docs/local/workspace.md`** (or
+   `workspaces-and-sharing.md`) — Add a section documenting `SCION_WORKSPACE_MODE`
+   and `SCION_WORKSPACE_GIT` under the sharing-mode discussion. Note the three
+   canonical values and the boolean-presence contract for `SCION_WORKSPACE_GIT`.
+
+2. **`docs-site/src/content/docs/local/skills.md:233-240`** — The `inject_when`
+   table may need updating if the follow-on work adds a `workspace_mode` condition;
+   leave unchanged in this PR unless the `inject_when` mechanism is touched.
+
+3. **Inline doc fix** (carry along):
+   `docs-site/src/content/docs/local/workspace.md:190-191` states shared
+   directories appear at **both** `/scion-volumes/<name>` and
+   `/workspace/.scion-volumes/<name>` by default. The code makes this
+   per-directory via `SharedDir.InWorkspace`. Correct the prose to "either/or
+   depending on the directory's `in_workspace` setting."
+
+---
+
+## Alternatives Considered
+
+### Alt 1: Emit the wire label, not the canonical value (for `SCION_WORKSPACE_MODE`)
+
+Expose `"shared"` / `"per-agent"` / `"worktree-per-agent"` directly.
+
+**Rejected:** The wire labels are a legacy implementation artifact — they appear
+in project K/V labels and existed before the canonical glossary was written.
+Exposing them to agents bakes in a historical accident. The canonical values are
+in the glossary and already used in all post-refactor documentation. Agents
+reading the env var should see the glossary-aligned names. (Open Question 1
+confirms this with the user before finalizing.)
+
+### Alt 2: Encode git-ness in `SCION_WORKSPACE_MODE` (no separate `SCION_WORKSPACE_GIT`)
+
+A `shared-git` fourth mode or a `shared-plain-git` sub-mode could unify the two
+signals.
+
+**Rejected:** The three-mode taxonomy is established in the glossary and in the
+`WorkspaceSharingMode` constants. Adding a fourth mode to carry git-ness for
+one case (shared-plain git) would require updating all mode switches and
+documentation. A separate boolean is cheaper and maps cleanly to the actual
+orthogonality: mode describes *who shares what*, git-ness describes *what
+storage backend is in use*.
+
+### Alt 3: Derive git-ness at runtime from the `.git` directory (no `SCION_WORKSPACE_GIT` env var)
+
+Agents could simply check for the presence of `.git/` at `/workspace/.git`.
+
+**Rejected:** An env var is faster (no filesystem read at startup), available
+before any directory access, and consistent with how other workspace properties
+are surfaced. It also works correctly in the worktree case, where `/workspace`
+is a worktree directory that contains `.git` as a file, not a directory — a
+nuance that agents would have to know to handle.
+
+### Alt 4: Add `WorkspaceMode` to `StartAgent`/`RestartAgent` signatures (for Change 3)
+
+Type-safe threading of the wire label through all 8 interface implementations
+and test doubles.
+
+**Rejected in favor of resolvedEnv injection.** The resolvedEnv pattern is the
+established precedent for this flow and the blast radius is much smaller. If the
+signatures need extending for other reasons in the future, `WorkspaceMode` could
+be added then.
+
+### Alt 5: Broker-side lookup — read WorkspaceMode from running container labels
+
+The broker could list running containers, find the agent by ID, and read a
+container label set at create time.
+
+**Rejected:** WorkspaceMode is not currently stored as a container label. Adding
+a label would require a parallel change (and labels are not guaranteed to be
+present if the container was created by an older broker version). The resolvedEnv
+approach requires zero new storage.
+
+---
+
+## Migration / Rollout
+
+**Backward compatibility:**
+
+- `SCION_WORKSPACE_MODE` and `SCION_WORKSPACE_GIT` are new env vars. Existing
+  agents that don't read them are unaffected.
+- `SCION_WORKSPACE_MODE` defaults to `shared-plain` for empty/unknown wire
+  labels (the current implicit behavior); nothing changes for existing projects
+  without an explicit mode label.
+- `SCION_SHARED_WORKSPACE` continues to be emitted (no removal in this PR).
+  Open Question 3 covers deprecation.
+
+**Forward compatibility:**
+
+- The canonical value set (`shared-plain`, `clone-per-agent`, `worktree-per-agent`)
+  matches the glossary and is stable. New modes, if ever added, would require
+  a new case in `ResolveWorkspaceSharingMode` and a doc update — no env var
+  contract break for existing values.
+- The `SCION_WORKSPACE_GIT` absence-equals-false contract is stable: future
+  git-backed modes would simply set the var.
+
+**Rollout:**
+
+- Hub and broker versions can deploy independently. If a new hub talks to an
+  old broker, the old broker ignores the new identity vars in resolvedEnv
+  (they arrive in the env but do nothing without the broker-side Change 1/2
+  code). If an old hub talks to a new broker, the broker falls back to
+  `shared-plain` for start/restart (same behavior as today, no regression).
+- No database migrations. No API version bumps needed.
+
+---
+
+## Open Questions
+
+Three decisions require user input before the design can be finalized.
+Raised serially below; do not continue past each until the user replies.
+
+**OQ1 — Canonical vs. wire labels in `SCION_WORKSPACE_MODE`:**  
+The design above emits canonical values (`shared-plain`, `clone-per-agent`,
+`worktree-per-agent`). This aligns with the glossary and the issue's
+recommendation. Confirm this is correct, or specify if wire labels (`shared`,
+`per-agent`, `worktree-per-agent`) are preferred. This decision is
+**load-bearing** — the string values baked into the env var become an agent API
+contract.
+
+**OQ2 — Ship Change 3 (WorkspaceMode propagation fix) with this PR or separately:**  
+Change 3 is a correctness bug on its own merits — restarted/resumed agents
+currently fall back to `shared-plain` regardless of their actual isolation
+level. Two options:
+- **Option A (together):** Ship Change 3 in the same PR. The fix is a
+  prerequisite for Changes 1 and 2 to be correct on restart paths.
+  Slightly larger PR, but logically cohesive.
+- **Option B (split):** File a separate issue for Change 3 (broker
+  WorkspaceMode propagation bug), fix it first, then ship Changes 1 and 2
+  in a follow-up. Cleaner history, but requires coordination between two PRs
+  and a narrow window where agents on restart still get wrong mode.
+
+The design doc is written to support either. This decision affects the phased
+plan below.
+
+**OQ3 — Deprecate `SCION_SHARED_WORKSPACE` once `SCION_WORKSPACE_MODE` lands:**  
+`SCION_SHARED_WORKSPACE=true` is currently consumed only by
+`sciontool init` (`cmd/sciontool/commands/init.go:330`) to detect shared-plain
+git workspaces. With `SCION_WORKSPACE_MODE=shared-plain` and
+`SCION_WORKSPACE_GIT=true` available, sciontool could read those instead.
+Two options:
+- **Option A (deprecate):** Keep emitting `SCION_SHARED_WORKSPACE` in this PR
+  for backward compat, update sciontool to read the new vars, then remove the
+  old var in a follow-up.
+- **Option B (retain independently):** Keep `SCION_SHARED_WORKSPACE` as-is
+  indefinitely; it serves a narrow sciontool bootstrap purpose and the
+  consolidation cost may not be worth it.
+
+---
+
+## Implementation Phases
+
+*(Adjusts based on answer to OQ2. Shown here as Option A — all together.)*
+
+### Phase 0 — Bug fix: WorkspaceMode propagation (Change 3)
+
+**Commit scope:** Hub (`pkg/hub/httpdispatcher.go`) only.
+
+1. In `DispatchAgentStart` (~:1287), add `SCION_WORKSPACE_MODE` (canonical) and
+   `SCION_WORKSPACE_GIT` to the resolvedEnv block alongside existing identity
+   vars.
+2. In `DispatchAgentRestart` (~:1479), same injection.
+3. Add unit tests verifying that start and restart resolvedEnv maps contain the
+   correct canonical values for each of the three modes.
+
+### Phase 1 — Emit `SCION_WORKSPACE_MODE` (Change 1)
+
+**Commit scope:** `pkg/runtimebroker/start_context.go`.
+
+1. In step 5 "Agent identity env" (~:298): add the `SCION_WORKSPACE_MODE`
+   emission using the conditional + fallback logic from the design above.
+2. Add tests:
+   - Create path with each of the three wire labels → correct canonical output.
+   - Start path with empty `WorkspaceMode` and hub-injected resolvedEnv →
+     correct canonical value.
+   - Empty/unrecognized mode → `shared-plain`.
+
+### Phase 2 — Emit `SCION_WORKSPACE_GIT` (Change 2)
+
+**Commit scope:** `pkg/runtimebroker/start_context.go`.
+
+1. After the git-clone/worktree block (~:497): add the `isGitWorkspace`
+   determination and `SCION_WORKSPACE_GIT` emission.
+2. Add tests:
+   - Worktree-provisioned path → `SCION_WORKSPACE_GIT=true`.
+   - Create path with `GitClone` config → `SCION_WORKSPACE_GIT=true`.
+   - Shared-plain with git workspace on disk → `SCION_WORKSPACE_GIT=true`.
+   - Start/restart path with hub-injected `SCION_WORKSPACE_GIT=true` →
+     var present.
+   - Non-git shared workspace → var absent.
+
+### Phase 3 — Documentation
+
+**Commit scope:** `docs-site/`.
+
+1. Add "Runtime Environment Variables" section to `workspace.md` or
+   `workspaces-and-sharing.md` documenting `SCION_WORKSPACE_MODE` (values,
+   defaults) and `SCION_WORKSPACE_GIT` (boolean-presence contract).
+2. Fix the shared-directories "both locations" doc bug in `workspace.md:190-191`
+   (either/or per `SharedDir.InWorkspace`, not always-both).
+3. Update `skills.md:233-240` inject_when table if needed.
+
+---
+
+## Acceptance Criteria
+
+The QA tester should verify:
+
+1. **Create path — all three modes:**
+   - Spawn an agent in each of `shared-plain`, `clone-per-agent`, and
+     `worktree-per-agent` projects.
+   - Inside each agent: `echo $SCION_WORKSPACE_MODE` returns the correct
+     canonical value.
+
+2. **Create path — `SCION_WORKSPACE_GIT`:**
+   - Agent in a git-backed project: `echo $SCION_WORKSPACE_GIT` → `true`.
+   - Agent in a plain (non-git) project: `SCION_WORKSPACE_GIT` is unset.
+
+3. **Start (resume) path:**
+   - Stop and re-start an agent in a `clone-per-agent` project.
+   - Inside the restarted agent: `SCION_WORKSPACE_MODE` → `clone-per-agent`
+     (not `shared-plain`).
+   - `SCION_WORKSPACE_GIT` → `true`.
+
+4. **Restart path:**
+   - Trigger a restart for an agent in a `worktree-per-agent` project.
+   - Inside the restarted agent: `SCION_WORKSPACE_MODE` → `worktree-per-agent`.
+
+5. **Default (no mode label):**
+   - Agent in a project with no `scion.dev/workspace-mode` label.
+   - `SCION_WORKSPACE_MODE` → `shared-plain`.
+
+6. **`SCION_SHARED_WORKSPACE` still emitted** (if OQ3 → retain):
+   - Existing shared-plain git agents still receive `SCION_SHARED_WORKSPACE=true`.
+
+7. **Documentation:**
+   - `workspace.md` or `workspaces-and-sharing.md` documents both new vars.
+   - The shared-directories "both locations" paragraph is corrected.
+
+8. **No regression:**
+   - Existing agents in plain projects function unchanged.
+   - `sciontool init` continues to work in shared-plain git workspaces.

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -327,7 +327,7 @@ func runInit(args []string) int {
 
 	// Configure git credentials for shared-workspace projects (git-workspace hybrid).
 	// The workspace is pre-cloned on the host; agents need credentials to push/pull.
-	if os.Getenv("SCION_SHARED_WORKSPACE") == "true" {
+	if resolveIsSharedGitWorkspace() {
 		configureSharedWorkspaceGit(agentHome)
 	}
 
@@ -1675,6 +1675,26 @@ func ensureWorkspaceOwnership(workspacePath string, uid, gid, currentEUID int, c
 	if err := chown(workspacePath, uid, gid); err != nil {
 		log.Error("Failed to chown workspace to UID=%d GID=%d: %v", uid, gid, err)
 	}
+}
+
+// resolveIsSharedGitWorkspace returns true when the agent is in a shared-plain
+// git workspace and should configure git credentials accordingly.
+//
+// Prefers the new canonical workspace mode env vars (SCION_WORKSPACE_MODE +
+// SCION_WORKSPACE_GIT) emitted by brokers >= workspace-mode-env release.
+// Falls back to the legacy SCION_SHARED_WORKSPACE var for older broker versions
+// that don't yet emit the new vars.
+//
+// Deprecated: SCION_SHARED_WORKSPACE — use SCION_WORKSPACE_MODE + SCION_WORKSPACE_GIT.
+// Removal is tracked in https://github.com/ptone/scion/issues/575.
+func resolveIsSharedGitWorkspace() bool {
+	if workspaceMode := os.Getenv("SCION_WORKSPACE_MODE"); workspaceMode != "" {
+		// New path: broker emits canonical workspace mode vars.
+		// A shared-plain workspace is git-backed when SCION_WORKSPACE_GIT=true.
+		return workspaceMode == "shared-plain" && os.Getenv("SCION_WORKSPACE_GIT") == "true"
+	}
+	// Fallback: older broker that only emits SCION_SHARED_WORKSPACE.
+	return os.Getenv("SCION_SHARED_WORKSPACE") == "true"
 }
 
 // configureSharedWorkspaceGit sets up git credentials for shared-workspace

--- a/cmd/sciontool/commands/init_test.go
+++ b/cmd/sciontool/commands/init_test.go
@@ -895,3 +895,71 @@ func TestEnsureWorkspaceOwnership_ChownsWhenRoot(t *testing.T) {
 		t.Fatalf("unexpected chown call: path=%q uid=%d gid=%d", gotPath, gotUID, gotGID)
 	}
 }
+
+// TestResolveIsSharedGitWorkspace verifies the compat shim logic for detecting
+// a shared-plain git workspace. It covers both the new canonical vars and the
+// legacy SCION_SHARED_WORKSPACE fallback path.
+func TestResolveIsSharedGitWorkspace(t *testing.T) {
+	cases := []struct {
+		name          string
+		workspaceMode string
+		workspaceGit  string
+		sharedLegacy  string
+		want          bool
+	}{
+		{
+			name:          "new vars: shared-plain + git → true",
+			workspaceMode: "shared-plain",
+			workspaceGit:  "true",
+			want:          true,
+		},
+		{
+			name:          "new vars: clone-per-agent + git → false (not shared)",
+			workspaceMode: "clone-per-agent",
+			workspaceGit:  "true",
+			want:          false,
+		},
+		{
+			name:          "new vars: shared-plain without git → false",
+			workspaceMode: "shared-plain",
+			workspaceGit:  "",
+			want:          false,
+		},
+		{
+			name:          "new vars: worktree-per-agent + git → false (not shared)",
+			workspaceMode: "worktree-per-agent",
+			workspaceGit:  "true",
+			want:          false,
+		},
+		{
+			name:         "legacy: SCION_SHARED_WORKSPACE=true → true (fallback)",
+			sharedLegacy: "true",
+			want:         true,
+		},
+		{
+			name:         "legacy: SCION_SHARED_WORKSPACE absent → false",
+			sharedLegacy: "",
+			want:         false,
+		},
+		{
+			name:          "new vars take precedence: mode set + legacy true → follows mode",
+			workspaceMode: "clone-per-agent",
+			workspaceGit:  "true",
+			sharedLegacy:  "true",
+			want:          false, // mode=clone-per-agent means not shared-plain
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SCION_WORKSPACE_MODE", tc.workspaceMode)
+			t.Setenv("SCION_WORKSPACE_GIT", tc.workspaceGit)
+			t.Setenv("SCION_SHARED_WORKSPACE", tc.sharedLegacy)
+
+			got := resolveIsSharedGitWorkspace()
+			if got != tc.want {
+				t.Errorf("resolveIsSharedGitWorkspace() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/docs-site/src/content/docs/local/workspace.md
+++ b/docs-site/src/content/docs/local/workspace.md
@@ -184,11 +184,13 @@ scion shared-dir remove <name>
 
 ### Mounting Shared Directories
 
-When an agent is created in a project that has shared directories, they are automatically mounted into the agent's container. 
+When an agent is created in a project that has shared directories, they are automatically mounted into the agent's container.
 
-By default, they are available at two locations within the agent:
-- **Standard Path:** `/scion-volumes/<name>`
-- **Workspace Path:** `/workspace/.scion-volumes/<name>`
+Each shared directory's mount location depends on its `in_workspace` setting:
+- **`in_workspace: false` (default):** `/scion-volumes/<name>` — mounted at the standard volume path, outside the workspace.
+- **`in_workspace: true`:** `/workspace/.scion-volumes/<name>` — mounted inside the workspace tree.
+
+A shared directory is mounted at one of these locations, not both.
 
 ### Web Dashboard File Viewer
 

--- a/docs-site/src/content/docs/local/workspaces-and-sharing.md
+++ b/docs-site/src/content/docs/local/workspaces-and-sharing.md
@@ -61,6 +61,30 @@ A useful rule of thumb:
 
 Note that the same git project used locally with worktrees may switch to clone-based provisioning once it is managed by a Hub, because Worktree-per-agent is not yet supported for Hub-managed projects.
 
+## Runtime environment variables
+
+Agents can discover their workspace provisioning at startup through two environment variables emitted by the broker into every container.
+
+### `SCION_WORKSPACE_MODE`
+
+The canonical workspace sharing mode for the project. Always present; defaults to `shared-plain` when no mode label is set.
+
+| Value | Description |
+|---|---|
+| `shared-plain` | One workspace directory shared by all agents (no per-agent isolation). |
+| `clone-per-agent` | Each agent has its own full git clone. |
+| `worktree-per-agent` | Each agent has its own git worktree over a shared checkout. |
+
+**Example:** An agent in a Hub-managed git project reads `SCION_WORKSPACE_MODE=clone-per-agent` to know it has a private checkout and can safely commit without affecting other agents.
+
+### `SCION_WORKSPACE_GIT`
+
+Present (value `"true"`) when the workspace is a git repository. Absent when the workspace is not git-backed.
+
+`SCION_WORKSPACE_GIT` is separate from `SCION_WORKSPACE_MODE` because `shared-plain` can be either git-backed or a plain directory — the mode alone cannot disambiguate. Absent means false; there is no `"false"` string value.
+
+**Compatibility note:** Older broker versions emitted only `SCION_SHARED_WORKSPACE=true` for shared-plain git workspaces. The `sciontool init` compat shim prefers the new vars and falls back to `SCION_SHARED_WORKSPACE` when they are absent. `SCION_SHARED_WORKSPACE` is deprecated and tracked for removal in [ptone/scion#575](https://github.com/ptone/scion/issues/575).
+
 ## Related workspace concepts
 
 A few adjacent terms are worth distinguishing from the sharing mode itself:

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -1302,6 +1302,23 @@ func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *sto
 		resolvedEnv["SCION_HUB_ENDPOINT"] = d.hubEndpoint
 	}
 
+	// Inject canonical workspace sharing mode and git-ness so the broker can
+	// surface them in the container env on the start path.  The createAgent
+	// path carries these via WorkspaceMode in the request body; the startAgent
+	// path relies on resolvedEnv injection (this block) following the existing
+	// SCION_AGENT_ID / SCION_METADATA_MODE pattern.
+	if projectInfo.workspaceMode != "" {
+		resolvedEnv["SCION_WORKSPACE_MODE"] = string(store.ResolveWorkspaceSharingMode(projectInfo.workspaceMode))
+	}
+	switch projectInfo.workspaceMode {
+	case store.WorkspaceModePerAgent, store.WorkspaceModeWorktreePerAgent:
+		resolvedEnv["SCION_WORKSPACE_GIT"] = "true"
+	case store.WorkspaceModeShared, "":
+		if agent.AppliedConfig != nil && agent.AppliedConfig.GitClone != nil {
+			resolvedEnv["SCION_WORKSPACE_GIT"] = "true"
+		}
+	}
+
 	// Inject GCP identity env vars so the broker can configure the
 	// metadata-server sidecar correctly on (re-)start.  During the
 	// createAgent path this information travels inside CreateAgentConfig,
@@ -1487,6 +1504,22 @@ func (d *HTTPAgentDispatcher) DispatchAgentRestart(ctx context.Context, agent *s
 	}
 	if d.hubEndpoint != "" {
 		resolvedEnv["SCION_HUB_ENDPOINT"] = d.hubEndpoint
+	}
+
+	// Inject canonical workspace sharing mode and git-ness so the broker can
+	// surface them in the container env on the restart path.  Follows the same
+	// pattern as DispatchAgentStart.
+	projectInfo := d.resolveDispatchProjectInfo(ctx, agent)
+	if projectInfo.workspaceMode != "" {
+		resolvedEnv["SCION_WORKSPACE_MODE"] = string(store.ResolveWorkspaceSharingMode(projectInfo.workspaceMode))
+	}
+	switch projectInfo.workspaceMode {
+	case store.WorkspaceModePerAgent, store.WorkspaceModeWorktreePerAgent:
+		resolvedEnv["SCION_WORKSPACE_GIT"] = "true"
+	case store.WorkspaceModeShared, "":
+		if agent.AppliedConfig != nil && agent.AppliedConfig.GitClone != nil {
+			resolvedEnv["SCION_WORKSPACE_GIT"] = "true"
+		}
 	}
 
 	injectModelEnv(resolvedEnv, agent.AppliedConfig)

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -1307,13 +1307,17 @@ func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *sto
 	// path carries these via WorkspaceMode in the request body; the startAgent
 	// path relies on resolvedEnv injection (this block) following the existing
 	// SCION_AGENT_ID / SCION_METADATA_MODE pattern.
+	//
+	// Resolve once so the switch below uses canonical constants — unrecognized
+	// or future wire labels safely fall back to shared-plain behavior.
+	resolvedMode := store.ResolveWorkspaceSharingMode(projectInfo.workspaceMode)
 	if projectInfo.workspaceMode != "" {
-		resolvedEnv["SCION_WORKSPACE_MODE"] = string(store.ResolveWorkspaceSharingMode(projectInfo.workspaceMode))
+		resolvedEnv["SCION_WORKSPACE_MODE"] = string(resolvedMode)
 	}
-	switch projectInfo.workspaceMode {
-	case store.WorkspaceModePerAgent, store.WorkspaceModeWorktreePerAgent:
+	switch resolvedMode {
+	case store.SharingModeClonePerAgent, store.SharingModeWorktreePerAgent:
 		resolvedEnv["SCION_WORKSPACE_GIT"] = "true"
-	case store.WorkspaceModeShared, "":
+	case store.SharingModeSharedPlain:
 		// For shared-plain, git-ness is detected from the applied GitClone config.
 		// Note: broker-local linked projects where the workspace is already a
 		// git repo on disk but has no HTTPS GitClone config cannot be detected
@@ -1515,15 +1519,16 @@ func (d *HTTPAgentDispatcher) DispatchAgentRestart(ctx context.Context, agent *s
 
 	// Inject canonical workspace sharing mode and git-ness so the broker can
 	// surface them in the container env on the restart path.  Follows the same
-	// pattern as DispatchAgentStart.
+	// pattern as DispatchAgentStart (resolve once, switch on canonical constants).
 	projectInfo := d.resolveDispatchProjectInfo(ctx, agent)
+	resolvedMode := store.ResolveWorkspaceSharingMode(projectInfo.workspaceMode)
 	if projectInfo.workspaceMode != "" {
-		resolvedEnv["SCION_WORKSPACE_MODE"] = string(store.ResolveWorkspaceSharingMode(projectInfo.workspaceMode))
+		resolvedEnv["SCION_WORKSPACE_MODE"] = string(resolvedMode)
 	}
-	switch projectInfo.workspaceMode {
-	case store.WorkspaceModePerAgent, store.WorkspaceModeWorktreePerAgent:
+	switch resolvedMode {
+	case store.SharingModeClonePerAgent, store.SharingModeWorktreePerAgent:
 		resolvedEnv["SCION_WORKSPACE_GIT"] = "true"
-	case store.WorkspaceModeShared, "":
+	case store.SharingModeSharedPlain:
 		// See DispatchAgentStart for the acknowledged limitation: broker-local
 		// linked projects without a GitClone config cannot be detected as
 		// git-backed here.

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -1314,6 +1314,13 @@ func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *sto
 	case store.WorkspaceModePerAgent, store.WorkspaceModeWorktreePerAgent:
 		resolvedEnv["SCION_WORKSPACE_GIT"] = "true"
 	case store.WorkspaceModeShared, "":
+		// For shared-plain, git-ness is detected from the applied GitClone config.
+		// Note: broker-local linked projects where the workspace is already a
+		// git repo on disk but has no HTTPS GitClone config cannot be detected
+		// as git-backed here. The broker's on-disk util.IsGitRepoDir check in
+		// buildStartContext covers this for the create path; on start/restart paths
+		// SCION_WORKSPACE_GIT will be absent for such workspaces. This is an
+		// acknowledged limitation noted in the design doc.
 		if agent.AppliedConfig != nil && agent.AppliedConfig.GitClone != nil {
 			resolvedEnv["SCION_WORKSPACE_GIT"] = "true"
 		}
@@ -1517,6 +1524,9 @@ func (d *HTTPAgentDispatcher) DispatchAgentRestart(ctx context.Context, agent *s
 	case store.WorkspaceModePerAgent, store.WorkspaceModeWorktreePerAgent:
 		resolvedEnv["SCION_WORKSPACE_GIT"] = "true"
 	case store.WorkspaceModeShared, "":
+		// See DispatchAgentStart for the acknowledged limitation: broker-local
+		// linked projects without a GitClone config cannot be detected as
+		// git-backed here.
 		if agent.AppliedConfig != nil && agent.AppliedConfig.GitClone != nil {
 			resolvedEnv["SCION_WORKSPACE_GIT"] = "true"
 		}

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -3736,53 +3736,120 @@ func TestHTTPAgentDispatcher_DispatchAgentStart_InjectsWorkspaceMode(t *testing.
 
 // TestHTTPAgentDispatcher_DispatchAgentRestart_InjectsWorkspaceMode verifies that
 // DispatchAgentRestart injects SCION_WORKSPACE_MODE and SCION_WORKSPACE_GIT into
-// resolvedEnv, following the same semantics as the start path.
+// resolvedEnv, following the same semantics as DispatchAgentStart. Uses a table
+// matching the DispatchAgentStart test cases so coverage is symmetric.
 func TestHTTPAgentDispatcher_DispatchAgentRestart_InjectsWorkspaceMode(t *testing.T) {
 	ctx := context.Background()
-	memStore := createTestStore(t)
 
-	project := &store.Project{
-		ID:        tid("proj-restart-wm"),
-		Name:      "restart-wm-test",
-		Slug:      "restart-wm-test",
-		GitRemote: "https://github.com/example/repo.git",
-		Labels:    map[string]string{store.LabelWorkspaceMode: store.WorkspaceModePerAgent},
-	}
-	if err := memStore.CreateProject(ctx, project); err != nil {
-		t.Fatalf("failed to create project: %v", err)
+	type testCase struct {
+		name               string
+		workspaceModeLabel string
+		gitRemote          string
+		appliedGitClone    *api.GitCloneConfig
+		wantMode           string
+		wantGit            bool
 	}
 
-	broker := &store.RuntimeBroker{
-		ID:       tid("broker-restart-wm"),
-		Name:     "test-broker",
-		Slug:     "test-broker",
-		Endpoint: "http://localhost:9800",
-		Status:   store.BrokerStatusOnline,
-	}
-	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
-		t.Fatalf("failed to create runtime broker: %v", err)
+	cases := []testCase{
+		{
+			name:               "shared-plain no git",
+			workspaceModeLabel: store.WorkspaceModeShared,
+			wantMode:           "shared-plain",
+			wantGit:            false,
+		},
+		{
+			name:               "shared-plain with git clone in applied config",
+			workspaceModeLabel: store.WorkspaceModeShared,
+			gitRemote:          "https://github.com/example/repo.git",
+			appliedGitClone:    &api.GitCloneConfig{URL: "https://github.com/example/repo.git"},
+			wantMode:           "shared-plain",
+			wantGit:            true,
+		},
+		{
+			name:               "clone-per-agent",
+			workspaceModeLabel: store.WorkspaceModePerAgent,
+			gitRemote:          "https://github.com/example/repo.git",
+			wantMode:           "clone-per-agent",
+			wantGit:            true,
+		},
+		{
+			name:               "worktree-per-agent",
+			workspaceModeLabel: store.WorkspaceModeWorktreePerAgent,
+			gitRemote:          "https://github.com/example/repo.git",
+			wantMode:           "worktree-per-agent",
+			wantGit:            true,
+		},
+		{
+			// When no workspace mode label is set, the hub does not inject
+			// SCION_WORKSPACE_MODE. The broker applies the shared-plain default.
+			name:               "empty label: hub does not inject mode",
+			workspaceModeLabel: "",
+			wantMode:           "",
+			wantGit:            false,
+		},
 	}
 
-	mockClient := &mockRuntimeBrokerClient{}
-	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			memStore := createTestStore(t)
 
-	agent := &store.Agent{
-		ID:              tid("agent-restart-wm"),
-		Name:            "test-agent",
-		Slug:            "test-agent",
-		ProjectID:       project.ID,
-		RuntimeBrokerID: broker.ID,
-	}
+			labels := map[string]string{}
+			if tc.workspaceModeLabel != "" {
+				labels[store.LabelWorkspaceMode] = tc.workspaceModeLabel
+			}
+			project := &store.Project{
+				ID:        tid("proj-rwm-" + tc.name),
+				Name:      "restart-wm-test",
+				Slug:      "restart-wm-test",
+				GitRemote: tc.gitRemote,
+				Labels:    labels,
+			}
+			if err := memStore.CreateProject(ctx, project); err != nil {
+				t.Fatalf("failed to create project: %v", err)
+			}
 
-	if err := dispatcher.DispatchAgentRestart(ctx, agent); err != nil {
-		t.Fatalf("DispatchAgentRestart failed: %v", err)
-	}
+			broker := &store.RuntimeBroker{
+				ID:       tid("broker-rwm-" + tc.name),
+				Name:     "test-broker",
+				Slug:     "test-broker",
+				Endpoint: "http://localhost:9800",
+				Status:   store.BrokerStatusOnline,
+			}
+			if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+				t.Fatalf("failed to create runtime broker: %v", err)
+			}
 
-	env := mockClient.lastRestartResolvedEnv
-	if got := env["SCION_WORKSPACE_MODE"]; got != "clone-per-agent" {
-		t.Errorf("SCION_WORKSPACE_MODE: got %q, want %q", got, "clone-per-agent")
-	}
-	if got := env["SCION_WORKSPACE_GIT"]; got != "true" {
-		t.Errorf("SCION_WORKSPACE_GIT: got %q, want %q", got, "true")
+			mockClient := &mockRuntimeBrokerClient{}
+			dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+
+			agent := &store.Agent{
+				ID:              tid("agent-rwm-" + tc.name),
+				Name:            "test-agent",
+				Slug:            "test-agent",
+				ProjectID:       project.ID,
+				RuntimeBrokerID: broker.ID,
+				AppliedConfig: &store.AgentAppliedConfig{
+					GitClone: tc.appliedGitClone,
+				},
+			}
+
+			if err := dispatcher.DispatchAgentRestart(ctx, agent); err != nil {
+				t.Fatalf("DispatchAgentRestart failed: %v", err)
+			}
+
+			env := mockClient.lastRestartResolvedEnv
+			if got := env["SCION_WORKSPACE_MODE"]; got != tc.wantMode {
+				t.Errorf("SCION_WORKSPACE_MODE: got %q, want %q", got, tc.wantMode)
+			}
+			if tc.wantGit {
+				if env["SCION_WORKSPACE_GIT"] != "true" {
+					t.Errorf("SCION_WORKSPACE_GIT: got %q, want %q", env["SCION_WORKSPACE_GIT"], "true")
+				}
+			} else {
+				if _, present := env["SCION_WORKSPACE_GIT"]; present {
+					t.Errorf("SCION_WORKSPACE_GIT: expected absent (false), but got %q", env["SCION_WORKSPACE_GIT"])
+				}
+			}
+		})
 	}
 }

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -48,30 +48,31 @@ func createTestStore(t *testing.T) store.Store {
 
 // mockRuntimeBrokerClient is a mock implementation of RuntimeBrokerClient for testing.
 type mockRuntimeBrokerClient struct {
-	createCalled     bool
-	startCalled      bool
-	stopCalled       bool
-	restartCalled    bool
-	deleteCalled     bool
-	messageCalled    bool
-	cleanupCalled    bool
-	lastBrokerID     string
-	lastEndpoint     string
-	lastAgentID      string
-	lastTask         string
-	lastProjectPath  string
-	lastProjectSlug  string
-	lastMessage      string
-	lastInterrupt    bool
-	lastResolvedEnv  map[string]string
-	lastInlineConfig *api.ScionConfig
-	lastCreateReq    *RemoteCreateAgentRequest
-	lastDeleteOpts   struct{ deleteFiles, removeBranch bool }
-	returnErr        error
-	cleanupErr       error
-	startReturnResp  *RemoteAgentResponse // custom start response if set
-	cleanupCalls     int
-	cleanupSlugs     []string
+	createCalled           bool
+	startCalled            bool
+	stopCalled             bool
+	restartCalled          bool
+	deleteCalled           bool
+	messageCalled          bool
+	cleanupCalled          bool
+	lastBrokerID           string
+	lastEndpoint           string
+	lastAgentID            string
+	lastTask               string
+	lastProjectPath        string
+	lastProjectSlug        string
+	lastMessage            string
+	lastInterrupt          bool
+	lastResolvedEnv        map[string]string
+	lastRestartResolvedEnv map[string]string
+	lastInlineConfig       *api.ScionConfig
+	lastCreateReq          *RemoteCreateAgentRequest
+	lastDeleteOpts         struct{ deleteFiles, removeBranch bool }
+	returnErr              error
+	cleanupErr             error
+	startReturnResp        *RemoteAgentResponse // custom start response if set
+	cleanupCalls           int
+	cleanupSlugs           []string
 }
 
 func (m *mockRuntimeBrokerClient) CreateAgent(ctx context.Context, brokerID, brokerEndpoint string, req *RemoteCreateAgentRequest) (*RemoteAgentResponse, error) {
@@ -134,6 +135,7 @@ func (m *mockRuntimeBrokerClient) RestartAgent(ctx context.Context, brokerID, br
 	m.lastBrokerID = brokerID
 	m.lastEndpoint = brokerEndpoint
 	m.lastAgentID = agentID
+	m.lastRestartResolvedEnv = resolvedEnv
 	return m.returnErr
 }
 
@@ -3610,4 +3612,177 @@ func TestBuildCreateRequest_RelativeWorkspaceSurvives(t *testing.T) {
 				mockClient.lastCreateReq.Config.Workspace)
 		}
 	})
+}
+
+// TestHTTPAgentDispatcher_DispatchAgentStart_InjectsWorkspaceMode verifies that
+// DispatchAgentStart injects SCION_WORKSPACE_MODE (canonical) and SCION_WORKSPACE_GIT
+// into resolvedEnv for each of the three workspace sharing modes.
+func TestHTTPAgentDispatcher_DispatchAgentStart_InjectsWorkspaceMode(t *testing.T) {
+	ctx := context.Background()
+
+	type testCase struct {
+		name               string
+		workspaceModeLabel string // project label value (wire format)
+		gitRemote          string
+		appliedGitClone    *api.GitCloneConfig
+		wantMode           string
+		wantGit            bool
+	}
+
+	cases := []testCase{
+		{
+			name:               "shared-plain no git",
+			workspaceModeLabel: store.WorkspaceModeShared,
+			wantMode:           "shared-plain",
+			wantGit:            false,
+		},
+		{
+			name:               "shared-plain with git clone in applied config",
+			workspaceModeLabel: store.WorkspaceModeShared,
+			gitRemote:          "https://github.com/example/repo.git",
+			appliedGitClone:    &api.GitCloneConfig{URL: "https://github.com/example/repo.git"},
+			wantMode:           "shared-plain",
+			wantGit:            true,
+		},
+		{
+			name:               "clone-per-agent",
+			workspaceModeLabel: store.WorkspaceModePerAgent,
+			gitRemote:          "https://github.com/example/repo.git",
+			wantMode:           "clone-per-agent",
+			wantGit:            true,
+		},
+		{
+			name:               "worktree-per-agent",
+			workspaceModeLabel: store.WorkspaceModeWorktreePerAgent,
+			gitRemote:          "https://github.com/example/repo.git",
+			wantMode:           "worktree-per-agent",
+			wantGit:            true,
+		},
+		{
+			// When no workspace mode label is set, the hub does not inject
+			// SCION_WORKSPACE_MODE. The broker applies the shared-plain default
+			// in buildStartContext when the key is absent from resolvedEnv.
+			name:               "empty label: hub does not inject mode",
+			workspaceModeLabel: "",
+			wantMode:           "", // absent from hub-injected resolvedEnv
+			wantGit:            false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			memStore := createTestStore(t)
+
+			labels := map[string]string{}
+			if tc.workspaceModeLabel != "" {
+				labels[store.LabelWorkspaceMode] = tc.workspaceModeLabel
+			}
+			project := &store.Project{
+				ID:        tid("proj-wm-" + tc.name),
+				Name:      "workspace-mode-test",
+				Slug:      "workspace-mode-test",
+				GitRemote: tc.gitRemote,
+				Labels:    labels,
+			}
+			if err := memStore.CreateProject(ctx, project); err != nil {
+				t.Fatalf("failed to create project: %v", err)
+			}
+
+			broker := &store.RuntimeBroker{
+				ID:       tid("broker-wm-" + tc.name),
+				Name:     "test-broker",
+				Slug:     "test-broker",
+				Endpoint: "http://localhost:9800",
+				Status:   store.BrokerStatusOnline,
+			}
+			if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+				t.Fatalf("failed to create runtime broker: %v", err)
+			}
+
+			mockClient := &mockRuntimeBrokerClient{}
+			dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+
+			agent := &store.Agent{
+				ID:              tid("agent-wm-" + tc.name),
+				Name:            "test-agent",
+				Slug:            "test-agent",
+				ProjectID:       project.ID,
+				RuntimeBrokerID: broker.ID,
+				AppliedConfig: &store.AgentAppliedConfig{
+					GitClone: tc.appliedGitClone,
+				},
+			}
+
+			if err := dispatcher.DispatchAgentStart(ctx, agent, "", false); err != nil {
+				t.Fatalf("DispatchAgentStart failed: %v", err)
+			}
+
+			env := mockClient.lastResolvedEnv
+			if got := env["SCION_WORKSPACE_MODE"]; got != tc.wantMode {
+				t.Errorf("SCION_WORKSPACE_MODE: got %q, want %q", got, tc.wantMode)
+			}
+			if tc.wantGit {
+				if env["SCION_WORKSPACE_GIT"] != "true" {
+					t.Errorf("SCION_WORKSPACE_GIT: got %q, want %q", env["SCION_WORKSPACE_GIT"], "true")
+				}
+			} else {
+				if _, present := env["SCION_WORKSPACE_GIT"]; present {
+					t.Errorf("SCION_WORKSPACE_GIT: expected absent (false), but got %q", env["SCION_WORKSPACE_GIT"])
+				}
+			}
+		})
+	}
+}
+
+// TestHTTPAgentDispatcher_DispatchAgentRestart_InjectsWorkspaceMode verifies that
+// DispatchAgentRestart injects SCION_WORKSPACE_MODE and SCION_WORKSPACE_GIT into
+// resolvedEnv, following the same semantics as the start path.
+func TestHTTPAgentDispatcher_DispatchAgentRestart_InjectsWorkspaceMode(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	project := &store.Project{
+		ID:        tid("proj-restart-wm"),
+		Name:      "restart-wm-test",
+		Slug:      "restart-wm-test",
+		GitRemote: "https://github.com/example/repo.git",
+		Labels:    map[string]string{store.LabelWorkspaceMode: store.WorkspaceModePerAgent},
+	}
+	if err := memStore.CreateProject(ctx, project); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-restart-wm"),
+		Name:     "test-broker",
+		Slug:     "test-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+
+	agent := &store.Agent{
+		ID:              tid("agent-restart-wm"),
+		Name:            "test-agent",
+		Slug:            "test-agent",
+		ProjectID:       project.ID,
+		RuntimeBrokerID: broker.ID,
+	}
+
+	if err := dispatcher.DispatchAgentRestart(ctx, agent); err != nil {
+		t.Fatalf("DispatchAgentRestart failed: %v", err)
+	}
+
+	env := mockClient.lastRestartResolvedEnv
+	if got := env["SCION_WORKSPACE_MODE"]; got != "clone-per-agent" {
+		t.Errorf("SCION_WORKSPACE_MODE: got %q, want %q", got, "clone-per-agent")
+	}
+	if got := env["SCION_WORKSPACE_GIT"]; got != "true" {
+		t.Errorf("SCION_WORKSPACE_GIT: got %q, want %q", got, "true")
+	}
 }

--- a/pkg/runtimebroker/start_context.go
+++ b/pkg/runtimebroker/start_context.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/provision"
 	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/GoogleCloudPlatform/scion/pkg/util"
 )
 
 // startContext holds all the resolved state needed to start an agent.
@@ -311,6 +312,21 @@ func (s *Server) buildStartContext(ctx context.Context, in startContextInputs) (
 		env["SCION_PROJECT_PATH"] = in.ProjectPath
 	}
 
+	// Emit canonical workspace sharing mode.
+	// On the create path, in.WorkspaceMode carries the wire label and we
+	// resolve it to the canonical value here. On start/restart paths,
+	// in.WorkspaceMode is empty but the hub pre-resolves the canonical value
+	// into resolvedEnv["SCION_WORKSPACE_MODE"] (see httpdispatcher.go); it was
+	// already merged into env in step 1 above, so the var is already present.
+	// Either way, we ensure a guaranteed non-empty value with a safe default.
+	if in.WorkspaceMode != "" {
+		env["SCION_WORKSPACE_MODE"] = string(store.ResolveWorkspaceSharingMode(in.WorkspaceMode))
+	}
+	if env["SCION_WORKSPACE_MODE"] == "" {
+		// Empty or unrecognized — default to shared-plain for backward compatibility.
+		env["SCION_WORKSPACE_MODE"] = string(store.SharingModeSharedPlain)
+	}
+
 	// 6. Broker identity
 	if s.config.BrokerName != "" {
 		env["SCION_BROKER_NAME"] = s.config.BrokerName
@@ -452,6 +468,9 @@ func (s *Server) buildStartContext(ctx context.Context, in startContextInputs) (
 	}
 
 	// --- Shared workspace mode (git-workspace hybrid) ---
+	// Deprecated: SCION_SHARED_WORKSPACE — superseded by SCION_WORKSPACE_MODE +
+	// SCION_WORKSPACE_GIT. Kept for compatibility during the transition period.
+	// Removal is tracked in https://github.com/ptone/scion/issues/575.
 	if in.Config != nil && in.Config.SharedWorkspace {
 		env["SCION_SHARED_WORKSPACE"] = "true"
 		if s.config.Debug {
@@ -494,6 +513,28 @@ func (s *Server) buildStartContext(ctx context.Context, in startContextInputs) (
 				"cloneURL", gc.URL, "branch", gc.Branch, "depth", gc.Depth)
 		}
 	}
+
+	// --- SCION_WORKSPACE_GIT ---
+	// Emit when the workspace is (or will be) a git repository. Mode alone is
+	// insufficient because shared-plain may or may not be git-backed.
+	//
+	// Priority:
+	//  1. worktreeProvisioned: host-side worktree was set up — always git.
+	//  2. opts.GitClone != nil: in-container clone configured — always git.
+	//  3. opts.Workspace on disk: shared-plain git workspace (check .git).
+	//  4. in.ResolvedEnv fallback: hub-injected on start/restart paths before
+	//     the on-disk workspace exists (e.g. clone-per-agent pre-clone).
+	isGitWorkspace := worktreeProvisioned || opts.GitClone != nil
+	if !isGitWorkspace && opts.Workspace != "" {
+		isGitWorkspace = util.IsGitRepoDir(opts.Workspace)
+	}
+	if !isGitWorkspace {
+		isGitWorkspace = in.ResolvedEnv["SCION_WORKSPACE_GIT"] == "true"
+	}
+	if isGitWorkspace {
+		env["SCION_WORKSPACE_GIT"] = "true"
+	}
+	// Absent when false — avoids encoding a "false" string agents must parse.
 
 	// --- Env + telemetry + secrets ---
 	opts.Env = env

--- a/pkg/runtimebroker/start_context_test.go
+++ b/pkg/runtimebroker/start_context_test.go
@@ -1262,3 +1262,188 @@ func TestBuildStartContext_NoAuth(t *testing.T) {
 		}
 	})
 }
+
+// TestBuildStartContext_WorkspaceMode verifies that SCION_WORKSPACE_MODE is emitted
+// with the correct canonical value for each wire label, and defaults to shared-plain.
+func TestBuildStartContext_WorkspaceMode(t *testing.T) {
+	cases := []struct {
+		name      string
+		wireLabel string
+		wantMode  string
+	}{
+		{
+			name:      "shared wire label",
+			wireLabel: store.WorkspaceModeShared,
+			wantMode:  "shared-plain",
+		},
+		{
+			name:      "per-agent wire label",
+			wireLabel: store.WorkspaceModePerAgent,
+			wantMode:  "clone-per-agent",
+		},
+		{
+			name:      "worktree-per-agent wire label",
+			wireLabel: store.WorkspaceModeWorktreePerAgent,
+			wantMode:  "worktree-per-agent",
+		},
+		{
+			name:      "empty wire label defaults to shared-plain",
+			wireLabel: "",
+			wantMode:  "shared-plain",
+		},
+		{
+			name:      "unrecognized wire label defaults to shared-plain",
+			wireLabel: "unknown-mode",
+			wantMode:  "shared-plain",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := DefaultServerConfig()
+			cfg.StateDir = t.TempDir()
+			srv := newTestServerForStartContext(t, cfg)
+
+			r := httptest.NewRequest("POST", "/api/v1/agents", nil)
+			sc, err := srv.buildStartContext(context.Background(), startContextInputs{
+				Name:          "agent-1",
+				WorkspaceMode: tc.wireLabel,
+				HTTPRequest:   r,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := sc.Opts.Env["SCION_WORKSPACE_MODE"]; got != tc.wantMode {
+				t.Errorf("SCION_WORKSPACE_MODE: got %q, want %q", got, tc.wantMode)
+			}
+		})
+	}
+}
+
+// TestBuildStartContext_WorkspaceMode_StartPathFallback verifies that on the
+// start/restart path (WorkspaceMode==""), a hub-injected SCION_WORKSPACE_MODE in
+// resolvedEnv is propagated to the container env, and the broker-side code does
+// not overwrite it with the shared-plain default.
+func TestBuildStartContext_WorkspaceMode_StartPathFallback(t *testing.T) {
+	cfg := DefaultServerConfig()
+	cfg.StateDir = t.TempDir()
+	srv := newTestServerForStartContext(t, cfg)
+
+	r := httptest.NewRequest("POST", "/api/v1/agents", nil)
+	sc, err := srv.buildStartContext(context.Background(), startContextInputs{
+		Name: "agent-resume",
+		// Hub injects canonical value via resolvedEnv on start path.
+		ResolvedEnv: map[string]string{
+			"SCION_WORKSPACE_MODE": "clone-per-agent",
+			"SCION_WORKSPACE_GIT":  "true",
+		},
+		// WorkspaceMode intentionally empty (start/restart path).
+		HTTPRequest: r,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := sc.Opts.Env["SCION_WORKSPACE_MODE"]; got != "clone-per-agent" {
+		t.Errorf("SCION_WORKSPACE_MODE: got %q, want %q", got, "clone-per-agent")
+	}
+	if got := sc.Opts.Env["SCION_WORKSPACE_GIT"]; got != "true" {
+		t.Errorf("SCION_WORKSPACE_GIT: got %q, want %q", got, "true")
+	}
+}
+
+// TestBuildStartContext_WorkspaceGit verifies that SCION_WORKSPACE_GIT is emitted
+// correctly based on the provisioning path.
+func TestBuildStartContext_WorkspaceGit(t *testing.T) {
+	t.Run("git clone config implies git workspace", func(t *testing.T) {
+		cfg := DefaultServerConfig()
+		cfg.StateDir = t.TempDir()
+		srv := newTestServerForStartContext(t, cfg)
+
+		r := httptest.NewRequest("POST", "/api/v1/agents", nil)
+		sc, err := srv.buildStartContext(context.Background(), startContextInputs{
+			Name: "agent-clone",
+			Config: &CreateAgentConfig{
+				GitClone: &api.GitCloneConfig{
+					URL:    "https://github.com/example/repo.git",
+					Branch: "main",
+				},
+			},
+			HTTPRequest: r,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := sc.Opts.Env["SCION_WORKSPACE_GIT"]; got != "true" {
+			t.Errorf("SCION_WORKSPACE_GIT: got %q, want %q", got, "true")
+		}
+	})
+
+	t.Run("no git clone and no workspace implies absent git var", func(t *testing.T) {
+		cfg := DefaultServerConfig()
+		cfg.StateDir = t.TempDir()
+		srv := newTestServerForStartContext(t, cfg)
+
+		r := httptest.NewRequest("POST", "/api/v1/agents", nil)
+		sc, err := srv.buildStartContext(context.Background(), startContextInputs{
+			Name:        "agent-plain",
+			Config:      &CreateAgentConfig{},
+			HTTPRequest: r,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v, present := sc.Opts.Env["SCION_WORKSPACE_GIT"]; present {
+			t.Errorf("SCION_WORKSPACE_GIT should be absent for non-git workspace, got %q", v)
+		}
+	})
+
+	t.Run("start path hub-injected SCION_WORKSPACE_GIT propagates", func(t *testing.T) {
+		cfg := DefaultServerConfig()
+		cfg.StateDir = t.TempDir()
+		srv := newTestServerForStartContext(t, cfg)
+
+		r := httptest.NewRequest("POST", "/api/v1/agents", nil)
+		sc, err := srv.buildStartContext(context.Background(), startContextInputs{
+			Name: "agent-start",
+			ResolvedEnv: map[string]string{
+				"SCION_WORKSPACE_GIT": "true",
+			},
+			HTTPRequest: r,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := sc.Opts.Env["SCION_WORKSPACE_GIT"]; got != "true" {
+			t.Errorf("SCION_WORKSPACE_GIT: got %q, want %q", got, "true")
+		}
+	})
+
+	t.Run("shared-plain git workspace on disk", func(t *testing.T) {
+		// Create a temporary git repo to simulate a shared-plain git workspace
+		gitDir := t.TempDir()
+		initCmd := exec.Command("git", "init", gitDir)
+		if out, err := initCmd.CombinedOutput(); err != nil {
+			t.Skipf("git init failed: %s", string(out))
+		}
+
+		cfg := DefaultServerConfig()
+		cfg.StateDir = t.TempDir()
+		srv := newTestServerForStartContext(t, cfg)
+
+		r := httptest.NewRequest("POST", "/api/v1/agents", nil)
+		sc, err := srv.buildStartContext(context.Background(), startContextInputs{
+			Name: "agent-shared-git",
+			Config: &CreateAgentConfig{
+				Workspace: gitDir,
+			},
+			HTTPRequest: r,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := sc.Opts.Env["SCION_WORKSPACE_GIT"]; got != "true" {
+			t.Errorf("SCION_WORKSPACE_GIT: got %q, want %q (shared git workspace on disk should set it)", got, "true")
+		}
+	})
+}

--- a/pkg/runtimebroker/start_context_test.go
+++ b/pkg/runtimebroker/start_context_test.go
@@ -1354,6 +1354,13 @@ func TestBuildStartContext_WorkspaceMode_StartPathFallback(t *testing.T) {
 
 // TestBuildStartContext_WorkspaceGit verifies that SCION_WORKSPACE_GIT is emitted
 // correctly based on the provisioning path.
+//
+// Coverage note: the highest-priority path — worktreeProvisioned=true (from
+// tryProvisionWorktree in start_context.go) — is not covered here because it
+// requires a real host-side git repository setup that is outside unit test scope.
+// The code path is simple (isGitWorkspace := worktreeProvisioned || ...) and
+// covered by the worktree integration tests. The remaining three priority levels
+// (GitClone config, on-disk git dir, hub-injected resolvedEnv) are tested below.
 func TestBuildStartContext_WorkspaceGit(t *testing.T) {
 	t.Run("git clone config implies git workspace", func(t *testing.T) {
 		cfg := DefaultServerConfig()


### PR DESCRIPTION
Summary: Agents can now discover workspace provisioning at startup via two new env vars emitted by the broker:
- SCION_WORKSPACE_MODE - canonical sharing mode (shared-plain, clone-per-agent, worktree-per-agent), always present, defaults to shared-plain
- SCION_WORKSPACE_GIT - present (true) when workspace is git-backed, absent otherwise

Changes by phase:
- Phase 0: hub start/restart propagation fix (httpdispatcher.go) - fixes bug where WorkspaceMode was only populated on create path
- Phase 1-2: broker emits both vars in start_context.go, with fallback chains for start/restart paths
- Phase 3: sciontool init compat shim - prefers new vars, falls back to legacy SCION_SHARED_WORKSPACE for older brokers
- Phase 4: docs (workspaces-and-sharing.md, workspace.md fix)

Deprecation of SCION_SHARED_WORKSPACE tracked in ptone/scion#575.

Test plan: 6 new test suites covering hub dispatch (start/restart), broker context building (mode + git detection), and the sciontool compat shim - 26 total new test cases. Independent reviewer approved