### PR TITLE
feat: add quick-message button for agents across all views

### DIFF
--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -56,6 +56,7 @@ import type { ScionAgentLogViewer } from '../shared/agent-log-viewer.js';
 import '../shared/agent-message-viewer.js';
 import type { ScionAgentMessageViewer } from '../shared/agent-message-viewer.js';
 import '../shared/hash-display.js';
+import '../shared/quick-message-dialog.js';
 
 /**
  * Parse a Go-style duration string (e.g. "2h30m", "1h", "45m", "90s") into
@@ -135,6 +136,9 @@ export class ScionPageAgentDetail extends LitElement {
 
   @state()
   private subscriptionLoading = false;
+
+  @state()
+  private quickMessageOpen = false;
 
   static override styles = css`
     :host {
@@ -969,6 +973,13 @@ export class ScionPageAgentDetail extends LitElement {
         </sl-tab-panel>
         <sl-tab-panel name="configuration">${this.renderConfigurationTab()}</sl-tab-panel>
       </sl-tab-group>
+
+      <scion-quick-message-dialog
+        agentId=${this.agentId}
+        agentName=${this.agent.name || ''}
+        ?open=${this.quickMessageOpen}
+        @sl-request-close=${() => { this.quickMessageOpen = false; }}
+      ></scion-quick-message-dialog>
     `;
   }
 
@@ -1013,6 +1024,19 @@ export class ScionPageAgentDetail extends LitElement {
           </div>
         </div>
         <div class="header-actions">
+          ${can(agent._capabilities, 'message')
+            ? html`
+                <sl-button
+                  variant="default"
+                  size="small"
+                  outline
+                  @click=${() => { this.quickMessageOpen = true; }}
+                >
+                  <sl-icon slot="prefix" name="chat-dots"></sl-icon>
+                  Message
+                </sl-button>
+              `
+            : nothing}
           ${can(agent._capabilities, 'attach')
             ? html`
                 <a href="/agents/${this.agentId}/terminal" style="text-decoration: none;">

--- a/web/src/components/pages/agents.ts
+++ b/web/src/components/pages/agents.ts
@@ -36,6 +36,7 @@ import type { ViewMode } from '../shared/view-toggle.js';
 import '../shared/status-badge.js';
 import '../shared/view-toggle.js';
 import '../shared/agent-tree-view.js';
+import '../shared/quick-message-dialog.js';
 
 @customElement('scion-page-agents')
 export class ScionPageAgents extends LitElement {
@@ -104,6 +105,15 @@ export class ScionPageAgents extends LitElement {
 
   @state()
   private sortDir: SortDir = 'desc';
+
+  @state()
+  private quickMessageAgentId = '';
+
+  @state()
+  private quickMessageAgentName = '';
+
+  @state()
+  private quickMessageOpen = false;
 
   static override styles = [
     listPageStyles,
@@ -724,6 +734,13 @@ export class ScionPageAgents extends LitElement {
         ${this.renderFilterBar()}
         ${this.renderAgents()}
       `}
+
+      <scion-quick-message-dialog
+        agentId=${this.quickMessageAgentId}
+        agentName=${this.quickMessageAgentName}
+        ?open=${this.quickMessageOpen}
+        @sl-request-close=${() => { this.quickMessageOpen = false; }}
+      ></scion-quick-message-dialog>
     `;
   }
 
@@ -879,6 +896,26 @@ export class ScionPageAgents extends LitElement {
     const isLoading = this.actionLoading[agent.id] || false;
 
     return html`
+      ${can(agent._capabilities, 'message') ? html`
+        <sl-tooltip content="Message">
+          <span style="display: inline-flex">
+            <sl-button
+              class="action-btn-primary"
+              variant="default"
+              size="small"
+              outline
+              @click=${() => {
+                this.quickMessageAgentId = agent.id;
+                this.quickMessageAgentName = agent.name;
+                this.quickMessageOpen = true;
+              }}
+              aria-label="Message"
+            >
+              <sl-icon slot="prefix" name="chat-dots"></sl-icon>
+            </sl-button>
+          </span>
+        </sl-tooltip>
+      ` : nothing}
       ${can(agent._capabilities, 'attach') ? html`
         <sl-tooltip content="Terminal">
           <span style="display: inline-flex">

--- a/web/src/components/shared/agent-tree-view.ts
+++ b/web/src/components/shared/agent-tree-view.ts
@@ -46,6 +46,7 @@ import {
 } from '../../shared/lineage.js';
 import type { StatusType } from './status-badge.js';
 import './status-badge.js';
+import './quick-message-dialog.js';
 
 const VARIANT_COLOR: Record<StatusVariant, string> = {
   success: 'var(--sl-color-success-600)',
@@ -87,6 +88,9 @@ export class ScionAgentTreeView extends LitElement {
   @state() private scale = 1;
   @state() private panX = 0;
   @state() private panY = 0;
+  @state() private quickMessageAgentId = '';
+  @state() private quickMessageAgentName = '';
+  @state() private quickMessageOpen = false;
 
   @query('.canvas') private canvasEl?: HTMLDivElement;
 
@@ -316,6 +320,30 @@ export class ScionAgentTreeView extends LitElement {
 
     .terminal-btn[disabled] {
       pointer-events: none;
+    }
+
+    /*
+     * Message icon button — lower-right corner, left of the terminal button.
+     * Same hover-reveal pattern as .terminal-btn.
+     */
+    .message-btn {
+      position: absolute;
+      bottom: 4px;
+      right: 28px;
+      z-index: 1;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      font-size: 1rem;
+      color: var(--sl-color-neutral-600);
+    }
+
+    .node-wrapper:hover .message-btn,
+    .node-wrapper:focus-within .message-btn {
+      opacity: 1;
+    }
+
+    .message-btn:hover {
+      color: var(--sl-color-primary-600);
     }
 
     /*
@@ -632,6 +660,13 @@ export class ScionAgentTreeView extends LitElement {
           <sl-button size="small" @click=${() => this.fitToView(width, height)} title="Fit to view">Fit</sl-button>
         </div>
       </div>
+
+      <scion-quick-message-dialog
+        agentId=${this.quickMessageAgentId}
+        agentName=${this.quickMessageAgentName}
+        ?open=${this.quickMessageOpen}
+        @sl-request-close=${() => { this.quickMessageOpen = false; }}
+      ></scion-quick-message-dialog>
     `;
   }
 
@@ -714,6 +749,20 @@ export class ScionAgentTreeView extends LitElement {
           ></scion-status-badge>
           ${agent.template ? html`<span class="meta">${agent.template}</span>` : nothing}
         </a>
+        ${can(agent._capabilities, 'message') ? html`
+          <sl-icon-button
+            class="message-btn"
+            name="chat-dots"
+            label="Message"
+            @click=${(e: Event) => {
+              e.preventDefault();
+              e.stopPropagation();
+              this.quickMessageAgentId = agent.id;
+              this.quickMessageAgentName = agent.name;
+              this.quickMessageOpen = true;
+            }}
+          ></sl-icon-button>
+        ` : nothing}
         ${can(agent._capabilities, 'attach') ? html`
           <sl-icon-button
             class="terminal-btn"

--- a/web/src/components/shared/index.ts
+++ b/web/src/components/shared/index.ts
@@ -47,3 +47,4 @@ export { ScionSubscriptionManager } from './subscription-manager.js';
 export { ScionGitRemoteDisplay } from './git-remote-display.js';
 export { ScionHashDisplay } from './hash-display.js';
 export { ScionPreStartHookList } from './pre-start-hook-list.js';
+export { ScionQuickMessageDialog } from './quick-message-dialog.js';

--- a/web/src/components/shared/quick-message-dialog.ts
+++ b/web/src/components/shared/quick-message-dialog.ts
@@ -1,0 +1,178 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Quick-message dialog component.
+ *
+ * A modal dialog for sending a quick message to an agent. Opened by message
+ * buttons on the agent detail page, agent list view, and graph/tree view.
+ * Always sends as formatted (plain: false), no urgent toggle.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { apiFetch, extractApiError } from '../../client/api.js';
+
+@customElement('scion-quick-message-dialog')
+export class ScionQuickMessageDialog extends LitElement {
+  /** The agent ID to send the message to. */
+  @property({ type: String }) agentId = '';
+
+  /** The agent name, used in the dialog title. */
+  @property({ type: String }) agentName = '';
+
+  /** Whether the dialog is open. */
+  @property({ type: Boolean, reflect: true }) open = false;
+
+  @state() private messageText = '';
+  @state() private sending = false;
+  @state() private sendError: string | null = null;
+
+  static styles = css`
+    .dialog-body {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    sl-textarea::part(textarea) {
+      min-height: 100px;
+      resize: vertical;
+    }
+
+    .dialog-error {
+      color: var(--sl-color-danger-600);
+      font-size: var(--sl-font-size-small);
+    }
+  `;
+
+  protected updated(changed: Map<string, unknown>): void {
+    if (changed.has('open') && this.open) {
+      // Reset state when opening
+      this.messageText = '';
+      this.sendError = null;
+      this.sending = false;
+      // Auto-focus the textarea after the dialog animation completes
+      this.updateComplete.then(() => {
+        const textarea = this.shadowRoot?.querySelector('sl-textarea');
+        if (textarea) {
+          textarea.focus();
+        }
+      });
+    }
+  }
+
+  private close(): void {
+    this.open = false;
+    this.dispatchEvent(new CustomEvent('sl-request-close'));
+  }
+
+  private async handleSend(): Promise<void> {
+    const text = this.messageText.trim();
+    if (!text || this.sending) return;
+
+    this.sending = true;
+    this.sendError = null;
+
+    try {
+      const url = `/api/v1/agents/${this.agentId}/message`;
+      const body = {
+        structured_message: { msg: text, plain: false },
+        interrupt: false,
+      };
+
+      const res = await apiFetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        this.sendError = await extractApiError(res, 'Failed to send message');
+        return;
+      }
+
+      // Success — close dialog
+      this.close();
+    } catch (err) {
+      this.sendError =
+        err instanceof Error ? err.message : 'Failed to send message';
+    } finally {
+      this.sending = false;
+    }
+  }
+
+  private handleKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void this.handleSend();
+    }
+  }
+
+  render() {
+    const label = this.agentName
+      ? `Message ${this.agentName}`
+      : 'Send Message';
+
+    return html`
+      <sl-dialog
+        label=${label}
+        ?open=${this.open}
+        @sl-request-close=${this.close}
+      >
+        <div class="dialog-body">
+          <sl-textarea
+            placeholder="Type your message…"
+            rows="4"
+            value=${this.messageText}
+            @sl-input=${(e: Event) => {
+              this.messageText = (e.target as HTMLInputElement).value;
+            }}
+            @keydown=${this.handleKeydown}
+            ?disabled=${this.sending}
+          ></sl-textarea>
+          ${this.sendError
+            ? html`<div class="dialog-error">${this.sendError}</div>`
+            : nothing}
+        </div>
+
+        <sl-button
+          slot="footer"
+          variant="default"
+          @click=${this.close}
+          ?disabled=${this.sending}
+        >
+          Cancel
+        </sl-button>
+        <sl-button
+          slot="footer"
+          variant="primary"
+          ?loading=${this.sending}
+          ?disabled=${this.sending || !this.messageText.trim()}
+          @click=${() => void this.handleSend()}
+        >
+          Send
+        </sl-button>
+      </sl-dialog>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-quick-message-dialog': ScionQuickMessageDialog;
+  }
+}

--- a/web/src/components/shared/quick-message-dialog.ts
+++ b/web/src/components/shared/quick-message-dialog.ts
@@ -137,7 +137,7 @@ export class ScionQuickMessageDialog extends LitElement {
           <sl-textarea
             placeholder="Type your message…"
             rows="4"
-            value=${this.messageText}
+            .value=${this.messageText}
             @sl-input=${(e: Event) => {
               this.messageText = (e.target as HTMLInputElement).value;
             }}


### PR DESCRIPTION
Adds a quick-message action button for agents in three placements: agent detail page (labeled Message button + chat icon, left of Terminal), agent list view (small square icon-only), and graph/tree view (tiny hover-revealed icon), mirroring the terminal-button pattern from PR 924/927.
Opens a modal dialog with an auto-focused textarea. Enter sends, Shift+Enter inserts a newline. Always sends formatted (not plain), reusing the existing POST /api/v1/agents/id/message API rather than a new implementation. Capability-gated via the existing message capability check.
New shared component: web/src/components/shared/quick-message-dialog.ts. Two independent fork review rounds, both approved.
Ref: ptone/scion#659
