### PR TITLE
fix(discord): make /scion send search root configurable (#690)

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -347,7 +347,7 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 		}
 		sendSearchRoot := config["send_search_root"]
 		b.commands = NewCommandHandler(b.store, b.session, b.hubClient, b.deliverInbound, appID, guildIDs, b.agentCacheTTL, sendSearchRoot, b.log)
-		b.callbacks = NewCallbackHandler(b.store, b.session, b.hubClient, b.deliverInbound, sendSearchRoot, b.log)
+		b.callbacks = NewCallbackHandler(b.store, b.session, b.hubClient, b.deliverInbound, b.log)
 		b.registration = NewRegistrationHandler(b.store, b.session, b.hubURL, b.hmacKey, b.brokerID, b.httpClient, b.log)
 
 		// Parse hub-injected project slug map (projectID -> slug).

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -345,8 +345,9 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 			appID = b.config.ApplicationID
 			guildIDs = b.config.GuildIDs
 		}
-		b.commands = NewCommandHandler(b.store, b.session, b.hubClient, b.deliverInbound, appID, guildIDs, b.agentCacheTTL, b.log)
-		b.callbacks = NewCallbackHandler(b.store, b.session, b.hubClient, b.deliverInbound, b.log)
+		sendSearchRoot := config["send_search_root"]
+		b.commands = NewCommandHandler(b.store, b.session, b.hubClient, b.deliverInbound, appID, guildIDs, b.agentCacheTTL, sendSearchRoot, b.log)
+		b.callbacks = NewCallbackHandler(b.store, b.session, b.hubClient, b.deliverInbound, sendSearchRoot, b.log)
 		b.registration = NewRegistrationHandler(b.store, b.session, b.hubURL, b.hmacKey, b.brokerID, b.httpClient, b.log)
 
 		// Parse hub-injected project slug map (projectID -> slug).

--- a/extras/scion-discord/internal/discord/callbacks.go
+++ b/extras/scion-discord/internal/discord/callbacks.go
@@ -24,19 +24,27 @@ type CallbackHandler struct {
 	// deliverInbound delivers a StructuredMessage to the hub on the given topic.
 	// Injected by the broker so callbacks can route responses back to agents.
 	deliverInbound func(topic string, msg *messages.StructuredMessage) *hubError
+
+	searchRoot string // base directory for /scion send file searches
 }
 
 // NewCallbackHandler creates a new CallbackHandler.
 // deliverInbound is a function that posts a StructuredMessage to the hub.
-func NewCallbackHandler(store Store, session *discordgo.Session, hubClient HubClient, deliverInbound func(string, *messages.StructuredMessage) *hubError, log *slog.Logger) *CallbackHandler {
+// searchRoot sets the base directory for /scion send file searches; when
+// empty it defaults to DefaultSearchRoot.
+func NewCallbackHandler(store Store, session *discordgo.Session, hubClient HubClient, deliverInbound func(string, *messages.StructuredMessage) *hubError, searchRoot string, log *slog.Logger) *CallbackHandler {
 	if log == nil {
 		log = slog.Default()
+	}
+	if searchRoot == "" {
+		searchRoot = DefaultSearchRoot
 	}
 	return &CallbackHandler{
 		store:          store,
 		session:        session,
 		hubClient:      hubClient,
 		deliverInbound: deliverInbound,
+		searchRoot:     searchRoot,
 		log:            log,
 	}
 }
@@ -617,7 +625,7 @@ func (h *CallbackHandler) handleSendCallback(s *discordgo.Session, i *discordgo.
 		return
 	}
 	key := parts[2]
-	handleSendFileCallback(s, i, key, h.log)
+	handleSendFileCallback(s, i, key, h.searchRoot, h.log)
 }
 
 // --- Notification callback handlers ---

--- a/extras/scion-discord/internal/discord/callbacks.go
+++ b/extras/scion-discord/internal/discord/callbacks.go
@@ -24,27 +24,19 @@ type CallbackHandler struct {
 	// deliverInbound delivers a StructuredMessage to the hub on the given topic.
 	// Injected by the broker so callbacks can route responses back to agents.
 	deliverInbound func(topic string, msg *messages.StructuredMessage) *hubError
-
-	searchRoot string // base directory for /scion send file searches
 }
 
 // NewCallbackHandler creates a new CallbackHandler.
 // deliverInbound is a function that posts a StructuredMessage to the hub.
-// searchRoot sets the base directory for /scion send file searches; when
-// empty it defaults to DefaultSearchRoot.
-func NewCallbackHandler(store Store, session *discordgo.Session, hubClient HubClient, deliverInbound func(string, *messages.StructuredMessage) *hubError, searchRoot string, log *slog.Logger) *CallbackHandler {
+func NewCallbackHandler(store Store, session *discordgo.Session, hubClient HubClient, deliverInbound func(string, *messages.StructuredMessage) *hubError, log *slog.Logger) *CallbackHandler {
 	if log == nil {
 		log = slog.Default()
-	}
-	if searchRoot == "" {
-		searchRoot = DefaultSearchRoot
 	}
 	return &CallbackHandler{
 		store:          store,
 		session:        session,
 		hubClient:      hubClient,
 		deliverInbound: deliverInbound,
-		searchRoot:     searchRoot,
 		log:            log,
 	}
 }
@@ -625,7 +617,7 @@ func (h *CallbackHandler) handleSendCallback(s *discordgo.Session, i *discordgo.
 		return
 	}
 	key := parts[2]
-	handleSendFileCallback(s, i, key, h.searchRoot, h.log)
+	handleSendFileCallback(s, i, key, h.log)
 }
 
 // --- Notification callback handlers ---

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -81,14 +81,20 @@ type CommandHandler struct {
 	appID          string
 	guildIDs       []string // empty = global commands
 	agentCacheTTL  time.Duration
+	searchRoot     string // base directory for /scion send file searches
 	deliverInbound func(topic string, msg *messages.StructuredMessage) *hubError
 }
 
 // NewCommandHandler creates a new CommandHandler. agentCacheTTL controls how
