### PR TITLE
feat(message): add @mention parsing and --cc flag for multi-recipient notifications

### DIFF
--- a/cmd/message.go
+++ b/cmd/message.go
@@ -147,6 +147,9 @@ Examples:
 			if msgRaw {
 				return fmt.Errorf("--cc cannot be combined with --raw")
 			}
+			if msgIn != "" || msgAt != "" {
+				return fmt.Errorf("--cc cannot be combined with --in or --at")
+			}
 			if userRecipient != "" {
 				return fmt.Errorf("--cc cannot be used with user recipients")
 			}
@@ -267,6 +270,11 @@ Examples:
 		// --notify requires Hub mode
 		if msgNotify && hubCtx == nil {
 			return fmt.Errorf("--notify requires Hub mode (use 'scion hub enable' first)")
+		}
+
+		// --cc requires Hub mode
+		if msgCC != "" && hubCtx == nil {
+			return fmt.Errorf("--cc requires Hub mode (use 'scion hub enable' first)")
 		}
 
 		// Stage attachments to shared volume (after Hub mode confirmed)
@@ -732,15 +740,10 @@ func sendGroupMessageViaHub(hubCtx *HubContext, recipients []messages.GroupRecip
 		fmt.Printf("Group delivery complete: %d/%d delivered.\n", delivered, len(recipients))
 	}
 
-	if delivered == 0 {
-		return fmt.Errorf("group delivery failed: 0/%d recipients received the message", len(recipients))
-	}
-	if delivered < len(recipients) {
-		return fmt.Errorf("group delivery partially failed: %d/%d delivered", delivered, len(recipients))
-	}
-
 	// @mention and --cc fan-out for group messages: mentioned agents that are
 	// not already group recipients receive a TypeMention notification.
+	// This runs regardless of partial delivery — mention recipients are
+	// independent of the group.
 	var mentionNames []string
 	mentionNames = append(mentionNames, extractMentions(message)...)
 	mentionNames = append(mentionNames, parseCCFlag(msgCC)...)
