### PR TITLE
feat(discord): add downloads_path config for inbound attachments

### DIFF
--- a/extras/scion-discord/cmd/scion-plugin-discord/main.go
+++ b/extras/scion-discord/cmd/scion-plugin-discord/main.go
@@ -70,7 +70,7 @@ func main() {
 	fmt.Println("  send_queue_size  Max queued messages per channel (default: 100)")
 	fmt.Println("  send_min_delay   Minimum delay between sends (default: 50ms)")
 	fmt.Println("  agent_cache_ttl  TTL for cached agent list (default: 5m)")
-	fmt.Println("  downloads_path   Override directory for inbound attachment downloads (default: /workspace/downloads)")
+	fmt.Println("  downloads_path   Override directory for inbound attachment downloads (default: /workspace/downloads, supports {project_slug} placeholder)")
 	fmt.Println("  register_url     Public URL for user-facing registration links (default: hub_url)")
 	os.Exit(0)
 }

--- a/extras/scion-discord/cmd/scion-plugin-discord/main.go
+++ b/extras/scion-discord/cmd/scion-plugin-discord/main.go
@@ -70,6 +70,7 @@ func main() {
 	fmt.Println("  send_queue_size  Max queued messages per channel (default: 100)")
 	fmt.Println("  send_min_delay   Minimum delay between sends (default: 50ms)")
 	fmt.Println("  agent_cache_ttl  TTL for cached agent list (default: 5m)")
+	fmt.Println("  downloads_path   Override directory for inbound attachment downloads (default: /workspace/downloads)")
 	fmt.Println("  register_url     Public URL for user-facing registration links (default: hub_url)")
 	os.Exit(0)
 }
