### PR TITLE
fix(uat): accept project:update as a valid UAT scope (enforcement already expects it)

### DIFF
--- a/pkg/hub/useraccesstoken_test.go
+++ b/pkg/hub/useraccesstoken_test.go
@@ -239,6 +239,23 @@ func TestCreateToken(t *testing.T) {
 		}
 	})
 
+	t.Run("accepts project:update", func(t *testing.T) {
+		_, token, err := svc.CreateToken(ctx, tid("user-1"), "proj-update-token", tid("project-1"),
+			[]string{"project:read", "project:update"}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		found := false
+		for _, sc := range token.Scopes {
+			if sc == store.UATScopeProjectUpdate {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected project:update in token scopes, got %v", token.Scopes)
+		}
+	})
+
 	t.Run("rejects invalid scope", func(t *testing.T) {
 		_, _, err := svc.CreateToken(ctx, tid("user-1"), "bad-token", tid("project-1"),
 			[]string{"invalid:scope"}, nil)

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -1440,6 +1440,7 @@ const UATPrefix = "scion_pat_"
 // UAT scope constants define the allowed capability scopes.
 const (
 	UATScopeProjectRead   = "project:read"
+	UATScopeProjectUpdate = "project:update"
 	UATScopeAgentCreate   = "agent:create"
 	UATScopeAgentRead     = "agent:read"
 	UATScopeAgentList     = "agent:list"
@@ -1455,6 +1456,7 @@ const (
 // UATValidScopes is the set of all valid UAT scope strings.
 var UATValidScopes = map[string]bool{
 	UATScopeProjectRead:   true,
+	UATScopeProjectUpdate: true,
 	UATScopeAgentCreate:   true,
 	UATScopeAgentRead:     true,
 	UATScopeAgentList:     true,


### PR DESCRIPTION
## Problem

`UATValidScopes` (pkg/store/models.go) lists `project:read` and the `agent:*`
scopes, but not `project:update`. minting a token with it is rejected:

    $ scion hub token create --scopes project:read,project:update
    400 invalid scope: project:update

The authorisation layer, however already expects that scope: the
capabilities table registers `ActionUpdate` for the `project` resource, and
`enforceUATConstraints` derives the required scope as `<resource>:<action>`.
A project write (e.g. `scion hub env set --project KEY=VALUE`) checks the
caller's token for exactly `project:update`. The result is a scope that is
required by enforcement but impossible to mint: any project-write action is
unreachable for UAT holders no matter what they were granted.

## Change

Two lines: add the `UATScopeProjectUpdate = "project:update"` constant and its
`UATValidScopes` entry, mirroring `project:read`. No enforcement changes — the
check that consumes the scope already exists. A small test asserts the scope
now mints and round-trips validation.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
