### PR TITLE
agent: flip gh:// skill resolution to hub-side cache (Phase 3 activation)

### DIFF
--- a/.design/project-log/ps-cache-p3-flip.md
+++ b/.design/project-log/ps-cache-p3-flip.md
@@ -1,0 +1,141 @@
+# ps-cache-p3-flip — Phase 3 gh:// cache flip
+
+**Agent:** ps-cache-p3-flip
+**Date:** 2026-07-29
+**Branch:** `scion/ps-cache-p3-flip`
+**Base:** `0eec8204` "fix Phase 2 hub-side gh:// cache defects (#901)"
+
+Activates Hub-first routing for `gh://` skill URIs. Phase 3 (#900) landed the
+`RegisterFallback` routing machinery but deliberately left `gh://` wired to
+`Register` — the local GitHub resolver — because the Hub-side resolver still
+had the Phase 2 defects that #901 has since fixed. This flips the switch, and
+first clears the one reviewer prerequisite (I-4) that was blocking it.
+
+---
+
+## Changes
+
+### 1. I-4 — fallback inherited the Hub's cancelled context
+
+File: `pkg/agent/routing_skill_resolver.go`
+
+`RoutingSkillResolver` passed the caller's `ctx` unchanged to the scheme
+fallback. If a caller set a tight deadline and the Hub call consumed it, the
+fallback was invoked with an already-cancelled context and failed instantly.
+The fallback existed but could not run in the exact scenario — a slow or hung
+Hub — that motivated it.
+
+Both call sites now detach cancellation:
+
+```go
+// transport-level retry in Resolve()
+sr, err = fb.Resolve(context.WithoutCancel(ctx), schemeRefs, opts)
+
+// per-URI retry in retryErrorsWithFallback()
+fr, err := fb.Resolve(context.WithoutCancel(ctx), retryRefs, opts)
+```
+
+`context.WithoutCancel` keeps the context's values — logging and tracing
+metadata still propagate — and drops only the cancellation signal. The caller's
+semantic intent is "resolve this skill", not "resolve it only if the Hub
+answers in time".
+
+Note this means a fallback call is no longer bounded by the caller's deadline.
+That is the intended trade: the local GitHub resolver has its own HTTP client
+timeouts, so the call is bounded, just not by a deadline the Hub has already
+burned through.
+
+Covered by `TestRoutingSkillResolver_RegisterFallback_CancelledPrimaryContext`,
+which uses a `ctxProbeResolver` double that records the cancellation state and
+values of the context it receives, and exercises both call sites with an
+already-cancelled caller context.
+
+### 2. The flip
+
+File: `pkg/runtimebroker/handlers.go`, plus new `pkg/runtimebroker/skill_router.go`
+
+`router.Register("gh", ghResolver)` → `router.RegisterFallback("gh", ghResolver)`.
+`gh://` URIs now go to the Hub first, so the Hub's DB-backed cache absorbs
+repeat resolutions and credentials are minted centrally; the local GitHub
+resolver stays wired as the backstop for Hub transport errors and per-URI
+failures.
+
+The router construction was extracted from the provisioning handler into
+`buildSkillRouter(hub, gh, gcp)`. This was not cosmetic: `RoutingSkillResolver`
+keeps its routing tables in unexported fields, so with the wiring inline in a
+200-line handler there is no way to assert the routing *policy* without driving
+a full provisioning request. A test written against the routing machinery in
+`pkg/agent` instead would have re-tested `RegisterFallback` — it would pass
+whether or not the broker actually called it, which is precisely the regression
+worth guarding. The extraction makes the policy directly assertable.
+
+### 3. Tests
+
+**`pkg/runtimebroker/skill_router_test.go`** — the flip itself:
+
+- `TestBuildSkillRouter_GHRoutesToHubFirst` — `gh://` reaches the Hub and the
+  local resolver is not called. Reverting to `Register` fails this test
+  (verified).
+- `TestBuildSkillRouter_GHFallsBackOnHubPerURIError` — a Hub that cannot
+  resolve one URI does not fail the request.
+- `TestBuildSkillRouter_GHFallsBackOnHubTransportError` — an unreachable Hub
+  degrades to direct GitHub resolution.
+- `TestBuildSkillRouter_OtherSchemes` — the schemes the flip must leave alone:
+  `skill://` and bare names still route to the Hub, `gcp-skill://` still
+  bypasses it.
+
+**`pkg/hub/skill_handlers_gh_cache_test.go`** — the payoff:
+
+- `TestSkillsResolve_GHCacheHitOnSecondResolve` — two identical
+  `POST /api/v1/skills/resolve` calls for the same `gh://` URI against a fake
+  GitHub `httptest.Server`. The first (a miss) makes two API calls,
+  `commits/<ref>` then `contents?ref=<sha>`; the second makes zero and returns
+  a byte-identical response.
+- `TestSkillsResolve_GHCacheKeyedByURI` — a different skill path misses, so the
+  cache is not over-sharing entries between skills.
+
+---
+
+## Notes and deviations
+
+**Call count is 2, not 1, on a miss.** The brief anticipated asserting exactly
+one GitHub call. A miss with a symbolic ref costs two: `ghResolveCommitSHA` to
+pin the SHA, then `ghListContents` at that SHA. Pinning the request to a full
+40-hex SHA would make it one — `ghResolveCommitSHA` short-circuits on an
+already-resolved SHA — but that skips the commits endpoint rather than caching
+it, and takes the 24h SHA TTL path instead of the 30min symbolic-ref path that
+real `gh://owner/repo/skill` references use. The test asserts on the symbolic
+ref (miss = 2, hit = 0), which exercises the branch production traffic takes.
+
+**`ghResolutionStore` is nil in test servers.** It is only assigned in
+`Server.SetIntegrationHA`, so `testServer(t)` leaves the Hub gh:// path
+completely uncached. Without wiring it explicitly the cache test would pass
+vacuously — both resolves would hit GitHub and the counter comparison would
+still hold at the wrong value. The test assigns
+`srv.ghResolutionStore = NewGitHubResolutionStore(enttest.NewClient(t))`.
+Confirmed the test fails when that line is removed.
+
+Worth flagging for whoever owns Hub test infrastructure: any future test that
+touches Hub-side gh:// caching has the same trap, and the failure mode is a
+green test rather than a red one.
+
+**Unrelated gofmt fix.** `pkg/agent/skill_resolver.go` picked up a stray blank
+line in `0eec8204` and fails `gofmt -l` on this branch. Folded into commit 1 so
+the branch passes CI; it is one line of whitespace and touches nothing else.
+
+---
+
+## Verification
+
+```
+gofmt -l pkg/ cmd/ internal/     clean
+go build ./...                   ok
+go vet ./pkg/{agent,runtimebroker,hub}/   clean
+go test ./pkg/agent/...          ok
+go test ./pkg/runtimebroker/...  ok
+go test ./pkg/hub/...            ok
+```
+
+Both new test groups were checked negatively — the broker test fails if the
+wiring reverts to `Register`, the hub test fails if the resolution store is not
+wired — so neither is vacuous.

--- a/.design/project-log/ps-cache-p3-flip.md
+++ b/.design/project-log/ps-cache-p3-flip.md
@@ -125,6 +125,51 @@ the branch passes CI; it is one line of whitespace and touches nothing else.
 
 ---
 
+## Post-review amendments
+
+Two reviewers looked at the branch after the sections above were written. Their
+findings changed the shape of the I-4 fix and surfaced a diagnosability gap in
+I-3. Both are recorded here so the narrative above is not read as current.
+
+**I-4 has moved on — `WithoutCancel` is no longer unconditional.** Commit
+`d236e899` reworked the fix into a `fallbackContext(ctx)` helper and added the
+H-1 guard (the Hub declines `?token=` URIs, so they route to the local resolver
+that can actually read the named broker secret). The helper detaches only a
+context that is *spent* — already cancelled/expired, or with less than
+`fallbackMinBudget` (10s) left before its deadline. A healthy context with a
+usable budget is inherited unchanged, so the caller's deadline still applies and
+a client disconnect mid-fallback still stops the work. The min-budget floor was
+added in the polish pass: a context with 5ms left passes `ctx.Err() == nil` but
+leaves the fallback an unserviceable sliver, which is the same failure mode as a
+spent context one moment earlier.
+
+The statement in section 1 that "a fallback call is no longer bounded by the
+caller's deadline" therefore applies **only to the detached path**, and even
+there the call is bounded — by `fallbackTimeout` (2 minutes), not just by the
+HTTP client's per-request timeouts.
+
+The `fallbackTimeout` comment was also corrected. It previously claimed the
+local GitHub resolver makes "at most two calls per skill URI"; in fact
+`resolveOne` makes two metadata API calls *plus one raw download per file*, so a
+15-file skill is ~17 HTTP requests — and the budget covers the entire retry
+batch (up to 50 refs) in a single call, not one URI. Two minutes remains
+generous for small batches; large batches could hit the ceiling, and the fix if
+that ever bites is to scale the budget by retry-set size rather than raise the
+constant.
+
+**I-3 — private-repo credential mismatch is a diagnosability gap.** Post-flip,
+a private repo that the project's GitHub App can read but the broker's
+`GITHUB_TOKEN` cannot will *resolve* successfully at the Hub and then fail at
+install time with a bare 404 on the download, because the raw URLs the Hub
+returns are fetched with the broker's credential. The resolve/install split
+makes this hard to diagnose: the failure surfaces far from its cause and looks
+like a missing file rather than a missing permission. Not a correctness
+regression — the request was always going to fail — but the error should say so.
+Future work: emit a named-credential hint in the download 404 message,
+identifying which credential was used and suggesting the mismatch.
+
+---
+
 ## Verification
 
 ```

--- a/pkg/agent/routing_skill_resolver.go
+++ b/pkg/agent/routing_skill_resolver.go
@@ -143,7 +143,11 @@ func (r *RoutingSkillResolver) Resolve(ctx context.Context, refs []api.SkillRefe
 				"fallback", resolverNameOf(fb),
 				"refs", len(schemeRefs),
 				"error", err)
-			sr, err = fb.Resolve(ctx, schemeRefs, opts)
+			// Use WithoutCancel so a Hub timeout or deadline expiry on the
+			// primary call does not immediately cancel the fallback. The
+			// caller's semantic intent is "resolve this skill", not "resolve
+			// it only if the Hub responds in time".
+			sr, err = fb.Resolve(context.WithoutCancel(ctx), schemeRefs, opts)
 			if err != nil {
 				return nil, fmt.Errorf("fallback resolver for scheme %q failed: %w", scheme, err)
 			}
@@ -208,7 +212,9 @@ func (r *RoutingSkillResolver) retryErrorsWithFallback(
 		"fallback", resolverNameOf(fb),
 		"refs", len(retryRefs))
 
-	fr, err := fb.Resolve(ctx, retryRefs, opts)
+	// WithoutCancel for the same reason as the transport-level retry above: a
+	// Hub deadline that has already expired must not pre-empt the fallback.
+	fr, err := fb.Resolve(context.WithoutCancel(ctx), retryRefs, opts)
 	if err != nil {
 		slog.Warn("fallback skill resolver failed, keeping primary errors",
 			"scheme", scheme,

--- a/pkg/agent/routing_skill_resolver.go
+++ b/pkg/agent/routing_skill_resolver.go
@@ -19,9 +19,31 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 )
+
+// fallbackTimeout bounds a fallback resolve that had to be detached from an
+// already-spent caller context. The local GitHub resolver uses a 30s HTTP
+// timeout and makes at most two calls per skill URI, so two minutes is
+// generous without being unbounded.
+const fallbackTimeout = 2 * time.Minute
+
+// fallbackContext returns a context for the fallback resolver. If the primary
+// ctx is still healthy it is used as-is, so the caller's cancellation and
+// deadline are preserved. If it is already cancelled or expired (e.g. the Hub
+// call consumed the caller's budget), the context is detached from the
+// cancellation signal and given a bounded budget so the fallback can still
+// complete. Values (logging, tracing) are preserved either way.
+func fallbackContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx.Err() == nil {
+		// Healthy — inherit the caller context, deadline and cancellation intact.
+		return ctx, func() {}
+	}
+	// Already spent — detach so the fallback can run with a fresh, bounded budget.
+	return context.WithTimeout(context.WithoutCancel(ctx), fallbackTimeout)
+}
 
 // RoutingSkillResolver dispatches SkillReferences to scheme-specific resolvers.
 // It groups incoming refs by URI scheme, sends each group to the registered
@@ -143,11 +165,14 @@ func (r *RoutingSkillResolver) Resolve(ctx context.Context, refs []api.SkillRefe
 				"fallback", resolverNameOf(fb),
 				"refs", len(schemeRefs),
 				"error", err)
-			// Use WithoutCancel so a Hub timeout or deadline expiry on the
-			// primary call does not immediately cancel the fallback. The
-			// caller's semantic intent is "resolve this skill", not "resolve
-			// it only if the Hub responds in time".
-			sr, err = fb.Resolve(context.WithoutCancel(ctx), schemeRefs, opts)
+			// A Hub timeout or deadline expiry on the primary call must not
+			// immediately cancel the fallback: the caller's semantic intent is
+			// "resolve this skill", not "resolve it only if the Hub responds in
+			// time". fallbackContext keeps a healthy caller context and swaps a
+			// spent one for a bounded budget.
+			fbCtx, fbCancel := fallbackContext(ctx)
+			sr, err = fb.Resolve(fbCtx, schemeRefs, opts)
+			fbCancel()
 			if err != nil {
 				return nil, fmt.Errorf("fallback resolver for scheme %q failed: %w", scheme, err)
 			}
@@ -212,9 +237,12 @@ func (r *RoutingSkillResolver) retryErrorsWithFallback(
 		"fallback", resolverNameOf(fb),
 		"refs", len(retryRefs))
 
-	// WithoutCancel for the same reason as the transport-level retry above: a
+	// fallbackContext for the same reason as the transport-level retry above: a
 	// Hub deadline that has already expired must not pre-empt the fallback.
-	fr, err := fb.Resolve(context.WithoutCancel(ctx), retryRefs, opts)
+	fbCtx, fbCancel := fallbackContext(ctx)
+	defer fbCancel()
+
+	fr, err := fb.Resolve(fbCtx, retryRefs, opts)
 	if err != nil {
 		slog.Warn("fallback skill resolver failed, keeping primary errors",
 			"scheme", scheme,

--- a/pkg/agent/routing_skill_resolver.go
+++ b/pkg/agent/routing_skill_resolver.go
@@ -24,24 +24,39 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 )
 
-// fallbackTimeout bounds a fallback resolve that had to be detached from an
-// already-spent caller context. The local GitHub resolver uses a 30s HTTP
-// timeout and makes at most two calls per skill URI, so two minutes is
-// generous without being unbounded.
+// fallbackTimeout is the budget for a detached fallback call. The local GitHub
+// resolver makes two metadata API calls plus one raw download per file in each
+// skill; a 15-file skill is ~17 HTTP requests, all with a 30s per-request
+// timeout. The fallback receives the whole retry set (up to 50 skills) in a
+// single call, so the budget must cover the batch. Two minutes is generous for
+// small batches; larger batches may hit the ceiling, in which case the budget
+// should be scaled by the number of refs being retried rather than raised
+// wholesale.
 const fallbackTimeout = 2 * time.Minute
 
+// fallbackMinBudget is the minimum remaining lifetime a caller context must have
+// to be worth inheriting. A context with less than this is treated as effectively
+// spent: the fallback is detached from it and given a fresh fallbackTimeout budget
+// instead. This prevents a Hub that is merely slow (rather than fully blocking)
+// from leaving the fallback with an unserviceable sliver of time.
+const fallbackMinBudget = 10 * time.Second
+
 // fallbackContext returns a context for the fallback resolver. If the primary
-// ctx is still healthy it is used as-is, so the caller's cancellation and
-// deadline are preserved. If it is already cancelled or expired (e.g. the Hub
-// call consumed the caller's budget), the context is detached from the
-// cancellation signal and given a bounded budget so the fallback can still
-// complete. Values (logging, tracing) are preserved either way.
+// ctx is still healthy and has a usable budget left it is used as-is, so the
+// caller's cancellation and deadline are preserved. If it is already cancelled
+// or expired — or so close to its deadline that the fallback could not finish
+// (e.g. the Hub call consumed nearly all of the caller's budget) — the context
+// is detached from the cancellation signal and given a bounded budget so the
+// fallback can still complete. Values (logging, tracing) are preserved either
+// way.
 func fallbackContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	if ctx.Err() == nil {
-		// Healthy — inherit the caller context, deadline and cancellation intact.
-		return ctx, func() {}
+		if dl, ok := ctx.Deadline(); !ok || time.Until(dl) >= fallbackMinBudget {
+			// Healthy with a usable budget — inherit deadline and cancellation.
+			return ctx, func() {}
+		}
 	}
-	// Already spent — detach so the fallback can run with a fresh, bounded budget.
+	// Spent, or too little budget left — detach with a bounded budget.
 	return context.WithTimeout(context.WithoutCancel(ctx), fallbackTimeout)
 }
 

--- a/pkg/agent/routing_skill_resolver_test.go
+++ b/pkg/agent/routing_skill_resolver_test.go
@@ -828,7 +828,7 @@ func TestRoutingSkillResolver_RegisterFallback_CancelledPrimaryContext(t *testin
 		// own deadline so a wedged fallback cannot run forever.
 		if !local.callHasDL {
 			t.Error("detached fallback context has no deadline; want a bounded budget")
-		} else if d := time.Until(local.callDeadline); d <= 0 || d > fallbackTimeout+time.Minute {
+		} else if d := time.Until(local.callDeadline); d <= 0 || d > fallbackTimeout {
 			t.Errorf("detached fallback budget = %v, want (0, %v]", d, fallbackTimeout)
 		}
 		if local.sawValue != "trace-abc" {
@@ -870,7 +870,7 @@ func TestRoutingSkillResolver_RegisterFallback_CancelledPrimaryContext(t *testin
 		}
 		if !local.callHasDL {
 			t.Error("detached fallback context has no deadline; want a bounded budget")
-		} else if d := time.Until(local.callDeadline); d <= 0 || d > fallbackTimeout+time.Minute {
+		} else if d := time.Until(local.callDeadline); d <= 0 || d > fallbackTimeout {
 			t.Errorf("detached fallback budget = %v, want (0, %v]", d, fallbackTimeout)
 		}
 		if local.sawValue != "trace-xyz" {
@@ -982,6 +982,34 @@ func TestRoutingSkillResolver_RegisterFallback_CancelledPrimaryContext(t *testin
 		}
 		if len(result.Resolved) != 1 {
 			t.Errorf("got %d resolved, want 1", len(result.Resolved))
+		}
+	})
+
+	// A context with a sliver of time left is not "healthy" in any useful sense:
+	// it passes ctx.Err() == nil but the fallback cannot possibly finish inside
+	// it. fallbackMinBudget makes that case behave like a fully-spent context.
+	t.Run("nearly spent context is detached rather than inherited", func(t *testing.T) {
+		nearlySpent := time.Now().Add(fallbackMinBudget - time.Second)
+		ctx, cancel := context.WithDeadline(
+			context.WithValue(context.Background(), ctxProbeKey{}, "trace-sliver"), nearlySpent)
+		defer cancel()
+
+		fbCtx, fbCancel := fallbackContext(ctx)
+		defer fbCancel()
+
+		if err := fbCtx.Err(); err != nil {
+			t.Fatalf("fallback context is already dead: %v", err)
+		}
+		dl, ok := fbCtx.Deadline()
+		if !ok {
+			t.Fatal("detached fallback context has no deadline; want a bounded budget")
+		}
+		if d := time.Until(dl); d < fallbackTimeout/2 || d > fallbackTimeout {
+			t.Errorf("fallback budget = %v, want a fresh budget in [%v, %v] rather than the caller's %v",
+				d, fallbackTimeout/2, fallbackTimeout, time.Until(nearlySpent))
+		}
+		if v, _ := fbCtx.Value(ctxProbeKey{}).(string); v != "trace-sliver" {
+			t.Errorf("detached fallback context lost caller values: got %q", v)
 		}
 	})
 }

--- a/pkg/agent/routing_skill_resolver_test.go
+++ b/pkg/agent/routing_skill_resolver_test.go
@@ -753,3 +753,112 @@ func TestRoutingSkillResolver_RegisterFallback_SilentDrop(t *testing.T) {
 		}
 	})
 }
+
+// ctxProbeResolver records the cancellation state of the context it is called
+// with, so tests can assert that the fallback is invoked with a context that
+// survived the primary's deadline.
+type ctxProbeResolver struct {
+	name     string
+	resolved []ResolvedSkill
+	errors   []ResolveError
+
+	called    []api.SkillReference
+	callCtxOK bool   // ctx.Err() == nil at call time
+	sawValue  string // value carried over from the caller's context
+}
+
+type ctxProbeKey struct{}
+
+func (m *ctxProbeResolver) ResolverName() string { return m.name }
+func (m *ctxProbeResolver) Resolve(ctx context.Context, refs []api.SkillReference, _ ResolveOpts) (*ResolveResult, error) {
+	m.called = append(m.called, refs...)
+	m.callCtxOK = ctx.Err() == nil
+	if v, ok := ctx.Value(ctxProbeKey{}).(string); ok {
+		m.sawValue = v
+	}
+	if !m.callCtxOK {
+		return nil, ctx.Err()
+	}
+	return &ResolveResult{Resolved: m.resolved, Errors: m.errors}, nil
+}
+
+// TestRoutingSkillResolver_RegisterFallback_CancelledPrimaryContext covers I-4:
+// the fallback must not inherit the primary's cancellation. If a tight caller
+// deadline is consumed by the Hub call, passing the same context straight to
+// the fallback makes the fallback fail instantly and defeats its purpose.
+// context.WithoutCancel detaches the cancellation while keeping values.
+func TestRoutingSkillResolver_RegisterFallback_CancelledPrimaryContext(t *testing.T) {
+	t.Run("transport error with exhausted context", func(t *testing.T) {
+		// The primary "times out": it fails, and the caller's context is dead
+		// by the time the router reaches for the fallback.
+		ctx, cancel := context.WithCancel(context.WithValue(context.Background(), ctxProbeKey{}, "trace-abc"))
+		hub := &mockSchemeResolver{name: "hub", hardErr: context.DeadlineExceeded}
+		local := &ctxProbeResolver{
+			name:     "github",
+			resolved: []ResolvedSkill{{Name: "gh-skill", URI: "gh://owner/repo/skill"}},
+		}
+		router := NewRoutingSkillResolver(hub)
+		router.RegisterFallback("gh", local)
+
+		cancel() // caller's deadline is gone before the fallback runs
+
+		result, err := router.Resolve(ctx, []api.SkillReference{
+			{URI: "gh://owner/repo/skill"},
+		}, ResolveOpts{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(local.called) != 1 {
+			t.Fatalf("fallback received %d refs, want 1", len(local.called))
+		}
+		if !local.callCtxOK {
+			t.Error("fallback was called with an already-cancelled context; want WithoutCancel")
+		}
+		if local.sawValue != "trace-abc" {
+			t.Errorf("fallback context lost caller values: got %q, want %q", local.sawValue, "trace-abc")
+		}
+		if len(result.Resolved) != 1 || result.Resolved[0].Name != "gh-skill" {
+			t.Errorf("unexpected resolved result: %+v", result.Resolved)
+		}
+	})
+
+	t.Run("per-URI retry with exhausted context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.WithValue(context.Background(), ctxProbeKey{}, "trace-xyz"))
+		hub := &mockSchemeResolver{
+			name: "hub",
+			errors: []ResolveError{
+				{URI: "gh://owner/repo/bad", Code: "resolve_failed", Message: "hub could not resolve"},
+			},
+		}
+		local := &ctxProbeResolver{
+			name:     "github",
+			resolved: []ResolvedSkill{{Name: "bad", URI: "gh://owner/repo/bad"}},
+		}
+		router := NewRoutingSkillResolver(hub)
+		router.RegisterFallback("gh", local)
+
+		cancel()
+
+		result, err := router.Resolve(ctx, []api.SkillReference{
+			{URI: "gh://owner/repo/bad"},
+		}, ResolveOpts{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(local.called) != 1 {
+			t.Fatalf("fallback received %d refs, want 1", len(local.called))
+		}
+		if !local.callCtxOK {
+			t.Error("fallback retry was called with an already-cancelled context; want WithoutCancel")
+		}
+		if local.sawValue != "trace-xyz" {
+			t.Errorf("fallback context lost caller values: got %q, want %q", local.sawValue, "trace-xyz")
+		}
+		if len(result.Resolved) != 1 {
+			t.Fatalf("got %d resolved, want 1: %+v", len(result.Resolved), result.Resolved)
+		}
+		if len(result.Errors) != 0 {
+			t.Errorf("expected hub error to be superseded by fallback, got %+v", result.Errors)
+		}
+	})
+}

--- a/pkg/agent/routing_skill_resolver_test.go
+++ b/pkg/agent/routing_skill_resolver_test.go
@@ -16,8 +16,10 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 )
@@ -762,9 +764,12 @@ type ctxProbeResolver struct {
 	resolved []ResolvedSkill
 	errors   []ResolveError
 
-	called    []api.SkillReference
-	callCtxOK bool   // ctx.Err() == nil at call time
-	sawValue  string // value carried over from the caller's context
+	called       []api.SkillReference
+	callCtxOK    bool      // ctx.Err() == nil at call time
+	sawValue     string    // value carried over from the caller's context
+	callDeadline time.Time // deadline of the context the fallback was called with
+	callHasDL    bool      // whether that context carried a deadline at all
+	onCall       func(ctx context.Context)
 }
 
 type ctxProbeKey struct{}
@@ -773,8 +778,13 @@ func (m *ctxProbeResolver) ResolverName() string { return m.name }
 func (m *ctxProbeResolver) Resolve(ctx context.Context, refs []api.SkillReference, _ ResolveOpts) (*ResolveResult, error) {
 	m.called = append(m.called, refs...)
 	m.callCtxOK = ctx.Err() == nil
+	m.callDeadline, m.callHasDL = ctx.Deadline()
 	if v, ok := ctx.Value(ctxProbeKey{}).(string); ok {
 		m.sawValue = v
+	}
+	if m.onCall != nil {
+		m.onCall(ctx)
+		m.callCtxOK = ctx.Err() == nil
 	}
 	if !m.callCtxOK {
 		return nil, ctx.Err()
@@ -812,7 +822,14 @@ func TestRoutingSkillResolver_RegisterFallback_CancelledPrimaryContext(t *testin
 			t.Fatalf("fallback received %d refs, want 1", len(local.called))
 		}
 		if !local.callCtxOK {
-			t.Error("fallback was called with an already-cancelled context; want WithoutCancel")
+			t.Error("fallback was called with an already-cancelled context; want a detached context")
+		}
+		// Detached, but not unbounded: the replacement context must carry its
+		// own deadline so a wedged fallback cannot run forever.
+		if !local.callHasDL {
+			t.Error("detached fallback context has no deadline; want a bounded budget")
+		} else if d := time.Until(local.callDeadline); d <= 0 || d > fallbackTimeout+time.Minute {
+			t.Errorf("detached fallback budget = %v, want (0, %v]", d, fallbackTimeout)
 		}
 		if local.sawValue != "trace-abc" {
 			t.Errorf("fallback context lost caller values: got %q, want %q", local.sawValue, "trace-abc")
@@ -849,7 +866,12 @@ func TestRoutingSkillResolver_RegisterFallback_CancelledPrimaryContext(t *testin
 			t.Fatalf("fallback received %d refs, want 1", len(local.called))
 		}
 		if !local.callCtxOK {
-			t.Error("fallback retry was called with an already-cancelled context; want WithoutCancel")
+			t.Error("fallback retry was called with an already-cancelled context; want a detached context")
+		}
+		if !local.callHasDL {
+			t.Error("detached fallback context has no deadline; want a bounded budget")
+		} else if d := time.Until(local.callDeadline); d <= 0 || d > fallbackTimeout+time.Minute {
+			t.Errorf("detached fallback budget = %v, want (0, %v]", d, fallbackTimeout)
 		}
 		if local.sawValue != "trace-xyz" {
 			t.Errorf("fallback context lost caller values: got %q, want %q", local.sawValue, "trace-xyz")
@@ -859,6 +881,107 @@ func TestRoutingSkillResolver_RegisterFallback_CancelledPrimaryContext(t *testin
 		}
 		if len(result.Errors) != 0 {
 			t.Errorf("expected hub error to be superseded by fallback, got %+v", result.Errors)
+		}
+	})
+
+	// The detach above is a repair for a spent context, not the default. When
+	// the caller's context is still healthy the fallback must inherit it, so
+	// the caller's deadline still applies and a client disconnect mid-fallback
+	// still stops the work.
+	t.Run("transport error with healthy context inherits caller context", func(t *testing.T) {
+		callerDeadline := time.Now().Add(30 * time.Second)
+		ctx, cancel := context.WithDeadline(
+			context.WithValue(context.Background(), ctxProbeKey{}, "trace-live"), callerDeadline)
+		defer cancel()
+
+		hub := &mockSchemeResolver{name: "hub", hardErr: errors.New("hub unreachable")}
+		local := &ctxProbeResolver{
+			name:     "github",
+			resolved: []ResolvedSkill{{Name: "gh-skill", URI: "gh://owner/repo/skill"}},
+		}
+		router := NewRoutingSkillResolver(hub)
+		router.RegisterFallback("gh", local)
+
+		result, err := router.Resolve(ctx, []api.SkillReference{
+			{URI: "gh://owner/repo/skill"},
+		}, ResolveOpts{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !local.callCtxOK {
+			t.Fatal("fallback context was already cancelled")
+		}
+		if !local.callHasDL || !local.callDeadline.Equal(callerDeadline) {
+			t.Errorf("fallback deadline = %v (set=%v), want caller deadline %v",
+				local.callDeadline, local.callHasDL, callerDeadline)
+		}
+		if local.sawValue != "trace-live" {
+			t.Errorf("fallback context lost caller values: got %q", local.sawValue)
+		}
+		if len(result.Resolved) != 1 {
+			t.Errorf("got %d resolved, want 1", len(result.Resolved))
+		}
+	})
+
+	t.Run("healthy context still propagates caller cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		hub := &mockSchemeResolver{name: "hub", hardErr: errors.New("hub unreachable")}
+		local := &ctxProbeResolver{
+			name:     "github",
+			resolved: []ResolvedSkill{{Name: "gh-skill", URI: "gh://owner/repo/skill"}},
+			// Simulate the caller disconnecting while the fallback is in flight.
+			onCall: func(context.Context) { cancel() },
+		}
+		router := NewRoutingSkillResolver(hub)
+		router.RegisterFallback("gh", local)
+
+		_, err := router.Resolve(ctx, []api.SkillReference{
+			{URI: "gh://owner/repo/skill"},
+		}, ResolveOpts{})
+		if err == nil {
+			t.Fatal("expected error when the caller cancels during the fallback")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("error = %v, want context.Canceled to propagate to the fallback", err)
+		}
+	})
+
+	t.Run("per-URI retry with healthy context inherits caller context", func(t *testing.T) {
+		callerDeadline := time.Now().Add(45 * time.Second)
+		ctx, cancel := context.WithDeadline(
+			context.WithValue(context.Background(), ctxProbeKey{}, "trace-live2"), callerDeadline)
+		defer cancel()
+
+		hub := &mockSchemeResolver{
+			name: "hub",
+			errors: []ResolveError{
+				{URI: "gh://owner/repo/bad", Code: "resolve_failed", Message: "hub could not resolve"},
+			},
+		}
+		local := &ctxProbeResolver{
+			name:     "github",
+			resolved: []ResolvedSkill{{Name: "bad", URI: "gh://owner/repo/bad"}},
+		}
+		router := NewRoutingSkillResolver(hub)
+		router.RegisterFallback("gh", local)
+
+		result, err := router.Resolve(ctx, []api.SkillReference{
+			{URI: "gh://owner/repo/bad"},
+		}, ResolveOpts{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !local.callHasDL || !local.callDeadline.Equal(callerDeadline) {
+			t.Errorf("fallback deadline = %v (set=%v), want caller deadline %v",
+				local.callDeadline, local.callHasDL, callerDeadline)
+		}
+		if local.sawValue != "trace-live2" {
+			t.Errorf("fallback context lost caller values: got %q", local.sawValue)
+		}
+		if len(result.Resolved) != 1 {
+			t.Errorf("got %d resolved, want 1", len(result.Resolved))
 		}
 	})
 }

--- a/pkg/agent/skill_resolver.go
+++ b/pkg/agent/skill_resolver.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/transfer"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"

--- a/pkg/hub/skill_handlers.go
+++ b/pkg/hub/skill_handlers.go
@@ -1595,6 +1595,15 @@ func (s *Server) resolveGitHubSkill(ctx context.Context, rawURI, projectID strin
 		return nil, fmt.Errorf("invalid gh:// URI: %w", err)
 	}
 
+	// gh:// URIs with ?token= name a ProvisionCredentials secret that lives on
+	// the broker, not the Hub. Resolving here would silently substitute the
+	// project's GitHub App token and hand back raw.githubusercontent.com URLs
+	// the broker cannot authenticate. Return an error so the per-URI fallback
+	// routes these to the local resolver, which looks up the named secret.
+	if ghRef.TokenSecretName != "" {
+		return nil, fmt.Errorf("gh:// URI with ?token= must be resolved by the local resolver")
+	}
+
 	// Default an omitted ref to HEAD, matching the local resolver
 	// (github_skill_resolver.go resolveCommitSHA). Doing this before the cache
 	// key is computed also means gh://o/r/p and gh://o/r/p@HEAD share one

--- a/pkg/hub/skill_handlers_gh_cache_test.go
+++ b/pkg/hub/skill_handlers_gh_cache_test.go
@@ -184,3 +184,77 @@ func TestSkillsResolve_GHCacheKeyedByURI(t *testing.T) {
 	assert.Equal(t, int64(4), gh.calls.Load(),
 		"a different skill path must miss the cache and hit GitHub")
 }
+
+// TestSkillsResolve_GHDeclinesTokenSecretURI pins the one gh:// shape the Hub
+// must refuse to resolve. `?token=NAME` names a ProvisionCredentials secret
+// that exists only on the broker; the Hub has no way to read it. If the Hub
+// resolved these anyway it would silently substitute the project's GitHub App
+// token and return raw.githubusercontent.com URLs the broker cannot
+// authenticate at install time — a confusing download failure well after the
+// resolve appeared to succeed.
+//
+// Declining with an error is load-bearing: the broker's
+// RoutingSkillResolver.retryErrorsWithFallback turns any per-URI error into a
+// fallback to the local resolver, which does look up the named secret. So the
+// error is the routing signal, not a dead end.
+//
+// The fake GitHub here would happily serve this URI, so the test genuinely
+// discriminates: without the guard the request resolves successfully.
+func TestSkillsResolve_GHDeclinesTokenSecretURI(t *testing.T) {
+	const (
+		owner     = "acme"
+		repo      = "private-repo"
+		skillPath = "skills/secret"
+		commitSHA = "cccccccccccccccccccccccccccccccccccccccc"
+	)
+
+	srv, _, alice, _, project := setupSkillAuthzTest(t)
+	srv.ghResolutionStore = NewGitHubResolutionStore(enttest.NewClient(t))
+
+	gh := newFakeGitHub(t, owner, repo, skillPath, commitSHA)
+	srv.config.GitHubAppConfig.APIBaseURL = gh.URL
+	srv.config.GitHubAppConfig.RawBaseURL = gh.URL
+
+	rec := doRequestAsUser(t, srv, alice, http.MethodPost, "/api/v1/skills/resolve", ResolveSkillsRequest{
+		Skills:    []ResolveSkillRef{{URI: "gh://" + owner + "/" + repo + "/secret?token=MY_TOKEN"}},
+		ProjectID: project.ID,
+	})
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp ResolveSkillsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	assert.Empty(t, resp.Resolved,
+		"Hub must not resolve a ?token= URI: it cannot read the named broker secret")
+	require.Len(t, resp.Errors, 1, "the declined URI must surface as a per-URI error")
+
+	// The error must be a resolve failure, not an authz denial: Alice owns the
+	// project, so authz passed and the Hub declined on its own terms. A
+	// "forbidden" here would mean the broker's fallback is masking a real
+	// permission bug.
+	assert.NotEqual(t, "forbidden", resp.Errors[0].Code,
+		"authz should pass for the project owner; got forbidden: %s", resp.Errors[0].Message)
+	assert.Equal(t, "resolve_failed", resp.Errors[0].Code)
+	assert.Contains(t, resp.Errors[0].Message, "local resolver",
+		"the error should explain that the local resolver owns this URI shape")
+
+	// The Hub must decline before contacting GitHub — otherwise it has already
+	// minted and spent the project's App token on a request it cannot serve.
+	assert.Zero(t, gh.calls.Load(),
+		"Hub must decline the ?token= URI without calling GitHub")
+
+	// A ?token=-free URI for the same skill still resolves, so the guard is
+	// scoped to the token parameter rather than disabling gh:// caching.
+	rec = doRequestAsUser(t, srv, alice, http.MethodPost, "/api/v1/skills/resolve", ResolveSkillsRequest{
+		Skills:    []ResolveSkillRef{{URI: "gh://" + owner + "/" + repo + "/secret"}},
+		ProjectID: project.ID,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Decode into a fresh value: omitted JSON fields leave the previous
+	// response's Errors in place and would make this assertion meaningless.
+	var plainResp ResolveSkillsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&plainResp))
+	assert.Empty(t, plainResp.Errors, "the same skill without ?token= must still resolve")
+	assert.Len(t, plainResp.Resolved, 1)
+}

--- a/pkg/hub/skill_handlers_gh_cache_test.go
+++ b/pkg/hub/skill_handlers_gh_cache_test.go
@@ -176,13 +176,24 @@ func TestSkillsResolve_GHCacheKeyedByURI(t *testing.T) {
 		require.Len(t, resp.Resolved, 1)
 	}
 
-	resolve(t, "gh://"+owner+"/"+repo+"/first")
+	const uriA = "gh://" + owner + "/" + repo + "/first"
+
+	resolve(t, uriA)
 	afterFirst := gh.calls.Load()
 	require.Equal(t, int64(2), afterFirst)
 
 	resolve(t, "gh://"+owner+"/"+repo+"/second")
-	assert.Equal(t, int64(4), gh.calls.Load(),
+	require.Equal(t, int64(4), gh.calls.Load(),
 		"a different skill path must miss the cache and hit GitHub")
+
+	// Re-resolve the first URI. Without this the test is vacuous: two distinct
+	// uncached resolves also cost 2 then 4 calls, so the assertions above hold
+	// even with caching disabled. A cache hit here pins both halves of the
+	// claim — caching is active, and the second URI's entry neither evicted the
+	// first nor aliased onto it.
+	resolve(t, uriA)
+	assert.Equal(t, int64(4), gh.calls.Load(),
+		"re-resolving the first URI must hit its own cache entry and make no further GitHub calls")
 }
 
 // TestSkillsResolve_GHDeclinesTokenSecretURI pins the one gh:// shape the Hub

--- a/pkg/hub/skill_handlers_gh_cache_test.go
+++ b/pkg/hub/skill_handlers_gh_cache_test.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store/enttest"
+)
+
+// fakeGitHub stands in for api.github.com for the two endpoints the gh://
+// resolver uses, counting every request it serves so tests can assert that a
+// cache hit reaches no further than the DB.
+type fakeGitHub struct {
+	*httptest.Server
+	calls atomic.Int64
+}
+
+// newFakeGitHub serves the commits and contents endpoints for owner/repo,
+// returning commitSHA and a single-file listing under skillPath.
+func newFakeGitHub(t *testing.T, owner, repo, skillPath, commitSHA string) *fakeGitHub {
+	t.Helper()
+
+	f := &fakeGitHub{}
+	commitsPrefix := "/repos/" + owner + "/" + repo + "/commits/"
+	contentsPrefix := "/repos/" + owner + "/" + repo + "/contents/"
+
+	f.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.calls.Add(1)
+		switch {
+		case strings.HasPrefix(r.URL.Path, commitsPrefix):
+			// Accept: application/vnd.github.v3.sha — a bare SHA, not JSON.
+			_, _ = w.Write([]byte(commitSHA))
+		case strings.HasPrefix(r.URL.Path, contentsPrefix):
+			assert.Equal(t, commitSHA, r.URL.Query().Get("ref"),
+				"contents must be fetched at the resolved commit, not the symbolic ref")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{
+				"name": "SKILL.md",
+				"path": "` + skillPath + `/SKILL.md",
+				"sha": "ce013625030ba8dba906f756967f9e9ca394464a",
+				"size": 6,
+				"type": "file",
+				"download_url": "https://example.invalid/should-be-ignored"
+			}]`))
+		default:
+			t.Errorf("unexpected GitHub API request: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(f.Close)
+	return f
+}
+
+// TestSkillsResolve_GHCacheHitOnSecondResolve is the end-to-end proof that the
+// Hub-side gh:// cache is what makes Phase 3 worth flipping: routing agent
+// gh:// resolutions through the Hub only pays off if the Hub absorbs repeat
+// resolutions instead of forwarding each one to GitHub.
+//
+// Two identical resolve calls must produce identical responses while the second
+// one reaches GitHub zero times.
+func TestSkillsResolve_GHCacheHitOnSecondResolve(t *testing.T) {
+	const (
+		owner     = "acme"
+		repo      = "private-repo"
+		skillPath = "skills/secret"
+		uri       = "gh://" + owner + "/" + repo + "/secret"
+		commitSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	srv, _, alice, _, project := setupSkillAuthzTest(t)
+
+	// testServer leaves ghResolutionStore nil (it is only wired by
+	// SetIntegrationHA in production), which would disable caching entirely and
+	// make this test vacuous. Give it its own migrated SQLite client.
+	srv.ghResolutionStore = NewGitHubResolutionStore(enttest.NewClient(t))
+
+	gh := newFakeGitHub(t, owner, repo, skillPath, commitSHA)
+	srv.config.GitHubAppConfig.APIBaseURL = gh.URL
+	srv.config.GitHubAppConfig.RawBaseURL = gh.URL
+
+	body := ResolveSkillsRequest{
+		Skills:    []ResolveSkillRef{{URI: uri}},
+		ProjectID: project.ID,
+	}
+
+	resolve := func(t *testing.T) ResolvedSkillResponse {
+		t.Helper()
+		rec := doRequestAsUser(t, srv, alice, http.MethodPost, "/api/v1/skills/resolve", body)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+		var resp ResolveSkillsResponse
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		require.Empty(t, resp.Errors, "resolution must succeed against the fake GitHub")
+		require.Len(t, resp.Resolved, 1)
+		return resp.Resolved[0]
+	}
+
+	// First resolve: a cache miss, so both GitHub endpoints are contacted —
+	// commits/<ref> to pin the SHA, then contents at that SHA.
+	first := resolve(t)
+	missCalls := gh.calls.Load()
+	require.Equal(t, int64(2), missCalls,
+		"cache miss should call commits + contents exactly once each")
+
+	// Second resolve: identical request, served entirely from the DB cache.
+	second := resolve(t)
+
+	assert.Equal(t, missCalls, gh.calls.Load(),
+		"second resolve must be served from the DB cache and make no GitHub API calls")
+	assert.Equal(t, first, second,
+		"a cache hit must reproduce the miss response byte for byte")
+
+	// Sanity-check that the cached response is actually populated, so an
+	// all-empty response cannot satisfy the equality assertion above.
+	assert.Equal(t, uri, second.URI)
+	assert.Equal(t, "secret", second.Name)
+	assert.NotEmpty(t, second.ContentHash)
+	require.Len(t, second.Files, 1)
+	assert.Contains(t, second.Files[0].URL, commitSHA,
+		"file URL must be pinned to the resolved commit")
+}
+
+// TestSkillsResolve_GHCacheKeyedByURI confirms the cache discriminates between
+// skills: a second, different gh:// URI must not be served the first one's
+// cached entry.
+func TestSkillsResolve_GHCacheKeyedByURI(t *testing.T) {
+	const (
+		owner     = "acme"
+		repo      = "private-repo"
+		commitSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	srv, _, alice, _, project := setupSkillAuthzTest(t)
+	srv.ghResolutionStore = NewGitHubResolutionStore(enttest.NewClient(t))
+
+	// Serve any skill path under the repo.
+	gh := newFakeGitHub(t, owner, repo, "skills/any", commitSHA)
+	srv.config.GitHubAppConfig.APIBaseURL = gh.URL
+	srv.config.GitHubAppConfig.RawBaseURL = gh.URL
+
+	resolve := func(t *testing.T, uri string) {
+		t.Helper()
+		rec := doRequestAsUser(t, srv, alice, http.MethodPost, "/api/v1/skills/resolve",
+			ResolveSkillsRequest{
+				Skills:    []ResolveSkillRef{{URI: uri}},
+				ProjectID: project.ID,
+			})
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+		var resp ResolveSkillsResponse
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		require.Empty(t, resp.Errors)
+		require.Len(t, resp.Resolved, 1)
+	}
+
+	resolve(t, "gh://"+owner+"/"+repo+"/first")
+	afterFirst := gh.calls.Load()
+	require.Equal(t, int64(2), afterFirst)
+
+	resolve(t, "gh://"+owner+"/"+repo+"/second")
+	assert.Equal(t, int64(4), gh.calls.Load(),
+		"a different skill path must miss the cache and hit GitHub")
+}

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -754,13 +754,8 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 	// Inject skill resolver from Hub connection for skill provisioning.
 	if conn := s.resolveHubConnection(r); conn != nil && conn.HubClient != nil {
 		hubResolver := agent.NewHubSkillResolver(conn.HubClient.Skills())
-		router := agent.NewRoutingSkillResolver(hubResolver)
 		defaultGHToken := req.ResolvedEnv["GITHUB_TOKEN"]
 		ghResolver := agent.NewGitHubSkillResolverWithCredentials(defaultGHToken, req.ProvisionCredentials, s.ghResolutionCache)
-		// RegisterFallback is wired for gh:// but not yet activated: Phase 2 Hub-side
-		// defects (hash format mismatch, no Content field, ref-defaulting) must be
-		// fixed before Hub routing can go live. Flip to RegisterFallback once resolved.
-		router.Register("gh", ghResolver)
 
 		// GCP resolver uses Hub API for registry alias lookup.
 		registrySvc := conn.HubClient.SkillRegistries()
@@ -779,7 +774,8 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 				Status:   reg.Status,
 			}, nil
 		}
-		router.Register("gcp-skill", agent.NewGCPSkillResolver(gcpLookup))
+
+		router := buildSkillRouter(hubResolver, ghResolver, agent.NewGCPSkillResolver(gcpLookup))
 
 		var resolver agent.SkillResolver = router
 		if s.skCache != nil {

--- a/pkg/runtimebroker/skill_router.go
+++ b/pkg/runtimebroker/skill_router.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtimebroker
+
+import (
+	"github.com/GoogleCloudPlatform/scion/pkg/agent"
+)
+
+// buildSkillRouter assembles the scheme routing table the broker installs for
+// agent skill provisioning.
+//
+// Routing policy:
+//
+//   - skill:// and bare names go to the Hub (the router's primary fallback).
+//   - gh:// is registered with RegisterFallback, not Register. That routes
+//     gh:// URIs through the Hub first, so the Hub's DB-backed cache absorbs
+//     repeated resolutions of the same skill and mints credentials centrally,
+//     while the local GitHub resolver stays wired as the backstop for Hub
+//     transport errors and per-URI failures.
+//   - gcp-skill:// goes straight to the GCP resolver; the Hub has no cache for
+//     it, so there is nothing to gain from routing it through the Hub.
+//
+// Extracted from provisioning so the routing policy — in particular the
+// Hub-first behaviour of gh:// — is assertable in isolation.
+func buildSkillRouter(hub, gh, gcp agent.SkillResolver) *agent.RoutingSkillResolver {
+	router := agent.NewRoutingSkillResolver(hub)
+	router.RegisterFallback("gh", gh)
+	router.Register("gcp-skill", gcp)
+	return router
+}

--- a/pkg/runtimebroker/skill_router_test.go
+++ b/pkg/runtimebroker/skill_router_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtimebroker
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/agent"
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+)
+
+// recordingResolver is a SkillResolver test double that records the refs it was
+// asked about and replays a canned outcome.
+type recordingResolver struct {
+	name     string
+	resolved []agent.ResolvedSkill
+	errors   []agent.ResolveError
+	hardErr  error
+
+	called []api.SkillReference
+}
+
+func (r *recordingResolver) ResolverName() string { return r.name }
+
+func (r *recordingResolver) Resolve(_ context.Context, refs []api.SkillReference, _ agent.ResolveOpts) (*agent.ResolveResult, error) {
+	r.called = append(r.called, refs...)
+	if r.hardErr != nil {
+		return nil, r.hardErr
+	}
+	return &agent.ResolveResult{Resolved: r.resolved, Errors: r.errors}, nil
+}
+
+const ghURI = "gh://owner/repo/skill"
+
+// TestBuildSkillRouter_GHRoutesToHubFirst pins the Phase 3 flip: gh:// URIs
+// must reach the Hub, not the local GitHub resolver, so the Hub's DB-backed
+// cache is what serves repeat resolutions. Reverting the wiring to
+// router.Register("gh", ...) fails this test.
+func TestBuildSkillRouter_GHRoutesToHubFirst(t *testing.T) {
+	hub := &recordingResolver{
+		name:     "hub",
+		resolved: []agent.ResolvedSkill{{Name: "gh-skill", URI: ghURI}},
+	}
+	gh := &recordingResolver{
+		name:     "github",
+		resolved: []agent.ResolvedSkill{{Name: "local-skill", URI: ghURI}},
+	}
+	gcp := &recordingResolver{name: "gcp"}
+
+	result, err := buildSkillRouter(hub, gh, gcp).Resolve(
+		context.Background(),
+		[]api.SkillReference{{URI: ghURI}},
+		agent.ResolveOpts{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(hub.called) != 1 {
+		t.Fatalf("hub received %d refs, want 1 — gh:// is not routed Hub-first", len(hub.called))
+	}
+	if hub.called[0].URI != ghURI {
+		t.Errorf("hub got URI %q, want %q", hub.called[0].URI, ghURI)
+	}
+	if len(gh.called) != 0 {
+		t.Errorf("local GitHub resolver was called %d time(s) despite Hub success; want 0", len(gh.called))
+	}
+	if len(result.Resolved) != 1 || result.Resolved[0].Name != "gh-skill" {
+		t.Errorf("result did not come from Hub: %+v", result.Resolved)
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("got %d errors, want 0: %+v", len(result.Errors), result.Errors)
+	}
+}
+
+// TestBuildSkillRouter_GHFallsBackOnHubPerURIError checks the backstop half of
+// the flip: a Hub that cannot resolve a particular gh:// URI must not fail the
+// request, because the local GitHub resolver is still wired behind it.
+func TestBuildSkillRouter_GHFallsBackOnHubPerURIError(t *testing.T) {
+	hub := &recordingResolver{
+		name: "hub",
+		errors: []agent.ResolveError{
+			{URI: ghURI, Code: "resolve_failed", Message: "hub could not resolve"},
+		},
+	}
+	gh := &recordingResolver{
+		name:     "github",
+		resolved: []agent.ResolvedSkill{{Name: "local-skill", URI: ghURI}},
+	}
+	gcp := &recordingResolver{name: "gcp"}
+
+	result, err := buildSkillRouter(hub, gh, gcp).Resolve(
+		context.Background(),
+		[]api.SkillReference{{URI: ghURI}},
+		agent.ResolveOpts{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(gh.called) != 1 {
+		t.Fatalf("local GitHub resolver received %d refs, want 1", len(gh.called))
+	}
+	if len(result.Resolved) != 1 || result.Resolved[0].Name != "local-skill" {
+		t.Fatalf("result did not come from the fallback: %+v", result.Resolved)
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("hub error should be superseded by the fallback, got %+v", result.Errors)
+	}
+}
+
+// TestBuildSkillRouter_GHFallsBackOnHubTransportError covers a Hub that is
+// entirely unreachable: gh:// provisioning must degrade to direct GitHub
+// resolution rather than failing outright.
+func TestBuildSkillRouter_GHFallsBackOnHubTransportError(t *testing.T) {
+	hub := &recordingResolver{name: "hub", hardErr: fmt.Errorf("connection refused")}
+	gh := &recordingResolver{
+		name:     "github",
+		resolved: []agent.ResolvedSkill{{Name: "local-skill", URI: ghURI}},
+	}
+	gcp := &recordingResolver{name: "gcp"}
+
+	result, err := buildSkillRouter(hub, gh, gcp).Resolve(
+		context.Background(),
+		[]api.SkillReference{{URI: ghURI}},
+		agent.ResolveOpts{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(gh.called) != 1 {
+		t.Fatalf("local GitHub resolver received %d refs, want 1", len(gh.called))
+	}
+	if len(result.Resolved) != 1 || result.Resolved[0].Name != "local-skill" {
+		t.Errorf("result did not come from the fallback: %+v", result.Resolved)
+	}
+}
+
+// TestBuildSkillRouter_OtherSchemes guards the schemes the flip must leave
+// alone: skill:// and bare names still go to the Hub, and gcp-skill:// still
+// bypasses the Hub entirely.
+func TestBuildSkillRouter_OtherSchemes(t *testing.T) {
+	tests := []struct {
+		name        string
+		uri         string
+		wantHub     int
+		wantGCP     int
+		resolvedURI string
+	}{
+		{name: "skill scheme goes to hub", uri: "skill://scion/core/s", wantHub: 1, resolvedURI: "skill://scion/core/s"},
+		{name: "bare name goes to hub", uri: "code-review", wantHub: 1, resolvedURI: "code-review"},
+		{name: "gcp-skill bypasses hub", uri: "gcp-skill://alias/ID", wantGCP: 1, resolvedURI: "gcp-skill://alias/ID"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hub := &recordingResolver{
+				name:     "hub",
+				resolved: []agent.ResolvedSkill{{Name: "s", URI: tt.resolvedURI}},
+			}
+			gh := &recordingResolver{name: "github"}
+			gcp := &recordingResolver{
+				name:     "gcp",
+				resolved: []agent.ResolvedSkill{{Name: "s", URI: tt.resolvedURI}},
+			}
+
+			if _, err := buildSkillRouter(hub, gh, gcp).Resolve(
+				context.Background(),
+				[]api.SkillReference{{URI: tt.uri}},
+				agent.ResolveOpts{},
+			); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(hub.called) != tt.wantHub {
+				t.Errorf("hub received %d refs, want %d", len(hub.called), tt.wantHub)
+			}
+			if len(gcp.called) != tt.wantGCP {
+				t.Errorf("gcp resolver received %d refs, want %d", len(gcp.called), tt.wantGCP)
+			}
+			if len(gh.called) != 0 {
+				t.Errorf("github resolver received %d refs, want 0", len(gh.called))
+			}
+		})
+	}
+}

--- a/pkg/runtimebroker/skill_router_test.go
+++ b/pkg/runtimebroker/skill_router_test.go
@@ -32,11 +32,17 @@ type recordingResolver struct {
 	hardErr  error
 
 	called []api.SkillReference
+	// calls counts Resolve invocations, which len(called) cannot distinguish
+	// from a single multi-ref call. Tests use it to prove the Hub was consulted
+	// at all — the assertion that actually fails if gh:// is reverted from
+	// RegisterFallback back to Register.
+	calls int
 }
 
 func (r *recordingResolver) ResolverName() string { return r.name }
 
 func (r *recordingResolver) Resolve(_ context.Context, refs []api.SkillReference, _ agent.ResolveOpts) (*agent.ResolveResult, error) {
+	r.calls++
 	r.called = append(r.called, refs...)
 	if r.hardErr != nil {
 		return nil, r.hardErr
@@ -70,6 +76,9 @@ func TestBuildSkillRouter_GHRoutesToHubFirst(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	if hub.calls != 1 {
+		t.Fatalf("hub was called %d time(s), want exactly 1 — gh:// is not routed Hub-first", hub.calls)
+	}
 	if len(hub.called) != 1 {
 		t.Fatalf("hub received %d refs, want 1 — gh:// is not routed Hub-first", len(hub.called))
 	}
@@ -112,6 +121,12 @@ func TestBuildSkillRouter_GHFallsBackOnHubPerURIError(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	// Without this the test passes even if gh:// is reverted to Register("gh",
+	// ghResolver): the local resolver would be called first and still return
+	// "local-skill". Asserting the Hub was tried is what makes it a flip guard.
+	if hub.calls != 1 {
+		t.Fatalf("hub was called %d time(s), want exactly 1 — gh:// must be tried Hub-first", hub.calls)
+	}
 	if len(gh.called) != 1 {
 		t.Fatalf("local GitHub resolver received %d refs, want 1", len(gh.called))
 	}
@@ -141,6 +156,11 @@ func TestBuildSkillRouter_GHFallsBackOnHubTransportError(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	// As above: proves the Hub was attempted before the local resolver, so a
+	// revert of the routing flip fails here rather than passing coincidentally.
+	if hub.calls != 1 {
+		t.Fatalf("hub was called %d time(s), want exactly 1 — gh:// must be tried Hub-first", hub.calls)
 	}
 	if len(gh.called) != 1 {
 		t.Fatalf("local GitHub resolver received %d refs, want 1", len(gh.called))
@@ -189,8 +209,17 @@ func TestBuildSkillRouter_OtherSchemes(t *testing.T) {
 			if len(hub.called) != tt.wantHub {
 				t.Errorf("hub received %d refs, want %d", len(hub.called), tt.wantHub)
 			}
+			// Each case sends a single ref, so the expected ref count doubles as
+			// the expected number of Resolve invocations: 1 for the Hub-routed
+			// schemes, 0 for the scheme that must bypass the Hub entirely.
+			if hub.calls != tt.wantHub {
+				t.Errorf("hub was called %d time(s), want %d", hub.calls, tt.wantHub)
+			}
 			if len(gcp.called) != tt.wantGCP {
 				t.Errorf("gcp resolver received %d refs, want %d", len(gcp.called), tt.wantGCP)
+			}
+			if gcp.calls != tt.wantGCP {
+				t.Errorf("gcp resolver was called %d time(s), want %d", gcp.calls, tt.wantGCP)
 			}
 			if len(gh.called) != 0 {
 				t.Errorf("github resolver received %d refs, want 0", len(gh.called))


### PR DESCRIPTION
## Summary
Activates hub-side caching for gh:// skill resolution: Register('gh') -> RegisterFallback('gh'), completing the cache-durability project (Track B). Depends on Phase 2b (already merged, #901) which fixed the defects this flip was held back for.

## Changes
1. I-4: fallbackContext() helper -- detaches a spent context with a 2m bound + 10s min-budget floor so Hub-side timeouts don't cascade into the broker fallback path; a healthy context is inherited as-is.
2. The flip itself: RegisterFallback('gh', ghResolver), buildSkillRouter extraction, broker routing tests, and a Hub cache integration test verifying 2 resolves collapse to 1 API call on a cache hit.
3. H-1: Hub declines ?token= URIs (per-credential-scoped requests bypass the shared hub-side cache, by design) -- routing test guards this.
4. Pre-merge polish: fallbackMinBudget floor, fixed assertion window, fixed a vacuous cache test.

## Quality gates
Code review: APPROVED (mutation-verified H-1 guard, fallbackContext, RegisterFallback flip). QA: PASS-WITH-NITS, all nits addressed in the final commit.

## Non-blocking follow-ups tracked
- Comment inaccuracy on fallbackTimeout (value is correct, comment is stale)
- Private repos reachable via App token but not broker GITHUB_TOKEN fail at install rather than resolve time -- future: named-credential hint in the 404
- buildSkillRouter could use struct params for transposition safety