### PR TITLE
fix(hub): two-pass as_needed resolution for env-gather completeness

### DIFF
--- a/pkg/hub/as_needed_resolution_test.go
+++ b/pkg/hub/as_needed_resolution_test.go
@@ -1,0 +1,651 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// --- resolveAsNeededForKeys tests ---
+
+func TestResolveAsNeededForKeys_EnvVars(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	hubID := "test-hub-resolve"
+
+	// Create hub-scope as_needed env var
+	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
+		ID:            tid("env-asneeded-1"),
+		Key:           "GEMINI_API_KEY",
+		Value:         "gemini-key-value",
+		Scope:         store.ScopeHub,
+		ScopeID:       hubID,
+		InjectionMode: store.InjectionModeAsNeeded,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create hub-scope always env var (should NOT be returned)
+	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
+		ID:            tid("env-always-1"),
+		Key:           "ALWAYS_KEY",
+		Value:         "always-value",
+		Scope:         store.ScopeHub,
+		ScopeID:       hubID,
+		InjectionMode: store.InjectionModeAlways,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetHubID(hubID)
+
+	agent := &store.Agent{
+		ID:            "agent-resolve-test",
+		Name:          "resolve-test",
+		OwnerID:       "user-1",
+		ProjectID:     "project-1",
+		AppliedConfig: &store.AgentAppliedConfig{},
+	}
+
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{"GEMINI_API_KEY", "OTHER_KEY"})
+
+	if v, ok := result["GEMINI_API_KEY"]; !ok {
+		t.Error("expected GEMINI_API_KEY in result")
+	} else if v != "gemini-key-value" {
+		t.Errorf("GEMINI_API_KEY = %q, want %q", v, "gemini-key-value")
+	}
+
+	if _, ok := result["ALWAYS_KEY"]; ok {
+		t.Error("ALWAYS_KEY (always mode) should not be in result")
+	}
+
+	if _, ok := result["OTHER_KEY"]; ok {
+		t.Error("OTHER_KEY should not be in result (not in storage)")
+	}
+}
+
+func TestResolveAsNeededForKeys_Secrets(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	hubID := "test-hub-secrets"
+
+	mockClient := &mockRuntimeBrokerClient{}
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetHubID(hubID)
+	d.SetSecretBackend(&mockSecretBackend{
+		secrets: []secret.SecretWithValue{
+			{
+				SecretMeta: secret.SecretMeta{
+					Name:          "gemini-secret",
+					SecretType:    "environment",
+					Target:        "GEMINI_API_KEY",
+					Scope:         "hub",
+					ScopeID:       hubID,
+					InjectionMode: "as_needed",
+				},
+				Value: "secret-gemini-value",
+			},
+			{
+				SecretMeta: secret.SecretMeta{
+					Name:          "always-secret",
+					SecretType:    "environment",
+					Target:        "ALWAYS_SECRET",
+					Scope:         "hub",
+					ScopeID:       hubID,
+					InjectionMode: "always",
+				},
+				Value: "always-secret-value",
+			},
+			{
+				SecretMeta: secret.SecretMeta{
+					Name:          "file-secret",
+					SecretType:    "file",
+					Target:        "/tmp/secret.json",
+					Scope:         "hub",
+					ScopeID:       hubID,
+					InjectionMode: "as_needed",
+				},
+				Value: "file-secret-content",
+			},
+		},
+	})
+
+	agent := &store.Agent{
+		ID:            "agent-secret-test",
+		Name:          "secret-test",
+		OwnerID:       "user-1",
+		ProjectID:     "project-1",
+		AppliedConfig: &store.AgentAppliedConfig{},
+	}
+
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{"GEMINI_API_KEY", "ALWAYS_SECRET", "/tmp/secret.json"})
+
+	if v, ok := result["GEMINI_API_KEY"]; !ok {
+		t.Error("expected GEMINI_API_KEY in result (as_needed environment secret)")
+	} else if v != "secret-gemini-value" {
+		t.Errorf("GEMINI_API_KEY = %q, want %q", v, "secret-gemini-value")
+	}
+
+	if _, ok := result["ALWAYS_SECRET"]; ok {
+		t.Error("ALWAYS_SECRET should not be in result (always mode)")
+	}
+
+	if _, ok := result["/tmp/secret.json"]; ok {
+		t.Error("file-type secret should not be in result (only environment-type handled)")
+	}
+}
+
+func TestResolveAsNeededForKeys_SecretNameFallback(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	hubID := "test-hub-fallback"
+
+	mockClient := &mockRuntimeBrokerClient{}
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetHubID(hubID)
+	d.SetSecretBackend(&mockSecretBackend{
+		secrets: []secret.SecretWithValue{
+			{
+				SecretMeta: secret.SecretMeta{
+					Name:          "MY_API_KEY",
+					SecretType:    "environment",
+					Target:        "", // Empty target — should fall back to Name
+					Scope:         "hub",
+					ScopeID:       hubID,
+					InjectionMode: "as_needed",
+				},
+				Value: "api-key-value",
+			},
+		},
+	})
+
+	agent := &store.Agent{
+		ID:            "agent-fallback-test",
+		Name:          "fallback-test",
+		OwnerID:       "user-1",
+		ProjectID:     "project-1",
+		AppliedConfig: &store.AgentAppliedConfig{},
+	}
+
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{"MY_API_KEY"})
+
+	if v, ok := result["MY_API_KEY"]; !ok {
+		t.Error("expected MY_API_KEY in result (secret with empty Target should fall back to Name)")
+	} else if v != "api-key-value" {
+		t.Errorf("MY_API_KEY = %q, want %q", v, "api-key-value")
+	}
+}
+
+func TestResolveAsNeededForKeys_ScopePrecedence(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	hubID := "test-hub-precedence"
+
+	// Create hub-scope as_needed env var
+	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
+		ID:            tid("env-hub-prec"),
+		Key:           "API_KEY",
+		Value:         "hub-value",
+		Scope:         store.ScopeHub,
+		ScopeID:       hubID,
+		InjectionMode: store.InjectionModeAsNeeded,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create user-scope as_needed env var (higher precedence)
+	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
+		ID:            tid("env-user-prec"),
+		Key:           "API_KEY",
+		Value:         "user-value",
+		Scope:         store.ScopeUser,
+		ScopeID:       "user-prec-1",
+		InjectionMode: store.InjectionModeAsNeeded,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetHubID(hubID)
+
+	agent := &store.Agent{
+		ID:            "agent-prec-test",
+		Name:          "prec-test",
+		OwnerID:       "user-prec-1",
+		ProjectID:     "project-prec-1",
+		AppliedConfig: &store.AgentAppliedConfig{},
+	}
+
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{"API_KEY"})
+
+	// User scope should win over hub scope (higher precedence, last-wins)
+	if v, ok := result["API_KEY"]; !ok {
+		t.Error("expected API_KEY in result")
+	} else if v != "user-value" {
+		t.Errorf("API_KEY = %q, want %q (user scope should win over hub scope)", v, "user-value")
+	}
+}
+
+func TestResolveAsNeededForKeys_NoBackend(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	mockClient := &mockRuntimeBrokerClient{}
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetHubID("test-hub-nobackend")
+
+	agent := &store.Agent{
+		ID:            "agent-nobackend",
+		Name:          "nobackend",
+		OwnerID:       "user-1",
+		ProjectID:     "project-1",
+		AppliedConfig: &store.AgentAppliedConfig{},
+	}
+
+	// Should not panic with nil secret backend
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{"SOME_KEY"})
+
+	if len(result) != 0 {
+		t.Errorf("expected empty result with no matching env vars and no secret backend, got %v", result)
+	}
+}
+
+func TestResolveAsNeededForKeys_EmptyKeys(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	mockClient := &mockRuntimeBrokerClient{}
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetHubID("test-hub-empty")
+
+	agent := &store.Agent{
+		ID:            "agent-empty-keys",
+		Name:          "empty-keys",
+		OwnerID:       "user-1",
+		ProjectID:     "project-1",
+		AppliedConfig: &store.AgentAppliedConfig{},
+	}
+
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{})
+
+	if len(result) != 0 {
+		t.Errorf("expected empty result for empty keys, got %v", result)
+	}
+}
+
+func TestResolveAsNeededForKeys_EnvVarPriorityOverSecret(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	hubID := "test-hub-priority"
+
+	// Create hub-scope as_needed env var
+	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
+		ID:            tid("env-priority"),
+		Key:           "SHARED_KEY",
+		Value:         "env-var-value",
+		Scope:         store.ScopeHub,
+		ScopeID:       hubID,
+		InjectionMode: store.InjectionModeAsNeeded,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetHubID(hubID)
+	d.SetSecretBackend(&mockSecretBackend{
+		secrets: []secret.SecretWithValue{
+			{
+				SecretMeta: secret.SecretMeta{
+					Name:          "shared-secret",
+					SecretType:    "environment",
+					Target:        "SHARED_KEY",
+					Scope:         "hub",
+					ScopeID:       hubID,
+					InjectionMode: "as_needed",
+				},
+				Value: "secret-value",
+			},
+		},
+	})
+
+	agent := &store.Agent{
+		ID:            "agent-priority-test",
+		Name:          "priority-test",
+		OwnerID:       "user-1",
+		ProjectID:     "project-1",
+		AppliedConfig: &store.AgentAppliedConfig{},
+	}
+
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{"SHARED_KEY"})
+
+	// Env var should be found first; secret should not overwrite (alreadySet check)
+	if v, ok := result["SHARED_KEY"]; !ok {
+		t.Error("expected SHARED_KEY in result")
+	} else if v != "env-var-value" {
+		t.Errorf("SHARED_KEY = %q, want %q (env var should take precedence over secret for same key)", v, "env-var-value")
+	}
+}
+
+// --- Two-pass flow integration tests ---
+
+// gatherMockBrokerClient is a test mock that can return env requirements from
+// CreateAgentWithGather, simulating the broker's 202 response with needs.
+type gatherMockBrokerClient struct {
+	mockRuntimeBrokerClient
+
+	// gatherEnvReqs is returned on the first CreateAgentWithGather call.
+	gatherEnvReqs *RemoteEnvRequirementsResponse
+
+	// finalizeEnvReqs is returned on subsequent CreateAgentWithGather calls
+	// (simulating the DispatchFinalizeEnv replay). If nil, the finalize
+	// succeeds (returns a normal response).
+	finalizeEnvReqs *RemoteEnvRequirementsResponse
+
+	callCount int
+}
+
+func (m *gatherMockBrokerClient) CreateAgentWithGather(ctx context.Context, brokerID, brokerEndpoint string, req *RemoteCreateAgentRequest) (*RemoteAgentResponse, *RemoteEnvRequirementsResponse, error) {
+	m.callCount++
+	m.createCalled = true
+	m.lastBrokerID = brokerID
+	m.lastEndpoint = brokerEndpoint
+	m.lastCreateReq = req
+
+	if m.returnErr != nil {
+		return nil, nil, m.returnErr
+	}
+
+	// First call: return env requirements (simulates broker 202)
+	if m.callCount == 1 && m.gatherEnvReqs != nil {
+		return nil, m.gatherEnvReqs, nil
+	}
+
+	// Subsequent calls (finalize): check if still missing
+	if m.callCount > 1 && m.finalizeEnvReqs != nil {
+		return nil, m.finalizeEnvReqs, nil
+	}
+
+	// Success case: all env satisfied
+	return &RemoteAgentResponse{
+		Agent: &RemoteAgentInfo{
+			ID:    req.ID,
+			Slug:  req.Slug,
+			Name:  req.Name,
+			Phase: "running",
+		},
+		Created: true,
+	}, nil, nil
+}
+
+func TestDispatchAgentCreateWithGather_TwoPass_FullResolution(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	hubID := "test-hub-twopass"
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-twopass"),
+		Name:     "twopass-broker",
+		Slug:     "twopass-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create hub-scope as_needed env var that should satisfy the need
+	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
+		ID:            tid("env-twopass"),
+		Key:           "GEMINI_API_KEY",
+		Value:         "resolved-gemini-key",
+		Scope:         store.ScopeHub,
+		ScopeID:       hubID,
+		InjectionMode: store.InjectionModeAsNeeded,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := &gatherMockBrokerClient{
+		gatherEnvReqs: &RemoteEnvRequirementsResponse{
+			AgentID:  "agent-twopass",
+			Required: []string{"GEMINI_API_KEY"},
+			HubHas:   []string{},
+			Needs:    []string{"GEMINI_API_KEY"},
+		},
+		// finalizeEnvReqs is nil → finalize succeeds
+	}
+
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetHubID(hubID)
+
+	agent := &store.Agent{
+		ID:              tid("agent-twopass"),
+		Name:            "twopass-agent",
+		Slug:            "twopass-agent",
+		ProjectID:       "project-twopass",
+		OwnerID:         "user-twopass",
+		RuntimeBrokerID: broker.ID,
+		AppliedConfig:   &store.AgentAppliedConfig{},
+	}
+
+	envReqs, err := d.DispatchAgentCreateWithGather(ctx, agent)
+	if err != nil {
+		t.Fatalf("DispatchAgentCreateWithGather: %v", err)
+	}
+
+	// The second pass should have resolved all needs — no env requirements returned
+	if envReqs != nil {
+		t.Errorf("expected nil envReqs (all needs resolved by as_needed), got %+v", envReqs)
+	}
+
+	// The broker should have been called twice (initial + finalize)
+	if mockClient.callCount != 2 {
+		t.Errorf("expected 2 broker calls (initial + finalize), got %d", mockClient.callCount)
+	}
+}
+
+func TestDispatchAgentCreateWithGather_TwoPass_PartialResolution(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	hubID := "test-hub-partial"
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-partial"),
+		Name:     "partial-broker",
+		Slug:     "partial-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only create one of the two needed keys
+	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
+		ID:            tid("env-partial"),
+		Key:           "KNOWN_KEY",
+		Value:         "known-value",
+		Scope:         store.ScopeHub,
+		ScopeID:       hubID,
+		InjectionMode: store.InjectionModeAsNeeded,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := &gatherMockBrokerClient{
+		gatherEnvReqs: &RemoteEnvRequirementsResponse{
+			AgentID:  "agent-partial",
+			Required: []string{"KNOWN_KEY", "UNKNOWN_KEY"},
+			HubHas:   []string{},
+			Needs:    []string{"KNOWN_KEY", "UNKNOWN_KEY"},
+		},
+		// Finalize will still report UNKNOWN_KEY as missing
+		finalizeEnvReqs: &RemoteEnvRequirementsResponse{
+			AgentID:  "agent-partial",
+			Required: []string{"KNOWN_KEY", "UNKNOWN_KEY"},
+			HubHas:   []string{"KNOWN_KEY"},
+			Needs:    []string{"UNKNOWN_KEY"},
+		},
+	}
+
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetHubID(hubID)
+
+	agent := &store.Agent{
+		ID:              tid("agent-partial"),
+		Name:            "partial-agent",
+		Slug:            "partial-agent",
+		ProjectID:       "project-partial",
+		OwnerID:         "user-partial",
+		RuntimeBrokerID: broker.ID,
+		AppliedConfig:   &store.AgentAppliedConfig{},
+	}
+
+	envReqs, err := d.DispatchAgentCreateWithGather(ctx, agent)
+	if err != nil {
+		t.Fatalf("DispatchAgentCreateWithGather: %v", err)
+	}
+
+	// Should return remaining needs
+	if envReqs == nil {
+		t.Fatal("expected non-nil envReqs (partial resolution)")
+	}
+	if len(envReqs.Needs) != 1 || envReqs.Needs[0] != "UNKNOWN_KEY" {
+		t.Errorf("expected Needs=[UNKNOWN_KEY], got %v", envReqs.Needs)
+	}
+}
+
+func TestDispatchAgentCreateWithGather_TwoPass_NoMatch(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	hubID := "test-hub-nomatch"
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-nomatch"),
+		Name:     "nomatch-broker",
+		Slug:     "nomatch-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatal(err)
+	}
+
+	// No as_needed env vars or secrets for the needed key
+	mockClient := &gatherMockBrokerClient{
+		gatherEnvReqs: &RemoteEnvRequirementsResponse{
+			AgentID:  "agent-nomatch",
+			Required: []string{"MISSING_KEY"},
+			HubHas:   []string{},
+			Needs:    []string{"MISSING_KEY"},
+		},
+	}
+
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetHubID(hubID)
+
+	agent := &store.Agent{
+		ID:              tid("agent-nomatch"),
+		Name:            "nomatch-agent",
+		Slug:            "nomatch-agent",
+		ProjectID:       "project-nomatch",
+		OwnerID:         "user-nomatch",
+		RuntimeBrokerID: broker.ID,
+		AppliedConfig:   &store.AgentAppliedConfig{},
+	}
+
+	envReqs, err := d.DispatchAgentCreateWithGather(ctx, agent)
+	if err != nil {
+		t.Fatalf("DispatchAgentCreateWithGather: %v", err)
+	}
+
+	// No as_needed match — should pass through the original needs
+	if envReqs == nil {
+		t.Fatal("expected non-nil envReqs (no as_needed match)")
+	}
+	if len(envReqs.Needs) != 1 || envReqs.Needs[0] != "MISSING_KEY" {
+		t.Errorf("expected Needs=[MISSING_KEY], got %v", envReqs.Needs)
+	}
+
+	// Should only have been called once (no finalize since no matches)
+	if mockClient.callCount != 1 {
+		t.Errorf("expected 1 broker call (no finalize needed), got %d", mockClient.callCount)
+	}
+}
+
+func TestDispatchAgentCreateWithGather_NoNeeds(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-noneeds"),
+		Name:     "noneeds-broker",
+		Slug:     "noneeds-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatal(err)
+	}
+
+	// Broker returns no needs (all env satisfied)
+	mockClient := &gatherMockBrokerClient{}
+
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetHubID("test-hub-noneeds")
+
+	agent := &store.Agent{
+		ID:              tid("agent-noneeds"),
+		Name:            "noneeds-agent",
+		Slug:            "noneeds-agent",
+		ProjectID:       "project-noneeds",
+		OwnerID:         "user-noneeds",
+		RuntimeBrokerID: broker.ID,
+		AppliedConfig:   &store.AgentAppliedConfig{},
+	}
+
+	envReqs, err := d.DispatchAgentCreateWithGather(ctx, agent)
+	if err != nil {
+		t.Fatalf("DispatchAgentCreateWithGather: %v", err)
+	}
+
+	if envReqs != nil {
+		t.Errorf("expected nil envReqs (no needs), got %+v", envReqs)
+	}
+
+	// Should only be called once
+	if mockClient.callCount != 1 {
+		t.Errorf("expected 1 broker call, got %d", mockClient.callCount)
+	}
+}

