### PR TITLE
fix(web): move auto-expose checkbox to configure form only

### DIFF
--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -437,6 +437,24 @@ func (s *Server) populateAgentConfig(ctx context.Context, agent *store.Agent, pr
 		}
 	}
 
+	// Apply hub-level AutoExposePortsDefault as lowest-priority fallback.
+	// Only injects SCION_AUTO_EXPOSE_PORTS if neither the agent config nor
+	// the project annotation already set it.
+	s.mu.RLock()
+	hubAutoExposeDefault := s.config.AutoExposePortsDefault
+	s.mu.RUnlock()
+	if hubAutoExposeDefault != nil && *hubAutoExposeDefault {
+		if agent.AppliedConfig.InlineConfig == nil {
+			agent.AppliedConfig.InlineConfig = &api.ScionConfig{}
+		}
+		if agent.AppliedConfig.InlineConfig.Env == nil {
+			agent.AppliedConfig.InlineConfig.Env = make(map[string]string)
+		}
+		if _, exists := agent.AppliedConfig.InlineConfig.Env["SCION_AUTO_EXPOSE_PORTS"]; !exists {
+			agent.AppliedConfig.InlineConfig.Env["SCION_AUTO_EXPOSE_PORTS"] = "true"
+		}
+	}
+
 	// Merge injected skills from hub/user/project scopes into InlineConfig.Skills
 	// so the provisioner's existing Step 3b handles them.
 	s.mergeInjectedSkills(ctx, agent, project)

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -438,12 +438,12 @@ func (s *Server) populateAgentConfig(ctx context.Context, agent *store.Agent, pr
 	}
 
 	// Apply hub-level AutoExposePortsDefault as lowest-priority fallback.
-	// Only injects SCION_AUTO_EXPOSE_PORTS if neither the agent config nor
-	// the project annotation already set it.
+	// Injects SCION_AUTO_EXPOSE_PORTS if neither the agent config nor
+	// the project annotation already set it, respecting both true and false defaults.
 	s.mu.RLock()
 	hubAutoExposeDefault := s.config.AutoExposePortsDefault
 	s.mu.RUnlock()
