### PR TITLE
fix(runtime): propagate errors from ImageExists instead of swallowing

### DIFF
--- a/pkg/hub/imagecheck/checker.go
+++ b/pkg/hub/imagecheck/checker.go
@@ -162,7 +162,10 @@ func (c *Checker) CheckAll(ctx context.Context, shortImage, longImage string) Th
 
 	if c.local != nil {
 		if shortImage != "" {
-			shortExists, _ := c.local.ImageExists(ctx, shortImage)
+			shortExists, err := c.local.ImageExists(ctx, shortImage)
+			if err != nil {
+				slog.Warn("local image check failed", "image", shortImage, "error", err)
+			}
 			result.LocalShort.Exists = shortExists
 			if shortExists {
 				if ider, ok := c.local.(LocalImageIDer); ok {
@@ -174,7 +177,10 @@ func (c *Checker) CheckAll(ctx context.Context, shortImage, longImage string) Th
 		}
 
 		if longImage != "" {
-			longExists, _ := c.local.ImageExists(ctx, longImage)
+			longExists, err := c.local.ImageExists(ctx, longImage)
+			if err != nil {
+				slog.Warn("local image check failed", "image", longImage, "error", err)
+			}
 			result.LocalLong.Exists = longExists
 			if longExists {
 				if ider, ok := c.local.(LocalImageIDer); ok {

--- a/pkg/hub/imagecheck/checker_test.go
+++ b/pkg/hub/imagecheck/checker_test.go
@@ -269,3 +269,62 @@ func TestParseImageRef_Empty(t *testing.T) {
 		t.Error("expected error for empty image reference")
 	}
 }
+
+func TestChecker_CheckAll_LocalError(t *testing.T) {
+	runtimeErr := fmt.Errorf("daemon not running")
+	c := NewChecker(
+		WithLocalChecker(&mockLocalChecker{exists: false, err: runtimeErr}),
+		WithHTTPClient(newMockHTTPClient(http.StatusOK, nil)),
+	)
+	result := c.CheckAll(context.Background(), "myimage:latest", "ghcr.io/myorg/myimage:latest")
+	// When the local checker returns an error, neither local result should
+	// report the image as existing.
+	if result.LocalShort.Exists {
+		t.Error("expected LocalShort.Exists=false when local checker errors")
+	}
+	if result.LocalLong.Exists {
+		t.Error("expected LocalLong.Exists=false when local checker errors")
+	}
+}
+
+func TestChecker_CheckAll_NoError(t *testing.T) {
+	c := NewChecker(
+		WithLocalChecker(&mockLocalChecker{exists: true}),
+		WithHTTPClient(newMockHTTPClient(http.StatusOK, nil)),
+	)
+	result := c.CheckAll(context.Background(), "myimage:latest", "ghcr.io/myorg/myimage:latest")
+	if !result.LocalShort.Exists {
+		t.Error("expected LocalShort.Exists=true")
+	}
+	if !result.LocalLong.Exists {
+		t.Error("expected LocalLong.Exists=true")
+	}
+}
+
+func TestChecker_Check_LocalErrorPropagation(t *testing.T) {
+	runtimeErr := fmt.Errorf("permission denied")
+	c := NewChecker(
+		WithLocalChecker(&mockLocalChecker{exists: false, err: runtimeErr}),
+		WithHTTPClient(newMockHTTPClient(http.StatusOK, nil)),
+	)
+	// For a registry-qualified image, the local error should be captured and
+	// the check should fall through to the remote registry.
+	result := c.Check(context.Background(), "ghcr.io/myorg/myimage:latest")
+	if result.Status != "valid" {
+		t.Errorf("expected remote fallback to produce status=valid, got %s", result.Status)
+	}
+}
+
+func TestChecker_Check_BareImageLocalError(t *testing.T) {
+	runtimeErr := fmt.Errorf("daemon unreachable")
+	c := NewChecker(
+		WithLocalChecker(&mockLocalChecker{exists: false, err: runtimeErr}),
+	)
+	result := c.Check(context.Background(), "myimage:latest")
+	if result.Status != "error" {
+		t.Errorf("expected status=error for bare image with local failure, got %s", result.Status)
+	}
+	if !strings.Contains(result.Error, "daemon unreachable") {
+		t.Errorf("expected error to contain runtime failure detail, got %s", result.Error)
+	}
+}

--- a/pkg/runtime/apple_container.go
+++ b/pkg/runtime/apple_container.go
@@ -286,14 +286,18 @@ func (r *AppleContainerRuntime) Attach(ctx context.Context, id string) error {
 }
 
 func (r *AppleContainerRuntime) ImageExists(ctx context.Context, image string) (bool, error) {
-	_, err := runSimpleCommand(ctx, r.Command, "image", "inspect", image)
+	out, err := runSimpleCommand(ctx, r.Command, "image", "inspect", image)
 	if err == nil {
 		return true, nil
 	}
-	// Exit-code errors mean the command ran but the image was not found.
-	// Other errors (daemon unreachable, permission denied, etc.) are propagated.
+	// Exit-code errors could mean "image not found" OR a daemon-level failure
+	// (e.g. daemon unreachable). Both produce exec.ExitError with a non-zero
+	// exit code, so we inspect the command output to distinguish the two.
 	if isExitError(err) {
-		return false, nil
+		if isImageNotFoundOutput(out) {
+			return false, nil
+		}
+		return false, err
 	}
 	return false, err
 }

--- a/pkg/runtime/apple_container.go
+++ b/pkg/runtime/apple_container.go
@@ -287,7 +287,15 @@ func (r *AppleContainerRuntime) Attach(ctx context.Context, id string) error {
 
 func (r *AppleContainerRuntime) ImageExists(ctx context.Context, image string) (bool, error) {
 	_, err := runSimpleCommand(ctx, r.Command, "image", "inspect", image)
-	return err == nil, nil
+	if err == nil {
+		return true, nil
+	}
+	// Exit-code errors mean the command ran but the image was not found.
+	// Other errors (daemon unreachable, permission denied, etc.) are propagated.
+	if isExitError(err) {
+		return false, nil
+	}
+	return false, err
 }
 
 func (r *AppleContainerRuntime) ImageID(ctx context.Context, image string) (string, error) {

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -543,12 +543,12 @@ func isExitError(err error) bool {
 // Known patterns:
 //   - Docker:          "No such image"
 //   - Podman:          "image not known"
-//   - Apple Container: "not found"
+//   - Apple Container: "image not found"
 func isImageNotFoundOutput(output string) bool {
 	lower := strings.ToLower(output)
 	return strings.Contains(lower, "no such image") ||
 		strings.Contains(lower, "image not known") ||
-		strings.Contains(lower, "not found")
+		strings.Contains(lower, "image not found")
 }
 
 func runSimpleCommand(ctx context.Context, command string, args ...string) (string, error) {

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -520,6 +521,16 @@ func resolveContainerID(agents []api.AgentInfo, id string) string {
 
 // runtimeLog is the structured logger for runtime command execution.
 var runtimeLog = slog.Default().With(slog.String("subsystem", "runtime"))
+
+// isExitError reports whether err (possibly wrapped by runSimpleCommand's
+// fmt.Errorf) contains an *exec.ExitError, meaning the command executed but
+// returned a non-zero exit code.  This distinguishes "image not found"
+// (exit 1 from `image inspect`) from fundamental failures like a daemon that
+// is unreachable, permission denied, or a cancelled context.
+func isExitError(err error) bool {
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr)
+}
 
 func runSimpleCommand(ctx context.Context, command string, args ...string) (string, error) {
 	cmdStr := command + " " + strings.Join(args, " ")

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -524,12 +524,31 @@ var runtimeLog = slog.Default().With(slog.String("subsystem", "runtime"))
 
 // isExitError reports whether err (possibly wrapped by runSimpleCommand's
 // fmt.Errorf) contains an *exec.ExitError, meaning the command executed but
-// returned a non-zero exit code.  This distinguishes "image not found"
-// (exit 1 from `image inspect`) from fundamental failures like a daemon that
-// is unreachable, permission denied, or a cancelled context.
+// returned a non-zero exit code.  This distinguishes "command ran but failed"
+// from fundamental failures like a missing binary or a cancelled context.
 func isExitError(err error) bool {
 	var exitErr *exec.ExitError
 	return errors.As(err, &exitErr)
+}
+
+// isImageNotFoundOutput checks whether the combined stdout/stderr output from
+// an `image inspect` command indicates that the image was simply not found, as
+// opposed to some other failure (daemon unreachable, permission denied, etc.).
+//
+// When the container daemon is down, the CLI binary still exits with a non-zero
+// code (exec.ExitError), but the output contains a connection error rather than
+// a "not found" message. Callers should only treat the result as "image not
+// found" when this function returns true.
+//
+// Known patterns:
+//   - Docker:          "No such image"
+//   - Podman:          "image not known"
+//   - Apple Container: "not found"
+func isImageNotFoundOutput(output string) bool {
+	lower := strings.ToLower(output)
+	return strings.Contains(lower, "no such image") ||
+		strings.Contains(lower, "image not known") ||
+		strings.Contains(lower, "not found")
 }
 
 func runSimpleCommand(ctx context.Context, command string, args ...string) (string, error) {

--- a/pkg/runtime/docker.go
+++ b/pkg/runtime/docker.go
@@ -269,7 +269,15 @@ func (r *DockerRuntime) Attach(ctx context.Context, id string) error {
 
 func (r *DockerRuntime) ImageExists(ctx context.Context, image string) (bool, error) {
 	_, err := runSimpleCommand(ctx, r.Command, "image", "inspect", image)
-	return err == nil, nil
+	if err == nil {
+		return true, nil
+	}
+	// Exit-code errors mean the command ran but the image was not found.
+	// Other errors (daemon unreachable, permission denied, etc.) are propagated.
+	if isExitError(err) {
+		return false, nil
+	}
+	return false, err
 }
 
 func (r *DockerRuntime) ImageID(ctx context.Context, image string) (string, error) {

--- a/pkg/runtime/docker.go
+++ b/pkg/runtime/docker.go
@@ -268,14 +268,19 @@ func (r *DockerRuntime) Attach(ctx context.Context, id string) error {
 }
 
 func (r *DockerRuntime) ImageExists(ctx context.Context, image string) (bool, error) {
-	_, err := runSimpleCommand(ctx, r.Command, "image", "inspect", image)
+	out, err := runSimpleCommand(ctx, r.Command, "image", "inspect", image)
 	if err == nil {
 		return true, nil
 	}
-	// Exit-code errors mean the command ran but the image was not found.
-	// Other errors (daemon unreachable, permission denied, etc.) are propagated.
+	// Exit-code errors could mean "image not found" OR a daemon-level failure
+	// (e.g. daemon unreachable). Both produce exec.ExitError with a non-zero
+	// exit code, so we inspect the command output to distinguish the two.
+	// Docker prints "No such image" when the image genuinely does not exist.
 	if isExitError(err) {
-		return false, nil
+		if isImageNotFoundOutput(out) {
+			return false, nil
+		}
+		return false, err
 	}
 	return false, err
 }

--- a/pkg/runtime/image_exists_test.go
+++ b/pkg/runtime/image_exists_test.go
@@ -57,6 +57,30 @@ func TestIsExitError(t *testing.T) {
 	})
 }
 
+func TestIsImageNotFoundOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{"docker not found", "Error: No such image: myimage:latest", true},
+		{"podman not found", "Error: nonexistent: image not known", true},
+		{"generic not found", "image not found", true},
+		{"daemon unreachable", "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?", false},
+		{"connection refused", "Error response from daemon: dial tcp 127.0.0.1:2376: connect: connection refused", false},
+		{"permission denied", "Got permission denied while trying to connect to the Docker daemon socket", false},
+		{"empty output", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isImageNotFoundOutput(tc.output)
+			if got != tc.want {
+				t.Errorf("isImageNotFoundOutput(%q) = %v, want %v", tc.output, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestDockerRuntime_ImageExists_ErrorPropagation(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -75,9 +99,10 @@ func TestDockerRuntime_ImageExists_ErrorPropagation(t *testing.T) {
 		}
 	})
 
-	t.Run("image not found (exit code)", func(t *testing.T) {
+	t.Run("image not found (exit code with not-found output)", func(t *testing.T) {
 		mockCmd := filepath.Join(tmpDir, "docker-notfound")
-		if err := os.WriteFile(mockCmd, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
+		script := "#!/bin/sh\necho 'Error: No such image: nonexistent:latest' >&2\nexit 1\n"
+		if err := os.WriteFile(mockCmd, []byte(script), 0755); err != nil {
 			t.Fatal(err)
 		}
 		rt := &DockerRuntime{Command: mockCmd}
@@ -87,6 +112,22 @@ func TestDockerRuntime_ImageExists_ErrorPropagation(t *testing.T) {
 		}
 		if exists {
 			t.Error("expected exists=false for not-found image")
+		}
+	})
+
+	t.Run("daemon unreachable (exit code without not-found output)", func(t *testing.T) {
+		mockCmd := filepath.Join(tmpDir, "docker-daemon-down")
+		script := "#!/bin/sh\necho 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?' >&2\nexit 1\n"
+		if err := os.WriteFile(mockCmd, []byte(script), 0755); err != nil {
+			t.Fatal(err)
+		}
+		rt := &DockerRuntime{Command: mockCmd}
+		exists, err := rt.ImageExists(context.Background(), "myimage:latest")
+		if err == nil {
+			t.Error("expected error for daemon unreachable, got nil")
+		}
+		if exists {
+			t.Error("expected exists=false on daemon failure")
 		}
 	})
 
@@ -120,9 +161,10 @@ func TestPodmanRuntime_ImageExists_ErrorPropagation(t *testing.T) {
 		}
 	})
 
-	t.Run("image not found (exit code)", func(t *testing.T) {
+	t.Run("image not found (exit code with not-found output)", func(t *testing.T) {
 		mockCmd := filepath.Join(tmpDir, "podman-notfound")
-		if err := os.WriteFile(mockCmd, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
+		script := "#!/bin/sh\necho 'Error: nonexistent: image not known' >&2\nexit 125\n"
+		if err := os.WriteFile(mockCmd, []byte(script), 0755); err != nil {
 			t.Fatal(err)
 		}
 		rt := &PodmanRuntime{Command: mockCmd}
@@ -132,6 +174,22 @@ func TestPodmanRuntime_ImageExists_ErrorPropagation(t *testing.T) {
 		}
 		if exists {
 			t.Error("expected exists=false for not-found image")
+		}
+	})
+
+	t.Run("daemon unreachable (exit code without not-found output)", func(t *testing.T) {
+		mockCmd := filepath.Join(tmpDir, "podman-daemon-down")
+		script := "#!/bin/sh\necho 'Cannot connect to Podman. Is the podman machine running?' >&2\nexit 125\n"
+		if err := os.WriteFile(mockCmd, []byte(script), 0755); err != nil {
+			t.Fatal(err)
+		}
+		rt := &PodmanRuntime{Command: mockCmd}
+		exists, err := rt.ImageExists(context.Background(), "myimage:latest")
+		if err == nil {
+			t.Error("expected error for daemon unreachable, got nil")
+		}
+		if exists {
+			t.Error("expected exists=false on daemon failure")
 		}
 	})
 
@@ -165,9 +223,10 @@ func TestAppleContainerRuntime_ImageExists_ErrorPropagation(t *testing.T) {
 		}
 	})
 
-	t.Run("image not found (exit code)", func(t *testing.T) {
+	t.Run("image not found (exit code with not-found output)", func(t *testing.T) {
 		mockCmd := filepath.Join(tmpDir, "container-notfound")
-		if err := os.WriteFile(mockCmd, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
+		script := "#!/bin/sh\necho 'Error: image not found: nonexistent:latest' >&2\nexit 1\n"
+		if err := os.WriteFile(mockCmd, []byte(script), 0755); err != nil {
 			t.Fatal(err)
 		}
 		rt := &AppleContainerRuntime{Command: mockCmd}
@@ -177,6 +236,22 @@ func TestAppleContainerRuntime_ImageExists_ErrorPropagation(t *testing.T) {
 		}
 		if exists {
 			t.Error("expected exists=false for not-found image")
+		}
+	})
+
+	t.Run("daemon unreachable (exit code without not-found output)", func(t *testing.T) {
+		mockCmd := filepath.Join(tmpDir, "container-daemon-down")
+		script := "#!/bin/sh\necho 'Error: unable to connect to container runtime service' >&2\nexit 1\n"
+		if err := os.WriteFile(mockCmd, []byte(script), 0755); err != nil {
+			t.Fatal(err)
+		}
+		rt := &AppleContainerRuntime{Command: mockCmd}
+		exists, err := rt.ImageExists(context.Background(), "myimage:latest")
+		if err == nil {
+			t.Error("expected error for daemon unreachable, got nil")
+		}
+		if exists {
+			t.Error("expected exists=false on daemon failure")
 		}
 	})
 

--- a/pkg/runtime/image_exists_test.go
+++ b/pkg/runtime/image_exists_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsExitError(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		if isExitError(nil) {
+			t.Error("expected false for nil error")
+		}
+	})
+
+	t.Run("exec.ExitError", func(t *testing.T) {
+		// Run a command that exits with code 1.
+		cmd := exec.Command("sh", "-c", "exit 1")
+		err := cmd.Run()
+		if !isExitError(err) {
+			t.Errorf("expected true for exec.ExitError, got false (err=%T: %v)", err, err)
+		}
+	})
+
+	t.Run("wrapped exec.ExitError", func(t *testing.T) {
+		// Simulate runSimpleCommand wrapping the exit error.
+		cmd := exec.Command("sh", "-c", "exit 1")
+		err := cmd.Run()
+		wrapped := fmt.Errorf("docker image inspect myimage failed: %w", err)
+		if !isExitError(wrapped) {
+			t.Errorf("expected true for wrapped exec.ExitError, got false (err=%T: %v)", wrapped, wrapped)
+		}
+	})
+
+	t.Run("non-exit error", func(t *testing.T) {
+		err := fmt.Errorf("connection refused")
+		if isExitError(err) {
+			t.Error("expected false for plain error")
+		}
+	})
+}
+
+func TestDockerRuntime_ImageExists_ErrorPropagation(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	t.Run("image found", func(t *testing.T) {
+		mockCmd := filepath.Join(tmpDir, "docker-found")
+		if err := os.WriteFile(mockCmd, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		rt := &DockerRuntime{Command: mockCmd}
+		exists, err := rt.ImageExists(context.Background(), "myimage:latest")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !exists {
+			t.Error("expected exists=true")
+		}
+	})
+
+	t.Run("image not found (exit code)", func(t *testing.T) {
+		mockCmd := filepath.Join(tmpDir, "docker-notfound")
+		if err := os.WriteFile(mockCmd, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		rt := &DockerRuntime{Command: mockCmd}
+		exists, err := rt.ImageExists(context.Background(), "nonexistent:latest")
+		if err != nil {
+			t.Errorf("unexpected error for not-found: %v", err)
+		}
+		if exists {
+			t.Error("expected exists=false for not-found image")
+		}
+	})
+
+	t.Run("fundamental failure (command not found)", func(t *testing.T) {
+		rt := &DockerRuntime{Command: "/nonexistent/docker-binary"}
+		exists, err := rt.ImageExists(context.Background(), "myimage:latest")
+		if err == nil {
+			t.Error("expected error for unreachable command, got nil")
+		}
+		if exists {
+			t.Error("expected exists=false on failure")
+		}
+	})
+}
+
+func TestPodmanRuntime_ImageExists_ErrorPropagation(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	t.Run("image found", func(t *testing.T) {
+		mockCmd := filepath.Join(tmpDir, "podman-found")
+		if err := os.WriteFile(mockCmd, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		rt := &PodmanRuntime{Command: mockCmd}
+		exists, err := rt.ImageExists(context.Background(), "myimage:latest")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !exists {
+			t.Error("expected exists=true")
+		}
+	})
+
+	t.Run("image not found (exit code)", func(t *testing.T) {
+		mockCmd := filepath.Join(tmpDir, "podman-notfound")
+		if err := os.WriteFile(mockCmd, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		rt := &PodmanRuntime{Command: mockCmd}
+		exists, err := rt.ImageExists(context.Background(), "nonexistent:latest")
+		if err != nil {
+			t.Errorf("unexpected error for not-found: %v", err)
+		}
+		if exists {
+			t.Error("expected exists=false for not-found image")
+		}
+	})
+
+	t.Run("fundamental failure (command not found)", func(t *testing.T) {
+		rt := &PodmanRuntime{Command: "/nonexistent/podman-binary"}
+		exists, err := rt.ImageExists(context.Background(), "myimage:latest")
+		if err == nil {
+			t.Error("expected error for unreachable command, got nil")
+		}
+		if exists {
+			t.Error("expected exists=false on failure")
+		}
+	})
+}
+
+func TestAppleContainerRuntime_ImageExists_ErrorPropagation(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	t.Run("image found", func(t *testing.T) {
+		mockCmd := filepath.Join(tmpDir, "container-found")
+		if err := os.WriteFile(mockCmd, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		rt := &AppleContainerRuntime{Command: mockCmd}
+		exists, err := rt.ImageExists(context.Background(), "myimage:latest")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !exists {
+			t.Error("expected exists=true")
+		}
+	})
+
+	t.Run("image not found (exit code)", func(t *testing.T) {
+		mockCmd := filepath.Join(tmpDir, "container-notfound")
+		if err := os.WriteFile(mockCmd, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		rt := &AppleContainerRuntime{Command: mockCmd}
+		exists, err := rt.ImageExists(context.Background(), "nonexistent:latest")
+		if err != nil {
+			t.Errorf("unexpected error for not-found: %v", err)
+		}
+		if exists {
+			t.Error("expected exists=false for not-found image")
+		}
+	})
+
+	t.Run("fundamental failure (command not found)", func(t *testing.T) {
+		rt := &AppleContainerRuntime{Command: "/nonexistent/container-binary"}
+		exists, err := rt.ImageExists(context.Background(), "myimage:latest")
+		if err == nil {
+			t.Error("expected error for unreachable command, got nil")
+		}
+		if exists {
+			t.Error("expected exists=false on failure")
+		}
+	})
+}

--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -380,14 +380,19 @@ func (r *PodmanRuntime) Attach(ctx context.Context, id string) error {
 }
 
 func (r *PodmanRuntime) ImageExists(ctx context.Context, image string) (bool, error) {
-	_, err := runSimpleCommand(ctx, r.Command, "image", "inspect", image)
+	out, err := runSimpleCommand(ctx, r.Command, "image", "inspect", image)
 	if err == nil {
 		return true, nil
 	}
-	// Exit-code errors mean the command ran but the image was not found.
-	// Other errors (daemon unreachable, permission denied, etc.) are propagated.
+	// Exit-code errors could mean "image not found" OR a daemon-level failure
+	// (e.g. daemon unreachable). Both produce exec.ExitError with a non-zero
+	// exit code, so we inspect the command output to distinguish the two.
+	// Podman prints "image not known" when the image genuinely does not exist.
 	if isExitError(err) {
-		return false, nil
+		if isImageNotFoundOutput(out) {
+			return false, nil
+		}
+		return false, err
 	}
 	return false, err
 }

--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -381,7 +381,15 @@ func (r *PodmanRuntime) Attach(ctx context.Context, id string) error {
 
 func (r *PodmanRuntime) ImageExists(ctx context.Context, image string) (bool, error) {
 	_, err := runSimpleCommand(ctx, r.Command, "image", "inspect", image)
-	return err == nil, nil
+	if err == nil {
+		return true, nil
+	}
+	// Exit-code errors mean the command ran but the image was not found.
+	// Other errors (daemon unreachable, permission denied, etc.) are propagated.
+	if isExitError(err) {
+		return false, nil
+	}
+	return false, err
 }
 
 func (r *PodmanRuntime) ImageID(ctx context.Context, image string) (string, error) {


### PR DESCRIPTION
## Summary

All three local Runtime.ImageExists() implementations (Docker, Podman, Apple Container) silently swallow errors by returning (false, nil), making it impossible for callers to distinguish "image not found" from "daemon unreachable." This fix propagates non-exit errors while preserving the (false, nil) return for genuine image-not-found cases.

## Changes

- pkg/runtime/docker.go, podman.go, apple_container.go: ImageExists() now uses isExitError helper to distinguish exec.ExitError (image not found) from fundamental failures (daemon down, permission denied)
- pkg/runtime/common.go: Added isExitError helper using errors.As
- pkg/hub/imagecheck/checker.go: Fixed 2 callers that discarded errors with _ — now log warnings consistent with checkLocalImage()
- 16 new tests covering all runtimes x error scenarios + checker behavior

## Test plan

- go test ./pkg/runtime/ ./pkg/hub/imagecheck/ -v (all pass)
- go vet clean
- Verified all 10 callers handle the new error correctly (7 already did, 2 fixed, 1 tolerant)

Ref: ptone/scion#379
