### PR TITLE
feat(cli): add scion hub shadow command for remote project access

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -181,6 +181,11 @@ _Avoid_: hub-native, hub-native project, hub workspace, hub-project, hosted proj
 A project whose workspace is a pre-existing path on a broker machine, linked to a Hub for cross-broker visibility — as opposed to a Hub-managed project. May be plain or git-backed.
 _Avoid_: local project, imported project, registered project
 
+**Shadowed project**:
+A local directory associated with a Hub project purely for CLI routing, with no workspace content, no provider registration, and no broker involvement — as opposed to a *Linked project*, whose workspace is a real pre-existing path on a broker machine.
+_Avoid_: linked, mounted, cloned
+_See also_: Hub-managed project
+
 **Server**:
 The `scion server` command group, and the single combined process it manages — one or more server components run together as a background daemon (or with `--foreground`) via `start`/`stop`/`restart`/`status`.
 _Avoid_: daemon, service, backend

--- a/cmd/hub_shadow.go
+++ b/cmd/hub_shadow.go
@@ -245,7 +245,22 @@ func runHubUnshadow(cmd *cobra.Command, args []string) error {
 
 	util.Debugf("Removed shadow marker for project %s (ID: %s)", marker.ProjectName, marker.ProjectID)
 
+	// Clean up the settings directory under ~/.scion/project-configs/<slug>__<shortuuid>/
+	settingsCleaned := false
+	home, homeErr := os.UserHomeDir()
+	if homeErr == nil && home != "" {
+		configDir := filepath.Join(home, config.GlobalDir, config.ProjectConfigsDir, marker.DirName())
+		if err := os.RemoveAll(configDir); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not remove settings directory %s: %v\n", configDir, err)
+		} else {
+			settingsCleaned = true
+		}
+	}
+
 	fmt.Printf("Removed shadow for project '%s' from this directory.\n", marker.ProjectName)
+	if settingsCleaned {
+		fmt.Println("Local settings directory cleaned up.")
+	}
 	fmt.Println("The project and its agents remain on the Hub.")
 
 	return nil

