### PR TITLE
agent-lifecycle: replace broker slot jargon

### DIFF
--- a/resources/platform_skills/scion-agent-manage/references/agent-lifecycle.md
+++ b/resources/platform_skills/scion-agent-manage/references/agent-lifecycle.md
@@ -4,7 +4,7 @@ When to delete an agent, when to stop one, and who may authorize it.
 
 ## Default: delete when done
 
-`scion delete <name> --non-interactive` frees the broker slot. `scion list` silently
+`scion delete <name> --non-interactive` frees system resources. `scion list` silently
 truncates at 50 agents — stopped agents count against that ceiling. **Delete is the
 default disposition for a completed agent.** Use `--preserve-branch` when the agent's
 branch may still need review.
@@ -65,6 +65,6 @@ accepted. Time-box it; do not leave agents stopped indefinitely.
 - **Interpreting "clean up" as permission to delete leads.** It never is, unless the
   human names the specific workstream being closed.
 - **Leaving agents stopped for audit trail.** Commit findings to files instead. Stopped
-  agents consume broker slots and count against the 50-agent list ceiling.
+  agents consume system resources and count against the 50-agent list ceiling.
 - **Deleting an agent with unpushed work.** Always verify work is pushed to the
   remote (not just committed locally) or written to the scratchpad before deletion.


### PR DESCRIPTION
Replace internal "broker slot" terminology with "system resources" per audience audit