### PR TITLE
fix(hub): add missing log output for tier 3 subsystem loggers

### DIFF
--- a/pkg/hub/audit.go
+++ b/pkg/hub/audit.go
@@ -215,6 +215,9 @@ func (l *LogAuditLogger) logger() *slog.Logger {
 
 // LogBrokerAuthEvent logs a broker authentication event to the standard logger.
 func (l *LogAuditLogger) LogBrokerAuthEvent(ctx context.Context, event *BrokerAuthEvent) error {
+	if event == nil {
+		return nil
+	}
 	level := slog.LevelInfo
 	if !event.Success {
 		level = slog.LevelWarn

--- a/pkg/hub/audit.go
+++ b/pkg/hub/audit.go
@@ -213,8 +213,37 @@ func (l *LogAuditLogger) logger() *slog.Logger {
 	return slog.Default()
 }
 
-// LogBrokerAuthEvent is a no-op implementation satisfying the AuditLogger interface.
+// LogBrokerAuthEvent logs a broker authentication event to the standard logger.
 func (l *LogAuditLogger) LogBrokerAuthEvent(ctx context.Context, event *BrokerAuthEvent) error {
+	level := slog.LevelInfo
+	if !event.Success {
+		level = slog.LevelWarn
+	}
+
+	attrs := []slog.Attr{
+		slog.String("event_type", string(event.EventType)),
+		slog.String("broker_id", event.BrokerID),
+		slog.Bool("success", event.Success),
+	}
+
+	if event.BrokerName != "" {
+		attrs = append(attrs, slog.String("broker_name", event.BrokerName))
+	}
+	if event.ActorID != "" {
+		attrs = append(attrs, slog.String("actor_id", event.ActorID))
+	}
+	if event.ActorType != "" {
+		attrs = append(attrs, slog.String("actor_type", event.ActorType))
+	}
+	if event.FailReason != "" {
+		attrs = append(attrs, slog.String("fail_reason", event.FailReason))
+	}
+	for k, v := range event.Details {
+		attrs = append(attrs, slog.String(k, v))
+	}
+
+	l.logger().LogAttrs(ctx, level, "broker auth event", attrs...)
+
 	return nil
 }
 

--- a/pkg/hub/events.go
+++ b/pkg/hub/events.go
@@ -339,7 +339,7 @@ func (p *ChannelEventPublisher) publish(subject string, event interface{}) {
 					matched++
 				default:
 					// Drop event on full buffer (backpressure)
-					p.logger().Warn("event dropped (subscriber buffer full)",
+					p.logger().Debug("event dropped (subscriber buffer full)",
 						"subject", subject, "pattern", pattern)
 				}
 			}

--- a/pkg/hub/events.go
+++ b/pkg/hub/events.go
@@ -292,6 +292,8 @@ func (p *ChannelEventPublisher) Subscribe(patterns ...string) (<-chan Event, fun
 	}
 	p.mu.Unlock()
 
+	p.logger().Info("subscriber added", "patterns", patterns)
+
 	unsubscribe := func() {
 		p.mu.Lock()
 		defer p.mu.Unlock()
@@ -304,6 +306,7 @@ func (p *ChannelEventPublisher) Subscribe(patterns ...string) (<-chan Event, fun
 				}
 			}
 		}
+		p.logger().Info("subscriber removed", "patterns", patterns)
 	}
 
 	return ch, unsubscribe
@@ -327,17 +330,23 @@ func (p *ChannelEventPublisher) publish(subject string, event interface{}) {
 		return
 	}
 
+	matched := 0
 	for pattern, subs := range p.subscribers {
 		if subjectMatchesPattern(pattern, subject) {
 			for _, ch := range subs {
 				select {
 				case ch <- evt:
+					matched++
 				default:
 					// Drop event on full buffer (backpressure)
+					p.logger().Warn("event dropped (subscriber buffer full)",
+						"subject", subject, "pattern", pattern)
 				}
 			}
 		}
 	}
+
+	p.logger().Debug("event published", "subject", subject, "subscribers", matched)
 }
 
 // PublishRaw publishes an arbitrary event on the given subject.
@@ -365,6 +374,8 @@ func (p *ChannelEventPublisher) Close() {
 			}
 		}
 	}
+
+	p.logger().Info("event publisher closed", "subscriber_channels", len(seen))
 }
 
 // PublishAgentStatus publishes an agent status event to both agent-specific

--- a/pkg/hub/handlers_groups.go
+++ b/pkg/hub/handlers_groups.go
@@ -209,6 +209,12 @@ func (s *Server) createGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.groupsLogger().Info("group created",
+		"group_id", group.ID,
+		"slug", group.Slug,
+		"group_type", group.GroupType,
+		"created_by", createdBy)
+
 	// Add the creating user as an owner of the new group
 	if createdBy != "" {
 		if err := s.store.AddGroupMember(ctx, &store.GroupMember{
@@ -352,6 +358,10 @@ func (s *Server) updateGroup(w http.ResponseWriter, r *http.Request, id string) 
 		return
 	}
 
+	s.groupsLogger().Info("group updated",
+		"group_id", group.ID,
+		"slug", group.Slug)
+
 	writeJSON(w, http.StatusOK, group)
 }
 
@@ -391,6 +401,10 @@ func (s *Server) deleteGroup(w http.ResponseWriter, r *http.Request, id string) 
 		writeErrorFromErr(w, err, "")
 		return
 	}
+
+	s.groupsLogger().Info("group deleted",
+		"group_id", group.ID,
+		"slug", group.Slug)
 
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -630,6 +644,12 @@ func (s *Server) addGroupMember(w http.ResponseWriter, r *http.Request, group *s
 		return
 	}
 
+	s.groupsLogger().Info("group member added",
+		"group_id", groupID,
+		"member_type", member.MemberType,
+		"member_id", member.MemberID,
+		"role", member.Role)
+
 	// Return enriched response with display name
 	resp := GroupMemberInfo{
 		GroupMember: *member,
@@ -729,6 +749,11 @@ func (s *Server) removeGroupMember(w http.ResponseWriter, r *http.Request, group
 		writeErrorFromErr(w, err, "")
 		return
 	}
+
+	s.groupsLogger().Info("group member removed",
+		"group_id", group.ID,
+		"member_type", memberType,
+		"member_id", memberID)
 
 	w.WriteHeader(http.StatusNoContent)
 }


### PR DESCRIPTION
Integration testing found that hub.groups, hub.audit, and hub.events subsystem loggers never emitted to Cloud Logging despite being correctly wired. The loggers were injected but the log call sites were missing or no-ops.

## Root causes and fixes

1. **hub.audit**: LogBrokerAuthEvent() was a no-op stub. Broker auth events are the most common audit event type. Implemented to log at INFO/WARN matching other Log*Event methods.
2. **hub.groups**: Only 1 log call existed (rarely-triggered error path). Added INFO logging for all CRUD operations (create, update, delete, member add/remove).
3. **hub.events**: Only logged on JSON marshal errors. Added INFO for subscriber lifecycle, WARN for dropped events, DEBUG for individual publishes.

Relates to ptone/scion#742
