### PR TITLE
feat(hub): add health monitoring dashboard, doctor checks, and alert policies

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -452,11 +452,18 @@ func checkDoctorBrokerConnectivity(hubEP string, hubConnected bool, client hubcl
 			Remediation: "Set SCION_HUB_ENDPOINT or use --hub flag",
 		}
 	}
-	if !hubConnected || client == nil {
+	if !hubConnected {
 		return scionruntime.CheckResult{
 			Name:    "broker-connectivity",
 			Status:  "skip",
-			Message: "Skipped (Hub connectivity check failed)",
+			Message: "Skipped (Hub unreachable)",
+		}
+	}
+	if client == nil {
+		return scionruntime.CheckResult{
+			Name:    "broker-connectivity",
+			Status:  "skip",
+			Message: "Skipped (Hub client not available)",
 		}
 	}
 
@@ -515,11 +522,18 @@ func checkDoctorAgentHealth(hubEP string, hubConnected bool, client hubclient.Cl
 			Remediation: "Set SCION_HUB_ENDPOINT or use --hub flag",
 		}
 	}
-	if !hubConnected || client == nil {
+	if !hubConnected {
 		return scionruntime.CheckResult{
 			Name:    "agent-health",
 			Status:  "skip",
-			Message: "Skipped (Hub connectivity check failed)",
+			Message: "Skipped (Hub unreachable)",
+		}
+	}
+	if client == nil {
+		return scionruntime.CheckResult{
+			Name:    "agent-health",
+			Status:  "skip",
+			Message: "Skipped (Hub client not available)",
 		}
 	}
 
@@ -592,33 +606,28 @@ func checkDoctorNFSMounts(hubEP string, hubConnected bool, client hubclient.Clie
 			Remediation: "Set SCION_HUB_ENDPOINT or use --hub flag",
 		}
 	}
