### PR TITLE
feat(a2a): real config management via admin UI (Phase 3)

### DIFF
--- a/extras/scion-a2a-bridge/cmd/scion-a2a-bridge/main.go
+++ b/extras/scion-a2a-bridge/cmd/scion-a2a-bridge/main.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -74,6 +75,30 @@ func main() {
 	}
 	defer store.Close()
 	log.Info("state database initialized", "path", dbPath)
+
+	// Determine state directory for admin overlay persistence.
+	stateDir := filepath.Dir(dbPath)
+
+	// Load and apply any persisted admin overlay (from a previous Configure push).
+	// This ensures the bridge boots with the last-known admin config, not just
+	// the base YAML, bridging the gap until the Hub's first Configure() push.
+	baseCfg := *cfg // snapshot of the base YAML config (immutable reference)
+	overlay, overlayErr := bridge.LoadPersistedOverlay(stateDir)
+	if overlayErr != nil {
+		log.Warn("failed to load persisted admin overlay, proceeding with base YAML config", "error", overlayErr)
+	}
+	if overlay != nil {
+		effective := bridge.ApplyOverlay(baseCfg, overlay)
+		cfg = &effective
+		log.Info("applied persisted admin overlay",
+			"auth_scheme", cfg.Auth.Scheme,
+			"external_url", cfg.Bridge.ExternalURL,
+			"projects", len(cfg.Projects),
+		)
+	}
+
+	// Build the initial config snapshot (base YAML + persisted overlay).
+	snapshot := bridge.NewSnapshotHolder(bridge.BuildSnapshot(*cfg))
 
 	// Load hub signing key.
 	signingKeyB64, err := loadSigningKey(cfg.Hub)
