### PR TITLE
fix(hub): resolve env vars and secrets in DispatchAgentRestart

### DIFF
--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -283,18 +283,15 @@ func runInit(args []string) int {
 			// LoadEnvOverlay use the existing file instead of aborting.
 			// This makes restarts resilient to transient provisioner failures
 			// while still requiring success on first creation.
+			var fallbackExists bool
 			if harnessReq.EnvOverlayPath != "" {
 				existingOverlay := hooks.ResolveContainerPath(harnessReq.EnvOverlayPath, agentHome)
 				if _, statErr := os.Stat(existingOverlay); statErr == nil {
 					log.Info("WARNING: Pre-start provisioning failed but previous env overlay exists at %s, using fallback", existingOverlay)
-					// Fall through — LoadEnvOverlay below will read the existing file
-				} else {
-					log.Error("Pre-start provisioning is required; aborting startup")
-					_ = statusHandler.UpdatePhase(state.PhaseError, "", "")
-					_ = statusHandler.SetMessage(fmt.Sprintf("pre-start hook failed: %v", err))
-					return 1
+					fallbackExists = true
 				}
-			} else {
+			}
+			if !fallbackExists {
 				log.Error("Pre-start provisioning is required; aborting startup")
 				_ = statusHandler.UpdatePhase(state.PhaseError, "", "")
 				_ = statusHandler.SetMessage(fmt.Sprintf("pre-start hook failed: %v", err))

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -278,10 +278,28 @@ func runInit(args []string) int {
 	if err := lifecycleManager.RunPreStart(); err != nil {
 		log.Error("Pre-start hooks failed: %v", err)
 		if harnessReq.Required || projectHookStaged {
-			log.Error("Pre-start provisioning is required; aborting startup")
-			_ = statusHandler.UpdatePhase(state.PhaseError, "", "")
-			_ = statusHandler.SetMessage(fmt.Sprintf("pre-start hook failed: %v", err))
-			return 1
+			// On restart, check for an existing env overlay from a previous
+			// successful run. If it exists, we can fall through and let
+			// LoadEnvOverlay use the existing file instead of aborting.
+			// This makes restarts resilient to transient provisioner failures
+			// while still requiring success on first creation.
+			if harnessReq.EnvOverlayPath != "" {
+				existingOverlay := hooks.ResolveContainerPath(harnessReq.EnvOverlayPath, agentHome)
+				if _, statErr := os.Stat(existingOverlay); statErr == nil {
+					log.Info("WARNING: Pre-start provisioning failed but previous env overlay exists at %s, using fallback", existingOverlay)
+					// Fall through — LoadEnvOverlay below will read the existing file
+				} else {
+					log.Error("Pre-start provisioning is required; aborting startup")
+					_ = statusHandler.UpdatePhase(state.PhaseError, "", "")
+					_ = statusHandler.SetMessage(fmt.Sprintf("pre-start hook failed: %v", err))
+					return 1
+				}
+			} else {
+				log.Error("Pre-start provisioning is required; aborting startup")
+				_ = statusHandler.UpdatePhase(state.PhaseError, "", "")
+				_ = statusHandler.SetMessage(fmt.Sprintf("pre-start hook failed: %v", err))
+				return 1
+			}
 		}
 		// Continue anyway — non-required harness hooks failing shouldn't prevent startup
 	}

--- a/pkg/harness/apply_auth_restage_regression_test.go
+++ b/pkg/harness/apply_auth_restage_regression_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package harness
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+)
+
+// TestApplyAuthSettings_RestagePreservesExistingSecretFiles is a regression test for #723.
+//
+// On agent restart, ApplyAuthSettings is called again. If the resolved auth has
+// empty EnvVars (because the auth gathering on the restart path didn't find
+// credentials), the newly written auth-candidates.json has empty
+// env_secret_files: {}. But the secret files from the original creation still
+// exist on disk.
+//
+// Expected behavior: the auth-candidates.json should reference any existing
+// secret files on disk if the new resolution produces empty env vars.
+//
+// This test demonstrates the bug: after a successful first provision that wrote
+// secret files and auth-candidates.json with proper references, a second call
+// to ApplyAuthSettings with empty env vars produces auth-candidates.json with
+// empty env_secret_files, even though the secret files still exist on disk.
+func TestApplyAuthSettings_RestagePreservesExistingSecretFiles(t *testing.T) {
+	h, _ := newTestContainerScriptHarness(t)
+	agentHome := t.TempDir()
+
+	// ---- First call: simulate initial creation with valid Vertex AI auth ----
+	firstResolved := &api.ResolvedAuth{
+		Method: "vertex-ai",
+		EnvVars: map[string]string{
+			"SCION_HARNESS_SELECTED_AUTH": "vertex-ai",
+			"GOOGLE_CLOUD_PROJECT":        "my-project",
+			"GOOGLE_CLOUD_REGION":         "us-central1",
+			"GOOGLE_CLOUD_LOCATION":       "us-central1",
+		},
+	}
+	if err := h.ApplyAuthSettings(agentHome, firstResolved); err != nil {
+		t.Fatalf("first ApplyAuthSettings: %v", err)
+	}
+
+	// Verify first call produced correct auth-candidates.json
+	firstData, err := os.ReadFile(filepath.Join(agentHome, ".scion", "harness", "inputs", "auth-candidates.json"))
+	if err != nil {
+		t.Fatalf("read first auth-candidates.json: %v", err)
+	}
+	var firstPayload map[string]interface{}
+	if err := json.Unmarshal(firstData, &firstPayload); err != nil {
+		t.Fatalf("unmarshal first auth-candidates.json: %v", err)
+	}
+
+	// Verify secret files were staged
+	secretDir := filepath.Join(agentHome, ".scion", "harness", "secrets")
+	for _, name := range []string{"GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_REGION", "GOOGLE_CLOUD_LOCATION"} {
+		data, err := os.ReadFile(filepath.Join(secretDir, name))
+		if err != nil {
+			t.Fatalf("secret file %s not staged: %v", name, err)
+		}
+		if len(data) == 0 {
+			t.Fatalf("secret file %s is empty", name)
+		}
+	}
+
+	// Verify env_secret_files references the staged files
+	firstEnvSecrets, ok := firstPayload["env_secret_files"].(map[string]interface{})
+	if !ok {
+		t.Fatal("first auth-candidates.json missing env_secret_files map")
+	}
+	if len(firstEnvSecrets) == 0 {
+		t.Fatal("first auth-candidates.json has empty env_secret_files; expected references to staged secrets")
+	}
+	if _, ok := firstEnvSecrets["GOOGLE_CLOUD_PROJECT"]; !ok {
+		t.Error("first auth-candidates.json missing GOOGLE_CLOUD_PROJECT in env_secret_files")
+	}
+
+	// ---- Second call: simulate restart with empty auth (the bug) ----
+	// On restart, GatherAuthWithEnv returns empty credentials because
+	// GOOGLE_CLOUD_PROJECT doesn't reach the auth overlay.
+	restartResolved := &api.ResolvedAuth{
+		Method:  "container-script",
+		EnvVars: map[string]string{},
+	}
+	if err := h.ApplyAuthSettings(agentHome, restartResolved); err != nil {
+		t.Fatalf("restart ApplyAuthSettings: %v", err)
+	}
+
+	// Read the re-staged auth-candidates.json
+	restartData, err := os.ReadFile(filepath.Join(agentHome, ".scion", "harness", "inputs", "auth-candidates.json"))
+	if err != nil {
+		t.Fatalf("read restart auth-candidates.json: %v", err)
+	}
+	var restartPayload map[string]interface{}
+	if err := json.Unmarshal(restartData, &restartPayload); err != nil {
+		t.Fatalf("unmarshal restart auth-candidates.json: %v", err)
+	}
+
+	// Verify secret files still exist on disk (they do — they're never deleted)
+	for _, name := range []string{"GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_REGION", "GOOGLE_CLOUD_LOCATION"} {
+		if _, err := os.Stat(filepath.Join(secretDir, name)); err != nil {
+			t.Fatalf("secret file %s was removed during restage: %v", name, err)
+		}
+	}
+
+	// BUG: The re-staged auth-candidates.json has empty env_secret_files
+	// because the restart resolved auth had empty EnvVars, so
+	// stageEnvSecretFiles returns an empty map. The existing secret files
+	// are ignored.
+	//
+	// The test asserts the DESIRED behavior: auth-candidates.json should
+	// still reference the existing secret files on disk.
+	restartEnvSecrets, ok := restartPayload["env_secret_files"].(map[string]interface{})
+	if !ok {
+		t.Fatal("restart auth-candidates.json missing env_secret_files map")
+	}
+	if len(restartEnvSecrets) == 0 {
+		t.Error("restart auth-candidates.json has empty env_secret_files — " +
+			"existing secret files from creation are not referenced. " +
+			"Bug #723: ApplyAuthSettings should preserve references to " +
+			"existing secret files when new resolution has empty env vars")
+	}
+}
+
+// TestApplyAuthSettings_RestageOverwritesExistingCandidates verifies the basic
+// overwrite semantics: a second call to ApplyAuthSettings with valid (non-empty)
+// credentials should produce a correct auth-candidates.json that replaces the
+// first one.
+func TestApplyAuthSettings_RestageOverwritesExistingCandidates(t *testing.T) {
+	h, _ := newTestContainerScriptHarness(t)
+	agentHome := t.TempDir()
+
+	// First call: API key auth
+	firstResolved := &api.ResolvedAuth{
+		Method: "api-key",
+		EnvVars: map[string]string{
+			"SCION_HARNESS_SELECTED_AUTH": "api-key",
+			"ANTHROPIC_API_KEY":           "sk-ant-first",
+		},
+	}
+	if err := h.ApplyAuthSettings(agentHome, firstResolved); err != nil {
+		t.Fatalf("first ApplyAuthSettings: %v", err)
+	}
+
+	// Second call: Vertex AI auth (credential rotation)
+	secondResolved := &api.ResolvedAuth{
+		Method: "vertex-ai",
+		EnvVars: map[string]string{
+			"SCION_HARNESS_SELECTED_AUTH": "vertex-ai",
+			"GOOGLE_CLOUD_PROJECT":        "my-project",
+			"GOOGLE_CLOUD_REGION":         "us-central1",
+		},
+	}
+	if err := h.ApplyAuthSettings(agentHome, secondResolved); err != nil {
+		t.Fatalf("second ApplyAuthSettings: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(agentHome, ".scion", "harness", "inputs", "auth-candidates.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Should reflect the second call's auth type
+	if payload["explicit_type"] != "vertex-ai" {
+		t.Errorf("explicit_type=%v, want vertex-ai", payload["explicit_type"])
+	}
+	if payload["resolved_method"] != "vertex-ai" {
+		t.Errorf("resolved_method=%v, want vertex-ai", payload["resolved_method"])
+	}
+
+	// Should have GOOGLE_CLOUD_PROJECT in env_secret_files, not ANTHROPIC_API_KEY
+	envSecrets, ok := payload["env_secret_files"].(map[string]interface{})
+	if !ok {
+		t.Fatal("missing env_secret_files")
+	}
+	if _, ok := envSecrets["GOOGLE_CLOUD_PROJECT"]; !ok {
+		t.Error("expected GOOGLE_CLOUD_PROJECT in env_secret_files")
+	}
+	if _, ok := envSecrets["ANTHROPIC_API_KEY"]; ok {
+		t.Error("ANTHROPIC_API_KEY should not be in env_secret_files after re-staging with vertex-ai")
+	}
+}

--- a/pkg/harness/auth.go
+++ b/pkg/harness/auth.go
@@ -256,7 +256,15 @@ func OverlaySettings(auth *api.AuthConfig, h api.Harness, agentDir string) {
 		}
 	}
 
-	auth.SelectedType = selectedType
+	// Guard: reject harness implementation names (e.g. "container-script")
+	// that may have leaked into scion-agent.json via a data-corruption bug.
+	// These are never valid auth types and would confuse auth resolution.
+	// The active repair at run.go cleans up the persisted value, but this
+	// guard prevents the corrupted value from entering the auth path on
+	// the first restart after corruption.
+	if !IsHarnessImplementationName(selectedType) {
+		auth.SelectedType = selectedType
+	}
 }
 
 // ValidateAuth checks a ResolvedAuth for completeness before container launch.

--- a/pkg/harness/auth_test.go
+++ b/pkg/harness/auth_test.go
@@ -621,6 +621,51 @@ func TestOverlaySettings_NoScionAgentJSON(t *testing.T) {
 	}
 }
 
+// TestOverlaySettings_RejectsHarnessImplementationName verifies that
+// OverlaySettings does NOT set auth.SelectedType when scion-agent.json
+// contains a harness implementation name (e.g. "container-script"). This
+// guards against data corruption where the harness implementation name
+// leaks into AuthSelectedType. See issue #723.
+func TestOverlaySettings_RejectsHarnessImplementationName(t *testing.T) {
+	for _, badValue := range []string{"container-script", "generic", "builtin", "passthrough"} {
+		t.Run(badValue, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			scionAgentPath := filepath.Join(tmpDir, "scion-agent.json")
+			_ = os.WriteFile(scionAgentPath,
+				[]byte(`{"auth_selectedType": "`+badValue+`"}`), 0644)
+
+			auth := api.AuthConfig{}
+			h := New("gemini")
+			OverlaySettings(&auth, h, tmpDir)
+
+			if auth.SelectedType != "" {
+				t.Errorf("SelectedType = %q, want empty (harness implementation name should be rejected)", auth.SelectedType)
+			}
+		})
+	}
+}
+
+// TestOverlaySettings_AcceptsValidAuthType verifies that OverlaySettings still
+// accepts legitimate auth types like "vertex-ai", "api-key", "auth-file".
+func TestOverlaySettings_AcceptsValidAuthType(t *testing.T) {
+	for _, validType := range []string{"vertex-ai", "api-key", "auth-file", "adc"} {
+		t.Run(validType, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			scionAgentPath := filepath.Join(tmpDir, "scion-agent.json")
+			_ = os.WriteFile(scionAgentPath,
+				[]byte(`{"auth_selectedType": "`+validType+`"}`), 0644)
+
+			auth := api.AuthConfig{}
+			h := New("gemini")
+			OverlaySettings(&auth, h, tmpDir)
+
+			if auth.SelectedType != validType {
+				t.Errorf("SelectedType = %q, want %q", auth.SelectedType, validType)
+			}
+		})
+	}
+}
+
 func TestGatherAuthWithEnv_BrokerMode(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)

