### PR TITLE
fix(ui): show last meaningful activity instead of heartbeat time in agent list

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -257,6 +257,7 @@ func hubAgentToAgentInfo(a hubclient.Agent) api.AgentInfo {
 		Created:           a.Created,
 		Updated:           a.Updated,
 		LastSeen:          a.LastSeen,
+		LastActivityEvent: a.LastActivityEvent,
 		DeletedAt:         a.DeletedAt,
 		CreatedBy:         a.CreatedBy,
 		OwnerID:           a.OwnerID,
@@ -378,7 +379,15 @@ func sortAgentsByField(agents []api.AgentInfo) {
 		case "updated":
 			less = agents[i].Updated.Before(agents[j].Updated)
 		case "last-seen":
-			less = agents[i].LastSeen.Before(agents[j].LastSeen)
+			ti := agents[i].LastActivityEvent
+			if ti.IsZero() {
+				ti = agents[i].LastSeen
+			}
+			tj := agents[j].LastActivityEvent
+			if tj.IsZero() {
+				tj = agents[j].LastSeen
+			}
+			less = ti.Before(tj)
 		default:
 			return false
 		}
@@ -410,7 +419,15 @@ func displayAgents(agents []api.AgentInfo, all bool, hubMode bool) error {
 		sortAgentsByField(agents)
 	} else if sortByTime {
 		sort.Slice(agents, func(i, j int) bool {
-			return agents[i].LastSeen.After(agents[j].LastSeen)
+			ti := agents[i].LastActivityEvent
+			if ti.IsZero() {
+				ti = agents[i].LastSeen
+			}
+			tj := agents[j].LastActivityEvent
+			if tj.IsZero() {
+				tj = agents[j].LastSeen
+			}
+			return ti.After(tj)
 		})
 	}
 
@@ -454,7 +471,11 @@ func displayAgents(agents []api.AgentInfo, all bool, hubMode bool) error {
 		if harnessConfig == "" {
 			harnessConfig = "-"
 		}
-		lastActivity := formatLastActivity(a.Activity, a.LastSeen)
+		activityTime := a.LastActivityEvent
+		if activityTime.IsZero() {
+			activityTime = a.LastSeen
+		}
+		lastActivity := formatLastActivity(a.Activity, activityTime)
 		// Use broker name if available, otherwise fall back to ID
 		broker := a.RuntimeBrokerName
 		if broker == "" {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -589,10 +589,11 @@ type AgentInfo struct {
 	Warnings   []string          `json:"warnings,omitempty"`
 
 	// Timestamps
-	Created   time.Time `json:"created,omitempty"`   // When the agent was created
-	Updated   time.Time `json:"updated,omitempty"`   // Last modification timestamp
-	LastSeen  time.Time `json:"lastSeen,omitempty"`  // Last heartbeat/status report
-	DeletedAt time.Time `json:"deletedAt,omitempty"` // When the agent was soft-deleted
+	Created           time.Time `json:"created,omitempty"`           // When the agent was created
+	Updated           time.Time `json:"updated,omitempty"`           // Last modification timestamp
+	LastSeen          time.Time `json:"lastSeen,omitempty"`          // Last heartbeat/status report
+	LastActivityEvent time.Time `json:"lastActivityEvent,omitempty"` // Last meaningful activity change
+	DeletedAt         time.Time `json:"deletedAt,omitempty"`         // When the agent was soft-deleted
 
 	// Ownership & access
 	CreatedBy  string   `json:"createdBy,omitempty"`  // User/system that created the agent

--- a/pkg/hub/events.go
+++ b/pkg/hub/events.go
@@ -105,13 +105,14 @@ type AgentDetail struct {
 
 // AgentStatusEvent is published when an agent's status changes.
 type AgentStatusEvent struct {
-	AgentID         string       `json:"agentId"`
-	ProjectID       string       `json:"projectId"`
-	GroveID         string       `json:"groveId"`
-	Phase           string       `json:"phase,omitempty"`
-	Activity        string       `json:"activity,omitempty"`
-	Detail          *AgentDetail `json:"detail,omitempty"`
-	ContainerStatus string       `json:"containerStatus,omitempty"`
+	AgentID           string       `json:"agentId"`
+	ProjectID         string       `json:"projectId"`
+	GroveID           string       `json:"groveId"`
+	Phase             string       `json:"phase,omitempty"`
+	Activity          string       `json:"activity,omitempty"`
+	Detail            *AgentDetail `json:"detail,omitempty"`
+	ContainerStatus   string       `json:"containerStatus,omitempty"`
+	LastActivityEvent string       `json:"lastActivityEvent,omitempty"`
 }
 
 // AgentCreatedEvent is published when an agent is created.
@@ -376,6 +377,9 @@ func (p *eventBuilder) PublishAgentStatus(_ context.Context, agent *store.Agent)
 		Phase:           agent.Phase,
 		Activity:        agent.Activity,
 		ContainerStatus: agent.ContainerStatus,
+	}
+	if !agent.LastActivityEvent.IsZero() {
+		evt.LastActivityEvent = agent.LastActivityEvent.Format("2006-01-02T15:04:05Z07:00")
 	}
 
 	detail := AgentDetail{

--- a/pkg/hubclient/types.go
+++ b/pkg/hubclient/types.go
@@ -52,6 +52,7 @@ type Agent struct {
 	Created           time.Time         `json:"created"`
 	Updated           time.Time         `json:"updated"`
 	LastSeen          time.Time         `json:"lastSeen,omitempty"`
+	LastActivityEvent time.Time         `json:"lastActivityEvent,omitempty"`
 	DeletedAt         time.Time         `json:"deletedAt,omitempty"`
 	CreatedBy         string            `json:"createdBy,omitempty"`
 	OwnerID           string            `json:"ownerId,omitempty"`

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -1233,8 +1233,8 @@ export class ScionPageAgentDetail extends LitElement {
                     status=${agent.activity as StatusType}
                     label=${agent.activity}
                     size="small"
-                  ></scion-status-badge>${(agent.lastActivityEvent || agent.updated || agent.updatedAt)
-                    ? html`<span style="color: var(--scion-text-muted, #64748b); font-size: 0.85em; margin-left: 0.5em;">${this.formatRelativeTime((agent.lastActivityEvent || agent.updated || agent.updatedAt)!)}</span>`
+                  ></scion-status-badge>${((agent.lastActivityEvent && !this.isZeroDate(agent.lastActivityEvent)) || agent.updated || agent.updatedAt)
+                    ? html`<span style="color: var(--scion-text-muted, #64748b); font-size: 0.85em; margin-left: 0.5em;">${this.formatRelativeTime(((agent.lastActivityEvent && !this.isZeroDate(agent.lastActivityEvent)) ? agent.lastActivityEvent : (agent.updated || agent.updatedAt))!)}</span>`
                     : ''}`
                 : html`<span style="color: var(--scion-text-muted, #64748b);">—</span>`}
             </span>

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -1233,8 +1233,8 @@ export class ScionPageAgentDetail extends LitElement {
                     status=${agent.activity as StatusType}
                     label=${agent.activity}
                     size="small"
-                  ></scion-status-badge>${(agent.updated || agent.updatedAt)
-                    ? html`<span style="color: var(--scion-text-muted, #64748b); font-size: 0.85em; margin-left: 0.5em;">${this.formatRelativeTime((agent.updated || agent.updatedAt)!)}</span>`
+                  ></scion-status-badge>${(agent.lastActivityEvent || agent.updated || agent.updatedAt)
+                    ? html`<span style="color: var(--scion-text-muted, #64748b); font-size: 0.85em; margin-left: 0.5em;">${this.formatRelativeTime((agent.lastActivityEvent || agent.updated || agent.updatedAt)!)}</span>`
                     : ''}`
                 : html`<span style="color: var(--scion-text-muted, #64748b);">—</span>`}
             </span>

--- a/web/src/components/pages/agents.ts
+++ b/web/src/components/pages/agents.ts
@@ -614,7 +614,7 @@ export class ScionPageAgents extends LitElement {
           cmp = (a.created || '').localeCompare(b.created || '');
           break;
         case 'updated':
-          cmp = (a.lastActivityEvent || a.updated || '').localeCompare(b.lastActivityEvent || b.updated || '');
+          cmp = ((a.lastActivityEvent && !a.lastActivityEvent.startsWith('0001')) ? a.lastActivityEvent : (a.updated || '')).localeCompare((b.lastActivityEvent && !b.lastActivityEvent.startsWith('0001')) ? b.lastActivityEvent : (b.updated || ''));
           break;
       }
       return this.sortDir === 'asc' ? cmp : -cmp;
@@ -1116,7 +1116,7 @@ export class ScionPageAgents extends LitElement {
             size="small"
           ></scion-status-badge>
         </td>
-        <td class="hide-mobile">${(agent.lastActivityEvent || agent.updated) ? this.formatRelativeTime((agent.lastActivityEvent || agent.updated)!) : '\u2014'}</td>
+        <td class="hide-mobile">${((agent.lastActivityEvent && !agent.lastActivityEvent.startsWith('0001')) || agent.updated) ? this.formatRelativeTime(((agent.lastActivityEvent && !agent.lastActivityEvent.startsWith('0001')) ? agent.lastActivityEvent : agent.updated)!) : '\u2014'}</td>
         <td class="hide-mobile">
           <span class="task-cell">${agent.taskSummary || '\u2014'}</span>
         </td>

--- a/web/src/components/pages/agents.ts
+++ b/web/src/components/pages/agents.ts
@@ -614,7 +614,7 @@ export class ScionPageAgents extends LitElement {
           cmp = (a.created || '').localeCompare(b.created || '');
           break;
         case 'updated':
-          cmp = (a.updated || '').localeCompare(b.updated || '');
+          cmp = (a.lastActivityEvent || a.updated || '').localeCompare(b.lastActivityEvent || b.updated || '');
           break;
       }
       return this.sortDir === 'asc' ? cmp : -cmp;
@@ -1116,7 +1116,7 @@ export class ScionPageAgents extends LitElement {
             size="small"
           ></scion-status-badge>
         </td>
-        <td class="hide-mobile">${agent.updated ? this.formatRelativeTime(agent.updated) : '\u2014'}</td>
+        <td class="hide-mobile">${(agent.lastActivityEvent || agent.updated) ? this.formatRelativeTime((agent.lastActivityEvent || agent.updated)!) : '\u2014'}</td>
         <td class="hide-mobile">
           <span class="task-cell">${agent.taskSummary || '\u2014'}</span>
         </td>

--- a/web/src/components/pages/project-detail.ts
+++ b/web/src/components/pages/project-detail.ts
@@ -1180,7 +1180,7 @@ export class ScionPageProjectDetail extends LitElement {
           cmp = (a.created || a.createdAt || '').localeCompare(b.created || b.createdAt || '');
           break;
         case 'updated':
-          cmp = (a.updated || a.updatedAt || '').localeCompare(b.updated || b.updatedAt || '');
+          cmp = (a.lastActivityEvent || a.updated || a.updatedAt || '').localeCompare(b.lastActivityEvent || b.updated || b.updatedAt || '');
           break;
       }
       return this.sortDir === 'asc' ? cmp : -cmp;
@@ -1927,7 +1927,7 @@ export class ScionPageProjectDetail extends LitElement {
             size="small"
           ></scion-status-badge>
         </td>
-        <td class="hide-mobile">${(agent.updated || agent.updatedAt) ? this.formatRelativeTime(agent.updated || agent.updatedAt!) : '\u2014'}</td>
+        <td class="hide-mobile">${(agent.lastActivityEvent || agent.updated || agent.updatedAt) ? this.formatRelativeTime((agent.lastActivityEvent || agent.updated || agent.updatedAt)!) : '\u2014'}</td>
         <td class="hide-mobile">
           <span class="task-cell">${agent.taskSummary || '\u2014'}</span>
         </td>

--- a/web/src/components/pages/project-detail.ts
+++ b/web/src/components/pages/project-detail.ts
@@ -1180,7 +1180,7 @@ export class ScionPageProjectDetail extends LitElement {
           cmp = (a.created || a.createdAt || '').localeCompare(b.created || b.createdAt || '');
           break;
         case 'updated':
-          cmp = (a.lastActivityEvent || a.updated || a.updatedAt || '').localeCompare(b.lastActivityEvent || b.updated || b.updatedAt || '');
+          cmp = ((a.lastActivityEvent && !a.lastActivityEvent.startsWith('0001')) ? a.lastActivityEvent : (a.updated || a.updatedAt || '')).localeCompare((b.lastActivityEvent && !b.lastActivityEvent.startsWith('0001')) ? b.lastActivityEvent : (b.updated || b.updatedAt || ''));
           break;
       }
       return this.sortDir === 'asc' ? cmp : -cmp;
@@ -1927,7 +1927,7 @@ export class ScionPageProjectDetail extends LitElement {
             size="small"
           ></scion-status-badge>
         </td>
-        <td class="hide-mobile">${(agent.lastActivityEvent || agent.updated || agent.updatedAt) ? this.formatRelativeTime((agent.lastActivityEvent || agent.updated || agent.updatedAt)!) : '\u2014'}</td>
+        <td class="hide-mobile">${((agent.lastActivityEvent && !agent.lastActivityEvent.startsWith('0001')) || agent.updated || agent.updatedAt) ? this.formatRelativeTime(((agent.lastActivityEvent && !agent.lastActivityEvent.startsWith('0001')) ? agent.lastActivityEvent : (agent.updated || agent.updatedAt))!) : '\u2014'}</td>
         <td class="hide-mobile">
           <span class="task-cell">${agent.taskSummary || '\u2014'}</span>
         </td>

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -415,6 +415,7 @@ export interface Agent {
   taskSummary?: string;
   message?: string;
   lastSeen?: string;
+  lastActivityEvent?: string;
   // Backend sends "created"/"updated"; legacy frontend code uses "createdAt"/"updatedAt".
   // Accept both so existing pages and new API responses both work.
   created?: string;


### PR DESCRIPTION
## Summary

Fixes ptone/scion#735.

The agent list "Updated" column always showed "just now" because the `updated` field is bumped by the heartbeat every ~30s. The system already has a `last_activity_event` field that tracks only meaningful activity changes (phase/activity transitions).

**Fix:** Switch all display layers to use `lastActivityEvent` with fallback to `updated`:
- Web UI: agents list, project detail, agent detail pages
- SSE: added `lastActivityEvent` to `AgentStatusEvent` for real-time updates
- CLI: `scion list` LAST ACTIVITY column prefers `LastActivityEvent` over `LastSeen`

No data model or heartbeat changes — display-only fix.

**Key files:**
- web/src/components/pages/agents.ts, project-detail.ts, agent-detail.ts
- pkg/hub/events.go — SSE event struct
- cmd/list.go — CLI list command

Ref: ptone/scion#737
