### PR TITLE
feat(notifications): add sweep + broker-connect hook for undispatched notification retry

### DIFF
--- a/pkg/ent/schema/notification.go
+++ b/pkg/ent/schema/notification.go
@@ -67,6 +67,10 @@ func (Notification) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("subscription_id"),
 		index.Fields("project_id", "subscriber_type", "subscriber_id"),
+		// Partial index for the undispatched-notification sweep: covers
+		// queries filtering on subscriber_type + created WHERE dispatched = false.
+		index.Fields("subscriber_type", "created").
+			Annotations(entsql.IndexWhere("dispatched = false")),
 	}
 }
 

--- a/pkg/hub/notification_sweep.go
+++ b/pkg/hub/notification_sweep.go
@@ -56,6 +56,9 @@ func (s *Server) notificationDispatchSweepHandler() func(ctx context.Context) {
 		// handles the latency-sensitive path. If sequential processing becomes
 		// a bottleneck under sustained load, consider bounded concurrency.
 		for i := range notifs {
+			if ctx.Err() != nil {
+				break
+			}
 			s.notificationDispatcher.RetryDispatch(ctx, &notifs[i])
 		}
 	}
@@ -86,6 +89,9 @@ func (s *Server) drainUndispatchedNotifications(ctx context.Context, brokerID st
 		"brokerID", brokerID, "count", len(notifs))
 
 	for i := range notifs {
+		if ctx.Err() != nil {
+			break
+		}
 		s.notificationDispatcher.RetryDispatch(ctx, &notifs[i])
 	}
 }
