### PR TITLE
fix(hub): derive telemetry project ID from SA credentials for metrics dashboard

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -58,6 +58,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/GoogleCloudPlatform/scion/pkg/store/entadapter"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
+	gcputil "github.com/GoogleCloudPlatform/scion/pkg/util/gcp"
 	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
 	"github.com/GoogleCloudPlatform/scion/web"
 	"github.com/knadh/koanf/v2"
@@ -1394,6 +1395,23 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 	if hostedMode && hubCfg.SharedSigningSecret == "" {
 		log.Println("WARNING: hosted mode is enabled but no session secret is configured. " +
 			"Set --session-secret or SCION_SERVER_SESSION_SECRET to avoid cross-replica session failures.")
+	}
+
+	// Derive TelemetryProjectID using a priority chain:
+	// 1. Explicit telemetry.cloud.gcp_project_id setting (highest priority)
+	// 2. Derived from scion-telemetry-gcp-credentials SA key JSON
+	// 3. Existing GCPProjectID fallback (SA minting project, handled in server.go)
+	if cfg.TelemetryConfig != nil && cfg.TelemetryConfig.Cloud != nil && cfg.TelemetryConfig.Cloud.GCPProjectID != nil && *cfg.TelemetryConfig.Cloud.GCPProjectID != "" {
+		hubCfg.TelemetryProjectID = *cfg.TelemetryConfig.Cloud.GCPProjectID
+		log.Printf("Telemetry project ID from settings: %s", hubCfg.TelemetryProjectID)
+	}
+	if hubCfg.TelemetryProjectID == "" && secretBackend != nil {
+		if sw, err := secretBackend.Get(ctx, "scion-telemetry-gcp-credentials", secret.ScopeHub, cfg.Hub.ResolveHubID()); err == nil && sw != nil && sw.Value != "" {
+			if pid := gcputil.ParseProjectID([]byte(sw.Value)); pid != "" {
+				hubCfg.TelemetryProjectID = pid
+				log.Printf("Telemetry project ID derived from SA credentials: %s", pid)
+			}
+		}
 	}
 
 	// Construct proxy authenticator when auth mode is "proxy"

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1401,16 +1401,14 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 	// 1. Explicit telemetry.cloud.gcp_project_id setting (highest priority)
 	// 2. Derived from scion-telemetry-gcp-credentials SA key JSON
 	// 3. Existing GCPProjectID fallback (SA minting project, handled in server.go)