@@ -139,6 +164,10 @@ func main() {
 	// Wire broker into the bridge for subscription management.
 	b.SetBroker(broker)
 
+	// Wire admin config management: snapshot + base config + state dir.
+	b.SetSnapshot(snapshot)
+	broker.SetAdminConfig(&baseCfg, snapshot, stateDir)
+
 	// Create SDK executor and request handler.
 	// Use a route-key authenticator so the in-memory task store associates tasks
 	// with the correct project/agent pair, and a ScopedTaskStore wrapper that
@@ -174,6 +203,7 @@ func main() {
 	}
 
 	srv := bridge.NewServer(b, cfg, metrics, log.With("component", "a2a-server"), sdkJSONRPCHandler)
+	srv.SetSnapshot(snapshot)
 	srv.WarnOnOpenAuth()
 
 	httpServer := &http.Server{

--- a/extras/scion-a2a-bridge/cmd/scion-a2a-bridge/main.go
+++ b/extras/scion-a2a-bridge/cmd/scion-a2a-bridge/main.go
@@ -204,6 +204,9 @@ func main() {
 
 	srv := bridge.NewServer(b, cfg, metrics, log.With("component", "a2a-server"), sdkJSONRPCHandler)
 	srv.SetSnapshot(snapshot)
+	if signingKey != nil {
+		srv.SetJWTValidator(bridge.NewJWTValidator(signingKey))
+	}
 	srv.WarnOnOpenAuth()
 
 	httpServer := &http.Server{

--- a/extras/scion-a2a-bridge/internal/bridge/adminoverlay.go
+++ b/extras/scion-a2a-bridge/internal/bridge/adminoverlay.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -42,7 +43,7 @@ type AdminOverlay struct {
 	UATCacheTTL        time.Duration
 	RateLimitEnabled   *bool   // pointer so we can distinguish absent from false
 	RateLimitRPS       float64 // 0 means not set
-	RateLimitBurst     int     // -1 means not set (0 is a valid value meaning "no burst")
+	RateLimitBurst     int     // -1 means not set (0 means use default 20)
 	SendMessageTimeout time.Duration
 	SSEKeepalive       time.Duration
 	PushRetryMax       int // -1 means not set
@@ -71,10 +72,10 @@ type persistedOverlay struct {
 	UATCacheTTL        string          `json:"uat_cache_ttl,omitempty"`
 	RateLimitEnabled   *bool           `json:"rate_limit_enabled,omitempty"`
 	RateLimitRPS       float64         `json:"rate_limit_rps,omitempty"`
-	RateLimitBurst     int             `json:"rate_limit_burst"`
+	RateLimitBurst     *int            `json:"rate_limit_burst,omitempty"`
 	SendMessageTimeout string          `json:"send_message_timeout,omitempty"`
 	SSEKeepalive       string          `json:"sse_keepalive,omitempty"`
-	PushRetryMax       int             `json:"push_retry_max"`
+	PushRetryMax       *int            `json:"push_retry_max,omitempty"`
 	ProviderOrg        string          `json:"provider_org,omitempty"`
 	ProviderURL        string          `json:"provider_url,omitempty"`
 	Projects           []ProjectConfig `json:"projects,omitempty"`
@@ -159,6 +160,9 @@ func ParseAdminOverlay(cfg map[string]string) (*AdminOverlay, error) {
 		}
 		if d < 0 {
 			return nil, fmt.Errorf("invalid uat_cache_ttl %q: must not be negative", v)
+		}
+		if d > 300*time.Second {
+			return nil, fmt.Errorf("invalid uat_cache_ttl %q: must not exceed 300s", v)
 		}
 		overlay.UATCacheTTL = d
 	}
@@ -359,10 +363,12 @@ func PersistOverlay(stateDir string, overlay *AdminOverlay) error {
 	}
 	// Only persist non-sentinel values for integer fields.
 	if overlay.RateLimitBurst >= 0 {
-		p.RateLimitBurst = overlay.RateLimitBurst
+		b := overlay.RateLimitBurst
+		p.RateLimitBurst = &b
 	}
 	if overlay.PushRetryMax >= 0 {
-		p.PushRetryMax = overlay.PushRetryMax
+		b := overlay.PushRetryMax
+		p.PushRetryMax = &b
 	}
 	if overlay.RateLimitEnabled != nil {
 		p.RateLimitEnabled = overlay.RateLimitEnabled
@@ -378,13 +384,17 @@ func PersistOverlay(stateDir string, overlay *AdminOverlay) error {
 	}
 
 	// Persist which keys were present so the overlay can be re-applied correctly.
+	// Keys are sorted for deterministic serialization.
+	keys := make([]string, 0, len(overlay.presentKeys))
 	for k := range overlay.presentKeys {
 		// Never persist api_key presence — it comes fresh on each Configure push.
 		if k == "api_key" {
 			continue
 		}
-		p.PresentKeys = append(p.PresentKeys, k)
+		keys = append(keys, k)
 	}
+	sort.Strings(keys)
+	p.PresentKeys = keys
 
 	data, err := json.MarshalIndent(p, "", "  ")
 	if err != nil {
@@ -416,12 +426,20 @@ func LoadPersistedOverlay(stateDir string) (*AdminOverlay, error) {
 		AuthScheme:       p.AuthScheme,
 		RateLimitEnabled: p.RateLimitEnabled,
 		RateLimitRPS:     p.RateLimitRPS,
-		RateLimitBurst:   p.RateLimitBurst,
-		PushRetryMax:     p.PushRetryMax,
+		RateLimitBurst:   -1, // sentinel: not set
+		PushRetryMax:     -1, // sentinel: not set
 		ProviderOrg:      p.ProviderOrg,
 		ProviderURL:      p.ProviderURL,
 		Projects:         p.Projects,
 		presentKeys:      make(map[string]bool),
+	}
+
+	// Dereference persisted pointers; nil means sentinel stays.
+	if p.RateLimitBurst != nil {
+		overlay.RateLimitBurst = *p.RateLimitBurst
+	}
+	if p.PushRetryMax != nil {
+		overlay.PushRetryMax = *p.PushRetryMax
 	}
 
 	// Restore present keys.

--- a/extras/scion-a2a-bridge/internal/bridge/adminoverlay.go
+++ b/extras/scion-a2a-bridge/internal/bridge/adminoverlay.go
@@ -130,8 +130,14 @@ func ParseAdminOverlay(cfg map[string]string) (*AdminOverlay, error) {
 		presentKeys:    make(map[string]bool),
 	}
 
-	for key := range cfg {
-		overlay.presentKeys[key] = true
+	// String fields can be explicitly cleared; non-string fields with empty
+	// values should not override base config.
+	for key, val := range cfg {
+		isStringField := key == "external_url" || key == "auth_scheme" || key == "api_key" ||
+			key == "provider_org" || key == "provider_url"
+		if val != "" || isStringField {
+			overlay.presentKeys[key] = true
+		}
 	}
 
 	// external_url

--- a/extras/scion-a2a-bridge/internal/bridge/adminoverlay.go
+++ b/extras/scion-a2a-bridge/internal/bridge/adminoverlay.go
@@ -1,0 +1,455 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"time"
+)
+
+// validAuthSchemes lists the recognized auth schemes for validation.
+var validAuthSchemes = map[string]bool{
+	"apiKey": true,
+	"bearer": true,
+	"none":   true,
+	"hubUAT": true,
+	"hubJWT": true,
+}
+
+// AdminOverlay holds the parsed admin-managed config values.
+// These override corresponding bridge YAML values when present.
+type AdminOverlay struct {
+	ExternalURL        string
+	AuthScheme         string // "apiKey"|"bearer"|"none"|"hubUAT"|"hubJWT"
+	APIKey             string // from secret backend, never persisted
+	UATCacheTTL        time.Duration
+	RateLimitEnabled   *bool   // pointer so we can distinguish absent from false
+	RateLimitRPS       float64 // 0 means not set
+	RateLimitBurst     int     // -1 means not set (0 is a valid value meaning "no burst")
+	SendMessageTimeout time.Duration
+	SSEKeepalive       time.Duration
+	PushRetryMax       int // -1 means not set
+	ProviderOrg        string
+	ProviderURL        string
+	Projects           []ProjectConfig // parsed from projects_json
+
+	// presentKeys tracks which keys were explicitly provided in the Configure push.
+	// Only present keys override base YAML values.
+	presentKeys map[string]bool
+}
+
+// IsPresent returns true if the given key was explicitly provided in the overlay.
+func (o *AdminOverlay) IsPresent(key string) bool {
+	if o == nil || o.presentKeys == nil {
+		return false
+	}
+	return o.presentKeys[key]
+}
+
+// persistedOverlay is the JSON-serializable form of AdminOverlay.
+// The api_key field is deliberately excluded.
+type persistedOverlay struct {
+	ExternalURL        string          `json:"external_url,omitempty"`
+	AuthScheme         string          `json:"auth_scheme,omitempty"`
+	UATCacheTTL        string          `json:"uat_cache_ttl,omitempty"`
+	RateLimitEnabled   *bool           `json:"rate_limit_enabled,omitempty"`
+	RateLimitRPS       float64         `json:"rate_limit_rps,omitempty"`
+	RateLimitBurst     int             `json:"rate_limit_burst"`
+	SendMessageTimeout string          `json:"send_message_timeout,omitempty"`
+	SSEKeepalive       string          `json:"sse_keepalive,omitempty"`
+	PushRetryMax       int             `json:"push_retry_max"`
+	ProviderOrg        string          `json:"provider_org,omitempty"`
+	ProviderURL        string          `json:"provider_url,omitempty"`
+	Projects           []ProjectConfig `json:"projects,omitempty"`
+	PresentKeys        []string        `json:"present_keys,omitempty"`
+}
+
+// ConfigSnapshot holds the effective runtime configuration.
+// Readers access it atomically; writers swap the entire snapshot.
+type ConfigSnapshot struct {
+	Config  Config         // effective merged config
+	Auth    AuthValidators // pre-built validators matching current scheme
+	Limiter *RateLimiter   // nil if disabled; rebuilt on config change
+}
+
+// AuthValidators holds the active auth validation functions.
+type AuthValidators struct {
+	Scheme       string
+	UATValidator *UATValidator // non-nil when scheme is hubUAT
+	JWTValidator *JWTValidator // non-nil when scheme is hubJWT
+	APIKey       string        // non-empty when scheme is apiKey or bearer
+}
+
+// SnapshotHolder wraps an atomic pointer to ConfigSnapshot for lock-free reads.
+type SnapshotHolder struct {
+	ptr atomic.Pointer[ConfigSnapshot]
+}
+
+// NewSnapshotHolder creates a SnapshotHolder initialized with the given snapshot.
+func NewSnapshotHolder(snap *ConfigSnapshot) *SnapshotHolder {
+	h := &SnapshotHolder{}
+	h.ptr.Store(snap)
+	return h
+}
+
+// Load returns the current snapshot.
+func (h *SnapshotHolder) Load() *ConfigSnapshot {
+	return h.ptr.Load()
+}
+
+// Store atomically replaces the current snapshot.
+func (h *SnapshotHolder) Store(snap *ConfigSnapshot) {
+	h.ptr.Store(snap)
+}
+
+// ParseAdminOverlay parses and validates the flat key map from Configure().
+// Returns an error for invalid values (the bridge rejects the push and keeps last-good).
+// Absent keys mean "not set by admin, use base YAML value."
+func ParseAdminOverlay(cfg map[string]string) (*AdminOverlay, error) {
+	overlay := &AdminOverlay{
+		RateLimitBurst: -1, // sentinel: not set
+		PushRetryMax:   -1, // sentinel: not set
+		presentKeys:    make(map[string]bool),
+	}
+
+	for key := range cfg {
+		overlay.presentKeys[key] = true
+	}
+
+	// external_url
+	if v, ok := cfg["external_url"]; ok {
+		overlay.ExternalURL = v
+	}
+
+	// auth_scheme
+	if v, ok := cfg["auth_scheme"]; ok {
+		if v != "" && !validAuthSchemes[v] {
+			return nil, fmt.Errorf("invalid auth_scheme %q: must be one of apiKey, bearer, none, hubUAT, hubJWT", v)
+		}
+		overlay.AuthScheme = v
+	}
+
+	// api_key (from secret backend)
+	if v, ok := cfg["api_key"]; ok {
+		overlay.APIKey = v
+	}
+
+	// uat_cache_ttl
+	if v, ok := cfg["uat_cache_ttl"]; ok && v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid uat_cache_ttl %q: %w", v, err)
+		}
+		if d < 0 {
+			return nil, fmt.Errorf("invalid uat_cache_ttl %q: must not be negative", v)
+		}
+		overlay.UATCacheTTL = d
+	}
+
+	// rate_limit_enabled
+	if v, ok := cfg["rate_limit_enabled"]; ok && v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid rate_limit_enabled %q: %w", v, err)
+		}
+		overlay.RateLimitEnabled = &b
+	}
+
+	// rate_limit_rps
+	if v, ok := cfg["rate_limit_rps"]; ok && v != "" {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid rate_limit_rps %q: %w", v, err)
+		}
+		if f <= 0 {
+			return nil, fmt.Errorf("invalid rate_limit_rps %q: must be > 0", v)
+		}
+		overlay.RateLimitRPS = f
+	}
+
+	// rate_limit_burst
+	if v, ok := cfg["rate_limit_burst"]; ok && v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid rate_limit_burst %q: %w", v, err)
+		}
+		if n < 0 {
+			return nil, fmt.Errorf("invalid rate_limit_burst %q: must be >= 0", v)
+		}
+		overlay.RateLimitBurst = n
+	}
+
+	// send_message_timeout
+	if v, ok := cfg["send_message_timeout"]; ok && v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid send_message_timeout %q: %w", v, err)
+		}
+		if d <= 0 {
+			return nil, fmt.Errorf("invalid send_message_timeout %q: must be positive", v)
+		}
+		overlay.SendMessageTimeout = d
+	}
+
+	// sse_keepalive
+	if v, ok := cfg["sse_keepalive"]; ok && v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid sse_keepalive %q: %w", v, err)
+		}
+		if d <= 0 {
+			return nil, fmt.Errorf("invalid sse_keepalive %q: must be positive", v)
+		}
+		overlay.SSEKeepalive = d
+	}
+
+	// push_retry_max
+	if v, ok := cfg["push_retry_max"]; ok && v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid push_retry_max %q: %w", v, err)
+		}
+		if n < 0 {
+			return nil, fmt.Errorf("invalid push_retry_max %q: must be >= 0", v)
+		}
+		overlay.PushRetryMax = n
+	}
+
+	// provider_org
+	if v, ok := cfg["provider_org"]; ok {
+		overlay.ProviderOrg = v
+	}
+
+	// provider_url
+	if v, ok := cfg["provider_url"]; ok {
+		overlay.ProviderURL = v
+	}
+
+	// projects_json
+	if v, ok := cfg["projects_json"]; ok && v != "" {
+		var projects []ProjectConfig
+		if err := json.Unmarshal([]byte(v), &projects); err != nil {
+			return nil, fmt.Errorf("invalid projects_json: %w", err)
+		}
+		overlay.Projects = projects
+	}
+
+	return overlay, nil
+}
+
+// ApplyOverlay merges an admin overlay onto a base config, producing the effective config.
+// Overlay values win for each present key; absent overlay keys leave base values intact.
+func ApplyOverlay(base Config, overlay *AdminOverlay) Config {
+	if overlay == nil {
+		return base
+	}
+
+	cfg := base // copy
+
+	if overlay.IsPresent("external_url") {
+		cfg.Bridge.ExternalURL = overlay.ExternalURL
+	}
+	if overlay.IsPresent("auth_scheme") {
+		cfg.Auth.Scheme = overlay.AuthScheme
+	}
+	if overlay.IsPresent("api_key") {
+		cfg.Auth.APIKey = overlay.APIKey
+	}
+	if overlay.IsPresent("uat_cache_ttl") {
+		cfg.Auth.UATCacheTTL = overlay.UATCacheTTL
+	}
+	if overlay.IsPresent("rate_limit_enabled") && overlay.RateLimitEnabled != nil {
+		cfg.RateLimit.Enabled = *overlay.RateLimitEnabled
+	}
+	if overlay.IsPresent("rate_limit_rps") && overlay.RateLimitRPS > 0 {
+		cfg.RateLimit.RequestsPerSec = overlay.RateLimitRPS
+	}
+	if overlay.IsPresent("rate_limit_burst") && overlay.RateLimitBurst >= 0 {
+		cfg.RateLimit.Burst = overlay.RateLimitBurst
+	}
+	if overlay.IsPresent("send_message_timeout") {
+		cfg.Timeouts.SendMessage = overlay.SendMessageTimeout
+	}
+	if overlay.IsPresent("sse_keepalive") {
+		cfg.Timeouts.SSEKeepalive = overlay.SSEKeepalive
+	}
+	if overlay.IsPresent("push_retry_max") && overlay.PushRetryMax >= 0 {
+		cfg.Timeouts.PushRetryMax = overlay.PushRetryMax
+	}
+	if overlay.IsPresent("provider_org") {
+		cfg.Bridge.Provider.Organization = overlay.ProviderOrg
+	}
+	if overlay.IsPresent("provider_url") {
+		cfg.Bridge.Provider.URL = overlay.ProviderURL
+	}
+	if overlay.IsPresent("projects_json") && overlay.Projects != nil {
+		cfg.Projects = overlay.Projects
+	}
+
+	return cfg
+}
+
+// BuildAuthValidators constructs the appropriate validators for the given config.
+func BuildAuthValidators(cfg *Config) AuthValidators {
+	av := AuthValidators{
+		Scheme: cfg.Auth.Scheme,
+	}
+	switch cfg.Auth.Scheme {
+	case "hubUAT":
+		ttl := cfg.Auth.UATCacheTTL
+		av.UATValidator = NewUATValidator(cfg.Hub.Endpoint, ttl)
+	case "hubJWT":
+		// JWTValidator requires a signing key which is loaded separately.
+		// It will be set via SetJWTValidator on the Server.
+	case "apiKey", "bearer", "":
+		av.APIKey = cfg.Auth.APIKey
+	}
+	return av
+}
+
+// BuildSnapshot creates a complete ConfigSnapshot from the effective config.
+func BuildSnapshot(cfg Config) *ConfigSnapshot {
+	snap := &ConfigSnapshot{
+		Config: cfg,
+		Auth:   BuildAuthValidators(&cfg),
+	}
+	if cfg.RateLimit.Enabled {
+		rate := cfg.RateLimit.RequestsPerSec
+		if rate == 0 {
+			rate = 10
+		}
+		burst := cfg.RateLimit.Burst
+		if burst == 0 {
+			burst = 20
+		}
+		snap.Limiter = NewRateLimiter(rate, burst)
+	}
+	return snap
+}
+
+const overlayFileName = "admin-overlay.json"
+
+// PersistOverlay writes the overlay to admin-overlay.json in the state directory.
+// The api_key field is deliberately excluded from persistence.
+func PersistOverlay(stateDir string, overlay *AdminOverlay) error {
+	p := persistedOverlay{
+		ExternalURL:  overlay.ExternalURL,
+		AuthScheme:   overlay.AuthScheme,
+		RateLimitRPS: overlay.RateLimitRPS,
+		ProviderOrg:  overlay.ProviderOrg,
+		ProviderURL:  overlay.ProviderURL,
+		Projects:     overlay.Projects,
+	}
+	// Only persist non-sentinel values for integer fields.
+	if overlay.RateLimitBurst >= 0 {
+		p.RateLimitBurst = overlay.RateLimitBurst
+	}
+	if overlay.PushRetryMax >= 0 {
+		p.PushRetryMax = overlay.PushRetryMax
+	}
+	if overlay.RateLimitEnabled != nil {
+		p.RateLimitEnabled = overlay.RateLimitEnabled
+	}
+	if overlay.UATCacheTTL > 0 {
+		p.UATCacheTTL = overlay.UATCacheTTL.String()
+	}
+	if overlay.SendMessageTimeout > 0 {
+		p.SendMessageTimeout = overlay.SendMessageTimeout.String()
+	}
+	if overlay.SSEKeepalive > 0 {
+		p.SSEKeepalive = overlay.SSEKeepalive.String()
+	}
+
+	// Persist which keys were present so the overlay can be re-applied correctly.
+	for k := range overlay.presentKeys {
+		// Never persist api_key presence — it comes fresh on each Configure push.
+		if k == "api_key" {
+			continue
+		}
+		p.PresentKeys = append(p.PresentKeys, k)
+	}
+
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal overlay: %w", err)
+	}
+
+	path := filepath.Join(stateDir, overlayFileName)
+	return os.WriteFile(path, data, 0600)
+}
+
+// LoadPersistedOverlay reads a previously saved overlay. Returns nil, nil if no file exists.
+func LoadPersistedOverlay(stateDir string) (*AdminOverlay, error) {
+	path := filepath.Join(stateDir, overlayFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read overlay file: %w", err)
+	}
+
+	var p persistedOverlay
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("parse overlay file: %w", err)
+	}
+
+	overlay := &AdminOverlay{
+		ExternalURL:      p.ExternalURL,
+		AuthScheme:       p.AuthScheme,
+		RateLimitEnabled: p.RateLimitEnabled,
+		RateLimitRPS:     p.RateLimitRPS,
+		RateLimitBurst:   p.RateLimitBurst,
+		PushRetryMax:     p.PushRetryMax,
+		ProviderOrg:      p.ProviderOrg,
+		ProviderURL:      p.ProviderURL,
+		Projects:         p.Projects,
+		presentKeys:      make(map[string]bool),
+	}
+
+	// Restore present keys.
+	for _, k := range p.PresentKeys {
+		overlay.presentKeys[k] = true
+	}
+
+	if p.UATCacheTTL != "" {
+		d, err := time.ParseDuration(p.UATCacheTTL)
+		if err != nil {
+			return nil, fmt.Errorf("parse persisted uat_cache_ttl: %w", err)
+		}
+		overlay.UATCacheTTL = d
+	}
+	if p.SendMessageTimeout != "" {
+		d, err := time.ParseDuration(p.SendMessageTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("parse persisted send_message_timeout: %w", err)
+		}
+		overlay.SendMessageTimeout = d
+	}
+	if p.SSEKeepalive != "" {
+		d, err := time.ParseDuration(p.SSEKeepalive)
+		if err != nil {
+			return nil, fmt.Errorf("parse persisted sse_keepalive: %w", err)
+		}
+		overlay.SSEKeepalive = d
+	}
+
+	return overlay, nil
+}

