### PR TITLE
feat: route message attachments through scratchpad shared volume

### DIFF
--- a/cmd/message.go
+++ b/cmd/message.go
@@ -837,7 +837,8 @@ func resolveAttachmentPath(p string) string {
 	}
 	p = filepath.Clean(p)
 
-	if strings.HasPrefix(p, "/workspace") || strings.HasPrefix(p, "/scion-volumes") {
+	if strings.HasPrefix(p, "/workspace/") || p == "/workspace" ||
+		strings.HasPrefix(p, "/scion-volumes/") || p == "/scion-volumes" {
 		return p
 	}
 
@@ -863,9 +864,10 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer dstFile.Close()
-
 	_, err = io.Copy(dstFile, srcFile)
+	if closeErr := dstFile.Close(); err == nil {
+		err = closeErr
+	}
 	return err
 }
 

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -17,7 +17,9 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -232,6 +234,15 @@ Examples:
 		// --notify requires Hub mode
 		if msgNotify && hubCtx == nil {
 			return fmt.Errorf("--notify requires Hub mode (use 'scion hub enable' first)")
+		}
+
+		// Stage attachments to shared volume (after Hub mode confirmed)
+		if len(msgAttach) > 0 && hubCtx != nil {
+			staged, err := stageAttachments(msgAttach)
+			if err != nil {
+				return fmt.Errorf("attachment staging failed: %w", err)
+			}
+			msgAttach = staged
 		}
 
 		// Group-targeted messages: fan out to each recipient
