### PR TITLE
scion-scheduler: add self-scheduling whoami recipe

### DIFF
--- a/resources/platform_skills/scion-scheduler/SKILL.md
+++ b/resources/platform_skills/scion-scheduler/SKILL.md
@@ -61,6 +61,17 @@ detector from flagging you during the wait. **Neither replaces the other.**
 agent or a scheduled event already tracked by the orchestration system —
 those fire their own state-change notifications.
 
+## Self-scheduling
+
+To schedule a message to yourself, resolve your own agent name first:
+
+```bash
+scion schedule create --non-interactive --type message \
+  --agent "$(scion whoami --non-interactive --format json | jq -r .name)" \
+  --message "Check if deployment completed" \
+  --in 15m
+```
+
 ## Two event types
 
 ### One-shot events


### PR DESCRIPTION
The whoami pattern for resolving own agent name was pulled from agent-team's scheduler skill but didn't land with the initial merge. Adding it now — it's the mechanically useful part that lets an agent expand the `agent:<self>` placeholder.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
