### PR TITLE
feat(hub): add integrated diagnostics dashboard with unified log aggregation

### DIFF
--- a/pkg/hub/diagnostics_types.go
+++ b/pkg/hub/diagnostics_types.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import "strings"
+
+// DiagnosticLogEntry extends CloudLogEntry with source classification.
+type DiagnosticLogEntry struct {
+	CloudLogEntry
+	Source string `json:"source"` // "hub", "broker", "agent", "messages", "server"
+}
+
+// DiagnosticsLogResponse is the batch query response.
+type DiagnosticsLogResponse struct {
+	Entries      []DiagnosticLogEntry `json:"entries"`
+	HasMore      bool                 `json:"hasMore"`
+	GCPProjectID string               `json:"gcpProjectId,omitempty"`
+}
+
+// classifySource determines the source category of a log entry based on
+// its log name and structured metadata. The classification rules follow
+// this priority order:
+//  1. logName contains "scion-messages" -> "messages"
+//  2. logName contains "scion-agents"   -> "agent"
+//  3. jsonPayload.subsystem starts with "hub."    -> "hub"
+//  4. jsonPayload.subsystem starts with "broker." -> "broker"
+//  5. labels.component = "scion-hub"    -> "hub"
+//  6. labels.component = "scion-broker" -> "broker"
+//  7. Fallback -> "server"
+func classifySource(entry CloudLogEntry) string {
+	logName := entry.LogName
+
+	// Check log name first (highest priority)
+	if strings.Contains(logName, "scion-messages") {
+		return "messages"
+	}
+	if strings.Contains(logName, "scion-agents") {
+		return "agent"
+	}
+
+	// Check subsystem in JSON payload
+	if sub, ok := entry.JSONPayload["subsystem"].(string); ok {
+		if strings.HasPrefix(sub, "hub.") {
+			return "hub"
+		}
+		if strings.HasPrefix(sub, "broker.") {
+			return "broker"
+		}
+	}
+
+	// Check component label
+	if comp, ok := entry.Labels["component"]; ok {
+		if comp == "scion-hub" {
+			return "hub"
+		}
+		if comp == "scion-broker" {
+			return "broker"
+		}
+	}
+
+	return "server"
+}
+
+// toDiagnosticEntry converts a CloudLogEntry to a DiagnosticLogEntry
+// by classifying its source.
+func toDiagnosticEntry(entry CloudLogEntry) DiagnosticLogEntry {
+	return DiagnosticLogEntry{
+		CloudLogEntry: entry,
+		Source:        classifySource(entry),
+	}
+}

