### PR TITLE
agent: RegisterFallback routing infrastructure for hub-side gh:// skill cache (Phase 3, conservative landing)

### DIFF
--- a/.design/project-log/ps-cache-p3-dev.md
+++ b/.design/project-log/ps-cache-p3-dev.md
@@ -1,0 +1,103 @@
+# Phase 3 — Route `gh://` skill resolution through the Hub
+
+**Branch:** `scion/ps-cache-p3-dev` (based on `scion/ps-cache-em-b`, which carries Phase 1 + Phase 2)
+**Date:** 2026-07-28
+
+## Goal
+
+Phase 1 gave the broker a singleton in-process resolution cache; Phase 2 gave the Hub a
+DB-backed `gh://` resolver. Phase 3 flips the routing so `gh://` skill URIs are resolved by
+the Hub (durable cache + GitHub App token minting) instead of by the broker-local GitHub
+resolver, while keeping the local resolver as a backstop so a Hub outage cannot break skill
+provisioning.
+
+## What changed
+
+### `pkg/agent/routing_skill_resolver.go`
+
+- Added a `fallbackResolvers map[string]SkillResolver` field to `RoutingSkillResolver`
+  (scheme → resolver used only when the Hub path fails).
+- Added `RegisterFallback(scheme, resolver)`. Registering a scheme here has two effects:
+  1. URIs with that scheme are routed to the primary fallback (Hub) *first*, so Hub-side
+     caching applies;
+  2. the registered resolver becomes the backstop if Hub fails.
+  It panics on an empty scheme or a duplicate registration, mirroring `Register`.
+- Reworked resolver selection in `Resolve()`. For each scheme group:
+  - an explicitly `Register`ed resolver still wins (unchanged behaviour);
+  - otherwise, if the scheme has a fallback resolver, Hub becomes the primary and the
+    registered resolver becomes the backstop;
+  - if no Hub is configured at all, the fallback resolver is used directly as primary
+    (avoids a nil-Hub regression for brokers without a Hub connection);
+  - otherwise the pre-existing `skill`/bare-name behaviour applies.
+- Added two failure paths:
+  - **Transport error** — Hub returns a hard error: log at `warn`, retry the *entire* scheme
+    group against the fallback. If the fallback also hard-errors, the error is surfaced as
+    `fallback resolver for scheme %q failed: ...`.
+  - **Per-URI errors** — Hub returns `ResolveError`s: log at `info`, retry only the affected
+    URIs against the fallback (`retryErrorsWithFallback`). Retried errors are dropped and
+    replaced by the fallback's resolved skills / errors; errors for URIs the fallback was not
+    asked about are preserved. If the fallback hard-errors during retry, Hub's original
+    errors are kept unchanged.
+- Added `resolverNameOf()` for nil-safe log field values. Note `SkillResolver` does **not**
+  declare `ResolverName()`, so this uses an interface type assertion and falls back to `%T`.
+
+Logging uses `log/slog`, consistent with the rest of `pkg/agent`.
+
+### `pkg/runtimebroker/handlers.go`
+
+Single-line routing change (plus a comment):
+
+```go
+- router.Register("gh", ghResolver)
++ router.RegisterFallback("gh", ghResolver)
+```
+
+`hub_skill_resolver.go` was intentionally left untouched — it already forwards
+`opts.ProjectID`, which the Hub needs for GitHub App token minting.
+
+## Tests added — `pkg/agent/routing_skill_resolver_test.go`
+
+Nine new cases, all using the existing `mockSchemeResolver`:
+
+| Test | Covers |
+| --- | --- |
+| `RegisterFallback_HubSuccess` | `gh://` goes to Hub; local resolver never called |
+| `RegisterFallback_HubTransportError` | Hub hard error → all group refs retried locally |
+| `RegisterFallback_BothFail` | Hub *and* fallback hard error → wrapped error surfaced |
+| `RegisterFallback_HubPerURIError` | only the errored URI retried; results merged, error cleared |
+| `RegisterFallback_FallbackAlsoErrors` | fallback's per-URI error replaces Hub's |
+| `RegisterFallback_NoHubUsesFallbackDirectly` | nil Hub → fallback used as primary |
+| `RegisterFallback_PrimaryTakesPrecedence` | `Register` beats `RegisterFallback` for a scheme |
+| `RegisterFallback_MixedBatch` | `skill://` + `gh://` both reach Hub in separate calls |
+| `RegisterFallbackPanics` | empty scheme and duplicate scheme both panic |
+
+## Build & test results
+
+| Check | Result |
+| --- | --- |
+| `gofmt -l pkg/agent pkg/runtimebroker` | clean |
+| `go build ./...` | pass |
+| `go vet ./pkg/agent/... ./pkg/runtimebroker/...` | pass |
+| `go test ./pkg/agent/ -run 'TestRoutingSkillResolver\|TestDetectScheme'` | 20/20 pass |
+| `go test ./pkg/runtimebroker/...` | pass |
+| `go test ./pkg/agent/...` | one **pre-existing** failure (see below) |
+
+### Pre-existing failure (not caused by Phase 3)
+
+`TestProvisionWritesTaskToPromptMd` (`with_task` and `without_task`) fails on the base
+commit `a42cb8ed` as well — verified by stashing the Phase 3 diff and re-running:
+
+```
+provision_test.go:252: Provision failed: stage project pre-start hook:
+  remove stale pre-start hook: .../hooks/pre-start.d/30-project-custom: not a directory
+```
+
+This comes from the pre-start hook staging work merged in #888, not from skill routing.
+Flagging it for the EM — it likely needs a separate fix on `main`.
+
+## Notes for review
+
+- The workspace was originally branched from `main`, which does **not** contain Phase 1 or
+  Phase 2. The branch was reset onto `origin/scion/ps-cache-em-b` before starting so Phase 3
+  builds on the correct base. `origin/main` is an ancestor of that branch (11 commits behind).
+- Not pushed — the EM will push after code review.

--- a/.design/project-log/ps-cache-p3-fix.md
+++ b/.design/project-log/ps-cache-p3-fix.md
@@ -1,0 +1,118 @@
+# ps-cache-p3-fix — Phase 3 review fixes
+
+**Agent:** ps-cache-p3-fix
+**Date:** 2026-07-29
+**Branch:** `scion/ps-cache-p3-fix` (pushed to `scion/ps-cache-p3`)
+**Base:** `1d4775ec` "Phase 3: route gh:// skill resolution through Hub with local fallback"
+
+Addresses the reviewer's REQUEST CHANGES on Phase 3. Of the three blocking
+issues, two (BLOCKING-1, BLOCKING-2) are pre-existing Phase 2 Hub-side defects
+on `main` and are being fixed separately. BLOCKING-3 was in this diff and is
+fixed here.
+
+---
+
+## Changes
+
+### 1. BLOCKING-3 — same-URI alias drop in `retryErrorsWithFallback`
+
+File: `pkg/agent/routing_skill_resolver.go`
+
+`retryErrorsWithFallback` deduplicated retry candidates by URI before calling
+the fallback. When the same URI appears under two different `As` aliases (the
+same `gh://` skill imported under two names), only the first alias's ref was
+sent to the fallback. The second alias was silently lost: its error was cleared
+from the merged result, but no resolved skill came back for it — a silent
+partial failure with no diagnostic.
+
+Fix: the retry set is now keyed by ref rather than by URI, so every alias of an
+errored URI is handed to the fallback.
+
+```go
+retryRefs := make([]api.SkillReference, 0, len(sr.Errors))
+retriedURIs := make(map[string]bool, len(sr.Errors))
+for _, ref := range schemeRefs {
+    if errored[ref.URI] {
+        retryRefs = append(retryRefs, ref)
+        retriedURIs[ref.URI] = true
+    }
+}
+```
+
+**Deviation from the brief (deliberate).** The brief specified filtering the
+merge step by `errored` rather than by a retried-set. Because `errored` is
+built *from* `sr.Errors`, the predicate `!errored[e.URI]` is false for every
+element of `sr.Errors` — the loop becomes dead code. That is harmless in the
+normal path, but it means an error whose URI has *no* matching ref in
+`schemeRefs` would be dropped without ever being retried: no resolved skill and
+no error, i.e. exactly the silent-failure class this ticket is fixing. It also
+contradicts the function's own doc comment ("errors for URIs the fallback was
+not asked about are preserved").
+
+I therefore filter by `retriedURIs`, derived from the refs actually sent to the
+fallback. This is identical to the brief's behaviour whenever the primary only
+reports errors for URIs it was asked about (the realistic case), fixes the
+alias drop equally, and additionally preserves the documented guarantee.
+
+### 2. Revert `gh://` activation, keep the machinery
+
+File: `pkg/runtimebroker/handlers.go`
+
+Per the reviewer's split recommendation: the routing machinery
+(`RegisterFallback`) lands, but the one-line switch that activates it for
+`gh://` is held back until the Phase 2 Hub defects (hash format mismatch,
+missing `Content` field, ref-defaulting) are fixed. `router.RegisterFallback`
+reverted to `router.Register`, with a comment recording why and what to flip.
+
+### 3. Design doc
+
+Copied `design-cache-durability.md` to `.design/ps-cache-durability.md`, the
+destination named in the doc's own header.
+
+---
+
+## Tests
+
+Added `TestRoutingSkillResolver_RegisterFallback_SameURIDifferentAliases` in
+`pkg/agent/routing_skill_resolver_test.go`, plus an `echoResolver` test double
+that resolves each ref into its own `ResolvedSkill` preserving `As`. The
+existing `mockSchemeResolver` returns a fixed result set and so cannot
+distinguish per-alias behaviour.
+
+The test drives Hub to return a per-URI error for a URI present twice under two
+`As` values, then asserts both aliases reach the fallback and both come back
+resolved. Against the pre-fix resolver it fails at `fallback received 1 refs,
+want 2`.
+
+### Verification status — BLOCKED, not run
+
+**The Go toolchain could not build in this workspace: the container volume is
+100% full.**
+
+```
+unzip .../google.golang.org/api/@v/v0.285.0.zip: no space left on device
+```
+
+`google.golang.org/api` (a transitive dep of `cloud.google.com/go/storage`,
+which `pkg/agent` imports) unpacks to several GB; free space was 274 MB on
+first attempt and fell to 84 MB over the session, so the pressure is from
+outside this container. Nothing meaningful is reclaimable from inside: the
+container's own footprint is ~3.5 GB, of which the Go module cache is 498 MB
+(all needed) and the build cache 9.3 MB; the largest files are base-image
+tooling (chromium 261 MB, claude 263 MB, scion 117 MB) that must not be
+deleted.
+
+Consequently **none** of the requested commands were run:
+
+- `go vet ./pkg/agent/... ./pkg/runtimebroker/...` — not run
+- `go test ./pkg/agent/... -run 'TestRoutingSkillResolver|TestDetectScheme'` — not run
+- `go test ./pkg/runtimebroker/...` — not run
+
+Nor could I confirm the noted pre-existing `TestProvisionWritesTaskToPromptMd`
+failure against the unmodified base.
+
+What *was* verified: `gofmt -l` is clean on all three modified files, and the
+diff was reviewed by hand. The changes are small and local — two map
+operations, a one-line call swap, and an additive test — but **they are
+unverified and must not be treated as tested.** Re-run the three commands above
+on a host with free disk before merging.

