### PR TITLE
fix(agent): use resolved agentHome from GetAgent in Provision hook staging

### DIFF
--- a/pkg/agent/provision.go
+++ b/pkg/agent/provision.go
@@ -357,7 +357,7 @@ func (m *AgentManager) Provision(ctx context.Context, opts api.StartOptions) (*a
 		}
 		inlineCfg.AuthSelectedType = opts.HarnessAuth
 	}
-	agentDir, _, _, cfg, err := GetAgent(ctx, opts.Name, opts.Template, opts.Image, opts.HarnessConfig, opts.ProjectPath, opts.Profile, "created", opts.Branch, opts.Workspace, inlineCfg)
+	agentDir, agentHome, _, cfg, err := GetAgent(ctx, opts.Name, opts.Template, opts.Image, opts.HarnessConfig, opts.ProjectPath, opts.Profile, "created", opts.Branch, opts.Workspace, inlineCfg)
 	if err == nil {
 		_ = UpdateAgentConfig(opts.Name, opts.ProjectPath, "created", m.Runtime.Name(), opts.Profile)
 	}
@@ -374,11 +374,12 @@ func (m *AgentManager) Provision(ctx context.Context, opts api.StartOptions) (*a
 	// Called unconditionally: with an empty script the helper removes any
 	// previously staged file, so a hook that no longer applies cannot survive
 	// on a reused agent home.
-	{
-		agentHome := config.GetAgentHomePath(opts.ProjectPath, opts.Name)
-		if err := harness.WriteProjectPreStartHook(agentHome, opts.ProjectPreStartHookScript); err != nil {
-			return cfg, fmt.Errorf("stage project pre-start hook: %w", err)
-		}
+	//
+	// Use agentHome from GetAgent (which resolves the project path correctly
+	// for non-git/external projects) rather than recomputing from opts.ProjectPath,
+	// which may be a marker file rather than a directory for such projects.
+	if err := harness.WriteProjectPreStartHook(agentHome, opts.ProjectPreStartHookScript); err != nil {
+		return cfg, fmt.Errorf("stage project pre-start hook: %w", err)
 	}
 
 	// Persist harness auth override to the on-disk config (for sciontool).

--- a/pkg/hub/scheduler_test.go
+++ b/pkg/hub/scheduler_test.go
@@ -475,10 +475,6 @@ func (m *mockScheduledEventStore) ListSkillInjections(_ context.Context, _, _ st
 	return nil, nil
 }
 
-func (m *mockScheduledEventStore) GetActiveProjectPreStartHook(_ context.Context, _ string) (*store.ProjectPreStartHook, error) {
-	return nil, store.ErrNotFound
-}
-
 // getEvent returns a snapshot of an event by ID (test helper, no error).
 // It returns a copy so callers can read fields without holding the lock.
 func (m *mockScheduledEventStore) getEvent(id string) *store.ScheduledEvent {


### PR DESCRIPTION
PR #888 introduced two CI-breaking bugs. 1) Provision computed agentHome from opts.ProjectPath instead of the resolved path, causing os.Remove to fail with ENOTDIR. Fixed by using the agentHome returned by GetAgent. 2) GetActiveProjectPreStartHook was declared twice on mockScheduledEventStore, failing the hub build. Fixed by removing the duplicate. Verified: go build and go test -tags no_sqlite both pass