### PR TITLE
fix(auth): guard harness auth corruption and add vertex-ai credential translation

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -775,11 +775,12 @@ authDone:
 		}
 		finalScionCfg.AuthSelectedType = opts.HarnessAuth
 		cfgData, marshalErr := json.MarshalIndent(finalScionCfg, "", "  ")
-		if marshalErr == nil {
-			configPath := filepath.Join(agentDir, "scion-agent.json")
-			if writeErr := os.WriteFile(configPath, cfgData, 0644); writeErr != nil {
-				return nil, fmt.Errorf("failed to write agent config %s: %w", configPath, writeErr)
-			}
+		if marshalErr != nil {
+			return nil, fmt.Errorf("failed to marshal agent config: %w", marshalErr)
+		}
+		configPath := filepath.Join(agentDir, "scion-agent.json")
+		if writeErr := os.WriteFile(configPath, cfgData, 0644); writeErr != nil {
+			return nil, fmt.Errorf("failed to write agent config %s: %w", configPath, writeErr)
 		}
 	} else if finalScionCfg != nil && harness.IsHarnessImplementationName(finalScionCfg.AuthSelectedType) {
 		// Active corruption repair: clear the corrupted value and rewrite.

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -147,7 +147,7 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 	if opts.InlineConfig != nil {
 		startInlineConfig = opts.InlineConfig
 	}
-	if opts.HarnessAuth != "" {
+	if opts.HarnessAuth != "" && !harness.IsHarnessImplementationName(opts.HarnessAuth) {
 		if startInlineConfig == nil {
 			startInlineConfig = &api.ScionConfig{}
 		}
@@ -490,7 +490,7 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		harness.OverlaySettings(&auth, h, agentDir)
 		// Apply CLI harness auth override (--harness-auth) before resolution.
 		// This has highest priority, overriding settings, templates, and harness configs.
-		if opts.HarnessAuth != "" {
+		if opts.HarnessAuth != "" && !harness.IsHarnessImplementationName(opts.HarnessAuth) {
 			auth.SelectedType = opts.HarnessAuth
 		}
 		util.Debugf("auth: after overlay — selectedType=%q", auth.SelectedType)
@@ -569,6 +569,13 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 			}
 		}
 
+		// If opts.HarnessAuth is still a harness implementation name (e.g.
+		// "container-script" from a corrupted scion-agent.json), clear it so
+		// it does not leak into persistence or other downstream logic.
+		if harness.IsHarnessImplementationName(opts.HarnessAuth) {
+			opts.HarnessAuth = ""
+		}
+
 		// Surface resolved auth method so CLI can display it
 		authDetail := resolved.Method
 		if nativeType, ok := resolved.EnvVars["GEMINI_DEFAULT_AUTH_TYPE"]; ok {
@@ -577,6 +584,13 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		warnings = append(warnings, fmt.Sprintf("Auth: resolved as %s", authDetail))
 	}
 authDone:
+
+	// Unconditionally clear corrupted opts.HarnessAuth. This runs even when
+	// NoAuth is true (the auth block is skipped) to prevent re-persisting
+	// a corrupted value from a prior run's scion-agent.json.
+	if harness.IsHarnessImplementationName(opts.HarnessAuth) {
+		opts.HarnessAuth = ""
+	}
 
 	// 4. Launch container
 	detached := true
@@ -751,11 +765,25 @@ authDone:
 
 	// Persist harness auth override to scion-agent.json so sciontool inside the container sees it.
 	// The actual auth resolution override is applied earlier in the auth gathering block.
+	//
+	// When opts.HarnessAuth is empty but finalScionCfg carries a corrupted
+	// auth_selectedType (harness implementation name from a prior bug), clear
+	// it and rewrite the file to break the self-perpetuating corruption cycle.
 	if opts.HarnessAuth != "" {
 		if finalScionCfg == nil {
 			finalScionCfg = &api.ScionConfig{}
 		}
 		finalScionCfg.AuthSelectedType = opts.HarnessAuth
+		cfgData, marshalErr := json.MarshalIndent(finalScionCfg, "", "  ")
+		if marshalErr == nil {
+			configPath := filepath.Join(agentDir, "scion-agent.json")
+			if writeErr := os.WriteFile(configPath, cfgData, 0644); writeErr != nil {
+				return nil, fmt.Errorf("failed to write agent config %s: %w", configPath, writeErr)
+			}
+		}
+	} else if finalScionCfg != nil && harness.IsHarnessImplementationName(finalScionCfg.AuthSelectedType) {
+		// Active corruption repair: clear the corrupted value and rewrite.
+		finalScionCfg.AuthSelectedType = ""
 		cfgData, marshalErr := json.MarshalIndent(finalScionCfg, "", "  ")
 		if marshalErr == nil {
 			configPath := filepath.Join(agentDir, "scion-agent.json")

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -785,11 +785,12 @@ authDone:
 		// Active corruption repair: clear the corrupted value and rewrite.
 		finalScionCfg.AuthSelectedType = ""
 		cfgData, marshalErr := json.MarshalIndent(finalScionCfg, "", "  ")
-		if marshalErr == nil {
-			configPath := filepath.Join(agentDir, "scion-agent.json")
-			if writeErr := os.WriteFile(configPath, cfgData, 0644); writeErr != nil {
-				return nil, fmt.Errorf("failed to write agent config %s: %w", configPath, writeErr)
-			}
+		if marshalErr != nil {
+			return nil, fmt.Errorf("failed to marshal repaired agent config: %w", marshalErr)
+		}
+		configPath := filepath.Join(agentDir, "scion-agent.json")
+		if writeErr := os.WriteFile(configPath, cfgData, 0644); writeErr != nil {
+			return nil, fmt.Errorf("failed to write agent config %s: %w", configPath, writeErr)
 		}
 	}
 

--- a/pkg/agent/run_test.go
+++ b/pkg/agent/run_test.go
@@ -1599,6 +1599,85 @@ profiles:
 	})
 }
 
+func TestHarnessAuthCorruptedValueNotPersisted(t *testing.T) {
+	// Regression test: when opts.HarnessAuth contains a harness implementation
+	// name (e.g. "container-script" from corrupted scion-agent.json), it must
+	// NOT be persisted to scion-agent.json. The guards at run.go:493 and
+	// run.go:754 prevent this.
+	tmpDir := t.TempDir()
+
+	oldWd, _ := os.Getwd()
+	_ = os.Chdir(tmpDir)
+	defer func() { _ = os.Chdir(oldWd) }()
+
+	originalHome := os.Getenv("HOME")
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+	_ = os.Setenv("HOME", tmpDir)
+
+	globalScionDir := filepath.Join(tmpDir, ".scion")
+
+	hcDir := filepath.Join(globalScionDir, "harness-configs", "test-harness")
+	_ = os.MkdirAll(hcDir, 0755)
+	_ = os.WriteFile(filepath.Join(hcDir, "config.yaml"), []byte("harness: gemini\nuser: scion\nimage: test-image:latest\n"), 0644)
+
+	tplDir := filepath.Join(globalScionDir, "templates", "default")
+	_ = os.MkdirAll(tplDir, 0755)
+	_ = os.WriteFile(filepath.Join(tplDir, "scion-agent.json"), []byte(`{"default_harness_config": "test-harness"}`), 0644)
+
+	_ = os.WriteFile(filepath.Join(globalScionDir, "settings.yaml"), []byte(`schema_version: "1"
+active_profile: local
+profiles:
+  local:
+    runtime: docker
+`), 0644)
+
+	projectDir := filepath.Join(tmpDir, "project")
+	projectScionDir := filepath.Join(projectDir, ".scion")
+	_ = os.MkdirAll(projectScionDir, 0755)
+
+	for _, implName := range []string{"container-script", "generic", "builtin", "passthrough"} {
+		t.Run(implName, func(t *testing.T) {
+			mockRT := &runtime.MockRuntime{
+				ListFunc: func(ctx context.Context, labelFilter map[string]string) ([]api.AgentInfo, error) {
+					return []api.AgentInfo{}, nil
+				},
+				RunFunc: func(ctx context.Context, config runtime.RunConfig) (string, error) {
+					return "mock-id", nil
+				},
+			}
+
+			agentName := "corrupt-" + implName
+			agentDir := filepath.Join(projectScionDir, "agents", agentName)
+			_ = os.MkdirAll(filepath.Join(agentDir, "home"), 0755)
+			// Simulate corrupted scion-agent.json with harness implementation name
+			_ = os.WriteFile(filepath.Join(agentDir, "scion-agent.json"), []byte(`{
+				"harness": "gemini",
+				"auth_selectedType": "`+implName+`"
+			}`), 0644)
+
+			mgr := NewManager(mockRT)
+			_, err := mgr.Start(context.Background(), api.StartOptions{
+				Name:        agentName,
+				ProjectPath: projectScionDir,
+				NoAuth:      true,
+				HarnessAuth: implName, // corrupted value from Hub
+			})
+			if err != nil {
+				t.Fatalf("Start failed: %v", err)
+			}
+
+			data, err := os.ReadFile(filepath.Join(agentDir, "scion-agent.json"))
+			if err != nil {
+				t.Fatalf("failed to read scion-agent.json: %v", err)
+			}
+			// The corrupted implementation name must NOT appear as auth_selectedType.
+			if strings.Contains(string(data), `"`+implName+`"`) {
+				t.Errorf("scion-agent.json still contains corrupted value %q: %s", implName, string(data))
+			}
+		})
+	}
+}
+
 func TestBuildAgentEnv_TelemetryNoOverrideExplicit(t *testing.T) {
 	// Explicit opts.Env values must not be overwritten by telemetry config.
 	enabled := true

--- a/pkg/harness/container_script_harness.go
+++ b/pkg/harness/container_script_harness.go
@@ -322,6 +322,30 @@ func (c *ContainerScriptHarness) ResolveAuth(auth api.AuthConfig) (*api.Resolved
 		})
 	}
 
