### PR TITLE
fix: remove graph button from projects list and scope agent-detail graph link to project

### DIFF
--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -1117,7 +1117,7 @@ export class ScionPageAgentDetail extends LitElement {
               `
             : nothing}
           <sl-tooltip content="See this agent in graph">
-            <a href="/agents/graph?focus=${this.agentId}" style="text-decoration: none;">
+            <a href="/agents/graph?project=${agent.projectId}&focus=${this.agentId}" style="text-decoration: none;">
               <sl-button variant="default" size="small">
                 <sl-icon slot="prefix" name="diagram-3"></sl-icon>
               </sl-button>

--- a/web/src/components/pages/projects.ts
+++ b/web/src/components/pages/projects.ts
@@ -315,6 +315,7 @@ export class ScionPageProjects extends LitElement {
           ` : nothing}
           <scion-view-toggle
             .view=${this.viewMode}
+            .showGraph=${false}
             storageKey="scion-view-projects"
             @view-change=${this.onViewChange}
           ></scion-view-toggle>

--- a/web/src/components/shared/view-toggle.ts
+++ b/web/src/components/shared/view-toggle.ts
@@ -22,7 +22,7 @@
  * dispatches a `view-change` CustomEvent.
  */
 
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 export type ViewMode = 'grid' | 'list' | 'graph';
@@ -40,6 +40,13 @@ export class ScionViewToggle extends LitElement {
    */
   @property({ type: String })
   storageKey = '';
+
+  /**
+   * Whether to show the graph-view segment. Set to false on pages
+   * that have no graph representation (e.g. the projects list).
+   */
+  @property({ type: Boolean })
+  showGraph = true;
 
   static override styles = css`
     :host {
@@ -145,7 +152,7 @@ export class ScionViewToggle extends LitElement {
         >
           <sl-icon name="list-ul"></sl-icon>
         </button>
-        ${this.renderGraphSegment()}
+        ${this.showGraph ? this.renderGraphSegment() : nothing}
       </div>
     `;
   }


### PR DESCRIPTION
Two small fixes: removes the graph-view toggle from the projects list page (there is no graph of projects), and scopes the agent-detail pages graph button to that agents own project (adds ?project= to the link) instead of linking to the all-agents graph.
Adds a showGraph property (default true) to the shared view-toggle component; all 5 other existing callers keep the graph segment since they omit the prop.
Files: web/src/components/shared/view-toggle.ts, web/src/components/pages/projects.ts, web/src/components/pages/agent-detail.ts. Fork review approved, tsc --noEmit clean.
Ref: ptone/scion#655
