### PR TITLE
fix: populate explicit_type from resolved auth, not harness config metadata

### DIFF
--- a/harnesses/scion_harness_test.py
+++ b/harnesses/scion_harness_test.py
@@ -203,6 +203,62 @@ class TestAuthAllOf(unittest.TestCase):
             ctx.select_auth(spec)
 
 
+class TestAuthExplicitTypeOverridesAutoDetect(unittest.TestCase):
+    """Regression: explicit_type must bypass auto-detection priority ordering.
+
+    When ANTHROPIC_API_KEY and GOOGLE_CLOUD_PROJECT are both present in
+    candidates but explicit_type is "vertex-ai", select_auth must pick
+    vertex-ai — not api-key (which would win under auto-detection because
+    api-key has higher priority in the spec method list).
+    """
+
+    def _claude_spec(self) -> sh.AuthSpec:
+        """Mirrors the AUTH spec from provision.py (Claude harness)."""
+        return sh.AuthSpec("claude", [
+            sh.env_method("api-key", any_of=["ANTHROPIC_API_KEY"]),
+            sh.env_method("oauth-token", any_of=["CLAUDE_CODE_OAUTH_TOKEN"]),
+            sh.env_method("vertex-ai",
+                          all_of=["GOOGLE_CLOUD_PROJECT"],
+                          any_of=["GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION"]),
+        ])
+
+    def test_explicit_vertex_ai_wins_over_api_key(self):
+        ctx = _make_ctx(candidates={
+            "explicit_type": "vertex-ai",
+            "env_vars": [
+                "ANTHROPIC_API_KEY",
+                "GOOGLE_CLOUD_PROJECT",
+                "GOOGLE_CLOUD_REGION",
+                "SCION_HARNESS_SELECTED_AUTH",
+            ],
+            "env_secret_files": {
+                "ANTHROPIC_API_KEY": "/dev/null",
+                "GOOGLE_CLOUD_PROJECT": "/dev/null",
+                "GOOGLE_CLOUD_REGION": "/dev/null",
+                "SCION_HARNESS_SELECTED_AUTH": "/dev/null",
+            },
+        })
+        result = ctx.select_auth(self._claude_spec())
+        self.assertEqual(result.method, "vertex-ai")
+
+    def test_without_explicit_type_api_key_wins(self):
+        """Verify auto-detection does pick api-key when explicit_type is empty."""
+        ctx = _make_ctx(candidates={
+            "env_vars": [
+                "ANTHROPIC_API_KEY",
+                "GOOGLE_CLOUD_PROJECT",
+                "GOOGLE_CLOUD_REGION",
+            ],
+            "env_secret_files": {
+                "ANTHROPIC_API_KEY": "/dev/null",
+                "GOOGLE_CLOUD_PROJECT": "/dev/null",
+                "GOOGLE_CLOUD_REGION": "/dev/null",
+            },
+        })
+        result = ctx.select_auth(self._claude_spec())
+        self.assertEqual(result.method, "api-key")
+
+
 class TestAuthFileMethod(unittest.TestCase):
     """File-based auth method detection."""
 

--- a/pkg/harness/container_script_harness.go
+++ b/pkg/harness/container_script_harness.go
@@ -509,9 +509,20 @@ func (c *ContainerScriptHarness) ApplyAuthSettings(agentHome string, resolved *a
 	// prevents the container-side script from writing the file).
 	resolved.Files = remainingFiles
 
+	// Prefer the resolved auth's selected type (staged as
+	// SCION_HARNESS_SELECTED_AUTH by ResolveAuth) over harness config
+	// metadata (c.entry.AuthSelectedType). The Go side resolves the
+	// auth method correctly on both create and resume; the config
+	// metadata may be empty or stale, causing the container-side
+	// provisioner to auto-detect and potentially pick a wrong method.
+	explicitType := c.entry.AuthSelectedType
+	if st := resolved.EnvVars["SCION_HARNESS_SELECTED_AUTH"]; st != "" {
+		explicitType = st
+	}
+
 	payload := map[string]interface{}{
 		"schema_version":    1,
-		"explicit_type":     c.entry.AuthSelectedType,
+		"explicit_type":     explicitType,
 		"resolved_method":   resolved.Method,
 		"env_vars":          sortedKeys(resolved.EnvVars),
 		"env_secret_files":  envSecretFiles,

--- a/pkg/harness/container_script_harness_test.go
+++ b/pkg/harness/container_script_harness_test.go
@@ -286,6 +286,87 @@ func TestContainerScriptHarness_ApplyAuthSettings_WritesCandidates(t *testing.T)
 	}
 }
 
