### PR TITLE
fix(extras): inherit IAP transport in Discord hub client longHTTPClient

### DIFF
--- a/extras/scion-discord/internal/discord/hubclient.go
+++ b/extras/scion-discord/internal/discord/hubclient.go
@@ -25,17 +25,20 @@ type httpHubClient struct {
 // If httpClient is nil, a default client with a 15s timeout is used.
 // A separate longHTTPClient with no global timeout is created for long-running
 // operations like CreateAgent (which synchronously dispatches container create+start
-// and routinely takes 30–120s).
+// and routinely takes 30–120s). The longHTTPClient inherits the Transport from
+// httpClient so that IAP-authenticated transport is preserved on long-running calls.
 func NewHTTPHubClient(hubURL, hmacKey, brokerID string, httpClient *http.Client) HubClient {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 15 * time.Second}
 	}
 	return &httpHubClient{
-		hubURL:         hubURL,
-		hmacKey:        hmacKey,
-		brokerID:       brokerID,
-		httpClient:     httpClient,
-		longHTTPClient: &http.Client{}, // no global timeout; per-call context controls deadline
+		hubURL:     hubURL,
+		hmacKey:    hmacKey,
+		brokerID:   brokerID,
+		httpClient: httpClient,
+		longHTTPClient: &http.Client{
+			Transport: httpClient.Transport, // inherit IAP/transport auth
+		},
 	}
 }
 

--- a/extras/scion-discord/internal/discord/hubclient_test.go
+++ b/extras/scion-discord/internal/discord/hubclient_test.go
@@ -1,0 +1,139 @@
+package discord
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingTransport is a test RoundTripper that counts calls and delegates
+// to a base transport. Used to verify that IAP-wrapped transports are
+// actually used on all HTTP paths.
+type countingTransport struct {
+	base  http.RoundTripper
+	calls atomic.Int64
+}
+
+func (ct *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ct.calls.Add(1)
+	if ct.base != nil {
+		return ct.base.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func TestNewHTTPHubClient_TransportInheritance(t *testing.T) {
+	t.Run("longHTTPClient inherits transport from httpClient", func(t *testing.T) {
+		// Create a custom transport that records calls.
+		transport := &countingTransport{}
+
+		httpClient := &http.Client{
+			Timeout:   15 * time.Second,
+			Transport: transport,
+		}
+
+		client := NewHTTPHubClient("http://example.com", "key", "broker-1", httpClient)
+		hc := client.(*httpHubClient)
+
+		// Verify the longHTTPClient has the same transport.
+		assert.Same(t, transport, hc.longHTTPClient.Transport,
+			"longHTTPClient should inherit the Transport from httpClient")
+
+		// Verify the longHTTPClient has no global timeout.
+		assert.Zero(t, hc.longHTTPClient.Timeout,
+			"longHTTPClient should have no global timeout")
+
+		// Verify the main httpClient retains its timeout.
+		assert.Equal(t, 15*time.Second, hc.httpClient.Timeout,
+			"httpClient should keep its original timeout")
+	})
+
+	t.Run("nil httpClient gets default with nil transport", func(t *testing.T) {
+		client := NewHTTPHubClient("http://example.com", "key", "broker-1", nil)
+		hc := client.(*httpHubClient)
+
+		// Default httpClient should have 15s timeout.
+		assert.Equal(t, 15*time.Second, hc.httpClient.Timeout)
+
+		// longHTTPClient should have nil transport (uses http.DefaultTransport).
+		assert.Nil(t, hc.longHTTPClient.Transport,
+			"longHTTPClient transport should be nil when httpClient has nil transport")
+
+		// longHTTPClient should have no timeout.
+		assert.Zero(t, hc.longHTTPClient.Timeout)
+	})
+}
+
+func TestHTTPHubClient_IAPTransport_UsedOnAllPaths(t *testing.T) {
+	// Set up a fake Hub API server.
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			json.NewEncoder(w).Encode(hubProjectsResponse{
+				Projects: []hubProject{{ID: "p1", Name: "test", Slug: "test"}},
+			})
+		case "/api/v1/projects/p1/agents":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(hubCreateAgentResponse{
+				Agent: struct {
+					Slug string `json:"slug"`
+					Name string `json:"name"`
+				}{Slug: "agent-1", Name: "Agent 1"},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer hub.Close()
+
+	transport := &countingTransport{base: hub.Client().Transport}
+	httpClient := &http.Client{
+		Timeout:   15 * time.Second,
+		Transport: transport,
+	}
+
+	client := NewHTTPHubClient(hub.URL, "", "", httpClient)
+	ctx := context.Background()
+
+	// Test ListProjects (uses httpClient).
+	_, err := client.ListProjects(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), transport.calls.Load(),
+		"ListProjects should use the custom transport")
+
+	// Test CreateAgent (uses longHTTPClient).
+	_, err = client.CreateAgent(ctx, "p1", CreateAgentRequest{
+		Name:     "Agent 1",
+		Template: "default",
+	}, "")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), transport.calls.Load(),
+		"CreateAgent should also use the custom transport via longHTTPClient")
+}
+
+func TestHTTPHubClient_PlainClient_WhenNoIAP(t *testing.T) {
+	// Set up a fake Hub API server.
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(hubProjectsResponse{
+			Projects: []hubProject{{ID: "p1", Name: "test", Slug: "test"}},
+		})
+	}))
+	defer hub.Close()
+
+	// Create hub client with nil httpClient (no IAP).
+	client := NewHTTPHubClient(hub.URL, "", "", nil)
+	ctx := context.Background()
+
+	// Should work without IAP transport.
+	projects, err := client.ListProjects(ctx)
+	require.NoError(t, err)
+	assert.Len(t, projects, 1)
+	assert.Equal(t, "test", projects[0].Slug)
+}

