### PR TITLE
fix(ui): prevent text selection during drag-to-pan in agent graph view

### DIFF
--- a/web/src/components/shared/agent-tree-view.ts
+++ b/web/src/components/shared/agent-tree-view.ts
@@ -128,6 +128,7 @@ export class ScionAgentTreeView extends LitElement {
       min-height: 340px;
       cursor: grab;
       touch-action: none;
+      user-select: none;
     }
 
     .canvas.dragging {
@@ -484,6 +485,7 @@ export class ScionAgentTreeView extends LitElement {
       const tag = (el as HTMLElement).tagName;
       if (tag === 'A' || tag === 'BUTTON' || tag === 'SL-BUTTON' || tag === 'SL-ICON-BUTTON') return;
     }
+    e.preventDefault();
     this.dragging = true;
     this.dragStartX = e.clientX;
     this.dragStartY = e.clientY;

--- a/web/src/components/shared/agent-tree-view.ts
+++ b/web/src/components/shared/agent-tree-view.ts
@@ -128,10 +128,10 @@ export class ScionAgentTreeView extends LitElement {
       min-height: 340px;
       cursor: grab;
       touch-action: none;
-      user-select: none;
     }
 
     .canvas.dragging {
+      user-select: none;
       cursor: grabbing;
     }
 


### PR DESCRIPTION
## Summary

Drag-to-pan in the agent graph view causes text selection. Adds user-select: none on .canvas and e.preventDefault() in onPointerDown.

Resolves ptone/scion#766

## Test plan
- Web build passes