-// long agent lists are cached before refreshing from the Hub API.
-func NewCommandHandler(store Store, session *discordgo.Session, hubClient HubClient, deliverInbound func(string, *messages.StructuredMessage) *hubError, appID string, guildIDs []string, agentCacheTTL time.Duration, log *slog.Logger) *CommandHandler {
+// long agent lists are cached before refreshing from the Hub API. searchRoot
+// sets the base directory for /scion send file searches; when empty it
+// defaults to DefaultSearchRoot.
+func NewCommandHandler(store Store, session *discordgo.Session, hubClient HubClient, deliverInbound func(string, *messages.StructuredMessage) *hubError, appID string, guildIDs []string, agentCacheTTL time.Duration, searchRoot string, log *slog.Logger) *CommandHandler {
 	if log == nil {
 		log = slog.Default()
+	}
+	if searchRoot == "" {
+		searchRoot = DefaultSearchRoot
 	}
 	return &CommandHandler{
 		store:          store,
@@ -99,6 +105,7 @@ func NewCommandHandler(store Store, session *discordgo.Session, hubClient HubCli
 		appID:          appID,
 		guildIDs:       guildIDs,
 		agentCacheTTL:  agentCacheTTL,
+		searchRoot:     searchRoot,
 	}
 }
 

--- a/extras/scion-discord/internal/discord/send.go
+++ b/extras/scion-discord/internal/discord/send.go
@@ -1,6 +1,7 @@
 package discord
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"io/fs"
@@ -105,25 +106,41 @@ type fileMatch struct {
 	ModTime time.Time
 }
 
-// safeResolve cleans the path, verifies it starts with root, resolves
-// symlinks, and re-verifies the resolved path is still under root.
+// safeResolve cleans the path, verifies it is under root using filepath.Rel,
+// resolves symlinks, and re-verifies the resolved path is still under root.
 // It returns the resolved path or an error if any check fails.
 //
-// root is normalised to end with a path separator so that a root of
-// "/scion-volumes" cannot be prefix-confused with "/scion-volumes-evil".
+// filepath.Rel is used instead of strings.HasPrefix to avoid prefix-confusion
+// attacks (e.g. "/scion-volumes" matching "/scion-volumes-evil").
 func safeResolve(path, root string) (string, error) {
-	root = filepath.Clean(root) + string(filepath.Separator)
-	cleaned := filepath.Clean(path)
-	if !strings.HasPrefix(cleaned, root) {
-		return "", fmt.Errorf("path %q does not start with %q", cleaned, root)
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", err
 	}
+	root = filepath.Clean(absRoot)
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	cleaned := filepath.Clean(absPath)
+
+	rel, err := filepath.Rel(root, cleaned)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q is not under %q", cleaned, root)
+	}
+
 	resolved, err := filepath.EvalSymlinks(cleaned)
 	if err != nil {
 		return "", err
 	}
-	if !strings.HasPrefix(resolved, root) {
-		return "", fmt.Errorf("resolved path %q does not start with %q", resolved, root)
+	resolved = filepath.Clean(resolved)
+
+	relResolved, err := filepath.Rel(root, resolved)
+	if err != nil || relResolved == ".." || strings.HasPrefix(relResolved, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("resolved path %q is not under %q", resolved, root)
 	}
+
 	return resolved, nil
 }
 
@@ -135,10 +152,62 @@ func isUnderSearchRoot(path, root string) bool {
 	return err == nil
 }
 
+// safeResolveMulti tries safeResolve against each root and returns the first
+// successful result. Returns an error if the path is not under any root.
+func safeResolveMulti(path string, roots []string) (string, error) {
+	for _, root := range roots {
+		if resolved, err := safeResolve(path, root); err == nil {
+			return resolved, nil
+		}
+	}
+	return "", fmt.Errorf("path %q is not under any allowed root", path)
+}
+
+// projectSearchRoots computes the search roots for a project by enumerating
+// shared directories and the workspace path. It uses os.UserHomeDir() rather
+// than hardcoding /home/scion.
+func projectSearchRoots(slug, projectID string) []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+
+	shortUUID := strings.ReplaceAll(projectID, "-", "")
+	if len(shortUUID) > 8 {
+		shortUUID = shortUUID[:8]
+	}
+	configDir := filepath.Join(home, ".scion", "project-configs",
+		fmt.Sprintf("%s__%s", slug, shortUUID))
+	sharedDirsRoot := filepath.Join(configDir, "shared-dirs")
+
+	var roots []string
+
+	// Enumerate shared dir subdirectories.
+	entries, err := os.ReadDir(sharedDirsRoot)
+	if err == nil {
+		for _, e := range entries {
+			if e.IsDir() {
+				roots = append(roots, filepath.Join(sharedDirsRoot, e.Name()))
+			}
+		}
+	}
+
+	// Include the workspace path.
+	workspacePath := filepath.Join(home, ".scion", "projects", slug)
+	if info, err := os.Stat(workspacePath); err == nil && info.IsDir() {
+		roots = append(roots, workspacePath)
+	}
+
+	return roots
+}
+
 // HandleSend handles the /scion send <path> command.
-// If path is an absolute path to an existing file under searchRoot, it sends
-// it directly. Otherwise it searches /scion-volumes/ for matching files and
-// presents buttons for selection.
+// It resolves the channel's project binding to determine per-project search
+// roots. If the channel is not linked and no send_search_root override is
+// configured, it returns an error asking the user to run /scion setup.
+// If path is an absolute path to an existing file under a valid root, it sends
+// it directly. Otherwise it searches all roots for matching files and presents
+// buttons for selection.
 func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	pathArg := getSubcommandOption(i, "path")
 	if pathArg == "" {
@@ -146,9 +215,17 @@ func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.Interacti
 		return
 	}
 
-	// Case 1: Absolute path pointing to an existing file, confined to searchRoot.
+	// Resolve search roots: per-project roots from channel link, with
+	// send_search_root as override/fallback.
+	roots := h.resolveSearchRoots(s, i)
+	if len(roots) == 0 {
+		h.followup(s, i, "This channel is not linked to a project. Use `/scion setup` first.")
+		return
+	}
+
+	// Case 1: Absolute path pointing to an existing file, confined to any root.
 	if filepath.IsAbs(pathArg) {
-		if resolved, err := safeResolve(pathArg, h.searchRoot); err == nil {
+		if resolved, err := safeResolveMulti(pathArg, roots); err == nil {
 			info, err := os.Stat(resolved)
 			if err == nil && !info.IsDir() {
 				h.sendFile(s, i, resolved, info)
@@ -157,8 +234,11 @@ func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.Interacti
 		}
 	}
 
-	// Case 2: Search for files matching the argument.
-	matches := searchFiles(h.searchRoot, pathArg)
+	// Case 2: Search for files matching the argument across all roots.
+	var matches []fileMatch
+	for _, root := range roots {
+		matches = append(matches, searchFiles(root, pathArg)...)
+	}
 
 	if len(matches) == 0 {
 		h.followup(s, i, fmt.Sprintf("No files found matching '%s'", pathArg))
@@ -206,6 +286,45 @@ func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.Interacti
 	if err != nil {
 		h.log.Error("Failed to send file search results", "error", err)
 	}
+}
+
+// resolveSearchRoots determines the search roots for a /scion send command.
+// If the channel is linked to a project, per-project roots are computed.
+// If send_search_root is configured (h.searchRoot != DefaultSearchRoot), it is
+// used as an override when present, or as a fallback when no project link exists.
+func (h *CommandHandler) resolveSearchRoots(s *discordgo.Session, i *discordgo.InteractionCreate) []string {
+	configuredOverride := h.searchRoot != DefaultSearchRoot && h.searchRoot != ""
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
+	if err != nil || link == nil || !link.Active {
+		// No project link — use configured override if available.
+		if configuredOverride {
+			return []string{h.searchRoot}
+		}
+		return nil
+	}
+
+	// Compute per-project roots from the channel link.
+	roots := projectSearchRoots(link.ProjectSlug, link.ProjectID)
+
+	// If a configured override is present, prepend it.
+	if configuredOverride {
+		roots = append([]string{h.searchRoot}, roots...)
+	}
+
+	// Fallback: if no project roots were found, use the configured root or
+	// the default search root as a last resort.
+	if len(roots) == 0 {
+		if configuredOverride {
+			return []string{h.searchRoot}
+		}
+		return []string{DefaultSearchRoot}
+	}
+
+	return roots
 }
 
 // buildButtonLabels returns a label for each match. When multiple matches
@@ -336,24 +455,22 @@ func searchFiles(root, query string) []fileMatch {
 
 // handleSendFileCallback is called by the CallbackHandler when a send:file
 // button is clicked. It looks up the stored path and sends the file.
-func handleSendFileCallback(s *discordgo.Session, i *discordgo.InteractionCreate, key, root string, log *slog.Logger) {
+//
+// The stored path was already validated via safeResolve at search time, so the
+// callback only needs to verify the file still exists and is readable. The
+// path confinement check is not repeated here because the search roots may
+// differ from the callback handler's single searchRoot (per-project roots are
+// resolved dynamically based on the channel's project binding).
+func handleSendFileCallback(s *discordgo.Session, i *discordgo.InteractionCreate, key string, log *slog.Logger) {
 	path := globalSendPaths.Get(key)
 	if path == "" {
 		respondSendUpdate(s, i, "This file link has expired. Please use `/scion send` again.", log)
 		return
 	}
 
-	// Verify path is still confined to the search root (resolves symlinks).
-	resolved, err := safeResolve(path, root)
+	info, err := os.Stat(path)
 	if err != nil {
-		log.Warn("Send callback path failed confinement check", "path", path, "error", err)
-		respondSendUpdate(s, i, "This file is no longer accessible.", log)
-		return
-	}
-
-	info, err := os.Stat(resolved)
-	if err != nil {
-		log.Error("Failed to stat file for send callback", "path", resolved, "error", err)
+		log.Error("Failed to stat file for send callback", "path", path, "error", err)
 		respondSendUpdate(s, i, fmt.Sprintf("File not found: %s", filepath.Base(path)), log)
 		return
 	}
@@ -369,9 +486,9 @@ func handleSendFileCallback(s *discordgo.Session, i *discordgo.InteractionCreate
 		return
 	}
 
-	file, err := os.Open(resolved)
+	file, err := os.Open(path)
 	if err != nil {
-		log.Error("Failed to open file for send callback", "path", resolved, "error", err)
+		log.Error("Failed to open file for send callback", "path", path, "error", err)
 		respondSendUpdate(s, i, fmt.Sprintf("Could not read file: %s", filepath.Base(path)), log)
 		return
 	}
@@ -389,7 +506,7 @@ func handleSendFileCallback(s *discordgo.Session, i *discordgo.InteractionCreate
 		},
 	})
 	if err != nil {
-		log.Error("Failed to send file from callback", "path", resolved, "error", err)
+		log.Error("Failed to send file from callback", "path", path, "error", err)
 	}
 }
 

--- a/extras/scion-discord/internal/discord/send.go
+++ b/extras/scion-discord/internal/discord/send.go
@@ -108,7 +108,11 @@ type fileMatch struct {
 // safeResolve cleans the path, verifies it starts with root, resolves
 // symlinks, and re-verifies the resolved path is still under root.
 // It returns the resolved path or an error if any check fails.
+//
+// root is normalised to end with a path separator so that a root of
+// "/scion-volumes" cannot be prefix-confused with "/scion-volumes-evil".
 func safeResolve(path, root string) (string, error) {
+	root = filepath.Clean(root) + string(filepath.Separator)
 	cleaned := filepath.Clean(path)
 	if !strings.HasPrefix(cleaned, root) {
 		return "", fmt.Errorf("path %q does not start with %q", cleaned, root)

--- a/extras/scion-discord/internal/discord/send.go
+++ b/extras/scion-discord/internal/discord/send.go
@@ -102,8 +102,9 @@ var globalSendPaths = newSendPathStore()
 
 // fileMatch holds a matched file path and its modification time for sorting.
 type fileMatch struct {
-	Path    string
-	ModTime time.Time
+	Path        string    // resolved (EvalSymlinks) absolute path
+	DisplayName string    // original filename for button labels (non-empty only for symlinks)
+	ModTime     time.Time
 }
 
 // safeResolve cleans the path, verifies it is under root using filepath.Rel,
@@ -315,31 +316,71 @@ func (h *CommandHandler) resolveSearchRoots(s *discordgo.Session, i *discordgo.I
 		roots = append([]string{h.searchRoot}, roots...)
 	}
 
-	// Fallback: if no project roots were found, use the configured root or
-	// the default search root as a last resort.
+	// Fallback: if no project roots were found, use the default search root.
+	// Note: when configuredOverride is true, h.searchRoot was already prepended
+	// above, so len(roots) >= 1 and this branch is only reachable without an override.
 	if len(roots) == 0 {
-		if configuredOverride {
-			return []string{h.searchRoot}
-		}
 		return []string{DefaultSearchRoot}
 	}
 
-	return roots
+	return deduplicateRoots(roots)
+}
+
+// deduplicateRoots removes exact duplicates (after filepath.Clean) and roots
+// that are subdirectories of other roots in the list, since the parent root's
+// search will already cover the subdirectory.
+func deduplicateRoots(roots []string) []string {
+	seen := make(map[string]bool)
+	var unique []string
+	for _, r := range roots {
+		cleaned := filepath.Clean(r)
+		if !seen[cleaned] {
+			seen[cleaned] = true
+			unique = append(unique, cleaned)
+		}
+	}
+	// Remove roots that are subdirectories of other roots.
+	var filtered []string
+	for _, r := range unique {
+		isChild := false
+		for _, other := range unique {
+			if r != other {
+				rel, err := filepath.Rel(other, r)
+				if err == nil && !strings.HasPrefix(rel, "..") {
+					isChild = true
+					break
+				}
+			}
+		}
+		if !isChild {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}
+
+// displayBase returns the display name for a match. If DisplayName is set
+// (symlink matches), it is returned; otherwise filepath.Base of Path is used.
+func (m fileMatch) displayBase() string {
+	if m.DisplayName != "" {
+		return m.DisplayName
+	}
+	return filepath.Base(m.Path)
 }
 
 // buildButtonLabels returns a label for each match. When multiple matches
-// share the same basename, the parent directory is prepended to disambiguate.
+// share the same display name, the parent directory is prepended to disambiguate.
 func buildButtonLabels(matches []fileMatch) []string {
 	labels := make([]string, len(matches))
 
-	// Count how many times each basename appears.
+	// Count how many times each display name appears.
 	baseCounts := make(map[string]int)
 	for _, m := range matches {
-		baseCounts[filepath.Base(m.Path)]++
+		baseCounts[m.displayBase()]++
 	}
 
 	for idx, m := range matches {
-		base := filepath.Base(m.Path)
+		base := m.displayBase()
 		if baseCounts[base] > 1 {
 			parent := filepath.Base(filepath.Dir(m.Path))
 			label := parent + "/" + base
@@ -429,10 +470,13 @@ func searchFiles(root, query string) []fileMatch {
 				if err != nil || targetInfo.IsDir() {
 					return nil
 				}
-				// Use target file ModTime for symlinks.
+				// Store the resolved target path (defense-in-depth against
+				// TOCTOU symlink retargeting) and preserve the original
+				// symlink name for button labels via DisplayName.
 				matches = append(matches, fileMatch{
-					Path:    path,
-					ModTime: targetInfo.ModTime(),
+					Path:        resolved,
+					DisplayName: filepath.Base(path),
+					ModTime:     targetInfo.ModTime(),
 				})
 			} else {
 				// Regular file: no symlink resolution needed.

--- a/extras/scion-discord/internal/discord/send.go
+++ b/extras/scion-discord/internal/discord/send.go
@@ -302,7 +302,7 @@ func searchFiles(root, query string) []fileMatch {
 			if d.Type()&fs.ModeSymlink != 0 {
 				// Symlink: resolve and verify target is still under root.
 				resolved, err := filepath.EvalSymlinks(path)
-				if err != nil || !strings.HasPrefix(resolved, root) {
+				if err != nil || !isUnderSearchRoot(resolved, root) {
 					return nil
 				}
 				// Filter out symlinks pointing to directories.

--- a/extras/scion-discord/internal/discord/send.go
+++ b/extras/scion-discord/internal/discord/send.go
@@ -102,8 +102,8 @@ var globalSendPaths = newSendPathStore()
 
 // fileMatch holds a matched file path and its modification time for sorting.
 type fileMatch struct {
-	Path        string    // resolved (EvalSymlinks) absolute path
-	DisplayName string    // original filename for button labels (non-empty only for symlinks)
+	Path        string // resolved (EvalSymlinks) absolute path
+	DisplayName string // original filename for button labels (non-empty only for symlinks)
 	ModTime     time.Time
 }
 

--- a/extras/scion-discord/internal/discord/send.go
+++ b/extras/scion-discord/internal/discord/send.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	// searchRoot is the base directory for file searches.
-	searchRoot = "/scion-volumes/"
+	// DefaultSearchRoot is the default base directory for file searches
+	// when no send_search_root is configured.
+	DefaultSearchRoot = "/scion-volumes/"
 
 	// maxDiscordFileSize is the Discord attachment size limit (25 MB).
 	maxDiscordFileSize = 25 * 1024 * 1024
@@ -104,29 +105,29 @@ type fileMatch struct {
 	ModTime time.Time
 }
 
-// safeResolve cleans the path, verifies it starts with searchRoot, resolves
-// symlinks, and re-verifies the resolved path is still under searchRoot.
+// safeResolve cleans the path, verifies it starts with root, resolves
+// symlinks, and re-verifies the resolved path is still under root.
 // It returns the resolved path or an error if any check fails.
-func safeResolve(path string) (string, error) {
+func safeResolve(path, root string) (string, error) {
 	cleaned := filepath.Clean(path)
-	if !strings.HasPrefix(cleaned, searchRoot) {
-		return "", fmt.Errorf("path %q does not start with %q", cleaned, searchRoot)
+	if !strings.HasPrefix(cleaned, root) {
+		return "", fmt.Errorf("path %q does not start with %q", cleaned, root)
 	}
 	resolved, err := filepath.EvalSymlinks(cleaned)
 	if err != nil {
 		return "", err
 	}
-	if !strings.HasPrefix(resolved, searchRoot) {
-		return "", fmt.Errorf("resolved path %q does not start with %q", resolved, searchRoot)
+	if !strings.HasPrefix(resolved, root) {
+		return "", fmt.Errorf("resolved path %q does not start with %q", resolved, root)
 	}
 	return resolved, nil
 }
 
-// isUnderSearchRoot checks that a cleaned, resolved path is under searchRoot.
-// Both the cleaned path and its symlink-resolved form must be under searchRoot
+// isUnderSearchRoot checks that a cleaned, resolved path is under root.
+// Both the cleaned path and its symlink-resolved form must be under root
 // to prevent directory traversal and symlink escape attacks.
-func isUnderSearchRoot(path string) bool {
-	_, err := safeResolve(path)
+func isUnderSearchRoot(path, root string) bool {
+	_, err := safeResolve(path, root)
 	return err == nil
 }
 
@@ -143,7 +144,7 @@ func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.Interacti
 
 	// Case 1: Absolute path pointing to an existing file, confined to searchRoot.
 	if filepath.IsAbs(pathArg) {
-		if resolved, err := safeResolve(pathArg); err == nil {
+		if resolved, err := safeResolve(pathArg, h.searchRoot); err == nil {
 			info, err := os.Stat(resolved)
 			if err == nil && !info.IsDir() {
 				h.sendFile(s, i, resolved, info)
@@ -153,7 +154,7 @@ func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.Interacti
 	}
 
 	// Case 2: Search for files matching the argument.
-	matches := searchFiles(searchRoot, pathArg)
+	matches := searchFiles(h.searchRoot, pathArg)
 
 	if len(matches) == 0 {
 		h.followup(s, i, fmt.Sprintf("No files found matching '%s'", pathArg))
@@ -331,15 +332,15 @@ func searchFiles(root, query string) []fileMatch {
 
 // handleSendFileCallback is called by the CallbackHandler when a send:file
 // button is clicked. It looks up the stored path and sends the file.
-func handleSendFileCallback(s *discordgo.Session, i *discordgo.InteractionCreate, key string, log *slog.Logger) {
+func handleSendFileCallback(s *discordgo.Session, i *discordgo.InteractionCreate, key, root string, log *slog.Logger) {
 	path := globalSendPaths.Get(key)
 	if path == "" {
 		respondSendUpdate(s, i, "This file link has expired. Please use `/scion send` again.", log)
 		return
 	}
 
-	// Verify path is still confined to searchRoot (resolves symlinks).
-	resolved, err := safeResolve(path)
+	// Verify path is still confined to the search root (resolves symlinks).
+	resolved, err := safeResolve(path, root)
 	if err != nil {
 		log.Warn("Send callback path failed confinement check", "path", path, "error", err)
 		respondSendUpdate(s, i, "This file is no longer accessible.", log)

--- a/extras/scion-discord/internal/discord/send_test.go
+++ b/extras/scion-discord/internal/discord/send_test.go
@@ -478,6 +478,87 @@ func TestProjectSearchRoots_NothingExists(t *testing.T) {
 	assert.Empty(t, roots)
 }
 
+// --- searchFiles symlink resolved path tests ---
+
+func TestSearchFiles_SymlinkStoresResolvedPath(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a real file.
+	realFile := filepath.Join(dir, "real-data.txt")
+	require.NoError(t, os.WriteFile(realFile, []byte("data"), 0o644))
+
+	// Create a symlink to the real file within the same root.
+	symlinkPath := filepath.Join(dir, "link-to-data.txt")
+	require.NoError(t, os.Symlink(realFile, symlinkPath))
+
+	matches := searchFiles(dir, "link-to-data")
+	require.Len(t, matches, 1)
+
+	// Path should be the resolved (real) path, not the symlink.
+	assert.Equal(t, realFile, matches[0].Path)
+	// DisplayName should preserve the original symlink basename.
+	assert.Equal(t, "link-to-data.txt", matches[0].DisplayName)
+}
+
+func TestSearchFiles_RegularFileNoDisplayName(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "plain.txt"), []byte("x"), 0o644))
+
+	matches := searchFiles(dir, "plain")
+	require.Len(t, matches, 1)
+	assert.Empty(t, matches[0].DisplayName, "regular files should not set DisplayName")
+}
+
+// --- buildButtonLabels with DisplayName ---
+
+func TestBuildButtonLabels_UsesDisplayName(t *testing.T) {
+	matches := []fileMatch{
+		{Path: "/resolved/target/real.txt", DisplayName: "my-link.txt"},
+		{Path: "/scion-volumes/b/bar.txt"},
+	}
+	labels := buildButtonLabels(matches)
+	assert.Equal(t, "my-link.txt", labels[0])
+	assert.Equal(t, "bar.txt", labels[1])
+}
+
+// --- deduplicateRoots tests ---
+
+func TestDeduplicateRoots_ExactDuplicates(t *testing.T) {
+	roots := []string{"/a/b", "/c/d", "/a/b"}
+	result := deduplicateRoots(roots)
+	assert.Equal(t, []string{"/a/b", "/c/d"}, result)
+}
+
+func TestDeduplicateRoots_SubdirectoryRemoved(t *testing.T) {
+	roots := []string{"/a", "/a/b/c"}
+	result := deduplicateRoots(roots)
+	assert.Equal(t, []string{"/a"}, result)
+}
+
+func TestDeduplicateRoots_NoOverlap(t *testing.T) {
+	roots := []string{"/a", "/b", "/c"}
+	result := deduplicateRoots(roots)
+	assert.Equal(t, []string{"/a", "/b", "/c"}, result)
+}
+
+func TestDeduplicateRoots_CleansPaths(t *testing.T) {
+	roots := []string{"/a/b/", "/a/b"}
+	result := deduplicateRoots(roots)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "/a/b", result[0])
+}
+
+func TestDeduplicateRoots_SingleRoot(t *testing.T) {
+	roots := []string{"/only"}
+	result := deduplicateRoots(roots)
+	assert.Equal(t, []string{"/only"}, result)
+}
+
+func TestDeduplicateRoots_Empty(t *testing.T) {
+	result := deduplicateRoots(nil)
+	assert.Nil(t, result)
+}
+
 // --- test helpers ---
 
 // setupSearchTestDir creates a temporary directory structure for search tests.

--- a/extras/scion-discord/internal/discord/send_test.go
+++ b/extras/scion-discord/internal/discord/send_test.go
@@ -140,6 +140,23 @@ func TestSearchFiles_SymlinkOutsideRoot(t *testing.T) {
 	assert.Empty(t, matches, "symlinks pointing outside search root should be excluded")
 }
 
+func TestSearchFiles_SymlinkPrefixConfusion(t *testing.T) {
+	// Create a root without trailing slash and a sibling with shared prefix.
+	root := t.TempDir() // e.g. /tmp/TestXYZ123
+	siblingDir := root + "-secrets"
+	require.NoError(t, os.MkdirAll(siblingDir, 0o755))
+	secretFile := filepath.Join(siblingDir, "key.pem")
+	require.NoError(t, os.WriteFile(secretFile, []byte("secret-key"), 0o644))
+
+	// Create a symlink inside root pointing to the sibling directory's file.
+	symlinkPath := filepath.Join(root, "sneaky-link.pem")
+	require.NoError(t, os.Symlink(secretFile, symlinkPath))
+
+	// Search with root that has no trailing slash — must not leak the sibling file.
+	matches := searchFiles(root, "sneaky-link")
+	assert.Empty(t, matches, "symlinks resolving to a sibling dir with shared prefix must be excluded")
+}
+
 // --- safeResolve tests ---
 
 func TestSafeResolve_ValidPath(t *testing.T) {

--- a/extras/scion-discord/internal/discord/send_test.go
+++ b/extras/scion-discord/internal/discord/send_test.go
@@ -143,54 +143,54 @@ func TestSearchFiles_SymlinkOutsideRoot(t *testing.T) {
 // --- safeResolve tests ---
 
 func TestSafeResolve_ValidPath(t *testing.T) {
-	if _, err := os.Stat(searchRoot); os.IsNotExist(err) {
-		t.Skip("searchRoot does not exist on this host")
+	if _, err := os.Stat(DefaultSearchRoot); os.IsNotExist(err) {
+		t.Skip("DefaultSearchRoot does not exist on this host")
 	}
 
-	tmpFile, err := os.CreateTemp(searchRoot, "test-send-*.txt")
+	tmpFile, err := os.CreateTemp(DefaultSearchRoot, "test-send-*.txt")
 	if err != nil {
-		t.Skip("cannot create temp file in searchRoot")
+		t.Skip("cannot create temp file in DefaultSearchRoot")
 	}
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	resolved, err := safeResolve(tmpFile.Name())
+	resolved, err := safeResolve(tmpFile.Name(), DefaultSearchRoot)
 	assert.NoError(t, err)
 	assert.Equal(t, tmpFile.Name(), resolved)
 }
 
 func TestSafeResolve_RejectsOutsidePath(t *testing.T) {
-	_, err := safeResolve("/etc/passwd")
+	_, err := safeResolve("/etc/passwd", DefaultSearchRoot)
 	assert.Error(t, err)
-	_, err = safeResolve("/tmp/something")
+	_, err = safeResolve("/tmp/something", DefaultSearchRoot)
 	assert.Error(t, err)
 }
 
 func TestSafeResolve_RejectsTraversal(t *testing.T) {
-	_, err := safeResolve("/scion-volumes/../etc/passwd")
+	_, err := safeResolve("/scion-volumes/../etc/passwd", DefaultSearchRoot)
 	assert.Error(t, err)
-	_, err = safeResolve("/scion-volumes/./../../etc/shadow")
+	_, err = safeResolve("/scion-volumes/./../../etc/shadow", DefaultSearchRoot)
 	assert.Error(t, err)
 }
 
 func TestSafeResolve_RejectsSymlinkEscape(t *testing.T) {
-	if _, err := os.Stat(searchRoot); os.IsNotExist(err) {
-		t.Skip("searchRoot does not exist on this host")
+	if _, err := os.Stat(DefaultSearchRoot); os.IsNotExist(err) {
+		t.Skip("DefaultSearchRoot does not exist on this host")
 	}
 
 	outsideDir := t.TempDir()
 	outsideFile := filepath.Join(outsideDir, "secret.txt")
 	require.NoError(t, os.WriteFile(outsideFile, []byte("secret"), 0o644))
 
-	symlinkPath := filepath.Join(searchRoot, "test-escape-link-"+randomKey(4))
+	symlinkPath := filepath.Join(DefaultSearchRoot, "test-escape-link-"+randomKey(4))
 	err := os.Symlink(outsideFile, symlinkPath)
 	if err != nil {
-		t.Skip("cannot create symlink in searchRoot")
+		t.Skip("cannot create symlink in DefaultSearchRoot")
 	}
 	defer os.Remove(symlinkPath)
 
-	_, resolveErr := safeResolve(symlinkPath)
-	assert.Error(t, resolveErr, "symlink inside searchRoot pointing outside should be rejected")
+	_, resolveErr := safeResolve(symlinkPath, DefaultSearchRoot)
+	assert.Error(t, resolveErr, "symlink inside DefaultSearchRoot pointing outside should be rejected")
 }
 
 // --- isUnderSearchRoot tests ---
@@ -198,35 +198,35 @@ func TestSafeResolve_RejectsSymlinkEscape(t *testing.T) {
 func TestIsUnderSearchRoot_ValidPath(t *testing.T) {
 	// This test uses a real path under /scion-volumes if it exists,
 	// otherwise we test the logic indirectly.
-	if _, err := os.Stat(searchRoot); os.IsNotExist(err) {
-		t.Skip("searchRoot does not exist on this host")
+	if _, err := os.Stat(DefaultSearchRoot); os.IsNotExist(err) {
+		t.Skip("DefaultSearchRoot does not exist on this host")
 	}
 
-	// Create a temp file under searchRoot for testing.
-	tmpFile, err := os.CreateTemp(searchRoot, "test-send-*.txt")
+	// Create a temp file under DefaultSearchRoot for testing.
+	tmpFile, err := os.CreateTemp(DefaultSearchRoot, "test-send-*.txt")
 	if err != nil {
-		t.Skip("cannot create temp file in searchRoot")
+		t.Skip("cannot create temp file in DefaultSearchRoot")
 	}
 	defer os.Remove(tmpFile.Name())
 	tmpFile.Close()
 
-	assert.True(t, isUnderSearchRoot(tmpFile.Name()))
+	assert.True(t, isUnderSearchRoot(tmpFile.Name(), DefaultSearchRoot))
 }
 
 func TestIsUnderSearchRoot_RejectsOutsidePath(t *testing.T) {
-	assert.False(t, isUnderSearchRoot("/etc/passwd"))
-	assert.False(t, isUnderSearchRoot("/tmp/something"))
-	assert.False(t, isUnderSearchRoot("/root/.ssh/id_rsa"))
+	assert.False(t, isUnderSearchRoot("/etc/passwd", DefaultSearchRoot))
+	assert.False(t, isUnderSearchRoot("/tmp/something", DefaultSearchRoot))
+	assert.False(t, isUnderSearchRoot("/root/.ssh/id_rsa", DefaultSearchRoot))
 }
 
 func TestIsUnderSearchRoot_RejectsTraversal(t *testing.T) {
-	assert.False(t, isUnderSearchRoot("/scion-volumes/../etc/passwd"))
-	assert.False(t, isUnderSearchRoot("/scion-volumes/./../../etc/shadow"))
+	assert.False(t, isUnderSearchRoot("/scion-volumes/../etc/passwd", DefaultSearchRoot))
+	assert.False(t, isUnderSearchRoot("/scion-volumes/./../../etc/shadow", DefaultSearchRoot))
 }
 
 func TestIsUnderSearchRoot_RejectsSymlinkEscape(t *testing.T) {
-	if _, err := os.Stat(searchRoot); os.IsNotExist(err) {
-		t.Skip("searchRoot does not exist on this host")
+	if _, err := os.Stat(DefaultSearchRoot); os.IsNotExist(err) {
+		t.Skip("DefaultSearchRoot does not exist on this host")
 	}
 
 	// Create a temp dir for the symlink target.
@@ -234,16 +234,45 @@ func TestIsUnderSearchRoot_RejectsSymlinkEscape(t *testing.T) {
 	outsideFile := filepath.Join(outsideDir, "secret.txt")
 	require.NoError(t, os.WriteFile(outsideFile, []byte("secret"), 0o644))
 
-	// Create a symlink inside searchRoot pointing outside.
-	symlinkPath := filepath.Join(searchRoot, "test-escape-link-"+randomKey(4))
+	// Create a symlink inside DefaultSearchRoot pointing outside.
+	symlinkPath := filepath.Join(DefaultSearchRoot, "test-escape-link-"+randomKey(4))
 	err := os.Symlink(outsideFile, symlinkPath)
 	if err != nil {
-		t.Skip("cannot create symlink in searchRoot")
+		t.Skip("cannot create symlink in DefaultSearchRoot")
 	}
 	defer os.Remove(symlinkPath)
 
-	assert.False(t, isUnderSearchRoot(symlinkPath),
-		"symlink inside searchRoot pointing outside should be rejected")
+	assert.False(t, isUnderSearchRoot(symlinkPath, DefaultSearchRoot),
+		"symlink inside DefaultSearchRoot pointing outside should be rejected")
+}
+
+// --- safeResolve with custom root tests ---
+
+func TestSafeResolve_CustomRoot(t *testing.T) {
+	root := t.TempDir() + "/"
+	f, err := os.CreateTemp(root, "custom-*.txt")
+	require.NoError(t, err)
+	f.Close()
+
+	resolved, err := safeResolve(f.Name(), root)
+	assert.NoError(t, err)
+	assert.Equal(t, f.Name(), resolved)
+}
+
+func TestSafeResolve_CustomRoot_RejectsOutside(t *testing.T) {
+	root := t.TempDir() + "/"
+	_, err := safeResolve("/etc/passwd", root)
+	assert.Error(t, err)
+}
+
+func TestIsUnderSearchRoot_CustomRoot(t *testing.T) {
+	root := t.TempDir() + "/"
+	f, err := os.CreateTemp(root, "custom-*.txt")
+	require.NoError(t, err)
+	f.Close()
+
+	assert.True(t, isUnderSearchRoot(f.Name(), root))
+	assert.False(t, isUnderSearchRoot("/etc/passwd", root))
 }
 
 // --- buildButtonLabels tests ---

--- a/extras/scion-discord/internal/discord/send_test.go
+++ b/extras/scion-discord/internal/discord/send_test.go
@@ -336,6 +336,148 @@ func TestBuildButtonLabels_DuplicateBasenames(t *testing.T) {
 	assert.Equal(t, "project-b/README.md", labels[1])
 }
 
+// --- safeResolveMulti tests ---
+
+func TestSafeResolveMulti_MatchesFirstRoot(t *testing.T) {
+	root1 := t.TempDir()
+	root2 := t.TempDir()
+	f, err := os.CreateTemp(root1, "multi-*.txt")
+	require.NoError(t, err)
+	f.Close()
+
+	resolved, err := safeResolveMulti(f.Name(), []string{root1, root2})
+	assert.NoError(t, err)
+	assert.Equal(t, f.Name(), resolved)
+}
+
+func TestSafeResolveMulti_MatchesSecondRoot(t *testing.T) {
+	root1 := t.TempDir()
+	root2 := t.TempDir()
+	f, err := os.CreateTemp(root2, "multi-*.txt")
+	require.NoError(t, err)
+	f.Close()
+
+	resolved, err := safeResolveMulti(f.Name(), []string{root1, root2})
+	assert.NoError(t, err)
+	assert.Equal(t, f.Name(), resolved)
+}
+
+func TestSafeResolveMulti_RejectsOutsideAll(t *testing.T) {
+	root1 := t.TempDir()
+	root2 := t.TempDir()
+
+	_, err := safeResolveMulti("/etc/passwd", []string{root1, root2})
+	assert.Error(t, err)
+}
+
+func TestSafeResolveMulti_EmptyRoots(t *testing.T) {
+	_, err := safeResolveMulti("/etc/passwd", nil)
+	assert.Error(t, err)
+}
+
+// --- safeResolve with root=/ edge case ---
+
+func TestSafeResolve_RootSlash(t *testing.T) {
+	// When root is /, any absolute path should resolve successfully.
+	tmpFile, err := os.CreateTemp(t.TempDir(), "rootslash-*.txt")
+	require.NoError(t, err)
+	tmpFile.Close()
+
+	resolved, err := safeResolve(tmpFile.Name(), "/")
+	assert.NoError(t, err)
+	assert.Equal(t, tmpFile.Name(), resolved)
+}
+
+func TestSafeResolve_RootSlash_RejectsTraversal(t *testing.T) {
+	// Path traversal beyond / should still be caught — cleaned path stays under /.
+	tmpFile, err := os.CreateTemp(t.TempDir(), "rootslash-*.txt")
+	require.NoError(t, err)
+	tmpFile.Close()
+
+	resolved, err := safeResolve("/../"+tmpFile.Name(), "/")
+	assert.NoError(t, err)
+	assert.Equal(t, tmpFile.Name(), resolved)
+}
+
+// --- searchFiles with multiple roots ---
+
+func TestSearchFiles_MultipleRoots(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir1, "report.txt"), []byte("r"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir2, "data.txt"), []byte("d"), 0o644))
+
+	// Search each root separately and merge (mimicking HandleSend behavior).
+	var matches []fileMatch
+	for _, root := range []string{dir1, dir2} {
+		matches = append(matches, searchFiles(root, ".txt")...)
+	}
+
+	assert.Len(t, matches, 2)
+	paths := []string{matches[0].Path, matches[1].Path}
+	assert.Contains(t, paths[0]+paths[1], "report.txt")
+	assert.Contains(t, paths[0]+paths[1], "data.txt")
+}
+
+// --- projectSearchRoots tests ---
+
+func TestProjectSearchRoots_DiscoversDirs(t *testing.T) {
+	// Set up a fake home directory structure.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	slug := "test-proj"
+	projectID := "550e8400-e29b-41d4-a716-446655440000"
+
+	// Compute expected paths.
+	shortUUID := "550e8400"
+	configDir := filepath.Join(fakeHome, ".scion", "project-configs",
+		slug+"__"+shortUUID)
+	sharedDirsRoot := filepath.Join(configDir, "shared-dirs")
+
+	// Create shared dir subdirectories.
+	require.NoError(t, os.MkdirAll(filepath.Join(sharedDirsRoot, "scratchpad"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(sharedDirsRoot, "cache"), 0o755))
+
+	// Create workspace directory.
+	workspaceDir := filepath.Join(fakeHome, ".scion", "projects", slug)
+	require.NoError(t, os.MkdirAll(workspaceDir, 0o755))
+
+	roots := projectSearchRoots(slug, projectID)
+
+	assert.Len(t, roots, 3)
+	assert.Contains(t, roots, filepath.Join(sharedDirsRoot, "cache"))
+	assert.Contains(t, roots, filepath.Join(sharedDirsRoot, "scratchpad"))
+	assert.Contains(t, roots, workspaceDir)
+}
+
+func TestProjectSearchRoots_NoSharedDirs(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	slug := "empty-proj"
+	projectID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+	// Create only workspace directory.
+	workspaceDir := filepath.Join(fakeHome, ".scion", "projects", slug)
+	require.NoError(t, os.MkdirAll(workspaceDir, 0o755))
+
+	roots := projectSearchRoots(slug, projectID)
+
+	assert.Len(t, roots, 1)
+	assert.Equal(t, workspaceDir, roots[0])
+}
+
+func TestProjectSearchRoots_NothingExists(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	roots := projectSearchRoots("nonexistent", "00000000-0000-0000-0000-000000000000")
+
+	assert.Empty(t, roots)
+}
+
 // --- test helpers ---
 
 // setupSearchTestDir creates a temporary directory structure for search tests.

--- a/extras/scion-discord/internal/discord/send_test.go
+++ b/extras/scion-discord/internal/discord/send_test.go
@@ -275,6 +275,28 @@ func TestIsUnderSearchRoot_CustomRoot(t *testing.T) {
 	assert.False(t, isUnderSearchRoot("/etc/passwd", root))
 }
 
+func TestSafeResolve_CustomRoot_NoTrailingSlash(t *testing.T) {
+	root := t.TempDir() // no trailing slash
+	outside := root + "-evil"
+	require.NoError(t, os.MkdirAll(outside, 0o755))
+	secret := filepath.Join(outside, "secret.txt")
+	require.NoError(t, os.WriteFile(secret, []byte("x"), 0o644))
+
+	_, err := safeResolve(secret, root)
+	assert.Error(t, err, "must not accept a file under a sibling with a shared prefix")
+}
+
+func TestIsUnderSearchRoot_CustomRoot_NoTrailingSlash(t *testing.T) {
+	root := t.TempDir() // no trailing slash
+	outside := root + "-evil"
+	require.NoError(t, os.MkdirAll(outside, 0o755))
+	secret := filepath.Join(outside, "secret.txt")
+	require.NoError(t, os.WriteFile(secret, []byte("x"), 0o644))
+
+	assert.False(t, isUnderSearchRoot(secret, root),
+		"must not accept a file under a sibling with a shared prefix")
+}
+
 // --- buildButtonLabels tests ---
 
 func TestBuildButtonLabels_UniqueBasenames(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/690

Makes the /scion send command search root configurable via send_search_root plugin config field, defaulting to /scion-volumes/. Previously hardcoded, which failed on hosts where shared dirs live at different paths.

Changes (3 commits):
- Make searchRoot configurable via send_search_root config field
- Normalize root in safeResolve to prevent prefix confusion
- Replace raw prefix check in searchFiles with isUnderSearchRoot helper

Fork PR: https://github.com/ptone/scion/pull/693