### PR TITLE
fix(hub): surface permission errors for secret creation instead of generic 500

### DIFF
--- a/pkg/hub/errors.go
+++ b/pkg/hub/errors.go
@@ -109,7 +109,13 @@ func writeErrorFromErr(w http.ResponseWriter, err error, requestID string) {
 	var statusCode int
 	var code, message string
 
+	var permErr *secret.PermissionError
+
 	switch {
+	case errors.As(err, &permErr):
+		statusCode = http.StatusForbidden
+		code = ErrCodeForbidden
+		message = permErr.Error()
 	case errors.Is(err, store.ErrNotFound):
 		statusCode = http.StatusNotFound
 		code = ErrCodeNotFound

--- a/pkg/hub/errors_test.go
+++ b/pkg/hub/errors_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestWriteErrorFromErr_PermissionError(t *testing.T) {
+	// Simulate a PermissionDenied error from GCP Secret Manager
+	grpcErr := status.Errorf(codes.PermissionDenied, "caller does not have permission")
+	permErr := &secret.PermissionError{
+		Operation: "create secret",
+		Err:       grpcErr,
+	}
+	// Wrap it like gcpbackend.go would
+	wrappedErr := fmt.Errorf("failed to create GCP SM secret: %w", permErr)
+
+	rr := httptest.NewRecorder()
+	writeErrorFromErr(rr, wrappedErr, "test-req-1")
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("expected status %d, got %d", http.StatusForbidden, rr.Code)
+	}
+
+	var resp ErrorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Error.Code != ErrCodeForbidden {
+		t.Errorf("expected error code %q, got %q", ErrCodeForbidden, resp.Error.Code)
+	}
+	if resp.Error.Message == "" {
+		t.Error("expected non-empty error message")
+	}
+	// The message should contain actionable guidance
+	if got := resp.Error.Message; got == "Internal server error" {
+		t.Errorf("error message should not be generic 500, got: %q", got)
+	}
+}
+
+func TestWriteErrorFromErr_GenericError_Still500(t *testing.T) {
+	// A generic error that is NOT a PermissionError should still be 500
+	err := fmt.Errorf("something went wrong")
+
+	rr := httptest.NewRecorder()
+	writeErrorFromErr(rr, err, "")
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, rr.Code)
+	}
+}

