### PR TITLE
feat(harness): auto-detect and expose listening ports in agent containers

### DIFF
--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -618,7 +618,7 @@ func TestSendOutboundMessageViaHub(t *testing.T) {
 		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 		case r.Method == http.MethodPost && (r.URL.Path == "/api/v1/projects/"+projectID+"/agents/my-agent/outbound-message" ||
-				r.URL.Path == "/api/v1/groves/"+projectID+"/agents/my-agent/outbound-message"):
+			r.URL.Path == "/api/v1/groves/"+projectID+"/agents/my-agent/outbound-message"):
 			var msg hubclient.OutboundMessageRequest
 			_ = json.NewDecoder(r.Body).Decode(&msg)
 			receivedMsg = &msg

--- a/cmd/sciontool/commands/expose.go
+++ b/cmd/sciontool/commands/expose.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/autoexpose"
 	scionhub "github.com/GoogleCloudPlatform/scion/pkg/sciontool/hub"
 	"github.com/spf13/cobra"
 )
@@ -34,6 +36,16 @@ var (
 var exposeCmd = &cobra.Command{
 	Use:   "expose [port]",
 	Short: "Expose an agent-local HTTP port through the Hub",
+	Long: `Expose an agent-local HTTP port through the Hub so it can be accessed
+via the Hub's proxy endpoint.
+
+Ports can also be auto-exposed by setting SCION_AUTO_EXPOSE_PORTS=true in the
+agent's environment. When auto-expose is enabled, listening TCP ports are
+automatically detected and registered with the Hub. Use SCION_AUTO_EXPOSE_MODE
+to control filtering (allowlist or denylist) and SCION_AUTO_EXPOSE_PORTS_LIST
+to specify the port list for the active filter mode.
+
+Use --list to see all currently exposed ports and the auto-expose status.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client := scionhub.NewClient()
 		if client == nil || !client.IsConfigured() {
@@ -42,6 +54,14 @@ var exposeCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 		defer cancel()
 		if exposeList {
+			// Print auto-expose status header.
+			cfg := autoexpose.ConfigFromEnv()
+			if cfg.Enabled {
+				_, _ = fmt.Fprintf(os.Stdout, "Auto-expose: enabled (mode: %s, interval: %s)\n", cfg.FilterMode, cfg.Interval)
+			} else {
+				_, _ = fmt.Fprintln(os.Stdout, "Auto-expose: disabled")
+			}
+
 			ports, err := client.ListPorts(ctx)
 			if err != nil {
 				return err
@@ -72,6 +92,23 @@ var exposeCmd = &cobra.Command{
 			Host:  exposeHost,
 		})
 		if err != nil {
+			// Treat 409 Conflict (already registered) as success — idempotent expose.
+			if strings.Contains(err.Error(), "error 409:") {
+				// Port is already registered; fetch current info to display.
+				ports, listErr := client.ListPorts(ctx)
+				if listErr != nil {
+					_, _ = fmt.Fprintf(os.Stdout, "Port %d is already exposed.\n", port)
+					return nil
+				}
+				for _, p := range ports {
+					if p.Port == port {
+						_, _ = fmt.Fprintf(os.Stdout, "Port %d is already exposed.\nURL: %s\nBase path: %s\n", p.Port, p.URL, p.BasePath)
+						return nil
+					}
+				}
+				_, _ = fmt.Fprintf(os.Stdout, "Port %d is already exposed.\n", port)
+				return nil
+			}
 			return err
 		}
 		_, _ = fmt.Fprintf(os.Stdout, "Port %d exposed.\nURL: %s\nBase path: %s\n", resp.Port, resp.URL, resp.BasePath)
@@ -82,7 +119,15 @@ var exposeCmd = &cobra.Command{
 var unexposeCmd = &cobra.Command{
 	Use:   "unexpose <port>",
 	Short: "Stop exposing an agent-local HTTP port through the Hub",
-	Args:  cobra.ExactArgs(1),
+	Long: `Stop exposing an agent-local HTTP port through the Hub.
+
+If the port is not currently exposed, this command succeeds silently. This
+makes it safe to call repeatedly (idempotent).
+
+Note: if auto-expose is enabled (SCION_AUTO_EXPOSE_PORTS=true), an unexposed
+port may be re-exposed automatically on the next scan cycle if it is still
+listening and passes the filter rules.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client := scionhub.NewClient()
 		if client == nil || !client.IsConfigured() {
@@ -95,6 +140,11 @@ var unexposeCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 		defer cancel()
 		if err := client.DeletePort(ctx, port); err != nil {
+			// Treat 404 (not found) as success — idempotent unexpose.
+			if strings.Contains(err.Error(), "error 404:") {
+				_, _ = fmt.Fprintf(os.Stdout, "Port %d is not currently exposed.\n", port)
+				return nil
+			}
 			return err
 		}
 		_, _ = fmt.Fprintf(os.Stdout, "Port %d unexposed.\n", port)

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/autoexpose"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hooks"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hooks/handlers"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hub"
@@ -564,6 +565,12 @@ func runInit(args []string) int {
 
 			go scionportforward.NewManager(hubClient).Run(ctx)
 			log.Info("Started port-forward tunnel manager")
+
+			// Auto-expose: detect and register listening ports
+			if autoExposeCfg := autoexpose.ConfigFromEnv(); autoExposeCfg.Enabled {
+				go autoexpose.NewReconciler(hubClient, autoExposeCfg).Run(ctx)
+				log.Info("Started auto-expose port scanner (interval: %s, mode: %s)", autoExposeCfg.Interval, autoExposeCfg.FilterMode)
+			}
 
 			// Read the agent token from the canonical token file (written by
 			// the host-side agent manager before the container started).

--- a/pkg/config/opsettings/registry.go
+++ b/pkg/config/opsettings/registry.go
@@ -82,6 +82,13 @@ func init() {
 			New: func() any { return &TelemetrySettings{} },
 		},
 		{
+			Name: "auto_expose_ports",
+			KoanfPaths: []string{
+				"auto_expose_ports.enabled",
+			},
+			New: func() any { return &AutoExposePortsSettings{} },
+		},
+		{
 			Name: "agent_defaults",
 			KoanfPaths: []string{
 				"default_template", "default_harness_config",
@@ -261,6 +268,13 @@ func compileSchemas() {
 			"properties": map[string]interface{}{
 				"admin_mode":          map[string]interface{}{"type": "boolean"},
 				"maintenance_message": map[string]interface{}{"type": "string"},
+			},
+			"additionalProperties": false,
+		},
+		"auto_expose_ports": {
+			"type": "object",
+			"properties": map[string]interface{}{
+				"enabled": map[string]interface{}{"type": "boolean"},
 			},
 			"additionalProperties": false,
 		},

--- a/pkg/config/opsettings/sections.go
+++ b/pkg/config/opsettings/sections.go
@@ -49,6 +49,11 @@ type TelemetrySettings struct {
 	config.V1TelemetryConfig
 }
 
+// AutoExposePortsSettings holds Layer-1 auto-expose ports configuration.
+type AutoExposePortsSettings struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
 // AgentDefaultsSettings holds Layer-1 default agent configuration.
 type AgentDefaultsSettings struct {
 	DefaultTemplate      string            `json:"default_template,omitempty"`

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -431,11 +431,7 @@ func (s *Server) populateAgentConfig(ctx context.Context, agent *store.Agent, pr
 					agent.AppliedConfig.InlineConfig.Env = make(map[string]string)
 				}
 				if _, exists := agent.AppliedConfig.InlineConfig.Env["SCION_AUTO_EXPOSE_PORTS"]; !exists {
-					if enabled {
-						agent.AppliedConfig.InlineConfig.Env["SCION_AUTO_EXPOSE_PORTS"] = "true"
-					} else {
-						agent.AppliedConfig.InlineConfig.Env["SCION_AUTO_EXPOSE_PORTS"] = "false"
-					}
+					agent.AppliedConfig.InlineConfig.Env["SCION_AUTO_EXPOSE_PORTS"] = strconv.FormatBool(enabled)
 				}
 			}
 		}

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -417,6 +417,30 @@ func (s *Server) populateAgentConfig(ctx context.Context, agent *store.Agent, pr
 		}
 	}
 
+	// Apply project-level AutoExposePortsEnabled override.
+	// Only set the env var if the agent's own config does not already specify it,
+	// so agent-level settings take priority over project-level.
+	if project != nil && project.Annotations != nil {
+		if val, ok := project.Annotations[projectSettingAutoExposePortsEnabled]; ok {
+			enabled, err := strconv.ParseBool(val)
+			if err == nil {
+				if agent.AppliedConfig.InlineConfig == nil {
+					agent.AppliedConfig.InlineConfig = &api.ScionConfig{}
+				}
+				if agent.AppliedConfig.InlineConfig.Env == nil {
+					agent.AppliedConfig.InlineConfig.Env = make(map[string]string)
+				}
+				if _, exists := agent.AppliedConfig.InlineConfig.Env["SCION_AUTO_EXPOSE_PORTS"]; !exists {
+					if enabled {
+						agent.AppliedConfig.InlineConfig.Env["SCION_AUTO_EXPOSE_PORTS"] = "true"
+					} else {
+						agent.AppliedConfig.InlineConfig.Env["SCION_AUTO_EXPOSE_PORTS"] = "false"
+					}
+				}
+			}
+		}
+	}
+
 	// Merge injected skills from hub/user/project scopes into InlineConfig.Skills
 	// so the provisioner's existing Step 3b handles them.
 	s.mergeInjectedSkills(ctx, agent, project)

--- a/pkg/hub/handlers_public_settings.go
+++ b/pkg/hub/handlers_public_settings.go
@@ -20,7 +20,8 @@ import (
 
 // PublicSettingsResponse contains non-sensitive server settings for the web UI.
 type PublicSettingsResponse struct {
-	TelemetryEnabled bool `json:"telemetryEnabled"`
+	TelemetryEnabled       bool `json:"telemetryEnabled"`
+	AutoExposePortsEnabled bool `json:"autoExposePortsEnabled"`
 }
 
 func (s *Server) handlePublicSettings(w http.ResponseWriter, r *http.Request) {
@@ -29,12 +30,18 @@ func (s *Server) handlePublicSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	enabled := false
+	telemetryEnabled := false
 	if s.config.TelemetryDefault != nil {
-		enabled = *s.config.TelemetryDefault
+		telemetryEnabled = *s.config.TelemetryDefault
+	}
+
+	autoExposePortsEnabled := false
+	if s.config.AutoExposePortsDefault != nil {
+		autoExposePortsEnabled = *s.config.AutoExposePortsDefault
 	}
 
 	writeJSON(w, http.StatusOK, PublicSettingsResponse{
-		TelemetryEnabled: enabled,
+		TelemetryEnabled:       telemetryEnabled,
+		AutoExposePortsEnabled: autoExposePortsEnabled,
 	})
 }

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -85,6 +85,9 @@ type Layer1Snapshot struct {
 	TelemetryEnabled *bool
 	TelemetryConfig  *config.V1TelemetryConfig
 
+	// Auto-expose ports
+	AutoExposePortsEnabled *bool
+
 	// Agent defaults
 	DefaultTemplate      string
 	DefaultHarnessConfig string
@@ -567,6 +570,12 @@ func buildSnapshotFromKoanf(k *koanf.Koanf) Layer1Snapshot {
 		v := k.Bool("telemetry.enabled")
 		snap.TelemetryEnabled = &v
 	}
+
+	// Auto-expose ports
+	if k.Exists("auto_expose_ports.enabled") {
+		v := k.Bool("auto_expose_ports.enabled")
+		snap.AutoExposePortsEnabled = &v
+	}
 	teleSub := k.Cut("telemetry")
 	if teleSub != nil && len(teleSub.Keys()) > 0 {
 		data, err := json.Marshal(teleSub.Raw())
@@ -684,6 +693,15 @@ func ApplySnapshot(s *Server, snap Layer1Snapshot) map[string]interface{} {
 	if snap.TelemetryConfig != nil {
 		s.config.TelemetryConfig = config.ConvertV1TelemetryToAPI(snap.TelemetryConfig)
 		applied = append(applied, "telemetry_config")
+	}
+
+	// Auto-expose ports
+	if snap.AutoExposePortsEnabled != nil {
+		oldVal := s.config.AutoExposePortsDefault
+		s.config.AutoExposePortsDefault = snap.AutoExposePortsEnabled
+		if oldVal == nil || *oldVal != *snap.AutoExposePortsEnabled {
+			applied = append(applied, "auto_expose_ports_default")
+		}
 	}
 
 	// Admin emails

--- a/pkg/hub/port_forward_handlers.go
+++ b/pkg/hub/port_forward_handlers.go
@@ -42,8 +42,12 @@ const (
 	maxConcurrentStreams    = 64
 )
 
+// deniedExposedPorts lists infrastructure ports that agents may not expose.
+// Port 8080 is intentionally excluded: the reverse tunnel architecture means
+// the agent-side port never collides with the hub listener, and in deployments
+// where the hub API is served behind a load balancer on a different port,
+// path-based forwarding on 8080 is valid.
 var deniedExposedPorts = map[int]string{
-	8080:  "scion web server",
 	9810:  "scion hub API",
 	18380: "scion metadata server",
 }

--- a/pkg/hub/project_settings_handlers.go
+++ b/pkg/hub/project_settings_handlers.go
@@ -29,12 +29,13 @@ import (
 // When adding a key here, add it to projectSettingKeys below as well.
 // TestProjectSettingKeys_NoDrift enforces this.
 const (
-	projectSettingDefaultTemplate      = "scion.io/default-template"
-	projectSettingDefaultHarnessConfig = "scion.io/default-harness-config"
-	projectSettingDefaultModel         = "scion.io/default-model"
-	projectSettingDefaultThinkingLevel = "scion.io/default-thinking-level"
-	projectSettingTelemetryEnabled     = "scion.io/telemetry-enabled"
-	projectSettingActiveProfile        = "scion.io/active-profile"
+	projectSettingDefaultTemplate        = "scion.io/default-template"
+	projectSettingDefaultHarnessConfig   = "scion.io/default-harness-config"
+	projectSettingDefaultModel           = "scion.io/default-model"
+	projectSettingDefaultThinkingLevel   = "scion.io/default-thinking-level"
+	projectSettingTelemetryEnabled       = "scion.io/telemetry-enabled"
+	projectSettingAutoExposePortsEnabled = "scion.io/auto-expose-ports-enabled"
+	projectSettingActiveProfile          = "scion.io/active-profile"
 
 	// Default agent limits
 	projectSettingDefaultMaxTurns      = "scion.io/default-max-turns"
@@ -118,6 +119,7 @@ var projectSettingKeys = []string{
 	projectSettingDefaultModel,
 	projectSettingDefaultThinkingLevel,
 	projectSettingTelemetryEnabled,
+	projectSettingAutoExposePortsEnabled,
 	projectSettingActiveProfile,
 
 	// Default agent limits
@@ -240,6 +242,12 @@ func projectSettingsFromAnnotations(project *store.Project) *hubclient.ProjectSe
 		}
 	}
 
+	if val, ok := project.Annotations[projectSettingAutoExposePortsEnabled]; ok {
+		if b, err := strconv.ParseBool(val); err == nil {
+			settings.AutoExposePortsEnabled = &b
+		}
+	}
+
 	// Default agent limits
 	if val, ok := project.Annotations[projectSettingDefaultMaxTurns]; ok {
 		if n, err := strconv.Atoi(val); err == nil {
@@ -309,6 +317,12 @@ func applyProjectSettingsToAnnotations(project *store.Project, settings *hubclie
 		project.Annotations[projectSettingTelemetryEnabled] = strconv.FormatBool(*settings.TelemetryEnabled)
 	} else {
 		delete(project.Annotations, projectSettingTelemetryEnabled)
+	}
+
+	if settings.AutoExposePortsEnabled != nil {
+		project.Annotations[projectSettingAutoExposePortsEnabled] = strconv.FormatBool(*settings.AutoExposePortsEnabled)
+	} else {
+		delete(project.Annotations, projectSettingAutoExposePortsEnabled)
 	}
 
 	// Default GCP identity

--- a/pkg/hub/project_settings_registry_test.go
+++ b/pkg/hub/project_settings_registry_test.go
@@ -38,7 +38,7 @@ const projectSettingsSourceFile = "project_settings_handlers.go"
 // .design/project-templates.md §3.1. It is asserted separately from the drift
 // guard so that adding or removing a setting shows up as a deliberate edit in
 // the diff rather than passing silently.
-const expectedProjectSettingCount = 16
+const expectedProjectSettingCount = 17
 
 // isProjectSettingConstName reports whether an identifier names a project
 // settings annotation key constant.

--- a/pkg/hub/project_settings_resolved.go
+++ b/pkg/hub/project_settings_resolved.go
@@ -171,6 +171,10 @@ const (
 	// agent_defaults has no telemetry field would be a false statement about a
 	// question asked of the wrong source.
 	hubSourceTelemetryDefault
+
+	// hubSourceAutoExposePortsDefault: Server.config.AutoExposePortsDefault,
+	// which is a *bool and therefore presence-faithful.
+	hubSourceAutoExposePortsDefault
 )
 
 // resolvedSettingDescriptor carries the per-key knowledge that the annotation
@@ -244,6 +248,9 @@ var resolvedSettingDescriptors = map[string]resolvedSettingDescriptor{
 	},
 	projectSettingTelemetryEnabled: {
 		source: hubSourceTelemetryDefault,
+	},
+	projectSettingAutoExposePortsEnabled: {
+		source: hubSourceAutoExposePortsDefault,
 	},
 	projectSettingActiveProfile: {
 		source: hubSourceNone,
@@ -422,6 +429,13 @@ func (s *Server) hubDefaultFor(
 		// is a nil pointer either way.
 		if s.config.TelemetryDefault != nil {
 			return ResolvedHubDefaultPresent, *s.config.TelemetryDefault
+		}
+		return ResolvedHubDefaultAbsent, nil
+
+	case hubSourceAutoExposePortsDefault:
+		// *bool — same presence-faithful pattern as TelemetryDefault.
+		if s.config.AutoExposePortsDefault != nil {
+			return ResolvedHubDefaultPresent, *s.config.AutoExposePortsDefault
 		}
 		return ResolvedHubDefaultAbsent, nil
 

--- a/pkg/hub/project_settings_resolved_guard_test.go
+++ b/pkg/hub/project_settings_resolved_guard_test.go
@@ -883,7 +883,7 @@ func TestResolvedSettings_DescriptorsWellFormed(t *testing.T) {
 			assert.NotEmptyf(t, desc.path,
 				"descriptor %q reads agent_defaults but has no path, so it can never "+
 					"report anything but unknown", key)
-		case hubSourceNone, hubSourceTelemetryDefault:
+		case hubSourceNone, hubSourceTelemetryDefault, hubSourceAutoExposePortsDefault:
 			assert.Emptyf(t, desc.path,
 				"descriptor %q does not read agent_defaults but carries a path %v, "+
 					"which is never used and is therefore misleading", key, desc.path)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -145,6 +145,9 @@ type ServerConfig struct {
 	// TelemetryDefault is the default telemetry enabled state for new agents.
 	// Exposed via GET /api/v1/settings/public so the web UI can pre-populate the checkbox.
 	TelemetryDefault *bool
+	// AutoExposePortsDefault is the default auto-expose-ports enabled state for new agents.
+	// Exposed via GET /api/v1/settings/public so the web UI can pre-populate the checkbox.
+	AutoExposePortsDefault *bool
 	// TelemetryConfig is the full hub-level telemetry config from settings.yaml.
 	// Used to populate default telemetry config on new agents when no per-agent
 	// or template-level telemetry config is set.

--- a/pkg/hubclient/types.go
+++ b/pkg/hubclient/types.go
@@ -199,16 +199,17 @@ type ProjectProvider struct {
 
 // ProjectSettings represents project configuration settings.
 type ProjectSettings struct {
-	ActiveProfile        string                 `json:"activeProfile,omitempty"`
-	DefaultTemplate      string                 `json:"defaultTemplate,omitempty"`
-	DefaultHarnessConfig string                 `json:"defaultHarnessConfig,omitempty"`
-	DefaultModel         string                 `json:"defaultModel,omitempty"`
-	DefaultThinkingLevel *int                   `json:"defaultThinkingLevel,omitempty"`
-	TelemetryEnabled     *bool                  `json:"telemetryEnabled,omitempty"`
-	Bucket               *BucketConfig          `json:"bucket,omitempty"`
-	Runtimes             map[string]interface{} `json:"runtimes,omitempty"`
-	Harnesses            map[string]interface{} `json:"harnesses,omitempty"`
-	Profiles             map[string]interface{} `json:"profiles,omitempty"`
+	ActiveProfile          string                 `json:"activeProfile,omitempty"`
+	DefaultTemplate        string                 `json:"defaultTemplate,omitempty"`
+	DefaultHarnessConfig   string                 `json:"defaultHarnessConfig,omitempty"`
+	DefaultModel           string                 `json:"defaultModel,omitempty"`
+	DefaultThinkingLevel   *int                   `json:"defaultThinkingLevel,omitempty"`
+	TelemetryEnabled       *bool                  `json:"telemetryEnabled,omitempty"`
+	AutoExposePortsEnabled *bool                  `json:"autoExposePortsEnabled,omitempty"`
+	Bucket                 *BucketConfig          `json:"bucket,omitempty"`
+	Runtimes               map[string]interface{} `json:"runtimes,omitempty"`
+	Harnesses              map[string]interface{} `json:"harnesses,omitempty"`
+	Profiles               map[string]interface{} `json:"profiles,omitempty"`
 
 	// Default agent limits
 	DefaultMaxTurns      int                  `json:"defaultMaxTurns,omitempty"`

--- a/pkg/sciontool/autoexpose/config.go
+++ b/pkg/sciontool/autoexpose/config.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autoexpose
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Environment variable names for auto-expose configuration.
+const (
+	EnvAutoExposePorts    = "SCION_AUTO_EXPOSE_PORTS"
+	EnvAutoExposeMode     = "SCION_AUTO_EXPOSE_MODE"
+	EnvAutoExposeList     = "SCION_AUTO_EXPOSE_PORTS_LIST"
+	EnvAutoExposeInterval = "SCION_AUTO_EXPOSE_INTERVAL"
+	EnvAutoExposeMinPort  = "SCION_AUTO_EXPOSE_MIN_PORT"
+)
+
+// Filter modes for auto-expose.
+const (
+	FilterModeAllowlist = "allowlist"
+	FilterModeDenylist  = "denylist"
+)
+
+// Default configuration values.
+const (
+	DefaultInterval = 3 * time.Second
+	DefaultMinPort  = 1024
+	DefaultMaxPorts = 10
+)
+
+// DefaultDeniedPorts are infrastructure ports that must never be auto-exposed.
+// Matches the hub-side deniedExposedPorts in port_forward_handlers.go.
+var DefaultDeniedPorts = []int{8080, 9810, 18380}
+
+// Config holds the auto-expose configuration.
+type Config struct {
+	// Enabled gates whether the auto-expose loop runs.
+	Enabled bool
+
+	// Interval is the scan/reconcile cycle interval.
+	Interval time.Duration
+
+	// FilterMode is "allowlist" or "denylist".
+	FilterMode string
+
+	// FilterPorts is the list of ports for the active filter mode.
+	// In allowlist mode: only these ports are auto-exposed.
+	// In denylist mode: these ports are excluded from auto-exposure.
+	FilterPorts []int
+
+	// DeniedPorts are always denied regardless of filter mode (infrastructure ports).
+	DeniedPorts []int
+
+	// MaxPorts is the maximum number of auto-exposed ports (matches hub limit).
+	MaxPorts int
+
+	// MinPort is the minimum port number to auto-expose.
+	MinPort int
+}
+
+// ConfigFromEnv reads auto-expose configuration from environment variables.
+func ConfigFromEnv() Config {
+	cfg := Config{
+		Enabled:     envBool(EnvAutoExposePorts, false),
+		Interval:    envDuration(EnvAutoExposeInterval, DefaultInterval),
+		FilterMode:  envString(EnvAutoExposeMode, FilterModeAllowlist),
+		FilterPorts: envIntList(EnvAutoExposeList),
+		DeniedPorts: DefaultDeniedPorts,
+		MaxPorts:    DefaultMaxPorts,
+		MinPort:     envInt(EnvAutoExposeMinPort, DefaultMinPort),
+	}
+
+	// Normalize filter mode.
+	switch strings.ToLower(cfg.FilterMode) {
+	case FilterModeAllowlist, FilterModeDenylist:
+		cfg.FilterMode = strings.ToLower(cfg.FilterMode)
+	default:
+		cfg.FilterMode = FilterModeAllowlist
+	}
+
+	return cfg
+}
+
+func envBool(key string, defaultVal bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultVal
+	}
+	return strings.EqualFold(v, "true") || v == "1"
+}
+
+func envString(key, defaultVal string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultVal
+	}
+	return v
+}
+
+func envDuration(key string, defaultVal time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultVal
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return defaultVal
+	}
+	return d
+}
+
+func envInt(key string, defaultVal int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultVal
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return defaultVal
+	}
+	return n
+}
+
+func envIntList(key string) []int {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	parts := strings.Split(v, ",")
+	var result []int
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			continue
+		}
+		result = append(result, n)
+	}
+	return result
+}

--- a/pkg/sciontool/autoexpose/config.go
+++ b/pkg/sciontool/autoexpose/config.go
@@ -85,6 +85,11 @@ func ConfigFromEnv() Config {
 		MinPort:     envInt(EnvAutoExposeMinPort, DefaultMinPort),
 	}
 
+	// Enforce minimum interval floor to prevent hammering the hub.
+	if cfg.Interval < time.Second {
+		cfg.Interval = time.Second
+	}
+
 	// Normalize filter mode.
 	switch strings.ToLower(cfg.FilterMode) {
 	case FilterModeAllowlist, FilterModeDenylist:

--- a/pkg/sciontool/autoexpose/config.go
+++ b/pkg/sciontool/autoexpose/config.go
@@ -45,7 +45,10 @@ const (
 
 // DefaultDeniedPorts are infrastructure ports that must never be auto-exposed.
 // Matches the hub-side deniedExposedPorts in port_forward_handlers.go.
-var DefaultDeniedPorts = []int{8080, 9810, 18380}
+// Port 8080 is intentionally excluded: the reverse tunnel architecture makes it
+// safe to expose, and in many deployments the hub API is served on a different
+// port behind a load balancer, making path-based forwarding on 8080 valid.
+var DefaultDeniedPorts = []int{9810, 18380}
 
 // Config holds the auto-expose configuration.
 type Config struct {

--- a/pkg/sciontool/autoexpose/config_test.go
+++ b/pkg/sciontool/autoexpose/config_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autoexpose
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConfigFromEnv_Defaults(t *testing.T) {
+	// Clear all auto-expose env vars.
+	for _, env := range []string{
+		EnvAutoExposePorts, EnvAutoExposeMode, EnvAutoExposeList,
+		EnvAutoExposeInterval, EnvAutoExposeMinPort,
+	} {
+		t.Setenv(env, "")
+	}
+
+	cfg := ConfigFromEnv()
+
+	if cfg.Enabled {
+		t.Error("expected Enabled=false by default")
+	}
+	if cfg.Interval != DefaultInterval {
+		t.Errorf("Interval = %v, want %v", cfg.Interval, DefaultInterval)
+	}
+	if cfg.FilterMode != FilterModeAllowlist {
+		t.Errorf("FilterMode = %q, want %q", cfg.FilterMode, FilterModeAllowlist)
+	}
+	if len(cfg.FilterPorts) != 0 {
+		t.Errorf("FilterPorts = %v, want empty", cfg.FilterPorts)
+	}
+	if cfg.MaxPorts != DefaultMaxPorts {
+		t.Errorf("MaxPorts = %d, want %d", cfg.MaxPorts, DefaultMaxPorts)
+	}
+	if cfg.MinPort != DefaultMinPort {
+		t.Errorf("MinPort = %d, want %d", cfg.MinPort, DefaultMinPort)
+	}
+	if len(cfg.DeniedPorts) != 3 {
+		t.Errorf("DeniedPorts = %v, want 3 entries", cfg.DeniedPorts)
+	}
+}
+
+func TestConfigFromEnv_Enabled(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"true", true},
+		{"True", true},
+		{"TRUE", true},
+		{"1", true},
+		{"false", false},
+		{"0", false},
+		{"", false},
+		{"yes", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Setenv(EnvAutoExposePorts, tt.value)
+			cfg := ConfigFromEnv()
+			if cfg.Enabled != tt.want {
+				t.Errorf("Enabled = %v for %q, want %v", cfg.Enabled, tt.value, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigFromEnv_FilterMode(t *testing.T) {
+	tests := []struct {
+		value string
+		want  string
+	}{
+		{"allowlist", FilterModeAllowlist},
+		{"denylist", FilterModeDenylist},
+		{"Allowlist", FilterModeAllowlist},
+		{"DENYLIST", FilterModeDenylist},
+		{"invalid", FilterModeAllowlist}, // falls back to allowlist
+		{"", FilterModeAllowlist},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Setenv(EnvAutoExposeMode, tt.value)
+			cfg := ConfigFromEnv()
+			if cfg.FilterMode != tt.want {
+				t.Errorf("FilterMode = %q for %q, want %q", cfg.FilterMode, tt.value, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigFromEnv_PortList(t *testing.T) {
+	tests := []struct {
+		value string
+		want  []int
+	}{
+		{"3000,5000,8000", []int{3000, 5000, 8000}},
+		{"3000", []int{3000}},
+		{"3000, 5000, 8000", []int{3000, 5000, 8000}},
+		{"", nil},
+		{"abc,3000,xyz", []int{3000}},
+		{",,3000,,", []int{3000}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Setenv(EnvAutoExposeList, tt.value)
+			cfg := ConfigFromEnv()
+			if len(cfg.FilterPorts) != len(tt.want) {
+				t.Fatalf("FilterPorts = %v, want %v", cfg.FilterPorts, tt.want)
+			}
+			for i := range tt.want {
+				if cfg.FilterPorts[i] != tt.want[i] {
+					t.Errorf("FilterPorts[%d] = %d, want %d", i, cfg.FilterPorts[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestConfigFromEnv_Interval(t *testing.T) {
+	tests := []struct {
+		value string
+		want  time.Duration
+	}{
+		{"5s", 5 * time.Second},
+		{"1m", time.Minute},
+		{"500ms", 500 * time.Millisecond},
+		{"invalid", DefaultInterval},
+		{"", DefaultInterval},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Setenv(EnvAutoExposeInterval, tt.value)
+			cfg := ConfigFromEnv()
+			if cfg.Interval != tt.want {
+				t.Errorf("Interval = %v for %q, want %v", cfg.Interval, tt.value, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigFromEnv_MinPort(t *testing.T) {
+	tests := []struct {
+		value string
+		want  int
+	}{
+		{"2048", 2048},
+		{"0", 0},
+		{"invalid", DefaultMinPort},
+		{"", DefaultMinPort},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Setenv(EnvAutoExposeMinPort, tt.value)
+			cfg := ConfigFromEnv()
+			if cfg.MinPort != tt.want {
+				t.Errorf("MinPort = %d for %q, want %d", cfg.MinPort, tt.value, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigFromEnv_FullConfig(t *testing.T) {
+	t.Setenv(EnvAutoExposePorts, "true")
+	t.Setenv(EnvAutoExposeMode, "denylist")
+	t.Setenv(EnvAutoExposeList, "22,80")
+	t.Setenv(EnvAutoExposeInterval, "10s")
+	t.Setenv(EnvAutoExposeMinPort, "2048")
+
+	cfg := ConfigFromEnv()
+
+	if !cfg.Enabled {
+		t.Error("expected Enabled=true")
+	}
+	if cfg.FilterMode != FilterModeDenylist {
+		t.Errorf("FilterMode = %q, want denylist", cfg.FilterMode)
+	}
+	if len(cfg.FilterPorts) != 2 || cfg.FilterPorts[0] != 22 || cfg.FilterPorts[1] != 80 {
+		t.Errorf("FilterPorts = %v, want [22, 80]", cfg.FilterPorts)
+	}
+	if cfg.Interval != 10*time.Second {
+		t.Errorf("Interval = %v, want 10s", cfg.Interval)
+	}
+	if cfg.MinPort != 2048 {
+		t.Errorf("MinPort = %d, want 2048", cfg.MinPort)
+	}
+}

--- a/pkg/sciontool/autoexpose/config_test.go
+++ b/pkg/sciontool/autoexpose/config_test.go
@@ -139,9 +139,32 @@ func TestConfigFromEnv_Interval(t *testing.T) {
 	}{
 		{"5s", 5 * time.Second},
 		{"1m", time.Minute},
-		{"500ms", 500 * time.Millisecond},
+		{"500ms", time.Second}, // clamped to 1s floor
 		{"invalid", DefaultInterval},
 		{"", DefaultInterval},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Setenv(EnvAutoExposeInterval, tt.value)
+			cfg := ConfigFromEnv()
+			if cfg.Interval != tt.want {
+				t.Errorf("Interval = %v for %q, want %v", cfg.Interval, tt.value, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigFromEnv_IntervalFloor(t *testing.T) {
+	tests := []struct {
+		value string
+		want  time.Duration
+	}{
+		{"100ms", time.Second},  // clamped to 1s
+		{"1ms", time.Second},    // clamped to 1s
+		{"999ms", time.Second},  // clamped to 1s
+		{"1s", time.Second},     // exactly at floor
+		{"2s", 2 * time.Second}, // above floor, unchanged
 	}
 
 	for _, tt := range tests {

--- a/pkg/sciontool/autoexpose/config_test.go
+++ b/pkg/sciontool/autoexpose/config_test.go
@@ -48,8 +48,8 @@ func TestConfigFromEnv_Defaults(t *testing.T) {
 	if cfg.MinPort != DefaultMinPort {
 		t.Errorf("MinPort = %d, want %d", cfg.MinPort, DefaultMinPort)
 	}
-	if len(cfg.DeniedPorts) != 3 {
-		t.Errorf("DeniedPorts = %v, want 3 entries", cfg.DeniedPorts)
+	if len(cfg.DeniedPorts) != 2 {
+		t.Errorf("DeniedPorts = %v, want 2 entries (9810, 18380)", cfg.DeniedPorts)
 	}
 }
 

--- a/pkg/sciontool/autoexpose/reconciler.go
+++ b/pkg/sciontool/autoexpose/reconciler.go
@@ -1,0 +1,284 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autoexpose
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	scionhub "github.com/GoogleCloudPlatform/scion/pkg/sciontool/hub"
+	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/log"
+)
+
+// autoExposeLabel is the label applied to auto-exposed ports so operators
+// can distinguish them from manually-exposed ports.
+const autoExposeLabel = "auto-scan"
+
+// HubPortClient is the subset of hub.Client needed by the reconciler.
+// Using an interface enables unit testing without a real Hub.
+type HubPortClient interface {
+	RegisterPort(ctx context.Context, req scionhub.RegisterPortRequest) (*scionhub.ExposedPort, error)
+	DeletePort(ctx context.Context, port int) error
+	ListPorts(ctx context.Context) ([]scionhub.ExposedPort, error)
+}
+
+// scanFunc is the function signature for scanning listeners.
+// Defaults to ScanListeners; overridable in tests.
+type scanFunc func() ([]ListenSocket, error)
+
+// Reconciler periodically scans for listening TCP ports and reconciles
+// them with the Hub's port registry. It only manages ports it auto-exposed
+// (tracked in a local set) and never un-exposes manually-registered ports.
+type Reconciler struct {
+	client HubPortClient
+	cfg    Config
+	scan   scanFunc
+
+	// autoExposed tracks ports this reconciler has registered.
+	// Only these ports are candidates for auto-unexpose.
+	autoExposed map[int]bool
+
+	// cachedRegistered is the last-known set of registered ports (port -> exposedBy).
+	// Refreshed after register/delete operations or every cacheRefreshInterval ticks.
+	cachedRegistered  map[int]string
+	ticksSinceRefresh int
+}
+
+// cacheRefreshInterval is the number of ticks between forced cache refreshes.
+// Between refreshes, the reconciler uses its local cache to avoid HTTP calls.
+const cacheRefreshInterval = 10
+
+// NewReconciler creates a new auto-expose reconciler.
+func NewReconciler(client HubPortClient, cfg Config) *Reconciler {
+	return &Reconciler{
+		client:      client,
+		cfg:         cfg,
+		scan:        ScanListeners,
+		autoExposed: make(map[int]bool),
+	}
+}
+
+// Run starts the reconciliation loop. It blocks until ctx is cancelled.
+func (r *Reconciler) Run(ctx context.Context) {
+	ticker := time.NewTicker(r.cfg.Interval)
+	defer ticker.Stop()
+
+	// Do an initial reconcile immediately.
+	r.reconcileOnce(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.reconcileOnce(ctx)
+		}
+	}
+}
+
+func (r *Reconciler) reconcileOnce(ctx context.Context) {
+	// 1. Scan for listening sockets.
+	sockets, err := r.scan()
+	if err != nil {
+		log.Error("auto-expose: scan failed: %v", err)
+		return
+	}
+
+	// 2. Filter through policy.
+	wanted := r.filterPorts(sockets)
+
+	// 3. Get currently registered ports (from cache or hub).
+	registered, err := r.getRegistered(ctx, false)
+	if err != nil {
+		log.Error("auto-expose: failed to list registered ports: %v", err)
+		return
+	}
+
+	// 4. Diff: ports to expose = wanted - registered.
+	toExpose := r.diffToExpose(wanted, registered)
+
+	// 5. Diff: ports to unexpose = autoExposed - wanted (only ports we registered).
+	toUnexpose := r.diffToUnexpose(wanted)
+
+	// 6. Register new ports.
+	changed := false
+	for _, port := range toExpose {
+		if err := r.registerPort(ctx, port); err != nil {
+			log.Error("auto-expose: failed to register port %d: %v", port, err)
+			continue
+		}
+		changed = true
+	}
+
+	// 7. Deregister stale ports.
+	for _, port := range toUnexpose {
+		if err := r.deregisterPort(ctx, port); err != nil {
+			log.Error("auto-expose: failed to deregister port %d: %v", port, err)
+			continue
+		}
+		changed = true
+	}
+
+	// Refresh cache if we made changes.
+	if changed {
+		if _, err := r.getRegistered(ctx, true); err != nil {
+			log.Debug("auto-expose: cache refresh after changes failed: %v", err)
+		}
+	}
+}
+
+// filterPorts applies the configured policy to scanned sockets, returning
+// the set of port numbers that should be exposed.
+func (r *Reconciler) filterPorts(sockets []ListenSocket) map[int]bool {
+	result := make(map[int]bool)
+
+	deniedSet := make(map[int]bool, len(r.cfg.DeniedPorts))
+	for _, p := range r.cfg.DeniedPorts {
+		deniedSet[p] = true
+	}
+
+	filterSet := make(map[int]bool, len(r.cfg.FilterPorts))
+	for _, p := range r.cfg.FilterPorts {
+		filterSet[p] = true
+	}
+
+	for _, s := range sockets {
+		port := s.Port
+
+		// Always deny infrastructure ports.
+		if deniedSet[port] {
+			continue
+		}
+
+		// Minimum port check.
+		if port < r.cfg.MinPort {
+			continue
+		}
+
+		// Apply filter mode.
+		switch r.cfg.FilterMode {
+		case FilterModeAllowlist:
+			if !filterSet[port] {
+				continue
+			}
+		case FilterModeDenylist:
+			if filterSet[port] {
+				continue
+			}
+		}
+
+		result[port] = true
+	}
+
+	return result
+}
+
+// diffToExpose returns ports that are wanted but not yet registered.
+func (r *Reconciler) diffToExpose(wanted map[int]bool, registered map[int]string) []int {
+	// Count currently auto-exposed ports.
+	autoCount := len(r.autoExposed)
+
+	var result []int
+	for port := range wanted {
+		if _, exists := registered[port]; exists {
+			continue
+		}
+		// Respect max ports limit.
+		if autoCount+len(result) >= r.cfg.MaxPorts {
+			break
+		}
+		result = append(result, port)
+	}
+	return result
+}
+
+// diffToUnexpose returns ports that we auto-exposed but are no longer wanted.
+// Never includes manually-exposed ports.
+func (r *Reconciler) diffToUnexpose(wanted map[int]bool) []int {
+	var result []int
+	for port := range r.autoExposed {
+		if !wanted[port] {
+			result = append(result, port)
+		}
+	}
+	return result
+}
+
+// getRegistered returns the currently registered ports, using the cache when
+// possible. Pass force=true to always query the Hub.
+func (r *Reconciler) getRegistered(ctx context.Context, force bool) (map[int]string, error) {
+	r.ticksSinceRefresh++
+
+	if !force && r.cachedRegistered != nil && r.ticksSinceRefresh < cacheRefreshInterval {
+		return r.cachedRegistered, nil
+	}
+
+	ports, err := r.client.ListPorts(ctx)
+	if err != nil {
+		return r.cachedRegistered, err
+	}
+
+	registered := make(map[int]string, len(ports))
+	for _, p := range ports {
+		registered[p.Port] = p.ExposedBy
+	}
+
+	r.cachedRegistered = registered
+	r.ticksSinceRefresh = 0
+	return registered, nil
+}
+
+// registerPort registers a port with the Hub and tracks it as auto-exposed.
+func (r *Reconciler) registerPort(ctx context.Context, port int) error {
+	_, err := r.client.RegisterPort(ctx, scionhub.RegisterPortRequest{
+		Port:  port,
+		Label: autoExposeLabel,
+		Host:  "127.0.0.1",
+	})
+	if err != nil {
+		// Treat 409 Conflict as success — port is already registered.
+		if isConflictError(err) {
+			log.Debug("auto-expose: port %d already registered (409 conflict)", port)
+			r.autoExposed[port] = true
+			return nil
+		}
+		return err
+	}
+
+	r.autoExposed[port] = true
+	log.Info("auto-expose: exposed port %d", port)
+	return nil
+}
+
+// deregisterPort removes a port from the Hub and stops tracking it.
+func (r *Reconciler) deregisterPort(ctx context.Context, port int) error {
+	if err := r.client.DeletePort(ctx, port); err != nil {
+		return err
+	}
+
+	delete(r.autoExposed, port)
+	log.Info("auto-expose: unexposed port %d", port)
+	return nil
+}
+
+// isConflictError checks if an error is a 409 Conflict from the Hub.
+func isConflictError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), fmt.Sprintf("error %d:", 409))
+}

--- a/pkg/sciontool/autoexpose/reconciler.go
+++ b/pkg/sciontool/autoexpose/reconciler.go
@@ -253,7 +253,9 @@ func (r *Reconciler) registerPort(ctx context.Context, port int) error {
 		// Treat 409 Conflict as success — port is already registered.
 		if isConflictError(err) {
 			log.Debug("auto-expose: port %d already registered (409 conflict)", port)
-			r.autoExposed[port] = true
+			// Do NOT track as auto-exposed — the port may have been manually registered.
+			// The next cache refresh will pick it up in 'registered' and diffToExpose
+			// will skip it.
 			return nil
 		}
 		return err

--- a/pkg/sciontool/autoexpose/reconciler.go
+++ b/pkg/sciontool/autoexpose/reconciler.go
@@ -16,7 +16,7 @@ package autoexpose
 
 import (
 	"context"
-	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -189,11 +189,18 @@ func (r *Reconciler) filterPorts(sockets []ListenSocket) map[int]bool {
 
 // diffToExpose returns ports that are wanted but not yet registered.
 func (r *Reconciler) diffToExpose(wanted map[int]bool, registered map[int]string) []int {
+	// Sort wanted ports for deterministic exposure order when exceeding MaxPorts.
+	sorted := make([]int, 0, len(wanted))
+	for port := range wanted {
+		sorted = append(sorted, port)
+	}
+	sort.Ints(sorted)
+
 	// Count currently auto-exposed ports.
 	autoCount := len(r.autoExposed)
 
 	var result []int
-	for port := range wanted {
+	for _, port := range sorted {
 		if _, exists := registered[port]; exists {
 			continue
 		}
@@ -282,5 +289,5 @@ func isConflictError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(err.Error(), fmt.Sprintf("error %d:", 409))
+	return strings.Contains(err.Error(), "error 409:")
 }

--- a/pkg/sciontool/autoexpose/reconciler_test.go
+++ b/pkg/sciontool/autoexpose/reconciler_test.go
@@ -258,17 +258,18 @@ func TestReconciler_DeniedPortsFiltering(t *testing.T) {
 
 	sockets := []ListenSocket{
 		{Port: 3000, BindAddr: "0.0.0.0"},
-		{Port: 8080, BindAddr: "0.0.0.0"},  // denied
-		{Port: 9810, BindAddr: "0.0.0.0"},  // denied
-		{Port: 18380, BindAddr: "0.0.0.0"}, // denied
+		{Port: 8080, BindAddr: "0.0.0.0"},  // NOT denied — reverse tunnel makes it safe
+		{Port: 9810, BindAddr: "0.0.0.0"},  // denied (hub API)
+		{Port: 18380, BindAddr: "0.0.0.0"}, // denied (metadata server)
 	}
 
 	r := newTestReconciler(client, cfg, sockets)
 	r.reconcileOnce(context.Background())
 
 	ports := client.registeredPorts()
-	if len(ports) != 1 || ports[0] != 3000 {
-		t.Errorf("expected [3000] (denied ports filtered), got %v", ports)
+	// 8080 is no longer denied, so both 3000 and 8080 should be registered.
+	if len(ports) != 2 || ports[0] != 3000 || ports[1] != 8080 {
+		t.Errorf("expected [3000, 8080] (only infra ports denied), got %v", ports)
 	}
 }
 
@@ -413,16 +414,17 @@ func TestReconciler_FilterPorts_CombinedDeniedAndDenylist(t *testing.T) {
 	sockets := []ListenSocket{
 		{Port: 3000, BindAddr: "0.0.0.0"},
 		{Port: 4000, BindAddr: "0.0.0.0"}, // in denylist
-		{Port: 8080, BindAddr: "0.0.0.0"}, // in denied ports
-		{Port: 9810, BindAddr: "0.0.0.0"}, // in denied ports
+		{Port: 8080, BindAddr: "0.0.0.0"}, // NOT denied — reverse tunnel makes it safe
+		{Port: 9810, BindAddr: "0.0.0.0"}, // in denied ports (hub API)
 	}
 
 	r := newTestReconciler(client, cfg, sockets)
 	r.reconcileOnce(context.Background())
 
 	ports := client.registeredPorts()
-	if len(ports) != 1 || ports[0] != 3000 {
-		t.Errorf("expected [3000] with combined deny, got %v", ports)
+	// 8080 is no longer in denied ports, so 3000 and 8080 should be registered.
+	if len(ports) != 2 || ports[0] != 3000 || ports[1] != 8080 {
+		t.Errorf("expected [3000, 8080] with combined deny, got %v", ports)
 	}
 }
 

--- a/pkg/sciontool/autoexpose/reconciler_test.go
+++ b/pkg/sciontool/autoexpose/reconciler_test.go
@@ -362,9 +362,10 @@ func TestReconciler_ConflictHandledGracefully(t *testing.T) {
 	r := newTestReconciler(client, defaultTestConfig(), sockets)
 	r.reconcileOnce(context.Background())
 
-	// Port 3000 should be tracked as auto-exposed despite 409.
-	if !r.autoExposed[3000] {
-		t.Error("port 3000 should be tracked as auto-exposed after 409 conflict")
+	// Port 3000 should NOT be tracked as auto-exposed after 409 —
+	// it may have been manually registered.
+	if r.autoExposed[3000] {
+		t.Error("port 3000 should NOT be tracked as auto-exposed after 409 conflict")
 	}
 
 	// Port 5000 should be registered normally.
@@ -443,6 +444,48 @@ func TestReconciler_LabelSetCorrectly(t *testing.T) {
 		}
 	} else {
 		t.Error("port 3000 not found in mock client")
+	}
+}
+
+func TestReconciler_ConflictDoesNotAutoUnexposeManualPort(t *testing.T) {
+	client := newMockHubClient()
+
+	// Simulate: user manually registered port 3000 between cache refresh and
+	// the register call. RegisterPort returns 409 for port 3000.
+	client.ports[3000] = &scionhub.ExposedPort{
+		Port:      3000,
+		ExposedBy: "agent", // manually registered
+	}
+
+	sockets := []ListenSocket{
+		{Port: 3000, BindAddr: "0.0.0.0"},
+	}
+
+	r := newTestReconciler(client, defaultTestConfig(), sockets)
+	// First tick: 3000 not in cache yet, tries to register, gets 409.
+	r.reconcileOnce(context.Background())
+
+	// Port 3000 must NOT be in autoExposed.
+	if r.autoExposed[3000] {
+		t.Fatal("port 3000 should NOT be tracked as auto-exposed after 409 conflict")
+	}
+
+	// Now the process on port 3000 stops listening.
+	r.scan = func() ([]ListenSocket, error) {
+		return nil, nil
+	}
+	r.reconcileOnce(context.Background())
+
+	// The manually-registered port 3000 must still be in the hub.
+	ports := client.registeredPorts()
+	found := false
+	for _, p := range ports {
+		if p == 3000 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("manual port 3000 should NOT have been auto-unexposed, got %v", ports)
 	}
 }
 

--- a/pkg/sciontool/autoexpose/reconciler_test.go
+++ b/pkg/sciontool/autoexpose/reconciler_test.go
@@ -1,0 +1,466 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autoexpose
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+
+	scionhub "github.com/GoogleCloudPlatform/scion/pkg/sciontool/hub"
+)
+
+// mockHubClient is a test double for HubPortClient.
+type mockHubClient struct {
+	mu         sync.Mutex
+	ports      map[int]*scionhub.ExposedPort
+	registerCb func(req scionhub.RegisterPortRequest) error // optional callback
+}
+
+func newMockHubClient() *mockHubClient {
+	return &mockHubClient{
+		ports: make(map[int]*scionhub.ExposedPort),
+	}
+}
+
+func (m *mockHubClient) RegisterPort(_ context.Context, req scionhub.RegisterPortRequest) (*scionhub.ExposedPort, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.registerCb != nil {
+		if err := m.registerCb(req); err != nil {
+			return nil, err
+		}
+	}
+
+	if _, exists := m.ports[req.Port]; exists {
+		return nil, fmt.Errorf("hub returned error 409: port already registered")
+	}
+
+	ep := &scionhub.ExposedPort{
+		Port:      req.Port,
+		Label:     req.Label,
+		Host:      req.Host,
+		ExposedBy: req.Label, // use label as exposedBy for testing
+	}
+	m.ports[req.Port] = ep
+	return ep, nil
+}
+
+func (m *mockHubClient) DeletePort(_ context.Context, port int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.ports, port)
+	return nil
+}
+
+func (m *mockHubClient) ListPorts(_ context.Context) ([]scionhub.ExposedPort, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var result []scionhub.ExposedPort
+	for _, ep := range m.ports {
+		result = append(result, *ep)
+	}
+	return result, nil
+}
+
+func (m *mockHubClient) registeredPorts() []int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var ports []int
+	for p := range m.ports {
+		ports = append(ports, p)
+	}
+	sort.Ints(ports)
+	return ports
+}
+
+func newTestReconciler(client *mockHubClient, cfg Config, sockets []ListenSocket) *Reconciler {
+	r := NewReconciler(client, cfg)
+	r.scan = func() ([]ListenSocket, error) {
+		return sockets, nil
+	}
+	return r
+}
+
+func defaultTestConfig() Config {
+	return Config{
+		Enabled:     true,
+		Interval:    DefaultInterval,
+		FilterMode:  FilterModeDenylist,
+		FilterPorts: nil,
+		DeniedPorts: DefaultDeniedPorts,
+		MaxPorts:    DefaultMaxPorts,
+		MinPort:     DefaultMinPort,
+	}
+}
+
+func TestReconciler_NewPortsExposed(t *testing.T) {
+	client := newMockHubClient()
+	sockets := []ListenSocket{
+		{Port: 3000, BindAddr: "0.0.0.0"},
+		{Port: 5000, BindAddr: "127.0.0.1"},
+	}
+
+	r := newTestReconciler(client, defaultTestConfig(), sockets)
+	r.reconcileOnce(context.Background())
+
+	ports := client.registeredPorts()
+	if len(ports) != 2 {
+		t.Fatalf("expected 2 ports registered, got %d: %v", len(ports), ports)
+	}
+	if ports[0] != 3000 || ports[1] != 5000 {
+		t.Errorf("registered ports = %v, want [3000, 5000]", ports)
+	}
+
+	// Check auto-exposed tracking.
+	if !r.autoExposed[3000] || !r.autoExposed[5000] {
+		t.Errorf("autoExposed = %v, want {3000: true, 5000: true}", r.autoExposed)
+	}
+}
+
+func TestReconciler_StalePortsUnexposed(t *testing.T) {
+	client := newMockHubClient()
+
+	// First tick: port 3000 and 5000 are listening.
+	sockets := []ListenSocket{
+		{Port: 3000, BindAddr: "0.0.0.0"},
+		{Port: 5000, BindAddr: "0.0.0.0"},
+	}
+	r := newTestReconciler(client, defaultTestConfig(), sockets)
+	r.reconcileOnce(context.Background())
+
+	if len(client.registeredPorts()) != 2 {
+		t.Fatalf("expected 2 ports after first tick, got %v", client.registeredPorts())
+	}
+
+	// Second tick: port 5000 stopped listening.
+	r.scan = func() ([]ListenSocket, error) {
+		return []ListenSocket{{Port: 3000, BindAddr: "0.0.0.0"}}, nil
+	}
+	r.reconcileOnce(context.Background())
+
+	ports := client.registeredPorts()
+	if len(ports) != 1 || ports[0] != 3000 {
+		t.Errorf("expected [3000] after unexpose, got %v", ports)
+	}
+	if r.autoExposed[5000] {
+		t.Error("port 5000 should be removed from autoExposed tracking")
+	}
+}
+
+func TestReconciler_AllowlistFiltering(t *testing.T) {
+	client := newMockHubClient()
+	cfg := defaultTestConfig()
+	cfg.FilterMode = FilterModeAllowlist
+	cfg.FilterPorts = []int{3000}
+
+	sockets := []ListenSocket{
+		{Port: 3000, BindAddr: "0.0.0.0"},
+		{Port: 5000, BindAddr: "0.0.0.0"},
+		{Port: 8000, BindAddr: "0.0.0.0"},
+	}
+
+	r := newTestReconciler(client, cfg, sockets)
+	r.reconcileOnce(context.Background())
+
+	ports := client.registeredPorts()
+	if len(ports) != 1 || ports[0] != 3000 {
+		t.Errorf("expected [3000] with allowlist, got %v", ports)
+	}
+}
+
+func TestReconciler_AllowlistEmpty(t *testing.T) {
+	client := newMockHubClient()
+	cfg := defaultTestConfig()
+	cfg.FilterMode = FilterModeAllowlist
+	cfg.FilterPorts = nil // empty allowlist
+
+	sockets := []ListenSocket{
+		{Port: 3000, BindAddr: "0.0.0.0"},
+		{Port: 5000, BindAddr: "0.0.0.0"},
+	}
+
+	r := newTestReconciler(client, cfg, sockets)
+	r.reconcileOnce(context.Background())
+
+	ports := client.registeredPorts()
+	if len(ports) != 0 {
+		t.Errorf("expected no ports with empty allowlist, got %v", ports)
+	}
+}
+
+func TestReconciler_DenylistFiltering(t *testing.T) {
+	client := newMockHubClient()
+	cfg := defaultTestConfig()
+	cfg.FilterMode = FilterModeDenylist
+	cfg.FilterPorts = []int{5000}
+
+	sockets := []ListenSocket{
+		{Port: 3000, BindAddr: "0.0.0.0"},
+		{Port: 5000, BindAddr: "0.0.0.0"},
+		{Port: 8000, BindAddr: "0.0.0.0"},
+	}
+
+	r := newTestReconciler(client, cfg, sockets)
+	r.reconcileOnce(context.Background())
+
+	ports := client.registeredPorts()
+	if len(ports) != 2 {
+		t.Fatalf("expected 2 ports with denylist, got %v", ports)
+	}
+	// 5000 should be excluded.
+	for _, p := range ports {
+		if p == 5000 {
+			t.Error("port 5000 should be denied by denylist")
+		}
+	}
+}
+
+func TestReconciler_MinPortFiltering(t *testing.T) {
+	client := newMockHubClient()
+	cfg := defaultTestConfig()
+	cfg.MinPort = 2000
+
+	sockets := []ListenSocket{
+		{Port: 80, BindAddr: "0.0.0.0"},
+		{Port: 443, BindAddr: "0.0.0.0"},
+		{Port: 1024, BindAddr: "0.0.0.0"},
+		{Port: 3000, BindAddr: "0.0.0.0"},
+	}
+
+	r := newTestReconciler(client, cfg, sockets)
+	r.reconcileOnce(context.Background())
+
+	ports := client.registeredPorts()
+	if len(ports) != 1 || ports[0] != 3000 {
+		t.Errorf("expected [3000] with minPort=2000, got %v", ports)
+	}
+}
+
+func TestReconciler_DeniedPortsFiltering(t *testing.T) {
+	client := newMockHubClient()
+	cfg := defaultTestConfig()
+
+	sockets := []ListenSocket{
+		{Port: 3000, BindAddr: "0.0.0.0"},
+		{Port: 8080, BindAddr: "0.0.0.0"},  // denied
+		{Port: 9810, BindAddr: "0.0.0.0"},  // denied
+		{Port: 18380, BindAddr: "0.0.0.0"}, // denied
+	}
+
+	r := newTestReconciler(client, cfg, sockets)
+	r.reconcileOnce(context.Background())
+
+	ports := client.registeredPorts()
+	if len(ports) != 1 || ports[0] != 3000 {
+		t.Errorf("expected [3000] (denied ports filtered), got %v", ports)
+	}
+}
+
+func TestReconciler_NeverUnexposeManualPorts(t *testing.T) {
+	client := newMockHubClient()
+
+	// Pre-register a port manually (not via auto-expose).
+	client.ports[5000] = &scionhub.ExposedPort{
+		Port:      5000,
+		ExposedBy: "agent",
+	}
+
+	sockets := []ListenSocket{
+		{Port: 3000, BindAddr: "0.0.0.0"},
+		{Port: 5000, BindAddr: "0.0.0.0"},
+	}
+
+	r := newTestReconciler(client, defaultTestConfig(), sockets)
+	r.reconcileOnce(context.Background())
+
+	// Now stop listening on port 5000.
+	r.scan = func() ([]ListenSocket, error) {
+		return []ListenSocket{{Port: 3000, BindAddr: "0.0.0.0"}}, nil
+	}
+	r.reconcileOnce(context.Background())
+
+	// Port 5000 should still be registered (manual port not touched).
+	ports := client.registeredPorts()
+	found5000 := false
+	for _, p := range ports {
+		if p == 5000 {
+			found5000 = true
+		}
+	}
+	if !found5000 {
+		t.Errorf("manual port 5000 should not be unexposed, got %v", ports)
+	}
+
+	// Port 3000 should also still be there.
+	found3000 := false
+	for _, p := range ports {
+		if p == 3000 {
+			found3000 = true
+		}
+	}
+	if !found3000 {
+		t.Errorf("auto port 3000 should be registered, got %v", ports)
+	}
+}
+
+func TestReconciler_MaxPortsLimit(t *testing.T) {
+	client := newMockHubClient()
+	cfg := defaultTestConfig()
+	cfg.MaxPorts = 3
+
+	sockets := []ListenSocket{
+		{Port: 3000, BindAddr: "0.0.0.0"},
+		{Port: 3001, BindAddr: "0.0.0.0"},
+		{Port: 3002, BindAddr: "0.0.0.0"},
+		{Port: 3003, BindAddr: "0.0.0.0"},
+		{Port: 3004, BindAddr: "0.0.0.0"},
+	}
+
+	r := newTestReconciler(client, cfg, sockets)
+	r.reconcileOnce(context.Background())
+
+	ports := client.registeredPorts()
+	if len(ports) > 3 {
+		t.Errorf("expected at most 3 ports (maxPorts=3), got %d: %v", len(ports), ports)
+	}
+}
+
+func TestReconciler_ConflictHandledGracefully(t *testing.T) {
+	client := newMockHubClient()
+
+	// Simulate a race condition: RegisterPort returns 409 for port 3000
+	// (registered by another process between scan and register), but
+	// ListPorts doesn't show it yet (cache staleness).
+	client.registerCb = func(req scionhub.RegisterPortRequest) error {
+		if req.Port == 3000 {
+			return fmt.Errorf("hub returned error 409: port already registered")
+		}
+		return nil
+	}
+
+	sockets := []ListenSocket{
+		{Port: 3000, BindAddr: "0.0.0.0"},
+		{Port: 5000, BindAddr: "0.0.0.0"},
+	}
+
+	r := newTestReconciler(client, defaultTestConfig(), sockets)
+	r.reconcileOnce(context.Background())
+
+	// Port 3000 should be tracked as auto-exposed despite 409.
+	if !r.autoExposed[3000] {
+		t.Error("port 3000 should be tracked as auto-exposed after 409 conflict")
+	}
+
+	// Port 5000 should be registered normally.
+	if !r.autoExposed[5000] {
+		t.Error("port 5000 should be tracked as auto-exposed")
+	}
+}
+
+func TestReconciler_NoOpAtSteadyState(t *testing.T) {
+	client := newMockHubClient()
+
+	sockets := []ListenSocket{
+		{Port: 3000, BindAddr: "0.0.0.0"},
+	}
+
+	r := newTestReconciler(client, defaultTestConfig(), sockets)
+
+	// First tick: registers port.
+	r.reconcileOnce(context.Background())
+	if len(client.registeredPorts()) != 1 {
+		t.Fatal("expected 1 port after first tick")
+	}
+
+	// Second tick: no changes — should be a no-op.
+	registerCalled := false
+	origRegister := client.registerCb
+	client.registerCb = func(_ scionhub.RegisterPortRequest) error {
+		registerCalled = true
+		return nil
+	}
+	r.reconcileOnce(context.Background())
+	client.registerCb = origRegister
+
+	if registerCalled {
+		t.Error("expected no RegisterPort call at steady state")
+	}
+}
+
+func TestReconciler_FilterPorts_CombinedDeniedAndDenylist(t *testing.T) {
+	client := newMockHubClient()
+	cfg := defaultTestConfig()
+	cfg.FilterMode = FilterModeDenylist
+	cfg.FilterPorts = []int{4000}
+
+	sockets := []ListenSocket{
+		{Port: 3000, BindAddr: "0.0.0.0"},
+		{Port: 4000, BindAddr: "0.0.0.0"}, // in denylist
+		{Port: 8080, BindAddr: "0.0.0.0"}, // in denied ports
+		{Port: 9810, BindAddr: "0.0.0.0"}, // in denied ports
+	}
+
+	r := newTestReconciler(client, cfg, sockets)
+	r.reconcileOnce(context.Background())
+
+	ports := client.registeredPorts()
+	if len(ports) != 1 || ports[0] != 3000 {
+		t.Errorf("expected [3000] with combined deny, got %v", ports)
+	}
+}
+
+func TestReconciler_LabelSetCorrectly(t *testing.T) {
+	client := newMockHubClient()
+
+	sockets := []ListenSocket{
+		{Port: 3000, BindAddr: "0.0.0.0"},
+	}
+
+	r := newTestReconciler(client, defaultTestConfig(), sockets)
+	r.reconcileOnce(context.Background())
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if ep, ok := client.ports[3000]; ok {
+		if ep.Label != autoExposeLabel {
+			t.Errorf("port label = %q, want %q", ep.Label, autoExposeLabel)
+		}
+	} else {
+		t.Error("port 3000 not found in mock client")
+	}
+}
+
+func TestIsConflictError(t *testing.T) {
+	tests := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{fmt.Errorf("hub returned error 409: port already registered"), true},
+		{fmt.Errorf("hub returned error 500: internal server error"), false},
+		{fmt.Errorf("network error"), false},
+	}
+
+	for _, tt := range tests {
+		got := isConflictError(tt.err)
+		if got != tt.want {
+			t.Errorf("isConflictError(%v) = %v, want %v", tt.err, got, tt.want)
+		}
+	}
+}

--- a/pkg/sciontool/autoexpose/scanner.go
+++ b/pkg/sciontool/autoexpose/scanner.go
@@ -19,6 +19,7 @@ package autoexpose
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -117,9 +118,11 @@ func parseLocalAddress(s string, ipv6 bool) (port int, bindAddr string, err erro
 
 	// Parse port (always 4 hex digits).
 	var p int
-	if _, err := fmt.Sscanf(hexPort, "%X", &p); err != nil {
+	portVal, err := strconv.ParseUint(hexPort, 16, 16)
+	if err != nil {
 		return 0, "", fmt.Errorf("invalid port hex %q: %w", hexPort, err)
 	}
+	p = int(portVal)
 
 	// Parse IP address.
 	addr, err := parseHexIP(hexIP, ipv6)
@@ -146,8 +149,8 @@ func parseHexIPv4(hex string) (string, error) {
 	}
 	var ip [4]byte
 	for i := 0; i < 4; i++ {
-		var b int
-		if _, err := fmt.Sscanf(hex[i*2:i*2+2], "%02X", &b); err != nil {
+		b, err := strconv.ParseUint(hex[i*2:i*2+2], 16, 8)
+		if err != nil {
 			return "", err
 		}
 		// /proc/net/tcp stores IPv4 in little-endian order: byte 0 is rightmost.
@@ -170,8 +173,8 @@ func parseHexIPv6(hex string) (string, error) {
 		// Read the 4 bytes, then reverse for little-endian.
 		var bytes [4]byte
 		for i := 0; i < 4; i++ {
-			var b int
-			if _, err := fmt.Sscanf(chunk[i*2:i*2+2], "%02X", &b); err != nil {
+			b, err := strconv.ParseUint(chunk[i*2:i*2+2], 16, 8)
+			if err != nil {
 				return "", err
 			}
 			bytes[i] = byte(b)

--- a/pkg/sciontool/autoexpose/scanner.go
+++ b/pkg/sciontool/autoexpose/scanner.go
@@ -42,9 +42,12 @@ func ScanListeners() ([]ListenSocket, error) {
 func scanListenersFrom(tcpPath, tcp6Path string) ([]ListenSocket, error) {
 	var result []ListenSocket
 
-	if sockets, err := parseProcNetTCP(tcpPath, false); err == nil {
-		result = append(result, sockets...)
+	sockets, err := parseProcNetTCP(tcpPath, false)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", tcpPath, err)
 	}
+	result = append(result, sockets...)
+
 	// tcp6 may not exist; ignore read errors.
 	if sockets, err := parseProcNetTCP(tcp6Path, true); err == nil {
 		result = append(result, sockets...)

--- a/pkg/sciontool/autoexpose/scanner.go
+++ b/pkg/sciontool/autoexpose/scanner.go
@@ -1,0 +1,199 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package autoexpose detects TCP listening ports inside agent containers by
+// parsing /proc/net/tcp{,6} and automatically exposes them through the Hub.
+package autoexpose
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// tcpListen is the hex state code for TCP_LISTEN in /proc/net/tcp.
+const tcpListen = "0A"
+
+// ListenSocket represents a TCP socket in the LISTEN state.
+type ListenSocket struct {
+	Port     int
+	BindAddr string // e.g. "0.0.0.0", "127.0.0.1", "::", "::1"
+}
+
+// ScanListeners reads /proc/net/tcp and /proc/net/tcp6, returning all
+// sockets in the TCP_LISTEN state. The function is pure Go, no subprocess.
+func ScanListeners() ([]ListenSocket, error) {
+	return scanListenersFrom("/proc/net/tcp", "/proc/net/tcp6")
+}
+
+// scanListenersFrom is the testable core — reads the given paths instead of
+// the real procfs files.
+func scanListenersFrom(tcpPath, tcp6Path string) ([]ListenSocket, error) {
+	var result []ListenSocket
+
+	if sockets, err := parseProcNetTCP(tcpPath, false); err == nil {
+		result = append(result, sockets...)
+	}
+	// tcp6 may not exist; ignore read errors.
+	if sockets, err := parseProcNetTCP(tcp6Path, true); err == nil {
+		result = append(result, sockets...)
+	}
+
+	return result, nil
+}
+
+// parseProcNetTCP parses a /proc/net/tcp or /proc/net/tcp6 file, returning
+// only LISTEN sockets.
+func parseProcNetTCP(path string, ipv6 bool) ([]ListenSocket, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return parseProcNetTCPData(string(data), ipv6)
+}
+
+// parseProcNetTCPData parses the content of a /proc/net/tcp{,6} file.
+// Exported for testing.
+func parseProcNetTCPData(data string, ipv6 bool) ([]ListenSocket, error) {
+	var result []ListenSocket
+
+	lines := strings.Split(strings.TrimSpace(data), "\n")
+	if len(lines) < 2 {
+		return nil, nil // header only or empty
+	}
+
+	// Skip the header line (line 0).
+	for _, line := range lines[1:] {
+		fields := strings.Fields(line)
+		// Need at least 4 fields: sl, local_address, rem_address, st
+		if len(fields) < 4 {
+			continue
+		}
+
+		state := fields[3]
+		if state != tcpListen {
+			continue
+		}
+
+		// local_address is "hex_ip:hex_port"
+		localAddr := fields[1]
+		port, bindAddr, err := parseLocalAddress(localAddr, ipv6)
+		if err != nil {
+			continue // skip malformed lines
+		}
+
+		result = append(result, ListenSocket{
+			Port:     port,
+			BindAddr: bindAddr,
+		})
+	}
+
+	return result, nil
+}
+
+// parseLocalAddress parses "HEXIP:HEXPORT" from /proc/net/tcp{,6}.
+func parseLocalAddress(s string, ipv6 bool) (port int, bindAddr string, err error) {
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return 0, "", fmt.Errorf("invalid local_address: %q", s)
+	}
+
+	hexIP := parts[0]
+	hexPort := parts[1]
+
+	// Parse port (always 4 hex digits).
+	var p int
+	if _, err := fmt.Sscanf(hexPort, "%X", &p); err != nil {
+		return 0, "", fmt.Errorf("invalid port hex %q: %w", hexPort, err)
+	}
+
+	// Parse IP address.
+	addr, err := parseHexIP(hexIP, ipv6)
+	if err != nil {
+		return 0, "", err
+	}
+
+	return p, addr, nil
+}
+
+// parseHexIP converts a hex-encoded IP from /proc/net/tcp to a human-readable string.
+// IPv4: 8 hex chars, little-endian 32-bit integer.
+// IPv6: 32 hex chars, four little-endian 32-bit groups.
+func parseHexIP(hex string, ipv6 bool) (string, error) {
+	if ipv6 {
+		return parseHexIPv6(hex)
+	}
+	return parseHexIPv4(hex)
+}
+
+func parseHexIPv4(hex string) (string, error) {
+	if len(hex) != 8 {
+		return "", fmt.Errorf("invalid IPv4 hex length: %d", len(hex))
+	}
+	var ip [4]byte
+	for i := 0; i < 4; i++ {
+		var b int
+		if _, err := fmt.Sscanf(hex[i*2:i*2+2], "%02X", &b); err != nil {
+			return "", err
+		}
+		// /proc/net/tcp stores IPv4 in little-endian order: byte 0 is rightmost.
+		ip[i] = byte(b)
+	}
+	// Reverse byte order (little-endian to host).
+	return fmt.Sprintf("%d.%d.%d.%d", ip[3], ip[2], ip[1], ip[0]), nil
+}
+
+func parseHexIPv6(hex string) (string, error) {
+	if len(hex) != 32 {
+		return "", fmt.Errorf("invalid IPv6 hex length: %d", len(hex))
+	}
+
+	// /proc/net/tcp6 stores each 32-bit group in little-endian.
+	// There are 4 groups of 8 hex chars.
+	var groups [4]uint32
+	for g := 0; g < 4; g++ {
+		chunk := hex[g*8 : g*8+8]
+		// Read the 4 bytes, then reverse for little-endian.
+		var bytes [4]byte
+		for i := 0; i < 4; i++ {
+			var b int
+			if _, err := fmt.Sscanf(chunk[i*2:i*2+2], "%02X", &b); err != nil {
+				return "", err
+			}
+			bytes[i] = byte(b)
+		}
+		// Reverse (little-endian to big-endian).
+		groups[g] = uint32(bytes[3])<<24 | uint32(bytes[2])<<16 | uint32(bytes[1])<<8 | uint32(bytes[0])
+	}
+
+	// Build standard IPv6 notation.
+	addr := fmt.Sprintf("%x:%x:%x:%x:%x:%x:%x:%x",
+		groups[0]>>16, groups[0]&0xFFFF,
+		groups[1]>>16, groups[1]&0xFFFF,
+		groups[2]>>16, groups[2]&0xFFFF,
+		groups[3]>>16, groups[3]&0xFFFF,
+	)
+
+	// Simplify well-known addresses.
+	switch addr {
+	case "0:0:0:0:0:0:0:0":
+		return "::", nil
+	case "0:0:0:0:0:0:0:1":
+		return "::1", nil
+	case "0:0:0:0:0:ffff:7f00:1":
+		return "127.0.0.1", nil // IPv4-mapped loopback
+	}
+
+	return addr, nil
+}

--- a/pkg/sciontool/autoexpose/scanner.go
+++ b/pkg/sciontool/autoexpose/scanner.go
@@ -117,12 +117,11 @@ func parseLocalAddress(s string, ipv6 bool) (port int, bindAddr string, err erro
 	hexPort := parts[1]
 
 	// Parse port (always 4 hex digits).
-	var p int
 	portVal, err := strconv.ParseUint(hexPort, 16, 16)
 	if err != nil {
 		return 0, "", fmt.Errorf("invalid port hex %q: %w", hexPort, err)
 	}
-	p = int(portVal)
+	port = int(portVal)
 
 	// Parse IP address.
 	addr, err := parseHexIP(hexIP, ipv6)
@@ -130,7 +129,7 @@ func parseLocalAddress(s string, ipv6 bool) (port int, bindAddr string, err erro
 		return 0, "", err
 	}
 
-	return p, addr, nil
+	return port, addr, nil
 }
 
 // parseHexIP converts a hex-encoded IP from /proc/net/tcp to a human-readable string.

--- a/pkg/sciontool/autoexpose/scanner_test.go
+++ b/pkg/sciontool/autoexpose/scanner_test.go
@@ -1,0 +1,246 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autoexpose
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// Sample /proc/net/tcp content with various socket states.
+const sampleProcNetTCP = `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0
+   1: 00000000:0BB8 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 12346 1 0000000000000000 100 0 0 10 0
+   2: 0100007F:47CC 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12347 1 0000000000000000 100 0 0 10 0
+   3: 0100007F:C350 01020304:0050 01 00000000:00000000 02:00000000 00000000  1000        0 12348 1 0000000000000000 100 0 0 10 0
+   4: 00000000:1388 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 12349 1 0000000000000000 100 0 0 10 0
+`
+
+// Sample /proc/net/tcp6 content.
+const sampleProcNetTCP6 = `  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000000000000000000000000000:1F90 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 23456 1 0000000000000000 100 0 0 10 0
+   1: 00000000000000000000000001000000:1F91 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 23457 1 0000000000000000 100 0 0 10 0
+   2: 00000000000000000000000000000000:0BB8 00000000000000000000000001000000:1F90 01 00000000:00000000 02:00000000 00000000  1000        0 23458 1 0000000000000000 100 0 0 10 0
+`
+
+func TestParseProcNetTCPData_IPv4(t *testing.T) {
+	sockets, err := parseProcNetTCPData(sampleProcNetTCP, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should find exactly 4 LISTEN sockets (state 0A), not the ESTABLISHED one (state 01).
+	if len(sockets) != 4 {
+		t.Fatalf("expected 4 LISTEN sockets, got %d", len(sockets))
+	}
+
+	// Sort by port for deterministic comparison.
+	sort.Slice(sockets, func(i, j int) bool { return sockets[i].Port < sockets[j].Port })
+
+	tests := []struct {
+		port     int
+		bindAddr string
+	}{
+		{3000, "0.0.0.0"},    // 0x0BB8 = 3000, 00000000 = 0.0.0.0
+		{5000, "0.0.0.0"},    // 0x1388 = 5000, 00000000 = 0.0.0.0
+		{8080, "127.0.0.1"},  // 0x1F90 = 8080, 0100007F = 127.0.0.1
+		{18380, "127.0.0.1"}, // 0x47CC = 18380, 0100007F = 127.0.0.1
+	}
+
+	for i, tt := range tests {
+		if sockets[i].Port != tt.port {
+			t.Errorf("socket[%d].Port = %d, want %d", i, sockets[i].Port, tt.port)
+		}
+		if sockets[i].BindAddr != tt.bindAddr {
+			t.Errorf("socket[%d].BindAddr = %q, want %q", i, sockets[i].BindAddr, tt.bindAddr)
+		}
+	}
+}
+
+func TestParseProcNetTCPData_IPv6(t *testing.T) {
+	sockets, err := parseProcNetTCPData(sampleProcNetTCP6, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should find 2 LISTEN sockets (not the ESTABLISHED one).
+	if len(sockets) != 2 {
+		t.Fatalf("expected 2 LISTEN sockets, got %d", len(sockets))
+	}
+
+	sort.Slice(sockets, func(i, j int) bool { return sockets[i].Port < sockets[j].Port })
+
+	// Port 8080 (0x1F90) on :: (all zeros)
+	if sockets[0].Port != 8080 {
+		t.Errorf("socket[0].Port = %d, want 8080", sockets[0].Port)
+	}
+	if sockets[0].BindAddr != "::" {
+		t.Errorf("socket[0].BindAddr = %q, want %q", sockets[0].BindAddr, "::")
+	}
+
+	// Port 8081 (0x1F91) on ::1
+	if sockets[1].Port != 8081 {
+		t.Errorf("socket[1].Port = %d, want 8081", sockets[1].Port)
+	}
+	if sockets[1].BindAddr != "::1" {
+		t.Errorf("socket[1].BindAddr = %q, want %q", sockets[1].BindAddr, "::1")
+	}
+}
+
+func TestParseProcNetTCPData_EmptyFile(t *testing.T) {
+	sockets, err := parseProcNetTCPData("", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sockets) != 0 {
+		t.Fatalf("expected 0 sockets from empty data, got %d", len(sockets))
+	}
+}
+
+func TestParseProcNetTCPData_HeaderOnly(t *testing.T) {
+	data := "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n"
+	sockets, err := parseProcNetTCPData(data, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sockets) != 0 {
+		t.Fatalf("expected 0 sockets from header-only data, got %d", len(sockets))
+	}
+}
+
+func TestParseProcNetTCPData_MalformedLines(t *testing.T) {
+	data := `  sl  local_address rem_address   st
+   0: BADDATA 0A
+   1: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12345
+   2: short
+`
+	sockets, err := parseProcNetTCPData(data, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Only the well-formed LISTEN line should parse.
+	if len(sockets) != 1 {
+		t.Fatalf("expected 1 socket from mixed data, got %d", len(sockets))
+	}
+	if sockets[0].Port != 8080 {
+		t.Errorf("port = %d, want 8080", sockets[0].Port)
+	}
+}
+
+func TestParseProcNetTCPData_NoListenSockets(t *testing.T) {
+	// All sockets are ESTABLISHED (state 01).
+	data := `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 0100007F:1F90 01020304:0050 01 00000000:00000000 02:00000000 00000000  1000        0 12345 1 0000000000000000 100 0 0 10 0
+   1: 0100007F:C350 01020304:0051 01 00000000:00000000 02:00000000 00000000  1000        0 12346 1 0000000000000000 100 0 0 10 0
+`
+	sockets, err := parseProcNetTCPData(data, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sockets) != 0 {
+		t.Fatalf("expected 0 LISTEN sockets, got %d", len(sockets))
+	}
+}
+
+func TestScanListenersFrom_BothFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	tcpPath := filepath.Join(dir, "tcp")
+	tcp6Path := filepath.Join(dir, "tcp6")
+
+	if err := os.WriteFile(tcpPath, []byte(sampleProcNetTCP), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tcp6Path, []byte(sampleProcNetTCP6), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sockets, err := scanListenersFrom(tcpPath, tcp6Path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 4 from tcp + 2 from tcp6 = 6 total.
+	if len(sockets) != 6 {
+		t.Errorf("expected 6 total sockets, got %d", len(sockets))
+	}
+}
+
+func TestScanListenersFrom_MissingTCP6(t *testing.T) {
+	dir := t.TempDir()
+
+	tcpPath := filepath.Join(dir, "tcp")
+	tcp6Path := filepath.Join(dir, "tcp6_missing")
+
+	if err := os.WriteFile(tcpPath, []byte(sampleProcNetTCP), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// tcp6 doesn't exist — should succeed with only tcp results.
+	sockets, err := scanListenersFrom(tcpPath, tcp6Path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(sockets) != 4 {
+		t.Errorf("expected 4 sockets from tcp only, got %d", len(sockets))
+	}
+}
+
+func TestParseHexIPv4(t *testing.T) {
+	tests := []struct {
+		hex  string
+		want string
+	}{
+		{"00000000", "0.0.0.0"},
+		{"0100007F", "127.0.0.1"},
+		{"0101A8C0", "192.168.1.1"},
+	}
+
+	for _, tt := range tests {
+		got, err := parseHexIPv4(tt.hex)
+		if err != nil {
+			t.Errorf("parseHexIPv4(%q) error: %v", tt.hex, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parseHexIPv4(%q) = %q, want %q", tt.hex, got, tt.want)
+		}
+	}
+}
+
+func TestParseHexIPv6_WellKnown(t *testing.T) {
+	tests := []struct {
+		hex  string
+		want string
+	}{
+		{"00000000000000000000000000000000", "::"},
+		{"00000000000000000000000001000000", "::1"},
+		{"0000000000000000FFFF00000100007F", "127.0.0.1"}, // IPv4-mapped ::ffff:127.0.0.1
+	}
+
+	for _, tt := range tests {
+		got, err := parseHexIPv6(tt.hex)
+		if err != nil {
+			t.Errorf("parseHexIPv6(%q) error: %v", tt.hex, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parseHexIPv6(%q) = %q, want %q", tt.hex, got, tt.want)
+		}
+	}
+}

--- a/pkg/sciontool/autoexpose/scanner_test.go
+++ b/pkg/sciontool/autoexpose/scanner_test.go
@@ -201,6 +201,23 @@ func TestScanListenersFrom_MissingTCP6(t *testing.T) {
 	}
 }
 
+func TestScanListenersFrom_TCPReadError(t *testing.T) {
+	dir := t.TempDir()
+
+	// tcp file does not exist — should return an error.
+	tcpPath := filepath.Join(dir, "tcp_missing")
+	tcp6Path := filepath.Join(dir, "tcp6")
+
+	if err := os.WriteFile(tcp6Path, []byte(sampleProcNetTCP6), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := scanListenersFrom(tcpPath, tcp6Path)
+	if err == nil {
+		t.Fatal("expected error when /proc/net/tcp is unreadable, got nil")
+	}
+}
+
 func TestParseHexIPv4(t *testing.T) {
 	tests := []struct {
 		hex  string

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -206,6 +206,8 @@ interface ServerConfigResponse {
   default_model?: string;
   default_thinking_level?: number | null;
 
+  auto_expose_ports?: { enabled?: boolean };
+
   // Settings-DB metadata (postgres mode only; absent in file/SQLite mode)
   settings_tier?: 'db' | 'file';
   env_overrides?: string[];
@@ -319,6 +321,8 @@ const KOANF_KEY_LABELS: Record<string, string> = {
   'server.hub.auto_suspend_stalled': 'Auto-Suspend Stalled Agents',
   'server.hub.soft_delete_retention': 'Soft Delete Retention',
   'server.hub.soft_delete_retain_files': 'Retain Files on Soft Delete',
+  // auto_expose_ports section
+  'auto_expose_ports.enabled': 'Auto-Expose Ports Enabled',
   // telemetry section
   'telemetry.enabled': 'Telemetry Enabled',
   'telemetry.cloud.enabled': 'Cloud Export Enabled',
@@ -456,6 +460,9 @@ export class ScionPageAdminServerConfig extends LitElement {
   // Secrets
   @state() private secretsBackend = '';
   @state() private secretsGCPProjectId = '';
+
+  // Auto-expose ports
+  @state() private autoExposePortsEnabled = false;
 
   // Telemetry
   @state() private telemetryEnabled = false;
@@ -1429,6 +1436,12 @@ export class ScionPageAdminServerConfig extends LitElement {
       }
     }
 
+    // Auto-expose ports
+    const aep = data.auto_expose_ports;
+    if (aep) {
+      this.autoExposePortsEnabled = aep.enabled || false;
+    }
+
     // Runtimes, harness_configs, profiles preserved via rawConfig
 
     // Settings-DB metadata (postgres mode only; absent in file/SQLite mode)
@@ -1638,6 +1651,13 @@ export class ScionPageAdminServerConfig extends LitElement {
       payload.telemetry = telemetry;
     }
 
+    // Auto-expose ports — Layer-1
+    if (ok('auto_expose_ports.enabled')) {
+      payload.auto_expose_ports = {
+        enabled: this.autoExposePortsEnabled,
+      };
+    }
+
     // Preserve runtimes, harness_configs, profiles from raw config
     if (this.rawConfig?.runtimes) payload.runtimes = this.rawConfig.runtimes;
     if (this.rawConfig?.harness_configs) payload.harness_configs = this.rawConfig.harness_configs;
@@ -1839,6 +1859,13 @@ export class ScionPageAdminServerConfig extends LitElement {
       };
     }
     if (Object.keys(telemetry).length > 0) payload.telemetry = telemetry;
+
+    // Auto-expose ports
+    if (ok('auto_expose_ports.enabled')) {
+      payload.auto_expose_ports = {
+        enabled: this.autoExposePortsEnabled,
+      };
+    }
 
     // Preserve runtimes, harness_configs, profiles from raw config
     if (this.rawConfig?.runtimes) payload.runtimes = this.rawConfig.runtimes;
@@ -2691,6 +2718,20 @@ export class ScionPageAdminServerConfig extends LitElement {
                     >`
                   )}
                   <span class="hint">Default opt-in state for new agents</span>
+                </div>
+                <div class="form-field full-width">
+                  ${this.renderFieldValue(
+                    'auto_expose_ports.enabled',
+                    this.autoExposePortsEnabled ? 'Enabled' : 'Disabled',
+                    html`${this.renderEnvBadge('auto_expose_ports.enabled')}<sl-switch
+                      ?checked=${this.autoExposePortsEnabled}
+                      @sl-change=${(e: Event) => {
+                        this.autoExposePortsEnabled = (e.target as HTMLInputElement).checked;
+                      }}
+                      >Enable Auto-Expose Ports</sl-switch
+                    >`
+                  )}
+                  <span class="hint">Automatically detect and expose listening TCP ports in agent containers</span>
                 </div>
                 <div class="form-field">
                   <label>Default Model</label>

--- a/web/src/components/pages/agent-configure.ts
+++ b/web/src/components/pages/agent-configure.ts
@@ -51,12 +51,6 @@ interface ScionConfigPayload {
   thinking_level?: number | null;
   env?: Record<string, string>;
   telemetry?: { enabled?: boolean };
-  auto_expose_ports?: {
-    enabled?: boolean;
-    mode?: string;
-    ports?: string;
-    interval?: string;
-  };
 }
 
 interface AppliedConfig {
@@ -463,10 +457,14 @@ export class ScionPageAgentConfigure extends LitElement {
     this.authMethod = ac?.harnessAuth || ic?.auth_selectedType || '';
     this.harnessConfig = ac?.harnessConfig || ic?.harness_config || '';
     this.telemetryEnabled = ic?.telemetry?.enabled ?? this.globalTelemetryDefault;
-    this.autoExposePortsEnabled = ic?.auto_expose_ports?.enabled ?? this.globalAutoExposePortsDefault;
-    this.autoExposePortsMode = ic?.auto_expose_ports?.mode || 'allowlist';
-    this.autoExposePortsList = ic?.auto_expose_ports?.ports || '';
-    this.autoExposePortsInterval = ic?.auto_expose_ports?.interval || '3s';
+    this.autoExposePortsEnabled = ic?.env?.SCION_AUTO_EXPOSE_PORTS === 'true'
+      ? true
+      : ic?.env?.SCION_AUTO_EXPOSE_PORTS === 'false'
+        ? false
+        : this.globalAutoExposePortsDefault;
+    this.autoExposePortsMode = ic?.env?.SCION_AUTO_EXPOSE_MODE || 'allowlist';
+    this.autoExposePortsList = ic?.env?.SCION_AUTO_EXPOSE_PORTS_LIST || '';
+    this.autoExposePortsInterval = ic?.env?.SCION_AUTO_EXPOSE_INTERVAL || '3s';
 
     // Task & Prompts
     this.task = ac?.task || ic?.task || '';
@@ -483,9 +481,15 @@ export class ScionPageAgentConfigure extends LitElement {
     this.memoryLimit = ic?.resources?.limits?.memory || '';
     this.disk = ic?.resources?.disk || '';
 
-    // Environment
+    // Environment — filter out auto-expose env vars managed by dedicated UI controls
+    const autoExposeEnvKeys = new Set([
+      'SCION_AUTO_EXPOSE_PORTS', 'SCION_AUTO_EXPOSE_MODE',
+      'SCION_AUTO_EXPOSE_PORTS_LIST', 'SCION_AUTO_EXPOSE_INTERVAL',
+    ]);
     const env = ac?.env || ic?.env || {};
-    this.envEntries = Object.entries(env).map(([key, value]) => ({ key, value }));
+    this.envEntries = Object.entries(env)
+      .filter(([key]) => !autoExposeEnvKeys.has(key))
+      .map(([key, value]) => ({ key, value }));
 
     // Detect required keys that are empty (from env gathering)
     this.requiredEnvKeys = this.envEntries
@@ -543,6 +547,17 @@ export class ScionPageAgentConfigure extends LitElement {
         env[entry.key] = entry.value;
       }
     }
+
+    // Auto-expose ports (written as env vars, matching agent-create)
+    env.SCION_AUTO_EXPOSE_PORTS = this.autoExposePortsEnabled ? 'true' : 'false';
+    if (this.autoExposePortsEnabled) {
+      env.SCION_AUTO_EXPOSE_MODE = this.autoExposePortsMode;
+      if (this.autoExposePortsList) {
+        env.SCION_AUTO_EXPOSE_PORTS_LIST = this.autoExposePortsList;
+      }
+      env.SCION_AUTO_EXPOSE_INTERVAL = this.autoExposePortsInterval || '3s';
+    }
+
     if (Object.keys(env).length > 0) {
       config.env = env;
     }
@@ -551,17 +566,6 @@ export class ScionPageAgentConfigure extends LitElement {
     if (!this.isUnsupported(caps?.telemetry.enabled)) {
       config.telemetry = { enabled: this.telemetryEnabled };
     }
-
-    // Auto-expose ports
-    const aep: Record<string, unknown> = { enabled: this.autoExposePortsEnabled };
-    if (this.autoExposePortsEnabled) {
-      aep.mode = this.autoExposePortsMode;
-      if (this.autoExposePortsList) {
-        aep.ports = this.autoExposePortsList;
-      }
-      aep.interval = this.autoExposePortsInterval || '3s';
-    }
-    config.auto_expose_ports = aep;
 
     return config;
   }

--- a/web/src/components/pages/agent-configure.ts
+++ b/web/src/components/pages/agent-configure.ts
@@ -51,6 +51,12 @@ interface ScionConfigPayload {
   thinking_level?: number | null;
   env?: Record<string, string>;
   telemetry?: { enabled?: boolean };
+  auto_expose_ports?: {
+    enabled?: boolean;
+    mode?: string;
+    ports?: string;
+    interval?: string;
+  };
 }
 
 interface AppliedConfig {
@@ -92,6 +98,10 @@ export class ScionPageAgentConfigure extends LitElement {
   @state() private authMethod = '';
   @state() private harnessConfig = '';
   @state() private telemetryEnabled = false;
+  @state() private autoExposePortsEnabled = false;
+  @state() private autoExposePortsMode = 'allowlist';
+  @state() private autoExposePortsList = '';
+  @state() private autoExposePortsInterval = '3s';
 
   // Form fields — Task & Prompts
   @state() private task = '';
@@ -385,6 +395,7 @@ export class ScionPageAgentConfigure extends LitElement {
   }
 
   private globalTelemetryDefault = false;
+  private globalAutoExposePortsDefault = false;
 
   private async loadAgent(): Promise<void> {
     this.loading = true;
@@ -397,8 +408,12 @@ export class ScionPageAgentConfigure extends LitElement {
       ]);
 
       if (settingsRes.ok) {
-        const data = (await settingsRes.json()) as { telemetryEnabled?: boolean };
+        const data = (await settingsRes.json()) as {
+          telemetryEnabled?: boolean;
+          autoExposePortsEnabled?: boolean;
+        };
         this.globalTelemetryDefault = data.telemetryEnabled ?? false;
+        this.globalAutoExposePortsDefault = data.autoExposePortsEnabled ?? false;
       }
 
       if (!agentRes.ok) {
@@ -448,6 +463,10 @@ export class ScionPageAgentConfigure extends LitElement {
     this.authMethod = ac?.harnessAuth || ic?.auth_selectedType || '';
     this.harnessConfig = ac?.harnessConfig || ic?.harness_config || '';
     this.telemetryEnabled = ic?.telemetry?.enabled ?? this.globalTelemetryDefault;
+    this.autoExposePortsEnabled = ic?.auto_expose_ports?.enabled ?? this.globalAutoExposePortsDefault;
+    this.autoExposePortsMode = ic?.auto_expose_ports?.mode || 'allowlist';
+    this.autoExposePortsList = ic?.auto_expose_ports?.ports || '';
+    this.autoExposePortsInterval = ic?.auto_expose_ports?.interval || '3s';
 
     // Task & Prompts
     this.task = ac?.task || ic?.task || '';
@@ -532,6 +551,17 @@ export class ScionPageAgentConfigure extends LitElement {
     if (!this.isUnsupported(caps?.telemetry.enabled)) {
       config.telemetry = { enabled: this.telemetryEnabled };
     }
+
+    // Auto-expose ports
+    const aep: Record<string, unknown> = { enabled: this.autoExposePortsEnabled };
+    if (this.autoExposePortsEnabled) {
+      aep.mode = this.autoExposePortsMode;
+      if (this.autoExposePortsList) {
+        aep.ports = this.autoExposePortsList;
+      }
+      aep.interval = this.autoExposePortsInterval || '3s';
+    }
+    config.auto_expose_ports = aep;
 
     return config;
   }
@@ -996,6 +1026,68 @@ export class ScionPageAgentConfigure extends LitElement {
           <span class="help-badge">?</span>
         </sl-tooltip>
       </div>
+
+      <div class="notify-field">
+        <sl-checkbox
+          ?checked=${this.autoExposePortsEnabled}
+          @sl-change=${(e: Event) => { this.autoExposePortsEnabled = (e.target as HTMLInputElement).checked; }}
+        >
+          Enable Auto-Expose Ports
+        </sl-checkbox>
+        <sl-tooltip
+          content="Automatically detect and expose TCP listening ports from this agent's container. The default reflects the global auto-expose setting."
+          hoist
+        >
+          <span class="help-badge">?</span>
+        </sl-tooltip>
+      </div>
+
+      ${this.autoExposePortsEnabled
+        ? html`
+            <div class="form-field">
+              <label for="auto-expose-mode">Port Filter Mode</label>
+              <sl-select
+                id="auto-expose-mode"
+                .value=${this.autoExposePortsMode}
+                @sl-change=${(e: Event) => {
+                  this.autoExposePortsMode = (e.target as HTMLElement & { value: string }).value;
+                }}
+              >
+                <sl-option value="allowlist">Allowlist</sl-option>
+                <sl-option value="denylist">Denylist</sl-option>
+              </sl-select>
+              <div class="hint">
+                ${this.autoExposePortsMode === 'allowlist'
+                  ? 'Only expose ports in the filter list below.'
+                  : 'Expose all ports except those in the filter list below.'}
+              </div>
+            </div>
+            <div class="form-field">
+              <label for="auto-expose-ports-list">Port Filter List</label>
+              <sl-input
+                id="auto-expose-ports-list"
+                placeholder="e.g. 3000,5173,8080"
+                .value=${this.autoExposePortsList}
+                @sl-input=${(e: Event) => {
+                  this.autoExposePortsList = (e.target as HTMLElement & { value: string }).value;
+                }}
+              ></sl-input>
+              <div class="hint">Comma-separated list of ports to ${this.autoExposePortsMode === 'allowlist' ? 'allow' : 'deny'}.</div>
+            </div>
+            <div class="form-field">
+              <label for="auto-expose-interval">Scan Interval</label>
+              <sl-input
+                id="auto-expose-interval"
+                placeholder="3s"
+                .value=${this.autoExposePortsInterval}
+                @sl-input=${(e: Event) => {
+                  this.autoExposePortsInterval = (e.target as HTMLElement & { value: string }).value;
+                }}
+              ></sl-input>
+              <div class="hint">How often to scan for new listening ports (e.g. 3s, 5s). Minimum 1s.</div>
+            </div>
+          `
+        : nothing}
     `;
   }
 

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -111,6 +111,18 @@ export class ScionPageAgentCreate extends LitElement {
   private telemetryEnabled = false;
 
   @state()
+  private autoExposePortsEnabled = false;
+
+  @state()
+  private autoExposePortsMode = 'allowlist';
+
+  @state()
+  private autoExposePortsList = '';
+
+  @state()
+  private autoExposePortsInterval = '3s';
+
+  @state()
   private gcpMetadataMode: 'block' | 'passthrough' | 'assign' = 'block';
 
   @state()
@@ -409,8 +421,12 @@ export class ScionPageAgentCreate extends LitElement {
       }
 
       if (settingsRes.ok) {
-        const data = (await settingsRes.json()) as { telemetryEnabled?: boolean };
+        const data = (await settingsRes.json()) as {
+          telemetryEnabled?: boolean;
+          autoExposePortsEnabled?: boolean;
+        };
         this.telemetryEnabled = data.telemetryEnabled ?? false;
+        this.autoExposePortsEnabled = data.autoExposePortsEnabled ?? false;
       }
 
       if (harnessConfigsRes.ok) {
@@ -537,11 +553,18 @@ export class ScionPageAgentCreate extends LitElement {
       }
 
       // Pass config options
-      const config: Record<string, unknown> = {
-        env: {
-          SCION_TELEMETRY_ENABLED: this.telemetryEnabled ? 'true' : 'false',
-        },
+      const env: Record<string, string> = {
+        SCION_TELEMETRY_ENABLED: this.telemetryEnabled ? 'true' : 'false',
+        SCION_AUTO_EXPOSE_PORTS: this.autoExposePortsEnabled ? 'true' : 'false',
       };
+      if (this.autoExposePortsEnabled) {
+        env.SCION_AUTO_EXPOSE_MODE = this.autoExposePortsMode;
+        if (this.autoExposePortsList) {
+          env.SCION_AUTO_EXPOSE_PORTS_LIST = this.autoExposePortsList;
+        }
+        env.SCION_AUTO_EXPOSE_INTERVAL = this.autoExposePortsInterval || '3s';
+      }
+      const config: Record<string, unknown> = { env };
 
       body.config = config;
 
@@ -1323,6 +1346,66 @@ private selectBrokerForProject(): void {
                           accounts in project settings.
                         </div>
                       `}
+                </div>
+              `
+            : ''}
+
+          <div class="form-field">
+            <label>Auto-Expose Ports</label>
+            <sl-checkbox
+              ?checked=${this.autoExposePortsEnabled}
+              @sl-change=${(e: Event) => {
+                this.autoExposePortsEnabled = (e.target as HTMLInputElement).checked;
+              }}
+            >
+              Enable Auto-Expose Ports
+            </sl-checkbox>
+            <div class="hint">Automatically detect and expose TCP listening ports from the agent container.</div>
+          </div>
+
+          ${this.autoExposePortsEnabled
+            ? html`
+                <div class="form-field">
+                  <label for="auto-expose-mode">Port Filter Mode</label>
+                  <sl-select
+                    id="auto-expose-mode"
+                    .value=${this.autoExposePortsMode}
+                    @sl-change=${(e: Event) => {
+                      this.autoExposePortsMode = (e.target as HTMLElement & { value: string }).value;
+                    }}
+                  >
+                    <sl-option value="allowlist">Allowlist</sl-option>
+                    <sl-option value="denylist">Denylist</sl-option>
+                  </sl-select>
+                  <div class="hint">
+                    ${this.autoExposePortsMode === 'allowlist'
+                      ? 'Only expose ports in the filter list below.'
+                      : 'Expose all ports except those in the filter list below.'}
+                  </div>
+                </div>
+                <div class="form-field">
+                  <label for="auto-expose-ports-list">Port Filter List</label>
+                  <sl-input
+                    id="auto-expose-ports-list"
+                    placeholder="e.g. 3000,5173,8080"
+                    .value=${this.autoExposePortsList}
+                    @sl-input=${(e: Event) => {
+                      this.autoExposePortsList = (e.target as HTMLElement & { value: string }).value;
+                    }}
+                  ></sl-input>
+                  <div class="hint">Comma-separated list of ports to ${this.autoExposePortsMode === 'allowlist' ? 'allow' : 'deny'}.</div>
+                </div>
+                <div class="form-field">
+                  <label for="auto-expose-interval">Scan Interval</label>
+                  <sl-input
+                    id="auto-expose-interval"
+                    placeholder="3s"
+                    .value=${this.autoExposePortsInterval}
+                    @sl-input=${(e: Event) => {
+                      this.autoExposePortsInterval = (e.target as HTMLElement & { value: string }).value;
+                    }}
+                  ></sl-input>
+                  <div class="hint">How often to scan for new listening ports (e.g. 3s, 5s). Minimum 1s.</div>
                 </div>
               `
             : ''}

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -55,6 +55,7 @@ interface ProjectSettings {
   defaultTemplate?: string | undefined;
   defaultHarnessConfig?: string | undefined;
   telemetryEnabled?: boolean | null | undefined;
+  autoExposePortsEnabled?: boolean | null | undefined;
   activeProfile?: string | undefined;
   defaultMaxTurns?: number | undefined;
   defaultMaxModelCalls?: number | undefined;
@@ -158,7 +159,13 @@ export class ScionPageProjectSettings extends LitElement {
   private configTelemetryEnabled: boolean | null = null;
 
   @state()
+  private configAutoExposePortsEnabled: boolean | null = null;
+
+  @state()
   private hubTelemetryDefault: boolean | null = null;
+
+  @state()
+  private hubAutoExposePortsDefault: boolean | null = null;
 
   /** Per-setting hub default info from the resolved endpoint. */
   @state()
@@ -961,6 +968,14 @@ export class ScionPageProjectSettings extends LitElement {
         } else {
           this.hubTelemetryDefault = null;
         }
+
+        // Extract auto-expose ports hub default from the resolved response.
+        const apeEntry = this.resolvedSettings['scion.io/auto-expose-ports-enabled'];
+        if (apeEntry?.hubDefault === 'present' && apeEntry.hubValue != null) {
+          this.hubAutoExposePortsDefault = apeEntry.hubValue as boolean;
+        } else {
+          this.hubAutoExposePortsDefault = null;
+        }
       } else if (resolvedResponse.status === 404) {
         // Backward compatibility: older hub without the resolved endpoint.
         // Fall back to the plain settings endpoint with generic placeholders.
@@ -991,6 +1006,7 @@ export class ScionPageProjectSettings extends LitElement {
       this.configDefaultTemplate = this.settings.defaultTemplate || '';
       this.configDefaultHarnessConfig = this.settings.defaultHarnessConfig || '';
       this.configTelemetryEnabled = this.settings.telemetryEnabled ?? null;
+      this.configAutoExposePortsEnabled = this.settings.autoExposePortsEnabled ?? null;
       this.configDefaultMaxTurns = this.settings.defaultMaxTurns || 0;
       this.configDefaultMaxModelCalls = this.settings.defaultMaxModelCalls || 0;
       this.configDefaultMaxDuration = this.settings.defaultMaxDuration || '';
@@ -1165,6 +1181,7 @@ export class ScionPageProjectSettings extends LitElement {
         defaultHarnessConfig: this.configDefaultHarnessConfig || undefined,
         defaultModel: defaultModel || undefined,
         telemetryEnabled: this.configTelemetryEnabled,
+        autoExposePortsEnabled: this.configAutoExposePortsEnabled,
         defaultMaxTurns: this.configDefaultMaxTurns || undefined,
         defaultMaxModelCalls: this.configDefaultMaxModelCalls || undefined,
         defaultMaxDuration: this.configDefaultMaxDuration || undefined,
@@ -1743,6 +1760,32 @@ export class ScionPageProjectSettings extends LitElement {
                 </sl-select>
                 <span class="field-help"
                   >Controls telemetry for agents in this project. "Use hub default" inherits the server-level setting.</span
+                >
+              </div>
+
+              <div class="config-field ${this.isHubDefault('scion.io/auto-expose-ports-enabled') ? 'hub-inherited' : ''}">
+                <label>Auto-Expose Ports ${this.renderHubIndicator('scion.io/auto-expose-ports-enabled')}</label>
+                <sl-select
+                  value=${this.configAutoExposePortsEnabled === true
+                    ? 'enabled'
+                    : this.configAutoExposePortsEnabled === false
+                      ? 'disabled'
+                      : 'inherit'}
+                  ?disabled=${!canEdit}
+                  @sl-change=${(e: Event) => {
+                    const val = (e.target as HTMLSelectElement).value;
+                    this.configAutoExposePortsEnabled =
+                      val === 'enabled' ? true : val === 'disabled' ? false : null;
+                  }}
+                >
+                  <sl-option value="inherit"
+                    >Use hub default (${this.hubAutoExposePortsDefault === null ? '…' : this.hubAutoExposePortsDefault ? 'enabled' : 'disabled'})</sl-option
+                  >
+                  <sl-option value="enabled">Enabled</sl-option>
+                  <sl-option value="disabled">Disabled</sl-option>
+                </sl-select>
+                <span class="field-help"
+                  >Automatically detect and expose listening TCP ports in agent containers. "Use hub default" inherits the server-level setting.</span
                 >
               </div>
 

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -334,16 +334,6 @@ export interface TelemetryConfig {
 }
 
 /**
- * Auto-expose ports configuration for an agent.
- */
-export interface AutoExposePortsConfig {
-  enabled?: boolean;
-  mode?: string;
-  ports?: string;
-  interval?: string;
-}
-
-/**
  * Inline configuration values set at agent creation time.
  */
 export interface AgentInlineConfig {
@@ -356,7 +346,6 @@ export interface AgentInlineConfig {
   task?: string;
   image?: string;
   telemetry?: TelemetryConfig;
-  auto_expose_ports?: AutoExposePortsConfig;
 }
 
 export type SupportLevel = 'no' | 'partial' | 'yes';

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -334,6 +334,16 @@ export interface TelemetryConfig {
 }
 
 /**
+ * Auto-expose ports configuration for an agent.
+ */
+export interface AutoExposePortsConfig {
+  enabled?: boolean;
+  mode?: string;
+  ports?: string;
+  interval?: string;
+}
+
+/**
  * Inline configuration values set at agent creation time.
  */
 export interface AgentInlineConfig {
@@ -346,6 +356,7 @@ export interface AgentInlineConfig {
   task?: string;
   image?: string;
   telemetry?: TelemetryConfig;
+  auto_expose_ports?: AutoExposePortsConfig;
 }
 
 export type SupportLevel = 'no' | 'partial' | 'yes';


### PR DESCRIPTION
Adds automatic port detection and exposure for agent containers. When enabled via SCION_AUTO_EXPOSE_PORTS=true, a reconciliation loop in sciontool init scans /proc/net/tcp and /proc/net/tcp6 for LISTEN sockets and auto-registers/deregisters them with the Hub.

Key design:
- New pkg/sciontool/autoexpose/ package (scanner, reconciler, config)
- Diff-based reconciliation on configurable ticker (default 3s)
- Reuses existing Hub client library (RegisterPort/DeletePort/ListPorts) -- no new API endpoints
- Integration as background goroutine in init.go alongside heartbeat and port-forward tunnel

Security controls (all required, all implemented):
- Opt-in disabled by default (SCION_AUTO_EXPOSE_PORTS env var)
- Allowlist filter mode by default (empty allowlist = nothing exposed)
- Denied infrastructure ports (8080, 9810, 18380) enforced client-side
- Minimum port threshold (default 1024)
- Auto-exposed ports labeled "auto-scan" to distinguish from manual
- Never auto-unexpose manually-exposed ports

Files: 7 (new package + init.go integration), 30 tests
Two independent fork review rounds, both approved.

Ref: ptone/scion#699
