### PR TITLE
fix(hub,discord): reject broker inbound messages to non-running agents

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -88,6 +88,8 @@ func (e *hubError) userFacingMessage() string {
 		return "Target agent not found. Use `/scion agents` to see available agents."
 	case "forbidden":
 		return "You don't have permission to message this agent."
+	case "agent_not_running":
+		return "Agent is not running. It may be stopped, suspended, or in error state."
 	case "broker_auth_failed", "unauthorized":
 		return "Authentication error — please contact an administrator."
 	default:

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -98,6 +98,11 @@ func TestHubError_UserFacingMessage(t *testing.T) {
 			contains: "Authentication error",
 		},
 		{
+			name:     "agent not running",
+			err:      hubError{StatusCode: 409, Code: "agent_not_running", Message: "Agent is in error state"},
+			contains: "Agent is not running",
+		},
+		{
 			name:     "server error",
 			err:      hubError{StatusCode: 502, Code: "runtime_error", Message: "agent unreachable"},
 			contains: "try again or contact",

--- a/pkg/hub/handlers_broker_inbound.go
+++ b/pkg/hub/handlers_broker_inbound.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
@@ -143,6 +144,28 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 				})
 			return
 		}
+	}
+
+	// Reject messages to non-running agents.
+	switch state.Phase(agent.Phase) {
+	case state.PhaseRunning:
+		// OK — proceed to dispatch
+	case state.PhaseSuspended:
+		writeError(w, http.StatusConflict, ErrCodeAgentNotRunning,
+			fmt.Sprintf("Agent %q is suspended.", agent.Slug), nil)
+		return
+	case state.PhaseStopped:
+		writeError(w, http.StatusConflict, ErrCodeAgentNotRunning,
+			fmt.Sprintf("Agent %q is stopped.", agent.Slug), nil)
+		return
+	case state.PhaseError:
+		writeError(w, http.StatusConflict, ErrCodeAgentNotRunning,
+			fmt.Sprintf("Agent %q is in error state.", agent.Slug), nil)
+		return
+	default:
+		writeError(w, http.StatusConflict, ErrCodeAgentNotRunning,
+			fmt.Sprintf("Agent %q is not yet running (phase: %s).", agent.Slug, agent.Phase), nil)
+		return
 	}
 
 	// A leading "!" in the message body acts as an inline interrupt signal:

--- a/pkg/hub/handlers_broker_inbound.go
+++ b/pkg/hub/handlers_broker_inbound.go
@@ -147,24 +147,19 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Reject messages to non-running agents.
-	switch state.Phase(agent.Phase) {
-	case state.PhaseRunning:
-		// OK — proceed to dispatch
-	case state.PhaseSuspended:
-		writeError(w, http.StatusConflict, ErrCodeAgentNotRunning,
-			fmt.Sprintf("Agent %q is suspended.", agent.Slug), nil)
-		return
-	case state.PhaseStopped:
-		writeError(w, http.StatusConflict, ErrCodeAgentNotRunning,
-			fmt.Sprintf("Agent %q is stopped.", agent.Slug), nil)
-		return
-	case state.PhaseError:
-		writeError(w, http.StatusConflict, ErrCodeAgentNotRunning,
-			fmt.Sprintf("Agent %q is in error state.", agent.Slug), nil)
-		return
-	default:
-		writeError(w, http.StatusConflict, ErrCodeAgentNotRunning,
-			fmt.Sprintf("Agent %q is not yet running (phase: %s).", agent.Slug, agent.Phase), nil)
+	if phase := state.Phase(agent.Phase); phase != state.PhaseRunning {
+		var msg string
+		switch phase {
+		case state.PhaseSuspended:
+			msg = fmt.Sprintf("Agent %q is suspended.", agent.Slug)
+		case state.PhaseStopped:
+			msg = fmt.Sprintf("Agent %q is stopped.", agent.Slug)
+		case state.PhaseError:
+			msg = fmt.Sprintf("Agent %q is in error state.", agent.Slug)
+		default:
+			msg = fmt.Sprintf("Agent %q is not yet running (phase: %s).", agent.Slug, agent.Phase)
+		}
+		writeError(w, http.StatusConflict, ErrCodeAgentNotRunning, msg, nil)
 		return
 	}
 

--- a/pkg/hub/handlers_broker_inbound_test.go
+++ b/pkg/hub/handlers_broker_inbound_test.go
@@ -248,8 +248,7 @@ func TestHandleBrokerInbound_AllowsRunningAgent(t *testing.T) {
 	rec := httptest.NewRecorder()
 	srv.mux.ServeHTTP(rec, req)
 
-	// Running agent should NOT get a 409 — it may fail later (no dispatcher)
-	// but should pass the phase check. A 503 (no dispatcher) is expected.
-	assert.NotEqual(t, http.StatusConflict, rec.Code,
-		"running agent should pass the phase check")
+	// Running agent passes the phase check but gets 503 because no
+	// dispatcher is configured in the test.
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }

--- a/pkg/hub/handlers_broker_inbound_test.go
+++ b/pkg/hub/handlers_broker_inbound_test.go
@@ -12,13 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !no_sqlite
+
 package hub
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
 func TestParseAgentMessageTopic(t *testing.T) {
@@ -91,4 +103,153 @@ func TestParseAgentMessageTopic(t *testing.T) {
 			assert.Equal(t, tt.agentSlug, agentSlug)
 		})
 	}
