### PR TITLE
feat(telemetry): add retry with exponential backoff to pipeline exports

### DIFF
--- a/pkg/observability/hubmetrics/hubmetrics.go
+++ b/pkg/observability/hubmetrics/hubmetrics.go
@@ -178,15 +178,15 @@ func (e *loggingExporter) Aggregation(k metric.InstrumentKind) metric.Aggregatio
 func (e *loggingExporter) Export(ctx context.Context, rm *metricdata.ResourceMetrics) error {
 	err := e.delegate.Export(ctx, rm)
 	if err != nil {
-		datapoints := 0
+		metricCount := 0
 		if rm != nil {
 			for _, sm := range rm.ScopeMetrics {
-				datapoints += len(sm.Metrics)
+				metricCount += len(sm.Metrics)
 			}
 		}
 		slog.Error("hub metrics export error",
 			"error", err,
-			"metric_count", datapoints,
+			"metric_count", metricCount,
 		)
 	}
 	return err

--- a/pkg/observability/hubmetrics/hubmetrics.go
+++ b/pkg/observability/hubmetrics/hubmetrics.go
@@ -10,6 +10,7 @@ package hubmetrics
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
@@ -84,10 +86,11 @@ func NewMeterProvider(ctx context.Context, gcpProjectID string, opts ...Option) 
 		fn(o)
 	}
 
-	exporter, err := mexporter.New(mexporter.WithProjectID(gcpProjectID))
+	baseExporter, err := mexporter.New(mexporter.WithProjectID(gcpProjectID))
 	if err != nil {
 		return nil, fmt.Errorf("creating GCP metric exporter: %w", err)
 	}
