### PR TITLE
fix: scope diagnostics log filter to Scion logs and current hub

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -671,6 +671,7 @@ func initServerLogging(cmd *cobra.Command) (cleanups []func(), requestLogger *sl
 	}
 
 	hubName := resolveHubNameFromEnv()
+	hubID := resolveHubIDFromEnv()
 
 	// Initialize OTel logging
 	ctx := context.Background()
@@ -704,7 +705,6 @@ func initServerLogging(cmd *cobra.Command) (cleanups []func(), requestLogger *sl
 	var cloudHandler slog.Handler
 	if cloudLoggingEnabled {
 		logLevel := logging.ResolveLogLevel(enableDebug)
-		hubID := resolveHubIDFromEnv()
 		logCfg := logging.CloudLoggingConfig{
 			Component: component,
 			HubName:   hubName,
@@ -728,7 +728,6 @@ func initServerLogging(cmd *cobra.Command) (cleanups []func(), requestLogger *sl
 	logging.SetupWithOTel(component, hubName, enableDebug, useGCP, logProvider, cloudHandler)
 
 	// Initialize request logger
-	hubID := resolveHubIDFromEnv()
 	reqLogCfg := logging.RequestLoggerConfig{
 		FilePath:   os.Getenv(logging.EnvRequestLogPath),
 		Component:  component,

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -704,11 +704,13 @@ func initServerLogging(cmd *cobra.Command) (cleanups []func(), requestLogger *sl
 	var cloudHandler slog.Handler
 	if cloudLoggingEnabled {
 		logLevel := logging.ResolveLogLevel(enableDebug)
-		cfg := logging.CloudLoggingConfig{
+		hubID := resolveHubIDFromEnv()
+		logCfg := logging.CloudLoggingConfig{
 			Component: component,
 			HubName:   hubName,
+			HubID:     hubID,
 		}
-		ch, cloudLogCleanup, cloudErr := logging.NewCloudHandler(ctx, cfg, logLevel)
+		ch, cloudLogCleanup, cloudErr := logging.NewCloudHandler(ctx, logCfg, logLevel)
 		if cloudErr != nil {
 			log.Printf("Warning: failed to initialize Cloud Logging: %v", cloudErr)
 		} else {
@@ -726,10 +728,12 @@ func initServerLogging(cmd *cobra.Command) (cleanups []func(), requestLogger *sl
 	logging.SetupWithOTel(component, hubName, enableDebug, useGCP, logProvider, cloudHandler)
 
 	// Initialize request logger
+	hubID := resolveHubIDFromEnv()
 	reqLogCfg := logging.RequestLoggerConfig{
 		FilePath:   os.Getenv(logging.EnvRequestLogPath),
 		Component:  component,
 		HubName:    hubName,
+		HubID:      hubID,
 		UseGCP:     useGCP,
 		Foreground: serverStartForeground,
 		Level:      logging.ResolveLogLevel(enableDebug),
@@ -752,6 +756,7 @@ func initServerLogging(cmd *cobra.Command) (cleanups []func(), requestLogger *sl
 	msgLogCfg := logging.MessageLoggerConfig{
 		Component: component,
 		HubName:   hubName,
+		HubID:     hubID,
 		UseGCP:    useGCP,
 		Level:     logging.ResolveLogLevel(enableDebug),
 	}
@@ -1287,6 +1292,16 @@ func parseAdminEmails(cfg *config.GlobalConfig) []string {
 		log.Printf("Admin emails configured: %v", adminEmailList)
 	}
 	return adminEmailList
+}
+
+// resolveHubIDFromEnv resolves the hub instance ID from environment variables,
+// falling back to the deterministic hostname-derived default. This is used
+// during early logging init before the full config is loaded.
+func resolveHubIDFromEnv() string {
+	if v := os.Getenv("SCION_SERVER_HUB_HUBID"); v != "" {
+		return v
+	}
+	return config.DefaultHubID()
 }
 
 // resolveHubNameFromEnv resolves the hub display name from environment variables,

--- a/pkg/hub/handlers_diagnostics.go
+++ b/pkg/hub/handlers_diagnostics.go
@@ -49,7 +49,9 @@ func (s *Server) handleDiagnosticsLogs(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 
 	// Parse query parameters
-	opts := LogQueryOptions{}
+	opts := LogQueryOptions{
+		HubName: s.config.HubName,
+	}
 
 	if v := query.Get("tail"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
@@ -139,7 +141,9 @@ func (s *Server) handleDiagnosticsLogsStream(w http.ResponseWriter, r *http.Requ
 	query := r.URL.Query()
 
 	// Parse query filters — no LogID or AgentID to stream all system logs
-	opts := LogQueryOptions{}
+	opts := LogQueryOptions{
+		HubName: s.config.HubName,
+	}
 	if v := query.Get("severity"); v != "" {
 		opts.Severity = v
 	}

--- a/pkg/hub/handlers_logs.go
+++ b/pkg/hub/handlers_logs.go
@@ -123,6 +123,7 @@ func (s *Server) handleAgentCloudLogs(w http.ResponseWriter, r *http.Request, ag
 	// Parse query parameters
 	query := r.URL.Query()
 	opts := LogQueryOptions{
+		HubName:   s.config.HubName,
 		AgentID:   agent.ID,
 		ProjectID: agent.ProjectID,
 	}
@@ -201,6 +202,7 @@ func (s *Server) handleAgentCloudLogsStream(w http.ResponseWriter, r *http.Reque
 	// Parse query filters
 	query := r.URL.Query()
 	opts := LogQueryOptions{
+		HubName: s.config.HubName,
 		AgentID: agent.ID,
 	}
 	if v := query.Get("severity"); v != "" {
@@ -300,6 +302,7 @@ func (s *Server) handleAgentMessageLogs(w http.ResponseWriter, r *http.Request, 
 
 	query := r.URL.Query()
 	opts := LogQueryOptions{
+		HubName:   s.config.HubName,
 		AgentID:   agent.ID,
 		ProjectID: agent.ProjectID,
 		LogID:     logging.MessageLogID,
@@ -370,6 +373,7 @@ func (s *Server) handleAgentMessageLogsStream(w http.ResponseWriter, r *http.Req
 	}
 
 	opts := LogQueryOptions{
+		HubName:   s.config.HubName,
 		AgentID:   agent.ID,
 		ProjectID: agent.ProjectID,
 		LogID:     logging.MessageLogID,
@@ -460,6 +464,7 @@ func (s *Server) handleProjectMessageLogs(w http.ResponseWriter, r *http.Request
 
 	query := r.URL.Query()
 	opts := LogQueryOptions{
+		HubName:   s.config.HubName,
 		ProjectID: project.ID,
 		LogID:     logging.MessageLogID,
 	}
@@ -528,6 +533,7 @@ func (s *Server) handleProjectMessageLogsStream(w http.ResponseWriter, r *http.R
 	}
 
 	opts := LogQueryOptions{
+		HubName:   s.config.HubName,
 		ProjectID: project.ID,
 		LogID:     logging.MessageLogID,
 	}

--- a/pkg/hub/logquery.go
+++ b/pkg/hub/logquery.go
@@ -74,6 +74,7 @@ type LogQueryOptions struct {
 	PageToken string
 	Sources   []string // optional: "hub", "broker", "agent", "messages" — restricts to matching logs/subsystems
 	Search    string   // optional: substring match on jsonPayload.message
+	HubName   string   // optional: filter by hub label to scope logs to this hub instance
 }
 
 // LogQueryResult contains the result of a log query.
@@ -166,9 +167,14 @@ func BuildLogFilter(opts LogQueryOptions, projectID ...string) string {
 	if opts.LogID != "" && len(projectID) > 0 && projectID[0] != "" {
 		parts = append(parts, fmt.Sprintf(`logName = "projects/%s/logs/%s"`, projectID[0], opts.LogID))
 	} else if len(projectID) > 0 && projectID[0] != "" {
-		// Exclude request logs from general log queries — they are high-volume
-		// server infrastructure logs that are not relevant to agent activity.
-		parts = append(parts, fmt.Sprintf(`logName != "projects/%s/logs/%s"`, projectID[0], logging.RequestLogID))
+		// Restrict to known Scion log names (whitelist). This excludes Cloud SQL,
+		// GCE audit, load balancer, and all other non-Scion logs in the project.
+		// The request log (scion_request_log) is excluded implicitly since it is
+		// not in the whitelist.
+		pid := projectID[0]
+		parts = append(parts, fmt.Sprintf(
+			`(logName = "projects/%s/logs/scion-server" OR logName = "projects/%s/logs/scion-agents" OR logName = "projects/%s/logs/scion-messages")`,
+			pid, pid, pid))
 	}
 	if opts.AgentID != "" && opts.LogID == logging.MessageLogID {
 		// For message logs, match where this agent is either the recipient
@@ -194,6 +200,9 @@ func BuildLogFilter(opts LogQueryOptions, projectID ...string) string {
 	}
 	if opts.Severity != "" {
 		parts = append(parts, fmt.Sprintf(`severity >= %s`, strings.ToUpper(opts.Severity)))
+	}
+	if opts.HubName != "" {
+		parts = append(parts, fmt.Sprintf(`labels.hub = %q`, opts.HubName))
 	}
 
 	if len(opts.Sources) > 0 && len(projectID) > 0 && projectID[0] != "" {

--- a/pkg/hub/logquery.go
+++ b/pkg/hub/logquery.go
@@ -173,8 +173,8 @@ func BuildLogFilter(opts LogQueryOptions, projectID ...string) string {
 		// not in the whitelist.
 		pid := projectID[0]
 		parts = append(parts, fmt.Sprintf(
-			`(logName = "projects/%s/logs/scion-server" OR logName = "projects/%s/logs/scion-agents" OR logName = "projects/%s/logs/scion-messages")`,
-			pid, pid, pid))
+			`(logName = "projects/%s/logs/%s" OR logName = "projects/%s/logs/%s" OR logName = "projects/%s/logs/%s")`,
+			pid, logging.ServerLogID, pid, logging.AgentLogID, pid, logging.MessageLogID))
 	}
 	if opts.AgentID != "" && opts.LogID == logging.MessageLogID {
 		// For message logs, match where this agent is either the recipient
@@ -212,16 +212,16 @@ func BuildLogFilter(opts LogQueryOptions, projectID ...string) string {
 			switch src {
 			case "hub":
 				srcParts = append(srcParts, fmt.Sprintf(
-					`(logName = "projects/%s/logs/scion-server" AND jsonPayload.subsystem =~ "^hub\\.")`, pid))
+					`(logName = "projects/%s/logs/%s" AND jsonPayload.subsystem =~ "^hub\\.")`, pid, logging.ServerLogID))
 			case "broker":
 				srcParts = append(srcParts, fmt.Sprintf(
-					`(logName = "projects/%s/logs/scion-server" AND jsonPayload.subsystem =~ "^broker\\.")`, pid))
+					`(logName = "projects/%s/logs/%s" AND jsonPayload.subsystem =~ "^broker\\.")`, pid, logging.ServerLogID))
 			case "agent":
 				srcParts = append(srcParts, fmt.Sprintf(
-					`logName = "projects/%s/logs/scion-agents"`, pid))
+					`logName = "projects/%s/logs/%s"`, pid, logging.AgentLogID))
 			case "messages":
 				srcParts = append(srcParts, fmt.Sprintf(
-					`logName = "projects/%s/logs/scion-messages"`, pid))
+					`logName = "projects/%s/logs/%s"`, pid, logging.MessageLogID))
 			}
 		}
 		if len(srcParts) > 0 {

--- a/pkg/hub/logquery_test.go
+++ b/pkg/hub/logquery_test.go
@@ -15,6 +15,7 @@
 package hub
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -133,12 +134,12 @@ func TestBuildLogFilter_LogID(t *testing.T) {
 			expected:  `(labels.recipient_id = "agent-123" OR labels.sender_id = "agent-123")`,
 		},
 		{
-			name: "no logID with project ID excludes request log",
+			name: "no logID with project ID uses whitelist filter",
 			opts: LogQueryOptions{
 				AgentID: "agent-123",
 			},
 			projectID: "my-project",
-			expected:  `logName != "projects/my-project/logs/scion_request_log" AND labels.agent_id = "agent-123"`,
+			expected:  `(logName = "projects/my-project/logs/scion-server" OR logName = "projects/my-project/logs/scion-agents" OR logName = "projects/my-project/logs/scion-messages") AND labels.agent_id = "agent-123"`,
 		},
 		{
 			name: "message log uses ID-based sender and recipient filter",
@@ -168,6 +169,138 @@ func TestBuildLogFilter_LogID(t *testing.T) {
 				t.Errorf("BuildLogFilter() = %q, want %q", result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestBuildLogFilter_Whitelist(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      LogQueryOptions
+		projectID string
+		expected  string
+	}{
+		{
+			name:      "default filter produces whitelist not exclusion",
+			opts:      LogQueryOptions{},
+			projectID: "my-project",
+			expected:  `(logName = "projects/my-project/logs/scion-server" OR logName = "projects/my-project/logs/scion-agents" OR logName = "projects/my-project/logs/scion-messages")`,
+		},
+		{
+			name:      "whitelist excludes Cloud SQL logs implicitly",
+			opts:      LogQueryOptions{},
+			projectID: "my-project",
+			// The whitelist only admits scion-server, scion-agents, scion-messages.
+			// A Cloud SQL logName like "projects/my-project/logs/cloudsql.googleapis.com%2Fpostgres.log"
+			// would NOT match any of these, so it is excluded.
+			expected: `(logName = "projects/my-project/logs/scion-server" OR logName = "projects/my-project/logs/scion-agents" OR logName = "projects/my-project/logs/scion-messages")`,
+		},
+		{
+			name:      "whitelist excludes request log implicitly",
+			opts:      LogQueryOptions{},
+			projectID: "my-project",
+			// scion_request_log is NOT in the whitelist, so it is excluded.
+			expected: `(logName = "projects/my-project/logs/scion-server" OR logName = "projects/my-project/logs/scion-agents" OR logName = "projects/my-project/logs/scion-messages")`,
+		},
+		{
+			name: "explicit LogID overrides whitelist",
+			opts: LogQueryOptions{
+				LogID: "scion-messages",
+			},
+			projectID: "my-project",
+			expected:  `logName = "projects/my-project/logs/scion-messages"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildLogFilter(tt.opts, tt.projectID)
+			if result != tt.expected {
+				t.Errorf("BuildLogFilter() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildLogFilter_HubName(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      LogQueryOptions
+		projectID string
+		expected  string
+	}{
+		{
+			name: "HubName filter emitted when set",
+			opts: LogQueryOptions{
+				HubName: "scion-community",
+			},
+			projectID: "my-project",
+			expected:  `(logName = "projects/my-project/logs/scion-server" OR logName = "projects/my-project/logs/scion-agents" OR logName = "projects/my-project/logs/scion-messages") AND labels.hub = "scion-community"`,
+		},
+		{
+			name: "HubName filter omitted when empty",
+			opts: LogQueryOptions{
+				HubName: "",
+			},
+			projectID: "my-project",
+			expected:  `(logName = "projects/my-project/logs/scion-server" OR logName = "projects/my-project/logs/scion-agents" OR logName = "projects/my-project/logs/scion-messages")`,
+		},
+		{
+			name: "HubName filter with agent and severity",
+			opts: LogQueryOptions{
+				AgentID:  "agent-123",
+				HubName:  "scion-gteam",
+				Severity: "ERROR",
+			},
+			projectID: "my-project",
+			expected:  `(logName = "projects/my-project/logs/scion-server" OR logName = "projects/my-project/logs/scion-agents" OR logName = "projects/my-project/logs/scion-messages") AND labels.agent_id = "agent-123" AND severity >= ERROR AND labels.hub = "scion-gteam"`,
+		},
+		{
+			name: "HubName filter without project ID",
+			opts: LogQueryOptions{
+				HubName: "scion-community",
+			},
+			expected: `labels.hub = "scion-community"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildLogFilter(tt.opts, tt.projectID)
+			if result != tt.expected {
+				t.Errorf("BuildLogFilter() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildLogFilter_CloudSQLExclusion(t *testing.T) {
+	// Verify that the whitelist approach excludes non-Scion log names.
+	// Cloud SQL logs like "cloudsql.googleapis.com/postgres.log" would have
+	// logName = "projects/my-project/logs/cloudsql.googleapis.com%2Fpostgres.log"
+	// which does NOT match any of the whitelisted Scion log names.
+	filter := BuildLogFilter(LogQueryOptions{}, "my-project")
+
+	// The filter should be a positive whitelist — it should contain OR clauses
+	// for scion-server, scion-agents, scion-messages only.
+	if !strings.Contains(filter, `logName = "projects/my-project/logs/scion-server"`) {
+		t.Error("filter should include scion-server in whitelist")
+	}
+	if !strings.Contains(filter, `logName = "projects/my-project/logs/scion-agents"`) {
+		t.Error("filter should include scion-agents in whitelist")
+	}
+	if !strings.Contains(filter, `logName = "projects/my-project/logs/scion-messages"`) {
+		t.Error("filter should include scion-messages in whitelist")
+	}
+	// Should NOT contain a negative filter
+	if strings.Contains(filter, `logName !=`) {
+		t.Error("filter should not use negative logName filter")
+	}
+	// Should NOT contain cloudsql or request log in the filter
+	if strings.Contains(filter, "cloudsql") {
+		t.Error("filter should not reference cloudsql logs")
+	}
+	if strings.Contains(filter, "scion_request_log") {
+		t.Error("filter should not reference scion_request_log (it should be excluded by omission from whitelist)")
 	}
 }
 

--- a/pkg/util/logging/cloud_handler.go
+++ b/pkg/util/logging/cloud_handler.go
@@ -387,13 +387,21 @@ func resolveProjectID() string {
 	return os.Getenv(EnvGoogleCloudProject)
 }
 
+// Cloud Logging log IDs for the server's log streams.
+const (
+	// ServerLogID is the Cloud Logging log ID for the main server log.
+	ServerLogID = "scion-server"
+	// AgentLogID is the Cloud Logging log ID for the agent log.
+	AgentLogID = "scion-agents"
+)
+
 // resolveLogID returns the Cloud Logging log ID from environment variables.
-// Defaults to "scion-server" if not set.
+// Defaults to ServerLogID if not set.
 func resolveLogID() string {
 	if v := os.Getenv(EnvCloudLoggingLogID); v != "" {
 		return v
 	}
-	return "scion-server"
+	return ServerLogID
 }
 
 // isCloudLoggingEnabled checks if direct Cloud Logging is enabled via env var.

--- a/pkg/util/logging/cloud_handler.go
+++ b/pkg/util/logging/cloud_handler.go
@@ -60,6 +60,8 @@ type CloudLoggingConfig struct {
 	Component string
 	// HubName is the logical hub identity used in the "hub" log label.
 	HubName string
+	// HubID is the stable unique hub instance ID used in the "hub_id" log label.
+	HubID string
 	// BufferedByteLimit is the maximum bytes the Cloud Logging client
 	// will buffer. Prevents unbounded memory growth when Cloud Logging
 	// is temporarily unavailable. Default: 8 MiB.
@@ -77,6 +79,7 @@ type CloudHandler struct {
 	level     slog.Level
 	component string
 	hubName   string
+	hubID     string
 	hostname  string
 	projectID string
 	version   string
@@ -134,6 +137,7 @@ func NewCloudHandler(ctx context.Context, config CloudLoggingConfig, level slog.
 		level:     level,
 		component: config.Component,
 		hubName:   config.HubName,
+		hubID:     config.HubID,
 		hostname:  hostname,
 		projectID: projectID,
 		version:   version.Short(),
@@ -218,6 +222,9 @@ func (h *CloudHandler) Handle(_ context.Context, r slog.Record) error {
 	if h.hubName != "" {
 		labels["hub"] = h.hubName
 	}
+	if h.hubID != "" {
+		labels["hub_id"] = h.hubID
+	}
 	if h.hostname != "" {
 		labels["node"] = h.hostname
 	}
@@ -270,6 +277,7 @@ func (h *CloudHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 		level:     h.level,
 		component: h.component,
 		hubName:   h.hubName,
+		hubID:     h.hubID,
 		hostname:  h.hostname,
 		projectID: h.projectID,
 		version:   h.version,
@@ -290,6 +298,7 @@ func (h *CloudHandler) WithGroup(name string) slog.Handler {
 		level:     h.level,
 		component: h.component,
 		hubName:   h.hubName,
+		hubID:     h.hubID,
 		hostname:  h.hostname,
 		projectID: h.projectID,
 		version:   h.version,
@@ -307,7 +316,8 @@ func (h *CloudHandler) Client() *gcplog.Client {
 
 // NewCloudHandlerFromClient creates a CloudHandler from an existing client.
 // This avoids opening a second connection for the request log stream.
-func NewCloudHandlerFromClient(client *gcplog.Client, logID, component, hubName string, level slog.Level) *CloudHandler {
+// hubID is optional — when non-empty, it is emitted as the "hub_id" label.
+func NewCloudHandlerFromClient(client *gcplog.Client, logID, component, hubName, hubID string, level slog.Level) *CloudHandler {
 	logger := client.Logger(logID)
 	hostname, _ := os.Hostname()
 	return &CloudHandler{
@@ -316,6 +326,7 @@ func NewCloudHandlerFromClient(client *gcplog.Client, logID, component, hubName 
 		level:     level,
 		component: component,
 		hubName:   hubName,
+		hubID:     hubID,
 		hostname:  hostname,
 		projectID: resolveProjectID(),
 		version:   version.Short(),

--- a/pkg/util/logging/message_log.go
+++ b/pkg/util/logging/message_log.go
@@ -192,9 +192,13 @@ func (h *messageCloudHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 			level:     h.level,
 			component: h.component,
 			hubName:   h.hubName,
+			hubID:     h.hubID,
 			hostname:  h.hostname,
+			projectID: h.projectID,
+			version:   h.version,
 			attrs:     newAttrs,
 			groups:    h.groups,
+			logHook:   h.logHook,
 		},
 	}
 }
@@ -211,9 +215,13 @@ func (h *messageCloudHandler) WithGroup(name string) slog.Handler {
 			level:     h.level,
 			component: h.component,
 			hubName:   h.hubName,
+			hubID:     h.hubID,
 			hostname:  h.hostname,
+			projectID: h.projectID,
+			version:   h.version,
 			attrs:     h.attrs,
 			groups:    newGroups,
+			logHook:   h.logHook,
 		},
 	}
 }

--- a/pkg/util/logging/message_log.go
+++ b/pkg/util/logging/message_log.go
@@ -41,6 +41,7 @@ type MessageLoggerConfig struct {
 	CircuitOpen func() bool    // Returns true when circuit breaker is open (nil = never open)
 	Component   string         // "scion-server", "scion-hub", "scion-broker"
 	HubName     string         // Logical hub identity for log labels
+	HubID       string         // Stable unique hub instance ID for log labels
 	UseGCP      bool           // Format output as GCP-compatible JSON
 	Level       slog.Level
 }
@@ -57,7 +58,7 @@ func NewMessageLogger(cfg MessageLoggerConfig) (*slog.Logger, func(), error) {
 
 	// Cloud handler with dedicated log ID and message-aware label promotion
 	if cfg.CloudClient != nil {
-		ch := newMessageCloudHandler(cfg.CloudClient, MessageLogID, cfg.Component, cfg.HubName, cfg.Level)
+		ch := newMessageCloudHandler(cfg.CloudClient, MessageLogID, cfg.Component, cfg.HubName, cfg.HubID, cfg.Level)
 		var cloudHandler slog.Handler = ch
 		if cfg.CircuitOpen != nil {
 			cloudHandler = &circuitGatedHandler{inner: ch, circuitOpen: cfg.CircuitOpen}
@@ -111,8 +112,8 @@ type messageCloudHandler struct {
 
 // newMessageCloudHandler creates a CloudHandler for the message log that
 // promotes sender, recipient, and msg_type to GCP labels.
-func newMessageCloudHandler(client *gcplog.Client, logID, component, hubName string, level slog.Level) *messageCloudHandler {
-	base := NewCloudHandlerFromClient(client, logID, component, hubName, level)
+func newMessageCloudHandler(client *gcplog.Client, logID, component, hubName, hubID string, level slog.Level) *messageCloudHandler {
+	base := NewCloudHandlerFromClient(client, logID, component, hubName, hubID, level)
 	return &messageCloudHandler{CloudHandler: *base}
 }
 
@@ -124,6 +125,9 @@ func (h *messageCloudHandler) Handle(ctx context.Context, r slog.Record) error {
 	}
 	if h.hubName != "" {
 		labels["hub"] = h.hubName
+	}
+	if h.hubID != "" {
+		labels["hub_id"] = h.hubID
 	}
 	if h.hostname != "" {
 		labels["node"] = h.hostname

--- a/pkg/util/logging/message_log_test.go
+++ b/pkg/util/logging/message_log_test.go
@@ -222,3 +222,119 @@ func TestPromoteMessageAttrToLabels(t *testing.T) {
 		})
 	}
 }
+
+func TestMessageCloudHandler_WithAttrs_PreservesFields(t *testing.T) {
+	hookCalled := false
+	h := &messageCloudHandler{
+		CloudHandler: CloudHandler{
+			level:     slog.LevelInfo,
+			component: "test-component",
+			hubName:   "test-hub",
+			hubID:     "hub-abc-123",
+			hostname:  "node-1",
+			projectID: "my-gcp-project",
+			version:   "v1.2.3",
+			logHook:   func(e gcplog.Entry) { hookCalled = true },
+		},
+	}
+
+	derived := h.WithAttrs([]slog.Attr{slog.String("extra", "val")})
+	mch, ok := derived.(*messageCloudHandler)
+	if !ok {
+		t.Fatal("WithAttrs should return a *messageCloudHandler")
+	}
+
+	if mch.hubID != "hub-abc-123" {
+		t.Errorf("hubID = %q, want %q", mch.hubID, "hub-abc-123")
+	}
+	if mch.projectID != "my-gcp-project" {
+		t.Errorf("projectID = %q, want %q", mch.projectID, "my-gcp-project")
+	}
+	if mch.version != "v1.2.3" {
+		t.Errorf("version = %q, want %q", mch.version, "v1.2.3")
+	}
+	if mch.logHook == nil {
+		t.Fatal("logHook should be preserved, got nil")
+	}
+	if mch.component != "test-component" {
+		t.Errorf("component = %q, want %q", mch.component, "test-component")
+	}
+	if mch.hubName != "test-hub" {
+		t.Errorf("hubName = %q, want %q", mch.hubName, "test-hub")
+	}
+	if mch.hostname != "node-1" {
+		t.Errorf("hostname = %q, want %q", mch.hostname, "node-1")
+	}
+	if len(mch.attrs) != 1 {
+		t.Errorf("expected 1 attr, got %d", len(mch.attrs))
+	}
+
+	// Verify the hook is callable (same function reference)
+	mch.logHook(gcplog.Entry{})
+	if !hookCalled {
+		t.Error("logHook should be the same function as original")
+	}
+
+	// Original should be unchanged
+	if len(h.attrs) != 0 {
+		t.Error("original handler should not be modified")
+	}
+}
+
+func TestMessageCloudHandler_WithGroup_PreservesFields(t *testing.T) {
+	hookCalled := false
+	h := &messageCloudHandler{
+		CloudHandler: CloudHandler{
+			level:     slog.LevelInfo,
+			component: "test-component",
+			hubName:   "test-hub",
+			hubID:     "hub-abc-123",
+			hostname:  "node-1",
+			projectID: "my-gcp-project",
+			version:   "v1.2.3",
+			logHook:   func(e gcplog.Entry) { hookCalled = true },
+		},
+	}
+
+	derived := h.WithGroup("mygroup")
+	mch, ok := derived.(*messageCloudHandler)
+	if !ok {
+		t.Fatal("WithGroup should return a *messageCloudHandler")
+	}
+
+	if mch.hubID != "hub-abc-123" {
+		t.Errorf("hubID = %q, want %q", mch.hubID, "hub-abc-123")
+	}
+	if mch.projectID != "my-gcp-project" {
+		t.Errorf("projectID = %q, want %q", mch.projectID, "my-gcp-project")
+	}
+	if mch.version != "v1.2.3" {
+		t.Errorf("version = %q, want %q", mch.version, "v1.2.3")
+	}
+	if mch.logHook == nil {
+		t.Fatal("logHook should be preserved, got nil")
+	}
+	if mch.component != "test-component" {
+		t.Errorf("component = %q, want %q", mch.component, "test-component")
+	}
+	if mch.hubName != "test-hub" {
+		t.Errorf("hubName = %q, want %q", mch.hubName, "test-hub")
+	}
+	if mch.hostname != "node-1" {
+		t.Errorf("hostname = %q, want %q", mch.hostname, "node-1")
+	}
+	if len(mch.groups) != 1 || mch.groups[0] != "mygroup" {
+		t.Errorf("groups = %v, want [mygroup]", mch.groups)
+	}
+
+	// Verify the hook is callable (same function reference)
+	mch.logHook(gcplog.Entry{})
+	if !hookCalled {
+		t.Error("logHook should be the same function as original")
+	}
+
+	// Original should be unchanged
+	if len(h.groups) != 0 {
+		t.Error("original handler should not be modified")
+	}
+}

--- a/pkg/util/logging/request_log.go
+++ b/pkg/util/logging/request_log.go
@@ -165,6 +165,7 @@ type RequestLoggerConfig struct {
 	ProjectID   string         // For trace URL formatting
 	Component   string         // "scion-server", "scion-hub", "scion-broker"
 	HubName     string         // Logical hub identity for log labels
+	HubID       string         // Stable unique hub instance ID for log labels
 	UseGCP      bool           // Format output as GCP-compatible JSON
 	Foreground  bool           // If true, suppress stdout output
 	Level       slog.Level
@@ -193,7 +194,7 @@ func NewRequestLogger(cfg RequestLoggerConfig) (*slog.Logger, func(), error) {
 
 	// Cloud handler
 	if cfg.CloudClient != nil {
-		ch := NewCloudHandlerFromClient(cfg.CloudClient, RequestLogID, cfg.Component, cfg.HubName, cfg.Level)
+		ch := NewCloudHandlerFromClient(cfg.CloudClient, RequestLogID, cfg.Component, cfg.HubName, cfg.HubID, cfg.Level)
 		var cloudHandler slog.Handler = ch
 		if cfg.CircuitOpen != nil {
 			cloudHandler = &circuitGatedHandler{inner: ch, circuitOpen: cfg.CircuitOpen}


### PR DESCRIPTION
Fixes two issues in the diagnostics log viewer:

1. **Cloud SQL and non-Scion logs appearing**: BuildLogFilter() used only a negative filter (exclude request log) when no specific LogID or Sources was set. Replaced with a positive whitelist of known Scion log names (scion-server, scion-agents, scion-messages). This excludes Cloud SQL, GCE audit, load balancer, and all other non-Scion logs.

2. **Cross-hub log leaking**: When multiple Scion hubs share the same GCP project, their logs intermingled. Added HubName field to LogQueryOptions and emit labels.hub filter in all log query handlers (diagnostics + agent-level).

3. **Hub ID in log labels**: Added hub_id label alongside existing hub name label on all Cloud Logging entries for improved traceability. Added exported constants ServerLogID, AgentLogID for log name consistency.

Key files:
- pkg/hub/logquery.go — whitelist filter + HubName filter
- pkg/hub/handlers_diagnostics.go — wire HubName into diagnostics handlers
- pkg/hub/handlers_logs.go — wire HubName into agent log handlers
- pkg/util/logging/cloud_handler.go — hub_id label + ServerLogID/AgentLogID constants
- pkg/hub/logquery_test.go — new test cases

Related: ptone/scion branch scion/fix-log-filter