+}
+
+func TestHandleBrokerInbound_RejectsNonRunningAgent(t *testing.T) {
+	tests := []struct {
+		name        string
+		phase       state.Phase
+		wantMessage string
+	}{
+		{
+			name:        "error phase",
+			phase:       state.PhaseError,
+			wantMessage: "is in error state",
+		},
+		{
+			name:        "stopped phase",
+			phase:       state.PhaseStopped,
+			wantMessage: "is stopped",
+		},
+		{
+			name:        "suspended phase",
+			phase:       state.PhaseSuspended,
+			wantMessage: "is suspended",
+		},
+		{
+			name:        "created phase (not yet running)",
+			phase:       state.PhaseCreated,
+			wantMessage: "is not yet running",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, s := testServer(t)
+			ctx := context.Background()
+
+			// Create project.
+			project := &store.Project{
+				ID:      tid("proj-broker-inbound"),
+				Slug:    "broker-inbound-proj",
+				Name:    "Broker Inbound Test Project",
+				Created: time.Now(),
+				Updated: time.Now(),
+			}
+			require.NoError(t, s.CreateProject(ctx, project))
+
+			// Create agent with the specified phase.
+			agent := &store.Agent{
+				ID:           tid("agent-errstate"),
+				Slug:         "errstate-agent",
+				Name:         "Error State Agent",
+				ProjectID:    project.ID,
+				Phase:        string(tt.phase),
+				StateVersion: 1,
+				Created:      time.Now(),
+				Updated:      time.Now(),
+			}
+			require.NoError(t, s.CreateAgent(ctx, agent))
+
+			// Build broker inbound request.
+			topic := "scion.project." + project.ID + ".agent." + agent.Slug + ".messages"
+			payload := inboundMessageRequest{
+				Topic: topic,
+				Message: &messages.StructuredMessage{
+					Version:   messages.Version,
+					Timestamp: time.Now().UTC().Format(time.RFC3339),
+					Channel:   "discord",
+					Sender:    "agent:other-agent",
+					Recipient: "agent:" + agent.Slug,
+					Msg:       "hello from discord",
+					Type:      messages.TypeInstruction,
+				},
+			}
+			body, err := json.Marshal(payload)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/broker/inbound", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			// Inject broker identity directly to bypass HMAC middleware.
+			req = req.WithContext(contextWithBrokerIdentity(req.Context(), NewBrokerIdentity("test-broker")))
+
+			rec := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rec, req)
+
+			// Verify 409 Conflict with agent_not_running error code.
+			assert.Equal(t, http.StatusConflict, rec.Code)
+
+			var errResp ErrorResponse
+			require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+			assert.Equal(t, ErrCodeAgentNotRunning, errResp.Error.Code)
+			assert.Contains(t, errResp.Error.Message, tt.wantMessage)
+		})
+	}
+}
+
+func TestHandleBrokerInbound_AllowsRunningAgent(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	// Create project.
+	project := &store.Project{
+		ID:      tid("proj-broker-running"),
+		Slug:    "broker-running-proj",
+		Name:    "Broker Running Test Project",
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	// Create a running agent.
+	agent := &store.Agent{
+		ID:           tid("agent-running"),
+		Slug:         "running-agent",
+		Name:         "Running Agent",
+		ProjectID:    project.ID,
+		Phase:        string(state.PhaseRunning),
+		StateVersion: 1,
+		Created:      time.Now(),
+		Updated:      time.Now(),
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	// Build broker inbound request.
+	topic := "scion.project." + project.ID + ".agent." + agent.Slug + ".messages"
+	payload := inboundMessageRequest{
+		Topic: topic,
+		Message: &messages.StructuredMessage{
+			Version:   messages.Version,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			Channel:   "discord",
+			Sender:    "agent:other-agent",
+			Recipient: "agent:" + agent.Slug,
+			Msg:       "hello",
+			Type:      messages.TypeInstruction,
+		},
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/broker/inbound", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithBrokerIdentity(req.Context(), NewBrokerIdentity("test-broker")))
+
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+
+	// Running agent should NOT get a 409 — it may fail later (no dispatcher)
+	// but should pass the phase check. A 503 (no dispatcher) is expected.
+	assert.NotEqual(t, http.StatusConflict, rec.Code,
+		"running agent should pass the phase check")
 }


### PR DESCRIPTION
Adds a phase check to the hub broker inbound handler so messages to agents in error/stopped/suspended state return 409 agent_not_running instead of being silently swallowed. Mirrors the existing pattern from the direct message handler. Also adds agent_not_running case to Discord broker userFacingMessage for actionable user feedback.

Fork PR: https://github.com/ptone/scion/pull/719