+func TestContainerScriptHarness_ApplyAuthSettings_ExplicitTypeFromResolvedAuth(t *testing.T) {
+	// Regression test: when SCION_HARNESS_SELECTED_AUTH is present in the
+	// resolved auth's env vars, explicit_type in auth-candidates.json must
+	// come from it — not from c.entry.AuthSelectedType (which may be empty).
+	// This ensures the container-side provisioner uses the Go side's resolved
+	// auth method instead of falling back to auto-detection, which can pick a
+	// wrong higher-priority method (e.g., api-key over vertex-ai).
+	h, _ := newTestContainerScriptHarness(t)
+	agentHome := t.TempDir()
+
+	// Simulate the scenario: resolved auth knows it's vertex-ai
+	// (SCION_HARNESS_SELECTED_AUTH), but c.entry.AuthSelectedType is empty
+	// (harness config metadata doesn't have it). Both ANTHROPIC_API_KEY and
+	// GOOGLE_CLOUD_PROJECT are present as candidates.
+	resolved := &api.ResolvedAuth{
+		Method: "container-script",
+		EnvVars: map[string]string{
+			"SCION_HARNESS_SELECTED_AUTH": "vertex-ai",
+			"ANTHROPIC_API_KEY":           "sk-test",
+			"GOOGLE_CLOUD_PROJECT":        "my-project",
+			"GOOGLE_CLOUD_REGION":         "us-central1",
+		},
+	}
+	if err := h.ApplyAuthSettings(agentHome, resolved); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(agentHome, ".scion", "harness", "inputs", "auth-candidates.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if payload["explicit_type"] != "vertex-ai" {
+		t.Errorf("explicit_type=%v, want vertex-ai", payload["explicit_type"])
+	}
+}
+
+func TestContainerScriptHarness_ApplyAuthSettings_ExplicitTypeFallsBackToEntry(t *testing.T) {
+	// When SCION_HARNESS_SELECTED_AUTH is absent from resolved env vars,
+	// explicit_type should fall back to c.entry.AuthSelectedType.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "config.yaml"), "harness: testharness\nimage: scion-test:latest\n")
+	writeFile(t, filepath.Join(dir, "provision.py"), "#!/usr/bin/env python3\nimport sys\nsys.exit(0)\n")
+	entry := config.HarnessConfigEntry{
+		Harness:          "testharness",
+		Image:            "scion-test:latest",
+		AuthSelectedType: "api-key",
+		Provisioner: &config.HarnessProvisionerConfig{
+			Type:             "container-script",
+			InterfaceVersion: 1,
+			Command:          []string{"python3", "$HOME/.scion/harness/provision.py"},
+		},
+	}
+	h, err := NewContainerScriptHarness(dir, entry)
+	if err != nil {
+		t.Fatalf("NewContainerScriptHarness: %v", err)
+	}
+
+	agentHome := t.TempDir()
+	resolved := &api.ResolvedAuth{
+		Method:  "container-script",
+		EnvVars: map[string]string{"ANTHROPIC_API_KEY": "sk-test"},
+	}
+	if err := h.ApplyAuthSettings(agentHome, resolved); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(agentHome, ".scion", "harness", "inputs", "auth-candidates.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if payload["explicit_type"] != "api-key" {
+		t.Errorf("explicit_type=%v, want api-key", payload["explicit_type"])
+	}
+}
+
 func TestContainerScriptHarness_ApplyAuthSettings_StagesFileSecrets(t *testing.T) {
 	// Harness entry with a required_files declaration matching Codex auth-file.
 	dir := t.TempDir()

--- a/pkg/harness/container_script_harness_test.go
+++ b/pkg/harness/container_script_harness_test.go
@@ -293,6 +293,8 @@ func TestContainerScriptHarness_ApplyAuthSettings_ExplicitTypeFromResolvedAuth(t
 	// This ensures the container-side provisioner uses the Go side's resolved
 	// auth method instead of falling back to auto-detection, which can pick a
 	// wrong higher-priority method (e.g., api-key over vertex-ai).
+	// entry.AuthSelectedType is intentionally empty here (zero value from
+	// newTestContainerScriptHarness) to isolate the resolved-auth signal.
 	h, _ := newTestContainerScriptHarness(t)
 	agentHome := t.TempDir()
 


### PR DESCRIPTION
Problem: ANTHROPIC_VERTEX_PROJECT_ID disappeared from the agent container after stop+resume for Claude-harness Vertex AI agents. Root cause: auth-candidates.json explicit_type was sourced from harness-config metadata (often empty) instead of the Go sides actual resolved auth type, so provision.pys priority-ordered auto-detection (api-key greater than oauth-token greater than auth-file greater than vertex-ai) could skip vertex-ai whenever a higher-priority credential was present, and vertex-ai is the only auth method whose env var name is not identical on both sides of the boundary.
Fix: ApplyAuthSettings now sources explicit_type from the resolved SCION_HARNESS_SELECTED_AUTH signal, falling back to the prior harness-config value when that signal is absent. No wire-format changes.
Tests: 2 Go + 2 Python regression tests exercising the actual priority-override scenario. Two independent fork reviews approved (first round, then a fresh second round).
Ref: ptone/scion#644