--- a/extras/scion-a2a-bridge/internal/bridge/adminoverlay_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/adminoverlay_test.go
@@ -221,7 +221,7 @@ func TestParseAdminOverlay_NegativeRateLimits(t *testing.T) {
 }
 
 func TestParseAdminOverlay_ZeroBurst(t *testing.T) {
-	// Zero burst is valid (means no burst capacity).
+	// Zero burst is valid (means use default 20).
 	cfg := map[string]string{"rate_limit_burst": "0"}
 	overlay, err := ParseAdminOverlay(cfg)
 	if err != nil {
@@ -229,6 +229,14 @@ func TestParseAdminOverlay_ZeroBurst(t *testing.T) {
 	}
 	if overlay.RateLimitBurst != 0 {
 		t.Errorf("RateLimitBurst = %d, want 0", overlay.RateLimitBurst)
+	}
+}
+
+func TestParseAdminOverlay_UATCacheTTLExceedsMax(t *testing.T) {
+	cfg := map[string]string{"uat_cache_ttl": "600s"}
+	_, err := ParseAdminOverlay(cfg)
+	if err == nil {
+		t.Fatal("expected error for uat_cache_ttl > 300s")
 	}
 }
 
@@ -327,6 +335,68 @@ func TestPersistAndLoadOverlay_RoundTrip(t *testing.T) {
 	}
 	if loaded.IsPresent("auth_scheme") != true {
 		t.Error("expected auth_scheme to be present")
+	}
+}
+
+func TestPersistAndLoadOverlay_SentinelPreservation(t *testing.T) {
+	// Regression: sentinel values (-1) for RateLimitBurst and PushRetryMax must
+	// survive a persist→load round-trip. Previously, -1 was skipped during
+	// persist (correct), but the zero value 0 was serialized instead, and on
+	// load 0 replaced the sentinel — causing ApplyOverlay to override the base
+	// YAML value with 0.
+	dir := t.TempDir()
+	overlay := &AdminOverlay{
+		ExternalURL:    "https://example.com",
+		RateLimitBurst: -1, // sentinel: not set
+		PushRetryMax:   -1, // sentinel: not set
+		presentKeys: map[string]bool{
+			"external_url": true,
+		},
+	}
+
+	if err := PersistOverlay(dir, overlay); err != nil {
+		t.Fatalf("PersistOverlay: %v", err)
+	}
+
+	// Verify the JSON does not contain the sentinel fields.
+	data, err := os.ReadFile(filepath.Join(dir, overlayFileName))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if _, ok := raw["rate_limit_burst"]; ok {
+		t.Error("rate_limit_burst should NOT be present in JSON when sentinel")
+	}
+	if _, ok := raw["push_retry_max"]; ok {
+		t.Error("push_retry_max should NOT be present in JSON when sentinel")
+	}
+
+	// Load and verify sentinels are restored.
+	loaded, err := LoadPersistedOverlay(dir)
+	if err != nil {
+		t.Fatalf("LoadPersistedOverlay: %v", err)
+	}
+	if loaded.RateLimitBurst != -1 {
+		t.Errorf("loaded RateLimitBurst = %d, want -1 (sentinel)", loaded.RateLimitBurst)
+	}
+	if loaded.PushRetryMax != -1 {
+		t.Errorf("loaded PushRetryMax = %d, want -1 (sentinel)", loaded.PushRetryMax)
+	}
+
+	// Verify ApplyOverlay does NOT override base values when sentinels are preserved.
+	base := Config{
+		RateLimit: RateLimitConfig{Burst: 42},
+		Timeouts:  TimeoutConfig{PushRetryMax: 7},
+	}
+	result := ApplyOverlay(base, loaded)
+	if result.RateLimit.Burst != 42 {
+		t.Errorf("ApplyOverlay burst = %d, want 42 (base preserved)", result.RateLimit.Burst)
+	}
+	if result.Timeouts.PushRetryMax != 7 {
+		t.Errorf("ApplyOverlay push_retry_max = %d, want 7 (base preserved)", result.Timeouts.PushRetryMax)
 	}
 }
 

