### PR TITLE
fix(init): stop blaming GITHUB_TOKEN for unclassified git clone errors

### DIFF
--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -1793,7 +1793,7 @@ func formatCloneError(sanitizedStderr, token string) error {
 	if guidance := gitErr.UserGuidance(); guidance != "" {
 		return fmt.Errorf("git clone failed (%s): %s", guidance, sanitizedStderr)
 	}
-	return fmt.Errorf("git clone failed (GITHUB_TOKEN may be invalid or lack Contents read access): %s", sanitizedStderr)
+	return fmt.Errorf("git clone failed (unclassified error): %s", sanitizedStderr)
 }
 
 // detectDefaultBranch uses `git ls-remote --symref origin HEAD` to discover

--- a/cmd/sciontool/commands/init_test.go
+++ b/cmd/sciontool/commands/init_test.go
@@ -648,6 +648,19 @@ func TestFormatCloneError(t *testing.T) {
 			t.Errorf("expected stderr in error, got: %v", err)
 		}
 	})
+
+	t.Run("unclassified error with token", func(t *testing.T) {
+		err := formatCloneError("fatal: disk full", "ghp_token123")
+		if strings.Contains(err.Error(), "GITHUB_TOKEN") {
+			t.Errorf("unclassified error should not mention GITHUB_TOKEN, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "unclassified error") {
+			t.Errorf("expected 'unclassified error' in message, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "fatal: disk full") {
+			t.Errorf("expected stderr in error, got: %v", err)
+		}
+	})
 }
 
 func TestIsClaude(t *testing.T) {


### PR DESCRIPTION
## Summary

Changed the formatCloneError fallback message from blaming GITHUB_TOKEN to a neutral "unclassified error" label. The fallback only fires when ClassifyGitError returns GitErrUnknown and UserGuidance() is empty — auth errors (GitErrAuth) have their own guidance and are unaffected.

Added test case for the unclassified-error path.

Ref: ptone/scion#682

## Files changed

- cmd/sciontool/commands/init.go — 1-line fix to fallback error message
- cmd/sciontool/commands/init_test.go — new test case for unclassified error path
