### PR TITLE
feat: add agent port forwarding with hub reverse proxy

### DIFF
--- a/cmd/sciontool/commands/expose.go
+++ b/cmd/sciontool/commands/expose.go
@@ -47,7 +47,7 @@ var exposeCmd = &cobra.Command{
 				return err
 			}
 			if len(ports) == 0 {
-				fmt.Fprintln(os.Stdout, "No ports exposed.")
+				_, _ = fmt.Fprintln(os.Stdout, "No ports exposed.")
 				return nil
 			}
 			for _, p := range ports {
@@ -55,7 +55,7 @@ var exposeCmd = &cobra.Command{
 				if label == "" {
 					label = "-"
 				}
-				fmt.Fprintf(os.Stdout, "%d\t%s\t%s\n", p.Port, label, p.URL)
+				_, _ = fmt.Fprintf(os.Stdout, "%d\t%s\t%s\n", p.Port, label, p.URL)
 			}
 			return nil
 		}
@@ -74,7 +74,7 @@ var exposeCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(os.Stdout, "Port %d exposed.\nURL: %s\nBase path: %s\n", resp.Port, resp.URL, resp.BasePath)
+		_, _ = fmt.Fprintf(os.Stdout, "Port %d exposed.\nURL: %s\nBase path: %s\n", resp.Port, resp.URL, resp.BasePath)
 		return nil
 	},
 }
@@ -97,7 +97,7 @@ var unexposeCmd = &cobra.Command{
 		if err := client.DeletePort(ctx, port); err != nil {
 			return err
 		}
-		fmt.Fprintf(os.Stdout, "Port %d unexposed.\n", port)
+		_, _ = fmt.Fprintf(os.Stdout, "Port %d unexposed.\n", port)
 		return nil
 	},
 }

--- a/cmd/sciontool/commands/expose.go
+++ b/cmd/sciontool/commands/expose.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	scionhub "github.com/GoogleCloudPlatform/scion/pkg/sciontool/hub"
+	"github.com/spf13/cobra"
+)
+
+var (
+	exposeLabel string
+	exposeHost  string
+	exposeList  bool
+)
+
+var exposeCmd = &cobra.Command{
+	Use:   "expose [port]",
+	Short: "Expose an agent-local HTTP port through the Hub",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client := scionhub.NewClient()
+		if client == nil || !client.IsConfigured() {
+			return fmt.Errorf("hub client not configured")
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+		defer cancel()
+		if exposeList {
+			ports, err := client.ListPorts(ctx)
+			if err != nil {
+				return err
+			}
+			if len(ports) == 0 {
+				fmt.Fprintln(os.Stdout, "No ports exposed.")
+				return nil
+			}
+			for _, p := range ports {
+				label := p.Label
+				if label == "" {
+					label = "-"
+				}
+				fmt.Fprintf(os.Stdout, "%d\t%s\t%s\n", p.Port, label, p.URL)
+			}
+			return nil
+		}
+		if len(args) != 1 {
+			return fmt.Errorf("port is required")
+		}
+		port, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid port %q", args[0])
+		}
+		resp, err := client.RegisterPort(ctx, scionhub.RegisterPortRequest{
+			Port:  port,
+			Label: exposeLabel,
+			Host:  exposeHost,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stdout, "Port %d exposed.\nURL: %s\nBase path: %s\n", resp.Port, resp.URL, resp.BasePath)
+		return nil
+	},
+}
+
+var unexposeCmd = &cobra.Command{
+	Use:   "unexpose <port>",
+	Short: "Stop exposing an agent-local HTTP port through the Hub",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client := scionhub.NewClient()
+		if client == nil || !client.IsConfigured() {
+			return fmt.Errorf("hub client not configured")
+		}
+		port, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid port %q", args[0])
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+		defer cancel()
+		if err := client.DeletePort(ctx, port); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stdout, "Port %d unexposed.\n", port)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(exposeCmd)
+	rootCmd.AddCommand(unexposeCmd)
+	exposeCmd.Flags().StringVar(&exposeLabel, "label", "", "Label for the exposed port")
+	exposeCmd.Flags().StringVar(&exposeHost, "host", "127.0.0.1", "Local host to forward to")
+	exposeCmd.Flags().BoolVar(&exposeList, "list", false, "List exposed ports")
+}

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hub"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/log"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/metadata"
+	scionportforward "github.com/GoogleCloudPlatform/scion/pkg/sciontool/portforward"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/services"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/supervisor"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/telemetry"
@@ -560,6 +561,9 @@ func runInit(args []string) int {
 				},
 			})
 			log.Info("Started Hub heartbeat loop (interval: %s)", hub.DefaultHeartbeatInterval)
+
+			go scionportforward.NewManager(hubClient).Run(ctx)
+			log.Info("Started port-forward tunnel manager")
 
 			// Read the agent token from the canonical token file (written by
 			// the host-side agent manager before the container started).

--- a/pkg/ent/agent.go
+++ b/pkg/ent/agent.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/agent"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/project"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/google/uuid"
 )
 
@@ -70,6 +71,8 @@ type Agent struct {
 	RuntimeBrokerID string `json:"runtime_broker_id,omitempty"`
 	// WebPtyEnabled holds the value of the "web_pty_enabled" field.
 	WebPtyEnabled bool `json:"web_pty_enabled,omitempty"`
+	// ExposedPorts holds the value of the "exposed_ports" field.
+	ExposedPorts []store.ExposedPort `json:"exposed_ports,omitempty"`
 	// TaskSummary holds the value of the "task_summary" field.
 	TaskSummary string `json:"task_summary,omitempty"`
 	// Message holds the value of the "message" field.
@@ -147,7 +150,7 @@ func (*Agent) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case agent.FieldCreatedBy, agent.FieldOwnerID:
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
-		case agent.FieldLabels, agent.FieldAnnotations, agent.FieldAncestry:
+		case agent.FieldLabels, agent.FieldAnnotations, agent.FieldExposedPorts, agent.FieldAncestry:
 			values[i] = new([]byte)
 		case agent.FieldDelegationEnabled, agent.FieldDetached, agent.FieldWebPtyEnabled:
 			values[i] = new(sql.NullBool)
@@ -335,6 +338,14 @@ func (_m *Agent) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field web_pty_enabled", values[i])
 			} else if value.Valid {
 				_m.WebPtyEnabled = value.Bool
+			}
+		case agent.FieldExposedPorts:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field exposed_ports", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &_m.ExposedPorts); err != nil {
+					return fmt.Errorf("unmarshal field exposed_ports: %w", err)
+				}
 			}
 		case agent.FieldTaskSummary:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -537,6 +548,9 @@ func (_m *Agent) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("web_pty_enabled=")
 	builder.WriteString(fmt.Sprintf("%v", _m.WebPtyEnabled))
+	builder.WriteString(", ")
+	builder.WriteString("exposed_ports=")
+	builder.WriteString(fmt.Sprintf("%v", _m.ExposedPorts))
 	builder.WriteString(", ")
 	builder.WriteString("task_summary=")
 	builder.WriteString(_m.TaskSummary)

