### PR TITLE
feat: resolve skill destination-name collisions with scope-based precedence

### DIFF
--- a/pkg/agent/gcp_skill_resolver.go
+++ b/pkg/agent/gcp_skill_resolver.go
@@ -168,12 +168,14 @@ func (r *GCPSkillResolver) resolveOne(ctx context.Context, gcpRef *GCPSkillRef, 
 	bundleHash := transfer.ComputeContentHash(fileInfos)
 
 	return &ResolvedSkill{
-		Name:    gcpRef.SkillID,
-		URI:     gcpRef.Raw,
-		As:      ref.As,
-		Version: skill.Version,
-		Hash:    bundleHash,
-		Files:   resolvedFiles,
+		Name:     gcpRef.SkillID,
+		URI:      gcpRef.Raw,
+		As:       ref.As,
+		Version:  skill.Version,
+		Hash:     bundleHash,
+		Scope:    ref.Scope,
+		Files:    resolvedFiles,
+		Optional: ref.Optional,
 	}, nil
 }
 

--- a/pkg/agent/github_skill_resolver.go
+++ b/pkg/agent/github_skill_resolver.go
@@ -302,12 +302,14 @@ func (r *GitHubSkillResolver) resolveOne(ctx context.Context, ghRef *GitHubSkill
 	bundleHash := transfer.ComputeContentHash(fileInfos)
 
 	resolved := &ResolvedSkill{
-		Name:    ghRef.SkillName,
-		URI:     ghRef.Raw,
-		As:      ref.As,
-		Version: commitSHA[:12],
-		Hash:    bundleHash,
-		Files:   resolvedFiles,
+		Name:     ghRef.SkillName,
+		URI:      ghRef.Raw,
+		As:       ref.As,
+		Version:  commitSHA[:12],
+		Hash:     bundleHash,
+		Scope:    ref.Scope,
+		Files:    resolvedFiles,
+		Optional: ref.Optional,
 	}
 
 	// Store in resolution cache under the token-hashed key.

--- a/pkg/agent/hub_skill_resolver.go
+++ b/pkg/agent/hub_skill_resolver.go
@@ -77,10 +77,12 @@ func (r *HubSkillResolver) Resolve(ctx context.Context, refs []api.SkillReferenc
 			As:                 ref.As,
 			Version:            rs.ResolvedVersion,
 			Hash:               rs.ContentHash,
+			Scope:              ref.Scope,
 			Files:              files,
 			Deprecated:         rs.Deprecated,
 			DeprecationMessage: rs.DeprecationMessage,
 			ReplacementURI:     rs.ReplacementURI,
+			Optional:           ref.Optional,
 		})
 	}
 

--- a/pkg/agent/skill_resolver.go
+++ b/pkg/agent/skill_resolver.go
@@ -73,10 +73,12 @@ type ResolvedSkill struct {
 	As                 string
 	Version            string
 	Hash               string // Bundle content hash (sha256:...)
+	Scope              string // Injection scope (hub, user, project, template, platform, "")
 	Files              []ResolvedFile
 	Deprecated         bool   `json:"-"`
 	DeprecationMessage string `json:"-"`
 	ReplacementURI     string `json:"-"`
+	Optional           bool   `json:"-"` // Propagated from SkillReference for collision log level
 }
 
 // DestName returns the directory name to use when installing this skill.
@@ -200,6 +202,7 @@ type SkillResolutionRecord struct {
 	ResolvedAt string                 `json:"resolvedAt"`
 	Resolver   string                 `json:"resolver"`
 	Skills     []SkillResolutionEntry `json:"skills"`
+	Collisions []SkillCollisionEntry  `json:"collisions,omitempty"`
 }
 
 // SkillResolutionEntry records a single installed skill.
@@ -224,6 +227,126 @@ type FileEntry struct {
 	Hash string `json:"hash"`
 }
 
