### PR TITLE
feat: auto-provision default scratchpad shared directory for new projects

### DIFF
--- a/pkg/config/opsettings/opsettings_test.go
+++ b/pkg/config/opsettings/opsettings_test.go
@@ -30,7 +30,8 @@ import (
 
 func TestRegistryHasAllSections(t *testing.T) {
 	expected := []string{"access", "lifecycle", "maintenance", "telemetry",
-		"agent_defaults", "endpoints", "github_app", "notifications"}
+		"agent_defaults", "endpoints", "github_app", "notifications",
+		"project_defaults"}
 	for _, name := range expected {
 		if SectionByName(name) == nil {
 			t.Errorf("section %q not found in registry", name)
@@ -63,10 +64,15 @@ func TestSectionMarshalUnmarshal(t *testing.T) {
 }
 
 func TestSectionHasKoanfPaths(t *testing.T) {
+	// Sections that are DB-only (no settings.yaml representation).
+	dbOnlySections := map[string]bool{
+		"maintenance":      true,
+		"project_defaults": true,
+	}
 	for _, sec := range Registry {
-		if sec.Name == "maintenance" {
+		if dbOnlySections[sec.Name] {
 			if len(sec.KoanfPaths) != 0 {
-				t.Errorf("maintenance section should have empty KoanfPaths, got %v", sec.KoanfPaths)
+				t.Errorf("%s section should have empty KoanfPaths, got %v", sec.Name, sec.KoanfPaths)
 			}
 			continue
 		}
@@ -182,6 +188,9 @@ func TestValidateValidDoc(t *testing.T) {
 		{"endpoints", `{"public_url":"https://hub.example.com","image_registry":"gcr.io/my-project"}`},
 		{"github_app", `{"app_id":12345,"webhooks_enabled":true}`},
 		{"notifications", `{"notification_channels":[{"type":"slack"}]}`},
+		{"project_defaults", `{"default_scratchpad":true}`},
+		{"project_defaults", `{"default_scratchpad":false}`},
+		{"project_defaults", `{}`},
 	}
 	for _, tt := range tests {
 		errs := Validate(tt.section, json.RawMessage(tt.doc))
@@ -202,6 +211,8 @@ func TestValidateInvalidDoc(t *testing.T) {
 		{"maintenance", `{"admin_mode":"yes"}`, "wrong type for boolean"},
 		{"agent_defaults", `{"default_max_turns":"not-a-number"}`, "wrong type for int"},
 		{"github_app", `{"app_id":"not-a-number"}`, "wrong type for int64"},
+		{"project_defaults", `{"default_scratchpad":"yes"}`, "wrong type for boolean"},
+		{"project_defaults", `{"unknown_field":true}`, "additional property"},
 	}
 	for _, tt := range tests {
 		errs := Validate(tt.section, json.RawMessage(tt.doc))
@@ -834,6 +845,17 @@ func TestSectionNames(t *testing.T) {
 	names := SectionNames()
 	if len(names) != len(Registry) {
 		t.Errorf("expected %d names, got %d", len(Registry), len(names))
+	}
+	// Verify project_defaults appears in the list.
+	found := false
+	for _, n := range names {
+		if n == "project_defaults" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("project_defaults not found in SectionNames()")
 	}
 }
 

--- a/pkg/config/opsettings/registry.go
+++ b/pkg/config/opsettings/registry.go
@@ -109,6 +109,15 @@ func init() {
 			KoanfPaths: []string{"server.notification_channels"},
 			New:        func() any { return &NotificationsSettings{} },
 		},
+		{
+			// project_defaults is durable via DB but has no settings.yaml
+			// representation. It controls hub-level defaults applied at
+			// project creation time (e.g. default scratchpad shared dir).
+			// Absent DB row = compiled defaults (default_scratchpad=true).
+			Name:       "project_defaults",
+			KoanfPaths: nil,
+			New:        func() any { return &ProjectDefaultsSettings{} },
+		},
 	}
 
 	ensureIndexes()
@@ -290,6 +299,15 @@ func compileSchemas() {
 			"additionalProperties": false,
 		},
 		"notifications": buildNotificationsSchema(),
+		// project_defaults schema is hand-written — like maintenance, it has
+		// no $defs in settings-v1.schema.json because it is runtime/DB state.
+		"project_defaults": {
+			"type": "object",
+			"properties": map[string]interface{}{
+				"default_scratchpad": map[string]interface{}{"type": "boolean"},
+			},
+			"additionalProperties": false,
+		},
 	}
 
 	rawSchemas = sectionSchemaMap

--- a/pkg/config/opsettings/sections.go
+++ b/pkg/config/opsettings/sections.go
@@ -80,3 +80,11 @@ type GitHubAppSettings struct {
 type NotificationsSettings struct {
 	NotificationChannels []config.V1NotificationChannelConfig `json:"notification_channels,omitempty"`
 }
+
+// ProjectDefaultsSettings holds Layer-1 project creation defaults.
+type ProjectDefaultsSettings struct {
+	// DefaultScratchpad controls whether new projects automatically get a
+	// "scratchpad" shared directory. When nil (section absent from DB),
+	// the compiled default is true (ON).
+	DefaultScratchpad *bool `json:"default_scratchpad,omitempty"`
+}

--- a/pkg/hub/admin_project_defaults.go
+++ b/pkg/hub/admin_project_defaults.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config/opsettings"
+)
+
+// handleAdminProjectDefaults handles GET/PUT /api/v1/admin/project-defaults.
+//
+// GET returns the current project defaults (merged with compiled defaults).
+// PUT accepts a partial update to the project_defaults opsettings section.
+//
+// Both endpoints are admin-gated (same auth check as handleAdminMaintenance).
+// The section follows the maintenance pattern: DB-only, no settings.yaml
+// representation, with a dedicated admin API endpoint.
+func (s *Server) handleAdminProjectDefaults(w http.ResponseWriter, r *http.Request) {
+	// Require admin user.
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil || user.Role() != "admin" {
+		Forbidden(w)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		s.handleGetProjectDefaults(w)
+	case http.MethodPut:
+		s.handlePutProjectDefaults(w, r)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// handleGetProjectDefaults returns the current project defaults, merging
+// the DB row with the compiled default. When no DB row exists, the compiled
+// default is returned (default_scratchpad: true).
+func (s *Server) handleGetProjectDefaults(w http.ResponseWriter) {
+	enabled := true // compiled default
+
+	if ops := s.GetOperationalSettings(); ops != nil {
+		enabled = ops.ProjectDefaultScratchpad()
+	}
+
+	writeJSON(w, http.StatusOK, opsettings.ProjectDefaultsSettings{
+		DefaultScratchpad: &enabled,
+	})
+}
+
+// handlePutProjectDefaults accepts a partial update to the project_defaults
+// section. It writes the section via OperationalSettings.Update() (which
+// handles validation, persistence, and cross-replica propagation) or falls
+// back to a simple validation-only response in file/SQLite mode.
+func (s *Server) handlePutProjectDefaults(w http.ResponseWriter, r *http.Request) {
+	var body opsettings.ProjectDefaultsSettings
+	if err := readJSON(r, &body); err != nil {
+		BadRequest(w, "Invalid request body: "+err.Error())
+		return
+	}
+
+	doc, err := json.Marshal(body)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
+			"Failed to marshal settings", nil)
+		return
+	}
+
+	// Validate the document against the section schema.
+	if errs := opsettings.Validate("project_defaults", doc); len(errs) > 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+			"error":  "validation_failed",
+			"errors": errs,
+		})
+		return
+	}
+
+	// In postgres mode, persist via OperationalSettings.
+	if ops := s.GetOperationalSettings(); ops != nil {
+		caller := GetUserIdentityFromContext(r.Context())
+		updatedBy := ""
+		if caller != nil {
+			updatedBy = caller.Email()
+		}
+
+		// last-writer-wins (-1) — no CAS needed for this endpoint.
+		if _, err := ops.Update(r.Context(), "project_defaults", doc, updatedBy, -1, "managed"); err != nil {
+			writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
+				"Failed to update project defaults: "+err.Error(), nil)
+			return
+		}
+
+		// Read back the applied state.
+		enabled := ops.ProjectDefaultScratchpad()
+		writeJSON(w, http.StatusOK, opsettings.ProjectDefaultsSettings{
+			DefaultScratchpad: &enabled,
+		})
+		return
+	}
+
+	// File/SQLite mode: no persistent storage for this section.
+	// Return the validated payload as acknowledgement.
+	writeJSON(w, http.StatusOK, body)
+}

--- a/pkg/hub/admin_project_defaults.go
+++ b/pkg/hub/admin_project_defaults.go
@@ -113,6 +113,13 @@ func (s *Server) handlePutProjectDefaults(w http.ResponseWriter, r *http.Request
 	}
 
 	// File/SQLite mode: no persistent storage for this section.
-	// Return the validated payload as acknowledgement.
-	writeJSON(w, http.StatusOK, body)
+	// Resolve against compiled default for a consistent response shape,
+	// regardless of deployment mode.
+	enabled := true // compiled default
+	if body.DefaultScratchpad != nil {
+		enabled = *body.DefaultScratchpad
+	}
+	writeJSON(w, http.StatusOK, opsettings.ProjectDefaultsSettings{
+		DefaultScratchpad: &enabled,
+	})
 }

--- a/pkg/hub/admin_project_defaults.go
+++ b/pkg/hub/admin_project_defaults.go
@@ -113,13 +113,7 @@ func (s *Server) handlePutProjectDefaults(w http.ResponseWriter, r *http.Request
 	}
 
 	// File/SQLite mode: no persistent storage for this section.
-	// Resolve against compiled default for a consistent response shape,
-	// regardless of deployment mode.
-	enabled := true // compiled default
-	if body.DefaultScratchpad != nil {
-		enabled = *body.DefaultScratchpad
-	}
-	writeJSON(w, http.StatusOK, opsettings.ProjectDefaultsSettings{
-		DefaultScratchpad: &enabled,
-	})
+	// Return 501 to signal that writes are not supported.
+	writeError(w, http.StatusNotImplemented, "not_implemented",
+		"Updating project defaults is not supported in file/SQLite mode", nil)
 }