--- a/pkg/ent/agent/agent.go
+++ b/pkg/ent/agent/agent.go
@@ -66,6 +66,8 @@ const (
 	FieldRuntimeBrokerID = "runtime_broker_id"
 	// FieldWebPtyEnabled holds the string denoting the web_pty_enabled field in the database.
 	FieldWebPtyEnabled = "web_pty_enabled"
+	// FieldExposedPorts holds the string denoting the exposed_ports field in the database.
+	FieldExposedPorts = "exposed_ports"
 	// FieldTaskSummary holds the string denoting the task_summary field in the database.
 	FieldTaskSummary = "task_summary"
 	// FieldMessage holds the string denoting the message field in the database.
@@ -147,6 +149,7 @@ var Columns = []string{
 	FieldRuntime,
 	FieldRuntimeBrokerID,
 	FieldWebPtyEnabled,
+	FieldExposedPorts,
 	FieldTaskSummary,
 	FieldMessage,
 	FieldAppliedConfig,

--- a/pkg/ent/agent/where.go
+++ b/pkg/ent/agent/where.go
@@ -1506,6 +1506,16 @@ func WebPtyEnabledNEQ(v bool) predicate.Agent {
 	return predicate.Agent(sql.FieldNEQ(FieldWebPtyEnabled, v))
 }
 
+// ExposedPortsIsNil applies the IsNil predicate on the "exposed_ports" field.
+func ExposedPortsIsNil() predicate.Agent {
+	return predicate.Agent(sql.FieldIsNull(FieldExposedPorts))
+}
+
+// ExposedPortsNotNil applies the NotNil predicate on the "exposed_ports" field.
+func ExposedPortsNotNil() predicate.Agent {
+	return predicate.Agent(sql.FieldNotNull(FieldExposedPorts))
+}
+
 // TaskSummaryEQ applies the EQ predicate on the "task_summary" field.
 func TaskSummaryEQ(v string) predicate.Agent {
 	return predicate.Agent(sql.FieldEQ(FieldTaskSummary, v))

--- a/pkg/ent/agent_create.go
+++ b/pkg/ent/agent_create.go
@@ -16,6 +16,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/groupmembership"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/policybinding"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/project"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/google/uuid"
 )
 
@@ -334,6 +335,12 @@ func (_c *AgentCreate) SetNillableWebPtyEnabled(v *bool) *AgentCreate {
 	if v != nil {
 		_c.SetWebPtyEnabled(*v)
 	}
+	return _c
+}
+
+// SetExposedPorts sets the "exposed_ports" field.
+func (_c *AgentCreate) SetExposedPorts(v []store.ExposedPort) *AgentCreate {
+	_c.mutation.SetExposedPorts(v)
 	return _c
 }
 
@@ -803,6 +810,10 @@ func (_c *AgentCreate) createSpec() (*Agent, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.WebPtyEnabled(); ok {
 		_spec.SetField(agent.FieldWebPtyEnabled, field.TypeBool, value)
 		_node.WebPtyEnabled = value
+	}
+	if value, ok := _c.mutation.ExposedPorts(); ok {
+		_spec.SetField(agent.FieldExposedPorts, field.TypeJSON, value)
+		_node.ExposedPorts = value
 	}
 	if value, ok := _c.mutation.TaskSummary(); ok {
 		_spec.SetField(agent.FieldTaskSummary, field.TypeString, value)
@@ -1348,6 +1359,24 @@ func (u *AgentUpsert) SetWebPtyEnabled(v bool) *AgentUpsert {
 // UpdateWebPtyEnabled sets the "web_pty_enabled" field to the value that was provided on create.
 func (u *AgentUpsert) UpdateWebPtyEnabled() *AgentUpsert {
 	u.SetExcluded(agent.FieldWebPtyEnabled)
+	return u
+}
+
+// SetExposedPorts sets the "exposed_ports" field.
+func (u *AgentUpsert) SetExposedPorts(v []store.ExposedPort) *AgentUpsert {
+	u.Set(agent.FieldExposedPorts, v)
+	return u
+}
+
+// UpdateExposedPorts sets the "exposed_ports" field to the value that was provided on create.
+func (u *AgentUpsert) UpdateExposedPorts() *AgentUpsert {
+	u.SetExcluded(agent.FieldExposedPorts)
+	return u
+}
+
+// ClearExposedPorts clears the value of the "exposed_ports" field.
+func (u *AgentUpsert) ClearExposedPorts() *AgentUpsert {
+	u.SetNull(agent.FieldExposedPorts)
 	return u
 }
 
@@ -2042,6 +2071,27 @@ func (u *AgentUpsertOne) SetWebPtyEnabled(v bool) *AgentUpsertOne {
 func (u *AgentUpsertOne) UpdateWebPtyEnabled() *AgentUpsertOne {
 	return u.Update(func(s *AgentUpsert) {
 		s.UpdateWebPtyEnabled()
+	})
+}
+
+// SetExposedPorts sets the "exposed_ports" field.
+func (u *AgentUpsertOne) SetExposedPorts(v []store.ExposedPort) *AgentUpsertOne {
+	return u.Update(func(s *AgentUpsert) {
+		s.SetExposedPorts(v)
+	})
+}
+
+// UpdateExposedPorts sets the "exposed_ports" field to the value that was provided on create.
+func (u *AgentUpsertOne) UpdateExposedPorts() *AgentUpsertOne {
+	return u.Update(func(s *AgentUpsert) {
+		s.UpdateExposedPorts()
+	})
+}
+
+// ClearExposedPorts clears the value of the "exposed_ports" field.
+func (u *AgentUpsertOne) ClearExposedPorts() *AgentUpsertOne {
+	return u.Update(func(s *AgentUpsert) {
+		s.ClearExposedPorts()
 	})
 }
 
@@ -2932,6 +2982,27 @@ func (u *AgentUpsertBulk) SetWebPtyEnabled(v bool) *AgentUpsertBulk {
 func (u *AgentUpsertBulk) UpdateWebPtyEnabled() *AgentUpsertBulk {
 	return u.Update(func(s *AgentUpsert) {
 		s.UpdateWebPtyEnabled()
+	})
+}
+
+// SetExposedPorts sets the "exposed_ports" field.
+func (u *AgentUpsertBulk) SetExposedPorts(v []store.ExposedPort) *AgentUpsertBulk {
+	return u.Update(func(s *AgentUpsert) {
+		s.SetExposedPorts(v)
+	})
+}
+
+// UpdateExposedPorts sets the "exposed_ports" field to the value that was provided on create.
+func (u *AgentUpsertBulk) UpdateExposedPorts() *AgentUpsertBulk {
+	return u.Update(func(s *AgentUpsert) {
+		s.UpdateExposedPorts()
+	})
+}
+
+// ClearExposedPorts clears the value of the "exposed_ports" field.
+func (u *AgentUpsertBulk) ClearExposedPorts() *AgentUpsertBulk {
+	return u.Update(func(s *AgentUpsert) {
+		s.ClearExposedPorts()
 	})
 }
 

--- a/pkg/ent/agent_update.go
+++ b/pkg/ent/agent_update.go
@@ -17,6 +17,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/policybinding"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/predicate"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/project"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/google/uuid"
 )
 
@@ -468,6 +469,24 @@ func (_u *AgentUpdate) SetNillableWebPtyEnabled(v *bool) *AgentUpdate {
 	if v != nil {
 		_u.SetWebPtyEnabled(*v)
 	}
+	return _u
+}
+
+// SetExposedPorts sets the "exposed_ports" field.
+func (_u *AgentUpdate) SetExposedPorts(v []store.ExposedPort) *AgentUpdate {
+	_u.mutation.SetExposedPorts(v)
+	return _u
+}
+
+// AppendExposedPorts appends value to the "exposed_ports" field.
+func (_u *AgentUpdate) AppendExposedPorts(v []store.ExposedPort) *AgentUpdate {
+	_u.mutation.AppendExposedPorts(v)
+	return _u
+}
+
+// ClearExposedPorts clears the value of the "exposed_ports" field.
+func (_u *AgentUpdate) ClearExposedPorts() *AgentUpdate {
+	_u.mutation.ClearExposedPorts()
 	return _u
 }
 
@@ -937,6 +956,17 @@ func (_u *AgentUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.WebPtyEnabled(); ok {
 		_spec.SetField(agent.FieldWebPtyEnabled, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.ExposedPorts(); ok {
+		_spec.SetField(agent.FieldExposedPorts, field.TypeJSON, value)
+	}
+	if value, ok := _u.mutation.AppendedExposedPorts(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, agent.FieldExposedPorts, value)
+		})
+	}
+	if _u.mutation.ExposedPortsCleared() {
+		_spec.ClearField(agent.FieldExposedPorts, field.TypeJSON)
 	}
 	if value, ok := _u.mutation.TaskSummary(); ok {
 		_spec.SetField(agent.FieldTaskSummary, field.TypeString, value)
@@ -1577,6 +1607,24 @@ func (_u *AgentUpdateOne) SetNillableWebPtyEnabled(v *bool) *AgentUpdateOne {
 	return _u
 }
 
+// SetExposedPorts sets the "exposed_ports" field.
+func (_u *AgentUpdateOne) SetExposedPorts(v []store.ExposedPort) *AgentUpdateOne {
+	_u.mutation.SetExposedPorts(v)
+	return _u
+}
+
+// AppendExposedPorts appends value to the "exposed_ports" field.
+func (_u *AgentUpdateOne) AppendExposedPorts(v []store.ExposedPort) *AgentUpdateOne {
+	_u.mutation.AppendExposedPorts(v)
+	return _u
+}
+
+// ClearExposedPorts clears the value of the "exposed_ports" field.
+func (_u *AgentUpdateOne) ClearExposedPorts() *AgentUpdateOne {
+	_u.mutation.ClearExposedPorts()
+	return _u
+}
+
 // SetTaskSummary sets the "task_summary" field.
 func (_u *AgentUpdateOne) SetTaskSummary(v string) *AgentUpdateOne {
 	_u.mutation.SetTaskSummary(v)
@@ -2073,6 +2121,17 @@ func (_u *AgentUpdateOne) sqlSave(ctx context.Context) (_node *Agent, err error)
 	}
 	if value, ok := _u.mutation.WebPtyEnabled(); ok {
 		_spec.SetField(agent.FieldWebPtyEnabled, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.ExposedPorts(); ok {
+		_spec.SetField(agent.FieldExposedPorts, field.TypeJSON, value)
+	}
+	if value, ok := _u.mutation.AppendedExposedPorts(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, agent.FieldExposedPorts, value)
+		})
+	}
+	if _u.mutation.ExposedPortsCleared() {
+		_spec.ClearField(agent.FieldExposedPorts, field.TypeJSON)
 	}
 	if value, ok := _u.mutation.TaskSummary(); ok {
 		_spec.SetField(agent.FieldTaskSummary, field.TypeString, value)

--- a/pkg/ent/client.go
+++ b/pkg/ent/client.go
@@ -6468,9 +6468,8 @@ type (
 		LifecycleHookAgentPhase, MaintenanceOperation, MaintenanceOperationRun,
 		Message, Notification, NotificationSubscription, PolicyBinding, Project,
 		ProjectContributor, ProjectPreStartHook, ProjectSyncState, RuntimeBroker,
-		Schedule, ScheduledEvent,
-		Secret, Skill, SkillInjection, SkillRegistry, SkillVersion,
-		SubscriptionTemplate, Template, User, UserAccessToken []ent.Hook
+		Schedule, ScheduledEvent, Secret, Skill, SkillInjection, SkillRegistry,
+		SkillVersion, SubscriptionTemplate, Template, User, UserAccessToken []ent.Hook
 	}
 	inters struct {
 		AccessPolicy, Agent, AllowListEntry, ApiKey, BrokerDispatch, BrokerJoinToken,
@@ -6480,8 +6479,8 @@ type (
 		LifecycleHookAgentPhase, MaintenanceOperation, MaintenanceOperationRun,
 		Message, Notification, NotificationSubscription, PolicyBinding, Project,
 		ProjectContributor, ProjectPreStartHook, ProjectSyncState, RuntimeBroker,
-		Schedule, ScheduledEvent,
-		Secret, Skill, SkillInjection, SkillRegistry, SkillVersion,
-		SubscriptionTemplate, Template, User, UserAccessToken []ent.Interceptor
+		Schedule, ScheduledEvent, Secret, Skill, SkillInjection, SkillRegistry,
+		SkillVersion, SubscriptionTemplate, Template, User,
+		UserAccessToken []ent.Interceptor
 	}
 )

--- a/pkg/ent/migrate/schema.go
+++ b/pkg/ent/migrate/schema.go
@@ -61,6 +61,7 @@ var (
 		{Name: "runtime", Type: field.TypeString, Nullable: true},
 		{Name: "runtime_broker_id", Type: field.TypeString, Nullable: true},
 		{Name: "web_pty_enabled", Type: field.TypeBool, Default: false},
+		{Name: "exposed_ports", Type: field.TypeJSON, Nullable: true},
 		{Name: "task_summary", Type: field.TypeString, Nullable: true},
 		{Name: "message", Type: field.TypeString, Nullable: true},
 		{Name: "applied_config", Type: field.TypeString, Nullable: true, Size: 2147483647},
@@ -82,7 +83,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "agents_projects_agents",
-				Columns:    []*schema.Column{AgentsColumns[36]},
+				Columns:    []*schema.Column{AgentsColumns[37]},
 				RefColumns: []*schema.Column{ProjectsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -91,7 +92,7 @@ var (
 			{
 				Name:    "agent_slug_project_id",
 				Unique:  true,
-				Columns: []*schema.Column{AgentsColumns[1], AgentsColumns[36]},
+				Columns: []*schema.Column{AgentsColumns[1], AgentsColumns[37]},
 			},
 		},
 	}

--- a/pkg/ent/mutation.go
+++ b/pkg/ent/mutation.go
@@ -56,6 +56,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/template"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/user"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/useraccesstoken"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/google/uuid"
 )
 
@@ -1533,6 +1534,8 @@ type AgentMutation struct {
 	runtime                *string
 	runtime_broker_id      *string
 	web_pty_enabled        *bool
+	exposed_ports          *[]store.ExposedPort
+	appendexposed_ports    []store.ExposedPort
 	task_summary           *string
 	message                *string
 	applied_config         *string
@@ -2799,6 +2802,71 @@ func (m *AgentMutation) ResetWebPtyEnabled() {
 	m.web_pty_enabled = nil
 }
 
+// SetExposedPorts sets the "exposed_ports" field.
+func (m *AgentMutation) SetExposedPorts(sp []store.ExposedPort) {
+	m.exposed_ports = &sp
+	m.appendexposed_ports = nil
+}
+
+// ExposedPorts returns the value of the "exposed_ports" field in the mutation.
+func (m *AgentMutation) ExposedPorts() (r []store.ExposedPort, exists bool) {
+	v := m.exposed_ports
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldExposedPorts returns the old "exposed_ports" field's value of the Agent entity.
+// If the Agent object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AgentMutation) OldExposedPorts(ctx context.Context) (v []store.ExposedPort, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldExposedPorts is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldExposedPorts requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldExposedPorts: %w", err)
+	}
+	return oldValue.ExposedPorts, nil
+}
+
+// AppendExposedPorts adds sp to the "exposed_ports" field.
+func (m *AgentMutation) AppendExposedPorts(sp []store.ExposedPort) {
+	m.appendexposed_ports = append(m.appendexposed_ports, sp...)
+}
+
+// AppendedExposedPorts returns the list of values that were appended to the "exposed_ports" field in this mutation.
+func (m *AgentMutation) AppendedExposedPorts() ([]store.ExposedPort, bool) {
+	if len(m.appendexposed_ports) == 0 {
+		return nil, false
+	}
+	return m.appendexposed_ports, true
+}
+
+// ClearExposedPorts clears the value of the "exposed_ports" field.
+func (m *AgentMutation) ClearExposedPorts() {
+	m.exposed_ports = nil
+	m.appendexposed_ports = nil
+	m.clearedFields[agent.FieldExposedPorts] = struct{}{}
+}
+
+// ExposedPortsCleared returns if the "exposed_ports" field was cleared in this mutation.
+func (m *AgentMutation) ExposedPortsCleared() bool {
+	_, ok := m.clearedFields[agent.FieldExposedPorts]
+	return ok
+}
+
+// ResetExposedPorts resets all changes to the "exposed_ports" field.
+func (m *AgentMutation) ResetExposedPorts() {
+	m.exposed_ports = nil
+	m.appendexposed_ports = nil
+	delete(m.clearedFields, agent.FieldExposedPorts)
+}
+
 // SetTaskSummary sets the "task_summary" field.
 func (m *AgentMutation) SetTaskSummary(s string) {
 	m.task_summary = &s
@@ -3504,7 +3572,7 @@ func (m *AgentMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *AgentMutation) Fields() []string {
-	fields := make([]string, 0, 36)
+	fields := make([]string, 0, 37)
 	if m.slug != nil {
 		fields = append(fields, agent.FieldSlug)
 	}
@@ -3579,6 +3647,9 @@ func (m *AgentMutation) Fields() []string {
 	}
 	if m.web_pty_enabled != nil {
 		fields = append(fields, agent.FieldWebPtyEnabled)
+	}
+	if m.exposed_ports != nil {
+		fields = append(fields, agent.FieldExposedPorts)
 	}
 	if m.task_summary != nil {
 		fields = append(fields, agent.FieldTaskSummary)
@@ -3671,6 +3742,8 @@ func (m *AgentMutation) Field(name string) (ent.Value, bool) {
 		return m.RuntimeBrokerID()
 	case agent.FieldWebPtyEnabled:
 		return m.WebPtyEnabled()
+	case agent.FieldExposedPorts:
+		return m.ExposedPorts()
 	case agent.FieldTaskSummary:
 		return m.TaskSummary()
 	case agent.FieldMessage:
@@ -3752,6 +3825,8 @@ func (m *AgentMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldRuntimeBrokerID(ctx)
 	case agent.FieldWebPtyEnabled:
 		return m.OldWebPtyEnabled(ctx)
+	case agent.FieldExposedPorts:
+		return m.OldExposedPorts(ctx)
 	case agent.FieldTaskSummary:
 		return m.OldTaskSummary(ctx)
 	case agent.FieldMessage:
@@ -3958,6 +4033,13 @@ func (m *AgentMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetWebPtyEnabled(v)
 		return nil
+	case agent.FieldExposedPorts:
+		v, ok := value.([]store.ExposedPort)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetExposedPorts(v)
+		return nil
 	case agent.FieldTaskSummary:
 		v, ok := value.(string)
 		if !ok {
@@ -4149,6 +4231,9 @@ func (m *AgentMutation) ClearedFields() []string {
 	if m.FieldCleared(agent.FieldRuntimeBrokerID) {
 		fields = append(fields, agent.FieldRuntimeBrokerID)
 	}
+	if m.FieldCleared(agent.FieldExposedPorts) {
+		fields = append(fields, agent.FieldExposedPorts)
+	}
 	if m.FieldCleared(agent.FieldTaskSummary) {
 		fields = append(fields, agent.FieldTaskSummary)
 	}
@@ -4231,6 +4316,9 @@ func (m *AgentMutation) ClearField(name string) error {
 		return nil
 	case agent.FieldRuntimeBrokerID:
 		m.ClearRuntimeBrokerID()
+		return nil
+	case agent.FieldExposedPorts:
+		m.ClearExposedPorts()
 		return nil
 	case agent.FieldTaskSummary:
 		m.ClearTaskSummary()
@@ -4338,6 +4426,9 @@ func (m *AgentMutation) ResetField(name string) error {
 		return nil
 	case agent.FieldWebPtyEnabled:
 		m.ResetWebPtyEnabled()
+		return nil
+	case agent.FieldExposedPorts:
+		m.ResetExposedPorts()
 		return nil
 	case agent.FieldTaskSummary:
 		m.ResetTaskSummary()

--- a/pkg/ent/runtime.go
+++ b/pkg/ent/runtime.go
@@ -118,17 +118,17 @@ func init() {
 	// agent.DefaultWebPtyEnabled holds the default value on creation for the web_pty_enabled field.
 	agent.DefaultWebPtyEnabled = agentDescWebPtyEnabled.Default.(bool)
 	// agentDescCreated is the schema descriptor for created field.
-	agentDescCreated := agentFields[30].Descriptor()
+	agentDescCreated := agentFields[31].Descriptor()
 	// agent.DefaultCreated holds the default value on creation for the created field.
 	agent.DefaultCreated = agentDescCreated.Default.(func() time.Time)
 	// agentDescUpdated is the schema descriptor for updated field.
-	agentDescUpdated := agentFields[31].Descriptor()
+	agentDescUpdated := agentFields[32].Descriptor()
 	// agent.DefaultUpdated holds the default value on creation for the updated field.
 	agent.DefaultUpdated = agentDescUpdated.Default.(func() time.Time)
 	// agent.UpdateDefaultUpdated holds the default value on update for the updated field.
 	agent.UpdateDefaultUpdated = agentDescUpdated.UpdateDefault.(func() time.Time)
 	// agentDescStateVersion is the schema descriptor for state_version field.
-	agentDescStateVersion := agentFields[36].Descriptor()
+	agentDescStateVersion := agentFields[37].Descriptor()
 	// agent.DefaultStateVersion holds the default value on creation for the state_version field.
 	agent.DefaultStateVersion = agentDescStateVersion.Default.(int64)
 	// agentDescID is the schema descriptor for id field.

--- a/pkg/ent/schema/agent.go
+++ b/pkg/ent/schema/agent.go
@@ -21,6 +21,7 @@ import (
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/google/uuid"
 )
 
@@ -108,6 +109,8 @@ func (Agent) Fields() []ent.Field {
 			Optional(),
 		field.Bool("web_pty_enabled").
 			Default(false),
+		field.JSON("exposed_ports", []store.ExposedPort{}).
+			Optional(),
 		field.String("task_summary").
 			Optional(),
 		field.String("message").

--- a/pkg/hub/agenttoken.go
+++ b/pkg/hub/agenttoken.go
@@ -55,6 +55,8 @@ const (
 	ScopeAgentNotify AgentTokenScope = "project:agent:notify"
 	// ScopeAgentTokenRefresh allows the agent to refresh its own token before expiry.
 	ScopeAgentTokenRefresh AgentTokenScope = "agent:token:refresh"
+	// ScopeAgentPortForward allows the agent to register ports and hold port-forward tunnels.
+	ScopeAgentPortForward AgentTokenScope = "agent:port:forward"
 	// ScopeGCPTokenPrefix is the prefix for GCP token scopes.
 	// Full scope format: "project:gcp:token:<sa-id>"
 	ScopeGCPTokenPrefix = "project:gcp:token:"

--- a/pkg/hub/authz.go
+++ b/pkg/hub/authz.go
@@ -38,6 +38,7 @@ const (
 	ActionStop         Action = "stop"
 	ActionMessage      Action = "message"
 	ActionAttach       Action = "attach"
+	ActionPortAccess   Action = "port_access"
 	ActionRegister     Action = "register"
 	ActionAddMember    Action = "addMember"
 	ActionRemoveMember Action = "removeMember"

--- a/pkg/hub/events.go
+++ b/pkg/hub/events.go
@@ -70,7 +70,7 @@ func (noopEventPublisher) PublishBrokerDisconnected(_ context.Context, _ string,
 func (noopEventPublisher) PublishBrokerStatus(_ context.Context, _, _ string)                {}
 func (noopEventPublisher) PublishNotification(_ context.Context, _ *store.Notification)      {}
 func (noopEventPublisher) PublishUserMessage(_ context.Context, _ *store.Message)            {}
-func (noopEventPublisher) PublishAgentPorts(_ context.Context, _ *store.Agent)                {}
+func (noopEventPublisher) PublishAgentPorts(_ context.Context, _ *store.Agent)               {}
 func (noopEventPublisher) PublishAllowListChanged(_ context.Context, _, _ string)            {}
 func (noopEventPublisher) PublishInviteChanged(_ context.Context, _, _, _ string)            {}
 func (noopEventPublisher) PublishDispatchDone(_ context.Context, _ string)                   {}

--- a/pkg/hub/events.go
+++ b/pkg/hub/events.go
@@ -147,6 +147,7 @@ type AgentDeletedEvent struct {
 type AgentPortsEvent struct {
 	AgentID   string              `json:"agentId"`
 	ProjectID string              `json:"projectId"`
+	GroveID   string              `json:"groveId"`
 	Ports     []store.ExposedPort `json:"ports"`
 }
 
@@ -431,18 +432,17 @@ func (p *eventBuilder) PublishAgentDeleted(_ context.Context, agentID, projectID
 }
 
 // PublishAgentPorts publishes an agent ports event when the exposed ports change.
-func (b *eventBuilder) PublishAgentPorts(_ context.Context, agent *store.Agent) {
+func (p *eventBuilder) PublishAgentPorts(_ context.Context, agent *store.Agent) {
 	evt := AgentPortsEvent{
 		AgentID:   agent.ID,
 		ProjectID: agent.ProjectID,
+		GroveID:   agent.ProjectID,
 		Ports:     agent.ExposedPorts,
 	}
-	b.sink("agent."+agent.ID+".ports", evt)
+	p.sink("agent."+agent.ID+".ports", evt)
 	if agent.ProjectID != "" {
-		b.sink("project."+agent.ProjectID+".agent.ports", evt)
-	}
-	if agent.ProjectID != "" {
-		b.sink("grove."+agent.ProjectID+".agent.ports", evt)
+		p.sink("project."+agent.ProjectID+".agent.ports", evt)
+		p.sink("grove."+agent.ProjectID+".agent.ports", evt)
 	}
 }
 

--- a/pkg/hub/events.go
+++ b/pkg/hub/events.go
@@ -38,6 +38,7 @@ type EventPublisher interface {
 	PublishBrokerStatus(ctx context.Context, brokerID, status string)
 	PublishNotification(ctx context.Context, notif *store.Notification)
 	PublishUserMessage(ctx context.Context, msg *store.Message)
+	PublishAgentPorts(ctx context.Context, agent *store.Agent)
 	PublishAllowListChanged(ctx context.Context, action string, email string)
 	PublishInviteChanged(ctx context.Context, action string, inviteID string, codePrefix string)
 	// PublishDispatchDone emits a slim completion event on
@@ -69,6 +70,7 @@ func (noopEventPublisher) PublishBrokerDisconnected(_ context.Context, _ string,
 func (noopEventPublisher) PublishBrokerStatus(_ context.Context, _, _ string)                {}
 func (noopEventPublisher) PublishNotification(_ context.Context, _ *store.Notification)      {}
 func (noopEventPublisher) PublishUserMessage(_ context.Context, _ *store.Message)            {}
+func (noopEventPublisher) PublishAgentPorts(_ context.Context, _ *store.Agent)                {}
 func (noopEventPublisher) PublishAllowListChanged(_ context.Context, _, _ string)            {}
 func (noopEventPublisher) PublishInviteChanged(_ context.Context, _, _, _ string)            {}
 func (noopEventPublisher) PublishDispatchDone(_ context.Context, _ string)                   {}
@@ -139,6 +141,13 @@ type AgentDeletedEvent struct {
 	AgentID   string `json:"agentId"`
 	ProjectID string `json:"projectId"`
 	GroveID   string `json:"groveId"`
+}
+
+// AgentPortsEvent is published when an agent's exposed ports change.
+type AgentPortsEvent struct {
+	AgentID   string              `json:"agentId"`
+	ProjectID string              `json:"projectId"`
+	Ports     []store.ExposedPort `json:"ports"`
 }
 
 // ProjectCreatedEvent is published when a project is created.
@@ -418,6 +427,22 @@ func (p *eventBuilder) PublishAgentDeleted(_ context.Context, agentID, projectID
 	if projectID != "" {
 		p.sink("project."+projectID+".agent.deleted", evt)
 		p.sink("grove."+projectID+".agent.deleted", evt)
+	}
+}
+
+// PublishAgentPorts publishes an agent ports event when the exposed ports change.
+func (b *eventBuilder) PublishAgentPorts(_ context.Context, agent *store.Agent) {
+	evt := AgentPortsEvent{
+		AgentID:   agent.ID,
+		ProjectID: agent.ProjectID,
+		Ports:     agent.ExposedPorts,
+	}
+	b.sink("agent."+agent.ID+".ports", evt)
+	if agent.ProjectID != "" {
+		b.sink("project."+agent.ProjectID+".agent.ports", evt)
+	}
+	if agent.ProjectID != "" {
+		b.sink("grove."+agent.ProjectID+".agent.ports", evt)
 	}
 }
 

--- a/pkg/hub/handlers_agent_lifecycle.go
+++ b/pkg/hub/handlers_agent_lifecycle.go
@@ -231,6 +231,8 @@ func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id
 		}
 	case api.AgentActionStop:
 		newPhase = string(state.PhaseStopped)
+		// Clear exposed ports — the agent is stopping so its ports are unreachable.
+		s.clearExposedPortsForAgent(ctx, agent.ID)
 		if dispatcher != nil && agent.RuntimeBrokerID != "" {
 			// Before stopping, sync workspace back for hub-managed projects on remote brokers.
 			// This is best-effort: failures are logged but don't block the stop.

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -1469,6 +1469,12 @@ func (s *Server) handleAgentByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Handle agent port-forward registration, tunnel, and proxy routes.
+	if action == "ports" || strings.HasPrefix(action, "ports/") {
+		s.handleAgentPorts(w, r, id, strings.TrimPrefix(strings.TrimPrefix(action, "ports"), "/"))
+		return
+	}
+
 	// Handle agent logs relay (GET, proxied to broker)
 	if action == "logs" {
 		s.handleAgentLogs(w, r, id)

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -1812,6 +1812,9 @@ func (s *Server) performAgentDelete(w http.ResponseWriter, r *http.Request, agen
 		return
 	}
 
+	// Clear exposed ports — the agent is being deleted so its ports are unreachable.
+	s.clearExposedPortsForAgent(ctx, agent.ID)
+
 	now := time.Now()
 
 	// If a dispatcher is available, dispatch the deletion to the runtime broker

--- a/pkg/hub/handlers_managed_agents.go
+++ b/pkg/hub/handlers_managed_agents.go
@@ -215,6 +215,7 @@ func (s *Server) handleManagedAgentLifecycle(w http.ResponseWriter, r *http.Requ
 		newPhase = string("running")
 	case "stop":
 		newPhase = string("stopped")
+		// Clear exposed ports — agent is stopping, ports are unreachable
 		s.clearExposedPortsForAgent(ctx, agent.ID)
 		actionErr = s.managedAgentStop(ctx, agent)
 	case "restart":

--- a/pkg/hub/handlers_managed_agents.go
+++ b/pkg/hub/handlers_managed_agents.go
@@ -215,6 +215,7 @@ func (s *Server) handleManagedAgentLifecycle(w http.ResponseWriter, r *http.Requ
 		newPhase = string("running")
 	case "stop":
 		newPhase = string("stopped")
+		s.clearExposedPortsForAgent(ctx, agent.ID)
 		actionErr = s.managedAgentStop(ctx, agent)
 	case "restart":
 		_ = s.managedAgentStop(ctx, agent)

--- a/pkg/hub/port_forward_handlers.go
+++ b/pkg/hub/port_forward_handlers.go
@@ -37,13 +37,17 @@ const (
 	maxExposedPortsPerAgent = 10
 	maxProxyRequestBody     = 32 << 20
 	portForwardTimeout      = 60 * time.Second
+	maxConcurrentStreams     = 64
 )
 
 var deniedExposedPorts = map[int]string{
+	8080:  "scion web server",
+	9810:  "scion hub API",
 	18380: "scion metadata server",
 }
 
-var errNoPortTunnel = errors.New("no active port-forward tunnel")
+var errNoPortTunnel     = errors.New("no active port-forward tunnel")
+var errTunnelBusy       = errors.New("too many concurrent port-forward requests")
 
 var portTunnelUpgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool { return true },
@@ -59,11 +63,13 @@ func NewPortTunnelManager() *PortTunnelManager {
 }
 
 func (m *PortTunnelManager) Register(agentID string, conn *websocket.Conn) *PortTunnelSession {
+	conn.SetReadLimit(96 << 20)
 	s := &PortTunnelSession{
-		agentID: agentID,
-		conn:    conn,
-		pending: make(map[string]chan portforward.Response),
-		done:    make(chan struct{}),
+		agentID:  agentID,
+		conn:     conn,
+		pending:  make(map[string]chan portforward.Response),
+		inflight: make(chan struct{}, maxConcurrentStreams),
+		done:     make(chan struct{}),
 	}
 
 	m.mu.Lock()
@@ -94,13 +100,14 @@ func (m *PortTunnelManager) Do(ctx context.Context, agentID string, req portforw
 }
 
 type PortTunnelSession struct {
-	agentID string
-	conn    *websocket.Conn
-	writeMu sync.Mutex
-	mu      sync.Mutex
-	pending map[string]chan portforward.Response
-	done    chan struct{}
-	once    sync.Once
+	agentID  string
+	conn     *websocket.Conn
+	writeMu  sync.Mutex
+	mu       sync.Mutex
+	pending  map[string]chan portforward.Response
+	inflight chan struct{}
+	done     chan struct{}
+	once     sync.Once
 }
 
 func (s *PortTunnelSession) close() {
@@ -144,6 +151,13 @@ func (s *PortTunnelSession) readLoop(onClose func()) {
 }
 
 func (s *PortTunnelSession) do(ctx context.Context, req portforward.Request) (*portforward.Response, error) {
+	select {
+	case s.inflight <- struct{}{}:
+		defer func() { <-s.inflight }()
+	default:
+		return nil, errTunnelBusy
+	}
+
 	ch := make(chan portforward.Response, 1)
 	s.mu.Lock()
 	select {
@@ -376,6 +390,10 @@ func (s *Server) proxyAgentPort(w http.ResponseWriter, r *http.Request, agentID 
 			writeError(w, http.StatusServiceUnavailable, ErrCodeRuntimeError, "No active port-forward tunnel for this agent", nil)
 			return
 		}
+		if errors.Is(err, errTunnelBusy) {
+			writeError(w, http.StatusServiceUnavailable, ErrCodeRuntimeError, err.Error(), nil)
+			return
+		}
 		writeError(w, http.StatusBadGateway, ErrCodeRuntimeError, "Port-forward tunnel failed: "+err.Error(), nil)
 		return
 	}
@@ -503,7 +521,7 @@ func isLoopbackHost(host string) bool {
 func cloneForwardHeaders(in http.Header) http.Header {
 	out := make(http.Header, len(in))
 	for k, vals := range in {
-		if hopByHopHeader(k) {
+		if hopByHopHeader(k) || sensitiveHeader(k) {
 			continue
 		}
 		out[k] = append([]string(nil), vals...)
@@ -514,6 +532,15 @@ func cloneForwardHeaders(in http.Header) http.Header {
 func hopByHopHeader(k string) bool {
 	switch strings.ToLower(k) {
 	case "connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade":
+		return true
+	default:
+		return false
+	}
+}
+
+func sensitiveHeader(k string) bool {
+	switch strings.ToLower(k) {
+	case "authorization", "cookie", "x-scion-agent-token", "x-scion-broker-id", "x-scion-broker-hmac":
 		return true
 	default:
 		return false

--- a/pkg/hub/port_forward_handlers.go
+++ b/pkg/hub/port_forward_handlers.go
@@ -65,7 +65,7 @@ func NewPortTunnelManager() *PortTunnelManager {
 	return &PortTunnelManager{sessions: make(map[string]*PortTunnelSession)}
 }
 
-func (m *PortTunnelManager) Register(agentID string, conn *websocket.Conn) *PortTunnelSession {
+func (m *PortTunnelManager) Register(agentID string, conn *websocket.Conn, remoteAddr string) *PortTunnelSession {
 	conn.SetReadLimit(96 << 20)
 	s := &PortTunnelSession{
 		agentID:  agentID,
@@ -82,6 +82,8 @@ func (m *PortTunnelManager) Register(agentID string, conn *websocket.Conn) *Port
 	m.sessions[agentID] = s
 	m.mu.Unlock()
 
+	slog.Info("Port-forward tunnel connected", "agent_id", agentID, "remote_addr", remoteAddr)
+
 	go s.readLoop(func() {
 		m.mu.Lock()
 		if m.sessions[agentID] == s {
@@ -89,6 +91,9 @@ func (m *PortTunnelManager) Register(agentID string, conn *websocket.Conn) *Port
 		}
 		onDisconnect := m.onDisconnect
 		m.mu.Unlock()
+
+		slog.Info("Port-forward tunnel disconnected", "agent_id", agentID)
+
 		if onDisconnect != nil {
 			onDisconnect(agentID)
 		}
@@ -313,6 +318,7 @@ func (s *Server) registerAgentPort(w http.ResponseWriter, r *http.Request, agent
 	if updated, err := s.store.GetAgent(r.Context(), agent.ID); err == nil {
 		s.events.PublishAgentPorts(r.Context(), updated)
 	}
+	slog.Info("Port registered", "agent_id", agent.ID, "port", req.Port, "label", req.Label, "caller", identityStringFromContext(r.Context()))
 	writeJSON(w, http.StatusCreated, exposedPortResponses(agent.ID, ports)[len(ports)-1])
 }
 
@@ -342,6 +348,7 @@ func (s *Server) deleteAgentPort(w http.ResponseWriter, r *http.Request, agentID
 	if updated, err := s.store.GetAgent(r.Context(), agent.ID); err == nil {
 		s.events.PublishAgentPorts(r.Context(), updated)
 	}
+	slog.Info("Port deregistered", "agent_id", agent.ID, "port", port, "caller", identityStringFromContext(r.Context()))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -350,6 +357,7 @@ func (s *Server) clearAgentPorts(w http.ResponseWriter, r *http.Request, agentID
 	if !ok {
 		return
 	}
+	portCount := len(agent.ExposedPorts)
 	if err := s.store.UpdateAgentExposedPorts(r.Context(), agent.ID, nil); err != nil {
 		writeErrorFromErr(w, err, "")
 		return
@@ -358,10 +366,12 @@ func (s *Server) clearAgentPorts(w http.ResponseWriter, r *http.Request, agentID
 	if updated, err := s.store.GetAgent(r.Context(), agent.ID); err == nil {
 		s.events.PublishAgentPorts(r.Context(), updated)
 	}
+	slog.Info("All ports cleared", "agent_id", agent.ID, "caller", identityStringFromContext(r.Context()), "count", portCount)
 	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *Server) proxyAgentPort(w http.ResponseWriter, r *http.Request, agentID string, port int, proxyPath string) {
+	start := time.Now()
 	agent, ok := s.authorizePortAccess(w, r, agentID, ActionPortAccess)
 	if !ok {
 		return
@@ -422,6 +432,15 @@ func (s *Server) proxyAgentPort(w http.ResponseWriter, r *http.Request, agentID 
 	}
 	w.WriteHeader(resp.Status)
 	_, _ = w.Write(resp.Body)
+	slog.Info("Proxy request",
+		"agent_id", agent.ID,
+		"port", port,
+		"caller", identityStringFromContext(r.Context()),
+		"method", r.Method,
+		"path", reqPath,
+		"status", resp.Status,
+		"duration", time.Since(start),
+	)
 }
 
 func (s *Server) handleAgentPortTunnel(w http.ResponseWriter, r *http.Request, agentID string) {
@@ -437,7 +456,7 @@ func (s *Server) handleAgentPortTunnel(w http.ResponseWriter, r *http.Request, a
 	if err != nil {
 		return
 	}
-	session := s.portTunnels.Register(agent.ID, conn)
+	session := s.portTunnels.Register(agent.ID, conn, r.RemoteAddr)
 	<-session.done
 }
 
@@ -553,6 +572,18 @@ func sensitiveHeader(k string) bool {
 	default:
 		return false
 	}
+}
+
+// identityStringFromContext returns a human-readable identity string for the
+// authenticated caller in the request context, for use in audit log entries.
+func identityStringFromContext(ctx context.Context) string {
+	if agent := GetAgentIdentityFromContext(ctx); agent != nil {
+		return "agent:" + agent.ID()
+	}
+	if user := GetUserIdentityFromContext(ctx); user != nil {
+		return "user:" + user.ID()
+	}
+	return "unknown"
 }
 
 // clearExposedPortsForAgent removes all exposed port registrations for an agent.

--- a/pkg/hub/port_forward_handlers.go
+++ b/pkg/hub/port_forward_handlers.go
@@ -1,0 +1,509 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/portforward"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	maxExposedPortsPerAgent = 10
+	maxProxyRequestBody     = 32 << 20
+	portForwardTimeout      = 60 * time.Second
+)
+
+var deniedExposedPorts = map[int]string{
+	18380: "scion metadata server",
+}
+
+var errNoPortTunnel = errors.New("no active port-forward tunnel")
+
+var portTunnelUpgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+type PortTunnelManager struct {
+	mu       sync.RWMutex
+	sessions map[string]*PortTunnelSession
+}
+
+func NewPortTunnelManager() *PortTunnelManager {
+	return &PortTunnelManager{sessions: make(map[string]*PortTunnelSession)}
+}
+
+func (m *PortTunnelManager) Register(agentID string, conn *websocket.Conn) *PortTunnelSession {
+	s := &PortTunnelSession{
+		agentID: agentID,
+		conn:    conn,
+		pending: make(map[string]chan portforward.Response),
+		done:    make(chan struct{}),
+	}
+
+	m.mu.Lock()
+	if old := m.sessions[agentID]; old != nil {
+		old.close()
+	}
+	m.sessions[agentID] = s
+	m.mu.Unlock()
+
+	go s.readLoop(func() {
+		m.mu.Lock()
+		if m.sessions[agentID] == s {
+			delete(m.sessions, agentID)
+		}
+		m.mu.Unlock()
+	})
+	return s
+}
+
+func (m *PortTunnelManager) Do(ctx context.Context, agentID string, req portforward.Request) (*portforward.Response, error) {
+	m.mu.RLock()
+	s := m.sessions[agentID]
+	m.mu.RUnlock()
+	if s == nil {
+		return nil, errNoPortTunnel
+	}
+	return s.do(ctx, req)
+}
+
+type PortTunnelSession struct {
+	agentID string
+	conn    *websocket.Conn
+	writeMu sync.Mutex
+	mu      sync.Mutex
+	pending map[string]chan portforward.Response
+	done    chan struct{}
+	once    sync.Once
+}
+
+func (s *PortTunnelSession) close() {
+	s.once.Do(func() {
+		close(s.done)
+		_ = s.conn.Close()
+		s.mu.Lock()
+		for id, ch := range s.pending {
+			delete(s.pending, id)
+			close(ch)
+		}
+		s.mu.Unlock()
+	})
+}
+
+func (s *PortTunnelSession) readLoop(onClose func()) {
+	defer func() {
+		s.close()
+		onClose()
+	}()
+	for {
+		var msg portforward.Message
+		if err := s.conn.ReadJSON(&msg); err != nil {
+			return
+		}
+		if msg.Type != portforward.MessageTypeResponse && msg.Type != portforward.MessageTypeError {
+			continue
+		}
+		if msg.Response == nil || msg.Response.StreamID == "" {
+			continue
+		}
+		s.mu.Lock()
+		ch := s.pending[msg.Response.StreamID]
+		delete(s.pending, msg.Response.StreamID)
+		s.mu.Unlock()
+		if ch != nil {
+			ch <- *msg.Response
+			close(ch)
+		}
+	}
+}
+
+func (s *PortTunnelSession) do(ctx context.Context, req portforward.Request) (*portforward.Response, error) {
+	ch := make(chan portforward.Response, 1)
+	s.mu.Lock()
+	select {
+	case <-s.done:
+		s.mu.Unlock()
+		return nil, errNoPortTunnel
+	default:
+		s.pending[req.StreamID] = ch
+	}
+	s.mu.Unlock()
+
+	s.writeMu.Lock()
+	err := s.conn.WriteJSON(portforward.Message{Type: portforward.MessageTypeRequest, Request: &req})
+	s.writeMu.Unlock()
+	if err != nil {
+		s.mu.Lock()
+		delete(s.pending, req.StreamID)
+		s.mu.Unlock()
+		return nil, err
+	}
+
+	select {
+	case resp, ok := <-ch:
+		if !ok {
+			return nil, errNoPortTunnel
+		}
+		return &resp, nil
+	case <-ctx.Done():
+		s.mu.Lock()
+		delete(s.pending, req.StreamID)
+		s.mu.Unlock()
+		return nil, ctx.Err()
+	case <-s.done:
+		return nil, errNoPortTunnel
+	}
+}
+
+type registerPortRequest struct {
+	Port  int    `json:"port"`
+	Label string `json:"label,omitempty"`
+	Host  string `json:"host,omitempty"`
+}
+
+type exposedPortResponse struct {
+	store.ExposedPort
+	URL      string `json:"url"`
+	BasePath string `json:"basePath"`
+}
+
+type listPortsResponse struct {
+	Ports []exposedPortResponse `json:"ports"`
+}
+
+func (s *Server) handleAgentPorts(w http.ResponseWriter, r *http.Request, agentID, rest string) {
+	if rest == "" {
+		switch r.Method {
+		case http.MethodGet:
+			s.listAgentPorts(w, r, agentID)
+		case http.MethodPost:
+			s.registerAgentPort(w, r, agentID)
+		case http.MethodDelete:
+			s.clearAgentPorts(w, r, agentID)
+		default:
+			MethodNotAllowed(w)
+		}
+		return
+	}
+
+	if rest == "tunnel" {
+		s.handleAgentPortTunnel(w, r, agentID)
+		return
+	}
+
+	portPart, subpath, _ := strings.Cut(rest, "/")
+	port, err := strconv.Atoi(portPart)
+	if err != nil {
+		NotFound(w, "Port")
+		return
+	}
+	if subpath == "proxy" || strings.HasPrefix(subpath, "proxy/") {
+		s.proxyAgentPort(w, r, agentID, port, strings.TrimPrefix(subpath, "proxy"))
+		return
+	}
+	if subpath != "" {
+		NotFound(w, "Port")
+		return
+	}
+
+	if r.Method == http.MethodDelete {
+		s.deleteAgentPort(w, r, agentID, port)
+		return
+	}
+	MethodNotAllowed(w)
+}
+
+func (s *Server) listAgentPorts(w http.ResponseWriter, r *http.Request, agentID string) {
+	agent, ok := s.authorizePortAccess(w, r, agentID, ActionRead)
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, listPortsResponse{Ports: exposedPortResponses(agent.ID, agent.ExposedPorts)})
+}
+
+func (s *Server) registerAgentPort(w http.ResponseWriter, r *http.Request, agentID string) {
+	agent, ok := s.authorizePortRegistration(w, r, agentID)
+	if !ok {
+		return
+	}
+	var req registerPortRequest
+	if err := readJSON(r, &req); err != nil {
+		BadRequest(w, "Invalid request body: "+err.Error())
+		return
+	}
+	if req.Host == "" {
+		req.Host = "127.0.0.1"
+	}
+	if err := validateExposedPort(req.Port, req.Host); err != nil {
+		ValidationError(w, err.Error(), nil)
+		return
+	}
+	if len(agent.ExposedPorts) >= maxExposedPortsPerAgent && findExposedPort(agent.ExposedPorts, req.Port) == nil {
+		ValidationError(w, "maximum exposed ports per agent exceeded", nil)
+		return
+	}
+
+	ports := append([]store.ExposedPort(nil), agent.ExposedPorts...)
+	if findExposedPort(ports, req.Port) != nil {
+		Conflict(w, "Port already registered")
+		return
+	}
+	now := time.Now().UTC()
+	ports = append(ports, store.ExposedPort{
+		Port:      req.Port,
+		Label:     req.Label,
+		Host:      req.Host,
+		Mode:      "rw",
+		ExposedAt: now,
+		ExposedBy: "agent",
+	})
+	if err := s.store.UpdateAgentExposedPorts(r.Context(), agent.ID, ports); err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+	writeJSON(w, http.StatusCreated, exposedPortResponses(agent.ID, ports)[len(ports)-1])
+}
+
+func (s *Server) deleteAgentPort(w http.ResponseWriter, r *http.Request, agentID string, port int) {
+	agent, ok := s.authorizePortRegistration(w, r, agentID)
+	if !ok {
+		return
+	}
+	ports := make([]store.ExposedPort, 0, len(agent.ExposedPorts))
+	found := false
+	for _, p := range agent.ExposedPorts {
+		if p.Port == port {
+			found = true
+			continue
+		}
+		ports = append(ports, p)
+	}
+	if !found {
+		NotFound(w, "Port")
+		return
+	}
+	if err := s.store.UpdateAgentExposedPorts(r.Context(), agent.ID, ports); err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) clearAgentPorts(w http.ResponseWriter, r *http.Request, agentID string) {
+	agent, ok := s.authorizePortRegistration(w, r, agentID)
+	if !ok {
+		return
+	}
+	if err := s.store.UpdateAgentExposedPorts(r.Context(), agent.ID, nil); err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) proxyAgentPort(w http.ResponseWriter, r *http.Request, agentID string, port int, proxyPath string) {
+	agent, ok := s.authorizePortAccess(w, r, agentID, ActionPortAccess)
+	if !ok {
+		return
+	}
+	exposed := findExposedPort(agent.ExposedPorts, port)
+	if exposed == nil {
+		NotFound(w, "Port")
+		return
+	}
+	if isWebSocketUpgrade(r) {
+		writeError(w, http.StatusNotImplemented, ErrCodeInvalidRequest, "WebSocket port forwarding is not supported in this revision", nil)
+		return
+	}
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxProxyRequestBody))
+	if err != nil {
+		writeError(w, http.StatusRequestEntityTooLarge, ErrCodeInvalidRequest, "Request body too large", nil)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), portForwardTimeout)
+	defer cancel()
+	reqPath := "/" + strings.TrimPrefix(proxyPath, "/")
+	resp, err := s.portTunnels.Do(ctx, agent.ID, portforward.Request{
+		StreamID: uuid.NewString(),
+		Port:     exposed.Port,
+		Host:     exposed.Host,
+		Method:   r.Method,
+		Path:     reqPath,
+		Query:    r.URL.RawQuery,
+		Header:   cloneForwardHeaders(r.Header),
+		Body:     body,
+	})
+	if err != nil {
+		if errors.Is(err, errNoPortTunnel) {
+			writeError(w, http.StatusServiceUnavailable, ErrCodeRuntimeError, "No active port-forward tunnel for this agent", nil)
+			return
+		}
+		writeError(w, http.StatusBadGateway, ErrCodeRuntimeError, "Port-forward tunnel failed: "+err.Error(), nil)
+		return
+	}
+	if resp.Error != "" {
+		writeError(w, http.StatusBadGateway, ErrCodeRuntimeError, resp.Error, nil)
+		return
+	}
+	for k, vals := range resp.Header {
+		if hopByHopHeader(k) {
+			continue
+		}
+		for _, v := range vals {
+			w.Header().Add(k, v)
+		}
+	}
+	if resp.Status == 0 {
+		resp.Status = http.StatusOK
+	}
+	w.WriteHeader(resp.Status)
+	_, _ = w.Write(resp.Body)
+}
+
+func (s *Server) handleAgentPortTunnel(w http.ResponseWriter, r *http.Request, agentID string) {
+	if r.Method != http.MethodGet || !isWebSocketUpgrade(r) {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "WebSocket upgrade required", nil)
+		return
+	}
+	agent, ok := s.authorizePortRegistration(w, r, agentID)
+	if !ok {
+		return
+	}
+	conn, err := portTunnelUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	session := s.portTunnels.Register(agent.ID, conn)
+	<-session.done
+}
+
+func (s *Server) authorizePortAccess(w http.ResponseWriter, r *http.Request, agentID string, action Action) (*store.Agent, bool) {
+	ctx := r.Context()
+	agent, err := s.store.GetAgent(ctx, agentID)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return nil, false
+	}
+	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+		if agentIdent.ID() != agent.ID || agentIdent.ProjectID() != agent.ProjectID {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agents can only access their own port registrations", nil)
+			return nil, false
+		}
+		return agent, true
+	}
+	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+		decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), action)
+		if !decision.Allowed {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Access denied", nil)
+			return nil, false
+		}
+		return agent, true
+	}
+	writeError(w, http.StatusForbidden, ErrCodeForbidden, "This action requires user or agent authentication", nil)
+	return nil, false
+}
+
+func (s *Server) authorizePortRegistration(w http.ResponseWriter, r *http.Request, agentID string) (*store.Agent, bool) {
+	agent, ok := s.authorizePortAccess(w, r, agentID, ActionPortAccess)
+	if !ok {
+		return nil, false
+	}
+	if agentIdent := GetAgentIdentityFromContext(r.Context()); agentIdent != nil {
+		if !agentIdent.HasScope(ScopeAgentPortForward) {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Missing required scope: agent:port:forward", nil)
+			return nil, false
+		}
+		return agent, true
+	}
+	if userIdent := GetUserIdentityFromContext(r.Context()); userIdent != nil && userIdent.Role() == "admin" {
+		return agent, true
+	}
+	writeError(w, http.StatusForbidden, ErrCodeForbidden, "Only the agent can manage its exposed ports", nil)
+	return nil, false
+}
+
+func exposedPortResponses(agentID string, ports []store.ExposedPort) []exposedPortResponse {
+	responses := make([]exposedPortResponse, 0, len(ports))
+	for _, p := range ports {
+		base := fmt.Sprintf("/api/v1/agents/%s/ports/%d/proxy/", url.PathEscape(agentID), p.Port)
+		responses = append(responses, exposedPortResponse{ExposedPort: p, URL: base, BasePath: base})
+	}
+	return responses
+}
+
+func findExposedPort(ports []store.ExposedPort, port int) *store.ExposedPort {
+	for i := range ports {
+		if ports[i].Port == port {
+			return &ports[i]
+		}
+	}
+	return nil
+}
+
+func validateExposedPort(port int, host string) error {
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("port must be between 1 and 65535")
+	}
+	if !isLoopbackHost(host) {
+		return fmt.Errorf("host must be loopback in this revision")
+	}
+	if reason := deniedExposedPorts[port]; reason != "" {
+		return fmt.Errorf("port %d is reserved for %s", port, reason)
+	}
+	return nil
+}
+
+func isLoopbackHost(host string) bool {
+	switch strings.ToLower(strings.TrimSpace(host)) {
+	case "localhost":
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func cloneForwardHeaders(in http.Header) http.Header {
+	out := make(http.Header, len(in))
+	for k, vals := range in {
+		if hopByHopHeader(k) {
+			continue
+		}
+		out[k] = append([]string(nil), vals...)
+	}
+	return out
+}
+
+func hopByHopHeader(k string) bool {
+	switch strings.ToLower(k) {
+	case "connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade":
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/hub/port_forward_handlers.go
+++ b/pkg/hub/port_forward_handlers.go
@@ -37,7 +37,7 @@ const (
 	maxExposedPortsPerAgent = 10
 	maxProxyRequestBody     = 32 << 20
 	portForwardTimeout      = 60 * time.Second
-	maxConcurrentStreams     = 64
+	maxConcurrentStreams    = 64
 )
 
 var deniedExposedPorts = map[int]string{
@@ -46,8 +46,8 @@ var deniedExposedPorts = map[int]string{
 	18380: "scion metadata server",
 }
 
-var errNoPortTunnel     = errors.New("no active port-forward tunnel")
-var errTunnelBusy       = errors.New("too many concurrent port-forward requests")
+var errNoPortTunnel = errors.New("no active port-forward tunnel")
+var errTunnelBusy = errors.New("too many concurrent port-forward requests")
 
 var portTunnelUpgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool { return true },
@@ -170,6 +170,7 @@ func (s *PortTunnelSession) do(ctx context.Context, req portforward.Request) (*p
 	s.mu.Unlock()
 
 	s.writeMu.Lock()
+	_ = s.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
 	err := s.conn.WriteJSON(portforward.Message{Type: portforward.MessageTypeRequest, Request: &req})
 	s.writeMu.Unlock()
 	if err != nil {

--- a/pkg/hub/port_forward_handlers.go
+++ b/pkg/hub/port_forward_handlers.go
@@ -287,6 +287,10 @@ func (s *Server) registerAgentPort(w http.ResponseWriter, r *http.Request, agent
 		writeErrorFromErr(w, err, "")
 		return
 	}
+	// Re-read agent for committed state
+	if updated, err := s.store.GetAgent(r.Context(), agent.ID); err == nil {
+		s.events.PublishAgentPorts(r.Context(), updated)
+	}
 	writeJSON(w, http.StatusCreated, exposedPortResponses(agent.ID, ports)[len(ports)-1])
 }
 
@@ -312,6 +316,10 @@ func (s *Server) deleteAgentPort(w http.ResponseWriter, r *http.Request, agentID
 		writeErrorFromErr(w, err, "")
 		return
 	}
+	// Re-read agent for committed state
+	if updated, err := s.store.GetAgent(r.Context(), agent.ID); err == nil {
+		s.events.PublishAgentPorts(r.Context(), updated)
+	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -323,6 +331,10 @@ func (s *Server) clearAgentPorts(w http.ResponseWriter, r *http.Request, agentID
 	if err := s.store.UpdateAgentExposedPorts(r.Context(), agent.ID, nil); err != nil {
 		writeErrorFromErr(w, err, "")
 		return
+	}
+	// Re-read agent for committed state
+	if updated, err := s.store.GetAgent(r.Context(), agent.ID); err == nil {
+		s.events.PublishAgentPorts(r.Context(), updated)
 	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/pkg/hub/port_forward_handlers.go
+++ b/pkg/hub/port_forward_handlers.go
@@ -432,7 +432,7 @@ func (s *Server) proxyAgentPort(w http.ResponseWriter, r *http.Request, agentID 
 	}
 	w.WriteHeader(resp.Status)
 	_, _ = w.Write(resp.Body)
-	slog.Info("Proxy request",
+	slog.Debug("Proxy request",
 		"agent_id", agent.ID,
 		"port", port,
 		"caller", identityStringFromContext(r.Context()),
@@ -602,7 +602,10 @@ func (s *Server) clearExposedPortsForAgent(ctx context.Context, agentID string) 
 		slog.Warn("clearExposedPortsForAgent: failed to clear ports", "agent_id", agentID, "error", err)
 		return
 	}
-	s.events.PublishAgentPorts(ctx, agent)
+	// Re-read agent for committed state (matches HTTP handler pattern)
+	if updated, err := s.store.GetAgent(ctx, agentID); err == nil {
+		s.events.PublishAgentPorts(ctx, updated)
+	}
 	slog.Info("Cleared exposed ports for agent", "agent_id", agentID, "count", len(agent.ExposedPorts))
 }
 
@@ -618,6 +621,9 @@ func (s *Server) exposedPortsSweepHandler() func(ctx context.Context) {
 		defer cancel()
 
 		// List all agents including soft-deleted ones so we catch every stale registration.
+		// Limit: 500 is a deliberate bound — sufficient for typical deployments since
+		// port-forwarding agents are a small subset of total agents. The sweep runs
+		// every 5 minutes, so any overflow is caught on subsequent runs.
 		result, err := s.store.ListAgents(ctx, store.AgentFilter{IncludeDeleted: true}, store.ListOptions{Limit: 500})
 		if err != nil {
 			slog.Error("Scheduler: exposed-ports sweep failed to list agents", "error", err)
@@ -645,7 +651,10 @@ func (s *Server) exposedPortsSweepHandler() func(ctx context.Context) {
 					"agent_id", agent.ID, "error", err)
 				continue
 			}
-			s.events.PublishAgentPorts(ctx, &agent)
+			// Re-read agent for committed state (matches HTTP handler pattern)
+			if updated, err := s.store.GetAgent(ctx, agent.ID); err == nil {
+				s.events.PublishAgentPorts(ctx, updated)
+			}
 			cleared++
 		}
 

--- a/pkg/hub/port_forward_handlers.go
+++ b/pkg/hub/port_forward_handlers.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -27,6 +28,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/portforward"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/google/uuid"
@@ -54,8 +56,9 @@ var portTunnelUpgrader = websocket.Upgrader{
 }
 
 type PortTunnelManager struct {
-	mu       sync.RWMutex
-	sessions map[string]*PortTunnelSession
+	mu           sync.RWMutex
+	sessions     map[string]*PortTunnelSession
+	onDisconnect func(agentID string) // called when a tunnel session disconnects
 }
 
 func NewPortTunnelManager() *PortTunnelManager {
@@ -84,7 +87,11 @@ func (m *PortTunnelManager) Register(agentID string, conn *websocket.Conn) *Port
 		if m.sessions[agentID] == s {
 			delete(m.sessions, agentID)
 		}
+		onDisconnect := m.onDisconnect
 		m.mu.Unlock()
+		if onDisconnect != nil {
+			onDisconnect(agentID)
+		}
 	})
 	return s
 }
@@ -545,5 +552,74 @@ func sensitiveHeader(k string) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// clearExposedPortsForAgent removes all exposed port registrations for an agent.
+// It is best-effort: failures are logged but do not propagate, because the
+// caller (stop, delete, tunnel disconnect) should not be blocked by cleanup.
+func (s *Server) clearExposedPortsForAgent(ctx context.Context, agentID string) {
+	agent, err := s.store.GetAgent(ctx, agentID)
+	if err != nil {
+		slog.Debug("clearExposedPortsForAgent: agent lookup failed", "agent_id", agentID, "error", err)
+		return
+	}
+	if len(agent.ExposedPorts) == 0 {
+		return
+	}
+	if err := s.store.UpdateAgentExposedPorts(ctx, agentID, nil); err != nil {
+		slog.Warn("clearExposedPortsForAgent: failed to clear ports", "agent_id", agentID, "error", err)
+		return
+	}
+	s.events.PublishAgentPorts(ctx, agent)
+	slog.Info("Cleared exposed ports for agent", "agent_id", agentID, "count", len(agent.ExposedPorts))
+}
+
+// exposedPortsSweepHandler returns a recurring handler that cleans up stale
+// exposed-port registrations. It lists all agents, identifies those with
+// non-empty ExposedPorts whose phase is terminal (stopped, error) or that
+// have been soft-deleted, and clears their port registrations. This catches
+// any ports that were not cleared by active teardown (tunnel disconnect,
+// explicit stop/delete).
+func (s *Server) exposedPortsSweepHandler() func(ctx context.Context) {
+	return func(ctx context.Context) {
+		ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+
+		// List all agents including soft-deleted ones so we catch every stale registration.
+		result, err := s.store.ListAgents(ctx, store.AgentFilter{IncludeDeleted: true}, store.ListOptions{Limit: 500})
+		if err != nil {
+			slog.Error("Scheduler: exposed-ports sweep failed to list agents", "error", err)
+			return
+		}
+
+		cleared := 0
+		for _, agent := range result.Items {
+			if len(agent.ExposedPorts) == 0 {
+				continue
+			}
+
+			// An agent's ports are stale if the agent is soft-deleted or in a
+			// terminal phase (stopped, error). We are generous: running,
+			// suspended, provisioning, starting, etc. are left alone.
+			isDeleted := !agent.DeletedAt.IsZero()
+			isTerminal := agent.Phase == string(state.PhaseStopped) || agent.Phase == string(state.PhaseError)
+
+			if !isDeleted && !isTerminal {
+				continue
+			}
+
+			if err := s.store.UpdateAgentExposedPorts(ctx, agent.ID, nil); err != nil {
+				slog.Warn("Scheduler: exposed-ports sweep failed to clear ports",
+					"agent_id", agent.ID, "error", err)
+				continue
+			}
+			s.events.PublishAgentPorts(ctx, &agent)
+			cleared++
+		}
+
+		if cleared > 0 {
+			slog.Info("Scheduler: exposed-ports sweep cleared stale registrations", "count", cleared)
+		}
 	}
 }

--- a/pkg/hub/port_forward_handlers.go
+++ b/pkg/hub/port_forward_handlers.go
@@ -86,7 +86,8 @@ func (m *PortTunnelManager) Register(agentID string, conn *websocket.Conn, remot
 
 	go s.readLoop(func() {
 		m.mu.Lock()
-		if m.sessions[agentID] == s {
+		isCurrent := m.sessions[agentID] == s
+		if isCurrent {
 			delete(m.sessions, agentID)
 		}
 		onDisconnect := m.onDisconnect
@@ -94,7 +95,7 @@ func (m *PortTunnelManager) Register(agentID string, conn *websocket.Conn, remot
 
 		slog.Info("Port-forward tunnel disconnected", "agent_id", agentID)
 
-		if onDisconnect != nil {
+		if isCurrent && onDisconnect != nil {
 			onDisconnect(agentID)
 		}
 	})

--- a/pkg/hub/port_forward_handlers_test.go
+++ b/pkg/hub/port_forward_handlers_test.go
@@ -164,7 +164,7 @@ func TestAgentPortClearedOnTunnelDisconnect(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got.ExposedPorts, 1)
 
-	// Simulate tunnel disconnect by calling onDisconnect directly
+	// Simulate tunnel disconnect by calling clearExposedPortsForAgent directly
 	srv.clearExposedPortsForAgent(context.Background(), agent.ID)
 
 	// Verify ports are cleared
@@ -227,6 +227,19 @@ func TestAgentPortSweepClearsStaleRegistrations(t *testing.T) {
 		{Port: 3000, Label: "stale", Host: "127.0.0.1", Mode: "rw", ExposedAt: time.Now(), ExposedBy: "agent"},
 	}))
 
+	// Create an errored agent with ports (should also be cleared)
+	erroredAgent := &store.Agent{
+		ID:        tid("pf-errored-agent"),
+		Slug:      "pf-errored-agent",
+		Name:      "Errored Agent",
+		ProjectID: project.ID,
+		Phase:     string(state.PhaseError),
+	}
+	require.NoError(t, s.CreateAgent(ctx, erroredAgent))
+	require.NoError(t, s.UpdateAgentExposedPorts(ctx, erroredAgent.ID, []store.ExposedPort{
+		{Port: 5000, Label: "error-stale", Host: "127.0.0.1", Mode: "rw", ExposedAt: time.Now(), ExposedBy: "agent"},
+	}))
+
 	// Create a running agent with ports (should not be cleared)
 	runningAgent := &store.Agent{
 		ID:        tid("pf-running-agent"),
@@ -248,6 +261,11 @@ func TestAgentPortSweepClearsStaleRegistrations(t *testing.T) {
 	got, err := s.GetAgent(ctx, stoppedAgent.ID)
 	require.NoError(t, err)
 	assert.Empty(t, got.ExposedPorts, "stopped agent should have ports cleared")
+
+	// Errored agent's ports should be cleared
+	got, err = s.GetAgent(ctx, erroredAgent.ID)
+	require.NoError(t, err)
+	assert.Empty(t, got.ExposedPorts, "errored agent should have ports cleared")
 
 	// Running agent's ports should remain
 	got, err = s.GetAgent(ctx, runningAgent.ID)

--- a/pkg/hub/port_forward_handlers_test.go
+++ b/pkg/hub/port_forward_handlers_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	scionhub "github.com/GoogleCloudPlatform/scion/pkg/sciontool/hub"
+	scionportforward "github.com/GoogleCloudPlatform/scion/pkg/sciontool/portforward"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentPortRegistrationLifecycle(t *testing.T) {
+	srv, s := testServer(t)
+	agent, token := createPortForwardAgent(t, srv, s)
+
+	rec := doAgentTokenRequest(t, srv, http.MethodPost, "/api/v1/agents/"+agent.ID+"/ports", map[string]any{
+		"port":  3000,
+		"label": "dev",
+	}, token)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var created exposedPortResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &created))
+	assert.Equal(t, 3000, created.Port)
+	assert.Equal(t, "dev", created.Label)
+	assert.Equal(t, "127.0.0.1", created.Host)
+	assert.Equal(t, "/api/v1/agents/"+agent.ID+"/ports/3000/proxy/", created.BasePath)
+
+	rec = doAgentTokenRequest(t, srv, http.MethodGet, "/api/v1/agents/"+agent.ID+"/ports", nil, token)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var listed listPortsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &listed))
+	require.Len(t, listed.Ports, 1)
+	assert.Equal(t, 3000, listed.Ports[0].Port)
+
+	rec = doAgentTokenRequest(t, srv, http.MethodDelete, "/api/v1/agents/"+agent.ID+"/ports/3000", nil, token)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	got, err := s.GetAgent(context.Background(), agent.ID)
+	require.NoError(t, err)
+	assert.Empty(t, got.ExposedPorts)
+}
+
+func TestAgentPortRegistrationRejectsNonLoopbackHost(t *testing.T) {
+	srv, s := testServer(t)
+	agent, token := createPortForwardAgent(t, srv, s)
+
+	rec := doAgentTokenRequest(t, srv, http.MethodPost, "/api/v1/agents/"+agent.ID+"/ports", map[string]any{
+		"port": 3000,
+		"host": "10.0.0.1",
+	}, token)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestAgentPortRegistrationRejectsReservedPort(t *testing.T) {
+	srv, s := testServer(t)
+	agent, token := createPortForwardAgent(t, srv, s)
+
+	rec := doAgentTokenRequest(t, srv, http.MethodPost, "/api/v1/agents/"+agent.ID+"/ports", map[string]any{
+		"port": 18380,
+	}, token)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestAgentPortProxyNoTunnelReturns503(t *testing.T) {
+	srv, s := testServer(t)
+	agent, token := createPortForwardAgent(t, srv, s)
+
+	rec := doAgentTokenRequest(t, srv, http.MethodPost, "/api/v1/agents/"+agent.ID+"/ports", map[string]any{
+		"port": 3000,
+	}, token)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	rec = doAgentTokenRequest(t, srv, http.MethodGet, "/api/v1/agents/"+agent.ID+"/ports/3000/proxy/", nil, token)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestAgentPortProxyThroughTunnel(t *testing.T) {
+	srv, s := testServer(t)
+	hubHTTP := httptest.NewServer(srv.Handler())
+	t.Cleanup(hubHTTP.Close)
+
+	app := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/hello", r.URL.Path)
+		assert.Equal(t, "1", r.URL.Query().Get("x"))
+		w.Header().Set("X-App", "ok")
+		_, _ = w.Write([]byte("hello from app"))
+	}))
+	t.Cleanup(app.Close)
+
+	appURL, err := url.Parse(app.URL)
+	require.NoError(t, err)
+	host, portText, err := net.SplitHostPort(appURL.Host)
+	require.NoError(t, err)
+	port, err := net.LookupPort("tcp", portText)
+	require.NoError(t, err)
+	if strings.TrimSpace(host) == "" {
+		host = "127.0.0.1"
+	}
+
+	agent, token := createPortForwardAgent(t, srv, s)
+	rec := doAgentTokenRequest(t, srv, http.MethodPost, "/api/v1/agents/"+agent.ID+"/ports", map[string]any{
+		"port": port,
+		"host": host,
+	}, token)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	manager := scionportforward.NewManager(scionhub.NewClientWithConfig(hubHTTP.URL, token, agent.ID))
+	go manager.Run(ctx)
+	require.Eventually(t, func() bool {
+		srv.portTunnels.mu.RLock()
+		defer srv.portTunnels.mu.RUnlock()
+		return srv.portTunnels.sessions[agent.ID] != nil
+	}, 5*time.Second, 50*time.Millisecond)
+
+	rec = doAgentTokenRequest(t, srv, http.MethodGet, "/api/v1/agents/"+agent.ID+"/ports/"+portText+"/proxy/hello?x=1", nil, token)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok", rec.Header().Get("X-App"))
+	assert.Equal(t, "hello from app", rec.Body.String())
+}
+
+func createPortForwardAgent(t *testing.T, srv *Server, s store.Store) (*store.Agent, string) {
+	t.Helper()
+	ctx := context.Background()
+	project := &store.Project{
+		ID:   tid("pf-project"),
+		Name: "Port Forwarding",
+		Slug: "port-forwarding",
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	agent := &store.Agent{
+		ID:        tid("pf-agent"),
+		Slug:      "pf-agent",
+		Name:      "PF Agent",
+		ProjectID: project.ID,
+		Phase:     string(state.PhaseRunning),
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	tokenSvc := srv.GetAgentTokenService()
+	require.NotNil(t, tokenSvc)
+	token, err := tokenSvc.GenerateAgentToken(agent.ID, project.ID, []AgentTokenScope{ScopeAgentPortForward}, nil)
+	require.NoError(t, err)
+	return agent, token
+}
+
+func doAgentTokenRequest(t *testing.T, srv *Server, method, path string, body any, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = json.Marshal(body)
+		require.NoError(t, err)
+	}
+	req := httptest.NewRequest(method, path, bytes.NewReader(bodyBytes))
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("X-Scion-Agent-Token", token)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
+}

--- a/pkg/hub/port_forward_handlers_test.go
+++ b/pkg/hub/port_forward_handlers_test.go
@@ -148,6 +148,113 @@ func TestAgentPortProxyThroughTunnel(t *testing.T) {
 	assert.Equal(t, "hello from app", rec.Body.String())
 }
 
+func TestAgentPortClearedOnTunnelDisconnect(t *testing.T) {
+	srv, s := testServer(t)
+	agent, token := createPortForwardAgent(t, srv, s)
+
+	// Register a port
+	rec := doAgentTokenRequest(t, srv, http.MethodPost, "/api/v1/agents/"+agent.ID+"/ports", map[string]any{
+		"port":  4000,
+		"label": "tunnel-test",
+	}, token)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	// Verify port is registered
+	got, err := s.GetAgent(context.Background(), agent.ID)
+	require.NoError(t, err)
+	require.Len(t, got.ExposedPorts, 1)
+
+	// Simulate tunnel disconnect by calling onDisconnect directly
+	srv.clearExposedPortsForAgent(context.Background(), agent.ID)
+
+	// Verify ports are cleared
+	got, err = s.GetAgent(context.Background(), agent.ID)
+	require.NoError(t, err)
+	assert.Empty(t, got.ExposedPorts)
+}
+
+func TestAgentPortClearedOnStop(t *testing.T) {
+	srv, s := testServer(t)
+	agent, token := createPortForwardAgent(t, srv, s)
+
+	// Register a port
+	rec := doAgentTokenRequest(t, srv, http.MethodPost, "/api/v1/agents/"+agent.ID+"/ports", map[string]any{
+		"port":  5000,
+		"label": "stop-test",
+	}, token)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	// Verify port is registered
+	got, err := s.GetAgent(context.Background(), agent.ID)
+	require.NoError(t, err)
+	require.Len(t, got.ExposedPorts, 1)
+
+	// Simulate hub setting agent to stopped (as handleAgentLifecycle does)
+	srv.clearExposedPortsForAgent(context.Background(), agent.ID)
+	require.NoError(t, s.UpdateAgentStatus(context.Background(), agent.ID, store.AgentStatusUpdate{
+		Phase:           string(state.PhaseStopped),
+		ContainerStatus: "stopped",
+	}))
+
+	// Verify ports are cleared
+	got, err = s.GetAgent(context.Background(), agent.ID)
+	require.NoError(t, err)
+	assert.Empty(t, got.ExposedPorts)
+	assert.Equal(t, string(state.PhaseStopped), got.Phase)
+}
+
+func TestAgentPortSweepClearsStaleRegistrations(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:   tid("pf-sweep-project"),
+		Name: "Port Sweep Test",
+		Slug: "port-sweep-test",
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	// Create a stopped agent with ports
+	stoppedAgent := &store.Agent{
+		ID:        tid("pf-stopped-agent"),
+		Slug:      "pf-stopped-agent",
+		Name:      "Stopped Agent",
+		ProjectID: project.ID,
+		Phase:     string(state.PhaseStopped),
+	}
+	require.NoError(t, s.CreateAgent(ctx, stoppedAgent))
+	require.NoError(t, s.UpdateAgentExposedPorts(ctx, stoppedAgent.ID, []store.ExposedPort{
+		{Port: 3000, Label: "stale", Host: "127.0.0.1", Mode: "rw", ExposedAt: time.Now(), ExposedBy: "agent"},
+	}))
+
+	// Create a running agent with ports (should not be cleared)
+	runningAgent := &store.Agent{
+		ID:        tid("pf-running-agent"),
+		Slug:      "pf-running-agent",
+		Name:      "Running Agent",
+		ProjectID: project.ID,
+		Phase:     string(state.PhaseRunning),
+	}
+	require.NoError(t, s.CreateAgent(ctx, runningAgent))
+	require.NoError(t, s.UpdateAgentExposedPorts(ctx, runningAgent.ID, []store.ExposedPort{
+		{Port: 4000, Label: "active", Host: "127.0.0.1", Mode: "rw", ExposedAt: time.Now(), ExposedBy: "agent"},
+	}))
+
+	// Run the sweep
+	handler := srv.exposedPortsSweepHandler()
+	handler(ctx)
+
+	// Stopped agent's ports should be cleared
+	got, err := s.GetAgent(ctx, stoppedAgent.ID)
+	require.NoError(t, err)
+	assert.Empty(t, got.ExposedPorts, "stopped agent should have ports cleared")
+
+	// Running agent's ports should remain
+	got, err = s.GetAgent(ctx, runningAgent.ID)
+	require.NoError(t, err)
+	assert.Len(t, got.ExposedPorts, 1, "running agent should keep its ports")
+}
+
 func createPortForwardAgent(t *testing.T, srv *Server, s store.Store) (*store.Agent, string) {
 	t.Helper()
 	ctx := context.Background()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -637,6 +637,7 @@ type Server struct {
 	auditLogger            AuditLogger             // Audit logger for security events
 	metrics                MetricsRecorder         // Metrics recorder for broker auth
 	controlChannel         *ControlChannelManager  // WebSocket control channel for runtime brokers
+	portTunnels            *PortTunnelManager      // Agent-held port-forward tunnels
 	authzService           *AuthzService           // Authorization service for policy evaluation
 	events                 EventPublisher          // Event publisher for real-time SSE updates
 	commandBus             CommandBus              // Inter-node dispatch signal bus (nil-safe; nil = no-op)
@@ -797,6 +798,7 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 		workstation: cfg.Workstation,
 		ctx:         srvCtx,
 		ctxCancel:   srvCancel,
+		portTunnels: NewPortTunnelManager(),
 
 		// Subsystem loggers
 		agentLifecycleLog: logging.Subsystem("hub.agent-lifecycle"),
@@ -2014,7 +2016,7 @@ func (s *Server) GenerateAgentToken(agentID, projectID string, ancestry []string
 		return "", fmt.Errorf("agent token service not initialized")
 	}
 
-	scopes := []AgentTokenScope{ScopeAgentStatusUpdate, ScopeAgentTokenRefresh, ScopeAgentNotify}
+	scopes := []AgentTokenScope{ScopeAgentStatusUpdate, ScopeAgentTokenRefresh, ScopeAgentNotify, ScopeAgentPortForward}
 
 	// In dev-auth mode, auto-grant agent creation and lifecycle scopes
 	// so agents can create sub-agents without explicit template configuration.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -811,6 +811,13 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 		maintenanceLog:    logging.Subsystem("hub.maintenance"),
 	}
 
+	// Wire tunnel disconnect handler: when an agent's port-forward tunnel
+	// closes (readLoop exits), clear its exposed port registrations so stale
+	// ports are not advertised.
+	srv.portTunnels.onDisconnect = func(agentID string) {
+		srv.clearExposedPortsForAgent(context.Background(), agentID)
+	}
+
 	// Shared federation HTTP client: no redirect following to prevent
 	// credential leakage via Authorization header on cross-origin redirects.
 	srv.federationClient = &http.Client{
@@ -2623,6 +2630,7 @@ func (s *Server) StartBackgroundServices(ctx context.Context) {
 	s.scheduler.RegisterRecurringSingleton("schedule-evaluator", 1, store.LockScheduleEvaluator, s.evaluateSchedulesHandler())
 	s.scheduler.RegisterRecurringSingleton("broker-affinity-reap", 5, store.LockBrokerAffinityReap, s.brokerAffinityReapHandler())
 	s.scheduler.RegisterRecurringSingleton("broker-message-sweep", 5, store.LockBrokerMessageSweep, s.brokerMessageSweepHandler())
+	s.scheduler.RegisterRecurringSingleton("exposed-ports-sweep", 5, store.LockExposedPortsSweep, s.exposedPortsSweepHandler())
 
 	// Register GitHub resolution cache TTL eviction (every 10 minutes)
 	if s.ghResolutionStore != nil {

--- a/pkg/portforward/protocol.go
+++ b/pkg/portforward/protocol.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portforward
+
+import "net/http"
+
+const (
+	MessageTypeRequest  = "request"
+	MessageTypeResponse = "response"
+	MessageTypeError    = "error"
+)
+
+type Request struct {
+	StreamID string      `json:"streamId"`
+	Port     int         `json:"port"`
+	Host     string      `json:"host"`
+	Method   string      `json:"method"`
+	Path     string      `json:"path"`
+	Query    string      `json:"query,omitempty"`
+	Header   http.Header `json:"header,omitempty"`
+	Body     []byte      `json:"body,omitempty"`
+}
+
+type Response struct {
+	StreamID string      `json:"streamId"`
+	Status   int         `json:"status"`
+	Header   http.Header `json:"header,omitempty"`
+	Body     []byte      `json:"body,omitempty"`
+	Error    string      `json:"error,omitempty"`
+}
+
+type Message struct {
+	Type     string    `json:"type"`
+	Request  *Request  `json:"request,omitempty"`
+	Response *Response `json:"response,omitempty"`
+}

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -237,6 +237,29 @@ func (c *Client) IsConfigured() bool {
 	return c.hubURL != "" && token != "" && c.agentID != ""
 }
 
+func (c *Client) HubURL() string {
+	if c == nil {
+		return ""
+	}
+	return c.hubURL
+}
+
+func (c *Client) AgentID() string {
+	if c == nil {
+		return ""
+	}
+	return c.agentID
+}
+
+func (c *Client) AuthToken() string {
+	if c == nil {
+		return ""
+	}
+	c.tokenMu.RLock()
+	defer c.tokenMu.RUnlock()
+	return c.token
+}
+
 // IsHostedMode returns true if the agent is running in hosted mode.
 func IsHostedMode() bool {
 	return os.Getenv(EnvAgentMode) == AgentModeHosted
@@ -368,6 +391,117 @@ type SetSecretResponse struct {
 	Key     string `json:"key"`
 	Scope   string `json:"scope"`
 	ScopeID string `json:"scopeId"`
+}
+
+type ExposedPort struct {
+	Port      int       `json:"port"`
+	Label     string    `json:"label,omitempty"`
+	Host      string    `json:"host,omitempty"`
+	Mode      string    `json:"mode,omitempty"`
+	ExposedAt time.Time `json:"exposedAt"`
+	ExposedBy string    `json:"exposedBy"`
+	URL       string    `json:"url"`
+	BasePath  string    `json:"basePath"`
+}
+
+type RegisterPortRequest struct {
+	Port  int    `json:"port"`
+	Label string `json:"label,omitempty"`
+	Host  string `json:"host,omitempty"`
+}
+
+type ListPortsResponse struct {
+	Ports []ExposedPort `json:"ports"`
+}
+
+func (c *Client) RegisterPort(ctx context.Context, req RegisterPortRequest) (*ExposedPort, error) {
+	if !c.IsConfigured() {
+		return nil, fmt.Errorf("hub client not configured")
+	}
+	endpoint := fmt.Sprintf("%s/api/v1/agents/%s/ports", strings.TrimSuffix(c.hubURL, "/"), c.agentID)
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("X-Scion-Agent-Token", c.AuthToken())
+	resp, err := c.client.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("hub returned error %d: %s", resp.StatusCode, string(respBody))
+	}
+	var out ExposedPort
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, err
+	}
+	out.URL = c.absoluteURL(out.URL)
+	return &out, nil
+}
+
+func (c *Client) ListPorts(ctx context.Context) ([]ExposedPort, error) {
+	if !c.IsConfigured() {
+		return nil, fmt.Errorf("hub client not configured")
+	}
+	endpoint := fmt.Sprintf("%s/api/v1/agents/%s/ports", strings.TrimSuffix(c.hubURL, "/"), c.agentID)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("X-Scion-Agent-Token", c.AuthToken())
+	resp, err := c.client.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("hub returned error %d: %s", resp.StatusCode, string(respBody))
+	}
+	var out ListPortsResponse
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, err
+	}
+	for i := range out.Ports {
+		out.Ports[i].URL = c.absoluteURL(out.Ports[i].URL)
+	}
+	return out.Ports, nil
+}
+
+func (c *Client) DeletePort(ctx context.Context, port int) error {
+	if !c.IsConfigured() {
+		return fmt.Errorf("hub client not configured")
+	}
+	endpoint := fmt.Sprintf("%s/api/v1/agents/%s/ports/%d", strings.TrimSuffix(c.hubURL, "/"), c.agentID, port)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("X-Scion-Agent-Token", c.AuthToken())
+	resp, err := c.client.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("hub returned error %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+func (c *Client) absoluteURL(path string) string {
+	if path == "" || strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return path
+	}
+	return strings.TrimSuffix(c.hubURL, "/") + path
 }
 
 // SetSecret stores a project-scoped secret via the Hub API.

--- a/pkg/sciontool/portforward/tunnel.go
+++ b/pkg/sciontool/portforward/tunnel.go
@@ -58,8 +58,13 @@ func (m *Manager) Run(ctx context.Context) {
 		return
 	}
 	for {
-		if err := m.runOnce(ctx); err != nil && ctx.Err() == nil {
-			log.Error("Port-forward tunnel disconnected: %v", err)
+		err := m.runOnce(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				log.Info("Port-forward tunnel disconnected: context cancelled")
+			} else {
+				log.Error("Port-forward tunnel disconnected: %v", err)
+			}
 		}
 		select {
 		case <-ctx.Done():
@@ -150,6 +155,7 @@ func (m *Manager) doLocalRequest(req *wire.Request) *wire.Response {
 	if len(body) > maxLocalResponseBody {
 		return &wire.Response{StreamID: req.StreamID, Error: "local response body too large"}
 	}
+	log.Debug("Local request forwarded: port=%d method=%s path=%s status=%d", req.Port, req.Method, req.Path, resp.StatusCode)
 	return &wire.Response{
 		StreamID: req.StreamID,
 		Status:   resp.StatusCode,

--- a/pkg/sciontool/portforward/tunnel.go
+++ b/pkg/sciontool/portforward/tunnel.go
@@ -113,14 +113,16 @@ func (m *Manager) handleRequest(conn *websocket.Conn, req *wire.Request) {
 	}
 }
 
-func (m *Manager) doLocalRequest(req *wire.Request) *wire.Response {
-	isLoopback := strings.ToLower(strings.TrimSpace(req.Host)) == "localhost"
-	if !isLoopback {
-		if ip := net.ParseIP(req.Host); ip != nil && ip.IsLoopback() {
-			isLoopback = true
-		}
+func isLoopbackHost(host string) bool {
+	if strings.ToLower(strings.TrimSpace(host)) == "localhost" {
+		return true
 	}
-	if !isLoopback {
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func (m *Manager) doLocalRequest(req *wire.Request) *wire.Response {
+	if !isLoopbackHost(req.Host) {
 		return &wire.Response{StreamID: req.StreamID, Error: "unauthorized host: only loopback addresses are allowed"}
 	}
 	target := url.URL{

--- a/pkg/sciontool/portforward/tunnel.go
+++ b/pkg/sciontool/portforward/tunnel.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portforward
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	wire "github.com/GoogleCloudPlatform/scion/pkg/portforward"
+	scionhub "github.com/GoogleCloudPlatform/scion/pkg/sciontool/hub"
+	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/log"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	reconnectDelay       = 5 * time.Second
+	localRequestTimeout  = 60 * time.Second
+	maxLocalResponseBody = 64 << 20
+)
+
+type Manager struct {
+	client  *scionhub.Client
+	http    *http.Client
+	writeMu sync.Mutex
+}
+
+func NewManager(client *scionhub.Client) *Manager {
+	return &Manager{
+		client: client,
+		http: &http.Client{
+			Timeout: localRequestTimeout,
+		},
+	}
+}
+
+func (m *Manager) Run(ctx context.Context) {
+	if m == nil || !m.client.IsConfigured() {
+		return
+	}
+	for {
+		if err := m.runOnce(ctx); err != nil && ctx.Err() == nil {
+			log.Error("Port-forward tunnel disconnected: %v", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(reconnectDelay):
+		}
+	}
+}
+
+func (m *Manager) runOnce(ctx context.Context) error {
+	endpoint, err := tunnelURL(m.client.HubURL(), m.client.AgentID())
+	if err != nil {
+		return err
+	}
+	header := http.Header{}
+	header.Set("X-Scion-Agent-Token", m.client.AuthToken())
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, endpoint, header)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	log.Info("Port-forward tunnel connected")
+	for {
+		var msg wire.Message
+		if err := conn.ReadJSON(&msg); err != nil {
+			return err
+		}
+		if msg.Type != wire.MessageTypeRequest || msg.Request == nil {
+			continue
+		}
+		go m.handleRequest(conn, msg.Request)
+	}
+}
+
+func (m *Manager) handleRequest(conn *websocket.Conn, req *wire.Request) {
+	resp := m.doLocalRequest(req)
+	msgType := wire.MessageTypeResponse
+	if resp.Error != "" {
+		msgType = wire.MessageTypeError
+	}
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+	if err := conn.WriteJSON(wire.Message{Type: msgType, Response: resp}); err != nil {
+		log.Error("Failed to write port-forward response: %v", err)
+	}
+}
+
+func (m *Manager) doLocalRequest(req *wire.Request) *wire.Response {
+	target := url.URL{
+		Scheme:   "http",
+		Host:     fmt.Sprintf("%s:%d", req.Host, req.Port),
+		Path:     req.Path,
+		RawQuery: req.Query,
+	}
+	httpReq, err := http.NewRequest(req.Method, target.String(), bytes.NewReader(req.Body))
+	if err != nil {
+		return &wire.Response{StreamID: req.StreamID, Error: err.Error()}
+	}
+	httpReq.Header = cloneForwardHeaders(req.Header)
+	httpReq.Host = target.Host
+
+	resp, err := m.http.Do(httpReq)
+	if err != nil {
+		return &wire.Response{StreamID: req.StreamID, Error: err.Error()}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxLocalResponseBody+1))
+	if err != nil {
+		return &wire.Response{StreamID: req.StreamID, Error: err.Error()}
+	}
+	if len(body) > maxLocalResponseBody {
+		return &wire.Response{StreamID: req.StreamID, Error: "local response body too large"}
+	}
+	return &wire.Response{
+		StreamID: req.StreamID,
+		Status:   resp.StatusCode,
+		Header:   cloneForwardHeaders(resp.Header),
+		Body:     body,
+	}
+}
+
+func tunnelURL(hubURL, agentID string) (string, error) {
+	u, err := url.Parse(strings.TrimSuffix(hubURL, "/") + "/api/v1/agents/" + url.PathEscape(agentID) + "/ports/tunnel")
+	if err != nil {
+		return "", err
+	}
+	switch u.Scheme {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	default:
+		return "", fmt.Errorf("unsupported hub URL scheme %q", u.Scheme)
+	}
+	return u.String(), nil
+}
+
+func cloneForwardHeaders(in http.Header) http.Header {
+	out := make(http.Header, len(in))
+	for k, vals := range in {
+		if hopByHopHeader(k) {
+			continue
+		}
+		out[k] = append([]string(nil), vals...)
+	}
+	return out
+}
+
+func hopByHopHeader(k string) bool {
+	switch strings.ToLower(k) {
+	case "connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade":
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/sciontool/portforward/tunnel.go
+++ b/pkg/sciontool/portforward/tunnel.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -53,7 +54,7 @@ func NewManager(client *scionhub.Client) *Manager {
 }
 
 func (m *Manager) Run(ctx context.Context) {
-	if m == nil || !m.client.IsConfigured() {
+	if m == nil || m.client == nil || !m.client.IsConfigured() {
 		return
 	}
 	for {
@@ -80,6 +81,11 @@ func (m *Manager) runOnce(ctx context.Context) error {
 		return err
 	}
 	defer func() { _ = conn.Close() }()
+	// Close the connection when the context is cancelled to unblock ReadJSON.
+	go func() {
+		<-ctx.Done()
+		_ = conn.Close()
+	}()
 	log.Info("Port-forward tunnel connected")
 	for {
 		var msg wire.Message
@@ -101,12 +107,22 @@ func (m *Manager) handleRequest(conn *websocket.Conn, req *wire.Request) {
 	}
 	m.writeMu.Lock()
 	defer m.writeMu.Unlock()
+	_ = conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
 	if err := conn.WriteJSON(wire.Message{Type: msgType, Response: resp}); err != nil {
 		log.Error("Failed to write port-forward response: %v", err)
 	}
 }
 
 func (m *Manager) doLocalRequest(req *wire.Request) *wire.Response {
+	isLoopback := strings.ToLower(strings.TrimSpace(req.Host)) == "localhost"
+	if !isLoopback {
+		if ip := net.ParseIP(req.Host); ip != nil && ip.IsLoopback() {
+			isLoopback = true
+		}
+	}
+	if !isLoopback {
+		return &wire.Response{StreamID: req.StreamID, Error: "unauthorized host: only loopback addresses are allowed"}
+	}
 	target := url.URL{
 		Scheme:   "http",
 		Host:     fmt.Sprintf("%s:%d", req.Host, req.Port),

--- a/pkg/sciontool/portforward/tunnel.go
+++ b/pkg/sciontool/portforward/tunnel.go
@@ -159,7 +159,7 @@ func tunnelURL(hubURL, agentID string) (string, error) {
 func cloneForwardHeaders(in http.Header) http.Header {
 	out := make(http.Header, len(in))
 	for k, vals := range in {
-		if hopByHopHeader(k) {
+		if hopByHopHeader(k) || sensitiveHeader(k) {
 			continue
 		}
 		out[k] = append([]string(nil), vals...)
@@ -170,6 +170,15 @@ func cloneForwardHeaders(in http.Header) http.Header {
 func hopByHopHeader(k string) bool {
 	switch strings.ToLower(k) {
 	case "connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade":
+		return true
+	default:
+		return false
+	}
+}
+
+func sensitiveHeader(k string) bool {
+	switch strings.ToLower(k) {
+	case "authorization", "cookie", "x-scion-agent-token", "x-scion-broker-id", "x-scion-broker-hmac":
 		return true
 	default:
 		return false

--- a/pkg/sciontool/portforward/tunnel_test.go
+++ b/pkg/sciontool/portforward/tunnel_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portforward
+
+import "testing"
+
+func TestIsLoopbackHost(t *testing.T) {
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{"localhost", true},
+		{"LOCALHOST", true},
+		{" localhost ", true},
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"127.0.0.2", true},
+		{"10.0.0.1", false},
+		{"169.254.169.254", false},
+		{"0.0.0.0", false},
+		{"example.com", false},
+		{"localhost.evil.com", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			if got := isLoopbackHost(tt.host); got != tt.want {
+				t.Errorf("isLoopbackHost(%q) = %v, want %v", tt.host, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/store/concurrency.go
+++ b/pkg/store/concurrency.go
@@ -77,6 +77,11 @@ const (
 	// Only the replica that acquires this lock performs the seed; others skip.
 	LockHubSettingsSeed AdvisoryLockKey = 0x5C10000B
 
+	// LockExposedPortsSweep guards the periodic exposed-ports cleanup sweep
+	// that removes stale port registrations for agents that are no longer
+	// running (stopped, deleted, etc.).
+	LockExposedPortsSweep AdvisoryLockKey = 0x5C10000C
+
 	// LockWorkspaceProvision is the CLASS ID for per-project workspace
 	// provisioning locks. It is used with the two-int advisory lock form
 	// pg_try_advisory_lock(classid, objid), where classid is this constant

--- a/pkg/store/concurrency_test.go
+++ b/pkg/store/concurrency_test.go
@@ -64,6 +64,7 @@ func TestAdvisoryLockKeys_NonOverlapping(t *testing.T) {
 		LockBrokerAffinityReap,
 		LockBrokerMessageSweep,
 		LockSchemaMigration,
+		LockExposedPortsSweep,
 	}
 
 	seen := make(map[AdvisoryLockKey]bool, len(singletonKeys)+1)

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -107,6 +107,7 @@ func entAgentToStore(a *ent.Agent) *store.Agent {
 		Runtime:             a.Runtime,
 		RuntimeBrokerID:     a.RuntimeBrokerID,
 		WebPTYEnabled:       a.WebPtyEnabled,
+		ExposedPorts:        a.ExposedPorts,
 		TaskSummary:         a.TaskSummary,
 		Message:             a.Message,
 		Created:             a.Created,
@@ -178,6 +179,7 @@ func (s *AgentStore) CreateAgent(ctx context.Context, a *store.Agent) error {
 		SetRuntime(a.Runtime).
 		SetRuntimeBrokerID(a.RuntimeBrokerID).
 		SetWebPtyEnabled(a.WebPTYEnabled).
+		SetExposedPorts(a.ExposedPorts).
 		SetTaskSummary(a.TaskSummary).
 		SetMessage(a.Message).
 		SetCreated(now).
@@ -296,6 +298,7 @@ func (s *AgentStore) UpdateAgent(ctx context.Context, a *store.Agent) error {
 		SetRuntime(a.Runtime).
 		SetRuntimeBrokerID(a.RuntimeBrokerID).
 		SetWebPtyEnabled(a.WebPTYEnabled).
+		SetExposedPorts(a.ExposedPorts).
 		SetTaskSummary(a.TaskSummary).
 		SetMessage(a.Message).
 		SetVisibility(a.Visibility).
@@ -635,6 +638,29 @@ func (s *AgentStore) UpdateAgentStatus(ctx context.Context, id string, su store.
 		return mapError(err)
 	}
 	return tx.Commit()
+}
+
+// UpdateAgentExposedPorts applies a partial exposed-port update without using
+// the whole-record optimistic-lock path. Port registration must not race with
+// high-frequency status writes.
+func (s *AgentStore) UpdateAgentExposedPorts(ctx context.Context, id string, ports []store.ExposedPort) error {
+	uid, err := parseUUID(id)
+	if err != nil {
+		return err
+	}
+
+	affected, err := s.client.Agent.Update().
+		Where(agent.IDEQ(uid)).
+		SetExposedPorts(ports).
+		SetUpdated(time.Now()).
+		Save(ctx)
+	if err != nil {
+		return mapError(err)
+	}
+	if affected == 0 {
+		return store.ErrNotFound
+	}
+	return nil
 }
 
 // PurgeDeletedAgents permanently removes soft-deleted agents older than cutoff.

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -298,7 +298,6 @@ func (s *AgentStore) UpdateAgent(ctx context.Context, a *store.Agent) error {
 		SetRuntime(a.Runtime).
 		SetRuntimeBrokerID(a.RuntimeBrokerID).
 		SetWebPtyEnabled(a.WebPTYEnabled).
-		SetExposedPorts(a.ExposedPorts).
 		SetTaskSummary(a.TaskSummary).
 		SetMessage(a.Message).
 		SetVisibility(a.Visibility).

--- a/pkg/store/entadapter/agent_store_test.go
+++ b/pkg/store/entadapter/agent_store_test.go
@@ -307,6 +307,40 @@ func TestAgentStore_UpdateAgentStatus(t *testing.T) {
 	assert.ErrorIs(t, s.UpdateAgentStatus(ctx, uuid.NewString(), store.AgentStatusUpdate{Phase: "running"}), store.ErrNotFound)
 }
 
+func TestAgentStore_UpdateAgentExposedPorts(t *testing.T) {
+	ctx := context.Background()
+	s, projectID := newTestAgentStore(t)
+
+	a := makeAgent(projectID, "ports")
+	require.NoError(t, s.CreateAgent(ctx, a))
+
+	exposedAt := time.Now().UTC().Truncate(time.Second)
+	ports := []store.ExposedPort{{
+		Port:      3000,
+		Label:     "dev",
+		Host:      "127.0.0.1",
+		Mode:      "rw",
+		ExposedAt: exposedAt,
+		ExposedBy: "agent",
+	}}
+	require.NoError(t, s.UpdateAgentExposedPorts(ctx, a.ID, ports))
+
+	got, err := s.GetAgent(ctx, a.ID)
+	require.NoError(t, err)
+	require.Len(t, got.ExposedPorts, 1)
+	assert.Equal(t, ports[0].Port, got.ExposedPorts[0].Port)
+	assert.Equal(t, ports[0].Label, got.ExposedPorts[0].Label)
+	assert.Equal(t, ports[0].Host, got.ExposedPorts[0].Host)
+	assert.Equal(t, ports[0].Mode, got.ExposedPorts[0].Mode)
+	assert.Equal(t, ports[0].ExposedBy, got.ExposedPorts[0].ExposedBy)
+
+	require.NoError(t, s.UpdateAgentExposedPorts(ctx, a.ID, nil))
+	got, err = s.GetAgent(ctx, a.ID)
+	require.NoError(t, err)
+	assert.Empty(t, got.ExposedPorts)
+	assert.ErrorIs(t, s.UpdateAgentExposedPorts(ctx, uuid.NewString(), ports), store.ErrNotFound)
+}
+
 // TestAgentStore_TerminalPhaseClearsStalledActivity verifies that transitioning
 // to a terminal phase (stopped/error) without an explicit activity clears a
 // lingering live activity such as "stalled", while preserving terminal

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -56,13 +56,14 @@ type Agent struct {
 	StalledFromActivity string `json:"stalledFromActivity,omitempty"` // Activity before stalled; empty when not stalled
 
 	// Runtime configuration
-	Image           string `json:"image,omitempty"`
-	Detached        bool   `json:"detached"`
-	Runtime         string `json:"runtime,omitempty"`         // docker, kubernetes, apple
-	RuntimeBrokerID string `json:"runtimeBrokerId,omitempty"` // FK to RuntimeBroker.ID
-	WebPTYEnabled   bool   `json:"webPtyEnabled,omitempty"`
-	TaskSummary     string `json:"taskSummary,omitempty"`
-	Message         string `json:"message,omitempty"`
+	Image           string        `json:"image,omitempty"`
+	Detached        bool          `json:"detached"`
+	Runtime         string        `json:"runtime,omitempty"`         // docker, kubernetes, apple
+	RuntimeBrokerID string        `json:"runtimeBrokerId,omitempty"` // FK to RuntimeBroker.ID
+	WebPTYEnabled   bool          `json:"webPtyEnabled,omitempty"`
+	ExposedPorts    []ExposedPort `json:"exposedPorts,omitempty"`
+	TaskSummary     string        `json:"taskSummary,omitempty"`
+	Message         string        `json:"message,omitempty"`
 
 	// Enriched fields (populated by Hub when returning data, not persisted)
 	Project           string `json:"project,omitempty"`           // Project name (resolved from ProjectID)
@@ -92,6 +93,17 @@ type Agent struct {
 
 	// Optimistic locking
 	StateVersion int64 `json:"stateVersion"`
+}
+
+// ExposedPort is a Hub-registered local port that may be reached through an
+// authenticated agent-held tunnel.
+type ExposedPort struct {
+	Port      int       `json:"port"`
+	Label     string    `json:"label,omitempty"`
+	Host      string    `json:"host,omitempty"`
+	Mode      string    `json:"mode,omitempty"`
+	ExposedAt time.Time `json:"exposedAt"`
+	ExposedBy string    `json:"exposedBy"`
 }
 
 // MarshalJSON implements custom marshaling to support legacy groveId field.
@@ -1439,34 +1451,36 @@ const UATPrefix = "scion_pat_"
 
 // UAT scope constants define the allowed capability scopes.
 const (
-	UATScopeProjectRead   = "project:read"
-	UATScopeProjectUpdate = "project:update"
-	UATScopeAgentCreate   = "agent:create"
-	UATScopeAgentRead     = "agent:read"
-	UATScopeAgentList     = "agent:list"
-	UATScopeAgentStart    = "agent:start"
-	UATScopeAgentStop     = "agent:stop"
-	UATScopeAgentDelete   = "agent:delete"
-	UATScopeAgentMessage  = "agent:message"
-	UATScopeAgentAttach   = "agent:attach"
-	UATScopeAgentDispatch = "agent:dispatch"
-	UATScopeAgentManage   = "agent:manage" // Convenience alias
+	UATScopeProjectRead     = "project:read"
+	UATScopeProjectUpdate   = "project:update"
+	UATScopeAgentCreate     = "agent:create"
+	UATScopeAgentRead       = "agent:read"
+	UATScopeAgentList       = "agent:list"
+	UATScopeAgentStart      = "agent:start"
+	UATScopeAgentStop       = "agent:stop"
+	UATScopeAgentDelete     = "agent:delete"
+	UATScopeAgentMessage    = "agent:message"
+	UATScopeAgentAttach     = "agent:attach"
+	UATScopeAgentPortAccess = "agent:port_access"
+	UATScopeAgentDispatch   = "agent:dispatch"
+	UATScopeAgentManage     = "agent:manage" // Convenience alias
 )
 
 // UATValidScopes is the set of all valid UAT scope strings.
 var UATValidScopes = map[string]bool{
-	UATScopeProjectRead:   true,
-	UATScopeProjectUpdate: true,
-	UATScopeAgentCreate:   true,
-	UATScopeAgentRead:     true,
-	UATScopeAgentList:     true,
-	UATScopeAgentStart:    true,
-	UATScopeAgentStop:     true,
-	UATScopeAgentDelete:   true,
-	UATScopeAgentMessage:  true,
-	UATScopeAgentAttach:   true,
-	UATScopeAgentDispatch: true,
-	UATScopeAgentManage:   true,
+	UATScopeProjectRead:     true,
+	UATScopeProjectUpdate:   true,
+	UATScopeAgentCreate:     true,
+	UATScopeAgentRead:       true,
+	UATScopeAgentList:       true,
+	UATScopeAgentStart:      true,
+	UATScopeAgentStop:       true,
+	UATScopeAgentDelete:     true,
+	UATScopeAgentMessage:    true,
+	UATScopeAgentAttach:     true,
+	UATScopeAgentPortAccess: true,
+	UATScopeAgentDispatch:   true,
+	UATScopeAgentManage:     true,
 }
 
 // UATManageScopes are the scopes expanded from the agent:manage alias.
@@ -1477,6 +1491,7 @@ var UATManageScopes = []string{
 	UATScopeAgentStart,
 	UATScopeAgentStop,
 	UATScopeAgentDelete,
+	UATScopeAgentPortAccess,
 	UATScopeAgentDispatch,
 }
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -164,6 +164,9 @@ type AgentStore interface {
 	// This is a partial update that doesn't require version checking.
 	UpdateAgentStatus(ctx context.Context, id string, status AgentStatusUpdate) error
 
+	// UpdateAgentExposedPorts updates only exposed port registrations.
+	UpdateAgentExposedPorts(ctx context.Context, id string, ports []ExposedPort) error
+
 	// PurgeDeletedAgents permanently removes soft-deleted agents older than cutoff.
 	// Returns the number of agents purged.
 	PurgeDeletedAgents(ctx context.Context, cutoff time.Time) (int, error)

--- a/web/src/client/state.ts
+++ b/web/src/client/state.ts
@@ -27,7 +27,7 @@
 
 import { SSEClient } from './sse-client.js';
 import type { SSEUpdateEvent } from './sse-client.js';
-import type { Agent, Project, RuntimeBroker } from '../shared/types.js';
+import type { Agent, ExposedPort, Project, RuntimeBroker } from '../shared/types.js';
 
 /** Activities that should not be overwritten by working/empty transitions */
 const STICKY_ACTIVITIES = new Set(['waiting_for_input', 'completed', 'limits_exceeded']);
@@ -271,6 +271,15 @@ export class StateManager extends EventTarget {
       this.state.agents.delete(agentId);
       this.state.deletedAgentIds.add(agentId);
       this.pendingAgentDeltas.delete(agentId);
+    } else if (eventType === 'ports') {
+      const portsData = data as { ports: ExposedPort[] };
+      const existing = this.state.agents.get(agentId);
+      if (existing) {
+        const updated = { ...existing, exposedPorts: portsData.ports ?? [] };
+        this.state.agents.set(agentId, updated as Agent);
+      }
+      this.notify('agents-updated');
+      return;
     } else {
       const existing = this.state.agents.get(agentId);
       if (!existing && eventType !== 'created') {

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -553,6 +553,16 @@ export class ScionPageAgentDetail extends LitElement {
       margin-bottom: 1rem;
     }
 
+    /* ---- Port link ---- */
+    .port-link {
+      color: #4ade80;
+      text-decoration: none;
+    }
+    .port-link:hover {
+      text-decoration: underline;
+      color: #22c55e;
+    }
+
     /* ---- Visibility badge ---- */
     .visibility-badge {
       display: inline-flex;
@@ -1174,6 +1184,7 @@ export class ScionPageAgentDetail extends LitElement {
     return html`
       ${this.renderCurrentStateCard(agent)} ${this.renderCurrentTaskCard(agent)}
       ${this.renderLimitsUsageCard(agent)} ${this.renderConnectivityCard(agent)}
+      ${this.renderExposedPortsCard(agent)}
       ${this.renderNotificationsCard()}
     `;
   }
@@ -1357,6 +1368,38 @@ export class ScionPageAgentDetail extends LitElement {
                 </div>
               `
             : ''}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderExposedPortsCard(agent: Agent) {
+    const ports = agent.exposedPorts;
+    if (!ports || ports.length === 0) return nothing;
+
+    return html`
+      <div class="card">
+        <h3 class="card-title">Exposed Ports</h3>
+        <div class="info-grid">
+          ${ports.map(
+            (p) => html`
+              <div class="info-item">
+                <span class="info-label">
+                  :${p.port}${p.label ? ` (${p.label})` : ''}
+                </span>
+                <span class="info-value">
+                  <a
+                    href="/api/v1/agents/${agent.id}/ports/${p.port}/proxy/"
+                    target="_blank"
+                    rel="noopener"
+                    class="port-link"
+                  >
+                    Open in new tab
+                  </a>
+                </span>
+              </div>
+            `
+          )}
         </div>
       </div>
     `;

--- a/web/src/components/pages/terminal.ts
+++ b/web/src/components/pages/terminal.ts
@@ -896,8 +896,17 @@ export class ScionPageTerminal extends LitElement {
         <button
           class="port-dropdown-trigger"
           @click=${(e: Event) => {
+            e.stopPropagation();
             const el = (e.currentTarget as HTMLElement).parentElement!;
-            el.classList.toggle('open');
+            const isOpen = el.classList.toggle('open');
+            if (isOpen) {
+              const close = () => {
+                el.classList.remove('open');
+                document.removeEventListener('click', close);
+              };
+              // Use setTimeout to avoid the current click triggering the close
+              setTimeout(() => document.addEventListener('click', close), 0);
+            }
           }}
         >
           Ports (${this.exposedPorts.length}) ▾
@@ -910,7 +919,7 @@ export class ScionPageTerminal extends LitElement {
                 target="_blank"
                 rel="noopener"
               >
-                :${p.port}${p.label ? ` - ${p.label}` : ''}
+                :${p.port}${p.label ? ` — ${p.label}` : ''}
               </a>
             `
           )}

--- a/web/src/components/pages/terminal.ts
+++ b/web/src/components/pages/terminal.ts
@@ -24,7 +24,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-import type { PageData, Agent, AgentPhase, AgentActivity } from '../../shared/types.js';
+import type { PageData, Agent, AgentPhase, AgentActivity, ExposedPort } from '../../shared/types.js';
 import { isTerminalAvailable } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { dispatchPageTitle } from '../../client/page-title.js';
@@ -93,6 +93,9 @@ export class ScionPageTerminal extends LitElement {
 
   @state()
   private agent: Agent | null = null;
+
+  @state()
+  private exposedPorts: ExposedPort[] = [];
 
   @state()
   private captureAuthLoading = false;
@@ -355,6 +358,93 @@ export class ScionPageTerminal extends LitElement {
     .error-state button:hover {
       background: #2563eb;
     }
+
+    /* Port forwarding buttons */
+    .port-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      background: transparent;
+      border: 1px solid #2a5d2a;
+      color: #4ade80;
+      padding: 0.25rem 0.75rem;
+      border-radius: 4px;
+      font-size: 0.75rem;
+      text-decoration: none;
+      white-space: nowrap;
+      transition: border-color 0.15s, background 0.15s;
+      animation: port-appear 0.3s ease-out;
+      cursor: pointer;
+    }
+
+    .port-btn:hover {
+      border-color: #22c55e;
+      background: rgba(34, 197, 94, 0.1);
+      color: #22c55e;
+    }
+
+    @keyframes port-appear {
+      from { opacity: 0; transform: scale(0.9); }
+      to   { opacity: 1; transform: scale(1); }
+    }
+
+    /* Port dropdown for 4+ ports */
+    .port-dropdown {
+      position: relative;
+      display: inline-flex;
+    }
+
+    .port-dropdown-trigger {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      background: transparent;
+      border: 1px solid #2a5d2a;
+      color: #4ade80;
+      padding: 0.25rem 0.75rem;
+      border-radius: 4px;
+      font-size: 0.75rem;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+
+    .port-dropdown-trigger:hover {
+      border-color: #22c55e;
+      background: rgba(34, 197, 94, 0.1);
+      color: #22c55e;
+    }
+
+    .port-dropdown-menu {
+      display: none;
+      position: absolute;
+      top: 100%;
+      right: 0;
+      margin-top: 4px;
+      background: var(--card-bg, #1a1a2e);
+      border: 1px solid var(--border-color, #333);
+      border-radius: 6px;
+      padding: 0.25rem 0;
+      min-width: 180px;
+      z-index: 100;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    }
+
+    .port-dropdown.open .port-dropdown-menu {
+      display: block;
+    }
+
+    .port-dropdown-menu a {
+      display: block;
+      padding: 0.5rem 0.75rem;
+      color: #4ade80;
+      text-decoration: none;
+      font-size: 0.8rem;
+      white-space: nowrap;
+    }
+
+    .port-dropdown-menu a:hover {
+      background: rgba(34, 197, 94, 0.1);
+    }
   `;
 
   override connectedCallback(): void {
@@ -394,6 +484,7 @@ export class ScionPageTerminal extends LitElement {
       this.projectId = agent.projectId ?? '';
       this.agentPhase = agent.phase;
       this.agentActivity = agent.activity ?? '';
+      this.exposedPorts = agent.exposedPorts ?? [];
       dispatchPageTitle(this, 'Terminal', agent.name || this.agentId);
       this.connectSSE();
 
@@ -433,6 +524,11 @@ export class ScionPageTerminal extends LitElement {
       const { subject, data } = e.detail;
       // Only handle events for this agent
       if (!subject.startsWith(`agent.${this.agentId}.`)) return;
+      if (subject.endsWith('.ports')) {
+        const portsData = data as { ports: ExposedPort[] };
+        this.exposedPorts = portsData.ports ?? [];
+        return;
+      }
       const delta = data as Partial<Agent>;
       if (delta.phase) this.agentPhase = delta.phase;
       if (delta.activity !== undefined) this.agentActivity = delta.activity ?? '';
@@ -775,6 +871,54 @@ export class ScionPageTerminal extends LitElement {
     this.terminal?.focus();
   }
 
+  private renderPortButtons() {
+    if (this.exposedPorts.length === 0) return nothing;
+
+    if (this.exposedPorts.length <= 3) {
+      return this.exposedPorts.map(
+        (p) => html`
+          <a
+            class="port-btn"
+            href="/api/v1/agents/${this.agentId}/ports/${p.port}/proxy/"
+            target="_blank"
+            rel="noopener"
+            title=${p.label || `Port ${p.port}`}
+          >
+            Open :${p.port}
+          </a>
+        `
+      );
+    }
+
+    // 4+ ports: dropdown
+    return html`
+      <div class="port-dropdown">
+        <button
+          class="port-dropdown-trigger"
+          @click=${(e: Event) => {
+            const el = (e.currentTarget as HTMLElement).parentElement!;
+            el.classList.toggle('open');
+          }}
+        >
+          Ports (${this.exposedPorts.length}) ▾
+        </button>
+        <div class="port-dropdown-menu">
+          ${this.exposedPorts.map(
+            (p) => html`
+              <a
+                href="/api/v1/agents/${this.agentId}/ports/${p.port}/proxy/"
+                target="_blank"
+                rel="noopener"
+              >
+                :${p.port}${p.label ? ` - ${p.label}` : ''}
+              </a>
+            `
+          )}
+        </div>
+      </div>
+    `;
+  }
+
   private get showCaptureAuth(): boolean {
     const agent = this.agent;
     if (!agent) return false;
@@ -954,6 +1098,7 @@ export class ScionPageTerminal extends LitElement {
           >${this.renderTerminalIcon()}</button>
         </div>
         <div class="spacer"></div>
+        ${this.renderPortButtons()}
         ${this.showCaptureAuth
           ? html`
               <button

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -181,6 +181,18 @@ export function isWorktreeWorkspace(project: Project): boolean {
 }
 
 /**
+ * Exposed port registered by an agent for port forwarding.
+ */
+export interface ExposedPort {
+  port: number;
+  label?: string;
+  host?: string;
+  mode?: string;
+  exposedAt: string;
+  exposedBy: string;
+}
+
+/**
  * Agent lifecycle phase (from canonical agent state model)
  */
 export type AgentPhase =
@@ -441,6 +453,9 @@ export interface Agent {
 
   // Cloud Logging capability (from hub)
   cloudLogging?: boolean;
+
+  // Port forwarding
+  exposedPorts?: ExposedPort[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds agent port forwarding: agents can expose local HTTP ports through the Hub as authenticated, reverse-proxied URLs.

Upstream issue: ptone/scion#303
