### PR TITLE
agent: fix GitHub skill resolver auth gap, full-SHA short-circuit, and cache logging

### DIFF
--- a/pkg/agent/github_skill_resolver.go
+++ b/pkg/agent/github_skill_resolver.go
@@ -64,7 +64,13 @@ type GitHubSkillResolver struct {
 func NewGitHubSkillResolver() *GitHubSkillResolver {
 	var cache *GitHubResolutionCache
 	if cacheDir, err := githubResolutionCacheDir(); err == nil {
-		cache, _ = NewGitHubResolutionCache(cacheDir, DefaultResolutionCacheTTL)
+		var cacheErr error
+		cache, cacheErr = NewGitHubResolutionCache(cacheDir, DefaultResolutionCacheTTL)
+		if cacheErr != nil {
+			// Log so a broken cache is visible rather than silently degrading
+			// to uncached operation (every request makes a fresh GitHub API call).
+			util.Debugf("github: failed to initialize resolution cache at %s: %v (proceeding without cache)", cacheDir, cacheErr)
+		}
 	}
 	return &GitHubSkillResolver{
 		httpClient:      &http.Client{Timeout: githubAPITimeout},
@@ -77,12 +83,26 @@ func NewGitHubSkillResolver() *GitHubSkillResolver {
 
 // NewGitHubSkillResolverWithCredentials constructs a resolver with an explicit
 // default token and a named-credential map for per-URI lookup.
-// If defaultToken is empty, falls back to the GITHUB_TOKEN environment variable.
+//
+// Token resolution order for bare gh:// URIs (no ?token= suffix):
+//  1. defaultToken (from req.ResolvedEnv["GITHUB_TOKEN"] — GitHub App or env-type secret).
+//  2. GITHUB_TOKEN from the broker process environment (os.Getenv, set by NewGitHubSkillResolver).
+//  3. GITHUB_TOKEN from provisionCredentials (project secret of any type).
+//  4. No token — unauthenticated calls, subject to GitHub's 60 req/hr per-IP limit.
+//
 // provisionCredentials maps secret name → value; may be nil.
 func NewGitHubSkillResolverWithCredentials(defaultToken string, provisionCredentials map[string]string) *GitHubSkillResolver {
 	r := NewGitHubSkillResolver()
 	if defaultToken != "" {
 		r.token = defaultToken
+	} else if r.token == "" {
+		// Neither an explicit token nor the broker-env GITHUB_TOKEN is available.
+		// Fall back to a project-scoped provision credential named GITHUB_TOKEN.
+		// This covers projects that store GITHUB_TOKEN as a secret but not as an
+		// env-type secret (which would have been included in req.ResolvedEnv).
+		if val := provisionCredentials["GITHUB_TOKEN"]; val != "" {
+			r.token = val
+		}
 	}
 	r.provisionCredentials = provisionCredentials
 	return r
@@ -243,10 +263,42 @@ type githubContentEntry struct {
 	DownloadURL string `json:"download_url"`
 }
 
+// isFullCommitSHA reports whether s is a complete 40-character lowercase
+// hexadecimal commit SHA. Such a ref is already fully resolved and requires
+// no GitHub API call to "resolve" it further.
+func isFullCommitSHA(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
 func (r *GitHubSkillResolver) resolveCommitSHA(ctx context.Context, ghRef *GitHubSkillRef, token string) (string, error) {
 	ref := ghRef.Ref
 	if ref == "" {
 		ref = "HEAD"
+	}
+
+	// Short-circuit: if the ref is already a full 40-char lowercase hex commit SHA,
+	// no API call is needed — the ref IS the resolved SHA.
+	if isFullCommitSHA(ref) {
+		util.Debugf("github: ref %s is already a full SHA, skipping resolveCommitSHA API call", ref)
+		return ref, nil
+	}
+
+	if token == "" {
+		// Warn early — unauthenticated GitHub API calls are limited to 60/hr per
+		// outbound IP (shared across all broker instances on Cloud Run / Cloud NAT).
+		// This limit is exhausted quickly under any multi-agent workload.
+		// To fix: set GITHUB_TOKEN in the project secrets or the broker's environment.
+		fmt.Fprintf(os.Stderr, "github: WARNING: no GITHUB_TOKEN configured for %s; "+
+			"making unauthenticated GitHub API call (limit: 60 req/hr per IP). "+
+			"Set a GITHUB_TOKEN project secret or broker env var to increase the limit.\n", ghRef.Raw)
 	}
 
 	reqURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s", r.apiBase,

--- a/pkg/agent/github_skill_resolver.go
+++ b/pkg/agent/github_skill_resolver.go
@@ -63,13 +63,16 @@ type GitHubSkillResolver struct {
 // are reused to avoid redundant GitHub API calls.
 func NewGitHubSkillResolver() *GitHubSkillResolver {
 	var cache *GitHubResolutionCache
-	if cacheDir, err := githubResolutionCacheDir(); err == nil {
+	cacheDir, cacheDirErr := githubResolutionCacheDir()
+	if cacheDirErr != nil {
+		// Print to stderr unconditionally: without a cache every request hits the
+		// GitHub API fresh, directly contributing to rate-limit exhaustion.
+		fmt.Fprintf(os.Stderr, "github: WARNING: failed to determine resolution cache dir: %v; proceeding without cache\n", cacheDirErr)
+	} else {
 		var cacheErr error
 		cache, cacheErr = NewGitHubResolutionCache(cacheDir, DefaultResolutionCacheTTL)
 		if cacheErr != nil {
-			// Print to stderr unconditionally (not debug-gated): a broken cache causes
-			// every request to make fresh GitHub API calls, contributing directly to
-			// rate-limit exhaustion. Operators need to see this in production logs.
+			// Same rationale: operators need to see cache failures in production logs.
 			fmt.Fprintf(os.Stderr, "github: WARNING: failed to initialize resolution cache at %s: %v (proceeding without cache)\n", cacheDir, cacheErr)
 		}
 	}

--- a/pkg/agent/github_skill_resolver.go
+++ b/pkg/agent/github_skill_resolver.go
@@ -67,9 +67,10 @@ func NewGitHubSkillResolver() *GitHubSkillResolver {
 		var cacheErr error
 		cache, cacheErr = NewGitHubResolutionCache(cacheDir, DefaultResolutionCacheTTL)
 		if cacheErr != nil {
-			// Log so a broken cache is visible rather than silently degrading
-			// to uncached operation (every request makes a fresh GitHub API call).
-			util.Debugf("github: failed to initialize resolution cache at %s: %v (proceeding without cache)", cacheDir, cacheErr)
+			// Print to stderr unconditionally (not debug-gated): a broken cache causes
+			// every request to make fresh GitHub API calls, contributing directly to
+			// rate-limit exhaustion. Operators need to see this in production logs.
+			fmt.Fprintf(os.Stderr, "github: WARNING: failed to initialize resolution cache at %s: %v (proceeding without cache)\n", cacheDir, cacheErr)
 		}
 	}
 	return &GitHubSkillResolver{
@@ -284,21 +285,24 @@ func (r *GitHubSkillResolver) resolveCommitSHA(ctx context.Context, ghRef *GitHu
 		ref = "HEAD"
 	}
 
+	// Warn before any API call path — including listContents and downloadRawFile
+	// called by the parent resolveOne after this function returns. Even when the
+	// full-SHA short-circuit below skips the SHA-lookup call, those subsequent
+	// calls still go out unauthenticated; the operator needs advance notice.
+	// Unauthenticated GitHub API calls are limited to 60/hr per outbound IP
+	// (shared across all broker instances on Cloud Run / Cloud NAT).
+	// To fix: set GITHUB_TOKEN in the project secrets or the broker's environment.
+	if token == "" {
+		fmt.Fprintf(os.Stderr, "github: WARNING: no GITHUB_TOKEN configured for %s; "+
+			"making unauthenticated GitHub API call (limit: 60 req/hr per IP). "+
+			"Set a GITHUB_TOKEN project secret or broker env var to increase the limit.\n", ghRef.Raw)
+	}
+
 	// Short-circuit: if the ref is already a full 40-char lowercase hex commit SHA,
 	// no API call is needed — the ref IS the resolved SHA.
 	if isFullCommitSHA(ref) {
 		util.Debugf("github: ref %s is already a full SHA, skipping resolveCommitSHA API call", ref)
 		return ref, nil
-	}
-
-	if token == "" {
-		// Warn early — unauthenticated GitHub API calls are limited to 60/hr per
-		// outbound IP (shared across all broker instances on Cloud Run / Cloud NAT).
-		// This limit is exhausted quickly under any multi-agent workload.
-		// To fix: set GITHUB_TOKEN in the project secrets or the broker's environment.
-		fmt.Fprintf(os.Stderr, "github: WARNING: no GITHUB_TOKEN configured for %s; "+
-			"making unauthenticated GitHub API call (limit: 60 req/hr per IP). "+
-			"Set a GITHUB_TOKEN project secret or broker env var to increase the limit.\n", ghRef.Raw)
 	}
 
 	reqURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s", r.apiBase,

--- a/pkg/agent/github_skill_resolver_test.go
+++ b/pkg/agent/github_skill_resolver_test.go
@@ -1034,6 +1034,180 @@ func TestGitHubPrivateRepoInstall_NoDoubleDownload(t *testing.T) {
 	}
 }
 
+// TestIsFullCommitSHA verifies the full-SHA detection helper.
+func TestIsFullCommitSHA(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"full 40-char lowercase hex", "abc123def456abc123def456abc123def456abcd", true},
+		{"all zeros (valid SHA)", "0000000000000000000000000000000000000000", true},
+		{"uppercase hex rejected", "ABC123DEF456ABC123DEF456ABC123DEF456ABCD", false},
+		{"mixed case rejected", "Abc123def456abc123def456abc123def456abcd", false},
+		{"39 chars too short", "abc123def456abc123def456abc123def456abc", false},
+		{"41 chars too long", "abc123def456abc123def456abc123def456abcde", false},
+		{"branch name rejected", "main", false},
+		{"short SHA (12 char) rejected", "abc123def456", false},
+		{"empty string rejected", "", false},
+		{"non-hex chars rejected", "abc123def456abc123def456abc123def456zzzz", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isFullCommitSHA(tt.in); got != tt.want {
+				t.Errorf("isFullCommitSHA(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveCommitSHA_FullSHAShortCircuit verifies that resolveCommitSHA skips
+// the GitHub API entirely when the ref is already a full 40-char commit SHA.
+func TestResolveCommitSHA_FullSHAShortCircuit(t *testing.T) {
+	server, mux := newTestGitHubServer(t)
+	apiCalled := false
+	mux.HandleFunc("/repos/owner/repo/commits/", func(w http.ResponseWriter, _ *http.Request) {
+		apiCalled = true
+		_, _ = w.Write([]byte(testCommitSHA))
+	})
+
+	resolver := newTestGitHubResolver(server)
+	ghRef := &GitHubSkillRef{
+		Owner:     "owner",
+		Repo:      "repo",
+		SkillPath: "skills/my-skill",
+		SkillName: "my-skill",
+		Ref:       testCommitSHA, // already a full SHA
+		Raw:       "gh://owner/repo/my-skill@" + testCommitSHA,
+	}
+
+	got, err := resolver.resolveCommitSHA(context.Background(), ghRef, "test-token")
+	if err != nil {
+		t.Fatalf("resolveCommitSHA failed: %v", err)
+	}
+	if got != testCommitSHA {
+		t.Errorf("expected %s, got %s", testCommitSHA, got)
+	}
+	if apiCalled {
+		t.Error("API should not have been called for a full-SHA ref, but it was")
+	}
+}
+
+// TestResolveCommitSHA_BranchStillCallsAPI verifies that branch names (non-SHA refs)
+// still trigger the GitHub API call.
+func TestResolveCommitSHA_BranchStillCallsAPI(t *testing.T) {
+	server, mux := newTestGitHubServer(t)
+	apiCalled := false
+	mux.HandleFunc("/repos/owner/repo/commits/main", func(w http.ResponseWriter, _ *http.Request) {
+		apiCalled = true
+		_, _ = w.Write([]byte(testCommitSHA))
+	})
+
+	resolver := newTestGitHubResolver(server)
+	ghRef := &GitHubSkillRef{
+		Owner:     "owner",
+		Repo:      "repo",
+		SkillPath: "skills/my-skill",
+		SkillName: "my-skill",
+		Ref:       "main",
+		Raw:       "gh://owner/repo/my-skill@main",
+	}
+
+	got, err := resolver.resolveCommitSHA(context.Background(), ghRef, "test-token")
+	if err != nil {
+		t.Fatalf("resolveCommitSHA failed: %v", err)
+	}
+	if got != testCommitSHA {
+		t.Errorf("expected %s, got %s", testCommitSHA, got)
+	}
+	if !apiCalled {
+		t.Error("API should have been called for a branch-name ref, but it was not")
+	}
+}
+
+// TestNewGitHubSkillResolverWithCredentials_ProvisionCredentialsFallback verifies
+// that when no explicit defaultToken is provided and the broker env lacks
+// GITHUB_TOKEN, the resolver falls back to a GITHUB_TOKEN entry in
+// provisionCredentials. This is the auth wiring fix for bare gh:// URIs.
+func TestNewGitHubSkillResolverWithCredentials_ProvisionCredentialsFallback(t *testing.T) {
+	// Ensure no GITHUB_TOKEN in the process env (clear it, restore after test).
+	old := os.Getenv("GITHUB_TOKEN")
+	if err := os.Unsetenv("GITHUB_TOKEN"); err != nil {
+		t.Fatalf("failed to unset GITHUB_TOKEN: %v", err)
+	}
+	t.Cleanup(func() {
+		if old != "" {
+			_ = os.Setenv("GITHUB_TOKEN", old)
+		}
+	})
+
+	creds := map[string]string{
+		"GITHUB_TOKEN": "provision-secret-token",
+		"OTHER_SECRET": "other-value",
+	}
+	r := NewGitHubSkillResolverWithCredentials("", creds)
+	if r.token != "provision-secret-token" {
+		t.Errorf("expected token from provisionCredentials fallback, got %q", r.token)
+	}
+}
+
+// TestNewGitHubSkillResolverWithCredentials_ExplicitTokenWins verifies that an
+// explicit defaultToken takes precedence over any provision credential.
+func TestNewGitHubSkillResolverWithCredentials_ExplicitTokenWins(t *testing.T) {
+	creds := map[string]string{
+		"GITHUB_TOKEN": "provision-secret-token",
+	}
+	r := NewGitHubSkillResolverWithCredentials("explicit-token", creds)
+	if r.token != "explicit-token" {
+		t.Errorf("expected explicit token to win, got %q", r.token)
+	}
+}
+
+// TestGitHubSkillResolver_FullSHAPinnedSkill verifies end-to-end resolution
+// of a skill pinned to a full commit SHA makes no resolveCommitSHA API call.
+func TestGitHubSkillResolver_FullSHAPinnedSkill(t *testing.T) {
+	server, mux := newTestGitHubServer(t)
+	commitEndpointCalled := false
+
+	// Register the commit endpoint — it should NOT be called.
+	mux.HandleFunc("/repos/owner/repo/commits/"+testCommitSHA, func(w http.ResponseWriter, _ *http.Request) {
+		commitEndpointCalled = true
+		_, _ = w.Write([]byte(testCommitSHA))
+	})
+
+	// Contents and raw endpoints are needed for the full resolution flow.
+	mux.HandleFunc("/repos/owner/repo/contents/skills/my-skill", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]githubContentEntry{
+			{Name: "SKILL.md", Path: "skills/my-skill/SKILL.md", Type: "file", Size: 5},
+		})
+	})
+	mux.HandleFunc("/raw/owner/repo/"+testCommitSHA+"/skills/my-skill/SKILL.md", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("hello"))
+	})
+
+	resolver := newTestGitHubResolver(server)
+
+	result, err := resolver.Resolve(context.Background(), []api.SkillReference{
+		{URI: "gh://owner/repo/my-skill@" + testCommitSHA},
+	}, ResolveOpts{})
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if len(result.Errors) != 0 {
+		t.Fatalf("unexpected errors: %v", result.Errors)
+	}
+	if len(result.Resolved) != 1 {
+		t.Fatalf("expected 1 resolved skill, got %d", len(result.Resolved))
+	}
+	if commitEndpointCalled {
+		t.Error("commit resolution API endpoint was called for a full-SHA ref; expected short-circuit")
+	}
+	// Version should be the first 12 chars of the pinned SHA.
+	if result.Resolved[0].Version != testCommitSHA[:12] {
+		t.Errorf("expected version %s, got %s", testCommitSHA[:12], result.Resolved[0].Version)
+	}
+}
+
 type stubSkillResolver struct {
 	result *ResolveResult
 }

--- a/pkg/agent/github_skill_resolver_test.go
+++ b/pkg/agent/github_skill_resolver_test.go
@@ -1151,6 +1151,27 @@ func TestNewGitHubSkillResolverWithCredentials_ProvisionCredentialsFallback(t *t
 	}
 }
 
+// TestNewGitHubSkillResolverWithCredentials_NilProvisionCredentials verifies that
+// passing nil provisionCredentials is safe when no GITHUB_TOKEN fallback is needed.
+// In Go, reading from a nil map returns "" (zero value), so the fallback is a no-op.
+func TestNewGitHubSkillResolverWithCredentials_NilProvisionCredentials(t *testing.T) {
+	old := os.Getenv("GITHUB_TOKEN")
+	if err := os.Unsetenv("GITHUB_TOKEN"); err != nil {
+		t.Fatalf("failed to unset GITHUB_TOKEN: %v", err)
+	}
+	t.Cleanup(func() {
+		if old != "" {
+			_ = os.Setenv("GITHUB_TOKEN", old)
+		}
+	})
+
+	// Must not panic; token should remain empty when no credential is available.
+	r := NewGitHubSkillResolverWithCredentials("", nil)
+	if r.token != "" {
+		t.Errorf("expected empty token with nil provisionCredentials and no env var, got %q", r.token)
+	}
+}
+
 // TestNewGitHubSkillResolverWithCredentials_ExplicitTokenWins verifies that an
 // explicit defaultToken takes precedence over any provision credential.
 func TestNewGitHubSkillResolverWithCredentials_ExplicitTokenWins(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes the immediate cause of skill-resolution rate-limit failures: GitHub API calls going out unauthenticated for bare gh:// URIs.

## Changes
- NewGitHubSkillResolverWithCredentials falls back to provisionCredentials["GITHUB_TOKEN"] when no explicit default token or broker env token is set
- resolveCommitSHA short-circuits for refs already a full 40-char commit SHA (skips the API call entirely)
- Cache-init error now logged to stderr unconditionally (was silently discarded)
- Clear warning before making an unauthenticated call, fires even when the SHA short-circuit applies (covers the subsequent content-fetch calls)

## Trade-off note
provisionCredentials["GITHUB_TOKEN"] was originally scoped per-URI (via ?token=SECRET_NAME). This fix promotes it to a default fallback for bare gh:// URIs with no explicit token param — noted for future maintainers.

Reviewed, rechecked, all findings addressed. 0 regressions in pkg/agent.