### PR TITLE
fix(broker): use detected runtime for heartbeat instead of hardcoding container

### DIFF
--- a/pkg/config/koanf.go
+++ b/pkg/config/koanf.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	goruntime "runtime"
 	"strings"
+	"sync"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/knadh/koanf/parsers/json"
@@ -31,6 +32,23 @@ import (
 	"github.com/knadh/koanf/providers/rawbytes"
 	"github.com/knadh/koanf/v2"
 )
+
+// detectLocalRuntimeOnce caches the result of DetectLocalRuntime so that
+// expensive external-command probes (container, podman, docker --version)
+// run at most once per process. GetDefaultSettingsDataYAML, which is called
+// on every LoadSettingsKoanf invocation, uses this wrapper.
+var detectLocalRuntimeOnce = sync.OnceValues(func() (string, error) {
+	return DetectLocalRuntime()
+})
+
+// resetDetectLocalRuntimeCache resets the cached runtime detection result.
+// This must be called in tests that override lookPathFunc/runCheckFunc to
+// ensure the new mock is picked up.
+func resetDetectLocalRuntimeCache() {
+	detectLocalRuntimeOnce = sync.OnceValues(func() (string, error) {
+		return DetectLocalRuntime()
+	})
+}
 
 // LoadSettingsKoanf loads settings using Koanf with provider priority:
 // 1. Embedded defaults (YAML) with OS-specific runtime adjustment
@@ -259,7 +277,7 @@ func GetDefaultSettingsDataYAML() ([]byte, error) {
 	}
 	// On macOS, detect the available runtime instead of hardcoding "container".
 	// This prevents failures when only podman is installed (no Apple Container CLI).
-	detected, err := DetectLocalRuntime()
+	detected, err := detectLocalRuntimeOnce()
 	if err != nil {
 		return getDefaultSettingsYAMLForRuntime("container") // fallback
 	}

--- a/pkg/config/koanf.go
+++ b/pkg/config/koanf.go
@@ -257,7 +257,13 @@ func GetDefaultSettingsDataYAML() ([]byte, error) {
 	if goruntime.GOOS != "darwin" {
 		return getDefaultSettingsYAMLForRuntime("docker")
 	}
-	return getDefaultSettingsYAMLForRuntime("container")
+	// On macOS, detect the available runtime instead of hardcoding "container".
+	// This prevents failures when only podman is installed (no Apple Container CLI).
+	detected, err := DetectLocalRuntime()
+	if err != nil {
+		return getDefaultSettingsYAMLForRuntime("container") // fallback
+	}
+	return getDefaultSettingsYAMLForRuntime(detected)
 }
 
 // GetProjectDefaultSettingsYAML returns the embedded project-level default settings YAML.

--- a/pkg/config/koanf_test.go
+++ b/pkg/config/koanf_test.go
@@ -15,8 +15,10 @@
 package config
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -844,6 +846,89 @@ profiles:
 	require.True(t, ok, "local profile should exist")
 	assert.Equal(t, "container", profile.Runtime,
 		"in-repo settings should override global profiles.local.runtime")
