### PR TITLE
fix(discord): add permission pre-check for /scion thread and update invite UI text

### DIFF
--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -1432,14 +1432,15 @@ func (h *CommandHandler) HandleThread(s *discordgo.Session, i *discordgo.Interac
 	// Full probe deferred to a follow-up change.
 
 	// Step 0.7: Check bot has permission to create threads in the target channel.
-	botPerms, permErr := s.State.UserChannelPermissions(s.State.User.ID, channelID)
-	if permErr == nil {
-		const createPublicThreads int64 = 0x800000000
-		if botPerms&createPublicThreads == 0 {
-			h.followup(s, i, "The bot does not have **Create Public Threads** permission in this channel. "+
-				"Please re-invite the bot using the invite link from the admin settings page, "+
-				"or grant the permission manually in Server Settings > Roles.")
-			return
+	if s.State != nil && s.State.User != nil {
+		botPerms, permErr := s.State.UserChannelPermissions(s.State.User.ID, channelID)
+		if permErr == nil {
+			if botPerms&discordgo.PermissionCreatePublicThreads == 0 {
+				h.followup(s, i, "The bot does not have **Create Public Threads** permission in this channel. "+
+					"Please re-invite the bot using the invite link from the admin settings page, "+
+					"or grant the permission manually in Server Settings > Roles.")
+				return
+			}
 		}
 	}
 

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -1431,6 +1431,18 @@ func (h *CommandHandler) HandleThread(s *discordgo.Session, i *discordgo.Interac
 	// would be ownerless — a condition that should be detected and reported.
 	// Full probe deferred to a follow-up change.
 
+	// Step 0.7: Check bot has permission to create threads in the target channel.
+	botPerms, permErr := s.State.UserChannelPermissions(s.State.User.ID, channelID)
+	if permErr == nil {
+		const createPublicThreads int64 = 0x800000000
+		if botPerms&createPublicThreads == 0 {
+			h.followup(s, i, "The bot does not have **Create Public Threads** permission in this channel. "+
+				"Please re-invite the bot using the invite link from the admin settings page, "+
+				"or grant the permission manually in Server Settings > Roles.")
+			return
+		}
+	}
+
 	// --- Phase 6: Concurrent fan-out ---
 	h.log.Info("Thread command validation passed, starting orchestration",
 		"title", title,
@@ -1511,11 +1523,15 @@ func (h *CommandHandler) HandleThread(s *discordgo.Session, i *discordgo.Interac
 		h.log.Error("Thread command: both agent and thread creation failed",
 			"agent_error", agentErr, "thread_error", threadErr,
 			"slug", slug, "title", title)
+		threadErrMsg := threadErr.Error()
+		if strings.Contains(threadErrMsg, "403") || strings.Contains(threadErrMsg, "Missing Access") {
+			threadErrMsg += " (This may be a permissions issue — try re-inviting the bot from the admin settings page.)"
+		}
 		h.followup(s, i, fmt.Sprintf(
 			"Failed to create both the agent and the thread.\n"+
 				"Agent error: %s\n"+
 				"Thread error: %s",
-			agentErr.Error(), threadErr.Error()))
+			agentErr.Error(), threadErrMsg))
 		return
 
 	case agentErr != nil && threadErr == nil:
@@ -1540,11 +1556,15 @@ func (h *CommandHandler) HandleThread(s *discordgo.Session, i *discordgo.Interac
 		// Agent OK, thread failed — ephemeral reply MUST name the slug.
 		h.log.Error("Thread command: thread creation failed but agent was created",
 			"thread_error", threadErr, "slug", agentResp.Slug)
+		threadErrMsg := threadErr.Error()
+		if strings.Contains(threadErrMsg, "403") || strings.Contains(threadErrMsg, "Missing Access") {
+			threadErrMsg += " (This may be a permissions issue — try re-inviting the bot from the admin settings page.)"
+		}
 		h.followup(s, i, fmt.Sprintf(
 			"Agent **%s** was created but the Discord thread could not be created.\n"+
 				"Error: %s\n"+
 				"The agent is running. Create a thread manually and run `/scion default %s` in it to bind.",
-			agentResp.Slug, threadErr.Error(), agentResp.Slug))
+			agentResp.Slug, threadErrMsg, agentResp.Slug))
 		return
 	}
 

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -1454,7 +1454,7 @@ export class ScionPageAdminIntegrations extends LitElement {
             <div>
               <p class="invite-link-description">Add the bot to your Discord server</p>
               <p class="invite-link-permissions">
-                Grants required permissions: Send Messages, Read Message History, View Channels, Embed Links, Manage Webhooks
+                Grants required permissions: View Channels, Send Messages, Send Messages in Threads, Create Public Threads, Manage Threads, Read Message History, Embed Links, Add Reactions, Manage Webhooks
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Adds pre-flight CREATE_PUBLIC_THREADS permission check in HandleThread
- Enhances 403 error messages to suggest re-inviting the bot
- Updates invite button to list all 9 granted permissions

## Changes
- extras/scion-discord/internal/discord/commands.go - permission pre-check, improved 403 errors
- web/src/components/pages/admin-integrations.ts - updated permission list text

## Test plan
- [ ] /scion thread shows clear error when bot lacks permission
- [ ] Invite button shows full permission list
