### PR TITLE
feat: batch-add injected skills from a GitHub directory (Phase 1)

### DIFF
--- a/.design/project-log/ps-dirbatch-p1-dev.md
+++ b/.design/project-log/ps-dirbatch-p1-dev.md
@@ -1,0 +1,116 @@
+# Directory Batch-Add for Injected Skills — Phase 1
+
+**Agent:** ps-dirbatch-p1-dev
+**Date:** 2026-07-30
+**Branch:** `scion/project-skills-dirbatch`
+**Design:** `/scion-volumes/scratchpad/projects/project-skills/design-dirbatch-skills.md`
+**Commits:** `276f0914` (backend), `f05fbd56` (frontend)
+
+## What was built
+
+Phase 1 of directory batch-add: point the injected-skills panel at a GitHub
+directory of skills, pick a subset from a checkbox list, and add them all in one
+operation. Works across all three scopes (project, user, hub). Phase 2 (the
+`--from-directory` CLI flag) is not in scope here.
+
+## Commit 1 — backend discover endpoint
+
+`POST /api/v1/skills/discover-directory` fetches a remote GitHub directory,
+scans it for subdirectories containing a `SKILL.md`, and returns
+`{ skills: [{uri, name}], count }`. Nothing is persisted — this is a read-only
+probe.
+
+**Files:**
+- `pkg/hub/handlers_skills_discover.go` (new) — `skillDiscoverKind`,
+  `DiscoverSkillsRequest` / `DiscoveredSkill` / `DiscoverSkillsResponse`,
+  `handleSkillsDiscoverDirectory`.
+- `pkg/hub/handlers_skills_discover_test.go` (new) — 11 tests.
+- `pkg/hub/server.go` — one route registration line next to
+  `/api/v1/resources/discover`.
+
+**Reuse:** `fetchRemoteForImport` (tarball fetch + GitHub App token /
+`GITHUB_TOKEN` secret auth) and `discoverResourceDirs` (leaf-vs-parent layout)
+are called verbatim; `api.NormalizeSkillURI` produces each canonical URI. Only
+`skillDiscoverKind` and the handler are net-new.
+
+## Commit 2 — frontend discovery dialog and batch-add
+
+**File:** `web/src/components/shared/injected-skills-panel.ts`
+(+ `injected-skills-panel.test.ts`, new, 16 tests)
+
+Five new `@state()` props, plus `showDiscoverButton` (getter),
+`handleDiscoverDirectory()`, `renderDiscoveryDialog()`, `addEntries()`,
+`handleDiscoveryConfirm()`, and `resetDiscovery()`. The selection dialog is
+rendered from `render()` alongside `renderDialog()`.
+
+## Key decisions
+
+**Where `skillDiscoverKind` lives.** The brief allowed `resource_import.go` "or a
+small adjacent file". It went in `handlers_skills_discover.go` so the kind sits
+next to its only consumer; `resource_import.go` holds the two kinds that have a
+`newStore`, and this one deliberately does not.
+
+**`newStore: nil` is safe.** Only `discoverResourceDirs` is ever called with this
+kind, and that function never touches `newStore`. Documented in a comment so a
+future caller does not assume the field is populated.
+
+**No `GetStorage()` guard.** Template and harness-config discovery bail out when
+hub object storage is unconfigured because their discover step is a prelude to
+an import that writes there. Skill discovery never writes, so the guard would
+only produce spurious 503s on hubs with no storage backend.
+
+**Empty result is a 400, not an empty 200.** Matches `discoverFromRemote`'s
+`"no scion <noun> found at <url>"` behaviour and gives the UI something
+actionable to display. The frontend also treats a `skills: []` 200 as an error,
+so a future relaxation of the backend contract cannot produce an empty dialog.
+
+**Agent auth also *narrows* the fetch.** Beyond the design's 403 checks (missing
+`ScopeAgentCreate`, or a `projectId` belonging to someone else), the handler
+overwrites `req.ProjectID` with the agent's own project when the caller omitted
+it. Without this an agent that left `projectId` off would silently get an
+unauthenticated fetch and fail on private repos.
+
+**Discover-button gating reads `dialogTransformed` first.** This is the
+substance of the Q3 B+C+D blend: a GitHub URL under a standard `skills/` path
+normalizes to `gh://` and so offers no discovery, while the same repo's
+`skills` parent stays `https://` and does. Falling back to the raw `dialogUri`
+only matters before normalization has produced a transform.
+
+**`addEntries()` vs. N × `addEntry()`.** Hub scope's PUT-whole-list API makes the
+naive loop O(N) round-trips with N-1 pointless intermediate server states.
+`addEntries()` builds the list once and PUTs once. Project/user scope keeps the
+per-item POST path unchanged — those endpoints are idempotent, and duplicating
+their logic would be the more fragile choice.
+
+**Dialog duplicated, not extracted.** Per Alt A2 in the design: the two checkbox
+pickers operate on `string[]` vs `{uri, name}[]`, so sharing would need generics
+or a render slot for ~70 lines of markup. The `.selection-*` CSS was copied into
+the panel's styles for the same reason (`resourceStyles` does not carry it).
+
+## Verification
+
+- `go build ./...` — clean
+- `go vet ./...` — clean
+- `go test ./pkg/hub/...` — all pass (166s)
+- `cd web && npm run typecheck` — clean
+- `cd web && npx vitest run` — 82 tests across 6 files pass
+
+Lint: `injected-skills-panel.ts` carries 35 pre-existing prettier/unbound-method
+errors on `main`. The changed file is at parity — verified by diffing the eslint
+error set against the stashed baseline. The new `.test.ts` file reports the same
+single "not in tsconfig" error every existing `*.test.ts` in the repo reports.
+
+## Acceptance criteria
+
+All Phase 1 backend criteria are covered by tests, including the three auth
+cases and the leaf-URL case. Frontend criteria are covered by unit tests for the
+button gating, the one-PUT hub batch, the N-POST project batch, and inline error
+display; the visual criteria (loading state, indeterminate Select All, count
+label) are implemented but verified by reading rather than by test.
+
+## Note for the EM
+
+The brief said branch `scion/project-skills-dirbatch` was already created from
+`origin/main`; it did not exist on the remote. I created it locally from
+`origin/main` (which `HEAD` already matched, at `d693a5ee`). Not pushed —
+pushing is the EM's step.

--- a/.design/project-log/ps-dirbatch-p1-dev.md
+++ b/.design/project-log/ps-dirbatch-p1-dev.md
@@ -82,6 +82,11 @@ naive loop O(N) round-trips with N-1 pointless intermediate server states.
 per-item POST path unchanged — those endpoints are idempotent, and duplicating
 their logic would be the more fragile choice.
 
+> **Correction (see `ps-dirbatch-p1-fix.md`, FIX-4):** the project/user POST
+> endpoints are *not* idempotent — they return 409 on a duplicate skill URI. The
+> claim above was wrong and the resulting partial-add defect was fixed in
+> commit `28c9ab74`.
+
 **Dialog duplicated, not extracted.** Per Alt A2 in the design: the two checkbox
 pickers operate on `string[]` vs `{uri, name}[]`, so sharing would need generics
 or a render slot for ~70 lines of markup. The `.selection-*` CSS was copied into

--- a/.design/project-log/ps-dirbatch-p1-fix.md
+++ b/.design/project-log/ps-dirbatch-p1-fix.md
@@ -1,0 +1,146 @@
+# Directory Batch-Add for Injected Skills — Phase 1 Review Remediation
+
+**Agent:** ps-dirbatch-p1-dev
+**Date:** 2026-07-30
+**Branch:** `scion/project-skills-dirbatch`
+**Brief:** `/scion-volumes/scratchpad/briefs/ps-dirbatch-p1-fix.md`
+**Phase 1 log:** `.design/project-log/ps-dirbatch-p1-dev.md`
+**Commits:** `b9176cb4` (backend), `28c9ab74` (frontend)
+
+Every finding from the code, security, and test reviews — blocking and
+non-blocking — is addressed here. The four shared-layer items (archive size
+bounds, orphaned cache dirs, rate limiting, cache-path race) and the backend
+test-helper consolidation were explicitly out of scope and are untouched.
+
+## Group 1 — blocking
+
+**FIX-1 — cross-tenant credential use (C-1 / HIGH-1).** The handler validated
+agent callers properly but for users only checked "is logged in". Supplying an
+arbitrary `projectId` made `fetchRemoteForImport` mint that project's GitHub App
+token, or read its `GITHUB_TOKEN` secret. User callers now go through the same
+`authzService.CheckAccess(agent / project / create)` as `authorizeProjectImport`,
+followed by a `GetProject` existence check so a typo'd UUID 404s instead of
+silently degrading to an unauthenticated fetch.
+
+The whole auth block moved into `authorizeSkillDiscover`, partly because the
+handler was getting long and partly because the *reason* discovery needs
+authorization at all is non-obvious — it persists nothing, but it spends
+credentials. That rationale is now a doc comment on the helper rather than a
+loose comment in the middle of the handler.
+
+**FIX-2 — sourceUrl restricted to `https://github.com/` (HIGH-2/3, I-1).**
+`config.IsRemoteURI` was the wrong predicate: it also accepts rclone connection
+strings (`:local:/` would have the hub copy its own filesystem into a cache dir
+and enumerate it) and bare `http://` URLs (an SSRF probe against hub-internal
+hosts). Neither can ever yield a usable skill URI, so the check is now an
+explicit `url.Parse` + scheme/host test. The comment names both rejected forms so
+nobody "simplifies" it back to `IsRemoteURI`.
+
+Note the host check is `strings.EqualFold` — hosts are case-insensitive, and
+`HTTPS://GitHub.com/...` is a URL a user will realistically paste.
+
+**FIX-3 — no raw error strings to the client (I-4 / MEDIUM-4).** This was the
+sharpest finding. `fetchRemoteForImport` falls back to a sparse git checkout
+whose remote is `https://x-access-token:<TOKEN>@github.com/...`, and
+`sparseGitCheckout` returns git's stderr verbatim — so a failed private-repo
+fetch could put a live GitHub token in an HTTP 400 body. Both error sites now log
+via `s.resourceLog.Warn` and return a fixed message. The test asserts the token
+value and the string `x-access-token` are absent from the response body.
+
+**FIX-4 — `addEntries()` duplicate/409 defect (I-2).** My Phase 1 comment claimed
+the project/user POST endpoints were "idempotent by design". They are not:
+`handlers_skills_injection.go:189` returns 409 on `store.ErrAlreadyExists`. The
+consequence was worse than an ugly error — the loop aborted on the first 409,
+leaving a partial add, and re-clicking "Add Selected" 409'd again on the skills
+that had just landed. Permanently stuck.
+
+Two changes: pre-existing URIs are filtered against `this.rows` before anything
+is sent, and the project/user loop collects per-item failures into one aggregate
+error rather than throwing mid-batch. Hub scope needed the same filter for a
+different reason — its PUT stores the list as given, so a re-discovery appended
+duplicate rows with no 409 to warn anyone.
+
+**FIX-5 — `?token=SECRET_NAME` suffix (I-3).** `discoverResourceDirs` builds child
+URLs by plain concatenation, so `.../skills?token=X` became
+`.../skills?token=X/child`, which `NormalizeSkillURI` rejects. Every child was
+dropped and the user saw "no skills found" — a confusing failure for a feature
+that looked like it worked. The suffix is split off before discovery and
+re-attached per skill. It is also irrelevant to the fetch (which authenticates
+from project credentials), so the fetch gets the bare URL; a test asserts the
+secret *name* never travels to GitHub.
+
+## Group 2 — non-blocking
+
+- **FIX-6** — discovered directory names containing `?#&=` or `..` are skipped. A
+  repo folder literally named `helper?token=PROD_SECRET` would otherwise smuggle
+  a secret reference into a URI the UI invites the user to add.
+- **FIX-7** — `http.MaxBytesReader` at 64 KiB. The body is two short strings.
+- **FIX-8** — `Skipped []string` in the response, populated from the
+  `discoverResourceDirs` return value that was previously discarded, so the UI
+  can explain why a folder the user expected is missing.
+- **FIX-9** — `closeDialog()` calls `resetDiscovery()`; the redundant call in
+  `handleDiscoveryConfirm()` is gone.
+- **FIX-10** — `showDiscoverButton` requires `https://github.com/`, matching the
+  tightened backend contract.
+- **FIX-11** — comment on why `handleDiscoverDirectory` posts the raw dialog URI
+  rather than `dialogTransformed`.
+- **FIX-12** — `TestSkillDiscoverKind` asserts `newStore == nil`, the invariant
+  that makes the handler safe on a hub with no object storage.
+
+## Group 3 — tests
+
+**Backend** (`handlers_skills_discover_test.go`, 11 → 21 tests). New:
+`_ProjectAuthToken` (captures the `Bearer` header on the wire — without it the
+entire credential-scoping path was unverified), `_UserNotInProject` (403),
+`_UnknownProject` (404), `_NonAdminUser` (200 — discover must not inherit the
+admin-only rule from hub-scope *add*), `_FetchFailure`, `_NonRemoteURL`
+(table-driven, 8 cases), `_MalformedBody`, `_TokenSuffix`,
+`_SkipsUnnormalizableChild`, `_AllChildrenUnnormalizable`,
+`_AgentOmitsProjectID`. Existing tests gained the outbound-URL assertion, the
+`Skipped` assertion, and `code`-field assertions.
+
+`mockSkillTarball` grew a `mockSkillTarballWithHook` variant so tests can inspect
+the outbound request instead of the mock being URL-agnostic.
+
+**Frontend** (`injected-skills-panel.test.ts`, 16 → 37 tests). New DOM-level
+coverage for the discover button (present in URI mode, absent for `gh://`, absent
+in search mode, and appearing only after the *real* `sl-input` handler runs
+`normalizeSkillURIClient`), the selection dialog (Select All, indeterminate,
+per-skill toggle asserting a new `Set` instance, Cancel with zero network calls),
+`discoveryLoading` across both outcomes, and the FIX-4 cases (hub dedup, project
+skip-already-present, 409 and 500 mid-batch continuation, partial-batch reporting
+through `handleDiscoveryConfirm`).
+
+## Notes on the fixes I did not make literally
+
+**`_SkipsUnnormalizableChild` tests the reachable case, not the literal one.** The
+brief asked for a child "whose derived URL can't be normalized" alongside valid
+siblings. With FIX-6 in place that combination is not actually constructible: the
+only per-child input to `NormalizeSkillURI` is the directory name, and every name
+that would fail normalization (`..`, `?#&=`) is now rejected by the earlier guard.
+The test therefore uses an unsafe-named sibling, which exercises the same
+skip-and-continue path for the same reason, and the comment says so. The
+`normErr` branch stays as defence in depth.
+
+**`_FetchFailure` empties `PATH`.** A 404 from the mock transport sends
+`fetchGitHubFolder` into its sparse-checkout fallback, which shells out to `git`
+against the real github.com. `t.Setenv("PATH", "")` makes `exec.LookPath` fail
+immediately, keeping the test hermetic and fast.
+
+**Two extra tests beyond the brief.** `_UnknownProject` covers the `GetProject`
+half of FIX-1 (the brief only specified the `CheckAccess` half), and
+`_NonRemoteURL` asserts that no outbound request was attempted for any rejected
+URL — the point of FIX-2 is that the fetch never happens, and a status-code-only
+assertion would pass even if it did.
+
+## Verification
+
+- `go build ./...` — clean
+- `go vet ./...` — clean
+- `go test ./pkg/hub/` — pass (160s)
+- `cd web && npm run typecheck` — clean
+- `cd web && npx vitest run` — 103 tests across 6 files pass
+
+Lint: `injected-skills-panel.ts` still carries its 35 pre-existing
+prettier/unbound-method errors and no others — verified by diffing the normalized
+eslint error set against the stashed baseline (net-new: none; removed: none).

--- a/.design/project-log/ps-dirbatch-p1-polish.md
+++ b/.design/project-log/ps-dirbatch-p1-polish.md
@@ -1,0 +1,139 @@
+# Directory Batch-Add for Injected Skills — Phase 1 Final Polish
+
+**Agent:** ps-dirbatch-p1-polish
+**Date:** 2026-07-30
+**Branch:** `scion/project-skills-dirbatch`
+**Brief:** `/scion-volumes/scratchpad/briefs/ps-dirbatch-p1-polish.md`
+**Prior logs:** `.design/project-log/ps-dirbatch-p1-dev.md`,
+`.design/project-log/ps-dirbatch-p1-fix.md`
+**Commits:** `dc070291` (backend), `ece9a0ae` (frontend)
+
+All three pass-2 reviews returned APPROVE. This change closes the remaining
+Low/Medium findings before the branch is signalled upstream. Nothing here is
+architectural; every item is a localized correctness, diagnostic, or test gap.
+
+The shared-layer items (archive size bounds, orphaned cache dirs, rate
+limiting, cache-path race, redirect-hop validation) and the tarball-mock
+consolidation remain out of scope and are untouched.
+
+## Backend — `pkg/hub/handlers_skills_discover.go`
+
+**P-1 — canonicalize `sourceUrl` after validation (N-1, N-2).** The URL was
+validated and then handed downstream more or less as pasted, with only `?`
+split off. It is now parsed once and canonicalized before anything else sees
+it:
+
+- *Host lowercased.* The gate is `strings.EqualFold` because hostnames are
+  case-insensitive and `https://GitHub.com/...` is a URL people paste — but
+  `config.DetectRemoteType` matches `"github.com"` exactly. So a mixed-case
+  host passed the gate and then failed inside the fetch layer with a generic
+  400: a valid URL producing a dead-end error.
+- *Fragment stripped.* `discoverResourceDirs` builds child URLs by plain
+  concatenation, so a surviving `#notes` yielded children like
+  `.../skills#notes/alpha-skill` — syntactically plausible, unresolvable.
+- *Query split off* into `tokenSuffix`, as before, but now via `u.RawQuery`
+  rather than a string index.
+
+**Beyond the brief: userinfo is also stripped.** Not in the brief, but it
+falls out of the same canonicalization and is the one item here with a real
+security edge. `https://x-access-token:SECRET@github.com/o/r/tree/main/skills`
+parses with `Host == "github.com"`, so it passed the gate; `base` is then
+written to the hub log on fetch failure *and* echoed back to the client in
+`"no skills found at <base>"`. A pasted credential therefore reached both. It
+is now cleared — discovery authenticates from project credentials, never from
+the URL. Covered by `_StripsURLCredentials`, which asserts the credential
+reaches neither the wire nor the response body.
+
+**P-2 — require a `/tree/<ref>/` path (test Finding 1).** `api.NormalizeSkillURI`
+requires that form. A bare-repo URL (`https://github.com/acme/repo`, or
+`.../repo/skills`) passed the host check, spent a full tarball fetch, and then
+failed normalization for *every* child — surfacing as "no skills found" for a
+repo that plainly has skills. Now rejected up front with a message naming the
+expected shape, and no outbound request.
+
+This makes the `normErr` skip-and-continue branch unreachable from
+well-formed input. It is kept as defence in depth, with a comment saying so —
+the alternative (deleting it) would make an unaddressable directory fail the
+whole discovery instead of just itself.
+
+**P-3 — report silently-dropped directories (N-3).** The unsafe-name guard and
+the `normErr` branch both `continue`d without recording anything, so a
+legitimately-named folder that happens to contain `=` simply vanished from the
+dialog. Both now append to a `droppedNames` slice that is merged into the
+response's `Skipped` list, which already existed for marker-less siblings.
+`_StandardSkillsDir` grows a `bad=name/SKILL.md` fixture and asserts it appears
+in `Skipped` — the assertion is order-independent, since the two skip paths
+contribute from different loops.
+
+**P-4 — `ErrCodeDiscoverFailed`.** Added to `pkg/hub/errors.go` and used at all
+three sites here, plus the three pre-existing literals in
+`handlers_resource_import.go` so the constant is not immediately inconsistent
+with its own package. Wire value unchanged.
+
+## Frontend — `web/src/components/shared/injected-skills-panel.ts`
+
+**P-5 — wire `skipped[]` into the dialog (test Finding 3).** The field was
+added in FIX-8 specifically so the UI could explain missing directories, and
+then never read — the rationale was stated and not honoured. `skipped[]` is now
+captured into a `skippedSkillNames` state property, rendered as a muted note
+below the selection list, and cleared in `resetDiscovery()` alongside the rest
+of the discovery state (so it cannot survive a Cancel, same invariant the
+existing lifecycle tests pin for `discoveredSkills`).
+
+**P-6 (code side) — document the silent no-op.** `addEntries()` returns early
+when every selected URI is already in `rows`. That is correct — an
+all-duplicates batch has nothing to write, and issuing it would mean a no-op
+PUT on hub scope — but the silence is easy to break by accident, so the reason
+is now a comment rather than an inference.
+
+The brief's N-4 (a toast for the all-already-present case) was explicitly
+optional and is not done; the current behaviour is "both dialogs close", which
+is defensible but does leave the user without confirmation. Worth revisiting if
+it comes up in use.
+
+## Tests
+
+Backend, all in `handlers_skills_discover_test.go`:
+
+- `_MixedCaseHost` — 200, and the outbound tarball URL is lowercase-host.
+- `_SourceURLWithFragment` — 200, fragment absent from the fetch URL, children
+  not corrupted.
+- `_StripsURLCredentials` — pasted userinfo reaches neither GitHub nor the
+  response body.
+- `_SourceURLWithoutTreeRef` — four URL shapes, each 400 with an actionable
+  message, and a `fetched` flag asserting no outbound request was made.
+- `_CacheCleanup` — P-7. `HOME` is redirected to a temp dir so the assertion
+  covers a private `~/.scion/cache/remote-templates`, and the entry count is
+  compared before and after. Verified as a real canary: with the handler's
+  `defer os.RemoveAll(cachePath)` removed, it fails with
+  `cache entries ... = 1 after discovery, want 0`.
+- `_StandardSkillsDir` extended for P-3.
+- The two `discover_failed` literal assertions now use the constant.
+
+Frontend, in `injected-skills-panel.test.ts`:
+
+- Skipped note rendered with the right text (DOM assertion on `shadowRoot`,
+  whitespace-collapsed).
+- Pluralization (`1 folder ... was` / `2 folders ... were`) and absence of the
+  note when the response carries no `skipped[]`.
+- P-6: all-selected-URIs-already-present closes both dialogs with zero network
+  calls and no error.
+- `skippedSkillNames` reset added to the existing `openDialog()` /
+  `closeDialog()` lifecycle tests.
+
+## Verification
+
+```
+go build ./...                                    ok
+go vet ./pkg/hub/                                 ok
+gofmt -l pkg/hub/                                 clean
+go test ./pkg/hub/                                ok (175s)
+cd web && npm run typecheck                       ok
+cd web && npx vitest run .../injected-skills-panel.test.ts
+                                                  40 passed (was 37)
+```
+
+Backend discover tests: 26 → 31 top-level cases. ESLint on the two changed
+frontend files is back at its pre-change baseline (62 problems, all
+pre-existing repo-wide prettier/return-type noise); the repo does not lint
+clean today, so the baseline comparison is the meaningful check.

--- a/.design/project-log/ps-dirbatch-p2-dev.md
+++ b/.design/project-log/ps-dirbatch-p2-dev.md
@@ -1,0 +1,38 @@
+# Phase 2 Dev: CLI --from-directory flag for skill batch-add
+
+**Date:** 2026-07-30
+**Branch:** `scion/project-skills-dirbatch`
+**Agent:** ps-dirbatch-p2-dev
+
+## Summary
+
+Added the `--from-directory` CLI flag to both `scion project skills add` and
+`scion user skills add`, enabling batch discovery and addition of skills from a
+GitHub directory URL.
+
+## Changes
+
+### New files
+- `pkg/hubclient/skill_discover.go` — client-side types and implementation for
+  `POST /api/v1/skills/discover-directory`
+- `pkg/hubclient/skill_discover_test.go` — happy path, error, and projectID
+  forwarding tests
+
+### Modified files
+- `pkg/hubclient/client.go` — added `DiscoverSkillsDirectory` to the `Client`
+  interface
+- `cmd/project_skills.go` — `--from-directory` flag, `runProjectSkillsFromDirectory`
+  function with TTY prompt, partial-failure handling
+- `cmd/user_skills.go` — mirror of the project-scope version for user scope
+  (no projectID in request, uses `UserInjectedSkills()`)
+- `cmd/project_skills_test.go` — 7 new tests: flag registration, non-TTY adds-all,
+  TTY+yes adds-all, TTY abort, no-skills, partial failure, discover error
+- `cmd/user_skills_test.go` — 5 new tests: flag registration, non-TTY adds-all,
+  TTY abort, no-skills, partial failure
+
+## Verification
+
+- `go build ./...` — clean
+- `go vet ./cmd/... ./pkg/hubclient/...` — clean
+- `go test ./pkg/hubclient/` — all pass (including 3 new discover tests)
+- `go test ./cmd/` — all pass (including 12 new from-directory tests)

--- a/.design/project-log/ps-dirbatch-p2-polish.md
+++ b/.design/project-log/ps-dirbatch-p2-polish.md
@@ -1,0 +1,74 @@
+# Project Log: ps-dirbatch-p2-polish
+
+**Date:** 2026-07-30
+**Branch:** `scion/project-skills-dirbatch`
+**Commit:** 0a44334
+**Agent:** ps-dirbatch-p2-polish
+
+## Summary
+
+Phase 2 polish pass on the CLI `--from-directory` flag for `scion project skills add`
+and `scion user skills add`. All findings from the Phase 2 quality gate reviews
+(code, test, security) are addressed in a single commit.
+
+## Changes
+
+### Security fixes
+- **Strip userinfo from directory URLs** (LOW-2): URLs like
+  `https://token:secret@github.com/...` now have credentials removed before the
+  discover request is sent. Applied to both `runProjectSkillsFromDirectory` and
+  `runUserSkillsFromDirectory`.
+- **Client-side URL validation** (LOW-1): New `looksLikeGitHubDirectoryURL()` helper
+  rejects non-GitHub and non-HTTPS URLs locally before making a network round-trip.
+  Table-driven test covers valid/invalid cases.
+
+### Bug fixes
+- **Context lifetime** (I-1): Replaced the single 60s context with separate 30s
+  (discover) and 60s (add) contexts. The add timeout starts after the user responds
+  to the prompt, not at function entry.
+- **Nil-error wrapping** (M-1): Split the `err != nil || hubCtx == nil` check into
+  two branches to avoid `fmt.Errorf("...: %w", nil)` producing a `<nil>` message.
+- **Total failure error** (M-3): When all `svc.Add()` calls fail, the command now
+  returns an error instead of exiting 0 with "Added 0 of N".
+
+### UX improvements
+- **Flag conflict checks** (M-2): `--as` and `--optional` with `--from-directory`
+  now produce a clear error instead of being silently ignored.
+- **Positional URI conflict** (M-4): Providing both a skill URI argument and
+  `--from-directory` now errors instead of silently discarding the URI.
+
+### Tests added
+- `TestLooksLikeGitHubDirectoryURL` — table-driven validation helper test
+- `TestRunProjectSkillsFromDirectory_StripsUserinfo` — asserts mock server receives
+  no credentials
+- `TestRunProjectSkillsFromDirectory_InvalidURL` — non-GitHub URL rejected locally
+- `TestRunProjectSkillsAdd_FromDirConflictWithAs` — --as + --from-directory error
+- `TestRunProjectSkillsAdd_FromDirConflictWithOptional` — --optional + --from-directory error
+- `TestRunProjectSkillsAdd_FromDirConflictWithSkillURI` — positional URI + --from-directory error
+- `TestRunProjectSkillsFromDirectory_TotalFailure` — all adds fail → error
+- `TestRunUserSkillsFromDirectory_TTY_Yes_AddsAll` — autoConfirm=true bypasses prompt
+- `TestRunUserSkillsFromDirectory_DiscoverError` — 500 from discover → error
+- `TestRunUserSkillsFromDirectory_StripsUserinfo` — user-scope userinfo stripping
+- `TestRunUserSkillsFromDirectory_InvalidURL` — user-scope URL validation
+- `TestRunUserSkillsAdd_FromDirConflictWithAs` — user-scope flag conflict
+- `TestRunUserSkillsFromDirectory_TotalFailure` — user-scope total failure
+
+### Documentation
+- Updated design doc `DiscoverSkillsResponse` Go type to include `Skipped` field.
+- Added CLI section note about skipped directory count display.
+
+## Verification
+
+```
+go build ./...          # pass
+go vet ./cmd/...        # pass
+go test ./cmd/ -count=1 # pass (5.7s)
+go test ./pkg/hubclient/ -run TestDiscoverSkills -v # pass
+```
+
+## Files changed
+
+- `cmd/project_skills.go` — fixes 1–7 + looksLikeGitHubDirectoryURL helper
+- `cmd/project_skills_test.go` — 7 new tests + TestLooksLikeGitHubDirectoryURL
+- `cmd/user_skills.go` — fixes 1–6 (user-scope mirrors)
+- `cmd/user_skills_test.go` — 7 new tests

