### PR TITLE
pkg/store: update stale SharingModeWorktreePerAgent doc comment (fixes #634)

### DIFF
--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -222,9 +222,11 @@ const (
 	SharingModeClonePerAgent WorkspaceSharingMode = "clone-per-agent"
 
 	// SharingModeWorktreePerAgent: each agent gets its own git worktree over
-	// one shared checkout. The shared checkout + all worktrees live on NFS.
+	// one shared checkout. Supported on Hub-managed git projects (Phase 1+).
+	// On Docker/VM runtimes the shared base and worktrees live on node-local
+	// storage; on Kubernetes the NFS backend is required (node-local worktrees
+	// on K8s are not supported and fall back to clone-per-agent).
 	// Maps from label value "worktree-per-agent".
-	// Note: not yet on Hub-managed projects — reserved for Phase 1+.
 	SharingModeWorktreePerAgent WorkspaceSharingMode = "worktree-per-agent"
 )
 


### PR DESCRIPTION
The comment on SharingModeWorktreePerAgent in pkg/store/models.go said worktree-per-agent was "not yet on Hub-managed projects - reserved for Phase 1+" and that "the shared checkout + all worktrees live on NFS". Both are now outdated after Phase 1 (merged via #350):

- Hub-managed git projects already accept worktree-per-agent today (handlers_projects_core.go:309, start_context.go:489).
- Phase 1 added node-local (Docker/VM) support; NFS is only required on Kubernetes (Phase 3).

No logic changes; comment only. go build ./... and go vet ./... pass.