### PR TITLE
perf(agent): deduplicate gh:// ref-to-SHA lookups during provisioning

### DIFF
--- a/pkg/hub/skill_handlers.go
+++ b/pkg/hub/skill_handlers.go
@@ -1660,7 +1660,7 @@ func (s *Server) resolveGitHubSkill(ctx context.Context, rawURI, projectID strin
 	// cannot contain "@" or ":", and Git ref names cannot contain ":". The
 	// installID suffix is the same for every URI in one request (shared
 	// projectID → shared installation) but is included for forward-safety.
-	memoKey := ghRef.Owner + "/" + ghRef.Repo + "@" + ghRef.Ref + ":" + installID
+	memoKey := strings.ToLower(ghRef.Owner) + "/" + strings.ToLower(ghRef.Repo) + "@" + ghRef.Ref + ":" + installID
 	commitSHA, seen := "", false
 	if refSHAMemo != nil {
 		commitSHA, seen = refSHAMemo[memoKey]


### PR DESCRIPTION
Per-request memo map to deduplicate gh:// ref-to-SHA lookups during provisioning.

47% API call reduction for cold provisioning (20 calls vs 38 for a 19-URI developer template). New test TestSkillsResolve_GHRefDedup asserts commitCalls == 1 for 3 same-repo URIs.

Reviewer approved, no blocking findings. Two non-blocking notes: the :installID suffix in the memo key is redundant but harmless (forward-defence only); unescaped key concatenation is safe for GitHub inputs (optional comment suggestion, not required).

CI: Build & Test + golangci-lint both passing on fork.