### PR TITLE
feat(web): horizontal layout option and keyboard shortcuts for the agent graph view

### DIFF
--- a/web/src/components/pages/agent-graph.ts
+++ b/web/src/components/pages/agent-graph.ts
@@ -19,6 +19,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import type { PageData, Agent } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { stateManager } from '../../client/state.js';
+import type { Orientation } from '../../shared/lineage.js';
 import type { ViewMode } from '../shared/view-toggle.js';
 import '../shared/view-toggle.js';
 import '../shared/agent-tree-view.js';
@@ -40,6 +41,8 @@ export class AgentGraphPage extends LitElement {
   @state() private loading = true;
   @state() private error: string | null = null;
   @state() private projectFilter = '';
+  /** Graph flow direction, persisted in the URL as ?dir=horizontal (absent = vertical). */
+  @state() private orientation: Orientation = 'vertical';
   /** True when the page was entered with a ?project= param already set in the URL. */
   private initiallyProjectScoped = false;
   /** Agent ID to center on load (?focus=<agent-id> deep link) */
@@ -56,6 +59,7 @@ export class AgentGraphPage extends LitElement {
     this.projectFilter = params.get('project') || '';
     this.initiallyProjectScoped = !!params.get('project');
     this.focusId = params.get('focus') || '';
+    this.orientation = params.get('dir') === 'horizontal' ? 'horizontal' : 'vertical';
 
     const hydrated = stateManager.getAgents();
     if (hydrated.length > 0) {
@@ -151,6 +155,18 @@ export class AgentGraphPage extends LitElement {
     window.history.replaceState({}, '', url);
   }
 
+  /** Keeps the URL's ?dir= param in sync with the graph orientation toggle. */
+  private onOrientationChange(e: CustomEvent<{ orientation: Orientation }>): void {
+    this.orientation = e.detail.orientation;
+    const url = new URL(window.location.href);
+    if (this.orientation === 'horizontal') {
+      url.searchParams.set('dir', 'horizontal');
+    } else {
+      url.searchParams.delete('dir');
+    }
+    window.history.replaceState({}, '', url);
+  }
+
   /** Grid/list picks from the toggle navigate back to the agents list. */
   private onViewChange(e: CustomEvent<{ view: ViewMode }>): void {
     const mode = e.detail.view;
@@ -208,6 +224,8 @@ export class AgentGraphPage extends LitElement {
                 <scion-agent-tree-view
                   .agents=${this.visibleAgents}
                   focusId=${this.focusId}
+                  orientation=${this.orientation}
+                  @orientation-change=${this.onOrientationChange}
                 ></scion-agent-tree-view>
               `}
       </div>

--- a/web/src/components/shared/agent-tree-view.test.ts
+++ b/web/src/components/shared/agent-tree-view.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the <scion-agent-tree-view> keyboard shortcuts:
+ *   o     — toggle orientation vertical ⇄ horizontal
+ *   f     — fit to view
+ *   + / = — zoom in
+ *   -     — zoom out
+ * Shortcuts must be ignored when a modifier key is held or when the event
+ * originates from a text-entry/overlay context (inputs, sl-dialog, etc.).
+ */
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import './agent-tree-view.js';
+import type { ScionAgentTreeView } from './agent-tree-view.js';
+import type { Agent } from '../../shared/types.js';
+
+// happy-dom's localStorage is not functional in this setup; the component
+// reads/writes the show-users preference from it, so provide a minimal stub.
+beforeAll(() => {
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+  });
+});
+
+function agent(id: string, name: string, ancestry?: string[]): Agent {
+  return { id, name, ancestry, projectId: 'p1', template: 't', phase: 'running' } as Agent;
+}
+
+function pressKey(key: string, init: KeyboardEventInit = {}, target: EventTarget = window): void {
+  target.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, composed: true, ...init }));
+}
+
+describe('scion-agent-tree-view keyboard shortcuts', () => {
+  let el: ScionAgentTreeView;
+
+  beforeEach(async () => {
+    el = document.createElement('scion-agent-tree-view') as ScionAgentTreeView;
+    el.agents = [agent('r1', 'root', ['user-1']), agent('k1', 'kid', ['user-1', 'r1'])];
+    document.body.appendChild(el);
+    await el.updateComplete;
+  });
+
+  afterEach(() => {
+    el.remove();
+    document.body.innerHTML = '';
+  });
+
+  it('toggles orientation on "t" and dispatches orientation-change', () => {
+    let eventOrientation: string | null = null;
+    el.addEventListener('orientation-change', e => {
+      eventOrientation = (e as CustomEvent<{ orientation: string }>).detail.orientation;
+    });
+
+    expect(el.orientation).toBe('vertical');
+    pressKey('t');
+    expect(el.orientation).toBe('horizontal');
+    expect(eventOrientation).toBe('horizontal');
+    pressKey('T');
+    expect(el.orientation).toBe('vertical');
+    expect(eventOrientation).toBe('vertical');
+  });
+
+  it('ignores shortcuts when a modifier key is held', () => {
+    pressKey('t', { ctrlKey: true });
+    pressKey('t', { metaKey: true });
+    pressKey('t', { altKey: true });
+    expect(el.orientation).toBe('vertical');
+  });
+
+  it('ignores shortcuts originating from text-entry targets', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    pressKey('t', {}, input);
+    expect(el.orientation).toBe('vertical');
+
+    const dialog = document.createElement('sl-dialog');
+    const inner = document.createElement('button');
+    dialog.appendChild(inner);
+    document.body.appendChild(dialog);
+    pressKey('t', {}, inner);
+    expect(el.orientation).toBe('vertical');
+
+    // Sanity check: the same key from the background still works.
+    pressKey('t');
+    expect(el.orientation).toBe('horizontal');
+  });
+
+  it('zooms in on "+"/"=" and out on "-"', () => {
+    // scale is internal state; reach in for assertion purposes only.
+    const scaleOf = () => (el as unknown as { scale: number }).scale;
+    const initial = scaleOf();
+    pressKey('+');
+    expect(scaleOf()).toBeCloseTo(initial * 1.25);
+    pressKey('=');
+    expect(scaleOf()).toBeCloseTo(initial * 1.25 * 1.25);
+    pressKey('-');
+    expect(scaleOf()).toBeCloseTo(initial * 1.25);
+  });
+
+  it('does not throw on "f" (fit) even when the canvas has no size', () => {
+    expect(() => pressKey('f')).not.toThrow();
+  });
+
+  it('stops handling keys after removal from the DOM', () => {
+    el.remove();
+    pressKey('t');
+    expect(el.orientation).toBe('vertical');
+  });
+});

--- a/web/src/components/shared/agent-tree-view.ts
+++ b/web/src/components/shared/agent-tree-view.ts
@@ -22,6 +22,15 @@
  * rendering, pan/zoom, hover-highlighting, and collapse/expand. Designed to
  * slot into the same content area as the grid/list views on the agents page
  * and project-detail page.
+ *
+ * Supports two flow directions via the `orientation` property/toolbar toggle:
+ * 'vertical' (default, roots on top) and 'horizontal' (roots on the left,
+ * depth increases to the right). Changing it dispatches an
+ * `orientation-change` CustomEvent so host pages can persist the choice.
+ *
+ * Keyboard shortcuts (ignored while typing in inputs/dialogs/dropdowns or
+ * when a modifier key is held): `t` transposes the orientation, `f` fits the graph
+ * to the viewport, `+`/`=` zooms in, `-` zooms out.
  */
 
 import { LitElement, html, css, svg, nothing } from 'lit';
@@ -37,9 +46,11 @@ import {
   parentIdOf,
   pruneCollapsed,
   rootUserOf,
+  transposeLayout,
   userKey,
   NODE_W,
   NODE_H,
+  type Orientation,
   type PositionedNode,
   type PositionedEdge,
   type PositionedUser,
@@ -82,6 +93,14 @@ export class ScionAgentTreeView extends LitElement {
   @property({ type: String })
   focusId = '';
 
+  /**
+   * Flow direction of the lineage forest. Host pages may set it (e.g. from a
+   * URL param); the toolbar toggle and the `t` shortcut update it in place
+   * and dispatch `orientation-change` so hosts can stay in sync.
+   */
+  @property({ type: String })
+  orientation: Orientation = 'vertical';
+
   @state() private showUsers = false;
   @state() private hoverId: string | null = null;
   @state() private collapsedIds: ReadonlySet<string> = new Set();
@@ -95,6 +114,10 @@ export class ScionAgentTreeView extends LitElement {
   @query('.canvas') private canvasEl?: HTMLDivElement;
 
   private boundOnWheel = (e: WheelEvent) => this.onWheel(e);
+  private boundOnKeyDown = (e: KeyboardEvent) => this.onKeyDown(e);
+  /** Canvas-content size of the last computed layout (for keyboard "fit"). */
+  private contentW = 0;
+  private contentH = 0;
   private dragging = false;
   private dragStartX = 0;
   private dragStartY = 0;
@@ -114,6 +137,52 @@ export class ScionAgentTreeView extends LitElement {
       gap: 0.75rem;
       margin-bottom: 0.5rem;
       flex-wrap: wrap;
+    }
+
+    /* Segmented vertical/horizontal control, same visual language as
+       <scion-view-toggle>. */
+    .orientation-toggle {
+      display: inline-flex;
+      border: 1px solid var(--sl-color-neutral-300);
+      border-radius: var(--sl-border-radius-medium, 6px);
+      overflow: hidden;
+    }
+
+    .orientation-toggle button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 2rem;
+      height: 2rem;
+      border: none;
+      padding: 0;
+      background: var(--sl-color-neutral-0);
+      color: var(--sl-color-neutral-600);
+      cursor: pointer;
+      transition: all 150ms ease;
+    }
+
+    .orientation-toggle button:not(:last-child) {
+      border-right: 1px solid var(--sl-color-neutral-300);
+    }
+
+    .orientation-toggle button:hover:not(.active) {
+      background: var(--sl-color-neutral-100);
+    }
+
+    .orientation-toggle button.active {
+      background: var(--sl-color-primary-600);
+      color: var(--sl-color-neutral-0);
+    }
+
+    .orientation-toggle sl-icon {
+      font-size: 0.875rem;
+    }
+
+    /* Bootstrap Icons has no left→right tree glyph; rotate the top-down one
+       so the root lands on the left. */
+    .orientation-toggle sl-icon.rotated {
+      transform: rotate(-90deg);
     }
 
     .canvas {
@@ -289,6 +358,16 @@ export class ScionAgentTreeView extends LitElement {
       color: var(--sl-color-primary-600);
     }
 
+    /* Horizontal orientation: children grow to the right, so the chip hangs
+       off the parent card's right-edge-center instead of bottom-center. */
+    .collapse-chip.horizontal {
+      bottom: auto;
+      left: auto;
+      right: -9px;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+
     /*
      * Terminal icon button — lower-right corner of the agent card.
      * Hidden by default; revealed on hover or keyboard focus-within so
@@ -398,15 +477,22 @@ export class ScionAgentTreeView extends LitElement {
     this.showUsers = localStorage.getItem('scion-graph-show-users') === 'true';
     // Wheel needs passive:false so we can preventDefault (prevent page zoom/scroll).
     this.addEventListener('wheel', this.boundOnWheel, { passive: false });
+    window.addEventListener('keydown', this.boundOnKeyDown);
   }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
     this.removeEventListener('wheel', this.boundOnWheel);
+    window.removeEventListener('keydown', this.boundOnKeyDown);
   }
 
   override willUpdate(changedProperties: Map<PropertyKey, unknown>): void {
     super.willUpdate(changedProperties);
+    // Flipping the flow direction swaps the canvas aspect ratio; re-fit so
+    // the whole forest stays visible.
+    if (changedProperties.has('orientation') && changedProperties.get('orientation') !== undefined) {
+      this.didAutoFit = false;
+    }
     if (changedProperties.has('agents')) {
       const oldAgents = changedProperties.get('agents') as Agent[] | undefined;
       // Re-fit when agents arrive for the first time or when the project
@@ -515,6 +601,73 @@ export class ScionAgentTreeView extends LitElement {
     this.didAutoFit = false;
   }
 
+  private setOrientation(orientation: Orientation): void {
+    if (this.orientation === orientation) return;
+    this.orientation = orientation;
+    this.dispatchEvent(
+      new CustomEvent('orientation-change', {
+        detail: { orientation },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  // --- Keyboard shortcuts ---------------------------------------------------
+
+  /**
+   * True when the keydown originated from a text-entry or overlay context
+   * (inputs, textareas, selects, contenteditable, or anything inside a
+   * Shoelace dialog/dropdown/input) — shortcuts must never fire while the
+   * user is typing in the project filter or the quick-message dialog.
+   */
+  private isTextEntryTarget(e: KeyboardEvent): boolean {
+    for (const el of e.composedPath()) {
+      if (!(el instanceof HTMLElement)) continue;
+      const tag = el.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable) {
+        return true;
+      }
+      if (
+        tag === 'SL-INPUT' ||
+        tag === 'SL-TEXTAREA' ||
+        tag === 'SL-SELECT' ||
+        tag === 'SL-DIALOG' ||
+        tag === 'SL-DROPDOWN'
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private onKeyDown(e: KeyboardEvent): void {
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    if (this.isTextEntryTarget(e)) return;
+    switch (e.key) {
+      case 't':
+      case 'T':
+        this.setOrientation(this.orientation === 'vertical' ? 'horizontal' : 'vertical');
+        break;
+      case 'f':
+      case 'F':
+        if (this.contentW > 0 && this.contentH > 0) {
+          this.fitToView(this.contentW, this.contentH);
+        }
+        break;
+      case '+':
+      case '=':
+        this.zoomButtons(1.25);
+        break;
+      case '-':
+        this.zoomButtons(1 / 1.25);
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+  }
+
   // --- Hover lineage highlight ---------------------------------------------
 
   /**
@@ -577,17 +730,39 @@ export class ScionAgentTreeView extends LitElement {
 
   // --- Rendering ------------------------------------------------------------
 
+  private renderToolbar() {
+    return html`
+      <div class="toolbar">
+        <sl-switch
+          size="small"
+          ?checked=${this.showUsers}
+          @sl-change=${this.onShowUsersChange}
+        >Show users</sl-switch>
+        <div class="orientation-toggle" role="group" aria-label="Graph orientation">
+          <button
+            class=${this.orientation === 'vertical' ? 'active' : ''}
+            title="Vertical layout (T)"
+            @click=${() => this.setOrientation('vertical')}
+          >
+            <sl-icon name="diagram-3"></sl-icon>
+          </button>
+          <button
+            class=${this.orientation === 'horizontal' ? 'active' : ''}
+            title="Horizontal layout (T)"
+            @click=${() => this.setOrientation('horizontal')}
+          >
+            <sl-icon name="diagram-3" class="rotated"></sl-icon>
+          </button>
+        </div>
+      </div>
+    `;
+  }
+
   override render() {
     const agents = this.agents;
     if (agents.length === 0) {
       return html`
-        <div class="toolbar">
-          <sl-switch
-            size="small"
-            ?checked=${this.showUsers}
-            @sl-change=${this.onShowUsersChange}
-          >Show users</sl-switch>
-        </div>
+        ${this.renderToolbar()}
         <div class="empty-state">
           <sl-icon name="diagram-3"></sl-icon>
           <p>No agents to display.</p>
@@ -598,9 +773,13 @@ export class ScionAgentTreeView extends LitElement {
     const forest = buildLineageForest(agents);
     const hiddenCounts = descendantCounts(forest);
     pruneCollapsed(forest, this.collapsedIds);
-    const { nodes, edges, users, width, height } = this.showUsers
-      ? layoutForestWithUsers(forest)
-      : layoutForest(forest);
+    let layout = this.showUsers ? layoutForestWithUsers(forest) : layoutForest(forest);
+    if (this.orientation === 'horizontal') {
+      layout = transposeLayout(layout);
+    }
+    const { nodes, edges, users, width, height } = layout;
+    this.contentW = width;
+    this.contentH = height;
     const related = this.relatedIds(agents);
 
     // First render with content: center on the deep-linked agent if there is
@@ -633,13 +812,7 @@ export class ScionAgentTreeView extends LitElement {
     }
 
     return html`
-      <div class="toolbar">
-        <sl-switch
-          size="small"
-          ?checked=${this.showUsers}
-          @sl-change=${this.onShowUsersChange}
-        >Show users</sl-switch>
-      </div>
+      ${this.renderToolbar()}
       <div
         class="canvas"
         @pointerdown=${this.onPointerDown}
@@ -657,9 +830,9 @@ export class ScionAgentTreeView extends LitElement {
           ${nodes.map(n => this.renderNode(n, related, hiddenCounts))}
         </div>
         <div class="zoom-controls">
-          <sl-button size="small" @click=${() => this.zoomButtons(1.25)} title="Zoom in">+</sl-button>
-          <sl-button size="small" @click=${() => this.zoomButtons(1 / 1.25)} title="Zoom out">−</sl-button>
-          <sl-button size="small" @click=${() => this.fitToView(width, height)} title="Fit to view">Fit</sl-button>
+          <sl-button size="small" @click=${() => this.zoomButtons(1.25)} title="Zoom in (+)">+</sl-button>
+          <sl-button size="small" @click=${() => this.zoomButtons(1 / 1.25)} title="Zoom out (−)">−</sl-button>
+          <sl-button size="small" @click=${() => this.fitToView(width, height)} title="Fit to view (F)">Fit</sl-button>
         </div>
       </div>
 
@@ -699,18 +872,32 @@ export class ScionAgentTreeView extends LitElement {
   private renderEdge(e: PositionedEdge, related: Set<string> | null) {
     const lit = related !== null && related.has(e.parentId) && related.has(e.childId);
     const dim = related !== null && !lit;
-    const midY = (e.y1 + e.y2) / 2;
-    // End with a short straight vertical segment so the arrowhead always
-    // points straight down. The stroke stops at the arrowhead's BASE — the
-    // marker (refX near 0) extends past the path end so the stroke can never
-    // poke out beyond the triangle's tip. The tip lands exactly on the
-    // card's top edge (y2): touching, but never hidden under the card.
-    const yEnd = e.y2 - 6.5;
-    const yApproach = yEnd - 4;
     return svg`<path
       class="edge ${lit ? 'lit' : ''} ${dim ? 'dim' : ''}"
-      d="M ${e.x1} ${e.y1} C ${e.x1} ${midY}, ${e.x2} ${midY}, ${e.x2} ${yApproach} L ${e.x2} ${yEnd}"
+      d=${this.edgePath(e)}
     />`;
+  }
+
+  /**
+   * Cubic sweep between the layout's edge anchors, finished with a short
+   * straight run-in so the arrowhead always points along the flow axis.
+   * Vertical: parent bottom-center → child top-center; horizontal: parent
+   * right-edge-center → child left-edge-center. The stroke stops at the
+   * arrowhead's BASE — the marker (refX near 0) extends past the path end so
+   * the stroke can never poke out beyond the triangle's tip, which lands
+   * exactly on the card's edge: touching, but never hidden under the card.
+   */
+  private edgePath(e: PositionedEdge): string {
+    if (this.orientation === 'horizontal') {
+      const midX = (e.x1 + e.x2) / 2;
+      const xEnd = e.x2 - 6.5;
+      const xApproach = xEnd - 4;
+      return `M ${e.x1} ${e.y1} C ${midX} ${e.y1}, ${midX} ${e.y2}, ${xApproach} ${e.y2} L ${xEnd} ${e.y2}`;
+    }
+    const midY = (e.y1 + e.y2) / 2;
+    const yEnd = e.y2 - 6.5;
+    const yApproach = yEnd - 4;
+    return `M ${e.x1} ${e.y1} C ${e.x1} ${midY}, ${e.x2} ${midY}, ${e.x2} ${yApproach} L ${e.x2} ${yEnd}`;
   }
 
   private toggleCollapse(agentId: string, e: Event): void {
@@ -782,7 +969,7 @@ export class ScionAgentTreeView extends LitElement {
         ` : nothing}
         ${descendants > 0 ? html`
           <button
-            class="collapse-chip"
+            class="collapse-chip ${this.orientation === 'horizontal' ? 'horizontal' : ''}"
             title=${collapsed ? `Expand ${descendants} hidden agent${descendants === 1 ? '' : 's'}` : 'Collapse subtree'}
             @click=${(e: Event) => this.toggleCollapse(agent.id, e)}
           >${collapsed ? `+${descendants}` : '−'}</button>

--- a/web/src/components/shared/agent-tree-view.ts
+++ b/web/src/components/shared/agent-tree-view.ts
@@ -642,6 +642,7 @@ export class ScionAgentTreeView extends LitElement {
   }
 
   private onKeyDown(e: KeyboardEvent): void {
+    if (!this.isConnected) return;
     if (e.metaKey || e.ctrlKey || e.altKey) return;
     if (this.isTextEntryTarget(e)) return;
     switch (e.key) {

--- a/web/src/shared/lineage.test.ts
+++ b/web/src/shared/lineage.test.ts
@@ -23,11 +23,14 @@ import {
   parentIdOf,
   pruneCollapsed,
   rootUserOf,
+  transposeLayout,
   userKey,
   NODE_W,
   NODE_H,
   GAP_X,
   GAP_Y,
+  H_GAP_X,
+  H_GAP_Y,
   PAD,
 } from './lineage.js';
 import type { Agent } from './types.js';
@@ -228,5 +231,91 @@ describe('layoutForestWithUsers', () => {
     expect(users.map(u => u.id)).toEqual(['user-1']);
     expect(nodes.map(n => n.agent.id).sort()).toEqual(['a1', 'u1']);
     expect(edges.filter(e => e.childId === 'u1')).toHaveLength(0);
+  });
+});
+
+describe('transposeLayout', () => {
+  it('maps depth to columns and leaf slots to rows', () => {
+    const parent = agent('p1', 'parent', ['user-1']);
+    const left = agent('l1', 'a-left', ['user-1', 'p1']);
+    const right = agent('r1', 'b-right', ['user-1', 'p1']);
+
+    const layout = transposeLayout(layoutForest(buildLineageForest([parent, left, right])));
+    const byId = new Map(layout.nodes.map(n => [n.agent.id, n]));
+
+    // Depth → x: root in the leftmost column, children one column right.
+    expect(byId.get('p1')!.px).toBe(PAD);
+    expect(byId.get('l1')!.px).toBe(PAD + NODE_W + H_GAP_X);
+    expect(byId.get('r1')!.px).toBe(PAD + NODE_W + H_GAP_X);
+
+    // Leaf slot → y: siblings stack, parent vertically centered between them.
+    expect(byId.get('l1')!.py).toBe(PAD);
+    expect(byId.get('r1')!.py).toBe(PAD + NODE_H + H_GAP_Y);
+    expect(byId.get('p1')!.py).toBe((byId.get('l1')!.py + byId.get('r1')!.py) / 2);
+  });
+
+  it('connects parent right-edge-center to child left-edge-center', () => {
+    const parent = agent('p1', 'parent', ['user-1']);
+    const left = agent('l1', 'a-left', ['user-1', 'p1']);
+    const right = agent('r1', 'b-right', ['user-1', 'p1']);
+
+    const layout = transposeLayout(layoutForest(buildLineageForest([parent, left, right])));
+    const byId = new Map(layout.nodes.map(n => [n.agent.id, n]));
+
+    expect(layout.edges).toHaveLength(2);
+    expect(layout.edges.map(e => `${e.parentId}->${e.childId}`).sort()).toEqual([
+      'p1->l1',
+      'p1->r1',
+    ]);
+    for (const e of layout.edges) {
+      const p = byId.get(e.parentId)!;
+      const c = byId.get(e.childId)!;
+      expect(e.x1).toBe(p.px + NODE_W);
+      expect(e.y1).toBe(p.py + NODE_H / 2);
+      expect(e.x2).toBe(c.px);
+      expect(e.y2).toBe(c.py + NODE_H / 2);
+      expect(e.x2).toBeGreaterThan(e.x1);
+    }
+  });
+
+  it('reports canvas size that bounds all nodes', () => {
+    const root = agent('r1', 'root', ['user-1']);
+    const mid = agent('m1', 'mid', ['user-1', 'r1']);
+    const leafA = agent('la', 'leaf-a', ['user-1', 'r1', 'm1']);
+    const leafB = agent('lb', 'leaf-b', ['user-1', 'r1', 'm1']);
+    const solo = agent('s1', 'solo', ['user-2']);
+
+    const layout = transposeLayout(layoutForest(buildLineageForest([root, mid, leafA, leafB, solo])));
+    for (const n of layout.nodes) {
+      expect(n.px).toBeGreaterThanOrEqual(PAD);
+      expect(n.py).toBeGreaterThanOrEqual(PAD);
+      expect(n.px + NODE_W).toBeLessThanOrEqual(layout.width);
+      expect(n.py + NODE_H).toBeLessThanOrEqual(layout.height);
+    }
+    // Three depth levels → the deepest column ends exactly PAD short of width.
+    expect(layout.width).toBe(PAD * 2 + 3 * NODE_W + 2 * H_GAP_X);
+  });
+
+  it('puts the user column on the left, centered across its roots', () => {
+    const a = agent('a1', 'alpha', ['user-1']);
+    const b = agent('b1', 'beta', ['user-1']);
+
+    const layout = transposeLayout(layoutForestWithUsers(buildLineageForest([a, b])));
+    const byId = new Map(layout.nodes.map(n => [n.agent.id, n]));
+
+    expect(layout.users).toHaveLength(1);
+    const u = layout.users[0];
+    expect(u.px).toBe(PAD);
+    expect(byId.get('a1')!.px).toBe(PAD + NODE_W + H_GAP_X);
+    expect(byId.get('b1')!.px).toBe(PAD + NODE_W + H_GAP_X);
+    expect(u.py).toBe((byId.get('a1')!.py + byId.get('b1')!.py) / 2);
+
+    // User → root edges leave the user card's right edge.
+    const uEdges = layout.edges.filter(e => e.parentId === userKey('user-1'));
+    expect(uEdges.map(e => e.childId).sort()).toEqual(['a1', 'b1']);
+    for (const e of uEdges) {
+      expect(e.x1).toBe(u.px + NODE_W);
+      expect(e.y1).toBe(u.py + NODE_H / 2);
+    }
   });
 });

--- a/web/src/shared/lineage.ts
+++ b/web/src/shared/lineage.ts
@@ -71,6 +71,17 @@ export const GAP_X = 24;
 export const GAP_Y = 52;
 export const PAD = 24;
 
+/** Graph flow direction: vertical = top→down (default), horizontal = left→right. */
+export type Orientation = 'vertical' | 'horizontal';
+
+/**
+ * Horizontal-orientation spacing. Cards keep their 180×76 size, so the
+ * along-depth gap between columns must clear the wide edge curves (cards are
+ * wider than tall), while sibling rows can pack tighter.
+ */
+export const H_GAP_X = 64;
+export const H_GAP_Y = 24;
+
 /** Edge/hover key for a user node, distinct from any agent ID. */
 export function userKey(userId: string): string {
   return `user:${userId}`;
@@ -294,4 +305,70 @@ export function layoutForestWithUsers(roots: LineageNode[]): ForestLayout {
   }
 
   return { ...base, edges, users };
+}
+
+/**
+ * Transposes a vertical layout (from layoutForest / layoutForestWithUsers)
+ * into a horizontal one: depth maps to the x axis (roots on the left, depth
+ * increases to the right) and leaf slots stack vertically. Cards keep their
+ * NODE_W×NODE_H size — only positions change — so the column pitch uses
+ * NODE_W + H_GAP_X and the row pitch NODE_H + H_GAP_Y. Edges are recomputed
+ * from the transposed node positions: parent right-edge-center → child
+ * left-edge-center. User nodes end up in the leftmost column, vertically
+ * centered across their group's roots.
+ *
+ * The vertical layout is the single source of truth for the tidy-tree
+ * algorithm; this helper only recovers the abstract (slot, depth) coordinates
+ * from the vertical pixel grid and re-projects them.
+ */
+export function transposeLayout(layout: ForestLayout): ForestLayout {
+  const slotOf = (px: number) => (px - PAD) / (NODE_W + GAP_X);
+  const depthOf = (py: number) => (py - PAD) / (NODE_H + GAP_Y);
+  const hx = (depth: number) => PAD + depth * (NODE_W + H_GAP_X);
+  const hy = (slot: number) => PAD + slot * (NODE_H + H_GAP_Y);
+
+  const nodes: PositionedNode[] = layout.nodes.map(n => ({
+    agent: n.agent,
+    px: hx(depthOf(n.py)),
+    py: hy(slotOf(n.px)),
+  }));
+  const users: PositionedUser[] = layout.users.map(u => ({
+    id: u.id,
+    px: hx(depthOf(u.py)),
+    py: hy(slotOf(u.px)),
+  }));
+
+  const posByKey = new Map<string, { px: number; py: number }>();
+  for (const n of nodes) posByKey.set(n.agent.id, n);
+  for (const u of users) posByKey.set(userKey(u.id), u);
+
+  const edges: PositionedEdge[] = [];
+  for (const e of layout.edges) {
+    const parent = posByKey.get(e.parentId);
+    const child = posByKey.get(e.childId);
+    if (!parent || !child) continue;
+    edges.push({
+      x1: parent.px + NODE_W,
+      y1: parent.py + NODE_H / 2,
+      x2: child.px,
+      y2: child.py + NODE_H / 2,
+      parentId: e.parentId,
+      childId: e.childId,
+    });
+  }
+
+  let maxX = 0;
+  let maxY = 0;
+  for (const p of posByKey.values()) {
+    maxX = Math.max(maxX, p.px + NODE_W);
+    maxY = Math.max(maxY, p.py + NODE_H);
+  }
+
+  return {
+    nodes,
+    edges,
+    users,
+    width: (posByKey.size > 0 ? maxX : PAD + NODE_W) + PAD,
+    height: (posByKey.size > 0 ? maxY : PAD + NODE_H) + PAD,
+  };
 }


### PR DESCRIPTION
Adds a left→right layout mode and keyboard shortcuts to `<scion-agent-tree-view>` (graph page, agents page, project detail).

### Horizontal layout
- New `orientation` property: `'vertical'` (default, unchanged) | `'horizontal'` (roots on the left, depth increases rightward, siblings stack vertically at a tighter pitch — cards keep their 180×76 size).
- Implemented as an additive `transposeLayout()` helper over the existing tidy layout — no changes to `layoutForest`/`layoutForestWithUsers` signatures or behavior.
- Edges run parent right-edge-center → child left-edge-center with the same arrowhead geometry as vertical (stroke stops at the arrowhead's base, tip touches the card edge, straight run-in keeps the arrow axis-aligned).
- Collapse chip moves to the card's right edge; the "Show users" column sits to the left of its trees.
- Segmented toolbar toggle reusing the registered `diagram-3` icon rotated −90° (Bootstrap Icons has no left→right tree glyph, so no new icon registration needed).
- The standalone `/agents/graph` page persists the choice as `?dir=horizontal` (absent = vertical), same pattern as `?project=`.

### Keyboard shortcuts
`T` transpose orientation · `F` fit to view · `+`/`=` zoom in · `-` zoom out

Single window listener, removed on disconnect. Ignored when a modifier is held or while typing in inputs/textareas/selects/contenteditable or inside Shoelace dialogs/dropdowns (checked via `composedPath`), so the project filter and quick-message dialog are unaffected. Button tooltips document the keys.

### Tests
- `transposeLayout`: column/row mapping, edge endpoints, canvas bounds, user-column placement.
- Keyboard handler DOM tests: toggle + event dispatch, modifier/typing-context ignores, zoom math, listener cleanup.
- Suite: 134 tests green; typecheck and production build clean.

> Note: stacked on #1013 (first commit here is that fix — the horizontal edge geometry builds on it). Happy to rebase once it lands.