### PR TITLE
feat(discord): container-to-host path translation in /scion send

### DIFF
--- a/extras/scion-discord/internal/discord/send.go
+++ b/extras/scion-discord/internal/discord/send.go
@@ -276,7 +276,10 @@ func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.Interacti
 	// store round-trip and a consistency hazard if the link changes between calls.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	link, _ := resolveChannelLink(ctx, s, h.store, i.ChannelID)
+	link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
+	if err != nil {
+		h.log.Error("Failed to resolve channel link", "channel_id", i.ChannelID, "error", err)
+	}
 	if link != nil && link.Active {
 		pathArg = translateContainerPath(pathArg, link.ProjectSlug, link.ProjectID)
 	}
@@ -345,7 +348,7 @@ func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.Interacti
 		}
 	}
 
-	_, err := s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+	_, err = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
 		Content:    fmt.Sprintf("Found %d file(s) matching '%s'. Select one to send:", len(matches), pathArg),
 		Components: rows,
 	})

--- a/extras/scion-discord/internal/discord/send.go
+++ b/extras/scion-discord/internal/discord/send.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/bwmarrin/discordgo"
 )
 
@@ -202,6 +203,57 @@ func projectSearchRoots(slug, projectID string) []string {
 	return roots
 }
 
+// containerPathPrefixes lists the path prefixes used inside agent containers
+// for shared directories. Both the root-level mount and the in-workspace
+// variant are supported.
+var containerPathPrefixes = []string{
+	"/scion-volumes/",
+	"/workspace/.scion-volumes/",
+}
+
+// translateContainerPath converts a container-internal path to its host-side
+// equivalent. If the path doesn't start with /scion-volumes/ or
+// /workspace/.scion-volumes/, it is returned unchanged.
+func translateContainerPath(path, projectSlug, projectID string) string {
+	for _, prefix := range containerPathPrefixes {
+		if !strings.HasPrefix(path, prefix) {
+			// Also match the prefix without trailing slash (bare shared dir name).
+			bare := strings.TrimSuffix(prefix, "/")
+			if path == bare {
+				// e.g. "/scion-volumes" with no shared dir name — can't translate.
+				return path
+			}
+			continue
+		}
+
+		// Strip the prefix to get "<sharedDirName>/remainder" or just "<sharedDirName>".
+		after := strings.TrimPrefix(path, prefix)
+		if after == "" {
+			// Path is exactly the prefix (e.g. "/scion-volumes/") — no shared
+			// dir name, so we can't translate.
+			return path
+		}
+
+		// Split into shared dir name and optional remainder.
+		var sharedDirName, remainder string
+		if idx := strings.IndexByte(after, '/'); idx >= 0 {
+			sharedDirName = after[:idx]
+			remainder = after[idx+1:]
+		} else {
+			sharedDirName = after
+		}
+
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+
+		hostSharedDir := config.SharedDirHostPath(home, projectSlug, projectID, sharedDirName)
+		return filepath.Join(hostSharedDir, remainder)
+	}
+	return path
+}
+
 // HandleSend handles the /scion send <path> command.
 // It resolves the channel's project binding to determine per-project search
 // roots. If the channel is not linked and no send_search_root override is
@@ -214,6 +266,15 @@ func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.Interacti
 	if pathArg == "" {
 		h.followup(s, i, "Please provide a file path or search term.")
 		return
+	}
+
+	// Resolve the channel link for project context. If available, translate
+	// container-internal paths (/scion-volumes/...) to host-side equivalents
+	// before file resolution.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID); err == nil && link != nil && link.Active {
+		pathArg = translateContainerPath(pathArg, link.ProjectSlug, link.ProjectID)
 	}
 
 	// Resolve search roots: per-project roots from channel link, with

