### PR TITLE
fix(hub): validate image_registry before starting runtime broker

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -374,6 +374,9 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 
 	// 13. Start Broker
 	if cfg.RuntimeBroker.Enabled {
+		if err := requireImageRegistryForBroker(); err != nil {
+			return err
+		}
 		if err := startRuntimeBroker(ctx, cmd, cfg, hubSrv, webSrv, s, hubEndpoint, devAuthToken, brokerSettings, globalDir, requestLogger, messageLogger, &wg, errCh); err != nil {
 			return err
 		}
@@ -2542,6 +2545,35 @@ func resolveMaintenanceConfig(cfg *config.GlobalConfig) hub.MaintenanceConfig {
 	}
 
 	return mc
+}
+
+// requireImageRegistryForBroker checks that an image registry is available from
+// at least one source before starting the runtime broker. The broker needs a
+// registry to pull agent container images; without one, image pulls fail with
+// opaque 404 errors at dispatch time. This check fails fast at startup with an
+// actionable error instead.
+//
+// Sources checked (in priority order):
+//  1. SCION_IMAGE_REGISTRY env var
+//  2. SCION_MAINTENANCE_IMAGE_REGISTRY env var
+//  3. image_registry in versioned settings (settings.yaml)
+func requireImageRegistryForBroker() error {
+	if v := os.Getenv("SCION_IMAGE_REGISTRY"); v != "" {
+		return nil
+	}
+	if v := os.Getenv("SCION_MAINTENANCE_IMAGE_REGISTRY"); v != "" {
+		return nil
+	}
+	vs, _, err := config.LoadEffectiveSettings("")
+	if err == nil && vs != nil && vs.IsImageRegistryConfigured("") {
+		return nil
+	}
+	return fmt.Errorf("image_registry is not configured, but the runtime broker requires it.\n\n" +
+		"The runtime broker pulls container images to run agents. Without a registry,\n" +
+		"image pulls will fail. To fix this:\n\n" +
+		"  Option 1: scion config set --global image_registry <your-registry>\n" +
+		"  Option 2: export SCION_IMAGE_REGISTRY=<your-registry>\n\n" +
+		"See image-build/README.md for instructions on building and pushing images.")
 }
 
 // migrateInlineSecrets performs a one-shot migration of secret config keys found

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2565,6 +2565,9 @@ func requireImageRegistryForBroker() error {
 		return nil
 	}
 	vs, _, err := config.LoadEffectiveSettings("")
+	if err != nil {
+		slog.Debug("Failed to load settings while checking image registry", "error", err)
+	}
 	if err == nil && vs != nil && vs.IsImageRegistryConfigured("") {
 		return nil
 	}

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2576,7 +2576,7 @@ func requireImageRegistryForBroker() error {
 		"image pulls will fail. To fix this:\n\n" +
 		"  Option 1: scion config set --global image_registry <your-registry>\n" +
 		"  Option 2: export SCION_IMAGE_REGISTRY=<your-registry>\n\n" +
-		"See image-build/README.md for instructions on building and pushing images.")
+		"See image-build/README.md for instructions on building and pushing images")
 }
 
 // migrateInlineSecrets performs a one-shot migration of secret config keys found