--- a/pkg/hub/admin_project_defaults_test.go
+++ b/pkg/hub/admin_project_defaults_test.go
@@ -211,31 +211,19 @@ func TestHandleAdminProjectDefaults_PutEmptyDocResolvesDefault(t *testing.T) {
 	}
 }
 
-func TestHandleAdminProjectDefaults_FileSQLiteMode_PutResolvesDefault(t *testing.T) {
-	// In file/SQLite mode (no OperationalSettings), PUT should still return
-	// the resolved value, not echo the raw body.
+func TestHandleAdminProjectDefaults_FileSQLiteMode_PutNotImplemented(t *testing.T) {
+	// In file/SQLite mode (no OperationalSettings), PUT should return 501
+	// because there is no persistent storage for this section.
 	srv := newAdminProjectDefaultsServer(t, nil) // nil store = file/SQLite mode
 
-	// PUT {} — file/SQLite mode should resolve against compiled default.
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/project-defaults",
-		bytes.NewBufferString(`{}`))
+		bytes.NewBufferString(`{"default_scratchpad": false}`))
 	req.Header.Set("Content-Type", "application/json")
 	req = adminContext(req)
 	rr := httptest.NewRecorder()
 	srv.handleAdminProjectDefaults(rr, req)
 
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
-	}
-
-	var resp opsettings.ProjectDefaultsSettings
-	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
-	if resp.DefaultScratchpad == nil {
-		t.Fatal("expected default_scratchpad to be present in resolved response")
-	}
-	if *resp.DefaultScratchpad != true {
-		t.Errorf("file/SQLite mode: expected default_scratchpad=true (compiled default), got %v", *resp.DefaultScratchpad)
+	if rr.Code != http.StatusNotImplemented {
+		t.Fatalf("expected 501, got %d: %s", rr.Code, rr.Body.String())
 	}
 }

