### PR TITLE
fix(ops): add certbot deploy hook for automated Caddy cert reload

### DIFF
--- a/scripts/starter-hub/gce-certs.sh
+++ b/scripts/starter-hub/gce-certs.sh
@@ -92,7 +92,7 @@ else
         --email ${EMAIL} \
         --non-interactive \
         --agree-tos \
-        --deploy-hook 'chown -R root:caddy /etc/letsencrypt/live /etc/letsencrypt/archive && chmod -R g+rX /etc/letsencrypt/live /etc/letsencrypt/archive && systemctl reload caddy'"
+        --deploy-hook 'chown -R root:caddy /etc/letsencrypt/live /etc/letsencrypt/archive && chmod -R g+rX /etc/letsencrypt/live /etc/letsencrypt/archive && (systemctl reload caddy || caddy reload --config /etc/caddy/Caddyfile)'"
 fi
 
 # 5. Reload Caddy if it's installed to pick up new/renewed certificates

--- a/scripts/starter-hub/gce-certs.sh
+++ b/scripts/starter-hub/gce-certs.sh
@@ -92,7 +92,7 @@ else
         --email ${EMAIL} \
         --non-interactive \
         --agree-tos \
-        --deploy-hook 'chown -R root:caddy /etc/letsencrypt/live /etc/letsencrypt/archive && chmod -R g+rX /etc/letsencrypt/live /etc/letsencrypt/archive && (systemctl reload caddy || caddy reload --config /etc/caddy/Caddyfile)'"
+        --deploy-hook 'chown root:caddy /etc/letsencrypt/live /etc/letsencrypt/archive && chmod g+x /etc/letsencrypt/live /etc/letsencrypt/archive && chown -R root:caddy /etc/letsencrypt/live/\${RENEWED_DOMAINS%%,*} /etc/letsencrypt/archive/\${RENEWED_DOMAINS%%,*} && chmod -R g+rX /etc/letsencrypt/live/\${RENEWED_DOMAINS%%,*} /etc/letsencrypt/archive/\${RENEWED_DOMAINS%%,*} && (systemctl reload caddy || caddy reload --config /etc/caddy/Caddyfile)'"
 fi
 
 # 5. Reload Caddy if it's installed to pick up new/renewed certificates

--- a/scripts/starter-hub/gce-certs.sh
+++ b/scripts/starter-hub/gce-certs.sh
@@ -91,7 +91,8 @@ else
         -d '*.${DOMAIN}' \
         --email ${EMAIL} \
         --non-interactive \
-        --agree-tos"
+        --agree-tos \
+        --deploy-hook 'chown -R root:caddy /etc/letsencrypt/live /etc/letsencrypt/archive && chmod -R g+rX /etc/letsencrypt/live /etc/letsencrypt/archive && systemctl reload caddy'"
 fi
 
 # 5. Reload Caddy if it's installed to pick up new/renewed certificates


### PR DESCRIPTION
## Summary

Adds a --deploy-hook to the certbot command in scripts/starter-hub/gce-certs.sh so that after each successful certificate renewal, cert file permissions are fixed for the caddy group and Caddy is reloaded to pick up the new cert.

Previously, certbot would renew certs on disk but Caddy continued serving the old (expired) cert until manually reloaded, causing HTTPS failures across all GCE hub instances.

Ref: ptone/scion#471

## Files changed

- scripts/starter-hub/gce-certs.sh -- added --deploy-hook flag to certbot certonly command