--- a/cmd/server_foreground_broker_test.go
+++ b/cmd/server_foreground_broker_test.go
@@ -85,11 +85,7 @@ func TestRequireImageRegistryForBroker_Settings(t *testing.T) {
 
 	// Change to the temp home so LoadEffectiveSettings doesn't find
 	// the workspace project root's .scion directory.
-	origDir, _ := os.Getwd()
-	if err := os.Chdir(tmpHome); err != nil {
-		t.Fatalf("failed to chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(origDir) }()
+	t.Chdir(tmpHome)
 
 	err := requireImageRegistryForBroker()
 	assert.NoError(t, err)

--- a/cmd/server_foreground_broker_test.go
+++ b/cmd/server_foreground_broker_test.go
@@ -33,6 +33,7 @@ func TestRequireImageRegistryForBroker_NoRegistry(t *testing.T) {
 	// Point HOME at an empty temp dir so settings.yaml is absent.
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Chdir(tmpHome)
 
 	err := requireImageRegistryForBroker()
 	assert.Error(t, err)
@@ -60,16 +61,17 @@ func TestRequireImageRegistryForBroker_MaintenanceEnvVar(t *testing.T) {
 }
 
 func TestRequireImageRegistryForBroker_Settings(t *testing.T) {
-	// Unset (not just empty) the env vars so the koanf env loader does not
+	// Use t.Setenv to register cleanup (restores original values when test
+	// ends), then unset the env vars so the koanf env loader does not
 	// override the settings file value with an empty string.
-	origImageReg := os.Getenv("SCION_IMAGE_REGISTRY")
-	origMaintReg := os.Getenv("SCION_MAINTENANCE_IMAGE_REGISTRY")
-	os.Unsetenv("SCION_IMAGE_REGISTRY")
-	os.Unsetenv("SCION_MAINTENANCE_IMAGE_REGISTRY")
-	defer func() {
-		os.Setenv("SCION_IMAGE_REGISTRY", origImageReg)
-		os.Setenv("SCION_MAINTENANCE_IMAGE_REGISTRY", origMaintReg)
-	}()
+	t.Setenv("SCION_IMAGE_REGISTRY", "")
+	t.Setenv("SCION_MAINTENANCE_IMAGE_REGISTRY", "")
+	if err := os.Unsetenv("SCION_IMAGE_REGISTRY"); err != nil {
+		t.Fatalf("failed to unsetenv SCION_IMAGE_REGISTRY: %v", err)
+	}
+	if err := os.Unsetenv("SCION_MAINTENANCE_IMAGE_REGISTRY"); err != nil {
+		t.Fatalf("failed to unsetenv SCION_MAINTENANCE_IMAGE_REGISTRY: %v", err)
+	}
 
 	// Create a temp home with settings.yaml containing image_registry.
 	tmpHome := t.TempDir()

--- a/cmd/server_foreground_broker_test.go
+++ b/cmd/server_foreground_broker_test.go
@@ -16,12 +16,84 @@ package cmd
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	scionruntime "github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestRequireImageRegistryForBroker_NoRegistry(t *testing.T) {
+	// Ensure no env vars provide a registry.
+	t.Setenv("SCION_IMAGE_REGISTRY", "")
+	t.Setenv("SCION_MAINTENANCE_IMAGE_REGISTRY", "")
+
+	// Point HOME at an empty temp dir so settings.yaml is absent.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	err := requireImageRegistryForBroker()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "image_registry is not configured")
+	assert.Contains(t, err.Error(), "SCION_IMAGE_REGISTRY")
+}
+
+func TestRequireImageRegistryForBroker_EnvVar(t *testing.T) {
+	t.Setenv("SCION_IMAGE_REGISTRY", "ghcr.io/test")
+
+	err := requireImageRegistryForBroker()
+	assert.NoError(t, err)
+}
+
+func TestRequireImageRegistryForBroker_MaintenanceEnvVar(t *testing.T) {
+	t.Setenv("SCION_IMAGE_REGISTRY", "")
+	t.Setenv("SCION_MAINTENANCE_IMAGE_REGISTRY", "ghcr.io/test-maintenance")
+
+	// Point HOME at an empty temp dir so settings.yaml is absent.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	err := requireImageRegistryForBroker()
+	assert.NoError(t, err)
+}
+
+func TestRequireImageRegistryForBroker_Settings(t *testing.T) {
+	// Unset (not just empty) the env vars so the koanf env loader does not
+	// override the settings file value with an empty string.
+	origImageReg := os.Getenv("SCION_IMAGE_REGISTRY")
+	origMaintReg := os.Getenv("SCION_MAINTENANCE_IMAGE_REGISTRY")
+	os.Unsetenv("SCION_IMAGE_REGISTRY")
+	os.Unsetenv("SCION_MAINTENANCE_IMAGE_REGISTRY")
+	defer func() {
+		os.Setenv("SCION_IMAGE_REGISTRY", origImageReg)
+		os.Setenv("SCION_MAINTENANCE_IMAGE_REGISTRY", origMaintReg)
+	}()
+
+	// Create a temp home with settings.yaml containing image_registry.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	scionDir := filepath.Join(tmpHome, ".scion")
+	if err := os.MkdirAll(scionDir, 0755); err != nil {
+		t.Fatalf("failed to create test .scion dir: %v", err)
+	}
+	settingsContent := "schema_version: \"1\"\nimage_registry: ghcr.io/from-settings\n"
+	if err := os.WriteFile(filepath.Join(scionDir, "settings.yaml"), []byte(settingsContent), 0644); err != nil {
+		t.Fatalf("failed to write test settings: %v", err)
+	}
+
+	// Change to the temp home so LoadEffectiveSettings doesn't find
+	// the workspace project root's .scion directory.
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpHome); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	err := requireImageRegistryForBroker()
+	assert.NoError(t, err)
+}
 
 func TestCloudRunLogicalBrokerIDIsDeterministic(t *testing.T) {
 	settings := &config.VersionedSettings{


### PR DESCRIPTION
## Summary

When a Hub starts with --enable-runtime-broker but no image_registry is configured, startup succeeds silently. Agents later fail with opaque image-pull 404s because image names go unrewritten.

This adds a startup-time validation in the broker startup path that fails fast with an actionable error message telling the user how to configure image_registry.

## Changes

- Added requireImageRegistryForBroker() in cmd/server_foreground.go that checks all registry sources (SCION_IMAGE_REGISTRY env var, SCION_MAINTENANCE_IMAGE_REGISTRY env var, settings.yaml image_registry)
- Returns a fatal error if no registry is available when the runtime broker is enabled
- Hub-only mode (without runtime broker) is unaffected

## Test plan

- 4 new tests in cmd/server_foreground_broker_test.go covering: no registry, env var, maintenance env var, settings file
- Existing TestServerStartDoesNotRequireImageRegistry continues to pass (hub-only mode regression)

Ref: ptone/scion#436