-	if hubAutoExposeDefault != nil && *hubAutoExposeDefault {
+	if hubAutoExposeDefault != nil {
 		if agent.AppliedConfig.InlineConfig == nil {
 			agent.AppliedConfig.InlineConfig = &api.ScionConfig{}
 		}
@@ -451,7 +451,7 @@ func (s *Server) populateAgentConfig(ctx context.Context, agent *store.Agent, pr
 			agent.AppliedConfig.InlineConfig.Env = make(map[string]string)
 		}
 		if _, exists := agent.AppliedConfig.InlineConfig.Env["SCION_AUTO_EXPOSE_PORTS"]; !exists {
-			agent.AppliedConfig.InlineConfig.Env["SCION_AUTO_EXPOSE_PORTS"] = "true"
+			agent.AppliedConfig.InlineConfig.Env["SCION_AUTO_EXPOSE_PORTS"] = strconv.FormatBool(*hubAutoExposeDefault)
 		}
 	}
 

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -111,18 +111,6 @@ export class ScionPageAgentCreate extends LitElement {
   private telemetryEnabled = false;
 
   @state()
-  private autoExposePortsEnabled = false;
-
-  @state()
-  private autoExposePortsMode = 'allowlist';
-
-  @state()
-  private autoExposePortsList = '';
-
-  @state()
-  private autoExposePortsInterval = '3s';
-
-  @state()
   private gcpMetadataMode: 'block' | 'passthrough' | 'assign' = 'block';
 
   @state()
@@ -423,10 +411,8 @@ export class ScionPageAgentCreate extends LitElement {
       if (settingsRes.ok) {
         const data = (await settingsRes.json()) as {
           telemetryEnabled?: boolean;
-          autoExposePortsEnabled?: boolean;
         };
         this.telemetryEnabled = data.telemetryEnabled ?? false;
-        this.autoExposePortsEnabled = data.autoExposePortsEnabled ?? false;
       }
 
       if (harnessConfigsRes.ok) {
@@ -557,15 +543,7 @@ export class ScionPageAgentCreate extends LitElement {
       // Pass config options
       const env: Record<string, string> = {
         SCION_TELEMETRY_ENABLED: this.telemetryEnabled ? 'true' : 'false',
-        SCION_AUTO_EXPOSE_PORTS: this.autoExposePortsEnabled ? 'true' : 'false',
       };
-      if (this.autoExposePortsEnabled) {
-        env.SCION_AUTO_EXPOSE_MODE = this.autoExposePortsMode;
-        if (this.autoExposePortsList) {
-          env.SCION_AUTO_EXPOSE_PORTS_LIST = this.autoExposePortsList;
-        }
-        env.SCION_AUTO_EXPOSE_INTERVAL = this.autoExposePortsInterval || '3s';
-      }
       const config: Record<string, unknown> = { env };
 
       body.config = config;
@@ -1350,66 +1328,6 @@ private selectBrokerForProject(): void {
                           accounts in project settings.
                         </div>
                       `}
-                </div>
-              `
-            : ''}
-
-          <div class="form-field">
-            <label>Auto-Expose Ports</label>
-            <sl-checkbox
-              ?checked=${this.autoExposePortsEnabled}
-              @sl-change=${(e: Event) => {
-                this.autoExposePortsEnabled = (e.target as HTMLInputElement).checked;
-              }}
-            >
-              Enable Auto-Expose Ports
-            </sl-checkbox>
-            <div class="hint">Automatically detect and expose TCP listening ports from the agent container.</div>
-          </div>
-
-          ${this.autoExposePortsEnabled
-            ? html`
-                <div class="form-field">
-                  <label for="auto-expose-mode">Port Filter Mode</label>
-                  <sl-select
-                    id="auto-expose-mode"
-                    .value=${this.autoExposePortsMode}
-                    @sl-change=${(e: Event) => {
-                      this.autoExposePortsMode = (e.target as HTMLElement & { value: string }).value;
-                    }}
-                  >
-                    <sl-option value="allowlist">Allowlist</sl-option>
-                    <sl-option value="denylist">Denylist</sl-option>
-                  </sl-select>
-                  <div class="hint">
-                    ${this.autoExposePortsMode === 'allowlist'
-                      ? 'Only expose ports in the filter list below.'
-                      : 'Expose all ports except those in the filter list below.'}
-                  </div>
-                </div>
-                <div class="form-field">
-                  <label for="auto-expose-ports-list">Port Filter List</label>
-                  <sl-input
-                    id="auto-expose-ports-list"
-                    placeholder="e.g. 3000,5173,8080"
-                    .value=${this.autoExposePortsList}
-                    @sl-input=${(e: Event) => {
-                      this.autoExposePortsList = (e.target as HTMLElement & { value: string }).value;
-                    }}
-                  ></sl-input>
-                  <div class="hint">Comma-separated list of ports to ${this.autoExposePortsMode === 'allowlist' ? 'allow' : 'deny'}.</div>
-                </div>
-                <div class="form-field">
-                  <label for="auto-expose-interval">Scan Interval</label>
-                  <sl-input
-                    id="auto-expose-interval"
-                    placeholder="3s"
-                    .value=${this.autoExposePortsInterval}
-                    @sl-input=${(e: Event) => {
-                      this.autoExposePortsInterval = (e.target as HTMLElement & { value: string }).value;
-                    }}
-                  ></sl-input>
-                  <div class="hint">How often to scan for new listening ports (e.g. 3s, 5s). Minimum 1s.</div>
                 </div>
               `
             : ''}


### PR DESCRIPTION
## Summary

Moves the auto-expose ports checkbox from the primary agent create form to the configure-only form (Create & Edit flow). Keeps the primary create form simpler.

- Removed auto-expose UI and state from agent-create.ts (82 lines)
- Added hub-level auto-expose default injection in populateAgentConfig() so agents created via Create & Start still respect the hub default

## Test plan
- Web build passes
- Go build and vet pass