### PR TITLE
fix(hub): decouple provisionCredentials from NoAuth guard

### DIFF
--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -618,7 +618,7 @@ func TestSendOutboundMessageViaHub(t *testing.T) {
 		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 		case r.Method == http.MethodPost && (r.URL.Path == "/api/v1/projects/"+projectID+"/agents/my-agent/outbound-message" ||
-				r.URL.Path == "/api/v1/groves/"+projectID+"/agents/my-agent/outbound-message"):
+			r.URL.Path == "/api/v1/groves/"+projectID+"/agents/my-agent/outbound-message"):
 			var msg hubclient.OutboundMessageRequest
 			_ = json.NewDecoder(r.Body).Decode(&msg)
 			receivedMsg = &msg

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -668,8 +668,10 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 
 	// Collect project-scope secrets for provision-time credential resolution.
 	// These are NOT merged into ResolvedEnv and will not appear in the container env.
-	// Skipped for NoAuth agents just as ResolvedSecrets are skipped.
-	if !noAuth && agent.ProjectID != "" && d.secretBackend != nil {
+	// NOT gated on noAuth: provisionCredentials serve skill resolution (gh://
+	// convention tokens like GH_{OWNER}), not harness auth. Suppressing them under
+	// noAuth starves the GitHubSkillResolver of credentials for private repos.
+	if agent.ProjectID != "" && d.secretBackend != nil {
 		projectSecrets, listErr := d.secretBackend.List(ctx, secret.Filter{
 			Scope:   secret.ScopeProject,
 			ScopeID: agent.ProjectID,

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -3378,6 +3378,89 @@ func TestBuildCreateRequest_NoAuth_SkipsSecrets(t *testing.T) {
 	})
 }
 
+// mockProvisionCredsBackend extends mockSecretBackend with List and Get support
+// for testing provisionCredentials collection.
+type mockProvisionCredsBackend struct {
+	mockSecretBackend
+	projectSecrets []secret.SecretMeta
+	secretValues   map[string]*secret.SecretWithValue
+}
+
+func (m *mockProvisionCredsBackend) List(_ context.Context, filter secret.Filter) ([]secret.SecretMeta, error) {
+	if filter.Scope == secret.ScopeProject {
+		return m.projectSecrets, nil
+	}
+	return nil, nil
+}
+
+func (m *mockProvisionCredsBackend) Get(_ context.Context, name, scope, scopeID string) (*secret.SecretWithValue, error) {
+	if sv, ok := m.secretValues[name]; ok {
+		return sv, nil
+	}
+	return nil, nil
+}
+
+func TestBuildCreateRequest_NoAuth_ProvisionCredentialsSurvive(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("host-1"),
+		Name:     "test-host",
+		Slug:     "test-host",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	dispatcher.SetSecretBackend(&mockProvisionCredsBackend{
+		mockSecretBackend: mockSecretBackend{
+			secrets: []secret.SecretWithValue{
+				{SecretMeta: secret.SecretMeta{Name: "CLAUDE_AUTH", SecretType: "file", Target: "~/.claude/.credentials.json"}, Value: "secret-data"},
+			},
+		},
+		projectSecrets: []secret.SecretMeta{
+			{Name: "GH_EXAMPLE", SecretType: "environment", Scope: secret.ScopeProject},
+		},
+		secretValues: map[string]*secret.SecretWithValue{
+			"GH_EXAMPLE": {SecretMeta: secret.SecretMeta{Name: "GH_EXAMPLE", SecretType: "environment"}, Value: "ghp_token123"},
+		},
+	})
+
+	agent := &store.Agent{
+		ID:              tid("agent-noauth-prov"),
+		Name:            "noauth-prov-agent",
+		Slug:            "noauth-prov-agent",
+		OwnerID:         tid("user-1"),
+		ProjectID:       tid("project-1"),
+		RuntimeBrokerID: tid("host-1"),
+		AppliedConfig:   &store.AgentAppliedConfig{NoAuth: true},
+	}
+
+	req, err := dispatcher.buildCreateRequest(ctx, agent, "TestNoAuthProvisionCreds")
+	if err != nil {
+		t.Fatalf("buildCreateRequest failed: %v", err)
+	}
+
+	// ProvisionCredentials must be populated even under NoAuth — they serve
+	// skill resolution (gh:// tokens), not harness auth.
+	if req.ProvisionCredentials == nil {
+		t.Fatal("expected ProvisionCredentials to be non-nil with NoAuth=true")
+	}
+	if req.ProvisionCredentials["GH_EXAMPLE"] != "ghp_token123" {
+		t.Errorf("expected ProvisionCredentials[GH_EXAMPLE]=%q, got %q", "ghp_token123", req.ProvisionCredentials["GH_EXAMPLE"])
+	}
+
+	// ResolvedSecrets must still be suppressed under NoAuth.
+	if len(req.ResolvedSecrets) != 0 {
+		t.Errorf("expected no resolved secrets with NoAuth=true, got %d", len(req.ResolvedSecrets))
+	}
+}
+
 func TestHTTPAgentDispatcher_DispatchAgentCreate_AppliesImageRegistry(t *testing.T) {
 	ctx := context.Background()
 	memStore := createTestStore(t)


### PR DESCRIPTION
## Summary

When a harness config triggers NoAuth fallback (e.g. antigravity with `no_auth.behavior: drop-to-shell`), the `!noAuth` guard at `httpdispatcher.go:672` suppressed `provisionCredentials` collection. This starved the broker-side `GitHubSkillResolver` of convention-based GH_ tokens (like `GH_SCION_FRONTIERS`), causing gh:// skill resolution to fall back to unauthenticated access and fail with "ref not found" on private repos.

## Changes

- Remove `!noAuth` from the `provisionCredentials` guard in `buildCreateRequest` — these credentials serve skill resolution (gh:// convention tokens), not harness auth
- Add `TestBuildCreateRequest_NoAuth_ProvisionCredentialsSurvive` verifying credentials are populated under NoAuth while `ResolvedSecrets` stays suppressed

## Key files

- `pkg/hub/httpdispatcher.go` — one-line fix + comment update
- `pkg/hub/httpdispatcher_test.go` — new test with mock secret backend

Addresses ptone/scion#708.
