### PR TITLE
fix(config): warn when settings file lacks schema_version

### DIFF
--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -1977,6 +1977,22 @@ func detectHierarchyFormat(projectPath string) (hasVersioned bool, missingSchema
 	return false, false
 }
 
+// settingsCandidateDirs returns the directories that may contain user settings
+// files (global and project), used to scan for silently-ignored content.
+func settingsCandidateDirs(projectPath string) []string {
+	var dirs []string
+	if globalDir, _ := GetGlobalDir(); globalDir != "" {
+		dirs = append(dirs, globalDir)
+	}
+	if effectiveProjectPath := resolveEffectiveProjectPath(projectPath); effectiveProjectPath != "" {
+		// Avoid duplicates if project path == global dir.
+		if len(dirs) == 0 || dirs[0] != effectiveProjectPath {
+			dirs = append(dirs, effectiveProjectPath)
+		}
+	}
+	return dirs
+}
+
 // LoadEffectiveSettings is a unified entry point that detects the settings format
 // and loads using the appropriate path.
 // - If any user file is versioned → uses LoadVersionedSettings
@@ -1996,12 +2012,42 @@ func LoadEffectiveSettings(projectPath string) (*VersionedSettings, []string, er
 		return vs, warnings, nil
 	}
 
+	// Before falling through to the legacy path, check if any settings file
+	// has real content that is being silently ignored because it lacks
+	// schema_version, harnesses key, and v1 runtime indicators.
+	var warnings []string
+	for _, dir := range settingsCandidateDirs(projectPath) {
+		path := GetSettingsPath(dir)
+		if path == "" {
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil || len(data) == 0 {
+			continue
+		}
+		version, isLegacy := DetectSettingsFormat(data)
+		if version != "" || isLegacy {
+			// File was recognized — not silently ignored.
+			continue
+		}
+		// Parse to check for real keys.
+		var raw map[string]interface{}
+		if err := yamlv3.Unmarshal(data, &raw); err != nil || len(raw) == 0 {
+			continue
+		}
+		warnings = append(warnings, fmt.Sprintf(
+			"settings file %s has no schema_version field and no recognized format indicators — its content is being ignored. Add 'schema_version: \"1\"' as the first line to enable versioned settings loading.",
+			path,
+		))
+	}
+
 	// Legacy path: load via existing loader, then adapt
 	legacy, err := LoadSettingsKoanf(projectPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading legacy settings: %w", err)
 	}
-	vs, warnings := AdaptLegacySettings(legacy)
+	vs, legacyWarnings := AdaptLegacySettings(legacy)
+	warnings = append(warnings, legacyWarnings...)
 	return vs, warnings, nil
 }
 

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -2036,7 +2036,7 @@ func LoadEffectiveSettings(projectPath string) (*VersionedSettings, []string, er
 			continue
 		}
 		warnings = append(warnings, fmt.Sprintf(
-			"settings file %s has no schema_version field and no recognized format indicators — its content is being ignored. Add 'schema_version: \"1\"' as the first line to enable versioned settings loading.",
+			"settings file %s has no schema_version field and no recognized format indicators. Add 'schema_version: \"1\"' as the first line for reliable versioned settings loading; without it, settings may not load correctly in future versions.",
 			path,
 		))
 	}

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -1981,12 +1981,13 @@ func detectHierarchyFormat(projectPath string) (hasVersioned bool, missingSchema
 // files (global and project), used to scan for files missing schema_version.
 func settingsCandidateDirs(projectPath string) []string {
 	var dirs []string
-	if globalDir, _ := GetGlobalDir(); globalDir != "" {
+	globalDir, _ := GetGlobalDir()
+	if globalDir != "" {
 		dirs = append(dirs, globalDir)
 	}
 	if effectiveProjectPath := resolveEffectiveProjectPath(projectPath); effectiveProjectPath != "" {
 		// Avoid duplicates if project path == global dir.
-		if len(dirs) == 0 || dirs[0] != effectiveProjectPath {
+		if effectiveProjectPath != globalDir {
 			dirs = append(dirs, effectiveProjectPath)
 		}
 	}

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -1978,7 +1978,7 @@ func detectHierarchyFormat(projectPath string) (hasVersioned bool, missingSchema
 }
 
 // settingsCandidateDirs returns the directories that may contain user settings
-// files (global and project), used to scan for silently-ignored content.
+// files (global and project), used to scan for files missing schema_version.
 func settingsCandidateDirs(projectPath string) []string {
 	var dirs []string
 	if globalDir, _ := GetGlobalDir(); globalDir != "" {
@@ -2013,8 +2013,8 @@ func LoadEffectiveSettings(projectPath string) (*VersionedSettings, []string, er
 	}
 
 	// Before falling through to the legacy path, check if any settings file
-	// has real content that is being silently ignored because it lacks
-	// schema_version, harnesses key, and v1 runtime indicators.
+	// has real content but lacks schema_version, harnesses key, and v1 runtime
+	// indicators — such files may not load correctly in future versions.
 	var warnings []string
 	for _, dir := range settingsCandidateDirs(projectPath) {
 		path := GetSettingsPath(dir)

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -724,6 +724,20 @@ func TestLoadEffectiveSettings_WarnOnIgnoredSettingsFile(t *testing.T) {
 				"comment-only file should not produce schema_version warning")
 		}
 	})
+
+	t.Run("legacy format file does not produce warning", func(t *testing.T) {
+		// Write a file with harnesses key (legacy format)
+		settingsPath := filepath.Join(projectDir, "settings.yaml")
+		require.NoError(t, os.WriteFile(settingsPath, []byte("harnesses:\n  claude:\n    image: test\n"), 0644))
+		defer os.Remove(settingsPath)
+
+		_, warnings, err := LoadEffectiveSettings(projectDir)
+		require.NoError(t, err)
+		for _, w := range warnings {
+			assert.NotContains(t, w, "no schema_version field",
+				"legacy format file should not produce schema_version warning")
+		}
+	})
 }
 
 // --- Default settings compatibility tests ---

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -666,6 +666,66 @@ func TestLoadEffectiveSettings_NoUserFiles(t *testing.T) {
 	_ = warnings
 }
 
+func TestLoadEffectiveSettings_WarnOnIgnoredSettingsFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	originalHome := os.Getenv("HOME")
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+	_ = os.Setenv("HOME", tmpDir)
+
+	projectDir := filepath.Join(tmpDir, "my-project", ".scion")
+	require.NoError(t, os.MkdirAll(projectDir, 0755))
+
+	t.Run("non-empty file without schema_version produces warning", func(t *testing.T) {
+		// Write settings with real keys but no schema_version, no harnesses,
+		// and no v1 runtime indicators — this file will be silently ignored.
+		settingsContent := "default_template: my-template\n"
+		settingsPath := filepath.Join(projectDir, "settings.yaml")
+		require.NoError(t, os.WriteFile(settingsPath, []byte(settingsContent), 0644))
+		defer os.Remove(settingsPath)
+
+		_, warnings, err := LoadEffectiveSettings(projectDir)
+		require.NoError(t, err)
+
+		found := false
+		for _, w := range warnings {
+			if strings.Contains(w, "no schema_version field") && strings.Contains(w, settingsPath) {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected warning about missing schema_version, got warnings: %v", warnings)
+	})
+
+	t.Run("empty file does not produce warning", func(t *testing.T) {
+		settingsPath := filepath.Join(projectDir, "settings.yaml")
+		require.NoError(t, os.WriteFile(settingsPath, []byte(""), 0644))
+		defer os.Remove(settingsPath)
+
+		_, warnings, err := LoadEffectiveSettings(projectDir)
+		require.NoError(t, err)
+
+		for _, w := range warnings {
+			assert.NotContains(t, w, "no schema_version field",
+				"empty file should not produce schema_version warning")
+		}
+	})
+
+	t.Run("file with only comments does not produce warning", func(t *testing.T) {
+		settingsPath := filepath.Join(projectDir, "settings.yaml")
+		require.NoError(t, os.WriteFile(settingsPath, []byte("# just a comment\n"), 0644))
+		defer os.Remove(settingsPath)
+
+		_, warnings, err := LoadEffectiveSettings(projectDir)
+		require.NoError(t, err)
+
+		for _, w := range warnings {
+			assert.NotContains(t, w, "no schema_version field",
+				"comment-only file should not produce schema_version warning")
+		}
+	})
+}
+
 // --- Default settings compatibility tests ---
 
 func TestGetDefaultSettingsData_ProducesSameEffectiveDefaults(t *testing.T) {

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -682,7 +682,7 @@ func TestLoadEffectiveSettings_WarnOnIgnoredSettingsFile(t *testing.T) {
 		settingsContent := "default_template: my-template\n"
 		settingsPath := filepath.Join(projectDir, "settings.yaml")
 		require.NoError(t, os.WriteFile(settingsPath, []byte(settingsContent), 0644))
-		defer os.Remove(settingsPath)
+		defer func() { _ = os.Remove(settingsPath) }()
 
 		_, warnings, err := LoadEffectiveSettings(projectDir)
 		require.NoError(t, err)
@@ -700,7 +700,7 @@ func TestLoadEffectiveSettings_WarnOnIgnoredSettingsFile(t *testing.T) {
 	t.Run("empty file does not produce warning", func(t *testing.T) {
 		settingsPath := filepath.Join(projectDir, "settings.yaml")
 		require.NoError(t, os.WriteFile(settingsPath, []byte(""), 0644))
-		defer os.Remove(settingsPath)
+		defer func() { _ = os.Remove(settingsPath) }()
 
 		_, warnings, err := LoadEffectiveSettings(projectDir)
 		require.NoError(t, err)
@@ -714,7 +714,7 @@ func TestLoadEffectiveSettings_WarnOnIgnoredSettingsFile(t *testing.T) {
 	t.Run("file with only comments does not produce warning", func(t *testing.T) {
 		settingsPath := filepath.Join(projectDir, "settings.yaml")
 		require.NoError(t, os.WriteFile(settingsPath, []byte("# just a comment\n"), 0644))
-		defer os.Remove(settingsPath)
+		defer func() { _ = os.Remove(settingsPath) }()
 
 		_, warnings, err := LoadEffectiveSettings(projectDir)
 		require.NoError(t, err)
@@ -729,7 +729,7 @@ func TestLoadEffectiveSettings_WarnOnIgnoredSettingsFile(t *testing.T) {
 		// Write a file with harnesses key (legacy format)
 		settingsPath := filepath.Join(projectDir, "settings.yaml")
 		require.NoError(t, os.WriteFile(settingsPath, []byte("harnesses:\n  claude:\n    image: test\n"), 0644))
-		defer os.Remove(settingsPath)
+		defer func() { _ = os.Remove(settingsPath) }()
 
 		_, warnings, err := LoadEffectiveSettings(projectDir)
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary

Adds a warning in LoadEffectiveSettings when a non-empty settings file has real configuration keys but no schema_version, no harnesses key, and no v1 runtime indicators. Previously, such files were loaded via the legacy path with no feedback -- users had no signal that adding schema_version would improve reliability.

Warning-only change -- no behavior change to settings loading.

Ref: ptone/scion#416

## Files changed

- pkg/config/settings_v1.go -- settingsCandidateDirs helper + warning logic in LoadEffectiveSettings
- pkg/config/settings_v1_test.go -- 4 test cases (real content, empty, comments-only, legacy format)