--- a/cmd/project_skills.go
+++ b/cmd/project_skills.go
@@ -464,13 +464,13 @@ func runProjectSkillsFromDirectory(cmd *cobra.Command, projectArg, dirURL string
 		}
 	}
 	if len(addErrors) > 0 {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %d of %d skills could not be added:\n", len(addErrors), len(result.Skills))
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %d of %d skills could not be added:\n", len(addErrors), len(result.Skills))
 		for _, e := range addErrors {
-			fmt.Fprintf(cmd.ErrOrStderr(), "  %s\n", e)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  %s\n", e)
 		}
 	}
 	added := len(result.Skills) - len(addErrors)
-	fmt.Fprintf(cmd.OutOrStdout(), "Added %d of %d skill(s).\n", added, len(result.Skills))
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Added %d of %d skill(s).\n", added, len(result.Skills))
 
 	// Fix 6: Return error when all adds fail.
 	if added == 0 && len(result.Skills) > 0 {

--- a/cmd/project_skills.go
+++ b/cmd/project_skills.go
@@ -73,8 +73,9 @@ is the project name/slug/UUID and the second is the skill URI.
 Examples:
   scion project skills add skill://my-skill
   scion project skills add my-project skill://my-skill
-  scion project skills add my-project skill://my-skill@1.2 --as alias --optional`,
-	Args: cobra.RangeArgs(1, 2),
+  scion project skills add my-project skill://my-skill@1.2 --as alias --optional
+  scion project skills add --from-directory https://github.com/org/repo/tree/main/skills`,
+	Args: cobra.RangeArgs(0, 2),
 	RunE: runProjectSkillsAdd,
 }
 
@@ -102,6 +103,7 @@ Examples:
 var (
 	projectSkillsAs       string
 	projectSkillsOptional bool
+	projectSkillsFromDir  string
 )
 
 func init() {
@@ -112,6 +114,8 @@ func init() {
 
 	projectSkillsAddCmd.Flags().StringVar(&projectSkillsAs, "as", "", "Alias for the skill (SkillAs)")
 	projectSkillsAddCmd.Flags().BoolVar(&projectSkillsOptional, "optional", false, "Mark the skill as optional (failure does not abort provisioning)")
+	projectSkillsAddCmd.Flags().StringVar(&projectSkillsFromDir, "from-directory", "",
+		"GitHub directory URL to discover skills from (e.g. https://github.com/org/repo/tree/main/skills)")
 }
 
 // resolveProjectSkillsClient resolves a hub client and project ID from an
@@ -215,6 +219,16 @@ func runProjectSkillsList(cmd *cobra.Command, args []string) error {
 }
 
 func runProjectSkillsAdd(cmd *cobra.Command, args []string) error {
+	if projectSkillsFromDir != "" {
+		// Project arg may still be present (first positional).
+		projectArg, _ := splitProjectSkillsArgs(args)
+		return runProjectSkillsFromDirectory(cmd, projectArg, projectSkillsFromDir)
+	}
+
+	if len(args) == 0 {
+		return fmt.Errorf("skill URI or --from-directory is required")
+	}
+
 	projectArg, skillURI := splitProjectSkillsArgs(args)
 	if skillURI == "" {
 		return fmt.Errorf("skill URI is required (expected format containing ://), got %q", args[0])
@@ -342,4 +356,81 @@ func printSkillInjectionTable(entries []api.SkillInjectionEntry) {
 			e.ID, e.SkillURI, alias, optional, e.SortOrder, name)
 	}
 	_ = tw.Flush()
+}
+
+func runProjectSkillsFromDirectory(cmd *cobra.Command, projectArg, dirURL string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	hubCtx, err := CheckHubAvailabilityWithOptions(projectPath, true)
+	if err != nil || hubCtx == nil {
+		return fmt.Errorf("hub connection required: %w", err)
+	}
+
+	// Resolve project ID for auth token forwarding.
+	var projectID string
+	if projectArg != "" {
+		proj, err := resolveProjectByNameOrID(ctx, hubCtx.Client, projectArg)
+		if err != nil {
+			return fmt.Errorf("could not resolve project %q: %w", projectArg, err)
+		}
+		projectID = proj.ID
+	} else {
+		projectID, err = GetProjectID(hubCtx)
+		if err != nil {
+			return fmt.Errorf("could not determine project ID: %w", err)
+		}
+	}
+
+	// Discover skills.
+	result, err := hubCtx.Client.DiscoverSkillsDirectory(ctx, hubclient.DiscoverSkillsDirectoryRequest{
+		SourceURL: dirURL,
+		ProjectID: projectID,
+	})
+	if err != nil {
+		return fmt.Errorf("skill discovery failed: %w", err)
+	}
+	if len(result.Skills) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No skills found at the given URL.")
+		return nil
+	}
+
+	// Print discovered skills.
+	fmt.Fprintf(cmd.OutOrStdout(), "Discovered %d skill(s):\n", len(result.Skills))
+	for _, s := range result.Skills {
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s  (%s)\n", s.URI, s.Name)
+	}
+	if len(result.Skipped) > 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "  (%d folder(s) skipped: not recognized as skills)\n", len(result.Skipped))
+	}
+
+	// TTY: prompt unless --yes/--non-interactive.
+	if isInteractiveTerminal() && !autoConfirm {
+		fmt.Fprintf(cmd.OutOrStdout(), "Add all %d skill(s)? [Y/n] ", len(result.Skills))
+		var answer string
+		fmt.Fscan(cmd.InOrStdin(), &answer)
+		if answer != "" && strings.ToLower(answer) != "y" && strings.ToLower(answer) != "yes" {
+			fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+			return nil
+		}
+	}
+
+	// Add each skill.
+	svc := hubCtx.Client.ProjectInjectedSkills(projectID)
+	var addErrors []string
+	for _, s := range result.Skills {
+		_, err := svc.Add(ctx, &hubclient.AddInjectedSkillRequest{SkillURI: s.URI})
+		if err != nil {
+			addErrors = append(addErrors, fmt.Sprintf("%s: %v", s.Name, err))
+		}
+	}
+	if len(addErrors) > 0 {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %d of %d skills could not be added:\n", len(addErrors), len(result.Skills))
+		for _, e := range addErrors {
+			fmt.Fprintf(cmd.ErrOrStderr(), "  %s\n", e)
+		}
+	}
+	added := len(result.Skills) - len(addErrors)
+	fmt.Fprintf(cmd.OutOrStdout(), "Added %d of %d skill(s).\n", added, len(result.Skills))
+	return nil
 }

--- a/cmd/project_skills.go
+++ b/cmd/project_skills.go
@@ -400,7 +400,11 @@ func runProjectSkillsFromDirectory(cmd *cobra.Command, projectArg, dirURL string
 
 	// Resolve project ID for auth token forwarding.
 	// Fix 3: Use separate context for discover phase (30s).
-	discoverCtx, discoverCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	parentCtx := cmd.Context()
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	discoverCtx, discoverCancel := context.WithTimeout(parentCtx, 30*time.Second)
 	defer discoverCancel()
 
 	var projectID string
@@ -443,7 +447,7 @@ func runProjectSkillsFromDirectory(cmd *cobra.Command, projectArg, dirURL string
 	if isInteractiveTerminal() && !autoConfirm {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Add all %d skill(s)? [Y/n] ", len(result.Skills))
 		var answer string
-		_, _ = fmt.Fscan(cmd.InOrStdin(), &answer)
+		_, _ = fmt.Fscanln(cmd.InOrStdin(), &answer)
 		if answer != "" && strings.ToLower(answer) != "y" && strings.ToLower(answer) != "yes" {
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
 			return nil
@@ -451,7 +455,7 @@ func runProjectSkillsFromDirectory(cmd *cobra.Command, projectArg, dirURL string
 	}
 
 	// Fix 3: Fresh timeout for add phase (60s), starts after the user responds.
-	addCtx, addCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	addCtx, addCancel := context.WithTimeout(parentCtx, 60*time.Second)
 	defer addCancel()
 
 	// Add each skill.

--- a/cmd/project_skills.go
+++ b/cmd/project_skills.go
@@ -426,26 +426,26 @@ func runProjectSkillsFromDirectory(cmd *cobra.Command, projectArg, dirURL string
 		return fmt.Errorf("skill discovery failed: %w", err)
 	}
 	if len(result.Skills) == 0 {
-		fmt.Fprintln(cmd.OutOrStdout(), "No skills found at the given URL.")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No skills found at the given URL.")
 		return nil
 	}
 
 	// Print discovered skills.
-	fmt.Fprintf(cmd.OutOrStdout(), "Discovered %d skill(s):\n", len(result.Skills))
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Discovered %d skill(s):\n", len(result.Skills))
 	for _, s := range result.Skills {
-		fmt.Fprintf(cmd.OutOrStdout(), "  %s  (%s)\n", s.URI, s.Name)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s  (%s)\n", s.URI, s.Name)
 	}
 	if len(result.Skipped) > 0 {
-		fmt.Fprintf(cmd.OutOrStdout(), "  (%d folder(s) skipped: not recognized as skills)\n", len(result.Skipped))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  (%d folder(s) skipped: not recognized as skills)\n", len(result.Skipped))
 	}
 
 	// TTY: prompt unless --yes/--non-interactive.
 	if isInteractiveTerminal() && !autoConfirm {
-		fmt.Fprintf(cmd.OutOrStdout(), "Add all %d skill(s)? [Y/n] ", len(result.Skills))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Add all %d skill(s)? [Y/n] ", len(result.Skills))
 		var answer string
-		fmt.Fscan(cmd.InOrStdin(), &answer)
+		_, _ = fmt.Fscan(cmd.InOrStdin(), &answer)
 		if answer != "" && strings.ToLower(answer) != "y" && strings.ToLower(answer) != "yes" {
-			fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
 			return nil
 		}
 	}

--- a/cmd/project_skills.go
+++ b/cmd/project_skills.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -220,8 +221,13 @@ func runProjectSkillsList(cmd *cobra.Command, args []string) error {
 
 func runProjectSkillsAdd(cmd *cobra.Command, args []string) error {
 	if projectSkillsFromDir != "" {
-		// Project arg may still be present (first positional).
-		projectArg, _ := splitProjectSkillsArgs(args)
+		if projectSkillsAs != "" || projectSkillsOptional {
+			return fmt.Errorf("--as and --optional cannot be used with --from-directory (they apply only to single-skill add)")
+		}
+		projectArg, skillRef := splitProjectSkillsArgs(args)
+		if skillRef != "" {
+			return fmt.Errorf("cannot combine a skill URI argument with --from-directory; choose one")
+		}
 		return runProjectSkillsFromDirectory(cmd, projectArg, projectSkillsFromDir)
 	}
 
@@ -358,19 +364,48 @@ func printSkillInjectionTable(entries []api.SkillInjectionEntry) {
 	_ = tw.Flush()
 }
 
-func runProjectSkillsFromDirectory(cmd *cobra.Command, projectArg, dirURL string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
+// looksLikeGitHubDirectoryURL returns true if s appears to be a GitHub
+// directory URL of the form https://github.com/org/repo/tree/<ref>/...
+// This is a client-side pre-check; the server validates authoritatively.
+func looksLikeGitHubDirectoryURL(s string) bool {
+	u, err := url.Parse(s)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == "https" &&
+		strings.EqualFold(u.Host, "github.com") &&
+		strings.Contains(u.Path, "/tree/")
+}
 
+func runProjectSkillsFromDirectory(cmd *cobra.Command, projectArg, dirURL string) error {
+	// Fix 1: Strip userinfo (e.g. token:secret@) before sending.
+	if parsed, err := url.Parse(dirURL); err == nil && parsed.User != nil {
+		parsed.User = nil
+		dirURL = parsed.String()
+	}
+
+	// Fix 2: Client-side URL validation.
+	if !looksLikeGitHubDirectoryURL(dirURL) {
+		return fmt.Errorf("--from-directory must be an https://github.com/.../tree/<ref>/... URL")
+	}
+
+	// Fix 4: Split nil-error check.
 	hubCtx, err := CheckHubAvailabilityWithOptions(projectPath, true)
-	if err != nil || hubCtx == nil {
+	if err != nil {
 		return fmt.Errorf("hub connection required: %w", err)
+	}
+	if hubCtx == nil {
+		return fmt.Errorf("hub is not enabled; configure hub.endpoint to use project skills")
 	}
 
 	// Resolve project ID for auth token forwarding.
+	// Fix 3: Use separate context for discover phase (30s).
+	discoverCtx, discoverCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer discoverCancel()
+
 	var projectID string
 	if projectArg != "" {
-		proj, err := resolveProjectByNameOrID(ctx, hubCtx.Client, projectArg)
+		proj, err := resolveProjectByNameOrID(discoverCtx, hubCtx.Client, projectArg)
 		if err != nil {
 			return fmt.Errorf("could not resolve project %q: %w", projectArg, err)
 		}
@@ -383,7 +418,7 @@ func runProjectSkillsFromDirectory(cmd *cobra.Command, projectArg, dirURL string
 	}
 
 	// Discover skills.
-	result, err := hubCtx.Client.DiscoverSkillsDirectory(ctx, hubclient.DiscoverSkillsDirectoryRequest{
+	result, err := hubCtx.Client.DiscoverSkillsDirectory(discoverCtx, hubclient.DiscoverSkillsDirectoryRequest{
 		SourceURL: dirURL,
 		ProjectID: projectID,
 	})
@@ -415,11 +450,15 @@ func runProjectSkillsFromDirectory(cmd *cobra.Command, projectArg, dirURL string
 		}
 	}
 
+	// Fix 3: Fresh timeout for add phase (60s), starts after the user responds.
+	addCtx, addCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer addCancel()
+
 	// Add each skill.
 	svc := hubCtx.Client.ProjectInjectedSkills(projectID)
 	var addErrors []string
 	for _, s := range result.Skills {
-		_, err := svc.Add(ctx, &hubclient.AddInjectedSkillRequest{SkillURI: s.URI})
+		_, err := svc.Add(addCtx, &hubclient.AddInjectedSkillRequest{SkillURI: s.URI})
 		if err != nil {
 			addErrors = append(addErrors, fmt.Sprintf("%s: %v", s.Name, err))
 		}
@@ -432,5 +471,11 @@ func runProjectSkillsFromDirectory(cmd *cobra.Command, projectArg, dirURL string
 	}
 	added := len(result.Skills) - len(addErrors)
 	fmt.Fprintf(cmd.OutOrStdout(), "Added %d of %d skill(s).\n", added, len(result.Skills))
+
+	// Fix 6: Return error when all adds fail.
+	if added == 0 && len(result.Skills) > 0 {
+		return fmt.Errorf("all %d skill(s) failed to add", len(result.Skills))
+	}
+
 	return nil
 }

--- a/cmd/project_skills_test.go
+++ b/cmd/project_skills_test.go
@@ -773,10 +773,10 @@ func TestRunProjectSkillsFromDirectory_PartialFailure(t *testing.T) {
 func TestRunProjectSkillsFromDirectory_DiscoverError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.URL.Path == "/healthz":
+		switch r.URL.Path {
+		case "/healthz":
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
-		case r.URL.Path == "/api/v1/skills/discover-directory":
+		case "/api/v1/skills/discover-directory":
 			w.WriteHeader(http.StatusInternalServerError)
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"code":    "internal_error",

--- a/cmd/project_skills_test.go
+++ b/cmd/project_skills_test.go
@@ -15,11 +15,14 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -523,4 +526,246 @@ func TestRunProjectSkillsList_APIError(t *testing.T) {
 func TestPrintSkillInjectionTable_NoOutput(t *testing.T) {
 	// Smoke test — should not panic on empty list.
 	printSkillInjectionTable(nil)
+}
+
+// =============================================================================
+// --from-directory tests
+// =============================================================================
+
+func TestProjectSkillsAddCmd_FromDirectoryFlag(t *testing.T) {
+	f := projectSkillsAddCmd.Flags().Lookup("from-directory")
+	assert.NotNil(t, f, "add command should have --from-directory flag")
+	assert.Equal(t, "string", f.Value.Type())
+}
+
+// newProjectFromDirMockServer returns a mock hub that handles discover-directory
+// and injected-skills add endpoints. addCalls tracks how many add POSTs were made.
+func newProjectFromDirMockServer(t *testing.T, skills []map[string]interface{}, addCalls *atomic.Int32, failSecondAdd bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+
+		case r.URL.Path == "/api/v1/projects/"+testProjectID && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":   testProjectID,
+				"name": "test-project",
+				"slug": "test-project",
+			})
+
+		case r.URL.Path == "/api/v1/skills/discover-directory" && r.Method == http.MethodPost:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"skills":  skills,
+				"count":   len(skills),
+				"skipped": []string{},
+			})
+
+		case strings.HasSuffix(r.URL.Path, "/injected-skills") && r.Method == http.MethodPost:
+			n := addCalls.Add(1)
+			if failSecondAdd && n == 2 {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"code":    "bad_request",
+					"message": "skill already exists",
+				})
+				return
+			}
+			var req map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":       "new-entry-uuid",
+				"skillUri": req["skillUri"],
+			})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"code":    "not_found",
+				"message": "not found",
+			})
+		}
+	}))
+}
+
+func TestRunProjectSkillsFromDirectory_NonTTY_AddsAll(t *testing.T) {
+	skills := []map[string]interface{}{
+		{"uri": "skill://org/skill-a", "name": "skill-a"},
+		{"uri": "skill://org/skill-b", "name": "skill-b"},
+	}
+	var addCalls atomic.Int32
+	server := newProjectFromDirMockServer(t, skills, &addCalls, false)
+	defer server.Close()
+	setProjectSkillsHubEnv(t, server.URL)
+
+	orig := projectPath
+	defer func() { projectPath = orig }()
+	projectDir := setupProjectSkillsProject(t, server.URL)
+	projectPath = projectDir
+
+	origInteractive := isInteractiveTerminal
+	defer func() { isInteractiveTerminal = origInteractive }()
+	isInteractiveTerminal = func() bool { return false }
+
+	var buf bytes.Buffer
+	projectSkillsAddCmd.SetOut(&buf)
+	defer projectSkillsAddCmd.SetOut(nil)
+
+	err := runProjectSkillsFromDirectory(projectSkillsAddCmd, "", "https://github.com/org/repo/tree/main/skills")
+	assert.NoError(t, err)
+	assert.Equal(t, int32(2), addCalls.Load())
+	assert.Contains(t, buf.String(), "Added 2 of 2")
+}
+
+func TestRunProjectSkillsFromDirectory_TTY_Yes_AddsAll(t *testing.T) {
+	skills := []map[string]interface{}{
+		{"uri": "skill://org/skill-a", "name": "skill-a"},
+		{"uri": "skill://org/skill-b", "name": "skill-b"},
+	}
+	var addCalls atomic.Int32
+	server := newProjectFromDirMockServer(t, skills, &addCalls, false)
+	defer server.Close()
+	setProjectSkillsHubEnv(t, server.URL)
+
+	orig := projectPath
+	defer func() { projectPath = orig }()
+	projectDir := setupProjectSkillsProject(t, server.URL)
+	projectPath = projectDir
+
+	origInteractive := isInteractiveTerminal
+	defer func() { isInteractiveTerminal = origInteractive }()
+	isInteractiveTerminal = func() bool { return true }
+
+	origAutoConfirm := autoConfirm
+	defer func() { autoConfirm = origAutoConfirm }()
+	autoConfirm = true
+
+	var buf bytes.Buffer
+	projectSkillsAddCmd.SetOut(&buf)
+	defer projectSkillsAddCmd.SetOut(nil)
+
+	err := runProjectSkillsFromDirectory(projectSkillsAddCmd, "", "https://github.com/org/repo/tree/main/skills")
+	assert.NoError(t, err)
+	assert.Equal(t, int32(2), addCalls.Load())
+	assert.Contains(t, buf.String(), "Added 2 of 2")
+}
+
+func TestRunProjectSkillsFromDirectory_TTY_Abort(t *testing.T) {
+	skills := []map[string]interface{}{
+		{"uri": "skill://org/skill-a", "name": "skill-a"},
+	}
+	var addCalls atomic.Int32
+	server := newProjectFromDirMockServer(t, skills, &addCalls, false)
+	defer server.Close()
+	setProjectSkillsHubEnv(t, server.URL)
+
+	orig := projectPath
+	defer func() { projectPath = orig }()
+	projectDir := setupProjectSkillsProject(t, server.URL)
+	projectPath = projectDir
+
+	origInteractive := isInteractiveTerminal
+	defer func() { isInteractiveTerminal = origInteractive }()
+	isInteractiveTerminal = func() bool { return true }
+
+	origAutoConfirm := autoConfirm
+	defer func() { autoConfirm = origAutoConfirm }()
+	autoConfirm = false
+
+	var buf bytes.Buffer
+	projectSkillsAddCmd.SetOut(&buf)
+	defer projectSkillsAddCmd.SetOut(nil)
+	projectSkillsAddCmd.SetIn(strings.NewReader("n\n"))
+	defer projectSkillsAddCmd.SetIn(nil)
+
+	err := runProjectSkillsFromDirectory(projectSkillsAddCmd, "", "https://github.com/org/repo/tree/main/skills")
+	assert.NoError(t, err)
+	assert.Equal(t, int32(0), addCalls.Load())
+	assert.Contains(t, buf.String(), "Aborted")
+}
+
+func TestRunProjectSkillsFromDirectory_NoSkills(t *testing.T) {
+	skills := []map[string]interface{}{}
+	var addCalls atomic.Int32
+	server := newProjectFromDirMockServer(t, skills, &addCalls, false)
+	defer server.Close()
+	setProjectSkillsHubEnv(t, server.URL)
+
+	orig := projectPath
+	defer func() { projectPath = orig }()
+	projectDir := setupProjectSkillsProject(t, server.URL)
+	projectPath = projectDir
+
+	var buf bytes.Buffer
+	projectSkillsAddCmd.SetOut(&buf)
+	defer projectSkillsAddCmd.SetOut(nil)
+
+	err := runProjectSkillsFromDirectory(projectSkillsAddCmd, "", "https://github.com/org/repo/tree/main/empty")
+	assert.NoError(t, err)
+	assert.Equal(t, int32(0), addCalls.Load())
+	assert.Contains(t, buf.String(), "No skills found")
+}
+
+func TestRunProjectSkillsFromDirectory_PartialFailure(t *testing.T) {
+	skills := []map[string]interface{}{
+		{"uri": "skill://org/skill-a", "name": "skill-a"},
+		{"uri": "skill://org/skill-b", "name": "skill-b"},
+	}
+	var addCalls atomic.Int32
+	server := newProjectFromDirMockServer(t, skills, &addCalls, true) // second add fails
+	defer server.Close()
+	setProjectSkillsHubEnv(t, server.URL)
+
+	orig := projectPath
+	defer func() { projectPath = orig }()
+	projectDir := setupProjectSkillsProject(t, server.URL)
+	projectPath = projectDir
+
+	origInteractive := isInteractiveTerminal
+	defer func() { isInteractiveTerminal = origInteractive }()
+	isInteractiveTerminal = func() bool { return false }
+
+	var outBuf bytes.Buffer
+	var errBuf bytes.Buffer
+	projectSkillsAddCmd.SetOut(&outBuf)
+	projectSkillsAddCmd.SetErr(&errBuf)
+	defer projectSkillsAddCmd.SetOut(nil)
+	defer projectSkillsAddCmd.SetErr(nil)
+
+	err := runProjectSkillsFromDirectory(projectSkillsAddCmd, "", "https://github.com/org/repo/tree/main/skills")
+	assert.NoError(t, err)
+	assert.Contains(t, outBuf.String(), "Added 1 of 2")
+	assert.Contains(t, errBuf.String(), "Warning: 1 of 2 skills could not be added")
+}
+
+func TestRunProjectSkillsFromDirectory_DiscoverError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/healthz":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+		case r.URL.Path == "/api/v1/skills/discover-directory":
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"code":    "internal_error",
+				"message": "internal server error",
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	setProjectSkillsHubEnv(t, server.URL)
+
+	orig := projectPath
+	defer func() { projectPath = orig }()
+	projectDir := setupProjectSkillsProject(t, server.URL)
+	projectPath = projectDir
+
+	err := runProjectSkillsFromDirectory(projectSkillsAddCmd, "", "https://github.com/org/repo/tree/main/skills")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "skill discovery failed")
 }

--- a/cmd/project_skills_test.go
+++ b/cmd/project_skills_test.go
@@ -30,6 +30,35 @@ import (
 )
 
 // =============================================================================
+// Tests for looksLikeGitHubDirectoryURL
+// =============================================================================
+
+func TestLooksLikeGitHubDirectoryURL(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"valid directory URL", "https://github.com/org/repo/tree/main/skills", true},
+		{"valid with nested path", "https://github.com/org/repo/tree/v1.0/skills/sub", true},
+		{"valid with uppercase host", "https://GitHub.com/org/repo/tree/main/skills", true},
+		{"missing tree segment", "https://github.com/org/repo/blob/main/file.go", false},
+		{"not github host", "https://gitlab.com/org/repo/tree/main/skills", false},
+		{"http scheme", "http://github.com/org/repo/tree/main/skills", false},
+		{"ftp scheme", "ftp://github.com/org/repo/tree/main/skills", false},
+		{"bare path", "/home/user/skills", false},
+		{"empty string", "", false},
+		{"skill URI", "skill://my-skill", false},
+		{"invalid URL", "://bad", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, looksLikeGitHubDirectoryURL(c.input))
+		})
+	}
+}
+
+// =============================================================================
 // Unit tests for pure helper functions (no network, no Hub)
 // =============================================================================
 
@@ -768,4 +797,181 @@ func TestRunProjectSkillsFromDirectory_DiscoverError(t *testing.T) {
 	err := runProjectSkillsFromDirectory(projectSkillsAddCmd, "", "https://github.com/org/repo/tree/main/skills")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "skill discovery failed")
