### PR TITLE
agent: fix Phase 2 hub-side gh:// cache defects (hash format, expiring URLs, ref defaulting, cross-project authz)

### DIFF
--- a/.design/project-log/ps-cache-p2b-fix.md
+++ b/.design/project-log/ps-cache-p2b-fix.md
@@ -185,3 +185,97 @@ clean runs. Worth flagging to infra — it is not specific to this branch.
    revisited alongside follow-up 1.
 3. **Phase 3 can proceed**: routing `gh://` to the Hub resolver is a one-line
    change in `pkg/runtimebroker/handlers.go`, deliberately not made here.
+
+---
+
+## Addendum: cross-project authorization gap in `handleSkillsResolve`
+
+**Date:** 2026-07-29
+**Agent:** ps-cache-p2b-authz
+**Commit:** one commit on top of the four fixes above.
+
+A fifth defect, found in review of this branch. Unlike the other four it is a
+security defect rather than a correctness one, so it is worth calling out
+separately.
+
+### The gap
+
+In `handleSkillsResolve`, the `gh://` branch ran at the top of the per-skill
+loop, *before* any identity or access check:
+
+```go
+for _, skillRef := range req.Skills {
+    if strings.HasPrefix(skillRef.URI, "gh://") {
+        ghResolved, err := s.resolveGitHubSkill(ctx, skillRef.URI, req.ProjectID)
+        ...
+        continue
+    }
+    // registry path — access-checked further down
+```
+
+`resolveGitHubSkill` calls `resolveGitHubToken(ctx, req.ProjectID)`, which
+loads that project and mints its GitHub App token. `req.ProjectID` is
+caller-supplied and was never validated against the caller's identity, so any
+authenticated principal could name *any* project and have the Hub mint that
+project's installation token — then use the resulting resolution to read files
+from repositories that installation can reach. The registry path immediately
+below has always checked access; the `gh://` path simply bypassed it by
+`continue`-ing first.
+
+This was latent rather than exploitable in production today, because Phase 2
+left `gh://` routed to the local resolver and nothing calls the Hub endpoint
+with a `gh://` URI yet. Phase 3 flips exactly that switch, so it had to be
+closed before the flip, not after.
+
+### The fix
+
+Authorize the caller against `req.ProjectID` before any `gh://` resolution,
+mirroring the check already used for project-scoped skill creation:
+
+- **Agent identity** — `agentIdent.ProjectID() == req.ProjectID`, the same
+  confinement agents get everywhere else.
+- **User identity** — `CheckAccess(userIdent, Resource{Type: "skill",
+  ParentType: "project", ParentID: req.ProjectID}, ActionRead)`. `ActionRead`
+  rather than `ActionCreate`: resolving reads a skill, it does not publish one.
+- **No identity** — denied.
+
+A failed check appends `ResolveSkillError{Code: "forbidden"}` and skips the
+entry, matching how the registry path reports a denial. The endpoint stays
+`200` with per-URI errors; one forbidden reference does not fail the batch.
+
+Two deliberate scoping choices:
+
+- **Only when `req.ProjectID != ""`.** An empty project ID makes
+  `resolveGitHubToken` return the `"public"` scope with no token, so there is
+  no credential to borrow and nothing to authorize. Checking anyway would break
+  anonymous resolution of public repos for no security gain.
+- **Evaluated once per request, not per URI**, and only when the batch actually
+  contains a `gh://` reference (`hasGitHubSkillRef`). The decision cannot vary
+  between URIs in a batch — same caller, same project — so a 50-item batch
+  should not cost 50 identical `CheckAccess` calls, and a batch with no `gh://`
+  references should cost none.
+
+### Files changed
+
+**`pkg/hub/skill_handlers.go`** — `hasGitHubSkillRef` and
+`Server.canUseProjectGitHubToken` helpers; the guard in `handleSkillsResolve`.
+
+### Test
+
+`TestSkillAuthz_Resolve_GH_ForbiddenProject` in
+`pkg/hub/skill_handlers_authz_test.go`, alongside the existing
+`TestSkillAuthz_Resolve_ForbiddenSkill`. Bob (not a member of Alice's project)
+POSTs a `gh://` URI with Alice's `ProjectID` and must get
+`Code: "forbidden"`.
+
+The test needs no GitHub mock, and that is the point: the assertion is
+specifically `forbidden` and not `resolve_failed`. Reverting the guard turns it
+into `resolve_failed` — the request reaches the GitHub API before failing — so
+the test distinguishes "denied" from "attempted and happened to fail", and
+would not pass on a fix that merely made the GitHub call fail. Verified by
+temporarily disabling the check and confirming that exact transition.
+
+```
+go test ./pkg/hub/... -run TestSkillAuthz    ok  1.4s
+gofmt -l                                     clean
+```

--- a/.design/project-log/ps-cache-p2b-fix.md
+++ b/.design/project-log/ps-cache-p2b-fix.md
@@ -1,0 +1,187 @@
+# Phase 2b Fix Log: Hub gh:// Resolver Defects
+
+**Date:** 2026-07-29
+**Agent:** ps-cache-p2b-fix
+**Branch:** `scion/ps-cache-p2b-fix`
+**Base:** `main` @ 13db010 (Phase 1: broker-singleton resolution cache, #885)
+
+## Summary
+
+Code review blocked Phase 3 ("route gh:// through the Hub") on three defects in
+the Hub-side gh:// resolution path added in Phase 2. All three are fixed here.
+While fixing the first I found a fourth, related defect that the brief did not
+mention and that would have kept the feature broken; it is covered below and
+changed the shape of the fix.
+
+The `gh://` scheme is **still routed to the local resolver** on this branch.
+Nothing here flips the switch — that remains Phase 3's job. These changes only
+make the Hub path correct so that flip can happen.
+
+## The four defects
+
+### 1. Per-file hash format mismatch (blocking)
+
+`ghListContents` stores GitHub's git blob object ID (bare 40-char SHA-1, from
+the Contents API `sha` field) as `GitHubFileEntry.Hash`. The broker's
+`installOneSkill` compared that against `transfer.HashFile`, which returns
+`"sha256:<hex64>"`. The two can never be equal, so every Hub-resolved gh://
+install failed verification.
+
+### 2. Bundle hash mismatch (blocking — not in the brief)
+
+The same mismatch exists one level up, and it matters because it invalidates
+the obvious fix for defect 1.
+
+The brief proposed sending an empty per-file hash and skipping the per-file
+check, on the reasoning that "the bundle hash still protects integrity". It
+does not: the Hub's `computeBundleHash` digests git blob IDs, while the
+broker's bundle check digests `sha256:` values. `skill.Hash` is non-empty, so
+the broker computes a bundle hash over different inputs and fails there
+instead. Installs would still have been broken 100% of the time, just with a
+different error message — and with per-file verification silently dropped.
+
+So the empty-hash approach was not viable on its own. Two ways out:
+
+- **Have the Hub download file bytes** so it can publish sha256 digests.
+  Uniform hash format everywhere, no broker change. But it puts N file
+  downloads on the Hub for every cache miss, which is most of what moving
+  resolution to the Hub was meant to avoid.
+- **Have the broker verify against the git blob ID.** The Hub stays at two API
+  calls per miss, and verification is preserved rather than discarded.
+
+Took the second. The two formats are distinguishable on sight — `sha256:`
+prefix versus bare 40-hex — so the broker hashes with whichever algorithm the
+expected value is written in (`hashFileAs` / `hashBytesAs`). Recording the
+result in the published format keeps the recomputed bundle hash comparable to
+the Hub's, so both checks pass and both remain real checks.
+
+On SHA-1: the git blob ID is not a general-purpose integrity primitive, and the
+new `pkg/transfer` helpers say so. It is adequate *here* because the entire
+trust chain for this path is already git's — content is fetched over TLS from
+raw.githubusercontent.com at a pinned commit SHA, itself a SHA-1 git object ID.
+Layering sha256 on top would not strengthen anything the commit pin does not
+already fix, and would cost the Hub a full content download per miss.
+
+The brief's `f.Hash != ""` guard is still in place, but now means "this
+resolver published no digest" rather than being the mechanism that makes gh://
+work.
+
+### 3. Expiring download URLs for private repos (blocking)
+
+For private repos the Contents API `download_url` is a CDN link carrying a
+short-lived signed token. The Hub caches entries for 30 minutes; the token dies
+in minutes. Any cache hit past the token's lifetime yielded a 404.
+
+`ghListContents` now builds the URL from the resolved commit SHA, which is
+immutable and therefore permanent. The origin is configurable
+(`GitHubAppServerConfig.RawBaseURL`, default `https://raw.githubusercontent.com`)
+for GitHub Enterprise and for tests.
+
+That leaves authentication. **The Hub does not send a credential**, contrary to
+one option floated in the brief (adding `GitHubToken` to `DownloadURLInfo`). A
+Hub-minted GitHub App token in an API response body would be persisted to the
+broker's on-disk resolution cache and exposed in any request logging — a
+meaningful widening of that token's blast radius for a convenience gain.
+
+Instead the broker supplies its own `GITHUB_TOKEN` (already present as
+`defaultGHToken`, already used by the local resolver) via
+`agent.ContextWithGitHubToken`. `downloadSkillFile` presents it **only to
+GitHub hosts**, so a Hub response naming an arbitrary origin cannot siphon the
+broker's credential. Context injection was chosen over a new `ResolvedFile`
+field because the token is a broker-environment property, not a per-file one,
+and a `ResolvedFile` field would need `json:"-"` to stay out of the disk cache
+anyway — which would make it useless on the restart-within-TTL path.
+
+**Known limitation:** this covers private repos reachable by the broker's own
+`GITHUB_TOKEN`. A repo readable *only* via the Hub's GitHub App installation
+will still 404 at download time. That is a narrower gap than today's behaviour
+(where every private-repo cache hit 404s), but it is a real gap and should be
+tracked separately — the fix is for the Hub to proxy the content, not to ship
+its token to brokers.
+
+### 4. Empty ref not defaulted to HEAD
+
+`resolveGitHubSkill` passed an omitted ref through verbatim, unlike the local
+resolver (`github_skill_resolver.go` `resolveCommitSHA`), which defaults to
+`HEAD`. Two consequences: unpinned URIs hit an unexpected code path in
+`ghResolveCommitSHA`, and — because the ref is part of the cache key —
+`gh://o/r/p` and `gh://o/r/p@HEAD` kept separate entries for the same commit.
+Defaulting happens before the key is computed, so both spellings now share one
+entry.
+
+## Files changed
+
+**`pkg/transfer/hash.go`** — added `GitBlobHashBytes`, `GitBlobHashFile`,
+`IsGitBlobHash`. Git object IDs are SHA-1 by definition; the import and both
+call sites carry `//nolint:gosec` with the rationale.
+
+**`pkg/agent/skill_resolver.go`**
+- `hashFileAs` / `hashBytesAs`: hash using the algorithm the expected value is
+  written in.
+- `installOneSkill`: use `hashFileAs`; skip comparison on an empty expected
+  hash; pass the GitHub token to `downloadSkillFile`.
+- `verifyInstalledSkillHash` (the cache-hit path): same dual-format handling,
+  which it needed too — it hardcoded sha256.
+- `ContextWithGitHubToken` / `GitHubTokenFromContext`.
+- `downloadSkillFile`: new `ghToken` parameter; `isGitHubHost` gate.
+
+**`pkg/hub/github_resolution_store.go`** — `ghListContents` takes `rawBase` and
+builds permanent URLs via the new `ghRawContentURL` / `ghEscapePathSegments`.
+
+**`pkg/hub/skill_handlers.go`** — default ref to `HEAD` before computing the
+cache key; thread `rawBase`; documented the hash format on
+`buildResolvedSkillResponse`.
+
+**`pkg/hub/server.go`** — `GitHubAppServerConfig.RawBaseURL`.
+
+**`pkg/runtimebroker/handlers.go`** — inject `defaultGHToken` into the
+provisioning context.
+
+## Tests
+
+New coverage:
+
+- `pkg/transfer`: git blob hashing checked against fixtures generated by real
+  `git hash-object` (empty, `hello\n`, `hello world`); `IsGitBlobHash` format
+  discrimination including a sha256 digest, wrong lengths, uppercase, non-hex.
+- `pkg/agent`: install succeeds end-to-end with git-blob per-file hashes *and*
+  a bundle hash over them (the defect-1+2 regression test); tampered content
+  under a git-blob hash is still rejected; empty hash installs; `hashFileAs`
+  algorithm selection; `isGitHubHost` including look-alike hosts
+  (`github.com.evil.test`, `notgithub.com`, `evilgithubusercontent.com`); token
+  is not sent to a non-GitHub host; token context round-trip.
+- `pkg/hub`: `ghRawContentURL` incl. trailing-slash and percent-escaping;
+  `ghListContents` produces token-free permanent URLs and skips directories;
+  `rawBase` override; a test documenting that the empty and `HEAD` cache keys
+  differ, which is *why* defect 4 mattered.
+
+Updated the four existing `downloadSkillFile` call sites for the new parameter.
+
+Results — all green, no pre-existing failures observed:
+
+```
+go build ./pkg/... ./cmd/...                     ok
+go vet ./pkg/agent/... ./pkg/transfer/... ./pkg/runtimebroker/...   ok
+go vet ./pkg/hub/...                             ok
+go test ./pkg/transfer/                          ok   0.0s
+go test ./pkg/agent/                             ok   7.2s
+go test ./pkg/hub/                               ok 189.9s
+```
+
+**Environment note:** the shared host volume repeatedly hit 100% during this
+work (`no space left on device` from the Go toolchain, unrelated to these
+changes). Commands were re-run once space freed; the results above are from
+clean runs. Worth flagging to infra — it is not specific to this branch.
+
+## Follow-ups
+
+1. **Private repos behind the Hub's App installation** still fail at download
+   (see defect 3). Proper fix: proxy content through the Hub rather than
+   distribute its token.
+2. **`ResolvedFile.Content` is `json:"-"`**, so the restart-within-TTL path
+   falls back to `downloadSkillFile`. With the token now threaded through, that
+   path works for broker-token-readable repos — previously noted as a
+   limitation in the field docs, which are now partly stale and could be
+   revisited alongside follow-up 1.
+3. **Phase 3 can proceed**: routing `gh://` to the Hub resolver is a one-line
+   change in `pkg/runtimebroker/handlers.go`, deliberately not made here.

--- a/pkg/agent/skill_resolver.go
+++ b/pkg/agent/skill_resolver.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"crypto/sha256"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/transfer"
@@ -510,7 +509,7 @@ func hashBytesAs(data []byte, expected string) string {
 	if transfer.IsGitBlobHash(expected) {
 		return transfer.GitBlobHashBytes(data)
 	}
-	return fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+	return transfer.HashBytes(data)
 }
 
 // validateFilePath checks that a relative path is safe for extraction.

--- a/pkg/agent/skill_resolver.go
+++ b/pkg/agent/skill_resolver.go
@@ -170,6 +170,29 @@ func ResolveUserIDFromContext(ctx context.Context) string {
 	return v
 }
 
+type gitHubTokenKey struct{}
+
+// ContextWithGitHubToken returns a context carrying a GitHub token for the
+// install phase.
+//
+// When the Hub resolves a gh:// skill it returns raw.githubusercontent.com
+// URLs but, deliberately, not the credential behind them — a Hub-minted App
+// token must not travel in an API response body or be persisted to the
+// broker's on-disk resolution cache. The broker therefore supplies its own
+// GITHUB_TOKEN here, which downloadSkillFile presents when fetching from
+// GitHub. Public repos need no token; private repos require one that can read
+// the repo in question.
+func ContextWithGitHubToken(ctx context.Context, token string) context.Context {
+	return context.WithValue(ctx, gitHubTokenKey{}, token)
+}
+
+// GitHubTokenFromContext retrieves the GitHub token for the install phase,
+// or "" if none was set.
+func GitHubTokenFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(gitHubTokenKey{}).(string)
+	return v
+}
+
 // --- Resolution record types ---
 
 // SkillResolutionRecord is written to agentHome/.scion/resolved-skills.json
