### PR TITLE
feat(hub): add session metrics API endpoints and web UI

### DIFF
--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -1538,6 +1538,12 @@ func (s *Server) handleAgentByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Handle agent session metrics summary (GET /api/v1/agents/{id}/metrics/summary)
+	if action == "metrics/summary" {
+		s.handleAgentMetricsSummary(w, r, id)
+		return
+	}
+
 	// Handle actions
 	if action != "" {
 		s.handleAgentAction(w, r, id, action)

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -1448,6 +1448,12 @@ func (s *Server) handleProjectRoutes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check for nested /metrics/summary path (DB-backed session metrics summary)
+	if subPath == "metrics/summary" {
+		s.handleProjectSessionMetricsSummary(w, r, projectID)
+		return
+	}
+
 	// Check for nested /metrics path (project-scoped metrics dashboard)
 	if subPath == "metrics" || strings.HasPrefix(subPath, "metrics/") {
 		metricsPath := strings.TrimPrefix(subPath, "metrics")

--- a/pkg/hub/handlers_session_metrics.go
+++ b/pkg/hub/handlers_session_metrics.go
@@ -1,0 +1,361 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// =============================================================================
+// Response types for session metrics API
+// =============================================================================
+
+// toolUsageSummary summarises call statistics for a single tool.
+type toolUsageSummary struct {
+	Name    string `json:"name"`
+	Calls   int    `json:"calls"`
+	Success int    `json:"success"`
+	Errors  int    `json:"errors"`
+}
+
+// modelUsageSummary counts sessions per model.
+type modelUsageSummary struct {
+	Model    string `json:"model"`
+	Sessions int    `json:"sessions"`
+}
+
+// agentMetricsSummaryResponse is returned by the agent metrics summary endpoint.
+type agentMetricsSummaryResponse struct {
+	AgentID             string             `json:"agentId"`
+	TotalSessions       int                `json:"totalSessions"`
+	TotalTokensInput    int64              `json:"totalTokensInput"`
+	TotalTokensOutput   int64              `json:"totalTokensOutput"`
+	TotalTokensCached   int64              `json:"totalTokensCached"`
+	TotalTokensReasoning int64             `json:"totalTokensReasoning"`
+	TotalToolCalls      int                `json:"totalToolCalls"`
+	AvgSessionDurationMs int64             `json:"avgSessionDurationMs"`
+	AvgTokensPerSession int64              `json:"avgTokensPerSession"`
+	MostUsedTools       []toolUsageSummary `json:"mostUsedTools"`
+	MostUsedModels      []modelUsageSummary `json:"mostUsedModels"`
+}
+
+// projectMetricsSummaryResponse is returned by the project metrics summary endpoint.
+type projectMetricsSummaryResponse struct {
+	ProjectID            string             `json:"projectId"`
+	TotalSessions        int                `json:"totalSessions"`
+	TotalTokensInput     int64              `json:"totalTokensInput"`
+	TotalTokensOutput    int64              `json:"totalTokensOutput"`
+	TotalTokensCached    int64              `json:"totalTokensCached"`
+	TotalTokensReasoning int64              `json:"totalTokensReasoning"`
+	ActiveAgents         int                `json:"activeAgents"`
+	MostUsedTools        []toolUsageSummary `json:"mostUsedTools"`
+	MostUsedModels       []modelUsageSummary `json:"mostUsedModels"`
+}
+
+// =============================================================================
+// Aggregation helpers
+// =============================================================================
+
+// aggregateToolCalls extracts tool usage statistics from session metrics records.
+func aggregateToolCalls(sessions []*store.AgentSessionMetrics) (tools []toolUsageSummary, totalCalls int) {
+	toolMap := make(map[string]*toolUsageSummary)
+	for _, s := range sessions {
+		for name, raw := range s.ToolCalls {
+			ts, ok := toolMap[name]
+			if !ok {
+				ts = &toolUsageSummary{Name: name}
+				toolMap[name] = ts
+			}
+			if m, ok := raw.(map[string]interface{}); ok {
+				calls := intFromAny(m["calls"])
+				success := intFromAny(m["success"])
+				errs := intFromAny(m["error"])
+				ts.Calls += calls
+				ts.Success += success
+				ts.Errors += errs
+				totalCalls += calls
+			}
+		}
+	}
+
+	tools = make([]toolUsageSummary, 0, len(toolMap))
+	for _, t := range toolMap {
+		tools = append(tools, *t)
+	}
+	sort.Slice(tools, func(i, j int) bool {
+		return tools[i].Calls > tools[j].Calls
+	})
+	if len(tools) > 10 {
+		tools = tools[:10]
+	}
+	return tools, totalCalls
+}
+
+// aggregateModels counts sessions per model.
+func aggregateModels(sessions []*store.AgentSessionMetrics) []modelUsageSummary {
+	counts := make(map[string]int)
+	for _, s := range sessions {
+		if s.Model != "" {
+			counts[s.Model]++
+		}
+	}
+
+	models := make([]modelUsageSummary, 0, len(counts))
+	for m, c := range counts {
+		models = append(models, modelUsageSummary{Model: m, Sessions: c})
+	}
+	sort.Slice(models, func(i, j int) bool {
+		return models[i].Sessions > models[j].Sessions
+	})
+	if len(models) > 10 {
+		models = models[:10]
+	}
+	return models
+}
+
+// avgSessionDuration computes the average session duration in milliseconds.
+func avgSessionDuration(sessions []*store.AgentSessionMetrics) int64 {
+	if len(sessions) == 0 {
+		return 0
+	}
+	var total time.Duration
+	var count int
+	for _, s := range sessions {
+		if s.EndedAt != nil {
+			total += s.EndedAt.Sub(s.StartedAt)
+			count++
+		}
+	}
+	if count == 0 {
+		return 0
+	}
+	return total.Milliseconds() / int64(count)
+}
+
+// intFromAny extracts an int from an interface{} that may be a float64 (JSON
+// numbers) or an int.
+func intFromAny(v interface{}) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	case int64:
+		return int(n)
+	default:
+		return 0
+	}
+}
+
+// =============================================================================
+// Handlers
+// =============================================================================
+
+// handleAgentMetricsSummary returns aggregate session metrics for an agent.
+// GET /api/v1/agents/{id}/metrics/summary
+func (s *Server) handleAgentMetricsSummary(w http.ResponseWriter, r *http.Request, agentID string) {
+	ctx := r.Context()
+
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	// Require user authentication.
+	userIdent := GetUserIdentityFromContext(ctx)
+	if userIdent == nil {
+		Unauthorized(w)
+		return
+	}
+
+	// Verify the agent exists and the user can view it.
+	agent, err := s.store.GetAgent(ctx, agentID)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), ActionRead)
+	if !decision.Allowed {
+		Forbidden(w)
+		return
+	}
+
+	// Fetch all session metrics for this agent.
+	sessions, err := s.store.ListAgentSessionMetricsByAgent(ctx, agentID)
+	if err != nil {
+		s.agentMetricsLog.Error("Failed to list session metrics for agent",
+			"agent_id", agentID, "error", err)
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Aggregate.
+	var totalInput, totalOutput, totalCached, totalReasoning int64
+	for _, sess := range sessions {
+		totalInput += sess.TokensInput
+		totalOutput += sess.TokensOutput
+		totalCached += sess.TokensCached
+		totalReasoning += sess.TokensReasoning
+	}
+
+	tools, totalToolCalls := aggregateToolCalls(sessions)
+	models := aggregateModels(sessions)
+	avgDuration := avgSessionDuration(sessions)
+
+	totalTokens := totalInput + totalOutput
+	var avgTokens int64
+	if len(sessions) > 0 {
+		avgTokens = totalTokens / int64(len(sessions))
+	}
+
+	resp := agentMetricsSummaryResponse{
+		AgentID:              agentID,
+		TotalSessions:        len(sessions),
+		TotalTokensInput:     totalInput,
+		TotalTokensOutput:    totalOutput,
+		TotalTokensCached:    totalCached,
+		TotalTokensReasoning: totalReasoning,
+		TotalToolCalls:       totalToolCalls,
+		AvgSessionDurationMs: avgDuration,
+		AvgTokensPerSession:  avgTokens,
+		MostUsedTools:        tools,
+		MostUsedModels:       models,
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleSessionMetrics returns a single session metrics record by ID.
+// GET /api/v1/metrics/session/{id}
+func (s *Server) handleSessionMetrics(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	// Require user authentication.
+	userIdent := GetUserIdentityFromContext(ctx)
+	if userIdent == nil {
+		Unauthorized(w)
+		return
+	}
+
+	id := extractID(r, "/api/v1/metrics/session")
+	if id == "" {
+		NotFound(w, "Session metrics")
+		return
+	}
+
+	metrics, err := s.store.GetAgentSessionMetrics(ctx, id)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, metrics)
+}
+
+// handleProjectSessionMetricsSummary returns aggregate session metrics for a project.
+// GET /api/v1/projects/{id}/metrics/summary
+func (s *Server) handleProjectSessionMetricsSummary(w http.ResponseWriter, r *http.Request, projectID string) {
+	ctx := r.Context()
+
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	// Verify the project exists.
+	project, err := s.store.GetProject(ctx, projectID)
+	if err != nil {
+		if err == store.ErrNotFound {
+			NotFound(w, "Project")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Authorize: any authenticated user with view access.
+	identity := GetIdentityFromContext(ctx)
+	if identity == nil {
+		Unauthorized(w)
+		return
+	}
+
+	if userIdent, ok := identity.(UserIdentity); ok {
+		decision := s.authzService.CheckAccess(ctx, userIdent, Resource{
+			Type:    "project",
+			ID:      project.ID,
+			OwnerID: project.OwnerID,
+		}, ActionRead)
+		if !decision.Allowed {
+			Forbidden(w)
+			return
+		}
+	} else if agentIdent, ok := identity.(AgentIdentity); ok {
+		if agentIdent.ProjectID() != projectID {
+			Forbidden(w)
+			return
+		}
+	} else {
+		Forbidden(w)
+		return
+	}
+
+	// Fetch all session metrics for this project.
+	sessions, err := s.store.ListAgentSessionMetricsByProject(ctx, projectID)
+	if err != nil {
+		s.agentMetricsLog.Error("Failed to list session metrics for project",
+			"project_id", projectID, "error", err)
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Aggregate.
+	var totalInput, totalOutput, totalCached, totalReasoning int64
+	activeAgentSet := make(map[string]struct{})
+	for _, sess := range sessions {
+		totalInput += sess.TokensInput
+		totalOutput += sess.TokensOutput
+		totalCached += sess.TokensCached
+		totalReasoning += sess.TokensReasoning
+		activeAgentSet[sess.AgentID] = struct{}{}
+	}
+
+	tools, _ := aggregateToolCalls(sessions)
+	models := aggregateModels(sessions)
+
+	resp := projectMetricsSummaryResponse{
+		ProjectID:            projectID,
+		TotalSessions:        len(sessions),
+		TotalTokensInput:     totalInput,
+		TotalTokensOutput:    totalOutput,
+		TotalTokensCached:    totalCached,
+		TotalTokensReasoning: totalReasoning,
+		ActiveAgents:         len(activeAgentSet),
+		MostUsedTools:        tools,
+		MostUsedModels:       models,
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/pkg/hub/handlers_session_metrics.go
+++ b/pkg/hub/handlers_session_metrics.go
@@ -233,7 +233,11 @@ func (s *Server) handleAgentMetricsSummary(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// List queries for tool/model breakdowns and avg duration (capped).
+	// Tool/model breakdowns and avg duration are derived from the most recent
+	// sessions returned by the list query, which is capped at 100 records
+	// (defaultMetricsListLimit). For agents with >100 sessions these values
+	// reflect only the newest subset — acceptable for MVP. A future iteration
+	// could push tool/model aggregation and AVG(duration) into SQL.
 	sessions, err := s.store.ListAgentSessionMetricsByAgent(ctx, agentID)
 	if err != nil {
 		s.agentMetricsLog.Error("Failed to list session metrics for agent",
@@ -372,7 +376,11 @@ func (s *Server) handleProjectSessionMetricsSummary(w http.ResponseWriter, r *ht
 		return
 	}
 
-	// List queries for tool/model breakdowns (capped).
+	// Tool/model breakdowns are derived from the most recent sessions returned
+	// by the list query, which is capped at 100 records (defaultMetricsListLimit).
+	// For projects with >100 sessions these values reflect only the newest
+	// subset — acceptable for MVP. A future iteration could push tool/model
+	// aggregation into SQL.
 	sessions, err := s.store.ListAgentSessionMetricsByProject(ctx, projectID)
 	if err != nil {
 		s.agentMetricsLog.Error("Failed to list session metrics for project",

--- a/pkg/hub/handlers_session_metrics.go
+++ b/pkg/hub/handlers_session_metrics.go
@@ -76,6 +76,9 @@ type projectMetricsSummaryResponse struct {
 func aggregateToolCalls(sessions []*store.AgentSessionMetrics) (tools []toolUsageSummary, totalCalls int) {
 	toolMap := make(map[string]*toolUsageSummary)
 	for _, s := range sessions {
+		if s == nil {
+			continue
+		}
 		for name, raw := range s.ToolCalls {
 			ts, ok := toolMap[name]
 			if !ok {
@@ -111,6 +114,9 @@ func aggregateToolCalls(sessions []*store.AgentSessionMetrics) (tools []toolUsag
 func aggregateModels(sessions []*store.AgentSessionMetrics) []modelUsageSummary {
 	counts := make(map[string]int)
 	for _, s := range sessions {
+		if s == nil {
+			continue
+		}
 		if s.Model != "" {
 			counts[s.Model]++
 		}
@@ -137,6 +143,9 @@ func avgSessionDuration(sessions []*store.AgentSessionMetrics) int64 {
 	var total time.Duration
 	var count int
 	for _, s := range sessions {
+		if s == nil {
+			continue
+		}
 		if s.EndedAt != nil {
 			total += s.EndedAt.Sub(s.StartedAt)
 			count++
@@ -171,6 +180,10 @@ func intFromAny(v interface{}) int {
 // agent) is allowed to read the given agent resource. Returns true if
 // access is allowed, false if a response was already written.
 func (s *Server) authorizeSessionMetricsAccess(w http.ResponseWriter, r *http.Request, agent *store.Agent) bool {
+	if agent == nil {
+		NotFound(w, "Agent")
+		return false
+	}
 	ctx := r.Context()
 	identity := GetIdentityFromContext(ctx)
 	if identity == nil {
@@ -292,6 +305,10 @@ func (s *Server) handleSessionMetrics(w http.ResponseWriter, r *http.Request) {
 	metrics, err := s.store.GetAgentSessionMetrics(ctx, id)
 	if err != nil {
 		writeErrorFromErr(w, err, "")
+		return
+	}
+	if metrics == nil {
+		NotFound(w, "Session metrics")
 		return
 	}
 

--- a/pkg/hub/handlers_session_metrics.go
+++ b/pkg/hub/handlers_session_metrics.go
@@ -31,7 +31,7 @@ type toolUsageSummary struct {
 	Name    string `json:"name"`
 	Calls   int    `json:"calls"`
 	Success int    `json:"success"`
-	Errors  int    `json:"errors"`
+	Error   int    `json:"error"`
 }
 
 // modelUsageSummary counts sessions per model.
@@ -42,34 +42,34 @@ type modelUsageSummary struct {
 
 // agentMetricsSummaryResponse is returned by the agent metrics summary endpoint.
 type agentMetricsSummaryResponse struct {
-	AgentID             string             `json:"agentId"`
-	TotalSessions       int                `json:"totalSessions"`
-	TotalTokensInput    int64              `json:"totalTokensInput"`
-	TotalTokensOutput   int64              `json:"totalTokensOutput"`
-	TotalTokensCached   int64              `json:"totalTokensCached"`
-	TotalTokensReasoning int64             `json:"totalTokensReasoning"`
-	TotalToolCalls      int                `json:"totalToolCalls"`
-	AvgSessionDurationMs int64             `json:"avgSessionDurationMs"`
-	AvgTokensPerSession int64              `json:"avgTokensPerSession"`
-	MostUsedTools       []toolUsageSummary `json:"mostUsedTools"`
-	MostUsedModels      []modelUsageSummary `json:"mostUsedModels"`
+	AgentID              string              `json:"agentId"`
+	TotalSessions        int                 `json:"totalSessions"`
+	TotalTokensInput     int64               `json:"totalTokensInput"`
+	TotalTokensOutput    int64               `json:"totalTokensOutput"`
+	TotalTokensCached    int64               `json:"totalTokensCached"`
+	TotalTokensReasoning int64               `json:"totalTokensReasoning"`
+	TotalToolCalls       int                 `json:"totalToolCalls"`
+	AvgSessionDurationMs int64               `json:"avgSessionDurationMs"`
+	AvgTokensPerSession  int64               `json:"avgTokensPerSession"`
+	MostUsedTools        []toolUsageSummary  `json:"mostUsedTools"`
+	MostUsedModels       []modelUsageSummary `json:"mostUsedModels"`
 }
 
 // projectMetricsSummaryResponse is returned by the project metrics summary endpoint.
 type projectMetricsSummaryResponse struct {
-	ProjectID            string             `json:"projectId"`
-	TotalSessions        int                `json:"totalSessions"`
-	TotalTokensInput     int64              `json:"totalTokensInput"`
-	TotalTokensOutput    int64              `json:"totalTokensOutput"`
-	TotalTokensCached    int64              `json:"totalTokensCached"`
-	TotalTokensReasoning int64              `json:"totalTokensReasoning"`
-	ActiveAgents         int                `json:"activeAgents"`
-	MostUsedTools        []toolUsageSummary `json:"mostUsedTools"`
+	ProjectID            string              `json:"projectId"`
+	TotalSessions        int                 `json:"totalSessions"`
+	TotalTokensInput     int64               `json:"totalTokensInput"`
+	TotalTokensOutput    int64               `json:"totalTokensOutput"`
+	TotalTokensCached    int64               `json:"totalTokensCached"`
+	TotalTokensReasoning int64               `json:"totalTokensReasoning"`
+	ActiveAgents         int                 `json:"activeAgents"`
+	MostUsedTools        []toolUsageSummary  `json:"mostUsedTools"`
 	MostUsedModels       []modelUsageSummary `json:"mostUsedModels"`
 }
 
 // =============================================================================
-// Aggregation helpers
+// Aggregation helpers (tool/model breakdowns from list queries)
 // =============================================================================
 
 // aggregateToolCalls extracts tool usage statistics from session metrics records.
@@ -88,7 +88,7 @@ func aggregateToolCalls(sessions []*store.AgentSessionMetrics) (tools []toolUsag
 				errs := intFromAny(m["error"])
 				ts.Calls += calls
 				ts.Success += success
-				ts.Errors += errs
+				ts.Error += errs
 				totalCalls += calls
 			}
 		}
@@ -164,10 +164,47 @@ func intFromAny(v interface{}) int {
 }
 
 // =============================================================================
+// Authorization helpers
+// =============================================================================
+
+// authorizeSessionMetricsAccess checks that the calling identity (user or
+// agent) is allowed to read the given agent resource. Returns true if
+// access is allowed, false if a response was already written.
+func (s *Server) authorizeSessionMetricsAccess(w http.ResponseWriter, r *http.Request, agent *store.Agent) bool {
+	ctx := r.Context()
+	identity := GetIdentityFromContext(ctx)
+	if identity == nil {
+		Unauthorized(w)
+		return false
+	}
+
+	if userIdent, ok := identity.(UserIdentity); ok {
+		decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), ActionRead)
+		if !decision.Allowed {
+			Forbidden(w)
+			return false
+		}
+	} else if agentIdent, ok := identity.(AgentIdentity); ok {
+		if agentIdent.ProjectID() != agent.ProjectID {
+			Forbidden(w)
+			return false
+		}
+	} else {
+		Forbidden(w)
+		return false
+	}
+	return true
+}
+
+// =============================================================================
 // Handlers
 // =============================================================================
 
 // handleAgentMetricsSummary returns aggregate session metrics for an agent.
+// Numeric totals (session count, token sums) are computed via SQL-level
+// aggregation; tool/model breakdowns are derived from the most recent
+// sessions (capped by the store list limit).
+//
 // GET /api/v1/agents/{id}/metrics/summary
 func (s *Server) handleAgentMetricsSummary(w http.ResponseWriter, r *http.Request, agentID string) {
 	ctx := r.Context()
@@ -177,27 +214,26 @@ func (s *Server) handleAgentMetricsSummary(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Require user authentication.
-	userIdent := GetUserIdentityFromContext(ctx)
-	if userIdent == nil {
-		Unauthorized(w)
-		return
-	}
-
-	// Verify the agent exists and the user can view it.
+	// Verify the agent exists and the caller can view it.
 	agent, err := s.store.GetAgent(ctx, agentID)
 	if err != nil {
 		writeErrorFromErr(w, err, "")
 		return
 	}
-
-	decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), ActionRead)
-	if !decision.Allowed {
-		Forbidden(w)
+	if !s.authorizeSessionMetricsAccess(w, r, agent) {
 		return
 	}
 
-	// Fetch all session metrics for this agent.
+	// SQL-level aggregation for accurate totals.
+	agg, err := s.store.AggregateByAgent(ctx, agentID)
+	if err != nil {
+		s.agentMetricsLog.Error("Failed to aggregate session metrics for agent",
+			"agent_id", agentID, "error", err)
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// List queries for tool/model breakdowns and avg duration (capped).
 	sessions, err := s.store.ListAgentSessionMetricsByAgent(ctx, agentID)
 	if err != nil {
 		s.agentMetricsLog.Error("Failed to list session metrics for agent",
@@ -206,32 +242,23 @@ func (s *Server) handleAgentMetricsSummary(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Aggregate.
-	var totalInput, totalOutput, totalCached, totalReasoning int64
-	for _, sess := range sessions {
-		totalInput += sess.TokensInput
-		totalOutput += sess.TokensOutput
-		totalCached += sess.TokensCached
-		totalReasoning += sess.TokensReasoning
-	}
-
 	tools, totalToolCalls := aggregateToolCalls(sessions)
 	models := aggregateModels(sessions)
 	avgDuration := avgSessionDuration(sessions)
 
-	totalTokens := totalInput + totalOutput
+	totalTokens := agg.SumTokensInput + agg.SumTokensOutput
 	var avgTokens int64
-	if len(sessions) > 0 {
-		avgTokens = totalTokens / int64(len(sessions))
+	if agg.Count > 0 {
+		avgTokens = totalTokens / int64(agg.Count)
 	}
 
 	resp := agentMetricsSummaryResponse{
 		AgentID:              agentID,
-		TotalSessions:        len(sessions),
-		TotalTokensInput:     totalInput,
-		TotalTokensOutput:    totalOutput,
-		TotalTokensCached:    totalCached,
-		TotalTokensReasoning: totalReasoning,
+		TotalSessions:        agg.Count,
+		TotalTokensInput:     agg.SumTokensInput,
+		TotalTokensOutput:    agg.SumTokensOutput,
+		TotalTokensCached:    agg.SumTokensCached,
+		TotalTokensReasoning: agg.SumTokensReason,
 		TotalToolCalls:       totalToolCalls,
 		AvgSessionDurationMs: avgDuration,
 		AvgTokensPerSession:  avgTokens,
@@ -252,13 +279,6 @@ func (s *Server) handleSessionMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Require user authentication.
-	userIdent := GetUserIdentityFromContext(ctx)
-	if userIdent == nil {
-		Unauthorized(w)
-		return
-	}
-
 	id := extractID(r, "/api/v1/metrics/session")
 	if id == "" {
 		NotFound(w, "Session metrics")
@@ -271,10 +291,23 @@ func (s *Server) handleSessionMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Authorize: verify the caller can view the owning agent.
+	agent, err := s.store.GetAgent(ctx, metrics.AgentID)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+	if !s.authorizeSessionMetricsAccess(w, r, agent) {
+		return
+	}
+
 	writeJSON(w, http.StatusOK, metrics)
 }
 
 // handleProjectSessionMetricsSummary returns aggregate session metrics for a project.
+// Numeric totals are computed via SQL-level aggregation; tool/model breakdowns
+// are derived from the most recent sessions (capped by the store list limit).
+//
 // GET /api/v1/projects/{id}/metrics/summary
 func (s *Server) handleProjectSessionMetricsSummary(w http.ResponseWriter, r *http.Request, projectID string) {
 	ctx := r.Context()
@@ -295,7 +328,7 @@ func (s *Server) handleProjectSessionMetricsSummary(w http.ResponseWriter, r *ht
 		return
 	}
 
-	// Authorize: any authenticated user with view access.
+	// Authorize: any authenticated identity with view access.
 	identity := GetIdentityFromContext(ctx)
 	if identity == nil {
 		Unauthorized(w)
@@ -322,7 +355,24 @@ func (s *Server) handleProjectSessionMetricsSummary(w http.ResponseWriter, r *ht
 		return
 	}
 
-	// Fetch all session metrics for this project.
+	// SQL-level aggregation for accurate totals.
+	agg, err := s.store.AggregateByProject(ctx, projectID)
+	if err != nil {
+		s.agentMetricsLog.Error("Failed to aggregate session metrics for project",
+			"project_id", projectID, "error", err)
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	activeAgents, err := s.store.CountDistinctAgentsByProject(ctx, projectID)
+	if err != nil {
+		s.agentMetricsLog.Error("Failed to count active agents for project",
+			"project_id", projectID, "error", err)
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// List queries for tool/model breakdowns (capped).
 	sessions, err := s.store.ListAgentSessionMetricsByProject(ctx, projectID)
 	if err != nil {
 		s.agentMetricsLog.Error("Failed to list session metrics for project",
@@ -331,28 +381,17 @@ func (s *Server) handleProjectSessionMetricsSummary(w http.ResponseWriter, r *ht
 		return
 	}
 
-	// Aggregate.
-	var totalInput, totalOutput, totalCached, totalReasoning int64
-	activeAgentSet := make(map[string]struct{})
-	for _, sess := range sessions {
-		totalInput += sess.TokensInput
-		totalOutput += sess.TokensOutput
-		totalCached += sess.TokensCached
-		totalReasoning += sess.TokensReasoning
-		activeAgentSet[sess.AgentID] = struct{}{}
-	}
-
 	tools, _ := aggregateToolCalls(sessions)
 	models := aggregateModels(sessions)
 
 	resp := projectMetricsSummaryResponse{
 		ProjectID:            projectID,
-		TotalSessions:        len(sessions),
-		TotalTokensInput:     totalInput,
-		TotalTokensOutput:    totalOutput,
-		TotalTokensCached:    totalCached,
-		TotalTokensReasoning: totalReasoning,
-		ActiveAgents:         len(activeAgentSet),
+		TotalSessions:        agg.Count,
+		TotalTokensInput:     agg.SumTokensInput,
+		TotalTokensOutput:    agg.SumTokensOutput,
+		TotalTokensCached:    agg.SumTokensCached,
+		TotalTokensReasoning: agg.SumTokensReason,
+		ActiveAgents:         activeAgents,
 		MostUsedTools:        tools,
 		MostUsedModels:       models,
 	}

--- a/pkg/hub/handlers_session_metrics_test.go
+++ b/pkg/hub/handlers_session_metrics_test.go
@@ -1,0 +1,371 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupSessionMetricsFixtures creates a project, two agents, and several
+// session metrics records for testing the session metrics API endpoints.
+func setupSessionMetricsFixtures(t *testing.T, s store.Store) (*store.Project, *store.Agent, *store.Agent) {
+	t.Helper()
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:   tid("sm-project"),
+		Name: "Session Metrics Project",
+		Slug: "sm-project",
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	agent1 := &store.Agent{
+		ID:        tid("sm-agent-1"),
+		Slug:      "sm-agent-1",
+		Name:      "SM Agent 1",
+		ProjectID: project.ID,
+		Phase:     string(state.PhaseRunning),
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent1))
+
+	agent2 := &store.Agent{
+		ID:        tid("sm-agent-2"),
+		Slug:      "sm-agent-2",
+		Name:      "SM Agent 2",
+		ProjectID: project.ID,
+		Phase:     string(state.PhaseRunning),
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent2))
+
+	// Create session metrics for agent1.
+	ended1 := time.Date(2026, 8, 1, 10, 5, 0, 0, time.UTC)
+	m1 := &store.AgentSessionMetrics{
+		AgentID:         agent1.ID,
+		ProjectID:       project.ID,
+		SessionID:       "session-a1-1",
+		StartedAt:       time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC),
+		EndedAt:         &ended1,
+		Status:          "completed",
+		TurnCount:       5,
+		Model:           "claude-4",
+		TokensInput:     1000,
+		TokensOutput:    200,
+		TokensCached:    100,
+		TokensReasoning: 50,
+		ToolCalls: map[string]any{
+			"read_file":  map[string]any{"calls": 3, "success": 3, "error": 0},
+			"write_file": map[string]any{"calls": 2, "success": 1, "error": 1},
+		},
+	}
+	require.NoError(t, s.CreateAgentSessionMetrics(ctx, m1))
+
+	ended2 := time.Date(2026, 8, 1, 11, 10, 0, 0, time.UTC)
+	m2 := &store.AgentSessionMetrics{
+		AgentID:         agent1.ID,
+		ProjectID:       project.ID,
+		SessionID:       "session-a1-2",
+		StartedAt:       time.Date(2026, 8, 1, 11, 0, 0, 0, time.UTC),
+		EndedAt:         &ended2,
+		Status:          "completed",
+		TurnCount:       3,
+		Model:           "gpt-4o",
+		TokensInput:     2000,
+		TokensOutput:    400,
+		TokensCached:    200,
+		TokensReasoning: 100,
+		ToolCalls: map[string]any{
+			"read_file": map[string]any{"calls": 5, "success": 5, "error": 0},
+		},
+	}
+	require.NoError(t, s.CreateAgentSessionMetrics(ctx, m2))
+
+	// Create session metrics for agent2.
+	ended3 := time.Date(2026, 8, 1, 12, 15, 0, 0, time.UTC)
+	m3 := &store.AgentSessionMetrics{
+		AgentID:         agent2.ID,
+		ProjectID:       project.ID,
+		SessionID:       "session-a2-1",
+		StartedAt:       time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC),
+		EndedAt:         &ended3,
+		Status:          "completed",
+		TurnCount:       7,
+		Model:           "claude-4",
+		TokensInput:     3000,
+		TokensOutput:    600,
+		TokensCached:    300,
+		TokensReasoning: 150,
+		ToolCalls: map[string]any{
+			"bash": map[string]any{"calls": 10, "success": 9, "error": 1},
+		},
+	}
+	require.NoError(t, s.CreateAgentSessionMetrics(ctx, m3))
+
+	return project, agent1, agent2
+}
+
+// =============================================================================
+// GET /api/v1/agents/{id}/metrics/summary
+// =============================================================================
+
+func TestHandleAgentMetricsSummary(t *testing.T) {
+	srv, s := testServer(t)
+	_, agent1, _ := setupSessionMetricsFixtures(t, s)
+
+	t.Run("returns aggregate metrics for agent", func(t *testing.T) {
+		rec := doRequest(t, srv, http.MethodGet,
+			"/api/v1/agents/"+agent1.ID+"/metrics/summary", nil)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp agentMetricsSummaryResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &resp)
+		require.NoError(t, err)
+
+		assert.Equal(t, agent1.ID, resp.AgentID)
+		assert.Equal(t, 2, resp.TotalSessions)
+		assert.Equal(t, int64(3000), resp.TotalTokensInput)    // 1000 + 2000
+		assert.Equal(t, int64(600), resp.TotalTokensOutput)     // 200 + 400
+		assert.Equal(t, int64(300), resp.TotalTokensCached)     // 100 + 200
+		assert.Equal(t, int64(150), resp.TotalTokensReasoning)  // 50 + 100
+		assert.Equal(t, 10, resp.TotalToolCalls)                // 3+2+5
+		assert.Greater(t, resp.AvgSessionDurationMs, int64(0))
+		assert.Equal(t, int64(1800), resp.AvgTokensPerSession)  // (3000+600)/2
+		assert.NotEmpty(t, resp.MostUsedTools)
+		assert.NotEmpty(t, resp.MostUsedModels)
+	})
+
+	t.Run("unauthenticated returns 401", func(t *testing.T) {
+		rec := doRequestNoAuth(t, srv, http.MethodGet,
+			"/api/v1/agents/"+agent1.ID+"/metrics/summary", nil)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("non-existent agent returns 404", func(t *testing.T) {
+		rec := doRequest(t, srv, http.MethodGet,
+			"/api/v1/agents/"+tid("no-such-agent")+"/metrics/summary", nil)
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("POST method not allowed", func(t *testing.T) {
+		rec := doRequest(t, srv, http.MethodPost,
+			"/api/v1/agents/"+agent1.ID+"/metrics/summary", nil)
+		assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	})
+}
+
+// =============================================================================
+// GET /api/v1/metrics/session/{id}
+// =============================================================================
+
+func TestHandleSessionMetrics(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:   tid("sm-session-project"),
+		Name: "Session Project",
+		Slug: "sm-session-project",
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	agent := &store.Agent{
+		ID:        tid("sm-session-agent"),
+		Slug:      "sm-session-agent",
+		Name:      "SM Session Agent",
+		ProjectID: project.ID,
+		Phase:     string(state.PhaseRunning),
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	ended := time.Date(2026, 8, 1, 10, 5, 0, 0, time.UTC)
+	m := &store.AgentSessionMetrics{
+		AgentID:      agent.ID,
+		ProjectID:    project.ID,
+		SessionID:    "session-detail-1",
+		StartedAt:    time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC),
+		EndedAt:      &ended,
+		Status:       "completed",
+		TurnCount:    4,
+		Model:        "claude-4",
+		TokensInput:  5000,
+		TokensOutput: 1200,
+	}
+	require.NoError(t, s.CreateAgentSessionMetrics(ctx, m))
+
+	t.Run("returns session metrics by ID", func(t *testing.T) {
+		rec := doRequest(t, srv, http.MethodGet,
+			"/api/v1/metrics/session/"+m.ID, nil)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp store.AgentSessionMetrics
+		err := json.Unmarshal(rec.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, m.ID, resp.ID)
+		assert.Equal(t, agent.ID, resp.AgentID)
+		assert.Equal(t, "session-detail-1", resp.SessionID)
+		assert.Equal(t, int64(5000), resp.TokensInput)
+	})
+
+	t.Run("non-existent session returns 404", func(t *testing.T) {
+		rec := doRequest(t, srv, http.MethodGet,
+			"/api/v1/metrics/session/"+tid("no-such-session"), nil)
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("unauthenticated returns 401", func(t *testing.T) {
+		rec := doRequestNoAuth(t, srv, http.MethodGet,
+			"/api/v1/metrics/session/"+m.ID, nil)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+}
+
+// =============================================================================
+// GET /api/v1/projects/{id}/metrics/summary
+// =============================================================================
+
+func TestHandleProjectSessionMetricsSummary(t *testing.T) {
+	srv, s := testServer(t)
+	project, _, _ := setupSessionMetricsFixtures(t, s)
+
+	t.Run("returns aggregate project metrics", func(t *testing.T) {
+		rec := doRequest(t, srv, http.MethodGet,
+			"/api/v1/projects/"+project.ID+"/metrics/summary", nil)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp projectMetricsSummaryResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &resp)
+		require.NoError(t, err)
+
+		assert.Equal(t, project.ID, resp.ProjectID)
+		assert.Equal(t, 3, resp.TotalSessions)                 // 2 from agent1 + 1 from agent2
+		assert.Equal(t, int64(6000), resp.TotalTokensInput)     // 1000+2000+3000
+		assert.Equal(t, int64(1200), resp.TotalTokensOutput)    // 200+400+600
+		assert.Equal(t, int64(600), resp.TotalTokensCached)     // 100+200+300
+		assert.Equal(t, int64(300), resp.TotalTokensReasoning)  // 50+100+150
+		assert.Equal(t, 2, resp.ActiveAgents)                   // agent1 and agent2
+		assert.NotEmpty(t, resp.MostUsedTools)
+		assert.NotEmpty(t, resp.MostUsedModels)
+	})
+
+	t.Run("unauthenticated returns 401", func(t *testing.T) {
+		rec := doRequestNoAuth(t, srv, http.MethodGet,
+			"/api/v1/projects/"+project.ID+"/metrics/summary", nil)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("non-existent project returns 404", func(t *testing.T) {
+		rec := doRequest(t, srv, http.MethodGet,
+			"/api/v1/projects/"+tid("no-such-project")+"/metrics/summary", nil)
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("POST method not allowed", func(t *testing.T) {
+		rec := doRequest(t, srv, http.MethodPost,
+			"/api/v1/projects/"+project.ID+"/metrics/summary", nil)
+		assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	})
+}
+
+// =============================================================================
+// Aggregation helper unit tests
+// =============================================================================
+
+func TestAggregateToolCalls(t *testing.T) {
+	sessions := []*store.AgentSessionMetrics{
+		{
+			ToolCalls: map[string]any{
+				"read_file":  map[string]any{"calls": float64(3), "success": float64(3), "error": float64(0)},
+				"write_file": map[string]any{"calls": float64(2), "success": float64(1), "error": float64(1)},
+			},
+		},
+		{
+			ToolCalls: map[string]any{
+				"read_file": map[string]any{"calls": float64(5), "success": float64(5), "error": float64(0)},
+				"bash":      map[string]any{"calls": float64(1), "success": float64(1), "error": float64(0)},
+			},
+		},
+	}
+
+	tools, total := aggregateToolCalls(sessions)
+
+	assert.Equal(t, 11, total) // 3+2+5+1
+	assert.Len(t, tools, 3)
+
+	// Sorted by calls descending: read_file(8), write_file(2), bash(1)
+	assert.Equal(t, "read_file", tools[0].Name)
+	assert.Equal(t, 8, tools[0].Calls)
+	assert.Equal(t, 8, tools[0].Success)
+}
+
+func TestAggregateModels(t *testing.T) {
+	sessions := []*store.AgentSessionMetrics{
+		{Model: "claude-4"},
+		{Model: "claude-4"},
+		{Model: "gpt-4o"},
+		{Model: ""},
+	}
+
+	models := aggregateModels(sessions)
+
+	assert.Len(t, models, 2)
+	// claude-4 has 2 sessions, gpt-4o has 1
+	assert.Equal(t, "claude-4", models[0].Model)
+	assert.Equal(t, 2, models[0].Sessions)
+}
+
+func TestAvgSessionDuration(t *testing.T) {
+	ended1 := time.Date(2026, 8, 1, 10, 5, 0, 0, time.UTC)  // 5 min
+	ended2 := time.Date(2026, 8, 1, 11, 15, 0, 0, time.UTC) // 15 min
+
+	sessions := []*store.AgentSessionMetrics{
+		{
+			StartedAt: time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC),
+			EndedAt:   &ended1,
+		},
+		{
+			StartedAt: time.Date(2026, 8, 1, 11, 0, 0, 0, time.UTC),
+			EndedAt:   &ended2,
+		},
+		{
+			// Session without EndedAt should be skipped.
+			StartedAt: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC),
+		},
+	}
+
+	avg := avgSessionDuration(sessions)
+	// Average of 5min and 15min = 10min = 600,000 ms
+	assert.Equal(t, int64(600000), avg)
+}
+
+func TestIntFromAny(t *testing.T) {
+	assert.Equal(t, 5, intFromAny(float64(5)))
+	assert.Equal(t, 3, intFromAny(int(3)))
+	assert.Equal(t, 7, intFromAny(int64(7)))
+	assert.Equal(t, 0, intFromAny("not a number"))
+	assert.Equal(t, 0, intFromAny(nil))
+}

--- a/pkg/hub/handlers_session_metrics_test.go
+++ b/pkg/hub/handlers_session_metrics_test.go
@@ -146,7 +146,7 @@ func TestHandleAgentMetricsSummary(t *testing.T) {
 
 		assert.Equal(t, agent1.ID, resp.AgentID)
 		assert.Equal(t, 2, resp.TotalSessions)
-		assert.Equal(t, int64(3000), resp.TotalTokensInput)   // 1000 + 2000
+		assert.Equal(t, int64(3000), resp.TotalTokensInput)    // 1000 + 2000
 		assert.Equal(t, int64(600), resp.TotalTokensOutput)    // 200 + 400
 		assert.Equal(t, int64(300), resp.TotalTokensCached)    // 100 + 200
 		assert.Equal(t, int64(150), resp.TotalTokensReasoning) // 50 + 100

--- a/pkg/hub/handlers_session_metrics_test.go
+++ b/pkg/hub/handlers_session_metrics_test.go
@@ -146,13 +146,13 @@ func TestHandleAgentMetricsSummary(t *testing.T) {
 
 		assert.Equal(t, agent1.ID, resp.AgentID)
 		assert.Equal(t, 2, resp.TotalSessions)
-		assert.Equal(t, int64(3000), resp.TotalTokensInput)    // 1000 + 2000
-		assert.Equal(t, int64(600), resp.TotalTokensOutput)     // 200 + 400
-		assert.Equal(t, int64(300), resp.TotalTokensCached)     // 100 + 200
-		assert.Equal(t, int64(150), resp.TotalTokensReasoning)  // 50 + 100
-		assert.Equal(t, 10, resp.TotalToolCalls)                // 3+2+5
+		assert.Equal(t, int64(3000), resp.TotalTokensInput)   // 1000 + 2000
+		assert.Equal(t, int64(600), resp.TotalTokensOutput)    // 200 + 400
+		assert.Equal(t, int64(300), resp.TotalTokensCached)    // 100 + 200
+		assert.Equal(t, int64(150), resp.TotalTokensReasoning) // 50 + 100
+		assert.Equal(t, 10, resp.TotalToolCalls)               // 3+2+5
 		assert.Greater(t, resp.AvgSessionDurationMs, int64(0))
-		assert.Equal(t, int64(1800), resp.AvgTokensPerSession)  // (3000+600)/2
+		assert.Equal(t, int64(1800), resp.AvgTokensPerSession) // (3000+600)/2
 		assert.NotEmpty(t, resp.MostUsedTools)
 		assert.NotEmpty(t, resp.MostUsedModels)
 	})
@@ -241,6 +241,26 @@ func TestHandleSessionMetrics(t *testing.T) {
 			"/api/v1/metrics/session/"+m.ID, nil)
 		assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	})
+
+	t.Run("session with deleted agent returns error", func(t *testing.T) {
+		// Create a session record pointing to an agent that does not exist.
+		// The handler must look up the agent for authorization; a missing
+		// agent should produce a 404 rather than leaking the record.
+		orphanMetrics := &store.AgentSessionMetrics{
+			AgentID:     tid("deleted-agent"),
+			ProjectID:   project.ID,
+			SessionID:   "session-orphan",
+			StartedAt:   time.Date(2026, 8, 1, 13, 0, 0, 0, time.UTC),
+			TokensInput: 999,
+		}
+		require.NoError(t, s.CreateAgentSessionMetrics(ctx, orphanMetrics))
+
+		rec := doRequest(t, srv, http.MethodGet,
+			"/api/v1/metrics/session/"+orphanMetrics.ID, nil)
+
+		// The agent lookup should fail with 404.
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
 }
 
 // =============================================================================
@@ -263,11 +283,11 @@ func TestHandleProjectSessionMetricsSummary(t *testing.T) {
 
 		assert.Equal(t, project.ID, resp.ProjectID)
 		assert.Equal(t, 3, resp.TotalSessions)                 // 2 from agent1 + 1 from agent2
-		assert.Equal(t, int64(6000), resp.TotalTokensInput)     // 1000+2000+3000
-		assert.Equal(t, int64(1200), resp.TotalTokensOutput)    // 200+400+600
-		assert.Equal(t, int64(600), resp.TotalTokensCached)     // 100+200+300
-		assert.Equal(t, int64(300), resp.TotalTokensReasoning)  // 50+100+150
-		assert.Equal(t, 2, resp.ActiveAgents)                   // agent1 and agent2
+		assert.Equal(t, int64(6000), resp.TotalTokensInput)    // 1000+2000+3000
+		assert.Equal(t, int64(1200), resp.TotalTokensOutput)   // 200+400+600
+		assert.Equal(t, int64(600), resp.TotalTokensCached)    // 100+200+300
+		assert.Equal(t, int64(300), resp.TotalTokensReasoning) // 50+100+150
+		assert.Equal(t, 2, resp.ActiveAgents)                  // agent1 and agent2
 		assert.NotEmpty(t, resp.MostUsedTools)
 		assert.NotEmpty(t, resp.MostUsedModels)
 	})

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2955,6 +2955,9 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/secrets", s.handleSecrets)
 	s.mux.HandleFunc("/api/v1/secrets/", s.handleSecretByKey)
 
+	// Session metrics (DB-backed, distinct from Cloud Monitoring metrics dashboard)
+	s.mux.HandleFunc("/api/v1/metrics/session/", s.handleSessionMetrics)
+
 	// Groups and Policies (Hub Permissions System)
 	s.mux.HandleFunc("/api/v1/groups", s.handleGroups)
 	s.mux.HandleFunc("/api/v1/groups/", s.handleGroupRoutes)

--- a/pkg/store/entadapter/agent_session_metrics_store.go
+++ b/pkg/store/entadapter/agent_session_metrics_store.go
@@ -179,12 +179,12 @@ func (s *AgentSessionMetricsStore) ListAgentSessionMetricsByProject(ctx context.
 // AggregateByAgent returns SQL-level aggregate totals for an agent's sessions.
 func (s *AgentSessionMetricsStore) AggregateByAgent(ctx context.Context, agentID string) (*store.AgentSessionMetricsAggregates, error) {
 	var agg []struct {
-		Count           int   `json:"count"`
-		SumTokensInput  int64 `json:"sum_tokens_input"`
-		SumTokensOutput int64 `json:"sum_tokens_output"`
-		SumTokensCached int64 `json:"sum_tokens_cached"`
-		SumTokensReason int64 `json:"sum_tokens_reasoning"`
-		SumTurnCount    int64 `json:"sum_turn_count"`
+		Count           int    `json:"count"`
+		SumTokensInput  *int64 `json:"sum_tokens_input"`
+		SumTokensOutput *int64 `json:"sum_tokens_output"`
+		SumTokensCached *int64 `json:"sum_tokens_cached"`
+		SumTokensReason *int64 `json:"sum_tokens_reasoning"`
+		SumTurnCount    *int64 `json:"sum_turn_count"`
 	}
 
 	err := s.client.AgentSessionMetrics.
@@ -207,25 +207,31 @@ func (s *AgentSessionMetricsStore) AggregateByAgent(ctx context.Context, agentID
 		return &store.AgentSessionMetricsAggregates{}, nil
 	}
 
+	deref := func(p *int64) int64 {
+		if p == nil {
+			return 0
+		}
+		return *p
+	}
 	return &store.AgentSessionMetricsAggregates{
 		Count:           agg[0].Count,
-		SumTokensInput:  agg[0].SumTokensInput,
-		SumTokensOutput: agg[0].SumTokensOutput,
-		SumTokensCached: agg[0].SumTokensCached,
-		SumTokensReason: agg[0].SumTokensReason,
-		SumTurnCount:    agg[0].SumTurnCount,
+		SumTokensInput:  deref(agg[0].SumTokensInput),
+		SumTokensOutput: deref(agg[0].SumTokensOutput),
+		SumTokensCached: deref(agg[0].SumTokensCached),
+		SumTokensReason: deref(agg[0].SumTokensReason),
+		SumTurnCount:    deref(agg[0].SumTurnCount),
 	}, nil
 }
 
 // AggregateByProject returns SQL-level aggregate totals for a project's sessions.
 func (s *AgentSessionMetricsStore) AggregateByProject(ctx context.Context, projectID string) (*store.AgentSessionMetricsAggregates, error) {
 	var agg []struct {
-		Count           int   `json:"count"`
-		SumTokensInput  int64 `json:"sum_tokens_input"`
-		SumTokensOutput int64 `json:"sum_tokens_output"`
-		SumTokensCached int64 `json:"sum_tokens_cached"`
-		SumTokensReason int64 `json:"sum_tokens_reasoning"`
-		SumTurnCount    int64 `json:"sum_turn_count"`
+		Count           int    `json:"count"`
+		SumTokensInput  *int64 `json:"sum_tokens_input"`
+		SumTokensOutput *int64 `json:"sum_tokens_output"`
+		SumTokensCached *int64 `json:"sum_tokens_cached"`
+		SumTokensReason *int64 `json:"sum_tokens_reasoning"`
+		SumTurnCount    *int64 `json:"sum_turn_count"`
 	}
 
 	err := s.client.AgentSessionMetrics.
@@ -248,13 +254,19 @@ func (s *AgentSessionMetricsStore) AggregateByProject(ctx context.Context, proje
 		return &store.AgentSessionMetricsAggregates{}, nil
 	}
 
+	deref := func(p *int64) int64 {
+		if p == nil {
+			return 0
+		}
+		return *p
+	}
 	return &store.AgentSessionMetricsAggregates{
 		Count:           agg[0].Count,
-		SumTokensInput:  agg[0].SumTokensInput,
-		SumTokensOutput: agg[0].SumTokensOutput,
-		SumTokensCached: agg[0].SumTokensCached,
-		SumTokensReason: agg[0].SumTokensReason,
-		SumTurnCount:    agg[0].SumTurnCount,
+		SumTokensInput:  deref(agg[0].SumTokensInput),
+		SumTokensOutput: deref(agg[0].SumTokensOutput),
+		SumTokensCached: deref(agg[0].SumTokensCached),
+		SumTokensReason: deref(agg[0].SumTokensReason),
+		SumTurnCount:    deref(agg[0].SumTurnCount),
 	}, nil
 }
 

--- a/pkg/store/entadapter/agent_session_metrics_store.go
+++ b/pkg/store/entadapter/agent_session_metrics_store.go
@@ -151,3 +151,23 @@ func (s *AgentSessionMetricsStore) ListAgentSessionMetricsByAgent(ctx context.Co
 	}
 	return result, nil
 }
+
+// ListAgentSessionMetricsByProject returns session metrics for all agents
+// in a project, ordered by started_at descending, capped at defaultMetricsListLimit.
+func (s *AgentSessionMetricsStore) ListAgentSessionMetricsByProject(ctx context.Context, projectID string) ([]*store.AgentSessionMetrics, error) {
+	entities, err := s.client.AgentSessionMetrics.
+		Query().
+		Where(entasm.GroveIDEQ(projectID)).
+		Order(ent.Desc(entasm.FieldStartedAt)).
+		Limit(defaultMetricsListLimit).
+		All(ctx)
+	if err != nil {
+		return nil, mapError(err)
+	}
+
+	result := make([]*store.AgentSessionMetrics, 0, len(entities))
+	for _, e := range entities {
+		result = append(result, entAgentSessionMetricsToStore(e))
+	}
+	return result, nil
+}

--- a/pkg/store/entadapter/agent_session_metrics_store.go
+++ b/pkg/store/entadapter/agent_session_metrics_store.go
@@ -171,3 +171,107 @@ func (s *AgentSessionMetricsStore) ListAgentSessionMetricsByProject(ctx context.
 	}
 	return result, nil
 }
+
+// ============================================================================
+// Aggregation queries (SQL-level COUNT/SUM)
+// ============================================================================
+
+// AggregateByAgent returns SQL-level aggregate totals for an agent's sessions.
+func (s *AgentSessionMetricsStore) AggregateByAgent(ctx context.Context, agentID string) (*store.AgentSessionMetricsAggregates, error) {
+	var agg []struct {
+		Count           int   `json:"count"`
+		SumTokensInput  int64 `json:"sum_tokens_input"`
+		SumTokensOutput int64 `json:"sum_tokens_output"`
+		SumTokensCached int64 `json:"sum_tokens_cached"`
+		SumTokensReason int64 `json:"sum_tokens_reasoning"`
+		SumTurnCount    int64 `json:"sum_turn_count"`
+	}
+
+	err := s.client.AgentSessionMetrics.
+		Query().
+		Where(entasm.AgentIDEQ(agentID)).
+		Aggregate(
+			ent.As(ent.Count(), "count"),
+			ent.As(ent.Sum(entasm.FieldTokensInput), "sum_tokens_input"),
+			ent.As(ent.Sum(entasm.FieldTokensOutput), "sum_tokens_output"),
+			ent.As(ent.Sum(entasm.FieldTokensCached), "sum_tokens_cached"),
+			ent.As(ent.Sum(entasm.FieldTokensReasoning), "sum_tokens_reasoning"),
+			ent.As(ent.Sum(entasm.FieldTurnCount), "sum_turn_count"),
+		).
+		Scan(ctx, &agg)
+	if err != nil {
+		return nil, mapError(err)
+	}
+
+	if len(agg) == 0 {
+		return &store.AgentSessionMetricsAggregates{}, nil
+	}
+
+	return &store.AgentSessionMetricsAggregates{
+		Count:           agg[0].Count,
+		SumTokensInput:  agg[0].SumTokensInput,
+		SumTokensOutput: agg[0].SumTokensOutput,
+		SumTokensCached: agg[0].SumTokensCached,
+		SumTokensReason: agg[0].SumTokensReason,
+		SumTurnCount:    agg[0].SumTurnCount,
+	}, nil
+}
+
+// AggregateByProject returns SQL-level aggregate totals for a project's sessions.
+func (s *AgentSessionMetricsStore) AggregateByProject(ctx context.Context, projectID string) (*store.AgentSessionMetricsAggregates, error) {
+	var agg []struct {
+		Count           int   `json:"count"`
+		SumTokensInput  int64 `json:"sum_tokens_input"`
+		SumTokensOutput int64 `json:"sum_tokens_output"`
+		SumTokensCached int64 `json:"sum_tokens_cached"`
+		SumTokensReason int64 `json:"sum_tokens_reasoning"`
+		SumTurnCount    int64 `json:"sum_turn_count"`
+	}
+
+	err := s.client.AgentSessionMetrics.
+		Query().
+		Where(entasm.GroveIDEQ(projectID)).
+		Aggregate(
+			ent.As(ent.Count(), "count"),
+			ent.As(ent.Sum(entasm.FieldTokensInput), "sum_tokens_input"),
+			ent.As(ent.Sum(entasm.FieldTokensOutput), "sum_tokens_output"),
+			ent.As(ent.Sum(entasm.FieldTokensCached), "sum_tokens_cached"),
+			ent.As(ent.Sum(entasm.FieldTokensReasoning), "sum_tokens_reasoning"),
+			ent.As(ent.Sum(entasm.FieldTurnCount), "sum_turn_count"),
+		).
+		Scan(ctx, &agg)
+	if err != nil {
+		return nil, mapError(err)
+	}
+
+	if len(agg) == 0 {
+		return &store.AgentSessionMetricsAggregates{}, nil
+	}
+
+	return &store.AgentSessionMetricsAggregates{
+		Count:           agg[0].Count,
+		SumTokensInput:  agg[0].SumTokensInput,
+		SumTokensOutput: agg[0].SumTokensOutput,
+		SumTokensCached: agg[0].SumTokensCached,
+		SumTokensReason: agg[0].SumTokensReason,
+		SumTurnCount:    agg[0].SumTurnCount,
+	}, nil
+}
+
+// CountDistinctAgentsByProject returns the number of distinct agents that have
+// at least one session metrics record in the given project.
+func (s *AgentSessionMetricsStore) CountDistinctAgentsByProject(ctx context.Context, projectID string) (int, error) {
+	var groups []struct {
+		AgentID string `json:"agent_id"`
+	}
+
+	err := s.client.AgentSessionMetrics.
+		Query().
+		Where(entasm.GroveIDEQ(projectID)).
+		GroupBy(entasm.FieldAgentID).
+		Scan(ctx, &groups)
+	if err != nil {
+		return 0, mapError(err)
+	}
+	return len(groups), nil
+}

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -2193,6 +2193,19 @@ type AgentSessionMetrics struct {
 	CreatedAt       time.Time      `json:"createdAt"`
 }
 
+// AgentSessionMetricsAggregates holds SQL-level aggregation results for
+// session metrics (COUNT, SUM). Fields that require per-row inspection (tool
+// calls, model distribution) are not included — those are derived from list
+// queries.
+type AgentSessionMetricsAggregates struct {
+	Count           int   `json:"count"`
+	SumTokensInput  int64 `json:"sumTokensInput"`
+	SumTokensOutput int64 `json:"sumTokensOutput"`
+	SumTokensCached int64 `json:"sumTokensCached"`
+	SumTokensReason int64 `json:"sumTokensReasoning"`
+	SumTurnCount    int64 `json:"sumTurnCount"`
+}
+
 // MarshalJSON implements custom marshaling to support legacy groveId field.
 func (m AgentSessionMetrics) MarshalJSON() ([]byte, error) {
 	type Alias AgentSessionMetrics

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1445,4 +1445,8 @@ type AgentSessionMetricsStore interface {
 	// ListAgentSessionMetricsByAgent returns all session metrics for an agent,
 	// ordered by started_at DESC.
 	ListAgentSessionMetricsByAgent(ctx context.Context, agentID string) ([]*AgentSessionMetrics, error)
+
+	// ListAgentSessionMetricsByProject returns all session metrics for a project,
+	// ordered by started_at DESC.
+	ListAgentSessionMetricsByProject(ctx context.Context, projectID string) ([]*AgentSessionMetrics, error)
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1449,4 +1449,14 @@ type AgentSessionMetricsStore interface {
 	// ListAgentSessionMetricsByProject returns all session metrics for a project,
 	// ordered by started_at DESC.
 	ListAgentSessionMetricsByProject(ctx context.Context, projectID string) ([]*AgentSessionMetrics, error)
+
+	// AggregateByAgent returns SQL-level aggregate totals for an agent's sessions.
+	AggregateByAgent(ctx context.Context, agentID string) (*AgentSessionMetricsAggregates, error)
+
+	// AggregateByProject returns SQL-level aggregate totals for a project's sessions.
+	AggregateByProject(ctx context.Context, projectID string) (*AgentSessionMetricsAggregates, error)
+
+	// CountDistinctAgentsByProject returns the number of distinct agents with
+	// session metrics in a project.
+	CountDistinctAgentsByProject(ctx context.Context, projectID string) (int, error)
 }

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -1498,8 +1498,8 @@ export class ScionPageAgentDetail extends LitElement {
                       <span class="info-label">${t.name.toUpperCase()}</span>
                       <span class="info-value">
                         ${t.calls} calls
-                        ${t.errors > 0
-                          ? html`<span style="color: var(--scion-danger-500, #ef4444)"> (${t.errors} errors)</span>`
+                        ${t.error > 0
+                          ? html`<span style="color: var(--scion-danger-500, #ef4444)"> (${t.error} errors)</span>`
                           : nothing}
                       </span>
                     </div>

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -34,6 +34,7 @@ import type {
   Project,
   Notification,
   Subscription,
+  AgentMetricsSummary,
 } from '../../shared/types.js';
 import {
   can,
@@ -141,6 +142,9 @@ export class ScionPageAgentDetail extends LitElement {
 
   @state()
   private quickMessageOpen = false;
+
+  @state()
+  private metricsSummary: AgentMetricsSummary | null = null;
 
   static override styles = css`
     :host {
@@ -708,6 +712,9 @@ export class ScionPageAgentDetail extends LitElement {
 
       await Promise.all(parallel);
 
+      // Load metrics summary (non-blocking).
+      this.loadMetricsSummary();
+
       stateManager.seedAgents([this.agent]);
       if (this.project) {
         stateManager.seedProjects([this.project]);
@@ -720,6 +727,17 @@ export class ScionPageAgentDetail extends LitElement {
       this.error = err instanceof Error ? err.message : 'Failed to load agent';
     } finally {
       this.loading = false;
+    }
+  }
+
+  private async loadMetricsSummary(): Promise<void> {
+    try {
+      const res = await apiFetch(`/api/v1/agents/${this.agentId}/metrics/summary`);
+      if (res.ok) {
+        this.metricsSummary = (await res.json()) as AgentMetricsSummary;
+      }
+    } catch {
+      // Metrics loading is optional — do not block the page.
     }
   }
 
@@ -958,11 +976,13 @@ export class ScionPageAgentDetail extends LitElement {
 
       <sl-tab-group @sl-tab-show=${this.handleTabShow}>
         <sl-tab slot="nav" panel="status">Status</sl-tab>
+        <sl-tab slot="nav" panel="metrics">Metrics</sl-tab>
         <sl-tab slot="nav" panel="logs">Logs</sl-tab>
         <sl-tab slot="nav" panel="messages">Messages</sl-tab>
         <sl-tab slot="nav" panel="configuration">Configuration</sl-tab>
 
         <sl-tab-panel name="status">${this.renderStatusTab()}</sl-tab-panel>
+        <sl-tab-panel name="metrics">${this.renderMetricsTab()}</sl-tab-panel>
         <sl-tab-panel name="logs">
           <scion-agent-log-viewer
             agentId=${this.agentId}
@@ -1405,6 +1425,119 @@ export class ScionPageAgentDetail extends LitElement {
         </div>
       </div>
     `;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Metrics Tab
+  // ---------------------------------------------------------------------------
+
+  private renderMetricsTab() {
+    const m = this.metricsSummary;
+    if (!m) {
+      return html`
+        <div class="card">
+          <h3 class="card-title">Session Metrics</h3>
+          <p style="color: var(--scion-text-muted, #888)">No session metrics available yet.</p>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="card">
+        <h3 class="card-title">Token Usage</h3>
+        <div class="info-grid">
+          <div class="info-item">
+            <span class="info-label">TOTAL SESSIONS</span>
+            <span class="info-value">${m.totalSessions.toLocaleString()}</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">INPUT TOKENS</span>
+            <span class="info-value">${m.totalTokensInput.toLocaleString()}</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">OUTPUT TOKENS</span>
+            <span class="info-value">${m.totalTokensOutput.toLocaleString()}</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">CACHED TOKENS</span>
+            <span class="info-value">${m.totalTokensCached.toLocaleString()}</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">REASONING TOKENS</span>
+            <span class="info-value">${m.totalTokensReasoning.toLocaleString()}</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">AVG TOKENS / SESSION</span>
+            <span class="info-value">${m.avgTokensPerSession.toLocaleString()}</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <h3 class="card-title">Session Statistics</h3>
+        <div class="info-grid">
+          <div class="info-item">
+            <span class="info-label">TOTAL TOOL CALLS</span>
+            <span class="info-value">${m.totalToolCalls.toLocaleString()}</span>
+          </div>
+          <div class="info-item">
+            <span class="info-label">AVG DURATION</span>
+            <span class="info-value">${this.formatDurationMs(m.avgSessionDurationMs)}</span>
+          </div>
+        </div>
+      </div>
+
+      ${m.mostUsedTools.length > 0
+        ? html`
+            <div class="card">
+              <h3 class="card-title">Most Used Tools</h3>
+              <div class="info-grid">
+                ${m.mostUsedTools.map(
+                  (t) => html`
+                    <div class="info-item">
+                      <span class="info-label">${t.name.toUpperCase()}</span>
+                      <span class="info-value">
+                        ${t.calls} calls
+                        ${t.errors > 0
+                          ? html`<span style="color: var(--scion-danger-500, #ef4444)"> (${t.errors} errors)</span>`
+                          : nothing}
+                      </span>
+                    </div>
+                  `
+                )}
+              </div>
+            </div>
+          `
+        : nothing}
+      ${m.mostUsedModels.length > 0
+        ? html`
+            <div class="card">
+              <h3 class="card-title">Models</h3>
+              <div class="info-grid">
+                ${m.mostUsedModels.map(
+                  (model) => html`
+                    <div class="info-item">
+                      <span class="info-label">${model.model.toUpperCase()}</span>
+                      <span class="info-value">${model.sessions} sessions</span>
+                    </div>
+                  `
+                )}
+              </div>
+            </div>
+          `
+        : nothing}
+    `;
+  }
+
+  private formatDurationMs(ms: number): string {
+    if (ms <= 0) return '—';
+    const totalSeconds = Math.round(ms / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    if (hours > 0) return `${hours}h ${minutes}m`;
+    if (minutes > 0) return `${minutes}m ${seconds}s`;
+    return `${seconds}s`;
   }
 
   // ---------------------------------------------------------------------------

--- a/web/src/components/pages/agents.ts
+++ b/web/src/components/pages/agents.ts
@@ -447,6 +447,7 @@ export class ScionPageAgents extends LitElement {
     const maxAgents = 20;
     const concurrency = 5;
     const subset = this.agents.slice(0, maxAgents);
+    const accumulatedMetrics = { ...this.agentMetrics };
 
     // Process in batches of `concurrency`.
     for (let i = 0; i < subset.length; i += concurrency) {
@@ -457,13 +458,14 @@ export class ScionPageAgents extends LitElement {
             const res = await apiFetch(`/api/v1/agents/${agent.id}/metrics/summary`);
             if (res.ok) {
               const data = (await res.json()) as AgentMetricsSummary;
-              this.agentMetrics = { ...this.agentMetrics, [agent.id]: data };
+              accumulatedMetrics[agent.id] = data;
             }
           } catch {
             // Metrics loading is optional per agent.
           }
         })
       );
+      this.agentMetrics = { ...accumulatedMetrics };
     }
   }
 

--- a/web/src/components/pages/agents.ts
+++ b/web/src/components/pages/agents.ts
@@ -439,19 +439,32 @@ export class ScionPageAgents extends LitElement {
     }
   }
 
+  /**
+   * Load metrics summaries for displayed agents. Caps the number of requests
+   * and limits concurrency to avoid overwhelming the backend.
+   */
   private async loadAgentMetrics(): Promise<void> {
-    const fetches = this.agents.map(async (agent) => {
-      try {
-        const res = await apiFetch(`/api/v1/agents/${agent.id}/metrics/summary`);
-        if (res.ok) {
-          const data = (await res.json()) as AgentMetricsSummary;
-          this.agentMetrics = { ...this.agentMetrics, [agent.id]: data };
-        }
-      } catch {
-        // Metrics loading is optional per agent.
-      }
-    });
-    await Promise.all(fetches);
+    const maxAgents = 20;
+    const concurrency = 5;
+    const subset = this.agents.slice(0, maxAgents);
+
+    // Process in batches of `concurrency`.
+    for (let i = 0; i < subset.length; i += concurrency) {
+      const batch = subset.slice(i, i + concurrency);
+      await Promise.all(
+        batch.map(async (agent) => {
+          try {
+            const res = await apiFetch(`/api/v1/agents/${agent.id}/metrics/summary`);
+            if (res.ok) {
+              const data = (await res.json()) as AgentMetricsSummary;
+              this.agentMetrics = { ...this.agentMetrics, [agent.id]: data };
+            }
+          } catch {
+            // Metrics loading is optional per agent.
+          }
+        })
+      );
+    }
   }
 
   private backgroundRefresh(): void {

--- a/web/src/components/pages/agents.ts
+++ b/web/src/components/pages/agents.ts
@@ -23,7 +23,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-import type { PageData, Agent, AgentPhase, Capabilities } from '../../shared/types.js';
+import type { PageData, Agent, AgentPhase, Capabilities, AgentMetricsSummary } from '../../shared/types.js';
 import { can, isTerminalAvailable, getAgentDisplayStatus, isAgentRunning } from '../../shared/types.js';
 
 type AgentSortField = 'name' | 'status' | 'created' | 'updated';
@@ -116,6 +116,10 @@ export class ScionPageAgents extends LitElement {
 
   @state()
   private quickMessageOpen = false;
+
+  /** Per-agent metrics summaries, keyed by agent ID. */
+  @state()
+  private agentMetrics: Record<string, AgentMetricsSummary> = {};
 
   static override styles = [
     listPageStyles,
@@ -425,12 +429,29 @@ export class ScionPageAgents extends LitElement {
 
     try {
       await this.fetchAndMergeAgents();
+      // Load metrics in background — non-blocking.
+      this.loadAgentMetrics();
     } catch (err) {
       console.error('Failed to load agents:', err);
       this.error = err instanceof Error ? err.message : 'Failed to load agents';
     } finally {
       this.loading = false;
     }
+  }
+
+  private async loadAgentMetrics(): Promise<void> {
+    const fetches = this.agents.map(async (agent) => {
+      try {
+        const res = await apiFetch(`/api/v1/agents/${agent.id}/metrics/summary`);
+        if (res.ok) {
+          const data = (await res.json()) as AgentMetricsSummary;
+          this.agentMetrics = { ...this.agentMetrics, [agent.id]: data };
+        }
+      } catch {
+        // Metrics loading is optional per agent.
+      }
+    });
+    await Promise.all(fetches);
   }
 
   private backgroundRefresh(): void {
@@ -1053,6 +1074,15 @@ export class ScionPageAgents extends LitElement {
 
         ${agent.taskSummary ? html` <div class="agent-task">${agent.taskSummary}</div> ` : ''}
 
+        ${this.agentMetrics[agent.id]
+          ? html`
+              <div class="agent-meta" style="margin-top: 0.5em; font-size: 0.8em; color: var(--scion-text-muted, #888);">
+                <div><sl-icon name="bar-chart"></sl-icon> ${this.agentMetrics[agent.id].totalSessions} sessions</div>
+                <div><sl-icon name="hash"></sl-icon> ${(this.agentMetrics[agent.id].totalTokensInput + this.agentMetrics[agent.id].totalTokensOutput).toLocaleString()} tokens</div>
+              </div>
+            `
+          : nothing}
+
         ${agent.labels && Object.keys(agent.labels).length > 0
           ? html`<div class="agent-labels" style="margin-top: 0.5em;">${Object.entries(agent.labels).map(
               ([k, v]) => html`<sl-tag size="small" variant="neutral" style="margin: 0.15em;">${k}: ${v}</sl-tag>`
@@ -1087,6 +1117,8 @@ export class ScionPageAgents extends LitElement {
                 @click=${() => this.toggleSort('updated')}
               >Updated <span class="sort-indicator">${this.sortIndicator('updated')}</span></th>
               <th class="hide-mobile">Task</th>
+              <th class="hide-mobile">Sessions</th>
+              <th class="hide-mobile">Tokens</th>
               <th style="text-align: right">Actions</th>
             </tr>
           </thead>
@@ -1120,6 +1152,8 @@ export class ScionPageAgents extends LitElement {
         <td class="hide-mobile">
           <span class="task-cell">${agent.taskSummary || '\u2014'}</span>
         </td>
+        <td class="hide-mobile">${this.agentMetrics[agent.id] ? this.agentMetrics[agent.id].totalSessions : '\u2014'}</td>
+        <td class="hide-mobile">${this.agentMetrics[agent.id] ? (this.agentMetrics[agent.id].totalTokensInput + this.agentMetrics[agent.id].totalTokensOutput).toLocaleString() : '\u2014'}</td>
         <td class="actions-cell">
           <span class="table-actions">
             ${this.renderActionButtons(agent)}

--- a/web/src/components/pages/project-detail.ts
+++ b/web/src/components/pages/project-detail.ts
@@ -23,7 +23,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-import type { PageData, Project, Agent, AgentPhase, Capabilities } from '../../shared/types.js';
+import type { PageData, Project, Agent, AgentPhase, Capabilities, ProjectSessionMetricsSummary } from '../../shared/types.js';
 import { can, canAny, getAgentDisplayStatus, isAgentRunning, isTerminalAvailable, isSharedWorkspace } from '../../shared/types.js';
 import type { StatusType } from '../shared/status-badge.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
@@ -160,6 +160,12 @@ export class ScionPageProjectDetail extends LitElement {
     activeAgents24h: number;
     periodLabel: string;
   } | null = null;
+
+  /**
+   * DB-backed session metrics summary for the project.
+   */
+  @state()
+  private sessionMetricsSummary: ProjectSessionMetricsSummary | null = null;
 
   /**
    * Whether the messages section is expanded (lazy-load trigger)
@@ -909,6 +915,7 @@ export class ScionPageProjectDetail extends LitElement {
 
       // Fetch metrics summary (non-blocking, gracefully degrades)
       void this.loadMetricsSummary();
+      void this.loadSessionMetricsSummary();
 
       // Auto-discover GitHub App installation if project has a GitHub remote but no installation
       if (this.project && this.project.gitRemote && /github\.com[/:]/.test(this.project.gitRemote) && this.project.githubInstallationId == null) {
@@ -938,6 +945,19 @@ export class ScionPageProjectDetail extends LitElement {
       this.metricsSummary = data;
     } catch {
       this.metricsSummary = null;
+    }
+  }
+
+  private async loadSessionMetricsSummary(): Promise<void> {
+    try {
+      const res = await apiFetch(`/api/v1/projects/${this.projectId}/metrics/summary`);
+      if (res.ok) {
+        this.sessionMetricsSummary = (await res.json()) as ProjectSessionMetricsSummary;
+      } else {
+        this.sessionMetricsSummary = null;
+      }
+    } catch {
+      this.sessionMetricsSummary = null;
     }
   }
 
@@ -1593,6 +1613,23 @@ export class ScionPageProjectDetail extends LitElement {
                 View Details
               </sl-button>
             </a>
+          </div>
+        </div>
+      ` : nothing}
+
+      ${this.sessionMetricsSummary ? html`
+        <div class="stats-row" style="margin-top: 0.5rem;">
+          <div class="stat">
+            <span class="stat-label">Total Sessions</span>
+            <span class="stat-value">${this.sessionMetricsSummary.totalSessions}</span>
+          </div>
+          <div class="stat">
+            <span class="stat-label">Total Tokens</span>
+            <span class="stat-value">${this.formatTokenCount(this.sessionMetricsSummary.totalTokensInput + this.sessionMetricsSummary.totalTokensOutput)}</span>
+          </div>
+          <div class="stat">
+            <span class="stat-label">Active Agents</span>
+            <span class="stat-value">${this.sessionMetricsSummary.activeAgents}</span>
           </div>
         </div>
       ` : nothing}

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -947,3 +947,85 @@ export interface PreStartHook extends PreStartHookSummary {
   created: string;
   updated: string;
 }
+
+// =============================================================================
+// Session Metrics (DB-backed, from M3/M4 milestone)
+// =============================================================================
+
+/**
+ * A single agent session metrics record.
+ * Mirrors the Go `store.AgentSessionMetrics` struct.
+ */
+export interface AgentSessionMetrics {
+  id: string;
+  agentId: string;
+  projectId: string;
+  sessionId: string;
+  startedAt: string;
+  endedAt?: string;
+  status?: string;
+  turnCount?: number;
+  model?: string;
+  tokensInput?: number;
+  tokensOutput?: number;
+  tokensCached?: number;
+  tokensReasoning?: number;
+  toolCalls?: Record<string, ToolCallStats>;
+  languages?: string[];
+  createdAt: string;
+}
+
+/** Tool call statistics within a session. */
+export interface ToolCallStats {
+  calls: number;
+  success: number;
+  error: number;
+}
+
+/** Tool usage summary in aggregate responses. */
+export interface ToolUsageSummary {
+  name: string;
+  calls: number;
+  success: number;
+  errors: number;
+}
+
+/** Model usage summary in aggregate responses. */
+export interface ModelUsageSummary {
+  model: string;
+  sessions: number;
+}
+
+/**
+ * Aggregate session metrics for a single agent.
+ * Response from GET /api/v1/agents/{id}/metrics/summary.
+ */
+export interface AgentMetricsSummary {
+  agentId: string;
+  totalSessions: number;
+  totalTokensInput: number;
+  totalTokensOutput: number;
+  totalTokensCached: number;
+  totalTokensReasoning: number;
+  totalToolCalls: number;
+  avgSessionDurationMs: number;
+  avgTokensPerSession: number;
+  mostUsedTools: ToolUsageSummary[];
+  mostUsedModels: ModelUsageSummary[];
+}
+
+/**
+ * Aggregate session metrics for a project.
+ * Response from GET /api/v1/projects/{id}/metrics/summary.
+ */
+export interface ProjectSessionMetricsSummary {
+  projectId: string;
+  totalSessions: number;
+  totalTokensInput: number;
+  totalTokensOutput: number;
+  totalTokensCached: number;
+  totalTokensReasoning: number;
+  activeAgents: number;
+  mostUsedTools: ToolUsageSummary[];
+  mostUsedModels: ModelUsageSummary[];
+}

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -987,7 +987,7 @@ export interface ToolUsageSummary {
   name: string;
   calls: number;
   success: number;
-  errors: number;
+  error: number;
 }
 
 /** Model usage summary in aggregate responses. */


### PR DESCRIPTION
Adds Hub API endpoints and web UI components for viewing agent session metrics (M4 milestone).

API endpoints:
- GET /api/v1/agents/{id}/metrics/summary — aggregate metrics for an agent
- GET /api/v1/metrics/session/{id} — detailed session metrics
- GET /api/v1/projects/{id}/metrics/summary — project-level aggregation

Web UI:
- Agent detail metrics tab showing session history with token counts, tool usage, model, duration
- Agents list with aggregate activity stats columns (total sessions, total tokens)
- Project summary metrics view

Key details:
- SQL-level aggregation for performance (no N+1 queries)
- Authorization checks on all API paths (IDOR fix)
- 100-record cap on tool/model breakdowns
- 19 test sub-tests

Depends on M3 (ptone/scion#678) for the agent_session_metrics table.
Addresses ptone/scion#679