@@ -771,6 +774,13 @@ func sendGroupMessageViaHub(hubCtx *HubContext, recipients []messages.GroupRecip
 		if len(filtered) > 0 {
 			sendMentionMessages(hubCtx, sender, mentionSource, message, filtered, agentSvc)
 		}
+	}
+
+	if delivered == 0 {
+		return fmt.Errorf("group delivery failed: 0/%d recipients received the message", len(recipients))
+	}
+	if delivered < len(recipients) {
+		return fmt.Errorf("group delivery partially failed: %d/%d delivered", delivered, len(recipients))
 	}
 
 	return nil

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -759,14 +759,14 @@ func sendGroupMessageViaHub(hubCtx *HubContext, recipients []messages.GroupRecip
 		groupSlugs := make(map[string]bool)
 		for _, r := range recipients {
 			if r.Kind == messages.RecipientAgent {
-				groupSlugs[strings.ToLower(r.Name)] = true
+				groupSlugs[api.Slugify(r.Name)] = true
 			}
 		}
 
 		// Filter out names already in the group
 		var filtered []string
 		for _, name := range mentionNames {
-			if !groupSlugs[strings.ToLower(name)] {
+			if !groupSlugs[api.Slugify(name)] {
 				filtered = append(filtered, name)
 			}
 		}
@@ -967,6 +967,9 @@ func sendMentionMessages(hubCtx *HubContext, sender, primaryRecipient, messageTe
 	resp, err := agentSvc.List(ctx, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not list project agents for @mention resolution: %s\n", err)
+		return
+	}
+	if resp == nil {
 		return
 	}
 

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"text/tabwriter"
 	"time"
+	"unicode"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
@@ -47,6 +48,7 @@ var msgNotify bool
 var msgWake bool
 var msgChannel string
 var msgThreadID string
+var msgCC string
 
 // messageCmd represents the message command
 var messageCmd = &cobra.Command{
@@ -135,6 +137,19 @@ Examples:
 		// Validate --notify restrictions
 		if msgNotify && (msgBroadcast || msgAll) {
 			return fmt.Errorf("--notify cannot be combined with --broadcast or --all")
+		}
+
+		// Validate --cc restrictions
+		if msgCC != "" {
+			if msgBroadcast || msgAll {
+				return fmt.Errorf("--cc cannot be combined with --broadcast or --all")
+			}
+			if msgRaw {
+				return fmt.Errorf("--cc cannot be combined with --raw")
+			}
+			if userRecipient != "" {
+				return fmt.Errorf("--cc cannot be used with user recipients")
+			}
 		}
 
 		// Validate user-recipient restrictions
@@ -524,6 +539,17 @@ func sendMessageViaHub(hubCtx *HubContext, agentName string, message string, int
 			fmt.Printf("Subscribed to notifications for agent '%s'.\n", agentName)
 		}
 	}
+
+	// @mention and --cc fan-out: send TypeMention messages to mentioned agents
+	var mentionNames []string
+	// Parse @mentions from message body
+	mentionNames = append(mentionNames, extractMentions(message)...)
+	// Parse --cc flag
+	mentionNames = append(mentionNames, parseCCFlag(msgCC)...)
+	if len(mentionNames) > 0 {
+		sendMentionMessages(hubCtx, sender, "agent:"+agentName, message, mentionNames, agentSvc)
+	}
+
 	return nil
 }
 
@@ -712,6 +738,41 @@ func sendGroupMessageViaHub(hubCtx *HubContext, recipients []messages.GroupRecip
 	if delivered < len(recipients) {
 		return fmt.Errorf("group delivery partially failed: %d/%d delivered", delivered, len(recipients))
 	}
+
+	// @mention and --cc fan-out for group messages: mentioned agents that are
+	// not already group recipients receive a TypeMention notification.
+	var mentionNames []string
+	mentionNames = append(mentionNames, extractMentions(message)...)
+	mentionNames = append(mentionNames, parseCCFlag(msgCC)...)
+	if len(mentionNames) > 0 {
+		// Build a mention source that reflects the group
+		recipientStrs := make([]string, len(recipients))
+		for i, r := range recipients {
+			recipientStrs[i] = r.String()
+		}
+		mentionSource := "group[" + strings.Join(recipientStrs, ",") + "]"
+
+		// Collect group recipient slugs to exclude from mentions
+		groupSlugs := make(map[string]bool)
+		for _, r := range recipients {
+			if r.Kind == messages.RecipientAgent {
+				groupSlugs[strings.ToLower(r.Name)] = true
+			}
+		}
+
+		// Filter out names already in the group
+		var filtered []string
+		for _, name := range mentionNames {
+			if !groupSlugs[strings.ToLower(name)] {
+				filtered = append(filtered, name)
+			}
+		}
+
+		if len(filtered) > 0 {
+			sendMentionMessages(hubCtx, sender, mentionSource, message, filtered, agentSvc)
+		}
+	}
+
 	return nil
 }
 
@@ -828,6 +889,136 @@ func validateChannel(hubCtx *HubContext, channel string) error {
 	return fmt.Errorf("channel %q is not registered; available channels: %s", channel, strings.Join(available, ", "))
 }
 
+// extractMentions scans message text for @name tokens and returns a deduplicated
+// list of mentioned names (without the @ prefix). Trailing punctuation (except
+// underscores and hyphens) is stripped from each token.
+func extractMentions(text string) []string {
+	var mentions []string
+	seen := make(map[string]bool)
+	for _, word := range strings.Fields(text) {
+		if !strings.HasPrefix(word, "@") {
+			continue
+		}
+		name := strings.TrimPrefix(word, "@")
+		name = strings.TrimRightFunc(name, func(r rune) bool {
+			return unicode.IsPunct(r) && r != '_' && r != '-'
+		})
+		if name == "" {
+			continue
+		}
+		lower := strings.ToLower(name)
+		if !seen[lower] {
+			seen[lower] = true
+			mentions = append(mentions, name)
+		}
+	}
+	return mentions
+}
+
+// parseCCFlag parses the --cc flag value into a slice of agent names.
+// Names are comma-separated and whitespace-trimmed.
+func parseCCFlag(cc string) []string {
+	if cc == "" {
+		return nil
+	}
+	parts := strings.Split(cc, ",")
+	var names []string
+	seen := make(map[string]bool)
+	for _, p := range parts {
+		name := strings.TrimSpace(p)
+		if name == "" {
+			continue
+		}
+		lower := strings.ToLower(name)
+		if !seen[lower] {
+			seen[lower] = true
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// maxMentionRecipients caps the number of mention recipients to avoid spam.
+const maxMentionRecipients = 10
+
+// sendMentionMessages resolves @mentions and --cc names against project agents
+// and sends TypeMention messages to each resolved agent. The primary recipient
+// is excluded from mentions. Unresolved names produce stderr warnings but do
+// not fail the primary send.
+func sendMentionMessages(hubCtx *HubContext, sender, primaryRecipient, messageText string, mentionNames []string, agentSvc hubclient.AgentService) {
+	if len(mentionNames) == 0 {
+		return
+	}
+
+	// List project agents for resolution
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := agentSvc.List(ctx, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not list project agents for @mention resolution: %s\n", err)
+		return
+	}
+
+	// Build lookup map of known agents (slug -> slug with original case)
+	knownAgents := make(map[string]string, len(resp.Agents))
+	for _, a := range resp.Agents {
+		knownAgents[strings.ToLower(a.Name)] = a.Name
+	}
+
+	// Determine the primary recipient's slug for dedup
+	primarySlug := strings.ToLower(strings.TrimPrefix(primaryRecipient, "agent:"))
+
+	// Resolve mentions and deduplicate
+	var resolved []string
+	seen := make(map[string]bool)
+	seen[primarySlug] = true // skip primary recipient
+
+	for _, name := range mentionNames {
+		if len(resolved) >= maxMentionRecipients {
+			fmt.Fprintf(os.Stderr, "Warning: too many @mentions; only the first %d will receive mention notifications\n", maxMentionRecipients)
+			break
+		}
+		lower := strings.ToLower(name)
+		if seen[lower] {
+			continue
+		}
+		seen[lower] = true
+
+		slug, ok := knownAgents[lower]
+		if !ok {
+			fmt.Fprintf(os.Stderr, "Warning: @%s does not match any agent in this project; skipping mention\n", name)
+			continue
+		}
+		resolved = append(resolved, slug)
+	}
+
+	if len(resolved) == 0 {
+		return
+	}
+
+	// Send TypeMention to each resolved agent
+	var wg sync.WaitGroup
+	for _, slug := range resolved {
+		wg.Add(1)
+		go func(agentSlug string) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			mentionMsg := messages.NewMention(sender, "agent:"+agentSlug, messageText, primaryRecipient)
+			if _, err := agentSvc.SendStructuredMessage(ctx, agentSlug, mentionMsg, false, false, false); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to send mention to @%s: %s\n", agentSlug, err)
+				return
+			}
+			if !isJSONOutput() {
+				fmt.Fprintf(os.Stderr, "Mention notification sent to @%s.\n", agentSlug)
+			}
+		}(slug)
+	}
+	wg.Wait()
+}
+
 func init() {
 	messageCmd.Flags().BoolVarP(&msgInterrupt, "interrupt", "i", false, "Interrupt the harness before sending the message")
 	messageCmd.Flags().BoolVarP(&msgBroadcast, "broadcast", "b", false, "Send the message to all running agents in the current project")
@@ -841,6 +1032,7 @@ func init() {
 	messageCmd.Flags().BoolVarP(&msgWake, "wake", "w", false, "Resume a suspended agent before delivering the message")
 	messageCmd.Flags().StringVar(&msgChannel, "channel", "", "Target a specific message channel (e.g. telegram, gchat, web)")
 	messageCmd.Flags().StringVar(&msgThreadID, "thread-id", "", "Target a specific thread within the channel")
+	messageCmd.Flags().StringVar(&msgCC, "cc", "", "CC additional agents (comma-separated names); each receives a mention notification")
 	messageCmd.AddCommand(messageChannelsCmd)
 	rootCmd.AddCommand(messageCmd)
 }

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -1502,3 +1502,481 @@ func TestStageAttachments_FilteredPathsSkipped(t *testing.T) {
 	// Cleanup
 	_ = os.RemoveAll(filepath.Dir(staged[0]))
 }
+
+// --- @mention and --cc tests ---
+
+func TestExtractMentions_Basic(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{
+			name: "no mentions",
+			text: "hello world",
+			want: nil,
+		},
+		{
+			name: "single mention",
+			text: "hey @alice check this out",
+			want: []string{"alice"},
+		},
+		{
+			name: "multiple mentions",
+			text: "hey @alice and @bob check this",
+			want: []string{"alice", "bob"},
+		},
+		{
+			name: "mention at start",
+			text: "@alice please review",
+			want: []string{"alice"},
+		},
+		{
+			name: "mention at end",
+			text: "please review @alice",
+			want: []string{"alice"},
+		},
+		{
+			name: "duplicate mentions",
+			text: "@alice hey @alice check this",
+			want: []string{"alice"},
+		},
+		{
+			name: "case insensitive dedup",
+			text: "@Alice hey @alice check this",
+			want: []string{"Alice"},
+		},
+		{
+			name: "mention with trailing punctuation",
+			text: "hey @alice, @bob! @charlie.",
+			want: []string{"alice", "bob", "charlie"},
+		},
+		{
+			name: "mention with hyphen",
+			text: "hey @my-agent check this",
+			want: []string{"my-agent"},
+		},
+		{
+			name: "mention with underscore",
+			text: "hey @my_agent check this",
+			want: []string{"my_agent"},
+		},
+		{
+			name: "double at sign",
+			text: "hey @@ what",
+			want: nil,
+		},
+		{
+			name: "bare at sign",
+			text: "hey @ what",
+			want: nil,
+		},
+		{
+			name: "email address not treated as mention",
+			text: "send to user@example.com",
+			want: nil,
+		},
+		{
+			name: "mention followed by colon",
+			text: "hey @alice: check this",
+			want: []string{"alice"},
+		},
+		{
+			name: "mention in parentheses",
+			text: "(cc @bob)",
+			want: []string{"bob"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractMentions(tc.text)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParseCCFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		cc   string
+		want []string
+	}{
+		{
+			name: "empty",
+			cc:   "",
+			want: nil,
+		},
+		{
+			name: "single name",
+			cc:   "alice",
+			want: []string{"alice"},
+		},
+		{
+			name: "multiple names",
+			cc:   "alice,bob,charlie",
+			want: []string{"alice", "bob", "charlie"},
+		},
+		{
+			name: "whitespace trimmed",
+			cc:   " alice , bob , charlie ",
+			want: []string{"alice", "bob", "charlie"},
+		},
+		{
+			name: "empty entries skipped",
+			cc:   "alice,,bob",
+			want: []string{"alice", "bob"},
+		},
+		{
+			name: "duplicates removed",
+			cc:   "alice,bob,alice",
+			want: []string{"alice", "bob"},
+		},
+		{
+			name: "case insensitive dedup",
+			cc:   "Alice,alice",
+			want: []string{"Alice"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseCCFlag(tc.cc)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestSendMessageViaHub_MentionFanOut(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	projectID := "grove-msg-mention"
+	agents := []hubclient.Agent{
+		{Name: "primary-agent", Status: "running"},
+		{Name: "mentioned-agent", Status: "running"},
+		{Name: "other-agent", Status: "running"},
+	}
+	server, sent := newMessageMockHubServer(t, projectID, agents)
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
+	}
+
+	// Reset CC flag
+	origCC := msgCC
+	msgCC = ""
+	defer func() { msgCC = origCC }()
+
+	err = sendMessageViaHub(hubCtx, "primary-agent", "hey @mentioned-agent check this", false, false, false, false, false)
+	require.NoError(t, err)
+
+	// Should have 2 messages: primary + mention
+	require.Len(t, *sent, 2)
+
+	// First message is the primary instruction
+	assert.Equal(t, "primary-agent", (*sent)[0].AgentName)
+	require.NotNil(t, (*sent)[0].StructuredMsg)
+	assert.Equal(t, messages.TypeInstruction, (*sent)[0].StructuredMsg.Type)
+
+	// Second message is the mention notification
+	assert.Equal(t, "mentioned-agent", (*sent)[1].AgentName)
+	require.NotNil(t, (*sent)[1].StructuredMsg)
+	assert.Equal(t, messages.TypeMention, (*sent)[1].StructuredMsg.Type)
+	assert.Equal(t, "agent:primary-agent", (*sent)[1].StructuredMsg.Metadata["mention_source"])
+	assert.Equal(t, "body", (*sent)[1].StructuredMsg.Metadata["mention_position"])
+}
+
+func TestSendMessageViaHub_MentionDedup(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	projectID := "grove-msg-mention-dedup"
+	agents := []hubclient.Agent{
+		{Name: "my-agent", Status: "running"},
+		{Name: "other-agent", Status: "running"},
+	}
+	server, sent := newMessageMockHubServer(t, projectID, agents)
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
+	}
+
+	origCC := msgCC
+	msgCC = ""
+	defer func() { msgCC = origCC }()
+
+	// Primary recipient is also @mentioned in body — should be deduplicated
+	err = sendMessageViaHub(hubCtx, "my-agent", "hey @my-agent check @other-agent", false, false, false, false, false)
+	require.NoError(t, err)
+
+	// Should have 2 messages: primary + mention for other-agent only (my-agent deduped)
+	require.Len(t, *sent, 2)
+	assert.Equal(t, "my-agent", (*sent)[0].AgentName)
+	assert.Equal(t, "other-agent", (*sent)[1].AgentName)
+	assert.Equal(t, messages.TypeMention, (*sent)[1].StructuredMsg.Type)
+}
+
+func TestSendMessageViaHub_UnknownMentionWarns(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	projectID := "grove-msg-mention-unknown"
+	agents := []hubclient.Agent{
+		{Name: "my-agent", Status: "running"},
+	}
+	server, sent := newMessageMockHubServer(t, projectID, agents)
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
+	}
+
+	origCC := msgCC
+	msgCC = ""
+	defer func() { msgCC = origCC }()
+
+	// @nonexistent doesn't match any agent — should warn but not fail
+	err = sendMessageViaHub(hubCtx, "my-agent", "hey @nonexistent check this", false, false, false, false, false)
+	require.NoError(t, err)
+
+	// Only the primary message should be sent
+	require.Len(t, *sent, 1)
+	assert.Equal(t, "my-agent", (*sent)[0].AgentName)
+}
+
+func TestSendMessageViaHub_CCFlag(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	projectID := "grove-msg-cc"
+	agents := []hubclient.Agent{
+		{Name: "primary-agent", Status: "running"},
+		{Name: "cc-agent-1", Status: "running"},
+		{Name: "cc-agent-2", Status: "running"},
+	}
+	server, sent := newMessageMockHubServer(t, projectID, agents)
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
+	}
+
+	origCC := msgCC
+	msgCC = "cc-agent-1,cc-agent-2"
+	defer func() { msgCC = origCC }()
+
+	err = sendMessageViaHub(hubCtx, "primary-agent", "check this out", false, false, false, false, false)
+	require.NoError(t, err)
+
+	// Should have 3 messages: primary + 2 CC mentions
+	require.Len(t, *sent, 3)
+	assert.Equal(t, "primary-agent", (*sent)[0].AgentName)
+	assert.Equal(t, messages.TypeInstruction, (*sent)[0].StructuredMsg.Type)
+
+	// CC agents get TypeMention messages (order may vary due to goroutines)
+	ccNames := []string{(*sent)[1].AgentName, (*sent)[2].AgentName}
+	assert.ElementsMatch(t, []string{"cc-agent-1", "cc-agent-2"}, ccNames)
+	for _, s := range (*sent)[1:] {
+		assert.Equal(t, messages.TypeMention, s.StructuredMsg.Type)
+		assert.Equal(t, "agent:primary-agent", s.StructuredMsg.Metadata["mention_source"])
+	}
+}
+
+func TestSendMessageViaHub_CCAndMentionCombined(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	projectID := "grove-msg-cc-mention"
+	agents := []hubclient.Agent{
+		{Name: "primary-agent", Status: "running"},
+		{Name: "mention-agent", Status: "running"},
+		{Name: "cc-agent", Status: "running"},
+	}
+	server, sent := newMessageMockHubServer(t, projectID, agents)
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
+	}
+
+	origCC := msgCC
+	msgCC = "cc-agent"
+	defer func() { msgCC = origCC }()
+
+	// Both @mention in body and --cc flag
+	err = sendMessageViaHub(hubCtx, "primary-agent", "hey @mention-agent check this", false, false, false, false, false)
+	require.NoError(t, err)
+
+	// Should have 3 messages: primary + @mention + --cc
+	require.Len(t, *sent, 3)
+	assert.Equal(t, "primary-agent", (*sent)[0].AgentName)
+
+	mentionNames := []string{(*sent)[1].AgentName, (*sent)[2].AgentName}
+	assert.ElementsMatch(t, []string{"mention-agent", "cc-agent"}, mentionNames)
+}
+
+func TestSendMessageViaHub_CCDedupWithMention(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	projectID := "grove-msg-cc-dedup"
+	agents := []hubclient.Agent{
+		{Name: "primary-agent", Status: "running"},
+		{Name: "shared-agent", Status: "running"},
+	}
+	server, sent := newMessageMockHubServer(t, projectID, agents)
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
+	}
+
+	origCC := msgCC
+	msgCC = "shared-agent"
+	defer func() { msgCC = origCC }()
+
+	// Same agent in both @mention and --cc — should only get one mention
+	err = sendMessageViaHub(hubCtx, "primary-agent", "hey @shared-agent check this", false, false, false, false, false)
+	require.NoError(t, err)
+
+	// Should have 2 messages: primary + 1 mention (deduped)
+	require.Len(t, *sent, 2)
+	assert.Equal(t, "primary-agent", (*sent)[0].AgentName)
+	assert.Equal(t, "shared-agent", (*sent)[1].AgentName)
+}
+
+func TestSendMessageViaHub_NoMentionsInBody(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	projectID := "grove-msg-no-mention"
+	agents := []hubclient.Agent{
+		{Name: "my-agent", Status: "running"},
+		{Name: "other-agent", Status: "running"},
+	}
+	server, sent := newMessageMockHubServer(t, projectID, agents)
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
+	}
+
+	origCC := msgCC
+	msgCC = ""
+	defer func() { msgCC = origCC }()
+
+	// No mentions in body, no --cc — only primary should be sent
+	err = sendMessageViaHub(hubCtx, "my-agent", "hello world", false, false, false, false, false)
+	require.NoError(t, err)
+
+	require.Len(t, *sent, 1)
+	assert.Equal(t, "my-agent", (*sent)[0].AgentName)
+}
+
+func TestCCFlagValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		cc        string
+		broadcast bool
+		all       bool
+		raw       bool
+		userRecip bool
+		wantErr   string
+	}{
+		{
+			name:      "cc with broadcast",
+			cc:        "agent-a",
+			broadcast: true,
+			wantErr:   "--cc cannot be combined with --broadcast or --all",
+		},
+		{
+			name:    "cc with all",
+			cc:      "agent-a",
+			all:     true,
+			wantErr: "--cc cannot be combined with --broadcast or --all",
+		},
+		{
+			name:    "cc with raw",
+			cc:      "agent-a",
+			raw:     true,
+			wantErr: "--cc cannot be combined with --raw",
+		},
+		{
+			name:      "cc with user recipient",
+			cc:        "agent-a",
+			userRecip: true,
+			wantErr:   "--cc cannot be used with user recipients",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			origCC := msgCC
+			origBroadcast := msgBroadcast
+			origAll := msgAll
+			origRaw := msgRaw
+			defer func() {
+				msgCC = origCC
+				msgBroadcast = origBroadcast
+				msgAll = origAll
+				msgRaw = origRaw
+			}()
+
+			msgCC = tc.cc
+			msgBroadcast = tc.broadcast
+			msgAll = tc.all
+			msgRaw = tc.raw
+
+			var args []string
+			if tc.broadcast || tc.all {
+				args = []string{"hello"}
+			} else if tc.userRecip {
+				args = []string{"user:alice", "hello"}
+			} else {
+				args = []string{"my-agent", "hello"}
+			}
+
+			err := messageCmd.RunE(messageCmd, args)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -1572,6 +1572,11 @@ func TestExtractMentions_Basic(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "double at with name",
+			text: "hey @@bob check this",
+			want: []string{"@bob"},
+		},
+		{
 			name: "email address not treated as mention",
 			text: "send to user@example.com",
 			want: nil,
@@ -1982,6 +1987,7 @@ func TestCCFlagValidation(t *testing.T) {
 		raw       bool
 		userRecip bool
 		in        string
+		at        string
 		wantErr   string
 	}{
 		{
@@ -2009,9 +2015,15 @@ func TestCCFlagValidation(t *testing.T) {
 			wantErr:   "--cc cannot be used with user recipients",
 		},
 		{
-			name:    "cc with scheduling",
+			name:    "cc with --in scheduling",
 			cc:      "agent-a",
 			in:      "5m",
+			wantErr: "--cc cannot be combined with --in or --at",
+		},
+		{
+			name:    "cc with --at scheduling",
+			cc:      "agent-a",
+			at:      "2026-01-01 12:00",
 			wantErr: "--cc cannot be combined with --in or --at",
 		},
 	}
@@ -2023,12 +2035,14 @@ func TestCCFlagValidation(t *testing.T) {
 			origAll := msgAll
 			origRaw := msgRaw
 			origIn := msgIn
+			origAt := msgAt
 			defer func() {
 				msgCC = origCC
 				msgBroadcast = origBroadcast
 				msgAll = origAll
 				msgRaw = origRaw
 				msgIn = origIn
+				msgAt = origAt
 			}()
 
 			msgCC = tc.cc
@@ -2036,6 +2050,7 @@ func TestCCFlagValidation(t *testing.T) {
 			msgAll = tc.all
 			msgRaw = tc.raw
 			msgIn = tc.in
+			msgAt = tc.at
 
 			var args []string
 			if tc.broadcast || tc.all {

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -1911,6 +1911,68 @@ func TestSendMessageViaHub_NoMentionsInBody(t *testing.T) {
 	assert.Equal(t, "my-agent", (*sent)[0].AgentName)
 }
 
+func TestSendGroupMessageViaHub_MentionFanOut(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	projectID := "grove-msg-group-mention"
+	agents := []hubclient.Agent{
+		{Name: "agent-a", Status: "running"},
+		{Name: "agent-b", Status: "running"},
+		{Name: "agent-c", Status: "running"},
+	}
+	server, sent := newMessageMockHubServer(t, projectID, agents)
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
+	}
+
+	// Reset CC flag
+	origCC := msgCC
+	msgCC = ""
+	defer func() { msgCC = origCC }()
+
+	recipients := []messages.GroupRecipient{
+		{Kind: messages.RecipientAgent, Name: "agent-a"},
+		{Kind: messages.RecipientAgent, Name: "agent-b"},
+	}
+
+	// Send to group[a,b] with @agent-c in body
+	err = sendGroupMessageViaHub(hubCtx, recipients, "hey @agent-c check this", false)
+	require.NoError(t, err)
+
+	// Should have 3 messages: agent-a, agent-b (group), agent-c (mention)
+	require.Len(t, *sent, 3)
+
+	// Categorize messages by type
+	var groupMsgs []sentMessage
+	var mentionMsgs []sentMessage
+	for _, s := range *sent {
+		require.NotNil(t, s.StructuredMsg)
+		if s.StructuredMsg.Type == messages.TypeMention {
+			mentionMsgs = append(mentionMsgs, s)
+		} else {
+			groupMsgs = append(groupMsgs, s)
+		}
+	}
+
+	// Group recipients get instruction messages
+	require.Len(t, groupMsgs, 2)
+	groupNames := []string{groupMsgs[0].AgentName, groupMsgs[1].AgentName}
+	assert.ElementsMatch(t, []string{"agent-a", "agent-b"}, groupNames)
+
+	// agent-c gets a mention notification, not an instruction
+	require.Len(t, mentionMsgs, 1)
+	assert.Equal(t, "agent-c", mentionMsgs[0].AgentName)
+	assert.Equal(t, messages.TypeMention, mentionMsgs[0].StructuredMsg.Type)
+}
+
 func TestCCFlagValidation(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -1919,6 +1981,7 @@ func TestCCFlagValidation(t *testing.T) {
 		all       bool
 		raw       bool
 		userRecip bool
+		in        string
 		wantErr   string
 	}{
 		{
@@ -1945,6 +2008,12 @@ func TestCCFlagValidation(t *testing.T) {
 			userRecip: true,
 			wantErr:   "--cc cannot be used with user recipients",
 		},
+		{
+			name:    "cc with scheduling",
+			cc:      "agent-a",
+			in:      "5m",
+			wantErr: "--cc cannot be combined with --in or --at",
+		},
 	}
 
 	for _, tc := range tests {
@@ -1953,17 +2022,20 @@ func TestCCFlagValidation(t *testing.T) {
 			origBroadcast := msgBroadcast
 			origAll := msgAll
 			origRaw := msgRaw
+			origIn := msgIn
 			defer func() {
 				msgCC = origCC
 				msgBroadcast = origBroadcast
 				msgAll = origAll
 				msgRaw = origRaw
+				msgIn = origIn
 			}()
 
 			msgCC = tc.cc
 			msgBroadcast = tc.broadcast
 			msgAll = tc.all
 			msgRaw = tc.raw
+			msgIn = tc.in
 
 			var args []string
 			if tc.broadcast || tc.all {


### PR DESCRIPTION
Adds @mention support and a --cc flag to scion message for multi-recipient notification fan-out.

Fixes https://github.com/ptone/scion/issues/760