### PR TITLE
fix(web): edge arrowhead geometry and row spacing in agent graph view

### DIFF
--- a/web/src/components/shared/agent-tree-view.ts
+++ b/web/src/components/shared/agent-tree-view.ts
@@ -680,9 +680,9 @@ export class ScionAgentTreeView extends LitElement {
       <marker
         id=${id}
         viewBox="0 0 8 8"
-        markerWidth="7"
-        markerHeight="7"
-        refX="6.5"
+        markerWidth="8"
+        markerHeight="8"
+        refX="0.5"
         refY="4"
         orient="auto"
         markerUnits="userSpaceOnUse"
@@ -700,10 +700,16 @@ export class ScionAgentTreeView extends LitElement {
     const lit = related !== null && related.has(e.parentId) && related.has(e.childId);
     const dim = related !== null && !lit;
     const midY = (e.y1 + e.y2) / 2;
-    const yEnd = e.y2 - 2;
+    // End with a short straight vertical segment so the arrowhead always
+    // points straight down. The stroke stops at the arrowhead's BASE — the
+    // marker (refX near 0) extends past the path end so the stroke can never
+    // poke out beyond the triangle's tip. The tip lands exactly on the
+    // card's top edge (y2): touching, but never hidden under the card.
+    const yEnd = e.y2 - 6.5;
+    const yApproach = yEnd - 4;
     return svg`<path
       class="edge ${lit ? 'lit' : ''} ${dim ? 'dim' : ''}"
-      d="M ${e.x1} ${e.y1} C ${e.x1} ${midY}, ${e.x2} ${midY}, ${e.x2} ${yEnd}"
+      d="M ${e.x1} ${e.y1} C ${e.x1} ${midY}, ${e.x2} ${midY}, ${e.x2} ${yApproach} L ${e.x2} ${yEnd}"
     />`;
   }
 

--- a/web/src/shared/lineage.ts
+++ b/web/src/shared/lineage.ts
@@ -68,7 +68,7 @@ export interface ForestLayout {
 export const NODE_W = 180;
 export const NODE_H = 76;
 export const GAP_X = 24;
-export const GAP_Y = 48;
+export const GAP_Y = 52;
 export const PAD = 24;
 
 /** Edge/hover key for a user node, distinct from any agent ID. */


### PR DESCRIPTION
Three small geometry defects in the graph view's edges, found while using the view at high zoom:

1. **Stroke poking past the arrowhead tip** — the edge path ran all the way to the tip, so the square butt end of the 1.6px stroke stuck out beyond the triangle's point (the triangle tapers below stroke width near its tip).
2. **Tip floating above / hiding under the card** — depending on the end offset, the arrowhead either hovered a couple of px above the child card's top edge or slid underneath it.
3. **Tilted arrowheads** — `orient="auto"` rotated the marker along the curve's end tangent, so arrows into horizontally distant children arrived visibly skewed.

### Fix
- The stroke now stops at the arrowhead's **base**: the marker uses `refX` near 0 so the triangle extends beyond the path end — the stroke can never overshoot the tip.
- The tip lands **exactly on the card's top edge**: touching, never covered.
- Every edge finishes with a short straight vertical run-in, so the arrowhead always points straight down regardless of how far the curve bends.
- Marker bumped 7px → 8px for legibility; row gap 48px → 52px gives the curves a little more room to bend.

Tests: web suite green (134 tests), `make web-typecheck` clean.