### PR TITLE
docs+observability: clarify gh:// cache layer routing, add broker content-cache hit/miss logging

### DIFF
--- a/.design/ps-cache-durability.md
+++ b/.design/ps-cache-durability.md
@@ -59,6 +59,29 @@ Understanding what each cache does is essential — the investigator's findings 
 
 **What Track B needs to cache:** Only the resolution metadata (commitSHA, file list, URLs, bundle hash) — less than 1 KB per skill. File delivery to containers is unchanged.
 
+### Which Layer Serves Which Path
+
+Stress testing (2026-07-29, build `b03a09ac`) confirmed that of the three documented layers, only
+the Hub DB layer (layer 3) populates during normal `developer`-template provisioning. This is
+by design — each layer is gated by a different trigger:
+
+| Layer | Cache | Serves which path | When it populates |
+|---|---|---|---|
+| 1 | Broker disk — resolution cache (`github-resolution-cache.json`) | `?token=SECRET_NAME` URIs only — broker-local resolution, not Hub-mediated | Only when broker resolves a `gh://` URI that carries a named `?token=` query parameter referencing a broker-known secret. The common public/App-token path resolves Hub-side and never touches this layer. |
+| 2 | Broker disk — content cache (`cache/skills/`) | All paths — but only during workspace materialisation | Populated when an agent actually **starts** and its workspace is materialized (file bytes downloaded). `scion create` (provision-only, no task) resolves the ref and file list but does not download bytes, so this layer stays empty on provision-only runs. |
+| 3 | Hub DB — resolution cache (`github_resolution_cache` table) | Public repos + GitHub App installation token path (Hub-mediated) | Populated on any `gh://` resolution routed through the Hub, including cold provisioning. This is the common path for the `developer` template and all public/App-token skills. |
+
+**Implication for validation:** Provision-only agents (`scion create`, no task) exercise only
+layer 3. Layers 1 and 2 require different triggers:
+
+- To exercise layer 1: use a `gh://` skill URI with a `?token=SECRET_NAME` query parameter
+  naming a broker secret.
+- To exercise layer 2: start an agent (not just provision), so that workspace materialization
+  actually downloads skill file bytes.
+
+Any runbook that says "clear all three, provision agents, confirm all three fill" is incorrect
+for layers 1 and 2 and will produce false "cache not populating" alarms.
+
 ---
 
 ## Proposed Design

--- a/.design/ps-cache-durability.md
+++ b/.design/ps-cache-durability.md
@@ -67,7 +67,7 @@ by design — each layer is gated by a different trigger:
 
 | Layer | Cache | Serves which path | When it populates |
 |---|---|---|---|
-| 1 | Broker disk — resolution cache (`github-resolution-cache.json`) | `?token=SECRET_NAME` URIs only — broker-local resolution, not Hub-mediated | Only when broker resolves a `gh://` URI that carries a named `?token=` query parameter referencing a broker-known secret. The common public/App-token path resolves Hub-side and never touches this layer. |
+| 1 | Broker disk — resolution cache (`github-resolution-cache.json`) | `?token=SECRET_NAME` URIs only — broker-local resolution, not Hub-mediated | Only when broker resolves a `gh://` URI that carries a named `?token=` query parameter referencing a broker-known secret. The common public/App-token path resolves Hub-side and never touches this layer. **Note:** credential-bearing entries (those with a token-hash suffix in the cache key) are intentionally kept in-memory only and never written to disk — see [#565 fix](#layer-1-stale-404-fix) below. |
 | 2 | Broker disk — content cache (`cache/skills/`) | All paths — but only during workspace materialisation | Populated when an agent actually **starts** and its workspace is materialized (file bytes downloaded). `scion create` (provision-only, no task) resolves the ref and file list but does not download bytes, so this layer stays empty on provision-only runs. |
 | 3 | Hub DB — resolution cache (`github_resolution_cache` table) | Public repos + GitHub App installation token path (Hub-mediated) | Populated on any `gh://` resolution routed through the Hub, including cold provisioning. This is the common path for the `developer` template and all public/App-token skills. |
 
@@ -81,6 +81,25 @@ layer 3. Layers 1 and 2 require different triggers:
 
 Any runbook that says "clear all three, provision agents, confirm all three fill" is incorrect
 for layers 1 and 2 and will produce false "cache not populating" alarms.
+
+### Layer 1 Stale-404 Fix {#layer-1-stale-404-fix}
+
+Issue #565 identified that the broker disk resolution cache caused 404s on private-repo skills
+after broker restart. Root cause: `ResolvedFile.Content` is tagged `json:"-"` and is stripped
+during serialisation. After restart, a disk cache hit returns entries with `Content == nil`,
+causing `installOneSkill` to fall through to `downloadSkillFile`. For `?token=` private-repo
+skills, that download uses the broker's default GitHub token (not the named per-URI credential),
+so it 404s on private repos.
+
+**Fix (implemented):** Credential-bearing cache entries — those whose key contains a `#<tokenhash>`
+suffix (appended by `resolutionCacheKey` when a GitHub token is present) — are kept in-memory
+only and never written to disk. Within the same broker process the entry retains its `Content`
+bytes for the full TTL window. After a broker restart, there is no stale entry to load, so the
+broker re-resolves the skill fresh (with the correct credential), populating `Content` again.
+
+Public-repo entries (keys without a `#` suffix, resolved without a per-URI token) continue to be
+persisted to disk as before. Their downloads use the broker's default token (or no token for truly
+public repos), which is available on restart, so the disk cache hit is safe for them.
 
 ---
 

