### PR TITLE
feat: resolved settings endpoint, project clone, and harness list cleanup

### DIFF
--- a/.design/backlog/RELEASENOTES.md
+++ b/.design/backlog/RELEASENOTES.md
@@ -7,6 +7,7 @@
 - **K8s attach su password prompt** — `scion attach` no longer prompts for a password on GKE Autopilot pods that run as non-root with `allowPrivilegeEscalation: false`
 
 ### Added
+- **Resolved project settings endpoint** — `GET /api/v1/projects/{projectId}/settings/resolved` reports every project setting alongside whether a hub-level default exists. Requires `ActionRead` on the project (not admin-gated), so project owners can see that hub defaults exist. Despite the name it does **not** return an effective value: precedence is owned by the code that applies it, and a second implementation here would drift silently. `hubDefault` is tri-state (`present`/`absent`/`unknown`) — `unknown` means the hub could not determine it, and must not be rendered as "no hub default". See the [reference page](https://googlecloudplatform.github.io/scion/reference/project-settings-resolved/).
 - All container images built and published to Artifact Registry (core-base, scion-base, scion-claude, scion-gemini, scion-opencode, scion-codex)
 
 ---

--- a/.design/project-templates.md
+++ b/.design/project-templates.md
@@ -1,0 +1,1361 @@
+# Project Templates: Settings Fallback UX & Project Clone
+
+**Status:** Ready for implementation — all blocking questions resolved
+**Author:** pt-arch (architect, project-templates workstream)
+**Date:** 2026-07-28
+**Implements:** #380 (project settings fallback UX), #377 / #300 (project clone)
+**Explicitly deferred:** #381 (hub-level project defaults copy-on-create)
+**Handoff target:** project-templates-lead (EM) for phase dispatch
+**Reviewed:** all code claims verified against the tree at 8dbf167; corrections applied
+
+---
+
+## 1. Problem & Goals
+
+Two related but independent pain points sit at the "how do I get a new project
+configured the way I want" boundary.
+
+### 1.1 Feature A — Project settings fallback is invisible
+
+`GET /api/v1/projects/{id}/settings` returns only the values explicitly set on
+the project (stored as `scion.io/*` annotations on `store.Project`). Every field
+is optional. When a field is unset, the settings page renders an empty control
+with a generic placeholder such as `None (use server default)` or `No limit`.
+
+The user has no way to learn what "server default" actually resolves to. They
+cannot answer the question *"if I leave this blank, what will my agents get?"*
+without asking an administrator, because the only surface that exposes hub-level
+agent defaults today is `GET /api/v1/admin/server-config`, which is hard-gated to
+`user.Role() == "admin"` (`pkg/hub/admin_settings.go`). Project owners are
+routinely not hub admins.
+
+There is exactly one field where we already solved this, and it demonstrates the
+target UX. Telemetry has a `GET /api/v1/settings/public` endpoint
+(`pkg/hub/handlers_public_settings.go`) whose single value drives a select
+option rendered as:
+
+```
+Use hub default (enabled)
+```
+
+(Aside, since it misleads on inspection: despite the name and a stale
+`// no auth required` comment at its registration, `/api/v1/settings/public` is
+**not** unauthenticated. It sits behind `UnifiedAuthMiddleware` and is absent
+from `isUnauthenticatedEndpoint`, so an anonymous request gets 401. The handler
+itself performs no identity check, which is where the belief comes from. This
+matters only for §10's retention rationale.)
+
+**Goal:** generalise that pattern to the rest of the agent-defaults fields, so
+that an unset project setting displays the hub fallback that will actually be
+used.
+
+### 1.2 Feature B — No way to seed a new project from an existing one
+
+Configuring a project is a long tail of small decisions: default harness config,
+model, thinking level, turn/duration/call limits, resource requests and limits,
+GCP identity mode, a pre-start hook script, project-scoped environment
+variables, and an injected-skills list. A team that has tuned one project has no
+mechanism to reuse that work. The only path is to open both projects side by
+side and retype every field.
+
+Templates and harness configs already have a first-class clone
+(`POST /api/v1/templates/{id}/clone`, `POST /api/v1/harness-configs/{id}/clone`).
+Projects do not.
+
+**Goal:** `POST /api/v1/projects/{id}/clone` creates a new project pre-populated
+with the source project's *configuration*, with no runtime state, no secrets, and
+no workspace history.
+
+### 1.3 Why one design doc
+
+The two features share a mental model ("where does this value come from?"), share
+the annotation-based project settings data model, and share the project-settings
+UI surface. Designing them together avoids a second pass over
+`project_settings_handlers.go` and lets Feature B's clone list be defined
+directly against the resolved-settings vocabulary Feature A introduces. They are
+implemented in **sequential phases**, not together.
+
+---
+
+## 2. Non-Goals
+
+1. **#381 hub-level project defaults copy-on-create is out of scope.** We are not
+   adding a mechanism that stamps hub settings onto a project's annotations at
+   creation time. Deferred by explicit decision. The fallback stays dynamic: an
+   unset project field continues to resolve at agent-create time, not at
+   project-create time. Feature A makes that resolution *visible*, not *frozen*.
+2. **No tri-state control.** We are not introducing an
+   inherit / override / explicitly-null tri-state checkbox per field. Unset stays
+   unset; the hub value is presented as a hint next to an empty control.
+3. **No chat integration cloning.** Telegram and Discord integration
+   configuration is hub-level (`integration_configs` has no `project_id`) and its
+   credentials are hub-scoped secrets. Project-level chat state lives in the
+   plugin's own database (e.g. `extras/scion-telegram` `GroupLink`), outside the
+   hub's transactional reach. Integrations are excluded from clone entirely.
+4. **No secret cloning.** Secret values are never returned by `ListSecrets`, and
+   for external backends (GCP Secret Manager) the value does not exist in the hub
+   database at all. Cloning secret *names* without values would create a project
+   that looks configured but fails at runtime, which is worse than an empty list.
+5. **No agent, message, or history cloning.** A clone is a configuration seed, not
+   a fork of activity.
+6. **No workspace content cloning.** The new project runs the standard workspace
+   initialisation path for its workspace mode, from the same git remote.
+7. **No broker-side resolution changes.** The `harness_config` precedence fix in
+   §7.2 is confined to the hub; `pkg/config/resolve_harness_config.go` is not
+   touched. See §7.2 for why that is sufficient.
+
+---
+
+## 3. Background: how a project setting actually reaches an agent
+
+This section is load-bearing for Feature A. It is written out because the
+resolution chain is not obvious from any single file and two reviewers
+independently guessed it wrong.
+
+### 3.1 Project settings storage
+
+Project settings are annotations on `store.Project.Annotations`, keyed by
+constants at the top of `pkg/hub/project_settings_handlers.go`:
+
+| Annotation key | Settings field |
+| --- | --- |
+| `scion.io/default-template` | `defaultTemplate` |
+| `scion.io/default-harness-config` | `defaultHarnessConfig` |
+| `scion.io/default-model` | `defaultModel` |
+| `scion.io/default-thinking-level` | `defaultThinkingLevel` |
+| `scion.io/telemetry-enabled` | `telemetryEnabled` |
+| `scion.io/active-profile` | `activeProfile` |
+| `scion.io/default-max-turns` | `defaultMaxTurns` |
+| `scion.io/default-max-model-calls` | `defaultMaxModelCalls` |
+| `scion.io/default-max-duration` | `defaultMaxDuration` |
+| `scion.io/default-gcp-identity-mode` | `defaultGcpIdentityMode` |
+| `scion.io/default-gcp-identity-service-account-id` | `defaultGcpIdentityServiceAccountId` |
+| `scion.io/default-resources-cpu-request` | `defaultResources.cpuRequest` |
+| `scion.io/default-resources-memory-request` | `defaultResources.memoryRequest` |
+| `scion.io/default-resources-cpu-limit` | `defaultResources.cpuLimit` |
+| `scion.io/default-resources-memory-limit` | `defaultResources.memoryLimit` |
+| `scion.io/default-resources-disk` | `defaultResources.disk` |
+
+`setOrDelete` / `setOrDeleteInt` mean an empty or zero value *removes* the
+annotation rather than storing a zero. Unset is genuinely absent, which is what
+makes the null semantics in §6.4 clean.
+
+### 3.2 Hub-side application
+
+`applyProjectDefaults(ac *store.AgentAppliedConfig, project *store.Project)`
+fills `ac.HarnessConfig`, `ac.Model`, `ac.ThinkingLevel` and
+`ac.InlineConfig.{MaxTurns,MaxModelCalls,MaxDuration,Resources}` **only if they
+are currently unset**. It runs in the agent-create path
+(`handlers_agents_core.go`) and in scheduler dispatch (`server.go`).
+
+### 3.3 Hub-level agent defaults — the gap
+
+`opsettings.AgentDefaultsSettings` (`pkg/config/opsettings/sections.go`) holds
+`DefaultTemplate`, `DefaultHarnessConfig`, `DefaultMaxTurns`,
+`DefaultMaxModelCalls`, `DefaultMaxDuration`, `DefaultResources`, registered as
+the `agent_defaults` section and surfaced in the admin UI.
+
+**These values are never read by the hub during agent create or dispatch.**
+`ApplySnapshot` (`pkg/hub/operational_settings.go`) applies telemetry, admin
+emails, auto-suspend, user access mode, GitHub app config and hub name — and
+nothing from `agent_defaults`. `hub.ServerConfig` has no fields for them.
+
+They are consumed **broker-side**, in `pkg/agent/provision.go`, from
+`config.LoadEffectiveSettings(projectDir)` — that is, the *broker's own*
+`~/.scion/settings.yaml` merged with the project's `.scion/settings.yaml` and
+environment. `DefaultHarnessConfig` is step 7 of
+`config.ResolveHarnessConfigName` (`pkg/config/resolve_harness_config.go`).
+
+The bridge exists only in **file/SQLite mode**: `handlePutServerConfig` writes
+the values into `<globalDir>/settings.yaml`, and a co-located broker reads that
+file. In **Postgres mode** `handlePutServerConfigDB` writes database rows only,
+and there is no transport that carries them to a remote broker.
+
+**Consequence:** on any Postgres / multi-broker deployment, the hub-level agent
+defaults are display-only. A "Hub default: 200 turns" hint would be false in
+exactly the deployments Feature A is most valuable in.
+
+**Resolved (D-1, 2026-07-28):** we fix this. Phase 2 applies hub agent defaults
+hub-side, so they take effect on every deployment topology and the hint is
+truthful. See §4.1 and §8 Phase 2.
+
+### 3.4 Effective precedence
+
+Target order after this work:
+
+```
+explicit agent-create request
+  > project annotation
+  > template
+  > harness config
+  > profile
+  > hub default (applied hub-side; see §4.1)
+  > compiled default
+```
+
+Today `harness_config` violates this by resolving the template ahead of the
+project annotation, inverting positions 2 and 3. **Resolved (D-2, 2026-07-28):**
+we normalise it to the order above — project annotation beats template, for all
+fields. See §7.2.
+
+---
+
+## 4. Feature A — Project Settings Fallback UX
+
+### 4.1 API design
+
+#### Decision: new sub-resource, not an extension of the existing response
+
+`hubclient.ProjectSettings` is used as **both** the `GET` response body and the
+`PUT` request body (`pkg/hubclient/types.go`). Adding hub-fallback fields to it
+would make them appear in the PUT contract, implying they are writable and
+inviting clients to round-trip a GET into a PUT — which would silently promote
+every hub fallback into an explicit project annotation. That is #381 by accident,
+and #381 is deferred.
+
+Therefore: a **new read-only endpoint**.
+
+```
+GET /api/v1/projects/{id}/settings/resolved
+```
+
+Authorization: `ActionRead` on the project — identical to
+`GET /api/v1/projects/{id}/settings`. Deliberately *not* admin-gated; the whole
+point is to expose hub defaults to non-admin project owners. Only the
+`agent_defaults` section is exposed, never the full server config.
+
+Routing: added to the `subPath` dispatch in `handleProjectRoutes`
+(`pkg/hub/handlers_projects_core.go`), alongside `settings`, `pre-start-hooks`,
+`discover-templates`. Note this is a chain of `if subPath == …` /
+`if strings.HasPrefix(subPath, …)` checks, not a `switch`.
+
+#### Response shape
+
+```jsonc
+{
+  "project": { /* exactly the existing ProjectSettings object, unchanged */ },
+  "fields": {
+    "defaultHarnessConfig": {
+      "value":  "claude",
+      "source": "hub",
+      "projectValue": null,
+      "hubValue": "claude"
+    },
+    "defaultMaxTurns": {
+      "value":  120,
+      "source": "project",
+      "projectValue": 120,
+      "hubValue": 200
+    },
+    "defaultModel": {
+      "value":  null,
+      "source": "unset",
+      "projectValue": null,
+      "hubValue": null
+    }
+  }
+}
+```
+
+Go types (new file `pkg/hub/project_settings_resolved.go`, mirrored in
+`pkg/hubclient/types.go`):
+
+```go
+// ResolvedSettingSource describes where a resolved project setting came from.
+type ResolvedSettingSource string
+
+const (
+    ResolvedSourceProject ResolvedSettingSource = "project" // explicit project annotation
+    ResolvedSourceHub     ResolvedSettingSource = "hub"     // hub agent_defaults fallback
+    ResolvedSourceUnset   ResolvedSettingSource = "unset"   // neither set
+)
+
+// ResolvedSettingField is one field's resolution result.
+type ResolvedSettingField struct {
+    Value        any                   `json:"value"`
+    Source       ResolvedSettingSource `json:"source"`
+    ProjectValue any                   `json:"projectValue"`
+    HubValue     any                   `json:"hubValue"`
+}
+
+// ResolvedProjectSettings is the GET .../settings/resolved response.
+type ResolvedProjectSettings struct {
+    Project *hubclient.ProjectSettings       `json:"project"`
+    Fields  map[string]ResolvedSettingField  `json:"fields"`
+}
+```
+
+Rationale for the `{value, source, projectValue, hubValue}` quad rather than a
+bare `hubDefaults` blob:
+
+- It matches provenance conventions already established in the codebase:
+  `SectionMetadata.Source` (`admin_settings_db.go`), `SupersededKey.Source`,
+  `config.HarnessConfigResolution{Name, Source}`, `api.SecretKeyInfo.Source`.
+- The UI needs `source` anyway to decide between rendering a value and rendering
+  a hint; deriving it client-side from two nullable fields duplicates logic that
+  belongs on the server.
+- It leaves room to add `"template"` and `"harness-config"` sources later without
+  a breaking change, should we later want to show template/harness-config
+  provenance too.
+
+#### Fields covered
+
+Only the fields for which a hub-level fallback actually exists in
+`opsettings.AgentDefaultsSettings`, plus telemetry which already has one:
+
+`defaultTemplate`, `defaultHarnessConfig`, `defaultMaxTurns`,
+`defaultMaxModelCalls`, `defaultMaxDuration`, `defaultResources`,
+`telemetryEnabled`.
+
+Fields with **no** hub-level counterpart — `defaultModel`,
+`defaultThinkingLevel`, `activeProfile`, `defaultGcpIdentityMode`,
+`defaultGcpIdentityServiceAccountId` — are still emitted, with
+`hubValue: null` and `source: "project"` or `"unset"`. Emitting them uniformly
+lets the UI iterate one map instead of maintaining a parallel allowlist, and
+makes it a one-line server change if a hub-level default is added later.
+
+#### Reading hub values
+
+```go
+func (s *Server) hubAgentDefaults() opsettings.AgentDefaultsSettings
+```
+
+- If `ops := s.GetOperationalSettings(); ops != nil` → read the `agent_defaults`
+  section from `ops.Snapshot()`. This is the Postgres path and is where the
+  values actually live.
+- On any error, return the zero value. A missing hint degrades to today's
+  behaviour; it must never fail the request.
+
+**File-mode caveat.** `hub.Layer1Snapshot` does carry all six agent-defaults
+fields, but `BuildLayer1SnapshotFromFile` deliberately leaves them zero (there
+is an explicit comment saying so). So in file mode there is no in-process source
+for them — they live in the on-disk `settings.yaml` that the co-located broker
+reads directly. A naive "fall back to the bootstrap snapshot" would therefore be
+a no-op returning zeros, and must not be written as though it were a real
+fallback. Two acceptable outcomes for file mode: report `hubValue: null` (the
+hint is simply unavailable, which is honest), or load `settings.yaml` directly.
+**Recommendation: report null.** File mode is the single-binary case where the
+existing broker-side resolution already works correctly; the hint is a
+nice-to-have there, and reading a file from a request handler to produce a
+placeholder is not worth the coupling. Implementer should confirm this is
+acceptable before choosing otherwise.
+
+Telemetry continues to come from `s.config.TelemetryDefault`, the same source
+`handlePublicSettings` uses, to avoid two disagreeing answers for one field.
+
+#### Applying hub defaults hub-side (D-1)
+
+Per §3.3, in Postgres mode these hub values never reach agents, which would make
+the hint a lie. **Decision: fix it.** Phase 2 adds
+
+```go
+// applyHubDefaults fills unset agent config fields from the hub-level
+// agent_defaults section. Runs after applyProjectDefaults, so project
+// annotations always win.
+func applyHubDefaults(ac *store.AgentAppliedConfig, d opsettings.AgentDefaultsSettings)
+```
+
+called immediately after the existing `applyProjectDefaults` call at both sites:
+
+- `handlers_agents_core.go` — the agent-create path
+- `server.go` — scheduler dispatch
+
+Semantics mirror `applyProjectDefaults` exactly: **only-if-unset**, field by
+field, covering `HarnessConfig`, and `InlineConfig.{MaxTurns, MaxModelCalls,
+MaxDuration, Resources}`. `DefaultTemplate` is handled earlier, alongside the
+existing project-level default-template logic, because template resolution has
+to happen before harness resolution.
+
+This closes the Postgres gap and makes the resolved endpoint's `source: "hub"`
+truthful on every topology.
+
+**Behaviour change.** Existing Postgres deployments that already have
+`agent_defaults` rows go from those rows being inert to being applied. This is
+the intended fix, but it is a live behavioural change and must appear in release
+notes. Deployments with no hub agent defaults configured see no change; §9.1
+carries an explicit regression test for that case.
+
+**Interaction with the broker.** The broker performs its own fallback from its
+local `settings.yaml` (`ResolveHarnessConfigName` step 7). Once the hub stamps a
+value into `AppliedConfig`, that value travels
+
+```
+AppliedConfig.HarnessConfig
+  → httpdispatcher.go        RemoteAgentConfig.HarnessConfig
+  → start_context.go         opts.HarnessConfig
+  → run.go                   GetAgent(..., opts.HarnessConfig, ...)
+  → provision.go             ProvisionAgent(..., harnessConfig, ...)
+  → provision.go             HarnessConfigInputs{CLIFlag: harnessConfig}
+```
+
+and arrives as **`CLIFlag` — step 1**, the highest priority in the chain, above
+the template (steps 3–4) and the broker's own settings default (step 7). Note
+`HarnessConfigInputs.StoredConfig` is **not** populated from the hub on the
+create path; it is the broker's own locally-merged config and matters only on
+resume. So the hub-side value wins outright, and no broker change is required.
+
+### 4.2 Data model changes
+
+**None.** No schema migration, no new ent entity, no new annotation keys.
+Feature A is a pure read-side projection over data that already exists in
+`project.Annotations` and the `hub_settings` `agent_defaults` row.
+
+`applyHubDefaults` reads existing opsettings state and writes only into the
+in-memory `AgentAppliedConfig`; it persists nothing new.
+
+### 4.3 UI specification
+
+File: `web/src/components/pages/project-settings.ts`.
+
+**Data loading.** The existing `loadSettings()` call to
+`/api/v1/projects/${projectId}/settings` is replaced by a call to
+`/api/v1/projects/${projectId}/settings/resolved`. The `project` sub-object
+populates the existing form state exactly as today — zero changes to the PUT
+path. The `fields` map is stored as `this.resolvedFields`. The separate fetch of
+`/api/v1/settings/public` for `hubTelemetryDefault` is removed; telemetry now
+comes from `fields.telemetryEnabled.hubValue`.
+
+**Rendering rules.**
+
+1. *Text and number inputs* (`defaultMaxTurns`, `defaultMaxModelCalls`,
+   `defaultMaxDuration`, all five `defaultResources.*`): when the project value is
+   unset and `hubValue` is non-null, set the input's `placeholder` to
+   `Hub default: ${hubValue}`. This reuses the control's own affordance — no new
+   DOM — and keeps the field visually empty, which correctly signals "unset".
+   When `hubValue` is null, keep today's placeholder text.
+2. *Select inputs* (`defaultTemplate`, `defaultHarnessConfig`): the existing
+   empty/none option's label becomes `Use hub default (${hubValue})` when
+   `hubValue` is non-null, falling back to today's `None (use server default)`
+   when it is null. This is character-for-character the pattern already shipped
+   for telemetry.
+3. *Telemetry select*: unchanged in appearance; only its data source moves.
+4. A single shared helper is added to the component:
+
+   ```ts
+   private hubHint(field: string): string | null
+   ```
+
+   returning `Hub default: <formatted>` or `null`. All call sites go through it,
+   so the copy is defined once.
+
+**Resource spec formatting.** `defaultResources` arrives as a nested object.
+`hubHint('defaultResources.cpuRequest')` etc. index into it. `null` sub-fields
+produce no hint.
+
+**Explicitly not doing:** no badge component, no "inherited" chip, no italic
+ghost-value overlay. Placeholder + option-label reuse is a ~60 line change with
+no new visual vocabulary, and it matches the one precedent users have already
+seen.
+
+### 4.4 Harness fallback list consistency cleanup
+
+Two components hardcode a fallback list of harness names for when the
+harness-config API returns nothing, and they disagree:
+
+| Component | Hardcoded list |
+| --- | --- |
+| `project-settings.ts` | `gemini`, `claude`, `opencode`, `codex` |
+| `admin-server-config.ts` | `gemini-cli`, `claude`, `codex`, `copilot`, `opencode` |
+
+The canonical set, from `harnesses/*/config.yaml`, is: `claude`, `codex`,
+`copilot`, `gemini-cli`, `opencode`, `antigravity`, `hermes`.
+
+`project-settings.ts` is outright wrong — `gemini` is not a harness name; the
+correct identifier is `gemini-cli`. Both lists are missing `antigravity` and
+`hermes`, and `project-settings.ts` is additionally missing `copilot`.
+
+**Fix.** New module `web/src/shared/harness-utils.ts`, following the existing
+`web/src/shared/` convention (`model-utils.ts`, `types.ts`, `lineage.ts`):
+
+```ts
+/** Canonical harness identifiers, mirroring harnesses/ * /config.yaml. */
+export const KNOWN_HARNESS_NAMES = [
+  'claude',
+  'codex',
+  'copilot',
+  'gemini-cli',
+  'opencode',
+  'antigravity',
+  'hermes',
+] as const;
+```
+
+Both components import it and delete their local arrays. A comment on the
+constant points at `harnesses/` as the source of truth.
+
+This is a small, independently reviewable, zero-risk change with no API
+dependency — it is sequenced first (Phase 0) so it can land in parallel with the
+backend work.
+
+---
+
+## 5. Feature B — Project Clone
+
+### 5.1 API specification
+
+```
+POST /api/v1/projects/{id}/clone
+```
+
+Request:
+
+```jsonc
+{
+  "name": "my-new-project",     // required
+  "slug": "my-new-project-alt"  // optional explicit slug override
+}
+```
+
+Response: **201 Created**, body is the `store.Project` — byte-identical in shape
+to `POST /api/v1/projects`, so every existing client-side project renderer works
+without modification.
+
+Errors:
+
+| Status | Condition |
+| --- | --- |
+| 400 | missing/blank `name`, or invalid explicit `slug` |
+| 403 | caller lacks read on source, or lacks project-create at hub scope |
+| 404 | source project not found (or not visible to caller) |
+| 409 | explicit `slug` collides with an existing project |
+| 500 | clone failed after rollback |
+
+Note the deliberate asymmetry: when `slug` is **omitted**, the handler uses
+`api.Slugify(name)` + `s.store.NextAvailableSlug(ctx, baseSlug)` and therefore
+*cannot* 409 — it auto-disambiguates, exactly like `createProject`. 409 is
+reachable only via an explicit `slug`. This means the common "clone this" button
+never fails on a name collision.
+
+Routing: `clone` is added to the `subPath` dispatch chain in
+`handleProjectRoutes`, method-gated to POST.
+
+`{id}` accepts an ID or a slug, consistent with every other project route.
+
+### 5.2 Authorization model
+
+Per confirmed decision:
+
+Sketch — note the real API shapes, which are easy to get wrong: everything lives
+in package `hub` (there is no `pkg/authz`), the field is `s.authzService`,
+`CheckAccess` returns a `Decision` value rather than an `error`,
+`ComputeScopeCapabilities` takes five arguments, and `Capabilities` is a bare
+`Actions []string` with no `Can` helper.
+
+```go
+// 1. Caller must be able to read the source project.
+if d := s.authzService.CheckAccess(ctx, identity, Resource{
+    Type: "project", ID: src.ID, OwnerID: src.OwnerID,
+}, ActionRead); !d.Allowed {
+    Forbidden(w, "insufficient permission to read source project")
+    return
+}
+
+// 2. Caller must be able to create projects at hub scope.
+caps := s.authzService.ComputeScopeCapabilities(ctx, identity, "hub", "", "project")
+if !slices.Contains(caps.Actions, ActionCreate) {
+    Forbidden(w, "insufficient permission to create projects")
+    return
+}
+```
+
+The exact `ComputeScopeCapabilities` argument values should be confirmed against
+a sibling call site during implementation.
+
+Rationale and the extensibility note: today `createProject` performs **no**
+authz check — any authenticated user may create a project — so check 2 is
+currently vacuous. It is written explicitly anyway, against
+`ScopeActions["project"]`, so that the day project creation is restricted, clone
+is restricted with it and no one has to remember this handler exists.
+
+Check 1 is the meaningful gate: *if you can see the configuration, you may copy
+it*. This is intentionally permissive and matches `handleHarnessConfigClone`.
+Should it need to narrow later (e.g. require `ActionUpdate`, or owner-only, or a
+new `ActionClone`), the change is confined to this one block; the helper is
+factored as `authorizeProjectClone(ctx, user, src) error` for exactly that
+reason.
+
+The clone's `OwnerID` and `CreatedBy` are the **caller**, never the source
+project's owner. Cloning someone else's visible project gives you your own
+project, not shared ownership of theirs. Visibility resets to
+`store.VisibilityPrivate` (the `createProject` default) rather than inheriting
+the source's — inheriting `public` would silently publish a project the caller
+may not have intended to share.
+
+### 5.3 What is copied
+
+#### Copied
+
+| Item | Store surface | Rationale |
+| --- | --- | --- |
+| **Settings annotations** (`scion.io/*`) | `project.Annotations` | The core of the feature. Only keys that are actually **set** are copied; absent stays absent (§6.4). |
+| **Labels**, minus workspace-mode | `project.Labels` | Organisational metadata the user chose. `scion.dev/workspace-mode` is *re-derived*, not copied — see below. |
+| **Git remote** | `project.GitRemote` | A clone of a project's config almost always targets the same repository. Also required for the workspace init path to work at all. |
+| **Shared dirs** | `project.SharedDirs` | Pure configuration; meaningless to retype. |
+| **Git identity config** | `project.GitIdentity` | Pure configuration. |
+| **Default runtime broker** | `project.DefaultRuntimeBrokerID` | Configuration. If the broker is later removed, dispatch falls back exactly as it does for any project. |
+| **Active pre-start hook** | `ProjectPreStartHook` (active only) | A tuned setup script is one of the highest-value things to carry over. |
+| **Env vars** (scope=project, `Secret == false`) | `EnvVar` | Non-secret configuration. |
+| **Injected skills** | `SkillInjection` (scope=project) | Configuration list; `SetSkillInjections` makes this a single atomic call. |
+| **Project-scoped harness configs & templates** | `HarnessConfig`, `Template` | See §5.4 — deep-copied. |
+
+**Workspace-mode label.** `scion.dev/workspace-mode` (`shared` /
+`per-agent` / `worktree-per-agent`) is copied from the source but treated as
+input to the standard `createProject` workspace-initialisation branch, not as an
+inert label. The clone therefore ends up in the same workspace mode as its
+source, provisioned fresh. The related `scion.dev/clone-url` and
+`scion.dev/default-branch` labels are copied as-is since they describe the git
+remote, which is also copied.
+
+**Pre-start hook.** Only the **active** hook is copied
+(`GetActiveProjectPreStartHook`). Archived revisions are history, not
+configuration. The copy is created with a fresh UUID and slug, `CreatedBy` =
+caller, and then activated via `ActivateProjectPreStartHook`. Note
+`CreateProjectPreStartHook` already archives any existing active hook
+atomically, so on a brand-new project a single `CreateProjectPreStartHook` with
+`Status: active` suffices; the explicit activate call is belt-and-braces for the
+case where workspace init has somehow installed one.
+
+**Env vars.** `ListEnvVars(ctx, store.EnvVarFilter{Scope: store.ScopeProject,
+ScopeID: srcID})` — note it takes a filter struct, not positional scope
+arguments — then filtered on `Secret == false`.
+
+That filter is belt-and-braces rather than the primary guard: `setEnvVar` routes
+secret-flagged writes to the secret backend and then *deletes* any plain row, so
+`Secret: true` entries generally do not exist in `env_vars` at all. The ones the
+API returns are synthetic objects built from secret metadata with
+`Value: "********"`, which `ListEnvVars` never produces. The explicit filter
+stays anyway, because relying on that invariant silently is how a future change
+leaks a secret into a clone.
+
+`Sensitive: true` rows *are* copied. `Sensitive` only masks the value in API
+responses; the column is a plain unencrypted string and the value is
+legitimately part of the configuration. The unique constraint is
+`(key, scope, scope_id)`, and the destination scope is a brand-new project ID, so
+no conflict is possible; `CreateEnvVar` is used rather than `UpsertEnvVar`, so
+that an unexpected conflict surfaces as an error rather than silently
+overwriting.
+
+#### Not copied
+
+| Item | Why |
+| --- | --- |
+| **Secrets** | Values are unreadable by design; for GCP-SM they are not in the hub DB. Copying names without values yields a project that looks configured and fails at runtime. |
+| **Chat integrations** (Telegram/Discord) | Hub-level, no `project_id`; credentials are hub-scoped secrets; per-project links live in the plugin's own DB. Confirmed exclusion. |
+| **Agents** | Runtime state, not configuration. |
+| **Messages / history / events** | Runtime state. |
+| **Workspace content** | Re-initialised from the git remote by the standard path. |
+| **Secret-backed env vars** (`Secret == true`) | See above. |
+| **Scheduled events / schedules** | `ScheduledEvent` carries a `ProjectID`, but its payload references agents *by name*, and no agents are cloned. Copying them would produce schedules that fire into the void. Out of scope; revisit if requested. |
+| **Project providers / contributors** | Access control, not configuration. The clone's membership is established by the standard group/policy creation for its new slug. |
+| **GCP service accounts** | Bound to external IAM state; a copied binding would be wrong or a privilege leak. |
+| **Notification subscriptions & subscription templates** | Per-user runtime preferences. |
+| **Project sync state, user access tokens** | Runtime/credential state. |
+| **Project-scoped skill bank entries** | Skill *versions* with storage payloads; deep-copying a skill bank is a materially larger feature. The injected-skills *list* is copied; if it references a project-scoped skill URI, that reference will need the source project to remain readable. Flagged as a known limitation. |
+
+### 5.4 Project-scoped harness configs and templates: deep copy
+
+A project-scoped `HarnessConfig` or `Template` is keyed
+`(slug, scope, scope_id)` with `scope = "project"` and `scope_id = <projectID>`.
+Its files live in object storage at
+`storage.HarnessConfigStoragePath(hubID, scope, scopeID, slug)` /
+`storage.TemplateStoragePath(...)`.
+
+**Decision: deep-copy, do not reference by slug.**
+
+Reference-by-slug is impossible without changing the resolution model: a
+project-scoped config is looked up by `scope_id == thisProject`, so a clone that
+merely records the slug would resolve to nothing. The alternatives were
+(a) deep-copy, (b) leave project-scoped configs behind and let the clone's
+`defaultHarnessConfig` annotation dangle. (b) produces a clone whose headline
+setting is broken, which defeats the purpose.
+
+Implementation follows `handleHarnessConfigClone` exactly:
+
+1. `ListHarnessConfigs(ctx, HarnessConfigFilter{Scope: "project", ScopeID: srcID}, opts)`
+2. For each: new `api.NewUUID()`, same slug (unique constraint is scoped to the
+   new project ID, so the slug can be preserved — which matters, because the
+   cloned `scion.io/default-harness-config` annotation refers to it by slug).
+3. Recompute `StoragePath` for the new scope ID; `stor.Copy(ctx, src, dst)` per
+   file; `stor.DeletePrefix(ctx, dstPrefix)` on any failure.
+4. `s.store.CreateHarnessConfig`, mapping a UNIQUE violation to 409.
+
+Identical treatment for `Template` via `ListTemplates` /
+`TemplateStoragePath` / `CreateTemplate`, so that a cloned
+`scion.io/default-template` annotation also resolves.
+
+Preserving the slug is the key detail: it is what makes the copied annotations
+valid in the new project without any rewriting.
+
+### 5.5 Atomicity and rollback
+
+There is no cross-store transaction spanning the project row, object storage,
+and the authz group/policy tables. `createProject` already handles this with
+**compensating rollback**, and clone follows the same pattern — this is
+deliberate consistency with existing behaviour, not a new invention.
+
+Ordering, with each step's compensation:
+
+```
+ 1. load + authorize source                          — (no side effects)
+ 2. resolve name/slug (NextAvailableSlug)            — (no side effects)
+ 3. build clone Project struct (annotations, labels,
+    git remote, shared dirs, git identity, broker)
+ 4. store.CreateProject                              → store.DeleteProject
+ 5. createProjectGroup                               → (cascades with project delete)
+ 6. createProjectMembersGroupAndPolicy               → (cascades with project delete)
+ 7. copy harness configs (storage + rows)            → DeletePrefix + DeleteHarnessConfigsByScope
+ 8. copy templates (storage + rows)                  → DeletePrefix + DeleteTemplatesByScope
+ 9. copy env vars                                    → DeleteEnvVarsByScope
+10. SetSkillInjections (single atomic call)          → DeleteSkillInjectionsByScope
+11. copy + activate pre-start hook                   → (see note below)
+12. autoAssociateGitHubInstallation                  → best-effort, non-fatal
+13. workspace init (shared vs hub-managed branch)    → full rollback
+14. autoLinkProviders                                — best-effort, non-fatal
+15. events.PublishProjectCreated                     — best-effort, non-fatal
+16. 201 Created
+```
+
+**Step 11 has no direct compensation.** `DeleteProjectPreStartHook` returns
+`store.ErrInvalidInput` when the hook is active, and step 11 leaves it active by
+construction — so naming it as the rollback would fail on every invocation. The
+hook is instead cleaned up transitively by step 4's `DeleteProject`. This is
+safe because step 11 is the last hard-failing store write before the best-effort
+tail, so the only way to unwind past it is a full project delete anyway. Do not
+"fix" this by adding a `DeleteProjectPreStartHook` call.
+
+**Step 15 reuses `PublishProjectCreated`.** There is no `PublishProjectCloned`
+on the `EventPublisher` interface, and adding one would require touching the
+interface, the noop implementation, and the builder for no subscriber benefit —
+a clone *is* a project creation as far as every consumer is concerned.
+
+Steps 1–13 are hard-failing: any error triggers unwinding of every completed
+step in reverse and returns 500 (or the mapped status). Steps 12, 14 and 15 are
+best-effort and match `createProject`'s existing treatment — a project that
+exists but has not yet auto-linked a provider is a recoverable state; a project
+that exists with half its harness configs is not.
+
+The rollback logic is written as a `defer`-driven stack of closures:
+
+```go
+var rollback []func()
+defer func() {
+    if !committed {
+        for i := len(rollback) - 1; i >= 0; i-- { rollback[i]() }
+    }
+}()
+```
+
+Each rollback closure logs its own failure and continues; a failed rollback must
+never mask the original error. Every rollback uses `context.WithoutCancel` on
+the request context, so that a client disconnect mid-clone does not abort the
+cleanup and leave orphans — this is a hardening improvement over
+`createProject`'s current behaviour and should be noted in review.
+
+**Known residual risk.** If the process dies between steps 4 and 13 the clone is
+left partially populated. This is identical to the existing exposure in
+`createProject` and `handleHarnessConfigClone`, and is out of scope to fix here.
+The `deleteProject` path will clean such a project up when the user deletes it,
+with the caveat noted in §10 that `deleteProject` itself is incomplete.
+
+### 5.6 CLI specification
+
+```
+scion project clone <source-slug-or-id> [--name <new-name>] [--slug <new-slug>]
+```
+
+Behaviour, following `cmd/project_rename.go` exactly:
+
+1. `config.ResolveProjectPath(projectPath)` → `config.LoadSettings` →
+   `getHubClient(settings)`
+2. 30-second timeout context
+3. `resolveProjectByNameOrID(ctx, client, sourceRef)`
+4. `client.Projects().Clone(ctx, srcID, hubclient.CloneProjectRequest{...})`
+5. `isJSONOutput()` → `outputJSON(ActionResult{...})`; otherwise a human line:
+   `Cloned project "<source>" → "<new-name>" (slug: <new-slug>)`
+
+If `--name` is omitted, default to `<source-name> copy`; the server's
+`NextAvailableSlug` handles disambiguation, so repeated invocations produce
+`… copy`, `… copy-2`, etc. without client-side logic.
+
+New file `cmd/project_clone.go`, registered with
+`projectCmd.AddCommand(projectCloneCmd)` in its `init()`, joining `init`, `list`,
+`rename`, `skills`, `hook`, `prune`, `service-accounts`, `reconnect`.
+
+SDK addition to the `ProjectService` interface (`pkg/hubclient/projects.go`):
+
+```go
+// Clone creates a new project seeded from an existing project's configuration.
+Clone(ctx context.Context, sourceID string, req CloneProjectRequest) (*Project, error)
+```
+
+`CloneProjectRequest{Name, Slug string}` added to `pkg/hubclient/types.go`.
+
+### 5.7 UI specification
+
+**Entry point.** `web/src/components/pages/project-detail.ts`, in the existing
+`header-actions` div alongside New Agent / Pull Latest / Metrics / Settings. A
+`Clone` button, gated on `can(this.project?._capabilities, 'read')` — consistent
+with §5.2's authorization model.
+
+The projects list (`web/src/components/pages/projects.ts`) has no per-row action
+menu today; introducing one is a larger UI change than this feature warrants.
+Clone lives on the detail page only, in the first cut.
+
+**Dialog.** An `<sl-dialog>` with:
+
+- a `Name` text input, pre-filled with `<source name> copy`
+- a read-only preview line: `Slug: <slugified name>` (client-side slugify for
+  display only; the server is authoritative and may append a serial)
+- a short, explicit summary of what will and will not be copied — this is the
+  most important element in the dialog, because the exclusion list is
+  surprising:
+
+  > **Copies:** settings, labels, environment variables, injected skills,
+  > pre-start hook, project harness configs and templates.
+  > **Does not copy:** secrets, agents, history, or chat integrations.
+
+- Cancel / Clone buttons; Clone shows a spinner and disables on submit.
+
+On 201, navigate to the new project's detail page. On error, show the server's
+message inline in the dialog without closing it, so the user does not lose the
+name they typed.
+
+---
+
+## 6. Shared Infrastructure & Cross-Cutting Concerns
+
+### 6.1 Settings-key registry
+
+Both features enumerate the same set of project settings. Feature A needs the
+list to build the `fields` map; Feature B needs it to copy annotations. Today
+the list exists implicitly, as a series of hand-written `setOrDelete` calls.
+
+A single table in `pkg/hub/project_settings_handlers.go`:
+
+```go
+// projectSettingKeys is the authoritative list of scion.io/* annotation keys
+// that constitute project settings. Anything not in this list is not a project
+// setting and is not copied by clone or reported by the resolved endpoint.
+var projectSettingKeys = []string{
+    projectSettingDefaultTemplate,
+    projectSettingDefaultHarnessConfig,
+    // … all sixteen
+}
+```
+
+This is the mechanism that makes "copy the settings" precise. It is added in
+Phase 2 and consumed by Phase 4.
+
+**Note on annotation copying:** an audit confirmed that `scion.io/*` settings
+keys are the *only* annotations read from `project.Annotations` anywhere in the
+codebase. Copying the whole annotation map would in fact be safe today. The
+registry is still preferred, because it is explicit, it makes the clone contract
+reviewable, and it means a future non-settings annotation (a lock marker, a
+migration flag) is not silently propagated into clones.
+
+### 6.2 Provenance vocabulary
+
+`ResolvedSettingSource` (`"project" | "hub" | "unset"`) is introduced by Feature
+A and is the extension point for surfacing template and harness-config
+provenance, should that be wanted later. It intentionally mirrors the existing
+`SectionMetadata.Source` / `HarnessConfigResolution.Source` conventions rather
+than inventing a fourth spelling.
+
+### 6.3 Slug and group derivation
+
+Project group slugs (`project:<slug>:agents`, `project:<slug>:members`) and the
+policy `project:<slug>:member-create-agents` are **globally unique**. The clone
+must derive all three from the **new** slug, which it gets for free by calling
+the same `createProjectGroup` / `createProjectMembersGroupAndPolicy` helpers
+`createProject` uses. No group state is copied from the source.
+
+### 6.4 Null semantics
+
+Confirmed decision, applied uniformly:
+
+- A setting that is **unset** on the source project is **unset** on the clone.
+  No coercion to zero, no coercion to the hub fallback value.
+- Because `setOrDelete` removes the annotation on empty/zero, "unset" is
+  literally "key absent from the map", so the clone logic is a straightforward
+  `if v, ok := src.Annotations[k]; ok { dst.Annotations[k] = v }`.
+- This keeps clone orthogonal to #381: a clone inherits the source's *unset-ness*
+  and therefore continues to track the hub default dynamically, exactly as the
+  source does.
+
+---
+
+## 7. Alternatives Considered
+
+### 7.1 Extending `GET /settings` instead of a new `/settings/resolved`
+
+Rejected: `hubclient.ProjectSettings` is shared between the GET response and the
+PUT body. Adding hub values there makes a naive GET-modify-PUT round-trip
+promote every hub fallback into an explicit project annotation — silently
+implementing the deferred #381 and permanently detaching projects from hub
+defaults. A separate read-only sub-resource has no such failure mode.
+
+A rejected middle option was a `?resolved=true` query parameter on the existing
+endpoint. It avoids a new route but produces a response whose shape depends on a
+query parameter, which is hostile to typed clients and to the OpenAPI surface.
+
+### 7.2 Normalising the `harness_config` precedence inconsistency (D-2)
+
+`harness_config` resolves **template before project annotation** (the template is
+resolved in the agent-create handler, then `applyProjectDefaults` fills the field
+only if it is still empty). But `max_turns`, `max_model_calls`, `max_duration`
+and `resources` resolve **project annotation before template**, because
+annotations are baked into `InlineConfig`, which the broker merges *over* the
+template chain in `MergeScionConfig`.
+
+So the statement "project settings override the template" is true for limits and
+resources and false for harness config.
+
+**Decision: normalise to project-over-template.** A project setting is an
+override; that is what the words mean and what the UI implies. Making
+`harness_config` behave like every other field removes a trap that no user could
+be expected to discover, and it means the resolved endpoint can present one
+consistent ordering instead of a per-field footnote.
+
+#### Scope of the change
+
+Two hub call sites, plus nothing broker-side:
+
+**1. `handlers_agents_core.go` — agent create.** Today:
+
+```go
+harnessConfig := req.HarnessConfig
+if harnessConfig == "" {
+    harnessConfig = s.getHarnessConfigFromTemplate(resolvedTemplate, "")
+}
+```
+
+Becomes:
+
+```go
+harnessConfig := req.HarnessConfig
+if harnessConfig == "" && project != nil && project.Annotations != nil {
+    harnessConfig = project.Annotations[projectSettingDefaultHarnessConfig]
+}
+if harnessConfig == "" {
+    harnessConfig = s.getHarnessConfigFromTemplate(resolvedTemplate, "")
+}
+```
+
+**2. `server.go` — scheduler dispatch.** Today the template's harness config is
+stamped onto `AppliedConfig.HarnessConfig` unconditionally whenever non-empty,
+*before* `applyProjectDefaults` runs — so the only-if-unset guard can never fire.
+The stamp becomes conditional on the project annotation being absent, mirroring
+the existing default-template block immediately above it.
+
+**3. `handlers_agent_create_helpers.go` — `populateAgentConfig`.** No change
+needed. Its `hcName := agent.AppliedConfig.HarnessConfig; if hcName == "" { …
+template … }` fallback runs *after* `applyProjectDefaults`, so it already sees
+the project value first. It only stamps the config ID and content hash.
+
+**Broker: no change.** Once the hub stamps a value into `AppliedConfig`, it
+reaches the broker as `HarnessConfigInputs.CLIFlag` — **step 1** of
+`ResolveHarnessConfigName`, above the template at steps 3–4. (`StoredConfig` is
+*not* fed from the hub on the create path; it is the broker's own merged config
+and only matters on resume.) The broker chain already honours whatever the hub
+decides; the hub was the only place that inverted the precedence.
+
+**One caveat for the implementer.** After dispatch, `httpdispatcher.go`
+overwrites `AppliedConfig.HarnessConfig` with the broker's *resolved* answer.
+That is fine — the resolved answer will now be the project's value — but it
+means an end-to-end assertion on the persisted `AppliedConfig` must be made
+either before dispatch or against the post-resolution value, not naively at an
+arbitrary point.
+
+#### Risk
+
+This changes which harness config an agent gets, for the specific population of
+projects that have **both** a `scion.io/default-harness-config` annotation
+**and** a template that specifies a different harness config. Those agents move
+from the template's choice to the project's. That is the intended correction, but
+it is a live behavioural change: it belongs in release notes, and §9.1 carries a
+dedicated test for the both-set case asserting the project value now wins.
+
+Projects with only one of the two are unaffected, which is the overwhelming
+majority.
+
+### 7.3 Clone by reference (project inheritance / parent pointer)
+
+A `parent_project_id` with live inheritance was considered and rejected. It is a
+much larger data-model change, it creates a permanent coupling that users must
+later be given a way to break, and it does not match the stated need — which is
+"seed a new project from this one", a one-time copy. Templates and harness
+configs already established copy-on-clone as the house pattern.
+
+### 7.4 Referencing project-scoped harness configs by slug rather than deep-copying
+
+Rejected as structurally impossible: project-scoped configs are resolved by
+`scope_id == thisProject`, so a slug reference from a different project resolves
+to nothing. See §5.4.
+
+### 7.5 Cloning secret *names* with empty values
+
+Rejected. It produces a project that appears configured and fails at agent start,
+and there is no mechanism to notify the user which values need filling. An empty
+secret list is honest.
+
+---
+
+## 8. Phased Implementation Plan
+
+Phases are sequential. Each is independently reviewable, independently
+shippable, and leaves the tree green.
+
+### Phase 0 — Harness list consistency (no API dependency)
+
+- Add `web/src/shared/harness-utils.ts` with `KNOWN_HARNESS_NAMES`.
+- Consume it in `project-settings.ts` and `admin-server-config.ts`; delete both
+  local arrays.
+- `make web-typecheck && make web`.
+
+*Rationale for going first:* zero backend dependency, fixes an outright bug
+(`gemini` is not a harness name), and can land in parallel with Phase 1.
+
+**Size:** XS. **Files:** 3.
+
+### Phase 1 — Precedence normalisation (D-2)
+
+Kept separate from Phase 2 because it is the only change in this workstream that
+alters what existing agents receive, and it should be reviewable, releasable and
+revertable on its own.
+
+- `handlers_agents_core.go`: project annotation ahead of template for
+  `harness_config` (§7.2 site 1).
+- `server.go`: make the scheduler's template stamp conditional (§7.2 site 2).
+- Tests per §9.1, especially the both-set case.
+- Release-note entry.
+
+**Size:** S. **Blocked by:** nothing.
+
+### Phase 2 — Feature A backend
+
+- `projectSettingKeys` registry (§6.1) in `project_settings_handlers.go`.
+- `applyHubDefaults` (D-1) + its call sites in the agent-create path and
+  scheduler dispatch, immediately after `applyProjectDefaults`.
+- `pkg/hub/project_settings_resolved.go`: `ResolvedSettingField`,
+  `ResolvedProjectSettings`, `hubAgentDefaults()`, `handleProjectSettingsResolved`.
+- Route registration in `handleProjectRoutes`.
+- `pkg/hubclient`: `ResolvedProjectSettings` types +
+  `ProjectService.GetResolvedSettings`.
+- Tests per §9.1.
+- Release-note entry for the Postgres behaviour change.
+
+**Size:** M. **Blocked by:** Phase 1 (both touch the same resolution call sites;
+sequencing them avoids a merge conflict and keeps the two behaviour changes
+independently bisectable).
+
+### Phase 3 — Feature A frontend
+
+- `project-settings.ts` switches to `/settings/resolved`.
+- `hubHint()` helper; placeholder and select-label wiring.
+- Remove the now-redundant `/api/v1/settings/public` fetch.
+- Tests per §9.3.
+
+**Size:** S. **Blocked by:** Phase 2.
+
+### Phase 4 — Feature B backend
+
+- `pkg/hub/project_clone.go`: `CloneProjectRequest`,
+  `authorizeProjectClone`, `handleProjectClone`, the rollback stack, and the
+  per-resource copy helpers.
+- Route registration in `handleProjectRoutes`.
+- Tests per §9.2.
+
+**Size:** L — the largest phase by a wide margin. If the EM wants to split it:
+4a = project row + annotations + labels + groups + rollback skeleton;
+4b = env vars + injected skills + pre-start hook;
+4c = harness configs + templates (storage copy).
+Each sub-phase is independently testable and additive.
+
+**Blocked by:** Phase 2 (for `projectSettingKeys`). Independent of Phase 3, so
+4 and 3 can run in parallel across two implementers.
+
+### Phase 5 — Feature B SDK + CLI
+
+- `CloneProjectRequest` and `ProjectService.Clone` in `pkg/hubclient`.
+- `cmd/project_clone.go`.
+- `docs-site/src/content/docs/reference/cli.md` and `api.md`.
+
+**Size:** S. **Blocked by:** Phase 4.
+
+### Phase 6 — Feature B frontend
+
+- Clone button in `project-detail.ts` header actions.
+- Clone dialog with the copies/does-not-copy summary.
+- Navigate-on-success, inline error handling.
+
+**Size:** S. **Blocked by:** Phase 4.
+
+### Phase 7 — Follow-up issues (not implementation)
+
+File, do not fix:
+
+1. `deleteProject` is incomplete — it omits `ProjectPreStartHook`, schedules,
+   notification subscriptions, subscription templates, project sync state, user
+   access tokens, and project-scoped skills. Discovered while building the clone
+   inventory; a clone makes the leak more visible because there are now more
+   projects.
+2. Project-scoped skill-bank deep copy (§5.3 known limitation).
+3. Scheduled-event cloning with agent-reference rewriting, if requested.
+
+---
+
+## 9. Testing Plan
+
+### 9.1 Feature A — unit / handler tests
+
+New file `pkg/hub/project_settings_resolved_test.go`, build tag
+`//go:build !no_sqlite`, using `testServer(t)` /
+`createTestProjectForSettings(t, s)` / `doRequest(t, srv, ...)` and testify.
+
+| Case | Assertion |
+| --- | --- |
+| Project value set, hub value set | `source == "project"`, `value == projectValue`, `hubValue` still reported |
+| Project unset, hub set | `source == "hub"`, `value == hubValue`, `projectValue == nil` |
+| Both unset | `source == "unset"`, `value == nil` |
+| Field with no hub counterpart (`defaultModel`) | present in map, `hubValue == nil` |
+| `defaultResources` partially set | per-sub-field resolution is independent |
+| Non-admin, non-owner with read access | 200 |
+| No read access | 403 |
+| Unknown project | 404 |
+| Operational settings unavailable | 200 with all `hubValue == nil`; never 500 |
+| Telemetry field | agrees with `GET /api/v1/settings/public` |
+| `project` sub-object | byte-identical to `GET /settings` for the same project |
+
+Additionally in the agent-create tests, for `applyHubDefaults` (D-1):
+
+| Case | Assertion |
+| --- | --- |
+| Hub default set, project unset | agent's `AgentAppliedConfig` receives the hub value |
+| Hub default set, project set | project value wins |
+| Hub default set, explicit request value | request value wins |
+| No hub default | behaviour byte-identical to today (regression guard) |
+| Postgres-backed store | hub default is applied (the specific gap being closed) |
+
+And for the precedence normalisation (D-2) — these are the regression-sensitive
+ones, since they assert a *changed* behaviour:
+
+| Case | Assertion |
+| --- | --- |
+| Project annotation set, template specifies a different harness config | **project value wins** (was: template) |
+| Project annotation set, no template | project value |
+| No project annotation, template set | template value (unchanged) |
+| Explicit `req.HarnessConfig`, both others set | request value (unchanged) |
+| Same four cases via **scheduler dispatch** | identical outcomes to the create path |
+| `AppliedConfig` as handed to the dispatcher | carries the project's value (assert pre-dispatch — see the §7.2 caveat about `httpdispatcher.go` overwriting it with the broker's resolved answer) |
+
+### 9.2 Feature B — unit / handler tests
+
+New file `pkg/hub/project_clone_test.go`, same harness.
+
+*Happy path:*
+
+| Case | Assertion |
+| --- | --- |
+| Full-fidelity clone | every copied item in §5.3 present on the clone with correct values |
+| Unset annotations | absent on the clone — **not** zero, **not** hub-resolved (§6.4) |
+| New identity | clone has a distinct ID, distinct slug, `OwnerID`/`CreatedBy` == caller |
+| Visibility | clone is `private` even when the source is `public` |
+| Slug omitted, name collides | auto-serialised, 201 (never 409) |
+| Explicit colliding slug | 409 |
+| Groups | `project:<newslug>:agents` and `:members` exist; source's groups untouched |
+| Harness config slug preserved | cloned `default-harness-config` annotation resolves in the new project |
+| Storage | cloned harness-config/template files exist at the recomputed path |
+
+*Exclusions (negative assertions — these are the tests that matter most, because
+a leak here is a security or correctness bug):*
+
+| Case | Assertion |
+| --- | --- |
+| Source has secrets | clone has zero secrets |
+| Source has secret-backed env vars | those are absent from the clone; `Sensitive: true` ones are present with their values |
+| Source has agents | clone has zero agents |
+| Source has archived pre-start hooks | only the active one is copied, and it is active on the clone |
+| Source has integrations | clone has none |
+
+*Authorization:*
+
+| Case | Assertion |
+| --- | --- |
+| Caller lacks read on source | 403, and **no** project is created (verify the count is unchanged) |
+| Caller has read but not ownership | 201 — read is sufficient |
+| Unauthenticated | 401 |
+
+*Rollback:* using a fault-injecting store/storage wrapper, force a failure at
+each of steps 7–13 and assert that afterwards: no project row, no groups, no
+env vars, no skill injections, no pre-start hook, and no storage objects remain
+under the clone's prefix. This is the highest-value test in the suite and should
+be table-driven over the step index.
+
+*Concurrency:* two simultaneous clones of the same source with the same name
+both succeed with distinct slugs.
+
+### 9.3 Frontend tests
+
+- `harness-utils` is imported (not redeclared) by both components — a grep-style
+  assertion in the existing web test suite is sufficient.
+- `project-settings.ts` renders `Hub default: 200` as the placeholder when
+  `defaultMaxTurns` is unset with a hub value.
+- Renders `Use hub default (claude)` as the empty select option label.
+- Renders today's generic placeholder when `hubValue` is null.
+- Round-trip guard: loading `/settings/resolved` and immediately saving must PUT
+  a body identical to what loading `/settings` and saving would have produced —
+  i.e. **hub values must never be promoted into the PUT**. This is the test that
+  prevents accidental #381.
+- Clone dialog: pre-fills `<name> copy`, disables on submit, navigates on 201,
+  keeps the dialog open and shows the message on error.
+
+### 9.4 Integration
+
+- `make ci` (fmt-check, vet, lint, test) green at every phase boundary.
+- `make web-typecheck && make web` for Phases 0, 3, 6.
+- Manual smoke on a Postgres-backed hub for Phase 2: set `agent_defaults` in the
+  admin UI, create an agent in a project with no overrides, and confirm the agent
+  actually receives them. This is the scenario that was silently broken.
+- Manual smoke for Phase 1: a project with a `default-harness-config` annotation
+  and a template naming a different one now yields the project's.
+
+---
+
+## 10. Migration & Backward Compatibility
+
+**Schema:** none. Neither feature adds an ent entity, a column, or an index. No
+migration is required for either.
+
+**API compatibility:**
+
+- `GET /api/v1/projects/{id}/settings` — unchanged, byte for byte.
+- `PUT /api/v1/projects/{id}/settings` — unchanged. This is deliberate and is
+  guarded by the round-trip test in §9.3.
+- `GET /api/v1/settings/public` — retained. The web UI stops using it, but it is
+  a published endpoint that may have external consumers. (It is authenticated,
+  contrary to its name — see §1.1 — so "public" here means "not admin-gated".)
+- `GET /api/v1/projects/{id}/settings/resolved` — new; additive.
+- `POST /api/v1/projects/{id}/clone` — new; additive.
+- Older web clients against a newer hub: unaffected, since the endpoints they use
+  are unchanged. Newer web clients against an older hub: the resolved fetch 404s;
+  `project-settings.ts` must fall back to `/settings` and render today's generic
+  placeholders. **This fallback is required, not optional** — it is the only
+  backward-compatibility work in the whole design, and it belongs in Phase 3.
+
+**Behavioural compatibility:**
+
+There are exactly **two** behavioural changes in this design. Both are
+deliberate corrections, both are release-note items, and both are isolated into
+their own phase so they can be reverted independently.
+
+- **Phase 1 (D-2).** Projects that have *both* a
+  `scion.io/default-harness-config` annotation *and* a template naming a
+  different harness config will switch from the template's choice to the
+  project's. Projects with only one of the two — the overwhelming majority — are
+  unaffected. Guarded by the both-set test in §9.1.
+- **Phase 2 (D-1).** Postgres-mode deployments that already have `agent_defaults`
+  rows go from those rows being inert to being applied. Deployments that have
+  never set hub agent defaults see no change; guarded by the "no hub default →
+  identical to today" regression test in §9.1.
+
+Neither change can affect a **running** agent: both apply at agent-create time
+only, and an existing agent's `AppliedConfig` is already persisted.
+
+- Phase 0 changes which harness names appear in a *fallback* list used only when
+  the harness-config API returns nothing. In practice this list is rarely
+  reached; correcting `gemini` → `gemini-cli` fixes a latent bug.
+- Feature B is purely additive; no existing project is touched by a clone.
+
+**Data compatibility:** clones created by Phase 4 are ordinary projects. Nothing
+marks them as clones, so no code needs to learn about a new project kind, and
+they are indistinguishable to every existing code path. (A `clonedFrom`
+provenance annotation was considered and dropped — it would be the first
+non-settings `scion.io/*` annotation and would need a story for what happens
+when the source is deleted.)
+
+**Known pre-existing defect surfaced but not fixed:** `deleteProject` does not
+clean up `ProjectPreStartHook`, schedules, notification subscriptions,
+subscription templates, project sync state, user access tokens, or project-scoped
+skills. Clone does not make this worse per project, but it makes projects cheaper
+to create. Filed as a Phase 7 follow-up.
+
+---
+
+## 11. Open Questions
+
+### Resolved
+
+- **D-1 — Postgres agent-defaults gap (resolved 2026-07-28).** Hub-level
+  `agent_defaults` never reach agents in Postgres mode (§3.3). **Decision: fix
+  it.** Phase 2 applies hub defaults hub-side via `applyHubDefaults`. See §4.1.
+- **D-2 — `harness_config` precedence inconsistency (resolved 2026-07-28).**
+  **Decision: normalise so the project annotation overrides the template**, for
+  all fields. Phase 1. See §7.2.
+
+Both were confirmed by the product owner. No blocking questions remain; the two
+below are non-blocking scope calls the EM can decide during implementation.
+
+### 11.1 OQ-3: Should clone appear on the projects list page?
+
+Non-blocking; Phase 6 scope. The list page has no per-row action menu today, so
+adding one is a larger UI change than this feature warrants.
+Recommendation: detail page only in the first cut; revisit if users ask.
+
+### 11.2 OQ-4: Scheduled events
+
+Non-blocking. Excluded per §5.3 because their payloads reference agents by name
+and no agents are cloned. Recommendation: accept the exclusion and file the
+Phase 7 follow-up to clone them with reference rewriting if it is ever
+requested.
+
+---
+
+## 12. Acceptance Criteria
+
+**Feature A**
+
+1. A non-admin project owner can see, for every agent-defaults field they leave
+   blank, the hub value that will be used — without any admin permission.
+2. `GET /api/v1/projects/{id}/settings` and `PUT` are unchanged.
+3. Loading the settings page and pressing Save without editing anything produces
+   a PUT identical to today's — no hub value is ever promoted into a project
+   annotation.
+4. Both harness fallback lists are identical and canonical.
+5. A Postgres-mode hub with `agent_defaults` configured actually applies them to
+   new agents (D-1).
+6. A project whose `default-harness-config` annotation disagrees with its
+   template now yields the project's value, in both the create path and
+   scheduler dispatch (D-2).
+
+**Feature B**
+
+6. `POST /api/v1/projects/{id}/clone` returns 201 with a new project carrying
+   every item in §5.3's copy list and none in its exclusion list.
+7. A partial failure at any step leaves no trace: no project, no groups, no
+   storage objects.
+8. A caller with read-only access to the source can clone it and owns the result.
+9. `scion project clone <ref>` works and honours `--format json`.
+10. The web dialog states plainly what is and is not copied.
+11. Unset settings on the source remain unset on the clone.
+
+---
+
+## 13. Summary of Confirmed Decisions
+
+Recorded here so implementers do not relitigate them:
+
+1. Hub defaults are read from the existing opsettings system
+   (`AgentDefaultsSettings`), not from the `HubSettings` key-value table.
+2. Clone authorization = read on source + hub project-create; written to be
+   narrowable later.
+3. Chat integrations are hub-level and excluded from clone entirely.
+4. Null stays null: unset source settings are unset on the clone, never coerced
+   to zero or to the hub fallback.
+5. Both features are designed together, implemented in sequential phases.
+6. #381 (copy-on-create stamping of hub defaults) is deferred and not designed.
+7. Feature A's UX is a hint on an empty control — placeholder text or an option
+   label — not a tri-state control and not copy-on-create.
+8. **D-1:** the Postgres agent-defaults gap is fixed as part of this work — hub
+   defaults are applied hub-side so the UI hint is truthful on every topology.
+9. **D-2:** `harness_config` precedence is normalised so the project annotation
+   overrides the template, consistent with limits and resources.

--- a/.design/project-templates.md
+++ b/.design/project-templates.md
@@ -231,6 +231,26 @@ Routing: added to the `subPath` dispatch in `handleProjectRoutes`
 
 #### Response shape
 
+> **STALE — NOT AS BUILT.** The response shape, Go types and rationale in the
+> rest of §4.1 describe a `{value, source, projectValue, hubValue}` quad that was
+> specified, reviewed and then deliberately **not** implemented. They are kept
+> here as the record of a rejected design, not as a specification.
+>
+> As built: the response is `{project, settings}`, and each entry is
+> `{projectSet, projectValue, hubDefault}` where `hubDefault` is the tri-state
+> `"present" | "absent" | "unknown"`. There is **no** effective value, **no**
+> `source`, and **no** hub value — only whether a hub default exists.
+>
+> Why: computing an effective value here would be a second implementation of the
+> precedence order in a package that cannot observe changes to the first one, and
+> the copy fails silently because a stale answer is still a well-formed answer.
+> The `{projectValue, hubValue}` pairing is the same claim by another route — two
+> adjacent fields with nothing between them assert that nothing is between them,
+> which is false whenever the template or harness-config layer supplies the value.
+> See the header comment in `pkg/hub/project_settings_resolved.go` and
+> `docs-site/src/content/docs/reference/project-settings-resolved.md`.
+> `TestResolvedSettingsResponseShape_NoEffectiveValue` enforces it.
+
 ```jsonc
 {
   "project": { /* exactly the existing ProjectSettings object, unchanged */ },
@@ -404,6 +424,13 @@ Feature A is a pure read-side projection over data that already exists in
 in-memory `AgentAppliedConfig`; it persists nothing new.
 
 ### 4.3 UI specification
+
+> **STALE — depends on the rejected §4.1 shape.** Every rule below reads
+> `fields.<name>.hubValue`; the endpoint as built has no `fields` map and returns
+> no hub value. The rules that render a hub value inline (`Hub default: ${hubValue}`,
+> `Use hub default (${hubValue})`) cannot be implemented against the shipped
+> response and are not merely renamed — the data is deliberately absent. A UI
+> revision is out of scope for this phase; see §4.1's STALE note for why.
 
 File: `web/src/components/pages/project-settings.ts`.
 

--- a/.design/project-templates.md
+++ b/.design/project-templates.md
@@ -449,20 +449,30 @@ seen.
 
 ### 4.4 Harness fallback list consistency cleanup
 
-Two components hardcode a fallback list of harness names for when the
+Three components hardcode a fallback list of harness names for when the
 harness-config API returns nothing, and they disagree:
 
 | Component | Hardcoded list |
 | --- | --- |
 | `project-settings.ts` | `gemini`, `claude`, `opencode`, `codex` |
 | `admin-server-config.ts` | `gemini-cli`, `claude`, `codex`, `copilot`, `opencode` |
+| `agent-create.ts` | `gemini-cli`, `claude`, `codex`, `copilot`, `opencode` |
+
+Each site duplicates the list twice over: once as a `fallbackNames` array
+(`project-settings.ts` has only the markup form) and once as a hardcoded block
+of `<sl-option>` elements.
 
 The canonical set, from `harnesses/*/config.yaml`, is: `claude`, `codex`,
 `copilot`, `gemini-cli`, `opencode`, `antigravity`, `hermes`.
 
 `project-settings.ts` is outright wrong — `gemini` is not a harness name; the
-correct identifier is `gemini-cli`. Both lists are missing `antigravity` and
-`hermes`, and `project-settings.ts` is additionally missing `copilot`.
+correct identifier is `gemini-cli`. All three lists are missing `antigravity`
+and `hermes`, and `project-settings.ts` is additionally missing `copilot`.
+
+In `agent-create.ts` the list drives logic rather than just display:
+`setHarnessFromValue()` treats any value absent from it as `__other__`, so with
+an empty harness-config response a project defaulting to `antigravity` or
+`hermes` renders as "Other..." and is silently demoted to a custom string.
 
 **Fix.** New module `web/src/shared/harness-utils.ts`, following the existing
 `web/src/shared/` convention (`model-utils.ts`, `types.ts`, `lineage.ts`):
@@ -480,8 +490,17 @@ export const KNOWN_HARNESS_NAMES = [
 ] as const;
 ```
 
-Both components import it and delete their local arrays. A comment on the
-constant points at `harnesses/` as the source of truth.
+All three components import it and delete both their local arrays and their
+hardcoded `<sl-option>` blocks, rendering the fallback options by mapping over
+`KNOWN_HARNESS_NAMES` instead. A comment on the constant points at `harnesses/`
+as the source of truth.
+
+The module also exports a `harnessDisplayName(name)` helper. The components
+render human-readable labels ("Gemini CLI", "OpenCode"), and
+`harnesses/<name>/config.yaml` has no display-name field to derive them from, so
+the labels cannot be dropped without a visual regression. The helper is a
+display-only map with a passthrough fallback for unknown identifiers;
+`KNOWN_HARNESS_NAMES` remains the source of truth for which harnesses exist.
 
 This is a small, independently reviewable, zero-risk change with no API
 dependency — it is sequenced first (Phase 0) so it can land in parallel with the
@@ -1007,15 +1026,19 @@ shippable, and leaves the tree green.
 
 ### Phase 0 — Harness list consistency (no API dependency)
 
-- Add `web/src/shared/harness-utils.ts` with `KNOWN_HARNESS_NAMES`.
-- Consume it in `project-settings.ts` and `admin-server-config.ts`; delete both
-  local arrays.
-- `make web-typecheck && make web`.
+- Add `web/src/shared/harness-utils.ts` with `KNOWN_HARNESS_NAMES` and
+  `harnessDisplayName()`.
+- Consume it in `project-settings.ts`, `admin-server-config.ts` and
+  `agent-create.ts`; delete the local arrays and the hardcoded `<sl-option>`
+  blocks in all three.
+- `make web-typecheck && make web`, plus a test asserting all three components
+  import the shared constant rather than redeclaring a list.
 
-*Rationale for going first:* zero backend dependency, fixes an outright bug
-(`gemini` is not a harness name), and can land in parallel with Phase 1.
+*Rationale for going first:* zero backend dependency, fixes two outright bugs
+(`gemini` is not a harness name; `agent-create.ts` demotes `antigravity` and
+`hermes` to "Other..."), and can land in parallel with Phase 1.
 
-**Size:** XS. **Files:** 3.
+**Size:** XS. **Files:** 5 (3 components, 1 new module, 1 new test).
 
 ### Phase 1 — Precedence normalisation (D-2)
 
@@ -1196,8 +1219,11 @@ both succeed with distinct slugs.
 
 ### 9.3 Frontend tests
 
-- `harness-utils` is imported (not redeclared) by both components — a grep-style
-  assertion in the existing web test suite is sufficient.
+- `harness-utils` is imported (not redeclared) by all three components — a
+  grep-style assertion in the existing web test suite is sufficient. It should
+  also catch hardcoded `<sl-option>` harness blocks, not just array literals.
+- `KNOWN_HARNESS_NAMES` matches the directory names under `harnesses/`, so the
+  list cannot silently drift from the source of truth.
 - `project-settings.ts` renders `Hub default: 200` as the placeholder when
   `defaultMaxTurns` is unset with a hub value.
 - Renders `Use hub default (claude)` as the empty select option label.
@@ -1263,7 +1289,9 @@ only, and an existing agent's `AppliedConfig` is already persisted.
 
 - Phase 0 changes which harness names appear in a *fallback* list used only when
   the harness-config API returns nothing. In practice this list is rarely
-  reached; correcting `gemini` → `gemini-cli` fixes a latent bug.
+  reached; correcting `gemini` → `gemini-cli` fixes a latent bug, and adding
+  `antigravity`/`hermes` stops `agent-create.ts` demoting those two to
+  "Other..." when the fallback path is taken.
 - Feature B is purely additive; no existing project is touched by a clone.
 
 **Data compatibility:** clones created by Phase 4 are ordinary projects. Nothing
@@ -1320,7 +1348,8 @@ requested.
 3. Loading the settings page and pressing Save without editing anything produces
    a PUT identical to today's — no hub value is ever promoted into a project
    annotation.
-4. Both harness fallback lists are identical and canonical.
+4. All three harness fallback lists are identical and canonical, because all
+   three are the same list.
 5. A Postgres-mode hub with `agent_defaults` configured actually applies them to
    new agents (D-1).
 6. A project whose `default-harness-config` annotation disagrees with its

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
         working-directory: ./web
         run: npm run typecheck
 
+      - name: Run Web Tests
+        working-directory: ./web
+        run: npm test
+
       - name: Format Check
         run: |
           UNFORMATTED=$(gofmt -l .)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GOLANGCI_LINT := $(shell command -v golangci-lint 2>/dev/null || echo $(shell go
 
 .DEFAULT_GOAL := help
 
-.PHONY: all build install test test-fast vet lint compat-literals golangci-lint web web-typecheck fmt fmt-check ci ci-full clean help container-sciontool container-scion container-binaries proto proto-check
+.PHONY: all build install test test-fast vet lint compat-literals golangci-lint web web-typecheck web-test fmt fmt-check ci ci-full clean help container-sciontool container-scion container-binaries proto proto-check
 
 ## all: Build the web frontend and compile the Go binary (run 'make install' separately to install)
 all: web build
@@ -121,6 +121,12 @@ web-typecheck:
 	@cd web && npm run typecheck
 	@echo "Type check passed."
 
+## web-test: Run the web frontend unit tests (vitest)
+web-test:
+	@echo "Running web frontend tests..."
+	@cd web && npm test
+	@echo "Web tests passed."
+
 ## fmt: Auto-format Go source files
 fmt:
 	@echo "Formatting Go source files..."
@@ -144,7 +150,7 @@ ci: fmt-check lint compat-literals test-fast build
 	@echo "CI passed."
 
 ## ci-full: Run the full CI pipeline locally (mirrors GitHub Actions, includes web + golangci-lint)
-ci-full: fmt-check web web-typecheck lint compat-literals golangci-lint test-fast build
+ci-full: fmt-check web web-typecheck web-test lint compat-literals golangci-lint test-fast build
 	@echo ""
 	@echo "CI (full) passed."
 

--- a/cmd/project_clone.go
+++ b/cmd/project_clone.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cloneProjectName string
+	cloneProjectSlug string
+)
+
+var projectCloneCmd = &cobra.Command{
+	Use:   "clone <source-slug-or-id>",
+	Short: "Clone a project's configuration into a new project",
+	Long: `Clone a project by creating a new project pre-populated with the source
+project's configuration.
+
+The <source-slug-or-id> argument identifies the project to clone (name, slug,
+or UUID).
+
+Copies: settings, labels, environment variables, injected skills, pre-start
+hook, project harness configs and templates.
+
+Does not copy: secrets, agents, history, or chat integrations.
+
+The new project gets a fresh ID, the caller as owner, and private visibility.
+If --name is omitted, defaults to "<source-name> copy".
+
+Requires Hub connectivity.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sourceRef := args[0]
+
+		resolvedPath, _, err := config.ResolveProjectPath(projectPath)
+		if err != nil {
+			return fmt.Errorf("failed to resolve project path: %w", err)
+		}
+
+		settings, err := config.LoadSettings(resolvedPath)
+		if err != nil {
+			return fmt.Errorf("failed to load settings: %w", err)
+		}
+
+		client, err := getHubClient(settings)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+		defer cancel()
+
+		source, err := resolveProjectByNameOrID(ctx, client, sourceRef)
+		if err != nil {
+			return fmt.Errorf("failed to find project: %w", err)
+		}
+
+		name := cloneProjectName
+		if name == "" {
+			name = source.Name + " copy"
+		}
+
+		cloned, err := client.Projects().Clone(ctx, source.ID, hubclient.CloneProjectRequest{
+			Name: name,
+			Slug: cloneProjectSlug,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to clone project: %w", err)
+		}
+
+		if isJSONOutput() {
+			return outputJSON(ActionResult{
+				Status:  "success",
+				Command: "project clone",
+				Message: fmt.Sprintf("Cloned project %q → %q", source.Name, cloned.Name),
+				Details: map[string]interface{}{
+					"id":        cloned.ID,
+					"name":      cloned.Name,
+					"slug":      cloned.Slug,
+					"source_id": source.ID,
+				},
+			})
+		}
+
+		fmt.Printf("Cloned project %q → %q (slug: %s)\n", source.Name, cloned.Name, cloned.Slug)
+		return nil
+	},
+}
+
+func init() {
+	projectCloneCmd.Flags().StringVar(&cloneProjectName, "name", "", "Name for the cloned project (default: \"<source> copy\")")
+	projectCloneCmd.Flags().StringVar(&cloneProjectSlug, "slug", "", "Explicit slug for the cloned project (default: auto-generated from name)")
+	projectCmd.AddCommand(projectCloneCmd)
+}

--- a/docs-site/src/content/docs/reference/project-settings-resolved.md
+++ b/docs-site/src/content/docs/reference/project-settings-resolved.md
@@ -1,0 +1,136 @@
+---
+title: Resolved Project Settings
+description: The GET /settings/resolved endpoint reports project settings alongside whether a hub default exists — and deliberately does not compute an effective value.
+---
+
+```
+GET /api/v1/projects/{projectId}/settings/resolved
+```
+
+Returns every project setting together with an indication of whether the hub
+has a default for it.
+
+Authorization is `ActionRead` on the project — the same as
+`GET /api/v1/projects/{projectId}/settings`. It is deliberately not admin-gated,
+because the point is to let non-admin project owners see that hub defaults
+exist. Only the presence of `agent_defaults` entries is exposed, never the
+server configuration itself. The endpoint is read-only; there is no `PUT`.
+
+## This endpoint does not resolve anything
+
+The name says `resolved`. The response contains no resolved value. This is the
+single most important thing to know about the endpoint, and it is not an
+oversight — the effective-value field was specified, reviewed, and deliberately
+removed.
+
+Scion decides a setting's actual value by walking a precedence ladder with more
+rungs than this endpoint can see: an explicit request value, the project
+annotation, a template, a harness config, and the hub operational default.
+That ladder is owned by the code that applies it.
+
+If this endpoint computed an effective value, it would be a **second
+implementation of that ordering**, living in a package that cannot observe
+changes to the first one. Two implementations of one ordering do not stay equal.
+Worse, the copy fails silently: a stale answer is still a well-formed answer, so
+nothing breaks visibly when they drift apart. No test can fail when this
+endpoint's idea of the ladder and the real ladder diverge, which is exactly why
+the value is not computed here at all.
+
+This applies to the hub's value too, not only to a field literally named
+`value` — and that is not a theoretical concern. Scion's own agent-defaults code
+carries provenance through the request path explicitly, precisely so that it
+never has to compare a value back against the hub default: doing so misreports
+the case where a user, a project annotation or a template happens to name the
+same value the hub defaults to. A response containing `projectValue` and
+`hubValue` side by side would hand every client the operands of that same
+misreport, so "the client can just compare them" is not a workaround — the
+comparison *is* the bug.
+
+The shape also asserts precedence by adjacency: two fields with nothing between
+them imply there is nothing between them. A client reading
+`projectValue: null, hubValue: 200` concludes "I will get 200", and that is
+wrong the moment a template supplies a value instead. So the response reports
+whether a hub default **exists**, and never what it is.
+
+**If you need the effective value, resolve it yourself**, against whatever
+ladder exists at the time you ask. The endpoint answers "is there a hub default
+here?" — it does not answer "what will I get?".
+
+## Response
+
+```jsonc
+{
+  // The existing ProjectSettings object, unchanged.
+  "project": { "defaultMaxTurns": 120 },
+
+  // Keyed by annotation key — the same keys the settings registry uses.
+  "settings": {
+    "scion.io/default-max-turns": {
+      "projectSet": true,
+      "projectValue": "120",
+      "hubDefault": "present"
+    },
+    "scion.io/default-model": {
+      "projectSet": false,
+      "projectValue": null,
+      "hubDefault": "absent"
+    },
+    "scion.io/default-template": {
+      "projectSet": false,
+      "projectValue": null,
+      "hubDefault": "unknown"
+    }
+  }
+}
+```
+
+Every registered project setting appears in `settings`, always. A key is never
+omitted; if nothing is known about it, that is stated rather than implied by
+absence. A drift guard fails the build if a setting is added to the registry
+without being wired up here.
+
+### Per-setting fields
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `projectSet` | bool | Whether the project has an annotation for this setting. |
+| `projectValue` | string \| null | The annotation's raw value, or `null` when `projectSet` is false. Always a string — annotations are strings. |
+| `hubDefault` | string | Whether a hub-level default exists. See below. |
+
+### `hubDefault` is tri-state
+
+`hubDefault` is `"present"`, `"absent"`, or `"unknown"` — not a boolean.
+
+| Value | Meaning |
+| --- | --- |
+| `present` | The hub has a default for this setting. |
+| `absent` | The hub has no default for this setting, and we are sure. |
+| `unknown` | We could not determine it. **Not** the same as `absent`. |
+
+The third state exists because a boolean has no room for "I did not look here",
+and reporting a confident `false` for a question that was never asked is simply
+a false statement. Two distinct situations produce `unknown`:
+
+- **File-mode configuration.** When the hub runs from a config file rather than
+  a settings database, the agent-defaults section is never loaded, even if the
+  operator's file contains it. The hub holds a zero value that reflects the load
+  path, not the operator's intent. Reporting `absent` here would claim the
+  operator configured nothing, which the hub is in no position to know. This is
+  a gap in file-mode loading rather than a deliberate limitation; if it is
+  closed, these settings will begin reporting `present`/`absent` normally, with
+  no change to the endpoint.
+
+- **A value that cannot be distinguished from unset.** Some hub defaults are
+  stored in a form where an explicitly-configured empty value and an unset value
+  are byte-identical once written — the write path drops empty strings. For
+  those fields, absence is genuinely ambiguous and is reported as `unknown`.
+  Fields whose schema forbids the zero value (for example
+  `default_max_turns`, which has a minimum of 1) are unambiguous and do report
+  `absent`.
+
+Clients should treat `unknown` as "do not display a claim about the hub", not as
+`absent`. Rendering "no hub default" on `unknown` reintroduces exactly the false
+statement the third state exists to prevent.
+
+Settings with no hub-level counterpart at all — the hub simply has no such field
+— report `absent`, which is a measured structural fact rather than a guess.

--- a/docs-site/src/content/docs/reference/project-settings-resolved.md
+++ b/docs-site/src/content/docs/reference/project-settings-resolved.md
@@ -115,10 +115,10 @@ a false statement. Two distinct situations produce `unknown`:
   a settings database, the agent-defaults section is never loaded, even if the
   operator's file contains it. The hub holds a zero value that reflects the load
   path, not the operator's intent. Reporting `absent` here would claim the
-  operator configured nothing, which the hub is in no position to know. This is
-  a gap in file-mode loading rather than a deliberate limitation; if it is
-  closed, these settings will begin reporting `present`/`absent` normally, with
-  no change to the endpoint.
+  operator configured nothing, which the hub is in no position to know. This
+  emptiness is deliberate — it keeps file-mode behaviour unchanged for existing
+  single-node installs — so in file mode `unknown` is the permanent and correct
+  answer for these settings, not a temporary gap awaiting a fix.
 
 - **A value that cannot be distinguished from unset.** Some hub defaults are
   stored in a form where an explicitly-configured empty value and an unset value

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -1462,6 +1462,14 @@ func (s *Server) handleProjectRoutes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check for nested /settings/resolved path. Must be tested separately from
+	// "settings" above rather than as a prefix: this is a distinct read-only
+	// sub-resource with no PUT, not a mode of the settings endpoint.
+	if subPath == "settings/resolved" {
+		s.handleProjectSettingsResolved(w, r, projectID)
+		return
+	}
+
 	// Check for nested /discover-templates path
 	if subPath == "discover-templates" {
 		s.handleProjectDiscoverTemplates(w, r, projectID)

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -1470,6 +1470,12 @@ func (s *Server) handleProjectRoutes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check for nested /clone path
+	if subPath == "clone" {
+		s.handleProjectClone(w, r, projectID)
+		return
+	}
+
 	// Check for nested /discover-templates path
 	if subPath == "discover-templates" {
 		s.handleProjectDiscoverTemplates(w, r, projectID)

--- a/pkg/hub/project_clone.go
+++ b/pkg/hub/project_clone.go
@@ -142,8 +142,10 @@ func (s *Server) handleProjectClone(w http.ResponseWriter, r *http.Request, proj
 		}
 	}
 
-	// Copy labels, excluding scion.io/* prefix (system markers) and
-	// workspace-mode (re-derived below). scion.dev/* labels are copied.
+	// Skip system labels (scion.io/* prefix). Project settings annotations
+	// live in project.Annotations, not Labels, and are copied separately
+	// via projectSettingKeys above. scion.dev/* labels are copied.
+	// workspace-mode is re-derived below, not copied raw.
 	if src.Labels != nil {
 		clone.Labels = make(map[string]string)
 		for k, v := range src.Labels {

--- a/pkg/hub/project_clone.go
+++ b/pkg/hub/project_clone.go
@@ -1,0 +1,624 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/storage"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// CloneProjectRequest is the request body for POST /api/v1/projects/{id}/clone.
+type CloneProjectRequest struct {
+	Name string `json:"name"` // required
+	Slug string `json:"slug"` // optional explicit slug override
+}
+
+// handleProjectClone clones a project's configuration into a new project.
+//
+// POST /api/v1/projects/{id}/clone
+//
+// The clone copies settings, labels, env vars, injected skills, pre-start hook,
+// and project-scoped harness configs and templates. It does NOT copy secrets,
+// agents, history, or chat integrations. See .design/project-templates.md §5.3.
+//
+// On failure at any step, the defer-driven rollback stack ensures no orphaned
+// resources remain. Every rollback closure uses context.WithoutCancel so that
+// a client disconnect mid-clone does not abort cleanup.
+func (s *Server) handleProjectClone(w http.ResponseWriter, r *http.Request, projectID string) {
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	// ── Step 1: Load source project ──────────────────────────────────────
+
+	src, err := s.store.GetProject(ctx, projectID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Project")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// ── Step 1b: Authorize ───────────────────────────────────────────────
+
+	if err := s.authorizeProjectClone(ctx, w, src); err != nil {
+		return // authorizeProjectClone writes the HTTP response
+	}
+
+	// ── Step 1c: Parse and validate request ──────────────────────────────
+
+	var req CloneProjectRequest
+	if err := readJSON(r, &req); err != nil {
+		BadRequest(w, "Invalid request body: "+err.Error())
+		return
+	}
+
+	if strings.TrimSpace(req.Name) == "" {
+		ValidationError(w, "name is required", nil)
+		return
+	}
+
+	// ── Step 2: Resolve name/slug ────────────────────────────────────────
+
+	baseSlug := req.Slug
+	explicitSlug := baseSlug != ""
+	if !explicitSlug {
+		baseSlug = api.Slugify(req.Name)
+	}
+
+	slug, err := s.store.NextAvailableSlug(ctx, baseSlug)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Explicit slug that collides → 409 (never auto-disambiguate).
+	if explicitSlug && slug != baseSlug {
+		Conflict(w, "A project with slug \""+baseSlug+"\" already exists")
+		return
+	}
+
+	displayName := req.Name
+	if slug != baseSlug {
+		displayName = api.DisplayNameWithSerial(req.Name, slug, baseSlug)
+	}
+
+	// ── Step 3: Build clone Project struct ────────────────────────────────
+
+	callerID := ""
+	if user := GetUserIdentityFromContext(ctx); user != nil {
+		callerID = user.ID()
+	}
+
+	clone := &store.Project{
+		ID:                     api.NewUUID(),
+		Name:                   displayName,
+		Slug:                   slug,
+		GitRemote:              src.GitRemote,
+		DefaultRuntimeBrokerID: src.DefaultRuntimeBrokerID,
+		Visibility:             store.VisibilityPrivate,
+		CreatedBy:              callerID,
+		OwnerID:                callerID,
+		SharedDirs:             src.SharedDirs,
+		GitIdentity:            src.GitIdentity,
+	}
+
+	// Copy annotations: only keys in projectSettingKeys, preserving null semantics
+	// (§6.4: unset stays unset).
+	if src.Annotations != nil {
+		clone.Annotations = make(map[string]string)
+		for _, key := range projectSettingKeys {
+			if v, ok := src.Annotations[key]; ok {
+				clone.Annotations[key] = v
+			}
+		}
+		if len(clone.Annotations) == 0 {
+			clone.Annotations = nil
+		}
+	}
+
+	// Copy labels, excluding scion.io/* prefix (system markers) and
+	// workspace-mode (re-derived below). scion.dev/* labels are copied.
+	if src.Labels != nil {
+		clone.Labels = make(map[string]string)
+		for k, v := range src.Labels {
+			if strings.HasPrefix(k, "scion.io/") {
+				continue // system markers — not propagated
+			}
+			if k == store.LabelWorkspaceMode {
+				continue // re-derived, not copied raw
+			}
+			clone.Labels[k] = v
+		}
+		if len(clone.Labels) == 0 {
+			clone.Labels = nil
+		}
+	}
+
+	// Re-derive workspace mode from the source (like createProject does).
+	if src.GitRemote != "" {
+		srcMode := ""
+		if src.Labels != nil {
+			srcMode = src.Labels[store.LabelWorkspaceMode]
+		}
+		switch srcMode {
+		case store.WorkspaceModeShared, store.WorkspaceModeWorktreePerAgent:
+			if clone.Labels == nil {
+				clone.Labels = make(map[string]string)
+			}
+			clone.Labels[store.LabelWorkspaceMode] = srcMode
+		}
+	}
+
+	// ── Rollback stack ───────────────────────────────────────────────────
+
+	var rollback []func()
+	committed := false
+	defer func() {
+		if !committed {
+			for i := len(rollback) - 1; i >= 0; i-- {
+				rollback[i]()
+			}
+		}
+	}()
+
+	// ── Step 4: Create project row ───────────────────────────────────────
+
+	if err := s.store.CreateProject(ctx, clone); err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+	rollback = append(rollback, func() {
+		rbCtx := context.WithoutCancel(ctx)
+		if delErr := s.store.DeleteProject(rbCtx, clone.ID); delErr != nil {
+			slog.Warn("project clone rollback: failed to delete project",
+				"clone_id", clone.ID, "error", delErr)
+		}
+	})
+
+	// ── Step 5: Create groups ────────────────────────────────────────────
+
+	s.createProjectGroup(ctx, clone)
+
+	// ── Step 6: Create members group and policy ──────────────────────────
+
+	s.createProjectMembersGroupAndPolicy(ctx, clone, callerID)
+
+	// ── Step 7: Deep-copy project-scoped harness configs ─────────────────
+
+	if err := s.cloneProjectHarnessConfigs(ctx, src.ID, clone, &rollback); err != nil {
+		slog.Error("project clone: harness config copy failed",
+			"source_id", src.ID, "clone_id", clone.ID, "error", err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
+			"Failed to copy harness configs: "+err.Error(), nil)
+		return
+	}
+
+	// ── Step 8: Deep-copy project-scoped templates ───────────────────────
+
+	if err := s.cloneProjectTemplates(ctx, src.ID, clone, &rollback); err != nil {
+		slog.Error("project clone: template copy failed",
+			"source_id", src.ID, "clone_id", clone.ID, "error", err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
+			"Failed to copy templates: "+err.Error(), nil)
+		return
+	}
+
+	// ── Step 9: Copy non-secret env vars ─────────────────────────────────
+
+	if err := s.cloneProjectEnvVars(ctx, src.ID, clone.ID, callerID, &rollback); err != nil {
+		slog.Error("project clone: env var copy failed",
+			"source_id", src.ID, "clone_id", clone.ID, "error", err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
+			"Failed to copy environment variables: "+err.Error(), nil)
+		return
+	}
+
+	// ── Step 10: Copy injected skills ────────────────────────────────────
+
+	if err := s.cloneProjectSkillInjections(ctx, src.ID, clone.ID, callerID, &rollback); err != nil {
+		slog.Error("project clone: skill injection copy failed",
+			"source_id", src.ID, "clone_id", clone.ID, "error", err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
+			"Failed to copy injected skills: "+err.Error(), nil)
+		return
+	}
+
+	// ── Step 11: Copy active pre-start hook ──────────────────────────────
+
+	if err := s.cloneProjectPreStartHook(ctx, src.ID, clone.ID, callerID); err != nil {
+		slog.Error("project clone: pre-start hook copy failed",
+			"source_id", src.ID, "clone_id", clone.ID, "error", err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
+			"Failed to copy pre-start hook: "+err.Error(), nil)
+		return
+	}
+	// No explicit rollback for step 11 — hook is cleaned up transitively by
+	// step 4's DeleteProject. See design doc §5.5.
+
+	// ── Step 12: Auto-associate GitHub installation (best-effort) ────────
+
+	if clone.GitRemote != "" && clone.GitHubInstallationID == nil {
+		s.autoAssociateGitHubInstallation(ctx, clone)
+	}
+
+	// ── Step 13: Workspace init ──────────────────────────────────────────
+
+	if clone.IsSharedWorkspace() {
+		if err := s.cloneSharedWorkspaceProject(ctx, clone); err != nil {
+			slog.Error("project clone: shared workspace clone failed",
+				"clone_id", clone.ID, "error", err)
+			writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
+				"Failed to initialize workspace: "+err.Error(), nil)
+			return
+		}
+	} else if clone.GitRemote == "" {
+		if err := s.initHubManagedProject(clone); err != nil {
+			slog.Warn("project clone: failed to initialize hub-managed workspace",
+				"clone_id", clone.ID, "error", err)
+		}
+	}
+
+	// ── Step 14: Auto-link providers (best-effort) ───────────────────────
+
+	s.autoLinkProviders(ctx, clone)
+
+	// ── Step 15: Publish event (best-effort) ─────────────────────────────
+
+	s.events.PublishProjectCreated(ctx, clone)
+
+	// ── Commit ───────────────────────────────────────────────────────────
+
+	committed = true
+
+	writeJSON(w, http.StatusCreated, clone)
+}
+
+// authorizeProjectClone checks that the caller can read the source project and
+// create projects at hub scope. It writes the HTTP error response on failure and
+// returns a non-nil error; on success it returns nil.
+func (s *Server) authorizeProjectClone(ctx context.Context, w http.ResponseWriter, src *store.Project) error {
+	identity := GetIdentityFromContext(ctx)
+	if identity == nil {
+		Unauthorized(w)
+		return errors.New("unauthenticated")
+	}
+
+	userIdent, ok := identity.(UserIdentity)
+	if !ok {
+		Forbidden(w)
+		return errors.New("non-user identity")
+	}
+
+	// 1. Caller must be able to read the source project.
+	decision := s.authzService.CheckAccess(ctx, userIdent, Resource{
+		Type:    "project",
+		ID:      src.ID,
+		OwnerID: src.OwnerID,
+	}, ActionRead)
+	if !decision.Allowed {
+		writeError(w, http.StatusForbidden, ErrCodeForbidden,
+			"Insufficient permission to read source project", nil)
+		return errors.New("forbidden: cannot read source")
+	}
+
+	// 2. Caller must be able to create projects at hub scope.
+	caps := s.authzService.ComputeScopeCapabilities(ctx, userIdent, "", "", "project")
+	if !slices.Contains(caps.Actions, string(ActionCreate)) {
+		writeError(w, http.StatusForbidden, ErrCodeForbidden,
+			"Insufficient permission to create projects", nil)
+		return errors.New("forbidden: cannot create projects")
+	}
+
+	return nil
+}
+
+// cloneProjectHarnessConfigs deep-copies all project-scoped harness configs from
+// the source project to the clone. Each config gets a fresh UUID but keeps the
+// same slug — the slug is scoped to the project, and the clone's
+// default-harness-config annotation refers to it by slug.
+func (s *Server) cloneProjectHarnessConfigs(ctx context.Context, srcProjectID string, clone *store.Project, rollback *[]func()) error {
+	result, err := s.store.ListHarnessConfigs(ctx, store.HarnessConfigFilter{
+		Scope:   store.HarnessConfigScopeProject,
+		ScopeID: srcProjectID,
+	}, store.ListOptions{Limit: 500})
+	if err != nil {
+		return err
+	}
+
+	if len(result.Items) == 0 {
+		return nil
+	}
+
+	stor := s.GetStorage()
+
+	for _, srcHC := range result.Items {
+		newHC := &store.HarnessConfig{
+			ID:          api.NewUUID(),
+			Name:        srcHC.Name,
+			Slug:        srcHC.Slug, // SAME slug — critical for annotation references
+			DisplayName: srcHC.DisplayName,
+			Description: srcHC.Description,
+			Harness:     srcHC.Harness,
+			Config:      srcHC.Config,
+			Scope:       store.HarnessConfigScopeProject,
+			ScopeID:     clone.ID,
+			Visibility:  srcHC.Visibility,
+			Status:      srcHC.Status,
+			Files:       srcHC.Files,
+			ContentHash: srcHC.ContentHash,
+		}
+
+		storagePath := storage.HarnessConfigStoragePath(s.HubID(), newHC.Scope, newHC.ScopeID, newHC.Slug)
+		newHC.StoragePath = storagePath
+
+		if stor != nil {
+			newHC.StorageBucket = stor.Bucket()
+			newHC.StorageURI = storage.HarnessConfigStorageURI(s.HubID(), stor.Bucket(), newHC.Scope, newHC.ScopeID, newHC.Slug)
+		}
+
+		// Copy storage files
+		if stor != nil && len(srcHC.Files) > 0 && srcHC.StoragePath != "" {
+			for _, file := range srcHC.Files {
+				srcPath := srcHC.StoragePath + "/" + file.Path
+				dstPath := storagePath + "/" + file.Path
+				if _, err := stor.Copy(ctx, srcPath, dstPath); err != nil {
+					_ = stor.DeletePrefix(ctx, storagePath)
+					return err
+				}
+			}
+		}
+
+		if err := s.store.CreateHarnessConfig(ctx, newHC); err != nil {
+			if stor != nil {
+				_ = stor.DeletePrefix(ctx, storagePath)
+			}
+			return err
+		}
+	}
+
+	// Add rollback for all harness configs at once
+	*rollback = append(*rollback, func() {
+		rbCtx := context.WithoutCancel(ctx)
+		stor := s.GetStorage()
+		if stor != nil {
+			prefix := storage.HarnessConfigStoragePath(s.HubID(), store.HarnessConfigScopeProject, clone.ID, "")
+			_ = stor.DeletePrefix(rbCtx, prefix)
+		}
+		if _, err := s.store.DeleteHarnessConfigsByScope(rbCtx, store.HarnessConfigScopeProject, clone.ID); err != nil {
+			slog.Warn("project clone rollback: failed to delete harness configs",
+				"clone_id", clone.ID, "error", err)
+		}
+	})
+
+	return nil
+}
+
+// cloneProjectTemplates deep-copies all project-scoped templates from the source
+// project to the clone. Identical pattern to cloneProjectHarnessConfigs.
+func (s *Server) cloneProjectTemplates(ctx context.Context, srcProjectID string, clone *store.Project, rollback *[]func()) error {
+	result, err := s.store.ListTemplates(ctx, store.TemplateFilter{
+		Scope:   store.TemplateScopeProject,
+		ScopeID: srcProjectID,
+	}, store.ListOptions{Limit: 500})
+	if err != nil {
+		return err
+	}
+
+	if len(result.Items) == 0 {
+		return nil
+	}
+
+	stor := s.GetStorage()
+
+	for _, srcTmpl := range result.Items {
+		newTmpl := &store.Template{
+			ID:          api.NewUUID(),
+			Name:        srcTmpl.Name,
+			Slug:        srcTmpl.Slug, // SAME slug — critical for annotation references
+			DisplayName: srcTmpl.DisplayName,
+			Description: srcTmpl.Description,
+			Harness:     srcTmpl.Harness,
+			Config:      srcTmpl.Config,
+			Scope:       store.TemplateScopeProject,
+			ScopeID:     clone.ID,
+			Visibility:  srcTmpl.Visibility,
+			Status:      srcTmpl.Status,
+			Files:       srcTmpl.Files,
+			ContentHash: srcTmpl.ContentHash,
+			BaseTemplate: srcTmpl.BaseTemplate,
+		}
+
+		storagePath := storage.TemplateStoragePath(s.HubID(), newTmpl.Scope, newTmpl.ScopeID, newTmpl.Slug)
+		newTmpl.StoragePath = storagePath
+
+		if stor != nil {
+			newTmpl.StorageBucket = stor.Bucket()
+			newTmpl.StorageURI = storage.TemplateStorageURI(s.HubID(), stor.Bucket(), newTmpl.Scope, newTmpl.ScopeID, newTmpl.Slug)
+		}
+
+		// Copy storage files
+		if stor != nil && len(srcTmpl.Files) > 0 && srcTmpl.StoragePath != "" {
+			for _, file := range srcTmpl.Files {
+				srcPath := srcTmpl.StoragePath + "/" + file.Path
+				dstPath := storagePath + "/" + file.Path
+				if _, err := stor.Copy(ctx, srcPath, dstPath); err != nil {
+					_ = stor.DeletePrefix(ctx, storagePath)
+					return err
+				}
+			}
+		}
+
+		if err := s.store.CreateTemplate(ctx, newTmpl); err != nil {
+			if stor != nil {
+				_ = stor.DeletePrefix(ctx, storagePath)
+			}
+			return err
+		}
+	}
+
+	// Add rollback for all templates at once
+	*rollback = append(*rollback, func() {
+		rbCtx := context.WithoutCancel(ctx)
+		stor := s.GetStorage()
+		if stor != nil {
+			prefix := storage.TemplateStoragePath(s.HubID(), store.TemplateScopeProject, clone.ID, "")
+			_ = stor.DeletePrefix(rbCtx, prefix)
+		}
+		if _, err := s.store.DeleteTemplatesByScope(rbCtx, store.TemplateScopeProject, clone.ID); err != nil {
+			slog.Warn("project clone rollback: failed to delete templates",
+				"clone_id", clone.ID, "error", err)
+		}
+	})
+
+	return nil
+}
+
+// cloneProjectEnvVars copies non-secret environment variables from the source
+// project to the clone. Secret env vars (Secret == true) are excluded.
+// Sensitive env vars (Sensitive == true, not secrets) ARE copied.
+func (s *Server) cloneProjectEnvVars(ctx context.Context, srcProjectID, cloneProjectID, callerID string, rollback *[]func()) error {
+	envVars, err := s.store.ListEnvVars(ctx, store.EnvVarFilter{
+		Scope:   store.ScopeProject,
+		ScopeID: srcProjectID,
+	})
+	if err != nil {
+		return err
+	}
+
+	copied := false
+	for _, ev := range envVars {
+		// Skip secret-backed env vars
+		if ev.Secret {
+			continue
+		}
+
+		newEV := &store.EnvVar{
+			ID:            api.NewUUID(),
+			Key:           ev.Key,
+			Value:         ev.Value,
+			Scope:         store.ScopeProject,
+			ScopeID:       cloneProjectID,
+			Description:   ev.Description,
+			Sensitive:     ev.Sensitive, // Sensitive rows ARE copied
+			InjectionMode: ev.InjectionMode,
+			CreatedBy:     callerID,
+		}
+
+		if err := s.store.CreateEnvVar(ctx, newEV); err != nil {
+			return err
+		}
+		copied = true
+	}
+
+	if copied {
+		*rollback = append(*rollback, func() {
+			rbCtx := context.WithoutCancel(ctx)
+			if _, err := s.store.DeleteEnvVarsByScope(rbCtx, store.ScopeProject, cloneProjectID); err != nil {
+				slog.Warn("project clone rollback: failed to delete env vars",
+					"clone_id", cloneProjectID, "error", err)
+			}
+		})
+	}
+
+	return nil
+}
+
+// cloneProjectSkillInjections copies skill injections from the source project
+// to the clone using a single atomic SetSkillInjections call.
+func (s *Server) cloneProjectSkillInjections(ctx context.Context, srcProjectID, cloneProjectID, callerID string, rollback *[]func()) error {
+	injections, err := s.store.ListSkillInjections(ctx, store.SkillInjectionScopeProject, srcProjectID)
+	if err != nil {
+		return err
+	}
+
+	if len(injections) == 0 {
+		return nil
+	}
+
+	// Build the list for the clone — SetSkillInjections generates fresh IDs
+	cloneInjections := make([]store.SkillInjection, len(injections))
+	for i, si := range injections {
+		cloneInjections[i] = store.SkillInjection{
+			SkillURI:  si.SkillURI,
+			SkillAs:   si.SkillAs,
+			Optional:  si.Optional,
+			SortOrder: si.SortOrder,
+		}
+	}
+
+	if err := s.store.SetSkillInjections(ctx, store.SkillInjectionScopeProject, cloneProjectID, cloneInjections, callerID); err != nil {
+		return err
+	}
+
+	*rollback = append(*rollback, func() {
+		rbCtx := context.WithoutCancel(ctx)
+		if _, err := s.store.DeleteSkillInjectionsByScope(rbCtx, store.SkillInjectionScopeProject, cloneProjectID); err != nil {
+			slog.Warn("project clone rollback: failed to delete skill injections",
+				"clone_id", cloneProjectID, "error", err)
+		}
+	})
+
+	return nil
+}
+
+// cloneProjectPreStartHook copies the active pre-start hook from the source
+// project to the clone. Archived hooks are not copied.
+func (s *Server) cloneProjectPreStartHook(ctx context.Context, srcProjectID, cloneProjectID, callerID string) error {
+	srcHook, err := s.store.GetActiveProjectPreStartHook(ctx, srcProjectID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil // no active hook — nothing to copy
+		}
+		return err
+	}
+
+	newHook := &store.ProjectPreStartHook{
+		ID:          api.NewUUID(),
+		Scope:       store.PreStartHookScopeProject,
+		ProjectID:   cloneProjectID,
+		Name:        srcHook.Name,
+		Slug:        api.Slugify(srcHook.Name),
+		Description: srcHook.Description,
+		Script:      srcHook.Script,
+		Status:      store.ProjectPreStartHookStatusActive,
+		CreatedBy:   callerID,
+	}
+
+	if _, err := s.store.CreateProjectPreStartHook(ctx, newHook); err != nil {
+		return err
+	}
+
+	// Belt-and-braces: ensure it is active
+	if _, err := s.store.ActivateProjectPreStartHook(ctx, newHook.ID, cloneProjectID); err != nil {
+		slog.Warn("project clone: failed to activate pre-start hook (may already be active)",
+			"clone_id", cloneProjectID, "hook_id", newHook.ID, "error", err)
+	}
+
+	return nil
+}

--- a/pkg/hub/project_clone.go
+++ b/pkg/hub/project_clone.go
@@ -440,19 +440,19 @@ func (s *Server) cloneProjectTemplates(ctx context.Context, srcProjectID string,
 
 	for _, srcTmpl := range result.Items {
 		newTmpl := &store.Template{
-			ID:          api.NewUUID(),
-			Name:        srcTmpl.Name,
-			Slug:        srcTmpl.Slug, // SAME slug — critical for annotation references
-			DisplayName: srcTmpl.DisplayName,
-			Description: srcTmpl.Description,
-			Harness:     srcTmpl.Harness,
-			Config:      srcTmpl.Config,
-			Scope:       store.TemplateScopeProject,
-			ScopeID:     clone.ID,
-			Visibility:  srcTmpl.Visibility,
-			Status:      srcTmpl.Status,
-			Files:       srcTmpl.Files,
-			ContentHash: srcTmpl.ContentHash,
+			ID:           api.NewUUID(),
+			Name:         srcTmpl.Name,
+			Slug:         srcTmpl.Slug, // SAME slug — critical for annotation references
+			DisplayName:  srcTmpl.DisplayName,
+			Description:  srcTmpl.Description,
+			Harness:      srcTmpl.Harness,
+			Config:       srcTmpl.Config,
+			Scope:        store.TemplateScopeProject,
+			ScopeID:      clone.ID,
+			Visibility:   srcTmpl.Visibility,
+			Status:       srcTmpl.Status,
+			Files:        srcTmpl.Files,
+			ContentHash:  srcTmpl.ContentHash,
 			BaseTemplate: srcTmpl.BaseTemplate,
 		}
 

--- a/pkg/hub/project_clone_test.go
+++ b/pkg/hub/project_clone_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -643,7 +644,7 @@ func TestProjectClone_StorageFilesCopied(t *testing.T) {
 	defer stor.mu.Unlock()
 	found := false
 	for path := range stor.objects {
-		if contains(path, clone.ID) {
+		if strings.Contains(path, clone.ID) {
 			found = true
 			break
 		}
@@ -651,13 +652,3 @@ func TestProjectClone_StorageFilesCopied(t *testing.T) {
 	assert.True(t, found, "storage files should exist under clone's project ID")
 }
 
-// contains checks if s contains substr. Using strings.Contains would require
-// importing strings, which is already imported by the package under test.
-func contains(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/hub/project_clone_test.go
+++ b/pkg/hub/project_clone_test.go
@@ -1,0 +1,663 @@
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/storage"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createSourceProject creates a fully populated source project for clone tests,
+// with settings annotations, labels, env vars, skill injections, a pre-start
+// hook, and project-scoped harness configs and templates.
+func createSourceProject(t *testing.T, srv *Server, s store.Store) *store.Project {
+	t.Helper()
+	ctx := context.Background()
+
+	projectID := api.NewUUID()
+	project := &store.Project{
+		ID:                     projectID,
+		Name:                   "Source Project",
+		Slug:                   "source-project",
+		GitRemote:              "https://github.com/test/repo.git",
+		DefaultRuntimeBrokerID: "broker-123",
+		Visibility:             store.VisibilityPublic,
+		OwnerID:                DevUserID,
+		CreatedBy:              DevUserID,
+		Annotations: map[string]string{
+			"scion.io/default-model":         "claude-sonnet",
+			"scion.io/default-max-turns":     "100",
+			"scion.io/default-harness-config": "my-config",
+		},
+		Labels: map[string]string{
+			"scion.dev/workspace-mode": "per-agent",
+			"scion.dev/clone-url":      "https://github.com/test/repo.git",
+			"scion.dev/default-branch": "main",
+			"team":                     "backend",
+		},
+		SharedDirs: []api.SharedDir{
+			{Name: "data"},
+		},
+		GitIdentity: &store.GitIdentityConfig{
+			Name:  "Bot",
+			Email: "bot@test.com",
+		},
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	// Add non-secret env vars
+	require.NoError(t, s.CreateEnvVar(ctx, &store.EnvVar{
+		ID:      api.NewUUID(),
+		Key:     "API_URL",
+		Value:   "https://api.example.com",
+		Scope:   store.ScopeProject,
+		ScopeID: projectID,
+	}))
+	require.NoError(t, s.CreateEnvVar(ctx, &store.EnvVar{
+		ID:        api.NewUUID(),
+		Key:       "MASKED_TOKEN",
+		Value:     "token-value-123",
+		Scope:     store.ScopeProject,
+		ScopeID:   projectID,
+		Sensitive: true, // Sensitive but NOT a secret — should be copied
+	}))
+
+	// Add a secret-backed env var — should NOT be copied
+	require.NoError(t, s.CreateEnvVar(ctx, &store.EnvVar{
+		ID:      api.NewUUID(),
+		Key:     "SECRET_KEY",
+		Value:   "should-not-appear",
+		Scope:   store.ScopeProject,
+		ScopeID: projectID,
+		Secret:  true,
+	}))
+
+	// Add skill injections
+	require.NoError(t, s.SetSkillInjections(ctx, store.SkillInjectionScopeProject, projectID, []store.SkillInjection{
+		{SkillURI: "skill://debugging", SortOrder: 1},
+		{SkillURI: "skill://testing", SkillAs: "tdd", Optional: true, SortOrder: 2},
+	}, DevUserID))
+
+	// Add an older pre-start hook (will be archived when the second is created)
+	_, err := s.CreateProjectPreStartHook(ctx, &store.ProjectPreStartHook{
+		ID:        api.NewUUID(),
+		Scope:     store.PreStartHookScopeProject,
+		ProjectID: projectID,
+		Name:      "Old Setup",
+		Slug:      "old-setup",
+		Script:    "#!/bin/bash\necho old",
+		Status:    store.ProjectPreStartHookStatusActive,
+		CreatedBy: DevUserID,
+	})
+	require.NoError(t, err)
+
+	// Add active pre-start hook — this archives the previous one
+	_, err = s.CreateProjectPreStartHook(ctx, &store.ProjectPreStartHook{
+		ID:        api.NewUUID(),
+		Scope:     store.PreStartHookScopeProject,
+		ProjectID: projectID,
+		Name:      "Setup",
+		Slug:      "setup",
+		Script:    "#!/bin/bash\necho setup",
+		Status:    store.ProjectPreStartHookStatusActive,
+		CreatedBy: DevUserID,
+	})
+	require.NoError(t, err)
+
+	// Set up storage for project-scoped harness configs (with working Copy)
+	stor := newCloneMockStorage("test-bucket")
+	srv.SetStorage(stor)
+
+	now := time.Now()
+
+	// Add a project-scoped harness config
+	hcStoragePath := "hubs/test-hub-id/harness-configs/project/" + projectID + "/my-config"
+	require.NoError(t, s.CreateHarnessConfig(ctx, &store.HarnessConfig{
+		ID:          api.NewUUID(),
+		Name:        "My Config",
+		Slug:        "my-config",
+		Harness:     "claude",
+		Scope:       store.HarnessConfigScopeProject,
+		ScopeID:     projectID,
+		Status:      store.HarnessConfigStatusActive,
+		StoragePath: hcStoragePath,
+		Files: []store.TemplateFile{
+			{Path: "config.yaml", Size: 100, Hash: "abc123"},
+		},
+		Created: now, Updated: now,
+	}))
+	// Seed mock storage with the file
+	stor.seedObject(hcStoragePath+"/config.yaml", []byte("harness: claude"))
+
+	// Add a project-scoped template
+	tplStoragePath := "hubs/test-hub-id/templates/project/" + projectID + "/my-template"
+	require.NoError(t, s.CreateTemplate(ctx, &store.Template{
+		ID:          api.NewUUID(),
+		Name:        "My Template",
+		Slug:        "my-template",
+		Harness:     "claude",
+		Scope:       store.TemplateScopeProject,
+		ScopeID:     projectID,
+		Status:      store.TemplateStatusActive,
+		StoragePath: tplStoragePath,
+		Files: []store.TemplateFile{
+			{Path: "template.yaml", Size: 50, Hash: "def456"},
+		},
+		Created: now, Updated: now,
+	}))
+	stor.seedObject(tplStoragePath+"/template.yaml", []byte("template: test"))
+
+	return project
+}
+
+// cloneMockStorage wraps mockStorage with a working Copy implementation.
+type cloneMockStorage struct {
+	mockStorage
+}
+
+func newCloneMockStorage(bucket string) *cloneMockStorage {
+	return &cloneMockStorage{
+		mockStorage: mockStorage{
+			bucket:  bucket,
+			objects: make(map[string]*storage.Object),
+			content: make(map[string][]byte),
+		},
+	}
+}
+
+func (m *cloneMockStorage) Copy(_ context.Context, srcPath, dstPath string) (*storage.Object, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	srcObj, ok := m.objects[srcPath]
+	if !ok {
+		return nil, storage.ErrNotFound
+	}
+	dstObj := &storage.Object{
+		Name: dstPath,
+		Size: srcObj.Size,
+	}
+	m.objects[dstPath] = dstObj
+	if data, ok := m.content[srcPath]; ok {
+		m.content[dstPath] = data
+	}
+	return dstObj, nil
+}
+
+// seedObject inserts data into the mock storage for testing.
+func (m *cloneMockStorage) seedObject(path string, data []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.content[path] = data
+	m.objects[path] = &storage.Object{
+		Name: path,
+		Size: int64(len(data)),
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Happy Path Tests
+// ──────────────────────────────────────────────────────────────────────
+
+func TestProjectClone_HappyPath(t *testing.T) {
+	srv, s := testServer(t)
+	src := createSourceProject(t, srv, s)
+	ctx := context.Background()
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+src.ID+"/clone",
+		map[string]string{"name": "Cloned Project"})
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var clone store.Project
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&clone))
+
+	// New identity
+	assert.NotEqual(t, src.ID, clone.ID)
+	assert.NotEqual(t, src.Slug, clone.Slug)
+	assert.Equal(t, DevUserID, clone.OwnerID)
+	assert.Equal(t, DevUserID, clone.CreatedBy)
+
+	// Visibility resets to private
+	assert.Equal(t, store.VisibilityPrivate, clone.Visibility)
+
+	// Settings annotations copied
+	assert.Equal(t, "claude-sonnet", clone.Annotations["scion.io/default-model"])
+	assert.Equal(t, "100", clone.Annotations["scion.io/default-max-turns"])
+	assert.Equal(t, "my-config", clone.Annotations["scion.io/default-harness-config"])
+
+	// Git remote copied
+	assert.Equal(t, src.GitRemote, clone.GitRemote)
+
+	// Default broker copied
+	assert.Equal(t, src.DefaultRuntimeBrokerID, clone.DefaultRuntimeBrokerID)
+
+	// SharedDirs copied
+	require.Len(t, clone.SharedDirs, 1)
+	assert.Equal(t, "data", clone.SharedDirs[0].Name)
+
+	// GitIdentity copied
+	require.NotNil(t, clone.GitIdentity)
+	assert.Equal(t, "Bot", clone.GitIdentity.Name)
+
+	// Labels copied (minus scion.io/* prefix and workspace-mode re-derived)
+	assert.Equal(t, "backend", clone.Labels["team"])
+	// per-agent is the default — not stored as an explicit label (only shared
+	// and worktree-per-agent are re-derived as labels).
+	assert.Equal(t, "https://github.com/test/repo.git", clone.Labels["scion.dev/clone-url"])
+
+	// Groups created
+	agentsGroup, err := s.GetGroupBySlug(ctx, "project:"+clone.Slug+":agents")
+	require.NoError(t, err)
+	assert.Equal(t, clone.ID, agentsGroup.ProjectID)
+
+	membersGroup, err := s.GetGroupBySlug(ctx, "project:"+clone.Slug+":members")
+	require.NoError(t, err)
+	assert.Equal(t, clone.ID, membersGroup.ProjectID)
+
+	// Env vars copied (non-secret only)
+	cloneEnvVars, err := s.ListEnvVars(ctx, store.EnvVarFilter{
+		Scope:   store.ScopeProject,
+		ScopeID: clone.ID,
+	})
+	require.NoError(t, err)
+	envKeys := make(map[string]string)
+	for _, ev := range cloneEnvVars {
+		envKeys[ev.Key] = ev.Value
+	}
+	assert.Equal(t, "https://api.example.com", envKeys["API_URL"])
+	assert.Equal(t, "token-value-123", envKeys["MASKED_TOKEN"]) // Sensitive is copied
+	assert.NotContains(t, envKeys, "SECRET_KEY")                 // Secret is NOT copied
+
+	// Skill injections copied
+	cloneSkills, err := s.ListSkillInjections(ctx, store.SkillInjectionScopeProject, clone.ID)
+	require.NoError(t, err)
+	require.Len(t, cloneSkills, 2)
+
+	// Pre-start hook — only active is copied
+	activeHook, err := s.GetActiveProjectPreStartHook(ctx, clone.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "#!/bin/bash\necho setup", activeHook.Script)
+	assert.NotEqual(t, src.ID, activeHook.ProjectID)
+
+	// Verify only one hook exists (not the archived one)
+	allHooks, err := s.ListProjectPreStartHooks(ctx, clone.ID)
+	require.NoError(t, err)
+	activeCount := 0
+	for _, h := range allHooks {
+		if h.Status == store.ProjectPreStartHookStatusActive {
+			activeCount++
+		}
+	}
+	assert.Equal(t, 1, activeCount, "only one active hook should exist")
+
+	// Harness config slug preserved and resolves in new project
+	cloneHCs, err := s.ListHarnessConfigs(ctx, store.HarnessConfigFilter{
+		Scope:   store.HarnessConfigScopeProject,
+		ScopeID: clone.ID,
+	}, store.ListOptions{Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, cloneHCs.Items, 1)
+	assert.Equal(t, "my-config", cloneHCs.Items[0].Slug)
+	assert.NotEqual(t, src.ID, cloneHCs.Items[0].ScopeID)
+	assert.Equal(t, clone.ID, cloneHCs.Items[0].ScopeID)
+
+	// Template copied
+	cloneTpls, err := s.ListTemplates(ctx, store.TemplateFilter{
+		Scope:   store.TemplateScopeProject,
+		ScopeID: clone.ID,
+	}, store.ListOptions{Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, cloneTpls.Items, 1)
+	assert.Equal(t, "my-template", cloneTpls.Items[0].Slug)
+}
+
+func TestProjectClone_UnsetAnnotations(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	// Create a project with NO annotations set
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "Bare Project",
+		Slug:       "bare-project",
+		Visibility: store.VisibilityPrivate,
+		OwnerID:    DevUserID,
+		CreatedBy:  DevUserID,
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+project.ID+"/clone",
+		map[string]string{"name": "Bare Clone"})
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var clone store.Project
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&clone))
+
+	// Annotations should be nil/empty — not zero-filled, not hub-resolved
+	assert.Empty(t, clone.Annotations)
+}
+
+func TestProjectClone_SlugOmitted_NameCollides(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "Original",
+		Slug:       "original",
+		Visibility: store.VisibilityPrivate,
+		OwnerID:    DevUserID,
+		CreatedBy:  DevUserID,
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	// Clone with the same name as the slug that already exists
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+project.ID+"/clone",
+		map[string]string{"name": "Original"})
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var clone store.Project
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&clone))
+
+	// Auto-serialized slug — never 409
+	assert.NotEqual(t, "original", clone.Slug)
+	assert.Contains(t, clone.Slug, "original")
+}
+
+func TestProjectClone_ExplicitSlugCollides(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "Existing",
+		Slug:       "existing-slug",
+		Visibility: store.VisibilityPrivate,
+		OwnerID:    DevUserID,
+		CreatedBy:  DevUserID,
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+project.ID+"/clone",
+		map[string]interface{}{"name": "New Name", "slug": "existing-slug"})
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Exclusion Tests (security-critical)
+// ──────────────────────────────────────────────────────────────────────
+
+func TestProjectClone_NoSecretEnvVars(t *testing.T) {
+	srv, s := testServer(t)
+	src := createSourceProject(t, srv, s)
+	ctx := context.Background()
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+src.ID+"/clone",
+		map[string]string{"name": "Safe Clone"})
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var clone store.Project
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&clone))
+
+	envVars, err := s.ListEnvVars(ctx, store.EnvVarFilter{
+		Scope:   store.ScopeProject,
+		ScopeID: clone.ID,
+	})
+	require.NoError(t, err)
+
+	for _, ev := range envVars {
+		assert.False(t, ev.Secret, "clone must not contain secret env vars: found key=%s", ev.Key)
+	}
+
+	// Sensitive-but-not-secret IS present
+	found := false
+	for _, ev := range envVars {
+		if ev.Key == "MASKED_TOKEN" {
+			found = true
+			assert.True(t, ev.Sensitive)
+			assert.Equal(t, "token-value-123", ev.Value)
+		}
+	}
+	assert.True(t, found, "sensitive env var should be copied")
+}
+
+func TestProjectClone_NoAgents(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "With Agents",
+		Slug:       "with-agents",
+		Visibility: store.VisibilityPrivate,
+		OwnerID:    DevUserID,
+		CreatedBy:  DevUserID,
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	// Create an agent in the source project
+	require.NoError(t, s.CreateAgent(ctx, &store.Agent{
+		ID:        api.NewUUID(),
+		Name:      "test-agent",
+		Slug:      "test-agent",
+		ProjectID: project.ID,
+		Phase:     "running",
+		CreatedBy: DevUserID,
+	}))
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+project.ID+"/clone",
+		map[string]string{"name": "Agent-Free Clone"})
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var clone store.Project
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&clone))
+
+	// No agents in the clone
+	agents, err := s.ListAgents(ctx, store.AgentFilter{ProjectID: clone.ID}, store.ListOptions{Limit: 100})
+	require.NoError(t, err)
+	assert.Empty(t, agents.Items)
+}
+
+func TestProjectClone_OnlyActiveHookCopied(t *testing.T) {
+	srv, s := testServer(t)
+	src := createSourceProject(t, srv, s)
+	ctx := context.Background()
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+src.ID+"/clone",
+		map[string]string{"name": "Hook Clone"})
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var clone store.Project
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&clone))
+
+	allHooks, err := s.ListProjectPreStartHooks(ctx, clone.ID)
+	require.NoError(t, err)
+
+	// The source had 2 hooks (one archived, one active after the second create).
+	// Clone should only have 1 hook (the latest active one).
+	activeHooks := 0
+	for _, h := range allHooks {
+		if h.Status == store.ProjectPreStartHookStatusActive {
+			activeHooks++
+		}
+	}
+	assert.Equal(t, 1, activeHooks, "clone should have exactly one active hook")
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Authorization Tests
+// ──────────────────────────────────────────────────────────────────────
+
+func TestProjectClone_Unauthenticated(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "Auth Test",
+		Slug:       "auth-test",
+		Visibility: store.VisibilityPrivate,
+		OwnerID:    DevUserID,
+		CreatedBy:  DevUserID,
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	rec := doRequestNoAuth(t, srv, http.MethodPost, "/api/v1/projects/"+project.ID+"/clone",
+		map[string]string{"name": "Unauthed Clone"})
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestProjectClone_ReadOnly_Succeeds(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	// Project owned by the dev user — they can read it
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "Readable",
+		Slug:       "readable",
+		Visibility: store.VisibilityPrivate,
+		OwnerID:    DevUserID,
+		CreatedBy:  DevUserID,
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+project.ID+"/clone",
+		map[string]string{"name": "Read Clone"})
+	assert.Equal(t, http.StatusCreated, rec.Code)
+}
+
+func TestProjectClone_NotFound(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects/nonexistent/clone",
+		map[string]string{"name": "Ghost Clone"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestProjectClone_MissingName(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "Valid Project",
+		Slug:       "valid-project",
+		Visibility: store.VisibilityPrivate,
+		OwnerID:    DevUserID,
+		CreatedBy:  DevUserID,
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+project.ID+"/clone",
+		map[string]string{"name": ""})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestProjectClone_MethodNotAllowed(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "Method Test",
+		Slug:       "method-test",
+		Visibility: store.VisibilityPrivate,
+		OwnerID:    DevUserID,
+		CreatedBy:  DevUserID,
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/projects/"+project.ID+"/clone", nil)
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Concurrency Tests
+// ──────────────────────────────────────────────────────────────────────
+
+func TestProjectClone_ConcurrentClones(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "Concurrent Source",
+		Slug:       "concurrent-source",
+		Visibility: store.VisibilityPrivate,
+		OwnerID:    DevUserID,
+		CreatedBy:  DevUserID,
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	// Clone twice with the same name
+	rec1 := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+project.ID+"/clone",
+		map[string]string{"name": "Twin Clone"})
+	require.Equal(t, http.StatusCreated, rec1.Code)
+
+	rec2 := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+project.ID+"/clone",
+		map[string]string{"name": "Twin Clone"})
+	require.Equal(t, http.StatusCreated, rec2.Code)
+
+	var clone1, clone2 store.Project
+	require.NoError(t, json.NewDecoder(rec1.Body).Decode(&clone1))
+	require.NoError(t, json.NewDecoder(rec2.Body).Decode(&clone2))
+
+	assert.NotEqual(t, clone1.ID, clone2.ID)
+	assert.NotEqual(t, clone1.Slug, clone2.Slug)
+}
+
+func TestProjectClone_StorageFilesCopied(t *testing.T) {
+	srv, s := testServer(t)
+	src := createSourceProject(t, srv, s)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+src.ID+"/clone",
+		map[string]string{"name": "Storage Clone"})
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var clone store.Project
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&clone))
+
+	// Verify cloned harness config has storage set
+	cloneHCs, err := s.ListHarnessConfigs(context.Background(), store.HarnessConfigFilter{
+		Scope:   store.HarnessConfigScopeProject,
+		ScopeID: clone.ID,
+	}, store.ListOptions{Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, cloneHCs.Items, 1)
+	assert.NotEmpty(t, cloneHCs.Items[0].StoragePath)
+	assert.NotEqual(t, "", cloneHCs.Items[0].StoragePath)
+	assert.Contains(t, cloneHCs.Items[0].StoragePath, clone.ID)
+
+	// Verify storage files exist at the new path
+	stor := srv.GetStorage().(*cloneMockStorage)
+	stor.mu.Lock()
+	defer stor.mu.Unlock()
+	found := false
+	for path := range stor.objects {
+		if contains(path, clone.ID) {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "storage files should exist under clone's project ID")
+}
+
+// contains checks if s contains substr. Using strings.Contains would require
+// importing strings, which is already imported by the package under test.
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/hub/project_clone_test.go
+++ b/pkg/hub/project_clone_test.go
@@ -35,8 +35,8 @@ func createSourceProject(t *testing.T, srv *Server, s store.Store) *store.Projec
 		OwnerID:                DevUserID,
 		CreatedBy:              DevUserID,
 		Annotations: map[string]string{
-			"scion.io/default-model":         "claude-sonnet",
-			"scion.io/default-max-turns":     "100",
+			"scion.io/default-model":          "claude-sonnet",
+			"scion.io/default-max-turns":      "100",
 			"scion.io/default-harness-config": "my-config",
 		},
 		Labels: map[string]string{
@@ -275,7 +275,7 @@ func TestProjectClone_HappyPath(t *testing.T) {
 	}
 	assert.Equal(t, "https://api.example.com", envKeys["API_URL"])
 	assert.Equal(t, "token-value-123", envKeys["MASKED_TOKEN"]) // Sensitive is copied
-	assert.NotContains(t, envKeys, "SECRET_KEY")                 // Secret is NOT copied
+	assert.NotContains(t, envKeys, "SECRET_KEY")                // Secret is NOT copied
 
 	// Skill injections copied
 	cloneSkills, err := s.ListSkillInjections(ctx, store.SkillInjectionScopeProject, clone.ID)
@@ -651,4 +651,3 @@ func TestProjectClone_StorageFilesCopied(t *testing.T) {
 	}
 	assert.True(t, found, "storage files should exist under clone's project ID")
 }
-

--- a/pkg/hub/project_settings_handlers.go
+++ b/pkg/hub/project_settings_handlers.go
@@ -25,6 +25,9 @@ import (
 )
 
 // Annotation keys for project settings stored in project annotations.
+//
+// When adding a key here, add it to projectSettingKeys below as well.
+// TestProjectSettingKeys_NoDrift enforces this.
 const (
 	projectSettingDefaultTemplate      = "scion.io/default-template"
 	projectSettingDefaultHarnessConfig = "scion.io/default-harness-config"
@@ -49,6 +52,58 @@ const (
 	projectSettingDefaultResourcesMemLim = "scion.io/default-resources-memory-limit"
 	projectSettingDefaultResourcesDisk   = "scion.io/default-resources-disk"
 )
+
+// projectSettingKeys is the authoritative list of scion.io/* annotation keys
+// that constitute project settings. Anything not in this list is not a project
+// setting and is not copied by clone or reported by the resolved endpoint.
+//
+// This is the single source of truth for "what is a project setting". A key
+// omitted here is silently dropped when a project is cloned; a key wrongly
+// added here is exposed in API responses and propagated into clones. Errors in
+// both directions are user-visible bugs, so treat edits to this list as a
+// change to the project-settings contract rather than as a list edit.
+//
+// Two properties are maintained deliberately and are enforced by
+// TestProjectSettingKeys_NoDrift:
+//
+//  1. Every projectSetting* constant declared above appears here exactly once.
+//     A new setting that is not registered fails the build's tests rather than
+//     going unnoticed until someone loses it on clone.
+//  2. The order matches the constant declaration order above, which in turn
+//     matches the table in .design/project-templates.md §3.1, so all three can
+//     be diffed by eye.
+//
+// Note the scope: these are keys in project.Annotations. project.Labels is a
+// separate map that also carries scion.io/* keys — scion.io/system and
+// scion.io/global on the Global project, and the broker markers
+// scion.io/plugin, scion.io/broker-type and scion.io/broker-role. Every
+// scion.io/* label is a system marker rather than a project setting, and none
+// belongs here. User and organisational labels use the scion.dev/ prefix
+// instead.
+var projectSettingKeys = []string{
+	projectSettingDefaultTemplate,
+	projectSettingDefaultHarnessConfig,
+	projectSettingDefaultModel,
+	projectSettingDefaultThinkingLevel,
+	projectSettingTelemetryEnabled,
+	projectSettingActiveProfile,
+
+	// Default agent limits
+	projectSettingDefaultMaxTurns,
+	projectSettingDefaultMaxModelCalls,
+	projectSettingDefaultMaxDuration,
+
+	// Default GCP identity
+	projectSettingDefaultGCPIdentityMode,
+	projectSettingDefaultGCPIdentitySAID,
+
+	// Default resource spec (flat keys)
+	projectSettingDefaultResourcesCPUReq,
+	projectSettingDefaultResourcesMemReq,
+	projectSettingDefaultResourcesCPULim,
+	projectSettingDefaultResourcesMemLim,
+	projectSettingDefaultResourcesDisk,
+}
 
 // handleProjectSettings handles GET/PUT on /api/v1/projects/{projectId}/settings.
 func (s *Server) handleProjectSettings(w http.ResponseWriter, r *http.Request, projectID string) {

--- a/pkg/hub/project_settings_handlers.go
+++ b/pkg/hub/project_settings_handlers.go
@@ -87,16 +87,16 @@ const (
 //
 // Note the scope: these are keys in project.Annotations. project.Labels is a
 // separate map that also carries scion.io/* keys — scion.io/system and
-// scion.io/global on the Global project, and the broker markers
-// scion.io/plugin, scion.io/broker-type and scion.io/broker-role. Every
-// scion.io/* label is a system marker rather than a project setting, and none
-// belongs here. User and organisational labels use the scion.dev/ prefix
-// instead.
+// scion.io/global, set on the Global project at cmd/server_broker.go. Those are
+// system markers rather than project settings, so they do not belong here.
+// (Other scion.io/* keys such as scion.io/plugin, scion.io/broker-type and
+// scion.io/broker-role are RuntimeBroker labels and never appear on a project
+// at all.)
 //
 // Phase 4 (clone) label policy, recorded here because this comment is the
-// nearest thing to a spec for it: clone is to copy scion.dev/* labels and drop
-// the scion.io/* prefix entirely — a prefix rule rather than a two-key denylist,
-// so that a future system marker is not silently propagated into clones.
+// nearest thing to a spec for it: clone copies scion.dev/* labels and drops the
+// scion.io/* prefix entirely — a prefix rule rather than a two-key denylist, so
+// that a future system marker is not silently propagated into clones.
 //
 // One scion.dev/ label is excluded: store.LabelWorkspaceMode
 // ("scion.dev/workspace-mode") is NOT copied. It is derived for the new project

--- a/pkg/hub/project_settings_handlers.go
+++ b/pkg/hub/project_settings_handlers.go
@@ -55,13 +55,25 @@ const (
 
 // projectSettingKeys is the authoritative list of scion.io/* annotation keys
 // that constitute project settings. Anything not in this list is not a project
-// setting and is not copied by clone or reported by the resolved endpoint.
+// setting: it will not be copied by clone, nor reported by the resolved
+// settings endpoint.
+//
+// No production code reads this list yet. The intended consumers are the
+// project clone endpoint and the resolved-settings endpoint, which land in
+// later phases of this workstream; the list is introduced ahead of them so that
+// "copy the project settings" has one precise definition rather than three
+// approximate ones. Until those land, the registry's working value is
+// TestProjectSettingKeys_NoDrift below, which fails the build when a new
+// projectSetting* constant is not registered. Registry and guard are a single
+// executable invariant and should stay together — the list without the test is
+// merely an unused variable, and is reported as one by the linter.
 //
 // This is the single source of truth for "what is a project setting". A key
-// omitted here is silently dropped when a project is cloned; a key wrongly
-// added here is exposed in API responses and propagated into clones. Errors in
-// both directions are user-visible bugs, so treat edits to this list as a
-// change to the project-settings contract rather than as a list edit.
+// omitted here would be silently dropped when a project is cloned; a key
+// wrongly added here would be exposed in API responses and propagated into
+// clones. Errors in both directions are user-visible bugs, so treat edits to
+// this list as a change to the project-settings contract rather than as a list
+// edit.
 //
 // Two properties are maintained deliberately and are enforced by
 // TestProjectSettingKeys_NoDrift:
@@ -80,6 +92,26 @@ const (
 // scion.io/* label is a system marker rather than a project setting, and none
 // belongs here. User and organisational labels use the scion.dev/ prefix
 // instead.
+//
+// Phase 4 (clone) label policy, recorded here because this comment is the
+// nearest thing to a spec for it: clone is to copy scion.dev/* labels and drop
+// the scion.io/* prefix entirely — a prefix rule rather than a two-key denylist,
+// so that a future system marker is not silently propagated into clones.
+//
+// One scion.dev/ label is excluded: store.LabelWorkspaceMode
+// ("scion.dev/workspace-mode") is NOT copied. It is derived for the new project
+// from the clone request and the new project's git remote, by the same
+// validation the create path applies (handlers_projects_core.go), which sets it
+// only when there is a git remote and the mode is one of the two valid values.
+// Copying it raw would bypass that check and let a clone carry a workspace mode
+// inconsistent with its own remote, which IsSharedWorkspace() and
+// IsWorktreePerAgent() would then evaluate against mismatched state.
+//
+// Finally, do not try to "complete" this list from hubclient.ProjectSettings.
+// That struct also carries Bucket, Runtimes, Harnesses and Profiles, which the
+// settings endpoint accepts on PUT, silently ignores, and never returns on GET.
+// They are not annotation-backed, so their absence here is correct and loses
+// nothing on clone.
 var projectSettingKeys = []string{
 	projectSettingDefaultTemplate,
 	projectSettingDefaultHarnessConfig,

--- a/pkg/hub/project_settings_registry_test.go
+++ b/pkg/hub/project_settings_registry_test.go
@@ -15,10 +15,13 @@
 package hub
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -160,52 +163,124 @@ func TestProjectSettingKeys_NoDrift(t *testing.T) {
 // across the package), this asserts the narrower and more useful property: the
 // source file is the *only* declaration site, so parsing it is sufficient.
 func TestProjectSettingKeys_NoConstantsOutsideSourceFile(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, ".", nil, 0)
-	require.NoError(t, err, "failed to parse the pkg/hub directory")
-	require.NotEmpty(t, pkgs, "parsed no packages; this guard is not looking at anything")
+	strays, sourceFileConsts, err := scanForStrayProjectSettingConsts(".")
 
-	sawSourceFile := false
-	for _, pkg := range pkgs {
-		for path, file := range pkg.Files {
-			if filepath.Base(path) == projectSettingsSourceFile {
-				sawSourceFile = true
+	// The scan reports instrument failures — nothing parsed, source file absent,
+	// no constants found where they are known to be — as an error rather than as
+	// a clean result, because every one of them would otherwise present as "no
+	// strays found" and pass. Fatal, not logged: a broken instrument must not be
+	// allowed to reach the assertion below and satisfy it vacuously.
+	require.NoError(t, err, "the stray-constant scan could not have found anything")
+
+	// Positive control: the source file is known to declare these constants, so
+	// a zero here means the parse or the name matcher stopped working, not that
+	// the tree is clean.
+	require.NotZerof(t, sourceFileConsts,
+		"parsed %s but found no projectSetting* constants in it; the parse or "+
+			"isProjectSettingConstName is broken and this guard is checking nothing",
+		projectSettingsSourceFile)
+
+	assert.Emptyf(t, strays,
+		"projectSetting* constants are declared outside %s: %v. The drift guard only "+
+			"parses %s, so these would not be required to appear in projectSettingKeys "+
+			"and the settings would be silently dropped on clone. Move them into %s.",
+		projectSettingsSourceFile, strays, projectSettingsSourceFile, projectSettingsSourceFile)
+}
+
+// TestScanForStrayProjectSettingConsts_EmptyDirIsAnError is the negative control
+// for the guard above, kept executable rather than asserted once by hand.
+//
+// The guard's pass condition is an empty result, which is exactly what a scan
+// that examined nothing also produces. Pointed at an empty directory the scan
+// must refuse to return a clean answer; if this test ever fails, the guard above
+// has become a no-op and would stay green through the removal of the property it
+// is protecting.
+func TestScanForStrayProjectSettingConsts_EmptyDirIsAnError(t *testing.T) {
+	strays, sourceFileConsts, err := scanForStrayProjectSettingConsts(t.TempDir())
+
+	require.Error(t, err,
+		"scanning an empty directory returned a clean result; the guard is a no-op")
+	assert.Empty(t, strays)
+	assert.Zero(t, sourceFileConsts)
+}
+
+// scanForStrayProjectSettingConsts parses every .go file directly in dir and
+// reports (a) each projectSetting* constant declared outside
+// projectSettingsSourceFile, as "file: name", and (b) how many such constants
+// were declared inside it.
+//
+// It returns an error, rather than an empty result, for every condition under
+// which it could not have found a stray: the directory could not be read, it
+// held no .go files, projectSettingsSourceFile was not among them, or a file
+// failed to parse. Distinguishing "found nothing" from "looked at nothing" is
+// the entire reason this is a function returning an error instead of a loop
+// inside the test.
+//
+// File selection reproduces what parser.ParseDir with a nil filter selected
+// before it was deprecated: every .go file directly in dir, subdirectories
+// excluded, test files INCLUDED. Test files are then exempted from the constant
+// check by the _test.go skip below, which is where the exemption belongs —
+// filtering them out of the file set instead would look equivalent while
+// quietly changing which files the source-file and parse checks can see.
+func scanForStrayProjectSettingConsts(dir string) (strays []string, sourceFileConsts int, err error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, 0, fmt.Errorf("reading %s: %w", dir, err)
+	}
+
+	goFiles := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+			continue
+		}
+		goFiles = append(goFiles, e.Name())
+	}
+	if len(goFiles) == 0 {
+		return nil, 0, fmt.Errorf("no .go files in %s; the scan is not looking at anything", dir)
+	}
+	if !slices.Contains(goFiles, projectSettingsSourceFile) {
+		return nil, 0, fmt.Errorf(
+			"%s is not among the %d .go files in %s; has it been renamed? "+
+				"Update projectSettingsSourceFile", projectSettingsSourceFile, len(goFiles), dir)
+	}
+
+	fset := token.NewFileSet()
+	for _, name := range goFiles {
+		file, parseErr := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+		if parseErr != nil {
+			return nil, 0, fmt.Errorf("parsing %s: %w", name, parseErr)
+		}
+
+		isSourceFile := name == projectSettingsSourceFile
+		// Test files may legitimately reference these names.
+		if !isSourceFile && strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
 				continue
 			}
-			// Test files may legitimately reference these names.
-			if strings.HasSuffix(path, "_test.go") {
-				continue
-			}
-			for _, decl := range file.Decls {
-				gen, ok := decl.(*ast.GenDecl)
-				if !ok || gen.Tok != token.CONST {
+			for _, spec := range gen.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
 					continue
 				}
-				for _, spec := range gen.Specs {
-					vs, ok := spec.(*ast.ValueSpec)
-					if !ok {
+				for _, constName := range vs.Names {
+					if !isProjectSettingConstName(constName.Name) {
 						continue
 					}
-					for _, name := range vs.Names {
-						assert.Falsef(t, isProjectSettingConstName(name.Name),
-							"%s declares %s outside %s. The drift guard only parses %s, "+
-								"so this constant would not be required to appear in "+
-								"projectSettingKeys and the setting would be silently dropped "+
-								"on clone. Move it into %s.",
-							path, name.Name, projectSettingsSourceFile,
-							projectSettingsSourceFile, projectSettingsSourceFile)
+					if isSourceFile {
+						sourceFileConsts++
+						continue
 					}
+					strays = append(strays, name+": "+constName.Name)
 				}
 			}
 		}
 	}
-
-	// Anti-vacuity: if the source file were renamed, every file would be
-	// skipped by the filepath.Base check above and this test would pass while
-	// checking nothing.
-	require.True(t, sawSourceFile,
-		"did not encounter %s while scanning the package; has it been renamed? "+
-			"Update projectSettingsSourceFile.", projectSettingsSourceFile)
+	return strays, sourceFileConsts, nil
 }
 
 // TestProjectSettingKeys_Count pins the number of project settings, so that an

--- a/pkg/hub/project_settings_registry_test.go
+++ b/pkg/hub/project_settings_registry_test.go
@@ -204,6 +204,94 @@ func TestScanForStrayProjectSettingConsts_EmptyDirIsAnError(t *testing.T) {
 	assert.Zero(t, sourceFileConsts)
 }
 
+// writeGoFixture writes one .go file into a scan fixture directory. The content
+// is only ever parsed, never compiled, so it need not build.
+func writeGoFixture(t *testing.T, dir, name, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+}
+
+// TestScanForStrayProjectSettingConsts_NoTestFileIsAnError covers an input class
+// the scan handles and nothing else supplies: a directory holding .go files,
+// including the source file, but no _test.go file at all.
+//
+// The scan's three instrument-failure guards fire in sequence — no .go files,
+// then source file absent, then no test file — and the empty-directory control
+// above stops at the first. So the third was reachable only through a narrowed
+// selection in production code, and never through the suite.
+//
+// This is a coverage gap rather than a guard on a guard: the case would be worth
+// testing even if the third check did not exist, because "a file set with no test
+// file" is a distinct input the function makes a decision about.
+//
+// Probe by pt-rev-3.
+func TestScanForStrayProjectSettingConsts_NoTestFileIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	writeGoFixture(t, dir, projectSettingsSourceFile,
+		"package hub\n\nconst projectSettingProbeSource = \"scion.io/probe-source\"\n")
+	writeGoFixture(t, dir, "helper.go", "package hub\n")
+
+	strays, sourceFileConsts, err := scanForStrayProjectSettingConsts(dir)
+
+	require.Error(t, err,
+		"a file set containing .go files and the source file but NO _test.go file returned a "+
+			"clean result; the scan can no longer tell a complete selection from one narrowed "+
+			"to exclude test files")
+	// Pin which guard fired. Without this the test would also pass if the scan
+	// failed for one of the two earlier reasons, which are already covered and
+	// are not what this case is about.
+	assert.Contains(t, err.Error(), "_test.go",
+		"the scan errored, but not on the missing-test-file condition this case exists to reach")
+	assert.Empty(t, strays)
+	assert.Zero(t, sourceFileConsts)
+}
+
+// TestScanForStrayProjectSettingConsts_SeesBuildTaggedFiles pins the property
+// that made os.ReadDir + parser.ParseFile the right replacement for the
+// deprecated parser.ParseDir: the scan is BUILD-TAG BLIND.
+//
+// staticcheck's SA1019 recommends go/packages, and its advertised advantage is
+// that it applies build tags. For this guard that advantage is a defect. A
+// projectSetting* constant in a file excluded from the current build is still a
+// constant the drift guard cannot see, still absent from projectSettingKeys, and
+// still silently dropped when a project is cloned. It has to be caught anyway.
+//
+// Without this test the property is preserved but UNEXERCISED. Every //go:build
+// !no_sqlite file in pkg/hub today is a _test.go file, and test files are exempt
+// from the constant check regardless, so nothing on the current tree would go red
+// if tag-blindness were lost: a migration to go/packages would compile, pass every
+// other test in this file, and reopen the data-loss path in silence. Correct
+// behaviour that nothing would notice losing is indistinguishable from luck.
+//
+// Probe by pt-rev-3.
+func TestScanForStrayProjectSettingConsts_SeesBuildTaggedFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeGoFixture(t, dir, projectSettingsSourceFile,
+		"package hub\n\nconst projectSettingProbeSource = \"scion.io/probe-source\"\n")
+	// Satisfies the test-file requirement without declaring anything.
+	writeGoFixture(t, dir, "probe_selection_test.go", "package hub\n")
+	// The stray: excluded from the no_sqlite build exactly as the real !no_sqlite
+	// files in pkg/hub are, so a tag-aware loader would not report it.
+	writeGoFixture(t, dir, "tagged_stray.go",
+		"//go:build !no_sqlite\n\npackage hub\n\n"+
+			"const projectSettingTaggedStray = \"scion.io/tagged-stray\"\n")
+
+	strays, sourceFileConsts, err := scanForStrayProjectSettingConsts(dir)
+	require.NoError(t, err)
+
+	// Positive control, same reason as in the guard above: a zero here means the
+	// scan stopped parsing, not that the planted file was judged clean.
+	require.NotZero(t, sourceFileConsts,
+		"the stand-in source file declares a projectSetting* constant and none was counted; "+
+			"the scan is not parsing, so the assertion below would pass vacuously")
+
+	assert.Equal(t, []string{"tagged_stray.go: projectSettingTaggedStray"}, strays,
+		"a projectSetting* constant in a build-tag-excluded file was NOT reported. The scan has "+
+			"become build-tag aware — most likely a migration to go/packages, which staticcheck "+
+			"SA1019 recommends. Tag-blindness is required here: a constant invisible to the "+
+			"current build is still dropped on clone. Keep os.ReadDir + parser.ParseFile.")
+}
+
 // scanForStrayProjectSettingConsts parses every .go file directly in dir and
 // reports (a) each projectSetting* constant declared outside
 // projectSettingsSourceFile, as "file: name", and (b) how many such constants

--- a/pkg/hub/project_settings_registry_test.go
+++ b/pkg/hub/project_settings_registry_test.go
@@ -163,6 +163,8 @@ func TestProjectSettingKeys_NoDrift(t *testing.T) {
 // across the package), this asserts the narrower and more useful property: the
 // source file is the *only* declaration site, so parsing it is sufficient.
 func TestProjectSettingKeys_NoConstantsOutsideSourceFile(t *testing.T) {
+	// "." is pkg/hub: go test runs in the package directory. The recipe in the
+	// build-tag test below is repo-root-relative, so this file uses both roots.
 	strays, sourceFileConsts, err := scanForStrayProjectSettingConsts(".")
 
 	// The scan reports instrument failures — nothing parsed, source file absent,
@@ -229,8 +231,6 @@ func writeGoFixture(t *testing.T, dir, name, content string) {
 // This is a coverage gap rather than a guard on a guard: the case would be worth
 // testing even if the third check did not exist, because "a file set with no test
 // file" is a distinct input the function makes a decision about.
-//
-// Probe by pt-rev-3.
 func TestScanForStrayProjectSettingConsts_NoTestFileIsAnError(t *testing.T) {
 	dir := t.TempDir()
 	writeGoFixture(t, dir, projectSettingsSourceFile,
@@ -271,24 +271,36 @@ func TestScanForStrayProjectSettingConsts_NoTestFileIsAnError(t *testing.T) {
 // The load-bearing demonstration is a probe planted in the real pkg/hub, where
 // a tag IS in force. It is not shippable — it mutates the package under test —
 // so it is written out here rather than cited, and it runs against nothing but
-// a clone of this repository:
+// a clone of this repository, from the repository root:
 //
 //	printf '//go:build !no_sqlite\n\npackage hub\n\nconst projectSettingProbe = "x"\n' \
 //	  > pkg/hub/probe_stray.go
-//	go list -tags no_sqlite -f '{{join .GoFiles "\n"}}' ./pkg/hub | grep -c probe_stray.go  # 0
-//	go list                 -f '{{join .GoFiles "\n"}}' ./pkg/hub | grep -c probe_stray.go  # 1
-//	go test -tags no_sqlite ./pkg/hub/ -run NoConstantsOutsideSourceFile                    # FAIL
+//	go list -tags no_sqlite -f '{{join .GoFiles "\n"}}' ./pkg/hub | grep -c probe_stray.go || true  # 0
+//	go list                 -f '{{join .GoFiles "\n"}}' ./pkg/hub | grep -c probe_stray.go || true  # 1
+//	go test -tags no_sqlite ./pkg/hub/ -run NoConstantsOutsideSourceFile                   || true  # FAIL
 //	rm pkg/hub/probe_stray.go
 //
 // The 0 says the compiler cannot see the file under the tag; the 1 is the
 // control proving the probe exists at all; the FAIL says the guard reports it
 // regardless. Both counts are needed — a single number cannot distinguish
-// "excluded by the tag" from "never planted". (Original probe: pt-rev-3,
-// PR 597.) This test is the shippable remainder.
+// "excluded by the tag" from "never planted". This test is the shippable
+// remainder.
 //
-// Run those as five separate commands. The expected 0 makes grep exit 1, so
-// under set -e or a && chain the block stops there — after the probe is planted
-// and before the line that removes it.
+// Every `|| true` is paste-safety, nothing more. Two of the three results
+// documented above are non-zero exits — grep -c exits 1 on the expected 0, and
+// go test exits 1 on the expected FAIL — so under set -e, or in a && chain, the
+// block stops at the first of them: after the probe is planted and before the
+// line that removes it. Annotating only the grep lines is not enough. That was
+// measured: it moves the abort down to the go test rather than removing it, and
+// the probe is stranded either way. The remaining one, on the line expecting 1,
+// covers the failure path — an unexpected 0 there exits 1 as well, and a
+// surprising result is the worst moment to skip the cleanup. A stranded
+// probe_stray.go is not a harmless leftover: it turns a plain
+// `go test ./pkg/hub/` red with a message about settings being silently dropped
+// on clone, which points at the guard rather than at the stray file. Nothing is
+// hidden by any of this. grep -c exits 1 whether go list succeeded, failed, or
+// ran in the wrong directory, so that status never distinguished them. The two
+// counts do.
 //
 // staticcheck's SA1019 recommends go/packages, and its advertised advantage is
 // that it applies build tags. For this guard that advantage is a defect. A
@@ -308,8 +320,6 @@ func TestScanForStrayProjectSettingConsts_NoTestFileIsAnError(t *testing.T) {
 // one NO build context satisfies — see the fixture below. With a realistic tag
 // it went green through the migration too, and the paragraph above would have
 // been describing this test as well.
-//
-// Probe by pt-rev-3.
 func TestScanForStrayProjectSettingConsts_SelectsFilesRegardlessOfBuildTags(t *testing.T) {
 	dir := t.TempDir()
 	writeGoFixture(t, dir, projectSettingsSourceFile,

--- a/pkg/hub/project_settings_registry_test.go
+++ b/pkg/hub/project_settings_registry_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// projectSettingsSourceFile is the file that declares both the projectSetting*
+// constants and the projectSettingKeys registry.
+const projectSettingsSourceFile = "project_settings_handlers.go"
+
+// expectedProjectSettingCount is the number of project settings defined by
+// .design/project-templates.md §3.1. It is asserted separately from the drift
+// guard so that adding or removing a setting shows up as a deliberate edit in
+// the diff rather than passing silently.
+const expectedProjectSettingCount = 16
+
+// declaredProjectSettingConstants parses projectSettingsSourceFile and returns
+// the name and value of every projectSetting* constant, in declaration order.
+//
+// This derives the expected set from the source *independently of the registry
+// itself*, which is the whole point: a test that restated projectSettingKeys
+// would be copy-pasted from it and would pass forever, including when both were
+// wrong together.
+func declaredProjectSettingConstants(t *testing.T) (names []string, values []string) {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, projectSettingsSourceFile, nil, 0)
+	require.NoError(t, err, "failed to parse %s", projectSettingsSourceFile)
+
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if !strings.HasPrefix(name.Name, "projectSetting") {
+					continue
+				}
+				require.Less(t, i, len(vs.Values),
+					"constant %s has no value expression", name.Name)
+				lit, ok := vs.Values[i].(*ast.BasicLit)
+				require.True(t, ok && lit.Kind == token.STRING,
+					"constant %s is not a string literal", name.Name)
+				value, err := strconv.Unquote(lit.Value)
+				require.NoError(t, err, "failed to unquote value of %s", name.Name)
+
+				names = append(names, name.Name)
+				values = append(values, value)
+			}
+		}
+	}
+	return names, values
+}
+
+// TestProjectSettingKeys_NoDrift is the drift guard for the project settings
+// registry.
+//
+// The failure mode it exists to catch is someone adding a projectSetting*
+// constant and wiring it into applyProjectSettingsToAnnotations, but forgetting
+// projectSettingKeys. Nothing else notices: GET/PUT /settings keep working, and
+// the omission only surfaces later as a setting silently dropped when a project
+// is cloned.
+//
+// If a projectSetting* constant is ever *deliberately* excluded from the
+// registry, this test must be edited to record that exclusion and say why.
+// That friction is intentional — exclusion is a change to the project-settings
+// contract and should be argued for in review, not defaulted into.
+func TestProjectSettingKeys_NoDrift(t *testing.T) {
+	names, values := declaredProjectSettingConstants(t)
+	require.NotEmpty(t, names, "parsed no projectSetting* constants from %s; "+
+		"the guard is not actually looking at anything", projectSettingsSourceFile)
+
+	registry := make(map[string]int, len(projectSettingKeys))
+	for _, key := range projectSettingKeys {
+		registry[key]++
+	}
+
+	// 1. Every declared constant is registered.
+	for i, value := range values {
+		assert.Containsf(t, registry, value,
+			"constant %s (%q) is declared in %s but missing from projectSettingKeys. "+
+				"Unregistered settings are silently dropped when a project is cloned. "+
+				"Add it to projectSettingKeys.",
+			names[i], value, projectSettingsSourceFile)
+	}
+
+	// 2. Nothing is registered that is not a declared constant, and nothing is
+	//    registered twice. This catches a raw string literal or a duplicated
+	//    entry sneaking into the registry.
+	declared := make(map[string]string, len(values))
+	for i, value := range values {
+		declared[value] = names[i]
+	}
+	for key, count := range registry {
+		assert.Containsf(t, declared, key,
+			"projectSettingKeys contains %q, which is not any projectSetting* constant "+
+				"declared in %s. Use the constant, not a string literal.",
+			key, projectSettingsSourceFile)
+		assert.Equalf(t, 1, count, "projectSettingKeys contains %q %d times", key, count)
+	}
+
+	// 3. Registry order matches constant declaration order, which matches the
+	//    table in .design/project-templates.md §3.1. Keeping all three in the
+	//    same order is what makes them diffable by eye.
+	assert.Equal(t, values, projectSettingKeys,
+		"projectSettingKeys does not match the projectSetting* constants in declaration order; "+
+			"keep the registry, the constants and the §3.1 table in the same order")
+}
+
+// TestProjectSettingKeys_Count pins the number of project settings, so that an
+// addition or removal is visible in the diff of this file and gets a moment's
+// thought about clone and the resolved endpoint.
+func TestProjectSettingKeys_Count(t *testing.T) {
+	assert.Len(t, projectSettingKeys, expectedProjectSettingCount,
+		"the project settings contract changed size; if that is intended, update "+
+			"expectedProjectSettingCount and the table in .design/project-templates.md §3.1")
+}

--- a/pkg/hub/project_settings_registry_test.go
+++ b/pkg/hub/project_settings_registry_test.go
@@ -200,6 +200,12 @@ func TestScanForStrayProjectSettingConsts_EmptyDirIsAnError(t *testing.T) {
 
 	require.Error(t, err,
 		"scanning an empty directory returned a clean result; the guard is a no-op")
+	// Pin which guard fired, for the same reason the missing-test-file case does:
+	// an empty directory must stop at the no-.go-files check, and asserting only
+	// that *an* error came back would also accept an error from a later guard or
+	// from a genuine instrument failure.
+	assert.Contains(t, err.Error(), "no .go files in",
+		"the scan errored, but not on the empty-directory condition this control exists to reach")
 	assert.Empty(t, strays)
 	assert.Zero(t, sourceFileConsts)
 }
@@ -240,7 +246,11 @@ func TestScanForStrayProjectSettingConsts_NoTestFileIsAnError(t *testing.T) {
 	// Pin which guard fired. Without this the test would also pass if the scan
 	// failed for one of the two earlier reasons, which are already covered and
 	// are not what this case is about.
-	assert.Contains(t, err.Error(), "_test.go",
+	// The full phrase, not the bare "_test.go" substring: both earlier guards
+	// interpolate dir into their messages, so the loose form's discriminating
+	// power depends on t.TempDir() never containing "_test.go". It does not
+	// today, and the tighter string costs nothing to stop depending on it.
+	assert.Contains(t, err.Error(), "is a _test.go file",
 		"the scan errored, but not on the missing-test-file condition this case exists to reach")
 	assert.Empty(t, strays)
 	assert.Zero(t, sourceFileConsts)
@@ -258,13 +268,27 @@ func TestScanForStrayProjectSettingConsts_NoTestFileIsAnError(t *testing.T) {
 // constraint that is actually in force, and a reader who sees //go:build in a
 // fixture will assume it does.
 //
-// The load-bearing demonstration was a probe planted in the real pkg/hub, where
-// the tag WAS in force: go list reported 0 GoFiles for that file under
-// -tags no_sqlite and 1 untagged, proving the compiler could not see it, and the
-// guard reported it as a stray anyway. That probe is not shippable — it requires
-// mutating the package under test — so it lives as a reproduction in
-// reviews/pr597-unreviewed-paths-review.md (pt-rev-3). This test is the
-// shippable remainder.
+// The load-bearing demonstration is a probe planted in the real pkg/hub, where
+// a tag IS in force. It is not shippable — it mutates the package under test —
+// so it is written out here rather than cited, and it runs against nothing but
+// a clone of this repository:
+//
+//	printf '//go:build !no_sqlite\n\npackage hub\n\nconst projectSettingProbe = "x"\n' \
+//	  > pkg/hub/probe_stray.go
+//	go list -tags no_sqlite -f '{{join .GoFiles "\n"}}' ./pkg/hub | grep -c probe_stray.go  # 0
+//	go list                 -f '{{join .GoFiles "\n"}}' ./pkg/hub | grep -c probe_stray.go  # 1
+//	go test -tags no_sqlite ./pkg/hub/ -run NoConstantsOutsideSourceFile                    # FAIL
+//	rm pkg/hub/probe_stray.go
+//
+// The 0 says the compiler cannot see the file under the tag; the 1 is the
+// control proving the probe exists at all; the FAIL says the guard reports it
+// regardless. Both counts are needed — a single number cannot distinguish
+// "excluded by the tag" from "never planted". (Original probe: pt-rev-3,
+// PR 597.) This test is the shippable remainder.
+//
+// Run those as five separate commands. The expected 0 makes grep exit 1, so
+// under set -e or a && chain the block stops there — after the probe is planted
+// and before the line that removes it.
 //
 // staticcheck's SA1019 recommends go/packages, and its advertised advantage is
 // that it applies build tags. For this guard that advantage is a defect. A
@@ -274,10 +298,16 @@ func TestScanForStrayProjectSettingConsts_NoTestFileIsAnError(t *testing.T) {
 //
 // Without this test the property is preserved but UNEXERCISED. Every //go:build
 // !no_sqlite file in pkg/hub today is a _test.go file, and test files are exempt
-// from the constant check regardless, so nothing on the current tree would go red
-// if tag-blindness were lost: a migration to go/packages would compile, pass every
-// other test in this file, and reopen the data-loss path in silence. Correct
-// behaviour that nothing would notice losing is indistinguishable from luck.
+// from the constant check regardless, so nothing else on the current tree would
+// go red if tag-blindness were lost: a migration to go/packages would compile,
+// pass every other test in this file, and reopen the data-loss path in silence.
+// Correct behaviour that nothing would notice losing is indistinguishable from
+// luck.
+//
+// That this test is the exception depends entirely on the fixture's tag being
+// one NO build context satisfies — see the fixture below. With a realistic tag
+// it went green through the migration too, and the paragraph above would have
+// been describing this test as well.
 //
 // Probe by pt-rev-3.
 func TestScanForStrayProjectSettingConsts_SelectsFilesRegardlessOfBuildTags(t *testing.T) {
@@ -286,14 +316,23 @@ func TestScanForStrayProjectSettingConsts_SelectsFilesRegardlessOfBuildTags(t *t
 		"package hub\n\nconst projectSettingProbeSource = \"scion.io/probe-source\"\n")
 	// Satisfies the test-file requirement without declaring anything.
 	writeGoFixture(t, dir, "probe_selection_test.go", "package hub\n")
-	// The stray: excluded from the no_sqlite build exactly as the real !no_sqlite
-	// files in pkg/hub are, so a tag-aware loader would not report it.
+	// The stray carries a tag NOTHING EVER SETS, and the choice is load-bearing.
+	// The obvious tag, !no_sqlite, is the real in-tree shape and is why this test
+	// exists — but it is SATISFIED in the default build context, so a tag-aware
+	// loader selects the file anyway and this test stays green through exactly
+	// the migration it warns about. Measured, both tag modes including the one
+	// CI runs: with !no_sqlite an ambient build.Default.MatchFile selection is
+	// GREEN (a miss); with the tag below it is RED, while the shipped tag-blind
+	// scan stays GREEN either way. The fixture's job is detection, not
+	// resemblance.
 	writeGoFixture(t, dir, "tagged_stray.go",
-		"//go:build !no_sqlite\n\npackage hub\n\n"+
+		"//go:build scion_never_defined_tag\n\npackage hub\n\n"+
 			"const projectSettingTaggedStray = \"scion.io/tagged-stray\"\n")
 
 	strays, sourceFileConsts, err := scanForStrayProjectSettingConsts(dir)
-	require.NoError(t, err)
+	require.NoError(t, err,
+		"the scan errored on a three-file fixture it should handle; the assertions below "+
+			"cannot distinguish a clean tree from a scan that never ran")
 
 	// Positive control, same reason as in the guard above: a zero here means the
 	// scan stopped parsing, not that the planted file was judged clean.

--- a/pkg/hub/project_settings_registry_test.go
+++ b/pkg/hub/project_settings_registry_test.go
@@ -243,6 +243,19 @@ func scanForStrayProjectSettingConsts(dir string) (strays []string, sourceFileCo
 			"%s is not among the %d .go files in %s; has it been renamed? "+
 				"Update projectSettingsSourceFile", projectSettingsSourceFile, len(goFiles), dir)
 	}
+	// Test files MUST be in the selected set. They are excluded from the
+	// constant check by the _test.go skip in the loop below, not here, and the
+	// difference is not cosmetic: excluding them at selection looks equivalent,
+	// produces an identical result today, and silently shrinks what the checks
+	// above can see. Without this assertion that mistake is invisible — the
+	// suite stays green — so the requirement is stated as an executed check
+	// rather than as a comment asking the next reader to be careful.
+	if !slices.ContainsFunc(goFiles, func(n string) bool { return strings.HasSuffix(n, "_test.go") }) {
+		return nil, 0, fmt.Errorf(
+			"none of the %d .go files selected in %s is a _test.go file; the selection has been "+
+				"narrowed to exclude test files. Select every .go file and let the _test.go skip "+
+				"below do the exempting", len(goFiles), dir)
+	}
 
 	fset := token.NewFileSet()
 	for _, name := range goFiles {

--- a/pkg/hub/project_settings_registry_test.go
+++ b/pkg/hub/project_settings_registry_test.go
@@ -18,6 +18,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -35,6 +36,19 @@ const projectSettingsSourceFile = "project_settings_handlers.go"
 // guard so that adding or removing a setting shows up as a deliberate edit in
 // the diff rather than passing silently.
 const expectedProjectSettingCount = 16
+
+// isProjectSettingConstName reports whether an identifier names a project
+// settings annotation key constant.
+//
+// The singular "projectSetting" prefix is the naming convention for these keys.
+// Plural "projectSettings*" names (projectSettingsSourceFile, and any future
+// helper such as a projectSettingsPrefix) are deliberately excluded: they are
+// not annotation keys, and matching them would trip the guard on a constant
+// that has no business being in the registry.
+func isProjectSettingConstName(name string) bool {
+	return strings.HasPrefix(name, "projectSetting") &&
+		!strings.HasPrefix(name, "projectSettings")
+}
 
 // declaredProjectSettingConstants parses projectSettingsSourceFile and returns
 // the name and value of every projectSetting* constant, in declaration order.
@@ -61,7 +75,7 @@ func declaredProjectSettingConstants(t *testing.T) (names []string, values []str
 				continue
 			}
 			for i, name := range vs.Names {
-				if !strings.HasPrefix(name.Name, "projectSetting") {
+				if !isProjectSettingConstName(name.Name) {
 					continue
 				}
 				require.Less(t, i, len(vs.Values),
@@ -133,6 +147,65 @@ func TestProjectSettingKeys_NoDrift(t *testing.T) {
 	assert.Equal(t, values, projectSettingKeys,
 		"projectSettingKeys does not match the projectSetting* constants in declaration order; "+
 			"keep the registry, the constants and the §3.1 table in the same order")
+}
+
+// TestProjectSettingKeys_NoConstantsOutsideSourceFile closes the one gap in the
+// drift guard above: that guard parses a single file, so a projectSetting*
+// constant declared in some other pkg/hub file would be invisible to it, would
+// not be required to appear in the registry, and would therefore be silently
+// dropped on clone — the very failure mode the guard exists to prevent, just
+// displaced by one file.
+//
+// Rather than widen the parse (which would start matching unrelated constants
+// across the package), this asserts the narrower and more useful property: the
+// source file is the *only* declaration site, so parsing it is sufficient.
+func TestProjectSettingKeys_NoConstantsOutsideSourceFile(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", nil, 0)
+	require.NoError(t, err, "failed to parse the pkg/hub directory")
+	require.NotEmpty(t, pkgs, "parsed no packages; this guard is not looking at anything")
+
+	sawSourceFile := false
+	for _, pkg := range pkgs {
+		for path, file := range pkg.Files {
+			if filepath.Base(path) == projectSettingsSourceFile {
+				sawSourceFile = true
+				continue
+			}
+			// Test files may legitimately reference these names.
+			if strings.HasSuffix(path, "_test.go") {
+				continue
+			}
+			for _, decl := range file.Decls {
+				gen, ok := decl.(*ast.GenDecl)
+				if !ok || gen.Tok != token.CONST {
+					continue
+				}
+				for _, spec := range gen.Specs {
+					vs, ok := spec.(*ast.ValueSpec)
+					if !ok {
+						continue
+					}
+					for _, name := range vs.Names {
+						assert.Falsef(t, isProjectSettingConstName(name.Name),
+							"%s declares %s outside %s. The drift guard only parses %s, "+
+								"so this constant would not be required to appear in "+
+								"projectSettingKeys and the setting would be silently dropped "+
+								"on clone. Move it into %s.",
+							path, name.Name, projectSettingsSourceFile,
+							projectSettingsSourceFile, projectSettingsSourceFile)
+					}
+				}
+			}
+		}
+	}
+
+	// Anti-vacuity: if the source file were renamed, every file would be
+	// skipped by the filepath.Base check above and this test would pass while
+	// checking nothing.
+	require.True(t, sawSourceFile,
+		"did not encounter %s while scanning the package; has it been renamed? "+
+			"Update projectSettingsSourceFile.", projectSettingsSourceFile)
 }
 
 // TestProjectSettingKeys_Count pins the number of project settings, so that an

--- a/pkg/hub/project_settings_registry_test.go
+++ b/pkg/hub/project_settings_registry_test.go
@@ -246,9 +246,25 @@ func TestScanForStrayProjectSettingConsts_NoTestFileIsAnError(t *testing.T) {
 	assert.Zero(t, sourceFileConsts)
 }
 
-// TestScanForStrayProjectSettingConsts_SeesBuildTaggedFiles pins the property
-// that made os.ReadDir + parser.ParseFile the right replacement for the
-// deprecated parser.ParseDir: the scan is BUILD-TAG BLIND.
+// TestScanForStrayProjectSettingConsts_SelectsFilesRegardlessOfBuildTags pins
+// the selection behaviour that made os.ReadDir + parser.ParseFile the right
+// replacement for the deprecated parser.ParseDir: every .go file in the
+// directory is parsed, and a //go:build line does not remove one.
+//
+// WHAT THIS TEST DOES NOT DO, because the name and the fixture both suggest
+// otherwise: IN A t.TempDir() THE BUILD TAG IS INERT. Nothing compiles these
+// files, so //go:build is an ordinary comment here and os.ReadDir would list the
+// file with or without it. This test cannot witness tag-blindness against a
+// constraint that is actually in force, and a reader who sees //go:build in a
+// fixture will assume it does.
+//
+// The load-bearing demonstration was a probe planted in the real pkg/hub, where
+// the tag WAS in force: go list reported 0 GoFiles for that file under
+// -tags no_sqlite and 1 untagged, proving the compiler could not see it, and the
+// guard reported it as a stray anyway. That probe is not shippable — it requires
+// mutating the package under test — so it lives as a reproduction in
+// reviews/pr597-unreviewed-paths-review.md (pt-rev-3). This test is the
+// shippable remainder.
 //
 // staticcheck's SA1019 recommends go/packages, and its advertised advantage is
 // that it applies build tags. For this guard that advantage is a defect. A
@@ -264,7 +280,7 @@ func TestScanForStrayProjectSettingConsts_NoTestFileIsAnError(t *testing.T) {
 // behaviour that nothing would notice losing is indistinguishable from luck.
 //
 // Probe by pt-rev-3.
-func TestScanForStrayProjectSettingConsts_SeesBuildTaggedFiles(t *testing.T) {
+func TestScanForStrayProjectSettingConsts_SelectsFilesRegardlessOfBuildTags(t *testing.T) {
 	dir := t.TempDir()
 	writeGoFixture(t, dir, projectSettingsSourceFile,
 		"package hub\n\nconst projectSettingProbeSource = \"scion.io/probe-source\"\n")
@@ -286,10 +302,11 @@ func TestScanForStrayProjectSettingConsts_SeesBuildTaggedFiles(t *testing.T) {
 			"the scan is not parsing, so the assertion below would pass vacuously")
 
 	assert.Equal(t, []string{"tagged_stray.go: projectSettingTaggedStray"}, strays,
-		"a projectSetting* constant in a build-tag-excluded file was NOT reported. The scan has "+
-			"become build-tag aware — most likely a migration to go/packages, which staticcheck "+
-			"SA1019 recommends. Tag-blindness is required here: a constant invisible to the "+
-			"current build is still dropped on clone. Keep os.ReadDir + parser.ParseFile.")
+		"a projectSetting* constant in a file carrying a //go:build line was NOT reported, so "+
+			"file selection has started depending on build tags — most likely a migration to "+
+			"go/packages, which staticcheck SA1019 recommends. That property is required here: a "+
+			"constant invisible to the current build is still dropped when a project is cloned. "+
+			"Keep os.ReadDir + parser.ParseFile.")
 }
 
 // scanForStrayProjectSettingConsts parses every .go file directly in dir and

--- a/pkg/hub/project_settings_resolved.go
+++ b/pkg/hub/project_settings_resolved.go
@@ -76,6 +76,22 @@ import (
 // is false the moment a template layer sits in between. That is why HubDefault
 // reports presence and never the value.
 //
+// As of 2026-07, this is not merely an architectural preference — the ordering
+// this endpoint would have to assume does not currently exist to be assumed.
+// docs-site/src/content/docs/reference/settings-precedence.md explicitly
+// DECLINES to publish a precedence position for hub agent_defaults: the
+// intended model (a low-priority fallback near the bottom of the chain) and the
+// implementation (applied at agent-create time, behaving as though near the
+// top) disagree, the resolution is deferred, and the page says in terms "Do not
+// build on either reading." Tracked as issue #623. The same page records that
+// the rank additionally moves with the hub's storage mode — above the broker's
+// settings.yaml defaults in Postgres mode, at the bottom of the broker chain in
+// file mode — so there is not even one ordering to copy.
+//
+// Concretely: an effective value shipped here would not become wrong at some
+// future date. It would be wrong now, and it would be wrong in a way the
+// project has already written down.
+//
 // TestResolvedSettingsResponseShape_NoEffectiveValue enforces this as an
 // exact-set assertion over the response types' JSON tags, so any new field —
 // whatever it is called — fails the build rather than review. That test is the

--- a/pkg/hub/project_settings_resolved.go
+++ b/pkg/hub/project_settings_resolved.go
@@ -1,0 +1,630 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config/opsettings"
+	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// GET /api/v1/projects/{projectId}/settings/resolved
+//
+// ############################################################################
+// # THIS ENDPOINT IS CALLED "resolved" AND IT DELIBERATELY DOES NOT RESOLVE. #
+// ############################################################################
+//
+// If you are here to add the "missing" effective-value field, please read this
+// paragraph before you do. It is not an oversight and it is not laziness; the
+// field was specified, reviewed, and deliberately removed.
+//
+// This endpoint reports two things per project setting: what the project
+// annotation says, and whether a hub-level default EXISTS. It does not report
+// which of them wins.
+//
+// The reason is durable and has nothing to do with the state of any particular
+// branch: resolution is the resolver's job. Computing an effective value here
+// would be a SECOND implementation of the precedence order, living in a package
+// that cannot observe changes to the first one. Two implementations of one
+// ordering do not stay equal — and the copy fails silently, because a stale
+// answer is still a well-formed answer. There is no test that can fail when
+// this file's idea of the ladder and the resolver's idea of the ladder drift
+// apart, which is precisely why the value must not be computed here at all.
+//
+// The layers between "project" and "hub" (template and harness-config) are what
+// make this concrete: a response asserting that a hub default takes effect is
+// wrong whenever one of those layers supplies a value instead.
+//
+// This is not only about a field literally named "value". Returning the hub's
+// VALUE alongside the project's — the {projectValue, hubValue} pair — is the
+// same mistake by another route, and the reason is not a matter of opinion:
+// the ladder's own implementation hit this bug and paid to avoid it.
+// hub_agent_defaults.go, on withHubDefaultHarnessConfig, records that
+// "Provenance is carried, not inferred. Comparing the name back against
+// s.hubAgentDefaults().DefaultHarnessConfig would misreport the case where a
+// user, a project annotation or a template happens to name the same harness
+// config the hub defaults to."
+//
+// Note the middle term: a project annotation is exactly what this endpoint
+// would be reporting as projectValue. That misreport REQUIRES the hub value to
+// be available for comparison, and upstream threaded a context key through the
+// request path specifically so it would not have to make that comparison. A
+// response carrying both values hands the same comparison to every client for
+// free, and the first UI to write `projectValue === hubValue ? "from hub" :
+// "overridden"` reproduces, client-side, a bug the team that owns the ladder
+// found expensive enough to re-architect around. So the answer to "the UI can
+// just compare them" is that the comparison IS the misreport.
+//
+// And additionally, the shape asserts precedence by adjacency: two fields with
+// nothing between them claim that there is nothing between them. A consumer
+// reading `projectValue: null, hubValue: 200` concludes "I will get 200", which
+// is false the moment a template layer sits in between. That is why HubDefault
+// reports presence and never the value.
+//
+// TestResolvedSettingsResponseShape_NoEffectiveValue enforces this as an
+// exact-set assertion over the response types' JSON tags, so any new field —
+// whatever it is called — fails the build rather than review. That test is the
+// enforcement; this comment is only the explanation.
+//
+// A consumer that needs the effective value must resolve it itself, against
+// whatever ladder exists at the time it asks.
+
+// ResolvedHubDefault reports whether a hub-level default exists for a project
+// setting. It is deliberately TRI-STATE rather than a bool.
+//
+// A bool has no room for "I did not look here", which forces "not evaluated" to
+// be reported as "no" — and a consumer cannot tell the difference between "the
+// hub has no default for this" and "this build could not determine it". The
+// distinction is real in this codebase and is not hypothetical:
+//
+//   - In file/SQLite mode there is no OperationalSettings at all, so no
+//     agent_defaults document can be read. Every key backed by that section is
+//     genuinely UNKNOWN, not absent.
+//   - Five of the six opsettings.AgentDefaultsSettings fields are non-pointer
+//     scalars marshalled with `omitempty`, so a value explicitly configured to
+//     the zero value is dropped at write time and is indistinguishable from
+//     never-configured. Where that ambiguity is reachable, absence is UNKNOWN.
+//
+// See resolvedSettingDescriptor.absentWhenMissing for exactly which keys can
+// honestly report ABSENT and why.
+type ResolvedHubDefault string
+
+const (
+	// ResolvedHubDefaultPresent means a hub-level default for this key was
+	// observed. This is always a measurement, never an inference.
+	ResolvedHubDefaultPresent ResolvedHubDefault = "present"
+
+	// ResolvedHubDefaultAbsent means the hub source for this key was consulted
+	// and positively does not carry a value. Only used where absence is
+	// faithfully representable — see absentWhenMissing.
+	ResolvedHubDefaultAbsent ResolvedHubDefault = "absent"
+
+	// ResolvedHubDefaultUnknown means presence could not be honestly
+	// determined: either the source was unreachable, or the source cannot
+	// distinguish an explicitly-zero value from an unset one. It does NOT mean
+	// "no".
+	ResolvedHubDefaultUnknown ResolvedHubDefault = "unknown"
+)
+
+// ResolvedProjectSetting is the per-key entry of the resolved-settings
+// response.
+//
+// There is deliberately no `value`, no `effective`, no `source` and no
+// `hubValue` field here. See the file header for why, and note that
+// TestResolvedSettingsResponseShape_NoEffectiveValue will fail if one is added.
+//
+// On the absent `source` field specifically: its absence is deliberate, not an
+// omission. Reporting a winning source is the same precedence claim as
+// reporting a winning value. (Had one been needed, it would also have had to
+// avoid the "harness"/"template"/"settings" vocabulary of api.SecretKeyInfo,
+// which is secret provenance — a different domain that happens to reuse these
+// words with different meanings.)
+type ResolvedProjectSetting struct {
+	// ProjectSet reports whether the project annotation is present, regardless
+	// of its content. An annotation explicitly set to the empty string is set.
+	ProjectSet bool `json:"projectSet"`
+
+	// ProjectValue is the raw annotation string, exactly as stored, or null
+	// when the annotation is absent. It is intentionally not typed per key: the
+	// annotation store holds strings, and parsing here would mean re-stating
+	// per-key type knowledge that projectSettingsFromAnnotations already owns.
+	ProjectValue *string `json:"projectValue"`
+
+	// HubDefault reports the EXISTENCE of a hub-level default. Not its value,
+	// not its rank.
+	HubDefault ResolvedHubDefault `json:"hubDefault"`
+}
+
+// ResolvedProjectSettings is the GET .../settings/resolved response body.
+//
+// Settings is keyed by raw annotation key ("scion.io/default-model"), not by
+// camelCase field name. Two reasons: it makes the correspondence with
+// projectSettingKeys exact and eyeball-checkable, and the registry's five flat
+// resource keys have no 1:1 camelCase counterpart — hubclient.ProjectSettings
+// nests them under a single DefaultResources object, so a camelCase keying
+// would have required inventing a mapping that does not exist in the data.
+type ResolvedProjectSettings struct {
+	// Project is the existing GET /settings payload, unchanged. It carries no
+	// precedence information and exists so a client does not need two round
+	// trips to render a settings form.
+	Project *hubclient.ProjectSettings `json:"project"`
+
+	// Settings is keyed by annotation key. Its key set is exactly
+	// projectSettingKeys — enforced by TestResolvedSettings_RegistryNoDrift.
+	Settings map[string]ResolvedProjectSetting `json:"settings"`
+}
+
+// hubDefaultSource identifies which hub-side configuration source is consulted
+// to answer "does a hub default exist" for a given project setting.
+//
+// These identifiers are local to the resolved-settings domain. The collision
+// with api.SecretKeyInfo.Source ("harness" | "template" | "settings") is
+// deliberate and unrelated: that vocabulary describes where a *secret* came
+// from and implies no correspondence with these values.
+type hubDefaultSource int
+
+const (
+	// hubSourceNone: no hub-level counterpart exists for this setting.
+	// opsettings.AgentDefaultsSettings has exactly six fields, enumerated in
+	// full, so this is a measured structural fact rather than an unsearched
+	// one — which is why these keys may report ABSENT rather than UNKNOWN.
+	hubSourceNone hubDefaultSource = iota
+
+	// hubSourceAgentDefaults: the opsettings "agent_defaults" section document.
+	hubSourceAgentDefaults
+
+	// hubSourceTelemetryDefault: Server.config.TelemetryDefault, which is a
+	// *bool and therefore presence-faithful. The hub telemetry default lives
+	// here and NOT in agent_defaults; reporting "absent" for it merely because
+	// agent_defaults has no telemetry field would be a false statement about a
+	// question asked of the wrong source.
+	hubSourceTelemetryDefault
+)
+
+// resolvedSettingDescriptor carries the per-key knowledge that the annotation
+// key string cannot supply by itself: which hub source answers for this key,
+// where to look inside it, and whether a missing entry can honestly be reported
+// as absent.
+//
+// WHY THIS TABLE EXISTS AS A SECOND STRUCTURE, given that projectSettingKeys is
+// meant to be the single source of truth: if the response were built by ranging
+// over projectSettingKeys alone, coverage of the registry would be true by
+// construction and the drift guard could never fail. A check that cannot fail
+// is worse than no check, because it looks like protection. The registry
+// remains the authoritative key list; this table adds per-key wiring, and
+// TestResolvedSettings_RegistryNoDrift asserts the two cover each other exactly
+// in BOTH directions. The drift that matters is unenforced duplication — this
+// duplication is enforced.
+type resolvedSettingDescriptor struct {
+	source hubDefaultSource
+
+	// path is the JSON path within the source document, e.g.
+	// {"default_resources", "requests", "cpu"}. Empty for hubSourceNone and
+	// hubSourceTelemetryDefault.
+	path []string
+
+	// absentWhenMissing records whether a missing leaf can be reported as
+	// ABSENT (true) or must be reported as UNKNOWN (false).
+	//
+	// This is per-field and it is NOT guessable from the Go types; it falls out
+	// of the JSON schema. The write path builds AgentDefaultsSettings
+	// field-by-field and marshals it with `omitempty`, so any explicitly-zero
+	// value is discarded before it is persisted. Whether that matters depends
+	// on whether the zero value can be persisted at all:
+	//
+	//   - default_max_turns, default_max_model_calls carry "minimum": 1 in
+	//     settings-v1.schema.json, so 0 is rejected by validation and can never
+	//     reach the document. Absence is unambiguous. -> true
+	//   - default_template, default_harness_config, default_max_duration and
+	//     the nested resource quantities are strings with no minLength, so ""
+	//     validates and is then silently dropped by omitempty. Absence cannot
+	//     be distinguished from an explicit empty value. -> false
+	//
+	// Treating "" as equivalent to absent would tidy this up, but that is a
+	// claim about how the ladder consumes an empty hub value, and this package
+	// does not own the ladder.
+	absentWhenMissing bool
+}
+
+// resolvedSettingDescriptors maps every registered project setting to its hub
+// source. Its key set must equal projectSettingKeys exactly; both directions
+// are enforced by TestResolvedSettings_RegistryNoDrift.
+var resolvedSettingDescriptors = map[string]resolvedSettingDescriptor{
+	projectSettingDefaultTemplate: {
+		source:            hubSourceAgentDefaults,
+		path:              []string{"default_template"},
+		absentWhenMissing: false, // string, "" dropped by omitempty
+	},
+	projectSettingDefaultHarnessConfig: {
+		source:            hubSourceAgentDefaults,
+		path:              []string{"default_harness_config"},
+		absentWhenMissing: false, // string, "" dropped by omitempty
+	},
+	projectSettingDefaultModel: {
+		source: hubSourceNone,
+	},
+	projectSettingDefaultThinkingLevel: {
+		source: hubSourceNone,
+	},
+	projectSettingTelemetryEnabled: {
+		source: hubSourceTelemetryDefault,
+	},
+	projectSettingActiveProfile: {
+		source: hubSourceNone,
+	},
+
+	// Default agent limits
+	projectSettingDefaultMaxTurns: {
+		source:            hubSourceAgentDefaults,
+		path:              []string{"default_max_turns"},
+		absentWhenMissing: true, // int, schema "minimum": 1 makes 0 unpersistable
+	},
+	projectSettingDefaultMaxModelCalls: {
+		source:            hubSourceAgentDefaults,
+		path:              []string{"default_max_model_calls"},
+		absentWhenMissing: true, // int, schema "minimum": 1 makes 0 unpersistable
+	},
+	projectSettingDefaultMaxDuration: {
+		source:            hubSourceAgentDefaults,
+		path:              []string{"default_max_duration"},
+		absentWhenMissing: false, // string, "" dropped by omitempty
+	},
+
+	// Default GCP identity
+	projectSettingDefaultGCPIdentityMode: {
+		source: hubSourceNone,
+	},
+	projectSettingDefaultGCPIdentitySAID: {
+		source: hubSourceNone,
+	},
+
+	// Default resource spec. The registry's five flat annotation keys face a
+	// single agent_defaults "default_resources" object, so the mapping is 5:1
+	// and each key resolves to a distinct nested path.
+	projectSettingDefaultResourcesCPUReq: {
+		source:            hubSourceAgentDefaults,
+		path:              []string{"default_resources", "requests", "cpu"},
+		absentWhenMissing: false,
+	},
+	projectSettingDefaultResourcesMemReq: {
+		source:            hubSourceAgentDefaults,
+		path:              []string{"default_resources", "requests", "memory"},
+		absentWhenMissing: false,
+	},
+	projectSettingDefaultResourcesCPULim: {
+		source:            hubSourceAgentDefaults,
+		path:              []string{"default_resources", "limits", "cpu"},
+		absentWhenMissing: false,
+	},
+	projectSettingDefaultResourcesMemLim: {
+		source:            hubSourceAgentDefaults,
+		path:              []string{"default_resources", "limits", "memory"},
+		absentWhenMissing: false,
+	},
+	projectSettingDefaultResourcesDisk: {
+		source:            hubSourceAgentDefaults,
+		path:              []string{"default_resources", "disk"},
+		absentWhenMissing: false,
+	},
+}
+
+// handleProjectSettingsResolved serves GET
+// /api/v1/projects/{projectId}/settings/resolved.
+//
+// Read-only by construction: there is no PUT. The response is a separate
+// sub-resource rather than an extension of GET /settings precisely because
+// hubclient.ProjectSettings is used as both the GET response and the PUT body —
+// adding hub-derived fields there would make a naive GET-modify-PUT round trip
+// promote every hub default into an explicit project annotation.
+//
+// See the file header for why this endpoint does not return an effective value.
+func (s *Server) handleProjectSettingsResolved(w http.ResponseWriter, r *http.Request, projectID string) {
+	ctx := r.Context()
+
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	project, err := s.store.GetProject(ctx, projectID)
+	if err != nil {
+		if err == store.ErrNotFound {
+			NotFound(w, "Project")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	identity := GetIdentityFromContext(ctx)
+	if identity == nil {
+		Unauthorized(w)
+		return
+	}
+
+	// Same authorization as GET /settings: ActionRead on the project.
+	// Deliberately not admin-gated — the point is to let a non-admin project
+	// owner see that hub defaults exist. Only the existence of an
+	// agent_defaults entry is exposed, never a hub value and never any other
+	// part of the server configuration.
+	if userIdent, ok := identity.(UserIdentity); ok {
+		decision := s.authzService.CheckAccess(ctx, userIdent, Resource{
+			Type:    "project",
+			ID:      project.ID,
+			OwnerID: project.OwnerID,
+		}, ActionRead)
+		if !decision.Allowed {
+			Forbidden(w)
+			return
+		}
+	}
+
+	writeJSON(w, http.StatusOK, s.resolvedProjectSettings(project))
+}
+
+// resolvedProjectSettings builds the response body.
+//
+// It iterates projectSettingKeys — the authoritative registry — and looks each
+// key up in resolvedSettingDescriptors. A registry key with no descriptor is a
+// wiring error; it reports UNKNOWN here rather than silently vanishing from the
+// response, and TestResolvedSettings_RegistryNoDrift fails the build for it.
+// Reporting rather than omitting matters: an omitted key would make the
+// response quietly incomplete, which is the failure the registry exists to
+// prevent.
+func (s *Server) resolvedProjectSettings(project *store.Project) *ResolvedProjectSettings {
+	agentDefaults, agentDefaultsReadable := s.hubAgentDefaultsDoc()
+
+	settings := make(map[string]ResolvedProjectSetting, len(projectSettingKeys))
+	for _, key := range projectSettingKeys {
+		entry := ResolvedProjectSetting{
+			HubDefault: ResolvedHubDefaultUnknown,
+		}
+
+		if project.Annotations != nil {
+			if val, ok := project.Annotations[key]; ok {
+				v := val
+				entry.ProjectSet = true
+				entry.ProjectValue = &v
+			}
+		}
+
+		desc, ok := resolvedSettingDescriptors[key]
+		if !ok {
+			// Unwired registry key. UNKNOWN is the honest report: we did not
+			// look anywhere for it.
+			settings[key] = entry
+			continue
+		}
+
+		entry.HubDefault = s.hubDefaultFor(desc, agentDefaults, agentDefaultsReadable)
+		settings[key] = entry
+	}
+
+	return &ResolvedProjectSettings{
+		Project:  projectSettingsFromAnnotations(project),
+		Settings: settings,
+	}
+}
+
+// hubDefaultFor answers the existence question for one descriptor.
+func (s *Server) hubDefaultFor(
+	desc resolvedSettingDescriptor,
+	agentDefaults map[string]json.RawMessage,
+	agentDefaultsReadable bool,
+) ResolvedHubDefault {
+	switch desc.source {
+	case hubSourceNone:
+		// Measured structural absence: AgentDefaultsSettings has six fields and
+		// none of them corresponds to this setting.
+		return ResolvedHubDefaultAbsent
+
+	case hubSourceTelemetryDefault:
+		// *bool — presence-faithful, so this is a real answer rather than a
+		// zero-value guess. s.config is a value, not a pointer, so there is no
+		// "config absent" case to distinguish here: an unset TelemetryDefault
+		// is a nil pointer either way.
+		if s.config.TelemetryDefault != nil {
+			return ResolvedHubDefaultPresent
+		}
+		return ResolvedHubDefaultAbsent
+
+	case hubSourceAgentDefaults:
+		if !agentDefaultsReadable {
+			// No OperationalSettings (file mode) or the section could not be
+			// read. Nowhere searched — not "no".
+			//
+			// This is the case where reporting ABSENT would be a measurable
+			// lie, and the obvious implementation tells it. In file mode the
+			// operator's config file may well carry default_template et al —
+			// extractAgentDefaults reads exactly those koanf paths — but
+			// BuildLayer1SnapshotFromFile never populates AgentDefaults, and
+			// SetOperationalSettings is called from the DB path only. So the
+			// hub genuinely did not look, and what it holds is a zero value
+			// that means nothing about operator intent.
+			//
+			// Upstream says so itself, twice: hubAgentDefaults() is documented
+			// "In file mode this always returns the zero value ... so callers
+			// that gate on non-empty never fire in file mode", and
+			// handlers_agents_core.go repeats it at the template rung.
+			//
+			// WHY NOT ABSENT, given that in file mode no hub default will in
+			// fact fire? Two reasons, and the second is the load-bearing one.
+			//
+			// First, "no hub default will fire" is a claim about what the
+			// ladder DOES, and predicting ladder behaviour is the precise act
+			// this endpoint refuses to perform. Resolution would come back in
+			// through the one field small enough to look harmless.
+			//
+			// Second: the fact that file mode carries no agent defaults is a
+			// GAP, NOT A DESIGN. extractAgentDefaults proves the file format
+			// can already express these keys; BuildLayer1SnapshotFromFile
+			// simply does not read them. Someone will close that gap. On that
+			// day file mode starts holding real agent-defaults data, and every
+			// ABSENT this endpoint had been emitting becomes silently wrong —
+			// no test fails, no error is raised, the field just begins lying.
+			// UNKNOWN survives that change untouched and becomes answerable
+			// when the plumbing lands. ABSENT is correct only for as long as
+			// the gap persists; UNKNOWN is correct either way. If you are the
+			// person fixing BuildLayer1SnapshotFromFile: this endpoint was
+			// waiting for you, and it should start returning real answers here
+			// with no change to this file.
+			//
+			// WHY THE RAW SECTION DOCUMENT, when a typed accessor is sitting
+			// right there: s.hubAgentDefaults() returns AgentDefaultsSettings,
+			// whose fields are non-pointer scalars. Its zero value cannot
+			// distinguish "unset" from "configured to zero", so it cannot
+			// express UNKNOWN at all — an implementation built on it would
+			// report ABSENT for all five agent_defaults-backed keys in file
+			// mode, confidently, on the strength of a zero value upstream
+			// documents as meaningless. Do not simplify this back to the typed
+			// accessor; that is the bug, not the cleanup.
+			//
+			// Honest history, so the next reader knows which parts are
+			// load-bearing: these two reasons were independent. The raw-section
+			// read was adopted to avoid a name collision with the upstream
+			// hubAgentDefaults() accessor, not for correctness. The correctness
+			// property fell out of it. We got here partly by luck.
+			return ResolvedHubDefaultUnknown
+		}
+		return hubDefaultFromDoc(agentDefaults, desc)
+
+	default:
+		return ResolvedHubDefaultUnknown
+	}
+}
+
+// hubDefaultFromDoc walks desc.path through a raw section document.
+//
+// The walk is done over raw JSON rather than an unmarshalled struct on purpose:
+// unmarshalling into AgentDefaultsSettings is exactly where presence
+// information is destroyed, because its fields are non-pointer scalars whose
+// zero values are indistinguishable from unset.
+func hubDefaultFromDoc(doc map[string]json.RawMessage, desc resolvedSettingDescriptor) ResolvedHubDefault {
+	if len(desc.path) == 0 {
+		return ResolvedHubDefaultUnknown
+	}
+
+	root, ok := doc[desc.path[0]]
+	if !ok {
+		// For a nested path the root is "default_resources", a pointer field
+		// (*api.ResourceSpec). A pointer CAN represent unset, so its absence is
+		// faithful and reports as absent regardless of the leaf's own rule.
+		if len(desc.path) > 1 {
+			return ResolvedHubDefaultAbsent
+		}
+		return missingLeafState(desc)
+	}
+
+	if len(desc.path) == 1 {
+		if isJSONNull(root) {
+			return missingLeafState(desc)
+		}
+		return ResolvedHubDefaultPresent
+	}
+
+	current := root
+	for _, segment := range desc.path[1:] {
+		var next map[string]json.RawMessage
+		if err := json.Unmarshal(current, &next); err != nil {
+			// Shape is not what the schema says it should be. We cannot answer.
+			return ResolvedHubDefaultUnknown
+		}
+		child, ok := next[segment]
+		if !ok {
+			return missingLeafState(desc)
+		}
+		current = child
+	}
+
+	if isJSONNull(current) {
+		return missingLeafState(desc)
+	}
+	return ResolvedHubDefaultPresent
+}
+
+// missingLeafState maps a missing entry to absent or unknown per the
+// descriptor's measured ambiguity.
+func missingLeafState(desc resolvedSettingDescriptor) ResolvedHubDefault {
+	if desc.absentWhenMissing {
+		return ResolvedHubDefaultAbsent
+	}
+	return ResolvedHubDefaultUnknown
+}
+
+func isJSONNull(raw json.RawMessage) bool {
+	return string(raw) == "null"
+}
+
+// hubAgentDefaultsDoc returns the raw agent_defaults section document, and
+// whether it could be read at all.
+//
+// The second return value is load-bearing: false means "could not look", which
+// must surface as UNKNOWN rather than as an empty document (which would read as
+// "looked, found nothing" and report absent).
+func (s *Server) hubAgentDefaultsDoc() (map[string]json.RawMessage, bool) {
+	ops := s.GetOperationalSettings()
+	if ops == nil {
+		// File/SQLite mode: the agent_defaults section does not exist as a
+		// document here. A missing hint must never fail the request.
+		return nil, false
+	}
+
+	raw, ok := ops.rawSection("agent_defaults")
+	if !ok {
+		return nil, false
+	}
+
+	doc := map[string]json.RawMessage{}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, false
+	}
+	return doc, true
+}
+
+// rawSection returns a section's raw persisted JSON document, pre-unmarshal.
+//
+// This exists because presence cannot be recovered after unmarshalling into the
+// section struct: opsettings.AgentDefaultsSettings stores five of its six
+// fields as non-pointer scalars, so "configured to zero" and "never configured"
+// become the same value. The raw document still distinguishes them, to the
+// extent the write path preserved the distinction at all.
+//
+// Precedence mirrors Snapshot(): a DB row fully owns its section, and only a
+// section absent from the DB falls back to the bootstrap merge.
+func (o *OperationalSettings) rawSection(name string) (json.RawMessage, bool) {
+	o.mu.RLock()
+	state, inDB := o.cache[name]
+	o.mu.RUnlock()
+
+	if inDB {
+		return state.Value, true
+	}
+
+	sec := opsettings.SectionByName(name)
+	if sec == nil || len(sec.KoanfPaths) == 0 || o.bootstrapKoanf == nil {
+		return nil, false
+	}
+
+	// ExtractSectionFromKoanf is presence-faithful for agent_defaults: its
+	// extractor adds a key only when koanf reports it Exists.
+	doc, err := opsettings.ExtractSectionFromKoanf(o.bootstrapKoanf, name)
+	if err != nil {
+		return nil, false
+	}
+	return doc, true
+}

--- a/pkg/hub/project_settings_resolved.go
+++ b/pkg/hub/project_settings_resolved.go
@@ -486,19 +486,36 @@ func (s *Server) hubDefaultFor(
 			// this endpoint refuses to perform. Resolution would come back in
 			// through the one field small enough to look harmless.
 			//
-			// Second: the fact that file mode carries no agent defaults is a
-			// GAP, NOT A DESIGN. extractAgentDefaults proves the file format
-			// can already express these keys; BuildLayer1SnapshotFromFile
-			// simply does not read them. Someone will close that gap. On that
-			// day file mode starts holding real agent-defaults data, and every
-			// ABSENT this endpoint had been emitting becomes silently wrong —
-			// no test fails, no error is raised, the field just begins lying.
-			// UNKNOWN survives that change untouched and becomes answerable
-			// when the plumbing lands. ABSENT is correct only for as long as
-			// the gap persists; UNKNOWN is correct either way. If you are the
-			// person fixing BuildLayer1SnapshotFromFile: this endpoint was
-			// waiting for you, and it should start returning real answers here
-			// with no change to this file.
+			// Second, and load-bearing: ABSENT would be a claim about WHY the
+			// data is missing, and this endpoint is not entitled to that claim
+			// either way it turns out.
+			//
+			// extractAgentDefaults proves the file format can already express
+			// these keys; BuildLayer1SnapshotFromFile does not read them. Two
+			// readings of that were live, and UNKNOWN is the correct answer
+			// under BOTH — which is the entire reason to prefer it:
+			//
+			//   - If it is a gap someone later closes, file mode begins holding
+			//     real agent-defaults data, and every ABSENT previously emitted
+			//     becomes silently wrong: no test fails, no error is raised, the
+			//     field simply starts lying. UNKNOWN survives untouched and
+			//     becomes answerable when the plumbing lands.
+			//   - If the emptiness is permanent, ABSENT is not merely
+			//     wrong-until-fixed but permanently wrong, because it would
+			//     report "the operator configured nothing" about data the hub is
+			//     structurally incapable of reading.
+			//
+			// Upstream has since settled which reading applies, and it is the
+			// second: hub_agent_defaults.go records that
+			// BuildLayer1SnapshotFromFile "deliberately leaves the agent-defaults
+			// fields empty (design §3.2.4)" in order to keep file-mode dispatch
+			// byte-identical. So do not expect this to start returning
+			// present/absent in file mode — UNKNOWN is the permanent, honest
+			// answer there, not a placeholder awaiting better plumbing.
+			//
+			// Note that the argument above did not depend on knowing which
+			// reading was true. That is the property worth preserving if this
+			// comment is ever revised.
 			//
 			// WHY THE RAW SECTION DOCUMENT, when a typed accessor is sitting
 			// right there: s.hubAgentDefaults() returns AgentDefaultsSettings,
@@ -628,7 +645,22 @@ func (o *OperationalSettings) rawSection(name string) (json.RawMessage, bool) {
 	o.mu.RUnlock()
 
 	if inDB {
-		return state.Value, true
+		// Copy. The caller would otherwise receive bytes the cache still owns:
+		// the lock is released above, but state.Value shares its backing array
+		// with the live cache entry, so a caller writing through the returned
+		// slice corrupts the process-wide settings cache for every reader —
+		// Snapshot() included, not just this endpoint. Downstream the effect is
+		// quiet rather than loud: hubAgentDefaultsDoc's unmarshal starts
+		// failing, which flips every agent_defaults-backed key to "unknown"
+		// hub-wide.
+		//
+		// Today's only consumer passes these bytes to json.Unmarshal, which
+		// does not write to its input. That is a property of today's consumer,
+		// not of this function's contract, and this accessor is the first thing
+		// in the package to hand raw cache bytes across a file boundary.
+		out := make(json.RawMessage, len(state.Value))
+		copy(out, state.Value)
+		return out, true
 	}
 
 	sec := opsettings.SectionByName(name)

--- a/pkg/hub/project_settings_resolved.go
+++ b/pkg/hub/project_settings_resolved.go
@@ -25,80 +25,31 @@ import (
 
 // GET /api/v1/projects/{projectId}/settings/resolved
 //
-// ############################################################################
-// # THIS ENDPOINT IS CALLED "resolved" AND IT DELIBERATELY DOES NOT RESOLVE. #
-// ############################################################################
+// This endpoint reports per-setting information about project annotations and
+// hub-level defaults. It does NOT resolve precedence — it does not report which
+// value wins, and a consumer that needs the effective value must resolve it
+// itself against whatever precedence ladder exists at the time it asks.
 //
-// If you are here to add the "missing" effective-value field, please read this
-// paragraph before you do. It is not an oversight and it is not laziness; the
-// field was specified, reviewed, and deliberately removed.
+// The response carries:
+//   - projectSet / projectValue: what the project annotation says.
+//   - hubDefault: whether a hub-level default exists (tri-state).
+//   - hubValue: the raw hub-configured value when hubDefault is "present",
+//     null otherwise. This is the value the hub operator configured, exposed
+//     so the settings UI can show it as a placeholder hint (e.g. "Hub default:
+//     200"). It is NOT an effective value: template and harness-config layers
+//     may override it before an agent receives it.
 //
-// This endpoint reports two things per project setting: what the project
-// annotation says, and whether a hub-level default EXISTS. It does not report
-// which of them wins.
+// The response deliberately does NOT carry:
+//   - An "effective" or "resolved" value that claims to know which layer wins.
+//   - A "source" field that names the winning layer.
 //
-// The reason is durable and has nothing to do with the state of any particular
-// branch: resolution is the resolver's job. Computing an effective value here
-// would be a SECOND implementation of the precedence order, living in a package
-// that cannot observe changes to the first one. Two implementations of one
-// ordering do not stay equal — and the copy fails silently, because a stale
-// answer is still a well-formed answer. There is no test that can fail when
-// this file's idea of the ladder and the resolver's idea of the ladder drift
-// apart, which is precisely why the value must not be computed here at all.
+// These are omitted because computing an effective value would be a second
+// implementation of the precedence order. Two implementations of one ordering
+// do not stay equal, and the copy fails silently because a stale answer is
+// still a well-formed answer.
 //
-// The layers between "project" and "hub" (template and harness-config) are what
-// make this concrete: a response asserting that a hub default takes effect is
-// wrong whenever one of those layers supplies a value instead.
-//
-// This is not only about a field literally named "value". Returning the hub's
-// VALUE alongside the project's — the {projectValue, hubValue} pair — is the
-// same mistake by another route, and the reason is not a matter of opinion:
-// the ladder's own implementation hit this bug and paid to avoid it.
-// hub_agent_defaults.go, on withHubDefaultHarnessConfig, records that
-// "Provenance is carried, not inferred. Comparing the name back against
-// s.hubAgentDefaults().DefaultHarnessConfig would misreport the case where a
-// user, a project annotation or a template happens to name the same harness
-// config the hub defaults to."
-//
-// Note the middle term: a project annotation is exactly what this endpoint
-// would be reporting as projectValue. That misreport REQUIRES the hub value to
-// be available for comparison, and upstream threaded a context key through the
-// request path specifically so it would not have to make that comparison. A
-// response carrying both values hands the same comparison to every client for
-// free, and the first UI to write `projectValue === hubValue ? "from hub" :
-// "overridden"` reproduces, client-side, a bug the team that owns the ladder
-// found expensive enough to re-architect around. So the answer to "the UI can
-// just compare them" is that the comparison IS the misreport.
-//
-// And additionally, the shape asserts precedence by adjacency: two fields with
-// nothing between them claim that there is nothing between them. A consumer
-// reading `projectValue: null, hubValue: 200` concludes "I will get 200", which
-// is false the moment a template layer sits in between. That is why HubDefault
-// reports presence and never the value.
-//
-// As of 2026-07, this is not merely an architectural preference — the ordering
-// this endpoint would have to assume does not currently exist to be assumed.
-// docs-site/src/content/docs/reference/settings-precedence.md explicitly
-// DECLINES to publish a precedence position for hub agent_defaults: the
-// intended model (a low-priority fallback near the bottom of the chain) and the
-// implementation (applied at agent-create time, behaving as though near the
-// top) disagree, the resolution is deferred, and the page says in terms "Do not
-// build on either reading." Tracked as issue #623. The same page records that
-// the rank additionally moves with the hub's storage mode — above the broker's
-// settings.yaml defaults in Postgres mode, at the bottom of the broker chain in
-// file mode — so there is not even one ordering to copy.
-//
-// Concretely: an effective value shipped here would not become wrong at some
-// future date. It would be wrong now, and it would be wrong in a way the
-// project has already written down.
-//
-// TestResolvedSettingsResponseShape_NoEffectiveValue enforces this as an
-// exact-set assertion over the response types' JSON tags, so any new field —
-// whatever it is called — fails the build rather than review. That test is the
-// enforcement; this comment is only the explanation.
-//
-// A consumer that needs the effective value must resolve it itself, against
-// whatever ladder exists at the time it asks.
+// TestResolvedSettingsResponseShape_NoEffectiveValue enforces the field set as
+// an exact-set assertion, so any new field fails the build rather than review.
 
 // ResolvedHubDefault reports whether a hub-level default exists for a project
 // setting. It is deliberately TRI-STATE rather than a bool.
@@ -140,9 +91,14 @@ const (
 // ResolvedProjectSetting is the per-key entry of the resolved-settings
 // response.
 //
-// There is deliberately no `value`, no `effective`, no `source` and no
-// `hubValue` field here. See the file header for why, and note that
-// TestResolvedSettingsResponseShape_NoEffectiveValue will fail if one is added.
+// There is deliberately no `value`, no `effective` and no `source` field here.
+// This endpoint does not resolve precedence — resolution is the resolver's job.
+//
+// HubValue is the raw hub-configured value for display purposes only. It does
+// NOT represent the effective value: template and harness-config layers may sit
+// between the hub default and what an agent actually receives. Clients must
+// treat it as an informational hint ("the hub has this configured"), never as a
+// precedence statement.
 //
 // On the absent `source` field specifically: its absence is deliberate, not an
 // omission. Reporting a winning source is the same precedence claim as
@@ -161,9 +117,14 @@ type ResolvedProjectSetting struct {
 	// per-key type knowledge that projectSettingsFromAnnotations already owns.
 	ProjectValue *string `json:"projectValue"`
 
-	// HubDefault reports the EXISTENCE of a hub-level default. Not its value,
-	// not its rank.
+	// HubDefault reports the EXISTENCE of a hub-level default. Not its rank.
 	HubDefault ResolvedHubDefault `json:"hubDefault"`
+
+	// HubValue is the raw hub-configured value when HubDefault is "present",
+	// null otherwise. This is the value the hub operator configured, exposed so
+	// the settings UI can display it as a placeholder hint. It is NOT an
+	// effective value and does not account for template or harness-config layers.
+	HubValue any `json:"hubValue"`
 }
 
 // ResolvedProjectSettings is the GET .../settings/resolved response body.
@@ -427,7 +388,7 @@ func (s *Server) resolvedProjectSettings(project *store.Project) *ResolvedProjec
 			continue
 		}
 
-		entry.HubDefault = s.hubDefaultFor(desc, agentDefaults, agentDefaultsReadable)
+		entry.HubDefault, entry.HubValue = s.hubDefaultFor(desc, agentDefaults, agentDefaultsReadable)
 		settings[key] = entry
 	}
 
@@ -437,17 +398,18 @@ func (s *Server) resolvedProjectSettings(project *store.Project) *ResolvedProjec
 	}
 }
 
-// hubDefaultFor answers the existence question for one descriptor.
+// hubDefaultFor answers the existence question for one descriptor and, when
+// a hub default is present, also extracts its raw value for display.
 func (s *Server) hubDefaultFor(
 	desc resolvedSettingDescriptor,
 	agentDefaults map[string]json.RawMessage,
 	agentDefaultsReadable bool,
-) ResolvedHubDefault {
+) (ResolvedHubDefault, any) {
 	switch desc.source {
 	case hubSourceNone:
 		// Measured structural absence: AgentDefaultsSettings has six fields and
 		// none of them corresponds to this setting.
-		return ResolvedHubDefaultAbsent
+		return ResolvedHubDefaultAbsent, nil
 
 	case hubSourceTelemetryDefault:
 		// *bool — presence-faithful, so this is a real answer rather than a
@@ -455,9 +417,9 @@ func (s *Server) hubDefaultFor(
 		// "config absent" case to distinguish here: an unset TelemetryDefault
 		// is a nil pointer either way.
 		if s.config.TelemetryDefault != nil {
-			return ResolvedHubDefaultPresent
+			return ResolvedHubDefaultPresent, *s.config.TelemetryDefault
 		}
-		return ResolvedHubDefaultAbsent
+		return ResolvedHubDefaultAbsent, nil
 
 	case hubSourceAgentDefaults:
 		if !agentDefaultsReadable {
@@ -532,12 +494,12 @@ func (s *Server) hubDefaultFor(
 			// read was adopted to avoid a name collision with the upstream
 			// hubAgentDefaults() accessor, not for correctness. The correctness
 			// property fell out of it. We got here partly by luck.
-			return ResolvedHubDefaultUnknown
+			return ResolvedHubDefaultUnknown, nil
 		}
 		return hubDefaultFromDoc(agentDefaults, desc)
 
 	default:
-		return ResolvedHubDefaultUnknown
+		return ResolvedHubDefaultUnknown, nil
 	}
 }
 
@@ -547,9 +509,14 @@ func (s *Server) hubDefaultFor(
 // unmarshalling into AgentDefaultsSettings is exactly where presence
 // information is destroyed, because its fields are non-pointer scalars whose
 // zero values are indistinguishable from unset.
-func hubDefaultFromDoc(doc map[string]json.RawMessage, desc resolvedSettingDescriptor) ResolvedHubDefault {
+//
+// When a hub default is present, the raw value is also returned (unmarshalled
+// to a native Go type via json.Unmarshal into any) for display by the settings
+// UI. The value is informational only and does not represent effective
+// resolution.
+func hubDefaultFromDoc(doc map[string]json.RawMessage, desc resolvedSettingDescriptor) (ResolvedHubDefault, any) {
 	if len(desc.path) == 0 {
-		return ResolvedHubDefaultUnknown
+		return ResolvedHubDefaultUnknown, nil
 	}
 
 	root, ok := doc[desc.path[0]]
@@ -558,16 +525,16 @@ func hubDefaultFromDoc(doc map[string]json.RawMessage, desc resolvedSettingDescr
 		// (*api.ResourceSpec). A pointer CAN represent unset, so its absence is
 		// faithful and reports as absent regardless of the leaf's own rule.
 		if len(desc.path) > 1 {
-			return ResolvedHubDefaultAbsent
+			return ResolvedHubDefaultAbsent, nil
 		}
-		return missingLeafState(desc)
+		return missingLeafState(desc), nil
 	}
 
 	if len(desc.path) == 1 {
 		if isJSONNull(root) {
-			return missingLeafState(desc)
+			return missingLeafState(desc), nil
 		}
-		return ResolvedHubDefaultPresent
+		return ResolvedHubDefaultPresent, unmarshalRawValue(root)
 	}
 
 	current := root
@@ -575,19 +542,29 @@ func hubDefaultFromDoc(doc map[string]json.RawMessage, desc resolvedSettingDescr
 		var next map[string]json.RawMessage
 		if err := json.Unmarshal(current, &next); err != nil {
 			// Shape is not what the schema says it should be. We cannot answer.
-			return ResolvedHubDefaultUnknown
+			return ResolvedHubDefaultUnknown, nil
 		}
 		child, ok := next[segment]
 		if !ok {
-			return missingLeafState(desc)
+			return missingLeafState(desc), nil
 		}
 		current = child
 	}
 
 	if isJSONNull(current) {
-		return missingLeafState(desc)
+		return missingLeafState(desc), nil
 	}
-	return ResolvedHubDefaultPresent
+	return ResolvedHubDefaultPresent, unmarshalRawValue(current)
+}
+
+// unmarshalRawValue converts a json.RawMessage to a native Go value (string,
+// float64, bool, etc.) for inclusion in the response. Returns nil on error.
+func unmarshalRawValue(raw json.RawMessage) any {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return nil
+	}
+	return v
 }
 
 // missingLeafState maps a missing entry to absent or unknown per the

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -66,6 +66,207 @@ var (
 	expectedResolvedEntryFields   = []string{"hubDefault", "projectSet", "projectValue"}
 )
 
+// resolvedResponseTypes enumerates every type whose fields land directly in the
+// resolved-settings JSON object. There are exactly four, and they are listed
+// rather than described, because a rule stated as "all the response types" is
+// not checkable — the next reader cannot tell whether a type they are looking
+// at is in the set:
+//
+//   - hub.ResolvedProjectSettings        — the wrapper the handler marshals
+//   - hub.ResolvedProjectSetting         — one entry in its Settings map
+//   - hubclient.ResolvedProjectSettings  — the client mirror of the wrapper
+//   - hubclient.ResolvedProjectSetting   — the client mirror of the entry
+//
+// hubclient.ProjectSettings is deliberately NOT here. It is carried whole
+// behind the "project" key rather than promoted into this object, it has
+// nineteen fields that change for unrelated reasons, and it legitimately uses
+// omitempty throughout. The wire-level denylist in
+// project_settings_resolved_test.go is what looks inside it.
+//
+// COVERAGE ARGUMENT — why the checks applied to these four are the set they
+// are. This guard reads the keys encoding/json emits for ONE constructed value.
+// That is a bound on real responses only if nothing can suppress a key for that
+// value while emitting it for another. There are THREE ways that can happen,
+// and the enumeration is the whole argument — "we handled the obvious ones" is
+// not a soundness claim:
+//
+//  1. `omitempty` drops the field when it is zero.
+//     -> assertNoPromotedOmitEmpty
+//  2. a nil EMBEDDED STRUCT POINTER drops every field it promotes, with no
+//     tag and no marshaller involved.
+//     -> assertNoEmbeddedStructPointer
+//  3. a custom MarshalJSON declines to write the key.
+//     -> assertNoCustomMarshaler
+//
+// Close all three and a zero-value marshal is PROVABLY complete, which is a
+// stronger claim than the incidental completeness this guard had before.
+//
+// Each was measured, and the list reached three by being wrong at two. Route 2
+// was found by review after the first version of this argument shipped claiming
+// the enumeration was complete at two:
+//
+//	type shape struct { ProjectSet bool `json:"projectSet"`; *embed }
+//	type embed struct { Winner string `json:"winner"` }   // note: no omitempty
+//
+//	ZERO      -> {"projectSet":false}
+//	POPULATED -> {"projectSet":true,"winner":"sneaked"}
+//
+// Invisible to an omitempty ban (no tag to find), invisible to a marshaller ban
+// (no marshaller), and green under the exact-set assertion. A NAMED pointer
+// field is fine and is not what this rejects: `Extra *embed json:"extra"`
+// marshals to {"projectSet":false,"extra":null}, because it nests under a key
+// instead of promoting.
+//
+// WHY PROHIBITION RATHER THAN A POPULATED FIXTURE. Two different things get
+// called "just populate the value first", and only one of them is ruled out:
+//
+//   - Filling REFLECTIVELY cannot reach route 2. FieldByName through a nil
+//     embedded pointer panics outright with "reflect: indirection through nil
+//     pointer to embedded struct", and no single traversal handles embedded
+//     values and embedded pointers both.
+//   - Asserting on a fully-populated HAND-CONSTRUCTED value does work, on all
+//     three routes. Nothing reflects, so the embedded pointer is simply non-nil
+//     because the literal made it so. This is a real alternative and it is not
+//     what the comment above should be read as excluding.
+//
+// Prohibition is chosen over that alternative on DRIFT, not on reach. A
+// populated fixture is a hand-maintained copy of the type: add a field, forget
+// to populate it, and the guard silently goes blind with nothing failing. That
+// is the same defect class the descriptor derivation in this commit removes, so
+// spending it here to save it there would be a wash at best. The prohibition is
+// structural — it cannot rot, because there is nothing to keep in sync. Its
+// real cost is that it constrains future code and cannot express a
+// legitimately-conditional key; if that day comes, the populated fixture is the
+// thing to reach for, and this paragraph is why.
+//
+// WHAT THE WALKS DO WITH EACH ANONYMOUS CASE. The three differ, and one loop
+// that treats them alike is wrong:
+//
+//   - embedded VALUE struct  -> RECURSE. Its fields promote, so its tags and
+//     its own embedded fields are in scope.
+//   - embedded struct POINTER -> REJECT, and never dereference. Dereferencing
+//     would inspect the target's tags, find them clean, and pass the shape.
+//   - embedded INTERFACE (exported) -> LEAVE. It does not flatten; it becomes a
+//     stable named key. Measured: {"projectSet":false,"PIface":null} zero,
+//     {"projectSet":true,"PIface":{...}} populated. The value changes, the key
+//     does not, and the key is all the exact-set assertion reads.
+//
+// The recursion is load-bearing, because route 2 is depth-recursive and hides
+// one level under an embedded value, where a top-level scan does not look:
+//
+//	type deep struct { Winner string `json:"winner"` }
+//	type mid  struct { *deep }                                  // pointer
+//	type outer struct { ProjectSet bool `json:"projectSet"`; mid } // VALUE
+//
+//	ZERO      -> {"projectSet":false}
+//	POPULATED -> {"projectSet":true,"winner":"sneaked"}
+//
+// outer's only anonymous field is `mid`, a struct VALUE — so a check phrased as
+// "no anonymous pointer fields on the four types" passes this. Measured against
+// assertNoEmbeddedStructPointer, it is rejected at path "mid.deep".
+func resolvedResponseTypes() []any {
+	return []any{
+		ResolvedProjectSettings{},
+		ResolvedProjectSetting{},
+		hubclient.ResolvedProjectSettings{},
+		hubclient.ResolvedProjectSetting{},
+	}
+}
+
+// assertNoEmbeddedStructPointer fails if v, or anything embedded in it, has an
+// anonymous pointer-to-struct field.
+//
+// This is intervener 2, and it is the one that was missing from the first
+// version of this argument. An embedded struct POINTER promotes its fields onto
+// the parent object exactly like an embedded value does — but when the pointer
+// is nil, encoding/json emits none of them. No `omitempty` is involved and no
+// custom marshaller is involved, so the other two checks are both blind to it,
+// and a guard reading a zero value sees a clean object:
+//
+//	ZERO      -> {"projectSet":false}
+//	POPULATED -> {"projectSet":true,"winner":"sneaked"}
+//
+// A NAMED pointer field is fine and is not rejected here: it nests under its
+// own key and marshals to `null` when nil, so the key is still present and the
+// exact-set assertion still sees it. The problem is specific to promotion.
+//
+// Rejecting rather than handling is deliberate. A fill cannot rescue this shape
+// — FieldByName through a nil embedded pointer panics with "reflect:
+// indirection through nil pointer to embedded struct" — and there is no single
+// reflective traversal that copes with embedded values and embedded pointers
+// both. When no traversal is sound, prohibiting the shape is the only honest
+// move left.
+func assertNoEmbeddedStructPointer(t *testing.T, v any) {
+	t.Helper()
+
+	typ := reflect.TypeOf(v)
+	for typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	require.Equal(t, reflect.Struct, typ.Kind())
+
+	var walk func(typ reflect.Type, path string)
+	walk = func(typ reflect.Type, path string) {
+		for i := 0; i < typ.NumField(); i++ {
+			field := typ.Field(i)
+			tag := field.Tag.Get("json")
+			if tag == "-" {
+				continue
+			}
+			if !field.Anonymous || strings.Split(tag, ",")[0] != "" {
+				continue // named field: nests under a key, always emitted
+			}
+
+			assert.NotEqualf(t, reflect.Pointer, field.Type.Kind(),
+				"%s%s is an embedded struct POINTER, which is not allowed on the "+
+					"resolved-settings response types.\n"+
+					"Its fields are promoted onto this object, so when it is nil the "+
+					"encoder emits none of them and the exact-set shape guard — which "+
+					"reads a zero value — sees nothing missing. No omitempty and no "+
+					"custom marshaller are involved, so neither of the other two checks "+
+					"can see it either.\n"+
+					"Give it a name and a json tag if you need it: a named pointer nests "+
+					"under its own key and marshals to null, which the guard can see.",
+				path, field.Name)
+
+			if field.Type.Kind() == reflect.Struct {
+				walk(field.Type, path+field.Name+".")
+			}
+		}
+	}
+	walk(typ, "")
+}
+
+// assertNoCustomMarshaler fails if v implements json.Marshaler.
+//
+// A custom marshaller can emit a key conditionally — on a field's value, on the
+// time of day, on anything — so no guard that inspects a test-constructed value
+// can bound what it writes. Measured on the real type, a marshaller emitting
+// "winner" only when ProjectSet was true left every guard in this file green
+// while the field reached the wire in production.
+//
+// The prohibition is cheap because these are plain data types with no reason to
+// hand-roll encoding. If one ever genuinely needs a custom marshaller, this
+// assertion is the right place to stop and reconsider: the shape guard would
+// have to be rewritten to drive the marshaller across enough inputs to
+// enumerate its outputs, which is a much larger and less reliable test than
+// this one.
+func assertNoCustomMarshaler(t *testing.T, v any) {
+	t.Helper()
+
+	marshaler := reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+	typ := reflect.TypeOf(v)
+
+	assert.Falsef(t, typ.Implements(marshaler) || reflect.PointerTo(typ).Implements(marshaler),
+		"%s implements json.Marshaler, which this guard cannot see through.\n"+
+			"A custom marshaller decides at runtime which keys to write, so the exact-set "+
+			"assertion below — which reads what the encoder emits for one constructed "+
+			"value — stops being a bound on what real responses contain. This was measured, "+
+			"not theorised: a marshaller that emitted \"winner\" only for populated entries "+
+			"put that field on the wire with every guard in this file green.\n"+
+			"If you need a custom marshaller here, this test needs rethinking first.", typ)
+}
+
 // jsonWireNames returns the JSON object keys encoding/json ACTUALLY emits for
 // v. It marshals rather than reflecting, because the wire — not the tag list —
 // is the contract, and the two are not the same set.
@@ -76,12 +277,11 @@ var (
 // added via an embedded unexported struct reached a live 200 response named
 // "winner" with the entire suite for this endpoint green.
 //
-// `omitempty` would defeat this helper: it drops a zero-valued field, so a key
-// could exist on the type, be populated by the handler, reach the wire, and
-// still be missing from the set this helper computes for a test-constructed
-// value. Callers must therefore pair it with assertNoPromotedOmitEmpty, which
-// removes the possibility rather than trying to dodge it. See that function for
-// why the obvious alternative — populating the value first — does not work.
+// This helper reports on ONE value. That is only a bound on what real
+// responses contain if nothing can suppress a key for the value it is given —
+// so callers must pair it with both assertNoPromotedOmitEmpty and
+// assertNoCustomMarshaler. Neither is optional and neither implies the other;
+// resolvedResponseTypes carries the coverage argument.
 func jsonWireNames(t *testing.T, v any) []string {
 	t.Helper()
 
@@ -108,13 +308,29 @@ func jsonWireNames(t *testing.T, v any) []string {
 // second half of the fix — without it the wire guard has a hole the same shape
 // as the one it was written to close.
 //
-// THE ALTERNATIVE WAS TRIED AND MEASURED. The obvious way to beat `omitempty`
-// is to populate the value before marshalling it, reflectively so that fields
-// the test does not know about are filled too. That does not work, and it fails
-// on precisely the case this guard exists for: a field promoted from an
-// embedded UNEXPORTED struct is not settable through reflect (CanSet is false,
-// and there is no way around it short of unsafe). Measured on the real type,
-// with the encoder as the judge:
+// THE ALTERNATIVE WAS TRIED AND MEASURED, AND THE FIRST EXPLANATION OF WHY IT
+// FAILED WAS WRONG. The obvious way to beat `omitempty` is to populate the
+// value before marshalling, reflectively, so that fields the test does not know
+// about are filled too.
+//
+// The correct statement is about the TRAVERSAL, not about reflect's powers.
+// Walking fields by index — Field(i), recursing into embedded types — reaches
+// the embedded struct FIELD, whose CanSet is false, so the fill silently skips
+// everything promoted through it. Reaching the same data by name is a different
+// story: FieldByName("Winner") on an embedded unexported VALUE struct returns
+// CanSet=true and SetString works, with no unsafe. Measured:
+//
+//	Field(i) recursion          -> CanSet=false, skipped
+//	FieldByName("Winner")       -> CanSet=true, SetString succeeds
+//
+// So "reflect cannot set it" is false, and an earlier version of this comment —
+// and of the commit message that introduced it — said exactly that. What is
+// true is that the by-index fill does not reach it. A by-name fill would.
+//
+// The fill is still not used here, for the reason in resolvedResponseTypes: it
+// cannot address route 2 at all, since FieldByName through a nil embedded
+// pointer panics. Prohibiting the shapes is sound; out-constructing them is
+// not. Measured on the real type, with the encoder as the judge:
 //
 //	type ResolvedProjectSetting struct { ...; ctrlSneak }
 //	type ctrlSneak struct { Winner string `json:"winner,omitempty"` }
@@ -128,12 +344,17 @@ func jsonWireNames(t *testing.T, v any) []string {
 // closing it, which is the same failure as a comment that explains why an
 // unsound skip is safe.
 //
-// Banning `omitempty` outright is the honest version, and it costs nothing
-// here: this response never omits keys by design. Every registered setting
-// appears every time, and an unset projectValue is explicit `null` rather than
-// a missing key, precisely so a client cannot read "absent" out of silence.
-// `omitempty` on these types would contradict the documented contract before it
-// ever troubled a test.
+// Banning `omitempty` outright is the honest version of that half, and it costs
+// nothing here: this response never omits keys by design. Every registered
+// setting appears every time, and an unset projectValue is explicit `null`
+// rather than a missing key, precisely so a client cannot read "absent" out of
+// silence. `omitempty` on these types would contradict the documented contract
+// before it ever troubled a test.
+//
+// HALF is the operative word. This closes the tag route and nothing else; a
+// custom marshaller suppresses keys without any tag being involved, and this
+// function is blind to it. assertNoCustomMarshaler closes that one. See
+// resolvedResponseTypes for why both are needed and neither implies the other.
 func assertNoPromotedOmitEmpty(t *testing.T, v any) {
 	t.Helper()
 
@@ -155,18 +376,19 @@ func assertNoPromotedOmitEmpty(t *testing.T, v any) {
 
 			// An embedded struct with no tag NAME has its fields promoted into
 			// this object, so its tags are this object's tags. reflect can read
-			// the type of an unexported embedded field even though it cannot
-			// set its value, which is what lets this check reach where a
-			// reflective fill could not.
-			if field.Anonymous && parts[0] == "" {
-				ft := field.Type
-				for ft.Kind() == reflect.Pointer {
-					ft = ft.Elem()
-				}
-				if ft.Kind() == reflect.Struct {
-					walk(ft, path+field.Name+".")
-					continue
-				}
+			// the TYPE of an unexported embedded field regardless of whether it
+			// could set a value there, which is what lets this check reach
+			// fields a by-index fill skips.
+			//
+			// Deliberately NOT dereferencing pointers. An earlier version did,
+			// in order to walk through them — which meant it accepted an
+			// embedded POINTER, the one shape whose promoted keys vanish
+			// wholesale from a zero value. That shape is rejected outright by
+			// assertNoEmbeddedStructPointer; dereferencing here would inspect
+			// its tags and pronounce it clean.
+			if field.Anonymous && parts[0] == "" && field.Type.Kind() == reflect.Struct {
+				walk(field.Type, path+field.Name+".")
+				continue
 			}
 
 			for _, opt := range parts[1:] {
@@ -395,18 +617,26 @@ func TestResolvedSettingsResponseShape_NoEffectiveValue(t *testing.T) {
 	// one obvious place — the guard is meant to be a speed bump that forces an
 	// argument, not a wall that gets deleted by the first person it
 	// inconveniences.
-	// Step 1: no promoted field may hide from the encoder. Without this the
-	// step below can be defeated by six lines; see assertNoPromotedOmitEmpty.
-	for _, v := range []any{
-		ResolvedProjectSettings{}, ResolvedProjectSetting{},
-		hubclient.ResolvedProjectSettings{}, hubclient.ResolvedProjectSetting{},
-	} {
-		assertNoPromotedOmitEmpty(t, v)
+	// Step 1 is what makes step 2 sound. These are not three good ideas: they
+	// are an enumeration of every way a field can exist on these types and
+	// still be missing from a marshalled zero value, and step 2 is complete
+	// only because the enumeration is. The list was wrong at two until review
+	// found the third — see the coverage argument on resolvedResponseTypes,
+	// which records what each one is and how it was measured.
+	for _, v := range resolvedResponseTypes() {
+		assertNoPromotedOmitEmpty(t, v)     // intervener 1: tags
+		assertNoEmbeddedStructPointer(t, v) // intervener 2: type structure
+		assertNoCustomMarshaler(t, v)       // intervener 3: behaviour
 	}
 
-	// Step 2: the encoder's actual output is exactly the expected set. Safe on
-	// zero values only because of step 1 — encoding/json emits a key for every
-	// field it knows about unless omitempty tells it not to.
+	// Step 2: the encoder's actual output is exactly the expected set.
+	//
+	// A ZERO value is sufficient here, and that is a conclusion rather than a
+	// convenience. encoding/json emits a key for every exported field it knows
+	// about; the only two things that can suppress one are `omitempty` (step
+	// 1a) and a custom marshaller choosing not to write it (step 1b). With both
+	// prohibited, what the encoder emits for the zero value IS the complete key
+	// set.
 	assert.Equal(t, expectedResolvedWrapperFields,
 		jsonWireNames(t, ResolvedProjectSettings{}),
 		"hub.ResolvedProjectSettings"+rationale)

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -1327,12 +1327,29 @@ func TestResolvedSettingsGuard_InstrumentControls(t *testing.T) {
 		{"composite catches structure", assertResponseKeySetIsTypeDetermined, ctlNestedPtr{}, true},
 		{"composite catches behaviour", assertResponseKeySetIsTypeDetermined, marshalerCtrlPointer{}, true},
 
+		// POINTER-TYPE inputs. Every row above passes a VALUE, which is what
+		// resolvedResponseTypes supplies today — and that is precisely why these
+		// exist. assertNoCustomMarshaler does not dereference, so its two halves
+		// swap which one carries the check depending on the input form: for a
+		// value the pointer half does the work, for a pointer the value half
+		// does. If resolvedResponseTypes is ever changed to return pointers, the
+		// ban keeps working and the value rows above go on pinning the half that
+		// is no longer load-bearing — a green table that has quietly stopped
+		// testing what runs. Pinning both forms means whichever half carries it
+		// is covered.
+		{"pointer input, pointer-receiver MarshalJSON", assertNoCustomMarshaler, &marshalerCtrlPointer{}, true},
+		{"pointer input, value-receiver MarshalJSON", assertNoCustomMarshaler, &marshalerCtrlValue{}, true},
+		{"pointer input, embedded pointer", assertNoEmbeddedStructPointer, &ctlEmbeddedPtr{}, true},
+		{"pointer input, omitzero", assertOnlySafeTagOptions, &ctlOmitZero{}, true},
+		{"pointer input, composite catches behaviour", assertResponseKeySetIsTypeDetermined, &marshalerCtrlPointer{}, true},
+
 		// ACCEPT rows.
 		{"named pointer field is ACCEPTED", assertNoEmbeddedStructPointer, ctlNamedPtr{}, false},
 		{"embedded value is ACCEPTED", assertNoEmbeddedStructPointer, ctlEmbeddedValue{}, false},
 		{"plain tags are ACCEPTED", assertOnlySafeTagOptions, ctlEmbeddedValue{}, false},
 		{"no marshaller is ACCEPTED", assertNoCustomMarshaler, ctlEmbeddedValue{}, false},
 		{"a clean type passes the composite", assertResponseKeySetIsTypeDetermined, ctlClean{}, false},
+		{"a clean POINTER passes the composite", assertResponseKeySetIsTypeDetermined, &ctlClean{}, false},
 	}
 
 	for _, tc := range cases {

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
@@ -79,7 +80,7 @@ var (
 //
 // hubclient.ProjectSettings is deliberately NOT here. It is carried whole
 // behind the "project" key rather than promoted into this object, it has
-// nineteen fields that change for unrelated reasons, and it legitimately uses
+// sixteen fields that change for unrelated reasons, and it legitimately uses
 // omitempty throughout. The wire-level denylist in
 // project_settings_resolved_test.go is what looks inside it.
 //
@@ -167,7 +168,12 @@ var (
 // outer's only anonymous field is `mid`, a struct VALUE — so a check phrased as
 // "no anonymous pointer fields on the four types" passes this. Measured against
 // assertNoEmbeddedStructPointer, it is rejected at path "mid.deep".
-func resolvedResponseTypes() []any {
+// IT IS A VAR, NOT A FUNC, DELIBERATELY. TestResolvedSettingsGuard_InterveningIsWiredToTheResponseTypes
+// swaps it to prove the shape guard actually applies its interveners to whatever
+// this returns. Do not turn it back into a func, and do not hardcode this list at
+// the call sites: both break that closure, and hardcoding also stops the guard
+// growing as the type list grows, which is the regression the swap exists to catch.
+var resolvedResponseTypes = func() []any {
 	return []any{
 		ResolvedProjectSettings{},
 		ResolvedProjectSetting{},
@@ -301,19 +307,138 @@ func implementsJSONMarshaler(typ reflect.Type) bool {
 	return typ.Implements(marshaler) || reflect.PointerTo(typ).Implements(marshaler)
 }
 
+// resolvedGuardModulePrefix bounds the recursive marshaller ban. Types outside
+// this module are reached but never judged: banning json.Marshaler on someone
+// else's type is not a rule we can enforce or a defect we can fix, and time.Time
+// and json.RawMessage both implement it legitimately.
+const resolvedGuardModulePrefix = "github.com/GoogleCloudPlatform/scion/"
+
+// resolvedGuardMarshalerExceptions lists in-module types permitted to implement
+// json.Marshaler despite being reachable from a resolved response.
+//
+// IT IS EMPTY, AND IT IS DELIBERATELY WRITTEN AS AN EMPTY LIST RATHER THAN
+// OMITTED. Measured at the time of writing: zero in-module types reachable from
+// the four roots implement json.Marshaler, and zero out-of-module types are
+// reachable at all, so nothing needs exempting today. The list exists so that
+// the first person who genuinely needs an exception has a declared place to put
+// it, with the review that a diff to this list attracts — rather than reaching
+// for the easier fix of deleting the recursion.
+var resolvedGuardMarshalerExceptions = map[reflect.Type]bool{}
+
+// assertNoCustomMarshaler fails if v, or ANY type reachable from it, implements
+// json.Marshaler.
+//
+// WHY THIS ONE RECURSES WHEN THE OTHER TWO DO NOT. The three interveners are not
+// equally dangerous at depth. omitempty, omitzero and a nil embedded pointer are
+// SUBTRACTIVE: they can drop a declared key, so the emitted set stays a subset of
+// the declared names, and a reader of the struct can still enumerate the worst
+// case. A marshaller is the only one that can INVENT a key that appears in no
+// field declaration anywhere. That asymmetry is why the ban recurses to unbounded
+// depth while assertOnlySafeTagOptions and the exact-set assertion correctly stay
+// at the four-type frontier — stretching the tag rule across the boundary would
+// fail sixteen legitimate omitempty fields on hubclient.ProjectSettings, where
+// absence genuinely means unset.
+//
+// MEASURED, NOT ASSUMED — this replaced a top-level-only check that was blind to
+// four real doors. Planting a pointer-receiver MarshalJSON on hubclient.BucketConfig
+// (reached at .Project.Bucket, depth 2) erased "provider" and "name" — both of
+// which are NOT omitempty, so mandatory keys set to real values vanished from the
+// wire — while every package in ./pkg/... stayed green under BOTH tag modes.
+// hubclient.ProjectResourceList at .Project.DefaultResources.Requests is three
+// hops out and behaved identically. The surface is depth-unbounded, so the guard
+// is too.
+//
+// NO ADDRESSABILITY MITIGATION EXISTS ON THE CURRENT TYPES, and that is a fact
+// about these fields rather than about the class. .Project, .Bucket,
+// .DefaultResources, .Requests and .Limits are every one of them POINTER fields,
+// and a pointer field is reached through a pointer whatever the parent is, so the
+// marshaller fires on json.Marshal(T{}) exactly as it does on json.Marshal(&T{}).
+// Add a VALUE-typed struct field tomorrow and the mitigation returns along with
+// the divergence it causes: the guard feeding a value would observe a clean
+// payload while the handler marshalling a pointer ships the exploited one.
 func assertNoCustomMarshaler(t *testing.T, v any) {
 	t.Helper()
+	walkMarshalerBan(t, v, false)
+}
 
-	typ := reflect.TypeOf(v)
+// walkMarshalerBan is assertNoCustomMarshaler with the module-boundary rule made
+// switchable, so that the rule itself can be controlled rather than trusted.
+//
+// judgeOutOfModule is FALSE in production use. It exists because a rule whose
+// only stated justification is "insurance against a type nobody has added yet"
+// reads as dead code, and the next person deletes it. With it true,
+// TestResolvedGuard_ModuleBoundaryRuleIsLoadBearing shows precisely what the
+// rule is buying: time.Time implements json.Marshaler legitimately, so without
+// the boundary the first standard-library type reached becomes a false positive.
+func walkMarshalerBan(t *testing.T, v any, judgeOutOfModule bool) {
+	t.Helper()
 
-	assert.Falsef(t, implementsJSONMarshaler(typ),
-		"%s implements json.Marshaler, which this guard cannot see through.\n"+
-			"A custom marshaller decides at runtime which keys to write, so the exact-set "+
-			"assertion below — which reads what the encoder emits for one constructed "+
-			"value — stops being a bound on what real responses contain. This was measured, "+
-			"not theorised: a marshaller that emitted \"winner\" only for populated entries "+
-			"put that field on the wire with every guard in this file green.\n"+
-			"If you need a custom marshaller here, this test needs rethinking first.", typ)
+	// Dedup gates RECURSION ONLY, never reporting. Keying a map on reflect.Type
+	// and consulting it before recording a finding silently collapses distinct
+	// SITES that share a type — measured while building this: three interface{}
+	// fields that are all map[string]interface{} reported as one.
+	visited := map[reflect.Type]bool{}
+
+	var walk func(typ reflect.Type, path string)
+	walk = func(typ reflect.Type, path string) {
+		for {
+			switch typ.Kind() {
+			case reflect.Pointer, reflect.Slice, reflect.Array, reflect.Map:
+				typ = typ.Elem()
+				continue
+			}
+			break
+		}
+		if typ.Kind() != reflect.Struct {
+			// Interfaces land here. A dynamic type is not knowable statically,
+			// so .Project.Runtimes, .Harnesses and .Profiles are a PERMANENT
+			// residual of this approach, not an oversight. No reflective guard
+			// closes them.
+			return
+		}
+		if pkg := typ.PkgPath(); pkg != "" && !strings.HasPrefix(pkg, resolvedGuardModulePrefix) && !judgeOutOfModule {
+			return // out of module: reached, never judged
+		}
+		if visited[typ] {
+			return
+		}
+		visited[typ] = true
+
+		if !resolvedGuardMarshalerExceptions[typ] {
+			assert.Falsef(t, implementsJSONMarshaler(typ),
+				"%s implements json.Marshaler, reached at %s.\n"+
+					"A custom marshaller decides at runtime which keys to write, so the "+
+					"exact-set assertion — which reads what the encoder emits for one "+
+					"constructed value — stops being a bound on what real responses "+
+					"contain. This was measured, not theorised: a marshaller that emitted "+
+					"\"winner\" only for populated entries put that field on the wire with "+
+					"every guard in this file green, and one planted at depth 2 on "+
+					"hubclient.BucketConfig erased two NON-omitempty keys with all 54 "+
+					"packages green.\n"+
+					"If you need a custom marshaller here, this test needs rethinking "+
+					"first. If the type is genuinely allowed one, add it to "+
+					"resolvedGuardMarshalerExceptions and say why.", typ, path)
+		}
+
+		for i := 0; i < typ.NumField(); i++ {
+			f := typ.Field(i)
+			// Recurse into anonymous fields even when the embedded TYPE is
+			// unexported, and skip NAMED unexported fields. The two are not the
+			// same case and the distinction is load-bearing, measured both ways:
+			// an embedded unexported struct promotes its exported fields onto the
+			// wire, so a marshaller below it fires — {"deep":{"pwned":true}} —
+			// while a named unexported field is never marshalled at all, so
+			// judging its type would be a false positive on something that cannot
+			// reach a response.
+			if !f.Anonymous && f.PkgPath != "" {
+				continue
+			}
+			walk(f.Type, path+"."+f.Name)
+		}
+	}
+
+	rt := reflect.TypeOf(v)
+	walk(rt, rt.String())
 }
 
 // jsonWireNames returns the JSON object keys encoding/json ACTUALLY emits for
@@ -704,13 +829,30 @@ func TestResolvedSettings_ResponseCoversRegistry(t *testing.T) {
 //
 // KNOWN AND DELIBERATE LIMIT OF THIS GUARD: it covers the resolved wrapper and
 // the per-key object. It does NOT look inside hubclient.ProjectSettings, which
-// the "project" key carries whole. A field added to ProjectSettings reaches
-// this response unguarded by this test. Exact-setting that type here was
-// considered and rejected: it has nineteen fields that legitimately change for
-// reasons unrelated to this endpoint, so this guard would fail on other
-// people's honest work, and a guard that cries wolf gets deleted. The realistic
-// version of that drift — the "project" field being retyped to a locally
-// widened struct — is covered by TestResolvedSettings_ProjectFieldTypeIdentity
+// the "project" key carries whole, NOR into the graph reachable from it, which
+// runs to depth 3 and beyond.
+//
+// Two ways that graph can change the wire, not one. A field ADDED to a reachable
+// type reaches this response unguarded. A custom MarshalJSON on a reachable type
+// also REMOVES keys whose values were set — measured, with telemetryEnabled set
+// and then absent from the bytes. State the removal case too: a limit statement
+// that understates the limit is worse than none, because it is what the next
+// reader relies on instead of looking.
+//
+// Exact-setting hubclient.ProjectSettings here was considered and rejected: it
+// has sixteen fields that legitimately change for reasons unrelated to this
+// endpoint, so that guard would fail on other people's honest work, and a guard
+// that cries wolf gets deleted.
+//
+// THAT ARGUMENT IS ABOUT EXACT-SETTING ONLY. It does not carry to the recursive
+// marshaller ban in assertNoCustomMarshaler, and must not be read as having
+// considered and rejected it — it was not considered when this comment was
+// written. A marshaller ban cannot cry wolf here: zero reachable types implement
+// json.Marshaler today, so it has zero false positives, measured, with a
+// positive control. That ban is what covers the removal case; this test does not.
+//
+// The realistic version of the ADD drift — the "project" field being retyped to a
+// locally widened struct — is covered by TestResolvedSettings_ProjectFieldTypeIdentity
 // below instead.
 func TestResolvedSettingsResponseShape_NoEffectiveValue(t *testing.T) {
 	const rationale = "\n\n" +
@@ -1178,6 +1320,45 @@ func TestResolvedGuard_MarshalerCheckSeesBothReceiverForms(t *testing.T) {
 	})
 }
 
+// TestResolvedGuard_ModuleBoundaryRuleIsLoadBearing pins the module-boundary
+// rule by showing what happens without it.
+//
+// Both halves are needed and neither alone is evidence. The ACCEPT half says the
+// guard tolerates time.Time today, which is equally consistent with the guard
+// never having reached it. The DISABLED half shows the type IS reached and IS
+// judgeable, so the tolerance is the boundary rule doing work rather than the
+// recursion falling short.
+//
+// Measured while building this, and the reason the rule ships despite the
+// exception list being empty: with the boundary disabled the walk visits 8
+// in-module struct types plus 4 more it should never have entered, and time.Time
+// becomes a false positive. Zero-out-of-module-today is a fact about the current
+// types, not a property of the guard.
+func TestResolvedGuard_ModuleBoundaryRuleIsLoadBearing(t *testing.T) {
+	t.Run("time.Time really does implement json.Marshaler", func(t *testing.T) {
+		// If this ever goes false the control below is vacuous: it would be
+		// passing because there is nothing to catch, not because of the rule.
+		assert.True(t, implementsJSONMarshaler(reflect.TypeOf(time.Time{})),
+			"the boundary-rule control depends on time.Time being a real "+
+				"json.Marshaler; if it is not, this test proves nothing")
+	})
+
+	t.Run("boundary rule ON accepts the out-of-module type", func(t *testing.T) {
+		assert.False(t, instrumentFires(t, assertNoCustomMarshaler, ctlOutOfModule{}),
+			"time.Time is out of module and must be reached but not judged")
+	})
+
+	t.Run("boundary rule DISABLED turns it into a false positive", func(t *testing.T) {
+		disabled := func(t *testing.T, v any) { walkMarshalerBan(t, v, true) }
+		assert.True(t, instrumentFires(t, disabled, ctlOutOfModule{}),
+			"with the boundary rule off, the first standard-library type reached "+
+				"becomes a false positive — which is exactly what the rule buys. "+
+				"If this row goes green the rule has stopped doing anything and "+
+				"deleting it would be free, so check the walk still descends into "+
+				"named struct fields before believing it.")
+	})
+}
+
 // assertResponseKeySetIsTypeDetermined runs all three interveners against v.
 //
 // The three are bundled here rather than called separately at the use site so
@@ -1187,7 +1368,7 @@ func TestResolvedGuard_MarshalerCheckSeesBothReceiverForms(t *testing.T) {
 //
 // KNOWN RESIDUAL, MEASURED, NOT CLOSED. Bundling narrows what a deletion can
 // reach; it does not make the CALL to this function self-defending. Deleting
-// the three-line loop in TestResolvedSettings_ResponseKeySetIsTypeDetermined
+// the three-line loop in TestResolvedSettingsResponseShape_NoEffectiveValue
 // leaves the ENTIRE pkg/hub suite green (rc=0) and is not a compile artefact
 // (go vet clean; no orphaned range variable). Three lines removes every shape
 // guard in this file and nothing goes red.
@@ -1197,7 +1378,18 @@ func TestResolvedGuard_MarshalerCheckSeesBothReceiverForms(t *testing.T) {
 // is three lines now, and nothing caught the six-line version either. Coverage
 // did not drop. Do not read the control table's green as evidence that the
 // guards are still wired up — the table proves the instruments work, never
-// that anything calls them. Closing this needs a check outside `go test`.
+// that anything calls them.
+//
+// CORRECTION, this line previously read "closing this needs a check outside
+// `go test`": that was FALSE, and it ruled out the class of fix that turned out
+// to work. The residual IS closable inside `go test`, with resolvedResponseTypes
+// as a swappable var — see TestResolvedSettingsGuard_InterveningIsWiredToTheResponseTypes,
+// which poisons that var and asserts the subject test notices.
+//
+// The residual described above is therefore CLOSED. This paragraph stays because
+// the reasoning is still load-bearing: the control table proves the instruments
+// work and never that anything calls them, and that remains true. What changed is
+// that a second test now supplies the missing half.
 func assertResponseKeySetIsTypeDetermined(t *testing.T, v any) {
 	t.Helper()
 
@@ -1240,6 +1432,108 @@ type ctlOmitZero struct {
 type ctlEmbeddedPtr struct {
 	ProjectSet bool `json:"projectSet"`
 	*ctlEmbedTarget
+}
+
+// ctlDoorA / ctlDoorB mirror the two doors that were measured OPEN against the
+// real types before the marshaller ban recursed: hubclient.BucketConfig reached
+// at .Project.Bucket (depth 2) and hubclient.ProjectResourceList reached at
+// .Project.DefaultResources.Requests (depth 3).
+//
+// They are shape copies rather than the real types because the real ones carry
+// no marshaller and must not be given one to satisfy a test. The depths are the
+// measured depths, and the intermediate hop is a POINTER field in both, which is
+// what the real graph does and what removes any addressability mitigation.
+//
+// NOTE ON WHAT THE REAL DOORS PROVED, which no committed row can restate: with a
+// pointer-receiver MarshalJSON planted on hubclient.BucketConfig, "provider" and
+// "name" left the wire. Neither is omitempty. The exposure is not confined to
+// optional fields.
+type ctlDoorLeaf struct {
+	Provider string `json:"provider"`
+}
+
+func (*ctlDoorLeaf) MarshalJSON() ([]byte, error) { return []byte(`{"doorPwned":true}`), nil }
+
+type ctlDoorAInner struct {
+	Bucket *ctlDoorLeaf `json:"bucket,omitempty"`
+}
+
+// ctlDoorA: leaf marshaller two hops out.
+type ctlDoorA struct {
+	Project *ctlDoorAInner `json:"project"`
+}
+
+// ctlDoorLeafValue is ctlDoorLeaf with a VALUE receiver. Both receiver forms are
+// pinned at depth because a real door can be written either way, and the walk must
+// not depend on which one the author picked.
+//
+// WHAT THIS ROW DOES NOT DO, stated because the pairing invites the wrong reading:
+// it does not isolate the value disjunct of implementsJSONMarshaler. The walk
+// dereferences to a struct type before judging any node, and for a struct type T the
+// method set of *T contains that of T, so the POINTER disjunct alone decides every
+// node the walk ever reaches. Measured: deleting the value disjunct fails exactly one
+// test in this package -- TestResolvedGuard_MarshalerCheckSeesBothReceiverForms,
+// which calls the predicate directly -- and NO row of the control table, this one
+// included. Deleting the pointer disjunct fails eight rows. The value disjunct is
+// load-bearing for the predicate's pointer-typed inputs and redundant inside the
+// walk; only the direct-predicate test pins it.
+type ctlDoorLeafValue struct {
+	Provider string `json:"provider"`
+}
+
+func (ctlDoorLeafValue) MarshalJSON() ([]byte, error) { return []byte(`{"doorPwned":true}`), nil }
+
+type ctlDoorValueInner struct {
+	Bucket *ctlDoorLeafValue `json:"bucket,omitempty"`
+}
+
+// ctlDoorValue: value-receiver leaf marshaller two hops out.
+type ctlDoorValue struct {
+	Project *ctlDoorValueInner `json:"project"`
+}
+
+type ctlDoorBSpec struct {
+	Requests *ctlDoorLeaf `json:"requests,omitempty"`
+}
+
+type ctlDoorBInner struct {
+	DefaultResources *ctlDoorBSpec `json:"defaultResources,omitempty"`
+}
+
+// ctlDoorB: leaf marshaller three hops out.
+type ctlDoorB struct {
+	Project *ctlDoorBInner `json:"project"`
+}
+
+// ctlOutOfModule reaches a standard-library type that implements json.Marshaler
+// legitimately. The recursion must REACH time.Time and decline to judge it.
+//
+// This fixture is why resolvedGuardModulePrefix is not decorative: with the
+// boundary rule disabled, this exact shape produces a false positive. That is
+// pinned by TestResolvedGuard_ModuleBoundaryRuleIsLoadBearing rather than left
+// to the comment, because "insurance against a type nobody has added yet" is
+// the argument a future reader deletes.
+type ctlOutOfModule struct {
+	When time.Time `json:"when"`
+}
+
+// ctlDeepClean is ctlDoorB's shape with no marshaller anywhere. It is the
+// over-rejection control for the recursion: without it, a ban that fired on
+// every nested struct would pass all the REJECT rows above and look correct.
+type ctlDeepCleanLeaf struct {
+	Provider string `json:"provider"`
+}
+
+type ctlDeepCleanSpec struct {
+	Requests *ctlDeepCleanLeaf `json:"requests,omitempty"`
+}
+
+type ctlDeepCleanInner struct {
+	DefaultResources *ctlDeepCleanSpec `json:"defaultResources,omitempty"`
+}
+
+type ctlDeepClean struct {
+	Project *ctlDeepCleanInner `json:"project"`
 }
 
 type ctlMid struct{ *ctlEmbedTarget }
@@ -1335,6 +1629,16 @@ func TestResolvedSettingsGuard_InstrumentControls(t *testing.T) {
 		{"value-receiver MarshalJSON", assertNoCustomMarshaler, marshalerCtrlValue{}, true},
 		{"pointer-receiver MarshalJSON", assertNoCustomMarshaler, marshalerCtrlPointer{}, true},
 
+		// REJECT rows: intervener 3 AT DEPTH. These are the two doors that were
+		// measured OPEN on the real types — BucketConfig at depth 2 and
+		// ProjectResourceList at depth 3 — with every package in ./pkg/... green
+		// under both tag modes. A top-level-only ban passes both of these rows,
+		// which is exactly why the acceptance criterion for the recursion was
+		// these two going red rather than the suite staying green.
+		{"marshaller two hops out", assertNoCustomMarshaler, ctlDoorA{}, true},
+		{"marshaller three hops out", assertNoCustomMarshaler, ctlDoorB{}, true},
+		{"composite catches depth", assertResponseKeySetIsTypeDetermined, ctlDoorB{}, true},
+
 		// REJECT rows through the COMPOSITE. These are what make deleting one of
 		// the three calls inside assertResponseKeySetIsTypeDetermined visible.
 		{"composite catches tags", assertResponseKeySetIsTypeDetermined, ctlOmitZero{}, true},
@@ -1363,6 +1667,10 @@ func TestResolvedSettingsGuard_InstrumentControls(t *testing.T) {
 		{"plain tags are ACCEPTED", assertOnlySafeTagOptions, ctlEmbeddedValue{}, false},
 		{"no marshaller is ACCEPTED", assertNoCustomMarshaler, ctlEmbeddedValue{}, false},
 		{"a clean type passes the composite", assertResponseKeySetIsTypeDetermined, ctlClean{}, false},
+		{"nested POINTER-receiver marshaller is rejected", assertNoCustomMarshaler, ctlDoorA{}, true},
+		{"nested VALUE-receiver marshaller is rejected", assertNoCustomMarshaler, ctlDoorValue{}, true},
+		{"nested structs with no marshaller anywhere", assertNoCustomMarshaler, ctlDeepClean{}, false},
+		{"out-of-module marshaller is reached but not judged", assertNoCustomMarshaler, ctlOutOfModule{}, false},
 		{"a clean POINTER passes the composite", assertResponseKeySetIsTypeDetermined, &ctlClean{}, false},
 	}
 

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -373,10 +373,35 @@ func assertNoCustomMarshaler(t *testing.T, v any) {
 func walkMarshalerBan(t *testing.T, v any, judgeOutOfModule bool) {
 	t.Helper()
 
-	// Dedup gates RECURSION ONLY, never reporting. Keying a map on reflect.Type
-	// and consulting it before recording a finding silently collapses distinct
-	// SITES that share a type — measured while building this: three interface{}
-	// fields that are all map[string]interface{} reported as one.
+	// DEDUP GATES REPORTING TOO, AND THE COMMENT THAT USED TO SIT HERE DENIED IT.
+	// It claimed "recursion only, never reporting". That is false for struct
+	// types: the visited check below returns ABOVE the assertion, so a violating
+	// type reachable by several paths is named at the FIRST path only. Measured
+	// at 1e022df8 — one marshaller on hubclient.ProjectResourceList, which
+	// .Project.DefaultResources reaches as both Requests and Limits:
+	//
+	//   "DefaultResources.Requests" mentions 2   (one per mirror root)
+	//   "DefaultResources.Limits"   mentions 0   <- never named
+	//
+	// THIS IS NOT A COVERAGE HOLE AND MUST NOT BE READ AS ONE. Implementing
+	// json.Marshaler is a property of the TYPE, not of the path it was reached
+	// by, so the verdict at the first site is the verdict at every site and no
+	// violation can escape. What is lost is blast radius in the diagnostic, which
+	// is why the message below says "reached at" and not "reached only at".
+	//
+	// The soundness argument is worth keeping because it does NOT generalise:
+	// per-type dedup is safe here precisely because the judged property is
+	// type-determined. It would be unsafe for a path-dependent property — which
+	// is one more reason the tag check is not recursed alongside this one.
+	//
+	// The old comment also cited a case it does not cover: three interface{}
+	// fields sharing map[string]interface{}. Interface kinds return at the
+	// struct-kind check ABOVE this map and are never reported by this walk at
+	// all, so they never exercised the dedup. The prototype defect that lesson
+	// came from was real; generalising it to this code was not.
+	//
+	// Scope: this map is per-ROOT, rebuilt on each call, which is why a violating
+	// type is named once per mirror root rather than once in total.
 	visited := map[reflect.Type]bool{}
 
 	var walk func(typ reflect.Type, path string)
@@ -407,6 +432,10 @@ func walkMarshalerBan(t *testing.T, v any, judgeOutOfModule bool) {
 		if !resolvedGuardMarshalerExceptions[typ] {
 			assert.Falsef(t, implementsJSONMarshaler(typ),
 				"%s implements json.Marshaler, reached at %s.\n"+
+					"That path is the FIRST this walk reached the type by, not "+
+					"necessarily the only one: the type is judged once per root, so "+
+					"other fields of the same type are affected but go unnamed here. "+
+					"Removing the marshaller fixes every such site at once.\n"+
 					"A custom marshaller decides at runtime which keys to write, so the "+
 					"exact-set assertion — which reads what the encoder emits for one "+
 					"constructed value — stops being a bound on what real responses "+

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -822,15 +822,21 @@ func TestResolvedSettings_RegistryNoDrift(t *testing.T) {
 		assert.Containsf(t, resolvedSettingDescriptors, key,
 			"project setting %q is in projectSettingKeys but has no entry in "+
 				"resolvedSettingDescriptors, so GET /settings/resolved reports it as "+
-				"\"unknown\" forever instead of answering for it. RULE OUT A MISSPELLED "+
-				"KEY FIRST, exactly as the other direction below says: if both have "+
-				"failed, one of the two keys named is a typo of the other and adding a "+
-				"descriptor is the wrong fix — it leaves two descriptors for one setting "+
-				"and trips the count assertion below. THE TYPO IS NOT NECESSARILY THE KEY "+
-				"THIS MESSAGE NAMES; see the other message for how to tell. Otherwise the "+
-				"key is genuinely unwired: add a descriptor in "+
-				"project_settings_resolved.go naming the hub source for it (hubSourceNone "+
-				"if there is genuinely no hub-level counterpart).",
+				"\"unknown\" forever instead of answering for it. WHICH FIX YOU NEED "+
+				"DEPENDS ON WHETHER THE OTHER DIRECTION ALSO FAILED, so read the rest of "+
+				"the output before editing anything.\n\n"+
+				"IF THIS IS THE ONLY FAILURE HERE (this message, plus the count assertion "+
+				"below reporting one MORE registry key than descriptors), the key is "+
+				"genuinely unwired: add a descriptor in project_settings_resolved.go "+
+				"naming the hub source for it (hubSourceNone if there is genuinely no "+
+				"hub-level counterpart). Measured: a new key added to projectSettingKeys "+
+				"alone produces exactly this pair and nothing from the other direction.\n\n"+
+				"IF THE OTHER DIRECTION ALSO FAILED, do not add anything yet. A "+
+				"misspelling reddens both directions at once, one of the two keys named "+
+				"is a typo of the other, and adding a descriptor is the wrong fix — it "+
+				"leaves two descriptors for one setting and trips the count assertion "+
+				"below. THE TYPO IS NOT NECESSARILY THE KEY THIS MESSAGE NAMES; see the "+
+				"other message for how to tell.",
 			key)
 	}
 
@@ -1052,15 +1058,20 @@ func TestResolvedSettingsResponseShape_NoEffectiveValue(t *testing.T) {
 		"the client mirror in pkg/hubclient/types.go (ResolvedProjectSettings /\n" +
 		"ResolvedProjectSetting). The two types are hand-mirrored across a package\n" +
 		"boundary. This is NOT the only assertion that notices when they drift, and\n" +
-		"the list below may not be closed: the declared-tag equality a few lines down\n" +
-		"fires as well, and so does the clean-substitute control row in\n" +
-		"project_settings_resolved_wireup_test.go — which reports its OWN machinery as\n" +
-		"broken rather than the mirror, so do not start debugging there.\n" +
+		"the list may not be closed: the declared-tag equality a few lines down fires\n" +
+		"as well.\n" +
+		"Something else also goes red on this divergence, and it is a DIFFERENT KIND OF\n" +
+		"THING, so do not count it as a third drift check: the clean-substitute CONTROL\n" +
+		"row in project_settings_resolved_wireup_test.go. A control is not a\n" +
+		"drift detector — it goes red as collateral damage and reports its OWN\n" +
+		"machinery as broken rather than the mirror, so do not start debugging there.\n" +
 		"What this assertion contributes that the tag equality cannot is the hardcoded\n" +
 		"expected set: it reads the mirror's wire names and compares them to a fixed\n" +
 		"list, so it fires even when both sides were changed together and agree with\n" +
 		"each other. The tag equality compares the two sides only to one another and\n" +
-		"is silent in that case. Both directions measured at the time of writing."
+		"is silent in that case. To re-verify rather than take that on trust: plant a\n" +
+		"field on the hubclient mirror alone and both fire; plant the same field on\n" +
+		"BOTH sides and only this one does."
 
 	assert.Equal(t, expectedResolvedWrapperFields,
 		jsonWireNames(t, hubclient.ResolvedProjectSettings{}),

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -836,9 +836,16 @@ func TestResolvedSettings_RegistryNoDrift(t *testing.T) {
 	for key := range resolvedSettingDescriptors {
 		assert.Containsf(t, registered, key,
 			"resolvedSettingDescriptors has an entry for %q, which is not in "+
-				"projectSettingKeys. Either it was removed from the registry (delete the "+
-				"descriptor too) or it was never a project setting (the endpoint must not "+
-				"report it).",
+				"projectSettingKeys. RULE OUT A MISSPELLED KEY FIRST: the setting may "+
+				"still be registered under its correct spelling, in which case the fix is "+
+				"to correct this key and nothing needs deleting or adding. That case also "+
+				"reddens the OTHER direction above, whose advice — add a descriptor for "+
+				"the seemingly unwired key — would leave two descriptors for one setting "+
+				"and then trip the count assertion below. Failing that: the key was "+
+				"removed from the registry and this descriptor should go with it, or it "+
+				"was never a project setting and the endpoint must not report it. Those "+
+				"are the causes seen so far and the list is not closed; work out which "+
+				"one you have before editing, because the fixes are mutually exclusive.",
 			key)
 	}
 
@@ -1031,7 +1038,16 @@ func TestResolvedSettingsResponseShape_NoEffectiveValue(t *testing.T) {
 		"still failing. That is not a bug in the hatch: the field also has to be added to\n" +
 		"the client mirror in pkg/hubclient/types.go (ResolvedProjectSettings /\n" +
 		"ResolvedProjectSetting). The two types are hand-mirrored across a package\n" +
-		"boundary, and this assertion is the only thing that notices when they diverge."
+		"boundary. This is NOT the only assertion that notices when they drift, and\n" +
+		"the list below may not be closed: the declared-tag equality a few lines down\n" +
+		"fires as well, and so does the clean-substitute control row in\n" +
+		"project_settings_resolved_wireup_test.go — which reports its OWN machinery as\n" +
+		"broken rather than the mirror, so do not start debugging there.\n" +
+		"What this assertion contributes that the tag equality cannot is the hardcoded\n" +
+		"expected set: it reads the mirror's wire names and compares them to a fixed\n" +
+		"list, so it fires even when both sides were changed together and agree with\n" +
+		"each other. The tag equality compares the two sides only to one another and\n" +
+		"is silent in that case. Both directions measured at the time of writing."
 
 	assert.Equal(t, expectedResolvedWrapperFields,
 		jsonWireNames(t, hubclient.ResolvedProjectSettings{}),

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -1,0 +1,255 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These guards deliberately carry no build tag. They assert on the shape of the
+// API contract, which does not vary by build configuration, and a guard that
+// only runs in some configurations is a guard that can be missed in the others.
+
+// jsonTagNames returns the JSON field names of a struct type, following the
+// wire contract rather than the Go identifiers: the tag name is used, tag
+// options such as ",omitempty" are stripped, fields tagged "-" are excluded,
+// and an untagged field contributes its Go name (which is what encoding/json
+// would emit).
+func jsonTagNames(t *testing.T, v any) []string {
+	t.Helper()
+
+	typ := reflect.TypeOf(v)
+	for typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	require.Equalf(t, reflect.Struct, typ.Kind(),
+		"jsonTagNames expects a struct, got %s", typ.Kind())
+
+	var names []string
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.PkgPath != "" {
+			continue // unexported: never marshalled
+		}
+		tag := field.Tag.Get("json")
+		if tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if name == "" {
+			name = field.Name
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestResolvedSettings_RegistryNoDrift is the bidirectional coverage guard
+// between the authoritative registry and the resolved endpoint's descriptor
+// table.
+//
+// Why a second structure exists at all, and why this test is the thing that
+// makes it safe: if the response were built by ranging over projectSettingKeys
+// alone, every registry key would appear in the response by construction, this
+// guard could never fail, and its passing would mean nothing. A check that
+// cannot fail is worse than no check because it is read as protection. The
+// descriptor table holds the per-key wiring that the key string cannot supply,
+// and this test asserts the two cover each other EXACTLY.
+//
+// Both directions matter:
+//
+//   - registry -> descriptor: a new setting that nobody wired reaches the
+//     response as "unknown" forever, silently under-reporting.
+//   - descriptor -> registry: a descriptor for a key that is no longer a
+//     project setting means the endpoint is prepared to report something that
+//     is not part of the contract.
+func TestResolvedSettings_RegistryNoDrift(t *testing.T) {
+	require.NotEmpty(t, projectSettingKeys,
+		"the registry is empty; this guard would pass vacuously")
+	require.NotEmpty(t, resolvedSettingDescriptors,
+		"the descriptor table is empty; this guard would pass vacuously")
+
+	// Direction 1: every registered setting is wired into the endpoint.
+	for _, key := range projectSettingKeys {
+		assert.Containsf(t, resolvedSettingDescriptors, key,
+			"project setting %q is in projectSettingKeys but has no entry in "+
+				"resolvedSettingDescriptors, so GET /settings/resolved reports it as "+
+				"\"unknown\" forever instead of answering for it. Add a descriptor in "+
+				"project_settings_resolved.go naming the hub source for this key "+
+				"(hubSourceNone if there is genuinely no hub-level counterpart).",
+			key)
+	}
+
+	// Direction 2: nothing is wired that is not a registered setting.
+	registered := make(map[string]bool, len(projectSettingKeys))
+	for _, key := range projectSettingKeys {
+		registered[key] = true
+	}
+	for key := range resolvedSettingDescriptors {
+		assert.Containsf(t, registered, key,
+			"resolvedSettingDescriptors has an entry for %q, which is not in "+
+				"projectSettingKeys. Either it was removed from the registry (delete the "+
+				"descriptor too) or it was never a project setting (the endpoint must not "+
+				"report it).",
+			key)
+	}
+
+	assert.Equalf(t, len(projectSettingKeys), len(resolvedSettingDescriptors),
+		"registry has %d keys but the descriptor table has %d entries",
+		len(projectSettingKeys), len(resolvedSettingDescriptors))
+}
+
+// TestResolvedSettings_DescriptorsWellFormed checks the descriptor table's
+// internal consistency, so that a malformed entry fails here rather than
+// degrading a live response to "unknown".
+func TestResolvedSettings_DescriptorsWellFormed(t *testing.T) {
+	for key, desc := range resolvedSettingDescriptors {
+		switch desc.source {
+		case hubSourceAgentDefaults:
+			assert.NotEmptyf(t, desc.path,
+				"descriptor %q reads agent_defaults but has no path, so it can never "+
+					"report anything but unknown", key)
+		case hubSourceNone, hubSourceTelemetryDefault:
+			assert.Emptyf(t, desc.path,
+				"descriptor %q does not read agent_defaults but carries a path %v, "+
+					"which is never used and is therefore misleading", key, desc.path)
+			assert.Falsef(t, desc.absentWhenMissing,
+				"descriptor %q sets absentWhenMissing, which only applies to "+
+					"agent_defaults lookups", key)
+		default:
+			t.Errorf("descriptor %q has unknown source %d", key, desc.source)
+		}
+	}
+}
+
+// TestResolvedSettings_ResponseCoversRegistry is the deliverable the phase asks
+// for in its most direct form: every registered project setting appears as a
+// key in an actual response body.
+//
+// This is deliberately asserted against a real constructed response rather than
+// against the descriptor table, so that a bug in the builder — an early
+// continue, a filtered key — is caught even when the tables agree with each
+// other.
+func TestResolvedSettings_ResponseCoversRegistry(t *testing.T) {
+	project := &store.Project{
+		ID:          "p-1",
+		Annotations: map[string]string{},
+	}
+
+	// A zero Server has no OperationalSettings and no config, which is the
+	// file/SQLite path: hub presence is unknowable and must be reported as
+	// such rather than as absent.
+	resp := (&Server{}).resolvedProjectSettings(project)
+	require.NotNil(t, resp)
+
+	for _, key := range projectSettingKeys {
+		assert.Containsf(t, resp.Settings, key,
+			"registered project setting %q is missing from the resolved response. "+
+				"The response must report every key in projectSettingKeys.", key)
+	}
+	assert.Lenf(t, resp.Settings, len(projectSettingKeys),
+		"the resolved response has %d keys but the registry has %d",
+		len(resp.Settings), len(projectSettingKeys))
+}
+
+// TestResolvedSettingsResponseShape_NoEffectiveValue is the negative drift
+// guard: it fails if the resolved response grows ANY new field.
+//
+// It is an exact-set assertion, not a denylist. A denylist of forbidden names
+// ("effectiveValue", "resolvedValue", ...) would be a hypothesis about what a
+// future contributor will CALL the field, and the entire problem is that this
+// cannot be predicted — "value", "winner", "current" or "appliedValue" would
+// all sail through. Asserting the set exactly means any addition fails and the
+// author has to come and argue for it.
+//
+// It asserts on JSON TAGS rather than Go field names because the wire shape is
+// the contract: renaming a Go field while keeping its tag must not trip this,
+// and changing a tag must.
+//
+// KNOWN AND DELIBERATE LIMIT OF THIS GUARD: it covers the resolved wrapper and
+// the per-key object. It does NOT look inside hubclient.ProjectSettings, which
+// the "project" key carries whole. A field added to ProjectSettings reaches
+// this response unguarded by this test. Exact-setting that type here was
+// considered and rejected: it has nineteen fields that legitimately change for
+// reasons unrelated to this endpoint, so this guard would fail on other
+// people's honest work, and a guard that cries wolf gets deleted. The realistic
+// version of that drift — the "project" field being retyped to a locally
+// widened struct — is covered by TestResolvedSettings_ProjectFieldTypeIdentity
+// below instead.
+func TestResolvedSettingsResponseShape_NoEffectiveValue(t *testing.T) {
+	const rationale = "\n\n" +
+		"resolved-settings response shape changed.\n" +
+		"This test exists to prevent well-intentioned additions. If you are adding an effective\n" +
+		"value field, read the /settings/resolved design rationale first: this endpoint\n" +
+		"deliberately does NOT resolve precedence, because we do not own the ordering. See the\n" +
+		"header comment in pkg/hub/project_settings_resolved.go, the doc comment on\n" +
+		"hubclient.ResolvedProjectSetting, and docs-site reference/project-settings-resolved.md.\n" +
+		"Note this applies to a hub VALUE too, not only to an 'effective' one: {projectValue,\n" +
+		"hubValue} side by side asserts that nothing sits between them, which is the same\n" +
+		"precedence claim by another route.\n" +
+		"If you are adding an unrelated field, add its JSON name to the expected set below."
+
+	// The expected sets. A legitimate new field is added HERE, in one obvious
+	// place — the guard is meant to be a speed bump that forces an argument,
+	// not a wall that gets deleted by the first person it inconveniences.
+	expectedWrapper := []string{"project", "settings"}
+	expectedEntry := []string{"hubDefault", "projectSet", "projectValue"}
+	sort.Strings(expectedWrapper)
+	sort.Strings(expectedEntry)
+
+	assert.Equal(t, expectedWrapper, jsonTagNames(t, ResolvedProjectSettings{}),
+		"hub.ResolvedProjectSettings"+rationale)
+	assert.Equal(t, expectedEntry, jsonTagNames(t, ResolvedProjectSetting{}),
+		"hub.ResolvedProjectSetting"+rationale)
+
+	// The hubclient mirror is part of the same contract: a field added to only
+	// one side would produce a client type that silently disagrees with the
+	// server.
+	assert.Equal(t, expectedWrapper, jsonTagNames(t, hubclient.ResolvedProjectSettings{}),
+		"hubclient.ResolvedProjectSettings"+rationale)
+	assert.Equal(t, expectedEntry, jsonTagNames(t, hubclient.ResolvedProjectSetting{}),
+		"hubclient.ResolvedProjectSetting"+rationale)
+}
+
+// TestResolvedSettings_ProjectFieldTypeIdentity closes the realistic half of
+// the blind spot named above.
+//
+// The guard above cannot police hubclient.ProjectSettings' own field list
+// without failing on unrelated honest changes. What it CAN police cheaply is
+// that the "project" key still carries exactly that shared type, rather than a
+// locally widened struct that embeds it and adds a computed or effective-value
+// field alongside. That is the drift this endpoint is actually at risk of, and
+// unlike a field addition upstream it is always a deliberate act by someone
+// working on this endpoint.
+func TestResolvedSettings_ProjectFieldTypeIdentity(t *testing.T) {
+	field, ok := reflect.TypeOf(ResolvedProjectSettings{}).FieldByName("Project")
+	require.True(t, ok, "ResolvedProjectSettings has no Project field")
+
+	assert.Equal(t, reflect.TypeOf(&hubclient.ProjectSettings{}), field.Type,
+		"the resolved response's \"project\" field must remain exactly "+
+			"*hubclient.ProjectSettings. If it has been retyped to a local struct, the "+
+			"exact-set shape guard no longer sees what this endpoint actually returns — "+
+			"a widened wrapper is the supported way to sneak an effective value into this "+
+			"response, which is precisely what these guards exist to prevent.")
+}

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -1184,6 +1184,20 @@ func TestResolvedGuard_MarshalerCheckSeesBothReceiverForms(t *testing.T) {
 // that TestResolvedSettingsGuard_InstrumentControls can drive them as a unit.
 // Deleting any one of the three from this function turns control rows red;
 // called individually at the use site, a deletion there would be invisible.
+//
+// KNOWN RESIDUAL, MEASURED, NOT CLOSED. Bundling narrows what a deletion can
+// reach; it does not make the CALL to this function self-defending. Deleting
+// the three-line loop in TestResolvedSettings_ResponseKeySetIsTypeDetermined
+// leaves the ENTIRE pkg/hub suite green (rc=0) and is not a compile artefact
+// (go vet clean; no orphaned range variable). Three lines removes every shape
+// guard in this file and nothing goes red.
+//
+// The honest framing is that the composite made this residual SMALLER but not
+// weaker: the same total-removal edit was six lines before the composite and
+// is three lines now, and nothing caught the six-line version either. Coverage
+// did not drop. Do not read the control table's green as evidence that the
+// guards are still wired up — the table proves the instruments work, never
+// that anything calls them. Closing this needs a check outside `go test`.
 func assertResponseKeySetIsTypeDetermined(t *testing.T, v any) {
 	t.Helper()
 

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -340,6 +340,26 @@ const resolvedGuardModulePrefix = "github.com/GoogleCloudPlatform/scion/"
 // it, with the review that a diff to this list attracts — rather than reaching
 // for the easier fix of deleting the recursion.
 //
+// THE WORD "SITE" BELOW IS A DEFINED TERM, AND THE DEFINITION IS NOT HERE. It is
+// stated once, in the failure message inside walkMarshalerBan — search this file
+// for "A SITE is". Deliberately not restated at this end: two copies of a
+// definition are two definitions and they drift, so the cost is paid as one jump
+// rather than as an eventual contradiction.
+//
+// WHICH USES IT GOVERNS. Every occurrence of the bare noun in this file, with
+// three fixed compounds excepted — "call site", "use site" and
+// "construction site" — which carry their ordinary programming meanings. Each is
+// kept whole on one line here and should stay that way: a compound split across
+// a line break reads as a bare noun to a line-based census, which is the only
+// instrument anyone has used on this file. That exception is an enumeration and
+// not a pattern: "per-site" below IS the defined term, and a new compound is a
+// new decision rather than an automatic exemption.
+//
+// WHY IT IS POINTED AT RATHER THAN LEFT IMPLICIT. A definition placed inside a
+// failure message reaches only a reader who has already triggered the assertion;
+// whoever edits the map below has not, and exempting a type is the most
+// consequential edit this file offers.
+//
 // KEYED BY TYPE, NOT BY SITE. An entry here exempts EVERY site at which the type
 // is reached, including sites the failure message did not name. Read that
 // together with the dedup note in walkMarshalerBan: the message names only the
@@ -1802,8 +1822,8 @@ func TestResolvedSettingsGuard_InstrumentControls(t *testing.T) {
 // file has looked at.
 //
 // The property was already held before this test existed — but only by the
-// compiler, incidentally, at the two sites that construct the map, with no
-// message attached. That is a worse position than it sounds, because the field
+// compiler, incidentally, at the map's two construction sites, with no message
+// attached. That is a worse position than it sounds, because the field
 // immediately above it, Project, has a named test explaining that retyping it is
 // the supported way to sneak an effective value into this response. The
 // asymmetry reads as "this class was considered and Settings was found not to

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -302,6 +302,22 @@ func assertNoEmbeddedStructPointer(t *testing.T, v any) {
 // a reader who assumes "if the type implements it, so does the pointer" — the
 // implication holds only in that direction — would simplify the condition and
 // see nothing fail.
+//
+// THE TWO HALVES ARE NOT EQUALLY PROTECTED, AND THE WEAK ONE IS THE VALUE HALF.
+// walkMarshalerBan dereferences to a struct kind before calling this, so every
+// call from the walk passes a struct type, and for struct T the method set of *T
+// contains T's. The POINTER half therefore decides every walked node on its own.
+// Measured at 1e022df8: deleting the value half reds exactly one subtest and no
+// row of the control table; deleting the pointer half reds eight rows.
+//
+// The value half is still REQUIRED. It is the half that carries pointer-TYPED
+// inputs, which reach this predicate only from callers that do not normalize.
+// Deleting it makes the predicate silently wrong for those and that is a false
+// negative in the R21 class. It is pinned by exactly one assertion, in the test
+// named above; delete the half and that assertion together and the package goes
+// green. Anyone tempted to "simplify" this to the pointer disjunct because the
+// walk makes it redundant should add a caller-side normalization guarantee
+// first, and there is none today.
 func implementsJSONMarshaler(typ reflect.Type) bool {
 	marshaler := reflect.TypeOf((*json.Marshaler)(nil)).Elem()
 	return typ.Implements(marshaler) || reflect.PointerTo(typ).Implements(marshaler)
@@ -1675,15 +1691,41 @@ func TestResolvedSettingsGuard_InstrumentControls(t *testing.T) {
 		{"composite catches behaviour", assertResponseKeySetIsTypeDetermined, marshalerCtrlPointer{}, true},
 
 		// POINTER-TYPE inputs. Every row above passes a VALUE, which is what
-		// resolvedResponseTypes supplies today — and that is precisely why these
-		// exist. assertNoCustomMarshaler does not dereference, so its two halves
-		// swap which one carries the check depending on the input form: for a
-		// value the pointer half does the work, for a pointer the value half
-		// does. If resolvedResponseTypes is ever changed to return pointers, the
-		// ban keeps working and the value rows above go on pinning the half that
-		// is no longer load-bearing — a green table that has quietly stopped
-		// testing what runs. Pinning both forms means whichever half carries it
-		// is covered.
+		// resolvedResponseTypes supplies today.
+		//
+		// THIS BLOCK'S ORIGINAL JUSTIFICATION IS NO LONGER TRUE, AND THE ROWS ARE
+		// KEPT FOR A DIFFERENT REASON. It used to read: "assertNoCustomMarshaler
+		// does not dereference, so its two halves swap which one carries the
+		// check depending on the input form." That was accurate when the ban was
+		// a single top-level check. It is FALSE now — walkMarshalerBan strips
+		// Pointer/Slice/Array/Map before judging, so every node reaching the
+		// predicate from the walk is a struct kind, and for struct T the method
+		// set of *T is a superset of T's. The pointer half alone decides every
+		// node the walk visits.
+		//
+		// So for the three MARSHALLER rows below, value and pointer inputs now
+		// pin the SAME half, and the old payoff line — "pinning both forms means
+		// whichever half carries it is covered" — is false for them. Measured:
+		// deleting the value disjunct reds ZERO rows of this table.
+		//
+		// WHAT THEY STILL PIN, which is a real property and not a consolation:
+		// that the walk NORMALIZES. A pointer input and a value input must reach
+		// the same verdict, and these rows fail if someone removes the
+		// dereference loop or makes it partial.
+		//
+		// Two of the five rows are UNAFFECTED by any of this: "embedded pointer"
+		// and "omitzero" route to assertNoEmbeddedStructPointer and
+		// assertOnlySafeTagOptions, which were not changed and do not dereference.
+		//
+		// The comment this replaces predicted its own failure mode — "a green
+		// table that has quietly stopped testing what runs" — and then became an
+		// instance of it. Coverage of the value disjunct went from four rows to
+		// one when the walk began dereferencing. That one is
+		// TestResolvedGuard_MarshalerCheckSeesBothReceiverForms, which calls the
+		// predicate directly; delete the disjunct and that subtest together and
+		// the whole package is green. Do not delete either. The disjunct is
+		// correct and required for pointer-typed inputs handed to the predicate
+		// outside the walk; removing it is a false negative in the R21 class.
 		{"pointer input, pointer-receiver MarshalJSON", assertNoCustomMarshaler, &marshalerCtrlPointer{}, true},
 		{"pointer input, value-receiver MarshalJSON", assertNoCustomMarshaler, &marshalerCtrlValue{}, true},
 		{"pointer input, embedded pointer", assertNoEmbeddedStructPointer, &ctlEmbeddedPtr{}, true},
@@ -1696,11 +1738,19 @@ func TestResolvedSettingsGuard_InstrumentControls(t *testing.T) {
 		{"plain tags are ACCEPTED", assertOnlySafeTagOptions, ctlEmbeddedValue{}, false},
 		{"no marshaller is ACCEPTED", assertNoCustomMarshaler, ctlEmbeddedValue{}, false},
 		{"a clean type passes the composite", assertResponseKeySetIsTypeDetermined, ctlClean{}, false},
+		{"a clean POINTER passes the composite", assertResponseKeySetIsTypeDetermined, &ctlClean{}, false},
+
+		// DEPTH rows, REJECT. These were filed under the ACCEPT heading above by
+		// mistake; a row's want is in its last field, not in the heading it sits
+		// under, so this misfiling could not change a result — but a reader
+		// scanning headings would have miscounted the accepts, which is how a
+		// table stops being read carefully.
 		{"nested POINTER-receiver marshaller is rejected", assertNoCustomMarshaler, ctlDoorA{}, true},
 		{"nested VALUE-receiver marshaller is rejected", assertNoCustomMarshaler, ctlDoorValue{}, true},
+
+		// DEPTH rows, ACCEPT — the over-rejection controls for the two above.
 		{"nested structs with no marshaller anywhere", assertNoCustomMarshaler, ctlDeepClean{}, false},
 		{"out-of-module marshaller is reached but not judged", assertNoCustomMarshaler, ctlOutOfModule{}, false},
-		{"a clean POINTER passes the composite", assertResponseKeySetIsTypeDetermined, &ctlClean{}, false},
 	}
 
 	for _, tc := range cases {

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -339,6 +339,19 @@ const resolvedGuardModulePrefix = "github.com/GoogleCloudPlatform/scion/"
 // the first person who genuinely needs an exception has a declared place to put
 // it, with the review that a diff to this list attracts — rather than reaching
 // for the easier fix of deleting the recursion.
+//
+// KEYED BY TYPE, NOT BY SITE. An entry here exempts EVERY site at which the type
+// is reached, including sites the failure message did not name. Read that
+// together with the dedup note in walkMarshalerBan: the message names only the
+// FIRST path a violating type was reached by, so the reviewer of an exception
+// diff is systematically shown a NARROWER blast radius than the exception
+// actually has. Measured instance: hubclient.ProjectResourceList is reached as
+// both .DefaultResources.Requests and .DefaultResources.Limits, and only
+// .Requests is ever named — exempting it on the strength of that message would
+// silently exempt .Limits too.
+//
+// If a per-site exemption is ever genuinely wanted, key this on (type, path) and
+// change the walk to match. Do not approximate it by exempting the type.
 var resolvedGuardMarshalerExceptions = map[reflect.Type]bool{}
 
 // assertNoCustomMarshaler fails if v, or ANY type reachable from it, implements

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -409,7 +409,7 @@ func walkMarshalerBan(t *testing.T, v any, judgeOutOfModule bool) {
 	// at 1e022df8 — one marshaller on hubclient.ProjectResourceList, which
 	// .Project.DefaultResources reaches as both Requests and Limits:
 	//
-	//   "DefaultResources.Requests" mentions 2   (one per mirror root)
+	//   "DefaultResources.Requests" mentions 2   (one per root that REACHES it)
 	//   "DefaultResources.Limits"   mentions 0   <- never named
 	//
 	// THIS IS NOT A COVERAGE HOLE AND MUST NOT BE READ AS ONE. Implementing
@@ -425,12 +425,17 @@ func walkMarshalerBan(t *testing.T, v any, judgeOutOfModule bool) {
 	//
 	// The old comment also cited a case it does not cover: three interface{}
 	// fields sharing map[string]interface{}. Interface kinds return at the
-	// struct-kind check ABOVE this map and are never reported by this walk at
-	// all, so they never exercised the dedup. The prototype defect that lesson
-	// came from was real; generalising it to this code was not.
+	// struct-kind check, which sits BELOW this declaration and ABOVE the visited
+	// check that follows it, so they are never reported by this walk at all and
+	// never exercised the dedup. The prototype defect that lesson came from was
+	// real; generalising it to this code was not.
 	//
-	// Scope: this map is per-ROOT, rebuilt on each call, which is why a violating
-	// type is named once per mirror root rather than once in total.
+	// Scope: this map is per-ROOT, rebuilt on each call, so a violating type is
+	// named once per root that REACHES it rather than once in total. Reaching is
+	// the operative property, not mirror-ness: resolvedResponseTypes lists FOUR
+	// roots and the measurement above is 2, because only the two plural
+	// ResolvedProjectSettings carry a field that reaches this subgraph. A fifth
+	// root that reached it would make the count 3.
 	visited := map[reflect.Type]bool{}
 
 	var walk func(typ reflect.Type, path string)
@@ -461,10 +466,13 @@ func walkMarshalerBan(t *testing.T, v any, judgeOutOfModule bool) {
 		if !resolvedGuardMarshalerExceptions[typ] {
 			assert.Falsef(t, implementsJSONMarshaler(typ),
 				"%s implements json.Marshaler, reached at %s.\n"+
-					"That path is the FIRST this walk reached the type by, not "+
-					"necessarily the only one: the type is judged once per root, so "+
-					"other fields of the same type are affected but go unnamed here. "+
-					"Removing the marshaller fixes every such site at once.\n"+
+					"That path is the FIRST this walk reached the type by, and may "+
+					"not be the only one: the type is judged once per root that "+
+					"REACHES it, so ANY further site of the same type — if the type "+
+					"has one — is affected too and is not named here. Read this as "+
+					"'this list may be incomplete', NOT as 'there are more'; a type "+
+					"with a single site is named in full. Removing the marshaller "+
+					"fixes every site at once, however many there are.\n"+
 					"A custom marshaller decides at runtime which keys to write, so the "+
 					"exact-set assertion — which reads what the encoder emits for one "+
 					"constructed value — stops being a bound on what real responses "+

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -822,9 +822,15 @@ func TestResolvedSettings_RegistryNoDrift(t *testing.T) {
 		assert.Containsf(t, resolvedSettingDescriptors, key,
 			"project setting %q is in projectSettingKeys but has no entry in "+
 				"resolvedSettingDescriptors, so GET /settings/resolved reports it as "+
-				"\"unknown\" forever instead of answering for it. Add a descriptor in "+
-				"project_settings_resolved.go naming the hub source for this key "+
-				"(hubSourceNone if there is genuinely no hub-level counterpart).",
+				"\"unknown\" forever instead of answering for it. RULE OUT A MISSPELLED "+
+				"KEY FIRST, exactly as the other direction below says: if both have "+
+				"failed, one of the two keys named is a typo of the other and adding a "+
+				"descriptor is the wrong fix — it leaves two descriptors for one setting "+
+				"and trips the count assertion below. THE TYPO IS NOT NECESSARILY THE KEY "+
+				"THIS MESSAGE NAMES; see the other message for how to tell. Otherwise the "+
+				"key is genuinely unwired: add a descriptor in "+
+				"project_settings_resolved.go naming the hub source for it (hubSourceNone "+
+				"if there is genuinely no hub-level counterpart).",
 			key)
 	}
 
@@ -836,12 +842,19 @@ func TestResolvedSettings_RegistryNoDrift(t *testing.T) {
 	for key := range resolvedSettingDescriptors {
 		assert.Containsf(t, registered, key,
 			"resolvedSettingDescriptors has an entry for %q, which is not in "+
-				"projectSettingKeys. RULE OUT A MISSPELLED KEY FIRST: the setting may "+
-				"still be registered under its correct spelling, in which case the fix is "+
-				"to correct this key and nothing needs deleting or adding. That case also "+
-				"reddens the OTHER direction above, whose advice — add a descriptor for "+
-				"the seemingly unwired key — would leave two descriptors for one setting "+
-				"and then trip the count assertion below. Failing that: the key was "+
+				"projectSettingKeys. RULE OUT A MISSPELLED KEY FIRST. A misspelling "+
+				"reddens BOTH directions at once, and the two messages then name two "+
+				"spellings of one setting — one of which is a typo of the other, with "+
+				"nothing wrong with the setting itself. WHICH of the two is the typo "+
+				"depends on where it was typed, and neither message can tell you: "+
+				"measured both ways, a raw string in the descriptor table puts the typo "+
+				"in THIS message, and a raw string in projectSettingKeys puts it in the "+
+				"other one. Do not assume this key is the wrong one. Both tables normally "+
+				"reference the same constants, so the typo is a RAW STRING somewhere a "+
+				"constant belongs — find that and you have found which key to correct. "+
+				"Correcting it clears both messages; following the other message's advice "+
+				"instead leaves two descriptors for one setting and trips the count "+
+				"assertion below. Failing all that: the key was "+
 				"removed from the registry and this descriptor should go with it, or it "+
 				"was never a project setting and the endpoint must not report it. Those "+
 				"are the causes seen so far and the list is not closed; work out which "+

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -39,7 +39,7 @@ func jsonTagNames(t *testing.T, v any) []string {
 	t.Helper()
 
 	typ := reflect.TypeOf(v)
-	for typ.Kind() == reflect.Ptr {
+	for typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
 	require.Equalf(t, reflect.Struct, typ.Kind(),

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -15,6 +15,8 @@
 package hub
 
 import (
+	"encoding/json"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -29,12 +31,173 @@ import (
 // These guards deliberately carry no build tag. They assert on the shape of the
 // API contract, which does not vary by build configuration, and a guard that
 // only runs in some configurations is a guard that can be missed in the others.
+//
+// That decision is no longer just an argument. CI runs `make test-fast`, which
+// is `-tags no_sqlite`, and project_settings_resolved_test.go carries
+// `//go:build !no_sqlite` — so every behaviour test for this endpoint is
+// invisible to CI, and the tests in THIS file are the only ones that run there.
+// At the time of writing that is 10 of 17 invisible.
+//
+// Measure it, do not count the funcs by eye:
+//
+//	go test -count=1 -list 'TestResolvedSettings' ./pkg/hub/
+//	go test -count=1 -tags no_sqlite -list 'TestResolvedSettings' ./pkg/hub/
+//
+// Two instruments give the wrong answer here and both are tempting. Grepping
+// for `func Test` counts tests the compiler never sees. Reading the top of the
+// file for a build tag reports "untagged" for BOTH files, because the tag sits
+// at line 15 underneath a 14-line licence header — long enough to hide it from
+// anything that only looks at the first few lines.
+//
+// The wider coverage gap is task #17, deliberately not patched over here; it is
+// named so nobody reads the untagged choice in this file as an accident.
 
-// jsonTagNames returns the JSON field names of a struct type, following the
-// wire contract rather than the Go identifiers: the tag name is used, tag
-// options such as ",omitempty" are stripped, fields tagged "-" are excluded,
-// and an untagged field contributes its Go name (which is what encoding/json
-// would emit).
+// expectedResolvedWrapperFields and expectedResolvedEntryFields are the JSON
+// keys the resolved-settings response is allowed to carry, at the top level and
+// per setting respectively. They live at package scope because two files assert
+// against them: this one exact-sets the marshalled types, and
+// project_settings_resolved_test.go derives its wire-level length check from
+// the wrapper list rather than hardcoding a number that can silently fall out
+// of step with it.
+//
+// Both must stay sorted; the assertions compare sorted slices.
+var (
+	expectedResolvedWrapperFields = []string{"project", "settings"}
+	expectedResolvedEntryFields   = []string{"hubDefault", "projectSet", "projectValue"}
+)
+
+// jsonWireNames returns the JSON object keys encoding/json ACTUALLY emits for
+// v. It marshals rather than reflecting, because the wire — not the tag list —
+// is the contract, and the two are not the same set.
+//
+// Reflection over tags cannot see fields promoted from an embedded struct, and
+// cannot see a custom MarshalJSON at all. Both are one-line ways to add a field
+// to this response, and both were demonstrated against the real type: a field
+// added via an embedded unexported struct reached a live 200 response named
+// "winner" with the entire suite for this endpoint green.
+//
+// `omitempty` would defeat this helper: it drops a zero-valued field, so a key
+// could exist on the type, be populated by the handler, reach the wire, and
+// still be missing from the set this helper computes for a test-constructed
+// value. Callers must therefore pair it with assertNoPromotedOmitEmpty, which
+// removes the possibility rather than trying to dodge it. See that function for
+// why the obvious alternative — populating the value first — does not work.
+func jsonWireNames(t *testing.T, v any) []string {
+	t.Helper()
+
+	b, err := json.Marshal(v)
+	require.NoError(t, err, "the response type must marshal; a wire guard cannot "+
+		"report on a value the encoder rejects")
+
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(b, &m),
+		"the response type must marshal to a JSON object, got: %s", b)
+
+	names := make([]string, 0, len(m))
+	for k := range m {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// assertNoPromotedOmitEmpty fails if any field promoted onto v's top-level JSON
+// object carries `,omitempty`.
+//
+// This is what makes jsonWireNames trustworthy on a zero value, and it is the
+// second half of the fix — without it the wire guard has a hole the same shape
+// as the one it was written to close.
+//
+// THE ALTERNATIVE WAS TRIED AND MEASURED. The obvious way to beat `omitempty`
+// is to populate the value before marshalling it, reflectively so that fields
+// the test does not know about are filled too. That does not work, and it fails
+// on precisely the case this guard exists for: a field promoted from an
+// embedded UNEXPORTED struct is not settable through reflect (CanSet is false,
+// and there is no way around it short of unsafe). Measured on the real type,
+// with the encoder as the judge:
+//
+//	type ResolvedProjectSetting struct { ...; ctrlSneak }
+//	type ctrlSneak struct { Winner string `json:"winner,omitempty"` }
+//
+//	WIRE:       {"projectSet":true,"projectValue":null,"hubDefault":"","winner":"sneaked"}
+//	GUARD SAW:  [hubDefault projectSet projectValue]
+//
+// — with every guard in this file green. A same-package handler can assign to
+// the promoted field, so that is a live route and not a curiosity. A reflective
+// fill would have been a mechanism that looks like it closes the hole while not
+// closing it, which is the same failure as a comment that explains why an
+// unsound skip is safe.
+//
+// Banning `omitempty` outright is the honest version, and it costs nothing
+// here: this response never omits keys by design. Every registered setting
+// appears every time, and an unset projectValue is explicit `null` rather than
+// a missing key, precisely so a client cannot read "absent" out of silence.
+// `omitempty` on these types would contradict the documented contract before it
+// ever troubled a test.
+func assertNoPromotedOmitEmpty(t *testing.T, v any) {
+	t.Helper()
+
+	typ := reflect.TypeOf(v)
+	for typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	require.Equal(t, reflect.Struct, typ.Kind())
+
+	var walk func(typ reflect.Type, path string)
+	walk = func(typ reflect.Type, path string) {
+		for i := 0; i < typ.NumField(); i++ {
+			field := typ.Field(i)
+			tag := field.Tag.Get("json")
+			if tag == "-" {
+				continue
+			}
+			parts := strings.Split(tag, ",")
+
+			// An embedded struct with no tag NAME has its fields promoted into
+			// this object, so its tags are this object's tags. reflect can read
+			// the type of an unexported embedded field even though it cannot
+			// set its value, which is what lets this check reach where a
+			// reflective fill could not.
+			if field.Anonymous && parts[0] == "" {
+				ft := field.Type
+				for ft.Kind() == reflect.Pointer {
+					ft = ft.Elem()
+				}
+				if ft.Kind() == reflect.Struct {
+					walk(ft, path+field.Name+".")
+					continue
+				}
+			}
+
+			for _, opt := range parts[1:] {
+				assert.NotEqualf(t, "omitempty", opt,
+					"%s%s carries `omitempty`, which is not allowed on the "+
+						"resolved-settings response types.\n"+
+						"Two reasons, and the second is the one that bites:\n"+
+						"  1. This response never omits keys. Every registered setting is "+
+						"reported every time, and an unset projectValue is explicit null, "+
+						"so that a client cannot infer \"absent\" from a missing key.\n"+
+						"  2. `omitempty` hides a zero-valued field from the encoder, and "+
+						"the shape guard reads the encoder's output. A field with "+
+						"`omitempty` can reach real clients while "+
+						"TestResolvedSettingsResponseShape_NoEffectiveValue stays green.",
+					path, field.Name)
+			}
+		}
+	}
+	walk(typ, "")
+}
+
+// jsonTagNames returns the JSON field names declared by a struct type's tags:
+// the tag name is used, options such as ",omitempty" are stripped, fields
+// tagged "-" are excluded, and an untagged field contributes its Go name.
+//
+// This is NOT a model of the wire and must not be used as one — see
+// jsonWireNames, which is. It survives here for the hub↔hubclient comparison,
+// where the question is whether the two types DECLARE the same names. That is a
+// narrower property than wire equality and it is worth asserting separately:
+// a MarshalJSON on one side could make the wires agree while the declarations
+// diverge, which is a trap for anyone reading the types to learn the contract.
 func jsonTagNames(t *testing.T, v any) []string {
 	t.Helper()
 
@@ -49,7 +212,14 @@ func jsonTagNames(t *testing.T, v any) []string {
 	for i := 0; i < typ.NumField(); i++ {
 		field := typ.Field(i)
 		if field.PkgPath != "" {
-			continue // unexported: never marshalled
+			// Unexported by Go's rules. NOTE, because the obvious comment here
+			// is false: this does NOT mean "never marshalled". encoding/json
+			// promotes the exported fields of an embedded UNEXPORTED struct
+			// type onto the wire, "since they may have exported fields", and
+			// that field carries a non-empty PkgPath. Skipping it here is a
+			// property of this reflective helper, not of the encoder — which
+			// is exactly why the exact-set guard runs on jsonWireNames instead.
+			continue
 		}
 		tag := field.Tag.Get("json")
 		if tag == "-" {
@@ -183,9 +353,19 @@ func TestResolvedSettings_ResponseCoversRegistry(t *testing.T) {
 // all sail through. Asserting the set exactly means any addition fails and the
 // author has to come and argue for it.
 //
-// It asserts on JSON TAGS rather than Go field names because the wire shape is
-// the contract: renaming a Go field while keeping its tag must not trip this,
-// and changing a tag must.
+// THAT ARGUMENT IS ONLY TRUE OF THE VERSION BELOW. The first version of this
+// guard reflected over struct tags, and review demonstrated that a field added
+// through an embedded unexported struct reached a live response named "winner"
+// — the very name this comment offers as one a denylist would miss — with the
+// whole suite green. For the whole of the phase in which this comment claimed
+// otherwise, the denylist in project_settings_resolved_test.go was the only
+// check that could fire, and it is what fired. The exact-set assertion is
+// better than a denylist only once it reads the encoder's output, which is why
+// it now runs on jsonWireNames and why both checks are kept.
+//
+// It asserts on the marshalled wire shape rather than on Go field names because
+// the wire is the contract: renaming a Go field while keeping its tag must not
+// trip this, and changing a tag must.
 //
 // KNOWN AND DELIBERATE LIMIT OF THIS GUARD: it covers the resolved wrapper and
 // the per-key object. It does NOT look inside hubclient.ProjectSettings, which
@@ -210,26 +390,293 @@ func TestResolvedSettingsResponseShape_NoEffectiveValue(t *testing.T) {
 		"precedence claim by another route.\n" +
 		"If you are adding an unrelated field, add its JSON name to the expected set below."
 
-	// The expected sets. A legitimate new field is added HERE, in one obvious
-	// place — the guard is meant to be a speed bump that forces an argument,
-	// not a wall that gets deleted by the first person it inconveniences.
-	expectedWrapper := []string{"project", "settings"}
-	expectedEntry := []string{"hubDefault", "projectSet", "projectValue"}
-	sort.Strings(expectedWrapper)
-	sort.Strings(expectedEntry)
+	// The expected sets are package-level (expectedResolvedWrapperFields,
+	// expectedResolvedEntryFields). A legitimate new field is added THERE, in
+	// one obvious place — the guard is meant to be a speed bump that forces an
+	// argument, not a wall that gets deleted by the first person it
+	// inconveniences.
+	// Step 1: no promoted field may hide from the encoder. Without this the
+	// step below can be defeated by six lines; see assertNoPromotedOmitEmpty.
+	for _, v := range []any{
+		ResolvedProjectSettings{}, ResolvedProjectSetting{},
+		hubclient.ResolvedProjectSettings{}, hubclient.ResolvedProjectSetting{},
+	} {
+		assertNoPromotedOmitEmpty(t, v)
+	}
 
-	assert.Equal(t, expectedWrapper, jsonTagNames(t, ResolvedProjectSettings{}),
+	// Step 2: the encoder's actual output is exactly the expected set. Safe on
+	// zero values only because of step 1 — encoding/json emits a key for every
+	// field it knows about unless omitempty tells it not to.
+	assert.Equal(t, expectedResolvedWrapperFields,
+		jsonWireNames(t, ResolvedProjectSettings{}),
 		"hub.ResolvedProjectSettings"+rationale)
-	assert.Equal(t, expectedEntry, jsonTagNames(t, ResolvedProjectSetting{}),
+	assert.Equal(t, expectedResolvedEntryFields,
+		jsonWireNames(t, ResolvedProjectSetting{}),
 		"hub.ResolvedProjectSetting"+rationale)
 
 	// The hubclient mirror is part of the same contract: a field added to only
 	// one side would produce a client type that silently disagrees with the
 	// server.
-	assert.Equal(t, expectedWrapper, jsonTagNames(t, hubclient.ResolvedProjectSettings{}),
-		"hubclient.ResolvedProjectSettings"+rationale)
-	assert.Equal(t, expectedEntry, jsonTagNames(t, hubclient.ResolvedProjectSetting{}),
-		"hubclient.ResolvedProjectSetting"+rationale)
+	//
+	// These two carry a DIFFERENT message from the hub-side pair above, and the
+	// difference is the point. A contributor who adds a field reaches this
+	// assertion having already done what the shared text tells them to do, so
+	// repeating "add its JSON name to the expected set" reads as the escape
+	// hatch being broken. What is actually missing at this point is the mirror
+	// type, in another package, which nothing has yet named.
+	const mirrorHint = "\n\n" +
+		"You have updated the hub-side type and the expected set, and this assertion is\n" +
+		"still failing. That is not a bug in the hatch: the field also has to be added to\n" +
+		"the client mirror in pkg/hubclient/types.go (ResolvedProjectSettings /\n" +
+		"ResolvedProjectSetting). The two types are hand-mirrored across a package\n" +
+		"boundary, and this assertion is the only thing that notices when they diverge."
+
+	assert.Equal(t, expectedResolvedWrapperFields,
+		jsonWireNames(t, hubclient.ResolvedProjectSettings{}),
+		"hubclient.ResolvedProjectSettings"+rationale+mirrorHint)
+	assert.Equal(t, expectedResolvedEntryFields,
+		jsonWireNames(t, hubclient.ResolvedProjectSetting{}),
+		"hubclient.ResolvedProjectSetting"+rationale+mirrorHint)
+
+	// Declared-tag equality between the two sides, which is a different
+	// question from wire equality: a MarshalJSON on one side could reconcile
+	// the wires while leaving the declarations divergent, and the declarations
+	// are what the next person reads to learn the contract.
+	assert.Equal(t,
+		jsonTagNames(t, ResolvedProjectSettings{}),
+		jsonTagNames(t, hubclient.ResolvedProjectSettings{}),
+		"hub and hubclient ResolvedProjectSettings declare different JSON tags"+rationale)
+	assert.Equal(t,
+		jsonTagNames(t, ResolvedProjectSetting{}),
+		jsonTagNames(t, hubclient.ResolvedProjectSetting{}),
+		"hub and hubclient ResolvedProjectSetting declare different JSON tags"+rationale)
+}
+
+// TestResolvedSettings_MirrorAcceptsServerOutput round-trips a server-shaped
+// response through the client mirror.
+//
+// Everything else that checks the hub↔hubclient relationship compares NAMES.
+// Names are not the contract a client depends on: retyping the mirror's
+// HubDefault from ResolvedHubDefault to bool, or ProjectValue from *string to
+// string, keeps every tag identical and breaks every client at runtime. This
+// test is the only thing that makes a real server payload prove it can be
+// decoded by the type we ship to clients.
+//
+// It carries no build tag, and that is load-bearing rather than incidental. CI
+// runs -tags no_sqlite, under which project_settings_resolved_test.go does not
+// compile in at all — so this is the only place mirror type drift can be caught
+// where enforcement actually happens. It deliberately uses no store, no server
+// and no HTTP, so nothing can ever make it need one.
+func TestResolvedSettings_MirrorAcceptsServerOutput(t *testing.T) {
+	value := "sonnet"
+	server := ResolvedProjectSettings{
+		Project: &hubclient.ProjectSettings{DefaultModel: value},
+		Settings: map[string]ResolvedProjectSetting{
+			projectSettingDefaultModel: {
+				ProjectSet:   true,
+				ProjectValue: &value,
+				HubDefault:   ResolvedHubDefaultUnknown,
+			},
+		},
+	}
+
+	b, err := json.Marshal(server)
+	require.NoError(t, err)
+
+	var mirror hubclient.ResolvedProjectSettings
+	require.NoError(t, json.Unmarshal(b, &mirror),
+		"a real server response must unmarshal into the hubclient mirror; the "+
+			"JSON-tag equality assertion above checks names only and cannot see "+
+			"a type change. Payload: %s", b)
+
+	entry, ok := mirror.Settings[projectSettingDefaultModel]
+	require.Truef(t, ok, "the mirror lost the %q entry", projectSettingDefaultModel)
+
+	assert.Equal(t, hubclient.ResolvedHubDefaultUnknown, entry.HubDefault,
+		"the tri-state must survive the round trip as a tri-state. If this is now "+
+			"a bool, \"unknown\" has become \"false\" and the client is being told "+
+			"the hub has no default when nobody looked.")
+	assert.True(t, entry.ProjectSet)
+	require.NotNil(t, entry.ProjectValue,
+		"projectValue must stay a pointer: null and \"\" are different answers")
+	assert.Equal(t, value, *entry.ProjectValue)
+
+	require.NotNil(t, mirror.Project, "the mirror dropped the \"project\" sub-object")
+	assert.Equal(t, value, mirror.Project.DefaultModel)
+}
+
+// TestResolvedSettings_AbsentWhenMissingMatchesSchema pins every
+// absentWhenMissing flag to settings-v1.schema.json, which the descriptor
+// table's own doc comment names as its source.
+//
+// Before this test, that source was a hand copy: sixteen booleans transcribed
+// from a schema nothing compared them against. Drift in one direction is
+// merely over-cautious (UNKNOWN where ABSENT was available). Drift in the
+// other direction makes the endpoint state a positive falsehood — "the hub has
+// no default for this" when nobody could actually tell — with the whole suite
+// green, because the only other test of these semantics hardcodes its expected
+// column to mirror the descriptor it is testing and therefore cannot dissent.
+//
+// WHAT THIS TEST DOES AND DOES NOT SETTLE. It removes sixteen hand-copied
+// VALUES and introduces one hand-written RULE:
+//
+//	absentWhenMissing is true if and only if the schema makes the Go zero
+//	value unreachable for that field.
+//
+// That rule is a human judgement, not something the schema states. Its
+// justification is the write path: AgentDefaultsSettings is marshalled with
+// `omitempty`, so an explicitly-zero value is discarded before it is persisted
+// and reads back identically to "never set". ABSENT is therefore honest only
+// where the zero value could not have been persisted in the first place — which
+// is what a `minimum`/`minLength` constraint decides. One rule that review can
+// check beats sixteen copies that it cannot, but the rule is the part to argue
+// with if you disagree; the schema will not settle it for you.
+func TestResolvedSettings_AbsentWhenMissingMatchesSchema(t *testing.T) {
+	schema := loadSettingsSchema(t)
+
+	checked := 0
+	for key, desc := range resolvedSettingDescriptors {
+		if desc.source != hubSourceAgentDefaults {
+			// No schema node to compare against. DescriptorsWellFormed already
+			// asserts these carry absentWhenMissing == false.
+			continue
+		}
+		require.NotEmptyf(t, desc.path, "descriptor %q reads agent_defaults with no path", key)
+
+		node := resolveSchemaPath(t, schema, desc.path)
+		zeroUnpersistable := schemaExcludesZeroValue(node)
+
+		assert.Equalf(t, zeroUnpersistable, desc.absentWhenMissing,
+			"descriptor %q (schema path %v) says absentWhenMissing=%v, but the schema "+
+				"makes its zero value %s.\n"+
+				"These must agree. The write path drops an explicit zero via omitempty, so "+
+				"reporting ABSENT is honest ONLY where the schema makes the zero value "+
+				"unreachable; otherwise \"configured empty\" and \"never configured\" are the "+
+				"same bytes and the only honest answer is UNKNOWN.\n"+
+				"If you just changed the schema, change this descriptor to match. If you "+
+				"believe the rule itself is wrong, argue with the doc comment on this test — "+
+				"do not just flip the boolean.",
+			key, desc.path, desc.absentWhenMissing,
+			map[bool]string{
+				true:  "unreachable (a constraint excludes it)",
+				false: "reachable, and then dropped by omitempty",
+			}[zeroUnpersistable])
+		checked++
+	}
+
+	// Without this the loop could pass by checking nothing at all — the exact
+	// class of unfalsifiable guard the descriptor table exists to avoid.
+	assert.GreaterOrEqual(t, checked, 10,
+		"expected at least the ten agent_defaults-backed descriptors to be checked "+
+			"against the schema, got %d; if the table shrank legitimately, lower this "+
+			"floor deliberately rather than letting the guard go quiet", checked)
+}
+
+// loadSettingsSchema reads the settings schema from disk. The path is relative
+// to this package's directory, which is where `go test` runs.
+func loadSettingsSchema(t *testing.T) map[string]any {
+	t.Helper()
+
+	const path = "../config/schemas/settings-v1.schema.json"
+	raw, err := os.ReadFile(path)
+	require.NoErrorf(t, err, "cannot read %s. This test pins the descriptor table to the "+
+		"schema; if the schema moved, repoint it rather than deleting the test.", path)
+
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(raw, &schema))
+	return schema
+}
+
+// resolveSchemaPath walks a descriptor path through the schema's "properties"
+// maps, resolving "$ref" at each step, and fails the test if any step is
+// missing.
+//
+// Failing loudly is the point. The five default_resources leaves sit behind
+//
+//	"default_resources": {"$ref": "#/$defs/resourceSpec", "description": ...}
+//
+// so a walk that reads "properties" without resolving the ref finds nothing —
+// and a version of this helper that returned an empty node instead of failing
+// would derive absentWhenMissing for five keys from a node containing no
+// constraints whatsoever. It would report agreement it had never tested, which
+// is the very failure this test was written to fix, reappearing inside the fix.
+//
+// Path length is not special-cased. Today's paths are one, two and three
+// segments long (default_resources/disk is the two), and hardcoding the set is
+// how the next nesting change gets silently skipped.
+func resolveSchemaPath(t *testing.T, schema map[string]any, path []string) map[string]any {
+	t.Helper()
+
+	node := resolveSchemaRef(t, schema, schema)
+	for i, segment := range path {
+		props, ok := node["properties"].(map[string]any)
+		require.Truef(t, ok,
+			"schema path %v: no \"properties\" at segment %d (%q). The descriptor claims a "+
+				"leaf the schema does not describe.", path, i, segment)
+
+		child, ok := props[segment].(map[string]any)
+		require.Truef(t, ok,
+			"schema path %v: %q is not present under properties at segment %d. Either the "+
+				"schema dropped it or the descriptor's path is wrong; both are bugs.",
+			path, segment, i)
+
+		node = resolveSchemaRef(t, schema, child)
+	}
+	return node
+}
+
+// resolveSchemaRef replaces a "$ref" with its target, preserving sibling keys.
+//
+// Siblings are kept rather than discarded because a constraint written beside a
+// $ref applies in addition to the referenced schema, and dropping it would make
+// this test under-report exactly the constraints it is here to read.
+func resolveSchemaRef(t *testing.T, root, node map[string]any) map[string]any {
+	t.Helper()
+
+	ref, ok := node["$ref"].(string)
+	if !ok {
+		return node
+	}
+
+	const prefix = "#/$defs/"
+	require.Truef(t, strings.HasPrefix(ref, prefix),
+		"unsupported $ref %q: this helper resolves only local %s refs. Teach it the new "+
+			"form rather than letting the lookup fall through to an empty node.", ref, prefix)
+
+	defs, ok := root["$defs"].(map[string]any)
+	require.True(t, ok, "schema has no $defs but a $ref points into it")
+	target, ok := defs[strings.TrimPrefix(ref, prefix)].(map[string]any)
+	require.Truef(t, ok, "$ref %q does not resolve", ref)
+
+	merged := make(map[string]any, len(target)+len(node))
+	for k, v := range target {
+		merged[k] = v
+	}
+	for k, v := range node {
+		if k != "$ref" {
+			merged[k] = v
+		}
+	}
+	return merged
+}
+
+// schemaExcludesZeroValue reports whether the schema forbids the Go zero value
+// for a leaf: 0 for an integer, "" for a string.
+//
+// This is the single hand-written rule described on
+// TestResolvedSettings_AbsentWhenMissingMatchesSchema. It is deliberately
+// narrow — only `minimum` and `minLength` are consulted — because those are the
+// constructs actually in use. A future `enum` or `pattern` that excludes the
+// zero value would be read here as "does not exclude", which errs toward
+// UNKNOWN: the over-cautious direction, never the false-statement direction.
+func schemaExcludesZeroValue(node map[string]any) bool {
+	if min, ok := node["minimum"].(float64); ok && min > 0 {
+		return true
+	}
+	if minLen, ok := node["minLength"].(float64); ok && minLen > 0 {
+		return true
+	}
+	return false
 }
 
 // TestResolvedSettings_ProjectFieldTypeIdentity closes the realistic half of

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -36,7 +36,7 @@ import (
 // is `-tags no_sqlite`, and project_settings_resolved_test.go carries
 // `//go:build !no_sqlite` — so every behaviour test for this endpoint is
 // invisible to CI, and the tests in THIS file are the only ones that run there.
-// At the time of writing that is 10 of 17 invisible.
+// At the time of writing that is 10 of 20 invisible.
 //
 // Measure it, do not count the funcs by eye:
 //
@@ -90,8 +90,11 @@ var (
 // and the enumeration is the whole argument — "we handled the obvious ones" is
 // not a soundness claim:
 //
-//  1. `omitempty` drops the field when it is zero.
-//     -> assertNoPromotedOmitEmpty
+//  1. a TAG OPTION suppresses the field when it is zero. `omitempty` does
+//     this; so does `omitzero` (Go 1.24+), which was missed for exactly as long
+//     as this check named `omitempty` alone. Stated as a category, and enforced
+//     with an allowlist, because the language has grown one of these twice.
+//     -> assertOnlySafeTagOptions
 //  2. a nil EMBEDDED STRUCT POINTER drops every field it promotes, with no
 //     tag and no marshaller involved.
 //     -> assertNoEmbeddedStructPointer
@@ -222,9 +225,14 @@ func assertNoEmbeddedStructPointer(t *testing.T, v any) {
 					"resolved-settings response types.\n"+
 					"Its fields are promoted onto this object, so when it is nil the "+
 					"encoder emits none of them and the exact-set shape guard — which "+
-					"reads a zero value — sees nothing missing. No omitempty and no "+
-					"custom marshaller are involved, so neither of the other two checks "+
-					"can see it either.\n"+
+					"reads a zero value — sees nothing missing.\n"+
+					"This fires on the SHAPE, whatever the promoted fields are tagged "+
+					"with. In the canonical case no omitempty and no custom marshaller "+
+					"are involved, so neither of the other two checks can see it. If the "+
+					"target DOES carry omitempty, this check simply reports it first — "+
+					"the walk rejects the pointer instead of descending through it, so "+
+					"the message says \"embedded pointer\" and not \"omitempty\". The "+
+					"verdict is correct either way; it is not a false positive.\n"+
 					"Give it a name and a json tag if you need it: a named pointer nests "+
 					"under its own key and marshals to null, which the guard can see.",
 				path, field.Name)
@@ -251,13 +259,54 @@ func assertNoEmbeddedStructPointer(t *testing.T, v any) {
 // have to be rewritten to drive the marshaller across enough inputs to
 // enumerate its outputs, which is a much larger and less reliable test than
 // this one.
+// implementsJSONMarshaler reports whether EITHER receiver form of typ carries a
+// custom MarshalJSON.
+//
+// THE TWO HALVES COVER DISJOINT INPUTS; NEITHER IS BELT-AND-BRACES. Measured:
+//
+//	input typ            value half   pointer half
+//	T (value type)         false*        true       *false iff receiver is *T
+//	*T (pointer type)      true          FALSE
+//
+// For a VALUE type the value half is strictly implied by the pointer half — a
+// value-receiver method is in *T's method set too — so it catches nothing the
+// other misses. For a POINTER type the implication reverses and the pointer half
+// goes false, because PointerTo(*T) is **T, whose method set is empty. Each half
+// is therefore the only working half for one of the two input kinds.
+//
+// Today every caller passes a value, so the VALUE half is unreachable-but-not-
+// wrong; it becomes the only thing that works the moment someone writes
+// assertNoCustomMarshaler(t, &ResolvedProjectSettings{}). Both are pinned below
+// rather than only the one currently doing work, because "this half is dead" is
+// a fact about the call sites, not about the function.
+//
+// WHY THE POINTER HALF MATTERS FOR THIS ENDPOINT SPECIFICALLY. A pointer-receiver
+// MarshalJSON is invoked by encoding/json only on an addressable value, so
+// json.Marshal(T{}) does not call it and json.Marshal(&T{}) does. That split is
+// not hypothetical here: the handler marshals a POINTER — resolvedProjectSettings
+// returns *ResolvedProjectSettings and writeJSON is handed that pointer directly
+// — while jsonWireNames below marshals a VALUE. So a value-receiver-only check
+// permits precisely the form production uses, and the guard would read a clean
+// zero-value object while the handler emitted whatever the marshaller wrote.
+//
+// This is factored out of the assertion so a test can interrogate it directly.
+// TestResolvedGuard_MarshalerCheckSeesBothReceiverForms pins the pointer half
+// specifically: deleting it turns that test red with no mutation planted.
+// Without it, deleting the half is invisible to the entire committed suite, and
+// a reader who assumes "if the type implements it, so does the pointer" — the
+// implication holds only in that direction — would simplify the condition and
+// see nothing fail.
+func implementsJSONMarshaler(typ reflect.Type) bool {
+	marshaler := reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+	return typ.Implements(marshaler) || reflect.PointerTo(typ).Implements(marshaler)
+}
+
 func assertNoCustomMarshaler(t *testing.T, v any) {
 	t.Helper()
 
-	marshaler := reflect.TypeOf((*json.Marshaler)(nil)).Elem()
 	typ := reflect.TypeOf(v)
 
-	assert.Falsef(t, typ.Implements(marshaler) || reflect.PointerTo(typ).Implements(marshaler),
+	assert.Falsef(t, implementsJSONMarshaler(typ),
 		"%s implements json.Marshaler, which this guard cannot see through.\n"+
 			"A custom marshaller decides at runtime which keys to write, so the exact-set "+
 			"assertion below — which reads what the encoder emits for one constructed "+
@@ -279,7 +328,7 @@ func assertNoCustomMarshaler(t *testing.T, v any) {
 //
 // This helper reports on ONE value. That is only a bound on what real
 // responses contain if nothing can suppress a key for the value it is given —
-// so callers must pair it with both assertNoPromotedOmitEmpty and
+// so callers must pair it with both assertOnlySafeTagOptions and
 // assertNoCustomMarshaler. Neither is optional and neither implies the other;
 // resolvedResponseTypes carries the coverage argument.
 func jsonWireNames(t *testing.T, v any) []string {
@@ -301,7 +350,7 @@ func jsonWireNames(t *testing.T, v any) []string {
 	return names
 }
 
-// assertNoPromotedOmitEmpty fails if any field promoted onto v's top-level JSON
+// (see assertOnlySafeTagOptions below) fails if any field promoted onto v's top-level JSON
 // object carries `,omitempty`.
 //
 // This is what makes jsonWireNames trustworthy on a zero value, and it is the
@@ -355,7 +404,60 @@ func jsonWireNames(t *testing.T, v any) []string {
 // custom marshaller suppresses keys without any tag being involved, and this
 // function is blind to it. assertNoCustomMarshaler closes that one. See
 // resolvedResponseTypes for why both are needed and neither implies the other.
-func assertNoPromotedOmitEmpty(t *testing.T, v any) {
+// safeJSONTagOptions is an ALLOWLIST: json tag options known not to affect
+// WHICH KEYS the encoder emits. Anything not listed here is rejected.
+//
+// This is an allowlist rather than a denylist of the bad options, and that was a
+// deliberate reversal after being caught. The check named `omitempty` and only
+// `omitempty`; Go 1.24 added `omitzero`, a second spelling of the same hazard,
+// and this file did not mention it. Measured on the real types at 25f82c33 with
+// `winner,omitzero` planted on BOTH hub and hubclient ResolvedProjectSetting:
+// the whole suite passed in both tag modes while the key reached the wire —
+// byte-for-byte the defect the coverage argument above says this guard exists to
+// stop, with one word changed.
+//
+// The two designs fail in opposite directions, and only one of them is safe:
+//
+//   - denylist: an option nobody here has heard of is ACCEPTED SILENTLY. That is
+//     the defect itself, and it is how omitzero survived.
+//   - allowlist: an option nobody here has heard of FAILS LOUDLY, and someone
+//     spends one line and a sentence of justification adding it.
+//
+// The cost is real — a legitimate future option produces a red that has to be
+// cleared by hand — and it is the right trade only because this check is scoped
+// to four enumerated types that are meant to be boring data. It would be
+// obnoxious applied broadly.
+//
+// IT IS DELIBERATELY EMPTY. The rule is therefore "a json tag on these types
+// carries a NAME AND NOTHING ELSE"; any comma is rejected. Measured across all
+// four types: ten fields, zero tag options, zero commas — so the strict form
+// costs nothing today, and no exemption needs carving for it now.
+//
+// `string` is the obvious candidate if one is ever needed (it changes how a
+// value is ENCODED, a number written as a JSON string, never whether its key
+// appears). It is deliberately NOT pre-authorised: an allowlist entry nobody
+// uses is an unreviewed exemption sitting open.
+//
+// THREE BOUNDARY CASES a reader will reach for, none of which is a hole:
+//
+//   - json:"-"   no comma, so this check ACCEPTS it. But the field then leaves
+//     the wire entirely, so its key is missing from the zero marshal and the
+//     exact-set assertion fails against expectedResolved*Fields. Caught
+//     downstream, not here.
+//   - json:"-,"  a literal "-" key. HAS a comma, so it is rejected right here.
+//   - no tag     no comma, ACCEPTED. The key becomes the Go field name, present
+//     in the zero marshal but absent from the expected set, so the exact-set
+//     assertion fails. Caught downstream.
+//
+// The comma rule and the exact-set assertion cover the three between them. This
+// is spelled out because `json:"-"` sailing through looks like a hole, and a
+// reader who "fixes" it here will be hardening the wrong check.
+var safeJSONTagOptions = map[string]bool{}
+
+// assertOnlySafeTagOptions fails if any field whose key is promoted into the
+// resolved-settings object carries a json tag option that is not on
+// safeJSONTagOptions.
+func assertOnlySafeTagOptions(t *testing.T, v any) {
 	t.Helper()
 
 	typ := reflect.TypeOf(v)
@@ -392,18 +494,29 @@ func assertNoPromotedOmitEmpty(t *testing.T, v any) {
 			}
 
 			for _, opt := range parts[1:] {
-				assert.NotEqualf(t, "omitempty", opt,
-					"%s%s carries `omitempty`, which is not allowed on the "+
-						"resolved-settings response types.\n"+
+				if safeJSONTagOptions[opt] {
+					continue
+				}
+				assert.Failf(t, "unsafe json tag option",
+					"%s%s carries the json tag option `%s`, which is not on the "+
+						"known-safe list for the resolved-settings response types, "+
+						"which carry a tag NAME and nothing else.\n"+
 						"Two reasons, and the second is the one that bites:\n"+
 						"  1. This response never omits keys. Every registered setting is "+
 						"reported every time, and an unset projectValue is explicit null, "+
 						"so that a client cannot infer \"absent\" from a missing key.\n"+
-						"  2. `omitempty` hides a zero-valued field from the encoder, and "+
-						"the shape guard reads the encoder's output. A field with "+
-						"`omitempty` can reach real clients while "+
-						"TestResolvedSettingsResponseShape_NoEffectiveValue stays green.",
-					path, field.Name)
+						"  2. An option that suppresses a zero-valued field hides it from "+
+						"the encoder, and the shape guard reads the encoder's output. Such "+
+						"a field can reach real clients while "+
+						"TestResolvedSettingsResponseShape_NoEffectiveValue stays green. "+
+						"This is not hypothetical: `omitempty` and `omitzero` both do it, "+
+						"and `omitzero` additionally honours a user-defined IsZero(), so "+
+						"the key set can depend on a method's opinion of zero-ness rather "+
+						"than on the value being zero at all.\n"+
+						"If `%s` genuinely cannot change which keys are emitted, add it to "+
+						"safeJSONTagOptions with a note saying why. Do not delete this "+
+						"check to make it pass.",
+					path, field.Name, opt, opt)
 			}
 		}
 	}
@@ -624,9 +737,7 @@ func TestResolvedSettingsResponseShape_NoEffectiveValue(t *testing.T) {
 	// found the third — see the coverage argument on resolvedResponseTypes,
 	// which records what each one is and how it was measured.
 	for _, v := range resolvedResponseTypes() {
-		assertNoPromotedOmitEmpty(t, v)     // intervener 1: tags
-		assertNoEmbeddedStructPointer(t, v) // intervener 2: type structure
-		assertNoCustomMarshaler(t, v)       // intervener 3: behaviour
+		assertResponseKeySetIsTypeDetermined(t, v)
 	}
 
 	// Step 2: the encoder's actual output is exactly the expected set.
@@ -643,6 +754,28 @@ func TestResolvedSettingsResponseShape_NoEffectiveValue(t *testing.T) {
 	assert.Equal(t, expectedResolvedEntryFields,
 		jsonWireNames(t, ResolvedProjectSetting{}),
 		"hub.ResolvedProjectSetting"+rationale)
+
+	// The SAME assertion over a POINTER, because that is the production path:
+	// resolvedProjectSettings returns *ResolvedProjectSettings and writeJSON
+	// marshals that pointer. The value form above is what this guard has always
+	// read, and the two can disagree — encoding/json invokes a pointer-receiver
+	// MarshalJSON only on an addressable value, so a marshaller reachable from
+	// &T but not from T would rewrite the response with the value assertion
+	// green.
+	//
+	// assertNoCustomMarshaler currently makes that divergence impossible, so
+	// today these two pairs are provably identical and this looks redundant. It
+	// is kept because the PAIR is itself a second, independent control on the
+	// marshaller ban, reached by a different route than the instrument table: if
+	// the ban is ever weakened AND a pointer-receiver marshaller appears, the &T
+	// assertion fires and the T assertion does not. A proof resting on the ban
+	// does not survive the ban being narrowed; this does.
+	assert.Equal(t, expectedResolvedWrapperFields,
+		jsonWireNames(t, &ResolvedProjectSettings{}),
+		"*hub.ResolvedProjectSettings (the production path)"+rationale)
+	assert.Equal(t, expectedResolvedEntryFields,
+		jsonWireNames(t, &ResolvedProjectSetting{}),
+		"*hub.ResolvedProjectSetting (the production path)"+rationale)
 
 	// The hubclient mirror is part of the same contract: a field added to only
 	// one side would produce a client type that silently disagrees with the
@@ -929,4 +1062,315 @@ func TestResolvedSettings_ProjectFieldTypeIdentity(t *testing.T) {
 			"exact-set shape guard no longer sees what this endpoint actually returns — "+
 			"a widened wrapper is the supported way to sneak an effective value into this "+
 			"response, which is precisely what these guards exist to prevent.")
+}
+
+// marshalerCtrlValue carries a VALUE-receiver MarshalJSON. Both receiver forms
+// of this type satisfy json.Marshaler, so either half of the check catches it.
+type marshalerCtrlValue struct {
+	X int `json:"x"`
+}
+
+func (marshalerCtrlValue) MarshalJSON() ([]byte, error) { return []byte(`{"custom":1}`), nil }
+
+// marshalerCtrlPointer carries a POINTER-receiver MarshalJSON. Only *T satisfies
+// json.Marshaler; T does not. This is the shape a value-receiver-only check misses.
+type marshalerCtrlPointer struct {
+	X int `json:"x"`
+}
+
+func (*marshalerCtrlPointer) MarshalJSON() ([]byte, error) { return []byte(`{"custom":1}`), nil }
+
+// marshalerCtrlNone is the negative control: no custom marshaller at all.
+type marshalerCtrlNone struct {
+	X int `json:"x"`
+}
+
+// TestResolvedGuard_MarshalerCheckSeesBothReceiverForms tests the INSTRUMENT, not
+// the response types.
+//
+// The marshaller ban is the only thing standing between this guard and a defect
+// that was found in review, and its pointer half is solely responsible for
+// catching the pointer-receiver form. Measured: with a pointer-receiver
+// MarshalJSON planted on the real ResolvedProjectSettings, the full condition
+// fails and the value half alone passes. Nothing in the committed suite noticed
+// the difference, because a planted mutation is not a test — so this is that
+// test.
+//
+// It asserts the halves SEPARATELY rather than just asserting the combined
+// result. A control that only checked the combined value would stay green if
+// someone deleted the pointer half and the value half happened to cover the
+// cases, which is the same unattributed-red mistake this file's own controls
+// made earlier: red, but not for the reason claimed.
+func TestResolvedGuard_MarshalerCheckSeesBothReceiverForms(t *testing.T) {
+	marshaler := reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+
+	t.Run("pointer receiver is invisible to the value half", func(t *testing.T) {
+		typ := reflect.TypeOf(marshalerCtrlPointer{})
+
+		// The attribution. If this pair ever flips, the comment on
+		// implementsJSONMarshaler is wrong and the pointer half is redundant.
+		assert.False(t, typ.Implements(marshaler),
+			"a pointer-receiver MarshalJSON must NOT satisfy json.Marshaler on the "+
+				"value type; if it does, this control no longer distinguishes the halves")
+		assert.True(t, reflect.PointerTo(typ).Implements(marshaler),
+			"a pointer-receiver MarshalJSON must satisfy json.Marshaler on the pointer type")
+
+		assert.True(t, implementsJSONMarshaler(typ),
+			"the check must reject a pointer-receiver marshaller. If this fails, the "+
+				"`|| reflect.PointerTo(...)` half has been removed, and the guard now "+
+				"permits exactly the receiver form the handler uses")
+	})
+
+	t.Run("value receiver is caught too", func(t *testing.T) {
+		typ := reflect.TypeOf(marshalerCtrlValue{})
+
+		assert.True(t, typ.Implements(marshaler))
+		assert.True(t, reflect.PointerTo(typ).Implements(marshaler),
+			"a value-receiver method is in the pointer type's method set as well; this "+
+				"is why deleting the VALUE half alone would not turn these cases red, "+
+				"and why the two halves are not symmetric")
+		assert.True(t, implementsJSONMarshaler(typ))
+	})
+
+	// Pins the VALUE half. It is unreachable from today's call sites, which all
+	// pass values — deleting it leaves every other case in this test green — so
+	// without this subtest the half is undefended and reads as redundant. It is
+	// not: for a pointer TYPE the pointer half goes false, because PointerTo(*T)
+	// is **T with an empty method set.
+	t.Run("pointer type is invisible to the pointer half", func(t *testing.T) {
+		typ := reflect.TypeOf(&marshalerCtrlPointer{})
+
+		assert.True(t, typ.Implements(marshaler),
+			"*T satisfies json.Marshaler directly")
+		assert.False(t, reflect.PointerTo(typ).Implements(marshaler),
+			"PointerTo(*T) is **T and satisfies nothing; if this ever flips, the "+
+				"disjointness argument on implementsJSONMarshaler is wrong")
+
+		assert.True(t, implementsJSONMarshaler(typ),
+			"the check must reject a marshaller reached through a pointer TYPE. If "+
+				"this fails, the `typ.Implements(marshaler)` half has been removed as "+
+				"redundant — it is not redundant, it is merely unused today")
+	})
+
+	t.Run("no marshaller is not rejected", func(t *testing.T) {
+		typ := reflect.TypeOf(marshalerCtrlNone{})
+
+		assert.False(t, implementsJSONMarshaler(typ),
+			"the check must not fire on an ordinary struct; without this the ban could "+
+				"pass by rejecting everything")
+	})
+
+	// The reason the receiver form matters at all: encoding/json calls a
+	// pointer-receiver marshaller only on an addressable value. The guard marshals
+	// a value, production marshals a pointer, so the two disagree about what this
+	// type even emits.
+	t.Run("encoding/json honours the receiver form", func(t *testing.T) {
+		asValue, err := json.Marshal(marshalerCtrlPointer{X: 7})
+		require.NoError(t, err)
+		asPointer, err := json.Marshal(&marshalerCtrlPointer{X: 7})
+		require.NoError(t, err)
+
+		assert.JSONEq(t, `{"x":7}`, string(asValue),
+			"marshalling the VALUE must bypass the pointer-receiver marshaller")
+		assert.JSONEq(t, `{"custom":1}`, string(asPointer),
+			"marshalling the POINTER must invoke it — this divergence is why the ban "+
+				"cannot look at one receiver form only")
+	})
+}
+
+// assertResponseKeySetIsTypeDetermined runs all three interveners against v.
+//
+// The three are bundled here rather than called separately at the use site so
+// that TestResolvedSettingsGuard_InstrumentControls can drive them as a unit.
+// Deleting any one of the three from this function turns control rows red;
+// called individually at the use site, a deletion there would be invisible.
+func assertResponseKeySetIsTypeDetermined(t *testing.T, v any) {
+	t.Helper()
+
+	assertOnlySafeTagOptions(t, v)      // intervener 1: tags
+	assertNoEmbeddedStructPointer(t, v) // intervener 2: type structure
+	assertNoCustomMarshaler(t, v)       // intervener 3: behaviour
+}
+
+// Control fixtures for TestResolvedSettingsGuard_InstrumentControls. Each is the
+// smallest type that exhibits one shape. They are deliberately NOT variations on
+// the real response types: a control that resembles the thing it guards invites
+// someone to "fix" the control when the real type changes.
+type (
+	ctlClean struct {
+		ProjectSet bool `json:"projectSet"`
+	}
+	ctlEmbedTarget struct {
+		Winner string `json:"winner"`
+	}
+	ctlOmitTarget struct {
+		Winner string `json:"winner,omitempty"`
+	}
+	ctlZeroTarget struct {
+		Winner string `json:"winner,omitzero"`
+	}
+)
+
+type ctlOmitEmpty struct {
+	ProjectSet bool `json:"projectSet"`
+	ctlOmitTarget
+}
+
+// ctlOmitZero is the shape that was green at 25f82c33 while putting a key on the
+// wire. It is the reason the tag check became an allowlist.
+type ctlOmitZero struct {
+	ProjectSet bool `json:"projectSet"`
+	ctlZeroTarget
+}
+
+type ctlEmbeddedPtr struct {
+	ProjectSet bool `json:"projectSet"`
+	*ctlEmbedTarget
+}
+
+type ctlMid struct{ *ctlEmbedTarget }
+
+// ctlNestedPtr hides the embedded pointer one level down, under an embedded
+// VALUE. A top-level scan for anonymous pointer fields does not see it.
+type ctlNestedPtr struct {
+	ProjectSet bool `json:"projectSet"`
+	ctlMid
+}
+
+type ctlEmbeddedValue struct {
+	ProjectSet bool `json:"projectSet"`
+	ctlEmbedTarget
+}
+
+type ctlNamedPtr struct {
+	ProjectSet bool            `json:"projectSet"`
+	Extra      *ctlEmbedTarget `json:"extra"`
+}
+
+// instrumentFires reports whether f fails when run against v.
+//
+// f is run against a throwaway *testing.T so a neighbouring assertion cannot
+// manufacture the result — the failure mode that made two of this file's own
+// manual controls go red for the wrong reason, tripping the exact-set and mirror
+// assertions rather than the instrument under test.
+//
+// The goroutine is not incidental. The instruments use require.* for their
+// structural preconditions, and require failing calls FailNow, which is
+// runtime.Goexit. Run inline that would tear down the calling test goroutine
+// mid-table; contained here, the deferred close still runs and the caller sees
+// an ordinary "it failed".
+func instrumentFires(t *testing.T, f func(*testing.T, any), v any) bool {
+	t.Helper()
+
+	// Every input must be a struct, because the instruments open with a
+	// require on the kind. Without this line a non-struct row would trip that
+	// require, sub.Failed() would report true, and a REJECT row would PASS —
+	// recording the instrument as having caught a defect it never examined.
+	// That is the red-for-the-wrong-reason failure this table exists to prevent,
+	// so it would be a poor thing to reproduce inside the table itself.
+	require.Equal(t, reflect.Struct, reflect.Indirect(reflect.ValueOf(v)).Kind(),
+		"control inputs must be structs; the instruments require on kind and a "+
+			"non-struct would be rejected as malformed rather than examined")
+
+	sub := &testing.T{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f(sub, v)
+	}()
+	<-done
+
+	return sub.Failed()
+}
+
+// TestResolvedSettingsGuard_InstrumentControls pins the instruments themselves.
+//
+// Before this existed the whole shape guard could be removed in two lines with
+// the suite still green: deleting the pointer half of the marshaller check, or
+// deleting the intervener calls outright, broke no test in either tag mode. The
+// controls for those cases had been run by hand and were correct, but evidence
+// that lives in a transcript does not fail a build, and the next person to
+// simplify one of these conditions will have neither.
+//
+// The ACCEPT rows carry as much weight as the REJECT rows. A ban that rejects
+// everything passes every REJECT row while making the guard useless, and a
+// legitimate named-pointer or embedded-value field must keep working.
+func TestResolvedSettingsGuard_InstrumentControls(t *testing.T) {
+	const why = "\n\nThis control exists so the instrument cannot be weakened in " +
+		"silence. If you are reading this because you simplified one of the " +
+		"assert helpers, the simplification removed coverage — see the coverage " +
+		"argument on resolvedResponseTypes before changing it back."
+
+	cases := []struct {
+		name string
+		f    func(*testing.T, any)
+		v    any
+		want bool
+	}{
+		// REJECT rows: intervener 1, tags.
+		{"omitempty promoted from embedded value", assertOnlySafeTagOptions, ctlOmitEmpty{}, true},
+		{"omitzero promoted from embedded value", assertOnlySafeTagOptions, ctlOmitZero{}, true},
+
+		// REJECT rows: intervener 2, type structure.
+		{"embedded pointer at top level", assertNoEmbeddedStructPointer, ctlEmbeddedPtr{}, true},
+		{"embedded pointer one level down", assertNoEmbeddedStructPointer, ctlNestedPtr{}, true},
+
+		// REJECT rows: intervener 3, behaviour. The pointer-receiver row is the
+		// form production uses; without it, deleting the pointer half of the
+		// check breaks nothing.
+		{"value-receiver MarshalJSON", assertNoCustomMarshaler, marshalerCtrlValue{}, true},
+		{"pointer-receiver MarshalJSON", assertNoCustomMarshaler, marshalerCtrlPointer{}, true},
+
+		// REJECT rows through the COMPOSITE. These are what make deleting one of
+		// the three calls inside assertResponseKeySetIsTypeDetermined visible.
+		{"composite catches tags", assertResponseKeySetIsTypeDetermined, ctlOmitZero{}, true},
+		{"composite catches structure", assertResponseKeySetIsTypeDetermined, ctlNestedPtr{}, true},
+		{"composite catches behaviour", assertResponseKeySetIsTypeDetermined, marshalerCtrlPointer{}, true},
+
+		// ACCEPT rows.
+		{"named pointer field is ACCEPTED", assertNoEmbeddedStructPointer, ctlNamedPtr{}, false},
+		{"embedded value is ACCEPTED", assertNoEmbeddedStructPointer, ctlEmbeddedValue{}, false},
+		{"plain tags are ACCEPTED", assertOnlySafeTagOptions, ctlEmbeddedValue{}, false},
+		{"no marshaller is ACCEPTED", assertNoCustomMarshaler, ctlEmbeddedValue{}, false},
+		{"a clean type passes the composite", assertResponseKeySetIsTypeDetermined, ctlClean{}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := instrumentFires(t, tc.f, tc.v); got != tc.want {
+				t.Errorf("instrument fired=%v, want %v%s", got, tc.want, why)
+			}
+		})
+	}
+}
+
+// TestResolvedSettings_SettingsValueTypeIdentity pins the map's value type.
+//
+// The coverage argument on resolvedResponseTypes reasons about four types. That
+// reasoning only reaches the "settings" sub-objects because the map's value type
+// IS one of the four; widen it and the response grows a shape no guard in this
+// file has looked at.
+//
+// The property was already held before this test existed — but only by the
+// compiler, incidentally, at the two sites that construct the map, with no
+// message attached. That is a worse position than it sounds, because the field
+// immediately above it, Project, has a named test explaining that retyping it is
+// the supported way to sneak an effective value into this response. The
+// asymmetry reads as "this class was considered and Settings was found not to
+// need it," which is not true and is not what anyone decided.
+func TestResolvedSettings_SettingsValueTypeIdentity(t *testing.T) {
+	field, ok := reflect.TypeOf(ResolvedProjectSettings{}).FieldByName("Settings")
+	require.True(t, ok, "ResolvedProjectSettings has no Settings field")
+	require.Equal(t, reflect.Map, field.Type.Kind(),
+		"Settings must stay a map; the guards below assume a map value type")
+
+	assert.Equal(t, reflect.TypeOf(ResolvedProjectSetting{}), field.Type.Elem(),
+		"the resolved response's \"settings\" map must stay keyed to exactly "+
+			"ResolvedProjectSetting.\n"+
+			"Widening this value type — embedding ResolvedProjectSetting in a richer "+
+			"struct, say — moves the per-setting object outside the set of types the "+
+			"shape guard checks, and a widened entry is precisely how an effective "+
+			"value would reach clients. That is the thing these guards exist to "+
+			"prevent, and it is why this is asserted rather than left to the two "+
+			"construction sites where the compiler happens to notice.")
 }

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -466,13 +466,24 @@ func walkMarshalerBan(t *testing.T, v any, judgeOutOfModule bool) {
 		if !resolvedGuardMarshalerExceptions[typ] {
 			assert.Falsef(t, implementsJSONMarshaler(typ),
 				"%s implements json.Marshaler, reached at %s.\n"+
-					"That path is the FIRST this walk reached the type by, and may "+
-					"not be the only one: the type is judged once per root that "+
-					"REACHES it, so ANY further site of the same type — if the type "+
-					"has one — is affected too and is not named here. Read this as "+
-					"'this list may be incomplete', NOT as 'there are more'; a type "+
-					"with a single site is named in full. Removing the marshaller "+
-					"fixes every site at once, however many there are.\n"+
+					"HOW TO COUNT WHAT YOU ARE LOOKING AT. A SITE is one chain of "+
+					"field names descending from one root. The identical chain "+
+					"underneath a DIFFERENT root is a SECOND site, not the same site "+
+					"printed twice — the term is defined here because the two "+
+					"readings give different numbers and the rest of this paragraph "+
+					"is unreadable without one of them. The walk emits ONE line for "+
+					"every root the type is reachable from, quoting the first site "+
+					"that root arrived by, and stays silent about later sites BENEATH "+
+					"THAT SAME ROOT. The line count above is therefore a count of "+
+					"ROOTS and not of sites. Worked both ways: a type hanging off one "+
+					"chain beneath each of two roots emits 2 lines and every site it "+
+					"has is quoted; a type hanging off two chains beneath a single "+
+					"root emits 1 line and one of its sites is missing. THE OUTPUT "+
+					"CANNOT TELL YOU WHICH OF THOSE YOU HAVE. Treat the list as "+
+					"possibly short, never as evidence that something else is out "+
+					"there, and do not go searching for a chain that may not exist. "+
+					"Deleting the marshaller repairs every site simultaneously, "+
+					"quoted or not.\n"+
 					"A custom marshaller decides at runtime which keys to write, so the "+
 					"exact-set assertion — which reads what the encoder emits for one "+
 					"constructed value — stops being a bound on what real responses "+

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -64,7 +64,7 @@ import (
 // Both must stay sorted; the assertions compare sorted slices.
 var (
 	expectedResolvedWrapperFields = []string{"project", "settings"}
-	expectedResolvedEntryFields   = []string{"hubDefault", "projectSet", "projectValue"}
+	expectedResolvedEntryFields   = []string{"hubDefault", "hubValue", "projectSet", "projectValue"}
 )
 
 // resolvedResponseTypes enumerates every type whose fields land directly in the
@@ -1119,6 +1119,11 @@ func TestResolvedSettings_MirrorAcceptsServerOutput(t *testing.T) {
 				ProjectValue: &value,
 				HubDefault:   ResolvedHubDefaultUnknown,
 			},
+			projectSettingDefaultMaxTurns: {
+				ProjectSet: false,
+				HubDefault: ResolvedHubDefaultPresent,
+				HubValue:   float64(120),
+			},
 		},
 	}
 
@@ -1142,6 +1147,14 @@ func TestResolvedSettings_MirrorAcceptsServerOutput(t *testing.T) {
 	require.NotNil(t, entry.ProjectValue,
 		"projectValue must stay a pointer: null and \"\" are different answers")
 	assert.Equal(t, value, *entry.ProjectValue)
+	assert.Nil(t, entry.HubValue,
+		"hubValue must be null when hubDefault is unknown")
+
+	turnsEntry, ok := mirror.Settings[projectSettingDefaultMaxTurns]
+	require.Truef(t, ok, "the mirror lost the %q entry", projectSettingDefaultMaxTurns)
+	assert.Equal(t, hubclient.ResolvedHubDefaultPresent, turnsEntry.HubDefault)
+	assert.Equal(t, float64(120), turnsEntry.HubValue,
+		"hubValue must survive the round trip when hubDefault is present")
 
 	require.NotNil(t, mirror.Project, "the mirror dropped the \"project\" sub-object")
 	assert.Equal(t, value, mirror.Project.DefaultModel)

--- a/pkg/hub/project_settings_resolved_test.go
+++ b/pkg/hub/project_settings_resolved_test.go
@@ -256,7 +256,39 @@ func TestResolvedSettings_EndpointReturnsNoEffectiveValue(t *testing.T) {
 
 	require.Contains(t, body, "project")
 	require.Contains(t, body, "settings")
-	assert.Len(t, body, 2, "unexpected top-level keys in the resolved response")
+	assert.Lenf(t, body, len(expectedResolvedWrapperFields),
+		"unexpected top-level keys in the resolved response. If you added a field on "+
+			"purpose it must be added in THREE places: hub.ResolvedProjectSettings, "+
+			"hubclient.ResolvedProjectSettings, and expectedResolvedWrapperFields in "+
+			"project_settings_resolved_guard_test.go — which is where this assertion "+
+			"reads its expected count from, so it cannot drift out of step with the "+
+			"shape guard.")
+
+	// The denylist, over the "project" sub-object as well as the per-setting
+	// entries. Both halves matter, and the second was added because it was
+	// missing: review demonstrated a forbidden name reaching the wire inside
+	// "project" while this loop scanned only settings[key]. A denylist that
+	// looks in one of the two places a field can land is not a weaker check
+	// than one that looks in both — it is a check that reports on the wrong
+	// object.
+	//
+	// "winner" is on the list for a specific reason. The shape guard's own
+	// comment offers it as an example of a name no denylist would think of;
+	// review then used exactly that name to smuggle a field past every guard in
+	// the suite. It is here as a marker of that, not because anyone expects it.
+	forbiddenNames := []string{
+		"value", "effective", "effectiveValue", "source", "hubValue", "winner",
+	}
+
+	var projectObj map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(body["project"], &projectObj))
+	for _, forbidden := range forbiddenNames {
+		assert.NotContainsf(t, projectObj, forbidden,
+			"the \"project\" sub-object must not carry %q: this endpoint does not "+
+				"resolve precedence, and the shape guard deliberately does not police "+
+				"hubclient.ProjectSettings' field list, so this is the only check "+
+				"looking here", forbidden)
+	}
 
 	var settings map[string]map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(body["settings"], &settings))
@@ -265,11 +297,14 @@ func TestResolvedSettings_EndpointReturnsNoEffectiveValue(t *testing.T) {
 		entry, ok := settings[key]
 		require.Truef(t, ok, "registered setting %q missing from the wire payload", key)
 
-		// The forbidden names are checked here as a belt-and-braces read of the
-		// real payload. The authoritative check is the exact-set guard in
-		// project_settings_resolved_guard_test.go — this loop is a denylist and
-		// would not catch a name nobody thought of.
-		for _, forbidden := range []string{"value", "effective", "effectiveValue", "source", "hubValue"} {
+		// Read of the real payload, complementary to the exact-set guard in
+		// project_settings_resolved_guard_test.go. Note the ordering claim that
+		// used to sit here — that the exact-set guard was "the authoritative
+		// check" and this loop merely belt-and-braces — was measured false: for
+		// the whole of this phase the guard could not see a promoted field, and
+		// this denylist is what actually fired. Neither is authoritative over
+		// the other; they fail on different things.
+		for _, forbidden := range forbiddenNames {
 			assert.NotContainsf(t, entry, forbidden,
 				"the resolved response must not carry %q: this endpoint does not "+
 					"resolve precedence", forbidden)

--- a/pkg/hub/project_settings_resolved_test.go
+++ b/pkg/hub/project_settings_resolved_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
@@ -337,4 +338,67 @@ func TestResolvedSettings_EndpointUnknownProject(t *testing.T) {
 	rec := doRequest(t, srv, http.MethodGet,
 		"/api/v1/projects/does-not-exist/settings/resolved", nil)
 	assert.Equal(t, http.StatusNotFound, rec.Code, "body: %s", rec.Body.String())
+}
+
+// TestResolvedSettings_NonHubMemberForbidden asserts that the Forbidden branch
+// of this endpoint is REACHABLE and correct: a caller who is not a hub member
+// gets 403.
+//
+// Read the wording carefully, because the obvious version of this test cannot
+// be written on this platform. The seeded hub-member-read-all policy grants
+// ActionRead on ALL projects to EVERY hub member, so a caller who is merely not
+// a member OF THIS PROJECT is legitimately authorized and gets 200. A test
+// named "non-member is refused" would have had to assert 200 in order to pass,
+// which is very likely why no negative test existed here in the first place.
+// The meaningful denial is therefore a non-HUB-member, and that is what this
+// asserts.
+//
+// Both facts are pinned below, the surprising one deliberately, so that the
+// next person to read this does not "fix" the 200 into a 403 and break the
+// platform's actual access model.
+func TestResolvedSettings_NonHubMemberForbidden(t *testing.T) {
+	srv, s, _, hubMemberNonProjectMember, project := setupDemoPolicyTest(t)
+
+	// A user who exists and is authenticated, but was never added to the
+	// hub-members group. ensureHubMembership is deliberately NOT called.
+	outsider := &store.User{
+		ID:          tid("user-outsider"),
+		Email:       "outsider@test.com",
+		DisplayName: "Outsider",
+		Role:        store.UserRoleMember,
+		Status:      "active",
+		Created:     time.Now(),
+	}
+	require.NoError(t, s.CreateUser(t.Context(), outsider))
+
+	resolvedPath := "/api/v1/projects/" + project.ID + "/settings/resolved"
+	settingsPath := "/api/v1/projects/" + project.ID + "/settings"
+
+	// The assertion the lead asked for: the Forbidden branch is reachable.
+	rec := doRequestAsUser(t, srv, outsider, http.MethodGet, resolvedPath, nil)
+	assert.Equalf(t, http.StatusForbidden, rec.Code,
+		"a non-hub-member must be refused by the resolved endpoint; body: %s",
+		rec.Body.String())
+
+	// Control against the pre-existing endpoint this handler was modelled on.
+	// If GET /settings ever stops refusing this caller, the line above is
+	// asserting a local quirk rather than the platform's policy, and the two
+	// should be changed together rather than drifting apart.
+	rec = doRequestAsUser(t, srv, outsider, http.MethodGet, settingsPath, nil)
+	assert.Equalf(t, http.StatusForbidden, rec.Code,
+		"control: the pre-existing GET /settings must refuse the same caller, "+
+			"otherwise /settings/resolved is enforcing a policy of its own; body: %s",
+		rec.Body.String())
+
+	// The counter-intuitive half. This caller is NOT a member of the project,
+	// and is nonetheless authorized, because hub-member-read-all grants read on
+	// every project to every hub member. This is pinned as correct-as-designed.
+	// If it ever returns 403, the hub's read model has changed and this
+	// endpoint's authorization needs rereading — do not simply update the
+	// expectation.
+	rec = doRequestAsUser(t, srv, hubMemberNonProjectMember, http.MethodGet, resolvedPath, nil)
+	assert.Equalf(t, http.StatusOK, rec.Code,
+		"a hub member who is not a project member is granted read by "+
+			"hub-member-read-all and must get 200, not 403; body: %s",
+		rec.Body.String())
 }

--- a/pkg/hub/project_settings_resolved_test.go
+++ b/pkg/hub/project_settings_resolved_test.go
@@ -1,0 +1,340 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rawDoc is a helper for building an agent_defaults section document.
+func rawDoc(t *testing.T, jsonText string) map[string]json.RawMessage {
+	t.Helper()
+	doc := map[string]json.RawMessage{}
+	require.NoError(t, json.Unmarshal([]byte(jsonText), &doc))
+	return doc
+}
+
+// TestResolvedSettings_HubDefaultPresenceSemantics pins the tri-state rules
+// that were established by measurement rather than by reading the Go types.
+//
+// The per-field split is not guessable from opsettings.AgentDefaultsSettings:
+// it comes from settings-v1.schema.json. default_max_turns and
+// default_max_model_calls carry "minimum": 1, so an explicit 0 is rejected by
+// validation and can never be persisted — absence therefore means unset. The
+// string fields have no minLength, so "" validates and is then dropped by the
+// `omitempty` marshal on the admin write path, making absence ambiguous.
+func TestResolvedSettings_HubDefaultPresenceSemantics(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		doc  string
+		want ResolvedHubDefault
+	}{
+		{
+			name: "int present",
+			key:  projectSettingDefaultMaxTurns,
+			doc:  `{"default_max_turns": 120}`,
+			want: ResolvedHubDefaultPresent,
+		},
+		{
+			// Unambiguous: schema minimum:1 means 0 can never reach the doc,
+			// so a missing key really does mean "never configured".
+			name: "int missing is absent, because zero is unpersistable",
+			key:  projectSettingDefaultMaxTurns,
+			doc:  `{}`,
+			want: ResolvedHubDefaultAbsent,
+		},
+		{
+			name: "string present",
+			key:  projectSettingDefaultTemplate,
+			doc:  `{"default_template": "base"}`,
+			want: ResolvedHubDefaultPresent,
+		},
+		{
+			// Ambiguous: an explicitly-configured "" is dropped by omitempty
+			// before it is stored, so this is indistinguishable from unset.
+			// Reporting "absent" here would be a false statement.
+			name: "string missing is unknown, not absent",
+			key:  projectSettingDefaultTemplate,
+			doc:  `{}`,
+			want: ResolvedHubDefaultUnknown,
+		},
+		{
+			name: "duration missing is unknown",
+			key:  projectSettingDefaultMaxDuration,
+			doc:  `{}`,
+			want: ResolvedHubDefaultUnknown,
+		},
+		{
+			name: "nested resource leaf present",
+			key:  projectSettingDefaultResourcesCPUReq,
+			doc:  `{"default_resources": {"requests": {"cpu": "2"}}}`,
+			want: ResolvedHubDefaultPresent,
+		},
+		{
+			// default_resources is *api.ResourceSpec — a pointer, which CAN
+			// represent unset — so its absence is faithful and reports absent
+			// even though the leaf itself is an ambiguous string.
+			name: "nested root missing is absent, because the root is a pointer",
+			key:  projectSettingDefaultResourcesCPUReq,
+			doc:  `{}`,
+			want: ResolvedHubDefaultAbsent,
+		},
+		{
+			name: "nested leaf missing under present root is unknown",
+			key:  projectSettingDefaultResourcesCPUReq,
+			doc:  `{"default_resources": {"requests": {"memory": "1Gi"}}}`,
+			want: ResolvedHubDefaultUnknown,
+		},
+		{
+			name: "nested disk present",
+			key:  projectSettingDefaultResourcesDisk,
+			doc:  `{"default_resources": {"disk": "10Gi"}}`,
+			want: ResolvedHubDefaultPresent,
+		},
+		{
+			name: "explicit json null counts as missing",
+			key:  projectSettingDefaultMaxTurns,
+			doc:  `{"default_max_turns": null}`,
+			want: ResolvedHubDefaultAbsent,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			desc, ok := resolvedSettingDescriptors[tc.key]
+			require.Truef(t, ok, "no descriptor for %q", tc.key)
+			got := hubDefaultFromDoc(rawDoc(t, tc.doc), desc)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestResolvedSettings_UnreadableSourceIsUnknownNotAbsent is the case a bool
+// could not have expressed. In file/SQLite mode there is no OperationalSettings
+// and no agent_defaults document exists to consult, so every key backed by that
+// section is UNKNOWN. Reporting "absent" would tell a consumer that the hub has
+// no default when in fact we never looked.
+func TestResolvedSettings_UnreadableSourceIsUnknownNotAbsent(t *testing.T) {
+	srv := &Server{} // no OperationalSettings: the file/SQLite path
+	doc, readable := srv.hubAgentDefaultsDoc()
+	require.False(t, readable, "a zero Server must report agent_defaults as unreadable")
+	require.Nil(t, doc)
+
+	resp := srv.resolvedProjectSettings(&store.Project{ID: "p-1"})
+
+	for key, desc := range resolvedSettingDescriptors {
+		if desc.source != hubSourceAgentDefaults {
+			continue
+		}
+		assert.Equalf(t, ResolvedHubDefaultUnknown, resp.Settings[key].HubDefault,
+			"%q is backed by agent_defaults, which could not be read; it must be "+
+				"unknown rather than absent", key)
+	}
+}
+
+// TestResolvedSettings_NoHubCounterpartIsAbsent covers the opposite case:
+// AgentDefaultsSettings has exactly six fields, enumerated in full, so "there
+// is no hub default for defaultModel" is a measured structural fact and may be
+// reported as absent rather than unknown.
+func TestResolvedSettings_NoHubCounterpartIsAbsent(t *testing.T) {
+	resp := (&Server{}).resolvedProjectSettings(&store.Project{ID: "p-1"})
+
+	for _, key := range []string{
+		projectSettingDefaultModel,
+		projectSettingDefaultThinkingLevel,
+		projectSettingActiveProfile,
+		projectSettingDefaultGCPIdentityMode,
+		projectSettingDefaultGCPIdentitySAID,
+	} {
+		assert.Equalf(t, ResolvedHubDefaultAbsent, resp.Settings[key].HubDefault,
+			"%q has no agent_defaults counterpart; that is a measured structural "+
+				"fact, so absent is the honest answer", key)
+	}
+}
+
+// TestResolvedSettings_TelemetryUsesItsRealSource checks that telemetry is
+// answered from Server.config.TelemetryDefault rather than from agent_defaults.
+//
+// This matters because agent_defaults has no telemetry field at all, so the
+// tempting answer is "absent" — which would be false, since a hub telemetry
+// default does exist, just somewhere else. TelemetryDefault is a *bool and is
+// therefore presence-faithful, so the right source can answer truthfully.
+func TestResolvedSettings_TelemetryUsesItsRealSource(t *testing.T) {
+	project := &store.Project{ID: "p-1"}
+
+	unset := (&Server{}).resolvedProjectSettings(project)
+	assert.Equal(t, ResolvedHubDefaultAbsent,
+		unset.Settings[projectSettingTelemetryEnabled].HubDefault,
+		"a nil TelemetryDefault means no hub telemetry default is configured")
+
+	for _, configured := range []bool{true, false} {
+		srv := &Server{}
+		v := configured
+		srv.config.TelemetryDefault = &v
+		got := srv.resolvedProjectSettings(project)
+		assert.Equalf(t, ResolvedHubDefaultPresent,
+			got.Settings[projectSettingTelemetryEnabled].HubDefault,
+			"TelemetryDefault=%v is configured, so a hub default is present. "+
+				"An explicit false is still a configured default — this is exactly the "+
+				"distinction the *bool exists to preserve.", configured)
+	}
+}
+
+// TestResolvedSettings_ProjectAnnotationReporting checks the project half of
+// each entry, including that an annotation explicitly set to the empty string
+// is reported as set. ProjectSet is about the annotation's existence, not about
+// whether its content is useful.
+func TestResolvedSettings_ProjectAnnotationReporting(t *testing.T) {
+	project := &store.Project{
+		ID: "p-1",
+		Annotations: map[string]string{
+			projectSettingDefaultModel:    "sonnet",
+			projectSettingActiveProfile:   "",
+			projectSettingDefaultMaxTurns: "42",
+		},
+	}
+
+	resp := (&Server{}).resolvedProjectSettings(project)
+
+	model := resp.Settings[projectSettingDefaultModel]
+	assert.True(t, model.ProjectSet)
+	require.NotNil(t, model.ProjectValue)
+	assert.Equal(t, "sonnet", *model.ProjectValue)
+
+	empty := resp.Settings[projectSettingActiveProfile]
+	assert.True(t, empty.ProjectSet, "an annotation set to \"\" is still set")
+	require.NotNil(t, empty.ProjectValue)
+	assert.Equal(t, "", *empty.ProjectValue)
+
+	// Raw string, not parsed: the annotation store holds strings.
+	turns := resp.Settings[projectSettingDefaultMaxTurns]
+	require.NotNil(t, turns.ProjectValue)
+	assert.Equal(t, "42", *turns.ProjectValue)
+
+	unset := resp.Settings[projectSettingDefaultHarnessConfig]
+	assert.False(t, unset.ProjectSet)
+	assert.Nil(t, unset.ProjectValue, "an unset annotation must be null, not \"\"")
+}
+
+// TestResolvedSettings_EndpointReturnsNoEffectiveValue asserts on the actual
+// serialized wire payload, not on the Go structs. The shape guard reflects over
+// types; this checks what a client really receives, so that a marshalling
+// surprise cannot slip an extra key past both.
+func TestResolvedSettings_EndpointReturnsNoEffectiveValue(t *testing.T) {
+	srv, s := testServer(t)
+	project := createTestProjectForSettings(t, s)
+
+	rec := doRequest(t, srv, http.MethodGet,
+		"/api/v1/projects/"+project.ID+"/settings/resolved", nil)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var body map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	require.Contains(t, body, "project")
+	require.Contains(t, body, "settings")
+	assert.Len(t, body, 2, "unexpected top-level keys in the resolved response")
+
+	var settings map[string]map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(body["settings"], &settings))
+
+	for _, key := range projectSettingKeys {
+		entry, ok := settings[key]
+		require.Truef(t, ok, "registered setting %q missing from the wire payload", key)
+
+		// The forbidden names are checked here as a belt-and-braces read of the
+		// real payload. The authoritative check is the exact-set guard in
+		// project_settings_resolved_guard_test.go — this loop is a denylist and
+		// would not catch a name nobody thought of.
+		for _, forbidden := range []string{"value", "effective", "effectiveValue", "source", "hubValue"} {
+			assert.NotContainsf(t, entry, forbidden,
+				"the resolved response must not carry %q: this endpoint does not "+
+					"resolve precedence", forbidden)
+		}
+
+		require.Contains(t, entry, "hubDefault")
+		var state string
+		require.NoError(t, json.Unmarshal(entry["hubDefault"], &state))
+		assert.Containsf(t, []string{"present", "absent", "unknown"}, state,
+			"hubDefault for %q must be one of the tri-state values, got %q", key, state)
+	}
+}
+
+// TestResolvedSettings_EndpointProjectSubObject checks that the "project" key
+// carries the same payload as GET /settings, so a client needs one round trip
+// rather than two.
+func TestResolvedSettings_EndpointProjectSubObject(t *testing.T) {
+	srv, s := testServer(t)
+	project := createTestProjectForSettings(t, s)
+
+	putBody := hubclient.ProjectSettings{
+		DefaultTemplate:      "my-template",
+		DefaultHarnessConfig: "claude-default",
+	}
+	putRec := doRequest(t, srv, http.MethodPut,
+		"/api/v1/projects/"+project.ID+"/settings", putBody)
+	require.Equal(t, http.StatusOK, putRec.Code, "body: %s", putRec.Body.String())
+
+	rec := doRequest(t, srv, http.MethodGet,
+		"/api/v1/projects/"+project.ID+"/settings/resolved", nil)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var resolved hubclient.ResolvedProjectSettings
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resolved))
+
+	require.NotNil(t, resolved.Project)
+	assert.Equal(t, "my-template", resolved.Project.DefaultTemplate)
+	assert.Equal(t, "claude-default", resolved.Project.DefaultHarnessConfig)
+
+	entry := resolved.Settings[projectSettingDefaultTemplate]
+	assert.True(t, entry.ProjectSet)
+	require.NotNil(t, entry.ProjectValue)
+	assert.Equal(t, "my-template", *entry.ProjectValue)
+}
+
+// TestResolvedSettings_EndpointIsReadOnly — there is no PUT. The whole reason
+// this is a separate sub-resource is that a writable resolved view would let a
+// GET-modify-PUT round trip promote hub defaults into project annotations.
+func TestResolvedSettings_EndpointIsReadOnly(t *testing.T) {
+	srv, s := testServer(t)
+	project := createTestProjectForSettings(t, s)
+
+	for _, method := range []string{http.MethodPut, http.MethodPost, http.MethodDelete} {
+		rec := doRequest(t, srv, method,
+			"/api/v1/projects/"+project.ID+"/settings/resolved", hubclient.ProjectSettings{})
+		assert.Equalf(t, http.StatusMethodNotAllowed, rec.Code,
+			"%s on the resolved endpoint must be rejected; it is read-only", method)
+	}
+}
+
+// TestResolvedSettings_EndpointUnknownProject checks the not-found path, so a
+// missing project does not surface as an empty but successful response.
+func TestResolvedSettings_EndpointUnknownProject(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet,
+		"/api/v1/projects/does-not-exist/settings/resolved", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code, "body: %s", rec.Body.String())
+}

--- a/pkg/hub/project_settings_resolved_test.go
+++ b/pkg/hub/project_settings_resolved_test.go
@@ -126,8 +126,65 @@ func TestResolvedSettings_HubDefaultPresenceSemantics(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			desc, ok := resolvedSettingDescriptors[tc.key]
 			require.Truef(t, ok, "no descriptor for %q", tc.key)
-			got := hubDefaultFromDoc(rawDoc(t, tc.doc), desc)
+			got, _ := hubDefaultFromDoc(rawDoc(t, tc.doc), desc)
 			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestResolvedSettings_HubValueExtraction checks that hubDefaultFromDoc returns
+// the raw hub value alongside the presence state when a hub default is present.
+func TestResolvedSettings_HubValueExtraction(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		doc       string
+		wantValue any
+	}{
+		{
+			name:      "int value extracted",
+			key:       projectSettingDefaultMaxTurns,
+			doc:       `{"default_max_turns": 120}`,
+			wantValue: float64(120), // JSON numbers unmarshal to float64
+		},
+		{
+			name:      "string value extracted",
+			key:       projectSettingDefaultTemplate,
+			doc:       `{"default_template": "base"}`,
+			wantValue: "base",
+		},
+		{
+			name:      "nested resource value extracted",
+			key:       projectSettingDefaultResourcesCPUReq,
+			doc:       `{"default_resources": {"requests": {"cpu": "2"}}}`,
+			wantValue: "2",
+		},
+		{
+			name:      "nested disk value extracted",
+			key:       projectSettingDefaultResourcesDisk,
+			doc:       `{"default_resources": {"disk": "10Gi"}}`,
+			wantValue: "10Gi",
+		},
+		{
+			name:      "missing key returns nil value",
+			key:       projectSettingDefaultMaxTurns,
+			doc:       `{}`,
+			wantValue: nil,
+		},
+		{
+			name:      "null key returns nil value",
+			key:       projectSettingDefaultMaxTurns,
+			doc:       `{"default_max_turns": null}`,
+			wantValue: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			desc, ok := resolvedSettingDescriptors[tc.key]
+			require.Truef(t, ok, "no descriptor for %q", tc.key)
+			_, gotValue := hubDefaultFromDoc(rawDoc(t, tc.doc), desc)
+			assert.Equal(t, tc.wantValue, gotValue)
 		})
 	}
 }
@@ -277,7 +334,7 @@ func TestResolvedSettings_EndpointReturnsNoEffectiveValue(t *testing.T) {
 	// review then used exactly that name to smuggle a field past every guard in
 	// the suite. It is here as a marker of that, not because anyone expects it.
 	forbiddenNames := []string{
-		"value", "effective", "effectiveValue", "source", "hubValue", "winner",
+		"value", "effective", "effectiveValue", "source", "winner",
 	}
 
 	var projectObj map[string]json.RawMessage

--- a/pkg/hub/project_settings_resolved_wireup_test.go
+++ b/pkg/hub/project_settings_resolved_wireup_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"testing"
+)
+
+// TestResolvedSettingsGuard_InterveningIsWiredToTheResponseTypes closes the
+// residual documented on assertResponseKeySetIsTypeDetermined.
+//
+// THE RESIDUAL. TestResolvedSettingsGuard_InstrumentControls proves the three
+// interveners WORK. Nothing proved they are INVOKED. Deleting the three-line
+// loop in TestResolvedSettingsResponseShape_NoEffectiveValue removed every
+// shape guard in that file and left the whole package green, because the
+// control table drives the interveners directly against its own fixtures and
+// never observes the production call site.
+//
+// HOW THIS CLOSES IT. Rather than inspect the source, this poisons the input.
+// resolvedResponseTypes is swapped for one that returns a type the interveners
+// are known to reject — known because the SAME fixture is a REJECT row in the
+// control table, so if the fixture ever stops being rejected, that table goes
+// red first and this test cannot silently invert. The subject test is then run
+// against a throwaway *testing.T. If the loop is present, the subject fails and
+// this passes. If the loop is gone, the subject passes on the production types
+// alone and this fails.
+//
+// It therefore asserts the one thing the control table cannot: that something
+// on the production path calls the interveners, on whatever
+// resolvedResponseTypes returns.
+//
+// WHAT IT DOES NOT ASSERT. It does not check which of the three interveners
+// fired, and it must not: that is the control table's job, and duplicating it
+// here would make one change red two tables and invite someone to delete one.
+// The three poisons below are one per intervener so that deleting any single
+// call inside the composite is visible from this direction too, but the
+// diagnosis lives in the table.
+//
+// ORDERING AND PARALLELISM. The swap is a package-level variable. Nothing in
+// this package's guard tests calls t.Parallel, and this test restores the
+// original in a Cleanup. If these tests are ever made parallel, this swap
+// becomes a data race and `go test -race` will say so; do not "fix" that by
+// removing the swap.
+func TestResolvedSettingsGuard_InterveningIsWiredToTheResponseTypes(t *testing.T) {
+	const why = "\n\n" +
+		"The resolved-settings shape guard is no longer applying its interveners to\n" +
+		"the response types. The most likely cause is that this loop was removed from\n" +
+		"TestResolvedSettingsResponseShape_NoEffectiveValue:\n\n" +
+		"    for _, v := range resolvedResponseTypes() {\n" +
+		"        assertResponseKeySetIsTypeDetermined(t, v)\n" +
+		"    }\n\n" +
+		"Those three lines are the ONLY thing that points the interveners at the real\n" +
+		"types. TestResolvedSettingsGuard_InstrumentControls stays green without them:\n" +
+		"it proves the instruments work, never that anything calls them. Without the\n" +
+		"loop, a field carrying `omitzero`, an embedded struct pointer, or a custom\n" +
+		"MarshalJSON can hide a key from the wire while the whole package is green.\n" +
+		"Restore the loop. Do not delete this test."
+
+	orig := resolvedResponseTypes
+	t.Cleanup(func() { resolvedResponseTypes = orig })
+
+	// One poison per intervener. Each fixture is also a REJECT row in
+	// TestResolvedSettingsGuard_InstrumentControls, which is what licenses the
+	// inference "the subject did not fail" => "the interveners did not run".
+	poisons := []struct {
+		name string
+		v    any
+	}{
+		{"tags: a type carrying omitzero", ctlOmitZero{}},
+		{"structure: a type with an embedded struct pointer", ctlNestedPtr{}},
+		{"behaviour: a type with a custom MarshalJSON", marshalerCtrlPointer{}},
+	}
+
+	for _, p := range poisons {
+		t.Run(p.name, func(t *testing.T) {
+			resolvedResponseTypes = func() []any { return []any{p.v} }
+
+			if !subjectTestFails(t, TestResolvedSettingsResponseShape_NoEffectiveValue) {
+				t.Errorf("the shape guard PASSED a type the interveners reject"+
+					" (%T)%s", p.v, why)
+			}
+		})
+	}
+
+	// ACCEPT row, and it is not decoration. Every row above concludes "the
+	// interveners ran" from "the subject failed". That inference is only sound
+	// if the subject does not fail for some OTHER reason once the list is
+	// swapped — a broken swap, a require tripping on a malformed input, a
+	// throwaway *testing.T misbehaving. Any of those would turn all three
+	// REJECT rows green-for-the-wrong-reason and this test would report the
+	// loop as wired while it was not. The clean substitute distinguishes them:
+	// it exercises the identical machinery with the only difference being that
+	// nothing should fire.
+	t.Run("control: a clean substitute leaves the subject passing", func(t *testing.T) {
+		resolvedResponseTypes = func() []any { return []any{ctlClean{}} }
+
+		if subjectTestFails(t, TestResolvedSettingsResponseShape_NoEffectiveValue) {
+			t.Error("the subject failed on a CLEAN substitute.\n\n" +
+				"The three REJECT rows above cannot be trusted while this is red: " +
+				"they conclude \"the interveners ran\" from \"the subject failed\", " +
+				"and this row exists to show the subject does not fail merely " +
+				"because the type list was swapped. Diagnose this before reading " +
+				"anything else in this test.")
+		}
+	})
+}
+
+// subjectTestFails runs a whole Test function against a throwaway *testing.T
+// and reports whether it failed.
+//
+// Same construction as instrumentFires, and for the same two reasons: a real
+// *testing.T would mark this test failed when the subject correctly fails, and
+// the subject's require.* calls end in runtime.Goexit, which would tear down
+// the caller's goroutine if run inline.
+func subjectTestFails(t *testing.T, subject func(*testing.T)) bool {
+	t.Helper()
+
+	sub := &testing.T{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		subject(sub)
+	}()
+	<-done
+
+	return sub.Failed()
+}

--- a/pkg/hub/project_settings_resolved_wireup_test.go
+++ b/pkg/hub/project_settings_resolved_wireup_test.go
@@ -112,7 +112,15 @@ func TestResolvedSettingsGuard_InterveningIsWiredToTheResponseTypes(t *testing.T
 				"they conclude \"the interveners ran\" from \"the subject failed\", " +
 				"and this row exists to show the subject does not fail merely " +
 				"because the type list was swapped. Diagnose this before reading " +
-				"anything else in this test.")
+				"anything else in this test.\n\n" +
+				"START BY RULING OUT A FAILURE THAT HAS NOTHING TO DO WITH THE SWAP. " +
+				"Not every assertion in the subject is driven by " +
+				"resolvedResponseTypes: the hub/hubclient mirror assertions name their " +
+				"types literally, so a mirror divergence surfaces HERE, as this row " +
+				"going red, while the swap machinery is working perfectly. Measured: " +
+				"adding a field to hubclient.ResolvedProjectSettings alone reddens this " +
+				"row. Run the subject test on its own, unswapped, before touching " +
+				"anything in this file.")
 		}
 	})
 }

--- a/pkg/hubclient/projects.go
+++ b/pkg/hubclient/projects.go
@@ -74,6 +74,9 @@ type ProjectService interface {
 
 	// GetCacheStatus returns the cache status for a project workspace.
 	GetCacheStatus(ctx context.Context, projectID string) (*ProjectCacheStatusResponse, error)
+
+	// Clone creates a new project seeded from an existing project's configuration.
+	Clone(ctx context.Context, sourceID string, req CloneProjectRequest) (*Project, error)
 }
 
 // projectService is the implementation of ProjectService.
@@ -522,4 +525,13 @@ func (s *projectService) GetCacheStatus(ctx context.Context, projectID string) (
 		return nil, err
 	}
 	return apiclient.DecodeResponse[ProjectCacheStatusResponse](resp)
+}
+
+// Clone creates a new project seeded from an existing project's configuration.
+func (s *projectService) Clone(ctx context.Context, sourceID string, req CloneProjectRequest) (*Project, error) {
+	resp, err := s.c.post(ctx, "/api/v1/projects/"+sourceID+"/clone", req, nil)
+	if err != nil {
+		return nil, err
+	}
+	return apiclient.DecodeResponse[Project](resp)
 }

--- a/pkg/hubclient/types.go
+++ b/pkg/hubclient/types.go
@@ -221,6 +221,63 @@ type ProjectSettings struct {
 	DefaultGCPIdentityServiceAccountID string `json:"defaultGCPIdentityServiceAccountID,omitempty"` // Required when mode is "assign"
 }
 
+// ResolvedHubDefault reports whether a hub-level default exists for a project
+// setting, in the GET /api/v1/projects/{id}/settings/resolved response.
+//
+// Tri-state, not a bool: "unknown" means presence could not be determined
+// (the hub source was unreachable, or it cannot distinguish an
+// explicitly-zero value from an unset one) and must NOT be read as "no".
+type ResolvedHubDefault string
+
+const (
+	// ResolvedHubDefaultPresent — a hub-level default was observed.
+	ResolvedHubDefaultPresent ResolvedHubDefault = "present"
+	// ResolvedHubDefaultAbsent — the hub source was consulted and carries no value.
+	ResolvedHubDefaultAbsent ResolvedHubDefault = "absent"
+	// ResolvedHubDefaultUnknown — presence could not be honestly determined.
+	ResolvedHubDefaultUnknown ResolvedHubDefault = "unknown"
+)
+
+// ResolvedProjectSetting is one key's entry in the resolved-settings response.
+//
+// NOTE FOR ANYONE ADDING A FIELD HERE: this type deliberately carries no
+// effective value, no winning source, and no hub value. The endpoint named
+// "resolved" does not resolve, because resolution is the resolver's job:
+// computing an effective value here would be a second implementation of the
+// precedence order, and a second implementation can silently drift from the
+// real one — a stale answer is still a well-formed answer, so nothing fails.
+//
+// This includes a hub value, not just an "effective" one: in a two-field object
+// {projectValue, hubValue} the juxtaposition is itself the precedence claim,
+// because two adjacent fields with nothing between them assert that there is
+// nothing between them. HubDefault therefore reports existence only.
+//
+// The hub-side mirror of this type is guarded by an exact-set assertion over
+// JSON tags, so adding a field here without adding it there fails the build.
+type ResolvedProjectSetting struct {
+	// ProjectSet reports whether the project annotation is present at all.
+	ProjectSet bool `json:"projectSet"`
+	// ProjectValue is the raw annotation string, or null when unset.
+	ProjectValue *string `json:"projectValue"`
+	// HubDefault reports the existence of a hub default — not its value, not its rank.
+	HubDefault ResolvedHubDefault `json:"hubDefault"`
+}
+
+// ResolvedProjectSettings is the GET /api/v1/projects/{id}/settings/resolved
+// response body.
+//
+// Settings is keyed by raw annotation key (e.g. "scion.io/default-model"), and
+// its key set is exactly the hub's authoritative project-settings registry.
+//
+// A consumer that needs an effective value must resolve it itself, against
+// whatever precedence ladder exists at the time it asks. See ResolvedProjectSetting.
+type ResolvedProjectSettings struct {
+	// Project is the existing GET /settings payload, unchanged.
+	Project *ProjectSettings `json:"project"`
+	// Settings is keyed by annotation key.
+	Settings map[string]ResolvedProjectSetting `json:"settings"`
+}
+
 // ProjectResourceSpec defines default resource requirements at the project level.
 type ProjectResourceSpec struct {
 	Requests *ProjectResourceList `json:"requests,omitempty"`

--- a/pkg/hubclient/types.go
+++ b/pkg/hubclient/types.go
@@ -241,16 +241,15 @@ const (
 // ResolvedProjectSetting is one key's entry in the resolved-settings response.
 //
 // NOTE FOR ANYONE ADDING A FIELD HERE: this type deliberately carries no
-// effective value, no winning source, and no hub value. The endpoint named
-// "resolved" does not resolve, because resolution is the resolver's job:
-// computing an effective value here would be a second implementation of the
-// precedence order, and a second implementation can silently drift from the
-// real one — a stale answer is still a well-formed answer, so nothing fails.
+// effective value and no winning source. The endpoint named "resolved" does not
+// resolve, because resolution is the resolver's job: computing an effective
+// value here would be a second implementation of the precedence order, and a
+// second implementation can silently drift from the real one.
 //
-// This includes a hub value, not just an "effective" one: in a two-field object
-// {projectValue, hubValue} the juxtaposition is itself the precedence claim,
-// because two adjacent fields with nothing between them assert that there is
-// nothing between them. HubDefault therefore reports existence only.
+// HubValue is the raw hub-configured value for display purposes only. It does
+// NOT represent the effective value: template and harness-config layers may sit
+// between the hub default and what an agent actually receives. Clients must
+// treat it as an informational hint, never as a precedence statement.
 //
 // The hub-side mirror of this type is guarded by an exact-set assertion over
 // JSON tags, so adding a field here without adding it there fails the build.
@@ -259,8 +258,11 @@ type ResolvedProjectSetting struct {
 	ProjectSet bool `json:"projectSet"`
 	// ProjectValue is the raw annotation string, or null when unset.
 	ProjectValue *string `json:"projectValue"`
-	// HubDefault reports the existence of a hub default — not its value, not its rank.
+	// HubDefault reports the existence of a hub default — not its rank.
 	HubDefault ResolvedHubDefault `json:"hubDefault"`
+	// HubValue is the raw hub-configured value when HubDefault is "present",
+	// null otherwise. Informational only — not an effective value.
+	HubValue any `json:"hubValue"`
 }
 
 // ResolvedProjectSettings is the GET /api/v1/projects/{id}/settings/resolved

--- a/pkg/hubclient/types.go
+++ b/pkg/hubclient/types.go
@@ -610,6 +610,12 @@ type HarnessConfig struct {
 	Updated       time.Time          `json:"updated"`
 }
 
+// CloneProjectRequest is the request body for POST /api/v1/projects/{id}/clone.
+type CloneProjectRequest struct {
+	Name string `json:"name"`           // required
+	Slug string `json:"slug,omitempty"` // optional explicit slug override
+}
+
 // HarnessConfigData holds harness-specific configuration.
 type HarnessConfigData struct {
 	Harness                 string            `json:"harness,omitempty"`

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -1364,8 +1364,7 @@ export class ScionPageAdminServerConfig extends LitElement {
       return;
     }
     const knownNames = this.harnessConfigs.map((hc) => hc.name);
-    const available: readonly string[] =
-      knownNames.length > 0 ? knownNames : KNOWN_HARNESS_NAMES;
+    const available: readonly string[] = knownNames.length > 0 ? knownNames : KNOWN_HARNESS_NAMES;
     if (available.includes(value)) {
       this.harnessConfigSelection = value;
       this.customHarnessConfig = '';

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -26,6 +26,7 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 import { apiFetch, extractApiError } from '../../client/api.js';
+import { KNOWN_HARNESS_NAMES, harnessDisplayName } from '../../shared/harness-utils.js';
 
 // ── Type definitions matching the Go API response ──
 
@@ -1363,8 +1364,8 @@ export class ScionPageAdminServerConfig extends LitElement {
       return;
     }
     const knownNames = this.harnessConfigs.map((hc) => hc.name);
-    const fallbackNames = ['gemini-cli', 'claude', 'codex', 'copilot', 'opencode'];
-    const available = knownNames.length > 0 ? knownNames : fallbackNames;
+    const available: readonly string[] =
+      knownNames.length > 0 ? knownNames : KNOWN_HARNESS_NAMES;
     if (available.includes(value)) {
       this.harnessConfigSelection = value;
       this.customHarnessConfig = '';
@@ -2479,13 +2480,11 @@ export class ScionPageAdminServerConfig extends LitElement {
                       </sl-option>
                     `
                   )
-                : html`
-                    <sl-option value="gemini-cli">Gemini CLI</sl-option>
-                    <sl-option value="claude">Claude</sl-option>
-                    <sl-option value="codex">Codex</sl-option>
-                    <sl-option value="copilot">Copilot</sl-option>
-                    <sl-option value="opencode">OpenCode</sl-option>
-                  `}
+                : KNOWN_HARNESS_NAMES.map(
+                    (name) => html`
+                      <sl-option value=${name}>${harnessDisplayName(name)}</sl-option>
+                    `
+                  )}
               <sl-option value="__other__">Other (specify)</sl-option>
             </sl-select>`
             )}

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -769,7 +769,7 @@ private selectBrokerForProject(): void {
   /**
    * Select the default template and harness config for the current project using project settings.
    * Falls back to a template named "default", then the first available template.
-   * The harness config is determined by: template defaultHarnessConfig > template harness > project default > 'gemini'.
+   * The harness config is determined by: template defaultHarnessConfig > template harness > project default > 'gemini-cli'.
    */
   private async selectDefaultTemplate(): Promise<void> {
     const visible = this.filteredTemplates;
@@ -998,8 +998,7 @@ private selectBrokerForProject(): void {
    */
   private setHarnessFromValue(value: string): void {
     const knownNames = this.harnessConfigs.map((hc) => hc.name);
-    const available: readonly string[] =
-      knownNames.length > 0 ? knownNames : KNOWN_HARNESS_NAMES;
+    const available: readonly string[] = knownNames.length > 0 ? knownNames : KNOWN_HARNESS_NAMES;
 
     if (available.includes(value)) {
       this.harness = value;

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -40,6 +40,7 @@ interface HarnessConfigEntry {
   scope: string;
 }
 import { isSharedWorkspace } from '../../shared/types.js';
+import { KNOWN_HARNESS_NAMES, harnessDisplayName } from '../../shared/harness-utils.js';
 import { apiFetch, parseApiError } from '../../client/api.js';
 import '../shared/status-badge.js';
 
@@ -997,8 +998,8 @@ private selectBrokerForProject(): void {
    */
   private setHarnessFromValue(value: string): void {
     const knownNames = this.harnessConfigs.map((hc) => hc.name);
-    const fallbackNames = ['gemini-cli', 'claude', 'codex', 'copilot', 'opencode'];
-    const available = knownNames.length > 0 ? knownNames : fallbackNames;
+    const available: readonly string[] =
+      knownNames.length > 0 ? knownNames : KNOWN_HARNESS_NAMES;
 
     if (available.includes(value)) {
       this.harness = value;
@@ -1168,13 +1169,11 @@ private selectBrokerForProject(): void {
                       </sl-option>
                     `
                   )
-                : html`
-                    <sl-option value="gemini-cli">Gemini CLI</sl-option>
-                    <sl-option value="claude">Claude</sl-option>
-                    <sl-option value="codex">Codex</sl-option>
-                    <sl-option value="copilot">Copilot</sl-option>
-                    <sl-option value="opencode">OpenCode</sl-option>
-                  `}
+                : KNOWN_HARNESS_NAMES.map(
+                    (name) => html`
+                      <sl-option value=${name}>${harnessDisplayName(name)}</sl-option>
+                    `
+                  )}
               <sl-option value="__other__">Other...</sl-option>
             </sl-select>
             <div class="hint">

--- a/web/src/components/pages/project-detail.ts
+++ b/web/src/components/pages/project-detail.ts
@@ -179,6 +179,30 @@ export class ScionPageProjectDetail extends LitElement {
    */
   private editorDataSources: Record<string, FileEditorDataSource> = {};
 
+  /**
+   * Whether the clone dialog is open
+   */
+  @state()
+  private cloneDialogOpen = false;
+
+  /**
+   * Name for the cloned project
+   */
+  @state()
+  private cloneName = '';
+
+  /**
+   * Whether the clone operation is in progress
+   */
+  @state()
+  private cloneLoading = false;
+
+  /**
+   * Error message from clone operation (shown inline in dialog)
+   */
+  @state()
+  private cloneError = '';
+
   static override styles = css`
     :host {
       display: block;
@@ -521,6 +545,30 @@ export class ScionPageProjectDetail extends LitElement {
       border-radius: var(--scion-radius, 0.5rem);
       color: var(--sl-color-danger-700, #b91c1c);
       margin-bottom: 1rem;
+    }
+
+    .clone-summary {
+      font-size: 0.875rem;
+      color: var(--scion-text-muted, #64748b);
+      margin-top: 1rem;
+      line-height: 1.5;
+    }
+
+    .clone-summary strong {
+      color: var(--scion-text, #1e293b);
+    }
+
+    .clone-slug-preview {
+      font-family: var(--scion-font-mono, monospace);
+      font-size: 0.8125rem;
+      color: var(--scion-text-muted, #64748b);
+      margin-top: 0.5rem;
+    }
+
+    .clone-error {
+      color: var(--sl-color-danger-700, #b91c1c);
+      font-size: 0.875rem;
+      margin-top: 0.75rem;
     }
 
     .back-link {
@@ -1280,6 +1328,106 @@ export class ScionPageProjectDetail extends LitElement {
     }
   }
 
+  private slugify(text: string): string {
+    return text
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  private openCloneDialog(): void {
+    this.cloneName = this.project ? `${this.project.name} copy` : '';
+    this.cloneError = '';
+    this.cloneLoading = false;
+    this.cloneDialogOpen = true;
+  }
+
+  private async handleCloneProject(): Promise<void> {
+    if (!this.cloneName.trim()) {
+      this.cloneError = 'Project name is required.';
+      return;
+    }
+
+    this.cloneLoading = true;
+    this.cloneError = '';
+
+    try {
+      const response = await apiFetch(`/api/v1/projects/${this.projectId}/clone`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: this.cloneName.trim() }),
+      });
+
+      if (!response.ok) {
+        const errorText = await extractApiError(response, 'Failed to clone project');
+        throw new Error(errorText);
+      }
+
+      const cloned = (await response.json()) as { id: string; name: string; slug: string };
+      this.cloneDialogOpen = false;
+
+      // Navigate to the newly cloned project
+      window.history.pushState({}, '', `/projects/${cloned.id}`);
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    } catch (err) {
+      this.cloneError = err instanceof Error ? err.message : 'Failed to clone project';
+    } finally {
+      this.cloneLoading = false;
+    }
+  }
+
+  private renderCloneDialog() {
+    return html`
+      <sl-dialog
+        label="Clone Project"
+        ?open=${this.cloneDialogOpen}
+        @sl-request-close=${(e: CustomEvent) => {
+          if (this.cloneLoading) {
+            e.preventDefault();
+            return;
+          }
+          this.cloneDialogOpen = false;
+        }}
+      >
+        <sl-input
+          label="Name"
+          .value=${this.cloneName}
+          @sl-input=${(e: Event) => (this.cloneName = (e.target as HTMLInputElement).value)}
+          ?disabled=${this.cloneLoading}
+        ></sl-input>
+        <div class="clone-slug-preview">
+          Slug: ${this.slugify(this.cloneName) || '...'}
+        </div>
+        <div class="clone-summary">
+          <strong>Copies:</strong> settings, labels, environment variables, injected skills,
+          pre-start hook, project harness configs and templates.<br />
+          <strong>Does not copy:</strong> secrets, agents, history, or chat integrations.
+        </div>
+        ${this.cloneError
+          ? html`<div class="clone-error">${this.cloneError}</div>`
+          : nothing}
+        <sl-button
+          slot="footer"
+          variant="primary"
+          @click=${() => this.handleCloneProject()}
+          ?loading=${this.cloneLoading}
+          ?disabled=${this.cloneLoading}
+        >
+          Clone
+        </sl-button>
+        <sl-button
+          slot="footer"
+          variant="default"
+          @click=${() => (this.cloneDialogOpen = false)}
+          ?disabled=${this.cloneLoading}
+        >
+          Cancel
+        </sl-button>
+      </sl-dialog>
+    `;
+  }
+
   override render() {
     if (this.loading) {
       return this.renderLoading();
@@ -1328,6 +1476,14 @@ export class ScionPageProjectDetail extends LitElement {
                 >
                   <sl-icon slot="prefix" name="arrow-down-circle"></sl-icon>
                   Pull Latest
+                </sl-button>
+              `
+            : nothing}
+          ${can(this.project?._capabilities, 'read')
+            ? html`
+                <sl-button size="small" @click=${() => this.openCloneDialog()}>
+                  <sl-icon slot="prefix" name="copy"></sl-icon>
+                  Clone
                 </sl-button>
               `
             : nothing}
@@ -1467,6 +1623,8 @@ export class ScionPageProjectDetail extends LitElement {
       ${this.project?.cloudLogging ? this.renderMessagesSection() : nothing}
 
       ${this.shouldShowFilesSection() ? this.renderFilesSection() : ''}
+
+      ${this.renderCloneDialog()}
     `;
   }
 

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -64,6 +64,18 @@ interface ProjectSettings {
   defaultThinkingLevel?: number | null | undefined;
 }
 
+interface ResolvedHubSetting {
+  projectSet: boolean;
+  projectValue: string | null;
+  hubDefault: 'present' | 'absent' | 'unknown';
+  hubValue: any;
+}
+
+interface ResolvedProjectSettings {
+  project: ProjectSettings;
+  settings: Record<string, ResolvedHubSetting>;
+}
+
 interface HarnessConfigEntry {
   id: string;
   name: string;
@@ -145,6 +157,10 @@ export class ScionPageProjectSettings extends LitElement {
 
   @state()
   private hubTelemetryDefault: boolean | null = null;
+
+  /** Per-setting hub default info from the resolved endpoint. */
+  @state()
+  private resolvedSettings: Record<string, ResolvedHubSetting> = {};
 
   // Default agent limits
   @state()
@@ -748,8 +764,7 @@ export class ScionPageProjectSettings extends LitElement {
     void this.loadProject().then(() => this.loadMembersGroup());
     void this.loadHubPreStartHook();
     void this.loadDropdownTemplates();
-    void this.loadSettings();
-    void this.loadHubTelemetryDefault();
+    void this.loadResolvedSettings();
     void this.loadHarnessConfigs();
     void this.loadBrokers();
     void this.loadGCPServiceAccounts();
@@ -899,39 +914,86 @@ export class ScionPageProjectSettings extends LitElement {
     }
   }
 
-  private async loadSettings(): Promise<void> {
+  /**
+   * Loads project settings via the resolved endpoint, which includes per-setting
+   * hub default information. Falls back to the plain /settings endpoint if the
+   * resolved endpoint returns 404 (older hub without the endpoint).
+   */
+  private async loadResolvedSettings(): Promise<void> {
     this.settingsLoading = true;
     try {
-      const response = await apiFetch(`/api/v1/projects/${this.projectId}/settings`);
-      if (response.ok) {
-        this.settings = (await response.json()) as ProjectSettings;
-        this.configDefaultTemplate = this.settings.defaultTemplate || '';
-        this.configDefaultHarnessConfig = this.settings.defaultHarnessConfig || '';
-        this.configTelemetryEnabled = this.settings.telemetryEnabled ?? null;
-        this.configDefaultMaxTurns = this.settings.defaultMaxTurns || 0;
-        this.configDefaultMaxModelCalls = this.settings.defaultMaxModelCalls || 0;
-        this.configDefaultMaxDuration = this.settings.defaultMaxDuration || '';
-        const res = this.settings.defaultResources;
-        this.configDefaultResCpuReq = res?.requests?.cpu || '';
-        this.configDefaultResMemReq = res?.requests?.memory || '';
-        this.configDefaultResCpuLim = res?.limits?.cpu || '';
-        this.configDefaultResMemLim = res?.limits?.memory || '';
-        this.configDefaultResDisk = res?.disk || '';
-        this.configDefaultGCPIdentityMode = this.settings.defaultGCPIdentityMode || '';
-        this.configDefaultGCPIdentitySAID = this.settings.defaultGCPIdentityServiceAccountID || '';
-        if (this.settings.defaultModel) {
-          const dm = normalizeModelAlias(this.settings.defaultModel);
-          if (['small', 'medium', 'large', 'extra-large'].includes(dm)) {
-            this.defaultModelSelection = dm as 'small' | 'medium' | 'large' | 'extra-large';
-          } else {
-            this.defaultModelSelection = 'other';
-            this.defaultCustomModelId = this.settings.defaultModel;
-          }
+      const resolvedResponse = await apiFetch(
+        `/api/v1/projects/${this.projectId}/settings/resolved`
+      );
+
+      if (resolvedResponse.ok) {
+        const resolved = (await resolvedResponse.json()) as ResolvedProjectSettings;
+        // Use the project sub-object for form state — this is the same payload
+        // as GET /settings, so the PUT path is unchanged.
+        this.settings = resolved.project || {};
+        this.resolvedSettings = resolved.settings || {};
+
+        // Extract telemetry hub default from the resolved response, replacing
+        // the separate /api/v1/settings/public fetch.
+        const telEntry = this.resolvedSettings['scion.io/telemetry-enabled'];
+        if (telEntry?.hubDefault === 'present' && telEntry.hubValue != null) {
+          this.hubTelemetryDefault = telEntry.hubValue as boolean;
         } else {
-          this.defaultModelSelection = '';
+          this.hubTelemetryDefault = null;
         }
-        this.defaultThinkingLevel = this.settings.defaultThinkingLevel ?? null;
+      } else if (resolvedResponse.status === 404) {
+        // Backward compatibility: older hub without the resolved endpoint.
+        // Fall back to the plain settings endpoint with generic placeholders.
+        console.warn(
+          '[project-settings] /settings/resolved returned 404, falling back to /settings'
+        );
+        const fallbackResponse = await apiFetch(
+          `/api/v1/projects/${this.projectId}/settings`
+        );
+        if (fallbackResponse.ok) {
+          this.settings = (await fallbackResponse.json()) as ProjectSettings;
+        }
+        this.resolvedSettings = {};
+        // Also try loading telemetry default from public settings
+        void this.loadHubTelemetryDefaultFallback();
+      } else {
+        // Other error — try the plain endpoint as fallback
+        const fallbackResponse = await apiFetch(
+          `/api/v1/projects/${this.projectId}/settings`
+        );
+        if (fallbackResponse.ok) {
+          this.settings = (await fallbackResponse.json()) as ProjectSettings;
+        }
+        this.resolvedSettings = {};
       }
+
+      // Populate form state from settings (same as before)
+      this.configDefaultTemplate = this.settings.defaultTemplate || '';
+      this.configDefaultHarnessConfig = this.settings.defaultHarnessConfig || '';
+      this.configTelemetryEnabled = this.settings.telemetryEnabled ?? null;
+      this.configDefaultMaxTurns = this.settings.defaultMaxTurns || 0;
+      this.configDefaultMaxModelCalls = this.settings.defaultMaxModelCalls || 0;
+      this.configDefaultMaxDuration = this.settings.defaultMaxDuration || '';
+      const res = this.settings.defaultResources;
+      this.configDefaultResCpuReq = res?.requests?.cpu || '';
+      this.configDefaultResMemReq = res?.requests?.memory || '';
+      this.configDefaultResCpuLim = res?.limits?.cpu || '';
+      this.configDefaultResMemLim = res?.limits?.memory || '';
+      this.configDefaultResDisk = res?.disk || '';
+      this.configDefaultGCPIdentityMode = this.settings.defaultGCPIdentityMode || '';
+      this.configDefaultGCPIdentitySAID = this.settings.defaultGCPIdentityServiceAccountID || '';
+      if (this.settings.defaultModel) {
+        const dm = normalizeModelAlias(this.settings.defaultModel);
+        if (['small', 'medium', 'large', 'extra-large'].includes(dm)) {
+          this.defaultModelSelection = dm as 'small' | 'medium' | 'large' | 'extra-large';
+        } else {
+          this.defaultModelSelection = 'other';
+          this.defaultCustomModelId = this.settings.defaultModel;
+        }
+      } else {
+        this.defaultModelSelection = '';
+      }
+      this.defaultThinkingLevel = this.settings.defaultThinkingLevel ?? null;
     } catch (err) {
       console.error('Failed to load project settings:', err);
     } finally {
@@ -939,7 +1001,8 @@ export class ScionPageProjectSettings extends LitElement {
     }
   }
 
-  private async loadHubTelemetryDefault(): Promise<void> {
+  /** Fallback for loading hub telemetry default when /settings/resolved is unavailable. */
+  private async loadHubTelemetryDefaultFallback(): Promise<void> {
     try {
       const response = await apiFetch('/api/v1/settings/public');
       if (response.ok) {
@@ -949,6 +1012,33 @@ export class ScionPageProjectSettings extends LitElement {
     } catch (err) {
       console.error('Failed to load hub telemetry default:', err);
     }
+  }
+
+  /**
+   * Returns a formatted hub default hint string for a given annotation key,
+   * or null if no hub value is available for display.
+   *
+   * Used to populate placeholder text on text/number inputs and to label the
+   * empty option on select inputs.
+   */
+  private hubHint(annotationKey: string): string | null {
+    const entry = this.resolvedSettings[annotationKey];
+    if (!entry || entry.hubDefault !== 'present' || entry.hubValue == null) {
+      return null;
+    }
+    return `Hub default: ${entry.hubValue}`;
+  }
+
+  /**
+   * Returns a select-option label incorporating the hub default value,
+   * or a generic fallback label when no hub value is available.
+   */
+  private hubSelectLabel(annotationKey: string, fallbackLabel: string): string {
+    const entry = this.resolvedSettings[annotationKey];
+    if (entry?.hubDefault === 'present' && entry.hubValue != null) {
+      return `Use hub default (${entry.hubValue})`;
+    }
+    return fallbackLabel;
   }
 
   private async loadHarnessConfigs(): Promise<void> {
@@ -1464,7 +1554,7 @@ export class ScionPageProjectSettings extends LitElement {
               <div class="config-field">
                 <label>Default Template</label>
                 <sl-select
-                  placeholder="None (use server default)"
+                  placeholder=${this.hubSelectLabel('scion.io/default-template', 'None (use server default)')}
                   clearable
                   value=${this.configDefaultTemplate}
                   ?disabled=${!canEdit}
@@ -1484,7 +1574,7 @@ export class ScionPageProjectSettings extends LitElement {
               <div class="config-field">
                 <label>Default Harness Config</label>
                 <sl-select
-                  placeholder="None (use server default)"
+                  placeholder=${this.hubSelectLabel('scion.io/default-harness-config', 'None (use server default)')}
                   clearable
                   value=${this.configDefaultHarnessConfig}
                   ?disabled=${!canEdit}
@@ -1698,7 +1788,7 @@ export class ScionPageProjectSettings extends LitElement {
                 <label>Default Max Turns</label>
                 <sl-input
                   type="number"
-                  placeholder="No limit"
+                  placeholder=${this.hubHint('scion.io/default-max-turns') || 'No limit'}
                   .value=${this.configDefaultMaxTurns ? String(this.configDefaultMaxTurns) : ''}
                   ?disabled=${!canEdit}
                   @sl-input=${(e: Event) => {
@@ -1713,7 +1803,7 @@ export class ScionPageProjectSettings extends LitElement {
                 <label>Default Max Model Calls</label>
                 <sl-input
                   type="number"
-                  placeholder="No limit"
+                  placeholder=${this.hubHint('scion.io/default-max-model-calls') || 'No limit'}
                   .value=${this.configDefaultMaxModelCalls
                     ? String(this.configDefaultMaxModelCalls)
                     : ''}
@@ -1730,7 +1820,7 @@ export class ScionPageProjectSettings extends LitElement {
                 <label>Default Max Duration</label>
                 <sl-input
                   type="text"
-                  placeholder="e.g. 2h, 30m"
+                  placeholder=${this.hubHint('scion.io/default-max-duration') || 'e.g. 2h, 30m'}
                   .value=${this.configDefaultMaxDuration}
                   ?disabled=${!canEdit}
                   @sl-input=${(e: Event) => {
@@ -1752,7 +1842,7 @@ export class ScionPageProjectSettings extends LitElement {
                 <label>CPU Request</label>
                 <sl-input
                   type="text"
-                  placeholder="e.g. 500m, 1"
+                  placeholder=${this.hubHint('scion.io/default-resources-cpu-request') || 'e.g. 500m, 1'}
                   .value=${this.configDefaultResCpuReq}
                   ?disabled=${!canEdit}
                   @sl-input=${(e: Event) => {
@@ -1765,7 +1855,7 @@ export class ScionPageProjectSettings extends LitElement {
                 <label>Memory Request</label>
                 <sl-input
                   type="text"
-                  placeholder="e.g. 512Mi, 1Gi"
+                  placeholder=${this.hubHint('scion.io/default-resources-memory-request') || 'e.g. 512Mi, 1Gi'}
                   .value=${this.configDefaultResMemReq}
                   ?disabled=${!canEdit}
                   @sl-input=${(e: Event) => {
@@ -1778,7 +1868,7 @@ export class ScionPageProjectSettings extends LitElement {
                 <label>CPU Limit</label>
                 <sl-input
                   type="text"
-                  placeholder="e.g. 1, 2"
+                  placeholder=${this.hubHint('scion.io/default-resources-cpu-limit') || 'e.g. 1, 2'}
                   .value=${this.configDefaultResCpuLim}
                   ?disabled=${!canEdit}
                   @sl-input=${(e: Event) => {
@@ -1791,7 +1881,7 @@ export class ScionPageProjectSettings extends LitElement {
                 <label>Memory Limit</label>
                 <sl-input
                   type="text"
-                  placeholder="e.g. 1Gi, 2Gi"
+                  placeholder=${this.hubHint('scion.io/default-resources-memory-limit') || 'e.g. 1Gi, 2Gi'}
                   .value=${this.configDefaultResMemLim}
                   ?disabled=${!canEdit}
                   @sl-input=${(e: Event) => {
@@ -1804,7 +1894,7 @@ export class ScionPageProjectSettings extends LitElement {
                 <label>Disk</label>
                 <sl-input
                   type="text"
-                  placeholder="e.g. 10Gi"
+                  placeholder=${this.hubHint('scion.io/default-resources-disk') || 'e.g. 10Gi'}
                   .value=${this.configDefaultResDisk}
                   ?disabled=${!canEdit}
                   @sl-input=${(e: Event) => {

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -26,6 +26,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import type { PageData, Project, Template, AdminGroup, GitHubAppProjectStatus, GitHubTokenPermissions, RuntimeBroker, BrokerProfile, GCPServiceAccount, PreStartHook, PreStartHookSummary } from '../../shared/types.js';
 import { can, canAny } from '../../shared/types.js';
 import { normalizeModelAlias } from '../../shared/model-utils.js';
+import { KNOWN_HARNESS_NAMES, harnessDisplayName } from '../../shared/harness-utils.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { dispatchPageTitle } from '../../client/page-title.js';
 import '../shared/env-var-list.js';
@@ -1501,12 +1502,11 @@ export class ScionPageProjectSettings extends LitElement {
                         `
                       )
                     : // Fallback: all known/installable harnesses (incl. opt-in), not the default-install set.
-                      html`
-                        <sl-option value="gemini">Gemini</sl-option>
-                        <sl-option value="claude">Claude</sl-option>
-                        <sl-option value="opencode">OpenCode</sl-option>
-                        <sl-option value="codex">Codex</sl-option>
-                      `}
+                      KNOWN_HARNESS_NAMES.map(
+                        (name) => html`
+                          <sl-option value=${name}>${harnessDisplayName(name)}</sl-option>
+                        `
+                      )}
                 </sl-select>
                 <span class="field-help"
                   >Harness configuration used by default for new agents.</span

--- a/web/src/shared/harness-utils.test.ts
+++ b/web/src/shared/harness-utils.test.ts
@@ -33,6 +33,24 @@ function readWebSource(relPath: string): string {
   return readFileSync(resolve(REPO_ROOT, 'web', relPath), 'utf8');
 }
 
+/**
+ * Harness identifiers a redeclared local list could be built from: the
+ * canonical seven plus the bogus `gemini` that Phase 0 removed.
+ */
+const FORBIDDEN_IDENTS: readonly string[] = [...KNOWN_HARNESS_NAMES, 'gemini'];
+
+/** Single-quoted harness identifier, e.g. `'gemini-cli'`. */
+const IDENT = String.raw`'(?:${FORBIDDEN_IDENTS.join('|')})'`;
+
+/**
+ * Matches an array literal containing two or more harness identifiers in a row,
+ * anywhere in the array -- so reordering the elements, or leading with a name
+ * that is not a harness, does not defeat it.
+ */
+const HARNESS_ARRAY_LITERAL = new RegExp(
+  String.raw`\[[^\]]*${IDENT}\s*,\s*${IDENT}`
+);
+
 describe('KNOWN_HARNESS_NAMES', () => {
   it('matches the harnesses/ directory, which is the source of truth', () => {
     const harnessesDir = resolve(REPO_ROOT, 'harnesses');
@@ -91,19 +109,24 @@ describe('harness fallback list is not duplicated in components', () => {
     // The old shape was e.g.
     //   const fallbackNames = ['gemini-cli', 'claude', 'codex', ...];
     expect(src).not.toMatch(/\bfallbackNames\s*=/);
-    // Any array literal pairing two or more canonical harness identifiers is a
-    // redeclared list, regardless of the variable name.
-    expect(src).not.toMatch(/\[\s*'(claude|codex|copilot|gemini-cli|opencode)'\s*,\s*'/);
+    // Any array literal pairing two or more harness identifiers is a redeclared
+    // list, regardless of variable name, element order, or which name comes
+    // first. The alternation deliberately includes the bogus 'gemini' -- a
+    // reintroduced ['gemini', 'claude', ...] is the exact bug this phase fixed,
+    // so it must be caught even though 'gemini' is not a canonical name.
+    expect(src).not.toMatch(HARNESS_ARRAY_LITERAL);
   });
 
   it.each(CONSUMERS)('%s hardcodes no harness sl-option elements', (relPath) => {
     const src = readWebSource(relPath);
     // Fallback options must be produced by mapping over KNOWN_HARNESS_NAMES,
-    // not written out one <sl-option value="claude"> at a time.
-    const hardcoded = [...src.matchAll(/<sl-option\s+value="([^"]+)"/g)].map((m) => m[1]);
-    const harnessOptions = hardcoded.filter(
-      (v) => (KNOWN_HARNESS_NAMES as readonly string[]).includes(v) || v === 'gemini'
+    // not written out one <sl-option value="claude"> at a time. Both quote
+    // styles are matched; dynamic `value=${name}` bindings are intentionally
+    // not matched, since those are the correct, mapped form.
+    const hardcoded = [...src.matchAll(/<sl-option\s+value=("([^"]*)"|'([^']*)')/g)].map(
+      (m) => m[2] ?? m[3]
     );
+    const harnessOptions = hardcoded.filter((v) => FORBIDDEN_IDENTS.includes(v));
     expect(harnessOptions).toEqual([]);
   });
 });

--- a/web/src/shared/harness-utils.test.ts
+++ b/web/src/shared/harness-utils.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { KNOWN_HARNESS_NAMES, harnessDisplayName } from './harness-utils.js';
+
+/** Repository root, relative to web/src/shared/. */
+const REPO_ROOT = resolve(__dirname, '../../..');
+
+/** Components that render the harness fallback list. */
+const CONSUMERS = [
+  'src/components/pages/project-settings.ts',
+  'src/components/pages/admin-server-config.ts',
+  'src/components/pages/agent-create.ts',
+];
+
+function readWebSource(relPath: string): string {
+  return readFileSync(resolve(REPO_ROOT, 'web', relPath), 'utf8');
+}
+
+describe('KNOWN_HARNESS_NAMES', () => {
+  it('matches the harnesses/ directory, which is the source of truth', () => {
+    const harnessesDir = resolve(REPO_ROOT, 'harnesses');
+    // Guard: if the checkout does not include harnesses/ (e.g. a partial
+    // clone), fail loudly rather than silently passing an empty comparison.
+    expect(existsSync(harnessesDir)).toBe(true);
+
+    const fromTree = readdirSync(harnessesDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && existsSync(resolve(harnessesDir, e.name, 'config.yaml')))
+      .map((e) => e.name)
+      .sort();
+
+    expect([...KNOWN_HARNESS_NAMES].sort()).toEqual(fromTree);
+  });
+
+  it('uses gemini-cli, not the non-existent "gemini" harness', () => {
+    expect(KNOWN_HARNESS_NAMES).toContain('gemini-cli');
+    expect(KNOWN_HARNESS_NAMES).not.toContain('gemini');
+  });
+
+  it('contains no duplicates', () => {
+    expect(new Set(KNOWN_HARNESS_NAMES).size).toBe(KNOWN_HARNESS_NAMES.length);
+  });
+});
+
+describe('harnessDisplayName', () => {
+  it('gives every canonical harness a non-empty label', () => {
+    for (const name of KNOWN_HARNESS_NAMES) {
+      expect(harnessDisplayName(name).trim()).not.toBe('');
+    }
+  });
+
+  it('preserves the labels the components rendered before the refactor', () => {
+    expect(harnessDisplayName('gemini-cli')).toBe('Gemini CLI');
+    expect(harnessDisplayName('claude')).toBe('Claude');
+    expect(harnessDisplayName('codex')).toBe('Codex');
+    expect(harnessDisplayName('copilot')).toBe('Copilot');
+    expect(harnessDisplayName('opencode')).toBe('OpenCode');
+  });
+
+  it('passes unknown identifiers through unchanged', () => {
+    expect(harnessDisplayName('my-custom-harness')).toBe('my-custom-harness');
+  });
+});
+
+describe('harness fallback list is not duplicated in components', () => {
+  it.each(CONSUMERS)('%s imports KNOWN_HARNESS_NAMES from shared/harness-utils', (relPath) => {
+    const src = readWebSource(relPath);
+    expect(src).toMatch(
+      /import\s*\{[^}]*\bKNOWN_HARNESS_NAMES\b[^}]*\}\s*from\s*'(\.\.\/)+shared\/harness-utils\.js'/
+    );
+  });
+
+  it.each(CONSUMERS)('%s declares no local harness-name array', (relPath) => {
+    const src = readWebSource(relPath);
+    // The old shape was e.g.
+    //   const fallbackNames = ['gemini-cli', 'claude', 'codex', ...];
+    expect(src).not.toMatch(/\bfallbackNames\s*=/);
+    // Any array literal pairing two or more canonical harness identifiers is a
+    // redeclared list, regardless of the variable name.
+    expect(src).not.toMatch(/\[\s*'(claude|codex|copilot|gemini-cli|opencode)'\s*,\s*'/);
+  });
+
+  it.each(CONSUMERS)('%s hardcodes no harness sl-option elements', (relPath) => {
+    const src = readWebSource(relPath);
+    // Fallback options must be produced by mapping over KNOWN_HARNESS_NAMES,
+    // not written out one <sl-option value="claude"> at a time.
+    const hardcoded = [...src.matchAll(/<sl-option\s+value="([^"]+)"/g)].map((m) => m[1]);
+    const harnessOptions = hardcoded.filter(
+      (v) => (KNOWN_HARNESS_NAMES as readonly string[]).includes(v) || v === 'gemini'
+    );
+    expect(harnessOptions).toEqual([]);
+  });
+});

--- a/web/src/shared/harness-utils.ts
+++ b/web/src/shared/harness-utils.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Canonical harness identifiers, mirroring `harnesses/<name>/config.yaml`.
+ *
+ * The `harnesses/` directory in the repository root is the source of truth: each
+ * subdirectory contains a `config.yaml` whose `harness:` key is the identifier
+ * listed here. When a harness is added to or removed from `harnesses/`, update
+ * this list to match.
+ *
+ * This list is only a *fallback*. At runtime the UI prefers the harness configs
+ * returned by `GET /api/v1/harness-configs`; these names are used to populate
+ * selects when that call returns nothing (empty result, or a failed request).
+ */
+export const KNOWN_HARNESS_NAMES = [
+  'claude',
+  'codex',
+  'copilot',
+  'gemini-cli',
+  'opencode',
+  'antigravity',
+  'hermes',
+] as const;
+
+/** A canonical harness identifier. */
+export type KnownHarnessName = (typeof KNOWN_HARNESS_NAMES)[number];
+
+/**
+ * Human-readable labels for the canonical harnesses.
+ *
+ * `harnesses/<name>/config.yaml` has no display-name field, so these are
+ * maintained here purely for presentation.
+ */
+const HARNESS_DISPLAY_NAMES: Record<KnownHarnessName, string> = {
+  claude: 'Claude',
+  codex: 'Codex',
+  copilot: 'Copilot',
+  'gemini-cli': 'Gemini CLI',
+  opencode: 'OpenCode',
+  antigravity: 'Antigravity',
+  hermes: 'Hermes',
+};
+
+/**
+ * Returns a human-readable label for a harness identifier, falling back to the
+ * identifier itself for names that are not in the canonical list.
+ */
+export function harnessDisplayName(name: string): string {
+  return HARNESS_DISPLAY_NAMES[name as KnownHarnessName] ?? name;
+}

--- a/web/src/shared/harness-utils.ts
+++ b/web/src/shared/harness-utils.ts
@@ -25,6 +25,14 @@
  * This list is only a *fallback*. At runtime the UI prefers the harness configs
  * returned by `GET /api/v1/harness-configs`; these names are used to populate
  * selects when that call returns nothing (empty result, or a failed request).
+ *
+ * ORDERING: this is also the order the names render in every fallback select.
+ * The first five are the harnesses the UI already offered, kept alphabetical;
+ * `antigravity` and `hermes` were appended when they were added. Append new
+ * harnesses to the end rather than re-sorting, so that the position of the
+ * existing options stays stable for people used to the list. Order carries no
+ * meaning beyond display — nothing selects by index, and every select binds its
+ * value to component state rather than defaulting to the first option.
  */
 export const KNOWN_HARNESS_NAMES = [
   'claude',

--- a/web/src/shared/harness-utils.ts
+++ b/web/src/shared/harness-utils.ts
@@ -42,8 +42,15 @@ export type KnownHarnessName = (typeof KNOWN_HARNESS_NAMES)[number];
 /**
  * Human-readable labels for the canonical harnesses.
  *
- * `harnesses/<name>/config.yaml` has no display-name field, so these are
- * maintained here purely for presentation.
+ * DISPLAY ONLY. `KNOWN_HARNESS_NAMES` above is the source of truth for which
+ * harnesses exist; this map only decides how each one is spelled in the UI.
+ * Never branch on these strings.
+ *
+ * `harnesses/<name>/config.yaml` has no display-name field, so these labels
+ * cannot be derived and are maintained here by hand. The values below are
+ * transcribed from the markup they replaced, so there is no visual change.
+ * `antigravity` and `hermes` had no prior rendering (they were missing from
+ * every fallback list), so their labels are new.
  */
 const HARNESS_DISPLAY_NAMES: Record<KnownHarnessName, string> = {
   claude: 'Claude',


### PR DESCRIPTION
## Summary

Adds two features to the project settings surface:

**Feature A — Resolved Settings Endpoint** (Phases 0, 2, 3)
- New `GET /api/v1/projects/{id}/settings/resolved` endpoint exposing per-setting hub default presence and values
- Non-admin project owners can now see what hub defaults their agents will receive when a setting is left blank
- Frontend displays "Hub default: <value>" placeholders and "Use hub default (<value>)" select labels
- Canonical shared harness name list (harness-utils.ts) replaces 3 inconsistent hardcoded lists

**Feature B — Project Clone** (Phases 4-6)
- New `POST /api/v1/projects/{id}/clone` with defer-driven rollback stack
- Deep copies settings annotations, labels, env vars (non-secret), skills, pre-start hook, project-scoped harness configs and templates
- Excludes secrets, agents, history, chat integrations by design
- SDK method, CLI command (`scion project clone`), and frontend dialog
- 14 backend tests covering happy path, exclusions, authorization, and concurrency