### PR TITLE
feat(a2a): dev-mode rebuild, Makefile target, catalog descriptions, and admin docs (Phase 5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GOLANGCI_LINT := $(shell command -v golangci-lint 2>/dev/null || echo $(shell go
 
 .DEFAULT_GOAL := help
 
-.PHONY: all build install test test-fast vet lint compat-literals golangci-lint web web-typecheck web-test fmt fmt-check ci ci-full clean help container-sciontool container-scion container-binaries proto proto-check
+.PHONY: all build build-a2a-bridge install test test-fast vet lint compat-literals golangci-lint web web-typecheck web-test fmt fmt-check ci ci-full clean help container-sciontool container-scion container-binaries proto proto-check
 
 ## all: Build the web frontend and compile the Go binary (run 'make install' separately to install)
 all: web build
@@ -27,6 +27,13 @@ build:
 	@mkdir -p $(BUILD_DIR)
 	@go build -buildvcs=false -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) $(MAIN_PKG)
 	@echo "Binary: $(BUILD_DIR)/$(BINARY)"
+
+## build-a2a-bridge: Build the A2A bridge binary into ./bin/
+build-a2a-bridge:
+	@echo "Building scion-a2a-bridge..."
+	@mkdir -p bin
+	@go build -o bin/scion-a2a-bridge ./extras/scion-a2a-bridge/cmd/scion-a2a-bridge/
+	@echo "Binary: bin/scion-a2a-bridge"
 
 ## install: Install a pre-built binary (default: /usr/local/bin, override with PREFIX=~/.local). Run 'make build' first.
 install:

--- a/extras/scion-a2a-bridge/README.md
+++ b/extras/scion-a2a-bridge/README.md
@@ -86,6 +86,54 @@ The A2A server listens on plain HTTP. **TLS must be terminated at a reverse prox
 | 8443 | A2A HTTP server (JSON-RPC, agent cards, health/metrics) |
 | 9090 | Broker plugin RPC (Hub connects here to push agent messages) |
 
+## Admin UI management
+
+The A2A bridge can be installed, configured, and monitored from the Scion Hub admin UI. This is the recommended approach for most deployments.
+
+### Installation via admin UI
+
+1. Navigate to **Admin > Integrations** in the Scion web UI.
+2. The A2A Bridge appears under **Available Integrations** (listed as "External service — installed separately, managed via admin UI").
+3. Click **Install** for the A2A Bridge entry.
+4. The Hub creates configuration files and registers the bridge in `settings.yaml`. The UI displays setup instructions including the binary name, config file path, and a sample start command.
+5. Build the bridge binary (see [Build the binary](#2-build-the-binary) below, or use `make build-a2a-bridge` from the repository root).
+6. Start the bridge process using the displayed command (e.g., `scion-a2a-bridge -config ~/.scion/scion-a2a-bridge.yaml`).
+7. Return to the admin UI and click **Reconnect** to activate the integration. The status changes to **Connected** once the Hub reaches the bridge's RPC endpoint.
+
+### Configuration via admin UI
+
+Once installed, the bridge's admin-managed settings can be edited from the integration detail page:
+
+| Setting | Description |
+|---------|-------------|
+| **Auth scheme** | Client authentication mode: `apiKey`, `bearer`, `none`, `hubUAT`, or `hubJWT`. Select from the dropdown. |
+| **API key** | Static API key for `apiKey`/`bearer` schemes. Stored in the Hub secret backend — never written to YAML files. Only shown when the auth scheme requires it. |
+| **External URL** | Public URL where A2A clients reach the bridge (e.g., `https://a2a.example.com`). Used in generated agent cards. |
+| **Rate limiting** | Enable/disable per-client rate limiting, with configurable requests-per-second and burst size. |
+| **Provider metadata** | Organization name and URL included in agent cards. |
+| **Timeouts** | Send-message timeout, SSE keepalive interval, and push notification retry limit. |
+
+Changes saved via the admin UI take effect immediately on the running bridge — no bridge restart is required. The Hub pushes the updated configuration over the existing RPC connection.
+
+### Project and agent exposure
+
+The admin UI provides a structured editor for controlling which projects and agents are reachable via A2A:
+
+- **Add projects**: Select a project from the dropdown to expose it over A2A.
+- **Restrict agents**: Optionally select specific agents within a project. Leave empty to expose all agents in the project.
+- **Auto-provision**: Toggle whether the bridge automatically provisions conversations for new A2A tasks.
+- **Default template**: Set the default agent template used when auto-provisioning.
+
+Changes to project/agent exposure take effect immediately without a bridge restart.
+
+### Operational notes
+
+- **Config changes are live.** Admin UI settings are pushed to the running bridge via RPC. No bridge restart is needed for admin-managed settings.
+- **Bootstrap settings remain operator-managed.** Listen addresses (`bridge.listen_address`, `plugin.listen_address`), TLS configuration, state database path, and the Hub signing key are configured in the bridge's own YAML file (`scion-a2a-bridge.yaml`). These are displayed as read-only in the admin UI.
+- **Config persistence.** The bridge persists admin overlay settings to `admin-overlay.json` in the state directory. This overlay survives bridge restarts — settings configured via the admin UI are re-applied at boot before the bridge begins serving.
+- **Version skew.** An older bridge binary with a newer Hub ignores the `Configure()` push (existing no-op behavior). A newer bridge with an older Hub simply never receives admin overlay pushes. Neither direction breaks messaging. The admin UI displays the bridge version so operators can identify pre-admin-support binaries.
+- **Dev-mode rebuild.** When the Hub is running with `MaintenanceConfig.RepoPath` set (development mode), the Update action rebuilds the bridge binary from source. The response instructs the operator to restart the bridge process manually — the Hub does not manage the bridge lifecycle.
+
 ## Setup and onboarding (agent instructions)
 
 Step-by-step instructions for installing, configuring, and running the A2A bridge from scratch. Every command is copy-paste ready.

--- a/extras/scion-a2a-bridge/internal/bridge/adminoverlay.go
+++ b/extras/scion-a2a-bridge/internal/bridge/adminoverlay.go
@@ -379,7 +379,7 @@ func PersistOverlay(stateDir string, overlay *AdminOverlay) error {
 	if overlay.RateLimitEnabled != nil {
 		p.RateLimitEnabled = overlay.RateLimitEnabled
 	}
-	if overlay.UATCacheTTL > 0 {
+	if overlay.IsPresent("uat_cache_ttl") {
 		p.UATCacheTTL = overlay.UATCacheTTL.String()
 	}
 	if overlay.SendMessageTimeout > 0 {

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -130,8 +130,9 @@ type IntegrationConfigUpdateRequest struct {
 
 // AvailableIntegration represents a plugin that could be installed.
 type AvailableIntegration struct {
-	Name     string `json:"name"`
-	Platform string `json:"platform"`
+	Name        string `json:"name"`
+	Platform    string `json:"platform"`
+	Description string `json:"description,omitempty"`
 }
 
 // IntegrationUpdateResponse is returned by POST update for HA integrations (202)
@@ -157,13 +158,14 @@ type KnownPlugin struct {
 	BinaryName  string // binary name, default "scion-plugin-<name>"
 	SourceDir   string // source directory, default "extras/scion-<name>"
 	SelfManaged bool   // true = register+instruct, never build/launch
+	Description string // human-readable description for the available-integrations list
 }
 
 var knownPluginCatalog = []KnownPlugin{
-	{Name: "telegram", Platform: "telegram", BinaryName: "scion-plugin-telegram", SourceDir: "extras/scion-telegram"},
-	{Name: "discord", Platform: "discord", BinaryName: "scion-plugin-discord", SourceDir: "extras/scion-discord"},
-	{Name: "slack", Platform: "slack", BinaryName: "scion-plugin-slack", SourceDir: "extras/scion-slack"},
-	{Name: "a2a-bridge", Platform: "a2a", BinaryName: "scion-a2a-bridge", SourceDir: "extras/scion-a2a-bridge", SelfManaged: true},
+	{Name: "telegram", Platform: "telegram", BinaryName: "scion-plugin-telegram", SourceDir: "extras/scion-telegram", Description: "Chat integration — built and managed by the Hub"},
+	{Name: "discord", Platform: "discord", BinaryName: "scion-plugin-discord", SourceDir: "extras/scion-discord", Description: "Chat integration — built and managed by the Hub"},
+	{Name: "slack", Platform: "slack", BinaryName: "scion-plugin-slack", SourceDir: "extras/scion-slack", Description: "Chat integration — built and managed by the Hub"},
+	{Name: "a2a-bridge", Platform: "a2a", BinaryName: "scion-a2a-bridge", SourceDir: "extras/scion-a2a-bridge", SelfManaged: true, Description: "External service — installed separately, managed via admin UI"},
 }
 
 var knownPluginSet = func() map[string]bool {
@@ -718,9 +720,15 @@ func (s *Server) handleUpdateIntegration(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	// Self-managed plugins cannot be updated via the Hub (no build/launch).
+	// Self-managed plugins: in dev mode (RepoPath set), offer a binary rebuild
+	// but do NOT restart the bridge process. Otherwise reject with guidance.
 	if kp := lookupKnownPlugin(name); kp != nil && kp.SelfManaged {
-		BadRequest(w, "self-managed integrations cannot be updated via the Hub — update the binary manually and click Reconnect")
+		repoPath := s.config.MaintenanceConfig.RepoPath
+		if repoPath == "" {
+			BadRequest(w, "self-managed integrations cannot be updated via the Hub — update the binary manually and click Reconnect")
+			return
+		}
+		s.handleRebuildSelfManaged(w, r, kp, repoPath)
 		return
 	}
 
@@ -1084,6 +1092,60 @@ func createBridgeConfigTemplate(name, configFilePath, hubEndpoint string) error 
 	return os.WriteFile(resolved, []byte(content), 0600)
 }
 
+// handleRebuildSelfManaged builds a self-managed plugin binary from source
+// (dev mode only). Unlike regular plugin updates, this does NOT restart the
+// bridge process — the response instructs the operator to restart manually.
+func (s *Server) handleRebuildSelfManaged(w http.ResponseWriter, _ *http.Request, kp *KnownPlugin, repoPath string) {
+	sourceDir := filepath.Join(repoPath, kp.SourceDir)
+	if _, err := os.Stat(sourceDir); err != nil {
+		NotFound(w, "plugin source directory")
+		return
+	}
+
+	mu := acquirePluginBuildLock(kp.Name)
+	if mu == nil {
+		writeJSON(w, http.StatusConflict, map[string]string{
+			"error": "a build is already in progress for this integration",
+		})
+		return
+	}
+	defer releasePluginBuildLock(kp.Name)
+
+	// Build the binary into the repo's bin/ directory using the same pattern
+	// as the Makefile target: go build -o bin/<binary> ./<source>/cmd/<binary>/
+	binDir := filepath.Join(repoPath, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		slog.Error("Failed to create bin directory", "path", binDir, "error", err)
+		InternalError(w)
+		return
+	}
+
+	binaryPath := filepath.Join(binDir, kp.BinaryName)
+	buildPkg := "./" + kp.SourceDir + "/cmd/" + kp.BinaryName + "/"
+
+	slog.Info("Rebuilding self-managed plugin binary",
+		"plugin", kp.Name, "source", sourceDir, "binary", binaryPath)
+
+	buildCmd := exec.Command("go", "build", "-o", binaryPath, buildPkg)
+	buildCmd.Dir = repoPath
+	output, err := buildCmd.CombinedOutput()
+	if err != nil {
+		slog.Error("Build failed for self-managed plugin", "plugin", kp.Name, "error", err, "output", string(output))
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
+			"Build failed — check server logs for details", nil)
+		return
+	}
+
+	slog.Info("Self-managed plugin binary rebuilt successfully",
+		"plugin", kp.Name, "binary", binaryPath)
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"status":      "rebuilt",
+		"binary_path": binaryPath,
+		"notes":       "Binary rebuilt successfully. Restart the bridge process to use the new binary.",
+	})
+}
+
 func (s *Server) handleListAvailableIntegrations(w http.ResponseWriter, _ *http.Request) {
 	s.mu.RLock()
 	mgr := s.pluginManager
@@ -1132,8 +1194,9 @@ func (s *Server) handleListAvailableIntegrations(w http.ResponseWriter, _ *http.
 		}
 
 		available = append(available, AvailableIntegration{
-			Name:     kp.Name,
-			Platform: kp.Platform,
+			Name:        kp.Name,
+			Platform:    kp.Platform,
+			Description: kp.Description,
 		})
 	}
 

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -2459,3 +2459,121 @@ func TestListAvailableIntegrations_IncludesA2ABridge(t *testing.T) {
 		t.Errorf("expected a2a-bridge in available integrations, got %v", result)
 	}
 }
+
+func TestListAvailableIntegrations_IncludesDescription(t *testing.T) {
+	repoDir := t.TempDir()
+	// Create source directories for a2a-bridge and telegram.
+	for _, d := range []string{"extras/scion-a2a-bridge", "extras/scion-telegram"} {
+		if err := os.MkdirAll(filepath.Join(repoDir, d), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mgr := newMockIntegrationManager()
+
+	srv := &Server{}
+	srv.config.MaintenanceConfig.RepoPath = repoDir
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/available", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var result []AvailableIntegration
+	if err := json.NewDecoder(rr.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	for _, a := range result {
+		if a.Description == "" {
+			t.Errorf("expected description for %s, got empty", a.Name)
+		}
+		if a.Name == "a2a-bridge" && !strings.Contains(a.Description, "External") {
+			t.Errorf("a2a-bridge should have external-service description, got %q", a.Description)
+		}
+	}
+}
+
+// --- Self-managed rebuild (dev mode) ---
+
+func TestUpdateIntegration_SelfManaged_DevModeRebuild_NoSource(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["a2a-bridge"] = map[string]string{}
+	mgr.selfManaged["a2a-bridge"] = true
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+	srv.config.MaintenanceConfig.RepoPath = t.TempDir() // RepoPath set but no source dir
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations/a2a-bridge/update", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 (no source dir), got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestUpdateIntegration_SelfManaged_NoRepoPath(t *testing.T) {
+	mgr := newMockIntegrationManager()
+	mgr.plugins["a2a-bridge"] = map[string]string{}
+	mgr.selfManaged["a2a-bridge"] = true
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+	// No RepoPath set → should reject with guidance
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations/a2a-bridge/update", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 (no repo path), got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "update the binary manually") {
+		t.Error("expected guidance message about manual update")
+	}
+}
+
+func TestUpdateIntegration_SelfManaged_DevModeRebuild_SourceExists(t *testing.T) {
+	// Create a temp repo directory with the source structure.
+	repoPath := t.TempDir()
+	sourceDir := filepath.Join(repoPath, "extras", "scion-a2a-bridge", "cmd", "scion-a2a-bridge")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := newMockIntegrationManager()
+	mgr.plugins["a2a-bridge"] = map[string]string{}
+	mgr.selfManaged["a2a-bridge"] = true
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+	srv.config.MaintenanceConfig.RepoPath = repoPath
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations/a2a-bridge/update", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	// Build will fail because there's no real Go source, but the handler should
+	// get past the source-dir check and reach the build step (500 from build failure).
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 (build failure on empty source), got %d: %s", rr.Code, rr.Body.String())
+	}
+	// Error body should not leak internal build output
+	if strings.Contains(rr.Body.String(), "go build") {
+		t.Error("response should not leak internal build details")
+	}
+}

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -213,7 +213,7 @@ export class ScionPageAdminIntegrations extends LitElement {
 
   // Available projects for A2A project selector
   @state() private availableProjects: ProjectInfo[] = [];
-  @state() private projectsJsonWarning: string | null = null;
+
 
   static override styles = css`
     :host {
@@ -1197,25 +1197,20 @@ export class ScionPageAdminIntegrations extends LitElement {
   // ── A2A Projects & Agent Exposure Editor ──
 
   /** Parse the projects_json flat config value into an array of project entries. */
-  private parseProjectsJSON(): A2AProjectEntry[] {
+  private parseProjectsJSON(): { projects: A2AProjectEntry[]; warning: string | null } {
     const raw = this.editedSettings['projects_json'] ?? '';
     if (!raw || raw === '[]') {
-      this.projectsJsonWarning = null;
-      return [];
+      return { projects: [], warning: null };
     }
     try {
       const parsed = JSON.parse(raw) as A2AProjectEntry[];
       if (!Array.isArray(parsed)) {
-        this.projectsJsonWarning = null;
-        return [];
+        return { projects: [], warning: null };
       }
-      this.projectsJsonWarning = null;
-      return parsed;
+      return { projects: parsed, warning: null };
     } catch (e) {
       console.warn('Could not parse projects_json configuration:', e);
-      this.projectsJsonWarning =
-        'Warning: Could not parse existing projects configuration.';
-      return [];
+      return { projects: [], warning: 'Warning: Could not parse existing projects configuration.' };
     }
   }
 
@@ -1231,7 +1226,7 @@ export class ScionPageAdminIntegrations extends LitElement {
     const platform = resolvePlatform(d.name);
     if (platform !== 'a2a') return nothing;
 
-    const projects = this.parseProjectsJSON();
+    const { projects, warning } = this.parseProjectsJSON();
 
     // Slugs already used — for duplicate-prevention in the dropdown.
     const usedSlugs = new Set(projects.map((p) => p.slug));
@@ -1239,10 +1234,10 @@ export class ScionPageAdminIntegrations extends LitElement {
     return html`
       <div class="section">
         <h3 class="section-title">Projects & Agent Exposure</h3>
-        ${this.projectsJsonWarning
+        ${warning
           ? html`<div class="warning-message" style="color: var(--sl-color-warning-600); margin-bottom: 0.5rem;">
               <sl-icon name="exclamation-triangle" style="margin-right: 0.25rem;"></sl-icon>
-              ${this.projectsJsonWarning}
+              ${warning}
             </div>`
           : nothing}
         ${projects.length === 0


### PR DESCRIPTION
## Summary
- Adds make a2a-bridge build target and dev-mode rebuild support
- Adds catalog descriptions for self-managed install flow
- Adds A2A bridge README with setup and admin documentation
- Adds integration tests for self-managed plugin install handler

Phase 5 (final) of A2A bridge admin capabilities.

Related: https://github.com/ptone/scion/issues/672

## Changes
- Makefile - a2a-bridge target
- extras/scion-a2a-bridge/README.md - setup and admin docs
- pkg/hub/handlers_integrations.go - catalog descriptions, dev-mode rebuild
- pkg/hub/handlers_integrations_test.go - self-managed install handler tests

## Test plan
- [ ] make a2a-bridge builds successfully
- [ ] Self-managed install handler tests pass