--- a/pkg/hub/envgather_hubscope_regression_test.go
+++ b/pkg/hub/envgather_hubscope_regression_test.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// TestBuildEnvGatherResponse_HubScopeSecretWarning is a regression test for #721.
+//
+// When a broker reports a needed key (e.g., GEMINI_API_KEY) and the Hub has a
+// hub-scope secret for that key, buildEnvGatherResponse should emit a warning
+// indicating the key exists at hub scope. Currently, the cross-check at
+// handlers_agents_core.go:1172-1209 only checks user and project scope for
+// both env vars and secrets, missing hub-scope entirely.
+//
+// This test SHOULD PASS once the fix is applied. With the current code it will
+// FAIL because the hub-scope check is missing.
+func TestBuildEnvGatherResponse_HubScopeSecretWarning(t *testing.T) {
+	srv, st := testServer(t)
+	ctx := context.Background()
+
+	// Create a hub-scope secret for GEMINI_API_KEY
+	if err := st.CreateSecret(ctx, &store.Secret{
+		ID:             tid("sec-hubscope-gemini"),
+		Key:            "GEMINI_API_KEY",
+		EncryptedValue: "encrypted-gemini-key",
+		SecretType:     store.SecretTypeEnvironment,
+		Target:         "GEMINI_API_KEY",
+		Scope:          store.ScopeHub,
+		ScopeID:        "test-hub-id", // matches testServer's hub ID
+		InjectionMode:  store.InjectionModeAsNeeded,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up the local secret backend so the cross-check can query it
+	backend := secret.NewLocalBackend(st, "test-hub-id")
+	srv.SetSecretBackend(backend)
+
+	agent := &store.Agent{
+		ID:        "agent-hubscope-warn",
+		Name:      "hubscope-warn-agent",
+		OwnerID:   "some-owner",
+		ProjectID: "some-project",
+	}
+
+	// Simulate broker response: GEMINI_API_KEY is required but not satisfied
+	brokerReqs := &RemoteEnvRequirementsResponse{
+		AgentID:  agent.ID,
+		Required: []string{"GEMINI_API_KEY"},
+		HubHas:   []string{},
+		Needs:    []string{"GEMINI_API_KEY"},
+	}
+
+	resp := srv.buildEnvGatherResponse(ctx, agent, brokerReqs)
+
+	// The cross-check should detect that GEMINI_API_KEY exists at hub scope
+	// and emit a warning. With the current code, no warning is emitted because
+	// only user and project scopes are checked.
+	if len(resp.HubWarnings) == 0 {
+		t.Error("expected HubWarnings for GEMINI_API_KEY (exists at hub scope but not dispatched); got none")
+	}
+
+	// Verify the warning mentions hub scope
+	found := false
+	for _, w := range resp.HubWarnings {
+		if strings.Contains(w, "GEMINI_API_KEY") && strings.Contains(w, "hub") {
+			found = true
+			break
+		}
+	}
+	if !found && len(resp.HubWarnings) > 0 {
+		t.Errorf("expected warning mentioning GEMINI_API_KEY at hub scope; got warnings: %v", resp.HubWarnings)
+	}
+}
+
+// TestBuildEnvGatherResponse_HubScopeEnvVarWarning is a regression test for #721.
+//
+// When a broker reports a needed key and the Hub has a hub-scope env var for
+// that key, buildEnvGatherResponse should emit a warning. Currently, the
+// cross-check only queries user and project scope for env vars.
+func TestBuildEnvGatherResponse_HubScopeEnvVarWarning(t *testing.T) {
+	srv, st := testServer(t)
+	ctx := context.Background()
+
+	// Create a hub-scope env var for GEMINI_API_KEY with as_needed mode
+	if err := st.CreateEnvVar(ctx, &store.EnvVar{
+		ID:            tid("env-hubscope-gemini"),
+		Key:           "GEMINI_API_KEY",
+		Value:         "hub-gemini-key",
+		Scope:         store.ScopeHub,
+		ScopeID:       "test-hub-id",
+		InjectionMode: store.InjectionModeAsNeeded,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	agent := &store.Agent{
+		ID:        "agent-hubscope-env-warn",
+		Name:      "hubscope-env-warn-agent",
+		OwnerID:   "some-owner",
+		ProjectID: "some-project",
+	}
+
+	brokerReqs := &RemoteEnvRequirementsResponse{
+		AgentID:  agent.ID,
+		Required: []string{"GEMINI_API_KEY"},
+		HubHas:   []string{},
+		Needs:    []string{"GEMINI_API_KEY"},
+	}
+
+	resp := srv.buildEnvGatherResponse(ctx, agent, brokerReqs)
+
+	if len(resp.HubWarnings) == 0 {
+		t.Error("expected HubWarnings for GEMINI_API_KEY (exists as hub-scope env var but not dispatched); got none")
+	}
+
+	found := false
+	for _, w := range resp.HubWarnings {
+		if strings.Contains(w, "GEMINI_API_KEY") && strings.Contains(w, "hub") {
+			found = true
+			break
+		}
+	}
+	if !found && len(resp.HubWarnings) > 0 {
+		t.Errorf("expected warning mentioning GEMINI_API_KEY at hub scope; got warnings: %v", resp.HubWarnings)
+	}
+}
+
+// TestResolveSecrets_HubScope_AsNeeded_Filtered is a regression test for #721.
+//
+// Hub-scope secrets with injection_mode=as_needed are correctly filtered out by
+// resolveSecrets. This test documents the current behavior — the filtering
+// itself is correct. The bug is that the env-gather cross-check doesn't detect
+// that the filtered secret exists when it should have been available.
+func TestResolveSecrets_HubScope_AsNeeded_Filtered(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	agent := &store.Agent{
+		ID:              "agent-hubscope-filter",
+		Name:            "hubscope-filter",
+		Slug:            "hubscope-filter",
+		ProjectID:       "project-hubscope-1",
+		OwnerID:         "user-hubscope-1",
+		RuntimeBrokerID: "broker-hubscope-1",
+		AppliedConfig:   &store.AgentAppliedConfig{},
+	}
+
+	hubID := "hub-hubscope-test"
+	mockClient := &mockRuntimeBrokerClient{}
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, nil)
+	d.SetHubID(hubID)
+	d.SetSecretBackend(&mockSecretBackend{
+		secrets: []secret.SecretWithValue{
+			{
+				SecretMeta: secret.SecretMeta{
+					Name:          "GEMINI_API_KEY",
+					SecretType:    "environment",
+					Target:        "GEMINI_API_KEY",
+					Scope:         "hub",
+					ScopeID:       hubID,
+					InjectionMode: "as_needed",
+				},
+				Value: "gemini-key-value",
+			},
+			{
+				SecretMeta: secret.SecretMeta{
+					Name:          "ALWAYS_HUB_SECRET",
+					SecretType:    "environment",
+					Target:        "ALWAYS_HUB_SECRET",
+					Scope:         "hub",
+					ScopeID:       hubID,
+					InjectionMode: "always",
+				},
+				Value: "always-hub-value",
+			},
+		},
+	})
+
+	resolved, err := d.resolveSecrets(ctx, agent)
+	if err != nil {
+		t.Fatalf("resolveSecrets: %v", err)
+	}
+
+	byName := make(map[string]ResolvedSecret, len(resolved))
+	for _, r := range resolved {
+		byName[r.Name] = r
+	}
+
+	// Hub-scope as_needed should be filtered out
+	if _, ok := byName["GEMINI_API_KEY"]; ok {
+		t.Error("GEMINI_API_KEY (hub scope, as_needed) should be filtered out")
+	}
+
+	// Hub-scope always should be included
+	if r, ok := byName["ALWAYS_HUB_SECRET"]; !ok {
+		t.Error("ALWAYS_HUB_SECRET (hub scope, always) should be present")
+	} else if r.Value != "always-hub-value" {
+		t.Errorf("ALWAYS_HUB_SECRET value = %q, want %q", r.Value, "always-hub-value")
+	}
+}

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -1187,6 +1187,15 @@ func (s *Server) buildEnvGatherResponse(ctx context.Context, agent *store.Agent,
 				continue
 			}
 		}
+		// Check hub-scope env_vars
+		if hubID := s.HubID(); hubID != "" {
+			vars, err := s.store.ListEnvVars(ctx, store.EnvVarFilter{Scope: "hub", ScopeID: hubID, Key: key})
+			if err == nil && len(vars) > 0 {
+				resp.HubWarnings = append(resp.HubWarnings,
+					fmt.Sprintf("%s is stored in Hub env storage (hub scope) but was not included in the dispatch — injection_mode may be as_needed", key))
+				continue
+			}
+		}
 		// Check secret backend
 		if s.secretBackend != nil {
 			if agent.OwnerID != "" {
@@ -1202,6 +1211,15 @@ func (s *Server) buildEnvGatherResponse(ctx context.Context, agent *store.Agent,
 				if err == nil && len(metas) > 0 {
 					resp.HubWarnings = append(resp.HubWarnings,
 						fmt.Sprintf("%s is stored in Hub secrets (project scope) but was not included in the dispatch — this may indicate a resolution issue", key))
+					continue
+				}
+			}
+			// Check hub-scope secrets
+			if hubID := s.HubID(); hubID != "" {
+				metas, err := s.secretBackend.List(ctx, secret.Filter{Scope: "hub", ScopeID: hubID, Name: key})
+				if err == nil && len(metas) > 0 {
+					resp.HubWarnings = append(resp.HubWarnings,
+						fmt.Sprintf("%s is stored in Hub secrets (hub scope) but was not included in the dispatch — injection_mode may be as_needed", key))
 					continue
 				}
 			}

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -993,20 +993,36 @@ func (d *HTTPAgentDispatcher) DispatchAgentCreateWithGather(ctx context.Context,
 		}
 	}
 	if errors.Is(err, ErrLifecycleDeferred) {
-		return d.deferredCreateWithGather(ctx, agent)
-	}
-	if err != nil {
+		envReqs, err = d.deferredCreateWithGather(ctx, agent)
+		if err != nil {
+			return nil, err
+		}
+		// Fall through to the second-pass as_needed resolution below.
+	} else if err != nil {
 		return nil, err
-	}
-
-	if envReqs != nil {
-		return envReqs, nil
-	}
-
-	if resp != nil {
+	} else if resp != nil {
 		d.applyBrokerResponse(agent, resp)
 	}
-	return nil, nil
+
+	// Second pass: if the broker reported needed keys, check whether any can
+	// be satisfied by as_needed env vars or secrets. If so, finalize them
+	// transparently without requiring CLI intervention.
+	if envReqs != nil && len(envReqs.Needs) > 0 {
+		asNeededEnv := d.resolveAsNeededForKeys(ctx, agent, envReqs.Needs)
+		if len(asNeededEnv) > 0 {
+			err := d.DispatchFinalizeEnv(ctx, agent, asNeededEnv)
+			if err == nil {
+				return nil, nil // All needs satisfied by as_needed entries
+			}
+			var stillMissing *ErrEnvStillMissing
+			if errors.As(err, &stillMissing) {
+				return stillMissing.Requirements, nil // Partial; remaining needs returned
+			}
+			return nil, err
+		}
+	}
+
+	return envReqs, nil
 }
 
 // deferredCreateWithGather handles a cross-node create-with-gather via durable dispatch.

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -1491,7 +1491,11 @@ func (d *HTTPAgentDispatcher) resolveAsNeededForKeys(
 				d.log.Warn("resolveAsNeededForKeys: failed to resolve secrets", "error", err)
 			}
 		} else {
-			for _, sv := range resolved {
+			// Iterate in reverse: resolved is ordered lowest-precedence first
+			// (hub < user < project < runtime_broker), so walking backwards
+			// lets higher-precedence secrets win.
+			for i := len(resolved) - 1; i >= 0; i-- {
+				sv := resolved[i]
 				if sv.InjectionMode != store.InjectionModeAsNeeded {
 					continue
 				}

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -1400,6 +1400,114 @@ func (d *HTTPAgentDispatcher) resolveEnvFromStorage(ctx context.Context, agent *
 	return result, nil
 }
 
+// resolveAsNeededForKeys resolves as_needed env vars and environment-type
+// secrets whose key/target matches one of the requested keys. It returns a
+// map suitable for passing to DispatchFinalizeEnv.
+//
+// This is the second pass of the two-pass env-gather resolution: the first
+// pass (resolveEnvFromStorage + resolveSecrets) skips as_needed entries, then
+// the broker reports which keys are still needed, and this function checks
+// whether any of those keys can be satisfied by as_needed entries.
+//
+// Known limitation: file-type as_needed secrets are not handled here because
+// DispatchFinalizeEnv only accepts a string key=value map. File-type secrets
+// that need on-demand injection would require a different mechanism.
+func (d *HTTPAgentDispatcher) resolveAsNeededForKeys(
+	ctx context.Context,
+	agent *store.Agent,
+	keys []string,
+) map[string]string {
+	result := make(map[string]string)
+	keySet := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		keySet[k] = struct{}{}
+	}
+
+	// 1. Check env_vars table (all scopes, in precedence order so last-wins).
+	for _, filter := range d.envScopesInPrecedenceOrder(agent) {
+		vars, err := d.store.ListEnvVars(ctx, filter)
+		if err != nil {
+			if d.debug {
+				d.log.Warn("resolveAsNeededForKeys: failed to list env vars",
+					"scope", filter.Scope, "scope_id", filter.ScopeID, "error", err)
+			}
+			continue
+		}
+		for _, v := range vars {
+			if v.InjectionMode != store.InjectionModeAsNeeded {
+				continue
+			}
+			if _, needed := keySet[v.Key]; needed {
+				result[v.Key] = v.Value
+			}
+		}
+	}
+
+	// 2. Check secrets (all scopes via backend.Resolve).
+	// Only environment-type secrets can be mapped to env key=value pairs.
+	if d.secretBackend != nil {
+		var resolveOpts *secret.ResolveOpts
+		if len(agent.Ancestry) > 1 && d.authzService != nil {
+			agentID := agent.ID
+			ancestry := agent.Ancestry
+			resolveOpts = &secret.ResolveOpts{
+				AgentAncestry: ancestry,
+				AuthzCheck: func(s secret.SecretMeta) bool {
+					decision := d.authzService.CheckAccess(ctx, &agentIdentityWrapper{
+						AgentTokenClaims: &AgentTokenClaims{
+							Claims:    jwt.Claims{Subject: agentID},
+							ProjectID: agent.ProjectID,
+							Ancestry:  ancestry,
+						},
+					}, Resource{
+						Type: "secret",
+						ID:   s.ID,
+					}, ActionRead)
+					return decision.Allowed
+				},
+			}
+		}
+
+		resolved, err := d.secretBackend.Resolve(
+			ctx, agent.OwnerID, agent.ProjectID, agent.RuntimeBrokerID, resolveOpts)
+		if err != nil {
+			if d.debug {
+				d.log.Warn("resolveAsNeededForKeys: failed to resolve secrets", "error", err)
+			}
+		} else {
+			for _, sv := range resolved {
+				if sv.InjectionMode != store.InjectionModeAsNeeded {
+					continue
+				}
+				// Only environment-type secrets map to env vars.
+				if sv.SecretType != store.SecretTypeEnvironment && sv.SecretType != "" {
+					continue
+				}
+				target := sv.Target
+				if target == "" {
+					target = sv.Name
+				}
+				if _, needed := keySet[target]; needed {
+					if _, alreadySet := result[target]; !alreadySet {
+						result[target] = sv.Value
+					}
+				}
+			}
+		}
+	}
+
+	if d.debug && len(result) > 0 {
+		resolvedKeys := make([]string, 0, len(result))
+		for k := range result {
+			resolvedKeys = append(resolvedKeys, k)
+		}
+		d.log.Debug("resolveAsNeededForKeys: resolved as_needed entries",
+			"count", len(result), "keys", resolvedKeys)
+	}
+
+	return result
+}
+
 // buildEnvSources creates a map of env key -> scope for reporting to the CLI.
 //
 // It walks the same scopes in the same order as resolveEnvFromStorage, from the


### PR DESCRIPTION
## Summary

Hub-scope secrets with injection_mode: as_needed (the column default) were filtered out by the dispatcher before the broker could evaluate whether they are needed, causing agent creation failures when harness required_env declarations could only be satisfied by as_needed secrets.

### Changes

1. **Two-pass resolution** (httpdispatcher.go): After the broker returns 202 with needs, DispatchAgentCreateWithGather now checks for matching as_needed env vars and secrets via a new resolveAsNeededForKeys function, then calls DispatchFinalizeEnv transparently. Both CLI and web UI paths benefit without handler changes.

2. **Hub-scope cross-check** (handlers_agents_core.go): buildEnvGatherResponse cross-check loop now checks hub-scope for both env_vars and secrets, warning when a hub-scope key exists but was not dispatched.

### Key files
- pkg/hub/httpdispatcher.go - resolveAsNeededForKeys + second-pass logic
- pkg/hub/handlers_agents_core.go - hub-scope cross-check additions

### Tests
- 3 regression tests + 11 new unit tests
- Full go test ./pkg/hub/... passes

Fixes ptone/scion#721
