### PR TITLE
fix(web): add missing page titles for integrations admin pages

### DIFF
--- a/web/src/components/app-shell.ts
+++ b/web/src/components/app-shell.ts
@@ -49,6 +49,7 @@ const PAGE_TITLES: Record<string, string> = {
   '/admin/users': 'Users',
   '/admin/groups': 'Groups',
   '/admin/server-config': 'Server Config',
+  '/admin/integrations': 'Integrations',
   '/metrics': 'Metrics',
   '/admin/skill-registries': 'Skill Registries',
   '/skills': 'Skills',
@@ -348,6 +349,9 @@ export class ScionApp extends LitElement {
     }
     if (this.currentPath === '/admin/maintenance') {
       return 'Maintenance';
+    }
+    if (this.currentPath.match(/^\/admin\/integrations\/[^/]+$/)) {
+      return 'Integration';
     }
     if (this.currentPath === '/skills/new') {
       return 'Create Skill';


### PR DESCRIPTION
## Summary

The integrations page (/admin/integrations) displayed "Page Not Found" as its header text even though the page rendered correctly. Root cause: getPageTitle() in app-shell.ts had no entry for integrations paths, falling through to the default "Page Not Found" string.

## Changes

- web/src/components/app-shell.ts: Added PAGE_TITLES entries for /admin/integrations (list view) and /admin/integrations/:name (detail view)

## Test plan

- TypeScript type-check passes (tsc --noEmit)
- All 124 web tests pass (vitest)

Fixes #616
