### PR TITLE
fix: add missing ProjectPreStartHooks to mockHubClient in templatecache tests

### DIFF
--- a/pkg/templatecache/hydrator_test.go
+++ b/pkg/templatecache/hydrator_test.go
@@ -127,6 +127,9 @@ func (m *mockHubClient) ProjectInjectedSkills(projectID string) hubclient.Inject
 	return nil
 }
 func (m *mockHubClient) UserInjectedSkills() hubclient.InjectedSkillsService { return nil }
+func (m *mockHubClient) ProjectPreStartHooks(projectID string) hubclient.ProjectPreStartHookService {
+	return nil
+}
 func (m *mockHubClient) Health(ctx context.Context) (*hubclient.HealthResponse, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Problem
Upstream main CI failing after PR #889: mockHubClient does not implement hubclient.Client (missing ProjectPreStartHooks).

## Fix
Add missing method stub to mockHubClient in hydrator_test.go