### PR TITLE
feat(hub): add Tier 3 subsystem logging tags to remaining CRUD handlers

### DIFF
--- a/pkg/hub/audit.go
+++ b/pkg/hub/audit.go
@@ -243,7 +243,7 @@ func (l *LogAuditLogger) LogInviteAuditEvent(ctx context.Context, event *InviteA
 		attrs = append(attrs, slog.String(k, v))
 	}
 
-	l.log.LogAttrs(ctx, level,"authz: "+string(event.EventType), attrs...)
+	l.log.LogAttrs(ctx, level, "authz: "+string(event.EventType), attrs...)
 
 	return nil
 }
@@ -267,7 +267,7 @@ func (l *LogAuditLogger) LogGCPTokenEvent(ctx context.Context, event *GCPTokenEv
 		attrs = append(attrs, slog.String("fail_reason", event.FailReason))
 	}
 
-	l.log.LogAttrs(ctx, level,"GCP token audit event", attrs...)
+	l.log.LogAttrs(ctx, level, "GCP token audit event", attrs...)
 
 	return nil
 }
@@ -290,7 +290,7 @@ func (l *LogAuditLogger) LogLifecycleHookEvent(ctx context.Context, event *Lifec
 		attrs = append(attrs, slog.String("fail_reason", event.FailReason))
 	}
 
-	l.log.LogAttrs(ctx, level,"lifecycle hook audit event", attrs...)
+	l.log.LogAttrs(ctx, level, "lifecycle hook audit event", attrs...)
 
 	return nil
 }
@@ -321,7 +321,7 @@ func (l *LogAuditLogger) LogLifecycleHookExecutionEvent(ctx context.Context, eve
 		attrs = append(attrs, slog.String("fail_reason", event.FailReason))
 	}
 
-	l.log.LogAttrs(ctx, level,"lifecycle hook execution event", attrs...)
+	l.log.LogAttrs(ctx, level, "lifecycle hook execution event", attrs...)
 
 	return nil
 }

--- a/pkg/hub/audit.go
+++ b/pkg/hub/audit.go
@@ -20,6 +20,8 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
 )
 
 // BrokerAuthEventType defines the type of broker authentication event.
@@ -187,6 +189,7 @@ type AuditLogger interface {
 type LogAuditLogger struct {
 	prefix string
 	debug  bool
+	log    *slog.Logger
 }
 
 // NewLogAuditLogger creates a new log-based audit logger.
@@ -197,6 +200,7 @@ func NewLogAuditLogger(prefix string, debug bool) *LogAuditLogger {
 	return &LogAuditLogger{
 		prefix: prefix,
 		debug:  debug,
+		log:    logging.Subsystem("hub.audit"),
 	}
 }
 
@@ -239,7 +243,7 @@ func (l *LogAuditLogger) LogInviteAuditEvent(ctx context.Context, event *InviteA
 		attrs = append(attrs, slog.String(k, v))
 	}
 
-	slog.LogAttrs(ctx, level, "authz: "+string(event.EventType), attrs...)
+	l.log.LogAttrs(ctx, level,"authz: "+string(event.EventType), attrs...)
 
 	return nil
 }
@@ -263,7 +267,7 @@ func (l *LogAuditLogger) LogGCPTokenEvent(ctx context.Context, event *GCPTokenEv
 		attrs = append(attrs, slog.String("fail_reason", event.FailReason))
 	}
 
-	slog.LogAttrs(ctx, level, "GCP token audit event", attrs...)
+	l.log.LogAttrs(ctx, level,"GCP token audit event", attrs...)
 
 	return nil
 }
@@ -286,7 +290,7 @@ func (l *LogAuditLogger) LogLifecycleHookEvent(ctx context.Context, event *Lifec
 		attrs = append(attrs, slog.String("fail_reason", event.FailReason))
 	}
 
-	slog.LogAttrs(ctx, level, "lifecycle hook audit event", attrs...)
+	l.log.LogAttrs(ctx, level,"lifecycle hook audit event", attrs...)
 
 	return nil
 }
@@ -317,7 +321,7 @@ func (l *LogAuditLogger) LogLifecycleHookExecutionEvent(ctx context.Context, eve
 		attrs = append(attrs, slog.String("fail_reason", event.FailReason))
 	}
 
-	slog.LogAttrs(ctx, level, "lifecycle hook execution event", attrs...)
+	l.log.LogAttrs(ctx, level,"lifecycle hook execution event", attrs...)
 
 	return nil
 }

--- a/pkg/hub/audit.go
+++ b/pkg/hub/audit.go
@@ -204,6 +204,15 @@ func NewLogAuditLogger(prefix string, debug bool) *LogAuditLogger {
 	}
 }
 
+// logger returns the audit subsystem logger, falling back to slog.Default()
+// when the field is nil (e.g. in tests that construct LogAuditLogger directly).
+func (l *LogAuditLogger) logger() *slog.Logger {
+	if l.log != nil {
+		return l.log
+	}
+	return slog.Default()
+}
+
 // LogBrokerAuthEvent is a no-op implementation satisfying the AuditLogger interface.
 func (l *LogAuditLogger) LogBrokerAuthEvent(ctx context.Context, event *BrokerAuthEvent) error {
 	return nil
@@ -243,7 +252,7 @@ func (l *LogAuditLogger) LogInviteAuditEvent(ctx context.Context, event *InviteA
 		attrs = append(attrs, slog.String(k, v))
 	}
 
-	l.log.LogAttrs(ctx, level, "authz: "+string(event.EventType), attrs...)
+	l.logger().LogAttrs(ctx, level, "authz: "+string(event.EventType), attrs...)
 
 	return nil
 }
@@ -267,7 +276,7 @@ func (l *LogAuditLogger) LogGCPTokenEvent(ctx context.Context, event *GCPTokenEv
 		attrs = append(attrs, slog.String("fail_reason", event.FailReason))
 	}
 
-	l.log.LogAttrs(ctx, level, "GCP token audit event", attrs...)
+	l.logger().LogAttrs(ctx, level, "GCP token audit event", attrs...)
 
 	return nil
 }
@@ -290,7 +299,7 @@ func (l *LogAuditLogger) LogLifecycleHookEvent(ctx context.Context, event *Lifec
 		attrs = append(attrs, slog.String("fail_reason", event.FailReason))
 	}
 
-	l.log.LogAttrs(ctx, level, "lifecycle hook audit event", attrs...)
+	l.logger().LogAttrs(ctx, level, "lifecycle hook audit event", attrs...)
 
 	return nil
 }
@@ -321,7 +330,7 @@ func (l *LogAuditLogger) LogLifecycleHookExecutionEvent(ctx context.Context, eve
 		attrs = append(attrs, slog.String("fail_reason", event.FailReason))
 	}
 
-	l.log.LogAttrs(ctx, level, "lifecycle hook execution event", attrs...)
+	l.logger().LogAttrs(ctx, level, "lifecycle hook execution event", attrs...)
 
 	return nil
 }

--- a/pkg/hub/events.go
+++ b/pkg/hub/events.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
 )
 
 // EventPublisher defines the interface for publishing Hub events.
