### PR TITLE
feat(ui): add GCP Project ID and Cloud Logging settings to admin telemetry UI

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -667,8 +667,15 @@ func initServerLogging(cmd *cobra.Command) (cleanups []func(), requestLogger *sl
 	// If Cloud Logging becomes unavailable (e.g. during a metadata
 	// service outage), the circuit breaker opens and the hub falls back to
 	// local-only logging automatically.
+	// Check env var first (SCION_CLOUD_LOGGING), then fall back to settings.
+	cloudLoggingEnabled := logging.IsCloudLoggingEnabled()
+	if !cloudLoggingEnabled {
+		if vs, err := config.LoadVersionedSettings(""); err == nil && vs.Telemetry != nil && vs.Telemetry.Cloud != nil && vs.Telemetry.Cloud.CloudLogging != nil {
+			cloudLoggingEnabled = *vs.Telemetry.Cloud.CloudLogging
+		}
+	}
 	var cloudHandler slog.Handler
-	if logging.IsCloudLoggingEnabled() {
+	if cloudLoggingEnabled {
 		logLevel := logging.ResolveLogLevel(enableDebug)
 		cfg := logging.CloudLoggingConfig{
 			Component: component,

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -668,8 +668,12 @@ func initServerLogging(cmd *cobra.Command) (cleanups []func(), requestLogger *sl
 	// service outage), the circuit breaker opens and the hub falls back to
 	// local-only logging automatically.
 	// Check env var first (SCION_CLOUD_LOGGING), then fall back to settings.
-	cloudLoggingEnabled := logging.IsCloudLoggingEnabled()
-	if !cloudLoggingEnabled {
+	// When the env var is set (even to "false"), it takes precedence over
+	// the settings value. Only consult settings when the env var is unset.
+	var cloudLoggingEnabled bool
+	if os.Getenv(logging.EnvCloudLogging) != "" {
+		cloudLoggingEnabled = logging.IsCloudLoggingEnabled()
+	} else {
 		if vs, err := config.LoadVersionedSettings(""); err == nil && vs.Telemetry != nil && vs.Telemetry.Cloud != nil && vs.Telemetry.Cloud.CloudLogging != nil {
 			cloudLoggingEnabled = *vs.Telemetry.Cloud.CloudLogging
 		}

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -674,7 +674,11 @@ func initServerLogging(cmd *cobra.Command) (cleanups []func(), requestLogger *sl
 	if os.Getenv(logging.EnvCloudLogging) != "" {
 		cloudLoggingEnabled = logging.IsCloudLoggingEnabled()
 	} else {
-		if vs, err := config.LoadVersionedSettings(""); err == nil && vs.Telemetry != nil && vs.Telemetry.Cloud != nil && vs.Telemetry.Cloud.CloudLogging != nil {
+		projectPath := ""
+		if globalMode {
+			projectPath = "global"
+		}
+		if vs, err := config.LoadVersionedSettings(projectPath); err == nil && vs.Telemetry != nil && vs.Telemetry.Cloud != nil && vs.Telemetry.Cloud.CloudLogging != nil {
 			cloudLoggingEnabled = *vs.Telemetry.Cloud.CloudLogging
 		}
 	}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -380,6 +380,7 @@ type TelemetryCloudConfig struct {
 	Batch        *TelemetryBatch   `json:"batch,omitempty" yaml:"batch,omitempty"`
 	Provider     string            `json:"provider,omitempty" yaml:"provider,omitempty"`
 	GCPProjectID *string           `json:"gcp_project_id,omitempty" yaml:"gcp_project_id,omitempty"`
+	CloudLogging *bool             `json:"cloud_logging,omitempty" yaml:"cloud_logging,omitempty"`
 }
 
 // TelemetryTLS holds TLS settings for OTLP export.

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -1033,6 +1033,13 @@
           "type": "string",
           "description": "GCP project ID for telemetry (Cloud Monitoring). Overrides auto-detection from SA credentials.",
           "x-since": "1"
+        },
+        "cloud_logging": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable direct Cloud Logging output. When set, the server writes structured logs to Cloud Logging. The SCION_CLOUD_LOGGING env var takes precedence over this setting.",
+          "x-env-var": "SCION_CLOUD_LOGGING",
+          "x-since": "1"
         }
       },
       "additionalProperties": false

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -1170,8 +1170,8 @@ func isSectionName(name string) bool {
 var knownTelemetryCompoundFields = []string{
 	"insecure_skip_verify",
 	"respect_debug_mode",
-	"cloud_logging",
 	"report_interval",
+	"cloud_logging",
 	"max_size",
 }
 

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -700,6 +700,7 @@ type V1TelemetryCloudConfig struct {
 	Batch        *V1TelemetryBatchConfig `json:"batch,omitempty" yaml:"batch,omitempty" koanf:"batch"`
 	Provider     string                  `json:"provider,omitempty" yaml:"provider,omitempty" koanf:"provider"`
 	GCPProjectID *string                 `json:"gcp_project_id,omitempty" yaml:"gcp_project_id,omitempty" koanf:"gcp_project_id"`
+	CloudLogging *bool                   `json:"cloud_logging,omitempty" yaml:"cloud_logging,omitempty" koanf:"cloud_logging"`
 }
 
 // V1TelemetryTLSConfig holds TLS settings for cloud OTLP export.
@@ -1169,6 +1170,7 @@ func isSectionName(name string) bool {
 var knownTelemetryCompoundFields = []string{
 	"insecure_skip_verify",
 	"respect_debug_mode",
+	"cloud_logging",
 	"report_interval",
 	"max_size",
 }

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -996,6 +996,9 @@ func mergeTelemetryConfig(base, override *api.TelemetryConfig) *api.TelemetryCon
 		if override.Cloud.GCPProjectID != nil {
 			result.Cloud.GCPProjectID = override.Cloud.GCPProjectID
 		}
+		if override.Cloud.CloudLogging != nil {
+			result.Cloud.CloudLogging = override.Cloud.CloudLogging
+		}
 	}
 	if override.Hub != nil {
 		if result.Hub == nil {

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -150,6 +150,8 @@ interface V1TelemetryCloudConfig {
   protocol?: string;
   headers?: Record<string, string>;
   provider?: string;
+  gcp_project_id?: string;
+  cloud_logging?: boolean;
 }
 
 interface V1TelemetryHubConfig {
@@ -329,6 +331,8 @@ const KOANF_KEY_LABELS: Record<string, string> = {
   'telemetry.cloud.endpoint': 'Cloud Export Endpoint',
   'telemetry.cloud.protocol': 'Cloud Export Protocol',
   'telemetry.cloud.provider': 'Cloud Export Provider',
+  'telemetry.cloud.gcp_project_id': 'GCP Project ID',
+  'telemetry.cloud.cloud_logging': 'Cloud Logging',
   'telemetry.hub.enabled': 'Hub Reporting Enabled',
   'telemetry.hub.report_interval': 'Hub Report Interval',
   'telemetry.local.enabled': 'Local Telemetry Enabled',
@@ -470,6 +474,8 @@ export class ScionPageAdminServerConfig extends LitElement {
   @state() private telemetryCloudEndpoint = '';
   @state() private telemetryCloudProtocol = '';
   @state() private telemetryCloudProvider = '';
+  @state() private telemetryCloudGcpProjectId = '';
+  @state() private telemetryCloudCloudLogging = false;
   @state() private telemetryHubEnabled = false;
   @state() private telemetryHubReportInterval = '';
   @state() private telemetryLocalEnabled = false;
@@ -1424,6 +1430,8 @@ export class ScionPageAdminServerConfig extends LitElement {
         this.telemetryCloudEndpoint = tel.cloud.endpoint || '';
         this.telemetryCloudProtocol = tel.cloud.protocol || '';
         this.telemetryCloudProvider = tel.cloud.provider || '';
+        this.telemetryCloudGcpProjectId = tel.cloud.gcp_project_id || '';
+        this.telemetryCloudCloudLogging = tel.cloud.cloud_logging || false;
       }
       if (tel.hub) {
         this.telemetryHubEnabled = tel.hub.enabled || false;
@@ -1633,6 +1641,8 @@ export class ScionPageAdminServerConfig extends LitElement {
           endpoint: this.telemetryCloudEndpoint,
           protocol: this.telemetryCloudProtocol,
           provider: this.telemetryCloudProvider,
+          gcp_project_id: this.telemetryCloudGcpProjectId || undefined,
+          cloud_logging: this.telemetryCloudCloudLogging || undefined,
         };
       }
       if (ok('telemetry.hub.enabled')) {
@@ -3594,6 +3604,33 @@ export class ScionPageAdminServerConfig extends LitElement {
                   this.telemetryCloudProvider = (e.target as HTMLInputElement).value;
                 }}
               ></sl-input>`
+            )}
+          </div>
+          <div class="form-field">
+            <label>GCP Project ID</label>
+            ${this.renderFieldValue(
+              'telemetry.cloud.gcp_project_id',
+              this.telemetryCloudGcpProjectId || '—',
+              html`${this.renderEnvBadge('telemetry.cloud.gcp_project_id')}<sl-input
+                value=${this.telemetryCloudGcpProjectId}
+                placeholder="e.g., my-gcp-project"
+                @sl-input=${(e: Event) => {
+                  this.telemetryCloudGcpProjectId = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>`
+            )}
+          </div>
+          <div class="form-field">
+            ${this.renderFieldValue(
+              'telemetry.cloud.cloud_logging',
+              this.telemetryCloudCloudLogging ? 'Enabled' : 'Disabled',
+              html`${this.renderEnvBadge('telemetry.cloud.cloud_logging')}<sl-switch
+                ?checked=${this.telemetryCloudCloudLogging}
+                @sl-change=${(e: Event) => {
+                  this.telemetryCloudCloudLogging = (e.target as HTMLInputElement).checked;
+                }}
+                >Enable Cloud Logging</sl-switch
+              >`
             )}
           </div>
         </div>

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -1642,7 +1642,7 @@ export class ScionPageAdminServerConfig extends LitElement {
           protocol: this.telemetryCloudProtocol,
           provider: this.telemetryCloudProvider,
           gcp_project_id: this.telemetryCloudGcpProjectId || undefined,
-          cloud_logging: this.telemetryCloudCloudLogging || undefined,
+          cloud_logging: this.telemetryCloudCloudLogging,
         };
       }
       if (ok('telemetry.hub.enabled')) {

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -1851,6 +1851,12 @@ export class ScionPageAdminServerConfig extends LitElement {
         provider: ok('telemetry.cloud.provider')
           ? this.telemetryCloudProvider || undefined
           : undefined,
+        gcp_project_id: ok('telemetry.cloud.gcp_project_id')
+          ? this.telemetryCloudGcpProjectId || undefined
+          : undefined,
+        cloud_logging: ok('telemetry.cloud.cloud_logging')
+          ? this.telemetryCloudCloudLogging
+          : undefined,
       };
     }
     if (ok('telemetry.hub.enabled')) {


### PR DESCRIPTION
Adds two missing telemetry settings to the Hub admin settings UI.

## Changes

- **GCP Project ID** (telemetry.cloud.gcp_project_id): text input field added to the admin telemetry config tab. The backend field existed (from the metrics dashboard config fix) but the frontend never declared, loaded, saved, or rendered it.
- **Cloud Logging toggle** (telemetry.cloud.cloud_logging): full-stack addition. New bool field in V1TelemetryCloudConfig, JSON schema entry, env var fallback logic (SCION_CLOUD_LOGGING takes precedence when set), config merge support, and frontend switch control.

## Key files

- web/src/components/pages/admin-server-config.ts — both fields added to all 6 UI touch points
- pkg/config/settings_v1.go — CloudLogging field added to V1TelemetryCloudConfig
- pkg/api/types.go — CloudLogging field added to API type
- pkg/config/schemas/settings-v1.schema.json — cloud_logging property added
- cmd/server_foreground.go — env var vs settings precedence logic
- pkg/config/templates.go — merge support for CloudLogging

Relates to ptone/scion#724