@@ -113,8 +119,20 @@ func (nd *NotificationDispatcher) RetryDispatch(ctx context.Context, notif *stor
 	// 2. Look up subscription context.
 	sub, err := nd.store.GetNotificationSubscription(ctx, notif.SubscriptionID)
 	if err != nil {
-		nd.log.Warn("retry: subscription not found, leaving claimed",
-			"subscriptionID", notif.SubscriptionID, "notificationID", notif.ID, "error", err)
+		if errors.Is(err, store.ErrNotFound) {
+			// Subscription permanently deleted — leave claimed so the sweep
+			// does not retry this notification every 5 minutes forever.
+			nd.log.Warn("retry: subscription deleted, leaving claimed",
+				"subscriptionID", notif.SubscriptionID, "notificationID", notif.ID)
+		} else {
+			// Transient error (DB timeout, connection issue) — revert claim
+			// so a future sweep can retry once the store is reachable again.
+			nd.log.Warn("retry: subscription lookup failed, reverting claim",
+				"subscriptionID", notif.SubscriptionID, "notificationID", notif.ID, "error", err)
+			if err2 := nd.store.UnmarkNotificationDispatched(ctx, notif.ID); err2 != nil {
+				nd.log.Error("retry: failed to revert claim", "notificationID", notif.ID, "error", err2)
+			}
+		}
 		return
 	}
 
@@ -161,9 +179,18 @@ func (nd *NotificationDispatcher) RetryDispatch(ctx context.Context, notif *stor
 	// 5. Resolve watched agent for the structured message.
 	watchedAgent, err := nd.store.GetAgent(ctx, notif.AgentID)
 	if err != nil {
-		nd.log.Warn("retry: watched agent not found, leaving claimed",
-			"agentID", notif.AgentID, "notificationID", notif.ID, "error", err)
-		// Agent may have been deleted — leave claimed (no point retrying).
+		if errors.Is(err, store.ErrNotFound) {
+			// Watched agent permanently deleted — leave claimed (no point retrying).
+			nd.log.Warn("retry: watched agent deleted, leaving claimed",
+				"agentID", notif.AgentID, "notificationID", notif.ID)
+		} else {
+			// Transient error — revert claim so a future sweep can retry.
+			nd.log.Warn("retry: watched agent lookup failed, reverting claim",
+				"agentID", notif.AgentID, "notificationID", notif.ID, "error", err)
+			if err2 := nd.store.UnmarkNotificationDispatched(ctx, notif.ID); err2 != nil {
+				nd.log.Error("retry: failed to revert claim", "notificationID", notif.ID, "error", err2)
+			}
+		}
 		return
 	}
 

--- a/pkg/hub/notification_sweep.go
+++ b/pkg/hub/notification_sweep.go
@@ -16,7 +16,6 @@ package hub
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
@@ -49,6 +48,12 @@ func (s *Server) notificationDispatchSweepHandler() func(ctx context.Context) {
 		s.agentLifecycleLog.Info("notification-dispatch-sweep: found undispatched",
 			"count", len(notifs))
 
+		// Notifications are processed sequentially under the handler's 30s
+		// timeout. This is acceptable because: (1) the batch is capped at 100,
+		// (2) each RetryDispatch is fast when the broker is reachable (CAS +
+		// one RPC), and (3) the sweep is a backstop — the broker-connect hook
+		// handles the latency-sensitive path. If sequential processing becomes
+		// a bottleneck under sustained load, consider bounded concurrency.
 		for i := range notifs {
 			s.notificationDispatcher.RetryDispatch(ctx, &notifs[i])
 		}
@@ -155,6 +160,7 @@ func (nd *NotificationDispatcher) RetryDispatch(ctx context.Context, notif *stor
 	}
 
 	// 6. Build and deliver.
+	// N.B. notif.Status is already uppercase (set by storeAndDispatch).
 	msgType := notificationMessageType(notif.Status)
 	structuredMsg := messages.NewNotification(
 		"agent:"+watchedAgent.Slug,
@@ -164,12 +170,11 @@ func (nd *NotificationDispatcher) RetryDispatch(ctx context.Context, notif *stor
 	)
 	structuredMsg.SenderID = watchedAgent.ID
 	structuredMsg.RecipientID = subscriber.ID
-	structuredMsg.Status = strings.ToUpper(notif.Status)
+	structuredMsg.Status = notif.Status
 
-	retryCtx, retryCancel := context.WithTimeout(ctx, 30*time.Second)
-	defer retryCancel()
-
-	if err := dispatchWithBrokerRetry(retryCtx, dispatcher, subscriber, notif.Message, false, structuredMsg); err != nil {
+	// Use the caller's context directly — the sweep/drain handler already
+	// sets a 30s timeout, and dispatchWithBrokerRetry respects ctx.Done().
+	if err := dispatchWithBrokerRetry(ctx, dispatcher, subscriber, notif.Message, false, structuredMsg); err != nil {
 		nd.log.Error("retry: delivery failed, leaving claimed",
 			"notificationID", notif.ID, "subscriberID", sub.SubscriberID, "error", err)
 		// Leave claimed (dispatched=true). The delivery attempt was made; the

--- a/pkg/hub/notification_sweep.go
+++ b/pkg/hub/notification_sweep.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// notificationDispatchSweepHandler returns a recurring handler that queries for
+// undispatched agent notifications and re-attempts delivery. Registered as a
+// RecurringSingleton guarded by LockNotificationDispatchSweep. This is the
+// backstop for notifications that could not be dispatched because the
+// subscriber agent had no RuntimeBrokerID or no dispatcher was available.
+func (s *Server) notificationDispatchSweepHandler() func(ctx context.Context) {
+	return func(ctx context.Context) {
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		if s.notificationDispatcher == nil {
+			return
+		}
+
+		notifs, err := s.store.GetUndispatchedAgentNotifications(ctx, "")
+		if err != nil {
+			s.agentLifecycleLog.Error("notification-dispatch-sweep: query failed", "error", err)
+			return
+		}
+		if len(notifs) == 0 {
+			return
+		}
+
+		s.agentLifecycleLog.Info("notification-dispatch-sweep: found undispatched",
+			"count", len(notifs))
+
+		for i := range notifs {
+			s.notificationDispatcher.RetryDispatch(ctx, &notifs[i])
+		}
+	}
+}
+
+// drainUndispatchedNotifications delivers undispatched notifications for agents
+// on the given broker. Called as a goroutine from markBrokerOnline for sub-second
+// delivery when a broker first connects.
+func (s *Server) drainUndispatchedNotifications(ctx context.Context, brokerID string) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if s.notificationDispatcher == nil {
+		return
+	}
+
+	notifs, err := s.store.GetUndispatchedAgentNotifications(ctx, brokerID)
+	if err != nil {
+		s.agentLifecycleLog.Error("broker-connect notification drain: query failed",
+			"brokerID", brokerID, "error", err)
+		return
+	}
+	if len(notifs) == 0 {
+		return
+	}
+
+	s.agentLifecycleLog.Info("broker-connect notification drain: delivering",
+		"brokerID", brokerID, "count", len(notifs))
+
+	for i := range notifs {
+		s.notificationDispatcher.RetryDispatch(ctx, &notifs[i])
+	}
+}
+
+// RetryDispatch re-attempts delivery of an existing undispatched notification.
+// It is the shared code path for both the periodic sweep backstop and the
+// broker-connect fast-path hook.
+//
+// Claim-first semantics: ClaimNotificationForDispatch (CAS on dispatched=false)
+// is called before delivery to prevent double-dispatch when the sweep and hook
+// race on the same notification. If the claim fails (another caller already
+// claimed it), this is a no-op. If delivery cannot proceed (no dispatcher, no
+// broker), the claim is reverted so a future sweep can retry.
+func (nd *NotificationDispatcher) RetryDispatch(ctx context.Context, notif *store.Notification) {
+	// 1. Claim: atomically mark dispatched (CAS: WHERE dispatched = false).
+	claimed, err := nd.store.ClaimNotificationForDispatch(ctx, notif.ID)
+	if err != nil {
+		nd.log.Error("retry: claim failed", "id", notif.ID, "error", err)
+		return
+	}
+	if !claimed {
+		return // another caller (sweep or hook) already claimed this one
+	}
+
+	// 2. Look up subscription context.
+	sub, err := nd.store.GetNotificationSubscription(ctx, notif.SubscriptionID)
+	if err != nil {
+		nd.log.Warn("retry: subscription not found, leaving claimed",
+			"subscriptionID", notif.SubscriptionID, "notificationID", notif.ID, "error", err)
+		return
+	}
+
+	// 3. Look up subscriber agent.
+	subscriber, err := nd.store.GetAgentBySlug(ctx, sub.ProjectID, sub.SubscriberID)
+	if err != nil {
+		nd.log.Warn("retry: subscriber agent not found",
+			"subscriberID", sub.SubscriberID, "notificationID", notif.ID, "error", err)
+		// Revert claim so a future sweep can retry (agent may be temporarily
+		// unreachable during a restart).
+		if err2 := nd.store.UnmarkNotificationDispatched(ctx, notif.ID); err2 != nil {
+			nd.log.Error("retry: failed to revert claim", "notificationID", notif.ID, "error", err2)
+		}
+		return
+	}
+
+	// 4. Check preconditions for delivery.
+	dispatcher := nd.getDispatcher()
+	if dispatcher == nil {
+		nd.log.Warn("retry: no dispatcher available, reverting claim",
+			"notificationID", notif.ID)
+		if err2 := nd.store.UnmarkNotificationDispatched(ctx, notif.ID); err2 != nil {
+			nd.log.Error("retry: failed to revert claim", "notificationID", notif.ID, "error", err2)
+		}
+		return
+	}
+
+	if subscriber.RuntimeBrokerID == "" {
+		nd.log.Debug("retry: subscriber has no broker, reverting claim",
+			"subscriberID", sub.SubscriberID, "notificationID", notif.ID)
+		if err2 := nd.store.UnmarkNotificationDispatched(ctx, notif.ID); err2 != nil {
+			nd.log.Error("retry: failed to revert claim", "notificationID", notif.ID, "error", err2)
+		}
+		return
+	}
+
+	// 5. Resolve watched agent for the structured message.
+	watchedAgent, err := nd.store.GetAgent(ctx, notif.AgentID)
+	if err != nil {
+		nd.log.Warn("retry: watched agent not found, leaving claimed",
+			"agentID", notif.AgentID, "notificationID", notif.ID, "error", err)
+		// Agent may have been deleted — leave claimed (no point retrying).
+		return
+	}
+
+	// 6. Build and deliver.
+	msgType := notificationMessageType(notif.Status)
+	structuredMsg := messages.NewNotification(
+		"agent:"+watchedAgent.Slug,
+		"agent:"+subscriber.Slug,
+		notif.Message,
+		msgType,
+	)
+	structuredMsg.SenderID = watchedAgent.ID
+	structuredMsg.RecipientID = subscriber.ID
+	structuredMsg.Status = strings.ToUpper(notif.Status)
+
+	retryCtx, retryCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer retryCancel()
+
+	if err := dispatchWithBrokerRetry(retryCtx, dispatcher, subscriber, notif.Message, false, structuredMsg); err != nil {
+		nd.log.Error("retry: delivery failed, leaving claimed",
+			"notificationID", notif.ID, "subscriberID", sub.SubscriberID, "error", err)
+		// Leave claimed (dispatched=true). The delivery attempt was made; the
+		// current contract is best-effort (same as the primary dispatch path).
+	} else {
+		nd.log.Info("retry: notification delivered",
+			"notificationID", notif.ID, "subscriberID", sub.SubscriberID,
+			"brokerID", subscriber.RuntimeBrokerID)
+		// Log to dedicated message audit log if available.
+		if nd.messageLog != nil {
+			logAttrs := []any{
+				"agent_id", subscriber.ID,
+				"agent_name", subscriber.Name,
+				"project_id", subscriber.ProjectID,
+				"notification_id", notif.ID,
+			}
+			logAttrs = append(logAttrs, structuredMsg.LogAttrs()...)
+			nd.messageLog.Debug("retry: notification message dispatched", logAttrs...)
+		}
+	}
+}

--- a/pkg/hub/notification_sweep.go
+++ b/pkg/hub/notification_sweep.go
@@ -16,6 +16,7 @@ package hub
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
@@ -120,12 +121,19 @@ func (nd *NotificationDispatcher) RetryDispatch(ctx context.Context, notif *stor
 	// 3. Look up subscriber agent.
 	subscriber, err := nd.store.GetAgentBySlug(ctx, sub.ProjectID, sub.SubscriberID)
 	if err != nil {
-		nd.log.Warn("retry: subscriber agent not found",
-			"subscriberID", sub.SubscriberID, "notificationID", notif.ID, "error", err)
-		// Revert claim so a future sweep can retry (agent may be temporarily
-		// unreachable during a restart).
-		if err2 := nd.store.UnmarkNotificationDispatched(ctx, notif.ID); err2 != nil {
-			nd.log.Error("retry: failed to revert claim", "notificationID", notif.ID, "error", err2)
+		if errors.Is(err, store.ErrNotFound) {
+			// Subscriber is permanently deleted — leave claimed so the sweep
+			// does not retry this notification every 5 minutes forever.
+			nd.log.Warn("retry: subscriber agent deleted, leaving claimed",
+				"subscriberID", sub.SubscriberID, "notificationID", notif.ID)
+		} else {
+			// Transient error (DB timeout, connection issue) — revert claim
+			// so a future sweep can retry once the store is reachable again.
+			nd.log.Warn("retry: subscriber lookup failed, reverting claim",
+				"subscriberID", sub.SubscriberID, "notificationID", notif.ID, "error", err)
+			if err2 := nd.store.UnmarkNotificationDispatched(ctx, notif.ID); err2 != nil {
+				nd.log.Error("retry: failed to revert claim", "notificationID", notif.ID, "error", err2)
+			}
 		}
 		return
 	}

--- a/pkg/hub/notification_sweep_test.go
+++ b/pkg/hub/notification_sweep_test.go
@@ -182,18 +182,49 @@ func TestRetryDispatch_SubscriberDeleted(t *testing.T) {
 	// Delete the subscriber agent
 	require.NoError(t, env.store.DeleteAgent(ctx, env.subscriber.ID))
 
-	// Retry — should claim, then find subscriber not found
+	// Retry — should claim, then find subscriber permanently deleted (ErrNotFound).
+	// The notification should remain claimed (dispatched=true) so the sweep
+	// does not retry it every 5 minutes forever.
 	env.nd.RetryDispatch(ctx, &notifs[0])
 
 	// No dispatch call
 	assert.Empty(t, env.dispatcher.getCalls())
 
-	// Notification should be reverted (subscriber might come back after restart)
+	// Notification should remain claimed (dispatched=true) — subscriber is gone
 	allNotifs, err := env.store.GetNotifications(ctx, store.SubscriberTypeAgent, env.subscriber.Slug, false)
 	require.NoError(t, err)
 	for _, n := range allNotifs {
 		if n.ID == notifs[0].ID {
-			assert.False(t, n.Dispatched, "notification should be reverted when subscriber not found")
+			assert.True(t, n.Dispatched, "notification should stay claimed when subscriber is permanently deleted")
+		}
+	}
+}
+
+func TestRetryDispatch_WatchedAgentDeleted(t *testing.T) {
+	env := setupRetryTest(t)
+	ctx := context.Background()
+
+	notifs, err := env.store.GetUndispatchedAgentNotifications(ctx, "")
+	require.NoError(t, err)
+	require.Len(t, notifs, 1)
+
+	// Delete the watched agent (the one that triggered the notification)
+	require.NoError(t, env.store.DeleteAgent(ctx, env.watched.ID))
+
+	// Retry — should claim, look up subscriber (still exists), but fail to
+	// resolve the watched agent. Notification remains claimed (dispatched=true)
+	// because the event source is gone and there is no point retrying.
+	env.nd.RetryDispatch(ctx, &notifs[0])
+
+	// No dispatch call
+	assert.Empty(t, env.dispatcher.getCalls())
+
+	// Notification should remain claimed
+	allNotifs, err := env.store.GetNotifications(ctx, store.SubscriberTypeAgent, env.subscriber.Slug, false)
+	require.NoError(t, err)
+	for _, n := range allNotifs {
+		if n.ID == notifs[0].ID {
+			assert.True(t, n.Dispatched, "notification should stay claimed when watched agent is deleted")
 		}
 	}
 }

--- a/pkg/hub/notification_sweep_test.go
+++ b/pkg/hub/notification_sweep_test.go
@@ -116,13 +116,16 @@ func TestRetryDispatch_NoBroker_Reverts(t *testing.T) {
 	env := setupRetryTest(t)
 	ctx := context.Background()
 
-	// Remove subscriber's broker
-	env.subscriber.RuntimeBrokerID = ""
-	require.NoError(t, env.store.UpdateAgent(ctx, env.subscriber))
-
+	// Fetch the notification while subscriber still has a broker (simulates
+	// the race where the sweep query ran before the broker disconnected).
 	notifs, err := env.store.GetUndispatchedAgentNotifications(ctx, "")
 	require.NoError(t, err)
 	require.Len(t, notifs, 1)
+
+	// Now remove subscriber's broker (simulates broker disconnect between
+	// query time and dispatch time).
+	env.subscriber.RuntimeBrokerID = ""
+	require.NoError(t, env.store.UpdateAgent(ctx, env.subscriber))
 
 	// Retry — should claim, then revert because no broker
 	env.nd.RetryDispatch(ctx, &notifs[0])

--- a/pkg/hub/notification_sweep_test.go
+++ b/pkg/hub/notification_sweep_test.go
@@ -313,3 +313,52 @@ func TestDrainUndispatchedNotifications_FiltersByBroker(t *testing.T) {
 	require.Len(t, remaining, 1)
 	assert.Equal(t, otherSubscriber.Slug, remaining[0].SubscriberID)
 }
+
+// TestDrainUndispatchedNotifications_PicksUpRecentNotifications verifies that
+// the broker-connect hook (non-empty brokerID) does NOT apply the 60s grace
+// period. This is the R1 fix: a notification created just seconds ago should
+// be drained immediately when the broker connects.
+func TestDrainUndispatchedNotifications_PicksUpRecentNotifications(t *testing.T) {
+	env := setupNotificationTest(t)
+	ctx := context.Background()
+
+	// Create a very recent undispatched notification (within the 60s grace
+	// period that the sweep would skip).
+	recentNotif := &store.Notification{
+		ID:             api.NewUUID(),
+		SubscriptionID: env.sub.ID,
+		AgentID:        env.watched.ID,
+		ProjectID:      env.project.ID,
+		SubscriberType: store.SubscriberTypeAgent,
+		SubscriberID:   env.subscriber.Slug,
+		Status:         "COMPLETED",
+		Message:        "watched-agent has reached a state of COMPLETED",
+		Dispatched:     false,
+		// CreatedAt defaults to time.Now() — well within the 60s grace period
+	}
+	require.NoError(t, env.store.CreateNotification(ctx, recentNotif))
+
+	// Verify sweep mode does NOT see this notification (it's too recent).
+	sweepNotifs, err := env.store.GetUndispatchedAgentNotifications(ctx, "")
+	require.NoError(t, err)
+	assert.Empty(t, sweepNotifs, "sweep should not see notifications within grace period")
+
+	// Verify broker-connect mode DOES see this notification.
+	brokerNotifs, err := env.store.GetUndispatchedAgentNotifications(ctx, tid("broker-1"))
+	require.NoError(t, err)
+	require.Len(t, brokerNotifs, 1, "broker drain should see recent notifications")
+	assert.Equal(t, env.subscriber.Slug, brokerNotifs[0].SubscriberID)
+
+	// Drain should deliver it.
+	srv := &Server{
+		store:                  env.store,
+		agentLifecycleLog:      slog.Default(),
+		notificationDispatcher: env.nd,
+	}
+	srv.drainUndispatchedNotifications(ctx, tid("broker-1"))
+
+	calls := env.dispatcher.getCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, env.subscriber.ID, calls[0].Agent.ID)
+	assert.Contains(t, calls[0].Message, "watched-agent has reached a state of COMPLETED")
+}

--- a/pkg/hub/notification_sweep_test.go
+++ b/pkg/hub/notification_sweep_test.go
@@ -1,0 +1,315 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupRetryTest creates a test environment with a pre-existing undispatched
+// notification. The notification is backdated beyond the 60s grace period so
+// the sweep will pick it up.
+func setupRetryTest(t *testing.T) *notificationTestEnv {
+	t.Helper()
+	env := setupNotificationTest(t)
+
+	// Create a notification record manually (simulating a previous dispatch
+	// that failed because subscriber had no broker).
+	ctx := context.Background()
+	notif := &store.Notification{
+		ID:             api.NewUUID(),
+		SubscriptionID: env.sub.ID,
+		AgentID:        env.watched.ID,
+		ProjectID:      env.project.ID,
+		SubscriberType: store.SubscriberTypeAgent,
+		SubscriberID:   env.subscriber.Slug,
+		Status:         "COMPLETED",
+		Message:        "watched-agent has reached a state of COMPLETED",
+		Dispatched:     false,
+		CreatedAt:      time.Now().Add(-2 * time.Minute), // beyond 60s grace period
+	}
+	require.NoError(t, env.store.CreateNotification(ctx, notif))
+
+	// Stash for test assertions
+	env.sub.AgentID = env.watched.ID // ensure AgentID is available
+	return env
+}
+
+func TestRetryDispatch_ClaimAndDeliver(t *testing.T) {
+	env := setupRetryTest(t)
+	ctx := context.Background()
+
+	// Fetch the undispatched notification
+	notifs, err := env.store.GetUndispatchedAgentNotifications(ctx, "")
+	require.NoError(t, err)
+	require.Len(t, notifs, 1)
+	assert.False(t, notifs[0].Dispatched)
+
+	// Retry dispatch
+	env.nd.RetryDispatch(ctx, &notifs[0])
+
+	// Verify dispatch was called
+	calls := env.dispatcher.getCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, env.subscriber.ID, calls[0].Agent.ID)
+	assert.Contains(t, calls[0].Message, "watched-agent has reached a state of COMPLETED")
+
+	// Verify notification is now marked dispatched
+	allNotifs, err := env.store.GetNotifications(ctx, store.SubscriberTypeAgent, env.subscriber.Slug, false)
+	require.NoError(t, err)
+	// Find our notification (there may be others from setup)
+	var found bool
+	for _, n := range allNotifs {
+		if n.ID == notifs[0].ID {
+			assert.True(t, n.Dispatched, "notification should be marked dispatched after retry")
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "notification should still exist")
+}
+
+func TestRetryDispatch_AlreadyClaimed(t *testing.T) {
+	env := setupRetryTest(t)
+	ctx := context.Background()
+
+	notifs, err := env.store.GetUndispatchedAgentNotifications(ctx, "")
+	require.NoError(t, err)
+	require.Len(t, notifs, 1)
+
+	// Claim the notification first (simulating another caller)
+	claimed, err := env.store.ClaimNotificationForDispatch(ctx, notifs[0].ID)
+	require.NoError(t, err)
+	assert.True(t, claimed)
+
+	// Now retry — should be a no-op
+	env.nd.RetryDispatch(ctx, &notifs[0])
+
+	// No dispatch call should have been made
+	assert.Empty(t, env.dispatcher.getCalls())
+}
+
+func TestRetryDispatch_NoBroker_Reverts(t *testing.T) {
+	env := setupRetryTest(t)
+	ctx := context.Background()
+
+	// Remove subscriber's broker
+	env.subscriber.RuntimeBrokerID = ""
+	require.NoError(t, env.store.UpdateAgent(ctx, env.subscriber))
+
+	notifs, err := env.store.GetUndispatchedAgentNotifications(ctx, "")
+	require.NoError(t, err)
+	require.Len(t, notifs, 1)
+
+	// Retry — should claim, then revert because no broker
+	env.nd.RetryDispatch(ctx, &notifs[0])
+
+	// No dispatch call
+	assert.Empty(t, env.dispatcher.getCalls())
+
+	// Notification should be back to undispatched
+	allNotifs, err := env.store.GetNotifications(ctx, store.SubscriberTypeAgent, env.subscriber.Slug, false)
+	require.NoError(t, err)
+	for _, n := range allNotifs {
+		if n.ID == notifs[0].ID {
+			assert.False(t, n.Dispatched, "notification should be reverted to undispatched")
+		}
+	}
+}
+
+func TestRetryDispatch_NoDispatcher_Reverts(t *testing.T) {
+	env := setupRetryTest(t)
+	ctx := context.Background()
+
+	// Create a dispatcher that returns nil
+	ndNoDispatcher := NewNotificationDispatcher(
+		env.store, env.pub,
+		func() AgentDispatcher { return nil },
+		slog.Default(),
+	)
+
+	notifs, err := env.store.GetUndispatchedAgentNotifications(ctx, "")
+	require.NoError(t, err)
+	require.Len(t, notifs, 1)
+
+	// Retry — should claim, then revert because no dispatcher
+	ndNoDispatcher.RetryDispatch(ctx, &notifs[0])
+
+	// No dispatch call
+	assert.Empty(t, env.dispatcher.getCalls())
+
+	// Notification should be back to undispatched
+	allNotifs, err := env.store.GetNotifications(ctx, store.SubscriberTypeAgent, env.subscriber.Slug, false)
+	require.NoError(t, err)
+	for _, n := range allNotifs {
+		if n.ID == notifs[0].ID {
+			assert.False(t, n.Dispatched, "notification should be reverted to undispatched")
+		}
+	}
+}
+
+func TestRetryDispatch_SubscriberDeleted(t *testing.T) {
+	env := setupRetryTest(t)
+	ctx := context.Background()
+
+	notifs, err := env.store.GetUndispatchedAgentNotifications(ctx, "")
+	require.NoError(t, err)
+	require.Len(t, notifs, 1)
+
+	// Delete the subscriber agent
+	require.NoError(t, env.store.DeleteAgent(ctx, env.subscriber.ID))
+
+	// Retry — should claim, then find subscriber not found
+	env.nd.RetryDispatch(ctx, &notifs[0])
+
+	// No dispatch call
+	assert.Empty(t, env.dispatcher.getCalls())
+
+	// Notification should be reverted (subscriber might come back after restart)
+	allNotifs, err := env.store.GetNotifications(ctx, store.SubscriberTypeAgent, env.subscriber.Slug, false)
+	require.NoError(t, err)
+	for _, n := range allNotifs {
+		if n.ID == notifs[0].ID {
+			assert.False(t, n.Dispatched, "notification should be reverted when subscriber not found")
+		}
+	}
+}
+
+func TestSweepHandler_QueriesAndRetries(t *testing.T) {
+	env := setupRetryTest(t)
+	ctx := context.Background()
+
+	// Simulate server with just the notification dispatcher
+	srv := &Server{
+		store:                  env.store,
+		agentLifecycleLog:      slog.Default(),
+		notificationDispatcher: env.nd,
+	}
+
+	// Run the sweep handler
+	handler := srv.notificationDispatchSweepHandler()
+	handler(ctx)
+
+	// Verify dispatch was called
+	calls := env.dispatcher.getCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, env.subscriber.ID, calls[0].Agent.ID)
+
+	// Verify notification is now dispatched
+	notifs, err := env.store.GetUndispatchedAgentNotifications(ctx, "")
+	require.NoError(t, err)
+	assert.Empty(t, notifs, "no undispatched notifications should remain")
+}
+
+func TestSweepHandler_EmptyResultNoOp(t *testing.T) {
+	env := setupNotificationTest(t)
+	ctx := context.Background()
+
+	// No undispatched notifications exist — just the test subscription
+	srv := &Server{
+		store:                  env.store,
+		agentLifecycleLog:      slog.Default(),
+		notificationDispatcher: env.nd,
+	}
+
+	handler := srv.notificationDispatchSweepHandler()
+	handler(ctx)
+
+	// No dispatch calls
+	assert.Empty(t, env.dispatcher.getCalls())
+}
+
+func TestDrainUndispatchedNotifications_FiltersByBroker(t *testing.T) {
+	env := setupRetryTest(t)
+	ctx := context.Background()
+
+	// Create a second agent with a different broker, with an undispatched notification
+	broker2 := &store.RuntimeBroker{
+		ID:     tid("broker-2"),
+		Name:   "Other Broker",
+		Slug:   "other-broker",
+		Status: store.BrokerStatusOnline,
+	}
+	require.NoError(t, env.store.CreateRuntimeBroker(ctx, broker2))
+
+	otherSubscriber := &store.Agent{
+		ID:              api.NewUUID(),
+		Slug:            "other-subscriber",
+		Name:            "Other Subscriber",
+		Template:        "claude",
+		ProjectID:       env.project.ID,
+		Phase:           string(state.PhaseRunning),
+		RuntimeBrokerID: tid("broker-2"),
+		Visibility:      store.VisibilityPrivate,
+	}
+	require.NoError(t, env.store.CreateAgent(ctx, otherSubscriber))
+
+	otherSub := &store.NotificationSubscription{
+		ID:                api.NewUUID(),
+		Scope:             store.SubscriptionScopeAgent,
+		AgentID:           env.watched.ID,
+		SubscriberType:    store.SubscriberTypeAgent,
+		SubscriberID:      otherSubscriber.Slug,
+		ProjectID:         env.project.ID,
+		TriggerActivities: []string{"COMPLETED"},
+		CreatedAt:         time.Now().Add(-time.Minute),
+		CreatedBy:         "test",
+	}
+	require.NoError(t, env.store.CreateNotificationSubscription(ctx, otherSub))
+
+	otherNotif := &store.Notification{
+		ID:             api.NewUUID(),
+		SubscriptionID: otherSub.ID,
+		AgentID:        env.watched.ID,
+		ProjectID:      env.project.ID,
+		SubscriberType: store.SubscriberTypeAgent,
+		SubscriberID:   otherSubscriber.Slug,
+		Status:         "COMPLETED",
+		Message:        "watched-agent has reached a state of COMPLETED",
+		Dispatched:     false,
+		CreatedAt:      time.Now().Add(-2 * time.Minute),
+	}
+	require.NoError(t, env.store.CreateNotification(ctx, otherNotif))
+
+	// Drain for broker-1 only
+	srv := &Server{
+		store:                  env.store,
+		agentLifecycleLog:      slog.Default(),
+		notificationDispatcher: env.nd,
+	}
+	srv.drainUndispatchedNotifications(ctx, tid("broker-1"))
+
+	// Should only deliver the notification for the subscriber on broker-1
+	calls := env.dispatcher.getCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, env.subscriber.ID, calls[0].Agent.ID)
+
+	// The notification for broker-2's subscriber should still be undispatched
+	remaining, err := env.store.GetUndispatchedAgentNotifications(ctx, tid("broker-2"))
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, otherSubscriber.Slug, remaining[0].SubscriberID)
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3406,6 +3406,13 @@ func (s *Server) markBrokerOnline(brokerID, sessionID string) {
 	// offline or owned elsewhere. Async so it never blocks the connect path;
 	// idempotent + CAS-gated so concurrent drains execute each item once.
 	go s.reconcileBroker(context.Background(), brokerID)
+
+	// Notification redeliver (ptone/scion#495): drain undispatched agent
+	// notifications for agents on this broker. Async + CAS-gated, same
+	// pattern as reconcileBroker above.
+	if s.notificationDispatcher != nil {
+		go s.drainUndispatchedNotifications(context.Background(), brokerID)
+	}
 }
 
 // isWebSocketUpgrade checks if the request is a WebSocket upgrade request.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2653,6 +2653,7 @@ func (s *Server) StartBackgroundServices(ctx context.Context) {
 	s.scheduler.RegisterRecurringSingleton("broker-affinity-reap", 5, store.LockBrokerAffinityReap, s.brokerAffinityReapHandler())
 	s.scheduler.RegisterRecurringSingleton("broker-message-sweep", 5, store.LockBrokerMessageSweep, s.brokerMessageSweepHandler())
 	s.scheduler.RegisterRecurringSingleton("exposed-ports-sweep", 5, store.LockExposedPortsSweep, s.exposedPortsSweepHandler())
+	s.scheduler.RegisterRecurringSingleton("notification-dispatch-sweep", 5, store.LockNotificationDispatchSweep, s.notificationDispatchSweepHandler())
 
 	// Register GitHub resolution cache TTL eviction (every 10 minutes)
 	if s.ghResolutionStore != nil {

--- a/pkg/store/concurrency.go
+++ b/pkg/store/concurrency.go
@@ -82,6 +82,11 @@ const (
 	// running (stopped, deleted, etc.).
 	LockExposedPortsSweep AdvisoryLockKey = 0x5C10000C
 
+	// LockNotificationDispatchSweep guards the periodic undispatched-notification
+	// re-delivery sweep so only one replica per tick scans and retries agent
+	// notifications that were not dispatched (e.g. subscriber had no broker).
+	LockNotificationDispatchSweep AdvisoryLockKey = 0x5C10000D
+
 	// LockWorkspaceProvision is the CLASS ID for per-project workspace
 	// provisioning locks. It is used with the two-int advisory lock form
 	// pg_try_advisory_lock(classid, objid), where classid is this constant

--- a/pkg/store/entadapter/notification_store.go
+++ b/pkg/store/entadapter/notification_store.go
@@ -636,16 +636,35 @@ func (s *NotificationStore) GetUndispatchedAgentNotifications(ctx context.Contex
 
 	if brokerID != "" {
 		// Filter to notifications whose subscriber agent has this broker.
-		// Use a correlated EXISTS subquery against the agents table to avoid
-		// an Ent edge dependency.
+		// Use a raw WHERE predicate with a correlated EXISTS subquery
+		// against the agents table. sel.C() returns the properly-qualified
+		// and quoted column reference for the outer notifications table.
 		query = query.Where(func(sel *entsql.Selector) {
-			sub := entsql.Select("1").From(entsql.Table("agents")).
-				Where(entsql.And(
-					entsql.ColumnsEQ("agents.slug", sel.C(notification.FieldSubscriberID)),
-					entsql.ColumnsEQ("agents.project_id", sel.C(notification.FieldProjectID)),
-					entsql.EQ("agents.runtime_broker_id", brokerID),
-				))
-			sel.Where(entsql.Exists(sub))
+			subIDCol := sel.C(notification.FieldSubscriberID)
+			projIDCol := sel.C(notification.FieldProjectID)
+			sel.Where(entsql.P(func(b *entsql.Builder) {
+				b.WriteString("EXISTS (SELECT 1 FROM ")
+				b.Ident("agents")
+				b.WriteString(" WHERE ")
+				b.Ident("agents")
+				b.WriteString(".")
+				b.Ident("slug")
+				b.WriteString(" = ")
+				b.WriteString(subIDCol)
+				b.WriteString(" AND ")
+				b.Ident("agents")
+				b.WriteString(".")
+				b.Ident("project_id")
+				b.WriteString(" = ")
+				b.WriteString(projIDCol)
+				b.WriteString(" AND ")
+				b.Ident("agents")
+				b.WriteString(".")
+				b.Ident("runtime_broker_id")
+				b.WriteString(" = ")
+				b.Arg(brokerID)
+				b.WriteString(")")
+			}))
 		})
 	}
 

--- a/pkg/store/entadapter/notification_store.go
+++ b/pkg/store/entadapter/notification_store.go
@@ -618,21 +618,26 @@ const undispatchedGracePeriod = 60 * time.Second
 const undispatchedBatchLimit = 100
 
 // GetUndispatchedAgentNotifications returns agent-targeted notifications with
-// dispatched=false, created before a 60s grace period, ordered oldest-first,
-// limited to 100 rows.
+// dispatched=false, ordered oldest-first, limited to 100 rows.
 //
-// When brokerID is non-empty, only notifications whose subscriber agent has
-// RuntimeBrokerID == brokerID are returned (broker-connect hook). When empty,
-// all undispatched agent notifications are returned (sweep backstop).
+// When brokerID is empty (sweep mode), a 60s grace period is applied so the
+// sweep does not race with an in-flight primary dispatch. When brokerID is
+// non-empty (broker-connect hook), no grace period is applied — the hook fires
+// precisely because the broker just came online, so even very recent
+// notifications should be drained immediately.
 func (s *NotificationStore) GetUndispatchedAgentNotifications(ctx context.Context, brokerID string) ([]store.Notification, error) {
-	cutoff := time.Now().Add(-undispatchedGracePeriod)
-
 	query := s.client.Notification.Query().
 		Where(
 			notification.DispatchedEQ(false),
 			notification.SubscriberTypeEQ(store.SubscriberTypeAgent),
-			notification.CreatedLT(cutoff),
 		)
+
+	// Grace period only in sweep mode (empty brokerID) to avoid racing with
+	// the primary dispatch path's 30s retry + margin.
+	if brokerID == "" {
+		cutoff := time.Now().Add(-undispatchedGracePeriod)
+		query = query.Where(notification.CreatedLT(cutoff))
+	}
 
 	if brokerID != "" {
 		// Filter to notifications whose subscriber agent has this broker.

--- a/pkg/store/entadapter/notification_store.go
+++ b/pkg/store/entadapter/notification_store.go
@@ -569,6 +569,96 @@ func notifsToStore(rows []*ent.Notification) []store.Notification {
 	return out
 }
 
+// ClaimNotificationForDispatch atomically claims an undispatched notification
+// for delivery by CAS-updating dispatched from false to true. Returns true if
+// this caller won the claim, false if the notification was already dispatched or
+// does not exist.
+func (s *NotificationStore) ClaimNotificationForDispatch(ctx context.Context, id string) (bool, error) {
+	uid, err := parseUUID(id)
+	if err != nil {
+		return false, err
+	}
+
+	affected, err := s.client.Notification.Update().
+		Where(
+			notification.IDEQ(uid),
+			notification.DispatchedEQ(false),
+		).
+		SetDispatched(true).
+		Save(ctx)
+	if err != nil {
+		return false, mapError(err)
+	}
+
+	return affected > 0, nil
+}
+
+// UnmarkNotificationDispatched reverts a notification's dispatched flag to false
+// so a future sweep can retry delivery.
+func (s *NotificationStore) UnmarkNotificationDispatched(ctx context.Context, id string) error {
+	uid, err := parseUUID(id)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.client.Notification.Update().
+		Where(notification.IDEQ(uid)).
+		SetDispatched(false).
+		Save(ctx)
+	return mapError(err)
+}
+
+// undispatchedGracePeriod is the minimum age of an undispatched notification
+// before the sweep picks it up. This prevents racing with an in-flight primary
+// dispatch (whose 30s retry + margin is well within this window).
+const undispatchedGracePeriod = 60 * time.Second
+
+// undispatchedBatchLimit caps the number of undispatched notifications returned
+// per query to avoid loading unbounded rows into memory.
+const undispatchedBatchLimit = 100
+
+// GetUndispatchedAgentNotifications returns agent-targeted notifications with
+// dispatched=false, created before a 60s grace period, ordered oldest-first,
+// limited to 100 rows.
+//
+// When brokerID is non-empty, only notifications whose subscriber agent has
+// RuntimeBrokerID == brokerID are returned (broker-connect hook). When empty,
+// all undispatched agent notifications are returned (sweep backstop).
+func (s *NotificationStore) GetUndispatchedAgentNotifications(ctx context.Context, brokerID string) ([]store.Notification, error) {
+	cutoff := time.Now().Add(-undispatchedGracePeriod)
+
+	query := s.client.Notification.Query().
+		Where(
+			notification.DispatchedEQ(false),
+			notification.SubscriberTypeEQ(store.SubscriberTypeAgent),
+			notification.CreatedLT(cutoff),
+		)
+
+	if brokerID != "" {
+		// Filter to notifications whose subscriber agent has this broker.
+		// Use a correlated EXISTS subquery against the agents table to avoid
+		// an Ent edge dependency.
+		query = query.Where(func(sel *entsql.Selector) {
+			sub := entsql.Select("1").From(entsql.Table("agents")).
+				Where(entsql.And(
+					entsql.ColumnsEQ("agents.slug", sel.C(notification.FieldSubscriberID)),
+					entsql.ColumnsEQ("agents.project_id", sel.C(notification.FieldProjectID)),
+					entsql.EQ("agents.runtime_broker_id", brokerID),
+				))
+			sel.Where(entsql.Exists(sub))
+		})
+	}
+
+	rows, err := query.
+		Order(notification.ByCreated()).
+		Limit(undispatchedBatchLimit).
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return notifsToStore(rows), nil
+}
+
 // ----------------------------------------------------------------------------
 // Subscription Template Operations
 // ----------------------------------------------------------------------------

--- a/pkg/store/entadapter/notification_store.go
+++ b/pkg/store/entadapter/notification_store.go
@@ -637,6 +637,37 @@ func (s *NotificationStore) GetUndispatchedAgentNotifications(ctx context.Contex
 	if brokerID == "" {
 		cutoff := time.Now().Add(-undispatchedGracePeriod)
 		query = query.Where(notification.CreatedLT(cutoff))
+
+		// Only return notifications whose subscriber agent currently has a
+		// RuntimeBrokerID. Without this filter the sweep would claim
+		// notifications for broker-less agents, fail to deliver them, and
+		// revert the claim — wasting cycles and starving deliverable
+		// notifications behind them (head-of-line blocking).
+		query = query.Where(func(sel *entsql.Selector) {
+			subIDCol := sel.C(notification.FieldSubscriberID)
+			projIDCol := sel.C(notification.FieldProjectID)
+			sel.Where(entsql.P(func(b *entsql.Builder) {
+				b.WriteString("EXISTS (SELECT 1 FROM ")
+				b.Ident("agents")
+				b.WriteString(" WHERE ")
+				b.Ident("agents")
+				b.WriteString(".")
+				b.Ident("slug")
+				b.WriteString(" = ")
+				b.WriteString(subIDCol)
+				b.WriteString(" AND ")
+				b.Ident("agents")
+				b.WriteString(".")
+				b.Ident("project_id")
+				b.WriteString(" = ")
+				b.WriteString(projIDCol)
+				b.WriteString(" AND ")
+				b.Ident("agents")
+				b.WriteString(".")
+				b.Ident("runtime_broker_id")
+				b.WriteString(" != '')")
+			}))
+		})
 	}
 
 	if brokerID != "" {

--- a/pkg/store/entadapter/notification_store_test.go
+++ b/pkg/store/entadapter/notification_store_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/GoogleCloudPlatform/scion/pkg/store/enttest"
@@ -301,4 +302,271 @@ func (p *countingPublisher) count(t NotificationEventType) int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.counts[t]
+}
+
+// ---------------------------------------------------------------------------
+// ClaimNotificationForDispatch tests
+// ---------------------------------------------------------------------------
+
+func TestClaimNotificationForDispatch_CAS(t *testing.T) {
+	ctx := context.Background()
+	s := newTestNotificationStore(t)
+
+	notifID := uuid.NewString()
+	require.NoError(t, s.CreateNotification(ctx, &store.Notification{
+		ID:             notifID,
+		SubscriptionID: uuid.NewString(),
+		AgentID:        uuid.NewString(),
+		ProjectID:      uuid.NewString(),
+		SubscriberType: "agent",
+		SubscriberID:   "some-agent",
+		Status:         "COMPLETED",
+		Message:        "done",
+	}))
+
+	// First claim should succeed.
+	claimed, err := s.ClaimNotificationForDispatch(ctx, notifID)
+	require.NoError(t, err)
+	assert.True(t, claimed, "first claim should succeed")
+
+	// Second claim should fail (already dispatched).
+	claimed2, err := s.ClaimNotificationForDispatch(ctx, notifID)
+	require.NoError(t, err)
+	assert.False(t, claimed2, "second claim must fail")
+
+	// Unknown notification returns false, nil.
+	claimed3, err := s.ClaimNotificationForDispatch(ctx, uuid.NewString())
+	require.NoError(t, err)
+	assert.False(t, claimed3, "unknown notification must not be claimed")
+}
+
+func TestClaimNotificationForDispatch_Concurrent(t *testing.T) {
+	ctx := context.Background()
+	s := newTestNotificationStore(t)
+
+	notifID := uuid.NewString()
+	require.NoError(t, s.CreateNotification(ctx, &store.Notification{
+		ID:             notifID,
+		SubscriptionID: uuid.NewString(),
+		AgentID:        uuid.NewString(),
+		ProjectID:      uuid.NewString(),
+		SubscriberType: "agent",
+		SubscriberID:   "some-agent",
+		Status:         "COMPLETED",
+		Message:        "done",
+	}))
+
+	const racers = 8
+	wins := make(chan bool, racers)
+	var wg sync.WaitGroup
+	wg.Add(racers)
+	for i := 0; i < racers; i++ {
+		go func() {
+			defer wg.Done()
+			claimed, err := s.ClaimNotificationForDispatch(ctx, notifID)
+			if err == nil {
+				wins <- claimed
+			}
+		}()
+	}
+	wg.Wait()
+	close(wins)
+
+	var winCount int
+	for w := range wins {
+		if w {
+			winCount++
+		}
+	}
+	assert.Equal(t, 1, winCount, "exactly one racer must win the claim")
+}
+
+// ---------------------------------------------------------------------------
+// UnmarkNotificationDispatched tests
+// ---------------------------------------------------------------------------
+
+func TestUnmarkNotificationDispatched(t *testing.T) {
+	ctx := context.Background()
+	s := newTestNotificationStore(t)
+
+	notifID := uuid.NewString()
+	require.NoError(t, s.CreateNotification(ctx, &store.Notification{
+		ID:             notifID,
+		SubscriptionID: uuid.NewString(),
+		AgentID:        uuid.NewString(),
+		ProjectID:      uuid.NewString(),
+		SubscriberType: "agent",
+		SubscriberID:   "some-agent",
+		Status:         "COMPLETED",
+		Message:        "done",
+	}))
+
+	// Mark dispatched.
+	require.NoError(t, s.MarkNotificationDispatched(ctx, notifID))
+
+	// Unmark.
+	require.NoError(t, s.UnmarkNotificationDispatched(ctx, notifID))
+
+	// Should be claimable again.
+	claimed, err := s.ClaimNotificationForDispatch(ctx, notifID)
+	require.NoError(t, err)
+	assert.True(t, claimed, "notification should be claimable after unmark")
+}
+
+// ---------------------------------------------------------------------------
+// GetUndispatchedAgentNotifications tests
+// ---------------------------------------------------------------------------
+
+func TestGetUndispatchedAgentNotifications_SweepMode(t *testing.T) {
+	ctx := context.Background()
+	client := enttest.NewClient(t)
+	s := NewNotificationStore(client)
+
+	projectID := uuid.New()
+	oldTime := time.Now().Add(-2 * time.Minute) // beyond 60s grace period
+
+	// Create an old undispatched agent notification (beyond 60s grace period).
+	require.NoError(t, s.CreateNotification(ctx, &store.Notification{
+		ID:             uuid.NewString(),
+		SubscriptionID: uuid.NewString(),
+		AgentID:        uuid.NewString(),
+		ProjectID:      projectID.String(),
+		SubscriberType: store.SubscriberTypeAgent,
+		SubscriberID:   "agent-a",
+		Status:         "COMPLETED",
+		Message:        "done",
+		CreatedAt:      oldTime, // set at creation (immutable field)
+	}))
+
+	// Create a recent undispatched agent notification (within grace period).
+	require.NoError(t, s.CreateNotification(ctx, &store.Notification{
+		ID:             uuid.NewString(),
+		SubscriptionID: uuid.NewString(),
+		AgentID:        uuid.NewString(),
+		ProjectID:      projectID.String(),
+		SubscriberType: store.SubscriberTypeAgent,
+		SubscriberID:   "agent-b",
+		Status:         "COMPLETED",
+		Message:        "also done",
+		// CreatedAt defaults to now (within grace period)
+	}))
+
+	// Create a dispatched agent notification (should be excluded).
+	require.NoError(t, s.CreateNotification(ctx, &store.Notification{
+		ID:             uuid.NewString(),
+		SubscriptionID: uuid.NewString(),
+		AgentID:        uuid.NewString(),
+		ProjectID:      projectID.String(),
+		SubscriberType: store.SubscriberTypeAgent,
+		SubscriberID:   "agent-c",
+		Status:         "COMPLETED",
+		Message:        "dispatched",
+		Dispatched:     true,
+		CreatedAt:      oldTime,
+	}))
+
+	// Create an undispatched USER notification (should be excluded).
+	require.NoError(t, s.CreateNotification(ctx, &store.Notification{
+		ID:             uuid.NewString(),
+		SubscriptionID: uuid.NewString(),
+		AgentID:        uuid.NewString(),
+		ProjectID:      projectID.String(),
+		SubscriberType: "user",
+		SubscriberID:   "user-1",
+		Status:         "COMPLETED",
+		Message:        "user notif",
+		CreatedAt:      oldTime,
+	}))
+
+	// Sweep mode (empty brokerID)
+	notifs, err := s.GetUndispatchedAgentNotifications(ctx, "")
+	require.NoError(t, err)
+
+	// Should only return the old agent notification
+	require.Len(t, notifs, 1)
+	assert.Equal(t, "agent-a", notifs[0].SubscriberID)
+	assert.False(t, notifs[0].Dispatched)
+}
+
+func TestGetUndispatchedAgentNotifications_BrokerFilter(t *testing.T) {
+	ctx := context.Background()
+	client := enttest.NewClient(t)
+	s := NewNotificationStore(client)
+
+	projectID := uuid.New()
+	brokerID := "broker-for-test"
+
+	// Create a project (required as FK for agents).
+	_, err := client.Project.Create().
+		SetID(projectID).
+		SetName("Test Project").
+		SetSlug("test-project").
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Create an agent with the target broker.
+	agentID := uuid.New()
+	_, err = client.Agent.Create().
+		SetID(agentID).
+		SetSlug("agent-on-broker").
+		SetName("Agent On Broker").
+		SetProjectID(projectID).
+		SetRuntimeBrokerID(brokerID).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Create another agent with a different broker.
+	otherAgentID := uuid.New()
+	_, err = client.Agent.Create().
+		SetID(otherAgentID).
+		SetSlug("agent-other-broker").
+		SetName("Agent Other Broker").
+		SetProjectID(projectID).
+		SetRuntimeBrokerID("different-broker").
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Create undispatched notifications for both agents, backdated past grace period.
+	oldTime := time.Now().Add(-2 * time.Minute)
+
+	require.NoError(t, s.CreateNotification(ctx, &store.Notification{
+		ID:             uuid.NewString(),
+		SubscriptionID: uuid.NewString(),
+		AgentID:        uuid.NewString(),
+		ProjectID:      projectID.String(),
+		SubscriberType: store.SubscriberTypeAgent,
+		SubscriberID:   "agent-on-broker",
+		Status:         "COMPLETED",
+		Message:        "msg1",
+		CreatedAt:      oldTime,
+	}))
+
+	require.NoError(t, s.CreateNotification(ctx, &store.Notification{
+		ID:             uuid.NewString(),
+		SubscriptionID: uuid.NewString(),
+		AgentID:        uuid.NewString(),
+		ProjectID:      projectID.String(),
+		SubscriberType: store.SubscriberTypeAgent,
+		SubscriberID:   "agent-other-broker",
+		Status:         "COMPLETED",
+		Message:        "msg2",
+		CreatedAt:      oldTime,
+	}))
+
+	// Filter by brokerID.
+	notifs, err := s.GetUndispatchedAgentNotifications(ctx, brokerID)
+	require.NoError(t, err)
+	require.Len(t, notifs, 1, "should only return notifications for agents on the target broker")
+	assert.Equal(t, "agent-on-broker", notifs[0].SubscriberID)
+
+	// Filter by the other broker.
+	notifs2, err := s.GetUndispatchedAgentNotifications(ctx, "different-broker")
+	require.NoError(t, err)
+	require.Len(t, notifs2, 1)
+	assert.Equal(t, "agent-other-broker", notifs2[0].SubscriberID)
+
+	// Sweep mode (all) returns both.
+	all, err := s.GetUndispatchedAgentNotifications(ctx, "")
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
 }

--- a/pkg/store/entadapter/notification_store_test.go
+++ b/pkg/store/entadapter/notification_store_test.go
@@ -425,6 +425,23 @@ func TestGetUndispatchedAgentNotifications_SweepMode(t *testing.T) {
 	projectID := uuid.New()
 	oldTime := time.Now().Add(-2 * time.Minute) // beyond 60s grace period
 
+	// Create project and agent records required for the sweep-mode EXISTS
+	// subquery (which filters for agents with a non-empty RuntimeBrokerID).
+	_, err := client.Project.Create().
+		SetID(projectID).
+		SetName("Sweep Project").
+		SetSlug("sweep-project").
+		Save(ctx)
+	require.NoError(t, err)
+	_, err = client.Agent.Create().
+		SetID(uuid.New()).
+		SetSlug("agent-a").
+		SetName("Agent A").
+		SetProjectID(projectID).
+		SetRuntimeBrokerID("some-broker").
+		Save(ctx)
+	require.NoError(t, err)
+
 	// Create an old undispatched agent notification (beyond 60s grace period).
 	require.NoError(t, s.CreateNotification(ctx, &store.Notification{
 		ID:             uuid.NewString(),

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1021,12 +1021,15 @@ type NotificationStore interface {
 	UnmarkNotificationDispatched(ctx context.Context, id string) error
 
 	// GetUndispatchedAgentNotifications returns agent-targeted notifications
-	// with dispatched=false, created before a grace period (60s).
+	// with dispatched=false.
 	//
-	// If brokerID is non-empty, only notifications whose subscriber agent
-	// currently has RuntimeBrokerID == brokerID are returned (broker-connect
-	// fast-path). If brokerID is empty, all undispatched agent notifications
-	// are returned (sweep backstop).
+	// If brokerID is empty (sweep mode), a 60s grace period is applied so
+	// the sweep does not race with an in-flight primary dispatch. All
+	// undispatched agent notifications older than 60s are returned.
+	//
+	// If brokerID is non-empty (broker-connect fast-path), no grace period
+	// is applied and only notifications whose subscriber agent currently
+	// has RuntimeBrokerID == brokerID are returned.
 	//
 	// Results are ordered by created_at ASC (oldest first), limited to 100.
 	GetUndispatchedAgentNotifications(ctx context.Context, brokerID string) ([]Notification, error)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1007,6 +1007,30 @@ type NotificationStore interface {
 	// for a given subscription. Returns ("", nil) if no notifications exist.
 	GetLastNotificationStatus(ctx context.Context, subscriptionID string) (string, error)
 
+	// ClaimNotificationForDispatch atomically transitions a notification from
+	// dispatched=false to dispatched=true, returning claimed=true if this caller
+	// won the CAS race. This is the retry-path concurrency primitive: exactly
+	// one caller (sweep or broker-connect hook) claims each notification.
+	// Returns (false, nil) if the notification is already dispatched or does
+	// not exist.
+	ClaimNotificationForDispatch(ctx context.Context, id string) (claimed bool, err error)
+
+	// UnmarkNotificationDispatched reverts a claimed notification back to
+	// dispatched=false so a future sweep can retry. Used when delivery cannot
+	// proceed (no dispatcher, no broker) after an optimistic claim.
+	UnmarkNotificationDispatched(ctx context.Context, id string) error
+
+	// GetUndispatchedAgentNotifications returns agent-targeted notifications
+	// with dispatched=false, created before a grace period (60s).
+	//
+	// If brokerID is non-empty, only notifications whose subscriber agent
+	// currently has RuntimeBrokerID == brokerID are returned (broker-connect
+	// fast-path). If brokerID is empty, all undispatched agent notifications
+	// are returned (sweep backstop).
+	//
+	// Results are ordered by created_at ASC (oldest first), limited to 100.
+	GetUndispatchedAgentNotifications(ctx context.Context, brokerID string) ([]Notification, error)
+
 	// CreateSubscriptionTemplate creates a new subscription template.
 	CreateSubscriptionTemplate(ctx context.Context, tmpl *SubscriptionTemplate) error
 


### PR DESCRIPTION
Adds periodic sweep backstop + broker-connect fast-path hook to redeliver agent notifications that could not be dispatched (no RuntimeBrokerID / no dispatcher). CAS claims prevent double-delivery between the two paths. 6 commits, 8 files, 1027 lines.

Key changes:
- Store: ClaimNotificationForDispatch (atomic CAS), UnmarkNotificationDispatched (revert), GetUndispatchedAgentNotifications (filtered query)
- Hub: RetryDispatch on NotificationDispatcher, periodic sweep handler (5-min singleton), broker-connect drain hook
- Schema: partial index on undispatched notifications
- 10+ tests covering CAS contention, revert semantics, sweep/drain paths

Ref: ptone/scion#495
