### PR TITLE
fix: suppress duplicate Cloud Logging entries on Cloud Run

### DIFF
--- a/pkg/util/logging/message_log.go
+++ b/pkg/util/logging/message_log.go
@@ -73,7 +73,7 @@ func NewMessageLogger(cfg MessageLoggerConfig) (*slog.Logger, func(), error) {
 	// Logging by the runtime. When a cloud handler is also active, the stdout
 	// handler would produce duplicate entries — skip it in that case.
 	onCloudRun := os.Getenv("K_SERVICE") != ""
-	if !(onCloudRun && cfg.CloudClient != nil) {
+	if !onCloudRun || cfg.CloudClient == nil {
 		if cfg.UseGCP {
 			handlers = append(handlers, NewGCPHandler(os.Stdout, opts, cfg.Component, cfg.HubName))
 		} else {

--- a/pkg/util/logging/message_log.go
+++ b/pkg/util/logging/message_log.go
@@ -68,13 +68,19 @@ func NewMessageLogger(cfg MessageLoggerConfig) (*slog.Logger, func(), error) {
 		})
 	}
 
-	// Stdout handler for local visibility (always enabled for message log)
-	if cfg.UseGCP {
-		handlers = append(handlers, NewGCPHandler(os.Stdout, opts, cfg.Component, cfg.HubName))
-	} else {
-		handlers = append(handlers, slog.NewJSONHandler(os.Stdout, opts).WithAttrs([]slog.Attr{
-			slog.String(AttrComponent, cfg.Component),
-		}))
+	// Stdout handler for local visibility.
+	// On Cloud Run (K_SERVICE set), stdout is captured and forwarded to Cloud
+	// Logging by the runtime. When a cloud handler is also active, the stdout
+	// handler would produce duplicate entries — skip it in that case.
+	onCloudRun := os.Getenv("K_SERVICE") != ""
+	if !(onCloudRun && cfg.CloudClient != nil) {
+		if cfg.UseGCP {
+			handlers = append(handlers, NewGCPHandler(os.Stdout, opts, cfg.Component, cfg.HubName))
+		} else {
+			handlers = append(handlers, slog.NewJSONHandler(os.Stdout, opts).WithAttrs([]slog.Attr{
+				slog.String(AttrComponent, cfg.Component),
+			}))
+		}
 	}
 
 	if len(handlers) == 0 {

--- a/pkg/util/logging/message_log_test.go
+++ b/pkg/util/logging/message_log_test.go
@@ -84,6 +84,53 @@ func TestNewMessageLogger_WritesSubsystemAttrs(t *testing.T) {
 	}
 }
 
+func TestNewMessageLogger_CloudRunSuppressesStdout(t *testing.T) {
+	// On Cloud Run with a cloud client, stdout handler should be suppressed.
+	t.Setenv("K_SERVICE", "my-service")
+
+	// We can't easily create a real gcplog.Client in tests, but we can test
+	// the non-Cloud-Run path to verify stdout is still included.
+	cfg := MessageLoggerConfig{
+		Component:   "test-server",
+		CloudClient: nil, // no cloud client → stdout must be present
+		UseGCP:      true,
+		Level:       slog.LevelInfo,
+	}
+
+	logger, cleanup, err := NewMessageLogger(cfg)
+	if err != nil {
+		t.Fatalf("NewMessageLogger() error = %v", err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if logger == nil {
+		t.Fatal("NewMessageLogger() returned nil logger")
+	}
+}
+
+func TestNewMessageLogger_NonCloudRunKeepsStdout(t *testing.T) {
+	// When not on Cloud Run, stdout handler should always be present.
+	t.Setenv("K_SERVICE", "")
+
+	cfg := MessageLoggerConfig{
+		Component: "test-server",
+		UseGCP:    true,
+		Level:     slog.LevelInfo,
+	}
+
+	logger, cleanup, err := NewMessageLogger(cfg)
+	if err != nil {
+		t.Fatalf("NewMessageLogger() error = %v", err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if logger == nil {
+		t.Fatal("NewMessageLogger() returned nil logger")
+	}
+}
+
 func TestPromoteMessageAttrToLabels(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/util/logging/message_log_test.go
+++ b/pkg/util/logging/message_log_test.go
@@ -135,7 +135,7 @@ func TestNewMessageLogger_CloudRunWithCloudClient_SuppressesStdout(t *testing.T)
 	if err != nil {
 		t.Fatalf("failed to create test gcplog.Client: %v", err)
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	cfg := MessageLoggerConfig{
 		Component:   "test-server",

--- a/pkg/util/logging/message_log_test.go
+++ b/pkg/util/logging/message_log_test.go
@@ -16,9 +16,15 @@ package logging
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"log/slog"
 	"testing"
+
+	gcplog "cloud.google.com/go/logging"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestNewMessageLogger_DefaultConfig(t *testing.T) {
@@ -84,12 +90,12 @@ func TestNewMessageLogger_WritesSubsystemAttrs(t *testing.T) {
 	}
 }
 
-func TestNewMessageLogger_CloudRunSuppressesStdout(t *testing.T) {
-	// On Cloud Run with a cloud client, stdout handler should be suppressed.
+func TestNewMessageLogger_CloudRunWithoutCloudClient_KeepsStdout(t *testing.T) {
+	// On Cloud Run but WITHOUT a cloud client, the stdout handler should
+	// still be present because the suppression condition requires both
+	// K_SERVICE set AND CloudClient != nil.
 	t.Setenv("K_SERVICE", "my-service")
 
-	// We can't easily create a real gcplog.Client in tests, but we can test
-	// the non-Cloud-Run path to verify stdout is still included.
 	cfg := MessageLoggerConfig{
 		Component:   "test-server",
 		CloudClient: nil, // no cloud client → stdout must be present
@@ -106,6 +112,59 @@ func TestNewMessageLogger_CloudRunSuppressesStdout(t *testing.T) {
 	}
 	if logger == nil {
 		t.Fatal("NewMessageLogger() returned nil logger")
+	}
+
+	// With CloudClient=nil and K_SERVICE set, only the stdout handler is
+	// created, so the logger handler should NOT be a multiHandler.
+	if _, ok := logger.Handler().(*multiHandler); ok {
+		t.Error("expected single stdout handler, not multiHandler — suppression should not engage without CloudClient")
+	}
+}
+
+func TestNewMessageLogger_CloudRunWithCloudClient_SuppressesStdout(t *testing.T) {
+	// On Cloud Run with a cloud client, the stdout handler should be
+	// suppressed to avoid duplicate entries (Cloud Run's runtime already
+	// forwards stdout to Cloud Logging).
+	t.Setenv("K_SERVICE", "my-service")
+
+	client, err := gcplog.NewClient(context.Background(), "projects/fake-project",
+		option.WithoutAuthentication(),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		option.WithEndpoint("localhost:1"),
+	)
+	if err != nil {
+		t.Fatalf("failed to create test gcplog.Client: %v", err)
+	}
+	defer client.Close()
+
+	cfg := MessageLoggerConfig{
+		Component:   "test-server",
+		CloudClient: client,
+		UseGCP:      true,
+		Level:       slog.LevelInfo,
+	}
+
+	logger, cleanup, err := NewMessageLogger(cfg)
+	if err != nil {
+		t.Fatalf("NewMessageLogger() error = %v", err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if logger == nil {
+		t.Fatal("NewMessageLogger() returned nil logger")
+	}
+
+	// With both K_SERVICE set and CloudClient non-nil, only the cloud
+	// handler should be active — the stdout handler must be suppressed.
+	// A single handler means no multiHandler wrapping.
+	h := logger.Handler()
+	if _, ok := h.(*multiHandler); ok {
+		t.Error("expected single cloud handler, not multiHandler — stdout handler was not suppressed on Cloud Run")
+	}
+	// Verify we got the cloud handler, not a stdout handler.
+	if _, ok := h.(*messageCloudHandler); !ok {
+		t.Errorf("expected *messageCloudHandler, got %T", h)
 	}
 }
 

--- a/pkg/util/logging/otel.go
+++ b/pkg/util/logging/otel.go
@@ -104,8 +104,8 @@ func SetupWithOTel(component, hubName string, debug bool, useGCP bool, lp log.Lo
 	// handler is also present in extraHandlers, including the stdout base
 	// handler would produce duplicate entries. Skip it in that case.
 	onCloudRun := os.Getenv("K_SERVICE") != ""
-	hasCloudHandler := hasNonNilHandler(extraHandlers)
-	if !(onCloudRun && hasCloudHandler) {
+	cloudHandlerPresent := hasCloudHandler(extraHandlers)
+	if !onCloudRun || !cloudHandlerPresent {
 		baseHandler := createBaseHandler(component, debug, useGCP, hubName)
 		handlers = append(handlers, baseHandler)
 	}
@@ -127,12 +127,28 @@ func SetupWithOTel(component, hubName string, debug bool, useGCP bool, lp log.Lo
 	slog.SetDefault(logger)
 }
 
-// hasNonNilHandler reports whether the slice contains at least one non-nil handler.
-func hasNonNilHandler(handlers []slog.Handler) bool {
+// hasCloudHandler reports whether the slice contains at least one Cloud Logging handler.
+func hasCloudHandler(handlers []slog.Handler) bool {
 	for _, h := range handlers {
-		if h != nil {
+		if isCloudHandler(h) {
 			return true
 		}
+	}
+	return false
+}
+
+// isCloudHandler reports whether h is a Cloud Logging handler.
+// It unwraps circuitGatedHandler to inspect the inner handler.
+func isCloudHandler(h slog.Handler) bool {
+	if h == nil {
+		return false
+	}
+	switch h.(type) {
+	case *CloudHandler, *messageCloudHandler:
+		return true
+	}
+	if cg, ok := h.(*circuitGatedHandler); ok {
+		return isCloudHandler(cg.inner)
 	}
 	return false
 }

--- a/pkg/util/logging/otel.go
+++ b/pkg/util/logging/otel.go
@@ -7,6 +7,7 @@ package logging
 import (
 	"context"
 	"log/slog"
+	"os"
 
 	"go.opentelemetry.io/contrib/bridges/otelslog"
 	"go.opentelemetry.io/otel/log"
@@ -95,11 +96,19 @@ func NewOTelHandler(component string, lp log.LoggerProvider) slog.Handler {
 // If lp is nil, falls back to standard Setup behavior.
 // Extra handlers (e.g., CloudHandler) are appended to the handler chain.
 func SetupWithOTel(component, hubName string, debug bool, useGCP bool, lp log.LoggerProvider, extraHandlers ...slog.Handler) {
-	// Create the base handler (same logic as Setup)
-	baseHandler := createBaseHandler(component, debug, useGCP, hubName)
-
 	// Collect all handlers
-	handlers := []slog.Handler{baseHandler}
+	var handlers []slog.Handler
+
+	// On Cloud Run (K_SERVICE set), stdout is automatically captured and
+	// forwarded to Cloud Logging by the runtime. When a direct Cloud Logging
+	// handler is also present in extraHandlers, including the stdout base
+	// handler would produce duplicate entries. Skip it in that case.
+	onCloudRun := os.Getenv("K_SERVICE") != ""
+	hasCloudHandler := hasNonNilHandler(extraHandlers)
+	if !(onCloudRun && hasCloudHandler) {
+		baseHandler := createBaseHandler(component, debug, useGCP, hubName)
+		handlers = append(handlers, baseHandler)
+	}
 
 	if lp != nil {
 		handlers = append(handlers, NewOTelHandler(component, lp))
@@ -116,4 +125,14 @@ func SetupWithOTel(component, hubName string, debug bool, useGCP bool, lp log.Lo
 
 	logger := slog.New(handler)
 	slog.SetDefault(logger)
+}
+
+// hasNonNilHandler reports whether the slice contains at least one non-nil handler.
+func hasNonNilHandler(handlers []slog.Handler) bool {
+	for _, h := range handlers {
+		if h != nil {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/util/logging/otel_test.go
+++ b/pkg/util/logging/otel_test.go
@@ -146,6 +146,89 @@ func TestInitOTelLogging_NoEndpoint(t *testing.T) {
 	cleanup() // Should not panic
 }
 
+func TestSetupWithOTel_CloudRunSuppressesStdout(t *testing.T) {
+	// When K_SERVICE is set and a cloud handler is present, the stdout base
+	// handler should be omitted to avoid duplicate Cloud Logging entries.
+	t.Setenv("K_SERVICE", "my-service")
+
+	// Use a minimal handler as the "cloud handler" stand-in.
+	cloudHandler := slog.NewJSONHandler(nil, nil)
+
+	SetupWithOTel("test-component", "", false, true, nil, cloudHandler)
+
+	// The default logger should be set (not nil).
+	logger := slog.Default()
+	if logger == nil {
+		t.Fatal("Default logger should be set")
+	}
+
+	// Verify the handler is directly the cloudHandler (no multiHandler
+	// wrapping needed when there's only one handler).
+	h := logger.Handler()
+	if _, ok := h.(*slog.JSONHandler); !ok {
+		// If it's a multiHandler, verify it contains only the cloud handler.
+		mh, isMH := h.(*multiHandler)
+		if !isMH {
+			t.Fatalf("expected cloud handler or multiHandler, got %T", h)
+		}
+		// Should have exactly 1 handler (the cloud handler), not 2.
+		if len(mh.handlers) != 1 {
+			t.Errorf("expected 1 handler (cloud only), got %d — stdout handler was not suppressed", len(mh.handlers))
+		}
+	}
+}
+
+func TestSetupWithOTel_NonCloudRunKeepsStdout(t *testing.T) {
+	// When K_SERVICE is NOT set, both stdout and cloud handlers should be present.
+	t.Setenv("K_SERVICE", "")
+
+	cloudHandler := slog.NewJSONHandler(nil, nil)
+
+	SetupWithOTel("test-component", "", false, true, nil, cloudHandler)
+
+	logger := slog.Default()
+	if logger == nil {
+		t.Fatal("Default logger should be set")
+	}
+
+	h := logger.Handler()
+	mh, ok := h.(*multiHandler)
+	if !ok {
+		t.Fatalf("expected multiHandler with 2 handlers, got single handler %T", h)
+	}
+	if len(mh.handlers) != 2 {
+		t.Errorf("expected 2 handlers (stdout + cloud), got %d", len(mh.handlers))
+	}
+}
+
+func TestSetupWithOTel_CloudRunNoCloudHandler(t *testing.T) {
+	// On Cloud Run but without a cloud handler — stdout should still be active.
+	t.Setenv("K_SERVICE", "my-service")
+
+	SetupWithOTel("test-component", "", false, true, nil)
+
+	logger := slog.Default()
+	if logger == nil {
+		t.Fatal("Default logger should be set")
+	}
+	// With only the base handler, the logger handler should not be a multiHandler.
+	if _, ok := logger.Handler().(*multiHandler); ok {
+		t.Error("expected single handler (base), not multiHandler")
+	}
+}
+
+func TestHasNonNilHandler(t *testing.T) {
+	if hasNonNilHandler(nil) {
+		t.Error("nil slice should return false")
+	}
+	if hasNonNilHandler([]slog.Handler{nil, nil}) {
+		t.Error("all-nil slice should return false")
+	}
+	if !hasNonNilHandler([]slog.Handler{nil, slog.NewJSONHandler(nil, nil)}) {
+		t.Error("slice with non-nil handler should return true")
+	}
+}
+
 func TestEnvVarConstants(t *testing.T) {
 	// Verify constants are set correctly
 	if EnvOTelEndpoint != "SCION_OTEL_ENDPOINT" {

--- a/pkg/util/logging/otel_test.go
+++ b/pkg/util/logging/otel_test.go
@@ -151,8 +151,8 @@ func TestSetupWithOTel_CloudRunSuppressesStdout(t *testing.T) {
 	// handler should be omitted to avoid duplicate Cloud Logging entries.
 	t.Setenv("K_SERVICE", "my-service")
 
-	// Use a minimal handler as the "cloud handler" stand-in.
-	cloudHandler := slog.NewJSONHandler(nil, nil)
+	// Use a real CloudHandler so hasCloudHandler detects it.
+	cloudHandler := &CloudHandler{}
 
 	SetupWithOTel("test-component", "", false, true, nil, cloudHandler)
 
@@ -165,11 +165,11 @@ func TestSetupWithOTel_CloudRunSuppressesStdout(t *testing.T) {
 	// Verify the handler is directly the cloudHandler (no multiHandler
 	// wrapping needed when there's only one handler).
 	h := logger.Handler()
-	if _, ok := h.(*slog.JSONHandler); !ok {
+	if _, ok := h.(*CloudHandler); !ok {
 		// If it's a multiHandler, verify it contains only the cloud handler.
 		mh, isMH := h.(*multiHandler)
 		if !isMH {
-			t.Fatalf("expected cloud handler or multiHandler, got %T", h)
+			t.Fatalf("expected CloudHandler or multiHandler, got %T", h)
 		}
 		// Should have exactly 1 handler (the cloud handler), not 2.
 		if len(mh.handlers) != 1 {
@@ -217,15 +217,18 @@ func TestSetupWithOTel_CloudRunNoCloudHandler(t *testing.T) {
 	}
 }
 
-func TestHasNonNilHandler(t *testing.T) {
-	if hasNonNilHandler(nil) {
+func TestHasCloudHandler(t *testing.T) {
+	if hasCloudHandler(nil) {
 		t.Error("nil slice should return false")
 	}
-	if hasNonNilHandler([]slog.Handler{nil, nil}) {
+	if hasCloudHandler([]slog.Handler{nil, nil}) {
 		t.Error("all-nil slice should return false")
 	}
-	if !hasNonNilHandler([]slog.Handler{nil, slog.NewJSONHandler(nil, nil)}) {
-		t.Error("slice with non-nil handler should return true")
+	if hasCloudHandler([]slog.Handler{nil, slog.NewJSONHandler(nil, nil)}) {
+		t.Error("non-cloud handler (JSONHandler) should return false")
+	}
+	if !hasCloudHandler([]slog.Handler{nil, &CloudHandler{}}) {
+		t.Error("slice with CloudHandler should return true")
 	}
 }
 


### PR DESCRIPTION
On Cloud Run, every slog call produced two Cloud Logging entries because the handler chain fanned out to both a stdout GCPHandler (whose output Cloud Run captures and forwards to Cloud Logging) and a direct ResilientCloudHandler (which sends via the Cloud Logging API).

Fix both duplication surfaces:

1. **otel.go (SetupWithOTel)**: When K_SERVICE is set and a cloud handler is present in extraHandlers, skip creating the stdout base handler. The direct API handler alone is sufficient on Cloud Run.

2. **message_log.go (NewMessageLogger)**: Same pattern — when K_SERVICE is set and CloudClient is non-nil, skip the stdout handler to avoid duplicating message audit entries.

Both fixes preserve existing behavior for non-Cloud-Run environments (workstations, VMs) where stdout is the only output path.

Key files:
- pkg/util/logging/otel.go
- pkg/util/logging/message_log.go
- pkg/util/logging/otel_test.go
- pkg/util/logging/message_log_test.go

Related: ptone/scion branch scion/fix-duplicate-logs