### PR TITLE
fix(discord): show thread-level default agent in /scion info

### DIFF
--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -805,14 +805,9 @@ func (h *CommandHandler) HandleInfo(s *discordgo.Session, i *discordgo.Interacti
 			sb.WriteString(fmt.Sprintf("\n**Channel project:** %s", link.ProjectSlug))
 
 			// Check for thread-level default agent.
-			infoParentID, ok := threadParentID(s, i.ChannelID)
-			if !ok {
-				h.log.Error("Failed to resolve channel details for info", "channel_id", i.ChannelID)
-				// Gracefully degrade: show channel-level default only. Unlike HandleDefault
-				// and HandleStatus which abort on failure, /scion info is best-effort display
-				// and partial info is still useful.
-			}
-			if infoParentID != "" {
+			// link.ChannelID is the parent channel (resolveChannelLink falls back);
+			// if it differs from i.ChannelID, we are in a thread.
+			if link.ChannelID != i.ChannelID {
 				threadDefault, tdErr := h.store.GetThreadDefault(ctx, link.ChannelID, i.ChannelID)
 				if tdErr != nil {
 					h.log.Error("Failed to get thread default for info", "error", tdErr)

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -803,8 +803,26 @@ func (h *CommandHandler) HandleInfo(s *discordgo.Session, i *discordgo.Interacti
 				sb.WriteString(fmt.Sprintf("\n**Server:** %s", link.GuildName))
 			}
 			sb.WriteString(fmt.Sprintf("\n**Channel project:** %s", link.ProjectSlug))
-			if link.DefaultAgent != "" {
-				sb.WriteString(fmt.Sprintf("\n**Default agent:** %s", link.DefaultAgent))
+
+			// Check for thread-level default agent.
+			infoParentID, ok := threadParentID(s, i.ChannelID)
+			if !ok {
+				h.log.Error("Failed to resolve channel details for info", "channel_id", i.ChannelID)
+			}
+			if infoParentID != "" {
+				threadDefault, tdErr := h.store.GetThreadDefault(ctx, link.ChannelID, i.ChannelID)
+				if tdErr == nil && threadDefault != "" {
+					sb.WriteString(fmt.Sprintf("\n**Thread default agent:** %s", threadDefault))
+				}
+				// Show channel default as context (it's the fallback)
+				if link.DefaultAgent != "" {
+					sb.WriteString(fmt.Sprintf("\n**Channel default agent:** %s", link.DefaultAgent))
+				}
+			} else {
+				// Not in a thread — show channel default as before
+				if link.DefaultAgent != "" {
+					sb.WriteString(fmt.Sprintf("\n**Default agent:** %s", link.DefaultAgent))
+				}
 			}
 		}
 	}

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -808,10 +808,15 @@ func (h *CommandHandler) HandleInfo(s *discordgo.Session, i *discordgo.Interacti
 			infoParentID, ok := threadParentID(s, i.ChannelID)
 			if !ok {
 				h.log.Error("Failed to resolve channel details for info", "channel_id", i.ChannelID)
+				// Gracefully degrade: show channel-level default only. Unlike HandleDefault
+				// and HandleStatus which abort on failure, /scion info is best-effort display
+				// and partial info is still useful.
 			}
 			if infoParentID != "" {
 				threadDefault, tdErr := h.store.GetThreadDefault(ctx, link.ChannelID, i.ChannelID)
-				if tdErr == nil && threadDefault != "" {
+				if tdErr != nil {
+					h.log.Error("Failed to get thread default for info", "error", tdErr)
+				} else if threadDefault != "" {
 					sb.WriteString(fmt.Sprintf("\n**Thread default agent:** %s", threadDefault))
 				}
 				// Show channel default as context (it's the fallback)


### PR DESCRIPTION
## Summary
- /scion info now shows the thread-level default agent when invoked from a thread
- Displays both thread default and channel default (as fallback context)
- Non-thread behavior unchanged

## Changes
- extras/scion-discord/internal/discord/commands.go - HandleInfo thread detection and dual-label display

## Test plan
- [ ] /scion info in thread with thread default shows both thread and channel defaults
- [ ] /scion info outside thread shows channel default as before