--- a/pkg/agent/github_resolution_cache.go
+++ b/pkg/agent/github_resolution_cache.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -99,6 +100,18 @@ func (c *GitHubResolutionCache) Get(uri string) (ResolvedSkill, bool) {
 }
 
 // Put stores a resolved skill in the cache.
+//
+// Credential-bearing entries — those whose URI key contains a token-hash
+// suffix (the "#<hex>" appended by resolutionCacheKey when a GitHub token is
+// present) — are kept in-memory only and never written to disk. This prevents
+// the stale-404 class of bug described in issue #565: ResolvedFile.Content is
+// tagged json:"-" and is not preserved through serialisation, so a disk-cache
+// hit after a broker restart returns Content == nil. installOneSkill then
+// falls back to downloadSkillFile using the broker's default GitHub token —
+// not the per-URI named credential — causing a 404 on private repos. By
+// keeping credential entries in-memory only, Content survives for the full
+// TTL window within the same process, and there is no stale entry to load
+// after a restart.
 func (c *GitHubResolutionCache) Put(uri string, skill ResolvedSkill) {
 	c.mu.Lock()
 	now := time.Now()
@@ -108,9 +121,21 @@ func (c *GitHubResolutionCache) Put(uri string, skill ResolvedSkill) {
 		ExpiresAt: now.Add(c.ttl),
 	}
 	c.evictExpired()
+
+	// Credential-bearing URI keys contain a "#<tokenhash>" suffix.
+	// Keep them in-memory only — do not persist to disk.
+	if strings.Contains(uri, "#") {
+		c.mu.Unlock()
+		return
+	}
+
+	// For public-repo entries, persist to disk. Exclude any credential
+	// entries that may be present in the map from earlier Puts.
 	snapshot := make(map[string]*resolutionCacheEntry, len(c.entries))
 	for k, v := range c.entries {
-		snapshot[k] = v
+		if !strings.Contains(k, "#") {
+			snapshot[k] = v
+		}
 	}
 	c.mu.Unlock()
 

--- a/pkg/agent/github_resolution_cache_test.go
+++ b/pkg/agent/github_resolution_cache_test.go
@@ -126,6 +126,98 @@ func TestGitHubResolutionCache_PersistAndReload(t *testing.T) {
 	}
 }
 
