### PR TITLE
fix(discord): use configurable register_url for user-facing registration links (#554)

### DIFF
--- a/extras/scion-discord/cmd/scion-plugin-discord/main.go
+++ b/extras/scion-discord/cmd/scion-plugin-discord/main.go
@@ -70,6 +70,7 @@ func main() {
 	fmt.Println("  send_queue_size  Max queued messages per channel (default: 100)")
 	fmt.Println("  send_min_delay   Minimum delay between sends (default: 50ms)")
 	fmt.Println("  agent_cache_ttl  TTL for cached agent list (default: 5m)")
+	fmt.Println("  register_url     Public URL for user-facing registration links (default: hub_url)")
 	os.Exit(0)
 }
 
@@ -158,6 +159,7 @@ func serveStandalone() {
 			"mention_routing", "send_queue_size", "send_min_delay",
 			"agent_cache_ttl",
 			"transport_mode", "transport_audience",
+			"register_url",
 		},
 		UpdateHook: os.Getenv("UPDATE_HOOK"),
 		Log:        log,

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -348,7 +348,8 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 		sendSearchRoot := config["send_search_root"]
 		b.commands = NewCommandHandler(b.store, b.session, b.hubClient, b.deliverInbound, appID, guildIDs, b.agentCacheTTL, sendSearchRoot, b.log)
 		b.callbacks = NewCallbackHandler(b.store, b.session, b.hubClient, b.deliverInbound, b.log)
-		b.registration = NewRegistrationHandler(b.store, b.session, b.hubURL, b.hmacKey, b.brokerID, b.httpClient, b.log)
+		registerURL := config["register_url"]
+		b.registration = NewRegistrationHandler(b.store, b.session, b.hubURL, registerURL, b.hmacKey, b.brokerID, b.httpClient, b.log)
 
 		// Parse hub-injected project slug map (projectID -> slug).
 		if slugMapJSON, ok := config["project_slug_map"]; ok && slugMapJSON != "" {

--- a/extras/scion-discord/internal/discord/register.go
+++ b/extras/scion-discord/internal/discord/register.go
@@ -21,13 +21,14 @@ import (
 // RegistrationHandler manages the hub-verified code-based registration flow
 // for Discord users.
 type RegistrationHandler struct {
-	store      Store
-	session    *discordgo.Session
-	hubURL     string
-	hmacKey    string
-	brokerID   string
-	httpClient *http.Client
-	log        *slog.Logger
+	store       Store
+	session     *discordgo.Session
+	hubURL      string
+	registerURL string // external URL for user-facing registration links; falls back to hubURL
+	hmacKey     string
+	brokerID    string
+	httpClient  *http.Client
+	log         *slog.Logger
 
 	mu      sync.Mutex
 	pending map[string]*pendingLinkReg // discordUserID -> pending registration
@@ -70,8 +71,10 @@ const (
 )
 
 // NewRegistrationHandler creates a new RegistrationHandler.
+// If registerURL is non-empty it is used for user-facing registration links;
+// otherwise hubURL is used as a fallback.
 // If httpClient is nil, a default client with a 15s timeout is used.
-func NewRegistrationHandler(store Store, session *discordgo.Session, hubURL, hmacKey, brokerID string, httpClient *http.Client, log *slog.Logger) *RegistrationHandler {
+func NewRegistrationHandler(store Store, session *discordgo.Session, hubURL, registerURL, hmacKey, brokerID string, httpClient *http.Client, log *slog.Logger) *RegistrationHandler {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -79,14 +82,15 @@ func NewRegistrationHandler(store Store, session *discordgo.Session, hubURL, hma
 		httpClient = &http.Client{Timeout: 15 * time.Second}
 	}
 	return &RegistrationHandler{
-		store:      store,
-		session:    session,
-		hubURL:     hubURL,
-		hmacKey:    hmacKey,
-		brokerID:   brokerID,
-		httpClient: httpClient,
-		log:        log,
-		pending:    make(map[string]*pendingLinkReg),
+		store:       store,
+		session:     session,
+		hubURL:      hubURL,
+		registerURL: registerURL,
+		hmacKey:     hmacKey,
+		brokerID:    brokerID,
+		httpClient:  httpClient,
+		log:         log,
+		pending:     make(map[string]*pendingLinkReg),
 	}
 }
 
@@ -158,9 +162,13 @@ func (h *RegistrationHandler) HandleRegister(s *discordgo.Session, i *discordgo.
 	h.pending[discordUserID] = reg
 	h.mu.Unlock()
 
-	// Build the link URL.
-	hubLink := fmt.Sprintf("%s/profile/discord?code=%s&user_name=%s",
-		strings.TrimRight(h.hubURL, "/"), code, discordUsername)
+	// Build the link URL. Prefer registerURL (the public-facing address)
+	// when configured; fall back to hubURL for backward compatibility.
+	baseURL := h.hubURL
+	if h.registerURL != "" {
+		baseURL = h.registerURL
+	}
+	hubLink := formatRegistrationLink(baseURL, code, discordUsername)
 
 	// Send follow-up with a URL button.
 	_, err = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
@@ -411,6 +419,13 @@ func interactionUsername(i *discordgo.InteractionCreate) string {
 		return i.User.Username
 	}
 	return ""
+}
+
+// formatRegistrationLink builds the user-facing registration URL from a base
+// URL, linking code, and Discord username.
+func formatRegistrationLink(baseURL, code, discordUsername string) string {
+	return fmt.Sprintf("%s/profile/discord?code=%s&user_name=%s",
+		strings.TrimRight(baseURL, "/"), code, discordUsername)
 }
 
 // generateLinkingCode creates a 6-character alphanumeric code using a

--- a/extras/scion-discord/internal/discord/register.go
+++ b/extras/scion-discord/internal/discord/register.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"math/big"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -94,6 +95,15 @@ func NewRegistrationHandler(store Store, session *discordgo.Session, hubURL, reg
 	}
 }
 
+// registrationBaseURL returns the base URL for user-facing registration links.
+// It prefers registerURL when configured; otherwise it falls back to hubURL.
+func (h *RegistrationHandler) registrationBaseURL() string {
+	if h.registerURL != "" {
+		return h.registerURL
+	}
+	return h.hubURL
+}
+
 // HandleRegister handles the /scion register command. It generates a short
 // linking code, registers it with the hub, and sends the user a link button.
 func (h *RegistrationHandler) HandleRegister(s *discordgo.Session, i *discordgo.InteractionCreate) {
@@ -162,13 +172,7 @@ func (h *RegistrationHandler) HandleRegister(s *discordgo.Session, i *discordgo.
 	h.pending[discordUserID] = reg
 	h.mu.Unlock()
 
-	// Build the link URL. Prefer registerURL (the public-facing address)
-	// when configured; fall back to hubURL for backward compatibility.
-	baseURL := h.hubURL
-	if h.registerURL != "" {
-		baseURL = h.registerURL
-	}
-	hubLink := formatRegistrationLink(baseURL, code, discordUsername)
+	hubLink := formatRegistrationLink(h.registrationBaseURL(), code, discordUsername)
 
 	// Send follow-up with a URL button.
 	_, err = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
@@ -425,7 +429,7 @@ func interactionUsername(i *discordgo.InteractionCreate) string {
 // URL, linking code, and Discord username.
 func formatRegistrationLink(baseURL, code, discordUsername string) string {
 	return fmt.Sprintf("%s/profile/discord?code=%s&user_name=%s",
-		strings.TrimRight(baseURL, "/"), code, discordUsername)
+		strings.TrimRight(baseURL, "/"), code, url.QueryEscape(discordUsername))
 }
 
 // generateLinkingCode creates a 6-character alphanumeric code using a

--- a/extras/scion-discord/internal/discord/register_test.go
+++ b/extras/scion-discord/internal/discord/register_test.go
@@ -1,0 +1,106 @@
+package discord
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestNewRegistrationHandler_RegisterURL(t *testing.T) {
+	t.Run("registerURL is stored when provided", func(t *testing.T) {
+		h := NewRegistrationHandler(nil, nil, "http://localhost:8080", "https://public.example.com", "key", "broker1", nil, testLogger())
+		require.NotNil(t, h)
+		assert.Equal(t, "http://localhost:8080", h.hubURL)
+		assert.Equal(t, "https://public.example.com", h.registerURL)
+	})
+
+	t.Run("registerURL is empty when not provided", func(t *testing.T) {
+		h := NewRegistrationHandler(nil, nil, "http://localhost:8080", "", "key", "broker1", nil, testLogger())
+		require.NotNil(t, h)
+		assert.Equal(t, "http://localhost:8080", h.hubURL)
+		assert.Equal(t, "", h.registerURL)
+	})
+
+	t.Run("default http client is created when nil", func(t *testing.T) {
+		h := NewRegistrationHandler(nil, nil, "http://localhost:8080", "", "key", "broker1", nil, testLogger())
+		require.NotNil(t, h.httpClient)
+		assert.Equal(t, 15*time.Second, h.httpClient.Timeout)
+	})
+
+	t.Run("custom http client is used when provided", func(t *testing.T) {
+		client := &http.Client{Timeout: 30 * time.Second}
+		h := NewRegistrationHandler(nil, nil, "http://localhost:8080", "", "key", "broker1", client, testLogger())
+		assert.Equal(t, client, h.httpClient)
+	})
+}
+
+func TestRegistrationHandler_LinkURL(t *testing.T) {
+	// Test the URL construction logic by verifying the baseURL selection.
+	// We can't easily test HandleRegister end-to-end without mocking the full
+	// Discord session and store, so we test the baseURL fallback logic directly.
+
+	t.Run("uses registerURL for link when set", func(t *testing.T) {
+		h := NewRegistrationHandler(nil, nil, "http://localhost:8080", "https://public.example.com", "", "", nil, testLogger())
+
+		baseURL := h.hubURL
+		if h.registerURL != "" {
+			baseURL = h.registerURL
+		}
+		assert.Equal(t, "https://public.example.com", baseURL)
+	})
+
+	t.Run("falls back to hubURL when registerURL is empty", func(t *testing.T) {
+		h := NewRegistrationHandler(nil, nil, "http://localhost:8080", "", "", "", nil, testLogger())
+
+		baseURL := h.hubURL
+		if h.registerURL != "" {
+			baseURL = h.registerURL
+		}
+		assert.Equal(t, "http://localhost:8080", baseURL)
+	})
+
+	t.Run("registerURL with trailing slash is trimmed in link", func(t *testing.T) {
+		h := NewRegistrationHandler(nil, nil, "http://localhost:8080", "https://public.example.com/", "", "", nil, testLogger())
+
+		baseURL := h.hubURL
+		if h.registerURL != "" {
+			baseURL = h.registerURL
+		}
+
+		// Simulate the same formatting as HandleRegister
+		link := formatRegistrationLink(baseURL, "ABC123", "testuser")
+		assert.Equal(t, "https://public.example.com/profile/discord?code=ABC123&user_name=testuser", link)
+	})
+
+	t.Run("hubURL with trailing slash is trimmed in link", func(t *testing.T) {
+		h := NewRegistrationHandler(nil, nil, "http://localhost:8080/", "", "", "", nil, testLogger())
+
+		baseURL := h.hubURL
+		if h.registerURL != "" {
+			baseURL = h.registerURL
+		}
+
+		link := formatRegistrationLink(baseURL, "ABC123", "testuser")
+		assert.Equal(t, "http://localhost:8080/profile/discord?code=ABC123&user_name=testuser", link)
+	})
+}
+
+func TestGenerateLinkingCode(t *testing.T) {
+	code, err := generateLinkingCode()
+	require.NoError(t, err)
+	assert.Len(t, code, linkingCodeLength)
+
+	// Verify all characters are from the allowed charset.
+	for _, c := range code {
+		assert.Contains(t, linkingCodeCharset, string(c))
+	}
+}

--- a/extras/scion-discord/internal/discord/register_test.go
+++ b/extras/scion-discord/internal/discord/register_test.go
@@ -44,53 +44,31 @@ func TestNewRegistrationHandler_RegisterURL(t *testing.T) {
 }
 
 func TestRegistrationHandler_LinkURL(t *testing.T) {
-	// Test the URL construction logic by verifying the baseURL selection.
-	// We can't easily test HandleRegister end-to-end without mocking the full
-	// Discord session and store, so we test the baseURL fallback logic directly.
-
 	t.Run("uses registerURL for link when set", func(t *testing.T) {
 		h := NewRegistrationHandler(nil, nil, "http://localhost:8080", "https://public.example.com", "", "", nil, testLogger())
-
-		baseURL := h.hubURL
-		if h.registerURL != "" {
-			baseURL = h.registerURL
-		}
-		assert.Equal(t, "https://public.example.com", baseURL)
+		assert.Equal(t, "https://public.example.com", h.registrationBaseURL())
 	})
 
 	t.Run("falls back to hubURL when registerURL is empty", func(t *testing.T) {
 		h := NewRegistrationHandler(nil, nil, "http://localhost:8080", "", "", "", nil, testLogger())
-
-		baseURL := h.hubURL
-		if h.registerURL != "" {
-			baseURL = h.registerURL
-		}
-		assert.Equal(t, "http://localhost:8080", baseURL)
+		assert.Equal(t, "http://localhost:8080", h.registrationBaseURL())
 	})
 
 	t.Run("registerURL with trailing slash is trimmed in link", func(t *testing.T) {
 		h := NewRegistrationHandler(nil, nil, "http://localhost:8080", "https://public.example.com/", "", "", nil, testLogger())
-
-		baseURL := h.hubURL
-		if h.registerURL != "" {
-			baseURL = h.registerURL
-		}
-
-		// Simulate the same formatting as HandleRegister
-		link := formatRegistrationLink(baseURL, "ABC123", "testuser")
+		link := formatRegistrationLink(h.registrationBaseURL(), "ABC123", "testuser")
 		assert.Equal(t, "https://public.example.com/profile/discord?code=ABC123&user_name=testuser", link)
 	})
 
 	t.Run("hubURL with trailing slash is trimmed in link", func(t *testing.T) {
 		h := NewRegistrationHandler(nil, nil, "http://localhost:8080/", "", "", "", nil, testLogger())
-
-		baseURL := h.hubURL
-		if h.registerURL != "" {
-			baseURL = h.registerURL
-		}
-
-		link := formatRegistrationLink(baseURL, "ABC123", "testuser")
+		link := formatRegistrationLink(h.registrationBaseURL(), "ABC123", "testuser")
 		assert.Equal(t, "http://localhost:8080/profile/discord?code=ABC123&user_name=testuser", link)
+	})
+
+	t.Run("special characters in username are URL-escaped", func(t *testing.T) {
+		link := formatRegistrationLink("https://example.com", "ABC123", "user name&foo")
+		assert.Equal(t, "https://example.com/profile/discord?code=ABC123&user_name=user+name%26foo", link)
 	})
 }
 


### PR DESCRIPTION
Fixes https://github.com/ptone/scion/issues/554

The Discord plugin /scion register command built user-facing registration links using hub_url (the internal API endpoint). Behind auth proxies, hub_url resolves to localhost, so registration links pointed users to the wrong address.

Changes:
- Added register_url config key to Discord plugin, mirroring the Telegram plugin pattern
- RegistrationHandler uses register_url for user-facing links, falls back to hub_url when not set
- Extracted formatRegistrationLink helper for link construction
- Added register_url to EnvKeys and usage docs in main.go
- Tests for override and fallback behavior

Fork PR: https://github.com/ptone/scion/pull/TBD