@@ -297,6 +320,11 @@ func installOneSkill(ctx context.Context, skill ResolvedSkill, dest, skillsDest 
 		return nil, fmt.Errorf("failed to create skill staging dir: %w", err)
 	}
 
+	// Credential for raw.githubusercontent.com downloads of gh:// skills that
+	// the Hub resolved on our behalf. Empty for public repos and for skills
+	// that carry pre-fetched content.
+	ghToken := GitHubTokenFromContext(ctx)
+
 	var fileEntries []FileEntry
 
 	for _, f := range skill.Files {
@@ -329,16 +357,16 @@ func installOneSkill(ctx context.Context, skill ResolvedSkill, dest, skillsDest 
 			if err := writeSkillFileContent(f.Content, destPath); err != nil {
 				return nil, fmt.Errorf("failed to write %s: %w", f.Path, err)
 			}
-		} else if err := downloadSkillFile(ctx, f.URL, destPath, defaultMaxFileSize); err != nil {
+		} else if err := downloadSkillFile(ctx, f.URL, destPath, defaultMaxFileSize, ghToken); err != nil {
 			return nil, fmt.Errorf("failed to download %s: %w", f.Path, err)
 		}
 
-		// S2: Verify per-file hash
-		actualHash, err := transfer.HashFile(destPath)
+		// S2: Verify per-file hash, in whichever format the resolver supplied.
+		actualHash, err := hashFileAs(destPath, f.Hash)
 		if err != nil {
 			return nil, fmt.Errorf("failed to hash %s: %w", f.Path, err)
 		}
-		if actualHash != f.Hash {
+		if f.Hash != "" && actualHash != f.Hash {
 			return nil, fmt.Errorf(
 				"hash mismatch for file %q in skill %q: expected %s, got %s",
 				f.Path, skill.URI, f.Hash, actualHash)
@@ -445,12 +473,44 @@ func verifyInstalledSkillHash(dir string, skill ResolvedSkill) error {
 		if err != nil {
 			return fmt.Errorf("missing file %s: %w", f.Path, err)
 		}
-		computed := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+		if f.Hash == "" {
+			continue
+		}
+		computed := hashBytesAs(data, f.Hash)
 		if computed != f.Hash {
 			return fmt.Errorf("hash mismatch for %s: expected %s, got %s", f.Path, f.Hash, computed)
 		}
 	}
 	return nil
+}
+
+// hashFileAs hashes the file at path using the same algorithm as the expected
+// hash, so the two are directly comparable.
+//
+// Two formats reach the install phase:
+//
+//   - "sha256:<hex64>" — produced by the Hub's registry storage and by the
+//     local GitHubSkillResolver, which downloads content during resolution.
+//   - a bare git blob object ID (40 hex chars) — produced by the Hub's gh://
+//     resolution cache, which copies the "sha" field straight out of GitHub's
+//     Contents API and so never sees the file bytes.
+//
+// An empty expected hash means the resolver published no per-file digest; the
+// file is still hashed as sha256 so the resolution record has a usable value,
+// and the caller skips comparison.
+func hashFileAs(path, expected string) (string, error) {
+	if transfer.IsGitBlobHash(expected) {
+		return transfer.GitBlobHashFile(path)
+	}
+	return transfer.HashFile(path)
+}
+
+// hashBytesAs is the in-memory counterpart to hashFileAs.
+func hashBytesAs(data []byte, expected string) string {
+	if transfer.IsGitBlobHash(expected) {
+		return transfer.GitBlobHashBytes(data)
+	}
+	return fmt.Sprintf("sha256:%x", sha256.Sum256(data))
 }
 
 // validateFilePath checks that a relative path is safe for extraction.
@@ -502,8 +562,22 @@ func validateFilePath(path string) error {
 	return nil
 }
 
+// isGitHubHost reports whether host belongs to GitHub, and is therefore a
+// permitted recipient of a GitHub token.
+func isGitHubHost(host string) bool {
+	host = strings.ToLower(host)
+	return host == "github.com" ||
+		strings.HasSuffix(host, ".github.com") ||
+		strings.HasSuffix(host, ".githubusercontent.com")
+}
+
 // downloadSkillFile downloads a single file from a URL to a local path.
-func downloadSkillFile(ctx context.Context, fileURL, destPath string, maxSize int64) error {
+//
+// ghToken, when non-empty, is sent as a bearer credential — but only to
+// GitHub hosts. Registry skills are served from signed object-store URLs that
+// have no business seeing a GitHub token, so the host check is what keeps the
+// credential from leaking to an unrelated origin named in a Hub response.
+func downloadSkillFile(ctx context.Context, fileURL, destPath string, maxSize int64, ghToken string) error {
 	parsed, err := url.Parse(fileURL)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)
@@ -536,6 +610,9 @@ func downloadSkillFile(ctx context.Context, fileURL, destPath string, maxSize in
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
+	}
+	if ghToken != "" && isGitHubHost(parsed.Hostname()) {
+		req.Header.Set("Authorization", "Bearer "+ghToken)
 	}
 
 	resp, err := client.Do(req)

--- a/pkg/agent/skill_resolver_test.go
+++ b/pkg/agent/skill_resolver_test.go
@@ -303,14 +303,14 @@ func TestDownloadSkillFile_HTTPSOnly(t *testing.T) {
 	// The httptest server uses HTTP, not HTTPS, and is not localhost from URL perspective
 	// but the URL will be http://127.0.0.1:PORT which is localhost
 	dest := filepath.Join(t.TempDir(), "test.txt")
-	err := downloadSkillFile(context.Background(), srv.URL+"/file", dest, defaultMaxFileSize)
+	err := downloadSkillFile(context.Background(), srv.URL+"/file", dest, defaultMaxFileSize, "")
 	// 127.0.0.1 is localhost, so HTTP is allowed
 	if err != nil {
 		t.Errorf("expected HTTP to localhost to be allowed, got: %v", err)
 	}
 
 	// Non-localhost HTTP should fail
-	err = downloadSkillFile(context.Background(), "http://example.com/file", dest, defaultMaxFileSize)
+	err = downloadSkillFile(context.Background(), "http://example.com/file", dest, defaultMaxFileSize, "")
 	if err == nil {
 		t.Fatal("expected error for non-HTTPS non-localhost URL")
 	}
@@ -332,7 +332,7 @@ func TestDownloadSkillFile_SizeLimit(t *testing.T) {
 	defer func() { http.DefaultTransport = origTransport }()
 
 	dest := filepath.Join(t.TempDir(), "test.txt")
-	err := downloadSkillFile(context.Background(), srv.URL+"/file", dest, 50) // 50 byte limit
+	err := downloadSkillFile(context.Background(), srv.URL+"/file", dest, 50, "") // 50 byte limit
 	if err == nil {
 		t.Fatal("expected error for oversized file")
 	}
@@ -358,7 +358,7 @@ func TestDownloadSkillFile_CrossHostRedirect(t *testing.T) {
 	defer func() { http.DefaultTransport = origTransport }()
 
 	dest := filepath.Join(t.TempDir(), "test.txt")
-	err := downloadSkillFile(context.Background(), srv.URL+"/file", dest, defaultMaxFileSize)
+	err := downloadSkillFile(context.Background(), srv.URL+"/file", dest, defaultMaxFileSize, "")
 	if err == nil {
 		t.Fatal("expected error for cross-host redirect")
 	}
@@ -706,5 +706,196 @@ func TestInstallResolvedSkills_EmptySkillsList(t *testing.T) {
 	}
 	if len(record.Skills) != 0 {
 		t.Errorf("expected empty skills in record, got %d", len(record.Skills))
+	}
+}
+
+// TestInstallOneSkill_GitBlobHashes covers the shape of a gh:// skill resolved
+// by the Hub: the Hub never downloads file bytes, so it publishes git blob
+// object IDs rather than sha256 digests, and the bundle hash is a digest over
+// those. Both the per-file and the bundle check must succeed.
+func TestInstallOneSkill_GitBlobHashes(t *testing.T) {
+	const body = "hello\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	blobHash := transfer.GitBlobHashBytes([]byte(body))
+	bundleHash := transfer.ComputeContentHash([]transfer.FileInfo{
+		{Path: "SKILL.md", Hash: blobHash},
+	})
+
+	skill := ResolvedSkill{
+		Name:    "gh-skill",
+		URI:     "gh://owner/repo/skills/gh-skill",
+		Version: "abc123def456",
+		Hash:    bundleHash,
+		Files: []ResolvedFile{
+			{Path: "SKILL.md", URL: srv.URL + "/SKILL.md", Hash: blobHash},
+		},
+	}
+
+	skillsDest := t.TempDir()
+	entry, err := installOneSkill(context.Background(), skill, "gh-skill", skillsDest)
+	if err != nil {
+		t.Fatalf("installOneSkill: %v", err)
+	}
+
+	installed := filepath.Join(skillsDest, "gh-skill", "SKILL.md")
+	got, err := os.ReadFile(installed)
+	if err != nil {
+		t.Fatalf("reading installed file: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("installed content = %q, want %q", got, body)
+	}
+
+	// The recorded hash stays in the format the resolver published, so the
+	// bundle hash recomputed from it still matches what the Hub sent.
+	if len(entry.Files) != 1 || entry.Files[0].Hash != blobHash {
+		t.Errorf("expected recorded hash %s, got %+v", blobHash, entry.Files)
+	}
+}
+
+// TestInstallOneSkill_GitBlobHashMismatch verifies that git-blob-format hashes
+// are actually enforced, not merely tolerated.
+func TestInstallOneSkill_GitBlobHashMismatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("tampered content"))
+	}))
+	defer srv.Close()
+
+	skill := ResolvedSkill{
+		Name: "gh-skill",
+		URI:  "gh://owner/repo/skills/gh-skill",
+		Files: []ResolvedFile{
+			// Git blob ID of "hello\n", which is not what the server serves.
+			{Path: "SKILL.md", URL: srv.URL + "/SKILL.md", Hash: "ce013625030ba8dba906f756967f9e9ca394464a"},
+		},
+	}
+
+	_, err := installOneSkill(context.Background(), skill, "gh-skill", t.TempDir())
+	if err == nil {
+		t.Fatal("expected a hash mismatch error")
+	}
+	if !strings.Contains(err.Error(), "hash mismatch") {
+		t.Errorf("error should mention hash mismatch, got: %v", err)
+	}
+}
+
+// TestInstallOneSkill_EmptyHashSkipsVerification documents that a resolver may
+// omit a per-file hash; the file installs and is recorded with a sha256 digest.
+func TestInstallOneSkill_EmptyHashSkipsVerification(t *testing.T) {
+	const body = "no hash published"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	skill := ResolvedSkill{
+		Name:  "loose-skill",
+		URI:   "gh://owner/repo/skills/loose-skill",
+		Files: []ResolvedFile{{Path: "SKILL.md", URL: srv.URL + "/SKILL.md"}},
+	}
+
+	skillsDest := t.TempDir()
+	if _, err := installOneSkill(context.Background(), skill, "loose-skill", skillsDest); err != nil {
+		t.Fatalf("installOneSkill: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(skillsDest, "loose-skill", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("reading installed file: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("installed content = %q, want %q", got, body)
+	}
+}
+
+func TestHashFileAs(t *testing.T) {
+	const body = "hello\n"
+	path := filepath.Join(t.TempDir(), "f.txt")
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	gitID := transfer.GitBlobHashBytes([]byte(body))
+	sha := transfer.HashBytes([]byte(body))
+
+	// A git-blob expectation selects git-blob hashing.
+	got, err := hashFileAs(path, gitID)
+	if err != nil {
+		t.Fatalf("hashFileAs: %v", err)
+	}
+	if got != gitID {
+		t.Errorf("hashFileAs with git blob expectation = %s, want %s", got, gitID)
+	}
+
+	// A sha256 expectation, and an absent expectation, both select sha256.
+	for _, expected := range []string{sha, ""} {
+		got, err := hashFileAs(path, expected)
+		if err != nil {
+			t.Fatalf("hashFileAs(%q): %v", expected, err)
+		}
+		if got != sha {
+			t.Errorf("hashFileAs(%q) = %s, want %s", expected, got, sha)
+		}
+	}
+}
+
+func TestIsGitHubHost(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"github.com", true},
+		{"api.github.com", true},
+		{"raw.githubusercontent.com", true},
+		{"objects.githubusercontent.com", true},
+		{"GitHub.com", true},
+		{"storage.googleapis.com", false},
+		{"example.com", false},
+		{"", false},
+		// Look-alikes must not match: the suffix check is on a dotted
+		// boundary, so these are rejected.
+		{"github.com.evil.test", false},
+		{"notgithub.com", false},
+		{"evilgithubusercontent.com", false},
+	}
+
+	for _, tc := range cases {
+		if got := isGitHubHost(tc.host); got != tc.want {
+			t.Errorf("isGitHubHost(%q) = %v, want %v", tc.host, got, tc.want)
+		}
+	}
+}
+
+// TestDownloadSkillFile_TokenNotSentToNonGitHubHost guards the credential
+// boundary: a Hub response naming an arbitrary host must not cause the
+// broker's GitHub token to be handed to that host.
+func TestDownloadSkillFile_TokenNotSentToNonGitHubHost(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("content"))
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "test.txt")
+	if err := downloadSkillFile(context.Background(), srv.URL+"/file", dest, defaultMaxFileSize, "secret-token"); err != nil {
+		t.Fatalf("downloadSkillFile: %v", err)
+	}
+	if gotAuth != "" {
+		t.Errorf("token leaked to non-GitHub host: Authorization = %q", gotAuth)
+	}
+}
+
+func TestGitHubTokenFromContext(t *testing.T) {
+	if got := GitHubTokenFromContext(context.Background()); got != "" {
+		t.Errorf("expected no token on a bare context, got %q", got)
+	}
+	ctx := ContextWithGitHubToken(context.Background(), "ghp_example")
+	if got := GitHubTokenFromContext(ctx); got != "ghp_example" {
+		t.Errorf("GitHubTokenFromContext = %q, want %q", got, "ghp_example")
 	}
 }