+// --- Destination-name collision resolution ---
+
+// scopeRank defines the precedence order for skill scopes when resolving
+// destination-name collisions. Higher rank wins.
+//
+// Precedence (highest to lowest): project > template > user > hub > platform > (unset)
+//
+// Rationale: project-level settings take precedence, consistent with other
+// project-level overrides in the system.
+var scopeRank = map[string]int{
+	"":         0,
+	"platform": 1,
+	"hub":      2,
+	"user":     3,
+	"template": 4,
+	"project":  5,
+}
+
+// SkillCollisionEntry records a single destination-name collision that was
+// resolved during skill installation. Persisted in resolved-skills.json.
+type SkillCollisionEntry struct {
+	DestName     string `json:"destName"`
+	WinnerURI    string `json:"winnerUri"`
+	WinnerScope  string `json:"winnerScope"`
+	DroppedURI   string `json:"droppedUri"`
+	DroppedScope string `json:"droppedScope"`
+}
+
+// deduplicateByDestName resolves destination-name collisions among resolved
+// skills using scope-based precedence. When two skills produce the same
+// DestName(), the skill with the higher scope rank wins. On equal scope,
+// the later entry wins (last-writer-wins, consistent with mergeSkillRefs).
+//
+// Returns the deduplicated list (preserving winner order of first appearance)
+// and a slice of collision entries for diagnostics.
+func deduplicateByDestName(skills []ResolvedSkill) ([]ResolvedSkill, []SkillCollisionEntry) {
+	type candidate struct {
+		index int
+		skill ResolvedSkill
+		dest  string
+	}
+
+	winners := map[string]*candidate{} // destName → winning candidate
+	var collisions []SkillCollisionEntry
+
+	for i, skill := range skills {
+		dest, err := skill.DestName()
+		if err != nil {
+			// DestName errors are caught later during install; pass through.
+			continue
+		}
+
+		existing, exists := winners[dest]
+		if !exists {
+			winners[dest] = &candidate{index: i, skill: skill, dest: dest}
+			continue
+		}
+
+		// Resolve collision: higher scope wins; on tie, later entry wins.
+		newRank := scopeRank[skill.Scope]
+		existingRank := scopeRank[existing.skill.Scope]
+
+		var winner, loser ResolvedSkill
+		if newRank >= existingRank {
+			winner = skill
+			loser = existing.skill
+			winners[dest] = &candidate{index: i, skill: skill, dest: dest}
+		} else {
+			winner = existing.skill
+			loser = skill
+		}
+
+		collisions = append(collisions, SkillCollisionEntry{
+			DestName:     dest,
+			WinnerURI:    winner.URI,
+			WinnerScope:  winner.Scope,
+			DroppedURI:   loser.URI,
+			DroppedScope: loser.Scope,
+		})
+
+		// Log at appropriate level: Debug for optional losers, Warn otherwise.
+		if loser.Optional {
+			slog.Debug("skill destination-name collision resolved (optional skill dropped)",
+				"dest_name", dest,
+				"winner_uri", winner.URI,
+				"winner_scope", winner.Scope,
+				"dropped_uri", loser.URI,
+				"dropped_scope", loser.Scope,
+			)
+		} else {
+			slog.Warn("skill destination-name collision resolved",
+				"dest_name", dest,
+				"winner_uri", winner.URI,
+				"winner_scope", winner.Scope,
+				"dropped_uri", loser.URI,
+				"dropped_scope", loser.Scope,
+			)
+		}
+	}
+
+	// Build deduplicated list preserving original order of winners.
+	// Collect and sort by first-appearance index so the output is deterministic.
+	sorted := make([]*candidate, 0, len(winners))
+	for _, c := range winners {
+		sorted = append(sorted, c)
+	}
+	// Sort by index for stable output order.
+	for i := 1; i < len(sorted); i++ {
+		for j := i; j > 0 && sorted[j].index < sorted[j-1].index; j-- {
+			sorted[j], sorted[j-1] = sorted[j-1], sorted[j]
+		}
+	}
+	deduplicated := make([]ResolvedSkill, len(sorted))
+	for i, c := range sorted {
+		deduplicated[i] = c.skill
+	}
+
+	return deduplicated, collisions
+}
+
 // --- Download, stage, verify, install ---
 
 // installResolvedSkills downloads, verifies, and installs resolved skills