--- a/pkg/secret/gcpbackend.go
+++ b/pkg/secret/gcpbackend.go
@@ -110,16 +110,13 @@ func (b *GCPBackend) Get(ctx context.Context, name, scope, scopeID string) (*Sec
 			if status.Code(err) == codes.NotFound {
 				return nil, store.ErrNotFound
 			}
-			if wrapped := wrapGCPError(err, "access secret"); wrapped != err {
-				return nil, wrapped
-			}
 		} else {
 			slog.Info("Recovered secret from GCP SM without DB record", "name", name, "scope", scope)
 		}
 	}
 	if err != nil {
-		if wrapped := wrapGCPError(err, "access secret"); wrapped != err {
-			return nil, wrapped
+		if permErr := wrapGCPError(err, "access secret"); permErr != nil {
+			return nil, permErr
 		}
 		return nil, fmt.Errorf("failed to access secret value from GCP SM: %w", err)
 	}
@@ -190,14 +187,14 @@ func (b *GCPBackend) Set(ctx context.Context, input *SetSecretInput) (bool, *Sec
 				},
 			})
 			if err != nil {
-				if wrapped := wrapGCPError(err, "create secret"); wrapped != err {
-					return false, nil, wrapped
+				if permErr := wrapGCPError(err, "create secret"); permErr != nil {
+					return false, nil, permErr
 				}
 				return false, nil, fmt.Errorf("failed to create GCP SM secret: %w", err)
 			}
 		} else {
-			if wrapped := wrapGCPError(err, "check secret"); wrapped != err {
-				return false, nil, wrapped
+			if permErr := wrapGCPError(err, "check secret"); permErr != nil {
+				return false, nil, permErr
 			}
 			return false, nil, fmt.Errorf("failed to check GCP SM secret: %w", err)
 		}
@@ -211,8 +208,8 @@ func (b *GCPBackend) Set(ctx context.Context, input *SetSecretInput) (bool, *Sec
 		},
 	})
 	if err != nil {
-		if wrapped := wrapGCPError(err, "add secret version"); wrapped != err {
-			return false, nil, wrapped
+		if permErr := wrapGCPError(err, "add secret version"); permErr != nil {
+			return false, nil, permErr
 		}
 		return false, nil, fmt.Errorf("failed to add GCP SM secret version: %w", err)
 	}
@@ -240,8 +237,8 @@ func (b *GCPBackend) Delete(ctx context.Context, name, scope, scopeID string) er
 		Name: fullName,
 	})
 	if err != nil && status.Code(err) != codes.NotFound {
-		if wrapped := wrapGCPError(err, "delete secret"); wrapped != err {
-			return wrapped
+		if permErr := wrapGCPError(err, "delete secret"); permErr != nil {
+			return permErr
 		}
 		return fmt.Errorf("failed to delete GCP SM secret: %w", err)
 	}
@@ -508,18 +505,13 @@ func buildLabels(input *SetSecretInput, target, hubName string) map[string]strin
 
 // wrapGCPError checks whether err is a gRPC PermissionDenied error and returns
 // a *PermissionError so that HTTP handlers can return 403 instead of 500.
-// Other error codes are returned unchanged.
+// Returns nil for all other error codes, enabling the idiomatic
+// "if permErr := wrapGCPError(...); permErr != nil" pattern.
 func wrapGCPError(err error, operation string) error {
-	if err == nil {
-		return nil
-	}
-	code := status.Code(err)
-	switch code {
-	case codes.PermissionDenied:
+	if status.Code(err) == codes.PermissionDenied {
 		return &PermissionError{Operation: operation, Err: err}
-	default:
-		return err
 	}
+	return nil
 }
 
 // resolveHubName returns the hub display name if set, falling back to the machine hostname.

--- a/pkg/secret/gcpbackend.go
+++ b/pkg/secret/gcpbackend.go
@@ -506,9 +506,9 @@ func buildLabels(input *SetSecretInput, target, hubName string) map[string]strin
 	return labels
 }
 
-// wrapGCPError checks whether err is a gRPC PermissionDenied or NotFound error
-// and returns a more descriptive error. PermissionDenied becomes a *PermissionError
-// so that HTTP handlers can return 403 instead of 500.
+// wrapGCPError checks whether err is a gRPC PermissionDenied error and returns
+// a *PermissionError so that HTTP handlers can return 403 instead of 500.
+// Other error codes are returned unchanged.
 func wrapGCPError(err error, operation string) error {
 	if err == nil {
 		return nil

--- a/pkg/secret/gcpbackend.go
+++ b/pkg/secret/gcpbackend.go
@@ -110,11 +110,17 @@ func (b *GCPBackend) Get(ctx context.Context, name, scope, scopeID string) (*Sec
 			if status.Code(err) == codes.NotFound {
 				return nil, store.ErrNotFound
 			}
+			if wrapped := wrapGCPError(err, "access secret"); wrapped != err {
+				return nil, wrapped
+			}
 		} else {
 			slog.Info("Recovered secret from GCP SM without DB record", "name", name, "scope", scope)
 		}
 	}
 	if err != nil {
+		if wrapped := wrapGCPError(err, "access secret"); wrapped != err {
+			return nil, wrapped
+		}
 		return nil, fmt.Errorf("failed to access secret value from GCP SM: %w", err)
 	}
 
@@ -184,9 +190,15 @@ func (b *GCPBackend) Set(ctx context.Context, input *SetSecretInput) (bool, *Sec
 				},
 			})
 			if err != nil {
+				if wrapped := wrapGCPError(err, "create secret"); wrapped != err {
+					return false, nil, wrapped
+				}
 				return false, nil, fmt.Errorf("failed to create GCP SM secret: %w", err)
 			}
 		} else {
+			if wrapped := wrapGCPError(err, "check secret"); wrapped != err {
+				return false, nil, wrapped
+			}
 			return false, nil, fmt.Errorf("failed to check GCP SM secret: %w", err)
 		}
 	}
@@ -199,6 +211,9 @@ func (b *GCPBackend) Set(ctx context.Context, input *SetSecretInput) (bool, *Sec
 		},
 	})
 	if err != nil {
+		if wrapped := wrapGCPError(err, "add secret version"); wrapped != err {
+			return false, nil, wrapped
+		}
 		return false, nil, fmt.Errorf("failed to add GCP SM secret version: %w", err)
 	}
 
