### PR TITLE
fix: resolve as_needed env vars stored under any_of alternative key names

### DIFF
--- a/pkg/hub/as_needed_resolution_test.go
+++ b/pkg/hub/as_needed_resolution_test.go
@@ -69,7 +69,7 @@ func TestResolveAsNeededForKeys_EnvVars(t *testing.T) {
 		AppliedConfig: &store.AgentAppliedConfig{},
 	}
 
-	result := d.resolveAsNeededForKeys(ctx, agent, []string{"GEMINI_API_KEY", "OTHER_KEY"})
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{"GEMINI_API_KEY", "OTHER_KEY"}, nil)
 
 	if v, ok := result["GEMINI_API_KEY"]; !ok {
 		t.Error("expected GEMINI_API_KEY in result")
@@ -141,7 +141,7 @@ func TestResolveAsNeededForKeys_Secrets(t *testing.T) {
 		AppliedConfig: &store.AgentAppliedConfig{},
 	}
 
-	result := d.resolveAsNeededForKeys(ctx, agent, []string{"GEMINI_API_KEY", "ALWAYS_SECRET", "/tmp/secret.json"})
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{"GEMINI_API_KEY", "ALWAYS_SECRET", "/tmp/secret.json"}, nil)
 
 	if v, ok := result["GEMINI_API_KEY"]; !ok {
 		t.Error("expected GEMINI_API_KEY in result (as_needed environment secret)")
@@ -191,7 +191,7 @@ func TestResolveAsNeededForKeys_SecretNameFallback(t *testing.T) {
 		AppliedConfig: &store.AgentAppliedConfig{},
 	}
 
-	result := d.resolveAsNeededForKeys(ctx, agent, []string{"MY_API_KEY"})
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{"MY_API_KEY"}, nil)
 
 	if v, ok := result["MY_API_KEY"]; !ok {
 		t.Error("expected MY_API_KEY in result (secret with empty Target should fall back to Name)")
@@ -242,7 +242,7 @@ func TestResolveAsNeededForKeys_ScopePrecedence(t *testing.T) {
 		AppliedConfig: &store.AgentAppliedConfig{},
 	}
 
-	result := d.resolveAsNeededForKeys(ctx, agent, []string{"API_KEY"})
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{"API_KEY"}, nil)
 
 	// User scope should win over hub scope (higher precedence, last-wins)
 	if v, ok := result["API_KEY"]; !ok {
@@ -269,7 +269,7 @@ func TestResolveAsNeededForKeys_NoBackend(t *testing.T) {
 	}
 
 	// Should not panic with nil secret backend
-	result := d.resolveAsNeededForKeys(ctx, agent, []string{"SOME_KEY"})
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{"SOME_KEY"}, nil)
 
 	if len(result) != 0 {
 		t.Errorf("expected empty result with no matching env vars and no secret backend, got %v", result)
@@ -292,7 +292,7 @@ func TestResolveAsNeededForKeys_EmptyKeys(t *testing.T) {
 		AppliedConfig: &store.AgentAppliedConfig{},
 	}
 
-	result := d.resolveAsNeededForKeys(ctx, agent, []string{})
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{}, nil)
 
 	if len(result) != 0 {
 		t.Errorf("expected empty result for empty keys, got %v", result)
@@ -344,7 +344,7 @@ func TestResolveAsNeededForKeys_EnvVarPriorityOverSecret(t *testing.T) {
 		AppliedConfig: &store.AgentAppliedConfig{},
 	}
 
-	result := d.resolveAsNeededForKeys(ctx, agent, []string{"SHARED_KEY"})
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{"SHARED_KEY"}, nil)
 
 	// Env var should be found first; secret should not overwrite (alreadySet check)
 	if v, ok := result["SHARED_KEY"]; !ok {
@@ -647,6 +647,148 @@ func TestDispatchAgentCreateWithGather_NoNeeds(t *testing.T) {
 	// Should only be called once
 	if mockClient.callCount != 1 {
 		t.Errorf("expected 1 broker call, got %d", mockClient.callCount)
+	}
+}
+
+// --- resolveAsNeededForKeys tests with alternatives ---
+
+func TestResolveAsNeededForKeys_AlternativeKeyMatching(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	hubID := "test-hub-alternatives"
+
+	// Store GOOGLE_CLOUD_LOCATION (an alternative name, not the canonical key)
+	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
+		ID:            tid("env-alt-location"),
+		Key:           "GOOGLE_CLOUD_LOCATION",
+		Value:         "us-central1",
+		Scope:         store.ScopeHub,
+		ScopeID:       hubID,
+		InjectionMode: store.InjectionModeAsNeeded,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetHubID(hubID)
+
+	agent := &store.Agent{
+		ID:            "agent-alt-test",
+		Name:          "alt-test",
+		OwnerID:       "user-1",
+		ProjectID:     "project-1",
+		AppliedConfig: &store.AgentAppliedConfig{},
+	}
+
+	// The broker reports canonical key GOOGLE_CLOUD_REGION in Needs,
+	// with alternatives that include GOOGLE_CLOUD_LOCATION.
+	alternatives := map[string][]string{
+		"GOOGLE_CLOUD_REGION": {"CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"},
+	}
+
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{"GOOGLE_CLOUD_REGION"}, alternatives)
+
+	// The stored var GOOGLE_CLOUD_LOCATION should match via alternatives and be
+	// stored under the canonical key GOOGLE_CLOUD_REGION.
+	if v, ok := result["GOOGLE_CLOUD_REGION"]; !ok {
+		t.Error("expected GOOGLE_CLOUD_REGION in result (matched via alternative GOOGLE_CLOUD_LOCATION)")
+	} else if v != "us-central1" {
+		t.Errorf("GOOGLE_CLOUD_REGION = %q, want %q", v, "us-central1")
+	}
+
+	// GOOGLE_CLOUD_LOCATION should NOT appear as a separate key in the result
+	if _, ok := result["GOOGLE_CLOUD_LOCATION"]; ok {
+		t.Error("GOOGLE_CLOUD_LOCATION should not be in result as a separate key; it should be mapped to the canonical key")
+	}
+}
+
+func TestResolveAsNeededForKeys_AlternativeKeyMatchingSecrets(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	hubID := "test-hub-alt-secrets"
+
+	mockClient := &mockRuntimeBrokerClient{}
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetHubID(hubID)
+	d.SetSecretBackend(&mockSecretBackend{
+		secrets: []secret.SecretWithValue{
+			{
+				SecretMeta: secret.SecretMeta{
+					Name:          "cloud-location",
+					SecretType:    "environment",
+					Target:        "GOOGLE_CLOUD_LOCATION",
+					Scope:         "hub",
+					ScopeID:       hubID,
+					InjectionMode: "as_needed",
+				},
+				Value: "europe-west1",
+			},
+		},
+	})
+
+	agent := &store.Agent{
+		ID:            "agent-alt-secret-test",
+		Name:          "alt-secret-test",
+		OwnerID:       "user-1",
+		ProjectID:     "project-1",
+		AppliedConfig: &store.AgentAppliedConfig{},
+	}
+
+	alternatives := map[string][]string{
+		"GOOGLE_CLOUD_REGION": {"CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"},
+	}
+
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{"GOOGLE_CLOUD_REGION"}, alternatives)
+
+	// The secret targeting GOOGLE_CLOUD_LOCATION should match and be stored under
+	// the canonical key GOOGLE_CLOUD_REGION.
+	if v, ok := result["GOOGLE_CLOUD_REGION"]; !ok {
+		t.Error("expected GOOGLE_CLOUD_REGION in result (matched via secret targeting alternative GOOGLE_CLOUD_LOCATION)")
+	} else if v != "europe-west1" {
+		t.Errorf("GOOGLE_CLOUD_REGION = %q, want %q", v, "europe-west1")
+	}
+}
+
+func TestResolveAsNeededForKeys_NilAlternatives(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	hubID := "test-hub-nil-alt"
+
+	// Store canonical key directly
+	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
+		ID:            tid("env-nil-alt"),
+		Key:           "GOOGLE_CLOUD_REGION",
+		Value:         "us-east1",
+		Scope:         store.ScopeHub,
+		ScopeID:       hubID,
+		InjectionMode: store.InjectionModeAsNeeded,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetHubID(hubID)
+
+	agent := &store.Agent{
+		ID:            "agent-nil-alt-test",
+		Name:          "nil-alt-test",
+		OwnerID:       "user-1",
+		ProjectID:     "project-1",
+		AppliedConfig: &store.AgentAppliedConfig{},
+	}
+
+	// nil alternatives should behave exactly like the old code path
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{"GOOGLE_CLOUD_REGION"}, nil)
+
+	if v, ok := result["GOOGLE_CLOUD_REGION"]; !ok {
+		t.Error("expected GOOGLE_CLOUD_REGION in result (exact match, nil alternatives)")
+	} else if v != "us-east1" {
+		t.Errorf("GOOGLE_CLOUD_REGION = %q, want %q", v, "us-east1")
 	}
 }
 

