### PR TITLE
feat(hermes): add web dashboard sidecar and auto-expose port 9119

### DIFF
--- a/harnesses/hermes/config.yaml
+++ b/harnesses/hermes/config.yaml
@@ -16,6 +16,11 @@ harness: hermes
 image: scion-hermes:latest
 user: scion
 
+env:
+  SCION_AUTO_EXPOSE_PORTS: "true"
+  SCION_AUTO_EXPOSE_MODE: "allowlist"
+  SCION_AUTO_EXPOSE_PORTS_LIST: "9119"
+
 provisioner:
   type: container-script
   interface_version: 1

--- a/harnesses/hermes/provision.py
+++ b/harnesses/hermes/provision.py
@@ -213,14 +213,14 @@ _SCION_SERVICES_YAML = """\
   restart: always
   ready_check:
     type: tcp
-    target: "localhost:9119"
+    target: "127.0.0.1:9119"
     timeout: "15s"
 """
 
 
 def _write_scion_services() -> None:
     """Write scion-services.yaml so the init process starts the Hermes dashboard."""
-    scion_dir = os.path.expanduser("~/.scion")
+    scion_dir = scion_harness.expand_path("~/.scion")
     os.makedirs(scion_dir, exist_ok=True)
     target = os.path.join(scion_dir, "scion-services.yaml")
     scion_harness.atomic_write_text(target, _SCION_SERVICES_YAML)

--- a/harnesses/hermes/provision.py
+++ b/harnesses/hermes/provision.py
@@ -196,6 +196,37 @@ def _apply_mcp_servers(ctx: scion_harness.ProvisionContext) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Sidecar service: Hermes web dashboard
+# ---------------------------------------------------------------------------
+
+_SCION_SERVICES_YAML = """\
+- name: hermes-dashboard
+  command:
+    - hermes
+    - dashboard
+    - "--no-open"
+    - "--skip-build"
+    - "--host"
+    - "127.0.0.1"
+    - "--port"
+    - "9119"
+  restart: always
+  ready_check:
+    type: tcp
+    target: "localhost:9119"
+    timeout: "15s"
+"""
+
+
+def _write_scion_services() -> None:
+    """Write scion-services.yaml so the init process starts the Hermes dashboard."""
+    scion_dir = os.path.expanduser("~/.scion")
+    os.makedirs(scion_dir, exist_ok=True)
+    target = os.path.join(scion_dir, "scion-services.yaml")
+    scion_harness.atomic_write_text(target, _SCION_SERVICES_YAML)
+
+
+# ---------------------------------------------------------------------------
 # Provision logic
 # ---------------------------------------------------------------------------
 
@@ -258,6 +289,9 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
 
     # MCP server configuration.
     _apply_mcp_servers(ctx)
+
+    # Write scion-services.yaml so the Hermes dashboard starts as a sidecar.
+    _write_scion_services()
 
     ctx.info(f"method={resolved.method}")
 

--- a/harnesses/hermes/provision_test.py
+++ b/harnesses/hermes/provision_test.py
@@ -570,7 +570,7 @@ class ScionServicesYamlTest(unittest.TestCase):
             # Ready check
             self.assertIn("ready_check:", content)
             self.assertIn("type: tcp", content)
-            self.assertIn('target: "localhost:9119"', content)
+            self.assertIn('target: "127.0.0.1:9119"', content)
             self.assertIn("timeout:", content)
 
 

--- a/harnesses/hermes/provision_test.py
+++ b/harnesses/hermes/provision_test.py
@@ -513,5 +513,66 @@ class MCPEntryBuildingTest(unittest.TestCase):
         self.assertIn("missing url", stderr.getvalue())
 
 
+class ScionServicesYamlTest(unittest.TestCase):
+    """Test that provision() writes scion-services.yaml for the Hermes dashboard."""
+
+    def test_provision_writes_scion_services_yaml(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, clean_vertex_env():
+            home = os.path.join(tmp, "home")
+            bundle = os.path.join(tmp, "bundle")
+            os.makedirs(os.path.join(bundle, "outputs"))
+            os.makedirs(home)
+
+            # Stage a secret file so api-key auth succeeds.
+            secrets_dir = os.path.join(bundle, "secrets")
+            os.makedirs(secrets_dir, exist_ok=True)
+            secret_path = os.path.join(secrets_dir, "GOOGLE_API_KEY")
+            with open(secret_path, "w") as f:
+                f.write("test-key-value")
+
+            ctx = _make_ctx(
+                bundle,
+                env_vars=["GOOGLE_API_KEY"],
+                env_secret_files={"GOOGLE_API_KEY": secret_path},
+                harness_config={
+                    "instructions_file": "AGENTS.md",
+                    "skills_dir": ".hermes/skills",
+                    "system_prompt_mode": "none",
+                },
+            )
+
+            stderr = io.StringIO()
+            with temporary_home(home), redirect_stderr(stderr):
+                provision.provision(ctx)
+
+            services_path = os.path.join(home, ".scion", "scion-services.yaml")
+            self.assertTrue(
+                os.path.isfile(services_path),
+                "scion-services.yaml should be written by provision()",
+            )
+
+            with open(services_path, "r") as f:
+                content = f.read()
+
+            # Service name
+            self.assertIn("hermes-dashboard", content)
+            # Command components
+            self.assertIn("hermes", content)
+            self.assertIn("dashboard", content)
+            self.assertIn("--no-open", content)
+            self.assertIn("--skip-build", content)
+            self.assertIn("--host", content)
+            self.assertIn("127.0.0.1", content)
+            self.assertIn("--port", content)
+            self.assertIn("9119", content)
+            # Restart policy
+            self.assertIn("restart: always", content)
+            # Ready check
+            self.assertIn("ready_check:", content)
+            self.assertIn("type: tcp", content)
+            self.assertIn('target: "localhost:9119"', content)
+            self.assertIn("timeout:", content)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Start the Hermes web dashboard as a scion sidecar service on agent startup and auto-expose port 9119 via the hub reverse proxy.

Changes:
- provision.py: write scion-services.yaml with hermes-dashboard service spec (--no-open --skip-build --host 127.0.0.1 --port 9119, restart: always, tcp ready check)
- config.yaml: add env block with SCION_AUTO_EXPOSE_PORTS=true, allowlist mode, port 9119
- provision_test.py: add ScionServicesYamlTest verifying scion-services.yaml content

How it works:
1. provision.py writes scion-services.yaml during pre-start hook
2. Init process starts hermes dashboard as sidecar before the agent child process
3. Auto-expose reconciler detects port 9119 and registers with the hub
4. Hub reverse proxy tunnels browser requests to the dashboard

The dashboard and chat CLI are independent processes running simultaneously. The dashboard serves a pre-built SPA from web_dist/ (no npm build needed at runtime).

Ref: ptone/scion#805