+}
+
+func TestRunProjectSkillsFromDirectory_StripsUserinfo(t *testing.T) {
+	var receivedSourceURL string
+	skills := []map[string]interface{}{
+		{"uri": "skill://org/skill-a", "name": "skill-a"},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+
+		case r.URL.Path == "/api/v1/projects/"+testProjectID && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":   testProjectID,
+				"name": "test-project",
+				"slug": "test-project",
+			})
+
+		case r.URL.Path == "/api/v1/skills/discover-directory" && r.Method == http.MethodPost:
+			var req map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			receivedSourceURL, _ = req["sourceUrl"].(string)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"skills":  skills,
+				"count":   len(skills),
+				"skipped": []string{},
+			})
+
+		case strings.HasSuffix(r.URL.Path, "/injected-skills") && r.Method == http.MethodPost:
+			var req map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":       "new-entry-uuid",
+				"skillUri": req["skillUri"],
+			})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	setProjectSkillsHubEnv(t, server.URL)
+
+	orig := projectPath
+	defer func() { projectPath = orig }()
+	projectDir := setupProjectSkillsProject(t, server.URL)
+	projectPath = projectDir
+
+	origInteractive := isInteractiveTerminal
+	defer func() { isInteractiveTerminal = origInteractive }()
+	isInteractiveTerminal = func() bool { return false }
+
+	var buf bytes.Buffer
+	projectSkillsAddCmd.SetOut(&buf)
+	defer projectSkillsAddCmd.SetOut(nil)
+
+	err := runProjectSkillsFromDirectory(projectSkillsAddCmd, "",
+		"https://token:secret@github.com/org/repo/tree/main/skills")
+	assert.NoError(t, err)
+	assert.NotContains(t, receivedSourceURL, "token")
+	assert.NotContains(t, receivedSourceURL, "secret")
+	assert.Contains(t, receivedSourceURL, "github.com/org/repo/tree/main/skills")
+}
+
+func TestRunProjectSkillsFromDirectory_InvalidURL(t *testing.T) {
+	err := runProjectSkillsFromDirectory(projectSkillsAddCmd, "", "ftp://example.com/skills")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--from-directory must be an https://github.com/")
+}
+
+func TestRunProjectSkillsAdd_FromDirConflictWithAs(t *testing.T) {
+	origFromDir := projectSkillsFromDir
+	origAs := projectSkillsAs
+	defer func() {
+		projectSkillsFromDir = origFromDir
+		projectSkillsAs = origAs
+	}()
+	projectSkillsFromDir = "https://github.com/org/repo/tree/main/skills"
+	projectSkillsAs = "my-alias"
+
+	err := runProjectSkillsAdd(projectSkillsAddCmd, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--as and --optional cannot be used with --from-directory")
+}
+
+func TestRunProjectSkillsAdd_FromDirConflictWithOptional(t *testing.T) {
+	origFromDir := projectSkillsFromDir
+	origOpt := projectSkillsOptional
+	defer func() {
+		projectSkillsFromDir = origFromDir
+		projectSkillsOptional = origOpt
+	}()
+	projectSkillsFromDir = "https://github.com/org/repo/tree/main/skills"
+	projectSkillsOptional = true
+
+	err := runProjectSkillsAdd(projectSkillsAddCmd, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--as and --optional cannot be used with --from-directory")
+}
+
+func TestRunProjectSkillsAdd_FromDirConflictWithSkillURI(t *testing.T) {
+	origFromDir := projectSkillsFromDir
+	defer func() { projectSkillsFromDir = origFromDir }()
+	projectSkillsFromDir = "https://github.com/org/repo/tree/main/skills"
+
+	err := runProjectSkillsAdd(projectSkillsAddCmd, []string{"skill://foo"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot combine a skill URI argument with --from-directory")
+}
+
+func TestRunProjectSkillsFromDirectory_TotalFailure(t *testing.T) {
+	skills := []map[string]interface{}{
+		{"uri": "skill://org/skill-a", "name": "skill-a"},
+		{"uri": "skill://org/skill-b", "name": "skill-b"},
+	}
+	var addCalls atomic.Int32
+	// Server that fails ALL add calls.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+
+		case r.URL.Path == "/api/v1/projects/"+testProjectID && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":   testProjectID,
+				"name": "test-project",
+				"slug": "test-project",
+			})
+
+		case r.URL.Path == "/api/v1/skills/discover-directory" && r.Method == http.MethodPost:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"skills":  skills,
+				"count":   len(skills),
+				"skipped": []string{},
+			})
+
+		case strings.HasSuffix(r.URL.Path, "/injected-skills") && r.Method == http.MethodPost:
+			addCalls.Add(1)
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"code":    "bad_request",
+				"message": "skill already exists",
+			})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	setProjectSkillsHubEnv(t, server.URL)
+
+	orig := projectPath
+	defer func() { projectPath = orig }()
+	projectDir := setupProjectSkillsProject(t, server.URL)
+	projectPath = projectDir
+
+	origInteractive := isInteractiveTerminal
+	defer func() { isInteractiveTerminal = origInteractive }()
+	isInteractiveTerminal = func() bool { return false }
+
+	var outBuf bytes.Buffer
+	var errBuf bytes.Buffer
+	projectSkillsAddCmd.SetOut(&outBuf)
+	projectSkillsAddCmd.SetErr(&errBuf)
+	defer projectSkillsAddCmd.SetOut(nil)
+	defer projectSkillsAddCmd.SetErr(nil)
+
+	err := runProjectSkillsFromDirectory(projectSkillsAddCmd, "", "https://github.com/org/repo/tree/main/skills")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "all 2 skill(s) failed to add")
+	assert.Equal(t, int32(2), addCalls.Load())
 }

--- a/cmd/user_skills.go
+++ b/cmd/user_skills.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
@@ -67,8 +68,9 @@ var userSkillsAddCmd = &cobra.Command{
 
 Examples:
   scion user skills add skill://my-skill
-  scion user skills add skill://my-skill@1.2 --as alias --optional`,
-	Args: cobra.ExactArgs(1),
+  scion user skills add skill://my-skill@1.2 --as alias --optional
+  scion user skills add --from-directory https://github.com/org/repo/tree/main/skills`,
+	Args: cobra.RangeArgs(0, 1),
 	RunE: runUserSkillsAdd,
 }
 
@@ -92,6 +94,7 @@ Examples:
 var (
 	userSkillsAs       string
 	userSkillsOptional bool
+	userSkillsFromDir  string
 )
 
 func init() {
@@ -103,6 +106,8 @@ func init() {
 
 	userSkillsAddCmd.Flags().StringVar(&userSkillsAs, "as", "", "Alias for the skill (SkillAs)")
 	userSkillsAddCmd.Flags().BoolVar(&userSkillsOptional, "optional", false, "Mark the skill as optional (failure does not abort provisioning)")
+	userSkillsAddCmd.Flags().StringVar(&userSkillsFromDir, "from-directory", "",
+		"GitHub directory URL to discover skills from")
 }
 
 // resolveUserSkillsService returns an InjectedSkillsService for the current user.
@@ -145,6 +150,14 @@ func runUserSkillsList(cmd *cobra.Command, args []string) error {
 }
 
 func runUserSkillsAdd(cmd *cobra.Command, args []string) error {
+	if userSkillsFromDir != "" {
+		return runUserSkillsFromDirectory(cmd, userSkillsFromDir)
+	}
+
+	if len(args) == 0 {
+		return fmt.Errorf("skill URI or --from-directory is required")
+	}
+
 	skillURI := args[0]
 
 	normalized, err := api.NormalizeSkillURI(skillURI)
@@ -215,5 +228,63 @@ func runUserSkillsRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Removed injected skill (ID: %s)\n", entryID)
+	return nil
+}
+
+func runUserSkillsFromDirectory(cmd *cobra.Command, dirURL string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	hubCtx, err := CheckHubAvailabilityWithOptions(projectPath, true)
+	if err != nil || hubCtx == nil {
+		return fmt.Errorf("hub connection required: %w", err)
+	}
+
+	result, err := hubCtx.Client.DiscoverSkillsDirectory(ctx, hubclient.DiscoverSkillsDirectoryRequest{
+		SourceURL: dirURL,
+		// No ProjectID for user scope.
+	})
+	if err != nil {
+		return fmt.Errorf("skill discovery failed: %w", err)
+	}
+	if len(result.Skills) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No skills found at the given URL.")
+		return nil
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Discovered %d skill(s):\n", len(result.Skills))
+	for _, s := range result.Skills {
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s  (%s)\n", s.URI, s.Name)
+	}
+	if len(result.Skipped) > 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "  (%d folder(s) skipped)\n", len(result.Skipped))
+	}
+
+	if isInteractiveTerminal() && !autoConfirm {
+		fmt.Fprintf(cmd.OutOrStdout(), "Add all %d skill(s)? [Y/n] ", len(result.Skills))
+		var answer string
+		fmt.Fscan(cmd.InOrStdin(), &answer)
+		if answer != "" && strings.ToLower(answer) != "y" && strings.ToLower(answer) != "yes" {
+			fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+			return nil
+		}
+	}
+
+	svc := hubCtx.Client.UserInjectedSkills()
+	var addErrors []string
+	for _, s := range result.Skills {
+		_, err := svc.Add(ctx, &hubclient.AddInjectedSkillRequest{SkillURI: s.URI})
+		if err != nil {
+			addErrors = append(addErrors, fmt.Sprintf("%s: %v", s.Name, err))
+		}
+	}
+	if len(addErrors) > 0 {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %d of %d skills could not be added:\n", len(addErrors), len(result.Skills))
+		for _, e := range addErrors {
+			fmt.Fprintf(cmd.ErrOrStderr(), "  %s\n", e)
+		}
+	}
+	added := len(result.Skills) - len(addErrors)
+	fmt.Fprintf(cmd.OutOrStdout(), "Added %d of %d skill(s).\n", added, len(result.Skills))
 	return nil
 }

--- a/cmd/user_skills.go
+++ b/cmd/user_skills.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -151,6 +152,9 @@ func runUserSkillsList(cmd *cobra.Command, args []string) error {
 
 func runUserSkillsAdd(cmd *cobra.Command, args []string) error {
 	if userSkillsFromDir != "" {
+		if userSkillsAs != "" || userSkillsOptional {
+			return fmt.Errorf("--as and --optional cannot be used with --from-directory (they apply only to single-skill add)")
+		}
 		return runUserSkillsFromDirectory(cmd, userSkillsFromDir)
 	}
 
@@ -232,15 +236,31 @@ func runUserSkillsRemove(cmd *cobra.Command, args []string) error {
 }
 
 func runUserSkillsFromDirectory(cmd *cobra.Command, dirURL string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	hubCtx, err := CheckHubAvailabilityWithOptions(projectPath, true)
-	if err != nil || hubCtx == nil {
-		return fmt.Errorf("hub connection required: %w", err)
+	// Fix 1: Strip userinfo (e.g. token:secret@) before sending.
+	if parsed, err := url.Parse(dirURL); err == nil && parsed.User != nil {
+		parsed.User = nil
+		dirURL = parsed.String()
 	}
 
-	result, err := hubCtx.Client.DiscoverSkillsDirectory(ctx, hubclient.DiscoverSkillsDirectoryRequest{
+	// Fix 2: Client-side URL validation.
+	if !looksLikeGitHubDirectoryURL(dirURL) {
+		return fmt.Errorf("--from-directory must be an https://github.com/.../tree/<ref>/... URL")
+	}
+
+	// Fix 4: Split nil-error check.
+	hubCtx, err := CheckHubAvailabilityWithOptions(projectPath, true)
+	if err != nil {
+		return fmt.Errorf("hub connection required: %w", err)
+	}
+	if hubCtx == nil {
+		return fmt.Errorf("hub is not enabled; configure hub.endpoint to use user skills")
+	}
+
+	// Fix 3: Separate context for discover phase (30s).
+	discoverCtx, discoverCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer discoverCancel()
+
+	result, err := hubCtx.Client.DiscoverSkillsDirectory(discoverCtx, hubclient.DiscoverSkillsDirectoryRequest{
 		SourceURL: dirURL,
 		// No ProjectID for user scope.
 	})
@@ -270,10 +290,14 @@ func runUserSkillsFromDirectory(cmd *cobra.Command, dirURL string) error {
 		}
 	}
 
+	// Fix 3: Fresh timeout for add phase (60s), starts after the user responds.
+	addCtx, addCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer addCancel()
+
 	svc := hubCtx.Client.UserInjectedSkills()
 	var addErrors []string
 	for _, s := range result.Skills {
-		_, err := svc.Add(ctx, &hubclient.AddInjectedSkillRequest{SkillURI: s.URI})
+		_, err := svc.Add(addCtx, &hubclient.AddInjectedSkillRequest{SkillURI: s.URI})
 		if err != nil {
 			addErrors = append(addErrors, fmt.Sprintf("%s: %v", s.Name, err))
 		}
@@ -286,5 +310,11 @@ func runUserSkillsFromDirectory(cmd *cobra.Command, dirURL string) error {
 	}
 	added := len(result.Skills) - len(addErrors)
 	fmt.Fprintf(cmd.OutOrStdout(), "Added %d of %d skill(s).\n", added, len(result.Skills))
+
+	// Fix 6: Return error when all adds fail.
+	if added == 0 && len(result.Skills) > 0 {
+		return fmt.Errorf("all %d skill(s) failed to add", len(result.Skills))
+	}
+
 	return nil
 }

--- a/cmd/user_skills.go
+++ b/cmd/user_skills.go
@@ -271,24 +271,24 @@ func runUserSkillsFromDirectory(cmd *cobra.Command, dirURL string) error {
 		return fmt.Errorf("skill discovery failed: %w", err)
 	}
 	if len(result.Skills) == 0 {
-		fmt.Fprintln(cmd.OutOrStdout(), "No skills found at the given URL.")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No skills found at the given URL.")
 		return nil
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "Discovered %d skill(s):\n", len(result.Skills))
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Discovered %d skill(s):\n", len(result.Skills))
 	for _, s := range result.Skills {
-		fmt.Fprintf(cmd.OutOrStdout(), "  %s  (%s)\n", s.URI, s.Name)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s  (%s)\n", s.URI, s.Name)
 	}
 	if len(result.Skipped) > 0 {
-		fmt.Fprintf(cmd.OutOrStdout(), "  (%d folder(s) skipped)\n", len(result.Skipped))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  (%d folder(s) skipped)\n", len(result.Skipped))
 	}
 
 	if isInteractiveTerminal() && !autoConfirm {
-		fmt.Fprintf(cmd.OutOrStdout(), "Add all %d skill(s)? [Y/n] ", len(result.Skills))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Add all %d skill(s)? [Y/n] ", len(result.Skills))
 		var answer string
-		fmt.Fscan(cmd.InOrStdin(), &answer)
+		_, _ = fmt.Fscan(cmd.InOrStdin(), &answer)
 		if answer != "" && strings.ToLower(answer) != "y" && strings.ToLower(answer) != "yes" {
-			fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
 			return nil
 		}
 	}

--- a/cmd/user_skills.go
+++ b/cmd/user_skills.go
@@ -155,6 +155,9 @@ func runUserSkillsAdd(cmd *cobra.Command, args []string) error {
 		if userSkillsAs != "" || userSkillsOptional {
 			return fmt.Errorf("--as and --optional cannot be used with --from-directory (they apply only to single-skill add)")
 		}
+		if len(args) > 0 {
+			return fmt.Errorf("cannot combine a skill URI argument with --from-directory; choose one")
+		}
 		return runUserSkillsFromDirectory(cmd, userSkillsFromDir)
 	}
 

--- a/cmd/user_skills.go
+++ b/cmd/user_skills.go
@@ -260,7 +260,11 @@ func runUserSkillsFromDirectory(cmd *cobra.Command, dirURL string) error {
 	}
 
 	// Fix 3: Separate context for discover phase (30s).
-	discoverCtx, discoverCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	parentCtx := cmd.Context()
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	discoverCtx, discoverCancel := context.WithTimeout(parentCtx, 30*time.Second)
 	defer discoverCancel()
 
 	result, err := hubCtx.Client.DiscoverSkillsDirectory(discoverCtx, hubclient.DiscoverSkillsDirectoryRequest{
@@ -286,7 +290,7 @@ func runUserSkillsFromDirectory(cmd *cobra.Command, dirURL string) error {
 	if isInteractiveTerminal() && !autoConfirm {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Add all %d skill(s)? [Y/n] ", len(result.Skills))
 		var answer string
-		_, _ = fmt.Fscan(cmd.InOrStdin(), &answer)
+		_, _ = fmt.Fscanln(cmd.InOrStdin(), &answer)
 		if answer != "" && strings.ToLower(answer) != "y" && strings.ToLower(answer) != "yes" {
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
 			return nil
@@ -294,7 +298,7 @@ func runUserSkillsFromDirectory(cmd *cobra.Command, dirURL string) error {
 	}
 
 	// Fix 3: Fresh timeout for add phase (60s), starts after the user responds.
-	addCtx, addCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	addCtx, addCancel := context.WithTimeout(parentCtx, 60*time.Second)
 	defer addCancel()
 
 	svc := hubCtx.Client.UserInjectedSkills()

--- a/cmd/user_skills.go
+++ b/cmd/user_skills.go
@@ -306,13 +306,13 @@ func runUserSkillsFromDirectory(cmd *cobra.Command, dirURL string) error {
 		}
 	}
 	if len(addErrors) > 0 {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %d of %d skills could not be added:\n", len(addErrors), len(result.Skills))
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %d of %d skills could not be added:\n", len(addErrors), len(result.Skills))
 		for _, e := range addErrors {
-			fmt.Fprintf(cmd.ErrOrStderr(), "  %s\n", e)
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  %s\n", e)
 		}
 	}
 	added := len(result.Skills) - len(addErrors)
-	fmt.Fprintf(cmd.OutOrStdout(), "Added %d of %d skill(s).\n", added, len(result.Skills))
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Added %d of %d skill(s).\n", added, len(result.Skills))
 
 	// Fix 6: Return error when all adds fail.
 	if added == 0 && len(result.Skills) > 0 {

--- a/cmd/user_skills_test.go
+++ b/cmd/user_skills_test.go
@@ -15,11 +15,14 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -389,6 +392,190 @@ func TestRunUserSkillsRemove_URINotFound(t *testing.T) {
 	err := runUserSkillsRemove(userSkillsRemoveCmd, []string{"skill://nonexistent"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no injected skill with URI")
+}
+
+// =============================================================================
+// --from-directory tests
+// =============================================================================
+
+func TestUserSkillsAddCmd_FromDirectoryFlag(t *testing.T) {
+	f := userSkillsAddCmd.Flags().Lookup("from-directory")
+	assert.NotNil(t, f, "add command should have --from-directory flag")
+	assert.Equal(t, "string", f.Value.Type())
+}
+
+// newUserFromDirMockServer returns a mock hub that handles discover-directory
+// and user injected-skills add endpoints.
+func newUserFromDirMockServer(t *testing.T, skills []map[string]interface{}, addCalls *atomic.Int32, failSecondAdd bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+
+		case r.URL.Path == "/api/v1/skills/discover-directory" && r.Method == http.MethodPost:
+			// Verify no projectId for user scope.
+			var req map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			if _, ok := req["projectId"]; ok && req["projectId"] != "" {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"code":    "bad_request",
+					"message": "unexpected projectId in user-scope discover",
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"skills":  skills,
+				"count":   len(skills),
+				"skipped": []string{},
+			})
+
+		case r.URL.Path == "/api/v1/users/me/injected-skills" && r.Method == http.MethodPost:
+			n := addCalls.Add(1)
+			if failSecondAdd && n == 2 {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"code":    "bad_request",
+					"message": "skill already exists",
+				})
+				return
+			}
+			var req map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":       "new-user-entry-uuid",
+				"skillUri": req["skillUri"],
+			})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"code":    "not_found",
+				"message": "not found",
+			})
+		}
+	}))
+}
+
+func TestRunUserSkillsFromDirectory_NonTTY_AddsAll(t *testing.T) {
+	skills := []map[string]interface{}{
+		{"uri": "skill://org/skill-a", "name": "skill-a"},
+		{"uri": "skill://org/skill-b", "name": "skill-b"},
+	}
+	var addCalls atomic.Int32
+	server := newUserFromDirMockServer(t, skills, &addCalls, false)
+	defer server.Close()
+	setUserSkillsHubEnv(t, server.URL)
+
+	orig := projectPath
+	defer func() { projectPath = orig }()
+	_, projectDir := setupUserSkillsProject(t, server.URL)
+	projectPath = projectDir
+
+	origInteractive := isInteractiveTerminal
+	defer func() { isInteractiveTerminal = origInteractive }()
+	isInteractiveTerminal = func() bool { return false }
+
+	var buf bytes.Buffer
+	userSkillsAddCmd.SetOut(&buf)
+	defer userSkillsAddCmd.SetOut(nil)
+
+	err := runUserSkillsFromDirectory(userSkillsAddCmd, "https://github.com/org/repo/tree/main/skills")
+	assert.NoError(t, err)
+	assert.Equal(t, int32(2), addCalls.Load())
+	assert.Contains(t, buf.String(), "Added 2 of 2")
+}
+
+func TestRunUserSkillsFromDirectory_TTY_Abort(t *testing.T) {
+	skills := []map[string]interface{}{
+		{"uri": "skill://org/skill-a", "name": "skill-a"},
+	}
+	var addCalls atomic.Int32
+	server := newUserFromDirMockServer(t, skills, &addCalls, false)
+	defer server.Close()
+	setUserSkillsHubEnv(t, server.URL)
+
+	orig := projectPath
+	defer func() { projectPath = orig }()
+	_, projectDir := setupUserSkillsProject(t, server.URL)
+	projectPath = projectDir
+
+	origInteractive := isInteractiveTerminal
+	defer func() { isInteractiveTerminal = origInteractive }()
+	isInteractiveTerminal = func() bool { return true }
+
+	origAutoConfirm := autoConfirm
+	defer func() { autoConfirm = origAutoConfirm }()
+	autoConfirm = false
+
+	var buf bytes.Buffer
+	userSkillsAddCmd.SetOut(&buf)
+	defer userSkillsAddCmd.SetOut(nil)
+	userSkillsAddCmd.SetIn(strings.NewReader("n\n"))
+	defer userSkillsAddCmd.SetIn(nil)
+
+	err := runUserSkillsFromDirectory(userSkillsAddCmd, "https://github.com/org/repo/tree/main/skills")
+	assert.NoError(t, err)
+	assert.Equal(t, int32(0), addCalls.Load())
+	assert.Contains(t, buf.String(), "Aborted")
+}
+
+func TestRunUserSkillsFromDirectory_NoSkills(t *testing.T) {
+	skills := []map[string]interface{}{}
+	var addCalls atomic.Int32
+	server := newUserFromDirMockServer(t, skills, &addCalls, false)
+	defer server.Close()
+	setUserSkillsHubEnv(t, server.URL)
+
+	orig := projectPath
+	defer func() { projectPath = orig }()
+	_, projectDir := setupUserSkillsProject(t, server.URL)
+	projectPath = projectDir
+
+	var buf bytes.Buffer
+	userSkillsAddCmd.SetOut(&buf)
+	defer userSkillsAddCmd.SetOut(nil)
+
+	err := runUserSkillsFromDirectory(userSkillsAddCmd, "https://github.com/org/repo/tree/main/empty")
+	assert.NoError(t, err)
+	assert.Equal(t, int32(0), addCalls.Load())
+	assert.Contains(t, buf.String(), "No skills found")
+}
+
+func TestRunUserSkillsFromDirectory_PartialFailure(t *testing.T) {
+	skills := []map[string]interface{}{
+		{"uri": "skill://org/skill-a", "name": "skill-a"},
+		{"uri": "skill://org/skill-b", "name": "skill-b"},
+	}
+	var addCalls atomic.Int32
+	server := newUserFromDirMockServer(t, skills, &addCalls, true)
+	defer server.Close()
+	setUserSkillsHubEnv(t, server.URL)
+
+	orig := projectPath
+	defer func() { projectPath = orig }()
+	_, projectDir := setupUserSkillsProject(t, server.URL)
+	projectPath = projectDir
+
+	origInteractive := isInteractiveTerminal
+	defer func() { isInteractiveTerminal = origInteractive }()
+	isInteractiveTerminal = func() bool { return false }
+
+	var outBuf bytes.Buffer
+	var errBuf bytes.Buffer
+	userSkillsAddCmd.SetOut(&outBuf)
+	userSkillsAddCmd.SetErr(&errBuf)
+	defer userSkillsAddCmd.SetOut(nil)
+	defer userSkillsAddCmd.SetErr(nil)
+
+	err := runUserSkillsFromDirectory(userSkillsAddCmd, "https://github.com/org/repo/tree/main/skills")
+	assert.NoError(t, err)
+	assert.Contains(t, outBuf.String(), "Added 1 of 2")
+	assert.Contains(t, errBuf.String(), "Warning: 1 of 2 skills could not be added")
 }
 
 func TestRunUserSkillsList_APIError(t *testing.T) {

--- a/cmd/user_skills_test.go
+++ b/cmd/user_skills_test.go
@@ -578,6 +578,204 @@ func TestRunUserSkillsFromDirectory_PartialFailure(t *testing.T) {
 	assert.Contains(t, errBuf.String(), "Warning: 1 of 2 skills could not be added")
 }
 
+func TestRunUserSkillsFromDirectory_TTY_Yes_AddsAll(t *testing.T) {
+	skills := []map[string]interface{}{
+		{"uri": "skill://org/skill-a", "name": "skill-a"},
+		{"uri": "skill://org/skill-b", "name": "skill-b"},
+	}
+	var addCalls atomic.Int32
+	server := newUserFromDirMockServer(t, skills, &addCalls, false)
+	defer server.Close()
+	setUserSkillsHubEnv(t, server.URL)
+
+	orig := projectPath
+	defer func() { projectPath = orig }()
+	_, projectDir := setupUserSkillsProject(t, server.URL)
+	projectPath = projectDir
+
+	origInteractive := isInteractiveTerminal
+	defer func() { isInteractiveTerminal = origInteractive }()
+	isInteractiveTerminal = func() bool { return true }
+
+	origAutoConfirm := autoConfirm
+	defer func() { autoConfirm = origAutoConfirm }()
+	autoConfirm = true
+
+	var buf bytes.Buffer
+	userSkillsAddCmd.SetOut(&buf)
+	defer userSkillsAddCmd.SetOut(nil)
+
+	err := runUserSkillsFromDirectory(userSkillsAddCmd, "https://github.com/org/repo/tree/main/skills")
+	assert.NoError(t, err)
+	assert.Equal(t, int32(2), addCalls.Load())
+	assert.Contains(t, buf.String(), "Added 2 of 2")
+}
+
+func TestRunUserSkillsFromDirectory_DiscoverError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/healthz":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+		case r.URL.Path == "/api/v1/skills/discover-directory":
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"code":    "internal_error",
+				"message": "internal server error",
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	setUserSkillsHubEnv(t, server.URL)
+
+	orig := projectPath
+	defer func() { projectPath = orig }()
+	_, projectDir := setupUserSkillsProject(t, server.URL)
+	projectPath = projectDir
+
+	err := runUserSkillsFromDirectory(userSkillsAddCmd, "https://github.com/org/repo/tree/main/skills")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "skill discovery failed")
+}
+
+func TestRunUserSkillsFromDirectory_StripsUserinfo(t *testing.T) {
+	var receivedSourceURL string
+	skills := []map[string]interface{}{
+		{"uri": "skill://org/skill-a", "name": "skill-a"},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+
+		case r.URL.Path == "/api/v1/skills/discover-directory" && r.Method == http.MethodPost:
+			var req map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			receivedSourceURL, _ = req["sourceUrl"].(string)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"skills":  skills,
+				"count":   len(skills),
+				"skipped": []string{},
+			})
+
+		case r.URL.Path == "/api/v1/users/me/injected-skills" && r.Method == http.MethodPost:
+			var req map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":       "new-user-entry-uuid",
+				"skillUri": req["skillUri"],
+			})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	setUserSkillsHubEnv(t, server.URL)
+
+	orig := projectPath
+	defer func() { projectPath = orig }()
+	_, projectDir := setupUserSkillsProject(t, server.URL)
+	projectPath = projectDir
+
+	origInteractive := isInteractiveTerminal
+	defer func() { isInteractiveTerminal = origInteractive }()
+	isInteractiveTerminal = func() bool { return false }
+
+	var buf bytes.Buffer
+	userSkillsAddCmd.SetOut(&buf)
+	defer userSkillsAddCmd.SetOut(nil)
+
+	err := runUserSkillsFromDirectory(userSkillsAddCmd,
+		"https://token:secret@github.com/org/repo/tree/main/skills")
+	assert.NoError(t, err)
+	assert.NotContains(t, receivedSourceURL, "token")
+	assert.NotContains(t, receivedSourceURL, "secret")
+	assert.Contains(t, receivedSourceURL, "github.com/org/repo/tree/main/skills")
+}
+
+func TestRunUserSkillsFromDirectory_InvalidURL(t *testing.T) {
+	err := runUserSkillsFromDirectory(userSkillsAddCmd, "ftp://example.com/skills")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--from-directory must be an https://github.com/")
+}
+
+func TestRunUserSkillsAdd_FromDirConflictWithAs(t *testing.T) {
+	origFromDir := userSkillsFromDir
+	origAs := userSkillsAs
+	defer func() {
+		userSkillsFromDir = origFromDir
+		userSkillsAs = origAs
+	}()
+	userSkillsFromDir = "https://github.com/org/repo/tree/main/skills"
+	userSkillsAs = "my-alias"
+
+	err := runUserSkillsAdd(userSkillsAddCmd, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--as and --optional cannot be used with --from-directory")
+}
+
+func TestRunUserSkillsFromDirectory_TotalFailure(t *testing.T) {
+	skills := []map[string]interface{}{
+		{"uri": "skill://org/skill-a", "name": "skill-a"},
+	}
+	var addCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+
+		case r.URL.Path == "/api/v1/skills/discover-directory" && r.Method == http.MethodPost:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"skills":  skills,
+				"count":   len(skills),
+				"skipped": []string{},
+			})
+
+		case r.URL.Path == "/api/v1/users/me/injected-skills" && r.Method == http.MethodPost:
+			addCalls.Add(1)
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"code":    "bad_request",
+				"message": "skill already exists",
+			})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	setUserSkillsHubEnv(t, server.URL)
+
+	orig := projectPath
+	defer func() { projectPath = orig }()
+	_, projectDir := setupUserSkillsProject(t, server.URL)
+	projectPath = projectDir
+
+	origInteractive := isInteractiveTerminal
+	defer func() { isInteractiveTerminal = origInteractive }()
+	isInteractiveTerminal = func() bool { return false }
+
+	var outBuf bytes.Buffer
+	var errBuf bytes.Buffer
+	userSkillsAddCmd.SetOut(&outBuf)
+	userSkillsAddCmd.SetErr(&errBuf)
+	defer userSkillsAddCmd.SetOut(nil)
+	defer userSkillsAddCmd.SetErr(nil)
+
+	err := runUserSkillsFromDirectory(userSkillsAddCmd, "https://github.com/org/repo/tree/main/skills")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "all 1 skill(s) failed to add")
+	assert.Equal(t, int32(1), addCalls.Load())
+}
+
 func TestRunUserSkillsList_APIError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/cmd/user_skills_test.go
