### PR TITLE
fix(hub): return 503 when verifying SA without token generator

### DIFF
--- a/pkg/hub/handlers_gcp_identity.go
+++ b/pkg/hub/handlers_gcp_identity.go
@@ -399,23 +399,28 @@ func (s *Server) verifyGCPServiceAccount(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	// Attempt to verify impersonation via the GCP token generator
-	if s.gcpTokenGenerator != nil {
-		if err := s.gcpTokenGenerator.VerifyImpersonation(r.Context(), sa.Email); err != nil {
-			// Persist the failure status
-			sa.Verified = false
-			sa.VerificationStatus = "failed"
-			sa.VerificationError = err.Error()
-			_ = s.store.UpdateGCPServiceAccount(r.Context(), sa)
+	// Fail-closed: if no token generator is configured, we cannot verify.
+	if s.gcpTokenGenerator == nil {
+		writeError(w, http.StatusServiceUnavailable, "gcp_not_configured",
+			"GCP token generation is not configured on this Hub", nil)
+		return
+	}
 
-			details := map[string]interface{}{
-				"hubServiceAccountEmail": s.gcpTokenGenerator.ServiceAccountEmail(),
-				"targetEmail":            sa.Email,
-			}
-			writeError(w, http.StatusBadGateway, "gcp_verification_failed",
-				"Failed to verify impersonation: "+err.Error(), details)
-			return
+	// Attempt to verify impersonation via the GCP token generator
+	if err := s.gcpTokenGenerator.VerifyImpersonation(r.Context(), sa.Email); err != nil {
+		// Persist the failure status
+		sa.Verified = false
+		sa.VerificationStatus = "failed"
+		sa.VerificationError = err.Error()
+		_ = s.store.UpdateGCPServiceAccount(r.Context(), sa)
+
+		details := map[string]interface{}{
+			"hubServiceAccountEmail": s.gcpTokenGenerator.ServiceAccountEmail(),
+			"targetEmail":            sa.Email,
 		}
+		writeError(w, http.StatusBadGateway, "gcp_verification_failed",
+			"Failed to verify impersonation: "+err.Error(), details)
+		return
 	}
 
 	sa.Verified = true

--- a/pkg/hub/handlers_gcp_identity_test.go
+++ b/pkg/hub/handlers_gcp_identity_test.go
@@ -783,6 +783,38 @@ func TestGCPSA_ProjectOwnerCanAddMembers(t *testing.T) {
 		"project owner should be able to add members to project group; got: %s", rec.Body.String())
 }
 
+func TestVerifyGCPServiceAccount_NoTokenGenerator_Returns503(t *testing.T) {
+	srv, s := testServer(t) // no token generator configured
+	projectID := createTestProjectForSA(t, srv, s)
+
+	// Create a SA to verify
+	body := map[string]string{
+		"email":     "agent@my-project.iam.gserviceaccount.com",
+		"projectId": "my-project",
+	}
+	rec := doRequest(t, srv, http.MethodPost,
+		fmt.Sprintf("/api/v1/projects/%s/gcp-service-accounts", projectID), body)
+	require.Equal(t, http.StatusCreated, rec.Code, "create SA: %s", rec.Body.String())
+
+	var sa store.GCPServiceAccount
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&sa))
+
+	// Attempt to verify — should fail with 503 because no token generator
+	rec = doRequest(t, srv, http.MethodPost,
+		fmt.Sprintf("/api/v1/projects/%s/gcp-service-accounts/%s/verify", projectID, sa.ID), nil)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code,
+		"verify without token generator should return 503; got: %s", rec.Body.String())
+
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "gcp_not_configured", errResp.Error.Code)
+
+	// Verify the SA was NOT marked as Verified=true
+	storedSA, err := s.GetGCPServiceAccount(context.Background(), sa.ID)
+	require.NoError(t, err)
+	assert.False(t, storedSA.Verified, "SA should NOT be marked as verified when token generator is nil")
+}
+
 func TestProjectIDFromServiceAccountEmail(t *testing.T) {
 	tests := []struct {
 		email string


### PR DESCRIPTION
## Summary

verifyGCPServiceAccount falsely marked SAs as Verified=true without contacting GCP when no token generator configured. Adds fail-closed 503 guard.

Ref: ptone/scion#757

## Test plan
- New test + all GCP tests pass