+	// For the Claude harness with vertex-ai auth, translate GCP env vars into
+	// the Anthropic-specific env vars that Claude Code requires. This is
+	// normally done by the Python provisioner (provision.py), but when the
+	// provisioner type is "builtin" (no command), the Python script never
+	// runs and the translation must happen here on the Go side.
+	if c.entry.Harness == "claude" {
+		selectedAuth := auth.SelectedType
+		if selectedAuth == "" {
+			// Infer vertex-ai from presence of GCP project credential
+			if auth.GoogleCloudProject != "" {
+				selectedAuth = "vertex-ai"
+			}
+		}
+		if selectedAuth == "vertex-ai" {
+			if proj := resolved.EnvVars["GOOGLE_CLOUD_PROJECT"]; proj != "" {
+				resolved.EnvVars["ANTHROPIC_VERTEX_PROJECT_ID"] = proj
+			}
+			if region := resolved.EnvVars["GOOGLE_CLOUD_REGION"]; region != "" {
+				resolved.EnvVars["CLOUD_ML_REGION"] = region
+			}
+			resolved.EnvVars["CLAUDE_CODE_USE_VERTEX"] = "1"
+		}
+	}
+
 	// The auth_candidates manifest written during Provision() captures the full
 	// candidate set for the script. ResolveAuth provides the env/file material
 	// the runtime needs to project secrets into the container.

