### PR TITLE
fix(web): add button spacing and Enter key support to confirm dialog

### DIFF
--- a/web/src/components/shared/confirm-dialog.ts
+++ b/web/src/components/shared/confirm-dialog.ts
@@ -90,8 +90,22 @@ export function showConfirm(
     confirmBtn.slot = 'footer';
     confirmBtn.setAttribute('variant', variant);
     confirmBtn.textContent = confirmText;
+    confirmBtn.style.marginInlineStart = '0.5rem';
     confirmBtn.addEventListener('click', () => cleanup(true));
     dialog.appendChild(confirmBtn);
+
+    // Enter key confirms the dialog (standard UX pattern).
+    // Guard against intercepting Enter inside form fields.
+    dialog.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        const tag = (e.target as HTMLElement)?.tagName?.toLowerCase();
+        if (tag === 'textarea' || tag === 'input' || tag === 'sl-textarea' || tag === 'sl-input') {
+          return;
+        }
+        e.preventDefault();
+        cleanup(true);
+      }
+    });
 
     let resolved = false;
     function cleanup(result: boolean) {

--- a/web/src/components/shared/confirm-dialog.ts
+++ b/web/src/components/shared/confirm-dialog.ts
@@ -99,7 +99,7 @@ export function showConfirm(
     dialog.addEventListener('keydown', (e: KeyboardEvent) => {
       if (e.key === 'Enter') {
         const tag = (e.target as HTMLElement)?.tagName?.toLowerCase();
-        if (tag === 'textarea' || tag === 'input' || tag === 'sl-textarea' || tag === 'sl-input') {
+        if (tag === 'textarea' || tag === 'input' || tag === 'sl-textarea' || tag === 'sl-input' || tag === 'button' || tag === 'sl-button') {
           return;
         }
         e.preventDefault();


### PR DESCRIPTION
## Summary

Fixes two issues in the confirm dialog component:

1. **Button spacing**: Added margin between Cancel and Confirm buttons (they were touching with no gap).
2. **Enter key support**: Added keydown listener so pressing Enter confirms the dialog, with guards against intercepting Enter in text inputs.

**Key files:**
- web/src/components/ — confirm dialog component