--- a/pkg/harness/container_script_harness.go
+++ b/pkg/harness/container_script_harness.go
@@ -524,22 +524,29 @@ func (c *ContainerScriptHarness) ApplyAuthSettings(agentHome string, resolved *a
 		return err
 	}
 
-	// When auth resolution produces empty env vars (e.g. on restart when
-	// credentials don't reach the auth overlay), preserve references to
-	// existing secret files from a previous successful run. This prevents
-	// overwriting a valid auth-candidates.json with one that has empty
-	// env_secret_files. See issue #723.
-	if len(envSecretFiles) == 0 {
-		existing := c.discoverExistingSecretFiles(agentHome)
-		if len(existing) > 0 {
-			envSecretFiles = existing
-		}
-	}
-
 	fileSecretFiles, remainingFiles, err := c.stageFileSecretFiles(agentHome, resolved.Files)
 	if err != nil {
 		return err
 	}
+
+	// Discover existing secrets on disk to preserve them across restarts.
+	// File-type secrets (CODEX_AUTH, CLAUDE_AUTH) are always merged when not
+	// already overridden by the new resolution, because they may not be
+	// re-resolved on restart. Env-type secrets are only merged when the new
+	// resolution produced none, to prevent stale credentials from leaking
+	// during credential rotation. See issue #723.
+	existingEnvSecrets, existingFileSecrets := c.discoverExistingSecretFiles(agentHome)
+	if len(envSecretFiles) == 0 {
+		for k, v := range existingEnvSecrets {
+			envSecretFiles[k] = v
+		}
+	}
+	for k, v := range existingFileSecrets {
+		if _, exists := fileSecretFiles[k]; !exists {
+			fileSecretFiles[k] = v
+		}
+	}
+
 	// Remove staged-as-secret FileMappings from resolved so the runtime does
 	// not also bind-mount them (which would create a read-only overlay that
 	// prevents the container-side script from writing the file).