@@ -225,6 +240,9 @@ func (b *GCPBackend) Delete(ctx context.Context, name, scope, scopeID string) er
 		Name: fullName,
 	})
 	if err != nil && status.Code(err) != codes.NotFound {
+		if wrapped := wrapGCPError(err, "delete secret"); wrapped != err {
+			return wrapped
+		}
 		return fmt.Errorf("failed to delete GCP SM secret: %w", err)
 	}
 
@@ -486,6 +504,22 @@ func buildLabels(input *SetSecretInput, target, hubName string) map[string]strin
 		labels["scion-userid"] = sanitizeLabel(input.UserEmail)
 	}
 	return labels
+}
+
+// wrapGCPError checks whether err is a gRPC PermissionDenied or NotFound error
+// and returns a more descriptive error. PermissionDenied becomes a *PermissionError
+// so that HTTP handlers can return 403 instead of 500.
+func wrapGCPError(err error, operation string) error {
+	if err == nil {
+		return nil
+	}
+	code := status.Code(err)
+	switch code {
+	case codes.PermissionDenied:
+		return &PermissionError{Operation: operation, Err: err}
+	default:
+		return err
+	}
 }
 
 // resolveHubName returns the hub display name if set, falling back to the machine hostname.

--- a/pkg/secret/gcpbackend_test.go
+++ b/pkg/secret/gcpbackend_test.go
@@ -722,6 +722,66 @@ func TestGCPBackend_Set_PermissionDenied(t *testing.T) {
 	if !strings.Contains(permErr.Error(), "roles/secretmanager.admin") {
 		t.Errorf("error message should mention the required role, got: %v", permErr.Error())
 	}
+	// Must NOT contain a granular permission name — the message should be
+	// operation-agnostic so it is correct for create, get, delete, etc.
+	if strings.Contains(permErr.Error(), "secretmanager.secrets.") {
+		t.Errorf("error message should not contain a granular permission name, got: %v", permErr.Error())
+	}
+}
+
+func TestGCPBackend_Set_GetSecretPermissionDenied(t *testing.T) {
+	// When GetSecret (the existence check) returns PermissionDenied,
+	// Set should surface a *PermissionError rather than a generic error.
+	s, err := newTestStore(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("failed to migrate test store: %v", err)
+	}
+
+	// Use a client that returns PermissionDenied on GetSecret (not just CreateSecret).
+	mock := &getPermDeniedSMClient{
+		mockSMClient: mockSMClient{
+			secrets:  make(map[string]*smpb.Secret),
+			versions: make(map[string][]byte),
+		},
+	}
+	backend := NewGCPBackendWithClient(s, mock, "test-project", "test-hub-id")
+
+	ctx := context.Background()
+	input := &SetSecretInput{
+		Name:       "API_KEY",
+		Value:      "sk-test-123",
+		SecretType: TypeEnvironment,
+		Target:     "API_KEY",
+		Scope:      ScopeUser,
+		ScopeID:    "user-1",
+	}
+
+	_, _, err = backend.Set(ctx, input)
+	if err == nil {
+		t.Fatal("expected error from Set when GetSecret returns PermissionDenied")
+	}
+
+	var permErr *PermissionError
+	if !errors.As(err, &permErr) {
+		t.Fatalf("expected *PermissionError, got %T: %v", err, err)
+	}
+	if permErr.Operation != "check secret" {
+		t.Errorf("expected operation %q, got %q", "check secret", permErr.Operation)
+	}
+}
+
+// getPermDeniedSMClient returns PermissionDenied specifically for GetSecret,
+// exercising the "check secret" branch in Set that is not covered by
+// permDeniedSMClient (which leaves GetSecret as the base NotFound mock).
+type getPermDeniedSMClient struct {
+	mockSMClient
+}
+
+func (m *getPermDeniedSMClient) GetSecret(_ context.Context, _ *smpb.GetSecretRequest) (*smpb.Secret, error) {
+	return nil, status.Errorf(codes.PermissionDenied, "caller does not have permission secretmanager.secrets.get")
 }
 
 func TestGCPBackend_Get_PermissionDenied(t *testing.T) {

--- a/pkg/secret/gcpbackend_test.go
+++ b/pkg/secret/gcpbackend_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -650,6 +651,133 @@ func TestGCPBackend_Labels_NoUserIDForNonUserScope(t *testing.T) {
 				t.Errorf("expected 6 labels for scope %q, got %d: %v", scope, len(sec.Labels), sec.Labels)
 			}
 		})
