### PR TITLE
fix(discord): correct agent status icons for all phases and activities

### DIFF
--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -1788,7 +1788,7 @@ func resolveChannelLink(ctx context.Context, s *discordgo.Session, store Store, 
 // Activity takes priority when present; phase is the fallback.
 func agentStatusEmoji(activity, phase string) string {
 	// Activity icons (priority)
-	switch activity {
+	switch strings.ToLower(activity) {
 	case "working":
 		return "⚙️" // gear
 	case "thinking":
@@ -1812,7 +1812,7 @@ func agentStatusEmoji(activity, phase string) string {
 	}
 
 	// Phase icons (fallback)
-	switch phase {
+	switch strings.ToLower(phase) {
 	case "created":
 		return "\U0001f4e6" // package
 	case "provisioning":

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -20,6 +20,7 @@ import (
 type AgentInfo struct {
 	Slug     string `json:"slug"`
 	Activity string `json:"activity,omitempty"`
+	Phase    string `json:"phase,omitempty"`
 }
 
 // ProjectOption holds a project's identifiers for display in selection UI.
@@ -747,7 +748,7 @@ func (h *CommandHandler) HandleAgents(s *discordgo.Session, i *discordgo.Interac
 
 	var lines []string
 	for _, agent := range agents {
-		emoji := activityEmoji(agent.Activity)
+		emoji := agentStatusEmoji(agent.Activity, agent.Phase)
 		label := agent.Slug
 		if agent.Activity != "" {
 			label += " -- " + agent.Activity
@@ -843,7 +844,7 @@ func (h *CommandHandler) HandleStatus(s *discordgo.Session, i *discordgo.Interac
 
 	for _, agent := range agents {
 		if agent.Slug == agentSlug {
-			emoji := activityEmoji(agent.Activity)
+			emoji := agentStatusEmoji(agent.Activity, agent.Phase)
 			activity := agent.Activity
 			if activity == "" {
 				activity = "unknown"
@@ -1783,24 +1784,54 @@ func resolveChannelLink(ctx context.Context, s *discordgo.Session, store Store, 
 	return link, nil
 }
 
-// activityEmoji returns an emoji for an agent activity state.
-func activityEmoji(activity string) string {
-	switch strings.ToLower(activity) {
-	case "idle":
-		return "💤"
-	case "executing":
-		return "⚙️"
+// agentStatusEmoji returns an icon based on the agent's activity and phase.
+// Activity takes priority when present; phase is the fallback.
+func agentStatusEmoji(activity, phase string) string {
+	// Activity icons (priority)
+	switch activity {
+	case "working":
+		return "⚙️" // gear
 	case "thinking":
-		return "💭"
+		return "\U0001f4ad" // thought balloon
+	case "executing":
+		return "⚙️" // gear
+	case "waiting_for_input":
+		return "\U0001f514" // bell
 	case "blocked":
-		return "🚧"
+		return "\U0001f6a7" // construction
 	case "completed":
-		return "✅"
-	case "error":
-		return "❌"
+		return "✅" // check mark
+	case "limits_exceeded":
+		return "\U0001f6ab" // prohibited
 	case "stalled":
-		return "⏳"
-	default:
-		return "▶️"
+		return "⏳" // hourglass
+	case "offline":
+		return "\U0001f4e1" // satellite antenna
+	case "crashed":
+		return "\U0001f4a5" // collision/crash
 	}
+
+	// Phase icons (fallback)
+	switch phase {
+	case "created":
+		return "\U0001f4e6" // package
+	case "provisioning":
+		return "\U0001f504" // counterclockwise arrows
+	case "cloning":
+		return "\U0001f4e5" // inbox tray
+	case "starting":
+		return "\U0001f680" // rocket
+	case "running":
+		return "▶️" // play
+	case "suspended":
+		return "⏸️" // pause
+	case "stopping":
+		return "\U0001f6d1" // stop sign
+	case "stopped":
+		return "⏹️" // stop button
+	case "error":
+		return "❌" // cross mark
+	}
+
+	return "▶️" // play (default)
 }

--- a/extras/scion-discord/internal/discord/commands_test.go
+++ b/extras/scion-discord/internal/discord/commands_test.go
@@ -1,0 +1,84 @@
+package discord
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// agentStatusEmoji
+// ---------------------------------------------------------------------------
+
+func TestAgentStatusEmoji_ActivityIcons(t *testing.T) {
+	tests := []struct {
+		activity string
+		want     string
+	}{
+		{"working", "⚙️"},
+		{"thinking", "\U0001f4ad"},
+		{"executing", "⚙️"},
+		{"waiting_for_input", "\U0001f514"},
+		{"blocked", "\U0001f6a7"},
+		{"completed", "✅"},
+		{"limits_exceeded", "\U0001f6ab"},
+		{"stalled", "⏳"},
+		{"offline", "\U0001f4e1"},
+		{"crashed", "\U0001f4a5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.activity, func(t *testing.T) {
+			got := agentStatusEmoji(tt.activity, "")
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAgentStatusEmoji_PhaseIcons(t *testing.T) {
+	tests := []struct {
+		phase string
+		want  string
+	}{
+		{"created", "\U0001f4e6"},
+		{"provisioning", "\U0001f504"},
+		{"cloning", "\U0001f4e5"},
+		{"starting", "\U0001f680"},
+		{"running", "▶️"},
+		{"suspended", "⏸️"},
+		{"stopping", "\U0001f6d1"},
+		{"stopped", "⏹️"},
+		{"error", "❌"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.phase, func(t *testing.T) {
+			got := agentStatusEmoji("", tt.phase)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAgentStatusEmoji_ActivityPriorityOverPhase(t *testing.T) {
+	// When both activity and phase are set, activity takes priority.
+	got := agentStatusEmoji("crashed", "stopped")
+	assert.Equal(t, "\U0001f4a5", got, "crashed activity should take priority over stopped phase")
+
+	got = agentStatusEmoji("limits_exceeded", "stopped")
+	assert.Equal(t, "\U0001f6ab", got, "limits_exceeded activity should take priority over stopped phase")
+
+	got = agentStatusEmoji("completed", "running")
+	assert.Equal(t, "✅", got, "completed activity should take priority over running phase")
+}
+
+func TestAgentStatusEmoji_EmptyBothDefaultsToPlay(t *testing.T) {
+	got := agentStatusEmoji("", "")
+	assert.Equal(t, "▶️", got, "empty activity and phase should return default play icon")
+}
+
+func TestAgentStatusEmoji_UnknownActivityFallsToPhase(t *testing.T) {
+	// Unknown activity should fall through to phase icon.
+	got := agentStatusEmoji("unknown_activity", "stopped")
+	assert.Equal(t, "⏹️", got, "unknown activity should fall through to phase icon")
+
+	got = agentStatusEmoji("unknown_activity", "error")
+	assert.Equal(t, "❌", got, "unknown activity should fall through to error phase icon")
+}

--- a/extras/scion-discord/internal/discord/commands_test.go
+++ b/extras/scion-discord/internal/discord/commands_test.go
@@ -69,6 +69,22 @@ func TestAgentStatusEmoji_ActivityPriorityOverPhase(t *testing.T) {
 	assert.Equal(t, "✅", got, "completed activity should take priority over running phase")
 }
 
+func TestAgentStatusEmoji_MixedCaseInput(t *testing.T) {
+	// Activity matching should be case-insensitive.
+	got := agentStatusEmoji("Working", "")
+	assert.Equal(t, "⚙️", got, "mixed-case activity 'Working' should return gear icon")
+
+	got = agentStatusEmoji("BLOCKED", "")
+	assert.Equal(t, "\U0001f6a7", got, "upper-case activity 'BLOCKED' should return construction icon")
+
+	// Phase matching should be case-insensitive.
+	got = agentStatusEmoji("", "Running")
+	assert.Equal(t, "▶️", got, "mixed-case phase 'Running' should return play icon")
+
+	got = agentStatusEmoji("", "STOPPED")
+	assert.Equal(t, "⏹️", got, "upper-case phase 'STOPPED' should return stop button icon")
+}
+
 func TestAgentStatusEmoji_EmptyBothDefaultsToPlay(t *testing.T) {
 	got := agentStatusEmoji("", "")
 	assert.Equal(t, "▶️", got, "empty activity and phase should return default play icon")

--- a/extras/scion-discord/internal/discord/hubclient.go
+++ b/extras/scion-discord/internal/discord/hubclient.go
@@ -59,6 +59,7 @@ type hubAgentsResponse struct {
 type hubAgent struct {
 	Slug     string `json:"slug"`
 	Activity string `json:"activity"`
+	Phase    string `json:"phase"`
 }
 
 func (c *httpHubClient) ListProjects(ctx context.Context) ([]ProjectOption, error) {
@@ -204,7 +205,7 @@ func (c *httpHubClient) ListAgents(ctx context.Context, projectID string) ([]Age
 
 	agents := make([]AgentInfo, len(result.Agents))
 	for i, a := range result.Agents {
-		agents[i] = AgentInfo{Slug: a.Slug, Activity: a.Activity}
+		agents[i] = AgentInfo{Slug: a.Slug, Activity: a.Activity, Phase: a.Phase}
 	}
 	return agents, nil
 }


### PR DESCRIPTION
Fixes incorrect agent status icons in /scion agents Discord command. Stopped, errored, limits-exceeded, crashed, offline, and waiting-for-input agents all showed generic play icon. Added Phase field to hub API structs and replaced activityEmoji() with two-tier agentStatusEmoji() covering all 10 activities and 9 phases.

Fork PR: https://github.com/ptone/scion/pull/736