--- a/pkg/hub/github_resolution_store.go
+++ b/pkg/hub/github_resolution_store.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -169,8 +170,16 @@ func ghResolveCommitSHA(ctx context.Context, apiBase, owner, repo, ref, token st
 }
 
 // ghListContents calls GET /repos/{owner}/{repo}/contents/{path}?ref={sha}
-// and returns a list of file entries with their raw CDN download URLs and git blob SHAs.
-func ghListContents(ctx context.Context, apiBase, owner, repo, path, commitSHA, token string) ([]GitHubFileEntry, error) {
+// and returns a list of file entries with permanent raw content URLs and git
+// blob SHAs.
+//
+// rawBase is the origin for raw content URLs (githubRawBase in production;
+// overridden by tests). It is deliberately not the download_url the Contents
+// API returns: for private repos that field is a CDN link carrying a
+// short-lived signed token, which would be dead long before this entry's
+// cache TTL expires. A URL built from the resolved commit SHA is permanent,
+// and the caller authenticates it with its own credential.
+func ghListContents(ctx context.Context, apiBase, rawBase, owner, repo, path, commitSHA, token string) ([]GitHubFileEntry, error) {
 	url := fmt.Sprintf("%s/repos/%s/%s/contents/%s?ref=%s", apiBase, owner, repo, path, commitSHA)
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
@@ -219,13 +228,32 @@ func ghListContents(ctx context.Context, apiBase, owner, repo, path, commitSHA, 
 		}
 		entries = append(entries, GitHubFileEntry{
 			Path: relPath,
-			URL:  item.DownloadURL,
-			Hash: item.SHA, // Git blob SHA for content addressing
+			URL:  ghRawContentURL(rawBase, owner, repo, commitSHA, item.Path),
+			Hash: item.SHA, // Git blob SHA; verified by the broker after download.
 			Size: item.Size,
 		})
 	}
 
 	return entries, nil
+}
+
+// ghRawContentURL builds a permanent raw content URL for a file at a pinned
+// commit SHA. Because the commit SHA is immutable, the URL stays valid for as
+// long as the commit is reachable — unlike the Contents API's download_url,
+// which expires within minutes for private repos.
+func ghRawContentURL(rawBase, owner, repo, commitSHA, filePath string) string {
+	return fmt.Sprintf("%s/%s/%s/%s/%s",
+		strings.TrimSuffix(rawBase, "/"), owner, repo, commitSHA, ghEscapePathSegments(filePath))
+}
+
+// ghEscapePathSegments percent-encodes each path segment while leaving the
+// separators intact.
+func ghEscapePathSegments(p string) string {
+	segments := strings.Split(p, "/")
+	for i, s := range segments {
+		segments[i] = url.PathEscape(s)
+	}
+	return strings.Join(segments, "/")
 }
 
 // isFullCommitSHA reports whether s is a complete 40-character lowercase hexadecimal SHA.