+	}
+}
+
+// permDeniedSMClient returns PermissionDenied for CreateSecret, AddSecretVersion,
+// AccessSecretVersion, and DeleteSecret. GetSecret returns NotFound to trigger
+// the creation path.
+type permDeniedSMClient struct {
+	mockSMClient
+}
+
+func newPermDeniedSMClient() *permDeniedSMClient {
+	return &permDeniedSMClient{
+		mockSMClient: mockSMClient{
+			secrets:  make(map[string]*smpb.Secret),
+			versions: make(map[string][]byte),
+		},
+	}
+}
+
+func (m *permDeniedSMClient) CreateSecret(_ context.Context, _ *smpb.CreateSecretRequest) (*smpb.Secret, error) {
+	return nil, status.Errorf(codes.PermissionDenied, "caller does not have permission secretmanager.secrets.create")
+}
+
+func (m *permDeniedSMClient) AddSecretVersion(_ context.Context, _ *smpb.AddSecretVersionRequest) (*smpb.SecretVersion, error) {
+	return nil, status.Errorf(codes.PermissionDenied, "caller does not have permission secretmanager.versions.add")
+}
+
+func (m *permDeniedSMClient) AccessSecretVersion(_ context.Context, _ *smpb.AccessSecretVersionRequest) (*smpb.AccessSecretVersionResponse, error) {
+	return nil, status.Errorf(codes.PermissionDenied, "caller does not have permission secretmanager.versions.access")
+}
+
+func (m *permDeniedSMClient) DeleteSecret(_ context.Context, _ *smpb.DeleteSecretRequest) error {
+	return status.Errorf(codes.PermissionDenied, "caller does not have permission secretmanager.secrets.delete")
+}
+
+func TestGCPBackend_Set_PermissionDenied(t *testing.T) {
+	s, err := newTestStore(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("failed to migrate test store: %v", err)
+	}
+	mock := newPermDeniedSMClient()
+	backend := NewGCPBackendWithClient(s, mock, "test-project", "test-hub-id")
+
+	ctx := context.Background()
+	input := &SetSecretInput{
+		Name:       "API_KEY",
+		Value:      "sk-test-123",
+		SecretType: TypeEnvironment,
+		Target:     "API_KEY",
+		Scope:      ScopeUser,
+		ScopeID:    "user-1",
+	}
+
+	_, _, err = backend.Set(ctx, input)
+	if err == nil {
+		t.Fatal("expected error from Set when SM returns PermissionDenied")
+	}
+
+	var permErr *PermissionError
+	if !errors.As(err, &permErr) {
+		t.Fatalf("expected *PermissionError, got %T: %v", err, err)
+	}
+	if !strings.Contains(permErr.Error(), "service account lacks the required Secret Manager permission") {
+		t.Errorf("error message should mention service account permission, got: %v", permErr.Error())
+	}
+	if !strings.Contains(permErr.Error(), "roles/secretmanager.admin") {
+		t.Errorf("error message should mention the required role, got: %v", permErr.Error())
+	}
+}
+
+func TestGCPBackend_Get_PermissionDenied(t *testing.T) {
+	s, err := newTestStore(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("failed to migrate test store: %v", err)
+	}
+	mock := newPermDeniedSMClient()
+	backend := NewGCPBackendWithClient(s, mock, "test-project", "test-hub-id")
+	ctx := context.Background()
+
+	// Store a metadata record so Get tries to access the GCP SM value
+	if _, err := s.UpsertSecret(ctx, &store.Secret{
+		ID:        tid("test-perm-denied"),
+		Key:       "API_KEY",
+		Scope:     "user",
+		ScopeID:   "user-1",
+		SecretRef: "gcpsm:projects/test-project/secrets/test-secret",
+	}); err != nil {
+		t.Fatalf("failed to seed DB: %v", err)
+	}
+
+	_, err = backend.Get(ctx, "API_KEY", "user", "user-1")
+	if err == nil {
+		t.Fatal("expected error from Get when SM returns PermissionDenied")
+	}
+
+	var permErr *PermissionError
+	if !errors.As(err, &permErr) {
+		t.Fatalf("expected *PermissionError, got %T: %v", err, err)
+	}
+}
+
+func TestGCPBackend_Delete_PermissionDenied(t *testing.T) {
+	s, err := newTestStore(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("failed to migrate test store: %v", err)
+	}
+	mock := newPermDeniedSMClient()
+	backend := NewGCPBackendWithClient(s, mock, "test-project", "test-hub-id")
+	ctx := context.Background()
+
+	err = backend.Delete(ctx, "API_KEY", "user", "user-1")
+	if err == nil {
+		t.Fatal("expected error from Delete when SM returns PermissionDenied")
+	}
+
+	var permErr *PermissionError
+	if !errors.As(err, &permErr) {
+		t.Fatalf("expected *PermissionError, got %T: %v", err, err)
 	}
 }
 

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -31,8 +31,8 @@ import (
 var ErrNoSecretBackend = errors.New("secret storage requires a configured secrets backend; set SCION_SERVER_SECRETS_BACKEND=gcpsm")
 
 // PermissionError indicates that a secret backend operation failed due to
-// insufficient permissions (e.g., the Hub service account lacks
-// secretmanager.secrets.create). Handlers should translate this to HTTP 403.
+// insufficient permissions (e.g., the Hub service account lacks a required
+// Secret Manager permission). Handlers should translate this to HTTP 403.
 type PermissionError struct {
 	Operation string // e.g., "create secret", "access secret version"
 	Err       error  // the underlying error
@@ -40,7 +40,7 @@ type PermissionError struct {
 
 func (e *PermissionError) Error() string {
 	return fmt.Sprintf("failed to %s: the Hub service account lacks the required Secret Manager permission. "+
-		"Grant roles/secretmanager.admin or a role with secretmanager.secrets.create to the Hub service account", e.Operation)
+		"Grant roles/secretmanager.admin to the Hub Runner service account", e.Operation)
 }
 
 func (e *PermissionError) Unwrap() error {

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -20,6 +20,7 @@ package secret
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 )
@@ -28,6 +29,23 @@ import (
 // secrets backend (e.g., GCP Secret Manager) but only the local backend is configured.
 // The local backend does not encrypt secret values, so write operations are rejected.
 var ErrNoSecretBackend = errors.New("secret storage requires a configured secrets backend; set SCION_SERVER_SECRETS_BACKEND=gcpsm")
+
+// PermissionError indicates that a secret backend operation failed due to
+// insufficient permissions (e.g., the Hub service account lacks
+// secretmanager.secrets.create). Handlers should translate this to HTTP 403.
+type PermissionError struct {
+	Operation string // e.g., "create secret", "access secret version"
+	Err       error  // the underlying error
+}
+
+func (e *PermissionError) Error() string {
+	return fmt.Sprintf("failed to %s: the Hub service account lacks the required Secret Manager permission. "+
+		"Grant roles/secretmanager.admin or a role with secretmanager.secrets.create to the Hub service account", e.Operation)
+}
+
+func (e *PermissionError) Unwrap() error {
+	return e.Err
+}
 
 // Secret type constants define how a secret is projected into the agent container.
 const (


### PR DESCRIPTION
## Summary

Fixes ptone/scion#731.

When the Hub Runner service account lacks Secret Manager permissions, the Hub returned a generic 500 "Internal Error". Users had to check Cloud Logging to diagnose the issue.

**Fix:**
- Added gRPC PermissionDenied error detection in the GCP secret backend via wrapGCPError()
- Returns HTTP 403 with actionable guidance: suggests granting roles/secretmanager.admin
- Covers all secret operations (create, get, delete) — uses operation-agnostic message
- Tests cover Set, Get, Delete permission errors and verify no hardcoded granular permission names

**Key files:**
- pkg/secret/ — GCP backend PermissionError type and wrapGCPError helper
- pkg/hub/ — HTTP error handler translation for PermissionError to 403

Ref: ptone/scion#732
