### PR TITLE
fix(hub): enforce as_needed injection mode for env vars and secrets

### DIFF
--- a/pkg/hub/envgather_resolution_test.go
+++ b/pkg/hub/envgather_resolution_test.go
@@ -52,11 +52,12 @@ func TestResolution_PlainEnvVar(t *testing.T) {
 
 	// Store a plain env var at user scope
 	_, err := memStore.UpsertEnvVar(ctx, &store.EnvVar{
-		ID:      api.NewUUID(),
-		Key:     "MY_API_KEY",
-		Value:   "plain-api-key-value",
-		Scope:   "user",
-		ScopeID: "user-res-1",
+		ID:            api.NewUUID(),
+		Key:           "MY_API_KEY",
+		Value:         "plain-api-key-value",
+		Scope:         "user",
+		ScopeID:       "user-res-1",
+		InjectionMode: store.InjectionModeAlways,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -114,11 +115,12 @@ func TestResolution_SecretUserScope(t *testing.T) {
 	// Store a secret via the local backend
 	backend := secret.NewLocalBackend(memStore, "test-hub-id")
 	_, _, err := backend.Set(ctx, &secret.SetSecretInput{
-		Name:       "SECRET_KEY",
-		Value:      "secret-key-value",
-		SecretType: secret.TypeEnvironment,
-		Scope:      secret.ScopeUser,
-		ScopeID:    "user-res-2",
+		Name:          "SECRET_KEY",
+		Value:         "secret-key-value",
+		SecretType:    secret.TypeEnvironment,
+		Scope:         secret.ScopeUser,
+		ScopeID:       "user-res-2",
+		InjectionMode: store.InjectionModeAlways,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -189,11 +191,12 @@ func TestResolution_ProjectEnvVar(t *testing.T) {
 
 	// Store a project-scoped env var
 	_, err := memStore.UpsertEnvVar(ctx, &store.EnvVar{
-		ID:      api.NewUUID(),
-		Key:     "GROVE_VAR",
-		Value:   "project-var-value",
-		Scope:   "project",
-		ScopeID: tid("project-res-3"),
+		ID:            api.NewUUID(),
+		Key:           "GROVE_VAR",
+		Value:         "project-var-value",
+		Scope:         "project",
+		ScopeID:       tid("project-res-3"),
+		InjectionMode: store.InjectionModeAlways,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -267,11 +270,12 @@ func TestResolution_SecretPromotedEnvVar(t *testing.T) {
 
 	// Promote to secret
 	_, _, err = backend.Set(ctx, &secret.SetSecretInput{
-		Name:       "GEMINI_API_KEY",
-		Value:      "secret-gemini-value",
-		SecretType: secret.TypeEnvironment,
-		Scope:      secret.ScopeUser,
-		ScopeID:    "user-res-4",
+		Name:          "GEMINI_API_KEY",
+		Value:         "secret-gemini-value",
+		SecretType:    secret.TypeEnvironment,
+		Scope:         secret.ScopeUser,
+		ScopeID:       "user-res-4",
+		InjectionMode: store.InjectionModeAlways,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/hub/envgather_test.go
+++ b/pkg/hub/envgather_test.go
@@ -325,6 +325,7 @@ func TestEnvGather_FinalizeReplay_MergePrecedence(t *testing.T) {
 	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
 		ID: tid("env-prec-1"), Key: "API_KEY", Value: "storage-value",
 		Scope: "project", ScopeID: tid("project-prec"),
+		InjectionMode: store.InjectionModeAlways,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -779,11 +780,12 @@ func TestEnvGather_HubEnvResolution(t *testing.T) {
 
 	// Store env vars in project scope
 	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
-		ID:      tid("env-1"),
-		Key:     "GROVE_API_KEY",
-		Value:   "project-key-value",
-		Scope:   "project",
-		ScopeID: tid("project-env"),
+		ID:            tid("env-1"),
+		Key:           "GROVE_API_KEY",
+		Value:         "project-key-value",
+		Scope:         "project",
+		ScopeID:       tid("project-env"),
+		InjectionMode: store.InjectionModeAlways,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1510,11 +1512,12 @@ func TestProjectRoute_ResolvesUserScopedEnvVars(t *testing.T) {
 
 	// Store a user-scoped env var for the dev-user (dev auth identity)
 	if err := st.CreateEnvVar(ctx, &store.EnvVar{
-		ID:      tid("env-owner-1"),
-		Key:     "GEMINI_API_KEY",
-		Value:   "user-scoped-gemini-key",
-		Scope:   "user",
-		ScopeID: DevUserID,
+		ID:            tid("env-owner-1"),
+		Key:           "GEMINI_API_KEY",
+		Value:         "user-scoped-gemini-key",
+		Scope:         "user",
+		ScopeID:       DevUserID,
+		InjectionMode: store.InjectionModeAlways,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1598,11 +1601,12 @@ func TestProjectRoute_ResolvesUserScopedSecrets(t *testing.T) {
 	// Store a user-scoped secret for the dev-user
 	backend := secret.NewLocalBackend(st, "test-hub-id")
 	_, _, err := backend.Set(ctx, &secret.SetSecretInput{
-		Name:       "GEMINI_API_KEY",
-		Value:      "secret-gemini-key",
-		SecretType: secret.TypeEnvironment,
-		Scope:      secret.ScopeUser,
-		ScopeID:    DevUserID,
+		Name:          "GEMINI_API_KEY",
+		Value:         "secret-gemini-key",
+		SecretType:    secret.TypeEnvironment,
+		Scope:         secret.ScopeUser,
+		ScopeID:       DevUserID,
+		InjectionMode: store.InjectionModeAlways,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -2227,7 +2227,7 @@ func (d *HTTPAgentDispatcher) resolveSecrets(ctx context.Context, agent *store.A
 	if err != nil {
 		return nil, err
 	}
-	var result []ResolvedSecret
+	result := make([]ResolvedSecret, 0, len(resolved))
 	for _, sv := range resolved {
 		if sv.InjectionMode == store.InjectionModeAsNeeded {
 			continue

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -1388,6 +1388,9 @@ func (d *HTTPAgentDispatcher) resolveEnvFromStorage(ctx context.Context, agent *
 			d.log.Debug("resolveEnvFromStorage: scope", "scope", filter.Scope, "scope_id", filter.ScopeID, "count", len(vars), "keys", keys)
 		}
 		for _, v := range vars {
+			if v.InjectionMode == store.InjectionModeAsNeeded {
+				continue
+			}
 			result[v.Key] = v.Value
 		}
 	}
@@ -1417,6 +1420,9 @@ func (d *HTTPAgentDispatcher) buildEnvSources(ctx context.Context, agent *store.
 		}
 		label := envScopeSourceLabel(filter.Scope)
 		for _, v := range vars {
+			if v.InjectionMode == store.InjectionModeAsNeeded {
+				continue
+			}
 			if _, inResolved := resolvedEnv[v.Key]; inResolved {
 				sources[v.Key] = label
 			}
@@ -2221,16 +2227,19 @@ func (d *HTTPAgentDispatcher) resolveSecrets(ctx context.Context, agent *store.A
 	if err != nil {
 		return nil, err
 	}
-	result := make([]ResolvedSecret, len(resolved))
-	for i, sv := range resolved {
-		result[i] = ResolvedSecret{
+	var result []ResolvedSecret
+	for _, sv := range resolved {
+		if sv.InjectionMode == store.InjectionModeAsNeeded {
+			continue
+		}
+		result = append(result, ResolvedSecret{
 			Name:   sv.Name,
 			Type:   sv.SecretType,
 			Target: sv.Target,
 			Value:  sv.Value,
 			Source: sv.Scope,
 			Ref:    sv.SecretRef,
-		}
+		})
 	}
 	if d.debug {
 		names := make([]string, len(result))

--- a/pkg/hub/httpdispatcher_envscope_test.go
+++ b/pkg/hub/httpdispatcher_envscope_test.go
@@ -72,11 +72,12 @@ func newEnvScopeDispatcher(t *testing.T, key string, valuesByScope map[string]st
 
 	for scope, value := range valuesByScope {
 		if _, err := memStore.UpsertEnvVar(ctx, &store.EnvVar{
-			ID:      api.NewUUID(),
-			Key:     key,
-			Value:   value,
-			Scope:   scope,
-			ScopeID: envScopeTestScopeID(t, scope),
+			ID:            api.NewUUID(),
+			Key:           key,
+			Value:         value,
+			Scope:         scope,
+			ScopeID:       envScopeTestScopeID(t, scope),
+			InjectionMode: store.InjectionModeAlways,
 		}); err != nil {
 			t.Fatalf("seeding %s-scoped env var: %v", scope, err)
 		}

--- a/pkg/hub/httpdispatcher_injection_mode_test.go
+++ b/pkg/hub/httpdispatcher_injection_mode_test.go
@@ -61,11 +61,11 @@ func TestResolveEnvFromStorage_InjectionMode(t *testing.T) {
 			InjectionMode: store.InjectionModeAsNeeded,
 		},
 		{
-			ID:            api.NewUUID(),
-			Key:           "DEFAULT_VAR",
-			Value:         "default-value",
-			Scope:         store.ScopeProject,
-			ScopeID:       agent.ProjectID,
+			ID:      api.NewUUID(),
+			Key:     "DEFAULT_VAR",
+			Value:   "default-value",
+			Scope:   store.ScopeProject,
+			ScopeID: agent.ProjectID,
 			// InjectionMode left empty — store normalises to "as_needed"
 		},
 	}

--- a/pkg/hub/httpdispatcher_injection_mode_test.go
+++ b/pkg/hub/httpdispatcher_injection_mode_test.go
@@ -1,0 +1,242 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// TestResolveEnvFromStorage_InjectionMode verifies that resolveEnvFromStorage
+// skips env vars with InjectionMode == "as_needed" and includes vars with
+// InjectionMode == "always".
+//
+// Note: the ent schema defaults injection_mode to "as_needed" and the store
+// adapter normalises empty strings to "as_needed" on write, so legacy env vars
+// with an unset InjectionMode are indistinguishable from explicit "as_needed"
+// at read time. The empty-string backward-compatibility case is tested at the
+// secret layer (TestResolveSecrets_InjectionMode) where the mock backend
+// bypasses the store's normalisation.
+func TestResolveEnvFromStorage_InjectionMode(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	agent := envScopeTestAgent()
+
+	// Seed env vars with explicit injection modes.
+	vars := []store.EnvVar{
+		{
+			ID:            api.NewUUID(),
+			Key:           "ALWAYS_VAR",
+			Value:         "always-value",
+			Scope:         store.ScopeProject,
+			ScopeID:       agent.ProjectID,
+			InjectionMode: store.InjectionModeAlways,
+		},
+		{
+			ID:            api.NewUUID(),
+			Key:           "AS_NEEDED_VAR",
+			Value:         "as-needed-value",
+			Scope:         store.ScopeProject,
+			ScopeID:       agent.ProjectID,
+			InjectionMode: store.InjectionModeAsNeeded,
+		},
+		{
+			ID:            api.NewUUID(),
+			Key:           "DEFAULT_VAR",
+			Value:         "default-value",
+			Scope:         store.ScopeProject,
+			ScopeID:       agent.ProjectID,
+			// InjectionMode left empty — store normalises to "as_needed"
+		},
+	}
+	for _, v := range vars {
+		if _, err := memStore.UpsertEnvVar(ctx, &v); err != nil {
+			t.Fatalf("seeding env var %s: %v", v.Key, err)
+		}
+	}
+
+	d := NewHTTPAgentDispatcherWithClient(memStore, &mockRuntimeBrokerClient{}, false, slog.Default())
+	d.SetHubID(envScopeTestHubID)
+
+	resolved, err := d.resolveEnvFromStorage(ctx, agent)
+	if err != nil {
+		t.Fatalf("resolveEnvFromStorage: %v", err)
+	}
+
+	// ALWAYS_VAR must be present.
+	if got, ok := resolved["ALWAYS_VAR"]; !ok {
+		t.Error("ALWAYS_VAR missing from resolved env, want present")
+	} else if got != "always-value" {
+		t.Errorf("ALWAYS_VAR = %q, want %q", got, "always-value")
+	}
+
+	// AS_NEEDED_VAR must NOT be present.
+	if _, ok := resolved["AS_NEEDED_VAR"]; ok {
+		t.Error("AS_NEEDED_VAR present in resolved env, want absent (injection_mode = as_needed)")
+	}
+
+	// DEFAULT_VAR (empty InjectionMode, normalised to as_needed by store) must NOT be present.
+	if _, ok := resolved["DEFAULT_VAR"]; ok {
+		t.Error("DEFAULT_VAR present in resolved env, want absent (store defaults empty to as_needed)")
+	}
+}
+
+// TestBuildEnvSources_InjectionMode verifies that buildEnvSources skips
+// as_needed env vars so they are not reported as sources.
+func TestBuildEnvSources_InjectionMode(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	agent := envScopeTestAgent()
+
+	vars := []store.EnvVar{
+		{
+			ID:            api.NewUUID(),
+			Key:           "ALWAYS_VAR",
+			Value:         "always-value",
+			Scope:         store.ScopeProject,
+			ScopeID:       agent.ProjectID,
+			InjectionMode: store.InjectionModeAlways,
+		},
+		{
+			ID:            api.NewUUID(),
+			Key:           "AS_NEEDED_VAR",
+			Value:         "as-needed-value",
+			Scope:         store.ScopeProject,
+			ScopeID:       agent.ProjectID,
+			InjectionMode: store.InjectionModeAsNeeded,
+		},
+	}
+	for _, v := range vars {
+		if _, err := memStore.UpsertEnvVar(ctx, &v); err != nil {
+			t.Fatalf("seeding env var %s: %v", v.Key, err)
+		}
+	}
+
+	d := NewHTTPAgentDispatcherWithClient(memStore, &mockRuntimeBrokerClient{}, false, slog.Default())
+	d.SetHubID(envScopeTestHubID)
+
+	// resolvedEnv contains only the var that passed the filter.
+	resolvedEnv := map[string]string{"ALWAYS_VAR": "always-value"}
+	sources := d.buildEnvSources(ctx, agent, resolvedEnv)
+
+	if got, ok := sources["ALWAYS_VAR"]; !ok || got != "project" {
+		t.Errorf("ALWAYS_VAR source = %q (present=%v), want %q", got, ok, "project")
+	}
+	if _, ok := sources["AS_NEEDED_VAR"]; ok {
+		t.Error("AS_NEEDED_VAR present in sources, want absent (injection_mode = as_needed)")
+	}
+}
+
+// TestResolveSecrets_InjectionMode verifies that resolveSecrets skips secrets
+// with InjectionMode == "as_needed" and includes secrets with InjectionMode ==
+// "always" or "" (empty/unset).
+func TestResolveSecrets_InjectionMode(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	agent := &store.Agent{
+		ID:              "agent-injmode-1",
+		Name:            "injmode-agent",
+		Slug:            "injmode-agent",
+		ProjectID:       "project-injmode-1",
+		OwnerID:         "user-injmode-1",
+		RuntimeBrokerID: "broker-injmode-1",
+		AppliedConfig:   &store.AgentAppliedConfig{},
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetSecretBackend(&mockSecretBackend{
+		secrets: []secret.SecretWithValue{
+			{
+				SecretMeta: secret.SecretMeta{
+					Name:          "ALWAYS_SECRET",
+					SecretType:    "environment",
+					Target:        "ALWAYS_SECRET",
+					Scope:         "project",
+					ScopeID:       agent.ProjectID,
+					InjectionMode: "always",
+				},
+				Value: "always-secret-value",
+			},
+			{
+				SecretMeta: secret.SecretMeta{
+					Name:          "AS_NEEDED_SECRET",
+					SecretType:    "environment",
+					Target:        "AS_NEEDED_SECRET",
+					Scope:         "project",
+					ScopeID:       agent.ProjectID,
+					InjectionMode: "as_needed",
+				},
+				Value: "as-needed-secret-value",
+			},
+			{
+				SecretMeta: secret.SecretMeta{
+					Name:       "UNSET_SECRET",
+					SecretType: "environment",
+					Target:     "UNSET_SECRET",
+					Scope:      "project",
+					ScopeID:    agent.ProjectID,
+					// InjectionMode left empty — legacy, treated as always
+				},
+				Value: "unset-secret-value",
+			},
+		},
+	})
+
+	resolved, err := d.resolveSecrets(ctx, agent)
+	if err != nil {
+		t.Fatalf("resolveSecrets: %v", err)
+	}
+
+	// Build a lookup for easy assertions.
+	byName := make(map[string]ResolvedSecret, len(resolved))
+	for _, r := range resolved {
+		byName[r.Name] = r
+	}
+
+	// ALWAYS_SECRET must be present.
+	if r, ok := byName["ALWAYS_SECRET"]; !ok {
+		t.Error("ALWAYS_SECRET missing from resolved secrets, want present")
+	} else if r.Value != "always-secret-value" {
+		t.Errorf("ALWAYS_SECRET value = %q, want %q", r.Value, "always-secret-value")
+	}
+
+	// AS_NEEDED_SECRET must NOT be present.
+	if _, ok := byName["AS_NEEDED_SECRET"]; ok {
+		t.Error("AS_NEEDED_SECRET present in resolved secrets, want absent (injection_mode = as_needed)")
+	}
+
+	// UNSET_SECRET (empty InjectionMode) must be present — backward compatibility.
+	if r, ok := byName["UNSET_SECRET"]; !ok {
+		t.Error("UNSET_SECRET missing from resolved secrets, want present (empty injection_mode = always)")
+	} else if r.Value != "unset-secret-value" {
+		t.Errorf("UNSET_SECRET value = %q, want %q", r.Value, "unset-secret-value")
+	}
+
+	// Total count: should be 2 (always + unset), not 3.
+	if len(resolved) != 2 {
+		t.Errorf("resolved %d secrets, want 2", len(resolved))
+	}
+}

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -1377,22 +1377,24 @@ func TestHTTPAgentDispatcher_DispatchAgentStart_ResolvesEnvFromStorage(t *testin
 
 	// Store an env var in project scope (simulating API key stored in hub)
 	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
-		ID:      tid("ev-project-1"),
-		Key:     "GEMINI_API_KEY",
-		Value:   "test-api-key-123",
-		Scope:   "project",
-		ScopeID: tid("project-env"),
+		ID:            tid("ev-project-1"),
+		Key:           "GEMINI_API_KEY",
+		Value:         "test-api-key-123",
+		Scope:         "project",
+		ScopeID:       tid("project-env"),
+		InjectionMode: store.InjectionModeAlways,
 	}); err != nil {
 		t.Fatalf("failed to set env var: %v", err)
 	}
 
 	// Store a user-scoped env var
 	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
-		ID:      tid("ev-user-1"),
-		Key:     "CUSTOM_VAR",
-		Value:   "user-value",
-		Scope:   "user",
-		ScopeID: "owner-1",
+		ID:            tid("ev-user-1"),
+		Key:           "CUSTOM_VAR",
+		Value:         "user-value",
+		Scope:         "user",
+		ScopeID:       "owner-1",
+		InjectionMode: store.InjectionModeAlways,
 	}); err != nil {
 		t.Fatalf("failed to set env var: %v", err)
 	}
@@ -1470,11 +1472,12 @@ func TestHTTPAgentDispatcher_DispatchAgentStart_ConfigEnvTakesPrecedence(t *test
 
 	// Store an env var that conflicts with config env
 	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
-		ID:      tid("ev-prec-1"),
-		Key:     "API_KEY",
-		Value:   "storage-value",
-		Scope:   "project",
-		ScopeID: tid("project-prec"),
+		ID:            tid("ev-prec-1"),
+		Key:           "API_KEY",
+		Value:         "storage-value",
+		Scope:         "project",
+		ScopeID:       tid("project-prec"),
+		InjectionMode: store.InjectionModeAlways,
 	}); err != nil {
 		t.Fatalf("failed to set env var: %v", err)
 	}
@@ -1533,11 +1536,12 @@ func TestHTTPAgentDispatcher_DispatchAgentStart_StorageOverridesEmptyConfigEnv(t
 
 	// Store an env var that should override the empty config value
 	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
-		ID:      tid("ev-empty-1"),
-		Key:     "GEMINI_API_KEY",
-		Value:   "stored-api-key",
-		Scope:   "project",
-		ScopeID: tid("project-empty-env"),
+		ID:            tid("ev-empty-1"),
+		Key:           "GEMINI_API_KEY",
+		Value:         "stored-api-key",
+		Scope:         "project",
+		ScopeID:       tid("project-empty-env"),
+		InjectionMode: store.InjectionModeAlways,
 	}); err != nil {
 		t.Fatalf("failed to set env var: %v", err)
 	}
@@ -2248,11 +2252,12 @@ func TestBuildCreateRequest_ResolvesStorageEnvVars(t *testing.T) {
 
 	// Store a user-scoped env var
 	envVar := &store.EnvVar{
-		ID:      tid("ev-1"),
-		Key:     "GEMINI_API_KEY",
-		Value:   "stored-key-value",
-		Scope:   "user",
-		ScopeID: tid("user-1"),
+		ID:            tid("ev-1"),
+		Key:           "GEMINI_API_KEY",
+		Value:         "stored-key-value",
+		Scope:         "user",
+		ScopeID:       tid("user-1"),
+		InjectionMode: store.InjectionModeAlways,
 	}
 	if err := memStore.CreateEnvVar(ctx, envVar); err != nil {
 		t.Fatalf("failed to create env var: %v", err)
@@ -2301,11 +2306,12 @@ func TestBuildCreateRequest_ConfigEnvOverridesStorage(t *testing.T) {
 
 	// Store a user-scoped env var with the same key as config env
 	envVar := &store.EnvVar{
-		ID:      tid("ev-1"),
-		Key:     "MY_KEY",
-		Value:   "storage-value",
-		Scope:   "user",
-		ScopeID: tid("user-1"),
+		ID:            tid("ev-1"),
+		Key:           "MY_KEY",
+		Value:         "storage-value",
+		Scope:         "user",
+		ScopeID:       tid("user-1"),
+		InjectionMode: store.InjectionModeAlways,
 	}
 	if err := memStore.CreateEnvVar(ctx, envVar); err != nil {
 		t.Fatalf("failed to create env var: %v", err)
@@ -2365,11 +2371,12 @@ func TestBuildCreateRequest_ResolvesProjectAndUserScopes(t *testing.T) {
 
 	// Store a project-scoped env var
 	projectEnv := &store.EnvVar{
-		ID:      tid("ev-project"),
-		Key:     "SHARED_KEY",
-		Value:   "project-value",
-		Scope:   "project",
-		ScopeID: tid("project-1"),
+		ID:            tid("ev-project"),
+		Key:           "SHARED_KEY",
+		Value:         "project-value",
+		Scope:         "project",
+		ScopeID:       tid("project-1"),
+		InjectionMode: store.InjectionModeAlways,
 	}
 	if err := memStore.CreateEnvVar(ctx, projectEnv); err != nil {
 		t.Fatalf("failed to create project env var: %v", err)
@@ -2377,11 +2384,12 @@ func TestBuildCreateRequest_ResolvesProjectAndUserScopes(t *testing.T) {
 
 	// Store a user-scoped env var with the same key (higher precedence)
 	userEnv := &store.EnvVar{
-		ID:      tid("ev-user"),
-		Key:     "SHARED_KEY",
-		Value:   "user-value",
-		Scope:   "user",
-		ScopeID: tid("user-1"),
+		ID:            tid("ev-user"),
+		Key:           "SHARED_KEY",
+		Value:         "user-value",
+		Scope:         "user",
+		ScopeID:       tid("user-1"),
+		InjectionMode: store.InjectionModeAlways,
 	}
 	if err := memStore.CreateEnvVar(ctx, userEnv); err != nil {
 		t.Fatalf("failed to create user env var: %v", err)
@@ -2389,11 +2397,12 @@ func TestBuildCreateRequest_ResolvesProjectAndUserScopes(t *testing.T) {
 
 	// Store a project-only env var
 	projectOnly := &store.EnvVar{
-		ID:      tid("ev-project-only"),
-		Key:     "GROVE_ONLY_KEY",
-		Value:   "project-only-value",
-		Scope:   "project",
-		ScopeID: tid("project-1"),
+		ID:            tid("ev-project-only"),
+		Key:           "GROVE_ONLY_KEY",
+		Value:         "project-only-value",
+		Scope:         "project",
+		ScopeID:       tid("project-1"),
+		InjectionMode: store.InjectionModeAlways,
 	}
 	if err := memStore.CreateEnvVar(ctx, projectOnly); err != nil {
 		t.Fatalf("failed to create project-only env var: %v", err)
@@ -2446,11 +2455,12 @@ func TestDispatchAgentCreate_IncludesStorageEnvVars(t *testing.T) {
 
 	// Store user-scoped env vars
 	envVar := &store.EnvVar{
-		ID:      tid("ev-1"),
-		Key:     "API_TOKEN",
-		Value:   "secret-token-123",
-		Scope:   "user",
-		ScopeID: tid("user-1"),
+		ID:            tid("ev-1"),
+		Key:           "API_TOKEN",
+		Value:         "secret-token-123",
+		Scope:         "user",
+		ScopeID:       tid("user-1"),
+		InjectionMode: store.InjectionModeAlways,
 	}
 	if err := memStore.CreateEnvVar(ctx, envVar); err != nil {
 		t.Fatalf("failed to create env var: %v", err)

--- a/pkg/hub/resolve_secrets_test.go
+++ b/pkg/hub/resolve_secrets_test.go
@@ -38,6 +38,7 @@ func TestResolveSecrets(t *testing.T) {
 		Target:         "API_KEY",
 		Scope:          store.ScopeUser,
 		ScopeID:        tid("user-1"),
+		InjectionMode:  store.InjectionModeAlways,
 	}
 	projectSecret := &store.Secret{
 		ID:             tid("s2"),
@@ -47,6 +48,7 @@ func TestResolveSecrets(t *testing.T) {
 		Target:         "DATABASE_PASSWORD",
 		Scope:          store.ScopeProject,
 		ScopeID:        tid("project-1"),
+		InjectionMode:  store.InjectionModeAlways,
 	}
 	// Project-level override of user API_KEY
 	projectOverride := &store.Secret{
@@ -57,6 +59,7 @@ func TestResolveSecrets(t *testing.T) {
 		Target:         "API_KEY",
 		Scope:          store.ScopeProject,
 		ScopeID:        tid("project-1"),
+		InjectionMode:  store.InjectionModeAlways,
 	}
 	fileSecret := &store.Secret{
 		ID:             tid("s4"),
@@ -66,6 +69,7 @@ func TestResolveSecrets(t *testing.T) {
 		Target:         "/etc/ssl/cert.pem",
 		Scope:          store.ScopeUser,
 		ScopeID:        tid("user-1"),
+		InjectionMode:  store.InjectionModeAlways,
 	}
 	varSecret := &store.Secret{
 		ID:             tid("s5"),
@@ -75,6 +79,7 @@ func TestResolveSecrets(t *testing.T) {
 		Target:         "config",
 		Scope:          store.ScopeUser,
 		ScopeID:        tid("user-1"),
+		InjectionMode:  store.InjectionModeAlways,
 	}
 
 	for _, s := range []*store.Secret{userSecret, projectSecret, projectOverride, fileSecret, varSecret} {
@@ -172,6 +177,7 @@ func TestResolveSecrets_WithBackend(t *testing.T) {
 			Target:         "API_KEY",
 			Scope:          store.ScopeUser,
 			ScopeID:        tid("user-1"),
+			InjectionMode:  store.InjectionModeAlways,
 		},
 		{
 			ID:             tid("s2"),
@@ -181,6 +187,7 @@ func TestResolveSecrets_WithBackend(t *testing.T) {
 			Target:         "API_KEY",
 			Scope:          store.ScopeProject,
 			ScopeID:        tid("project-1"),
+			InjectionMode:  store.InjectionModeAlways,
 		},
 		{
 			ID:             tid("s3"),
@@ -190,6 +197,7 @@ func TestResolveSecrets_WithBackend(t *testing.T) {
 			Target:         "DATABASE_PASSWORD",
 			Scope:          store.ScopeProject,
 			ScopeID:        tid("project-1"),
+			InjectionMode:  store.InjectionModeAlways,
 		},
 	} {
 		if err := memStore.CreateSecret(ctx, s); err != nil {
@@ -283,6 +291,7 @@ func TestResolveSecrets_HubScope(t *testing.T) {
 		Target:         "ORG_API_KEY",
 		Scope:          store.ScopeHub,
 		ScopeID:        "test-hub-id",
+		InjectionMode:  store.InjectionModeAlways,
 	}
 	// Create a hub secret that will be overridden by user scope
 	hubOverridden := &store.Secret{
@@ -293,9 +302,10 @@ func TestResolveSecrets_HubScope(t *testing.T) {
 		Target:         "API_KEY",
 		Scope:          store.ScopeHub,
 		ScopeID:        "test-hub-id",
+		InjectionMode:  store.InjectionModeAlways,
 	}
 	// Create user secret that overrides hub
-	userSecret := &store.Secret{
+	userSecret2 := &store.Secret{
 		ID:             tid("su1"),
 		Key:            "API_KEY",
 		EncryptedValue: "user-personal-api-key",
@@ -303,6 +313,7 @@ func TestResolveSecrets_HubScope(t *testing.T) {
 		Target:         "API_KEY",
 		Scope:          store.ScopeUser,
 		ScopeID:        tid("user-1"),
+		InjectionMode:  store.InjectionModeAlways,
 	}
 	// Create a hub secret overridden by project scope
 	hubProjectOverridden := &store.Secret{
@@ -313,6 +324,7 @@ func TestResolveSecrets_HubScope(t *testing.T) {
 		Target:         "DB_PASS",
 		Scope:          store.ScopeHub,
 		ScopeID:        "test-hub-id",
+		InjectionMode:  store.InjectionModeAlways,
 	}
 	projectSecret := &store.Secret{
 		ID:             tid("sg1"),
@@ -322,9 +334,10 @@ func TestResolveSecrets_HubScope(t *testing.T) {
 		Target:         "DB_PASS",
 		Scope:          store.ScopeProject,
 		ScopeID:        tid("project-1"),
+		InjectionMode:  store.InjectionModeAlways,
 	}
 
-	for _, s := range []*store.Secret{hubSecret, hubOverridden, userSecret, hubProjectOverridden, projectSecret} {
+	for _, s := range []*store.Secret{hubSecret, hubOverridden, userSecret2, hubProjectOverridden, projectSecret} {
 		if err := memStore.CreateSecret(ctx, s); err != nil {
 			t.Fatalf("failed to create test secret %s (scope=%s): %v", s.Key, s.Scope, err)
 		}


### PR DESCRIPTION
Secrets and env vars marked with injection_mode = as_needed were injected into the agent container environment regardless of that flag. The as_needed annotation was stored and surfaced in the UI but not enforced at dispatch time.

This fix adds filtering at all three injection paths in httpdispatcher.go:
- resolveEnvFromStorage(): skips as_needed env vars
- buildEnvSources(): skips as_needed env vars in source tracking
- resolveSecrets(): skips as_needed secrets

When InjectionMode is empty/unset (legacy secrets from external backends), items are still injected (treated as always) for backward compatibility. Env vars use the ent schema default of as_needed.

Key files: pkg/hub/httpdispatcher.go
Tests: pkg/hub/httpdispatcher_injection_mode_test.go (new, 242 lines covering all three filter paths and backward compat)

Ref: ptone/scion#557