### PR TITLE
fix(harness): prevent auth backfill from writing implementation name as auth type

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -559,8 +559,8 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		// resolved.Method, which for container-script harnesses is always
 		// "container-script" — an implementation name, not a valid auth type.
 		// Both branches reject harness implementation names so that
-		// already-corrupted scion-agent.json data is cleared on resume
-		// rather than re-persisted indefinitely.
+		// already-corrupted scion-agent.json data is not re-persisted
+		// on resume (opts.HarnessAuth stays empty → no write-back).
 		if opts.HarnessAuth == "" {
 			if authType := resolved.EnvVars["SCION_HARNESS_SELECTED_AUTH"]; authType != "" && !harness.IsHarnessImplementationName(authType) {
 				opts.HarnessAuth = authType

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -558,10 +558,13 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		// Prefer SCION_HARNESS_SELECTED_AUTH (the true auth type) over
 		// resolved.Method, which for container-script harnesses is always
 		// "container-script" — an implementation name, not a valid auth type.
+		// Both branches reject harness implementation names so that
+		// already-corrupted scion-agent.json data is cleared on resume
+		// rather than re-persisted indefinitely.
 		if opts.HarnessAuth == "" {
-			if authType := resolved.EnvVars["SCION_HARNESS_SELECTED_AUTH"]; authType != "" {
+			if authType := resolved.EnvVars["SCION_HARNESS_SELECTED_AUTH"]; authType != "" && !harness.IsHarnessImplementationName(authType) {
 				opts.HarnessAuth = authType
-			} else if resolved.Method != "" {
+			} else if resolved.Method != "" && !harness.IsHarnessImplementationName(resolved.Method) {
 				opts.HarnessAuth = resolved.Method
 			}
 		}

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -552,11 +552,18 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 			}
 		}
 
-		// Persist the resolved auth method so it can be reported to the Hub.
+		// Persist the resolved auth type so it can be reported to the Hub.
 		// For auto-detected auth, opts.HarnessAuth may be empty; capture the
-		// actual method the harness selected (e.g. "api-key", "vertex-ai").
-		if opts.HarnessAuth == "" && resolved.Method != "" {
-			opts.HarnessAuth = resolved.Method
+		// actual auth type (e.g. "api-key", "vertex-ai").
+		// Prefer SCION_HARNESS_SELECTED_AUTH (the true auth type) over
+		// resolved.Method, which for container-script harnesses is always
+		// "container-script" — an implementation name, not a valid auth type.
+		if opts.HarnessAuth == "" {
+			if authType := resolved.EnvVars["SCION_HARNESS_SELECTED_AUTH"]; authType != "" {
+				opts.HarnessAuth = authType
+			} else if resolved.Method != "" {
+				opts.HarnessAuth = resolved.Method
+			}
 		}
 
 		// Surface resolved auth method so CLI can display it

--- a/pkg/harness/container_script_harness.go
+++ b/pkg/harness/container_script_harness.go
@@ -522,7 +522,7 @@ func (c *ContainerScriptHarness) ApplyAuthSettings(agentHome string, resolved *a
 	// the auth type). These are never valid auth types and would crash
 	// the container-side provisioner.
 	explicitType := c.entry.AuthSelectedType
-	if st := resolved.EnvVars["SCION_HARNESS_SELECTED_AUTH"]; st != "" && !isHarnessImplementationName(st) {
+	if st := resolved.EnvVars["SCION_HARNESS_SELECTED_AUTH"]; st != "" && !IsHarnessImplementationName(st) {
 		explicitType = st
 	}
 
@@ -542,13 +542,17 @@ func (c *ContainerScriptHarness) ApplyAuthSettings(agentHome string, resolved *a
 	return c.stageInputFile(agentHome, "auth-candidates.json", data)
 }
 
-// isHarnessImplementationName returns true if s is a known harness
-// implementation/method name rather than a valid auth type. These values
-// can leak into SCION_HARNESS_SELECTED_AUTH via data-corruption bugs and
-// must never be passed through as explicit_type.
-func isHarnessImplementationName(s string) bool {
+// IsHarnessImplementationName returns true if s is a known harness
+// implementation or method name rather than a valid auth type. These
+// values can leak into SCION_HARNESS_SELECTED_AUTH via data-corruption
+// bugs and must never be used as an auth type or explicit_type.
+//
+// The list covers both Implementation values ("container-script",
+// "generic") and Method values ("container-script", "passthrough"),
+// plus the legacy "builtin" provisioner type.
+func IsHarnessImplementationName(s string) bool {
 	switch s {
-	case "container-script", "generic", "builtin":
+	case "container-script", "generic", "builtin", "passthrough":
 		return true
 	}
 	return false

--- a/pkg/harness/container_script_harness.go
+++ b/pkg/harness/container_script_harness.go
@@ -515,8 +515,14 @@ func (c *ContainerScriptHarness) ApplyAuthSettings(agentHome string, resolved *a
 	// auth method correctly on both create and resume; the config
 	// metadata may be empty or stale, causing the container-side
 	// provisioner to auto-detect and potentially pick a wrong method.
+	//
+	// Guard: reject harness implementation names that may have leaked
+	// into SCION_HARNESS_SELECTED_AUTH via a prior data-corruption bug
+	// (the run.go backfill incorrectly wrote resolved.Method instead of
+	// the auth type). These are never valid auth types and would crash
+	// the container-side provisioner.
 	explicitType := c.entry.AuthSelectedType
-	if st := resolved.EnvVars["SCION_HARNESS_SELECTED_AUTH"]; st != "" {
+	if st := resolved.EnvVars["SCION_HARNESS_SELECTED_AUTH"]; st != "" && !isHarnessImplementationName(st) {
 		explicitType = st
 	}
 
@@ -534,6 +540,18 @@ func (c *ContainerScriptHarness) ApplyAuthSettings(agentHome string, resolved *a
 		return fmt.Errorf("marshal auth candidates: %w", err)
 	}
 	return c.stageInputFile(agentHome, "auth-candidates.json", data)
+}
+
+// isHarnessImplementationName returns true if s is a known harness
+// implementation/method name rather than a valid auth type. These values
+// can leak into SCION_HARNESS_SELECTED_AUTH via data-corruption bugs and
+// must never be passed through as explicit_type.
+func isHarnessImplementationName(s string) bool {
+	switch s {
+	case "container-script", "generic", "builtin":
+		return true
+	}
+	return false
 }
 
 // stageFileSecretFiles reads the content of each FileMapping whose ContainerPath

--- a/pkg/harness/container_script_harness_test.go
+++ b/pkg/harness/container_script_harness_test.go
@@ -423,7 +423,7 @@ func TestContainerScriptHarness_ApplyAuthSettings_RejectsHarnessImplementationNa
 
 func TestContainerScriptHarness_ApplyAuthSettings_RejectsAllImplementationNames(t *testing.T) {
 	// Verify that all known harness implementation names are rejected.
-	for _, implName := range []string{"container-script", "generic", "builtin"} {
+	for _, implName := range []string{"container-script", "generic", "builtin", "passthrough"} {
 		t.Run(implName, func(t *testing.T) {
 			h, _ := newTestContainerScriptHarness(t)
 			agentHome := t.TempDir()
@@ -460,6 +460,7 @@ func TestIsHarnessImplementationName(t *testing.T) {
 		{"container-script", true},
 		{"generic", true},
 		{"builtin", true},
+		{"passthrough", true},
 		{"vertex-ai", false},
 		{"api-key", false},
 		{"oauth-token", false},
@@ -468,8 +469,8 @@ func TestIsHarnessImplementationName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isHarnessImplementationName(tt.name); got != tt.want {
-				t.Errorf("isHarnessImplementationName(%q)=%v, want %v", tt.name, got, tt.want)
+			if got := IsHarnessImplementationName(tt.name); got != tt.want {
+				t.Errorf("IsHarnessImplementationName(%q)=%v, want %v", tt.name, got, tt.want)
 			}
 		})
 	}

--- a/pkg/harness/container_script_harness_test.go
+++ b/pkg/harness/container_script_harness_test.go
@@ -369,6 +369,112 @@ func TestContainerScriptHarness_ApplyAuthSettings_ExplicitTypeFallsBackToEntry(t
 	}
 }
 
+func TestContainerScriptHarness_ApplyAuthSettings_RejectsHarnessImplementationName(t *testing.T) {
+	// Regression test for data-corruption bug: if a prior backfill incorrectly
+	// wrote the harness implementation name ("container-script") into
+	// SCION_HARNESS_SELECTED_AUTH, ApplyAuthSettings must discard it and fall
+	// back to c.entry.AuthSelectedType rather than propagating it as
+	// explicit_type — which would crash the container-side provisioner with
+	// "unknown auth type 'container-script'".
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "config.yaml"), "harness: testharness\nimage: scion-test:latest\n")
+	writeFile(t, filepath.Join(dir, "provision.py"), "#!/usr/bin/env python3\nimport sys\nsys.exit(0)\n")
+	entry := config.HarnessConfigEntry{
+		Harness:          "testharness",
+		Image:            "scion-test:latest",
+		AuthSelectedType: "vertex-ai",
+		Provisioner: &config.HarnessProvisionerConfig{
+			Type:             "container-script",
+			InterfaceVersion: 1,
+			Command:          []string{"python3", "$HOME/.scion/harness/provision.py"},
+		},
+	}
+	h, err := NewContainerScriptHarness(dir, entry)
+	if err != nil {
+		t.Fatalf("NewContainerScriptHarness: %v", err)
+	}
+
+	agentHome := t.TempDir()
+	// Simulate corrupted state: SCION_HARNESS_SELECTED_AUTH contains the
+	// harness implementation name instead of a valid auth type.
+	resolved := &api.ResolvedAuth{
+		Method: "container-script",
+		EnvVars: map[string]string{
+			"SCION_HARNESS_SELECTED_AUTH": "container-script",
+			"ANTHROPIC_API_KEY":           "sk-test",
+		},
+	}
+	if err := h.ApplyAuthSettings(agentHome, resolved); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(agentHome, ".scion", "harness", "inputs", "auth-candidates.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	// Must fall back to c.entry.AuthSelectedType, NOT use "container-script".
+	if payload["explicit_type"] != "vertex-ai" {
+		t.Errorf("explicit_type=%v, want vertex-ai (should reject container-script)", payload["explicit_type"])
+	}
+}
+
+func TestContainerScriptHarness_ApplyAuthSettings_RejectsAllImplementationNames(t *testing.T) {
+	// Verify that all known harness implementation names are rejected.
+	for _, implName := range []string{"container-script", "generic", "builtin"} {
+		t.Run(implName, func(t *testing.T) {
+			h, _ := newTestContainerScriptHarness(t)
+			agentHome := t.TempDir()
+			resolved := &api.ResolvedAuth{
+				Method: "container-script",
+				EnvVars: map[string]string{
+					"SCION_HARNESS_SELECTED_AUTH": implName,
+				},
+			}
+			if err := h.ApplyAuthSettings(agentHome, resolved); err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(filepath.Join(agentHome, ".scion", "harness", "inputs", "auth-candidates.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var payload map[string]interface{}
+			if err := json.Unmarshal(data, &payload); err != nil {
+				t.Fatalf("invalid JSON: %v", err)
+			}
+			// explicit_type must NOT be the implementation name.
+			if payload["explicit_type"] == implName {
+				t.Errorf("explicit_type=%v — should have been rejected", implName)
+			}
+		})
+	}
+}
+
+func TestIsHarnessImplementationName(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"container-script", true},
+		{"generic", true},
+		{"builtin", true},
+		{"vertex-ai", false},
+		{"api-key", false},
+		{"oauth-token", false},
+		{"auth-file", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isHarnessImplementationName(tt.name); got != tt.want {
+				t.Errorf("isHarnessImplementationName(%q)=%v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestContainerScriptHarness_ApplyAuthSettings_StagesFileSecrets(t *testing.T) {
 	// Harness entry with a required_files declaration matching Codex auth-file.
 	dir := t.TempDir()


### PR DESCRIPTION
Follow-up to GoogleCloudPlatform/scion#921. That fix was correct but exposed a separate, pre-existing data-corruption bug: a resume-time backfill in run.go wrote the harness implementation name (e.g. container-script) into the auth-type field instead of the actual resolved auth type (e.g. vertex-ai). #921s own fix then faithfully propagated that corrupted value into explicit_type, causing provision.py to crash with unknown auth type container-script for Vertex AI agents that had been resumed.
Fix: the backfill now prefers the actual resolved auth type over the harness method name, and a defensive guard in ApplyAuthSettings rejects known harness-implementation names outright so corrupted persisted data cannot reach the provisioner. Already-corrupted scion-agent.json data is not actively cleared, but the guard prevents it from causing harm or being re-persisted on every future resume.
Files: pkg/agent/run.go, pkg/harness/container_script_harness.go (+test). Two independent fork review rounds with elevated scrutiny (this is a second attempt after #921 alone proved insufficient), both approved, high confidence in the fix.
Ref: ptone/scion#669