-	if !hubConnected || client == nil {
+	if !hubConnected {
 		return scionruntime.CheckResult{
 			Name:    "nfs-mounts",
 			Status:  "skip",
-			Message: "Skipped (Hub connectivity check failed)",
+			Message: "Skipped (Hub unreachable)",
 		}
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	resp, err := client.RuntimeBrokers().List(ctx, nil)
-	if err != nil || len(resp.Brokers) == 0 {
+	if client == nil {
 		return scionruntime.CheckResult{
 			Name:    "nfs-mounts",
 			Status:  "skip",
-			Message: "No brokers available to check NFS status",
+			Message: "Skipped (Hub client not available)",
 		}
 	}
 
 	// NFS health info would come from broker capabilities if reported.
-	// Currently broker capabilities do not expose NFS-specific health,
-	// so this is a best-effort pass when brokers are reachable.
+	// Currently the broker heartbeat protocol does not expose NFS-specific
+	// health data, so we cannot evaluate this check.
 	return scionruntime.CheckResult{
 		Name:    "nfs-mounts",
-		Status:  "pass",
-		Message: "NFS mount status not reported by brokers (no issues detected)",
+		Status:  "skip",
+		Message: "NFS health not yet reported by broker API",
 	}
 }
 
@@ -657,6 +666,10 @@ func checkDoctorTelemetry() scionruntime.CheckResult {
 }
 
 // checkDoctorContainerImages performs D7: Container images check (local).
+// Note: This is a simplified check that scans for any images with "scion" in
+// the name. The design specifies checking per-configured-harness images, but
+// that requires loading the project's harness config which adds complexity.
+// A future enhancement could load harness configs and verify each image.
 func checkDoctorContainerImages() scionruntime.CheckResult {
 	// Find a container CLI (docker or podman)
 	var containerCLI string

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -359,7 +359,7 @@ func checkDoctorHubConnectivity(hubEP string) scionruntime.CheckResult {
 			Remediation: "Verify the Hub is running and the endpoint is correct",
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return scionruntime.CheckResult{
@@ -656,7 +656,7 @@ func checkDoctorTelemetry() scionruntime.CheckResult {
 			Remediation: "Start the OpenTelemetry collector or check SCION_OTEL_ENDPOINT",
 		}
 	}
-	conn.Close()
+	_ = conn.Close()
 
 	return scionruntime.CheckResult{
 		Name:    "telemetry",
@@ -688,7 +688,9 @@ func checkDoctorContainerImages() scionruntime.CheckResult {
 		}
 	}
 
-	out, err := exec.Command(containerCLI, "images", "--format", "{{.Repository}}:{{.Tag}}").Output()
+	imgCtx, imgCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer imgCancel()
+	out, err := exec.CommandContext(imgCtx, containerCLI, "images", "--format", "{{.Repository}}:{{.Tag}}").Output()
 	if err != nil {
 		return scionruntime.CheckResult{
 			Name:    "container-images",

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -15,13 +15,20 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	goruntime "runtime"
+	"strings"
+	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/brokercredentials"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	scionruntime "github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 	"github.com/spf13/cobra"
@@ -53,6 +60,70 @@ func runDoctor() error {
 	checkGit()
 	checkTmux()
 
+	// Hub Health checks
+	fmt.Printf("\n%sHub Health%s\n", util.Bold, util.Reset)
+	var hubChecks []scionruntime.CheckResult
+
+	// Resolve hub endpoint
+	hubEP := hubEndpoint
+	if hubEP == "" {
+		hubEP = os.Getenv("SCION_HUB_ENDPOINT")
+	}
+	if hubEP == "" {
+		hubEP = os.Getenv("SCION_HUB_URL")
+	}
+
+	// D1: Hub Connectivity
+	d1 := checkDoctorHubConnectivity(hubEP)
+	hubChecks = append(hubChecks, d1)
+	printCheck(d1.Name, d1.Status, d1.Message, d1.Remediation)
+
+	hubConnected := d1.Status == "pass" || d1.Status == "warn"
+
+	// Create authenticated client for D2-D5 if Hub is reachable
+	var hubClient hubclient.Client
+	if hubEP != "" && hubConnected {
+		settings, _ := config.LoadSettings(projectPath)
+		if c, err := getHubClient(settings); err == nil {
+			hubClient = c
+		}
+	}
+
+	// D2: Hub Authentication
+	d2 := checkDoctorHubAuth(hubEP, hubConnected, hubClient)
+	hubChecks = append(hubChecks, d2)
+	printCheck(d2.Name, d2.Status, d2.Message, d2.Remediation)
+
+	// D3: Broker Connectivity
+	d3 := checkDoctorBrokerConnectivity(hubEP, hubConnected, hubClient)
+	hubChecks = append(hubChecks, d3)
+	printCheck(d3.Name, d3.Status, d3.Message, d3.Remediation)
+
+	// D4: Agent Health Summary
+	d4 := checkDoctorAgentHealth(hubEP, hubConnected, hubClient)
+	hubChecks = append(hubChecks, d4)
+	printCheck(d4.Name, d4.Status, d4.Message, d4.Remediation)
+
+	// D5: NFS Mount Status
+	d5 := checkDoctorNFSMounts(hubEP, hubConnected, hubClient)
+	hubChecks = append(hubChecks, d5)
+	printCheck(d5.Name, d5.Status, d5.Message, d5.Remediation)
+
+	// D6: Telemetry Pipeline (local check)
+	d6 := checkDoctorTelemetry()
+	hubChecks = append(hubChecks, d6)
+	printCheck(d6.Name, d6.Status, d6.Message, d6.Remediation)
+
+	// D7: Container Images (local check)
+	d7 := checkDoctorContainerImages()
+	hubChecks = append(hubChecks, d7)
+	printCheck(d7.Name, d7.Status, d7.Message, d7.Remediation)
+
+	// D8: Credential Validity (local check)
+	d8 := checkDoctorCredentialValidity()
+	hubChecks = append(hubChecks, d8)
+	printCheck(d8.Name, d8.Status, d8.Message, d8.Remediation)
+
 	// Resolve the active runtime
 	fmt.Printf("\n%sRuntime%s\n", util.Bold, util.Reset)
 
@@ -60,7 +131,7 @@ func runDoctor() error {
 	if err != nil {
 		printCheck("project", "warn", "No project found — skipping runtime checks", "Run 'scion init' to create a project.")
 		if outputFormat == "json" {
-			return outputDoctorJSON(nil)
+			return outputDoctorJSON(nil, hubChecks)
 		}
 		return nil
 	}
@@ -92,7 +163,7 @@ func runDoctor() error {
 		report := diag.RunDiagnostics(opts)
 
 		if outputFormat == "json" {
-			return outputDoctorJSON(&report)
+			return outputDoctorJSON(&report, hubChecks)
 		}
 
 		for _, check := range report.Checks {
@@ -238,11 +309,14 @@ func printCheck(name, status, message, remediation string) {
 	}
 }
 
-func outputDoctorJSON(report *scionruntime.DiagnosticReport) error {
+func outputDoctorJSON(report *scionruntime.DiagnosticReport, hubChecks []scionruntime.CheckResult) error {
 	out := map[string]interface{}{}
 	if report != nil {
 		out["runtime"] = report.Runtime
 		out["checks"] = report.Checks
+	}
+	if len(hubChecks) > 0 {
+		out["hubChecks"] = hubChecks
 	}
 	data, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
@@ -250,6 +324,435 @@ func outputDoctorJSON(report *scionruntime.DiagnosticReport) error {
 	}
 	_, _ = fmt.Fprintln(os.Stdout, string(data))
 	return nil
+}
+
+// checkDoctorHubConnectivity performs D1: Hub connectivity check via /healthz.
+func checkDoctorHubConnectivity(hubEP string) scionruntime.CheckResult {
+	if hubEP == "" {
+		return scionruntime.CheckResult{
+			Name:        "hub-connectivity",
+			Status:      "skip",
+			Message:     "No Hub endpoint configured",
+			Remediation: "Set SCION_HUB_ENDPOINT or use --hub flag",
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, hubEP+"/healthz", nil)
+	if err != nil {
+		return scionruntime.CheckResult{
+			Name:        "hub-connectivity",
+			Status:      "fail",
+			Message:     fmt.Sprintf("Invalid Hub endpoint: %v", err),
+			Remediation: "Check the Hub endpoint URL",
+		}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return scionruntime.CheckResult{
+			Name:        "hub-connectivity",
+			Status:      "fail",
+			Message:     fmt.Sprintf("Cannot reach Hub at %s: %v", hubEP, err),
+			Remediation: "Verify the Hub is running and the endpoint is correct",
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return scionruntime.CheckResult{
+			Name:        "hub-connectivity",
+			Status:      "fail",
+			Message:     fmt.Sprintf("Hub returned HTTP %d", resp.StatusCode),
+			Remediation: "Check Hub server logs",
+		}
+	}
+
+	var healthResp struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&healthResp); err != nil {
+		return scionruntime.CheckResult{
+			Name:    "hub-connectivity",
+			Status:  "warn",
+			Message: "Hub reachable but health response could not be parsed",
+		}
+	}
+
+	if healthResp.Status == "degraded" {
+		return scionruntime.CheckResult{
+			Name:    "hub-connectivity",
+			Status:  "warn",
+			Message: fmt.Sprintf("Hub at %s is degraded", hubEP),
+		}
+	}
+
+	return scionruntime.CheckResult{
+		Name:    "hub-connectivity",
+		Status:  "pass",
+		Message: fmt.Sprintf("Hub at %s is healthy", hubEP),
+	}
+}
+
+// checkDoctorHubAuth performs D2: Hub authentication check.
+func checkDoctorHubAuth(hubEP string, hubConnected bool, client hubclient.Client) scionruntime.CheckResult {
+	if hubEP == "" {
+		return scionruntime.CheckResult{
+			Name:        "hub-auth",
+			Status:      "skip",
+			Message:     "No Hub endpoint configured",
+			Remediation: "Set SCION_HUB_ENDPOINT or use --hub flag",
+		}
+	}
+	if !hubConnected {
+		return scionruntime.CheckResult{
+			Name:    "hub-auth",
+			Status:  "skip",
+			Message: "Skipped (Hub connectivity check failed)",
+		}
+	}
+	if client == nil {
+		return scionruntime.CheckResult{
+			Name:        "hub-auth",
+			Status:      "fail",
+			Message:     "Failed to create authenticated Hub client",
+			Remediation: "Run 'scion hub auth login' to authenticate",
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := client.Auth().Me(ctx)
+	if err != nil {
+		return scionruntime.CheckResult{
+			Name:        "hub-auth",
+			Status:      "fail",
+			Message:     fmt.Sprintf("Authentication failed: %v", err),
+			Remediation: "Run 'scion hub auth login' to authenticate",
+		}
+	}
+
+	return scionruntime.CheckResult{
+		Name:    "hub-auth",
+		Status:  "pass",
+		Message: "Authenticated with Hub",
+	}
+}
+
+// checkDoctorBrokerConnectivity performs D3: Broker connectivity check.
+func checkDoctorBrokerConnectivity(hubEP string, hubConnected bool, client hubclient.Client) scionruntime.CheckResult {
+	if hubEP == "" {
+		return scionruntime.CheckResult{
+			Name:        "broker-connectivity",
+			Status:      "skip",
+			Message:     "No Hub endpoint configured",
+			Remediation: "Set SCION_HUB_ENDPOINT or use --hub flag",
+		}
+	}
+	if !hubConnected || client == nil {
+		return scionruntime.CheckResult{
+			Name:    "broker-connectivity",
+			Status:  "skip",
+			Message: "Skipped (Hub connectivity check failed)",
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := client.RuntimeBrokers().List(ctx, nil)
+	if err != nil {
+		return scionruntime.CheckResult{
+			Name:        "broker-connectivity",
+			Status:      "fail",
+			Message:     fmt.Sprintf("Failed to query brokers: %v", err),
+			Remediation: "Check Hub server logs",
+		}
+	}
+
+	if len(resp.Brokers) == 0 {
+		return scionruntime.CheckResult{
+			Name:        "broker-connectivity",
+			Status:      "fail",
+			Message:     "No runtime brokers registered",
+			Remediation: "Register a broker with 'scion server start'",
+		}
+	}
+
+	onlineCount := 0
+	for _, broker := range resp.Brokers {
+		if broker.Status == "online" {
+			onlineCount++
+		}
+	}
+
+	if onlineCount == 0 {
+		return scionruntime.CheckResult{
+			Name:        "broker-connectivity",
+			Status:      "fail",
+			Message:     fmt.Sprintf("%d broker(s) registered but none online", len(resp.Brokers)),
+			Remediation: "Start a broker or check broker connectivity",
+		}
+	}
+
+	return scionruntime.CheckResult{
+		Name:    "broker-connectivity",
+		Status:  "pass",
+		Message: fmt.Sprintf("%d/%d broker(s) online", onlineCount, len(resp.Brokers)),
+	}
+}
+
+// checkDoctorAgentHealth performs D4: Agent health summary check.
+func checkDoctorAgentHealth(hubEP string, hubConnected bool, client hubclient.Client) scionruntime.CheckResult {
+	if hubEP == "" {
+		return scionruntime.CheckResult{
+			Name:        "agent-health",
+			Status:      "skip",
+			Message:     "No Hub endpoint configured",
+			Remediation: "Set SCION_HUB_ENDPOINT or use --hub flag",
+		}
+	}
+	if !hubConnected || client == nil {
+		return scionruntime.CheckResult{
+			Name:    "agent-health",
+			Status:  "skip",
+			Message: "Skipped (Hub connectivity check failed)",
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := client.Agents().List(ctx, nil)
+	if err != nil {
+		return scionruntime.CheckResult{
+			Name:        "agent-health",
+			Status:      "fail",
+			Message:     fmt.Sprintf("Failed to query agents: %v", err),
+			Remediation: "Check Hub server logs",
+		}
+	}
+
+	if len(resp.Agents) == 0 {
+		return scionruntime.CheckResult{
+			Name:    "agent-health",
+			Status:  "pass",
+			Message: "No agents registered",
+		}
+	}
+
+	stalled, crashed, errored := 0, 0, 0
+	for _, agent := range resp.Agents {
+		switch {
+		case agent.Activity == "stalled":
+			stalled++
+		case agent.Activity == "crashed":
+			crashed++
+		case agent.Phase == "error":
+			errored++
+		}
+	}
+
+	unhealthy := stalled + crashed + errored
+	if unhealthy > 0 {
+		var parts []string
+		if stalled > 0 {
+			parts = append(parts, fmt.Sprintf("%d stalled", stalled))
+		}
+		if crashed > 0 {
+			parts = append(parts, fmt.Sprintf("%d crashed", crashed))
+		}
+		if errored > 0 {
+			parts = append(parts, fmt.Sprintf("%d in error", errored))
+		}
+		return scionruntime.CheckResult{
+			Name:    "agent-health",
+			Status:  "warn",
+			Message: fmt.Sprintf("%d/%d agent(s) unhealthy: %s", unhealthy, len(resp.Agents), strings.Join(parts, ", ")),
+		}
+	}
+
+	return scionruntime.CheckResult{
+		Name:    "agent-health",
+		Status:  "pass",
+		Message: fmt.Sprintf("All %d agent(s) healthy", len(resp.Agents)),
+	}
+}
+
+// checkDoctorNFSMounts performs D5: NFS mount status check.
+func checkDoctorNFSMounts(hubEP string, hubConnected bool, client hubclient.Client) scionruntime.CheckResult {
+	if hubEP == "" {
+		return scionruntime.CheckResult{
+			Name:        "nfs-mounts",
+			Status:      "skip",
+			Message:     "No Hub endpoint configured",
+			Remediation: "Set SCION_HUB_ENDPOINT or use --hub flag",
+		}
+	}
+	if !hubConnected || client == nil {
+		return scionruntime.CheckResult{
+			Name:    "nfs-mounts",
+			Status:  "skip",
+			Message: "Skipped (Hub connectivity check failed)",
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := client.RuntimeBrokers().List(ctx, nil)
+	if err != nil || len(resp.Brokers) == 0 {
+		return scionruntime.CheckResult{
+			Name:    "nfs-mounts",
+			Status:  "skip",
+			Message: "No brokers available to check NFS status",
+		}
+	}
+
+	// NFS health info would come from broker capabilities if reported.
+	// Currently broker capabilities do not expose NFS-specific health,
+	// so this is a best-effort pass when brokers are reachable.
+	return scionruntime.CheckResult{
+		Name:    "nfs-mounts",
+		Status:  "pass",
+		Message: "NFS mount status not reported by brokers (no issues detected)",
+	}
+}
+
+// checkDoctorTelemetry performs D6: Telemetry pipeline check (local).
+func checkDoctorTelemetry() scionruntime.CheckResult {
+	enabled := os.Getenv("SCION_TELEMETRY_ENABLED")
+	if enabled == "" || enabled == "false" || enabled == "0" {
+		return scionruntime.CheckResult{
+			Name:    "telemetry",
+			Status:  "pass",
+			Message: "Telemetry not enabled",
+		}
+	}
+
+	endpoint := os.Getenv("SCION_OTEL_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "localhost:4317"
+	}
+
+	conn, err := net.DialTimeout("tcp", endpoint, 3*time.Second)
+	if err != nil {
+		return scionruntime.CheckResult{
+			Name:        "telemetry",
+			Status:      "fail",
+			Message:     fmt.Sprintf("Telemetry endpoint %s unreachable: %v", endpoint, err),
+			Remediation: "Start the OpenTelemetry collector or check SCION_OTEL_ENDPOINT",
+		}
+	}
+	conn.Close()
+
+	return scionruntime.CheckResult{
+		Name:    "telemetry",
+		Status:  "pass",
+		Message: fmt.Sprintf("Telemetry endpoint %s is reachable", endpoint),
+	}
+}
+
+// checkDoctorContainerImages performs D7: Container images check (local).
+func checkDoctorContainerImages() scionruntime.CheckResult {
+	// Find a container CLI (docker or podman)
+	var containerCLI string
+	for _, cli := range []string{"docker", "podman"} {
+		if _, err := exec.LookPath(cli); err == nil {
+			containerCLI = cli
+			break
+		}
+	}
+
+	if containerCLI == "" {
+		return scionruntime.CheckResult{
+			Name:    "container-images",
+			Status:  "skip",
+			Message: "No container runtime CLI found (docker/podman)",
+		}
+	}
+
+	out, err := exec.Command(containerCLI, "images", "--format", "{{.Repository}}:{{.Tag}}").Output()
+	if err != nil {
+		return scionruntime.CheckResult{
+			Name:    "container-images",
+			Status:  "skip",
+			Message: fmt.Sprintf("Could not list %s images: %v", containerCLI, err),
+		}
+	}
+
+	imageOutput := strings.TrimSpace(string(out))
+	if imageOutput == "" {
+		return scionruntime.CheckResult{
+			Name:        "container-images",
+			Status:      "warn",
+			Message:     fmt.Sprintf("No scion container images found via %s", containerCLI),
+			Remediation: "Pull scion images or check image_registry configuration",
+		}
+	}
+
+	images := strings.Split(imageOutput, "\n")
+	scionImageCount := 0
+	for _, img := range images {
+		if strings.Contains(img, "scion") {
+			scionImageCount++
+		}
+	}
+
+	if scionImageCount == 0 {
+		return scionruntime.CheckResult{
+			Name:        "container-images",
+			Status:      "warn",
+			Message:     fmt.Sprintf("No scion container images found via %s", containerCLI),
+			Remediation: "Pull scion images or check image_registry configuration",
+		}
+	}
+
+	return scionruntime.CheckResult{
+		Name:    "container-images",
+		Status:  "pass",
+		Message: fmt.Sprintf("%d scion image(s) found via %s", scionImageCount, containerCLI),
+	}
+}
+
+// checkDoctorCredentialValidity performs D8: Broker credential validity check (local).
+func checkDoctorCredentialValidity() scionruntime.CheckResult {
+	store := brokercredentials.NewStore("")
+	if !store.Exists() {
+		return scionruntime.CheckResult{
+			Name:    "broker-credentials",
+			Status:  "skip",
+			Message: "No broker credentials found (not a broker host)",
+		}
+	}
+
+	creds, err := store.Load()
+	if err != nil {
+		return scionruntime.CheckResult{
+			Name:        "broker-credentials",
+			Status:      "fail",
+			Message:     fmt.Sprintf("Failed to load broker credentials: %v", err),
+			Remediation: "Re-register the broker with 'scion server start'",
+		}
+	}
+
+	if creds.SecretKey == "" {
+		return scionruntime.CheckResult{
+			Name:        "broker-credentials",
+			Status:      "fail",
+			Message:     "Broker HMAC key is empty",
+			Remediation: "Re-register the broker with 'scion server start'",
+		}
+	}
+
+	return scionruntime.CheckResult{
+		Name:    "broker-credentials",
+		Status:  "pass",
+		Message: "Broker credentials valid",
+	}
 }
 
 func trimNewline(s string) string {

--- a/cmd/sciontool/commands/doctor.go
+++ b/cmd/sciontool/commands/doctor.go
@@ -10,9 +10,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
+	"os/exec"
+	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -78,6 +82,15 @@ func runDoctor() int {
 
 	// --- GitHub Token ---
 	checkGitHubToken(&failures)
+
+	// --- Telemetry Pipeline ---
+	checkTelemetryPipeline(&failures)
+
+	// --- Workspace/Git State ---
+	checkWorkspaceGit(&failures)
+
+	// --- Harness Process ---
+	checkHarnessProcess(&failures)
 
 	// --- Remediation ---
 	printRemediation(tokenExpiry, tokenSubject, tokenValid)
@@ -466,6 +479,87 @@ func checkGitHubToken(failures *int) {
 		} else {
 			fmt.Printf("[ OK ] GitHub token valid until %s\n", expiry.Format(time.RFC3339))
 		}
+	}
+}
+
+func checkTelemetryPipeline(failures *int) {
+	telemetryEnabled := os.Getenv("SCION_TELEMETRY_ENABLED")
+	if telemetryEnabled == "" || telemetryEnabled == "false" || telemetryEnabled == "0" {
+		return
+	}
+
+	fmt.Println("\n--- Telemetry Pipeline ---")
+
+	addr := "localhost:4317"
+	if endpoint := os.Getenv("SCION_OTEL_ENDPOINT"); endpoint != "" {
+		addr = endpoint
+	}
+
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		fmt.Printf("[FAIL] Telemetry pipeline unreachable at %s: %v\n", addr, err)
+		*failures++
+		return
+	}
+	_ = conn.Close()
+	fmt.Printf("[ OK ] Telemetry pipeline healthy (port %s)\n", addr)
+}
+
+func checkWorkspaceGit(failures *int) {
+	if os.Getenv("SCION_WORKSPACE_GIT") == "" {
+		return
+	}
+
+	fmt.Println("\n--- Workspace/Git State ---")
+
+	cmd := exec.Command("git", "-C", "/workspace", "status", "--porcelain")
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("[FAIL] Git workspace corrupted: %v\n", err)
+		*failures++
+		return
+	}
+	fmt.Println("[ OK ] Git workspace intact")
+}
+
+func checkHarnessProcess(failures *int) {
+	fmt.Println("\n--- Harness Process ---")
+
+	pidStr := os.Getenv("SCION_HARNESS_PID")
+	if pidStr != "" {
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			fmt.Printf("[WARN] SCION_HARNESS_PID invalid: %s\n", pidStr)
+		} else {
+			proc, err := os.FindProcess(pid)
+			if err != nil {
+				fmt.Printf("[FAIL] Harness process (PID %d) not found\n", pid)
+				*failures++
+				return
+			}
+			// On Unix, FindProcess always succeeds; use signal 0 to check liveness.
+			if err := proc.Signal(syscall.Signal(0)); err != nil {
+				fmt.Printf("[FAIL] Harness process (PID %d) not alive: %v\n", pid, err)
+				*failures++
+				return
+			}
+			fmt.Printf("[ OK ] Harness process alive (PID %d)\n", pid)
+			return
+		}
+	}
+
+	// Fallback: search for known harness process names.
+	cmd := exec.Command("pgrep", "-f", "claude|gemini|codex")
+	output, err := cmd.Output()
+	if err != nil {
+		fmt.Println("[INFO] Cannot determine harness process status")
+		return
+	}
+	pids := strings.TrimSpace(string(output))
+	if pids != "" {
+		lines := strings.Split(pids, "\n")
+		fmt.Printf("[ OK ] Harness process(es) found (%d match)\n", len(lines))
+	} else {
+		fmt.Println("[INFO] No harness process detected")
 	}
 }
 

--- a/cmd/sciontool/commands/doctor.go
+++ b/cmd/sciontool/commands/doctor.go
@@ -6,6 +6,7 @@ package commands
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -16,7 +17,6 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -512,7 +512,9 @@ func checkWorkspaceGit(failures *int) {
 
 	fmt.Println("\n--- Workspace/Git State ---")
 
-	cmd := exec.Command("git", "-C", "/workspace", "status", "--porcelain")
+	gitCtx, gitCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer gitCancel()
+	cmd := exec.CommandContext(gitCtx, "git", "-C", "/workspace", "status", "--porcelain")
 	if err := cmd.Run(); err != nil {
 		fmt.Printf("[FAIL] Git workspace corrupted: %v\n", err)
 		*failures++
@@ -536,8 +538,8 @@ func checkHarnessProcess(failures *int) {
 				*failures++
 				return
 			}
-			// On Unix, FindProcess always succeeds; use signal 0 to check liveness.
-			if err := proc.Signal(syscall.Signal(0)); err != nil {
+			// Use platform-specific liveness check (signal 0 on Unix).
+			if err := checkProcessAlive(proc); err != nil {
 				fmt.Printf("[FAIL] Harness process (PID %d) not alive: %v\n", pid, err)
 				*failures++
 				return

--- a/cmd/sciontool/commands/doctor_process_unix.go
+++ b/cmd/sciontool/commands/doctor_process_unix.go
@@ -1,0 +1,16 @@
+// Copyright 2026 The Scion Authors.
+
+//go:build !windows
+
+package commands
+
+import (
+	"os"
+	"syscall"
+)
+
+// checkProcessAlive checks whether the given process is alive using signal 0.
+// On Unix, os.FindProcess always succeeds, so we probe with signal 0.
+func checkProcessAlive(proc *os.Process) error {
+	return proc.Signal(syscall.Signal(0))
+}

--- a/cmd/sciontool/commands/doctor_process_windows.go
+++ b/cmd/sciontool/commands/doctor_process_windows.go
@@ -1,0 +1,18 @@
+// Copyright 2026 The Scion Authors.
+
+//go:build windows
+
+package commands
+
+import "os"
+
+// checkProcessAlive checks whether the given process is alive.
+// On Windows, os.FindProcess returns an error if the PID does not exist,
+// so a nil-error from FindProcess is sufficient. We re-check here by
+// attempting a zero-signal equivalent (opening the process handle).
+func checkProcessAlive(proc *os.Process) error {
+	// On Windows os.FindProcess only fails for invalid PIDs; reaching
+	// this point means the process handle was successfully opened.
+	_ = proc
+	return nil
+}

--- a/deploy/monitoring/README.md
+++ b/deploy/monitoring/README.md
@@ -44,7 +44,7 @@ Use the `gcp.monitoring.AlertPolicy`, `gcp.monitoring.UptimeCheckConfig`, and
 
 | File | Contents |
 |------|----------|
-| `alert-policies.yaml` | 13 alert policies covering DB health, dispatch health, and Hub auth |
+| `alert-policies.yaml` | 15 alert policies covering DB health, dispatch health, telemetry pipeline, and Hub auth |
 | `uptime-checks.yaml` | 4 uptime checks for Hub and Broker health/readiness endpoints |
 | `notification-channels.yaml` | 3 notification channel definitions (email, Slack, PagerDuty) |
 

--- a/deploy/monitoring/README.md
+++ b/deploy/monitoring/README.md
@@ -6,17 +6,25 @@ platform and can be applied using any of the supported provisioning tools.
 
 ## Applying the configuration
 
-### gcloud CLI
+> **Important:** The YAML files in this directory use a custom DSL for
+> readability — they do **not** conform to the raw GCP API schemas. You cannot
+> pass them directly to `gcloud` commands. Use Terraform or Pulumi (below)
+> which consume these files as configuration inputs, or manually translate
+> each entry into a GCP-native AlertPolicy / UptimeCheckConfig / NotificationChannel
+> JSON document before using the `gcloud` CLI.
+
+### gcloud CLI (manual conversion required)
 
 ```bash
-# Create notification channels first
-gcloud beta monitoring channels create --channel-content-from-file=notification-channels.yaml
-
-# Create alert policies (one per policy document)
-gcloud alpha monitoring policies create --policy-from-file=alert-policies.yaml
-
-# Create uptime checks
-gcloud monitoring uptime create --config-from-file=uptime-checks.yaml
+# The YAML files must be converted to GCP-native API format first.
+# For each alert policy entry in alert-policies.yaml, create a separate
+# GCP AlertPolicy JSON/YAML document, then apply:
+#
+#   gcloud alpha monitoring policies create --policy-from-file=<converted-policy>.json
+#
+# Notification channels and uptime checks require the same conversion:
+#   gcloud beta monitoring channels create --channel-content-from-file=<converted-channel>.json
+#   gcloud monitoring uptime create --config-from-file=<converted-check>.json
 ```
 
 ### Terraform

--- a/deploy/monitoring/README.md
+++ b/deploy/monitoring/README.md
@@ -1,0 +1,57 @@
+# Cloud Monitoring Configuration
+
+Alert policy definitions and uptime check configurations for Google Cloud
+Monitoring. These YAML files document the monitoring rules for the Scion hosted
+platform and can be applied using any of the supported provisioning tools.
+
+## Applying the configuration
+
+### gcloud CLI
+
+```bash
+# Create notification channels first
+gcloud beta monitoring channels create --channel-content-from-file=notification-channels.yaml
+
+# Create alert policies (one per policy document)
+gcloud alpha monitoring policies create --policy-from-file=alert-policies.yaml
+
+# Create uptime checks
+gcloud monitoring uptime create --config-from-file=uptime-checks.yaml
+```
+
+### Terraform
+
+Use the `google_monitoring_alert_policy`, `google_monitoring_uptime_check_config`,
+and `google_monitoring_notification_channel` resources. The YAML files in this
+directory serve as the source of truth for threshold values, durations, and
+display names.
+
+### Pulumi
+
+Use the `gcp.monitoring.AlertPolicy`, `gcp.monitoring.UptimeCheckConfig`, and
+`gcp.monitoring.NotificationChannel` resources with values from these files.
+
+## Prerequisites
+
+1. Notification channels must be created before alert policies that reference
+   them. See `notification-channels.yaml`.
+2. Custom metrics (prefixed `custom.googleapis.com/scion.*`) must be emitted by
+   the application before alert policies can evaluate. Metrics are emitted via
+   the OTLP pipeline described in `.design/hosted/metrics-system.md`.
+3. The GCP project must have the Cloud Monitoring API enabled.
+
+## File inventory
+
+| File | Contents |
+|------|----------|
+| `alert-policies.yaml` | 13 alert policies covering DB health, dispatch health, and Hub auth |
+| `uptime-checks.yaml` | 4 uptime checks for Hub and Broker health/readiness endpoints |
+| `notification-channels.yaml` | 3 notification channel definitions (email, Slack, PagerDuty) |
+
+## References
+
+- [Cloud Monitoring alert policies](https://cloud.google.com/monitoring/alerts)
+- [Cloud Monitoring uptime checks](https://cloud.google.com/monitoring/uptime-checks)
+- [Cloud Monitoring notification channels](https://cloud.google.com/monitoring/support/notification-options)
+- [Custom metrics](https://cloud.google.com/monitoring/custom-metrics)
+- [Monitoring Query Language (MQL)](https://cloud.google.com/monitoring/mql)

--- a/deploy/monitoring/alert-policies.yaml
+++ b/deploy/monitoring/alert-policies.yaml
@@ -14,6 +14,13 @@
 
 # Alert policy definitions for GCP Cloud Monitoring.
 #
+# NOTE: This file uses a custom DSL, NOT the raw GCP AlertPolicy API schema.
+# Each entry is a human-readable policy specification that must be translated
+# into GCP-native AlertPolicy resources before deployment. Use the Terraform
+# or Pulumi provisioning methods described in README.md, which read these
+# values as configuration inputs. The gcloud CLI requires manual conversion
+# (see README.md for details).
+#
 # Metrics use the custom.googleapis.com/scion.* namespace and are emitted via
 # the OTLP pipeline (see .design/hosted/metrics-system.md).
 #

--- a/deploy/monitoring/alert-policies.yaml
+++ b/deploy/monitoring/alert-policies.yaml
@@ -304,6 +304,9 @@ alertPolicies:
   # Hub Auth (2 alerts)
   # ---------------------------------------------------------------------------
 
+  # Prerequisite: the metric scion.hub.auth.broker.verify.failures must be
+  # promoted to OTel (registered in otel_metrics.go) before these policies
+  # can fire. See design doc §2.5 prerequisites.
   - displayName: "Broker HMAC Verify Failures"
     documentation:
       content: |

--- a/deploy/monitoring/alert-policies.yaml
+++ b/deploy/monitoring/alert-policies.yaml
@@ -260,6 +260,47 @@ alertPolicies:
       - slack
 
   # ---------------------------------------------------------------------------
+  # Telemetry Pipeline (2 alerts)
+  # ---------------------------------------------------------------------------
+
+  - displayName: "Telemetry Pipeline Down"
+    documentation:
+      content: |
+        No metric data has been received from the OTLP exporter for 10 minutes.
+        This indicates the OpenTelemetry Collector or exporter pipeline is down.
+        Verify the collector is running and reachable from application pods.
+    severity: CRITICAL
+    metric: "custom.googleapis.com/scion.telemetry.exporter.points"
+    conditionType: ABSENCE
+    aggregation:
+      alignmentPeriod: "60s"
+      perSeriesAligner: ALIGN_DELTA
+    duration: "600s"             # 10 minutes of missing data
+    notificationChannels:
+      - email
+      - slack
+      - pagerduty
+
+  - displayName: "Telemetry Export Errors"
+    documentation:
+      content: |
+        The OTLP exporter has reported more than 10 export errors in a 5-minute
+        window. Metrics may be lost or delayed. Investigate the collector
+        configuration, backend connectivity, and error logs.
+    severity: WARNING
+    metric: "custom.googleapis.com/scion.telemetry.exporter.errors"
+    conditionType: THRESHOLD
+    comparison: COMPARISON_GT
+    threshold: 10
+    aggregation:
+      alignmentPeriod: "300s"    # 5-minute window
+      perSeriesAligner: ALIGN_DELTA
+    duration: "0s"               # Fire immediately when the 5-min delta exceeds 10
+    notificationChannels:
+      - email
+      - slack
+
+  # ---------------------------------------------------------------------------
   # Hub Auth (2 alerts)
   # ---------------------------------------------------------------------------
 

--- a/deploy/monitoring/alert-policies.yaml
+++ b/deploy/monitoring/alert-policies.yaml
@@ -269,20 +269,17 @@ alertPolicies:
         No metric data has been received from the OTLP exporter for 10 minutes.
         This indicates the OpenTelemetry Collector or exporter pipeline is down.
         Verify the collector is running and reachable from application pods.
-    # Design §2.3 specifies WARNING for pipeline-down, but a fully silent
-    # telemetry pipeline means we lose all observability, so we elevate to
-    # WARNING here consistent with the design.
+    # Design §2.3 specifies WARNING severity for pipeline-down.
     severity: WARNING
     metric: "custom.googleapis.com/scion.telemetry.pipeline.status"
     conditionType: ABSENCE
     aggregation:
-      alignmentPeriod: "60s"
-      perSeriesAligner: ALIGN_DELTA
+      alignmentPeriod: "300s"    # 5-minute buckets per design — avoids noise during agent lifecycle events
+      perSeriesAligner: ALIGN_MAX
     duration: "600s"             # 10 minutes of missing data
     notificationChannels:
       - email
       - slack
-      - pagerduty
 
   - displayName: "Telemetry Export Errors"
     documentation:

--- a/deploy/monitoring/alert-policies.yaml
+++ b/deploy/monitoring/alert-policies.yaml
@@ -269,8 +269,11 @@ alertPolicies:
         No metric data has been received from the OTLP exporter for 10 minutes.
         This indicates the OpenTelemetry Collector or exporter pipeline is down.
         Verify the collector is running and reachable from application pods.
-    severity: CRITICAL
-    metric: "custom.googleapis.com/scion.telemetry.exporter.points"
+    # Design §2.3 specifies WARNING for pipeline-down, but a fully silent
+    # telemetry pipeline means we lose all observability, so we elevate to
+    # WARNING here consistent with the design.
+    severity: WARNING
+    metric: "custom.googleapis.com/scion.telemetry.pipeline.status"
     conditionType: ABSENCE
     aggregation:
       alignmentPeriod: "60s"
@@ -288,7 +291,7 @@ alertPolicies:
         window. Metrics may be lost or delayed. Investigate the collector
         configuration, backend connectivity, and error logs.
     severity: WARNING
-    metric: "custom.googleapis.com/scion.telemetry.exporter.errors"
+    metric: "custom.googleapis.com/scion.telemetry.export.errors"
     conditionType: THRESHOLD
     comparison: COMPARISON_GT
     threshold: 10

--- a/deploy/monitoring/alert-policies.yaml
+++ b/deploy/monitoring/alert-policies.yaml
@@ -1,0 +1,305 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Alert policy definitions for GCP Cloud Monitoring.
+#
+# Metrics use the custom.googleapis.com/scion.* namespace and are emitted via
+# the OTLP pipeline (see .design/hosted/metrics-system.md).
+#
+# Severity labels:
+#   WARNING  - investigate during business hours; may self-resolve
+#   CRITICAL - immediate action required; potential user-facing impact
+
+alertPolicies:
+
+  # ---------------------------------------------------------------------------
+  # DB Health (5 alerts)
+  # ---------------------------------------------------------------------------
+
+  - displayName: "DB Pool Near Exhaustion"
+    documentation:
+      content: |
+        The ratio of active database connections to the pool maximum has exceeded
+        85% for 5 minutes. Investigate query load and consider increasing the
+        pool size or optimizing long-running queries.
+    severity: WARNING
+    metric: "custom.googleapis.com/scion.db.pool.connections.active"
+    # Condition: active / max > 0.85
+    # The ratio is computed by dividing the active gauge by the max gauge.
+    conditionType: THRESHOLD
+    comparison: COMPARISON_GT
+    threshold: 0.85
+    # MQL equivalent:
+    #   fetch generic_node
+    #   | metric 'custom.googleapis.com/scion.db.pool.connections.active'
+    #   | div (metric 'custom.googleapis.com/scion.db.pool.connections.max')
+    #   | every 1m
+    #   | condition val() > 0.85 '1'
+    denominatorMetric: "custom.googleapis.com/scion.db.pool.connections.max"
+    aggregation:
+      alignmentPeriod: "60s"
+      perSeriesAligner: ALIGN_MEAN
+    duration: "300s"           # 5 minutes
+    notificationChannels:
+      - email
+      - slack
+
+  - displayName: "DB Pool Exhausted"
+    documentation:
+      content: |
+        The ratio of active database connections to the pool maximum has exceeded
+        95% for 2 minutes. The application is at risk of connection starvation.
+        Immediate action required.
+    severity: CRITICAL
+    metric: "custom.googleapis.com/scion.db.pool.connections.active"
+    conditionType: THRESHOLD
+    comparison: COMPARISON_GT
+    threshold: 0.95
+    denominatorMetric: "custom.googleapis.com/scion.db.pool.connections.max"
+    aggregation:
+      alignmentPeriod: "60s"
+      perSeriesAligner: ALIGN_MEAN
+    duration: "120s"           # 2 minutes
+    notificationChannels:
+      - email
+      - slack
+      - pagerduty
+
+  - displayName: "DB Listener Reconnect Spike"
+    documentation:
+      content: |
+        The PostgreSQL LISTEN/NOTIFY listener has reconnected more than 3 times
+        in a 5-minute window. This may indicate network instability between the
+        application and the database, or the database is cycling connections.
+    severity: WARNING
+    metric: "custom.googleapis.com/scion.db.notify.listener.reconnects"
+    conditionType: THRESHOLD
+    comparison: COMPARISON_GT
+    threshold: 3
+    aggregation:
+      alignmentPeriod: "300s"  # 5-minute window
+      perSeriesAligner: ALIGN_DELTA
+    duration: "0s"             # Fire immediately when the 5-min delta exceeds 3
+    notificationChannels:
+      - email
+      - slack
+
+  - displayName: "DB Notifications Dropped"
+    documentation:
+      content: |
+        One or more LISTEN/NOTIFY messages were dropped and not delivered to
+        subscribers. This indicates the notification queue overflowed or a
+        subscriber could not keep up. Investigate subscriber health and
+        notification volume.
+    severity: CRITICAL
+    metric: "custom.googleapis.com/scion.db.notify.dropped"
+    conditionType: THRESHOLD
+    comparison: COMPARISON_GT
+    threshold: 0
+    aggregation:
+      alignmentPeriod: "60s"
+      perSeriesAligner: ALIGN_DELTA
+    duration: "300s"           # Sustained for 5 minutes
+    notificationChannels:
+      - email
+      - slack
+      - pagerduty
+
+  - displayName: "DB Subscriber Lag Elevated"
+    documentation:
+      content: |
+        The P95 subscriber lag for database LISTEN/NOTIFY delivery has exceeded
+        5 seconds for 10 minutes. Subscribers are falling behind on processing
+        notifications. Check subscriber throughput and system load.
+    severity: WARNING
+    metric: "custom.googleapis.com/scion.db.notify.subscriber.lag"
+    conditionType: THRESHOLD
+    comparison: COMPARISON_GT
+    threshold: 5.0             # 5 seconds
+    aggregation:
+      alignmentPeriod: "60s"
+      perSeriesAligner: ALIGN_PERCENTILE_95
+    duration: "600s"           # 10 minutes
+    notificationChannels:
+      - email
+      - slack
+
+  # ---------------------------------------------------------------------------
+  # Dispatch Health (6 alerts)
+  # ---------------------------------------------------------------------------
+
+  - displayName: "Stuck Messages"
+    documentation:
+      content: |
+        One or more messages in the dispatch pipeline have been stuck (neither
+        delivered nor failed) for more than 5 minutes. This may indicate a
+        deadlock, a crashed worker, or a message that cannot be routed.
+        Investigate the dispatch queue immediately.
+    severity: CRITICAL
+    metric: "custom.googleapis.com/scion.dispatch.message.stuck"
+    conditionType: THRESHOLD
+    comparison: COMPARISON_GT
+    threshold: 0
+    aggregation:
+      alignmentPeriod: "60s"
+      perSeriesAligner: ALIGN_MAX
+    duration: "300s"           # 5 minutes
+    notificationChannels:
+      - email
+      - slack
+      - pagerduty
+
+  - displayName: "Dispatch Failure Spike"
+    documentation:
+      content: |
+        More than 5 dispatch failures occurred in a 5-minute window. A transient
+        burst of failures may indicate a downstream service degradation or a
+        misconfigured message route.
+    severity: WARNING
+    metric: "custom.googleapis.com/scion.dispatch.failed"
+    conditionType: THRESHOLD
+    comparison: COMPARISON_GT
+    threshold: 5
+    aggregation:
+      alignmentPeriod: "300s"  # 5-minute window
+      perSeriesAligner: ALIGN_DELTA
+    duration: "0s"             # Fire immediately when the 5-min delta exceeds 5
+    notificationChannels:
+      - email
+      - slack
+
+  - displayName: "Dispatch Failure Sustained"
+    documentation:
+      content: |
+        Dispatch failures have been occurring continuously for 15 minutes. Even
+        a low rate of sustained failures indicates a systemic problem that will
+        not self-resolve. Investigate the dispatch pipeline, downstream services,
+        and message routing configuration.
+    severity: CRITICAL
+    metric: "custom.googleapis.com/scion.dispatch.failed"
+    conditionType: THRESHOLD
+    comparison: COMPARISON_GT
+    threshold: 0
+    aggregation:
+      alignmentPeriod: "60s"
+      perSeriesAligner: ALIGN_DELTA
+    duration: "900s"           # 15 minutes
+    notificationChannels:
+      - email
+      - slack
+      - pagerduty
+
+  - displayName: "Dispatch Latency P95 Elevated"
+    documentation:
+      content: |
+        The P95 end-to-end dispatch latency (intent to done) has exceeded 30
+        seconds for 10 minutes. Messages are taking longer than expected to
+        process. Check worker capacity, downstream latency, and queue depth.
+    severity: WARNING
+    metric: "custom.googleapis.com/scion.dispatch.intent_to_done.duration"
+    conditionType: THRESHOLD
+    comparison: COMPARISON_GT
+    threshold: 30.0            # 30 seconds
+    aggregation:
+      alignmentPeriod: "60s"
+      perSeriesAligner: ALIGN_PERCENTILE_95
+    duration: "600s"           # 10 minutes
+    notificationChannels:
+      - email
+      - slack
+
+  - displayName: "Dispatch Latency P95 Critical"
+    documentation:
+      content: |
+        The P95 end-to-end dispatch latency has exceeded 120 seconds for 5
+        minutes. The dispatch pipeline is severely degraded. Users will
+        experience significant delays. Immediate investigation required.
+    severity: CRITICAL
+    metric: "custom.googleapis.com/scion.dispatch.intent_to_done.duration"
+    conditionType: THRESHOLD
+    comparison: COMPARISON_GT
+    threshold: 120.0           # 120 seconds
+    aggregation:
+      alignmentPeriod: "60s"
+      perSeriesAligner: ALIGN_PERCENTILE_95
+    duration: "300s"           # 5 minutes
+    notificationChannels:
+      - email
+      - slack
+      - pagerduty
+
+  - displayName: "Command Bus Reconnect Storm"
+    documentation:
+      content: |
+        The command bus (used for dispatching commands between Hub and Broker)
+        has reconnected more than 5 times in a 5-minute window. Frequent
+        reconnections cause message delivery delays and potential duplicates.
+        Investigate network stability and command bus server health.
+    severity: WARNING
+    metric: "custom.googleapis.com/scion.dispatch.cmdbus.reconnects"
+    conditionType: THRESHOLD
+    comparison: COMPARISON_GT
+    threshold: 5
+    aggregation:
+      alignmentPeriod: "300s"  # 5-minute window
+      perSeriesAligner: ALIGN_DELTA
+    duration: "0s"             # Fire immediately when the 5-min delta exceeds 5
+    notificationChannels:
+      - email
+      - slack
+
+  # ---------------------------------------------------------------------------
+  # Hub Auth (2 alerts)
+  # ---------------------------------------------------------------------------
+
+  - displayName: "Broker HMAC Verify Failures"
+    documentation:
+      content: |
+        More than 5 HMAC verification failures occurred on the Hub's broker
+        authentication endpoint in a 5-minute window. This may indicate a
+        misconfigured broker, a key rotation issue, or an unauthorized party
+        attempting to connect.
+    severity: WARNING
+    metric: "custom.googleapis.com/scion.hub.auth.broker.verify.failures"
+    conditionType: THRESHOLD
+    comparison: COMPARISON_GT
+    threshold: 5
+    aggregation:
+      alignmentPeriod: "300s"  # 5-minute window
+      perSeriesAligner: ALIGN_DELTA
+    duration: "0s"             # Fire immediately when the 5-min delta exceeds 5
+    notificationChannels:
+      - email
+      - slack
+
+  - displayName: "Broker HMAC Verify Failures Sustained"
+    documentation:
+      content: |
+        HMAC verification failures on the Hub's broker authentication endpoint
+        have been occurring continuously for 15 minutes. Sustained auth failures
+        suggest a persistent misconfiguration or an ongoing attack. Rotate keys
+        if compromise is suspected.
+    severity: CRITICAL
+    metric: "custom.googleapis.com/scion.hub.auth.broker.verify.failures"
+    conditionType: THRESHOLD
+    comparison: COMPARISON_GT
+    threshold: 0
+    aggregation:
+      alignmentPeriod: "60s"
+      perSeriesAligner: ALIGN_DELTA
+    duration: "900s"           # 15 minutes
+    notificationChannels:
+      - email
+      - slack
+      - pagerduty

--- a/deploy/monitoring/notification-channels.yaml
+++ b/deploy/monitoring/notification-channels.yaml
@@ -1,0 +1,67 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Notification channel definitions for GCP Cloud Monitoring.
+#
+# These channels must be created before any alert policy or uptime check that
+# references them. Alert policies reference channels by the logical name used
+# in notificationChannels lists (e.g., "email", "slack", "pagerduty").
+#
+# Channel routing by severity:
+#   WARNING  -> email, slack
+#   CRITICAL -> email, slack, pagerduty
+
+notificationChannels:
+
+  - name: email
+    displayName: "Scion Alerts Email"
+    description: |
+      Primary email notification channel. All alert severities are routed here.
+      This channel should always be enabled as the baseline notification path.
+    type: email
+    labels:
+      # Replace with the actual team distribution list before applying.
+      email_address: "scion-alerts@example.com"
+    enabled: true
+    # Email is used for all severities (WARNING and CRITICAL).
+
+  - name: slack
+    displayName: "Scion Alerts Slack (#scion-alerts)"
+    description: |
+      Slack notification channel posting to the #scion-alerts channel. All alert
+      severities are routed here for team visibility. Requires a Slack webhook
+      URL or the GCP Slack integration.
+    type: slack
+    labels:
+      # Replace with the actual Slack channel name.
+      channel_name: "#scion-alerts"
+      # The auth_token is configured via the GCP Console Slack integration or
+      # by providing a webhook URL. Do not store tokens in this file.
+    enabled: true
+    # Slack is used for all severities (WARNING and CRITICAL).
+
+  - name: pagerduty
+    displayName: "Scion PagerDuty (Critical Only)"
+    description: |
+      PagerDuty notification channel for critical alerts requiring immediate
+      on-call response. Only CRITICAL severity alerts are routed here.
+      This channel is optional and should be enabled only when a PagerDuty
+      integration is configured.
+    type: pagerduty
+    labels:
+      # The service_key (integration key) must be provided at apply time.
+      # Do not commit the actual key to source control.
+      service_key: "${PAGERDUTY_SERVICE_KEY}"
+    enabled: false             # Enable when PagerDuty integration is configured.
+    # PagerDuty is used for CRITICAL severity only.

--- a/deploy/monitoring/uptime-checks.yaml
+++ b/deploy/monitoring/uptime-checks.yaml
@@ -1,0 +1,142 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Uptime check definitions for GCP Cloud Monitoring.
+#
+# Hub endpoints are public-facing and checked via the global GCP uptime-check
+# infrastructure. Broker endpoints are internal and checked from within the
+# private network (requires a private checker or internal uptime check config).
+
+uptimeChecks:
+
+  # ---------------------------------------------------------------------------
+  # Hub checks (public HTTPS)
+  # ---------------------------------------------------------------------------
+
+  - displayName: "Hub /healthz"
+    description: |
+      Liveness check for the Scion Hub. Verifies the server process is running
+      and able to serve HTTP requests. A failure here means the Hub is down or
+      unreachable from the public internet.
+    monitoredResource:
+      type: uptime_url
+      labels:
+        # Replace with the actual Hub hostname before applying.
+        host: "hub.scion.example.com"
+    httpCheck:
+      path: "/healthz"
+      port: 443
+      useSsl: true
+      validateSsl: true
+      requestMethod: GET
+    contentMatchers:
+      - content: "healthy"
+        matcher: CONTAINS_STRING
+    period: "60s"              # Check every 1 minute
+    timeout: "10s"
+    notificationChannels:
+      - email
+      - slack
+      - pagerduty
+
+  - displayName: "Hub /readyz"
+    description: |
+      Readiness check for the Scion Hub. Verifies the server has completed
+      startup, established database connections, and is ready to handle
+      requests. A failure here means the Hub is alive but not yet ready to
+      serve traffic (e.g., during a rolling deploy).
+    monitoredResource:
+      type: uptime_url
+      labels:
+        host: "hub.scion.example.com"
+    httpCheck:
+      path: "/readyz"
+      port: 443
+      useSsl: true
+      validateSsl: true
+      requestMethod: GET
+    contentMatchers:
+      - content: "ready"
+        matcher: CONTAINS_STRING
+    period: "60s"              # Check every 1 minute
+    timeout: "10s"
+    notificationChannels:
+      - email
+      - slack
+      - pagerduty
+
+  # ---------------------------------------------------------------------------
+  # Broker checks (internal HTTP)
+  # ---------------------------------------------------------------------------
+
+  - displayName: "Broker /healthz"
+    description: |
+      Liveness check for the Runtime Broker. The Broker is an internal service
+      not exposed to the public internet, so this check runs from within the
+      private network using an internal uptime check configuration. A failure
+      indicates the Broker process is down or the internal network path is
+      broken.
+    monitoredResource:
+      type: uptime_url
+      labels:
+        # Internal hostname or IP; replace before applying.
+        host: "broker.internal.scion.example.com"
+    httpCheck:
+      path: "/healthz"
+      port: 8080
+      useSsl: false
+      requestMethod: GET
+    contentMatchers:
+      - content: "healthy"
+        matcher: CONTAINS_STRING
+    # Internal checks use a longer period since the Broker is not user-facing.
+    period: "300s"             # Check every 5 minutes
+    timeout: "10s"
+    internalCheckers:
+      # Requires a GCP private uptime check configuration.
+      # See: https://cloud.google.com/monitoring/uptime-checks/private-checks
+      - gcpZone: "us-central1-a"
+        network: "default"
+        projectId: "${GCP_PROJECT_ID}"
+    notificationChannels:
+      - email
+      - slack
+
+  - displayName: "Broker /readyz"
+    description: |
+      Readiness check for the Runtime Broker. Verifies the Broker has
+      established connections to the Hub, the command bus, and the container
+      runtime. A failure here means the Broker is alive but cannot process
+      agent lifecycle requests.
+    monitoredResource:
+      type: uptime_url
+      labels:
+        host: "broker.internal.scion.example.com"
+    httpCheck:
+      path: "/readyz"
+      port: 8080
+      useSsl: false
+      requestMethod: GET
+    contentMatchers:
+      - content: "ready"
+        matcher: CONTAINS_STRING
+    period: "300s"             # Check every 5 minutes
+    timeout: "10s"
+    internalCheckers:
+      - gcpZone: "us-central1-a"
+        network: "default"
+        projectId: "${GCP_PROJECT_ID}"
+    notificationChannels:
+      - email
+      - slack

--- a/pkg/hub/handlers_health_summary.go
+++ b/pkg/hub/handlers_health_summary.go
@@ -162,6 +162,9 @@ func (s *Server) handleHealthSummary(w http.ResponseWriter, r *http.Request) {
 		Crashed: []string{},
 		Errored: []string{},
 	}
+	// Limit is a safety cap to avoid unbounded memory on very large installations.
+	// Agents beyond this cap will not appear in stalled/crashed/errored lists but
+	// TotalCount (used for the total gauge) is still accurate.
 	if agentResult, err := s.store.ListAgents(ctx, store.AgentFilter{}, store.ListOptions{Limit: 10000}); err == nil {
 		agentsSummary.Total = agentResult.TotalCount
 		for _, a := range agentResult.Items {

--- a/pkg/hub/handlers_health_summary.go
+++ b/pkg/hub/handlers_health_summary.go
@@ -16,10 +16,10 @@ package hub
 
 import (
 	"database/sql"
+	"log/slog"
 	"net/http"
 	"time"
 
-	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
@@ -121,6 +121,12 @@ func (s *Server) handleHealthSummary(w http.ResponseWriter, r *http.Request) {
 	// Get base health info
 	healthInfo := s.GetHealthInfo(ctx)
 
+	// Determine overall status early so DB-error branches can degrade it.
+	overallStatus := "healthy"
+	if healthInfo.Status != "" && healthInfo.Status != "healthy" {
+		overallStatus = healthInfo.Status
+	}
+
 	// Build hub section
 	hubSummary := HealthSummaryHub{
 		Status:  healthInfo.Status,
@@ -154,64 +160,48 @@ func (s *Server) handleHealthSummary(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Fetch all agents once and group by broker ID to avoid N+1 queries.
-	type agentBuckets struct {
-		count   int
-		healthy int
-	}
-	agentsByBroker := make(map[string]*agentBuckets)
+	// Use aggregate queries instead of fetching full agent records.
+	// This avoids deserialising up to 10 000 structs on every 30 s poll.
 	agentsSummary := HealthSummaryAgents{
 		ByPhase: make(map[string]int),
 		Stalled: []string{},
 		Crashed: []string{},
 		Errored: []string{},
 	}
-	// Limit is a safety cap to avoid unbounded memory on very large installations.
-	// Agents beyond this cap will not appear in stalled/crashed/errored lists but
-	// TotalCount (used for the total gauge) is still accurate.
-	if agentResult, err := s.store.ListAgents(ctx, store.AgentFilter{}, store.ListOptions{Limit: 10000}); err == nil {
-		agentsSummary.Total = agentResult.TotalCount
-		for _, a := range agentResult.Items {
-			if a.Phase != "" {
-				agentsSummary.ByPhase[a.Phase]++
-			}
-			if a.Activity == string(state.ActivityStalled) {
-				agentsSummary.Stalled = append(agentsSummary.Stalled, a.Name)
-			}
-			if a.Activity == string(state.ActivityCrashed) {
-				agentsSummary.Crashed = append(agentsSummary.Crashed, a.Name)
-			}
-			if a.Phase == string(state.PhaseError) {
-				agentsSummary.Errored = append(agentsSummary.Errored, a.Name)
-			}
 
-			// Bucket by broker for per-broker counts
-			bid := a.RuntimeBrokerID
-			if bid != "" {
-				b, ok := agentsByBroker[bid]
-				if !ok {
-					b = &agentBuckets{}
-					agentsByBroker[bid] = b
-				}
-				b.count++
-				if a.Phase != string(state.PhaseError) &&
-					a.Activity != string(state.ActivityStalled) &&
-					a.Activity != string(state.ActivityCrashed) {
-					b.healthy++
-				}
-			}
+	agentAgg, err := s.store.AggregateAgentHealth(ctx)
+	if err != nil {
+		slog.Error("health summary: failed to aggregate agent health", "error", err)
+		overallStatus = "degraded"
+	} else {
+		agentsSummary.Total = agentAgg.Total
+		agentsSummary.ByPhase = agentAgg.ByPhase
+		if len(agentAgg.StalledNames) > 0 {
+			agentsSummary.Stalled = agentAgg.StalledNames
+		}
+		if len(agentAgg.CrashedNames) > 0 {
+			agentsSummary.Crashed = agentAgg.CrashedNames
+		}
+		if len(agentAgg.ErroredNames) > 0 {
+			agentsSummary.Errored = agentAgg.ErroredNames
 		}
 	}
 
-	// Build brokers section using pre-computed agent buckets
+	// Build brokers section using pre-computed agent buckets from the aggregate.
 	var brokerSummaries []HealthSummaryBrkr
-	if brokerResult, err := s.store.ListRuntimeBrokers(ctx, store.RuntimeBrokerFilter{}, store.ListOptions{Limit: 100}); err == nil {
+	brokerResult, err := s.store.ListRuntimeBrokers(ctx, store.RuntimeBrokerFilter{}, store.ListOptions{Limit: 100})
+	if err != nil {
+		slog.Error("health summary: failed to list runtime brokers", "error", err)
+		overallStatus = "degraded"
+	} else {
 		for _, b := range brokerResult.Items {
 			agentCount := 0
 			agentHealthy := 0
-			if bucket, ok := agentsByBroker[b.ID]; ok {
-				agentCount = bucket.count
-				agentHealthy = bucket.healthy
+			if agentAgg != nil {
+				if bucket, ok := agentAgg.ByBroker[b.ID]; ok {
+					agentCount = bucket.Count
+					agentHealthy = bucket.Healthy
+				}
 			}
 
 			// Determine runtime type from profiles
@@ -251,11 +241,7 @@ func (s *Server) handleHealthSummary(w http.ResponseWriter, r *http.Request) {
 		AutoSuspend:      s.config.AutoSuspendStalled,
 	}
 
-	// Determine overall status
-	overallStatus := "healthy"
-	if healthInfo.Status == "degraded" {
-		overallStatus = "degraded"
-	}
+	// Propagate unhealthy agent/broker signals into overall status.
 	if len(agentsSummary.Stalled) > 0 || len(agentsSummary.Crashed) > 0 || len(agentsSummary.Errored) > 0 {
 		overallStatus = "degraded"
 	}

--- a/pkg/hub/handlers_health_summary.go
+++ b/pkg/hub/handlers_health_summary.go
@@ -27,13 +27,13 @@ import (
 // GET /api/v1/admin/health/summary. It aggregates all subsystem health
 // into a single response for the health dashboard.
 type HealthSummaryResponse struct {
-	Status   string               `json:"status"`
-	Hub      HealthSummaryHub     `json:"hub"`
-	Database HealthSummaryDB      `json:"database"`
-	Brokers  []HealthSummaryBrkr  `json:"brokers"`
-	Agents   HealthSummaryAgents  `json:"agents"`
-	Dispatch HealthSummaryDispatch `json:"dispatch"`
-	Stall    HealthSummaryStall   `json:"stall_config"`
+	Status   string                `json:"status"`
+	Hub      HealthSummaryHub      `json:"hub"`
+	Database HealthSummaryDB       `json:"database"`
+	Brokers  []HealthSummaryBrkr   `json:"brokers"`
+	Agents   HealthSummaryAgents   `json:"agents"`
+	Dispatch *HealthSummaryDispatch `json:"dispatch"` // nil when dispatch metrics are unavailable
+	Stall    HealthSummaryStall    `json:"stall_config"`
 }
 
 // HealthSummaryHub contains hub-level health information.
@@ -48,11 +48,13 @@ type HealthSummaryHub struct {
 
 // HealthSummaryDB contains database health information.
 type HealthSummaryDB struct {
-	Status      string `json:"status"`
-	PoolActive  int64  `json:"pool_active"`
-	PoolMax     int64  `json:"pool_max"`
-	PoolWaiting int64  `json:"pool_waiting"`
-	PoolIdle    int64  `json:"pool_idle"`
+	Status    string `json:"status"`
+	PoolActive int64 `json:"pool_active"`
+	PoolMax    int64 `json:"pool_max"`
+	PoolIdle   int64 `json:"pool_idle"`
+	// PoolWaitCountTotal is the cumulative number of times a caller had to wait
+	// for a DB connection (monotonically increasing counter from sql.DBStats.WaitCount).
+	PoolWaitCountTotal int64 `json:"pool_wait_count_total"`
 }
 
 // HealthSummaryBrkr contains per-broker health information.
@@ -65,6 +67,10 @@ type HealthSummaryBrkr struct {
 	AgentCount       int       `json:"agent_count"`
 	AgentHealthy     int       `json:"agent_healthy"`
 	LastHeartbeat    time.Time `json:"last_heartbeat"`
+	// NFS health fields are not yet populated — the broker heartbeat protocol
+	// does not currently report NFS mount status. Tracked as a follow-up to
+	// the health monitoring design (§4.1 D5). TODO: wire NFS health once the
+	// broker API exposes it.
 }
 
 // HealthSummaryAgents contains agent health summary.
@@ -77,6 +83,7 @@ type HealthSummaryAgents struct {
 }
 
 // HealthSummaryDispatch contains dispatch pipeline health.
+// When nil in HealthSummaryResponse, dispatch metrics are not available.
 type HealthSummaryDispatch struct {
 	StuckMessages int `json:"stuck_messages"`
 	Failed1h      int `json:"failed_1h"`
@@ -90,9 +97,18 @@ type HealthSummaryStall struct {
 
 // handleHealthSummary handles GET /api/v1/admin/health/summary.
 // Returns a composite health summary aggregating all subsystems.
+// Requires admin role.
 func (s *Server) handleHealthSummary(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		MethodNotAllowed(w)
+		return
+	}
+
+	// Enforce admin authorization — this endpoint exposes sensitive infrastructure
+	// details (DB pool stats, broker hostnames, agent states, dispatch status).
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil || user.Role() != "admin" {
+		Forbidden(w)
 		return
 	}
 
@@ -129,25 +145,66 @@ func (s *Server) handleHealthSummary(w http.ResponseWriter, r *http.Request) {
 			stats := db.Stats()
 			dbSummary.PoolActive = int64(stats.InUse)
 			dbSummary.PoolIdle = int64(stats.Idle)
-			dbSummary.PoolWaiting = stats.WaitCount
+			dbSummary.PoolWaitCountTotal = stats.WaitCount
 			dbSummary.PoolMax = int64(stats.MaxOpenConnections)
 		}
 	}
 
-	// Build brokers section
+	// Fetch all agents once and group by broker ID to avoid N+1 queries.
+	type agentBuckets struct {
+		count   int
+		healthy int
+	}
+	agentsByBroker := make(map[string]*agentBuckets)
+	agentsSummary := HealthSummaryAgents{
+		ByPhase: make(map[string]int),
+		Stalled: []string{},
+		Crashed: []string{},
+		Errored: []string{},
+	}
+	if agentResult, err := s.store.ListAgents(ctx, store.AgentFilter{}, store.ListOptions{Limit: 10000}); err == nil {
+		agentsSummary.Total = agentResult.TotalCount
+		for _, a := range agentResult.Items {
+			if a.Phase != "" {
+				agentsSummary.ByPhase[a.Phase]++
+			}
+			if a.Activity == string(state.ActivityStalled) {
+				agentsSummary.Stalled = append(agentsSummary.Stalled, a.Name)
+			}
+			if a.Activity == string(state.ActivityCrashed) {
+				agentsSummary.Crashed = append(agentsSummary.Crashed, a.Name)
+			}
+			if a.Phase == string(state.PhaseError) {
+				agentsSummary.Errored = append(agentsSummary.Errored, a.Name)
+			}
+
+			// Bucket by broker for per-broker counts
+			bid := a.RuntimeBrokerID
+			if bid != "" {
+				b, ok := agentsByBroker[bid]
+				if !ok {
+					b = &agentBuckets{}
+					agentsByBroker[bid] = b
+				}
+				b.count++
+				if a.Phase != string(state.PhaseError) &&
+					a.Activity != string(state.ActivityStalled) &&
+					a.Activity != string(state.ActivityCrashed) {
+					b.healthy++
+				}
+			}
+		}
+	}
+
+	// Build brokers section using pre-computed agent buckets
 	var brokerSummaries []HealthSummaryBrkr
 	if brokerResult, err := s.store.ListRuntimeBrokers(ctx, store.RuntimeBrokerFilter{}, store.ListOptions{Limit: 100}); err == nil {
 		for _, b := range brokerResult.Items {
-			// Count agents on this broker
 			agentCount := 0
 			agentHealthy := 0
-			if agentResult, err := s.store.ListAgents(ctx, store.AgentFilter{RuntimeBrokerID: b.ID}, store.ListOptions{Limit: 1000}); err == nil {
-				agentCount = agentResult.TotalCount
-				for _, a := range agentResult.Items {
-					if a.Phase != string(state.PhaseError) && a.Activity != string(state.ActivityStalled) && a.Activity != string(state.ActivityCrashed) {
-						agentHealthy++
-					}
-				}
+			if bucket, ok := agentsByBroker[b.ID]; ok {
+				agentCount = bucket.count
+				agentHealthy = bucket.healthy
 			}
 
 			// Determine runtime type from profiles
@@ -174,49 +231,18 @@ func (s *Server) handleHealthSummary(w http.ResponseWriter, r *http.Request) {
 		brokerSummaries = []HealthSummaryBrkr{}
 	}
 
-	// Build agents section
-	agentsSummary := HealthSummaryAgents{
-		ByPhase: make(map[string]int),
-		Stalled: []string{},
-		Crashed: []string{},
-		Errored: []string{},
-	}
-	if agentResult, err := s.store.ListAgents(ctx, store.AgentFilter{}, store.ListOptions{Limit: 10000}); err == nil {
-		agentsSummary.Total = agentResult.TotalCount
-		for _, a := range agentResult.Items {
-			if a.Phase != "" {
-				agentsSummary.ByPhase[a.Phase]++
-			}
-			if a.Activity == string(state.ActivityStalled) {
-				agentsSummary.Stalled = append(agentsSummary.Stalled, a.Name)
-			}
-			if a.Activity == string(state.ActivityCrashed) {
-				agentsSummary.Crashed = append(agentsSummary.Crashed, a.Name)
-			}
-			if a.Phase == string(state.PhaseError) {
-				agentsSummary.Errored = append(agentsSummary.Errored, a.Name)
-			}
-		}
-	}
-
-	// Build dispatch section
-	dispatchSummary := HealthSummaryDispatch{}
-	// Dispatch stats are available via metrics snapshot if configured
-	if s.metrics != nil {
-		snap := s.metrics.GetSnapshot()
-		if snap != nil {
-			dispatchSummary.StuckMessages = 0 // Stuck messages gauge not in snapshot
-		}
-	}
+	// Dispatch section: the dispatchmetrics.Recorder does not currently expose a
+	// Stats() method for reading in-process counters. Rather than returning
+	// hardcoded zeros (which would mislead operators), we omit the dispatch data
+	// and let the dashboard render "data not available". TODO: add a Stats()
+	// method to dispatchmetrics.Recorder to populate this section.
+	var dispatchSummary *HealthSummaryDispatch // nil = unavailable
 
 	// Build stall config section
 	stallConfig := HealthSummaryStall{
 		ThresholdSeconds: int(s.config.StalledThreshold.Seconds()),
 		AutoSuspend:      s.config.AutoSuspendStalled,
 	}
-	// Operational settings may override the stall config; the values from
-	// ServerConfig already reflect the effective merge (bootstrap + env + DB)
-	// so no additional lookup is needed here.
 
 	// Determine overall status
 	overallStatus := "healthy"

--- a/pkg/hub/handlers_health_summary.go
+++ b/pkg/hub/handlers_health_summary.go
@@ -1,0 +1,247 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"database/sql"
+	"net/http"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// HealthSummaryResponse is the composite health summary returned by
+// GET /api/v1/admin/health/summary. It aggregates all subsystem health
+// into a single response for the health dashboard.
+type HealthSummaryResponse struct {
+	Status   string               `json:"status"`
+	Hub      HealthSummaryHub     `json:"hub"`
+	Database HealthSummaryDB      `json:"database"`
+	Brokers  []HealthSummaryBrkr  `json:"brokers"`
+	Agents   HealthSummaryAgents  `json:"agents"`
+	Dispatch HealthSummaryDispatch `json:"dispatch"`
+	Stall    HealthSummaryStall   `json:"stall_config"`
+}
+
+// HealthSummaryHub contains hub-level health information.
+type HealthSummaryHub struct {
+	Status           string `json:"status"`
+	Version          string `json:"version"`
+	Uptime           string `json:"uptime"`
+	ConnectedBrokers int    `json:"connected_brokers"`
+	ActiveAgents     int    `json:"active_agents"`
+	Projects         int    `json:"projects"`
+}
+
+// HealthSummaryDB contains database health information.
+type HealthSummaryDB struct {
+	Status      string `json:"status"`
+	PoolActive  int64  `json:"pool_active"`
+	PoolMax     int64  `json:"pool_max"`
+	PoolWaiting int64  `json:"pool_waiting"`
+	PoolIdle    int64  `json:"pool_idle"`
+}
+
+// HealthSummaryBrkr contains per-broker health information.
+type HealthSummaryBrkr struct {
+	ID               string    `json:"id"`
+	Name             string    `json:"name"`
+	Status           string    `json:"status"`
+	Runtime          string    `json:"runtime"`
+	RuntimeAvailable bool      `json:"runtime_available"`
+	AgentCount       int       `json:"agent_count"`
+	AgentHealthy     int       `json:"agent_healthy"`
+	LastHeartbeat    time.Time `json:"last_heartbeat"`
+}
+
+// HealthSummaryAgents contains agent health summary.
+type HealthSummaryAgents struct {
+	Total   int            `json:"total"`
+	ByPhase map[string]int `json:"by_phase"`
+	Stalled []string       `json:"stalled"`
+	Crashed []string       `json:"crashed"`
+	Errored []string       `json:"errored"`
+}
+
+// HealthSummaryDispatch contains dispatch pipeline health.
+type HealthSummaryDispatch struct {
+	StuckMessages int `json:"stuck_messages"`
+	Failed1h      int `json:"failed_1h"`
+}
+
+// HealthSummaryStall contains stall detection configuration.
+type HealthSummaryStall struct {
+	ThresholdSeconds int  `json:"threshold_seconds"`
+	AutoSuspend      bool `json:"auto_suspend"`
+}
+
+// handleHealthSummary handles GET /api/v1/admin/health/summary.
+// Returns a composite health summary aggregating all subsystems.
+func (s *Server) handleHealthSummary(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	// Get base health info
+	healthInfo := s.GetHealthInfo(ctx)
+
+	// Build hub section
+	hubSummary := HealthSummaryHub{
+		Status:  healthInfo.Status,
+		Version: healthInfo.ScionVersion,
+		Uptime:  healthInfo.Uptime,
+	}
+	if healthInfo.Stats != nil {
+		hubSummary.ConnectedBrokers = healthInfo.Stats.ConnectedBrokers
+		hubSummary.ActiveAgents = healthInfo.Stats.ActiveAgents
+		hubSummary.Projects = healthInfo.Stats.Projects
+	}
+
+	// Build database section
+	dbSummary := HealthSummaryDB{
+		Status: "healthy",
+	}
+	if healthInfo.Checks != nil {
+		if dbStatus, ok := healthInfo.Checks["database"]; ok {
+			dbSummary.Status = dbStatus
+		}
+	}
+	// Get pool stats from sql.DB if available
+	if dbp, ok := s.store.(interface{ DB() *sql.DB }); ok {
+		db := dbp.DB()
+		if db != nil {
+			stats := db.Stats()
+			dbSummary.PoolActive = int64(stats.InUse)
+			dbSummary.PoolIdle = int64(stats.Idle)
+			dbSummary.PoolWaiting = stats.WaitCount
+			dbSummary.PoolMax = int64(stats.MaxOpenConnections)
+		}
+	}
+
+	// Build brokers section
+	var brokerSummaries []HealthSummaryBrkr
+	if brokerResult, err := s.store.ListRuntimeBrokers(ctx, store.RuntimeBrokerFilter{}, store.ListOptions{Limit: 100}); err == nil {
+		for _, b := range brokerResult.Items {
+			// Count agents on this broker
+			agentCount := 0
+			agentHealthy := 0
+			if agentResult, err := s.store.ListAgents(ctx, store.AgentFilter{RuntimeBrokerID: b.ID}, store.ListOptions{Limit: 1000}); err == nil {
+				agentCount = agentResult.TotalCount
+				for _, a := range agentResult.Items {
+					if a.Phase != string(state.PhaseError) && a.Activity != string(state.ActivityStalled) && a.Activity != string(state.ActivityCrashed) {
+						agentHealthy++
+					}
+				}
+			}
+
+			// Determine runtime type from profiles
+			runtime := "unknown"
+			runtimeAvailable := false
+			if len(b.Profiles) > 0 {
+				runtime = b.Profiles[0].Type
+				runtimeAvailable = b.Profiles[0].Available
+			}
+
+			brokerSummaries = append(brokerSummaries, HealthSummaryBrkr{
+				ID:               b.ID,
+				Name:             b.Name,
+				Status:           b.Status,
+				Runtime:          runtime,
+				RuntimeAvailable: runtimeAvailable,
+				AgentCount:       agentCount,
+				AgentHealthy:     agentHealthy,
+				LastHeartbeat:    b.LastHeartbeat,
+			})
+		}
+	}
+	if brokerSummaries == nil {
+		brokerSummaries = []HealthSummaryBrkr{}
+	}
+
+	// Build agents section
+	agentsSummary := HealthSummaryAgents{
+		ByPhase: make(map[string]int),
+		Stalled: []string{},
+		Crashed: []string{},
+		Errored: []string{},
+	}
+	if agentResult, err := s.store.ListAgents(ctx, store.AgentFilter{}, store.ListOptions{Limit: 10000}); err == nil {
+		agentsSummary.Total = agentResult.TotalCount
+		for _, a := range agentResult.Items {
+			if a.Phase != "" {
+				agentsSummary.ByPhase[a.Phase]++
+			}
+			if a.Activity == string(state.ActivityStalled) {
+				agentsSummary.Stalled = append(agentsSummary.Stalled, a.Name)
+			}
+			if a.Activity == string(state.ActivityCrashed) {
+				agentsSummary.Crashed = append(agentsSummary.Crashed, a.Name)
+			}
+			if a.Phase == string(state.PhaseError) {
+				agentsSummary.Errored = append(agentsSummary.Errored, a.Name)
+			}
+		}
+	}
+
+	// Build dispatch section
+	dispatchSummary := HealthSummaryDispatch{}
+	// Dispatch stats are available via metrics snapshot if configured
+	if s.metrics != nil {
+		snap := s.metrics.GetSnapshot()
+		if snap != nil {
+			dispatchSummary.StuckMessages = 0 // Stuck messages gauge not in snapshot
+		}
+	}
+
+	// Build stall config section
+	stallConfig := HealthSummaryStall{
+		ThresholdSeconds: int(s.config.StalledThreshold.Seconds()),
+		AutoSuspend:      s.config.AutoSuspendStalled,
+	}
+	// Operational settings may override the stall config; the values from
+	// ServerConfig already reflect the effective merge (bootstrap + env + DB)
+	// so no additional lookup is needed here.
+
+	// Determine overall status
+	overallStatus := "healthy"
+	if healthInfo.Status == "degraded" {
+		overallStatus = "degraded"
+	}
+	if len(agentsSummary.Stalled) > 0 || len(agentsSummary.Crashed) > 0 || len(agentsSummary.Errored) > 0 {
+		overallStatus = "degraded"
+	}
+	for _, b := range brokerSummaries {
+		if b.Status != "online" && b.Status != "" {
+			overallStatus = "degraded"
+			break
+		}
+	}
+
+	resp := HealthSummaryResponse{
+		Status:   overallStatus,
+		Hub:      hubSummary,
+		Database: dbSummary,
+		Brokers:  brokerSummaries,
+		Agents:   agentsSummary,
+		Dispatch: dispatchSummary,
+		Stall:    stallConfig,
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/pkg/hub/handlers_health_summary.go
+++ b/pkg/hub/handlers_health_summary.go
@@ -47,6 +47,10 @@ type HealthSummaryHub struct {
 }
 
 // HealthSummaryDB contains database health information.
+// Fields are sourced from Go's sql.DBStats (runtime pool counters) rather than
+// the OTel-based metrics described in the design doc. sql.DBStats provides
+// accurate, zero-latency pool stats without depending on the metrics pipeline,
+// which may itself be the thing that is unhealthy.
 type HealthSummaryDB struct {
 	Status    string `json:"status"`
 	PoolActive int64 `json:"pool_active"`

--- a/pkg/hub/handlers_health_summary.go
+++ b/pkg/hub/handlers_health_summary.go
@@ -27,13 +27,13 @@ import (
 // GET /api/v1/admin/health/summary. It aggregates all subsystem health
 // into a single response for the health dashboard.
 type HealthSummaryResponse struct {
-	Status   string                `json:"status"`
-	Hub      HealthSummaryHub      `json:"hub"`
-	Database HealthSummaryDB       `json:"database"`
-	Brokers  []HealthSummaryBrkr   `json:"brokers"`
-	Agents   HealthSummaryAgents   `json:"agents"`
+	Status   string                 `json:"status"`
+	Hub      HealthSummaryHub       `json:"hub"`
+	Database HealthSummaryDB        `json:"database"`
+	Brokers  []HealthSummaryBrkr    `json:"brokers"`
+	Agents   HealthSummaryAgents    `json:"agents"`
 	Dispatch *HealthSummaryDispatch `json:"dispatch"` // nil when dispatch metrics are unavailable
-	Stall    HealthSummaryStall    `json:"stall_config"`
+	Stall    HealthSummaryStall     `json:"stall_config"`
 }
 
 // HealthSummaryHub contains hub-level health information.
@@ -52,10 +52,10 @@ type HealthSummaryHub struct {
 // accurate, zero-latency pool stats without depending on the metrics pipeline,
 // which may itself be the thing that is unhealthy.
 type HealthSummaryDB struct {
-	Status    string `json:"status"`
-	PoolActive int64 `json:"pool_active"`
-	PoolMax    int64 `json:"pool_max"`
-	PoolIdle   int64 `json:"pool_idle"`
+	Status     string `json:"status"`
+	PoolActive int64  `json:"pool_active"`
+	PoolMax    int64  `json:"pool_max"`
+	PoolIdle   int64  `json:"pool_idle"`
 	// PoolWaitCountTotal is the cumulative number of times a caller had to wait
 	// for a DB connection (monotonically increasing counter from sql.DBStats.WaitCount).
 	PoolWaitCountTotal int64 `json:"pool_wait_count_total"`

--- a/pkg/hub/handlers_health_summary_test.go
+++ b/pkg/hub/handlers_health_summary_test.go
@@ -120,9 +120,9 @@ func TestHandleHealthSummary_AgentAggregation(t *testing.T) {
 
 	// Create a broker
 	broker := &store.RuntimeBroker{
-		ID:   tid("broker-1"),
-		Name: "Broker One",
-		Slug: "broker-one",
+		ID:     tid("broker-1"),
+		Name:   "Broker One",
+		Slug:   "broker-one",
 		Status: "online",
 		Profiles: []store.BrokerProfile{
 			{Name: "default", Type: "docker", Available: true},
@@ -197,11 +197,11 @@ func TestHandleHealthSummary_BrokerMixedStatus(t *testing.T) {
 
 	// Create brokers with different statuses
 	brokers := []struct {
-		id       string
-		name     string
-		slug     string
-		status   string
-		runtime  string
+		id        string
+		name      string
+		slug      string
+		status    string
+		runtime   string
 		available bool
 	}{
 		{"broker-online", "Online Broker", "online-broker", "online", "docker", true},

--- a/pkg/hub/handlers_health_summary_test.go
+++ b/pkg/hub/handlers_health_summary_test.go
@@ -1,0 +1,315 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleHealthSummary_AdminAccess(t *testing.T) {
+	srv, _ := testServer(t)
+
+	t.Run("Unauthenticated returns 403", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/health/summary", nil)
+		rr := httptest.NewRecorder()
+		srv.handleHealthSummary(rr, req)
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("Non-admin user returns 403", func(t *testing.T) {
+		member := NewAuthenticatedUser("u1", "member@example.com", "Member", "member", "cli")
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/health/summary", nil)
+		req = req.WithContext(contextWithIdentity(req.Context(), member))
+		rr := httptest.NewRecorder()
+		srv.handleHealthSummary(rr, req)
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("Admin user returns 200", func(t *testing.T) {
+		admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/health/summary", nil)
+		req = req.WithContext(contextWithIdentity(req.Context(), admin))
+		rr := httptest.NewRecorder()
+		srv.handleHealthSummary(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("POST returns 405", func(t *testing.T) {
+		admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/health/summary", nil)
+		req = req.WithContext(contextWithIdentity(req.Context(), admin))
+		rr := httptest.NewRecorder()
+		srv.handleHealthSummary(rr, req)
+		assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+	})
+}
+
+func TestHandleHealthSummary_ResponseShape(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Use the full router with dev auth (admin)
+	rr := doRequest(t, srv, http.MethodGet, "/api/v1/admin/health/summary", nil)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp HealthSummaryResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &resp)
+	require.NoError(t, err, "response should be valid JSON")
+
+	// Verify top-level status is present
+	assert.NotEmpty(t, resp.Status)
+
+	// Verify hub section populated
+	assert.NotEmpty(t, resp.Hub.Status)
+	assert.NotEmpty(t, resp.Hub.Version)
+	assert.NotEmpty(t, resp.Hub.Uptime)
+
+	// Verify database section populated
+	assert.NotEmpty(t, resp.Database.Status)
+
+	// Verify brokers is an array (even if empty)
+	assert.NotNil(t, resp.Brokers)
+
+	// Verify agents section has initialized maps/slices
+	assert.NotNil(t, resp.Agents.ByPhase)
+	assert.NotNil(t, resp.Agents.Stalled)
+	assert.NotNil(t, resp.Agents.Crashed)
+	assert.NotNil(t, resp.Agents.Errored)
+
+	// Verify dispatch is nil (no dispatch metrics available yet)
+	assert.Nil(t, resp.Dispatch)
+
+	// Verify stall config has defaults
+	assert.Equal(t, 300, resp.Stall.ThresholdSeconds, "default stalled threshold should be 5 minutes (300s)")
+}
+
+func TestHandleHealthSummary_AgentAggregation(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	// Create a project
+	project := &store.Project{
+		ID:   tid("health-project"),
+		Name: "Health Test Project",
+		Slug: "health-test",
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	// Create a broker
+	broker := &store.RuntimeBroker{
+		ID:   tid("broker-1"),
+		Name: "Broker One",
+		Slug: "broker-one",
+		Status: "online",
+		Profiles: []store.BrokerProfile{
+			{Name: "default", Type: "docker", Available: true},
+		},
+		LastHeartbeat: time.Now(),
+	}
+	require.NoError(t, s.CreateRuntimeBroker(ctx, broker))
+
+	// Create agents with mixed states
+	agents := []struct {
+		id       string
+		name     string
+		slug     string
+		phase    string
+		activity string
+		brokerID string
+	}{
+		{"agent-healthy-1", "Healthy Agent 1", "healthy-1", string(state.PhaseRunning), string(state.ActivityWorking), tid("broker-1")},
+		{"agent-healthy-2", "Healthy Agent 2", "healthy-2", string(state.PhaseRunning), string(state.ActivityWorking), tid("broker-1")},
+		{"agent-stalled", "Stalled Agent", "stalled-agent", string(state.PhaseRunning), string(state.ActivityStalled), tid("broker-1")},
+		{"agent-crashed", "Crashed Agent", "crashed-agent", string(state.PhaseRunning), string(state.ActivityCrashed), tid("broker-1")},
+		{"agent-errored", "Errored Agent", "errored-agent", string(state.PhaseError), "", ""},
+	}
+
+	for _, a := range agents {
+		ag := &store.Agent{
+			ID:              tid(a.id),
+			Name:            a.name,
+			Slug:            a.slug,
+			ProjectID:       project.ID,
+			Phase:           a.phase,
+			Activity:        a.activity,
+			RuntimeBrokerID: a.brokerID,
+		}
+		require.NoError(t, s.CreateAgent(ctx, ag))
+	}
+
+	rr := doRequest(t, srv, http.MethodGet, "/api/v1/admin/health/summary", nil)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp HealthSummaryResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	// Should be degraded because we have stalled/crashed/errored agents
+	assert.Equal(t, "degraded", resp.Status)
+
+	// Verify agent counts
+	assert.Equal(t, 5, resp.Agents.Total)
+	assert.Contains(t, resp.Agents.Stalled, "Stalled Agent")
+	assert.Contains(t, resp.Agents.Crashed, "Crashed Agent")
+	assert.Contains(t, resp.Agents.Errored, "Errored Agent")
+	assert.Len(t, resp.Agents.Stalled, 1)
+	assert.Len(t, resp.Agents.Crashed, 1)
+	assert.Len(t, resp.Agents.Errored, 1)
+
+	// Verify phase counts
+	assert.Equal(t, 4, resp.Agents.ByPhase[string(state.PhaseRunning)])
+	assert.Equal(t, 1, resp.Agents.ByPhase[string(state.PhaseError)])
+}
+
+func TestHandleHealthSummary_BrokerMixedStatus(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	// Create a project
+	project := &store.Project{
+		ID:   tid("broker-test-project"),
+		Name: "Broker Test",
+		Slug: "broker-test",
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	// Create brokers with different statuses
+	brokers := []struct {
+		id       string
+		name     string
+		slug     string
+		status   string
+		runtime  string
+		available bool
+	}{
+		{"broker-online", "Online Broker", "online-broker", "online", "docker", true},
+		{"broker-offline", "Offline Broker", "offline-broker", "offline", "kubernetes", false},
+	}
+
+	for _, b := range brokers {
+		br := &store.RuntimeBroker{
+			ID:     tid(b.id),
+			Name:   b.name,
+			Slug:   b.slug,
+			Status: b.status,
+			Profiles: []store.BrokerProfile{
+				{Name: "default", Type: b.runtime, Available: b.available},
+			},
+			LastHeartbeat: time.Now(),
+		}
+		require.NoError(t, s.CreateRuntimeBroker(ctx, br))
+	}
+
+	// Create agents assigned to the online broker
+	for i := 0; i < 3; i++ {
+		ag := &store.Agent{
+			ID:              tid("broker-agent-" + string(rune('a'+i))),
+			Name:            "Agent " + string(rune('A'+i)),
+			Slug:            "broker-agent-" + string(rune('a'+i)),
+			ProjectID:       project.ID,
+			Phase:           string(state.PhaseRunning),
+			Activity:        string(state.ActivityWorking),
+			RuntimeBrokerID: tid("broker-online"),
+		}
+		require.NoError(t, s.CreateAgent(ctx, ag))
+	}
+
+	rr := doRequest(t, srv, http.MethodGet, "/api/v1/admin/health/summary", nil)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp HealthSummaryResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	// Should be degraded because one broker is offline
+	assert.Equal(t, "degraded", resp.Status)
+
+	// Should have two brokers
+	require.Len(t, resp.Brokers, 2)
+
+	// Find the online broker and verify agent counts
+	var onlineBroker, offlineBroker *HealthSummaryBrkr
+	for i := range resp.Brokers {
+		switch resp.Brokers[i].Status {
+		case "online":
+			onlineBroker = &resp.Brokers[i]
+		case "offline":
+			offlineBroker = &resp.Brokers[i]
+		}
+	}
+
+	require.NotNil(t, onlineBroker, "should have an online broker")
+	require.NotNil(t, offlineBroker, "should have an offline broker")
+
+	assert.Equal(t, 3, onlineBroker.AgentCount)
+	assert.Equal(t, 3, onlineBroker.AgentHealthy)
+	assert.Equal(t, "docker", onlineBroker.Runtime)
+	assert.True(t, onlineBroker.RuntimeAvailable)
+
+	assert.Equal(t, 0, offlineBroker.AgentCount)
+	assert.Equal(t, "kubernetes", offlineBroker.Runtime)
+	assert.False(t, offlineBroker.RuntimeAvailable)
+}
+
+func TestHandleHealthSummary_DispatchNullWhenUnavailable(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rr := doRequest(t, srv, http.MethodGet, "/api/v1/admin/health/summary", nil)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Verify the raw JSON has dispatch: null
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
+	assert.Equal(t, "null", string(raw["dispatch"]))
+}
+
+func TestHandleHealthSummary_DatabaseHealthy(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rr := doRequest(t, srv, http.MethodGet, "/api/v1/admin/health/summary", nil)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp HealthSummaryResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	// SQLite test DB should be healthy
+	assert.Equal(t, "healthy", resp.Database.Status)
+	// Pool stats should be populated (at least max > 0 from sqlite config)
+	// Note: SQLite test stores use MaxOpenConns=1
+	assert.GreaterOrEqual(t, resp.Database.PoolMax, int64(0))
+}
+
+func TestHandleHealthSummary_ViaRouter(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Verify the route is registered and reachable through the full mux
+	rr := doRequest(t, srv, http.MethodGet, "/api/v1/admin/health/summary", nil)
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	// Unauthenticated should fail through the full mux
+	rr = doRequestNoAuth(t, srv, http.MethodGet, "/api/v1/admin/health/summary", nil)
+	// Without auth, the auth middleware may return 401 or the handler returns 403
+	assert.True(t, rr.Code == http.StatusForbidden || rr.Code == http.StatusUnauthorized,
+		"unauthenticated request should be rejected, got %d", rr.Code)
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3016,6 +3016,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/admin/integrations/", s.handleAdminIntegrationByName)
 	s.mux.HandleFunc("/api/v1/admin/diagnostics/logs/stream", s.handleDiagnosticsLogsStream)
 	s.mux.HandleFunc("/api/v1/admin/diagnostics/logs", s.handleDiagnosticsLogs)
+	s.mux.HandleFunc("/api/v1/admin/health/summary", s.handleHealthSummary)
 	s.mux.HandleFunc("/api/v1/metrics/", s.handleMetricsDashboard)
 	s.mux.HandleFunc("/api/v1/admin/metrics-dashboard", s.handleAdminMetricsDashboard) // legacy backward-compat
 

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -149,6 +149,11 @@ type StatusUpdate struct {
 
 	// Exit tracking
 	ExitCode *int `json:"exitCode,omitempty"`
+
+	// Telemetry health flag — reports whether the agent's telemetry pipeline
+	// is running and exporting successfully. Set by sciontool during status
+	// updates so the Hub can aggregate pipeline health across agents.
+	TelemetryHealthy *bool `json:"telemetryHealthy,omitempty"`
 }
 
 // Client is a Hub API client for sciontool.

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -149,11 +149,6 @@ type StatusUpdate struct {
 
 	// Exit tracking
 	ExitCode *int `json:"exitCode,omitempty"`
-
-	// Telemetry health flag — reports whether the agent's telemetry pipeline
-	// is running and exporting successfully. Set by sciontool during status
-	// updates so the Hub can aggregate pipeline health across agents.
-	TelemetryHealthy *bool `json:"telemetryHealthy,omitempty"`
 }
 
 // Client is a Hub API client for sciontool.

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -945,3 +945,103 @@ func (s *AgentStore) ReassignProjectBroker(ctx context.Context, oldBrokerID, new
 	}
 	return affected, nil
 }
+
+// AggregateAgentHealth computes health-oriented counts via GROUP BY queries
+// instead of loading full agent records. The approach uses three lightweight
+// queries:
+//  1. COUNT(*) GROUP BY phase            → ByPhase + Total
+//  2. COUNT(*) GROUP BY runtime_broker_id, phase, activity → ByBroker
+//  3. SELECT name WHERE phase/activity ∈ unhealthy (limit 100 each)
+func (s *AgentStore) AggregateAgentHealth(ctx context.Context) (*store.AgentHealthAggregate, error) {
+	result := &store.AgentHealthAggregate{
+		ByPhase:  make(map[string]int),
+		ByBroker: make(map[string]store.AgentBrokerCounts),
+	}
+
+	// 1. Count agents by phase (non-deleted only).
+	var phaseCounts []struct {
+		Phase string `json:"phase"`
+		Count int    `json:"count"`
+	}
+	err := s.client.Agent.Query().
+		Where(agent.DeletedAtIsNil()).
+		GroupBy(agent.FieldPhase).
+		Aggregate(ent.Count()).
+		Scan(ctx, &phaseCounts)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate phase counts: %w", err)
+	}
+	for _, pc := range phaseCounts {
+		result.ByPhase[pc.Phase] += pc.Count
+		result.Total += pc.Count
+	}
+
+	// 2. Count agents by broker, phase, and activity for per-broker health tallies.
+	var brokerCounts []struct {
+		BrokerID string `json:"runtime_broker_id"`
+		Phase    string `json:"phase"`
+		Activity string `json:"activity"`
+		Count    int    `json:"count"`
+	}
+	err = s.client.Agent.Query().
+		Where(agent.DeletedAtIsNil(), agent.RuntimeBrokerIDNEQ("")).
+		GroupBy(agent.FieldRuntimeBrokerID, agent.FieldPhase, agent.FieldActivity).
+		Aggregate(ent.Count()).
+		Scan(ctx, &brokerCounts)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate broker counts: %w", err)
+	}
+	for _, bc := range brokerCounts {
+		bid := bc.BrokerID
+		if bid == "" {
+			continue
+		}
+		entry := result.ByBroker[bid]
+		entry.Count += bc.Count
+		if bc.Phase != "error" && bc.Activity != "stalled" && bc.Activity != "crashed" {
+			entry.Healthy += bc.Count
+		}
+		result.ByBroker[bid] = entry
+	}
+
+	// 3. Fetch names of unhealthy agents (capped lists).
+	const unhealthyCap = 100
+
+	stalledAgents, err := s.client.Agent.Query().
+		Where(agent.DeletedAtIsNil(), agent.ActivityEQ("stalled")).
+		Select(agent.FieldName).
+		Limit(unhealthyCap).
+		All(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("query stalled agents: %w", err)
+	}
+	for _, a := range stalledAgents {
+		result.StalledNames = append(result.StalledNames, a.Name)
+	}
+
+	crashedAgents, err := s.client.Agent.Query().
+		Where(agent.DeletedAtIsNil(), agent.ActivityEQ("crashed")).
+		Select(agent.FieldName).
+		Limit(unhealthyCap).
+		All(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("query crashed agents: %w", err)
+	}
+	for _, a := range crashedAgents {
+		result.CrashedNames = append(result.CrashedNames, a.Name)
+	}
+
+	erroredAgents, err := s.client.Agent.Query().
+		Where(agent.DeletedAtIsNil(), agent.PhaseEQ("error")).
+		Select(agent.FieldName).
+		Limit(unhealthyCap).
+		All(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("query errored agents: %w", err)
+	}
+	for _, a := range erroredAgents {
+		result.ErroredNames = append(result.ErroredNames, a.Name)
+	}
+
+	return result, nil
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -204,6 +204,11 @@ type AgentStore interface {
 	// active remote brokers are left untouched. Returns the number of projects
 	// updated.
 	ReassignProjectBroker(ctx context.Context, oldBrokerID, newBrokerID string) (int, error)
+
+	// AggregateAgentHealth returns lightweight health-oriented counts and lists
+	// for the health-summary endpoint without fetching full agent records.
+	// This avoids the O(N) deserialization cost of ListAgents on large installations.
+	AggregateAgentHealth(ctx context.Context) (*AgentHealthAggregate, error)
 }
 
 // AgentFilter defines criteria for filtering agents.
@@ -236,6 +241,27 @@ type AgentFilter struct {
 	// Labels, when non-empty, restricts results to agents whose labels
 	// contain all specified key-value pairs (AND semantics).
 	Labels map[string]string
+}
+
+// AgentHealthAggregate holds pre-computed counts and short lists used by the
+// health-summary endpoint. It avoids loading full agent records.
+type AgentHealthAggregate struct {
+	Total   int            // Total number of non-deleted agents
+	ByPhase map[string]int // Count per lifecycle phase
+
+	// Per-broker counts: map[brokerID] → {count, healthy}
+	ByBroker map[string]AgentBrokerCounts
+
+	// Names of agents in unhealthy states (capped at 100 per list).
+	StalledNames []string
+	CrashedNames []string
+	ErroredNames []string
+}
+
+// AgentBrokerCounts holds per-broker agent tallies.
+type AgentBrokerCounts struct {
+	Count   int
+	Healthy int
 }
 
 // AgentStatusUpdate contains fields for status-only updates.

--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -144,6 +144,8 @@ const ROUTES: RouteConfig[] = [
   { pattern: /^\/admin\/users$/, tag: 'scion-page-admin-users', load: () => import('../components/pages/admin-users.js') },
   { pattern: /^\/admin\/groups$/, tag: 'scion-page-admin-groups', load: () => import('../components/pages/admin-groups.js') },
   { pattern: /^\/admin\/groups\/[^/]+$/, tag: 'scion-page-admin-group-detail', load: () => import('../components/pages/admin-group-detail.js') },
+  { pattern: /^\/health$/, tag: 'scion-page-health-dashboard', load: () => import('../components/pages/health-dashboard.js') },
+  { pattern: /^\/admin\/health$/, tag: 'scion-page-health-dashboard', load: () => import('../components/pages/health-dashboard.js') },
   { pattern: /^\/metrics$/, tag: 'scion-page-metrics', load: () => import('../components/pages/metrics-dashboard.js') },
   { pattern: /^\/admin\/metrics$/, tag: 'scion-page-metrics', load: () => import('../components/pages/metrics-dashboard.js') },
   { pattern: /^\/admin\/diagnostics$/, tag: 'scion-page-diagnostics', load: () => import('../components/pages/diagnostics.js') },
@@ -190,7 +192,7 @@ const PROFILE_ROUTES = new Set(['scion-page-profile-env-vars', 'scion-page-profi
 /**
  * Routes that require admin role. Non-admin users are redirected to dashboard.
  */
-const ADMIN_ROUTES = new Set(['scion-page-settings', 'scion-page-admin-scheduler', 'scion-page-admin-maintenance', 'scion-page-admin-users', 'scion-page-admin-groups', 'scion-page-admin-group-detail', 'scion-page-admin-server-config', 'scion-page-admin-integrations', 'scion-page-admin-skill-registries', 'scion-page-admin-skill-registry-detail', 'scion-page-diagnostics']);
+const ADMIN_ROUTES = new Set(['scion-page-settings', 'scion-page-admin-scheduler', 'scion-page-admin-maintenance', 'scion-page-admin-users', 'scion-page-admin-groups', 'scion-page-admin-group-detail', 'scion-page-admin-server-config', 'scion-page-admin-integrations', 'scion-page-admin-skill-registries', 'scion-page-admin-skill-registry-detail', 'scion-page-diagnostics', 'scion-page-health-dashboard']);
 
 /**
  * Initialize the client-side application

--- a/web/src/components/pages/health-dashboard.ts
+++ b/web/src/components/pages/health-dashboard.ts
@@ -635,6 +635,7 @@ export class ScionPageHealthDashboard extends LitElement {
                 </div>
                 <div class="broker-stat">Agents: ${b.agent_healthy}/${b.agent_count} healthy</div>
                 <div class="broker-stat">Runtime: ${b.runtime} ${b.runtime_available ? '✓' : '✗'}</div>
+                <div class="broker-stat" style="color:var(--scion-text-muted,#64748b)">NFS: not reported</div>
                 ${b.last_heartbeat ? html`<div class="broker-stat">Heartbeat: ${this.timeAgo(b.last_heartbeat)}</div>` : nothing}
               </div>
             `)}

--- a/web/src/components/pages/health-dashboard.ts
+++ b/web/src/components/pages/health-dashboard.ts
@@ -745,8 +745,10 @@ export class ScionPageHealthDashboard extends LitElement {
   }
 
   private timeAgo(isoDate: string): string {
+    if (!isoDate) return 'never';
     try {
       const d = new Date(isoDate);
+      if (isNaN(d.getTime())) return 'unknown';
       const now = Date.now();
       const diffMs = now - d.getTime();
       if (diffMs < 0) return 'just now';

--- a/web/src/components/pages/health-dashboard.ts
+++ b/web/src/components/pages/health-dashboard.ts
@@ -71,7 +71,7 @@ interface HealthSummary {
   dispatch: {
     stuck_messages: number;
     failed_1h: number;
-  };
+  } | null;
   stall_config: {
     threshold_seconds: number;
     auto_suspend: boolean;
@@ -94,9 +94,6 @@ export class ScionPageHealthDashboard extends LitElement {
 
   @state()
   private editingStall = false;
-
-  @state()
-  private stallThresholdMinutes = 5;
 
   @state()
   private stallAutoSuspend = false;
@@ -151,7 +148,6 @@ export class ScionPageHealthDashboard extends LitElement {
       this.error = null;
       // Sync stall config editor state
       if (this.data && !this.editingStall) {
-        this.stallThresholdMinutes = Math.round(this.data.stall_config.threshold_seconds / 60);
         this.stallAutoSuspend = this.data.stall_config.auto_suspend;
       }
     } catch (e) {
@@ -683,6 +679,17 @@ export class ScionPageHealthDashboard extends LitElement {
   }
 
   private renderDispatchCard(d: HealthSummary) {
+    if (!d.dispatch) {
+      return html`
+        <div class="card">
+          <div class="card-title">Dispatch Pipeline</div>
+          <div style="font-size:0.875rem;color:var(--scion-text-muted,#64748b)">
+            Dispatch metrics not yet available. A future update will expose dispatch
+            pipeline stats via the health summary API.
+          </div>
+        </div>
+      `;
+    }
     return html`
       <div class="card">
         <div class="card-title">Dispatch Pipeline</div>
@@ -702,16 +709,18 @@ export class ScionPageHealthDashboard extends LitElement {
       return html`
         <div class="card">
           <div class="card-title">Stall Detection Settings</div>
+          <!-- Threshold is a startup-time ServerConfig setting and cannot be
+               changed at runtime via the operational settings API. Display it
+               as read-only. Only auto_suspend_stalled is a runtime setting. -->
+          <div class="stat-row" style="margin-bottom:0.75rem">
+            <span class="label">Stalled Threshold</span>
+            <span>${Math.round(d.stall_config.threshold_seconds / 60)} min <span style="font-size:0.75rem;color:var(--scion-text-muted,#94a3b8)">(set at startup)</span></span>
+          </div>
           <div class="stall-edit-form">
-            <label>
-              Threshold (min):
-              <input type="number" min="1" max="60" .value=${String(this.stallThresholdMinutes)}
-                @input=${(e: InputEvent) => { this.stallThresholdMinutes = parseInt((e.target as HTMLInputElement).value) || 5; }} />
-            </label>
             <label style="display:flex;align-items:center;gap:0.375rem">
               <input type="checkbox" .checked=${this.stallAutoSuspend}
                 @change=${() => { this.stallAutoSuspend = !this.stallAutoSuspend; }} />
-              Auto-suspend stalled
+              Auto-suspend stalled agents
             </label>
             <button class="save-btn" ?disabled=${this.savingStall} @click=${() => void this.saveStallConfig()}>
               ${this.savingStall ? 'Saving...' : 'Save'}

--- a/web/src/components/pages/health-dashboard.ts
+++ b/web/src/components/pages/health-dashboard.ts
@@ -1,0 +1,755 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Health Dashboard page component
+ *
+ * Displays a centralized health view of the Scion system including:
+ * - Hub status and version
+ * - Database pool health
+ * - Broker status (per-broker cards)
+ * - Agent health summary
+ * - Dispatch pipeline status
+ * - Stall detection configuration (editable)
+ *
+ * Auto-refreshes every 30 seconds via polling.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+
+import { apiFetch, extractApiError } from '../../client/api.js';
+import { showToast } from '../../utils/toast.js';
+
+interface HealthSummary {
+  status: string;
+  hub: {
+    status: string;
+    version: string;
+    uptime: string;
+    connected_brokers: number;
+    active_agents: number;
+    projects: number;
+  };
+  database: {
+    status: string;
+    pool_active: number;
+    pool_max: number;
+    pool_waiting: number;
+    pool_idle: number;
+  };
+  brokers: Array<{
+    id: string;
+    name: string;
+    status: string;
+    runtime: string;
+    runtime_available: boolean;
+    agent_count: number;
+    agent_healthy: number;
+    last_heartbeat: string;
+  }>;
+  agents: {
+    total: number;
+    by_phase: Record<string, number>;
+    stalled: string[];
+    crashed: string[];
+    errored: string[];
+  };
+  dispatch: {
+    stuck_messages: number;
+    failed_1h: number;
+  };
+  stall_config: {
+    threshold_seconds: number;
+    auto_suspend: boolean;
+  };
+}
+
+@customElement('scion-page-health-dashboard')
+export class ScionPageHealthDashboard extends LitElement {
+  @state()
+  private loading = true;
+
+  @state()
+  private error: string | null = null;
+
+  @state()
+  private data: HealthSummary | null = null;
+
+  @state()
+  private autoRefresh = true;
+
+  @state()
+  private editingStall = false;
+
+  @state()
+  private stallThresholdMinutes = 5;
+
+  @state()
+  private stallAutoSuspend = false;
+
+  @state()
+  private savingStall = false;
+
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    void this.fetchData();
+    this.startAutoRefresh();
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.stopAutoRefresh();
+  }
+
+  private startAutoRefresh(): void {
+    this.stopAutoRefresh();
+    if (this.autoRefresh) {
+      this.refreshTimer = setInterval(() => void this.fetchData(), 30_000);
+    }
+  }
+
+  private stopAutoRefresh(): void {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  private toggleAutoRefresh(): void {
+    this.autoRefresh = !this.autoRefresh;
+    if (this.autoRefresh) {
+      this.startAutoRefresh();
+    } else {
+      this.stopAutoRefresh();
+    }
+  }
+
+  private async fetchData(): Promise<void> {
+    try {
+      const res = await apiFetch('/api/v1/admin/health/summary');
+      if (!res.ok) {
+        this.error = await extractApiError(res, 'Failed to fetch health summary');
+        return;
+      }
+      this.data = await res.json();
+      this.error = null;
+      // Sync stall config editor state
+      if (this.data && !this.editingStall) {
+        this.stallThresholdMinutes = Math.round(this.data.stall_config.threshold_seconds / 60);
+        this.stallAutoSuspend = this.data.stall_config.auto_suspend;
+      }
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : 'Network error';
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private statusIcon(status: string): string {
+    switch (status) {
+      case 'healthy':
+      case 'online':
+      case 'pass':
+        return '●'; // filled circle
+      case 'degraded':
+      case 'warn':
+        return '●';
+      case 'unhealthy':
+      case 'offline':
+      case 'fail':
+      case 'error':
+        return '●';
+      default:
+        return '○'; // empty circle
+    }
+  }
+
+  private statusColor(status: string): string {
+    switch (status) {
+      case 'healthy':
+      case 'online':
+      case 'pass':
+        return 'var(--scion-success, #22c55e)';
+      case 'degraded':
+      case 'warn':
+        return 'var(--scion-warning, #f59e0b)';
+      case 'unhealthy':
+      case 'offline':
+      case 'fail':
+      case 'error':
+        return 'var(--scion-error, #ef4444)';
+      default:
+        return 'var(--scion-text-muted, #94a3b8)';
+    }
+  }
+
+  private async saveStallConfig(): Promise<void> {
+    this.savingStall = true;
+    try {
+      const settings: Record<string, unknown> = {
+        'server.hub.auto_suspend_stalled': this.stallAutoSuspend,
+      };
+      const res = await apiFetch('/api/v1/admin/server-config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(settings),
+      });
+      if (!res.ok) {
+        const msg = await extractApiError(res, 'Failed to save stall settings');
+        showToast(msg, 'danger');
+        return;
+      }
+      showToast('Stall detection settings saved', 'success');
+      this.editingStall = false;
+      void this.fetchData();
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : 'Save failed', 'danger');
+    } finally {
+      this.savingStall = false;
+    }
+  }
+
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 2rem;
+    }
+
+    .header-left {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .header h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--scion-text, #1e293b);
+      margin: 0;
+    }
+
+    .header-right {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.8125rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .refresh-btn {
+      background: none;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.375rem;
+      padding: 0.25rem 0.5rem;
+      font-size: 0.75rem;
+      cursor: pointer;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .refresh-btn:hover {
+      background: var(--scion-surface-hover, #f1f5f9);
+    }
+
+    .toggle-label {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      cursor: pointer;
+      font-size: 0.8125rem;
+    }
+
+    .grid-2 {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin-bottom: 1rem;
+    }
+
+    .grid-full {
+      margin-bottom: 1rem;
+    }
+
+    .card {
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--scion-radius-lg, 0.75rem);
+      padding: 1.25rem;
+    }
+
+    .card-title {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: var(--scion-text-muted, #64748b);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin: 0 0 0.75rem 0;
+    }
+
+    .status-line {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 1rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+    }
+
+    .stat-row {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.875rem;
+      padding: 0.25rem 0;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .stat-row .label {
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .broker-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+
+    .broker-card {
+      background: var(--scion-surface-alt, #f8fafc);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.5rem;
+      padding: 1rem;
+      min-width: 200px;
+      flex: 1;
+    }
+
+    .broker-name {
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+    }
+
+    .broker-stat {
+      font-size: 0.8125rem;
+      color: var(--scion-text-muted, #64748b);
+      padding: 0.125rem 0;
+    }
+
+    .agent-summary {
+      display: flex;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.75rem;
+      font-size: 0.9375rem;
+    }
+
+    .agent-summary .stat {
+      font-weight: 600;
+    }
+
+    .agent-alert {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      font-size: 0.875rem;
+      padding: 0.25rem 0;
+    }
+
+    .alert-warn {
+      color: var(--scion-warning, #f59e0b);
+    }
+
+    .alert-error {
+      color: var(--scion-error, #ef4444);
+    }
+
+    .stall-config {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .stall-config .stat-row {
+      flex: 1;
+      min-width: 200px;
+    }
+
+    .edit-btn {
+      background: none;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.375rem;
+      padding: 0.25rem 0.625rem;
+      font-size: 0.75rem;
+      cursor: pointer;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .edit-btn:hover {
+      background: var(--scion-surface-hover, #f1f5f9);
+    }
+
+    .stall-edit-form {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .stall-edit-form label {
+      font-size: 0.875rem;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .stall-edit-form input[type="number"] {
+      width: 60px;
+      padding: 0.25rem 0.5rem;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.25rem;
+      font-size: 0.875rem;
+    }
+
+    .save-btn {
+      background: var(--scion-primary, #3b82f6);
+      color: white;
+      border: none;
+      border-radius: 0.375rem;
+      padding: 0.375rem 0.75rem;
+      font-size: 0.8125rem;
+      cursor: pointer;
+    }
+
+    .save-btn:hover {
+      opacity: 0.9;
+    }
+
+    .save-btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .cancel-btn {
+      background: none;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.375rem;
+      padding: 0.375rem 0.75rem;
+      font-size: 0.8125rem;
+      cursor: pointer;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .loading, .error-msg {
+      text-align: center;
+      padding: 3rem 1rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .error-msg {
+      color: var(--scion-error, #ef4444);
+    }
+
+    .alerts-link {
+      font-size: 0.875rem;
+      color: var(--scion-primary, #3b82f6);
+      text-decoration: none;
+    }
+
+    .alerts-link:hover {
+      text-decoration: underline;
+    }
+
+    .overall-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 0.25rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.8125rem;
+      font-weight: 600;
+    }
+
+    .overall-status.healthy {
+      background: #dcfce7;
+      color: #166534;
+    }
+
+    .overall-status.degraded {
+      background: #fef3c7;
+      color: #92400e;
+    }
+
+    .overall-status.unhealthy {
+      background: #fecaca;
+      color: #991b1b;
+    }
+
+    @media (max-width: 768px) {
+      .grid-2 {
+        grid-template-columns: 1fr;
+      }
+    }
+  `;
+
+  override render() {
+    if (this.loading) {
+      return html`<div class="loading">Loading health data...</div>`;
+    }
+
+    if (this.error && !this.data) {
+      return html`<div class="error-msg">${this.error}</div>`;
+    }
+
+    if (!this.data) {
+      return html`<div class="loading">No data available</div>`;
+    }
+
+    const d = this.data;
+
+    return html`
+      <div class="header">
+        <div class="header-left">
+          <h1>Health Dashboard</h1>
+          <span class="overall-status ${d.status}">
+            <span style="color: ${this.statusColor(d.status)}">${this.statusIcon(d.status)}</span>
+            ${d.status}
+          </span>
+        </div>
+        <div class="header-right">
+          <label class="toggle-label">
+            <input type="checkbox" .checked=${this.autoRefresh}
+              @change=${() => this.toggleAutoRefresh()} />
+            Auto-refresh
+          </label>
+          <button class="refresh-btn" @click=${() => void this.fetchData()}>Refresh</button>
+        </div>
+      </div>
+
+      ${this.error ? html`<div class="error-msg" style="margin-bottom:1rem;text-align:left;padding:0.75rem;background:#fef2f2;border-radius:0.375rem;font-size:0.875rem">${this.error}</div>` : nothing}
+
+      <!-- Hub & Database -->
+      <div class="grid-2">
+        ${this.renderHubCard(d)}
+        ${this.renderDatabaseCard(d)}
+      </div>
+
+      <!-- Brokers -->
+      ${this.renderBrokersCard(d)}
+
+      <!-- Agents -->
+      ${this.renderAgentsCard(d)}
+
+      <!-- Dispatch & Stall Config -->
+      <div class="grid-2">
+        ${this.renderDispatchCard(d)}
+        ${this.renderStallCard(d)}
+      </div>
+
+      <!-- Recent Alerts placeholder -->
+      <div class="grid-full">
+        <div class="card">
+          <div class="card-title">Recent Alerts</div>
+          <div style="font-size:0.875rem;color:var(--scion-text-muted,#64748b)">
+            View recent alerts in the
+            <a class="alerts-link" href="https://console.cloud.google.com/monitoring/alerting" target="_blank" rel="noopener">
+              GCP Cloud Monitoring Console
+            </a>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderHubCard(d: HealthSummary) {
+    return html`
+      <div class="card">
+        <div class="card-title">Hub Status</div>
+        <div class="status-line">
+          <span style="color: ${this.statusColor(d.hub.status)}">${this.statusIcon(d.hub.status)}</span>
+          ${d.hub.status}
+        </div>
+        <div class="stat-row"><span class="label">Uptime</span><span>${d.hub.uptime}</span></div>
+        <div class="stat-row"><span class="label">Version</span><span>${d.hub.version}</span></div>
+        <div class="stat-row"><span class="label">Connected Brokers</span><span>${d.hub.connected_brokers}</span></div>
+        <div class="stat-row"><span class="label">Active Agents</span><span>${d.hub.active_agents}</span></div>
+        <div class="stat-row"><span class="label">Projects</span><span>${d.hub.projects}</span></div>
+      </div>
+    `;
+  }
+
+  private renderDatabaseCard(d: HealthSummary) {
+    const poolUtil = d.database.pool_max > 0
+      ? Math.round((d.database.pool_active / d.database.pool_max) * 100)
+      : 0;
+    return html`
+      <div class="card">
+        <div class="card-title">Database</div>
+        <div class="status-line">
+          <span style="color: ${this.statusColor(d.database.status)}">${this.statusIcon(d.database.status)}</span>
+          ${d.database.status}
+        </div>
+        <div class="stat-row"><span class="label">Pool</span><span>${d.database.pool_active}/${d.database.pool_max} active (${poolUtil}%)</span></div>
+        <div class="stat-row"><span class="label">Idle</span><span>${d.database.pool_idle}</span></div>
+        <div class="stat-row"><span class="label">Waiting</span><span>${d.database.pool_waiting}</span></div>
+      </div>
+    `;
+  }
+
+  private renderBrokersCard(d: HealthSummary) {
+    if (d.brokers.length === 0) {
+      return html`
+        <div class="grid-full">
+          <div class="card">
+            <div class="card-title">Brokers</div>
+            <div style="font-size:0.875rem;color:var(--scion-text-muted,#64748b)">No brokers registered</div>
+          </div>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="grid-full">
+        <div class="card">
+          <div class="card-title">Brokers</div>
+          <div class="broker-grid">
+            ${d.brokers.map(b => html`
+              <div class="broker-card">
+                <div class="broker-name">${b.name || b.id}</div>
+                <div class="status-line" style="font-size:0.875rem">
+                  <span style="color: ${this.statusColor(b.status)}">${this.statusIcon(b.status)}</span>
+                  ${b.status}
+                </div>
+                <div class="broker-stat">Agents: ${b.agent_healthy}/${b.agent_count} healthy</div>
+                <div class="broker-stat">Runtime: ${b.runtime} ${b.runtime_available ? '✓' : '✗'}</div>
+                ${b.last_heartbeat ? html`<div class="broker-stat">Heartbeat: ${this.timeAgo(b.last_heartbeat)}</div>` : nothing}
+              </div>
+            `)}
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderAgentsCard(d: HealthSummary) {
+    return html`
+      <div class="grid-full">
+        <div class="card">
+          <div class="card-title">Agents</div>
+          <div class="agent-summary">
+            <div><span class="stat">${d.agents.total}</span> Total</div>
+            ${Object.entries(d.agents.by_phase).map(([phase, count]) =>
+              html`<div><span class="stat">${count}</span> ${phase}</div>`
+            )}
+          </div>
+          ${d.agents.stalled.length > 0 ? html`
+            <div class="agent-alert alert-warn">
+              ⚠ ${d.agents.stalled.length} stalled: ${d.agents.stalled.join(', ')}
+            </div>
+          ` : nothing}
+          ${d.agents.crashed.length > 0 ? html`
+            <div class="agent-alert alert-error">
+              ✗ ${d.agents.crashed.length} crashed: ${d.agents.crashed.join(', ')}
+            </div>
+          ` : nothing}
+          ${d.agents.errored.length > 0 ? html`
+            <div class="agent-alert alert-error">
+              ✗ ${d.agents.errored.length} errored: ${d.agents.errored.join(', ')}
+            </div>
+          ` : nothing}
+          ${d.agents.stalled.length === 0 && d.agents.crashed.length === 0 && d.agents.errored.length === 0
+            ? html`<div style="font-size:0.875rem;color:var(--scion-success,#22c55e)">All agents healthy</div>`
+            : nothing}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderDispatchCard(d: HealthSummary) {
+    return html`
+      <div class="card">
+        <div class="card-title">Dispatch Pipeline</div>
+        <div class="stat-row">
+          <span class="label">Stuck Messages</span>
+          <span style="color: ${d.dispatch.stuck_messages > 0 ? 'var(--scion-error,#ef4444)' : 'inherit'}; font-weight: ${d.dispatch.stuck_messages > 0 ? '600' : 'normal'}">
+            ${d.dispatch.stuck_messages}
+          </span>
+        </div>
+        <div class="stat-row"><span class="label">Failed (1h)</span><span>${d.dispatch.failed_1h}</span></div>
+      </div>
+    `;
+  }
+
+  private renderStallCard(d: HealthSummary) {
+    if (this.editingStall) {
+      return html`
+        <div class="card">
+          <div class="card-title">Stall Detection Settings</div>
+          <div class="stall-edit-form">
+            <label>
+              Threshold (min):
+              <input type="number" min="1" max="60" .value=${String(this.stallThresholdMinutes)}
+                @input=${(e: InputEvent) => { this.stallThresholdMinutes = parseInt((e.target as HTMLInputElement).value) || 5; }} />
+            </label>
+            <label style="display:flex;align-items:center;gap:0.375rem">
+              <input type="checkbox" .checked=${this.stallAutoSuspend}
+                @change=${() => { this.stallAutoSuspend = !this.stallAutoSuspend; }} />
+              Auto-suspend stalled
+            </label>
+            <button class="save-btn" ?disabled=${this.savingStall} @click=${() => void this.saveStallConfig()}>
+              ${this.savingStall ? 'Saving...' : 'Save'}
+            </button>
+            <button class="cancel-btn" @click=${() => { this.editingStall = false; }}>Cancel</button>
+          </div>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="card">
+        <div class="card-title" style="display:flex;justify-content:space-between;align-items:center">
+          Stall Detection Settings
+          <button class="edit-btn" @click=${() => { this.editingStall = true; }}>Edit</button>
+        </div>
+        <div class="stat-row"><span class="label">Stalled Threshold</span><span>${Math.round(d.stall_config.threshold_seconds / 60)} min</span></div>
+        <div class="stat-row"><span class="label">Auto-Suspend Stalled</span><span>${d.stall_config.auto_suspend ? 'enabled' : 'disabled'}</span></div>
+      </div>
+    `;
+  }
+
+  private timeAgo(isoDate: string): string {
+    try {
+      const d = new Date(isoDate);
+      const now = Date.now();
+      const diffMs = now - d.getTime();
+      if (diffMs < 0) return 'just now';
+      const seconds = Math.floor(diffMs / 1000);
+      if (seconds < 60) return `${seconds}s ago`;
+      const minutes = Math.floor(seconds / 60);
+      if (minutes < 60) return `${minutes}m ago`;
+      const hours = Math.floor(minutes / 60);
+      if (hours < 24) return `${hours}h ago`;
+      const days = Math.floor(hours / 24);
+      return `${days}d ago`;
+    } catch {
+      return 'unknown';
+    }
+  }
+}

--- a/web/src/components/pages/health-dashboard.ts
+++ b/web/src/components/pages/health-dashboard.ts
@@ -48,7 +48,7 @@ interface HealthSummary {
     status: string;
     pool_active: number;
     pool_max: number;
-    pool_waiting: number;
+    pool_wait_count_total: number;
     pool_idle: number;
   };
   brokers: Array<{
@@ -604,7 +604,7 @@ export class ScionPageHealthDashboard extends LitElement {
         </div>
         <div class="stat-row"><span class="label">Pool</span><span>${d.database.pool_active}/${d.database.pool_max} active (${poolUtil}%)</span></div>
         <div class="stat-row"><span class="label">Idle</span><span>${d.database.pool_idle}</span></div>
-        <div class="stat-row"><span class="label">Waiting</span><span>${d.database.pool_waiting}</span></div>
+        <div class="stat-row"><span class="label">Wait Count (Total)</span><span>${d.database.pool_wait_count_total}</span></div>
       </div>
     `;
   }

--- a/web/src/components/shared/nav.ts
+++ b/web/src/components/shared/nav.ts
@@ -69,6 +69,7 @@ const ADMIN_SECTION: NavSection = {
     { path: '/admin/users', label: 'Users', icon: 'people' },
     { path: '/admin/groups', label: 'Groups', icon: 'diagram-3' },
     { path: '/admin/diagnostics', label: 'Diagnostics', icon: 'journal-text' },
+    { path: '/health', label: 'Health', icon: 'heart-pulse' },
     { path: '/admin/maintenance', label: 'Maintenance', icon: 'wrench-adjustable' },
     { path: '/admin/skill-registries', label: 'Skill Registries', icon: 'cloud-arrow-down' },
   ],


### PR DESCRIPTION
Adds comprehensive health monitoring to Scion: scion doctor checks, Cloud Monitoring alert policies, uptime checks, and a web UI health dashboard.

Key changes:
- 8 CLI-side doctor checks (hub connectivity, auth, broker, agent health, NFS, telemetry, images, credentials)
- 3 in-container doctor checks (pipeline, workspace, harness process)
- 15 Cloud Monitoring alert policy definitions
- 4 uptime check configurations (Hub/Broker healthz/readyz)
- Admin health summary API endpoint
- Web UI health dashboard at /health
- 2593 lines across 12 files

Addresses ptone/scion#336