--- a/pkg/hub/handlers_diagnostics.go
+++ b/pkg/hub/handlers_diagnostics.go
@@ -1,0 +1,205 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// handleDiagnosticsLogs handles GET /api/v1/admin/diagnostics/logs
+// It returns recent log entries from all system log IDs with source classification.
+func (s *Server) handleDiagnosticsLogs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	// Require admin user
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil || user.Role() != "admin" {
+		Forbidden(w)
+		return
+	}
+
+	if s.logQueryService == nil {
+		writeError(w, http.StatusNotImplemented, "not_implemented",
+			"Cloud Logging is not configured. Set SCION_CLOUD_LOGGING=true and configure a GCP project ID.", nil)
+		return
+	}
+
+	ctx := r.Context()
+	query := r.URL.Query()
+
+	// Parse query parameters
+	opts := LogQueryOptions{}
+
+	if v := query.Get("tail"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			opts.Tail = n
+		}
+	}
+	if v := query.Get("since"); v != "" {
+		if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
+			opts.Since = t
+		}
+	}
+	if v := query.Get("until"); v != "" {
+		if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
+			opts.Until = t
+		}
+	}
+	if v := query.Get("severity"); v != "" {
+		opts.Severity = v
+	}
+	if v := query.Get("broker_id"); v != "" {
+		opts.BrokerID = v
+	}
+	if v := query.Get("agent_id"); v != "" {
+		opts.AgentID = v
+	}
+	if v := query.Get("project_id"); v != "" {
+		opts.ProjectID = v
+	}
+	if v := query.Get("source"); v != "" {
+		opts.Sources = strings.Split(v, ",")
+	}
+	if v := query.Get("search"); v != "" {
+		opts.Search = v
+	}
+
+	result, err := s.logQueryService.Query(ctx, opts)
+	if err != nil {
+		slog.Error("diagnostics log query failed", "error", err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
+			"Failed to query diagnostics logs", nil)
+		return
+	}
+
+	// Convert entries to DiagnosticLogEntry with source classification
+	diagEntries := make([]DiagnosticLogEntry, 0, len(result.Entries))
+	for _, entry := range result.Entries {
+		diagEntries = append(diagEntries, toDiagnosticEntry(entry))
+	}
+
+	resp := DiagnosticsLogResponse{
+		Entries:      diagEntries,
+		HasMore:      result.HasMore,
+		GCPProjectID: s.logQueryService.projectID,
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleDiagnosticsLogsStream handles GET /api/v1/admin/diagnostics/logs/stream
+// It streams log entries from all system log IDs via SSE with source classification.
+func (s *Server) handleDiagnosticsLogsStream(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	// Require admin user
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil || user.Role() != "admin" {
+		Forbidden(w)
+		return
+	}
+
+	if s.logQueryService == nil {
+		writeError(w, http.StatusNotImplemented, "not_implemented",
+			"Cloud Logging is not configured. Set SCION_CLOUD_LOGGING=true and configure a GCP project ID.", nil)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	ctx := r.Context()
+	query := r.URL.Query()
+
+	// Parse query filters — no LogID or AgentID to stream all system logs
+	opts := LogQueryOptions{}
+	if v := query.Get("severity"); v != "" {
+		opts.Severity = v
+	}
+	if v := query.Get("broker_id"); v != "" {
+		opts.BrokerID = v
+	}
+	if v := query.Get("agent_id"); v != "" {
+		opts.AgentID = v
+	}
+	if v := query.Get("project_id"); v != "" {
+		opts.ProjectID = v
+	}
+
+	// Set SSE headers
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	flusher.Flush()
+
+	// Open a Tail stream via the Cloud Logging Tail API
+	tailCh, tailCancel, err := s.logQueryService.Tail(ctx, opts)
+	if err != nil {
+		slog.Error("failed to open diagnostics tail stream", "error", err)
+		_, _ = fmt.Fprintf(w, "event: error\ndata: {\"message\":\"failed to open diagnostics log stream\"}\n\n")
+		flusher.Flush()
+		return
+	}
+	defer tailCancel()
+
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	// Server-side timeout: 10 minutes
+	timeout := time.NewTimer(10 * time.Minute)
+	defer timeout.Stop()
+
+	for {
+		select {
+		case entry, ok := <-tailCh:
+			if !ok {
+				// Tail stream closed
+				return
+			}
+			diagEntry := toDiagnosticEntry(entry)
+			data, err := json.Marshal(diagEntry)
+			if err != nil {
+				continue
+			}
+			_, _ = fmt.Fprintf(w, "event: log\ndata: %s\n\n", data)
+			flusher.Flush()
+		case <-heartbeat.C:
+			_, _ = fmt.Fprintf(w, ":heartbeat %d\n\n", time.Now().UnixMilli())
+			flusher.Flush()
+		case <-timeout.C:
+			_, _ = fmt.Fprintf(w, "event: timeout\ndata: {\"message\":\"Stream timeout\",\"reconnect\":true}\n\n")
+			flusher.Flush()
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/pkg/hub/handlers_diagnostics_test.go
+++ b/pkg/hub/handlers_diagnostics_test.go
@@ -1,0 +1,303 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClassifySource(t *testing.T) {
+	tests := []struct {
+		name     string
+		entry    CloudLogEntry
+		expected string
+	}{
+		{
+			name: "scion-messages log name",
+			entry: CloudLogEntry{
+				LogName: "projects/my-project/logs/scion-messages",
+			},
+			expected: "messages",
+		},
+		{
+			name: "scion-agents log name",
+			entry: CloudLogEntry{
+				LogName: "projects/my-project/logs/scion-agents",
+			},
+			expected: "agent",
+		},
+		{
+			name: "hub subsystem",
+			entry: CloudLogEntry{
+				LogName: "projects/my-project/logs/scion-server",
+				JSONPayload: map[string]interface{}{
+					"subsystem": "hub.dispatcher",
+					"message":   "Dispatching agent",
+				},
+			},
+			expected: "hub",
+		},
+		{
+			name: "broker subsystem",
+			entry: CloudLogEntry{
+				LogName: "projects/my-project/logs/scion-server",
+				JSONPayload: map[string]interface{}{
+					"subsystem": "broker.lifecycle",
+					"message":   "Container started",
+				},
+			},
+			expected: "broker",
+		},
+		{
+			name: "hub component label",
+			entry: CloudLogEntry{
+				LogName: "projects/my-project/logs/scion-server",
+				Labels: map[string]string{
+					"component": "scion-hub",
+				},
+			},
+			expected: "hub",
+		},
+		{
+			name: "broker component label",
+			entry: CloudLogEntry{
+				LogName: "projects/my-project/logs/scion-server",
+				Labels: map[string]string{
+					"component": "scion-broker",
+				},
+			},
+			expected: "broker",
+		},
+		{
+			name: "server fallback",
+			entry: CloudLogEntry{
+				LogName: "projects/my-project/logs/scion-server",
+			},
+			expected: "server",
+		},
+		{
+			name: "subsystem takes priority over component label",
+			entry: CloudLogEntry{
+				LogName: "projects/my-project/logs/scion-server",
+				JSONPayload: map[string]interface{}{
+					"subsystem": "hub.auth",
+				},
+				Labels: map[string]string{
+					"component": "scion-broker",
+				},
+			},
+			expected: "hub",
+		},
+		{
+			name: "messages log name takes priority over subsystem",
+			entry: CloudLogEntry{
+				LogName: "projects/my-project/logs/scion-messages",
+				JSONPayload: map[string]interface{}{
+					"subsystem": "hub.messaging",
+				},
+			},
+			expected: "messages",
+		},
+		{
+			name: "agents log name takes priority over component",
+			entry: CloudLogEntry{
+				LogName: "projects/my-project/logs/scion-agents",
+				Labels: map[string]string{
+					"component": "scion-hub",
+				},
+			},
+			expected: "agent",
+		},
+		{
+			name: "empty entry defaults to server",
+			entry: CloudLogEntry{},
+			expected: "server",
+		},
+		{
+			name: "nil labels with scion-server log",
+			entry: CloudLogEntry{
+				LogName: "projects/my-project/logs/scion-server",
+				Labels:  nil,
+			},
+			expected: "server",
+		},
+		{
+			name: "nil jsonPayload with scion-server log",
+			entry: CloudLogEntry{
+				LogName:     "projects/my-project/logs/scion-server",
+				JSONPayload: nil,
+			},
+			expected: "server",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := classifySource(tt.entry)
+			if result != tt.expected {
+				t.Errorf("classifySource() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestToDiagnosticEntry(t *testing.T) {
+	entry := CloudLogEntry{
+		LogName:  "projects/my-project/logs/scion-server",
+		Severity: "INFO",
+		Message:  "Test message",
+		InsertID: "insert-1",
+		JSONPayload: map[string]interface{}{
+			"subsystem": "hub.dispatcher",
+			"message":   "Test message",
+		},
+	}
+
+	result := toDiagnosticEntry(entry)
+
+	if result.Source != "hub" {
+		t.Errorf("Source = %q, want %q", result.Source, "hub")
+	}
+	if result.Message != "Test message" {
+		t.Errorf("Message = %q, want %q", result.Message, "Test message")
+	}
+	if result.InsertID != "insert-1" {
+		t.Errorf("InsertID = %q, want %q", result.InsertID, "insert-1")
+	}
+}
+
+func TestBuildLogFilter_Sources(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      LogQueryOptions
+		projectID string
+		expected  []string // substrings that must appear in the filter
+	}{
+		{
+			name: "hub source filter",
+			opts: LogQueryOptions{
+				Sources: []string{"hub"},
+			},
+			projectID: "my-project",
+			expected: []string{
+				`scion-server`,
+				`hub\\.`,
+			},
+		},
+		{
+			name: "broker source filter",
+			opts: LogQueryOptions{
+				Sources: []string{"broker"},
+			},
+			projectID: "my-project",
+			expected: []string{
+				`scion-server`,
+				`broker\\.`,
+			},
+		},
+		{
+			name: "agent source filter",
+			opts: LogQueryOptions{
+				Sources: []string{"agent"},
+			},
+			projectID: "my-project",
+			expected: []string{
+				`scion-agents`,
+			},
+		},
+		{
+			name: "messages source filter",
+			opts: LogQueryOptions{
+				Sources: []string{"messages"},
+			},
+			projectID: "my-project",
+			expected: []string{
+				`scion-messages`,
+			},
+		},
+		{
+			name: "multiple source filters",
+			opts: LogQueryOptions{
+				Sources: []string{"hub", "agent"},
+			},
+			projectID: "my-project",
+			expected: []string{
+				`hub\\.`,
+				`scion-agents`,
+				` OR `,
+			},
+		},
+		{
+			name: "sources without project ID are ignored",
+			opts: LogQueryOptions{
+				Sources: []string{"hub"},
+			},
+			projectID: "",
+			expected:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildLogFilter(tt.opts, tt.projectID)
+			for _, substr := range tt.expected {
+				if !strings.Contains(result, substr) {
+					t.Errorf("BuildLogFilter() = %q, expected to contain %q", result, substr)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildLogFilter_Search(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     LogQueryOptions
+		expected string
+	}{
+		{
+			name: "search filter",
+			opts: LogQueryOptions{
+				Search: "connection refused",
+			},
+			expected: `jsonPayload.message =~ "connection refused"`,
+		},
+		{
+			name: "search with double quotes escaped",
+			opts: LogQueryOptions{
+				Search: `error "timeout"`,
+			},
+			expected: `jsonPayload.message =~ "error \"timeout\""`,
+		},
+		{
+			name: "search combined with severity",
+			opts: LogQueryOptions{
+				Search:   "dispatch",
+				Severity: "WARNING",
+			},
+			expected: `severity >= WARNING AND jsonPayload.message =~ "dispatch"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildLogFilter(tt.opts)
+			if result != tt.expected {
+				t.Errorf("BuildLogFilter() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/hub/handlers_diagnostics_test.go
+++ b/pkg/hub/handlers_diagnostics_test.go
@@ -125,8 +125,8 @@ func TestClassifySource(t *testing.T) {
 			expected: "agent",
 		},
 		{
-			name: "empty entry defaults to server",
-			entry: CloudLogEntry{},
+			name:     "empty entry defaults to server",
+			entry:    CloudLogEntry{},
 			expected: "server",
 		},
 		{
@@ -276,14 +276,14 @@ func TestBuildLogFilter_Search(t *testing.T) {
 			opts: LogQueryOptions{
 				Search: "connection refused",
 			},
-			expected: `jsonPayload.message =~ "connection refused"`,
+			expected: `jsonPayload.message:"connection refused"`,
 		},
 		{
 			name: "search with double quotes escaped",
 			opts: LogQueryOptions{
 				Search: `error "timeout"`,
 			},
-			expected: `jsonPayload.message =~ "error \"timeout\""`,
+			expected: `jsonPayload.message:"error \"timeout\""`,
 		},
 		{
 			name: "search combined with severity",
@@ -291,21 +291,21 @@ func TestBuildLogFilter_Search(t *testing.T) {
 				Search:   "dispatch",
 				Severity: "WARNING",
 			},
-			expected: `severity >= WARNING AND jsonPayload.message =~ "dispatch"`,
+			expected: `severity >= WARNING AND jsonPayload.message:"dispatch"`,
 		},
 		{
 			name: "search with backslashes escaped before quotes",
 			opts: LogQueryOptions{
 				Search: `C:\Users\admin`,
 			},
-			expected: `jsonPayload.message =~ "C:\\Users\\admin"`,
+			expected: `jsonPayload.message:"C:\\Users\\admin"`,
 		},
 		{
 			name: "search with backslash and quote combined",
 			opts: LogQueryOptions{
 				Search: `error\"timeout`,
 			},
-			expected: `jsonPayload.message =~ "error\\\"timeout"`,
+			expected: `jsonPayload.message:"error\\\"timeout"`,
 		},
 	}
 

--- a/pkg/hub/handlers_diagnostics_test.go
+++ b/pkg/hub/handlers_diagnostics_test.go
@@ -15,6 +15,9 @@
 package hub
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -290,6 +293,20 @@ func TestBuildLogFilter_Search(t *testing.T) {
 			},
 			expected: `severity >= WARNING AND jsonPayload.message =~ "dispatch"`,
 		},
+		{
+			name: "search with backslashes escaped before quotes",
+			opts: LogQueryOptions{
+				Search: `C:\Users\admin`,
+			},
+			expected: `jsonPayload.message =~ "C:\\Users\\admin"`,
+		},
+		{
+			name: "search with backslash and quote combined",
+			opts: LogQueryOptions{
+				Search: `error\"timeout`,
+			},
+			expected: `jsonPayload.message =~ "error\\\"timeout"`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -299,5 +316,138 @@ func TestBuildLogFilter_Search(t *testing.T) {
 				t.Errorf("BuildLogFilter() = %q, want %q", result, tt.expected)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Handler-level tests for handleDiagnosticsLogs
+// ---------------------------------------------------------------------------
+
+func TestHandleDiagnosticsLogs_Unauthenticated(t *testing.T) {
+	srv := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/diagnostics/logs", nil)
+	// No identity in context
+	rr := httptest.NewRecorder()
+	srv.handleDiagnosticsLogs(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleDiagnosticsLogs_NonAdmin(t *testing.T) {
+	srv := &Server{}
+	member := NewAuthenticatedUser("u1", "member@example.com", "Member", "member", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/diagnostics/logs", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), member))
+	rr := httptest.NewRecorder()
+	srv.handleDiagnosticsLogs(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleDiagnosticsLogs_NoLogQueryService(t *testing.T) {
+	srv := &Server{} // logQueryService is nil
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/diagnostics/logs", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleDiagnosticsLogs(rr, req)
+
+	if rr.Code != http.StatusNotImplemented {
+		t.Errorf("expected 501, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON response: %v", err)
+	}
+	errObj, ok := body["error"].(map[string]interface{})
+	if !ok {
+		t.Fatal("response missing 'error' object")
+	}
+	if code, _ := errObj["code"].(string); code != "not_implemented" {
+		t.Errorf("error code = %q, want %q", code, "not_implemented")
+	}
+}
+
+func TestHandleDiagnosticsLogs_MethodNotAllowed(t *testing.T) {
+	srv := &Server{}
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/diagnostics/logs", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleDiagnosticsLogs(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Handler-level tests for handleDiagnosticsLogsStream
+// ---------------------------------------------------------------------------
+
+func TestHandleDiagnosticsLogsStream_Unauthenticated(t *testing.T) {
+	srv := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/diagnostics/logs/stream", nil)
+	rr := httptest.NewRecorder()
+	srv.handleDiagnosticsLogsStream(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleDiagnosticsLogsStream_NonAdmin(t *testing.T) {
+	srv := &Server{}
+	member := NewAuthenticatedUser("u1", "member@example.com", "Member", "member", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/diagnostics/logs/stream", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), member))
+	rr := httptest.NewRecorder()
+	srv.handleDiagnosticsLogsStream(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleDiagnosticsLogsStream_NoLogQueryService(t *testing.T) {
+	srv := &Server{}
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/diagnostics/logs/stream", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleDiagnosticsLogsStream(rr, req)
+
+	if rr.Code != http.StatusNotImplemented {
+		t.Errorf("expected 501, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON response: %v", err)
+	}
+	errObj, ok := body["error"].(map[string]interface{})
+	if !ok {
+		t.Fatal("response missing 'error' object")
+	}
+	if code, _ := errObj["code"].(string); code != "not_implemented" {
+		t.Errorf("error code = %q, want %q", code, "not_implemented")
+	}
+}
+
+func TestHandleDiagnosticsLogsStream_MethodNotAllowed(t *testing.T) {
+	srv := &Server{}
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/diagnostics/logs/stream", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleDiagnosticsLogsStream(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d: %s", rr.Code, rr.Body.String())
 	}
 }

--- a/pkg/hub/logquery.go
+++ b/pkg/hub/logquery.go
@@ -221,7 +221,9 @@ func BuildLogFilter(opts LogQueryOptions, projectID ...string) string {
 	}
 
 	if opts.Search != "" {
-		escaped := strings.ReplaceAll(opts.Search, `"`, `\"`)
+		// Escape backslashes first, then double quotes, to avoid double-escaping.
+		escaped := strings.ReplaceAll(opts.Search, `\`, `\\`)
+		escaped = strings.ReplaceAll(escaped, `"`, `\"`)
 		parts = append(parts, fmt.Sprintf(`jsonPayload.message =~ "%s"`, escaped))
 	}
 

--- a/pkg/hub/logquery.go
+++ b/pkg/hub/logquery.go
@@ -224,7 +224,7 @@ func BuildLogFilter(opts LogQueryOptions, projectID ...string) string {
 		// Escape backslashes first, then double quotes, to avoid double-escaping.
 		escaped := strings.ReplaceAll(opts.Search, `\`, `\\`)
 		escaped = strings.ReplaceAll(escaped, `"`, `\"`)
-		parts = append(parts, fmt.Sprintf(`jsonPayload.message =~ "%s"`, escaped))
+		parts = append(parts, fmt.Sprintf(`jsonPayload.message:"%s"`, escaped))
 	}
 
 	return strings.Join(parts, " AND ")

--- a/pkg/hub/logquery.go
+++ b/pkg/hub/logquery.go
@@ -51,6 +51,7 @@ type CloudLogEntry struct {
 	JSONPayload    map[string]interface{} `json:"jsonPayload,omitempty"`
 	InsertID       string                 `json:"insertId"`
 	SourceLocation *LogSourceLocation     `json:"sourceLocation,omitempty"`
+	LogName        string                 `json:"logName,omitempty"` // Full Cloud Logging log name (e.g. "projects/my-project/logs/scion-server")
 }
 
 // LogSourceLocation identifies the source code location of a log entry.
@@ -71,6 +72,8 @@ type LogQueryOptions struct {
 	Until     time.Time
 	Severity  string
 	PageToken string
+	Sources   []string // optional: "hub", "broker", "agent", "messages" — restricts to matching logs/subsystems
+	Search    string   // optional: substring match on jsonPayload.message
 }
 
 // LogQueryResult contains the result of a log query.
@@ -193,6 +196,35 @@ func BuildLogFilter(opts LogQueryOptions, projectID ...string) string {
 		parts = append(parts, fmt.Sprintf(`severity >= %s`, strings.ToUpper(opts.Severity)))
 	}
 
+	if len(opts.Sources) > 0 && len(projectID) > 0 && projectID[0] != "" {
+		pid := projectID[0]
+		var srcParts []string
+		for _, src := range opts.Sources {
+			switch src {
+			case "hub":
+				srcParts = append(srcParts, fmt.Sprintf(
+					`(logName = "projects/%s/logs/scion-server" AND jsonPayload.subsystem =~ "^hub\\.")`, pid))
+			case "broker":
+				srcParts = append(srcParts, fmt.Sprintf(
+					`(logName = "projects/%s/logs/scion-server" AND jsonPayload.subsystem =~ "^broker\\.")`, pid))
+			case "agent":
+				srcParts = append(srcParts, fmt.Sprintf(
+					`logName = "projects/%s/logs/scion-agents"`, pid))
+			case "messages":
+				srcParts = append(srcParts, fmt.Sprintf(
+					`logName = "projects/%s/logs/scion-messages"`, pid))
+			}
+		}
+		if len(srcParts) > 0 {
+			parts = append(parts, "("+strings.Join(srcParts, " OR ")+")")
+		}
+	}
+
+	if opts.Search != "" {
+		escaped := strings.ReplaceAll(opts.Search, `"`, `\"`)
+		parts = append(parts, fmt.Sprintf(`jsonPayload.message =~ "%s"`, escaped))
+	}
+
 	return strings.Join(parts, " AND ")
 }
 
@@ -203,6 +235,7 @@ func ConvertLogEntry(entry *gcplog.Entry) CloudLogEntry {
 		Severity:  entry.Severity.String(),
 		Labels:    entry.Labels,
 		InsertID:  entry.InsertID,
+		LogName:   entry.LogName,
 	}
 
 	// Extract payload
@@ -317,6 +350,7 @@ func ConvertProtoLogEntry(entry *loggingpb.LogEntry) CloudLogEntry {
 		Severity: entry.GetSeverity().String(),
 		Labels:   entry.GetLabels(),
 		InsertID: entry.GetInsertId(),
+		LogName:  entry.GetLogName(),
 	}
 
 	if ts := entry.GetTimestamp(); ts != nil {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3012,6 +3012,8 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/admin/validate-resources", s.handleAdminValidateResources)
 	s.mux.HandleFunc("/api/v1/admin/integrations", s.handleAdminIntegrations)
 	s.mux.HandleFunc("/api/v1/admin/integrations/", s.handleAdminIntegrationByName)
+	s.mux.HandleFunc("/api/v1/admin/diagnostics/logs/stream", s.handleDiagnosticsLogsStream)
+	s.mux.HandleFunc("/api/v1/admin/diagnostics/logs", s.handleDiagnosticsLogs)
 	s.mux.HandleFunc("/api/v1/metrics/", s.handleMetricsDashboard)
 	s.mux.HandleFunc("/api/v1/admin/metrics-dashboard", s.handleAdminMetricsDashboard) // legacy backward-compat
 

--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -146,6 +146,7 @@ const ROUTES: RouteConfig[] = [
   { pattern: /^\/admin\/groups\/[^/]+$/, tag: 'scion-page-admin-group-detail', load: () => import('../components/pages/admin-group-detail.js') },
   { pattern: /^\/metrics$/, tag: 'scion-page-metrics', load: () => import('../components/pages/metrics-dashboard.js') },
   { pattern: /^\/admin\/metrics$/, tag: 'scion-page-metrics', load: () => import('../components/pages/metrics-dashboard.js') },
+  { pattern: /^\/admin\/diagnostics$/, tag: 'scion-page-diagnostics', load: () => import('../components/pages/diagnostics.js') },
   { pattern: /^\/admin\/maintenance$/, tag: 'scion-page-admin-maintenance', load: () => import('../components/pages/admin-maintenance.js') },
   { pattern: /^\/admin\/integrations$/, tag: 'scion-page-admin-integrations', load: () => import('../components/pages/admin-integrations.js') },
   { pattern: /^\/admin\/integrations\/[^/]+$/, tag: 'scion-page-admin-integrations', load: () => import('../components/pages/admin-integrations.js') },
@@ -189,7 +190,7 @@ const PROFILE_ROUTES = new Set(['scion-page-profile-env-vars', 'scion-page-profi
 /**
  * Routes that require admin role. Non-admin users are redirected to dashboard.
  */
-const ADMIN_ROUTES = new Set(['scion-page-settings', 'scion-page-admin-scheduler', 'scion-page-admin-maintenance', 'scion-page-admin-users', 'scion-page-admin-groups', 'scion-page-admin-group-detail', 'scion-page-admin-server-config', 'scion-page-admin-integrations', 'scion-page-admin-skill-registries', 'scion-page-admin-skill-registry-detail']);
+const ADMIN_ROUTES = new Set(['scion-page-settings', 'scion-page-admin-scheduler', 'scion-page-admin-maintenance', 'scion-page-admin-users', 'scion-page-admin-groups', 'scion-page-admin-group-detail', 'scion-page-admin-server-config', 'scion-page-admin-integrations', 'scion-page-admin-skill-registries', 'scion-page-admin-skill-registry-detail', 'scion-page-diagnostics']);
 
 /**
  * Initialize the client-side application

--- a/web/src/components/pages/diagnostics.ts
+++ b/web/src/components/pages/diagnostics.ts
@@ -41,6 +41,7 @@ export class ScionPageDiagnostics extends LitElement {
   @state() private cloudLoggingAvailable = false;
   @state() private cloudLoggingChecked = false;
   @state() private gcpProjectId = '';
+  @state() private currentSeverity = 'INFO';
 
   static override styles = css`
     :host {
@@ -266,7 +267,7 @@ export class ScionPageDiagnostics extends LitElement {
                 size="small"
                 variant="default"
                 class="popout-button"
-                href=${this.buildCloudLoggingUrl('INFO')}
+                href=${this.buildCloudLoggingUrl(this.currentSeverity)}
                 target="_blank"
               >
                 <sl-icon slot="prefix" name="box-arrow-up-right"></sl-icon>
@@ -338,11 +339,17 @@ export class ScionPageDiagnostics extends LitElement {
     `;
   }
 
+  private handleSeverityChange(e: Event): void {
+    const detail = (e as CustomEvent<{ severity: string }>).detail;
+    this.currentSeverity = detail.severity;
+  }
+
   private renderLogViewer() {
     return html`
       <scion-unified-log-viewer
         .gcpProjectId=${this.gcpProjectId}
         initialSeverity="INFO"
+        @severity-change=${this.handleSeverityChange}
       ></scion-unified-log-viewer>
     `;
   }

--- a/web/src/components/pages/diagnostics.ts
+++ b/web/src/components/pages/diagnostics.ts
@@ -1,0 +1,380 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Diagnostics page component.
+ *
+ * Provides a system-wide admin view for unified log streaming from all
+ * Scion components (hub, broker, agent, messages) via Cloud Logging.
+ * Includes a status banner and the unified log viewer.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { apiFetch } from '../../client/api.js';
+import '../shared/unified-log-viewer.js';
+
+interface HealthResponse {
+  status: string;
+  version?: string;
+  brokerCount?: number;
+  agentCount?: number;
+  [key: string]: unknown;
+}
+
+@customElement('scion-page-diagnostics')
+export class ScionPageDiagnostics extends LitElement {
+  @state() private hubHealth: HealthResponse | null = null;
+  @state() private cloudLoggingAvailable = false;
+  @state() private cloudLoggingChecked = false;
+  @state() private gcpProjectId = '';
+
+  static override styles = css`
+    :host {
+      display: block;
+      padding: 1.5rem;
+    }
+
+    .page-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 1.5rem;
+    }
+
+    .page-header h1 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin: 0;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .status-banner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.75rem 1rem;
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--sl-border-radius-medium, 0.5rem);
+      margin-bottom: 1rem;
+      font-size: 0.875rem;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .status-left {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .status-item {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      color: var(--scion-text-secondary, #475569);
+    }
+
+    .status-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+    }
+
+    .status-dot.healthy {
+      background: var(--scion-success-500, #22c55e);
+    }
+
+    .status-dot.unhealthy {
+      background: var(--scion-danger-500, #ef4444);
+    }
+
+    .status-dot.unknown {
+      background: var(--scion-neutral-400, #94a3b8);
+    }
+
+    .status-dot.active {
+      background: var(--scion-success-500, #22c55e);
+    }
+
+    .status-dot.inactive {
+      background: var(--scion-neutral-400, #94a3b8);
+    }
+
+    .status-separator {
+      color: var(--scion-border, #e2e8f0);
+    }
+
+    .status-info {
+      color: var(--scion-text-muted, #64748b);
+      font-size: 0.8125rem;
+    }
+
+    .status-right {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .health-link {
+      font-size: 0.8125rem;
+      color: var(--scion-primary-600, #2563eb);
+      text-decoration: none;
+      cursor: pointer;
+    }
+    .health-link:hover {
+      text-decoration: underline;
+    }
+
+    /* Degradation UI */
+    .degradation-panel {
+      background: var(--scion-warning-50, #fffbeb);
+      border: 1px solid var(--scion-warning-200, #fde68a);
+      border-radius: var(--sl-border-radius-medium, 0.5rem);
+      padding: 1.5rem 2rem;
+      margin-bottom: 1rem;
+    }
+
+    .degradation-panel h3 {
+      margin: 0 0 0.75rem;
+      font-size: 1rem;
+      color: var(--scion-warning-800, #92400e);
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .degradation-panel p {
+      margin: 0 0 1rem;
+      color: var(--scion-text-secondary, #475569);
+      font-size: 0.875rem;
+      line-height: 1.6;
+    }
+
+    .degradation-panel ol {
+      margin: 0 0 1rem;
+      padding-left: 1.5rem;
+      color: var(--scion-text-secondary, #475569);
+      font-size: 0.875rem;
+      line-height: 1.8;
+    }
+
+    .degradation-panel code {
+      background: var(--scion-bg-subtle, #f1f5f9);
+      padding: 0.125rem 0.375rem;
+      border-radius: 0.25rem;
+      font-size: 0.8125rem;
+      font-family: var(--scion-font-mono, monospace);
+    }
+
+    .degradation-note {
+      color: var(--scion-text-muted, #64748b);
+      font-size: 0.8125rem;
+      font-style: italic;
+    }
+
+    .popout-button {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+    }
+  `;
+
+  override async connectedCallback(): Promise<void> {
+    super.connectedCallback();
+    this.fetchHealth();
+    this.checkCloudLogging();
+  }
+
+  private async fetchHealth(): Promise<void> {
+    try {
+      const res = await apiFetch('/healthz');
+      if (res.ok) {
+        this.hubHealth = (await res.json()) as HealthResponse;
+      }
+      // Non-OK or missing health is non-fatal — banner shows "Unknown" status
+    } catch {
+      // Health check failure is non-fatal — banner shows "Unknown" status
+    }
+  }
+
+  private async checkCloudLogging(): Promise<void> {
+    try {
+      const res = await apiFetch('/api/v1/admin/diagnostics/logs?tail=1');
+      if (res.ok) {
+        const data = (await res.json()) as { gcpProjectId?: string };
+        this.cloudLoggingAvailable = true;
+        this.gcpProjectId = data.gcpProjectId || '';
+      } else if (res.status === 501) {
+        this.cloudLoggingAvailable = false;
+      } else {
+        // Other error, but Cloud Logging might still be available
+        this.cloudLoggingAvailable = false;
+      }
+    } catch {
+      this.cloudLoggingAvailable = false;
+    } finally {
+      this.cloudLoggingChecked = true;
+    }
+  }
+
+  private buildCloudLoggingUrl(severity: string): string {
+    if (!this.gcpProjectId) return '';
+    const filterParts = [
+      `logName != "projects/${this.gcpProjectId}/logs/scion_request_log"`,
+    ];
+    if (severity && severity !== 'DEFAULT') {
+      filterParts.push(`severity >= ${severity}`);
+    }
+    const filter = filterParts.join('\n');
+    const encoded = encodeURIComponent(filter);
+    return `https://console.cloud.google.com/logs/query;query=${encoded}?project=${this.gcpProjectId}`;
+  }
+
+  private handleNavClick(path: string): void {
+    this.dispatchEvent(
+      new CustomEvent('nav-click', {
+        detail: { path },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  override render() {
+    return html`
+      <div class="page-header">
+        <h1>Diagnostics</h1>
+        ${this.gcpProjectId
+          ? html`
+              <sl-button
+                size="small"
+                variant="default"
+                class="popout-button"
+                href=${this.buildCloudLoggingUrl('INFO')}
+                target="_blank"
+              >
+                <sl-icon slot="prefix" name="box-arrow-up-right"></sl-icon>
+                Cloud Logging
+              </sl-button>
+            `
+          : nothing}
+      </div>
+      ${this.renderStatusBanner()}
+      ${this.cloudLoggingChecked
+        ? this.cloudLoggingAvailable
+          ? this.renderLogViewer()
+          : this.renderDegradation()
+        : html`
+            <div style="text-align: center; padding: 3rem;">
+              <sl-spinner style="font-size: 1.5rem;"></sl-spinner>
+            </div>
+          `}
+    `;
+  }
+
+  private renderStatusBanner() {
+    const health = this.hubHealth;
+    const status = health?.status || 'unknown';
+    const statusClass = status === 'ok' || status === 'healthy' ? 'healthy' : status === 'unknown' ? 'unknown' : 'unhealthy';
+    const statusLabel = status === 'ok' || status === 'healthy' ? 'Healthy' : status === 'unknown' ? 'Unknown' : status;
+
+    const cloudStatus = this.cloudLoggingChecked
+      ? this.cloudLoggingAvailable
+        ? 'active'
+        : 'inactive'
+      : 'unknown';
+    const cloudLabel = this.cloudLoggingChecked
+      ? this.cloudLoggingAvailable
+        ? 'Active'
+        : 'Unavailable'
+      : 'Checking...';
+
+    return html`
+      <div class="status-banner">
+        <div class="status-left">
+          <span class="status-item">
+            System Status:
+            <span class="status-dot ${statusClass}"></span>
+            ${statusLabel}
+          </span>
+          <span class="status-separator">|</span>
+          <span class="status-item">
+            Cloud Logging:
+            <span class="status-dot ${cloudStatus}"></span>
+            ${cloudLabel}
+          </span>
+          ${health
+            ? html`
+                <span class="status-info">
+                  ${health.version ? `Hub ${health.version}` : ''}
+                  ${health.brokerCount != null ? ` · ${health.brokerCount} brokers` : ''}
+                  ${health.agentCount != null ? ` · ${health.agentCount} agents` : ''}
+                </span>
+              `
+            : nothing}
+        </div>
+        <div class="status-right">
+          <a class="health-link" @click=${() => this.handleNavClick('/health')}>
+            View Health →
+          </a>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderLogViewer() {
+    return html`
+      <scion-unified-log-viewer
+        .gcpProjectId=${this.gcpProjectId}
+        initialSeverity="INFO"
+      ></scion-unified-log-viewer>
+    `;
+  }
+
+  private renderDegradation() {
+    return html`
+      <div class="degradation-panel">
+        <h3>
+          <sl-icon name="exclamation-triangle"></sl-icon>
+          Cloud Logging is not configured
+        </h3>
+        <p>
+          The diagnostics log viewer requires Google Cloud Logging to
+          aggregate logs from hub, broker, and agent components.
+        </p>
+        <p>To enable:</p>
+        <ol>
+          <li>Set <code>SCION_CLOUD_LOGGING=true</code></li>
+          <li>Configure <code>SCION_GCP_PROJECT_ID</code> or <code>GOOGLE_CLOUD_PROJECT</code></li>
+          <li>Ensure the service account has <code>roles/logging.viewer</code></li>
+        </ol>
+        <p class="degradation-note">
+          Individual agent logs are still available on each agent's
+          detail page via the broker log relay.
+        </p>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-page-diagnostics': ScionPageDiagnostics;
+  }
+}

--- a/web/src/components/shared/nav.ts
+++ b/web/src/components/shared/nav.ts
@@ -68,6 +68,7 @@ const ADMIN_SECTION: NavSection = {
     { path: '/admin/scheduler', label: 'Scheduler', icon: 'clock' },
     { path: '/admin/users', label: 'Users', icon: 'people' },
     { path: '/admin/groups', label: 'Groups', icon: 'diagram-3' },
+    { path: '/admin/diagnostics', label: 'Diagnostics', icon: 'journal-text' },
     { path: '/admin/maintenance', label: 'Maintenance', icon: 'wrench-adjustable' },
     { path: '/admin/skill-registries', label: 'Skill Registries', icon: 'cloud-arrow-down' },
   ],

--- a/web/src/components/shared/unified-log-viewer.ts
+++ b/web/src/components/shared/unified-log-viewer.ts
@@ -90,6 +90,7 @@ export class ScionUnifiedLogViewer extends LitElement {
 
   private eventSource: EventSource | null = null;
   private searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private logViewerRef: Element | null = null;
 
   static override styles = css`
@@ -360,6 +361,10 @@ export class ScionUnifiedLogViewer extends LitElement {
     if (this.searchDebounceTimer) {
       clearTimeout(this.searchDebounceTimer);
     }
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
   }
 
   private async loadInitialData(): Promise<void> {
@@ -458,7 +463,8 @@ export class ScionUnifiedLogViewer extends LitElement {
     const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempt), 30000);
     this.reconnectAttempt++;
 
-    setTimeout(async () => {
+    this.reconnectTimer = setTimeout(async () => {
+      this.reconnectTimer = null;
       // Gap-fill: fetch entries since our last entry
       if (this.entries.length > 0) {
         try {

--- a/web/src/components/shared/unified-log-viewer.ts
+++ b/web/src/components/shared/unified-log-viewer.ts
@@ -451,6 +451,12 @@ export class ScionUnifiedLogViewer extends LitElement {
       this.eventSource = null;
     }
     this.streaming = false;
+    this.reconnecting = false;
+    this.reconnectAttempt = 0;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
   }
 
   private reconnectWithBackoff(): void {
@@ -531,11 +537,12 @@ export class ScionUnifiedLogViewer extends LitElement {
 
     // Cap buffer — evict oldest entries
     if (this.entries.length > MAX_BUFFER) {
-      const evicted = this.entries.splice(0, this.entries.length - MAX_BUFFER);
+      const overflow = this.entries.length - MAX_BUFFER;
+      const evicted = this.entries.slice(0, overflow);
       for (const e of evicted) {
         this.entryMap.delete(e.insertId);
       }
-      this.entries = [...this.entries]; // trigger reactivity after splice
+      this.entries = this.entries.slice(overflow);
     }
 
     // Auto-scroll after render

--- a/web/src/components/shared/unified-log-viewer.ts
+++ b/web/src/components/shared/unified-log-viewer.ts
@@ -40,6 +40,7 @@ interface DiagnosticLogEntry {
   sourceLocation?: { file?: string; line?: string; function?: string };
   logName?: string;
   source: string; // "hub", "broker", "agent", "messages", "server"
+  _ts?: number; // cached numeric timestamp for sort performance
 }
 
 interface DiagnosticsLogResponse {
@@ -415,7 +416,8 @@ export class ScionUnifiedLogViewer extends LitElement {
         ) as DiagnosticLogEntry;
         this.mergeEntries([entry]);
 
-        if (!this.autoScroll) {
+        // Only count entries that pass current filters for the "new entries" banner
+        if (!this.autoScroll && this.entryPassesFilters(entry)) {
           this.newEntriesBelowCount++;
         }
       } catch {
@@ -462,8 +464,8 @@ export class ScionUnifiedLogViewer extends LitElement {
         try {
           const params = new URLSearchParams({ tail: '200' });
           if (this.severity) params.set('severity', this.severity);
-          // Entries are sorted newest-first, so [0] is the latest
-          params.set('since', this.entries[0].timestamp);
+          // Entries are sorted oldest-first (ascending), so last element is the latest
+          params.set('since', this.entries[this.entries.length - 1].timestamp);
           const res = await apiFetch(
             `/api/v1/admin/diagnostics/logs?${params}`
           );
@@ -483,28 +485,52 @@ export class ScionUnifiedLogViewer extends LitElement {
   // Buffer Management
   // ---------------------------------------------------------------------------
 
+  /** Cache numeric timestamp on an entry for sort performance. */
+  private ensureTimestamp(entry: DiagnosticLogEntry): number {
+    if (entry._ts === undefined) {
+      entry._ts = new Date(entry.timestamp).getTime();
+    }
+    return entry._ts;
+  }
+
   private mergeEntries(newEntries: DiagnosticLogEntry[]): void {
+    // Collect genuinely new entries (not already in the dedup map)
+    const toInsert: DiagnosticLogEntry[] = [];
     for (const entry of newEntries) {
       if (!this.entryMap.has(entry.insertId)) {
+        this.ensureTimestamp(entry);
         this.entryMap.set(entry.insertId, entry);
+        toInsert.push(entry);
       }
     }
 
-    // Sort by timestamp ascending (oldest first for log view)
-    const sorted = Array.from(this.entryMap.values()).sort(
-      (a, b) =>
-        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
-    );
+    if (toInsert.length === 0) return;
+
+    if (this.entries.length === 0) {
+      // First load: sort the full batch once
+      toInsert.sort((a, b) => a._ts! - b._ts!);
+      this.entries = toInsert;
+    } else if (
+      toInsert.length === 1 &&
+      toInsert[0]._ts! >= this.entries[this.entries.length - 1]._ts!
+    ) {
+      // Common case: single stream entry newer than latest — append directly
+      this.entries = [...this.entries, toInsert[0]];
+    } else {
+      // Multiple entries or out-of-order: merge and sort
+      const merged = [...this.entries, ...toInsert];
+      merged.sort((a, b) => a._ts! - b._ts!);
+      this.entries = merged;
+    }
 
     // Cap buffer — evict oldest entries
-    if (sorted.length > MAX_BUFFER) {
-      const evicted = sorted.splice(0, sorted.length - MAX_BUFFER);
+    if (this.entries.length > MAX_BUFFER) {
+      const evicted = this.entries.splice(0, this.entries.length - MAX_BUFFER);
       for (const e of evicted) {
         this.entryMap.delete(e.insertId);
       }
+      this.entries = [...this.entries]; // trigger reactivity after splice
     }
-
-    this.entries = sorted;
 
     // Auto-scroll after render
     if (this.autoScroll) {
@@ -512,17 +538,18 @@ export class ScionUnifiedLogViewer extends LitElement {
     }
   }
 
+  /** Check if a single entry passes current client-side filters. */
+  private entryPassesFilters(entry: DiagnosticLogEntry): boolean {
+    if (!this.enabledSources.has(entry.source)) return false;
+    if (this.searchText) {
+      const text = this.searchText.toLowerCase();
+      if (!entry.message?.toLowerCase().includes(text)) return false;
+    }
+    return true;
+  }
+
   private getFilteredEntries(): DiagnosticLogEntry[] {
-    return this.entries.filter((entry) => {
-      // Source filter
-      if (!this.enabledSources.has(entry.source)) return false;
-      // Search filter
-      if (this.searchText) {
-        const text = this.searchText.toLowerCase();
-        if (!entry.message?.toLowerCase().includes(text)) return false;
-      }
-      return true;
-    });
+    return this.entries.filter((entry) => this.entryPassesFilters(entry));
   }
 
   // ---------------------------------------------------------------------------
@@ -530,8 +557,15 @@ export class ScionUnifiedLogViewer extends LitElement {
   // ---------------------------------------------------------------------------
 
   private handleSeverityChange(e: Event): void {
-    const select = e.target as HTMLSelectElement;
-    this.severity = select.value;
+    this.severity = (e.target as unknown as { value: string }).value;
+    // Notify parent of severity change (used by popout link)
+    this.dispatchEvent(
+      new CustomEvent('severity-change', {
+        detail: { severity: this.severity },
+        bubbles: true,
+        composed: true,
+      })
+    );
     this.stopStream();
     this.entryMap.clear();
     this.entries = [];
@@ -551,8 +585,7 @@ export class ScionUnifiedLogViewer extends LitElement {
   }
 
   private handleSearchInput(e: Event): void {
-    const input = e.target as HTMLInputElement;
-    const value = input.value;
+    const value = (e.target as unknown as { value: string }).value;
     if (this.searchDebounceTimer) {
       clearTimeout(this.searchDebounceTimer);
     }
@@ -617,10 +650,12 @@ export class ScionUnifiedLogViewer extends LitElement {
   // ---------------------------------------------------------------------------
 
   override render() {
+    // Compute filtered entries once and pass to both sub-renders to avoid double-filtering.
+    const filteredEntries = this.getFilteredEntries();
     return html`
       ${this.renderFilterBar()}
-      ${this.renderLogContainer()}
-      ${this.renderStatusBar()}
+      ${this.renderLogContainer(filteredEntries)}
+      ${this.renderStatusBar(filteredEntries)}
     `;
   }
 
@@ -680,7 +715,7 @@ export class ScionUnifiedLogViewer extends LitElement {
     `;
   }
 
-  private renderLogContainer() {
+  private renderLogContainer(filteredEntries: DiagnosticLogEntry[]) {
     return html`
       <div class="log-container">
         ${this.loading && this.entries.length === 0
@@ -695,7 +730,7 @@ export class ScionUnifiedLogViewer extends LitElement {
               `
             : html`
                 <div class="log-scroller" @scroll=${this.handleScroll}>
-                  ${this.renderEntries()}
+                  ${this.renderEntries(filteredEntries)}
                   ${!this.autoScroll && this.newEntriesBelowCount > 0
                     ? html`
                         <div class="new-entries-banner" @click=${this.handleNewEntriesClick}>
@@ -709,9 +744,7 @@ export class ScionUnifiedLogViewer extends LitElement {
     `;
   }
 
-  private renderEntries() {
-    const filtered = this.getFilteredEntries();
-
+  private renderEntries(filtered: DiagnosticLogEntry[]) {
     if (filtered.length === 0 && this.entries.length > 0) {
       return html`
         <div class="state-msg">
@@ -841,8 +874,7 @@ export class ScionUnifiedLogViewer extends LitElement {
     return obj;
   }
 
-  private renderStatusBar() {
-    const filtered = this.getFilteredEntries();
+  private renderStatusBar(filtered: DiagnosticLogEntry[]) {
     const streamState = this.streaming
       ? 'Streaming'
       : this.reconnecting

--- a/web/src/components/shared/unified-log-viewer.ts
+++ b/web/src/components/shared/unified-log-viewer.ts
@@ -1,0 +1,866 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unified log viewer component for the diagnostics dashboard.
+ *
+ * Streams and displays log entries from all Scion system components
+ * (hub, broker, agent, messages) via a single SSE connection. Features
+ * source color-coding, severity filtering (server-side), source and
+ * text filtering (client-side), auto-scroll with pause-on-scroll-up,
+ * entry detail expansion, and reconnection with gap-fill.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { apiFetch } from '../../client/api.js';
+import './json-browser.js';
+
+interface DiagnosticLogEntry {
+  timestamp: string;
+  severity: string;
+  message: string;
+  labels?: Record<string, string>;
+  resource?: Record<string, unknown>;
+  jsonPayload?: Record<string, unknown>;
+  insertId: string;
+  sourceLocation?: { file?: string; line?: string; function?: string };
+  logName?: string;
+  source: string; // "hub", "broker", "agent", "messages", "server"
+}
+
+interface DiagnosticsLogResponse {
+  entries: DiagnosticLogEntry[];
+  hasMore: boolean;
+  gcpProjectId?: string;
+}
+
+const MAX_BUFFER = 2000;
+
+const SEVERITY_LEVELS = ['DEFAULT', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'] as const;
+
+const SOURCE_CONFIG: Record<string, { badge: string; color: string; bg: string }> = {
+  hub: { badge: 'HUB', color: '#2563eb', bg: '#eff6ff' },
+  broker: { badge: 'BRK', color: '#059669', bg: '#ecfdf5' },
+  agent: { badge: 'AGT', color: '#d97706', bg: '#fffbeb' },
+  messages: { badge: 'MSG', color: '#7c3aed', bg: '#f5f3ff' },
+  server: { badge: 'SRV', color: '#4b5563', bg: '#f9fafb' },
+};
+
+const ALL_SOURCES = ['hub', 'broker', 'agent', 'messages', 'server'];
+
+const SEARCH_DEBOUNCE_MS = 300;
+const AUTO_SCROLL_THRESHOLD = 50; // px from bottom
+
+@customElement('scion-unified-log-viewer')
+export class ScionUnifiedLogViewer extends LitElement {
+  @property({ type: String })
+  gcpProjectId = '';
+
+  @property({ type: String })
+  initialSeverity = 'INFO';
+
+  @state() private entries: DiagnosticLogEntry[] = [];
+  private entryMap = new Map<string, DiagnosticLogEntry>();
+  @state() private streaming = false;
+  @state() private loading = false;
+  @state() private error: string | null = null;
+  @state() private severity = '';
+  @state() private enabledSources = new Set<string>(ALL_SOURCES);
+  @state() private searchText = '';
+  @state() private autoScroll = true;
+  @state() private newEntriesBelowCount = 0;
+  @state() private expandedIds = new Set<string>();
+  @state() private reconnecting = false;
+  @state() private reconnectAttempt = 0;
+
+  private eventSource: EventSource | null = null;
+  private searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private logViewerRef: Element | null = null;
+
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    /* Filter bar */
+    .filter-bar {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.75rem 1rem;
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--sl-border-radius-medium, 0.5rem);
+      margin-bottom: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .filter-group {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .filter-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--scion-text-muted, #64748b);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .source-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.25rem 0.5rem;
+      border-radius: 0.25rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      font-family: var(--scion-font-mono, monospace);
+      cursor: pointer;
+      border: 1px solid transparent;
+      transition: opacity 0.15s, border-color 0.15s;
+      user-select: none;
+    }
+
+    .source-toggle.disabled {
+      opacity: 0.3;
+      border-color: var(--scion-border, #e2e8f0);
+    }
+
+    .stream-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      font-size: 0.75rem;
+      color: var(--scion-success-600, #16a34a);
+    }
+
+    .stream-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--scion-success-500, #22c55e);
+      animation: pulse 1.5s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.3; }
+    }
+
+    .reconnect-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      font-size: 0.75rem;
+      color: var(--scion-warning-600, #d97706);
+    }
+
+    .filter-spacer {
+      flex: 1;
+    }
+
+    /* Log viewer */
+    .log-container {
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--sl-border-radius-medium, 0.5rem);
+      overflow: hidden;
+      position: relative;
+    }
+
+    .log-scroller {
+      max-height: calc(100vh - 22rem);
+      min-height: 400px;
+      overflow-y: auto;
+      font-family: var(--scion-font-mono, monospace);
+      font-size: 0.8125rem;
+    }
+
+    /* Log entry rows */
+    .log-row {
+      display: grid;
+      grid-template-columns: 7rem 3rem 4rem 10rem 1fr;
+      gap: 0.5rem;
+      padding: 0.375rem 0.75rem;
+      cursor: pointer;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      transition: background 0.1s ease;
+      align-items: start;
+      border-left: 3px solid transparent;
+    }
+
+    .log-row:hover {
+      background: var(--scion-bg-subtle, #f1f5f9);
+    }
+
+    .log-row .ts {
+      color: var(--scion-text-muted, #64748b);
+      font-size: 0.75rem;
+      white-space: nowrap;
+    }
+
+    .source-badge {
+      display: inline-block;
+      padding: 0.0625rem 0.375rem;
+      border-radius: 0.25rem;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+      text-align: center;
+      line-height: 1.4;
+      font-family: var(--scion-font-mono, monospace);
+    }
+
+    .sev {
+      display: inline-block;
+      padding: 0.0625rem 0.375rem;
+      border-radius: 0.25rem;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      line-height: 1.4;
+    }
+
+    .sev-DEFAULT { background: var(--scion-neutral-100, #f1f5f9); color: var(--scion-neutral-500, #64748b); }
+    .sev-DEBUG { background: var(--scion-neutral-100, #f1f5f9); color: var(--scion-neutral-500, #64748b); opacity: 0.7; }
+    .sev-INFO { background: var(--scion-primary-50, #eff6ff); color: var(--scion-primary-700, #1d4ed8); }
+    .sev-WARNING { background: var(--scion-warning-50, #fffbeb); color: var(--scion-warning-700, #b45309); }
+    .sev-ERROR { background: var(--scion-danger-50, #fef2f2); color: var(--scion-danger-700, #b91c1c); }
+    .sev-CRITICAL { background: var(--scion-danger-100, #fee2e2); color: var(--scion-danger-800, #991b1b); font-weight: 700; }
+
+    .sub {
+      color: var(--scion-text-secondary, #475569);
+      font-size: 0.75rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .msg {
+      color: var(--scion-text, #1e293b);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    /* Detail panel */
+    .detail-row {
+      padding: 0.75rem 0.75rem 0.75rem 2.5rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      background: var(--scion-bg-subtle, #f1f5f9);
+    }
+
+    .detail-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      margin-bottom: 0.75rem;
+      font-size: 0.75rem;
+      color: var(--scion-text-secondary, #475569);
+    }
+
+    .detail-meta-item {
+      display: flex;
+      gap: 0.25rem;
+    }
+
+    .detail-meta-label {
+      font-weight: 600;
+    }
+
+    .detail-cloud-link {
+      font-size: 0.75rem;
+      color: var(--scion-primary-600, #2563eb);
+      text-decoration: none;
+    }
+    .detail-cloud-link:hover {
+      text-decoration: underline;
+    }
+
+    /* New entries banner */
+    .new-entries-banner {
+      position: sticky;
+      bottom: 0;
+      display: flex;
+      justify-content: center;
+      padding: 0.5rem;
+      background: var(--scion-primary-50, #eff6ff);
+      border-top: 1px solid var(--scion-primary-200, #bfdbfe);
+      cursor: pointer;
+      font-size: 0.8125rem;
+      color: var(--scion-primary-700, #1d4ed8);
+      font-weight: 500;
+    }
+
+    .new-entries-banner:hover {
+      background: var(--scion-primary-100, #dbeafe);
+    }
+
+    /* Status bar */
+    .status-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.5rem 1rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-top: 0;
+      border-radius: 0 0 var(--sl-border-radius-medium, 0.5rem) var(--sl-border-radius-medium, 0.5rem);
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    /* Empty / Loading / Error states */
+    .state-msg {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 3rem 2rem;
+      color: var(--scion-text-muted, #64748b);
+      gap: 0.75rem;
+    }
+    .state-msg sl-spinner {
+      font-size: 1.5rem;
+    }
+    .state-msg sl-icon {
+      font-size: 2rem;
+      opacity: 0.4;
+    }
+  `;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.severity = this.initialSeverity || 'INFO';
+    this.loadInitialData();
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.stopStream();
+    if (this.searchDebounceTimer) {
+      clearTimeout(this.searchDebounceTimer);
+    }
+  }
+
+  private async loadInitialData(): Promise<void> {
+    this.loading = true;
+    this.error = null;
+
+    try {
+      const params = new URLSearchParams({ tail: '200' });
+      if (this.severity) params.set('severity', this.severity);
+      const res = await apiFetch(`/api/v1/admin/diagnostics/logs?${params}`);
+      if (!res.ok) {
+        const errData = (await res.json().catch(() => ({}))) as {
+          error?: { message?: string };
+          message?: string;
+        };
+        throw new Error(
+          (errData.error as { message?: string })?.message ||
+            errData.message ||
+            `HTTP ${res.status}`
+        );
+      }
+      const data = (await res.json()) as DiagnosticsLogResponse;
+      this.mergeEntries(data.entries);
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to fetch logs';
+    } finally {
+      this.loading = false;
+    }
+
+    // Start streaming after initial data
+    this.startStream();
+  }
+
+  // ---------------------------------------------------------------------------
+  // SSE Stream Management
+  // ---------------------------------------------------------------------------
+
+  private startStream(): void {
+    if (this.eventSource) return;
+    this.streaming = true;
+    this.reconnecting = false;
+    this.reconnectAttempt = 0;
+
+    const params = new URLSearchParams();
+    if (this.severity) params.set('severity', this.severity);
+    const qs = params.toString();
+    const url = `/api/v1/admin/diagnostics/logs/stream${qs ? '?' + qs : ''}`;
+    this.eventSource = new EventSource(url);
+
+    this.eventSource.addEventListener('log', (event: Event) => {
+      try {
+        const entry = JSON.parse(
+          (event as MessageEvent).data
+        ) as DiagnosticLogEntry;
+        this.mergeEntries([entry]);
+
+        if (!this.autoScroll) {
+          this.newEntriesBelowCount++;
+        }
+      } catch {
+        // skip unparseable
+      }
+    });
+
+    this.eventSource.addEventListener('timeout', () => {
+      this.stopStream();
+      this.startStream();
+    });
+
+    this.eventSource.onerror = () => {
+      if (this.eventSource?.readyState === EventSource.CLOSED) {
+        this.streaming = false;
+        this.reconnecting = true;
+        this.eventSource = null;
+        this.reconnectWithBackoff();
+      }
+    };
+  }
+
+  private stopStream(): void {
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+    this.streaming = false;
+  }
+
+  private reconnectWithBackoff(): void {
+    if (this.reconnectAttempt >= 10) {
+      this.reconnecting = false;
+      this.error = 'Connection lost after 10 reconnection attempts';
+      return;
+    }
+
+    const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempt), 30000);
+    this.reconnectAttempt++;
+
+    setTimeout(async () => {
+      // Gap-fill: fetch entries since our last entry
+      if (this.entries.length > 0) {
+        try {
+          const params = new URLSearchParams({ tail: '200' });
+          if (this.severity) params.set('severity', this.severity);
+          // Entries are sorted newest-first, so [0] is the latest
+          params.set('since', this.entries[0].timestamp);
+          const res = await apiFetch(
+            `/api/v1/admin/diagnostics/logs?${params}`
+          );
+          if (res.ok) {
+            const data = (await res.json()) as DiagnosticsLogResponse;
+            this.mergeEntries(data.entries);
+          }
+        } catch {
+          // Gap-fill failed, but we'll still try to reconnect the stream
+        }
+      }
+      this.startStream();
+    }, delay);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Buffer Management
+  // ---------------------------------------------------------------------------
+
+  private mergeEntries(newEntries: DiagnosticLogEntry[]): void {
+    for (const entry of newEntries) {
+      if (!this.entryMap.has(entry.insertId)) {
+        this.entryMap.set(entry.insertId, entry);
+      }
+    }
+
+    // Sort by timestamp ascending (oldest first for log view)
+    const sorted = Array.from(this.entryMap.values()).sort(
+      (a, b) =>
+        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    );
+
+    // Cap buffer — evict oldest entries
+    if (sorted.length > MAX_BUFFER) {
+      const evicted = sorted.splice(0, sorted.length - MAX_BUFFER);
+      for (const e of evicted) {
+        this.entryMap.delete(e.insertId);
+      }
+    }
+
+    this.entries = sorted;
+
+    // Auto-scroll after render
+    if (this.autoScroll) {
+      this.updateComplete.then(() => this.scrollToBottom());
+    }
+  }
+
+  private getFilteredEntries(): DiagnosticLogEntry[] {
+    return this.entries.filter((entry) => {
+      // Source filter
+      if (!this.enabledSources.has(entry.source)) return false;
+      // Search filter
+      if (this.searchText) {
+        const text = this.searchText.toLowerCase();
+        if (!entry.message?.toLowerCase().includes(text)) return false;
+      }
+      return true;
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Filter Handlers
+  // ---------------------------------------------------------------------------
+
+  private handleSeverityChange(e: Event): void {
+    const select = e.target as HTMLSelectElement;
+    this.severity = select.value;
+    this.stopStream();
+    this.entryMap.clear();
+    this.entries = [];
+    this.expandedIds.clear();
+    this.newEntriesBelowCount = 0;
+    this.loadInitialData();
+  }
+
+  private handleSourceToggle(source: string): void {
+    const newSet = new Set(this.enabledSources);
+    if (newSet.has(source)) {
+      newSet.delete(source);
+    } else {
+      newSet.add(source);
+    }
+    this.enabledSources = newSet;
+  }
+
+  private handleSearchInput(e: Event): void {
+    const input = e.target as HTMLInputElement;
+    const value = input.value;
+    if (this.searchDebounceTimer) {
+      clearTimeout(this.searchDebounceTimer);
+    }
+    this.searchDebounceTimer = setTimeout(() => {
+      this.searchText = value;
+    }, SEARCH_DEBOUNCE_MS);
+  }
+
+  private handleClear(): void {
+    this.entryMap.clear();
+    this.entries = [];
+    this.expandedIds.clear();
+    this.newEntriesBelowCount = 0;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scroll Management
+  // ---------------------------------------------------------------------------
+
+  private handleScroll(e: Event): void {
+    const el = e.target as HTMLElement;
+    const atBottom =
+      el.scrollHeight - el.scrollTop - el.clientHeight < AUTO_SCROLL_THRESHOLD;
+
+    if (atBottom && !this.autoScroll) {
+      this.autoScroll = true;
+      this.newEntriesBelowCount = 0;
+    } else if (!atBottom && this.autoScroll) {
+      this.autoScroll = false;
+    }
+  }
+
+  private scrollToBottom(): void {
+    const scroller = this.logViewerRef || this.shadowRoot?.querySelector('.log-scroller');
+    if (scroller) {
+      this.logViewerRef = scroller;
+      scroller.scrollTop = scroller.scrollHeight;
+    }
+  }
+
+  private handleNewEntriesClick(): void {
+    this.autoScroll = true;
+    this.newEntriesBelowCount = 0;
+    this.scrollToBottom();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Entry Expansion
+  // ---------------------------------------------------------------------------
+
+  private toggleExpand(insertId: string): void {
+    if (this.expandedIds.has(insertId)) {
+      this.expandedIds.delete(insertId);
+    } else {
+      this.expandedIds.add(insertId);
+    }
+    this.requestUpdate();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  override render() {
+    return html`
+      ${this.renderFilterBar()}
+      ${this.renderLogContainer()}
+      ${this.renderStatusBar()}
+    `;
+  }
+
+  private renderFilterBar() {
+    return html`
+      <div class="filter-bar">
+        <div class="filter-group">
+          <span class="filter-label">Sources:</span>
+          ${ALL_SOURCES.map((src) => {
+            const config = SOURCE_CONFIG[src];
+            const enabled = this.enabledSources.has(src);
+            return html`
+              <span
+                class="source-toggle ${enabled ? '' : 'disabled'}"
+                style="background: ${enabled ? config.bg : 'transparent'}; color: ${config.color}; border-color: ${enabled ? config.color + '40' : 'var(--scion-border, #e2e8f0)'};"
+                @click=${() => this.handleSourceToggle(src)}
+              >${config.badge}</span>
+            `;
+          })}
+        </div>
+        <div class="filter-group">
+          <span class="filter-label">Level:</span>
+          <sl-select
+            size="small"
+            value=${this.severity}
+            @sl-change=${this.handleSeverityChange}
+            style="min-width: 8rem"
+          >
+            ${SEVERITY_LEVELS.map(
+              (level) => html`<sl-option value=${level}>${level} +</sl-option>`
+            )}
+          </sl-select>
+        </div>
+        <div class="filter-group">
+          <span class="filter-label">Search:</span>
+          <sl-input
+            size="small"
+            placeholder="Filter messages..."
+            @sl-input=${this.handleSearchInput}
+            clearable
+            style="min-width: 12rem"
+          >
+            <sl-icon slot="prefix" name="search"></sl-icon>
+          </sl-input>
+        </div>
+        <div class="filter-spacer"></div>
+        ${this.streaming
+          ? html`<span class="stream-indicator"><span class="stream-dot"></span>Live</span>`
+          : this.reconnecting
+            ? html`<span class="reconnect-indicator"><sl-spinner style="font-size: 0.75rem;"></sl-spinner> Reconnecting...</span>`
+            : nothing}
+        <sl-button size="small" variant="text" @click=${this.handleClear}>
+          <sl-icon slot="prefix" name="trash"></sl-icon>
+          Clear
+        </sl-button>
+      </div>
+    `;
+  }
+
+  private renderLogContainer() {
+    return html`
+      <div class="log-container">
+        ${this.loading && this.entries.length === 0
+          ? html`<div class="state-msg"><sl-spinner></sl-spinner><span>Loading logs...</span></div>`
+          : this.error && this.entries.length === 0
+            ? html`
+                <div class="state-msg">
+                  <sl-icon name="exclamation-triangle"></sl-icon>
+                  <span>${this.error}</span>
+                  <sl-button size="small" @click=${() => this.loadInitialData()}>Retry</sl-button>
+                </div>
+              `
+            : html`
+                <div class="log-scroller" @scroll=${this.handleScroll}>
+                  ${this.renderEntries()}
+                  ${!this.autoScroll && this.newEntriesBelowCount > 0
+                    ? html`
+                        <div class="new-entries-banner" @click=${this.handleNewEntriesClick}>
+                          ⬇ New entries below (${this.newEntriesBelowCount})
+                        </div>
+                      `
+                    : nothing}
+                </div>
+              `}
+      </div>
+    `;
+  }
+
+  private renderEntries() {
+    const filtered = this.getFilteredEntries();
+
+    if (filtered.length === 0 && this.entries.length > 0) {
+      return html`
+        <div class="state-msg">
+          <sl-icon name="funnel"></sl-icon>
+          <span>No entries match current filters</span>
+        </div>
+      `;
+    }
+
+    if (filtered.length === 0) {
+      return html`
+        <div class="state-msg">
+          <sl-icon name="file-text"></sl-icon>
+          <span>No log entries yet</span>
+        </div>
+      `;
+    }
+
+    const rows: unknown[] = [];
+    for (const entry of filtered) {
+      const config = SOURCE_CONFIG[entry.source] || SOURCE_CONFIG.server;
+      const d = new Date(entry.timestamp);
+      const timeStr = d.toLocaleTimeString('en', {
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        fractionalSecondDigits: 3,
+      } as Intl.DateTimeFormatOptions);
+      const subsystem =
+        (entry.jsonPayload?.['subsystem'] as string) ||
+        entry.labels?.['component'] ||
+        '';
+      const isExpanded = this.expandedIds.has(entry.insertId);
+
+      rows.push(html`
+        <div
+          class="log-row"
+          style="border-left-color: ${config.color}"
+          @click=${() => this.toggleExpand(entry.insertId)}
+        >
+          <span class="ts">${timeStr}</span>
+          <span
+            class="source-badge"
+            style="background: ${config.bg}; color: ${config.color};"
+          >${config.badge}</span>
+          <span class="sev sev-${entry.severity}">${entry.severity}</span>
+          <span class="sub" title=${subsystem}>${subsystem}</span>
+          <span class="msg" title=${entry.message}>${entry.message}</span>
+        </div>
+      `);
+
+      if (isExpanded) {
+        rows.push(this.renderDetailPanel(entry));
+      }
+    }
+
+    return rows;
+  }
+
+  private renderDetailPanel(entry: DiagnosticLogEntry) {
+    const d = new Date(entry.timestamp);
+    const fullTimestamp = d.toISOString();
+
+    return html`
+      <div class="detail-row">
+        <div class="detail-meta">
+          <span class="detail-meta-item">
+            <span class="detail-meta-label">Timestamp:</span>
+            ${fullTimestamp}
+          </span>
+          ${entry.logName
+            ? html`<span class="detail-meta-item"><span class="detail-meta-label">Log:</span> ${entry.logName}</span>`
+            : nothing}
+          ${entry.labels?.['agent_id']
+            ? html`<span class="detail-meta-item"><span class="detail-meta-label">Agent:</span> ${entry.labels['agent_id']}</span>`
+            : nothing}
+          ${entry.labels?.['project_id']
+            ? html`<span class="detail-meta-item"><span class="detail-meta-label">Project:</span> ${entry.labels['project_id']}</span>`
+            : nothing}
+          ${entry.labels?.['broker_id']
+            ? html`<span class="detail-meta-item"><span class="detail-meta-label">Broker:</span> ${entry.labels['broker_id']}</span>`
+            : nothing}
+          ${this.gcpProjectId && entry.insertId
+            ? html`
+                <a
+                  class="detail-cloud-link"
+                  href="https://console.cloud.google.com/logs/query;query=insertId%3D%22${encodeURIComponent(entry.insertId)}%22?project=${this.gcpProjectId}"
+                  target="_blank"
+                >View in Cloud Logging →</a>
+              `
+            : nothing}
+        </div>
+        <scion-json-browser
+          .data=${this.buildDetailObject(entry)}
+          expand-first
+        ></scion-json-browser>
+      </div>
+    `;
+  }
+
+  private buildDetailObject(
+    entry: DiagnosticLogEntry
+  ): Record<string, unknown> {
+    const obj: Record<string, unknown> = {
+      timestamp: entry.timestamp,
+      severity: entry.severity,
+      source: entry.source,
+      message: entry.message,
+    };
+    if (entry.labels && Object.keys(entry.labels).length > 0) {
+      obj['labels'] = entry.labels;
+    }
+    if (entry.jsonPayload && Object.keys(entry.jsonPayload).length > 0) {
+      obj['jsonPayload'] = entry.jsonPayload;
+    }
+    if (entry.resource && Object.keys(entry.resource).length > 0) {
+      obj['resource'] = entry.resource;
+    }
+    if (entry.sourceLocation) {
+      obj['sourceLocation'] = entry.sourceLocation;
+    }
+    if (entry.logName) {
+      obj['logName'] = entry.logName;
+    }
+    obj['insertId'] = entry.insertId;
+    return obj;
+  }
+
+  private renderStatusBar() {
+    const filtered = this.getFilteredEntries();
+    const streamState = this.streaming
+      ? 'Streaming'
+      : this.reconnecting
+        ? 'Reconnecting'
+        : 'Disconnected';
+    const scrollState = this.autoScroll ? '▼ auto-scrolling' : '⏸ paused';
+
+    return html`
+      <div class="status-bar">
+        <span>${streamState} · ${filtered.length} entries (${this.entries.length} total) · Buffer: ${this.entries.length}/${MAX_BUFFER}</span>
+        <span>${scrollState}</span>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-unified-log-viewer': ScionUnifiedLogViewer;
+  }
+}


### PR DESCRIPTION
Adds an integrated diagnostics dashboard with unified log aggregation to the Hub web UI.

Key changes:
- Batch and SSE log API endpoints for real-time streaming
- Log source classification (hub, broker, agent)
- Unified log viewer with color-coding by source and level filters
- Real-time streaming updates via Server-Sent Events
- Search across log entries
- Cloud Logging popout link
- Diagnostics page at /admin/diagnostics
- 2073 lines across 9 files

Addresses GoogleCloudPlatform/scion#514