### PR TITLE
scion-agent-manage: troubleshooting additions

### DIFF
--- a/resources/platform_skills/scion-agent-manage/references/troubleshooting.md
+++ b/resources/platform_skills/scion-agent-manage/references/troubleshooting.md
@@ -8,10 +8,11 @@ Most stuck agents are recoverable without recreation. Always start with `scion l
 |---|---|---|
 | Transient API error in log | LLM provider rate-limit or timeout | `scion message <agent> "continue"` — do NOT recreate |
 | `LIMITS_EXCEEDED` state | Context/rate limit hit | `scion message <agent> "continue"` |
-| `failed to verify token: error in cryptographic primitive` | Hub regenerated signing keys on restart | `scion message <agent> "continue"` (triggers token refresh) |
+| `failed to verify token: error in cryptographic primitive` | Hub regenerated signing keys on restart, or multi-replica key mismatch (resolved by `SharedSigningSecret`) | `scion message <agent> "continue"` (triggers token refresh). If looping across login/session_expired, escalate — server-side signing key configuration issue |
 | `Token refresh failed … 401` repeating every 30s | Token expired; refresh deadlocked | `scion message <agent> "continue"` — if no effect, recreate |
 | Container exit 255 / status `Exited` | Container crash | Recreate the agent |
-| Phase `created`, lastSeen zero, persists 5+ min | Broker dispatch exceeded CLI timeout | Wait a few minutes; if stuck, delete and recreate |
+| Phase `created`, lastSeen zero, persists 5+ min | Broker dispatch exceeded CLI timeout | Wait a few minutes; if stuck, delete and recreate. **If recurring:** broker is under pressure — reduce concurrent agent count rather than retrying |
+| `scion start` fails with 422 `no_runtime_broker` | Broker heartbeat/provider status split-brain during reconnect | Wait 30–60s for heartbeat cycle to reconcile, then retry. If persistent, the hub process may need a restart. Reduce concurrent starts if it recurs under load |
 | Phase `starting` + activity `completed` | Duplicate sciontool process reset phase via hub API | Kill duplicate process, recreate |
 | Context at 100% | Memory/context limit reached | Send raw clear sequence (see below) |
 | `gh` CLI returns 401 | Stale `GH_TOKEN` env var, not an agent state issue | Fall back to `curl` with known-good token |

--- a/resources/platform_skills/scion-agent-manage/references/troubleshooting.md
+++ b/resources/platform_skills/scion-agent-manage/references/troubleshooting.md
@@ -8,7 +8,7 @@ Most stuck agents are recoverable without recreation. Always start with `scion l
 |---|---|---|
 | Transient API error in log | LLM provider rate-limit or timeout | `scion message <agent> "continue"` — do NOT recreate |
 | `LIMITS_EXCEEDED` state | Context/rate limit hit | `scion message <agent> "continue"` |
-| `failed to verify token: error in cryptographic primitive` | Hub regenerated signing keys on restart, or multi-replica key mismatch (resolved by `SharedSigningSecret`) | `scion message <agent> "continue"` (triggers token refresh). If looping across login/session_expired, escalate — server-side signing key configuration issue |
+| `failed to verify token: error in cryptographic primitive` | Hub regenerated signing keys on restart, or multi-replica key mismatch (resolved by `SharedSigningSecret`) | `scion message <agent> "continue"` (triggers token refresh). If looping across `login` / `session_expired`, escalate — server-side signing key configuration issue |
 | `Token refresh failed … 401` repeating every 30s | Token expired; refresh deadlocked | `scion message <agent> "continue"` — if no effect, recreate |
 | Container exit 255 / status `Exited` | Container crash | Recreate the agent |
 | Phase `created`, lastSeen zero, persists 5+ min | Broker dispatch exceeded CLI timeout | Wait a few minutes; if stuck, delete and recreate. **If recurring:** broker is under pressure — reduce concurrent agent count rather than retrying |


### PR DESCRIPTION
Three triage rows surfaced from .design docs: broker 422 no_runtime_broker, multi-replica signing key expansion, broker pressure prevention. Unblocks contrib agent-recovery skill deletion