### PR TITLE
fix(cli): validate --attach file paths before sending message

### DIFF
--- a/cmd/message.go
+++ b/cmd/message.go
@@ -196,8 +196,12 @@ Examples:
 			if resolved == "" {
 				return fmt.Errorf("attachment %q: path is outside allowed roots (/workspace, /scion-volumes)", p)
 			}
-			if _, err := os.Stat(resolved); err != nil {
+			info, err := os.Stat(resolved)
+			if err != nil {
 				return fmt.Errorf("attachment %q: %w", p, err)
+			}
+			if info.IsDir() {
+				return fmt.Errorf("attachment %q: is a directory, not a regular file", p)
 			}
 		}
 

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -190,6 +190,17 @@ Examples:
 			return fmt.Errorf("--attach cannot be combined with --in or --at")
 		}
 
+		// Validate attachment file paths exist
+		for _, p := range msgAttach {
+			resolved := resolveAttachmentPath(p)
+			if resolved == "" {
+				return fmt.Errorf("attachment %q: path is outside allowed roots (/workspace, /scion-volumes)", p)
+			}
+			if _, err := os.Stat(resolved); err != nil {
+				return fmt.Errorf("attachment %q: %w", p, err)
+			}
+		}
+
 		// Check if Hub should be used
 		var hubCtx *HubContext
 		var err error

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -200,8 +200,11 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("attachment %q: %w", p, err)
 			}
-			if info.IsDir() {
-				return fmt.Errorf("attachment %q: is a directory, not a regular file", p)
+			if !info.Mode().IsRegular() {
+				if info.IsDir() {
+					return fmt.Errorf("attachment %q: is a directory, not a regular file", p)
+				}
+				return fmt.Errorf("attachment %q: is not a regular file", p)
 			}
 		}
 

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -921,10 +921,15 @@ func TestAttachFlagValidation_OutsideAllowedRoots(t *testing.T) {
 }
 
 func TestAttachFlagValidation_Directory(t *testing.T) {
+	if _, err := os.Stat("/workspace"); os.IsNotExist(err) {
+		t.Skip("skipping: /workspace not available")
+	}
+
 	orig := saveMessageTestState()
 	defer orig.restore()
 
-	// Create a temporary directory under /workspace to use as an attachment
+	// Create a temporary directory under /workspace so it passes
+	// resolveAttachmentPath's allowed-roots check.
 	testDir := filepath.Join("/workspace", ".test-attach-dir-validation")
 	err := os.MkdirAll(testDir, 0755)
 	require.NoError(t, err)

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -895,6 +895,31 @@ func TestAttachFlagValidation(t *testing.T) {
 	}
 }
 
+func TestAttachFlagValidation_NonExistentFile(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	msgAttach = []string{"/workspace/this-file-does-not-exist-xyz.go"}
+	defer func() { msgAttach = nil }()
+
+	err := messageCmd.RunE(messageCmd, []string{"agent1", "hello"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "this-file-does-not-exist-xyz.go")
+	assert.Contains(t, err.Error(), "attachment")
+}
+
+func TestAttachFlagValidation_OutsideAllowedRoots(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	msgAttach = []string{"/etc/passwd"}
+	defer func() { msgAttach = nil }()
+
+	err := messageCmd.RunE(messageCmd, []string{"agent1", "hello"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outside allowed roots")
+}
+
 func TestSendGroupMessageViaHub(t *testing.T) {
 	orig := saveMessageTestState()
 	defer orig.restore()

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -920,6 +920,24 @@ func TestAttachFlagValidation_OutsideAllowedRoots(t *testing.T) {
 	assert.Contains(t, err.Error(), "outside allowed roots")
 }
 
+func TestAttachFlagValidation_Directory(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	// Create a temporary directory under /workspace to use as an attachment
+	testDir := filepath.Join("/workspace", ".test-attach-dir-validation")
+	err := os.MkdirAll(testDir, 0755)
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(testDir) }()
+
+	msgAttach = []string{testDir}
+	defer func() { msgAttach = nil }()
+
+	err = messageCmd.RunE(messageCmd, []string{"agent1", "hello"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is a directory, not a regular file")
+}
+
 func TestSendGroupMessageViaHub(t *testing.T) {
 	orig := saveMessageTestState()
 	defer orig.restore()


### PR DESCRIPTION
## Summary

Adds early validation of --attach file paths in the scion message command before Hub availability checks. Previously, a nonexistent file path would exit 0 with "Message sent" -- now it fails fast with a clear error and non-zero exit code.

Validates: file existence, allowed roots (/workspace, /scion-volumes), and regular file (not directory).

Ref: ptone/scion#571

## Files changed

- cmd/message.go -- 15-line early validation block after existing attachment checks
- cmd/message_test.go -- 3 new test functions (nonexistent file, outside roots, directory)