+++ b/cmd/user_skills_test.go
@@ -614,10 +614,10 @@ func TestRunUserSkillsFromDirectory_TTY_Yes_AddsAll(t *testing.T) {
 func TestRunUserSkillsFromDirectory_DiscoverError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.URL.Path == "/healthz":
+		switch r.URL.Path {
+		case "/healthz":
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
-		case r.URL.Path == "/api/v1/skills/discover-directory":
+		case "/api/v1/skills/discover-directory":
 			w.WriteHeader(http.StatusInternalServerError)
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"code":    "internal_error",

--- a/cmd/user_skills_test.go
+++ b/cmd/user_skills_test.go
@@ -720,6 +720,16 @@ func TestRunUserSkillsAdd_FromDirConflictWithAs(t *testing.T) {
 	assert.Contains(t, err.Error(), "--as and --optional cannot be used with --from-directory")
 }
 
+func TestRunUserSkillsAdd_FromDirConflictWithSkillURI(t *testing.T) {
+	origFromDir := userSkillsFromDir
+	defer func() { userSkillsFromDir = origFromDir }()
+	userSkillsFromDir = "https://github.com/org/repo/tree/main/skills"
+
+	err := runUserSkillsAdd(userSkillsAddCmd, []string{"skill://foo"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot combine a skill URI argument with --from-directory")
+}
+
 func TestRunUserSkillsFromDirectory_TotalFailure(t *testing.T) {
 	skills := []map[string]interface{}{
 		{"uri": "skill://org/skill-a", "name": "skill-a"},

--- a/pkg/hub/errors.go
+++ b/pkg/hub/errors.go
@@ -60,6 +60,9 @@ const (
 	ErrCodeMissingEnvVars = "missing_env_vars"
 	ErrCodeCloneFailed    = "clone_failed"
 	ErrCodePullFailed     = "pull_failed"
+	// ErrCodeDiscoverFailed reports a remote-directory probe that could not be
+	// fetched or yielded nothing usable (see handleSkillsDiscoverDirectory).
+	ErrCodeDiscoverFailed = "discover_failed"
 
 	// Delivery error codes
 	ErrCodeAgentNotFound   = "agent_not_found"

--- a/pkg/hub/handlers_resource_import.go
+++ b/pkg/hub/handlers_resource_import.go
@@ -585,7 +585,7 @@ func (s *Server) handleProjectDiscoverTemplates(w http.ResponseWriter, r *http.R
 		names, skipped, err = s.discoverFromRemote(ctx, projectID, req.SourceURL, s.templateImportKind())
 	}
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "discover_failed", err.Error(), nil)
+		writeError(w, http.StatusBadRequest, ErrCodeDiscoverFailed, err.Error(), nil)
 		return
 	}
 
@@ -665,7 +665,7 @@ func (s *Server) handleProjectDiscoverHarnessConfigs(w http.ResponseWriter, r *h
 		names, skipped, err = s.discoverFromRemote(ctx, projectID, req.SourceURL, s.harnessConfigImportKind())
 	}
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "discover_failed", err.Error(), nil)
+		writeError(w, http.StatusBadRequest, ErrCodeDiscoverFailed, err.Error(), nil)
 		return
 	}
 
@@ -773,7 +773,7 @@ func (s *Server) handleResourcesDiscover(w http.ResponseWriter, r *http.Request)
 
 	names, skipped, err := s.discoverFromRemote(ctx, projectID, sourceURL, kind)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "discover_failed", err.Error(), nil)
+		writeError(w, http.StatusBadRequest, ErrCodeDiscoverFailed, err.Error(), nil)
 		return
 	}
 

--- a/pkg/hub/handlers_skills_discover.go
+++ b/pkg/hub/handlers_skills_discover.go
@@ -65,8 +65,10 @@ type DiscoveredSkill struct {
 
 // DiscoverSkillsResponse is the response body for
 // POST /api/v1/skills/discover-directory.
-// Skipped names the child directories that were passed over because they had no
-// SKILL.md, so the UI can explain why a folder the user expected is missing.
+// Skipped names the child directories that were passed over — either because
+// they had no SKILL.md, or because their name could not be turned into a safe,
+// addressable skill URI — so the UI can explain why a folder the user expected
+// is missing.
 type DiscoverSkillsResponse struct {
 	Skills  []DiscoveredSkill `json:"skills"`
 	Skipped []string          `json:"skipped,omitempty"`
@@ -113,22 +115,52 @@ func (s *Server) handleSkillsDiscoverDirectory(w http.ResponseWriter, r *http.Re
 	// rclone connection strings (":local:/" would have the hub copy its own
 	// filesystem) and bare http:// URLs (an SSRF vector against hub-internal
 	// hosts). Neither can ever yield a usable skill URI.
-	if u, parseErr := url.Parse(req.SourceURL); parseErr != nil ||
-		u.Scheme != "https" || !strings.EqualFold(u.Host, "github.com") {
+	u, parseErr := url.Parse(req.SourceURL)
+	if parseErr != nil || u.Scheme != "https" || !strings.EqualFold(u.Host, "github.com") {
 		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest,
 			"sourceUrl must be an https://github.com/... URL", nil)
 		return
 	}
 
-	// A skill URI may carry a ?token=SECRET_NAME suffix naming the secret used to
-	// resolve it. discoverResourceDirs builds child URLs by plain concatenation
-	// ("<sourceURL>/<child>"), which would bury the query mid-path and make every
-	// child unnormalizable. Split it off here and re-attach it per skill below.
-	// The suffix is also irrelevant to the fetch itself, which authenticates from
-	// project credentials, so the fetch gets the bare URL too.
-	base, tokenSuffix := req.SourceURL, ""
-	if i := strings.Index(req.SourceURL, "?"); i >= 0 {
-		base, tokenSuffix = req.SourceURL[:i], req.SourceURL[i:]
+	// Canonicalize before anything downstream sees the URL:
+	//
+	//   - Lowercase the host. The gate above is case-insensitive (hostnames are),
+	//     but config.DetectRemoteType matches "github.com" exactly, so a
+	//     "https://GitHub.com/..." URL would otherwise sail past this check and
+	//     die later with a generic fetch error.
+	//   - Split off a ?token=SECRET_NAME suffix. A skill URI may name the secret
+	//     used to resolve it, but discoverResourceDirs builds child URLs by plain
+	//     concatenation ("<sourceURL>/<child>"), which would bury the query
+	//     mid-path and make every child unnormalizable. It is re-attached per
+	//     skill below. It is also irrelevant to the fetch itself, which
+	//     authenticates from project credentials, so the fetch gets the bare URL.
+	//   - Drop any #fragment, for the same concatenation reason: ".../skills#notes"
+	//     would yield child URLs like ".../skills#notes/alpha-skill".
+	//   - Drop any userinfo. "https://x-access-token:SECRET@github.com/..." parses
+	//     with Host == "github.com", and base is both logged and echoed in the
+	//     "no skills found at <base>" message — so leaving it in would write a
+	//     pasted credential to the hub log and hand it back to the client.
+	//     Discovery authenticates from project credentials, never from the URL.
+	tokenSuffix := ""
+	if u.RawQuery != "" {
+		tokenSuffix = "?" + u.RawQuery
+	}
+	u.Host = "github.com"
+	u.User = nil
+	u.RawQuery = ""
+	u.Fragment = ""
+	base := u.String()
+
+	// api.NormalizeSkillURI requires the /tree/<ref>/ path form. A bare-repo URL
+	// ("https://github.com/acme/repo") would pass the host check, trigger a full
+	// tarball fetch, and then fail normalization for every child — surfacing as a
+	// misleading "no skills found" for a repo that plainly has skills. Reject it
+	// up front with an actionable message instead.
+	if !strings.Contains(u.Path, "/tree/") {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest,
+			"sourceUrl must point to a directory in a GitHub repository "+
+				"(e.g. https://github.com/org/repo/tree/main/skills)", nil)
+		return
 	}
 
 	cachePath, err := s.fetchRemoteForImport(ctx, req.ProjectID, base)
@@ -138,7 +170,7 @@ func (s *Server) handleSkillsDiscoverDirectory(w http.ResponseWriter, r *http.Re
 		// embeds that URL verbatim on failure.
 		s.resourceLog.Warn("skill discovery fetch failed",
 			"sourceURL", base, "projectID", req.ProjectID, "error", err)
-		writeError(w, http.StatusBadRequest, "discover_failed",
+		writeError(w, http.StatusBadRequest, ErrCodeDiscoverFailed,
 			"Failed to fetch remote skills; check the URL and repository access", nil)
 		return
 	}
@@ -147,10 +179,15 @@ func (s *Server) handleSkillsDiscoverDirectory(w http.ResponseWriter, r *http.Re
 	dirs, skippedDirs, err := discoverResourceDirs(cachePath, base, skillDiscoverKind)
 	if err != nil {
 		s.resourceLog.Warn("skill discovery scan failed", "sourceURL", base, "error", err)
-		writeError(w, http.StatusBadRequest, "discover_failed",
+		writeError(w, http.StatusBadRequest, ErrCodeDiscoverFailed,
 			"Failed to scan skills at the given URL", nil)
 		return
 	}
+
+	// Directories dropped inside the loop below. They are merged into the
+	// response's Skipped list so a user whose folder vanished from the dialog
+	// gets an explanation rather than a silent omission.
+	var droppedNames []string
 
 	skills := make([]DiscoveredSkill, 0, len(dirs))
 	for _, d := range dirs {
@@ -159,30 +196,35 @@ func (s *Server) handleSkillsDiscoverDirectory(w http.ResponseWriter, r *http.Re
 		// parameter into the skill URI we hand back to the client.
 		if strings.ContainsAny(d.name, "?#&=") || strings.Contains(d.name, "..") {
 			s.resourceLog.Warn("skipping discovered skill with unsafe directory name", "name", d.name)
+			droppedNames = append(droppedNames, d.name)
 			continue
 		}
 		uri, normErr := api.NormalizeSkillURI(d.sourceURL + tokenSuffix)
 		if normErr != nil {
-			// A directory whose URL cannot be expressed as a skill URI is not
-			// addressable, so it cannot be added. Drop it rather than failing
-			// the whole discovery.
+			// Defence in depth. The /tree/ check above means a well-formed GitHub
+			// URL should always normalize, so this branch is not reachable from
+			// validated input — but a directory whose URL cannot be expressed as a
+			// skill URI is not addressable and so cannot be added. Drop it rather
+			// than failing the whole discovery.
 			s.resourceLog.Warn("skipping discovered skill with unnormalizable URI",
 				"sourceURL", d.sourceURL, "error", normErr)
+			droppedNames = append(droppedNames, d.name)
 			continue
 		}
 		skills = append(skills, DiscoveredSkill{URI: uri, Name: d.name})
 	}
 
 	if len(skills) == 0 {
-		writeError(w, http.StatusBadRequest, "discover_failed",
+		writeError(w, http.StatusBadRequest, ErrCodeDiscoverFailed,
 			"no skills found at "+base, nil)
 		return
 	}
 
-	skipped := make([]string, 0, len(skippedDirs))
+	skipped := make([]string, 0, len(skippedDirs)+len(droppedNames))
 	for _, sd := range skippedDirs {
 		skipped = append(skipped, sd.name)
 	}
+	skipped = append(skipped, droppedNames...)
 
 	writeJSON(w, http.StatusOK, DiscoverSkillsResponse{
 		Skills:  skills,

--- a/pkg/hub/handlers_skills_discover.go
+++ b/pkg/hub/handlers_skills_discover.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// skillDiscoverKind is the resourceImportKind used to scan a fetched remote
+// directory for skills. A directory is a skill when it contains a SKILL.md.
+//
+// newStore is nil because skill discovery never persists anything: skills are
+// referenced by URI, not imported into hub object storage. Only
+// discoverResourceDirs is ever called with this kind, and that function does
+// not touch newStore.
+var skillDiscoverKind = resourceImportKind{
+	noun:   "skills",
+	marker: "SKILL.md",
+	isResourceDir: func(dir string) bool {
+		_, err := os.Stat(filepath.Join(dir, "SKILL.md"))
+		return err == nil
+	},
+	newStore: nil,
+}
+
+// DiscoverSkillsRequest is the request body for
+// POST /api/v1/skills/discover-directory.
+//
+// ProjectID is optional; when set it is used to resolve GitHub credentials (a
+// GitHub App installation token, falling back to the project's GITHUB_TOKEN
+// secret) so private repositories can be scanned.
+type DiscoverSkillsRequest struct {
+	SourceURL string `json:"sourceUrl"`
+	ProjectID string `json:"projectId,omitempty"`
+}
+
+// DiscoveredSkill is one skill found at the discovered directory. URI is the
+// canonical skill URI (as produced by api.NormalizeSkillURI) and Name is the
+// bare directory name, used as the display label.
+type DiscoveredSkill struct {
+	URI  string `json:"uri"`
+	Name string `json:"name"`
+}
+
+// DiscoverSkillsResponse is the response body for
+// POST /api/v1/skills/discover-directory.
+type DiscoverSkillsResponse struct {
+	Skills []DiscoveredSkill `json:"skills"`
+	Count  int               `json:"count"`
+}
+
+// handleSkillsDiscoverDirectory handles POST /api/v1/skills/discover-directory:
+// it fetches a remote GitHub directory, scans it for subdirectories containing
+// a SKILL.md, and returns the canonical skill URI plus display name for each.
+//
+// Nothing is persisted — this is a read-only probe used by the UI (and, in a
+// later phase, the CLI) to offer a batch-add selection list. Unlike template
+// and harness-config discovery, no hub object storage is required.
+func (s *Server) handleSkillsDiscoverDirectory(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	var req DiscoverSkillsRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "Invalid request body", nil)
+		return
+	}
+
+	// Auth: agents need project:agent:create and may only discover for their own
+	// project (mirrors handleProjectDiscoverTemplates); users need only to be
+	// authenticated, since discovery reads a public-or-project-credentialed
+	// GitHub URL and persists nothing.
+	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+		if !agentIdent.HasScope(ScopeAgentCreate) {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Missing required scope: project:agent:create", nil)
+			return
+		}
+		if req.ProjectID != "" && req.ProjectID != agentIdent.ProjectID() {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agents can only discover skills within their own project", nil)
+			return
+		}
+		// Scope the fetch to the agent's own project even when the caller
+		// omitted projectId, so project GitHub credentials still apply.
+		req.ProjectID = agentIdent.ProjectID()
+	} else if userIdent := GetUserIdentityFromContext(ctx); userIdent == nil {
+		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "Authentication required", nil)
+		return
+	}
+
+	if req.SourceURL == "" {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "sourceUrl is required", nil)
+		return
+	}
+	if !config.IsRemoteURI(req.SourceURL) {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest,
+			"sourceUrl must be a remote URI (http://, https://, or rclone)", nil)
+		return
+	}
+
+	cachePath, err := s.fetchRemoteForImport(ctx, req.ProjectID, req.SourceURL)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "discover_failed", "Failed to fetch remote skills: "+err.Error(), nil)
+		return
+	}
+	defer func() { _ = os.RemoveAll(cachePath) }()
+
+	dirs, _, err := discoverResourceDirs(cachePath, req.SourceURL, skillDiscoverKind)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "discover_failed", err.Error(), nil)
+		return
+	}
+
+	skills := make([]DiscoveredSkill, 0, len(dirs))
+	for _, d := range dirs {
+		uri, normErr := api.NormalizeSkillURI(d.sourceURL)
+		if normErr != nil {
+			// A directory whose URL cannot be expressed as a skill URI is not
+			// addressable, so it cannot be added. Drop it rather than failing
+			// the whole discovery.
+			s.resourceLog.Warn("skipping discovered skill with unnormalizable URI",
+				"sourceURL", d.sourceURL, "error", normErr)
+			continue
+		}
+		skills = append(skills, DiscoveredSkill{URI: uri, Name: d.name})
+	}
+
+	if len(skills) == 0 {
+		writeError(w, http.StatusBadRequest, "discover_failed",
+			"no skills found at "+req.SourceURL, nil)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, DiscoverSkillsResponse{Skills: skills, Count: len(skills)})
+}

--- a/pkg/hub/handlers_skills_discover.go
+++ b/pkg/hub/handlers_skills_discover.go
@@ -15,12 +15,16 @@
 package hub
 
 import (
+	"context"
+	"errors"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
-	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
 // skillDiscoverKind is the resourceImportKind used to scan a fetched remote
@@ -61,10 +65,17 @@ type DiscoveredSkill struct {
 
 // DiscoverSkillsResponse is the response body for
 // POST /api/v1/skills/discover-directory.
+// Skipped names the child directories that were passed over because they had no
+// SKILL.md, so the UI can explain why a folder the user expected is missing.
 type DiscoverSkillsResponse struct {
-	Skills []DiscoveredSkill `json:"skills"`
-	Count  int               `json:"count"`
+	Skills  []DiscoveredSkill `json:"skills"`
+	Skipped []string          `json:"skipped,omitempty"`
+	Count   int               `json:"count"`
 }
+
+// maxDiscoverBodyBytes caps the request body. The body is two short strings;
+// anything larger is a mistake or an attempt to make the hub buffer garbage.
+const maxDiscoverBodyBytes = 64 << 10
 
 // handleSkillsDiscoverDirectory handles POST /api/v1/skills/discover-directory:
 // it fetches a remote GitHub directory, scans it for subdirectories containing
@@ -81,30 +92,15 @@ func (s *Server) handleSkillsDiscoverDirectory(w http.ResponseWriter, r *http.Re
 
 	ctx := r.Context()
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxDiscoverBodyBytes)
+
 	var req DiscoverSkillsRequest
 	if err := readJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "Invalid request body", nil)
 		return
 	}
 
-	// Auth: agents need project:agent:create and may only discover for their own
-	// project (mirrors handleProjectDiscoverTemplates); users need only to be
-	// authenticated, since discovery reads a public-or-project-credentialed
-	// GitHub URL and persists nothing.
-	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
-		if !agentIdent.HasScope(ScopeAgentCreate) {
-			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Missing required scope: project:agent:create", nil)
-			return
-		}
-		if req.ProjectID != "" && req.ProjectID != agentIdent.ProjectID() {
-			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agents can only discover skills within their own project", nil)
-			return
-		}
-		// Scope the fetch to the agent's own project even when the caller
-		// omitted projectId, so project GitHub credentials still apply.
-		req.ProjectID = agentIdent.ProjectID()
-	} else if userIdent := GetUserIdentityFromContext(ctx); userIdent == nil {
-		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "Authentication required", nil)
+	if !s.authorizeSkillDiscover(ctx, w, &req) {
 		return
 	}
 
@@ -112,28 +108,60 @@ func (s *Server) handleSkillsDiscoverDirectory(w http.ResponseWriter, r *http.Re
 		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "sourceUrl is required", nil)
 		return
 	}
-	if !config.IsRemoteURI(req.SourceURL) {
+	// Skills are only resolvable from GitHub, so anything else is a mistake or an
+	// attack. config.IsRemoteURI is deliberately not used here: it also admits
+	// rclone connection strings (":local:/" would have the hub copy its own
+	// filesystem) and bare http:// URLs (an SSRF vector against hub-internal
+	// hosts). Neither can ever yield a usable skill URI.
+	if u, parseErr := url.Parse(req.SourceURL); parseErr != nil ||
+		u.Scheme != "https" || !strings.EqualFold(u.Host, "github.com") {
 		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest,
-			"sourceUrl must be a remote URI (http://, https://, or rclone)", nil)
+			"sourceUrl must be an https://github.com/... URL", nil)
 		return
 	}
 
-	cachePath, err := s.fetchRemoteForImport(ctx, req.ProjectID, req.SourceURL)
+	// A skill URI may carry a ?token=SECRET_NAME suffix naming the secret used to
+	// resolve it. discoverResourceDirs builds child URLs by plain concatenation
+	// ("<sourceURL>/<child>"), which would bury the query mid-path and make every
+	// child unnormalizable. Split it off here and re-attach it per skill below.
+	// The suffix is also irrelevant to the fetch itself, which authenticates from
+	// project credentials, so the fetch gets the bare URL too.
+	base, tokenSuffix := req.SourceURL, ""
+	if i := strings.Index(req.SourceURL, "?"); i >= 0 {
+		base, tokenSuffix = req.SourceURL[:i], req.SourceURL[i:]
+	}
+
+	cachePath, err := s.fetchRemoteForImport(ctx, req.ProjectID, base)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "discover_failed", "Failed to fetch remote skills: "+err.Error(), nil)
+		// Never echo err: the sparse-checkout fallback shells out to git with a
+		// "https://x-access-token:<TOKEN>@github.com/..." remote, and git's stderr
+		// embeds that URL verbatim on failure.
+		s.resourceLog.Warn("skill discovery fetch failed",
+			"sourceURL", base, "projectID", req.ProjectID, "error", err)
+		writeError(w, http.StatusBadRequest, "discover_failed",
+			"Failed to fetch remote skills; check the URL and repository access", nil)
 		return
 	}
 	defer func() { _ = os.RemoveAll(cachePath) }()
 
-	dirs, _, err := discoverResourceDirs(cachePath, req.SourceURL, skillDiscoverKind)
+	dirs, skippedDirs, err := discoverResourceDirs(cachePath, base, skillDiscoverKind)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "discover_failed", err.Error(), nil)
+		s.resourceLog.Warn("skill discovery scan failed", "sourceURL", base, "error", err)
+		writeError(w, http.StatusBadRequest, "discover_failed",
+			"Failed to scan skills at the given URL", nil)
 		return
 	}
 
 	skills := make([]DiscoveredSkill, 0, len(dirs))
 	for _, d := range dirs {
-		uri, normErr := api.NormalizeSkillURI(d.sourceURL)
+		// Reject names that would inject URI syntax. A repo directory literally
+		// named "helper?token=PROD_SECRET" would otherwise smuggle a token
+		// parameter into the skill URI we hand back to the client.
+		if strings.ContainsAny(d.name, "?#&=") || strings.Contains(d.name, "..") {
+			s.resourceLog.Warn("skipping discovered skill with unsafe directory name", "name", d.name)
+			continue
+		}
+		uri, normErr := api.NormalizeSkillURI(d.sourceURL + tokenSuffix)
 		if normErr != nil {
 			// A directory whose URL cannot be expressed as a skill URI is not
 			// addressable, so it cannot be added. Drop it rather than failing
@@ -147,9 +175,80 @@ func (s *Server) handleSkillsDiscoverDirectory(w http.ResponseWriter, r *http.Re
 
 	if len(skills) == 0 {
 		writeError(w, http.StatusBadRequest, "discover_failed",
-			"no skills found at "+req.SourceURL, nil)
+			"no skills found at "+base, nil)
 		return
 	}
 
-	writeJSON(w, http.StatusOK, DiscoverSkillsResponse{Skills: skills, Count: len(skills)})
+	skipped := make([]string, 0, len(skippedDirs))
+	for _, sd := range skippedDirs {
+		skipped = append(skipped, sd.name)
+	}
+
+	writeJSON(w, http.StatusOK, DiscoverSkillsResponse{
+		Skills:  skills,
+		Skipped: skipped,
+		Count:   len(skills),
+	})
+}
+
+// authorizeSkillDiscover authorizes the caller and, for agents, forces the
+// request onto the agent's own project. It writes the error response and
+// returns false when the caller is rejected.
+//
+// Discovery persists nothing, but it does *spend* a project's GitHub
+// credentials: fetchRemoteForImport mints a GitHub App installation token or
+// reads the project's GITHUB_TOKEN secret. Supplying a projectId therefore has
+// to be authorized exactly like any other use of that project's credentials,
+// which is why the user branch runs the same CheckAccess as
+// authorizeProjectImport rather than settling for "is logged in".
+func (s *Server) authorizeSkillDiscover(ctx context.Context, w http.ResponseWriter, req *DiscoverSkillsRequest) bool {
+	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+		if !agentIdent.HasScope(ScopeAgentCreate) {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Missing required scope: project:agent:create", nil)
+			return false
+		}
+		if req.ProjectID != "" && req.ProjectID != agentIdent.ProjectID() {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agents can only discover skills within their own project", nil)
+			return false
+		}
+		// Scope the fetch to the agent's own project even when the caller
+		// omitted projectId, so project GitHub credentials still apply.
+		req.ProjectID = agentIdent.ProjectID()
+		return true
+	}
+
+	userIdent := GetUserIdentityFromContext(ctx)
+	if userIdent == nil {
+		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "Authentication required", nil)
+		return false
+	}
+
+	// No projectId means an unauthenticated fetch of a public repo — any
+	// logged-in user may do that.
+	if req.ProjectID == "" {
+		return true
+	}
+
+	decision := s.authzService.CheckAccess(ctx, userIdent, Resource{
+		Type:       "agent",
+		ParentType: "project",
+		ParentID:   req.ProjectID,
+	}, ActionCreate)
+	if !decision.Allowed {
+		writeError(w, http.StatusForbidden, ErrCodeForbidden,
+			"You don't have permission to discover skills in this project", nil)
+		return false
+	}
+
+	// Confirm the project exists so a typo'd UUID fails loudly rather than
+	// silently degrading to an unauthenticated fetch.
+	if _, perr := s.store.GetProject(ctx, req.ProjectID); perr != nil {
+		if errors.Is(perr, store.ErrNotFound) {
+			NotFound(w, "Project")
+			return false
+		}
+		writeErrorFromErr(w, perr, "")
+		return false
+	}
+	return true
 }

