### PR TITLE
fix(hub): add unique constraint on policy names per scope

### DIFF
--- a/pkg/ent/accesspolicy/accesspolicy.go
+++ b/pkg/ent/accesspolicy/accesspolicy.go
@@ -92,6 +92,8 @@ func ValidColumn(column string) bool {
 var (
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
+	// DefaultScopeID holds the default value on creation for the "scope_id" field.
+	DefaultScopeID string
 	// ResourceTypeValidator is a validator for the "resource_type" field. It is called by the builders before save.
 	ResourceTypeValidator func(string) error
 	// DefaultPriority holds the default value on creation for the "priority" field.

--- a/pkg/ent/accesspolicy/where.go
+++ b/pkg/ent/accesspolicy/where.go
@@ -316,16 +316,6 @@ func ScopeIDHasSuffix(v string) predicate.AccessPolicy {
 	return predicate.AccessPolicy(sql.FieldHasSuffix(FieldScopeID, v))
 }
 
-// ScopeIDIsNil applies the IsNil predicate on the "scope_id" field.
-func ScopeIDIsNil() predicate.AccessPolicy {
-	return predicate.AccessPolicy(sql.FieldIsNull(FieldScopeID))
-}
-
-// ScopeIDNotNil applies the NotNil predicate on the "scope_id" field.
-func ScopeIDNotNil() predicate.AccessPolicy {
-	return predicate.AccessPolicy(sql.FieldNotNull(FieldScopeID))
-}
-
 // ScopeIDEqualFold applies the EqualFold predicate on the "scope_id" field.
 func ScopeIDEqualFold(v string) predicate.AccessPolicy {
 	return predicate.AccessPolicy(sql.FieldEqualFold(FieldScopeID, v))

--- a/pkg/ent/accesspolicy_create.go
+++ b/pkg/ent/accesspolicy_create.go
@@ -236,6 +236,10 @@ func (_c *AccessPolicyCreate) ExecX(ctx context.Context) {
 
 // defaults sets the default values of the builder before save.
 func (_c *AccessPolicyCreate) defaults() {
+	if _, ok := _c.mutation.ScopeID(); !ok {
+		v := accesspolicy.DefaultScopeID
+		_c.mutation.SetScopeID(v)
+	}
 	if _, ok := _c.mutation.Priority(); !ok {
 		v := accesspolicy.DefaultPriority
 		_c.mutation.SetPriority(v)
@@ -271,6 +275,9 @@ func (_c *AccessPolicyCreate) check() error {
 		if err := accesspolicy.ScopeTypeValidator(v); err != nil {
 			return &ValidationError{Name: "scope_type", err: fmt.Errorf(`ent: validator failed for field "AccessPolicy.scope_type": %w`, err)}
 		}
+	}
+	if _, ok := _c.mutation.ScopeID(); !ok {
+		return &ValidationError{Name: "scope_id", err: errors.New(`ent: missing required field "AccessPolicy.scope_id"`)}
 	}
 	if _, ok := _c.mutation.ResourceType(); !ok {
 		return &ValidationError{Name: "resource_type", err: errors.New(`ent: missing required field "AccessPolicy.resource_type"`)}
@@ -512,12 +519,6 @@ func (u *AccessPolicyUpsert) SetScopeID(v string) *AccessPolicyUpsert {
 // UpdateScopeID sets the "scope_id" field to the value that was provided on create.
 func (u *AccessPolicyUpsert) UpdateScopeID() *AccessPolicyUpsert {
 	u.SetExcluded(accesspolicy.FieldScopeID)
-	return u
-}
-
-// ClearScopeID clears the value of the "scope_id" field.
-func (u *AccessPolicyUpsert) ClearScopeID() *AccessPolicyUpsert {
-	u.SetNull(accesspolicy.FieldScopeID)
 	return u
 }
 
@@ -794,13 +795,6 @@ func (u *AccessPolicyUpsertOne) SetScopeID(v string) *AccessPolicyUpsertOne {
 func (u *AccessPolicyUpsertOne) UpdateScopeID() *AccessPolicyUpsertOne {
 	return u.Update(func(s *AccessPolicyUpsert) {
 		s.UpdateScopeID()
-	})
-}
-
-// ClearScopeID clears the value of the "scope_id" field.
-func (u *AccessPolicyUpsertOne) ClearScopeID() *AccessPolicyUpsertOne {
-	return u.Update(func(s *AccessPolicyUpsert) {
-		s.ClearScopeID()
 	})
 }
 
@@ -1271,13 +1265,6 @@ func (u *AccessPolicyUpsertBulk) SetScopeID(v string) *AccessPolicyUpsertBulk {
 func (u *AccessPolicyUpsertBulk) UpdateScopeID() *AccessPolicyUpsertBulk {
 	return u.Update(func(s *AccessPolicyUpsert) {
 		s.UpdateScopeID()
-	})
-}
-
-// ClearScopeID clears the value of the "scope_id" field.
-func (u *AccessPolicyUpsertBulk) ClearScopeID() *AccessPolicyUpsertBulk {
-	return u.Update(func(s *AccessPolicyUpsert) {
-		s.ClearScopeID()
 	})
 }
 

--- a/pkg/ent/accesspolicy_update.go
+++ b/pkg/ent/accesspolicy_update.go
@@ -94,12 +94,6 @@ func (_u *AccessPolicyUpdate) SetNillableScopeID(v *string) *AccessPolicyUpdate 
 	return _u
 }
 
-// ClearScopeID clears the value of the "scope_id" field.
-func (_u *AccessPolicyUpdate) ClearScopeID() *AccessPolicyUpdate {
-	_u.mutation.ClearScopeID()
-	return _u
-}
-
 // SetResourceType sets the "resource_type" field.
 func (_u *AccessPolicyUpdate) SetResourceType(v string) *AccessPolicyUpdate {
 	_u.mutation.SetResourceType(v)
@@ -378,9 +372,6 @@ func (_u *AccessPolicyUpdate) sqlSave(ctx context.Context) (_node int, err error
 	if value, ok := _u.mutation.ScopeID(); ok {
 		_spec.SetField(accesspolicy.FieldScopeID, field.TypeString, value)
 	}
-	if _u.mutation.ScopeIDCleared() {
-		_spec.ClearField(accesspolicy.FieldScopeID, field.TypeString)
-	}
 	if value, ok := _u.mutation.ResourceType(); ok {
 		_spec.SetField(accesspolicy.FieldResourceType, field.TypeString, value)
 	}
@@ -561,12 +552,6 @@ func (_u *AccessPolicyUpdateOne) SetNillableScopeID(v *string) *AccessPolicyUpda
 	if v != nil {
 		_u.SetScopeID(*v)
 	}
-	return _u
-}
-
-// ClearScopeID clears the value of the "scope_id" field.
-func (_u *AccessPolicyUpdateOne) ClearScopeID() *AccessPolicyUpdateOne {
-	_u.mutation.ClearScopeID()
 	return _u
 }
 
@@ -877,9 +862,6 @@ func (_u *AccessPolicyUpdateOne) sqlSave(ctx context.Context) (_node *AccessPoli
 	}
 	if value, ok := _u.mutation.ScopeID(); ok {
 		_spec.SetField(accesspolicy.FieldScopeID, field.TypeString, value)
-	}
-	if _u.mutation.ScopeIDCleared() {
-		_spec.ClearField(accesspolicy.FieldScopeID, field.TypeString)
 	}
 	if value, ok := _u.mutation.ResourceType(); ok {
 		_spec.SetField(accesspolicy.FieldResourceType, field.TypeString, value)

--- a/pkg/ent/migrate/schema.go
+++ b/pkg/ent/migrate/schema.go
@@ -33,6 +33,13 @@ var (
 		Name:       "access_policies",
 		Columns:    AccessPoliciesColumns,
 		PrimaryKey: []*schema.Column{AccessPoliciesColumns[0]},
+		Indexes: []*schema.Index{
+			{
+				Name:    "accesspolicy_name_scope_type_scope_id",
+				Unique:  true,
+				Columns: []*schema.Column{AccessPoliciesColumns[1], AccessPoliciesColumns[3], AccessPoliciesColumns[4]},
+			},
+		},
 	}
 	// AgentsColumns holds the columns for the "agents" table.
 	AgentsColumns = []*schema.Column{

--- a/pkg/ent/migrate/schema.go
+++ b/pkg/ent/migrate/schema.go
@@ -15,7 +15,7 @@ var (
 		{Name: "name", Type: field.TypeString},
 		{Name: "description", Type: field.TypeString, Nullable: true},
 		{Name: "scope_type", Type: field.TypeEnum, Enums: []string{"hub", "project", "resource"}},
-		{Name: "scope_id", Type: field.TypeString, Nullable: true},
+		{Name: "scope_id", Type: field.TypeString, Default: ""},
 		{Name: "resource_type", Type: field.TypeString},
 		{Name: "resource_id", Type: field.TypeString, Nullable: true},
 		{Name: "actions", Type: field.TypeJSON, Nullable: true},

--- a/pkg/ent/mutation.go
+++ b/pkg/ent/mutation.go
@@ -403,22 +403,9 @@ func (m *AccessPolicyMutation) OldScopeID(ctx context.Context) (v string, err er
 	return oldValue.ScopeID, nil
 }
 
-// ClearScopeID clears the value of the "scope_id" field.
-func (m *AccessPolicyMutation) ClearScopeID() {
-	m.scope_id = nil
-	m.clearedFields[accesspolicy.FieldScopeID] = struct{}{}
-}
-
-// ScopeIDCleared returns if the "scope_id" field was cleared in this mutation.
-func (m *AccessPolicyMutation) ScopeIDCleared() bool {
-	_, ok := m.clearedFields[accesspolicy.FieldScopeID]
-	return ok
-}
-
 // ResetScopeID resets all changes to the "scope_id" field.
 func (m *AccessPolicyMutation) ResetScopeID() {
 	m.scope_id = nil
-	delete(m.clearedFields, accesspolicy.FieldScopeID)
 }
 
 // SetResourceType sets the "resource_type" field.
@@ -1304,9 +1291,6 @@ func (m *AccessPolicyMutation) ClearedFields() []string {
 	if m.FieldCleared(accesspolicy.FieldDescription) {
 		fields = append(fields, accesspolicy.FieldDescription)
 	}
-	if m.FieldCleared(accesspolicy.FieldScopeID) {
-		fields = append(fields, accesspolicy.FieldScopeID)
-	}
 	if m.FieldCleared(accesspolicy.FieldResourceID) {
 		fields = append(fields, accesspolicy.FieldResourceID)
 	}
@@ -1341,9 +1325,6 @@ func (m *AccessPolicyMutation) ClearField(name string) error {
 	switch name {
 	case accesspolicy.FieldDescription:
 		m.ClearDescription()
-		return nil
-	case accesspolicy.FieldScopeID:
-		m.ClearScopeID()
 		return nil
 	case accesspolicy.FieldResourceID:
 		m.ClearResourceID()

--- a/pkg/ent/runtime.go
+++ b/pkg/ent/runtime.go
@@ -62,6 +62,10 @@ func init() {
 	accesspolicyDescName := accesspolicyFields[1].Descriptor()
 	// accesspolicy.NameValidator is a validator for the "name" field. It is called by the builders before save.
 	accesspolicy.NameValidator = accesspolicyDescName.Validators[0].(func(string) error)
+	// accesspolicyDescScopeID is the schema descriptor for scope_id field.
+	accesspolicyDescScopeID := accesspolicyFields[4].Descriptor()
+	// accesspolicy.DefaultScopeID holds the default value on creation for the scope_id field.
+	accesspolicy.DefaultScopeID = accesspolicyDescScopeID.Default.(string)
 	// accesspolicyDescResourceType is the schema descriptor for resource_type field.
 	accesspolicyDescResourceType := accesspolicyFields[5].Descriptor()
 	// accesspolicy.ResourceTypeValidator is a validator for the "resource_type" field. It is called by the builders before save.

--- a/pkg/ent/schema/policy.go
+++ b/pkg/ent/schema/policy.go
@@ -20,6 +20,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
 	"github.com/google/uuid"
 )
 
@@ -68,6 +69,13 @@ func (AccessPolicy) Fields() []ent.Field {
 			UpdateDefault(time.Now),
 		field.String("created_by").
 			Optional(),
+	}
+}
+
+// Indexes of the AccessPolicy.
+func (AccessPolicy) Indexes() []ent.Index {
+	return []ent.Index{
+		index.Fields("name", "scope_type", "scope_id").Unique(),
 	}
 }
 

--- a/pkg/ent/schema/policy.go
+++ b/pkg/ent/schema/policy.go
@@ -44,7 +44,7 @@ func (AccessPolicy) Fields() []ent.Field {
 		field.Enum("scope_type").
 			Values("hub", "project", "resource"),
 		field.String("scope_id").
-			Optional(),
+			Default(""),
 		field.String("resource_type").
 			NotEmpty(),
 		field.String("resource_id").

--- a/pkg/hub/demo_policy_test.go
+++ b/pkg/hub/demo_policy_test.go
@@ -685,3 +685,64 @@ func TestDemoPolicy_ProjectDeleteCleansUpGroupsAndPolicies(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, policies.TotalCount, "policy should be deleted after project deletion")
 }
+
+// ============================================================================
+// Duplicate Policy Name Tests (Issue #610)
+// ============================================================================
+
+// TestCreatePolicy_DuplicateNameConflict verifies that creating two policies
+// with the same name in the same scope returns HTTP 409 Conflict.
+func TestCreatePolicy_DuplicateNameConflict(t *testing.T) {
+	srv, _, alice, _, _ := setupDemoPolicyTest(t)
+
+	policyReq := CreatePolicyRequest{
+		Name:         "unique-test-policy",
+		ScopeType:    "hub",
+		ResourceType: "*",
+		Actions:      []string{"read"},
+		Effect:       "allow",
+	}
+
+	// First creation should succeed.
+	rec := doRequestAsUser(t, srv, alice, http.MethodPost, "/api/v1/policies", policyReq)
+	require.Equal(t, http.StatusCreated, rec.Code,
+		"first policy creation should succeed; got: %s", rec.Body.String())
+
+	// Second creation with the same name and scope should return 409.
+	rec2 := doRequestAsUser(t, srv, alice, http.MethodPost, "/api/v1/policies", policyReq)
+	assert.Equal(t, http.StatusConflict, rec2.Code,
+		"duplicate policy name in same scope should return 409; got: %s", rec2.Body.String())
+}
+
+// TestCreatePolicy_SameNameDifferentScope verifies that policies with the same
+// name but different scopes are allowed (no conflict).
+func TestCreatePolicy_SameNameDifferentScope(t *testing.T) {
+	srv, _, alice, _, project := setupDemoPolicyTest(t)
+
+	hubPolicy := CreatePolicyRequest{
+		Name:         "shared-policy-name",
+		ScopeType:    "hub",
+		ResourceType: "*",
+		Actions:      []string{"read"},
+		Effect:       "allow",
+	}
+
+	projectPolicy := CreatePolicyRequest{
+		Name:         "shared-policy-name",
+		ScopeType:    "project",
+		ScopeID:      project.ID,
+		ResourceType: "*",
+		Actions:      []string{"read"},
+		Effect:       "allow",
+	}
+
+	// Hub-scoped policy.
+	rec := doRequestAsUser(t, srv, alice, http.MethodPost, "/api/v1/policies", hubPolicy)
+	require.Equal(t, http.StatusCreated, rec.Code,
+		"hub-scoped policy creation should succeed; got: %s", rec.Body.String())
+
+	// Project-scoped policy with the same name should also succeed.
+	rec2 := doRequestAsUser(t, srv, alice, http.MethodPost, "/api/v1/policies", projectPolicy)
+	assert.Equal(t, http.StatusCreated, rec2.Code,
+		"same name in different scope should succeed; got: %s", rec2.Body.String())
+}

--- a/pkg/hub/handlers_policies.go
+++ b/pkg/hub/handlers_policies.go
@@ -365,6 +365,10 @@ func (s *Server) updatePolicy(w http.ResponseWriter, r *http.Request, id string)
 	}
 
 	if err := s.store.UpdatePolicy(ctx, policy); err != nil {
+		if errors.Is(err, store.ErrAlreadyExists) {
+			Conflict(w, "A policy with this name already exists in this scope")
+			return
+		}
 		writeErrorFromErr(w, err, "")
 		return
 	}

--- a/pkg/hub/handlers_policies.go
+++ b/pkg/hub/handlers_policies.go
@@ -16,6 +16,7 @@ package hub
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -232,6 +233,10 @@ func (s *Server) createPolicy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.store.CreatePolicy(ctx, policy); err != nil {
+		if errors.Is(err, store.ErrAlreadyExists) {
+			Conflict(w, "A policy with this name already exists in this scope")
+			return
+		}
 		writeErrorFromErr(w, err, "")
 		return
 	}

--- a/pkg/store/entadapter/policy_store.go
+++ b/pkg/store/entadapter/policy_store.go
@@ -119,9 +119,11 @@ func (s *PolicyStore) CreatePolicy(ctx context.Context, p *store.Policy) error {
 		SetEffect(accesspolicy.Effect(p.Effect)).
 		SetPriority(p.Priority)
 
-	if p.ScopeID != "" {
-		create.SetScopeID(p.ScopeID)
-	}
+	// Always set scope_id (even when empty) so the unique index on
+	// (name, scope_type, scope_id) works correctly. SQL NULL values do not
+	// participate in unique constraints, so leaving scope_id as NULL would
+	// allow duplicate policy names within the same scope.
+	create.SetScopeID(p.ScopeID)
 	if p.ResourceID != "" {
 		create.SetResourceID(p.ResourceID)
 	}

--- a/pkg/store/entadapter/policy_store.go
+++ b/pkg/store/entadapter/policy_store.go
@@ -183,11 +183,9 @@ func (s *PolicyStore) UpdatePolicy(ctx context.Context, p *store.Policy) error {
 		SetEffect(accesspolicy.Effect(p.Effect)).
 		SetPriority(p.Priority)
 
-	if p.ScopeID != "" {
-		update.SetScopeID(p.ScopeID)
-	} else {
-		update.ClearScopeID()
-	}
+	// Always set scope_id (even when empty) so the unique index on
+	// (name, scope_type, scope_id) works correctly — matches CreatePolicy.
+	update.SetScopeID(p.ScopeID)
 	if p.ResourceID != "" {
 		update.SetResourceID(p.ResourceID)
 	} else {


### PR DESCRIPTION
## Summary

CreatePolicy had no unique constraint — duplicates allowed. Adds unique index on (name, scope_type, scope_id), fixes NULL scope_id for hub-scoped policies, adds 409 handlers.

Resolves ptone/scion#758

## Test plan
- All policy tests pass