--- a/pkg/hub/github_resolution_store_test.go
+++ b/pkg/hub/github_resolution_store_test.go
@@ -16,6 +16,8 @@ package hub
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -173,4 +175,127 @@ func TestIsFullCommitSHA(t *testing.T) {
 	require.False(t, isFullCommitSHA("ABCDEF1234567890ABCDEF1234567890ABCDEF12")) // Uppercase
 	require.False(t, isFullCommitSHA("main"))                                     // Not a SHA
 	require.False(t, isFullCommitSHA(""))                                         // Empty
+}
+
+func TestGHRawContentURL(t *testing.T) {
+	cases := []struct {
+		name      string
+		rawBase   string
+		owner     string
+		repo      string
+		commitSHA string
+		filePath  string
+		want      string
+	}{
+		{
+			name:      "simple path",
+			rawBase:   "https://raw.githubusercontent.com",
+			owner:     "acme",
+			repo:      "skills",
+			commitSHA: "abcdef1234567890abcdef1234567890abcdef12",
+			filePath:  "skills/deploy/SKILL.md",
+			want:      "https://raw.githubusercontent.com/acme/skills/abcdef1234567890abcdef1234567890abcdef12/skills/deploy/SKILL.md",
+		},
+		{
+			name:      "trailing slash on base is not doubled",
+			rawBase:   "https://raw.githubusercontent.com/",
+			owner:     "acme",
+			repo:      "skills",
+			commitSHA: "abcdef1234567890abcdef1234567890abcdef12",
+			filePath:  "SKILL.md",
+			want:      "https://raw.githubusercontent.com/acme/skills/abcdef1234567890abcdef1234567890abcdef12/SKILL.md",
+		},
+		{
+			name:      "spaces are escaped but separators are preserved",
+			rawBase:   "https://raw.githubusercontent.com",
+			owner:     "acme",
+			repo:      "skills",
+			commitSHA: "abcdef1234567890abcdef1234567890abcdef12",
+			filePath:  "my skills/read me.md",
+			want:      "https://raw.githubusercontent.com/acme/skills/abcdef1234567890abcdef1234567890abcdef12/my%20skills/read%20me.md",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ghRawContentURL(tc.rawBase, tc.owner, tc.repo, tc.commitSHA, tc.filePath)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestGHListContents_PermanentURLs is the regression test for the expiring
+// download URL defect: the Contents API hands back a CDN link carrying a
+// short-lived token for private repos, which would be dead long before this
+// entry's cache TTL elapses. The stored URL must instead be built from the
+// pinned commit SHA.
+func TestGHListContents_PermanentURLs(t *testing.T) {
+	const commitSHA = "abcdef1234567890abcdef1234567890abcdef12"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/repos/acme/skills/contents/skills/deploy", r.URL.Path)
+		require.Equal(t, commitSHA, r.URL.Query().Get("ref"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"name":"SKILL.md","path":"skills/deploy/SKILL.md","sha":"ce013625030ba8dba906f756967f9e9ca394464a","size":6,"type":"file",
+			 "download_url":"https://raw.githubusercontent.com/acme/skills/` + commitSHA + `/skills/deploy/SKILL.md?token=EXPIRES_SOON"},
+			{"name":"helper.py","path":"skills/deploy/helper.py","sha":"95d09f2b10159347eece71399a7e2e907ea3df4f","size":11,"type":"file",
+			 "download_url":"https://raw.githubusercontent.com/acme/skills/` + commitSHA + `/skills/deploy/helper.py?token=EXPIRES_SOON"},
+			{"name":"nested","path":"skills/deploy/nested","sha":"1111111111111111111111111111111111111111","size":0,"type":"dir",
+			 "download_url":null}
+		]`))
+	}))
+	defer srv.Close()
+
+	entries, err := ghListContents(context.Background(), srv.URL, "https://raw.githubusercontent.com",
+		"acme", "skills", "skills/deploy", commitSHA, "")
+	require.NoError(t, err)
+
+	// Directories are skipped.
+	require.Len(t, entries, 2)
+
+	require.Equal(t, "SKILL.md", entries[0].Path)
+	require.Equal(t,
+		"https://raw.githubusercontent.com/acme/skills/"+commitSHA+"/skills/deploy/SKILL.md",
+		entries[0].URL)
+	require.Equal(t, "ce013625030ba8dba906f756967f9e9ca394464a", entries[0].Hash)
+	require.Equal(t, int64(6), entries[0].Size)
+
+	require.Equal(t, "helper.py", entries[1].Path)
+	require.Equal(t,
+		"https://raw.githubusercontent.com/acme/skills/"+commitSHA+"/skills/deploy/helper.py",
+		entries[1].URL)
+
+	for _, e := range entries {
+		require.NotContains(t, e.URL, "token=", "stored URL must not carry an expiring CDN token")
+	}
+}
+
+// TestGHListContents_RawBaseOverride confirms the raw origin is configurable,
+// which is what lets a GitHub Enterprise deployment work.
+func TestGHListContents_RawBaseOverride(t *testing.T) {
+	const commitSHA = "abcdef1234567890abcdef1234567890abcdef12"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[{"name":"SKILL.md","path":"s/SKILL.md","sha":"ce013625030ba8dba906f756967f9e9ca394464a","size":6,"type":"file","download_url":"https://example.invalid/x"}]`))
+	}))
+	defer srv.Close()
+
+	entries, err := ghListContents(context.Background(), srv.URL, "https://raw.ghe.example.com",
+		"acme", "skills", "s", commitSHA, "")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t,
+		"https://raw.ghe.example.com/acme/skills/"+commitSHA+"/s/SKILL.md",
+		entries[0].URL)
+}
+
+// TestComputeCacheKey_EmptyRefDiffersFromHEAD documents why resolveGitHubSkill
+// must default an omitted ref before computing the cache key: the two spellings
+// resolve to the same commit but key differently, so leaving the ref empty
+// would halve the hit rate for every unpinned gh:// URI.
+func TestComputeCacheKey_EmptyRefDiffersFromHEAD(t *testing.T) {
+	empty := computeCacheKey("acme", "skills", "skills/deploy", "", "public")
+	head := computeCacheKey("acme", "skills", "skills/deploy", "HEAD", "public")
+	require.NotEqual(t, empty, head)
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -225,6 +225,10 @@ type GitHubAppServerConfig struct {
 	PrivateKey      string
 	WebhookSecret   string
 	APIBaseURL      string
+	// RawBaseURL overrides the origin used to build raw file-content URLs
+	// (default https://raw.githubusercontent.com). Set alongside APIBaseURL
+	// for GitHub Enterprise or for tests that serve fixture content.
+	RawBaseURL      string
 	WebhooksEnabled bool
 	InstallationURL string
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -220,11 +220,11 @@ type MaintenanceConfig struct {
 
 // GitHubAppServerConfig holds the GitHub App configuration for the Hub server.
 type GitHubAppServerConfig struct {
-	AppID           int64
-	PrivateKeyPath  string
-	PrivateKey      string
-	WebhookSecret   string
-	APIBaseURL      string
+	AppID          int64
+	PrivateKeyPath string
+	PrivateKey     string
+	WebhookSecret  string
+	APIBaseURL     string
 	// RawBaseURL overrides the origin used to build raw file-content URLs
 	// (default https://raw.githubusercontent.com). Set alongside APIBaseURL
 	// for GitHub Enterprise or for tests that serve fixture content.

--- a/pkg/hub/skill_handlers.go
+++ b/pkg/hub/skill_handlers.go
@@ -1303,9 +1303,27 @@ func (s *Server) handleSkillsResolve(w http.ResponseWriter, r *http.Request) {
 	var resolved []ResolvedSkillResponse
 	var resolveErrors []ResolveSkillError
 
+	// Resolving a gh:// URI with a non-empty ProjectID makes the Hub mint that
+	// project's GitHub App token, so the caller must be authorized for the
+	// project — otherwise anyone could borrow another project's installation to
+	// read its private repositories. An empty ProjectID resolves anonymously
+	// (no token minted) and needs no check. Evaluated once, up front, and only
+	// when the request actually contains a gh:// URI.
+	ghProjectAllowed := true
+	if req.ProjectID != "" && hasGitHubSkillRef(req.Skills) {
+		ghProjectAllowed = s.canUseProjectGitHubToken(ctx, req.ProjectID)
+	}
+
 	for _, skillRef := range req.Skills {
 		// GitHub skill resolution: gh:// URIs are handled by the Hub's GitHub resolution cache
 		if strings.HasPrefix(skillRef.URI, "gh://") {
+			if !ghProjectAllowed {
+				resolveErrors = append(resolveErrors, ResolveSkillError{
+					URI: skillRef.URI, Code: "forbidden",
+					Message: "you do not have permission to resolve GitHub skills for this project",
+				})
+				continue
+			}
 			ghResolved, err := s.resolveGitHubSkill(ctx, skillRef.URI, req.ProjectID)
 			if err != nil {
 				resolveErrors = append(resolveErrors, ResolveSkillError{
@@ -1491,6 +1509,35 @@ func skillResource(s *store.Skill) Resource {
 		r.ParentID = s.ScopeID
 	}
 	return r
+}
+
+// hasGitHubSkillRef reports whether any reference in the batch is a gh:// URI.
+func hasGitHubSkillRef(refs []ResolveSkillRef) bool {
+	for _, ref := range refs {
+		if strings.HasPrefix(ref.URI, "gh://") {
+			return true
+		}
+	}
+	return false
+}
+
+// canUseProjectGitHubToken reports whether the caller in ctx is permitted to have
+// the Hub mint projectID's GitHub App token on their behalf. Agents are confined
+// to their own project; users must hold read access on the project's skills.
+// Unauthenticated callers are always denied.
+func (s *Server) canUseProjectGitHubToken(ctx context.Context, projectID string) bool {
+	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+		return agentIdent.ProjectID() == projectID
+	}
+	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+		if s.authzService == nil {
+			return false
+		}
+		return s.authzService.CheckAccess(ctx, userIdent, Resource{
+			Type: "skill", ParentType: "project", ParentID: projectID,
+		}, ActionRead).Allowed
+	}
+	return false
 }
 
 // resolveGitHubToken determines the GitHub token scope and mints a token if needed.

--- a/pkg/hub/skill_handlers.go
+++ b/pkg/hub/skill_handlers.go
@@ -38,6 +38,7 @@ import (
 
 const (
 	githubAPIBase = "https://api.github.com"
+	githubRawBase = "https://raw.githubusercontent.com"
 )
 
 // CreateSkillRequest is the request body for creating a skill.
@@ -1536,6 +1537,14 @@ func (s *Server) resolveGitHubSkill(ctx context.Context, rawURI, projectID strin
 		return nil, fmt.Errorf("invalid gh:// URI: %w", err)
 	}
 
+	// Default an omitted ref to HEAD, matching the local resolver
+	// (github_skill_resolver.go resolveCommitSHA). Doing this before the cache
+	// key is computed also means gh://o/r/p and gh://o/r/p@HEAD share one
+	// entry rather than each missing the other's.
+	if ghRef.Ref == "" {
+		ghRef.Ref = "HEAD"
+	}
+
 	// 2. Determine token scope
 	installID, token, err := s.resolveGitHubToken(ctx, projectID)
 	if err != nil {
@@ -1563,13 +1572,17 @@ func (s *Server) resolveGitHubSkill(ctx context.Context, rawURI, projectID strin
 	if s.config.GitHubAppConfig.APIBaseURL != "" {
 		apiBase = s.config.GitHubAppConfig.APIBaseURL
 	}
+	rawBase := githubRawBase
+	if s.config.GitHubAppConfig.RawBaseURL != "" {
+		rawBase = s.config.GitHubAppConfig.RawBaseURL
+	}
 
 	commitSHA, err := ghResolveCommitSHA(ctx, apiBase, ghRef.Owner, ghRef.Repo, ghRef.Ref, token)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve commit SHA: %w", err)
 	}
 
-	fileEntries, err := ghListContents(ctx, apiBase, ghRef.Owner, ghRef.Repo, ghRef.SkillPath, commitSHA, token)
+	fileEntries, err := ghListContents(ctx, apiBase, rawBase, ghRef.Owner, ghRef.Repo, ghRef.SkillPath, commitSHA, token)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list contents: %w", err)
 	}
@@ -1613,6 +1626,13 @@ func (s *Server) resolveGitHubSkill(ctx context.Context, rawURI, projectID strin
 }
 
 // buildResolvedSkillResponse constructs a ResolvedSkillResponse from a cache entry.
+//
+// Hash values here are git blob object IDs (bare 40-char hex), not the
+// "sha256:<hex>" digests used elsewhere in the API: the Hub resolves gh://
+// skills from GitHub metadata alone and never downloads the bytes, so a
+// sha256 digest is not available to it. The client recognises the format and
+// verifies accordingly (see hashFileAs in pkg/agent/skill_resolver.go).
+// ContentHash is likewise a digest over the git blob IDs.
 func buildResolvedSkillResponse(ghRef *agent.GitHubSkillRef, entry *GitHubCacheEntry) *ResolvedSkillResponse {
 	files := make([]DownloadURLInfo, len(entry.FileEntries))
 	for i, f := range entry.FileEntries {

--- a/pkg/hub/skill_handlers.go
+++ b/pkg/hub/skill_handlers.go
@@ -1522,16 +1522,20 @@ func hasGitHubSkillRef(refs []ResolveSkillRef) bool {
 }
 
 // canUseProjectGitHubToken reports whether the caller in ctx is permitted to have
-// the Hub mint projectID's GitHub App token on their behalf. Brokers are trusted
-// Hub clients and are always allowed; agents are confined to their own project;
-// users must hold read access on the project's skills.
+// the Hub mint projectID's GitHub App token on their behalf. Agents are confined
+// to their own project; users must hold read access on the project's skills;
+// brokers must be registered as a provider for the project.
 // Unauthenticated callers are always denied.
 func (s *Server) canUseProjectGitHubToken(ctx context.Context, projectID string) bool {
-	// Brokers are authenticated Hub clients serving project agents; they are
-	// trusted to request tokens for the projects they serve. This mirrors the
-	// broker handling in handlers_env_secrets.go and admin_mode.go.
-	if GetBrokerIdentityFromContext(ctx) != nil {
-		return true
+	// A BrokerIdentity is NOT a global privilege: broker join is unauthenticated,
+	// so anyone can mint one. A broker may only borrow the token of a project it
+	// is registered to serve, which GetProjectProvider confirms.
+	if brokerIdent := GetBrokerIdentityFromContext(ctx); brokerIdent != nil {
+		if s.store == nil {
+			return false
+		}
+		_, err := s.store.GetProjectProvider(ctx, projectID, brokerIdent.BrokerID())
+		return err == nil
 	}
 	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
 		return agentIdent.ProjectID() == projectID

--- a/pkg/hub/skill_handlers.go
+++ b/pkg/hub/skill_handlers.go
@@ -1522,10 +1522,17 @@ func hasGitHubSkillRef(refs []ResolveSkillRef) bool {
 }
 
 // canUseProjectGitHubToken reports whether the caller in ctx is permitted to have
-// the Hub mint projectID's GitHub App token on their behalf. Agents are confined
-// to their own project; users must hold read access on the project's skills.
+// the Hub mint projectID's GitHub App token on their behalf. Brokers are trusted
+// Hub clients and are always allowed; agents are confined to their own project;
+// users must hold read access on the project's skills.
 // Unauthenticated callers are always denied.
 func (s *Server) canUseProjectGitHubToken(ctx context.Context, projectID string) bool {
+	// Brokers are authenticated Hub clients serving project agents; they are
+	// trusted to request tokens for the projects they serve. This mirrors the
+	// broker handling in handlers_env_secrets.go and admin_mode.go.
+	if GetBrokerIdentityFromContext(ctx) != nil {
+		return true
+	}
 	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
 		return agentIdent.ProjectID() == projectID
 	}

--- a/pkg/hub/skill_handlers_authz_test.go
+++ b/pkg/hub/skill_handlers_authz_test.go
@@ -222,6 +222,29 @@ func TestSkillAuthz_Resolve_ForbiddenSkill(t *testing.T) {
 	assert.Equal(t, "forbidden", resp.Errors[0].Code)
 }
 
+// TestSkillAuthz_Resolve_GH_ForbiddenProject guards the cross-project token-borrowing
+// gap: resolving a gh:// URI with a ProjectID makes the Hub mint that project's GitHub
+// App token, so a caller with no access to the project must be rejected. The authz
+// check short-circuits before any GitHub API call, so no GitHub mock is needed.
+func TestSkillAuthz_Resolve_GH_ForbiddenProject(t *testing.T) {
+	srv, _, _, bob, project := setupSkillAuthzTest(t)
+
+	// Bob is not a member of Alice's project.
+	rec := doRequestAsUser(t, srv, bob, http.MethodPost, "/api/v1/skills/resolve", ResolveSkillsRequest{
+		Skills:    []ResolveSkillRef{{URI: "gh://acme/private-repo/skills/secret"}},
+		ProjectID: project.ID,
+	})
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ResolveSkillsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	assert.Empty(t, resp.Resolved, "gh:// skill must not resolve for a non-member of the project")
+	require.NotEmpty(t, resp.Errors, "gh:// resolve against another project should error")
+	assert.Equal(t, "forbidden", resp.Errors[0].Code,
+		"expected forbidden (not resolve_failed): the authz check must fire before GitHub is contacted")
+}
+
 func TestSkillAuthz_Resolve_PublicSkillAllowed(t *testing.T) {
 	srv, s, alice, bob, _ := setupSkillAuthzTest(t)
 	skill := createTestSkill(t, s, "public-skill", store.SkillScopeGlobal, "", alice.ID)

--- a/pkg/hub/skill_handlers_authz_test.go
+++ b/pkg/hub/skill_handlers_authz_test.go
@@ -248,11 +248,31 @@ func TestSkillAuthz_Resolve_GH_ForbiddenProject(t *testing.T) {
 // TestSkillAuthz_Resolve_GH_BrokerAllowed is the ALLOW counterpart to
 // TestSkillAuthz_Resolve_GH_ForbiddenProject. The production Runtime Broker
 // authenticates to the Hub over HMAC, which populates BrokerIdentity — not
-// AgentIdentity or UserIdentity. If canUseProjectGitHubToken does not honour
-// BrokerIdentity, every broker gh:// resolution fails closed with "forbidden",
-// breaking the only production caller. This test pins that behaviour.
+// AgentIdentity or UserIdentity. A broker registered as a provider for the
+// project must clear the authz gate; if it did not, every broker gh:// resolution
+// would fail closed with "forbidden", breaking the only production caller.
 func TestSkillAuthz_Resolve_GH_BrokerAllowed(t *testing.T) {
-	srv, _, _, _, project := setupSkillAuthzTest(t)
+	srv, s, _, _, project := setupSkillAuthzTest(t)
+	ctx := context.Background()
+
+	// The project has no GitHub App installation, so resolveGitHubToken returns
+	// the "public" scope and the GitHub API is still contacted (with an empty
+	// token). Point the Hub at a local server so no live call is made.
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(ghServer.Close)
+	srv.config.GitHubAppConfig.APIBaseURL = ghServer.URL
+
+	// Register the broker as a provider for the project: that registration, not
+	// the mere existence of a BrokerIdentity, is what grants access.
+	brokerID := api.NewUUID()
+	require.NoError(t, s.AddProjectProvider(ctx, &store.ProjectProvider{
+		ProjectID:  project.ID,
+		BrokerID:   brokerID,
+		BrokerName: "skill-test-broker",
+		Status:     "online",
+	}))
 
 	body, err := json.Marshal(ResolveSkillsRequest{
 		Skills:    []ResolveSkillRef{{URI: "gh://acme/private-repo/skills/secret"}},
@@ -264,7 +284,7 @@ func TestSkillAuthz_Resolve_GH_BrokerAllowed(t *testing.T) {
 	// identity directly, mirroring what brokerauth does on a real request.
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/skills/resolve", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req = req.WithContext(contextWithBrokerIdentity(req.Context(), NewBrokerIdentity(tid("skill-broker"))))
+	req = req.WithContext(contextWithBrokerIdentity(req.Context(), NewBrokerIdentity(brokerID)))
 
 	rec := httptest.NewRecorder()
 	srv.mux.ServeHTTP(rec, req)
@@ -280,6 +300,38 @@ func TestSkillAuthz_Resolve_GH_BrokerAllowed(t *testing.T) {
 		assert.NotEqual(t, "forbidden", e.Code,
 			"broker identity must pass canUseProjectGitHubToken; got forbidden: %s", e.Message)
 	}
+}
+
+// TestSkillAuthz_Resolve_GH_BrokerDenied is the DENY counterpart to
+// TestSkillAuthz_Resolve_GH_BrokerAllowed. POST /api/v1/brokers/join is
+// unauthenticated, so any anonymous caller can mint a BrokerIdentity. A broker
+// that is not registered as a provider for the project must therefore not be
+// able to make the Hub mint that project's GitHub App token.
+func TestSkillAuthz_Resolve_GH_BrokerDenied(t *testing.T) {
+	srv, _, _, _, project := setupSkillAuthzTest(t)
+
+	body, err := json.Marshal(ResolveSkillsRequest{
+		Skills:    []ResolveSkillRef{{URI: "gh://acme/private-repo/skills/secret"}},
+		ProjectID: project.ID,
+	})
+	require.NoError(t, err)
+
+	// Broker not registered as a provider for this project. No GitHub stub is
+	// needed: authz rejects the request before GitHub is contacted.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/skills/resolve", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithBrokerIdentity(req.Context(), NewBrokerIdentity(api.NewUUID())))
+
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ResolveSkillsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	assert.Empty(t, resp.Resolved, "unregistered broker must not resolve a project gh:// skill")
+	require.NotEmpty(t, resp.Errors, "unregistered broker should get forbidden")
+	assert.Equal(t, "forbidden", resp.Errors[0].Code)
 }
 
 func TestSkillAuthz_Resolve_PublicSkillAllowed(t *testing.T) {

--- a/pkg/hub/skill_handlers_authz_test.go
+++ b/pkg/hub/skill_handlers_authz_test.go
@@ -245,6 +245,43 @@ func TestSkillAuthz_Resolve_GH_ForbiddenProject(t *testing.T) {
 		"expected forbidden (not resolve_failed): the authz check must fire before GitHub is contacted")
 }
 
+// TestSkillAuthz_Resolve_GH_BrokerAllowed is the ALLOW counterpart to
+// TestSkillAuthz_Resolve_GH_ForbiddenProject. The production Runtime Broker
+// authenticates to the Hub over HMAC, which populates BrokerIdentity — not
+// AgentIdentity or UserIdentity. If canUseProjectGitHubToken does not honour
+// BrokerIdentity, every broker gh:// resolution fails closed with "forbidden",
+// breaking the only production caller. This test pins that behaviour.
+func TestSkillAuthz_Resolve_GH_BrokerAllowed(t *testing.T) {
+	srv, _, _, _, project := setupSkillAuthzTest(t)
+
+	body, err := json.Marshal(ResolveSkillsRequest{
+		Skills:    []ResolveSkillRef{{URI: "gh://acme/private-repo/skills/secret"}},
+		ProjectID: project.ID,
+	})
+	require.NoError(t, err)
+
+	// Bypass the auth middleware (which expects HMAC) and inject a broker
+	// identity directly, mirroring what brokerauth does on a real request.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/skills/resolve", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithBrokerIdentity(req.Context(), NewBrokerIdentity(tid("skill-broker"))))
+
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ResolveSkillsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	// The broker must clear the authz gate. Resolution itself still fails in
+	// this test (no GitHub App is configured), so assert on the error *code*:
+	// anything but "forbidden" means the authz check let the broker through.
+	for _, e := range resp.Errors {
+		assert.NotEqual(t, "forbidden", e.Code,
+			"broker identity must pass canUseProjectGitHubToken; got forbidden: %s", e.Message)
+	}
+}
+
 func TestSkillAuthz_Resolve_PublicSkillAllowed(t *testing.T) {
 	srv, s, alice, bob, _ := setupSkillAuthzTest(t)
 	skill := createTestSkill(t, s, "public-skill", store.SkillScopeGlobal, "", alice.ID)

--- a/pkg/hub/skill_handlers_authz_test.go
+++ b/pkg/hub/skill_handlers_authz_test.go
@@ -275,7 +275,7 @@ func TestSkillAuthz_Resolve_GH_BrokerAllowed(t *testing.T) {
 	}))
 
 	body, err := json.Marshal(ResolveSkillsRequest{
-		Skills:    []ResolveSkillRef{{URI: "gh://acme/private-repo/skills/secret"}},
+		Skills:    []ResolveSkillRef{{URI: "gh://acme/private-repo/secret"}},
 		ProjectID: project.ID,
 	})
 	require.NoError(t, err)
@@ -294,8 +294,10 @@ func TestSkillAuthz_Resolve_GH_BrokerAllowed(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 
 	// The broker must clear the authz gate. Resolution itself still fails in
-	// this test (no GitHub App is configured), so assert on the error *code*:
-	// anything but "forbidden" means the authz check let the broker through.
+	// this test (no GitHub App is configured; ghServer returns 404), so assert
+	// on the error *code*: anything but "forbidden" means the authz check let
+	// the broker through.
+	require.NotEmpty(t, resp.Errors, "resolution must fail in test (no GitHub App configured)")
 	for _, e := range resp.Errors {
 		assert.NotEqual(t, "forbidden", e.Code,
 			"broker identity must pass canUseProjectGitHubToken; got forbidden: %s", e.Message)
@@ -311,7 +313,7 @@ func TestSkillAuthz_Resolve_GH_BrokerDenied(t *testing.T) {
 	srv, _, _, _, project := setupSkillAuthzTest(t)
 
 	body, err := json.Marshal(ResolveSkillsRequest{
-		Skills:    []ResolveSkillRef{{URI: "gh://acme/private-repo/skills/secret"}},
+		Skills:    []ResolveSkillRef{{URI: "gh://acme/private-repo/secret"}},
 		ProjectID: project.ID,
 	})
 	require.NoError(t, err)

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -783,6 +783,12 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 			resolver = agent.NewCachingSkillResolver(resolver, s.skCache)
 		}
 		ctx = agent.ContextWithSkillResolver(ctx, resolver)
+		// Credential for install-phase downloads of gh:// skills resolved by
+		// the Hub, which returns raw.githubusercontent.com URLs but not the
+		// token behind them. Only ever sent to GitHub hosts.
+		if defaultGHToken != "" {
+			ctx = agent.ContextWithGitHubToken(ctx, defaultGHToken)
+		}
 		if req.ProjectID != "" {
 			ctx = agent.ContextWithResolveProjectID(ctx, req.ProjectID)
 		}

--- a/pkg/transfer/hash.go
+++ b/pkg/transfer/hash.go
@@ -53,8 +53,9 @@ func IsGitBlobHash(s string) bool {
 // general-purpose integrity primitive — prefer HashBytes/HashFile for that.
 func GitBlobHashBytes(data []byte) string {
 	h := sha1.New() //nolint:gosec // Git object IDs are SHA-1 by definition.
-	fmt.Fprintf(h, "blob %d\x00", len(data))
-	h.Write(data)
+	// hash.Hash writes never return an error, but errcheck cannot know that.
+	_, _ = fmt.Fprintf(h, "blob %d\x00", len(data))
+	_, _ = h.Write(data)
 	return hex.EncodeToString(h.Sum(nil))
 }
 
@@ -73,7 +74,8 @@ func GitBlobHashFile(path string) (string, error) {
 	}
 
 	h := sha1.New() //nolint:gosec // Git object IDs are SHA-1 by definition.
-	fmt.Fprintf(h, "blob %d\x00", info.Size())
+	// hash.Hash writes never return an error, but errcheck cannot know that.
+	_, _ = fmt.Fprintf(h, "blob %d\x00", info.Size())
 	if _, err := io.Copy(h, f); err != nil {
 		return "", err
 	}

--- a/pkg/transfer/hash.go
+++ b/pkg/transfer/hash.go
@@ -15,15 +15,71 @@
 package transfer
 
 import (
+	"crypto/sha1" //nolint:gosec // Git object IDs are SHA-1 by definition; see GitBlobHashFile.
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"sort"
 )
 
 // HashPrefix is the prefix for SHA-256 hashes.
 const HashPrefix = "sha256:"
+
+// gitBlobHashPattern matches a bare git object ID: 40 lowercase hex characters.
+var gitBlobHashPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+// IsGitBlobHash reports whether s is formatted as a git blob object ID
+// (40 lowercase hex characters, no algorithm prefix).
+//
+// It is used to tell apart the two hash formats that flow through skill
+// resolution: "sha256:<hex64>" digests produced by this package, and bare git
+// blob object IDs supplied verbatim by GitHub's Contents API.
+func IsGitBlobHash(s string) bool {
+	return gitBlobHashPattern.MatchString(s)
+}
+
+// GitBlobHashBytes computes the git blob object ID of data, i.e.
+// SHA-1("blob <len>\x00" + data), returned as bare lowercase hex.
+//
+// This is the value GitHub's Contents API reports in the "sha" field of a
+// file entry. Computing it locally lets a caller verify content fetched from
+// GitHub against metadata GitHub already published, without the metadata
+// producer having to download the content itself.
+//
+// SHA-1 is used because git's object model mandates it. This is not a
+// general-purpose integrity primitive — prefer HashBytes/HashFile for that.
+func GitBlobHashBytes(data []byte) string {
+	h := sha1.New() //nolint:gosec // Git object IDs are SHA-1 by definition.
+	fmt.Fprintf(h, "blob %d\x00", len(data))
+	h.Write(data)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// GitBlobHashFile computes the git blob object ID of a file's contents.
+// See GitBlobHashBytes for the format and the rationale for SHA-1.
+func GitBlobHashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+
+	h := sha1.New() //nolint:gosec // Git object IDs are SHA-1 by definition.
+	fmt.Fprintf(h, "blob %d\x00", info.Size())
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
 
 // HashFile computes the SHA-256 hash of a file.
 // Returns the hash in format "sha256:<hex>".

--- a/pkg/transfer/hash_test.go
+++ b/pkg/transfer/hash_test.go
@@ -122,3 +122,81 @@ func TestComputeContentHash_Deterministic(t *testing.T) {
 		t.Errorf("content hash should be deterministic: %s != %s", hash1, hash2)
 	}
 }
+
+// TestGitBlobHashBytes checks the implementation against object IDs produced
+// by git itself (`git hash-object`), which is the authority for this format.
+func TestGitBlobHashBytes(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		// printf '' | git hash-object --stdin
+		{"empty", "", "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+		// printf 'hello\n' | git hash-object --stdin
+		{"hello newline", "hello\n", "ce013625030ba8dba906f756967f9e9ca394464a"},
+		// printf 'hello world' | git hash-object --stdin
+		{"hello world", "hello world", "95d09f2b10159347eece71399a7e2e907ea3df4f"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := GitBlobHashBytes([]byte(tc.content)); got != tc.want {
+				t.Errorf("GitBlobHashBytes(%q) = %s, want %s", tc.content, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGitBlobHashFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "blob.txt")
+	if err := os.WriteFile(path, []byte("hello\n"), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	got, err := GitBlobHashFile(path)
+	if err != nil {
+		t.Fatalf("GitBlobHashFile: %v", err)
+	}
+	const want = "ce013625030ba8dba906f756967f9e9ca394464a"
+	if got != want {
+		t.Errorf("GitBlobHashFile = %s, want %s", got, want)
+	}
+
+	// Must agree with the in-memory variant.
+	if mem := GitBlobHashBytes([]byte("hello\n")); mem != got {
+		t.Errorf("GitBlobHashFile (%s) disagrees with GitBlobHashBytes (%s)", got, mem)
+	}
+}
+
+func TestGitBlobHashFile_Missing(t *testing.T) {
+	if _, err := GitBlobHashFile(filepath.Join(t.TempDir(), "nope.txt")); err == nil {
+		t.Error("expected an error for a missing file")
+	}
+}
+
+func TestIsGitBlobHash(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"ce013625030ba8dba906f756967f9e9ca394464a", true},
+		{"", false},
+		// A sha256 digest must not be mistaken for a git object ID.
+		{"sha256:ce013625030ba8dba906f756967f9e9ca394464a", false},
+		{HashBytes([]byte("hello")), false},
+		// Wrong length.
+		{"ce013625030ba8dba906f756967f9e9ca394464", false},
+		{"ce013625030ba8dba906f756967f9e9ca394464ab", false},
+		// Uppercase hex is not the canonical git form.
+		{"CE013625030BA8DBA906F756967F9E9CA394464A", false},
+		// Non-hex.
+		{"ze013625030ba8dba906f756967f9e9ca394464a", false},
+	}
+
+	for _, tc := range cases {
+		if got := IsGitBlobHash(tc.in); got != tc.want {
+			t.Errorf("IsGitBlobHash(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Fixes 4 defects found during Phase 3 review of the already-merged Phase 2 hub-side gh:// resolution cache. These block activating hub-side caching (Phase 3's flip PR) safely.

## Fixes
- BUG-1: dual-algorithm hash verification -- Hub returns git blob SHA-1, broker expected sha256:<hex> only. Now dispatches on format.
- BUG-2: Hub stored expiring raw.githubusercontent.com CDN download_url instead of a permanent URL; replaced with a stable URL, GITHUB_TOKEN threaded through context (host-gated).
- BUG-3: empty @ref wasn't defaulted to HEAD before building the cache key, causing near-zero cache hits for unpinned refs (the common case).
- BUG-4 (security): Hub's gh:// endpoint minted a project's GitHub App token without checking the caller owns that project -- cross-project token escalation. Fixed: authz scoped to GetProjectProvider for broker identities, own-project check for agents, ActionRead for users, deny for unauthenticated.

## Review note
The initial BUG-4 fix was unconditional; review caught that unauthenticated /api/v1/brokers/join lets any caller mint a BrokerIdentity, requiring the final scoped-by-project fix. 3 review passes, 2 blocking rounds, final APPROVE.

## Deferred (non-blocking)
- RawBaseURL config knob currently dead code, needs a companion isGitHubHost fix -- tracked for a follow-up, do together.

Once merged, the Phase 3 flip PR (Register -> RegisterFallback) can proceed.