-	if cfg.TelemetryConfig != nil && cfg.TelemetryConfig.Cloud != nil && cfg.TelemetryConfig.Cloud.GCPProjectID != nil && *cfg.TelemetryConfig.Cloud.GCPProjectID != "" {
-		hubCfg.TelemetryProjectID = *cfg.TelemetryConfig.Cloud.GCPProjectID
-		log.Printf("Telemetry project ID from settings: %s", hubCfg.TelemetryProjectID)
+	if pid := telemetryGCPProjectFromSettings(cfg); pid != "" {
+		hubCfg.TelemetryProjectID = pid
+		log.Printf("Telemetry project ID from settings: %s", pid)
 	}
 	if hubCfg.TelemetryProjectID == "" && secretBackend != nil {
-		if sw, err := secretBackend.Get(ctx, "scion-telemetry-gcp-credentials", secret.ScopeHub, cfg.Hub.ResolveHubID()); err == nil && sw != nil && sw.Value != "" {
-			if pid := gcputil.ParseProjectID([]byte(sw.Value)); pid != "" {
-				hubCfg.TelemetryProjectID = pid
-				log.Printf("Telemetry project ID derived from SA credentials: %s", pid)
-			}
+		if pid := telemetryGCPProjectFromSecret(ctx, secretBackend, cfg.Hub.ResolveHubID()); pid != "" {
+			hubCfg.TelemetryProjectID = pid
+			log.Printf("Telemetry project ID derived from SA credentials: %s", pid)
 		}
 	}
 
@@ -2710,4 +2708,26 @@ func injectPluginSecretsIntoConfig(ctx context.Context, sb secret.SecretBackend,
 		cfg[m.ConfigKey] = sv.Value
 	}
 	return cfg
+}
+
+// telemetryGCPProjectFromSettings returns the explicit telemetry.cloud.gcp_project_id
+// setting value, or "" if not configured.
+func telemetryGCPProjectFromSettings(cfg *config.GlobalConfig) string {
+	if cfg.TelemetryConfig == nil || cfg.TelemetryConfig.Cloud == nil {
+		return ""
+	}
+	if cfg.TelemetryConfig.Cloud.GCPProjectID == nil {
+		return ""
+	}
+	return *cfg.TelemetryConfig.Cloud.GCPProjectID
+}
+
+// telemetryGCPProjectFromSecret reads the scion-telemetry-gcp-credentials hub
+// secret and extracts the project_id from the SA key JSON.
+func telemetryGCPProjectFromSecret(ctx context.Context, sb secret.SecretBackend, hubID string) string {
+	sw, err := sb.Get(ctx, "scion-telemetry-gcp-credentials", secret.ScopeHub, hubID)
+	if err != nil || sw == nil || sw.Value == "" {
+		return ""
+	}
+	return gcputil.ParseProjectID([]byte(sw.Value))
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -372,13 +372,14 @@ type TelemetryConfig struct {
 
 // TelemetryCloudConfig holds cloud OTLP forwarding settings.
 type TelemetryCloudConfig struct {
-	Enabled  *bool             `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	Endpoint string            `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
-	Protocol string            `json:"protocol,omitempty" yaml:"protocol,omitempty"`
-	Headers  map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
-	TLS      *TelemetryTLS     `json:"tls,omitempty" yaml:"tls,omitempty"`
-	Batch    *TelemetryBatch   `json:"batch,omitempty" yaml:"batch,omitempty"`
-	Provider string            `json:"provider,omitempty" yaml:"provider,omitempty"`
+	Enabled      *bool             `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Endpoint     string            `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	Protocol     string            `json:"protocol,omitempty" yaml:"protocol,omitempty"`
+	Headers      map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+	TLS          *TelemetryTLS     `json:"tls,omitempty" yaml:"tls,omitempty"`
+	Batch        *TelemetryBatch   `json:"batch,omitempty" yaml:"batch,omitempty"`
+	Provider     string            `json:"provider,omitempty" yaml:"provider,omitempty"`
+	GCPProjectID *string           `json:"gcp_project_id,omitempty" yaml:"gcp_project_id,omitempty"`
 }
 
 // TelemetryTLS holds TLS settings for OTLP export.

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -1023,7 +1023,17 @@
           "x-since": "1"
         },
         "tls": { "$ref": "#/$defs/telemetryTLS" },
-        "batch": { "$ref": "#/$defs/telemetryBatch" }
+        "batch": { "$ref": "#/$defs/telemetryBatch" },
+        "provider": {
+          "type": "string",
+          "description": "Cloud telemetry provider (e.g., 'gcp' for GCP-native export).",
+          "x-since": "1"
+        },
+        "gcp_project_id": {
+          "type": "string",
+          "description": "GCP project ID for telemetry (Cloud Monitoring). Overrides auto-detection from SA credentials.",
+          "x-since": "1"
+        }
       },
       "additionalProperties": false
     },

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -692,13 +692,14 @@ type V1TelemetryConfig struct {
 
 // V1TelemetryCloudConfig holds cloud OTLP forwarding settings.
 type V1TelemetryCloudConfig struct {
-	Enabled  *bool                   `json:"enabled,omitempty" yaml:"enabled,omitempty" koanf:"enabled"`
-	Endpoint string                  `json:"endpoint,omitempty" yaml:"endpoint,omitempty" koanf:"endpoint"`
-	Protocol string                  `json:"protocol,omitempty" yaml:"protocol,omitempty" koanf:"protocol"`
-	Headers  map[string]string       `json:"headers,omitempty" yaml:"headers,omitempty" koanf:"headers"`
-	TLS      *V1TelemetryTLSConfig   `json:"tls,omitempty" yaml:"tls,omitempty" koanf:"tls"`
-	Batch    *V1TelemetryBatchConfig `json:"batch,omitempty" yaml:"batch,omitempty" koanf:"batch"`
-	Provider string                  `json:"provider,omitempty" yaml:"provider,omitempty" koanf:"provider"`
+	Enabled      *bool                   `json:"enabled,omitempty" yaml:"enabled,omitempty" koanf:"enabled"`
+	Endpoint     string                  `json:"endpoint,omitempty" yaml:"endpoint,omitempty" koanf:"endpoint"`
+	Protocol     string                  `json:"protocol,omitempty" yaml:"protocol,omitempty" koanf:"protocol"`
+	Headers      map[string]string       `json:"headers,omitempty" yaml:"headers,omitempty" koanf:"headers"`
+	TLS          *V1TelemetryTLSConfig   `json:"tls,omitempty" yaml:"tls,omitempty" koanf:"tls"`
+	Batch        *V1TelemetryBatchConfig `json:"batch,omitempty" yaml:"batch,omitempty" koanf:"batch"`
+	Provider     string                  `json:"provider,omitempty" yaml:"provider,omitempty" koanf:"provider"`
+	GCPProjectID *string                 `json:"gcp_project_id,omitempty" yaml:"gcp_project_id,omitempty" koanf:"gcp_project_id"`
 }
 
 // V1TelemetryTLSConfig holds TLS settings for cloud OTLP export.

--- a/pkg/config/telemetry_convert.go
+++ b/pkg/config/telemetry_convert.go
@@ -37,11 +37,12 @@ func ConvertV1TelemetryToAPI(v1 *V1TelemetryConfig) *api.TelemetryConfig {
 
 	if v1.Cloud != nil {
 		result.Cloud = &api.TelemetryCloudConfig{
-			Enabled:  v1.Cloud.Enabled,
-			Endpoint: v1.Cloud.Endpoint,
-			Protocol: v1.Cloud.Protocol,
-			Headers:  v1.Cloud.Headers,
-			Provider: v1.Cloud.Provider,
+			Enabled:      v1.Cloud.Enabled,
+			Endpoint:     v1.Cloud.Endpoint,
+			Protocol:     v1.Cloud.Protocol,
+			Headers:      v1.Cloud.Headers,
+			Provider:     v1.Cloud.Provider,
+			GCPProjectID: v1.Cloud.GCPProjectID,
 		}
 		if v1.Cloud.TLS != nil {
 			result.Cloud.TLS = &api.TelemetryTLS{
@@ -148,6 +149,9 @@ func TelemetryConfigToEnv(cfg *api.TelemetryConfig) map[string]string {
 		}
 		if cfg.Cloud.Provider != "" {
 			env["SCION_TELEMETRY_CLOUD_PROVIDER"] = cfg.Cloud.Provider
+		}
+		if cfg.Cloud.GCPProjectID != nil && *cfg.Cloud.GCPProjectID != "" {
+			env["SCION_GCP_PROJECT_ID"] = *cfg.Cloud.GCPProjectID
 		}
 	}
 

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -984,6 +984,9 @@ func mergeTelemetryConfig(base, override *api.TelemetryConfig) *api.TelemetryCon
 		if override.Cloud.Provider != "" {
 			result.Cloud.Provider = override.Cloud.Provider
 		}
+		if override.Cloud.GCPProjectID != nil {
+			result.Cloud.GCPProjectID = override.Cloud.GCPProjectID
+		}
 	}
 	if override.Hub != nil {
 		if result.Hub == nil {

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -943,6 +943,9 @@ func mergeTelemetryConfig(base, override *api.TelemetryConfig) *api.TelemetryCon
 	if override.Cloud != nil {
 		if result.Cloud == nil {
 			result.Cloud = &api.TelemetryCloudConfig{}
+		} else {
+			cloudCopy := *result.Cloud
+			result.Cloud = &cloudCopy
 		}
 		if override.Cloud.Enabled != nil {
 			result.Cloud.Enabled = override.Cloud.Enabled
@@ -959,6 +962,9 @@ func mergeTelemetryConfig(base, override *api.TelemetryConfig) *api.TelemetryCon
 		if override.Cloud.TLS != nil {
 			if result.Cloud.TLS == nil {
 				result.Cloud.TLS = &api.TelemetryTLS{}
+			} else {
+				tlsCopy := *result.Cloud.TLS
+				result.Cloud.TLS = &tlsCopy
 			}
 			if override.Cloud.TLS.Enabled != nil {
 				result.Cloud.TLS.Enabled = override.Cloud.TLS.Enabled
@@ -973,6 +979,9 @@ func mergeTelemetryConfig(base, override *api.TelemetryConfig) *api.TelemetryCon
 		if override.Cloud.Batch != nil {
 			if result.Cloud.Batch == nil {
 				result.Cloud.Batch = &api.TelemetryBatch{}
+			} else {
+				batchCopy := *result.Cloud.Batch
+				result.Cloud.Batch = &batchCopy
 			}
 			if override.Cloud.Batch.MaxSize > 0 {
 				result.Cloud.Batch.MaxSize = override.Cloud.Batch.MaxSize
@@ -991,6 +1000,9 @@ func mergeTelemetryConfig(base, override *api.TelemetryConfig) *api.TelemetryCon
 	if override.Hub != nil {
 		if result.Hub == nil {
 			result.Hub = &api.TelemetryHubConfig{}
+		} else {
+			hubCopy := *result.Hub
+			result.Hub = &hubCopy
 		}
 		if override.Hub.Enabled != nil {
 			result.Hub.Enabled = override.Hub.Enabled
@@ -1002,6 +1014,9 @@ func mergeTelemetryConfig(base, override *api.TelemetryConfig) *api.TelemetryCon
 	if override.Local != nil {
 		if result.Local == nil {
 			result.Local = &api.TelemetryLocalConfig{}
+		} else {
+			localCopy := *result.Local
+			result.Local = &localCopy
 		}
 		if override.Local.Enabled != nil {
 			result.Local.Enabled = override.Local.Enabled
@@ -1016,6 +1031,9 @@ func mergeTelemetryConfig(base, override *api.TelemetryConfig) *api.TelemetryCon
 	if override.Filter != nil {
 		if result.Filter == nil {
 			result.Filter = &api.TelemetryFilterConfig{}
+		} else {
+			filterCopy := *result.Filter
+			result.Filter = &filterCopy
 		}
 		if override.Filter.Enabled != nil {
 			result.Filter.Enabled = override.Filter.Enabled
@@ -1026,6 +1044,9 @@ func mergeTelemetryConfig(base, override *api.TelemetryConfig) *api.TelemetryCon
 		if override.Filter.Events != nil {
 			if result.Filter.Events == nil {
 				result.Filter.Events = &api.TelemetryEventsConfig{}
+			} else {
+				eventsCopy := *result.Filter.Events
+				result.Filter.Events = &eventsCopy
 			}
 			if override.Filter.Events.Include != nil {
 				result.Filter.Events.Include = override.Filter.Events.Include
@@ -1037,6 +1058,9 @@ func mergeTelemetryConfig(base, override *api.TelemetryConfig) *api.TelemetryCon
 		if override.Filter.Attributes != nil {
 			if result.Filter.Attributes == nil {
 				result.Filter.Attributes = &api.TelemetryAttributesConfig{}
+			} else {
+				attrCopy := *result.Filter.Attributes
+				result.Filter.Attributes = &attrCopy
 			}
 			if override.Filter.Attributes.Redact != nil {
 				result.Filter.Attributes.Redact = override.Filter.Attributes.Redact
@@ -1048,6 +1072,9 @@ func mergeTelemetryConfig(base, override *api.TelemetryConfig) *api.TelemetryCon
 		if override.Filter.Sampling != nil {
 			if result.Filter.Sampling == nil {
 				result.Filter.Sampling = &api.TelemetrySamplingConfig{}
+			} else {
+				sampCopy := *result.Filter.Sampling
+				result.Filter.Sampling = &sampCopy
 			}
 			if override.Filter.Sampling.Default != nil {
 				result.Filter.Sampling.Default = override.Filter.Sampling.Default

--- a/pkg/sciontool/telemetry/config.go
+++ b/pkg/sciontool/telemetry/config.go
@@ -7,12 +7,13 @@ Copyright 2025 The Scion Authors.
 package telemetry
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/util/gcp"
 )
 
 // Environment variable names for telemetry configuration.
@@ -181,7 +182,7 @@ func LoadConfig() *Config {
 
 	// Auto-resolve project ID from GCP credentials file if not explicitly set
 	if cfg.ProjectID == "" && cfg.GCPCredentialsFile != "" {
-		cfg.ProjectID = readProjectIDFromCredentials(cfg.GCPCredentialsFile)
+		cfg.ProjectID = gcp.ExtractProjectID(cfg.GCPCredentialsFile)
 	}
 
 	// Apply default exclude list if not explicitly set
@@ -245,20 +246,11 @@ func (c *Config) IsGCP() bool {
 	return c != nil && c.CloudProvider == "gcp"
 }
 
-// readProjectIDFromCredentials reads the project_id field from a GCP service
-// account credentials JSON file. Returns empty string on any error.
+// readProjectIDFromCredentials is a thin wrapper around gcp.ExtractProjectID
+// for backward compatibility. Both the hub server and sciontool now use the
+// shared implementation in pkg/util/gcp.
 func readProjectIDFromCredentials(path string) string {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return ""
-	}
-	var creds struct {
-		ProjectID string `json:"project_id"`
-	}
-	if err := json.Unmarshal(data, &creds); err != nil {
-		return ""
-	}
-	return creds.ProjectID
+	return gcp.ExtractProjectID(path)
 }
 
 // parseBoolEnv parses a boolean environment variable with a default value.

--- a/pkg/sciontool/telemetry/config.go
+++ b/pkg/sciontool/telemetry/config.go
@@ -246,13 +246,6 @@ func (c *Config) IsGCP() bool {
 	return c != nil && c.CloudProvider == "gcp"
 }
 
-// readProjectIDFromCredentials is a thin wrapper around gcp.ExtractProjectID
-// for backward compatibility. Both the hub server and sciontool now use the
-// shared implementation in pkg/util/gcp.
-func readProjectIDFromCredentials(path string) string {
-	return gcp.ExtractProjectID(path)
-}
-
 // parseBoolEnv parses a boolean environment variable with a default value.
 func parseBoolEnv(key string, defaultVal bool) bool {
 	val := os.Getenv(key)

--- a/pkg/sciontool/telemetry/config_test.go
+++ b/pkg/sciontool/telemetry/config_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/util/gcp"
 )
 
 func TestLoadConfig_Defaults(t *testing.T) {
@@ -318,7 +320,7 @@ func TestIsGCP(t *testing.T) {
 	}
 }
 
-func TestReadProjectIDFromCredentials(t *testing.T) {
+func TestExtractProjectIDFromCredentials(t *testing.T) {
 	// Write a temp credentials file
 	tmpFile, err := os.CreateTemp("", "gcp-creds-*.json")
 	if err != nil {
@@ -332,15 +334,15 @@ func TestReadProjectIDFromCredentials(t *testing.T) {
 	}
 	_ = tmpFile.Close()
 
-	got := readProjectIDFromCredentials(tmpFile.Name())
+	got := gcp.ExtractProjectID(tmpFile.Name())
 	if got != "test-project-123" {
-		t.Errorf("readProjectIDFromCredentials() = %q, want %q", got, "test-project-123")
+		t.Errorf("ExtractProjectID() = %q, want %q", got, "test-project-123")
 	}
 
 	// Non-existent file
-	got = readProjectIDFromCredentials("/nonexistent/path.json")
+	got = gcp.ExtractProjectID("/nonexistent/path.json")
 	if got != "" {
-		t.Errorf("readProjectIDFromCredentials(nonexistent) = %q, want empty", got)
+		t.Errorf("ExtractProjectID(nonexistent) = %q, want empty", got)
 	}
 
 	// Invalid JSON
@@ -348,9 +350,9 @@ func TestReadProjectIDFromCredentials(t *testing.T) {
 	defer func() { _ = os.Remove(badFile.Name()) }()
 	_, _ = badFile.WriteString("not json")
 	_ = badFile.Close()
-	got = readProjectIDFromCredentials(badFile.Name())
+	got = gcp.ExtractProjectID(badFile.Name())
 	if got != "" {
-		t.Errorf("readProjectIDFromCredentials(invalid) = %q, want empty", got)
+		t.Errorf("ExtractProjectID(invalid) = %q, want empty", got)
 	}
 }
 

--- a/pkg/util/gcp/credentials.go
+++ b/pkg/util/gcp/credentials.go
@@ -25,6 +25,9 @@ import (
 // project_id field. Returns empty string on any error (file not found, invalid
 // JSON, missing field).
 func ExtractProjectID(credentialsPath string) string {
+	if credentialsPath == "" {
+		return ""
+	}
 	data, err := os.ReadFile(credentialsPath)
 	if err != nil {
 		return ""

--- a/pkg/util/gcp/credentials.go
+++ b/pkg/util/gcp/credentials.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gcp provides shared GCP utility functions used by both the hub server
+// and sciontool for extracting metadata from GCP service account credentials.
+package gcp
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// ExtractProjectID reads a GCP service account JSON key file and returns the
+// project_id field. Returns empty string on any error (file not found, invalid
+// JSON, missing field).
+func ExtractProjectID(credentialsPath string) string {
+	data, err := os.ReadFile(credentialsPath)
+	if err != nil {
+		return ""
+	}
+	return ParseProjectID(data)
+}
+
+// ParseProjectID extracts the project_id field from raw GCP service account
+// JSON key data. Returns empty string if the data is not valid JSON or lacks
+// a project_id field.
+func ParseProjectID(data []byte) string {
+	var creds struct {
+		ProjectID string `json:"project_id"`
+	}
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return ""
+	}
+	return creds.ProjectID
+}

--- a/pkg/util/gcp/credentials_test.go
+++ b/pkg/util/gcp/credentials_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseProjectID(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want string
+	}{
+		{
+			name: "valid SA key JSON",
+			data: []byte(`{"type":"service_account","project_id":"my-project-123","private_key_id":"abc"}`),
+			want: "my-project-123",
+		},
+		{
+			name: "empty project_id",
+			data: []byte(`{"type":"service_account","project_id":"","private_key_id":"abc"}`),
+			want: "",
+		},
+		{
+			name: "missing project_id field",
+			data: []byte(`{"type":"service_account","private_key_id":"abc"}`),
+			want: "",
+		},
+		{
+			name: "invalid JSON",
+			data: []byte(`not json at all`),
+			want: "",
+		},
+		{
+			name: "empty input",
+			data: []byte{},
+			want: "",
+		},
+		{
+			name: "nil input",
+			data: nil,
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseProjectID(tt.data)
+			if got != tt.want {
+				t.Errorf("ParseProjectID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractProjectID(t *testing.T) {
+	t.Run("valid credentials file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "sa-key.json")
+		data := []byte(`{"type":"service_account","project_id":"test-project","private_key_id":"xyz"}`)
+		if err := os.WriteFile(path, data, 0600); err != nil {
+			t.Fatal(err)
+		}
+		got := ExtractProjectID(path)
+		if got != "test-project" {
+			t.Errorf("ExtractProjectID() = %q, want %q", got, "test-project")
+		}
+	})
+
+	t.Run("nonexistent file", func(t *testing.T) {
+		got := ExtractProjectID("/nonexistent/path/to/creds.json")
+		if got != "" {
+			t.Errorf("ExtractProjectID() = %q, want empty", got)
+		}
+	})
+
+	t.Run("invalid JSON file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bad.json")
+		if err := os.WriteFile(path, []byte("not json"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		got := ExtractProjectID(path)
+		if got != "" {
+			t.Errorf("ExtractProjectID() = %q, want empty", got)
+		}
+	})
+}


### PR DESCRIPTION
The metrics dashboard showed "no telemetry project ID" because the hub never extracted the GCP project ID from the scion-telemetry-gcp-credentials SA key it already has. The agent-side pipeline worked because sciontool performs this extraction, but the hub never adopted the pattern.

## Changes

- New shared package pkg/util/gcp/ with ExtractProjectID and ParseProjectID, factored out of sciontool for reuse
- Hub init derives telemetry project ID from SA credentials secret with priority chain: explicit setting > SA credentials > SA minting fallback
- Added gcp_project_id to V1TelemetryCloudConfig, API types, JSON schema, conversion, and merge logic
- Sciontool updated to use shared gcp.ExtractProjectID

Relates to ptone/scion#724

## Key files

- pkg/util/gcp/credentials.go — shared SA key project ID extraction
- cmd/server_foreground.go — hub init derivation with helper functions
- pkg/config/settings_v1.go, pkg/api/types.go — new GCPProjectID field
- pkg/config/schemas/settings-v1.schema.json — schema update
- pkg/config/telemetry_convert.go, pkg/config/templates.go — wiring

## Test notes

All existing tests pass. New test suite in pkg/util/gcp covers valid SA key, missing field, malformed JSON, empty file edge cases.