--- a/pkg/harness/container_script_harness_test.go
+++ b/pkg/harness/container_script_harness_test.go
@@ -476,6 +476,130 @@ func TestIsHarnessImplementationName(t *testing.T) {
 	}
 }
 
+func newClaudeHarness(t *testing.T) *ContainerScriptHarness {
+	t.Helper()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "config.yaml"), "harness: claude\nimage: scion-claude:latest\n")
+	writeFile(t, filepath.Join(dir, "provision.py"), "#!/usr/bin/env python3\nimport sys\nsys.exit(0)\n")
+	entry := config.HarnessConfigEntry{
+		Harness: "claude",
+		Image:   "scion-claude:latest",
+		Provisioner: &config.HarnessProvisionerConfig{
+			Type:             "builtin",
+			InterfaceVersion: 1,
+		},
+	}
+	h, err := NewContainerScriptHarness(dir, entry)
+	if err != nil {
+		t.Fatalf("NewContainerScriptHarness: %v", err)
+	}
+	return h
+}
+
+func TestContainerScriptHarness_ResolveAuth_VertexAICredentialTranslation(t *testing.T) {
+	// When the harness is "claude" and auth type is "vertex-ai", ResolveAuth
+	// must translate GCP env vars into Anthropic-specific env vars that Claude
+	// Code requires. This translation is normally done by the Python
+	// provisioner, but when provisioner type is "builtin" (no command), the
+	// Python script never runs and Go must handle it.
+	h := newClaudeHarness(t)
+
+	resolved, err := h.ResolveAuth(api.AuthConfig{
+		SelectedType:     "vertex-ai",
+		GoogleCloudProject: "my-project",
+		GoogleCloudRegion:  "us-central1",
+	})
+	if err != nil {
+		t.Fatalf("ResolveAuth: %v", err)
+	}
+
+	// Must set Anthropic-specific Vertex AI env vars.
+	if got := resolved.EnvVars["ANTHROPIC_VERTEX_PROJECT_ID"]; got != "my-project" {
+		t.Errorf("ANTHROPIC_VERTEX_PROJECT_ID=%q, want %q", got, "my-project")
+	}
+	if got := resolved.EnvVars["CLOUD_ML_REGION"]; got != "us-central1" {
+		t.Errorf("CLOUD_ML_REGION=%q, want %q", got, "us-central1")
+	}
+	if got := resolved.EnvVars["CLAUDE_CODE_USE_VERTEX"]; got != "1" {
+		t.Errorf("CLAUDE_CODE_USE_VERTEX=%q, want %q", got, "1")
+	}
+
+	// Must also still have the raw GCP env vars.
+	if got := resolved.EnvVars["GOOGLE_CLOUD_PROJECT"]; got != "my-project" {
+		t.Errorf("GOOGLE_CLOUD_PROJECT=%q, want %q", got, "my-project")
+	}
+	if got := resolved.EnvVars["GOOGLE_CLOUD_REGION"]; got != "us-central1" {
+		t.Errorf("GOOGLE_CLOUD_REGION=%q, want %q", got, "us-central1")
+	}
+}
+
+func TestContainerScriptHarness_ResolveAuth_VertexAIInferredFromProject(t *testing.T) {
+	// When SelectedType is empty but GoogleCloudProject is set, ResolveAuth
+	// should infer vertex-ai and apply the credential translation.
+	h := newClaudeHarness(t)
+
+	resolved, err := h.ResolveAuth(api.AuthConfig{
+		GoogleCloudProject: "inferred-project",
+		GoogleCloudRegion:  "europe-west1",
+	})
+	if err != nil {
+		t.Fatalf("ResolveAuth: %v", err)
+	}
+
+	if got := resolved.EnvVars["ANTHROPIC_VERTEX_PROJECT_ID"]; got != "inferred-project" {
+		t.Errorf("ANTHROPIC_VERTEX_PROJECT_ID=%q, want %q", got, "inferred-project")
+	}
+	if got := resolved.EnvVars["CLAUDE_CODE_USE_VERTEX"]; got != "1" {
+		t.Errorf("CLAUDE_CODE_USE_VERTEX=%q, want %q", got, "1")
+	}
+}
+
+func TestContainerScriptHarness_ResolveAuth_NoVertexTranslationForNonClaude(t *testing.T) {
+	// Vertex AI credential translation must NOT happen for non-Claude harnesses.
+	h, _ := newTestContainerScriptHarness(t) // harness name is "testharness"
+
+	resolved, err := h.ResolveAuth(api.AuthConfig{
+		SelectedType:     "vertex-ai",
+		GoogleCloudProject: "my-project",
+		GoogleCloudRegion:  "us-central1",
+	})
+	if err != nil {
+		t.Fatalf("ResolveAuth: %v", err)
+	}
+
+	// Must NOT set Anthropic-specific vars for non-Claude harness.
+	if _, ok := resolved.EnvVars["ANTHROPIC_VERTEX_PROJECT_ID"]; ok {
+		t.Error("ANTHROPIC_VERTEX_PROJECT_ID should not be set for non-Claude harness")
+	}
+	if _, ok := resolved.EnvVars["CLAUDE_CODE_USE_VERTEX"]; ok {
+		t.Error("CLAUDE_CODE_USE_VERTEX should not be set for non-Claude harness")
+	}
+	if _, ok := resolved.EnvVars["CLOUD_ML_REGION"]; ok {
+		t.Error("CLOUD_ML_REGION should not be set for non-Claude harness")
+	}
+}
+
+func TestContainerScriptHarness_ResolveAuth_NoVertexTranslationForAPIKey(t *testing.T) {
+	// When auth type is api-key, Vertex AI translation must not happen
+	// even for Claude harness.
+	h := newClaudeHarness(t)
+
+	resolved, err := h.ResolveAuth(api.AuthConfig{
+		SelectedType:    "api-key",
+		AnthropicAPIKey: "sk-ant-test",
+	})
+	if err != nil {
+		t.Fatalf("ResolveAuth: %v", err)
+	}
+
+	if _, ok := resolved.EnvVars["ANTHROPIC_VERTEX_PROJECT_ID"]; ok {
+		t.Error("ANTHROPIC_VERTEX_PROJECT_ID should not be set for api-key auth")
+	}
+	if _, ok := resolved.EnvVars["CLAUDE_CODE_USE_VERTEX"]; ok {
+		t.Error("CLAUDE_CODE_USE_VERTEX should not be set for api-key auth")
+	}
+}
+
 func TestContainerScriptHarness_ApplyAuthSettings_StagesFileSecrets(t *testing.T) {
 	// Harness entry with a required_files declaration matching Codex auth-file.
 	dir := t.TempDir()

--- a/pkg/harness/container_script_harness_test.go
+++ b/pkg/harness/container_script_harness_test.go
@@ -505,7 +505,7 @@ func TestContainerScriptHarness_ResolveAuth_VertexAICredentialTranslation(t *tes
 	h := newClaudeHarness(t)
 
 	resolved, err := h.ResolveAuth(api.AuthConfig{
-		SelectedType:     "vertex-ai",
+		SelectedType:       "vertex-ai",
 		GoogleCloudProject: "my-project",
 		GoogleCloudRegion:  "us-central1",
 	})
@@ -559,7 +559,7 @@ func TestContainerScriptHarness_ResolveAuth_NoVertexTranslationForNonClaude(t *t
 	h, _ := newTestContainerScriptHarness(t) // harness name is "testharness"
 
 	resolved, err := h.ResolveAuth(api.AuthConfig{
-		SelectedType:     "vertex-ai",
+		SelectedType:       "vertex-ai",
 		GoogleCloudProject: "my-project",
 		GoogleCloudRegion:  "us-central1",
 	})


### PR DESCRIPTION
Fix self-perpetuating auth corruption where harness implementation names (e.g. "container-script") leaked into opts.HarnessAuth and scion-agent.json, causing Vertex AI agents to fail with "not logged in" on every restart.

Three converging failures fixed:
1. Guard pre-resolution assignment (run.go:493) and persistence (run.go:754) to reject harness implementation names
2. Unconditional corrupted-value clearing after authDone (covers both normal and NoAuth paths)
3. Active corruption repair: rewrites scion-agent.json to clear corrupted auth_selectedType
4. Add vertex-ai credential translation in ResolveAuth for Claude harness (GOOGLE_CLOUD_PROJECT -> ANTHROPIC_VERTEX_PROJECT_ID, etc.) for builtin provisioner type

Files: pkg/agent/run.go, pkg/harness/container_script_harness.go (+tests)
5 new tests, all existing tests pass.

Ref: ptone/scion#687
Prior: GoogleCloudPlatform/scion#921, GoogleCloudPlatform/scion#936
