### PR TITLE
fix(hubclient): check Content-Type before falling back to legacy grove endpoint

### DIFF
--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -617,7 +617,8 @@ func TestSendOutboundMessageViaHub(t *testing.T) {
 		switch {
 		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
-		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/groves/"+projectID+"/agents/my-agent/outbound-message":
+		case r.Method == http.MethodPost && (r.URL.Path == "/api/v1/projects/"+projectID+"/agents/my-agent/outbound-message" ||
+				r.URL.Path == "/api/v1/groves/"+projectID+"/agents/my-agent/outbound-message"):
 			var msg hubclient.OutboundMessageRequest
 			_ = json.NewDecoder(r.Body).Decode(&msg)
 			receivedMsg = &msg

--- a/pkg/hubclient/client.go
+++ b/pkg/hubclient/client.go
@@ -325,7 +325,7 @@ func (c *client) get(ctx context.Context, path string, headers http.Header) (*ht
 func (c *client) getWithQuery(ctx context.Context, path string, query url.Values, headers http.Header) (*http.Response, error) {
 	resp, err := c.transport.GetWithQuery(ctx, path, query, headers)
 	if err == nil && resp.StatusCode == http.StatusNotFound && strings.Contains(path, "/projects") {
-		ct := resp.Header.Get("Content-Type")
+		ct := strings.ToLower(resp.Header.Get("Content-Type"))
 		if !strings.Contains(ct, "application/json") {
 			legacyPath := strings.Replace(path, "/projects", "/groves", 1)
 			_ = resp.Body.Close()
@@ -341,7 +341,7 @@ func (c *client) getWithQuery(ctx context.Context, path string, query url.Values
 func (c *client) post(ctx context.Context, path string, body interface{}, headers http.Header) (*http.Response, error) {
 	resp, err := c.transport.Post(ctx, path, body, headers)
 	if err == nil && resp.StatusCode == http.StatusNotFound && strings.Contains(path, "/projects") {
-		ct := resp.Header.Get("Content-Type")
+		ct := strings.ToLower(resp.Header.Get("Content-Type"))
 		if !strings.Contains(ct, "application/json") {
 			legacyPath := strings.Replace(path, "/projects", "/groves", 1)
 			_ = resp.Body.Close()
@@ -357,7 +357,7 @@ func (c *client) post(ctx context.Context, path string, body interface{}, header
 func (c *client) put(ctx context.Context, path string, body interface{}, headers http.Header) (*http.Response, error) {
 	resp, err := c.transport.Put(ctx, path, body, headers)
 	if err == nil && resp.StatusCode == http.StatusNotFound && strings.Contains(path, "/projects") {
-		ct := resp.Header.Get("Content-Type")
+		ct := strings.ToLower(resp.Header.Get("Content-Type"))
 		if !strings.Contains(ct, "application/json") {
 			legacyPath := strings.Replace(path, "/projects", "/groves", 1)
 			_ = resp.Body.Close()
@@ -373,7 +373,7 @@ func (c *client) put(ctx context.Context, path string, body interface{}, headers
 func (c *client) patch(ctx context.Context, path string, body interface{}, headers http.Header) (*http.Response, error) {
 	resp, err := c.transport.Patch(ctx, path, body, headers)
 	if err == nil && resp.StatusCode == http.StatusNotFound && strings.Contains(path, "/projects") {
-		ct := resp.Header.Get("Content-Type")
+		ct := strings.ToLower(resp.Header.Get("Content-Type"))
 		if !strings.Contains(ct, "application/json") {
 			legacyPath := strings.Replace(path, "/projects", "/groves", 1)
 			_ = resp.Body.Close()
@@ -389,7 +389,7 @@ func (c *client) patch(ctx context.Context, path string, body interface{}, heade
 func (c *client) delete(ctx context.Context, path string, headers http.Header) (*http.Response, error) {
 	resp, err := c.transport.Delete(ctx, path, headers)
 	if err == nil && resp.StatusCode == http.StatusNotFound && strings.Contains(path, "/projects") {
-		ct := resp.Header.Get("Content-Type")
+		ct := strings.ToLower(resp.Header.Get("Content-Type"))
 		if !strings.Contains(ct, "application/json") {
 			legacyPath := strings.Replace(path, "/projects", "/groves", 1)
 			_ = resp.Body.Close()

--- a/pkg/hubclient/client.go
+++ b/pkg/hubclient/client.go
@@ -325,11 +325,14 @@ func (c *client) get(ctx context.Context, path string, headers http.Header) (*ht
 func (c *client) getWithQuery(ctx context.Context, path string, query url.Values, headers http.Header) (*http.Response, error) {
 	resp, err := c.transport.GetWithQuery(ctx, path, query, headers)
 	if err == nil && resp.StatusCode == http.StatusNotFound && strings.Contains(path, "/projects") {
-		legacyPath := strings.Replace(path, "/projects", "/groves", 1)
-		_ = resp.Body.Close()
-		resp, err = c.transport.GetWithQuery(ctx, legacyPath, query, headers)
-		c.checkForDeprecation(resp)
-		return resp, err
+		ct := resp.Header.Get("Content-Type")
+		if !strings.Contains(ct, "application/json") {
+			legacyPath := strings.Replace(path, "/projects", "/groves", 1)
+			_ = resp.Body.Close()
+			resp, err = c.transport.GetWithQuery(ctx, legacyPath, query, headers)
+			c.checkForDeprecation(resp)
+			return resp, err
+		}
 	}
 	return resp, err
 }
@@ -338,11 +341,14 @@ func (c *client) getWithQuery(ctx context.Context, path string, query url.Values
 func (c *client) post(ctx context.Context, path string, body interface{}, headers http.Header) (*http.Response, error) {
 	resp, err := c.transport.Post(ctx, path, body, headers)
 	if err == nil && resp.StatusCode == http.StatusNotFound && strings.Contains(path, "/projects") {
-		legacyPath := strings.Replace(path, "/projects", "/groves", 1)
-		_ = resp.Body.Close()
-		resp, err = c.transport.Post(ctx, legacyPath, body, headers)
-		c.checkForDeprecation(resp)
-		return resp, err
+		ct := resp.Header.Get("Content-Type")
+		if !strings.Contains(ct, "application/json") {
+			legacyPath := strings.Replace(path, "/projects", "/groves", 1)
+			_ = resp.Body.Close()
+			resp, err = c.transport.Post(ctx, legacyPath, body, headers)
+			c.checkForDeprecation(resp)
+			return resp, err
+		}
 	}
 	return resp, err
 }
@@ -351,11 +357,14 @@ func (c *client) post(ctx context.Context, path string, body interface{}, header
 func (c *client) put(ctx context.Context, path string, body interface{}, headers http.Header) (*http.Response, error) {
 	resp, err := c.transport.Put(ctx, path, body, headers)
 	if err == nil && resp.StatusCode == http.StatusNotFound && strings.Contains(path, "/projects") {
-		legacyPath := strings.Replace(path, "/projects", "/groves", 1)
-		_ = resp.Body.Close()
-		resp, err = c.transport.Put(ctx, legacyPath, body, headers)
-		c.checkForDeprecation(resp)
-		return resp, err
+		ct := resp.Header.Get("Content-Type")
+		if !strings.Contains(ct, "application/json") {
+			legacyPath := strings.Replace(path, "/projects", "/groves", 1)
+			_ = resp.Body.Close()
+			resp, err = c.transport.Put(ctx, legacyPath, body, headers)
+			c.checkForDeprecation(resp)
+			return resp, err
+		}
 	}
 	return resp, err
 }
@@ -364,11 +373,14 @@ func (c *client) put(ctx context.Context, path string, body interface{}, headers
 func (c *client) patch(ctx context.Context, path string, body interface{}, headers http.Header) (*http.Response, error) {
 	resp, err := c.transport.Patch(ctx, path, body, headers)
 	if err == nil && resp.StatusCode == http.StatusNotFound && strings.Contains(path, "/projects") {
-		legacyPath := strings.Replace(path, "/projects", "/groves", 1)
-		_ = resp.Body.Close()
-		resp, err = c.transport.Patch(ctx, legacyPath, body, headers)
-		c.checkForDeprecation(resp)
-		return resp, err
+		ct := resp.Header.Get("Content-Type")
+		if !strings.Contains(ct, "application/json") {
+			legacyPath := strings.Replace(path, "/projects", "/groves", 1)
+			_ = resp.Body.Close()
+			resp, err = c.transport.Patch(ctx, legacyPath, body, headers)
+			c.checkForDeprecation(resp)
+			return resp, err
+		}
 	}
 	return resp, err
 }
@@ -377,11 +389,14 @@ func (c *client) patch(ctx context.Context, path string, body interface{}, heade
 func (c *client) delete(ctx context.Context, path string, headers http.Header) (*http.Response, error) {
 	resp, err := c.transport.Delete(ctx, path, headers)
 	if err == nil && resp.StatusCode == http.StatusNotFound && strings.Contains(path, "/projects") {
-		legacyPath := strings.Replace(path, "/projects", "/groves", 1)
-		_ = resp.Body.Close()
-		resp, err = c.transport.Delete(ctx, legacyPath, headers)
-		c.checkForDeprecation(resp)
-		return resp, err
+		ct := resp.Header.Get("Content-Type")
+		if !strings.Contains(ct, "application/json") {
+			legacyPath := strings.Replace(path, "/projects", "/groves", 1)
+			_ = resp.Body.Close()
+			resp, err = c.transport.Delete(ctx, legacyPath, headers)
+			c.checkForDeprecation(resp)
+			return resp, err
+		}
 	}
 	return resp, err
 }

--- a/pkg/hubclient/client_test.go
+++ b/pkg/hubclient/client_test.go
@@ -364,6 +364,41 @@ func TestFallback(t *testing.T) {
 	}
 }
 
+func TestFallbackSkippedOnJSONNotFound(t *testing.T) {
+	var attempts []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts = append(attempts, r.URL.Path)
+		if r.URL.Path == "/api/v1/projects/my-project" {
+			// Application-level 404: the route matched, but the resource doesn't exist.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "project not found"})
+			return
+		}
+		// The groves fallback should never be reached.
+		if r.URL.Path == "/api/v1/groves/my-project" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(Project{ID: "my-project", Name: "My Project"})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, _ := New(server.URL)
+	_, err := client.Projects().Get(context.Background(), "my-project")
+	if err == nil {
+		t.Fatal("expected an error for application-level 404, got nil")
+	}
+
+	if len(attempts) != 1 {
+		t.Errorf("expected 1 attempt (no fallback), got %d: %v", len(attempts), attempts)
+	}
+	if attempts[0] != "/api/v1/projects/my-project" {
+		t.Errorf("expected attempt to /api/v1/projects/my-project, got %s", attempts[0])
+	}
+}
+
 func TestWithBearerToken(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		auth := r.Header.Get("Authorization")


### PR DESCRIPTION
## Summary

Fixes spurious deprecation warning that fires on every `scion start` (and other commands). The hubclient HTTP fallback conflates mux-level 404s (old Hub lacking /projects/ routes) with application-level 404s (current Hub returning 404 for a non-existent resource). This adds a Content-Type check: JSON 404 responses indicate an app-level resource-not-found from a current Hub and should not trigger the legacy /groves/ fallback.

## Changes

- Added Content-Type check to all 5 HTTP method fallback blocks in pkg/hubclient/client.go
- Fallback only fires on non-JSON 404s (mux-level route miss), not JSON 404s (app-level resource not found)
- Added TestFallbackSkippedOnJSONNotFound test; existing TestFallback still passes

## Test plan

- go test ./pkg/hubclient/ -run Fallback -v (both tests pass)
- go vet clean

Ref: ptone/scion#700
