### PR TITLE
fix(hub): wire auto_expose_ports through admin settings API

### DIFF
--- a/pkg/config/opsettings/koanf.go
+++ b/pkg/config/opsettings/koanf.go
@@ -104,6 +104,9 @@ var koanfPathToJSONField = map[string]map[string]string{
 		"server.github_app.installation_url": "installation_url",
 		"server.github_app.private_key_path": "private_key_path",
 	},
+	"auto_expose_ports": {
+		"auto_expose_ports.enabled": "enabled",
+	},
 }
 
 // jsonFieldToKoanfPaths maps section name → json field → koanf path for the
@@ -129,6 +132,9 @@ var jsonFieldToKoanfPaths = map[string]map[string]string{
 		"webhooks_enabled": "server.github_app.webhooks_enabled",
 		"installation_url": "server.github_app.installation_url",
 		"private_key_path": "server.github_app.private_key_path",
+	},
+	"auto_expose_ports": {
+		"enabled": "auto_expose_ports.enabled",
 	},
 }
 

--- a/pkg/config/opsettings/opsettings_test.go
+++ b/pkg/config/opsettings/opsettings_test.go
@@ -31,7 +31,7 @@ import (
 func TestRegistryHasAllSections(t *testing.T) {
 	expected := []string{"access", "lifecycle", "maintenance", "telemetry",
 		"agent_defaults", "endpoints", "github_app", "notifications",
-		"project_defaults"}
+		"project_defaults", "auto_expose_ports"}
 	for _, name := range expected {
 		if SectionByName(name) == nil {
 			t.Errorf("section %q not found in registry", name)
@@ -113,6 +113,7 @@ func TestOwningSection(t *testing.T) {
 		{"server.github_app.app_id", "github_app"},
 		{"server.github_app.webhooks_enabled", "github_app"},
 		{"server.notification_channels", "notifications"},
+		{"auto_expose_ports.enabled", "auto_expose_ports"},
 	}
 	for _, tt := range tests {
 		got := OwningSection(tt.key)
@@ -191,6 +192,8 @@ func TestValidateValidDoc(t *testing.T) {
 		{"project_defaults", `{"default_scratchpad":true}`},
 		{"project_defaults", `{"default_scratchpad":false}`},
 		{"project_defaults", `{}`},
+		{"auto_expose_ports", `{"enabled":true}`},
+		{"auto_expose_ports", `{}`},
 	}
 	for _, tt := range tests {
 		errs := Validate(tt.section, json.RawMessage(tt.doc))
@@ -262,8 +265,9 @@ func TestExtractSectionFromKoanf(t *testing.T) {
 		"server.notification_channels": []interface{}{
 			map[string]interface{}{"type": "slack", "params": map[string]interface{}{"url": "https://hooks.slack.com/test"}},
 		},
-		"server.database.driver": "postgres",
-		"server.hub.port":        9810,
+		"server.database.driver":    "postgres",
+		"server.hub.port":           9810,
+		"auto_expose_ports.enabled": true,
 	}, "."), nil)
 	if err != nil {
 		t.Fatalf("load koanf: %v", err)
@@ -317,6 +321,11 @@ func TestExtractSectionFromKoanf(t *testing.T) {
 		{"notifications", func(t *testing.T, doc map[string]interface{}) {
 			if doc["notification_channels"] == nil {
 				t.Error("expected notification_channels")
+			}
+		}},
+		{"auto_expose_ports", func(t *testing.T, doc map[string]interface{}) {
+			if doc["enabled"] != true {
+				t.Errorf("expected enabled=true, got %v", doc["enabled"])
 			}
 		}},
 	}
@@ -415,8 +424,9 @@ func TestRoundTrip(t *testing.T) {
 		"server.notification_channels": []interface{}{
 			map[string]interface{}{"type": "slack"},
 		},
-		"server.database.driver": "postgres",
-		"server.hub.port":        9810,
+		"server.database.driver":    "postgres",
+		"server.hub.port":           9810,
+		"auto_expose_ports.enabled": true,
 	}
 	if err := k.Load(confmap.Provider(original, "."), nil); err != nil {
 		t.Fatalf("load original: %v", err)
@@ -448,6 +458,7 @@ func TestRoundTrip(t *testing.T) {
 		{"telemetry.cloud.endpoint", "https://otel.example.com"},
 		{"server.github_app.app_id", nil},
 		{"server.github_app.webhooks_enabled", true},
+		{"auto_expose_ports.enabled", true},
 	}
 
 	for _, c := range checks {
@@ -558,6 +569,8 @@ default_resources:
     memory: "1Gi"
   disk: "5Gi"
 image_registry: "gcr.io/my-project"
+auto_expose_ports:
+  enabled: true
 `
 
 	dir := t.TempDir()
@@ -991,6 +1004,65 @@ func TestKoanfPathFromSectionKey(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("KoanfPathFromSectionKey(%q, %q) = %q, want %q", tt.section, tt.jsonKey, got, tt.want)
 		}
+	}
+}
+
+// TestAutoExposePortsKoanfRoundTrip verifies that auto_expose_ports can be
+// extracted from koanf and loaded back without data loss.
+func TestAutoExposePortsKoanfRoundTrip(t *testing.T) {
+	k := koanf.New(".")
+	err := k.Load(confmap.Provider(map[string]interface{}{
+		"auto_expose_ports.enabled": true,
+	}, "."), nil)
+	if err != nil {
+		t.Fatalf("load koanf: %v", err)
+	}
+
+	// Extract the section.
+	raw, err := ExtractSectionFromKoanf(k, "auto_expose_ports")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	var doc map[string]interface{}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if doc["enabled"] != true {
+		t.Errorf("expected enabled=true in extracted doc, got %v", doc["enabled"])
+	}
+
+	// Reload into a fresh koanf.
+	sections := map[string]json.RawMessage{
+		"auto_expose_ports": raw,
+	}
+	reloaded, err := LoadSectionsIntoKoanf(sections)
+	if err != nil {
+		t.Fatalf("load sections: %v", err)
+	}
+
+	if !reloaded.Exists("auto_expose_ports.enabled") {
+		t.Fatal("expected auto_expose_ports.enabled to exist in reloaded koanf")
+	}
+	if reloaded.Bool("auto_expose_ports.enabled") != true {
+		t.Errorf("expected auto_expose_ports.enabled=true, got %v", reloaded.Get("auto_expose_ports.enabled"))
+	}
+}
+
+// TestAutoExposePortsEmptyExtract verifies that ExtractSectionFromKoanf returns
+// an empty doc when auto_expose_ports is not set.
+func TestAutoExposePortsEmptyExtract(t *testing.T) {
+	k := koanf.New(".")
+	raw, err := ExtractSectionFromKoanf(k, "auto_expose_ports")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(doc) != 0 {
+		t.Errorf("expected empty doc for absent auto_expose_ports, got %v", doc)
 	}
 }
 

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -292,6 +292,14 @@ type VersionedSettings struct {
 	// Credentials file is automatically injected into agent containers in
 	// co-located (workstation) mode.
 	AutoInjectGcloudADC bool `json:"auto_inject_gcloud_adc,omitempty" yaml:"auto_inject_gcloud_adc,omitempty" koanf:"auto_inject_gcloud_adc"`
+
+	// AutoExposePorts controls whether ports are automatically exposed in agent containers.
+	AutoExposePorts *AutoExposePortsSettings `json:"auto_expose_ports,omitempty" yaml:"auto_expose_ports,omitempty" koanf:"auto_expose_ports"`
+}
+
+// AutoExposePortsSettings holds the auto-expose ports configuration.
+type AutoExposePortsSettings struct {
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" koanf:"enabled"`
 }
 
 // V1ServerConfig holds server-side configuration in the versioned settings format.

--- a/pkg/hub/admin_settings.go
+++ b/pkg/hub/admin_settings.go
@@ -67,6 +67,9 @@ type ServerConfigResponse struct {
 	// AutoInjectGcloudADC controls whether gcloud ADC is injected into agent containers.
 	AutoInjectGcloudADC bool `json:"auto_inject_gcloud_adc,omitempty"`
 
+	// AutoExposePorts controls whether ports are automatically exposed in agent containers.
+	AutoExposePorts *config.AutoExposePortsSettings `json:"auto_expose_ports,omitempty"`
+
 	// EnvOverrides lists koanf keys overridden by SCION_SERVER_* env vars
 	// on this node. Present in both file-mode and DB-mode responses so the
 	// admin UI can show env-pinned fields regardless of settings tier.
@@ -99,6 +102,9 @@ type ServerConfigUpdateRequest struct {
 
 	// AutoInjectGcloudADC controls whether gcloud ADC is injected into agent containers.
 	AutoInjectGcloudADC *bool `json:"auto_inject_gcloud_adc,omitempty"`
+
+	// AutoExposePorts controls whether ports are automatically exposed in agent containers.
+	AutoExposePorts *config.AutoExposePortsSettings `json:"auto_expose_ports,omitempty"`
 }
 
 // handleAdminServerConfig handles GET/PUT /api/v1/admin/server-config.
@@ -253,6 +259,7 @@ func (s *Server) handleGetServerConfig(w http.ResponseWriter) {
 		DefaultModel:         vs.DefaultModel,
 		DefaultThinkingLevel: vs.DefaultThinkingLevel,
 		AutoInjectGcloudADC:  vs.AutoInjectGcloudADC,
+		AutoExposePorts:      vs.AutoExposePorts,
 	}
 
 	// Env overrides — detect SCION_SERVER_* env vars so the admin UI can
@@ -471,6 +478,9 @@ func applySettingsUpdates(raw map[string]interface{}, req *ServerConfigUpdateReq
 		} else {
 			delete(raw, "auto_inject_gcloud_adc")
 		}
+	}
+	if req.AutoExposePorts != nil {
+		raw["auto_expose_ports"] = marshalToMap(req.AutoExposePorts)
 	}
 }
 

--- a/pkg/hub/admin_settings.go
+++ b/pkg/hub/admin_settings.go
@@ -480,7 +480,11 @@ func applySettingsUpdates(raw map[string]interface{}, req *ServerConfigUpdateReq
 		}
 	}
 	if req.AutoExposePorts != nil {
-		raw["auto_expose_ports"] = marshalToMap(req.AutoExposePorts)
+		if req.AutoExposePorts.Enabled != nil {
+			raw["auto_expose_ports"] = marshalToMap(req.AutoExposePorts)
+		} else {
+			delete(raw, "auto_expose_ports")
+		}
 	}
 }
 

--- a/pkg/hub/admin_settings_db.go
+++ b/pkg/hub/admin_settings_db.go
@@ -240,6 +240,13 @@ func applySnapshotToResponse(resp *ServerConfigResponse, snap Layer1Snapshot) {
 	// Notifications — always set from snapshot so an explicit empty DB
 	// value overrides file-loaded channels.
 	resp.Server.NotificationChannels = snap.NotificationChannels
+
+	// Auto-expose ports
+	if snap.AutoExposePortsEnabled != nil {
+		resp.AutoExposePorts = &config.AutoExposePortsSettings{
+			Enabled: snap.AutoExposePortsEnabled,
+		}
+	}
 }
 
 // buildSectionMetadata reads the OperationalSettings cache to determine
@@ -659,6 +666,10 @@ func extractKoanfKeysFromRequest(req *ServerConfigUpdateRequest) []string {
 		keys = append(keys, "default_thinking_level")
 	}
 
+	if req.AutoExposePorts != nil {
+		keys = append(keys, "auto_expose_ports.enabled")
+	}
+
 	if req.Telemetry != nil {
 		keys = append(keys, "telemetry.enabled")
 	}
@@ -1012,6 +1023,13 @@ func buildSingleSectionDoc(req *ServerConfigUpdateRequest, secName string, fp *f
 			d.PrivateKeyPath = ga.PrivateKeyPath
 		}
 		doc = d
+
+	case "auto_expose_ports":
+		if req.AutoExposePorts != nil {
+			doc = req.AutoExposePorts
+		} else {
+			return nil, nil
+		}
 
 	case "notifications":
 		d := &opsettings.NotificationsSettings{}

--- a/pkg/hub/admin_settings_test.go
+++ b/pkg/hub/admin_settings_test.go
@@ -158,6 +158,79 @@ func TestApplySettingsUpdates_PreservesServerKeys(t *testing.T) {
 	}
 }
 
+func TestApplySettingsUpdates_AutoExposePortsNilEnabled(t *testing.T) {
+	// When AutoExposePorts is provided but Enabled is nil, the key should be
+	// deleted to avoid persisting an empty auto_expose_ports: {} block.
+	raw := map[string]interface{}{
+		"schema_version": "1",
+		"auto_expose_ports": map[string]interface{}{
+			"enabled": true,
+		},
+	}
+
+	req := &ServerConfigUpdateRequest{
+		AutoExposePorts: &config.AutoExposePortsSettings{
+			Enabled: nil, // nil signals deletion
+		},
+	}
+
+	applySettingsUpdates(raw, req)
+
+	if _, ok := raw["auto_expose_ports"]; ok {
+		t.Error("expected auto_expose_ports key to be deleted when Enabled is nil")
+	}
+}
+
+func TestApplySettingsUpdates_AutoExposePortsWithEnabled(t *testing.T) {
+	// When AutoExposePorts is provided with a non-nil Enabled, the key should
+	// be set normally.
+	raw := map[string]interface{}{
+		"schema_version": "1",
+	}
+
+	enabled := true
+	req := &ServerConfigUpdateRequest{
+		AutoExposePorts: &config.AutoExposePortsSettings{
+			Enabled: &enabled,
+		},
+	}
+
+	applySettingsUpdates(raw, req)
+
+	aep, ok := raw["auto_expose_ports"]
+	if !ok {
+		t.Fatal("expected auto_expose_ports key to be present")
+	}
+	aepMap, ok := aep.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected auto_expose_ports to be a map, got %T", aep)
+	}
+	if aepMap["enabled"] != true {
+		t.Errorf("expected enabled=true, got %v", aepMap["enabled"])
+	}
+}
+
+func TestApplySettingsUpdates_AutoExposePortsNilRequest(t *testing.T) {
+	// When AutoExposePorts itself is nil in the request, the existing value
+	// should be preserved (no change).
+	raw := map[string]interface{}{
+		"schema_version": "1",
+		"auto_expose_ports": map[string]interface{}{
+			"enabled": true,
+		},
+	}
+
+	req := &ServerConfigUpdateRequest{
+		AutoExposePorts: nil,
+	}
+
+	applySettingsUpdates(raw, req)
+
+	if _, ok := raw["auto_expose_ports"]; !ok {
+		t.Error("expected auto_expose_ports to be preserved when request field is nil")
+	}
+}
+
 func serverConfigForMaskTest() config.V1ServerConfig {
 	return config.V1ServerConfig{
 		Auth: &config.V1AuthConfig{


### PR DESCRIPTION
## Summary

The Auto-Expose Ports toggle in the admin server config page did not persist. Adds the auto_expose_ports field to API structs and handlers in both file-mode and DB-mode code paths.

Ref: ptone/scion#746

## Test plan
- go build, go vet, go test all pass
- 3 files changed, 36 additions
