### PR TITLE
feat: allow git remote override in project clone

### DIFF
--- a/cmd/project_clone.go
+++ b/cmd/project_clone.go
@@ -25,9 +25,10 @@ import (
 )
 
 var (
-	cloneProjectName string
-	cloneProjectSlug string
-	cloneAsTemplate  bool
+	cloneProjectName      string
+	cloneProjectSlug      string
+	cloneAsTemplate       bool
+	cloneProjectGitRemote string
 )
 
 var projectCloneCmd = &cobra.Command{
@@ -84,6 +85,7 @@ Requires Hub connectivity.`,
 			Name:       name,
 			Slug:       cloneProjectSlug,
 			AsTemplate: cloneAsTemplate,
+			GitRemote:  cloneProjectGitRemote,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to clone project: %w", err)
@@ -112,5 +114,6 @@ func init() {
 	projectCloneCmd.Flags().StringVar(&cloneProjectName, "name", "", "Name for the cloned project (default: \"<source> copy\")")
 	projectCloneCmd.Flags().StringVar(&cloneProjectSlug, "slug", "", "Explicit slug for the cloned project (default: auto-generated from name)")
 	projectCloneCmd.Flags().BoolVar(&cloneAsTemplate, "as-template", false, "Mark the cloned project as a template (admin-only)")
+	projectCloneCmd.Flags().StringVar(&cloneProjectGitRemote, "git-remote", "", "Override the git remote URL for the cloned project")
 	projectCmd.AddCommand(projectCloneCmd)
 }

--- a/pkg/hub/project_clone.go
+++ b/pkg/hub/project_clone.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/GoogleCloudPlatform/scion/pkg/util"
 )
 
 // CloneProjectRequest is the request body for POST /api/v1/projects/{id}/clone.
@@ -32,6 +33,7 @@ type CloneProjectRequest struct {
 	Name       string `json:"name"`                 // required
 	Slug       string `json:"slug"`                 // optional explicit slug override
 	AsTemplate bool   `json:"asTemplate,omitempty"` // mark clone as template
+	GitRemote  string `json:"gitRemote,omitempty"`  // override source git remote
 }
 
 // handleProjectClone clones a project's configuration into a new project.
@@ -127,6 +129,12 @@ func (s *Server) handleProjectClone(w http.ResponseWriter, r *http.Request, proj
 		OwnerID:                callerID,
 		SharedDirs:             src.SharedDirs,
 		GitIdentity:            src.GitIdentity,
+	}
+
+	// Allow callers to override the git remote (e.g. creating from a template
+	// with a different repository).
+	if req.GitRemote != "" {
+		clone.GitRemote = util.NormalizeGitRemote(req.GitRemote)
 	}
 
 	// Copy annotations: only keys in projectSettingKeys, preserving null semantics

--- a/pkg/hub/project_clone_test.go
+++ b/pkg/hub/project_clone_test.go
@@ -320,6 +320,40 @@ func TestProjectClone_HappyPath(t *testing.T) {
 	assert.Equal(t, "my-template", cloneTpls.Items[0].Slug)
 }
 
+func TestProjectClone_GitRemoteOverride(t *testing.T) {
+	srv, s := testServer(t)
+	src := createSourceProject(t, srv, s)
+
+	overrideURL := "https://github.com/other-org/other-repo.git"
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+src.ID+"/clone",
+		map[string]interface{}{"name": "Override Remote", "gitRemote": overrideURL})
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var clone store.Project
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&clone))
+
+	// The clone should have the overridden git remote (normalized), not the source's
+	assert.NotEqual(t, src.GitRemote, clone.GitRemote)
+	// NormalizeGitRemote strips scheme and .git suffix
+	assert.Equal(t, "github.com/other-org/other-repo", clone.GitRemote)
+}
+
+func TestProjectClone_NoGitRemoteOverride(t *testing.T) {
+	srv, s := testServer(t)
+	src := createSourceProject(t, srv, s)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+src.ID+"/clone",
+		map[string]interface{}{"name": "No Override"})
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var clone store.Project
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&clone))
+
+	// Without override, the clone should keep the source's git remote
+	assert.Equal(t, src.GitRemote, clone.GitRemote)
+}
+
 func TestProjectClone_UnsetAnnotations(t *testing.T) {
 	srv, s := testServer(t)
 	ctx := context.Background()

--- a/pkg/hubclient/types.go
+++ b/pkg/hubclient/types.go
@@ -617,6 +617,7 @@ type CloneProjectRequest struct {
 	Name       string `json:"name"`                 // required
 	Slug       string `json:"slug,omitempty"`       // optional explicit slug override
 	AsTemplate bool   `json:"asTemplate,omitempty"` // mark clone as template
+	GitRemote  string `json:"gitRemote,omitempty"`  // override source git remote
 }
 
 // HarnessConfigData holds harness-specific configuration.

--- a/web/src/components/pages/project-create.ts
+++ b/web/src/components/pages/project-create.ts
@@ -112,6 +112,9 @@ export class ScionPageProjectCreate extends LitElement {
   @state()
   private templatesLoading = false;
 
+  @state()
+  private templateGitRemote = '';
+
   private pathCheckTimer: ReturnType<typeof setTimeout> | null = null;
 
   override connectedCallback(): void {
@@ -552,7 +555,10 @@ export class ScionPageProjectCreate extends LitElement {
         const response = await apiFetch(`/api/v1/projects/${this.selectedTemplateId}/clone`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: this.name.trim() }),
+          body: JSON.stringify({
+            name: this.name.trim(),
+            ...(this.templateGitRemote ? { gitRemote: this.templateGitRemote } : {}),
+          }),
         });
         if (!response.ok) {
           const errorText = await extractApiError(response, 'Failed to create project from template');
@@ -821,6 +827,17 @@ export class ScionPageProjectCreate extends LitElement {
                       : this.templates.map(t => html`<sl-option value=${t.id}>${t.name}</sl-option>`)}
                   </sl-select>
                   `}
+                </div>
+                <div class="form-field">
+                  <label>Git Remote URL (optional)</label>
+                  <sl-input
+                    placeholder="https://github.com/org/repo.git"
+                    .value=${this.templateGitRemote}
+                    @sl-input=${(e: Event) => { this.templateGitRemote = (e.target as HTMLElement & {value: string}).value; }}
+                  ></sl-input>
+                  <div class="hint">
+                    Override the git remote from the template. Leave blank to use the template's default.
+                  </div>
                 </div>
               `
             : nothing}

--- a/web/src/components/pages/project-create.ts
+++ b/web/src/components/pages/project-create.ts
@@ -447,6 +447,8 @@ export class ScionPageProjectCreate extends LitElement {
     this.mode = (e.target as HTMLElement & { value: string }).value as ProjectMode;
     if (this.mode === 'template') {
       void this.loadTemplates();
+    } else {
+      this.templateGitRemote = '';
     }
   }
 


### PR DESCRIPTION
Add optional gitRemote field to CloneProjectRequest so users can override the git URL when creating a project from a template. Lets templates carry configuration while the user supplies their own repository.

Changes:
- Backend: GitRemote field on CloneProjectRequest, override via NormalizeGitRemote after clone struct build
- Tests: 2 new cases (with/without override), all 18 clone tests pass
- SDK/CLI: GitRemote in hubclient types, --git-remote CLI flag
- Frontend: optional git URL input in From Template mode, cleared on mode switch

ptone/scion#784