### PR TITLE
feat(web): replace native alert/confirm with shared toast and confirmation dialog

### DIFF
--- a/web/src/components/app-shell.ts
+++ b/web/src/components/app-shell.ts
@@ -32,6 +32,7 @@ import './shared/debug-panel.js';
 
 import type { User } from '../shared/types.js';
 import type { AccessDeniedDetail } from '../client/api.js';
+import { showToast } from '../utils/toast.js';
 import { setDocumentTitle, PAGE_TITLE_EVENT } from '../client/page-title.js';
 import type { PageTitleDetail } from '../client/page-title.js';
 
@@ -238,17 +239,7 @@ export class ScionApp extends LitElement {
     const action = detail.action || 'perform this action on';
     const message = `You don't have permission to ${action} this resource.`;
 
-    const alert = Object.assign(document.createElement('sl-alert'), {
-      variant: 'warning',
-      closable: true,
-      duration: 5000,
-    });
-    alert.innerHTML = `
-      <sl-icon name="exclamation-triangle" slot="icon"></sl-icon>
-      ${message}
-    `;
-    document.body.appendChild(alert);
-    void (alert as HTMLElement & { toast(): Promise<void> }).toast();
+    showToast(message, 'warning');
   }
 
   override render() {

--- a/web/src/components/pages/admin-maintenance.ts
+++ b/web/src/components/pages/admin-maintenance.ts
@@ -27,6 +27,7 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 import { apiFetch, extractApiError } from '../../client/api.js';
+import { showToast } from '../../utils/toast.js';
 
 interface MaintenanceOperation {
   id: string;
@@ -1026,7 +1027,7 @@ export class ScionPageAdminMaintenance extends LitElement {
       }
       this.resetAuthAllResult = await response.json();
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to reset auth for all agents');
+      showToast(err instanceof Error ? err.message : 'Failed to reset auth for all agents');
     } finally {
       this.resetAuthAllLoading = false;
     }

--- a/web/src/components/pages/admin-skill-registry-detail.ts
+++ b/web/src/components/pages/admin-skill-registry-detail.ts
@@ -27,6 +27,7 @@ import type { SkillRegistry } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import '../shared/status-badge.js';
 import '../shared/hash-display.js';
+import { showToast } from '../../utils/toast.js';
 
 interface PinnedHash {
   uri: string;
@@ -367,7 +368,7 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
         void this.loadPinnedHashes();
       }
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to save');
+      showToast(err instanceof Error ? err.message : 'Failed to save');
     } finally {
       this.saving = false;
     }
@@ -390,7 +391,7 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
       }
       this.registry = (await res.json()) as SkillRegistry;
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to toggle status');
+      showToast(err instanceof Error ? err.message : 'Failed to toggle status');
     } finally {
       this.actionLoading = { ...this.actionLoading, toggle: false };
     }
@@ -409,7 +410,7 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
       window.history.pushState({}, '', '/admin/skill-registries');
       window.dispatchEvent(new PopStateEvent('popstate'));
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to delete');
+      showToast(err instanceof Error ? err.message : 'Failed to delete');
     } finally {
       this.actionLoading = { ...this.actionLoading, delete: false };
     }
@@ -434,7 +435,7 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
       this.pinHash = '';
       void this.loadPinnedHashes();
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to pin');
+      showToast(err instanceof Error ? err.message : 'Failed to pin');
     } finally {
       this.pinning = false;
     }
@@ -453,7 +454,7 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
       }
       void this.loadPinnedHashes();
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to unpin');
+      showToast(err instanceof Error ? err.message : 'Failed to unpin');
     }
   }
 

--- a/web/src/components/pages/admin-skill-registry-detail.ts
+++ b/web/src/components/pages/admin-skill-registry-detail.ts
@@ -28,6 +28,7 @@ import { apiFetch, extractApiError } from '../../client/api.js';
 import '../shared/status-badge.js';
 import '../shared/hash-display.js';
 import { showToast } from '../../utils/toast.js';