@@ -753,17 +760,19 @@ func isSafeEnvName(name string) bool {
 }
 
 // discoverExistingSecretFiles scans the secrets directory for files left by a
-// previous successful ApplyAuthSettings call. It returns a map of env-var name
-// to container-relative path, matching the format produced by stageEnvSecretFiles.
-// This enables auth-candidates.json to reference existing secrets when the
-// current auth resolution produced empty env vars (e.g. on restart).
-func (c *ContainerScriptHarness) discoverExistingSecretFiles(agentHome string) map[string]string {
+// previous successful ApplyAuthSettings call. It returns two maps of secret
+// name to container-relative path: one for env-type secrets and one for
+// file-type secrets (distinguished via isRequiredFileSecret). This enables
+// auth-candidates.json to reference existing secrets when the current auth
+// resolution produced empty env vars (e.g. on restart).
+func (c *ContainerScriptHarness) discoverExistingSecretFiles(agentHome string) (map[string]string, map[string]string) {
 	dir := filepath.Join(agentHome, ".scion", "harness", "secrets")
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
-	result := map[string]string{}
+	envSecrets := map[string]string{}
+	fileSecrets := map[string]string{}
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
@@ -777,9 +786,31 @@ func (c *ContainerScriptHarness) discoverExistingSecretFiles(agentHome string) m
 		if err != nil || info.Size() == 0 {
 			continue
 		}
-		result[name] = "$HOME/.scion/harness/secrets/" + name
+		path := "$HOME/.scion/harness/secrets/" + name
+		if c.isRequiredFileSecret(name) {
+			fileSecrets[name] = path
+		} else {
+			envSecrets[name] = path
+		}
 	}
-	return result
+	return envSecrets, fileSecrets
+}
+
+// isRequiredFileSecret returns true if name matches a required_files
+// declaration in any auth type of the harness config. These are file-type
+// secrets (e.g. CODEX_AUTH, CLAUDE_AUTH) as opposed to env-type secrets.
+func (c *ContainerScriptHarness) isRequiredFileSecret(name string) bool {
+	if c.entry.Auth == nil {
+		return false
+	}
+	for _, authType := range c.entry.Auth.Types {
+		for _, rf := range authType.RequiredFiles {
+			if rf.Name == name {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // ApplyMCPSettings stages the universal mcp_servers map into

--- a/pkg/harness/container_script_harness.go
+++ b/pkg/harness/container_script_harness.go
@@ -524,6 +524,18 @@ func (c *ContainerScriptHarness) ApplyAuthSettings(agentHome string, resolved *a
 		return err
 	}
 
+	// When auth resolution produces empty env vars (e.g. on restart when
+	// credentials don't reach the auth overlay), preserve references to
+	// existing secret files from a previous successful run. This prevents
+	// overwriting a valid auth-candidates.json with one that has empty
+	// env_secret_files. See issue #723.
+	if len(envSecretFiles) == 0 {
+		existing := c.discoverExistingSecretFiles(agentHome)
+		if len(existing) > 0 {
+			envSecretFiles = existing
+		}
+	}
+
 	fileSecretFiles, remainingFiles, err := c.stageFileSecretFiles(agentHome, resolved.Files)
 	if err != nil {
 		return err
@@ -738,6 +750,36 @@ func isSafeEnvName(name string) bool {
 		}
 	}
 	return true
+}
+
+// discoverExistingSecretFiles scans the secrets directory for files left by a
+// previous successful ApplyAuthSettings call. It returns a map of env-var name
+// to container-relative path, matching the format produced by stageEnvSecretFiles.
+// This enables auth-candidates.json to reference existing secrets when the
+// current auth resolution produced empty env vars (e.g. on restart).
+func (c *ContainerScriptHarness) discoverExistingSecretFiles(agentHome string) map[string]string {
+	dir := filepath.Join(agentHome, ".scion", "harness", "secrets")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	result := map[string]string{}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !isSafeEnvName(name) {
+			continue
+		}
+		// Verify the file has non-empty content
+		info, err := e.Info()
+		if err != nil || info.Size() == 0 {
+			continue
+		}
+		result[name] = "$HOME/.scion/harness/secrets/" + name
+	}
+	return result
 }
 
 // ApplyMCPSettings stages the universal mcp_servers map into

--- a/pkg/harness/container_script_harness_test.go
+++ b/pkg/harness/container_script_harness_test.go
@@ -1093,38 +1093,69 @@ func TestResolve_LegacyBuiltinCodexNoDir(t *testing.T) {
 }
 
 // TestDiscoverExistingSecretFiles verifies that discoverExistingSecretFiles
-// returns a map of env-var name to container-relative path for non-empty files
-// in the secrets directory.
+// returns two maps (env-type and file-type) of secret name to container-relative
+// path for non-empty files in the secrets directory, correctly categorised via
+// the harness auth config's required_files declarations.
 func TestDiscoverExistingSecretFiles(t *testing.T) {
 	h, _ := newTestContainerScriptHarness(t)
 	agentHome := t.TempDir()
 
-	// No secrets dir yet — should return nil
-	result := h.discoverExistingSecretFiles(agentHome)
-	if result != nil {
-		t.Errorf("expected nil for missing secrets dir, got %v", result)
+	// No secrets dir yet — should return nil, nil
+	envSecrets, fileSecrets := h.discoverExistingSecretFiles(agentHome)
+	if envSecrets != nil {
+		t.Errorf("expected nil env secrets for missing secrets dir, got %v", envSecrets)
+	}
+	if fileSecrets != nil {
+		t.Errorf("expected nil file secrets for missing secrets dir, got %v", fileSecrets)
 	}
 
-	// Create secrets dir with some files
+	// Set up auth config with a file-type secret so categorisation can be tested.
+	h.entry.Auth = &config.HarnessAuthMetadata{
+		Types: map[string]config.HarnessAuthTypeMetadata{
+			"claude": {
+				RequiredFiles: []config.HarnessAuthFileRequirement{
+					{Name: "CLAUDE_AUTH"},
+				},
+			},
+		},
+	}
+
+	// Create secrets dir with env-type, file-type, and empty files
 	secretDir := filepath.Join(agentHome, ".scion", "harness", "secrets")
 	if err := os.MkdirAll(secretDir, 0700); err != nil {
 		t.Fatal(err)
 	}
 	_ = os.WriteFile(filepath.Join(secretDir, "GOOGLE_CLOUD_PROJECT"), []byte("my-project"), 0600)
 	_ = os.WriteFile(filepath.Join(secretDir, "GOOGLE_CLOUD_REGION"), []byte("us-central1"), 0600)
+	_ = os.WriteFile(filepath.Join(secretDir, "CLAUDE_AUTH"), []byte("auth-token"), 0600)
 	_ = os.WriteFile(filepath.Join(secretDir, "EMPTY_SECRET"), []byte(""), 0600) // empty — should be skipped
 
-	result = h.discoverExistingSecretFiles(agentHome)
-	if len(result) != 2 {
-		t.Fatalf("expected 2 secrets, got %d: %v", len(result), result)
+	envSecrets, fileSecrets = h.discoverExistingSecretFiles(agentHome)
+
+	// Env-type: GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_REGION
+	if len(envSecrets) != 2 {
+		t.Fatalf("expected 2 env secrets, got %d: %v", len(envSecrets), envSecrets)
 	}
-	if result["GOOGLE_CLOUD_PROJECT"] != "$HOME/.scion/harness/secrets/GOOGLE_CLOUD_PROJECT" {
-		t.Errorf("GOOGLE_CLOUD_PROJECT path = %q", result["GOOGLE_CLOUD_PROJECT"])
+	if envSecrets["GOOGLE_CLOUD_PROJECT"] != "$HOME/.scion/harness/secrets/GOOGLE_CLOUD_PROJECT" {
+		t.Errorf("GOOGLE_CLOUD_PROJECT path = %q", envSecrets["GOOGLE_CLOUD_PROJECT"])
 	}
-	if result["GOOGLE_CLOUD_REGION"] != "$HOME/.scion/harness/secrets/GOOGLE_CLOUD_REGION" {
-		t.Errorf("GOOGLE_CLOUD_REGION path = %q", result["GOOGLE_CLOUD_REGION"])
+	if envSecrets["GOOGLE_CLOUD_REGION"] != "$HOME/.scion/harness/secrets/GOOGLE_CLOUD_REGION" {
+		t.Errorf("GOOGLE_CLOUD_REGION path = %q", envSecrets["GOOGLE_CLOUD_REGION"])
 	}
-	if _, ok := result["EMPTY_SECRET"]; ok {
-		t.Error("empty secret file should not be included")
+
+	// File-type: CLAUDE_AUTH (matches required_files in auth config)
+	if len(fileSecrets) != 1 {
+		t.Fatalf("expected 1 file secret, got %d: %v", len(fileSecrets), fileSecrets)
+	}
+	if fileSecrets["CLAUDE_AUTH"] != "$HOME/.scion/harness/secrets/CLAUDE_AUTH" {
+		t.Errorf("CLAUDE_AUTH path = %q", fileSecrets["CLAUDE_AUTH"])
+	}
+
+	// Empty secret should not appear in either map
+	if _, ok := envSecrets["EMPTY_SECRET"]; ok {
+		t.Error("empty secret file should not be included in env secrets")
+	}
+	if _, ok := fileSecrets["EMPTY_SECRET"]; ok {
+		t.Error("empty secret file should not be included in file secrets")
 	}
 }

--- a/pkg/harness/container_script_harness_test.go
+++ b/pkg/harness/container_script_harness_test.go
@@ -1091,3 +1091,40 @@ func TestResolve_LegacyBuiltinCodexNoDir(t *testing.T) {
 		t.Errorf("Implementation=%q want generic", resolved.Implementation)
 	}
 }
+
+// TestDiscoverExistingSecretFiles verifies that discoverExistingSecretFiles
+// returns a map of env-var name to container-relative path for non-empty files
+// in the secrets directory.
+func TestDiscoverExistingSecretFiles(t *testing.T) {
+	h, _ := newTestContainerScriptHarness(t)
+	agentHome := t.TempDir()
+
+	// No secrets dir yet — should return nil
+	result := h.discoverExistingSecretFiles(agentHome)
+	if result != nil {
+		t.Errorf("expected nil for missing secrets dir, got %v", result)
+	}
+
+	// Create secrets dir with some files
+	secretDir := filepath.Join(agentHome, ".scion", "harness", "secrets")
+	if err := os.MkdirAll(secretDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.WriteFile(filepath.Join(secretDir, "GOOGLE_CLOUD_PROJECT"), []byte("my-project"), 0600)
+	_ = os.WriteFile(filepath.Join(secretDir, "GOOGLE_CLOUD_REGION"), []byte("us-central1"), 0600)
+	_ = os.WriteFile(filepath.Join(secretDir, "EMPTY_SECRET"), []byte(""), 0600) // empty — should be skipped
+
+	result = h.discoverExistingSecretFiles(agentHome)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 secrets, got %d: %v", len(result), result)
+	}
+	if result["GOOGLE_CLOUD_PROJECT"] != "$HOME/.scion/harness/secrets/GOOGLE_CLOUD_PROJECT" {
+		t.Errorf("GOOGLE_CLOUD_PROJECT path = %q", result["GOOGLE_CLOUD_PROJECT"])
+	}
+	if result["GOOGLE_CLOUD_REGION"] != "$HOME/.scion/harness/secrets/GOOGLE_CLOUD_REGION" {
+		t.Errorf("GOOGLE_CLOUD_REGION path = %q", result["GOOGLE_CLOUD_REGION"])
+	}
+	if _, ok := result["EMPTY_SECRET"]; ok {
+		t.Error("empty secret file should not be included")
+	}
+}

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -1737,10 +1737,56 @@ func (d *HTTPAgentDispatcher) DispatchAgentRestart(ctx context.Context, agent *s
 		return err
 	}
 
-	// Build resolved env with fresh auth token and identity vars so the
-	// restarted container retains Hub connectivity. Without this, the
-	// broker's restartAgent handler has no token to inject.
+	// Build resolved env with all env vars, secrets, and a fresh auth token
+	// so the restarted container has full credentials and Hub connectivity.
+	// This mirrors the resolution in DispatchAgentStart — without it, env vars
+	// like GOOGLE_CLOUD_PROJECT are missing and auth provisioning fails.
 	resolvedEnv := make(map[string]string)
+
+	// Start with agent's applied config env (template/config-level vars) —
+	// same as DispatchAgentStart.
+	if agent.AppliedConfig != nil {
+		for k, v := range agent.AppliedConfig.Env {
+			resolvedEnv[k] = v
+		}
+	}
+
+	injectModelEnv(resolvedEnv, agent.AppliedConfig)
+	injectThinkingLevelEnv(resolvedEnv, agent.AppliedConfig)
+
+	// Merge env vars from Hub storage; storage vars fill in keys not already
+	// set (with a non-empty value) — same precedence as DispatchAgentStart.
+	envFromStorage, err := d.resolveEnvFromStorage(ctx, agent)
+	if err != nil {
+		if d.debug {
+			d.log.Warn("DispatchAgentRestart: failed to resolve env from storage", "error", err)
+		}
+	} else if len(envFromStorage) > 0 {
+		for k, v := range envFromStorage {
+			if existing, exists := resolvedEnv[k]; !exists || existing == "" {
+				resolvedEnv[k] = v
+			}
+		}
+	}
+
+	// Resolve type-aware secrets and inject environment-type secrets —
+	// same as DispatchAgentStart.
+	resolvedSecrets, secretErr := d.resolveSecrets(ctx, agent)
+	if secretErr != nil {
+		if d.debug {
+			d.log.Warn("DispatchAgentRestart: failed to resolve secrets", "error", secretErr)
+		}
+	} else {
+		for _, s := range resolvedSecrets {
+			if (s.Type == "environment" || s.Type == "") && s.Target != "" {
+				if existing, exists := resolvedEnv[s.Target]; !exists || existing == "" {
+					resolvedEnv[s.Target] = s.Value
+				}
+			}
+		}
+	}
+
+	// Identity vars at highest precedence (set after storage/secrets merge).
 	if agent.ID != "" {
 		resolvedEnv["SCION_AGENT_ID"] = agent.ID
 	}
@@ -1775,8 +1821,17 @@ func (d *HTTPAgentDispatcher) DispatchAgentRestart(ctx context.Context, agent *s
 		}
 	}
 
-	injectModelEnv(resolvedEnv, agent.AppliedConfig)
-	injectThinkingLevelEnv(resolvedEnv, agent.AppliedConfig)
+	// Inject GCP identity env vars so the broker can configure the
+	// metadata-server sidecar correctly on restart — same as DispatchAgentStart.
+	if agent.AppliedConfig != nil {
+		if gcpID := agent.AppliedConfig.GCPIdentity; gcpID != nil {
+			resolvedEnv["SCION_METADATA_MODE"] = gcpID.MetadataMode
+			if gcpID.MetadataMode == store.GCPMetadataModeAssign {
+				resolvedEnv["SCION_METADATA_SA_EMAIL"] = gcpID.ServiceAccountEmail
+				resolvedEnv["SCION_METADATA_PROJECT_ID"] = gcpID.ProjectID
+			}
+		}
+	}
 
 	if d.tokenGenerator != nil {
 		var additionalScopes []AgentTokenScope
@@ -1811,6 +1866,42 @@ func (d *HTTPAgentDispatcher) DispatchAgentRestart(ctx context.Context, agent *s
 			resolvedEnv["SCION_TRANSPORT_TOKEN_EXPIRY"] = tExpiry.UTC().Format(time.RFC3339)
 			if d.transportMode != "" {
 				resolvedEnv["SCION_TRANSPORT_MODE"] = d.transportMode
+			}
+		}
+	}
+
+	// GitHub App token minting for agent restart — same as DispatchAgentStart.
+	if d.githubAppMinter != nil && agent.ProjectID != "" {
+		project, projectErr := d.store.GetProject(ctx, agent.ProjectID)
+		if projectErr == nil {
+			mintProject := project
+			if project.GitHubInstallationID == nil {
+				if sourceProjectID := agent.Labels["scion.dev/github-token-source-project"]; sourceProjectID != "" {
+					if sg, sgErr := d.store.GetProject(ctx, sourceProjectID); sgErr == nil && sg.GitHubInstallationID != nil {
+						mintProject = sg
+					}
+				}
+			}
+			if mintProject.GitHubInstallationID != nil {
+				if resolvedEnv["GITHUB_TOKEN"] == "" {
+					token, expiry, mintErr := d.githubAppMinter.MintGitHubAppTokenForProject(ctx, mintProject)
+					if mintErr != nil {
+						if d.debug {
+							d.log.Warn("DispatchAgentRestart: GitHub App token minting failed",
+								"error", mintErr, "project_id", agent.ProjectID)
+						}
+					} else if token != "" {
+						resolvedEnv["GITHUB_TOKEN"] = token
+						resolvedEnv["SCION_GITHUB_APP_ENABLED"] = "true"
+						resolvedEnv["SCION_GITHUB_TOKEN_EXPIRY"] = expiry
+						resolvedEnv["SCION_GITHUB_TOKEN_PATH"] = "/tmp/.github-token"
+					}
+				} else {
+					d.log.Warn("DispatchAgentRestart: user GITHUB_TOKEN takes precedence over GitHub App token — user token will be used for gh CLI, GitHub App for git credential helper",
+						"project_id", agent.ProjectID)
+					resolvedEnv["SCION_USER_GITHUB_TOKEN"] = "true"
+					resolvedEnv["SCION_GITHUB_APP_ENABLED"] = "true"
+				}
 			}
 		}
 	}

--- a/pkg/hub/httpdispatcher_restart_env_test.go
+++ b/pkg/hub/httpdispatcher_restart_env_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// TestHTTPAgentDispatcher_DispatchAgentRestart_ResolvesEnvFromStorage verifies
+// that DispatchAgentRestart resolves env vars from hub storage — the root cause
+// fix for issue #723 where GOOGLE_CLOUD_PROJECT was missing on restart.
+func TestHTTPAgentDispatcher_DispatchAgentRestart_ResolvesEnvFromStorage(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-restart-env"),
+		Name:     "test-broker",
+		Slug:     "test-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	agent := &store.Agent{
+		ID:              tid("agent-restart-env"),
+		Name:            "restart-env-agent",
+		Slug:            "restart-env-agent",
+		ProjectID:       tid("project-restart-env"),
+		OwnerID:         tid("user-restart-env"),
+		RuntimeBrokerID: tid("broker-restart-env"),
+		AppliedConfig: &store.AgentAppliedConfig{
+			Env: map[string]string{
+				"TEMPLATE_VAR": "from-config",
+			},
+		},
+	}
+
+	// Seed a hub-scope env var (like GOOGLE_CLOUD_PROJECT) with injection_mode=always
+	envVar := store.EnvVar{
+		ID:            api.NewUUID(),
+		Key:           "GOOGLE_CLOUD_PROJECT",
+		Value:         "my-gcp-project",
+		Scope:         store.ScopeProject,
+		ScopeID:       agent.ProjectID,
+		InjectionMode: store.InjectionModeAlways,
+	}
+	if _, err := memStore.UpsertEnvVar(ctx, &envVar); err != nil {
+		t.Fatalf("seeding env var: %v", err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+
+	err := dispatcher.DispatchAgentRestart(ctx, agent)
+	if err != nil {
+		t.Fatalf("DispatchAgentRestart failed: %v", err)
+	}
+
+	if !mockClient.restartCalled {
+		t.Fatal("expected RestartAgent to be called")
+	}
+
+	env := mockClient.lastRestartResolvedEnv
+
+	// GOOGLE_CLOUD_PROJECT should be present from storage resolution
+	if got, ok := env["GOOGLE_CLOUD_PROJECT"]; !ok {
+		t.Error("GOOGLE_CLOUD_PROJECT missing from restart resolvedEnv — storage env not resolved")
+	} else if got != "my-gcp-project" {
+		t.Errorf("GOOGLE_CLOUD_PROJECT = %q, want %q", got, "my-gcp-project")
+	}
+
+	// Template/config-level env vars should also be present
+	if got, ok := env["TEMPLATE_VAR"]; !ok {
+		t.Error("TEMPLATE_VAR missing from restart resolvedEnv — AppliedConfig.Env not merged")
+	} else if got != "from-config" {
+		t.Errorf("TEMPLATE_VAR = %q, want %q", got, "from-config")
+	}
+
+	// Identity vars should still be present at highest precedence
+	if got := env["SCION_AGENT_ID"]; got != agent.ID {
+		t.Errorf("SCION_AGENT_ID = %q, want %q", got, agent.ID)
+	}
+	if got := env["SCION_PROJECT_ID"]; got != agent.ProjectID {
+		t.Errorf("SCION_PROJECT_ID = %q, want %q", got, agent.ProjectID)
+	}
+}
+
+// TestHTTPAgentDispatcher_DispatchAgentRestart_ResolvesSecrets verifies that
+// DispatchAgentRestart resolves type-aware secrets and injects environment-type
+// secrets into resolvedEnv.
+func TestHTTPAgentDispatcher_DispatchAgentRestart_ResolvesSecrets(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-restart-secrets"),
+		Name:     "test-broker",
+		Slug:     "test-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	agent := &store.Agent{
+		ID:              tid("agent-restart-secrets"),
+		Name:            "restart-secrets-agent",
+		Slug:            "restart-secrets-agent",
+		ProjectID:       tid("project-restart-secrets"),
+		OwnerID:         tid("user-restart-secrets"),
+		RuntimeBrokerID: tid("broker-restart-secrets"),
+		AppliedConfig:   &store.AgentAppliedConfig{},
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	dispatcher.SetSecretBackend(&mockSecretBackend{
+		secrets: []secret.SecretWithValue{
+			{
+				SecretMeta: secret.SecretMeta{
+					Name:          "API_KEY_SECRET",
+					SecretType:    "environment",
+					Target:        "API_KEY",
+					Scope:         "project",
+					ScopeID:       agent.ProjectID,
+					InjectionMode: "always",
+				},
+				Value: "secret-api-key-value",
+			},
+		},
+	})
+
+	err := dispatcher.DispatchAgentRestart(ctx, agent)
+	if err != nil {
+		t.Fatalf("DispatchAgentRestart failed: %v", err)
+	}
+
+	env := mockClient.lastRestartResolvedEnv
+
+	// Environment-type secret should be injected into resolvedEnv
+	if got, ok := env["API_KEY"]; !ok {
+		t.Error("API_KEY missing from restart resolvedEnv — secrets not resolved")
+	} else if got != "secret-api-key-value" {
+		t.Errorf("API_KEY = %q, want %q", got, "secret-api-key-value")
+	}
+}
+
+// TestHTTPAgentDispatcher_DispatchAgentRestart_ConfigEnvTakesPrecedence verifies
+// that explicit config env vars take precedence over storage-resolved vars,
+// matching the same precedence rules as DispatchAgentStart.
+func TestHTTPAgentDispatcher_DispatchAgentRestart_ConfigEnvTakesPrecedence(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-restart-prec"),
+		Name:     "test-broker",
+		Slug:     "test-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	agent := &store.Agent{
+		ID:              tid("agent-restart-prec"),
+		Name:            "restart-prec-agent",
+		Slug:            "restart-prec-agent",
+		ProjectID:       tid("project-restart-prec"),
+		OwnerID:         tid("user-restart-prec"),
+		RuntimeBrokerID: tid("broker-restart-prec"),
+		AppliedConfig: &store.AgentAppliedConfig{
+			Env: map[string]string{
+				"SHARED_VAR": "from-config",
+			},
+		},
+	}
+
+	// Seed same key in storage
+	envVar := store.EnvVar{
+		ID:            api.NewUUID(),
+		Key:           "SHARED_VAR",
+		Value:         "from-storage",
+		Scope:         store.ScopeProject,
+		ScopeID:       agent.ProjectID,
+		InjectionMode: store.InjectionModeAlways,
+	}
+	if _, err := memStore.UpsertEnvVar(ctx, &envVar); err != nil {
+		t.Fatalf("seeding env var: %v", err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+
+	err := dispatcher.DispatchAgentRestart(ctx, agent)
+	if err != nil {
+		t.Fatalf("DispatchAgentRestart failed: %v", err)
+	}
+
+	env := mockClient.lastRestartResolvedEnv
+
+	// Config env should win over storage
+	if got := env["SHARED_VAR"]; got != "from-config" {
+		t.Errorf("SHARED_VAR = %q, want %q (config should take precedence over storage)", got, "from-config")
+	}
+}


### PR DESCRIPTION
## Summary

On agent restart, DispatchAgentRestart did not resolve env vars from storage or secrets, leaving GOOGLE_CLOUD_PROJECT absent from the auth overlay and causing provisioner failure.

### Changes
1. P0: DispatchAgentRestart resolves AppliedConfig.Env, storage env, secrets, GCP identity, GitHub App tokens
2. P1: init.go falls back to existing env overlay when pre-start fails on restart
3. P1: OverlaySettings rejects corrupted auth types
4. P2: ApplyAuthSettings preserves existing auth-candidates.json on empty restage

Fixes ptone/scion#723
