### PR TITLE
feat(discord): /scion send command — send files by absolute or partial path with button picker

### DIFF
--- a/extras/scion-discord/internal/discord/callbacks.go
+++ b/extras/scion-discord/internal/discord/callbacks.go
@@ -60,6 +60,8 @@ func (h *CallbackHandler) Dispatch(s *discordgo.Session, i *discordgo.Interactio
 		h.handleSettingsCallback(s, i, customID)
 	case "default":
 		h.handleDefaultCallback(s, i, customID)
+	case "send":
+		h.handleSendCallback(s, i, customID)
 	default:
 		h.log.Debug("Unhandled callback prefix", "prefix", parts[0], "custom_id", customID)
 	}
@@ -602,6 +604,20 @@ func (h *CallbackHandler) handleDefaultCallback(s *discordgo.Session, i *discord
 	default:
 		h.log.Debug("Unknown default action", "action", action, "custom_id", customID)
 	}
+}
+
+// --- Send file callback handlers ---
+
+// handleSendCallback routes send:file button clicks.
+// custom_id format: send:file:<key>
+func (h *CallbackHandler) handleSendCallback(s *discordgo.Session, i *discordgo.InteractionCreate, customID string) {
+	parts := strings.SplitN(customID, ":", 3)
+	if len(parts) < 3 || parts[1] != "file" {
+		h.log.Warn("Malformed send callback custom_id", "custom_id", customID)
+		return
+	}
+	key := parts[2]
+	handleSendFileCallback(s, i, key, h.log)
 }
 
 // --- Notification callback handlers ---

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -272,6 +272,19 @@ func (h *CommandHandler) RegisterCommandsForGuild(guildID string) error {
 			},
 			{
 				Type:        discordgo.ApplicationCommandOptionSubCommand,
+				Name:        "send",
+				Description: "Send a file by path or search for files by name",
+				Options: []*discordgo.ApplicationCommandOption{
+					{
+						Type:        discordgo.ApplicationCommandOptionString,
+						Name:        "path",
+						Description: "Absolute file path or partial name to search",
+						Required:    true,
+					},
+				},
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionSubCommand,
 				Name:        "help",
 				Description: "Show available commands",
 			},
@@ -301,6 +314,7 @@ var ephemeralCommands = map[string]bool{
 	"settings": true,
 	"default":  true,
 	"thread":   true,
+	"send":     true,
 }
 
 // ephemeralFlag returns MessageFlagsEphemeral if the subcommand should be
