### PR TITLE
fix(messages): preserve mention metadata in delivery messages with allowlist filter

### DIFF
--- a/pkg/messages/format.go
+++ b/pkg/messages/format.go
@@ -27,6 +27,10 @@ const (
 // deliveryMetadataAllowlist defines the metadata keys that are forwarded to
 // agents during delivery. Platform-specific keys (e.g. telegram_chat_id) are
 // excluded to avoid leaking implementation details.
+//
+// "channel" and "thread_id" duplicate first-class fields on deliveryMessage
+// but are included here for completeness — callers may set them as metadata
+// instead of (or in addition to) the top-level fields.
 var deliveryMetadataAllowlist = map[string]bool{
 	"mention_source":   true,
 	"mention_position": true,

--- a/pkg/messages/format.go
+++ b/pkg/messages/format.go
@@ -86,19 +86,16 @@ func FormatForDelivery(msg *StructuredMessage) string {
 }
 
 // filterMetadata returns a copy of m containing only the keys in
-// deliveryMetadataAllowlist. Returns nil when the result would be empty.
+// deliveryMetadataAllowlist. Returns nil when no keys match.
 func filterMetadata(m map[string]string) map[string]string {
-	if len(m) == 0 {
-		return nil
-	}
-	filtered := make(map[string]string)
+	var filtered map[string]string
 	for k, v := range m {
 		if deliveryMetadataAllowlist[k] {
+			if filtered == nil {
+				filtered = make(map[string]string)
+			}
 			filtered[k] = v
 		}
-	}
-	if len(filtered) == 0 {
-		return nil
 	}
 	return filtered
 }

--- a/pkg/messages/format.go
+++ b/pkg/messages/format.go
@@ -24,6 +24,16 @@ const (
 	deliveryIntro  = "You are receiving a message from the orchestration system:"
 )
 
+// deliveryMetadataAllowlist defines the metadata keys that are forwarded to
+// agents during delivery. Platform-specific keys (e.g. telegram_chat_id) are
+// excluded to avoid leaking implementation details.
+var deliveryMetadataAllowlist = map[string]bool{
+	"mention_source":   true,
+	"mention_position": true,
+	"channel":          true,
+	"thread_id":        true,
+}
+
 // deliveryMessage is the subset of StructuredMessage fields delivered to the agent.
 // The recipient and version fields are stripped to save tokens.
 type deliveryMessage struct {
@@ -59,7 +69,7 @@ func FormatForDelivery(msg *StructuredMessage) string {
 		Attachments: msg.Attachments,
 		Channel:     msg.Channel,
 		ThreadID:    msg.ThreadID,
-		Metadata:    msg.Metadata,
+		Metadata:    filterMetadata(msg.Metadata),
 	}
 
 	jsonBytes, err := json.MarshalIndent(dm, "", "  ")
@@ -69,4 +79,22 @@ func FormatForDelivery(msg *StructuredMessage) string {
 	}
 
 	return deliveryIntro + "\n\n" + beginDelimiter + "\n" + string(jsonBytes) + "\n" + endDelimiter
+}
+
+// filterMetadata returns a copy of m containing only the keys in
+// deliveryMetadataAllowlist. Returns nil when the result would be empty.
+func filterMetadata(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	filtered := make(map[string]string)
+	for k, v := range m {
+		if deliveryMetadataAllowlist[k] {
+			filtered[k] = v
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
 }

--- a/pkg/messages/format.go
+++ b/pkg/messages/format.go
@@ -27,16 +27,17 @@ const (
 // deliveryMessage is the subset of StructuredMessage fields delivered to the agent.
 // The recipient and version fields are stripped to save tokens.
 type deliveryMessage struct {
-	Timestamp   string   `json:"timestamp"`
-	Sender      string   `json:"sender"`
-	Recipients  string   `json:"recipients,omitempty"`
-	Msg         string   `json:"msg"`
-	Type        string   `json:"type"`
-	Urgent      bool     `json:"urgent,omitempty"`
-	Broadcasted bool     `json:"broadcasted,omitempty"`
-	Attachments []string `json:"attachments,omitempty"`
-	Channel     string   `json:"channel,omitempty"`
-	ThreadID    string   `json:"thread_id,omitempty"`
+	Timestamp   string            `json:"timestamp"`
+	Sender      string            `json:"sender"`
+	Recipients  string            `json:"recipients,omitempty"`
+	Msg         string            `json:"msg"`
+	Type        string            `json:"type"`
+	Urgent      bool              `json:"urgent,omitempty"`
+	Broadcasted bool              `json:"broadcasted,omitempty"`
+	Attachments []string          `json:"attachments,omitempty"`
+	Channel     string            `json:"channel,omitempty"`
+	ThreadID    string            `json:"thread_id,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
 // FormatForDelivery formats a structured message for delivery to an agent via tmux.
@@ -58,6 +59,7 @@ func FormatForDelivery(msg *StructuredMessage) string {
 		Attachments: msg.Attachments,
 		Channel:     msg.Channel,
 		ThreadID:    msg.ThreadID,
+		Metadata:    msg.Metadata,
 	}
 
 	jsonBytes, err := json.MarshalIndent(dm, "", "  ")

--- a/pkg/messages/format_test.go
+++ b/pkg/messages/format_test.go
@@ -168,6 +168,50 @@ func TestFormatForDelivery_OmitsEmptyRecipients(t *testing.T) {
 	}
 }
 
+func TestFormatForDelivery_MentionMetadata(t *testing.T) {
+	msg := NewMention("user:alice", "agent:observer", "check the design", "agent:primary-dev")
+
+	result := FormatForDelivery(msg)
+
+	// Should contain mention_source in the JSON output
+	if !strings.Contains(result, `"mention_source": "agent:primary-dev"`) {
+		t.Error("missing mention_source in delivery output")
+	}
+
+	// Should contain mention_position in the JSON output
+	if !strings.Contains(result, `"mention_position": "body"`) {
+		t.Error("missing mention_position in delivery output")
+	}
+
+	// Should still have the correct type
+	if !strings.Contains(result, `"type": "mention"`) {
+		t.Error("missing mention type in delivery output")
+	}
+}
+
+func TestFormatForDelivery_NoMetadataRegression(t *testing.T) {
+	msg := &StructuredMessage{
+		Version:   Version,
+		Timestamp: "2026-03-07T14:30:00Z",
+		Sender:    "user:alice",
+		Recipient: "agent:dev",
+		Msg:       "do the thing",
+		Type:      TypeInstruction,
+	}
+
+	result := FormatForDelivery(msg)
+
+	// Messages without metadata should not include a metadata field
+	if strings.Contains(result, `"metadata"`) {
+		t.Error("metadata should be omitted when empty/nil")
+	}
+
+	// Should still format correctly
+	if !strings.Contains(result, `"sender": "user:alice"`) {
+		t.Error("missing sender in output")
+	}
+}
+
 func TestFormatForDelivery_WithAttachments(t *testing.T) {
 	msg := &StructuredMessage{
 		Version:     Version,

--- a/pkg/messages/format_test.go
+++ b/pkg/messages/format_test.go
@@ -212,6 +212,63 @@ func TestFormatForDelivery_NoMetadataRegression(t *testing.T) {
 	}
 }
 
+func TestFormatForDelivery_MetadataFiltersNonAllowlisted(t *testing.T) {
+	msg := &StructuredMessage{
+		Version:   Version,
+		Timestamp: "2026-06-01T10:00:00Z",
+		Sender:    "user:alice",
+		Recipient: "agent:dev",
+		Msg:       "hello from telegram",
+		Type:      TypeMention,
+		Metadata: map[string]string{
+			"mention_source":   "agent:primary",
+			"mention_position": "body",
+			"telegram_chat_id": "123456789",
+			"platform_token":   "secret-token",
+		},
+	}
+
+	result := FormatForDelivery(msg)
+
+	// Allowlisted keys should be present
+	if !strings.Contains(result, `"mention_source": "agent:primary"`) {
+		t.Error("missing allowlisted mention_source in delivery output")
+	}
+	if !strings.Contains(result, `"mention_position": "body"`) {
+		t.Error("missing allowlisted mention_position in delivery output")
+	}
+
+	// Non-allowlisted keys must be excluded
+	if strings.Contains(result, "telegram_chat_id") {
+		t.Error("non-allowlisted telegram_chat_id should be filtered from delivery output")
+	}
+	if strings.Contains(result, "platform_token") {
+		t.Error("non-allowlisted platform_token should be filtered from delivery output")
+	}
+}
+
+func TestFormatForDelivery_AllMetadataFiltered(t *testing.T) {
+	msg := &StructuredMessage{
+		Version:   Version,
+		Timestamp: "2026-06-01T10:00:00Z",
+		Sender:    "user:alice",
+		Recipient: "agent:dev",
+		Msg:       "platform-only metadata",
+		Type:      TypeInstruction,
+		Metadata: map[string]string{
+			"telegram_chat_id": "123456789",
+			"internal_flag":    "true",
+		},
+	}
+
+	result := FormatForDelivery(msg)
+
+	// When all metadata keys are non-allowlisted, metadata should be omitted entirely
+	if strings.Contains(result, `"metadata"`) {
+		t.Error("metadata should be omitted when all keys are filtered out")
+	}
+}
+
 func TestFormatForDelivery_WithAttachments(t *testing.T) {
 	msg := &StructuredMessage{
 		Version:     Version,


### PR DESCRIPTION
## Summary

Fixes a bug where mention-type messages dropped the Metadata field during delivery formatting, causing CC'd agents to not see who the primary recipients were.

Staging fork PR: ptone/scion#691
Staging fork issue: ptone/scion#689
