### PR TITLE
feat(scheduler): make interval and concurrency configurable

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1315,6 +1315,8 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 		SoftDeleteRetainFiles:        cfg.Hub.SoftDeleteRetainFiles,
 		AdminMode:                    adminMode,
 		MaintenanceMessage:           maintenanceMessage,
+		SchedulerIntervalSeconds:     cfg.Scheduler.IntervalSeconds,
+		SchedulerMaxConcurrency:      cfg.Scheduler.MaxConcurrency,
 		Workstation:                  !hostedMode,
 		DevUserConfig: hub.DevUserConfig{
 			Username:    cfg.Auth.Username,

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1316,7 +1316,7 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 		AdminMode:                    adminMode,
 		MaintenanceMessage:           maintenanceMessage,
 		SchedulerIntervalSeconds:     cfg.Scheduler.IntervalSeconds,
-		SchedulerMaxConcurrency:      cfg.Scheduler.MaxConcurrency,
+		SchedulerMaxConcurrency:      cfg.Scheduler.MaxConcurrency, // *int: nil = use default, *0 = unlimited
 		Workstation:                  !hostedMode,
 		DevUserConfig: hub.DevUserConfig{
 			Username:    cfg.Auth.Username,

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -364,7 +364,8 @@ type GlobalConfig struct {
 type SchedulerConfig struct {
 	// IntervalSeconds is the root ticker interval in seconds. Default: 60.
 	IntervalSeconds int `json:"intervalSeconds,omitempty" yaml:"intervalSeconds,omitempty" koanf:"intervalSeconds"`
-	// MaxConcurrency limits simultaneous recurring handlers per tick. Default: 0 (unlimited).
+	// MaxConcurrency limits simultaneous recurring handlers per tick.
+	// When 0 (unset), the scheduler uses its built-in default of 2.
 	MaxConcurrency int `json:"maxConcurrency,omitempty" yaml:"maxConcurrency,omitempty" koanf:"maxConcurrency"`
 }
 

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -355,6 +355,17 @@ type GlobalConfig struct {
 
 	// GitHub App settings
 	GitHubApp GitHubAppConfig `json:"githubApp" yaml:"githubApp" koanf:"githubApp"`
+
+	// Scheduler settings
+	Scheduler SchedulerConfig `json:"scheduler" yaml:"scheduler" koanf:"scheduler"`
+}
+
+// SchedulerConfig holds configuration for the Hub background task scheduler.
+type SchedulerConfig struct {
+	// IntervalSeconds is the root ticker interval in seconds. Default: 60.
+	IntervalSeconds int `json:"intervalSeconds,omitempty" yaml:"intervalSeconds,omitempty" koanf:"intervalSeconds"`
+	// MaxConcurrency limits simultaneous recurring handlers per tick. Default: 0 (unlimited).
+	MaxConcurrency int `json:"maxConcurrency,omitempty" yaml:"maxConcurrency,omitempty" koanf:"maxConcurrency"`
 }
 
 // GitHubAppConfig holds configuration for the Hub's GitHub App integration.

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -365,8 +365,9 @@ type SchedulerConfig struct {
 	// IntervalSeconds is the root ticker interval in seconds. Default: 60.
 	IntervalSeconds int `json:"intervalSeconds,omitempty" yaml:"intervalSeconds,omitempty" koanf:"intervalSeconds"`
 	// MaxConcurrency limits simultaneous recurring handlers per tick.
-	// When 0 (unset), the scheduler uses its built-in default of 2.
-	MaxConcurrency int `json:"maxConcurrency,omitempty" yaml:"maxConcurrency,omitempty" koanf:"maxConcurrency"`
+	// When nil (unset), the scheduler uses its built-in default of 2.
+	// Set to 0 for unlimited (pre-fix behavior).
+	MaxConcurrency *int `json:"maxConcurrency,omitempty" yaml:"maxConcurrency,omitempty" koanf:"maxConcurrency"`
 }
 
 // GitHubAppConfig holds configuration for the Hub's GitHub App integration.

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -76,7 +76,8 @@
           "default": "text",
           "x-env-var": "SCION_SERVER_LOG_FORMAT",
           "x-since": "1"
-        }
+        },
+        "scheduler": { "$ref": "#/$defs/serverScheduler" }
       },
       "additionalProperties": false
     },
@@ -940,6 +941,30 @@
         "gcp_project_id": { "type": "string", "x-env-var": "SCION_SERVER_SECRETS_GCPPROJECTID" },
         "gcp_credentials": { "type": "string", "x-env-var": "SCION_SERVER_SECRETS_GCPCREDENTIALS" }
       }
