### PR TITLE
fix(claude-harness): resolve model alias and set ANTHROPIC_MODEL in provision.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ downloads/
 
 # PR review artifacts
 pr-*-review*.md
+
+# Python bytecode (harness provisioner unit tests)
+__pycache__/
+*.pyc

--- a/harnesses/authoring-guide.md
+++ b/harnesses/authoring-guide.md
@@ -163,16 +163,27 @@ model_aliases:
   extra-large: gpt-5.5
 ```
 
-Templates reference abstract sizes; the alias resolves to a concrete model at
-provision time (available to your script via the manifest's
-`model_resolution`). Provide all four conventional aliases.
+Templates reference abstract sizes. Provide all four conventional aliases.
 
-Apply the model in `provision.py`: read `ctx.model_resolution["resolved_model"]`,
-fall back to the `SCION_MODEL` env var, resolve it against
-`ctx.harness_config["model_aliases"]` (a raw tier name can still reach the
-container), then write it to the tool's native settings file and/or the env
-overlay. Do **not** pin the tool's model env var in the `env` block below —
-see the precedence note there.
+Scion delivers the agent's model to the container in the `SCION_MODEL` env
+var — that is the only live channel. (`ctx.model_resolution` reads a manifest
+key that the Go side never writes; see changelog 2026-07-20. Don't build on
+it.) `SCION_MODEL` may still carry a raw tier name, so resolve it in
+`provision.py`:
+
+```python
+raw = os.environ.get("SCION_MODEL", "").strip()
+aliases = ctx.harness_config.get("model_aliases") or {}
+model = aliases.get(raw.lower(), raw) or "<your default>"
+```
+
+Mirror `config.NormalizeModelAlias` / `config.ResolveModelAlias`
+(`pkg/config/templates.go`) when you normalize: Scion also passes
+`--model <resolved>` on the CLI command line when the agent has a model
+configured, and a harness-side spelling the Go side does not accept would
+make the two disagree. Then write the result to the tool's native settings
+file or the env overlay. Do **not** pin the tool's model env var in the `env`
+block below — see the precedence note there.
 
 ### Environment
 
@@ -371,7 +382,9 @@ helpers), never from `os.environ`.
 `agent_name`, `agent_home`, `agent_workspace`, `harness_bundle_dir`,
 `harness_config` (your parsed config.yaml — read `instructions_file`,
 `system_prompt_mode`, etc. from here rather than hardcoding), `inputs` /
-`outputs` paths, `model_resolution`, and `platform`.
+`outputs` paths, and `platform`. (`ProvisionContext.model_resolution` reads a
+`model_resolution` key that `ProvisionManifest` does not emit — it is always
+empty; use `SCION_MODEL` instead.)
 
 ### What provision.py must do
 
@@ -443,7 +456,8 @@ Key API surface:
 - **`ProvisionContext`** — properties: `bundle_dir`, `inputs_dir`, `home`,
   `workspace`, `harness_config`, `candidates`, `explicit_type`, `env_keys`,
   `file_paths`, `env_secret_files`, `file_secret_files`, `telemetry`,
-  `model_resolution`. Methods: `read_secret(name)` / `read_file_secret(name)`
+  `model_resolution` (always empty — see above). Methods:
+  `read_secret(name)` / `read_file_secret(name)`
   (staged secret values, trailing newline stripped), `read_input_text(name)`,
   `select_auth(spec)`, `write_outputs(resolved, env=, extra=)`,
   `info()` / `warn()` (stderr).

--- a/harnesses/authoring-guide.md
+++ b/harnesses/authoring-guide.md
@@ -167,11 +167,25 @@ Templates reference abstract sizes; the alias resolves to a concrete model at
 provision time (available to your script via the manifest's
 `model_resolution`). Provide all four conventional aliases.
 
+Apply the model in `provision.py`: read `ctx.model_resolution["resolved_model"]`,
+fall back to the `SCION_MODEL` env var, resolve it against
+`ctx.harness_config["model_aliases"]` (a raw tier name can still reach the
+container), then write it to the tool's native settings file and/or the env
+overlay. Do **not** pin the tool's model env var in the `env` block below —
+see the precedence note there.
+
 ### Environment
 
 - `env`: static env vars set in the container.
 - `env_template`: values with placeholder expansion — `{{ .AgentName }}`,
   `{{ .AgentHome }}`, `{{ .UnixUsername }}` (only these three).
+
+Precedence: container env (`env`, `env_template`, template/CLI env) beats the
+`env.json` overlay your provisioner writes — the overlay only adds keys that
+are not already set, so a runtime value can never be masked by a harness
+script. That makes the `env` block the wrong place for anything the
+provisioner needs to compute at start time (the selected model, auth-mode
+dependent vars); put the default in `provision.py` instead.
 
 ### Interrupts
 

--- a/harnesses/claude/config.yaml
+++ b/harnesses/claude/config.yaml
@@ -53,6 +53,8 @@ env:
   # it resolves SCION_MODEL through model_aliases above and falls back to
   # "opus" when no model is requested. Setting ANTHROPIC_MODEL here (or in a
   # template's env block) still works as an explicit, non-overridable pin.
+  # Consequence: ANTHROPIC_MODEL now reaches the supervised harness process
+  # (and what it spawns) rather than every process in the container.
   ANTHROPIC_DEFAULT_HAIKU_MODEL: "haiku-4-5"
 command:
   base: ["claude", "--no-chrome", "--dangerously-skip-permissions"]

--- a/harnesses/claude/config.yaml
+++ b/harnesses/claude/config.yaml
@@ -46,7 +46,13 @@ model_aliases:
   large: opus
   extra-large: fable
 env:
-  ANTHROPIC_MODEL: "opus"
+  # ANTHROPIC_MODEL is intentionally NOT set here. Entries in this block land
+  # in the container environment, and the container environment always wins
+  # over the provisioner's env overlay, which made the agent's requested model
+  # (SCION_MODEL) impossible to apply. provision.py now owns ANTHROPIC_MODEL:
+  # it resolves SCION_MODEL through model_aliases above and falls back to
+  # "opus" when no model is requested. Setting ANTHROPIC_MODEL here (or in a
+  # template's env block) still works as an explicit, non-overridable pin.
   ANTHROPIC_DEFAULT_HAIKU_MODEL: "haiku-4-5"
 command:
   base: ["claude", "--no-chrome", "--dangerously-skip-permissions"]

--- a/harnesses/claude/provision.py
+++ b/harnesses/claude/provision.py
@@ -37,9 +37,9 @@ This script's job:
   3. Update .claude.json project paths to point at the container workspace.
   4. Translate universal MCP servers into Claude Code's native mcpServers
      format in .claude.json.
-  5. Resolve the requested model (SCION_MODEL / manifest model_resolution),
-     mapping size aliases (small/medium/large/extra-large) through config.yaml's
-     model_aliases, and apply it via ANTHROPIC_MODEL plus ~/.claude/settings.json.
+  5. Resolve the requested model (the SCION_MODEL env var), mapping size
+     aliases (small/medium/large/extra-large) through config.yaml's
+     model_aliases, and publish it as ANTHROPIC_MODEL in the env overlay.
   6. Write outputs/resolved-auth.json describing the chosen method.
   7. Write outputs/env.json with env vars to project into the harness process
      (e.g. ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_MODEL, or
@@ -69,7 +69,6 @@ assert scion_harness.INTERFACE_VERSION >= 2, (
 
 CLAUDE_JSON_FILE = "~/.claude.json"
 CLAUDE_AUTH_FILE = "~/.claude/.credentials.json"
-CLAUDE_SETTINGS_FILE = "~/.claude/settings.json"
 
 # Model used when the agent config does not request one. This preserves the
 # historical default that used to live in config.yaml's env block
@@ -79,15 +78,20 @@ CLAUDE_SETTINGS_FILE = "~/.claude/settings.json"
 # requested model impossible to apply.
 DEFAULT_MODEL = "opus"
 
-# Single-letter / shorthand spellings accepted for the size aliases declared
-# in config.yaml's model_aliases map.
+# The canonical size aliases, mirroring config.KnownModelAliases
+# (pkg/config/templates.go). Only these four resolve through config.yaml's
+# model_aliases map; anything else is treated as a concrete model name.
+KNOWN_MODEL_ALIASES = frozenset({"small", "medium", "large", "extra-large"})
+
+# Shorthand spellings for those aliases, mirroring config.NormalizeModelAlias
+# (pkg/config/templates.go). Deliberately no extra spellings: a form accepted
+# here but not there would make ANTHROPIC_MODEL disagree with the --model flag
+# the Go side computes from the same request.
 MODEL_ALIAS_SHORTHAND = {
     "s": "small",
     "m": "medium",
     "l": "large",
     "xl": "extra-large",
-    "extra_large": "extra-large",
-    "xlarge": "extra-large",
 }
 
 AUTH = scion_harness.AuthSpec(
@@ -236,95 +240,78 @@ def _update_project_paths(ctx: scion_harness.ProvisionContext) -> None:
     scion_harness.atomic_write_json(claude_json_path, cfg)
 
 
-def _requested_model(ctx: scion_harness.ProvisionContext) -> str:
-    """Return the model requested for this agent, before alias resolution.
+def _normalize_model_alias(model: str) -> str:
+    """Lower-case a model string and expand the single-letter shorthands.
 
-    Prefers the manifest's model_resolution block and falls back to the
-    SCION_MODEL env var that Scion injects into every agent container.
+    Mirrors config.NormalizeModelAlias (pkg/config/templates.go) exactly so the
+    model this script derives cannot disagree with the one the Go side derives
+    for --model / SCION_MODEL. Keep the two in sync.
     """
-    model = str(ctx.model_resolution.get("resolved_model") or "").strip()
-    if model:
-        return model
-    return os.environ.get("SCION_MODEL", "").strip()
+    normalized = model.strip().lower()
+    return MODEL_ALIAS_SHORTHAND.get(normalized, normalized)
 
 
 def _resolve_model_alias(ctx: scion_harness.ProvisionContext, raw_model: str) -> str:
     """Resolve a size alias (e.g. 'medium') to a concrete Claude model name.
 
-    The mapping comes from config.yaml's model_aliases block, so operators can
-    re-point the tiers without touching this script. A value that is not a
-    known alias (e.g. 'sonnet' or 'claude-sonnet-4-5') is returned unchanged.
+    Mirrors config.ResolveModelAlias (pkg/config/templates.go): only the four
+    canonical tiers are treated as aliases, and the concrete name they map to
+    comes from config.yaml's model_aliases block so operators can re-point the
+    tiers without touching this script. Anything else (e.g. 'sonnet' or
+    'claude-sonnet-4-5') is a concrete model name and passes through.
     """
     if not raw_model:
         return ""
 
-    aliases = ctx.harness_config.get("model_aliases") or {}
-    if not isinstance(aliases, dict) or not aliases:
-        return raw_model
+    normalized = _normalize_model_alias(raw_model)
+    if normalized not in KNOWN_MODEL_ALIASES:
+        return normalized
 
-    normalized = raw_model.strip().lower()
-    normalized = MODEL_ALIAS_SHORTHAND.get(normalized, normalized)
+    aliases = ctx.harness_config.get("model_aliases") or {}
+    if not isinstance(aliases, dict):
+        return normalized
 
     concrete = aliases.get(normalized)
-    if not concrete or concrete == raw_model:
-        return raw_model
+    if not concrete:
+        return normalized
 
-    ctx.info(f"resolved model alias {raw_model!r} → {concrete!r}")
+    if str(concrete) != raw_model:
+        ctx.info(f"resolved model alias {raw_model!r} → {concrete!r}")
     return str(concrete)
 
 
-def _apply_model_setting(ctx: scion_harness.ProvisionContext, model: str) -> None:
-    """Write the resolved model into ~/.claude/settings.json.
-
-    ANTHROPIC_MODEL (set via the env overlay) outranks this setting for the
-    supervised session, but the settings file also covers sessions launched by
-    hand inside the container (e.g. the drop-to-shell flow), where the overlay
-    is not applied.
-    """
-    if not model:
-        return
-
-    settings_path = scion_harness.expand_path(CLAUDE_SETTINGS_FILE)
-    settings: dict[str, Any] = {}
-    if os.path.isfile(settings_path):
-        try:
-            settings = scion_harness.load_json(settings_path) or {}
-        except (OSError, json.JSONDecodeError):
-            settings = {}
-    if not isinstance(settings, dict):
-        settings = {}
-
-    if settings.get("model") == model:
-        return
-
-    settings["model"] = model
-    scion_harness.atomic_write_json(settings_path, settings)
-
-
 def _apply_model(ctx: scion_harness.ProvisionContext, env: dict[str, str]) -> str:
-    """Resolve the requested model and project it into env + settings.json.
+    """Resolve the requested model and publish it as ANTHROPIC_MODEL.
+
+    The request arrives as the SCION_MODEL env var, which Scion injects into
+    every agent container from the agent's applied config. (The manifest has no
+    model_resolution field — see changelog 2026-07-20 — so SCION_MODEL is the
+    only live channel, and it can still carry a raw tier name: an agent started
+    with `--model medium` reaches the container as SCION_MODEL=medium.)
+
+    Where this sits in Claude Code's precedence chain
+    (--model > ANTHROPIC_MODEL > settings.json `model`): when the agent has a
+    model configured, pkg/agent/run.go also prepends `--model <resolved>` to
+    the CLI args, and that outranks ANTHROPIC_MODEL. ANTHROPIC_MODEL is what
+    covers the rest — the default when nothing is requested, subprocesses the
+    harness spawns, and any consumer reading the env var directly — and this
+    keeps it agreeing with the flag instead of contradicting it.
 
     Returns the concrete model name that was applied.
     """
-    requested = _requested_model(ctx)
+    requested = os.environ.get("SCION_MODEL", "").strip()
     model = _resolve_model_alias(ctx, requested) or DEFAULT_MODEL
 
     preset = os.environ.get("ANTHROPIC_MODEL", "").strip()
     if requested and preset and preset != model:
         ctx.warn(
-            f"ANTHROPIC_MODEL is already set to {preset!r} in the container "
-            f"environment and takes precedence over the requested model "
-            f"{model!r}; unset it (or re-run `scion harness-config update claude` "
-            "if it comes from a stale harness-config) to use the requested model"
+            f"ANTHROPIC_MODEL={preset!r} is set in the container environment and "
+            f"takes precedence over the requested model {model!r}. This usually "
+            "comes from an `env:` entry in your template or harness-config; "
+            "remove it there to let the agent's model setting apply."
         )
 
     env["ANTHROPIC_MODEL"] = model
-
-    try:
-        _apply_model_setting(ctx, model)
-    except OSError as exc:
-        ctx.warn(f"failed to write model setting: {exc}")
-
     return model
 
 

--- a/harnesses/claude/provision.py
+++ b/harnesses/claude/provision.py
@@ -37,9 +37,13 @@ This script's job:
   3. Update .claude.json project paths to point at the container workspace.
   4. Translate universal MCP servers into Claude Code's native mcpServers
      format in .claude.json.
-  5. Write outputs/resolved-auth.json describing the chosen method.
-  6. Write outputs/env.json with env vars to project into the harness process
-     (e.g. ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or Vertex AI vars).
+  5. Resolve the requested model (SCION_MODEL / manifest model_resolution),
+     mapping size aliases (small/medium/large/extra-large) through config.yaml's
+     model_aliases, and apply it via ANTHROPIC_MODEL plus ~/.claude/settings.json.
+  6. Write outputs/resolved-auth.json describing the chosen method.
+  7. Write outputs/env.json with env vars to project into the harness process
+     (e.g. ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_MODEL, or
+     Vertex AI vars).
 
 The script is intentionally stdlib-only so it works on any container image
 that ships python3 (declared in config.yaml's required_image_tools).
@@ -65,6 +69,26 @@ assert scion_harness.INTERFACE_VERSION >= 2, (
 
 CLAUDE_JSON_FILE = "~/.claude.json"
 CLAUDE_AUTH_FILE = "~/.claude/.credentials.json"
+CLAUDE_SETTINGS_FILE = "~/.claude/settings.json"
+
+# Model used when the agent config does not request one. This preserves the
+# historical default that used to live in config.yaml's env block
+# (ANTHROPIC_MODEL: "opus"); it now lives here because a static env entry in
+# config.yaml lands in the container environment, and the container
+# environment always wins over the provisioner's env overlay — which made the
+# requested model impossible to apply.
+DEFAULT_MODEL = "opus"
+
+# Single-letter / shorthand spellings accepted for the size aliases declared
+# in config.yaml's model_aliases map.
+MODEL_ALIAS_SHORTHAND = {
+    "s": "small",
+    "m": "medium",
+    "l": "large",
+    "xl": "extra-large",
+    "extra_large": "extra-large",
+    "xlarge": "extra-large",
+}
 
 AUTH = scion_harness.AuthSpec(
     harness="claude",
@@ -212,6 +236,98 @@ def _update_project_paths(ctx: scion_harness.ProvisionContext) -> None:
     scion_harness.atomic_write_json(claude_json_path, cfg)
 
 
+def _requested_model(ctx: scion_harness.ProvisionContext) -> str:
+    """Return the model requested for this agent, before alias resolution.
+
+    Prefers the manifest's model_resolution block and falls back to the
+    SCION_MODEL env var that Scion injects into every agent container.
+    """
+    model = str(ctx.model_resolution.get("resolved_model") or "").strip()
+    if model:
+        return model
+    return os.environ.get("SCION_MODEL", "").strip()
+
+
+def _resolve_model_alias(ctx: scion_harness.ProvisionContext, raw_model: str) -> str:
+    """Resolve a size alias (e.g. 'medium') to a concrete Claude model name.
+
+    The mapping comes from config.yaml's model_aliases block, so operators can
+    re-point the tiers without touching this script. A value that is not a
+    known alias (e.g. 'sonnet' or 'claude-sonnet-4-5') is returned unchanged.
+    """
+    if not raw_model:
+        return ""
+
+    aliases = ctx.harness_config.get("model_aliases") or {}
+    if not isinstance(aliases, dict) or not aliases:
+        return raw_model
+
+    normalized = raw_model.strip().lower()
+    normalized = MODEL_ALIAS_SHORTHAND.get(normalized, normalized)
+
+    concrete = aliases.get(normalized)
+    if not concrete or concrete == raw_model:
+        return raw_model
+
+    ctx.info(f"resolved model alias {raw_model!r} → {concrete!r}")
+    return str(concrete)
+
+
+def _apply_model_setting(ctx: scion_harness.ProvisionContext, model: str) -> None:
+    """Write the resolved model into ~/.claude/settings.json.
+
+    ANTHROPIC_MODEL (set via the env overlay) outranks this setting for the
+    supervised session, but the settings file also covers sessions launched by
+    hand inside the container (e.g. the drop-to-shell flow), where the overlay
+    is not applied.
+    """
+    if not model:
+        return
+
+    settings_path = scion_harness.expand_path(CLAUDE_SETTINGS_FILE)
+    settings: dict[str, Any] = {}
+    if os.path.isfile(settings_path):
+        try:
+            settings = scion_harness.load_json(settings_path) or {}
+        except (OSError, json.JSONDecodeError):
+            settings = {}
+    if not isinstance(settings, dict):
+        settings = {}
+
+    if settings.get("model") == model:
+        return
+
+    settings["model"] = model
+    scion_harness.atomic_write_json(settings_path, settings)
+
+
+def _apply_model(ctx: scion_harness.ProvisionContext, env: dict[str, str]) -> str:
+    """Resolve the requested model and project it into env + settings.json.
+
+    Returns the concrete model name that was applied.
+    """
+    requested = _requested_model(ctx)
+    model = _resolve_model_alias(ctx, requested) or DEFAULT_MODEL
+
+    preset = os.environ.get("ANTHROPIC_MODEL", "").strip()
+    if requested and preset and preset != model:
+        ctx.warn(
+            f"ANTHROPIC_MODEL is already set to {preset!r} in the container "
+            f"environment and takes precedence over the requested model "
+            f"{model!r}; unset it (or re-run `scion harness-config update claude` "
+            "if it comes from a stale harness-config) to use the requested model"
+        )
+
+    env["ANTHROPIC_MODEL"] = model
+
+    try:
+        _apply_model_setting(ctx, model)
+    except OSError as exc:
+        ctx.warn(f"failed to write model setting: {exc}")
+
+    return model
+
+
 def _build_env_overlay(ctx: scion_harness.ProvisionContext, auth: scion_harness.ResolvedAuth) -> dict[str, str]:
     """Build the env vars overlay for outputs/env.json."""
     if auth.method == "api-key" and auth.env_key:
@@ -245,10 +361,12 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
                 ctx.warn(f"failed to write API key approval: {exc}")
 
     env = _build_env_overlay(ctx, auth)
+    model = _apply_model(ctx, env)
     extra: dict[str, Any] | None = None
     if auth.method == "vertex-ai":
         extra = {"vertex_ai": True}
     ctx.write_outputs(auth, env=env, extra=extra)
+    ctx.info(f"method={auth.method} model={model}")
 
     mcp_mapping = dict(CLAUDE_MCP_MAPPING)
     mcp_mapping["project_config_path"] = f"projects.{ctx.workspace}.mcpServers"

--- a/harnesses/claude/provision_test.py
+++ b/harnesses/claude/provision_test.py
@@ -75,7 +75,7 @@ def env_vars(**values: str | None):
                 os.environ[key] = val
 
 
-def make_ctx(home: str, *, model_resolution: dict | None = None):
+def make_ctx(home: str):
     manifest = {
         "harness_bundle_dir": os.path.join(home, ".scion", "harness"),
         "harness_config": {
@@ -83,8 +83,6 @@ def make_ctx(home: str, *, model_resolution: dict | None = None):
             "instructions_file": ".claude/CLAUDE.md",
         },
     }
-    if model_resolution is not None:
-        manifest["model_resolution"] = model_resolution
     return scion_harness.ProvisionContext("claude", manifest)
 
 
@@ -105,12 +103,59 @@ class ModelResolutionTest(unittest.TestCase):
             "L": "opus",
             "XL": "fable",
             "SMALL": "haiku",
+            "extra-large": "fable",
         }
         for raw, want in cases.items():
             with self.subTest(raw=raw):
                 with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
                     ctx = make_ctx(tmp)
                     self.assertEqual(provision._resolve_model_alias(ctx, raw), want)
+
+    def test_shorthand_set_matches_go_normalize_model_alias(self) -> None:
+        """Python must not accept spellings the Go --model path rejects.
+
+        config.NormalizeModelAlias (pkg/config/templates.go) handles only
+        s/m/l/xl plus lower-casing, and config.ResolveModelAlias gates the
+        map lookup on config.KnownModelAliases. A spelling accepted only here
+        would make ANTHROPIC_MODEL disagree with the higher-precedence
+        --model flag.
+        """
+        self.assertEqual(
+            provision.MODEL_ALIAS_SHORTHAND,
+            {"s": "small", "m": "medium", "l": "large", "xl": "extra-large"},
+        )
+        self.assertEqual(
+            provision.KNOWN_MODEL_ALIASES,
+            frozenset({"small", "medium", "large", "extra-large"}),
+        )
+
+        with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
+            ctx = make_ctx(tmp)
+            # Spellings Go does not normalize stay concrete (lower-cased),
+            # exactly as `config.ResolveModelAlias` would leave them.
+            for raw in ("xlarge", "extra_large"):
+                with self.subTest(raw=raw):
+                    self.assertEqual(provision._resolve_model_alias(ctx, raw), raw)
+
+    def test_unmapped_alias_falls_back_to_the_tier_name(self) -> None:
+        """Matches config.ResolveModelAlias: unmapped alias passes through."""
+        with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
+            manifest = {
+                "harness_bundle_dir": os.path.join(tmp, ".scion", "harness"),
+                "harness_config": {"model_aliases": {"small": "haiku"}},
+            }
+            ctx = scion_harness.ProvisionContext("claude", manifest)
+            self.assertEqual(provision._resolve_model_alias(ctx, "large"), "large")
+
+    def test_custom_non_tier_alias_keys_are_ignored(self) -> None:
+        """Only the four canonical tiers resolve, as on the Go side."""
+        with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
+            manifest = {
+                "harness_bundle_dir": os.path.join(tmp, ".scion", "harness"),
+                "harness_config": {"model_aliases": {"fast": "haiku"}},
+            }
+            ctx = scion_harness.ProvisionContext("claude", manifest)
+            self.assertEqual(provision._resolve_model_alias(ctx, "fast"), "fast")
 
     def test_concrete_model_passes_through_unchanged(self) -> None:
         with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
@@ -122,15 +167,6 @@ class ModelResolutionTest(unittest.TestCase):
         self.assertEqual(model, "claude-sonnet-4-5")
         self.assertEqual(env["ANTHROPIC_MODEL"], "claude-sonnet-4-5")
 
-    def test_manifest_model_resolution_wins_over_scion_model_env(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
-            ctx = make_ctx(tmp, model_resolution={"resolved_model": "haiku"})
-            with env_vars(SCION_MODEL="large", ANTHROPIC_MODEL=None):
-                env: dict[str, str] = {}
-                model = provision._apply_model(ctx, env)
-
-        self.assertEqual(model, "haiku")
-
     def test_no_requested_model_falls_back_to_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
             ctx = make_ctx(tmp)
@@ -141,23 +177,38 @@ class ModelResolutionTest(unittest.TestCase):
         self.assertEqual(model, provision.DEFAULT_MODEL)
         self.assertEqual(env["ANTHROPIC_MODEL"], provision.DEFAULT_MODEL)
 
-    def test_resolved_model_written_to_claude_settings(self) -> None:
+    def test_claude_settings_json_is_left_untouched(self) -> None:
+        """The provisioner must not rewrite the file that holds the deny list.
+
+        ~/.claude/settings.json carries the agent's permissions.deny list,
+        the disable* flags and the sciontool hooks. Model selection goes
+        through ANTHROPIC_MODEL, which outranks the settings `model` key
+        anyway, so there is no reason for this script to touch the file.
+        """
+        seed = os.path.join(
+            os.path.dirname(__file__), "home", ".claude", "settings.json"
+        )
+        with open(seed, "rb") as f:
+            original = f.read()
+
         with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
             settings_path = os.path.join(tmp, ".claude", "settings.json")
             os.makedirs(os.path.dirname(settings_path))
-            with open(settings_path, "w", encoding="utf-8") as f:
-                json.dump({"includeCoAuthoredBy": False}, f)
+            with open(settings_path, "wb") as f:
+                f.write(original)
 
             ctx = make_ctx(tmp)
             with env_vars(SCION_MODEL="medium", ANTHROPIC_MODEL=None):
                 provision._apply_model(ctx, {})
 
-            with open(settings_path, "r", encoding="utf-8") as f:
-                settings = json.load(f)
+            with open(settings_path, "rb") as f:
+                after = f.read()
 
-        self.assertEqual(settings["model"], "sonnet")
-        # Existing keys are preserved.
-        self.assertIs(settings["includeCoAuthoredBy"], False)
+        self.assertEqual(after, original)
+        # Sanity-check the fixture really is the containment-bearing file.
+        settings = json.loads(original)
+        self.assertIn("EnterPlanMode", settings["permissions"]["deny"])
+        self.assertIs(settings["disableBundledSkills"], True)
 
     def test_preset_anthropic_model_is_reported_but_not_overwritten(self) -> None:
         """A container env ANTHROPIC_MODEL outranks the overlay — warn about it."""

--- a/harnesses/claude/provision_test.py
+++ b/harnesses/claude/provision_test.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the Claude harness provisioner.
+
+Run with:  python3 -m unittest provision_test -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from contextlib import contextmanager
+
+PROVISION_PATH = os.path.join(os.path.dirname(__file__), "provision.py")
+SPEC = importlib.util.spec_from_file_location("claude_provision", PROVISION_PATH)
+assert SPEC is not None
+provision = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(provision)
+
+scion_harness = provision.scion_harness
+
+MODEL_ALIASES = {
+    "small": "haiku",
+    "medium": "sonnet",
+    "large": "opus",
+    "extra-large": "fable",
+}
+
+
+@contextmanager
+def temporary_home(path: str):
+    old_home = os.environ.get("HOME")
+    os.environ["HOME"] = path
+    try:
+        yield
+    finally:
+        if old_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = old_home
+
+
+@contextmanager
+def env_vars(**values: str | None):
+    """Temporarily set (or unset, with None) environment variables."""
+    previous = {k: os.environ.get(k) for k in values}
+    for key, val in values.items():
+        if val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = val
+    try:
+        yield
+    finally:
+        for key, val in previous.items():
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+
+def make_ctx(home: str, *, model_resolution: dict | None = None):
+    manifest = {
+        "harness_bundle_dir": os.path.join(home, ".scion", "harness"),
+        "harness_config": {
+            "model_aliases": dict(MODEL_ALIASES),
+            "instructions_file": ".claude/CLAUDE.md",
+        },
+    }
+    if model_resolution is not None:
+        manifest["model_resolution"] = model_resolution
+    return scion_harness.ProvisionContext("claude", manifest)
+
+
+class ModelResolutionTest(unittest.TestCase):
+    def test_size_alias_resolves_through_config_model_aliases(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
+            ctx = make_ctx(tmp)
+            with env_vars(SCION_MODEL="medium", ANTHROPIC_MODEL=None):
+                env: dict[str, str] = {}
+                model = provision._apply_model(ctx, env)
+
+        self.assertEqual(model, "sonnet")
+        self.assertEqual(env["ANTHROPIC_MODEL"], "sonnet")
+
+    def test_alias_matching_is_case_insensitive_and_accepts_shorthand(self) -> None:
+        cases = {
+            "Medium": "sonnet",
+            "L": "opus",
+            "XL": "fable",
+            "SMALL": "haiku",
+        }
+        for raw, want in cases.items():
+            with self.subTest(raw=raw):
+                with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
+                    ctx = make_ctx(tmp)
+                    self.assertEqual(provision._resolve_model_alias(ctx, raw), want)
+
+    def test_concrete_model_passes_through_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
+            ctx = make_ctx(tmp)
+            with env_vars(SCION_MODEL="claude-sonnet-4-5", ANTHROPIC_MODEL=None):
+                env: dict[str, str] = {}
+                model = provision._apply_model(ctx, env)
+
+        self.assertEqual(model, "claude-sonnet-4-5")
+        self.assertEqual(env["ANTHROPIC_MODEL"], "claude-sonnet-4-5")
+
+    def test_manifest_model_resolution_wins_over_scion_model_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
+            ctx = make_ctx(tmp, model_resolution={"resolved_model": "haiku"})
+            with env_vars(SCION_MODEL="large", ANTHROPIC_MODEL=None):
+                env: dict[str, str] = {}
+                model = provision._apply_model(ctx, env)
+
+        self.assertEqual(model, "haiku")
+
+    def test_no_requested_model_falls_back_to_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
+            ctx = make_ctx(tmp)
+            with env_vars(SCION_MODEL=None, ANTHROPIC_MODEL=None):
+                env: dict[str, str] = {}
+                model = provision._apply_model(ctx, env)
+
+        self.assertEqual(model, provision.DEFAULT_MODEL)
+        self.assertEqual(env["ANTHROPIC_MODEL"], provision.DEFAULT_MODEL)
+
+    def test_resolved_model_written_to_claude_settings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
+            settings_path = os.path.join(tmp, ".claude", "settings.json")
+            os.makedirs(os.path.dirname(settings_path))
+            with open(settings_path, "w", encoding="utf-8") as f:
+                json.dump({"includeCoAuthoredBy": False}, f)
+
+            ctx = make_ctx(tmp)
+            with env_vars(SCION_MODEL="medium", ANTHROPIC_MODEL=None):
+                provision._apply_model(ctx, {})
+
+            with open(settings_path, "r", encoding="utf-8") as f:
+                settings = json.load(f)
+
+        self.assertEqual(settings["model"], "sonnet")
+        # Existing keys are preserved.
+        self.assertIs(settings["includeCoAuthoredBy"], False)
+
+    def test_preset_anthropic_model_is_reported_but_not_overwritten(self) -> None:
+        """A container env ANTHROPIC_MODEL outranks the overlay — warn about it."""
+        warnings: list[str] = []
+        with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
+            ctx = make_ctx(tmp)
+            ctx.warn = warnings.append  # type: ignore[method-assign]
+            with env_vars(SCION_MODEL="medium", ANTHROPIC_MODEL="opus"):
+                env: dict[str, str] = {}
+                model = provision._apply_model(ctx, env)
+
+        self.assertEqual(model, "sonnet")
+        self.assertEqual(env["ANTHROPIC_MODEL"], "sonnet")
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("ANTHROPIC_MODEL", warnings[0])
+
+    def test_no_warning_when_preset_matches_resolved_model(self) -> None:
+        warnings: list[str] = []
+        with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
+            ctx = make_ctx(tmp)
+            ctx.warn = warnings.append  # type: ignore[method-assign]
+            with env_vars(SCION_MODEL="medium", ANTHROPIC_MODEL="sonnet"):
+                provision._apply_model(ctx, {})
+
+        self.assertEqual(warnings, [])
+
+    def test_no_warning_when_no_model_requested(self) -> None:
+        """An operator-set ANTHROPIC_MODEL with no requested model is intentional."""
+        warnings: list[str] = []
+        with tempfile.TemporaryDirectory() as tmp, temporary_home(tmp):
+            ctx = make_ctx(tmp)
+            ctx.warn = warnings.append  # type: ignore[method-assign]
+            with env_vars(SCION_MODEL=None, ANTHROPIC_MODEL="claude-opus-4-6"):
+                provision._apply_model(ctx, {})
+
+        self.assertEqual(warnings, [])
+
+
+class ConfigYamlTest(unittest.TestCase):
+    def test_config_yaml_does_not_pin_anthropic_model(self) -> None:
+        """config.yaml env entries land in the container env and would win.
+
+        Keeping ANTHROPIC_MODEL out of that block is what lets provision.py's
+        env overlay apply the agent's requested model.
+        """
+        config_path = os.path.join(os.path.dirname(__file__), "config.yaml")
+        with open(config_path, "r", encoding="utf-8") as f:
+            lines = [line.rstrip("\n") for line in f]
+
+        in_env = False
+        env_keys: list[str] = []
+        for line in lines:
+            if line.startswith("env:"):
+                in_env = True
+                continue
+            if in_env:
+                if not line.startswith((" ", "\t")):
+                    break
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                env_keys.append(stripped.split(":", 1)[0].strip())
+
+        self.assertIn("ANTHROPIC_DEFAULT_HAIKU_MODEL", env_keys)
+        self.assertNotIn("ANTHROPIC_MODEL", env_keys)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
When model is set to an alias (e.g. "medium"), the claude harness received the raw alias via SCION_MODEL but never resolved it or set ANTHROPIC_MODEL, so the container defaulted to Opus regardless of the requested model.

## Root cause (two parts)
1. config.yaml had a static ANTHROPIC_MODEL=opus pin in the env block
2. provision.py never read SCION_MODEL or resolved model aliases

## Fix
- Removed static ANTHROPIC_MODEL pin from config.yaml
- provision.py resolves SCION_MODEL through model_aliases (s/m/l/xl aligned to Go)
- Emits ANTHROPIC_MODEL in supervised-process overlay
- Removed dead ctx.model_resolution code
- 12 tests, no Go files touched

## Note
ANTHROPIC_MODEL scope: supervised process only, not container-wide