### PR TITLE
fix(web): sort harness config list alphabetically in new agent form

### DIFF
--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -433,7 +433,9 @@ export class ScionPageAgentCreate extends LitElement {
         const data = (await harnessConfigsRes.json()) as {
           harnessConfigs?: HarnessConfigEntry[];
         };
-        this.harnessConfigs = data.harnessConfigs || [];
+        this.harnessConfigs = (data.harnessConfigs || []).sort((a, b) =>
+          (a.displayName || a.name).localeCompare(b.displayName || b.name)
+        );
       }
 
       // If returning from configure page, populate form from existing agent
@@ -901,7 +903,9 @@ private selectBrokerForProject(): void {
       const res = await apiFetch(url);
       if (res.ok) {
         const data = (await res.json()) as { harnessConfigs?: HarnessConfigEntry[] };
-        this.harnessConfigs = data.harnessConfigs || [];
+        this.harnessConfigs = (data.harnessConfigs || []).sort((a, b) =>
+          (a.displayName || a.name).localeCompare(b.displayName || b.name)
+        );
       }
     } catch (err) {
       console.error('Failed to load harness configs:', err);


### PR DESCRIPTION
## Summary

Sorts the harness config dropdown alphabetically by displayName (falling back to name) in the new agent creation form. Both the initial load path and the project-scoped load path are covered.

**Key files:**
- web/src/components/pages/agent-create.ts — sort in loadFormData() and loadHarnessConfigs()

Ref: ptone/scion#733