--- a/extras/scion-telegram/internal/telegram/hubclient_test.go
+++ b/extras/scion-telegram/internal/telegram/hubclient_test.go
@@ -1,0 +1,120 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingTransport is a test RoundTripper that records whether it was called
+// and delegates to a base transport.
+type recordingTransport struct {
+	base  http.RoundTripper
+	calls atomic.Int64
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.calls.Add(1)
+	if rt.base != nil {
+		return rt.base.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func TestNewHTTPHubClient_UsesProvidedTransport(t *testing.T) {
+	t.Run("custom transport is used for API calls", func(t *testing.T) {
+		// Set up a fake Hub API server.
+		hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(hubProjectsResponse{
+				Projects: []hubProject{{ID: "p1", Name: "test", Slug: "test"}},
+			})
+		}))
+		defer hub.Close()
+
+		transport := &recordingTransport{base: hub.Client().Transport}
+		httpClient := &http.Client{
+			Timeout:   10 * time.Second,
+			Transport: transport,
+		}
+
+		client := NewHTTPHubClient(hub.URL, "", "", httpClient)
+		ctx := context.Background()
+
+		// Verify transport is used when listing projects.
+		projects, err := client.ListProjects(ctx)
+		require.NoError(t, err)
+		assert.Len(t, projects, 1)
+		assert.Equal(t, int64(1), transport.calls.Load(),
+			"ListProjects should use the custom transport (IAP transport)")
+	})
+
+	t.Run("custom transport is used for ListAgents", func(t *testing.T) {
+		hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(hubAgentsResponse{
+				Agents: []hubAgent{{Slug: "coder", Activity: "active"}},
+			})
+		}))
+		defer hub.Close()
+
+		transport := &recordingTransport{base: hub.Client().Transport}
+		httpClient := &http.Client{
+			Timeout:   10 * time.Second,
+			Transport: transport,
+		}
+
+		client := NewHTTPHubClient(hub.URL, "", "", httpClient)
+		ctx := context.Background()
+
+		agents, err := client.ListAgents(ctx, "p1")
+		require.NoError(t, err)
+		assert.Len(t, agents, 1)
+		assert.Equal(t, int64(1), transport.calls.Load(),
+			"ListAgents should use the custom transport (IAP transport)")
+	})
+}
+
+func TestNewHTTPHubClient_NilClient_PlainTransport(t *testing.T) {
+	// Set up a fake Hub API server.
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(hubProjectsResponse{
+			Projects: []hubProject{{ID: "p1", Name: "test", Slug: "test"}},
+		})
+	}))
+	defer hub.Close()
+
+	// Create hub client with nil httpClient (no IAP configured).
+	client := NewHTTPHubClient(hub.URL, "", "", nil)
+	hc := client.(*httpHubClient)
+
+	// Should have a default timeout.
+	assert.Equal(t, 10*time.Second, hc.httpClient.Timeout)
+
+	// Should work without IAP transport.
+	ctx := context.Background()
+	projects, err := client.ListProjects(ctx)
+	require.NoError(t, err)
+	assert.Len(t, projects, 1)
+	assert.Equal(t, "test", projects[0].Slug)
+}
+
+func TestNewHTTPHubClient_TransportPreserved(t *testing.T) {
+	// Verify that the httpClient's transport is preserved as-is.
+	transport := &recordingTransport{}
+	httpClient := &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: transport,
+	}
+
+	client := NewHTTPHubClient("http://example.com", "key", "broker-1", httpClient)
+	hc := client.(*httpHubClient)
+
+	assert.Same(t, transport, hc.httpClient.Transport,
+		"httpClient transport should be the same object as provided")
+}


### PR DESCRIPTION
The Discord bot creates a longHTTPClient for long-running operations (CreateAgent, which synchronously dispatches container create+start and routinely takes 30-120s). This client was created as a plain http.Client{} without inheriting the Transport from the main httpClient. When the main client was configured with IAP-authenticated transport, the longHTTPClient did not have it, causing 401 errors on IAP-protected deployments (Cloud Run with IAP enabled).

Fix: longHTTPClient now copies httpClient.Transport to inherit IAP auth. When IAP is not configured (nil transport), behavior is unchanged (Go falls through to http.DefaultTransport).

Telegram confirmed unaffected: it has no longHTTPClient/CreateAgent path.

Key file: extras/scion-discord/internal/discord/hubclient.go
Tests: hubclient_test.go in both Discord and Telegram extras modules

Ref: ptone/scion#530