### PR TITLE
feat(discord,telegram): show build version and git commit in /help command

### DIFF
--- a/extras/scion-discord/Dockerfile
+++ b/extras/scion-discord/Dockerfile
@@ -16,7 +16,10 @@ COPY extras/scion-discord/ extras/scion-discord/
 
 # Build from the discord module directory
 WORKDIR /src/extras/scion-discord
-RUN CGO_ENABLED=0 go build -tags no_embed_web -o /discord-bot ./cmd/scion-plugin-discord
+COPY hack/version.sh /src/hack/version.sh
+RUN CGO_ENABLED=0 go build -tags no_embed_web \
+    -ldflags "$(sh /src/hack/version.sh)" \
+    -o /discord-bot ./cmd/scion-plugin-discord
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=builder /discord-bot /discord-bot

--- a/extras/scion-discord/Dockerfile
+++ b/extras/scion-discord/Dockerfile
@@ -1,4 +1,8 @@
 FROM golang:1.26 AS builder
+
+ARG GIT_COMMIT=unknown
+ARG BUILD_VERSION=dev
+
 WORKDIR /src
 
 # Copy root module (needed by replace directive in extras/scion-discord/go.mod)
@@ -16,9 +20,8 @@ COPY extras/scion-discord/ extras/scion-discord/
 
 # Build from the discord module directory
 WORKDIR /src/extras/scion-discord
-COPY hack/version.sh /src/hack/version.sh
 RUN CGO_ENABLED=0 go build -tags no_embed_web \
-    -ldflags "$(sh /src/hack/version.sh)" \
+    -ldflags "-X 'github.com/GoogleCloudPlatform/scion/pkg/version.Commit=${GIT_COMMIT}' -X 'github.com/GoogleCloudPlatform/scion/pkg/version.Version=${BUILD_VERSION}'" \
     -o /discord-bot ./cmd/scion-plugin-discord
 
 FROM gcr.io/distroless/static-debian12

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
+	"github.com/GoogleCloudPlatform/scion/pkg/version"
 	"github.com/bwmarrin/discordgo"
 )
 
@@ -410,7 +411,8 @@ func helpText() string {
 		"`/scion settings` — Configure channel notification settings\n" +
 		"`/scion info` — Show your registration info\n" +
 		"`/scion help` — Show this help message\n\n" +
-		"Mention the bot or an agent by name in a linked channel to send messages."
+		"Mention the bot or an agent by name in a linked channel to send messages.\n\n" +
+		fmt.Sprintf("_Scion Discord Integration — %s_", version.Get())
 }
 
 // HandleHelp responds with a listing of available commands.

--- a/extras/scion-telegram/Dockerfile
+++ b/extras/scion-telegram/Dockerfile
@@ -17,6 +17,9 @@
 
 FROM golang:1.26-bookworm AS builder
 
+ARG GIT_COMMIT=unknown
+ARG BUILD_VERSION=dev
+
 WORKDIR /src
 
 # Copy the root module (required by the replace directive).
@@ -26,14 +29,13 @@ COPY cmd/ cmd/
 
 # Copy the telegram module.
 COPY extras/scion-telegram/ extras/scion-telegram/
-COPY hack/version.sh /src/hack/version.sh
 
 WORKDIR /src/extras/scion-telegram
 
 RUN go mod download
 
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath \
-    -ldflags="-s -w $(sh /src/hack/version.sh)" \
+    -ldflags="-s -w -X 'github.com/GoogleCloudPlatform/scion/pkg/version.Commit=${GIT_COMMIT}' -X 'github.com/GoogleCloudPlatform/scion/pkg/version.Version=${BUILD_VERSION}'" \
     -o /scion-plugin-telegram ./cmd/scion-plugin-telegram
 
 FROM gcr.io/distroless/static-debian12:nonroot

--- a/extras/scion-telegram/Dockerfile
+++ b/extras/scion-telegram/Dockerfile
@@ -26,12 +26,14 @@ COPY cmd/ cmd/
 
 # Copy the telegram module.
 COPY extras/scion-telegram/ extras/scion-telegram/
+COPY hack/version.sh /src/hack/version.sh
 
 WORKDIR /src/extras/scion-telegram
 
 RUN go mod download
 
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" \
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath \
+    -ldflags="-s -w $(sh /src/hack/version.sh)" \
     -o /scion-plugin-telegram ./cmd/scion-plugin-telegram
 
 FROM gcr.io/distroless/static-debian12:nonroot

--- a/extras/scion-telegram/internal/telegram/commands.go
+++ b/extras/scion-telegram/internal/telegram/commands.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
+	"github.com/GoogleCloudPlatform/scion/pkg/version"
 )
 
 // AgentInfo holds an agent's slug and current activity state.
