### PR TITLE
fix: chown root-owned files after provisioning to prevent undeletable agents

### DIFF
--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/fs"
 	"net/url"
 	"os"
 	"os/exec"
@@ -282,6 +283,26 @@ func runInit(args []string) int {
 			return 1
 		}
 		// Continue anyway — non-required harness hooks failing shouldn't prevent startup
+	}
+
+	// After pre-start hooks, fix up ownership of any files provisioners
+	// created as root. Provisioning runs before privilege drop, so scripts
+	// may write files owned by root:root into the bind-mounted workspace
+	// or the agent home directory. The non-root broker cannot delete
+	// root-owned files later, so we chown them now.
+	if targetUID != 0 && os.Geteuid() == 0 {
+		workspacePath := os.Getenv("SCION_WORKSPACE_PATH")
+		if workspacePath == "" {
+			workspacePath = "/workspace"
+		}
+		for _, dir := range []string{workspacePath, agentHome} {
+			if dir == "" {
+				continue
+			}
+			if err := chownTreeRootOwned(dir, targetUID, targetGID); err != nil {
+				log.Error("Failed to chown %s after pre-start hooks: %v", dir, err)
+			}
+		}
 	}
 
 	// Load the env overlay produced by the pre-start provisioner. Resolve
@@ -1670,6 +1691,34 @@ func gitCloneWorkspace(uid, gid int, agentHome string) error {
 
 	log.Info("Git clone complete: %s on branch %s", normalizedURL, branchName)
 	return nil
+}
+
+// chownTreeRootOwned recursively chowns files owned by root (UID 0) to
+// the specified uid:gid. Files already owned by the target user are
+// skipped for efficiency. This is called after pre-start hooks to fix up
+// files created by provisioners running as root, which would otherwise be
+// undeletable by the non-root broker.
+func chownTreeRootOwned(root string, uid, gid int) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Skip permission errors on walk (e.g., lost+found).
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return nil
+		}
+		if stat.Uid == 0 {
+			if chErr := os.Chown(path, uid, gid); chErr != nil {
+				log.Error("chownTreeRootOwned: failed to chown %s: %v", path, chErr)
+			}
+		}
+		return nil
+	})
 }
 
 func ensureWorkspaceOwnership(workspacePath string, uid, gid, currentEUID int, chown func(string, int, int) error) {

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -1713,7 +1713,7 @@ func chownTreeRootOwned(root string, uid, gid int) error {
 			return nil
 		}
 		if stat.Uid == 0 {
-			if chErr := os.Chown(path, uid, gid); chErr != nil {
+			if chErr := os.Lchown(path, uid, gid); chErr != nil {
 				log.Error("chownTreeRootOwned: failed to chown %s: %v", path, chErr)
 			}
 		}

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -237,7 +237,8 @@ def _generate_hooks_json(home: str) -> None:
 
     # AGY only fires project-local hooks. The global path
     # (~/.gemini/antigravity-cli/hooks.json) loads but never executes.
-    agents_dir = os.path.join("/workspace", ".agents")
+    workspace_path = os.environ.get("SCION_WORKSPACE_PATH", "/workspace")
+    agents_dir = os.path.join(workspace_path, ".agents")
     try:
         os.makedirs(agents_dir, exist_ok=True)
         hooks_path = os.path.join(agents_dir, "hooks.json")
@@ -249,11 +250,11 @@ def _generate_hooks_json(home: str) -> None:
         # Fix ownership — provisioner runs as root but workspace is owned
         # by the scion user. Without this, the broker (non-root) cannot
         # delete root-owned files, blocking agent deletion.
-        ws_stat = os.stat('/workspace')
+        ws_stat = os.stat(workspace_path)
         target_uid, target_gid = ws_stat.st_uid, ws_stat.st_gid
         if target_uid != 0:
-            os.chown(agents_dir, target_uid, target_gid)
-            os.chown(hooks_path, target_uid, target_gid)
+            os.lchown(agents_dir, target_uid, target_gid)
+            os.lchown(hooks_path, target_uid, target_gid)
     except (OSError, PermissionError) as exc:
         print(
             f"antigravity provision: warning: could not write hooks.json "

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -246,6 +246,14 @@ def _generate_hooks_json(home: str) -> None:
             f"antigravity provision: generated hooks.json at {hooks_path}",
             file=sys.stderr,
         )
+        # Fix ownership — provisioner runs as root but workspace is owned
+        # by the scion user. Without this, the broker (non-root) cannot
+        # delete root-owned files, blocking agent deletion.
+        ws_stat = os.stat('/workspace')
+        target_uid, target_gid = ws_stat.st_uid, ws_stat.st_gid
+        if target_uid != 0:
+            os.chown(agents_dir, target_uid, target_gid)
+            os.chown(hooks_path, target_uid, target_gid)
     except (OSError, PermissionError) as exc:
         print(
             f"antigravity provision: warning: could not write hooks.json "


### PR DESCRIPTION
## Summary

- Pre-start hooks (harness provisioning) run as root before privilege drop. Files written into bind-mounted /workspace are root-owned, making agents undeletable by the non-root broker.
- Adds chownTreeRootOwned() in sciontool init that recursively walks /workspace and agentHome after pre-start hooks, chowning root-owned files (UID 0) to the target user. Only root-owned files are touched — safe for shared-plain workspaces.
- Complementary fix: antigravity provisioner now self-chowns .agents/ and hooks.json after writing.

Fixes ptone/scion#712

## Key files
- cmd/sciontool/commands/init.go — framework chown after RunPreStart()
- harnesses/antigravity/provision.py — provisioner self-chown

## Test notes
- Build passes, gofmt clean
- Existing tests unaffected (no behavioral change to init flow, only ownership fixup)
