### PR TITLE
platform skills: update cli-operations, agent-manage, and messaging

### DIFF
--- a/resources/platform_skills/scion-agent-manage/SKILL.md
+++ b/resources/platform_skills/scion-agent-manage/SKILL.md
@@ -39,6 +39,28 @@ The best and most current reference for the CLI commands is available from `scio
 
 6. **Preserve branches**: Use `--preserve-branch` to keep the branch after deletion for later review. The flag does not push — confirm the branch is on the remote first.
 
+7. **Agent state**: Do not attempt to resume an agent unless you were the one who stopped it. An 'idle' agent may still be working.
+
+## Creating Agents
+
+To translate a natural-language request into a `scion start` command, map intent to flags:
+
+| Intent | Flag | Example |
+|---|---|---|
+| Agent role | `-t` / `--type` | `-t developer`, `-t researcher`, `-t code-reviewer` |
+| LLM interface | `--harness` | `--harness claude`, `--harness gemini-cli` |
+| Model override | `--model` | `--model claude-sonnet-4-20250514` |
+
+Example — "have a claude xl developer write a file":
+
+```bash
+scion start file-writer -t developer --harness claude --model xl \
+  --non-interactive \
+  "Read your brief at /scion-volumes/scratchpad/briefs/file-writer.md and follow it."
+```
+
+Additional options like `--thinking-level` (0–100) can tune agent reasoning depth. Run `scion start --help` for the full flag reference.
+
 ## Briefing
 
 Every agent you create needs a brief. Write the brief to a **shared scratchpad file and

--- a/resources/platform_skills/scion-agent-manage/SKILL.md
+++ b/resources/platform_skills/scion-agent-manage/SKILL.md
@@ -55,7 +55,6 @@ Example — "have a claude xl developer write a file":
 
 ```bash
 scion start file-writer -t developer --harness claude --model xl \
-  --non-interactive \
   "Read your brief at /scion-volumes/scratchpad/briefs/file-writer.md and follow it."
 ```
 

--- a/resources/platform_skills/scion-agent-manage/references/agent-lifecycle.md
+++ b/resources/platform_skills/scion-agent-manage/references/agent-lifecycle.md
@@ -29,6 +29,21 @@ accepted. Time-box it; do not leave agents stopped indefinitely.
 | Project initiator — the first agent on a project, whatever role it started as | **Only on explicit human instruction** | It is the project's continuity point from first research through closure; its starting role does not govern its lifespan |
 | Engineering manager, coordinator, project lead | **Only on explicit human instruction naming the workstream** | Human says "close down the X workstream" or equivalent |
 
+### Hierarchy teardown: bottom-up deletion
+
+**In general, do not delete agents you did not create.** When tearing down a
+hierarchy, deletion happens bottom-up — each level confirms its subtree is torn
+down before the level above deletes it:
+
+1. The parent learns work is complete; notifies the orchestrator below.
+2. The orchestrator deletes its workers (developers, reviewers).
+3. The orchestrator confirms its subtree is torn down.
+4. The parent deletes the orchestrator.
+
+Apply the role-based authority table above at each step — the orchestrator's
+category (bounded worker vs. free-standing lead) determines whether its creator
+can delete it directly or explicit human instruction is required.
+
 ### Rules
 
 1. **Completion of a task is not completion of an agent.** A completion signal means the
@@ -65,7 +80,9 @@ accepted. Time-box it; do not leave agents stopped indefinitely.
   or apply the role-based rules above.
 - **Interpreting "clean up" as permission to delete leads.** It never is, unless the
   human names the specific workstream being closed.
-- **Leaving agents stopped for audit trail.** Commit findings to files instead. Stopped
-  agents consume system resources and count against the 50-agent list ceiling.
+- **Leaving agents stopped indefinitely as an audit trail.** Terminal logs have value
+  during an active workstream, but stopped agents consume system resources and count
+  against the 50-agent ceiling. Time-box it: GC stopped agents at milestone boundaries
+  and commit durable findings to files.
 - **Deleting an agent with unpushed work.** Always verify work is pushed to the
   remote (not just committed locally) or written to a shared volume before deletion.

--- a/resources/platform_skills/scion-cli-operations/SKILL.md
+++ b/resources/platform_skills/scion-cli-operations/SKILL.md
@@ -2,8 +2,7 @@
 name: scion-cli-operations
 description: >-
   Operational constraints for Scion agents running in containerized sandboxes.
-  Covers non-interactive mode, prohibited commands, hub-only API access, and
-  system message format. Complements the scion CLI reference and messaging skills.
+  Covers prohibited commands, hub-only API access, and system message format. Complements the scion CLI reference and messaging skills.
 ---
 
 # Scion CLI Operating Constraints
@@ -12,7 +11,6 @@ You are an autonomous Scion agent running inside a containerized sandbox. Your w
 
 ## Core Rules (DO NOT VIOLATE)
 
-- **Non-Interactive Mode**: You MUST use the `--non-interactive` flag with the Scion CLI, ALWAYS. This flag implies `--yes` and will cause any command that requires user input to error instead of blocking. Failure to use `--non-interactive` can result in you getting stuck at an interactive prompt indefinitely.
 - **Structured Output**: To get detailed, machine-readable output from nearly all commands, use the `--format json` flag.
 - **Prohibited Commands**: DO NOT use the `sync` or `cdw` commands.
 - **Agent State**: Do not attempt to resume an agent unless you were the one who stopped it. An 'idle' agent may still be working.
@@ -26,14 +24,17 @@ You are an autonomous Scion agent running inside a containerized sandbox. Your w
 The `scion start` task prompt is embedded in a shell command. **Do not use backticks, `$variables`, or other shell metacharacters** in the inlined prompt — they cause the shell to exit before the agent starts, with no visible error. For long or formatted briefs, write the content to a file and pass a filepath reference instead:
 
 ```bash