+import { showConfirm } from '../shared/confirm-dialog.js';
 
 interface PinnedHash {
   uri: string;
@@ -400,7 +401,7 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
   // -- Delete --
 
   private async handleDelete(): Promise<void> {
-    if (!confirm('Are you sure you want to delete this registry?')) return;
+    if (!(await showConfirm('Are you sure you want to delete this registry?'))) return;
     this.actionLoading = { ...this.actionLoading, delete: true };
     try {
       const res = await apiFetch(`/api/v1/skill-registries/${this.registryId}`, { method: 'DELETE' });
@@ -442,7 +443,7 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
   }
 
   private async handleUnpin(uri: string): Promise<void> {
-    if (!confirm(`Unpin "${uri}"?`)) return;
+    if (!(await showConfirm(`Unpin "${uri}"?`))) return;
     try {
       const res = await apiFetch(`/api/v1/skill-registries/${this.registryId}/unpin`, {
         method: 'POST',

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -58,6 +58,7 @@ import type { ScionAgentMessageViewer } from '../shared/agent-message-viewer.js'
 import '../shared/hash-display.js';
 import '../shared/quick-message-dialog.js';
 import { showToast } from '../../utils/toast.js';
+import { showConfirm } from '../shared/confirm-dialog.js';
 
 /**
  * Parse a Go-style duration string (e.g. "2h30m", "1h", "45m", "90s") into
@@ -777,7 +778,7 @@ export class ScionPageAgentDetail extends LitElement {
     if (!this.agent) return;
 
     if (action === 'delete') {
-      if (!event?.altKey && !confirm('Are you sure you want to delete this agent?')) {
+      if (!event?.altKey && !(await showConfirm('Are you sure you want to delete this agent?'))) {
         return;
       }
       this.actionLoading = { ...this.actionLoading, delete: true };

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -57,6 +57,7 @@ import '../shared/agent-message-viewer.js';
 import type { ScionAgentMessageViewer } from '../shared/agent-message-viewer.js';
 import '../shared/hash-display.js';
 import '../shared/quick-message-dialog.js';
+import { showToast } from '../../utils/toast.js';
 
 /**
  * Parse a Go-style duration string (e.g. "2h30m", "1h", "45m", "90s") into
@@ -793,7 +794,7 @@ export class ScionPageAgentDetail extends LitElement {
         window.location.href = this.project ? `/projects/${this.project.id}` : '/agents';
       } catch (err) {
         console.error('Failed to delete agent:', err);
-        alert(err instanceof Error ? err.message : 'Failed to delete agent');
+        showToast(err instanceof Error ? err.message : 'Failed to delete agent');
       } finally {
         this.actionLoading = { ...this.actionLoading, delete: false };
       }
@@ -815,7 +816,7 @@ export class ScionPageAgentDetail extends LitElement {
         this.backgroundRefresh();
       } catch (err) {
         console.error('Failed to reset auth:', err);
-        alert(err instanceof Error ? err.message : 'Failed to reset auth');
+        showToast(err instanceof Error ? err.message : 'Failed to reset auth');
       } finally {
         this.actionLoading = { ...this.actionLoading, 'reset-auth': false };
       }
@@ -850,7 +851,7 @@ export class ScionPageAgentDetail extends LitElement {
       this.backgroundRefresh();
     } catch (err) {
       console.error(`Failed to ${action} agent:`, err);
-      alert(err instanceof Error ? err.message : `Failed to ${action} agent`);
+      showToast(err instanceof Error ? err.message : `Failed to ${action} agent`);
       this.backgroundRefresh();
     }
   }

--- a/web/src/components/pages/agents.ts
+++ b/web/src/components/pages/agents.ts
@@ -37,6 +37,7 @@ import '../shared/status-badge.js';
 import '../shared/view-toggle.js';
 import '../shared/agent-tree-view.js';
 import '../shared/quick-message-dialog.js';
+import { showToast } from '../../utils/toast.js';
 
 @customElement('scion-page-agents')
 export class ScionPageAgents extends LitElement {
@@ -495,7 +496,7 @@ export class ScionPageAgents extends LitElement {
         this.backgroundRefresh();
       } catch (err) {
         console.error('Failed to delete agent:', err);
-        alert(err instanceof Error ? err.message : 'Failed to delete agent');
+        showToast(err instanceof Error ? err.message : 'Failed to delete agent');
       } finally {
         this.actionLoading = { ...this.actionLoading, [agentId]: false };
       }
@@ -534,7 +535,7 @@ export class ScionPageAgents extends LitElement {
       this.backgroundRefresh();
     } catch (err) {
       console.error(`Failed to ${action} agent:`, err);
-      alert(err instanceof Error ? err.message : `Failed to ${action} agent`);
+      showToast(err instanceof Error ? err.message : `Failed to ${action} agent`);
       // Roll back optimistic update on failure
       this.backgroundRefresh();
     }
@@ -566,13 +567,13 @@ export class ScionPageAgents extends LitElement {
 
       const result = (await response.json()) as { stopped: number; failed: number };
       if (result.failed > 0) {
-        alert(`Stopped ${result.stopped} agents, ${result.failed} failed.`);
+        showToast(`Stopped ${result.stopped} agents, ${result.failed} failed.`, 'warning');
       }
 
       this.backgroundRefresh();
     } catch (err) {
       console.error('Failed to stop all agents:', err);
-      alert(err instanceof Error ? err.message : 'Failed to stop all agents');
+      showToast(err instanceof Error ? err.message : 'Failed to stop all agents');
       this.backgroundRefresh();
     } finally {
       this.stopAllLoading = false;

--- a/web/src/components/pages/agents.ts
+++ b/web/src/components/pages/agents.ts
@@ -38,6 +38,7 @@ import '../shared/view-toggle.js';
 import '../shared/agent-tree-view.js';
 import '../shared/quick-message-dialog.js';
 import { showToast } from '../../utils/toast.js';
+import { showConfirm } from '../shared/confirm-dialog.js';
 
 @customElement('scion-page-agents')
 export class ScionPageAgents extends LitElement {
@@ -475,7 +476,7 @@ export class ScionPageAgents extends LitElement {
     event?: MouseEvent
   ): Promise<void> {
     if (action === 'delete') {
-      if (!event?.altKey && !confirm('Are you sure you want to delete this agent?')) {
+      if (!event?.altKey && !(await showConfirm('Are you sure you want to delete this agent?'))) {
         return;
       }
       // Show per-button spinner for delete; don't optimistically remove
@@ -546,7 +547,7 @@ export class ScionPageAgents extends LitElement {
   }
 
   private async handleStopAll(): Promise<void> {
-    if (!confirm('Are you sure you want to stop all running agents?')) {
+    if (!(await showConfirm('Are you sure you want to stop all running agents?'))) {
       return;
     }
 

--- a/web/src/components/pages/harness-config-detail.ts
+++ b/web/src/components/pages/harness-config-detail.ts
@@ -37,6 +37,7 @@ import type { FileBrowserDataSource } from '../shared/file-browser.js';
 import { HarnessConfigFileEditorDataSource } from '../shared/file-editor.js';
 import type { FileEditorDataSource } from '../shared/file-editor.js';
 import '../shared/hash-display.js';
+import { showToast } from '../../utils/toast.js';
 
 @customElement('scion-page-harness-config-detail')
 export class ScionPageHarnessConfigDetail extends LitElement {
@@ -1024,7 +1025,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
         this.imageStatus = await resp.json();
       } else {
         const msg = await extractApiError(resp, `HTTP ${resp.status}`);
-        alert(msg);
+        showToast(msg);
       }
     } finally {
       this.imageActionRunning = false;
@@ -1042,7 +1043,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
         await this.recheckImage();
       } else {
         const msg = await extractApiError(resp, `HTTP ${resp.status}`);
-        alert(msg);
+        showToast(msg);
       }
     } finally {
       this.imageActionRunning = false;
@@ -1060,7 +1061,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
         await this.recheckImage();
       } else {
         const msg = await extractApiError(resp, `HTTP ${resp.status}`);
-        alert(msg);
+        showToast(msg);
       }
     } finally {
       this.imageActionRunning = false;

--- a/web/src/components/pages/project-detail.ts
+++ b/web/src/components/pages/project-detail.ts
@@ -42,6 +42,7 @@ import type { FileBrowserDataSource } from '../shared/file-browser.js';
 import { WorkspaceFileEditorDataSource, SharedDirFileEditorDataSource } from '../shared/file-editor.js';
 import type { FileEditorDataSource } from '../shared/file-editor.js';
 import { showToast } from '../../utils/toast.js';
+import { showConfirm } from '../shared/confirm-dialog.js';
 
 type AgentSortField = 'name' | 'status' | 'created' | 'updated';
 type SortDir = 'asc' | 'desc';
@@ -1082,7 +1083,7 @@ export class ScionPageProjectDetail extends LitElement {
     event?: MouseEvent
   ): Promise<void> {
     if (action === 'delete') {
-      if (!event?.altKey && !confirm('Are you sure you want to delete this agent?')) {
+      if (!event?.altKey && !(await showConfirm('Are you sure you want to delete this agent?'))) {
         return;
       }
       this.actionLoading = { ...this.actionLoading, [agentId]: true };
@@ -1294,7 +1295,7 @@ export class ScionPageProjectDetail extends LitElement {
     const confirmMsg = isProjectAdmin
       ? 'Are you sure you want to stop all running agents in this project?'
       : 'Are you sure you want to stop all of your running agents in this project?';
-    if (!confirm(confirmMsg)) {
+    if (!(await showConfirm(confirmMsg))) {
       return;
     }
 

--- a/web/src/components/pages/project-detail.ts
+++ b/web/src/components/pages/project-detail.ts
@@ -41,6 +41,7 @@ import { WorkspaceFileBrowserDataSource, SharedDirFileBrowserDataSource } from '
 import type { FileBrowserDataSource } from '../shared/file-browser.js';
 import { WorkspaceFileEditorDataSource, SharedDirFileEditorDataSource } from '../shared/file-editor.js';
 import type { FileEditorDataSource } from '../shared/file-editor.js';
+import { showToast } from '../../utils/toast.js';
 
 type AgentSortField = 'name' | 'status' | 'created' | 'updated';
 type SortDir = 'asc' | 'desc';
@@ -1101,7 +1102,7 @@ export class ScionPageProjectDetail extends LitElement {
         this.backgroundRefresh();
       } catch (err) {
         console.error('Failed to delete agent:', err);
-        alert(err instanceof Error ? err.message : 'Failed to delete agent');
+        showToast(err instanceof Error ? err.message : 'Failed to delete agent');
       } finally {
         this.actionLoading = { ...this.actionLoading, [agentId]: false };
       }
@@ -1140,7 +1141,7 @@ export class ScionPageProjectDetail extends LitElement {
       this.backgroundRefresh();
     } catch (err) {
       console.error(`Failed to ${action} agent:`, err);
-      alert(err instanceof Error ? err.message : `Failed to ${action} agent`);
+      showToast(err instanceof Error ? err.message : `Failed to ${action} agent`);
       this.backgroundRefresh();
     }
   }
@@ -1314,13 +1315,13 @@ export class ScionPageProjectDetail extends LitElement {
 
       const result = (await response.json()) as { stopped: number; failed: number; scope?: string };
       if (result.failed > 0) {
-        alert(`Stopped ${result.stopped} agents, ${result.failed} failed.`);
+        showToast(`Stopped ${result.stopped} agents, ${result.failed} failed.`, 'warning');
       }
 
       this.backgroundRefresh();
     } catch (err) {
       console.error('Failed to stop agents:', err);
-      alert(err instanceof Error ? err.message : 'Failed to stop agents');
+      showToast(err instanceof Error ? err.message : 'Failed to stop agents');
       this.backgroundRefresh();
     } finally {
       this.stopAllLoading = false;

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -41,6 +41,7 @@ import '../shared/resource-list.js';
 import '../shared/resource-import.js';
 import '../shared/injected-skills-panel.js';
 import '../shared/pre-start-hook-list.js';
+import { showToast } from '../../utils/toast.js';
 
 
 interface ProjectResourceSpec {
@@ -1223,7 +1224,7 @@ export class ScionPageProjectSettings extends LitElement {
       window.dispatchEvent(new PopStateEvent('popstate'));
     } catch (err) {
       console.error('Failed to delete project:', err);
-      alert(err instanceof Error ? err.message : 'Failed to delete project');
+      showToast(err instanceof Error ? err.message : 'Failed to delete project');
     } finally {
       this.deleteLoading = false;
     }

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -42,6 +42,7 @@ import '../shared/resource-import.js';
 import '../shared/injected-skills-panel.js';
 import '../shared/pre-start-hook-list.js';
 import { showToast } from '../../utils/toast.js';
+import { showConfirm } from '../shared/confirm-dialog.js';
 
 
 interface ProjectResourceSpec {
@@ -1201,9 +1202,9 @@ export class ScionPageProjectSettings extends LitElement {
 
     if (
       !event?.altKey &&
-      !confirm(
+      !(await showConfirm(
         `Are you sure you want to delete "${projectName}"?\n\nAll agents in this project will be stopped and deleted.\n\nThis action cannot be undone.`
-      )
+      ))
     ) {
       return;
     }
@@ -1544,7 +1545,7 @@ export class ScionPageProjectSettings extends LitElement {
   }
 
   private async removeGitHubInstallation(): Promise<void> {
-    if (!confirm('Remove GitHub App installation from this project? Agents will fall back to PAT authentication.')) return;
+    if (!(await showConfirm('Remove GitHub App installation from this project? Agents will fall back to PAT authentication.'))) return;
     this.githubAppLoading = true;
     this.githubAppError = null;
     try {
@@ -2226,7 +2227,7 @@ export class ScionPageProjectSettings extends LitElement {
   }
 
   private async handleRemoveBroker(brokerId: string, brokerName: string): Promise<void> {
-    const confirmed = confirm(`Remove broker "${brokerName}" from this project?`);
+    const confirmed = await showConfirm(`Remove broker "${brokerName}" from this project?`);
     if (!confirmed) return;
 
     try {

--- a/web/src/components/pages/skill-detail.ts
+++ b/web/src/components/pages/skill-detail.ts
@@ -31,6 +31,7 @@ import '../shared/status-badge.js';
 import '../shared/hash-display.js';
 import '../shared/skill-publish-dialog.js';
 import { showToast } from '../../utils/toast.js';
+import { showConfirm } from '../shared/confirm-dialog.js';
 
 @customElement('scion-page-skill-detail')
 export class ScionPageSkillDetail extends LitElement {
@@ -495,7 +496,7 @@ export class ScionPageSkillDetail extends LitElement {
   // -- Archive --
 
   private async handleArchive(): Promise<void> {
-    if (!confirm('Are you sure you want to archive this skill?')) return;
+    if (!(await showConfirm('Are you sure you want to archive this skill?'))) return;
     this.actionLoading = { ...this.actionLoading, archive: true };
 
     try {

--- a/web/src/components/pages/skill-detail.ts
+++ b/web/src/components/pages/skill-detail.ts
@@ -30,6 +30,7 @@ import { apiFetch, extractApiError } from '../../client/api.js';
 import '../shared/status-badge.js';
 import '../shared/hash-display.js';
 import '../shared/skill-publish-dialog.js';
+import { showToast } from '../../utils/toast.js';
 
 @customElement('scion-page-skill-detail')
 export class ScionPageSkillDetail extends LitElement {
@@ -485,7 +486,7 @@ export class ScionPageSkillDetail extends LitElement {
       this.editing = false;
     } catch (err) {
       console.error('Failed to save skill:', err);
-      alert(err instanceof Error ? err.message : 'Failed to save skill');
+      showToast(err instanceof Error ? err.message : 'Failed to save skill');
     } finally {
       this.saving = false;
     }
@@ -506,7 +507,7 @@ export class ScionPageSkillDetail extends LitElement {
       window.dispatchEvent(new PopStateEvent('popstate'));
     } catch (err) {
       console.error('Failed to archive skill:', err);
-      alert(err instanceof Error ? err.message : 'Failed to archive skill');
+      showToast(err instanceof Error ? err.message : 'Failed to archive skill');
     } finally {
       this.actionLoading = { ...this.actionLoading, archive: false };
     }
@@ -545,7 +546,7 @@ export class ScionPageSkillDetail extends LitElement {
       void this.loadData();
     } catch (err) {
       console.error('Failed to deprecate version:', err);
-      alert(err instanceof Error ? err.message : 'Failed to deprecate version');
+      showToast(err instanceof Error ? err.message : 'Failed to deprecate version');
     } finally {
       this.deprecateLoading = false;
     }

--- a/web/src/components/pages/terminal.ts
+++ b/web/src/components/pages/terminal.ts
@@ -32,6 +32,7 @@ import { SSEClient } from '../../client/sse-client.js';
 import type { SSEUpdateEvent } from '../../client/sse-client.js';
 import type { StatusType } from '../shared/status-badge.js';
 import '../shared/status-badge.js';
+import { showToast } from '../../utils/toast.js';
 
 // xterm.js imports are client-side only — guarded by typeof check in lifecycle
 // These will be imported dynamically in firstUpdated() since they require DOM APIs
@@ -954,17 +955,19 @@ export class ScionPageTerminal extends LitElement {
 
       if (!response.ok) {
         const msg = await extractApiError(response, 'Failed to run capture auth');
-        alert(msg);
+        showToast(msg);
         return;
       }
 
       const result = await response.json() as { output: string; exitCode: number };
 
       if (result.exitCode === 0) {
-        alert(`Credentials captured successfully.\n\n${result.output}`);
+        showToast('Credentials captured successfully.', 'success');
+        if (result.output) console.log('Capture auth output:', result.output);
         await this.refreshAgentData();
       } else if (result.exitCode === 2) {
-        alert(`No credentials found yet.\n\nAuthenticate first (e.g., run 'agy' inside the container), then try again.\n\n${result.output}`);
+        showToast('No credentials found yet. Authenticate first, then try again.', 'neutral');
+        if (result.output) console.log('Capture auth output:', result.output);
       } else {
         const conflicts: string[] = [];
         for (const m of result.output.matchAll(ScionPageTerminal.SECRET_CONFLICT_RE)) {
@@ -973,12 +976,13 @@ export class ScionPageTerminal extends LitElement {
         if (conflicts.length > 0) {
           this.captureAuthConflicts = conflicts;
         } else {
-          alert(`Capture failed (exit ${result.exitCode}).\n\n${result.output}`);
+          showToast(`Capture failed (exit ${result.exitCode}).`);
+          if (result.output) console.log('Capture auth output:', result.output);
         }
       }
     } catch (err) {
       console.error('Failed to capture auth:', err);
-      alert(err instanceof Error ? err.message : 'Failed to capture auth');
+      showToast(err instanceof Error ? err.message : 'Failed to capture auth');
     } finally {
       this.captureAuthLoading = false;
     }

--- a/web/src/components/shared/confirm-dialog.ts
+++ b/web/src/components/shared/confirm-dialog.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared confirmation dialog.
+ *
+ * Provides an imperative `showConfirm()` function that replaces the native
+ * `confirm()` call with a Shoelace-based modal dialog. Uses `sl-dialog`
+ * internally, consistent with `scion-quick-message-dialog`.
+ *
+ * Usage:
+ *   import { showConfirm } from '../shared/confirm-dialog.js';
+ *
+ *   // Simple — mirrors confirm():
+ *   if (!(await showConfirm('Delete this agent?'))) return;
+ *
+ *   // With the altKey bypass pattern:
+ *   if (!event?.altKey && !(await showConfirm('Delete this agent?'))) return;
+ */
+
+export interface ConfirmOptions {
+  /** Dialog title. Default: "Confirm". */
+  title?: string;
+  /** Label for the confirm button. Default: "Confirm". */
+  confirmText?: string;
+  /** Label for the cancel button. Default: "Cancel". */
+  cancelText?: string;
+  /** Variant for the confirm button. Default: 'danger' (destructive actions). */
+  variant?: 'primary' | 'danger';
+}
+
+/**
+ * Show a confirmation dialog and return a promise that resolves to `true`
+ * (confirmed) or `false` (cancelled / dismissed).
+ */
+export function showConfirm(
+  message: string,
+  options?: ConfirmOptions,
+): Promise<boolean> {
+  const title = options?.title ?? 'Confirm';
+  const confirmText = options?.confirmText ?? 'Confirm';
+  const cancelText = options?.cancelText ?? 'Cancel';
+  const variant = options?.variant ?? 'danger';
+
+  return new Promise<boolean>((resolve) => {
+    const dialog = document.createElement('sl-dialog');
+    dialog.label = title;
+
+    // Prevent closing on overlay click — user must choose a button.
+    dialog.addEventListener('sl-request-close', (e: Event) => {
+      const detail = (e as CustomEvent<{ source: string }>).detail;
+      if (detail?.source === 'overlay') {
+        e.preventDefault();
+        return;
+      }
+      // Escape key or close button → treat as cancel
+      cleanup(false);
+    });
+
+    // Build the message content. Newlines are preserved with <br>.
+    const body = document.createElement('div');
+    body.style.whiteSpace = 'pre-line';
+    body.textContent = message;
+    dialog.appendChild(body);
+
+    // Cancel button
+    const cancelBtn = document.createElement('sl-button');
+    cancelBtn.slot = 'footer';
+    cancelBtn.setAttribute('variant', 'default');
+    cancelBtn.textContent = cancelText;
+    cancelBtn.addEventListener('click', () => cleanup(false));
+    dialog.appendChild(cancelBtn);
+
+    // Confirm button
+    const confirmBtn = document.createElement('sl-button');
+    confirmBtn.slot = 'footer';
+    confirmBtn.setAttribute('variant', variant);
+    confirmBtn.textContent = confirmText;
+    confirmBtn.addEventListener('click', () => cleanup(true));
+    dialog.appendChild(confirmBtn);
+
+    let resolved = false;
+    function cleanup(result: boolean) {
+      if (resolved) return;
+      resolved = true;
+      dialog.open = false;
+      // Wait for the close animation before removing from DOM.
+      dialog.addEventListener(
+        'sl-after-hide',
+        () => {
+          dialog.remove();
+          resolve(result);
+        },
+        { once: true },
+      );
+    }
+
+    document.body.appendChild(dialog);
+    // Open after appending so Shoelace can initialise.
+    requestAnimationFrame(() => {
+      dialog.open = true;
+    });
+  });
+}

--- a/web/src/components/shared/confirm-dialog.ts
+++ b/web/src/components/shared/confirm-dialog.ts
@@ -71,7 +71,7 @@ export function showConfirm(
       cleanup(false);
     });
 
-    // Build the message content. Newlines are preserved with <br>.
+    // Build the message content. Newlines are preserved via CSS white-space.
     const body = document.createElement('div');
     body.style.whiteSpace = 'pre-line';
     body.textContent = message;

--- a/web/src/components/shared/confirm-dialog.ts
+++ b/web/src/components/shared/confirm-dialog.ts
@@ -59,11 +59,12 @@ export function showConfirm(
     const dialog = document.createElement('sl-dialog');
     dialog.label = title;
 
-    // Prevent closing on overlay click — user must choose a button.
+    // Intercept all close requests so cleanup() owns the close exclusively.
     dialog.addEventListener('sl-request-close', (e: Event) => {
+      e.preventDefault();
       const detail = (e as CustomEvent<{ source: string }>).detail;
       if (detail?.source === 'overlay') {
-        e.preventDefault();
+        // Prevent closing on overlay click — user must choose a button.
         return;
       }
       // Escape key or close button → treat as cancel

--- a/web/src/components/shared/env-var-list.ts
+++ b/web/src/components/shared/env-var-list.ts
@@ -31,6 +31,7 @@ import type { EnvVar, ResourceScope, InjectionMode } from '../../shared/types.js
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { resourceStyles } from './resource-styles.js';
 import { showToast } from '../../utils/toast.js';
+import { showConfirm } from './confirm-dialog.js';
 
 @customElement('scion-env-var-list')
 export class ScionEnvVarList extends LitElement {
@@ -168,7 +169,7 @@ export class ScionEnvVarList extends LitElement {
   }
 
   private async handleDelete(envVar: EnvVar, event?: MouseEvent): Promise<void> {
-    if (!event?.altKey && !confirm(`Delete environment variable "${envVar.key}"? This cannot be undone.`)) {
+    if (!event?.altKey && !(await showConfirm(`Delete environment variable "${envVar.key}"? This cannot be undone.`))) {
       return;
     }
 

--- a/web/src/components/shared/env-var-list.ts
+++ b/web/src/components/shared/env-var-list.ts
@@ -30,6 +30,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import type { EnvVar, ResourceScope, InjectionMode } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { resourceStyles } from './resource-styles.js';
+import { showToast } from '../../utils/toast.js';
 
 @customElement('scion-env-var-list')
 export class ScionEnvVarList extends LitElement {
@@ -187,7 +188,7 @@ export class ScionEnvVarList extends LitElement {
       await this.loadEnvVars();
     } catch (err) {
       console.error('Failed to delete environment variable:', err);
-      alert(err instanceof Error ? err.message : 'Failed to delete');
+      showToast(err instanceof Error ? err.message : 'Failed to delete');
     } finally {
       this.deletingKey = null;
     }

--- a/web/src/components/shared/file-browser.ts
+++ b/web/src/components/shared/file-browser.ts
@@ -29,6 +29,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
+import { showConfirm } from './confirm-dialog.js';
 
 // ────────────────────────────────────────────────────────────
 // Types
@@ -921,7 +922,7 @@ export class ScionFileBrowser extends LitElement {
 
   private async handleDelete(filePath: string, event?: MouseEvent): Promise<void> {
     if (!this.dataSource) return;
-    if (!event?.altKey && !confirm(`Delete ${filePath}?`)) return;
+    if (!event?.altKey && !(await showConfirm(`Delete ${filePath}?`))) return;
 
     try {
       await this.dataSource.deleteFile(filePath);

--- a/web/src/components/shared/file-editor.ts
+++ b/web/src/components/shared/file-editor.ts
@@ -34,6 +34,7 @@ import { getLanguageFromPath } from './code-editor.js';
 // Ensure sub-components are registered
 import './code-editor.js';
 import './markdown-preview.js';
+import { showConfirm } from './confirm-dialog.js';
 
 // ────────────────────────────────────────────────────────────
 // Types
@@ -434,9 +435,9 @@ export class ScionFileEditor extends LitElement {
     }
   }
 
-  private handleRevert(): void {
+  private async handleRevert(): Promise<void> {
     if (!this.dirty) return;
-    if (!confirm('Discard unsaved changes?')) return;
+    if (!(await showConfirm('Discard unsaved changes?'))) return;
     this.currentContent = this.originalContent;
     this.error = null;
   }
@@ -445,9 +446,9 @@ export class ScionFileEditor extends LitElement {
     this.showPreview = !this.showPreview;
   }
 
-  private handleClose(): void {
+  private async handleClose(): Promise<void> {
     if (this.dirty) {
-      if (!confirm('You have unsaved changes. Close anyway?')) return;
+      if (!(await showConfirm('You have unsaved changes. Close anyway?'))) return;
     }
 
     this.dispatchEvent(

--- a/web/src/components/shared/gcp-service-account-list.ts
+++ b/web/src/components/shared/gcp-service-account-list.ts
@@ -28,6 +28,7 @@ import type { GCPServiceAccount, GCPVerificationStatus, Capabilities, GCPMintQuo
 import { can } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { resourceStyles } from './resource-styles.js';
+import { showToast } from '../../utils/toast.js';
 
 @customElement('scion-gcp-service-account-list')
 export class ScionGCPServiceAccountList extends LitElement {
@@ -376,7 +377,7 @@ export class ScionGCPServiceAccountList extends LitElement {
       await this.loadAccounts();
     } catch (err) {
       console.error('Failed to delete service account:', err);
-      alert(err instanceof Error ? err.message : 'Failed to delete');
+      showToast(err instanceof Error ? err.message : 'Failed to delete');
     } finally {
       this.deletingId = null;
     }

--- a/web/src/components/shared/gcp-service-account-list.ts
+++ b/web/src/components/shared/gcp-service-account-list.ts
@@ -29,6 +29,7 @@ import { can } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { resourceStyles } from './resource-styles.js';
 import { showToast } from '../../utils/toast.js';
+import { showConfirm } from './confirm-dialog.js';
 
 @customElement('scion-gcp-service-account-list')
 export class ScionGCPServiceAccountList extends LitElement {
@@ -357,7 +358,7 @@ export class ScionGCPServiceAccountList extends LitElement {
   private async handleDelete(account: GCPServiceAccount, event?: MouseEvent): Promise<void> {
     if (
       !event?.altKey &&
-      !confirm(`Delete service account "${account.email}"? This cannot be undone.`)
+      !(await showConfirm(`Delete service account "${account.email}"? This cannot be undone.`))
     ) {
       return;
     }

--- a/web/src/components/shared/group-member-editor.ts
+++ b/web/src/components/shared/group-member-editor.ts
@@ -29,6 +29,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 import type { GroupMember, AdminGroup } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
+import { showToast } from '../../utils/toast.js';
 
 @customElement('scion-group-member-editor')
 export class ScionGroupMemberEditor extends LitElement {
@@ -595,7 +596,7 @@ export class ScionGroupMemberEditor extends LitElement {
       await this.loadMembers();
     } catch (err) {
       console.error('Failed to remove member:', err);
-      alert(err instanceof Error ? err.message : 'Failed to remove member');
+      showToast(err instanceof Error ? err.message : 'Failed to remove member');
     } finally {
       this.removingMember = null;
     }

--- a/web/src/components/shared/group-member-editor.ts
+++ b/web/src/components/shared/group-member-editor.ts
@@ -30,6 +30,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import type { GroupMember, AdminGroup } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { showToast } from '../../utils/toast.js';
+import { showConfirm } from './confirm-dialog.js';
 
 @customElement('scion-group-member-editor')
 export class ScionGroupMemberEditor extends LitElement {
@@ -576,7 +577,7 @@ export class ScionGroupMemberEditor extends LitElement {
 
   private async handleRemoveMember(member: GroupMember): Promise<void> {
     const displayName = member.displayName || member.memberId;
-    if (!confirm(`Remove ${member.memberType} "${displayName}" from this group?`)) {
+    if (!(await showConfirm(`Remove ${member.memberType} "${displayName}" from this group?`))) {
       return;
     }
 

--- a/web/src/components/shared/injected-skills-panel.ts
+++ b/web/src/components/shared/injected-skills-panel.ts
@@ -34,6 +34,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import type { Skill } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { resourceStyles } from './resource-styles.js';
+import { showToast } from '../../utils/toast.js';
 
 export type InjectedSkillsScope = 'project' | 'user' | 'hub';
 
@@ -1266,7 +1267,7 @@ export class ScionInjectedSkillsPanel extends LitElement {
       await this.deleteEntry(row, resolvedIndex);
     } catch (err) {
       console.error('Failed to delete skill:', err);
-      alert(err instanceof Error ? err.message : 'Failed to remove skill');
+      showToast(err instanceof Error ? err.message : 'Failed to remove skill');
     } finally {
       this._deletingIndex = null;
     }

--- a/web/src/components/shared/injected-skills-panel.ts
+++ b/web/src/components/shared/injected-skills-panel.ts
@@ -35,6 +35,7 @@ import type { Skill } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { resourceStyles } from './resource-styles.js';
 import { showToast } from '../../utils/toast.js';
+import { showConfirm } from './confirm-dialog.js';
 
 export type InjectedSkillsScope = 'project' | 'user' | 'hub';
 
@@ -1249,11 +1250,11 @@ export class ScionInjectedSkillsPanel extends LitElement {
 
   private async handleDeleteRow(row: SkillRow, rowIndex: number): Promise<void> {
     const label = row.skillName || row.uri;
-    if (!confirm(`Remove skill "${label}" from this ${this.scope === 'hub' ? 'hub' : this.scope === 'project' ? 'project' : 'profile'}?`)) {
+    if (!(await showConfirm(`Remove skill "${label}" from this ${this.scope === 'hub' ? 'hub' : this.scope === 'project' ? 'project' : 'profile'}?`))) {
       return;
     }
     // Guard against stale rowIndex: a concurrent drag-reorder between the click
-    // and the confirm() call could shift row positions. Re-find the row by its
+    // and the showConfirm() call could shift row positions. Re-find the row by its
     // stable identity (URI + id) before committing the delete.
     let resolvedIndex = rowIndex;
     const currentAtIndex = this.rows[rowIndex];

--- a/web/src/components/shared/pre-start-hook-list.test.ts
+++ b/web/src/components/shared/pre-start-hook-list.test.ts
@@ -242,12 +242,27 @@ describe('scion-pre-start-hook-list', () => {
   it('deletes a hook after confirmation', async () => {
     const calls: RecordedCall[] = [];
     const el = await createComponent([HOOK_ACTIVE, HOOK_ARCHIVED], calls);
-    vi.stubGlobal(
-      'confirm',
-      vi.fn(() => true)
-    );
 
-    await el.handleDelete(HOOK_ARCHIVED);
+    // Start the delete — don't await yet, it blocks on the confirm dialog.
+    const deletePromise = el.handleDelete(HOOK_ARCHIVED);
+
+    // Let requestAnimationFrame fire so the dialog opens.
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Find the confirm dialog that showConfirm() appended to document.body.
+    const dialog = document.body.querySelector('sl-dialog') as HTMLElement;
+    expect(dialog).toBeTruthy();
+
+    // Click the confirm button (second sl-button in the dialog footer).
+    const buttons = dialog.querySelectorAll('sl-button');
+    const confirmBtn = buttons[1] as HTMLElement;
+    confirmBtn.click();
+
+    // happy-dom doesn't fire sl-after-hide automatically — dispatch it so
+    // showConfirm's cleanup completes and the Promise resolves.
+    dialog.dispatchEvent(new Event('sl-after-hide'));
+
+    await deletePromise;
 
     const del = calls.find((c) => c.method === 'DELETE');
     expect(del?.url).toBe('/api/v1/projects/proj-1/pre-start-hooks/hook-2');
@@ -256,12 +271,22 @@ describe('scion-pre-start-hook-list', () => {
   it('does not delete when the confirmation is dismissed', async () => {
     const calls: RecordedCall[] = [];
     const el = await createComponent([HOOK_ACTIVE, HOOK_ARCHIVED], calls);
-    vi.stubGlobal(
-      'confirm',
-      vi.fn(() => false)
-    );
 
-    await el.handleDelete(HOOK_ARCHIVED);
+    const deletePromise = el.handleDelete(HOOK_ARCHIVED);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const dialog = document.body.querySelector('sl-dialog') as HTMLElement;
+    expect(dialog).toBeTruthy();
+
+    // Click the cancel button (first sl-button in the dialog footer).
+    const buttons = dialog.querySelectorAll('sl-button');
+    const cancelBtn = buttons[0] as HTMLElement;
+    cancelBtn.click();
+
+    dialog.dispatchEvent(new Event('sl-after-hide'));
+
+    await deletePromise;
 
     expect(calls.some((c) => c.method === 'DELETE')).toBe(false);
   });

--- a/web/src/components/shared/pre-start-hook-list.ts
+++ b/web/src/components/shared/pre-start-hook-list.ts
@@ -38,6 +38,7 @@ import type { PreStartHook, PreStartHookSummary } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { resourceStyles } from './resource-styles.js';
 import { showToast } from '../../utils/toast.js';
+import { showConfirm } from './confirm-dialog.js';
 
 /** Maximum script size accepted by the hub API (64 KB). */
 const SCRIPT_MAX_BYTES = 64 * 1024;
@@ -440,7 +441,7 @@ export class ScionPreStartHookList extends LitElement {
     const message =
       `Delete pre-start hook "${hook.name}"? This cannot be undone. ` +
       'Existing agents that inherited this hook will continue to run it until recreated.';
-    if (!confirm(message)) {
+    if (!(await showConfirm(message))) {
       return;
     }
     this.busyId = hook.id;

--- a/web/src/components/shared/pre-start-hook-list.ts
+++ b/web/src/components/shared/pre-start-hook-list.ts
@@ -37,6 +37,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import type { PreStartHook, PreStartHookSummary } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { resourceStyles } from './resource-styles.js';
+import { showToast } from '../../utils/toast.js';
 
 /** Maximum script size accepted by the hub API (64 KB). */
 const SCRIPT_MAX_BYTES = 64 * 1024;
@@ -426,7 +427,7 @@ export class ScionPreStartHookList extends LitElement {
       await this.load();
     } catch (err) {
       console.error('Failed to activate pre-start hook:', err);
-      alert(err instanceof Error ? err.message : 'Failed to activate pre-start hook');
+      showToast(err instanceof Error ? err.message : 'Failed to activate pre-start hook');
     } finally {
       this.busyId = null;
     }
@@ -456,7 +457,7 @@ export class ScionPreStartHookList extends LitElement {
       await this.load();
     } catch (err) {
       console.error('Failed to delete pre-start hook:', err);
-      alert(err instanceof Error ? err.message : 'Failed to delete pre-start hook');
+      showToast(err instanceof Error ? err.message : 'Failed to delete pre-start hook');
     } finally {
       this.busyId = null;
     }

--- a/web/src/components/shared/secret-list.ts
+++ b/web/src/components/shared/secret-list.ts
@@ -30,6 +30,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import type { Secret, SecretType, ResourceScope, InjectionMode } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { resourceStyles } from './resource-styles.js';
+import { showToast } from '../../utils/toast.js';
 
 @customElement('scion-secret-list')
 export class ScionSecretList extends LitElement {
@@ -203,7 +204,7 @@ export class ScionSecretList extends LitElement {
       await this.loadSecrets();
     } catch (err) {
       console.error('Failed to delete secret:', err);
-      alert(err instanceof Error ? err.message : 'Failed to delete');
+      showToast(err instanceof Error ? err.message : 'Failed to delete');
     } finally {
       this.deletingKey = null;
     }

--- a/web/src/components/shared/secret-list.ts
+++ b/web/src/components/shared/secret-list.ts
@@ -31,6 +31,7 @@ import type { Secret, SecretType, ResourceScope, InjectionMode } from '../../sha
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { resourceStyles } from './resource-styles.js';
 import { showToast } from '../../utils/toast.js';
+import { showConfirm } from './confirm-dialog.js';
 
 @customElement('scion-secret-list')
 export class ScionSecretList extends LitElement {
@@ -184,7 +185,7 @@ export class ScionSecretList extends LitElement {
   }
 
   private async handleDelete(secret: Secret, event?: MouseEvent): Promise<void> {
-    if (!event?.altKey && !confirm(`Delete secret "${secret.key}"? This cannot be undone.`)) {
+    if (!event?.altKey && !(await showConfirm(`Delete secret "${secret.key}"? This cannot be undone.`))) {
       return;
     }
 

--- a/web/src/components/shared/shared-dir-list.ts
+++ b/web/src/components/shared/shared-dir-list.ts
@@ -29,6 +29,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import type { SharedDir } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { resourceStyles } from './resource-styles.js';
+import { showToast } from '../../utils/toast.js';
 
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
 
@@ -176,7 +177,7 @@ export class ScionSharedDirList extends LitElement {
       await this.loadSharedDirs();
     } catch (err) {
       console.error('Failed to delete shared directory:', err);
-      alert(err instanceof Error ? err.message : 'Failed to delete');
+      showToast(err instanceof Error ? err.message : 'Failed to delete');
     } finally {
       this.deletingName = null;
     }

--- a/web/src/components/shared/shared-dir-list.ts
+++ b/web/src/components/shared/shared-dir-list.ts
@@ -30,6 +30,7 @@ import type { SharedDir } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { resourceStyles } from './resource-styles.js';
 import { showToast } from '../../utils/toast.js';
+import { showConfirm } from './confirm-dialog.js';
 
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
 
@@ -155,9 +156,9 @@ export class ScionSharedDirList extends LitElement {
   private async handleDelete(dir: SharedDir, event?: MouseEvent): Promise<void> {
     if (
       !event?.altKey &&
-      !confirm(
+      !(await showConfirm(
         `Remove shared directory "${dir.name}" from this project?\n\nThis removes the configuration. Host-side data may still exist.`
-      )
+      ))
     ) {
       return;
     }

--- a/web/src/components/shared/token-list.ts
+++ b/web/src/components/shared/token-list.ts
@@ -28,6 +28,7 @@ import { customElement, state } from 'lit/decorators.js';
 import type { Project } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { resourceStyles } from './resource-styles.js';
+import { showToast } from '../../utils/toast.js';
 
 interface AccessToken {
   id: string;
@@ -360,7 +361,7 @@ export class ScionTokenList extends LitElement {
       await this.loadData();
     } catch (err) {
       console.error('Failed to revoke token:', err);
-      alert(err instanceof Error ? err.message : 'Failed to revoke');
+      showToast(err instanceof Error ? err.message : 'Failed to revoke');
     } finally {
       this.actionLoadingId = null;
     }
@@ -384,7 +385,7 @@ export class ScionTokenList extends LitElement {
       await this.loadData();
     } catch (err) {
       console.error('Failed to delete token:', err);
-      alert(err instanceof Error ? err.message : 'Failed to delete');
+      showToast(err instanceof Error ? err.message : 'Failed to delete');
     } finally {
       this.actionLoadingId = null;
     }

--- a/web/src/components/shared/token-list.ts
+++ b/web/src/components/shared/token-list.ts
@@ -29,6 +29,7 @@ import type { Project } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { resourceStyles } from './resource-styles.js';
 import { showToast } from '../../utils/toast.js';
+import { showConfirm } from './confirm-dialog.js';
 
 interface AccessToken {
   id: string;
@@ -344,7 +345,7 @@ export class ScionTokenList extends LitElement {
   // ── Revoke / Delete ────────────────────────────────────────────────
 
   private async handleRevoke(token: AccessToken): Promise<void> {
-    if (!confirm(`Revoke token "${token.name}"? It will no longer be usable for authentication.`)) {
+    if (!(await showConfirm(`Revoke token "${token.name}"? It will no longer be usable for authentication.`))) {
       return;
     }
 
@@ -368,7 +369,7 @@ export class ScionTokenList extends LitElement {
   }
 
   private async handleDelete(token: AccessToken): Promise<void> {
-    if (!confirm(`Permanently delete token "${token.name}"? This cannot be undone.`)) {
+    if (!(await showConfirm(`Permanently delete token "${token.name}"? This cannot be undone.`))) {
       return;
     }
 

--- a/web/src/utils/toast.ts
+++ b/web/src/utils/toast.ts
@@ -58,7 +58,7 @@ const DEFAULT_DURATIONS: Record<ToastVariant, number> = {
 /**
  * Show a toast notification using Shoelace's built-in toast stack.
  *
- * @param message  The text to display. HTML is escaped automatically.
+ * @param message  The text to display.
  * @param variant  Visual style — defaults to `'danger'` (most calls are errors).
  * @param options  Optional overrides for icon, duration, and closable state.
  */
@@ -83,22 +83,11 @@ export function showToast(
   iconEl.setAttribute('slot', 'icon');
   alert.appendChild(iconEl);
 
-  // Append escaped message text.
-  const escaped = escapeHtml(message);
+  // Append message text.
   const span = document.createElement('span');
-  span.innerHTML = escaped;
+  span.textContent = message;
   alert.appendChild(span);
 
   document.body.appendChild(alert);
   void (alert as HTMLElement & { toast(): Promise<void> }).toast();
-}
-
-/** Minimal HTML escaping for user-supplied message text. */
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
 }

--- a/web/src/utils/toast.ts
+++ b/web/src/utils/toast.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared toast notification utility.
+ *
+ * Wraps Shoelace's `sl-alert.toast()` to provide a consistent, non-blocking
+ * notification surface across the entire frontend. Replaces native `alert()`.
+ */
+
+export type ToastVariant =
+  | 'primary'
+  | 'success'
+  | 'neutral'
+  | 'warning'
+  | 'danger';
+
+export interface ToastOptions {
+  /** Shoelace icon name. Defaults to a variant-appropriate icon. */
+  icon?: string;
+  /** Auto-dismiss duration in ms. Defaults vary by variant. */
+  duration?: number;
+  /** Show a close button. Default true. */
+  closable?: boolean;
+}
+
+/** Maps variant to a sensible default icon (Bootstrap Icons via Shoelace). */
+const DEFAULT_ICONS: Record<ToastVariant, string> = {
+  danger: 'exclamation-octagon',
+  warning: 'exclamation-triangle',
+  success: 'check-circle',
+  neutral: 'info-circle',
+  primary: 'info-circle',
+};
+
+/** Default auto-dismiss durations in ms, per variant. */
+const DEFAULT_DURATIONS: Record<ToastVariant, number> = {
+  danger: 8000,
+  warning: 6000,
+  success: 3000,
+  neutral: 5000,
+  primary: 5000,
+};
+
+/**
+ * Show a toast notification using Shoelace's built-in toast stack.
+ *
+ * @param message  The text to display. HTML is escaped automatically.
+ * @param variant  Visual style — defaults to `'danger'` (most calls are errors).
+ * @param options  Optional overrides for icon, duration, and closable state.
+ */
+export function showToast(
+  message: string,
+  variant: ToastVariant = 'danger',
+  options?: ToastOptions,
+): void {
+  const icon = options?.icon ?? DEFAULT_ICONS[variant];
+  const duration = options?.duration ?? DEFAULT_DURATIONS[variant];
+  const closable = options?.closable ?? true;
+
+  const alert = Object.assign(document.createElement('sl-alert'), {
+    variant,
+    closable,
+    duration,
+  });
+
+  // Build inner HTML with icon + escaped message text.
+  const escaped = escapeHtml(message);
+  alert.innerHTML = `
+    <sl-icon name="${icon}" slot="icon"></sl-icon>
+    ${escaped}
+  `;
+
+  document.body.appendChild(alert);
+  void (alert as HTMLElement & { toast(): Promise<void> }).toast();
+}
+
+/** Minimal HTML escaping for user-supplied message text. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}

--- a/web/src/utils/toast.ts
+++ b/web/src/utils/toast.ts
@@ -88,6 +88,12 @@ export function showToast(
   span.textContent = message;
   alert.appendChild(span);
 
+  // Remove the alert element from the DOM after it hides to prevent
+  // accumulation — same pattern used in confirm-dialog.ts.
+  alert.addEventListener('sl-after-hide', () => {
+    alert.remove();
+  }, { once: true });
+
   document.body.appendChild(alert);
   void (alert as HTMLElement & { toast(): Promise<void> }).toast();
 }

--- a/web/src/utils/toast.ts
+++ b/web/src/utils/toast.ts
@@ -77,12 +77,17 @@ export function showToast(
     duration,
   });
 
-  // Build inner HTML with icon + escaped message text.
+  // Build icon element via DOM API to avoid interpolating into innerHTML.
+  const iconEl = document.createElement('sl-icon');
+  iconEl.setAttribute('name', icon);
+  iconEl.setAttribute('slot', 'icon');
+  alert.appendChild(iconEl);
+
+  // Append escaped message text.
   const escaped = escapeHtml(message);
-  alert.innerHTML = `
-    <sl-icon name="${icon}" slot="icon"></sl-icon>
-    ${escaped}
-  `;
+  const span = document.createElement('span');
+  span.innerHTML = escaped;
+  alert.appendChild(span);
 
   document.body.appendChild(alert);
   void (alert as HTMLElement & { toast(): Promise<void> }).toast();


### PR DESCRIPTION
Replaces all native alert() and confirm() calls in the web frontend with shared Shoelace-based showToast() and showConfirm() utilities. 22 files changed, 39 alert and 23 confirm calls migrated. Ref: ptone/scion#352