@@ -234,20 +357,10 @@ func installResolvedSkills(
 	skillsDest string,
 	agentHome string,
 ) (*SkillResolutionRecord, error) {
-	// S6: Detect duplicate destinations
-	destMap := make(map[string]string) // destName → URI
-	for _, skill := range skills {
-		dest, err := skill.DestName()
-		if err != nil {
-			return nil, err
-		}
-		if existing, ok := destMap[dest]; ok {
-			return nil, fmt.Errorf(
-				"skill resolution conflict: two skills resolve to the same destination directory %q:\n  - %s\n  - %s",
-				dest, existing, skill.URI)
-		}
-		destMap[dest] = skill.URI
-	}
+	// S6: Resolve destination-name collisions via scope-based precedence.
+	// Previously this was a hard error; now collisions are resolved by dropping
+	// the lower-scope skill and logging a warning.
+	skills, collisions := deduplicateByDestName(skills)
 
 	if err := os.MkdirAll(skillsDest, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create skills directory: %w", err)
@@ -256,6 +369,7 @@ func installResolvedSkills(
 	record := &SkillResolutionRecord{
 		ResolvedAt: time.Now().UTC().Format(time.RFC3339),
 		Resolver:   "mock",
+		Collisions: collisions,
 	}
 
 	for _, skill := range skills {
@@ -425,10 +539,13 @@ func installOneSkill(ctx context.Context, skill ResolvedSkill, dest, skillsDest 
 
 // buildSkillEntry creates a SkillResolutionEntry for a successfully installed skill.
 func buildSkillEntry(skill ResolvedSkill, dest, skillsDest string) (*SkillResolutionEntry, error) {
-	var scope string
-	parsed, err := api.ParseSkillURI(skill.URI)
-	if err == nil {
-		scope = parsed.Scope
+	scope := skill.Scope
+	if scope == "" {
+		// Fall back to URI-derived scope when the injection scope is not set.
+		parsed, err := api.ParseSkillURI(skill.URI)
+		if err == nil {
+			scope = parsed.Scope
+		}
 	}
 
 	var fileEntries []FileEntry

--- a/pkg/agent/skill_resolver.go
+++ b/pkg/agent/skill_resolver.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -234,8 +235,10 @@ type FileEntry struct {
 //
 // Precedence (highest to lowest): project > template > user > hub > platform > (unset)
 //
-// Rationale: project-level settings take precedence, consistent with other
-// project-level overrides in the system.
+// Rationale: project-level settings take precedence for destination-name
+// collisions, as approved in #654. Note: hub-side base-URI dedup
+// (mergeSkillRefs) uses the opposite order (template > project); the two
+// dedup passes operate on different dimensions (base URI vs dest name).
 var scopeRank = map[string]int{
 	"":         0,
 	"platform": 1,
@@ -271,11 +274,14 @@ func deduplicateByDestName(skills []ResolvedSkill) ([]ResolvedSkill, []SkillColl
 
 	winners := map[string]*candidate{} // destName → winning candidate
 	var collisions []SkillCollisionEntry
+	var passthrough []ResolvedSkill // skills with DestName errors; cannot participate in dedup
 
 	for i, skill := range skills {
 		dest, err := skill.DestName()
 		if err != nil {
-			// DestName errors are caught later during install; pass through.
+			// Cannot participate in dedup; pass through so the install loop
+			// surfaces the DestName error with a clear diagnostic.
+			passthrough = append(passthrough, skill)
 			continue
 		}
 
@@ -333,16 +339,16 @@ func deduplicateByDestName(skills []ResolvedSkill) ([]ResolvedSkill, []SkillColl
 	for _, c := range winners {
 		sorted = append(sorted, c)
 	}
-	// Sort by index for stable output order.
-	for i := 1; i < len(sorted); i++ {
-		for j := i; j > 0 && sorted[j].index < sorted[j-1].index; j-- {
-			sorted[j], sorted[j-1] = sorted[j-1], sorted[j]
-		}
+	slices.SortFunc(sorted, func(a, b *candidate) int {
+		return a.index - b.index
+	})
+	deduplicated := make([]ResolvedSkill, 0, len(sorted)+len(passthrough))
+	for _, c := range sorted {
+		deduplicated = append(deduplicated, c.skill)
 	}
-	deduplicated := make([]ResolvedSkill, len(sorted))
-	for i, c := range sorted {
-		deduplicated[i] = c.skill
-	}
+	// Append skills with DestName errors so installResolvedSkills surfaces
+	// the error rather than silently dropping the skill.
+	deduplicated = append(deduplicated, passthrough...)
 
 	return deduplicated, collisions
 }
@@ -373,7 +379,10 @@ func installResolvedSkills(
 	}
 
 	for _, skill := range skills {
-		dest, _ := skill.DestName() // already validated above
+		dest, err := skill.DestName()
+		if err != nil {
+			return nil, fmt.Errorf("skill %q has invalid destination name: %w", skill.URI, err)
+		}
 
 		entry, err := installOneSkill(ctx, skill, dest, skillsDest)
 		if err != nil {

--- a/pkg/agent/skill_resolver.go
+++ b/pkg/agent/skill_resolver.go
@@ -265,7 +265,7 @@ type SkillCollisionEntry struct {
 //
 // Returns the deduplicated list (preserving winner order of first appearance)
 // and a slice of collision entries for diagnostics.
-func deduplicateByDestName(skills []ResolvedSkill) ([]ResolvedSkill, []SkillCollisionEntry) {
+func deduplicateByDestName(ctx context.Context, skills []ResolvedSkill) ([]ResolvedSkill, []SkillCollisionEntry) {
 	type candidate struct {
 		index int
 		skill ResolvedSkill
@@ -315,7 +315,7 @@ func deduplicateByDestName(skills []ResolvedSkill) ([]ResolvedSkill, []SkillColl
 
 		// Log at appropriate level: Debug for optional losers, Warn otherwise.
 		if loser.Optional {
-			slog.Debug("skill destination-name collision resolved (optional skill dropped)",
+			slog.DebugContext(ctx, "skill destination-name collision resolved (optional skill dropped)",
 				"dest_name", dest,
 				"winner_uri", winner.URI,
 				"winner_scope", winner.Scope,
@@ -323,7 +323,7 @@ func deduplicateByDestName(skills []ResolvedSkill) ([]ResolvedSkill, []SkillColl
 				"dropped_scope", loser.Scope,
 			)
 		} else {
-			slog.Warn("skill destination-name collision resolved",
+			slog.WarnContext(ctx, "skill destination-name collision resolved",
 				"dest_name", dest,
 				"winner_uri", winner.URI,
 				"winner_scope", winner.Scope,
@@ -366,7 +366,7 @@ func installResolvedSkills(
 	// S6: Resolve destination-name collisions via scope-based precedence.
 	// Previously this was a hard error; now collisions are resolved by dropping
 	// the lower-scope skill and logging a warning.
-	skills, collisions := deduplicateByDestName(skills)
+	skills, collisions := deduplicateByDestName(ctx, skills)
 
 	if err := os.MkdirAll(skillsDest, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create skills directory: %w", err)

--- a/pkg/agent/skill_resolver_test.go
+++ b/pkg/agent/skill_resolver_test.go
@@ -40,7 +40,7 @@ func (h *collectHandler) Handle(_ context.Context, r slog.Record) error {
 	return nil
 }
 func (h *collectHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
-func (h *collectHandler) WithGroup(_ string) slog.Handler       { return h }
+func (h *collectHandler) WithGroup(_ string) slog.Handler      { return h }
 
 // mockResolver implements SkillResolver for testing.
 type mockResolver struct {

--- a/pkg/agent/skill_resolver_test.go
+++ b/pkg/agent/skill_resolver_test.go
@@ -270,27 +270,74 @@ func TestInstallResolvedSkills_PathTraversal(t *testing.T) {
 }
 
 func TestInstallResolvedSkills_DuplicateDestination(t *testing.T) {
+	// After the collision resolution change, duplicate destinations are resolved
+	// via scope-based precedence instead of producing a hard error.
+	content := []byte("# Winner Skill")
+	contentHash := transfer.HashBytes(content)
+	bundleHash := transfer.ComputeContentHash([]transfer.FileInfo{
+		{Path: "SKILL.md", Hash: contentHash},
+	})
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(content)
+	}))
+	defer srv.Close()
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = srv.Client().Transport
+	defer func() { http.DefaultTransport = origTransport }()
+
 	skills := []ResolvedSkill{
 		{
-			Name: "scion",
-			URI:  "skill://scion/core/scion@^1.0",
+			Name:  "scion",
+			URI:   "skill://scion/core/scion@^1.0",
+			Scope: "template",
+			Hash:  bundleHash,
+			Files: []ResolvedFile{
+				{Path: "SKILL.md", URL: srv.URL + "/SKILL.md", Hash: contentHash},
+			},
 		},
 		{
-			Name: "custom",
-			URI:  "skill://project/custom@latest",
-			As:   "scion", // same dest name
+			Name:  "custom",
+			URI:   "skill://project/custom@latest",
+			As:    "scion", // same dest name
+			Scope: "project",
+			Hash:  bundleHash,
+			Files: []ResolvedFile{
+				{Path: "SKILL.md", URL: srv.URL + "/SKILL.md", Hash: contentHash},
+			},
 		},
 	}
 
 	agentHome := t.TempDir()
 	skillsDest := filepath.Join(agentHome, ".claude", "skills")
 
-	_, err := installResolvedSkills(context.Background(), skills, skillsDest, agentHome)
-	if err == nil {
-		t.Fatal("expected error for duplicate destination")
+	record, err := installResolvedSkills(context.Background(), skills, skillsDest, agentHome)
+	if err != nil {
+		t.Fatalf("expected success after collision resolution, got error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "conflict") {
-		t.Errorf("error should mention conflict, got: %v", err)
+
+	// Project scope wins over template scope.
+	if len(record.Skills) != 1 {
+		t.Fatalf("expected 1 installed skill, got %d", len(record.Skills))
+	}
+	if record.Skills[0].URI != "skill://project/custom@latest" {
+		t.Errorf("expected project-scope skill to win, got URI %q", record.Skills[0].URI)
+	}
+
+	// Collision should be recorded.
+	if len(record.Collisions) != 1 {
+		t.Fatalf("expected 1 collision entry, got %d", len(record.Collisions))
+	}
+	c := record.Collisions[0]
+	if c.DestName != "scion" {
+		t.Errorf("collision destName = %q, want %q", c.DestName, "scion")
+	}
+	if c.WinnerURI != "skill://project/custom@latest" {
+		t.Errorf("collision winner = %q, want project skill", c.WinnerURI)
+	}
+	if c.DroppedURI != "skill://scion/core/scion@^1.0" {
+		t.Errorf("collision dropped = %q, want template skill", c.DroppedURI)
 	}
 }
 
@@ -897,5 +944,208 @@ func TestGitHubTokenFromContext(t *testing.T) {
 	ctx := ContextWithGitHubToken(context.Background(), "ghp_example")
 	if got := GitHubTokenFromContext(ctx); got != "ghp_example" {
 		t.Errorf("GitHubTokenFromContext = %q, want %q", got, "ghp_example")
+	}
+}
+
+// --- deduplicateByDestName tests ---
+
+func TestDeduplicateByDestName_ProjectWinsOverTemplate(t *testing.T) {
+	skills := []ResolvedSkill{
+		{Name: "my-skill", URI: "skill://scion/core/my-skill@1.0", Scope: "template"},
+		{Name: "my-skill", URI: "gh://org/repo/skills/my-skill", Scope: "project"},
+	}
+
+	deduped, collisions := deduplicateByDestName(skills)
+
+	if len(deduped) != 1 {
+		t.Fatalf("expected 1 skill after dedup, got %d", len(deduped))
+	}
+	if deduped[0].URI != "gh://org/repo/skills/my-skill" {
+		t.Errorf("expected project-scope skill to win, got URI %q", deduped[0].URI)
+	}
+
+	if len(collisions) != 1 {
+		t.Fatalf("expected 1 collision, got %d", len(collisions))
+	}
+	c := collisions[0]
+	if c.WinnerScope != "project" {
+		t.Errorf("winner scope = %q, want %q", c.WinnerScope, "project")
+	}
+	if c.DroppedScope != "template" {
+		t.Errorf("dropped scope = %q, want %q", c.DroppedScope, "template")
+	}
+}
+
+func TestDeduplicateByDestName_SameScopeLaterWins(t *testing.T) {
+	skills := []ResolvedSkill{
+		{Name: "my-skill", URI: "skill://scion/core/my-skill@1.0", Scope: "template"},
+		{Name: "my-skill", URI: "skill://scion/core/my-skill@2.0", Scope: "template"},
+	}
+
+	deduped, collisions := deduplicateByDestName(skills)
+
+	if len(deduped) != 1 {
+		t.Fatalf("expected 1 skill after dedup, got %d", len(deduped))
+	}
+	// Later entry (index 1) should win on equal scope.
+	if deduped[0].URI != "skill://scion/core/my-skill@2.0" {
+		t.Errorf("expected later entry to win on same scope, got URI %q", deduped[0].URI)
+	}
+
+	if len(collisions) != 1 {
+		t.Fatalf("expected 1 collision, got %d", len(collisions))
+	}
+	if collisions[0].DroppedURI != "skill://scion/core/my-skill@1.0" {
+		t.Errorf("expected earlier entry to be dropped, got %q", collisions[0].DroppedURI)
+	}
+}
+
+func TestDeduplicateByDestName_NoCollision(t *testing.T) {
+	skills := []ResolvedSkill{
+		{Name: "skill-a", URI: "skill://scion/core/skill-a@1.0", Scope: "template"},
+		{Name: "skill-b", URI: "skill://scion/core/skill-b@1.0", Scope: "project"},
+		{Name: "skill-c", URI: "gh://org/repo/skills/skill-c", Scope: "hub"},
+	}
+
+	deduped, collisions := deduplicateByDestName(skills)
+
+	if len(deduped) != 3 {
+		t.Fatalf("expected 3 skills (no collision), got %d", len(deduped))
+	}
+	if len(collisions) != 0 {
+		t.Errorf("expected 0 collisions, got %d", len(collisions))
+	}
+
+	// Verify order is preserved.
+	if deduped[0].Name != "skill-a" || deduped[1].Name != "skill-b" || deduped[2].Name != "skill-c" {
+		t.Errorf("order not preserved: got %q, %q, %q", deduped[0].Name, deduped[1].Name, deduped[2].Name)
+	}
+}
+
+func TestDeduplicateByDestName_CollisionRecordedInRecord(t *testing.T) {
+	content := []byte("# Skill")
+	contentHash := transfer.HashBytes(content)
+	bundleHash := transfer.ComputeContentHash([]transfer.FileInfo{
+		{Path: "SKILL.md", Hash: contentHash},
+	})
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(content)
+	}))
+	defer srv.Close()
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = srv.Client().Transport
+	defer func() { http.DefaultTransport = origTransport }()
+
+	skills := []ResolvedSkill{
+		{
+			Name: "shared-name", URI: "skill://hub/shared-name@1.0", Scope: "hub",
+			Hash: bundleHash, Files: []ResolvedFile{
+				{Path: "SKILL.md", URL: srv.URL + "/SKILL.md", Hash: contentHash},
+			},
+		},
+		{
+			Name: "shared-name", URI: "skill://project/shared-name@2.0", Scope: "project",
+			Hash: bundleHash, Files: []ResolvedFile{
+				{Path: "SKILL.md", URL: srv.URL + "/SKILL.md", Hash: contentHash},
+			},
+		},
+	}
+
+	agentHome := t.TempDir()
+	skillsDest := filepath.Join(agentHome, ".claude", "skills")
+
+	record, err := installResolvedSkills(context.Background(), skills, skillsDest, agentHome)
+	if err != nil {
+		t.Fatalf("installResolvedSkills() error: %v", err)
+	}
+
+	if len(record.Collisions) != 1 {
+		t.Fatalf("expected 1 collision in record, got %d", len(record.Collisions))
+	}
+	c := record.Collisions[0]
+	if c.DestName != "shared-name" {
+		t.Errorf("collision destName = %q, want %q", c.DestName, "shared-name")
+	}
+	if c.WinnerURI != "skill://project/shared-name@2.0" {
+		t.Errorf("collision winner = %q, want project skill", c.WinnerURI)
+	}
+	if c.DroppedURI != "skill://hub/shared-name@1.0" {
+		t.Errorf("collision dropped = %q, want hub skill", c.DroppedURI)
+	}
+}
+
+func TestDeduplicateByDestName_OptionalLoserNoWarn(t *testing.T) {
+	// When the dropped skill is optional, the collision should still be recorded
+	// but the log level should be Debug, not Warn. We verify the collision entry
+	// is present and that the Optional field on the loser is correctly set.
+	skills := []ResolvedSkill{
+		{Name: "my-skill", URI: "skill://scion/core/my-skill@1.0", Scope: "hub", Optional: true},
+		{Name: "my-skill", URI: "skill://scion/core/my-skill@2.0", Scope: "project"},
+	}
+
+	deduped, collisions := deduplicateByDestName(skills)
+
+	if len(deduped) != 1 {
+		t.Fatalf("expected 1 skill after dedup, got %d", len(deduped))
+	}
+	if deduped[0].URI != "skill://scion/core/my-skill@2.0" {
+		t.Errorf("expected project-scope skill to win, got URI %q", deduped[0].URI)
+	}
+	if len(collisions) != 1 {
+		t.Fatalf("expected 1 collision, got %d", len(collisions))
+	}
+	// The collision entry should reflect the dropped (optional) skill.
+	if collisions[0].DroppedURI != "skill://scion/core/my-skill@1.0" {
+		t.Errorf("expected optional skill to be dropped, got %q", collisions[0].DroppedURI)
+	}
+}
+
+func TestDeduplicateByDestName_FullPrecedenceOrder(t *testing.T) {
+	// Verify the full precedence chain: project > template > user > hub > platform > ""
+	scopes := []string{"", "platform", "hub", "user", "template", "project"}
+
+	for i := 0; i < len(scopes)-1; i++ {
+		lower := scopes[i]
+		higher := scopes[i+1]
+		t.Run(fmt.Sprintf("%s_beats_%s", higher, lower), func(t *testing.T) {
+			skills := []ResolvedSkill{
+				{Name: "test-skill", URI: "skill://lower/test-skill@1.0", Scope: lower},
+				{Name: "test-skill", URI: "skill://higher/test-skill@2.0", Scope: higher},
+			}
+
+			deduped, collisions := deduplicateByDestName(skills)
+
+			if len(deduped) != 1 {
+				t.Fatalf("expected 1 skill, got %d", len(deduped))
+			}
+			if deduped[0].Scope != higher {
+				t.Errorf("expected scope %q to win, got %q", higher, deduped[0].Scope)
+			}
+			if len(collisions) != 1 {
+				t.Fatalf("expected 1 collision, got %d", len(collisions))
+			}
+			if collisions[0].WinnerScope != higher {
+				t.Errorf("winner scope = %q, want %q", collisions[0].WinnerScope, higher)
+			}
+		})
+	}
+}
+
+func TestDeduplicateByDestName_AsAlias(t *testing.T) {
+	// Skills with explicit As aliases that don't collide should pass through.
+	skills := []ResolvedSkill{
+		{Name: "my-skill", URI: "skill://scion/core/my-skill@1.0", Scope: "template"},
+		{Name: "my-skill", URI: "gh://org/repo/skills/my-skill", Scope: "project", As: "my-skill-alt"},
+	}
+
+	deduped, collisions := deduplicateByDestName(skills)
+
+	if len(deduped) != 2 {
+		t.Fatalf("expected 2 skills (alias avoids collision), got %d", len(deduped))
+	}
+	if len(collisions) != 0 {
+		t.Errorf("expected 0 collisions with alias, got %d", len(collisions))
 	}
 }

--- a/pkg/agent/skill_resolver_test.go
+++ b/pkg/agent/skill_resolver_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
@@ -31,11 +32,14 @@ import (
 
 // collectHandler is a slog.Handler that collects records for test assertions.
 type collectHandler struct {
+	mu      sync.Mutex
 	records *[]slog.Record
 }
 
 func (h *collectHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
 func (h *collectHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	*h.records = append(*h.records, r)
 	return nil
 }
@@ -969,7 +973,7 @@ func TestDeduplicateByDestName_ProjectWinsOverTemplate(t *testing.T) {
 		{Name: "my-skill", URI: "gh://org/repo/skills/my-skill", Scope: "project"},
 	}
 
-	deduped, collisions := deduplicateByDestName(skills)
+	deduped, collisions := deduplicateByDestName(context.Background(), skills)
 
 	if len(deduped) != 1 {
 		t.Fatalf("expected 1 skill after dedup, got %d", len(deduped))
@@ -996,7 +1000,7 @@ func TestDeduplicateByDestName_SameScopeLaterWins(t *testing.T) {
 		{Name: "my-skill", URI: "skill://scion/core/my-skill@2.0", Scope: "template"},
 	}
 
-	deduped, collisions := deduplicateByDestName(skills)
+	deduped, collisions := deduplicateByDestName(context.Background(), skills)
 
 	if len(deduped) != 1 {
 		t.Fatalf("expected 1 skill after dedup, got %d", len(deduped))
@@ -1021,7 +1025,7 @@ func TestDeduplicateByDestName_NoCollision(t *testing.T) {
 		{Name: "skill-c", URI: "gh://org/repo/skills/skill-c", Scope: "hub"},
 	}
 
-	deduped, collisions := deduplicateByDestName(skills)
+	deduped, collisions := deduplicateByDestName(context.Background(), skills)
 
 	if len(deduped) != 3 {
 		t.Fatalf("expected 3 skills (no collision), got %d", len(deduped))
@@ -1104,7 +1108,7 @@ func TestDeduplicateByDestName_OptionalLoserUsesDebugLevel(t *testing.T) {
 		{Name: "my-skill", URI: "skill://scion/core/my-skill@2.0", Scope: "project"},
 	}
 
-	deduped, collisions := deduplicateByDestName(skills)
+	deduped, collisions := deduplicateByDestName(context.Background(), skills)
 
 	if len(deduped) != 1 {
 		t.Fatalf("expected 1 skill after dedup, got %d", len(deduped))
@@ -1147,7 +1151,7 @@ func TestDeduplicateByDestName_FullPrecedenceOrder(t *testing.T) {
 				{Name: "test-skill", URI: "skill://higher/test-skill@2.0", Scope: higher},
 			}
 
-			deduped, collisions := deduplicateByDestName(skills)
+			deduped, collisions := deduplicateByDestName(context.Background(), skills)
 
 			if len(deduped) != 1 {
 				t.Fatalf("expected 1 skill, got %d", len(deduped))
@@ -1174,7 +1178,7 @@ func TestDeduplicateByDestName_DestNameErrorPassthrough(t *testing.T) {
 		{Name: "INVALID", URI: "skill://scion/core/bad@1.0", Scope: "project"}, // invalid name
 	}
 
-	deduped, collisions := deduplicateByDestName(skills)
+	deduped, collisions := deduplicateByDestName(context.Background(), skills)
 
 	// Both should be in the output: good-skill via the winners map, bad via passthrough.
 	if len(deduped) != 2 {
@@ -1216,7 +1220,7 @@ func TestDeduplicateByDestName_ThreeWayCollision(t *testing.T) {
 		{Name: "shared", URI: "skill://project/shared@3.0", Scope: "project"},
 	}
 
-	deduped, collisions := deduplicateByDestName(skills)
+	deduped, collisions := deduplicateByDestName(context.Background(), skills)
 
 	if len(deduped) != 1 {
 		t.Fatalf("expected 1 skill after three-way dedup, got %d", len(deduped))
@@ -1251,7 +1255,7 @@ func TestDeduplicateByDestName_AsAlias(t *testing.T) {
 		{Name: "my-skill", URI: "gh://org/repo/skills/my-skill", Scope: "project", As: "my-skill-alt"},
 	}
 
-	deduped, collisions := deduplicateByDestName(skills)
+	deduped, collisions := deduplicateByDestName(context.Background(), skills)
 
 	if len(deduped) != 2 {
 		t.Fatalf("expected 2 skills (alias avoids collision), got %d", len(deduped))

--- a/pkg/agent/skill_resolver_test.go
+++ b/pkg/agent/skill_resolver_test.go
@@ -17,6 +17,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -27,6 +28,19 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/transfer"
 )
+
+// collectHandler is a slog.Handler that collects records for test assertions.
+type collectHandler struct {
+	records *[]slog.Record
+}
+
+func (h *collectHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *collectHandler) Handle(_ context.Context, r slog.Record) error {
+	*h.records = append(*h.records, r)
+	return nil
+}
+func (h *collectHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *collectHandler) WithGroup(_ string) slog.Handler       { return h }
 
 // mockResolver implements SkillResolver for testing.
 type mockResolver struct {
@@ -1076,10 +1090,15 @@ func TestDeduplicateByDestName_CollisionRecordedInRecord(t *testing.T) {
 	}
 }
 
-func TestDeduplicateByDestName_OptionalLoserNoWarn(t *testing.T) {
-	// When the dropped skill is optional, the collision should still be recorded
-	// but the log level should be Debug, not Warn. We verify the collision entry
-	// is present and that the Optional field on the loser is correctly set.
+func TestDeduplicateByDestName_OptionalLoserUsesDebugLevel(t *testing.T) {
+	// When the dropped skill is optional, the collision log should be at Debug
+	// level, not Warn. Capture slog output to verify.
+	var records []slog.Record
+	handler := &collectHandler{records: &records}
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	defer slog.SetDefault(oldLogger)
+
 	skills := []ResolvedSkill{
 		{Name: "my-skill", URI: "skill://scion/core/my-skill@1.0", Scope: "hub", Optional: true},
 		{Name: "my-skill", URI: "skill://scion/core/my-skill@2.0", Scope: "project"},
@@ -1096,9 +1115,22 @@ func TestDeduplicateByDestName_OptionalLoserNoWarn(t *testing.T) {
 	if len(collisions) != 1 {
 		t.Fatalf("expected 1 collision, got %d", len(collisions))
 	}
-	// The collision entry should reflect the dropped (optional) skill.
 	if collisions[0].DroppedURI != "skill://scion/core/my-skill@1.0" {
 		t.Errorf("expected optional skill to be dropped, got %q", collisions[0].DroppedURI)
+	}
+
+	// Verify that the collision was logged at Debug level, not Warn.
+	var foundCollisionLog bool
+	for _, r := range records {
+		if strings.Contains(r.Message, "collision resolved") {
+			foundCollisionLog = true
+			if r.Level != slog.LevelDebug {
+				t.Errorf("expected Debug level for optional loser collision log, got %v", r.Level)
+			}
+		}
+	}
+	if !foundCollisionLog {
+		t.Error("expected a collision log record, found none")
 	}
 }
 
@@ -1130,6 +1162,85 @@ func TestDeduplicateByDestName_FullPrecedenceOrder(t *testing.T) {
 				t.Errorf("winner scope = %q, want %q", collisions[0].WinnerScope, higher)
 			}
 		})
+	}
+}
+
+func TestDeduplicateByDestName_DestNameErrorPassthrough(t *testing.T) {
+	// A skill with an invalid DestName (e.g. "INVALID" fails ValidateSkillName)
+	// must not be silently dropped. It should pass through the dedup and surface
+	// as an error during install.
+	skills := []ResolvedSkill{
+		{Name: "good-skill", URI: "skill://scion/core/good-skill@1.0", Scope: "template"},
+		{Name: "INVALID", URI: "skill://scion/core/bad@1.0", Scope: "project"}, // invalid name
+	}
+
+	deduped, collisions := deduplicateByDestName(skills)
+
+	// Both should be in the output: good-skill via the winners map, bad via passthrough.
+	if len(deduped) != 2 {
+		t.Fatalf("expected 2 skills (including passthrough), got %d", len(deduped))
+	}
+	if len(collisions) != 0 {
+		t.Errorf("expected 0 collisions, got %d", len(collisions))
+	}
+
+	// Verify the invalid skill is in the output so installResolvedSkills can surface the error.
+	foundInvalid := false
+	for _, s := range deduped {
+		if s.Name == "INVALID" {
+			foundInvalid = true
+		}
+	}
+	if !foundInvalid {
+		t.Error("expected invalid-name skill to pass through dedup, but it was dropped")
+	}
+
+	// Verify installResolvedSkills surfaces the error for the invalid skill.
+	agentHome := t.TempDir()
+	skillsDest := filepath.Join(agentHome, ".claude", "skills")
+	_, err := installResolvedSkills(context.Background(), skills, skillsDest, agentHome)
+	if err == nil {
+		t.Fatal("expected error for skill with invalid DestName")
+	}
+	if !strings.Contains(err.Error(), "invalid") {
+		t.Errorf("error should mention invalid destination name, got: %v", err)
+	}
+}
+
+func TestDeduplicateByDestName_ThreeWayCollision(t *testing.T) {
+	// Three skills collide on the same DestName. The highest scope should win,
+	// and two collision entries should be recorded.
+	skills := []ResolvedSkill{
+		{Name: "shared", URI: "skill://hub/shared@1.0", Scope: "hub"},
+		{Name: "shared", URI: "skill://template/shared@2.0", Scope: "template"},
+		{Name: "shared", URI: "skill://project/shared@3.0", Scope: "project"},
+	}
+
+	deduped, collisions := deduplicateByDestName(skills)
+
+	if len(deduped) != 1 {
+		t.Fatalf("expected 1 skill after three-way dedup, got %d", len(deduped))
+	}
+	if deduped[0].URI != "skill://project/shared@3.0" {
+		t.Errorf("expected project-scope skill to win three-way collision, got URI %q", deduped[0].URI)
+	}
+	if deduped[0].Scope != "project" {
+		t.Errorf("expected scope %q, got %q", "project", deduped[0].Scope)
+	}
+
+	// Two collisions should be recorded (hub→template, then template→project).
+	if len(collisions) != 2 {
+		t.Fatalf("expected 2 collision entries for three-way, got %d", len(collisions))
+	}
+	// First collision: template beats hub.
+	if collisions[0].WinnerURI != "skill://template/shared@2.0" || collisions[0].DroppedURI != "skill://hub/shared@1.0" {
+		t.Errorf("first collision: winner=%q dropped=%q, want template over hub",
+			collisions[0].WinnerURI, collisions[0].DroppedURI)
+	}
+	// Second collision: project beats template.
+	if collisions[1].WinnerURI != "skill://project/shared@3.0" || collisions[1].DroppedURI != "skill://template/shared@2.0" {
+		t.Errorf("second collision: winner=%q dropped=%q, want project over template",
+			collisions[1].WinnerURI, collisions[1].DroppedURI)
 	}
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -684,6 +684,10 @@ type SkillReference struct {
 	URI      string `json:"uri" yaml:"uri" koanf:"uri"`
 	As       string `json:"as,omitempty" yaml:"as,omitempty" koanf:"as"`
 	Optional bool   `json:"optional,omitempty" yaml:"optional,omitempty" koanf:"optional"`
+	// Scope indicates the injection source of this skill reference.
+	// Valid values: "hub", "user", "project", "template", "platform", "" (empty = lowest precedence).
+	// Used for destination-name collision resolution: higher-scope skills win.
+	Scope string `json:"scope,omitempty" yaml:"scope,omitempty" koanf:"scope"`
 }
 
 // SkillInjectionEntry is the API representation of one injected-skills list entry.

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -862,13 +862,16 @@ func MergeScionConfig(base, override *api.ScionConfig) *api.ScionConfig {
 	// Skills: append (deferred override semantics per #230).
 	// Annotate override skills with "template" scope for destination-name
 	// collision resolution on the local (non-hub) provisioning path.
+	// Copy the slice to avoid mutating the caller's config.
 	if len(override.Skills) > 0 {
-		for i := range override.Skills {
-			if override.Skills[i].Scope == "" {
-				override.Skills[i].Scope = "template"
+		annotated := make([]api.SkillReference, len(override.Skills))
+		copy(annotated, override.Skills)
+		for i := range annotated {
+			if annotated[i].Scope == "" {
+				annotated[i].Scope = "template"
 			}
 		}
-		result.Skills = append(result.Skills, override.Skills...)
+		result.Skills = append(result.Skills, annotated...)
 	}
 
 	return &result

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -860,7 +860,14 @@ func MergeScionConfig(base, override *api.ScionConfig) *api.ScionConfig {
 	}
 
 	// Skills: append (deferred override semantics per #230).
+	// Annotate override skills with "template" scope for destination-name
+	// collision resolution on the local (non-hub) provisioning path.
 	if len(override.Skills) > 0 {
+		for i := range override.Skills {
+			if override.Skills[i].Scope == "" {
+				override.Skills[i].Scope = "template"
+			}
+		}
 		result.Skills = append(result.Skills, override.Skills...)
 	}
 

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -483,14 +483,25 @@ func (s *Server) mergeInjectedSkills(ctx context.Context, agent *store.Agent, pr
 			}
 		}
 	}
+	// Copy the slice to avoid mutating the original SkillReference values.
+	if len(projectRefs) > 0 {
+		copied := make([]api.SkillReference, len(projectRefs))
+		copy(copied, projectRefs)
+		projectRefs = copied
+	}
 	for i := range projectRefs {
 		projectRefs[i].Scope = "project"
 	}
 
 	// Template refs are already in InlineConfig.Skills (highest precedence).
-	templateRefs := agent.AppliedConfig.InlineConfig.Skills
-	for i := range templateRefs {
-		templateRefs[i].Scope = "template"
+	// Copy the slice to avoid mutating the caller's InlineConfig.Skills in place.
+	var templateRefs []api.SkillReference
+	if len(agent.AppliedConfig.InlineConfig.Skills) > 0 {
+		templateRefs = make([]api.SkillReference, len(agent.AppliedConfig.InlineConfig.Skills))
+		copy(templateRefs, agent.AppliedConfig.InlineConfig.Skills)
+		for i := range templateRefs {
+			templateRefs[i].Scope = "template"
+		}
 	}
 
 	// Merge: hub → user → project → template (lowest to highest precedence).

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -447,6 +447,9 @@ func (s *Server) mergeInjectedSkills(ctx context.Context, agent *store.Agent, pr
 			hubRefs = append(setting.System, setting.UserDefined...)
 		}
 	}
+	for i := range hubRefs {
+		hubRefs[i].Scope = "hub"
+	}
 
 	// Fetch user-scope injected skills.
 	var userRefs []api.SkillReference
@@ -461,6 +464,9 @@ func (s *Server) mergeInjectedSkills(ctx context.Context, agent *store.Agent, pr
 				userRefs = append(userRefs, si.ToSkillReference())
 			}
 		}
+	}
+	for i := range userRefs {
+		userRefs[i].Scope = "user"
 	}
 
 	// Fetch project-scope injected skills.
@@ -477,9 +483,15 @@ func (s *Server) mergeInjectedSkills(ctx context.Context, agent *store.Agent, pr
 			}
 		}
 	}
+	for i := range projectRefs {
+		projectRefs[i].Scope = "project"
+	}
 
 	// Template refs are already in InlineConfig.Skills (highest precedence).
 	templateRefs := agent.AppliedConfig.InlineConfig.Skills
+	for i := range templateRefs {
+		templateRefs[i].Scope = "template"
+	}
 
 	// Merge: hub → user → project → template (lowest to highest precedence).
 	merged := mergeSkillRefs(hubRefs, userRefs, projectRefs, templateRefs)


### PR DESCRIPTION
Replace the S6 hard error in installResolvedSkills with a scope-based precedence dedup pass that resolves destination-name collisions at agent provisioning time.

When two skills from different scopes (hub, user, project, template) produce the same destination directory name but have different URIs, the higher-scope skill now wins deterministically (project > template > user > hub > platform) instead of failing agent creation.

Key changes:
- Add Scope field to api.SkillReference, annotated at all injection sites (hub-side mergeInjectedSkills, local-side MergeScionConfig, all resolvers)
- Add deduplicateByDestName() with scope-based precedence resolution in installResolvedSkills
- Collisions logged as slog.Warn (slog.Debug for optional losers) and recorded in resolved-skills.json via Collisions field on SkillResolutionRecord
- Skills with invalid DestName() pass through dedup for proper error reporting at install time

Files changed: pkg/api/types.go, pkg/agent/skill_resolver.go, pkg/hub/handlers_agent_create_helpers.go, pkg/config/templates.go, pkg/agent/{hub,github,gcp}_skill_resolver.go

10 new/updated tests covering full precedence chain, three-way collisions, DestName error passthrough, optional loser diagnostics, and backward compatibility.

Refs ptone/scion#654