@@ -814,4 +825,119 @@ func init() {
 	messageCmd.Flags().StringVar(&msgThreadID, "thread-id", "", "Target a specific thread within the channel")
 	messageCmd.AddCommand(messageChannelsCmd)
 	rootCmd.AddCommand(messageCmd)
+}
+
+// resolveAttachmentPath resolves a relative or absolute attachment path.
+// Relative paths are resolved relative to /workspace. Absolute paths outside
+// /workspace and /scion-volumes are filtered out with a warning. Returns ""
+// for filtered paths.
+func resolveAttachmentPath(p string) string {
+	if !filepath.IsAbs(p) {
+		p = filepath.Join("/workspace", p)
+	}
+	p = filepath.Clean(p)
+
+	if strings.HasPrefix(p, "/workspace") || strings.HasPrefix(p, "/scion-volumes") {
+		return p
+	}
+
+	fmt.Fprintf(os.Stderr, "Warning: attachment path %q is outside allowed roots "+
+		"(/workspace, /scion-volumes); skipping\n", p)
+	return ""
+}
+
+// copyFile copies the file at src to dst, preserving permissions.
+func copyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	srcInfo, err := srcFile.Stat()
+	if err != nil {
+		return err
+	}
+
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode())
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	return err
+}
+
+// uniqueDest returns a unique destination path in dir for basename. If basename
+// already exists in dir, appends _1, _2, etc. before the extension.
+func uniqueDest(dir, basename string) string {
+	dest := filepath.Join(dir, basename)
+	if _, err := os.Stat(dest); os.IsNotExist(err) {
+		return dest
+	}
+
+	ext := filepath.Ext(basename)
+	name := strings.TrimSuffix(basename, ext)
+	for i := 1; ; i++ {
+		candidate := filepath.Join(dir, fmt.Sprintf("%s_%d%s", name, i, ext))
+		if _, err := os.Stat(candidate); os.IsNotExist(err) {
+			return candidate
+		}
+	}
+}
+
+// stageAttachments copies attachment files to the scratchpad shared volume
+// and returns the new paths. Returns an error if the scratchpad is not
+// available — attachments require shared storage for cross-agent delivery.
+func stageAttachments(paths []string) ([]string, error) {
+	scratchpad := "/scion-volumes/scratchpad"
+
+	// Check scratchpad availability — hard error if absent
+	if _, err := os.Stat(scratchpad); os.IsNotExist(err) {
+		return nil, fmt.Errorf("scratchpad volume not available at %s; "+
+			"attachments require a scratchpad shared volume for cross-agent "+
+			"file transfer. Create one with: scion shared-dir create scratchpad",
+			scratchpad)
+	}
+
+	// Determine agent slug for per-agent directory
+	agentSlug := os.Getenv("SCION_AGENT_NAME")
+	if agentSlug == "" {
+		agentSlug = "_user"
+	}
+
+	// Generate per-message staging directory under agent slug
+	msgID := api.NewUUID()
+	stageDir := filepath.Join(scratchpad, ".attachments", agentSlug, msgID)
+	if err := os.MkdirAll(stageDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create attachment staging directory: %w", err)
+	}
+
+	staged := make([]string, 0, len(paths))
+	for _, p := range paths {
+		// Resolve path
+		resolved := resolveAttachmentPath(p)
+		if resolved == "" {
+			continue // filtered out (warning already printed)
+		}
+
+		// Validate file exists and is a regular file
+		info, err := os.Stat(resolved)
+		if err != nil {
+			return nil, fmt.Errorf("attachment %q: %w", p, err)
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("attachment %q: not a regular file", p)
+		}
+
+		// Copy to staging directory (handle duplicate basenames)
+		dest := uniqueDest(stageDir, filepath.Base(resolved))
+		if err := copyFile(resolved, dest); err != nil {
+			return nil, fmt.Errorf("failed to stage attachment %q: %w", p, err)
+		}
+		staged = append(staged, dest)
+	}
+
+	return staged, nil
 }

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -853,7 +853,7 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer srcFile.Close()
+	defer func() { _ = srcFile.Close() }()
 
 	srcInfo, err := srcFile.Stat()
 	if err != nil {

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -835,11 +835,17 @@ func resolveAttachmentPath(p string) string {
 	if !filepath.IsAbs(p) {
 		p = filepath.Join("/workspace", p)
 	}
-	p = filepath.Clean(p)
 
-	if strings.HasPrefix(p, "/workspace/") || p == "/workspace" ||
-		strings.HasPrefix(p, "/scion-volumes/") || p == "/scion-volumes" {
-		return p
+	// Resolve symlinks to prevent directory traversal via symlinks
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		// If we can't resolve (e.g., file doesn't exist yet), fall back to Clean
+		resolved = filepath.Clean(p)
+	}
+
+	if strings.HasPrefix(resolved, "/workspace/") || resolved == "/workspace" ||
+		strings.HasPrefix(resolved, "/scion-volumes/") || resolved == "/scion-volumes" {
+		return resolved
 	}
 
 	fmt.Fprintf(os.Stderr, "Warning: attachment path %q is outside allowed roots "+
@@ -848,7 +854,7 @@ func resolveAttachmentPath(p string) string {
 }
 
 // copyFile copies the file at src to dst, preserving permissions.
-func copyFile(src, dst string) error {
+func copyFile(src, dst string) (err error) {
 	srcFile, err := os.Open(src)
 	if err != nil {
 		return err
@@ -864,27 +870,38 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if closeErr := dstFile.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
 	_, err = io.Copy(dstFile, srcFile)
-	if closeErr := dstFile.Close(); err == nil {
-		err = closeErr
-	}
 	return err
 }
 
 // uniqueDest returns a unique destination path in dir for basename. If basename
 // already exists in dir, appends _1, _2, etc. before the extension.
-func uniqueDest(dir, basename string) string {
+func uniqueDest(dir, basename string) (string, error) {
 	dest := filepath.Join(dir, basename)
-	if _, err := os.Stat(dest); os.IsNotExist(err) {
-		return dest
+	_, err := os.Stat(dest)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return dest, nil
+		}
+		return "", err
 	}
 
 	ext := filepath.Ext(basename)
 	name := strings.TrimSuffix(basename, ext)
 	for i := 1; ; i++ {
 		candidate := filepath.Join(dir, fmt.Sprintf("%s_%d%s", name, i, ext))
-		if _, err := os.Stat(candidate); os.IsNotExist(err) {
-			return candidate
+		_, err := os.Stat(candidate)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return candidate, nil
+			}
+			return "", err
 		}
 	}
 }
@@ -892,7 +909,7 @@ func uniqueDest(dir, basename string) string {
 // stageAttachments copies attachment files to the scratchpad shared volume
 // and returns the new paths. Returns an error if the scratchpad is not
 // available — attachments require shared storage for cross-agent delivery.
-func stageAttachments(paths []string) ([]string, error) {
+func stageAttachments(paths []string) (staged []string, err error) {
 	scratchpad := "/scion-volumes/scratchpad"
 
 	// Check scratchpad availability — hard error if absent
@@ -916,7 +933,14 @@ func stageAttachments(paths []string) ([]string, error) {
 		return nil, fmt.Errorf("failed to create attachment staging directory: %w", err)
 	}
 
-	staged := make([]string, 0, len(paths))
+	// Clean up staging directory if we return an error
+	defer func() {
+		if err != nil {
+			_ = os.RemoveAll(stageDir)
+		}
+	}()
+
+	staged = make([]string, 0, len(paths))
 	for _, p := range paths {
 		// Resolve path
 		resolved := resolveAttachmentPath(p)
@@ -934,7 +958,10 @@ func stageAttachments(paths []string) ([]string, error) {
 		}
 
 		// Copy to staging directory (handle duplicate basenames)
-		dest := uniqueDest(stageDir, filepath.Base(resolved))
+		dest, err := uniqueDest(stageDir, filepath.Base(resolved))
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine destination for attachment %q: %w", p, err)
+		}
 		if err := copyFile(resolved, dest); err != nil {
 			return nil, fmt.Errorf("failed to stage attachment %q: %w", p, err)
 		}

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -1270,7 +1270,7 @@ func TestStageAttachments_HappyPath(t *testing.T) {
 	testDir := filepath.Join("/workspace", ".test-attachments-happy")
 	err := os.MkdirAll(testDir, 0755)
 	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	defer func() { _ = os.RemoveAll(testDir) }()
 
 	testFile1 := filepath.Join(testDir, "test1.txt")
 	testFile2 := filepath.Join(testDir, "test2.txt")
@@ -1304,7 +1304,7 @@ func TestStageAttachments_HappyPath(t *testing.T) {
 	assert.Equal(t, "test2.txt", filepath.Base(staged[1]))
 
 	// Clean up staged files
-	os.RemoveAll(filepath.Dir(staged[0]))
+	_ = os.RemoveAll(filepath.Dir(staged[0]))
 }
 
 func TestStageAttachments_MissingScratchpad(t *testing.T) {
@@ -1333,7 +1333,7 @@ func TestStageAttachments_DuplicateBasenames(t *testing.T) {
 	require.NoError(t, err)
 	err = os.MkdirAll(dir2, 0755)
 	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	defer func() { _ = os.RemoveAll(testDir) }()
 
 	err = os.WriteFile(filepath.Join(dir1, "types.go"), []byte("package v1"), 0644)
 	require.NoError(t, err)
@@ -1361,7 +1361,7 @@ func TestStageAttachments_DuplicateBasenames(t *testing.T) {
 	assert.Equal(t, "package v2", string(c2))
 
 	// Cleanup
-	os.RemoveAll(filepath.Dir(staged[0]))
+	_ = os.RemoveAll(filepath.Dir(staged[0]))
 }
 
 func TestStageAttachments_NonExistentFile(t *testing.T) {
@@ -1387,7 +1387,7 @@ func TestStageAttachments_NonRegularFile(t *testing.T) {
 	testDir := filepath.Join("/workspace", ".test-nonreg-attach")
 	err := os.MkdirAll(testDir, 0755)
 	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	defer func() { _ = os.RemoveAll(testDir) }()
 
 	_, err = stageAttachments([]string{testDir})
 	require.Error(t, err)
@@ -1404,7 +1404,7 @@ func TestStageAttachments_DefaultAgentSlug(t *testing.T) {
 	testDir := filepath.Join("/workspace", ".test-slug-default")
 	err := os.MkdirAll(testDir, 0755)
 	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	defer func() { _ = os.RemoveAll(testDir) }()
 
 	testFile := filepath.Join(testDir, "file.txt")
 	err = os.WriteFile(testFile, []byte("test"), 0644)
@@ -1418,7 +1418,7 @@ func TestStageAttachments_DefaultAgentSlug(t *testing.T) {
 	assert.Contains(t, staged[0], "/_user/")
 
 	// Cleanup
-	os.RemoveAll(filepath.Dir(staged[0]))
+	_ = os.RemoveAll(filepath.Dir(staged[0]))
 }
 
 func TestStageAttachments_FilteredPathsSkipped(t *testing.T) {
@@ -1432,7 +1432,7 @@ func TestStageAttachments_FilteredPathsSkipped(t *testing.T) {
 	testDir := filepath.Join("/workspace", ".test-filter-attach")
 	err := os.MkdirAll(testDir, 0755)
 	require.NoError(t, err)
-	defer os.RemoveAll(testDir)
+	defer func() { _ = os.RemoveAll(testDir) }()
 
 	validFile := filepath.Join(testDir, "valid.go")
 	err = os.WriteFile(validFile, []byte("package valid"), 0644)
@@ -1446,5 +1446,5 @@ func TestStageAttachments_FilteredPathsSkipped(t *testing.T) {
 	assert.Equal(t, "valid.go", filepath.Base(staged[0]))
 
 	// Cleanup
-	os.RemoveAll(filepath.Dir(staged[0]))
+	_ = os.RemoveAll(filepath.Dir(staged[0]))
 }

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -1225,15 +1225,17 @@ func TestUniqueDest(t *testing.T) {
 	dir := t.TempDir()
 
 	// First call: no conflict
-	dest := uniqueDest(dir, "file.go")
+	dest, err := uniqueDest(dir, "file.go")
+	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(dir, "file.go"), dest)
 
 	// Create the file so the next call must pick a new name
-	err := os.WriteFile(dest, []byte("x"), 0644)
+	err = os.WriteFile(dest, []byte("x"), 0644)
 	require.NoError(t, err)
 
 	// Second call: conflict, should get _1
-	dest2 := uniqueDest(dir, "file.go")
+	dest2, err := uniqueDest(dir, "file.go")
+	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(dir, "file_1.go"), dest2)
 
 	// Create that file too
@@ -1241,7 +1243,8 @@ func TestUniqueDest(t *testing.T) {
 	require.NoError(t, err)
 
 	// Third call: should get _2
-	dest3 := uniqueDest(dir, "file.go")
+	dest3, err := uniqueDest(dir, "file.go")
+	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(dir, "file_2.go"), dest3)
 }
 
@@ -1249,13 +1252,15 @@ func TestUniqueDest_NoExtension(t *testing.T) {
 	dir := t.TempDir()
 
 	// File without extension
-	dest := uniqueDest(dir, "Makefile")
+	dest, err := uniqueDest(dir, "Makefile")
+	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(dir, "Makefile"), dest)
 
-	err := os.WriteFile(dest, []byte("x"), 0644)
+	err = os.WriteFile(dest, []byte("x"), 0644)
 	require.NoError(t, err)
 
-	dest2 := uniqueDest(dir, "Makefile")
+	dest2, err := uniqueDest(dir, "Makefile")
+	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(dir, "Makefile_1"), dest2)
 }
 

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -1153,6 +1153,21 @@ func TestResolveAttachmentPath(t *testing.T) {
 			path: "pkg/../cmd/message.go",
 			want: "/workspace/cmd/message.go",
 		},
+		{
+			name: "path with workspace prefix but different directory is filtered",
+			path: "/workspace-evil/secret.txt",
+			want: "",
+		},
+		{
+			name: "path with scion-volumes prefix but different directory is filtered",
+			path: "/scion-volumes-other/data.txt",
+			want: "",
+		},
+		{
+			name: "path with workspace prefix no separator is filtered",
+			path: "/workspacefoo",
+			want: "",
+		},
 	}
 
 	for _, tc := range tests {

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -1103,4 +1105,331 @@ func TestNotifyFlagValidation(t *testing.T) {
 			assert.Contains(t, err.Error(), tc.wantErr)
 		})
 	}
+}
+
+func TestResolveAttachmentPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "relative path resolves to /workspace",
+			path: "src/main.go",
+			want: "/workspace/src/main.go",
+		},
+		{
+			name: "bare filename resolves to /workspace",
+			path: "file.txt",
+			want: "/workspace/file.txt",
+		},
+		{
+			name: "absolute path under /workspace is accepted",
+			path: "/workspace/pkg/api/types.go",
+			want: "/workspace/pkg/api/types.go",
+		},
+		{
+			name: "absolute path under /scion-volumes is accepted",
+			path: "/scion-volumes/scratchpad/notes.md",
+			want: "/scion-volumes/scratchpad/notes.md",
+		},
+		{
+			name: "absolute path outside allowed roots is filtered",
+			path: "/etc/shadow",
+			want: "",
+		},
+		{
+			name: "absolute path outside allowed roots - tmp",
+			path: "/tmp/secret.txt",
+			want: "",
+		},
+		{
+			name: "path with dot-dot traversal outside workspace is filtered",
+			path: "/workspace/../etc/passwd",
+			want: "",
+		},
+		{
+			name: "relative path with dot-dot staying inside workspace",
+			path: "pkg/../cmd/message.go",
+			want: "/workspace/cmd/message.go",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveAttachmentPath(tc.path)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestCopyFile(t *testing.T) {
+	// Create a temp source file
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "source.txt")
+	content := []byte("hello world\nthis is a test file\n")
+	err := os.WriteFile(srcPath, content, 0644)
+	require.NoError(t, err)
+
+	// Copy it
+	dstDir := t.TempDir()
+	dstPath := filepath.Join(dstDir, "dest.txt")
+	err = copyFile(srcPath, dstPath)
+	require.NoError(t, err)
+
+	// Verify content matches
+	got, err := os.ReadFile(dstPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+
+	// Verify permissions are preserved
+	srcInfo, err := os.Stat(srcPath)
+	require.NoError(t, err)
+	dstInfo, err := os.Stat(dstPath)
+	require.NoError(t, err)
+	assert.Equal(t, srcInfo.Mode(), dstInfo.Mode())
+}
+
+func TestCopyFile_PreservesExecutablePermission(t *testing.T) {
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "script.sh")
+	err := os.WriteFile(srcPath, []byte("#!/bin/sh\necho hi\n"), 0755)
+	require.NoError(t, err)
+
+	dstDir := t.TempDir()
+	dstPath := filepath.Join(dstDir, "script.sh")
+	err = copyFile(srcPath, dstPath)
+	require.NoError(t, err)
+
+	dstInfo, err := os.Stat(dstPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0755), dstInfo.Mode().Perm())
+}
+
+func TestUniqueDest(t *testing.T) {
+	dir := t.TempDir()
+
+	// First call: no conflict
+	dest := uniqueDest(dir, "file.go")
+	assert.Equal(t, filepath.Join(dir, "file.go"), dest)
+
+	// Create the file so the next call must pick a new name
+	err := os.WriteFile(dest, []byte("x"), 0644)
+	require.NoError(t, err)
+
+	// Second call: conflict, should get _1
+	dest2 := uniqueDest(dir, "file.go")
+	assert.Equal(t, filepath.Join(dir, "file_1.go"), dest2)
+
+	// Create that file too
+	err = os.WriteFile(dest2, []byte("y"), 0644)
+	require.NoError(t, err)
+
+	// Third call: should get _2
+	dest3 := uniqueDest(dir, "file.go")
+	assert.Equal(t, filepath.Join(dir, "file_2.go"), dest3)
+}
+
+func TestUniqueDest_NoExtension(t *testing.T) {
+	dir := t.TempDir()
+
+	// File without extension
+	dest := uniqueDest(dir, "Makefile")
+	assert.Equal(t, filepath.Join(dir, "Makefile"), dest)
+
+	err := os.WriteFile(dest, []byte("x"), 0644)
+	require.NoError(t, err)
+
+	dest2 := uniqueDest(dir, "Makefile")
+	assert.Equal(t, filepath.Join(dir, "Makefile_1"), dest2)
+}
+
+func TestStageAttachments_HappyPath(t *testing.T) {
+	if _, err := os.Stat("/scion-volumes/scratchpad"); os.IsNotExist(err) {
+		t.Skip("skipping stageAttachments integration test: /scion-volumes/scratchpad not available")
+	}
+
+	t.Setenv("SCION_AGENT_NAME", "test-agent")
+
+	// Create test files under /workspace
+	testDir := filepath.Join("/workspace", ".test-attachments-happy")
+	err := os.MkdirAll(testDir, 0755)
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
+	testFile1 := filepath.Join(testDir, "test1.txt")
+	testFile2 := filepath.Join(testDir, "test2.txt")
+	err = os.WriteFile(testFile1, []byte("content1"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(testFile2, []byte("content2"), 0644)
+	require.NoError(t, err)
+
+	staged, err := stageAttachments([]string{testFile1, testFile2})
+	require.NoError(t, err)
+	require.Len(t, staged, 2)
+
+	// Verify staged files exist under the correct agent directory
+	for _, sp := range staged {
+		assert.Contains(t, sp, "/scion-volumes/scratchpad/.attachments/test-agent/")
+		_, err := os.Stat(sp)
+		require.NoError(t, err)
+	}
+
+	// Verify content was copied correctly
+	c1, err := os.ReadFile(staged[0])
+	require.NoError(t, err)
+	assert.Equal(t, "content1", string(c1))
+
+	c2, err := os.ReadFile(staged[1])
+	require.NoError(t, err)
+	assert.Equal(t, "content2", string(c2))
+
+	// Verify original filenames are preserved
+	assert.Equal(t, "test1.txt", filepath.Base(staged[0]))
+	assert.Equal(t, "test2.txt", filepath.Base(staged[1]))
+
+	// Clean up staged files
+	os.RemoveAll(filepath.Dir(staged[0]))
+}
+
+func TestStageAttachments_MissingScratchpad(t *testing.T) {
+	if _, err := os.Stat("/scion-volumes/scratchpad"); err == nil {
+		t.Skip("skipping missing-scratchpad test: /scion-volumes/scratchpad is mounted")
+	}
+
+	_, err := stageAttachments([]string{"/workspace/some/file.go"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scratchpad volume not available")
+	assert.Contains(t, err.Error(), "scion shared-dir create scratchpad")
+}
+
+func TestStageAttachments_DuplicateBasenames(t *testing.T) {
+	if _, err := os.Stat("/scion-volumes/scratchpad"); os.IsNotExist(err) {
+		t.Skip("skipping: /scion-volumes/scratchpad not available")
+	}
+
+	t.Setenv("SCION_AGENT_NAME", "dup-test-agent")
+
+	// Create two files with the same basename in different directories
+	testDir := filepath.Join("/workspace", ".test-dup-basenames")
+	dir1 := filepath.Join(testDir, "v1")
+	dir2 := filepath.Join(testDir, "v2")
+	err := os.MkdirAll(dir1, 0755)
+	require.NoError(t, err)
+	err = os.MkdirAll(dir2, 0755)
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
+	err = os.WriteFile(filepath.Join(dir1, "types.go"), []byte("package v1"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(dir2, "types.go"), []byte("package v2"), 0644)
+	require.NoError(t, err)
+
+	staged, err := stageAttachments([]string{
+		filepath.Join(dir1, "types.go"),
+		filepath.Join(dir2, "types.go"),
+	})
+	require.NoError(t, err)
+	require.Len(t, staged, 2)
+
+	// First should be types.go, second should be types_1.go
+	assert.Equal(t, "types.go", filepath.Base(staged[0]))
+	assert.Equal(t, "types_1.go", filepath.Base(staged[1]))
+
+	// Verify content is correct
+	c1, err := os.ReadFile(staged[0])
+	require.NoError(t, err)
+	assert.Equal(t, "package v1", string(c1))
+
+	c2, err := os.ReadFile(staged[1])
+	require.NoError(t, err)
+	assert.Equal(t, "package v2", string(c2))
+
+	// Cleanup
+	os.RemoveAll(filepath.Dir(staged[0]))
+}
+
+func TestStageAttachments_NonExistentFile(t *testing.T) {
+	if _, err := os.Stat("/scion-volumes/scratchpad"); os.IsNotExist(err) {
+		t.Skip("skipping: /scion-volumes/scratchpad not available")
+	}
+
+	t.Setenv("SCION_AGENT_NAME", "noexist-test")
+
+	_, err := stageAttachments([]string{"/workspace/this-file-does-not-exist-xyz.go"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "this-file-does-not-exist-xyz.go")
+}
+
+func TestStageAttachments_NonRegularFile(t *testing.T) {
+	if _, err := os.Stat("/scion-volumes/scratchpad"); os.IsNotExist(err) {
+		t.Skip("skipping: /scion-volumes/scratchpad not available")
+	}
+
+	t.Setenv("SCION_AGENT_NAME", "nonreg-test")
+
+	// Create a directory (not a regular file) and try to attach it
+	testDir := filepath.Join("/workspace", ".test-nonreg-attach")
+	err := os.MkdirAll(testDir, 0755)
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
+	_, err = stageAttachments([]string{testDir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a regular file")
+}
+
+func TestStageAttachments_DefaultAgentSlug(t *testing.T) {
+	if _, err := os.Stat("/scion-volumes/scratchpad"); os.IsNotExist(err) {
+		t.Skip("skipping: /scion-volumes/scratchpad not available")
+	}
+
+	t.Setenv("SCION_AGENT_NAME", "")
+
+	testDir := filepath.Join("/workspace", ".test-slug-default")
+	err := os.MkdirAll(testDir, 0755)
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
+	testFile := filepath.Join(testDir, "file.txt")
+	err = os.WriteFile(testFile, []byte("test"), 0644)
+	require.NoError(t, err)
+
+	staged, err := stageAttachments([]string{testFile})
+	require.NoError(t, err)
+	require.Len(t, staged, 1)
+
+	// Should use _user as the agent slug
+	assert.Contains(t, staged[0], "/_user/")
+
+	// Cleanup
+	os.RemoveAll(filepath.Dir(staged[0]))
+}
+
+func TestStageAttachments_FilteredPathsSkipped(t *testing.T) {
+	if _, err := os.Stat("/scion-volumes/scratchpad"); os.IsNotExist(err) {
+		t.Skip("skipping: /scion-volumes/scratchpad not available")
+	}
+
+	t.Setenv("SCION_AGENT_NAME", "filter-test")
+
+	// Create a valid file
+	testDir := filepath.Join("/workspace", ".test-filter-attach")
+	err := os.MkdirAll(testDir, 0755)
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
+	validFile := filepath.Join(testDir, "valid.go")
+	err = os.WriteFile(validFile, []byte("package valid"), 0644)
+	require.NoError(t, err)
+
+	// Pass one valid path and one that will be filtered
+	staged, err := stageAttachments([]string{validFile, "/etc/passwd"})
+	require.NoError(t, err)
+	// Only the valid file should be staged
+	require.Len(t, staged, 1)
+	assert.Equal(t, "valid.go", filepath.Base(staged[0]))
+
+	// Cleanup
+	os.RemoveAll(filepath.Dir(staged[0]))
 }


### PR DESCRIPTION
## Summary

Fixes silent attachment delivery failure in isolated workspace modes. Stages attachments through scratchpad shared volume for cross-agent accessibility.

Staging fork PR: ptone/scion#652
Staging fork issue: ptone/scion#651
