### PR TITLE
feat(chat): add /scion terminal command for Discord and Telegram

### DIFF
--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -18,6 +18,7 @@ import (
 
 // AgentInfo holds an agent's slug and current activity state.
 type AgentInfo struct {
+	ID       string `json:"id"`
 	Slug     string `json:"slug"`
 	Activity string `json:"activity,omitempty"`
 	Phase    string `json:"phase,omitempty"`
@@ -71,6 +72,9 @@ type HubClient interface {
 	// onBehalfOf is a namespaced principal (e.g. "user:alice@example.com"); it is
 	// sent as the X-Scion-On-Behalf-Of header, NOT in the body.
 	CreateAgent(ctx context.Context, projectID string, req CreateAgentRequest, onBehalfOf string) (*CreateAgentResponse, error)
+
+	// HubBaseURL returns the base URL of the hub (e.g. "https://hub.example.com").
+	HubBaseURL() string
 }
 
 // CommandHandler manages Discord slash command registration and dispatch.
@@ -280,6 +284,18 @@ func (h *CommandHandler) RegisterCommandsForGuild(guildID string) error {
 			},
 			{
 				Type:        discordgo.ApplicationCommandOptionSubCommand,
+				Name:        "terminal",
+				Description: "Get the web terminal URL for an agent",
+				Options: []*discordgo.ApplicationCommandOption{{
+					Type:         discordgo.ApplicationCommandOptionString,
+					Name:         "agent",
+					Description:  "Agent name",
+					Required:     true,
+					Autocomplete: true,
+				}},
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionSubCommand,
 				Name:        "send",
 				Description: "Send a file by path or search for files by name",
 				Options: []*discordgo.ApplicationCommandOption{
@@ -321,6 +337,7 @@ var ephemeralCommands = map[string]bool{
 	"unlink":   true,
 	"settings": true,
 	"default":  true,
+	"terminal": true,
 	"thread":   true,
 	"send":     true,
 }
@@ -390,6 +407,8 @@ func (h *CommandHandler) HandleSlashCommand(s *discordgo.Session, i *discordgo.I
 			h.HandleSettings(s, i)
 		case "default":
 			h.HandleDefault(s, i)
+		case "terminal":
+			h.HandleTerminal(s, i)
 		case "thread":
 			h.HandleThread(s, i)
 		case "send":
@@ -526,6 +545,7 @@ func helpText() string {
 		"`/scion msg <agent> <text>` — Send a message to an agent\n" +
 		"`/scion logs <agent>` — View agent logs\n" +
 		"`/scion default [agent]` — Set or clear the default agent\n" +
+		"`/scion terminal <agent>` — Get the web terminal URL for an agent\n" +
 		"`/scion send <path>` — Send a file by path or search for files\n" +
 		"`/scion thread <title> [template]` — Create a thread with a new agent\n" +
 		"`/scion register` — Link your Discord account to Scion Hub\n" +
@@ -1229,6 +1249,48 @@ func isForumChannelType(s *discordgo.Session, channelID string) bool {
 
 	return ch.Type == discordgo.ChannelTypeGuildForum ||
 		ch.Type == discordgo.ChannelTypeGuildMedia
+}
+
+// HandleTerminal returns the web terminal URL for a running agent.
+func (h *CommandHandler) HandleTerminal(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	agentSlug := getSubcommandOption(i, "agent")
+	if agentSlug == "" {
+		h.followup(s, i, "Usage: `/scion terminal <agent-name>`")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
+	if err != nil || link == nil {
+		h.followup(s, i, "This channel is not linked to a project. Use `/scion setup` first.")
+		return
+	}
+
+	agents, err := h.hubClient.ListAgents(ctx, link.ProjectID)
+	if err != nil {
+		h.followup(s, i, "Failed to fetch agents. Please try again.")
+		return
+	}
+
+	for _, agent := range agents {
+		if strings.EqualFold(agent.Slug, agentSlug) {
+			if strings.ToLower(agent.Phase) != "running" {
+				phase := agent.Phase
+				if phase == "" {
+					phase = "unknown"
+				}
+				h.followup(s, i, fmt.Sprintf("Agent **%s** is not running (phase: %s).", agent.Slug, phase))
+				return
+			}
+			terminalURL := fmt.Sprintf("%s/agents/%s/terminal", h.hubClient.HubBaseURL(), agent.ID)
+			h.followup(s, i, fmt.Sprintf("Terminal for **%s**: %s", agent.Slug, terminalURL))
+			return
+		}
+	}
+
+	h.followup(s, i, fmt.Sprintf("Agent '%s' not found in this project.", agentSlug))
 }
 
 // HandleThread creates a Discord thread and a Scion agent in one command.

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -1263,14 +1263,20 @@ func (h *CommandHandler) HandleTerminal(s *discordgo.Session, i *discordgo.Inter
 	defer cancel()
 
 	link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
-	if err != nil || link == nil {
+	if err != nil {
+		h.log.Error("Failed to get channel link", "error", err, "channel_id", i.ChannelID)
+		h.followup(s, i, "Something went wrong. Please try again.")
+		return
+	}
+	if link == nil {
 		h.followup(s, i, "This channel is not linked to a project. Use `/scion setup` first.")
 		return
 	}
 
 	agents, err := h.hubClient.ListAgents(ctx, link.ProjectID)
 	if err != nil {
-		h.followup(s, i, "Failed to fetch agents. Please try again.")
+		h.log.Error("Failed to list agents", "error", err, "project_id", link.ProjectID)
+		h.followup(s, i, "Failed to fetch agents. Please try again later.")
 		return
 	}
 

--- a/extras/scion-discord/internal/discord/hubclient.go
+++ b/extras/scion-discord/internal/discord/hubclient.go
@@ -57,6 +57,7 @@ type hubAgentsResponse struct {
 }
 
 type hubAgent struct {
+	ID       string `json:"id"`
 	Slug     string `json:"slug"`
 	Activity string `json:"activity"`
 	Phase    string `json:"phase"`
@@ -205,7 +206,7 @@ func (c *httpHubClient) ListAgents(ctx context.Context, projectID string) ([]Age
 
 	agents := make([]AgentInfo, len(result.Agents))
 	for i, a := range result.Agents {
-		agents[i] = AgentInfo{Slug: a.Slug, Activity: a.Activity, Phase: a.Phase}
+		agents[i] = AgentInfo{ID: a.ID, Slug: a.Slug, Activity: a.Activity, Phase: a.Phase}
 	}
 	return agents, nil
 }
@@ -387,6 +388,10 @@ func (c *httpHubClient) CreateAgent(ctx context.Context, projectID string, req C
 		he := parseHubError(resp)
 		return nil, fmt.Errorf("create agent returned status %d: %s", resp.StatusCode, he.Message)
 	}
+}
+
+func (c *httpHubClient) HubBaseURL() string {
+	return c.hubURL
 }
 
 func (c *httpHubClient) signRequest(req *http.Request) error {

--- a/extras/scion-telegram/internal/telegram/broker_v2_test.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2_test.go
@@ -73,6 +73,10 @@ func (f *fakeHubClient) ListAgents(_ context.Context, projectID string) ([]Agent
 	return f.agents[projectID], nil
 }
 
+func (f *fakeHubClient) HubBaseURL() string {
+	return "https://hub.example.com"
+}
+
 // fakeTGServerV2 extends fakeTelegramServer with v2 endpoint support.
 type fakeTGServerV2 struct {
 	srv *httptest.Server

--- a/extras/scion-telegram/internal/telegram/commands.go
+++ b/extras/scion-telegram/internal/telegram/commands.go
@@ -31,8 +31,10 @@ import (
 
 // AgentInfo holds an agent's slug and current activity state.
 type AgentInfo struct {
+	ID       string `json:"id"`
 	Slug     string `json:"slug"`
 	Activity string `json:"activity,omitempty"`
+	Phase    string `json:"phase,omitempty"`
 }
 
 // HubClient provides access to the Scion hub API for project and agent listing.
@@ -41,6 +43,9 @@ type HubClient interface {
 	ListProjectsFresh(ctx context.Context) ([]ProjectOption, error)
 	ListProjectsForUser(ctx context.Context, ownerID string) ([]ProjectOption, error)
 	ListAgents(ctx context.Context, projectID string) ([]AgentInfo, error)
+
+	// HubBaseURL returns the base URL of the hub (e.g. "https://hub.example.com").
+	HubBaseURL() string
 }
 
 // CommandHandler processes bot commands from incoming Telegram messages.
@@ -104,6 +109,9 @@ func (h *CommandHandler) HandleCommand(msg *TGMessage) bool {
 		return true
 	case "/help":
 		h.handleHelp(msg)
+		return true
+	case "/terminal":
+		h.handleTerminal(msg)
 		return true
 	case "/status":
 		h.handleStatus(msg)
@@ -245,6 +253,58 @@ func (h *CommandHandler) handleDefault(msg *TGMessage) {
 	h.replyWithKeyboardInThread(chatID, threadID, promptText, kb)
 }
 
+func (h *CommandHandler) handleTerminal(msg *TGMessage) {
+	chatID := msg.Chat.ID
+
+	// Parse agent name from the message text.
+	parts := strings.Fields(msg.Text)
+	if len(parts) < 2 {
+		h.reply(chatID, "Usage: /terminal <agent-name>")
+		return
+	}
+	agentName := parts[1]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	link, err := h.store.GetGroupLink(ctx, chatID)
+	if err != nil {
+		h.log.Error("Failed to get group link", "chat_id", chatID, "error", err)
+		h.reply(chatID, "Something went wrong. Please try again.")
+		return
+	}
+
+	if link == nil {
+		h.reply(chatID, "This group is not linked to a project. Use /setup first.")
+		return
+	}
+
+	agents, err := h.hubClient.ListAgents(ctx, link.ProjectID)
+	if err != nil {
+		h.log.Error("Failed to list agents", "project_id", link.ProjectID, "error", err)
+		h.reply(chatID, "Failed to fetch agents. Please try again later.")
+		return
+	}
+
+	for _, agent := range agents {
+		if strings.EqualFold(agent.Slug, agentName) {
+			if strings.ToLower(agent.Phase) != "running" {
+				phase := agent.Phase
+				if phase == "" {
+					phase = "unknown"
+				}
+				h.reply(chatID, fmt.Sprintf("Agent '%s' is not running (phase: %s).", agent.Slug, phase))
+				return
+			}
+			terminalURL := fmt.Sprintf("%s/agents/%s/terminal", h.hubClient.HubBaseURL(), agent.ID)
+			h.reply(chatID, fmt.Sprintf("Terminal for *%s*: %s", agent.Slug, terminalURL))
+			return
+		}
+	}
+
+	h.reply(chatID, fmt.Sprintf("Agent '%s' not found in this project.", agentName))
+}
+
 func (h *CommandHandler) handleAgents(msg *TGMessage) {
 	chatID := msg.Chat.ID
 
@@ -339,6 +399,7 @@ func (h *CommandHandler) handleHelp(msg *TGMessage) {
 			"/setup — Link this group to a project\n" +
 			"/default — Set the default agent\n" +
 			"/agents — List agents in the linked project\n" +
+			"/terminal <agent> — Get the web terminal URL for an agent\n" +
 			"/settings — Configure group settings\n" +
 			"/unlink — Unlink this group from its project\n" +
 			"/help — Show this help message\n\n" +
@@ -658,8 +719,10 @@ type hubAgentsResponse struct {
 }
 
 type hubAgent struct {
+	ID       string `json:"id"`
 	Slug     string `json:"slug"`
 	Activity string `json:"activity"`
+	Phase    string `json:"phase"`
 }
 
 func (c *httpHubClient) ListProjects(ctx context.Context) ([]ProjectOption, error) {
@@ -804,9 +867,13 @@ func (c *httpHubClient) ListAgents(ctx context.Context, projectID string) ([]Age
 
 	agents := make([]AgentInfo, len(result.Agents))
 	for i, a := range result.Agents {
-		agents[i] = AgentInfo{Slug: a.Slug, Activity: a.Activity}
+		agents[i] = AgentInfo{ID: a.ID, Slug: a.Slug, Activity: a.Activity, Phase: a.Phase}
 	}
 	return agents, nil
+}
+
+func (c *httpHubClient) HubBaseURL() string {
+	return c.hubURL
 }
 
 func (c *httpHubClient) signRequest(req *http.Request) error {


### PR DESCRIPTION
## Summary
- Adds /scion terminal (Discord) and /terminal (Telegram) commands
- Takes agent name, resolves via Hub API, returns web terminal URL
- Extends hubAgent struct with id (UUID) and phase fields
- Adds HubBaseURL() to HubClient interface

## Changes
- extras/scion-discord/internal/discord/commands.go - HandleTerminal, registration, help
- extras/scion-discord/internal/discord/hubclient.go - ID field, HubBaseURL()
- extras/scion-telegram/internal/telegram/commands.go - handleTerminal, dispatch, struct fields
- extras/scion-telegram/internal/telegram/broker_v2_test.go - fakeHubClient update

## Test plan
- [ ] Discord: /scion terminal returns terminal URL for running agent
- [ ] Telegram: /terminal returns terminal URL
- [ ] Both bots build successfully