--- a/pkg/hub/as_needed_resolution_test.go
+++ b/pkg/hub/as_needed_resolution_test.go
@@ -752,6 +752,66 @@ func TestResolveAsNeededForKeys_AlternativeKeyMatchingSecrets(t *testing.T) {
 	}
 }
 
+func TestResolveAsNeededForKeys_CanonicalKeyWinsOverAlternative(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	hubID := "test-hub-canonical-wins"
+
+	// Store BOTH the canonical key and an alternative in the same scope.
+	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
+		ID:            tid("env-canonical"),
+		Key:           "GOOGLE_CLOUD_REGION",
+		Value:         "us-central1",
+		Scope:         store.ScopeHub,
+		ScopeID:       hubID,
+		InjectionMode: store.InjectionModeAsNeeded,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := memStore.CreateEnvVar(ctx, &store.EnvVar{
+		ID:            tid("env-alt-dup"),
+		Key:           "GOOGLE_CLOUD_LOCATION",
+		Value:         "europe-west4",
+		Scope:         store.ScopeHub,
+		ScopeID:       hubID,
+		InjectionMode: store.InjectionModeAsNeeded,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	d := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	d.SetHubID(hubID)
+
+	agent := &store.Agent{
+		ID:            "agent-canonical-wins",
+		Name:          "canonical-wins",
+		OwnerID:       "user-1",
+		ProjectID:     "project-1",
+		AppliedConfig: &store.AgentAppliedConfig{},
+	}
+
+	alternatives := map[string][]string{
+		"GOOGLE_CLOUD_REGION": {"CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"},
+	}
+
+	result := d.resolveAsNeededForKeys(ctx, agent, []string{"GOOGLE_CLOUD_REGION"}, alternatives)
+
+	// The canonical key's value must be preserved — the alternative must not
+	// overwrite it regardless of ListEnvVars iteration order.
+	if v, ok := result["GOOGLE_CLOUD_REGION"]; !ok {
+		t.Error("expected GOOGLE_CLOUD_REGION in result")
+	} else if v != "us-central1" {
+		t.Errorf("GOOGLE_CLOUD_REGION = %q, want %q (canonical value should win over alternative)", v, "us-central1")
+	}
+
+	// Only one entry should be in the result.
+	if len(result) != 1 {
+		t.Errorf("expected 1 result entry, got %d: %v", len(result), result)
+	}
+}
+
 func TestResolveAsNeededForKeys_NilAlternatives(t *testing.T) {
 	ctx := context.Background()
 	memStore := createTestStore(t)

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -1476,11 +1476,14 @@ func (d *HTTPAgentDispatcher) resolveAsNeededForKeys(
 	// Expand keySet with alternatives and build a reverse map so that when
 	// a stored var is keyed by an alternative name, we store its value under
 	// the canonical key (which is what the broker expects).
-	altToCanonical := make(map[string]string)
-	for canonical, alts := range alternatives {
-		for _, alt := range alts {
-			keySet[alt] = struct{}{}
-			altToCanonical[alt] = canonical
+	var altToCanonical map[string]string
+	if len(alternatives) > 0 {
+		altToCanonical = make(map[string]string)
+		for canonical, alts := range alternatives {
+			for _, alt := range alts {
+				keySet[alt] = struct{}{}
+				altToCanonical[alt] = canonical
+			}
 		}
 	}
 
@@ -1502,6 +1505,9 @@ func (d *HTTPAgentDispatcher) resolveAsNeededForKeys(
 				// Store under the canonical key if this was an alternative match
 				resultKey := v.Key
 				if canonical, isAlt := altToCanonical[v.Key]; isAlt {
+					if _, already := result[canonical]; already {
+						continue // canonical key already matched; don't overwrite
+					}
 					resultKey = canonical
 				}
 				result[resultKey] = v.Value
@@ -1561,6 +1567,9 @@ func (d *HTTPAgentDispatcher) resolveAsNeededForKeys(
 					// Store under the canonical key if this was an alternative match
 					resultKey := target
 					if canonical, isAlt := altToCanonical[target]; isAlt {
+						if _, already := result[canonical]; already {
+							continue // canonical key already matched; don't overwrite
+						}
 						resultKey = canonical
 					}
 					if _, alreadySet := result[resultKey]; !alreadySet {

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -1477,6 +1477,8 @@ func (d *HTTPAgentDispatcher) resolveAsNeededForKeys(
 	// a stored var is keyed by an alternative name, we store its value under
 	// the canonical key (which is what the broker expects).
 	var altToCanonical map[string]string
+	resultIsCanonical := make(map[string]bool)
+	resultScopeIdx := make(map[string]int)
 	if len(alternatives) > 0 {
 		altToCanonical = make(map[string]string)
 		for canonical, alts := range alternatives {
@@ -1502,15 +1504,24 @@ func (d *HTTPAgentDispatcher) resolveAsNeededForKeys(
 				continue
 			}
 			if _, needed := keySet[v.Key]; needed {
-				// Store under the canonical key if this was an alternative match
+				canonical, isAlt := altToCanonical[v.Key]
 				resultKey := v.Key
-				if canonical, isAlt := altToCanonical[v.Key]; isAlt {
-					if _, already := result[canonical]; already {
-						continue // canonical key already matched; don't overwrite
-					}
+				if isAlt {
 					resultKey = canonical
 				}
-				result[resultKey] = v.Value
+				currentScopeIdx := slices.Index(envScopePrecedence, filter.Scope)
+				isCanonical := !isAlt
+				storedScopeIdx, alreadySet := resultScopeIdx[resultKey]
+				if !alreadySet || currentScopeIdx > storedScopeIdx {
+					result[resultKey] = v.Value
+					resultIsCanonical[resultKey] = isCanonical
+					resultScopeIdx[resultKey] = currentScopeIdx
+				} else if currentScopeIdx == storedScopeIdx {
+					if isCanonical && !resultIsCanonical[resultKey] {
+						result[resultKey] = v.Value
+						resultIsCanonical[resultKey] = true
+					}
+				}
 			}
 		}
 	}

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -1020,7 +1020,7 @@ func (d *HTTPAgentDispatcher) DispatchAgentCreateWithGather(ctx context.Context,
 	// be satisfied by as_needed env vars or secrets. If so, finalize them
 	// transparently without requiring CLI intervention.
 	if envReqs != nil && len(envReqs.Needs) > 0 {
-		asNeededEnv := d.resolveAsNeededForKeys(ctx, agent, envReqs.Needs)
+		asNeededEnv := d.resolveAsNeededForKeys(ctx, agent, envReqs.Needs, envReqs.Alternatives)
 		if len(asNeededEnv) > 0 {
 			err := d.DispatchFinalizeEnv(ctx, agent, asNeededEnv)
 			if err == nil {
@@ -1108,7 +1108,7 @@ func (d *HTTPAgentDispatcher) DispatchFinalizeEnv(ctx context.Context, agent *st
 	if envReqs != nil && len(envReqs.Needs) > 0 {
 		// Second pass: try to satisfy remaining needs with as_needed entries,
 		// mirroring the pattern in DispatchAgentCreateWithGather.
-		asNeededEnv := d.resolveAsNeededForKeys(ctx, agent, envReqs.Needs)
+		asNeededEnv := d.resolveAsNeededForKeys(ctx, agent, envReqs.Needs, envReqs.Alternatives)
 		if len(asNeededEnv) > 0 {
 			for k, v := range asNeededEnv {
 				req.ResolvedEnv[k] = v
@@ -1465,11 +1465,23 @@ func (d *HTTPAgentDispatcher) resolveAsNeededForKeys(
 	ctx context.Context,
 	agent *store.Agent,
 	keys []string,
+	alternatives map[string][]string,
 ) map[string]string {
 	result := make(map[string]string)
 	keySet := make(map[string]struct{}, len(keys))
 	for _, k := range keys {
 		keySet[k] = struct{}{}
+	}
+
+	// Expand keySet with alternatives and build a reverse map so that when
+	// a stored var is keyed by an alternative name, we store its value under
+	// the canonical key (which is what the broker expects).
+	altToCanonical := make(map[string]string)
+	for canonical, alts := range alternatives {
+		for _, alt := range alts {
+			keySet[alt] = struct{}{}
+			altToCanonical[alt] = canonical
+		}
 	}
 
 	// 1. Check env_vars table (all scopes, in precedence order so last-wins).
@@ -1487,7 +1499,12 @@ func (d *HTTPAgentDispatcher) resolveAsNeededForKeys(
 				continue
 			}
 			if _, needed := keySet[v.Key]; needed {
-				result[v.Key] = v.Value
+				// Store under the canonical key if this was an alternative match
+				resultKey := v.Key
+				if canonical, isAlt := altToCanonical[v.Key]; isAlt {
+					resultKey = canonical
+				}
+				result[resultKey] = v.Value
 			}
 		}
 	}
@@ -1541,8 +1558,13 @@ func (d *HTTPAgentDispatcher) resolveAsNeededForKeys(
 					target = sv.Name
 				}
 				if _, needed := keySet[target]; needed {
-					if _, alreadySet := result[target]; !alreadySet {
-						result[target] = sv.Value
+					// Store under the canonical key if this was an alternative match
+					resultKey := target
+					if canonical, isAlt := altToCanonical[target]; isAlt {
+						resultKey = canonical
+					}
+					if _, alreadySet := result[resultKey]; !alreadySet {
+						result[resultKey] = sv.Value
 					}
 				}
 			}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -605,12 +605,13 @@ type SecretKeyInfo struct {
 }
 
 type RemoteEnvRequirementsResponse struct {
-	AgentID    string                   `json:"agentId"`
-	Required   []string                 `json:"required"`
-	HubHas     []string                 `json:"hubHas"`
-	BrokerHas  []string                 `json:"brokerHas"`
-	Needs      []string                 `json:"needs"`
-	SecretInfo map[string]SecretKeyInfo `json:"secretInfo,omitempty"`
+	AgentID      string                   `json:"agentId"`
+	Required     []string                 `json:"required"`
+	HubHas       []string                 `json:"hubHas"`
+	BrokerHas    []string                 `json:"brokerHas"`
+	Needs        []string                 `json:"needs"`
+	SecretInfo   map[string]SecretKeyInfo `json:"secretInfo,omitempty"`
+	Alternatives map[string][]string      `json:"alternatives,omitempty"` // Maps canonical key in Needs to alternative key names from the same any_of group
 }
 
 // RemoteAgentInfo contains agent information from a remote runtime broker.

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -524,7 +524,7 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		required, secretInfo := s.extractRequiredEnvKeys(req, hydratedHCPath)
+		required, secretInfo, alternatives := s.extractRequiredEnvKeys(req, hydratedHCPath)
 		if s.config.Debug {
 			s.envSecretLog.Debug("Env-gather: evaluating env completeness",
 				"gatherEnv", req.GatherEnv,
@@ -594,12 +594,24 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 
+				// Build alternatives for needed keys only
+				var respAlternatives map[string][]string
+				for _, key := range needs {
+					if alts, ok := alternatives[key]; ok {
+						if respAlternatives == nil {
+							respAlternatives = make(map[string][]string)
+						}
+						respAlternatives[key] = alts
+					}
+				}
+
 				resp := EnvRequirementsResponse{
-					AgentID:    agentKey,
-					Required:   required,
-					HubHas:     hubHas,
-					Needs:      needs,
-					SecretInfo: respSecretInfo,
+					AgentID:      agentKey,
+					Required:     required,
+					HubHas:       hubHas,
+					Needs:        needs,
+					SecretInfo:   respSecretInfo,
+					Alternatives: respAlternatives,
 				}
 				if attempt != nil {
 					s.dispatchAttemptsMu.Lock()
@@ -2026,8 +2038,9 @@ func (s *Server) checkAgentPrompt(w http.ResponseWriter, r *http.Request, id, pr
 // config directory that supplements the on-disk search. This allows env-gather
 // to see auth metadata from hub-managed harness-configs that haven't been
 // downloaded to the standard on-disk locations yet.
-func (s *Server) extractRequiredEnvKeys(req CreateAgentRequest, hydratedHarnessConfigPath ...string) ([]string, map[string]api.SecretKeyInfo) {
+func (s *Server) extractRequiredEnvKeys(req CreateAgentRequest, hydratedHarnessConfigPath ...string) ([]string, map[string]api.SecretKeyInfo, map[string][]string) {
 	required := make(map[string]struct{})
+	alternatives := make(map[string][]string)
 
 	var settings *config.VersionedSettings
 	settingsPath := req.ProjectPath
@@ -2244,6 +2257,11 @@ func (s *Server) extractRequiredEnvKeys(req CreateAgentRequest, hydratedHarnessC
 					canonicalKey := group[0]
 					required[canonicalKey] = struct{}{}
 					secretInfo[canonicalKey] = api.SecretKeyInfo{Source: "auth"}
+					// Record alternative key names so the hub can match
+					// as_needed env vars stored under non-canonical names.
+					if len(group) > 1 {
+						alternatives[canonicalKey] = group[1:]
+					}
 				}
 			}
 		}
@@ -2393,7 +2411,7 @@ func (s *Server) extractRequiredEnvKeys(req CreateAgentRequest, hydratedHarnessC
 	for k := range required {
 		keys = append(keys, k)
 	}
-	return keys, secretInfo
+	return keys, secretInfo, alternatives
 }
 
 // resolveHarnessConfigForEnvGather determines the harness-config name for the

--- a/pkg/runtimebroker/handlers_dispatch_test.go
+++ b/pkg/runtimebroker/handlers_dispatch_test.go
@@ -276,7 +276,7 @@ auth:
 			HarnessConfig: "custom-auth",
 		},
 	}
-	required, _ := srv.extractRequiredEnvKeys(req)
+	required, _, _ := srv.extractRequiredEnvKeys(req)
 
 	// Build a set for stable lookup.
 	got := make(map[string]bool)
@@ -314,7 +314,7 @@ auth:
 			HarnessConfig: "claude-legacy",
 		},
 	}
-	required, _ := srv.extractRequiredEnvKeys(req)
+	required, _, _ := srv.extractRequiredEnvKeys(req)
 
 	got := make(map[string]bool)
 	for _, k := range required {

--- a/pkg/runtimebroker/handlers_envgather_test.go
+++ b/pkg/runtimebroker/handlers_envgather_test.go
@@ -2033,3 +2033,82 @@ profiles:
 		t.Errorf("expected GOOGLE_CLOUD_PROJECT in needs/required when harnessAuth=vertex-ai, got needs=%v required=%v", envReqs.Needs, envReqs.Required)
 	}
 }
+
+// TestEnvGather_AlternativesForAnyOfGroup tests that when the broker returns a
+// 202 with a needed key from an any_of group, the Alternatives field maps the
+// canonical key to its alternative names from the group.
+// Regression test for the GOOGLE_CLOUD_LOCATION as_needed bug: the hub needs
+// to know that CLOUD_ML_REGION and GOOGLE_CLOUD_LOCATION are alternatives for
+// GOOGLE_CLOUD_REGION so it can match as_needed env vars stored under those names.
+func TestEnvGather_AlternativesForAnyOfGroup(t *testing.T) {
+	srv, _, projectDir := newTestServerWithHarnessConfig(t, "claude",
+		"harness: claude\nimage: test-image\nuser: scion\n"+claudeAuthBlock,
+		`
+schema_version: "1"
+harness_configs:
+  claude:
+    harness: claude
+profiles:
+  default:
+    runtime: mock
+`)
+
+	body := `{
+		"name": "test-agent-alternatives",
+		"id": "agent-uuid-alt",
+		"gatherEnv": true,
+		"grovePath": "` + projectDir + `",
+		"resolvedEnv": {
+			"GOOGLE_CLOUD_PROJECT": "my-project"
+		},
+		"config": {"template": "claude", "harnessConfig": "claude", "profile": "default"}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 (vertex-ai needs region), got %d: %s", w.Code, w.Body.String())
+	}
+
+	var envReqs EnvRequirementsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &envReqs); err != nil {
+		t.Fatal("failed to decode response:", err)
+	}
+
+	// Verify GOOGLE_CLOUD_REGION is in Needs (canonical key)
+	needsMap := make(map[string]struct{})
+	for _, k := range envReqs.Needs {
+		needsMap[k] = struct{}{}
+	}
+	if _, ok := needsMap["GOOGLE_CLOUD_REGION"]; !ok {
+		t.Fatalf("expected GOOGLE_CLOUD_REGION in Needs, got %v", envReqs.Needs)
+	}
+
+	// Verify Alternatives map contains the any_of alternatives for GOOGLE_CLOUD_REGION
+	if envReqs.Alternatives == nil {
+		t.Fatal("expected non-nil Alternatives map")
+	}
+	alts, ok := envReqs.Alternatives["GOOGLE_CLOUD_REGION"]
+	if !ok {
+		t.Fatalf("expected GOOGLE_CLOUD_REGION in Alternatives map, got %v", envReqs.Alternatives)
+	}
+
+	altSet := make(map[string]struct{}, len(alts))
+	for _, a := range alts {
+		altSet[a] = struct{}{}
+	}
+	if _, ok := altSet["CLOUD_ML_REGION"]; !ok {
+		t.Errorf("expected CLOUD_ML_REGION in alternatives for GOOGLE_CLOUD_REGION, got %v", alts)
+	}
+	if _, ok := altSet["GOOGLE_CLOUD_LOCATION"]; !ok {
+		t.Errorf("expected GOOGLE_CLOUD_LOCATION in alternatives for GOOGLE_CLOUD_REGION, got %v", alts)
+	}
+
+	// Satisfied keys should NOT appear in Alternatives
+	if _, ok := envReqs.Alternatives["GOOGLE_CLOUD_PROJECT"]; ok {
+		t.Errorf("GOOGLE_CLOUD_PROJECT should not be in Alternatives (it is satisfied)")
+	}
+}

--- a/pkg/runtimebroker/types.go
+++ b/pkg/runtimebroker/types.go
@@ -462,12 +462,13 @@ type CreateAgentResponse struct {
 // and the merged environment is missing required keys. The broker returns
 // HTTP 202 with this payload instead of starting the agent.
 type EnvRequirementsResponse struct {
-	AgentID    string                       `json:"agentId"`
-	Required   []string                     `json:"required"`
-	HubHas     []string                     `json:"hubHas"`
-	BrokerHas  []string                     `json:"brokerHas"` // Deprecated: always empty; kept for API compatibility
-	Needs      []string                     `json:"needs"`
-	SecretInfo map[string]api.SecretKeyInfo `json:"secretInfo,omitempty"`
+	AgentID      string                       `json:"agentId"`
+	Required     []string                     `json:"required"`
+	HubHas       []string                     `json:"hubHas"`
+	BrokerHas    []string                     `json:"brokerHas"` // Deprecated: always empty; kept for API compatibility
+	Needs        []string                     `json:"needs"`
+	SecretInfo   map[string]api.SecretKeyInfo `json:"secretInfo,omitempty"`
+	Alternatives map[string][]string          `json:"alternatives,omitempty"` // Maps canonical key in Needs to alternative key names from the same any_of group
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes a bug where hub env vars stored under alternative key names from any_of groups (e.g. GOOGLE_CLOUD_LOCATION instead of GOOGLE_CLOUD_REGION) were not resolved during the as_needed second-pass env-gather.

### Root cause
resolveAsNeededForKeys used exact key matching against the broker's needs list, which contains only canonical (first) keys from any_of groups. Alternative key names were never checked.

### Changes
- Added Alternatives field to EnvRequirementsResponse (broker) and RemoteEnvRequirementsResponse (hub) carrying any_of group alternatives for needed canonical keys
- extractRequiredEnvKeys now returns alternatives map alongside required keys
- resolveAsNeededForKeys expands its key lookup set with alternatives and maps matched values back to canonical keys
- Canonical-wins guard prevents non-deterministic overwrite when both canonical and alternative keys are stored

Fixes ptone/scion#797