--- a/.design/project-log/ps-cache-p3-review-v2.md
+++ b/.design/project-log/ps-cache-p3-review-v2.md
@@ -65,3 +65,71 @@ Before `router.Register("gh", ...)` → `router.RegisterFallback("gh", ...)` is 
 3. `ctx` timeout issue (I-4) addressed
 4. Broker integration test: Hub success path for `gh://` (currently zero coverage of handlers.go:760)
 5. Hub integration test: two sequential resolve calls → 1 GitHub API call (Phase 2 acceptance criterion)
+
+---
+
+## Gemini PR feedback fixes
+
+Applied to `pkg/agent/routing_skill_resolver.go` (branch `scion/ps-cache-p3`).
+
+### 1. Silently omitted refs now trigger the fallback retry (closes I-6)
+
+The fallback retry was gated on `len(sr.Errors) > 0`. If Hub returned a short
+result with no matching error entry — a URI dropped outright, or two `As`
+aliases of one URI collapsed into a single `ResolvedSkill` — the router
+accepted the truncated result and the ref vanished from the install set with no
+error surfaced to the caller.
+
+Gate is now `len(sr.Resolved) < len(schemeRefs)`: any shortfall between refs
+requested and skills returned triggers the retry, whether or not the primary
+bothered to explain itself.
+
+### 2. Retry set keyed by (URI, As), not by URI
+
+`retryErrorsWithFallback` built an `errored map[string]bool` from `sr.Errors`
+and retried refs whose URI appeared in it. That could only ever retry refs the
+primary explicitly errored on, and treated all aliases of a URI as a unit.
+
+Replaced with a `resolvedRefs map[string]int` built from `sr.Resolved`, keyed by
+`refKey(uri, as)` = `uri + "\x00" + as`. Each ref in `schemeRefs` consumes one
+matching resolved slot; refs with no slot left are retried. Consequences:
+
+- An alias the primary omitted is retried even when its sibling alias resolved.
+- An alias the primary *did* resolve is **not** re-fetched from the fallback
+  (avoids the duplicate-work half of I-2/NB-1).
+- Counts rather than booleans, so a genuinely duplicated `(URI, As)` pair in the
+  request is matched one-for-one instead of collapsing.
+
+Error merging is unchanged in shape: primary errors for URIs that were retried
+are superseded by the fallback's outcome; errors for URIs never retried are
+preserved. `\x00` cannot occur in a URI or a skill alias, so the key is
+unambiguous.
+
+### 3. Log message corrected
+
+`"primary skill resolver reported errors, retrying..."` →
+`"primary skill resolver did not resolve all refs, retrying..."`, since the
+retry no longer implies the primary reported anything.
+
+### Test coverage
+
+Added `TestRoutingSkillResolver_RegisterFallback_SilentDrop` with three subtests:
+
+| Subtest | Scenario | Asserts |
+|---|---|---|
+| `ref omitted with no error` | Hub returns 1 of 2 refs, no errors | Only the dropped URI is retried; both come back resolved; no errors |
+| `alias omitted with no error` | Hub returns `As:"first"` only, no errors | Only `As:"second"` is retried; both aliases resolved |
+| `no retry when every ref is accounted for` | Hub returns both aliases | Fallback never called |
+
+The second subtest is the direct regression guard for the old gate — under
+`len(sr.Errors) > 0` the fallback is never invoked and the result is short by
+one alias.
+
+Existing tests unchanged and passing, including
+`TestRoutingSkillResolver_RegisterFallback_SameURIDifferentAliases` (both
+aliases still reach the fallback when Hub errors on the URI).
+
+**Status:** `go vet ./pkg/agent/...` clean; `go test ./pkg/agent/...` fully green.
+
+**Note:** I-4 (shared `ctx` between Hub call and fallback) is *not* addressed
+here and remains an open entry-criterion item.

--- a/.design/project-log/ps-cache-p3-review-v2.md
+++ b/.design/project-log/ps-cache-p3-review-v2.md
@@ -1,0 +1,67 @@
+# Phase 3 Code Review v2 — APPROVE
+
+**Branch:** `scion/ps-cache-p3`  
+**Commits reviewed:** `1d4775ec` + `fb971fc1`  
+**Reviewer:** `ps-cache-p3-review`  
+**Date:** 2026-07-29  
+**Verdict:** ✅ APPROVE — safe to merge
+
+---
+
+## Summary
+
+Both in-diff conditions from the v1 REQUEST CHANGES are met, and met well.
+
+**BLOCKING-3 fixed:** `retryErrorsWithFallback` now keys the retry set by *ref* (not URI), so every `As` alias of an errored URI reaches the fallback. The new test `TestRoutingSkillResolver_RegisterFallback_SameURIDifferentAliases` is a REAL regression guard — it FAILS against the old resolver (`1d4775e`) and passes against the new one. Not a tautological test.
+
+**handlers.go revert:** Exactly the split recommended in v1. Net production diff vs main is now THREE COMMENT LINES. `RegisterFallback` has zero production callers. BLOCKING-1 and BLOCKING-2 are unreachable via the broker. Merging this is safe.
+
+The `ps-cache-p3-fix` commit message independently identifies the correct reason for keying the merge filter on `retriedURIs` rather than `errored` — that is independent thinking, not patch-application. `echoResolver` (new mock for per-alias testing) was also the right call.
+
+---
+
+## Verification Status
+
+**Tests:** 26/26 pass via EM-container run (`go test ./pkg/agent/... -run 'TestRoutingSkillResolver|TestDetectScheme'` and `go test ./pkg/runtimebroker/...`) and independently verified by reviewer via standalone compilation of the routing resolver against type stubs (go vet clean, gofmt clean, 26/26).
+
+**Note:** The commit message on `fb971fc1` says "NOT VERIFIED" (tests could not run in the developer's full-disk container). The EM container ran the same tests successfully. The contradiction is a record-keeping issue in the commit message — the tests are confirmed green by two independent executions.
+
+---
+
+## Findings
+
+### RESOLVED
+
+- **BLOCKING-1** (hash format mismatch): Deferred — unreachable via broker now that `Register("gh",...)` is back. Tracked in Phase 2b fix workstream (`ps-cache-p2b-fix`).
+- **BLOCKING-2** (missing Content field): Same — deferred to Phase 2b.
+- **BLOCKING-3** (same-URI alias drop): ✅ Fixed in `fb971fc1`. Confirmed by regression test.
+- **I-7** (handlers.go no broker test): ✅ RESOLVED — comment-only change in handlers.go means there is no broker behaviour to test.
+
+### STILL OPEN — Phase 2b priority (LIVE on main regardless of revert)
+
+- **I-3 (IMPORTANT — LIVE):** Hub's `gh://` branch in `/api/v1/skills/resolve` runs `resolveGitHubSkill()` before `CheckAccess` with the caller-supplied `ProjectID`. The registry path has a cross-project access check (`TestSkillAuthz_Resolve_ForbiddenSkill:211`). The `gh://` branch has no equivalent: a caller can POST with a `ProjectID` they do not own and the Hub will mint that project's GitHub App token. The endpoint IS authenticated (nil-identity test exists), but cross-project isolation is unguarded. This is live on main; reverting `handlers.go` changes broker routing, not Hub endpoint behaviour. **Fix before Phase 3 flip, not after.**
+
+### DEFERRED — fix before Phase 3 "flip the switch" PR
+
+- **I-1:** `retryErrorsWithFallback` silently discards primary resolver's `Resolved` entries for URIs that also have errors (contradicts the Hub's spec of returning either Resolved or Error per URI, not both — but fix is defensive).
+- **I-2:** `retryErrorsWithFallback` over-retry: if Hub returns the same URI in both `Resolved` and `Errors` (possible if a URI appears twice in the request), the retry path produces 3 resolved entries for 2 refs. Visible (not silent), but worth fixing.
+- **I-4:** `ctx` passed to fallback is the same ctx used for the Hub call; a Hub timeout that cancels `ctx` will also immediately fail the fallback. A parent context should be used.
+- **I-5:** Primary resolver errors are discarded on retry; no structured log of Hub's original errors before they are replaced.
+- **I-6:** Hub may omit a URI from its response entirely (no Resolved, no Error entry); silently dropped.
+
+### NON-BLOCKING (all green to merge now)
+
+- **NB-1:** `retryErrorsWithFallback` over-count when Hub returns URI in both Resolved and Errors (same as I-2 above; visible artefact, not silent failure).
+- **NB-2 through NB-6:** Various minor observations per original review.
+
+---
+
+## Entry criteria for Phase 3 "flip the switch" PR
+
+Before `router.Register("gh", ...)` → `router.RegisterFallback("gh", ...)` is re-activated:
+
+1. Phase 2b defects fixed and merged: hash format (BUG-1), expiring URLs (BUG-2), ref-defaulting (BUG-3), cross-project authz (I-3)
+2. `retryErrorsWithFallback` I-2 over-retry fixed
+3. `ctx` timeout issue (I-4) addressed
+4. Broker integration test: Hub success path for `gh://` (currently zero coverage of handlers.go:760)
+5. Hub integration test: two sequential resolve calls → 1 GitHub API call (Phase 2 acceptance criterion)