--- a/pkg/hub/handlers_skills_discover_test.go
+++ b/pkg/hub/handlers_skills_discover_test.go
@@ -1,0 +1,364 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+const skillsDiscoverPath = "/api/v1/skills/discover-directory"
+
+// mockSkillTarball installs a mock HTTP transport serving a gzip tarball built
+// from the given path→content map, and returns a cleanup func restoring the
+// previous transport. Paths are relative to the tarball root and must include
+// the repo-<ref> top-level prefix that GitHub codeload tarballs carry (e.g.
+// "repo-main/skills/my-skill/SKILL.md").
+//
+// It must not be used with t.Parallel(): it mutates http.DefaultClient.Transport
+// globally.
+func mockSkillTarball(t *testing.T, files map[string]string) func() {
+	t.Helper()
+	old := http.DefaultClient.Transport
+	http.DefaultClient.Transport = &mockRoundTripper{
+		roundTrip: func(_ *http.Request) (*http.Response, error) {
+			var buf bytes.Buffer
+			gzw := gzip.NewWriter(&buf)
+			tw := tar.NewWriter(gzw)
+			for name, body := range files {
+				if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0600, Size: int64(len(body))}); err != nil {
+					return nil, err
+				}
+				if _, err := tw.Write([]byte(body)); err != nil {
+					return nil, err
+				}
+			}
+			if err := tw.Close(); err != nil {
+				return nil, err
+			}
+			if err := gzw.Close(); err != nil {
+				return nil, err
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(buf.Bytes()))}, nil
+		},
+	}
+	return func() { http.DefaultClient.Transport = old }
+}
+
+// skillDiscoverAdmin creates a hub-member admin user for discover tests.
+func skillDiscoverAdmin(t *testing.T, s store.Store, id string) *store.User {
+	t.Helper()
+	ctx := context.Background()
+	admin := &store.User{ID: tid(id), Email: id + "@test.com", DisplayName: "Admin", Role: store.UserRoleAdmin}
+	if err := s.CreateUser(ctx, admin); err != nil {
+		t.Fatal(err)
+	}
+	ensureHubMembership(ctx, s, admin.ID)
+	return admin
+}
+
+// decodeDiscoverSkills parses a successful discover response body.
+func decodeDiscoverSkills(t *testing.T, rec *httptest.ResponseRecorder) DiscoverSkillsResponse {
+	t.Helper()
+	var resp DiscoverSkillsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response %q: %v", rec.Body.String(), err)
+	}
+	return resp
+}
+
+// TestHandleSkillsDiscoverDirectory_StandardSkillsDir verifies the happy path:
+// a URL pointing at a standard skills/ directory returns one entry per child
+// with a gh:// shorthand URI and a non-empty name.
+func TestHandleSkillsDiscoverDirectory_StandardSkillsDir(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-std")
+
+	defer mockSkillTarball(t, map[string]string{
+		"repo-main/skills/alpha-skill/SKILL.md": "---\nname: alpha-skill\n---\nAlpha",
+		"repo-main/skills/beta-skill/SKILL.md":  "---\nname: beta-skill\n---\nBeta",
+		"repo-main/skills/not-a-skill/README":   "no marker here",
+	})()
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	resp := decodeDiscoverSkills(t, rec)
+	if resp.Count != 2 || len(resp.Skills) != 2 {
+		t.Fatalf("expected 2 skills, got %+v", resp)
+	}
+	byName := map[string]string{}
+	for _, sk := range resp.Skills {
+		if sk.Name == "" {
+			t.Errorf("skill has empty name: %+v", sk)
+		}
+		byName[sk.Name] = sk.URI
+	}
+	if got := byName["alpha-skill"]; got != "gh://acme/repo/alpha-skill@main" {
+		t.Errorf("alpha-skill URI = %q, want gh://acme/repo/alpha-skill@main", got)
+	}
+	if got := byName["beta-skill"]; got != "gh://acme/repo/beta-skill@main" {
+		t.Errorf("beta-skill URI = %q, want gh://acme/repo/beta-skill@main", got)
+	}
+	if _, ok := byName["not-a-skill"]; ok {
+		t.Errorf("directory without SKILL.md should not be discovered: %+v", resp.Skills)
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_CustomPathDir verifies that skills outside a
+// standard skills/ directory keep their full https:// URL form, since the gh://
+// shorthand implies the skills/ prefix.
+func TestHandleSkillsDiscoverDirectory_CustomPathDir(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-custom")
+
+	defer mockSkillTarball(t, map[string]string{
+		"repo-main/tools/helpers/one-skill/SKILL.md": "one",
+	})()
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/tools/helpers",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	resp := decodeDiscoverSkills(t, rec)
+	if resp.Count != 1 || len(resp.Skills) != 1 {
+		t.Fatalf("expected 1 skill, got %+v", resp)
+	}
+	want := "https://github.com/acme/repo/tree/main/tools/helpers/one-skill"
+	if resp.Skills[0].URI != want {
+		t.Errorf("URI = %q, want %q", resp.Skills[0].URI, want)
+	}
+	if resp.Skills[0].Name != "one-skill" {
+		t.Errorf("Name = %q, want one-skill", resp.Skills[0].Name)
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_LeafSkillURL verifies that pointing at a
+// single skill directory (rather than a directory of skills) yields exactly one
+// entry, so the UI can still offer it for add.
+func TestHandleSkillsDiscoverDirectory_LeafSkillURL(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-leaf")
+
+	defer mockSkillTarball(t, map[string]string{
+		"repo-main/skills/solo-skill/SKILL.md": "solo",
+	})()
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills/solo-skill",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	resp := decodeDiscoverSkills(t, rec)
+	if resp.Count != 1 || len(resp.Skills) != 1 {
+		t.Fatalf("expected exactly 1 skill, got %+v", resp)
+	}
+	if resp.Skills[0].URI != "gh://acme/repo/solo-skill@main" {
+		t.Errorf("URI = %q, want gh://acme/repo/solo-skill@main", resp.Skills[0].URI)
+	}
+	if resp.Skills[0].Name != "solo-skill" {
+		t.Errorf("Name = %q, want solo-skill", resp.Skills[0].Name)
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_NoSkillsFound verifies a directory with no
+// SKILL.md-bearing children is a 400 rather than an empty 200.
+func TestHandleSkillsDiscoverDirectory_NoSkillsFound(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-empty")
+
+	defer mockSkillTarball(t, map[string]string{
+		"repo-main/skills/just-docs/README.md": "nothing to see",
+	})()
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !bytes.Contains([]byte(body), []byte("no skills found")) {
+		t.Errorf("expected 'no skills found' in body, got %q", body)
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_MissingSourceURL verifies sourceUrl is required.
+func TestHandleSkillsDiscoverDirectory_MissingSourceURL(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-nourl")
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_Unauthenticated verifies an anonymous
+// request is rejected with 401.
+func TestHandleSkillsDiscoverDirectory_Unauthenticated(t *testing.T) {
+	srv, _, _ := testTemplateBootstrapServer(t)
+
+	body, _ := json.Marshal(DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills",
+	})
+	req := httptest.NewRequest(http.MethodPost, skillsDiscoverPath, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_MethodNotAllowed verifies non-POST methods
+// are rejected.
+func TestHandleSkillsDiscoverDirectory_MethodNotAllowed(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-method")
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodGet, skillsDiscoverPath, nil)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// setupSkillDiscoverAgent creates a project plus an agent in it and returns the
+// server, the project ID, and a token minted with the given scopes.
+func setupSkillDiscoverAgent(t *testing.T, suffix string, scopes []AgentTokenScope) (*Server, string, string) {
+	t.Helper()
+	srv, s, _ := testTemplateBootstrapServer(t)
+	ctx := context.Background()
+
+	projectID := tid("project-skill-discover-" + suffix)
+	if err := s.CreateProject(ctx, &store.Project{
+		ID: projectID, Name: "Skill Discover " + suffix, Slug: "skill-discover-" + suffix,
+		Created: time.Now(), Updated: time.Now(),
+	}); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	agentID := tid("agent-skill-discover-" + suffix)
+	if err := s.CreateAgent(ctx, &store.Agent{
+		ID: agentID, Slug: "skill-discover-" + suffix, Name: "Skill Discover Agent",
+		ProjectID: projectID, Phase: string(state.PhaseRunning), StateVersion: 1,
+		Created: time.Now(), Updated: time.Now(),
+	}); err != nil {
+		t.Fatalf("failed to create agent: %v", err)
+	}
+
+	token, err := srv.agentTokenService.GenerateAgentToken(agentID, projectID, scopes, nil)
+	if err != nil {
+		t.Fatalf("failed to generate agent token: %v", err)
+	}
+	return srv, projectID, token
+}
+
+// TestHandleSkillsDiscoverDirectory_AgentWithScope verifies an agent holding
+// project:agent:create may discover skills for its own project.
+func TestHandleSkillsDiscoverDirectory_AgentWithScope(t *testing.T) {
+	srv, projectID, token := setupSkillDiscoverAgent(t, "ok",
+		[]AgentTokenScope{ScopeAgentStatusUpdate, ScopeAgentCreate})
+
+	defer mockSkillTarball(t, map[string]string{
+		"repo-main/skills/agent-skill/SKILL.md": "hi",
+	})()
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills",
+		ProjectID: projectID,
+	}, token)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	resp := decodeDiscoverSkills(t, rec)
+	if resp.Count != 1 || resp.Skills[0].URI != "gh://acme/repo/agent-skill@main" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_AgentMissingScope verifies an agent without
+// project:agent:create is rejected with 403.
+func TestHandleSkillsDiscoverDirectory_AgentMissingScope(t *testing.T) {
+	srv, projectID, token := setupSkillDiscoverAgent(t, "noscope",
+		[]AgentTokenScope{ScopeAgentStatusUpdate})
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills",
+		ProjectID: projectID,
+	}, token)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_AgentOtherProject verifies an agent may not
+// discover skills on behalf of a project it does not belong to.
+func TestHandleSkillsDiscoverDirectory_AgentOtherProject(t *testing.T) {
+	srv, _, token := setupSkillDiscoverAgent(t, "otherproj",
+		[]AgentTokenScope{ScopeAgentStatusUpdate, ScopeAgentCreate})
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills",
+		ProjectID: tid("project-somebody-else"),
+	}, token)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestSkillDiscoverKind verifies the kind's marker predicate: a directory is a
+// skill only when it contains a SKILL.md.
+func TestSkillDiscoverKind(t *testing.T) {
+	dir := t.TempDir()
+	if skillDiscoverKind.isResourceDir(dir) {
+		t.Error("empty dir should not be a skill dir")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: x\n---\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !skillDiscoverKind.isResourceDir(dir) {
+		t.Error("dir with SKILL.md should be a skill dir")
+	}
+	if skillDiscoverKind.marker != "SKILL.md" || skillDiscoverKind.noun != "skills" {
+		t.Errorf("unexpected kind config: %+v", skillDiscoverKind)
+	}
+}

--- a/pkg/hub/handlers_skills_discover_test.go
+++ b/pkg/hub/handlers_skills_discover_test.go
@@ -173,6 +173,9 @@ func TestHandleSkillsDiscoverDirectory_StandardSkillsDir(t *testing.T) {
 		"repo-main/skills/alpha-skill/SKILL.md": "---\nname: alpha-skill\n---\nAlpha",
 		"repo-main/skills/beta-skill/SKILL.md":  "---\nname: beta-skill\n---\nBeta",
 		"repo-main/skills/not-a-skill/README":   "no marker here",
+		// Carries a SKILL.md but its name would inject URI syntax, so the name
+		// guard drops it. It must still be reported in Skipped.
+		"repo-main/skills/bad=name/SKILL.md": "---\nname: bad\n---\nBad",
 	}, func(req *http.Request) { requestedURL = req.URL.String() })()
 
 	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
@@ -207,9 +210,14 @@ func TestHandleSkillsDiscoverDirectory_StandardSkillsDir(t *testing.T) {
 	if _, ok := byName["not-a-skill"]; ok {
 		t.Errorf("directory without SKILL.md should not be discovered: %+v", resp.Skills)
 	}
-	// The marker-less sibling is reported so the UI can explain its absence.
-	if len(resp.Skipped) != 1 || resp.Skipped[0] != "not-a-skill" {
-		t.Errorf("Skipped = %v, want [not-a-skill]", resp.Skipped)
+	// Both the marker-less sibling and the unsafely-named one are reported so
+	// the UI can explain their absence rather than silently dropping them.
+	gotSkipped := map[string]bool{}
+	for _, name := range resp.Skipped {
+		gotSkipped[name] = true
+	}
+	if len(resp.Skipped) != 2 || !gotSkipped["not-a-skill"] || !gotSkipped["bad=name"] {
+		t.Errorf("Skipped = %v, want [not-a-skill bad=name] in some order", resp.Skipped)
 	}
 }
 
@@ -294,8 +302,8 @@ func TestHandleSkillsDiscoverDirectory_NoSkillsFound(t *testing.T) {
 	if !strings.Contains(apiErr.Message, "no skills found") {
 		t.Errorf("expected 'no skills found' in message, got %q", apiErr.Message)
 	}
-	if apiErr.Code != "discover_failed" {
-		t.Errorf("code = %q, want discover_failed", apiErr.Code)
+	if apiErr.Code != ErrCodeDiscoverFailed {
+		t.Errorf("code = %q, want %q", apiErr.Code, ErrCodeDiscoverFailed)
 	}
 }
 
@@ -575,8 +583,8 @@ func TestHandleSkillsDiscoverDirectory_FetchFailure(t *testing.T) {
 	if !strings.Contains(apiErr.Message, "Failed to fetch remote skills") {
 		t.Errorf("message = %q, want it to contain %q", apiErr.Message, "Failed to fetch remote skills")
 	}
-	if apiErr.Code != "discover_failed" {
-		t.Errorf("code = %q, want discover_failed", apiErr.Code)
+	if apiErr.Code != ErrCodeDiscoverFailed {
+		t.Errorf("code = %q, want %q", apiErr.Code, ErrCodeDiscoverFailed)
 	}
 	if body := rec.Body.String(); strings.Contains(body, "leaky-token-98765") ||
 		strings.Contains(body, "x-access-token") {
@@ -631,6 +639,210 @@ func TestHandleSkillsDiscoverDirectory_NonRemoteURL(t *testing.T) {
 	}
 	if fetched {
 		t.Error("handler attempted a fetch for a rejected sourceUrl")
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_MixedCaseHost verifies the host gate and the
+// downstream fetch agree on case. The gate is deliberately case-insensitive
+// (hostnames are), but config.DetectRemoteType matches "github.com" exactly, so
+// without canonicalization a mixed-case host passed validation and then died in
+// the fetch layer with a generic 400.
+func TestHandleSkillsDiscoverDirectory_MixedCaseHost(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-mixedcase")
+
+	var requestedURL string
+	defer mockSkillTarballWithHook(t, map[string]string{
+		"repo-main/skills/alpha-skill/SKILL.md": "alpha",
+	}, func(req *http.Request) { requestedURL = req.URL.String() })()
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://GitHub.COM/acme/repo/tree/main/skills",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	const wantURL = "https://github.com/acme/repo/archive/refs/heads/main.tar.gz"
+	if requestedURL != wantURL {
+		t.Errorf("outbound tarball URL = %q, want %q", requestedURL, wantURL)
+	}
+
+	resp := decodeDiscoverSkills(t, rec)
+	if resp.Count != 1 || resp.Skills[0].URI != "gh://acme/repo/alpha-skill@main" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_SourceURLWithFragment verifies a #fragment is
+// stripped before discoverResourceDirs appends "/<child>". Left in place it would
+// produce child URLs like ".../skills#notes/alpha-skill", which look plausible
+// but resolve to nothing.
+func TestHandleSkillsDiscoverDirectory_SourceURLWithFragment(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-fragment")
+
+	var requestedURL string
+	defer mockSkillTarballWithHook(t, map[string]string{
+		"repo-main/skills/alpha-skill/SKILL.md": "alpha",
+		"repo-main/skills/beta-skill/SKILL.md":  "beta",
+	}, func(req *http.Request) { requestedURL = req.URL.String() })()
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills#notes",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(requestedURL, "notes") {
+		t.Errorf("fragment leaked into the fetch URL: %s", requestedURL)
+	}
+
+	resp := decodeDiscoverSkills(t, rec)
+	if resp.Count != 2 {
+		t.Fatalf("expected 2 skills, got %+v", resp)
+	}
+	want := map[string]bool{
+		"gh://acme/repo/alpha-skill@main": true,
+		"gh://acme/repo/beta-skill@main":  true,
+	}
+	for _, sk := range resp.Skills {
+		if !want[sk.URI] {
+			t.Errorf("unexpected URI %q; want one of %v", sk.URI, want)
+		}
+		delete(want, sk.URI)
+	}
+	if len(want) != 0 {
+		t.Errorf("missing URIs: %v", want)
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_StripsURLCredentials verifies userinfo is
+// dropped during canonicalization. "https://x-access-token:SECRET@github.com/..."
+// parses with Host == "github.com", and the canonical base is both logged and
+// echoed in the "no skills found at <base>" message — so a pasted credential
+// would otherwise reach the hub log, the client, and GitHub.
+func TestHandleSkillsDiscoverDirectory_StripsURLCredentials(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-userinfo")
+
+	var requestedURL, authHeader string
+	defer mockSkillTarballWithHook(t, map[string]string{
+		"repo-main/skills/alpha-skill/SKILL.md": "alpha",
+	}, func(req *http.Request) {
+		requestedURL = req.URL.String()
+		authHeader = req.Header.Get("Authorization")
+	})()
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://x-access-token:pasted-secret-4242@github.com/acme/repo/tree/main/skills",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	const wantURL = "https://github.com/acme/repo/archive/refs/heads/main.tar.gz"
+	if requestedURL != wantURL {
+		t.Errorf("outbound tarball URL = %q, want %q", requestedURL, wantURL)
+	}
+	if strings.Contains(authHeader, "pasted-secret-4242") {
+		t.Errorf("pasted credential reached the wire as auth: %q", authHeader)
+	}
+	if body := rec.Body.String(); strings.Contains(body, "pasted-secret-4242") ||
+		strings.Contains(body, "x-access-token") {
+		t.Errorf("response body echoes the pasted credential: %s", body)
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_SourceURLWithoutTreeRef verifies a GitHub URL
+// with no /tree/<ref>/ segment is rejected up front. Such a URL would otherwise
+// pass the host check, spend a full tarball fetch, and then fail normalization
+// for every child — surfacing as a misleading "no skills found".
+func TestHandleSkillsDiscoverDirectory_SourceURLWithoutTreeRef(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-notree")
+
+	// Any fetch attempt is a failure of the test's premise; make it loud.
+	old := http.DefaultClient.Transport
+	defer func() { http.DefaultClient.Transport = old }()
+	fetched := false
+	http.DefaultClient.Transport = &mockRoundTripper{
+		roundTrip: func(req *http.Request) (*http.Response, error) {
+			fetched = true
+			return nil, fmt.Errorf("unexpected outbound request to %s", req.URL)
+		},
+	}
+
+	cases := []struct {
+		name      string
+		sourceURL string
+	}{
+		{"bare repo", "https://github.com/acme/repo"},
+		{"repo with trailing slash", "https://github.com/acme/repo/"},
+		{"path without tree", "https://github.com/acme/repo/skills"},
+		{"org only", "https://github.com/acme"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+				SourceURL: tc.sourceURL,
+			})
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 for %q, got %d: %s", tc.sourceURL, rec.Code, rec.Body.String())
+			}
+			apiErr := decodeDiscoverError(t, rec)
+			if apiErr.Code != ErrCodeInvalidRequest {
+				t.Errorf("code = %q, want %q", apiErr.Code, ErrCodeInvalidRequest)
+			}
+			if !strings.Contains(apiErr.Message, "tree") {
+				t.Errorf("message = %q, want an actionable message mentioning 'tree'", apiErr.Message)
+			}
+		})
+	}
+	if fetched {
+		t.Error("handler attempted a fetch for a sourceUrl with no /tree/<ref>/ segment")
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_CacheCleanup is a canary for the handler's
+// `defer os.RemoveAll(cachePath)`: discovery persists nothing, so the fetched
+// tarball must not outlive the response. HOME is redirected so the assertion
+// covers a private copy of ~/.scion/cache/remote-templates.
+func TestHandleSkillsDiscoverDirectory_CacheCleanup(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cacheRoot := filepath.Join(home, ".scion", "cache", "remote-templates")
+
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-cleanup")
+
+	defer mockSkillTarball(t, map[string]string{
+		"repo-main/skills/alpha-skill/SKILL.md": "alpha",
+	})()
+
+	countCacheEntries := func() int {
+		entries, err := os.ReadDir(cacheRoot)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return 0
+			}
+			t.Fatalf("failed to read cache root %s: %v", cacheRoot, err)
+		}
+		return len(entries)
+	}
+
+	before := countCacheEntries()
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if after := countCacheEntries(); after != before {
+		t.Errorf("cache entries under %s = %d after discovery, want %d — the fetched "+
+			"tree was not cleaned up", cacheRoot, after, before)
 	}
 }
 

--- a/pkg/hub/handlers_skills_discover_test.go
+++ b/pkg/hub/handlers_skills_discover_test.go
@@ -22,15 +22,18 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
@@ -46,9 +49,20 @@ const skillsDiscoverPath = "/api/v1/skills/discover-directory"
 // globally.
 func mockSkillTarball(t *testing.T, files map[string]string) func() {
 	t.Helper()
+	return mockSkillTarballWithHook(t, files, nil)
+}
+
+// mockSkillTarballWithHook is mockSkillTarball plus an inspection hook invoked
+// with every outbound request before the tarball is served. Tests use it to
+// assert the request URL and Authorization header that reached the wire.
+func mockSkillTarballWithHook(t *testing.T, files map[string]string, hook func(*http.Request)) func() {
+	t.Helper()
 	old := http.DefaultClient.Transport
 	http.DefaultClient.Transport = &mockRoundTripper{
-		roundTrip: func(_ *http.Request) (*http.Response, error) {
+		roundTrip: func(req *http.Request) (*http.Response, error) {
+			if hook != nil {
+				hook(req)
+			}
 			var buf bytes.Buffer
 			gzw := gzip.NewWriter(&buf)
 			tw := tar.NewWriter(gzw)
@@ -70,6 +84,47 @@ func mockSkillTarball(t *testing.T, files map[string]string) func() {
 		},
 	}
 	return func() { http.DefaultClient.Transport = old }
+}
+
+// skillDiscoverMember creates a hub-member non-admin user for discover tests.
+// Hub members get read/list on everything and create on projects, but nothing
+// that grants ActionCreate on an agent inside a project they don't belong to.
+func skillDiscoverMember(t *testing.T, s store.Store, id string) *store.User {
+	t.Helper()
+	ctx := context.Background()
+	u := &store.User{
+		ID: tid(id), Email: id + "@test.com", DisplayName: "Member",
+		Role: store.UserRoleMember, Status: "active", Created: time.Now(),
+	}
+	if err := s.CreateUser(ctx, u); err != nil {
+		t.Fatal(err)
+	}
+	ensureHubMembership(ctx, s, u.ID)
+	return u
+}
+
+// skillDiscoverProject creates a project and, when token is non-empty, stores it
+// as that project's GITHUB_TOKEN secret via the local secret backend.
+func skillDiscoverProject(t *testing.T, srv *Server, s store.Store, suffix, token string) string {
+	t.Helper()
+	ctx := context.Background()
+	projectID := tid("project-skill-discover-" + suffix)
+	if err := s.CreateProject(ctx, &store.Project{
+		ID: projectID, Name: "Skill Discover " + suffix, Slug: "skill-discover-" + suffix,
+		Created: time.Now(), Updated: time.Now(),
+	}); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+	if token != "" {
+		srv.SetSecretBackend(secret.NewLocalBackend(s, ""))
+		if _, _, err := srv.GetSecretBackend().Set(ctx, &secret.SetSecretInput{
+			Name: "GITHUB_TOKEN", Value: token, SecretType: secret.TypeEnvironment,
+			Scope: secret.ScopeProject, ScopeID: projectID,
+		}); err != nil {
+			t.Fatalf("failed to store GITHUB_TOKEN: %v", err)
+		}
+	}
+	return projectID
 }
 
 // skillDiscoverAdmin creates a hub-member admin user for discover tests.
@@ -94,24 +149,42 @@ func decodeDiscoverSkills(t *testing.T, rec *httptest.ResponseRecorder) Discover
 	return resp
 }
 
+// decodeDiscoverError parses an error response body and returns the APIError.
+func decodeDiscoverError(t *testing.T, rec *httptest.ResponseRecorder) APIError {
+	t.Helper()
+	var resp ErrorResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode error response %q: %v", rec.Body.String(), err)
+	}
+	return resp.Error
+}
+
 // TestHandleSkillsDiscoverDirectory_StandardSkillsDir verifies the happy path:
 // a URL pointing at a standard skills/ directory returns one entry per child
-// with a gh:// shorthand URI and a non-empty name.
+// with a gh:// shorthand URI and a non-empty name. It also pins the outbound
+// tarball URL so a wrong-repo/wrong-ref regression cannot hide behind the
+// URL-agnostic transport mock.
 func TestHandleSkillsDiscoverDirectory_StandardSkillsDir(t *testing.T) {
 	srv, s, _ := testTemplateBootstrapServer(t)
 	admin := skillDiscoverAdmin(t, s, "user-skill-discover-std")
 
-	defer mockSkillTarball(t, map[string]string{
+	var requestedURL string
+	defer mockSkillTarballWithHook(t, map[string]string{
 		"repo-main/skills/alpha-skill/SKILL.md": "---\nname: alpha-skill\n---\nAlpha",
 		"repo-main/skills/beta-skill/SKILL.md":  "---\nname: beta-skill\n---\nBeta",
 		"repo-main/skills/not-a-skill/README":   "no marker here",
-	})()
+	}, func(req *http.Request) { requestedURL = req.URL.String() })()
 
 	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
 		SourceURL: "https://github.com/acme/repo/tree/main/skills",
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	const wantURL = "https://github.com/acme/repo/archive/refs/heads/main.tar.gz"
+	if requestedURL != wantURL {
+		t.Errorf("outbound tarball URL = %q, want %q", requestedURL, wantURL)
 	}
 
 	resp := decodeDiscoverSkills(t, rec)
@@ -133,6 +206,10 @@ func TestHandleSkillsDiscoverDirectory_StandardSkillsDir(t *testing.T) {
 	}
 	if _, ok := byName["not-a-skill"]; ok {
 		t.Errorf("directory without SKILL.md should not be discovered: %+v", resp.Skills)
+	}
+	// The marker-less sibling is reported so the UI can explain its absence.
+	if len(resp.Skipped) != 1 || resp.Skipped[0] != "not-a-skill" {
+		t.Errorf("Skipped = %v, want [not-a-skill]", resp.Skipped)
 	}
 }
 
@@ -213,8 +290,12 @@ func TestHandleSkillsDiscoverDirectory_NoSkillsFound(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
 	}
-	if body := rec.Body.String(); !bytes.Contains([]byte(body), []byte("no skills found")) {
-		t.Errorf("expected 'no skills found' in body, got %q", body)
+	apiErr := decodeDiscoverError(t, rec)
+	if !strings.Contains(apiErr.Message, "no skills found") {
+		t.Errorf("expected 'no skills found' in message, got %q", apiErr.Message)
+	}
+	if apiErr.Code != "discover_failed" {
+		t.Errorf("code = %q, want discover_failed", apiErr.Code)
 	}
 }
 
@@ -226,6 +307,9 @@ func TestHandleSkillsDiscoverDirectory_MissingSourceURL(t *testing.T) {
 	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{})
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if code := decodeDiscoverError(t, rec).Code; code != ErrCodeInvalidRequest {
+		t.Errorf("code = %q, want %q", code, ErrCodeInvalidRequest)
 	}
 }
 
@@ -360,5 +444,358 @@ func TestSkillDiscoverKind(t *testing.T) {
 	}
 	if skillDiscoverKind.marker != "SKILL.md" || skillDiscoverKind.noun != "skills" {
 		t.Errorf("unexpected kind config: %+v", skillDiscoverKind)
+	}
+	// Design invariant: skill discovery never persists anything, so the kind
+	// carries no store constructor. This is what makes the handler safe to call
+	// on a hub with no object storage configured — assert it so a future edit
+	// that populates newStore has to justify itself.
+	if skillDiscoverKind.newStore != nil {
+		t.Error("skillDiscoverKind.newStore must be nil: discovery never writes to a store")
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_ProjectAuthToken verifies that supplying a
+// projectId makes the fetch spend that project's GitHub credentials: the
+// GITHUB_TOKEN secret must reach the wire as a Bearer header. Without this the
+// whole credential-scoping path (and the authorization that guards it) is
+// unverified.
+func TestHandleSkillsDiscoverDirectory_ProjectAuthToken(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-token")
+	projectID := skillDiscoverProject(t, srv, s, "token", "my-secret-token-12345")
+
+	var capturedAuthHeader string
+	defer mockSkillTarballWithHook(t, map[string]string{
+		"repo-main/skills/private-skill/SKILL.md": "private",
+	}, func(req *http.Request) {
+		capturedAuthHeader = req.Header.Get("Authorization")
+	})()
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills",
+		ProjectID: projectID,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if capturedAuthHeader != "Bearer my-secret-token-12345" {
+		t.Errorf("Authorization header = %q, want %q", capturedAuthHeader, "Bearer my-secret-token-12345")
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_UserNotInProject verifies FIX-1: a
+// hub-member user who is not a member of the named project may not spend that
+// project's GitHub credentials.
+func TestHandleSkillsDiscoverDirectory_UserNotInProject(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	outsider := skillDiscoverMember(t, s, "user-skill-discover-outsider")
+	projectID := skillDiscoverProject(t, srv, s, "outsider", "should-never-be-used")
+
+	// No transport mock: a correctly-behaving handler rejects before fetching.
+	rec := doRequestAsUser(t, srv, outsider, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills",
+		ProjectID: projectID,
+	})
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if code := decodeDiscoverError(t, rec).Code; code != ErrCodeForbidden {
+		t.Errorf("code = %q, want %q", code, ErrCodeForbidden)
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_UnknownProject verifies a projectId that
+// does not resolve fails loudly rather than silently degrading to an
+// unauthenticated fetch. Uses an admin so the authz check passes and the
+// existence check is what rejects.
+func TestHandleSkillsDiscoverDirectory_UnknownProject(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-noproj")
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills",
+		ProjectID: tid("project-does-not-exist"),
+	})
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_NonAdminUser verifies discovery is not
+// accidentally admin-only. Adding a hub-scope injected skill requires admin,
+// but probing a public repo does not.
+func TestHandleSkillsDiscoverDirectory_NonAdminUser(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	member := skillDiscoverMember(t, s, "user-skill-discover-plain")
+
+	defer mockSkillTarball(t, map[string]string{
+		"repo-main/skills/public-skill/SKILL.md": "public",
+	})()
+
+	rec := doRequestAsUser(t, srv, member, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_FetchFailure verifies a failed fetch returns
+// a generic message. The raw error must never be echoed: the sparse-checkout
+// fallback builds an "https://x-access-token:<TOKEN>@github.com/..." remote and
+// git's stderr repeats that URL verbatim.
+func TestHandleSkillsDiscoverDirectory_FetchFailure(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-fetchfail")
+	projectID := skillDiscoverProject(t, srv, s, "fetchfail", "leaky-token-98765")
+
+	// Emptying PATH makes the git fallback fail on exec.LookPath, so the test
+	// stays hermetic (no clone attempt against the real github.com).
+	t.Setenv("PATH", "")
+
+	old := http.DefaultClient.Transport
+	defer func() { http.DefaultClient.Transport = old }()
+	http.DefaultClient.Transport = &mockRoundTripper{
+		roundTrip: func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(bytes.NewReader(nil)),
+			}, nil
+		},
+	}
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills",
+		ProjectID: projectID,
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	apiErr := decodeDiscoverError(t, rec)
+	if !strings.Contains(apiErr.Message, "Failed to fetch remote skills") {
+		t.Errorf("message = %q, want it to contain %q", apiErr.Message, "Failed to fetch remote skills")
+	}
+	if apiErr.Code != "discover_failed" {
+		t.Errorf("code = %q, want discover_failed", apiErr.Code)
+	}
+	if body := rec.Body.String(); strings.Contains(body, "leaky-token-98765") ||
+		strings.Contains(body, "x-access-token") {
+		t.Errorf("response body leaks credentials: %s", body)
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_NonRemoteURL verifies FIX-2: only
+// https://github.com/ URLs are accepted. config.IsRemoteURI would have admitted
+// the rclone and http:// forms, giving an attacker a filesystem-copy and an
+// SSRF primitive respectively.
+func TestHandleSkillsDiscoverDirectory_NonRemoteURL(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-badurl")
+
+	// Any fetch attempt is a failure of the test's premise; make it loud.
+	old := http.DefaultClient.Transport
+	defer func() { http.DefaultClient.Transport = old }()
+	fetched := false
+	http.DefaultClient.Transport = &mockRoundTripper{
+		roundTrip: func(req *http.Request) (*http.Response, error) {
+			fetched = true
+			return nil, fmt.Errorf("unexpected outbound request to %s", req.URL)
+		},
+	}
+
+	cases := []struct {
+		name      string
+		sourceURL string
+	}{
+		{"gh shorthand", "gh://org/repo/skill@main"},
+		{"rclone local", ":local:/"},
+		{"rclone remote", "myremote:bucket/skills"},
+		{"ftp scheme", "ftp://host/x"},
+		{"plain http internal host", "http://internal/path"},
+		{"http github", "http://github.com/acme/repo/tree/main/skills"},
+		{"other https host", "https://gitlab.com/acme/repo/tree/main/skills"},
+		{"bare name", "my-skill"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+				SourceURL: tc.sourceURL,
+			})
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 for %q, got %d: %s", tc.sourceURL, rec.Code, rec.Body.String())
+			}
+			if code := decodeDiscoverError(t, rec).Code; code != ErrCodeInvalidRequest {
+				t.Errorf("code = %q, want %q", code, ErrCodeInvalidRequest)
+			}
+		})
+	}
+	if fetched {
+		t.Error("handler attempted a fetch for a rejected sourceUrl")
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_MalformedBody verifies a body that is not
+// JSON is a 400 rather than a panic or a 500.
+func TestHandleSkillsDiscoverDirectory_MalformedBody(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-badbody")
+
+	token, _, _, err := srv.userTokenService.GenerateTokenPair(
+		admin.ID, admin.Email, admin.DisplayName, admin.Role, ClientTypeWeb,
+	)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, skillsDiscoverPath, bytes.NewReader([]byte("{not json")))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_TokenSuffix verifies FIX-5: a
+// ?token=SECRET_NAME suffix survives discovery. discoverResourceDirs builds
+// child URLs by plain concatenation, so without the split/re-attach every child
+// URL would read ".../skills?token=X/child" and fail normalization, producing a
+// spurious "no skills found".
+func TestHandleSkillsDiscoverDirectory_TokenSuffix(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-tokensuffix")
+
+	var requestedURL string
+	defer mockSkillTarballWithHook(t, map[string]string{
+		"repo-main/skills/alpha-skill/SKILL.md": "alpha",
+		"repo-main/skills/beta-skill/SKILL.md":  "beta",
+	}, func(req *http.Request) { requestedURL = req.URL.String() })()
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills?token=SKILLS_TOKEN",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// The suffix names a secret; it must not travel to GitHub.
+	if strings.Contains(requestedURL, "SKILLS_TOKEN") {
+		t.Errorf("token suffix leaked into the fetch URL: %s", requestedURL)
+	}
+
+	resp := decodeDiscoverSkills(t, rec)
+	if resp.Count != 2 {
+		t.Fatalf("expected 2 skills, got %+v", resp)
+	}
+	want := map[string]bool{
+		"gh://acme/repo/alpha-skill@main?token=SKILLS_TOKEN": true,
+		"gh://acme/repo/beta-skill@main?token=SKILLS_TOKEN":  true,
+	}
+	for _, sk := range resp.Skills {
+		if !want[sk.URI] {
+			t.Errorf("unexpected URI %q; want one of %v", sk.URI, want)
+		}
+		delete(want, sk.URI)
+	}
+	if len(want) != 0 {
+		t.Errorf("missing URIs: %v", want)
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_SkipsUnnormalizableChild verifies graceful
+// degradation: a child that cannot yield a valid skill URI is dropped and the
+// rest are still returned.
+//
+// With the FIX-6 name guard in place, the reachable form of "unnormalizable
+// child" is a directory whose name carries URI syntax — the guard rejects it
+// before NormalizeSkillURI would, and for the same reason: a directory named
+// "helper?token=PROD_SECRET" would otherwise smuggle a secret reference into a
+// URI the client is invited to add.
+func TestHandleSkillsDiscoverDirectory_SkipsUnnormalizableChild(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-skipchild")
+
+	defer mockSkillTarball(t, map[string]string{
+		"repo-main/skills/alpha-skill/SKILL.md":              "alpha",
+		"repo-main/skills/beta-skill/SKILL.md":               "beta",
+		"repo-main/skills/helper?token=PROD_SECRET/SKILL.md": "sneaky",
+	})()
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	resp := decodeDiscoverSkills(t, rec)
+	if resp.Count != 2 || len(resp.Skills) != 2 {
+		t.Fatalf("expected exactly the 2 valid skills, got %+v", resp)
+	}
+	for _, sk := range resp.Skills {
+		if strings.Contains(sk.URI, "PROD_SECRET") || strings.Contains(sk.Name, "?") {
+			t.Errorf("unsafe directory name leaked into the response: %+v", sk)
+		}
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_AllChildrenUnnormalizable is the companion
+// to the case above: when nothing survives, the result is a 400 rather than an
+// empty 200.
+func TestHandleSkillsDiscoverDirectory_AllChildrenUnnormalizable(t *testing.T) {
+	srv, s, _ := testTemplateBootstrapServer(t)
+	admin := skillDiscoverAdmin(t, s, "user-skill-discover-allbad")
+
+	defer mockSkillTarball(t, map[string]string{
+		"repo-main/skills/one?token=A/SKILL.md": "one",
+		"repo-main/skills/two=two/SKILL.md":     "two",
+	})()
+
+	rec := doRequestAsUser(t, srv, admin, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if msg := decodeDiscoverError(t, rec).Message; !strings.Contains(msg, "no skills found") {
+		t.Errorf("message = %q, want it to contain 'no skills found'", msg)
+	}
+}
+
+// TestHandleSkillsDiscoverDirectory_AgentOmitsProjectID verifies the handler
+// force-scopes an agent's request onto its own project. Without that, an agent
+// that left projectId off would silently get an unauthenticated fetch and fail
+// on private repos.
+func TestHandleSkillsDiscoverDirectory_AgentOmitsProjectID(t *testing.T) {
+	srv, projectID, token := setupSkillDiscoverAgent(t, "noprojid",
+		[]AgentTokenScope{ScopeAgentStatusUpdate, ScopeAgentCreate})
+
+	srv.SetSecretBackend(secret.NewLocalBackend(srv.store, ""))
+	if _, _, err := srv.GetSecretBackend().Set(context.Background(), &secret.SetSecretInput{
+		Name: "GITHUB_TOKEN", Value: "agent-project-token", SecretType: secret.TypeEnvironment,
+		Scope: secret.ScopeProject, ScopeID: projectID,
+	}); err != nil {
+		t.Fatalf("failed to store GITHUB_TOKEN: %v", err)
+	}
+
+	var capturedAuthHeader string
+	defer mockSkillTarballWithHook(t, map[string]string{
+		"repo-main/skills/agent-skill/SKILL.md": "hi",
+	}, func(req *http.Request) {
+		capturedAuthHeader = req.Header.Get("Authorization")
+	})()
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodPost, skillsDiscoverPath, DiscoverSkillsRequest{
+		SourceURL: "https://github.com/acme/repo/tree/main/skills",
+	}, token)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if capturedAuthHeader != "Bearer agent-project-token" {
+		t.Errorf("Authorization header = %q, want %q — agent request was not scoped to its own project",
+			capturedAuthHeader, "Bearer agent-project-token")
 	}
 }

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2994,6 +2994,11 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/resources/import", s.handleResourcesImport)
 	s.mux.HandleFunc("/api/v1/resources/discover", s.handleResourcesDiscover)
 
+	// Skill directory discovery (batch-add support for injected skills). Registered
+	// as an exact path so it takes precedence over the /api/v1/skills/ subtree
+	// handler above.
+	s.mux.HandleFunc("/api/v1/skills/discover-directory", s.handleSkillsDiscoverDirectory)
+
 	// GitHub App webhook and setup callback (unauthenticated — uses webhook signature)
 	s.mux.HandleFunc("/api/v1/webhooks/github", s.handleGitHubWebhook)
 	s.mux.HandleFunc("/github-app/setup", s.handleGitHubAppSetup)

--- a/pkg/hubclient/client.go
+++ b/pkg/hubclient/client.go
@@ -113,6 +113,10 @@ type Client interface {
 	// HubPreStartHooks returns the hub-scoped pre-start hook service.
 	HubPreStartHooks() HubPreStartHookService
 
+	// DiscoverSkillsDirectory calls POST /api/v1/skills/discover-directory and returns
+	// the list of skills found at the given GitHub directory URL.
+	DiscoverSkillsDirectory(ctx context.Context, req DiscoverSkillsDirectoryRequest) (*DiscoverSkillsDirectoryResponse, error)
+
 	// Health checks API availability.
 	Health(ctx context.Context) (*HealthResponse, error)
 }

--- a/pkg/hubclient/skill_discover.go
+++ b/pkg/hubclient/skill_discover.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hubclient
+
+import (
+	"context"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
+)
+
+// DiscoverSkillsDirectoryRequest is the request body for POST /api/v1/skills/discover-directory.
+type DiscoverSkillsDirectoryRequest struct {
+	SourceURL string `json:"sourceUrl"`
+	ProjectID string `json:"projectId,omitempty"`
+}
+
+// DiscoveredSkill is one entry in a discover-directory response.
+type DiscoveredSkill struct {
+	URI  string `json:"uri"`
+	Name string `json:"name"`
+}
+
+// DiscoverSkillsDirectoryResponse is the response body for POST /api/v1/skills/discover-directory.
+type DiscoverSkillsDirectoryResponse struct {
+	Skills  []DiscoveredSkill `json:"skills"`
+	Count   int               `json:"count"`
+	Skipped []string          `json:"skipped,omitempty"`
+}
+
+// DiscoverSkillsDirectory calls POST /api/v1/skills/discover-directory and returns
+// the list of skills found at the given GitHub directory URL.
+func (c *client) DiscoverSkillsDirectory(ctx context.Context, req DiscoverSkillsDirectoryRequest) (*DiscoverSkillsDirectoryResponse, error) {
+	resp, err := c.post(ctx, "/api/v1/skills/discover-directory", req, nil)
+	if err != nil {
+		return nil, err
+	}
+	return apiclient.DecodeResponse[DiscoverSkillsDirectoryResponse](resp)
+}

--- a/pkg/hubclient/skill_discover_test.go
+++ b/pkg/hubclient/skill_discover_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hubclient_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverSkillsDirectory_HappyPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/api/v1/skills/discover-directory" && r.Method == http.MethodPost {
+			_ = json.NewEncoder(w).Encode(hubclient.DiscoverSkillsDirectoryResponse{
+				Skills: []hubclient.DiscoveredSkill{
+					{URI: "skill://org/skill-a", Name: "skill-a"},
+					{URI: "skill://org/skill-b", Name: "skill-b"},
+				},
+				Count: 2,
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	c, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	resp, err := c.DiscoverSkillsDirectory(context.Background(), hubclient.DiscoverSkillsDirectoryRequest{
+		SourceURL: "https://github.com/org/repo/tree/main/skills",
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp.Skills, 2)
+	assert.Equal(t, "skill://org/skill-a", resp.Skills[0].URI)
+	assert.Equal(t, "skill-a", resp.Skills[0].Name)
+	assert.Equal(t, "skill://org/skill-b", resp.Skills[1].URI)
+	assert.Equal(t, "skill-b", resp.Skills[1].Name)
+	assert.Equal(t, 2, resp.Count)
+}
+
+func TestDiscoverSkillsDirectory_ErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/api/v1/skills/discover-directory" && r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"code":    "bad_request",
+				"message": "invalid source URL",
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	c, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	_, err = c.DiscoverSkillsDirectory(context.Background(), hubclient.DiscoverSkillsDirectoryRequest{
+		SourceURL: "not-a-valid-url",
+	})
+	assert.Error(t, err)
+}
+
+func TestDiscoverSkillsDirectory_ProjectIDForwarded(t *testing.T) {
+	var receivedProjectID string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/api/v1/skills/discover-directory" && r.Method == http.MethodPost {
+			var req hubclient.DiscoverSkillsDirectoryRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			receivedProjectID = req.ProjectID
+			_ = json.NewEncoder(w).Encode(hubclient.DiscoverSkillsDirectoryResponse{
+				Skills: []hubclient.DiscoveredSkill{
+					{URI: "skill://org/skill-a", Name: "skill-a"},
+				},
+				Count: 1,
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	c, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	_, err = c.DiscoverSkillsDirectory(context.Background(), hubclient.DiscoverSkillsDirectoryRequest{
+		SourceURL: "https://github.com/org/repo/tree/main/skills",
+		ProjectID: "my-project-id",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "my-project-id", receivedProjectID)
+}

--- a/pkg/templatecache/hydrator_test.go
+++ b/pkg/templatecache/hydrator_test.go
@@ -131,6 +131,9 @@ func (m *mockHubClient) ProjectPreStartHooks(projectID string) hubclient.Project
 	return nil
 }
 func (m *mockHubClient) HubPreStartHooks() hubclient.HubPreStartHookService { return nil }
+func (m *mockHubClient) DiscoverSkillsDirectory(ctx context.Context, req hubclient.DiscoverSkillsDirectoryRequest) (*hubclient.DiscoverSkillsDirectoryResponse, error) {
+	return nil, nil
+}
 func (m *mockHubClient) Health(ctx context.Context) (*hubclient.HealthResponse, error) {
 	return nil, nil
 }

--- a/web/src/components/shared/injected-skills-panel.test.ts
+++ b/web/src/components/shared/injected-skills-panel.test.ts
@@ -17,15 +17,23 @@
 /**
  * Tests for the directory batch-add flow in injected-skills-panel.ts.
  *
- * Three behaviours matter and are easy to regress:
+ * Four behaviours matter and are easy to regress:
  *
  *  1. The "Discover Skills from Directory" button is gated on the *normalized*
- *     URI, not the raw input. gh:// and skill:// URIs are unambiguously single
- *     skills and must not offer discovery; a URL that stays https:// might be
- *     a directory, so discovery is offered alongside plain add.
+ *     URI, not the raw input, and only for github.com hosts. gh:// and skill://
+ *     URIs are unambiguously single skills and must not offer discovery; a URL
+ *     that stays https://github.com/ might be a directory, so discovery is
+ *     offered alongside plain add.
  *  2. Hub scope must batch into exactly ONE PUT. Hub injected skills use a
  *     PUT-whole-list API, so a naive loop would issue N read-modify-writes.
- *  3. Project/user scope keeps using the per-item POST endpoint, once per URI.
+ *  3. Project/user scope keeps using the per-item POST endpoint, once per URI —
+ *     and that endpoint 409s on duplicates, so addEntries() must filter what is
+ *     already present and must not abort the batch on the first failure.
+ *  4. Discovery state must not survive a Cancel.
+ *
+ * Shoelace elements are not registered in this environment; they render as
+ * unknown elements, which is enough to assert presence, attributes, and to
+ * dispatch the sl-* events the component listens for.
  */
 
 // @vitest-environment happy-dom
@@ -43,13 +51,34 @@ interface Call {
   body: any;
 }
 
+/** Knobs for the fetch mock. All optional; defaults are the happy path. */
+interface MockOptions {
+  /** Response for POST /api/v1/skills/discover-directory. */
+  discover?: { status: number; body: unknown };
+  /** Deferred gate: when set, the discover response waits on this promise. */
+  discoverGate?: Promise<void>;
+  /** Per-skillUri status override for injected-skill POSTs (default 201). */
+  postStatus?: Record<string, number>;
+  /** Status for the hub PUT (default 200). */
+  putStatus?: number;
+  /** Entries returned by the list GET, in project/user wire shape. */
+  entries?: Array<{ id: string; skillUri: string }>;
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
 /**
  * Build a fetch mock that records every call and answers the endpoints the
- * panel touches: list GETs, project/user POSTs, hub PUTs, and the new
+ * panel touches: list GETs, project/user POSTs, hub PUTs, and the
  * discover-directory POST.
  */
-function makeFetchMock(calls: Call[], discoverResponse?: { status: number; body: unknown }) {
-  return (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+function makeFetchMock(calls: Call[], opts: MockOptions = {}) {
+  return async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const href = String(url);
     const method = init?.method ?? 'GET';
     let parsed: any = undefined;
@@ -63,42 +92,95 @@ function makeFetchMock(calls: Call[], discoverResponse?: { status: number; body:
     calls.push({ url: href, method, body: parsed });
 
     if (href.includes('/skills/discover-directory')) {
-      const r = discoverResponse ?? { status: 200, body: { skills: [], count: 0 } };
-      return Promise.resolve(
-        new Response(JSON.stringify(r.body), {
-          status: r.status,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      );
+      if (opts.discoverGate) await opts.discoverGate;
+      const r = opts.discover ?? { status: 200, body: { skills: [], count: 0 } };
+      return jsonResponse(r.body, r.status);
+    }
+
+    if (method === 'POST') {
+      const status = opts.postStatus?.[parsed?.skillUri as string] ?? 201;
+      if (status >= 400) {
+        return jsonResponse({ error: { code: 'conflict', message: `rejected ${status}` } }, status);
+      }
+      return jsonResponse({ id: 'new-entry' }, status);
+    }
+
+    if (method === 'PUT') {
+      const status = opts.putStatus ?? 200;
+      if (status >= 400) {
+        return jsonResponse({ error: { message: 'boom' } }, status);
+      }
+      return jsonResponse({}, status);
     }
 
     // Hub list GET and project/user list GET have different shapes; return both
-    // keys so either read path finds an empty list.
-    return Promise.resolve(
-      new Response(JSON.stringify({ entries: [], system: [], user_defined: [] }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
+    // keys so either read path finds the configured list.
+    return jsonResponse(
+      { entries: opts.entries ?? [], system: [], user_defined: [] },
+      200
     );
   };
+}
+
+/** Wait until the panel's initial (or in-flight) load() has settled. */
+async function settle(el: any): Promise<void> {
+  await vi.waitFor(() => {
+    if (el.loading) throw new Error('panel still loading');
+  });
+  await el.updateComplete;
 }
 
 /** Create the panel for a given scope and let its initial load() settle. */
 async function createPanel(
   scope: 'project' | 'user' | 'hub',
   calls: Call[],
-  discoverResponse?: { status: number; body: unknown }
+  opts: MockOptions = {}
 ) {
-  vi.stubGlobal('fetch', vi.fn(makeFetchMock(calls, discoverResponse)));
+  vi.stubGlobal('fetch', vi.fn(makeFetchMock(calls, opts)));
   const el = document.createElement('scion-injected-skills-panel') as any;
   el.scope = scope;
   if (scope === 'project') el.scopeId = 'proj-1';
   document.body.appendChild(el);
-  await el.updateComplete;
-  await new Promise((r) => setTimeout(r, 20));
-  await el.updateComplete;
+  await settle(el);
   calls.length = 0; // Drop the initial load GET so assertions see only the action.
   return el;
+}
+
+/** Build a SkillRow the way load() would. */
+function row(uri: string, readonly = false) {
+  return {
+    id: `id-${uri}`,
+    uri,
+    as: '',
+    optional: false,
+    sortOrder: 0,
+    skillName: '',
+    skillSlug: '',
+    readonly,
+  };
+}
+
+/** All <sl-button> labels currently in the panel's shadow DOM. */
+function buttonLabels(el: any): string[] {
+  return [...el.shadowRoot.querySelectorAll('sl-button')].map((b: any) =>
+    (b.textContent ?? '').trim()
+  );
+}
+
+const DISCOVER_LABEL = 'Discover Skills from Directory';
+
+/** Open the add dialog in URI mode with the given input value. */
+async function openUriDialog(el: any, uri: string) {
+  el.dialogOpen = true;
+  el.dialogMode = 'uri';
+  el.dialogUri = uri;
+  await el.updateComplete;
+}
+
+function cleanup() {
+  document.body.innerHTML = '';
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 }
 
 describe('injected-skills-panel — discover button gating', () => {
@@ -108,10 +190,7 @@ describe('injected-skills-panel — discover button gating', () => {
     expect(ScionInjectedSkillsPanel).toBeDefined();
   });
 
-  afterEach(() => {
-    document.body.innerHTML = '';
-    vi.restoreAllMocks();
-  });
+  afterEach(cleanup);
 
   it('does not offer discovery for a gh:// URI', async () => {
     const el = await createPanel('project', []);
@@ -135,7 +214,7 @@ describe('injected-skills-panel — discover button gating', () => {
     expect(el.showDiscoverButton).toBe(false);
   });
 
-  it('offers discovery when the normalized result stays https://', async () => {
+  it('offers discovery when the normalized result stays a github.com https:// URL', async () => {
     const el = await createPanel('project', []);
     el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
     el.dialogTransformed = null;
@@ -148,6 +227,77 @@ describe('injected-skills-panel — discover button gating', () => {
     el.dialogTransformed = 'https://github.com/org/repo/tree/main/custom';
     expect(el.showDiscoverButton).toBe(true);
   });
+
+  it('does not offer discovery for a non-github https:// host', async () => {
+    // The backend rejects anything but https://github.com/, so offering the
+    // button here would only buy the user a round-trip to a 400.
+    const el = await createPanel('project', []);
+    el.dialogUri = 'https://gitlab.com/org/repo/tree/main/skills';
+    el.dialogTransformed = null;
+    expect(el.showDiscoverButton).toBe(false);
+  });
+
+  it('matches the github.com host case-insensitively', async () => {
+    const el = await createPanel('project', []);
+    el.dialogUri = 'HTTPS://GitHub.com/org/repo/tree/main/skills';
+    el.dialogTransformed = null;
+    expect(el.showDiscoverButton).toBe(true);
+  });
+});
+
+describe('injected-skills-panel — discover button in the DOM', () => {
+  beforeAll(async () => {
+    await import('./injected-skills-panel.js');
+  });
+
+  afterEach(cleanup);
+
+  it('renders the discover button for a GitHub directory URL in URI mode', async () => {
+    const el = await createPanel('project', []);
+    await openUriDialog(el, 'https://github.com/org/repo/tree/main/skills');
+    expect(buttonLabels(el)).toContain(DISCOVER_LABEL);
+  });
+
+  it('omits the discover button for a gh:// URI', async () => {
+    const el = await createPanel('project', []);
+    await openUriDialog(el, 'gh://org/repo/my-skill@main');
+    expect(buttonLabels(el)).not.toContain(DISCOVER_LABEL);
+  });
+
+  it('omits the discover button in skill-bank search mode', async () => {
+    // Search mode picks a hub-bank skill by slug; there is no URL to probe.
+    const el = await createPanel('project', []);
+    el.dialogOpen = true;
+    el.dialogMode = 'search';
+    el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
+    await el.updateComplete;
+    expect(buttonLabels(el)).not.toContain(DISCOVER_LABEL);
+  });
+
+  it('shows the button once typing produces a directory URL', async () => {
+    // Drive the real sl-input handler so normalizeSkillURIClient runs, rather
+    // than setting dialogTransformed by hand and bypassing the gate under test.
+    const el = await createPanel('project', []);
+    el.dialogOpen = true;
+    el.dialogMode = 'uri';
+    await el.updateComplete;
+
+    const input: any = el.shadowRoot.querySelector('sl-input[label="Skill URI"]');
+    expect(input).toBeTruthy();
+
+    // A standard skills/<name> path normalizes to gh:// — single skill, no button.
+    input.value = 'https://github.com/org/repo/tree/main/skills/my-skill';
+    input.dispatchEvent(new Event('sl-input'));
+    await el.updateComplete;
+    expect(el.dialogTransformed).toBe('gh://org/repo/my-skill@main');
+    expect(buttonLabels(el)).not.toContain(DISCOVER_LABEL);
+
+    // The parent directory stays https:// — offer discovery.
+    input.value = 'https://github.com/org/repo/tree/main/skills';
+    input.dispatchEvent(new Event('sl-input'));
+    await el.updateComplete;
+    expect(buttonLabels(el)).toContain(DISCOVER_LABEL);
+  });
 });
 
 describe('injected-skills-panel — handleDiscoverDirectory', () => {
@@ -155,21 +305,20 @@ describe('injected-skills-panel — handleDiscoverDirectory', () => {
     await import('./injected-skills-panel.js');
   });
 
-  afterEach(() => {
-    document.body.innerHTML = '';
-    vi.restoreAllMocks();
-  });
+  afterEach(cleanup);
 
   it('opens the selection dialog with everything pre-selected on success', async () => {
     const calls: Call[] = [];
     const el = await createPanel('project', calls, {
-      status: 200,
-      body: {
-        skills: [
-          { uri: 'gh://org/repo/a@main', name: 'a' },
-          { uri: 'gh://org/repo/b@main', name: 'b' },
-        ],
-        count: 2,
+      discover: {
+        status: 200,
+        body: {
+          skills: [
+            { uri: 'gh://org/repo/a@main', name: 'a' },
+            { uri: 'gh://org/repo/b@main', name: 'b' },
+          ],
+          count: 2,
+        },
       },
     });
 
@@ -185,35 +334,64 @@ describe('injected-skills-panel — handleDiscoverDirectory', () => {
     expect(el.discoveryError).toBeNull();
   });
 
-  it('sends projectId for project scope but not for hub scope', async () => {
-    const projectCalls: Call[] = [];
-    const projectPanel = await createPanel('project', projectCalls, {
-      status: 200,
-      body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 },
+  it('sends projectId for project scope', async () => {
+    const calls: Call[] = [];
+    const el = await createPanel('project', calls, {
+      discover: { status: 200, body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 } },
     });
-    projectPanel.dialogUri = 'https://github.com/org/repo/tree/main/skills';
-    await projectPanel.handleDiscoverDirectory();
-    const projectDiscover = projectCalls.find((c) => c.url.includes('discover-directory'));
-    expect(projectDiscover?.body.projectId).toBe('proj-1');
+    el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
+    await el.handleDiscoverDirectory();
 
-    document.body.innerHTML = '';
+    const discover = calls.find((c) => c.url.includes('discover-directory'));
+    expect(discover?.body.projectId).toBe('proj-1');
+  });
 
-    const hubCalls: Call[] = [];
-    const hubPanel = await createPanel('hub', hubCalls, {
-      status: 200,
-      body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 },
+  it('sends no projectId for hub scope', async () => {
+    const calls: Call[] = [];
+    const el = await createPanel('hub', calls, {
+      discover: { status: 200, body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 } },
     });
-    hubPanel.dialogUri = 'https://github.com/org/repo/tree/main/skills';
-    await hubPanel.handleDiscoverDirectory();
-    const hubDiscover = hubCalls.find((c) => c.url.includes('discover-directory'));
-    expect(hubDiscover?.body.projectId).toBeUndefined();
-    expect(hubDiscover?.body.sourceUrl).toBe('https://github.com/org/repo/tree/main/skills');
+    el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
+    await el.handleDiscoverDirectory();
+
+    const discover = calls.find((c) => c.url.includes('discover-directory'));
+    expect(discover?.body.projectId).toBeUndefined();
+    expect(discover?.body.sourceUrl).toBe('https://github.com/org/repo/tree/main/skills');
+  });
+
+  it('sends no projectId for user scope', async () => {
+    // User scope has no project credentials to spend; the hub does an
+    // unauthenticated fetch of a public repo.
+    const calls: Call[] = [];
+    const el = await createPanel('user', calls, {
+      discover: { status: 200, body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 } },
+    });
+    el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
+    await el.handleDiscoverDirectory();
+
+    const discover = calls.find((c) => c.url.includes('discover-directory'));
+    expect(discover?.body.projectId).toBeUndefined();
+  });
+
+  it('posts the raw directory URL, not the normalized form', async () => {
+    const calls: Call[] = [];
+    const el = await createPanel('project', calls, {
+      discover: { status: 200, body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 } },
+    });
+    el.dialogUri = 'https://github.com/org/repo/tree/main/custom/dir';
+    el.dialogTransformed = 'https://github.com/org/repo/tree/main/custom/dir';
+    await el.handleDiscoverDirectory();
+
+    const discover = calls.find((c) => c.url.includes('discover-directory'));
+    expect(discover?.body.sourceUrl).toBe('https://github.com/org/repo/tree/main/custom/dir');
   });
 
   it('surfaces a backend error inline and does not open the selection dialog', async () => {
     const el = await createPanel('project', [], {
-      status: 400,
-      body: { error: { code: 'discover_failed', message: 'no skills found at ...' } },
+      discover: {
+        status: 400,
+        body: { error: { code: 'discover_failed', message: 'no skills found at ...' } },
+      },
     });
 
     el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
@@ -225,8 +403,7 @@ describe('injected-skills-panel — handleDiscoverDirectory', () => {
 
   it('treats an empty skills array as an error, not an empty dialog', async () => {
     const el = await createPanel('project', [], {
-      status: 200,
-      body: { skills: [], count: 0 },
+      discover: { status: 200, body: { skills: [], count: 0 } },
     });
 
     el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
@@ -245,6 +422,125 @@ describe('injected-skills-panel — handleDiscoverDirectory', () => {
     expect(calls.filter((c) => c.url.includes('discover-directory'))).toHaveLength(0);
     expect(el.discoveryError).toBeTruthy();
   });
+
+  it('holds discoveryLoading for the duration of the probe, on success and on failure', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const el = await createPanel('project', [], {
+      discoverGate: gate,
+      discover: { status: 200, body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 } },
+    });
+    el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
+
+    const inFlight = el.handleDiscoverDirectory();
+    expect(el.discoveryLoading).toBe(true);
+    release();
+    await inFlight;
+    expect(el.discoveryLoading).toBe(false);
+
+    // Same guarantee on the error path.
+    const failing: Call[] = [];
+    const el2 = await createPanel('project', failing, {
+      discover: { status: 500, body: { error: { message: 'boom' } } },
+    });
+    el2.dialogUri = 'https://github.com/org/repo/tree/main/skills';
+    await el2.handleDiscoverDirectory();
+    expect(el2.discoveryLoading).toBe(false);
+    expect(el2.discoveryError).toBeTruthy();
+  });
+});
+
+describe('injected-skills-panel — selection dialog interaction', () => {
+  beforeAll(async () => {
+    await import('./injected-skills-panel.js');
+  });
+
+  afterEach(cleanup);
+
+  /** Mount a panel with the selection dialog open over three discovered skills. */
+  async function withSelection(calls: Call[], scope: 'project' | 'hub' = 'project') {
+    const el = await createPanel(scope, calls);
+    el.discoveredSkills = [
+      { uri: 'gh://org/repo/a@main', name: 'a' },
+      { uri: 'gh://org/repo/b@main', name: 'b' },
+      { uri: 'gh://org/repo/c@main', name: 'c' },
+    ];
+    el.selectedSkillURIs = new Set(el.discoveredSkills.map((s: any) => s.uri));
+    el.discoveryDialogOpen = true;
+    await el.updateComplete;
+    return el;
+  }
+
+  function selectAllCheckbox(el: any) {
+    return el.shadowRoot.querySelector('.selection-header sl-checkbox');
+  }
+
+  function skillCheckboxes(el: any) {
+    return [...el.shadowRoot.querySelectorAll('.selection-item sl-checkbox')];
+  }
+
+  it('Select All clears and restores the whole selection', async () => {
+    const el = await withSelection([]);
+    const header: any = selectAllCheckbox(el);
+    expect(header).toBeTruthy();
+
+    header.checked = false;
+    header.dispatchEvent(new Event('sl-change'));
+    await el.updateComplete;
+    expect(el.selectedSkillURIs.size).toBe(0);
+
+    header.checked = true;
+    header.dispatchEvent(new Event('sl-change'));
+    await el.updateComplete;
+    expect(el.selectedSkillURIs.size).toBe(3);
+  });
+
+  it('marks Select All indeterminate when only some skills are selected', async () => {
+    const el = await withSelection([]);
+    expect(selectAllCheckbox(el).hasAttribute('indeterminate')).toBe(false);
+
+    const [first]: any[] = skillCheckboxes(el);
+    first.checked = false;
+    first.dispatchEvent(new Event('sl-change'));
+    await el.updateComplete;
+
+    expect(el.selectedSkillURIs.size).toBe(2);
+    expect(selectAllCheckbox(el).hasAttribute('indeterminate')).toBe(true);
+  });
+
+  it('toggling one skill assigns a new Set instance so Lit re-renders', async () => {
+    const el = await withSelection([]);
+    const before = el.selectedSkillURIs;
+
+    const [first]: any[] = skillCheckboxes(el);
+    first.checked = false;
+    first.dispatchEvent(new Event('sl-change'));
+    await el.updateComplete;
+
+    expect(el.selectedSkillURIs).not.toBe(before);
+    expect(el.selectedSkillURIs.has('gh://org/repo/a@main')).toBe(false);
+
+    first.checked = true;
+    first.dispatchEvent(new Event('sl-change'));
+    await el.updateComplete;
+    expect(el.selectedSkillURIs.has('gh://org/repo/a@main')).toBe(true);
+  });
+
+  it('closing the selection dialog makes no network calls', async () => {
+    const calls: Call[] = [];
+    const el = await withSelection(calls);
+
+    const dialog = el.shadowRoot.querySelector('sl-dialog[label="Select Skills to Add"]');
+    expect(dialog).toBeTruthy();
+    dialog.dispatchEvent(new Event('sl-request-close'));
+    await el.updateComplete;
+
+    expect(el.discoveryDialogOpen).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
 });
 
 describe('injected-skills-panel — addEntries batching', () => {
@@ -252,10 +548,7 @@ describe('injected-skills-panel — addEntries batching', () => {
     await import('./injected-skills-panel.js');
   });
 
-  afterEach(() => {
-    document.body.innerHTML = '';
-    vi.restoreAllMocks();
-  });
+  afterEach(cleanup);
 
   it('hub scope writes all selected skills in exactly one PUT', async () => {
     const calls: Call[] = [];
@@ -263,10 +556,7 @@ describe('injected-skills-panel — addEntries batching', () => {
 
     // Pretend the hub already holds one system entry and one user entry: the
     // PUT must preserve the user entry and drop the readonly system one.
-    el.rows = [
-      { id: '', uri: 'skill://sys/one', as: '', optional: false, sortOrder: 0, skillName: '', skillSlug: '', readonly: true },
-      { id: '', uri: 'gh://org/repo/existing@main', as: '', optional: false, sortOrder: 1, skillName: '', skillSlug: '', readonly: false },
-    ];
+    el.rows = [row('skill://sys/one', true), row('gh://org/repo/existing@main')];
 
     await el.addEntries(['gh://org/repo/a@main', 'gh://org/repo/b@main', 'gh://org/repo/c@main']);
 
@@ -283,6 +573,23 @@ describe('injected-skills-panel — addEntries batching', () => {
     expect(calls.filter((c) => c.method === 'POST')).toHaveLength(0);
   });
 
+  it('hub scope does not duplicate a URI that is already present', async () => {
+    // setHubInjectedSkills stores whatever list it is handed, so a re-discovery
+    // of the same directory would otherwise append the same URI twice.
+    const calls: Call[] = [];
+    const el = await createPanel('hub', calls);
+    el.rows = [row('gh://org/repo/a@main')];
+
+    await el.addEntries(['gh://org/repo/a@main', 'gh://org/repo/b@main']);
+
+    const puts = calls.filter((c) => c.method === 'PUT');
+    expect(puts).toHaveLength(1);
+    expect(puts[0].body.user_defined.map((r: any) => r.uri)).toEqual([
+      'gh://org/repo/a@main',
+      'gh://org/repo/b@main',
+    ]);
+  });
+
   it('project scope issues one POST per selected skill', async () => {
     const calls: Call[] = [];
     const el = await createPanel('project', calls);
@@ -297,6 +604,18 @@ describe('injected-skills-panel — addEntries batching', () => {
     ]);
     expect(posts[0].url).toContain('/api/v1/projects/proj-1/injected-skills');
     expect(calls.filter((c) => c.method === 'PUT')).toHaveLength(0);
+  });
+
+  it('project scope skips URIs already present rather than POSTing a guaranteed 409', async () => {
+    const calls: Call[] = [];
+    const el = await createPanel('project', calls);
+    el.rows = [row('gh://org/repo/a@main')];
+
+    await el.addEntries(['gh://org/repo/a@main', 'gh://org/repo/b@main']);
+
+    const posts = calls.filter((c) => c.method === 'POST');
+    expect(posts).toHaveLength(1);
+    expect(posts[0].body.skillUri).toBe('gh://org/repo/b@main');
   });
 
   it('user scope issues one POST per selected skill', async () => {
@@ -318,6 +637,41 @@ describe('injected-skills-panel — addEntries batching', () => {
 
     expect(calls).toHaveLength(0);
   });
+
+  it('keeps going past a 409 and reports the failure at the end', async () => {
+    // The injected-skill POST endpoint returns 409 on a duplicate skillUri. A
+    // loop that aborts on the first failure would leave a partial add that can
+    // never be retried, because the skills that did land 409 on the next try.
+    const calls: Call[] = [];
+    const el = await createPanel('project', calls, {
+      postStatus: { 'gh://org/repo/a@main': 409 },
+    });
+
+    await expect(
+      el.addEntries(['gh://org/repo/a@main', 'gh://org/repo/b@main', 'gh://org/repo/c@main'])
+    ).rejects.toThrow(/1 of 3/);
+
+    const posts = calls.filter((c) => c.method === 'POST');
+    expect(posts.map((p) => p.body.skillUri)).toEqual([
+      'gh://org/repo/a@main',
+      'gh://org/repo/b@main',
+      'gh://org/repo/c@main',
+    ]);
+  });
+
+  it('attempts every URI even when one POST fails with a 500', async () => {
+    const calls: Call[] = [];
+    const el = await createPanel('project', calls, {
+      postStatus: { 'gh://org/repo/b@main': 500 },
+    });
+
+    await expect(
+      el.addEntries(['gh://org/repo/a@main', 'gh://org/repo/b@main', 'gh://org/repo/c@main'])
+    ).rejects.toThrow(/gh:\/\/org\/repo\/b@main/);
+
+    const posts = calls.filter((c) => c.method === 'POST');
+    expect(posts).toHaveLength(3);
+  });
 });
 
 describe('injected-skills-panel — handleDiscoveryConfirm', () => {
@@ -325,10 +679,7 @@ describe('injected-skills-panel — handleDiscoveryConfirm', () => {
     await import('./injected-skills-panel.js');
   });
 
-  afterEach(() => {
-    document.body.innerHTML = '';
-    vi.restoreAllMocks();
-  });
+  afterEach(cleanup);
 
   it('adds the selected skills and closes both dialogs', async () => {
     const calls: Call[] = [];
@@ -353,34 +704,7 @@ describe('injected-skills-panel — handleDiscoveryConfirm', () => {
 
   it('keeps the selection dialog open and shows the error when the add fails', async () => {
     const calls: Call[] = [];
-    vi.stubGlobal(
-      'fetch',
-      vi.fn((url: string | URL | Request, init?: RequestInit): Promise<Response> => {
-        const href = String(url);
-        const method = init?.method ?? 'GET';
-        calls.push({ url: href, method, body: undefined });
-        if (method === 'PUT') {
-          return Promise.resolve(
-            new Response(JSON.stringify({ error: { message: 'boom' } }), {
-              status: 500,
-              headers: { 'Content-Type': 'application/json' },
-            })
-          );
-        }
-        return Promise.resolve(
-          new Response(JSON.stringify({ entries: [], system: [], user_defined: [] }), {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          })
-        );
-      })
-    );
-
-    const el = document.createElement('scion-injected-skills-panel') as any;
-    el.scope = 'hub';
-    document.body.appendChild(el);
-    await el.updateComplete;
-    await new Promise((r) => setTimeout(r, 20));
+    const el = await createPanel('hub', calls, { putStatus: 500 });
 
     el.dialogOpen = true;
     el.discoveryDialogOpen = true;
@@ -391,5 +715,66 @@ describe('injected-skills-panel — handleDiscoveryConfirm', () => {
 
     expect(el.discoveryDialogOpen).toBe(true);
     expect(el.discoveryError).toBeTruthy();
+  });
+
+  it('reports a partial project-scope batch without losing the successful adds', async () => {
+    const calls: Call[] = [];
+    const el = await createPanel('project', calls, {
+      postStatus: { 'gh://org/repo/b@main': 409 },
+    });
+
+    el.dialogOpen = true;
+    el.discoveryDialogOpen = true;
+    el.discoveredSkills = [
+      { uri: 'gh://org/repo/a@main', name: 'a' },
+      { uri: 'gh://org/repo/b@main', name: 'b' },
+      { uri: 'gh://org/repo/c@main', name: 'c' },
+    ];
+    el.selectedSkillURIs = new Set(el.discoveredSkills.map((s: any) => s.uri));
+
+    await el.handleDiscoveryConfirm();
+
+    // a and c landed; the dialog stays open naming b.
+    expect(calls.filter((c) => c.method === 'POST')).toHaveLength(3);
+    expect(el.discoveryDialogOpen).toBe(true);
+    expect(el.discoveryError).toContain('gh://org/repo/b@main');
+    expect(el.discoveryLoading).toBe(false);
+  });
+});
+
+describe('injected-skills-panel — discovery state lifecycle', () => {
+  beforeAll(async () => {
+    await import('./injected-skills-panel.js');
+  });
+
+  afterEach(cleanup);
+
+  it('openDialog() clears stale discovery state', async () => {
+    const el = await createPanel('project', []);
+    el.discoveryError = 'stale error';
+    el.discoveredSkills = [{ uri: 'gh://org/repo/a@main', name: 'a' }];
+    el.selectedSkillURIs = new Set(['gh://org/repo/a@main']);
+    el.discoveryDialogOpen = true;
+
+    el.openDialog();
+
+    expect(el.discoveryError).toBeNull();
+    expect(el.discoveredSkills).toEqual([]);
+    expect(el.selectedSkillURIs.size).toBe(0);
+    expect(el.discoveryDialogOpen).toBe(false);
+    expect(el.dialogOpen).toBe(true);
+  });
+
+  it('closeDialog() clears discovery state so a Cancel does not leave a stale error', async () => {
+    const el = await createPanel('project', []);
+    el.dialogOpen = true;
+    el.discoveryError = 'no skills found at ...';
+    el.discoveredSkills = [{ uri: 'gh://org/repo/a@main', name: 'a' }];
+
+    el.closeDialog();
+
+    expect(el.dialogOpen).toBe(false);
+    expect(el.discoveryError).toBeNull();
+    expect(el.discoveredSkills).toEqual([]);
   });
 });

--- a/web/src/components/shared/injected-skills-panel.test.ts
+++ b/web/src/components/shared/injected-skills-panel.test.ts
@@ -423,6 +423,68 @@ describe('injected-skills-panel — handleDiscoverDirectory', () => {
     expect(el.discoveryError).toBeTruthy();
   });
 
+  it('captures the backend skipped[] list and explains it in the dialog', async () => {
+    // The backend reports child directories it passed over (no SKILL.md, or an
+    // unsafe name). Without surfacing them, a folder the user expected simply
+    // vanishes from the list with no explanation.
+    const el = await createPanel('project', [], {
+      discover: {
+        status: 200,
+        body: {
+          skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }],
+          skipped: ['not-a-skill'],
+          count: 1,
+        },
+      },
+    });
+
+    el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
+    await el.handleDiscoverDirectory();
+    await el.updateComplete;
+
+    expect(el.skippedSkillNames).toEqual(['not-a-skill']);
+    const note = el.shadowRoot.querySelector('.discovery-skipped-note');
+    expect(note).toBeTruthy();
+    // Collapse the template's incidental whitespace before matching.
+    expect(note.textContent.replace(/\s+/g, ' ').trim()).toBe(
+      '1 folder not recognized as skills was skipped.'
+    );
+  });
+
+  it('pluralizes the skipped note and omits it when nothing was skipped', async () => {
+    const el = await createPanel('project', [], {
+      discover: {
+        status: 200,
+        body: {
+          skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }],
+          skipped: ['not-a-skill', 'docs'],
+          count: 1,
+        },
+      },
+    });
+    el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
+    await el.handleDiscoverDirectory();
+    await el.updateComplete;
+
+    expect(
+      el.shadowRoot.querySelector('.discovery-skipped-note').textContent.replace(/\s+/g, ' ').trim()
+    ).toBe('2 folders not recognized as skills were skipped.');
+
+    // A response with no skipped[] must not render an empty note.
+    const clean = await createPanel('project', [], {
+      discover: {
+        status: 200,
+        body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 },
+      },
+    });
+    clean.dialogUri = 'https://github.com/org/repo/tree/main/skills';
+    await clean.handleDiscoverDirectory();
+    await clean.updateComplete;
+
+    expect(clean.skippedSkillNames).toEqual([]);
+    expect(clean.shadowRoot.querySelector('.discovery-skipped-note')).toBeNull();
+  });
+
   it('holds discoveryLoading for the duration of the probe, on success and on failure', async () => {
     let release!: () => void;
     const gate = new Promise<void>((resolve) => {
@@ -717,6 +779,31 @@ describe('injected-skills-panel — handleDiscoveryConfirm', () => {
     expect(el.discoveryError).toBeTruthy();
   });
 
+  it('closes both dialogs silently when every selected URI is already present', async () => {
+    // addEntries() returns early when nothing is fresh, so no request is made.
+    // That is intentional — an all-duplicates batch has nothing to write — but
+    // the silence is easy to break by accident, so pin it.
+    const calls: Call[] = [];
+    const el = await createPanel('hub', calls);
+
+    el.rows = [row('gh://org/repo/a@main'), row('gh://org/repo/b@main')];
+    el.dialogOpen = true;
+    el.discoveryDialogOpen = true;
+    el.discoveredSkills = [
+      { uri: 'gh://org/repo/a@main', name: 'a' },
+      { uri: 'gh://org/repo/b@main', name: 'b' },
+    ];
+    el.selectedSkillURIs = new Set(el.discoveredSkills.map((s: any) => s.uri));
+
+    await el.handleDiscoveryConfirm();
+
+    expect(calls).toHaveLength(0);
+    expect(el.discoveryDialogOpen).toBe(false);
+    expect(el.dialogOpen).toBe(false);
+    expect(el.discoveryError).toBeNull();
+    expect(el.discoveryLoading).toBe(false);
+  });
+
   it('reports a partial project-scope batch without losing the successful adds', async () => {
     const calls: Call[] = [];
     const el = await createPanel('project', calls, {
@@ -753,6 +840,7 @@ describe('injected-skills-panel — discovery state lifecycle', () => {
     const el = await createPanel('project', []);
     el.discoveryError = 'stale error';
     el.discoveredSkills = [{ uri: 'gh://org/repo/a@main', name: 'a' }];
+    el.skippedSkillNames = ['stale-folder'];
     el.selectedSkillURIs = new Set(['gh://org/repo/a@main']);
     el.discoveryDialogOpen = true;
 
@@ -760,6 +848,7 @@ describe('injected-skills-panel — discovery state lifecycle', () => {
 
     expect(el.discoveryError).toBeNull();
     expect(el.discoveredSkills).toEqual([]);
+    expect(el.skippedSkillNames).toEqual([]);
     expect(el.selectedSkillURIs.size).toBe(0);
     expect(el.discoveryDialogOpen).toBe(false);
     expect(el.dialogOpen).toBe(true);
@@ -770,11 +859,13 @@ describe('injected-skills-panel — discovery state lifecycle', () => {
     el.dialogOpen = true;
     el.discoveryError = 'no skills found at ...';
     el.discoveredSkills = [{ uri: 'gh://org/repo/a@main', name: 'a' }];
+    el.skippedSkillNames = ['stale-folder'];
 
     el.closeDialog();
 
     expect(el.dialogOpen).toBe(false);
     expect(el.discoveryError).toBeNull();
     expect(el.discoveredSkills).toEqual([]);
+    expect(el.skippedSkillNames).toEqual([]);
   });
 });

--- a/web/src/components/shared/injected-skills-panel.test.ts
+++ b/web/src/components/shared/injected-skills-panel.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the directory batch-add flow in injected-skills-panel.ts.
+ *
+ * Three behaviours matter and are easy to regress:
+ *
+ *  1. The "Discover Skills from Directory" button is gated on the *normalized*
+ *     URI, not the raw input. gh:// and skill:// URIs are unambiguously single
+ *     skills and must not offer discovery; a URL that stays https:// might be
+ *     a directory, so discovery is offered alongside plain add.
+ *  2. Hub scope must batch into exactly ONE PUT. Hub injected skills use a
+ *     PUT-whole-list API, so a naive loop would issue N read-modify-writes.
+ *  3. Project/user scope keeps using the per-item POST endpoint, once per URI.
+ */
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+let ScionInjectedSkillsPanel: any;
+
+/** One recorded fetch call. */
+interface Call {
+  url: string;
+  method: string;
+  body: any;
+}
+
+/**
+ * Build a fetch mock that records every call and answers the endpoints the
+ * panel touches: list GETs, project/user POSTs, hub PUTs, and the new
+ * discover-directory POST.
+ */
+function makeFetchMock(calls: Call[], discoverResponse?: { status: number; body: unknown }) {
+  return (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const href = String(url);
+    const method = init?.method ?? 'GET';
+    let parsed: any = undefined;
+    if (init?.body) {
+      try {
+        parsed = JSON.parse(init.body as string);
+      } catch {
+        /* non-JSON body — ignore */
+      }
+    }
+    calls.push({ url: href, method, body: parsed });
+
+    if (href.includes('/skills/discover-directory')) {
+      const r = discoverResponse ?? { status: 200, body: { skills: [], count: 0 } };
+      return Promise.resolve(
+        new Response(JSON.stringify(r.body), {
+          status: r.status,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    }
+
+    // Hub list GET and project/user list GET have different shapes; return both
+    // keys so either read path finds an empty list.
+    return Promise.resolve(
+      new Response(JSON.stringify({ entries: [], system: [], user_defined: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+  };
+}
+
+/** Create the panel for a given scope and let its initial load() settle. */
+async function createPanel(
+  scope: 'project' | 'user' | 'hub',
+  calls: Call[],
+  discoverResponse?: { status: number; body: unknown }
+) {
+  vi.stubGlobal('fetch', vi.fn(makeFetchMock(calls, discoverResponse)));
+  const el = document.createElement('scion-injected-skills-panel') as any;
+  el.scope = scope;
+  if (scope === 'project') el.scopeId = 'proj-1';
+  document.body.appendChild(el);
+  await el.updateComplete;
+  await new Promise((r) => setTimeout(r, 20));
+  await el.updateComplete;
+  calls.length = 0; // Drop the initial load GET so assertions see only the action.
+  return el;
+}
+
+describe('injected-skills-panel — discover button gating', () => {
+  beforeAll(async () => {
+    const mod = await import('./injected-skills-panel.js');
+    ScionInjectedSkillsPanel = mod.ScionInjectedSkillsPanel;
+    expect(ScionInjectedSkillsPanel).toBeDefined();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('does not offer discovery for a gh:// URI', async () => {
+    const el = await createPanel('project', []);
+    el.dialogUri = 'gh://org/repo/my-skill@main';
+    el.dialogTransformed = null;
+    expect(el.showDiscoverButton).toBe(false);
+  });
+
+  it('does not offer discovery for a skill:// URI', async () => {
+    const el = await createPanel('project', []);
+    el.dialogUri = 'skill://scion/core/my-skill';
+    el.dialogTransformed = null;
+    expect(el.showDiscoverButton).toBe(false);
+  });
+
+  it('does not offer discovery when a GitHub URL normalizes to gh:// shorthand', async () => {
+    const el = await createPanel('project', []);
+    // A standard skills/ path collapses to gh://, so it is a single skill.
+    el.dialogUri = 'https://github.com/org/repo/tree/main/skills/my-skill';
+    el.dialogTransformed = 'gh://org/repo/my-skill@main';
+    expect(el.showDiscoverButton).toBe(false);
+  });
+
+  it('offers discovery when the normalized result stays https://', async () => {
+    const el = await createPanel('project', []);
+    el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
+    el.dialogTransformed = null;
+    expect(el.showDiscoverButton).toBe(true);
+  });
+
+  it('offers discovery for a custom-path URL that normalizes to a full https:// URL', async () => {
+    const el = await createPanel('project', []);
+    el.dialogUri = 'https://github.com/org/repo/tree/main/custom';
+    el.dialogTransformed = 'https://github.com/org/repo/tree/main/custom';
+    expect(el.showDiscoverButton).toBe(true);
+  });
+});
+
+describe('injected-skills-panel — handleDiscoverDirectory', () => {
+  beforeAll(async () => {
+    await import('./injected-skills-panel.js');
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('opens the selection dialog with everything pre-selected on success', async () => {
+    const calls: Call[] = [];
+    const el = await createPanel('project', calls, {
+      status: 200,
+      body: {
+        skills: [
+          { uri: 'gh://org/repo/a@main', name: 'a' },
+          { uri: 'gh://org/repo/b@main', name: 'b' },
+        ],
+        count: 2,
+      },
+    });
+
+    el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
+    await el.handleDiscoverDirectory();
+
+    expect(el.discoveryDialogOpen).toBe(true);
+    expect(el.discoveredSkills).toHaveLength(2);
+    expect([...el.selectedSkillURIs].sort()).toEqual([
+      'gh://org/repo/a@main',
+      'gh://org/repo/b@main',
+    ]);
+    expect(el.discoveryError).toBeNull();
+  });
+
+  it('sends projectId for project scope but not for hub scope', async () => {
+    const projectCalls: Call[] = [];
+    const projectPanel = await createPanel('project', projectCalls, {
+      status: 200,
+      body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 },
+    });
+    projectPanel.dialogUri = 'https://github.com/org/repo/tree/main/skills';
+    await projectPanel.handleDiscoverDirectory();
+    const projectDiscover = projectCalls.find((c) => c.url.includes('discover-directory'));
+    expect(projectDiscover?.body.projectId).toBe('proj-1');
+
+    document.body.innerHTML = '';
+
+    const hubCalls: Call[] = [];
+    const hubPanel = await createPanel('hub', hubCalls, {
+      status: 200,
+      body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 },
+    });
+    hubPanel.dialogUri = 'https://github.com/org/repo/tree/main/skills';
+    await hubPanel.handleDiscoverDirectory();
+    const hubDiscover = hubCalls.find((c) => c.url.includes('discover-directory'));
+    expect(hubDiscover?.body.projectId).toBeUndefined();
+    expect(hubDiscover?.body.sourceUrl).toBe('https://github.com/org/repo/tree/main/skills');
+  });
+
+  it('surfaces a backend error inline and does not open the selection dialog', async () => {
+    const el = await createPanel('project', [], {
+      status: 400,
+      body: { error: { code: 'discover_failed', message: 'no skills found at ...' } },
+    });
+
+    el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
+    await el.handleDiscoverDirectory();
+
+    expect(el.discoveryDialogOpen).toBe(false);
+    expect(el.discoveryError).toBeTruthy();
+  });
+
+  it('treats an empty skills array as an error, not an empty dialog', async () => {
+    const el = await createPanel('project', [], {
+      status: 200,
+      body: { skills: [], count: 0 },
+    });
+
+    el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
+    await el.handleDiscoverDirectory();
+
+    expect(el.discoveryDialogOpen).toBe(false);
+    expect(el.discoveryError).toBe('No skills found at this URL.');
+  });
+
+  it('does not call the backend for an empty URI', async () => {
+    const calls: Call[] = [];
+    const el = await createPanel('project', calls);
+    el.dialogUri = '   ';
+    await el.handleDiscoverDirectory();
+
+    expect(calls.filter((c) => c.url.includes('discover-directory'))).toHaveLength(0);
+    expect(el.discoveryError).toBeTruthy();
+  });
+});
+
+describe('injected-skills-panel — addEntries batching', () => {
+  beforeAll(async () => {
+    await import('./injected-skills-panel.js');
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('hub scope writes all selected skills in exactly one PUT', async () => {
+    const calls: Call[] = [];
+    const el = await createPanel('hub', calls);
+
+    // Pretend the hub already holds one system entry and one user entry: the
+    // PUT must preserve the user entry and drop the readonly system one.
+    el.rows = [
+      { id: '', uri: 'skill://sys/one', as: '', optional: false, sortOrder: 0, skillName: '', skillSlug: '', readonly: true },
+      { id: '', uri: 'gh://org/repo/existing@main', as: '', optional: false, sortOrder: 1, skillName: '', skillSlug: '', readonly: false },
+    ];
+
+    await el.addEntries(['gh://org/repo/a@main', 'gh://org/repo/b@main', 'gh://org/repo/c@main']);
+
+    const puts = calls.filter((c) => c.method === 'PUT');
+    expect(puts).toHaveLength(1);
+    expect(puts[0].url).toContain('/api/v1/hub/settings/injected-skills');
+    expect(puts[0].body.user_defined.map((r: any) => r.uri)).toEqual([
+      'gh://org/repo/existing@main',
+      'gh://org/repo/a@main',
+      'gh://org/repo/b@main',
+      'gh://org/repo/c@main',
+    ]);
+    // No per-item POSTs for hub scope.
+    expect(calls.filter((c) => c.method === 'POST')).toHaveLength(0);
+  });
+
+  it('project scope issues one POST per selected skill', async () => {
+    const calls: Call[] = [];
+    const el = await createPanel('project', calls);
+
+    await el.addEntries(['gh://org/repo/a@main', 'gh://org/repo/b@main']);
+
+    const posts = calls.filter((c) => c.method === 'POST');
+    expect(posts).toHaveLength(2);
+    expect(posts.map((p) => p.body.skillUri)).toEqual([
+      'gh://org/repo/a@main',
+      'gh://org/repo/b@main',
+    ]);
+    expect(posts[0].url).toContain('/api/v1/projects/proj-1/injected-skills');
+    expect(calls.filter((c) => c.method === 'PUT')).toHaveLength(0);
+  });
+
+  it('user scope issues one POST per selected skill', async () => {
+    const calls: Call[] = [];
+    const el = await createPanel('user', calls);
+
+    await el.addEntries(['gh://org/repo/a@main']);
+
+    const posts = calls.filter((c) => c.method === 'POST');
+    expect(posts).toHaveLength(1);
+    expect(posts[0].url).toContain('/api/v1/users/me/injected-skills');
+  });
+
+  it('makes no network calls for an empty URI list', async () => {
+    const calls: Call[] = [];
+    const el = await createPanel('hub', calls);
+
+    await el.addEntries([]);
+
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('injected-skills-panel — handleDiscoveryConfirm', () => {
+  beforeAll(async () => {
+    await import('./injected-skills-panel.js');
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('adds the selected skills and closes both dialogs', async () => {
+    const calls: Call[] = [];
+    const el = await createPanel('hub', calls);
+
+    el.dialogOpen = true;
+    el.discoveryDialogOpen = true;
+    el.discoveredSkills = [
+      { uri: 'gh://org/repo/a@main', name: 'a' },
+      { uri: 'gh://org/repo/b@main', name: 'b' },
+    ];
+    el.selectedSkillURIs = new Set(['gh://org/repo/a@main']);
+
+    await el.handleDiscoveryConfirm();
+
+    const puts = calls.filter((c) => c.method === 'PUT');
+    expect(puts).toHaveLength(1);
+    expect(puts[0].body.user_defined.map((r: any) => r.uri)).toEqual(['gh://org/repo/a@main']);
+    expect(el.discoveryDialogOpen).toBe(false);
+    expect(el.dialogOpen).toBe(false);
+  });
+
+  it('keeps the selection dialog open and shows the error when the add fails', async () => {
+    const calls: Call[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const href = String(url);
+        const method = init?.method ?? 'GET';
+        calls.push({ url: href, method, body: undefined });
+        if (method === 'PUT') {
+          return Promise.resolve(
+            new Response(JSON.stringify({ error: { message: 'boom' } }), {
+              status: 500,
+              headers: { 'Content-Type': 'application/json' },
+            })
+          );
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ entries: [], system: [], user_defined: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        );
+      })
+    );
+
+    const el = document.createElement('scion-injected-skills-panel') as any;
+    el.scope = 'hub';
+    document.body.appendChild(el);
+    await el.updateComplete;
+    await new Promise((r) => setTimeout(r, 20));
+
+    el.dialogOpen = true;
+    el.discoveryDialogOpen = true;
+    el.discoveredSkills = [{ uri: 'gh://org/repo/a@main', name: 'a' }];
+    el.selectedSkillURIs = new Set(['gh://org/repo/a@main']);
+
+    await el.handleDiscoveryConfirm();
+
+    expect(el.discoveryDialogOpen).toBe(true);
+    expect(el.discoveryError).toBeTruthy();
+  });
+});

--- a/web/src/components/shared/injected-skills-panel.ts
+++ b/web/src/components/shared/injected-skills-panel.ts
@@ -202,6 +202,13 @@ export class ScionInjectedSkillsPanel extends LitElement {
   // the user probes a GitHub directory URL for the skills it contains.
   @state() private discoveryDialogOpen = false;
   @state() private discoveredSkills: Array<{ uri: string; name: string }> = [];
+  /**
+   * Child directory names the backend passed over (no SKILL.md, or a name that
+   * could not be turned into a safe skill URI). Surfaced in the selection dialog
+   * so a folder the user expected to see gets an explanation rather than
+   * vanishing silently.
+   */
+  @state() private skippedSkillNames: string[] = [];
   @state() private selectedSkillURIs: Set<string> = new Set();
   @state() private discoveryLoading = false;
   @state() private discoveryError: string | null = null;
@@ -363,6 +370,12 @@ export class ScionInjectedSkillsPanel extends LitElement {
 
       .selection-item {
         padding: 0.25rem 0;
+      }
+
+      .discovery-skipped-note {
+        margin: 0.75rem 0 0;
+        font-size: 0.75rem;
+        color: var(--scion-text-muted, #64748b);
       }
 
       .no-results {
@@ -556,6 +569,9 @@ export class ScionInjectedSkillsPanel extends LitElement {
   private async addEntries(uris: string[]): Promise<void> {
     const existing = new Set(this.rows.map((r) => r.uri));
     const fresh = uris.filter((u) => !existing.has(u));
+    // When every selected skill is already present, close silently — no network
+    // call needed. Issuing an empty batch would be a no-op PUT on hub scope and
+    // zero POSTs elsewhere, so the only effect would be a pointless round-trip.
     if (fresh.length === 0) return;
 
     if (this.scope === 'hub') {
@@ -688,6 +704,7 @@ export class ScionInjectedSkillsPanel extends LitElement {
   private resetDiscovery(): void {
     this.discoveryDialogOpen = false;
     this.discoveredSkills = [];
+    this.skippedSkillNames = [];
     this.selectedSkillURIs = new Set();
     this.discoveryLoading = false;
     this.discoveryError = null;
@@ -829,8 +846,12 @@ export class ScionInjectedSkillsPanel extends LitElement {
       if (!res.ok) {
         throw new Error(await extractApiError(res, `Discovery failed (HTTP ${res.status})`));
       }
-      const data = (await res.json()) as { skills?: Array<{ uri: string; name: string }> };
+      const data = (await res.json()) as {
+        skills?: Array<{ uri: string; name: string }>;
+        skipped?: string[];
+      };
       this.discoveredSkills = data.skills ?? [];
+      this.skippedSkillNames = data.skipped ?? [];
       if (this.discoveredSkills.length === 0) {
         this.discoveryError = 'No skills found at this URL.';
         return;
@@ -919,6 +940,13 @@ export class ScionInjectedSkillsPanel extends LitElement {
             `
           )}
         </div>
+        ${this.skippedSkillNames.length > 0
+          ? html`<p class="discovery-skipped-note">
+              ${this.skippedSkillNames.length}
+              folder${this.skippedSkillNames.length === 1 ? '' : 's'} not recognized as skills
+              ${this.skippedSkillNames.length === 1 ? 'was' : 'were'} skipped.
+            </p>`
+          : nothing}
         ${this.discoveryError
           ? html`<div class="dialog-error">${this.discoveryError}</div>`
           : nothing}

--- a/web/src/components/shared/injected-skills-panel.ts
+++ b/web/src/components/shared/injected-skills-panel.ts
@@ -198,6 +198,14 @@ export class ScionInjectedSkillsPanel extends LitElement {
   /** When a URI input is transformed to canonical form, holds the preview string. */
   @state() private dialogTransformed: string | null = null;
 
+  // Directory discovery (batch-add). Populated by handleDiscoverDirectory() when
+  // the user probes a GitHub directory URL for the skills it contains.
+  @state() private discoveryDialogOpen = false;
+  @state() private discoveredSkills: Array<{ uri: string; name: string }> = [];
+  @state() private selectedSkillURIs: Set<string> = new Set();
+  @state() private discoveryLoading = false;
+  @state() private discoveryError: string | null = null;
+
   // Delete — tracked by index to avoid key collisions on hub rows (all have id='')
   @state() private _deletingIndex: number | null = null;
 
@@ -327,6 +335,34 @@ export class ScionInjectedSkillsPanel extends LitElement {
         font-family: var(--scion-font-mono, monospace);
         font-size: 0.75rem;
         color: var(--scion-text-muted, #64748b);
+      }
+
+      /* Directory-discovery selection dialog. Mirrors the equivalent block in
+         resource-import.ts so both checkbox pickers look the same. */
+      .selection-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding-bottom: 0.75rem;
+        border-bottom: 1px solid var(--scion-border, #e2e8f0);
+        margin-bottom: 0.75rem;
+      }
+
+      .selection-count {
+        font-size: 0.75rem;
+        color: var(--scion-text-muted, #64748b);
+      }
+
+      .selection-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        max-height: 400px;
+        overflow-y: auto;
+      }
+
+      .selection-item {
+        padding: 0.25rem 0;
       }
 
       .no-results {
@@ -498,6 +534,34 @@ export class ScionInjectedSkillsPanel extends LitElement {
     await this.load();
   }
 
+  /**
+   * Add several skill URIs at once.
+   *
+   * Hub scope uses a PUT-whole-list API, so calling addEntry() N times would
+   * issue N read-modify-write round-trips and leave N-1 pointless intermediate
+   * states on the server. Instead we build the full user_defined list once and
+   * write it in a single PUT.
+   *
+   * Project and user scopes have per-item POST endpoints, so they degrade to N
+   * individual addEntry() calls — unchanged behaviour, and those endpoints are
+   * idempotent by design.
+   */
+  private async addEntries(uris: string[]): Promise<void> {
+    if (uris.length === 0) return;
+    if (this.scope === 'hub') {
+      const userDefined = this.rows.filter((r) => !r.readonly).map((r) => this.rowToSkillRef(r));
+      for (const uri of uris) {
+        userDefined.push(this.buildSkillRef(uri, '', false));
+      }
+      await this.putHubUserDefined(userDefined);
+      await this.load();
+    } else {
+      for (const uri of uris) {
+        await this.addEntry(uri, '', false);
+      }
+    }
+  }
+
   private async deleteEntry(row: SkillRow, rowIndex: number): Promise<void> {
     if (this.scope === 'hub') {
       // For hub: remove from user_defined and PUT.
@@ -591,7 +655,17 @@ export class ScionInjectedSkillsPanel extends LitElement {
     this.dialogLoading = false;
     this.dialogError = null;
     this.dialogTransformed = null;
+    this.resetDiscovery();
     this.dialogOpen = true;
+  }
+
+  /** Clear all directory-discovery state (called when the add dialog opens/closes). */
+  private resetDiscovery(): void {
+    this.discoveryDialogOpen = false;
+    this.discoveredSkills = [];
+    this.selectedSkillURIs = new Set();
+    this.discoveryLoading = false;
+    this.discoveryError = null;
   }
 
   private closeDialog(): void {
@@ -680,6 +754,166 @@ export class ScionInjectedSkillsPanel extends LitElement {
     } finally {
       this.dialogLoading = false;
     }
+  }
+
+  // ── Directory discovery (batch add) ──────────────────────────────────────
+
+  /**
+   * True when the URI currently typed in the dialog should offer directory
+   * discovery. A URL that normalizes to a gh:// or skill:// URI is
+   * unambiguously a single skill, so only "Add Skill" is offered. A URL that
+   * stays a full https:// URL either points at a directory of skills or at a
+   * single skill on a non-standard path — the user's choice of button
+   * disambiguates.
+   */
+  private get showDiscoverButton(): boolean {
+    const candidate = this.dialogTransformed ?? this.dialogUri.trim();
+    return candidate.startsWith('https://');
+  }
+
+  /**
+   * Probe the pasted URL for skills. On success this opens the selection
+   * dialog with everything pre-selected; on failure the error is shown inline
+   * in the add dialog and no selection dialog is opened.
+   */
+  private async handleDiscoverDirectory(): Promise<void> {
+    const sourceUrl = this.dialogUri.trim();
+    if (!sourceUrl) {
+      this.discoveryError = 'Skill URI is required';
+      return;
+    }
+
+    this.discoveryLoading = true;
+    this.discoveryError = null;
+    this.dialogError = null;
+    try {
+      const body: { sourceUrl: string; projectId?: string } = { sourceUrl };
+      if (this.scope === 'project' && this.scopeId) body.projectId = this.scopeId;
+
+      const res = await apiFetch('/api/v1/skills/discover-directory', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        throw new Error(await extractApiError(res, `Discovery failed (HTTP ${res.status})`));
+      }
+      const data = (await res.json()) as { skills?: Array<{ uri: string; name: string }> };
+      this.discoveredSkills = data.skills ?? [];
+      if (this.discoveredSkills.length === 0) {
+        this.discoveryError = 'No skills found at this URL.';
+        return;
+      }
+      this.selectedSkillURIs = new Set(this.discoveredSkills.map((s) => s.uri));
+      this.discoveryDialogOpen = true;
+    } catch (err) {
+      this.discoveryError = err instanceof Error ? err.message : 'Discovery failed';
+    } finally {
+      this.discoveryLoading = false;
+    }
+  }
+
+  /** Add every checked skill, then close both the selection and add dialogs. */
+  private async handleDiscoveryConfirm(): Promise<void> {
+    this.discoveryLoading = true;
+    this.discoveryError = null;
+    try {
+      await this.addEntries([...this.selectedSkillURIs]);
+      this.discoveryDialogOpen = false;
+      this.closeDialog();
+      this.resetDiscovery();
+    } catch (err) {
+      this.discoveryError = err instanceof Error ? err.message : 'Failed to add selected skills';
+    } finally {
+      this.discoveryLoading = false;
+    }
+  }
+
+  /**
+   * Checkbox list of discovered skills. Rows show the bare directory name; no
+   * SKILL.md frontmatter is read, so there is no description to display.
+   *
+   * This deliberately duplicates the select-all/list/count shape of
+   * resource-import.ts rather than sharing a component: the two dialogs operate
+   * on different data shapes and the duplication is ~70 lines.
+   */
+  private renderDiscoveryDialog() {
+    if (!this.discoveryDialogOpen) return nothing;
+
+    const total = this.discoveredSkills.length;
+    const allSelected = this.selectedSkillURIs.size === total;
+    const noneSelected = this.selectedSkillURIs.size === 0;
+
+    return html`
+      <sl-dialog
+        label="Select Skills to Add"
+        open
+        @sl-request-close=${() => {
+          this.discoveryDialogOpen = false;
+        }}
+        style="--width: 560px;"
+      >
+        <div class="selection-header">
+          <sl-checkbox
+            ?checked=${allSelected}
+            ?indeterminate=${!allSelected && !noneSelected}
+            @sl-change=${(e: Event) => {
+              const checked = (e.target as HTMLInputElement).checked;
+              this.selectedSkillURIs = checked
+                ? new Set(this.discoveredSkills.map((s) => s.uri))
+                : new Set();
+            }}
+          >
+            Select All
+          </sl-checkbox>
+          <span class="selection-count">${this.selectedSkillURIs.size} of ${total} selected</span>
+        </div>
+        <div class="selection-list">
+          ${this.discoveredSkills.map(
+            (skill) => html`
+              <div class="selection-item">
+                <sl-checkbox
+                  ?checked=${this.selectedSkillURIs.has(skill.uri)}
+                  @sl-change=${(e: Event) => {
+                    const checked = (e.target as HTMLInputElement).checked;
+                    const updated = new Set(this.selectedSkillURIs);
+                    if (checked) updated.add(skill.uri);
+                    else updated.delete(skill.uri);
+                    this.selectedSkillURIs = updated;
+                  }}
+                >
+                  ${skill.name}
+                </sl-checkbox>
+              </div>
+            `
+          )}
+        </div>
+        ${this.discoveryError
+          ? html`<div class="dialog-error">${this.discoveryError}</div>`
+          : nothing}
+
+        <sl-button
+          slot="footer"
+          variant="default"
+          ?disabled=${this.discoveryLoading}
+          @click=${() => {
+            this.discoveryDialogOpen = false;
+          }}
+        >
+          Cancel
+        </sl-button>
+        <sl-button
+          slot="footer"
+          variant="primary"
+          ?loading=${this.discoveryLoading}
+          ?disabled=${noneSelected || this.discoveryLoading}
+          @click=${() => void this.handleDiscoveryConfirm()}
+        >
+          <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+          Add Selected (${this.selectedSkillURIs.size})
+        </sl-button>
+      </sl-dialog>
+    `;
   }
 
   // ── Drag & drop ──────────────────────────────────────────────────────────
@@ -777,7 +1011,7 @@ export class ScionInjectedSkillsPanel extends LitElement {
             ? this.renderEmpty()
             : this.renderTable()}
 
-      ${this.renderDialog()}
+      ${this.renderDialog()} ${this.renderDiscoveryDialog()}
     `;
   }
 
@@ -1050,6 +1284,16 @@ export class ScionInjectedSkillsPanel extends LitElement {
                       Will be stored as: <strong>${this.dialogTransformed}</strong>
                     </div>`
                   : nothing}
+                ${this.showDiscoverButton
+                  ? html`<div class="dialog-hint">
+                      <sl-icon name="folder2-open"></sl-icon>
+                      This looks like it could be a directory of skills — use
+                      <strong>Discover Skills from Directory</strong> to pick several at once.
+                    </div>`
+                  : nothing}
+                ${this.discoveryError
+                  ? html`<div class="dialog-error">${this.discoveryError}</div>`
+                  : nothing}
               `}
 
           <sl-input
@@ -1088,15 +1332,29 @@ export class ScionInjectedSkillsPanel extends LitElement {
           slot="footer"
           variant="default"
           @click=${this.closeDialog}
-          ?disabled=${this.dialogLoading}
+          ?disabled=${this.dialogLoading || this.discoveryLoading}
         >
           Cancel
         </sl-button>
+        ${!isSearchMode && this.showDiscoverButton
+          ? html`
+              <sl-button
+                slot="footer"
+                variant="default"
+                ?loading=${this.discoveryLoading}
+                ?disabled=${this.dialogLoading || this.discoveryLoading}
+                @click=${() => void this.handleDiscoverDirectory()}
+              >
+                <sl-icon slot="prefix" name="folder2-open"></sl-icon>
+                Discover Skills from Directory
+              </sl-button>
+            `
+          : nothing}
         <sl-button
           slot="footer"
           variant="primary"
           ?loading=${this.dialogLoading}
-          ?disabled=${this.dialogLoading}
+          ?disabled=${this.dialogLoading || this.discoveryLoading}
           @click=${this.handleAddSkill}
         >
           Add Skill

--- a/web/src/components/shared/injected-skills-panel.ts
+++ b/web/src/components/shared/injected-skills-panel.ts
@@ -537,28 +537,49 @@ export class ScionInjectedSkillsPanel extends LitElement {
   /**
    * Add several skill URIs at once.
    *
+   * URIs already present in this scope are dropped first. Neither backend
+   * de-duplicates: the project/user POST endpoint returns 409 on a duplicate
+   * skillUri, and the hub PUT stores whatever list it is given, so a
+   * re-discovery of the same directory would otherwise either fail outright or
+   * append duplicate rows.
+   *
    * Hub scope uses a PUT-whole-list API, so calling addEntry() N times would
    * issue N read-modify-write round-trips and leave N-1 pointless intermediate
    * states on the server. Instead we build the full user_defined list once and
    * write it in a single PUT.
    *
-   * Project and user scopes have per-item POST endpoints, so they degrade to N
-   * individual addEntry() calls — unchanged behaviour, and those endpoints are
-   * idempotent by design.
+   * Project and user scopes have per-item POST endpoints and no batch variant,
+   * so they degrade to N individual addEntry() calls. Failures are collected
+   * rather than aborting the loop: a mid-batch throw would leave a partial add
+   * with no recovery path, since retrying would 409 on the skills that did land.
    */
   private async addEntries(uris: string[]): Promise<void> {
-    if (uris.length === 0) return;
+    const existing = new Set(this.rows.map((r) => r.uri));
+    const fresh = uris.filter((u) => !existing.has(u));
+    if (fresh.length === 0) return;
+
     if (this.scope === 'hub') {
       const userDefined = this.rows.filter((r) => !r.readonly).map((r) => this.rowToSkillRef(r));
-      for (const uri of uris) {
+      for (const uri of fresh) {
         userDefined.push(this.buildSkillRef(uri, '', false));
       }
       await this.putHubUserDefined(userDefined);
       await this.load();
-    } else {
-      for (const uri of uris) {
+      return;
+    }
+
+    const failures: string[] = [];
+    for (const uri of fresh) {
+      try {
         await this.addEntry(uri, '', false);
+      } catch (err) {
+        failures.push(`${uri}: ${err instanceof Error ? err.message : 'failed'}`);
       }
+    }
+    if (failures.length > 0) {
+      throw new Error(
+        `${failures.length} of ${fresh.length} skills could not be added — ${failures.join('; ')}`
+      );
     }
   }
 
@@ -659,7 +680,11 @@ export class ScionInjectedSkillsPanel extends LitElement {
     this.dialogOpen = true;
   }
 
-  /** Clear all directory-discovery state (called when the add dialog opens/closes). */
+  /**
+   * Clear all directory-discovery state. Called from both openDialog() and
+   * closeDialog() so a discovery error or a stale selection can never survive a
+   * Cancel and reappear the next time the add dialog is opened.
+   */
   private resetDiscovery(): void {
     this.discoveryDialogOpen = false;
     this.discoveredSkills = [];
@@ -676,6 +701,7 @@ export class ScionInjectedSkillsPanel extends LitElement {
     }
     // Abort any in-flight search so it doesn't update state after close.
     this.cancelSearch();
+    this.resetDiscovery();
   }
 
   private handleSearchInput(query: string): void {
@@ -765,10 +791,14 @@ export class ScionInjectedSkillsPanel extends LitElement {
    * stays a full https:// URL either points at a directory of skills or at a
    * single skill on a non-standard path — the user's choice of button
    * disambiguates.
+   *
+   * The github.com host is required because the discover endpoint rejects
+   * anything else; offering the button for other hosts would only buy the user
+   * a round-trip to a 400.
    */
   private get showDiscoverButton(): boolean {
     const candidate = this.dialogTransformed ?? this.dialogUri.trim();
-    return candidate.startsWith('https://');
+    return candidate.toLowerCase().startsWith('https://github.com/');
   }
 
   /**
@@ -777,6 +807,7 @@ export class ScionInjectedSkillsPanel extends LitElement {
    * in the add dialog and no selection dialog is opened.
    */
   private async handleDiscoverDirectory(): Promise<void> {
+    // Post the raw directory URL, not the normalized form — discover needs the directory path.
     const sourceUrl = this.dialogUri.trim();
     if (!sourceUrl) {
       this.discoveryError = 'Skill URI is required';
@@ -820,8 +851,8 @@ export class ScionInjectedSkillsPanel extends LitElement {
     try {
       await this.addEntries([...this.selectedSkillURIs]);
       this.discoveryDialogOpen = false;
+      // closeDialog() clears discovery state via resetDiscovery().
       this.closeDialog();
-      this.resetDiscovery();
     } catch (err) {
       this.discoveryError = err instanceof Error ? err.message : 'Failed to add selected skills';
     } finally {


### PR DESCRIPTION
## Summary
Phase 1 of directory batch-add for injected skills: paste a GitHub directory URL, discover skill subdirectories, present a checkbox interstitial for selection, add all checked as individual skill URI references via a single atomic PUT. Reuses ~70% of existing template-import discovery infrastructure.

## Changes
- New backend discover-directory endpoint
- injected-skills-panel.ts UI extension (Discover button, checkbox dialog)
- Security fix found during review: strip userinfo/credentials from URLs before logging or echoing them back

## Quality gates
Build, vet clean. 31 backend discover tests, 40 frontend vitest tests pass. Targeted code review APPROVE, including explicit sign-off on the userinfo-strip fix. CI green (Build & Test + golangci-lint).

Phase 2 (CLI --from-directory flag) follows separately.