### PR TITLE
chore(harness): add whoami shim in agent containers that maps to scion whoami

### DIFF
--- a/image-build/scion-base/Dockerfile
+++ b/image-build/scion-base/Dockerfile
@@ -73,6 +73,12 @@ RUN if [ -f /usr/bin/gh ]; then \
       chmod +x /usr/bin/gh; \
     fi
 
+# Install whoami shim that delegates to scion whoami.
+# The shim is placed in /usr/local/bin so it shadows /usr/bin/whoami via PATH
+# ordering. The system whoami remains accessible at its original path.
+RUN printf '#!/bin/sh\nexec scion whoami "$@"\n' > /usr/local/bin/whoami && \
+    chmod +x /usr/local/bin/whoami
+
 # Create dev-override bin directory at highest PATH priority.
 # When SCION_DEV_BINARIES is set, this directory is bind-mounted with
 # locally-built binaries, allowing rapid iteration without image rebuilds.

--- a/image-build/scion-base/Dockerfile
+++ b/image-build/scion-base/Dockerfile
@@ -76,7 +76,11 @@ RUN if [ -f /usr/bin/gh ]; then \
 # Install whoami shim that delegates to scion whoami.
 # The shim is placed in /usr/local/bin so it shadows /usr/bin/whoami via PATH
 # ordering. The system whoami remains accessible at its original path.
-RUN printf '#!/bin/sh\nexec scion whoami "$@"\n' > /usr/local/bin/whoami && \
+# Guard: only delegate when Scion agent env vars are set. Otherwise fall back
+# to the real /usr/bin/whoami to preserve Unix-username detection (e.g.
+# ExecAsUserCmd) and avoid an infinite fork loop when scion whoami itself
+# calls exec.LookPath("whoami").
+RUN printf '#!/bin/sh\nif [ -n "${SCION_AGENT_SLUG:-}" ] || [ -n "${SCION_AGENT_NAME:-}" ]; then\n    exec scion whoami "$@"\nfi\nexec /usr/bin/whoami "$@"\n' > /usr/local/bin/whoami && \
     chmod +x /usr/local/bin/whoami
 
 # Create dev-override bin directory at highest PATH priority.

--- a/pkg/runtime/exec_user.go
+++ b/pkg/runtime/exec_user.go
@@ -58,6 +58,6 @@ func ExecAsUserCmd(user, cmd string) []string {
 	// error messages), arg1 becomes $1, etc. We label $0 as
 	// "exec-as-user" so any diagnostic that prints it is
 	// self-describing.
-	const script = `if [ "$(whoami)" = "$1" ]; then exec sh -c "$2"; else exec su - "$1" -c "$2"; fi`
+	const script = `if [ "$(/usr/bin/whoami)" = "$1" ]; then exec sh -c "$2"; else exec su - "$1" -c "$2"; fi`
 	return []string{"sh", "-c", script, "exec-as-user", user, cmd}
 }

--- a/pkg/runtime/exec_user_test.go
+++ b/pkg/runtime/exec_user_test.go
@@ -51,7 +51,7 @@ func TestExecAsUserCmd_Shape(t *testing.T) {
 	// The script body itself is fixed and references $1/$2 — it
 	// must not leak the user or cmd values into its text.
 	script := got[2]
-	if !strings.Contains(script, `[ "$(whoami)" = "$1" ]`) {
+	if !strings.Contains(script, `[ "$(/usr/bin/whoami)" = "$1" ]`) {
 		t.Errorf("expected script to compare whoami against $1, got: %s", script)
 	}
 	if !strings.Contains(script, `exec sh -c "$2"`) {


### PR DESCRIPTION
## Summary

Adds a whoami shim to the scion-base container image so running `whoami` inside an agent container returns the Scion agent identity (via `scion whoami`) instead of the Unix username. The system `/usr/bin/whoami` remains accessible at its original path.

## Changes

- image-build/scion-base/Dockerfile: Added /usr/local/bin/whoami shim script that delegates to `scion whoami` when agent env vars are set, falls back to /usr/bin/whoami otherwise
- pkg/runtime/exec_user.go: Changed $(whoami) to $(/usr/bin/whoami) so ExecAsUserCmd uses the real binary for Unix-username detection, bypassing the shim

## Safety

The shim guards on SCION_AGENT_SLUG/SCION_AGENT_NAME env vars before delegating. When unset, it falls back to /usr/bin/whoami (absolute path). This prevents:
- Infinite fork loop (scion whoami calling whoami calling the shim)
- ExecAsUserCmd PAM regression (Unix username detection must return the real user)

## Test plan

- ExecAsUserCmd tests updated and passing
- No other callers of bare whoami in the codebase are affected

Ref: ptone/scion#709
