### PR TITLE
fix(messages): set group message type to group-set for recipients

### DIFF
--- a/cmd/message.go
+++ b/cmd/message.go
@@ -687,7 +687,7 @@ func sendGroupMessageViaHub(hubCtx *HubContext, recipients []messages.GroupRecip
 					Attachments: msgAttach,
 					Channel:     msgChannel,
 					ThreadID:    msgThreadID,
-					Metadata:    map[string]string{"recipients": recipientsStr},
+					Metadata:    map[string]string{"recipients": recipientsStr, "group_id": groupID},
 				}
 				if err := agentSvc.SendOutboundMessage(ctx, senderAgent, outMsg); err != nil {
 					results[idx] = recipientResult{Recipient: recipStr, Status: "failed", Error: err.Error()}

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -619,6 +619,13 @@ func sendGroupMessageViaHub(hubCtx *HubContext, recipients []messages.GroupRecip
 	}
 	agentSvc := hubCtx.Client.ProjectAgents(projectID)
 
+	// Build the recipients string once before the fan-out loop.
+	recipientStrs := make([]string, len(recipients))
+	for i, r := range recipients {
+		recipientStrs[i] = r.String()
+	}
+	recipientsStr := messages.FormatGroupRecipients(sender, recipientStrs)
+
 	if !isJSONOutput() {
 		fmt.Printf("Sending message to %d recipients...\n", len(recipients))
 	}
@@ -644,6 +651,8 @@ func sendGroupMessageViaHub(hubCtx *HubContext, recipients []messages.GroupRecip
 			case messages.RecipientAgent:
 				slug := api.Slugify(recip.Name)
 				msg := buildStructuredMessage(sender, "agent:"+slug, message)
+				msg.Type = messages.TypeGroupSet
+				msg.Recipients = recipientsStr
 				msg.Metadata = map[string]string{"group_id": groupID}
 				if _, err := agentSvc.SendStructuredMessage(ctx, slug, msg, interrupt, false, false); err != nil {
 					results[idx] = recipientResult{Recipient: recipStr, Status: "failed", Error: err.Error()}
@@ -673,11 +682,12 @@ func sendGroupMessageViaHub(hubCtx *HubContext, recipients []messages.GroupRecip
 				outMsg := &hubclient.OutboundMessageRequest{
 					Recipient:   userRecip,
 					Msg:         message,
-					Type:        "instruction",
+					Type:        messages.TypeGroupSet,
 					Urgent:      interrupt,
 					Attachments: msgAttach,
 					Channel:     msgChannel,
 					ThreadID:    msgThreadID,
+					Metadata:    map[string]string{"recipients": recipientsStr},
 				}
 				if err := agentSvc.SendOutboundMessage(ctx, senderAgent, outMsg); err != nil {
 					results[idx] = recipientResult{Recipient: recipStr, Status: "failed", Error: err.Error()}

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -980,8 +981,63 @@ func TestSendGroupMessageViaHub(t *testing.T) {
 		assert.Equal(t, "group hello", s.Message)
 		require.NotNil(t, s.StructuredMsg)
 		assert.NotEmpty(t, s.StructuredMsg.Metadata["group_id"])
+		// Verify group-set type and recipients are set
+		assert.Equal(t, messages.TypeGroupSet, s.StructuredMsg.Type, "group message type should be group-set")
+		assert.NotEmpty(t, s.StructuredMsg.Recipients, "group message should have recipients populated")
+		assert.True(t, messages.IsGroupRecipient(s.StructuredMsg.Recipients), "recipients should be a valid group[] string")
 	}
 	assert.ElementsMatch(t, []string{"agent-a", "agent-b"}, names)
+}
+
+func TestSendGroupMessageViaHub_UserRecipientType(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	projectID := "grove-msg-group-user"
+	t.Setenv("SCION_AGENT_NAME", "my-agent")
+
+	var receivedMsg *hubclient.OutboundMessageRequest
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/outbound-message"):
+			var msg hubclient.OutboundMessageRequest
+			_ = json.NewDecoder(r.Body).Decode(&msg)
+			mu.Lock()
+			receivedMsg = &msg
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
+	}
+
+	recipients := []messages.GroupRecipient{
+		{Kind: messages.RecipientUser, Name: "alice"},
+	}
+
+	err = sendGroupMessageViaHub(hubCtx, recipients, "hello group", false)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotNil(t, receivedMsg)
+	assert.Equal(t, messages.TypeGroupSet, receivedMsg.Type, "user recipient in group should get type group-set")
+	assert.NotEmpty(t, receivedMsg.Metadata["recipients"], "user recipient in group should have recipients in metadata")
 }
 
 func TestSendGroupMessageViaHub_RequiresHub(t *testing.T) {

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -1038,6 +1038,7 @@ func TestSendGroupMessageViaHub_UserRecipientType(t *testing.T) {
 	require.NotNil(t, receivedMsg)
 	assert.Equal(t, messages.TypeGroupSet, receivedMsg.Type, "user recipient in group should get type group-set")
 	assert.NotEmpty(t, receivedMsg.Metadata["recipients"], "user recipient in group should have recipients in metadata")
+	assert.NotEmpty(t, receivedMsg.Metadata["group_id"], "user recipient in group should have group_id in metadata")
 }
 
 func TestSendGroupMessageViaHub_RequiresHub(t *testing.T) {

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -192,10 +192,13 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		ThreadID:    req.ThreadID,
 		Metadata:    req.Metadata,
 	}
-	// Propagate recipients from metadata for group-set messages.
+	// Propagate recipients and group_id from metadata for group-set messages.
 	if req.Metadata != nil {
 		if r, ok := req.Metadata["recipients"]; ok {
 			structuredMsg.Recipients = r
+		}
+		if gid, ok := req.Metadata["group_id"]; ok {
+			storeMsg.GroupID = gid
 		}
 	}
 

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -33,14 +33,15 @@ import (
 
 // OutboundMessageRequest is the request body for POST /api/v1/agents/{id}/outbound-message.
 type OutboundMessageRequest struct {
-	Recipient   string   `json:"recipient,omitempty"`
-	RecipientID string   `json:"recipient_id,omitempty"`
-	Msg         string   `json:"msg"`
-	Type        string   `json:"type,omitempty"`
-	Urgent      bool     `json:"urgent,omitempty"`
-	Attachments []string `json:"attachments,omitempty"`
-	Channel     string   `json:"channel,omitempty"`
-	ThreadID    string   `json:"thread_id,omitempty"`
+	Recipient   string            `json:"recipient,omitempty"`
+	RecipientID string            `json:"recipient_id,omitempty"`
+	Msg         string            `json:"msg"`
+	Type        string            `json:"type,omitempty"`
+	Urgent      bool              `json:"urgent,omitempty"`
+	Attachments []string          `json:"attachments,omitempty"`
+	Channel     string            `json:"channel,omitempty"`
+	ThreadID    string            `json:"thread_id,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
 // handleAgentOutboundMessage handles POST /api/v1/agents/{id}/outbound-message.
@@ -189,6 +190,13 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		Attachments: req.Attachments,
 		Channel:     req.Channel,
 		ThreadID:    req.ThreadID,
+		Metadata:    req.Metadata,
+	}
+	// Propagate recipients from metadata for group-set messages.
+	if req.Metadata != nil {
+		if r, ok := req.Metadata["recipients"]; ok {
+			structuredMsg.Recipients = r
+		}
 	}
 
 	// Route through broker when available; otherwise persist and publish
@@ -779,6 +787,7 @@ func (s *Server) handleGroupMessage(w http.ResponseWriter, r *http.Request, anch
 			}
 
 			agentMsg := *msg
+			agentMsg.Type = messages.TypeGroupSet
 			agentMsg.Recipient = "agent:" + agent.Slug
 			agentMsg.RecipientID = agent.ID
 			agentMsg.Recipients = recipientsSet
@@ -873,6 +882,7 @@ func (s *Server) handleGroupMessage(w http.ResponseWriter, r *http.Request, anch
 			}
 
 			userMsg := *msg
+			userMsg.Type = messages.TypeGroupSet
 			userMsg.Recipient = userRecip
 			userMsg.RecipientID = userID
 			userMsg.Recipients = recipientsSet

--- a/pkg/hubclient/agents.go
+++ b/pkg/hubclient/agents.go
@@ -516,14 +516,15 @@ func (s *agentService) SendStructuredMessage(ctx context.Context, agentID string
 
 // OutboundMessageRequest is the request body for sending an agent-to-human outbound message.
 type OutboundMessageRequest struct {
-	Recipient   string   `json:"recipient,omitempty"`
-	RecipientID string   `json:"recipient_id,omitempty"`
-	Msg         string   `json:"msg"`
-	Type        string   `json:"type,omitempty"`
-	Urgent      bool     `json:"urgent,omitempty"`
-	Attachments []string `json:"attachments,omitempty"`
-	Channel     string   `json:"channel,omitempty"`
-	ThreadID    string   `json:"thread_id,omitempty"`
+	Recipient   string            `json:"recipient,omitempty"`
+	RecipientID string            `json:"recipient_id,omitempty"`
+	Msg         string            `json:"msg"`
+	Type        string            `json:"type,omitempty"`
+	Urgent      bool              `json:"urgent,omitempty"`
+	Attachments []string          `json:"attachments,omitempty"`
+	Channel     string            `json:"channel,omitempty"`
+	ThreadID    string            `json:"thread_id,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
 // SendOutboundMessage sends a message from an agent to a human inbox.

--- a/pkg/messages/types.go
+++ b/pkg/messages/types.go
@@ -184,6 +184,20 @@ func (m *StructuredMessage) Validate() error {
 	return nil
 }
 
+// NewGroupSet creates a group-set message delivered to each member of a group.
+func NewGroupSet(sender, recipient, msg, recipients string) *StructuredMessage {
+	m := &StructuredMessage{
+		Version:    Version,
+		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+		Sender:     sender,
+		Recipient:  recipient,
+		Msg:        msg,
+		Type:       TypeGroupSet,
+		Recipients: recipients,
+	}
+	return m
+}
+
 // NewInstruction creates a new instruction message with standard defaults.
 func NewInstruction(sender, recipient, msg string) *StructuredMessage {
 	return &StructuredMessage{

--- a/pkg/messages/types_test.go
+++ b/pkg/messages/types_test.go
@@ -241,6 +241,37 @@ func TestStructuredMessage_ValidateChannel(t *testing.T) {
 	})
 }
 
+func TestNewGroupSet(t *testing.T) {
+	recipients := "group[user:alice,agent:coder,agent:reviewer]"
+	m := NewGroupSet("user:alice", "agent:coder", "hello team", recipients)
+	if m.Version != Version {
+		t.Errorf("version = %d, want %d", m.Version, Version)
+	}
+	if m.Type != TypeGroupSet {
+		t.Errorf("type = %q, want %q", m.Type, TypeGroupSet)
+	}
+	if m.Sender != "user:alice" {
+		t.Errorf("sender = %q, want %q", m.Sender, "user:alice")
+	}
+	if m.Recipient != "agent:coder" {
+		t.Errorf("recipient = %q, want %q", m.Recipient, "agent:coder")
+	}
+	if m.Msg != "hello team" {
+		t.Errorf("msg = %q, want %q", m.Msg, "hello team")
+	}
+	if m.Timestamp == "" {
+		t.Error("timestamp should be set")
+	}
+	if m.Recipients != recipients {
+		t.Errorf("recipients = %q, want %q", m.Recipients, recipients)
+	}
+
+	// Verify the message validates successfully
+	if err := m.Validate(); err != nil {
+		t.Errorf("unexpected validation error: %v", err)
+	}
+}
+
 func TestNewInstruction(t *testing.T) {
 	m := NewInstruction("user:alice", "agent:dev", "do something")
 	if m.Version != Version {


### PR DESCRIPTION
Fixes group messages being delivered as type instruction instead of type group-set. Recipients now receive the correct type and can see the full group membership via the recipients field.