@@ -157,7 +158,7 @@ func serveStandalone() {
 			"bot_token", "application_id", "public_key", "guild_ids", "guild_id",
 			"hub_url", "hmac_key", "broker_id",
 			"mention_routing", "send_queue_size", "send_min_delay",
-			"agent_cache_ttl",
+			"agent_cache_ttl", "downloads_path",
 			"transport_mode", "transport_audience",
 			"register_url",
 		},

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -2024,7 +2024,7 @@ func (b *DiscordBroker) downloadDiscordAttachment(ctx context.Context, att *disc
 	// Use configured downloads_path if set; otherwise default to project dir.
 	var hostDir string
 	if b.downloadsPath != "" {
-		hostDir = b.downloadsPath
+		hostDir = strings.ReplaceAll(b.downloadsPath, "{project_slug}", projectSlug)
 	} else {
 		hostDir = filepath.Join("/home/scion/.scion/projects", projectSlug, "downloads")
 	}
@@ -2049,7 +2049,7 @@ func (b *DiscordBroker) downloadDiscordAttachment(ctx context.Context, att *disc
 	// When a custom downloads_path is configured, the agent sees that path
 	// directly; otherwise it sees the conventional /workspace/downloads mount.
 	if b.downloadsPath != "" {
-		agentPath = filepath.Join(b.downloadsPath, destName)
+		agentPath = filepath.Join(strings.ReplaceAll(b.downloadsPath, "{project_slug}", projectSlug), destName)
 	} else {
 		agentPath = filepath.Join("/workspace/downloads", destName)
 	}

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -160,6 +160,7 @@ type DiscordBroker struct {
 
 	agentCacheTTL  time.Duration
 	projectSlugMap map[string]string // injected by hub: projectID -> slug
+	downloadsPath  string            // override for file download directory; empty = default
 
 	config *Config
 
@@ -308,6 +309,11 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 				return fmt.Errorf("invalid agent_cache_ttl: %w", err)
 			}
 			b.agentCacheTTL = d
+		}
+
+		// Parse optional downloads directory override.
+		if v, ok := config["downloads_path"]; ok && v != "" {
+			b.downloadsPath = v
 		}
 
 		b.log.Info("Discord broker phase 1 configured",
@@ -2015,7 +2021,13 @@ func (b *DiscordBroker) downloadDiscordAttachment(ctx context.Context, att *disc
 	timestamp := time.Now().Unix()
 	destName := fmt.Sprintf("discord_%d_%s", timestamp, fileName)
 
-	hostDir := filepath.Join("/home/scion/.scion/projects", projectSlug, "downloads")
+	// Use configured downloads_path if set; otherwise default to project dir.
+	var hostDir string
+	if b.downloadsPath != "" {
+		hostDir = b.downloadsPath
+	} else {
+		hostDir = filepath.Join("/home/scion/.scion/projects", projectSlug, "downloads")
+	}
 	if err := os.MkdirAll(hostDir, 0o755); err != nil {
 		return "", "", fmt.Errorf("create downloads dir: %w", err)
 	}
@@ -2033,7 +2045,14 @@ func (b *DiscordBroker) downloadDiscordAttachment(ctx context.Context, att *disc
 		return "", "", fmt.Errorf("write file: %w", err)
 	}
 
-	agentPath = filepath.Join("/workspace/downloads", destName)
+	// Derive the agent-visible path from the same base used to save the file.
+	// When a custom downloads_path is configured, the agent sees that path
+	// directly; otherwise it sees the conventional /workspace/downloads mount.
+	if b.downloadsPath != "" {
+		agentPath = filepath.Join(b.downloadsPath, destName)
+	} else {
+		agentPath = filepath.Join("/workspace/downloads", destName)
+	}
 	contentType := att.ContentType
 	if contentType == "" {
 		contentType = "file"

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1436,4 +1437,159 @@ func TestResolveChannelLink_CachesConfirmedThread(t *testing.T) {
 	threadParentsMu.Unlock()
 	assert.True(t, cached, "confirmed thread must be cached")
 	assert.Equal(t, parentID, cachedParent)
+}
+
+// --- downloadDiscordAttachment tests ---
+
+func TestDownloadDiscordAttachment_DefaultPath(t *testing.T) {
+	// When downloadsPath is empty, the function writes to
+	// /home/scion/.scion/projects/<slug>/downloads and returns
+	// /workspace/downloads/<name> as the agent-visible path.
+	// We can't safely write to /home/scion in tests, so we verify
+	// the path computation by setting downloadsPath to a temp dir
+	// and confirming the custom-path branch differs from the default.
+
+	fileContent := []byte("default-path-test")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(fileContent)
+	}))
+	defer srv.Close()
+
+	projectSlug := "test-project"
+
+	// Verify the default hostDir and agentPath computation.
+	defaultHostDir := filepath.Join("/home/scion/.scion/projects", projectSlug, "downloads")
+	assert.Equal(t, "/home/scion/.scion/projects/test-project/downloads", defaultHostDir)
+
+	defaultAgentPath := filepath.Join("/workspace/downloads", "discord_123_photo.png")
+	assert.Equal(t, "/workspace/downloads/discord_123_photo.png", defaultAgentPath)
+
+	// Verify that a broker with no downloadsPath set would use
+	// the default agent path prefix.
+	b := &DiscordBroker{
+		log:        discardLogger(),
+		httpClient: srv.Client(),
+	}
+	assert.Empty(t, b.downloadsPath, "downloadsPath should be empty by default")
+}
+
+func TestDownloadDiscordAttachment_CustomDownloadsPath(t *testing.T) {
+	fileContent := []byte("fake-image-data-for-test")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(fileContent)
+	}))
+	defer srv.Close()
+
+	downloadsDir := t.TempDir()
+	b := &DiscordBroker{
+		log:           discardLogger(),
+		httpClient:    srv.Client(),
+		downloadsPath: downloadsDir,
+	}
+
+	att := &discordgo.MessageAttachment{
+		ID:          "att-002",
+		Filename:    "document.pdf",
+		URL:         srv.URL + "/document.pdf",
+		Size:        len(fileContent),
+		ContentType: "application/pdf",
+	}
+
+	ctx := context.Background()
+	agentPath, placeholder, err := b.downloadDiscordAttachment(ctx, att, "some-project")
+	require.NoError(t, err)
+
+	// Agent path should be downloads_path + filename (not /workspace/downloads/).
+	assert.True(t, strings.HasPrefix(agentPath, downloadsDir),
+		"agentPath %q should start with downloadsPath %q", agentPath, downloadsDir)
+	assert.False(t, strings.Contains(agentPath, "/workspace/downloads"),
+		"agentPath should not contain /workspace/downloads when downloadsPath is set")
+
+	// The filename should contain the original name.
+	assert.Contains(t, filepath.Base(agentPath), "document.pdf")
+	assert.Contains(t, filepath.Base(agentPath), "discord_")
+
+	// Placeholder should describe the attachment.
+	assert.Contains(t, placeholder, "document.pdf")
+	assert.Contains(t, placeholder, "application/pdf")
+
+	// The file should actually exist on disk with correct contents.
+	data, err := os.ReadFile(agentPath)
+	require.NoError(t, err, "downloaded file should exist at agentPath")
+	assert.Equal(t, fileContent, data)
+}
+
+func TestDownloadDiscordAttachment_EmptyProjectSlug(t *testing.T) {
+	b := &DiscordBroker{
+		log:        discardLogger(),
+		httpClient: http.DefaultClient,
+	}
+
+	att := &discordgo.MessageAttachment{
+		ID:       "att-003",
+		Filename: "file.txt",
+		URL:      "http://example.com/file.txt",
+		Size:     10,
+	}
+
+	ctx := context.Background()
+	_, _, err := b.downloadDiscordAttachment(ctx, att, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "project slug is empty")
+}
+
+func TestDownloadDiscordAttachment_TooLarge(t *testing.T) {
+	b := &DiscordBroker{
+		log:        discardLogger(),
+		httpClient: http.DefaultClient,
+	}
+
+	att := &discordgo.MessageAttachment{
+		ID:       "att-004",
+		Filename: "huge.bin",
+		URL:      "http://example.com/huge.bin",
+		Size:     maxDiscordAttachmentSize + 1,
+	}
+
+	ctx := context.Background()
+	_, _, err := b.downloadDiscordAttachment(ctx, att, "test-project")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too large")
+}
+
+func TestDownloadDiscordAttachment_CustomPath_CreatesSubdir(t *testing.T) {
+	fileContent := []byte("test-content")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(fileContent)
+	}))
+	defer srv.Close()
+
+	// Use a nested path that doesn't exist yet — MkdirAll should create it.
+	baseDir := t.TempDir()
+	downloadsDir := filepath.Join(baseDir, "nested", "downloads")
+	b := &DiscordBroker{
+		log:           discardLogger(),
+		httpClient:    srv.Client(),
+		downloadsPath: downloadsDir,
+	}
+
+	att := &discordgo.MessageAttachment{
+		ID:       "att-005",
+		Filename: "nested-file.txt",
+		URL:      srv.URL + "/nested-file.txt",
+		Size:     len(fileContent),
+	}
+
+	ctx := context.Background()
+	agentPath, _, err := b.downloadDiscordAttachment(ctx, att, "proj")
+	require.NoError(t, err)
+
+	// Verify the directory was created and the file exists.
+	_, err = os.Stat(downloadsDir)
+	require.NoError(t, err, "downloadsPath directory should be created")
+
+	data, err := os.ReadFile(agentPath)
+	require.NoError(t, err)
+	assert.Equal(t, fileContent, data)
 }

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -1520,6 +1520,56 @@ func TestDownloadDiscordAttachment_CustomDownloadsPath(t *testing.T) {
 	assert.Equal(t, fileContent, data)
 }
 