--- a/pkg/hub/admin_project_defaults_test.go
+++ b/pkg/hub/admin_project_defaults_test.go
@@ -1,0 +1,241 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config/opsettings"
+)
+
+// newAdminProjectDefaultsServer creates a minimal Server with an
+// OperationalSettings backed by the given fakeHubSettingStore. If store is nil,
+// no OperationalSettings is set (simulating file/SQLite mode).
+func newAdminProjectDefaultsServer(t *testing.T, store *fakeHubSettingStore) *Server {
+	t.Helper()
+	srv := &Server{}
+	if store != nil {
+		ops := NewOperationalSettings(store, emptyKoanf(), emptyKoanf())
+		if _, err := ops.Refresh(context.Background()); err != nil {
+			t.Fatalf("Refresh: %v", err)
+		}
+		srv.operationalSettings.Store(ops)
+	}
+	return srv
+}
+
+func adminContext(r *http.Request) *http.Request {
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	return r.WithContext(contextWithIdentity(r.Context(), admin))
+}
+
+func nonAdminContext(r *http.Request) *http.Request {
+	user := NewAuthenticatedUser("u2", "user@example.com", "User", "member", "cli")
+	return r.WithContext(contextWithIdentity(r.Context(), user))
+}
+
+// --- HTTP-level tests for handleAdminProjectDefaults ---
+
+func TestHandleAdminProjectDefaults_GetCompiledDefault(t *testing.T) {
+	// GET with no DB row returns the compiled default: default_scratchpad=true.
+	srv := newAdminProjectDefaultsServer(t, newFakeHubSettingStore())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/project-defaults", nil)
+	req = adminContext(req)
+	rr := httptest.NewRecorder()
+	srv.handleAdminProjectDefaults(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var body opsettings.ProjectDefaultsSettings
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body.DefaultScratchpad == nil {
+		t.Fatal("expected default_scratchpad to be present")
+	}
+	if *body.DefaultScratchpad != true {
+		t.Errorf("expected default_scratchpad=true (compiled default), got %v", *body.DefaultScratchpad)
+	}
+}
+
+func TestHandleAdminProjectDefaults_PutAndGet(t *testing.T) {
+	// PUT {"default_scratchpad": false} then GET verifies the change persisted.
+	srv := newAdminProjectDefaultsServer(t, newFakeHubSettingStore())
+
+	// PUT to disable scratchpad.
+	putBody := `{"default_scratchpad": false}`
+	putReq := httptest.NewRequest(http.MethodPut, "/api/v1/admin/project-defaults",
+		bytes.NewBufferString(putBody))
+	putReq.Header.Set("Content-Type", "application/json")
+	putReq = adminContext(putReq)
+	putRR := httptest.NewRecorder()
+	srv.handleAdminProjectDefaults(putRR, putReq)
+
+	if putRR.Code != http.StatusOK {
+		t.Fatalf("PUT expected 200, got %d: %s", putRR.Code, putRR.Body.String())
+	}
+
+	// Verify PUT response contains the resolved value.
+	var putResp opsettings.ProjectDefaultsSettings
+	if err := json.NewDecoder(putRR.Body).Decode(&putResp); err != nil {
+		t.Fatalf("failed to decode PUT response: %v", err)
+	}
+	if putResp.DefaultScratchpad == nil || *putResp.DefaultScratchpad != false {
+		t.Errorf("PUT response: expected default_scratchpad=false, got %v", putResp.DefaultScratchpad)
+	}
+
+	// GET to verify persistence.
+	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/admin/project-defaults", nil)
+	getReq = adminContext(getReq)
+	getRR := httptest.NewRecorder()
+	srv.handleAdminProjectDefaults(getRR, getReq)
+
+	if getRR.Code != http.StatusOK {
+		t.Fatalf("GET expected 200, got %d: %s", getRR.Code, getRR.Body.String())
+	}
+
+	var getResp opsettings.ProjectDefaultsSettings
+	if err := json.NewDecoder(getRR.Body).Decode(&getResp); err != nil {
+		t.Fatalf("failed to decode GET response: %v", err)
+	}
+	if getResp.DefaultScratchpad == nil || *getResp.DefaultScratchpad != false {
+		t.Errorf("GET after PUT: expected default_scratchpad=false, got %v", getResp.DefaultScratchpad)
+	}
+}
+
+func TestHandleAdminProjectDefaults_PutInvalidPayload(t *testing.T) {
+	// PUT with a non-boolean value should return 400.
+	srv := newAdminProjectDefaultsServer(t, newFakeHubSettingStore())
+
+	payload := `{"default_scratchpad": "yes"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/project-defaults",
+		bytes.NewBufferString(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req = adminContext(req)
+	rr := httptest.NewRecorder()
+	srv.handleAdminProjectDefaults(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid payload, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleAdminProjectDefaults_Forbidden(t *testing.T) {
+	// Non-admin user should get 403.
+	srv := newAdminProjectDefaultsServer(t, newFakeHubSettingStore())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/project-defaults", nil)
+	req = nonAdminContext(req)
+	rr := httptest.NewRecorder()
+	srv.handleAdminProjectDefaults(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("non-admin should get 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleAdminProjectDefaults_Unauthenticated(t *testing.T) {
+	// No identity in context should get 403.
+	srv := newAdminProjectDefaultsServer(t, newFakeHubSettingStore())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/project-defaults", nil)
+	rr := httptest.NewRecorder()
+	srv.handleAdminProjectDefaults(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("unauthenticated should get 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleAdminProjectDefaults_MethodNotAllowed(t *testing.T) {
+	// POST and DELETE should return 405.
+	srv := newAdminProjectDefaultsServer(t, newFakeHubSettingStore())
+
+	for _, method := range []string{http.MethodPost, http.MethodDelete} {
+		req := httptest.NewRequest(method, "/api/v1/admin/project-defaults", nil)
+		req = adminContext(req)
+		rr := httptest.NewRecorder()
+		srv.handleAdminProjectDefaults(rr, req)
+
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Errorf("%s: expected 405, got %d: %s", method, rr.Code, rr.Body.String())
+		}
+	}
+}
+
+func TestHandleAdminProjectDefaults_PutEmptyDocResolvesDefault(t *testing.T) {
+	// PUT {} should return the resolved compiled default (default_scratchpad=true),
+	// not an empty object.
+	srv := newAdminProjectDefaultsServer(t, newFakeHubSettingStore())
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/project-defaults",
+		bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = adminContext(req)
+	rr := httptest.NewRecorder()
+	srv.handleAdminProjectDefaults(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp opsettings.ProjectDefaultsSettings
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.DefaultScratchpad == nil {
+		t.Fatal("expected default_scratchpad to be present in response")
+	}
+	if *resp.DefaultScratchpad != true {
+		t.Errorf("expected default_scratchpad=true (compiled default), got %v", *resp.DefaultScratchpad)
+	}
+}
+
+func TestHandleAdminProjectDefaults_FileSQLiteMode_PutResolvesDefault(t *testing.T) {
+	// In file/SQLite mode (no OperationalSettings), PUT should still return
+	// the resolved value, not echo the raw body.
+	srv := newAdminProjectDefaultsServer(t, nil) // nil store = file/SQLite mode
+
+	// PUT {} — file/SQLite mode should resolve against compiled default.
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/project-defaults",
+		bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = adminContext(req)
+	rr := httptest.NewRecorder()
+	srv.handleAdminProjectDefaults(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp opsettings.ProjectDefaultsSettings
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.DefaultScratchpad == nil {
+		t.Fatal("expected default_scratchpad to be present in resolved response")
+	}
+	if *resp.DefaultScratchpad != true {
+		t.Errorf("file/SQLite mode: expected default_scratchpad=true (compiled default), got %v", *resp.DefaultScratchpad)
+	}
+}

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -333,6 +333,15 @@ func (s *Server) createProject(w http.ResponseWriter, r *http.Request) {
 		project.OwnerID = user.ID()
 	}
 
+	// Apply default shared dirs from hub settings.
+	// Only stamp when the project has no shared dirs. Since
+	// CreateProjectRequest has no SharedDirs field, this is always
+	// true for direct-create — but the guard future-proofs against
+	// API evolution.
+	if len(project.SharedDirs) == 0 {
+		project.SharedDirs = s.defaultProjectSharedDirs()
+	}
+
 	if err := s.store.CreateProject(ctx, project); err != nil {
 		writeErrorFromErr(w, err, "")
 		return
@@ -1035,6 +1044,11 @@ func (s *Server) handleProjectRegister(w http.ResponseWriter, r *http.Request) {
 		if user := GetUserIdentityFromContext(ctx); user != nil {
 			project.CreatedBy = user.ID()
 			project.OwnerID = user.ID()
+		}
+
+		// Apply default shared dirs from hub settings (new projects only).
+		if len(project.SharedDirs) == 0 {
+			project.SharedDirs = s.defaultProjectSharedDirs()
 		}
 
 		if err := s.store.CreateProject(ctx, project); err != nil {

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -804,6 +804,29 @@ func ApplyMaintenanceFromSnapshot(s *Server, snap Layer1Snapshot) {
 	s.maintenance.Set(snap.AdminMode, snap.MaintenanceMessage)
 }
 
+// ProjectDefaultScratchpad returns whether the default scratchpad shared
+// dir is enabled for new projects. Returns true (compiled default) when
+// the project_defaults section is absent from the DB.
+func (o *OperationalSettings) ProjectDefaultScratchpad() bool {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+
+	state, ok := o.cache["project_defaults"]
+	if !ok {
+		return true // compiled default: ON
+	}
+
+	var pd opsettings.ProjectDefaultsSettings
+	if err := json.Unmarshal(state.Value, &pd); err != nil {
+		return true // parse error → fall back to compiled default
+	}
+
+	if pd.DefaultScratchpad != nil {
+		return *pd.DefaultScratchpad
+	}
+	return true // field omitted in doc → compiled default
+}
+
 // applySnapshotLogLevel applies the log-level portion of the snapshot.
 // This is separated from applySnapshot because log level is a Layer-0 setting
 // (per design §3.1) and is only changed in file mode via reloadSettings.

--- a/pkg/hub/project_defaults.go
+++ b/pkg/hub/project_defaults.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import "github.com/GoogleCloudPlatform/scion/pkg/api"
+
+// defaultProjectSharedDirs returns the hub-configured default shared dirs
+// for new projects. Returns a scratchpad shared dir when enabled (the
+// compiled default), or nil when the operator has explicitly disabled it.
+//
+// Thread-safe: reads from OperationalSettings under its internal lock.
+func (s *Server) defaultProjectSharedDirs() []api.SharedDir {
+	enabled := true // compiled default: ON
+
+	if ops := s.GetOperationalSettings(); ops != nil {
+		enabled = ops.ProjectDefaultScratchpad()
+	}
+	// File/SQLite mode: ops is nil → compiled default (ON) applies.
+
+	if !enabled {
+		return nil
+	}
+	return []api.SharedDir{{Name: "scratchpad"}}
+}

--- a/pkg/hub/project_defaults_test.go
+++ b/pkg/hub/project_defaults_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+)
+
+// --- ProjectDefaultScratchpad() unit tests ---
+
+func TestProjectDefaultScratchpad_AbsentSection(t *testing.T) {
+	// No project_defaults section in the cache → compiled default (true).
+	fakeStore := newFakeHubSettingStore()
+	ops := NewOperationalSettings(fakeStore, emptyKoanf(), emptyKoanf())
+	_, _ = ops.Refresh(context.Background())
+
+	if got := ops.ProjectDefaultScratchpad(); !got {
+		t.Error("expected true (compiled default) when section is absent, got false")
+	}
+}
+
+func TestProjectDefaultScratchpad_ExplicitTrue(t *testing.T) {
+	fakeStore := newFakeHubSettingStore()
+	fakeStore.seed("project_defaults", json.RawMessage(`{"default_scratchpad":true}`))
+	ops := NewOperationalSettings(fakeStore, emptyKoanf(), emptyKoanf())
+	_, _ = ops.Refresh(context.Background())
+
+	if got := ops.ProjectDefaultScratchpad(); !got {
+		t.Error("expected true when explicitly set to true, got false")
+	}
+}
+
+func TestProjectDefaultScratchpad_ExplicitFalse(t *testing.T) {
+	fakeStore := newFakeHubSettingStore()
+	fakeStore.seed("project_defaults", json.RawMessage(`{"default_scratchpad":false}`))
+	ops := NewOperationalSettings(fakeStore, emptyKoanf(), emptyKoanf())
+	_, _ = ops.Refresh(context.Background())
+
+	if got := ops.ProjectDefaultScratchpad(); got {
+		t.Error("expected false when explicitly set to false, got true")
+	}
+}
+
+func TestProjectDefaultScratchpad_EmptyDoc(t *testing.T) {
+	// Section exists in DB but field is omitted → compiled default (true).
+	fakeStore := newFakeHubSettingStore()
+	fakeStore.seed("project_defaults", json.RawMessage(`{}`))
+	ops := NewOperationalSettings(fakeStore, emptyKoanf(), emptyKoanf())
+	_, _ = ops.Refresh(context.Background())
+
+	if got := ops.ProjectDefaultScratchpad(); !got {
+		t.Error("expected true (compiled default) when field is omitted, got false")
+	}
+}
+
+func TestProjectDefaultScratchpad_InvalidJSON(t *testing.T) {
+	// Section exists but contains unparseable JSON → compiled default (true).
+	fakeStore := newFakeHubSettingStore()
+	fakeStore.seed("project_defaults", json.RawMessage(`{invalid`))
+	ops := NewOperationalSettings(fakeStore, emptyKoanf(), emptyKoanf())
+	_, _ = ops.Refresh(context.Background())
+
+	if got := ops.ProjectDefaultScratchpad(); !got {
+		t.Error("expected true (compiled default) on parse error, got false")
+	}
+}
+
+// --- defaultProjectSharedDirs() unit tests ---
+
+func TestDefaultProjectSharedDirs_NoOps(t *testing.T) {
+	// No OperationalSettings (file/SQLite mode) → compiled default (scratchpad ON).
+	srv := &Server{}
+	dirs := srv.defaultProjectSharedDirs()
+	if len(dirs) != 1 {
+		t.Fatalf("expected 1 shared dir, got %d", len(dirs))
+	}
+	if dirs[0].Name != "scratchpad" {
+		t.Errorf("expected name=scratchpad, got %q", dirs[0].Name)
+	}
+	if dirs[0].ReadOnly {
+		t.Error("expected ReadOnly=false")
+	}
+	if dirs[0].InWorkspace {
+		t.Error("expected InWorkspace=false")
+	}
+}
+
+func TestDefaultProjectSharedDirs_Enabled(t *testing.T) {
+	fakeStore := newFakeHubSettingStore()
+	fakeStore.seed("project_defaults", json.RawMessage(`{"default_scratchpad":true}`))
+	ops := NewOperationalSettings(fakeStore, emptyKoanf(), emptyKoanf())
+	_, _ = ops.Refresh(context.Background())
+
+	srv := &Server{}
+	srv.operationalSettings.Store(ops)
+
+	dirs := srv.defaultProjectSharedDirs()
+	if len(dirs) != 1 || dirs[0].Name != "scratchpad" {
+		t.Errorf("expected [scratchpad], got %v", dirs)
+	}
+}
+
+func TestDefaultProjectSharedDirs_Disabled(t *testing.T) {
+	fakeStore := newFakeHubSettingStore()
+	fakeStore.seed("project_defaults", json.RawMessage(`{"default_scratchpad":false}`))
+	ops := NewOperationalSettings(fakeStore, emptyKoanf(), emptyKoanf())
+	_, _ = ops.Refresh(context.Background())
+
+	srv := &Server{}
+	srv.operationalSettings.Store(ops)
+
+	dirs := srv.defaultProjectSharedDirs()
+	if dirs != nil {
+		t.Errorf("expected nil when disabled, got %v", dirs)
+	}
+}
+
+func TestDefaultProjectSharedDirs_SharedDirSpec(t *testing.T) {
+	// Verify the returned SharedDir matches the design spec exactly.
+	srv := &Server{}
+	dirs := srv.defaultProjectSharedDirs()
+	expected := api.SharedDir{Name: "scratchpad", ReadOnly: false, InWorkspace: false}
+	if len(dirs) != 1 || dirs[0] != expected {
+		t.Errorf("expected %+v, got %+v", expected, dirs)
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2944,6 +2944,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/admin/server-config/schema", s.handleAdminServerConfigSchema)
 	s.mux.HandleFunc("/api/v1/admin/server-config/sections/", s.handleAdminServerConfigSectionReset)
 	s.mux.HandleFunc("/api/v1/admin/server-config", s.handleAdminServerConfig)
+	s.mux.HandleFunc("/api/v1/admin/project-defaults", s.handleAdminProjectDefaults)
 	s.mux.HandleFunc("/api/v1/admin/agents/reset-auth-all", s.handleAdminResetAuthAll)
 	s.mux.HandleFunc("/api/v1/admin/gcp-quota", s.handleAdminGCPQuota)
 	s.mux.HandleFunc("/api/v1/admin/lifecycle-hooks", s.handleAdminLifecycleHooks)


### PR DESCRIPTION
## Summary

Adds a new `project_defaults` operational settings section with a `default_scratchpad` boolean toggle (compiled default: ON). When enabled, new projects automatically receive a `scratchpad` shared directory mounted at `/scion-volumes/scratchpad`.

Related fork issue: https://github.com/ptone/scion/issues/649
