### PR TITLE
feat(resume): add --force to recover crashed agents from the error phase

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -378,6 +378,36 @@ func GetProjectID(hubCtx *HubContext) (string, error) {
 	return resp.Projects[0].ID, nil
 }
 
+// localResumeDecision mirrors the Hub's resumeInPlaceDecision
+// (pkg/hub/handlers_agent_create_helpers.go) for local (non-Hub) mode, so the
+// two paths present the same contract to the operator.
+//
+// Rules:
+//   - Suspended agents always get harness resume (--continue/--resume), even
+//     when invoked via 'start' (implicit resume).
+//   - Stopped agents always get a fresh session, even when invoked via
+//     'resume'. --force does not change this: a clean shutdown is not a crash.
+//   - Error-phase agents are refused without --force, matching the Hub's 409.
+//     With --force they continue the session interrupted mid-run.
+//
+// Returns the resume flag to hand the harness, plus whether this was an
+// implicit resume or a forced recovery (both purely for operator messaging).
+func localResumeDecision(savedPhase string, resume, force bool, agentName string) (effectiveResume, implicitResume, forcedRecovery bool, err error) {
+	if resume && savedPhase == string(state.PhaseError) && !force {
+		return false, false, false, fmt.Errorf("agent '%s' is in the error phase (e.g. after a host crash) and cannot be resumed without --force", agentName)
+	}
+
+	switch {
+	case savedPhase == string(state.PhaseSuspended):
+		return true, !resume, false, nil
+	case resume && force && savedPhase == string(state.PhaseError):
+		return true, false, true, nil
+	case resume && savedPhase == string(state.PhaseStopped):
+		return false, false, false, nil
+	}
+	return resume, false, false, nil
+}
+
 func RunAgent(cmd *cobra.Command, args []string, resume bool) error {
 	agentName := api.Slugify(args[0])
 	task := strings.Join(args[1:], " ")
@@ -507,23 +537,16 @@ func RunAgent(cmd *cobra.Command, args []string, resume bool) error {
 	}
 
 	// Determine harness resume behavior from the saved phase.
-	// Suspended agents always get harness resume (--continue/--resume),
-	// even when invoked via 'start' (implicit resume). Stopped agents
-	// always get a fresh session, even when invoked via 'resume'.
-	// --force overrides the stopped-means-fresh rule so a crashed agent can
-	// continue the session it was interrupted mid-run.
-	effectiveResume := resume
 	savedPhase := agent.GetSavedPhase(agentName, projectPath)
-	if savedPhase == string(state.PhaseSuspended) {
-		effectiveResume = true
-		if !resume {
-			statusf("Resuming agent '%s'...\n", agentName)
-		}
-	} else if resume && forceResume {
-		effectiveResume = true
+	effectiveResume, implicitResume, forcedRecovery, err := localResumeDecision(savedPhase, resume, forceResume, agentName)
+	if err != nil {
+		return err
+	}
+	if implicitResume {
+		statusf("Resuming agent '%s'...\n", agentName)
+	}
+	if forcedRecovery {
 		statusf("Force-resuming agent '%s' (saved phase: %s)...\n", agentName, savedPhase)
-	} else if resume && savedPhase == string(state.PhaseStopped) {
-		effectiveResume = false
 	}
 
 	opts := api.StartOptions{

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -64,6 +64,7 @@ var (
 	agentImage            string
 	noAuth                bool
 	attach                bool
+	forceResume           bool
 	branch                string
 	workspace             string
 	runtimeBrokerID       string
@@ -509,6 +510,8 @@ func RunAgent(cmd *cobra.Command, args []string, resume bool) error {
 	// Suspended agents always get harness resume (--continue/--resume),
 	// even when invoked via 'start' (implicit resume). Stopped agents
 	// always get a fresh session, even when invoked via 'resume'.
+	// --force overrides the stopped-means-fresh rule so a crashed agent can
+	// continue the session it was interrupted mid-run.
 	effectiveResume := resume
 	savedPhase := agent.GetSavedPhase(agentName, projectPath)
 	if savedPhase == string(state.PhaseSuspended) {
@@ -516,6 +519,9 @@ func RunAgent(cmd *cobra.Command, args []string, resume bool) error {
 		if !resume {
 			statusf("Resuming agent '%s'...\n", agentName)
 		}
+	} else if resume && forceResume {
+		effectiveResume = true
+		statusf("Force-resuming agent '%s' (saved phase: %s)...\n", agentName, savedPhase)
 	} else if resume && savedPhase == string(state.PhaseStopped) {
 		effectiveResume = false
 	}
@@ -733,6 +739,7 @@ func startAgentViaHub(hubCtx *HubContext, agentName, task string, resume bool, i
 		Workspace:       workspace,
 		Labels:          parsedLabels,
 		Resume:          resume,
+		ForceResume:     resume && forceResume,
 		Attach:          attach,
 		GatherEnv:       true, // Enable env-gather flow
 		Notify:          !startNoNotify,
@@ -849,6 +856,9 @@ func startAgentViaHub(hubCtx *HubContext, agentName, task string, resume bool, i
 		action := "Starting"
 		if resume {
 			action = "Resuming"
+		}
+		if resume && forceResume {
+			action = "Force-resuming"
 		}
 		fmt.Printf("%s agent '%s'...\n", action, agentName)
 	}

--- a/cmd/common_resume_test.go
+++ b/cmd/common_resume_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import "testing"
+
+// TestLocalResumeDecision pins local mode to the same contract the Hub applies
+// in resumeInPlaceDecision: --force is an error-phase recovery tool only, and
+// an error-phase agent is refused without it.
+func TestLocalResumeDecision(t *testing.T) {
+	tests := []struct {
+		name         string
+		savedPhase   string
+		resume       bool
+		force        bool
+		wantResume   bool
+		wantImplicit bool
+		wantForced   bool
+		wantErr      bool
+	}{
+		{
+			name:         "suspended resumes implicitly on start",
+			savedPhase:   "suspended",
+			wantResume:   true,
+			wantImplicit: true,
+		},
+		{
+			name:       "suspended resumes explicitly without implicit notice",
+			savedPhase: "suspended",
+			resume:     true,
+			wantResume: true,
+		},
+		{
+			name:       "stopped gets a fresh session on resume",
+			savedPhase: "stopped",
+			resume:     true,
+		},
+		{
+			// --force must not turn a clean shutdown into a session continue;
+			// the Hub treats this as an ordinary resume too.
+			name:       "stopped ignores force",
+			savedPhase: "stopped",
+			resume:     true,
+			force:      true,
+		},
+		{
+			// Mirrors the Hub's 409 on a crashed agent.
+			name:       "error without force is refused",
+			savedPhase: "error",
+			resume:     true,
+			wantErr:    true,
+		},
+		{
+			name:       "error with force continues the interrupted session",
+			savedPhase: "error",
+			resume:     true,
+			force:      true,
+			wantResume: true,
+			wantForced: true,
+		},
+		{
+			// 'start' on a crashed agent is not a resume request, so it is not
+			// refused; it simply starts fresh.
+			name:       "error without resume starts fresh",
+			savedPhase: "error",
+			force:      true,
+		},
+		{
+			name:       "running with force is not a forced recovery",
+			savedPhase: "running",
+			resume:     true,
+			force:      true,
+			wantResume: true,
+		},
+		{
+			name:       "unknown phase falls through to the resume flag",
+			savedPhase: "",
+			resume:     true,
+			wantResume: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResume, gotImplicit, gotForced, err := localResumeDecision(tt.savedPhase, tt.resume, tt.force, "agent-x")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotResume != tt.wantResume {
+				t.Errorf("effectiveResume = %v, want %v", gotResume, tt.wantResume)
+			}
+			if gotImplicit != tt.wantImplicit {
+				t.Errorf("implicitResume = %v, want %v", gotImplicit, tt.wantImplicit)
+			}
+			if gotForced != tt.wantForced {
+				t.Errorf("forcedRecovery = %v, want %v", gotForced, tt.wantForced)
+			}
+		})
+	}
+}

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -28,7 +28,12 @@ preserving its previous state.
 
 The agent-name is required as the first argument. Subsequent arguments
 are optional and form a task prompt to be added to the resumed session
-(if supported by the harness).`,
+(if supported by the harness).
+
+Use --force to recover an agent the Hub considers failed (phase=error), such
+as one whose host crashed mid-run. Normally such an agent is rejected as a
+duplicate. --force acts on one named agent at a time and never applies to a
+running agent, which must not be recreated while it is live.`,
 	Args:              cobra.MinimumNArgs(1),
 	ValidArgsFunction: getAgentNames,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -42,6 +47,7 @@ func init() {
 	resumeCmd.Flags().StringVarP(&agentImage, "image", "i", "", "Container image to use (overrides template)")
 	resumeCmd.Flags().BoolVar(&noAuth, "no-auth", false, "Disable authentication propagation")
 	resumeCmd.Flags().BoolVarP(&attach, "attach", "a", false, "Attach to the agent TTY after starting")
+	resumeCmd.Flags().BoolVar(&forceResume, "force", false, "Resume an agent in the error phase (e.g. after a host crash), continuing its previous session")
 
 	resumeCmd.Flags().StringVar(&runtimeBrokerID, "broker", "", "Preferred runtime broker ID or name")
 

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -30,10 +30,11 @@ The agent-name is required as the first argument. Subsequent arguments
 are optional and form a task prompt to be added to the resumed session
 (if supported by the harness).
 
-Use --force to recover an agent the Hub considers failed (phase=error), such
-as one whose host crashed mid-run. Normally such an agent is rejected as a
-duplicate. --force acts on one named agent at a time and never applies to a
-running agent, which must not be recreated while it is live.`,
+An agent in the error phase (e.g. one whose host crashed mid-run) is refused
+unless --force is given. --force is an error-phase recovery tool only: it acts
+on one named agent at a time, has no effect on a cleanly stopped agent (which
+always starts a fresh session), and never applies to a running agent, which
+must not be recreated while it is live.`,
 	Args:              cobra.MinimumNArgs(1),
 	ValidArgsFunction: getAgentNames,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -523,6 +523,9 @@ func (s *Server) createNotifySubscription(ctx context.Context, agentID, projectI
 // phase may be restarted in place rather than rejected as a duplicate, and
 // whether the harness should be handed its resume flag when that happens.
 //
+// Local (non-Hub) mode applies the same contract in localResumeDecision
+// (cmd/common.go); keep the two in step.
+//
 // A stopped agent restarts with a *fresh* harness session even when resume was
 // requested, mirroring the local CLI's effectiveResume. A forced recovery is
 // the opposite case: the agent died without a clean shutdown (typically a host

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -519,6 +519,28 @@ func (s *Server) createNotifySubscription(ctx context.Context, agentID, projectI
 	}
 }
 
+// resumeInPlaceDecision decides whether an existing agent in a terminal-ish
+// phase may be restarted in place rather than rejected as a duplicate, and
+// whether the harness should be handed its resume flag when that happens.
+//
+// A stopped agent restarts with a *fresh* harness session even when resume was
+// requested, mirroring the local CLI's effectiveResume. A forced recovery is
+// the opposite case: the agent died without a clean shutdown (typically a host
+// crash), so the whole point is to continue the interrupted session.
+//
+// phase=running is deliberately not forceable. A live agent must not be
+// recreated out from under itself, and an operator who truly wants that can
+// stop it first.
+func resumeInPlaceDecision(phase string, resume, force bool) (resumeInPlace, forcedRecovery bool) {
+	if !resume {
+		return false, false
+	}
+	if force && phase == string(state.PhaseError) {
+		return true, true
+	}
+	return phase == string(state.PhaseStopped), false
+}
+
 // handleExistingAgent encapsulates the full decision tree for an agent that
 // already exists when a create/start request arrives.
 //
@@ -609,8 +631,8 @@ func (s *Server) handleExistingAgent(
 			existingAgent.Phase == string(state.PhaseStopped) ||
 			existingAgent.Phase == string(state.PhaseError)) {
 
-		// Resume a stopped agent in-place when explicitly requested.
-		if req.Resume && existingAgent.Phase == string(state.PhaseStopped) {
+		resumeInPlace, forcedRecovery := resumeInPlaceDecision(existingAgent.Phase, req.Resume, req.ForceResume)
+		if resumeInPlace {
 			if existingAgent.RuntimeBrokerID == "" && runtimeBrokerID != "" {
 				existingAgent.RuntimeBrokerID = runtimeBrokerID
 			}
@@ -632,7 +654,15 @@ func (s *Server) handleExistingAgent(
 
 			// A stopped agent restarts with a fresh harness session even when
 			// resume was requested (mirrors the local CLI's effectiveResume).
-			if err := dispatcher.DispatchAgentStart(ctx, existingAgent, req.Task, false); err != nil {
+			// A forced recovery is the opposite: the whole point is to continue
+			// the session the crash interrupted, so the harness resume flag is
+			// passed through.
+			if forcedRecovery {
+				s.agentLifecycleLog.Warn("Force-resuming agent from error phase",
+					"agent_id", existingAgent.ID, "agent", existingAgent.Name,
+					"container_status", existingAgent.ContainerStatus)
+			}
+			if err := dispatcher.DispatchAgentStart(ctx, existingAgent, req.Task, forcedRecovery); err != nil {
 				if isContainerNameConflict(err) {
 					Conflict(w, "Agent name is already in use by a stopped container. Please delete the existing agent or choose a different name.")
 				} else {

--- a/pkg/hub/handlers_agent_create_helpers_test.go
+++ b/pkg/hub/handlers_agent_create_helpers_test.go
@@ -652,3 +652,50 @@ func TestPopulateAgentConfig_PreStartHook_PreStampedIDPreserved(t *testing.T) {
 	assert.Equal(t, "preset-hook-id", agent.AppliedConfig.ProjectPreStartHookID)
 	assert.Equal(t, "#!/bin/sh\necho preset\n", agent.AppliedConfig.ProjectPreStartHookScript)
 }
+
+// TestResumeInPlaceDecision covers the guard that lets `scion resume --force`
+// recover an agent whose host crashed mid-run (phase=error), which is
+// otherwise rejected as a duplicate with a 409.
+func TestResumeInPlaceDecision(t *testing.T) {
+	tests := []struct {
+		name        string
+		phase       string
+		resume      bool
+		force       bool
+		wantInPlace bool
+		wantForced  bool
+	}{
+		// Baseline: resume must be explicitly requested.
+		{"no resume requested, stopped", "stopped", false, false, false, false},
+		{"no resume requested, error", "error", false, false, false, false},
+		{"force without resume is inert", "error", false, true, false, false},
+
+		// Pre-existing behavior: stopped resumes in place but with a FRESH
+		// session (forced=false), mirroring the local CLI's effectiveResume.
+		{"stopped resumes in place, fresh session", "stopped", true, false, true, false},
+
+		// The fix: error phase is recoverable only with force, and continues
+		// the interrupted session.
+		{"error rejected without force", "error", true, false, false, false},
+		{"error recovered with force, session continued", "error", true, true, true, true},
+
+		// Running is never forceable — a live agent must not be recreated.
+		{"running rejected without force", "running", true, false, false, false},
+		{"running rejected even with force", "running", true, true, false, false},
+
+		// Suspended is handled earlier in handleExistingAgent; it should not
+		// be picked up by this guard.
+		{"suspended not handled here", "suspended", true, true, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inPlace, forced := resumeInPlaceDecision(tt.phase, tt.resume, tt.force)
+			assert.Equal(t, tt.wantInPlace, inPlace, "resumeInPlace")
+			assert.Equal(t, tt.wantForced, forced, "forcedRecovery")
+			if forced {
+				assert.True(t, inPlace, "forcedRecovery implies resumeInPlace")
+			}
+		})
+	}
+}

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -94,6 +94,13 @@ type CreateAgentRequest struct {
 	// rather than create a brand-new one. When true and a stopped agent with
 	// the same name exists, the Hub recovers it instead of creating fresh.
 	Resume bool `json:"resume,omitempty"`
+	// ForceResume permits resuming an agent the Hub considers failed
+	// (phase=error), such as one whose host crashed mid-run. Without it such an
+	// agent is rejected as a duplicate. Only meaningful alongside Resume, and
+	// deliberately does NOT cover phase=running: a live agent must not be
+	// recreated out from under itself. The harness receives its resume flag so
+	// the prior session is continued rather than restarted fresh.
+	ForceResume bool `json:"forceResume,omitempty"`
 	// NoAuth indicates the agent should start with zero injected credentials.
 	// When true, the Hub skips secret resolution and the broker skips credential injection.
 	NoAuth bool `json:"noAuth,omitempty"`

--- a/pkg/hub/scheduler_test.go
+++ b/pkg/hub/scheduler_test.go
@@ -475,10 +475,6 @@ func (m *mockScheduledEventStore) ListSkillInjections(_ context.Context, _, _ st
 	return nil, nil
 }
 
-func (m *mockScheduledEventStore) GetActiveProjectPreStartHook(_ context.Context, _ string) (*store.ProjectPreStartHook, error) {
-	return nil, store.ErrNotFound
-}
-
 // getEvent returns a snapshot of an event by ID (test helper, no error).
 // It returns a copy so callers can read fields without holding the lock.
 func (m *mockScheduledEventStore) getEvent(id string) *store.ScheduledEvent {

--- a/pkg/hubclient/agents.go
+++ b/pkg/hubclient/agents.go
@@ -172,6 +172,7 @@ type CreateAgentRequest struct {
 	Annotations     map[string]string `json:"annotations,omitempty"`
 	Config          *api.ScionConfig  `json:"config,omitempty"`
 	Resume          bool              `json:"resume,omitempty"`
+	ForceResume     bool              `json:"forceResume,omitempty"`
 	Attach          bool              `json:"attach,omitempty"`        // If true, signals interactive attach mode to the broker/harness
 	ProvisionOnly   bool              `json:"provisionOnly,omitempty"` // If true, provision only (write task to prompt.md) without starting
 	// WorkspaceFiles is populated for non-git workspace bootstrap.


### PR DESCRIPTION
An agent whose host crashes mid-run lands in phase=error, which handleExistingAgent rejects as a duplicate (409). There was no way to get such an agent running again with its prior session intact: the only in-place restart path required phase=stopped, and that path hardcoded resume=false, so even a successful restart began a fresh harness session.

scion resume --force fills the gap. It permits in-place restart from phase=error and passes the harness its resume flag so the interrupted session is continued rather than discarded.

Scope is deliberately narrow:
- Only phase=error. A running agent is never forceable.
- One named agent at a time; no bulk form.
- --force is inert without resume, so start --force cannot trip it.

Existing behavior is unchanged: a stopped agent still restarts with a fresh session even when resume is requested.

The decision is extracted into resumeInPlaceDecision() so the phase matrix is unit-testable without dispatcher/broker scaffolding.

Also removes a duplicate mockScheduledEventStore.GetActiveProjectPreStartHook declaration in scheduler_test.go, which failed the pkg/hub test build on HEAD and is unrelated to this change