+    },
+    "serverScheduler": {
+      "type": "object",
+      "description": "Hub background task scheduler settings. Controls tick frequency and concurrency to tune DB load.",
+      "x-since": "1",
+      "properties": {
+        "interval_seconds": {
+          "type": "integer",
+          "minimum": 10,
+          "default": 60,
+          "description": "Root ticker interval in seconds. All recurring handlers fire at multiples of this interval. Increasing this value reduces DB connection pressure on small deployments.",
+          "x-env-var": "SCION_SERVER_SCHEDULER_INTERVAL_SECONDS",
+          "x-since": "1"
+        },
+        "max_concurrency": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "Maximum number of recurring handlers that may run simultaneously in a single tick. 0 means unlimited. Setting to 2-3 prevents all handlers from competing for DB connections at once.",
+          "x-env-var": "SCION_SERVER_SCHEDULER_MAX_CONCURRENCY",
+          "x-since": "1"
+        }
+      },
+      "additionalProperties": false
     },
     "telemetryConfig": {
       "type": "object",

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -958,8 +958,8 @@
         "max_concurrency": {
           "type": "integer",
           "minimum": 0,
-          "default": 0,
-          "description": "Maximum number of recurring handlers that may run simultaneously in a single tick. 0 means unlimited. Setting to 2-3 prevents all handlers from competing for DB connections at once.",
+          "default": 2,
+          "description": "Maximum number of recurring handlers that may run simultaneously in a single tick. Default 2 to prevent DB connection pool saturation on small deployments. Set to 0 for unlimited (pre-fix behavior).",
           "x-env-var": "SCION_SERVER_SCHEDULER_MAX_CONCURRENCY",
           "x-since": "1"
         }

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -354,9 +354,10 @@ type V1SchedulerConfig struct {
 	// Increasing this value reduces DB connection pressure on small deployments.
 	IntervalSeconds int `json:"interval_seconds,omitempty" yaml:"interval_seconds,omitempty" koanf:"interval_seconds"`
 	// MaxConcurrency limits the number of recurring handlers that may run
-	// simultaneously in a single tick. Default: 0 (unlimited).
-	// On resource-constrained deployments, setting this to 2-3 prevents
-	// all handlers from competing for DB connections at once.
+	// simultaneously in a single tick. When unset (0), the scheduler uses its
+	// built-in default of 2, so the fix for issue #367 (DB connection pool
+	// saturation) is active out-of-the-box. Set to a higher value to allow
+	// more parallel handlers on larger deployments.
 	MaxConcurrency int `json:"max_concurrency,omitempty" yaml:"max_concurrency,omitempty" koanf:"max_concurrency"`
 }
 

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -354,11 +354,11 @@ type V1SchedulerConfig struct {
 	// Increasing this value reduces DB connection pressure on small deployments.
 	IntervalSeconds int `json:"interval_seconds,omitempty" yaml:"interval_seconds,omitempty" koanf:"interval_seconds"`
 	// MaxConcurrency limits the number of recurring handlers that may run
-	// simultaneously in a single tick. When unset (0), the scheduler uses its
-	// built-in default of 2, so the fix for issue #367 (DB connection pool
-	// saturation) is active out-of-the-box. Set to a higher value to allow
-	// more parallel handlers on larger deployments.
-	MaxConcurrency int `json:"max_concurrency,omitempty" yaml:"max_concurrency,omitempty" koanf:"max_concurrency"`
+	// simultaneously in a single tick. When nil (unset), the scheduler uses
+	// its built-in default of 2, so the fix for issue #367 (DB connection
+	// pool saturation) is active out-of-the-box. Set to 0 for unlimited
+	// (pre-fix behavior), or a higher value for larger deployments.
+	MaxConcurrency *int `json:"max_concurrency,omitempty" yaml:"max_concurrency,omitempty" koanf:"max_concurrency"`
 }
 
 // V1NotificationChannelConfig holds configuration for an external notification channel.
@@ -1537,7 +1537,7 @@ func ConvertV1ServerToGlobalConfig(v1 *V1ServerConfig) *GlobalConfig {
 	// Scheduler
 	if v1.Scheduler != nil {
 		gc.Scheduler.IntervalSeconds = v1.Scheduler.IntervalSeconds
-		gc.Scheduler.MaxConcurrency = v1.Scheduler.MaxConcurrency
+		gc.Scheduler.MaxConcurrency = v1.Scheduler.MaxConcurrency // both are *int; nil propagates
 	}
 
 	return &gc
@@ -1695,7 +1695,7 @@ func ConvertGlobalToV1ServerConfig(gc *GlobalConfig) *V1ServerConfig {
 	}
 
 	// Scheduler config
-	if gc.Scheduler.IntervalSeconds != 0 || gc.Scheduler.MaxConcurrency != 0 {
+	if gc.Scheduler.IntervalSeconds != 0 || gc.Scheduler.MaxConcurrency != nil {
 		v1.Scheduler = &V1SchedulerConfig{
 			IntervalSeconds: gc.Scheduler.IntervalSeconds,
 			MaxConcurrency:  gc.Scheduler.MaxConcurrency,

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -329,6 +329,9 @@ type V1ServerConfig struct {
 
 	// GitHubApp configures the Hub's GitHub App integration for agent git authentication.
 	GitHubApp *V1GitHubAppConfig `json:"github_app,omitempty" yaml:"github_app,omitempty" koanf:"github_app"`
+
+	// Scheduler configures the Hub background task scheduler.
+	Scheduler *V1SchedulerConfig `json:"scheduler,omitempty" yaml:"scheduler,omitempty" koanf:"scheduler"`
 }
 
 // V1GitHubAppConfig holds the GitHub App configuration in settings.yaml format.
@@ -340,6 +343,21 @@ type V1GitHubAppConfig struct {
 	APIBaseURL      string `json:"api_base_url,omitempty" yaml:"api_base_url,omitempty" koanf:"api_base_url"`
 	WebhooksEnabled bool   `json:"webhooks_enabled,omitempty" yaml:"webhooks_enabled,omitempty" koanf:"webhooks_enabled"`
 	InstallationURL string `json:"installation_url,omitempty" yaml:"installation_url,omitempty" koanf:"installation_url"`
+}
+
+// V1SchedulerConfig holds configuration for the Hub background task scheduler.
+// Controls the tick interval and concurrency of recurring maintenance tasks
+// to allow operators to tune scheduler load to match DB capacity.
+type V1SchedulerConfig struct {
+	// IntervalSeconds is the root ticker interval in seconds. All recurring
+	// handlers fire at multiples of this interval. Default: 60 (1 minute).
+	// Increasing this value reduces DB connection pressure on small deployments.
+	IntervalSeconds int `json:"interval_seconds,omitempty" yaml:"interval_seconds,omitempty" koanf:"interval_seconds"`
+	// MaxConcurrency limits the number of recurring handlers that may run
+	// simultaneously in a single tick. Default: 0 (unlimited).
+	// On resource-constrained deployments, setting this to 2-3 prevents
+	// all handlers from competing for DB connections at once.
+	MaxConcurrency int `json:"max_concurrency,omitempty" yaml:"max_concurrency,omitempty" koanf:"max_concurrency"`
 }
 
 // V1NotificationChannelConfig holds configuration for an external notification channel.
@@ -1040,6 +1058,8 @@ var knownCompoundFields = []string{
 	"soft_delete_retention",
 	"authorized_domains",
 	"platform_auth_sa",
+	"interval_seconds",
+	"max_concurrency",
 	"oidc_audience",
 	"jwks_url",
 	"broker_nickname",
@@ -1134,7 +1154,8 @@ func mapEnvKeyRecursive(key string) string {
 func isSectionName(name string) bool {
 	switch name {
 	case "hub", "broker", "database", "auth", "oauth", "storage", "secrets", "cors",
-		"web", "cli", "device", "google", "github", "proxy", "iap", "transport":
+		"web", "cli", "device", "google", "github", "proxy", "iap", "transport",
+		"scheduler":
 		return true
 	}
 	return false
@@ -1512,6 +1533,12 @@ func ConvertV1ServerToGlobalConfig(v1 *V1ServerConfig) *GlobalConfig {
 		gc.GitHubApp.InstallationURL = v1.GitHubApp.InstallationURL
 	}
 
+	// Scheduler
+	if v1.Scheduler != nil {
+		gc.Scheduler.IntervalSeconds = v1.Scheduler.IntervalSeconds
+		gc.Scheduler.MaxConcurrency = v1.Scheduler.MaxConcurrency
+	}
+
 	return &gc
 }
 
@@ -1663,6 +1690,14 @@ func ConvertGlobalToV1ServerConfig(gc *GlobalConfig) *V1ServerConfig {
 			APIBaseURL:      gc.GitHubApp.APIBaseURL,
 			WebhooksEnabled: gc.GitHubApp.WebhooksEnabled,
 			InstallationURL: gc.GitHubApp.InstallationURL,
+		}
+	}
+
+	// Scheduler config
+	if gc.Scheduler.IntervalSeconds != 0 || gc.Scheduler.MaxConcurrency != 0 {
+		v1.Scheduler = &V1SchedulerConfig{
+			IntervalSeconds: gc.Scheduler.IntervalSeconds,
+			MaxConcurrency:  gc.Scheduler.MaxConcurrency,
 		}
 	}
 

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -4000,6 +4000,62 @@ func TestWorkspaceStorageConfig_BackendUnset_IsLocal(t *testing.T) {
 	assert.Nil(t, ws.NFS, "no NFS block when backend is local/empty")
 }
 
+// ============================================================================
+// Scheduler Config Tests
+// ============================================================================
+
+func TestConvertV1ServerToGlobalConfig_Scheduler(t *testing.T) {
+	v1 := &V1ServerConfig{
+		Scheduler: &V1SchedulerConfig{
+			IntervalSeconds: 120,
+			MaxConcurrency:  3,
+		},
+	}
+	gc := ConvertV1ServerToGlobalConfig(v1)
+	assert.Equal(t, 120, gc.Scheduler.IntervalSeconds)
+	assert.Equal(t, 3, gc.Scheduler.MaxConcurrency)
+}
+
+func TestConvertV1ServerToGlobalConfig_SchedulerNil(t *testing.T) {
+	v1 := &V1ServerConfig{}
+	gc := ConvertV1ServerToGlobalConfig(v1)
+	assert.Equal(t, 0, gc.Scheduler.IntervalSeconds, "nil scheduler should leave defaults (zero)")
+	assert.Equal(t, 0, gc.Scheduler.MaxConcurrency, "nil scheduler should leave defaults (zero)")
+}
+
+func TestConvertGlobalToV1ServerConfig_Scheduler(t *testing.T) {
+	gc := DefaultGlobalConfig()
+	gc.Scheduler.IntervalSeconds = 180
+	gc.Scheduler.MaxConcurrency = 2
+	v1 := ConvertGlobalToV1ServerConfig(&gc)
+	require.NotNil(t, v1.Scheduler)
+	assert.Equal(t, 180, v1.Scheduler.IntervalSeconds)
+	assert.Equal(t, 2, v1.Scheduler.MaxConcurrency)
+}
+
+func TestConvertGlobalToV1ServerConfig_SchedulerZeroOmitted(t *testing.T) {
+	gc := DefaultGlobalConfig()
+	// Zero values — scheduler block should not be emitted
+	v1 := ConvertGlobalToV1ServerConfig(&gc)
+	assert.Nil(t, v1.Scheduler, "zero-value scheduler should be omitted in V1")
+}
+
+func TestVersionedEnvKeyMapper_Scheduler(t *testing.T) {
+	tests := []struct {
+		env  string
+		want string
+	}{
+		{"SCION_SERVER_SCHEDULER_INTERVAL_SECONDS", "server.scheduler.interval_seconds"},
+		{"SCION_SERVER_SCHEDULER_MAX_CONCURRENCY", "server.scheduler.max_concurrency"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.env, func(t *testing.T) {
+			got := versionedEnvKeyMapper(tt.env)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // --- Helper ---
 
 func boolPtr(b bool) *bool {

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -4008,36 +4008,56 @@ func TestConvertV1ServerToGlobalConfig_Scheduler(t *testing.T) {
 	v1 := &V1ServerConfig{
 		Scheduler: &V1SchedulerConfig{
 			IntervalSeconds: 120,
-			MaxConcurrency:  3,
+			MaxConcurrency:  intPtr(3),
 		},
 	}
 	gc := ConvertV1ServerToGlobalConfig(v1)
 	assert.Equal(t, 120, gc.Scheduler.IntervalSeconds)
-	assert.Equal(t, 3, gc.Scheduler.MaxConcurrency)
+	require.NotNil(t, gc.Scheduler.MaxConcurrency)
+	assert.Equal(t, 3, *gc.Scheduler.MaxConcurrency)
 }
 
 func TestConvertV1ServerToGlobalConfig_SchedulerNil(t *testing.T) {
 	v1 := &V1ServerConfig{}
 	gc := ConvertV1ServerToGlobalConfig(v1)
 	assert.Equal(t, 0, gc.Scheduler.IntervalSeconds, "nil scheduler should leave defaults (zero)")
-	assert.Equal(t, 0, gc.Scheduler.MaxConcurrency, "nil scheduler should leave defaults (zero)")
+	assert.Nil(t, gc.Scheduler.MaxConcurrency, "nil scheduler should leave MaxConcurrency nil (use scheduler default)")
 }
 
 func TestConvertGlobalToV1ServerConfig_Scheduler(t *testing.T) {
 	gc := DefaultGlobalConfig()
 	gc.Scheduler.IntervalSeconds = 180
-	gc.Scheduler.MaxConcurrency = 2
+	gc.Scheduler.MaxConcurrency = intPtr(2)
 	v1 := ConvertGlobalToV1ServerConfig(&gc)
 	require.NotNil(t, v1.Scheduler)
 	assert.Equal(t, 180, v1.Scheduler.IntervalSeconds)
-	assert.Equal(t, 2, v1.Scheduler.MaxConcurrency)
+	require.NotNil(t, v1.Scheduler.MaxConcurrency)
+	assert.Equal(t, 2, *v1.Scheduler.MaxConcurrency)
 }
 
 func TestConvertGlobalToV1ServerConfig_SchedulerZeroOmitted(t *testing.T) {
 	gc := DefaultGlobalConfig()
-	// Zero values — scheduler block should not be emitted
+	// Zero/nil values — scheduler block should not be emitted
 	v1 := ConvertGlobalToV1ServerConfig(&gc)
 	assert.Nil(t, v1.Scheduler, "zero-value scheduler should be omitted in V1")
+}
+
+func TestSchedulerMaxConcurrency_ExplicitZeroRoundTrips(t *testing.T) {
+	// Regression: explicit max_concurrency=0 (unlimited) must survive the
+	// V1 → Global → V1 round-trip and not be confused with "unset".
+	v1 := &V1ServerConfig{
+		Scheduler: &V1SchedulerConfig{
+			MaxConcurrency: intPtr(0),
+		},
+	}
+	gc := ConvertV1ServerToGlobalConfig(v1)
+	require.NotNil(t, gc.Scheduler.MaxConcurrency, "explicit 0 must not be nil")
+	assert.Equal(t, 0, *gc.Scheduler.MaxConcurrency)
+
+	v1Out := ConvertGlobalToV1ServerConfig(gc)
+	require.NotNil(t, v1Out.Scheduler, "scheduler block must be emitted for explicit 0")
+	require.NotNil(t, v1Out.Scheduler.MaxConcurrency)
+	assert.Equal(t, 0, *v1Out.Scheduler.MaxConcurrency)
 }
 
 func TestVersionedEnvKeyMapper_Scheduler(t *testing.T) {
@@ -4060,4 +4080,8 @@ func TestVersionedEnvKeyMapper_Scheduler(t *testing.T) {
 
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+func intPtr(i int) *int {
+	return &i
 }

--- a/pkg/hub/scheduler.go
+++ b/pkg/hub/scheduler.go
@@ -52,10 +52,10 @@ type Scheduler struct {
 	MaxJitter time.Duration
 
 	// MaxConcurrency limits the number of recurring handlers that may execute
-	// simultaneously in a single tick. When set to 0 (the default), all
-	// eligible handlers run concurrently. On resource-constrained deployments,
-	// setting this to a small number (e.g. 2-3) prevents all handlers from
-	// competing for DB connections at once.
+	// simultaneously in a single tick. Defaults to defaultMaxConcurrency (2)
+	// to prevent all handlers from competing for DB connections at once —
+	// the original issue (#367) showed 6+ handlers saturating a small DB's
+	// connection pool. Set to 0 for unlimited (pre-#367 behavior).
 	MaxConcurrency int
 
 	// Recurring handlers
@@ -109,28 +109,35 @@ func WithTickInterval(d time.Duration) SchedulerOption {
 }
 
 // WithMaxConcurrency limits simultaneous recurring handler goroutines per tick.
-// Zero (the default) means unlimited.
+// Values > 0 set the limit; 0 explicitly disables the limit (unlimited).
+// Negative values are ignored (default preserved).
 func WithMaxConcurrency(n int) SchedulerOption {
 	return func(s *Scheduler) {
-		if n > 0 {
+		if n >= 0 {
 			s.MaxConcurrency = n
 		}
 	}
 }
 
-// NewScheduler creates a new Scheduler with a 1-minute root ticker interval
-// and a 30-second max jitter to desynchronize recurring handlers.
-// Optional SchedulerOption values can override the default interval and
-// concurrency limit.
+// defaultMaxConcurrency is the out-of-the-box limit on simultaneous recurring
+// handlers per tick. Set to 2 so the fix for issue #367 (6+ handlers
+// saturating a small DB's connection pool) is active without configuration.
+const defaultMaxConcurrency = 2
+
+// NewScheduler creates a new Scheduler with a 1-minute root ticker interval,
+// a 30-second max jitter, and a default max concurrency of 2 to prevent
+// overwhelming small DB connection pools.
+// Optional SchedulerOption values can override the defaults.
 func NewScheduler(st store.Store, log *slog.Logger, opts ...SchedulerOption) *Scheduler {
 	s := &Scheduler{
-		store:         st,
-		tickInterval:  1 * time.Minute,
-		MaxJitter:     maxJitter,
-		timers:        make(map[string]*scheduledTimer),
-		eventHandlers: make(map[string]EventHandler),
-		log:           log,
-		stopCh:        make(chan struct{}),
+		store:          st,
+		tickInterval:   1 * time.Minute,
+		MaxJitter:      maxJitter,
+		MaxConcurrency: defaultMaxConcurrency,
+		timers:         make(map[string]*scheduledTimer),
+		eventHandlers:  make(map[string]EventHandler),
+		log:            log,
+		stopCh:         make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -289,12 +296,15 @@ const maxJitter = 30 * time.Second
 
 // runRecurringHandlers invokes all handlers whose interval divides the current
 // tick count. Each handler runs in its own goroutine with a timeout context.
-// A random jitter (0–MaxJitter) is added before each invocation so background
-// tasks desynchronize and avoid saturating the DB connection pool.
 //
-// When MaxConcurrency > 0, a semaphore limits the number of handlers running
-// simultaneously, preventing resource-constrained deployments from being
-// overwhelmed by concurrent background work.
+// The execution pipeline is: jitter sleep → semaphore acquire → handler work.
+// Jitter runs BEFORE the semaphore so handlers don't hold concurrency slots
+// during dead sleep time — the jitter spreads arrivals at the semaphore over
+// the MaxJitter window, and only actual DB work counts against the limit.
+//
+// When MaxConcurrency > 0 (default: 2), a semaphore limits the number of
+// handlers doing real work simultaneously, preventing resource-constrained
+// deployments from being overwhelmed by concurrent background tasks.
 func (s *Scheduler) runRecurringHandlers(ctx context.Context) {
 	// Collect eligible handlers for this tick.
 	var eligible []RecurringHandler
@@ -316,6 +326,22 @@ func (s *Scheduler) runRecurringHandlers(ctx context.Context) {
 	for _, h := range eligible {
 		handler := h // capture loop variable
 		go func() {
+			// Stagger start: sleep a random 0–MaxJitter BEFORE acquiring a
+			// semaphore slot. This spreads arrivals at the semaphore over the
+			// jitter window so handlers don't hold concurrency slots during
+			// dead sleep time.
+			jitter := time.Duration(0)
+			if s.MaxJitter > 0 {
+				jitter = time.Duration(rand.Int63n(int64(s.MaxJitter)))
+			}
+			if jitter > 0 {
+				select {
+				case <-time.After(jitter):
+				case <-ctx.Done():
+					return
+				}
+			}
+
 			// Acquire semaphore slot if concurrency is limited.
 			if sem != nil {
 				select {
@@ -324,18 +350,6 @@ func (s *Scheduler) runRecurringHandlers(ctx context.Context) {
 				case <-ctx.Done():
 					return
 				}
-			}
-
-			// Stagger start: sleep a random 0–MaxJitter so tasks that fire on
-			// the same tick don't all compete for DB connections at once.
-			jitter := time.Duration(0)
-			if s.MaxJitter > 0 {
-				jitter = time.Duration(rand.Int63n(int64(s.MaxJitter)))
-			}
-			select {
-			case <-time.After(jitter):
-			case <-ctx.Done():
-				return
 			}
 
 			handlerCtx, cancel := context.WithTimeout(ctx, 55*time.Second)

--- a/pkg/hub/scheduler.go
+++ b/pkg/hub/scheduler.go
@@ -29,8 +29,8 @@ import (
 type EventHandler func(ctx context.Context, evt store.ScheduledEvent) error
 
 // Scheduler manages recurring and one-shot timers within the Hub server.
-// A single root ticker fires every 1 minute and drives all registered
-// recurring handlers based on their configured interval.
+// A single root ticker fires at a configurable interval (default 1 minute) and
+// drives all registered recurring handlers based on their configured interval.
 //
 // One-shot timers are persisted in the database and scheduled in memory
 // via time.AfterFunc. On startup, expired timers fire immediately; future
@@ -50,6 +50,13 @@ type Scheduler struct {
 	// "thundering herd" where all background tasks hit the DB simultaneously.
 	// Defaults to 30 s in production; tests can set it to 0 for determinism.
 	MaxJitter time.Duration
+
+	// MaxConcurrency limits the number of recurring handlers that may execute
+	// simultaneously in a single tick. When set to 0 (the default), all
+	// eligible handlers run concurrently. On resource-constrained deployments,
+	// setting this to a small number (e.g. 2-3) prevents all handlers from
+	// competing for DB connections at once.
+	MaxConcurrency int
 
 	// Recurring handlers
 	recurring []RecurringHandler
@@ -89,10 +96,34 @@ type scheduledTimer struct {
 	Cancel context.CancelFunc
 }
 
+// SchedulerOption configures optional Scheduler parameters.
+type SchedulerOption func(*Scheduler)
+
+// WithTickInterval overrides the default 1-minute root ticker interval.
+func WithTickInterval(d time.Duration) SchedulerOption {
+	return func(s *Scheduler) {
+		if d > 0 {
+			s.tickInterval = d
+		}
+	}
+}
+
+// WithMaxConcurrency limits simultaneous recurring handler goroutines per tick.
+// Zero (the default) means unlimited.
+func WithMaxConcurrency(n int) SchedulerOption {
+	return func(s *Scheduler) {
+		if n > 0 {
+			s.MaxConcurrency = n
+		}
+	}
+}
+
 // NewScheduler creates a new Scheduler with a 1-minute root ticker interval
 // and a 30-second max jitter to desynchronize recurring handlers.
-func NewScheduler(st store.Store, log *slog.Logger) *Scheduler {
-	return &Scheduler{
+// Optional SchedulerOption values can override the default interval and
+// concurrency limit.
+func NewScheduler(st store.Store, log *slog.Logger, opts ...SchedulerOption) *Scheduler {
+	s := &Scheduler{
 		store:         st,
 		tickInterval:  1 * time.Minute,
 		MaxJitter:     maxJitter,
@@ -101,6 +132,10 @@ func NewScheduler(st store.Store, log *slog.Logger) *Scheduler {
 		log:           log,
 		stopCh:        make(chan struct{}),
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // RegisterEventHandler registers a handler for a specific event type.
@@ -254,45 +289,74 @@ const maxJitter = 30 * time.Second
 
 // runRecurringHandlers invokes all handlers whose interval divides the current
 // tick count. Each handler runs in its own goroutine with a timeout context.
-// A random jitter (0–30 s) is added before each invocation so background tasks
-// desynchronize and avoid saturating the DB connection pool.
+// A random jitter (0–MaxJitter) is added before each invocation so background
+// tasks desynchronize and avoid saturating the DB connection pool.
+//
+// When MaxConcurrency > 0, a semaphore limits the number of handlers running
+// simultaneously, preventing resource-constrained deployments from being
+// overwhelmed by concurrent background work.
 func (s *Scheduler) runRecurringHandlers(ctx context.Context) {
+	// Collect eligible handlers for this tick.
+	var eligible []RecurringHandler
 	for _, h := range s.recurring {
 		if s.tickCount%uint64(h.Interval) == 0 {
-			handler := h // capture loop variable
-			go func() {
-				// Stagger start: sleep a random 0–MaxJitter so tasks that fire on
-				// the same tick don't all compete for DB connections at once.
-				jitter := time.Duration(0)
-				if s.MaxJitter > 0 {
-					jitter = time.Duration(rand.Int63n(int64(s.MaxJitter)))
-				}
+			eligible = append(eligible, h)
+		}
+	}
+	if len(eligible) == 0 {
+		return
+	}
+
+	// Build an optional concurrency-limiting semaphore.
+	var sem chan struct{}
+	if s.MaxConcurrency > 0 {
+		sem = make(chan struct{}, s.MaxConcurrency)
+	}
+
+	for _, h := range eligible {
+		handler := h // capture loop variable
+		go func() {
+			// Acquire semaphore slot if concurrency is limited.
+			if sem != nil {
 				select {
-				case <-time.After(jitter):
+				case sem <- struct{}{}:
+					defer func() { <-sem }()
 				case <-ctx.Done():
 					return
 				}
+			}
 
-				handlerCtx, cancel := context.WithTimeout(ctx, 55*time.Second)
-				defer cancel()
+			// Stagger start: sleep a random 0–MaxJitter so tasks that fire on
+			// the same tick don't all compete for DB connections at once.
+			jitter := time.Duration(0)
+			if s.MaxJitter > 0 {
+				jitter = time.Duration(rand.Int63n(int64(s.MaxJitter)))
+			}
+			select {
+			case <-time.After(jitter):
+			case <-ctx.Done():
+				return
+			}
 
-				start := time.Now()
-				s.log.Debug("Scheduler: running recurring handler", "name", handler.Name, "tick", s.tickCount)
+			handlerCtx, cancel := context.WithTimeout(ctx, 55*time.Second)
+			defer cancel()
 
-				func() {
-					defer func() {
-						if r := recover(); r != nil {
-							s.log.Error("Scheduler: recurring handler panicked",
-								"name", handler.Name, "panic", r)
-						}
-					}()
-					handler.Fn(handlerCtx)
+			start := time.Now()
+			s.log.Debug("Scheduler: running recurring handler", "name", handler.Name, "tick", s.tickCount)
+
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						s.log.Error("Scheduler: recurring handler panicked",
+							"name", handler.Name, "panic", r)
+					}
 				}()
-
-				s.log.Debug("Scheduler: recurring handler completed",
-					"name", handler.Name, "duration", time.Since(start))
+				handler.Fn(handlerCtx)
 			}()
-		}
+
+			s.log.Debug("Scheduler: recurring handler completed",
+				"name", handler.Name, "duration", time.Since(start))
+		}()
 	}
 }
 
@@ -465,11 +529,12 @@ func (s *Scheduler) ScheduleEvent(ctx context.Context, evt store.ScheduledEvent)
 
 // SchedulerStatus holds a point-in-time snapshot of the scheduler's state.
 type SchedulerStatus struct {
-	TickCount     uint64                 `json:"tickCount"`
-	TickInterval  string                 `json:"tickInterval"`
-	Recurring     []RecurringHandlerInfo `json:"recurringHandlers"`
-	EventHandlers []string               `json:"eventHandlers"`
-	ActiveTimers  int                    `json:"activeTimers"`
+	TickCount      uint64                 `json:"tickCount"`
+	TickInterval   string                 `json:"tickInterval"`
+	MaxConcurrency int                    `json:"maxConcurrency"`
+	Recurring      []RecurringHandlerInfo `json:"recurringHandlers"`
+	EventHandlers  []string               `json:"eventHandlers"`
+	ActiveTimers   int                    `json:"activeTimers"`
 }
 
 // RecurringHandlerInfo is the public view of a registered recurring handler.
@@ -498,11 +563,12 @@ func (s *Scheduler) Status() SchedulerStatus {
 	s.mu.Unlock()
 
 	return SchedulerStatus{
-		TickCount:     s.tickCount,
-		TickInterval:  s.tickInterval.String(),
-		Recurring:     recurring,
-		EventHandlers: eventHandlers,
-		ActiveTimers:  activeTimers,
+		TickCount:      s.tickCount,
+		TickInterval:   s.tickInterval.String(),
+		MaxConcurrency: s.MaxConcurrency,
+		Recurring:      recurring,
+		EventHandlers:  eventHandlers,
+		ActiveTimers:   activeTimers,
 	}
 }
 

--- a/pkg/hub/scheduler.go
+++ b/pkg/hub/scheduler.go
@@ -52,11 +52,18 @@ type Scheduler struct {
 	MaxJitter time.Duration
 
 	// MaxConcurrency limits the number of recurring handlers that may execute
-	// simultaneously in a single tick. Defaults to defaultMaxConcurrency (2)
-	// to prevent all handlers from competing for DB connections at once —
-	// the original issue (#367) showed 6+ handlers saturating a small DB's
-	// connection pool. Set to 0 for unlimited (pre-#367 behavior).
+	// simultaneously. Defaults to defaultMaxConcurrency (2) to prevent all
+	// handlers from competing for DB connections at once — the original
+	// issue (#367) showed 6+ handlers saturating a small DB's connection
+	// pool. Set to 0 for unlimited (pre-#367 behavior).
 	MaxConcurrency int
+
+	// sem is the concurrency-limiting semaphore, initialized once in
+	// NewScheduler and shared across all ticks. This ensures the limit
+	// applies globally — slow handlers from tick N still hold slots when
+	// tick N+1 fires, preventing cross-tick concurrency blow-up. Nil when
+	// MaxConcurrency == 0 (unlimited).
+	sem chan struct{}
 
 	// Recurring handlers
 	recurring []RecurringHandler
@@ -141,6 +148,11 @@ func NewScheduler(st store.Store, log *slog.Logger, opts ...SchedulerOption) *Sc
 	}
 	for _, opt := range opts {
 		opt(s)
+	}
+	// Initialize the semaphore once so it is shared across all ticks.
+	// Slow handlers from tick N still hold slots when tick N+1 fires.
+	if s.MaxConcurrency > 0 {
+		s.sem = make(chan struct{}, s.MaxConcurrency)
 	}
 	return s
 }
@@ -301,10 +313,13 @@ const maxJitter = 30 * time.Second
 // Jitter runs BEFORE the semaphore so handlers don't hold concurrency slots
 // during dead sleep time — the jitter spreads arrivals at the semaphore over
 // the MaxJitter window, and only actual DB work counts against the limit.
+// The semaphore (s.sem) is shared across all ticks, so slow handlers from a
+// previous tick still count against the concurrency limit.
 //
-// When MaxConcurrency > 0 (default: 2), a semaphore limits the number of
-// handlers doing real work simultaneously, preventing resource-constrained
-// deployments from being overwhelmed by concurrent background tasks.
+// When MaxConcurrency > 0 (default: 2), s.sem (initialized once in
+// NewScheduler) limits the number of handlers doing real work simultaneously
+// across ALL ticks — slow handlers from tick N still hold slots when tick N+1
+// fires, preventing cross-tick concurrency blow-up.
 func (s *Scheduler) runRecurringHandlers(ctx context.Context) {
 	// Collect eligible handlers for this tick.
 	var eligible []RecurringHandler
@@ -315,12 +330,6 @@ func (s *Scheduler) runRecurringHandlers(ctx context.Context) {
 	}
 	if len(eligible) == 0 {
 		return
-	}
-
-	// Build an optional concurrency-limiting semaphore.
-	var sem chan struct{}
-	if s.MaxConcurrency > 0 {
-		sem = make(chan struct{}, s.MaxConcurrency)
 	}
 
 	for _, h := range eligible {
@@ -343,10 +352,11 @@ func (s *Scheduler) runRecurringHandlers(ctx context.Context) {
 			}
 
 			// Acquire semaphore slot if concurrency is limited.
-			if sem != nil {
+			// s.sem is shared across all ticks (initialized once in NewScheduler).
+			if s.sem != nil {
 				select {
-				case sem <- struct{}{}:
-					defer func() { <-sem }()
+				case s.sem <- struct{}{}:
+					defer func() { <-s.sem }()
 				case <-ctx.Done():
 					return
 				}

--- a/pkg/hub/scheduler_test.go
+++ b/pkg/hub/scheduler_test.go
@@ -1689,6 +1689,55 @@ func TestSchedulerMaxConcurrencyLimitsParallelism(t *testing.T) {
 	}
 }
 
+func TestSchedulerMaxConcurrencyAcrossTicks(t *testing.T) {
+	// Regression: the semaphore must be shared across ticks. If a handler from
+	// tick N is still running when tick N+1 fires, the total running handlers
+	// must not exceed MaxConcurrency. A per-tick local semaphore would allow
+	// each tick to independently reach MaxConcurrency, blowing past the limit.
+	s := NewScheduler(nil, slog.Default(), WithMaxConcurrency(2))
+	s.tickInterval = 40 * time.Millisecond // Ticks faster than handler duration
+	s.MaxJitter = 0
+
+	var (
+		peakConcurrency atomic.Int32
+		currentRunning  atomic.Int32
+	)
+
+	// Register 2 handlers that each take 80ms — longer than the tick interval.
+	// Without cross-tick limiting, tick 0 and tick 1 would each run 2 handlers
+	// (peak = 4). With a shared semaphore, peak must stay ≤ 2.
+	for i := 0; i < 2; i++ {
+		name := fmt.Sprintf("slow-handler-%d", i)
+		s.RegisterRecurring(name, 1, func(_ context.Context) {
+			cur := currentRunning.Add(1)
+			for {
+				old := peakConcurrency.Load()
+				if cur <= old || peakConcurrency.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			time.Sleep(80 * time.Millisecond)
+			currentRunning.Add(-1)
+		})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.Start(ctx)
+	// Let several ticks fire while handlers are still running from previous ticks.
+	time.Sleep(250 * time.Millisecond)
+	s.Stop()
+
+	peak := peakConcurrency.Load()
+	if peak > 2 {
+		t.Errorf("peak concurrency across ticks was %d, expected at most 2 (shared semaphore)", peak)
+	}
+	if peak == 0 {
+		t.Error("no handlers ran")
+	}
+}
+
 func TestSchedulerUnlimitedConcurrency(t *testing.T) {
 	// With MaxConcurrency=0 (unlimited), all handlers should run concurrently.
 	s := NewScheduler(nil, slog.Default(), WithMaxConcurrency(0))

--- a/pkg/hub/scheduler_test.go
+++ b/pkg/hub/scheduler_test.go
@@ -1594,10 +1594,10 @@ func TestWithTickInterval(t *testing.T) {
 }
 
 func TestWithMaxConcurrency(t *testing.T) {
-	// Default is 0 (unlimited).
+	// Default is 2 (conservative limit for issue #367).
 	s := NewScheduler(nil, slog.Default())
-	if s.MaxConcurrency != 0 {
-		t.Fatalf("expected default MaxConcurrency 0, got %d", s.MaxConcurrency)
+	if s.MaxConcurrency != 2 {
+		t.Fatalf("expected default MaxConcurrency 2, got %d", s.MaxConcurrency)
 	}
 
 	// Custom concurrency via option.
@@ -1606,14 +1606,16 @@ func TestWithMaxConcurrency(t *testing.T) {
 		t.Fatalf("expected MaxConcurrency 3, got %d", s.MaxConcurrency)
 	}
 
-	// Zero/negative should be ignored — default preserved.
+	// Zero explicitly disables the limit (unlimited).
 	s = NewScheduler(nil, slog.Default(), WithMaxConcurrency(0))
 	if s.MaxConcurrency != 0 {
-		t.Fatalf("expected default MaxConcurrency 0 for zero input, got %d", s.MaxConcurrency)
+		t.Fatalf("expected MaxConcurrency 0 (unlimited) for zero input, got %d", s.MaxConcurrency)
 	}
+
+	// Negative should be ignored — default preserved.
 	s = NewScheduler(nil, slog.Default(), WithMaxConcurrency(-1))
-	if s.MaxConcurrency != 0 {
-		t.Fatalf("expected default MaxConcurrency 0 for negative input, got %d", s.MaxConcurrency)
+	if s.MaxConcurrency != 2 {
+		t.Fatalf("expected default MaxConcurrency 2 for negative input, got %d", s.MaxConcurrency)
 	}
 }
 
@@ -1689,7 +1691,7 @@ func TestSchedulerMaxConcurrencyLimitsParallelism(t *testing.T) {
 
 func TestSchedulerUnlimitedConcurrency(t *testing.T) {
 	// With MaxConcurrency=0 (unlimited), all handlers should run concurrently.
-	s := NewScheduler(nil, slog.Default()) // default: unlimited
+	s := NewScheduler(nil, slog.Default(), WithMaxConcurrency(0))
 	s.tickInterval = 1 * time.Second
 	s.MaxJitter = 0
 
@@ -1765,12 +1767,12 @@ func TestSchedulerStatusIncludesMaxConcurrency(t *testing.T) {
 	}
 }
 
-func TestSchedulerStatusUnlimited(t *testing.T) {
+func TestSchedulerStatusDefault(t *testing.T) {
 	s := NewScheduler(nil, slog.Default())
 
 	status := s.Status()
-	if status.MaxConcurrency != 0 {
-		t.Errorf("expected MaxConcurrency 0 (unlimited) in status, got %d", status.MaxConcurrency)
+	if status.MaxConcurrency != 2 {
+		t.Errorf("expected default MaxConcurrency 2 in status, got %d", status.MaxConcurrency)
 	}
 }
 

--- a/pkg/hub/scheduler_test.go
+++ b/pkg/hub/scheduler_test.go
@@ -1564,3 +1564,226 @@ func TestSingletonGuard_SkipsWhenHeldByAnother(t *testing.T) {
 		t.Fatalf("handler ran %d times while lock held by another replica; expected 0", got)
 	}
 }
+
+// ============================================================================
+// Configurable Interval & Concurrency Tests
+// ============================================================================
+
+func TestWithTickInterval(t *testing.T) {
+	// Default interval is 1 minute.
+	s := NewScheduler(nil, slog.Default())
+	if s.tickInterval != 1*time.Minute {
+		t.Fatalf("expected default tick interval 1m, got %v", s.tickInterval)
+	}
+
+	// Custom interval via option.
+	s = NewScheduler(nil, slog.Default(), WithTickInterval(2*time.Minute))
+	if s.tickInterval != 2*time.Minute {
+		t.Fatalf("expected tick interval 2m, got %v", s.tickInterval)
+	}
+
+	// Zero/negative interval should be ignored — default preserved.
+	s = NewScheduler(nil, slog.Default(), WithTickInterval(0))
+	if s.tickInterval != 1*time.Minute {
+		t.Fatalf("expected default tick interval 1m for zero input, got %v", s.tickInterval)
+	}
+	s = NewScheduler(nil, slog.Default(), WithTickInterval(-5*time.Second))
+	if s.tickInterval != 1*time.Minute {
+		t.Fatalf("expected default tick interval 1m for negative input, got %v", s.tickInterval)
+	}
+}
+
+func TestWithMaxConcurrency(t *testing.T) {
+	// Default is 0 (unlimited).
+	s := NewScheduler(nil, slog.Default())
+	if s.MaxConcurrency != 0 {
+		t.Fatalf("expected default MaxConcurrency 0, got %d", s.MaxConcurrency)
+	}
+
+	// Custom concurrency via option.
+	s = NewScheduler(nil, slog.Default(), WithMaxConcurrency(3))
+	if s.MaxConcurrency != 3 {
+		t.Fatalf("expected MaxConcurrency 3, got %d", s.MaxConcurrency)
+	}
+
+	// Zero/negative should be ignored — default preserved.
+	s = NewScheduler(nil, slog.Default(), WithMaxConcurrency(0))
+	if s.MaxConcurrency != 0 {
+		t.Fatalf("expected default MaxConcurrency 0 for zero input, got %d", s.MaxConcurrency)
+	}
+	s = NewScheduler(nil, slog.Default(), WithMaxConcurrency(-1))
+	if s.MaxConcurrency != 0 {
+		t.Fatalf("expected default MaxConcurrency 0 for negative input, got %d", s.MaxConcurrency)
+	}
+}
+
+func TestSchedulerCustomTickInterval(t *testing.T) {
+	// Use a custom fast tick interval and verify handlers fire at the right cadence.
+	s := NewScheduler(nil, slog.Default(), WithTickInterval(30*time.Millisecond))
+	s.MaxJitter = 0 // deterministic
+
+	var called atomic.Int32
+	s.RegisterRecurring("fast-ticker", 1, func(_ context.Context) {
+		called.Add(1)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.Start(ctx)
+	time.Sleep(100 * time.Millisecond)
+	s.Stop()
+
+	// With 30ms interval and 100ms sleep, expect ~3-4 ticks (tick 0, 1, 2, 3)
+	if got := called.Load(); got < 2 {
+		t.Errorf("expected at least 2 handler invocations with fast tick, got %d", got)
+	}
+}
+
+func TestSchedulerMaxConcurrencyLimitsParallelism(t *testing.T) {
+	// Register 4 handlers that all fire every tick, but limit concurrency to 2.
+	// Each handler holds a slot for a short time. We verify that no more than 2
+	// are running simultaneously.
+	s := NewScheduler(nil, slog.Default(), WithMaxConcurrency(2))
+	s.tickInterval = 1 * time.Second // Long enough that only tick 0 fires
+	s.MaxJitter = 0
+
+	var (
+		peakConcurrency atomic.Int32
+		currentRunning  atomic.Int32
+	)
+
+	for i := 0; i < 4; i++ {
+		name := fmt.Sprintf("handler-%d", i)
+		s.RegisterRecurring(name, 1, func(_ context.Context) {
+			cur := currentRunning.Add(1)
+			// Track peak
+			for {
+				old := peakConcurrency.Load()
+				if cur <= old || peakConcurrency.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			currentRunning.Add(-1)
+		})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.Start(ctx)
+	// Wait for all handlers to run (each takes 50ms, with concurrency=2
+	// they'll take ~100ms for 4 handlers)
+	time.Sleep(300 * time.Millisecond)
+	s.Stop()
+
+	peak := peakConcurrency.Load()
+	if peak > 2 {
+		t.Errorf("peak concurrency was %d, expected at most 2 (MaxConcurrency limit)", peak)
+	}
+	if peak == 0 {
+		t.Error("no handlers ran — peak concurrency should be > 0")
+	}
+}
+
+func TestSchedulerUnlimitedConcurrency(t *testing.T) {
+	// With MaxConcurrency=0 (unlimited), all handlers should run concurrently.
+	s := NewScheduler(nil, slog.Default()) // default: unlimited
+	s.tickInterval = 1 * time.Second
+	s.MaxJitter = 0
+
+	var (
+		peakConcurrency atomic.Int32
+		currentRunning  atomic.Int32
+	)
+
+	for i := 0; i < 4; i++ {
+		name := fmt.Sprintf("handler-%d", i)
+		s.RegisterRecurring(name, 1, func(_ context.Context) {
+			cur := currentRunning.Add(1)
+			for {
+				old := peakConcurrency.Load()
+				if cur <= old || peakConcurrency.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			currentRunning.Add(-1)
+		})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.Start(ctx)
+	time.Sleep(200 * time.Millisecond)
+	s.Stop()
+
+	peak := peakConcurrency.Load()
+	if peak < 3 {
+		t.Errorf("peak concurrency was %d, expected at least 3 with unlimited concurrency", peak)
+	}
+}
+
+func TestSchedulerJitter(t *testing.T) {
+	// Verify that MaxJitter > 0 causes handlers to start at different times.
+	// We can't test randomness precisely, but we can verify that:
+	// 1. Handlers run when MaxJitter > 0 (they don't get stuck)
+	// 2. They complete within a reasonable window
+	s := NewScheduler(nil, slog.Default())
+	s.tickInterval = 1 * time.Second
+	s.MaxJitter = 100 * time.Millisecond // Short jitter for testing
+
+	var called atomic.Int32
+	s.RegisterRecurring("jittered", 1, func(_ context.Context) {
+		called.Add(1)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.Start(ctx)
+	// Wait for tick 0 handler + jitter to complete
+	time.Sleep(300 * time.Millisecond)
+	s.Stop()
+
+	if got := called.Load(); got < 1 {
+		t.Errorf("jittered handler should have been called at least once, got %d", got)
+	}
+}
+
+func TestSchedulerStatusIncludesMaxConcurrency(t *testing.T) {
+	s := NewScheduler(nil, slog.Default(), WithMaxConcurrency(5))
+
+	status := s.Status()
+	if status.MaxConcurrency != 5 {
+		t.Errorf("expected MaxConcurrency 5 in status, got %d", status.MaxConcurrency)
+	}
+	if status.TickInterval != "1m0s" {
+		t.Errorf("expected TickInterval '1m0s', got %q", status.TickInterval)
+	}
+}
+
+func TestSchedulerStatusUnlimited(t *testing.T) {
+	s := NewScheduler(nil, slog.Default())
+
+	status := s.Status()
+	if status.MaxConcurrency != 0 {
+		t.Errorf("expected MaxConcurrency 0 (unlimited) in status, got %d", status.MaxConcurrency)
+	}
+}
+
+func TestSchedulerMultipleOptions(t *testing.T) {
+	// Apply both options at once.
+	s := NewScheduler(nil, slog.Default(),
+		WithTickInterval(5*time.Minute),
+		WithMaxConcurrency(3),
+	)
+	if s.tickInterval != 5*time.Minute {
+		t.Errorf("expected tick interval 5m, got %v", s.tickInterval)
+	}
+	if s.MaxConcurrency != 3 {
+		t.Errorf("expected MaxConcurrency 3, got %d", s.MaxConcurrency)
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -213,9 +213,9 @@ type ServerConfig struct {
 	// pressure on small deployments.
 	SchedulerIntervalSeconds int
 	// SchedulerMaxConcurrency limits the number of recurring handlers that may
-	// run simultaneously in a single tick. Default: 0 (unlimited). Setting this
-	// to 2-3 prevents all handlers from competing for DB connections at once on
-	// resource-constrained deployments.
+	// run simultaneously in a single tick. When 0 (unset), the scheduler uses
+	// its built-in default of 2 so the fix for issue #367 is active
+	// out-of-the-box.
 	SchedulerMaxConcurrency int
 
 	// Workstation indicates non-production, single-user mode (e.g. local laptop).

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -208,6 +208,16 @@ type ServerConfig struct {
 	// TransportMinter mints transport-layer OIDC tokens for agents.
 	// Nil when TransportMode == "none" or unset.
 	TransportMinter TransportTokenMinter
+	// SchedulerIntervalSeconds is the root ticker interval for the background
+	// scheduler, in seconds. Default: 60. Increasing this reduces DB connection
+	// pressure on small deployments.
+	SchedulerIntervalSeconds int
+	// SchedulerMaxConcurrency limits the number of recurring handlers that may
+	// run simultaneously in a single tick. Default: 0 (unlimited). Setting this
+	// to 2-3 prevents all handlers from competing for DB connections at once on
+	// resource-constrained deployments.
+	SchedulerMaxConcurrency int
+
 	// Workstation indicates non-production, single-user mode (e.g. local laptop).
 	// When true, /api/v1/system/* and other workstation-only endpoints are enabled.
 	Workstation bool
@@ -2600,8 +2610,17 @@ func (s *Server) StartBackgroundServices(ctx context.Context) {
 	}
 	s.mu.Unlock()
 
-	// Initialize and start the scheduler
-	s.scheduler = NewScheduler(s.store, logging.Subsystem("hub.scheduler"))
+	// Initialize and start the scheduler. Interval and concurrency are
+	// configurable via server.scheduler in settings.yaml to let operators
+	// tune background load to match their DB capacity (see issue #367).
+	var schedOpts []SchedulerOption
+	if s.config.SchedulerIntervalSeconds > 0 {
+		schedOpts = append(schedOpts, WithTickInterval(time.Duration(s.config.SchedulerIntervalSeconds)*time.Second))
+	}
+	if s.config.SchedulerMaxConcurrency > 0 {
+		schedOpts = append(schedOpts, WithMaxConcurrency(s.config.SchedulerMaxConcurrency))
+	}
+	s.scheduler = NewScheduler(s.store, logging.Subsystem("hub.scheduler"), schedOpts...)
 	// Recurring sweeps are cluster-wide-once work: under multi-replica Postgres
 	// they must run on a single replica per tick (gated by an advisory lock),
 	// otherwise every replica would publish duplicate offline/stalled events and

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -213,10 +213,10 @@ type ServerConfig struct {
 	// pressure on small deployments.
 	SchedulerIntervalSeconds int
 	// SchedulerMaxConcurrency limits the number of recurring handlers that may
-	// run simultaneously in a single tick. When 0 (unset), the scheduler uses
-	// its built-in default of 2 so the fix for issue #367 is active
-	// out-of-the-box.
-	SchedulerMaxConcurrency int
+	// run simultaneously in a single tick. When nil (unset), the scheduler
+	// uses its built-in default of 2 so the fix for issue #367 is active
+	// out-of-the-box. Pointer-to-0 explicitly means unlimited.
+	SchedulerMaxConcurrency *int
 
 	// Workstation indicates non-production, single-user mode (e.g. local laptop).
 	// When true, /api/v1/system/* and other workstation-only endpoints are enabled.
@@ -2617,8 +2617,8 @@ func (s *Server) StartBackgroundServices(ctx context.Context) {
 	if s.config.SchedulerIntervalSeconds > 0 {
 		schedOpts = append(schedOpts, WithTickInterval(time.Duration(s.config.SchedulerIntervalSeconds)*time.Second))
 	}
-	if s.config.SchedulerMaxConcurrency > 0 {
-		schedOpts = append(schedOpts, WithMaxConcurrency(s.config.SchedulerMaxConcurrency))
+	if s.config.SchedulerMaxConcurrency != nil {
+		schedOpts = append(schedOpts, WithMaxConcurrency(*s.config.SchedulerMaxConcurrency))
 	}
 	s.scheduler = NewScheduler(s.store, logging.Subsystem("hub.scheduler"), schedOpts...)
 	// Recurring sweeps are cluster-wide-once work: under multi-replica Postgres

--- a/settings.yaml.example
+++ b/settings.yaml.example
@@ -218,6 +218,16 @@ server:
   #       config: {}
 
   # -------------------------------------------------------------------------
+  # Layer 0 — Scheduler (restart required)
+  # Controls the Hub's background task scheduler. On resource-constrained
+  # deployments (small CloudSQL, few replicas), increase the interval or
+  # limit concurrency to reduce DB connection pressure.
+  # -------------------------------------------------------------------------
+  # scheduler:
+  #   interval_seconds: 60               # Root ticker interval (default 60s)
+  #   max_concurrency: 0                 # Max simultaneous handlers (0 = unlimited)
+
+  # -------------------------------------------------------------------------
   # Layer 1 — GitHub App (section: github_app)
   # Note: private_key and webhook_secret belong in the secret backend.
   # webhooks_enabled has a Go zero-value limitation: false is

--- a/settings.yaml.example
+++ b/settings.yaml.example
@@ -225,7 +225,7 @@ server:
   # -------------------------------------------------------------------------
   # scheduler:
   #   interval_seconds: 60               # Root ticker interval (default 60s)
-  #   max_concurrency: 0                 # Max simultaneous handlers (0 = unlimited)
+  #   max_concurrency: 2                 # Max simultaneous handlers (default 2)
 
   # -------------------------------------------------------------------------
   # Layer 1 — GitHub App (section: github_app)


### PR DESCRIPTION
The Hub scheduler ran 6+ background tasks every 60s regardless of deployment scale, saturating DB connection pools on small deployments (context deadline exceeded for 6+ hours observed on a db-g1-small instance).
Adds configurable scheduler interval and per-task concurrency (max_concurrency, defaults to 2 so the fix is active out of the box; explicit 0 means unlimited, using a *int so explicit-zero is distinguishable from unset). Adds jitter before semaphore acquire to avoid thundering-herd without holding concurrency slots during sleep.
Three independent fork review rounds (one design-level request-changes on the zero-value bug, since fixed), CI green throughout final round.
Ref: ptone/scion#367
