### PR TITLE
feat(admin): add A2A bridge to admin integrations (Phases 1+2)

### DIFF
--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -344,6 +344,104 @@ func AddSelfManagedPluginToSettings(entry SelfManagedPluginEntry) error {
 	return os.WriteFile(settingsPath, out, 0644)
 }
 
+// AddSelfManagedPluginWithBrokerType combines AddSelfManagedPluginToSettings and
+// AddPluginToMessageBrokerTypes into a single read-modify-write cycle, avoiding
+// the redundant file I/O of calling them separately.
+func AddSelfManagedPluginWithBrokerType(entry SelfManagedPluginEntry) error {
+	globalDir, err := GetGlobalDir()
+	if err != nil {
+		return fmt.Errorf("resolve global dir: %w", err)
+	}
+
+	settingsPath := filepath.Join(globalDir, "settings.yaml")
+
+	var raw map[string]interface{}
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("read settings file: %w", err)
+		}
+		raw = make(map[string]interface{})
+	} else {
+		if err := yamlv3.Unmarshal(data, &raw); err != nil {
+			return fmt.Errorf("parse settings file: %w", err)
+		}
+		if raw == nil {
+			raw = make(map[string]interface{})
+		}
+	}
+
+	server, _ := raw["server"].(map[string]interface{})
+	if server == nil {
+		server = make(map[string]interface{})
+		raw["server"] = server
+	}
+
+	// --- Plugin entry ---
+	plugins, _ := server["plugins"].(map[string]interface{})
+	if plugins == nil {
+		plugins = make(map[string]interface{})
+		server["plugins"] = plugins
+	}
+
+	broker, _ := plugins["broker"].(map[string]interface{})
+	if broker == nil {
+		broker = make(map[string]interface{})
+		plugins["broker"] = broker
+	}
+
+	broker[entry.Name] = map[string]interface{}{
+		"self_managed": true,
+		"mode":         "self-managed",
+		"address":      entry.Address,
+		"config_file":  entry.ConfigFile,
+	}
+
+	// --- Message broker types ---
+	mb, _ := server["message_broker"].(map[string]interface{})
+	if mb == nil {
+		mb = make(map[string]interface{})
+		server["message_broker"] = mb
+	}
+
+	mb["enabled"] = true
+
+	var types []string
+	if existing, ok := mb["types"]; ok {
+		if arr, ok := existing.([]interface{}); ok {
+			for _, v := range arr {
+				if s, ok := v.(string); ok {
+					types = append(types, s)
+				}
+			}
+		}
+	}
+
+	hasPlugin := false
+	for _, t := range types {
+		if t == entry.Name {
+			hasPlugin = true
+			break
+		}
+	}
+	if !hasPlugin {
+		types = append(types, entry.Name)
+	}
+
+	iface := make([]interface{}, len(types))
+	for i, t := range types {
+		iface[i] = t
+	}
+	mb["types"] = iface
+
+	out, err := yamlv3.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("marshal settings: %w", err)
+	}
+
+	return os.WriteFile(settingsPath, out, 0644)
+}
+
 // AddPluginToSettings adds a broker plugin entry to the global settings.yaml.
 func AddPluginToSettings(pluginName, configFilePath string) error {
 	globalDir, err := GetGlobalDir()

--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -42,6 +42,9 @@ const (
 
 	// Google Chat
 	SecretGChatSigningKey = "GCHAT_SIGNING_KEY"
+
+	// A2A Bridge
+	SecretA2AAPIKey = "A2A_API_KEY"
 )
 
 // IntegrationConfigProvider defines the interface for reading and writing
@@ -162,6 +165,9 @@ var PluginSecretKeyMap = map[string][]IntegrationSecretMapping{
 	"chat-app": {
 		{SecretGChatSigningKey, "signing_key"},
 	},
+	"a2a-bridge": {
+		{SecretA2AAPIKey, "api_key"},
+	},
 }
 
 // wiringKeys are config keys that always come from settings.yaml inline config,
@@ -204,6 +210,7 @@ var backendSecretKeys = []string{
 	SecretDiscordBotToken, SecretDiscordPublicKey,
 	SecretSlackBotToken, SecretSlackAppToken, SecretSlackSigningSecret,
 	SecretGChatSigningKey,
+	SecretA2AAPIKey,
 }
 
 // ResolvePluginConfig builds the config map for a plugin with consistent precedence.
@@ -268,6 +275,73 @@ func ResolvePluginConfig(configFile string, inlineConfig map[string]string) (map
 	}
 
 	return merged, nil
+}
+
+// SelfManagedPluginEntry holds the parameters for registering a self-managed
+// broker plugin in settings.yaml.
+type SelfManagedPluginEntry struct {
+	Name       string // plugin name (settings.yaml key)
+	Address    string // RPC address, e.g. "localhost:9090"
+	ConfigFile string // path to the Hub-side admin config file
+}
+
+// AddSelfManagedPluginToSettings adds a self-managed broker plugin entry to
+// the global settings.yaml with mode, address, and config_file fields.
+func AddSelfManagedPluginToSettings(entry SelfManagedPluginEntry) error {
+	globalDir, err := GetGlobalDir()
+	if err != nil {
+		return fmt.Errorf("resolve global dir: %w", err)
+	}
+
+	settingsPath := filepath.Join(globalDir, "settings.yaml")
+
+	var raw map[string]interface{}
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("read settings file: %w", err)
+		}
+		raw = make(map[string]interface{})
+	} else {
+		if err := yamlv3.Unmarshal(data, &raw); err != nil {
+			return fmt.Errorf("parse settings file: %w", err)
+		}
+		if raw == nil {
+			raw = make(map[string]interface{})
+		}
+	}
+
+	server, _ := raw["server"].(map[string]interface{})
+	if server == nil {
+		server = make(map[string]interface{})
+		raw["server"] = server
+	}
+
+	plugins, _ := server["plugins"].(map[string]interface{})
+	if plugins == nil {
+		plugins = make(map[string]interface{})
+		server["plugins"] = plugins
+	}
+
+	broker, _ := plugins["broker"].(map[string]interface{})
+	if broker == nil {
+		broker = make(map[string]interface{})
+		plugins["broker"] = broker
+	}
+
+	broker[entry.Name] = map[string]interface{}{
+		"self_managed": true,
+		"mode":         "self-managed",
+		"address":      entry.Address,
+		"config_file":  entry.ConfigFile,
+	}
+
+	out, err := yamlv3.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("marshal settings: %w", err)
+	}
+
+	return os.WriteFile(settingsPath, out, 0644)
 }
 
 // AddPluginToSettings adds a broker plugin entry to the global settings.yaml.