--- a/cmd/hub_shadow.go
+++ b/cmd/hub_shadow.go
@@ -1,0 +1,252 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/credentials"
+	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
+	"github.com/GoogleCloudPlatform/scion/pkg/hubsync"
+	"github.com/GoogleCloudPlatform/scion/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// hubShadowCmd creates a local shadow of a remote hub project.
+var hubShadowCmd = &cobra.Command{
+	Use:   "shadow <project-ref>",
+	Short: "Shadow a Hub project in the current directory",
+	Long: `Create a local shadow of a Hub project in the current directory.
+
+A shadowed project is a directory linked to a Hub project purely for CLI
+routing — no workspace content, no provider registration, and no broker
+involvement. It allows running commands like 'scion list', 'scion look',
+and 'scion attach' against hub-managed agents from any workstation.
+
+The <project-ref> can be a project slug, UUID, or git URL.
+
+Examples:
+  # Shadow by slug
+  scion hub shadow my-project
+
+  # Shadow by UUID
+  scion hub shadow 1dfdd6c7-f077-4acd-bde2-978d12f34f9a
+
+  # Shadow by git URL
+  scion hub shadow https://github.com/example/repo.git
+
+  # Shadow with a specific hub endpoint
+  scion hub shadow my-project --hub https://hub.example.com`,
+	Args: cobra.ExactArgs(1),
+	RunE: runHubShadow,
+}
+
+// hubUnshadowCmd removes the shadow link from the current directory.
+var hubUnshadowCmd = &cobra.Command{
+	Use:   "unshadow",
+	Short: "Remove the Hub shadow from the current directory",
+	Long: `Remove the shadow link from the current directory.
+
+This removes the .scion marker file, disconnecting this directory from
+the Hub project. Only works if the current directory is a shadowed project.
+
+Examples:
+  # Remove the shadow
+  scion hub unshadow`,
+	RunE: runHubUnshadow,
+}
+
+func init() {
+	hubCmd.AddCommand(hubShadowCmd)
+	hubCmd.AddCommand(hubUnshadowCmd)
+}
+
+func runHubShadow(cmd *cobra.Command, args []string) error {
+	projectRef := args[0]
+
+	// Check if .scion already exists in the current directory.
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+	dotScionPath := filepath.Join(wd, config.DotScion)
+	if info, err := os.Stat(dotScionPath); err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("this directory is already a Scion project (has a .scion directory).\n" +
+				"Use 'scion hub link' to link an existing project to the Hub")
+		}
+		// .scion is a file — check if it's a shadow marker (idempotent replace per D2).
+		marker, mErr := config.ReadProjectMarker(dotScionPath)
+		if mErr != nil || !marker.IsShadow() {
+			return fmt.Errorf("this directory already has a .scion marker file for a non-shadow project.\n" +
+				"Remove it first or use a different directory")
+		}
+		// Existing shadow marker — will be replaced below.
+	}
+
+	// Load settings from global (or whatever fallback is available) to get hub config.
+	fallbackPath, _, err := config.ResolveProjectPath("")
+	if err != nil {
+		// No project found — try loading global settings directly.
+		home, homeErr := os.UserHomeDir()
+		if homeErr != nil {
+			return fmt.Errorf("failed to find home directory: %w", homeErr)
+		}
+		fallbackPath = filepath.Join(home, config.GlobalDir)
+	}
+
+	settings, err := config.LoadSettings(fallbackPath)
+	if err != nil {
+		// Create minimal settings to work with --hub flag
+		settings = &config.Settings{}
+	}
+
+	// Determine hub endpoint
+	endpoint := GetHubEndpoint(settings)
+	if hubEndpoint != "" {
+		endpoint = hubEndpoint
+	}
+	if endpoint == "" {
+		return fmt.Errorf("hub endpoint not configured.\n\n" +
+			"Configure via:\n" +
+			"  scion hub shadow <project> --hub <url>\n" +
+			"  scion config set hub.endpoint <url>\n" +
+			"  SCION_HUB_ENDPOINT=<url>")
+	}
+
+	// Verify authentication
+	authInfo := getAuthInfo(settings, endpoint)
+	if authInfo.MethodType == "none" {
+		// Also check credentials directly for the endpoint
+		if !credentials.IsAuthenticated(endpoint) {
+			return fmt.Errorf("not authenticated to Hub at %s\n\nPlease log in first:\n  scion hub auth login --hub %s", endpoint, endpoint)
+		}
+	}
+
+	// Create Hub client
+	client, err := getHubClient(settings)
+	if err != nil {
+		return fmt.Errorf("failed to create Hub client: %w", err)
+	}
+
+	// Health check
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	if _, err := client.Health(ctx); err != nil {
+		return fmt.Errorf("hub at %s is not responding: %w", endpoint, hubclient.HintProxyError(err))
+	}
+
+	// Resolve the project on the hub
+	project, err := hubsync.ResolveProjectOnHub(ctx, client, projectRef)
+	if err != nil {
+		return err
+	}
+
+	// Determine the slug — use the hub's slug if available, otherwise generate one.
+	slug := project.Slug
+	if slug == "" {
+		slug = api.Slugify(project.Name)
+	}
+
+	// Write the .scion marker file with type: shadow
+	marker := &config.ProjectMarker{
+		ProjectID:   project.ID,
+		ProjectName: project.Name,
+		ProjectSlug: slug,
+		Type:        "shadow",
+	}
+	if err := config.WriteProjectMarker(dotScionPath, marker); err != nil {
+		return fmt.Errorf("failed to write project marker: %w", err)
+	}
+
+	// Create the external project-config directory with settings
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to find home directory: %w", err)
+	}
+
+	configDir := filepath.Join(home, config.GlobalDir, config.ProjectConfigsDir, marker.DirName(), config.DotScion)
+	hubEnabled := true
+	vs := &config.VersionedSettings{
+		SchemaVersion: "1",
+		ProjectType:   string(config.ProjectTypeShadow),
+		Hub: &config.V1HubClientConfig{
+			Enabled:   &hubEnabled,
+			Endpoint:  endpoint,
+			ProjectID: project.ID,
+		},
+	}
+	if err := config.SaveVersionedSettings(configDir, vs); err != nil {
+		// Clean up the marker file on failure
+		_ = os.Remove(dotScionPath)
+		return fmt.Errorf("failed to write project config: %w", err)
+	}
+
+	fmt.Printf("Shadowed project '%s' (slug: %s) from hub at %s\n", project.Name, slug, endpoint)
+	fmt.Println("\nYou can now use commands like:")
+	fmt.Println("  scion list          - List agents")
+	fmt.Println("  scion look <agent>  - View agent output")
+	fmt.Println("  scion attach <agent> - Attach to agent")
+	fmt.Println("\nTo remove the shadow: scion hub unshadow")
+
+	return nil
+}
+
+func runHubUnshadow(cmd *cobra.Command, args []string) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	dotScionPath := filepath.Join(wd, config.DotScion)
+	info, err := os.Stat(dotScionPath)
+	if err != nil {
+		return fmt.Errorf("no .scion marker found in the current directory")
+	}
+
+	if info.IsDir() {
+		return fmt.Errorf("this directory is a full Scion project, not a shadow.\n" +
+			"Use 'scion hub unlink' to unlink from the Hub")
+	}
+
+	marker, err := config.ReadProjectMarker(dotScionPath)
+	if err != nil {
+		return fmt.Errorf("failed to read .scion marker: %w", err)
+	}
+
+	if !marker.IsShadow() {
+		return fmt.Errorf("this directory has a project marker but is not a shadow.\n" +
+			"Only shadow markers can be removed with 'hub unshadow'")
+	}
+
+	// Remove the marker file
+	if err := os.Remove(dotScionPath); err != nil {
+		return fmt.Errorf("failed to remove .scion marker: %w", err)
+	}
+
+	util.Debugf("Removed shadow marker for project %s (ID: %s)", marker.ProjectName, marker.ProjectID)
+
+	fmt.Printf("Removed shadow for project '%s' from this directory.\n", marker.ProjectName)
+	fmt.Println("The project and its agents remain on the Hub.")
+
+	return nil
+}

