### PR TITLE
fix(web): add fixed height and scroll to project page agent list

### DIFF
--- a/web/src/components/pages/project-detail.ts
+++ b/web/src/components/pages/project-detail.ts
@@ -327,6 +327,8 @@ export class ScionPageProjectDetail extends LitElement {
       display: grid;
       grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
       gap: 1.5rem;
+      max-height: 26rem;
+      overflow-y: auto;
     }
 
     .agent-card {
@@ -414,7 +416,8 @@ export class ScionPageProjectDetail extends LitElement {
       background: var(--scion-surface, #ffffff);
       border: 1px solid var(--scion-border, #e2e8f0);
       border-radius: var(--scion-radius-lg, 0.75rem);
-      overflow: hidden;
+      max-height: 26rem;
+      overflow-y: auto;
     }
 
     .agent-table-container table {


### PR DESCRIPTION
## Summary

Constrains the agent list on the project detail page to a fixed max-height (26rem, matching the file browser) with overflow-y: auto scrollbar. Previously the list grew unbounded with agent count.

CSS-only change in web/src/components/pages/project-detail.ts (+4/-1). Both grid and table views constrained.

Ref: ptone/scion#802