--- a/pkg/config/integration_config_test.go
+++ b/pkg/config/integration_config_test.go
@@ -506,6 +506,79 @@ func TestIsSecretConfigKey(t *testing.T) {
 	}
 }
 
+func TestPluginSecretKeyMap_A2ABridge(t *testing.T) {
+	mappings, ok := PluginSecretKeyMap["a2a-bridge"]
+	if !ok {
+		t.Fatal("a2a-bridge not in PluginSecretKeyMap")
+	}
+	if len(mappings) != 1 {
+		t.Fatalf("expected 1 mapping, got %d", len(mappings))
+	}
+	if mappings[0].SecretKey != SecretA2AAPIKey {
+		t.Errorf("expected SecretKey=%q, got %q", SecretA2AAPIKey, mappings[0].SecretKey)
+	}
+	if mappings[0].ConfigKey != "api_key" {
+		t.Errorf("expected ConfigKey=%q, got %q", "api_key", mappings[0].ConfigKey)
+	}
+}
+
+func TestIsSecretConfigKey_A2AApiKey(t *testing.T) {
+	if !IsSecretConfigKey("api_key") {
+		t.Error("expected api_key to be a secret config key")
+	}
+}
+
+func TestAddSelfManagedPluginToSettings(t *testing.T) {
+	_, settingsPath := setupTestHome(t)
+
+	// Seed a minimal settings.yaml.
+	if err := os.WriteFile(settingsPath, []byte("server:\n  plugins: {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	entry := SelfManagedPluginEntry{
+		Name:       "a2a-bridge",
+		Address:    "localhost:9090",
+		ConfigFile: "~/.scion/scion-a2a-bridge-admin.yaml",
+	}
+
+	if err := AddSelfManagedPluginToSettings(entry); err != nil {
+		t.Fatalf("AddSelfManagedPluginToSettings() error: %v", err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+
+	server := raw["server"].(map[string]interface{})
+	plugins := server["plugins"].(map[string]interface{})
+	broker := plugins["broker"].(map[string]interface{})
+
+	a2aEntry, ok := broker["a2a-bridge"].(map[string]interface{})
+	if !ok {
+		t.Fatal("a2a-bridge entry not found in broker map")
+	}
+
+	if sm, ok := a2aEntry["self_managed"].(bool); !ok || !sm {
+		t.Error("expected self_managed = true")
+	}
+	if mode, ok := a2aEntry["mode"].(string); !ok || mode != "self-managed" {
+		t.Errorf("expected mode = self-managed, got %v", a2aEntry["mode"])
+	}
+	if addr, ok := a2aEntry["address"].(string); !ok || addr != "localhost:9090" {
+		t.Errorf("expected address = localhost:9090, got %v", a2aEntry["address"])
+	}
+	if cf, ok := a2aEntry["config_file"].(string); !ok || cf != "~/.scion/scion-a2a-bridge-admin.yaml" {
+		t.Errorf("expected config_file, got %v", a2aEntry["config_file"])
+	}
+}
+
 func TestLoadPluginConfigFile_FiltersSecretKeys(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "plugin.yaml")

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -968,16 +968,14 @@ func (s *Server) handleInstallSelfManaged(w http.ResponseWriter, r *http.Request
 		slog.Info("Bridge config file already exists, preserving", "plugin", name, "path", resolvedBridgePath)
 	}
 
-	// 3. Register in settings.yaml with self-managed fields.
+	// 3. Register in settings.yaml with self-managed fields and broker type
+	//    in a single read-modify-write cycle.
 	settingsWriteMu.Lock()
-	err = config.AddSelfManagedPluginToSettings(config.SelfManagedPluginEntry{
+	err = config.AddSelfManagedPluginWithBrokerType(config.SelfManagedPluginEntry{
 		Name:       name,
 		Address:    "localhost:9090",
 		ConfigFile: adminConfigPath,
 	})
-	if err == nil {
-		err = config.AddPluginToMessageBrokerTypes(name)
-	}
 	settingsWriteMu.Unlock()
 	if err != nil {
 		slog.Error("Failed to add self-managed plugin to settings.yaml", "plugin", name, "error", err)
@@ -986,7 +984,10 @@ func (s *Server) handleInstallSelfManaged(w http.ResponseWriter, r *http.Request
 	}
 
 	// 4. Attempt LoadOne — non-fatal if the bridge is not running.
-	pluginsDir, _ := plugin.DefaultPluginsDir()
+	pluginsDir, err := plugin.DefaultPluginsDir()
+	if err != nil {
+		slog.Warn("Failed to resolve plugins directory, continuing without it", "plugin", name, "error", err)
+	}
 	if err := mgr.LoadOne(plugin.PluginTypeBroker, name, plugin.PluginEntry{
 		SelfManaged: true,
 		Mode:        "self-managed",

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -147,16 +147,42 @@ type IntegrationUpdateResponse struct {
 	UpdatedAt   string `json:"updated_at,omitempty"`
 }
 
-// knownPlugins is the list of plugins that can be discovered for installation.
-var knownPlugins = []string{"telegram", "discord", "slack"}
+// KnownPlugin describes a plugin that can be discovered for installation.
+// The catalog replaces the former knownPlugins string list so that per-plugin
+// metadata (binary name, source directory, self-managed flag) is explicit
+// rather than derived from naming conventions.
+type KnownPlugin struct {
+	Name        string // settings.yaml key: "a2a-bridge"
+	Platform    string // platform identifier: "a2a"
+	BinaryName  string // binary name, default "scion-plugin-<name>"
+	SourceDir   string // source directory, default "extras/scion-<name>"
+	SelfManaged bool   // true = register+instruct, never build/launch
+}
+
+var knownPluginCatalog = []KnownPlugin{
+	{Name: "telegram", Platform: "telegram", BinaryName: "scion-plugin-telegram", SourceDir: "extras/scion-telegram"},
+	{Name: "discord", Platform: "discord", BinaryName: "scion-plugin-discord", SourceDir: "extras/scion-discord"},
+	{Name: "slack", Platform: "slack", BinaryName: "scion-plugin-slack", SourceDir: "extras/scion-slack"},
+	{Name: "a2a-bridge", Platform: "a2a", BinaryName: "scion-a2a-bridge", SourceDir: "extras/scion-a2a-bridge", SelfManaged: true},
+}
 
 var knownPluginSet = func() map[string]bool {
-	s := make(map[string]bool, len(knownPlugins))
-	for _, n := range knownPlugins {
-		s[n] = true
+	s := make(map[string]bool, len(knownPluginCatalog))
+	for _, p := range knownPluginCatalog {
+		s[p.Name] = true
 	}
 	return s
 }()
+
+// lookupKnownPlugin returns the catalog entry for the named plugin, or nil.
+func lookupKnownPlugin(name string) *KnownPlugin {
+	for i := range knownPluginCatalog {
+		if knownPluginCatalog[i].Name == name {
+			return &knownPluginCatalog[i]
+		}
+	}
+	return nil
+}
 
 // settingsWriteMu guards concurrent writes to settings.yaml.
 var settingsWriteMu sync.Mutex
@@ -692,6 +718,12 @@ func (s *Server) handleUpdateIntegration(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
+	// Self-managed plugins cannot be updated via the Hub (no build/launch).
+	if kp := lookupKnownPlugin(name); kp != nil && kp.SelfManaged {
+		BadRequest(w, "self-managed integrations cannot be updated via the Hub — update the binary manually and click Reconnect")
+		return
+	}
+
 	// HA (Mode 3) integrations: insert an update request row + NOTIFY.
 	if s.isHAIntegration(mgr, name) {
 		s.handleUpdateIntegrationHA(w, r, name)
@@ -750,8 +782,22 @@ func (s *Server) handleInstallIntegration(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// Look up the catalog entry for this plugin.
+	kp := lookupKnownPlugin(name)
+	if kp == nil {
+		BadRequest(w, "unknown integration: "+name)
+		return
+	}
+
+	// Self-managed plugins have a distinct install flow: register + scaffold
+	// + instruct, no build or process launch.
+	if kp.SelfManaged {
+		s.handleInstallSelfManaged(w, r, mgr, kp)
+		return
+	}
+
 	repoPath := s.config.MaintenanceConfig.RepoPath
-	binaryName := "scion-plugin-" + name
+	binaryName := kp.BinaryName
 	_, lookPathErr := exec.LookPath(binaryName)
 	binaryOnPath := lookPathErr == nil
 
@@ -765,7 +811,7 @@ func (s *Server) handleInstallIntegration(w http.ResponseWriter, r *http.Request
 
 	// Source-dir check and build lock only apply when building from source.
 	if repoPath != "" {
-		sourceDir := filepath.Join(repoPath, "extras", "scion-"+name)
+		sourceDir := filepath.Join(repoPath, kp.SourceDir)
 		if _, err := os.Stat(sourceDir); err != nil {
 			NotFound(w, "plugin source")
 			return
@@ -860,6 +906,127 @@ func (s *Server) handleInstallIntegration(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
+// handleInstallSelfManaged implements the install flow for self-managed plugins
+// (e.g. A2A bridge): create the Hub-side admin config file, register in
+// settings.yaml with self_managed/mode/address/config_file, attempt LoadOne
+// (non-fatal if the bridge process is not running), and return setup
+// instructions.
+func (s *Server) handleInstallSelfManaged(w http.ResponseWriter, r *http.Request, mgr IntegrationManager, kp *KnownPlugin) {
+	name := kp.Name
+
+	// Also reject if already registered in settings.yaml but not loaded.
+	if entry := installedPluginSettingsEntry(name); entry != nil {
+		BadRequest(w, "integration is already installed")
+		return
+	}
+
+	// 1. Create the Hub-side flat admin config file (if absent).
+	adminConfigPath := "~/.scion/scion-" + name + "-admin.yaml"
+	resolvedAdminPath := adminConfigPath
+	if home, err := os.UserHomeDir(); err == nil {
+		resolvedAdminPath = filepath.Join(home, adminConfigPath[2:])
+	}
+	if _, err := os.Stat(resolvedAdminPath); err != nil {
+		if !os.IsNotExist(err) {
+			slog.Error("Failed to check admin config file", "plugin", name, "path", resolvedAdminPath, "error", err)
+			InternalError(w)
+			return
+		}
+		if err := createSelfManagedAdminConfig(name, adminConfigPath); err != nil {
+			slog.Error("Failed to create admin config file", "plugin", name, "error", err)
+			InternalError(w)
+			return
+		}
+	} else {
+		slog.Info("Admin config file already exists, preserving", "plugin", name, "path", resolvedAdminPath)
+	}
+
+	// 2. Register in settings.yaml with self-managed fields.
+	settingsWriteMu.Lock()
+	err := config.AddSelfManagedPluginToSettings(config.SelfManagedPluginEntry{
+		Name:       name,
+		Address:    "localhost:9090",
+		ConfigFile: adminConfigPath,
+	})
+	if err == nil {
+		err = config.AddPluginToMessageBrokerTypes(name)
+	}
+	settingsWriteMu.Unlock()
+	if err != nil {
+		slog.Error("Failed to add self-managed plugin to settings.yaml", "plugin", name, "error", err)
+		InternalError(w)
+		return
+	}
+
+	// 3. Attempt LoadOne — non-fatal if the bridge is not running.
+	pluginsDir, _ := plugin.DefaultPluginsDir()
+	if err := mgr.LoadOne(plugin.PluginTypeBroker, name, plugin.PluginEntry{
+		SelfManaged: true,
+		Mode:        "self-managed",
+		Address:     "localhost:9090",
+		ConfigFile:  adminConfigPath,
+	}, pluginsDir); err != nil {
+		slog.Warn("Self-managed plugin installed but bridge not reachable (expected for fresh installs)",
+			"plugin", name, "error", err)
+	} else {
+		// If LoadOne succeeded, wire up the spoke and reconfigure.
+		if err := s.reconfigureIntegration(r.Context(), mgr, name); err != nil {
+			slog.Warn("Self-managed plugin reconfigure failed after LoadOne", "plugin", name, "error", err)
+		}
+		s.ensureBrokerSpoke(mgr, name)
+	}
+
+	// 4. Return setup instructions.
+	configFile := "~/.scion/scion-" + name + ".yaml"
+	startCommand := kp.BinaryName + " -config " + configFile
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"status": "installed",
+		"setup": map[string]string{
+			"binary":        kp.BinaryName,
+			"config_file":   configFile,
+			"start_command": startCommand,
+			"notes":         "Start the bridge process, then click Reconnect to activate.",
+		},
+	})
+}
+
+// createSelfManagedAdminConfig creates a default Hub-side flat admin config
+// file for a self-managed plugin.
+func createSelfManagedAdminConfig(pluginName, configFilePath string) error {
+	resolved := configFilePath
+	if strings.HasPrefix(resolved, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("resolve home dir: %w", err)
+		}
+		resolved = filepath.Join(home, resolved[2:])
+	}
+
+	dir := filepath.Dir(resolved)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	content := "# Scion admin configuration for " + pluginName + "\n"
+	switch pluginName {
+	case "a2a-bridge":
+		content += "external_url: \"\"\n"
+		content += "auth_scheme: \"none\"\n"
+		content += "rate_limit_enabled: \"false\"\n"
+		content += "rate_limit_rps: \"10\"\n"
+		content += "rate_limit_burst: \"20\"\n"
+		content += "send_message_timeout: \"120s\"\n"
+		content += "sse_keepalive: \"30s\"\n"
+		content += "push_retry_max: \"3\"\n"
+		content += "provider_org: \"\"\n"
+		content += "provider_url: \"\"\n"
+		content += "projects_json: \"[]\"\n"
+	}
+
+	return os.WriteFile(resolved, []byte(content), 0600)
+}
+
 func (s *Server) handleListAvailableIntegrations(w http.ResponseWriter, _ *http.Request) {
 	s.mu.RLock()
 	mgr := s.pluginManager
@@ -882,24 +1049,22 @@ func (s *Server) handleListAvailableIntegrations(w http.ResponseWriter, _ *http.
 	}
 
 	var available []AvailableIntegration
-	for _, name := range knownPlugins {
-		if mgr != nil && mgr.HasPlugin("broker", name) {
+	for _, kp := range knownPluginCatalog {
+		if mgr != nil && mgr.HasPlugin("broker", kp.Name) {
 			continue
 		}
 		// Also skip if registered in settings.yaml (installed but not yet loaded).
-		if _, ok := settingsBroker[name]; ok {
+		if _, ok := settingsBroker[kp.Name]; ok {
 			continue
 		}
 
-		binaryName := "scion-plugin-" + name
-
 		// Check 1: binary is on $PATH (covers Homebrew / package-manager installs).
-		_, onPathErr := exec.LookPath(binaryName)
+		_, onPathErr := exec.LookPath(kp.BinaryName)
 
 		// Check 2: source checkout exists (covers development installs).
 		inSourceCheckout := false
 		if repoPath != "" {
-			sourceDir := filepath.Join(repoPath, "extras", "scion-"+name)
+			sourceDir := filepath.Join(repoPath, kp.SourceDir)
 			if _, err := os.Stat(sourceDir); err == nil {
 				inSourceCheckout = true
 			}
@@ -910,8 +1075,8 @@ func (s *Server) handleListAvailableIntegrations(w http.ResponseWriter, _ *http.
 		}
 
 		available = append(available, AvailableIntegration{
-			Name:     name,
-			Platform: resolvePlatform(name),
+			Name:     kp.Name,
+			Platform: kp.Platform,
 		})
 	}
 
@@ -1010,6 +1175,8 @@ func resolvePlatform(name string) string {
 		return "slack"
 	case "chat-app":
 		return "gchat"
+	case "a2a-bridge":
+		return "a2a"
 	default:
 		return name
 	}

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -835,9 +835,11 @@ func (s *Server) handleInstallIntegration(w http.ResponseWriter, r *http.Request
 	}
 
 	configFilePath := "~/.scion/scion-" + name + ".yaml"
-	resolvedConfigPath := configFilePath
-	if home, err := os.UserHomeDir(); err == nil {
-		resolvedConfigPath = filepath.Join(home, configFilePath[2:])
+	resolvedConfigPath, err := resolveTilde(configFilePath)
+	if err != nil {
+		slog.Error("Failed to resolve config file path", "plugin", name, "error", err)
+		InternalError(w)
+		return
 	}
 	if _, err := os.Stat(resolvedConfigPath); err != nil {
 		if !os.IsNotExist(err) {
@@ -922,9 +924,11 @@ func (s *Server) handleInstallSelfManaged(w http.ResponseWriter, r *http.Request
 
 	// 1. Create the Hub-side flat admin config file (if absent).
 	adminConfigPath := "~/.scion/scion-" + name + "-admin.yaml"
-	resolvedAdminPath := adminConfigPath
-	if home, err := os.UserHomeDir(); err == nil {
-		resolvedAdminPath = filepath.Join(home, adminConfigPath[2:])
+	resolvedAdminPath, err := resolveTilde(adminConfigPath)
+	if err != nil {
+		slog.Error("Failed to resolve admin config path", "plugin", name, "error", err)
+		InternalError(w)
+		return
 	}
 	if _, err := os.Stat(resolvedAdminPath); err != nil {
 		if !os.IsNotExist(err) {
@@ -941,9 +945,32 @@ func (s *Server) handleInstallSelfManaged(w http.ResponseWriter, r *http.Request
 		slog.Info("Admin config file already exists, preserving", "plugin", name, "path", resolvedAdminPath)
 	}
 
-	// 2. Register in settings.yaml with self-managed fields.
+	// 2. Create bridge bootstrap config template (if absent).
+	bridgeConfigPath := "~/.scion/scion-" + name + ".yaml"
+	resolvedBridgePath, err := resolveTilde(bridgeConfigPath)
+	if err != nil {
+		slog.Error("Failed to resolve bridge config path", "plugin", name, "error", err)
+		InternalError(w)
+		return
+	}
+	if _, err := os.Stat(resolvedBridgePath); err != nil {
+		if !os.IsNotExist(err) {
+			slog.Error("Failed to check bridge config file", "plugin", name, "path", resolvedBridgePath, "error", err)
+			InternalError(w)
+			return
+		}
+		if err := createBridgeConfigTemplate(name, bridgeConfigPath, s.config.HubEndpoint); err != nil {
+			slog.Error("Failed to create bridge config template", "plugin", name, "error", err)
+			InternalError(w)
+			return
+		}
+	} else {
+		slog.Info("Bridge config file already exists, preserving", "plugin", name, "path", resolvedBridgePath)
+	}
+
+	// 3. Register in settings.yaml with self-managed fields.
 	settingsWriteMu.Lock()
-	err := config.AddSelfManagedPluginToSettings(config.SelfManagedPluginEntry{
+	err = config.AddSelfManagedPluginToSettings(config.SelfManagedPluginEntry{
 		Name:       name,
 		Address:    "localhost:9090",
 		ConfigFile: adminConfigPath,
@@ -958,7 +985,7 @@ func (s *Server) handleInstallSelfManaged(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// 3. Attempt LoadOne — non-fatal if the bridge is not running.
+	// 4. Attempt LoadOne — non-fatal if the bridge is not running.
 	pluginsDir, _ := plugin.DefaultPluginsDir()
 	if err := mgr.LoadOne(plugin.PluginTypeBroker, name, plugin.PluginEntry{
 		SelfManaged: true,
@@ -976,7 +1003,7 @@ func (s *Server) handleInstallSelfManaged(w http.ResponseWriter, r *http.Request
 		s.ensureBrokerSpoke(mgr, name)
 	}
 
-	// 4. Return setup instructions.
+	// 5. Return setup instructions.
 	configFile := "~/.scion/scion-" + name + ".yaml"
 	startCommand := kp.BinaryName + " -config " + configFile
 
@@ -994,13 +1021,9 @@ func (s *Server) handleInstallSelfManaged(w http.ResponseWriter, r *http.Request
 // createSelfManagedAdminConfig creates a default Hub-side flat admin config
 // file for a self-managed plugin.
 func createSelfManagedAdminConfig(pluginName, configFilePath string) error {
-	resolved := configFilePath
-	if strings.HasPrefix(resolved, "~/") {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("resolve home dir: %w", err)
-		}
-		resolved = filepath.Join(home, resolved[2:])
+	resolved, err := resolveTilde(configFilePath)
+	if err != nil {
+		return err
 	}
 
 	dir := filepath.Dir(resolved)
@@ -1013,6 +1036,7 @@ func createSelfManagedAdminConfig(pluginName, configFilePath string) error {
 	case "a2a-bridge":
 		content += "external_url: \"\"\n"
 		content += "auth_scheme: \"none\"\n"
+		content += "uat_cache_ttl: \"60s\"\n"
 		content += "rate_limit_enabled: \"false\"\n"
 		content += "rate_limit_rps: \"10\"\n"
 		content += "rate_limit_burst: \"20\"\n"
@@ -1023,6 +1047,38 @@ func createSelfManagedAdminConfig(pluginName, configFilePath string) error {
 		content += "provider_url: \"\"\n"
 		content += "projects_json: \"[]\"\n"
 	}
+
+	return os.WriteFile(resolved, []byte(content), 0600)
+}
+
+// createBridgeConfigTemplate creates a bridge bootstrap config template file
+// pre-filled with the Hub endpoint and default plugin listen address. The
+// template gives operators a working starting point for the bridge's own
+// nested YAML configuration.
+func createBridgeConfigTemplate(name, configFilePath, hubEndpoint string) error {
+	resolved, err := resolveTilde(configFilePath)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(resolved)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	content := "# Scion A2A bridge bootstrap configuration\n"
+	content += "# This file is operator-managed. Edit it to configure listen addresses,\n"
+	content += "# TLS, state database, and signing key settings.\n"
+	content += "hub:\n"
+	content += "  endpoint: \"" + hubEndpoint + "\"\n"
+	content += "plugin:\n"
+	content += "  listen_address: \"localhost:9090\"\n"
+	content += "# bridge:\n"
+	content += "#   listen_address: \":8081\"\n"
+	content += "# state:\n"
+	content += "#   database: \"~/.scion/scion-a2a-bridge.db\"\n"
+	content += "# logging:\n"
+	content += "#   level: \"info\"\n"
 
 	return os.WriteFile(resolved, []byte(content), 0600)
 }
@@ -1087,6 +1143,19 @@ func (s *Server) handleListAvailableIntegrations(w http.ResponseWriter, _ *http.
 }
 
 // --- Helpers ---
+
+// resolveTilde expands a leading "~/" in path to the user's home directory.
+// If the path does not start with "~/", it is returned unchanged.
+func resolveTilde(path string) (string, error) {
+	if !strings.HasPrefix(path, "~/") {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, path[2:]), nil
+}
 
 // installedPluginSettingsEntry returns the settings.yaml broker entry for the
 // named plugin, or nil if the plugin is not registered there. Used as the

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -2202,6 +2202,7 @@ func TestInstallIntegration_SelfManaged_CreatesAdminConfig(t *testing.T) {
 
 	srv := &Server{}
 	srv.pluginManager = mgr
+	srv.config.HubEndpoint = "http://hub.example.com:8080"
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations/a2a-bridge/install", nil)
@@ -2219,8 +2220,26 @@ func TestInstallIntegration_SelfManaged_CreatesAdminConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("admin config file not created: %v", err)
 	}
-	if !strings.Contains(string(data), "auth_scheme") {
-		t.Errorf("admin config missing expected defaults: %s", string(data))
+	adminStr := string(data)
+	if !strings.Contains(adminStr, "auth_scheme") {
+		t.Errorf("admin config missing expected defaults: %s", adminStr)
+	}
+	if !strings.Contains(adminStr, "uat_cache_ttl") {
+		t.Errorf("admin config missing uat_cache_ttl: %s", adminStr)
+	}
+
+	// Verify bridge bootstrap config template was created.
+	bridgeConfigPath := filepath.Join(tmpHome, ".scion", "scion-a2a-bridge.yaml")
+	bridgeData, err := os.ReadFile(bridgeConfigPath)
+	if err != nil {
+		t.Fatalf("bridge config file not created: %v", err)
+	}
+	bridgeStr := string(bridgeData)
+	if !strings.Contains(bridgeStr, "http://hub.example.com:8080") {
+		t.Errorf("bridge config missing hub endpoint: %s", bridgeStr)
+	}
+	if !strings.Contains(bridgeStr, "localhost:9090") {
+		t.Errorf("bridge config missing plugin listen_address: %s", bridgeStr)
 	}
 
 	// Verify settings.yaml was updated with self-managed entry.
@@ -2251,6 +2270,129 @@ func TestInstallIntegration_SelfManaged_CreatesAdminConfig(t *testing.T) {
 	}
 	if setup["binary"] != "scion-a2a-bridge" {
 		t.Errorf("expected binary=scion-a2a-bridge, got %v", setup["binary"])
+	}
+}
+
+func TestCreateBridgeConfigTemplate(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".scion"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	configPath := "~/.scion/scion-a2a-bridge.yaml"
+	hubEndpoint := "https://my-hub.example.com:9443"
+
+	if err := createBridgeConfigTemplate("a2a-bridge", configPath, hubEndpoint); err != nil {
+		t.Fatalf("createBridgeConfigTemplate failed: %v", err)
+	}
+
+	resolvedPath := filepath.Join(tmpHome, ".scion", "scion-a2a-bridge.yaml")
+	data, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		t.Fatalf("bridge config file not created: %v", err)
+	}
+
+	content := string(data)
+
+	// Verify hub endpoint is pre-filled.
+	if !strings.Contains(content, hubEndpoint) {
+		t.Errorf("bridge config missing hub endpoint %q: %s", hubEndpoint, content)
+	}
+
+	// Verify plugin listen address is set.
+	if !strings.Contains(content, "localhost:9090") {
+		t.Errorf("bridge config missing plugin listen_address: %s", content)
+	}
+
+	// Verify it contains commented-out defaults for operator reference.
+	if !strings.Contains(content, "# bridge:") {
+		t.Errorf("bridge config missing commented bridge section: %s", content)
+	}
+	if !strings.Contains(content, "operator-managed") {
+		t.Errorf("bridge config missing operator-managed note: %s", content)
+	}
+}
+
+func TestCreateBridgeConfigTemplate_PreservesExisting(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	scionDir := filepath.Join(tmpHome, ".scion")
+	if err := os.MkdirAll(scionDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-create the bridge config with custom content.
+	existingPath := filepath.Join(scionDir, "scion-a2a-bridge.yaml")
+	originalContent := "hub:\n  endpoint: \"https://custom-hub:1234\"\n"
+	if err := os.WriteFile(existingPath, []byte(originalContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Install should NOT overwrite existing bridge config — verified via the
+	// stat-before-create guard in handleInstallSelfManaged (the function itself
+	// always writes). Here we verify the guard at the handler level.
+	mgr := newMockIntegrationManager()
+	srv := &Server{}
+	srv.pluginManager = mgr
+	srv.config.HubEndpoint = "http://other-hub:8080"
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations/a2a-bridge/install", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify original content was preserved.
+	data, err := os.ReadFile(existingPath)
+	if err != nil {
+		t.Fatalf("failed to read bridge config: %v", err)
+	}
+	if string(data) != originalContent {
+		t.Errorf("bridge config was overwritten: got %q, want %q", string(data), originalContent)
+	}
+}
+
+func TestInstallIntegration_SelfManaged_RegisteredButNotLoaded(t *testing.T) {
+	// Test the installedPluginSettingsEntry(name) check path: plugin is
+	// registered in settings.yaml but NOT loaded into the manager.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".scion"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed settings.yaml with a2a-bridge entry (simulates a previous install
+	// where the bridge process was never started, so LoadOne never succeeded).
+	if err := config.AddSelfManagedPluginToSettings(config.SelfManagedPluginEntry{
+		Name:       "a2a-bridge",
+		Address:    "localhost:9090",
+		ConfigFile: "~/.scion/scion-a2a-bridge-admin.yaml",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := newMockIntegrationManager() // a2a-bridge NOT in mgr.plugins
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations/a2a-bridge/install", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for registered-but-not-loaded, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "already installed") {
+		t.Errorf("error should mention already installed: %s", rr.Body.String())
 	}
 }
 

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -2104,3 +2104,216 @@ func TestGetIntegration_ReadsFromConfigFile(t *testing.T) {
 		t.Error("hub_url should be filtered from settings")
 	}
 }
+
+// --- KnownPlugin catalog tests ---
+
+func TestLookupKnownPlugin_Found(t *testing.T) {
+	for _, name := range []string{"telegram", "discord", "slack", "a2a-bridge"} {
+		kp := lookupKnownPlugin(name)
+		if kp == nil {
+			t.Errorf("lookupKnownPlugin(%q) returned nil, want non-nil", name)
+			continue
+		}
+		if kp.Name != name {
+			t.Errorf("lookupKnownPlugin(%q).Name = %q", name, kp.Name)
+		}
+	}
+}
+
+func TestLookupKnownPlugin_NotFound(t *testing.T) {
+	if kp := lookupKnownPlugin("nonexistent"); kp != nil {
+		t.Errorf("lookupKnownPlugin(nonexistent) = %+v, want nil", kp)
+	}
+}
+
+func TestKnownPluginCatalog_A2ABridgeIsSelfManaged(t *testing.T) {
+	kp := lookupKnownPlugin("a2a-bridge")
+	if kp == nil {
+		t.Fatal("a2a-bridge not in catalog")
+	}
+	if !kp.SelfManaged {
+		t.Error("a2a-bridge should be SelfManaged")
+	}
+	if kp.Platform != "a2a" {
+		t.Errorf("a2a-bridge platform: got %q, want %q", kp.Platform, "a2a")
+	}
+	if kp.BinaryName != "scion-a2a-bridge" {
+		t.Errorf("a2a-bridge BinaryName: got %q, want %q", kp.BinaryName, "scion-a2a-bridge")
+	}
+	if kp.SourceDir != "extras/scion-a2a-bridge" {
+		t.Errorf("a2a-bridge SourceDir: got %q, want %q", kp.SourceDir, "extras/scion-a2a-bridge")
+	}
+}
+
+func TestKnownPluginCatalog_ChatPluginsNotSelfManaged(t *testing.T) {
+	for _, name := range []string{"telegram", "discord", "slack"} {
+		kp := lookupKnownPlugin(name)
+		if kp == nil {
+			t.Fatalf("%s not in catalog", name)
+		}
+		if kp.SelfManaged {
+			t.Errorf("%s should NOT be SelfManaged", name)
+		}
+	}
+}
+
+func TestKnownPluginSet_IncludesA2ABridge(t *testing.T) {
+	if !knownPluginSet["a2a-bridge"] {
+		t.Error("knownPluginSet should include a2a-bridge")
+	}
+}
+
+func TestResolvePlatform_A2ABridge(t *testing.T) {
+	if got := resolvePlatform("a2a-bridge"); got != "a2a" {
+		t.Errorf("resolvePlatform(a2a-bridge) = %q, want %q", got, "a2a")
+	}
+}
+
+func TestUpdateIntegration_SelfManagedRejected(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["a2a-bridge"] = map[string]string{}
+	mgr.selfManaged["a2a-bridge"] = true
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations/a2a-bridge/update", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for self-managed update, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "self-managed") {
+		t.Errorf("error should mention self-managed: %s", rr.Body.String())
+	}
+}
+
+func TestInstallIntegration_SelfManaged_CreatesAdminConfig(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".scion"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := newMockIntegrationManager()
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations/a2a-bridge/install", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify admin config file was created.
+	adminConfigPath := filepath.Join(tmpHome, ".scion", "scion-a2a-bridge-admin.yaml")
+	data, err := os.ReadFile(adminConfigPath)
+	if err != nil {
+		t.Fatalf("admin config file not created: %v", err)
+	}
+	if !strings.Contains(string(data), "auth_scheme") {
+		t.Errorf("admin config missing expected defaults: %s", string(data))
+	}
+
+	// Verify settings.yaml was updated with self-managed entry.
+	settingsPath := filepath.Join(tmpHome, ".scion", "settings.yaml")
+	settingsData, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("settings.yaml not created: %v", err)
+	}
+	settingsStr := string(settingsData)
+	if !strings.Contains(settingsStr, "a2a-bridge") {
+		t.Errorf("settings.yaml missing a2a-bridge entry: %s", settingsStr)
+	}
+	if !strings.Contains(settingsStr, "self_managed") {
+		t.Errorf("settings.yaml missing self_managed field: %s", settingsStr)
+	}
+
+	// Verify the response includes setup instructions.
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if resp["status"] != "installed" {
+		t.Errorf("expected status=installed, got %v", resp["status"])
+	}
+	setup, ok := resp["setup"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected setup object in response")
+	}
+	if setup["binary"] != "scion-a2a-bridge" {
+		t.Errorf("expected binary=scion-a2a-bridge, got %v", setup["binary"])
+	}
+}
+
+func TestInstallIntegration_SelfManaged_AlreadyInstalled(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".scion"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := newMockIntegrationManager()
+	mgr.plugins["a2a-bridge"] = map[string]string{}
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations/a2a-bridge/install", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for already-installed, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestListAvailableIntegrations_IncludesA2ABridge(t *testing.T) {
+	repoDir := t.TempDir()
+	// Create source directory for a2a-bridge.
+	if err := os.MkdirAll(filepath.Join(repoDir, "extras", "scion-a2a-bridge"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := newMockIntegrationManager()
+
+	srv := &Server{}
+	srv.config.MaintenanceConfig.RepoPath = repoDir
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/available", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var result []AvailableIntegration
+	if err := json.NewDecoder(rr.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	found := false
+	for _, a := range result {
+		if a.Name == "a2a-bridge" && a.Platform == "a2a" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a2a-bridge in available integrations, got %v", result)
+	}
+}

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -125,6 +125,15 @@ const PLATFORM_FIELDS: Record<string, PlatformFieldDef[]> = {
   a2a: [
     { key: 'external_url', label: 'External URL', description: 'Public URL for agent cards', defaultValue: '' },
     { key: 'auth_scheme', label: 'Auth Scheme', description: 'apiKey, bearer, none, hubUAT, or hubJWT', defaultValue: 'none' },
+    { key: 'uat_cache_ttl', label: 'UAT Cache TTL', description: 'Cache duration for UAT validation results', defaultValue: '60s' },
+    { key: 'rate_limit_enabled', label: 'Rate Limiting Enabled', description: 'Enable request rate limiting (true/false)', defaultValue: 'false' },
+    { key: 'rate_limit_rps', label: 'Rate Limit (req/s)', description: 'Maximum requests per second', defaultValue: '10' },
+    { key: 'rate_limit_burst', label: 'Rate Limit Burst', description: 'Maximum burst size for rate limiter', defaultValue: '20' },
+    { key: 'send_message_timeout', label: 'Send Message Timeout', description: 'Timeout for sending messages to agents', defaultValue: '120s' },
+    { key: 'sse_keepalive', label: 'SSE Keepalive Interval', description: 'Interval for SSE keepalive pings', defaultValue: '30s' },
+    { key: 'push_retry_max', label: 'Push Notification Retries', description: 'Maximum retries for push notification delivery', defaultValue: '3' },
+    { key: 'provider_org', label: 'Provider Organization', description: 'Organization name for agent card metadata', defaultValue: '' },
+    { key: 'provider_url', label: 'Provider URL', description: 'Organization URL for agent card metadata', defaultValue: '' },
   ],
 };
 

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -83,6 +83,9 @@ const PLATFORM_SECRETS: Record<string, PlatformSecretDef[]> = {
     { key: 'app_token', label: 'App Token', description: 'Slack app-level token for Socket Mode (xapp-...)' },
     { key: 'signing_secret', label: 'Signing Secret', description: 'Slack signing secret for HTTP mode' },
   ],
+  a2a: [
+    { key: 'api_key', label: 'API Key', description: 'Static API key for apiKey/bearer auth schemes' },
+  ],
 };
 
 function resolvePlatform(name: string): string {
@@ -91,6 +94,7 @@ function resolvePlatform(name: string): string {
     case 'discord': return 'discord';
     case 'slack': return 'slack';
     case 'chat-app': return 'gchat';
+    case 'a2a-bridge': return 'a2a';
     default: return name;
   }
 }
@@ -117,6 +121,10 @@ const PLATFORM_FIELDS: Record<string, PlatformFieldDef[]> = {
     { key: 'listen_address', label: 'Listen Address', description: 'HTTP listen address (HTTP mode only)', defaultValue: ':3000' },
     { key: 'db_path', label: 'Database Path', description: 'Path to SQLite database', defaultValue: '~/.scion/scion-slack.db' },
     { key: 'agent_cache_ttl', label: 'Agent Cache TTL', description: 'How long to cache agent info', defaultValue: '5m' },
+  ],
+  a2a: [
+    { key: 'external_url', label: 'External URL', description: 'Public URL for agent cards', defaultValue: '' },
+    { key: 'auth_scheme', label: 'Auth Scheme', description: 'apiKey, bearer, none, hubUAT, or hubJWT', defaultValue: 'none' },
   ],
 };
 
@@ -877,6 +885,7 @@ export class ScionPageAdminIntegrations extends LitElement {
 
       ${this.renderStatusSection(d.status)}
       ${this.renderSetupBanner(d)}
+      ${this.renderA2ASetupSection(d)}
       ${this.renderSecretsSection(d)}
       ${this.renderConfigSection(d)}
       ${this.renderDiscordInviteLink(d)}
@@ -1061,6 +1070,45 @@ export class ScionPageAdminIntegrations extends LitElement {
     `;
   }
 
+  private renderA2ASetupSection(d: IntegrationDetail) {
+    const platform = resolvePlatform(d.name);
+    if (platform !== 'a2a') return nothing;
+
+    // Only show the setup section when the bridge is not connected.
+    if (d.status?.connected) return nothing;
+
+    const binaryName = 'scion-a2a-bridge';
+    const configFile = '~/.scion/scion-a2a-bridge.yaml';
+    const startCommand = `${binaryName} -config ${configFile}`;
+
+    return html`
+      <div class="section">
+        <h3 class="section-title">Bridge Setup</h3>
+        <div class="setup-banner">
+          <sl-icon name="info-circle"></sl-icon>
+          <div>
+            <strong>The A2A bridge process is not connected</strong>
+            Start the bridge process and click Reconnect to activate.
+          </div>
+        </div>
+        <div style="font-size: 0.875rem; display: flex; flex-direction: column; gap: 0.5rem;">
+          <div class="status-row">
+            <span class="status-label">Binary</span>
+            <span style="font-family: var(--sl-font-mono, monospace); font-size: 0.8125rem;">${binaryName}</span>
+          </div>
+          <div class="status-row">
+            <span class="status-label">Config File</span>
+            <span style="font-family: var(--sl-font-mono, monospace); font-size: 0.8125rem;">${configFile}</span>
+          </div>
+          <div class="status-row">
+            <span class="status-label">Start Command</span>
+            <span style="font-family: var(--sl-font-mono, monospace); font-size: 0.8125rem;">${startCommand}</span>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
   private renderSetupBanner(d: IntegrationDetail) {
     const platform = resolvePlatform(d.name);
     const secretDefs = PLATFORM_SECRETS[platform] ?? [];
@@ -1138,6 +1186,7 @@ export class ScionPageAdminIntegrations extends LitElement {
   private renderActionsSection() {
     const mode = this.detail?.deployment_mode ?? 'plugin';
     const showUpdate = this.detail && mode !== 'external';
+    const restartLabel = mode === 'external' ? 'Reconnect' : 'Restart';
     return html`
       <div class="actions">
         <sl-button
@@ -1153,7 +1202,7 @@ export class ScionPageAdminIntegrations extends LitElement {
           @click=${() => { void this.handleRestart(); }}
         >
           <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
-          Restart
+          ${restartLabel}
         </sl-button>
         ${showUpdate
           ? html`
@@ -1255,6 +1304,8 @@ export class ScionPageAdminIntegrations extends LitElement {
         return 'Slack';
       case 'gchat':
         return 'Google Chat';
+      case 'a2a':
+        return 'A2A Bridge';
       default:
         return platform;
     }


### PR DESCRIPTION
Adds A2A bridge to the Hub admin integration management system, achieving visibility and install parity with Discord/Telegram/Slack.

Phase 1 - Hub Recognition:
- Replaces knownPlugins []string with KnownPlugin catalog struct with per-plugin metadata
- Adds a2a-bridge entry with Platform a2a, SelfManaged true
- Adds resolvePlatform case, PluginSecretKeyMap entry (A2A_API_KEY), self-managed install guard

Phase 2 - Install Flow + Minimal UI:
- Self-managed install handler: creates admin config, registers in settings.yaml, returns setup instructions
- Frontend: A2A platform in integrations list/detail, PLATFORM_SECRETS/PLATFORM_FIELDS, setup section
- Restart relabeled to Reconnect for external deployment mode

Part of the A2A admin capabilities project (5 phases total). Phases 3-5 follow in separate PRs.