-scion start <name> --non-interactive \
+scion start <name> \
   "Read your brief at /path/to/brief.md and follow it."
 ```
 
 **Use absolute paths** in task prompts and briefs. A sub-agent's working directory may differ from yours — relative paths resolve against the sub-agent's `/workspace`, not yours.
 
+**Avoid non-ASCII escape sequences in shell strings.** Bash only expands `\x` hex escapes inside `$'...'` quoting — inside double quotes, `\xe2\x80\x94` sends 12 literal characters, not an em-dash. Use plain ASCII punctuation in task prompts and messages.
+
 ## Recommended Commands
 
+- **Know Yourself**: `scion whoami` — shows your agent identity, project, template, and configuration. Use `--format json` for structured output.
 - **Inspect an Agent**: `scion look <agent-id>` — inspect the recent output and current terminal-UI state of any running agent.
 - **Full CLI Details**: `scion --help` — for specific details on all hierarchical commands.
 - **Focused Usage**: Use the scion CLI as needed for your task. Do not pre-emptively explore `.scion` folders, read agent-template files, etc. — focus only on what you need.

--- a/resources/platform_skills/scion-cli-operations/SKILL.md
+++ b/resources/platform_skills/scion-cli-operations/SKILL.md
@@ -2,7 +2,8 @@
 name: scion-cli-operations
 description: >-
   Operational constraints for Scion agents running in containerized sandboxes.
-  Covers prohibited commands, hub-only API access, and system message format. Complements the scion CLI reference and messaging skills.
+  Covers prohibited commands and hub-only API access.
+  Complements the scion CLI reference and messaging skills.
 ---
 
 # Scion CLI Operating Constraints
@@ -37,16 +38,3 @@ scion start <name> \
 - **Inspect an Agent**: `scion look <agent-id>` — inspect the recent output and current terminal-UI state of any running agent.
 - **Full CLI Details**: `scion --help` — for specific details on all hierarchical commands.
 - **Focused Usage**: Use the scion CLI as needed for your task. Do not pre-emptively explore `.scion` folders, read agent-template files, etc. — focus only on what you need.
-
-## System Message Format
-
-You may be sent messages via the system. These will include markers:
-
-```
----BEGIN SCION MESSAGE---
----END SCION MESSAGE---
-```
-
-They will contain information about the sender and may be instructions, or a notification about an agent you are interacting with (for example, it completed its task or needs input).
-
-See scion-messaging skill for more information on messages

--- a/resources/platform_skills/scion-cli-operations/SKILL.md
+++ b/resources/platform_skills/scion-cli-operations/SKILL.md
@@ -13,7 +13,6 @@ You are an autonomous Scion agent running inside a containerized sandbox. Your w
 
 - **Structured Output**: To get detailed, machine-readable output from nearly all commands, use the `--format json` flag.
 - **Prohibited Commands**: DO NOT use the `sync` or `cdw` commands.
-- **Agent State**: Do not attempt to resume an agent unless you were the one who stopped it. An 'idle' agent may still be working.
 - **Hub API Only**: Do not use the `--no-hub` option to work around issues; you only have access to the system through the hub.
 - **Don't Relay Instructions**: The agents you start are informed by these instructions — you don't need to tell them to use things like sciontool.
 - **Do Not Use Global**: Never use the `--global` option; you are operating in a grove workspace and it is set implicitly by default.

--- a/resources/platform_skills/scion-messaging/SKILL.md
+++ b/resources/platform_skills/scion-messaging/SKILL.md
@@ -45,6 +45,9 @@ Effective communication requires balancing responsiveness with focus.
 Every message should move work forward. High-signal messages are functional and concrete.
 
 - **Be Functional**: No banter, cheerleading, or "Ready to help!" filler.
+- **Keep tone conversational and short.** Messages should be functional but not robotic — write like a colleague, not a status report.
+- **You are identified as a sender** — the system already shows your identity with every message. Don't open with "Hi, this is agent-X" or restate who you are.
+- **Confirm receipt, then report completion.** When you receive a task, respond immediately to confirm you got it. Then report again when the work is done. Don't leave a user wondering whether their message was received.
 - **Include Concrete Details**: Reference file paths, branch names, URLs, and specific error messages.
 - **Surface Decisions**: When asking a user for input, provide 2-3 concrete options, state your recommendation, and include the timing impact of each.
 - **Keep it Concise**: Focus on key findings and links rather than lengthy narratives.
@@ -69,6 +72,7 @@ The `scion message` command provides powerful flags for advanced orchestration:
 ## Agent-to-Agent Coordination Patterns
 
 - **Coordinator Relay**: Workers generally communicate through the coordinator rather than directly with each other. This guidance may be set by the coordinator.
+- **Avoid being a relay.** If an agent needs to communicate something to a user, have them message the user directly rather than relaying through you. Relay adds latency, risks reframing the message in transit, and wastes context.
 - **Self-Callback Heartbeat**: For very long external tasks, use `scion message --in` to send yourself a reminder to check on the process or provide a status update. (during long blocked periods)
 
 ## Multi-User Communication
@@ -97,8 +101,11 @@ If your user-directed message is long:
 
 ## Inbound Message Types
 
-**Check the `type` field before replying.** Messages carry a type that tells
-you whether they are addressed to you or are notifications about another agent.
+Messages arrive wrapped in `---BEGIN SCION MESSAGE---` / `---END SCION MESSAGE---`
+markers and include sender and type metadata.
+
+**Check the `type` field before replying.** The type tells you whether a message
+is addressed to you or is a notification about another agent.
 
 - **`instruction`** — addressed to you. Read and act on it.
 - **`state-change`** — a notification that an agent changed state (e.g., completed, stalled). No reply needed.


### PR DESCRIPTION
Combined skill updates:

- scion-cli-operations: remove obsolete --non-interactive rule, add whoami tip, add shell escape warning, move Agent State and System Message Format to their proper skills
- scion-agent-manage: add Creating Agents section (flag-mapping table), add hierarchy teardown rule, soften audit-trail anti-pattern
- scion-messaging: add tone guidance, anti-relay rule, absorb system message format into Inbound Message Types