### PR TITLE
fix: web picker generates canonical skill://scion/<slug> URIs

### DIFF
--- a/pkg/hub/handlers_skills_injection_test.go
+++ b/pkg/hub/handlers_skills_injection_test.go
@@ -496,6 +496,45 @@ func TestAddProjectInjectedSkill_RejectsInvalidScheme(t *testing.T) {
 	}
 }
 
+// TestSetProjectInjectedSkills_AcceptsLegacySingleSegmentSkillURI verifies that
+// a bulk PUT containing a legacy skill://<slug> entry (single segment after
+// skill://) does not 400. ParseSkillURI's single-segment heuristic treats this
+// as skill://scion/<slug>. Regression test for ptone/scion#582.
+func TestSetProjectInjectedSkills_AcceptsLegacySingleSegmentSkillURI(t *testing.T) {
+	srv, s, project, alice, _ := setupInjectedSkillsTest(t)
+	ctx := context.Background()
+
+	// Pre-seed a legacy entry in the store (mimics what the old web picker stored).
+	legacy := &store.SkillInjection{
+		Scope:    store.SkillInjectionScopeProject,
+		ScopeID:  project.ID,
+		SkillURI: "skill://scion-process",
+	}
+	require.NoError(t, s.AddSkillInjection(ctx, legacy))
+
+	// Bulk PUT the same list back (this is what save/reorder does).
+	newList := api.SkillInjectionList{
+		Entries: []api.SkillInjectionEntry{
+			{SkillURI: "skill://scion-process"},
+		},
+	}
+	rec := doRequestAsUser(t, srv, alice, http.MethodPut,
+		"/api/v1/projects/"+project.ID+"/injected-skills", newList)
+	require.Equal(t, http.StatusOK, rec.Code, "legacy skill://<slug> must not 400; body: %s", rec.Body.String())
+
+	var resp api.SkillInjectionList
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Entries, 1)
+	assert.Equal(t, "skill://scion-process", resp.Entries[0].SkillURI,
+		"legacy URI must be accepted and returned as-is")
+
+	sis, err := s.ListSkillInjections(ctx, store.SkillInjectionScopeProject, project.ID)
+	require.NoError(t, err)
+	require.Len(t, sis, 1)
+	assert.Equal(t, "skill://scion-process", sis[0].SkillURI,
+		"stored URI must match the legacy form")
+}
+
 // =============================================================================
 // Project-scope: delete
 // =============================================================================

--- a/web/src/components/shared/injected-skills-panel.test.ts
+++ b/web/src/components/shared/injected-skills-panel.test.ts
@@ -869,3 +869,92 @@ describe('injected-skills-panel — discovery state lifecycle', () => {
     expect(el.skippedSkillNames).toEqual([]);
   });
 });
+
+// ── Picker (search-mode) URI generation ───────────────────────────────────
+//
+// Regression test for https://github.com/ptone/scion/issues/582:
+// The skill picker previously generated `skill://<slug>` which was rejected
+// by ParseSkillURI (treated the single segment as a registry, not a name).
+// The fix generates `skill://scion/<slug>` — the canonical two-segment form.
+
+describe('injected-skills-panel — search-mode picker URI', () => {
+  beforeAll(async () => {
+    await import('./injected-skills-panel.js');
+  });
+
+  afterEach(cleanup);
+
+  it('generates skill://scion/<slug> when adding a skill from the picker', async () => {
+    const calls: Call[] = [];
+    const el = await createPanel('project', calls);
+
+    // Simulate selecting a skill in the search dialog.
+    el.dialogOpen = true;
+    el.dialogMode = 'search';
+    el.dialogSelectedSkill = {
+      id: 'test-id',
+      name: 'Security Audit',
+      slug: 'security-audit',
+      scope: 'core',
+      status: 'active',
+      visibility: 'public',
+      created: '2026-01-01',
+      updated: '2026-01-01',
+    };
+    await el.updateComplete;
+
+    // Trigger handleAddSkill via the method (it expects an Event with
+    // preventDefault).
+    await el.handleAddSkill(new Event('submit', { cancelable: true }));
+
+    // The POST must contain the canonical two-segment URI.
+    const posts = calls.filter((c: Call) => c.method === 'POST');
+    expect(posts).toHaveLength(1);
+    expect(posts[0].body.skillUri).toBe('skill://scion/security-audit');
+  });
+
+  it('does NOT generate the old skill://<slug> form (regression guard)', async () => {
+    const calls: Call[] = [];
+    const el = await createPanel('hub', calls);
+
+    el.dialogOpen = true;
+    el.dialogMode = 'search';
+    el.dialogSelectedSkill = {
+      id: 'test-id-2',
+      name: 'Code Review',
+      slug: 'code-review',
+      scope: 'core',
+      status: 'active',
+      visibility: 'public',
+      created: '2026-01-01',
+      updated: '2026-01-01',
+    };
+    await el.updateComplete;
+
+    await el.handleAddSkill(new Event('submit', { cancelable: true }));
+
+    // Hub scope uses PUT. The user_defined array must contain the canonical URI.
+    const puts = calls.filter((c: Call) => c.method === 'PUT');
+    expect(puts).toHaveLength(1);
+    const uris: string[] = puts[0].body.user_defined.map((r: any) => r.uri);
+    expect(uris).toContain('skill://scion/code-review');
+    // The old form must NOT appear.
+    expect(uris).not.toContain('skill://code-review');
+  });
+
+  it('sets dialogError when no skill is selected', async () => {
+    const calls: Call[] = [];
+    const el = await createPanel('project', calls);
+
+    el.dialogOpen = true;
+    el.dialogMode = 'search';
+    el.dialogSelectedSkill = null;
+    await el.updateComplete;
+
+    await el.handleAddSkill(new Event('submit', { cancelable: true }));
+
+    expect(el.dialogError).toBe('Please select a skill from the search results');
+    // No network calls should have been made.
+    expect(calls.filter((c: Call) => c.method === 'POST')).toHaveLength(0);
+  });
+});

--- a/web/src/components/shared/injected-skills-panel.ts
+++ b/web/src/components/shared/injected-skills-panel.ts
@@ -769,8 +769,11 @@ export class ScionInjectedSkillsPanel extends LitElement {
         this.dialogError = 'Please select a skill from the search results';
         return;
       }
-      // Build a skill bank URI from the skill's slug
-      uri = `skill://${this.dialogSelectedSkill.slug}`;
+      // Build a canonical skill bank URI: skill://scion/<slug>
+      // A single-segment form (skill://<slug>) is now accepted by
+      // ParseSkillURI, but the two-segment form is the canonical stored
+      // shape and avoids ambiguity with the registry field.
+      uri = `skill://scion/${this.dialogSelectedSkill.slug}`;
     } else {
       const raw = this.dialogUri.trim();
       if (!raw) {


### PR DESCRIPTION
Since upstream PR 866 (skill URI validation), the web skill picker generated skill://slug URIs that the hub rejects (a single segment after skill:// is parsed as the registry, not the name). Fixes the picker to generate the canonical two-segment form skill://scion/slug instead, matching what ParseSkillURI expects. Adds test coverage for the picker URI generation and confirms bulk PUT still accepts legacy skill://slug stored entries without erroring.
Files: injected-skills-panel.ts (1-line production fix) plus new web and Go tests. Fork review approved clean on first pass, CI green.
Ref: ptone/scion#582