+// TestGitHubResolutionCache_CredentialEntryNotPersistedToDisk verifies that
+// credential-bearing cache keys (those with a "#<tokenhash>" suffix, produced
+// by resolutionCacheKey when a GitHub token is present) are kept in-memory
+// only and never written to disk.
+//
+// This prevents the stale-404 bug from issue #565: ResolvedFile.Content is
+// json:"-" and is stripped on serialisation. A disk-loaded entry would have
+// Content == nil, causing installOneSkill to re-download using the wrong token
+// (the broker's default, not the per-URI named credential) and 404 on private
+// repos. Memory-only entries retain Content for the full TTL window.
+func TestGitHubResolutionCache_CredentialEntryNotPersistedToDisk(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := NewGitHubResolutionCache(dir, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("NewGitHubResolutionCache: %v", err)
+	}
+
+	// A key with a token-hash suffix (simulating a ?token= private-repo URI).
+	credKey := "gh://owner/repo/my-skill@main#deadbeef12345678"
+	skill := ResolvedSkill{
+		Name:    "private-skill",
+		URI:     "gh://owner/repo/my-skill@main",
+		Version: "abc123def456",
+		Hash:    "sha256:private",
+		Files: []ResolvedFile{
+			{Path: "SKILL.md", Content: []byte("private content")},
+		},
+	}
+	cache.Put(credKey, skill)
+
+	// In-memory Get must hit.
+	got, ok := cache.Get(credKey)
+	if !ok {
+		t.Fatal("expected in-memory cache hit for credential entry, got miss")
+	}
+	if got.Name != "private-skill" {
+		t.Errorf("expected name private-skill, got %s", got.Name)
+	}
+
+	// The cache file must not exist (credential entries are never written to disk).
+	cacheFile := filepath.Join(dir, resolutionCacheFileName)
+	if _, err := os.Stat(cacheFile); err == nil {
+		t.Error("credential-bearing entry was persisted to disk; expected memory-only")
+	}
+
+	// A new cache instance loading from the same dir must NOT see the credential entry.
+	cache2, err := NewGitHubResolutionCache(dir, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("NewGitHubResolutionCache (reload): %v", err)
+	}
+	if _, ok := cache2.Get(credKey); ok {
+		t.Error("credential entry should not be loadable from disk after restart")
+	}
+}
+
+// TestGitHubResolutionCache_MixedPublicAndCredential verifies that a cache
+// containing both public-repo and credential-bearing entries persists only
+// the public-repo entries to disk.
+func TestGitHubResolutionCache_MixedPublicAndCredential(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := NewGitHubResolutionCache(dir, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("NewGitHubResolutionCache: %v", err)
+	}
+
+	publicKey := "gh://owner/repo/pub-skill@main"
+	credKey := "gh://owner/repo/priv-skill@main#deadbeef12345678"
+
+	cache.Put(publicKey, ResolvedSkill{Name: "pub-skill", URI: publicKey})
+	cache.Put(credKey, ResolvedSkill{Name: "priv-skill", URI: "gh://owner/repo/priv-skill@main"})
+
+	// Both accessible in-memory.
+	if _, ok := cache.Get(publicKey); !ok {
+		t.Error("public entry: expected in-memory hit")
+	}
+	if _, ok := cache.Get(credKey); !ok {
+		t.Error("credential entry: expected in-memory hit")
+	}
+
+	// After reload, only public entry survives.
+	cache2, err := NewGitHubResolutionCache(dir, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("NewGitHubResolutionCache (reload): %v", err)
+	}
+	if _, ok := cache2.Get(publicKey); !ok {
+		t.Error("public entry: expected disk hit after reload")
+	}
+	if _, ok := cache2.Get(credKey); ok {
+		t.Error("credential entry: must not survive reload (should be memory-only)")
+	}
+}
+
 func TestGitHubResolutionCache_ExpiredNotLoaded(t *testing.T) {
 	dir := t.TempDir()
 	cache, err := NewGitHubResolutionCache(dir, 1*time.Millisecond)

--- a/pkg/agent/skill_resolver.go
+++ b/pkg/agent/skill_resolver.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -296,10 +297,17 @@ func installOneSkill(ctx context.Context, skill ResolvedSkill, dest, skillsDest 
 					_ = os.RemoveAll(finalDest)
 				} else {
 					util.Debugf("provision: skill installed from cache: %s@%s", skill.Name, skill.Version)
+					slog.InfoContext(ctx, "skill_content_cache: cache hit",
+						"skill", skill.Name, "version", skill.Version,
+						"hash", truncHash(skill.Hash), "cache_hit", true)
 					return buildSkillEntry(skill, dest, skillsDest)
 				}
 			}
 			// Cache copy failed — fall through to download
+		} else {
+			slog.InfoContext(ctx, "skill_content_cache: cache miss",
+				"skill", skill.Name, "version", skill.Version,
+				"hash", truncHash(skill.Hash), "cache_hit", false)
 		}
 	}
 

--- a/pkg/agent/skill_resolver.go
+++ b/pkg/agent/skill_resolver.go
@@ -303,9 +303,12 @@ func installOneSkill(ctx context.Context, skill ResolvedSkill, dest, skillsDest 
 					return buildSkillEntry(skill, dest, skillsDest)
 				}
 			}
-			// Cache copy failed — fall through to download
+			// Cache entry unusable (copy or hash verification failed) — re-downloading.
+			slog.InfoContext(ctx, "skill_content_cache: cache error, re-downloading",
+				"skill", skill.Name, "version", skill.Version,
+				"hash", truncHash(skill.Hash), "cache_hit", false)
 		} else {
-			slog.InfoContext(ctx, "skill_content_cache: cache miss",
+			slog.InfoContext(ctx, "skill_content_cache: cache miss, will download",
 				"skill", skill.Name, "version", skill.Version,
 				"hash", truncHash(skill.Hash), "cache_hit", false)
 		}


### PR DESCRIPTION
## Summary
Stress-test finding: only the Hub DB cache layer populates during standard developer-template provisioning; the two broker disk cache layers are correctly bypassed for that path but this wasn't documented, producing false "cache not populating" alarms during validation.

## Changes
- Docs: new "Which Layer Serves Which Path" table in .design/ps-cache-durability.md -- Hub DB = common public/App-token path; broker disk resolution cache = ?token=-scoped local resolution only; broker content cache = post-start byte download only. States explicitly that provision-only agents exercise only the Hub DB layer.
- Observability: added structured hit/miss log lines for the broker content cache in installOneSkill, mirroring the Hub's existing github_resolution_cache: cache hit/miss pattern.

## Deferred
A third item (whether the broker disk resolution cache still earns its keep beyond ?token= URIs, and whether it needs a TTL/version guard given issue #565) is a design question sent to the user separately -- not part of this PR.

Reviewed and approved.