### PR TITLE
fix: apply gofmt formatting to internal/fixturegen/spec.go

### DIFF
--- a/internal/fixturegen/spec.go
+++ b/internal/fixturegen/spec.go
@@ -416,10 +416,10 @@ func Spec() []TableFixture {
 		// ---- Skill injections ----
 		{Table: "skill_injections", Rows: []row{
 			{
-				"id": "si000000-0000-0000-0000-000000000001",
+				"id":    "si000000-0000-0000-0000-000000000001",
 				"scope": "project", "scope_id": projectID,
 				"skill_uri": "registry:reviewer@1.0.0",
-				"optional":   false, "sort_order": 0,
+				"optional":  false, "sort_order": 0,
 				"created_at": baseTime, "created_by": userID,
 			},
 		}},


### PR DESCRIPTION
The Format Check CI step was failing because internal/fixturegen/spec.go had misaligned struct literal field spacing introduced in a recent commit.

Verification: gofmt -l . clean, go build/vet pass, make test-fast passes all packages.

Fixes the Format Check CI breakage affecting commits db8f6fc, 298ff87, and 5679285