@@ -329,6 +330,8 @@ func (h *CommandHandler) handleUnlink(msg *TGMessage) {
 func (h *CommandHandler) handleHelp(msg *TGMessage) {
 	chatID := msg.Chat.ID
 
+	versionLine := fmt.Sprintf("\n_Scion Telegram Integration — %s_", version.Get())
+
 	if isGroupChat(chatID) {
 		h.reply(chatID, "Available commands:\n"+
 			"/setup — Link this group to a project\n"+
@@ -337,7 +340,8 @@ func (h *CommandHandler) handleHelp(msg *TGMessage) {
 			"/settings — Configure group settings\n"+
 			"/unlink — Unlink this group from its project\n"+
 			"/help — Show this help message\n\n"+
-			"Send /help in a DM to the bot for account management commands.")
+			"Send /help in a DM to the bot for account management commands."+
+			versionLine)
 	} else {
 		h.reply(chatID, "Available commands (DM):\n"+
 			"/register — Link your Telegram account to your scion hub identity\n"+
@@ -345,7 +349,8 @@ func (h *CommandHandler) handleHelp(msg *TGMessage) {
 			"/status — Show linked groups and registration status\n"+
 			"/notifications — Manage per-agent notification subscriptions\n"+
 			"/help — Show this help message\n\n"+
-			"Add me to a group and use /setup there to link it to a scion project.")
+			"Add me to a group and use /setup there to link it to a scion project."+
+			versionLine)
 	}
 }
 

--- a/extras/scion-telegram/internal/telegram/commands.go
+++ b/extras/scion-telegram/internal/telegram/commands.go
@@ -330,27 +330,34 @@ func (h *CommandHandler) handleUnlink(msg *TGMessage) {
 func (h *CommandHandler) handleHelp(msg *TGMessage) {
 	chatID := msg.Chat.ID
 
-	versionLine := fmt.Sprintf("\n_Scion Telegram Integration — %s_", version.Get())
+	versionLine := fmt.Sprintf("\n\n_Scion Telegram Integration — %s_", version.Get())
 
+	var text string
 	if isGroupChat(chatID) {
-		h.reply(chatID, "Available commands:\n"+
-			"/setup — Link this group to a project\n"+
-			"/default — Set the default agent\n"+
-			"/agents — List agents in the linked project\n"+
-			"/settings — Configure group settings\n"+
-			"/unlink — Unlink this group from its project\n"+
-			"/help — Show this help message\n\n"+
-			"Send /help in a DM to the bot for account management commands."+
-			versionLine)
+		text = "Available commands:\n" +
+			"/setup — Link this group to a project\n" +
+			"/default — Set the default agent\n" +
+			"/agents — List agents in the linked project\n" +
+			"/settings — Configure group settings\n" +
+			"/unlink — Unlink this group from its project\n" +
+			"/help — Show this help message\n\n" +
+			"Send /help in a DM to the bot for account management commands." +
+			versionLine
 	} else {
-		h.reply(chatID, "Available commands (DM):\n"+
-			"/register — Link your Telegram account to your scion hub identity\n"+
-			"/unregister — Remove your Telegram account link\n"+
-			"/status — Show linked groups and registration status\n"+
-			"/notifications — Manage per-agent notification subscriptions\n"+
-			"/help — Show this help message\n\n"+
-			"Add me to a group and use /setup there to link it to a scion project."+
-			versionLine)
+		text = "Available commands (DM):\n" +
+			"/register — Link your Telegram account to your scion hub identity\n" +
+			"/unregister — Remove your Telegram account link\n" +
+			"/status — Show linked groups and registration status\n" +
+			"/notifications — Manage per-agent notification subscriptions\n" +
+			"/help — Show this help message\n\n" +
+			"Add me to a group and use /setup there to link it to a scion project." +
+			versionLine
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := h.api.SendMessage(ctx, chatID, text, "Markdown"); err != nil {
+		h.log.Error("Failed to send help reply", "chat_id", chatID, "error", err)
 	}
 }
 

--- a/extras/scion-telegram/internal/telegram/commands.go
+++ b/extras/scion-telegram/internal/telegram/commands.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -330,7 +331,7 @@ func (h *CommandHandler) handleUnlink(msg *TGMessage) {
 func (h *CommandHandler) handleHelp(msg *TGMessage) {
 	chatID := msg.Chat.ID
 
-	versionLine := fmt.Sprintf("\n\n_Scion Telegram Integration — %s_", version.Get())
+	versionLine := fmt.Sprintf("\n\n<i>Scion Telegram Integration — %s</i>", html.EscapeString(version.Get()))
 
 	var text string
 	if isGroupChat(chatID) {
@@ -356,7 +357,7 @@ func (h *CommandHandler) handleHelp(msg *TGMessage) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	if _, err := h.api.SendMessage(ctx, chatID, text, "Markdown"); err != nil {
+	if _, err := h.api.SendMessage(ctx, chatID, text, "HTML"); err != nil {
 		h.log.Error("Failed to send help reply", "chat_id", chatID, "error", err)
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/637

Adds pkg/version package with build-time version/commit injection. /help commands in both Discord and Telegram now show a footer with build version and short git commit hash, helping operators debug which build of the integration they are actually running.

Dockerfiles accept GIT_COMMIT and BUILD_VERSION as build ARGs (computed on the host, since .git is excluded from the Docker build context via .dockerignore) and inject them via ldflags. Safe defaults (unknown/dev) when ARGs are not passed.

Telegram help reply now correctly sets parseMode so markdown formatting renders. Footer formatting made consistent between both integrations