### PR TITLE
feat(messages): introduce type:system message category

### DIFF
--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -626,7 +626,7 @@ func runInit(args []string) int {
 			log.Info("Started port-forward tunnel manager")
 
 			// Auto-expose: detect and register listening ports
-			if autoExposeCfg := autoexpose.ConfigFromEnv(); autoExposeCfg.Enabled {
+			if autoExposeCfg := autoexpose.ConfigFromEnv(); autoExposeCfg.Enabled && hubClient != nil {
 				reconciler := autoexpose.NewReconciler(hubClient, autoExposeCfg)
 				reconciler.SetMessageClient(&hubMessageAdapter{client: hubClient})
 				go reconciler.Run(ctx)
@@ -2049,6 +2049,9 @@ type hubMessageAdapter struct {
 }
 
 func (a *hubMessageAdapter) SendSelfMessage(ctx context.Context, msg string, metadata map[string]string) error {
+	if a.client == nil {
+		return fmt.Errorf("hub client is nil")
+	}
 	recipient := "agent:" + a.client.AgentID()
 	return a.client.SendSelfMessage(ctx, messages.NewSystemMessage("system", recipient, msg, metadata["system_category"]))
 }

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -626,7 +626,9 @@ func runInit(args []string) int {
 
 			// Auto-expose: detect and register listening ports
 			if autoExposeCfg := autoexpose.ConfigFromEnv(); autoExposeCfg.Enabled {
-				go autoexpose.NewReconciler(hubClient, autoExposeCfg).Run(ctx)
+				reconciler := autoexpose.NewReconciler(hubClient, autoExposeCfg)
+				reconciler.SetMessageClient(&hubMessageAdapter{client: hubClient})
+				go reconciler.Run(ctx)
 				log.Info("Started auto-expose port scanner (interval: %s, mode: %s)", autoExposeCfg.Interval, autoExposeCfg.FilterMode)
 			}
 
@@ -2037,6 +2039,20 @@ func isWorkspaceEmpty(path string) bool {
 		}
 	}
 	return true
+}
+
+// hubMessageAdapter adapts the Hub client to the autoexpose.MessageClient interface
+// so the reconciler can notify the agent about auto-exposed ports.
+type hubMessageAdapter struct {
+	client *hub.Client
+}
+
+func (a *hubMessageAdapter) SendSelfMessage(ctx context.Context, msg string, metadata map[string]string) error {
+	return a.client.SendOutboundMessage(ctx, hub.OutboundMessage{
+		Msg:      msg,
+		Type:     "system",
+		Metadata: metadata,
+	})
 }
 
 // cleanGcloudConfigForMetadata removes gcloud configuration state files from

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -2049,7 +2049,8 @@ type hubMessageAdapter struct {
 }
 
 func (a *hubMessageAdapter) SendSelfMessage(ctx context.Context, msg string, metadata map[string]string) error {
-	return a.client.SendSelfMessage(ctx, messages.NewSystemMessage("system", "", msg, metadata["system_category"]))
+	recipient := "agent:" + a.client.AgentID()
+	return a.client.SendSelfMessage(ctx, messages.NewSystemMessage("system", recipient, msg, metadata["system_category"]))
 }
 
 // cleanGcloudConfigForMetadata removes gcloud configuration state files from

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/autoexpose"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hooks"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hooks/handlers"
@@ -2048,11 +2049,7 @@ type hubMessageAdapter struct {
 }
 
 func (a *hubMessageAdapter) SendSelfMessage(ctx context.Context, msg string, metadata map[string]string) error {
-	return a.client.SendOutboundMessage(ctx, hub.OutboundMessage{
-		Msg:      msg,
-		Type:     "system",
-		Metadata: metadata,
-	})
+	return a.client.SendSelfMessage(ctx, messages.NewSystemMessage("system", "", msg, metadata["system_category"]))
 }
 
 // cleanGcloudConfigForMetadata removes gcloud configuration state files from

--- a/extras/scion-a2a-bridge/internal/bridge/bridge.go
+++ b/extras/scion-a2a-bridge/internal/bridge/bridge.go
@@ -794,13 +794,15 @@ func (b *Bridge) dispatchToWaiter(taskID string, msg *messages.StructuredMessage
 	if !ok {
 		return false
 	}
-	if msg.Type == messages.TypeStateChange {
+	if msg.Type == messages.TypeStateChange || msg.Type == messages.TypeSystem {
 		// Terminal state-changes must still be persisted to the DB even though
 		// we skip the waiter — otherwise the task's stored state is never updated.
-		if taskState := MapActivityToTaskState(msg.Msg); IsTerminalState(taskState) {
-			if err := b.store.UpdateTaskState(taskID, taskState); err != nil {
-				b.log.Error("failed to persist terminal state from waiter path",
-					"task_id", taskID, "state", taskState, "error", err)
+		if msg.Type == messages.TypeStateChange {
+			if taskState := MapActivityToTaskState(msg.Msg); IsTerminalState(taskState) {
+				if err := b.store.UpdateTaskState(taskID, taskState); err != nil {
+					b.log.Error("failed to persist terminal state from waiter path",
+						"task_id", taskID, "state", taskState, "error", err)
+				}
 			}
 		}
 		return true
@@ -841,6 +843,12 @@ func (b *Bridge) dispatchToActiveTask(ctx context.Context, taskID, agentSlug str
 			b.unregisterActiveTask(taskID, aKey)
 			b.streams.CloseAll(taskID)
 		}
+		return
+	}
+
+	// System messages are non-conversational — log and skip content dispatch.
+	if msg.Type == messages.TypeSystem {
+		b.log.Debug("skipping system message in A2A bridge", "task_id", taskID, "sender", msg.Sender)
 		return
 	}
 

--- a/extras/scion-chat-app/internal/chatapp/notifications.go
+++ b/extras/scion-chat-app/internal/chatapp/notifications.go
@@ -309,6 +309,8 @@ func extractActivity(msg *messages.StructuredMessage) string {
 		return "WAITING_FOR_INPUT"
 	case messages.TypeStateChange:
 		return "STATE_CHANGE"
+	case messages.TypeSystem:
+		return "SYSTEM"
 	default:
 		return "INFO"
 	}

--- a/extras/scion-slack/internal/slack/blocks.go
+++ b/extras/scion-slack/internal/slack/blocks.go
@@ -173,6 +173,36 @@ func RenderInputNeededBlocks(msg *messages.StructuredMessage, agentSlug, request
 	return blocks
 }
 
+// FormatSystemMessage formats a TypeSystem message as mrkdwn text.
+// System messages are operational notices (e.g. scheduled events, delivery
+// failures, port auto-expose) and are rendered with a gear prefix.
+func FormatSystemMessage(msg *messages.StructuredMessage) string {
+	if msg == nil {
+		return ""
+	}
+
+	category := "system"
+	if msg.Metadata != nil {
+		if cat, ok := msg.Metadata["system_category"]; ok && cat != "" {
+			category = cat
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, ":gear: *[%s]*", category)
+
+	if msg.Status != "" {
+		fmt.Fprintf(&b, " [%s]", msg.Status)
+	}
+
+	if msg.Msg != "" {
+		b.WriteString("\n")
+		b.WriteString(msg.Msg)
+	}
+
+	return truncateMessage(b.String())
+}
+
 // truncateMessage ensures the message fits within Slack's message length limit.
 func truncateMessage(text string) string {
 	if len(text) <= maxSlackMessageLength {

--- a/extras/scion-slack/internal/slack/broker.go
+++ b/extras/scion-slack/internal/slack/broker.go
@@ -510,7 +510,9 @@ func (b *SlackBroker) Publish(ctx context.Context, topic string, msg *messages.S
 		}
 
 		var text string
-		if isStateChange {
+		if msg.Type == messages.TypeSystem {
+			text = FormatSystemMessage(msg)
+		} else if isStateChange {
 			text = FormatStateChange(msg, agentSlug)
 		} else {
 			text = FormatWebhookMessage(msg)

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -588,6 +588,32 @@ func (b *TelegramBrokerV2) Publish(ctx context.Context, topic string, msg *messa
 	// Determine the project and agent from the topic.
 	projectID, agentSlug := parseTopicComponents(topic)
 
+	// Route system messages to linked groups (similar to state-change
+	// with notify_in_group). System messages are operational notices and
+	// do not need DM routing.
+	if msg != nil && msg.Type == messages.TypeSystem {
+		if store != nil && projectID != "" {
+			links, _ := store.GetGroupLinksForProject(ctx, projectID)
+			for _, link := range links {
+				if link.Active && link.NotifyInGroup {
+					text := FormatSystemCard(msg)
+					if text != "" {
+						if sq != nil {
+							if _, err := sq.Send(ctx, link.ChatID, text, "HTML", nil, 0); err != nil {
+								b.log.Warn("Failed to send system message group notification",
+									"chat_id", link.ChatID, "error", err)
+							}
+						} else if _, err := api.SendMessage(ctx, link.ChatID, text, "HTML"); err != nil {
+							b.log.Warn("Failed to send system message group notification",
+								"chat_id", link.ChatID, "error", err)
+						}
+					}
+				}
+			}
+		}
+		return nil
+	}
+
 	// Route state-change notifications to the user's personal DM
 	// instead of the group chat.
 	if msg != nil && msg.Type == messages.TypeStateChange {

--- a/extras/scion-telegram/internal/telegram/format.go
+++ b/extras/scion-telegram/internal/telegram/format.go
@@ -273,6 +273,43 @@ func FormatInputNeededCard(msg *messages.StructuredMessage, agentSlug string) st
 	return truncateHTMLMessage(b.String())
 }
 
+// FormatSystemCard converts a system StructuredMessage into an HTML-formatted
+// card for Telegram. The card shows a gear icon, the system category (if
+// available), timestamp, and message body. All user-supplied content is
+// HTML-escaped to prevent injection.
+func FormatSystemCard(msg *messages.StructuredMessage) string {
+	if msg == nil {
+		return ""
+	}
+
+	category := "System"
+	if msg.Metadata != nil {
+		if cat, ok := msg.Metadata["system_category"]; ok && cat != "" {
+			category = strings.ToUpper(cat[:1]) + cat[1:]
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "<b>⚙️ %s</b>\n", html.EscapeString(category))
+
+	ts := formatTimestamp(msg.Timestamp)
+	if ts != "" {
+		fmt.Fprintf(&b, "🕐 %s\n", html.EscapeString(ts))
+	}
+
+	body := strings.TrimSpace(msg.Msg)
+	if body != "" {
+		summaryBudget := maxTelegramMessageLength - htmlCardOverhead
+		if summaryBudget > maxTaskSummaryLength {
+			summaryBudget = maxTaskSummaryLength
+		}
+		body = truncatePlainText(body, summaryBudget)
+		b.WriteString(html.EscapeString(body))
+	}
+
+	return truncateHTMLMessage(b.String())
+}
+
 // formatTimestamp parses an RFC3339 timestamp and returns a human-friendly
 // representation like "May 13, 2:30 PM UTC". Returns the raw string if
 // parsing fails.

--- a/extras/scion-telegram/internal/telegram/format.go
+++ b/extras/scion-telegram/internal/telegram/format.go
@@ -285,7 +285,12 @@ func FormatSystemCard(msg *messages.StructuredMessage) string {
 	category := "System"
 	if msg.Metadata != nil {
 		if cat, ok := msg.Metadata["system_category"]; ok && cat != "" {
-			category = strings.ToUpper(cat[:1]) + cat[1:]
+			r, size := utf8.DecodeRuneInString(cat)
+			if r != utf8.RuneError {
+				category = strings.ToUpper(string(r)) + cat[size:]
+			} else {
+				category = cat
+			}
 		}
 	}
 

--- a/pkg/hub/channels_discord.go
+++ b/pkg/hub/channels_discord.go
@@ -181,6 +181,9 @@ func extractDiscordUserIDs(s string) []string {
 	return ids
 }
 
+// discordColorSystem is the colour for system/operational messages.
+const discordColorSystem = 0x95a5a6 // grey — system/operational
+
 func discordColorForMessage(msg *messages.StructuredMessage) int {
 	if msg.Urgent {
 		return discordColorUrgent
@@ -192,6 +195,8 @@ func discordColorForMessage(msg *messages.StructuredMessage) int {
 		return discordColorInputNeeded
 	case messages.TypeInstruction:
 		return discordColorInstruction
+	case messages.TypeSystem:
+		return discordColorSystem
 	default:
 		return discordColorStateChange
 	}

--- a/pkg/hub/channels_slack.go
+++ b/pkg/hub/channels_slack.go
@@ -115,6 +115,8 @@ func formatSlackMessage(msg *messages.StructuredMessage, mentionOnUrgent string)
 		b.WriteString(":information_source: ")
 	case messages.TypeInputNeeded:
 		b.WriteString(":raising_hand: ")
+	case messages.TypeSystem:
+		b.WriteString(":gear: ")
 	default:
 		b.WriteString(":speech_balloon: ")
 	}

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -1135,8 +1135,9 @@ func (s *Server) publishBroadcastDeliveryFailed(ctx context.Context, targetAgent
 		Recipient:   msg.Sender,
 		RecipientID: senderAgent.ID,
 		Msg:         failMsg,
-		Type:        messages.TypeStateChange,
+		Type:        messages.TypeSystem,
 		Status:      "DELIVERY_FAILED",
+		Metadata:    map[string]string{"system_category": messages.SystemCategoryDeliveryFailed},
 	}
 
 	dispatcher := s.GetDispatcher()

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -1945,11 +1945,24 @@ func (s *Server) handleAgentAction(w http.ResponseWriter, r *http.Request, id, a
 	// For actions other than status/token refresh and outbound-message
 	// (self-access), we require user or agent authentication
 	// with appropriate scopes. Self-access endpoints enforce their own auth checks.
-	if action != api.AgentActionStatus &&
-		action != api.AgentActionMetrics &&
-		action != api.AgentActionTokenRefresh &&
-		action != api.AgentActionRefreshToken &&
-		action != api.AgentActionOutboundMessage {
+	selfAccess := action == api.AgentActionStatus ||
+		action == api.AgentActionMetrics ||
+		action == api.AgentActionTokenRefresh ||
+		action == api.AgentActionRefreshToken ||
+		action == api.AgentActionOutboundMessage
+
+	// Self-message: allow an agent to deliver a message to itself using its
+	// own token, without requiring the ScopeAgentLifecycle scope. This mirrors
+	// the outbound-message self-access pattern and is used by sciontool to
+	// send system notifications (e.g. port auto-expose) to the agent's own
+	// harness input.
+	if action == api.AgentActionMessage {
+		if claims := GetAgentFromContext(r.Context()); claims != nil && claims.Subject == id {
+			selfAccess = true
+		}
+	}
+
+	if !selfAccess {
 		userIdent := GetUserIdentityFromContext(r.Context())
 		agentIdent := GetAgentIdentityFromContext(r.Context())
 		if userIdent == nil && agentIdent == nil {

--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -668,8 +668,9 @@ func (p *MessageBrokerProxy) publishDeliveryFailed(ctx context.Context, projectI
 		Sender:    "system",
 		Recipient: msg.Sender,
 		Msg:       failMsg,
-		Type:      messages.TypeStateChange,
+		Type:      messages.TypeSystem,
 		Status:    "DELIVERY_FAILED",
+		Metadata:  map[string]string{"system_category": messages.SystemCategoryDeliveryFailed},
 	}
 	structuredMsg.RecipientID = senderAgent.ID
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2309,7 +2309,7 @@ func (s *Server) messageEventHandler() EventHandler {
 		}
 
 		// Reconstruct structured message from payload to preserve traits like Plain.
-		structuredMsg := messages.NewInstruction("scheduler", "agent:"+agent.Slug, payload.Message)
+		structuredMsg := messages.NewSystemMessage("scheduler", "agent:"+agent.Slug, payload.Message, messages.SystemCategoryScheduler)
 		structuredMsg.SenderID = "SCHEDULER"
 		structuredMsg.RecipientID = agent.ID
 		structuredMsg.Plain = payload.Plain

--- a/pkg/messages/format.go
+++ b/pkg/messages/format.go
@@ -36,6 +36,7 @@ var deliveryMetadataAllowlist = map[string]bool{
 	"mention_position": true,
 	"channel":          true,
 	"thread_id":        true,
+	"system_category":  true,
 }
 
 // deliveryMessage is the subset of StructuredMessage fields delivered to the agent.

--- a/pkg/messages/format_test.go
+++ b/pkg/messages/format_test.go
@@ -269,6 +269,35 @@ func TestFormatForDelivery_AllMetadataFiltered(t *testing.T) {
 	}
 }
 
+func TestFormatForDelivery_SystemMessage(t *testing.T) {
+	msg := NewSystemMessage("system", "agent:dev", "Port 8080 has been auto-exposed", SystemCategoryPortForward)
+
+	result := FormatForDelivery(msg)
+
+	// Should have the intro and delimiters
+	if !strings.Contains(result, deliveryIntro) {
+		t.Error("missing delivery intro")
+	}
+	if !strings.Contains(result, beginDelimiter) {
+		t.Error("missing begin delimiter")
+	}
+
+	// Should contain system type
+	if !strings.Contains(result, `"type": "system"`) {
+		t.Error("missing system type in output")
+	}
+
+	// Should contain system_category in metadata (it's in the allowlist)
+	if !strings.Contains(result, `"system_category": "port-forward"`) {
+		t.Error("missing system_category in delivery output")
+	}
+
+	// Should contain the message body
+	if !strings.Contains(result, "Port 8080 has been auto-exposed") {
+		t.Error("missing message body in output")
+	}
+}
+
 func TestFormatForDelivery_WithAttachments(t *testing.T) {
 	msg := &StructuredMessage{
 		Version:     Version,

--- a/pkg/messages/types.go
+++ b/pkg/messages/types.go
@@ -56,6 +56,14 @@ const (
 	TypeAssistantReply = "assistant-reply"
 	TypeGroupSet       = "group-set"
 	TypeMention        = "mention"
+	TypeSystem         = "system"
+)
+
+// System message category constants identify the origin of a system message.
+const (
+	SystemCategoryScheduler       = "scheduler"
+	SystemCategoryPortForward     = "port-forward"
+	SystemCategoryDeliveryFailed  = "delivery-failed"
 )
 
 // Visibility constants control which consumers see a message.
@@ -86,6 +94,7 @@ var validTypes = map[string]bool{
 	TypeAssistantReply: true,
 	TypeGroupSet:       true,
 	TypeMention:        true,
+	TypeSystem:         true,
 }
 
 // StructuredMessage represents a formatted Scion message.
@@ -119,7 +128,7 @@ type StructuredMessage struct {
 // ValidateType returns an error if the message type is not in the closed enum.
 func ValidateType(t string) error {
 	if !validTypes[t] {
-		return fmt.Errorf("invalid message type %q: must be one of: instruction, input-needed, state-change, assistant-reply, group-set, mention", t)
+		return fmt.Errorf("invalid message type %q: must be one of: instruction, input-needed, state-change, assistant-reply, group-set, mention, system", t)
 	}
 	return nil
 }
@@ -214,6 +223,20 @@ func NewMention(sender, recipient, msg, mentionSource string) *StructuredMessage
 			"mention_source":   mentionSource,
 			"mention_position": "body",
 		},
+	}
+}
+
+// NewSystemMessage creates a new system-originated message with a category.
+// The category is stored in metadata["system_category"] for downstream consumers.
+func NewSystemMessage(sender, recipient, msg, category string) *StructuredMessage {
+	return &StructuredMessage{
+		Version:   Version,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Sender:    sender,
+		Recipient: recipient,
+		Msg:       msg,
+		Type:      TypeSystem,
+		Metadata:  map[string]string{"system_category": category},
 	}
 }
 

--- a/pkg/messages/types.go
+++ b/pkg/messages/types.go
@@ -61,9 +61,9 @@ const (
 
 // System message category constants identify the origin of a system message.
 const (
-	SystemCategoryScheduler       = "scheduler"
-	SystemCategoryPortForward     = "port-forward"
-	SystemCategoryDeliveryFailed  = "delivery-failed"
+	SystemCategoryScheduler      = "scheduler"
+	SystemCategoryPortForward    = "port-forward"
+	SystemCategoryDeliveryFailed = "delivery-failed"
 )
 
 // Visibility constants control which consumers see a message.

--- a/pkg/messages/types_test.go
+++ b/pkg/messages/types_test.go
@@ -30,6 +30,7 @@ func TestValidateType(t *testing.T) {
 		{TypeAssistantReply, false},
 		{TypeGroupSet, false},
 		{TypeMention, false},
+		{TypeSystem, false},
 		{"unknown", true},
 		{"", true},
 	}
@@ -438,6 +439,70 @@ func TestNewMention(t *testing.T) {
 	}
 	if got := m.Metadata["mention_position"]; got != "body" {
 		t.Errorf("metadata[mention_position] = %q, want %q", got, "body")
+	}
+}
+
+func TestNewSystemMessage(t *testing.T) {
+	m := NewSystemMessage("system", "agent:dev", "Port 8080 has been auto-exposed", SystemCategoryPortForward)
+	if m.Version != Version {
+		t.Errorf("version = %d, want %d", m.Version, Version)
+	}
+	if m.Type != TypeSystem {
+		t.Errorf("type = %q, want %q", m.Type, TypeSystem)
+	}
+	if m.Sender != "system" {
+		t.Errorf("sender = %q, want %q", m.Sender, "system")
+	}
+	if m.Recipient != "agent:dev" {
+		t.Errorf("recipient = %q, want %q", m.Recipient, "agent:dev")
+	}
+	if m.Msg != "Port 8080 has been auto-exposed" {
+		t.Errorf("msg = %q, want %q", m.Msg, "Port 8080 has been auto-exposed")
+	}
+	if m.Timestamp == "" {
+		t.Error("timestamp should be set")
+	}
+	if m.Metadata == nil {
+		t.Fatal("metadata should not be nil")
+	}
+	if got := m.Metadata["system_category"]; got != SystemCategoryPortForward {
+		t.Errorf("metadata[system_category] = %q, want %q", got, SystemCategoryPortForward)
+	}
+}
+
+func TestNewSystemMessage_Categories(t *testing.T) {
+	tests := []struct {
+		category string
+		want     string
+	}{
+		{SystemCategoryScheduler, "scheduler"},
+		{SystemCategoryPortForward, "port-forward"},
+		{SystemCategoryDeliveryFailed, "delivery-failed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.category, func(t *testing.T) {
+			m := NewSystemMessage("system", "agent:test", "test msg", tt.category)
+			if got := m.Metadata["system_category"]; got != tt.want {
+				t.Errorf("system_category = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStructuredMessage_ValidateSystem(t *testing.T) {
+	m := &StructuredMessage{
+		Version:   Version,
+		Timestamp: "2026-08-03T10:00:00Z",
+		Sender:    "system",
+		Recipient: "agent:worker",
+		Msg:       "Scheduled event fired",
+		Type:      TypeSystem,
+		Metadata: map[string]string{
+			"system_category": SystemCategoryScheduler,
+		},
+	}
+	if err := m.Validate(); err != nil {
+		t.Errorf("unexpected error for valid system message: %v", err)
 	}
 }
 

--- a/pkg/sciontool/autoexpose/reconciler.go
+++ b/pkg/sciontool/autoexpose/reconciler.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	scionhub "github.com/GoogleCloudPlatform/scion/pkg/sciontool/hub"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/log"
 )
@@ -288,7 +289,7 @@ func (r *Reconciler) registerPort(ctx context.Context, port int) error {
 	// Notify the agent that a port was auto-exposed.
 	if r.msgClient != nil {
 		notifyMsg := fmt.Sprintf("Port %d has been auto-exposed for proxy access. Run 'sciontool port list' for the full proxy URL.", port)
-		metadata := map[string]string{"system_category": "port-forward"}
+		metadata := map[string]string{"system_category": messages.SystemCategoryPortForward}
 		if err := r.msgClient.SendSelfMessage(ctx, notifyMsg, metadata); err != nil {
 			log.Error("auto-expose: failed to send notification for port %d: %v", port, err)
 		}

--- a/pkg/sciontool/autoexpose/reconciler.go
+++ b/pkg/sciontool/autoexpose/reconciler.go
@@ -16,6 +16,7 @@ package autoexpose
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -36,6 +37,12 @@ type HubPortClient interface {
 	ListPorts(ctx context.Context) ([]scionhub.ExposedPort, error)
 }
 
+// MessageClient sends messages via the Hub API.
+// Used to notify the agent when ports are auto-exposed.
+type MessageClient interface {
+	SendSelfMessage(ctx context.Context, msg string, metadata map[string]string) error
+}
+
 // scanFunc is the function signature for scanning listeners.
 // Defaults to ScanListeners; overridable in tests.
 type scanFunc func() ([]ListenSocket, error)
@@ -44,9 +51,10 @@ type scanFunc func() ([]ListenSocket, error)
 // them with the Hub's port registry. It only manages ports it auto-exposed
 // (tracked in a local set) and never un-exposes manually-registered ports.
 type Reconciler struct {
-	client HubPortClient
-	cfg    Config
-	scan   scanFunc
+	client    HubPortClient
+	msgClient MessageClient // optional; nil means no notifications
+	cfg       Config
+	scan      scanFunc
 
 	// autoExposed tracks ports this reconciler has registered.
 	// Only these ports are candidates for auto-unexpose.
@@ -70,6 +78,12 @@ func NewReconciler(client HubPortClient, cfg Config) *Reconciler {
 		scan:        ScanListeners,
 		autoExposed: make(map[int]bool),
 	}
+}
+
+// SetMessageClient sets the optional message client used to notify the agent
+// when ports are auto-exposed. If nil (the default), notifications are skipped.
+func (r *Reconciler) SetMessageClient(mc MessageClient) {
+	r.msgClient = mc
 }
 
 // Run starts the reconciliation loop. It blocks until ctx is cancelled.
@@ -270,6 +284,16 @@ func (r *Reconciler) registerPort(ctx context.Context, port int) error {
 
 	r.autoExposed[port] = true
 	log.Info("auto-expose: exposed port %d", port)
+
+	// Notify the agent that a port was auto-exposed.
+	if r.msgClient != nil {
+		notifyMsg := fmt.Sprintf("Port %d has been auto-exposed for proxy access. Run 'sciontool port list' for the full proxy URL.", port)
+		metadata := map[string]string{"system_category": "port-forward"}
+		if err := r.msgClient.SendSelfMessage(ctx, notifyMsg, metadata); err != nil {
+			log.Error("auto-expose: failed to send notification for port %d: %v", port, err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	state "github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
 )
 
@@ -1384,6 +1385,54 @@ func (c *Client) SendOutboundMessage(ctx context.Context, msg OutboundMessage) e
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send outbound message: %w", err)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("hub returned error %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// selfMessageRequest is the payload for delivering a message to the current agent
+// via the hub's inbound agent message endpoint (POST /api/v1/agents/{id}/message).
+type selfMessageRequest struct {
+	StructuredMessage *messages.StructuredMessage `json:"structured_message"`
+}
+
+// SendSelfMessage delivers a structured message to the current agent via the
+// hub's inbound message endpoint. Unlike SendOutboundMessage (which targets
+// a human inbox), this delivers a message into the agent's own harness input.
+// No retries — this is a best-effort fire-and-forget call.
+func (c *Client) SendSelfMessage(ctx context.Context, msg *messages.StructuredMessage) error {
+	if !c.IsConfigured() {
+		return fmt.Errorf("hub client not configured")
+	}
+
+	endpoint := fmt.Sprintf("%s/api/v1/agents/%s/message",
+		strings.TrimSuffix(c.hubURL, "/"), c.agentID)
+
+	payload := selfMessageRequest{StructuredMessage: msg}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal self message: %w", err)
+	}
+
+	c.tokenMu.RLock()
+	currentToken := c.token
+	c.tokenMu.RUnlock()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Scion-Agent-Token", currentToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send self message: %w", err)
 	}
 	respBody, _ := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()

--- a/resources/platform_skills/scion-messaging/SKILL.md
+++ b/resources/platform_skills/scion-messaging/SKILL.md
@@ -112,6 +112,7 @@ is addressed to you or is a notification about another agent.
 - **`input-needed`** — an agent is waiting for input. See below.
 - **`mention`** — you were CC'd or mentioned in a message primarily directed at someone else. Treat as FYI — no action needed unless the message text clearly directs you to do something.
 - **`group-set`** — a user @-mentioned multiple agents (not `@all`). Read and act on it like an `instruction`.
+- **`system`** — a hub-generated operational notice (e.g. scheduled event fired, port auto-exposed, message delivery failed). Read for situational awareness; no reply needed. Check `metadata.system_category` for the specific category.
 
 ### Handling `input-needed`
 


### PR DESCRIPTION
Adds a new `type:system` message type for hub-generated operational notices, distinct from instruction and state-change.

Three system message categories:
- `delivery-failed` — reclassified from TypeStateChange
- `scheduler` — reclassified from TypeInstruction
- `port-forward` — new auto-expose notification

Key changes (20 files, ~358 lines):
- TypeSystem constant + SystemCategory constants + NewSystemMessage constructor
- SendSelfMessage hub client method for agent self-notification
- Rendering support in Discord, Slack, Telegram, Google Chat, A2A bridge
- Platform skill documentation updated

Ref: ptone/scion#747