### PR TITLE
fix(discord): prevent threadParents negative-cache poisoning (#576)

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1642,6 +1642,7 @@ func (b *DiscordBroker) resolveThreadParent(channelID string) (parentID string, 
 			// poison the cache. Returning ("", false) lets the caller
 			// retry on the next lookup. Compare with the fix in
 			// commands.go's resolveChannelLink (issue #576).
+			b.log.Error("Failed to resolve thread parent", "channel_id", channelID, "error", err)
 			return "", false
 		}
 	}

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1638,6 +1638,10 @@ func (b *DiscordBroker) resolveThreadParent(channelID string) (parentID string, 
 	if ch == nil || err != nil {
 		ch, err = session.Channel(channelID)
 		if err != nil {
+			// Intentionally NOT cached: a transient REST failure must not
+			// poison the cache. Returning ("", false) lets the caller
+			// retry on the next lookup. Compare with the fix in
+			// commands.go's resolveChannelLink (issue #576).
 			return "", false
 		}
 	}

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -1062,3 +1062,181 @@ func TestPublish_ObserveFilter_StateChangeThreadResolvesParentLink(t *testing.T)
 		})
 	}
 }
+
+// --- threadParentID / resolveChannelLink cache-poisoning tests (issue #576) ---
+
+// failingTransport returns HTTP 500 for every Discord REST call, simulating a
+// transient API outage.
+type failingTransport struct{}
+
+func (ft *failingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(strings.NewReader(`{"message":"internal server error"}`)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+// newFailingSession returns a Session whose REST calls always return 500 and
+// whose state cache is empty.
+func newFailingSession(t *testing.T) *discordgo.Session {
+	t.Helper()
+	s, err := discordgo.New("Bot test-token")
+	require.NoError(t, err)
+	s.Client = &http.Client{Transport: &failingTransport{}}
+	s.MaxRestRetries = 0
+	s.ShouldRetryOnRateLimit = false
+	return s
+}
+
+func TestThreadParentID_DistinguishesFailureFromNonThread(t *testing.T) {
+	t.Run("confirmed thread returns parentID and ok=true", func(t *testing.T) {
+		s := stubSession([]*discordgo.Channel{
+			{
+				ID:       "thread-1",
+				Type:     discordgo.ChannelTypeGuildPublicThread,
+				ParentID: "parent-1",
+			},
+		})
+		parentID, ok := threadParentID(s, "thread-1")
+		assert.True(t, ok, "lookup succeeded — ok must be true")
+		assert.Equal(t, "parent-1", parentID)
+	})
+
+	t.Run("confirmed non-thread returns empty and ok=true", func(t *testing.T) {
+		s := stubSession([]*discordgo.Channel{
+			{ID: "text-chan", Type: discordgo.ChannelTypeGuildText},
+		})
+		parentID, ok := threadParentID(s, "text-chan")
+		assert.True(t, ok, "lookup succeeded — ok must be true")
+		assert.Equal(t, "", parentID)
+	})
+
+	t.Run("REST failure returns empty and ok=false", func(t *testing.T) {
+		s := newFailingSession(t)
+		parentID, ok := threadParentID(s, "unknown-chan")
+		assert.False(t, ok, "REST failed — ok must be false")
+		assert.Equal(t, "", parentID)
+	})
+}
+
+func TestResolveChannelLink_NoCachePoisoningOnRESTFailure(t *testing.T) {
+	ctx := context.Background()
+
+	parentID := "parent-nocache"
+	threadID := "thread-nocache"
+	t.Cleanup(func() {
+		threadParentsMu.Lock()
+		delete(threadParents, threadID)
+		threadParentsMu.Unlock()
+	})
+
+	store := newTestBrokerStore(t)
+
+	// --- Phase 1: REST is failing — resolveChannelLink must NOT cache. ---
+	failSession := newFailingSession(t)
+
+	link, err := resolveChannelLink(ctx, failSession, store, threadID)
+	require.NoError(t, err)
+	// No channel link exists anywhere, so link should be nil.
+	assert.Nil(t, link, "no link exists yet")
+
+	// Verify the cache was NOT poisoned.
+	threadParentsMu.Lock()
+	_, cached := threadParents[threadID]
+	threadParentsMu.Unlock()
+	assert.False(t, cached, "failed lookup must not be cached")
+
+	// --- Phase 2: REST recovers — resolveChannelLink retries and caches. ---
+	goodSession, _ := newRecordingSession(t, []*discordgo.Channel{
+		{ID: parentID, Type: discordgo.ChannelTypeGuildText},
+		{
+			ID:       threadID,
+			Type:     discordgo.ChannelTypeGuildPublicThread,
+			ParentID: parentID,
+		},
+	})
+
+	// Create a channel link on the parent so the fallback succeeds.
+	require.NoError(t, store.CreateChannelLink(ctx, &ChannelLink{
+		ChannelID:   parentID,
+		GuildID:     testGuildID,
+		ProjectID:   "proj-nc",
+		ProjectSlug: "nc",
+		Active:      true,
+		LinkedAt:    time.Now(),
+	}))
+
+	link, err = resolveChannelLink(ctx, goodSession, store, threadID)
+	require.NoError(t, err)
+	require.NotNil(t, link, "parent link must be resolved through thread")
+	assert.Equal(t, parentID, link.ChannelID)
+
+	// Verify the cache now contains the correct parent.
+	threadParentsMu.Lock()
+	cachedParent, cached := threadParents[threadID]
+	threadParentsMu.Unlock()
+	assert.True(t, cached, "successful lookup must be cached")
+	assert.Equal(t, parentID, cachedParent)
+}
+
+func TestResolveChannelLink_CachesConfirmedNonThread(t *testing.T) {
+	ctx := context.Background()
+
+	channelID := "text-cached"
+	t.Cleanup(func() {
+		threadParentsMu.Lock()
+		delete(threadParents, channelID)
+		threadParentsMu.Unlock()
+	})
+
+	session, _ := newRecordingSession(t, []*discordgo.Channel{
+		{ID: channelID, Type: discordgo.ChannelTypeGuildText},
+	})
+
+	store := newTestBrokerStore(t)
+
+	_, err := resolveChannelLink(ctx, session, store, channelID)
+	require.NoError(t, err)
+
+	// Confirmed non-thread should be cached (empty string = not a thread).
+	threadParentsMu.Lock()
+	cachedParent, cached := threadParents[channelID]
+	threadParentsMu.Unlock()
+	assert.True(t, cached, "confirmed non-thread must be cached")
+	assert.Equal(t, "", cachedParent)
+}
+
+func TestResolveChannelLink_CachesConfirmedThread(t *testing.T) {
+	ctx := context.Background()
+
+	parentID := "parent-cached"
+	threadID := "thread-cached"
+	t.Cleanup(func() {
+		threadParentsMu.Lock()
+		delete(threadParents, threadID)
+		threadParentsMu.Unlock()
+	})
+
+	session, _ := newRecordingSession(t, []*discordgo.Channel{
+		{ID: parentID, Type: discordgo.ChannelTypeGuildText},
+		{
+			ID:       threadID,
+			Type:     discordgo.ChannelTypeGuildPublicThread,
+			ParentID: parentID,
+		},
+	})
+
+	store := newTestBrokerStore(t)
+
+	_, err := resolveChannelLink(ctx, session, store, threadID)
+	require.NoError(t, err)
+
+	// Confirmed thread should be cached with parent ID.
+	threadParentsMu.Lock()
+	cachedParent, cached := threadParents[threadID]
+	threadParentsMu.Unlock()
+	assert.True(t, cached, "confirmed thread must be cached")
+	assert.Equal(t, parentID, cachedParent)
+}

--- a/extras/scion-discord/internal/discord/callbacks.go
+++ b/extras/scion-discord/internal/discord/callbacks.go
@@ -185,7 +185,7 @@ func (h *CallbackHandler) saveChannelLink(ctx context.Context, i *discordgo.Inte
 	guildID := i.GuildID
 
 	channelID := i.ChannelID
-	if parentID := threadParentID(h.session, channelID); parentID != "" {
+	if parentID, _ := threadParentID(h.session, channelID); parentID != "" {
 		channelID = parentID
 	}
 

--- a/extras/scion-discord/internal/discord/callbacks.go
+++ b/extras/scion-discord/internal/discord/callbacks.go
@@ -185,7 +185,11 @@ func (h *CallbackHandler) saveChannelLink(ctx context.Context, i *discordgo.Inte
 	guildID := i.GuildID
 
 	channelID := i.ChannelID
-	if parentID, _ := threadParentID(h.session, channelID); parentID != "" {
+	parentID, ok := threadParentID(h.session, channelID)
+	if !ok {
+		h.log.Error("Failed to resolve thread parent during saveChannelLink", "channel_id", channelID)
+	}
+	if parentID != "" {
 		channelID = parentID
 	}
 

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -598,7 +598,11 @@ func (h *CommandHandler) HandleSetup(s *discordgo.Session, i *discordgo.Interact
 
 	// If running in a thread/forum topic, resolve the parent channel.
 	var link *ChannelLink
-	parentID, _ := threadParentID(s, i.ChannelID)
+	parentID, ok := threadParentID(s, i.ChannelID)
+	if !ok {
+		h.followup(s, i, "Failed to resolve channel details due to a Discord API error. Please try again.")
+		return
+	}
 	if parentID != "" {
 		link, err = h.store.GetChannelLink(ctx, parentID)
 		if err != nil {
@@ -831,7 +835,11 @@ func (h *CommandHandler) HandleStatus(s *discordgo.Session, i *discordgo.Interac
 	}
 
 	// Detect thread context for default info display.
-	statusParentID, _ := threadParentID(s, i.ChannelID)
+	statusParentID, ok := threadParentID(s, i.ChannelID)
+	if !ok {
+		h.followup(s, i, "Failed to resolve channel details due to a Discord API error. Please try again.")
+		return
+	}
 
 	for _, agent := range agents {
 		if agent.Slug == agentSlug {
@@ -1028,7 +1036,11 @@ func (h *CommandHandler) HandleDefault(s *discordgo.Session, i *discordgo.Intera
 	}
 
 	// Detect thread context.
-	parentID, _ := threadParentID(s, i.ChannelID)
+	parentID, ok := threadParentID(s, i.ChannelID)
+	if !ok {
+		h.followup(s, i, "Failed to resolve channel details due to a Discord API error. Please try again.")
+		return
+	}
 	isThread := parentID != ""
 	threadID := ""
 	if isThread {
@@ -1236,7 +1248,11 @@ func (h *CommandHandler) HandleThread(s *discordgo.Session, i *discordgo.Interac
 	// If invoked from inside a thread, create a sibling in the parent channel
 	// (decision 1a). If in a regular channel, use the current channel.
 	channelID := i.ChannelID
-	parentID, _ := threadParentID(s, channelID)
+	parentID, ok := threadParentID(s, channelID)
+	if !ok {
+		h.followup(s, i, "Failed to resolve channel details due to a Discord API error. Please try again.")
+		return
+	}
 	if parentID != "" {
 		// We are inside a thread — create sibling in parent channel.
 		channelID = parentID

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -598,7 +598,7 @@ func (h *CommandHandler) HandleSetup(s *discordgo.Session, i *discordgo.Interact
 
 	// If running in a thread/forum topic, resolve the parent channel.
 	var link *ChannelLink
-	parentID := threadParentID(s, i.ChannelID)
+	parentID, _ := threadParentID(s, i.ChannelID)
 	if parentID != "" {
 		link, err = h.store.GetChannelLink(ctx, parentID)
 		if err != nil {
@@ -831,7 +831,7 @@ func (h *CommandHandler) HandleStatus(s *discordgo.Session, i *discordgo.Interac
 	}
 
 	// Detect thread context for default info display.
-	statusParentID := threadParentID(s, i.ChannelID)
+	statusParentID, _ := threadParentID(s, i.ChannelID)
 
 	for _, agent := range agents {
 		if agent.Slug == agentSlug {
@@ -1028,7 +1028,7 @@ func (h *CommandHandler) HandleDefault(s *discordgo.Session, i *discordgo.Intera
 	}
 
 	// Detect thread context.
-	parentID := threadParentID(s, i.ChannelID)
+	parentID, _ := threadParentID(s, i.ChannelID)
 	isThread := parentID != ""
 	threadID := ""
 	if isThread {
@@ -1236,7 +1236,7 @@ func (h *CommandHandler) HandleThread(s *discordgo.Session, i *discordgo.Interac
 	// If invoked from inside a thread, create a sibling in the parent channel
 	// (decision 1a). If in a regular channel, use the current channel.
 	channelID := i.ChannelID
-	parentID := threadParentID(s, channelID)
+	parentID, _ := threadParentID(s, channelID)
 	if parentID != "" {
 		// We are inside a thread — create sibling in parent channel.
 		channelID = parentID
@@ -1708,9 +1708,14 @@ var (
 	threadParents   = make(map[string]string)
 )
 
-// threadParentID returns the parent channel ID if channelID is a thread,
-// or empty string if it is not a thread or the lookup fails.
-func threadParentID(s *discordgo.Session, channelID string) string {
+// threadParentID returns the parent channel ID if channelID is a thread.
+//
+// Return values:
+//   - (parentID, true)  — channelID is a thread; parentID is its parent.
+//   - ("", true)        — channelID is confirmed NOT a thread.
+//   - ("", false)       — lookup failed (e.g. transient REST error); caller
+//     should NOT cache the result so the next call can retry.
+func threadParentID(s *discordgo.Session, channelID string) (string, bool) {
 	var ch *discordgo.Channel
 	var err error
 	if s.State != nil {
@@ -1719,15 +1724,15 @@ func threadParentID(s *discordgo.Session, channelID string) string {
 	if ch == nil || err != nil {
 		ch, err = s.Channel(channelID)
 		if err != nil {
-			return ""
+			return "", false // lookup failed — do not cache
 		}
 	}
 	if ch.Type == discordgo.ChannelTypeGuildPublicThread ||
 		ch.Type == discordgo.ChannelTypeGuildPrivateThread ||
 		ch.Type == discordgo.ChannelTypeGuildNewsThread {
-		return ch.ParentID
+		return ch.ParentID, true
 	}
-	return ""
+	return "", true // confirmed not a thread
 }
 
 // resolveChannelLink looks up a ChannelLink for channelID. If no active link
@@ -1743,10 +1748,16 @@ func resolveChannelLink(ctx context.Context, s *discordgo.Session, store Store, 
 		threadParentsMu.Unlock()
 
 		if !cached {
-			parentID = threadParentID(s, channelID)
-			threadParentsMu.Lock()
-			threadParents[channelID] = parentID
-			threadParentsMu.Unlock()
+			var ok bool
+			parentID, ok = threadParentID(s, channelID)
+			if ok {
+				// Only cache when the lookup succeeded. On failure (!ok)
+				// we leave the entry absent so the next call retries,
+				// avoiding negative-cache poisoning from transient errors.
+				threadParentsMu.Lock()
+				threadParents[channelID] = parentID
+				threadParentsMu.Unlock()
+			}
 		}
 
 		if parentID != "" {


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/576

threadParentID() returned empty string for both "not a thread" and "REST call failed". resolveChannelLink() cached both permanently. A transient Discord API error would poison the cache, permanently blocking thread parent lookups for that channel until restart.

Changes:
- threadParentID() now returns (string, bool) distinguishing confirmed result from lookup failure
- resolveChannelLink() only caches when lookup succeeded (ok == true)
- All 6 callers updated to handle the new signature
- resolveThreadParent() in broker.go documented (already correct — does not cache failures)
- Tests: cache poisoning prevention, confirmed non-thread caching, confirmed thread caching, three-state return verification

Fork PR: https://github.com/ptone/scion/pull/TBD