--- a/cmd/hub_shadow.go
+++ b/cmd/hub_shadow.go
@@ -87,6 +87,10 @@ func runHubShadow(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get working directory: %w", err)
 	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to find home directory: %w", err)
+	}
 	dotScionPath := filepath.Join(wd, config.DotScion)
 	if info, err := os.Stat(dotScionPath); err == nil {
 		if info.IsDir() {
@@ -106,10 +110,6 @@ func runHubShadow(cmd *cobra.Command, args []string) error {
 	fallbackPath, _, err := config.ResolveProjectPath("")
 	if err != nil {
 		// No project found — try loading global settings directly.
-		home, homeErr := os.UserHomeDir()
-		if homeErr != nil {
-			return fmt.Errorf("failed to find home directory: %w", homeErr)
-		}
 		fallbackPath = filepath.Join(home, config.GlobalDir)
 	}
 
@@ -179,16 +179,12 @@ func runHubShadow(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create the external project-config directory with settings
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("failed to find home directory: %w", err)
-	}
-
 	configDir := filepath.Join(home, config.GlobalDir, config.ProjectConfigsDir, marker.DirName(), config.DotScion)
 	hubEnabled := true
 	vs := &config.VersionedSettings{
 		SchemaVersion: "1",
 		ProjectType:   string(config.ProjectTypeShadow),
+		WorkspacePath: wd,
 		Hub: &config.V1HubClientConfig{
 			Enabled:   &hubEnabled,
 			Endpoint:  endpoint,
@@ -247,9 +243,9 @@ func runHubUnshadow(cmd *cobra.Command, args []string) error {
 
 	// Clean up the settings directory under ~/.scion/project-configs/<slug>__<shortuuid>/
 	settingsCleaned := false
-	home, homeErr := os.UserHomeDir()
-	if homeErr == nil && home != "" {
-		configDir := filepath.Join(home, config.GlobalDir, config.ProjectConfigsDir, marker.DirName())
+	globalDir, globalErr := config.GetGlobalDir()
+	if globalErr == nil && globalDir != "" {
+		configDir := filepath.Join(globalDir, config.ProjectConfigsDir, marker.DirName())
 		if err := os.RemoveAll(configDir); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: could not remove settings directory %s: %v\n", configDir, err)
 		} else {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,6 +91,12 @@ return an error instead of blocking.`,
 		case "init":
 			// Both top-level init and project init don't require existing project
 			requiresProject = false
+		case "shadow", "unshadow":
+			// hub shadow/unshadow create/remove the project marker — they must
+			// run in a directory with no existing project.
+			if parentName == "hub" {
+				requiresProject = false
+			}
 		case "scion":
 			// Root command itself doesn't require project
 			requiresProject = false
@@ -163,6 +169,12 @@ return an error instead of blocking.`,
 		}
 		if requiresRegistry && config.IsHubContext() {
 			requiresRegistry = false
+		}
+		// Shadow projects never launch containers locally — skip registry check.
+		if requiresRegistry {
+			if isShadowProject() {
+				requiresRegistry = false
+			}
 		}
 		if requiresRegistry {
 			if err := config.RequireImageRegistry(projectPath, profile); err != nil {
@@ -451,6 +463,33 @@ func usesWorktrees(cmd *cobra.Command) bool {
 		return true
 	}
 	return false
+}
+
+// isShadowProject returns true if the current directory is inside a shadowed
+// project (a directory linked to a hub project purely for CLI routing, with no
+// local workspace or broker involvement). It reads the .scion marker file from
+// the project root discovered via FindProjectRoot.
+func isShadowProject() bool {
+	root, found := config.FindProjectRoot()
+	if !found {
+		return false
+	}
+	// The marker file is the .scion regular file in the workspace directory,
+	// not the resolved external config path. Walk up from cwd to find it.
+	markerPath := config.FindProjectMarkerPath()
+	if markerPath == "" {
+		// Fallback: if root itself looks like an external config, we can't
+		// directly read the workspace marker. Check versioned settings instead.
+		if vs, err := config.LoadVersionedSettings(root); err == nil && vs != nil {
+			return vs.ProjectType == string(config.ProjectTypeShadow)
+		}
+		return false
+	}
+	marker, err := config.ReadProjectMarker(markerPath)
+	if err != nil {
+		return false
+	}
+	return marker.IsShadow()
 }
 
 // isLocalEndpoint returns true if the given endpoint URL points to a local address

--- a/pkg/config/paths.go
+++ b/pkg/config/paths.go
@@ -92,6 +92,30 @@ func FindProjectRoot() (string, bool) {
 	return "", false
 }
 
+// FindProjectMarkerPath walks up from the current working directory looking for a
+// .scion marker file (a regular file, not a directory). Returns the absolute path
+// to the marker file, or "" if none is found.
+func FindProjectMarkerPath() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	dir := wd
+	for {
+		p := filepath.Join(dir, DotScion)
+		info, err := os.Stat(p)
+		if err == nil && !info.IsDir() {
+			return p
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return ""
+}
+
 // GetResolvedProjectDir returns the active .scion directory based on precedence.
 // This is a convenience wrapper around ResolveProjectPath that discards the isGlobal flag.
 func GetResolvedProjectDir(explicitPath string) (string, error) {

--- a/pkg/config/paths.go
+++ b/pkg/config/paths.go
@@ -95,6 +95,11 @@ func FindProjectRoot() (string, bool) {
 // FindProjectMarkerPath walks up from the current working directory looking for a
 // .scion marker file (a regular file, not a directory). Returns the absolute path
 // to the marker file, or "" if none is found.
+//
+// The walk stops at the first .scion entry it encounters, regardless of type.
+// If the entry is a regular file, its path is returned. If it is a directory,
+// "" is returned immediately — this keeps the walk consistent with
+// FindProjectRoot, which also stops at the first .scion it finds.
 func FindProjectMarkerPath() string {
 	wd, err := os.Getwd()
 	if err != nil {
@@ -104,8 +109,11 @@ func FindProjectMarkerPath() string {
 	for {
 		p := filepath.Join(dir, DotScion)
 		info, err := os.Stat(p)
-		if err == nil && !info.IsDir() {
-			return p
+		if err == nil {
+			if !info.IsDir() {
+				return p // found a marker file
+			}
+			return "" // found a .scion directory — not a marker
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {

--- a/pkg/config/paths_test.go
+++ b/pkg/config/paths_test.go
@@ -559,6 +559,90 @@ func TestResolveProjectPath_ProjectNotGlobal(t *testing.T) {
 	}
 }
 
+func TestFindProjectMarkerPath_MarkerFile(t *testing.T) {
+	// Directory with .scion file -> returns path
+	tmpDir := t.TempDir()
+	markerPath := filepath.Join(tmpDir, DotScion)
+	_ = os.WriteFile(markerPath, []byte("project-id: test-id\nproject-slug: test\n"), 0644)
+
+	origWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origWd) }()
+	_ = os.Chdir(tmpDir)
+
+	got := FindProjectMarkerPath()
+	if got != markerPath {
+		t.Errorf("FindProjectMarkerPath() = %q, want %q", got, markerPath)
+	}
+}
+
+func TestFindProjectMarkerPath_Directory(t *testing.T) {
+	// Directory with .scion directory -> returns "" (the R1 fix)
+	tmpDir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(tmpDir, DotScion), 0755)
+
+	origWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origWd) }()
+	_ = os.Chdir(tmpDir)
+
+	got := FindProjectMarkerPath()
+	if got != "" {
+		t.Errorf("FindProjectMarkerPath() = %q, want empty string when .scion is a directory", got)
+	}
+}
+
+func TestFindProjectMarkerPath_WalkUpFindsParent(t *testing.T) {
+	// Walk-up: marker in parent dir, none in cwd -> returns parent path
+	parentDir := t.TempDir()
+	markerPath := filepath.Join(parentDir, DotScion)
+	_ = os.WriteFile(markerPath, []byte("project-id: test-id\nproject-slug: test\n"), 0644)
+
+	childDir := filepath.Join(parentDir, "subdir")
+	_ = os.MkdirAll(childDir, 0755)
+
+	origWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origWd) }()
+	_ = os.Chdir(childDir)
+
+	got := FindProjectMarkerPath()
+	if got != markerPath {
+		t.Errorf("FindProjectMarkerPath() = %q, want %q", got, markerPath)
+	}
+}
+
+func TestFindProjectMarkerPath_DirInCwdBlocksParentMarker(t *testing.T) {
+	// Walk-up: .scion dir in cwd, .scion file in parent -> returns "" (stops at dir)
+	parentDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(parentDir, DotScion), []byte("project-id: parent-id\nproject-slug: parent\n"), 0644)
+
+	childDir := filepath.Join(parentDir, "subdir")
+	_ = os.MkdirAll(filepath.Join(childDir, DotScion), 0755) // .scion directory in child
+
+	origWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origWd) }()
+	_ = os.Chdir(childDir)
+
+	got := FindProjectMarkerPath()
+	if got != "" {
+		t.Errorf("FindProjectMarkerPath() = %q, want empty string when .scion dir in cwd blocks walk-up to parent marker", got)
+	}
+}
+
+func TestFindProjectMarkerPath_NoScionAnywhere(t *testing.T) {
+	// No .scion anywhere -> returns ""
+	tmpDir := t.TempDir()
+	childDir := filepath.Join(tmpDir, "a", "b", "c")
+	_ = os.MkdirAll(childDir, 0755)
+
+	origWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origWd) }()
+	_ = os.Chdir(childDir)
+
+	got := FindProjectMarkerPath()
+	if got != "" {
+		t.Errorf("FindProjectMarkerPath() = %q, want empty string when no .scion exists", got)
+	}
+}
+
 func containsSubstring(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstringHelper(s, substr))
 }

--- a/pkg/config/project_discovery.go
+++ b/pkg/config/project_discovery.go
@@ -27,6 +27,7 @@ const (
 	ProjectTypeGlobal   ProjectType = "global"
 	ProjectTypeGit      ProjectType = "git"
 	ProjectTypeExternal ProjectType = "external"
+	ProjectTypeShadow   ProjectType = "shadow"
 )
 
 // ProjectStatus indicates the health of a project config.
@@ -200,11 +201,26 @@ func projectInfoFromGitExternalWithConfig(configPath, agentsDir, dirName, slug s
 		ConfigPath: configPath,
 		Status:     ProjectStatusOK,
 	}
-	pi.AgentCount = countAgents(agentsDir)
+
+	// Check if this is a shadow project via versioned settings.
+	// A shadowed project is never orphaned — it has no local agents by design.
+	if vs, vsErr := LoadVersionedSettings(configPath); vsErr == nil && vs != nil {
+		if vs.ProjectType == string(ProjectTypeShadow) {
+			if vs.Hub != nil && vs.Hub.ProjectID != "" {
+				pi.ProjectID = vs.Hub.ProjectID
+				pi.GroveID = vs.Hub.ProjectID
+			}
+			pi.Type = ProjectTypeShadow
+			pi.Status = ProjectStatusOK
+			return pi
+		}
+	}
+
 	if settings, err := LoadSettings(configPath); err == nil {
 		pi.ProjectID = settings.ProjectID
 		pi.GroveID = settings.ProjectID
 	}
+	pi.AgentCount = countAgents(agentsDir)
 	if pi.ProjectID == "" {
 		if marker, workspacePath, err := readWorkspaceMarkerForSlug(slug); err == nil {
 			pi.ProjectID = marker.ProjectID

--- a/pkg/config/project_discovery.go
+++ b/pkg/config/project_discovery.go
@@ -131,10 +131,14 @@ func scanConfigDir(projects []ProjectInfo, configDir string, seenSlugs map[strin
 		var pi ProjectInfo
 		switch {
 		case scionExists:
-			// .scion/ exists — distinguish external vs git by checking for
-			// a workspace_path in settings (external projects point back to
-			// their original project directory).
-			if settings, err := LoadSettings(configPath); err == nil && settings.WorkspacePath != "" {
+			// .scion/ exists — distinguish external vs git vs shadow.
+			// Shadow projects store workspace_path for orphan detection but
+			// are not external (non-git) projects; route them through the
+			// git-external handler which has shadow-aware logic.
+			if vs, vsErr := LoadVersionedSettings(configPath); vsErr == nil && vs != nil && vs.ProjectType == string(ProjectTypeShadow) {
+				agentsDir := filepath.Join(configPath, "agents")
+				pi = projectInfoFromGitExternalWithConfig(configPath, agentsDir, dirName, slug)
+			} else if settings, err := LoadSettings(configPath); err == nil && settings.WorkspacePath != "" {
 				pi = projectInfoFromExternal(configPath, dirName, slug)
 			} else {
 				agentsDir := filepath.Join(configPath, "agents")
@@ -203,7 +207,6 @@ func projectInfoFromGitExternalWithConfig(configPath, agentsDir, dirName, slug s
 	}
 
 	// Check if this is a shadow project via versioned settings.
-	// A shadowed project is never orphaned — it has no local agents by design.
 	if vs, vsErr := LoadVersionedSettings(configPath); vsErr == nil && vs != nil {
 		if vs.ProjectType == string(ProjectTypeShadow) {
 			if vs.Hub != nil && vs.Hub.ProjectID != "" {
@@ -211,7 +214,11 @@ func projectInfoFromGitExternalWithConfig(configPath, agentsDir, dirName, slug s
 				pi.GroveID = vs.Hub.ProjectID
 			}
 			pi.Type = ProjectTypeShadow
+			pi.WorkspacePath = vs.WorkspacePath
 			pi.Status = ProjectStatusOK
+			if vs.WorkspacePath == "" || !isValidWorkspace(vs.WorkspacePath, pi.ProjectID, configPath) {
+				pi.Status = ProjectStatusOrphaned
+			}
 			return pi
 		}
 	}

--- a/pkg/config/project_discovery_test.go
+++ b/pkg/config/project_discovery_test.go
@@ -404,6 +404,55 @@ func TestDiscoverProjects_StaleExternalAfterMarkerRecreate(t *testing.T) {
 	}
 }
 
+func TestDiscoverProjects_ShadowProjectNotOrphaned(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	_ = os.Setenv("HOME", tmpHome)
+	defer func() { _ = os.Setenv("HOME", origHome) }()
+
+	_ = os.MkdirAll(filepath.Join(tmpHome, ".scion"), 0755)
+
+	// Create a shadow project config directory with versioned settings
+	projectDir := filepath.Join(tmpHome, ".scion", "project-configs", "remote-proj__aabb1122")
+	scionDir := filepath.Join(projectDir, ".scion")
+	_ = os.MkdirAll(scionDir, 0755)
+
+	// Write versioned settings with project_type: shadow and hub config
+	settingsContent := `schema_version: "1"
+project_type: shadow
+hub:
+  enabled: true
+  endpoint: https://hub.example.com
+  project_id: aabb1122-0000-0000-0000-000000000000
+`
+	_ = os.WriteFile(filepath.Join(scionDir, "settings.yaml"), []byte(settingsContent), 0644)
+
+	projects, err := DiscoverProjects()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var shadow *ProjectInfo
+	for i := range projects {
+		if projects[i].Name == "remote-proj" {
+			shadow = &projects[i]
+			break
+		}
+	}
+	if shadow == nil {
+		t.Fatal("expected to find shadow project")
+	}
+	if shadow.Type != ProjectTypeShadow {
+		t.Errorf("expected type %q, got %q", ProjectTypeShadow, shadow.Type)
+	}
+	if shadow.Status != ProjectStatusOK {
+		t.Errorf("expected status %q for shadow project (should not be orphaned), got %q", ProjectStatusOK, shadow.Status)
+	}
+	if shadow.ProjectID != "aabb1122-0000-0000-0000-000000000000" {
+		t.Errorf("expected project ID from hub config, got %q", shadow.ProjectID)
+	}
+}
+
 func TestDiscoverProjects_GitProjectExternal(t *testing.T) {
 	tmpHome := t.TempDir()
 	origHome := os.Getenv("HOME")

--- a/pkg/config/project_discovery_test.go
+++ b/pkg/config/project_discovery_test.go
@@ -412,19 +412,24 @@ func TestDiscoverProjects_ShadowProjectNotOrphaned(t *testing.T) {
 
 	_ = os.MkdirAll(filepath.Join(tmpHome, ".scion"), 0755)
 
+	// Create a workspace directory with a valid shadow marker
+	workspaceDir := filepath.Join(tmpHome, "remote-proj")
+	_ = os.MkdirAll(workspaceDir, 0755)
+	marker := &ProjectMarker{
+		ProjectID:   "aabb1122-0000-0000-0000-000000000000",
+		ProjectName: "remote-proj",
+		ProjectSlug: "remote-proj",
+		Type:        "shadow",
+	}
+	_ = WriteProjectMarker(filepath.Join(workspaceDir, DotScion), marker)
+
 	// Create a shadow project config directory with versioned settings
 	projectDir := filepath.Join(tmpHome, ".scion", "project-configs", "remote-proj__aabb1122")
 	scionDir := filepath.Join(projectDir, ".scion")
 	_ = os.MkdirAll(scionDir, 0755)
 
-	// Write versioned settings with project_type: shadow and hub config
-	settingsContent := `schema_version: "1"
-project_type: shadow
-hub:
-  enabled: true
-  endpoint: https://hub.example.com
-  project_id: aabb1122-0000-0000-0000-000000000000
-`
+	// Write versioned settings with project_type: shadow, hub config, and workspace_path
+	settingsContent := "schema_version: \"1\"\nproject_type: shadow\nworkspace_path: " + workspaceDir + "\nhub:\n  enabled: true\n  endpoint: https://hub.example.com\n  project_id: aabb1122-0000-0000-0000-000000000000\n"
 	_ = os.WriteFile(filepath.Join(scionDir, "settings.yaml"), []byte(settingsContent), 0644)
 
 	projects, err := DiscoverProjects()

--- a/pkg/config/project_marker.go
+++ b/pkg/config/project_marker.go
@@ -32,6 +32,7 @@ type ProjectMarker struct {
 	ProjectID   string `yaml:"project-id"`
 	ProjectName string `yaml:"project-name"`
 	ProjectSlug string `yaml:"project-slug"`
+	Type        string `yaml:"type,omitempty"` // "shadow" for shadowed projects
 }
 
 // UnmarshalYAML implements custom unmarshaling to handle legacy "grove-" tags.
@@ -60,6 +61,11 @@ func (m *ProjectMarker) UnmarshalYAML(value *yaml.Node) error {
 		m.ProjectSlug = aux.GroveSlug
 	}
 	return nil
+}
+
+// IsShadow returns true if this marker represents a shadowed project.
+func (m *ProjectMarker) IsShadow() bool {
+	return m.Type == "shadow"
 }
 
 // ShortUUID returns a short form of the project ID for use in directory names.

--- a/pkg/config/project_marker_test.go
+++ b/pkg/config/project_marker_test.go
@@ -20,6 +20,31 @@ import (
 	"testing"
 )
 
+func TestProjectMarker_IsShadow(t *testing.T) {
+	tests := []struct {
+		name     string
+		typ      string
+		expected bool
+	}{
+		{"shadow type returns true", "shadow", true},
+		{"empty type returns false", "", false},
+		{"other type returns false", "other", false},
+		{"workspace type returns false", "workspace", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &ProjectMarker{
+				ProjectID:   "test-id",
+				ProjectSlug: "test",
+				Type:        tt.typ,
+			}
+			if got := m.IsShadow(); got != tt.expected {
+				t.Errorf("IsShadow() with Type=%q = %v, want %v", tt.typ, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestProjectMarker_ShortUUID(t *testing.T) {
 	tests := []struct {
 		projectID string

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -262,6 +262,7 @@ func PrintDeprecationWarnings(warnings []string) {
 // VersionedSettings is the root configuration struct for versioned settings (v1+).
 type VersionedSettings struct {
 	SchemaVersion        string                        `json:"schema_version" yaml:"schema_version" koanf:"schema_version"`
+	ProjectType          string                        `json:"project_type,omitempty" yaml:"project_type,omitempty" koanf:"project_type"`
 	ActiveProfile        string                        `json:"active_profile,omitempty" yaml:"active_profile,omitempty" koanf:"active_profile"`
 	DefaultTemplate      string                        `json:"default_template,omitempty" yaml:"default_template,omitempty" koanf:"default_template"`
 	DefaultHarnessConfig string                        `json:"default_harness_config,omitempty" yaml:"default_harness_config,omitempty" koanf:"default_harness_config"`

--- a/pkg/hubsync/resolve.go
+++ b/pkg/hubsync/resolve.go
@@ -153,8 +153,13 @@ func resolveHubProjectRef(ref string, opts EnsureHubReadyOptions) (*HubContext, 
 	return hubCtx, nil
 }
 
-// resolveProjectOnHub resolves a project reference on the hub, trying multiple
+// ResolveProjectOnHub resolves a project reference on the hub, trying multiple
 // strategies in order: UUID, git URL, slug, name.
+func ResolveProjectOnHub(ctx context.Context, client hubclient.Client, ref string) (*hubclient.Project, error) {
+	return resolveProjectOnHub(ctx, client, ref)
+}
+
+// resolveProjectOnHub is the internal implementation of ResolveProjectOnHub.
 func resolveProjectOnHub(ctx context.Context, client hubclient.Client, ref string) (*hubclient.Project, error) {
 	// 1. Try as UUID
 	if _, err := uuid.Parse(ref); err == nil {


### PR DESCRIPTION
## Summary

Adds scion hub shadow/unshadow commands for local directory links to remote hub projects, enabling workstation users to run scion list, scion look, and scion attach without a local broker.

- ProjectTypeShadow with marker and settings discriminator
- Gate exemptions for requiresProject and image_registry
- Orphan detection exclusion, unshadow settings cleanup
- 7 new unit tests, glossary entry

Ref: ptone/scion#791