+	exporter := &loggingExporter{delegate: baseExporter}
 
 	resAttrs := []attribute.KeyValue{
 		semconv.ServiceName("scion-hub"),
@@ -152,4 +155,47 @@ func GroupScopes() []MetricGroup {
 // dispatchmetrics package, useful for building Views in tests.
 func InstrumentationScope(name string) instrumentation.Scope {
 	return instrumentation.Scope{Name: name}
+}
+
+// loggingExporter wraps a metric.Exporter and logs any export errors with
+// structured context before returning them. This gives hub operators
+// visibility into metric export failures that the OTel SDK would otherwise
+// only surface through the global error handler.
+type loggingExporter struct {
+	delegate metric.Exporter
+}
+
+var _ metric.Exporter = (*loggingExporter)(nil)
+
+func (e *loggingExporter) Temporality(k metric.InstrumentKind) metricdata.Temporality {
+	return e.delegate.Temporality(k)
+}
+
+func (e *loggingExporter) Aggregation(k metric.InstrumentKind) metric.Aggregation {
+	return e.delegate.Aggregation(k)
+}
+
+func (e *loggingExporter) Export(ctx context.Context, rm *metricdata.ResourceMetrics) error {
+	err := e.delegate.Export(ctx, rm)
+	if err != nil {
+		datapoints := 0
+		if rm != nil {
+			for _, sm := range rm.ScopeMetrics {
+				datapoints += len(sm.Metrics)
+			}
+		}
+		slog.Error("hub metrics export error",
+			"error", err,
+			"metric_count", datapoints,
+		)
+	}
+	return err
+}
+
+func (e *loggingExporter) ForceFlush(ctx context.Context) error {
+	return e.delegate.ForceFlush(ctx)
+}
+
+func (e *loggingExporter) Shutdown(ctx context.Context) error {
+	return e.delegate.Shutdown(ctx)
 }

--- a/pkg/observability/hubmetrics/hubmetrics_test.go
+++ b/pkg/observability/hubmetrics/hubmetrics_test.go
@@ -6,6 +6,7 @@ package hubmetrics
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 
@@ -168,5 +169,85 @@ func TestPoolMetricsNotDroppedWhenNotifyDisabled(t *testing.T) {
 
 	if !names[dbmetrics.MetricPoolConnectionsActive] {
 		t.Error("pool metric should still be exported when only db-notify is disabled")
+	}
+}
+
+// --- loggingExporter tests ---
+
+// mockExporter implements metric.Exporter for testing the loggingExporter wrapper.
+type mockExporter struct {
+	exportErr    error
+	exportCalled bool
+}
+
+func (m *mockExporter) Temporality(k metric.InstrumentKind) metricdata.Temporality {
+	return metricdata.CumulativeTemporality
+}
+
+func (m *mockExporter) Aggregation(k metric.InstrumentKind) metric.Aggregation {
+	return nil
+}
+
+func (m *mockExporter) Export(ctx context.Context, rm *metricdata.ResourceMetrics) error {
+	m.exportCalled = true
+	return m.exportErr
+}
+
+func (m *mockExporter) ForceFlush(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockExporter) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+func TestLoggingExporter_DelegatesOnSuccess(t *testing.T) {
+	mock := &mockExporter{}
+	le := &loggingExporter{delegate: mock}
+
+	err := le.Export(context.Background(), &metricdata.ResourceMetrics{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !mock.exportCalled {
+		t.Error("expected delegate Export to be called")
+	}
+}
+
+func TestLoggingExporter_LogsAndReturnsError(t *testing.T) {
+	exportErr := errors.New("cloud monitoring write failed")
+	mock := &mockExporter{exportErr: exportErr}
+	le := &loggingExporter{delegate: mock}
+
+	err := le.Export(context.Background(), &metricdata.ResourceMetrics{
+		ScopeMetrics: []metricdata.ScopeMetrics{
+			{Metrics: []metricdata.Metrics{{Name: "test.metric"}}},
+		},
+	})
+	if err == nil {
+		t.Error("expected error to be returned")
+	}
+	if !errors.Is(err, exportErr) {
+		t.Errorf("expected original error, got: %v", err)
+	}
+}
+
+func TestLoggingExporter_DelegatesTemporality(t *testing.T) {
+	mock := &mockExporter{}
+	le := &loggingExporter{delegate: mock}
+
+	got := le.Temporality(metric.InstrumentKindCounter)
+	if got != metricdata.CumulativeTemporality {
+		t.Errorf("expected CumulativeTemporality, got %v", got)
+	}
+}
+
+func TestLoggingExporter_DelegatesAggregation(t *testing.T) {
+	mock := &mockExporter{}
+	le := &loggingExporter{delegate: mock}
+
+	got := le.Aggregation(metric.InstrumentKindCounter)
+	if got != nil {
+		t.Errorf("expected nil aggregation, got %v", got)
 	}
 }

--- a/pkg/sciontool/telemetry/pipeline.go
+++ b/pkg/sciontool/telemetry/pipeline.go
@@ -269,7 +269,13 @@ func (p *Pipeline) handleSpans(ctx context.Context, resourceSpans []*tracepb.Res
 		}
 	}
 
-	// Forward to cloud exporter if available
+	// Forward to cloud exporter if available.
+	// This retry sits above the gRPC/SDK transport-level retry. Both layers
+	// are intentional: transport retries handle transient network blips,
+	// while this pipeline-level retry catches higher-level failures (quota,
+	// timeout) that the transport considers terminal. In the worst case a
+	// batch sees ~16 network attempts (4 pipeline × ~4 transport), which is
+	// acceptable for background telemetry where data loss is costlier.
 	if p.exporter != nil {
 		err := retryExport(ctx, p.retryConfig, "spans", func() error {
 			return p.exporter.ExportProtoSpans(ctx, filtered)
@@ -406,6 +412,8 @@ func (p *Pipeline) flushMetricBuffer(ctx context.Context, force bool) {
 		}
 	}
 
+	// Pipeline-level retry on top of gRPC/SDK transport retry — see
+	// handleSpans for the rationale on intentional double-retry layering.
 	err := retryExport(ctx, p.retryConfig, "metrics", func() error {
 		return p.exporter.ExportProtoMetrics(ctx, deduped)
 	})
@@ -586,7 +594,9 @@ func (p *Pipeline) handleLogs(ctx context.Context, resourceLogs []*logspb.Resour
 		}
 	}
 
-	// Forward to cloud exporter if available
+	// Forward to cloud exporter if available.
+	// Pipeline-level retry on top of gRPC/SDK transport retry — see
+	// handleSpans for the rationale on intentional double-retry layering.
 	if p.exporter != nil {
 		err := retryExport(ctx, p.retryConfig, "logs", func() error {
 			return p.exporter.ExportProtoLogs(ctx, resourceLogs)

--- a/pkg/sciontool/telemetry/pipeline.go
+++ b/pkg/sciontool/telemetry/pipeline.go
@@ -424,10 +424,17 @@ func (p *Pipeline) flushMetricBuffer(ctx context.Context, force bool) {
 		// Re-buffer failed metrics so they can be retried on the next flush
 		// cycle. Cap the buffer to maxMetricBufCap to avoid unbounded growth.
 		p.metricBufMu.Lock()
-		p.metricBuf = append(p.metricBuf, deduped...)
+		// Prepend the failed metrics so they remain the oldest in the buffer,
+		// and newly accumulated metrics remain the newest.
+		p.metricBuf = append(deduped, p.metricBuf...)
 		if len(p.metricBuf) > maxMetricBufCap {
 			log.Error("Metric re-buffer exceeds cap (%d > %d), discarding oldest entries", len(p.metricBuf), maxMetricBufCap)
-			p.metricBuf = p.metricBuf[len(p.metricBuf)-maxMetricBufCap:]
+			discardCount := len(p.metricBuf) - maxMetricBufCap
+			// Nil out discarded pointers to prevent memory leaks
+			for i := 0; i < discardCount; i++ {
+				p.metricBuf[i] = nil
+			}
+			p.metricBuf = p.metricBuf[discardCount:]
 		}
 		p.metricBufMu.Unlock()
 		return

--- a/pkg/sciontool/telemetry/pipeline.go
+++ b/pkg/sciontool/telemetry/pipeline.go
@@ -32,6 +32,12 @@ import (
 // processes (hooks) send metrics in rapid succession.
 const metricFlushInterval = 15 * time.Second
 
+// maxMetricBufCap is the maximum number of ResourceMetrics batches kept in
+// the re-buffer when metric export fails after retries are exhausted. This
+// prevents unbounded memory growth — it allows roughly 2x the normal inflow
+// between flush intervals to accumulate before older entries are discarded.
+const maxMetricBufCap = 100
+
 // Pipeline orchestrates the telemetry collection and forwarding.
 type Pipeline struct {
 	config       *Config
@@ -43,6 +49,7 @@ type Pipeline struct {
 	healthCancel context.CancelFunc
 	exportErrors otelmetric.Int64Counter
 	meter        otelmetric.Meter
+	retryConfig  RetryConfig
 
 	metricsDropWarned sync.Once
 	logsDropWarned    sync.Once
@@ -64,8 +71,9 @@ func New() *Pipeline {
 		return nil
 	}
 	return &Pipeline{
-		config: config,
-		filter: NewFilter(config.Filter),
+		config:      config,
+		filter:      NewFilter(config.Filter),
+		retryConfig: DefaultRetryConfig(),
 	}
 }
 
@@ -75,8 +83,9 @@ func NewWithConfig(config *Config) *Pipeline {
 		return nil
 	}
 	return &Pipeline{
-		config: config,
-		filter: NewFilter(config.Filter),
+		config:      config,
+		filter:      NewFilter(config.Filter),
+		retryConfig: DefaultRetryConfig(),
 	}
 }
 
@@ -262,7 +271,10 @@ func (p *Pipeline) handleSpans(ctx context.Context, resourceSpans []*tracepb.Res
 
 	// Forward to cloud exporter if available
 	if p.exporter != nil {
-		if err := p.exporter.ExportProtoSpans(ctx, filtered); err != nil {
+		err := retryExport(ctx, p.retryConfig, "spans", func() error {
+			return p.exporter.ExportProtoSpans(ctx, filtered)
+		})
+		if err != nil {
 			p.recordExportError(ctx, "spans", err)
 			log.Error("Failed to export spans to cloud: %v", err)
 			return err
@@ -394,9 +406,22 @@ func (p *Pipeline) flushMetricBuffer(ctx context.Context, force bool) {
 		}
 	}
 
-	if err := p.exporter.ExportProtoMetrics(ctx, deduped); err != nil {
+	err := retryExport(ctx, p.retryConfig, "metrics", func() error {
+		return p.exporter.ExportProtoMetrics(ctx, deduped)
+	})
+	if err != nil {
 		p.recordExportError(ctx, "metrics", err)
 		log.Error("Failed to export %d buffered metrics to cloud: %v", metricCount, err)
+
+		// Re-buffer failed metrics so they can be retried on the next flush
+		// cycle. Cap the buffer to maxMetricBufCap to avoid unbounded growth.
+		p.metricBufMu.Lock()
+		p.metricBuf = append(p.metricBuf, deduped...)
+		if len(p.metricBuf) > maxMetricBufCap {
+			log.Error("Metric re-buffer exceeds cap (%d > %d), discarding oldest entries", len(p.metricBuf), maxMetricBufCap)
+			p.metricBuf = p.metricBuf[len(p.metricBuf)-maxMetricBufCap:]
+		}
+		p.metricBufMu.Unlock()
 		return
 	}
 	p.metricBufMu.Lock()
@@ -563,7 +588,10 @@ func (p *Pipeline) handleLogs(ctx context.Context, resourceLogs []*logspb.Resour
 
 	// Forward to cloud exporter if available
 	if p.exporter != nil {
-		if err := p.exporter.ExportProtoLogs(ctx, resourceLogs); err != nil {
+		err := retryExport(ctx, p.retryConfig, "logs", func() error {
+			return p.exporter.ExportProtoLogs(ctx, resourceLogs)
+		})
+		if err != nil {
 			p.recordExportError(ctx, "logs", err)
 			log.Error("Failed to export logs to cloud: %v", err)
 			return err

--- a/pkg/sciontool/telemetry/retry.go
+++ b/pkg/sciontool/telemetry/retry.go
@@ -85,14 +85,12 @@ func retryExport(ctx context.Context, cfg RetryConfig, signal string, fn func() 
 
 		log.Debug("Export %s retry %d/%d after %v (error: %v)", signal, attempt, cfg.MaxRetries, sleep, err)
 
-		// NOTE: time.After leaks its timer if the context is cancelled before
-		// it fires. With max backoff of 5s and 3 retries this is at most ~15s
-		// of leaked timers — negligible for this use case. If retryExport is
-		// ever promoted to a hot path, switch to time.NewTimer + t.Stop().
+		timer := time.NewTimer(sleep)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return ctx.Err()
-		case <-time.After(sleep):
+		case <-timer.C:
 		}
 
 		err = fn()

--- a/pkg/sciontool/telemetry/retry.go
+++ b/pkg/sciontool/telemetry/retry.go
@@ -55,14 +55,12 @@ func DefaultRetryConfig() RetryConfig {
 // classification. Auth errors are not retryable because they will not
 // self-heal without credential rotation.
 func isRetryable(err error) bool {
-	switch classifyError(err) {
-	case "auth":
+	if err == nil {
 		return false
-	case "timeout", "quota", "other":
-		return true
-	default:
-		return true
 	}
+	// Known retryable classes: timeout, quota, other (unknown).
+	// Only auth is explicitly non-retryable.
+	return classifyError(err) != "auth"
 }
 
 // retryExport retries fn with exponential backoff until it succeeds, a
@@ -87,6 +85,10 @@ func retryExport(ctx context.Context, cfg RetryConfig, signal string, fn func() 
 
 		log.Debug("Export %s retry %d/%d after %v (error: %v)", signal, attempt, cfg.MaxRetries, sleep, err)
 
+		// NOTE: time.After leaks its timer if the context is cancelled before
+		// it fires. With max backoff of 5s and 3 retries this is at most ~15s
+		// of leaked timers — negligible for this use case. If retryExport is
+		// ever promoted to a hot path, switch to time.NewTimer + t.Stop().
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/pkg/sciontool/telemetry/retry.go
+++ b/pkg/sciontool/telemetry/retry.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 The Scion Authors.
+*/
+
+package telemetry
+
+import (
+	"context"
+	"math"
+	"math/rand/v2"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/log"
+)
+
+// Default retry configuration constants.
+const (
+	defaultMaxRetries     = 3
+	defaultInitialBackoff = 100 * time.Millisecond
+	defaultMaxBackoff     = 5 * time.Second
+	defaultBackoffMult    = 2.0
+	defaultJitterMin      = 0.10
+	defaultJitterMax      = 0.20
+)
+
+// RetryConfig holds configuration for export retry behavior.
+type RetryConfig struct {
+	// MaxRetries is the maximum number of retry attempts after the initial call.
+	MaxRetries int
+	// InitialBackoff is the delay before the first retry.
+	InitialBackoff time.Duration
+	// MaxBackoff caps the backoff duration.
+	MaxBackoff time.Duration
+	// BackoffMultiplier scales the backoff after each attempt.
+	BackoffMultiplier float64
+	// JitterMin is the minimum jitter fraction (e.g. 0.10 for 10%).
+	JitterMin float64
+	// JitterMax is the maximum jitter fraction (e.g. 0.20 for 20%).
+	JitterMax float64
+}
+
+// DefaultRetryConfig returns the default retry configuration.
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxRetries:        defaultMaxRetries,
+		InitialBackoff:    defaultInitialBackoff,
+		MaxBackoff:        defaultMaxBackoff,
+		BackoffMultiplier: defaultBackoffMult,
+		JitterMin:         defaultJitterMin,
+		JitterMax:         defaultJitterMax,
+	}
+}
+
+// isRetryable reports whether the error should be retried based on its
+// classification. Auth errors are not retryable because they will not
+// self-heal without credential rotation.
+func isRetryable(err error) bool {
+	switch classifyError(err) {
+	case "auth":
+		return false
+	case "timeout", "quota", "other":
+		return true
+	default:
+		return true
+	}
+}
+
+// retryExport retries fn with exponential backoff until it succeeds, a
+// non-retryable error is encountered, retries are exhausted, or the context
+// is cancelled. It returns the last error when all retries are exhausted.
+func retryExport(ctx context.Context, cfg RetryConfig, signal string, fn func() error) error {
+	err := fn()
+	if err == nil {
+		return nil
+	}
+
+	if !isRetryable(err) {
+		log.Debug("Export %s failed with non-retryable error (%s): %v", signal, classifyError(err), err)
+		return err
+	}
+
+	backoff := cfg.InitialBackoff
+	for attempt := 1; attempt <= cfg.MaxRetries; attempt++ {
+		// Apply jitter: multiply backoff by (1 + random(jitterMin, jitterMax))
+		jitter := cfg.JitterMin + rand.Float64()*(cfg.JitterMax-cfg.JitterMin)
+		sleep := time.Duration(float64(backoff) * (1 + jitter))
+
+		log.Debug("Export %s retry %d/%d after %v (error: %v)", signal, attempt, cfg.MaxRetries, sleep, err)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(sleep):
+		}
+
+		err = fn()
+		if err == nil {
+			log.Debug("Export %s succeeded on retry %d", signal, attempt)
+			return nil
+		}
+
+		if !isRetryable(err) {
+			log.Debug("Export %s retry %d hit non-retryable error (%s): %v", signal, attempt, classifyError(err), err)
+			return err
+		}
+
+		// Increase backoff with multiplier, capped at MaxBackoff.
+		backoff = time.Duration(math.Min(
+			float64(backoff)*cfg.BackoffMultiplier,
+			float64(cfg.MaxBackoff),
+		))
+	}
+
+	return err
+}

--- a/pkg/sciontool/telemetry/retry_test.go
+++ b/pkg/sciontool/telemetry/retry_test.go
@@ -85,7 +85,7 @@ func TestIsRetryable(t *testing.T) {
 		err       error
 		retryable bool
 	}{
-		{"nil error", nil, true},
+		{"nil error", nil, false},
 		{"timeout error", context.DeadlineExceeded, true},
 		{"canceled error", context.Canceled, true},
 		{"auth 401 error", &googleapi.Error{Code: 401}, false},

--- a/pkg/sciontool/telemetry/retry_test.go
+++ b/pkg/sciontool/telemetry/retry_test.go
@@ -1,0 +1,500 @@
+/*
+Copyright 2026 The Scion Authors.
+*/
+
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc"
+
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	colmetricpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// --- Mock gRPC clients for testing ---
+
+type mockTraceClient struct {
+	exportFunc func(ctx context.Context, in *coltracepb.ExportTraceServiceRequest, opts ...grpc.CallOption) (*coltracepb.ExportTraceServiceResponse, error)
+}
+
+func (m *mockTraceClient) Export(ctx context.Context, in *coltracepb.ExportTraceServiceRequest, opts ...grpc.CallOption) (*coltracepb.ExportTraceServiceResponse, error) {
+	return m.exportFunc(ctx, in, opts...)
+}
+
+type mockLogClient struct {
+	exportFunc func(ctx context.Context, in *collogspb.ExportLogsServiceRequest, opts ...grpc.CallOption) (*collogspb.ExportLogsServiceResponse, error)
+}
+
+func (m *mockLogClient) Export(ctx context.Context, in *collogspb.ExportLogsServiceRequest, opts ...grpc.CallOption) (*collogspb.ExportLogsServiceResponse, error) {
+	return m.exportFunc(ctx, in, opts...)
+}
+
+type mockMetricClient struct {
+	exportFunc func(ctx context.Context, in *colmetricpb.ExportMetricsServiceRequest, opts ...grpc.CallOption) (*colmetricpb.ExportMetricsServiceResponse, error)
+}
+
+func (m *mockMetricClient) Export(ctx context.Context, in *colmetricpb.ExportMetricsServiceRequest, opts ...grpc.CallOption) (*colmetricpb.ExportMetricsServiceResponse, error) {
+	return m.exportFunc(ctx, in, opts...)
+}
+
+// newTestPipelineWithExporter creates a Pipeline with a CloudExporter backed
+// by mock gRPC clients for testing.
+func newTestPipelineWithExporter(
+	traceClient *mockTraceClient,
+	metricClient *mockMetricClient,
+	logClient *mockLogClient,
+) *Pipeline {
+	cfg := &Config{Enabled: true, GRPCPort: 0, HTTPPort: 0}
+	p := NewWithConfig(cfg)
+	p.exporter = &CloudExporter{
+		grpcClient:   traceClient,
+		metricClient: metricClient,
+		logClient:    logClient,
+	}
+	return p
+}
+
+// fastRetryConfig returns a retry config with minimal backoff for testing.
+func fastRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxRetries:        3,
+		InitialBackoff:    1 * time.Millisecond,
+		MaxBackoff:        10 * time.Millisecond,
+		BackoffMultiplier: 2.0,
+		JitterMin:         0.0,
+		JitterMax:         0.0,
+	}
+}
+
+// --- isRetryable tests ---
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{"nil error", nil, true},
+		{"timeout error", context.DeadlineExceeded, true},
+		{"canceled error", context.Canceled, true},
+		{"auth 401 error", &googleapi.Error{Code: 401}, false},
+		{"auth 403 error", &googleapi.Error{Code: 403}, false},
+		{"quota 429 error", &googleapi.Error{Code: 429}, true},
+		{"auth string match", errors.New("unauthenticated"), false},
+		{"permission denied string", errors.New("permission denied"), false},
+		{"quota string match", errors.New("resource exhausted"), true},
+		{"timeout string match", errors.New("deadline exceeded"), true},
+		{"generic error", errors.New("something went wrong"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRetryable(tt.err)
+			if got != tt.retryable {
+				t.Errorf("isRetryable(%v) = %v, want %v", tt.err, got, tt.retryable)
+			}
+		})
+	}
+}
+
+// --- retryExport tests ---
+
+func TestRetryExport_SuccessOnFirstCall(t *testing.T) {
+	calls := 0
+	err := retryExport(context.Background(), fastRetryConfig(), "test", func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestRetryExport_SuccessAfterRetries(t *testing.T) {
+	calls := 0
+	err := retryExport(context.Background(), fastRetryConfig(), "test", func() error {
+		calls++
+		if calls < 3 {
+			return context.DeadlineExceeded // retryable
+		}
+		return nil
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestRetryExport_ExhaustRetries(t *testing.T) {
+	calls := 0
+	retryErr := errors.New("persistent failure")
+	err := retryExport(context.Background(), fastRetryConfig(), "test", func() error {
+		calls++
+		return retryErr
+	})
+	if err == nil {
+		t.Error("expected error after exhausting retries")
+	}
+	// 1 initial + 3 retries = 4 calls
+	if calls != 4 {
+		t.Errorf("expected 4 calls (1 initial + 3 retries), got %d", calls)
+	}
+}
+
+func TestRetryExport_NonRetryableError(t *testing.T) {
+	calls := 0
+	authErr := &googleapi.Error{Code: 403, Message: "forbidden"}
+	err := retryExport(context.Background(), fastRetryConfig(), "test", func() error {
+		calls++
+		return authErr
+	})
+	if err == nil {
+		t.Error("expected error for non-retryable failure")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call (no retry for auth error), got %d", calls)
+	}
+}
+
+func TestRetryExport_NonRetryableAfterRetries(t *testing.T) {
+	calls := 0
+	authErr := &googleapi.Error{Code: 401, Message: "unauthorized"}
+	err := retryExport(context.Background(), fastRetryConfig(), "test", func() error {
+		calls++
+		if calls == 1 {
+			return context.DeadlineExceeded // first call: retryable
+		}
+		return authErr // second call: non-retryable
+	})
+	if err == nil {
+		t.Error("expected error")
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls, got %d", calls)
+	}
+}
+
+func TestRetryExport_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	err := retryExport(ctx, fastRetryConfig(), "test", func() error {
+		calls++
+		cancel() // cancel after first attempt
+		return errors.New("transient")
+	})
+	if err == nil {
+		t.Error("expected error when context cancelled")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call before context cancellation, got %d", calls)
+	}
+}
+
+func TestRetryExport_BackoffTiming(t *testing.T) {
+	cfg := RetryConfig{
+		MaxRetries:        2,
+		InitialBackoff:    20 * time.Millisecond,
+		MaxBackoff:        1 * time.Second,
+		BackoffMultiplier: 2.0,
+		JitterMin:         0.0,
+		JitterMax:         0.0,
+	}
+	start := time.Now()
+	calls := 0
+	_ = retryExport(context.Background(), cfg, "test", func() error {
+		calls++
+		return errors.New("fail")
+	})
+	elapsed := time.Since(start)
+
+	// With 0 jitter: 20ms + 40ms = 60ms minimum
+	if elapsed < 50*time.Millisecond {
+		t.Errorf("backoff too fast: %v (expected >= 60ms)", elapsed)
+	}
+	// Sanity upper bound: shouldn't take more than 500ms
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("backoff too slow: %v", elapsed)
+	}
+}
+
+func TestRetryExport_MaxBackoffCap(t *testing.T) {
+	cfg := RetryConfig{
+		MaxRetries:        3,
+		InitialBackoff:    50 * time.Millisecond,
+		MaxBackoff:        60 * time.Millisecond,
+		BackoffMultiplier: 10.0, // aggressive multiplier
+		JitterMin:         0.0,
+		JitterMax:         0.0,
+	}
+	start := time.Now()
+	_ = retryExport(context.Background(), cfg, "test", func() error {
+		return errors.New("fail")
+	})
+	elapsed := time.Since(start)
+
+	// Without cap: 50 + 500 + 5000 = 5550ms
+	// With cap at 60ms: 50 + 60 + 60 = 170ms
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("max backoff cap not applied: %v", elapsed)
+	}
+}
+
+func TestRetryExport_NoOverheadOnSuccess(t *testing.T) {
+	start := time.Now()
+	err := retryExport(context.Background(), DefaultRetryConfig(), "test", func() error {
+		return nil
+	})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Should complete nearly instantly (well under 10ms) on success
+	if elapsed > 10*time.Millisecond {
+		t.Errorf("unexpected overhead on success: %v", elapsed)
+	}
+}
+
+// --- Handler-level retry tests ---
+
+func TestHandleSpans_RetriesOnTransientError(t *testing.T) {
+	calls := 0
+	traceClient := &mockTraceClient{
+		exportFunc: func(_ context.Context, _ *coltracepb.ExportTraceServiceRequest, _ ...grpc.CallOption) (*coltracepb.ExportTraceServiceResponse, error) {
+			calls++
+			if calls < 3 {
+				return nil, context.DeadlineExceeded
+			}
+			return &coltracepb.ExportTraceServiceResponse{}, nil
+		},
+	}
+
+	p := newTestPipelineWithExporter(traceClient, nil, nil)
+	p.retryConfig = fastRetryConfig()
+
+	err := p.handleSpans(context.Background(), []*tracepb.ResourceSpans{
+		{ScopeSpans: []*tracepb.ScopeSpans{{Spans: []*tracepb.Span{{Name: "test"}}}}},
+	})
+	if err != nil {
+		t.Errorf("expected success after retries, got: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 export calls, got %d", calls)
+	}
+}
+
+func TestHandleSpans_NoRetryOnAuthError(t *testing.T) {
+	calls := 0
+	traceClient := &mockTraceClient{
+		exportFunc: func(_ context.Context, _ *coltracepb.ExportTraceServiceRequest, _ ...grpc.CallOption) (*coltracepb.ExportTraceServiceResponse, error) {
+			calls++
+			return nil, &googleapi.Error{Code: 403, Message: "forbidden"}
+		},
+	}
+
+	p := newTestPipelineWithExporter(traceClient, nil, nil)
+	p.retryConfig = fastRetryConfig()
+
+	err := p.handleSpans(context.Background(), []*tracepb.ResourceSpans{
+		{ScopeSpans: []*tracepb.ScopeSpans{{Spans: []*tracepb.Span{{Name: "test"}}}}},
+	})
+	if err == nil {
+		t.Error("expected auth error")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call (no retry for auth), got %d", calls)
+	}
+}
+
+func TestHandleLogs_RetriesOnTransientError(t *testing.T) {
+	calls := 0
+	logClient := &mockLogClient{
+		exportFunc: func(_ context.Context, _ *collogspb.ExportLogsServiceRequest, _ ...grpc.CallOption) (*collogspb.ExportLogsServiceResponse, error) {
+			calls++
+			if calls < 2 {
+				return nil, errors.New("resource exhausted")
+			}
+			return &collogspb.ExportLogsServiceResponse{}, nil
+		},
+	}
+
+	p := newTestPipelineWithExporter(nil, nil, logClient)
+	p.retryConfig = fastRetryConfig()
+
+	err := p.handleLogs(context.Background(), []*logspb.ResourceLogs{
+		{ScopeLogs: []*logspb.ScopeLogs{{LogRecords: []*logspb.LogRecord{{}}}}},
+	})
+	if err != nil {
+		t.Errorf("expected success after retries, got: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 export calls, got %d", calls)
+	}
+}
+
+func TestHandleLogs_NoRetryOnAuthError(t *testing.T) {
+	calls := 0
+	logClient := &mockLogClient{
+		exportFunc: func(_ context.Context, _ *collogspb.ExportLogsServiceRequest, _ ...grpc.CallOption) (*collogspb.ExportLogsServiceResponse, error) {
+			calls++
+			return nil, errors.New("permission denied")
+		},
+	}
+
+	p := newTestPipelineWithExporter(nil, nil, logClient)
+	p.retryConfig = fastRetryConfig()
+
+	err := p.handleLogs(context.Background(), []*logspb.ResourceLogs{
+		{ScopeLogs: []*logspb.ScopeLogs{{LogRecords: []*logspb.LogRecord{{}}}}},
+	})
+	if err == nil {
+		t.Error("expected auth error")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call (no retry for auth), got %d", calls)
+	}
+}
+
+// --- Metric re-buffer tests ---
+
+func TestFlushMetricBuffer_RebufferOnExhaustion(t *testing.T) {
+	metricClient := &mockMetricClient{
+		exportFunc: func(_ context.Context, _ *colmetricpb.ExportMetricsServiceRequest, _ ...grpc.CallOption) (*colmetricpb.ExportMetricsServiceResponse, error) {
+			return nil, errors.New("temporary failure")
+		},
+	}
+
+	p := newTestPipelineWithExporter(nil, metricClient, nil)
+	p.retryConfig = fastRetryConfig()
+
+	// Add metrics to buffer
+	testMetrics := []*metricpb.ResourceMetrics{
+		{ScopeMetrics: []*metricpb.ScopeMetrics{{Metrics: []*metricpb.Metric{{Name: "test.metric"}}}}},
+	}
+	p.metricBuf = testMetrics
+
+	// Flush (should fail and re-buffer)
+	p.flushMetricBuffer(context.Background(), true)
+
+	p.metricBufMu.Lock()
+	bufLen := len(p.metricBuf)
+	p.metricBufMu.Unlock()
+
+	if bufLen == 0 {
+		t.Error("expected metrics to be re-buffered after export failure")
+	}
+}
+
+func TestFlushMetricBuffer_RebufferCapped(t *testing.T) {
+	metricClient := &mockMetricClient{
+		exportFunc: func(_ context.Context, _ *colmetricpb.ExportMetricsServiceRequest, _ ...grpc.CallOption) (*colmetricpb.ExportMetricsServiceResponse, error) {
+			return nil, errors.New("temporary failure")
+		},
+	}
+
+	p := newTestPipelineWithExporter(nil, metricClient, nil)
+	p.retryConfig = fastRetryConfig()
+
+	// Pre-fill the buffer with maxMetricBufCap entries to simulate accumulation
+	existing := make([]*metricpb.ResourceMetrics, maxMetricBufCap)
+	for i := range existing {
+		existing[i] = &metricpb.ResourceMetrics{
+			ScopeMetrics: []*metricpb.ScopeMetrics{{
+				Metrics: []*metricpb.Metric{{Name: fmt.Sprintf("existing.%d", i)}},
+			}},
+		}
+	}
+	// Put some of these in the buffer to be flushed, rest stay
+	p.metricBuf = existing[:maxMetricBufCap-10]
+
+	// Flush — these will fail and be re-buffered
+	p.flushMetricBuffer(context.Background(), true)
+
+	p.metricBufMu.Lock()
+	bufLen := len(p.metricBuf)
+	p.metricBufMu.Unlock()
+
+	if bufLen > maxMetricBufCap {
+		t.Errorf("re-buffer exceeded cap: got %d, max %d", bufLen, maxMetricBufCap)
+	}
+}
+
+func TestFlushMetricBuffer_SuccessfulExport(t *testing.T) {
+	exported := false
+	metricClient := &mockMetricClient{
+		exportFunc: func(_ context.Context, _ *colmetricpb.ExportMetricsServiceRequest, _ ...grpc.CallOption) (*colmetricpb.ExportMetricsServiceResponse, error) {
+			exported = true
+			return &colmetricpb.ExportMetricsServiceResponse{}, nil
+		},
+	}
+
+	p := newTestPipelineWithExporter(nil, metricClient, nil)
+	p.retryConfig = fastRetryConfig()
+
+	p.metricBuf = []*metricpb.ResourceMetrics{
+		{ScopeMetrics: []*metricpb.ScopeMetrics{{Metrics: []*metricpb.Metric{{Name: "test"}}}}},
+	}
+
+	p.flushMetricBuffer(context.Background(), true)
+
+	if !exported {
+		t.Error("expected metrics to be exported")
+	}
+
+	p.metricBufMu.Lock()
+	bufLen := len(p.metricBuf)
+	p.metricBufMu.Unlock()
+
+	if bufLen != 0 {
+		t.Errorf("expected empty buffer after successful export, got %d", bufLen)
+	}
+}
+
+func TestFlushMetricBuffer_SuccessAfterRetry(t *testing.T) {
+	calls := 0
+	metricClient := &mockMetricClient{
+		exportFunc: func(_ context.Context, _ *colmetricpb.ExportMetricsServiceRequest, _ ...grpc.CallOption) (*colmetricpb.ExportMetricsServiceResponse, error) {
+			calls++
+			if calls < 2 {
+				return nil, context.DeadlineExceeded
+			}
+			return &colmetricpb.ExportMetricsServiceResponse{}, nil
+		},
+	}
+
+	p := newTestPipelineWithExporter(nil, metricClient, nil)
+	p.retryConfig = fastRetryConfig()
+
+	p.metricBuf = []*metricpb.ResourceMetrics{
+		{ScopeMetrics: []*metricpb.ScopeMetrics{{Metrics: []*metricpb.Metric{{Name: "test"}}}}},
+	}
+
+	p.flushMetricBuffer(context.Background(), true)
+
+	p.metricBufMu.Lock()
+	bufLen := len(p.metricBuf)
+	p.metricBufMu.Unlock()
+
+	if bufLen != 0 {
+		t.Errorf("expected empty buffer after successful retry, got %d", bufLen)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 export calls, got %d", calls)
+	}
+}

--- a/pkg/sciontool/telemetry/retry_test.go
+++ b/pkg/sciontool/telemetry/retry_test.go
@@ -17,6 +17,7 @@ import (
 	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	colmetricpb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
 	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
@@ -402,28 +403,48 @@ func TestFlushMetricBuffer_RebufferOnExhaustion(t *testing.T) {
 }
 
 func TestFlushMetricBuffer_RebufferCapped(t *testing.T) {
+	// makeDistinct creates n ResourceMetrics with unique scope+metric names
+	// so deduplicateMetrics does not collapse them.
+	makeDistinct := func(n int, prefix string) []*metricpb.ResourceMetrics {
+		out := make([]*metricpb.ResourceMetrics, n)
+		for i := range out {
+			out[i] = &metricpb.ResourceMetrics{
+				ScopeMetrics: []*metricpb.ScopeMetrics{{
+					Scope:   &commonpb.InstrumentationScope{Name: fmt.Sprintf("%s.scope.%d", prefix, i)},
+					Metrics: []*metricpb.Metric{{Name: fmt.Sprintf("%s.metric.%d", prefix, i)}},
+				}},
+			}
+		}
+		return out
+	}
+
+	// The mock export function simulates concurrent handleMetrics calls
+	// flooding the buffer during the retry window. flushMetricBuffer sets
+	// metricBuf = nil before calling the exporter, so entries added here
+	// accumulate in the buffer while the export retries. After retries
+	// exhaust, the re-buffer appends deduped data on top of these entries.
+	var p *Pipeline
 	metricClient := &mockMetricClient{
 		exportFunc: func(_ context.Context, _ *colmetricpb.ExportMetricsServiceRequest, _ ...grpc.CallOption) (*colmetricpb.ExportMetricsServiceResponse, error) {
+			// Simulate concurrent handleMetrics adding entries during retry.
+			p.metricBufMu.Lock()
+			p.metricBuf = append(p.metricBuf, makeDistinct(maxMetricBufCap/2, "concurrent")...)
+			p.metricBufMu.Unlock()
 			return nil, errors.New("temporary failure")
 		},
 	}
 
-	p := newTestPipelineWithExporter(nil, metricClient, nil)
+	p = newTestPipelineWithExporter(nil, metricClient, nil)
 	p.retryConfig = fastRetryConfig()
 
-	// Pre-fill the buffer with maxMetricBufCap entries to simulate accumulation
-	existing := make([]*metricpb.ResourceMetrics, maxMetricBufCap)
-	for i := range existing {
-		existing[i] = &metricpb.ResourceMetrics{
-			ScopeMetrics: []*metricpb.ScopeMetrics{{
-				Metrics: []*metricpb.Metric{{Name: fmt.Sprintf("existing.%d", i)}},
-			}},
-		}
-	}
-	// Put some of these in the buffer to be flushed, rest stay
-	p.metricBuf = existing[:maxMetricBufCap-10]
+	// Seed the buffer with one batch.
+	p.metricBuf = makeDistinct(10, "initial")
 
-	// Flush — these will fail and be re-buffered
+	// Flush — export fails on every attempt. Each attempt adds
+	// maxMetricBufCap/2 entries to the buffer (simulating concurrent
+	// handleMetrics calls). After 4 attempts (1 + 3 retries) the buffer
+	// holds 4*(maxMetricBufCap/2) = 2*maxMetricBufCap entries, plus the
+	// re-buffered deduped batch. The cap should trim it.
 	p.flushMetricBuffer(context.Background(), true)
 
 	p.metricBufMu.Lock()
@@ -432,6 +453,9 @@ func TestFlushMetricBuffer_RebufferCapped(t *testing.T) {
 
 	if bufLen > maxMetricBufCap {
 		t.Errorf("re-buffer exceeded cap: got %d, max %d", bufLen, maxMetricBufCap)
+	}
+	if bufLen == 0 {
+		t.Error("expected re-buffered metrics, got empty buffer")
 	}
 }
 


### PR DESCRIPTION
Adds retryExport helper with exponential backoff (100ms initial, 5s max, 3 retries, jitter) to handleSpans, handleLogs, and flushMetricBuffer in the sciontool telemetry pipeline receiver.

Key changes:
- retryExport() helper with configurable backoff and jitter
- Auth errors short-circuit (no retry on permanent failures)
- Failed metrics re-buffered with cap at 100 entries
- loggingExporter wrapper on hub MeterProvider for export error visibility
- 22 new tests

Addresses ptone/scion#242