+}
+
+func TestGetDefaultSettingsYAMLForRuntime_Docker(t *testing.T) {
+	data, err := getDefaultSettingsYAMLForRuntime("docker")
+	if err != nil {
+		t.Fatalf("getDefaultSettingsYAMLForRuntime failed: %v", err)
+	}
+	// Should contain "runtime: docker" instead of "runtime: container"
+	if !bytes.Contains(data, []byte("runtime: docker")) {
+		t.Error("expected YAML to contain 'runtime: docker'")
+	}
+	if bytes.Contains(data, []byte("runtime: container")) {
+		t.Error("expected YAML to NOT contain 'runtime: container' when docker is specified")
+	}
+}
+
+func TestGetDefaultSettingsYAMLForRuntime_Container(t *testing.T) {
+	data, err := getDefaultSettingsYAMLForRuntime("container")
+	if err != nil {
+		t.Fatalf("getDefaultSettingsYAMLForRuntime failed: %v", err)
+	}
+	// Should contain "runtime: container" (the embedded default, unchanged)
+	if !bytes.Contains(data, []byte("runtime: container")) {
+		t.Error("expected YAML to contain 'runtime: container'")
+	}
+}
+
+func TestGetDefaultSettingsYAMLForRuntime_Podman(t *testing.T) {
+	data, err := getDefaultSettingsYAMLForRuntime("podman")
+	if err != nil {
+		t.Fatalf("getDefaultSettingsYAMLForRuntime failed: %v", err)
+	}
+	// Should contain "runtime: podman" instead of "runtime: container"
+	if !bytes.Contains(data, []byte("runtime: podman")) {
+		t.Error("expected YAML to contain 'runtime: podman'")
+	}
+	if bytes.Contains(data, []byte("runtime: container")) {
+		t.Error("expected YAML to NOT contain 'runtime: container' when podman is specified")
+	}
+}
+
+func TestGetDefaultSettingsDataYAML_UsesDetectedRuntime(t *testing.T) {
+	// Mock runtime detection to return "podman" (simulating a macOS host
+	// with only podman installed, no Apple Container CLI).
+	mockRuntimeDetection(t, "podman")
+
+	data, err := GetDefaultSettingsDataYAML()
+	if err != nil {
+		t.Fatalf("GetDefaultSettingsDataYAML failed: %v", err)
+	}
+
+	// On non-darwin this will return "docker" regardless of detection;
+	// on darwin it should use the detected runtime ("podman").
+	if goruntime.GOOS == "darwin" {
+		if !bytes.Contains(data, []byte("runtime: podman")) {
+			t.Error("on macOS, expected detected runtime 'podman' in defaults")
+		}
+	} else {
+		if !bytes.Contains(data, []byte("runtime: docker")) {
+			t.Error("on Linux, expected 'docker' in defaults regardless of detection")
+		}
+	}
+}
+
+func TestGetDefaultSettingsDataYAML_FallsBackToContainerOnDetectFailure(t *testing.T) {
+	// Mock runtime detection to fail (no runtimes available)
+	mockRuntimeDetectionNone(t)
+
+	data, err := GetDefaultSettingsDataYAML()
+	if err != nil {
+		t.Fatalf("GetDefaultSettingsDataYAML failed: %v", err)
+	}
+
+	// On darwin with no runtimes detected, should fall back to "container"
+	if goruntime.GOOS == "darwin" {
+		if !bytes.Contains(data, []byte("runtime: container")) {
+			t.Error("on macOS with no runtimes, expected fallback to 'container'")
+		}
+	} else {
+		if !bytes.Contains(data, []byte("runtime: docker")) {
+			t.Error("on Linux, expected 'docker' regardless")
+		}
+	}
 }
 
 func TestLoadSettingsKoanf_ExternalOverridesInRepo(t *testing.T) {

--- a/pkg/config/runtime_detect.go
+++ b/pkg/config/runtime_detect.go
@@ -105,8 +105,10 @@ func OverrideRuntimeDetection(
 	origRC := runCheckFunc
 	lookPathFunc = lookPath
 	runCheckFunc = runCheck
+	resetDetectLocalRuntimeCache()
 	return func() {
 		lookPathFunc = origLP
 		runCheckFunc = origRC
+		resetDetectLocalRuntimeCache()
 	}
 }

--- a/pkg/config/runtime_detect_test.go
+++ b/pkg/config/runtime_detect_test.go
@@ -30,7 +30,9 @@ func mockRuntimeDetection(t *testing.T, availableRuntime string) {
 	t.Cleanup(func() {
 		lookPathFunc = origLookPath
 		runCheckFunc = origRunCheck
+		resetDetectLocalRuntimeCache()
 	})
+	resetDetectLocalRuntimeCache()
 	lookPathFunc = func(file string) (string, error) {
 		if file == availableRuntime {
 			return "/usr/bin/" + file, nil
@@ -53,7 +55,9 @@ func mockRuntimeDetectionMulti(t *testing.T, available map[string]bool) {
 	t.Cleanup(func() {
 		lookPathFunc = origLookPath
 		runCheckFunc = origRunCheck
+		resetDetectLocalRuntimeCache()
 	})
+	resetDetectLocalRuntimeCache()
 	lookPathFunc = func(file string) (string, error) {
 		if available[file] {
 			return "/usr/bin/" + file, nil
@@ -76,7 +80,9 @@ func mockRuntimeDetectionNone(t *testing.T) {
 	t.Cleanup(func() {
 		lookPathFunc = origLookPath
 		runCheckFunc = origRunCheck
+		resetDetectLocalRuntimeCache()
 	})
+	resetDetectLocalRuntimeCache()
 	lookPathFunc = func(file string) (string, error) {
 		return "", fmt.Errorf("not found: %s", file)
 	}

--- a/pkg/runtimebroker/heartbeat.go
+++ b/pkg/runtimebroker/heartbeat.go
@@ -208,11 +208,13 @@ func (s *HeartbeatService) gatherProjectAgents() []hubclient.ProjectHeartbeat {
 		return nil
 	}
 
-	// List all agents managed by this broker (default runtime)
+	// List all agents managed by this broker (default runtime).
+	// If the default manager fails (e.g. its runtime binary is missing),
+	// log a warning and continue — auxiliary managers may still work.
 	agents, err := s.manager.List(context.Background(), nil)
 	if err != nil {
-		s.log.Error("Failed to list agents for heartbeat", "error", err)
-		return nil
+		s.log.Warn("Default runtime agent listing failed for heartbeat, trying auxiliary runtimes", "error", err)
+		agents = nil
 	}
 
 	// Also include agents from auxiliary runtimes (e.g. Kubernetes).

--- a/pkg/runtimebroker/heartbeat.go
+++ b/pkg/runtimebroker/heartbeat.go
@@ -179,12 +179,12 @@ func (s *HeartbeatService) run(ctx context.Context) {
 
 // sendHeartbeat sends a single heartbeat to the Hub.
 func (s *HeartbeatService) sendHeartbeat(ctx context.Context) error {
-	heartbeat := s.buildHeartbeat()
+	heartbeat := s.buildHeartbeat(ctx)
 	return s.client.Heartbeat(ctx, s.brokerID, heartbeat)
 }
 
 // buildHeartbeat constructs the heartbeat payload from current state.
-func (s *HeartbeatService) buildHeartbeat() *hubclient.BrokerHeartbeat {
+func (s *HeartbeatService) buildHeartbeat(ctx context.Context) *hubclient.BrokerHeartbeat {
 	status := "online"
 
 	heartbeat := &hubclient.BrokerHeartbeat{
@@ -193,7 +193,7 @@ func (s *HeartbeatService) buildHeartbeat() *hubclient.BrokerHeartbeat {
 
 	// If we have a manager, gather per-project agent counts
 	if s.manager != nil {
-		projectAgents := s.gatherProjectAgents()
+		projectAgents := s.gatherProjectAgents(ctx)
 		if len(projectAgents) > 0 {
 			heartbeat.Projects = projectAgents
 		}
@@ -203,7 +203,7 @@ func (s *HeartbeatService) buildHeartbeat() *hubclient.BrokerHeartbeat {
 }
 
 // gatherProjectAgents collects agent information grouped by project.
-func (s *HeartbeatService) gatherProjectAgents() []hubclient.ProjectHeartbeat {
+func (s *HeartbeatService) gatherProjectAgents(ctx context.Context) []hubclient.ProjectHeartbeat {
 	if s.manager == nil {
 		return nil
 	}
@@ -211,7 +211,7 @@ func (s *HeartbeatService) gatherProjectAgents() []hubclient.ProjectHeartbeat {
 	// List all agents managed by this broker (default runtime).
 	// If the default manager fails (e.g. its runtime binary is missing),
 	// log a warning and continue — auxiliary managers may still work.
-	agents, err := s.manager.List(context.Background(), nil)
+	agents, err := s.manager.List(ctx, nil)
 	if err != nil {
 		s.log.Warn("Default runtime agent listing failed for heartbeat, trying auxiliary runtimes", "error", err)
 		agents = nil
@@ -231,7 +231,7 @@ func (s *HeartbeatService) gatherProjectAgents() []hubclient.ProjectHeartbeat {
 			seen[heartbeatAgentKey(ag)] = true
 		}
 		for _, auxMgr := range s.auxiliaryManagers() {
-			auxAgents, auxErr := auxMgr.List(context.Background(), nil)
+			auxAgents, auxErr := auxMgr.List(ctx, nil)
 			if auxErr != nil {
 				continue
 			}

--- a/pkg/runtimebroker/heartbeat_test.go
+++ b/pkg/runtimebroker/heartbeat_test.go
@@ -16,6 +16,7 @@ package runtimebroker
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"testing"
@@ -543,6 +544,96 @@ func TestHeartbeatService_AuxiliaryRuntimeDedupSameAgent(t *testing.T) {
 	}
 	if got := heartbeat.Projects[0].AgentCount; got != 1 {
 		t.Errorf("Expected the same agent to be deduplicated to 1, got %d", got)
+	}
+}
+
+// TestHeartbeatService_DefaultManagerFailsFallsBackToAuxiliary verifies that
+// when the default manager's List() returns an error (e.g. the runtime binary
+// is missing), the heartbeat still collects agents from auxiliary managers
+// instead of short-circuiting with nil.
+func TestHeartbeatService_DefaultManagerFailsFallsBackToAuxiliary(t *testing.T) {
+	client := &mockRuntimeBrokerService{}
+
+	// Default manager fails (simulating missing "container" binary on macOS)
+	defaultMgr := &heartbeatMockManager{
+		err: fmt.Errorf("exec: \"container\": executable file not found in $PATH"),
+	}
+
+	// Auxiliary manager (e.g. podman) has agents
+	auxMgr := &heartbeatMockManager{
+		agents: []api.AgentInfo{
+			{Name: "podman-agent-1", ProjectID: "grove-1", Phase: "running", Activity: "thinking"},
+			{Name: "podman-agent-2", ProjectID: "grove-1", Phase: "running", Activity: "working"},
+		},
+	}
+
+	svc := NewHeartbeatService(client, "test-host", time.Hour, defaultMgr, nil, slog.Default())
+	svc.auxiliaryManagers = func() []agent.Manager { return []agent.Manager{auxMgr} }
+
+	err := svc.ForceHeartbeat(context.Background())
+	if err != nil {
+		t.Fatalf("ForceHeartbeat failed: %v", err)
+	}
+
+	calls := client.getHeartbeatCalls()
+	if len(calls) != 1 {
+		t.Fatalf("Expected 1 heartbeat call, got %d", len(calls))
+	}
+
+	heartbeat := calls[0].Heartbeat
+	if len(heartbeat.Projects) != 1 {
+		t.Fatalf("Expected 1 project from auxiliary runtime, got %d", len(heartbeat.Projects))
+	}
+
+	project := heartbeat.Projects[0]
+	if project.ProjectID != "grove-1" {
+		t.Errorf("Expected project ID 'grove-1', got %q", project.ProjectID)
+	}
+	if project.AgentCount != 2 {
+		t.Errorf("Expected 2 agents from auxiliary runtime, got %d", project.AgentCount)
+	}
+
+	// Verify both agents are present
+	agentMap := make(map[string]hubclient.AgentHeartbeat)
+	for _, ag := range project.Agents {
+		agentMap[ag.Slug] = ag
+	}
+	if _, ok := agentMap["podman-agent-1"]; !ok {
+		t.Error("Expected podman-agent-1 from auxiliary runtime in heartbeat")
+	}
+	if _, ok := agentMap["podman-agent-2"]; !ok {
+		t.Error("Expected podman-agent-2 from auxiliary runtime in heartbeat")
+	}
+}
+
+// TestHeartbeatService_DefaultManagerFailsNoAuxiliary verifies that when the
+// default manager fails and there are no auxiliary managers, the heartbeat
+// still sends successfully with no project data (rather than crashing).
+func TestHeartbeatService_DefaultManagerFailsNoAuxiliary(t *testing.T) {
+	client := &mockRuntimeBrokerService{}
+
+	defaultMgr := &heartbeatMockManager{
+		err: fmt.Errorf("exec: \"container\": executable file not found in $PATH"),
+	}
+
+	svc := NewHeartbeatService(client, "test-host", time.Hour, defaultMgr, nil, slog.Default())
+
+	err := svc.ForceHeartbeat(context.Background())
+	if err != nil {
+		t.Fatalf("ForceHeartbeat failed: %v", err)
+	}
+
+	calls := client.getHeartbeatCalls()
+	if len(calls) != 1 {
+		t.Fatalf("Expected 1 heartbeat call, got %d", len(calls))
+	}
+
+	heartbeat := calls[0].Heartbeat
+	if heartbeat.Status != "online" {
+		t.Errorf("Expected status 'online', got %q", heartbeat.Status)
+	}
+	if len(heartbeat.Projects) != 0 {
+		t.Errorf("Expected 0 projects when default manager fails and no auxiliary, got %d", len(heartbeat.Projects))
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes ptone/scion#177.

On macOS workstation mode with podman configured, the broker heartbeat logs ERROR every ~30s claiming `container` CLI is missing. Two bugs:

1. **Default settings** (`pkg/config/koanf.go`): `GetDefaultSettingsDataYAML()` hardcoded `container` as the macOS runtime, bypassing auto-detection that would find podman. Fixed to use `DetectLocalRuntime()` with `container` fallback.

2. **Heartbeat resilience** (`pkg/runtimebroker/heartbeat.go`): `gatherProjectAgents()` short-circuited (returned nil) when the default manager's `List()` failed, never trying auxiliary managers with working runtimes. Fixed to log a warning and continue to auxiliary managers.

**Key files:**
- `pkg/config/koanf.go` — use DetectLocalRuntime() on macOS
- `pkg/runtimebroker/heartbeat.go` — continue to auxiliary managers on default failure
- 5 new tests covering both fixes

Ref: ptone/scion#720
