### PR TITLE
fix(config): write project_id instead of legacy grove_id in settings

### DIFF
--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -513,7 +513,7 @@ func writeProjectSettings(externalPath, workspacePath, projectID string, opt Ini
 				hub = make(map[string]interface{})
 				settingsMap["hub"] = hub
 			}
-			hub["grove_id"] = projectID
+			hub["project_id"] = projectID
 		} else {
 			settingsMap["project_id"] = projectID
 		}

--- a/pkg/config/init_project_test.go
+++ b/pkg/config/init_project_test.go
@@ -168,8 +168,8 @@ func TestInitProject_NonGitCreatesMarkerAndExternalDir(t *testing.T) {
 	if !containsSubstring(string(data), "workspace_path") {
 		t.Error("settings.yaml should contain workspace_path")
 	}
-	if !containsSubstring(string(data), "grove_id") {
-		t.Error("settings.yaml should contain grove_id")
+	if !containsSubstring(string(data), "project_id") {
+		t.Error("settings.yaml should contain project_id")
 	}
 }
 

--- a/pkg/config/init_test.go
+++ b/pkg/config/init_test.go
@@ -869,17 +869,17 @@ func TestWriteProjectSettings_V1PlacesProjectIDUnderHub(t *testing.T) {
 		t.Skipf("default project settings are not v1 format (schema_version=%q), skipping v1-specific test", v)
 	}
 
-	// grove_id should NOT be at the top level
-	if _, exists := settingsMap["grove_id"]; exists {
-		t.Error("grove_id should not be at the top level in v1 format; expected it under hub.grove_id")
+	// project_id should NOT be at the top level
+	if _, exists := settingsMap["project_id"]; exists {
+		t.Error("project_id should not be at the top level in v1 format; expected it under hub.project_id")
 	}
 
-	// grove_id should be under hub.grove_id
+	// project_id should be under hub.project_id
 	hub, ok := settingsMap["hub"].(map[string]interface{})
 	if !ok {
 		t.Fatal("expected hub section in settings")
 	}
-	if hub["grove_id"] != projectID {
-		t.Errorf("expected hub.grove_id=%q, got %v", projectID, hub["grove_id"])
+	if hub["project_id"] != projectID {
+		t.Errorf("expected hub.project_id=%q, got %v", projectID, hub["project_id"])
 	}
 }

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -668,7 +668,7 @@ type V1HubClientConfig struct {
 	Enabled   *bool  `json:"enabled,omitempty" yaml:"enabled,omitempty" koanf:"enabled"`
 	Linked    *bool  `json:"linked,omitempty" yaml:"linked,omitempty" koanf:"linked"`
 	Endpoint  string `json:"endpoint,omitempty" yaml:"endpoint,omitempty" koanf:"endpoint"`
-	ProjectID string `json:"grove_id,omitempty" yaml:"grove_id,omitempty" koanf:"grove_id"`
+	ProjectID string `json:"project_id,omitempty" yaml:"project_id,omitempty" koanf:"project_id"`
 	LocalOnly *bool  `json:"local_only,omitempty" yaml:"local_only,omitempty" koanf:"local_only"`
 }
 
@@ -988,17 +988,18 @@ func LoadVersionedSettings(projectPath string) (*VersionedSettings, error) {
 		if projectPath != globalDir {
 			if projectID, err := ReadProjectID(projectPath); err == nil && projectID != "" {
 				_ = k.Load(confmap.Provider(map[string]interface{}{
-					projectcompat.ConfigHubGroveIDKey: projectID,
+					projectcompat.ConfigHubProjectIDKey: projectID,
 				}, "."), nil)
 			}
 		}
 	}
 
-	// Remap hub.project_id to hub.grove_id for backward compatibility with V1 structs.
-	// SCION_HUB_PROJECT_ID maps to hub.project_id via versionedEnvKeyMapper.
-	if k.Exists(projectcompat.ConfigHubProjectIDKey) && !k.Exists(projectcompat.ConfigHubGroveIDKey) {
+	// Remap hub.grove_id to hub.project_id for backward compatibility.
+	// Old settings files may still use grove_id; the V1HubClientConfig struct
+	// now uses koanf:"project_id", so grove_id values must be copied across.
+	if k.Exists(projectcompat.ConfigHubGroveIDKey) && !k.Exists(projectcompat.ConfigHubProjectIDKey) {
 		_ = k.Load(confmap.Provider(map[string]interface{}{
-			projectcompat.ConfigHubGroveIDKey: k.String(projectcompat.ConfigHubProjectIDKey),
+			projectcompat.ConfigHubProjectIDKey: k.String(projectcompat.ConfigHubGroveIDKey),
 		}, "."), nil)
 	}
 
@@ -1024,7 +1025,7 @@ func versionedEnvKeyMapper(s string) string {
 	}
 	key := strings.ToLower(strings.TrimPrefix(s, "SCION_"))
 
-	// Handle nested hub keys (single level: hub.endpoint, hub.grove_id, etc.)
+	// Handle nested hub keys (single level: hub.endpoint, hub.project_id, etc.)
 	if strings.HasPrefix(key, "hub_") {
 		return "hub." + strings.TrimPrefix(key, "hub_")
 	}
@@ -2097,6 +2098,23 @@ func LoadSingleFileVersioned(dir string) (*VersionedSettings, error) {
 	// Ensure schema_version is set
 	if vs.SchemaVersion == "" {
 		vs.SchemaVersion = "1"
+	}
+
+	// Backward compatibility: old settings files may use hub.grove_id instead of
+	// hub.project_id. Since the struct yaml tag is now "project_id", grove_id
+	// values are not unmarshaled automatically. Check the raw YAML and remap.
+	if vs.Hub == nil || vs.Hub.ProjectID == "" {
+		var raw map[string]interface{}
+		if err := yamlv3.Unmarshal(data, &raw); err == nil {
+			if hub, ok := raw["hub"].(map[string]interface{}); ok {
+				if gid, ok := hub["grove_id"].(string); ok && gid != "" {
+					if vs.Hub == nil {
+						vs.Hub = &V1HubClientConfig{}
+					}
+					vs.Hub.ProjectID = gid
+				}
+			}
+		}
 	}
 
 	return &vs, nil

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -3087,8 +3087,8 @@ hub:
 	version, _ := DetectSettingsFormat(data)
 	assert.Equal(t, "1", version, "legacy file should be migrated to v1 after UpdateSetting")
 
-	// Verify the update was applied
-	assert.Contains(t, string(data), "grove_id: my-grove-id")
+	// Verify the update was applied (struct tags now use project_id)
+	assert.Contains(t, string(data), "project_id: my-grove-id")
 
 	// Verify original values were preserved
 	assert.Contains(t, string(data), "active_profile: local")

--- a/pkg/config/v7_fixes_test.go
+++ b/pkg/config/v7_fixes_test.go
@@ -19,7 +19,7 @@ func TestLoadVersionedSettings_ProjectIDRemapping(t *testing.T) {
 	projectDir := filepath.Join(tmpDir, "my-project", ".scion")
 	require.NoError(t, os.MkdirAll(projectDir, 0755))
 
-	// Test SCION_HUB_PROJECT_ID maps correctly and remaps to grove_id
+	// Test SCION_HUB_PROJECT_ID maps correctly to hub.project_id
 	_ = os.Setenv("SCION_HUB_PROJECT_ID", "env-project-id")
 	defer func() { _ = os.Unsetenv("SCION_HUB_PROJECT_ID") }()
 
@@ -27,10 +27,75 @@ func TestLoadVersionedSettings_ProjectIDRemapping(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, vs.Hub)
-	// V1HubClientConfig.ProjectID has koanf:"grove_id" tag,
-	// so it should be populated from SCION_HUB_PROJECT_ID (mapped to hub.project_id)
-	// via our new remapping logic.
+	// V1HubClientConfig.ProjectID has koanf:"project_id" tag,
+	// so it should be populated from SCION_HUB_PROJECT_ID (mapped to hub.project_id).
 	assert.Equal(t, "env-project-id", vs.Hub.ProjectID)
+}
+
+func TestLoadSingleFileVersioned_GroveIDBackwardCompat(t *testing.T) {
+	// Verify that settings files using the legacy grove_id key under hub
+	// are still read correctly after the struct tag migration to project_id.
+	tmpDir := t.TempDir()
+
+	settingsContent := `schema_version: "1"
+hub:
+  endpoint: "https://hub.example.com"
+  grove_id: "legacy-grove-uuid-1234"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "settings.yaml"), []byte(settingsContent), 0644))
+
+	vs, err := LoadSingleFileVersioned(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, vs.Hub)
+	assert.Equal(t, "legacy-grove-uuid-1234", vs.Hub.ProjectID, "grove_id should be read into ProjectID for backward compatibility")
+	assert.Equal(t, "https://hub.example.com", vs.Hub.Endpoint)
+}
+
+func TestLoadVersionedSettings_GroveIDBackwardCompat(t *testing.T) {
+	// Verify that the koanf-based loader also handles grove_id in settings files.
+	tmpDir := t.TempDir()
+
+	originalHome := os.Getenv("HOME")
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+	_ = os.Setenv("HOME", tmpDir)
+
+	globalDir := filepath.Join(tmpDir, ".scion")
+	require.NoError(t, os.MkdirAll(globalDir, 0755))
+
+	settingsContent := `schema_version: "1"
+hub:
+  endpoint: "https://hub.example.com"
+  grove_id: "legacy-grove-uuid-5678"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(globalDir, "settings.yaml"), []byte(settingsContent), 0644))
+
+	projectDir := filepath.Join(tmpDir, "my-project", ".scion")
+	require.NoError(t, os.MkdirAll(projectDir, 0755))
+
+	vs, err := LoadVersionedSettings(projectDir)
+	require.NoError(t, err)
+	require.NotNil(t, vs.Hub)
+	assert.Equal(t, "legacy-grove-uuid-5678", vs.Hub.ProjectID, "grove_id should be remapped to project_id in koanf loading")
+}
+
+func TestSaveVersionedSettings_WritesProjectID(t *testing.T) {
+	// Verify that saving settings now writes project_id (not grove_id) in the YAML output.
+	tmpDir := t.TempDir()
+
+	vs := &VersionedSettings{
+		SchemaVersion: "1",
+		Hub: &V1HubClientConfig{
+			Endpoint:  "https://hub.example.com",
+			ProjectID: "my-project-id",
+		},
+	}
+
+	require.NoError(t, SaveVersionedSettings(tmpDir, vs))
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "settings.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "project_id: my-project-id", "should write project_id, not grove_id")
+	assert.NotContains(t, string(data), "grove_id", "should not write grove_id")
 }
 
 func TestUpdateVersionedSetting_SnakeCaseKeys(t *testing.T) {

--- a/pkg/hubsync/sync.go
+++ b/pkg/hubsync/sync.go
@@ -272,7 +272,7 @@ func EnsureHubReady(projectPath string, opts EnsureHubReadyOptions) (*HubContext
 		} else {
 			// Generate project_id for projects that don't have one
 			projectID = config.GenerateProjectIDForDir(filepath.Dir(resolvedPath))
-			if err := config.UpdateSetting(resolvedPath, "grove_id", projectID, isGlobal); err != nil {
+			if err := config.UpdateSetting(resolvedPath, "project_id", projectID, isGlobal); err != nil {
 				return nil, fmt.Errorf("failed to save project_id: %w", err)
 			}
 			// Reload settings to get the updated project_id
@@ -384,11 +384,11 @@ func EnsureHubReady(projectPath string, opts EnsureHubReadyOptions) (*HubContext
 					case ProjectChoiceLink:
 						// Store the hub project ID separately — don't overwrite
 						// the local project_id.
-						if err := config.UpdateSetting(resolvedPath, "hub.groveId", selectedID, isGlobal); err != nil {
+						if err := config.UpdateSetting(resolvedPath, "hub.projectId", selectedID, isGlobal); err != nil {
 							return nil, fmt.Errorf("failed to save hub project ID: %w", err)
 						}
 						hubCtx.ProjectID = selectedID
-						debugf("Stored hub.groveId: %s", selectedID)
+						debugf("Stored hub.projectId: %s", selectedID)
 					case ProjectChoiceRegisterNew:
 						// Register as new project with the existing local project_id.
 						// The hub will assign its own ID if needed.
@@ -409,7 +409,7 @@ func EnsureHubReady(projectPath string, opts EnsureHubReadyOptions) (*HubContext
 		if err := registerProject(context.Background(), hubCtx, projectName, isGlobal); err != nil {
 			return nil, wrapHubError(fmt.Errorf("failed to register project: %w", err))
 		}
-		// Reload settings to get updated broker ID and hub.groveId
+		// Reload settings to get updated broker ID and hub.projectId
 		settings, err = config.LoadSettings(resolvedPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to reload settings: %w", err)
@@ -1281,7 +1281,7 @@ func registerProject(ctx context.Context, hubCtx *HubContext, projectName string
 	// Don't overwrite project_id — changing it shifts the external config
 	// directory, orphaning settings.
 	if resp.Project.ID != hubCtx.ProjectID {
-		if err := config.UpdateSetting(hubCtx.ProjectPath, "hub.groveId", resp.Project.ID, isGlobal); err != nil {
+		if err := config.UpdateSetting(hubCtx.ProjectPath, "hub.projectId", resp.Project.ID, isGlobal); err != nil {
 			fmt.Printf("Warning: failed to save hub project ID: %v\n", err)
 		} else {
 			hubCtx.ProjectID = resp.Project.ID

--- a/pkg/hubsync/sync.go
+++ b/pkg/hubsync/sync.go
@@ -303,7 +303,7 @@ func EnsureHubReady(projectPath string, opts EnsureHubReadyOptions) (*HubContext
 		brokerID = settings.Hub.BrokerID
 	}
 
-	// Prefer hub.groveId (explicit link to a hub project) over project_id
+	// Prefer hub.projectId (explicit link to a hub project) over project_id
 	// (deterministic local identity). For hub API calls, we need the ID
 	// the hub knows the project by.
 	effectiveProjectID := projectID
@@ -415,7 +415,7 @@ func EnsureHubReady(projectPath string, opts EnsureHubReadyOptions) (*HubContext
 			return nil, fmt.Errorf("failed to reload settings: %w", err)
 		}
 		hubCtx.Settings = settings
-		// Prefer hub.groveId (explicit link) over project_id (deterministic local ID)
+		// Prefer hub.projectId (explicit link) over project_id (deterministic local ID)
 		if hgid := settings.GetHubProjectID(); hgid != "" {
 			hubCtx.ProjectID = hgid
 		} else {

--- a/pkg/hubsync/sync_test.go
+++ b/pkg/hubsync/sync_test.go
@@ -1259,8 +1259,8 @@ server:
 	if !strings.Contains(content, "endpoint") {
 		t.Error("hub.endpoint should be preserved")
 	}
-	if !strings.Contains(content, "grove_id") {
-		t.Error("hub.grove_id should be preserved")
+	if !strings.Contains(content, "project_id") {
+		t.Error("hub.project_id should be preserved")
 	}
 }
 


### PR DESCRIPTION
## Summary

Config write paths in hubsync and config/init still used legacy grove_id/groveId key names when persisting settings. The config reader already supports both old and new names via remapping in pkg/config/koanf.go. This updates the writes to use the canonical project_id/projectId names.

## Changes

- pkg/hubsync/sync.go: 3 write locations changed from grove_id/hub.groveId to project_id/hub.projectId, plus 2 stale comments updated
- pkg/config/init.go: 1 write location changed from grove_id to project_id
- Test expectations updated in pkg/config/init_test.go and pkg/config/init_project_test.go
- Read paths and koanf remapping untouched (backward compatibility preserved)

## Test plan

- go test ./pkg/hubsync/ ./pkg/config/ -v (all pass)
- go vet clean
- Existing projects with grove_id in config files continue to work via koanf remapping

Ref: ptone/scion#701
