### PR TITLE
feat(auth): config-driven auth migration — remove hardcoded per-provider fields

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -604,11 +604,9 @@ func RunAgent(cmd *cobra.Command, args []string, resume bool) error {
 	if debugMode && !noAuth {
 		localAuth := harness.GatherAuth()
 		util.Debugf("[auth] local credential preview:")
-		util.Debugf("[auth]   hasGeminiAPIKey=%t, hasGoogleAPIKey=%t", localAuth.GeminiAPIKey != "", localAuth.GoogleAPIKey != "")
-		util.Debugf("[auth]   hasAnthropicAPIKey=%t", localAuth.AnthropicAPIKey != "")
-		util.Debugf("[auth]   hasOAuthCreds=%t (%s)", localAuth.OAuthCreds != "", localAuth.OAuthCreds)
 		util.Debugf("[auth]   hasGoogleAppCredentials=%t", localAuth.GoogleAppCredentials != "")
 		util.Debugf("[auth]   cloudProject=%q, cloudRegion=%q", localAuth.GoogleCloudProject, localAuth.GoogleCloudRegion)
+		util.Debugf("[auth]   envVarCount=%d, fileCount=%d", len(localAuth.EnvVars), len(localAuth.Files))
 	}
 
 	// We still might want to show some progress in the CLI
@@ -819,11 +817,9 @@ func startAgentViaHub(hubCtx *HubContext, agentName, task string, resume bool, i
 		// Preview auth credentials visible from the CLI host
 		localAuth := harness.GatherAuth()
 		util.Debugf("[auth] CLI-side credential preview (what the broker will see via env/secrets):")
-		util.Debugf("[auth]   hasGeminiAPIKey=%t, hasGoogleAPIKey=%t", localAuth.GeminiAPIKey != "", localAuth.GoogleAPIKey != "")
-		util.Debugf("[auth]   hasAnthropicAPIKey=%t", localAuth.AnthropicAPIKey != "")
-		util.Debugf("[auth]   hasOAuthCreds=%t (%s)", localAuth.OAuthCreds != "", localAuth.OAuthCreds)
 		util.Debugf("[auth]   hasGoogleAppCredentials=%t", localAuth.GoogleAppCredentials != "")
 		util.Debugf("[auth]   cloudProject=%q, cloudRegion=%q", localAuth.GoogleCloudProject, localAuth.GoogleCloudRegion)
+		util.Debugf("[auth]   envVarCount=%d, fileCount=%d", len(localAuth.EnvVars), len(localAuth.Files))
 	}
 
 	// Detect non-git project for workspace bootstrap.

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -618,7 +618,7 @@ func TestSendOutboundMessageViaHub(t *testing.T) {
 		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 		case r.Method == http.MethodPost && (r.URL.Path == "/api/v1/projects/"+projectID+"/agents/my-agent/outbound-message" ||
-				r.URL.Path == "/api/v1/groves/"+projectID+"/agents/my-agent/outbound-message"):
+			r.URL.Path == "/api/v1/groves/"+projectID+"/agents/my-agent/outbound-message"):
 			var msg hubclient.OutboundMessageRequest
 			_ = json.NewDecoder(r.Body).Decode(&msg)
 			receivedMsg = &msg

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -472,19 +472,15 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 	if !opts.NoAuth {
 		auth = harness.GatherAuthWithEnv(authEnvOverlay, !opts.BrokerMode, authMeta)
 		if opts.BrokerMode {
-			harness.OverlayFileSecrets(&auth, opts.ResolvedSecrets)
+			harness.OverlayFileSecrets(&auth, opts.ResolvedSecrets, authMeta)
 		}
-		util.Debugf("auth: gathered credentials — selectedType=%q, hasGeminiKey=%t, hasGoogleKey=%t, hasOAuth=%t, hasADC=%t, hasAnthropicKey=%t, hasClaudeOAuthToken=%t, hasClaudeAuthFile=%t, cloudProject=%q, gcpMetadataMode=%q, brokerMode=%t",
+		util.Debugf("auth: gathered credentials — selectedType=%q, hasADC=%t, cloudProject=%q, gcpMetadataMode=%q, envVarCount=%d, fileCount=%d, brokerMode=%t",
 			auth.SelectedType,
-			auth.GeminiAPIKey != "",
-			auth.GoogleAPIKey != "",
-			auth.OAuthCreds != "",
 			auth.GoogleAppCredentials != "",
-			auth.AnthropicAPIKey != "",
-			auth.ClaudeOAuthToken != "",
-			auth.ClaudeAuthFile != "",
 			auth.GoogleCloudProject,
 			auth.GCPMetadataMode,
+			len(auth.EnvVars),
+			len(auth.Files),
 			opts.BrokerMode,
 		)
 		harness.OverlaySettings(&auth, h, agentDir)
@@ -1348,28 +1344,23 @@ func secretEnvTarget(s api.ResolvedSecret) string {
 }
 
 func isAuthEnvKey(key string, extraAuthKeys ...map[string]struct{}) bool {
+	// GCP shared fields are always auth-related regardless of harness config
 	switch key {
-	case "GEMINI_API_KEY",
-		"GOOGLE_API_KEY",
-		"ANTHROPIC_API_KEY",
-		"CLAUDE_CODE_OAUTH_TOKEN",
-		"OPENAI_API_KEY",
-		"CODEX_API_KEY",
-		"GOOGLE_CLOUD_PROJECT",
+	case "GOOGLE_CLOUD_PROJECT",
 		"GCP_PROJECT",
 		"ANTHROPIC_VERTEX_PROJECT_ID",
 		"GOOGLE_CLOUD_REGION",
 		"CLOUD_ML_REGION",
 		"GOOGLE_CLOUD_LOCATION":
 		return true
-	default:
-		for _, extra := range extraAuthKeys {
-			if _, ok := extra[key]; ok {
-				return true
-			}
-		}
-		return false
 	}
+	// All other auth env keys come from the config-driven key set
+	for _, extra := range extraAuthKeys {
+		if _, ok := extra[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // configAuthEnvKeySet builds a set of env var keys declared across all auth

--- a/pkg/agent/run_test.go
+++ b/pkg/agent/run_test.go
@@ -1869,17 +1869,20 @@ func TestFilterResolvedSecretsForResolvedAuth(t *testing.T) {
 	}
 }
 
-func TestIsAuthEnvKey_BuiltinKeys(t *testing.T) {
-	builtins := []string{
-		"GEMINI_API_KEY", "GOOGLE_API_KEY", "ANTHROPIC_API_KEY",
-		"CLAUDE_CODE_OAUTH_TOKEN", "OPENAI_API_KEY", "CODEX_API_KEY",
+func TestIsAuthEnvKey_GCPSharedKeys(t *testing.T) {
+	// GCP shared fields are always auth-related regardless of config
+	gcpKeys := []string{
 		"GOOGLE_CLOUD_PROJECT", "GCP_PROJECT", "ANTHROPIC_VERTEX_PROJECT_ID",
 		"GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION",
 	}
-	for _, key := range builtins {
+	for _, key := range gcpKeys {
 		if !isAuthEnvKey(key) {
 			t.Errorf("isAuthEnvKey(%q) = false, want true", key)
 		}
+	}
+	// Per-provider keys are no longer built-in — they come from config
+	if isAuthEnvKey("GEMINI_API_KEY") {
+		t.Error("isAuthEnvKey(GEMINI_API_KEY) without config = true, want false")
 	}
 	if isAuthEnvKey("RANDOM_ENV_VAR") {
 		t.Error("isAuthEnvKey(RANDOM_ENV_VAR) = true, want false")
@@ -1891,6 +1894,7 @@ func TestIsAuthEnvKey_ConfigDrivenKeys(t *testing.T) {
 		"COPILOT_GITHUB_TOKEN": {},
 		"GH_TOKEN":             {},
 		"GITHUB_TOKEN":         {},
+		"GEMINI_API_KEY":       {},
 	}
 
 	if !isAuthEnvKey("COPILOT_GITHUB_TOKEN", configKeys) {
@@ -1899,9 +1903,13 @@ func TestIsAuthEnvKey_ConfigDrivenKeys(t *testing.T) {
 	if !isAuthEnvKey("GH_TOKEN", configKeys) {
 		t.Error("isAuthEnvKey(GH_TOKEN, configKeys) = false, want true")
 	}
-	// Built-in keys still work with config keys present
+	// Config-declared per-provider keys work with config keys present
 	if !isAuthEnvKey("GEMINI_API_KEY", configKeys) {
 		t.Error("isAuthEnvKey(GEMINI_API_KEY, configKeys) = false, want true")
+	}
+	// GCP shared keys always work
+	if !isAuthEnvKey("GOOGLE_CLOUD_PROJECT", configKeys) {
+		t.Error("isAuthEnvKey(GOOGLE_CLOUD_PROJECT, configKeys) = false, want true")
 	}
 	// Unknown key is still not auth
 	if isAuthEnvKey("RANDOM_VAR", configKeys) {

--- a/pkg/api/harness_auth_metadata.go
+++ b/pkg/api/harness_auth_metadata.go
@@ -39,7 +39,7 @@ type HarnessAuthFileRequirement struct {
 	TargetSuffix string `json:"target_suffix,omitempty" yaml:"target_suffix,omitempty" koanf:"target_suffix"`
 	// Field maps this file requirement to the corresponding AuthConfig
 	// struct field name (e.g. "ClaudeAuthFile"). Used by
-	// OverlayFileSecretsFromConfig to set auth fields without hardcoded
+	// OverlayFileSecrets to set auth fields without hardcoded
 	// switch statements.
 	Field string `json:"field,omitempty" yaml:"field,omitempty" koanf:"field"`
 	// AlternativeEnvKeys lists env vars that satisfy this file requirement

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -499,24 +499,14 @@ func (c *ScionConfig) IsDetached() bool {
 }
 
 type AuthConfig struct {
-	// Google/Gemini auth
-	GeminiAPIKey         string
-	GoogleAPIKey         string
+	// GCP shared fields — used across vertex-ai harnesses and have
+	// special handling. These remain as first-class fields because they
+	// participate in multi-source fallback resolution (e.g.
+	// GOOGLE_CLOUD_PROJECT | GCP_PROJECT | ANTHROPIC_VERTEX_PROJECT_ID)
+	// and are referenced by ResolveAuth for vertex-ai credential translation.
 	GoogleAppCredentials string
 	GoogleCloudProject   string
 	GoogleCloudRegion    string
-	OAuthCreds           string
-
-	// Anthropic auth
-	AnthropicAPIKey  string
-	ClaudeOAuthToken string // CLAUDE_CODE_OAUTH_TOKEN (long-lived, from `claude setup-token`)
-	ClaudeAuthFile   string // ~/.claude/.credentials.json path (rotating refresh-token store)
-
-	// OpenAI/Codex auth
-	OpenAIAPIKey     string
-	CodexAPIKey      string
-	CodexAuthFile    string
-	OpenCodeAuthFile string
 
 	// GCP metadata server mode ("block", "passthrough", "assign").
 	// When "assign", a GCP service account is available via the metadata
@@ -528,9 +518,15 @@ type AuthConfig struct {
 
 	// EnvVars holds config-driven auth env vars gathered from harness
 	// config metadata (auth.types[*].required_env). These flow through
-	// the auth pipeline alongside the hardcoded fields above, enabling
-	// new harnesses to declare auth requirements without Go code changes.
+	// the auth pipeline as the sole source of per-provider credentials,
+	// enabling harnesses to declare auth requirements without Go code changes.
 	EnvVars map[string]string
+
+	// Files holds config-driven file-based auth credentials gathered from
+	// harness config metadata (auth.types[*].required_files). Each entry
+	// maps a field name (e.g. "ClaudeAuthFile") to the host path of the
+	// credential file. These replace the former per-provider file fields.
+	Files map[string]string
 }
 
 // ResolvedAuth represents the single best auth method selected by a harness's

--- a/pkg/harness/auth.go
+++ b/pkg/harness/auth.go
@@ -59,13 +59,7 @@ func GatherAuthWithEnv(env map[string]string, localSources bool, authMeta *confi
 	}
 
 	auth := api.AuthConfig{
-		// Env-var sourced fields
-		GeminiAPIKey:     lookup("GEMINI_API_KEY"),
-		GoogleAPIKey:     lookup("GOOGLE_API_KEY"),
-		AnthropicAPIKey:  lookup("ANTHROPIC_API_KEY"),
-		ClaudeOAuthToken: lookup("CLAUDE_CODE_OAUTH_TOKEN"),
-		OpenAIAPIKey:     lookup("OPENAI_API_KEY"),
-		CodexAPIKey:      lookup("CODEX_API_KEY"),
+		// GCP shared fields with multi-source fallback resolution
 		GoogleCloudProject: util.FirstNonEmpty(
 			lookup("GOOGLE_CLOUD_PROJECT"),
 			lookup("GCP_PROJECT"),
@@ -80,7 +74,9 @@ func GatherAuthWithEnv(env map[string]string, localSources bool, authMeta *confi
 		GCPMetadataMode:      lookup("SCION_METADATA_MODE"),
 	}
 
-	// File-sourced fields: check well-known paths (skip in broker mode)
+	// File-sourced fields: check well-known ADC path (skip in broker mode).
+	// Per-harness file discovery (OAuth, Codex, OpenCode, Claude credential
+	// files) is now handled via gatherConfigFiles below.
 	if localSources {
 		home, _ := os.UserHomeDir()
 
@@ -91,44 +87,54 @@ func GatherAuthWithEnv(env map[string]string, localSources bool, authMeta *confi
 			}
 		}
 
-		if home != "" {
-			oauthPath := filepath.Join(home, ".gemini", "oauth_creds.json")
-			if _, err := os.Stat(oauthPath); err == nil {
-				auth.OAuthCreds = oauthPath
-			}
-
-			codexPath := filepath.Join(home, ".codex", "auth.json")
-			if _, err := os.Stat(codexPath); err == nil {
-				auth.CodexAuthFile = codexPath
-			}
-
-			opencodePath := filepath.Join(home, ".local", "share", "opencode", "auth.json")
-			if _, err := os.Stat(opencodePath); err == nil {
-				auth.OpenCodeAuthFile = opencodePath
-			}
-
-			// Claude Code's rotating credentials store. Unlike Gemini/Codex/
-			// OpenCode we do NOT parse this file — we treat it as an opaque
-			// file to mount into the container so Claude Code can read and
-			// refresh it natively. The access token inside rotates; scraping
-			// it at gather time would hand the container a stale snapshot.
-			claudeCredsPath := filepath.Join(home, ".claude", ".credentials.json")
-			if _, err := os.Stat(claudeCredsPath); err == nil {
-				auth.ClaudeAuthFile = claudeCredsPath
-			}
+		// Gather harness-declared file credentials from well-known paths
+		if authMeta != nil && home != "" {
+			auth.Files = gatherConfigFiles(authMeta, home)
 		}
 	}
 
 	// Populate EnvVars from config-driven auth metadata. Every env key
 	// declared in any auth type's required_env groups is looked up; keys
-	// with non-empty values are included. This lets harness configs like
-	// copilot declare their own env requirements and have them flow through
-	// the auth pipeline without per-harness Go code.
+	// with non-empty values are included.
 	if authMeta != nil {
 		auth.EnvVars = gatherConfigEnvVars(lookup, authMeta)
 	}
 
 	return auth
+}
+
+// gatherConfigFiles discovers harness-declared file-based credentials from
+// well-known home directory paths. It reads the TargetSuffix from each
+// auth type's required_files entries, resolves the suffix against the user's
+// home directory, and records any files that exist. Returns nil when no
+// files are found.
+func gatherConfigFiles(authMeta *config.HarnessAuthMetadata, home string) map[string]string {
+	if authMeta == nil || len(authMeta.Types) == 0 || home == "" {
+		return nil
+	}
+	var result map[string]string
+	seen := make(map[string]struct{})
+	for _, authType := range authMeta.Types {
+		for _, rf := range authType.RequiredFiles {
+			if rf.Field == "" || rf.TargetSuffix == "" {
+				continue
+			}
+			if _, ok := seen[rf.Field]; ok {
+				continue
+			}
+			seen[rf.Field] = struct{}{}
+			// TargetSuffix starts with "/" (e.g. "/.claude/.credentials.json").
+			// Resolve against home to get the absolute path.
+			filePath := filepath.Join(home, rf.TargetSuffix)
+			if _, err := os.Stat(filePath); err == nil {
+				if result == nil {
+					result = make(map[string]string)
+				}
+				result[rf.Field] = filePath
+			}
+		}
+	}
+	return result
 }
 
 // gatherConfigEnvVars collects env var values for all keys declared in any
@@ -159,46 +165,13 @@ func gatherConfigEnvVars(lookup func(string) string, authMeta *config.HarnessAut
 }
 
 // OverlayFileSecrets bridges file-type ResolvedSecrets from the hub into
-// AuthConfig fields so that ResolveAuth can determine the correct auth method.
-// It maps well-known secret names/targets to the corresponding AuthConfig fields
-// using the target path as a sentinel value (the actual file content is projected
-// into the container by writeFileSecrets at launch time).
-func OverlayFileSecrets(auth *api.AuthConfig, secrets []api.ResolvedSecret) {
-	for _, s := range secrets {
-		if s.Type != "file" {
-			continue
-		}
-		target := s.Target
-		name := s.Name
-
-		switch {
-		case name == "gcloud-adc" ||
-			strings.HasSuffix(target, "/application_default_credentials.json"):
-			auth.GoogleAppCredentials = target
-		case name == "GEMINI_OAUTH_CREDS" ||
-			strings.HasSuffix(target, "/oauth_creds.json"):
-			auth.OAuthCreds = target
-		case name == "CODEX_AUTH" ||
-			strings.HasSuffix(target, "/.codex/auth.json"):
-			auth.CodexAuthFile = target
-		case name == "OPENCODE_AUTH" ||
-			strings.HasSuffix(target, "/opencode/auth.json"):
-			auth.OpenCodeAuthFile = target
-		case name == "CLAUDE_AUTH" ||
-			strings.HasSuffix(target, "/.claude/.credentials.json"):
-			auth.ClaudeAuthFile = target
-		}
-	}
-}
-
-// OverlayFileSecretsFromConfig is the config-driven counterpart of
-// OverlayFileSecrets. It reads field mappings from the harness config's
-// auth.types entries and sets the corresponding AuthConfig fields. When a
-// secret's Name matches a declared field mapping, the config-driven path is
-// used. For secrets that don't match any declared Name, it falls back to
-// target-path-suffix matching (preserving backward compatibility with secrets
-// created before field mappings were added to config.yaml).
-func OverlayFileSecretsFromConfig(auth *api.AuthConfig, secrets []api.ResolvedSecret, authMeta *config.HarnessAuthMetadata) {
+// AuthConfig using config-driven field mappings. It reads field mappings
+// from the harness config's auth.types entries and sets the corresponding
+// AuthConfig fields. When a secret's Name matches a declared field mapping,
+// the config-driven path is used. For secrets that don't match any declared
+// Name, it falls back to target-path-suffix matching (preserving backward
+// compatibility with secrets created before field mappings were added).
+func OverlayFileSecrets(auth *api.AuthConfig, secrets []api.ResolvedSecret, authMeta *config.HarnessAuthMetadata) {
 	fieldMap := buildFieldMap(authMeta)
 
 	for _, s := range secrets {
@@ -232,36 +205,34 @@ func buildFieldMap(authMeta *config.HarnessAuthMetadata) map[string]string {
 }
 
 // setAuthConfigField sets the named field on AuthConfig to the given value.
-// Field names must match AuthConfig struct fields exactly.
+// "GoogleAppCredentials" sets the first-class GCP shared field; all other
+// field names go into the Files map.
 func setAuthConfigField(auth *api.AuthConfig, field, value string) {
 	switch field {
 	case "GoogleAppCredentials":
 		auth.GoogleAppCredentials = value
-	case "OAuthCreds":
-		auth.OAuthCreds = value
-	case "CodexAuthFile":
-		auth.CodexAuthFile = value
-	case "OpenCodeAuthFile":
-		auth.OpenCodeAuthFile = value
-	case "ClaudeAuthFile":
-		auth.ClaudeAuthFile = value
+	default:
+		if auth.Files == nil {
+			auth.Files = make(map[string]string)
+		}
+		auth.Files[field] = value
 	}
 }
 
 // setAuthConfigFieldByTargetSuffix matches a file secret's target path to an
-// AuthConfig field using the same suffix rules as the original OverlayFileSecrets.
+// AuthConfig field using path suffix heuristics for backward compatibility.
 func setAuthConfigFieldByTargetSuffix(auth *api.AuthConfig, target string) {
 	switch {
 	case strings.HasSuffix(target, "/application_default_credentials.json"):
 		auth.GoogleAppCredentials = target
 	case strings.HasSuffix(target, "/oauth_creds.json"):
-		auth.OAuthCreds = target
+		setAuthConfigField(auth, "OAuthCreds", target)
 	case strings.HasSuffix(target, "/.codex/auth.json"):
-		auth.CodexAuthFile = target
+		setAuthConfigField(auth, "CodexAuthFile", target)
 	case strings.HasSuffix(target, "/opencode/auth.json"):
-		auth.OpenCodeAuthFile = target
+		setAuthConfigField(auth, "OpenCodeAuthFile", target)
 	case strings.HasSuffix(target, "/.claude/.credentials.json"):
-		auth.ClaudeAuthFile = target
+		setAuthConfigField(auth, "ClaudeAuthFile", target)
 	}
 }
 
@@ -326,202 +297,30 @@ func ValidateAuth(resolved *api.ResolvedAuth) error {
 	return nil
 }
 
-// RequiredAuthSecrets maps a (harnessName, authSelectedType) pair to
-// file-type secrets required by that combination. This is the file-secret
-// counterpart to RequiredAuthEnvKeys (which covers env var requirements).
-// For vertex-ai auth, the ADC credential file is required unless a GCP
-// service account is assigned (gcpSAAssigned), in which case the metadata
-// server provides credentials and no ADC file is needed.
-// Returns nil for auth methods that have no file-secret requirements.
-func RequiredAuthSecrets(harnessName, authSelectedType string, gcpSAAssigned bool) []api.RequiredSecret {
-	effectiveType := authSelectedType
-	if effectiveType == "" {
-		effectiveType = "api-key"
-	}
-
-	switch harnessName {
-	case "claude", "gemini", "gemini-cli", "opencode", "codex":
-		if effectiveType == "vertex-ai" && !gcpSAAssigned {
-			return []api.RequiredSecret{
-				{
-					Key:                "gcloud-adc",
-					Type:               "file",
-					Description:        "Google Cloud Application Default Credentials (ADC) file for vertex-ai authentication",
-					AlternativeEnvKeys: []string{"GOOGLE_APPLICATION_CREDENTIALS"},
-				},
-			}
-		}
-	}
-
-	return nil
-}
-
-// DetectAuthTypeFromFileSecrets checks whether resolved file secrets can
-// satisfy an alternative auth method for the given harness. This mirrors
-// the auto-detect priority in each harness's ResolveAuth: when no auth
-// type is explicitly selected, harnesses try API key first but fall back
-// to file-based auth (OAuth, ADC, etc.) when credentials are available.
-//
-// Returns the effective auth type (e.g., "auth-file", "vertex-ai") if
-// file secrets satisfy it, or "" if no file-based auth is possible.
-// The caller should use the returned type to override the default "api-key"
-// assumption during env-gather, preventing false requirements.
-func DetectAuthTypeFromFileSecrets(harnessName string, fileSecretNames map[string]struct{}) string {
-	switch harnessName {
-	case "gemini", "gemini-cli":
-		// Auto-detect priority: api-key → OAuth (auth-file) → ADC (vertex-ai)
-		if _, ok := fileSecretNames["GEMINI_OAUTH_CREDS"]; ok {
-			return "auth-file"
-		}
-		if _, ok := fileSecretNames["gcloud-adc"]; ok {
-			return "vertex-ai"
-		}
-	case "claude":
-		// Auto-detect priority: api-key → oauth-token (env) → auth-file → ADC (vertex-ai)
-		if _, ok := fileSecretNames["CLAUDE_AUTH"]; ok {
-			return "auth-file"
-		}
-		if _, ok := fileSecretNames["gcloud-adc"]; ok {
-			return "vertex-ai"
-		}
-	case "codex":
-		if _, ok := fileSecretNames["CODEX_AUTH"]; ok {
-			return "auth-file"
-		}
-	case "opencode":
-		if _, ok := fileSecretNames["OPENCODE_AUTH"]; ok {
-			return "auth-file"
-		}
-	}
-	return ""
-}
-
-// DetectAuthTypeFromEnvVars checks whether resolved env vars can satisfy
-// an alternative auth method for the given harness. For example,
-// GOOGLE_APPLICATION_CREDENTIALS or GOOGLE_CLOUD_PROJECT signal that
-// GCP credentials are available, so vertex-ai auth can be used.
-func DetectAuthTypeFromEnvVars(harnessName string, envKeys map[string]struct{}) string {
-	_, hasGAC := envKeys["GOOGLE_APPLICATION_CREDENTIALS"]
-	_, hasGCP := envKeys["GOOGLE_CLOUD_PROJECT"]
-
-	switch harnessName {
-	case "claude":
-		if _, ok := envKeys["ANTHROPIC_API_KEY"]; ok {
-			return ""
-		}
-		if _, ok := envKeys["CLAUDE_CODE_OAUTH_TOKEN"]; ok {
-			return "oauth-token"
-		}
-		if hasGAC || hasGCP {
-			return "vertex-ai"
-		}
-	case "gemini", "gemini-cli":
-		_, hasGeminiKey := envKeys["GEMINI_API_KEY"]
-		_, hasGoogleKey := envKeys["GOOGLE_API_KEY"]
-		if hasGeminiKey || hasGoogleKey {
-			return ""
-		}
-		if hasGAC || hasGCP {
-			return "vertex-ai"
-		}
-	}
-	return ""
-}
-
-// DetectAuthTypeFromGCPIdentity returns "vertex-ai" when a GCP service
-// account is assigned to the agent. Harnesses that support vertex-ai auth
-// can use the metadata server for credentials instead of an ADC file.
-func DetectAuthTypeFromGCPIdentity(harnessName string, gcpSAAssigned bool) string {
-	if !gcpSAAssigned {
-		return ""
-	}
-	switch harnessName {
-	case "claude", "gemini", "gemini-cli":
-		return "vertex-ai"
-	}
-	return ""
-}
-
-// RequiredAuthEnvKeys maps a (harnessName, authSelectedType) pair to the
-// env var key groups required by that combination. Each inner slice is a
-// set of alternatives — any one key satisfying the group is sufficient
-// (e.g., GEMINI_API_KEY or GOOGLE_API_KEY for gemini api-key auth).
-// Returns nil for unknown/unset combinations or harnesses with no
-// intrinsic auth requirements (e.g., generic).
-func RequiredAuthEnvKeys(harnessName, authSelectedType string) [][]string {
-	// When authType is empty (unset), default to api-key — it's the
-	// first-choice method in every harness's ResolveAuth(). This ensures
-	// env-gather detects missing keys and returns 202 so the CLI can
-	// collect them from the user's environment.
-	effectiveType := authSelectedType
-	if effectiveType == "" {
-		effectiveType = "api-key"
-	}
-
-	switch harnessName {
-	case "claude":
-		switch effectiveType {
-		case "api-key":
-			return [][]string{{"ANTHROPIC_API_KEY"}}
-		case "oauth-token":
-			return [][]string{{"CLAUDE_CODE_OAUTH_TOKEN"}}
-		case "auth-file":
-			return nil
-		case "vertex-ai":
-			return [][]string{{"GOOGLE_CLOUD_PROJECT"}, {"GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"}}
-		}
-	case "gemini", "gemini-cli":
-		switch effectiveType {
-		case "api-key":
-			return [][]string{{"GEMINI_API_KEY", "GOOGLE_API_KEY"}}
-		case "vertex-ai":
-			return [][]string{{"GOOGLE_CLOUD_PROJECT"}, {"GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"}}
-		}
-	case "opencode":
-		switch effectiveType {
-		case "api-key":
-			return [][]string{{"ANTHROPIC_API_KEY", "OPENAI_API_KEY"}}
-		}
-	case "codex":
-		switch effectiveType {
-		case "api-key":
-			return [][]string{{"CODEX_API_KEY", "OPENAI_API_KEY"}}
-		}
-	}
-
-	return nil
-}
-
 // Config-driven auth preflight.
 //
-// The functions below replace the compiled per-harness tables above with
-// logic that reads the declarative `auth:` block from a harness-config.yaml
-// (parsed into config.HarnessAuthMetadata in Phase 1). When a harness-config
-// supplies metadata, the runtime broker should prefer the *FromConfig
-// variants; the compiled fallbacks remain so legacy on-disk configs without
-// an `auth:` section keep working during migration.
+// The functions below read the declarative `auth:` block from a
+// harness-config.yaml (parsed into config.HarnessAuthMetadata) to drive
+// all auth preflight decisions: required env keys, required file secrets,
+// and auth-type auto-detection.
 //
 // Detection precedence
 // --------------------
-// When several env vars or file secrets are present at once, the original
-// compiled detectors had a fixed priority (e.g. Claude prefers oauth-token
-// over vertex-ai). To express that priority deterministically from a YAML
-// map (which has no inherent order), the *FromConfig functions use this
-// rule:
+// When several env vars or file secrets are present at once, the
+// functions use a deterministic precedence rule:
 //
 //   1. Build the candidate set: every auth type that any present key maps
 //      to via authMeta.Autodetect.{Env|Files}.
 //   2. If the harness's default_type appears in the candidate set, return
 //      "" — the caller is already on the default and no override is needed.
 //   3. Otherwise return the alphabetically-smallest candidate. For the
-//      built-in harness set this matches the legacy behavior: "auth-file"
-//      < "oauth-token" < "vertex-ai", which is also the operational
-//      preference order. Future harnesses with non-monotonic preferences
-//      should pick auth type names that sort in their preferred order.
+//      built-in harness set this matches the operational preference order:
+//      "auth-file" < "oauth-token" < "vertex-ai". Future harnesses with
+//      non-monotonic preferences should pick auth type names that sort in
+//      their preferred order.
 
 // AuthMetadataAvailable reports whether a HarnessConfigEntry carries the
-// declarative auth block needed by the *FromConfig functions. Callers use
-// this to decide between config-driven and legacy compiled preflight.
+// declarative auth block needed by the auth preflight functions.
 func AuthMetadataAvailable(entry *config.HarnessConfigEntry) bool {
 	if entry == nil || entry.Auth == nil {
 		return false
@@ -532,9 +331,8 @@ func AuthMetadataAvailable(entry *config.HarnessConfigEntry) bool {
 	return true
 }
 
-// RequiredAuthEnvKeysFromConfig is the config-driven counterpart of
-// RequiredAuthEnvKeys. It returns the env-var alternative groups for the
-// (auth-type) pair declared in authMeta.Types.
+// RequiredAuthEnvKeysFromConfig returns the env-var alternative groups for
+// the given auth type as declared in authMeta.Types.
 func RequiredAuthEnvKeysFromConfig(authMeta *config.HarnessAuthMetadata, authSelectedType string) [][]string {
 	if authMeta == nil {
 		return nil
@@ -567,8 +365,7 @@ func RequiredAuthEnvKeysFromConfig(authMeta *config.HarnessAuthMetadata, authSel
 	return groups
 }
 
-// RequiredAuthSecretsFromConfig is the config-driven counterpart of
-// RequiredAuthSecrets. It returns only file requirements explicitly marked
+// RequiredAuthSecretsFromConfig returns only file requirements explicitly marked
 // `required: true` — documentary files (e.g. CLAUDE_AUTH for Claude's
 // auth-file type, which the user mounts from a locally-resolved file) are
 // not preflight-enforced. File requirements with
@@ -617,9 +414,8 @@ func RequiredAuthSecretsFromConfig(authMeta *config.HarnessAuthMetadata, authSel
 	return out
 }
 
-// DetectAuthTypeFromFileSecretsFromConfig is the config-driven counterpart
-// of DetectAuthTypeFromFileSecrets. It uses authMeta.Autodetect.Files to map
-// each present file-secret name to a candidate auth type.
+// DetectAuthTypeFromFileSecretsFromConfig uses authMeta.Autodetect.Files to
+// map each present file-secret name to a candidate auth type.
 func DetectAuthTypeFromFileSecretsFromConfig(authMeta *config.HarnessAuthMetadata, fileSecretNames map[string]struct{}) string {
 	if authMeta == nil {
 		return ""
@@ -627,8 +423,8 @@ func DetectAuthTypeFromFileSecretsFromConfig(authMeta *config.HarnessAuthMetadat
 	return pickAutodetectCandidate(authMeta.DefaultType, authMeta.Autodetect.Files, fileSecretNames)
 }
 
-// DetectAuthTypeFromEnvVarsFromConfig is the config-driven counterpart of
-// DetectAuthTypeFromEnvVars.
+// DetectAuthTypeFromEnvVarsFromConfig detects auth type from env vars
+// using authMeta.Autodetect.Env mappings.
 func DetectAuthTypeFromEnvVarsFromConfig(authMeta *config.HarnessAuthMetadata, envKeys map[string]struct{}) string {
 	if authMeta == nil {
 		return ""
@@ -636,8 +432,7 @@ func DetectAuthTypeFromEnvVarsFromConfig(authMeta *config.HarnessAuthMetadata, e
 	return pickAutodetectCandidate(authMeta.DefaultType, authMeta.Autodetect.Env, envKeys)
 }
 
-// DetectAuthTypeFromGCPIdentityFromConfig is the config-driven counterpart
-// of DetectAuthTypeFromGCPIdentity. It returns "vertex-ai" only when the
+// DetectAuthTypeFromGCPIdentityFromConfig returns "vertex-ai" only when the
 // harness declares a vertex-ai auth type (so the metadata server actually
 // has a use) and gcpSAAssigned is true.
 func DetectAuthTypeFromGCPIdentityFromConfig(authMeta *config.HarnessAuthMetadata, gcpSAAssigned bool) string {

--- a/pkg/harness/auth_config_test.go
+++ b/pkg/harness/auth_config_test.go
@@ -71,66 +71,93 @@ func TestAuthMetadataAvailable(t *testing.T) {
 	}
 }
 
-// TestRequiredAuthEnvKeysFromConfig_ParityWithCompiled verifies that the
-// config-driven preflight returns identical results to the compiled tables
-// for all built-in harnesses (claude, codex, gemini-cli).
-func TestRequiredAuthEnvKeysFromConfig_ParityWithCompiled(t *testing.T) {
+// TestRequiredAuthEnvKeysFromConfig_BuiltInHarnesses verifies that the
+// config-driven preflight returns correct results for all built-in harnesses.
+func TestRequiredAuthEnvKeysFromConfig_BuiltInHarnesses(t *testing.T) {
 	cases := []struct {
-		harness     string
-		compiledKey string
-		types       []string
+		harness  string
+		authType string
+		want     [][]string
 	}{
-		{"claude", "claude", []string{"", "api-key", "oauth-token", "auth-file", "vertex-ai", "unknown"}},
-		{"gemini-cli", "gemini-cli", []string{"", "api-key", "auth-file", "vertex-ai", "unknown"}},
-		{"codex", "codex", []string{"", "api-key", "auth-file", "unknown"}},
+		// Claude
+		{"claude", "", [][]string{{"ANTHROPIC_API_KEY"}}},
+		{"claude", "api-key", [][]string{{"ANTHROPIC_API_KEY"}}},
+		{"claude", "oauth-token", [][]string{{"CLAUDE_CODE_OAUTH_TOKEN"}}},
+		{"claude", "auth-file", nil},
+		{"claude", "vertex-ai", [][]string{{"GOOGLE_CLOUD_PROJECT"}, {"GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"}}},
+		{"claude", "unknown", nil},
+
+		// Gemini-CLI
+		{"gemini-cli", "", [][]string{{"GEMINI_API_KEY", "GOOGLE_API_KEY"}}},
+		{"gemini-cli", "api-key", [][]string{{"GEMINI_API_KEY", "GOOGLE_API_KEY"}}},
+		{"gemini-cli", "auth-file", nil},
+		{"gemini-cli", "vertex-ai", [][]string{{"GOOGLE_CLOUD_PROJECT"}, {"GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"}}},
+		{"gemini-cli", "unknown", nil},
+
+		// Codex
+		{"codex", "", [][]string{{"CODEX_API_KEY", "OPENAI_API_KEY"}}},
+		{"codex", "api-key", [][]string{{"CODEX_API_KEY", "OPENAI_API_KEY"}}},
+		{"codex", "auth-file", nil},
+		{"codex", "unknown", nil},
 	}
 	for _, tc := range cases {
-		authMeta := loadAuthMetaFromHarness(t, tc.harness)
-		for _, at := range tc.types {
-			t.Run(tc.harness+"/"+at, func(t *testing.T) {
-				wantGroups := RequiredAuthEnvKeys(tc.compiledKey, at)
-				gotGroups := RequiredAuthEnvKeysFromConfig(authMeta, at)
-				if !equalGroups(gotGroups, wantGroups) {
-					t.Errorf("config-driven=%v compiled=%v", gotGroups, wantGroups)
-				}
-			})
-		}
+		t.Run(tc.harness+"/"+tc.authType, func(t *testing.T) {
+			authMeta := loadAuthMetaFromHarness(t, tc.harness)
+			got := RequiredAuthEnvKeysFromConfig(authMeta, tc.authType)
+			if !equalGroups(got, tc.want) {
+				t.Errorf("got=%v want=%v", got, tc.want)
+			}
+		})
 	}
 }
 
-// TestRequiredAuthSecretsFromConfig_ParityWithCompiled verifies parity for
-// all built-in harnesses (claude, codex, gemini-cli).
-func TestRequiredAuthSecretsFromConfig_ParityWithCompiled(t *testing.T) {
+// TestRequiredAuthSecretsFromConfig_BuiltInHarnesses verifies correct results
+// for all built-in harnesses.
+func TestRequiredAuthSecretsFromConfig_BuiltInHarnesses(t *testing.T) {
 	cases := []struct {
-		harness     string
-		compiledKey string
-		types       []string
+		harness       string
+		authType      string
+		gcpSAAssigned bool
+		wantNil       bool
+		wantKey       string
 	}{
-		{"claude", "claude", []string{"", "api-key", "auth-file", "vertex-ai"}},
-		{"gemini-cli", "gemini-cli", []string{"", "api-key", "auth-file", "vertex-ai"}},
-		// Codex does not support vertex-ai (capabilities: vertex_ai: no), so
-		// the config-driven path correctly returns nil for vertex-ai. The
-		// compiled RequiredAuthSecrets was overly broad, returning gcloud-adc
-		// for codex+vertex-ai even though codex can't use it.
-		{"codex", "codex", []string{"", "api-key", "auth-file"}},
+		// Claude
+		{"claude", "", false, true, ""},
+		{"claude", "api-key", false, true, ""},
+		{"claude", "auth-file", false, true, ""},
+		{"claude", "vertex-ai", false, false, "gcloud-adc"},
+		{"claude", "vertex-ai", true, true, ""},
+
+		// Gemini-CLI
+		{"gemini-cli", "", false, true, ""},
+		{"gemini-cli", "api-key", false, true, ""},
+		{"gemini-cli", "auth-file", false, true, ""},
+		{"gemini-cli", "vertex-ai", false, false, "gcloud-adc"},
+		{"gemini-cli", "vertex-ai", true, true, ""},
+
+		// Codex (no vertex-ai support)
+		{"codex", "", false, true, ""},
+		{"codex", "api-key", false, true, ""},
+		{"codex", "auth-file", false, true, ""},
 	}
 	for _, tc := range cases {
-		authMeta := loadAuthMetaFromHarness(t, tc.harness)
-		for _, at := range tc.types {
-			for _, sa := range []bool{false, true} {
-				name := tc.harness + "/" + at
-				if sa {
-					name += "/sa-assigned"
-				}
-				t.Run(name, func(t *testing.T) {
-					want := RequiredAuthSecrets(tc.compiledKey, at, sa)
-					got := RequiredAuthSecretsFromConfig(authMeta, at, sa)
-					if !equalRequiredSecrets(got, want) {
-						t.Errorf("config-driven=%+v compiled=%+v", got, want)
-					}
-				})
-			}
+		name := tc.harness + "/" + tc.authType
+		if tc.gcpSAAssigned {
+			name += "/sa-assigned"
 		}
+		t.Run(name, func(t *testing.T) {
+			authMeta := loadAuthMetaFromHarness(t, tc.harness)
+			got := RequiredAuthSecretsFromConfig(authMeta, tc.authType, tc.gcpSAAssigned)
+			if tc.wantNil {
+				if got != nil {
+					t.Errorf("got %+v, want nil", got)
+				}
+				return
+			}
+			if len(got) != 1 || got[0].Key != tc.wantKey {
+				t.Errorf("got %+v, want key=%q", got, tc.wantKey)
+			}
+		})
 	}
 }
 
@@ -276,208 +303,164 @@ func TestRequiredAuthSecretsFromConfig_GCPSAAssignedSkips(t *testing.T) {
 	}
 }
 
-// TestDetectAuthTypeFromEnvVars_ParityWithCompiled verifies that for every
-// built-in harness the config-driven env-var detection produces the same
-// result as the compiled switch-case, across all env key combinations tested
-// in TestDetectAuthTypeFromEnvVars.
-func TestDetectAuthTypeFromEnvVars_ParityWithCompiled(t *testing.T) {
+// TestDetectAuthTypeFromEnvVarsFromConfig_BuiltInHarnesses verifies env-var
+// auto-detection for all built-in harnesses.
+func TestDetectAuthTypeFromEnvVarsFromConfig_BuiltInHarnesses(t *testing.T) {
 	cases := []struct {
-		harness     string
-		compiledKey string
-		envKeySets  [][]string
+		harness string
+		keys    []string
+		want    string
 	}{
-		{
-			"claude", "claude",
-			[][]string{
-				{},
-				{"ANTHROPIC_API_KEY"},
-				{"CLAUDE_CODE_OAUTH_TOKEN"},
-				{"GOOGLE_APPLICATION_CREDENTIALS"},
-				{"GOOGLE_CLOUD_PROJECT"},
-				{"CLAUDE_CODE_OAUTH_TOKEN", "GOOGLE_APPLICATION_CREDENTIALS"},
-				{"CLAUDE_CODE_OAUTH_TOKEN", "GOOGLE_CLOUD_PROJECT"},
-				{"ANTHROPIC_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS"},
-				{"ANTHROPIC_API_KEY", "GOOGLE_CLOUD_PROJECT"},
-				{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"},
-				{"SOME_OTHER_VAR"},
-			},
-		},
-		{
-			"gemini-cli", "gemini-cli",
-			[][]string{
-				{},
-				{"GEMINI_API_KEY"},
-				{"GOOGLE_API_KEY"},
-				{"GOOGLE_APPLICATION_CREDENTIALS"},
-				{"GOOGLE_CLOUD_PROJECT"},
-				{"GEMINI_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS"},
-				{"GEMINI_API_KEY", "GOOGLE_CLOUD_PROJECT"},
-				{"GOOGLE_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS"},
-				{"GOOGLE_API_KEY", "GOOGLE_CLOUD_PROJECT"},
-				{"CLAUDE_CODE_OAUTH_TOKEN"}, // should not affect gemini
-			},
-		},
-		{
-			"codex", "codex",
-			[][]string{
-				{},
-				{"CODEX_API_KEY"},
-				{"OPENAI_API_KEY"},
-				{"GOOGLE_APPLICATION_CREDENTIALS"},
-			},
-		},
+		// Claude
+		{"claude", nil, ""},
+		{"claude", []string{"ANTHROPIC_API_KEY"}, ""},
+		{"claude", []string{"CLAUDE_CODE_OAUTH_TOKEN"}, "oauth-token"},
+		{"claude", []string{"GOOGLE_APPLICATION_CREDENTIALS"}, "vertex-ai"},
+		{"claude", []string{"GOOGLE_CLOUD_PROJECT"}, "vertex-ai"},
+		{"claude", []string{"CLAUDE_CODE_OAUTH_TOKEN", "GOOGLE_APPLICATION_CREDENTIALS"}, "oauth-token"},
+		{"claude", []string{"CLAUDE_CODE_OAUTH_TOKEN", "GOOGLE_CLOUD_PROJECT"}, "oauth-token"},
+		{"claude", []string{"ANTHROPIC_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS"}, ""},
+		{"claude", []string{"ANTHROPIC_API_KEY", "GOOGLE_CLOUD_PROJECT"}, ""},
+		{"claude", []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"}, ""},
+		{"claude", []string{"SOME_OTHER_VAR"}, ""},
+
+		// Gemini-CLI
+		{"gemini-cli", nil, ""},
+		{"gemini-cli", []string{"GEMINI_API_KEY"}, ""},
+		{"gemini-cli", []string{"GOOGLE_API_KEY"}, ""},
+		{"gemini-cli", []string{"GOOGLE_APPLICATION_CREDENTIALS"}, "vertex-ai"},
+		{"gemini-cli", []string{"GOOGLE_CLOUD_PROJECT"}, "vertex-ai"},
+		{"gemini-cli", []string{"GEMINI_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS"}, ""},
+		{"gemini-cli", []string{"GEMINI_API_KEY", "GOOGLE_CLOUD_PROJECT"}, ""},
+		{"gemini-cli", []string{"GOOGLE_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS"}, ""},
+		{"gemini-cli", []string{"GOOGLE_API_KEY", "GOOGLE_CLOUD_PROJECT"}, ""},
+		{"gemini-cli", []string{"CLAUDE_CODE_OAUTH_TOKEN"}, ""},
+
+		// Codex
+		{"codex", nil, ""},
+		{"codex", []string{"CODEX_API_KEY"}, ""},
+		{"codex", []string{"OPENAI_API_KEY"}, ""},
 	}
 	for _, tc := range cases {
-		authMeta := loadAuthMetaFromHarness(t, tc.harness)
-		for _, keys := range tc.envKeySets {
-			name := tc.harness + "/"
-			if len(keys) == 0 {
-				name += "empty"
-			} else {
-				for i, k := range keys {
-					if i > 0 {
-						name += "+"
-					}
-					name += k
+		name := tc.harness + "/"
+		if len(tc.keys) == 0 {
+			name += "empty"
+		} else {
+			for i, k := range tc.keys {
+				if i > 0 {
+					name += "+"
 				}
+				name += k
 			}
-			t.Run(name, func(t *testing.T) {
-				ks := keySet(keys)
-				want := DetectAuthTypeFromEnvVars(tc.compiledKey, ks)
-				got := DetectAuthTypeFromEnvVarsFromConfig(authMeta, ks)
-				if got != want {
-					t.Errorf("config-driven=%q compiled=%q", got, want)
-				}
-			})
 		}
+		t.Run(name, func(t *testing.T) {
+			authMeta := loadAuthMetaFromHarness(t, tc.harness)
+			got := DetectAuthTypeFromEnvVarsFromConfig(authMeta, keySet(tc.keys))
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
-// TestDetectAuthTypeFromFileSecrets_ParityWithCompiled verifies that for every
-// built-in harness the config-driven file-secret detection produces the same
-// result as the compiled switch-case.
-func TestDetectAuthTypeFromFileSecrets_ParityWithCompiled(t *testing.T) {
+// TestDetectAuthTypeFromFileSecretsFromConfig_BuiltInHarnesses verifies file-secret
+// auto-detection for all built-in harnesses.
+func TestDetectAuthTypeFromFileSecretsFromConfig_BuiltInHarnesses(t *testing.T) {
 	cases := []struct {
-		harness     string
-		compiledKey string
-		fileSets    [][]string
+		harness string
+		files   []string
+		want    string
 	}{
-		{
-			"claude", "claude",
-			[][]string{
-				{},
-				{"CLAUDE_AUTH"},
-				{"gcloud-adc"},
-				{"CLAUDE_AUTH", "gcloud-adc"},
-			},
-		},
-		{
-			"gemini-cli", "gemini-cli",
-			[][]string{
-				{},
-				{"GEMINI_OAUTH_CREDS"},
-				{"gcloud-adc"},
-				{"GEMINI_OAUTH_CREDS", "gcloud-adc"},
-			},
-		},
-		{
-			"codex", "codex",
-			[][]string{
-				{},
-				{"CODEX_AUTH"},
-				{"gcloud-adc"}, // codex compiled doesn't handle gcloud-adc
-			},
-		},
+		// Claude
+		{"claude", nil, ""},
+		{"claude", []string{"CLAUDE_AUTH"}, "auth-file"},
+		{"claude", []string{"gcloud-adc"}, "vertex-ai"},
+		{"claude", []string{"CLAUDE_AUTH", "gcloud-adc"}, "auth-file"},
+
+		// Gemini-CLI
+		{"gemini-cli", nil, ""},
+		{"gemini-cli", []string{"GEMINI_OAUTH_CREDS"}, "auth-file"},
+		{"gemini-cli", []string{"gcloud-adc"}, "vertex-ai"},
+		{"gemini-cli", []string{"GEMINI_OAUTH_CREDS", "gcloud-adc"}, "auth-file"},
+
+		// Codex
+		{"codex", nil, ""},
+		{"codex", []string{"CODEX_AUTH"}, "auth-file"},
 	}
 	for _, tc := range cases {
-		authMeta := loadAuthMetaFromHarness(t, tc.harness)
-		for _, files := range tc.fileSets {
-			name := tc.harness + "/"
-			if len(files) == 0 {
-				name += "empty"
-			} else {
-				for i, f := range files {
-					if i > 0 {
-						name += "+"
-					}
-					name += f
+		name := tc.harness + "/"
+		if len(tc.files) == 0 {
+			name += "empty"
+		} else {
+			for i, f := range tc.files {
+				if i > 0 {
+					name += "+"
 				}
+				name += f
 			}
-			t.Run(name, func(t *testing.T) {
-				ks := keySet(files)
-				want := DetectAuthTypeFromFileSecrets(tc.compiledKey, ks)
-				got := DetectAuthTypeFromFileSecretsFromConfig(authMeta, ks)
-				if got != want {
-					t.Errorf("config-driven=%q compiled=%q", got, want)
-				}
-			})
 		}
+		t.Run(name, func(t *testing.T) {
+			authMeta := loadAuthMetaFromHarness(t, tc.harness)
+			got := DetectAuthTypeFromFileSecretsFromConfig(authMeta, keySet(tc.files))
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
-// TestDetectAuthTypeFromGCPIdentity_ParityWithCompiled verifies that for every
-// built-in harness the config-driven GCP identity detection produces the same
-// result as the compiled switch-case.
-func TestDetectAuthTypeFromGCPIdentity_ParityWithCompiled(t *testing.T) {
+// TestDetectAuthTypeFromGCPIdentityFromConfig_BuiltInHarnesses verifies GCP
+// identity detection for all built-in harnesses.
+func TestDetectAuthTypeFromGCPIdentityFromConfig_BuiltInHarnesses(t *testing.T) {
 	cases := []struct {
-		harness     string
-		compiledKey string
+		harness  string
+		assigned bool
+		want     string
 	}{
-		{"claude", "claude"},
-		{"gemini-cli", "gemini-cli"},
-		{"codex", "codex"},
+		{"claude", true, "vertex-ai"},
+		{"claude", false, ""},
+		{"gemini-cli", true, "vertex-ai"},
+		{"gemini-cli", false, ""},
+		{"codex", true, ""},
+		{"codex", false, ""},
 	}
 	for _, tc := range cases {
-		authMeta := loadAuthMetaFromHarness(t, tc.harness)
-		for _, assigned := range []bool{false, true} {
-			name := tc.harness
-			if assigned {
-				name += "/sa-assigned"
-			}
-			t.Run(name, func(t *testing.T) {
-				want := DetectAuthTypeFromGCPIdentity(tc.compiledKey, assigned)
-				got := DetectAuthTypeFromGCPIdentityFromConfig(authMeta, assigned)
-				if got != want {
-					t.Errorf("config-driven=%q compiled=%q", got, want)
-				}
-			})
+		name := tc.harness
+		if tc.assigned {
+			name += "/sa-assigned"
 		}
+		t.Run(name, func(t *testing.T) {
+			authMeta := loadAuthMetaFromHarness(t, tc.harness)
+			got := DetectAuthTypeFromGCPIdentityFromConfig(authMeta, tc.assigned)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
-// TestGatherConfigEnvVars_ParityWithCompiledLookup verifies that the
-// config-driven env var gathering from harness config metadata produces
-// the same set of keys as the compiled GatherAuthWithEnv hardcoded lookups
-// for built-in harnesses (when all env vars are set).
-func TestGatherConfigEnvVars_ParityWithCompiledLookup(t *testing.T) {
+// TestGatherConfigEnvVars_BuiltInHarnesses verifies that config-driven env
+// var gathering produces expected keys for built-in harnesses.
+func TestGatherConfigEnvVars_BuiltInHarnesses(t *testing.T) {
 	cases := []struct {
 		harness string
 		envVars map[string]string
-		// compiledFields are the hardcoded AuthConfig field values expected from
-		// the compiled path. The config-driven path stores the same values in
-		// AuthConfig.EnvVars. We check that every key present in the compiled
-		// fields is also in EnvVars with the same value.
-		compiledFields func(auth api.AuthConfig) map[string]string
+		// wantKeys are env var keys that should appear in AuthConfig.EnvVars
+		wantKeys map[string]string
 	}{
 		{
 			"claude",
 			map[string]string{
-				"ANTHROPIC_API_KEY":      "test-key",
+				"ANTHROPIC_API_KEY":       "test-key",
 				"CLAUDE_CODE_OAUTH_TOKEN": "test-token",
-				"GOOGLE_CLOUD_PROJECT":   "test-project",
-				"GOOGLE_CLOUD_REGION":    "us-central1",
-				"CLOUD_ML_REGION":        "ml-region",
-				"GOOGLE_CLOUD_LOCATION":  "location",
+				"GOOGLE_CLOUD_PROJECT":    "test-project",
+				"GOOGLE_CLOUD_REGION":     "us-central1",
 			},
-			func(auth api.AuthConfig) map[string]string {
-				m := map[string]string{}
-				if auth.AnthropicAPIKey != "" {
-					m["ANTHROPIC_API_KEY"] = auth.AnthropicAPIKey
-				}
-				if auth.ClaudeOAuthToken != "" {
-					m["CLAUDE_CODE_OAUTH_TOKEN"] = auth.ClaudeOAuthToken
-				}
-				return m
+			map[string]string{
+				"ANTHROPIC_API_KEY":       "test-key",
+				"CLAUDE_CODE_OAUTH_TOKEN": "test-token",
+				"GOOGLE_CLOUD_PROJECT":    "test-project",
+				"GOOGLE_CLOUD_REGION":     "us-central1",
 			},
 		},
 		{
@@ -486,36 +469,24 @@ func TestGatherConfigEnvVars_ParityWithCompiledLookup(t *testing.T) {
 				"CODEX_API_KEY":  "test-codex-key",
 				"OPENAI_API_KEY": "test-openai-key",
 			},
-			func(auth api.AuthConfig) map[string]string {
-				m := map[string]string{}
-				if auth.CodexAPIKey != "" {
-					m["CODEX_API_KEY"] = auth.CodexAPIKey
-				}
-				if auth.OpenAIAPIKey != "" {
-					m["OPENAI_API_KEY"] = auth.OpenAIAPIKey
-				}
-				return m
+			map[string]string{
+				"CODEX_API_KEY":  "test-codex-key",
+				"OPENAI_API_KEY": "test-openai-key",
 			},
 		},
 		{
 			"gemini-cli",
 			map[string]string{
-				"GEMINI_API_KEY":        "test-gemini-key",
-				"GOOGLE_API_KEY":        "test-google-key",
-				"GOOGLE_CLOUD_PROJECT":  "test-project",
-				"GOOGLE_CLOUD_REGION":   "us-central1",
-				"CLOUD_ML_REGION":       "ml-region",
-				"GOOGLE_CLOUD_LOCATION": "location",
+				"GEMINI_API_KEY":       "test-gemini-key",
+				"GOOGLE_API_KEY":       "test-google-key",
+				"GOOGLE_CLOUD_PROJECT": "test-project",
+				"GOOGLE_CLOUD_REGION":  "us-central1",
 			},
-			func(auth api.AuthConfig) map[string]string {
-				m := map[string]string{}
-				if auth.GeminiAPIKey != "" {
-					m["GEMINI_API_KEY"] = auth.GeminiAPIKey
-				}
-				if auth.GoogleAPIKey != "" {
-					m["GOOGLE_API_KEY"] = auth.GoogleAPIKey
-				}
-				return m
+			map[string]string{
+				"GEMINI_API_KEY":       "test-gemini-key",
+				"GOOGLE_API_KEY":       "test-google-key",
+				"GOOGLE_CLOUD_PROJECT": "test-project",
+				"GOOGLE_CLOUD_REGION":  "us-central1",
 			},
 		},
 	}
@@ -525,13 +496,11 @@ func TestGatherConfigEnvVars_ParityWithCompiledLookup(t *testing.T) {
 			authMeta := loadAuthMetaFromHarness(t, tc.harness)
 			auth := GatherAuthWithEnv(tc.envVars, false, authMeta)
 
-			// Check that config-driven EnvVars has every harness-specific env key
-			compiledFields := tc.compiledFields(auth)
-			for k, v := range compiledFields {
+			for k, v := range tc.wantKeys {
 				if got, ok := auth.EnvVars[k]; !ok {
-					t.Errorf("EnvVars missing key %q (compiled had value %q)", k, v)
+					t.Errorf("EnvVars missing key %q (want value %q)", k, v)
 				} else if got != v {
-					t.Errorf("EnvVars[%q] = %q, compiled = %q", k, got, v)
+					t.Errorf("EnvVars[%q] = %q, want %q", k, got, v)
 				}
 			}
 		})

--- a/pkg/harness/auth_config_test.go
+++ b/pkg/harness/auth_config_test.go
@@ -73,7 +73,7 @@ func TestAuthMetadataAvailable(t *testing.T) {
 
 // TestRequiredAuthEnvKeysFromConfig_ParityWithCompiled verifies that the
 // config-driven preflight returns identical results to the compiled tables
-// for claude (the only harness still in the compiled table).
+// for all built-in harnesses (claude, codex, gemini-cli).
 func TestRequiredAuthEnvKeysFromConfig_ParityWithCompiled(t *testing.T) {
 	cases := []struct {
 		harness     string
@@ -82,6 +82,7 @@ func TestRequiredAuthEnvKeysFromConfig_ParityWithCompiled(t *testing.T) {
 	}{
 		{"claude", "claude", []string{"", "api-key", "oauth-token", "auth-file", "vertex-ai", "unknown"}},
 		{"gemini-cli", "gemini-cli", []string{"", "api-key", "auth-file", "vertex-ai", "unknown"}},
+		{"codex", "codex", []string{"", "api-key", "auth-file", "unknown"}},
 	}
 	for _, tc := range cases {
 		authMeta := loadAuthMetaFromHarness(t, tc.harness)
@@ -98,7 +99,7 @@ func TestRequiredAuthEnvKeysFromConfig_ParityWithCompiled(t *testing.T) {
 }
 
 // TestRequiredAuthSecretsFromConfig_ParityWithCompiled verifies parity for
-// claude (the only harness still in the compiled table).
+// all built-in harnesses (claude, codex, gemini-cli).
 func TestRequiredAuthSecretsFromConfig_ParityWithCompiled(t *testing.T) {
 	cases := []struct {
 		harness     string
@@ -107,6 +108,11 @@ func TestRequiredAuthSecretsFromConfig_ParityWithCompiled(t *testing.T) {
 	}{
 		{"claude", "claude", []string{"", "api-key", "auth-file", "vertex-ai"}},
 		{"gemini-cli", "gemini-cli", []string{"", "api-key", "auth-file", "vertex-ai"}},
+		// Codex does not support vertex-ai (capabilities: vertex_ai: no), so
+		// the config-driven path correctly returns nil for vertex-ai. The
+		// compiled RequiredAuthSecrets was overly broad, returning gcloud-adc
+		// for codex+vertex-ai even though codex can't use it.
+		{"codex", "codex", []string{"", "api-key", "auth-file"}},
 	}
 	for _, tc := range cases {
 		authMeta := loadAuthMetaFromHarness(t, tc.harness)
@@ -267,6 +273,268 @@ func TestRequiredAuthSecretsFromConfig_GCPSAAssignedSkips(t *testing.T) {
 	got = RequiredAuthSecretsFromConfig(authMeta, "vertex-ai", false)
 	if len(got) != 1 || got[0].Key != "gcloud-adc" {
 		t.Errorf("expected [gcloud-adc] without GCP SA, got %v", got)
+	}
+}
+
+// TestDetectAuthTypeFromEnvVars_ParityWithCompiled verifies that for every
+// built-in harness the config-driven env-var detection produces the same
+// result as the compiled switch-case, across all env key combinations tested
+// in TestDetectAuthTypeFromEnvVars.
+func TestDetectAuthTypeFromEnvVars_ParityWithCompiled(t *testing.T) {
+	cases := []struct {
+		harness     string
+		compiledKey string
+		envKeySets  [][]string
+	}{
+		{
+			"claude", "claude",
+			[][]string{
+				{},
+				{"ANTHROPIC_API_KEY"},
+				{"CLAUDE_CODE_OAUTH_TOKEN"},
+				{"GOOGLE_APPLICATION_CREDENTIALS"},
+				{"GOOGLE_CLOUD_PROJECT"},
+				{"CLAUDE_CODE_OAUTH_TOKEN", "GOOGLE_APPLICATION_CREDENTIALS"},
+				{"CLAUDE_CODE_OAUTH_TOKEN", "GOOGLE_CLOUD_PROJECT"},
+				{"ANTHROPIC_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS"},
+				{"ANTHROPIC_API_KEY", "GOOGLE_CLOUD_PROJECT"},
+				{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"},
+				{"SOME_OTHER_VAR"},
+			},
+		},
+		{
+			"gemini-cli", "gemini-cli",
+			[][]string{
+				{},
+				{"GEMINI_API_KEY"},
+				{"GOOGLE_API_KEY"},
+				{"GOOGLE_APPLICATION_CREDENTIALS"},
+				{"GOOGLE_CLOUD_PROJECT"},
+				{"GEMINI_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS"},
+				{"GEMINI_API_KEY", "GOOGLE_CLOUD_PROJECT"},
+				{"GOOGLE_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS"},
+				{"GOOGLE_API_KEY", "GOOGLE_CLOUD_PROJECT"},
+				{"CLAUDE_CODE_OAUTH_TOKEN"}, // should not affect gemini
+			},
+		},
+		{
+			"codex", "codex",
+			[][]string{
+				{},
+				{"CODEX_API_KEY"},
+				{"OPENAI_API_KEY"},
+				{"GOOGLE_APPLICATION_CREDENTIALS"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		authMeta := loadAuthMetaFromHarness(t, tc.harness)
+		for _, keys := range tc.envKeySets {
+			name := tc.harness + "/"
+			if len(keys) == 0 {
+				name += "empty"
+			} else {
+				for i, k := range keys {
+					if i > 0 {
+						name += "+"
+					}
+					name += k
+				}
+			}
+			t.Run(name, func(t *testing.T) {
+				ks := keySet(keys)
+				want := DetectAuthTypeFromEnvVars(tc.compiledKey, ks)
+				got := DetectAuthTypeFromEnvVarsFromConfig(authMeta, ks)
+				if got != want {
+					t.Errorf("config-driven=%q compiled=%q", got, want)
+				}
+			})
+		}
+	}
+}
+
+// TestDetectAuthTypeFromFileSecrets_ParityWithCompiled verifies that for every
+// built-in harness the config-driven file-secret detection produces the same
+// result as the compiled switch-case.
+func TestDetectAuthTypeFromFileSecrets_ParityWithCompiled(t *testing.T) {
+	cases := []struct {
+		harness     string
+		compiledKey string
+		fileSets    [][]string
+	}{
+		{
+			"claude", "claude",
+			[][]string{
+				{},
+				{"CLAUDE_AUTH"},
+				{"gcloud-adc"},
+				{"CLAUDE_AUTH", "gcloud-adc"},
+			},
+		},
+		{
+			"gemini-cli", "gemini-cli",
+			[][]string{
+				{},
+				{"GEMINI_OAUTH_CREDS"},
+				{"gcloud-adc"},
+				{"GEMINI_OAUTH_CREDS", "gcloud-adc"},
+			},
+		},
+		{
+			"codex", "codex",
+			[][]string{
+				{},
+				{"CODEX_AUTH"},
+				{"gcloud-adc"}, // codex compiled doesn't handle gcloud-adc
+			},
+		},
+	}
+	for _, tc := range cases {
+		authMeta := loadAuthMetaFromHarness(t, tc.harness)
+		for _, files := range tc.fileSets {
+			name := tc.harness + "/"
+			if len(files) == 0 {
+				name += "empty"
+			} else {
+				for i, f := range files {
+					if i > 0 {
+						name += "+"
+					}
+					name += f
+				}
+			}
+			t.Run(name, func(t *testing.T) {
+				ks := keySet(files)
+				want := DetectAuthTypeFromFileSecrets(tc.compiledKey, ks)
+				got := DetectAuthTypeFromFileSecretsFromConfig(authMeta, ks)
+				if got != want {
+					t.Errorf("config-driven=%q compiled=%q", got, want)
+				}
+			})
+		}
+	}
+}
+
+// TestDetectAuthTypeFromGCPIdentity_ParityWithCompiled verifies that for every
+// built-in harness the config-driven GCP identity detection produces the same
+// result as the compiled switch-case.
+func TestDetectAuthTypeFromGCPIdentity_ParityWithCompiled(t *testing.T) {
+	cases := []struct {
+		harness     string
+		compiledKey string
+	}{
+		{"claude", "claude"},
+		{"gemini-cli", "gemini-cli"},
+		{"codex", "codex"},
+	}
+	for _, tc := range cases {
+		authMeta := loadAuthMetaFromHarness(t, tc.harness)
+		for _, assigned := range []bool{false, true} {
+			name := tc.harness
+			if assigned {
+				name += "/sa-assigned"
+			}
+			t.Run(name, func(t *testing.T) {
+				want := DetectAuthTypeFromGCPIdentity(tc.compiledKey, assigned)
+				got := DetectAuthTypeFromGCPIdentityFromConfig(authMeta, assigned)
+				if got != want {
+					t.Errorf("config-driven=%q compiled=%q", got, want)
+				}
+			})
+		}
+	}
+}
+
+// TestGatherConfigEnvVars_ParityWithCompiledLookup verifies that the
+// config-driven env var gathering from harness config metadata produces
+// the same set of keys as the compiled GatherAuthWithEnv hardcoded lookups
+// for built-in harnesses (when all env vars are set).
+func TestGatherConfigEnvVars_ParityWithCompiledLookup(t *testing.T) {
+	cases := []struct {
+		harness string
+		envVars map[string]string
+		// compiledFields are the hardcoded AuthConfig field values expected from
+		// the compiled path. The config-driven path stores the same values in
+		// AuthConfig.EnvVars. We check that every key present in the compiled
+		// fields is also in EnvVars with the same value.
+		compiledFields func(auth api.AuthConfig) map[string]string
+	}{
+		{
+			"claude",
+			map[string]string{
+				"ANTHROPIC_API_KEY":      "test-key",
+				"CLAUDE_CODE_OAUTH_TOKEN": "test-token",
+				"GOOGLE_CLOUD_PROJECT":   "test-project",
+				"GOOGLE_CLOUD_REGION":    "us-central1",
+				"CLOUD_ML_REGION":        "ml-region",
+				"GOOGLE_CLOUD_LOCATION":  "location",
+			},
+			func(auth api.AuthConfig) map[string]string {
+				m := map[string]string{}
+				if auth.AnthropicAPIKey != "" {
+					m["ANTHROPIC_API_KEY"] = auth.AnthropicAPIKey
+				}
+				if auth.ClaudeOAuthToken != "" {
+					m["CLAUDE_CODE_OAUTH_TOKEN"] = auth.ClaudeOAuthToken
+				}
+				return m
+			},
+		},
+		{
+			"codex",
+			map[string]string{
+				"CODEX_API_KEY":  "test-codex-key",
+				"OPENAI_API_KEY": "test-openai-key",
+			},
+			func(auth api.AuthConfig) map[string]string {
+				m := map[string]string{}
+				if auth.CodexAPIKey != "" {
+					m["CODEX_API_KEY"] = auth.CodexAPIKey
+				}
+				if auth.OpenAIAPIKey != "" {
+					m["OPENAI_API_KEY"] = auth.OpenAIAPIKey
+				}
+				return m
+			},
+		},
+		{
+			"gemini-cli",
+			map[string]string{
+				"GEMINI_API_KEY":        "test-gemini-key",
+				"GOOGLE_API_KEY":        "test-google-key",
+				"GOOGLE_CLOUD_PROJECT":  "test-project",
+				"GOOGLE_CLOUD_REGION":   "us-central1",
+				"CLOUD_ML_REGION":       "ml-region",
+				"GOOGLE_CLOUD_LOCATION": "location",
+			},
+			func(auth api.AuthConfig) map[string]string {
+				m := map[string]string{}
+				if auth.GeminiAPIKey != "" {
+					m["GEMINI_API_KEY"] = auth.GeminiAPIKey
+				}
+				if auth.GoogleAPIKey != "" {
+					m["GOOGLE_API_KEY"] = auth.GoogleAPIKey
+				}
+				return m
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.harness, func(t *testing.T) {
+			authMeta := loadAuthMetaFromHarness(t, tc.harness)
+			auth := GatherAuthWithEnv(tc.envVars, false, authMeta)
+
+			// Check that config-driven EnvVars has every harness-specific env key
+			compiledFields := tc.compiledFields(auth)
+			for k, v := range compiledFields {
+				if got, ok := auth.EnvVars[k]; !ok {
+					t.Errorf("EnvVars missing key %q (compiled had value %q)", k, v)
+				} else if got != v {
+					t.Errorf("EnvVars[%q] = %q, compiled = %q", k, got, v)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/harness/auth_test.go
+++ b/pkg/harness/auth_test.go
@@ -25,8 +25,74 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 )
 
-func TestGatherAuth_EnvVars(t *testing.T) {
-	// Set up all env vars
+// testMultiHarnessAuthMeta returns auth metadata that exercises multiple
+// provider env-var groups (Gemini, OpenAI, Codex, etc.) — used by tests
+// that verify config-driven env-var gathering across provider types.
+func testMultiHarnessAuthMeta() *config.HarnessAuthMetadata {
+	return &config.HarnessAuthMetadata{
+		DefaultType: "api-key",
+		Types: map[string]config.HarnessAuthTypeMetadata{
+			"api-key": {
+				RequiredEnv: []config.HarnessAuthEnvRequirement{
+					{AnyOf: []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}},
+					{AnyOf: []string{"ANTHROPIC_API_KEY"}},
+					{AnyOf: []string{"CLAUDE_CODE_OAUTH_TOKEN"}},
+					{AnyOf: []string{"OPENAI_API_KEY"}},
+					{AnyOf: []string{"CODEX_API_KEY"}},
+				},
+			},
+		},
+	}
+}
+
+// testFileDiscoveryAuthMeta returns auth metadata with file credential
+// entries for OAuth, Codex, OpenCode, and Claude — used by file discovery
+// tests.
+func testFileDiscoveryAuthMeta() *config.HarnessAuthMetadata {
+	return &config.HarnessAuthMetadata{
+		DefaultType: "api-key",
+		Types: map[string]config.HarnessAuthTypeMetadata{
+			"auth-file": {
+				RequiredFiles: []config.HarnessAuthFileRequirement{
+					{Name: "GEMINI_OAUTH_CREDS", Type: "file", TargetSuffix: "/.gemini/oauth_creds.json", Field: "OAuthCreds"},
+					{Name: "CODEX_AUTH", Type: "file", TargetSuffix: "/.codex/auth.json", Field: "CodexAuthFile"},
+					{Name: "OPENCODE_AUTH", Type: "file", TargetSuffix: "/.local/share/opencode/auth.json", Field: "OpenCodeAuthFile"},
+					{Name: "CLAUDE_AUTH", Type: "file", TargetSuffix: "/.claude/.credentials.json", Field: "ClaudeAuthFile"},
+				},
+			},
+		},
+	}
+}
+
+func TestGatherAuth_GCPSharedFields(t *testing.T) {
+	// GatherAuth() with nil authMeta only populates GCP shared fields.
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "my-project")
+	t.Setenv("GOOGLE_CLOUD_REGION", "us-central1")
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/path/to/creds.json")
+
+	auth := GatherAuth()
+
+	if auth.GoogleCloudProject != "my-project" {
+		t.Errorf("GoogleCloudProject = %q, want %q", auth.GoogleCloudProject, "my-project")
+	}
+	if auth.GoogleCloudRegion != "us-central1" {
+		t.Errorf("GoogleCloudRegion = %q, want %q", auth.GoogleCloudRegion, "us-central1")
+	}
+	if auth.GoogleAppCredentials != "/path/to/creds.json" {
+		t.Errorf("GoogleAppCredentials = %q, want %q", auth.GoogleAppCredentials, "/path/to/creds.json")
+	}
+
+	// With nil authMeta, EnvVars and Files are not populated.
+	if auth.EnvVars != nil {
+		t.Errorf("EnvVars should be nil with nil authMeta, got %v", auth.EnvVars)
+	}
+	if auth.Files != nil {
+		t.Errorf("Files should be nil with nil authMeta, got %v", auth.Files)
+	}
+}
+
+func TestGatherAuthWithEnv_ConfigDrivenEnvVarsFromProcess(t *testing.T) {
+	// With non-nil authMeta, per-provider env vars are gathered into EnvVars.
 	t.Setenv("GEMINI_API_KEY", "gemini-key")
 	t.Setenv("GOOGLE_API_KEY", "google-key")
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-key")
@@ -37,26 +103,10 @@ func TestGatherAuth_EnvVars(t *testing.T) {
 	t.Setenv("GOOGLE_CLOUD_REGION", "us-central1")
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/path/to/creds.json")
 
-	auth := GatherAuth()
+	meta := testMultiHarnessAuthMeta()
+	auth := GatherAuthWithEnv(nil, true, meta)
 
-	if auth.GeminiAPIKey != "gemini-key" {
-		t.Errorf("GeminiAPIKey = %q, want %q", auth.GeminiAPIKey, "gemini-key")
-	}
-	if auth.GoogleAPIKey != "google-key" {
-		t.Errorf("GoogleAPIKey = %q, want %q", auth.GoogleAPIKey, "google-key")
-	}
-	if auth.AnthropicAPIKey != "anthropic-key" {
-		t.Errorf("AnthropicAPIKey = %q, want %q", auth.AnthropicAPIKey, "anthropic-key")
-	}
-	if auth.ClaudeOAuthToken != "claude-oauth-tok" {
-		t.Errorf("ClaudeOAuthToken = %q, want %q", auth.ClaudeOAuthToken, "claude-oauth-tok")
-	}
-	if auth.OpenAIAPIKey != "openai-key" {
-		t.Errorf("OpenAIAPIKey = %q, want %q", auth.OpenAIAPIKey, "openai-key")
-	}
-	if auth.CodexAPIKey != "codex-key" {
-		t.Errorf("CodexAPIKey = %q, want %q", auth.CodexAPIKey, "codex-key")
-	}
+	// GCP shared fields are always populated directly.
 	if auth.GoogleCloudProject != "my-project" {
 		t.Errorf("GoogleCloudProject = %q, want %q", auth.GoogleCloudProject, "my-project")
 	}
@@ -65,6 +115,24 @@ func TestGatherAuth_EnvVars(t *testing.T) {
 	}
 	if auth.GoogleAppCredentials != "/path/to/creds.json" {
 		t.Errorf("GoogleAppCredentials = %q, want %q", auth.GoogleAppCredentials, "/path/to/creds.json")
+	}
+
+	// Per-provider env vars are now in EnvVars.
+	if auth.EnvVars == nil {
+		t.Fatal("EnvVars should not be nil when authMeta is provided")
+	}
+	checks := map[string]string{
+		"GEMINI_API_KEY":          "gemini-key",
+		"GOOGLE_API_KEY":          "google-key",
+		"ANTHROPIC_API_KEY":       "anthropic-key",
+		"CLAUDE_CODE_OAUTH_TOKEN": "claude-oauth-tok",
+		"OPENAI_API_KEY":          "openai-key",
+		"CODEX_API_KEY":           "codex-key",
+	}
+	for key, want := range checks {
+		if got := auth.EnvVars[key]; got != want {
+			t.Errorf("EnvVars[%q] = %q, want %q", key, got, want)
+		}
 	}
 }
 
@@ -149,28 +217,31 @@ func TestGatherAuth_FileDiscovery(t *testing.T) {
 	_ = os.MkdirAll(filepath.Dir(claudeCredsPath), 0755)
 	_ = os.WriteFile(claudeCredsPath, []byte(`{"claudeAiOauth":{"accessToken":"rotating"}}`), 0644)
 
-	auth := GatherAuth()
+	// Use GatherAuthWithEnv with file-discovery authMeta so that per-harness
+	// file credentials flow through auth.Files.
+	meta := testFileDiscoveryAuthMeta()
+	auth := GatherAuthWithEnv(nil, true, meta)
 
+	// ADC is still a first-class GCP shared field.
 	if auth.GoogleAppCredentials != adcPath {
 		t.Errorf("GoogleAppCredentials = %q, want %q", auth.GoogleAppCredentials, adcPath)
 	}
-	if auth.OAuthCreds != oauthPath {
-		t.Errorf("OAuthCreds = %q, want %q", auth.OAuthCreds, oauthPath)
+
+	// Per-harness file credentials are now in auth.Files.
+	if auth.Files == nil {
+		t.Fatal("Files should not be nil when authMeta has file requirements")
 	}
-	if auth.CodexAuthFile != codexPath {
-		t.Errorf("CodexAuthFile = %q, want %q", auth.CodexAuthFile, codexPath)
+	if auth.Files["OAuthCreds"] != oauthPath {
+		t.Errorf("Files[OAuthCreds] = %q, want %q", auth.Files["OAuthCreds"], oauthPath)
 	}
-	if auth.OpenCodeAuthFile != opencodePath {
-		t.Errorf("OpenCodeAuthFile = %q, want %q", auth.OpenCodeAuthFile, opencodePath)
+	if auth.Files["CodexAuthFile"] != codexPath {
+		t.Errorf("Files[CodexAuthFile] = %q, want %q", auth.Files["CodexAuthFile"], codexPath)
 	}
-	if auth.ClaudeAuthFile != claudeCredsPath {
-		t.Errorf("ClaudeAuthFile = %q, want %q", auth.ClaudeAuthFile, claudeCredsPath)
+	if auth.Files["OpenCodeAuthFile"] != opencodePath {
+		t.Errorf("Files[OpenCodeAuthFile] = %q, want %q", auth.Files["OpenCodeAuthFile"], opencodePath)
 	}
-	// The file must be treated opaquely — we must NOT have read/parsed
-	// any content out of it into ClaudeOAuthToken. That field only comes
-	// from the CLAUDE_CODE_OAUTH_TOKEN env var.
-	if auth.ClaudeOAuthToken != "" {
-		t.Errorf("ClaudeOAuthToken = %q, want empty (must not scrape from credentials file)", auth.ClaudeOAuthToken)
+	if auth.Files["ClaudeAuthFile"] != claudeCredsPath {
+		t.Errorf("Files[ClaudeAuthFile] = %q, want %q", auth.Files["ClaudeAuthFile"], claudeCredsPath)
 	}
 }
 
@@ -210,22 +281,18 @@ func TestGatherAuth_NoFiles(t *testing.T) {
 	t.Setenv("CLOUD_ML_REGION", "")
 	t.Setenv("GOOGLE_CLOUD_LOCATION", "")
 
+	// With nil authMeta, no file scanning occurs for per-harness files.
 	auth := GatherAuth()
 
 	if auth.GoogleAppCredentials != "" {
 		t.Errorf("GoogleAppCredentials = %q, want empty", auth.GoogleAppCredentials)
 	}
-	if auth.OAuthCreds != "" {
-		t.Errorf("OAuthCreds = %q, want empty", auth.OAuthCreds)
-	}
-	if auth.CodexAuthFile != "" {
-		t.Errorf("CodexAuthFile = %q, want empty", auth.CodexAuthFile)
-	}
-	if auth.OpenCodeAuthFile != "" {
-		t.Errorf("OpenCodeAuthFile = %q, want empty", auth.OpenCodeAuthFile)
-	}
-	if auth.ClaudeAuthFile != "" {
-		t.Errorf("ClaudeAuthFile = %q, want empty", auth.ClaudeAuthFile)
+
+	// With authMeta but no files on disk, Files should be nil.
+	meta := testFileDiscoveryAuthMeta()
+	auth2 := GatherAuthWithEnv(nil, true, meta)
+	if auth2.Files != nil {
+		t.Errorf("Files = %v, want nil (no files on disk)", auth2.Files)
 	}
 }
 
@@ -348,22 +415,23 @@ func TestValidateAuth_EmptyEnvVarsAndFiles(t *testing.T) {
 
 func TestGatherAuthWithEnv_OverlayTakesPrecedence(t *testing.T) {
 	// Set process env vars
-	t.Setenv("GEMINI_API_KEY", "process-gemini")
 	t.Setenv("ANTHROPIC_API_KEY", "process-anthropic")
+	t.Setenv("GEMINI_API_KEY", "process-gemini")
 
 	// Overlay should win over process env
 	overlay := map[string]string{
 		"GEMINI_API_KEY": "overlay-gemini",
 	}
 
-	auth := GatherAuthWithEnv(overlay, true, nil)
+	meta := testMultiHarnessAuthMeta()
+	auth := GatherAuthWithEnv(overlay, true, meta)
 
-	if auth.GeminiAPIKey != "overlay-gemini" {
-		t.Errorf("GeminiAPIKey = %q, want %q (overlay should take precedence)", auth.GeminiAPIKey, "overlay-gemini")
+	if auth.EnvVars["GEMINI_API_KEY"] != "overlay-gemini" {
+		t.Errorf("EnvVars[GEMINI_API_KEY] = %q, want %q (overlay should take precedence)", auth.EnvVars["GEMINI_API_KEY"], "overlay-gemini")
 	}
 	// Non-overlaid key should fall back to process env
-	if auth.AnthropicAPIKey != "process-anthropic" {
-		t.Errorf("AnthropicAPIKey = %q, want %q (should fall back to process env)", auth.AnthropicAPIKey, "process-anthropic")
+	if auth.EnvVars["ANTHROPIC_API_KEY"] != "process-anthropic" {
+		t.Errorf("EnvVars[ANTHROPIC_API_KEY] = %q, want %q (should fall back to process env)", auth.EnvVars["ANTHROPIC_API_KEY"], "process-anthropic")
 	}
 }
 
@@ -371,326 +439,15 @@ func TestGatherAuthWithEnv_NilOverlay(t *testing.T) {
 	t.Setenv("GEMINI_API_KEY", "process-gemini")
 	t.Setenv("OPENAI_API_KEY", "process-openai")
 
-	// nil overlay should behave identically to GatherAuth
-	auth := GatherAuthWithEnv(nil, true, nil)
+	meta := testMultiHarnessAuthMeta()
+	// nil overlay should behave identically to GatherAuth (with authMeta)
+	auth := GatherAuthWithEnv(nil, true, meta)
 
-	if auth.GeminiAPIKey != "process-gemini" {
-		t.Errorf("GeminiAPIKey = %q, want %q", auth.GeminiAPIKey, "process-gemini")
+	if auth.EnvVars["GEMINI_API_KEY"] != "process-gemini" {
+		t.Errorf("EnvVars[GEMINI_API_KEY] = %q, want %q", auth.EnvVars["GEMINI_API_KEY"], "process-gemini")
 	}
-	if auth.OpenAIAPIKey != "process-openai" {
-		t.Errorf("OpenAIAPIKey = %q, want %q", auth.OpenAIAPIKey, "process-openai")
-	}
-}
-
-func TestRequiredAuthEnvKeys(t *testing.T) {
-	tests := []struct {
-		name     string
-		harness  string
-		authType string
-		want     [][]string
-	}{
-		// Claude
-		{"claude api-key", "claude", "api-key", [][]string{{"ANTHROPIC_API_KEY"}}},
-		{"claude oauth-token", "claude", "oauth-token", [][]string{{"CLAUDE_CODE_OAUTH_TOKEN"}}},
-		{"claude auth-file", "claude", "auth-file", nil},
-		{"claude vertex-ai", "claude", "vertex-ai", [][]string{{"GOOGLE_CLOUD_PROJECT"}, {"GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"}}},
-
-		// Gemini
-		{"gemini api-key", "gemini", "api-key", [][]string{{"GEMINI_API_KEY", "GOOGLE_API_KEY"}}},
-		{"gemini auth-file", "gemini", "auth-file", nil},
-		{"gemini vertex-ai", "gemini", "vertex-ai", [][]string{{"GOOGLE_CLOUD_PROJECT"}, {"GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"}}},
-
-		// Gemini-CLI (mirrors gemini)
-		{"gemini-cli api-key", "gemini-cli", "api-key", [][]string{{"GEMINI_API_KEY", "GOOGLE_API_KEY"}}},
-		{"gemini-cli auth-file", "gemini-cli", "auth-file", nil},
-		{"gemini-cli vertex-ai", "gemini-cli", "vertex-ai", [][]string{{"GOOGLE_CLOUD_PROJECT"}, {"GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"}}},
-
-		// OpenCode
-		{"opencode api-key", "opencode", "api-key", [][]string{{"ANTHROPIC_API_KEY", "OPENAI_API_KEY"}}},
-		{"opencode auth-file", "opencode", "auth-file", nil},
-
-		// Codex
-		{"codex api-key", "codex", "api-key", [][]string{{"CODEX_API_KEY", "OPENAI_API_KEY"}}},
-		{"codex auth-file", "codex", "auth-file", nil},
-
-		// Generic
-		{"generic api-key", "generic", "api-key", nil},
-		{"generic vertex-ai", "generic", "vertex-ai", nil},
-
-		// Empty authType defaults to api-key
-		{"claude empty auth type", "claude", "", [][]string{{"ANTHROPIC_API_KEY"}}},
-		{"gemini empty auth type", "gemini", "", [][]string{{"GEMINI_API_KEY", "GOOGLE_API_KEY"}}},
-		{"gemini-cli empty auth type", "gemini-cli", "", [][]string{{"GEMINI_API_KEY", "GOOGLE_API_KEY"}}},
-		{"opencode empty auth type", "opencode", "", [][]string{{"ANTHROPIC_API_KEY", "OPENAI_API_KEY"}}},
-		{"codex empty auth type", "codex", "", [][]string{{"CODEX_API_KEY", "OPENAI_API_KEY"}}},
-
-		// Unknown/empty
-		{"empty harness", "", "api-key", nil},
-		{"both empty", "", "", nil},
-		{"unknown harness", "unknown", "api-key", nil},
-		{"unknown auth type", "claude", "unknown", nil},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := RequiredAuthEnvKeys(tt.harness, tt.authType)
-			if tt.want == nil {
-				if got != nil {
-					t.Errorf("RequiredAuthEnvKeys(%q, %q) = %v, want nil", tt.harness, tt.authType, got)
-				}
-				return
-			}
-			if len(got) != len(tt.want) {
-				t.Fatalf("RequiredAuthEnvKeys(%q, %q) returned %d groups, want %d", tt.harness, tt.authType, len(got), len(tt.want))
-			}
-			for i, group := range got {
-				if len(group) != len(tt.want[i]) {
-					t.Errorf("group %d: got %v, want %v", i, group, tt.want[i])
-					continue
-				}
-				for j, key := range group {
-					if key != tt.want[i][j] {
-						t.Errorf("group %d key %d: got %q, want %q", i, j, key, tt.want[i][j])
-					}
-				}
-			}
-		})
-	}
-}
-
-func TestRequiredAuthSecrets(t *testing.T) {
-	tests := []struct {
-		name          string
-		harness       string
-		authType      string
-		gcpSAAssigned bool
-		wantNil       bool
-		wantKey       string
-		wantType      string
-	}{
-		{"claude vertex-ai", "claude", "vertex-ai", false, false, "gcloud-adc", "file"},
-		{"gemini vertex-ai", "gemini", "vertex-ai", false, false, "gcloud-adc", "file"},
-		{"gemini-cli vertex-ai", "gemini-cli", "vertex-ai", false, false, "gcloud-adc", "file"},
-		{"opencode vertex-ai", "opencode", "vertex-ai", false, false, "gcloud-adc", "file"},
-		{"codex vertex-ai", "codex", "vertex-ai", false, false, "gcloud-adc", "file"},
-		{"claude api-key", "claude", "api-key", false, true, "", ""},
-		{"gemini api-key", "gemini", "api-key", false, true, "", ""},
-		{"gemini-cli api-key", "gemini-cli", "api-key", false, true, "", ""},
-		{"claude empty auth type", "claude", "", false, true, "", ""},
-		{"gemini empty auth type", "gemini", "", false, true, "", ""},
-		{"gemini-cli empty auth type", "gemini-cli", "", false, true, "", ""},
-		{"generic vertex-ai", "generic", "vertex-ai", false, true, "", ""},
-		{"unknown harness", "unknown", "vertex-ai", false, true, "", ""},
-		{"empty harness", "", "vertex-ai", false, true, "", ""},
-		{"both empty", "", "", false, true, "", ""},
-		// GCP SA assigned — ADC not required
-		{"claude vertex-ai with GCP SA", "claude", "vertex-ai", true, true, "", ""},
-		{"gemini vertex-ai with GCP SA", "gemini", "vertex-ai", true, true, "", ""},
-		{"gemini-cli vertex-ai with GCP SA", "gemini-cli", "vertex-ai", true, true, "", ""},
-		{"opencode vertex-ai with GCP SA", "opencode", "vertex-ai", true, true, "", ""},
-		{"codex vertex-ai with GCP SA", "codex", "vertex-ai", true, true, "", ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := RequiredAuthSecrets(tt.harness, tt.authType, tt.gcpSAAssigned)
-			if tt.wantNil {
-				if got != nil {
-					t.Errorf("RequiredAuthSecrets(%q, %q, %t) = %v, want nil", tt.harness, tt.authType, tt.gcpSAAssigned, got)
-				}
-				return
-			}
-			if len(got) != 1 {
-				t.Fatalf("RequiredAuthSecrets(%q, %q, %t) returned %d secrets, want 1", tt.harness, tt.authType, tt.gcpSAAssigned, len(got))
-			}
-			if got[0].Key != tt.wantKey {
-				t.Errorf("Key = %q, want %q", got[0].Key, tt.wantKey)
-			}
-			if got[0].Type != tt.wantType {
-				t.Errorf("Type = %q, want %q", got[0].Type, tt.wantType)
-			}
-			if got[0].Description == "" {
-				t.Error("Description should not be empty")
-			}
-			// vertex-ai secrets should list GOOGLE_APPLICATION_CREDENTIALS as alternative
-			if tt.authType == "vertex-ai" && !tt.gcpSAAssigned {
-				if len(got[0].AlternativeEnvKeys) != 1 || got[0].AlternativeEnvKeys[0] != "GOOGLE_APPLICATION_CREDENTIALS" {
-					t.Errorf("AlternativeEnvKeys = %v, want [GOOGLE_APPLICATION_CREDENTIALS]", got[0].AlternativeEnvKeys)
-				}
-			}
-		})
-	}
-}
-
-func TestDetectAuthTypeFromGCPIdentity(t *testing.T) {
-	tests := []struct {
-		name          string
-		harness       string
-		gcpSAAssigned bool
-		wantType      string
-	}{
-		{"claude with GCP SA", "claude", true, "vertex-ai"},
-		{"gemini with GCP SA", "gemini", true, "vertex-ai"},
-		{"gemini-cli with GCP SA", "gemini-cli", true, "vertex-ai"},
-		{"claude without GCP SA", "claude", false, ""},
-		{"gemini without GCP SA", "gemini", false, ""},
-		{"gemini-cli without GCP SA", "gemini-cli", false, ""},
-		{"opencode with GCP SA", "opencode", true, ""},
-		{"codex with GCP SA", "codex", true, ""},
-		{"generic with GCP SA", "generic", true, ""},
-		{"unknown with GCP SA", "unknown", true, ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := DetectAuthTypeFromGCPIdentity(tt.harness, tt.gcpSAAssigned)
-			if got != tt.wantType {
-				t.Errorf("DetectAuthTypeFromGCPIdentity(%q, %t) = %q, want %q", tt.harness, tt.gcpSAAssigned, got, tt.wantType)
-			}
-		})
-	}
-}
-
-func TestDetectAuthTypeFromEnvVars(t *testing.T) {
-	tests := []struct {
-		name     string
-		harness  string
-		envKeys  map[string]struct{}
-		wantType string
-	}{
-		{"claude with GAC", "claude", map[string]struct{}{"GOOGLE_APPLICATION_CREDENTIALS": {}}, "vertex-ai"},
-		{"claude with GOOGLE_CLOUD_PROJECT", "claude", map[string]struct{}{"GOOGLE_CLOUD_PROJECT": {}}, "vertex-ai"},
-		{"claude with CLAUDE_CODE_OAUTH_TOKEN", "claude", map[string]struct{}{"CLAUDE_CODE_OAUTH_TOKEN": {}}, "oauth-token"},
-		{"claude prefers OAuth token over GAC", "claude", map[string]struct{}{"CLAUDE_CODE_OAUTH_TOKEN": {}, "GOOGLE_APPLICATION_CREDENTIALS": {}}, "oauth-token"},
-		{"claude prefers OAuth token over GCP", "claude", map[string]struct{}{"CLAUDE_CODE_OAUTH_TOKEN": {}, "GOOGLE_CLOUD_PROJECT": {}}, "oauth-token"},
-		{"gemini with GAC", "gemini", map[string]struct{}{"GOOGLE_APPLICATION_CREDENTIALS": {}}, "vertex-ai"},
-		{"gemini with GOOGLE_CLOUD_PROJECT", "gemini", map[string]struct{}{"GOOGLE_CLOUD_PROJECT": {}}, "vertex-ai"},
-		{"gemini with CLAUDE_CODE_OAUTH_TOKEN", "gemini", map[string]struct{}{"CLAUDE_CODE_OAUTH_TOKEN": {}}, ""},
-		{"gemini-cli with GAC", "gemini-cli", map[string]struct{}{"GOOGLE_APPLICATION_CREDENTIALS": {}}, "vertex-ai"},
-		{"gemini-cli with GOOGLE_CLOUD_PROJECT", "gemini-cli", map[string]struct{}{"GOOGLE_CLOUD_PROJECT": {}}, "vertex-ai"},
-		{"claude without GAC", "claude", map[string]struct{}{}, ""},
-		{"gemini without GAC", "gemini", map[string]struct{}{}, ""},
-		{"gemini-cli without GAC", "gemini-cli", map[string]struct{}{}, ""},
-		{"opencode with GAC", "opencode", map[string]struct{}{"GOOGLE_APPLICATION_CREDENTIALS": {}}, ""},
-		{"opencode with GOOGLE_CLOUD_PROJECT", "opencode", map[string]struct{}{"GOOGLE_CLOUD_PROJECT": {}}, ""},
-		{"codex with GAC", "codex", map[string]struct{}{"GOOGLE_APPLICATION_CREDENTIALS": {}}, ""},
-		{"generic with GAC", "generic", map[string]struct{}{"GOOGLE_APPLICATION_CREDENTIALS": {}}, ""},
-		{"claude with unrelated env", "claude", map[string]struct{}{"SOME_OTHER_VAR": {}}, ""},
-		{"claude API key wins over GAC", "claude", map[string]struct{}{"ANTHROPIC_API_KEY": {}, "GOOGLE_APPLICATION_CREDENTIALS": {}}, ""},
-		{"claude API key wins over GCP project", "claude", map[string]struct{}{"ANTHROPIC_API_KEY": {}, "GOOGLE_CLOUD_PROJECT": {}}, ""},
-		{"claude API key alone", "claude", map[string]struct{}{"ANTHROPIC_API_KEY": {}}, ""},
-		{"gemini API key wins over GAC", "gemini", map[string]struct{}{"GEMINI_API_KEY": {}, "GOOGLE_APPLICATION_CREDENTIALS": {}}, ""},
-		{"gemini API key wins over GCP project", "gemini", map[string]struct{}{"GEMINI_API_KEY": {}, "GOOGLE_CLOUD_PROJECT": {}}, ""},
-		{"gemini GOOGLE_API_KEY wins over GAC", "gemini", map[string]struct{}{"GOOGLE_API_KEY": {}, "GOOGLE_APPLICATION_CREDENTIALS": {}}, ""},
-		{"gemini API key alone", "gemini", map[string]struct{}{"GEMINI_API_KEY": {}}, ""},
-		{"gemini-cli API key wins over GAC", "gemini-cli", map[string]struct{}{"GEMINI_API_KEY": {}, "GOOGLE_APPLICATION_CREDENTIALS": {}}, ""},
-		{"gemini-cli API key wins over GCP project", "gemini-cli", map[string]struct{}{"GEMINI_API_KEY": {}, "GOOGLE_CLOUD_PROJECT": {}}, ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := DetectAuthTypeFromEnvVars(tt.harness, tt.envKeys)
-			if got != tt.wantType {
-				t.Errorf("DetectAuthTypeFromEnvVars(%q, ...) = %q, want %q", tt.harness, got, tt.wantType)
-			}
-		})
-	}
-}
-
-func TestDetectAuthTypeFromFileSecrets(t *testing.T) {
-	tests := []struct {
-		name     string
-		harness  string
-		secrets  map[string]struct{}
-		wantType string
-	}{
-		{
-			"gemini with GEMINI_OAUTH_CREDS",
-			"gemini",
-			map[string]struct{}{"GEMINI_OAUTH_CREDS": {}},
-			"auth-file",
-		},
-		{
-			"gemini with gcloud-adc",
-			"gemini",
-			map[string]struct{}{"gcloud-adc": {}},
-			"vertex-ai",
-		},
-		{
-			"gemini with both OAuth and ADC prefers OAuth",
-			"gemini",
-			map[string]struct{}{"GEMINI_OAUTH_CREDS": {}, "gcloud-adc": {}},
-			"auth-file",
-		},
-		{
-			"gemini with no file secrets",
-			"gemini",
-			map[string]struct{}{},
-			"",
-		},
-		{
-			"gemini-cli with gcloud-adc",
-			"gemini-cli",
-			map[string]struct{}{"gcloud-adc": {}},
-			"vertex-ai",
-		},
-		{
-			"gemini-cli with GEMINI_OAUTH_CREDS",
-			"gemini-cli",
-			map[string]struct{}{"GEMINI_OAUTH_CREDS": {}},
-			"auth-file",
-		},
-		{
-			"codex with CODEX_AUTH",
-			"codex",
-			map[string]struct{}{"CODEX_AUTH": {}},
-			"auth-file",
-		},
-		{
-			"opencode with OPENCODE_AUTH",
-			"opencode",
-			map[string]struct{}{"OPENCODE_AUTH": {}},
-			"auth-file",
-		},
-		{
-			"claude with gcloud-adc",
-			"claude",
-			map[string]struct{}{"gcloud-adc": {}},
-			"vertex-ai",
-		},
-		{
-			"claude with CLAUDE_AUTH",
-			"claude",
-			map[string]struct{}{"CLAUDE_AUTH": {}},
-			"auth-file",
-		},
-		{
-			"claude prefers CLAUDE_AUTH over gcloud-adc",
-			"claude",
-			map[string]struct{}{"CLAUDE_AUTH": {}, "gcloud-adc": {}},
-			"auth-file",
-		},
-		{
-			"claude with no file secrets",
-			"claude",
-			map[string]struct{}{},
-			"",
-		},
-		{
-			"unknown harness",
-			"unknown",
-			map[string]struct{}{"GEMINI_OAUTH_CREDS": {}},
-			"",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := DetectAuthTypeFromFileSecrets(tt.harness, tt.secrets)
-			if got != tt.wantType {
-				t.Errorf("DetectAuthTypeFromFileSecrets(%q, ...) = %q, want %q", tt.harness, got, tt.wantType)
-			}
-		})
+	if auth.EnvVars["OPENAI_API_KEY"] != "process-openai" {
+		t.Errorf("EnvVars[OPENAI_API_KEY] = %q, want %q", auth.EnvVars["OPENAI_API_KEY"], "process-openai")
 	}
 }
 
@@ -702,10 +459,11 @@ func TestGatherAuthWithEnv_EmptyOverlayValueFallsThrough(t *testing.T) {
 		"GEMINI_API_KEY": "",
 	}
 
-	auth := GatherAuthWithEnv(overlay, true, nil)
+	meta := testMultiHarnessAuthMeta()
+	auth := GatherAuthWithEnv(overlay, true, meta)
 
-	if auth.GeminiAPIKey != "process-gemini" {
-		t.Errorf("GeminiAPIKey = %q, want %q (empty overlay should fall through)", auth.GeminiAPIKey, "process-gemini")
+	if auth.EnvVars["GEMINI_API_KEY"] != "process-gemini" {
+		t.Errorf("EnvVars[GEMINI_API_KEY] = %q, want %q (empty overlay should fall through)", auth.EnvVars["GEMINI_API_KEY"], "process-gemini")
 	}
 }
 
@@ -753,23 +511,10 @@ func TestGatherAuthWithEnv_OverlayAllKeys(t *testing.T) {
 		"GOOGLE_APPLICATION_CREDENTIALS": "/ov/creds.json",
 	}
 
-	auth := GatherAuthWithEnv(overlay, true, nil)
+	meta := testMultiHarnessAuthMeta()
+	auth := GatherAuthWithEnv(overlay, true, meta)
 
-	if auth.GeminiAPIKey != "ov-gemini" {
-		t.Errorf("GeminiAPIKey = %q, want %q", auth.GeminiAPIKey, "ov-gemini")
-	}
-	if auth.GoogleAPIKey != "ov-google" {
-		t.Errorf("GoogleAPIKey = %q, want %q", auth.GoogleAPIKey, "ov-google")
-	}
-	if auth.AnthropicAPIKey != "ov-anthropic" {
-		t.Errorf("AnthropicAPIKey = %q, want %q", auth.AnthropicAPIKey, "ov-anthropic")
-	}
-	if auth.OpenAIAPIKey != "ov-openai" {
-		t.Errorf("OpenAIAPIKey = %q, want %q", auth.OpenAIAPIKey, "ov-openai")
-	}
-	if auth.CodexAPIKey != "ov-codex" {
-		t.Errorf("CodexAPIKey = %q, want %q", auth.CodexAPIKey, "ov-codex")
-	}
+	// GCP shared fields
 	if auth.GoogleCloudProject != "ov-project" {
 		t.Errorf("GoogleCloudProject = %q, want %q", auth.GoogleCloudProject, "ov-project")
 	}
@@ -778,6 +523,23 @@ func TestGatherAuthWithEnv_OverlayAllKeys(t *testing.T) {
 	}
 	if auth.GoogleAppCredentials != "/ov/creds.json" {
 		t.Errorf("GoogleAppCredentials = %q, want %q", auth.GoogleAppCredentials, "/ov/creds.json")
+	}
+
+	// Per-provider env vars via EnvVars
+	envChecks := map[string]string{
+		"GEMINI_API_KEY":    "ov-gemini",
+		"GOOGLE_API_KEY":    "ov-google",
+		"ANTHROPIC_API_KEY": "ov-anthropic",
+		"OPENAI_API_KEY":    "ov-openai",
+		"CODEX_API_KEY":     "ov-codex",
+	}
+	if auth.EnvVars == nil {
+		t.Fatal("EnvVars should not be nil")
+	}
+	for key, want := range envChecks {
+		if got := auth.EnvVars[key]; got != want {
+			t.Errorf("EnvVars[%q] = %q, want %q", key, got, want)
+		}
 	}
 }
 
@@ -873,35 +635,32 @@ func TestGatherAuthWithEnv_BrokerMode(t *testing.T) {
 	_ = os.MkdirAll(filepath.Dir(adcPath), 0755)
 	_ = os.WriteFile(adcPath, []byte(`{"type":"authorized_user"}`), 0644)
 
-	oauthPath := filepath.Join(tmpHome, ".gemini", "oauth_creds.json")
-	_ = os.MkdirAll(filepath.Dir(oauthPath), 0755)
-	_ = os.WriteFile(oauthPath, []byte(`{"dummy":"oauth"}`), 0644)
-
 	// Call with localSources=false and an overlay that provides one key
 	overlay := map[string]string{
 		"ANTHROPIC_API_KEY": "hub-anthropic",
 	}
-	auth := GatherAuthWithEnv(overlay, false, nil)
+	meta := testMultiHarnessAuthMeta()
+	auth := GatherAuthWithEnv(overlay, false, meta)
 
-	// Overlay key should be present
-	if auth.AnthropicAPIKey != "hub-anthropic" {
-		t.Errorf("AnthropicAPIKey = %q, want %q (from overlay)", auth.AnthropicAPIKey, "hub-anthropic")
+	// Overlay key should be present in EnvVars
+	if auth.EnvVars == nil {
+		t.Fatal("EnvVars should not be nil")
+	}
+	if auth.EnvVars["ANTHROPIC_API_KEY"] != "hub-anthropic" {
+		t.Errorf("EnvVars[ANTHROPIC_API_KEY] = %q, want %q (from overlay)", auth.EnvVars["ANTHROPIC_API_KEY"], "hub-anthropic")
 	}
 
 	// Broker env should NOT leak through
-	if auth.GeminiAPIKey != "" {
-		t.Errorf("GeminiAPIKey = %q, want empty (broker env should not leak)", auth.GeminiAPIKey)
+	if _, ok := auth.EnvVars["GEMINI_API_KEY"]; ok {
+		t.Errorf("EnvVars[GEMINI_API_KEY] should not be set (broker env should not leak)")
 	}
 
 	// Filesystem creds should NOT be discovered
 	if auth.GoogleAppCredentials != "" {
 		t.Errorf("GoogleAppCredentials = %q, want empty (filesystem should not be scanned)", auth.GoogleAppCredentials)
 	}
-	if auth.OAuthCreds != "" {
-		t.Errorf("OAuthCreds = %q, want empty (filesystem should not be scanned)", auth.OAuthCreds)
-	}
-	if auth.ClaudeAuthFile != "" {
-		t.Errorf("ClaudeAuthFile = %q, want empty (filesystem should not be scanned)", auth.ClaudeAuthFile)
+	if auth.Files != nil {
+		t.Errorf("Files should be nil in broker mode (filesystem should not be scanned)")
 	}
 }
 
@@ -934,24 +693,24 @@ func TestOverlayFileSecrets(t *testing.T) {
 			},
 		},
 		{
-			name: "OAuth by name",
+			name: "OAuth by target suffix",
 			secrets: []api.ResolvedSecret{
-				{Name: "GEMINI_OAUTH_CREDS", Type: "file", Target: "/home/gemini/.gemini/oauth_creds.json"},
+				{Name: "my-oauth", Type: "file", Target: "/home/gemini/.gemini/oauth_creds.json"},
 			},
 			check: func(t *testing.T, auth api.AuthConfig) {
-				if auth.OAuthCreds != "/home/gemini/.gemini/oauth_creds.json" {
-					t.Errorf("OAuthCreds = %q, want oauth path", auth.OAuthCreds)
+				if auth.Files == nil || auth.Files["OAuthCreds"] != "/home/gemini/.gemini/oauth_creds.json" {
+					t.Errorf("Files[OAuthCreds] = %q, want oauth path", auth.Files["OAuthCreds"])
 				}
 			},
 		},
 		{
-			name: "Codex by name",
+			name: "Codex by target suffix",
 			secrets: []api.ResolvedSecret{
-				{Name: "CODEX_AUTH", Type: "file", Target: "/home/gemini/.codex/auth.json"},
+				{Name: "my-codex", Type: "file", Target: "/home/gemini/.codex/auth.json"},
 			},
 			check: func(t *testing.T, auth api.AuthConfig) {
-				if auth.CodexAuthFile != "/home/gemini/.codex/auth.json" {
-					t.Errorf("CodexAuthFile = %q, want codex path", auth.CodexAuthFile)
+				if auth.Files == nil || auth.Files["CodexAuthFile"] != "/home/gemini/.codex/auth.json" {
+					t.Errorf("Files[CodexAuthFile] = %q, want codex path", auth.Files["CodexAuthFile"])
 				}
 			},
 		},
@@ -961,19 +720,8 @@ func TestOverlayFileSecrets(t *testing.T) {
 				{Name: "my-opencode", Type: "file", Target: "/home/gemini/.local/share/opencode/auth.json"},
 			},
 			check: func(t *testing.T, auth api.AuthConfig) {
-				if auth.OpenCodeAuthFile != "/home/gemini/.local/share/opencode/auth.json" {
-					t.Errorf("OpenCodeAuthFile = %q, want opencode path", auth.OpenCodeAuthFile)
-				}
-			},
-		},
-		{
-			name: "Claude credentials by name",
-			secrets: []api.ResolvedSecret{
-				{Name: "CLAUDE_AUTH", Type: "file", Target: "/home/agent/.claude/.credentials.json"},
-			},
-			check: func(t *testing.T, auth api.AuthConfig) {
-				if auth.ClaudeAuthFile != "/home/agent/.claude/.credentials.json" {
-					t.Errorf("ClaudeAuthFile = %q, want credentials path", auth.ClaudeAuthFile)
+				if auth.Files == nil || auth.Files["OpenCodeAuthFile"] != "/home/gemini/.local/share/opencode/auth.json" {
+					t.Errorf("Files[OpenCodeAuthFile] = %q, want opencode path", auth.Files["OpenCodeAuthFile"])
 				}
 			},
 		},
@@ -983,8 +731,8 @@ func TestOverlayFileSecrets(t *testing.T) {
 				{Name: "my-claude-creds", Type: "file", Target: "/home/agent/.claude/.credentials.json"},
 			},
 			check: func(t *testing.T, auth api.AuthConfig) {
-				if auth.ClaudeAuthFile == "" {
-					t.Error("ClaudeAuthFile should be set from target suffix match")
+				if auth.Files == nil || auth.Files["ClaudeAuthFile"] == "" {
+					t.Error("Files[ClaudeAuthFile] should be set from target suffix match")
 				}
 			},
 		},
@@ -1004,13 +752,13 @@ func TestOverlayFileSecrets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			auth := api.AuthConfig{}
-			OverlayFileSecrets(&auth, tt.secrets)
+			OverlayFileSecrets(&auth, tt.secrets, nil)
 			tt.check(t, auth)
 		})
 	}
 }
 
-func TestOverlayFileSecretsFromConfig(t *testing.T) {
+func TestOverlayFileSecrets_WithAuthMeta(t *testing.T) {
 	claudeAuthMeta := &config.HarnessAuthMetadata{
 		DefaultType: "api-key",
 		Types: map[string]config.HarnessAuthTypeMetadata{
@@ -1040,8 +788,20 @@ func TestOverlayFileSecretsFromConfig(t *testing.T) {
 				{Name: "CLAUDE_AUTH", Type: "file", Target: "/home/agent/.claude/.credentials.json"},
 			},
 			check: func(t *testing.T, auth api.AuthConfig) {
-				if auth.ClaudeAuthFile != "/home/agent/.claude/.credentials.json" {
-					t.Errorf("ClaudeAuthFile = %q, want credentials path", auth.ClaudeAuthFile)
+				if auth.Files == nil || auth.Files["ClaudeAuthFile"] != "/home/agent/.claude/.credentials.json" {
+					t.Errorf("Files[ClaudeAuthFile] = %q, want credentials path", auth.Files["ClaudeAuthFile"])
+				}
+			},
+		},
+		{
+			name: "config-driven field mapping for gcloud-adc (first-class field)",
+			meta: claudeAuthMeta,
+			secrets: []api.ResolvedSecret{
+				{Name: "gcloud-adc", Type: "file", Target: "/home/agent/.config/gcloud/application_default_credentials.json"},
+			},
+			check: func(t *testing.T, auth api.AuthConfig) {
+				if auth.GoogleAppCredentials != "/home/agent/.config/gcloud/application_default_credentials.json" {
+					t.Errorf("GoogleAppCredentials = %q, want ADC path", auth.GoogleAppCredentials)
 				}
 			},
 		},
@@ -1052,24 +812,8 @@ func TestOverlayFileSecretsFromConfig(t *testing.T) {
 				{Name: "my-custom-claude-creds", Type: "file", Target: "/home/agent/.claude/.credentials.json"},
 			},
 			check: func(t *testing.T, auth api.AuthConfig) {
-				if auth.ClaudeAuthFile != "/home/agent/.claude/.credentials.json" {
-					t.Errorf("ClaudeAuthFile = %q, want credentials path from suffix fallback", auth.ClaudeAuthFile)
-				}
-			},
-		},
-		{
-			name: "config-driven matches hardcoded behavior",
-			meta: claudeAuthMeta,
-			secrets: []api.ResolvedSecret{
-				{Name: "CLAUDE_AUTH", Type: "file", Target: "/home/agent/.claude/.credentials.json"},
-			},
-			check: func(t *testing.T, auth api.AuthConfig) {
-				hardcoded := api.AuthConfig{}
-				OverlayFileSecrets(&hardcoded, []api.ResolvedSecret{
-					{Name: "CLAUDE_AUTH", Type: "file", Target: "/home/agent/.claude/.credentials.json"},
-				})
-				if auth.ClaudeAuthFile != hardcoded.ClaudeAuthFile {
-					t.Errorf("config-driven ClaudeAuthFile = %q, hardcoded = %q", auth.ClaudeAuthFile, hardcoded.ClaudeAuthFile)
+				if auth.Files == nil || auth.Files["ClaudeAuthFile"] != "/home/agent/.claude/.credentials.json" {
+					t.Errorf("Files[ClaudeAuthFile] = %q, want credentials path from suffix fallback", auth.Files["ClaudeAuthFile"])
 				}
 			},
 		},
@@ -1080,8 +824,8 @@ func TestOverlayFileSecretsFromConfig(t *testing.T) {
 				{Name: "CLAUDE_AUTH", Type: "environment", Target: "CLAUDE_AUTH", Value: "some-value"},
 			},
 			check: func(t *testing.T, auth api.AuthConfig) {
-				if auth.ClaudeAuthFile != "" {
-					t.Errorf("ClaudeAuthFile = %q, want empty (env-type should be skipped)", auth.ClaudeAuthFile)
+				if auth.Files != nil && auth.Files["ClaudeAuthFile"] != "" {
+					t.Errorf("Files[ClaudeAuthFile] = %q, want empty (env-type should be skipped)", auth.Files["ClaudeAuthFile"])
 				}
 			},
 		},
@@ -1092,8 +836,8 @@ func TestOverlayFileSecretsFromConfig(t *testing.T) {
 				{Name: "CLAUDE_AUTH", Type: "file", Target: "/home/agent/.claude/.credentials.json"},
 			},
 			check: func(t *testing.T, auth api.AuthConfig) {
-				if auth.ClaudeAuthFile != "/home/agent/.claude/.credentials.json" {
-					t.Errorf("ClaudeAuthFile = %q, want credentials path from suffix fallback", auth.ClaudeAuthFile)
+				if auth.Files == nil || auth.Files["ClaudeAuthFile"] != "/home/agent/.claude/.credentials.json" {
+					t.Errorf("Files[ClaudeAuthFile] = %q, want credentials path from suffix fallback", auth.Files["ClaudeAuthFile"])
 				}
 			},
 		},
@@ -1102,7 +846,7 @@ func TestOverlayFileSecretsFromConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			auth := api.AuthConfig{}
-			OverlayFileSecretsFromConfig(&auth, tt.secrets, tt.meta)
+			OverlayFileSecrets(&auth, tt.secrets, tt.meta)
 			tt.check(t, auth)
 		})
 	}

--- a/pkg/harness/claude_provision_test.go
+++ b/pkg/harness/claude_provision_test.go
@@ -852,8 +852,8 @@ func TestClaudeContainerScriptResolveAuthShape(t *testing.T) {
 	// Pass both an Anthropic key and an auth file; the container-script
 	// wrapper must surface BOTH so the in-container script can choose.
 	resolved, err := scripted.ResolveAuth(api.AuthConfig{
-		AnthropicAPIKey: "sk-ant-xx",
-		ClaudeAuthFile:  "/tmp/credentials.json",
+		EnvVars: map[string]string{"ANTHROPIC_API_KEY": "sk-ant-xx"},
+		Files:   map[string]string{"ClaudeAuthFile": "/tmp/credentials.json"},
 	})
 	if err != nil {
 		t.Fatalf("ResolveAuth: %v", err)

--- a/pkg/harness/container_script_harness.go
+++ b/pkg/harness/container_script_harness.go
@@ -290,20 +290,30 @@ func (c *ContainerScriptHarness) ResolveAuth(auth api.AuthConfig) (*api.Resolved
 	// Forward config-driven file credentials. The Files map uses field names
 	// as keys (e.g. "ClaudeAuthFile") and host paths as values. We map the
 	// field names to their container target paths using the harness config's
-	// required_files entries.
+	// required_files entries. A seen set keyed by Field prevents duplicate
+	// mappings when the same field appears in multiple auth types.
 	if c.entry.Auth != nil {
+		seenFields := make(map[string]struct{})
 		for _, authType := range c.entry.Auth.Types {
 			for _, rf := range authType.RequiredFiles {
 				if rf.Field == "" || rf.TargetSuffix == "" {
 					continue
 				}
+				if _, dup := seenFields[rf.Field]; dup {
+					continue
+				}
+				seenFields[rf.Field] = struct{}{}
 				hostPath := auth.Files[rf.Field]
 				if hostPath == "" {
 					continue
 				}
-				// TargetSuffix starts with "/" — prepend "~" to make it relative
-				// to home (e.g. "/.claude/.credentials.json" → "~/.claude/.credentials.json")
-				containerPath := "~" + rf.TargetSuffix
+				// Normalize TargetSuffix to ensure it starts with "/" before
+				// prepending "~" (e.g. ".claude/foo" → "~/.claude/foo").
+				suffix := rf.TargetSuffix
+				if !strings.HasPrefix(suffix, "/") {
+					suffix = "/" + suffix
+				}
+				containerPath := "~" + suffix
 				resolved.Files = append(resolved.Files, api.FileMapping{
 					SourcePath:    hostPath,
 					ContainerPath: containerPath,

--- a/pkg/harness/container_script_harness.go
+++ b/pkg/harness/container_script_harness.go
@@ -263,63 +263,53 @@ func (c *ContainerScriptHarness) ResolveAuth(auth api.AuthConfig) (*api.Resolved
 		resolved.EnvVars["SCION_HARNESS_SELECTED_AUTH"] = auth.SelectedType
 	}
 
-	// Forward any explicit auth env vars to the container. The script may
-	// move them into final harness-native files. Harness-config metadata
-	// could also drive this declaratively, but keeping it permissive at the
-	// staging layer matches the design's "stage all candidates" guidance.
-	addIfPresent := func(key, val string) {
-		if val != "" {
-			resolved.EnvVars[key] = val
-		}
+	// Forward GCP shared fields that have multi-source fallback resolution.
+	if auth.GoogleCloudProject != "" {
+		resolved.EnvVars["GOOGLE_CLOUD_PROJECT"] = auth.GoogleCloudProject
 	}
-	addIfPresent("ANTHROPIC_API_KEY", auth.AnthropicAPIKey)
-	addIfPresent("CLAUDE_CODE_OAUTH_TOKEN", auth.ClaudeOAuthToken)
-	addIfPresent("OPENAI_API_KEY", auth.OpenAIAPIKey)
-	addIfPresent("GEMINI_API_KEY", auth.GeminiAPIKey)
-	addIfPresent("GOOGLE_API_KEY", auth.GoogleAPIKey)
-	addIfPresent("GOOGLE_CLOUD_PROJECT", auth.GoogleCloudProject)
-	addIfPresent("GOOGLE_CLOUD_REGION", auth.GoogleCloudRegion)
-	addIfPresent("CODEX_API_KEY", auth.CodexAPIKey)
+	if auth.GoogleCloudRegion != "" {
+		resolved.EnvVars["GOOGLE_CLOUD_REGION"] = auth.GoogleCloudRegion
+	}
 
-	// Forward config-driven auth env vars. These come from harness config
-	// metadata (auth.types[*].required_env) and are gathered by
-	// GatherAuthWithEnv. They are additive — hardcoded fields above take
-	// precedence if the same key appears in both.
+	// Forward all config-driven auth env vars gathered from harness config
+	// metadata (auth.types[*].required_env).
 	for k, v := range auth.EnvVars {
 		if _, exists := resolved.EnvVars[k]; !exists {
 			resolved.EnvVars[k] = v
 		}
 	}
 
+	// GCP ADC file (first-class GCP shared field)
 	if auth.GoogleAppCredentials != "" {
 		resolved.Files = append(resolved.Files, api.FileMapping{
 			SourcePath:    auth.GoogleAppCredentials,
 			ContainerPath: "~/.config/gcloud/application_default_credentials.json",
 		})
 	}
-	if auth.ClaudeAuthFile != "" {
-		resolved.Files = append(resolved.Files, api.FileMapping{
-			SourcePath:    auth.ClaudeAuthFile,
-			ContainerPath: "~/.claude/.credentials.json",
-		})
-	}
-	if auth.CodexAuthFile != "" {
-		resolved.Files = append(resolved.Files, api.FileMapping{
-			SourcePath:    auth.CodexAuthFile,
-			ContainerPath: "~/.codex/auth.json",
-		})
-	}
-	if auth.OpenCodeAuthFile != "" {
-		resolved.Files = append(resolved.Files, api.FileMapping{
-			SourcePath:    auth.OpenCodeAuthFile,
-			ContainerPath: "~/.local/share/opencode/auth.json",
-		})
-	}
-	if auth.OAuthCreds != "" {
-		resolved.Files = append(resolved.Files, api.FileMapping{
-			SourcePath:    auth.OAuthCreds,
-			ContainerPath: "~/.scion/oauth_creds.json",
-		})
+
+	// Forward config-driven file credentials. The Files map uses field names
+	// as keys (e.g. "ClaudeAuthFile") and host paths as values. We map the
+	// field names to their container target paths using the harness config's
+	// required_files entries.
+	if c.entry.Auth != nil {
+		for _, authType := range c.entry.Auth.Types {
+			for _, rf := range authType.RequiredFiles {
+				if rf.Field == "" || rf.TargetSuffix == "" {
+					continue
+				}
+				hostPath := auth.Files[rf.Field]
+				if hostPath == "" {
+					continue
+				}
+				// TargetSuffix starts with "/" — prepend "~" to make it relative
+				// to home (e.g. "/.claude/.credentials.json" → "~/.claude/.credentials.json")
+				containerPath := "~" + rf.TargetSuffix
+				resolved.Files = append(resolved.Files, api.FileMapping{
+					SourcePath:    hostPath,
+					ContainerPath: containerPath,
+				})
+			}
+		}
 	}
 
 	// For the Claude harness with vertex-ai auth, translate GCP env vars into

--- a/pkg/harness/container_script_harness_test.go
+++ b/pkg/harness/container_script_harness_test.go
@@ -246,8 +246,7 @@ func TestContainerScriptHarness_StagesBundle(t *testing.T) {
 func TestContainerScriptHarness_ResolveAuth_StagesCandidateEnv(t *testing.T) {
 	h, _ := newTestContainerScriptHarness(t)
 	resolved, err := h.ResolveAuth(api.AuthConfig{
-		AnthropicAPIKey: "sk-ant-xxx",
-		ClaudeAuthFile:  "/tmp/.credentials.json",
+		EnvVars: map[string]string{"ANTHROPIC_API_KEY": "sk-ant-xxx"},
 	})
 	if err != nil {
 		t.Fatalf("ResolveAuth: %v", err)
@@ -257,9 +256,6 @@ func TestContainerScriptHarness_ResolveAuth_StagesCandidateEnv(t *testing.T) {
 	}
 	if resolved.EnvVars["ANTHROPIC_API_KEY"] != "sk-ant-xxx" {
 		t.Errorf("missing ANTHROPIC_API_KEY in env")
-	}
-	if len(resolved.Files) != 1 || !strings.Contains(resolved.Files[0].ContainerPath, ".claude/.credentials.json") {
-		t.Errorf("unexpected file mappings: %+v", resolved.Files)
 	}
 }
 
@@ -585,8 +581,8 @@ func TestContainerScriptHarness_ResolveAuth_NoVertexTranslationForAPIKey(t *test
 	h := newClaudeHarness(t)
 
 	resolved, err := h.ResolveAuth(api.AuthConfig{
-		SelectedType:    "api-key",
-		AnthropicAPIKey: "sk-ant-test",
+		SelectedType: "api-key",
+		EnvVars:      map[string]string{"ANTHROPIC_API_KEY": "sk-ant-test"},
 	})
 	if err != nil {
 		t.Fatalf("ResolveAuth: %v", err)

--- a/pkg/harness/generic.go
+++ b/pkg/harness/generic.go
@@ -113,21 +113,7 @@ func (g *Generic) ResolveAuth(auth api.AuthConfig) (*api.ResolvedAuth, error) {
 		EnvVars: make(map[string]string),
 	}
 
-	if auth.AnthropicAPIKey != "" {
-		result.EnvVars["ANTHROPIC_API_KEY"] = auth.AnthropicAPIKey
-	}
-	if auth.GeminiAPIKey != "" {
-		result.EnvVars["GEMINI_API_KEY"] = auth.GeminiAPIKey
-	}
-	if auth.GoogleAPIKey != "" {
-		result.EnvVars["GOOGLE_API_KEY"] = auth.GoogleAPIKey
-	}
-	if auth.OpenAIAPIKey != "" {
-		result.EnvVars["OPENAI_API_KEY"] = auth.OpenAIAPIKey
-	}
-	if auth.CodexAPIKey != "" {
-		result.EnvVars["CODEX_API_KEY"] = auth.CodexAPIKey
-	}
+	// GCP shared fields
 	if auth.GoogleCloudProject != "" {
 		result.EnvVars["GOOGLE_CLOUD_PROJECT"] = auth.GoogleCloudProject
 	}
@@ -135,35 +121,18 @@ func (g *Generic) ResolveAuth(auth api.AuthConfig) (*api.ResolvedAuth, error) {
 		result.EnvVars["GOOGLE_CLOUD_REGION"] = auth.GoogleCloudRegion
 	}
 
+	// Forward all config-driven auth env vars
 	for k, v := range auth.EnvVars {
 		if _, exists := result.EnvVars[k]; !exists {
 			result.EnvVars[k] = v
 		}
 	}
 
+	// GCP ADC file
 	if auth.GoogleAppCredentials != "" {
-		adcContainerPath := "~/.config/gcloud/application_default_credentials.json"
 		result.Files = append(result.Files, api.FileMapping{
 			SourcePath:    auth.GoogleAppCredentials,
-			ContainerPath: adcContainerPath,
-		})
-	}
-	if auth.OAuthCreds != "" {
-		result.Files = append(result.Files, api.FileMapping{
-			SourcePath:    auth.OAuthCreds,
-			ContainerPath: "~/.scion/oauth_creds.json",
-		})
-	}
-	if auth.CodexAuthFile != "" {
-		result.Files = append(result.Files, api.FileMapping{
-			SourcePath:    auth.CodexAuthFile,
-			ContainerPath: "~/.codex/auth.json",
-		})
-	}
-	if auth.OpenCodeAuthFile != "" {
-		result.Files = append(result.Files, api.FileMapping{
-			SourcePath:    auth.OpenCodeAuthFile,
-			ContainerPath: "~/.local/share/opencode/auth.json",
+			ContainerPath: "~/.config/gcloud/application_default_credentials.json",
 		})
 	}
 

--- a/pkg/harness/generic_test.go
+++ b/pkg/harness/generic_test.go
@@ -106,17 +106,16 @@ func TestGenericResolveAuth_EmptyConfig(t *testing.T) {
 func TestGenericResolveAuth_AllCreds(t *testing.T) {
 	g := &Generic{}
 	auth := api.AuthConfig{
-		AnthropicAPIKey:      "anthropic",
-		GeminiAPIKey:         "gemini",
-		GoogleAPIKey:         "google",
-		OpenAIAPIKey:         "openai",
-		CodexAPIKey:          "codex",
 		GoogleCloudProject:   "proj",
 		GoogleCloudRegion:    "region",
 		GoogleAppCredentials: "/adc.json",
-		OAuthCreds:           "/oauth.json",
-		CodexAuthFile:        "/codex-auth.json",
-		OpenCodeAuthFile:     "/opencode-auth.json",
+		EnvVars: map[string]string{
+			"ANTHROPIC_API_KEY": "anthropic",
+			"GEMINI_API_KEY":    "gemini",
+			"GOOGLE_API_KEY":    "google",
+			"OPENAI_API_KEY":    "openai",
+			"CODEX_API_KEY":     "codex",
+		},
 	}
 	result, err := g.ResolveAuth(auth)
 	if err != nil {
@@ -138,15 +137,17 @@ func TestGenericResolveAuth_AllCreds(t *testing.T) {
 		}
 	}
 
-	// Should have 4 file mappings: ADC, OAuth, Codex, OpenCode
-	if len(result.Files) != 4 {
-		t.Fatalf("expected 4 file mappings, got %d", len(result.Files))
+	// Should have 1 file mapping: ADC
+	if len(result.Files) != 1 {
+		t.Fatalf("expected 1 file mapping (ADC), got %d", len(result.Files))
 	}
 }
 
 func TestGenericResolveAuth_PartialCreds(t *testing.T) {
 	g := &Generic{}
-	auth := api.AuthConfig{AnthropicAPIKey: "key-only"}
+	auth := api.AuthConfig{
+		EnvVars: map[string]string{"ANTHROPIC_API_KEY": "key-only"},
+	}
 	result, err := g.ResolveAuth(auth)
 	if err != nil {
 		t.Fatalf("generic should never error: %v", err)

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -1111,12 +1111,7 @@ func (s *Server) hasRequiredAuthCredentials(ctx context.Context, agent *store.Ag
 	}
 
 	// Explicit auth type selected or no authMeta — use config-driven check when available.
-	var keyGroups [][]string
-	if authMeta != nil {
-		keyGroups = harness.RequiredAuthEnvKeysFromConfig(authMeta, agent.AppliedConfig.HarnessAuth)
-	} else {
-		keyGroups = harness.RequiredAuthEnvKeys(harnessType, agent.AppliedConfig.HarnessAuth)
-	}
+	keyGroups := harness.RequiredAuthEnvKeysFromConfig(authMeta, agent.AppliedConfig.HarnessAuth)
 	if len(keyGroups) == 0 && authMeta == nil {
 		return true, nil
 	}

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -1962,8 +1962,8 @@ func (s *Server) checkAgentPrompt(w http.ResponseWriter, r *http.Request, id, pr
 // harness, auth type, and settings profile. It uses a multi-phase approach:
 //
 // Phase 1 (auth-aware): Resolves the harness type and auth_selected_type from
-// on-disk harness-config and settings, then calls RequiredAuthEnvKeys() to get
-// intrinsic credential requirements for the (harness, authType) pair.
+// on-disk harness-config and settings, then calls RequiredAuthEnvKeysFromConfig()
+// to get intrinsic credential requirements for the (harness, authType) pair.
 //
 // Phase 2 (settings-based): Extracts keys with empty values from settings
 // harness_configs[*].env and profiles[*].env, allowing users to declare custom
@@ -2117,10 +2117,8 @@ func (s *Server) extractRequiredEnvKeys(req CreateAgentRequest, hydratedHarnessC
 		// defaulting to api-key. This mirrors the auto-detect priority in each
 		// harness's ResolveAuth.
 		//
-		// Phase 3: when the harness-config carries declarative auth metadata
-		// (authMeta != nil), the *FromConfig variants drive detection. Older
-		// configs without the `auth:` block still hit the compiled fallbacks.
-		useConfigDriven := harness.AuthMetadataAvailable(&config.HarnessConfigEntry{Auth: authMeta})
+		// All auth preflight uses the config-driven path. The *FromConfig
+		// functions are safe to call with nil authMeta (they return zero values).
 		if authType == "" {
 			fileSecretNames := make(map[string]struct{})
 			for _, sec := range req.ResolvedSecrets {
@@ -2128,13 +2126,7 @@ func (s *Server) extractRequiredEnvKeys(req CreateAgentRequest, hydratedHarnessC
 					fileSecretNames[sec.Name] = struct{}{}
 				}
 			}
-			var detected string
-			if useConfigDriven {
-				detected = harness.DetectAuthTypeFromFileSecretsFromConfig(authMeta, fileSecretNames)
-			} else {
-				detected = harness.DetectAuthTypeFromFileSecrets(harnessType, fileSecretNames)
-			}
-			if detected != "" {
+			if detected := harness.DetectAuthTypeFromFileSecretsFromConfig(authMeta, fileSecretNames); detected != "" {
 				authType = detected
 			}
 		}
@@ -2156,35 +2148,18 @@ func (s *Server) extractRequiredEnvKeys(req CreateAgentRequest, hydratedHarnessC
 					}
 				}
 			}
-			var detected string
-			if useConfigDriven {
-				detected = harness.DetectAuthTypeFromEnvVarsFromConfig(authMeta, resolvedEnvKeys)
-			} else {
-				detected = harness.DetectAuthTypeFromEnvVars(harnessType, resolvedEnvKeys)
-			}
-			if detected != "" {
+			if detected := harness.DetectAuthTypeFromEnvVarsFromConfig(authMeta, resolvedEnvKeys); detected != "" {
 				authType = detected
 			}
 		}
 		if authType == "" {
-			var detected string
-			if useConfigDriven {
-				detected = harness.DetectAuthTypeFromGCPIdentityFromConfig(authMeta, gcpSAAssigned)
-			} else {
-				detected = harness.DetectAuthTypeFromGCPIdentity(harnessType, gcpSAAssigned)
-			}
-			if detected != "" {
+			if detected := harness.DetectAuthTypeFromGCPIdentityFromConfig(authMeta, gcpSAAssigned); detected != "" {
 				authType = detected
 			}
 		}
 
 		// Resolve auth key groups and check satisfaction
-		var keyGroups [][]string
-		if useConfigDriven {
-			keyGroups = harness.RequiredAuthEnvKeysFromConfig(authMeta, authType)
-		} else {
-			keyGroups = harness.RequiredAuthEnvKeys(harnessType, authType)
-		}
+		keyGroups := harness.RequiredAuthEnvKeysFromConfig(authMeta, authType)
 		if len(keyGroups) > 0 {
 			// Build lookup of already-satisfied keys
 			envKeys := make(map[string]struct{})
@@ -2225,12 +2200,7 @@ func (s *Server) extractRequiredEnvKeys(req CreateAgentRequest, hydratedHarnessC
 		// Phase 1b: Auth-required file secrets (e.g. ADC for vertex-ai).
 		// When a GCP service account is assigned, the metadata server provides
 		// credentials, so the ADC file is not required.
-		var authSecrets []api.RequiredSecret
-		if useConfigDriven {
-			authSecrets = harness.RequiredAuthSecretsFromConfig(authMeta, authType, gcpSAAssigned)
-		} else {
-			authSecrets = harness.RequiredAuthSecrets(harnessType, authType, gcpSAAssigned)
-		}
+		authSecrets := harness.RequiredAuthSecretsFromConfig(authMeta, authType, gcpSAAssigned)
 		if len(authSecrets) > 0 {
 			// Build lookup of file-type resolved secrets by Name and Target suffix
 			fileSecrets := make(map[string]struct{})

--- a/pkg/runtimebroker/handlers_dispatch_test.go
+++ b/pkg/runtimebroker/handlers_dispatch_test.go
@@ -291,15 +291,20 @@ auth:
 	}
 }
 
-// TestExtractRequiredEnvKeys_CompiledFallback verifies the compiled table
-// still drives preflight when the harness-config has no `auth:` block. This
-// is the legacy path required during migration so older configs do not
-// suddenly stop reporting missing credentials.
+// TestExtractRequiredEnvKeys_CompiledFallback verifies that a harness-config
+// with a declarative auth block correctly reports required env keys (e.g.
+// ANTHROPIC_API_KEY for api-key auth type) via the config-driven path.
 func TestExtractRequiredEnvKeys_CompiledFallback(t *testing.T) {
 	srv, _, dotScion := dispatchTestEnv(t, false)
 
 	writeHarnessConfig(t, dotScion, "claude-legacy", `harness: claude
 image: scion-claude:test
+auth:
+  default_type: api-key
+  types:
+    api-key:
+      required_env:
+        - any_of: ["ANTHROPIC_API_KEY"]
 `)
 
 	req := CreateAgentRequest{

--- a/pkg/runtimebroker/handlers_envgather_test.go
+++ b/pkg/runtimebroker/handlers_envgather_test.go
@@ -27,6 +27,73 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
 )
 
+// claudeAuthBlock is the declarative auth metadata for the claude harness,
+// matching the production harnesses/claude/config.yaml. Tests that need
+// config-driven auth preflight include this block in their harness-config fixture.
+const claudeAuthBlock = `auth:
+  default_type: api-key
+  types:
+    api-key:
+      required_env:
+        - any_of: ["ANTHROPIC_API_KEY"]
+    vertex-ai:
+      required_env:
+        - any_of: ["GOOGLE_CLOUD_PROJECT"]
+        - any_of: ["GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"]
+      required_files:
+        - name: gcloud-adc
+          type: file
+          description: "Google Cloud Application Default Credentials (ADC) file for vertex-ai authentication"
+          field: GoogleAppCredentials
+          alternative_env_keys: ["GOOGLE_APPLICATION_CREDENTIALS"]
+          skipped_when_gcp_service_account_assigned: true
+          required: true
+  autodetect:
+    env:
+      GOOGLE_APPLICATION_CREDENTIALS: vertex-ai
+      GOOGLE_CLOUD_PROJECT: vertex-ai
+      ANTHROPIC_API_KEY: api-key
+    files:
+      gcloud-adc: vertex-ai
+`
+
+// geminiAuthBlock is the declarative auth metadata for the gemini harness,
+// matching the production harnesses/gemini-cli/config.yaml.
+const geminiAuthBlock = `auth:
+  default_type: api-key
+  types:
+    api-key:
+      required_env:
+        - any_of: ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
+    auth-file:
+      required_files:
+        - name: GEMINI_OAUTH_CREDS
+          type: file
+          target_suffix: "/.gemini/oauth_creds.json"
+          field: OAuthCreds
+    vertex-ai:
+      required_env:
+        - any_of: ["GOOGLE_CLOUD_PROJECT"]
+        - any_of: ["GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"]
+      required_files:
+        - name: gcloud-adc
+          type: file
+          description: "Google Cloud Application Default Credentials (ADC) file for vertex-ai authentication"
+          field: GoogleAppCredentials
+          alternative_env_keys: ["GOOGLE_APPLICATION_CREDENTIALS"]
+          skipped_when_gcp_service_account_assigned: true
+          required: true
+  autodetect:
+    env:
+      GEMINI_API_KEY: api-key
+      GOOGLE_API_KEY: api-key
+      GOOGLE_APPLICATION_CREDENTIALS: vertex-ai
+      GOOGLE_CLOUD_PROJECT: vertex-ai
+    files:
+      GEMINI_OAUTH_CREDS: auth-file
+      gcloud-adc: vertex-ai
+`
+
 // newTestServerWithProjectPath creates a test server with a temporary project path
 // that has versioned settings with declared env vars.
 func newTestServerWithProjectPath(t *testing.T, settingsYAML string) (*Server, *envCapturingManager, string) {
@@ -1299,7 +1366,7 @@ profiles:
 // and SecretInfo showing type=file.
 func TestEnvGather_VertexAI_RequiresADCFile(t *testing.T) {
 	srv, _, projectDir := newTestServerWithHarnessConfig(t, "claude",
-		"harness: claude\nimage: test-image\nuser: scion\nauth_selected_type: vertex-ai\n",
+		"harness: claude\nimage: test-image\nuser: scion\nauth_selected_type: vertex-ai\n"+claudeAuthBlock,
 		`
 schema_version: "1"
 harness_configs:
@@ -1425,7 +1492,7 @@ profiles:
 func TestEnvGather_AutoDetectVertexAI_FromGACEnvVar(t *testing.T) {
 	// No auth_selected_type set — auto-detect should kick in
 	srv, _, projectDir := newTestServerWithHarnessConfig(t, "claude",
-		"harness: claude\nimage: test-image\nuser: scion\n",
+		"harness: claude\nimage: test-image\nuser: scion\n"+claudeAuthBlock,
 		`
 schema_version: "1"
 harness_configs:
@@ -1588,7 +1655,7 @@ profiles:
 // non-admin users who only have GCP credentials.
 func TestEnvGather_AutoDetectVertexAI_FromGCPProject(t *testing.T) {
 	srv, _, projectDir := newTestServerWithHarnessConfig(t, "claude",
-		"harness: claude\nimage: test-image\nuser: scion\n",
+		"harness: claude\nimage: test-image\nuser: scion\n"+claudeAuthBlock,
 		`
 schema_version: "1"
 harness_configs:
@@ -1739,7 +1806,7 @@ func TestEnvGather_HarnessAuthOverride(t *testing.T) {
 	// Provide an OAuth file secret so auto-detect would normally pick auth-file.
 	// But --harness-auth api-key should override to api-key, requiring GEMINI_API_KEY.
 	srv, _, projectDir := newTestServerWithHarnessConfig(t, "gemini",
-		"harness: gemini\nimage: test-image\nuser: scion\n",
+		"harness: gemini\nimage: test-image\nuser: scion\n"+geminiAuthBlock,
 		`
 schema_version: "1"
 profiles:
@@ -1820,7 +1887,7 @@ profiles:
 	if err := os.MkdirAll(hcDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(hcDir, "config.yaml"), []byte("harness: gemini\nimage: test-image\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(hcDir, "config.yaml"), []byte("harness: gemini\nimage: test-image\n"+geminiAuthBlock), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1918,7 +1985,7 @@ profiles:
 
 func TestEnvGather_HarnessAuthOverrideVertexAI(t *testing.T) {
 	srv, _, projectDir := newTestServerWithHarnessConfig(t, "gemini",
-		"harness: gemini\nimage: test-image\nuser: scion\n",
+		"harness: gemini\nimage: test-image\nuser: scion\n"+geminiAuthBlock,
 		`
 schema_version: "1"
 profiles:


### PR DESCRIPTION
Complete phases 3-4 of the auth pipeline decoupling effort. The config-driven auth infrastructure (FromConfig variants) was built in phases 1-2 and already used by newer harnesses (copilot, antigravity, hermes, opencode). This PR makes it the only path and removes the compiled fallbacks.

Phase 3: Parity tests proving config-driven functions produce identical results to compiled functions for all built-in harnesses (claude, codex, gemini-cli) across all auth types.

Phase 4: Remove per-provider hardcoded auth fields and switch-case tables:
- AuthConfig per-provider fields removed (AnthropicAPIKey, GeminiAPIKey, CodexAPIKey, etc.)
- GatherAuthWithEnv hardcoded lookup() calls removed
- RequiredAuthEnvKeys compiled switch-case removed
- DetectAuthType compiled functions removed
- ResolveAuth per-provider addIfPresent calls replaced with generic EnvVars/Files loop
- isAuthEnvKey hardcoded allowlist removed

Net: -312 lines across 15 files. GCP shared fields, vertex-ai credential translation, and backward-compatible suffix matching all preserved.

Ref: ptone/scion#311