### PR TITLE
fix(init): run git clone before pre-start hooks to prevent workspace pollution

### DIFF
--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -273,6 +273,37 @@ func runInit(args []string) int {
 	_, projectHookStatErr := os.Stat(projectHookPath)
 	projectHookStaged := projectHookStatErr == nil
 
+	// Clone git workspace BEFORE pre-start hooks so that provisioners
+	// (e.g. antigravity) see the populated workspace rather than an empty
+	// one.  The clone depends only on environment variables and agent
+	// config — not on anything produced by pre-start hooks.  Running it
+	// first also prevents provisioner-created files (e.g. .agents/) from
+	// causing isWorkspaceEmpty to return false and skipping the clone.
+	// See: https://github.com/ptone/scion/issues/739
+	if err := gitCloneWorkspace(targetUID, targetGID, agentHome); err != nil {
+		log.Error("Git clone failed: %v", err)
+
+		// Update local agent-info.json to error state so local status readers
+		// and the broker heartbeat see the failure and error message.
+		errMsg := fmt.Sprintf("git clone failed: %v", err)
+		_ = statusHandler.UpdatePhase(state.PhaseError, "", "")
+		_ = statusHandler.SetMessage(errMsg)
+
+		// Report error to Hub directly so the agent doesn't stay stuck in "cloning" state.
+		// This is best-effort; the broker heartbeat will also pick up the error from
+		// agent-info.json as a fallback if this call fails (e.g. network unreachable).
+		if hubClient := hub.NewClient(); hubClient != nil && hubClient.IsConfigured() {
+			hubCtx, hubCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			if hubErr := hubClient.ReportState(hubCtx, state.PhaseError, "", errMsg); hubErr != nil {
+				log.Error("Failed to report clone error to Hub: %v", hubErr)
+			}
+			hubCancel()
+		} else {
+			log.Info("Hub client not configured, clone error will be relayed via broker heartbeat")
+		}
+		return 1
+	}
+
 	// Run pre-start hooks (after setup, before child process)
 	log.Info("Running pre-start hooks...")
 	if err := lifecycleManager.RunPreStart(); err != nil {
@@ -343,31 +374,6 @@ func runInit(args []string) int {
 			harnessEnvOverlay = overlay
 			log.Info("Loaded %d env overlay entries from %s", len(overlay), overlayPath)
 		}
-	}
-
-	// Clone git workspace if configured (hub-first git projects)
-	if err := gitCloneWorkspace(targetUID, targetGID, agentHome); err != nil {
-		log.Error("Git clone failed: %v", err)
-
-		// Update local agent-info.json to error state so local status readers
-		// and the broker heartbeat see the failure and error message.
-		errMsg := fmt.Sprintf("git clone failed: %v", err)
-		_ = statusHandler.UpdatePhase(state.PhaseError, "", "")
-		_ = statusHandler.SetMessage(errMsg)
-
-		// Report error to Hub directly so the agent doesn't stay stuck in "cloning" state.
-		// This is best-effort; the broker heartbeat will also pick up the error from
-		// agent-info.json as a fallback if this call fails (e.g. network unreachable).
-		if hubClient := hub.NewClient(); hubClient != nil && hubClient.IsConfigured() {
-			hubCtx, hubCancel := context.WithTimeout(context.Background(), 10*time.Second)
-			if hubErr := hubClient.ReportState(hubCtx, state.PhaseError, "", errMsg); hubErr != nil {
-				log.Error("Failed to report clone error to Hub: %v", hubErr)
-			}
-			hubCancel()
-		} else {
-			log.Info("Hub client not configured, clone error will be relayed via broker heartbeat")
-		}
-		return 1
 	}
 
 	// Configure git credentials for shared-workspace projects (git-workspace hybrid).
@@ -2022,7 +2028,7 @@ func isWorkspaceEmpty(path string) bool {
 	// Filter out known marker entries that don't indicate a real workspace
 	for _, e := range entries {
 		switch e.Name() {
-		case ".scion", ".scion-volumes":
+		case ".scion", ".scion-volumes", ".agents":
 			// Provisioning marker / shared-dir mount directory — ignore
 			continue
 		default:

--- a/cmd/sciontool/commands/init_test.go
+++ b/cmd/sciontool/commands/init_test.go
@@ -282,6 +282,33 @@ func TestIsWorkspaceEmpty(t *testing.T) {
 			t.Error("expected false when workspace has .scion and real files")
 		}
 	})
+
+	t.Run("directory with only .agents marker", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		_ = os.MkdirAll(filepath.Join(tmpDir, ".agents"), 0755)
+		if !isWorkspaceEmpty(tmpDir) {
+			t.Error("expected true when workspace contains only .agents marker")
+		}
+	})
+
+	t.Run("directory with all provisioning markers", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		_ = os.MkdirAll(filepath.Join(tmpDir, ".scion"), 0755)
+		_ = os.MkdirAll(filepath.Join(tmpDir, ".scion-volumes"), 0755)
+		_ = os.MkdirAll(filepath.Join(tmpDir, ".agents"), 0755)
+		if !isWorkspaceEmpty(tmpDir) {
+			t.Error("expected true when workspace contains only .scion, .scion-volumes, and .agents")
+		}
+	})
+
+	t.Run("directory with .agents and real content", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		_ = os.MkdirAll(filepath.Join(tmpDir, ".agents"), 0755)
+		_ = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main"), 0644)
+		if isWorkspaceEmpty(tmpDir) {
+			t.Error("expected false when workspace has .agents and real files")
+		}
+	})
 }
 
 func TestSanitizeGitOutput(t *testing.T) {


### PR DESCRIPTION
## Summary

Pre-start hooks (provisioners) ran before gitCloneWorkspace, so provisioner-created files in /workspace caused isWorkspaceEmpty to return false and skip the clone. The antigravity provisioner writes /workspace/.agents/hooks.json during pre-start, blocking the clone.

### Changes
1. Reordered gitCloneWorkspace() before RunPreStart() in init.go
2. Added .agents to isWorkspaceEmpty filter as defensive fallback
3. Tests for isWorkspaceEmpty with .agents marker

Found by integration-tester.
Fixes ptone/scion#739