--- a/extras/scion-a2a-bridge/internal/bridge/adminoverlay_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/adminoverlay_test.go
@@ -1,0 +1,714 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestParseAdminOverlay_FullConfig(t *testing.T) {
+	cfg := map[string]string{
+		"external_url":         "https://a2a.example.com",
+		"auth_scheme":          "apiKey",
+		"api_key":              "secret123",
+		"uat_cache_ttl":        "120s",
+		"rate_limit_enabled":   "true",
+		"rate_limit_rps":       "50",
+		"rate_limit_burst":     "100",
+		"send_message_timeout": "60s",
+		"sse_keepalive":        "15s",
+		"push_retry_max":       "5",
+		"provider_org":         "Test Org",
+		"provider_url":         "https://test.com",
+		"projects_json":        `[{"slug":"proj1","default_template":"default","auto_provision":true,"exposed_agents":["a1","a2"]}]`,
+	}
+
+	overlay, err := ParseAdminOverlay(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if overlay.ExternalURL != "https://a2a.example.com" {
+		t.Errorf("ExternalURL = %q, want %q", overlay.ExternalURL, "https://a2a.example.com")
+	}
+	if overlay.AuthScheme != "apiKey" {
+		t.Errorf("AuthScheme = %q, want %q", overlay.AuthScheme, "apiKey")
+	}
+	if overlay.APIKey != "secret123" {
+		t.Errorf("APIKey = %q, want %q", overlay.APIKey, "secret123")
+	}
+	if overlay.UATCacheTTL != 120*time.Second {
+		t.Errorf("UATCacheTTL = %v, want %v", overlay.UATCacheTTL, 120*time.Second)
+	}
+	if overlay.RateLimitEnabled == nil || !*overlay.RateLimitEnabled {
+		t.Error("RateLimitEnabled should be true")
+	}
+	if overlay.RateLimitRPS != 50 {
+		t.Errorf("RateLimitRPS = %v, want 50", overlay.RateLimitRPS)
+	}
+	if overlay.RateLimitBurst != 100 {
+		t.Errorf("RateLimitBurst = %v, want 100", overlay.RateLimitBurst)
+	}
+	if overlay.SendMessageTimeout != 60*time.Second {
+		t.Errorf("SendMessageTimeout = %v, want 60s", overlay.SendMessageTimeout)
+	}
+	if overlay.SSEKeepalive != 15*time.Second {
+		t.Errorf("SSEKeepalive = %v, want 15s", overlay.SSEKeepalive)
+	}
+	if overlay.PushRetryMax != 5 {
+		t.Errorf("PushRetryMax = %v, want 5", overlay.PushRetryMax)
+	}
+	if overlay.ProviderOrg != "Test Org" {
+		t.Errorf("ProviderOrg = %q, want %q", overlay.ProviderOrg, "Test Org")
+	}
+	if overlay.ProviderURL != "https://test.com" {
+		t.Errorf("ProviderURL = %q, want %q", overlay.ProviderURL, "https://test.com")
+	}
+	if len(overlay.Projects) != 1 {
+		t.Fatalf("Projects = %d, want 1", len(overlay.Projects))
+	}
+	if overlay.Projects[0].Slug != "proj1" {
+		t.Errorf("Projects[0].Slug = %q, want %q", overlay.Projects[0].Slug, "proj1")
+	}
+	if !overlay.Projects[0].AutoProvision {
+		t.Error("Projects[0].AutoProvision should be true")
+	}
+	if len(overlay.Projects[0].ExposedAgents) != 2 {
+		t.Errorf("Projects[0].ExposedAgents = %d, want 2", len(overlay.Projects[0].ExposedAgents))
+	}
+}
+
+func TestParseAdminOverlay_MinimalConfig(t *testing.T) {
+	cfg := map[string]string{
+		"external_url": "https://minimal.example.com",
+	}
+
+	overlay, err := ParseAdminOverlay(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if overlay.ExternalURL != "https://minimal.example.com" {
+		t.Errorf("ExternalURL = %q, want %q", overlay.ExternalURL, "https://minimal.example.com")
+	}
+	if overlay.AuthScheme != "" {
+		t.Errorf("AuthScheme = %q, want empty", overlay.AuthScheme)
+	}
+	if overlay.RateLimitEnabled != nil {
+		t.Error("RateLimitEnabled should be nil (absent)")
+	}
+	if overlay.RateLimitBurst != -1 {
+		t.Errorf("RateLimitBurst = %d, want -1 (not set)", overlay.RateLimitBurst)
+	}
+	if overlay.PushRetryMax != -1 {
+		t.Errorf("PushRetryMax = %d, want -1 (not set)", overlay.PushRetryMax)
+	}
+
+	// Verify IsPresent
+	if !overlay.IsPresent("external_url") {
+		t.Error("expected external_url to be present")
+	}
+	if overlay.IsPresent("auth_scheme") {
+		t.Error("expected auth_scheme to NOT be present")
+	}
+}
+
+func TestParseAdminOverlay_EmptyConfig(t *testing.T) {
+	cfg := map[string]string{}
+
+	overlay, err := ParseAdminOverlay(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if overlay.ExternalURL != "" {
+		t.Errorf("ExternalURL = %q, want empty", overlay.ExternalURL)
+	}
+}
+
+func TestParseAdminOverlay_InvalidAuthScheme(t *testing.T) {
+	cfg := map[string]string{
+		"auth_scheme": "bogus",
+	}
+
+	_, err := ParseAdminOverlay(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid auth_scheme")
+	}
+}
+
+func TestParseAdminOverlay_ValidAuthSchemes(t *testing.T) {
+	schemes := []string{"apiKey", "bearer", "none", "hubUAT", "hubJWT"}
+	for _, scheme := range schemes {
+		cfg := map[string]string{"auth_scheme": scheme}
+		overlay, err := ParseAdminOverlay(cfg)
+		if err != nil {
+			t.Errorf("scheme %q: unexpected error: %v", scheme, err)
+		}
+		if overlay.AuthScheme != scheme {
+			t.Errorf("scheme %q: got %q", scheme, overlay.AuthScheme)
+		}
+	}
+}
+
+func TestParseAdminOverlay_InvalidDuration(t *testing.T) {
+	tests := []struct {
+		key   string
+		value string
+	}{
+		{"uat_cache_ttl", "not_a_duration"},
+		{"send_message_timeout", "abc"},
+		{"sse_keepalive", "xyz"},
+	}
+	for _, tt := range tests {
+		cfg := map[string]string{tt.key: tt.value}
+		_, err := ParseAdminOverlay(cfg)
+		if err == nil {
+			t.Errorf("key %q value %q: expected error", tt.key, tt.value)
+		}
+	}
+}
+
+func TestParseAdminOverlay_NegativeDuration(t *testing.T) {
+	cfg := map[string]string{"uat_cache_ttl": "-5s"}
+	_, err := ParseAdminOverlay(cfg)
+	if err == nil {
+		t.Fatal("expected error for negative uat_cache_ttl")
+	}
+}
+
+func TestParseAdminOverlay_InvalidProjectsJSON(t *testing.T) {
+	cfg := map[string]string{"projects_json": "not valid json"}
+	_, err := ParseAdminOverlay(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid projects_json")
+	}
+}
+
+func TestParseAdminOverlay_NegativeRateLimits(t *testing.T) {
+	tests := []struct {
+		key   string
+		value string
+	}{
+		{"rate_limit_rps", "-5"},
+		{"rate_limit_rps", "0"},
+		{"rate_limit_burst", "-1"},
+		{"push_retry_max", "-1"},
+	}
+	for _, tt := range tests {
+		cfg := map[string]string{tt.key: tt.value}
+		_, err := ParseAdminOverlay(cfg)
+		if err == nil {
+			t.Errorf("key %q value %q: expected error", tt.key, tt.value)
+		}
+	}
+}
+
+func TestParseAdminOverlay_ZeroBurst(t *testing.T) {
+	// Zero burst is valid (means no burst capacity).
+	cfg := map[string]string{"rate_limit_burst": "0"}
+	overlay, err := ParseAdminOverlay(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if overlay.RateLimitBurst != 0 {
+		t.Errorf("RateLimitBurst = %d, want 0", overlay.RateLimitBurst)
+	}
+}
+
+func TestPersistAndLoadOverlay_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	rlEnabled := true
+	overlay := &AdminOverlay{
+		ExternalURL:        "https://a2a.example.com",
+		AuthScheme:         "hubUAT",
+		APIKey:             "should-not-persist",
+		UATCacheTTL:        90 * time.Second,
+		RateLimitEnabled:   &rlEnabled,
+		RateLimitRPS:       25,
+		RateLimitBurst:     50,
+		SendMessageTimeout: 60 * time.Second,
+		SSEKeepalive:       10 * time.Second,
+		PushRetryMax:       7,
+		ProviderOrg:        "Test Org",
+		ProviderURL:        "https://test.com",
+		Projects: []ProjectConfig{
+			{Slug: "p1", DefaultTemplate: "default", AutoProvision: true, ExposedAgents: []string{"a1"}},
+		},
+		presentKeys: map[string]bool{
+			"external_url":         true,
+			"auth_scheme":          true,
+			"api_key":              true,
+			"uat_cache_ttl":        true,
+			"rate_limit_enabled":   true,
+			"rate_limit_rps":       true,
+			"rate_limit_burst":     true,
+			"send_message_timeout": true,
+			"sse_keepalive":        true,
+			"push_retry_max":       true,
+			"provider_org":         true,
+			"provider_url":         true,
+			"projects_json":        true,
+		},
+	}
+
+	if err := PersistOverlay(dir, overlay); err != nil {
+		t.Fatalf("PersistOverlay: %v", err)
+	}
+
+	loaded, err := LoadPersistedOverlay(dir)
+	if err != nil {
+		t.Fatalf("LoadPersistedOverlay: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected non-nil overlay")
+	}
+
+	// Verify values round-tripped.
+	if loaded.ExternalURL != overlay.ExternalURL {
+		t.Errorf("ExternalURL = %q, want %q", loaded.ExternalURL, overlay.ExternalURL)
+	}
+	if loaded.AuthScheme != overlay.AuthScheme {
+		t.Errorf("AuthScheme = %q, want %q", loaded.AuthScheme, overlay.AuthScheme)
+	}
+	if loaded.UATCacheTTL != overlay.UATCacheTTL {
+		t.Errorf("UATCacheTTL = %v, want %v", loaded.UATCacheTTL, overlay.UATCacheTTL)
+	}
+	if loaded.RateLimitEnabled == nil || *loaded.RateLimitEnabled != true {
+		t.Error("RateLimitEnabled should be true")
+	}
+	if loaded.RateLimitRPS != overlay.RateLimitRPS {
+		t.Errorf("RateLimitRPS = %v, want %v", loaded.RateLimitRPS, overlay.RateLimitRPS)
+	}
+	if loaded.RateLimitBurst != overlay.RateLimitBurst {
+		t.Errorf("RateLimitBurst = %v, want %v", loaded.RateLimitBurst, overlay.RateLimitBurst)
+	}
+	if loaded.SendMessageTimeout != overlay.SendMessageTimeout {
+		t.Errorf("SendMessageTimeout = %v, want %v", loaded.SendMessageTimeout, overlay.SendMessageTimeout)
+	}
+	if loaded.SSEKeepalive != overlay.SSEKeepalive {
+		t.Errorf("SSEKeepalive = %v, want %v", loaded.SSEKeepalive, overlay.SSEKeepalive)
+	}
+	if loaded.PushRetryMax != overlay.PushRetryMax {
+		t.Errorf("PushRetryMax = %v, want %v", loaded.PushRetryMax, overlay.PushRetryMax)
+	}
+	if loaded.ProviderOrg != overlay.ProviderOrg {
+		t.Errorf("ProviderOrg = %q, want %q", loaded.ProviderOrg, overlay.ProviderOrg)
+	}
+	if loaded.ProviderURL != overlay.ProviderURL {
+		t.Errorf("ProviderURL = %q, want %q", loaded.ProviderURL, overlay.ProviderURL)
+	}
+	if len(loaded.Projects) != 1 {
+		t.Fatalf("Projects = %d, want 1", len(loaded.Projects))
+	}
+	if loaded.Projects[0].Slug != "p1" {
+		t.Errorf("Projects[0].Slug = %q, want %q", loaded.Projects[0].Slug, "p1")
+	}
+
+	// Verify present keys are restored (except api_key).
+	if loaded.IsPresent("external_url") != true {
+		t.Error("expected external_url to be present")
+	}
+	if loaded.IsPresent("auth_scheme") != true {
+		t.Error("expected auth_scheme to be present")
+	}
+}
+
+func TestPersistOverlay_APIKeyNotPersisted(t *testing.T) {
+	dir := t.TempDir()
+	overlay := &AdminOverlay{
+		APIKey:      "super-secret",
+		presentKeys: map[string]bool{"api_key": true},
+	}
+
+	if err := PersistOverlay(dir, overlay); err != nil {
+		t.Fatalf("PersistOverlay: %v", err)
+	}
+
+	// Read the raw JSON to verify api_key is not present.
+	data, err := os.ReadFile(filepath.Join(dir, overlayFileName))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if _, ok := raw["api_key"]; ok {
+		t.Error("api_key should NOT be present in persisted overlay")
+	}
+
+	// api_key should also not be in present_keys.
+	if keys, ok := raw["present_keys"]; ok {
+		for _, k := range keys.([]interface{}) {
+			if k.(string) == "api_key" {
+				t.Error("api_key should NOT be in present_keys")
+			}
+		}
+	}
+
+	// Load and verify APIKey is empty.
+	loaded, err := LoadPersistedOverlay(dir)
+	if err != nil {
+		t.Fatalf("LoadPersistedOverlay: %v", err)
+	}
+	if loaded.APIKey != "" {
+		t.Errorf("loaded APIKey = %q, want empty", loaded.APIKey)
+	}
+}
+
+func TestLoadPersistedOverlay_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	overlay, err := LoadPersistedOverlay(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if overlay != nil {
+		t.Error("expected nil overlay when no file exists")
+	}
+}
+
+func TestApplyOverlay_Precedence(t *testing.T) {
+	base := Config{
+		Bridge: BridgeConfig{
+			ExternalURL: "https://base.example.com",
+			Provider:    ProviderConfig{Organization: "Base Org", URL: "https://base.com"},
+		},
+		Auth: AuthConfig{
+			Scheme: "apiKey",
+			APIKey: "base-key",
+		},
+		RateLimit: RateLimitConfig{
+			Enabled:        false,
+			RequestsPerSec: 5,
+			Burst:          10,
+		},
+		Timeouts: TimeoutConfig{
+			SendMessage:  60 * time.Second,
+			SSEKeepalive: 15 * time.Second,
+			PushRetryMax: 2,
+		},
+		Projects: []ProjectConfig{
+			{Slug: "base-proj"},
+		},
+	}
+
+	rlEnabled := true
+	overlay := &AdminOverlay{
+		ExternalURL:        "https://overlay.example.com",
+		AuthScheme:         "hubUAT",
+		RateLimitEnabled:   &rlEnabled,
+		RateLimitRPS:       25,
+		RateLimitBurst:     -1, // not set — keep base
+		SendMessageTimeout: 90 * time.Second,
+		PushRetryMax:       -1, // not set — keep base
+		ProviderOrg:        "Overlay Org",
+		presentKeys: map[string]bool{
+			"external_url":         true,
+			"auth_scheme":          true,
+			"rate_limit_enabled":   true,
+			"rate_limit_rps":       true,
+			"send_message_timeout": true,
+			"provider_org":         true,
+		},
+	}
+
+	result := ApplyOverlay(base, overlay)
+
+	// Overlay wins for present keys.
+	if result.Bridge.ExternalURL != "https://overlay.example.com" {
+		t.Errorf("ExternalURL = %q, want overlay value", result.Bridge.ExternalURL)
+	}
+	if result.Auth.Scheme != "hubUAT" {
+		t.Errorf("Auth.Scheme = %q, want overlay value", result.Auth.Scheme)
+	}
+	if !result.RateLimit.Enabled {
+		t.Error("RateLimit.Enabled should be true (overlay)")
+	}
+	if result.RateLimit.RequestsPerSec != 25 {
+		t.Errorf("RateLimit.RequestsPerSec = %v, want 25 (overlay)", result.RateLimit.RequestsPerSec)
+	}
+	if result.Timeouts.SendMessage != 90*time.Second {
+		t.Errorf("Timeouts.SendMessage = %v, want 90s (overlay)", result.Timeouts.SendMessage)
+	}
+	if result.Bridge.Provider.Organization != "Overlay Org" {
+		t.Errorf("Provider.Organization = %q, want overlay value", result.Bridge.Provider.Organization)
+	}
+
+	// Base wins for absent overlay keys.
+	if result.Auth.APIKey != "base-key" {
+		t.Errorf("Auth.APIKey = %q, want base value", result.Auth.APIKey)
+	}
+	if result.RateLimit.Burst != 10 {
+		t.Errorf("RateLimit.Burst = %d, want 10 (base, overlay sentinel -1)", result.RateLimit.Burst)
+	}
+	if result.Timeouts.SSEKeepalive != 15*time.Second {
+		t.Errorf("Timeouts.SSEKeepalive = %v, want 15s (base)", result.Timeouts.SSEKeepalive)
+	}
+	if result.Timeouts.PushRetryMax != 2 {
+		t.Errorf("Timeouts.PushRetryMax = %d, want 2 (base)", result.Timeouts.PushRetryMax)
+	}
+	if result.Bridge.Provider.URL != "https://base.com" {
+		t.Errorf("Provider.URL = %q, want base value", result.Bridge.Provider.URL)
+	}
+	if len(result.Projects) != 1 || result.Projects[0].Slug != "base-proj" {
+		t.Error("Projects should be base value (overlay absent)")
+	}
+}
+
+func TestApplyOverlay_NilOverlay(t *testing.T) {
+	base := Config{
+		Bridge: BridgeConfig{ExternalURL: "https://base.example.com"},
+	}
+
+	result := ApplyOverlay(base, nil)
+	if result.Bridge.ExternalURL != "https://base.example.com" {
+		t.Errorf("ExternalURL = %q, want base value", result.Bridge.ExternalURL)
+	}
+}
+
+func TestBuildSnapshot_RateLimitDisabled(t *testing.T) {
+	cfg := Config{
+		RateLimit: RateLimitConfig{Enabled: false},
+	}
+	snap := BuildSnapshot(cfg)
+	if snap.Limiter != nil {
+		t.Error("limiter should be nil when rate limiting is disabled")
+	}
+}
+
+func TestBuildSnapshot_RateLimitEnabled(t *testing.T) {
+	cfg := Config{
+		RateLimit: RateLimitConfig{Enabled: true, RequestsPerSec: 10, Burst: 20},
+	}
+	snap := BuildSnapshot(cfg)
+	if snap.Limiter == nil {
+		t.Error("limiter should not be nil when rate limiting is enabled")
+	}
+}
+
+func TestBuildAuthValidators_Schemes(t *testing.T) {
+	tests := []struct {
+		scheme    string
+		expectUAT bool
+		expectKey bool
+	}{
+		{"apiKey", false, true},
+		{"bearer", false, true},
+		{"none", false, false},
+		{"hubUAT", true, false},
+		{"hubJWT", false, false},
+		{"", false, true}, // default legacy scheme
+	}
+
+	for _, tt := range tests {
+		cfg := &Config{
+			Auth: AuthConfig{
+				Scheme: tt.scheme,
+				APIKey: "test-key",
+			},
+			Hub: HubConfig{Endpoint: "https://hub.example.com"},
+		}
+		av := BuildAuthValidators(cfg)
+		if av.Scheme != tt.scheme {
+			t.Errorf("scheme %q: Scheme = %q", tt.scheme, av.Scheme)
+		}
+		if (av.UATValidator != nil) != tt.expectUAT {
+			t.Errorf("scheme %q: UATValidator present = %v, want %v", tt.scheme, av.UATValidator != nil, tt.expectUAT)
+		}
+		if (av.APIKey != "") != tt.expectKey {
+			t.Errorf("scheme %q: APIKey present = %v, want %v", tt.scheme, av.APIKey != "", tt.expectKey)
+		}
+	}
+}
+
+func TestSnapshotHolder_AtomicSwap(t *testing.T) {
+	cfg1 := Config{Bridge: BridgeConfig{ExternalURL: "https://v1.example.com"}}
+	cfg2 := Config{Bridge: BridgeConfig{ExternalURL: "https://v2.example.com"}}
+
+	snap1 := BuildSnapshot(cfg1)
+	holder := NewSnapshotHolder(snap1)
+
+	if got := holder.Load().Config.Bridge.ExternalURL; got != "https://v1.example.com" {
+		t.Errorf("initial Load = %q, want v1", got)
+	}
+
+	snap2 := BuildSnapshot(cfg2)
+	holder.Store(snap2)
+
+	if got := holder.Load().Config.Bridge.ExternalURL; got != "https://v2.example.com" {
+		t.Errorf("after Store = %q, want v2", got)
+	}
+}
+
+func TestConfigure_RejectsBadConfig(t *testing.T) {
+	broker := NewBrokerServer(nil, discardLogger(), nil)
+	baseCfg := &Config{}
+	snap := NewSnapshotHolder(BuildSnapshot(*baseCfg))
+	broker.SetAdminConfig(baseCfg, snap, "")
+
+	badConfig := map[string]string{
+		"auth_scheme": "bogus",
+	}
+	err := broker.Configure(badConfig)
+	if err == nil {
+		t.Fatal("expected error for invalid config")
+	}
+
+	// Verify the snapshot was NOT updated (last-good preserved).
+	if snap.Load().Config.Auth.Scheme != "" {
+		t.Errorf("snapshot auth scheme should remain empty after rejected push")
+	}
+}
+
+func TestConfigure_AppliesGoodConfig(t *testing.T) {
+	broker := NewBrokerServer(nil, discardLogger(), nil)
+	baseCfg := &Config{
+		Bridge: BridgeConfig{ExternalURL: "https://base.example.com"},
+		Auth:   AuthConfig{Scheme: "none"},
+	}
+	snap := NewSnapshotHolder(BuildSnapshot(*baseCfg))
+	dir := t.TempDir()
+	broker.SetAdminConfig(baseCfg, snap, dir)
+
+	goodConfig := map[string]string{
+		"external_url": "https://overlay.example.com",
+		"auth_scheme":  "apiKey",
+		"api_key":      "new-key",
+	}
+	err := broker.Configure(goodConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the snapshot was updated.
+	current := snap.Load()
+	if current.Config.Bridge.ExternalURL != "https://overlay.example.com" {
+		t.Errorf("ExternalURL = %q, want overlay value", current.Config.Bridge.ExternalURL)
+	}
+	if current.Config.Auth.Scheme != "apiKey" {
+		t.Errorf("Auth.Scheme = %q, want apiKey", current.Config.Auth.Scheme)
+	}
+	if current.Auth.APIKey != "new-key" {
+		t.Errorf("Auth.APIKey = %q, want new-key", current.Auth.APIKey)
+	}
+
+	// Verify overlay was persisted.
+	loaded, err := LoadPersistedOverlay(dir)
+	if err != nil {
+		t.Fatalf("LoadPersistedOverlay: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected persisted overlay")
+	}
+	if loaded.ExternalURL != "https://overlay.example.com" {
+		t.Errorf("persisted ExternalURL = %q, want overlay value", loaded.ExternalURL)
+	}
+	// API key should NOT be in persisted overlay.
+	if loaded.APIKey != "" {
+		t.Errorf("persisted APIKey = %q, want empty", loaded.APIKey)
+	}
+}
+
+func TestConfigure_KeepsLastGoodOnReject(t *testing.T) {
+	broker := NewBrokerServer(nil, discardLogger(), nil)
+	baseCfg := &Config{Auth: AuthConfig{Scheme: "none"}}
+	snap := NewSnapshotHolder(BuildSnapshot(*baseCfg))
+	broker.SetAdminConfig(baseCfg, snap, "")
+
+	// Apply good config first.
+	goodConfig := map[string]string{
+		"auth_scheme": "apiKey",
+		"api_key":     "key1",
+	}
+	if err := broker.Configure(goodConfig); err != nil {
+		t.Fatalf("first configure failed: %v", err)
+	}
+	if snap.Load().Config.Auth.Scheme != "apiKey" {
+		t.Fatal("expected apiKey after first configure")
+	}
+
+	// Now push bad config.
+	badConfig := map[string]string{
+		"auth_scheme": "invalid",
+	}
+	err := broker.Configure(badConfig)
+	if err == nil {
+		t.Fatal("expected error for invalid config")
+	}
+
+	// Verify last-good is preserved.
+	if snap.Load().Config.Auth.Scheme != "apiKey" {
+		t.Errorf("auth scheme should remain apiKey after rejected push, got %q", snap.Load().Config.Auth.Scheme)
+	}
+}
+
+func TestConfigure_NoAdminConfigWired(t *testing.T) {
+	// When admin config management is not wired, Configure is a no-op.
+	broker := NewBrokerServer(nil, discardLogger(), nil)
+
+	err := broker.Configure(map[string]string{"auth_scheme": "none"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHealthCheck_EnrichedDetails(t *testing.T) {
+	broker := NewBrokerServer(nil, discardLogger(), nil)
+	cfg := Config{
+		Bridge: BridgeConfig{
+			ExternalURL: "https://a2a.example.com",
+			Provider:    ProviderConfig{Organization: "Test Org"},
+		},
+		Auth: AuthConfig{Scheme: "hubUAT"},
+		Projects: []ProjectConfig{
+			{Slug: "p1"},
+			{Slug: "p2"},
+		},
+	}
+	snap := NewSnapshotHolder(BuildSnapshot(cfg))
+	broker.SetAdminConfig(&cfg, snap, "")
+	broker.configured = true
+
+	hs, err := broker.HealthCheck()
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if hs.Status != "healthy" {
+		t.Errorf("Status = %q, want healthy", hs.Status)
+	}
+	if hs.Details["auth_scheme"] != "hubUAT" {
+		t.Errorf("Details[auth_scheme] = %q, want hubUAT", hs.Details["auth_scheme"])
+	}
+	if hs.Details["external_url"] != "https://a2a.example.com" {
+		t.Errorf("Details[external_url] = %q, want https://a2a.example.com", hs.Details["external_url"])
+	}
+	if hs.Details["exposed_projects"] != "2" {
+		t.Errorf("Details[exposed_projects] = %q, want 2", hs.Details["exposed_projects"])
+	}
+	if hs.Details["provider_org"] != "Test Org" {
+		t.Errorf("Details[provider_org] = %q, want Test Org", hs.Details["provider_org"])
+	}
+}
+
+func discardLogger() *slog.Logger {
+	return slog.Default()
+}

--- a/extras/scion-a2a-bridge/internal/bridge/adminoverlay_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/adminoverlay_test.go
@@ -779,6 +779,110 @@ func TestHealthCheck_EnrichedDetails(t *testing.T) {
 	}
 }
 
+func TestParseAdminOverlay_EmptyNonStringFieldsNotPresent(t *testing.T) {
+	// Regression: empty string values for non-string fields (durations, ints,
+	// bools, projects_json) must NOT be marked as present — otherwise
+	// ApplyOverlay overwrites base YAML values with zero values.
+	cfg := map[string]string{
+		"uat_cache_ttl":        "",
+		"send_message_timeout": "",
+		"sse_keepalive":        "",
+		"rate_limit_enabled":   "",
+		"rate_limit_rps":       "",
+		"rate_limit_burst":     "",
+		"push_retry_max":       "",
+		"projects_json":        "",
+	}
+
+	overlay, err := ParseAdminOverlay(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	nonStringKeys := []string{
+		"uat_cache_ttl", "send_message_timeout", "sse_keepalive",
+		"rate_limit_enabled", "rate_limit_rps", "rate_limit_burst",
+		"push_retry_max", "projects_json",
+	}
+	for _, key := range nonStringKeys {
+		if overlay.IsPresent(key) {
+			t.Errorf("%q should NOT be marked as present when value is empty", key)
+		}
+	}
+
+	// Verify ApplyOverlay does not override base values.
+	base := Config{
+		Auth:     AuthConfig{UATCacheTTL: 90 * time.Second},
+		Timeouts: TimeoutConfig{SendMessage: 60 * time.Second, SSEKeepalive: 15 * time.Second, PushRetryMax: 5},
+	}
+	result := ApplyOverlay(base, overlay)
+	if result.Auth.UATCacheTTL != 90*time.Second {
+		t.Errorf("UATCacheTTL = %v, want 90s (base preserved)", result.Auth.UATCacheTTL)
+	}
+	if result.Timeouts.SendMessage != 60*time.Second {
+		t.Errorf("SendMessage = %v, want 60s (base preserved)", result.Timeouts.SendMessage)
+	}
+	if result.Timeouts.SSEKeepalive != 15*time.Second {
+		t.Errorf("SSEKeepalive = %v, want 15s (base preserved)", result.Timeouts.SSEKeepalive)
+	}
+	if result.Timeouts.PushRetryMax != 5 {
+		t.Errorf("PushRetryMax = %d, want 5 (base preserved)", result.Timeouts.PushRetryMax)
+	}
+}
+
+func TestParseAdminOverlay_EmptyStringFieldsStillPresent(t *testing.T) {
+	// String fields (external_url, auth_scheme, api_key, provider_org,
+	// provider_url) can be explicitly cleared by setting them to empty. They
+	// should still be marked as present so ApplyOverlay writes the empty value.
+	cfg := map[string]string{
+		"external_url": "",
+		"auth_scheme":  "",
+		"api_key":      "",
+		"provider_org": "",
+		"provider_url": "",
+	}
+
+	overlay, err := ParseAdminOverlay(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stringKeys := []string{"external_url", "auth_scheme", "api_key", "provider_org", "provider_url"}
+	for _, key := range stringKeys {
+		if !overlay.IsPresent(key) {
+			t.Errorf("%q should be marked as present even when value is empty", key)
+		}
+	}
+
+	// Verify ApplyOverlay clears base values.
+	base := Config{
+		Bridge: BridgeConfig{
+			ExternalURL: "https://base.example.com",
+			Provider:    ProviderConfig{Organization: "Base Org", URL: "https://base.com"},
+		},
+		Auth: AuthConfig{
+			Scheme: "apiKey",
+			APIKey: "base-key",
+		},
+	}
+	result := ApplyOverlay(base, overlay)
+	if result.Bridge.ExternalURL != "" {
+		t.Errorf("ExternalURL = %q, want empty (cleared)", result.Bridge.ExternalURL)
+	}
+	if result.Auth.Scheme != "" {
+		t.Errorf("Auth.Scheme = %q, want empty (cleared)", result.Auth.Scheme)
+	}
+	if result.Auth.APIKey != "" {
+		t.Errorf("Auth.APIKey = %q, want empty (cleared)", result.Auth.APIKey)
+	}
+	if result.Bridge.Provider.Organization != "" {
+		t.Errorf("Provider.Organization = %q, want empty (cleared)", result.Bridge.Provider.Organization)
+	}
+	if result.Bridge.Provider.URL != "" {
+		t.Errorf("Provider.URL = %q, want empty (cleared)", result.Bridge.Provider.URL)
+	}
+}
+
 func discardLogger() *slog.Logger {
 	return slog.Default()
 }

--- a/extras/scion-a2a-bridge/internal/bridge/bridge.go
+++ b/extras/scion-a2a-bridge/internal/bridge/bridge.go
@@ -53,6 +53,7 @@ type Bridge struct {
 	hubClient hubclient.Client
 	minter    *identity.TokenMinter
 	config    *Config
+	snapshot  *SnapshotHolder // atomic snapshot of effective config (hot-apply)
 	broker    *BrokerServer
 	streams   *StreamManager
 	push      *PushDispatcher
@@ -139,7 +140,7 @@ func New(store *state.Store, hubClient hubclient.Client, minter *identity.TokenM
 func (b *Bridge) janitor() {
 	defer b.wg.Done()
 
-	maxAge := 2 * b.config.Timeouts.SendMessage
+	maxAge := 2 * b.effectiveConfig().Timeouts.SendMessage
 	if maxAge == 0 {
 		maxAge = 4 * time.Minute
 	}
@@ -231,6 +232,21 @@ func (b *Bridge) Shutdown() {
 // SetBroker wires the broker server for subscription management.
 func (b *Bridge) SetBroker(broker *BrokerServer) {
 	b.broker = broker
+}
+
+// SetSnapshot wires the atomic config snapshot for hot-apply support.
+func (b *Bridge) SetSnapshot(snap *SnapshotHolder) {
+	b.snapshot = snap
+}
+
+// effectiveConfig returns the effective config from the snapshot if available,
+// or the static config as fallback.
+func (b *Bridge) effectiveConfig() *Config {
+	if b.snapshot != nil {
+		snap := b.snapshot.Load()
+		return &snap.Config
+	}
+	return b.config
 }
 
 // SetSDKRequestHandler stores the SDK RequestHandler for multi-transport access.
@@ -366,7 +382,7 @@ func (b *Bridge) SendMessage(ctx context.Context, projectSlug, agentSlug, contex
 		b.log.Error("failed to update task state", "error", err, "task_id", taskID)
 	}
 
-	timeout := b.config.Timeouts.SendMessage
+	timeout := b.effectiveConfig().Timeouts.SendMessage
 	if timeout == 0 {
 		timeout = 120 * time.Second
 	}
@@ -477,7 +493,7 @@ func (b *Bridge) sendFollowUp(ctx context.Context, projectSlug, agentSlug, taskI
 			return nil, fmt.Errorf("send follow-up to agent: %w", err)
 		}
 
-		timeout := b.config.Timeouts.SendMessage
+		timeout := b.effectiveConfig().Timeouts.SendMessage
 		if timeout == 0 {
 			timeout = 120 * time.Second
 		}
@@ -977,7 +993,8 @@ func (b *Bridge) subscribeAdminUserTopics(projectID string) {
 // GenerateAgentCard builds an agent card for the given project and agent,
 // enriching it with metadata from the Hub API when available.
 func (b *Bridge) GenerateAgentCard(ctx context.Context, projectSlug, agentSlug string) map[string]interface{} {
-	baseURL := strings.TrimRight(b.config.Bridge.ExternalURL, "/")
+	cfg := b.effectiveConfig()
+	baseURL := strings.TrimRight(cfg.Bridge.ExternalURL, "/")
 	agentURL := fmt.Sprintf("%s/projects/%s/agents/%s", baseURL, projectSlug, agentSlug)
 
 	name := agentSlug
@@ -1030,10 +1047,10 @@ func (b *Bridge) GenerateAgentCard(ctx context.Context, projectSlug, agentSlug s
 		"skills":             skills,
 	}
 
-	if b.config.Bridge.Provider.Organization != "" {
+	if cfg.Bridge.Provider.Organization != "" {
 		card["provider"] = map[string]string{
-			"organization": b.config.Bridge.Provider.Organization,
-			"url":          b.config.Bridge.Provider.URL,
+			"organization": cfg.Bridge.Provider.Organization,
+			"url":          cfg.Bridge.Provider.URL,
 		}
 	}
 
@@ -1095,10 +1112,11 @@ func (b *Bridge) evictStaleAgentCache() {
 // GetProjectConfig returns the configuration for a project slug, or nil if not configured.
 // Returns a pointer to a copy to avoid aliasing the live config slice.
 func (b *Bridge) GetProjectConfig(projectSlug string) *ProjectConfig {
-	for i := range b.config.Projects {
-		if b.config.Projects[i].Slug == projectSlug {
-			cfg := b.config.Projects[i]
-			return &cfg
+	cfg := b.effectiveConfig()
+	for i := range cfg.Projects {
+		if cfg.Projects[i].Slug == projectSlug {
+			pc := cfg.Projects[i]
+			return &pc
 		}
 	}
 	return nil

--- a/extras/scion-a2a-bridge/internal/bridge/broker.go
+++ b/extras/scion-a2a-bridge/internal/bridge/broker.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"strconv"
 	"sync"
 	"time"
 
@@ -41,6 +42,11 @@ type BrokerServer struct {
 	mu            sync.RWMutex
 	subscriptions map[string]bool
 	configured    bool
+
+	// Admin config management fields (Phase 3).
+	baseConfig *Config         // base YAML config loaded at boot (immutable after init)
+	snapshot   *SnapshotHolder // atomic snapshot of effective config
+	stateDir   string          // directory for admin-overlay.json persistence
 }
 
 var _ plugin.MessageBrokerPluginInterface = (*BrokerServer)(nil)
@@ -63,13 +69,69 @@ func (b *BrokerServer) SetHandler(handler MessageHandler) {
 	b.handler = handler
 }
 
+// SetAdminConfig wires the base config, snapshot holder, and state directory
+// for admin overlay management. Must be called before the first Configure() push.
+func (b *BrokerServer) SetAdminConfig(baseCfg *Config, snap *SnapshotHolder, stateDir string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.baseConfig = baseCfg
+	b.snapshot = snap
+	b.stateDir = stateDir
+}
+
 // Configure is called by the Hub plugin manager during initialization.
+// It parses the flat key map, validates values, applies the overlay onto the
+// base YAML config, and atomically swaps the effective snapshot.
 func (b *BrokerServer) Configure(config map[string]string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	if b.baseConfig == nil || b.snapshot == nil {
+		// Admin config management not wired — fall back to no-op.
+		b.configured = true
+		b.log.Info("broker plugin configured (no admin config wired)", "config_keys", len(config))
+		return nil
+	}
+
+	overlay, err := ParseAdminOverlay(config)
+	if err != nil {
+		b.log.Error("rejected admin config push", "error", err)
+		return err // Hub surfaces this error to the admin UI
+	}
+
+	b.applyOverlay(overlay)
+
+	if b.stateDir != "" {
+		if err := PersistOverlay(b.stateDir, overlay); err != nil {
+			b.log.Warn("failed to persist admin overlay", "error", err)
+			// Non-fatal: config is applied in memory, just won't survive restart.
+		}
+	}
+
 	b.configured = true
-	b.log.Info("broker plugin configured", "config_keys", len(config))
+	b.log.Info("admin config applied",
+		"auth_scheme", overlay.AuthScheme,
+		"external_url", overlay.ExternalURL,
+		"projects", len(overlay.Projects),
+	)
 	return nil
+}
+
+// applyOverlay merges the overlay onto the base config and swaps the snapshot.
+// Must be called with b.mu held.
+func (b *BrokerServer) applyOverlay(overlay *AdminOverlay) {
+	effective := ApplyOverlay(*b.baseConfig, overlay)
+	snap := BuildSnapshot(effective)
+
+	// Preserve the JWT validator from the current snapshot if the scheme
+	// is still hubJWT — the signing key is loaded at boot and doesn't change.
+	if snap.Auth.Scheme == "hubJWT" {
+		if current := b.snapshot.Load(); current != nil && current.Auth.JWTValidator != nil {
+			snap.Auth.JWTValidator = current.Auth.JWTValidator
+		}
+	}
+
+	b.snapshot.Store(snap)
 }
 
 // Publish receives a message from the Hub and routes it to the handler.
@@ -121,7 +183,7 @@ func (b *BrokerServer) GetInfo() (*plugin.PluginInfo, error) {
 	}, nil
 }
 
-// HealthCheck returns the plugin's health status.
+// HealthCheck returns the plugin's health status with effective config details.
 func (b *BrokerServer) HealthCheck() (*plugin.HealthStatus, error) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
@@ -133,10 +195,28 @@ func (b *BrokerServer) HealthCheck() (*plugin.HealthStatus, error) {
 		msg = "not yet configured by hub"
 	}
 
-	return &plugin.HealthStatus{
+	hs := &plugin.HealthStatus{
 		Status:  status,
 		Message: msg,
-	}, nil
+	}
+
+	// Enrich with effective config details from the snapshot.
+	if b.snapshot != nil {
+		snap := b.snapshot.Load()
+		if snap != nil {
+			if hs.Details == nil {
+				hs.Details = make(map[string]string)
+			}
+			hs.Details["auth_scheme"] = snap.Config.Auth.Scheme
+			hs.Details["external_url"] = snap.Config.Bridge.ExternalURL
+			hs.Details["exposed_projects"] = strconv.Itoa(len(snap.Config.Projects))
+			if snap.Config.Bridge.Provider.Organization != "" {
+				hs.Details["provider_org"] = snap.Config.Bridge.Provider.Organization
+			}
+		}
+	}
+
+	return hs, nil
 }
 
 // SetHostCallbacks is called by the go-plugin framework to provide the reverse channel.

--- a/extras/scion-a2a-bridge/internal/bridge/config.go
+++ b/extras/scion-a2a-bridge/internal/bridge/config.go
@@ -79,10 +79,10 @@ type AuthConfig struct {
 
 // ProjectConfig configures a project exposed via the bridge.
 type ProjectConfig struct {
-	Slug            string   `yaml:"slug"`
-	DefaultTemplate string   `yaml:"default_template"`
-	AutoProvision   bool     `yaml:"auto_provision"`
-	ExposedAgents   []string `yaml:"exposed_agents"`
+	Slug            string   `yaml:"slug" json:"slug"`
+	DefaultTemplate string   `yaml:"default_template" json:"default_template"`
+	AutoProvision   bool     `yaml:"auto_provision" json:"auto_provision"`
+	ExposedAgents   []string `yaml:"exposed_agents" json:"exposed_agents"`
 }
 
 // GroveConfig is a legacy alias for ProjectConfig.

--- a/extras/scion-a2a-bridge/internal/bridge/followup_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/followup_test.go
@@ -166,8 +166,12 @@ func (m *mockHubClient) UserInjectedSkills() hubclient.InjectedSkillsService { r
 func (m *mockHubClient) ProjectPreStartHooks(projectID string) hubclient.ProjectPreStartHookService {
 	return nil
 }
+func (m *mockHubClient) HubPreStartHooks() hubclient.HubPreStartHookService { return nil }
 func (m *mockHubClient) Health(ctx context.Context) (*hubclient.HealthResponse, error) {
 	return &hubclient.HealthResponse{}, nil
+}
+func (m *mockHubClient) DiscoverSkillsDirectory(ctx context.Context, req hubclient.DiscoverSkillsDirectoryRequest) (*hubclient.DiscoverSkillsDirectoryResponse, error) {
+	return nil, nil
 }
 
 // --- Test helpers ---

--- a/extras/scion-a2a-bridge/internal/bridge/server.go
+++ b/extras/scion-a2a-bridge/internal/bridge/server.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -33,11 +34,13 @@ var slugRE = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,62}$`)
 
 // Server is the A2A HTTP server that routes requests to the SDK handler.
 type Server struct {
-	bridge       *Bridge
-	config       *Config
-	metrics      *Metrics
-	log          *slog.Logger
-	sdkHandler   http.Handler // SDK JSON-RPC handler
+	bridge     *Bridge
+	config     *Config         // base config (kept for backward compat in non-snapshot paths)
+	snapshot   *SnapshotHolder // atomic snapshot of effective config (hot-apply)
+	metrics    *Metrics
+	log        *slog.Logger
+	sdkHandler http.Handler // SDK JSON-RPC handler
+	// Legacy validators — used only when snapshot is nil (tests, backward compat).
 	uatValidator *UATValidator
 	jwtValidator *JWTValidator
 }
@@ -62,10 +65,27 @@ func NewServer(bridge *Bridge, cfg *Config, metrics *Metrics, log *slog.Logger, 
 	return s
 }
 
+// SetSnapshot wires the atomic config snapshot for hot-apply support.
+// When set, auth middleware and rate limiting read from the snapshot
+// instead of the static config pointer.
+func (s *Server) SetSnapshot(snap *SnapshotHolder) {
+	s.snapshot = snap
+}
+
 // SetJWTValidator sets the JWT validator for hubJWT mode. Called after the
 // signing key is loaded (which may require Secret Manager access).
+// Also updates the snapshot if one is wired.
 func (s *Server) SetJWTValidator(v *JWTValidator) {
 	s.jwtValidator = v
+	if s.snapshot != nil {
+		snap := s.snapshot.Load()
+		if snap != nil && snap.Auth.Scheme == "hubJWT" {
+			// Create a new snapshot with the validator set.
+			newSnap := *snap
+			newSnap.Auth.JWTValidator = v
+			s.snapshot.Store(&newSnap)
+		}
+	}
 }
 
 // ValidateConfig checks that required configuration fields are present and consistent.
@@ -122,7 +142,8 @@ func ValidateConfig(cfg *Config) error {
 
 // WarnOnOpenAuth logs a warning if the auth configuration leaves the bridge open.
 func (s *Server) WarnOnOpenAuth() {
-	switch s.config.Auth.Scheme {
+	cfg := s.effectiveConfig()
+	switch cfg.Auth.Scheme {
 	case "none":
 		s.log.Warn("bridge auth is explicitly DISABLED (auth.scheme: none) — all requests will be accepted without authentication")
 	case "":
@@ -132,7 +153,7 @@ func (s *Server) WarnOnOpenAuth() {
 	case "hubJWT":
 		s.log.Info("bridge auth: hubJWT — per-user Scion JWT authentication enabled")
 	}
-	if s.config.RateLimit.TrustProxy {
+	if cfg.RateLimit.TrustProxy {
 		s.log.Warn("rate_limit.trust_proxy is enabled — X-Forwarded-For is trusted unconditionally, which allows clients to spoof their IP and bypass per-IP rate limits; consider adding network-level proxy restrictions")
 	}
 }
@@ -159,7 +180,11 @@ func (s *Server) Handler() http.Handler {
 
 	// Wrap with middleware chain: metrics -> rate limit -> auth.
 	handler := s.authMiddleware(mux)
-	handler = RateLimitMiddleware(handler, s.config.RateLimit)
+	if s.snapshot != nil {
+		handler = s.snapshotRateLimitMiddleware(handler)
+	} else {
+		handler = RateLimitMiddleware(handler, s.config.RateLimit)
+	}
 	handler = InstrumentHandler(handler, s.metrics)
 	return handler
 }
@@ -210,10 +235,11 @@ func (s *Server) handleReadyz(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleWellKnownAgentCard(w http.ResponseWriter, r *http.Request) {
+	cfg := s.effectiveConfig()
 	registry := map[string]interface{}{
 		"name":        "scion-a2a-bridge",
 		"description": "Scion A2A Protocol Bridge — exposes Scion agents as A2A endpoints",
-		"url":         s.config.Bridge.ExternalURL,
+		"url":         cfg.Bridge.ExternalURL,
 		"version":     "1.0.0",
 		"capabilities": map[string]bool{
 			"streaming":         true,
@@ -221,10 +247,10 @@ func (s *Server) handleWellKnownAgentCard(w http.ResponseWriter, r *http.Request
 		},
 	}
 
-	if s.config.Bridge.Provider.Organization != "" {
+	if cfg.Bridge.Provider.Organization != "" {
 		registry["provider"] = map[string]string{
-			"organization": s.config.Bridge.Provider.Organization,
-			"url":          s.config.Bridge.Provider.URL,
+			"organization": cfg.Bridge.Provider.Organization,
+			"url":          cfg.Bridge.Provider.URL,
 		}
 	}
 
@@ -323,6 +349,9 @@ func writeJSONRPCError(w http.ResponseWriter, id interface{}, code int, message 
 }
 
 // authMiddleware validates authentication on non-public endpoints.
+// When a snapshot is available, auth scheme and validators are read from the
+// snapshot for hot-apply support. Each request loads the snapshot once for
+// consistency even if a config swap happens mid-flight.
 func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Public endpoints skip auth.
@@ -338,7 +367,26 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		switch s.config.Auth.Scheme {
+		// Resolve auth scheme and validators from snapshot (hot-apply) or static config.
+		var scheme string
+		var uatV *UATValidator
+		var jwtV *JWTValidator
+		var configAPIKey string
+
+		if s.snapshot != nil {
+			snap := s.snapshot.Load()
+			scheme = snap.Auth.Scheme
+			uatV = snap.Auth.UATValidator
+			jwtV = snap.Auth.JWTValidator
+			configAPIKey = snap.Auth.APIKey
+		} else {
+			scheme = s.config.Auth.Scheme
+			uatV = s.uatValidator
+			jwtV = s.jwtValidator
+			configAPIKey = s.config.Auth.APIKey
+		}
+
+		switch scheme {
 		case "none":
 			next.ServeHTTP(w, r)
 			return
@@ -349,7 +397,12 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 				http.Error(w, "unauthorized: expected scion_pat_* token", http.StatusUnauthorized)
 				return
 			}
-			caller, err := s.uatValidator.Validate(r.Context(), token)
+			if uatV == nil {
+				s.log.Error("hubUAT scheme configured but UAT validator not initialized")
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+				return
+			}
+			caller, err := uatV.Validate(r.Context(), token)
 			if err != nil {
 				s.log.Debug("UAT validation failed", "error", err)
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
@@ -365,12 +418,12 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 				http.Error(w, "unauthorized: missing bearer token", http.StatusUnauthorized)
 				return
 			}
-			if s.jwtValidator == nil {
+			if jwtV == nil {
 				s.log.Error("hubJWT scheme configured but JWT validator not initialized")
 				http.Error(w, "internal server error", http.StatusInternalServerError)
 				return
 			}
-			caller, err := s.jwtValidator.Validate(token)
+			caller, err := jwtV.Validate(token)
 			if err != nil {
 				s.log.Debug("JWT validation failed", "error", err)
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
@@ -384,7 +437,7 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			// Legacy schemes: "apiKey", "bearer", or "" (accept either header).
 			// No CallerIdentity is injected.
 			var apiKey string
-			switch s.config.Auth.Scheme {
+			switch scheme {
 			case "apiKey":
 				apiKey = r.Header.Get("X-API-Key")
 			case "bearer":
@@ -399,7 +452,7 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			}
 
 			// Compare SHA-256 hashes to avoid leaking key length via timing.
-			expectedHash := sha256.Sum256([]byte(s.config.Auth.APIKey))
+			expectedHash := sha256.Sum256([]byte(configAPIKey))
 			providedHash := sha256.Sum256([]byte(apiKey))
 			if subtle.ConstantTimeCompare(expectedHash[:], providedHash[:]) != 1 {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
@@ -409,6 +462,61 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		}
 	})
+}
+
+// snapshotRateLimitMiddleware uses the snapshot's pre-built rate limiter.
+// A nil limiter (rate limiting disabled) passes through.
+func (s *Server) snapshotRateLimitMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Skip rate limiting for operational endpoints.
+		if r.URL.Path == "/healthz" || r.URL.Path == "/readyz" || r.URL.Path == "/metrics" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		snap := s.snapshot.Load()
+		if snap.Limiter == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		key := hashKey(r.Header.Get("X-API-Key"))
+		if key == "" {
+			host, _, err := net.SplitHostPort(r.RemoteAddr)
+			if err != nil {
+				host = r.RemoteAddr
+			}
+			if snap.Config.RateLimit.TrustProxy {
+				if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+					if i := strings.Index(xff, ","); i >= 0 {
+						host = strings.TrimSpace(xff[:i])
+					} else {
+						host = strings.TrimSpace(xff)
+					}
+				}
+			}
+			key = host
+		}
+
+		if !snap.Limiter.Allow(key) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(`{"error":"rate limit exceeded"}`))
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// effectiveConfig returns the effective config from the snapshot if available,
+// or the static config as fallback.
+func (s *Server) effectiveConfig() *Config {
+	if s.snapshot != nil {
+		snap := s.snapshot.Load()
+		return &snap.Config
+	}
+	return s.config
 }
 
 // extractBearerToken extracts the token from an Authorization: Bearer header.

--- a/extras/scion-a2a-bridge/internal/bridge/server.go
+++ b/extras/scion-a2a-bridge/internal/bridge/server.go
@@ -75,6 +75,9 @@ func (s *Server) SetSnapshot(snap *SnapshotHolder) {
 // SetJWTValidator sets the JWT validator for hubJWT mode. Called after the
 // signing key is loaded (which may require Secret Manager access).
 // Also updates the snapshot if one is wired.
+//
+// NOTE: not safe for concurrent use with Configure(). Currently only called
+// once during boot before the HTTP server starts.
 func (s *Server) SetJWTValidator(v *JWTValidator) {
 	s.jwtValidator = v
 	if s.snapshot != nil {

--- a/extras/scion-a2a-bridge/internal/bridge/server_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/server_test.go
@@ -538,6 +538,118 @@ func TestAuthorizeTaskReturnsNilNil(t *testing.T) {
 	}
 }
 
+func TestSetJWTValidator_EnablesHubJWTAuth(t *testing.T) {
+	// Verify that calling SetJWTValidator on the server with a signing key
+	// initializes the JWTValidator so hubJWT auth works (and doesn't 500).
+	dir := t.TempDir()
+	store, err := state.New(filepath.Join(dir, "jwt-test.db"))
+	if err != nil {
+		t.Fatalf("state.New: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	signingKey := make([]byte, 32)
+	for i := range signingKey {
+		signingKey[i] = byte(i + 1) // deterministic key for test
+	}
+
+	cfg := &Config{
+		Bridge: BridgeConfig{
+			ExternalURL: "https://a2a.test.example.com",
+		},
+		Auth: AuthConfig{
+			Scheme: "hubJWT",
+		},
+		Projects: []ProjectConfig{
+			{
+				Slug:          "proj",
+				ExposedAgents: []string{"agent-1"},
+			},
+		},
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := New(store, nil, nil, cfg, nil, log)
+
+	executor := NewScionExecutor(b, log)
+	routeAuth := RouteKeyAuthenticator()
+	innerStore := taskstore.NewInMemory(&taskstore.InMemoryStoreConfig{
+		Authenticator: routeAuth,
+	})
+	scopedStore := NewScopedTaskStore(innerStore)
+	sdkRequestHandler := a2asrv.NewHandler(
+		executor,
+		a2asrv.WithLogger(log),
+		a2asrv.WithCapabilityChecks(&a2a.AgentCapabilities{
+			Streaming:         true,
+			PushNotifications: false,
+		}),
+		a2asrv.WithTaskStore(scopedStore),
+	)
+	b.SetSDKRequestHandler(sdkRequestHandler)
+	sdkJSONRPCHandler := a2asrv.NewJSONRPCHandler(sdkRequestHandler)
+
+	srv := NewServer(b, cfg, nil, log, sdkJSONRPCHandler)
+
+	// Wire snapshot so the JWTValidator is propagated to the auth middleware.
+	snapshot := NewSnapshotHolder(BuildSnapshot(*cfg))
+	srv.SetSnapshot(snapshot)
+
+	// Simulate what main.go should do: call SetJWTValidator after loading key.
+	srv.SetJWTValidator(NewJWTValidator(signingKey))
+
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	// Mint a valid JWT.
+	token := mintTestJWT(t, signingKey, validClaims())
+
+	// A request with a valid JWT should succeed (not 500).
+	rpcReq, _ := json.Marshal(jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tasks/get",
+		Params:  json.RawMessage(`{"id":"nonexistent"}`),
+	})
+	httpReq, _ := http.NewRequest(http.MethodPost,
+		ts.URL+"/projects/proj/agents/agent-1/jsonrpc",
+		bytes.NewReader(rpcReq))
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	resp.Body.Close()
+
+	// Should be 200 (the RPC itself may error with task-not-found, but auth passes).
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("hubJWT auth status = %d, want 200 (auth should pass)", resp.StatusCode)
+	}
+
+	// Without JWT validator, requests should 500. Verify by clearing it.
+	// (Reset snapshot to one without JWTValidator.)
+	snapshot.Store(BuildSnapshot(*cfg))
+	srv.SetJWTValidator(nil)
+
+	httpReq, _ = http.NewRequest(http.MethodPost,
+		ts.URL+"/projects/proj/agents/agent-1/jsonrpc",
+		bytes.NewReader(rpcReq))
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err = http.DefaultClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("without JWTValidator status = %d, want 500", resp.StatusCode)
+	}
+}
+
 func TestRouteInfoContext(t *testing.T) {
 	ctx := WithRouteInfo(context.Background(), RouteInfo{ProjectSlug: "proj", AgentSlug: "agt"})
 	info, ok := RouteInfoFrom(ctx)

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -61,6 +61,8 @@ interface PlatformFieldDef {
   description: string;
   defaultValue: string;
   placeholder?: string;
+  type?: 'text' | 'select' | 'toggle';  // default 'text'
+  options?: { value: string; label: string }[];  // for 'select' type
 }
 
 interface PlatformSecretDef {
@@ -123,17 +125,47 @@ const PLATFORM_FIELDS: Record<string, PlatformFieldDef[]> = {
     { key: 'agent_cache_ttl', label: 'Agent Cache TTL', description: 'How long to cache agent info', defaultValue: '5m' },
   ],
   a2a: [
-    { key: 'external_url', label: 'External URL', description: 'Public URL for agent cards', defaultValue: '' },
-    { key: 'auth_scheme', label: 'Auth Scheme', description: 'apiKey, bearer, none, hubUAT, or hubJWT', defaultValue: 'none' },
-    { key: 'uat_cache_ttl', label: 'UAT Cache TTL', description: 'Cache duration for UAT validation results', defaultValue: '60s' },
-    { key: 'rate_limit_enabled', label: 'Rate Limiting Enabled', description: 'Enable request rate limiting (true/false)', defaultValue: 'false' },
-    { key: 'rate_limit_rps', label: 'Rate Limit (req/s)', description: 'Maximum requests per second', defaultValue: '10' },
-    { key: 'rate_limit_burst', label: 'Rate Limit Burst', description: 'Maximum burst size for rate limiter', defaultValue: '20' },
-    { key: 'send_message_timeout', label: 'Send Message Timeout', description: 'Timeout for sending messages to agents', defaultValue: '120s' },
-    { key: 'sse_keepalive', label: 'SSE Keepalive Interval', description: 'Interval for SSE keepalive pings', defaultValue: '30s' },
-    { key: 'push_retry_max', label: 'Push Notification Retries', description: 'Maximum retries for push notification delivery', defaultValue: '3' },
-    { key: 'provider_org', label: 'Provider Organization', description: 'Organization name for agent card metadata', defaultValue: '' },
-    { key: 'provider_url', label: 'Provider URL', description: 'Organization URL for agent card metadata', defaultValue: '' },
+    { key: 'external_url', label: 'External URL',
+      description: 'Public URL where the bridge serves agent cards and JSON-RPC',
+      defaultValue: '', placeholder: 'https://a2a.example.com' },
+    { key: 'auth_scheme', label: 'Auth Scheme',
+      description: 'Authentication method for A2A clients',
+      defaultValue: 'none',
+      type: 'select',
+      options: [
+        { value: 'none', label: 'None' },
+        { value: 'apiKey', label: 'API Key' },
+        { value: 'bearer', label: 'Bearer Token' },
+        { value: 'hubUAT', label: 'Hub UAT' },
+        { value: 'hubJWT', label: 'Hub JWT' },
+      ] },
+    { key: 'rate_limit_enabled', label: 'Rate Limiting',
+      description: 'Enable request rate limiting',
+      defaultValue: 'false', type: 'toggle' },
+    { key: 'rate_limit_rps', label: 'Rate Limit (req/s)',
+      description: 'Maximum requests per second',
+      defaultValue: '10', placeholder: '10' },
+    { key: 'rate_limit_burst', label: 'Rate Limit Burst',
+      description: 'Maximum burst size for rate limiter',
+      defaultValue: '20', placeholder: '20' },
+    { key: 'send_message_timeout', label: 'Send Message Timeout',
+      description: 'Timeout for sending messages to agents',
+      defaultValue: '120s', placeholder: '120s' },
+    { key: 'sse_keepalive', label: 'SSE Keepalive Interval',
+      description: 'Interval for SSE keepalive pings',
+      defaultValue: '30s', placeholder: '30s' },
+    { key: 'push_retry_max', label: 'Push Notification Retries',
+      description: 'Maximum retries for push notification delivery',
+      defaultValue: '3', placeholder: '3' },
+    { key: 'provider_org', label: 'Provider Organization',
+      description: 'Organization name for agent card metadata',
+      defaultValue: '', placeholder: 'My Organization' },
+    { key: 'provider_url', label: 'Provider URL',
+      description: 'Organization URL for agent card metadata',
+      defaultValue: '', placeholder: 'https://example.com' },
+    { key: 'uat_cache_ttl', label: 'UAT Cache TTL',
+      description: 'How long to cache UAT validation results',
+      defaultValue: '60s', placeholder: '60s' },
   ],
 };
 
@@ -1007,16 +1039,7 @@ export class ScionPageAdminIntegrations extends LitElement {
             (field) => html`
               <div class="form-field">
                 <label>${field.label}</label>
-                <sl-input
-                  .value=${this.editedSettings[field.key] ?? field.defaultValue}
-                  placeholder=${field.placeholder ?? field.defaultValue}
-                  @sl-change=${(e: Event) => {
-                    this.editedSettings = {
-                      ...this.editedSettings,
-                      [field.key]: (e.target as HTMLInputElement).value,
-                    };
-                  }}
-                ></sl-input>
+                ${this.renderFieldInput(field)}
                 <span class="hint">${field.description}</span>
               </div>
             `
@@ -1039,6 +1062,59 @@ export class ScionPageAdminIntegrations extends LitElement {
           )}
         </div>
       </div>
+    `;
+  }
+
+  private renderFieldInput(field: PlatformFieldDef) {
+    const fieldType = field.type ?? 'text';
+
+    if (fieldType === 'select' && field.options) {
+      const currentValue = this.editedSettings[field.key] ?? field.defaultValue;
+      return html`
+        <sl-select
+          .value=${currentValue}
+          @sl-change=${(e: Event) => {
+            this.editedSettings = {
+              ...this.editedSettings,
+              [field.key]: (e.target as HTMLSelectElement).value,
+            };
+          }}
+        >
+          ${field.options.map(
+            (opt) => html`<sl-option value=${opt.value}>${opt.label}</sl-option>`
+          )}
+        </sl-select>
+      `;
+    }
+
+    if (fieldType === 'toggle') {
+      const currentValue = this.editedSettings[field.key] ?? field.defaultValue;
+      const isChecked = currentValue === 'true';
+      return html`
+        <sl-switch
+          ?checked=${isChecked}
+          @sl-change=${(e: Event) => {
+            this.editedSettings = {
+              ...this.editedSettings,
+              [field.key]: (e.target as HTMLInputElement).checked ? 'true' : 'false',
+            };
+          }}
+        ></sl-switch>
+      `;
+    }
+
+    // Default: text input
+    return html`
+      <sl-input
+        .value=${this.editedSettings[field.key] ?? field.defaultValue}
+        placeholder=${field.placeholder ?? field.defaultValue}
+        @sl-change=${(e: Event) => {
+          this.editedSettings = {
+            ...this.editedSettings,
+            [field.key]: (e.target as HTMLInputElement).value,
+          };
+        }}
+      ></sl-input>
     `;
   }
 
@@ -1151,13 +1227,20 @@ export class ScionPageAdminIntegrations extends LitElement {
       ...secretKeys.filter((k) => !secretDefMap.has(k)),
     ];
 
+    // For A2A, the api_key secret is only relevant when auth_scheme is apiKey or bearer.
+    const authScheme = platform === 'a2a' ? (this.editedSettings['auth_scheme'] ?? 'none') : '';
+    const apiKeyRelevant = authScheme === 'apiKey' || authScheme === 'bearer';
+
     return html`
       <div class="section">
         <h3 class="section-title">Secrets</h3>
         ${sortedKeys.map((key) => {
+          // Conditionally hide api_key for A2A when scheme doesn't need it.
+          if (platform === 'a2a' && key === 'api_key' && !apiKeyRelevant) return nothing;
           const def = secretDefMap.get(key);
           const label = def?.label ?? key;
-          const isRequired = def?.required ?? false;
+          // For A2A, mark api_key as required when the scheme needs it.
+          const isRequired = platform === 'a2a' && key === 'api_key' ? apiKeyRelevant : (def?.required ?? false);
           const isConfigured = d.has_secrets?.[key];
           return html`
             <div class="secret-row">


### PR DESCRIPTION
Implements real config management for the A2A bridge via the Hub admin UI. The flat key schema becomes the interface contract between Hub and bridge.

Bridge-side (extras/scion-a2a-bridge/):
- Configure() becomes real: parses/validates flat keys, applies via atomic snapshot swap, persists overlay
- adminoverlay.go: ParseAdminOverlay, Apply (hot-swap auth validators, rate limiter, timeouts, URLs, projects)
- Boot: base YAML + persisted admin-overlay.json = effective config (overlay wins per key)
- HealthCheck() enriched: reports effective auth_scheme, external_url, exposed_projects, active_tasks, active_sse

Part of the A2A admin project. Phase 1+2 (upstream PR #992), Phase 4 (projects editor) follows.