@@ -255,12 +256,14 @@ type ChannelEventPublisher struct {
 	mu          sync.RWMutex
 	subscribers map[string][]chan Event
 	closed      bool
+	log         *slog.Logger
 }
 
 // NewChannelEventPublisher creates a new ChannelEventPublisher.
 func NewChannelEventPublisher() *ChannelEventPublisher {
 	p := &ChannelEventPublisher{
 		subscribers: make(map[string][]chan Event),
+		log:         logging.Subsystem("hub.events"),
 	}
 	p.sink = p.publish
 	return p
@@ -300,7 +303,7 @@ func (p *ChannelEventPublisher) Subscribe(patterns ...string) (<-chan Event, fun
 func (p *ChannelEventPublisher) publish(subject string, event interface{}) {
 	data, err := json.Marshal(event)
 	if err != nil {
-		slog.Error("Failed to marshal event", "subject", subject, "error", err)
+		p.log.Error("Failed to marshal event", "subject", subject, "error", err)
 		return
 	}
 

--- a/pkg/hub/events.go
+++ b/pkg/hub/events.go
@@ -259,6 +259,16 @@ type ChannelEventPublisher struct {
 	log         *slog.Logger
 }
 
+// logger returns the events subsystem logger, falling back to slog.Default()
+// when the field is nil (e.g. in tests that construct ChannelEventPublisher
+// directly).
+func (p *ChannelEventPublisher) logger() *slog.Logger {
+	if p.log != nil {
+		return p.log
+	}
+	return slog.Default()
+}
+
 // NewChannelEventPublisher creates a new ChannelEventPublisher.
 func NewChannelEventPublisher() *ChannelEventPublisher {
 	p := &ChannelEventPublisher{
@@ -303,7 +313,7 @@ func (p *ChannelEventPublisher) Subscribe(patterns ...string) (<-chan Event, fun
 func (p *ChannelEventPublisher) publish(subject string, event interface{}) {
 	data, err := json.Marshal(event)
 	if err != nil {
-		p.log.Error("Failed to marshal event", "subject", subject, "error", err)
+		p.logger().Error("Failed to marshal event", "subject", subject, "error", err)
 		return
 	}
 

--- a/pkg/hub/handlers_groups.go
+++ b/pkg/hub/handlers_groups.go
@@ -16,7 +16,6 @@ package hub
 
 import (
 	"context"
-	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -219,7 +218,7 @@ func (s *Server) createGroup(w http.ResponseWriter, r *http.Request) {
 			Role:       store.GroupMemberRoleOwner,
 		}); err != nil && err != store.ErrAlreadyExists {
 			// Log but don't fail the group creation
-			slog.Warn("failed to add creator as owner of new group",
+			s.groupsLog.Warn("failed to add creator as owner of new group",
 				"group", group.ID, "user", createdBy, "error", err)
 		}
 	}

--- a/pkg/hub/handlers_groups.go
+++ b/pkg/hub/handlers_groups.go
@@ -218,7 +218,7 @@ func (s *Server) createGroup(w http.ResponseWriter, r *http.Request) {
 			Role:       store.GroupMemberRoleOwner,
 		}); err != nil && err != store.ErrAlreadyExists {
 			// Log but don't fail the group creation
-			s.groupsLog.Warn("failed to add creator as owner of new group",
+			s.groupsLogger().Warn("failed to add creator as owner of new group",
 				"group", group.ID, "user", createdBy, "error", err)
 		}
 	}

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -378,10 +377,10 @@ func (s *Server) createProject(w http.ResponseWriter, r *http.Request) {
 			UpdatedBy:     project.CreatedBy,
 		}
 		if _, _, err := s.secretBackend.Set(ctx, tokenInput); err != nil {
-			slog.Error("failed to save GitHub token as project secret",
+			s.projectsLog.Error("failed to save GitHub token as project secret",
 				"project_id", project.ID, "error", err)
 			if delErr := s.store.DeleteProject(ctx, project.ID); delErr != nil {
-				slog.Warn("failed to clean up project record after secret save failure",
+				s.projectsLog.Warn("failed to clean up project record after secret save failure",
 					"project_id", project.ID, "error", delErr)
 			}
 			writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
@@ -395,16 +394,16 @@ func (s *Server) createProject(w http.ResponseWriter, r *http.Request) {
 		// Shared-workspace git project: clone the repository into the workspace.
 		// Clone failure is a creation failure — clean up the project record.
 		if err := s.cloneSharedWorkspaceProject(ctx, project); err != nil {
-			slog.Error("shared workspace clone failed, rolling back project creation",
+			s.projectsLog.Error("shared workspace clone failed, rolling back project creation",
 				"project_id", project.ID, "slug", project.Slug, "error", err)
 			if req.GitHubToken != "" && s.secretBackend != nil && project.GitRemote != "" {
 				if delErr := s.secretBackend.Delete(ctx, "GITHUB_TOKEN", secret.ScopeProject, project.ID); delErr != nil {
-					slog.Warn("failed to clean up project secret after clone failure",
+					s.projectsLog.Warn("failed to clean up project secret after clone failure",
 						"project_id", project.ID, "error", delErr)
 				}
 			}
 			if delErr := s.store.DeleteProject(ctx, project.ID); delErr != nil {
-				slog.Warn("failed to clean up project record after clone failure",
+				s.projectsLog.Warn("failed to clean up project record after clone failure",
 					"project_id", project.ID, "error", delErr)
 			}
 			// Use appropriate HTTP status based on the error kind
@@ -429,7 +428,7 @@ func (s *Server) createProject(w http.ResponseWriter, r *http.Request) {
 	} else if project.GitRemote == "" {
 		// Hub-native project (no git remote): create workspace directory.
 		if err := s.initHubManagedProject(project); err != nil {
-			slog.Warn("failed to initialize project workspace",
+			s.projectsLog.Warn("failed to initialize project workspace",
 				"project_id", project.ID, "slug", project.Slug, "error", err)
 		}
 	}
@@ -458,20 +457,20 @@ func (s *Server) createProjectGroup(ctx context.Context, project *store.Project)
 	}
 	if err := s.store.CreateGroup(ctx, projectGroup); err != nil {
 		if !errors.Is(err, store.ErrAlreadyExists) {
-			slog.Warn("failed to create project group", "project_id", project.ID, "error", err.Error())
+			s.projectsLog.Warn("failed to create project group", "project_id", project.ID, "error", err.Error())
 			return
 		}
 		// Slug conflict — look it up and ensure project_id is current
 		existing, lookupErr := s.store.GetGroupBySlug(ctx, agentsSlug)
 		if lookupErr != nil {
-			slog.Warn("failed to look up existing project agents group by slug",
+			s.projectsLog.Warn("failed to look up existing project agents group by slug",
 				"project_id", project.ID, "slug", agentsSlug, "error", lookupErr.Error())
 			return
 		}
 		if existing.ProjectID != project.ID {
 			existing.ProjectID = project.ID
 			if updateErr := s.store.UpdateGroup(ctx, existing); updateErr != nil {
-				slog.Warn("failed to update existing project agents group",
+				s.projectsLog.Warn("failed to update existing project agents group",
 					"project_id", project.ID, "slug", agentsSlug, "error", updateErr.Error())
 			}
 		}
@@ -488,7 +487,7 @@ func (s *Server) createProjectGroup(ctx context.Context, project *store.Project)
 func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project *store.Project, callerUserID ...string) {
 	membersSlug := "project:" + project.Slug + ":members"
 
-	slog.Debug("ensuring project members group",
+	s.projectsLog.Debug("ensuring project members group",
 		"project_id", project.ID, "slug", project.Slug, "membersSlug", membersSlug)
 
 	// Create project members group, or look up the existing one
@@ -507,20 +506,20 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 		// when authentication uses proxy headers without provisioning a DB user record
 		// (e.g. legacy trusted-proxy auth on a fresh Postgres deployment). Retry
 		// without OwnerID so the group and its associated policy are still created.
-		slog.Warn("project members group owner not found, retrying without owner",
+		s.projectsLog.Warn("project members group owner not found, retrying without owner",
 			"project_id", project.ID, "owner_id", membersGroup.OwnerID, "error", createErr.Error())
 		membersGroup.OwnerID = ""
 		createErr = s.store.CreateGroup(ctx, membersGroup)
 	}
 	if createErr != nil {
 		if !errors.Is(createErr, store.ErrAlreadyExists) {
-			slog.Warn("failed to create project members group", "project_id", project.ID, "error", createErr.Error())
+			s.projectsLog.Warn("failed to create project members group", "project_id", project.ID, "error", createErr.Error())
 			return
 		}
 		// Slug conflict — look up existing group
 		existing, lookupErr := s.store.GetGroupBySlug(ctx, membersSlug)
 		if lookupErr != nil {
-			slog.Warn("failed to look up existing project members group by slug",
+			s.projectsLog.Warn("failed to look up existing project members group by slug",
 				"project_id", project.ID, "slug", membersSlug, "error", lookupErr.Error())
 			return
 		}
@@ -538,12 +537,12 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 		}
 		if needsUpdate {
 			if updateErr := s.store.UpdateGroup(ctx, membersGroup); updateErr != nil {
-				slog.Warn("failed to update existing project members group",
+				s.projectsLog.Warn("failed to update existing project members group",
 					"project_id", project.ID, "slug", membersSlug, "error", updateErr.Error())
 			}
 		}
 	} else {
-		slog.Info("created project members group",
+		s.projectsLog.Info("created project members group",
 			"project_id", project.ID, "group", membersGroup.ID, "slug", membersSlug)
 	}
 
@@ -555,7 +554,7 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 			MemberID:   project.CreatedBy,
 			Role:       store.GroupMemberRoleOwner,
 		}); err != nil && !errors.Is(err, store.ErrAlreadyExists) {
-			slog.Warn("failed to add creator as owner of project members group",
+			s.projectsLog.Warn("failed to add creator as owner of project members group",
 				"project_id", project.ID, "user", project.CreatedBy, "error", err.Error())
 		}
 	}
@@ -569,7 +568,7 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 			MemberID:   callerUserID[0],
 			Role:       store.GroupMemberRoleOwner,
 		}); err != nil && !errors.Is(err, store.ErrAlreadyExists) {
-			slog.Warn("failed to add caller as owner of project members group",
+			s.projectsLog.Warn("failed to add caller as owner of project members group",
 				"project_id", project.ID, "user", callerUserID[0], "error", err.Error())
 		}
 	}
@@ -583,10 +582,10 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 		if err == nil && len(members) == 1 && members[0].MemberType == store.GroupMemberTypeUser {
 			if promoteErr := s.store.UpdateGroupMemberRole(ctx, membersGroup.ID,
 				members[0].MemberType, members[0].MemberID, store.GroupMemberRoleOwner); promoteErr != nil {
-				slog.Warn("failed to promote sole member to owner",
+				s.projectsLog.Warn("failed to promote sole member to owner",
 					"project_id", project.ID, "group", membersGroup.ID, "user", members[0].MemberID, "error", promoteErr.Error())
 			} else {
-				slog.Info("promoted sole project member to owner",
+				s.projectsLog.Info("promoted sole project member to owner",
 					"project_id", project.ID, "group", membersGroup.ID, "user", members[0].MemberID)
 			}
 		}
@@ -606,7 +605,7 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 	}
 	if err := s.store.CreatePolicy(ctx, policy); err != nil {
 		if !errors.Is(err, store.ErrAlreadyExists) {
-			slog.Warn("failed to create project member policy",
+			s.projectsLog.Warn("failed to create project member policy",
 				"project_id", project.ID, "policy", policyName, "error", err.Error())
 			return
 		}
@@ -614,7 +613,7 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 		// project was recreated. Also ensure the binding to the current members group.
 		existing, lookupErr := s.store.ListPolicies(ctx, store.PolicyFilter{Name: policyName}, store.ListOptions{Limit: 1})
 		if lookupErr != nil || len(existing.Items) == 0 {
-			slog.Warn("failed to look up existing project member policy",
+			s.projectsLog.Warn("failed to look up existing project member policy",
 				"project_id", project.ID, "policy", policyName, "error", lookupErr)
 			return
 		}
@@ -638,7 +637,7 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 		}
 		if needsUpdate {
 			if updateErr := s.store.UpdatePolicy(ctx, policy); updateErr != nil {
-				slog.Warn("failed to update existing project member policy",
+				s.projectsLog.Warn("failed to update existing project member policy",
 					"project_id", project.ID, "policy", policyName, "error", updateErr.Error())
 			}
 		}
@@ -650,7 +649,7 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 		PrincipalType: "group",
 		PrincipalID:   membersGroup.ID,
 	}); err != nil && !errors.Is(err, store.ErrAlreadyExists) {
-		slog.Warn("failed to bind project member policy",
+		s.projectsLog.Warn("failed to bind project member policy",
 			"project_id", project.ID, "policy", policyName, "error", err.Error())
 	}
 }
@@ -738,7 +737,7 @@ func (s *Server) initHubManagedProject(project *store.Project) error {
 	}
 	for key, value := range settingsUpdates {
 		if err := config.UpdateSetting(scionDir, key, value, false); err != nil {
-			slog.Warn("failed to update hub-managed project setting",
+			s.projectsLog.Warn("failed to update hub-managed project setting",
 				"project_id", project.ID, "key", key, "error", err.Error())
 		}
 	}
@@ -779,7 +778,7 @@ func (s *Server) cloneSharedWorkspaceProject(ctx context.Context, project *store
 	// Seed the .scion project on top of the cloned workspace
 	scionDir := filepath.Join(workspacePath, ".scion")
 	if err := config.InitProject(scionDir, nil, config.InitProjectOpts{SkipRuntimeCheck: true}); err != nil {
-		slog.Warn("failed to initialize .scion in cloned workspace",
+		s.projectsLog.Warn("failed to initialize .scion in cloned workspace",
 			"project_id", project.ID, "error", err.Error())
 	}
 
@@ -792,7 +791,7 @@ func (s *Server) cloneSharedWorkspaceProject(ctx context.Context, project *store
 	}
 	for key, value := range settingsUpdates {
 		if err := config.UpdateSetting(scionDir, key, value, false); err != nil {
-			slog.Warn("failed to update shared-workspace project setting",
+			s.projectsLog.Warn("failed to update shared-workspace project setting",
 				"project_id", project.ID, "key", key, "error", err.Error())
 		}
 	}
@@ -814,7 +813,7 @@ func (s *Server) autoAssociateGitHubInstallation(ctx context.Context, project *s
 		Status: store.GitHubInstallationStatusActive,
 	})
 	if err != nil {
-		slog.Warn("failed to list GitHub App installations for auto-association",
+		s.projectsLog.Warn("failed to list GitHub App installations for auto-association",
 			"project_id", project.ID, "error", err)
 		return
 	}
@@ -830,10 +829,10 @@ func (s *Server) autoAssociateGitHubInstallation(ctx context.Context, project *s
 					LastChecked: timeNow(),
 				}
 				if err := s.store.UpdateProject(ctx, project); err != nil {
-					slog.Warn("failed to persist GitHub App installation association",
+					s.projectsLog.Warn("failed to persist GitHub App installation association",
 						"project_id", project.ID, "installation_id", installID, "error", err)
 				} else {
-					slog.Info("auto-associated project with GitHub App installation at creation time",
+					s.projectsLog.Info("auto-associated project with GitHub App installation at creation time",
 						"project_id", project.ID, "project_name", project.Name,
 						"installation_id", installID, "account", inst.AccountLogin)
 					s.events.PublishProjectUpdated(ctx, project)
@@ -857,7 +856,7 @@ func (s *Server) resolveCloneToken(ctx context.Context, project *store.Project) 
 			return token
 		}
 		if err != nil {
-			slog.Warn("failed to mint GitHub App token for clone, trying secrets",
+			s.projectsLog.Warn("failed to mint GitHub App token for clone, trying secrets",
 				"project_id", project.ID, "error", err.Error())
 		}
 	}
@@ -873,7 +872,7 @@ func (s *Server) resolveCloneToken(ctx context.Context, project *store.Project) 
 		if project.CreatedBy != "" {
 			sv, err = s.secretBackend.Get(ctx, "GITHUB_TOKEN", "user", project.CreatedBy)
 			if err == nil && sv != nil && sv.Value != "" {
-				slog.Info("using creator's GitHub token for project clone",
+				s.projectsLog.Info("using creator's GitHub token for project clone",
 					"project_id", project.ID, "user_id", project.CreatedBy)
 				return sv.Value
 			}
@@ -1074,7 +1073,7 @@ func (s *Server) handleProjectRegister(w http.ResponseWriter, r *http.Request) {
 		if user := GetUserIdentityFromContext(ctx); user != nil {
 			callerID = user.ID()
 		}
-		slog.Debug("ensuring groups for existing project during register",
+		s.projectsLog.Debug("ensuring groups for existing project during register",
 			"project_id", project.ID, "slug", project.Slug, "caller", callerID)
 		s.createProjectGroup(ctx, project)
 		s.createProjectMembersGroupAndPolicy(ctx, project, callerID)
@@ -1130,7 +1129,7 @@ func (s *Server) handleProjectRegister(w http.ResponseWriter, r *http.Request) {
 		if localPath != "" {
 			scionDir := filepath.Join(localPath, ".scion")
 			if err := config.InitProject(scionDir, nil, config.InitProjectOpts{SkipRuntimeCheck: true}); err != nil {
-				slog.Warn("failed to initialize .scion in linked project",
+				s.projectsLog.Warn("failed to initialize .scion in linked project",
 					"project_id", project.ID, "localPath", localPath, "error", err.Error())
 			}
 		}
@@ -2005,7 +2004,7 @@ func (s *Server) handleProjectAgentAction(w http.ResponseWriter, r *http.Request
 		if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
 			decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), ActionAttach)
 			if !decision.Allowed {
-				slog.Warn("agent authz check failed",
+				s.projectsLog.Warn("agent authz check failed",
 					"agent_id", agent.ID,
 					"agent_slug", agent.Slug,
 					"agent_owner_id", agent.OwnerID,
@@ -2207,11 +2206,11 @@ func (s *Server) migrateProjectSlug(ctx context.Context, project *store.Project,
 		group.Slug = newAgentsSlug
 		group.Name = project.Name + " Agents"
 		if err := s.store.UpdateGroup(ctx, group); err != nil {
-			slog.Warn("failed to migrate project agents group slug",
+			s.projectsLog.Warn("failed to migrate project agents group slug",
 				"project_id", project.ID, "old_slug", oldAgentsSlug, "new_slug", newAgentsSlug, "error", err)
 		}
 	} else if err != store.ErrNotFound {
-		slog.Warn("failed to retrieve project agents group for migration",
+		s.projectsLog.Warn("failed to retrieve project agents group for migration",
 			"project_id", project.ID, "old_slug", oldAgentsSlug, "error", err)
 	}
 
@@ -2222,11 +2221,11 @@ func (s *Server) migrateProjectSlug(ctx context.Context, project *store.Project,
 		group.Slug = newMembersSlug
 		group.Name = project.Name + " Members"
 		if err := s.store.UpdateGroup(ctx, group); err != nil {
-			slog.Warn("failed to migrate project members group slug",
+			s.projectsLog.Warn("failed to migrate project members group slug",
 				"project_id", project.ID, "old_slug", oldMembersSlug, "new_slug", newMembersSlug, "error", err)
 		}
 	} else if err != store.ErrNotFound {
-		slog.Warn("failed to retrieve project members group for migration",
+		s.projectsLog.Warn("failed to retrieve project members group for migration",
 			"project_id", project.ID, "old_slug", oldMembersSlug, "error", err)
 	}
 
@@ -2237,11 +2236,11 @@ func (s *Server) migrateProjectSlug(ctx context.Context, project *store.Project,
 		policy := &policies.Items[0]
 		policy.Name = newPolicyName
 		if err := s.store.UpdatePolicy(ctx, policy); err != nil {
-			slog.Warn("failed to migrate project member policy name",
+			s.projectsLog.Warn("failed to migrate project member policy name",
 				"project_id", project.ID, "old_policy", oldPolicyName, "new_policy", newPolicyName, "error", err)
 		}
 	} else if err != nil {
-		slog.Warn("failed to retrieve project member policy for migration",
+		s.projectsLog.Warn("failed to retrieve project member policy for migration",
 			"project_id", project.ID, "old_policy", oldPolicyName, "error", err)
 	}
 
@@ -2252,7 +2251,7 @@ func (s *Server) migrateProjectSlug(ctx context.Context, project *store.Project,
 			newPath := filepath.Join(filepath.Dir(oldPath), newSlug)
 			if _, statErr := os.Stat(newPath); os.IsNotExist(statErr) {
 				if err := os.Rename(oldPath, newPath); err != nil {
-					slog.Warn("failed to rename project workspace directory",
+					s.projectsLog.Warn("failed to rename project workspace directory",
 						"project_id", project.ID, "old_path", oldPath, "new_path", newPath, "error", err)
 				}
 			}
@@ -2276,7 +2275,7 @@ func (s *Server) migrateProjectSlug(ctx context.Context, project *store.Project,
 				if _, statErr := os.Stat(newConfigDir); os.IsNotExist(statErr) {
 					if err := os.MkdirAll(filepath.Dir(newConfigDir), 0755); err == nil {
 						if err := os.Rename(oldConfigDir, newConfigDir); err != nil {
-							slog.Warn("failed to rename project config directory",
+							s.projectsLog.Warn("failed to rename project config directory",
 								"project_id", project.ID, "old_path", oldConfigDir, "new_path", newConfigDir, "error", err)
 						}
 					}
@@ -2314,7 +2313,7 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 	if projectGroups, err := s.store.ListGroups(ctx, store.GroupFilter{ProjectID: id}, store.ListOptions{Limit: 100}); err == nil {
 		for _, g := range projectGroups.Items {
 			if delErr := s.store.DeleteGroup(ctx, g.ID); delErr != nil {
-				slog.Warn("failed to delete project group", "project_id", id, "group", g.ID, "slug", g.Slug, "error", delErr.Error())
+				s.projectsLog.Warn("failed to delete project group", "project_id", id, "group", g.ID, "slug", g.Slug, "error", delErr.Error())
 			}
 		}
 	}
@@ -2323,7 +2322,7 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 	if projectPolicies, err := s.store.ListPolicies(ctx, store.PolicyFilter{ScopeType: "project", ScopeID: id}, store.ListOptions{Limit: 100}); err == nil {
 		for _, p := range projectPolicies.Items {
 			if delErr := s.store.DeletePolicy(ctx, p.ID); delErr != nil {
-				slog.Warn("failed to delete project policy", "project_id", id, "policy", p.ID, "name", p.Name, "error", delErr.Error())
+				s.projectsLog.Warn("failed to delete project policy", "project_id", id, "policy", p.ID, "name", p.Name, "error", delErr.Error())
 			}
 		}
 	}
@@ -2331,24 +2330,24 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 	// Clean up project-scoped env vars (best-effort).
 	// These use scope/scope_id without FK cascade.
 	if n, err := s.store.DeleteEnvVarsByScope(ctx, store.ScopeProject, id); err != nil {
-		slog.Warn("failed to delete project env vars", "project_id", id, "error", err)
+		s.projectsLog.Warn("failed to delete project env vars", "project_id", id, "error", err)
 	} else if n > 0 {
-		slog.Info("deleted project env vars", "project_id", id, "count", n)
+		s.projectsLog.Info("deleted project env vars", "project_id", id, "count", n)
 	}
 
 	// Clean up project-scoped secrets (best-effort).
 	if n, err := s.store.DeleteSecretsByScope(ctx, store.ScopeProject, id); err != nil {
-		slog.Warn("failed to delete project secrets", "project_id", id, "error", err)
+		s.projectsLog.Warn("failed to delete project secrets", "project_id", id, "error", err)
 	} else if n > 0 {
-		slog.Info("deleted project secrets", "project_id", id, "count", n)
+		s.projectsLog.Info("deleted project secrets", "project_id", id, "count", n)
 	}
 
 	// Clean up project-scoped skill injections (best-effort).
 	// These use scope/scope_id without FK cascade.
 	if n, err := s.store.DeleteSkillInjectionsByScope(ctx, store.SkillInjectionScopeProject, id); err != nil {
-		slog.Warn("failed to delete project skill injections", "project_id", id, "error", err)
+		s.projectsLog.Warn("failed to delete project skill injections", "project_id", id, "error", err)
 	} else if n > 0 {
-		slog.Info("deleted project skill injections", "project_id", id, "count", n)
+		s.projectsLog.Info("deleted project skill injections", "project_id", id, "count", n)
 	}
 
 	// Warn about retained managed GCP service accounts (best-effort).
@@ -2362,7 +2361,7 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 	}); err == nil {
 		for _, sa := range sas {
 			if delErr := s.store.DeleteGCPServiceAccount(ctx, sa.ID); delErr != nil {
-				slog.Warn("failed to delete project GCP service account registration",
+				s.projectsLog.Warn("failed to delete project GCP service account registration",
 					"project_id", id, "sa_id", sa.ID, "email", sa.Email, "error", delErr.Error())
 			}
 		}
@@ -2390,7 +2389,7 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 	if (project.GitRemote == "" || project.IsSharedWorkspace()) && project.Slug != "" {
 		if projectPath, err := hubManagedProjectPath(project.Slug); err == nil {
 			if err := util.RemoveAllSafe(projectPath); err != nil {
-				slog.Warn("failed to remove hub-managed project directory",
+				s.projectsLog.Warn("failed to remove hub-managed project directory",
 					"project_id", id, "slug", project.Slug, "path", projectPath, "error", err)
 			}
 		}
@@ -2409,7 +2408,7 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 			// remove the parent (<slug__uuid>) directory.
 			projectConfigDir := filepath.Dir(configPath)
 			if err := config.RemoveProjectConfig(projectConfigDir); err != nil && !os.IsNotExist(err) {
-				slog.Warn("failed to remove project config directory",
+				s.projectsLog.Warn("failed to remove project config directory",
 					"project_id", id, "slug", project.Slug, "path", projectConfigDir, "error", err)
 			}
 		}
@@ -2457,12 +2456,12 @@ func (s *Server) deleteProjectTemplates(ctx context.Context, projectID string) {
 		ScopeID: projectID,
 	}, store.ListOptions{Limit: 1000})
 	if err != nil {
-		slog.Warn("failed to list project templates for deletion", "project_id", projectID, "error", err)
+		s.projectsLog.Warn("failed to list project templates for deletion", "project_id", projectID, "error", err)
 	} else if stor := s.GetStorage(); stor != nil {
 		for _, tmpl := range templates.Items {
 			if tmpl.StoragePath != "" {
 				if err := stor.DeletePrefix(ctx, tmpl.StoragePath); err != nil {
-					slog.Warn("failed to delete template storage files",
+					s.projectsLog.Warn("failed to delete template storage files",
 						"project_id", projectID, "template", tmpl.ID, "path", tmpl.StoragePath, "error", err)
 				}
 			}
@@ -2470,9 +2469,9 @@ func (s *Server) deleteProjectTemplates(ctx context.Context, projectID string) {
 	}
 
 	if n, err := s.store.DeleteTemplatesByScope(ctx, store.ScopeProject, projectID); err != nil {
-		slog.Warn("failed to delete project templates", "project_id", projectID, "error", err)
+		s.projectsLog.Warn("failed to delete project templates", "project_id", projectID, "error", err)
 	} else if n > 0 {
-		slog.Info("deleted project templates", "project_id", projectID, "count", n)
+		s.projectsLog.Info("deleted project templates", "project_id", projectID, "count", n)
 	}
 }
 
@@ -2486,12 +2485,12 @@ func (s *Server) warnManagedGCPServiceAccounts(ctx context.Context, projectID st
 		Managed: &managed,
 	})
 	if err != nil {
-		slog.Warn("failed to list managed GCP SAs for project deletion warning",
+		s.projectsLog.Warn("failed to list managed GCP SAs for project deletion warning",
 			"project_id", projectID, "error", err)
 		return
 	}
 	for _, sa := range sas {
-		slog.Warn("project deletion: managed GCP service account retained in GCP — manual cleanup may be required",
+		s.projectsLog.Warn("project deletion: managed GCP service account retained in GCP — manual cleanup may be required",
 			"project_id", projectID, "sa_email", sa.Email, "sa_id", sa.ID, "project_id", sa.ProjectID)
 	}
 }
@@ -2506,12 +2505,12 @@ func (s *Server) deleteProjectHarnessConfigs(ctx context.Context, projectID stri
 		ScopeID: projectID,
 	}, store.ListOptions{Limit: 1000})
 	if err != nil {
-		slog.Warn("failed to list project harness configs for deletion", "project_id", projectID, "error", err)
+		s.projectsLog.Warn("failed to list project harness configs for deletion", "project_id", projectID, "error", err)
 	} else if stor := s.GetStorage(); stor != nil {
 		for _, hc := range configs.Items {
 			if hc.StoragePath != "" {
 				if err := stor.DeletePrefix(ctx, hc.StoragePath); err != nil {
-					slog.Warn("failed to delete harness config storage files",
+					s.projectsLog.Warn("failed to delete harness config storage files",
 						"project_id", projectID, "harnessConfig", hc.ID, "path", hc.StoragePath, "error", err)
 				}
 			}
@@ -2519,9 +2518,9 @@ func (s *Server) deleteProjectHarnessConfigs(ctx context.Context, projectID stri
 	}
 
 	if n, err := s.store.DeleteHarnessConfigsByScope(ctx, store.ScopeProject, projectID); err != nil {
-		slog.Warn("failed to delete project harness configs", "project_id", projectID, "error", err)
+		s.projectsLog.Warn("failed to delete project harness configs", "project_id", projectID, "error", err)
 	} else if n > 0 {
-		slog.Info("deleted project harness configs", "project_id", projectID, "count", n)
+		s.projectsLog.Info("deleted project harness configs", "project_id", projectID, "count", n)
 	}
 }
 
@@ -2536,7 +2535,7 @@ func (s *Server) cleanupBrokerProjectDirectories(ctx context.Context, project *s
 
 	providers, err := s.store.GetProjectProviders(ctx, project.ID)
 	if err != nil {
-		slog.Warn("failed to get project providers for cleanup", "project_id", project.ID, "error", err)
+		s.projectsLog.Warn("failed to get project providers for cleanup", "project_id", project.ID, "error", err)
 		return
 	}
 
@@ -2552,7 +2551,7 @@ func (s *Server) cleanupBrokerProjectDirectories(ctx context.Context, project *s
 		}
 	}
 	if client == nil {
-		slog.Warn("no RuntimeBrokerClient available for project cleanup dispatch", "project_id", project.ID)
+		s.projectsLog.Warn("no RuntimeBrokerClient available for project cleanup dispatch", "project_id", project.ID)
 		return
 	}
 
@@ -2564,13 +2563,13 @@ func (s *Server) cleanupBrokerProjectDirectories(ctx context.Context, project *s
 
 		broker, err := s.store.GetRuntimeBroker(ctx, provider.BrokerID)
 		if err != nil {
-			slog.Warn("failed to get broker for project cleanup",
+			s.projectsLog.Warn("failed to get broker for project cleanup",
 				"project_id", project.ID, "broker", provider.BrokerID, "error", err)
 			continue
 		}
 
 		if err := client.CleanupProject(ctx, provider.BrokerID, broker.Endpoint, project.Slug, project.ID); err != nil {
-			slog.Warn("failed to cleanup project on broker",
+			s.projectsLog.Warn("failed to cleanup project on broker",
 				"project_id", project.ID, "slug", project.Slug,
 				"broker", provider.BrokerID, "endpoint", broker.Endpoint, "error", err)
 		}

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -377,10 +377,10 @@ func (s *Server) createProject(w http.ResponseWriter, r *http.Request) {
 			UpdatedBy:     project.CreatedBy,
 		}
 		if _, _, err := s.secretBackend.Set(ctx, tokenInput); err != nil {
-			s.projectsLog.Error("failed to save GitHub token as project secret",
+			s.projectsLogger().Error("failed to save GitHub token as project secret",
 				"project_id", project.ID, "error", err)
 			if delErr := s.store.DeleteProject(ctx, project.ID); delErr != nil {
-				s.projectsLog.Warn("failed to clean up project record after secret save failure",
+				s.projectsLogger().Warn("failed to clean up project record after secret save failure",
 					"project_id", project.ID, "error", delErr)
 			}
 			writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
@@ -394,16 +394,16 @@ func (s *Server) createProject(w http.ResponseWriter, r *http.Request) {
 		// Shared-workspace git project: clone the repository into the workspace.
 		// Clone failure is a creation failure — clean up the project record.
 		if err := s.cloneSharedWorkspaceProject(ctx, project); err != nil {
-			s.projectsLog.Error("shared workspace clone failed, rolling back project creation",
+			s.projectsLogger().Error("shared workspace clone failed, rolling back project creation",
 				"project_id", project.ID, "slug", project.Slug, "error", err)
 			if req.GitHubToken != "" && s.secretBackend != nil && project.GitRemote != "" {
 				if delErr := s.secretBackend.Delete(ctx, "GITHUB_TOKEN", secret.ScopeProject, project.ID); delErr != nil {
-					s.projectsLog.Warn("failed to clean up project secret after clone failure",
+					s.projectsLogger().Warn("failed to clean up project secret after clone failure",
 						"project_id", project.ID, "error", delErr)
 				}
 			}
 			if delErr := s.store.DeleteProject(ctx, project.ID); delErr != nil {
-				s.projectsLog.Warn("failed to clean up project record after clone failure",
+				s.projectsLogger().Warn("failed to clean up project record after clone failure",
 					"project_id", project.ID, "error", delErr)
 			}
 			// Use appropriate HTTP status based on the error kind
@@ -428,7 +428,7 @@ func (s *Server) createProject(w http.ResponseWriter, r *http.Request) {
 	} else if project.GitRemote == "" {
 		// Hub-native project (no git remote): create workspace directory.
 		if err := s.initHubManagedProject(project); err != nil {
-			s.projectsLog.Warn("failed to initialize project workspace",
+			s.projectsLogger().Warn("failed to initialize project workspace",
 				"project_id", project.ID, "slug", project.Slug, "error", err)
 		}
 	}
@@ -457,20 +457,20 @@ func (s *Server) createProjectGroup(ctx context.Context, project *store.Project)
 	}
 	if err := s.store.CreateGroup(ctx, projectGroup); err != nil {
 		if !errors.Is(err, store.ErrAlreadyExists) {
-			s.projectsLog.Warn("failed to create project group", "project_id", project.ID, "error", err.Error())
+			s.projectsLogger().Warn("failed to create project group", "project_id", project.ID, "error", err.Error())
 			return
 		}
 		// Slug conflict — look it up and ensure project_id is current
 		existing, lookupErr := s.store.GetGroupBySlug(ctx, agentsSlug)
 		if lookupErr != nil {
-			s.projectsLog.Warn("failed to look up existing project agents group by slug",
+			s.projectsLogger().Warn("failed to look up existing project agents group by slug",
 				"project_id", project.ID, "slug", agentsSlug, "error", lookupErr.Error())
 			return
 		}
 		if existing.ProjectID != project.ID {
 			existing.ProjectID = project.ID
 			if updateErr := s.store.UpdateGroup(ctx, existing); updateErr != nil {
-				s.projectsLog.Warn("failed to update existing project agents group",
+				s.projectsLogger().Warn("failed to update existing project agents group",
 					"project_id", project.ID, "slug", agentsSlug, "error", updateErr.Error())
 			}
 		}
@@ -487,7 +487,7 @@ func (s *Server) createProjectGroup(ctx context.Context, project *store.Project)
 func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project *store.Project, callerUserID ...string) {
 	membersSlug := "project:" + project.Slug + ":members"
 
-	s.projectsLog.Debug("ensuring project members group",
+	s.projectsLogger().Debug("ensuring project members group",
 		"project_id", project.ID, "slug", project.Slug, "membersSlug", membersSlug)
 
 	// Create project members group, or look up the existing one
@@ -506,20 +506,20 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 		// when authentication uses proxy headers without provisioning a DB user record
 		// (e.g. legacy trusted-proxy auth on a fresh Postgres deployment). Retry
 		// without OwnerID so the group and its associated policy are still created.
-		s.projectsLog.Warn("project members group owner not found, retrying without owner",
+		s.projectsLogger().Warn("project members group owner not found, retrying without owner",
 			"project_id", project.ID, "owner_id", membersGroup.OwnerID, "error", createErr.Error())
 		membersGroup.OwnerID = ""
 		createErr = s.store.CreateGroup(ctx, membersGroup)
 	}
 	if createErr != nil {
 		if !errors.Is(createErr, store.ErrAlreadyExists) {
-			s.projectsLog.Warn("failed to create project members group", "project_id", project.ID, "error", createErr.Error())
+			s.projectsLogger().Warn("failed to create project members group", "project_id", project.ID, "error", createErr.Error())
 			return
 		}
 		// Slug conflict — look up existing group
 		existing, lookupErr := s.store.GetGroupBySlug(ctx, membersSlug)
 		if lookupErr != nil {
-			s.projectsLog.Warn("failed to look up existing project members group by slug",
+			s.projectsLogger().Warn("failed to look up existing project members group by slug",
 				"project_id", project.ID, "slug", membersSlug, "error", lookupErr.Error())
 			return
 		}
@@ -537,12 +537,12 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 		}
 		if needsUpdate {
 			if updateErr := s.store.UpdateGroup(ctx, membersGroup); updateErr != nil {
-				s.projectsLog.Warn("failed to update existing project members group",
+				s.projectsLogger().Warn("failed to update existing project members group",
 					"project_id", project.ID, "slug", membersSlug, "error", updateErr.Error())
 			}
 		}
 	} else {
-		s.projectsLog.Info("created project members group",
+		s.projectsLogger().Info("created project members group",
 			"project_id", project.ID, "group", membersGroup.ID, "slug", membersSlug)
 	}
 
@@ -554,7 +554,7 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 			MemberID:   project.CreatedBy,
 			Role:       store.GroupMemberRoleOwner,
 		}); err != nil && !errors.Is(err, store.ErrAlreadyExists) {
-			s.projectsLog.Warn("failed to add creator as owner of project members group",
+			s.projectsLogger().Warn("failed to add creator as owner of project members group",
 				"project_id", project.ID, "user", project.CreatedBy, "error", err.Error())
 		}
 	}
@@ -568,7 +568,7 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 			MemberID:   callerUserID[0],
 			Role:       store.GroupMemberRoleOwner,
 		}); err != nil && !errors.Is(err, store.ErrAlreadyExists) {
-			s.projectsLog.Warn("failed to add caller as owner of project members group",
+			s.projectsLogger().Warn("failed to add caller as owner of project members group",
 				"project_id", project.ID, "user", callerUserID[0], "error", err.Error())
 		}
 	}
@@ -582,10 +582,10 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 		if err == nil && len(members) == 1 && members[0].MemberType == store.GroupMemberTypeUser {
 			if promoteErr := s.store.UpdateGroupMemberRole(ctx, membersGroup.ID,
 				members[0].MemberType, members[0].MemberID, store.GroupMemberRoleOwner); promoteErr != nil {
-				s.projectsLog.Warn("failed to promote sole member to owner",
+				s.projectsLogger().Warn("failed to promote sole member to owner",
 					"project_id", project.ID, "group", membersGroup.ID, "user", members[0].MemberID, "error", promoteErr.Error())
 			} else {
-				s.projectsLog.Info("promoted sole project member to owner",
+				s.projectsLogger().Info("promoted sole project member to owner",
 					"project_id", project.ID, "group", membersGroup.ID, "user", members[0].MemberID)
 			}
 		}
@@ -605,7 +605,7 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 	}
 	if err := s.store.CreatePolicy(ctx, policy); err != nil {
 		if !errors.Is(err, store.ErrAlreadyExists) {
-			s.projectsLog.Warn("failed to create project member policy",
+			s.projectsLogger().Warn("failed to create project member policy",
 				"project_id", project.ID, "policy", policyName, "error", err.Error())
 			return
 		}
@@ -613,7 +613,7 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 		// project was recreated. Also ensure the binding to the current members group.
 		existing, lookupErr := s.store.ListPolicies(ctx, store.PolicyFilter{Name: policyName}, store.ListOptions{Limit: 1})
 		if lookupErr != nil || len(existing.Items) == 0 {
-			s.projectsLog.Warn("failed to look up existing project member policy",
+			s.projectsLogger().Warn("failed to look up existing project member policy",
 				"project_id", project.ID, "policy", policyName, "error", lookupErr)
 			return
 		}
@@ -637,7 +637,7 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 		}
 		if needsUpdate {
 			if updateErr := s.store.UpdatePolicy(ctx, policy); updateErr != nil {
-				s.projectsLog.Warn("failed to update existing project member policy",
+				s.projectsLogger().Warn("failed to update existing project member policy",
 					"project_id", project.ID, "policy", policyName, "error", updateErr.Error())
 			}
 		}
@@ -649,7 +649,7 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 		PrincipalType: "group",
 		PrincipalID:   membersGroup.ID,
 	}); err != nil && !errors.Is(err, store.ErrAlreadyExists) {
-		s.projectsLog.Warn("failed to bind project member policy",
+		s.projectsLogger().Warn("failed to bind project member policy",
 			"project_id", project.ID, "policy", policyName, "error", err.Error())
 	}
 }
@@ -737,7 +737,7 @@ func (s *Server) initHubManagedProject(project *store.Project) error {
 	}
 	for key, value := range settingsUpdates {
 		if err := config.UpdateSetting(scionDir, key, value, false); err != nil {
-			s.projectsLog.Warn("failed to update hub-managed project setting",
+			s.projectsLogger().Warn("failed to update hub-managed project setting",
 				"project_id", project.ID, "key", key, "error", err.Error())
 		}
 	}
@@ -778,7 +778,7 @@ func (s *Server) cloneSharedWorkspaceProject(ctx context.Context, project *store
 	// Seed the .scion project on top of the cloned workspace
 	scionDir := filepath.Join(workspacePath, ".scion")
 	if err := config.InitProject(scionDir, nil, config.InitProjectOpts{SkipRuntimeCheck: true}); err != nil {
-		s.projectsLog.Warn("failed to initialize .scion in cloned workspace",
+		s.projectsLogger().Warn("failed to initialize .scion in cloned workspace",
 			"project_id", project.ID, "error", err.Error())
 	}
 
@@ -791,7 +791,7 @@ func (s *Server) cloneSharedWorkspaceProject(ctx context.Context, project *store
 	}
 	for key, value := range settingsUpdates {
 		if err := config.UpdateSetting(scionDir, key, value, false); err != nil {
-			s.projectsLog.Warn("failed to update shared-workspace project setting",
+			s.projectsLogger().Warn("failed to update shared-workspace project setting",
 				"project_id", project.ID, "key", key, "error", err.Error())
 		}
 	}
@@ -813,7 +813,7 @@ func (s *Server) autoAssociateGitHubInstallation(ctx context.Context, project *s
 		Status: store.GitHubInstallationStatusActive,
 	})
 	if err != nil {
-		s.projectsLog.Warn("failed to list GitHub App installations for auto-association",
+		s.projectsLogger().Warn("failed to list GitHub App installations for auto-association",
 			"project_id", project.ID, "error", err)
 		return
 	}
@@ -829,10 +829,10 @@ func (s *Server) autoAssociateGitHubInstallation(ctx context.Context, project *s
 					LastChecked: timeNow(),
 				}
 				if err := s.store.UpdateProject(ctx, project); err != nil {
-					s.projectsLog.Warn("failed to persist GitHub App installation association",
+					s.projectsLogger().Warn("failed to persist GitHub App installation association",
 						"project_id", project.ID, "installation_id", installID, "error", err)
 				} else {
-					s.projectsLog.Info("auto-associated project with GitHub App installation at creation time",
+					s.projectsLogger().Info("auto-associated project with GitHub App installation at creation time",
 						"project_id", project.ID, "project_name", project.Name,
 						"installation_id", installID, "account", inst.AccountLogin)
 					s.events.PublishProjectUpdated(ctx, project)
@@ -856,7 +856,7 @@ func (s *Server) resolveCloneToken(ctx context.Context, project *store.Project) 
 			return token
 		}
 		if err != nil {
-			s.projectsLog.Warn("failed to mint GitHub App token for clone, trying secrets",
+			s.projectsLogger().Warn("failed to mint GitHub App token for clone, trying secrets",
 				"project_id", project.ID, "error", err.Error())
 		}
 	}
@@ -872,7 +872,7 @@ func (s *Server) resolveCloneToken(ctx context.Context, project *store.Project) 
 		if project.CreatedBy != "" {
 			sv, err = s.secretBackend.Get(ctx, "GITHUB_TOKEN", "user", project.CreatedBy)
 			if err == nil && sv != nil && sv.Value != "" {
-				s.projectsLog.Info("using creator's GitHub token for project clone",
+				s.projectsLogger().Info("using creator's GitHub token for project clone",
 					"project_id", project.ID, "user_id", project.CreatedBy)
 				return sv.Value
 			}
@@ -1073,7 +1073,7 @@ func (s *Server) handleProjectRegister(w http.ResponseWriter, r *http.Request) {
 		if user := GetUserIdentityFromContext(ctx); user != nil {
 			callerID = user.ID()
 		}
-		s.projectsLog.Debug("ensuring groups for existing project during register",
+		s.projectsLogger().Debug("ensuring groups for existing project during register",
 			"project_id", project.ID, "slug", project.Slug, "caller", callerID)
 		s.createProjectGroup(ctx, project)
 		s.createProjectMembersGroupAndPolicy(ctx, project, callerID)
@@ -1129,7 +1129,7 @@ func (s *Server) handleProjectRegister(w http.ResponseWriter, r *http.Request) {
 		if localPath != "" {
 			scionDir := filepath.Join(localPath, ".scion")
 			if err := config.InitProject(scionDir, nil, config.InitProjectOpts{SkipRuntimeCheck: true}); err != nil {
-				s.projectsLog.Warn("failed to initialize .scion in linked project",
+				s.projectsLogger().Warn("failed to initialize .scion in linked project",
 					"project_id", project.ID, "localPath", localPath, "error", err.Error())
 			}
 		}
@@ -2004,7 +2004,7 @@ func (s *Server) handleProjectAgentAction(w http.ResponseWriter, r *http.Request
 		if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
 			decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), ActionAttach)
 			if !decision.Allowed {
-				s.projectsLog.Warn("agent authz check failed",
+				s.projectsLogger().Warn("agent authz check failed",
 					"agent_id", agent.ID,
 					"agent_slug", agent.Slug,
 					"agent_owner_id", agent.OwnerID,
@@ -2206,11 +2206,11 @@ func (s *Server) migrateProjectSlug(ctx context.Context, project *store.Project,
 		group.Slug = newAgentsSlug
 		group.Name = project.Name + " Agents"
 		if err := s.store.UpdateGroup(ctx, group); err != nil {
-			s.projectsLog.Warn("failed to migrate project agents group slug",
+			s.projectsLogger().Warn("failed to migrate project agents group slug",
 				"project_id", project.ID, "old_slug", oldAgentsSlug, "new_slug", newAgentsSlug, "error", err)
 		}
 	} else if err != store.ErrNotFound {
-		s.projectsLog.Warn("failed to retrieve project agents group for migration",
+		s.projectsLogger().Warn("failed to retrieve project agents group for migration",
 			"project_id", project.ID, "old_slug", oldAgentsSlug, "error", err)
 	}
 
@@ -2221,11 +2221,11 @@ func (s *Server) migrateProjectSlug(ctx context.Context, project *store.Project,
 		group.Slug = newMembersSlug
 		group.Name = project.Name + " Members"
 		if err := s.store.UpdateGroup(ctx, group); err != nil {
-			s.projectsLog.Warn("failed to migrate project members group slug",
+			s.projectsLogger().Warn("failed to migrate project members group slug",
 				"project_id", project.ID, "old_slug", oldMembersSlug, "new_slug", newMembersSlug, "error", err)
 		}
 	} else if err != store.ErrNotFound {
-		s.projectsLog.Warn("failed to retrieve project members group for migration",
+		s.projectsLogger().Warn("failed to retrieve project members group for migration",
 			"project_id", project.ID, "old_slug", oldMembersSlug, "error", err)
 	}
 
@@ -2236,11 +2236,11 @@ func (s *Server) migrateProjectSlug(ctx context.Context, project *store.Project,
 		policy := &policies.Items[0]
 		policy.Name = newPolicyName
 		if err := s.store.UpdatePolicy(ctx, policy); err != nil {
-			s.projectsLog.Warn("failed to migrate project member policy name",
+			s.projectsLogger().Warn("failed to migrate project member policy name",
 				"project_id", project.ID, "old_policy", oldPolicyName, "new_policy", newPolicyName, "error", err)
 		}
 	} else if err != nil {
-		s.projectsLog.Warn("failed to retrieve project member policy for migration",
+		s.projectsLogger().Warn("failed to retrieve project member policy for migration",
 			"project_id", project.ID, "old_policy", oldPolicyName, "error", err)
 	}
 
@@ -2251,7 +2251,7 @@ func (s *Server) migrateProjectSlug(ctx context.Context, project *store.Project,
 			newPath := filepath.Join(filepath.Dir(oldPath), newSlug)
 			if _, statErr := os.Stat(newPath); os.IsNotExist(statErr) {
 				if err := os.Rename(oldPath, newPath); err != nil {
-					s.projectsLog.Warn("failed to rename project workspace directory",
+					s.projectsLogger().Warn("failed to rename project workspace directory",
 						"project_id", project.ID, "old_path", oldPath, "new_path", newPath, "error", err)
 				}
 			}
@@ -2275,7 +2275,7 @@ func (s *Server) migrateProjectSlug(ctx context.Context, project *store.Project,
 				if _, statErr := os.Stat(newConfigDir); os.IsNotExist(statErr) {
 					if err := os.MkdirAll(filepath.Dir(newConfigDir), 0755); err == nil {
 						if err := os.Rename(oldConfigDir, newConfigDir); err != nil {
-							s.projectsLog.Warn("failed to rename project config directory",
+							s.projectsLogger().Warn("failed to rename project config directory",
 								"project_id", project.ID, "old_path", oldConfigDir, "new_path", newConfigDir, "error", err)
 						}
 					}
@@ -2313,7 +2313,7 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 	if projectGroups, err := s.store.ListGroups(ctx, store.GroupFilter{ProjectID: id}, store.ListOptions{Limit: 100}); err == nil {
 		for _, g := range projectGroups.Items {
 			if delErr := s.store.DeleteGroup(ctx, g.ID); delErr != nil {
-				s.projectsLog.Warn("failed to delete project group", "project_id", id, "group", g.ID, "slug", g.Slug, "error", delErr.Error())
+				s.projectsLogger().Warn("failed to delete project group", "project_id", id, "group", g.ID, "slug", g.Slug, "error", delErr.Error())
 			}
 		}
 	}
@@ -2322,7 +2322,7 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 	if projectPolicies, err := s.store.ListPolicies(ctx, store.PolicyFilter{ScopeType: "project", ScopeID: id}, store.ListOptions{Limit: 100}); err == nil {
 		for _, p := range projectPolicies.Items {
 			if delErr := s.store.DeletePolicy(ctx, p.ID); delErr != nil {
-				s.projectsLog.Warn("failed to delete project policy", "project_id", id, "policy", p.ID, "name", p.Name, "error", delErr.Error())
+				s.projectsLogger().Warn("failed to delete project policy", "project_id", id, "policy", p.ID, "name", p.Name, "error", delErr.Error())
 			}
 		}
 	}
@@ -2330,24 +2330,24 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 	// Clean up project-scoped env vars (best-effort).
 	// These use scope/scope_id without FK cascade.
 	if n, err := s.store.DeleteEnvVarsByScope(ctx, store.ScopeProject, id); err != nil {
-		s.projectsLog.Warn("failed to delete project env vars", "project_id", id, "error", err)
+		s.projectsLogger().Warn("failed to delete project env vars", "project_id", id, "error", err)
 	} else if n > 0 {
-		s.projectsLog.Info("deleted project env vars", "project_id", id, "count", n)
+		s.projectsLogger().Info("deleted project env vars", "project_id", id, "count", n)
 	}
 
 	// Clean up project-scoped secrets (best-effort).
 	if n, err := s.store.DeleteSecretsByScope(ctx, store.ScopeProject, id); err != nil {
-		s.projectsLog.Warn("failed to delete project secrets", "project_id", id, "error", err)
+		s.projectsLogger().Warn("failed to delete project secrets", "project_id", id, "error", err)
 	} else if n > 0 {
-		s.projectsLog.Info("deleted project secrets", "project_id", id, "count", n)
+		s.projectsLogger().Info("deleted project secrets", "project_id", id, "count", n)
 	}
 
 	// Clean up project-scoped skill injections (best-effort).
 	// These use scope/scope_id without FK cascade.
 	if n, err := s.store.DeleteSkillInjectionsByScope(ctx, store.SkillInjectionScopeProject, id); err != nil {
-		s.projectsLog.Warn("failed to delete project skill injections", "project_id", id, "error", err)
+		s.projectsLogger().Warn("failed to delete project skill injections", "project_id", id, "error", err)
 	} else if n > 0 {
-		s.projectsLog.Info("deleted project skill injections", "project_id", id, "count", n)
+		s.projectsLogger().Info("deleted project skill injections", "project_id", id, "count", n)
 	}
 
 	// Warn about retained managed GCP service accounts (best-effort).
@@ -2361,7 +2361,7 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 	}); err == nil {
 		for _, sa := range sas {
 			if delErr := s.store.DeleteGCPServiceAccount(ctx, sa.ID); delErr != nil {
-				s.projectsLog.Warn("failed to delete project GCP service account registration",
+				s.projectsLogger().Warn("failed to delete project GCP service account registration",
 					"project_id", id, "sa_id", sa.ID, "email", sa.Email, "error", delErr.Error())
 			}
 		}
@@ -2389,7 +2389,7 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 	if (project.GitRemote == "" || project.IsSharedWorkspace()) && project.Slug != "" {
 		if projectPath, err := hubManagedProjectPath(project.Slug); err == nil {
 			if err := util.RemoveAllSafe(projectPath); err != nil {
-				s.projectsLog.Warn("failed to remove hub-managed project directory",
+				s.projectsLogger().Warn("failed to remove hub-managed project directory",
 					"project_id", id, "slug", project.Slug, "path", projectPath, "error", err)
 			}
 		}
@@ -2408,7 +2408,7 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 			// remove the parent (<slug__uuid>) directory.
 			projectConfigDir := filepath.Dir(configPath)
 			if err := config.RemoveProjectConfig(projectConfigDir); err != nil && !os.IsNotExist(err) {
-				s.projectsLog.Warn("failed to remove project config directory",
+				s.projectsLogger().Warn("failed to remove project config directory",
 					"project_id", id, "slug", project.Slug, "path", projectConfigDir, "error", err)
 			}
 		}
@@ -2456,12 +2456,12 @@ func (s *Server) deleteProjectTemplates(ctx context.Context, projectID string) {
 		ScopeID: projectID,
 	}, store.ListOptions{Limit: 1000})
 	if err != nil {
-		s.projectsLog.Warn("failed to list project templates for deletion", "project_id", projectID, "error", err)
+		s.projectsLogger().Warn("failed to list project templates for deletion", "project_id", projectID, "error", err)
 	} else if stor := s.GetStorage(); stor != nil {
 		for _, tmpl := range templates.Items {
 			if tmpl.StoragePath != "" {
 				if err := stor.DeletePrefix(ctx, tmpl.StoragePath); err != nil {
-					s.projectsLog.Warn("failed to delete template storage files",
+					s.projectsLogger().Warn("failed to delete template storage files",
 						"project_id", projectID, "template", tmpl.ID, "path", tmpl.StoragePath, "error", err)
 				}
 			}
@@ -2469,9 +2469,9 @@ func (s *Server) deleteProjectTemplates(ctx context.Context, projectID string) {
 	}
 
 	if n, err := s.store.DeleteTemplatesByScope(ctx, store.ScopeProject, projectID); err != nil {
-		s.projectsLog.Warn("failed to delete project templates", "project_id", projectID, "error", err)
+		s.projectsLogger().Warn("failed to delete project templates", "project_id", projectID, "error", err)
 	} else if n > 0 {
-		s.projectsLog.Info("deleted project templates", "project_id", projectID, "count", n)
+		s.projectsLogger().Info("deleted project templates", "project_id", projectID, "count", n)
 	}
 }
 
@@ -2485,12 +2485,12 @@ func (s *Server) warnManagedGCPServiceAccounts(ctx context.Context, projectID st
 		Managed: &managed,
 	})
 	if err != nil {
-		s.projectsLog.Warn("failed to list managed GCP SAs for project deletion warning",
+		s.projectsLogger().Warn("failed to list managed GCP SAs for project deletion warning",
 			"project_id", projectID, "error", err)
 		return
 	}
 	for _, sa := range sas {
-		s.projectsLog.Warn("project deletion: managed GCP service account retained in GCP — manual cleanup may be required",
+		s.projectsLogger().Warn("project deletion: managed GCP service account retained in GCP — manual cleanup may be required",
 			"project_id", projectID, "sa_email", sa.Email, "sa_id", sa.ID, "project_id", sa.ProjectID)
 	}
 }
@@ -2505,12 +2505,12 @@ func (s *Server) deleteProjectHarnessConfigs(ctx context.Context, projectID stri
 		ScopeID: projectID,
 	}, store.ListOptions{Limit: 1000})
 	if err != nil {
-		s.projectsLog.Warn("failed to list project harness configs for deletion", "project_id", projectID, "error", err)
+		s.projectsLogger().Warn("failed to list project harness configs for deletion", "project_id", projectID, "error", err)
 	} else if stor := s.GetStorage(); stor != nil {
 		for _, hc := range configs.Items {
 			if hc.StoragePath != "" {
 				if err := stor.DeletePrefix(ctx, hc.StoragePath); err != nil {
-					s.projectsLog.Warn("failed to delete harness config storage files",
+					s.projectsLogger().Warn("failed to delete harness config storage files",
 						"project_id", projectID, "harnessConfig", hc.ID, "path", hc.StoragePath, "error", err)
 				}
 			}
@@ -2518,9 +2518,9 @@ func (s *Server) deleteProjectHarnessConfigs(ctx context.Context, projectID stri
 	}
 
 	if n, err := s.store.DeleteHarnessConfigsByScope(ctx, store.ScopeProject, projectID); err != nil {
-		s.projectsLog.Warn("failed to delete project harness configs", "project_id", projectID, "error", err)
+		s.projectsLogger().Warn("failed to delete project harness configs", "project_id", projectID, "error", err)
 	} else if n > 0 {
-		s.projectsLog.Info("deleted project harness configs", "project_id", projectID, "count", n)
+		s.projectsLogger().Info("deleted project harness configs", "project_id", projectID, "count", n)
 	}
 }
 
@@ -2535,7 +2535,7 @@ func (s *Server) cleanupBrokerProjectDirectories(ctx context.Context, project *s
 
 	providers, err := s.store.GetProjectProviders(ctx, project.ID)
 	if err != nil {
-		s.projectsLog.Warn("failed to get project providers for cleanup", "project_id", project.ID, "error", err)
+		s.projectsLogger().Warn("failed to get project providers for cleanup", "project_id", project.ID, "error", err)
 		return
 	}
 
@@ -2551,7 +2551,7 @@ func (s *Server) cleanupBrokerProjectDirectories(ctx context.Context, project *s
 		}
 	}
 	if client == nil {
-		s.projectsLog.Warn("no RuntimeBrokerClient available for project cleanup dispatch", "project_id", project.ID)
+		s.projectsLogger().Warn("no RuntimeBrokerClient available for project cleanup dispatch", "project_id", project.ID)
 		return
 	}
 
@@ -2563,13 +2563,13 @@ func (s *Server) cleanupBrokerProjectDirectories(ctx context.Context, project *s
 
 		broker, err := s.store.GetRuntimeBroker(ctx, provider.BrokerID)
 		if err != nil {
-			s.projectsLog.Warn("failed to get broker for project cleanup",
+			s.projectsLogger().Warn("failed to get broker for project cleanup",
 				"project_id", project.ID, "broker", provider.BrokerID, "error", err)
 			continue
 		}
 
 		if err := client.CleanupProject(ctx, provider.BrokerID, broker.Endpoint, project.Slug, project.ID); err != nil {
-			s.projectsLog.Warn("failed to cleanup project on broker",
+			s.projectsLogger().Warn("failed to cleanup project on broker",
 				"project_id", project.ID, "slug", project.Slug,
 				"broker", provider.BrokerID, "endpoint", broker.Endpoint, "error", err)
 		}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -738,19 +738,14 @@ type Server struct {
 
 	// Subsystem loggers for handler methods
 	agentLifecycleLog *slog.Logger
-	auditLog          *slog.Logger
 	authLog           *slog.Logger
-	brokersLog        *slog.Logger
 	envSecretLog      *slog.Logger
-	eventsLog         *slog.Logger
 	groupsLog         *slog.Logger
 	maintenanceLog    *slog.Logger
 	messageLog        *slog.Logger
-	policiesLog       *slog.Logger
 	projectsLog       *slog.Logger
 	resourceLog       *slog.Logger
 	templateLog       *slog.Logger
-	webLog            *slog.Logger
 	workspaceLog      *slog.Logger
 
 	// Cached rate limit info from the most recent GitHub App API call
@@ -822,19 +817,14 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 
 		// Subsystem loggers
 		agentLifecycleLog: logging.Subsystem("hub.agent-lifecycle"),
-		auditLog:          logging.Subsystem("hub.audit"),
 		authLog:           logging.Subsystem("hub.auth"),
-		brokersLog:        logging.Subsystem("hub.brokers"),
 		envSecretLog:      logging.Subsystem("hub.env-secrets"),
-		eventsLog:         logging.Subsystem("hub.events"),
 		groupsLog:         logging.Subsystem("hub.groups"),
 		maintenanceLog:    logging.Subsystem("hub.maintenance"),
 		messageLog:        logging.Subsystem("hub.messages"),
-		policiesLog:       logging.Subsystem("hub.policies"),
 		projectsLog:       logging.Subsystem("hub.projects"),
 		resourceLog:       logging.Subsystem("hub.resources"),
 		templateLog:       logging.Subsystem("hub.templates"),
-		webLog:            logging.Subsystem("hub.web"),
 		workspaceLog:      logging.Subsystem("hub.workspace"),
 	}
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -738,13 +738,20 @@ type Server struct {
 
 	// Subsystem loggers for handler methods
 	agentLifecycleLog *slog.Logger
-	messageLog        *slog.Logger
+	auditLog          *slog.Logger
 	authLog           *slog.Logger
+	brokersLog        *slog.Logger
 	envSecretLog      *slog.Logger
-	templateLog       *slog.Logger
-	resourceLog       *slog.Logger
-	workspaceLog      *slog.Logger
+	eventsLog         *slog.Logger
+	groupsLog         *slog.Logger
 	maintenanceLog    *slog.Logger
+	messageLog        *slog.Logger
+	policiesLog       *slog.Logger
+	projectsLog       *slog.Logger
+	resourceLog       *slog.Logger
+	templateLog       *slog.Logger
+	webLog            *slog.Logger
+	workspaceLog      *slog.Logger
 
 	// Cached rate limit info from the most recent GitHub App API call
 	githubAppRateLimit *githubapp.RateLimitInfo
@@ -815,13 +822,20 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 
 		// Subsystem loggers
 		agentLifecycleLog: logging.Subsystem("hub.agent-lifecycle"),
-		messageLog:        logging.Subsystem("hub.messages"),
+		auditLog:          logging.Subsystem("hub.audit"),
 		authLog:           logging.Subsystem("hub.auth"),
+		brokersLog:        logging.Subsystem("hub.brokers"),
 		envSecretLog:      logging.Subsystem("hub.env-secrets"),
-		templateLog:       logging.Subsystem("hub.templates"),
-		resourceLog:       logging.Subsystem("hub.resources"),
-		workspaceLog:      logging.Subsystem("hub.workspace"),
+		eventsLog:         logging.Subsystem("hub.events"),
+		groupsLog:         logging.Subsystem("hub.groups"),
 		maintenanceLog:    logging.Subsystem("hub.maintenance"),
+		messageLog:        logging.Subsystem("hub.messages"),
+		policiesLog:       logging.Subsystem("hub.policies"),
+		projectsLog:       logging.Subsystem("hub.projects"),
+		resourceLog:       logging.Subsystem("hub.resources"),
+		templateLog:       logging.Subsystem("hub.templates"),
+		webLog:            logging.Subsystem("hub.web"),
+		workspaceLog:      logging.Subsystem("hub.workspace"),
 	}
 
 	// Wire tunnel disconnect handler: when an agent's port-forward tunnel

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -781,6 +781,25 @@ type Server struct {
 	ghResolutionStore *GitHubResolutionStore
 }
 
+// groupsLogger returns the groups subsystem logger, falling back to
+// slog.Default() when the field is nil (e.g. in tests that construct Server
+// directly without the constructor).
+func (s *Server) groupsLogger() *slog.Logger {
+	if s.groupsLog != nil {
+		return s.groupsLog
+	}
+	return slog.Default()
+}
+
+// projectsLogger returns the projects subsystem logger, falling back to
+// slog.Default() when the field is nil.
+func (s *Server) projectsLogger() *slog.Logger {
+	if s.projectsLog != nil {
+		return s.projectsLog
+	}
+	return slog.Default()
+}
+
 func newInstanceID() string {
 	if podName := os.Getenv("POD_NAME"); podName != "" {
 		return podName + "-" + uuid.NewString()

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -411,6 +411,15 @@ type spaShellData struct {
 	InitialData template.JS
 }
 
+// logger returns the web subsystem logger, falling back to slog.Default()
+// when the field is nil (e.g. in tests that construct WebServer directly).
+func (ws *WebServer) logger() *slog.Logger {
+	if ws.log != nil {
+		return ws.log
+	}
+	return slog.Default()
+}
+
 // NewWebServer creates a new web frontend server.
 func NewWebServer(cfg WebServerConfig) *WebServer {
 	if cfg.Port == 0 {
@@ -433,10 +442,10 @@ func NewWebServer(cfg WebServerConfig) *WebServer {
 		// Generate a random key for development/testing
 		b := make([]byte, 32)
 		if _, err := rand.Read(b); err != nil {
-			ws.log.Error("Failed to generate session secret", "error", err)
+			ws.logger().Error("Failed to generate session secret", "error", err)
 		}
 		sessionKey = hex.EncodeToString(b)
-		ws.log.Warn("No session secret configured, using random key (sessions will not persist across restarts)")
+		ws.logger().Warn("No session secret configured, using random key (sessions will not persist across restarts)")
 	}
 
 	// Use an encrypted, signed cookie session store so that NO session state
@@ -481,27 +490,27 @@ func NewWebServer(cfg WebServerConfig) *WebServer {
 	// Resolve asset source
 	if cfg.AssetsDir != "" {
 		ws.assetsDisk = cfg.AssetsDir
-		ws.log.Info("Web server using filesystem assets", "dir", cfg.AssetsDir)
+		ws.logger().Info("Web server using filesystem assets", "dir", cfg.AssetsDir)
 	} else if web.AssetsEmbedded {
 		sub, err := fs.Sub(web.ClientAssets, "dist/client")
 		if err != nil {
-			ws.log.Error("Failed to create sub-filesystem from embedded assets. Run 'make web && make build' to rebuild with web assets included, or use --web-assets-dir.", "error", err)
+			ws.logger().Error("Failed to create sub-filesystem from embedded assets. Run 'make web && make build' to rebuild with web assets included, or use --web-assets-dir.", "error", err)
 		} else if _, err := fs.Stat(sub, "assets/main.js"); err != nil {
-			ws.log.Warn("Embedded web assets directory exists but main.js is missing. Run 'make all' (or 'make web && make build') to rebuild with web assets included, or use --web-assets-dir.")
+			ws.logger().Warn("Embedded web assets directory exists but main.js is missing. Run 'make all' (or 'make web && make build') to rebuild with web assets included, or use --web-assets-dir.")
 		} else {
 			ws.assets = sub
 		}
 		if ws.assets != nil {
-			ws.log.Info("Web server using embedded assets")
+			ws.logger().Info("Web server using embedded assets")
 		}
 	} else {
-		ws.log.Warn("No web assets available: build with embedded assets or use --web-assets-dir")
+		ws.logger().Warn("No web assets available: build with embedded assets or use --web-assets-dir")
 	}
 
 	// Parse SPA shell template
 	tmpl, err := template.New("spa-shell").Parse(spaShellTemplate)
 	if err != nil {
-		ws.log.Error("Failed to parse SPA shell template", "error", err)
+		ws.logger().Error("Failed to parse SPA shell template", "error", err)
 	}
 	ws.shellTmpl = tmpl
 
@@ -626,10 +635,10 @@ func (ws *WebServer) sessionToBearerMiddleware(next http.Handler) http.Handler {
 					session.Values[sessKeyHubRefreshToken] = newRefresh
 					session.Values[sessKeyHubTokenExpiry] = time.Now().Add(time.Duration(expiresIn) * time.Second).UnixMilli()
 					if err := session.Save(r, w); err != nil {
-						ws.log.Warn("Failed to persist refreshed Hub token to session", "error", err)
+						ws.logger().Warn("Failed to persist refreshed Hub token to session", "error", err)
 					}
 				} else {
-					ws.log.Debug("Failed to refresh Hub token", "error", err)
+					ws.logger().Debug("Failed to refresh Hub token", "error", err)
 				}
 			}
 		}
@@ -637,14 +646,14 @@ func (ws *WebServer) sessionToBearerMiddleware(next http.Handler) http.Handler {
 		// If token is still invalid after refresh attempt, the signing
 		// key was likely rotated. Clear the session and force re-login.
 		if !tokenValid {
-			ws.log.Info("Hub token irrecoverably invalid, clearing session",
+			ws.logger().Info("Hub token irrecoverably invalid, clearing session",
 				"user", session.Values[sessKeyUserEmail])
 			for key := range session.Values {
 				delete(session.Values, key)
 			}
 			session.Options.MaxAge = -1
 			if err := session.Save(r, w); err != nil {
-				ws.log.Warn("Failed to clear invalid session", "error", err)
+				ws.logger().Warn("Failed to clear invalid session", "error", err)
 			}
 
 			if isBrowserRequest(r) {
@@ -675,7 +684,7 @@ func (ws *WebServer) sessionToBearerMiddleware(next http.Handler) http.Handler {
 						session.Values[sessKeyHubRefreshToken] = newRefresh
 						session.Values[sessKeyHubTokenExpiry] = time.Now().Add(time.Duration(expiresIn) * time.Second).UnixMilli()
 						if err := session.Save(r, w); err != nil {
-							ws.log.Warn("Failed to persist refreshed Hub token to session", "error", err)
+							ws.logger().Warn("Failed to persist refreshed Hub token to session", "error", err)
 						}
 					}
 				}
@@ -925,7 +934,7 @@ func (ws *WebServer) prefetchPageData(r *http.Request) template.JS {
 
 	raw, err := json.Marshal(envelope)
 	if err != nil {
-		ws.log.Error("Failed to marshal SSR page data", "error", err)
+		ws.logger().Error("Failed to marshal SSR page data", "error", err)
 		return template.JS("{}")
 	}
 
@@ -976,7 +985,7 @@ func (ws *WebServer) spaHandler() http.HandlerFunc {
 			InitialData:     ws.prefetchPageData(r),
 		}
 		if err := ws.shellTmpl.Execute(w, data); err != nil {
-			ws.log.Error("Failed to render SPA shell", "error", err)
+			ws.logger().Error("Failed to render SPA shell", "error", err)
 		}
 	}
 }
@@ -1048,7 +1057,7 @@ func (ws *WebServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 	// causing reconnection churn and wasted connection-pool slots.
 	rc := http.NewResponseController(w)
 	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
-		ws.log.Debug("Failed to clear write deadline for SSE", "error", err)
+		ws.logger().Debug("Failed to clear write deadline for SSE", "error", err)
 	}
 
 	w.Header().Set("Content-Type", "text/event-stream")
@@ -1264,7 +1273,7 @@ func (ws *WebServer) devAuthMiddleware(next http.Handler) http.Handler {
 		}
 
 		if err := session.Save(r, w); err != nil {
-			ws.log.Error("Failed to save dev-auth session", "error", err)
+			ws.logger().Error("Failed to save dev-auth session", "error", err)
 		}
 
 		ctx := context.WithValue(r.Context(), webUserContextKey{}, devUser)
@@ -1324,7 +1333,7 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 					next.ServeHTTP(w, r.WithContext(ctx))
 					return
 				}
-				ws.log.Info("Session role updated",
+				ws.logger().Info("Session role updated",
 					"email", email,
 					"old_role", currentRole,
 					"new_role", expectedRole,
@@ -1342,11 +1351,11 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 						session.Values[sessKeyHubRefreshToken] = refreshToken
 						session.Values[sessKeyHubTokenExpiry] = time.Now().Add(time.Duration(expiresIn) * time.Second).UnixMilli()
 					} else {
-						ws.log.Warn("Failed to regenerate Hub tokens for role change", "error", err)
+						ws.logger().Warn("Failed to regenerate Hub tokens for role change", "error", err)
 					}
 				}
 				if err := session.Save(r, w); err != nil {
-					ws.log.Error("Failed to save session after role update", "error", err)
+					ws.logger().Error("Failed to save session after role update", "error", err)
 				}
 			}
 			next.ServeHTTP(w, r)
@@ -1358,7 +1367,7 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 		if proxyErr != nil {
 			// Assertion present but invalid — reject. Log the real error
 			// internally but return a generic message to avoid information disclosure.
-			ws.log.Warn("Proxy auth rejected in web middleware",
+			ws.logger().Warn("Proxy auth rejected in web middleware",
 				"provider", ws.config.ProxyAuthenticator.Name(),
 				"error", proxyErr,
 				"path", r.URL.Path)
@@ -1375,13 +1384,13 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 		// Verified proxy identity — check authorization and provision/lookup user
 		ctx := r.Context()
 		if ws.store == nil {
-			ws.log.Error("Proxy auth: store not configured")
+			ws.logger().Error("Proxy auth: store not configured")
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
 
 		if !checkUserAuthorized(ctx, proxyUser.Email, ws.config.AuthorizedDomains, ws.config.AdminEmails, ws.config.UserAccessMode, ws.store) {
-			ws.log.Warn("Proxy auth: user not authorized", "email", proxyUser.Email)
+			ws.logger().Warn("Proxy auth: user not authorized", "email", proxyUser.Email)
 			http.Error(w, "access denied: email not authorized", http.StatusForbidden)
 			return
 		}
@@ -1390,7 +1399,7 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 		user, err := ws.store.GetUserByEmail(ctx, proxyUser.Email)
 		if err != nil && !errors.Is(err, store.ErrNotFound) {
 			// Genuine DB error — don't treat as "create new user"
-			ws.log.Error("Proxy auth: failed to look up user", "email", proxyUser.Email, "error", err)
+			ws.logger().Error("Proxy auth: failed to look up user", "email", proxyUser.Email, "error", err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
@@ -1408,15 +1417,15 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 				LastLogin:   time.Now(),
 			}
 			if err := ws.store.CreateUser(ctx, user); err != nil {
-				ws.log.Error("Proxy auth: failed to create user", "email", proxyUser.Email, "error", err)
+				ws.logger().Error("Proxy auth: failed to create user", "email", proxyUser.Email, "error", err)
 				http.Error(w, "internal server error", http.StatusInternalServerError)
 				return
 			}
-			ws.log.Info("Proxy auth: created new user", "email", proxyUser.Email, "user_id", user.ID)
+			ws.logger().Info("Proxy auth: created new user", "email", proxyUser.Email, "user_id", user.ID)
 		} else {
 			// Reject suspended users
 			if user.Status == "suspended" {
-				ws.log.Warn("Proxy auth: user is suspended", "email", proxyUser.Email, "user_id", user.ID)
+				ws.logger().Warn("Proxy auth: user is suspended", "email", proxyUser.Email, "user_id", user.ID)
 				http.Error(w, "access denied: user account is suspended", http.StatusForbidden)
 				return
 			}
@@ -1427,11 +1436,11 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 			}
 			// Re-evaluate admin status on every login (matches handleOAuthCallback / provisionUser)
 			if newRole := determineUserRole(proxyUser.Email, ws.config.AdminEmails); user.Role != newRole {
-				ws.log.Info("User role changed on proxy login", "email", proxyUser.Email, "old_role", user.Role, "new_role", newRole)
+				ws.logger().Info("User role changed on proxy login", "email", proxyUser.Email, "old_role", user.Role, "new_role", newRole)
 				user.Role = newRole
 			}
 			if err := ws.store.UpdateUser(ctx, user); err != nil {
-				ws.log.Warn("Failed to update user via proxy auth", "email", proxyUser.Email, "error", err)
+				ws.logger().Warn("Failed to update user via proxy auth", "email", proxyUser.Email, "error", err)
 			}
 		}
 
@@ -1448,7 +1457,7 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 				session.Values[sessKeyHubRefreshToken] = refreshToken
 				session.Values[sessKeyHubTokenExpiry] = time.Now().Add(time.Duration(expiresIn) * time.Second).UnixMilli()
 			} else {
-				ws.log.Warn("Proxy auth: failed to generate Hub tokens", "error", err)
+				ws.logger().Warn("Proxy auth: failed to generate Hub tokens", "error", err)
 			}
 		}
 
@@ -1460,10 +1469,10 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 		session.Values[sessKeyUserRole] = user.Role
 
 		if err := session.Save(r, w); err != nil {
-			ws.log.Error("Proxy auth: failed to save session", "error", err)
+			ws.logger().Error("Proxy auth: failed to save session", "error", err)
 		}
 
-		ws.log.Info("Proxy auth: session created",
+		ws.logger().Info("Proxy auth: session created",
 			"provider", ws.config.ProxyAuthenticator.Name(),
 			"email", user.Email,
 			"user_id", user.ID)
@@ -1587,7 +1596,7 @@ func (ws *WebServer) handleOAuthLogin(w http.ResponseWriter, r *http.Request) {
 	}
 	session.Values[sessKeyOAuthState] = state
 	if err := session.Save(r, w); err != nil {
-		ws.log.Error("Failed to save OAuth state to session", "error", err)
+		ws.logger().Error("Failed to save OAuth state to session", "error", err)
 		http.Error(w, "session error", http.StatusInternalServerError)
 		return
 	}
@@ -1598,7 +1607,7 @@ func (ws *WebServer) handleOAuthLogin(w http.ResponseWriter, r *http.Request) {
 	// Get authorization URL
 	authURL, err := ws.oauthService.GetAuthorizationURLForClient(OAuthClientTypeWeb, provider, redirectURI, state)
 	if err != nil {
-		ws.log.Error("Failed to generate OAuth URL", "provider", provider, "error", err)
+		ws.logger().Error("Failed to generate OAuth URL", "provider", provider, "error", err)
 		http.Error(w, "failed to generate auth URL", http.StatusInternalServerError)
 		return
 	}
@@ -1626,7 +1635,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 	// Load session
 	session, err := ws.sessionStore.Get(r, webSessionName)
 	if err != nil {
-		ws.log.Error("Failed to load session for callback", "error", err)
+		ws.logger().Error("Failed to load session for callback", "error", err)
 		http.Redirect(w, r, "/login?error=session_error", http.StatusFound)
 		return
 	}
@@ -1635,7 +1644,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 	expectedState, _ := session.Values[sessKeyOAuthState].(string)
 	actualState := r.URL.Query().Get("state")
 	if expectedState == "" || !apiclient.ValidateDevToken(actualState, expectedState) {
-		ws.log.Warn("OAuth state mismatch", "provider", provider)
+		ws.logger().Warn("OAuth state mismatch", "provider", provider)
 		http.Redirect(w, r, "/login?error=state_mismatch", http.StatusFound)
 		return
 	}
@@ -1645,7 +1654,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 
 	// Check for error from provider
 	if errParam := r.URL.Query().Get("error"); errParam != "" {
-		ws.log.Warn("OAuth provider returned error", "provider", provider, "error", errParam)
+		ws.logger().Warn("OAuth provider returned error", "provider", provider, "error", errParam)
 		http.Redirect(w, r, "/login?error="+errParam, http.StatusFound)
 		return
 	}
@@ -1663,14 +1672,14 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 	ctx := r.Context()
 	userInfo, err := ws.oauthService.ExchangeCodeForClient(ctx, OAuthClientTypeWeb, provider, code, redirectURI)
 	if err != nil {
-		ws.log.Error("OAuth code exchange failed", "provider", provider, "error", err)
+		ws.logger().Error("OAuth code exchange failed", "provider", provider, "error", err)
 		http.Redirect(w, r, "/login?error=exchange_failed", http.StatusFound)
 		return
 	}
 
 	// Check if user is authorized (admin bypass, domain check, access mode)
 	if !checkUserAuthorized(ctx, userInfo.Email, ws.config.AuthorizedDomains, ws.config.AdminEmails, ws.config.UserAccessMode, ws.store) {
-		ws.log.Warn("Unauthorized user", "email", userInfo.Email)
+		ws.logger().Warn("Unauthorized user", "email", userInfo.Email)
 		http.Redirect(w, r, "/login?error=unauthorized_domain", http.StatusFound)
 		return
 	}
@@ -1691,7 +1700,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 			LastLogin:   time.Now(),
 		}
 		if err := ws.store.CreateUser(ctx, user); err != nil {
-			ws.log.Error("Failed to create user", "email", userInfo.Email, "error", err)
+			ws.logger().Error("Failed to create user", "email", userInfo.Email, "error", err)
 			http.Redirect(w, r, "/login?error=user_create_failed", http.StatusFound)
 			return
 		}
@@ -1707,11 +1716,11 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 		// Re-evaluate admin status on every login
 		newRole := determineUserRole(userInfo.Email, ws.config.AdminEmails)
 		if user.Role != newRole {
-			ws.log.Info("User role changed on login", "email", userInfo.Email, "old_role", user.Role, "new_role", newRole)
+			ws.logger().Info("User role changed on login", "email", userInfo.Email, "old_role", user.Role, "new_role", newRole)
 			user.Role = newRole
 		}
 		if err := ws.store.UpdateUser(ctx, user); err != nil {
-			ws.log.Warn("Failed to update user on login", "email", userInfo.Email, "error", err)
+			ws.logger().Warn("Failed to update user on login", "email", userInfo.Email, "error", err)
 		}
 	}
 
@@ -1724,7 +1733,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 			user.ID, user.Email, user.DisplayName, user.Role, ClientTypeWeb,
 		)
 		if err != nil {
-			ws.log.Warn("Failed to generate Hub tokens", "error", err)
+			ws.logger().Warn("Failed to generate Hub tokens", "error", err)
 		} else {
 			session.Values[sessKeyHubAccessToken] = accessToken
 			session.Values[sessKeyHubRefreshToken] = refreshToken
@@ -1744,7 +1753,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 	delete(session.Values, sessKeyReturnTo)
 
 	if err := session.Save(r, w); err != nil {
-		ws.log.Error("Failed to save session after OAuth callback", "error", err)
+		ws.logger().Error("Failed to save session after OAuth callback", "error", err)
 		http.Redirect(w, r, "/login?error=session_error", http.StatusFound)
 		return
 	}
@@ -1787,7 +1796,7 @@ func (ws *WebServer) handleLogout(w http.ResponseWriter, r *http.Request) {
 	}
 	session.Options.MaxAge = -1 // Delete cookie
 	if err := session.Save(r, w); err != nil {
-		ws.log.Error("Failed to clear session on logout", "error", err)
+		ws.logger().Error("Failed to clear session on logout", "error", err)
 	}
 
 	if isBrowserRequest(r) {
@@ -1935,7 +1944,7 @@ func (ws *WebServer) loggingMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(wrapped, r)
 
 		if ws.config.Debug || wrapped.statusCode >= 400 {
-			ws.log.Info("Web request",
+			ws.logger().Info("Web request",
 				slog.String("method", r.Method),
 				slog.String("path", r.URL.Path),
 				slog.Int("status", wrapped.statusCode),
@@ -1996,7 +2005,7 @@ func (ws *WebServer) Start(ctx context.Context) error {
 		WriteTimeout: 60 * time.Second,
 	}
 
-	ws.log.Info("Web frontend server starting", "host", ws.config.Host, "port", ws.config.Port, "h2c", true)
+	ws.logger().Info("Web frontend server starting", "host", ws.config.Host, "port", ws.config.Port, "h2c", true)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -2020,12 +2029,12 @@ func (ws *WebServer) Shutdown(ctx context.Context) error {
 		return nil
 	}
 
-	ws.log.Info("Web frontend server shutting down...")
+	ws.logger().Info("Web frontend server shutting down...")
 
 	// Clean up mounted Hub resources (control channels, broker auth, event publisher)
 	if ws.hubShutdown != nil {
 		if err := ws.hubShutdown(ctx); err != nil {
-			ws.log.Error("Failed to clean up Hub resources during web server shutdown", "error", err)
+			ws.logger().Error("Failed to clean up Hub resources during web server shutdown", "error", err)
 		}
 	}
 

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -169,6 +169,7 @@ type WebServer struct {
 	hubShutdown  func(context.Context) error // Hub resource cleanup, or nil
 	maintenance  *MaintenanceState           // runtime maintenance mode state (shared with Hub)
 	startTime    time.Time
+	log          *slog.Logger // subsystem logger for hub.web
 
 	// Dedicated request logger (nil = disabled)
 	requestLogger *slog.Logger
@@ -423,6 +424,7 @@ func NewWebServer(cfg WebServerConfig) *WebServer {
 		config:    cfg,
 		mux:       http.NewServeMux(),
 		startTime: time.Now(),
+		log:       logging.Subsystem("hub.web"),
 	}
 
 	// Initialize session store
@@ -431,10 +433,10 @@ func NewWebServer(cfg WebServerConfig) *WebServer {
 		// Generate a random key for development/testing
 		b := make([]byte, 32)
 		if _, err := rand.Read(b); err != nil {
-			slog.Error("Failed to generate session secret", "error", err)
+			ws.log.Error("Failed to generate session secret", "error", err)
 		}
 		sessionKey = hex.EncodeToString(b)
-		slog.Warn("No session secret configured, using random key (sessions will not persist across restarts)")
+		ws.log.Warn("No session secret configured, using random key (sessions will not persist across restarts)")
 	}
 
 	// Use an encrypted, signed cookie session store so that NO session state
@@ -479,27 +481,27 @@ func NewWebServer(cfg WebServerConfig) *WebServer {
 	// Resolve asset source
 	if cfg.AssetsDir != "" {
 		ws.assetsDisk = cfg.AssetsDir
-		slog.Info("Web server using filesystem assets", "dir", cfg.AssetsDir)
+		ws.log.Info("Web server using filesystem assets", "dir", cfg.AssetsDir)
 	} else if web.AssetsEmbedded {
 		sub, err := fs.Sub(web.ClientAssets, "dist/client")
 		if err != nil {
-			slog.Error("Failed to create sub-filesystem from embedded assets. Run 'make web && make build' to rebuild with web assets included, or use --web-assets-dir.", "error", err)
+			ws.log.Error("Failed to create sub-filesystem from embedded assets. Run 'make web && make build' to rebuild with web assets included, or use --web-assets-dir.", "error", err)
 		} else if _, err := fs.Stat(sub, "assets/main.js"); err != nil {
-			slog.Warn("Embedded web assets directory exists but main.js is missing. Run 'make all' (or 'make web && make build') to rebuild with web assets included, or use --web-assets-dir.")
+			ws.log.Warn("Embedded web assets directory exists but main.js is missing. Run 'make all' (or 'make web && make build') to rebuild with web assets included, or use --web-assets-dir.")
 		} else {
 			ws.assets = sub
 		}
 		if ws.assets != nil {
-			slog.Info("Web server using embedded assets")
+			ws.log.Info("Web server using embedded assets")
 		}
 	} else {
-		slog.Warn("No web assets available: build with embedded assets or use --web-assets-dir")
+		ws.log.Warn("No web assets available: build with embedded assets or use --web-assets-dir")
 	}
 
 	// Parse SPA shell template
 	tmpl, err := template.New("spa-shell").Parse(spaShellTemplate)
 	if err != nil {
-		slog.Error("Failed to parse SPA shell template", "error", err)
+		ws.log.Error("Failed to parse SPA shell template", "error", err)
 	}
 	ws.shellTmpl = tmpl
 
@@ -624,10 +626,10 @@ func (ws *WebServer) sessionToBearerMiddleware(next http.Handler) http.Handler {
 					session.Values[sessKeyHubRefreshToken] = newRefresh
 					session.Values[sessKeyHubTokenExpiry] = time.Now().Add(time.Duration(expiresIn) * time.Second).UnixMilli()
 					if err := session.Save(r, w); err != nil {
-						slog.Warn("Failed to persist refreshed Hub token to session", "error", err)
+						ws.log.Warn("Failed to persist refreshed Hub token to session", "error", err)
 					}
 				} else {
-					slog.Debug("Failed to refresh Hub token", "error", err)
+					ws.log.Debug("Failed to refresh Hub token", "error", err)
 				}
 			}
 		}
@@ -635,14 +637,14 @@ func (ws *WebServer) sessionToBearerMiddleware(next http.Handler) http.Handler {
 		// If token is still invalid after refresh attempt, the signing
 		// key was likely rotated. Clear the session and force re-login.
 		if !tokenValid {
-			slog.Info("Hub token irrecoverably invalid, clearing session",
+			ws.log.Info("Hub token irrecoverably invalid, clearing session",
 				"user", session.Values[sessKeyUserEmail])
 			for key := range session.Values {
 				delete(session.Values, key)
 			}
 			session.Options.MaxAge = -1
 			if err := session.Save(r, w); err != nil {
-				slog.Warn("Failed to clear invalid session", "error", err)
+				ws.log.Warn("Failed to clear invalid session", "error", err)
 			}
 
 			if isBrowserRequest(r) {
@@ -673,7 +675,7 @@ func (ws *WebServer) sessionToBearerMiddleware(next http.Handler) http.Handler {
 						session.Values[sessKeyHubRefreshToken] = newRefresh
 						session.Values[sessKeyHubTokenExpiry] = time.Now().Add(time.Duration(expiresIn) * time.Second).UnixMilli()
 						if err := session.Save(r, w); err != nil {
-							slog.Warn("Failed to persist refreshed Hub token to session", "error", err)
+							ws.log.Warn("Failed to persist refreshed Hub token to session", "error", err)
 						}
 					}
 				}
@@ -923,7 +925,7 @@ func (ws *WebServer) prefetchPageData(r *http.Request) template.JS {
 
 	raw, err := json.Marshal(envelope)
 	if err != nil {
-		slog.Error("Failed to marshal SSR page data", "error", err)
+		ws.log.Error("Failed to marshal SSR page data", "error", err)
 		return template.JS("{}")
 	}
 
@@ -974,7 +976,7 @@ func (ws *WebServer) spaHandler() http.HandlerFunc {
 			InitialData:     ws.prefetchPageData(r),
 		}
 		if err := ws.shellTmpl.Execute(w, data); err != nil {
-			slog.Error("Failed to render SPA shell", "error", err)
+			ws.log.Error("Failed to render SPA shell", "error", err)
 		}
 	}
 }
@@ -1046,7 +1048,7 @@ func (ws *WebServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 	// causing reconnection churn and wasted connection-pool slots.
 	rc := http.NewResponseController(w)
 	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
-		slog.Debug("Failed to clear write deadline for SSE", "error", err)
+		ws.log.Debug("Failed to clear write deadline for SSE", "error", err)
 	}
 
 	w.Header().Set("Content-Type", "text/event-stream")
@@ -1262,7 +1264,7 @@ func (ws *WebServer) devAuthMiddleware(next http.Handler) http.Handler {
 		}
 
 		if err := session.Save(r, w); err != nil {
-			slog.Error("Failed to save dev-auth session", "error", err)
+			ws.log.Error("Failed to save dev-auth session", "error", err)
 		}
 
 		ctx := context.WithValue(r.Context(), webUserContextKey{}, devUser)
@@ -1322,7 +1324,7 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 					next.ServeHTTP(w, r.WithContext(ctx))
 					return
 				}
-				slog.Info("Session role updated",
+				ws.log.Info("Session role updated",
 					"email", email,
 					"old_role", currentRole,
 					"new_role", expectedRole,
@@ -1340,11 +1342,11 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 						session.Values[sessKeyHubRefreshToken] = refreshToken
 						session.Values[sessKeyHubTokenExpiry] = time.Now().Add(time.Duration(expiresIn) * time.Second).UnixMilli()
 					} else {
-						slog.Warn("Failed to regenerate Hub tokens for role change", "error", err)
+						ws.log.Warn("Failed to regenerate Hub tokens for role change", "error", err)
 					}
 				}
 				if err := session.Save(r, w); err != nil {
-					slog.Error("Failed to save session after role update", "error", err)
+					ws.log.Error("Failed to save session after role update", "error", err)
 				}
 			}
 			next.ServeHTTP(w, r)
@@ -1356,7 +1358,7 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 		if proxyErr != nil {
 			// Assertion present but invalid — reject. Log the real error
 			// internally but return a generic message to avoid information disclosure.
-			slog.Warn("Proxy auth rejected in web middleware",
+			ws.log.Warn("Proxy auth rejected in web middleware",
 				"provider", ws.config.ProxyAuthenticator.Name(),
 				"error", proxyErr,
 				"path", r.URL.Path)
@@ -1373,13 +1375,13 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 		// Verified proxy identity — check authorization and provision/lookup user
 		ctx := r.Context()
 		if ws.store == nil {
-			slog.Error("Proxy auth: store not configured")
+			ws.log.Error("Proxy auth: store not configured")
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
 
 		if !checkUserAuthorized(ctx, proxyUser.Email, ws.config.AuthorizedDomains, ws.config.AdminEmails, ws.config.UserAccessMode, ws.store) {
-			slog.Warn("Proxy auth: user not authorized", "email", proxyUser.Email)
+			ws.log.Warn("Proxy auth: user not authorized", "email", proxyUser.Email)
 			http.Error(w, "access denied: email not authorized", http.StatusForbidden)
 			return
 		}
@@ -1388,7 +1390,7 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 		user, err := ws.store.GetUserByEmail(ctx, proxyUser.Email)
 		if err != nil && !errors.Is(err, store.ErrNotFound) {
 			// Genuine DB error — don't treat as "create new user"
-			slog.Error("Proxy auth: failed to look up user", "email", proxyUser.Email, "error", err)
+			ws.log.Error("Proxy auth: failed to look up user", "email", proxyUser.Email, "error", err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
@@ -1406,15 +1408,15 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 				LastLogin:   time.Now(),
 			}
 			if err := ws.store.CreateUser(ctx, user); err != nil {
-				slog.Error("Proxy auth: failed to create user", "email", proxyUser.Email, "error", err)
+				ws.log.Error("Proxy auth: failed to create user", "email", proxyUser.Email, "error", err)
 				http.Error(w, "internal server error", http.StatusInternalServerError)
 				return
 			}
-			slog.Info("Proxy auth: created new user", "email", proxyUser.Email, "user_id", user.ID)
+			ws.log.Info("Proxy auth: created new user", "email", proxyUser.Email, "user_id", user.ID)
 		} else {
 			// Reject suspended users
 			if user.Status == "suspended" {
-				slog.Warn("Proxy auth: user is suspended", "email", proxyUser.Email, "user_id", user.ID)
+				ws.log.Warn("Proxy auth: user is suspended", "email", proxyUser.Email, "user_id", user.ID)
 				http.Error(w, "access denied: user account is suspended", http.StatusForbidden)
 				return
 			}
@@ -1425,11 +1427,11 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 			}
 			// Re-evaluate admin status on every login (matches handleOAuthCallback / provisionUser)
 			if newRole := determineUserRole(proxyUser.Email, ws.config.AdminEmails); user.Role != newRole {
-				slog.Info("User role changed on proxy login", "email", proxyUser.Email, "old_role", user.Role, "new_role", newRole)
+				ws.log.Info("User role changed on proxy login", "email", proxyUser.Email, "old_role", user.Role, "new_role", newRole)
 				user.Role = newRole
 			}
 			if err := ws.store.UpdateUser(ctx, user); err != nil {
-				slog.Warn("Failed to update user via proxy auth", "email", proxyUser.Email, "error", err)
+				ws.log.Warn("Failed to update user via proxy auth", "email", proxyUser.Email, "error", err)
 			}
 		}
 
@@ -1446,7 +1448,7 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 				session.Values[sessKeyHubRefreshToken] = refreshToken
 				session.Values[sessKeyHubTokenExpiry] = time.Now().Add(time.Duration(expiresIn) * time.Second).UnixMilli()
 			} else {
-				slog.Warn("Proxy auth: failed to generate Hub tokens", "error", err)
+				ws.log.Warn("Proxy auth: failed to generate Hub tokens", "error", err)
 			}
 		}
 
@@ -1458,10 +1460,10 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 		session.Values[sessKeyUserRole] = user.Role
 
 		if err := session.Save(r, w); err != nil {
-			slog.Error("Proxy auth: failed to save session", "error", err)
+			ws.log.Error("Proxy auth: failed to save session", "error", err)
 		}
 
-		slog.Info("Proxy auth: session created",
+		ws.log.Info("Proxy auth: session created",
 			"provider", ws.config.ProxyAuthenticator.Name(),
 			"email", user.Email,
 			"user_id", user.ID)
@@ -1585,7 +1587,7 @@ func (ws *WebServer) handleOAuthLogin(w http.ResponseWriter, r *http.Request) {
 	}
 	session.Values[sessKeyOAuthState] = state
 	if err := session.Save(r, w); err != nil {
-		slog.Error("Failed to save OAuth state to session", "error", err)
+		ws.log.Error("Failed to save OAuth state to session", "error", err)
 		http.Error(w, "session error", http.StatusInternalServerError)
 		return
 	}
@@ -1596,7 +1598,7 @@ func (ws *WebServer) handleOAuthLogin(w http.ResponseWriter, r *http.Request) {
 	// Get authorization URL
 	authURL, err := ws.oauthService.GetAuthorizationURLForClient(OAuthClientTypeWeb, provider, redirectURI, state)
 	if err != nil {
-		slog.Error("Failed to generate OAuth URL", "provider", provider, "error", err)
+		ws.log.Error("Failed to generate OAuth URL", "provider", provider, "error", err)
 		http.Error(w, "failed to generate auth URL", http.StatusInternalServerError)
 		return
 	}
@@ -1624,7 +1626,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 	// Load session
 	session, err := ws.sessionStore.Get(r, webSessionName)
 	if err != nil {
-		slog.Error("Failed to load session for callback", "error", err)
+		ws.log.Error("Failed to load session for callback", "error", err)
 		http.Redirect(w, r, "/login?error=session_error", http.StatusFound)
 		return
 	}
@@ -1633,7 +1635,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 	expectedState, _ := session.Values[sessKeyOAuthState].(string)
 	actualState := r.URL.Query().Get("state")
 	if expectedState == "" || !apiclient.ValidateDevToken(actualState, expectedState) {
-		slog.Warn("OAuth state mismatch", "provider", provider)
+		ws.log.Warn("OAuth state mismatch", "provider", provider)
 		http.Redirect(w, r, "/login?error=state_mismatch", http.StatusFound)
 		return
 	}
@@ -1643,7 +1645,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 
 	// Check for error from provider
 	if errParam := r.URL.Query().Get("error"); errParam != "" {
-		slog.Warn("OAuth provider returned error", "provider", provider, "error", errParam)
+		ws.log.Warn("OAuth provider returned error", "provider", provider, "error", errParam)
 		http.Redirect(w, r, "/login?error="+errParam, http.StatusFound)
 		return
 	}
@@ -1661,14 +1663,14 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 	ctx := r.Context()
 	userInfo, err := ws.oauthService.ExchangeCodeForClient(ctx, OAuthClientTypeWeb, provider, code, redirectURI)
 	if err != nil {
-		slog.Error("OAuth code exchange failed", "provider", provider, "error", err)
+		ws.log.Error("OAuth code exchange failed", "provider", provider, "error", err)
 		http.Redirect(w, r, "/login?error=exchange_failed", http.StatusFound)
 		return
 	}
 
 	// Check if user is authorized (admin bypass, domain check, access mode)
 	if !checkUserAuthorized(ctx, userInfo.Email, ws.config.AuthorizedDomains, ws.config.AdminEmails, ws.config.UserAccessMode, ws.store) {
-		slog.Warn("Unauthorized user", "email", userInfo.Email)
+		ws.log.Warn("Unauthorized user", "email", userInfo.Email)
 		http.Redirect(w, r, "/login?error=unauthorized_domain", http.StatusFound)
 		return
 	}
@@ -1689,7 +1691,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 			LastLogin:   time.Now(),
 		}
 		if err := ws.store.CreateUser(ctx, user); err != nil {
-			slog.Error("Failed to create user", "email", userInfo.Email, "error", err)
+			ws.log.Error("Failed to create user", "email", userInfo.Email, "error", err)
 			http.Redirect(w, r, "/login?error=user_create_failed", http.StatusFound)
 			return
 		}
@@ -1705,11 +1707,11 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 		// Re-evaluate admin status on every login
 		newRole := determineUserRole(userInfo.Email, ws.config.AdminEmails)
 		if user.Role != newRole {
-			slog.Info("User role changed on login", "email", userInfo.Email, "old_role", user.Role, "new_role", newRole)
+			ws.log.Info("User role changed on login", "email", userInfo.Email, "old_role", user.Role, "new_role", newRole)
 			user.Role = newRole
 		}
 		if err := ws.store.UpdateUser(ctx, user); err != nil {
-			slog.Warn("Failed to update user on login", "email", userInfo.Email, "error", err)
+			ws.log.Warn("Failed to update user on login", "email", userInfo.Email, "error", err)
 		}
 	}
 
@@ -1722,7 +1724,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 			user.ID, user.Email, user.DisplayName, user.Role, ClientTypeWeb,
 		)
 		if err != nil {
-			slog.Warn("Failed to generate Hub tokens", "error", err)
+			ws.log.Warn("Failed to generate Hub tokens", "error", err)
 		} else {
 			session.Values[sessKeyHubAccessToken] = accessToken
 			session.Values[sessKeyHubRefreshToken] = refreshToken
@@ -1742,7 +1744,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 	delete(session.Values, sessKeyReturnTo)
 
 	if err := session.Save(r, w); err != nil {
-		slog.Error("Failed to save session after OAuth callback", "error", err)
+		ws.log.Error("Failed to save session after OAuth callback", "error", err)
 		http.Redirect(w, r, "/login?error=session_error", http.StatusFound)
 		return
 	}
@@ -1785,7 +1787,7 @@ func (ws *WebServer) handleLogout(w http.ResponseWriter, r *http.Request) {
 	}
 	session.Options.MaxAge = -1 // Delete cookie
 	if err := session.Save(r, w); err != nil {
-		slog.Error("Failed to clear session on logout", "error", err)
+		ws.log.Error("Failed to clear session on logout", "error", err)
 	}
 
 	if isBrowserRequest(r) {
@@ -1933,7 +1935,7 @@ func (ws *WebServer) loggingMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(wrapped, r)
 
 		if ws.config.Debug || wrapped.statusCode >= 400 {
-			slog.Info("Web request",
+			ws.log.Info("Web request",
 				slog.String("method", r.Method),
 				slog.String("path", r.URL.Path),
 				slog.Int("status", wrapped.statusCode),
@@ -1994,7 +1996,7 @@ func (ws *WebServer) Start(ctx context.Context) error {
 		WriteTimeout: 60 * time.Second,
 	}
 
-	slog.Info("Web frontend server starting", "host", ws.config.Host, "port", ws.config.Port, "h2c", true)
+	ws.log.Info("Web frontend server starting", "host", ws.config.Host, "port", ws.config.Port, "h2c", true)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -2018,12 +2020,12 @@ func (ws *WebServer) Shutdown(ctx context.Context) error {
 		return nil
 	}
 
-	slog.Info("Web frontend server shutting down...")
+	ws.log.Info("Web frontend server shutting down...")
 
 	// Clean up mounted Hub resources (control channels, broker auth, event publisher)
 	if ws.hubShutdown != nil {
 		if err := ws.hubShutdown(ctx); err != nil {
-			slog.Error("Failed to clean up Hub resources during web server shutdown", "error", err)
+			ws.log.Error("Failed to clean up Hub resources during web server shutdown", "error", err)
 		}
 	}
 


### PR DESCRIPTION
Adds subsystem-tagged loggers to the remaining hub CRUD handlers, completing the Tier 3 logging subsystem coverage.

## Changes

- Added subsystem loggers (slog.With("subsystem", "hub.<area>")) to 5 handler areas: projects, groups, audit, events, web
- Removed unused Server logger fields discovered during implementation
- Fixed gofmt formatting in audit.go
- Brokers and policies handlers confirmed to have no slog calls requiring conversion

## Key files

- pkg/hub/server.go — subsystem logger injection
- pkg/hub/handlers_projects_core.go — hub.projects subsystem
- pkg/hub/handlers_groups.go — hub.groups subsystem
- pkg/hub/audit.go — hub.audit subsystem
- pkg/hub/events.go — hub.events subsystem
- pkg/hub/web.go — hub.web subsystem

Design reference: .design/hosted/logging-components.md (Tier 3 naming convention)

Relates to ptone/scion#681
