### PR TITLE
perf(hub): deduplicate gh:// ref->SHA lookups within a resolve request

### DIFF
--- a/pkg/hub/skill_handlers.go
+++ b/pkg/hub/skill_handlers.go
@@ -1314,6 +1314,11 @@ func (s *Server) handleSkillsResolve(w http.ResponseWriter, r *http.Request) {
 		ghProjectAllowed = s.canUseProjectGitHubToken(ctx, req.ProjectID)
 	}
 
+	// Per-request memo for (owner,repo,ref,tokenScope) → commitSHA.
+	// URIs sharing the same tuple — the common case for a skill bundle in one
+	// repo — perform a single ref→SHA lookup instead of one per URI.
+	refSHAMemo := make(map[string]string)
+
 	for _, skillRef := range req.Skills {
 		// GitHub skill resolution: gh:// URIs are handled by the Hub's GitHub resolution cache
 		if strings.HasPrefix(skillRef.URI, "gh://") {
@@ -1324,7 +1329,7 @@ func (s *Server) handleSkillsResolve(w http.ResponseWriter, r *http.Request) {
 				})
 				continue
 			}
-			ghResolved, err := s.resolveGitHubSkill(ctx, skillRef.URI, req.ProjectID)
+			ghResolved, err := s.resolveGitHubSkill(ctx, skillRef.URI, req.ProjectID, refSHAMemo)
 			if err != nil {
 				resolveErrors = append(resolveErrors, ResolveSkillError{
 					URI: skillRef.URI, Code: "resolve_failed", Message: err.Error(),
@@ -1588,7 +1593,12 @@ func (s *Server) resolveGitHubToken(ctx context.Context, projectID string) (inst
 // 3. Checks the DB-backed resolution cache
 // 4. On cache miss, calls GitHub API to resolve commit SHA and file list
 // 5. Stores the result in the cache and returns it
-func (s *Server) resolveGitHubSkill(ctx context.Context, rawURI, projectID string) (*ResolvedSkillResponse, error) {
+//
+// refSHAMemo is a per-request memo map keyed by "(owner)/(repo)@(ref):(tokenScope)"
+// that is shared across all URIs in one handleSkillsResolve call. It prevents
+// redundant commits/{ref} API lookups for URIs that share the same tuple. Pass a
+// non-nil map to enable memoisation; nil disables it (treated as always-miss).
+func (s *Server) resolveGitHubSkill(ctx context.Context, rawURI, projectID string, refSHAMemo map[string]string) (*ResolvedSkillResponse, error) {
 	// 1. Parse gh:// URI
 	ghRef, err := agent.ParseGitHubSkillURI(rawURI)
 	if err != nil {
@@ -1644,9 +1654,22 @@ func (s *Server) resolveGitHubSkill(ctx context.Context, rawURI, projectID strin
 		rawBase = s.config.GitHubAppConfig.RawBaseURL
 	}
 
-	commitSHA, err := ghResolveCommitSHA(ctx, apiBase, ghRef.Owner, ghRef.Repo, ghRef.Ref, token)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve commit SHA: %w", err)
+	// Resolve ref → commit SHA, reusing a prior lookup if this (owner, repo,
+	// ref, tokenScope) tuple was already resolved within this request.
+	memoKey := ghRef.Owner + "/" + ghRef.Repo + "@" + ghRef.Ref + ":" + installID
+	commitSHA, seen := "", false
+	if refSHAMemo != nil {
+		commitSHA, seen = refSHAMemo[memoKey]
+	}
+	if !seen {
+		var err error
+		commitSHA, err = ghResolveCommitSHA(ctx, apiBase, ghRef.Owner, ghRef.Repo, ghRef.Ref, token)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve commit SHA: %w", err)
+		}
+		if refSHAMemo != nil {
+			refSHAMemo[memoKey] = commitSHA
+		}
 	}
 
 	fileEntries, err := ghListContents(ctx, apiBase, rawBase, ghRef.Owner, ghRef.Repo, ghRef.SkillPath, commitSHA, token)

--- a/pkg/hub/skill_handlers.go
+++ b/pkg/hub/skill_handlers.go
@@ -1656,6 +1656,10 @@ func (s *Server) resolveGitHubSkill(ctx context.Context, rawURI, projectID strin
 
 	// Resolve ref → commit SHA, reusing a prior lookup if this (owner, repo,
 	// ref, tokenScope) tuple was already resolved within this request.
+	// The separators "/" "@" ":" are safe for GitHub names: owner/repo names
+	// cannot contain "@" or ":", and Git ref names cannot contain ":". The
+	// installID suffix is the same for every URI in one request (shared
+	// projectID → shared installation) but is included for forward-safety.
 	memoKey := ghRef.Owner + "/" + ghRef.Repo + "@" + ghRef.Ref + ":" + installID
 	commitSHA, seen := "", false
 	if refSHAMemo != nil {

--- a/pkg/hub/skill_handlers_gh_cache_test.go
+++ b/pkg/hub/skill_handlers_gh_cache_test.go
@@ -35,7 +35,8 @@ import (
 // cache hit reaches no further than the DB.
 type fakeGitHub struct {
 	*httptest.Server
-	calls atomic.Int64
+	calls       atomic.Int64 // total calls (commits + contents)
+	commitCalls atomic.Int64 // commits/{ref} calls only
 }
 
 // newFakeGitHub serves the commits and contents endpoints for owner/repo,
@@ -51,6 +52,7 @@ func newFakeGitHub(t *testing.T, owner, repo, skillPath, commitSHA string) *fake
 		f.calls.Add(1)
 		switch {
 		case strings.HasPrefix(r.URL.Path, commitsPrefix):
+			f.commitCalls.Add(1)
 			// Accept: application/vnd.github.v3.sha — a bare SHA, not JSON.
 			_, _ = w.Write([]byte(commitSHA))
 		case strings.HasPrefix(r.URL.Path, contentsPrefix):
@@ -268,4 +270,55 @@ func TestSkillsResolve_GHDeclinesTokenSecretURI(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&plainResp))
 	assert.Empty(t, plainResp.Errors, "the same skill without ?token= must still resolve")
 	assert.Len(t, plainResp.Resolved, 1)
+}
+
+// TestSkillsResolve_GHRefDedup asserts that a batch request containing N URIs
+// sharing the same (owner, repo, ref) performs only one ref→SHA lookup via
+// commits/{ref}, not one per URI. Each URI still triggers its own contents
+// lookup — dedup applies only to the SHA resolution step.
+//
+// This is the acceptance test for the issue-1 performance fix: 19 same-repo
+// URIs should cost 1 + 19 = 20 GitHub API calls, not 19 × 2 = 38.
+func TestSkillsResolve_GHRefDedup(t *testing.T) {
+	const (
+		owner     = "acme"
+		repo      = "bundle-repo"
+		commitSHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+
+	srv, _, alice, _, project := setupSkillAuthzTest(t)
+	srv.ghResolutionStore = NewGitHubResolutionStore(enttest.NewClient(t))
+
+	gh := newFakeGitHub(t, owner, repo, "skills/any", commitSHA)
+	srv.config.GitHubAppConfig.APIBaseURL = gh.URL
+	srv.config.GitHubAppConfig.RawBaseURL = gh.URL
+
+	// Three URIs in the same (owner, repo) with the same implicit ref (HEAD)
+	// but different skill paths — the common case for a skill bundle.
+	const n = 3
+	skills := []ResolveSkillRef{
+		{URI: "gh://" + owner + "/" + repo + "/skill-a"},
+		{URI: "gh://" + owner + "/" + repo + "/skill-b"},
+		{URI: "gh://" + owner + "/" + repo + "/skill-c"},
+	}
+
+	rec := doRequestAsUser(t, srv, alice, http.MethodPost, "/api/v1/skills/resolve",
+		ResolveSkillsRequest{Skills: skills, ProjectID: project.ID})
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resp ResolveSkillsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Empty(t, resp.Errors, "all %d URIs must resolve successfully", n)
+	require.Len(t, resp.Resolved, n, "all %d skills must be present in the response", n)
+
+	// The key assertion: only 1 commits/{ref} call for N URIs sharing the same
+	// (owner, repo, ref). Before the fix this would be N.
+	assert.Equal(t, int64(1), gh.commitCalls.Load(),
+		"ref→SHA resolution must be deduplicated: %d URIs, same repo+ref → 1 commit lookup (got %d)",
+		n, gh.commitCalls.Load())
+
+	// Sanity: each URI's contents lookup must still happen independently.
+	contentsCalls := gh.calls.Load() - gh.commitCalls.Load()
+	assert.Equal(t, int64(n), contentsCalls,
+		"each URI must still trigger its own contents lookup: expected %d, got %d", n, contentsCalls)
 }

--- a/pkg/hub/skill_handlers_gh_cache_test.go
+++ b/pkg/hub/skill_handlers_gh_cache_test.go
@@ -295,12 +295,12 @@ func TestSkillsResolve_GHRefDedup(t *testing.T) {
 
 	// Three URIs in the same (owner, repo) with the same implicit ref (HEAD)
 	// but different skill paths — the common case for a skill bundle.
-	const n = 3
 	skills := []ResolveSkillRef{
 		{URI: "gh://" + owner + "/" + repo + "/skill-a"},
 		{URI: "gh://" + owner + "/" + repo + "/skill-b"},
 		{URI: "gh://" + owner + "/" + repo + "/skill-c"},
 	}
+	n := len(skills) // derived so assertions stay in sync if the slice grows
 
 	rec := doRequestAsUser(t, srv, alice, http.MethodPost, "/api/v1/skills/resolve",
 		ResolveSkillsRequest{Skills: skills, ProjectID: project.ID})


### PR DESCRIPTION
## Summary
Stress-test finding: cold resolution of N gh:// URIs sharing the same (owner, repo, ref) made N redundant commits/{ref} GitHub API calls instead of 1 -- the exact call-volume pattern that caused the original rate-limit incident. Measured: 19-URI same-repo developer template went from 38 total API calls to 20 (~47% reduction).

## Changes
- Per-request memo map (owner/repo@ref:tokenScope) in handleSkillsResolve, checked/populated by resolveGitHubSkill before calling ghResolveCommitSHA.
- ghListContents is correctly excluded from memoization (still one call per URI, different paths).
- New test TestSkillsResolve_GHRefDedup asserts commitCalls==1 for a 3-URI same-repo batch (fails on pre-fix code).
- Follow-up commit addresses reviewer's non-blocking documentation notes.

Reviewed independently: memo scoping confirmed request-local (no cross-request contamination), key correctly stratified by token scope, error paths don't poison the memo, empty-ref->HEAD normalization handled correctly. APPROVED.