### PR TITLE
fix: middle-truncate skill URIs to preserve skill name

### DIFF
--- a/web/src/components/shared/injected-skills-panel.ts
+++ b/web/src/components/shared/injected-skills-panel.ts
@@ -1094,6 +1094,9 @@ export class ScionInjectedSkillsPanel extends LitElement {
    * (last path segment) is always fully visible.
    */
   private renderMiddleTruncatedUri(uri: string) {
+    if (!uri) {
+      return nothing;
+    }
     const lastSlash = uri.lastIndexOf('/');
     if (lastSlash === -1 || lastSlash === uri.length - 1) {
       // No path separator or trailing slash — show the whole URI as-is

--- a/web/src/components/shared/injected-skills-panel.ts
+++ b/web/src/components/shared/injected-skills-panel.ts
@@ -291,6 +291,9 @@ export class ScionInjectedSkillsPanel extends LitElement {
         color: var(--scion-text-muted, #64748b);
         margin-top: 0.125rem;
         display: inline-flex;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
         max-width: 300px;
       }
 

--- a/web/src/components/shared/injected-skills-panel.ts
+++ b/web/src/components/shared/injected-skills-panel.ts
@@ -290,10 +290,21 @@ export class ScionInjectedSkillsPanel extends LitElement {
         font-size: 0.75rem;
         color: var(--scion-text-muted, #64748b);
         margin-top: 0.125rem;
+        display: inline-flex;
+        max-width: 300px;
+      }
+
+      .skill-uri-prefix {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        max-width: 300px;
+        flex-shrink: 1;
+        min-width: 0;
+      }
+
+      .skill-uri-name {
+        white-space: nowrap;
+        flex-shrink: 0;
       }
 
       .skill-info {
@@ -1074,6 +1085,28 @@ export class ScionInjectedSkillsPanel extends LitElement {
     `;
   }
 
+  /**
+   * Renders a skill URI with middle-truncation: the prefix (scheme + path)
+   * truncates with an ellipsis when space is tight, while the skill name
+   * (last path segment) is always fully visible.
+   */
+  private renderMiddleTruncatedUri(uri: string) {
+    const lastSlash = uri.lastIndexOf('/');
+    if (lastSlash === -1 || lastSlash === uri.length - 1) {
+      // No path separator or trailing slash — show the whole URI as-is
+      // (still needs nowrap to avoid wrapping in the flex container)
+      return html`<span class="skill-uri" title=${uri}
+        ><span class="skill-uri-name">${uri}</span></span
+      >`;
+    }
+    const prefix = uri.slice(0, lastSlash + 1);
+    const name = uri.slice(lastSlash + 1);
+    return html`<span class="skill-uri" title=${uri}
+      ><span class="skill-uri-prefix">${prefix}</span
+      ><span class="skill-uri-name">${name}</span></span
+    >`;
+  }
+
   private renderDescription(): string {
     switch (this.scope) {
       case 'project':
@@ -1159,7 +1192,7 @@ export class ScionInjectedSkillsPanel extends LitElement {
             ${row.skillName
               ? html`<span class="skill-name">${row.skillName}</span>`
               : nothing}
-            <span class="skill-uri">${row.uri}</span>
+            ${this.renderMiddleTruncatedUri(row.uri)}
             ${row.skillSlug
               ? html`<span class="skill-uri">/${row.skillSlug}</span>`
               : nothing}


### PR DESCRIPTION
The project-view skill list end-truncated long skill URIs, hiding the skill name (the most important, identifying part, at the end of the URI). Changes to middle-truncation instead: a shrinkable prefix span (text-overflow: ellipsis) plus a fixed-width skill-name span that is always fully visible, full URI available via title on hover.
Single file: web/src/components/shared/injected-skills-panel.ts. Two independent fork review rounds, both approved.
Ref: ptone/scion#665
