### PR TITLE
fix(discord): show error for messages to non-existent agents

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1273,8 +1273,17 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 	// Filter targets to only start-mention agents, or exclude body-mention agents if no start-mentions exist.
 	// Body-mention agents will be handled by the TypeMention delivery loop.
 	if !isAll {
-		if len(classified.StartMentions) > 0 {
-			startMentionSet := make(map[string]bool, len(classified.StartMentions))
+		// Count only agent-kind start mentions for filtering.
+		// Unknown-kind start mentions (non-existent agents) must not
+		// trigger filtering, otherwise they empty the target list.
+		agentStartMentions := 0
+		for _, sm := range classified.StartMentions {
+			if sm.Kind == "agent" {
+				agentStartMentions++
+			}
+		}
+		if agentStartMentions > 0 {
+			startMentionSet := make(map[string]bool, agentStartMentions)
 			for _, sm := range classified.StartMentions {
 				if sm.Kind == "agent" {
 					startMentionSet[strings.ToLower(sm.Name)] = true
@@ -1309,11 +1318,22 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 		}
 
 		// If body-mention filter emptied targets, restore default agent so instruction is delivered.
-		if len(targets) == 0 && len(classified.StartMentions) == 0 && effectiveDefault != "" && !hasNonBotMentions(m.Message, botUserID) {
+		if len(targets) == 0 && agentStartMentions == 0 && effectiveDefault != "" && !hasNonBotMentions(m.Message, botUserID) {
 			text := strings.TrimSpace(m.Content)
 			if text != "" && !strings.HasPrefix(text, "/") {
 				targets = []string{effectiveDefault}
 			}
+		}
+	}
+
+	// After all routing logic, if targets is empty and there were unresolved
+	// @mentions (non-existent agents), show an error to the user.
+	if len(targets) == 0 {
+		unresolved := extractUnresolvedMentions(m.Content, botUserID, agents)
+		if len(unresolved) > 0 {
+			errMsg := fmt.Sprintf("Unknown agent: %q. Use `/scion agents` to see available agents.", unresolved[0])
+			s.ChannelMessageSend(channelID, errMsg)
+			return
 		}
 	}
 

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1228,7 +1228,7 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 		if isBotMentioned(m, botUserID) {
 			unresolved := extractUnresolvedMentions(m.Content, botUserID, agents)
 			if len(unresolved) > 0 {
-				errMsg := fmt.Sprintf("Unknown agent: %q. Use `/scion agents` to see available agents.", unresolved[0])
+				errMsg := fmt.Sprintf("Unknown agent: %s. Use `/scion agents` to see available agents.", strings.Join(unresolved, ", "))
 				s.ChannelMessageSend(channelID, errMsg)
 			}
 		}
@@ -1255,6 +1255,24 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 			// User resolution via store mapping is not yet wired up.
 			return "", false
 		})
+
+		// If the user typed an unknown @mention at the start, show an error
+		// instead of silently routing to the default agent.
+		hasUnknownStartMention := false
+		for _, sm := range classified.StartMentions {
+			if sm.Kind == "unknown" {
+				hasUnknownStartMention = true
+				break
+			}
+		}
+		if hasUnknownStartMention {
+			unresolved := extractUnresolvedMentions(m.Content, botUserID, agents)
+			if len(unresolved) > 0 {
+				errMsg := fmt.Sprintf("Unknown agent: %s. Use `/scion agents` to see available agents.", strings.Join(unresolved, ", "))
+				s.ChannelMessageSend(channelID, errMsg)
+				return
+			}
+		}
 	}
 
 	// Determine which agent slugs are start-mentions (to strip from text).
@@ -1276,12 +1294,7 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 		// Count only agent-kind start mentions for filtering.
 		// Unknown-kind start mentions (non-existent agents) must not
 		// trigger filtering, otherwise they empty the target list.
-		agentStartMentions := 0
-		for _, sm := range classified.StartMentions {
-			if sm.Kind == "agent" {
-				agentStartMentions++
-			}
-		}
+		agentStartMentions := countAgentStartMentions(classified)
 		if agentStartMentions > 0 {
 			startMentionSet := make(map[string]bool, agentStartMentions)
 			for _, sm := range classified.StartMentions {
@@ -1323,17 +1336,6 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 			if text != "" && !strings.HasPrefix(text, "/") {
 				targets = []string{effectiveDefault}
 			}
-		}
-	}
-
-	// After all routing logic, if targets is empty and there were unresolved
-	// @mentions (non-existent agents), show an error to the user.
-	if len(targets) == 0 {
-		unresolved := extractUnresolvedMentions(m.Content, botUserID, agents)
-		if len(unresolved) > 0 {
-			errMsg := fmt.Sprintf("Unknown agent: %q. Use `/scion agents` to see available agents.", unresolved[0])
-			s.ChannelMessageSend(channelID, errMsg)
-			return
 		}
 	}
 

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1266,7 +1266,12 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 			}
 		}
 		if hasUnknownStartMention && countAgentStartMentions(classified) == 0 {
-			unresolved := extractUnresolvedMentions(m.Content, botUserID, agents)
+			var unresolved []string
+			for _, sm := range classified.StartMentions {
+				if sm.Kind == "unknown" {
+					unresolved = append(unresolved, sm.Name)
+				}
+			}
 			if len(unresolved) > 0 {
 				errMsg := fmt.Sprintf("Unknown agent: %s. Use `/scion agents` to see available agents.", strings.Join(unresolved, ", "))
 				s.ChannelMessageSend(channelID, errMsg)

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1265,7 +1265,7 @@ func (b *DiscordBroker) handleIncomingMessage(s *discordgo.Session, m *discordgo
 				break
 			}
 		}
-		if hasUnknownStartMention {
+		if hasUnknownStartMention && countAgentStartMentions(classified) == 0 {
 			unresolved := extractUnresolvedMentions(m.Content, botUserID, agents)
 			if len(unresolved) > 0 {
 				errMsg := fmt.Sprintf("Unknown agent: %s. Use `/scion agents` to see available agents.", strings.Join(unresolved, ", "))

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -36,71 +36,92 @@ func newTestStructuredMessage() *messages.StructuredMessage {
 	}
 }
 
-// TestStartMentionFiltering_UnknownMention verifies that an unknown @mention
-// at the start of a message does not cause agent-kind filtering to empty the
-// target list. This is a regression test for the silent-drop bug.
-func TestStartMentionFiltering_UnknownMention(t *testing.T) {
+// TestUnknownMentionRouting traces the actual routing logic in
+// handleIncomingMessage for unknown @mentions and verifies the error path
+// fires (R1) and unresolved names are reported (N2).
+func TestUnknownMentionRouting(t *testing.T) {
 	knownAgents := []string{"coder", "reviewer"}
 	botUserID := "BOT123"
 
-	t.Run("unknown mention with default agent shows error", func(t *testing.T) {
-		// Simulate the routing logic in handleIncomingMessage:
-		// 1. resolveTargetAgents returns empty (unknown mention)
-		// 2. Default fallback sets targets
-		// 3. classifyMentions classifies the unknown mention
-		// 4. Filtering logic should NOT empty targets
-
+	t.Run("unknown mention with default agent triggers error path", func(t *testing.T) {
+		// Trace the handleIncomingMessage flow for "@not-an-agent hello"
+		// with effectiveDefault = "coder".
 		content := "@not-an-agent hello"
 
-		// Step 1: resolveTargetAgents would return empty for unknown mention
+		// Step 1: resolveTargetAgents returns empty for unknown mention.
 		msg := newMockMessage(content, nil)
 		targets, _ := resolveTargetAgents(msg, botUserID, "coder", knownAgents)
 		assert.Empty(t, targets, "unknown mention should not resolve")
 
-		// Step 2: Default fallback sets targets
+		// Step 2: Default fallback sets targets = ["coder"].
 		effectiveDefault := "coder"
 		targets = []string{effectiveDefault}
 
-		// Step 3: classifyMentions
+		// Step 3: classifyMentions identifies the unknown start mention.
 		classified := classifyMentions(content, botUserID, knownAgents, noopResolver)
-
-		// Step 4: Count agent-kind start mentions (the fix)
-		agentStartMentions := 0
-		for _, sm := range classified.StartMentions {
-			if sm.Kind == "agent" {
-				agentStartMentions++
-			}
-		}
-
-		// With the fix, agentStartMentions == 0 so the filtering branch
-		// should NOT activate. Unknown mentions must not trigger filtering.
-		assert.Equal(t, 0, agentStartMentions,
+		assert.Equal(t, 0, countAgentStartMentions(classified),
 			"unknown start mentions should not count as agent start mentions")
 		assert.True(t, len(classified.StartMentions) > 0,
 			"unknown mention should still be in StartMentions")
 
-		// The filtering branch would only run if agentStartMentions > 0.
-		// Since it's 0, targets should NOT be filtered.
-		// But the post-filtering error check should still catch it:
+		// Step 4: The error check fires BEFORE the filtering block.
+		// In the actual code, after classifyMentions, we check for unknown
+		// start mentions and return an error instead of routing to default.
+		hasUnknownStartMention := false
+		for _, sm := range classified.StartMentions {
+			if sm.Kind == "unknown" {
+				hasUnknownStartMention = true
+				break
+			}
+		}
+		assert.True(t, hasUnknownStartMention,
+			"error path must detect unknown start mention")
+
 		unresolved := extractUnresolvedMentions(content, botUserID, knownAgents)
 		assert.Equal(t, []string{"not-an-agent"}, unresolved,
 			"unresolved mentions should be detected for error feedback")
+
+		// Verify the error message that would be sent.
+		errMsg := fmt.Sprintf("Unknown agent: %s. Use `/scion agents` to see available agents.",
+			strings.Join(unresolved, ", "))
+		assert.Contains(t, errMsg, "not-an-agent")
 	})
 
-	t.Run("unknown mention without default agent shows error", func(t *testing.T) {
+	t.Run("multiple unknown mentions reports all names", func(t *testing.T) {
+		// N2: "@foo @bar hello" should report both unknown names.
+		content := "@foo @bar hello"
+
+		classified := classifyMentions(content, botUserID, knownAgents, noopResolver)
+		assert.Equal(t, 0, countAgentStartMentions(classified))
+		assert.Len(t, classified.StartMentions, 2)
+
+		unresolved := extractUnresolvedMentions(content, botUserID, knownAgents)
+		assert.Equal(t, []string{"foo", "bar"}, unresolved)
+
+		errMsg := fmt.Sprintf("Unknown agent: %s. Use `/scion agents` to see available agents.",
+			strings.Join(unresolved, ", "))
+		assert.Contains(t, errMsg, "foo, bar",
+			"error message should list all unresolved mentions")
+	})
+
+	t.Run("unknown mention without default agent returns early", func(t *testing.T) {
+		// Without a default, targets stays empty and the function returns
+		// at the early exit (line ~1226). The error feedback at that point
+		// only fires when isBotMentioned is true (Discord structured mention).
+		// Text-format @unknown does not set isBotMentioned.
 		content := "@not-an-agent hello"
 
 		msg := newMockMessage(content, nil)
 		targets, _ := resolveTargetAgents(msg, botUserID, "", knownAgents)
 		assert.Empty(t, targets)
 
-		// No default agent, targets stays empty.
-		// Post-filtering error check should catch it.
+		// No default → targets stays empty → early return before classifyMentions.
+		// Verify unresolved mentions are detectable for the early-return path.
 		unresolved := extractUnresolvedMentions(content, botUserID, knownAgents)
 		assert.Equal(t, []string{"not-an-agent"}, unresolved)
 	})
 
-	t.Run("known agent mention still routes correctly", func(t *testing.T) {
+	t.Run("known agent mention routes correctly", func(t *testing.T) {
 		content := "@coder fix this bug"
 
 		msg := newMockMessage(content, nil)
@@ -108,16 +129,20 @@ func TestStartMentionFiltering_UnknownMention(t *testing.T) {
 		assert.Equal(t, []string{"coder"}, targets)
 
 		classified := classifyMentions(content, botUserID, knownAgents, noopResolver)
+		assert.Equal(t, 1, countAgentStartMentions(classified))
 
-		agentStartMentions := 0
+		// No unknown start mentions → error path does NOT fire.
+		hasUnknownStartMention := false
 		for _, sm := range classified.StartMentions {
-			if sm.Kind == "agent" {
-				agentStartMentions++
+			if sm.Kind == "unknown" {
+				hasUnknownStartMention = true
+				break
 			}
 		}
-		assert.Equal(t, 1, agentStartMentions)
+		assert.False(t, hasUnknownStartMention,
+			"known agent should not trigger error path")
 
-		// Filtering should preserve the known agent target.
+		// Filtering preserves the known agent.
 		startMentionSet := make(map[string]bool)
 		for _, sm := range classified.StartMentions {
 			if sm.Kind == "agent" {
@@ -133,7 +158,6 @@ func TestStartMentionFiltering_UnknownMention(t *testing.T) {
 		assert.Equal(t, []string{"coder"}, filteredTargets,
 			"known agent should remain in targets after filtering")
 
-		// No unresolved mentions.
 		unresolved := extractUnresolvedMentions(content, botUserID, knownAgents)
 		assert.Empty(t, unresolved)
 	})
@@ -145,17 +169,10 @@ func TestStartMentionFiltering_UnknownMention(t *testing.T) {
 
 		classified := classifyMentions(content, botUserID, knownAgents, noopResolver)
 
-		agentStartMentions := 0
-		for _, sm := range classified.StartMentions {
-			if sm.Kind == "agent" {
-				agentStartMentions++
-			}
-		}
-
-		// No start mentions, so agentStartMentions == 0.
+		// No start mentions, so countAgentStartMentions == 0.
 		// Safety net condition: len(targets) == 0 && agentStartMentions == 0
 		// should allow default restoration.
-		assert.Equal(t, 0, agentStartMentions)
+		assert.Equal(t, 0, countAgentStartMentions(classified))
 		assert.Empty(t, classified.StartMentions)
 		assert.Len(t, classified.BodyMentions, 1)
 	})

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -104,6 +104,37 @@ func TestUnknownMentionRouting(t *testing.T) {
 			"error message should list all unresolved mentions")
 	})
 
+	t.Run("mixed known and unknown start mentions delivers to known agent", func(t *testing.T) {
+		// R2: "@coder @not-an-agent fix this" should deliver to coder,
+		// not show an error. The error path must not fire when there are
+		// valid agent start mentions alongside unknown ones.
+		content := "@coder @not-an-agent fix this"
+
+		msg := newMockMessage(content, nil)
+		targets, _ := resolveTargetAgents(msg, botUserID, "coder", knownAgents)
+		assert.Equal(t, []string{"coder"}, targets)
+
+		classified := classifyMentions(content, botUserID, knownAgents, noopResolver)
+		// Has both agent and unknown start mentions.
+		assert.Equal(t, 1, countAgentStartMentions(classified))
+		assert.Len(t, classified.StartMentions, 2)
+
+		// Error path should NOT fire because there are valid agent start mentions.
+		// The guard: hasUnknownStartMention && countAgentStartMentions(classified) == 0
+		// ensures mixed cases are delivered, not blocked.
+		hasUnknownStartMention := false
+		for _, sm := range classified.StartMentions {
+			if sm.Kind == "unknown" {
+				hasUnknownStartMention = true
+				break
+			}
+		}
+		assert.True(t, hasUnknownStartMention,
+			"unknown mention should be detected")
+		assert.True(t, countAgentStartMentions(classified) > 0,
+			"mixed case must not trigger error path — known agent should receive message")
+	})
+
 	t.Run("unknown mention without default agent returns early", func(t *testing.T) {
 		// Without a default, targets stays empty and the function returns
 		// at the early exit (line ~1226). The error feedback at that point

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -36,6 +36,131 @@ func newTestStructuredMessage() *messages.StructuredMessage {
 	}
 }
 
+// TestStartMentionFiltering_UnknownMention verifies that an unknown @mention
+// at the start of a message does not cause agent-kind filtering to empty the
+// target list. This is a regression test for the silent-drop bug.
+func TestStartMentionFiltering_UnknownMention(t *testing.T) {
+	knownAgents := []string{"coder", "reviewer"}
+	botUserID := "BOT123"
+
+	t.Run("unknown mention with default agent shows error", func(t *testing.T) {
+		// Simulate the routing logic in handleIncomingMessage:
+		// 1. resolveTargetAgents returns empty (unknown mention)
+		// 2. Default fallback sets targets
+		// 3. classifyMentions classifies the unknown mention
+		// 4. Filtering logic should NOT empty targets
+
+		content := "@not-an-agent hello"
+
+		// Step 1: resolveTargetAgents would return empty for unknown mention
+		msg := newMockMessage(content, nil)
+		targets, _ := resolveTargetAgents(msg, botUserID, "coder", knownAgents)
+		assert.Empty(t, targets, "unknown mention should not resolve")
+
+		// Step 2: Default fallback sets targets
+		effectiveDefault := "coder"
+		targets = []string{effectiveDefault}
+
+		// Step 3: classifyMentions
+		classified := classifyMentions(content, botUserID, knownAgents, noopResolver)
+
+		// Step 4: Count agent-kind start mentions (the fix)
+		agentStartMentions := 0
+		for _, sm := range classified.StartMentions {
+			if sm.Kind == "agent" {
+				agentStartMentions++
+			}
+		}
+
+		// With the fix, agentStartMentions == 0 so the filtering branch
+		// should NOT activate. Unknown mentions must not trigger filtering.
+		assert.Equal(t, 0, agentStartMentions,
+			"unknown start mentions should not count as agent start mentions")
+		assert.True(t, len(classified.StartMentions) > 0,
+			"unknown mention should still be in StartMentions")
+
+		// The filtering branch would only run if agentStartMentions > 0.
+		// Since it's 0, targets should NOT be filtered.
+		// But the post-filtering error check should still catch it:
+		unresolved := extractUnresolvedMentions(content, botUserID, knownAgents)
+		assert.Equal(t, []string{"not-an-agent"}, unresolved,
+			"unresolved mentions should be detected for error feedback")
+	})
+
+	t.Run("unknown mention without default agent shows error", func(t *testing.T) {
+		content := "@not-an-agent hello"
+
+		msg := newMockMessage(content, nil)
+		targets, _ := resolveTargetAgents(msg, botUserID, "", knownAgents)
+		assert.Empty(t, targets)
+
+		// No default agent, targets stays empty.
+		// Post-filtering error check should catch it.
+		unresolved := extractUnresolvedMentions(content, botUserID, knownAgents)
+		assert.Equal(t, []string{"not-an-agent"}, unresolved)
+	})
+
+	t.Run("known agent mention still routes correctly", func(t *testing.T) {
+		content := "@coder fix this bug"
+
+		msg := newMockMessage(content, nil)
+		targets, _ := resolveTargetAgents(msg, botUserID, "coder", knownAgents)
+		assert.Equal(t, []string{"coder"}, targets)
+
+		classified := classifyMentions(content, botUserID, knownAgents, noopResolver)
+
+		agentStartMentions := 0
+		for _, sm := range classified.StartMentions {
+			if sm.Kind == "agent" {
+				agentStartMentions++
+			}
+		}
+		assert.Equal(t, 1, agentStartMentions)
+
+		// Filtering should preserve the known agent target.
+		startMentionSet := make(map[string]bool)
+		for _, sm := range classified.StartMentions {
+			if sm.Kind == "agent" {
+				startMentionSet[strings.ToLower(sm.Name)] = true
+			}
+		}
+		filteredTargets := make([]string, 0)
+		for _, t2 := range targets {
+			if startMentionSet[strings.ToLower(t2)] {
+				filteredTargets = append(filteredTargets, t2)
+			}
+		}
+		assert.Equal(t, []string{"coder"}, filteredTargets,
+			"known agent should remain in targets after filtering")
+
+		// No unresolved mentions.
+		unresolved := extractUnresolvedMentions(content, botUserID, knownAgents)
+		assert.Empty(t, unresolved)
+	})
+
+	t.Run("safety net restores default when only body mentions exist", func(t *testing.T) {
+		// When all agents are body-mentioned (no start mentions), the safety
+		// net should restore the default agent. Verify the fix preserves this.
+		content := "please ask @reviewer about this"
+
+		classified := classifyMentions(content, botUserID, knownAgents, noopResolver)
+
+		agentStartMentions := 0
+		for _, sm := range classified.StartMentions {
+			if sm.Kind == "agent" {
+				agentStartMentions++
+			}
+		}
+
+		// No start mentions, so agentStartMentions == 0.
+		// Safety net condition: len(targets) == 0 && agentStartMentions == 0
+		// should allow default restoration.
+		assert.Equal(t, 0, agentStartMentions)
+		assert.Empty(t, classified.StartMentions)
+		assert.Len(t, classified.BodyMentions, 1)
+	})
+}
+
 func TestParseHubError(t *testing.T) {
 	t.Run("valid error response", func(t *testing.T) {
 		body := `{"error":{"code":"agent_not_found","message":"Agent \"coder\" not found in project"}}`

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -77,7 +77,14 @@ func TestUnknownMentionRouting(t *testing.T) {
 		assert.True(t, hasUnknownStartMention,
 			"error path must detect unknown start mention")
 
-		unresolved := extractUnresolvedMentions(content, botUserID, knownAgents)
+		// Extract unresolved names directly from classified.StartMentions
+		// (mirrors the production code path in broker.go).
+		var unresolved []string
+		for _, sm := range classified.StartMentions {
+			if sm.Kind == "unknown" {
+				unresolved = append(unresolved, sm.Name)
+			}
+		}
 		assert.Equal(t, []string{"not-an-agent"}, unresolved,
 			"unresolved mentions should be detected for error feedback")
 
@@ -95,7 +102,13 @@ func TestUnknownMentionRouting(t *testing.T) {
 		assert.Equal(t, 0, countAgentStartMentions(classified))
 		assert.Len(t, classified.StartMentions, 2)
 
-		unresolved := extractUnresolvedMentions(content, botUserID, knownAgents)
+		// Extract unresolved names directly from classified.StartMentions.
+		var unresolved []string
+		for _, sm := range classified.StartMentions {
+			if sm.Kind == "unknown" {
+				unresolved = append(unresolved, sm.Name)
+			}
+		}
 		assert.Equal(t, []string{"foo", "bar"}, unresolved)
 
 		errMsg := fmt.Sprintf("Unknown agent: %s. Use `/scion agents` to see available agents.",
@@ -189,7 +202,13 @@ func TestUnknownMentionRouting(t *testing.T) {
 		assert.Equal(t, []string{"coder"}, filteredTargets,
 			"known agent should remain in targets after filtering")
 
-		unresolved := extractUnresolvedMentions(content, botUserID, knownAgents)
+		// Verify no unknown start mentions exist (error path would not fire).
+		var unresolved []string
+		for _, sm := range classified.StartMentions {
+			if sm.Kind == "unknown" {
+				unresolved = append(unresolved, sm.Name)
+			}
+		}
 		assert.Empty(t, unresolved)
 	})
 

--- a/extras/scion-discord/internal/discord/mentions.go
+++ b/extras/scion-discord/internal/discord/mentions.go
@@ -176,6 +176,19 @@ func extractUnresolvedMentions(text string, botUserID string, knownAgents []stri
 	return unresolved
 }
 
+// countAgentStartMentions returns the number of start mentions with Kind == "agent"
+// in a ClassifiedMentions result. Unknown-kind start mentions (non-existent agents)
+// are excluded — they must not trigger the filtering branch.
+func countAgentStartMentions(classified ClassifiedMentions) int {
+	n := 0
+	for _, sm := range classified.StartMentions {
+		if sm.Kind == "agent" {
+			n++
+		}
+	}
+	return n
+}
+
 // Mention represents a classified @mention in a message.
 type Mention struct {
 	Name     string // agent slug or username (without @)

--- a/extras/scion-discord/internal/discord/mentions_test.go
+++ b/extras/scion-discord/internal/discord/mentions_test.go
@@ -456,6 +456,30 @@ func TestClassifyMentions_UserResolver(t *testing.T) {
 	}, result.BodyMentions)
 }
 
+func TestClassifyMentions_UnknownStartMention(t *testing.T) {
+	// An unknown @mention at the start should be classified as Kind="unknown"
+	// in StartMentions. This is the input condition that previously caused
+	// the filtering bug (empty startMentionSet wiping all targets).
+	result := classifyMentions("@not-an-agent hello", "BOT123",
+		[]string{"agent-a", "agent-b"}, noopResolver)
+
+	assert.Len(t, result.StartMentions, 1)
+	assert.Equal(t, "not-an-agent", result.StartMentions[0].Name)
+	assert.Equal(t, "unknown", result.StartMentions[0].Kind)
+	assert.Empty(t, result.BodyMentions)
+}
+
+func TestClassifyMentions_UnknownAndKnownStartMentions(t *testing.T) {
+	// Mixed known and unknown @mentions at the start.
+	result := classifyMentions("@agent-a @not-an-agent do this", "BOT123",
+		[]string{"agent-a", "agent-b"}, noopResolver)
+
+	assert.Len(t, result.StartMentions, 2)
+	assert.Equal(t, Mention{Name: "agent-a", Kind: "agent", Identity: "agent:agent-a"}, result.StartMentions[0])
+	assert.Equal(t, "not-an-agent", result.StartMentions[1].Name)
+	assert.Equal(t, "unknown", result.StartMentions[1].Kind)
+}
+
 func TestClassifyMentions_UnknownBodyMentionsSkipped(t *testing.T) {
 	// Unknown mentions in the body should be skipped.
 	result := classifyMentions("do this @stranger", "BOT123",


### PR DESCRIPTION
Fixes a regression where messages to non-existent agents (e.g. @not-an-agent hello) were silently dropped instead of showing an error.

Root cause: classifyMentions filtering treated unknown @mentions as triggering the start-mention filtering branch, but the filter set only included agent-kind mentions, causing all targets to be emptied.

Fix: (1) Start-mention filtering only activates for agent-kind start mentions. (2) Unknown-mention error check fires before the default fallback and reports all unresolved names. (3) Mixed known+unknown guard ensures @known @unknown delivers to known agent.

Files changed: broker.go, broker_test.go, mentions.go, mentions_test.go (all in extras/scion-discord/internal/discord/)

Fork PR: https://github.com/ptone/scion/pull/714