--- a/.design/ps-cache-durability.md
+++ b/.design/ps-cache-durability.md
@@ -1,0 +1,435 @@
+# Design: gh:// Resolution Cache Durability (Track B)
+
+**Author:** ps-cache-arch-b  
+**Date:** 2026-07-27  
+**Status:** Approved by user — ready for implementation (pending PR #878 merge)  
+**Design doc destination (in PR):** `.design/ps-cache-durability.md`
+
+---
+
+## Problem & Goals
+
+The GitHub skill resolution cache (`GitHubResolutionCache`) is per-process, ephemeral, and unshared. On Cloud Run, each broker instance has a permanently cold cache, causing `resolveCommitSHA` — a rate-limited GitHub REST API call — to be made on every agent-creation request. With a shared outbound IP (Cloud NAT), 10 concurrent broker instances each making 2 API calls per skill can exhaust the 60/hr unauthenticated limit in minutes, and stresses the 5000/hr authenticated limit at scale.
+
+**Root causes (from `ps-cache-inv` investigation):**
+
+1. `GitHubSkillResolver` is instantiated per-request — disk cache is reloaded from JSON on every request, even within the same instance.
+2. Cache is local to each broker instance — N instances = N independent cold caches for the same URI.
+3. Disk cache is ephemeral on Cloud Run — lost on instance restart.
+
+**Note on Track A / PR #878:** Track A (upstream PR #878, `scion/project-skills-cache-auth-fix`) is addressing the immediate auth-gap symptom and the full-SHA short-circuit. Do not duplicate those changes. PR #878 makes three changes relevant to Track B:
+1. `resolveCommitSHA` short-circuits for full 40-char SHA refs — after #878 lands, SHA refs never reach the Hub's resolve path from Phase 3 (they short-circuit at the broker). The Hub-side SHA TTL constant is still worth defining for completeness.
+2. Cache-init error is now logged — Phase 1's singleton approach moves this from a per-request log to a startup log; both are additive.
+3. `provisionCredentials["GITHUB_TOKEN"]` is now a general fallback token — Phase 3's fallback resolver inherits this behavior.
+
+**Track B must be implemented on a branch rebased onto main after PR #878 merges.** The Phase 1 singleton change touches the same files as #878 (github_skill_resolver.go) — rebase is mandatory before starting Track B implementation.
+
+**Goals:**
+
+- Eliminate per-request cold-cache loads within a single broker instance (within-instance fix).
+- Eliminate duplicate GitHub API calls across multiple broker instances (cross-instance fix).
+- Make the resolution cache durable across broker instance restarts.
+- HA-compatible: cache survives Hub restarts (DB-backed, not in-memory).
+- No change to how skill files reach agent containers — this design only affects the metadata resolution step.
+
+---
+
+## Non-Goals
+
+- Full-SHA short-circuit (Track A).
+- Cache init error logging (Track A).
+- Auth gap fix (Track A).
+- Changing skill file delivery into agent containers (bind-mount for Docker, tar-stream via K8s exec for GKE — these are correct and unchanged).
+- Rate-limit observability / alerting.
+- Caching skill file bytes at the Hub level (Hub returns URLs; brokers download files from GitHub CDN as they do today).
+
+---
+
+## Background: The Three-Cache Architecture
+
+Understanding what each cache does is essential — the investigator's findings contain a key code detail worth restating here.
+
+| Cache | Location | Keyed by | Stores | Survives restart? |
+|---|---|---|---|---|
+| `GitHubResolutionCache` | Broker disk (`~/.scion/cache/github-resolution/`) | `sha256(URI + token_hash)` | Resolution metadata: commitSHA, file list, URLs, bundle hash. **File bytes are `json:"-"` — not persisted.** | No (Cloud Run ephemeral). |
+| `skCache` (`templatecache.Cache`) | Broker disk (`~/.scion/cache/skills/`) | Bundle content hash | Actual skill file bytes, content-addressed. Already a server-level singleton. | No (Cloud Run ephemeral). |
+| In-memory map | Per `GitHubSkillResolver` instance | Same as resolution cache | Same as resolution cache, but ephemeral per-request. | N/A — destroyed per request today. |
+
+**Critical finding:** `ResolvedFile.Content` has tag `json:"-"` — file bytes are never written to the disk resolution cache. After a broker restart, a resolution cache HIT returns the metadata but `Content == nil`, so `installOneSkill` falls through to download files from `raw.githubusercontent.com` (GitHub's CDN, which is not subject to the same rate limits as the REST API). The resolution cache's sole job is to save the two rate-limited REST API calls: `GET /repos/{owner}/{repo}/commits/{ref}` and `GET /repos/{owner}/{repo}/contents/{path}`.
+
+**What Track B needs to cache:** Only the resolution metadata (commitSHA, file list, URLs, bundle hash) — less than 1 KB per skill. File delivery to containers is unchanged.
+
+---
+
+## Proposed Design
+
+### Approach: Hub-Side Shared Resolution Cache (Option C)
+
+All broker instances route `gh://` skill resolution through the Hub's existing `/api/v1/skills/resolve` endpoint. The Hub maintains a DB-backed (PostgreSQL via ent ORM) cache of `(uri, token_scope) → {commitSHA, file_list}`. The Hub calls GitHub API only on cache misses. Since all brokers share one Hub, all instances share one resolution cache. The DB backend makes the cache durable across Hub restarts.
+
+This design has three sub-changes that can be deployed independently in sequence.
+
+---
+
+### Sub-change 1 (Phase 1): Broker Singleton Resolution Cache
+
+**What it fixes:** Per-request cold disk loads within a single instance.  
+**Independent of Hub changes.** Deployable alone.
+
+**Current code path (handlers.go:759):**
+```go
+// Per-request: loads JSON from disk every time
+ghResolver := agent.NewGitHubSkillResolverWithCredentials(defaultGHToken, req.ProvisionCredentials)
+```
+
+`NewGitHubSkillResolver()` calls `NewGitHubResolutionCache()` which calls `c.load()` (disk read) on every request. The result is a fresh, ephemeral in-memory cache that's discarded after the request.
+
+**Change:**
+
+Add `ghResolutionCache *agent.GitHubResolutionCache` to the `server` struct alongside `skCache` and `hcCache`. Initialize once at startup in `initHubIntegration`. Pass the singleton into `NewGitHubSkillResolverWithCredentials`.
+
+```pseudocode
+// server struct:
+ghResolutionCache *agent.GitHubResolutionCache
+
+// initHubIntegration:
+ghResDir, err := agent.GitHubResolutionCacheDir()
+if err != nil {
+    slog.Warn("github resolution cache: cannot determine cache dir", "error", err)
+} else {
+    cache, err := agent.NewGitHubResolutionCache(ghResDir, agent.DefaultResolutionCacheTTL)
+    if err != nil {
+        slog.Warn("github resolution cache: init failed (running uncached)", "error", err)
+        // nil cache is safe — resolver falls through to API call
+    }
+    s.ghResolutionCache = cache
+}
+
+// handlers.go:
+ghResolver := agent.NewGitHubSkillResolverWithCredentials(
+    defaultGHToken, req.ProvisionCredentials, s.ghResolutionCache,
+)
+```
+
+`NewGitHubSkillResolverWithCredentials` signature gains an optional `*GitHubResolutionCache` parameter (or the singleton is wired via a setter). The cache's `mu sync.RWMutex` already makes it safe for concurrent goroutines.
+
+**TTL consideration:** Also increase `DefaultResolutionCacheTTL` from 5 minutes to 30 minutes for branch refs. For SHA refs, Track A's short-circuit means Hub is never called, so TTL is moot. A separate `DefaultSHAResolutionCacheTTL = 24h` constant can be added for completeness when the Hub-side design lands.
+
+**Effect:** Within one instance's lifetime, the second request for the same skill URI makes 0 GitHub API calls. The first request still makes 2 (resolveCommitSHA + listContents) on a cold start.
+
+---
+
+### Sub-change 2 (Phase 2): Hub DB Schema and Resolver
+
+#### New ent Schema Entity
+
+```go
+// pkg/ent/schema/github_resolution_cache.go
+type GitHubResolutionCache struct { ent.Schema }
+
+func (GitHubResolutionCache) Fields() []ent.Field {
+    return []ent.Field{
+        field.String("cache_key").NotEmpty().Unique(),  // sha256(uri + ":" + token_scope)
+        field.String("original_uri").NotEmpty(),         // for debugging
+        field.String("commit_sha").NotEmpty(),
+        field.JSON("file_entries", []GitHubFileEntry{}), // [{path, url, hash, size}, ...]
+        field.String("bundle_hash").NotEmpty(),
+        field.String("token_scope").Default("public"),   // GitHub App installation ID or "public"
+        field.Time("expires_at"),
+        field.Time("create_time").Default(time.Now).Immutable(),
+    }
+}
+
+func (GitHubResolutionCache) Indexes() []ent.Index {
+    return []ent.Index{
+        index.Fields("cache_key").Unique(),
+        index.Fields("expires_at"),  // for efficient TTL eviction
+    }
+}
+
+func (GitHubResolutionCache) Annotations() []schema.Annotation {
+    return []schema.Annotation{
+        entsql.Annotation{Table: "github_resolution_cache"},
+    }
+}
+```
+
+`GitHubFileEntry` is a value type (not ent entity): `{Path, URL, Hash string; Size int64}`. Stored as JSONB on Postgres, TEXT (JSON string) on SQLite.
+
+**SQLite compatibility:** Phase 2 works transparently on both SQLite (single-node Hub deployments) and PostgreSQL (HA deployments). The ent `field.JSON()` type maps to JSONB on Postgres and TEXT on SQLite — identical to the existing `HubSetting.value` field pattern. The eviction query only filters by `expires_at` (a standard TIME field); no Postgres-specific JSONB operators are used. The `Get`/`Put` operations are plain row lookups by primary key. SQLite's single-writer model is fine for single-node deployments; Postgres handles concurrent Hub instances for HA.
+
+#### Cache Key Design
+
+```
+cache_key = sha256hex(normalized_uri + ":" + token_scope_id)
+
+normalized_uri = "gh://{owner}/{repo}/{path}@{ref}"  // lowercased owner/repo
+token_scope_id = GitHub App installation ID (stable, not the rotating token value)
+               = "public" for unauthenticated/public repos
+```
+
+**Why installation ID not token hash:** App tokens rotate every hour. The installation ID is stable for the lifetime of a GitHub App installation on a repo. Using it as the scope ID ensures cache entries remain valid across token rotations. For public repos, `"public"` is used (no credential).
+
+#### Hub Server Changes
+
+Add to `Server` struct:
+```pseudocode
+ghResolutionStore *GitHubResolutionStore  // nil if DB not available
+```
+
+Initialize in `Server.Start()` or `initHubIntegration`.
+
+Add `resolveGitHubSkill(ctx, uri, projectID string) (*ResolvedSkillResponse, error)`:
+
+```pseudocode
+func (s *Server) resolveGitHubSkill(ctx, rawURI, projectID string) (*ResolvedSkillResponse, error) {
+    // 1. Parse gh:// URI (owner, repo, path, ref)
+    ghRef, err := parseGitHubSkillURI(rawURI)
+
+    // 2. Determine token scope
+    installID, token, err := s.resolveGitHubToken(ctx, projectID)
+    // installID = "public" if no App integration for this project
+    // token = minted App installation token, or ""
+
+    // 3. Cache lookup
+    cacheKey = computeCacheKey(ghRef, installID)
+    if entry, ok := s.ghResolutionStore.Get(ctx, cacheKey); ok {
+        return entryToResponse(entry), nil
+    }
+
+    // 4. Cache miss: call GitHub API
+    commitSHA, fileList, bundleHash, err := resolveViaGitHubAPI(ctx, ghRef, token)
+    
+    // 5. Determine TTL
+    ttl = branchRefTTL  // default 30 min, from Hub admin settings
+    if isFullSHA(ghRef.Ref) { ttl = shaRefTTL }  // 24h
+
+    // 6. Store and return
+    s.ghResolutionStore.Put(ctx, cacheKey, {commitSHA, fileList, bundleHash, installID, expiresAt: now+ttl})
+    return buildResponse(ghRef, commitSHA, fileList, bundleHash), nil
+}
+```
+
+Wire into `handleSkillsResolve` before the existing `resolveSkill` call:
+
+```pseudocode
+// In the per-skill loop in handleSkillsResolve:
+if strings.HasPrefix(skillRef.URI, "gh://") {
+    resolved, err := s.resolveGitHubSkill(ctx, skillRef.URI, req.ProjectID)
+    if err != nil {
+        resolveErrors = append(resolveErrors, ResolveSkillError{...})
+    } else {
+        resolved = append(resolved, *resolved)
+    }
+    continue
+}
+// existing registry-skill resolution follows
+```
+
+#### Token Resolution on Hub
+
+```pseudocode
+func (s *Server) resolveGitHubToken(ctx, projectID string) (installID, token string, err error) {
+    if projectID == "" {
+        return "public", "", nil
+    }
+    project, err := s.store.GetProject(ctx, projectID)
+    if project.GitHubInstallationID == nil {
+        return "public", "", nil
+    }
+    token, _, err = s.mintGitHubAppToken(ctx, project)
+    installID = strconv.FormatInt(*project.GitHubInstallationID, 10)
+    return installID, token, err
+}
+```
+
+`mintGitHubAppToken` already exists on the Hub server struct (`handlers_github_app_webhook.go:704`). This reuses the exact same mechanism used by `httpdispatcher.go` for agent creation.
+
+#### Background TTL Eviction
+
+Start a goroutine in Hub startup:
+
+```pseudocode
+go func() {
+    ticker := time.NewTicker(10 * time.Minute)
+    for range ticker.C {
+        if err := s.ghResolutionStore.PurgeExpired(ctx); err != nil {
+            slog.Warn("github_resolution_cache: eviction failed", "error", err)
+        }
+    }
+}()
+```
+
+`PurgeExpired` deletes rows where `expires_at < now()`. Max expected table size: (number of distinct skill URIs × projects) × row size ≈ negligible.
+
+#### Hub Admin Settings
+
+Add two new keys to Hub admin settings (existing `hub_settings` table):
+
+```json
+{
+  "github_resolution_cache": {
+    "branch_ref_ttl_minutes": 30,
+    "sha_ref_ttl_hours": 24,
+    "enabled": true
+  }
+}
+```
+
+These can be read at resolve time; the defaults ship in the seed data.
+
+---
+
+### Sub-change 3 (Phase 3): Broker Routing Change
+
+Remove local `GitHubSkillResolver` as the primary handler for the `"gh"` URI scheme. `gh://` URIs fall through to `HubSkillResolver`, which calls Hub's `/api/v1/skills/resolve` endpoint.
+
+```pseudocode
+// handlers.go — BEFORE:
+ghResolver := agent.NewGitHubSkillResolverWithCredentials(defaultGHToken, req.ProvisionCredentials)
+router.Register("gh", ghResolver)
+
+// handlers.go — AFTER:
+// gh:// URIs fall through to Hub resolver (hub handles them server-side)
+// Keep ghResolver available as fallback only:
+ghResolver := agent.NewGitHubSkillResolverWithCredentials(defaultGHToken, req.ProvisionCredentials, s.ghResolutionCache)
+router.RegisterFallback("gh", ghResolver)  // only called if Hub returns resolve error for gh:// URI
+```
+
+**`RegisterFallback` semantics** (new method on `RoutingSkillResolver`, or handled in the `HubSkillResolver` error path): if Hub returns a `not_found` or `resolve_failed` error for a `gh://` URI, retry with the registered fallback resolver. This provides resilience during Hub downtime and gradual rollout.
+
+**`ProjectID` in resolve request:** `HubSkillResolver.Resolve()` must pass `req.ProjectID` in `ResolveSkillsRequest.ProjectID`. Verify this is already threaded through; if not, add it. The Hub needs `ProjectID` to mint the App token.
+
+---
+
+## Alternatives Considered
+
+### B1: Full-SHA Short-Circuit Only (Already in Track A)
+
+Eliminates API calls for pinned SHA refs (the most common production pattern). Does not help with branch refs or the per-instance problem. Track B is the correct home for the remaining cross-instance issue.
+
+### B2: Shared Persistent Volume (GCS FUSE or NFS)
+
+Mount the broker's `~/.scion/cache/github-resolution/` on a GCS FUSE volume or Cloud Filestore NFS share. All instances read/write the same JSON file.
+
+**Rejected because:**
+1. `os.Rename()` atomicity — the current write pattern (`write tmpfile → rename`) is NOT atomic on GCS FUSE. Concurrent writes from N instances can silently lose entries (last-write-wins on the underlying object), and the tmpfile+rename trick doesn't protect against this on GCS FUSE.
+2. NFS avoids the rename issue but introduces network latency on every cache read/write, and requires per-Cloud-Run-service NFS mount provisioning.
+3. GCS FUSE has significant per-operation latency (10–100ms) for small random file reads — unacceptable for a cache that's consulted on every request.
+4. Does not survive Hub restarts (separate concern, but Hub-side DB handles both broker-restart and Hub-restart durability in one design).
+
+### Option A: Broker Singleton Only (No Hub Changes)
+
+Lift `GitHubResolutionCache` to server-level singleton. Fixes the per-request cold load. Does NOT solve the cross-instance problem — 10 fresh broker instances each build their own independent in-process caches. Adopted as **Sub-change 1 (Phase 1)** as an independent improvement and as the L1 in-process cache in the layered design, but insufficient alone for HA broker fleets.
+
+### Hub In-Memory Cache (DB-less)
+
+Hub maintains a process-level in-memory `sync.Map` for resolution entries. Simpler than DB. Rejected because: (a) multiple Hub instances lose the single-point-of-truth property, (b) Hub restarts clear the cache — cold start amplification happens at Hub restarts too if Hub fleet scales. DB-backed cache satisfies the user's HA requirement.
+
+---
+
+## Migration / Rollout
+
+This design is three independently-deployable phases:
+
+**Phase 1 — Broker singleton (no Hub changes, no DB change)**
+- Broker restart needed (not a Hub change).
+- Immediately reduces per-request disk I/O within each broker instance.
+- Backward-compatible: nil singleton is handled gracefully (resolver falls through to API).
+- Also bump `DefaultResolutionCacheTTL` from 5 min → 30 min.
+
+**Phase 2 — Hub DB and resolver (Hub change + DB migration)**
+- DB migration: add `github_resolution_cache` table (additive, zero-downtime migration via ent's `AutoMigrate` or explicit migration script).
+- Hub instances without the new code simply skip the `gh://` branch — the broker's local fallback (still registered) handles resolution.
+- Hub instances with the new code begin populating the cache. Old and new Hub instances can coexist during rollout.
+- No broker change at this phase.
+
+**Phase 3 — Broker routing change (broker change, depends on Phase 2 being complete)**
+- After Hub is fully updated (Phase 2 complete across all Hub instances), update brokers to prefer Hub for `gh://` resolution.
+- Keep fallback to local resolver (Sub-change 1 singleton cache) during rollout for resilience.
+- Monitor Hub logs for `gh://` cache hit/miss ratio to validate.
+- Once hit rate stabilizes, the fallback can be kept indefinitely (adds resilience, costs nothing in the happy path).
+
+**Forward compatibility:** If Hub is upgraded before the broker, Hub handles `gh://` URIs but brokers haven't changed their routing yet — brokers still call local resolver, Hub's new capability is unused but not harmful.
+
+**Backward compatibility:** If broker is upgraded (Phase 3) before Hub (Phase 2), Hub returns resolve errors for `gh://` URIs, broker falls back to local resolver — no user-visible failure.
+
+---
+
+## Open Questions
+
+1. **Hub instance count:** If Hub itself runs N > 1 instances for HA, the in-memory tier is absent (no `ghResolutionCache` on Hub), and the DB table is the only shared state. This is correct — the DB provides the cross-Hub-instance durability the user required. Confirm Hub instances share a single PostgreSQL DB (expected: yes, standard for HA Postgres deployments).
+
+2. **Monitoring:** The Hub's resolve handler should emit a structured log line distinguishing cache hit vs. miss for `gh://` URIs (`"github_resolution_cache_hit": true/false`). The Phase 3 broker routing change makes these logs the primary observability signal for the new system. Add a metric counter if the Hub has a Prometheus registry.
+
+3. **GKE broker topology:** The investigation focused on Cloud Run brokers. If brokers also run on GKE (separate deployment), the same design applies — GKE broker instances also share the same Hub, so they benefit from Phase 2 and 3 identically.
+
+## Resolved Design Decisions (from user sign-off)
+
+- **Credential passing for `?token=SECRET_NAME` URIs:** Hub has access to project secrets via its existing secrets store. Developer should look up the named secret using `ProjectID` via `s.store` (same access path used elsewhere in the Hub for project secret resolution). If the secret is not found Hub-side, fall back to broker-local resolution.
+
+- **SQLite compatibility:** Phase 2 works on both SQLite and Postgres (see note in ent schema section above).
+
+- **PR #878 sequencing:** Track B implementation starts only after PR #878 merges into upstream main. Branch must be rebased onto post-#878 main before starting Phase 1.
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Broker Singleton Cache (~30 LoC)
+
+Load-bearing files: `pkg/runtimebroker/server.go`, `pkg/runtimebroker/handlers.go`, `pkg/agent/github_skill_resolver.go`
+
+1. Export `githubResolutionCacheDir()` → `GitHubResolutionCacheDir()` (needed by server.go).
+2. Add `ghResolutionCache *agent.GitHubResolutionCache` field to `server` struct.
+3. Initialize in `initHubIntegration` alongside `skCache` init; log error on failure (don't fatal).
+4. Add `resolutionCache *GitHubResolutionCache` parameter to `NewGitHubSkillResolverWithCredentials` (or a `WithResolutionCache(c)` option). Remove the per-request `NewGitHubResolutionCache` call from `NewGitHubSkillResolver`.
+5. Pass `s.ghResolutionCache` from `handlers.go`.
+6. Bump `DefaultResolutionCacheTTL` from 5m to 30m.
+7. Unit test: verify two sequential `resolveOne` calls with same URI produce one disk-cache load.
+
+### Phase 2 — Hub DB Schema and Resolver (~350 LoC + generated ent code)
+
+Load-bearing files: new `pkg/ent/schema/github_resolution_cache.go`, new `pkg/hub/github_resolution_store.go`, `pkg/hub/skill_handlers.go`, `pkg/hub/server.go`
+
+1. Add ent schema entity `GitHubResolutionCache` (fields as above). Run `go generate ./pkg/ent/...` to regenerate ent client.
+2. Implement `GitHubResolutionStore`: `Get`, `Put`, `PurgeExpired` backed by ent client.
+3. Add `resolveGitHubToken(ctx, projectID)` to Server (reuses `mintGitHubAppToken`).
+4. Add `resolveGitHubSkill(ctx, uri, projectID)` to Server.
+5. Wire into `handleSkillsResolve`: detect `gh://` prefix, dispatch to `resolveGitHubSkill`, continue.
+6. Start background `PurgeExpired` goroutine in Hub startup.
+7. Add `github_resolution_cache` section to Hub admin settings seed data (TTL defaults).
+8. Unit test: `resolveGitHubSkill` with mock GitHub API and mock DB — verify cache hit skips API call; cache miss populates DB.
+9. Integration test (if Hub integration test infra available): two sequential resolve calls for same URI → 1 GitHub API call.
+
+### Phase 3 — Broker Routing Change (~40 LoC + tests)
+
+Load-bearing files: `pkg/runtimebroker/handlers.go`, `pkg/agent/routing_skill_resolver.go` (or wherever `Register` is defined)
+
+1. Add `RegisterFallback(scheme string, resolver SkillResolver)` to `RoutingSkillResolver`, or handle fallback in the Hub error path.
+2. In `handlers.go`: stop calling `router.Register("gh", ghResolver)`; call `router.RegisterFallback("gh", ghResolver)` (or equivalent fallback registration).
+3. Ensure `HubSkillResolver.Resolve` passes `ProjectID` from resolve opts into `ResolveSkillsRequest.ProjectID`.
+4. Update broker integration test: mock Hub returning `gh://` resolution result; verify broker uses it.
+5. Update broker integration test: mock Hub returning error for `gh://`; verify broker falls back to local resolver.
+
+---
+
+## Acceptance Criteria
+
+QA tester should verify all of the following before this is considered done:
+
+1. **Cross-instance deduplication (Phase 2+3):** Simulate 10 fresh broker instances resolving the same `gh://` URI simultaneously. Exactly 1 GitHub REST API call is made (observable via Hub access logs or GitHub rate-limit remaining header dropping by 1 not 10). All others return Hub cache hits.
+
+2. **Hub restart durability (Phase 2):** Populate the resolution cache. Restart the Hub. Verify the previously cached entry is still returned (not expired) — confirming DB-backed durability.
+
+3. **Branch-ref TTL (Phase 2):** With branch_ref_ttl = 2 minutes (override for testing): cache an entry at t=0; verify cache hit at t=1m; verify fresh GitHub API call at t=3m and cache updated with new entry.
+
+4. **Within-instance deduplication (Phase 1):** On a single broker instance, create two agents using the same `gh://` skill back-to-back. Verify second creation makes 0 GitHub API calls (within TTL window). First creation still makes 2.
+
+5. **Hub unavailability fallback (Phase 3):** Simulate Hub timeout for `gh://` resolve. Verify broker logs a warning and falls back to local resolution, returning a valid skill result to the agent creation request.
+
+6. **Private repo skill with App token (Phase 2):** A skill using `gh://` on a private repo, where the project has a GitHub App installation, resolves successfully via the Hub using the minted App token. Cache is populated under the installation ID scope.
+
+7. **Log observability:** Hub emits a distinguishable log entry for each `gh://` resolve with `cache_hit: true/false` (or equivalent). Hit rate trend visible after traffic runs through the new code.
+
+8. **No regression for Hub-registered skills:** Hub-registered skills (`scion://`, `project://` etc.) resolve identically to before — the new `gh://` branch does not interfere with the existing `resolveSkill` path.

--- a/pkg/agent/routing_skill_resolver.go
+++ b/pkg/agent/routing_skill_resolver.go
@@ -17,6 +17,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
@@ -28,14 +29,20 @@ import (
 type RoutingSkillResolver struct {
 	resolvers map[string]SkillResolver // scheme → resolver
 	fallback  SkillResolver            // for "skill" scheme and bare names
+
+	// fallbackResolvers holds scheme → resolver used only when the primary
+	// fallback (Hub) fails for that scheme. Registering a scheme here also
+	// routes it through Hub first, so Hub-side caching applies.
+	fallbackResolvers map[string]SkillResolver
 }
 
 // NewRoutingSkillResolver creates a routing resolver that uses hub as the
 // fallback for skill:// URIs and bare names.
 func NewRoutingSkillResolver(hub SkillResolver) *RoutingSkillResolver {
 	return &RoutingSkillResolver{
-		resolvers: make(map[string]SkillResolver),
-		fallback:  hub,
+		resolvers:         make(map[string]SkillResolver),
+		fallback:          hub,
+		fallbackResolvers: make(map[string]SkillResolver),
 	}
 }
 
@@ -49,6 +56,29 @@ func (r *RoutingSkillResolver) Register(scheme string, resolver SkillResolver) {
 		panic(fmt.Sprintf("RoutingSkillResolver.Register: scheme %q already registered", scheme))
 	}
 	r.resolvers[scheme] = resolver
+}
+
+// RegisterFallback registers a scheme-specific fallback resolver. URIs with
+// this scheme are routed to the primary fallback (Hub) first — so that Hub-side
+// caching and credential minting apply — and only if Hub fails (transport error
+// or per-URI errors) is the registered resolver used for the affected URIs.
+//
+// A resolver registered via Register for the same scheme takes precedence and
+// disables the Hub-first routing for that scheme.
+//
+// Panics if scheme is empty or already registered as a fallback (catches wiring
+// bugs at startup, not at request time).
+func (r *RoutingSkillResolver) RegisterFallback(scheme string, resolver SkillResolver) {
+	if scheme == "" {
+		panic("RoutingSkillResolver.RegisterFallback: scheme must not be empty")
+	}
+	if r.fallbackResolvers == nil {
+		r.fallbackResolvers = make(map[string]SkillResolver)
+	}
+	if _, exists := r.fallbackResolvers[scheme]; exists {
+		panic(fmt.Sprintf("RoutingSkillResolver.RegisterFallback: scheme %q already registered", scheme))
+	}
+	r.fallbackResolvers[scheme] = resolver
 }
 
 func (r *RoutingSkillResolver) ResolverName() string { return "routing" }
@@ -72,9 +102,20 @@ func (r *RoutingSkillResolver) Resolve(ctx context.Context, refs []api.SkillRefe
 			schemeRefs[i] = ir.ref
 		}
 
+		// fb is the scheme's fallback resolver, used only when the primary
+		// resolver for this group is Hub and Hub fails.
+		var fb SkillResolver
+
 		resolver := r.resolvers[scheme]
 		if resolver == nil {
-			if scheme == "skill" || scheme == "" {
+			if schemeFB, hasFB := r.fallbackResolvers[scheme]; hasFB {
+				// Hub-first routing: Hub is primary, schemeFB is the backstop.
+				resolver, fb = r.fallback, schemeFB
+				if resolver == nil {
+					// No Hub configured — use the fallback directly.
+					resolver, fb = schemeFB, nil
+				}
+			} else if scheme == "skill" || scheme == "" {
 				resolver = r.fallback
 			}
 		}
@@ -92,13 +133,96 @@ func (r *RoutingSkillResolver) Resolve(ctx context.Context, refs []api.SkillRefe
 
 		sr, err := resolver.Resolve(ctx, schemeRefs, opts)
 		if err != nil {
-			return nil, fmt.Errorf("resolver for scheme %q failed: %w", scheme, err)
+			if fb == nil {
+				return nil, fmt.Errorf("resolver for scheme %q failed: %w", scheme, err)
+			}
+			// Transport-level failure: retry the whole group with the fallback.
+			slog.Warn("primary skill resolver failed, retrying with fallback resolver",
+				"scheme", scheme,
+				"primary", resolverNameOf(resolver),
+				"fallback", resolverNameOf(fb),
+				"refs", len(schemeRefs),
+				"error", err)
+			sr, err = fb.Resolve(ctx, schemeRefs, opts)
+			if err != nil {
+				return nil, fmt.Errorf("fallback resolver for scheme %q failed: %w", scheme, err)
+			}
+		} else if fb != nil && len(sr.Errors) > 0 {
+			sr = r.retryErrorsWithFallback(ctx, scheme, resolver, fb, schemeRefs, sr, opts)
 		}
 		result.Resolved = append(result.Resolved, sr.Resolved...)
 		result.Errors = append(result.Errors, sr.Errors...)
 	}
 
 	return result, nil
+}
+
+// retryErrorsWithFallback re-resolves the URIs that the primary resolver
+// reported per-URI errors for, using the scheme's fallback resolver. Errors for
+// retried URIs are replaced by the fallback's outcome; errors for URIs the
+// fallback was not asked about are preserved. If the fallback itself fails, the
+// primary's result is returned unchanged.
+func (r *RoutingSkillResolver) retryErrorsWithFallback(
+	ctx context.Context,
+	scheme string,
+	primary, fb SkillResolver,
+	schemeRefs []api.SkillReference,
+	sr *ResolveResult,
+	opts ResolveOpts,
+) *ResolveResult {
+	errored := make(map[string]bool, len(sr.Errors))
+	for _, e := range sr.Errors {
+		errored[e.URI] = true
+	}
+
+	retryRefs := make([]api.SkillReference, 0, len(sr.Errors))
+	retried := make(map[string]bool, len(sr.Errors))
+	for _, ref := range schemeRefs {
+		if errored[ref.URI] && !retried[ref.URI] {
+			retryRefs = append(retryRefs, ref)
+			retried[ref.URI] = true
+		}
+	}
+	if len(retryRefs) == 0 {
+		return sr
+	}
+
+	slog.Info("primary skill resolver reported errors, retrying with fallback resolver",
+		"scheme", scheme,
+		"primary", resolverNameOf(primary),
+		"fallback", resolverNameOf(fb),
+		"refs", len(retryRefs))
+
+	fr, err := fb.Resolve(ctx, retryRefs, opts)
+	if err != nil {
+		slog.Warn("fallback skill resolver failed, keeping primary errors",
+			"scheme", scheme,
+			"fallback", resolverNameOf(fb),
+			"error", err)
+		return sr
+	}
+
+	merged := &ResolveResult{Resolved: sr.Resolved}
+	for _, e := range sr.Errors {
+		if !retried[e.URI] {
+			merged.Errors = append(merged.Errors, e)
+		}
+	}
+	merged.Resolved = append(merged.Resolved, fr.Resolved...)
+	merged.Errors = append(merged.Errors, fr.Errors...)
+	return merged
+}
+
+// resolverNameOf returns a resolver's name for logging. SkillResolver does not
+// require a name, so this falls back to the concrete type when unavailable.
+func resolverNameOf(r SkillResolver) string {
+	if r == nil {
+		return "<nil>"
+	}
+	if named, ok := r.(interface{ ResolverName() string }); ok {
+		return named.ResolverName()
+	}
+	return fmt.Sprintf("%T", r)
 }
 
 // detectScheme extracts the routing scheme from a skill URI.

--- a/pkg/agent/routing_skill_resolver.go
+++ b/pkg/agent/routing_skill_resolver.go
@@ -147,7 +147,10 @@ func (r *RoutingSkillResolver) Resolve(ctx context.Context, refs []api.SkillRefe
 			if err != nil {
 				return nil, fmt.Errorf("fallback resolver for scheme %q failed: %w", scheme, err)
 			}
-		} else if fb != nil && len(sr.Errors) > 0 {
+		} else if fb != nil && len(sr.Resolved) < len(schemeRefs) {
+			// Fewer resolved skills than refs means the primary either reported
+			// per-URI errors or silently omitted refs (e.g. dropped a duplicate
+			// URI carrying a distinct As alias). Both cases need a fallback retry.
 			sr = r.retryErrorsWithFallback(ctx, scheme, resolver, fb, schemeRefs, sr, opts)
 		}
 		result.Resolved = append(result.Resolved, sr.Resolved...)
@@ -157,11 +160,16 @@ func (r *RoutingSkillResolver) Resolve(ctx context.Context, refs []api.SkillRefe
 	return result, nil
 }
 
-// retryErrorsWithFallback re-resolves the URIs that the primary resolver
-// reported per-URI errors for, using the scheme's fallback resolver. Errors for
-// retried URIs are replaced by the fallback's outcome; errors for URIs the
-// fallback was not asked about are preserved. If the fallback itself fails, the
-// primary's result is returned unchanged.
+// retryErrorsWithFallback re-resolves every ref the primary resolver did not
+// account for, using the scheme's fallback resolver. A ref is considered
+// unaccounted for when the primary returned no ResolvedSkill matching its
+// (URI, As) pair — whether because the primary reported an explicit per-URI
+// error, or because it silently omitted the ref from its result (for example
+// by collapsing two aliases of the same URI into a single entry).
+//
+// Errors for retried URIs are replaced by the fallback's outcome; errors for
+// URIs the fallback was not asked about are preserved. If the fallback itself
+// fails, the primary's result is returned unchanged.
 func (r *RoutingSkillResolver) retryErrorsWithFallback(
 	ctx context.Context,
 	scheme string,
@@ -170,28 +178,31 @@ func (r *RoutingSkillResolver) retryErrorsWithFallback(
 	sr *ResolveResult,
 	opts ResolveOpts,
 ) *ResolveResult {
-	errored := make(map[string]bool, len(sr.Errors))
-	for _, e := range sr.Errors {
-		errored[e.URI] = true
+	// Key resolved skills by (URI, As) so that two aliases of the same URI are
+	// tracked independently: resolving one alias must not mask the other's
+	// absence. Counts handle the case where the same (URI, As) pair legitimately
+	// appears more than once in the request.
+	resolvedRefs := make(map[string]int, len(sr.Resolved))
+	for _, rs := range sr.Resolved {
+		resolvedRefs[refKey(rs.URI, rs.As)]++
 	}
 
-	// Include every ref whose URI errored — the same URI may appear multiple
-	// times under different As aliases, and each alias needs its own resolved
-	// skill back from the fallback. Deduplicating by URI here would silently
-	// drop all but the first alias.
-	retryRefs := make([]api.SkillReference, 0, len(sr.Errors))
-	retriedURIs := make(map[string]bool, len(sr.Errors))
+	retryRefs := make([]api.SkillReference, 0, len(schemeRefs)-len(sr.Resolved))
+	retriedURIs := make(map[string]bool, len(schemeRefs))
 	for _, ref := range schemeRefs {
-		if errored[ref.URI] {
-			retryRefs = append(retryRefs, ref)
-			retriedURIs[ref.URI] = true
+		key := refKey(ref.URI, ref.As)
+		if resolvedRefs[key] > 0 {
+			resolvedRefs[key]--
+			continue
 		}
+		retryRefs = append(retryRefs, ref)
+		retriedURIs[ref.URI] = true
 	}
 	if len(retryRefs) == 0 {
 		return sr
 	}
 
-	slog.Info("primary skill resolver reported errors, retrying with fallback resolver",
+	slog.Info("primary skill resolver did not resolve all refs, retrying with fallback resolver",
 		"scheme", scheme,
 		"primary", resolverNameOf(primary),
 		"fallback", resolverNameOf(fb),
@@ -208,9 +219,9 @@ func (r *RoutingSkillResolver) retryErrorsWithFallback(
 
 	merged := &ResolveResult{Resolved: sr.Resolved}
 	for _, e := range sr.Errors {
-		// Every alias of a retried URI went to the fallback, so the fallback's
-		// outcome fully supersedes the primary's error. Errors for URIs that had
-		// no matching ref (and so were never retried) are preserved.
+		// Every unresolved alias of a retried URI went to the fallback, so the
+		// fallback's outcome supersedes the primary's error. Errors for URIs that
+		// had no matching ref (and so were never retried) are preserved.
 		if !retriedURIs[e.URI] {
 			merged.Errors = append(merged.Errors, e)
 		}
@@ -218,6 +229,12 @@ func (r *RoutingSkillResolver) retryErrorsWithFallback(
 	merged.Resolved = append(merged.Resolved, fr.Resolved...)
 	merged.Errors = append(merged.Errors, fr.Errors...)
 	return merged
+}
+
+// refKey builds a map key identifying a skill reference by URI and alias. The
+// NUL separator cannot appear in either component, so the key is unambiguous.
+func refKey(uri, as string) string {
+	return uri + "\x00" + as
 }
 
 // resolverNameOf returns a resolver's name for logging. SkillResolver does not

--- a/pkg/agent/routing_skill_resolver.go
+++ b/pkg/agent/routing_skill_resolver.go
@@ -175,12 +175,16 @@ func (r *RoutingSkillResolver) retryErrorsWithFallback(
 		errored[e.URI] = true
 	}
 
+	// Include every ref whose URI errored — the same URI may appear multiple
+	// times under different As aliases, and each alias needs its own resolved
+	// skill back from the fallback. Deduplicating by URI here would silently
+	// drop all but the first alias.
 	retryRefs := make([]api.SkillReference, 0, len(sr.Errors))
-	retried := make(map[string]bool, len(sr.Errors))
+	retriedURIs := make(map[string]bool, len(sr.Errors))
 	for _, ref := range schemeRefs {
-		if errored[ref.URI] && !retried[ref.URI] {
+		if errored[ref.URI] {
 			retryRefs = append(retryRefs, ref)
-			retried[ref.URI] = true
+			retriedURIs[ref.URI] = true
 		}
 	}
 	if len(retryRefs) == 0 {
@@ -204,7 +208,10 @@ func (r *RoutingSkillResolver) retryErrorsWithFallback(
 
 	merged := &ResolveResult{Resolved: sr.Resolved}
 	for _, e := range sr.Errors {
-		if !retried[e.URI] {
+		// Every alias of a retried URI went to the fallback, so the fallback's
+		// outcome fully supersedes the primary's error. Errors for URIs that had
+		// no matching ref (and so were never retried) are preserved.
+		if !retriedURIs[e.URI] {
 			merged.Errors = append(merged.Errors, e)
 		}
 	}

--- a/pkg/agent/routing_skill_resolver_test.go
+++ b/pkg/agent/routing_skill_resolver_test.go
@@ -256,6 +256,261 @@ func TestRoutingSkillResolver_RegisterPanics(t *testing.T) {
 	})
 }
 
+func TestRoutingSkillResolver_RegisterFallback_HubSuccess(t *testing.T) {
+	hub := &mockSchemeResolver{
+		name:     "hub",
+		resolved: []ResolvedSkill{{Name: "gh-skill", URI: "gh://owner/repo/skill"}},
+	}
+	local := &mockSchemeResolver{
+		name:     "github",
+		resolved: []ResolvedSkill{{Name: "local-skill", URI: "gh://owner/repo/skill"}},
+	}
+	router := NewRoutingSkillResolver(hub)
+	router.RegisterFallback("gh", local)
+
+	result, err := router.Resolve(context.Background(), []api.SkillReference{
+		{URI: "gh://owner/repo/skill"},
+	}, ResolveOpts{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(hub.called) != 1 {
+		t.Fatalf("hub received %d refs, want 1", len(hub.called))
+	}
+	if hub.called[0].URI != "gh://owner/repo/skill" {
+		t.Errorf("hub got URI %q, want %q", hub.called[0].URI, "gh://owner/repo/skill")
+	}
+	if len(local.called) != 0 {
+		t.Errorf("local resolver received %d refs, want 0", len(local.called))
+	}
+	if len(result.Resolved) != 1 || result.Resolved[0].Name != "gh-skill" {
+		t.Errorf("unexpected resolved result: %+v", result.Resolved)
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("got %d errors, want 0", len(result.Errors))
+	}
+}
+
+func TestRoutingSkillResolver_RegisterFallback_HubTransportError(t *testing.T) {
+	hub := &mockSchemeResolver{name: "hub", hardErr: fmt.Errorf("connection refused")}
+	local := &mockSchemeResolver{
+		name: "github",
+		resolved: []ResolvedSkill{
+			{Name: "a", URI: "gh://owner/repo/a"},
+			{Name: "b", URI: "gh://owner/repo/b"},
+		},
+	}
+	router := NewRoutingSkillResolver(hub)
+	router.RegisterFallback("gh", local)
+
+	result, err := router.Resolve(context.Background(), []api.SkillReference{
+		{URI: "gh://owner/repo/a"},
+		{URI: "gh://owner/repo/b"},
+	}, ResolveOpts{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(local.called) != 2 {
+		t.Fatalf("local resolver received %d refs, want 2 (all group refs)", len(local.called))
+	}
+	if len(result.Resolved) != 2 {
+		t.Errorf("got %d resolved, want 2", len(result.Resolved))
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("got %d errors, want 0: %+v", len(result.Errors), result.Errors)
+	}
+}
+
+func TestRoutingSkillResolver_RegisterFallback_BothFail(t *testing.T) {
+	hub := &mockSchemeResolver{name: "hub", hardErr: fmt.Errorf("connection refused")}
+	local := &mockSchemeResolver{name: "github", hardErr: fmt.Errorf("github unreachable")}
+	router := NewRoutingSkillResolver(hub)
+	router.RegisterFallback("gh", local)
+
+	_, err := router.Resolve(context.Background(), []api.SkillReference{
+		{URI: "gh://owner/repo/a"},
+	}, ResolveOpts{})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := err.Error(); got != `fallback resolver for scheme "gh" failed: github unreachable` {
+		t.Errorf("unexpected error message: %s", got)
+	}
+}
+
+func TestRoutingSkillResolver_RegisterFallback_HubPerURIError(t *testing.T) {
+	hub := &mockSchemeResolver{
+		name:     "hub",
+		resolved: []ResolvedSkill{{Name: "ok", URI: "gh://owner/repo/ok"}},
+		errors: []ResolveError{
+			{URI: "gh://owner/repo/bad", Code: "resolve_failed", Message: "hub could not resolve"},
+		},
+	}
+	local := &mockSchemeResolver{
+		name:     "github",
+		resolved: []ResolvedSkill{{Name: "bad", URI: "gh://owner/repo/bad"}},
+	}
+	router := NewRoutingSkillResolver(hub)
+	router.RegisterFallback("gh", local)
+
+	result, err := router.Resolve(context.Background(), []api.SkillReference{
+		{URI: "gh://owner/repo/ok"},
+		{URI: "gh://owner/repo/bad"},
+	}, ResolveOpts{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(local.called) != 1 {
+		t.Fatalf("local resolver received %d refs, want 1 (only the errored URI)", len(local.called))
+	}
+	if local.called[0].URI != "gh://owner/repo/bad" {
+		t.Errorf("local resolver got URI %q, want %q", local.called[0].URI, "gh://owner/repo/bad")
+	}
+	if len(result.Resolved) != 2 {
+		t.Fatalf("got %d resolved, want 2: %+v", len(result.Resolved), result.Resolved)
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("hub per-URI error should be replaced by fallback result, got %+v", result.Errors)
+	}
+}
+
+func TestRoutingSkillResolver_RegisterFallback_FallbackAlsoErrors(t *testing.T) {
+	hub := &mockSchemeResolver{
+		name: "hub",
+		errors: []ResolveError{
+			{URI: "gh://owner/repo/bad", Code: "resolve_failed", Message: "hub could not resolve"},
+		},
+	}
+	local := &mockSchemeResolver{
+		name: "github",
+		errors: []ResolveError{
+			{URI: "gh://owner/repo/bad", Code: "not_found", Message: "no such skill"},
+		},
+	}
+	router := NewRoutingSkillResolver(hub)
+	router.RegisterFallback("gh", local)
+
+	result, err := router.Resolve(context.Background(), []api.SkillReference{
+		{URI: "gh://owner/repo/bad"},
+	}, ResolveOpts{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Errors) != 1 {
+		t.Fatalf("got %d errors, want 1: %+v", len(result.Errors), result.Errors)
+	}
+	if result.Errors[0].Code != "not_found" {
+		t.Errorf("error code = %q, want %q (fallback error should win)", result.Errors[0].Code, "not_found")
+	}
+}
+
+func TestRoutingSkillResolver_RegisterFallback_NoHubUsesFallbackDirectly(t *testing.T) {
+	local := &mockSchemeResolver{
+		name:     "github",
+		resolved: []ResolvedSkill{{Name: "gh-skill", URI: "gh://owner/repo/skill"}},
+	}
+	router := NewRoutingSkillResolver(nil)
+	router.RegisterFallback("gh", local)
+
+	result, err := router.Resolve(context.Background(), []api.SkillReference{
+		{URI: "gh://owner/repo/skill"},
+	}, ResolveOpts{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(local.called) != 1 {
+		t.Fatalf("local resolver received %d refs, want 1", len(local.called))
+	}
+	if len(result.Resolved) != 1 {
+		t.Errorf("got %d resolved, want 1", len(result.Resolved))
+	}
+}
+
+func TestRoutingSkillResolver_RegisterFallback_PrimaryTakesPrecedence(t *testing.T) {
+	hub := &mockSchemeResolver{name: "hub"}
+	primary := &mockSchemeResolver{
+		name:     "gh-primary",
+		resolved: []ResolvedSkill{{Name: "gh-skill", URI: "gh://owner/repo/skill"}},
+	}
+	local := &mockSchemeResolver{name: "github-fallback"}
+	router := NewRoutingSkillResolver(hub)
+	router.Register("gh", primary)
+	router.RegisterFallback("gh", local)
+
+	if _, err := router.Resolve(context.Background(), []api.SkillReference{
+		{URI: "gh://owner/repo/skill"},
+	}, ResolveOpts{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(primary.called) != 1 {
+		t.Errorf("primary received %d refs, want 1", len(primary.called))
+	}
+	if len(hub.called) != 0 {
+		t.Errorf("hub received %d refs, want 0", len(hub.called))
+	}
+	if len(local.called) != 0 {
+		t.Errorf("fallback received %d refs, want 0", len(local.called))
+	}
+}
+
+func TestRoutingSkillResolver_RegisterFallback_MixedBatch(t *testing.T) {
+	hub := &mockSchemeResolver{
+		name:     "hub",
+		resolved: []ResolvedSkill{{Name: "hub-skill", URI: "skill://scion/core/hub-skill"}},
+	}
+	local := &mockSchemeResolver{name: "github"}
+	router := NewRoutingSkillResolver(hub)
+	router.RegisterFallback("gh", local)
+
+	result, err := router.Resolve(context.Background(), []api.SkillReference{
+		{URI: "skill://scion/core/hub-skill"},
+		{URI: "gh://owner/repo/skill"},
+	}, ResolveOpts{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Both groups go to Hub, in two separate calls.
+	if len(hub.called) != 2 {
+		t.Errorf("hub received %d refs, want 2", len(hub.called))
+	}
+	if len(local.called) != 0 {
+		t.Errorf("local resolver received %d refs, want 0", len(local.called))
+	}
+	if len(result.Resolved) == 0 {
+		t.Error("expected at least one resolved skill")
+	}
+}
+
+func TestRoutingSkillResolver_RegisterFallbackPanics(t *testing.T) {
+	t.Run("empty scheme", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected panic for empty scheme")
+			}
+		}()
+		router := NewRoutingSkillResolver(nil)
+		router.RegisterFallback("", &mockSchemeResolver{})
+	})
+
+	t.Run("duplicate scheme", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected panic for duplicate scheme")
+			}
+		}()
+		router := NewRoutingSkillResolver(nil)
+		router.RegisterFallback("gh", &mockSchemeResolver{})
+		router.RegisterFallback("gh", &mockSchemeResolver{})
+	})
+}
+
 func TestRoutingSkillResolver_GitHubFullURL(t *testing.T) {
 	hub := &mockSchemeResolver{name: "hub"}
 	ghMock := &mockSchemeResolver{

--- a/pkg/agent/routing_skill_resolver_test.go
+++ b/pkg/agent/routing_skill_resolver_test.go
@@ -616,3 +616,140 @@ func TestRoutingSkillResolver_RegisterFallback_SameURIDifferentAliases(t *testin
 		t.Errorf("expected no errors after successful fallback, got %+v", result.Errors)
 	}
 }
+
+// TestRoutingSkillResolver_RegisterFallback_SilentDrop covers a primary
+// resolver that returns fewer skills than it was asked for *without* reporting
+// any per-URI error. Gating the fallback retry on len(sr.Errors) > 0 would miss
+// this entirely and hand back a short result; gating on
+// len(sr.Resolved) < len(schemeRefs) catches it.
+//
+// Two shapes of silent drop are exercised:
+//   - a URI omitted outright, with no matching error
+//   - a URI returned under only one of its two As aliases
+func TestRoutingSkillResolver_RegisterFallback_SilentDrop(t *testing.T) {
+	t.Run("ref omitted with no error", func(t *testing.T) {
+		const kept = "gh://owner/repo/kept"
+		const dropped = "gh://owner/repo/dropped"
+
+		// Hub resolves one ref and silently forgets the other — no error at all.
+		hub := &mockSchemeResolver{
+			name: "hub",
+			resolved: []ResolvedSkill{
+				{Name: "kept", URI: kept},
+			},
+		}
+		local := &echoResolver{name: "github"}
+		router := NewRoutingSkillResolver(hub)
+		router.RegisterFallback("gh", local)
+
+		result, err := router.Resolve(context.Background(), []api.SkillReference{
+			{URI: kept},
+			{URI: dropped},
+		}, ResolveOpts{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Only the dropped ref should be retried — the resolved one must not be
+		// re-fetched from the fallback.
+		if len(local.called) != 1 {
+			t.Fatalf("fallback received %d refs, want 1: %+v", len(local.called), local.called)
+		}
+		if local.called[0].URI != dropped {
+			t.Errorf("fallback asked about %q, want %q", local.called[0].URI, dropped)
+		}
+
+		if len(result.Resolved) != 2 {
+			t.Fatalf("got %d resolved, want 2: %+v", len(result.Resolved), result.Resolved)
+		}
+		gotURIs := map[string]bool{}
+		for _, rs := range result.Resolved {
+			gotURIs[rs.URI] = true
+		}
+		for _, want := range []string{kept, dropped} {
+			if !gotURIs[want] {
+				t.Errorf("URI %q missing from resolved set; got %+v", want, result.Resolved)
+			}
+		}
+		if len(result.Errors) != 0 {
+			t.Errorf("expected no errors, got %+v", result.Errors)
+		}
+	})
+
+	t.Run("alias omitted with no error", func(t *testing.T) {
+		const uri = "gh://owner/repo/skill"
+
+		// Hub collapses two aliases of the same URI into a single entry and
+		// reports no error for the alias it dropped.
+		hub := &mockSchemeResolver{
+			name: "hub",
+			resolved: []ResolvedSkill{
+				{Name: "skill", URI: uri, As: "first"},
+			},
+		}
+		local := &echoResolver{name: "github"}
+		router := NewRoutingSkillResolver(hub)
+		router.RegisterFallback("gh", local)
+
+		result, err := router.Resolve(context.Background(), []api.SkillReference{
+			{URI: uri, As: "first"},
+			{URI: uri, As: "second"},
+		}, ResolveOpts{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// The alias hub already resolved must not be retried; the missing one must.
+		if len(local.called) != 1 {
+			t.Fatalf("fallback received %d refs, want 1 (only the dropped alias): %+v", len(local.called), local.called)
+		}
+		if local.called[0].As != "second" {
+			t.Errorf("fallback asked about alias %q, want %q", local.called[0].As, "second")
+		}
+
+		if len(result.Resolved) != 2 {
+			t.Fatalf("got %d resolved, want 2 (one per alias): %+v", len(result.Resolved), result.Resolved)
+		}
+		gotAliases := map[string]bool{}
+		for _, rs := range result.Resolved {
+			gotAliases[rs.As] = true
+		}
+		for _, want := range []string{"first", "second"} {
+			if !gotAliases[want] {
+				t.Errorf("alias %q missing from resolved set; got %+v", want, result.Resolved)
+			}
+		}
+		if len(result.Errors) != 0 {
+			t.Errorf("expected no errors, got %+v", result.Errors)
+		}
+	})
+
+	t.Run("no retry when every ref is accounted for", func(t *testing.T) {
+		const uri = "gh://owner/repo/skill"
+
+		hub := &mockSchemeResolver{
+			name: "hub",
+			resolved: []ResolvedSkill{
+				{Name: "skill", URI: uri, As: "first"},
+				{Name: "skill", URI: uri, As: "second"},
+			},
+		}
+		local := &echoResolver{name: "github"}
+		router := NewRoutingSkillResolver(hub)
+		router.RegisterFallback("gh", local)
+
+		result, err := router.Resolve(context.Background(), []api.SkillReference{
+			{URI: uri, As: "first"},
+			{URI: uri, As: "second"},
+		}, ResolveOpts{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(local.called) != 0 {
+			t.Errorf("fallback should not have been called, got %+v", local.called)
+		}
+		if len(result.Resolved) != 2 {
+			t.Errorf("got %d resolved, want 2: %+v", len(result.Resolved), result.Resolved)
+		}
+	})
+}

--- a/pkg/agent/routing_skill_resolver_test.go
+++ b/pkg/agent/routing_skill_resolver_test.go
@@ -534,3 +534,85 @@ func TestRoutingSkillResolver_GitHubFullURL(t *testing.T) {
 		t.Errorf("hub received %d refs, want 0", len(hub.called))
 	}
 }
+
+// echoResolver resolves each ref it is given into its own ResolvedSkill,
+// preserving the ref's As alias. This makes it possible to assert that every
+// alias of a URI — not just the first — reached the fallback.
+type echoResolver struct {
+	name   string
+	called []api.SkillReference
+}
+
+func (m *echoResolver) ResolverName() string { return m.name }
+func (m *echoResolver) Resolve(_ context.Context, refs []api.SkillReference, _ ResolveOpts) (*ResolveResult, error) {
+	m.called = append(m.called, refs...)
+	result := &ResolveResult{}
+	for _, ref := range refs {
+		result.Resolved = append(result.Resolved, ResolvedSkill{
+			Name: "skill",
+			URI:  ref.URI,
+			As:   ref.As,
+		})
+	}
+	return result, nil
+}
+
+// TestRoutingSkillResolver_RegisterFallback_SameURIDifferentAliases guards
+// against dropping aliases when the same URI is imported under two names. The
+// retry set is keyed by ref, not by URI, so both aliases must reach the
+// fallback and both must come back resolved.
+func TestRoutingSkillResolver_RegisterFallback_SameURIDifferentAliases(t *testing.T) {
+	const uri = "gh://owner/repo/skill"
+
+	hub := &mockSchemeResolver{
+		name: "hub",
+		errors: []ResolveError{
+			{URI: uri, Code: "resolve_failed", Message: "hub could not resolve"},
+		},
+	}
+	local := &echoResolver{name: "github"}
+	router := NewRoutingSkillResolver(hub)
+	router.RegisterFallback("gh", local)
+
+	result, err := router.Resolve(context.Background(), []api.SkillReference{
+		{URI: uri, As: "first"},
+		{URI: uri, As: "second"},
+	}, ResolveOpts{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Both aliases must be handed to the fallback.
+	if len(local.called) != 2 {
+		t.Fatalf("fallback received %d refs, want 2 (one per alias): %+v", len(local.called), local.called)
+	}
+	gotCalled := map[string]bool{}
+	for _, ref := range local.called {
+		gotCalled[ref.As] = true
+	}
+	for _, want := range []string{"first", "second"} {
+		if !gotCalled[want] {
+			t.Errorf("fallback was not asked about alias %q; got %+v", want, local.called)
+		}
+	}
+
+	// Both aliases must come back resolved.
+	if len(result.Resolved) != 2 {
+		t.Fatalf("got %d resolved, want 2 (one per alias): %+v", len(result.Resolved), result.Resolved)
+	}
+	gotResolved := map[string]bool{}
+	for _, rs := range result.Resolved {
+		gotResolved[rs.As] = true
+	}
+	for _, want := range []string{"first", "second"} {
+		if !gotResolved[want] {
+			t.Errorf("alias %q missing from resolved set; got %+v", want, result.Resolved)
+		}
+	}
+
+	// The hub error was fully superseded by the fallback.
+	if len(result.Errors) != 0 {
+		t.Errorf("expected no errors after successful fallback, got %+v", result.Errors)
+	}
+}

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -757,7 +757,9 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 		router := agent.NewRoutingSkillResolver(hubResolver)
 		defaultGHToken := req.ResolvedEnv["GITHUB_TOKEN"]
 		ghResolver := agent.NewGitHubSkillResolverWithCredentials(defaultGHToken, req.ProvisionCredentials, s.ghResolutionCache)
-		router.Register("gh", ghResolver)
+		// Route gh:// through Hub first (DB-backed resolution cache + GitHub App
+		// token minting); fall back to in-broker GitHub resolution if Hub fails.
+		router.RegisterFallback("gh", ghResolver)
 
 		// GCP resolver uses Hub API for registry alias lookup.
 		registrySvc := conn.HubClient.SkillRegistries()

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -757,9 +757,10 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 		router := agent.NewRoutingSkillResolver(hubResolver)
 		defaultGHToken := req.ResolvedEnv["GITHUB_TOKEN"]
 		ghResolver := agent.NewGitHubSkillResolverWithCredentials(defaultGHToken, req.ProvisionCredentials, s.ghResolutionCache)
-		// Route gh:// through Hub first (DB-backed resolution cache + GitHub App
-		// token minting); fall back to in-broker GitHub resolution if Hub fails.
-		router.RegisterFallback("gh", ghResolver)
+		// RegisterFallback is wired for gh:// but not yet activated: Phase 2 Hub-side
+		// defects (hash format mismatch, no Content field, ref-defaulting) must be
+		// fixed before Hub routing can go live. Flip to RegisterFallback once resolved.
+		router.Register("gh", ghResolver)
 
 		// GCP resolver uses Hub API for registry alias lookup.
 		registrySvc := conn.HubClient.SkillRegistries()


### PR DESCRIPTION
## Summary
Phase 3 of the cache-durability project: adds RegisterFallback routing infrastructure for hub-side gh:// skill resolution. Landed conservatively per reviewer recommendation: handlers.go still calls Register('gh', ...), NOT RegisterFallback -- net production impact is zero (three comment lines are the only visible change).

## Why conservative
Phase 3 review uncovered 2 blocking defects in the already-merged Phase 2 hub-side cache: a hash-format mismatch (git blob SHA-1 vs the broker's expected sha256:<hex>) that fails every Hub-resolved install, and a missing file-content field forcing an unauthenticated re-download for private repos. A ref-defaulting gap (empty @ref not defaulted to HEAD) meant these went uncaught in typical testing. Those are being fixed in a separate Phase 2b workstream; this PR only lands the routing scaffolding, not the activation.

## Next step
Once Phase 2b fixes land and review clean, a follow-up one-line PR flips Register -> RegisterFallback to activate hub-side caching.