### PR TITLE
fix: agent label display, project-level label filter, and missing filter icon

### DIFF
--- a/web/scripts/copy-shoelace-icons.mjs
+++ b/web/scripts/copy-shoelace-icons.mjs
@@ -132,6 +132,7 @@ const USED_ICONS = [
   'star-fill',
   'stop-circle',
   'sun',
+  'tag',
   'terminal',
   'three-dots-vertical',
   'trash',

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -1218,18 +1218,6 @@ export class ScionPageAgentDetail extends LitElement {
                 </div>
               `
             : ''}
-          ${agent.labels && Object.keys(agent.labels).length > 0
-            ? html`
-                <div class="info-item">
-                  <span class="info-label">Labels</span>
-                  <span class="info-value">
-                    ${Object.entries(agent.labels).map(
-                      ([k, v]) => html`<sl-tag size="small" variant="neutral" style="margin: 0.15em;">${k}: ${v}</sl-tag>`
-                    )}
-                  </span>
-                </div>
-              `
-            : ''}
         </div>
       </div>
     `;

--- a/web/src/components/pages/project-detail.ts
+++ b/web/src/components/pages/project-detail.ts
@@ -122,6 +122,9 @@ export class ScionPageProjectDetail extends LitElement {
   private phaseFilter: AgentPhase | '' = '';
 
   @state()
+  private labelFilter = '';
+
+  @state()
   private sortField: AgentSortField = 'updated';
 
   @state()
@@ -1143,6 +1146,16 @@ export class ScionPageProjectDetail extends LitElement {
     if (this.phaseFilter) {
       list = list.filter(a => a.phase === this.phaseFilter);
     }
+    if (this.labelFilter.trim()) {
+      const parts = this.labelFilter.trim().split('=');
+      const filterKey = parts[0];
+      const filterValue = parts.slice(1).join('=');
+      list = list.filter(a => {
+        if (!a.labels) return false;
+        if (filterValue) return a.labels[filterKey] === filterValue;
+        return filterKey in a.labels;
+      });
+    }
     const sorted = [...list];
     sorted.sort((a, b) => {
       let cmp = 0;
@@ -1231,6 +1244,20 @@ export class ScionPageProjectDetail extends LitElement {
             @click=${() => this.setPhaseFilter('error')}
           >Error</button>
         </div>
+        <sl-input
+          size="small"
+          placeholder="Filter by label (key=value)"
+          clearable
+          .value=${this.labelFilter}
+          @sl-input=${(e: Event) => {
+            this.labelFilter = (e.target as HTMLElement & { value: string }).value;
+          }}
+          @sl-change=${() => { this.backgroundRefresh(); }}
+          @sl-clear=${() => { this.labelFilter = ''; this.backgroundRefresh(); }}
+          style="max-width: 220px;"
+        >
+          <sl-icon slot="prefix" name="tag"></sl-icon>
+        </sl-input>
         ${this.viewMode === 'grid' ? html`
           <sl-dropdown>
             <sl-button slot="trigger" size="small" outline>

--- a/web/src/components/pages/project-detail.ts
+++ b/web/src/components/pages/project-detail.ts
@@ -953,7 +953,15 @@ export class ScionPageProjectDetail extends LitElement {
   }
 
   private async fetchAndMergeAgents(): Promise<void> {
-    const response = await apiFetch(`/api/v1/projects/${this.projectId}/agents`);
+    const params = new URLSearchParams();
+    if (this.labelFilter.trim() && this.labelFilter.includes('=')) {
+      params.append('label', this.labelFilter.trim());
+    }
+    const qs = params.toString();
+    const url = qs
+      ? `/api/v1/projects/${this.projectId}/agents?${qs}`
+      : `/api/v1/projects/${this.projectId}/agents`;
+    const response = await apiFetch(url);
     if (!response.ok) return;
 
     const data = (await response.json()) as
@@ -1252,8 +1260,8 @@ export class ScionPageProjectDetail extends LitElement {
           @sl-input=${(e: Event) => {
             this.labelFilter = (e.target as HTMLElement & { value: string }).value;
           }}
-          @sl-change=${() => { this.backgroundRefresh(); }}
-          @sl-clear=${() => { this.labelFilter = ''; this.backgroundRefresh(); }}
+          @sl-change=${() => void this.backgroundRefresh()}
+          @sl-clear=${() => { this.labelFilter = ''; void this.backgroundRefresh(); }}
           style="max-width: 220px;"
         >
           <sl-icon slot="prefix" name="tag"></sl-icon>


### PR DESCRIPTION
Three small fixes: removes duplicate labels display from the agent-detail Status tab (Configuration tab already renders them via renderLabelsCard, verified no regression), adds the label-filter control to the project-level agent list to match the existing global list, and fixes a missing tag icon (added to USED_ICONS) on that filter box.
Files: agent-detail.ts, project-detail.ts, agents.ts, scripts/copy-shoelace-icons.mjs. Two independent fork review rounds, both approved.
Ref: ptone/scion#657