--- a/extras/scion-discord/internal/discord/send.go
+++ b/extras/scion-discord/internal/discord/send.go
@@ -214,7 +214,15 @@ var containerPathPrefixes = []string{
 // translateContainerPath converts a container-internal path to its host-side
 // equivalent. If the path doesn't start with /scion-volumes/ or
 // /workspace/.scion-volumes/, it is returned unchanged.
+//
+// The returned path is NOT validated for confinement; callers MUST pass it
+// through safeResolve or safeResolveMulti before use.
 func translateContainerPath(path, projectSlug, projectID string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+
 	for _, prefix := range containerPathPrefixes {
 		if !strings.HasPrefix(path, prefix) {
 			// Also match the prefix without trailing slash (bare shared dir name).
@@ -243,11 +251,6 @@ func translateContainerPath(path, projectSlug, projectID string) string {
 			sharedDirName = after
 		}
 
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return path
-		}
-
 		hostSharedDir := config.SharedDirHostPath(home, projectSlug, projectID, sharedDirName)
 		return filepath.Join(hostSharedDir, remainder)
 	}
@@ -268,18 +271,19 @@ func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.Interacti
 		return
 	}
 
-	// Resolve the channel link for project context. If available, translate
-	// container-internal paths (/scion-volumes/...) to host-side equivalents
-	// before file resolution.
+	// Resolve the channel link once for project context. The result is shared
+	// by both path translation and search-root resolution to avoid a duplicate
+	// store round-trip and a consistency hazard if the link changes between calls.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID); err == nil && link != nil && link.Active {
+	link, _ := resolveChannelLink(ctx, s, h.store, i.ChannelID)
+	if link != nil && link.Active {
 		pathArg = translateContainerPath(pathArg, link.ProjectSlug, link.ProjectID)
 	}
 
 	// Resolve search roots: per-project roots from channel link, with
 	// send_search_root as override/fallback.
-	roots := h.resolveSearchRoots(s, i)
+	roots := h.resolveSearchRoots(link)
 	if len(roots) == 0 {
 		h.followup(s, i, "This channel is not linked to a project. Use `/scion setup` first.")
 		return
@@ -354,14 +358,13 @@ func (h *CommandHandler) HandleSend(s *discordgo.Session, i *discordgo.Interacti
 // If the channel is linked to a project, per-project roots are computed.
 // If send_search_root is configured (h.searchRoot != DefaultSearchRoot), it is
 // used as an override when present, or as a fallback when no project link exists.
-func (h *CommandHandler) resolveSearchRoots(s *discordgo.Session, i *discordgo.InteractionCreate) []string {
+//
+// The caller resolves the channel link once and passes it in so that the same
+// result is shared with path translation (avoiding a duplicate store round-trip).
+func (h *CommandHandler) resolveSearchRoots(link *ChannelLink) []string {
 	configuredOverride := h.searchRoot != DefaultSearchRoot && h.searchRoot != ""
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
-	if err != nil || link == nil || !link.Active {
+	if link == nil || !link.Active {
 		// No project link — use configured override if available.
 		if configuredOverride {
 			return []string{h.searchRoot}

--- a/extras/scion-discord/internal/discord/send_test.go
+++ b/extras/scion-discord/internal/discord/send_test.go
@@ -559,6 +559,72 @@ func TestDeduplicateRoots_Empty(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+// --- translateContainerPath tests ---
+
+func TestTranslateContainerPath_ScionVolumes(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	slug := "my-proj"
+	projectID := "aabbccdd-1122-3344-5566-778899aabbcc"
+
+	got := translateContainerPath("/scion-volumes/scratchpad/foo/bar.md", slug, projectID)
+
+	expected := filepath.Join(fakeHome, ".scion", "project-configs",
+		"my-proj__aabbccdd", "shared-dirs", "scratchpad", "foo", "bar.md")
+	assert.Equal(t, expected, got)
+}
+
+func TestTranslateContainerPath_ScionVolumesNoRemainder(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	slug := "my-proj"
+	projectID := "aabbccdd-1122-3344-5566-778899aabbcc"
+
+	got := translateContainerPath("/scion-volumes/scratchpad", slug, projectID)
+
+	expected := filepath.Join(fakeHome, ".scion", "project-configs",
+		"my-proj__aabbccdd", "shared-dirs", "scratchpad")
+	assert.Equal(t, expected, got)
+}
+
+func TestTranslateContainerPath_WorkspaceScionVolumes(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	slug := "my-proj"
+	projectID := "aabbccdd-1122-3344-5566-778899aabbcc"
+
+	got := translateContainerPath("/workspace/.scion-volumes/scratchpad/foo.md", slug, projectID)
+
+	expected := filepath.Join(fakeHome, ".scion", "project-configs",
+		"my-proj__aabbccdd", "shared-dirs", "scratchpad", "foo.md")
+	assert.Equal(t, expected, got)
+}
+
+func TestTranslateContainerPath_NonContainerPathUnchanged(t *testing.T) {
+	got := translateContainerPath("/home/scion/something", "slug", "id")
+	assert.Equal(t, "/home/scion/something", got)
+}
+
+func TestTranslateContainerPath_PartialQueryUnchanged(t *testing.T) {
+	got := translateContainerPath("report.txt", "slug", "id")
+	assert.Equal(t, "report.txt", got)
+}
+
+func TestTranslateContainerPath_BarePrefix(t *testing.T) {
+	// "/scion-volumes" with no shared dir name — can't translate.
+	got := translateContainerPath("/scion-volumes", "slug", "id")
+	assert.Equal(t, "/scion-volumes", got)
+}
+
+func TestTranslateContainerPath_TrailingSlashOnly(t *testing.T) {
+	// "/scion-volumes/" with no shared dir name — can't translate.
+	got := translateContainerPath("/scion-volumes/", "slug", "id")
+	assert.Equal(t, "/scion-volumes/", got)
+}
+
 // --- test helpers ---
 
 // setupSearchTestDir creates a temporary directory structure for search tests.

--- a/extras/scion-discord/internal/discord/send_test.go
+++ b/extras/scion-discord/internal/discord/send_test.go
@@ -426,6 +426,7 @@ func TestProjectSearchRoots_DiscoversDirs(t *testing.T) {
 	// Set up a fake home directory structure.
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
+	t.Setenv("USERPROFILE", fakeHome)
 
 	slug := "test-proj"
 	projectID := "550e8400-e29b-41d4-a716-446655440000"
@@ -455,6 +456,7 @@ func TestProjectSearchRoots_DiscoversDirs(t *testing.T) {
 func TestProjectSearchRoots_NoSharedDirs(t *testing.T) {
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
+	t.Setenv("USERPROFILE", fakeHome)
 
 	slug := "empty-proj"
 	projectID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
@@ -472,6 +474,7 @@ func TestProjectSearchRoots_NoSharedDirs(t *testing.T) {
 func TestProjectSearchRoots_NothingExists(t *testing.T) {
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
+	t.Setenv("USERPROFILE", fakeHome)
 
 	roots := projectSearchRoots("nonexistent", "00000000-0000-0000-0000-000000000000")
 
@@ -564,6 +567,7 @@ func TestDeduplicateRoots_Empty(t *testing.T) {
 func TestTranslateContainerPath_ScionVolumes(t *testing.T) {
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
+	t.Setenv("USERPROFILE", fakeHome)
 
 	slug := "my-proj"
 	projectID := "aabbccdd-1122-3344-5566-778899aabbcc"
@@ -578,6 +582,7 @@ func TestTranslateContainerPath_ScionVolumes(t *testing.T) {
 func TestTranslateContainerPath_ScionVolumesNoRemainder(t *testing.T) {
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
+	t.Setenv("USERPROFILE", fakeHome)
 
 	slug := "my-proj"
 	projectID := "aabbccdd-1122-3344-5566-778899aabbcc"
@@ -592,6 +597,7 @@ func TestTranslateContainerPath_ScionVolumesNoRemainder(t *testing.T) {
 func TestTranslateContainerPath_WorkspaceScionVolumes(t *testing.T) {
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
+	t.Setenv("USERPROFILE", fakeHome)
 
 	slug := "my-proj"
 	projectID := "aabbccdd-1122-3344-5566-778899aabbcc"


### PR DESCRIPTION
Follow-up to https://github.com/GoogleCloudPlatform/scion/pull/945

Adds container-to-host path translation so users can paste agent container paths
(e.g. /scion-volumes/scratchpad/projects/foo/STATUS.md) directly into /scion send
and have them resolve to the correct host-side location.

Changes:
- translateContainerPath maps /scion-volumes/<name>/... to host-side shared dir paths
  using config.SharedDirHostPath and the channel project binding
- Also handles /workspace/.scion-volumes/<name>/... (in-workspace variant)
- Deduplicated resolveChannelLink call in HandleSend (resolved once, passed to both
  path translation and search root resolution)
- Doc-comment warns translateContainerPath output is unconfined; callers must validate
- 7 unit tests for path translation edge cases

Fixes https://github.com/ptone/scion/issues/690