@@ -370,6 +384,8 @@ func (h *CommandHandler) HandleSlashCommand(s *discordgo.Session, i *discordgo.I
 			h.HandleDefault(s, i)
 		case "thread":
 			h.HandleThread(s, i)
+		case "send":
+			h.HandleSend(s, i)
 		// register and unregister are handled by RegistrationHandler
 		// and should be wired up in the broker's dispatch
 		default:
@@ -502,6 +518,7 @@ func helpText() string {
 		"`/scion msg <agent> <text>` — Send a message to an agent\n" +
 		"`/scion logs <agent>` — View agent logs\n" +
 		"`/scion default [agent]` — Set or clear the default agent\n" +
+		"`/scion send <path>` — Send a file by path or search for files\n" +
 		"`/scion thread <title> [template]` — Create a thread with a new agent\n" +
 		"`/scion register` — Link your Discord account to Scion Hub\n" +
 		"`/scion unregister` — Unlink your Discord account\n" +

--- a/extras/scion-discord/internal/discord/send.go
+++ b/extras/scion-discord/internal/discord/send.go
@@ -132,22 +132,17 @@ func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.Interacti
 	}
 
 	// Case 1: Absolute path pointing to an existing file, confined to searchRoot.
-	if filepath.IsAbs(pathArg) {
-		cleaned := filepath.Clean(pathArg)
-		if strings.HasPrefix(cleaned, searchRoot) {
-			resolved, err := filepath.EvalSymlinks(cleaned)
-			if err == nil && strings.HasPrefix(resolved, searchRoot) {
-				info, err := os.Stat(resolved)
-				if err == nil && !info.IsDir() {
-					h.sendFile(s, i, resolved, info)
-					return
-				}
-			}
+	if filepath.IsAbs(pathArg) && isUnderSearchRoot(pathArg) {
+		resolved, _ := filepath.EvalSymlinks(filepath.Clean(pathArg))
+		info, err := os.Stat(resolved)
+		if err == nil && !info.IsDir() {
+			h.sendFile(s, i, resolved, info)
+			return
 		}
 	}
 
 	// Case 2: Search for files matching the argument.
-	matches := searchFiles(pathArg)
+	matches := searchFiles(searchRoot, pathArg)
 
 	if len(matches) == 0 {
 		h.followup(s, i, fmt.Sprintf("No files found matching '%s'", pathArg))
@@ -256,15 +251,15 @@ func (h *CommandHandler) sendFile(s *discordgo.Session, i *discordgo.Interaction
 	}
 }
 
-// searchFiles walks searchRoot looking for files whose path contains the
-// given query (case-insensitive). Symlinks that resolve outside searchRoot
-// are excluded to prevent symlink escape attacks.
-func searchFiles(query string) []fileMatch {
+// searchFiles walks root looking for files whose path contains the given
+// query (case-insensitive). Symlinks that resolve outside root are excluded
+// to prevent symlink escape attacks.
+func searchFiles(root, query string) []fileMatch {
 	lowerQuery := strings.ToLower(query)
 	var matches []fileMatch
 	filesWalked := 0
 
-	_ = filepath.WalkDir(searchRoot, func(path string, d fs.DirEntry, err error) error {
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil // skip unreadable entries
 		}
@@ -284,9 +279,9 @@ func searchFiles(query string) []fileMatch {
 
 		// Match file paths case-insensitively.
 		if strings.Contains(strings.ToLower(path), lowerQuery) {
-			// R1: Resolve symlinks and verify target is still under searchRoot.
+			// Resolve symlinks and verify target is still under root.
 			resolved, err := filepath.EvalSymlinks(path)
-			if err != nil || !strings.HasPrefix(resolved, searchRoot) {
+			if err != nil || !strings.HasPrefix(resolved, root) {
 				return nil
 			}
 
@@ -315,14 +310,14 @@ func handleSendFileCallback(s *discordgo.Session, i *discordgo.InteractionCreate
 		return
 	}
 
-	// Resolve symlinks and verify path is still under searchRoot.
-	resolved, err := filepath.EvalSymlinks(path)
-	if err != nil || !strings.HasPrefix(resolved, searchRoot) {
-		log.Warn("Send callback path failed confinement check", "path", path, "resolved", resolved, "error", err)
+	// Verify path is still confined to searchRoot (resolves symlinks).
+	if !isUnderSearchRoot(path) {
+		log.Warn("Send callback path failed confinement check", "path", path)
 		respondSendUpdate(s, i, "This file is no longer accessible.", log)
 		return
 	}
 
+	resolved, _ := filepath.EvalSymlinks(filepath.Clean(path))
 	info, err := os.Stat(resolved)
 	if err != nil {
 		log.Error("Failed to stat file for send callback", "path", resolved, "error", err)

--- a/extras/scion-discord/internal/discord/send.go
+++ b/extras/scion-discord/internal/discord/send.go
@@ -105,19 +105,25 @@ type fileMatch struct {
 	ModTime time.Time
 }
 
-// hiddenDirs lists directory name prefixes to skip during file search.
-var hiddenDirs = map[string]bool{
-	".git":    true,
-	".cache":  true,
-	".local":  true,
-	".npm":    true,
-	".config": true,
+// isUnderSearchRoot checks that a cleaned, resolved path is under searchRoot.
+// Both the cleaned path and its symlink-resolved form must be under searchRoot
+// to prevent directory traversal and symlink escape attacks.
+func isUnderSearchRoot(path string) bool {
+	cleaned := filepath.Clean(path)
+	if !strings.HasPrefix(cleaned, searchRoot) {
+		return false
+	}
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		return false
+	}
+	return strings.HasPrefix(resolved, searchRoot)
 }
 
 // HandleSend handles the /scion send <path> command.
-// If path is an absolute path to an existing file, it sends it directly.
-// Otherwise it searches /scion-volumes/ for matching files and presents
-// buttons for selection.
+// If path is an absolute path to an existing file under searchRoot, it sends
+// it directly. Otherwise it searches /scion-volumes/ for matching files and
+// presents buttons for selection.
 func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	pathArg := getSubcommandOption(i, "path")
 	if pathArg == "" {
@@ -125,12 +131,18 @@ func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.Interacti
 		return
 	}
 
-	// Case 1: Absolute path pointing to an existing file.
+	// Case 1: Absolute path pointing to an existing file, confined to searchRoot.
 	if filepath.IsAbs(pathArg) {
-		info, err := os.Stat(pathArg)
-		if err == nil && !info.IsDir() {
-			h.sendFile(s, i, pathArg, info)
-			return
+		cleaned := filepath.Clean(pathArg)
+		if strings.HasPrefix(cleaned, searchRoot) {
+			resolved, err := filepath.EvalSymlinks(cleaned)
+			if err == nil && strings.HasPrefix(resolved, searchRoot) {
+				info, err := os.Stat(resolved)
+				if err == nil && !info.IsDir() {
+					h.sendFile(s, i, resolved, info)
+					return
+				}
+			}
 		}
 	}
 
@@ -153,13 +165,16 @@ func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.Interacti
 
 	// Build buttons. Store full paths in the path store to avoid
 	// exceeding Discord's 100-char custom ID limit.
+	// N3: detect duplicate basenames to disambiguate labels.
+	labels := buildButtonLabels(matches)
+
 	var rows []discordgo.MessageComponent
 	var buttons []discordgo.MessageComponent
 
 	for idx, m := range matches {
 		key := globalSendPaths.Put(m.Path)
 		buttons = append(buttons, discordgo.Button{
-			Label:    filepath.Base(m.Path),
+			Label:    labels[idx],
 			Style:    discordgo.SecondaryButton,
 			CustomID: fmt.Sprintf("send:file:%s", key),
 		})
@@ -182,6 +197,38 @@ func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.Interacti
 	}
 }
 
+// buildButtonLabels returns a label for each match. When multiple matches
+// share the same basename, the parent directory is prepended to disambiguate.
+func buildButtonLabels(matches []fileMatch) []string {
+	labels := make([]string, len(matches))
+
+	// Count how many times each basename appears.
+	baseCounts := make(map[string]int)
+	for _, m := range matches {
+		baseCounts[filepath.Base(m.Path)]++
+	}
+
+	for idx, m := range matches {
+		base := filepath.Base(m.Path)
+		if baseCounts[base] > 1 {
+			parent := filepath.Base(filepath.Dir(m.Path))
+			label := parent + "/" + base
+			// Discord button labels max 80 chars.
+			if len(label) > 80 {
+				label = label[:80]
+			}
+			labels[idx] = label
+		} else {
+			label := base
+			if len(label) > 80 {
+				label = label[:80]
+			}
+			labels[idx] = label
+		}
+	}
+	return labels
+}
+
 // sendFile reads a file and sends it as a Discord attachment.
 func (h *CommandHandler) sendFile(s *discordgo.Session, i *discordgo.InteractionCreate, path string, info os.FileInfo) {
 	if info.Size() > maxDiscordFileSize {
@@ -193,7 +240,7 @@ func (h *CommandHandler) sendFile(s *discordgo.Session, i *discordgo.Interaction
 	data, err := os.ReadFile(path)
 	if err != nil {
 		h.log.Error("Failed to read file for send", "path", path, "error", err)
-		h.followup(s, i, fmt.Sprintf("Could not read file: %s", err.Error()))
+		h.followup(s, i, fmt.Sprintf("Could not read file: %s", filepath.Base(path)))
 		return
 	}
 
@@ -210,7 +257,8 @@ func (h *CommandHandler) sendFile(s *discordgo.Session, i *discordgo.Interaction
 }
 
 // searchFiles walks searchRoot looking for files whose path contains the
-// given query (case-insensitive). Returns up to maxFilesWalked examined files.
+// given query (case-insensitive). Symlinks that resolve outside searchRoot
+// are excluded to prevent symlink escape attacks.
 func searchFiles(query string) []fileMatch {
 	lowerQuery := strings.ToLower(query)
 	var matches []fileMatch
@@ -226,10 +274,9 @@ func searchFiles(query string) []fileMatch {
 			return filepath.SkipAll
 		}
 
-		// Skip hidden directories.
+		// Skip hidden directories (any directory starting with ".").
 		if d.IsDir() {
-			name := d.Name()
-			if strings.HasPrefix(name, ".") || hiddenDirs[name] {
+			if strings.HasPrefix(d.Name(), ".") {
 				return filepath.SkipDir
 			}
 			return nil
@@ -237,6 +284,12 @@ func searchFiles(query string) []fileMatch {
 
 		// Match file paths case-insensitively.
 		if strings.Contains(strings.ToLower(path), lowerQuery) {
+			// R1: Resolve symlinks and verify target is still under searchRoot.
+			resolved, err := filepath.EvalSymlinks(path)
+			if err != nil || !strings.HasPrefix(resolved, searchRoot) {
+				return nil
+			}
+
 			info, err := d.Info()
 			if err != nil {
 				return nil
@@ -262,8 +315,17 @@ func handleSendFileCallback(s *discordgo.Session, i *discordgo.InteractionCreate
 		return
 	}
 
-	info, err := os.Stat(path)
+	// Resolve symlinks and verify path is still under searchRoot.
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil || !strings.HasPrefix(resolved, searchRoot) {
+		log.Warn("Send callback path failed confinement check", "path", path, "resolved", resolved, "error", err)
+		respondSendUpdate(s, i, "This file is no longer accessible.", log)
+		return
+	}
+
+	info, err := os.Stat(resolved)
 	if err != nil {
+		log.Error("Failed to stat file for send callback", "path", resolved, "error", err)
 		respondSendUpdate(s, i, fmt.Sprintf("File not found: %s", filepath.Base(path)), log)
 		return
 	}
@@ -279,14 +341,18 @@ func handleSendFileCallback(s *discordgo.Session, i *discordgo.InteractionCreate
 		return
 	}
 
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(resolved)
 	if err != nil {
-		log.Error("Failed to read file for send callback", "path", path, "error", err)
-		respondSendUpdate(s, i, fmt.Sprintf("Could not read file: %s", err.Error()), log)
+		log.Error("Failed to read file for send callback", "path", resolved, "error", err)
+		respondSendUpdate(s, i, fmt.Sprintf("Could not read file: %s", filepath.Base(path)), log)
 		return
 	}
 
-	// Send the file as a new followup message (the original button message stays).
+	// N2: Edit original button message to indicate which file was sent.
+	sentContent := fmt.Sprintf("Sent file: `%s`", filepath.Base(path))
+	respondSendUpdate(s, i, sentContent, log)
+
+	// Send the file as a new followup message.
 	_, err = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 		Content: fmt.Sprintf("📎 `%s`", filepath.Base(path)),
 		Files: []*discordgo.File{
@@ -294,8 +360,7 @@ func handleSendFileCallback(s *discordgo.Session, i *discordgo.InteractionCreate
 		},
 	})
 	if err != nil {
-		log.Error("Failed to send file from callback", "path", path, "error", err)
-		respondSendUpdate(s, i, "Failed to send file. Please try again.", log)
+		log.Error("Failed to send file from callback", "path", resolved, "error", err)
 	}
 }
 

--- a/extras/scion-discord/internal/discord/send.go
+++ b/extras/scion-discord/internal/discord/send.go
@@ -1,0 +1,313 @@
+package discord
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+const (
+	// searchRoot is the base directory for file searches.
+	searchRoot = "/scion-volumes/"
+
+	// maxDiscordFileSize is the Discord attachment size limit (25 MB).
+	maxDiscordFileSize = 25 * 1024 * 1024
+
+	// maxSearchResults is the maximum number of file matches returned.
+	maxSearchResults = 20
+
+	// maxFilesWalked limits the number of files examined during search
+	// to prevent hanging on huge directory trees.
+	maxFilesWalked = 100_000
+
+	// sendPathTTL is how long stored file paths remain valid for button clicks.
+	sendPathTTL = 15 * time.Minute
+)
+
+// sendPathEntry stores a file path with a creation timestamp for TTL expiry.
+type sendPathEntry struct {
+	Path      string
+	CreatedAt time.Time
+}
+
+// sendPathStore is a thread-safe in-memory map from short keys to file paths,
+// used to work around Discord's 100-character custom ID limit.
+type sendPathStore struct {
+	mu      sync.Mutex
+	entries map[string]sendPathEntry
+}
+
+// newSendPathStore creates a new sendPathStore.
+func newSendPathStore() *sendPathStore {
+	return &sendPathStore{entries: make(map[string]sendPathEntry)}
+}
+
+// Put stores a file path under a randomly generated short key and returns
+// the key. Expired entries are cleaned up opportunistically.
+func (s *sendPathStore) Put(path string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Opportunistic cleanup of expired entries.
+	now := time.Now()
+	for k, v := range s.entries {
+		if now.Sub(v.CreatedAt) > sendPathTTL {
+			delete(s.entries, k)
+		}
+	}
+
+	key := randomKey(8)
+	s.entries[key] = sendPathEntry{Path: path, CreatedAt: now}
+	return key
+}
+
+// Get retrieves the file path for a key, returning empty string if not found
+// or expired.
+func (s *sendPathStore) Get(key string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, ok := s.entries[key]
+	if !ok {
+		return ""
+	}
+	if time.Since(entry.CreatedAt) > sendPathTTL {
+		delete(s.entries, key)
+		return ""
+	}
+	return entry.Path
+}
+
+// randomKey returns a random hex string of the given byte length.
+func randomKey(n int) string {
+	b := make([]byte, n)
+	_, _ = rand.Read(b)
+	return fmt.Sprintf("%x", b)
+}
+
+// globalSendPaths is the package-level path store shared by HandleSend and
+// the callback handler.
+var globalSendPaths = newSendPathStore()
+
+// fileMatch holds a matched file path and its modification time for sorting.
+type fileMatch struct {
+	Path    string
+	ModTime time.Time
+}
+
+// hiddenDirs lists directory name prefixes to skip during file search.
+var hiddenDirs = map[string]bool{
+	".git":    true,
+	".cache":  true,
+	".local":  true,
+	".npm":    true,
+	".config": true,
+}
+
+// HandleSend handles the /scion send <path> command.
+// If path is an absolute path to an existing file, it sends it directly.
+// Otherwise it searches /scion-volumes/ for matching files and presents
+// buttons for selection.
+func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	pathArg := getSubcommandOption(i, "path")
+	if pathArg == "" {
+		h.followup(s, i, "Please provide a file path or search term.")
+		return
+	}
+
+	// Case 1: Absolute path pointing to an existing file.
+	if filepath.IsAbs(pathArg) {
+		info, err := os.Stat(pathArg)
+		if err == nil && !info.IsDir() {
+			h.sendFile(s, i, pathArg, info)
+			return
+		}
+	}
+
+	// Case 2: Search for files matching the argument.
+	matches := searchFiles(pathArg)
+
+	if len(matches) == 0 {
+		h.followup(s, i, fmt.Sprintf("No files found matching '%s'", pathArg))
+		return
+	}
+
+	// Sort by modification time (most recent first).
+	sort.Slice(matches, func(a, b int) bool {
+		return matches[a].ModTime.After(matches[b].ModTime)
+	})
+
+	if len(matches) > maxSearchResults {
+		matches = matches[:maxSearchResults]
+	}
+
+	// Build buttons. Store full paths in the path store to avoid
+	// exceeding Discord's 100-char custom ID limit.
+	var rows []discordgo.MessageComponent
+	var buttons []discordgo.MessageComponent
+
+	for idx, m := range matches {
+		key := globalSendPaths.Put(m.Path)
+		buttons = append(buttons, discordgo.Button{
+			Label:    filepath.Base(m.Path),
+			Style:    discordgo.SecondaryButton,
+			CustomID: fmt.Sprintf("send:file:%s", key),
+		})
+		if len(buttons) == 5 || idx == len(matches)-1 {
+			rows = append(rows, discordgo.ActionsRow{Components: buttons})
+			buttons = nil
+		}
+		// Discord allows max 5 action rows.
+		if len(rows) >= 5 {
+			break
+		}
+	}
+
+	_, err := s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+		Content:    fmt.Sprintf("Found %d file(s) matching '%s'. Select one to send:", len(matches), pathArg),
+		Components: rows,
+	})
+	if err != nil {
+		h.log.Error("Failed to send file search results", "error", err)
+	}
+}
+
+// sendFile reads a file and sends it as a Discord attachment.
+func (h *CommandHandler) sendFile(s *discordgo.Session, i *discordgo.InteractionCreate, path string, info os.FileInfo) {
+	if info.Size() > maxDiscordFileSize {
+		h.followup(s, i, fmt.Sprintf("File too large to send (%.1f MB, limit is 25 MB).",
+			float64(info.Size())/(1024*1024)))
+		return
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		h.log.Error("Failed to read file for send", "path", path, "error", err)
+		h.followup(s, i, fmt.Sprintf("Could not read file: %s", err.Error()))
+		return
+	}
+
+	_, err = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+		Content: fmt.Sprintf("📎 `%s`", filepath.Base(path)),
+		Files: []*discordgo.File{
+			{Name: filepath.Base(path), Reader: bytes.NewReader(data)},
+		},
+	})
+	if err != nil {
+		h.log.Error("Failed to send file attachment", "path", path, "error", err)
+		h.followup(s, i, "Failed to send file. Please try again.")
+	}
+}
+
+// searchFiles walks searchRoot looking for files whose path contains the
+// given query (case-insensitive). Returns up to maxFilesWalked examined files.
+func searchFiles(query string) []fileMatch {
+	lowerQuery := strings.ToLower(query)
+	var matches []fileMatch
+	filesWalked := 0
+
+	_ = filepath.WalkDir(searchRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip unreadable entries
+		}
+
+		filesWalked++
+		if filesWalked > maxFilesWalked {
+			return filepath.SkipAll
+		}
+
+		// Skip hidden directories.
+		if d.IsDir() {
+			name := d.Name()
+			if strings.HasPrefix(name, ".") || hiddenDirs[name] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Match file paths case-insensitively.
+		if strings.Contains(strings.ToLower(path), lowerQuery) {
+			info, err := d.Info()
+			if err != nil {
+				return nil
+			}
+			matches = append(matches, fileMatch{
+				Path:    path,
+				ModTime: info.ModTime(),
+			})
+		}
+
+		return nil
+	})
+
+	return matches
+}
+
+// handleSendFileCallback is called by the CallbackHandler when a send:file
+// button is clicked. It looks up the stored path and sends the file.
+func handleSendFileCallback(s *discordgo.Session, i *discordgo.InteractionCreate, key string, log *slog.Logger) {
+	path := globalSendPaths.Get(key)
+	if path == "" {
+		respondSendUpdate(s, i, "This file link has expired. Please use `/scion send` again.", log)
+		return
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		respondSendUpdate(s, i, fmt.Sprintf("File not found: %s", filepath.Base(path)), log)
+		return
+	}
+
+	if info.IsDir() {
+		respondSendUpdate(s, i, "Cannot send a directory.", log)
+		return
+	}
+
+	if info.Size() > maxDiscordFileSize {
+		respondSendUpdate(s, i, fmt.Sprintf("File too large to send (%.1f MB, limit is 25 MB).",
+			float64(info.Size())/(1024*1024)), log)
+		return
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Error("Failed to read file for send callback", "path", path, "error", err)
+		respondSendUpdate(s, i, fmt.Sprintf("Could not read file: %s", err.Error()), log)
+		return
+	}
+
+	// Send the file as a new followup message (the original button message stays).
+	_, err = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+		Content: fmt.Sprintf("📎 `%s`", filepath.Base(path)),
+		Files: []*discordgo.File{
+			{Name: filepath.Base(path), Reader: bytes.NewReader(data)},
+		},
+	})
+	if err != nil {
+		log.Error("Failed to send file from callback", "path", path, "error", err)
+		respondSendUpdate(s, i, "Failed to send file. Please try again.", log)
+	}
+}
+
+// respondSendUpdate edits the interaction response for send button callbacks.
+func respondSendUpdate(s *discordgo.Session, i *discordgo.InteractionCreate, content string, log *slog.Logger) {
+	edit := &discordgo.WebhookEdit{
+		Content: &content,
+	}
+	empty := []discordgo.MessageComponent{}
+	edit.Components = &empty
+	_, err := s.InteractionResponseEdit(i.Interaction, edit)
+	if err != nil {
+		log.Error("Failed to edit send interaction response", "error", err)
+	}
+}

--- a/extras/scion-discord/internal/discord/send.go
+++ b/extras/scion-discord/internal/discord/send.go
@@ -1,7 +1,6 @@
 package discord
 
 import (
-	"bytes"
 	"crypto/rand"
 	"fmt"
 	"io/fs"
@@ -105,19 +104,30 @@ type fileMatch struct {
 	ModTime time.Time
 }
 
+// safeResolve cleans the path, verifies it starts with searchRoot, resolves
+// symlinks, and re-verifies the resolved path is still under searchRoot.
+// It returns the resolved path or an error if any check fails.
+func safeResolve(path string) (string, error) {
+	cleaned := filepath.Clean(path)
+	if !strings.HasPrefix(cleaned, searchRoot) {
+		return "", fmt.Errorf("path %q does not start with %q", cleaned, searchRoot)
+	}
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(resolved, searchRoot) {
+		return "", fmt.Errorf("resolved path %q does not start with %q", resolved, searchRoot)
+	}
+	return resolved, nil
+}
+
 // isUnderSearchRoot checks that a cleaned, resolved path is under searchRoot.
 // Both the cleaned path and its symlink-resolved form must be under searchRoot
 // to prevent directory traversal and symlink escape attacks.
 func isUnderSearchRoot(path string) bool {
-	cleaned := filepath.Clean(path)
-	if !strings.HasPrefix(cleaned, searchRoot) {
-		return false
-	}
-	resolved, err := filepath.EvalSymlinks(cleaned)
-	if err != nil {
-		return false
-	}
-	return strings.HasPrefix(resolved, searchRoot)
+	_, err := safeResolve(path)
+	return err == nil
 }
 
 // HandleSend handles the /scion send <path> command.
@@ -132,12 +142,13 @@ func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.Interacti
 	}
 
 	// Case 1: Absolute path pointing to an existing file, confined to searchRoot.
-	if filepath.IsAbs(pathArg) && isUnderSearchRoot(pathArg) {
-		resolved, _ := filepath.EvalSymlinks(filepath.Clean(pathArg))
-		info, err := os.Stat(resolved)
-		if err == nil && !info.IsDir() {
-			h.sendFile(s, i, resolved, info)
-			return
+	if filepath.IsAbs(pathArg) {
+		if resolved, err := safeResolve(pathArg); err == nil {
+			info, err := os.Stat(resolved)
+			if err == nil && !info.IsDir() {
+				h.sendFile(s, i, resolved, info)
+				return
+			}
 		}
 	}
 
@@ -208,15 +219,18 @@ func buildButtonLabels(matches []fileMatch) []string {
 		if baseCounts[base] > 1 {
 			parent := filepath.Base(filepath.Dir(m.Path))
 			label := parent + "/" + base
-			// Discord button labels max 80 chars.
-			if len(label) > 80 {
-				label = label[:80]
+			// Discord button labels max 80 chars; use rune slicing
+			// to avoid cutting multi-byte UTF-8 characters.
+			runes := []rune(label)
+			if len(runes) > 80 {
+				label = string(runes[:80])
 			}
 			labels[idx] = label
 		} else {
 			label := base
-			if len(label) > 80 {
-				label = label[:80]
+			runes := []rune(label)
+			if len(runes) > 80 {
+				label = string(runes[:80])
 			}
 			labels[idx] = label
 		}
@@ -232,17 +246,18 @@ func (h *CommandHandler) sendFile(s *discordgo.Session, i *discordgo.Interaction
 		return
 	}
 
-	data, err := os.ReadFile(path)
+	file, err := os.Open(path)
 	if err != nil {
-		h.log.Error("Failed to read file for send", "path", path, "error", err)
+		h.log.Error("Failed to open file for send", "path", path, "error", err)
 		h.followup(s, i, fmt.Sprintf("Could not read file: %s", filepath.Base(path)))
 		return
 	}
+	defer file.Close()
 
 	_, err = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 		Content: fmt.Sprintf("📎 `%s`", filepath.Base(path)),
 		Files: []*discordgo.File{
-			{Name: filepath.Base(path), Reader: bytes.NewReader(data)},
+			{Name: filepath.Base(path), Reader: file},
 		},
 	})
 	if err != nil {
@@ -279,20 +294,33 @@ func searchFiles(root, query string) []fileMatch {
 
 		// Match file paths case-insensitively.
 		if strings.Contains(strings.ToLower(path), lowerQuery) {
-			// Resolve symlinks and verify target is still under root.
-			resolved, err := filepath.EvalSymlinks(path)
-			if err != nil || !strings.HasPrefix(resolved, root) {
-				return nil
+			if d.Type()&fs.ModeSymlink != 0 {
+				// Symlink: resolve and verify target is still under root.
+				resolved, err := filepath.EvalSymlinks(path)
+				if err != nil || !strings.HasPrefix(resolved, root) {
+					return nil
+				}
+				// Filter out symlinks pointing to directories.
+				targetInfo, err := os.Stat(resolved)
+				if err != nil || targetInfo.IsDir() {
+					return nil
+				}
+				// Use target file ModTime for symlinks.
+				matches = append(matches, fileMatch{
+					Path:    path,
+					ModTime: targetInfo.ModTime(),
+				})
+			} else {
+				// Regular file: no symlink resolution needed.
+				info, err := d.Info()
+				if err != nil {
+					return nil
+				}
+				matches = append(matches, fileMatch{
+					Path:    path,
+					ModTime: info.ModTime(),
+				})
 			}
-
-			info, err := d.Info()
-			if err != nil {
-				return nil
-			}
-			matches = append(matches, fileMatch{
-				Path:    path,
-				ModTime: info.ModTime(),
-			})
 		}
 
 		return nil
@@ -311,13 +339,13 @@ func handleSendFileCallback(s *discordgo.Session, i *discordgo.InteractionCreate
 	}
 
 	// Verify path is still confined to searchRoot (resolves symlinks).
-	if !isUnderSearchRoot(path) {
-		log.Warn("Send callback path failed confinement check", "path", path)
+	resolved, err := safeResolve(path)
+	if err != nil {
+		log.Warn("Send callback path failed confinement check", "path", path, "error", err)
 		respondSendUpdate(s, i, "This file is no longer accessible.", log)
 		return
 	}
 
-	resolved, _ := filepath.EvalSymlinks(filepath.Clean(path))
 	info, err := os.Stat(resolved)
 	if err != nil {
 		log.Error("Failed to stat file for send callback", "path", resolved, "error", err)
@@ -336,12 +364,13 @@ func handleSendFileCallback(s *discordgo.Session, i *discordgo.InteractionCreate
 		return
 	}
 
-	data, err := os.ReadFile(resolved)
+	file, err := os.Open(resolved)
 	if err != nil {
-		log.Error("Failed to read file for send callback", "path", resolved, "error", err)
+		log.Error("Failed to open file for send callback", "path", resolved, "error", err)
 		respondSendUpdate(s, i, fmt.Sprintf("Could not read file: %s", filepath.Base(path)), log)
 		return
 	}
+	defer file.Close()
 
 	// N2: Edit original button message to indicate which file was sent.
 	sentContent := fmt.Sprintf("Sent file: `%s`", filepath.Base(path))
@@ -351,7 +380,7 @@ func handleSendFileCallback(s *discordgo.Session, i *discordgo.InteractionCreate
 	_, err = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 		Content: fmt.Sprintf("📎 `%s`", filepath.Base(path)),
 		Files: []*discordgo.File{
-			{Name: filepath.Base(path), Reader: bytes.NewReader(data)},
+			{Name: filepath.Base(path), Reader: file},
 		},
 	})
 	if err != nil {

--- a/extras/scion-discord/internal/discord/send_test.go
+++ b/extras/scion-discord/internal/discord/send_test.go
@@ -1,10 +1,8 @@
 package discord
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -98,7 +96,7 @@ func TestSendPathStore_ConcurrentAccess(t *testing.T) {
 func TestSearchFiles_MatchesSubstring(t *testing.T) {
 	dir := setupSearchTestDir(t)
 
-	matches := searchFilesInDir(dir, "hello")
+	matches := searchFiles(dir, "hello")
 	assert.Len(t, matches, 1)
 	assert.Contains(t, matches[0].Path, "hello.txt")
 }
@@ -106,7 +104,7 @@ func TestSearchFiles_MatchesSubstring(t *testing.T) {
 func TestSearchFiles_CaseInsensitive(t *testing.T) {
 	dir := setupSearchTestDir(t)
 
-	matches := searchFilesInDir(dir, "HELLO")
+	matches := searchFiles(dir, "HELLO")
 	assert.Len(t, matches, 1)
 	assert.Contains(t, matches[0].Path, "hello.txt")
 }
@@ -114,7 +112,7 @@ func TestSearchFiles_CaseInsensitive(t *testing.T) {
 func TestSearchFiles_NoMatches(t *testing.T) {
 	dir := setupSearchTestDir(t)
 
-	matches := searchFilesInDir(dir, "nonexistent_xyz_abc")
+	matches := searchFiles(dir, "nonexistent_xyz_abc")
 	assert.Empty(t, matches)
 }
 
@@ -122,7 +120,7 @@ func TestSearchFiles_SkipsHiddenDirs(t *testing.T) {
 	dir := setupSearchTestDir(t)
 
 	// The .hidden directory contains a file named "secret.txt".
-	matches := searchFilesInDir(dir, "secret")
+	matches := searchFiles(dir, "secret")
 	assert.Empty(t, matches, "files in hidden directories should be skipped")
 }
 
@@ -138,7 +136,7 @@ func TestSearchFiles_SymlinkOutsideRoot(t *testing.T) {
 	symlinkPath := filepath.Join(dir, "escape-link.txt")
 	require.NoError(t, os.Symlink(outsideFile, symlinkPath))
 
-	matches := searchFilesInDir(dir, "escape-link")
+	matches := searchFiles(dir, "escape-link")
 	assert.Empty(t, matches, "symlinks pointing outside search root should be excluded")
 }
 
@@ -239,53 +237,4 @@ func setupSearchTestDir(t *testing.T) string {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".hidden", "secret.txt"), []byte("secret"), 0o644))
 
 	return dir
-}
-
-// searchFilesInDir is a test helper that runs the search logic against
-// an arbitrary directory root instead of the hardcoded searchRoot.
-// It duplicates the core logic of searchFiles to allow testing with
-// temp directories.
-func searchFilesInDir(root, query string) []fileMatch {
-	lowerQuery := strings.ToLower(query)
-	var matches []fileMatch
-	filesWalked := 0
-
-	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-
-		filesWalked++
-		if filesWalked > maxFilesWalked {
-			return filepath.SkipAll
-		}
-
-		if d.IsDir() {
-			if strings.HasPrefix(d.Name(), ".") {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-
-		if strings.Contains(strings.ToLower(path), lowerQuery) {
-			// Verify symlink target is under the root.
-			resolved, err := filepath.EvalSymlinks(path)
-			if err != nil || !strings.HasPrefix(resolved, root) {
-				return nil
-			}
-
-			info, err := d.Info()
-			if err != nil {
-				return nil
-			}
-			matches = append(matches, fileMatch{
-				Path:    path,
-				ModTime: info.ModTime(),
-			})
-		}
-
-		return nil
-	})
-
-	return matches
 }

--- a/extras/scion-discord/internal/discord/send_test.go
+++ b/extras/scion-discord/internal/discord/send_test.go
@@ -1,0 +1,291 @@
+package discord
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- sendPathStore tests ---
+
+func TestSendPathStore_PutAndGet(t *testing.T) {
+	store := newSendPathStore()
+	key := store.Put("/some/file.txt")
+	assert.NotEmpty(t, key)
+
+	got := store.Get(key)
+	assert.Equal(t, "/some/file.txt", got)
+}
+
+func TestSendPathStore_GetUnknownKey(t *testing.T) {
+	store := newSendPathStore()
+	got := store.Get("nonexistent")
+	assert.Empty(t, got)
+}
+
+func TestSendPathStore_TTLExpiry(t *testing.T) {
+	store := newSendPathStore()
+
+	// Manually insert an entry that is already expired.
+	store.mu.Lock()
+	store.entries["old"] = sendPathEntry{
+		Path:      "/expired/file.txt",
+		CreatedAt: time.Now().Add(-sendPathTTL - time.Minute),
+	}
+	store.mu.Unlock()
+
+	got := store.Get("old")
+	assert.Empty(t, got, "expired entry should return empty")
+}
+
+func TestSendPathStore_OpportunisticCleanup(t *testing.T) {
+	store := newSendPathStore()
+
+	// Insert an expired entry manually.
+	store.mu.Lock()
+	store.entries["expired"] = sendPathEntry{
+		Path:      "/old.txt",
+		CreatedAt: time.Now().Add(-sendPathTTL - time.Minute),
+	}
+	store.mu.Unlock()
+
+	// Put a new entry — should trigger cleanup.
+	store.Put("/new.txt")
+
+	store.mu.Lock()
+	_, exists := store.entries["expired"]
+	store.mu.Unlock()
+	assert.False(t, exists, "expired entry should be cleaned up during Put")
+}
+
+func TestSendPathStore_ConcurrentAccess(t *testing.T) {
+	store := newSendPathStore()
+	var wg sync.WaitGroup
+
+	// Concurrent writers.
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			key := store.Put("/concurrent/file.txt")
+			// Read back — may or may not get our entry if another goroutine
+			// expired it, but should not panic.
+			store.Get(key)
+		}(i)
+	}
+
+	// Concurrent readers.
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			store.Get("somekey")
+		}()
+	}
+
+	wg.Wait()
+}
+
+// --- searchFiles tests ---
+
+func TestSearchFiles_MatchesSubstring(t *testing.T) {
+	dir := setupSearchTestDir(t)
+
+	matches := searchFilesInDir(dir, "hello")
+	assert.Len(t, matches, 1)
+	assert.Contains(t, matches[0].Path, "hello.txt")
+}
+
+func TestSearchFiles_CaseInsensitive(t *testing.T) {
+	dir := setupSearchTestDir(t)
+
+	matches := searchFilesInDir(dir, "HELLO")
+	assert.Len(t, matches, 1)
+	assert.Contains(t, matches[0].Path, "hello.txt")
+}
+
+func TestSearchFiles_NoMatches(t *testing.T) {
+	dir := setupSearchTestDir(t)
+
+	matches := searchFilesInDir(dir, "nonexistent_xyz_abc")
+	assert.Empty(t, matches)
+}
+
+func TestSearchFiles_SkipsHiddenDirs(t *testing.T) {
+	dir := setupSearchTestDir(t)
+
+	// The .hidden directory contains a file named "secret.txt".
+	matches := searchFilesInDir(dir, "secret")
+	assert.Empty(t, matches, "files in hidden directories should be skipped")
+}
+
+func TestSearchFiles_SymlinkOutsideRoot(t *testing.T) {
+	dir := setupSearchTestDir(t)
+
+	// Create a file outside the search root.
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "external.txt")
+	require.NoError(t, os.WriteFile(outsideFile, []byte("external"), 0o644))
+
+	// Create a symlink inside the search root pointing outside.
+	symlinkPath := filepath.Join(dir, "escape-link.txt")
+	require.NoError(t, os.Symlink(outsideFile, symlinkPath))
+
+	matches := searchFilesInDir(dir, "escape-link")
+	assert.Empty(t, matches, "symlinks pointing outside search root should be excluded")
+}
+
+// --- isUnderSearchRoot tests ---
+
+func TestIsUnderSearchRoot_ValidPath(t *testing.T) {
+	// This test uses a real path under /scion-volumes if it exists,
+	// otherwise we test the logic indirectly.
+	if _, err := os.Stat(searchRoot); os.IsNotExist(err) {
+		t.Skip("searchRoot does not exist on this host")
+	}
+
+	// Create a temp file under searchRoot for testing.
+	tmpFile, err := os.CreateTemp(searchRoot, "test-send-*.txt")
+	if err != nil {
+		t.Skip("cannot create temp file in searchRoot")
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	assert.True(t, isUnderSearchRoot(tmpFile.Name()))
+}
+
+func TestIsUnderSearchRoot_RejectsOutsidePath(t *testing.T) {
+	assert.False(t, isUnderSearchRoot("/etc/passwd"))
+	assert.False(t, isUnderSearchRoot("/tmp/something"))
+	assert.False(t, isUnderSearchRoot("/root/.ssh/id_rsa"))
+}
+
+func TestIsUnderSearchRoot_RejectsTraversal(t *testing.T) {
+	assert.False(t, isUnderSearchRoot("/scion-volumes/../etc/passwd"))
+	assert.False(t, isUnderSearchRoot("/scion-volumes/./../../etc/shadow"))
+}
+
+func TestIsUnderSearchRoot_RejectsSymlinkEscape(t *testing.T) {
+	if _, err := os.Stat(searchRoot); os.IsNotExist(err) {
+		t.Skip("searchRoot does not exist on this host")
+	}
+
+	// Create a temp dir for the symlink target.
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "secret.txt")
+	require.NoError(t, os.WriteFile(outsideFile, []byte("secret"), 0o644))
+
+	// Create a symlink inside searchRoot pointing outside.
+	symlinkPath := filepath.Join(searchRoot, "test-escape-link-"+randomKey(4))
+	err := os.Symlink(outsideFile, symlinkPath)
+	if err != nil {
+		t.Skip("cannot create symlink in searchRoot")
+	}
+	defer os.Remove(symlinkPath)
+
+	assert.False(t, isUnderSearchRoot(symlinkPath),
+		"symlink inside searchRoot pointing outside should be rejected")
+}
+
+// --- buildButtonLabels tests ---
+
+func TestBuildButtonLabels_UniqueBasenames(t *testing.T) {
+	matches := []fileMatch{
+		{Path: "/scion-volumes/a/foo.txt"},
+		{Path: "/scion-volumes/b/bar.txt"},
+	}
+	labels := buildButtonLabels(matches)
+	assert.Equal(t, "foo.txt", labels[0])
+	assert.Equal(t, "bar.txt", labels[1])
+}
+
+func TestBuildButtonLabels_DuplicateBasenames(t *testing.T) {
+	matches := []fileMatch{
+		{Path: "/scion-volumes/project-a/README.md"},
+		{Path: "/scion-volumes/project-b/README.md"},
+	}
+	labels := buildButtonLabels(matches)
+	assert.Equal(t, "project-a/README.md", labels[0])
+	assert.Equal(t, "project-b/README.md", labels[1])
+}
+
+// --- test helpers ---
+
+// setupSearchTestDir creates a temporary directory structure for search tests.
+// Structure:
+//
+//	<root>/
+//	  hello.txt
+//	  subdir/
+//	    world.txt
+//	  .hidden/
+//	    secret.txt
+func setupSearchTestDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hello"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "subdir"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "subdir", "world.txt"), []byte("world"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".hidden"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".hidden", "secret.txt"), []byte("secret"), 0o644))
+
+	return dir
+}
+
+// searchFilesInDir is a test helper that runs the search logic against
+// an arbitrary directory root instead of the hardcoded searchRoot.
+// It duplicates the core logic of searchFiles to allow testing with
+// temp directories.
+func searchFilesInDir(root, query string) []fileMatch {
+	lowerQuery := strings.ToLower(query)
+	var matches []fileMatch
+	filesWalked := 0
+
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		filesWalked++
+		if filesWalked > maxFilesWalked {
+			return filepath.SkipAll
+		}
+
+		if d.IsDir() {
+			if strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if strings.Contains(strings.ToLower(path), lowerQuery) {
+			// Verify symlink target is under the root.
+			resolved, err := filepath.EvalSymlinks(path)
+			if err != nil || !strings.HasPrefix(resolved, root) {
+				return nil
+			}
+
+			info, err := d.Info()
+			if err != nil {
+				return nil
+			}
+			matches = append(matches, fileMatch{
+				Path:    path,
+				ModTime: info.ModTime(),
+			})
+		}
+
+		return nil
+	})
+
+	return matches
+}

--- a/extras/scion-discord/internal/discord/send_test.go
+++ b/extras/scion-discord/internal/discord/send_test.go
@@ -140,6 +140,59 @@ func TestSearchFiles_SymlinkOutsideRoot(t *testing.T) {
 	assert.Empty(t, matches, "symlinks pointing outside search root should be excluded")
 }
 
+// --- safeResolve tests ---
+
+func TestSafeResolve_ValidPath(t *testing.T) {
+	if _, err := os.Stat(searchRoot); os.IsNotExist(err) {
+		t.Skip("searchRoot does not exist on this host")
+	}
+
+	tmpFile, err := os.CreateTemp(searchRoot, "test-send-*.txt")
+	if err != nil {
+		t.Skip("cannot create temp file in searchRoot")
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	resolved, err := safeResolve(tmpFile.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, tmpFile.Name(), resolved)
+}
+
+func TestSafeResolve_RejectsOutsidePath(t *testing.T) {
+	_, err := safeResolve("/etc/passwd")
+	assert.Error(t, err)
+	_, err = safeResolve("/tmp/something")
+	assert.Error(t, err)
+}
+
+func TestSafeResolve_RejectsTraversal(t *testing.T) {
+	_, err := safeResolve("/scion-volumes/../etc/passwd")
+	assert.Error(t, err)
+	_, err = safeResolve("/scion-volumes/./../../etc/shadow")
+	assert.Error(t, err)
+}
+
+func TestSafeResolve_RejectsSymlinkEscape(t *testing.T) {
+	if _, err := os.Stat(searchRoot); os.IsNotExist(err) {
+		t.Skip("searchRoot does not exist on this host")
+	}
+
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "secret.txt")
+	require.NoError(t, os.WriteFile(outsideFile, []byte("secret"), 0o644))
+
+	symlinkPath := filepath.Join(searchRoot, "test-escape-link-"+randomKey(4))
+	err := os.Symlink(outsideFile, symlinkPath)
+	if err != nil {
+		t.Skip("cannot create symlink in searchRoot")
+	}
+	defer os.Remove(symlinkPath)
+
+	_, resolveErr := safeResolve(symlinkPath)
+	assert.Error(t, resolveErr, "symlink inside searchRoot pointing outside should be rejected")
+}
+
 // --- isUnderSearchRoot tests ---
 
 func TestIsUnderSearchRoot_ValidPath(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a new `/scion send <path>` slash command to the Discord integration that lets users request files from the shared scratchpad without asking an agent to send them.

**Behavior:**
- Absolute path to an existing file under /scion-volumes/ sends the file as a Discord attachment immediately
- Partial path/substring searches /scion-volumes/ and returns up to 20 matching files as Discord buttons, sorted by last modified
- Clicking a button sends that file as an attachment

**Security:**
- All file access confined to /scion-volumes/ via filepath.Clean + prefix check + EvalSymlinks + re-check
- Symlink traversal protection on both direct send and search paths
- OS errors logged server-side only; user sees generic messages

**Key files:**
- extras/scion-discord/internal/discord/send.go — HandleSend, searchFiles, path store, isUnderSearchRoot
- extras/scion-discord/internal/discord/send_test.go — 16 unit tests
- extras/scion-discord/internal/discord/commands.go — command registration
- extras/scion-discord/internal/discord/callbacks.go — button click handler

Staging fork PR: ptone/scion#663
Staging fork issue: ptone/scion#662
