### PR TITLE
fix(hub): exempt file-type secrets from as_needed injection mode filter

### DIFF
--- a/pkg/hub/as_needed_resolution_test.go
+++ b/pkg/hub/as_needed_resolution_test.go
@@ -649,3 +649,113 @@ func TestDispatchAgentCreateWithGather_NoNeeds(t *testing.T) {
 		t.Errorf("expected 1 broker call, got %d", mockClient.callCount)
 	}
 }
+
+// --- resolveSecrets tests: file-type and variable-type secrets pass through ---
+
+func TestResolveSecrets_FileTypePassesThroughAsNeeded(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	hubID := "test-hub-file-passthrough"
+
+	mockClient := &mockRuntimeBrokerClient{}
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetHubID(hubID)
+	d.SetSecretBackend(&mockSecretBackend{
+		secrets: []secret.SecretWithValue{
+			{
+				SecretMeta: secret.SecretMeta{
+					Name:          "AGY_TOKEN",
+					SecretType:    store.SecretTypeFile,
+					Target:        "~/.gemini/antigravity-cli/antigravity-oauth-token",
+					Scope:         "project",
+					ScopeID:       "project-file-test",
+					InjectionMode: store.InjectionModeAsNeeded,
+				},
+				Value: "oauth-token-content",
+			},
+			{
+				SecretMeta: secret.SecretMeta{
+					Name:          "ENV_SECRET",
+					SecretType:    store.SecretTypeEnvironment,
+					Target:        "MY_ENV",
+					Scope:         "project",
+					ScopeID:       "project-file-test",
+					InjectionMode: store.InjectionModeAsNeeded,
+				},
+				Value: "env-secret-value",
+			},
+			{
+				SecretMeta: secret.SecretMeta{
+					Name:          "VAR_SECRET",
+					SecretType:    store.SecretTypeVariable,
+					Target:        "MY_VAR",
+					Scope:         "project",
+					ScopeID:       "project-file-test",
+					InjectionMode: store.InjectionModeAsNeeded,
+				},
+				Value: "var-secret-value",
+			},
+			{
+				SecretMeta: secret.SecretMeta{
+					Name:          "ALWAYS_ENV",
+					SecretType:    store.SecretTypeEnvironment,
+					Target:        "ALWAYS_KEY",
+					Scope:         "project",
+					ScopeID:       "project-file-test",
+					InjectionMode: store.InjectionModeAlways,
+				},
+				Value: "always-env-value",
+			},
+		},
+	})
+
+	agent := &store.Agent{
+		ID:        "agent-file-passthrough",
+		Name:      "file-passthrough",
+		OwnerID:   "user-1",
+		ProjectID: "project-file-test",
+	}
+
+	result, err := d.resolveSecrets(ctx, agent)
+	if err != nil {
+		t.Fatalf("resolveSecrets: %v", err)
+	}
+
+	// Build lookup by name for easier assertions.
+	byName := make(map[string]ResolvedSecret, len(result))
+	for _, rs := range result {
+		byName[rs.Name] = rs
+	}
+
+	// File-type secret with as_needed should pass through.
+	if rs, ok := byName["AGY_TOKEN"]; !ok {
+		t.Error("expected AGY_TOKEN (file-type, as_needed) to pass through resolveSecrets")
+	} else {
+		if rs.Type != store.SecretTypeFile {
+			t.Errorf("AGY_TOKEN type = %q, want %q", rs.Type, store.SecretTypeFile)
+		}
+		if rs.Target != "~/.gemini/antigravity-cli/antigravity-oauth-token" {
+			t.Errorf("AGY_TOKEN target = %q, want %q", rs.Target, "~/.gemini/antigravity-cli/antigravity-oauth-token")
+		}
+		if rs.Value != "oauth-token-content" {
+			t.Errorf("AGY_TOKEN value = %q, want %q", rs.Value, "oauth-token-content")
+		}
+	}
+
+	// Variable-type secret with as_needed should also pass through.
+	if _, ok := byName["VAR_SECRET"]; !ok {
+		t.Error("expected VAR_SECRET (variable-type, as_needed) to pass through resolveSecrets")
+	}
+
+	// Environment-type secret with as_needed should be filtered out
+	// (handled by the two-pass env-gather flow instead).
+	if _, ok := byName["ENV_SECRET"]; ok {
+		t.Error("ENV_SECRET (environment-type, as_needed) should be filtered by resolveSecrets")
+	}
+
+	// Environment-type secret with always should pass through.
+	if _, ok := byName["ALWAYS_ENV"]; !ok {
+		t.Error("expected ALWAYS_ENV (environment-type, always) to pass through resolveSecrets")
+	}
+}

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -2450,7 +2450,11 @@ func (d *HTTPAgentDispatcher) resolveSecrets(ctx context.Context, agent *store.A
 	}
 	result := make([]ResolvedSecret, 0, len(resolved))
 	for _, sv := range resolved {
-		if sv.InjectionMode == store.InjectionModeAsNeeded {
+		// Only skip as_needed environment-type secrets (handled by the
+		// two-pass env-gather flow). File-type and variable-type secrets
+		// should always be placed regardless of injection mode — the
+		// as_needed concept does not apply to them.
+		if sv.InjectionMode == store.InjectionModeAsNeeded && sv.SecretType == store.SecretTypeEnvironment {
 			continue
 		}
 		result = append(result, ResolvedSecret{

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -2454,7 +2454,7 @@ func (d *HTTPAgentDispatcher) resolveSecrets(ctx context.Context, agent *store.A
 		// two-pass env-gather flow). File-type and variable-type secrets
 		// should always be placed regardless of injection mode — the
 		// as_needed concept does not apply to them.
-		if sv.InjectionMode == store.InjectionModeAsNeeded && sv.SecretType == store.SecretTypeEnvironment {
+		if sv.InjectionMode == store.InjectionModeAsNeeded && (sv.SecretType == store.SecretTypeEnvironment || sv.SecretType == "") {
 			continue
 		}
 		result = append(result, ResolvedSecret{


### PR DESCRIPTION
## Summary

Follow-up to #967. File-type and variable-type secrets with the default as_needed injection mode were silently dropped by resolveSecrets, meaning target files were never placed in containers.

The as_needed filter now applies only to environment-type secrets (which are handled by the two-pass resolution from #967). File-type and variable-type secrets pass through regardless of injection mode, matching user intent — creating a file-type secret always means "put this file here."

### Changes
- pkg/hub/httpdispatcher.go: Narrow as_needed filter in resolveSecrets to env-type only
- pkg/hub/as_needed_resolution_test.go: Test covering all four type+mode combinations

Fixes ptone/scion#721