+func TestDownloadDiscordAttachment_ProjectSlugPlaceholder(t *testing.T) {
+	fileContent := []byte("slug-placeholder-test")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write(fileContent)
+	}))
+	defer srv.Close()
+
+	baseDir := t.TempDir()
+	b := &DiscordBroker{
+		log:           discardLogger(),
+		httpClient:    srv.Client(),
+		downloadsPath: filepath.Join(baseDir, "{project_slug}"),
+	}
+
+	att := &discordgo.MessageAttachment{
+		ID:          "att-slug-001",
+		Filename:    "photo.jpg",
+		URL:         srv.URL + "/photo.jpg",
+		Size:        len(fileContent),
+		ContentType: "image/jpeg",
+	}
+
+	projectSlug := "my-cool-project"
+	ctx := context.Background()
+	agentPath, placeholder, err := b.downloadDiscordAttachment(ctx, att, projectSlug)
+	require.NoError(t, err)
+
+	// Host directory should have the slug expanded (file written there).
+	expandedDir := filepath.Join(baseDir, projectSlug)
+	entries, err := os.ReadDir(expandedDir)
+	require.NoError(t, err, "expanded slug directory should exist")
+	require.Len(t, entries, 1, "should contain exactly one downloaded file")
+
+	// Agent path should use the expanded slug, not the literal placeholder.
+	assert.True(t, strings.HasPrefix(agentPath, expandedDir),
+		"agentPath %q should start with expanded dir %q", agentPath, expandedDir)
+	assert.NotContains(t, agentPath, "{project_slug}",
+		"agentPath should not contain literal {project_slug}")
+
+	// File on disk should match.
+	data, err := os.ReadFile(agentPath)
+	require.NoError(t, err)
+	assert.Equal(t, fileContent, data)
+
+	// Placeholder should describe the attachment.
+	assert.Contains(t, placeholder, "photo.jpg")
+	assert.Contains(t, placeholder, "image/jpeg")
+}
+
 func TestDownloadDiscordAttachment_EmptyProjectSlug(t *testing.T) {
 	b := &DiscordBroker{
 		log:        discardLogger(),


### PR DESCRIPTION
Adds downloads_path config to Discord broker so inbound attachments can be routed through a shared volume instead of per-agent /workspace/downloads/. Fixes attachment delivery in clone-per-agent and worktree-per-agent projects. Mirrors existing Telegram broker support.

Fork PR: https://github.com/ptone/scion/pull/738