### PR TITLE
feat(web): add terminal button to agent graph card

### DIFF
--- a/web/src/components/shared/agent-tree-view.ts
+++ b/web/src/components/shared/agent-tree-view.ts
@@ -286,7 +286,8 @@ export class ScionAgentTreeView extends LitElement {
 
     /*
      * Terminal icon button — lower-right corner of the agent card.
-     * Only visible on hover; uses sl-icon-button for minimal padding.
+     * Hidden by default; revealed on hover or keyboard focus-within so
+     * the button is reachable without a pointer device.
      */
     .terminal-btn {
       position: absolute;
@@ -299,7 +300,8 @@ export class ScionAgentTreeView extends LitElement {
       color: var(--sl-color-neutral-600);
     }
 
-    .node-wrapper:hover .terminal-btn {
+    .node-wrapper:hover .terminal-btn,
+    .node-wrapper:focus-within .terminal-btn:not([disabled]) {
       opacity: 1;
     }
 

--- a/web/src/components/shared/agent-tree-view.ts
+++ b/web/src/components/shared/agent-tree-view.ts
@@ -718,12 +718,8 @@ export class ScionAgentTreeView extends LitElement {
             class="terminal-btn"
             name="terminal"
             label="Terminal"
+            href="/agents/${agent.id}/terminal"
             ?disabled=${!isTerminalAvailable(agent)}
-            @click=${(e: Event) => {
-              e.preventDefault();
-              e.stopPropagation();
-              window.location.href = `/agents/${agent.id}/terminal`;
-            }}
           ></sl-icon-button>
         ` : nothing}
         ${descendants > 0 ? html`

--- a/web/src/components/shared/agent-tree-view.ts
+++ b/web/src/components/shared/agent-tree-view.ts
@@ -300,9 +300,13 @@ export class ScionAgentTreeView extends LitElement {
       color: var(--sl-color-neutral-600);
     }
 
-    .node-wrapper:hover .terminal-btn,
+    .node-wrapper:hover .terminal-btn:not([disabled]),
     .node-wrapper:focus-within .terminal-btn:not([disabled]) {
       opacity: 1;
+    }
+
+    .node-wrapper:hover .terminal-btn[disabled] {
+      opacity: 0.4;
     }
 
     .terminal-btn:hover {
@@ -310,12 +314,7 @@ export class ScionAgentTreeView extends LitElement {
     }
 
     .terminal-btn[disabled] {
-      opacity: 0.4;
       pointer-events: none;
-    }
-
-    .node-wrapper:hover .terminal-btn[disabled] {
-      opacity: 0.4;
     }
 
     /*

--- a/web/src/components/shared/agent-tree-view.ts
+++ b/web/src/components/shared/agent-tree-view.ts
@@ -27,7 +27,7 @@
 import { LitElement, html, css, svg, nothing } from 'lit';
 import { customElement, property, state, query } from 'lit/decorators.js';
 import type { Agent } from '../../shared/types.js';
-import { getAgentDisplayStatus } from '../../shared/types.js';
+import { getAgentDisplayStatus, can, isTerminalAvailable } from '../../shared/types.js';
 import { getStateDisplay, type StatusVariant } from '../../shared/agent-state-display.js';
 import {
   buildLineageForest,
@@ -285,6 +285,38 @@ export class ScionAgentTreeView extends LitElement {
     }
 
     /*
+     * Terminal icon button — lower-right corner of the agent card.
+     * Only visible on hover; uses sl-icon-button for minimal padding.
+     */
+    .terminal-btn {
+      position: absolute;
+      bottom: 4px;
+      right: 4px;
+      z-index: 1;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      font-size: 1rem;
+      color: var(--sl-color-neutral-600);
+    }
+
+    .node-wrapper:hover .terminal-btn {
+      opacity: 1;
+    }
+
+    .terminal-btn:hover {
+      color: var(--sl-color-primary-600);
+    }
+
+    .terminal-btn[disabled] {
+      opacity: 0.4;
+      pointer-events: none;
+    }
+
+    .node-wrapper:hover .terminal-btn[disabled] {
+      opacity: 0.4;
+    }
+
+    /*
      * User (human) nodes are placed directly in the stage (no wrapper div),
      * so they keep position:absolute and use inline left/top for placement.
      */
@@ -420,7 +452,7 @@ export class ScionAgentTreeView extends LitElement {
     for (const el of e.composedPath()) {
       if (el === this.canvasEl) break;
       const tag = (el as HTMLElement).tagName;
-      if (tag === 'A' || tag === 'BUTTON' || tag === 'SL-BUTTON') return;
+      if (tag === 'A' || tag === 'BUTTON' || tag === 'SL-BUTTON' || tag === 'SL-ICON-BUTTON') return;
     }
     this.dragging = true;
     this.dragStartX = e.clientX;
@@ -680,6 +712,19 @@ export class ScionAgentTreeView extends LitElement {
           ></scion-status-badge>
           ${agent.template ? html`<span class="meta">${agent.template}</span>` : nothing}
         </a>
+        ${can(agent._capabilities, 'attach') ? html`
+          <sl-icon-button
+            class="terminal-btn"
+            name="terminal"
+            label="Terminal"
+            ?disabled=${!isTerminalAvailable(agent)}
+            @click=${(e: Event) => {
+              e.preventDefault();
+              e.stopPropagation();
+              window.location.href = `/agents/${agent.id}/terminal`;
+            }}
+          ></sl-icon-button>
+        ` : nothing}
         ${descendants > 0 ? html`
           <button
             class="collapse-chip"

--- a/web/src/components/shared/agent-tree-view.ts
+++ b/web/src/components/shared/agent-tree-view.ts
@@ -305,7 +305,8 @@ export class ScionAgentTreeView extends LitElement {
       opacity: 1;
     }
 
-    .node-wrapper:hover .terminal-btn[disabled] {
+    .node-wrapper:hover .terminal-btn[disabled],
+    .node-wrapper:focus-within .terminal-btn[disabled] {
       opacity: 0.4;
     }
 
@@ -718,7 +719,7 @@ export class ScionAgentTreeView extends LitElement {
             class="terminal-btn"
             name="terminal"
             label="Terminal"
-            href="/agents/${agent.id}/terminal"
+            href=${isTerminalAvailable(agent) ? `/agents/${agent.id}/terminal` : nothing}
             ?disabled=${!isTerminalAvailable(agent)}
           ></sl-icon-button>
         ` : nothing}


### PR DESCRIPTION
Small UI addition: icon-only connect-to-terminal button on each agent card in the graph view (lower-right corner, no text), reusing the same icon and /agents/{id}/terminal route as the agent detail page.
Gated by the attach capability, disabled for offline/non-running agents. Keyboard-accessible (focus-within reveals it), uses href for SPA navigation matching the existing sl-button precedent elsewhere.
Single file changed: web/src/components/shared/agent-tree-view.ts. Four independent fork reviews across the fix cycle (rounds 1-4), all approved, only cosmetic/non-blocking notes remaining (explicitly declined, documented in review history).
Ref: ptone/scion#647
