### PR TITLE
fix(config): stop project init from overriding global default_harness_config

### DIFF
--- a/pkg/config/embeds/default_project_settings.yaml
+++ b/pkg/config/embeds/default_project_settings.yaml
@@ -27,14 +27,6 @@ schema_version: "1"
 # Env: SCION_ACTIVE_PROFILE
 active_profile: local
 
-# Default harness template for new agents
-# Env: SCION_DEFAULT_TEMPLATE
-default_template: default
-
-# Default harness-config for new agents
-# Env: SCION_DEFAULT_HARNESS_CONFIG
-default_harness_config: claude
-
 # CLI behavior settings
 cli:
   autohelp: true

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -153,9 +153,7 @@ default_template: claude
 func TestLoadVersionedSettings_GlobalHarnessConfigNotOverriddenByProjectDefaults(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	originalHome := os.Getenv("HOME")
-	defer func() { _ = os.Setenv("HOME", originalHome) }()
-	_ = os.Setenv("HOME", tmpDir)
+	t.Setenv("HOME", tmpDir)
 
 	// Set up global settings with custom default_harness_config and default_template.
 	globalScionDir := filepath.Join(tmpDir, ".scion")

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -143,6 +143,51 @@ default_template: claude
 	assert.Equal(t, "claude", vs.DefaultTemplate)
 }
 
+// TestLoadVersionedSettings_GlobalHarnessConfigNotOverriddenByProjectDefaults
+// verifies that when a user sets default_harness_config and default_template in
+// their global settings, initializing a project (which writes the embedded
+// project defaults into the project settings file) does not override those
+// global values.
+//
+// Regression test for GoogleCloudPlatform/scion#212.
+func TestLoadVersionedSettings_GlobalHarnessConfigNotOverriddenByProjectDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	originalHome := os.Getenv("HOME")
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+	_ = os.Setenv("HOME", tmpDir)
+
+	// Set up global settings with custom default_harness_config and default_template.
+	globalScionDir := filepath.Join(tmpDir, ".scion")
+	require.NoError(t, os.MkdirAll(globalScionDir, 0755))
+
+	globalSettings := `
+schema_version: "1"
+default_harness_config: opencode
+default_template: my-template
+`
+	require.NoError(t, os.WriteFile(filepath.Join(globalScionDir, "settings.yaml"), []byte(globalSettings), 0644))
+
+	// Set up a project directory with the embedded project defaults — this is
+	// exactly what scion init writes into the project settings file.
+	projectDir := filepath.Join(tmpDir, "my-project", ".scion")
+	require.NoError(t, os.MkdirAll(projectDir, 0755))
+
+	projectDefaults, err := GetProjectDefaultSettingsYAML()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "settings.yaml"), projectDefaults, 0644))
+
+	// Load merged settings. The project defaults must NOT override the user's
+	// global preferences for default_harness_config and default_template.
+	vs, err := LoadVersionedSettings(projectDir)
+	require.NoError(t, err)
+
+	assert.Equal(t, "opencode", vs.DefaultHarnessConfig,
+		"global default_harness_config should not be overridden by project defaults (issue #212)")
+	assert.Equal(t, "my-template", vs.DefaultTemplate,
+		"global default_template should not be overridden by project defaults")
+}
+
 func TestLoadVersionedSettings_GroveOverride(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Fixes GoogleCloudPlatform/scion#212.

`scion init` seeds every new project's settings.yaml from an embedded defaults template that includes `default_harness_config: claude` and `default_template: default`. Because koanf merges project settings on top of global settings, these values silently override the user's global preferences.

**Fix:** Remove `default_harness_config` and `default_template` from `pkg/config/embeds/default_project_settings.yaml`. The global-level defaults in `default_settings.yaml` already provide the fallback. Projects that want to enforce a specific harness or template can still add these explicitly.

**Key files:**
- `pkg/config/embeds/default_project_settings.yaml` — removed override lines
- Added regression test verifying global settings survive project init

Ref: ptone/scion#718
